### PR TITLE
Back to ids

### DIFF
--- a/lib/oli/editing/editor.ex
+++ b/lib/oli/editing/editor.ex
@@ -230,15 +230,11 @@ defmodule Oli.Editing.ResourceEditor do
   end
 
   defp update_revision(revision, update) do
-    IO.puts "UPDATED"
-    IO.inspect update
 
     converted_back_to_ids = case Map.get(update, "objectives") do
       nil -> update
       objectives -> Map.put(update, "objectives", Learning.get_ids_from_objective_slugs(objectives))
     end
-
-    IO.inspect converted_back_to_ids
 
     {:ok, updated} = Resources.update_resource_revision(revision, converted_back_to_ids)
     updated

--- a/lib/oli/learning.ex
+++ b/lib/oli/learning.ex
@@ -13,7 +13,16 @@ defmodule Oli.Learning do
   alias Oli.Learning.ObjectiveRevision
   alias Oli.Publishing
   alias Oli.Publishing.ObjectiveMapping
-  
+
+  # From a list of objective revision slugs, convert to a list of objective ids
+  def get_ids_from_objective_slugs(slugs) do
+    result = Repo.all from rev in ObjectiveRevision,
+      where: rev.slug in ^slugs,
+      select: map(rev, [:objective_id])
+
+    Enum.map(result, fn m -> Map.get(m, :objective_id) end)
+  end
+
   def create_objective_family(attrs \\ %{}) do
     %ObjectiveFamily{}
     |> ObjectiveFamily.changeset(attrs)

--- a/lib/oli/publishing.ex
+++ b/lib/oli/publishing.ex
@@ -13,15 +13,17 @@ defmodule Oli.Publishing do
   alias Oli.Publishing.ObjectiveMapping
 
   @doc """
-  Returns the list of objectives (their slugs and titles)
+  Returns the list of objectives (their objective_ids, slugs and titles)
   that pertain to a given publication.
   """
   def get_published_objectives(publication_id) do
     Repo.all from mapping in ObjectiveMapping,
       join: rev in ObjectiveRevision, on: mapping.revision_id == rev.id,
       where: mapping.publication_id == ^publication_id,
-      select: map(rev, [:slug, :title])
+      select: map(rev, [:objective_id, :slug, :title])
   end
+
+
 
   @doc """
   Returns the list of publications.

--- a/lib/oli/resources/resource_revision.ex
+++ b/lib/oli/resources/resource_revision.ex
@@ -5,9 +5,9 @@ defmodule Oli.Resources.ResourceRevision do
   alias Oli.Utils.Slug
 
   schema "resource_revisions" do
-    field :children, {:array, :string}, default: []
+    field :children, {:array, :id}, default: []
     field :content, {:array, :map}, default: []
-    field :objectives, {:array, :string}, default: []
+    field :objectives, {:array, :id}, default: []
     field :deleted, :boolean, default: false
     field :slug, :string
     field :title, :string

--- a/priv/repo/migrations/20200310193550_init_core_schemas.exs
+++ b/priv/repo/migrations/20200310193550_init_core_schemas.exs
@@ -143,8 +143,8 @@ defmodule Oli.Repo.Migrations.InitCoreSchemas do
       add :title, :string
       add :slug, :string
       add :content, {:array, :map}
-      add :children, {:array, :string}
-      add :objectives, {:array, :string}
+      add :children, {:array, :id}
+      add :objectives, {:array, :id}
       add :deleted, :boolean, default: false, null: false
       add :author_id, references(:authors)
       add :resource_id, references(:resources)

--- a/test/oli/learning_test.exs
+++ b/test/oli/learning_test.exs
@@ -115,4 +115,26 @@ defmodule Oli.LearningTest do
       assert %Ecto.Changeset{} = Learning.change_objective_revision(objective_revision)
     end
   end
+
+  describe "slugs to id test" do
+
+    setup do
+      Seeder.base_project_with_resource()
+        |> Seeder.add_objective("one")
+        |> Seeder.add_objective("two")
+        |> Seeder.add_objective("three")
+    end
+
+    test "get_ids_from_objective_slugs/1 returns ids", _ do
+      ids = Learning.get_ids_from_objective_slugs(["one", "two", "three"])
+      assert length(ids) == 3
+      assert Kernel.is_number(hd(ids))
+    end
+
+    test "get_ids_from_objective_slugs/1 returns only valid ones", _ do
+      ids = Learning.get_ids_from_objective_slugs(["one", "dog", "apply"])
+      assert length(ids) == 1
+      assert Kernel.is_number(hd(ids))
+    end
+  end
 end


### PR DESCRIPTION
This converts the usage of slugs in resource children and attached objectives back to database ids.

Logic was added in the resource editor to convert back and forth so that revision slugs are sent down to the client editing code.