### PR TITLE
Local activity registration and activity map generation

### DIFF
--- a/assets/src/components/activities/multiple_choice/MultipleChoice.tsx
+++ b/assets/src/components/activities/multiple_choice/MultipleChoice.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+export const MultipleChoiceDelivery = () => {
+  return <p>Multiple Choice Delivery</p>;
+};
+
+export const MultipleChoiceAuthoring = () => {
+  return <p>Multiple Choice Authoring</p>;
+};

--- a/assets/src/components/activities/multiple_choice/MultipleChoice.tsx
+++ b/assets/src/components/activities/multiple_choice/MultipleChoice.tsx
@@ -1,9 +1,0 @@
-import * as React from 'react';
-
-export const MultipleChoiceDelivery = () => {
-  return <p>Multiple Choice Delivery</p>;
-};
-
-export const MultipleChoiceAuthoring = () => {
-  return <p>Multiple Choice Authoring</p>;
-};

--- a/assets/src/components/activities/multiple_choice/MultipleChoiceAuthoring.tsx
+++ b/assets/src/components/activities/multiple_choice/MultipleChoiceAuthoring.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+const MultipleChoice = (props: any) => {
+  return (
+    <div style={{ width: '100%', height: '100px', border: 'solid 1px gray' }}>
+      <p>{props.model.stem}</p>
+    </div>
+  );
+};
+
+export class MultipleChoiceAuthoring extends HTMLElement {
+
+  mountPoint: HTMLDivElement;
+
+  constructor() {
+    super();
+
+    this.mountPoint = document.createElement('div');
+  }
+
+  props() {
+
+    const token = this.getAttribute('token');
+    const model = this.getAttribute('model');
+    const state = this.getAttribute('state');
+
+    return {
+      token,
+      model,
+      state,
+    };
+  }
+
+  connectedCallback() {
+    this.attachShadow({ mode: 'open' }).appendChild(this.mountPoint);
+    ReactDOM.render(<MultipleChoice {...this.props()} />, this.mountPoint);
+  }
+
+  attributeChangedCallback(name: any, oldValue: any, newValue: any) {
+    ReactDOM.render(<MultipleChoice {...this.props()} />, this.mountPoint);
+  }
+}
+
+
+import * as ActivityTypes from '../types';
+const manifest = require('./manifest.json') as ActivityTypes.Manifest;
+window.customElements.define(manifest.authoring.element, MultipleChoiceAuthoring);
+
+

--- a/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
+++ b/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
@@ -24,7 +24,6 @@ export class MultipleChoiceDelivery extends HTMLElement {
 
   constructor() {
     super();
-    console.log('here we are');
     this.mountPoint = document.createElement('div');
   }
 
@@ -33,7 +32,7 @@ export class MultipleChoiceDelivery extends HTMLElement {
     const token = this.getAttribute('token');
     const model = JSON.parse(this.getAttribute('model') as any);
     const state = JSON.parse(this.getAttribute('state') as any);
-    console.log(model);
+
     return {
       token,
       model,

--- a/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
+++ b/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+const MultipleChoice = (props: any) => {
+  return (
+    <div style={{ width: '100%', height: '100px', border: 'solid 1px gray' }}>
+      <p>{props.model.stem}</p>
+    </div>
+  );
+};
+
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      'oli-multiple-choice': any;
+    }
+  }
+}
+
+export class MultipleChoiceDelivery extends HTMLElement {
+
+  mountPoint: HTMLDivElement;
+
+  constructor() {
+    super();
+    console.log('here we are');
+    this.mountPoint = document.createElement('div');
+  }
+
+  props() {
+
+    const token = this.getAttribute('token');
+    const model = JSON.parse(this.getAttribute('model') as any);
+    const state = JSON.parse(this.getAttribute('state') as any);
+    console.log(model);
+    return {
+      token,
+      model,
+      state,
+    };
+  }
+
+  connectedCallback() {
+    this.attachShadow({ mode: 'open' }).appendChild(this.mountPoint);
+    ReactDOM.render(<MultipleChoice {...this.props()} />, this.mountPoint);
+  }
+
+  attributeChangedCallback(name: any, oldValue: any, newValue: any) {
+    ReactDOM.render(<MultipleChoice {...this.props()} />, this.mountPoint);
+  }
+}
+
+import * as ActivityTypes from '../types';
+const manifest = require('./manifest.json') as ActivityTypes.Manifest;
+window.customElements.define(manifest.delivery.element, MultipleChoiceDelivery);

