### PR TITLE
Add support for tracking and checking LTI nonce

### DIFF
--- a/lib/oli/lti.ex
+++ b/lib/oli/lti.ex
@@ -1,0 +1,114 @@
+defmodule Oli.Lti do
+  @moduledoc """
+  The Lti context.
+  """
+
+  # nonces only persist for a day
+  @max_nonce_ttl_sec 86400
+
+  import Ecto.Query, warn: false
+  alias Oli.Repo
+
+  alias Oli.Lti.Nonce
+
+  @doc """
+  Returns the list of nonce_store.
+
+  ## Examples
+
+      iex> list_nonce_store()
+      [%Nonce{}, ...]
+
+  """
+  def list_nonce_store do
+    Repo.all(Nonce)
+  end
+
+  @doc """
+  Gets a single nonce.
+
+  Raises `Ecto.NoResultsError` if the Nonce does not exist.
+
+  ## Examples
+
+      iex> get_nonce!(123)
+      %Nonce{}
+
+      iex> get_nonce!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_nonce!(id), do: Repo.get!(Nonce, id)
+
+  @doc """
+  Creates a nonce.
+
+  ## Examples
+
+      iex> create_nonce(%{field: value})
+      {:ok, %Nonce{}}
+
+      iex> create_nonce(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_nonce(attrs \\ %{}) do
+    %Nonce{}
+    |> Nonce.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a nonce.
+
+  ## Examples
+
+      iex> update_nonce(nonce, %{field: new_value})
+      {:ok, %Nonce{}}
+
+      iex> update_nonce(nonce, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_nonce(%Nonce{} = nonce, attrs) do
+    nonce
+    |> Nonce.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a nonce.
+
+  ## Examples
+
+      iex> delete_nonce(nonce)
+      {:ok, %Nonce{}}
+
+      iex> delete_nonce(nonce)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_nonce(%Nonce{} = nonce) do
+    Repo.delete(nonce)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking nonce changes.
+
+  ## Examples
+
+      iex> change_nonce(nonce)
+      %Ecto.Changeset{source: %Nonce{}}
+
+  """
+  def change_nonce(%Nonce{} = nonce) do
+    Nonce.changeset(nonce, %{})
+  end
+
+  def cleanup_nonce_store() do
+    # delete all nonces older than configured @max_nonce_ttl_sec
+    nonce_expiry = DateTime.add(DateTime.utc_now(), -1 * @max_nonce_ttl_sec, :second)
+    from(n in Nonce, where: n.inserted_at < ^nonce_expiry)
+    |> Repo.delete_all
+  end
+end

--- a/lib/oli/lti/nonce.ex
+++ b/lib/oli/lti/nonce.ex
@@ -1,0 +1,18 @@
+defmodule Oli.Lti.Nonce do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "nonce_store" do
+    field :value, :string
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(nonce, attrs) do
+    nonce
+    |> cast(attrs, [:value])
+    |> validate_required([:value])
+    |> unique_constraint(:value)
+  end
+end

--- a/lib/oli/lti/provider.ex
+++ b/lib/oli/lti/provider.ex
@@ -1,5 +1,9 @@
 defmodule Oli.Lti.Provider do
   alias Oli.Lti.HmacSHA1
+  alias Oli.Lti
+
+  # amount of time an oauth_timestamp is valid is 5 min
+  @oauth_timestamp_ttl_sec 300
 
   @type lti_message_params :: [
     lti_message_type: String.t, # "basic-lti-launch-request" | "ContentItemSelectionRequest",
@@ -86,17 +90,48 @@ defmodule Oli.Lti.Provider do
 
   @spec validate_oauth(String.t, String.t, lti_message_params, String.t) :: { :ok } | { :invalid, String.t}
   def validate_oauth(url, method, body_params, shared_secret) do
-    req_signature = HmacSHA1.build_signature(
-      url,
-      method,
-      body_params,
-      shared_secret
-    )
+    case validate_timestamp(Keyword.get(body_params, :oauth_timestamp)) do
+      { :ok } ->
+        case validate_nonce(Keyword.get(body_params, :oauth_nonce)) do
+          { :ok } ->
+            req_signature = HmacSHA1.build_signature(
+              url,
+              method,
+              body_params,
+              shared_secret
+            )
 
-    if req_signature == Keyword.get(body_params, :oauth_signature) do
-      { :ok }
+            if req_signature == Keyword.get(body_params, :oauth_signature) do
+              { :ok }
+            else
+              { :invalid, "Invalid OAuth - Signature does not match"}
+            end
+          { :invalid } -> { :invalid, "Invalid OAuth - Duplicate nonce"}
+        end
+      { :invalid } -> { :invalid, "Invalid OAuth - Expired timestamp"}
+    end
+  end
+
+  def validate_timestamp(oauth_timestamp) do
+    timestamp = DateTime.from_unix!(String.to_integer(oauth_timestamp))
+    current_time = DateTime.utc_now()
+    timestamp_expiry = DateTime.add(current_time, -1 * @oauth_timestamp_ttl_sec)
+    if timestamp > timestamp_expiry do
+      {:ok}
     else
-      { :invalid, "Invalid OAuth - Signature does not match"}
+      {:invalid}
+    end
+  end
+
+  def validate_nonce(nonce) do
+    case Lti.create_nonce(%{value: nonce}) do
+      {:ok, _nonce} ->
+        # FIXME: This runs a query to delete all expired nonces on every call. This could present
+        # a performance bottleneck and may need to be optimized
+        Lti.cleanup_nonce_store()
+        { :ok }
+      {:error, %{ errors: [ value: { _msg, [{:constraint, :unique} | _]}]}} ->
+        { :invalid }
     end
   end
 

--- a/lib/oli/utils.ex
+++ b/lib/oli/utils.ex
@@ -5,4 +5,26 @@ defmodule Oli.Utils do
   def random_string(length) do
     :crypto.strong_rand_bytes(length) |> Base.encode16 |> binary_part(0, length)
   end
+
+
+  @doc """
+  Converts a map of LTI parameters to a keyword list.
+  This function is unsafe because it expects an atom to exist for each map key,
+  which makes it only safe for requests with known parameter names that are defined as atoms
+  """
+  def unsafe_map_to_keyword_list(map) do
+    Enum.map(map, fn({key, value}) -> {String.to_atom(key), value} end)
+  end
+
+  @doc """
+  Returns the specified value if not nil, otherwise returns the default value
+  """
+  def value_or(value, default_value) do
+    if value == nil do
+      default_value
+    else
+      value
+    end
+  end
+
 end

--- a/lib/oli_web/controllers/lti_controller.ex
+++ b/lib/oli_web/controllers/lti_controller.ex
@@ -2,6 +2,7 @@ defmodule OliWeb.LtiController do
   use OliWeb, :controller
 
   import Oli.Lti.Provider
+  import Oli.Utils
 
   alias Oli.Repo
   alias Oli.Accounts
@@ -20,7 +21,7 @@ defmodule OliWeb.LtiController do
         render(conn, "basic_launch_invalid.html", reason: "Institution with consumer_key '#{consumer_key}' does not exist")
       institution ->
         shared_secret = institution.shared_secret
-        case validate_request(url, method, unsafe_map_to_keyword_list(conn.body_params), shared_secret) do
+        case validate_request(url, method, unsafe_map_to_keyword_list(conn.body_params), shared_secret, DateTime.utc_now()) do
           { :ok } ->
             handle_valid_request(conn, institution)
           { :invalid, reason } ->
@@ -59,13 +60,6 @@ defmodule OliWeb.LtiController do
 
   def handle_invalid_request(conn, reason) do
     render(conn, "basic_launch_invalid.html", reason: reason)
-  end
-
-  # Converts a map of LTI parameters to a keyword list.
-  # This function is unsafe because it expects an atom to exist for each map key,
-  # which makes it only safe for known LTI requests
-  defp unsafe_map_to_keyword_list(map) do
-    Enum.map(map, fn({key, value}) -> {String.to_atom(key), value} end)
   end
 
 end

--- a/priv/repo/migrations/20200310193550_init_core_schemas.exs
+++ b/priv/repo/migrations/20200310193550_init_core_schemas.exs
@@ -63,6 +63,14 @@ defmodule Oli.Repo.Migrations.InitCoreSchemas do
       timestamps()
     end
 
+    create table(:nonce_store) do
+      add :value, :string
+
+      timestamps()
+    end
+
+    create unique_index(:nonce_store, [:value])
+
     create table(:user) do
       add :email, :string
       add :first_name, :string

--- a/test/oli/lti/provider_test.exs
+++ b/test/oli/lti/provider_test.exs
@@ -50,7 +50,8 @@ defmodule Oli.Lti.ProviderTest do
           oauth_signature: "8vGuVoSKBBVUL+ZxC8Du7Rtkbqk=",
           custom_param1: "value1"
         ],
-        "secret"
+        "secret",
+        DateTime.from_unix!(0)
       )
     end
 
@@ -67,7 +68,8 @@ defmodule Oli.Lti.ProviderTest do
           oauth_signature: "notavalidsignature=",
           custom_param1: "value1"
         ],
-        "secret"
+        "secret",
+        DateTime.from_unix!(0)
       )
     end
   end
@@ -89,7 +91,8 @@ defmodule Oli.Lti.ProviderTest do
           oauth_signature: "Hra/KZuAi95CCMHVHR5LjFpWQhA=",
           custom_param1: "value1"
         ],
-        "secret"
+        "secret",
+        DateTime.from_unix!(0)
       )
     end
 
@@ -108,7 +111,8 @@ defmodule Oli.Lti.ProviderTest do
           oauth_signature: "notavalidsignature=",
           custom_param1: "value1"
         ],
-        "secret"
+        "secret",
+        DateTime.from_unix!(0)
       )
     end
   end

--- a/test/oli/lti_test.exs
+++ b/test/oli/lti_test.exs
@@ -1,0 +1,64 @@
+defmodule Oli.LtiTest do
+  use Oli.DataCase
+
+  alias Oli.Lti
+
+  describe "nonce_store" do
+    alias Oli.Lti.Nonce
+
+    @valid_attrs %{value: "some value"}
+    @update_attrs %{value: "some updated value"}
+    @invalid_attrs %{value: nil}
+
+    def nonce_fixture(attrs \\ %{}) do
+      {:ok, nonce} =
+        attrs
+        |> Enum.into(@valid_attrs)
+        |> Lti.create_nonce()
+
+      nonce
+    end
+
+    test "list_nonce_store/0 returns all nonce_store" do
+      nonce = nonce_fixture()
+      assert Lti.list_nonce_store() == [nonce]
+    end
+
+    test "get_nonce!/1 returns the nonce with given id" do
+      nonce = nonce_fixture()
+      assert Lti.get_nonce!(nonce.id) == nonce
+    end
+
+    test "create_nonce/1 with valid data creates a nonce" do
+      assert {:ok, %Nonce{} = nonce} = Lti.create_nonce(@valid_attrs)
+      assert nonce.value == "some value"
+    end
+
+    test "create_nonce/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Lti.create_nonce(@invalid_attrs)
+    end
+
+    test "update_nonce/2 with valid data updates the nonce" do
+      nonce = nonce_fixture()
+      assert {:ok, %Nonce{} = nonce} = Lti.update_nonce(nonce, @update_attrs)
+      assert nonce.value == "some updated value"
+    end
+
+    test "update_nonce/2 with invalid data returns error changeset" do
+      nonce = nonce_fixture()
+      assert {:error, %Ecto.Changeset{}} = Lti.update_nonce(nonce, @invalid_attrs)
+      assert nonce == Lti.get_nonce!(nonce.id)
+    end
+
+    test "delete_nonce/1 deletes the nonce" do
+      nonce = nonce_fixture()
+      assert {:ok, %Nonce{}} = Lti.delete_nonce(nonce)
+      assert_raise Ecto.NoResultsError, fn -> Lti.get_nonce!(nonce.id) end
+    end
+
+    test "change_nonce/1 returns a nonce changeset" do
+      nonce = nonce_fixture()
+      assert %Ecto.Changeset{} = Lti.change_nonce(nonce)
+    end
+  end
+end

--- a/test/oli_web/controllers/lti_controller_test.exs
+++ b/test/oli_web/controllers/lti_controller_test.exs
@@ -4,6 +4,7 @@ defmodule OliWeb.LtiControllerTest do
   alias Oli.Repo
   alias Oli.Accounts
   alias Oli.Accounts.Author
+  alias Oli.Lti.HmacSHA1
 
   @institution_attrs %{
     country_code: "some country_code",
@@ -15,52 +16,70 @@ defmodule OliWeb.LtiControllerTest do
     shared_secret: "6BCF251D1C1181C938BFA91896D4BE9B",
   }
 
-  @sample_lti_request_data %{
-    oauth_consumer_key: "60dc6375-5eeb-4475-8788-fb69e32153b6",
-    oauth_signature_method: "HMAC-SHA1",
-    oauth_timestamp: "1584560550",
-    oauth_nonce: "2MkTeXy05t9a3ySh0DwWeOq7iIWYJotNgQLqn1lOdI",
-    oauth_version: "1.0",
-    context_id: "4dde05e8ca1973bcca9bffc13e1548820eee93a3",
-    context_label: "Torus",
-    context_title: "Torus Test",
-    custom_canvas_api_domain: "canvas.oli.cmu.edu",
-    custom_canvas_course_id: "1",
-    custom_canvas_enrollment_state: "active",
-    custom_canvas_user_id: "14",
-    custom_canvas_user_login_id: "exampleuser",
-    custom_canvas_workflow_state: "available",
-    ext_roles: "urn:lti:instrole:ims/lis/Student,urn:lti:role:ims/lis/Learner,urn:lti:sysrole:ims/lis/User",
-    launch_presentation_document_target: "iframe",
-    launch_presentation_locale: "en",
-    launch_presentation_return_url: "https://canvas.oli.cmu.edu/courses/1/external_content/success/external_tool_redirect",
-    lis_person_contact_email_primary: "exampleuser@example.edu",
-    lis_person_name_family: "User",
-    lis_person_name_full: "Example User",
-    lis_person_name_given: "Example",
-    lti_message_type: "basic-lti-launch-request",
-    lti_version: "LTI-1p0",
-    oauth_callback: "about:blank",
-    resource_link_id: "82f5cc6b61288d047fc5213547ac8fba4790bffa",
-    resource_link_title: "Torus OLI",
-    roles: "Learner",
-    tool_consumer_info_product_family_code: "canvas",
-    tool_consumer_info_version: "cloud",
-    tool_consumer_instance_contact_email: "admin@canvas.oli.cmu.edu",
-    tool_consumer_instance_guid: "8865aa05b4b79b64a91a86042e43af5ea8ae79eb.localhost:8900",
-    tool_consumer_instance_name: "OLI Canvas Admin",
-    user_id: "dc86d3e58c1025af0b2cce49205ad2cb1019d546",
-    user_image: "https://canvas.oli.cmu.edu/images/messages/avatar-50.png",
-    oauth_signature: "39n9SmyZgdk4SbH1QJMrYnzApYo=",
-  }
+  def url_from_conn(conn) do
+    scheme = if conn.scheme == :https, do: "https", else: "http"
+    scheme = System.get_env("LTI_PROTOCOL", scheme)
+    port = if conn.port == 80 or conn.port == 443, do: "", else: ":#{conn.port}"
+
+    "#{scheme}://#{conn.host}#{port}/lti/basic_launch"
+  end
+
+  def build_lti_request(req_url, shared_secret, nonce) do
+    body_params = %{
+      oauth_consumer_key: "60dc6375-5eeb-4475-8788-fb69e32153b6",
+      oauth_signature_method: "HMAC-SHA1",
+      oauth_timestamp: DateTime.utc_now() |> DateTime.to_unix() |> Integer.to_string,
+      oauth_nonce: nonce,
+      oauth_version: "1.0",
+      context_id: "4dde05e8ca1973bcca9bffc13e1548820eee93a3",
+      context_label: "Torus",
+      context_title: "Torus Test",
+      custom_canvas_api_domain: "canvas.oli.cmu.edu",
+      custom_canvas_course_id: "1",
+      custom_canvas_enrollment_state: "active",
+      custom_canvas_user_id: "14",
+      custom_canvas_user_login_id: "exampleuser",
+      custom_canvas_workflow_state: "available",
+      ext_roles: "urn:lti:instrole:ims/lis/Student,urn:lti:role:ims/lis/Learner,urn:lti:sysrole:ims/lis/User",
+      launch_presentation_document_target: "iframe",
+      launch_presentation_locale: "en",
+      launch_presentation_return_url: "https://canvas.oli.cmu.edu/courses/1/external_content/success/external_tool_redirect",
+      lis_person_contact_email_primary: "exampleuser@example.edu",
+      lis_person_name_family: "User",
+      lis_person_name_full: "Example User",
+      lis_person_name_given: "Example",
+      lti_message_type: "basic-lti-launch-request",
+      lti_version: "LTI-1p0",
+      oauth_callback: "about:blank",
+      resource_link_id: "82f5cc6b61288d047fc5213547ac8fba4790bffa",
+      resource_link_title: "Torus OLI",
+      roles: "Learner",
+      tool_consumer_info_product_family_code: "canvas",
+      tool_consumer_info_version: "cloud",
+      tool_consumer_instance_contact_email: "admin@canvas.oli.cmu.edu",
+      tool_consumer_instance_guid: "8865aa05b4b79b64a91a86042e43af5ea8ae79eb.localhost:8900",
+      tool_consumer_instance_name: "OLI Canvas Admin",
+      user_id: "dc86d3e58c1025af0b2cce49205ad2cb1019d546",
+      user_image: "https://canvas.oli.cmu.edu/images/messages/avatar-50.png",
+    }
+
+    oauth_signature = HmacSHA1.build_signature(
+      req_url,
+      "POST",
+      Map.to_list(body_params),
+      shared_secret
+    )
+
+    Map.put(body_params, :oauth_signature, oauth_signature)
+  end
 
   describe "basic_launch" do
     setup [:create_institution]
 
     test "creates new user on first time lti request", %{conn: conn, institution: _institution} do
       conn = conn
-      |> Map.put(:host, "dcf69df7.ngrok.io")
-      |> post(Routes.lti_path(conn, :basic_launch), @sample_lti_request_data)
+      |> Map.put(:host, "www.example.com")
+      |> post(Routes.lti_path(conn, :basic_launch), build_lti_request(url_from_conn(conn), "6BCF251D1C1181C938BFA91896D4BE9B", "2MkTeXy05t9a3ySh0DwWeOq7iIWYJotNgQLqn1lOdI"))
 
 
       assert html_response(conn, 200) =~ "Welcome Example User"
@@ -70,7 +89,7 @@ defmodule OliWeb.LtiControllerTest do
     test "handles invalid lti request", %{conn: conn, institution: _institution} do
       conn = conn
       |> Map.put(:host, "some.invalid.host")
-      |> post(Routes.lti_path(conn, :basic_launch), @sample_lti_request_data)
+      |> post(Routes.lti_path(conn, :basic_launch), build_lti_request(url_from_conn(conn), "6BCF251D1C1181C938BFA91896D4BE9B", "2MkTeXy05t9a3ySh0DwWeOq7iIWYJotNgQLqn1lOdI"))
 
       assert html_response(conn, 200) =~ "LTI Launch Invalid"
       assert Enum.count(Repo.all(Accounts.User)) == 0
@@ -78,17 +97,33 @@ defmodule OliWeb.LtiControllerTest do
 
     test "uses existing user on subsequent lti requests", %{conn: conn, institution: _institution} do
       # issue first request
-      conn
-      |> Map.put(:host, "dcf69df7.ngrok.io")
-      |> post(Routes.lti_path(conn, :basic_launch), @sample_lti_request_data)
+      conn = conn
+      |> Map.put(:host, "www.example.com")
+      |> post(Routes.lti_path(conn, :basic_launch), build_lti_request(url_from_conn(conn), "6BCF251D1C1181C938BFA91896D4BE9B", "2MkTeXy05t9a3ySh0DwWeOq7iIWYJotNgQLqn1lOdI"))
+      assert html_response(conn, 200) =~ "Welcome Example User"
 
       # issue a second request with same user information
-      conn
-      |> Map.put(:host, "dcf69df7.ngrok.io")
-      |> post(Routes.lti_path(conn, :basic_launch), @sample_lti_request_data)
+      conn = conn
+      |> Map.put(:host, "www.example.com")
+      |> post(Routes.lti_path(conn, :basic_launch), build_lti_request(url_from_conn(conn), "6BCF251D1C1181C938BFA91896D4BE9B", "yggRHFN54fEXbhiVnFZNtXYZpeeE8d9uVmUeFpVho"))
+      assert html_response(conn, 200) =~ "Welcome Example User"
 
       # assert that only one user was created through both requests
       assert Enum.count(Repo.all(Accounts.User)) == 1
+    end
+
+    test "fails on duplicate nonce", %{conn: conn, institution: _institution} do
+      # issue first request
+      conn = conn
+      |> Map.put(:host, "www.example.com")
+      |> post(Routes.lti_path(conn, :basic_launch), build_lti_request(url_from_conn(conn), "6BCF251D1C1181C938BFA91896D4BE9B", "2MkTeXy05t9a3ySh0DwWeOq7iIWYJotNgQLqn1lOdI"))
+      assert html_response(conn, 200) =~ "Welcome Example User"
+
+      # issue a second request with same user information
+      conn = conn
+      |> Map.put(:host, "www.example.com")
+      |> post(Routes.lti_path(conn, :basic_launch), build_lti_request(url_from_conn(conn), "6BCF251D1C1181C938BFA91896D4BE9B", "2MkTeXy05t9a3ySh0DwWeOq7iIWYJotNgQLqn1lOdI"))
+      assert html_response(conn, 200) =~ "Invalid OAuth - Duplicate nonce"
     end
   end
 


### PR DESCRIPTION
This PR adds a table for storing LTI nonce and checking on every request that a duplicate nonce is not provided within the allowed request window. LTI request timestamp must be within 5 mins of the current time and nonces which are older than 1 day are purged to ensure that duplicate nonces are not used while minimizing the amount of nonces being stored.

Requirement for this feature comes from the LTI spec: [https://www.imsglobal.org/specs/ltiv2p0/security](https://www.imsglobal.org/specs/ltiv2p0/security)
"Upon receipt of the POST, the Tool Provider will perform the OAuth validation utilizing the shared secret it must have stored locally for the relationship with the Tool Consumer associated with the oauth_consumer_key.  The timestamp should also be validated to be within a specific time interval.  This time interval can be Tool Provider defined, but should be small (on the order of a few minutes if you do not record nonces or a few hours if you do).  It does rely on the time on the Tool Consumer and the Tool Provider being in sync though.

The Tool Provider should keep a record of nonces received and only allow the use of any nonce a single time.  Combined with the timestamp, this means that they only have to keep track of nonces for a period of time equal to their acceptable time interval.  Recommended practice would be to have a time interval of 90 minutes so that you keep a record of nonces for 90 minutes. "

**Recommended test procedure:**
Testing this feature is difficult because you must repeat an LTI request with the same nonce within a 5 min timeframe of the first request. While this can be accomplished using curl or postman, unit tests are provided as part of this PR as well