### PR TITLE
Enhanced editor

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -155,3 +155,222 @@ nav.navbar .user img {
   overflow: hidden;
   clip: rect(0 0 0 0);
 }
+
+.objectives-editor {
+  color: #666666;
+  padding-bottom: 20px;
+  margin-bottom: 20px;
+  border-bottom: 1px solid #cccccc;
+}
+
+.objectives-editor .learning-objectives-label {
+  margin-top: 10px;
+  margin-bottom: 4px;
+  font-size: .8em;
+  text-transform: uppercase;
+}
+
+
+/*
+Inlined react-bootstrap-typeahead styles
+*/
+
+.rbt .rbt-input-main::-ms-clear {
+  display: none;
+}
+
+/**
+ * Menu
+ */
+.rbt-menu {
+  margin-bottom: 2px;
+}
+
+.rbt-menu > .dropdown-item {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.rbt-menu > .dropdown-item:focus {
+  outline: none;
+}
+
+.rbt-menu-pagination-option {
+  text-align: center;
+}
+
+/**
+ * Multi-select Input
+ */
+.rbt-input-multi {
+  cursor: text;
+  overflow: hidden;
+  position: relative;
+  height: auto;
+}
+
+.rbt-input-multi.focus {
+  border-color: #80bdff;
+  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
+  color: #495057;
+  outline: 0;
+}
+
+.rbt-input-multi.form-control[disabled] {
+  background-color: #e9ecef;
+  opacity: 1;
+}
+
+.rbt-input-multi.is-invalid.focus {
+  border-color: #dc3545;
+  box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.25);
+}
+
+.rbt-input-multi.is-valid.focus {
+  border-color: #28a745;
+  box-shadow: 0 0 0 0.2rem rgba(40, 167, 69, 0.25);
+}
+
+.rbt-input-multi input::-moz-placeholder {
+  color: #6c757d;
+  opacity: 1;
+}
+
+.rbt-input-multi input:-ms-input-placeholder {
+  color: #6c757d;
+}
+
+.rbt-input-multi input::-webkit-input-placeholder {
+  color: #6c757d;
+}
+
+.rbt-input-multi .rbt-input-wrapper {
+  align-items: flex-start;
+  display: flex;
+  flex-wrap: wrap;
+  margin-bottom: -4px;
+  margin-top: -1px;
+  overflow: hidden;
+}
+
+.rbt-input-multi .rbt-input-main {
+  margin: 1px 0 4px;
+}
+
+/**
+ * Close Button
+ */
+.rbt-close {
+  z-index: 1;
+}
+
+.rbt-close-lg {
+  font-size: 24px;
+}
+
+/**
+ * Token
+ */
+.rbt-token {
+  background-color: #e7f4ff;
+  border: 0;
+  border-radius: .25rem;
+  color: #007bff;
+  display: inline-block;
+  line-height: 1em;
+  margin: 1px 3px 2px 0;
+  padding: 4px 7px;
+  position: relative;
+}
+
+.rbt-token-disabled {
+  background-color: rgba(0, 0, 0, 0.1);
+  color: #495057;
+  pointer-events: none;
+}
+
+.rbt-token-removeable {
+  cursor: pointer;
+  padding-right: 21px;
+}
+
+.rbt-token-active {
+  background-color: #007bff;
+  color: #fff;
+  outline: none;
+  text-decoration: none;
+}
+
+.rbt-token .rbt-token-remove-button {
+  bottom: 0;
+  color: inherit;
+  font-size: inherit;
+  font-weight: normal;
+  opacity: 1;
+  outline: none;
+  padding: 3px 7px;
+  position: absolute;
+  right: 0;
+  text-shadow: none;
+  top: -2px;
+}
+
+/**
+ * Loader + CloseButton container
+ */
+.rbt-aux {
+  align-items: center;
+  display: flex;
+  bottom: 0;
+  justify-content: center;
+  pointer-events: none;
+  /* Don't block clicks on the input */
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: 34px;
+}
+
+.rbt-aux-lg {
+  width: 46px;
+}
+
+.rbt-aux .rbt-close {
+  margin-top: -4px;
+  pointer-events: auto;
+  /* Override pointer-events: none; above */
+}
+
+.has-aux .rbt-input {
+  padding-right: 34px;
+}
+
+.rbt-highlight-text {
+  background-color: inherit;
+  color: inherit;
+  font-weight: bold;
+  padding: 0;
+}
+
+/**
+ * Input Groups
+ */
+.input-group > .rbt {
+  flex: 1;
+}
+
+.input-group > .rbt .rbt-input-hint,
+.input-group > .rbt .rbt-aux {
+  z-index: 5;
+}
+
+.input-group > .rbt:not(:first-child) .form-control {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.input-group > .rbt:not(:last-child) .form-control {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -144,3 +144,14 @@ nav.navbar .user img {
   cursor: -webkit-grabbing;
   cursor: -moz-grabbing;
 }
+
+.assistive-text {
+  position: absolute;
+  margin: -1px;
+  border: 0;
+  padding: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+}

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -159,8 +159,8 @@ nav.navbar .user img {
 .objectives-editor {
   color: #666666;
   padding-bottom: 20px;
-  margin-bottom: 20px;
-  border-bottom: 1px solid #cccccc;
+  padding-left: 10px;
+  padding-right: 10px;
 }
 
 .objectives-editor .learning-objectives-label {

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -125,3 +125,22 @@ nav.navbar .user img {
 .flex-1 {
   flex: 1;
 }
+
+.dragHandleGrab {
+  cursor: -webkit-grab;
+  cursor: -moz-grab;
+  display: inline-block;
+  vertical-align: middle;
+}
+.dragHandleGrab .grip {
+  width: 12px;
+  height: 100%;
+  background-image: -webkit-repeating-radial-gradient(center center, rgba(0,0,0,0.2), rgba(0,0,0,0.3) 1px, transparent 1px, transparent 100%);
+  background-repeat: repeat;
+  background-size: 4px 4px;
+}
+
+.dragHandleGrab:active {
+  cursor: -webkit-grabbing;
+  cursor: -moz-grabbing;
+}

--- a/assets/package.json
+++ b/assets/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@types/jquery": "^3.3.31",
     "@types/react": "^16.9.2",
+    "@types/react-bootstrap-typeahead": "^3.4.5",
     "@types/react-dom": "^16.9.5",
     "@types/react-redux": "^7.1.7",
     "@types/redux-logger": "^3.0.7",
@@ -27,6 +28,7 @@
     "phoenix_html": "file:../deps/phoenix_html",
     "phoenix_live_view": "file:../deps/phoenix_live_view",
     "react": "^16.9.0",
+    "react-bootstrap-typeahead": "^5.0.0-alpha.1",
     "react-dom": "^16.9.0",
     "react-redux": "^7.1.3",
     "redux": "^4.0.5",

--- a/assets/src/components/TextEditor.tsx
+++ b/assets/src/components/TextEditor.tsx
@@ -7,6 +7,7 @@ export interface TextEditorProps {
   showAffordances: boolean;
   editMode: boolean;
   size?: 'regular' | 'large';
+  allowEmptyContents?: boolean;
 }
 
 export interface LabelledTextEditorProps extends TextEditorProps {
@@ -25,63 +26,82 @@ export const LabelledTextEditor = (props: LabelledTextEditorProps) => {
 export const TextEditor = (props: TextEditorProps) => {
 
   const { model, showAffordances, onEdit, editMode } = props;
+  const allowEmpty = props.allowEmptyContents === undefined ? true : props.allowEmptyContents;
   const [current, setCurrent] = useState(model);
+  const [value, setValue] = useState(model);
   const [isEditing, setIsEditing] = useState(false);
 
   useEffect(() => {
     setCurrent(model);
   }, [model]);
 
+  const isValid = (value : string) => value.trim() !== '';
+
   const onTitleEdit = (e: any) => {
     setIsEditing(false);
-    onEdit(current);
+    if (isValid(value)) {
+      setCurrent(value);
+      onEdit(value);
+    }
   };
 
   const onSave = (e: any) => {
     setIsEditing(false);
-    onEdit(current);
+    if (isValid(value)) {
+      setCurrent(value);
+      onEdit(value);
+    }
   };
 
   const onCancel = () => setIsEditing(false);
 
   const onBeginEdit = () => {
+    setValue(current);
     setIsEditing(true);
   };
 
   const onTextChange = (e: any) => {
-    setCurrent(e.target.value);
+    setValue(e.target.value);
   };
 
   const onKeyUp = (e: any) => {
     if (e.keyCode === ESCAPE_KEYCODE) {
       onCancel();
     } else if (e.keyCode === ENTER_KEYCODE) {
-      onTitleEdit(e);
+      if (allowEmpty || isValid(value)) {
+        onTitleEdit(e);
+      }
     }
   };
 
   const editingUI = () => {
-    const style = { marginTop: '5px' };
+    const style = { marginTop: '5px', width: '90%', display: 'inline' };
+
+    const validity = !allowEmpty && !isValid(value) ? 'is-invalid' : '';
+    const size = props.size === 'large' ? 'form-control-lg' : '';
+    const inputClass = `form-control ${validity} ${size}`;
 
     return (
       <div data-slate-editor style={{ display: 'inline' }}>
-        <input type="text" className={props.size === 'large' ? 'form-control-lg' : ''}
+        <input type="text"
+          className={inputClass}
           onKeyUp={onKeyUp}
           onChange={onTextChange}
-          value={current}
+          value={value}
           style={style} />
         <button
           key="save"
           onClick={onSave}
           type="button"
-          className="btn btn-sm">
+          disabled={!allowEmpty && !isValid(value)}
+          className="btn btn-link btn-sm">
           Done
         </button>
         <button
           key="cancel"
           onClick={onCancel}
           type="button"
-          className="btn btn-sm">
+          className="btn btn-link btn-sm">
           Cancel
         </button>
       </div>

--- a/assets/src/components/TextEditor.tsx
+++ b/assets/src/components/TextEditor.tsx
@@ -6,6 +6,7 @@ export interface TextEditorProps {
   model: string;
   showAffordances: boolean;
   editMode: boolean;
+  size?: 'regular' | 'large';
 }
 
 export interface LabelledTextEditorProps extends TextEditorProps {
@@ -64,7 +65,7 @@ export const TextEditor = (props: TextEditorProps) => {
 
     return (
       <div data-slate-editor style={{ display: 'inline' }}>
-        <input type="text"
+        <input type="text" className={props.size === 'large' ? 'form-control-lg' : ''}
           onKeyUp={onKeyUp}
           onChange={onTextChange}
           value={current}
@@ -94,6 +95,7 @@ export const TextEditor = (props: TextEditorProps) => {
       textAlign: 'left',
       color: 'black',
       fontWeight: 'normal',
+      fontSize: props.size === 'large' ? '18pt' : '12pt',
     };
 
     return (

--- a/assets/src/components/resource/DragHandle.tsx
+++ b/assets/src/components/resource/DragHandle.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+
+export interface DragHandleProps {
+  hidden?: boolean;
+}
+
+export const DragHandle = (props: DragHandleProps) => {
+
+  const { hidden = false } = props;
+
+  return (
+    <div className={`dragHandleGrab ${hidden ? 'invisible' : ''}`}>
+      <div className="grip" />
+    </div>
+  );
+};

--- a/assets/src/components/resource/Editors.tsx
+++ b/assets/src/components/resource/Editors.tsx
@@ -15,6 +15,13 @@ export type EditorsProps = {
   resourceType: ResourceType,
 };
 
+function createEditorWithLabel(
+  content: ResourceContent, resourceType: ResourceType,
+  editMode: boolean, onEdit: (content: ResourceContent) => void) {
+
+
+}
+
 // The list of editors
 export const Editors = (props: EditorsProps) => {
 
@@ -23,31 +30,17 @@ export const Editors = (props: EditorsProps) => {
   // Factory for creating top level editors, for things like structured
   // content or referenced activities
   const createEditor = (
-    editorMap: ActivityEditorMap,
     content: ResourceContent,
-    editMode: boolean,
     onEdit: (content: ResourceContent) => void,
-    onRemove: () => void,
-    contentSize: number,
-    ) : JSX.Element => {
+    ) : [JSX.Element, string] => {
 
     if (content.type === 'content') {
-
-      const editor = <StructuredContentEditor
+      return [<StructuredContentEditor
         key={content.id}
         editMode={editMode}
         content={content}
         onEdit={onEdit}
-        toolbarItems={getToolbarForResourceType(resourceType)}/>;
-
-      return contentSize > 1
-        ?
-        <ResourceContentFrame
-          key={content.id}
-          allowRemoval={true} editMode={editMode} label="Content" onRemove={onRemove}>
-            {editor}
-        </ResourceContentFrame>
-        : editor;
+        toolbarItems={getToolbarForResourceType(resourceType)}/>, 'Content'];
     }
 
     const unsupported : EditorDesc = {
@@ -61,23 +54,10 @@ export const Editors = (props: EditorsProps) => {
     const editor = editorMap[content.type]
       ? editorMap[content.type] : unsupported;
 
-    const props = {
+    const props = {};
 
-    };
+    return [React.createElement(editor.deliveryElement, props), editor.friendlyName];
 
-    const editorElement = React.createElement(editor.deliveryElement, props);
-
-    return contentSize > 1
-        ?
-        <ResourceContentFrame
-          key={content.id}
-          allowRemoval={contentSize > 1}
-          editMode={editMode}
-          label={editor.friendlyName}
-          onRemove={onRemove}>
-          {editorElement}
-        </ResourceContentFrame>
-        : editorElement;
   };
 
   const editors = content.map((c, index) => {
@@ -85,7 +65,20 @@ export const Editors = (props: EditorsProps) => {
     const onEdit = (u : ResourceContent) => props.onEdit(content.set(index, u));
     const onRemove = () => props.onEdit(content.remove(index));
 
-    return createEditor(editorMap, c, editMode, onEdit, onRemove, content.size);
+    const [editor, label] = createEditor(c, onEdit);
+
+    return (
+      <ResourceContentFrame
+        key={c.id}
+        allowRemoval={content.size > 1}
+        editMode={editMode}
+        label={label}
+        onRemove={onRemove}>
+
+        {editor}
+
+      </ResourceContentFrame>
+    );
   });
 
   return (

--- a/assets/src/components/resource/Editors.tsx
+++ b/assets/src/components/resource/Editors.tsx
@@ -32,18 +32,22 @@ export const Editors = (props: EditorsProps) => {
     ) : JSX.Element => {
 
     if (content.type === 'content') {
-      return (
+
+      const editor = <StructuredContentEditor
+        key={content.id}
+        editMode={editMode}
+        content={content}
+        onEdit={onEdit}
+        toolbarItems={getToolbarForResourceType(resourceType)}/>;
+
+      return contentSize > 1
+        ?
         <ResourceContentFrame
           key={content.id}
-          allowRemoval={contentSize > 1} editMode={editMode} label="Content" onRemove={onRemove}>
-          <StructuredContentEditor
-            key={content.id}
-            editMode={editMode}
-            content={content}
-            onEdit={onEdit}
-            toolbarItems={getToolbarForResourceType(resourceType)}/>
+          allowRemoval={true} editMode={editMode} label="Content" onRemove={onRemove}>
+            {editor}
         </ResourceContentFrame>
-      );
+        : editor;
     }
 
     const unsupported : EditorDesc = {
@@ -61,17 +65,19 @@ export const Editors = (props: EditorsProps) => {
 
     };
 
-    return (
-      <ResourceContentFrame
-        key={content.id}
-        allowRemoval={contentSize > 1}
-        editMode={editMode}
-        label={editor.friendlyName}
-        onRemove={onRemove}>
+    const editorElement = React.createElement(editor.deliveryElement, props);
 
-        {React.createElement(editor.deliveryElement, props)}
-      </ResourceContentFrame>
-    );
+    return contentSize > 1
+        ?
+        <ResourceContentFrame
+          key={content.id}
+          allowRemoval={contentSize > 1}
+          editMode={editMode}
+          label={editor.friendlyName}
+          onRemove={onRemove}>
+          {editorElement}
+        </ResourceContentFrame>
+        : editorElement;
   };
 
   const editors = content.map((c, index) => {

--- a/assets/src/components/resource/Objectives.tsx
+++ b/assets/src/components/resource/Objectives.tsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react';
+import * as Immutable from 'immutable';
+import { Typeahead } from 'react-bootstrap-typeahead';
+import { Objective, ObjectiveSlug } from 'data/content/objective';
+import guid from 'utils/guid';
+
+import 'react-bootstrap-typeahead/css/Typeahead.css';
+
+export type ObjectivesProps = {
+  objectives: Immutable.List<Objective>;
+  selected: Immutable.List<ObjectiveSlug>;
+  editMode: boolean;
+  onEdit: (objectives: Immutable.List<ObjectiveSlug>) => void;
+};
+
+export const Objectives = (props: ObjectivesProps) => {
+
+  const { objectives, onEdit, editMode, selected } = props;
+  const [id] = useState('' + guid);
+
+  const map = Immutable.Map<ObjectiveSlug, Objective>(objectives.toArray().map(o => [o.id, o]));
+  const asObjectives = selected.toArray().map(s => map.get(s) as Objective);
+
+  return (
+    <div className="objectives-editor">
+      <div className="learning-objectives-label">Learning Objectives</div>
+      <Typeahead
+        id={id}
+        multiple={true}
+        disabled={!editMode}
+        onChange={(updated: Objective[]) => {
+          if (updated.length !== selected.size) {
+            onEdit(Immutable.List<ObjectiveSlug>(updated.map(o => o.id)));
+          }
+        }}
+        options={objectives.toArray()}
+        labelKey="title"
+        selected={asObjectives}
+        placeholder="Select learning objectives..."
+      />
+    </div>
+  );
+};

--- a/assets/src/components/resource/Outline.tsx
+++ b/assets/src/components/resource/Outline.tsx
@@ -71,7 +71,8 @@ const OutlineContent = ({ content, index, onDrop, desc }) => {
   return (
     <React.Fragment>
       <DropTarget id={content.id} index={index} onDrop={onDrop}/>
-      <div draggable={true} key={content.id} className="border-0 p-1"
+      <div
+        draggable={true} key={content.id} className="border-0 p-1"
         onDragStart={handleDragStart}
       >
         <div className="d-flex">

--- a/assets/src/components/resource/Outline.tsx
+++ b/assets/src/components/resource/Outline.tsx
@@ -2,9 +2,9 @@ import * as Immutable from 'immutable';
 import React, { useState } from 'react';
 import { ResourceContent } from 'data/content/resource';
 import { ActivityEditorMap } from 'data/content/editors';
-import { getContentDescription } from 'data/content/utils';
 import { toSimpleText } from '../editor/utils';
 import { DragHandle } from './DragHandle';
+import { getContentDescription } from 'data/content/utils';
 
 export type ResourceEditorProps = {
   editMode: boolean,              // Whether or not we can edit
@@ -79,11 +79,11 @@ const OutlineContent = ({ content, index, onDrop, desc, onFocus, onMove }) => {
   return (
     <div
       onKeyDown={handleKeyDown}
-      onFocus={e => onFocus(index, desc)}
+      onFocus={e => onFocus(index)}
       role="option"
       aria-describedby="outline-list-operation"
       tabIndex={index}
-      style={ { paddingLeft: '4px' } }>
+      style={ { paddingLeft: '4px', paddingRight: '4px' } }>
 
       <DropTarget id={content.id} index={index} onDrop={onDrop}/>
 
@@ -93,9 +93,9 @@ const OutlineContent = ({ content, index, onDrop, desc, onFocus, onMove }) => {
       >
         <div className="d-flex">
           <DragHandle/>
-          <div className="m-2">
+          <div className="m-2 text-truncate">
             <div className="d-flex justify-content-between">
-              <h5 className="mb-1">Content</h5>
+              <div className="mb-1">Content</div>
               {content.purpose !== 'None' ? <small>{content.purpose}</small> : null}
             </div>
             <small>{desc}</small>
@@ -112,7 +112,7 @@ type OutlineEntryProps = {
   editorMap: ActivityEditorMap,
   index: number,
   onDrop: (id: React.DragEvent<HTMLDivElement>, index: number) => void,
-  onFocus: (index: number, desc: string) => void,
+  onFocus: (index: number) => void,
   onMove: (index: number, up: boolean) => void,
 };
 
@@ -121,7 +121,7 @@ const OutlineEntry = (props: OutlineEntryProps) => {
   const { content, editorMap } = props;
 
   const desc = content.type === 'content'
-    ? 'Content' : editorMap[content.type].friendlyName;
+    ? getContentDescription(content) : editorMap[content.type].friendlyName;
 
   return (
     <OutlineContent {...props} desc={desc} />
@@ -135,7 +135,11 @@ export const Outline = (props: ResourceEditorProps) => {
   const content = Immutable.List<ResourceContent>(props.content);
   const [assisstive, setAssisstive] = useState('');
 
-  const onFocus = (index: number, desc: string) => {
+  const onFocus = (index: number) => {
+    const item = content.get(index) as ResourceContent;
+    const desc = item.type === 'content'
+      ? getContentDescription(item) : editorMap[item.type].friendlyName;
+
     setAssisstive(
       `Listbox. ${index + 1} of ${content.size}. ${desc}.`);
   };

--- a/assets/src/components/resource/Outline.tsx
+++ b/assets/src/components/resource/Outline.tsx
@@ -23,9 +23,45 @@ export const Outline = (props: ResourceEditorProps) => {
     editorMap: ActivityEditorMap,
     content: ResourceContent) : JSX.Element => {
 
+    const handleDragEnter = (e: React.DragEvent<HTMLAnchorElement>) => {
+      e.preventDefault();
+      e.stopPropagation();
+    };
+    const handleDragLeave = (e: React.DragEvent<HTMLAnchorElement>) => {
+      e.preventDefault();
+      e.stopPropagation();
+    };
+    const handleDrop = (e: React.DragEvent<HTMLAnchorElement>) => {
+      e.preventDefault();
+      e.stopPropagation();
+    };
+
     if (content.type === 'content') {
+
+      const handleDragStart = (e: React.DragEvent<HTMLAnchorElement>) => {
+        const dt = e.dataTransfer;
+        const preview = `
+          <a href="#" style="margin-top: 0px;" class="list-group-item">
+            <div className="d-flex w-100 justify-content-between">
+              <h5 className="mb-1">Content</h5>
+              <small></small>
+            </div>
+            <small>${getContentDescription(content)}</small>
+          </a>
+        `;
+        dt.setData('text/html', preview);
+
+        //e.preventDefault();
+        //e.stopPropagation();
+      };
+
       return (
-        <a href="#" key={content.id} style={ { marginTop: '0px' } } className="list-group-item list-group-item-action">
+        <a draggable={true} href="#" key={content.id} style={ { marginTop: '0px' } } className="list-group-item list-group-item-action"
+          onDrop={handleDrop}
+          onDragEnter={handleDragEnter}
+          onDragLeave={handleDragLeave}
+          onDragStart={handleDragStart}
+        >
           <div className="d-flex w-100 justify-content-between">
             <h5 className="mb-1">Content</h5>
             {content.purpose !== 'None' ? <small>{content.purpose}</small> : null}
@@ -38,7 +74,11 @@ export const Outline = (props: ResourceEditorProps) => {
     const activityEditor = editorMap[content.type];
 
     return (
-      <a href="#" key={content.id} style={ { marginTop: '0px' } } className="list-group-item list-group-item-action">
+      <a href="#" key={content.id} style={ { marginTop: '0px' } } className="list-group-item list-group-item-action"
+        onDrop={handleDrop}
+        onDragEnter={handleDragEnter}
+        onDragLeave={handleDragLeave}
+      >
         <div className="d-flex w-100 justify-content-between">
           <h5 className="mb-1">{activityEditor.friendlyName}</h5>
           {content.purpose !== 'None' ? <small>{content.purpose}</small> : null}

--- a/assets/src/components/resource/ResourceEditor.tsx
+++ b/assets/src/components/resource/ResourceEditor.tsx
@@ -162,6 +162,23 @@ export class ResourceEditor extends React.Component<ResourceEditorProps, Resourc
     const onAddItem = (c : ResourceContent) =>
       this.update({ content: this.state.undoable.current.content.push(c) });
 
+    const editingImpl = state.undoable.current.content.size > 1
+      ? (
+          <div className="d-flex flex-row align-items-start">
+            <Outline {...props} editMode={this.state.editMode}
+              onEdit={c => onEdit(c)} content={state.undoable.current.content}/>
+            <Editors {...props} editMode={this.state.editMode}
+              onEdit={c => onEdit(c)} content={state.undoable.current.content}/>
+          </div>
+        )
+      : (
+          <div className="p-4">
+            <Editors {...props} editMode={this.state.editMode}
+              onEdit={c => onEdit(c)} content={state.undoable.current.content}/>
+          </div>
+        );
+
+
     return (
       <div>
         <TitleBar
@@ -175,17 +192,7 @@ export class ResourceEditor extends React.Component<ResourceEditorProps, Resourc
           editMode={this.state.editMode}
           editorMap={this.props.editorMap}/>
 
-        <div className="d-flex flex-row align-items-baseline">
-          {
-          // We only show the outline if there is more than one content element in the resource
-          state.undoable.current.content.size > 0
-            ? <Outline {...props} editMode={this.state.editMode}
-            onEdit={c => onEdit(c)} content={state.undoable.current.content}/>
-            : null
-          }
-          <Editors {...props} editMode={this.state.editMode}
-            onEdit={c => onEdit(c)} content={state.undoable.current.content}/>
-        </div>
+        {editingImpl}
       </div>
     );
   }

--- a/assets/src/components/resource/ResourceEditor.tsx
+++ b/assets/src/components/resource/ResourceEditor.tsx
@@ -21,7 +21,7 @@ export type ResourceEditorProps = {
   resourceSlug: ResourceSlug,     // The current resource
   title: string,                  // The title of the resource
   content: ResourceContent[],     // Content of the resource
-  objectives: Objective[],        // Attached objectives
+  objectives: ObjectiveSlug[],        // Attached objectives
   allObjectives: Objective[],     // All objectives
   editorMap: ActivityEditorMap,   // Map of activity types to activity elements
 };
@@ -87,7 +87,7 @@ export class ResourceEditor extends React.Component<ResourceEditorProps, Resourc
       editMode: true,
       undoable: init({
         title,
-        objectives: Immutable.List<ObjectiveSlug>(objectives.map(o => o.id)),
+        objectives: Immutable.List<ObjectiveSlug>(objectives),
         content: Immutable.List<ResourceContent>(withDefaultContent(content)),
       }),
       persistence: 'idle',

--- a/assets/src/components/resource/ResourceEditor.tsx
+++ b/assets/src/components/resource/ResourceEditor.tsx
@@ -165,23 +165,6 @@ export class ResourceEditor extends React.Component<ResourceEditorProps, Resourc
     const onAddItem = (c : ResourceContent) =>
       this.update({ content: this.state.undoable.current.content.push(c) });
 
-    const editingImpl = state.undoable.current.content.size > 1
-      ? (
-          <div className="d-flex flex-row align-items-start">
-            <Outline {...props} editMode={this.state.editMode}
-              onEdit={c => onEdit(c)} content={state.undoable.current.content}/>
-            <Editors {...props} editMode={this.state.editMode}
-              onEdit={c => onEdit(c)} content={state.undoable.current.content}/>
-          </div>
-        )
-      : (
-          <div className="p-4">
-            <Editors {...props} editMode={this.state.editMode}
-              onEdit={c => onEdit(c)} content={state.undoable.current.content}/>
-          </div>
-        );
-
-
     return (
       <div>
         <TitleBar
@@ -199,7 +182,12 @@ export class ResourceEditor extends React.Component<ResourceEditorProps, Resourc
           selected={this.state.undoable.current.objectives}
           objectives={this.state.allObjectives}
           onEdit={objectives => this.update({ objectives })} />
-        {editingImpl}
+        <div className="d-flex flex-row align-items-start">
+          <Outline {...props} editMode={this.state.editMode}
+            onEdit={c => onEdit(c)} content={state.undoable.current.content}/>
+          <Editors {...props} editMode={this.state.editMode}
+            onEdit={c => onEdit(c)} content={state.undoable.current.content}/>
+        </div>
       </div>
     );
   }

--- a/assets/src/components/resource/TitleBar.tsx
+++ b/assets/src/components/resource/TitleBar.tsx
@@ -25,9 +25,13 @@ export const TitleBar = (props: TitleBarProps) => {
 
   return (
     <div className="d-flex flex-row align-items-baseline">
-      <div className="flex-grow-1">
+      <div className="flex-grow-1 p-4">
         <TextEditor
-          onEdit={onTitleEdit} model={title} showAffordances={true} editMode={editMode}/>
+          onEdit={onTitleEdit}
+          model={title}
+          showAffordances={true}
+          size="large"
+          editMode={editMode}/>
       </div>
 
       <div className="btn-group btn-group-sm" role="group" aria-label="Undo redo creation">

--- a/assets/src/components/resource/TitleBar.tsx
+++ b/assets/src/components/resource/TitleBar.tsx
@@ -31,6 +31,7 @@ export const TitleBar = (props: TitleBarProps) => {
           model={title}
           showAffordances={true}
           size="large"
+          allowEmptyContents={false}
           editMode={editMode}/>
       </div>
 

--- a/assets/src/components/resource/undo.ts
+++ b/assets/src/components/resource/undo.ts
@@ -16,12 +16,12 @@ export function init<T>(current: T): UndoableState<T> {
 
 export function processUndo<T>(state: UndoableState<T>): UndoableState<T> {
 
-  const current = state.undoStack.peek();
+  const next = state.undoStack.peek();
 
-  if (current !== undefined) {
+  if (next !== undefined) {
     const undoStack = state.undoStack.pop();
-    const redoStack = state.redoStack.push(current);
-    return { current, undoStack, redoStack };
+    const redoStack = state.redoStack.push(state.current);
+    return { current: next, undoStack, redoStack };
   }
 
   return state;
@@ -29,12 +29,12 @@ export function processUndo<T>(state: UndoableState<T>): UndoableState<T> {
 
 export function processRedo<T>(state: UndoableState<T>): UndoableState<T> {
 
-  const current = state.redoStack.peek();
+  const next = state.redoStack.peek();
 
-  if (current !== undefined) {
-    const undoStack = state.undoStack.push(current);
+  if (next !== undefined) {
+    const undoStack = state.undoStack.push(state.current);
     const redoStack = state.redoStack.pop();
-    return { current, undoStack, redoStack };
+    return { current: next, undoStack, redoStack };
   }
 
   return state;

--- a/assets/src/data/content/objective.ts
+++ b/assets/src/data/content/objective.ts
@@ -2,6 +2,6 @@ import { ObjectiveSlug } from 'data/types';
 export { ObjectiveSlug } from 'data/types';
 
 export type Objective = {
-  id: ObjectiveSlug,
+  slug: ObjectiveSlug,
   title: string,
 };

--- a/assets/src/data/content/objective.ts
+++ b/assets/src/data/content/objective.ts
@@ -1,5 +1,7 @@
+import { ObjectiveSlug } from 'data/types';
+export { ObjectiveSlug } from 'data/types';
 
 export type Objective = {
-  id: number,
+  id: ObjectiveSlug,
   title: string,
 };

--- a/assets/src/data/content/resource.ts
+++ b/assets/src/data/content/resource.ts
@@ -46,4 +46,5 @@ export interface ActivityReference {
   id: number;
   idRef: number;
   purpose: ActivityPurpose;
+  children: [];
 }

--- a/assets/src/data/types.ts
+++ b/assets/src/data/types.ts
@@ -1,5 +1,6 @@
 
 export type ResourceSlug = string;
 export type ProjectSlug = string;
+export type ObjectiveSlug = string;
 export type ElementId = number;
 export type UserEmail = string;

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -740,6 +740,13 @@
     "@babel/plugin-transform-react-jsx-self" "^7.8.3"
     "@babel/plugin-transform-react-jsx-source" "^7.8.3"
 
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.8.7":
+  version "7.9.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.2.tgz#d90df0583a3a252f09aaa619665367bae518db06"
+  integrity sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.5.5":
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.4.tgz#d79f5a2040f7caa24d53e563aad49cbc05581308"
@@ -1007,6 +1014,14 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
+"@restart/hooks@^0.3.12":
+  version "0.3.22"
+  resolved "https://registry.yarnpkg.com/@restart/hooks/-/hooks-0.3.22.tgz#bb7e27c832bf576f56977d0a0b8b9d8ccee877b8"
+  integrity sha512-tW0T3hP6emYNOc76/iC96rlu+f7JYLSVk/Wnn+7dj1gJUcw4CkQNLy16vx2mBLtVKsFMZ9miVEZXat8blruDHQ==
+  dependencies:
+    lodash "^4.17.15"
+    lodash-es "^4.17.15"
+
 "@sinonjs/commons@^1.7.0":
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.7.1.tgz#da5fd19a5f71177a53778073978873964f49acf1"
@@ -1144,6 +1159,13 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
+"@types/react-bootstrap-typeahead@^3.4.5":
+  version "3.4.5"
+  resolved "https://registry.yarnpkg.com/@types/react-bootstrap-typeahead/-/react-bootstrap-typeahead-3.4.5.tgz#94ea5a90b611e238fa8c3467eb1e3172427b1053"
+  integrity sha512-waTJZ1QER+bUUmNXqLw2QwJxe/G2EfjYuSLg6BURUe2rEkBTKRTmjiCrVBfRQ2JqqoaC7ScYEasm/DPw3lkvCA==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-dom@^16.9.5":
   version "16.9.5"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.5.tgz#5de610b04a35d07ffd8f44edad93a71032d9aaa7"
@@ -1165,6 +1187,14 @@
   version "16.9.19"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.19.tgz#c842aa83ea490007d29938146ff2e4d9e4360c40"
   integrity sha512-LJV97//H+zqKWMms0kvxaKYJDG05U2TtQB3chRLF8MPNs+MQh/H1aGlyDUxjaHvu08EAGerdX2z4LTBc7ns77A==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
+
+"@types/react@^16.9.11":
+  version "16.9.34"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.34.tgz#f7d5e331c468f53affed17a8a4d488cd44ea9349"
+  integrity sha512-8AJlYMOfPe1KGLKyHpflCg5z46n0b5DbRfqDksxBLBTUpB75ypDBAO9eCUcjNwE6LCUslwTz00yyG/X9gaVtow==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
@@ -2146,6 +2176,11 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classnames@^2.2.0:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
+
 clean-stack@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
@@ -2406,6 +2441,14 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+create-react-context@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.3.0.tgz#546dede9dc422def0d3fc2fe03afe0bc0f4f7d8c"
+  integrity sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==
+  dependencies:
+    gud "^1.0.0"
+    warning "^4.0.3"
+
 cross-spawn@6.0.5, cross-spawn@^6.0.0:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -2538,6 +2581,11 @@ csstype@^2.2.0:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.8.tgz#0fb6fc2417ffd2816a418c9336da74d7f07db431"
   integrity sha512-msVS9qTuMT5zwAGCVm4mxfrZ18BNc6Csd0oJAtiFMZ1FAx1CCvy2+5MDmYoix63LM/6NDbNtodCiGYGmFgO0dA==
 
+csstype@^2.6.7:
+  version "2.6.10"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.10.tgz#e63af50e66d7c266edb6b32909cfd0aabe03928b"
+  integrity sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==
+
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -2612,6 +2660,18 @@ deep-diff@^0.3.5:
   version "0.3.8"
   resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.8.tgz#c01de63efb0eec9798801d40c7e0dae25b582c84"
   integrity sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ=
+
+deep-equal@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz#b5c98c942ceffaf7cb051e24e1434a25a2e6076a"
+  integrity sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==
+  dependencies:
+    is-arguments "^1.0.4"
+    is-date-object "^1.0.1"
+    is-regex "^1.0.4"
+    object-is "^1.0.1"
+    object-keys "^1.1.1"
+    regexp.prototype.flags "^1.2.0"
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -2742,6 +2802,14 @@ doctrine@0.7.2:
   dependencies:
     esutils "^1.1.6"
     isarray "0.0.1"
+
+dom-helpers@^5.1.0:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.1.4.tgz#4609680ab5c79a45f2531441f1949b79d6587f4b"
+  integrity sha512-TjMyeVUvNEnOnhzs6uAn9Ya47GmMo3qq7m+Lr/3ON0Rs5kHvb8I+SQYjLUSYn7qhEm0QjW0yrBkvz9yOrwwz1A==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+    csstype "^2.6.7"
 
 domain-browser@^1.1.1:
   version "1.2.0"
@@ -2875,6 +2943,11 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
+
+escape-string-regexp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
+  integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
 
 escodegen@^1.11.1:
   version "1.14.1"
@@ -3406,6 +3479,11 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
+gud@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
+  integrity sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==
+
 har-schema@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
@@ -3687,7 +3765,7 @@ interpret@1.2.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
   integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
 
-invariant@^2.2.2, invariant@^2.2.4:
+invariant@^2.2.1, invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -3727,6 +3805,11 @@ is-accessor-descriptor@^1.0.0:
   integrity sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==
   dependencies:
     kind-of "^6.0.0"
+
+is-arguments@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.0.4.tgz#3faf966c7cba0ff437fb31f6250082fcf0448cf3"
+  integrity sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -3893,7 +3976,7 @@ is-plain-object@^3.0.0:
   dependencies:
     isobject "^4.0.0"
 
-is-regex@^1.0.5:
+is-regex@^1.0.4, is-regex@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.5.tgz#39d589a358bf18967f726967120b8fc1aed74eae"
   integrity sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==
@@ -4616,7 +4699,7 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash-es@^4.2.1:
+lodash-es@^4.17.15, lodash-es@^4.2.1:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
   integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
@@ -5164,6 +5247,11 @@ object-inspect@^1.7.0:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.7.0.tgz#f4f6bd181ad77f006b5ece60bd0b6f398ff74a67"
   integrity sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==
 
+object-is@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.0.2.tgz#6b80eb84fe451498f65007982f035a5b445edec4"
+  integrity sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ==
+
 object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
@@ -5499,6 +5587,11 @@ pn@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
   integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
+
+popper.js@^1.14.4, popper.js@^1.15.0:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
+  integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
 
 posix-character-classes@^0.1.0:
   version "0.1.1"
@@ -5842,7 +5935,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.4"
 
-prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.8, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -5966,6 +6059,23 @@ randomfill@^1.0.3:
     randombytes "^2.0.5"
     safe-buffer "^5.1.0"
 
+react-bootstrap-typeahead@^5.0.0-alpha.1:
+  version "5.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/react-bootstrap-typeahead/-/react-bootstrap-typeahead-5.0.0-alpha.1.tgz#58a57ff2abf38534219b352d1b7ef58b29673917"
+  integrity sha512-kT6kkmb+C5ZqossAreExvyKTkxiQXEkTeLDsJ980t2shKvMsQCeha7HgtIeaWU4FY8vfe4aNsFdyce0etCf75w==
+  dependencies:
+    "@babel/runtime" "^7.3.4"
+    classnames "^2.2.0"
+    escape-string-regexp "^2.0.0"
+    fast-deep-equal "^3.1.1"
+    invariant "^2.2.1"
+    lodash.debounce "^4.0.8"
+    prop-types "^15.5.8"
+    react-overlays "^2.0.0"
+    react-popper "^1.0.0"
+    scroll-into-view-if-needed "^2.2.20"
+    warning "^4.0.1"
+
 react-dom@^16.9.0:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.12.0.tgz#0da4b714b8d13c2038c9396b54a92baea633fe11"
@@ -5980,6 +6090,37 @@ react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.9.0:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
+
+react-lifecycles-compat@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
+  integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-overlays@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-2.1.1.tgz#ffe2090c4a10da6b8947a1c7b1a67d0457648a0d"
+  integrity sha512-gaQJwmb8Ij2IGVt4D1HmLtl4A0mDVYxlsv/8i0dHWK7Mw0kNat6ORelbbEWzaXTK1TqMeQtJw/jraL3WOADz3w==
+  dependencies:
+    "@babel/runtime" "^7.4.5"
+    "@restart/hooks" "^0.3.12"
+    dom-helpers "^5.1.0"
+    popper.js "^1.15.0"
+    prop-types "^15.7.2"
+    uncontrollable "^7.0.0"
+    warning "^4.0.3"
+
+react-popper@^1.0.0:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-1.3.7.tgz#f6a3471362ef1f0d10a4963673789de1baca2324"
+  integrity sha512-nmqYTx7QVjCm3WUZLeuOomna138R1luC4EqkW3hxJUrAe+3eNz3oFCLYdnPwILfn0mX1Ew2c3wctrjlUMYYUww==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    create-react-context "^0.3.0"
+    deep-equal "^1.1.1"
+    popper.js "^1.14.4"
+    prop-types "^15.6.1"
+    typed-styles "^0.0.7"
+    warning "^4.0.2"
 
 react-redux@^7.1.3:
   version "7.1.3"
@@ -6146,6 +6287,11 @@ regenerator-runtime@^0.13.2:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
   integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
 
+regenerator-runtime@^0.13.4:
+  version "0.13.5"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz#d878a1d094b4306d10b9096484b33ebd55e26697"
+  integrity sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==
+
 regenerator-transform@^0.14.0:
   version "0.14.1"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.14.1.tgz#3b2fce4e1ab7732c08f665dfdb314749c7ddd2fb"
@@ -6160,6 +6306,14 @@ regex-not@^1.0.0, regex-not@^1.0.2:
   dependencies:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
+
+regexp.prototype.flags@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz#7aba89b3c13a64509dabcf3ca8d9fbb9bdf5cb75"
+  integrity sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.0-next.1"
 
 regexpu-core@^4.6.0:
   version "4.6.0"
@@ -7262,6 +7416,11 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
+typed-styles@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/typed-styles/-/typed-styles-0.0.7.tgz#93392a008794c4595119ff62dde6809dbc40a3d9"
+  integrity sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q==
+
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
@@ -7300,6 +7459,16 @@ uglifyjs-webpack-plugin@^1.2.4:
     uglify-es "^3.3.4"
     webpack-sources "^1.1.0"
     worker-farm "^1.5.2"
+
+uncontrollable@^7.0.0:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/uncontrollable/-/uncontrollable-7.1.1.tgz#f67fed3ef93637126571809746323a9db815d556"
+  integrity sha512-EcPYhot3uWTS3w00R32R2+vS8Vr53tttrvMj/yA1uYRhf8hbTG2GyugGqWDY0qIskxn0uTTojVd6wPYW9ZEf8Q==
+  dependencies:
+    "@babel/runtime" "^7.6.3"
+    "@types/react" "^16.9.11"
+    invariant "^2.2.4"
+    react-lifecycles-compat "^3.0.4"
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
@@ -7493,6 +7662,13 @@ walker@^1.0.7, walker@~1.0.5:
   integrity sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=
   dependencies:
     makeerror "1.0.x"
+
+warning@^4.0.1, warning@^4.0.2, warning@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
+  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
+  dependencies:
+    loose-envify "^1.0.0"
 
 watchpack@^1.6.0:
   version "1.6.0"

--- a/lib/oli/db_seeder.ex
+++ b/lib/oli/db_seeder.ex
@@ -14,7 +14,7 @@ defmodule Oli.Seeder do
   alias Oli.Resources.Resource
   alias Oli.Resources.ResourceFamily
   alias Oli.Resources.ResourceRevision
-  alias Oli.Learning
+
   alias Oli.Learning.Objective
   alias Oli.Learning.ObjectiveFamily
   alias Oli.Learning.ObjectiveRevision

--- a/lib/oli/editing/editor.ex
+++ b/lib/oli/editing/editor.ex
@@ -165,7 +165,7 @@ defmodule Oli.Editing.ResourceEditor do
       resourceSlug: revision_slug,
       editorMap: %{},
       objectives: [],
-      allObjectives: [],
+      allObjectives: [%{ id: "one", title: "First one"}, %{ id: "two", title: "Second one"}],
       title: revision.title,
       resourceType: revision.resource_type.type,
       content: revision.content

--- a/lib/oli/editing/editor.ex
+++ b/lib/oli/editing/editor.ex
@@ -147,25 +147,26 @@ defmodule Oli.Editing.ResourceEditor do
   def create_context(project_slug, revision_slug, author) do
 
     with {:ok, publication} <- Publishing.get_unpublished_publication(project_slug, author.id) |> trap_nil(),
-         {:ok, resource} <- Resources.get_resource_from_slugs(project_slug, revision_slug) |> trap_nil()
+         {:ok, resource} <- Resources.get_resource_from_slugs(project_slug, revision_slug) |> trap_nil(),
+         {:ok, objectives} <- Publishing.get_published_objectives(publication.id) |> trap_nil()
     do
       case get_latest_revision(publication, resource) do
         nil -> {:error, :not_found}
-        revision -> {:ok, create(revision, project_slug, revision_slug, author)}
+        revision -> {:ok, create(revision, project_slug, revision_slug, author, objectives)}
       end
     else
       _ -> {:error, :not_found}
     end
   end
 
-  defp create(revision, project_slug, revision_slug, author) do
+  defp create(revision, project_slug, revision_slug, author, all_objectives) do
     %Oli.Editing.ResourceContext{
       authorEmail: author.email,
       projectSlug: project_slug,
       resourceSlug: revision_slug,
       editorMap: %{},
-      objectives: [],
-      allObjectives: [%{ id: "one", title: "First one"}, %{ id: "two", title: "Second one"}],
+      objectives: revision.objectives,
+      allObjectives: all_objectives,
       title: revision.title,
       resourceType: revision.resource_type.type,
       content: revision.content

--- a/lib/oli/learning/objective_revision.ex
+++ b/lib/oli/learning/objective_revision.ex
@@ -2,6 +2,8 @@ defmodule Oli.Learning.ObjectiveRevision do
   use Ecto.Schema
   import Ecto.Changeset
 
+  alias Oli.Utils.Slug
+
   schema "objective_revisions" do
     field :title, :string
     field :slug, :string
@@ -19,5 +21,6 @@ defmodule Oli.Learning.ObjectiveRevision do
     objective_revision
     |> cast(attrs, [:title, :slug, :children, :deleted, :objective_id, :previous_revision_id])
     |> validate_required([:title, :children, :deleted, :objective_id])
+    |> Slug.maybe_update_slug("objective_revisions")
   end
 end

--- a/lib/oli/learning/objective_revision.ex
+++ b/lib/oli/learning/objective_revision.ex
@@ -4,6 +4,7 @@ defmodule Oli.Learning.ObjectiveRevision do
 
   schema "objective_revisions" do
     field :title, :string
+    field :slug, :string
     field :children, {:array, :id}
     field :deleted, :boolean, default: false
 
@@ -16,7 +17,7 @@ defmodule Oli.Learning.ObjectiveRevision do
   @doc false
   def changeset(objective_revision, attrs) do
     objective_revision
-    |> cast(attrs, [:title, :children, :deleted, :objective_id, :previous_revision_id])
+    |> cast(attrs, [:title, :slug, :children, :deleted, :objective_id, :previous_revision_id])
     |> validate_required([:title, :children, :deleted, :objective_id])
   end
 end

--- a/lib/oli/publishing.ex
+++ b/lib/oli/publishing.ex
@@ -9,6 +9,19 @@ defmodule Oli.Publishing do
   alias Oli.Publishing.Publication
   alias Oli.Course.Project
   alias Oli.Accounts.Author
+  alias Oli.Learning.ObjectiveRevision
+  alias Oli.Publishing.ObjectiveMapping
+
+  @doc """
+  Returns the list of objectives (their slugs and titles)
+  that pertain to a given publication.
+  """
+  def get_published_objectives(publication_id) do
+    Repo.all from mapping in ObjectiveMapping,
+      join: rev in ObjectiveRevision, on: mapping.revision_id == rev.id,
+      where: mapping.publication_id == ^publication_id,
+      select: map(rev, [:slug, :title])
+  end
 
   @doc """
   Returns the list of publications.

--- a/lib/oli/resources/resource_revision.ex
+++ b/lib/oli/resources/resource_revision.ex
@@ -5,9 +5,9 @@ defmodule Oli.Resources.ResourceRevision do
   alias Oli.Utils.Slug
 
   schema "resource_revisions" do
-    field :children, {:array, :id}, default: []
+    field :children, {:array, :string}, default: []
     field :content, {:array, :map}, default: []
-    field :objectives, {:array, :id}, default: []
+    field :objectives, {:array, :string}, default: []
     field :deleted, :boolean, default: false
     field :slug, :string
     field :title, :string

--- a/priv/repo/migrations/20200310193550_init_core_schemas.exs
+++ b/priv/repo/migrations/20200310193550_init_core_schemas.exs
@@ -143,8 +143,8 @@ defmodule Oli.Repo.Migrations.InitCoreSchemas do
       add :title, :string
       add :slug, :string
       add :content, {:array, :map}
-      add :children, {:array, :id}
-      add :objectives, {:array, :id}
+      add :children, {:array, :string}
+      add :objectives, {:array, :string}
       add :deleted, :boolean, default: false, null: false
       add :author_id, references(:authors)
       add :resource_id, references(:resources)
@@ -153,6 +153,7 @@ defmodule Oli.Repo.Migrations.InitCoreSchemas do
 
       timestamps()
     end
+    create unique_index(:resource_revisions, [:slug], name: :index_slug_resources)
 
     create table(:activity_registrations) do
       add :title, :string
@@ -188,7 +189,7 @@ defmodule Oli.Repo.Migrations.InitCoreSchemas do
 
       timestamps()
     end
-
+    create unique_index(:activity_revisions, [:slug], name: :index_slug_activities)
 
     create table(:objective_families) do
       timestamps()
@@ -203,6 +204,7 @@ defmodule Oli.Repo.Migrations.InitCoreSchemas do
 
     create table(:objective_revisions) do
       add :title, :string
+      add :slug, :string
       add :children, {:array, :id}
       add :deleted, :boolean, default: false, null: false
 
@@ -211,6 +213,7 @@ defmodule Oli.Repo.Migrations.InitCoreSchemas do
 
       timestamps()
     end
+    create unique_index(:objective_revisions, [:slug], name: :index_slug_objectives)
 
     create table(:resource_mappings) do
       add :resource_id, references(:resources)

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -115,5 +115,8 @@ if Mix.env == :dev do
   Oli.Seeder.base_project_with_resource()
     |> Oli.Seeder.add_author(admin_author, :admin_author)
     |> Oli.Seeder.add_author(test_author, :test_author)
+    |> Oli.Seeder.add_objective("Define and describe something")
+    |> Oli.Seeder.add_objective("Compare and contrast something")
+    |> Oli.Seeder.add_objective("Pick and choose when something")
 
 end

--- a/test/oli/activities_test.exs
+++ b/test/oli/activities_test.exs
@@ -102,10 +102,12 @@ defmodule Oli.ActivitiesTest do
     end
 
     test "create_activity_revision/1 with valid data creates a activity_revision", %{valid_attrs: valid_attrs} do
-      assert {:ok, %ActivityRevision{} = activity_revision} = Activities.create_activity_revision(valid_attrs)
+
+      with_different_slug = Map.put(valid_attrs, :slug, "different")
+      assert {:ok, %ActivityRevision{} = activity_revision} = Activities.create_activity_revision(with_different_slug)
       assert activity_revision.content == %{}
       assert activity_revision.deleted == true
-      assert activity_revision.slug == "some slug"
+      assert activity_revision.slug == "different"
     end
 
     test "create_activity_revision/1 with invalid data returns error changeset" do

--- a/test/oli/publishing_test.exs
+++ b/test/oli/publishing_test.exs
@@ -39,6 +39,21 @@ defmodule Oli.PublishingTest do
       {:ok, %{publication: publication, project: project, family: family, valid_attrs: valid_attrs}}
     end
 
+    test "get_published_objectives/1 returns the objective revisions", _ do
+
+      %{publication: publication} = Oli.Seeder.base_project_with_resource()
+        |> Oli.Seeder.add_objective("one")
+        |> Oli.Seeder.add_objective("two")
+        |> Oli.Seeder.add_objective("three")
+
+      [first | rest ] = Publishing.get_published_objectives(publication.id)
+      assert length(rest) == 2
+      assert first.slug == "one"
+      assert first.title == "one"
+
+    end
+
+
     test "get_unpublished_publications/2 returns the correct publication", %{publication: publication, family: family, project: project} do
 
       # add a few more published publications


### PR DESCRIPTION
This PR completes the 'enhanced resource editor'.  It adds in:

* Ability to reorder resource content items via drag and drop
* Ability to reorder resource content items via accessible keyboard manipulation (SHIFT + arrow keys)
* Ability to attach and detach learning objectives to a resource

Run `mix ecto.reset` after syncing.  The test project with the default resource will then contain three learning objectives that you can test adding / removing. 

Closes #40 
Closes #50 
Closes #54 