--- a/assets/src/components/activities/multiple_choice/authoring-entry.ts
+++ b/assets/src/components/activities/multiple_choice/authoring-entry.ts
@@ -1,0 +1,2 @@
+export { MultipleChoiceDelivery } from './MultipleChoiceDelivery';
+export { MultipleChoiceAuthoring } from './MultipleChoiceAuthoring';

--- a/assets/src/components/activities/multiple_choice/delivery-entry.ts
+++ b/assets/src/components/activities/multiple_choice/delivery-entry.ts
@@ -1,0 +1,1 @@
+export { MultipleChoiceDelivery } from './MultipleChoiceDelivery';

--- a/assets/src/components/activities/multiple_choice/manifest.json
+++ b/assets/src/components/activities/multiple_choice/manifest.json
@@ -1,0 +1,13 @@
+{
+  "id": "oli-multiple-choice",
+  "friendlyName": "Multiple Choice",
+  "description": "A traditional multiple choice question with one correct answer",
+  "delivery": {
+    "element": "oli-multiple-choice-delivery",
+    "entry": "./delivery-entry.ts"
+  },
+  "authoring": {
+    "element": "oli-multiple-choice-authoring",
+    "entry": "./authoring-entry.ts"
+  }
+}

--- a/assets/src/components/activities/types.ts
+++ b/assets/src/components/activities/types.ts
@@ -1,0 +1,13 @@
+
+export type ModeSpecification = {
+  element: string,
+  entry: string,
+};
+
+export type Manifest = {
+  id: string,
+  friendlyName: string,
+  description: string,
+  delivery: ModeSpecification,
+  authoring: ModeSpecification,
+};

--- a/assets/src/components/activities/types.ts
+++ b/assets/src/components/activities/types.ts
@@ -5,7 +5,7 @@ export type ModeSpecification = {
 };
 
 export type Manifest = {
-  id: string,
+  type: string,
   friendlyName: string,
   description: string,
   delivery: ModeSpecification,

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -6,17 +6,45 @@ const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 
+// Determines the entry points for the webpack by looking at activity
+// implementations in src/components/activities folder
+const populateEntries = () => {
+
+  // These are the non-activity bundles
+  const initialEntries = {
+    app: ['./js/app.js'],
+    components: ['./src/components.tsx'],
+  };
+
+  const manifests = glob.sync("./src/components/activities/*/manifest.json", {});
+
+  const foundActivities = manifests.map((manifestPath) => {
+    const manifest = require(manifestPath);
+    const rootPath = manifestPath.substr(0, manifestPath.indexOf('manifest.json'));
+    return {
+      [manifest.id + '-authoring']: [rootPath + manifest.authoring.entry],
+      [manifest.id + '-delivery']: [rootPath + manifest.delivery.entry],
+    };
+  });
+
+  // Merge the attributes of all found activities and the initialEntries
+  // into one single object.
+  const merged = foundActivities.reduce((p, c) => Object.assign({}, p, c), initialEntries);
+
+  // Validate: We should have (2 * foundActivities.length) + number of keys in initialEntries
+  // If we don't it is likely due to a naming collision in two or more manifests
+  if (Object.keys(merged).length != Object.keys(initialEntries).length + (2 * foundActivities.length)) {
+    throw new Error('Encountered a possible naming collision in activity manifests. Aborting.');
+  }
+
+  return merged;
+};
+
 module.exports = (env, options) => ({
   optimization: {
     chunkIds: "named",
 		splitChunks: {
 			cacheGroups: {
-				commons: {
-					chunks: "initial",
-					minChunks: 2,
-					maxInitialRequests: 5, // The default limit is too small to showcase the effect
-					minSize: 0 // This is example is too small to create commons chunks
-				},
 				vendor: {
 					test: /node_modules/,
 					chunks: "initial",
@@ -31,10 +59,7 @@ module.exports = (env, options) => ({
       new OptimizeCSSAssetsPlugin({})
     ]
   },
-  entry: {
-    app: ['./js/app.js'],
-    components: ['./src/components.tsx'],
-  },
+  entry: populateEntries(),
   output: {
     filename: '[name].js',
     path: path.resolve(__dirname, '../priv/static/js')

--- a/lib/oli/activities.ex
+++ b/lib/oli/activities.ex
@@ -8,6 +8,19 @@ defmodule Oli.Activities do
 
   alias Oli.Activities.Activity
   alias Oli.Activities.ActivityFamily
+  alias Oli.Activities.Manifest
+
+  def register_activity(%Manifest{} = manifest) do
+    create_registration(%{
+      authoring_script: manifest.id <> "-authoring.js",
+      authoring_element: manifest.authoring.element,
+      delivery_script: manifest.id <> "-delivery.js",
+      delivery_element: manifest.delivery.element,
+      description: manifest.description,
+      title: manifest.friendlyName,
+      icon: "nothing",
+    })
+  end
 
   def create_activity_family(attrs \\ %{}) do
     %ActivityFamily{}

--- a/lib/oli/activities.ex
+++ b/lib/oli/activities.ex
@@ -19,7 +19,14 @@ defmodule Oli.Activities do
       description: manifest.description,
       title: manifest.friendlyName,
       icon: "nothing",
+      slug: manifest.id,
     })
+  end
+
+  def create_registered_activity_map() do
+    list_activity_registrations()
+      |> Enum.map(&Oli.Activities.ActivityMapEntry.from_registration/1)
+      |> Enum.reduce(%{}, fn e, m -> Map.put(m, e.slug, e) end)
   end
 
   def create_activity_family(attrs \\ %{}) do

--- a/lib/oli/activities/activity_map_entry.ex
+++ b/lib/oli/activities/activity_map_entry.ex
@@ -1,0 +1,13 @@
+defmodule Oli.Activities.ActivityMapEntry do
+
+  alias Oli.Activities.Registration
+
+  @derive Jason.Encoder
+  defstruct [:deliveryElement, :authoringElement, :icon, :description, :friendlyName, :slug]
+
+  def from_registration(%Registration{slug: slug, description: description, icon: icon, title: title, authoring_element: authoring_element, delivery_element: delivery_element}) do
+    %Oli.Activities.ActivityMapEntry{slug: slug, friendlyName: title, description: description, authoringElement: authoring_element, icon: icon, deliveryElement: delivery_element}
+  end
+
+end
+

--- a/lib/oli/activities/manifest.ex
+++ b/lib/oli/activities/manifest.ex
@@ -1,0 +1,14 @@
+defmodule Oli.Activities.Manifest do
+
+  defstruct [:id, :friendlyName, :description, :delivery, :authoring]
+
+  def parse(%{"id" => id, "friendlyName" => friendlyName, "description" => description, "delivery" => delivery, "authoring" => authoring }) do
+    %Oli.Activities.Manifest{
+      id: id,
+      friendlyName: friendlyName,
+      description: description,
+      delivery: Oli.Activities.ModeSpecification.parse(delivery),
+      authoring: Oli.Activities.ModeSpecification.parse(authoring)}
+  end
+
+end

--- a/lib/oli/activities/mode_spec.ex
+++ b/lib/oli/activities/mode_spec.ex
@@ -1,0 +1,9 @@
+defmodule Oli.Activities.ModeSpecification do
+
+  defstruct [:element, :entry]
+
+  def parse(%{"element" => element, "entry" => entry }) do
+    %Oli.Activities.ModeSpecification{element: element, entry: entry}
+  end
+
+end

--- a/lib/oli/activities/registration.ex
+++ b/lib/oli/activities/registration.ex
@@ -6,7 +6,8 @@ defmodule Oli.Activities.Registration do
     field :authoring_script, :string
     field :delivery_script, :string
     field :description, :string
-    field :element_name, :string
+    field :authoring_element, :string
+    field :delivery_element, :string
     field :icon, :string
     field :title, :string
 
@@ -16,7 +17,7 @@ defmodule Oli.Activities.Registration do
   @doc false
   def changeset(registration, attrs) do
     registration
-    |> cast(attrs, [:title, :icon, :description, :element_name, :delivery_script, :authoring_script])
-    |> validate_required([:title, :icon, :description, :element_name, :delivery_script, :authoring_script])
+    |> cast(attrs, [:title, :icon, :description, :delivery_element, :authoring_element, :delivery_script, :authoring_script])
+    |> validate_required([:title, :icon, :description, :delivery_element, :authoring_element, :delivery_script, :authoring_script])
   end
 end

--- a/lib/oli/activities/registration.ex
+++ b/lib/oli/activities/registration.ex
@@ -3,6 +3,7 @@ defmodule Oli.Activities.Registration do
   import Ecto.Changeset
 
   schema "activity_registrations" do
+    field :slug, :string
     field :authoring_script, :string
     field :delivery_script, :string
     field :description, :string
@@ -17,7 +18,12 @@ defmodule Oli.Activities.Registration do
   @doc false
   def changeset(registration, attrs) do
     registration
-    |> cast(attrs, [:title, :icon, :description, :delivery_element, :authoring_element, :delivery_script, :authoring_script])
-    |> validate_required([:title, :icon, :description, :delivery_element, :authoring_element, :delivery_script, :authoring_script])
+    |> cast(attrs, [:slug, :title, :icon, :description, :delivery_element, :authoring_element, :delivery_script, :authoring_script])
+    |> validate_required([:slug, :title, :icon, :description, :delivery_element, :authoring_element, :delivery_script, :authoring_script])
+    |> unique_constraint(:slug)
+    |> unique_constraint(:authoring_element)
+    |> unique_constraint(:delivery_element)
+    |> unique_constraint(:delivery_script)
+    |> unique_constraint(:authoring_script)
   end
 end

--- a/lib/oli/editing/editor.ex
+++ b/lib/oli/editing/editor.ex
@@ -164,7 +164,7 @@ defmodule Oli.Editing.ResourceEditor do
       authorEmail: author.email,
       projectSlug: project_slug,
       resourceSlug: revision_slug,
-      editorMap: %{},
+      editorMap: Oli.Activities.create_registered_activity_map(),
       objectives: revision.objectives,
       allObjectives: all_objectives,
       title: revision.title,

--- a/lib/oli/registrar.ex
+++ b/lib/oli/registrar.ex
@@ -1,0 +1,22 @@
+defmodule Oli.Registrar do
+
+  alias Oli.Activities
+  alias Oli.Activities.Manifest
+
+  def register_local_activities() do
+    read_local_manifests()
+      |> Enum.map(fn m -> Activities.register_activity(m) end)
+  end
+
+  defp read_local_manifests() do
+    Path.wildcard(File.cwd! <> "/assets/src/components/activities/*/manifest.json")
+      |> Enum.map(&read_manifest/1)
+      |> Enum.map(&Manifest.parse/1)
+  end
+
+  defp read_manifest(filename) do
+    with {:ok, body} <- File.read(filename),
+          {:ok, json} <- Jason.decode(body), do: json
+  end
+
+end

--- a/priv/repo/migrations/20200310193550_init_core_schemas.exs
+++ b/priv/repo/migrations/20200310193550_init_core_schemas.exs
@@ -156,6 +156,7 @@ defmodule Oli.Repo.Migrations.InitCoreSchemas do
     create unique_index(:resource_revisions, [:slug], name: :index_slug_resources)
 
     create table(:activity_registrations) do
+      add :slug, :string
       add :title, :string
       add :icon, :string
       add :description, :string
@@ -166,6 +167,12 @@ defmodule Oli.Repo.Migrations.InitCoreSchemas do
 
       timestamps()
     end
+    create unique_index(:activity_registrations, [:slug], name: :index_slug_registrations)
+    create unique_index(:activity_registrations, [:delivery_element], name: :index_delivery_element_registrations)
+    create unique_index(:activity_registrations, [:authoring_element], name: :index_authoring_element_registrations)
+    create unique_index(:activity_registrations, [:delivery_script], name: :index_delivery_script_registrations)
+    create unique_index(:activity_registrations, [:authoring_script], name: :index_authoring_script_registrations)
+
 
     create table(:activity_families) do
       timestamps()

--- a/priv/repo/migrations/20200310193550_init_core_schemas.exs
+++ b/priv/repo/migrations/20200310193550_init_core_schemas.exs
@@ -159,7 +159,8 @@ defmodule Oli.Repo.Migrations.InitCoreSchemas do
       add :title, :string
       add :icon, :string
       add :description, :string
-      add :element_name, :string
+      add :delivery_element, :string
+      add :authoring_element, :string
       add :delivery_script, :string
       add :authoring_script, :string
 

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -79,6 +79,10 @@ if !Oli.Repo.get_by(Oli.Resources.ResourceType, id: 1) do
 
 end
 
+# Seed the database with the locally implemented activity types
+Oli.Registrar.register_local_activities()
+
+
 # only seed with sample data if in development mode
 if Mix.env == :dev do
   # create an example institution

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -80,8 +80,9 @@ if !Oli.Repo.get_by(Oli.Resources.ResourceType, id: 1) do
 end
 
 # Seed the database with the locally implemented activity types
-Oli.Registrar.register_local_activities()
-
+if (length(Oli.Activities.list_activity_registrations()) == 0) do
+  Oli.Registrar.register_local_activities()
+end
 
 # only seed with sample data if in development mode
 if Mix.env == :dev do

--- a/test/oli/activities_test.exs
+++ b/test/oli/activities_test.exs
@@ -79,7 +79,7 @@ defmodule Oli.ActivitiesTest do
 
       {:ok, activity_family} = ActivityFamily.changeset(%ActivityFamily{}, %{}) |> Repo.insert
       {:ok, activity} = Activity.changeset(%Activity{}, %{project_id: project.id, family_id: activity_family.id}) |> Repo.insert
-      {:ok, activity_type} = Registration.changeset(%Registration{}, %{authoring_script: "1", delivery_script: "2", description: "d", authoring_element: "n", delivery_element: "n", icon: "i", title: "t"}) |> Repo.insert
+      {:ok, activity_type} = Registration.changeset(%Registration{}, %{slug: "slug", authoring_script: "1", delivery_script: "2", description: "d", authoring_element: "n", delivery_element: "n", icon: "i", title: "t"}) |> Repo.insert
 
       valid_attrs = Map.put(@valid_attrs, :project_id, project.id)
         |> Map.put(:author_id, author.id)
@@ -139,9 +139,9 @@ defmodule Oli.ActivitiesTest do
   describe "activity_registrations" do
     alias Oli.Activities.Registration
 
-    @valid_attrs %{authoring_script: "some authoring_script", delivery_script: "some delivery_script", description: "some description", delivery_element: "some element_name", authoring_element: "some element_name", icon: "some icon", title: "some title"}
-    @update_attrs %{authoring_script: "some updated authoring_script", delivery_script: "some updated delivery_script", description: "some updated description", delivery_element: "some updated element_name", authoring_element: "some updated element_name", icon: "some updated icon", title: "some updated title"}
-    @invalid_attrs %{authoring_script: nil, delivery_script: nil, description: nil, element_name: nil, icon: nil, title: nil}
+    @valid_attrs %{slug: "slug", authoring_script: "some authoring_script", delivery_script: "some delivery_script", description: "some description", delivery_element: "some element_name", authoring_element: "some element_name", icon: "some icon", title: "some title"}
+    @update_attrs %{slug: "slug", authoring_script: "some updated authoring_script", delivery_script: "some updated delivery_script", description: "some updated description", delivery_element: "some updated element_name", authoring_element: "some updated element_name", icon: "some updated icon", title: "some updated title"}
+    @invalid_attrs %{slug: nil, authoring_script: nil, delivery_script: nil, description: nil, element_name: nil, icon: nil, title: nil}
 
     def registration_fixture(attrs \\ %{}) do
       {:ok, registration} =
@@ -153,8 +153,9 @@ defmodule Oli.ActivitiesTest do
     end
 
     test "list_activity_registrations/0 returns all activity_registrations" do
-      registration = registration_fixture()
-      assert Activities.list_activity_registrations() == [registration]
+      registration_fixture()
+      registrations = Activities.list_activity_registrations()
+      assert length(registrations) == 2
     end
 
     test "get_registration!/1 returns the registration with given id" do

--- a/test/oli/activities_test.exs
+++ b/test/oli/activities_test.exs
@@ -79,7 +79,7 @@ defmodule Oli.ActivitiesTest do
 
       {:ok, activity_family} = ActivityFamily.changeset(%ActivityFamily{}, %{}) |> Repo.insert
       {:ok, activity} = Activity.changeset(%Activity{}, %{project_id: project.id, family_id: activity_family.id}) |> Repo.insert
-      {:ok, activity_type} = Registration.changeset(%Registration{}, %{authoring_script: "1", delivery_script: "2", description: "d", element_name: "n", icon: "i", title: "t"}) |> Repo.insert
+      {:ok, activity_type} = Registration.changeset(%Registration{}, %{authoring_script: "1", delivery_script: "2", description: "d", authoring_element: "n", delivery_element: "n", icon: "i", title: "t"}) |> Repo.insert
 
       valid_attrs = Map.put(@valid_attrs, :project_id, project.id)
         |> Map.put(:author_id, author.id)
@@ -139,8 +139,8 @@ defmodule Oli.ActivitiesTest do
   describe "activity_registrations" do
     alias Oli.Activities.Registration
 
-    @valid_attrs %{authoring_script: "some authoring_script", delivery_script: "some delivery_script", description: "some description", element_name: "some element_name", icon: "some icon", title: "some title"}
-    @update_attrs %{authoring_script: "some updated authoring_script", delivery_script: "some updated delivery_script", description: "some updated description", element_name: "some updated element_name", icon: "some updated icon", title: "some updated title"}
+    @valid_attrs %{authoring_script: "some authoring_script", delivery_script: "some delivery_script", description: "some description", delivery_element: "some element_name", authoring_element: "some element_name", icon: "some icon", title: "some title"}
+    @update_attrs %{authoring_script: "some updated authoring_script", delivery_script: "some updated delivery_script", description: "some updated description", delivery_element: "some updated element_name", authoring_element: "some updated element_name", icon: "some updated icon", title: "some updated title"}
     @invalid_attrs %{authoring_script: nil, delivery_script: nil, description: nil, element_name: nil, icon: nil, title: nil}
 
     def registration_fixture(attrs \\ %{}) do
@@ -167,7 +167,7 @@ defmodule Oli.ActivitiesTest do
       assert registration.authoring_script == "some authoring_script"
       assert registration.delivery_script == "some delivery_script"
       assert registration.description == "some description"
-      assert registration.element_name == "some element_name"
+      assert registration.authoring_element == "some element_name"
       assert registration.icon == "some icon"
       assert registration.title == "some title"
     end
@@ -182,7 +182,7 @@ defmodule Oli.ActivitiesTest do
       assert registration.authoring_script == "some updated authoring_script"
       assert registration.delivery_script == "some updated delivery_script"
       assert registration.description == "some updated description"
-      assert registration.element_name == "some updated element_name"
+      assert registration.authoring_element == "some updated element_name"
       assert registration.icon == "some updated icon"
       assert registration.title == "some updated title"
     end

--- a/test/oli/publishing_test.exs
+++ b/test/oli/publishing_test.exs
@@ -197,7 +197,7 @@ defmodule Oli.PublishingTest do
 
       {:ok, activity_family} = ActivityFamily.changeset(%ActivityFamily{}, %{}) |> Repo.insert
       {:ok, activity} = Activity.changeset(%Activity{}, %{project_id: project.id, family_id: activity_family.id}) |> Repo.insert
-      {:ok, activity_type} = Registration.changeset(%Registration{}, %{authoring_script: "1", delivery_script: "2", description: "d", authoring_element: "n", delivery_element: "n", icon: "i", title: "t"}) |> Repo.insert
+      {:ok, activity_type} = Registration.changeset(%Registration{}, %{slug: "slug", authoring_script: "1", delivery_script: "2", description: "d", authoring_element: "n", delivery_element: "n", icon: "i", title: "t"}) |> Repo.insert
       {:ok, revision} = ActivityRevision.changeset(%ActivityRevision{}, %{author_id: author.id, activity_id: activity.id, activity_type_id: activity_type.id, content: %{}, objectives: [], deleted: true, slug: "some slug"}) |> Repo.insert
 
       valid_attrs = Map.put(@valid_attrs, :revision_id, revision.id)

--- a/test/oli/publishing_test.exs
+++ b/test/oli/publishing_test.exs
@@ -197,7 +197,7 @@ defmodule Oli.PublishingTest do
 
       {:ok, activity_family} = ActivityFamily.changeset(%ActivityFamily{}, %{}) |> Repo.insert
       {:ok, activity} = Activity.changeset(%Activity{}, %{project_id: project.id, family_id: activity_family.id}) |> Repo.insert
-      {:ok, activity_type} = Registration.changeset(%Registration{}, %{authoring_script: "1", delivery_script: "2", description: "d", element_name: "n", icon: "i", title: "t"}) |> Repo.insert
+      {:ok, activity_type} = Registration.changeset(%Registration{}, %{authoring_script: "1", delivery_script: "2", description: "d", authoring_element: "n", delivery_element: "n", icon: "i", title: "t"}) |> Repo.insert
       {:ok, revision} = ActivityRevision.changeset(%ActivityRevision{}, %{author_id: author.id, activity_id: activity.id, activity_type_id: activity_type.id, content: %{}, objectives: [], deleted: true, slug: "some slug"}) |> Repo.insert
 
       valid_attrs = Map.put(@valid_attrs, :revision_id, revision.id)

--- a/test/oli/registrar_test.exs
+++ b/test/oli/registrar_test.exs
@@ -2,19 +2,10 @@ defmodule Oli.RegistrarTest do
   use Oli.DataCase
 
   alias Oli.Activities
-  alias Oli.Registrar
 
   describe "activity registration" do
 
-    setup do
-      Seeder.base_project_with_resource()
-    end
-
     test "register_local_activities/0 registers", _ do
-
-      assert length(Activities.list_activity_registrations()) == 0
-
-      Registrar.register_local_activities()
 
       registrations = Activities.list_activity_registrations()
       assert length(registrations) == 1
@@ -27,6 +18,22 @@ defmodule Oli.RegistrarTest do
       assert r.delivery_script == "oli-multiple-choice-delivery.js"
       assert r.authoring_element == "oli-multiple-choice-authoring"
       assert r.delivery_element == "oli-multiple-choice-delivery"
+
+    end
+
+    test "create_registered_activity_map/0 creates correctly", _ do
+
+      map = Activities.create_registered_activity_map()
+
+      assert (Map.keys(map) |> length) == 1
+
+      r = Map.get(map, "oli-multiple-choice")
+
+      assert r.slug == "oli-multiple-choice"
+      assert r.description == "A traditional multiple choice question with one correct answer"
+      assert r.friendlyName == "Multiple Choice"
+      assert r.authoringElement == "oli-multiple-choice-authoring"
+      assert r.deliveryElement == "oli-multiple-choice-delivery"
 
     end
 

--- a/test/oli/registrar_test.exs
+++ b/test/oli/registrar_test.exs
@@ -1,0 +1,34 @@
+defmodule Oli.RegistrarTest do
+  use Oli.DataCase
+
+  alias Oli.Activities
+  alias Oli.Registrar
+
+  describe "activity registration" do
+
+    setup do
+      Seeder.base_project_with_resource()
+    end
+
+    test "register_local_activities/0 registers", _ do
+
+      assert length(Activities.list_activity_registrations()) == 0
+
+      Registrar.register_local_activities()
+
+      registrations = Activities.list_activity_registrations()
+      assert length(registrations) == 1
+
+      r = hd(registrations)
+
+      assert r.title == "Multiple Choice"
+      assert r.description == "A traditional multiple choice question with one correct answer"
+      assert r.authoring_script == "oli-multiple-choice-authoring.js"
+      assert r.delivery_script == "oli-multiple-choice-delivery.js"
+      assert r.authoring_element == "oli-multiple-choice-authoring"
+      assert r.delivery_element == "oli-multiple-choice-delivery"
+
+    end
+
+  end
+end


### PR DESCRIPTION
This PR implements a couple of key pieces of the emerging activity infrastructure:

1. The ability for the system to compile and bundle locally developed activities so that they can be delivered via standalone scripts includes (one for authoring and one for delivery).  This delivery script only includes the delivery component, the authoring includes both since the delivery component is needed for live preview of an activity.
2. The ability to "register" locally developed activities.  This involves populating the activity_registrations table with the activities that are found to be locally developed.
3. The ability to generate an "activity map", which is sent to the resource editor as part of its context. The activity map specifies to the front end application a mapping from activity types (via slugs) to a description of the activity, including the web components to use in delivery and authoring.

Don't pay too much attention to the actual impl of MultipleChoice delivery and authoring components - these are mainly just stubs at this point and will be replaced with a complete, correct impl shortly. 