### PR TITLE
Activity creation

### DIFF
--- a/assets/src/components.tsx
+++ b/assets/src/components.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
-import * as Immutable from 'immutable';
 import { Provider } from 'react-redux';
 import { Maybe, maybe } from 'tsmonad';
 import { CountDisplay } from 'components/CountDisplay';
@@ -44,5 +43,4 @@ let store = configureStore();
 };
 
 // Expose other libraries to server-side rendered templates
-(window as any).Immutable = Immutable;
 (window as any).Maybe = Maybe;

--- a/assets/src/components/TextEditor.tsx
+++ b/assets/src/components/TextEditor.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import ReactDOM from 'react-dom';
 
 export interface TextEditorProps {
   onEdit: (model: string) => void;

--- a/assets/src/components/activities/creation.ts
+++ b/assets/src/components/activities/creation.ts
@@ -1,0 +1,26 @@
+import { Manifest, ActivityModelSchema, CreationContext } from './types';
+import { ResourceContext } from 'data/content/resource';
+
+export type creationFn = (context: CreationContext) => Promise<ActivityModelSchema>;
+
+export function registerCreationFunc(manifest: Manifest, fn: creationFn) {
+
+  if ((window as any).oliCreationFuncs === undefined) {
+    (window as any).oliCreationFuncs = {};
+  }
+
+  (window as any).oliCreationFuncs[manifest.id] = fn;
+}
+
+export function invokeCreationFunc(
+  id: string, context: ResourceContext) : Promise<ActivityModelSchema> {
+
+  if ((window as any).oliCreationFuncs !== undefined) {
+    const fn = (window as any).oliCreationFuncs[id];
+    if (typeof fn === 'function') {
+      return fn.apply(undefined, [context]);
+    }
+  }
+  return Promise.reject('could not invoke creation function for ' + id);
+}
+

--- a/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
+++ b/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
@@ -28,15 +28,10 @@ export class MultipleChoiceDelivery extends HTMLElement {
   }
 
   props() {
-
-    const token = this.getAttribute('token');
     const model = JSON.parse(this.getAttribute('model') as any);
-    const state = JSON.parse(this.getAttribute('state') as any);
 
     return {
-      token,
       model,
-      state,
     };
   }
 

--- a/assets/src/components/activities/multiple_choice/authoring-entry.ts
+++ b/assets/src/components/activities/multiple_choice/authoring-entry.ts
@@ -1,2 +1,24 @@
 export { MultipleChoiceDelivery } from './MultipleChoiceDelivery';
 export { MultipleChoiceAuthoring } from './MultipleChoiceAuthoring';
+
+import { Manifest, ActivityModelSchema, CreationContext } from '../types';
+import { registerCreationFunc } from '../creation';
+const manifest : Manifest = require('./manifest.json');
+
+interface MultipleChoiceSchema extends ActivityModelSchema {
+  stem: string;
+  choices: string[];
+  feedback: string[];
+}
+
+const model : MultipleChoiceSchema = {
+  stem: '',
+  choices: ['A', 'B', 'C', 'D'],
+  feedback: ['A', 'B', 'C', 'D'],
+};
+
+function createFn(content: CreationContext) : Promise<MultipleChoiceSchema> {
+  return Promise.resolve(model);
+}
+
+registerCreationFunc(manifest, createFn);

--- a/assets/src/components/activities/multiple_choice/manifest.json
+++ b/assets/src/components/activities/multiple_choice/manifest.json
@@ -1,5 +1,5 @@
 {
-  "id": "oli-multiple-choice",
+  "id": "oli_multiple_choice",
   "friendlyName": "Multiple Choice",
   "description": "A traditional multiple choice question with one correct answer",
   "delivery": {
@@ -9,5 +9,9 @@
   "authoring": {
     "element": "oli-multiple-choice-authoring",
     "entry": "./authoring-entry.ts"
+  },
+  "schemaPruning": {
+    "type": "keys",
+    "keys": ["feedback"]
   }
 }

--- a/assets/src/components/activities/types.ts
+++ b/assets/src/components/activities/types.ts
@@ -1,3 +1,4 @@
+import { ResourceContext } from 'data/content/resource';
 
 export type ModeSpecification = {
   element: string,
@@ -5,9 +6,17 @@ export type ModeSpecification = {
 };
 
 export type Manifest = {
-  type: string,
+  id: string,
   friendlyName: string,
   description: string,
   delivery: ModeSpecification,
   authoring: ModeSpecification,
 };
+
+export interface ActivityModelSchema {
+  delivery?: any;
+}
+
+export interface CreationContext extends ResourceContext {
+
+}

--- a/assets/src/components/editor/editors.tsx
+++ b/assets/src/components/editor/editors.tsx
@@ -9,7 +9,6 @@ import { LinkEditor, commandDesc as linkCmd } from './editors/Link';
 import { AudioEditor } from './editors/Audio';
 import { CodeEditor, CodeBlockLine } from './editors/Code';
 import * as Table from './editors/Table';
-import { assertNever } from 'utils/common';
 import { EditorProps } from './editors/interfaces';
 import { createToggleFormatCommand as format } from './commands';
 

--- a/assets/src/components/editor/editors/Popover.tsx
+++ b/assets/src/components/editor/editors/Popover.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect } from 'react';
 import * as ReactDOM from 'react-dom';
-import { ReactEditor, useSlate } from 'slate-react';
+import { useSlate } from 'slate-react';
 
 function position(el: HTMLElement, source: HTMLElement) {
 

--- a/assets/src/components/editor/utils.tsx
+++ b/assets/src/components/editor/utils.tsx
@@ -1,4 +1,4 @@
-import { Node, Editor, Path } from 'slate';
+import { Node, Editor } from 'slate';
 import { ReactEditor } from 'slate-react';
 import { Marks, schema } from 'data/content/model';
 import { Maybe } from 'tsmonad';

--- a/assets/src/components/resource/Editors.tsx
+++ b/assets/src/components/resource/Editors.tsx
@@ -1,6 +1,6 @@
 import * as Immutable from 'immutable';
 import React from 'react';
-import { ResourceContent, ResourceType } from 'data/content/resource';
+import { ResourceContent, Activity, ResourceType } from 'data/content/resource';
 import { ActivityEditorMap, EditorDesc } from 'data/content/editors';
 import { UnsupportedActivity } from './UnsupportedActivity';
 import { getToolbarForResourceType } from './toolbar';
@@ -13,19 +13,14 @@ export type EditorsProps = {
   onEdit: (content: Immutable.List<ResourceContent>) => void,
   editorMap: ActivityEditorMap,   // Map of activity types to activity elements
   resourceType: ResourceType,
+  activities: Immutable.Map<string, Activity>,
 };
 
-function createEditorWithLabel(
-  content: ResourceContent, resourceType: ResourceType,
-  editMode: boolean, onEdit: (content: ResourceContent) => void) {
-
-
-}
 
 // The list of editors
 export const Editors = (props: EditorsProps) => {
 
-  const { editorMap, editMode, resourceType, content } = props;
+  const { editorMap, editMode, resourceType, content, activities } = props;
 
   // Factory for creating top level editors, for things like structured
   // content or referenced activities
@@ -52,12 +47,24 @@ export const Editors = (props: EditorsProps) => {
       slug: 'unknown',
     };
 
-    const editor = editorMap[content.type]
-      ? editorMap[content.type] : unsupported;
+    const activity = activities.get(content.activitySlug);
+    let editor;
+    let props;
+    if (activity !== undefined) {
+      editor = editorMap[activity.typeSlug]
+        ? editorMap[activity.typeSlug] : unsupported;
 
-    const props = {};
+      props = {
+        model: JSON.stringify(activity !== undefined ? activity.model : {}),
+      };
 
-    return [React.createElement(editor.deliveryElement, props), editor.friendlyName];
+    } else {
+      editor = unsupported;
+      props = {};
+    }
+
+    return [React.createElement(editor.deliveryElement,
+      props as any), editor.friendlyName];
 
   };
 

--- a/assets/src/components/resource/Editors.tsx
+++ b/assets/src/components/resource/Editors.tsx
@@ -49,6 +49,7 @@ export const Editors = (props: EditorsProps) => {
       icon: '',
       description: 'Not supported',
       friendlyName: 'Not supported',
+      slug: 'unknown',
     };
 
     const editor = editorMap[content.type]

--- a/assets/src/components/resource/ResourceEditor.tsx
+++ b/assets/src/components/resource/ResourceEditor.tsx
@@ -38,7 +38,7 @@ function prepareSaveFn(project: ProjectSlug, resource: ResourceSlug, body: any) 
     const params = {
       method: 'PUT',
       body: JSON.stringify({ update: body }),
-      url: `/project/${project}/${resource}/edit`,
+      url: `/project/${project}/resource/${resource}`,
     };
 
     return makeRequest(params);

--- a/assets/src/components/resource/ResourceEditor.tsx
+++ b/assets/src/components/resource/ResourceEditor.tsx
@@ -2,7 +2,7 @@ import * as Immutable from 'immutable';
 import React from 'react';
 import { PersistenceStrategy } from 'data/persistence/PersistenceStrategy';
 import { DeferredPersistenceStrategy } from 'data/persistence/DeferredPersistenceStrategy';
-import { ResourceContent, ResourceType, createDefaultStructuredContent } from 'data/content/resource';
+import { ResourceContent, ResourceContext, createDefaultStructuredContent } from 'data/content/resource';
 import { Objective } from 'data/content/objective';
 import { ActivityEditorMap } from 'data/content/editors';
 import { Editors } from './Editors';
@@ -14,17 +14,9 @@ import { makeRequest } from 'data/persistence/common';
 import { UndoableState, processRedo, processUndo, processUpdate, init } from './undo';
 import { releaseLock, acquireLock } from 'data/persistence/lock';
 
-export type ResourceEditorProps = {
-  resourceType: ResourceType,     // Page or assessment?
-  authorEmail: string,            // The current author
-  projectSlug: ProjectSlug,       // The current project
-  resourceSlug: ResourceSlug,     // The current resource
-  title: string,                  // The title of the resource
-  content: ResourceContent[],     // Content of the resource
-  objectives: ObjectiveSlug[],        // Attached objectives
-  allObjectives: Objective[],     // All objectives
-  editorMap: ActivityEditorMap,   // Map of activity types to activity elements
-};
+export interface ResourceEditorProps extends ResourceContext {
+  editorMap: ActivityEditorMap;   // Map of activity types to activity elements
+}
 
 // This is the state of our resource that is undoable
 type Undoable = {
@@ -168,6 +160,7 @@ export class ResourceEditor extends React.Component<ResourceEditorProps, Resourc
     return (
       <div>
         <TitleBar
+          resourceContext={props}
           onUndo={this.undo}
           onRedo={this.redo}
           canUndo={state.undoable.undoStack.size > 0}

--- a/assets/src/components/resource/TitleBar.tsx
+++ b/assets/src/components/resource/TitleBar.tsx
@@ -1,22 +1,83 @@
 
 import React from 'react';
-import { ResourceContent, createDefaultStructuredContent } from 'data/content/resource';
-import { ActivityEditorMap } from 'data/content/editors';
+import { ResourceContent, ResourceContext, createDefaultStructuredContent } from 'data/content/resource';
+import { ActivityEditorMap, EditorDesc } from 'data/content/editors';
 import { TextEditor } from '../TextEditor';
+import { invokeCreationFunc } from 'components/activities/creation';
+
+type AddCallback = (content: ResourceContent) => void;
 
 export type TitleBarProps = {
   title: string,                  // The title of the resource
   editorMap: ActivityEditorMap,   // Map of activity types to activity elements
   editMode: boolean,              // Whether or not the user is editing
   onTitleEdit: (title: string) => void;
-  onAddItem: (content: ResourceContent) => void;
+  onAddItem: AddCallback;
   canUndo: boolean;
   canRedo: boolean;
   onUndo: () => void;
   onRedo: () => void;
+  resourceContext: ResourceContext;
 };
 
-// The resource editor
+const ItemCreationDropDown = (
+  { editMode, onAddItem, editorMap, resourceContext }
+  : {editMode: boolean, onAddItem: AddCallback,
+    editorMap: ActivityEditorMap, resourceContext: ResourceContext}) => {
+
+  const handleAdd = (editorDesc: EditorDesc) => {
+    invokeCreationFunc(editorDesc.slug, resourceContext)
+      .then((model) => {
+        // console.log(model);
+      })
+      .catch((err) => {
+        // console.log(err);
+      });
+  };
+
+  const content = <a className="dropdown-item" key="content"
+    onClick={() => onAddItem(createDefaultStructuredContent())}>Content</a>;
+
+  const activityEntries = Object
+    .keys(editorMap)
+    .map((k: string) => {
+      const editorDesc : EditorDesc = editorMap[k];
+      return (
+        <a className="dropdown-item"
+          key={editorDesc.slug}
+          onClick={handleAdd.bind(this, editorDesc)}>{editorDesc.friendlyName}</a>
+      );
+    });
+
+  return (
+    <div className="dropdown">
+      <button className={`btn dropdown-toggle ${editMode ? '' : 'disabled'}`} type="button"
+        id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        +
+      </button>
+      <div className="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
+        {[content, ...activityEntries]}
+      </div>
+    </div>
+  );
+};
+
+const UndoRedo = ({ canUndo, canRedo, onUndo, onRedo }
+  : {canUndo: boolean, canRedo: boolean, onUndo: () => void, onRedo: () => void}) => {
+
+  return (
+    <div className="btn-group btn-group-sm" role="group" aria-label="Undo redo creation">
+      <button className={`btn ${canUndo ? '' : 'disabled'}`} type="button" onClick={onUndo}>
+        <span><i className="fas fa-undo"></i></span>
+      </button>
+      <button className={`btn ${canRedo ? '' : 'disabled'}`} type="button" onClick={onRedo}>
+      <span><i className="fas fa-redo"></i></span>
+      </button>
+    </div>
+  );
+};
+
+
 export const TitleBar = (props: TitleBarProps) => {
 
   const { editMode, title, onTitleEdit, onAddItem, canUndo, canRedo } = props;
@@ -35,27 +96,8 @@ export const TitleBar = (props: TitleBarProps) => {
           editMode={editMode}/>
       </div>
 
-      <div className="btn-group btn-group-sm" role="group" aria-label="Undo redo creation">
-        <button className={`btn ${canUndo ? '' : 'disabled'}`} type="button" onClick={props.onUndo}>
-          <span><i className="fas fa-undo"></i></span>
-        </button>
-        <button className={`btn ${canRedo ? '' : 'disabled'}`} type="button" onClick={props.onRedo}>
-        <span><i className="fas fa-redo"></i></span>
-        </button>
-        <div className="">
-          <div className="dropdown">
-            <button className={`btn dropdown-toggle ${editMode ? '' : 'disabled'}`} type="button"
-              id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-              +
-            </button>
-            <div className="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
-              <a className="dropdown-item" onClick={onAddContent}>Content</a>
-              <a className="dropdown-item disabled" href="#">Multiple Choice</a>
-              <a className="dropdown-item disabled" href="#">Short Answer</a>
-            </div>
-          </div>
-        </div>
-      </div>
+      <UndoRedo {...props}/>
+      <ItemCreationDropDown {...props}/>
     </div>
   );
 };

--- a/assets/src/components/resource/TitleBar.tsx
+++ b/assets/src/components/resource/TitleBar.tsx
@@ -1,16 +1,15 @@
 
 import React from 'react';
-import { ResourceContent, ResourceContext, ActivityReference,
+import { ResourceContent, Activity, ResourceContext, ActivityReference,
   ActivityPurpose, createDefaultStructuredContent } from 'data/content/resource';
 import { ActivityEditorMap, EditorDesc } from 'data/content/editors';
 import { ActivityModelSchema } from 'components/activities/types';
 import { TextEditor } from '../TextEditor';
 import { invokeCreationFunc } from 'components/activities/creation';
 import { createActivity, Created } from 'data/persistence/activity';
-import { ProjectSlug } from 'data/types';
 import guid from 'utils/guid';
 
-type AddCallback = (content: ResourceContent) => void;
+type AddCallback = (content: ResourceContent, a? : Activity) => void;
 
 export type TitleBarProps = {
   title: string,                  // The title of the resource
@@ -39,6 +38,7 @@ const ItemCreationDropDown = (
         return createActivity(resourceContext.projectSlug, editorDesc.slug, model);
       })
       .then((result: Created) => {
+
         const resourceContent : ActivityReference = {
           type: 'activity-reference',
           id: guid(),
@@ -46,7 +46,15 @@ const ItemCreationDropDown = (
           purpose: ActivityPurpose.none,
           children: [],
         };
-        onAddItem(resourceContent);
+
+        const activity : Activity = {
+          type: 'activity',
+          activitySlug: result.revisionSlug,
+          typeSlug: editorDesc.slug,
+          model,
+        };
+
+        onAddItem(resourceContent, activity);
       })
       .catch((err) => {
         // console.log(err);

--- a/assets/src/data/content/editors.ts
+++ b/assets/src/data/content/editors.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 
 export type EditorDesc = {
+  slug: string;
   deliveryElement: string | React.FunctionComponent;
   authoringElement: string | React.FunctionComponent;
   icon: string;

--- a/assets/src/data/content/resource.ts
+++ b/assets/src/data/content/resource.ts
@@ -4,7 +4,7 @@ import { Objective } from 'data/content/objective';
 
 import guid from 'utils/guid';
 import { ActivityModelSchema } from 'components/activities/types';
-export type ResourceContent = StructuredContent | ActivityRef;
+export type ResourceContent = StructuredContent | ActivityReference;
 
 
 export type ResourceContext = {
@@ -58,8 +58,8 @@ export interface StructuredContent {
   purpose: ContentPurpose;
 }
 
-export interface ActivityRef {
-  type: 'activityRef';
+export interface ActivityReference {
+  type: 'activity-reference';
   id: number;
   activitySlug: ActivitySlug;
   purpose: ActivityPurpose;
@@ -71,4 +71,8 @@ export interface Activity {
   activitySlug: ActivitySlug;
   typeSlug: ActivityTypeSlug;
   model: ActivityModelSchema;
+}
+
+export interface ActivityMap {
+  [prop: string]: Activity;
 }

--- a/assets/src/data/content/resource.ts
+++ b/assets/src/data/content/resource.ts
@@ -1,6 +1,22 @@
 import { ModelElement } from './model';
+import { ProjectSlug, ResourceSlug, ObjectiveSlug } from 'data/types';
+import { Objective } from 'data/content/objective';
+
 import guid from 'utils/guid';
 export type ResourceContent = StructuredContent | ActivityReference;
+
+
+export type ResourceContext = {
+  resourceType: ResourceType,     // Page or assessment?
+  authorEmail: string,            // The current author
+  projectSlug: ProjectSlug,       // The current project
+  resourceSlug: ResourceSlug,     // The current resource
+  title: string,                  // The title of the resource
+  content: ResourceContent[],     // Content of the resource
+  objectives: ObjectiveSlug[],    // Attached objectives
+  allObjectives: Objective[],     // All objectives
+};
+
 
 export enum ResourceType {
   'page',

--- a/assets/src/data/content/resource.ts
+++ b/assets/src/data/content/resource.ts
@@ -1,9 +1,10 @@
 import { ModelElement } from './model';
-import { ProjectSlug, ResourceSlug, ObjectiveSlug } from 'data/types';
+import { ProjectSlug, ResourceSlug, ObjectiveSlug, ActivitySlug, ActivityTypeSlug } from 'data/types';
 import { Objective } from 'data/content/objective';
 
 import guid from 'utils/guid';
-export type ResourceContent = StructuredContent | ActivityReference;
+import { ActivityModelSchema } from 'components/activities/types';
+export type ResourceContent = StructuredContent | ActivityRef;
 
 
 export type ResourceContext = {
@@ -57,10 +58,17 @@ export interface StructuredContent {
   purpose: ContentPurpose;
 }
 
-export interface ActivityReference {
-  type: 'activity';
+export interface ActivityRef {
+  type: 'activityRef';
   id: number;
-  idRef: number;
+  activitySlug: ActivitySlug;
   purpose: ActivityPurpose;
   children: [];
+}
+
+export interface Activity {
+  type: 'activity';
+  activitySlug: ActivitySlug;
+  typeSlug: ActivityTypeSlug;
+  model: ActivityModelSchema;
 }

--- a/assets/src/data/persistence/activity.ts
+++ b/assets/src/data/persistence/activity.ts
@@ -1,0 +1,17 @@
+import { ProjectSlug, ActivityTypeSlug } from 'data/types';
+import { ActivityModelSchema } from 'components/activities/types';
+import { makeRequest } from './common';
+
+export type Created = { type: 'success', revisionSlug: string };
+
+export function createActivity(
+  project: ProjectSlug, activityTypeSlug: ActivityTypeSlug, model: ActivityModelSchema) {
+
+  const params = {
+    method: 'POST',
+    body: JSON.stringify({ model }),
+    url: `/project/${project}/activity/${activityTypeSlug}`,
+  };
+
+  return makeRequest<Created>(params);
+}

--- a/assets/src/data/persistence/lock.ts
+++ b/assets/src/data/persistence/lock.ts
@@ -16,7 +16,7 @@ export function releaseLock(
   project: ProjectSlug, resource: ResourceSlug): Promise<LockResult> {
 
   const params = {
-    url: `/project/${project}/${resource}/lock`,
+    url: `/project/${project}/lock/${resource}`,
     method: 'DELETE',
   };
   return makeRequest<LockResult>(params);
@@ -26,7 +26,7 @@ export function acquireLock(
   project: ProjectSlug, resource: ResourceSlug): Promise<LockResult> {
 
   const params = {
-    url: `/project/${project}/${resource}/lock`,
+    url: `/project/${project}/lock/${resource}`,
     method: 'POST',
   };
   return makeRequest<LockResult>(params);

--- a/assets/src/data/types.ts
+++ b/assets/src/data/types.ts
@@ -2,5 +2,7 @@
 export type ResourceSlug = string;
 export type ProjectSlug = string;
 export type ObjectiveSlug = string;
+export type ActivitySlug = string;
+export type ActivityTypeSlug = string;
 export type ElementId = number;
 export type UserEmail = string;

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -22,8 +22,8 @@ const populateEntries = () => {
     const manifest = require(manifestPath);
     const rootPath = manifestPath.substr(0, manifestPath.indexOf('manifest.json'));
     return {
-      [manifest.id + '-authoring']: [rootPath + manifest.authoring.entry],
-      [manifest.id + '-delivery']: [rootPath + manifest.delivery.entry],
+      [manifest.id + '_authoring']: [rootPath + manifest.authoring.entry],
+      [manifest.id + '_delivery']: [rootPath + manifest.delivery.entry],
     };
   });
 

--- a/lib/oli/activities.ex
+++ b/lib/oli/activities.ex
@@ -163,6 +163,14 @@ defmodule Oli.Activities do
   end
 
   @doc """
+  Returns the activity revisions for a list of revision slugs.
+  """
+  def get_activity_revisions(slugs) do
+    Repo.all(from p in ActivityRevision, where: p.slug in ^slugs)
+  end
+
+
+  @doc """
   Gets a single activity_revision.
 
   Raises `Ecto.NoResultsError` if the Activity revision does not exist.

--- a/lib/oli/activities.ex
+++ b/lib/oli/activities.ex
@@ -8,13 +8,14 @@ defmodule Oli.Activities do
 
   alias Oli.Activities.Activity
   alias Oli.Activities.ActivityFamily
+  alias Oli.Activities.Registration
   alias Oli.Activities.Manifest
 
   def register_activity(%Manifest{} = manifest) do
     create_registration(%{
-      authoring_script: manifest.id <> "-authoring.js",
+      authoring_script: manifest.id <> "_authoring.js",
       authoring_element: manifest.authoring.element,
-      delivery_script: manifest.id <> "-delivery.js",
+      delivery_script: manifest.id <> "_delivery.js",
       delivery_element: manifest.delivery.element,
       description: manifest.description,
       title: manifest.friendlyName,
@@ -39,6 +40,10 @@ defmodule Oli.Activities do
     %ActivityFamily{}
       |> ActivityFamily.changeset(%{
       })
+  end
+
+  def get_registration_by_slug(slug) do
+    Repo.one(from p in Registration, where: p.slug == ^slug)
   end
 
   @doc """
@@ -238,7 +243,6 @@ defmodule Oli.Activities do
     ActivityRevision.changeset(activity_revision, %{})
   end
 
-  alias Oli.Activities.Registration
 
   @doc """
   Returns the list of activity_registrations.

--- a/lib/oli/activities/activity_revision.ex
+++ b/lib/oli/activities/activity_revision.ex
@@ -2,11 +2,15 @@ defmodule Oli.Activities.ActivityRevision do
   use Ecto.Schema
   import Ecto.Changeset
 
+  alias Oli.Utils.Slug
+  alias Oli.Repo
+
   @derive {Phoenix.Param, key: :slug}
   schema "activity_revisions" do
     field :content, :map
     field :deleted, :boolean, default: false
     field :slug, :string
+    field :title, :string
     field :objectives, {:array, :map}
 
     belongs_to :author, Oli.Accounts.Author
@@ -20,8 +24,23 @@ defmodule Oli.Activities.ActivityRevision do
   @doc false
   def changeset(activity_revision, attrs) do
     activity_revision
-    |> cast(attrs, [:content, :slug, :deleted, :objectives, :author_id, :activity_id, :previous_revision_id, :activity_id])
-    |> validate_required([:content, :slug, :deleted, :objectives,  :author_id, :activity_id, :activity_id])
-    |> unique_constraint(:slug)
+    |> cast(attrs, [:content, :slug, :title, :deleted, :objectives, :author_id, :activity_id, :previous_revision_id, :activity_type_id])
+    |> validate_required([:content, :deleted, :objectives,  :author_id, :activity_id, :activity_type_id])
+    |> title_from_registration()
+    |> Slug.maybe_update_slug("activity_revisions")
+  end
+
+
+  # if the title is not present in the changeset, use the title of the
+  # activity registration
+  def title_from_registration(changeset) do
+    if changeset.valid? and Ecto.Changeset.get_change(changeset, :title) == nil do
+      case Repo.get(Oli.Activities.Registration, Ecto.Changeset.get_field(changeset, :activity_type_id)) do
+        %{title: title} -> Ecto.Changeset.put_change(changeset, :title, title)
+        _ -> changeset
+      end
+    else
+      changeset
+    end
   end
 end

--- a/lib/oli/editing/activity.ex
+++ b/lib/oli/editing/activity.ex
@@ -1,0 +1,49 @@
+defmodule Oli.Editing.ActivityEditor do
+  @moduledoc """
+  This module provides content editing facilities for activities.
+
+  """
+
+  import Oli.Editing.Utils
+  alias Oli.Activities.ActivityRevision
+  alias Oli.Publishing
+  alias Oli.Activities
+  alias Oli.Accounts.Author
+  alias Oli.Course
+  alias Oli.Repo
+
+  @doc """
+  Attempts to process a request to create a new activity.
+
+  Returns:
+
+  .`{:ok, %ActivityRevision{}}` when the creation processes succeeds
+  .`{:error, {:not_found}}` if the project, resource, or user cannot be found
+  .`{:error, {:not_authorized}}` if the user is not authorized to create this activity
+  .`{:error, {:error}}` unknown error
+  """
+  @spec create(String.t, String.t, %Author{}, %{})
+    :: {:ok, %ActivityRevision{}} | {:error, {:not_found}} | {:error, {:error}} | {:error, {:not_authorized}}
+  def create(project_slug, activity_type_slug, author, model) do
+
+    Repo.transaction(fn ->
+
+      with {:ok, project} <- Course.get_project_by_slug(project_slug) |> trap_nil(),
+         {:ok} <- authorize_user(author, project),
+         {:ok, publication} <- Publishing.get_unpublished_publication(project_slug, author.id) |> trap_nil(),
+         {:ok, family} <- Activities.create_activity_family(),
+         {:ok, activity} <- Activities.create_activity(%{project_id: project.id, family_id: family.id}),
+         {:ok, activity_type} <- Activities.get_registration_by_slug(activity_type_slug) |> trap_nil(),
+         {:ok, revision} <- Activities.create_activity_revision(%{objectives: [%{}], author_id: author.id, activity_id: activity.id, content: model, activity_type_id: activity_type.id}),
+         {:ok, _mapping} <- Publishing.create_activity_mapping(%{publication_id: publication.id, activity_id: activity.id, revision_id: revision.id})
+      do
+        revision
+      else
+        error -> IO.inspect(error) |> Repo.rollback()
+      end
+
+    end)
+
+  end
+
+end

--- a/lib/oli/editing/activity.ex
+++ b/lib/oli/editing/activity.ex
@@ -39,7 +39,7 @@ defmodule Oli.Editing.ActivityEditor do
       do
         revision
       else
-        error -> IO.inspect(error) |> Repo.rollback()
+        error -> Repo.rollback(error)
       end
 
     end)

--- a/lib/oli/editing/context.ex
+++ b/lib/oli/editing/context.ex
@@ -1,7 +1,7 @@
 defmodule Oli.Editing.ResourceContext do
 
   @derive Jason.Encoder
-  defstruct [:resourceType, :authorEmail, :projectSlug, :resourceSlug, :title, :content, :objectives, :allObjectives, :editorMap]
+  defstruct [:resourceType, :authorEmail, :projectSlug, :resourceSlug, :title, :content, :objectives, :allObjectives, :editorMap, :activities]
 
 
 end

--- a/lib/oli/editing/editor.ex
+++ b/lib/oli/editing/editor.ex
@@ -183,7 +183,8 @@ defmodule Oli.Editing.ResourceEditor do
       allObjectives: all_objectives,
       title: revision.title,
       resourceType: revision.resource_type.type,
-      content: revision.content
+      content: revision.content,
+      activities: %{}
     }
   end
 

--- a/lib/oli/editing/editor.ex
+++ b/lib/oli/editing/editor.ex
@@ -217,6 +217,10 @@ defmodule Oli.Editing.ResourceEditor do
 
   end
 
+  defp convert_to_activity_ids(update) do
+    update
+  end
+
   defp convert_to_activity_slugs(content, publication_id) do
 
     found_activities = Enum.filter(content, fn c -> Map.get(c, "type") == "activity-reference" end)

--- a/lib/oli/editing/util.ex
+++ b/lib/oli/editing/util.ex
@@ -1,0 +1,18 @@
+defmodule Oli.Editing.Utils do
+
+  alias Oli.Accounts
+
+  def authorize_user(author, project) do
+    case Accounts.can_access?(author, project) do
+      true -> {:ok}
+      false -> {:error, {:not_authorized}}
+    end
+  end
+
+  def trap_nil(result) do
+    case result do
+      nil -> {:error, {:not_found}}
+      _ -> {:ok, result}
+    end
+  end
+end

--- a/lib/oli/publishing.ex
+++ b/lib/oli/publishing.ex
@@ -12,6 +12,9 @@ defmodule Oli.Publishing do
   alias Oli.Learning.ObjectiveRevision
   alias Oli.Publishing.ObjectiveMapping
 
+  alias Oli.Publishing.ActivityMapping
+  alias Oli.Activities.ActivityRevision
+
   @doc """
   Returns the list of objectives (their objective_ids, slugs and titles)
   that pertain to a given publication.
@@ -23,6 +26,16 @@ defmodule Oli.Publishing do
       select: map(rev, [:objective_id, :slug, :title])
   end
 
+  @doc """
+  Returns the activity revisions for a list of activity ids
+  that pertain to a given publication.
+  """
+  def get_published_activity_revisions(publication_id, activity_ids) do
+    Repo.all from mapping in ActivityMapping,
+      join: rev in ActivityRevision, on: mapping.revision_id == rev.id,
+      where: mapping.publication_id == ^publication_id and mapping.activity_id in ^activity_ids,
+      select: rev
+  end
 
 
   @doc """

--- a/lib/oli_web/controllers/activity_controller.ex
+++ b/lib/oli_web/controllers/activity_controller.ex
@@ -16,15 +16,15 @@ defmodule OliWeb.ActivityController do
 
   end
 
-  def update(conn, %{"project" => project_slug, "activity" => activity_slug, "model" => model }) do
+  def update(conn, %{"project" => _project_slug, "activity" => _activity_slug, "model" => _model }) do
 
-    author = conn.assigns[:current_author]
+    _author = conn.assigns[:current_author]
 
   end
 
-  def delete(conn, %{"project" => project_slug, "activity" => activity_slug }) do
+  def delete(conn, %{"project" => _project_slug, "activity" => _activity_slug }) do
 
-    author = conn.assigns[:current_author]
+    _author = conn.assigns[:current_author]
 
   end
 

--- a/lib/oli_web/controllers/activity_controller.ex
+++ b/lib/oli_web/controllers/activity_controller.ex
@@ -1,0 +1,37 @@
+defmodule OliWeb.ActivityController do
+  use OliWeb, :controller
+
+  alias Oli.Editing.ActivityEditor
+
+  def create(conn, %{"project" => project_slug, "activity_type" => activity_type_slug, "model" => model }) do
+
+    author = conn.assigns[:current_author]
+
+    case ActivityEditor.create(project_slug, activity_type_slug, author, model) do
+      {:ok, %{slug: slug}} -> json conn, %{ "type" => "success", "revisionSlug" => slug}
+      {:error, {:not_found}} -> error(conn, 404, "not found")
+      {:error, {:not_authorized}} -> error(conn, 403, "unauthorized")
+      _ -> error(conn, 500, "server error")
+    end
+
+  end
+
+  def update(conn, %{"project" => project_slug, "activity" => activity_slug, "model" => model }) do
+
+    author = conn.assigns[:current_author]
+
+  end
+
+  def delete(conn, %{"project" => project_slug, "activity" => activity_slug }) do
+
+    author = conn.assigns[:current_author]
+
+  end
+
+  defp error(conn, code, reason) do
+    conn
+    |> send_resp(code, reason)
+    |> halt()
+  end
+
+end

--- a/lib/oli_web/controllers/resource_controller.ex
+++ b/lib/oli_web/controllers/resource_controller.ex
@@ -2,6 +2,8 @@ defmodule OliWeb.ResourceController do
   use OliWeb, :controller
 
   alias Oli.Editing.ResourceEditor
+  alias Oli.Activities
+
   import OliWeb.ProjectPlugs
 
   plug :fetch_project when action not in [:view, :update]
@@ -14,10 +16,15 @@ defmodule OliWeb.ResourceController do
   def edit(conn, %{"project_id" => project_slug, "revision_slug" => revision_slug}) do
 
     case ResourceEditor.create_context(project_slug, revision_slug, conn.assigns[:current_author]) do
-      {:ok, context} -> render(conn, "edit.html", title: "Resource Editor", context: Jason.encode!(context))
+      {:ok, context} -> render(conn, "edit.html", title: "Resource Editor", context: Jason.encode!(context), scripts: get_scripts())
       {:error, :not_found} -> render conn, OliWeb.SharedView, "_not_found.html"
     end
 
+  end
+
+  defp get_scripts() do
+    Activities.list_activity_registrations()
+      |> Enum.map(fn r -> Map.get(r, :authoring_script) end)
   end
 
   def update(conn, %{"project" => project_slug, "resource" => resource_slug, "update" => update }) do

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -96,10 +96,14 @@ defmodule OliWeb.Router do
   scope "/api/v1/project", OliWeb do
     pipe_through [:api, :protected]
 
-    put "/:project/:resource/edit", ResourceController, :update
+    put "/:project/resource/:resource", ResourceController, :update
 
-    post "/:project/:resource/lock", LockController, :acquire
-    delete "/:project/:resource/lock", LockController, :release
+    post "/:project/activity/:activity_type", ActivityController, :create
+    put "/:project/activity/:activity", ActivityController, :update
+    delete "/:project/activity", ActivityController, :delete
+
+    post "/:project/lock/:resource", LockController, :acquire
+    delete "/:project/lock/:resource", LockController, :release
 
   end
 

--- a/lib/oli_web/templates/resource/edit.html.eex
+++ b/lib/oli_web/templates/resource/edit.html.eex
@@ -1,5 +1,9 @@
 <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/components.js") %>"></script>
 
+<%= for script <- @scripts do %>
+  <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/" <> script) %>"></script>
+<% end %>
+
 <div id="editor"/>
 
 <script>

--- a/priv/repo/migrations/20200310193550_init_core_schemas.exs
+++ b/priv/repo/migrations/20200310193550_init_core_schemas.exs
@@ -186,8 +186,9 @@ defmodule Oli.Repo.Migrations.InitCoreSchemas do
 
     create table(:activity_revisions) do
       add :content, :map
-      add :objectives, {:array, :id}
+      add :objectives, {:array, :map}
       add :slug, :string
+      add :title, :string
       add :deleted, :boolean, default: false, null: false
 
       add :author_id, references(:authors)

--- a/test/oli/activities_test.exs
+++ b/test/oli/activities_test.exs
@@ -64,8 +64,8 @@ defmodule Oli.ActivitiesTest do
   describe "activity_revisions" do
     alias Oli.Activities.ActivityRevision
 
-    @valid_attrs %{content: %{}, objectives: [], deleted: true, slug: "some slug"}
-    @update_attrs %{content: %{"test" => "ok"}, objectives: [], deleted: false, slug: "some updated slug"}
+    @valid_attrs %{content: %{}, objectives: [], deleted: true, title: "some slug"}
+    @update_attrs %{content: %{"test" => "ok"}, objectives: [], deleted: false, title: "test"}
     @invalid_attrs %{content: nil, deleted: nil, slug: nil}
 
 
@@ -103,11 +103,10 @@ defmodule Oli.ActivitiesTest do
 
     test "create_activity_revision/1 with valid data creates a activity_revision", %{valid_attrs: valid_attrs} do
 
-      with_different_slug = Map.put(valid_attrs, :slug, "different")
-      assert {:ok, %ActivityRevision{} = activity_revision} = Activities.create_activity_revision(with_different_slug)
+      assert {:ok, %ActivityRevision{} = activity_revision} = Activities.create_activity_revision(valid_attrs)
       assert activity_revision.content == %{}
       assert activity_revision.deleted == true
-      assert activity_revision.slug == "different"
+      assert activity_revision.slug != "some_slug"
     end
 
     test "create_activity_revision/1 with invalid data returns error changeset" do
@@ -118,7 +117,7 @@ defmodule Oli.ActivitiesTest do
       assert {:ok, %ActivityRevision{} = activity_revision} = Activities.update_activity_revision(activity_revision, @update_attrs)
       assert activity_revision.content == %{"test" => "ok"}
       assert activity_revision.deleted == false
-      assert activity_revision.slug == "some updated slug"
+      assert activity_revision.slug == "test"
     end
 
     test "update_activity_revision/2 with invalid data returns error changeset", %{activity_revision: activity_revision} do

--- a/test/oli/editing/activity_edit_test.exs
+++ b/test/oli/editing/activity_edit_test.exs
@@ -1,0 +1,22 @@
+defmodule Oli.ActivityEditingTest do
+  use Oli.DataCase
+
+  alias Oli.Editing.ActivityEditor
+
+  describe "editing" do
+
+    setup do
+      Seeder.base_project_with_resource()
+    end
+
+    test "create/4 creates an activity revision", %{author: author, project: project } do
+
+      content = %{ "stem" => "Hey there" }
+      {:ok, revision} = ActivityEditor.create(project.slug, "oli_multiple_choice", author, content)
+      assert revision.content == %{ "stem" => "Hey there" }
+    end
+
+
+  end
+
+end

--- a/test/oli/editing/activity_edit_test.exs
+++ b/test/oli/editing/activity_edit_test.exs
@@ -2,8 +2,10 @@ defmodule Oli.ActivityEditingTest do
   use Oli.DataCase
 
   alias Oli.Editing.ActivityEditor
+  alias Oli.Editing.ResourceEditor
+  alias Oli.Editing.ResourceContext
 
-  describe "editing" do
+  describe "activity editing" do
 
     setup do
       Seeder.base_project_with_resource()
@@ -16,6 +18,44 @@ defmodule Oli.ActivityEditingTest do
       assert revision.content == %{ "stem" => "Hey there" }
     end
 
+    test "can create and attach an activity to a resource", %{author: author, project: project, revision: revision } do
+
+      content = %{ "stem" => "Hey there" }
+      {:ok, %{slug: slug, activity_id: activity_id}} = ActivityEditor.create(project.slug, "oli_multiple_choice", author, content)
+
+      # Verify that we can issue a resource edit that attaches the activity
+      update = %{ "content" => [%{ "type" => "activity-reference", "id" => 1, "activitySlug" => slug, "purpose" => "none"}]}
+      assert {:ok, updated_revision} =  ResourceEditor.edit(project.slug, revision.slug, author.email, update)
+
+      # Verify that the slug was translated to the correct activity id
+      activity_ref = hd(updated_revision.content)
+      assert activity_id == Map.get(activity_ref, "activity_id")
+      refute Map.has_key?(activity_ref, "activitySlug")
+
+
+      # Now generate the resource editing context with this attached activity in place
+      # so that we can verify that the activities, editorMap and content are all wired
+      # together correctly
+      {:ok, %ResourceContext{activities: activities, content: content, editorMap: editorMap}} = ResourceEditor.create_context(project.slug, revision.slug, author)
+
+      activity_ref = hd(content)
+
+      # verifies that the content entry has an activitySlug that references an activity map entry
+      activity_slug = Map.get(activity_ref, "activitySlug")
+      assert Map.has_key?(activities, activity_slug)
+
+      # and that activity map entry has a type slug that references an editor map entry
+      %{typeSlug: typeSlug} = Map.get(activities, activity_slug)
+      assert Map.has_key?(editorMap, typeSlug)
+
+    end
+
+    test "attaching an unknown activity to a resource fails", %{author: author, project: project, revision: revision } do
+
+      update = %{ "content" => [%{ "type" => "activity-reference", "id" => 1, "activitySlug" => "missing", "purpose" => "none"}]}
+      assert {:error, :not_found} =  ResourceEditor.edit(project.slug, revision.slug, author.email, update)
+
+    end
 
   end
 

--- a/test/oli/editing/edit_test.exs
+++ b/test/oli/editing/edit_test.exs
@@ -18,7 +18,7 @@ defmodule Oli.EditingTest do
     test "edit/4 creates a new revision when no lock in place", %{author: author, revision: revision } do
 
       content = [%{ "type" => "p", children: [%{ "text" => "A paragraph."}] }]
-      {:ok, updated_revision} = ResourceEditor.edit("title", "some_title", author.email, %{ content: content })
+      {:ok, updated_revision} = ResourceEditor.edit("title", "some_title", author.email, %{ "content" => content })
 
       assert revision.id != updated_revision.id
     end
@@ -28,7 +28,7 @@ defmodule Oli.EditingTest do
       content = [%{ "type" => "p", children: [%{ "text" => "A paragraph."}] }]
       title = "a new title"
 
-      {:ok, updated_revision} = ResourceEditor.edit("title", "some_title", author.email, %{ title: title, content: content })
+      {:ok, updated_revision} = ResourceEditor.edit("title", "some_title", author.email, %{ "title" => title, "content" => content })
 
       # read it back from the db and verify both edits were made
       from_db = Resources.get_resource_revision!(updated_revision.id)
@@ -55,7 +55,7 @@ defmodule Oli.EditingTest do
       Publishing.update_resource_mapping(mapping, %{lock_updated_at: Time.now(), locked_by_id: author.id})
 
       content = [%{ "type" => "p", children: [%{ "text" => "A paragraph."}] }]
-      {:ok, updated_revision} = ResourceEditor.edit("title", "some_title", author.email, %{ content: content })
+      {:ok, updated_revision} = ResourceEditor.edit("title", "some_title", author.email, %{ "content" => content })
 
       assert revision.id == updated_revision.id
     end
@@ -66,7 +66,7 @@ defmodule Oli.EditingTest do
       Publishing.update_resource_mapping(mapping, %{lock_updated_at: yesterday(), locked_by_id: author.id})
 
       content = [%{ "type" => "p", children: [%{ "text" => "A paragraph."}] }]
-      {:ok, updated_revision} = ResourceEditor.edit("title", "some_title", author.email, %{ content: content })
+      {:ok, updated_revision} = ResourceEditor.edit("title", "some_title", author.email, %{ "content" => content })
 
       assert revision.id != updated_revision.id
     end
@@ -79,7 +79,7 @@ defmodule Oli.EditingTest do
 
       # now try to make the edit with the original user
       content = [%{ "type" => "p", children: [%{ "text" => "A paragraph."}] }]
-      result = ResourceEditor.edit("title", "some_title", author.email, %{ content: content })
+      result = ResourceEditor.edit("title", "some_title", author.email, %{ "content" => content })
 
       id = author2.id
       assert {:error, {:lock_not_acquired, {^id, _}}} = result
@@ -89,7 +89,7 @@ defmodule Oli.EditingTest do
 
       # try to make the edit on a resource that isn't found via a revision slug
       content = [%{ "type" => "p", children: [%{ "text" => "A paragraph."}] }]
-      result = ResourceEditor.edit("title", "some_missing_slug", author.email, %{ content: content })
+      result = ResourceEditor.edit("title", "some_missing_slug", author.email, %{ "content" => content })
 
       assert {:error, {:not_found}} = result
     end
@@ -98,7 +98,7 @@ defmodule Oli.EditingTest do
 
       # try to make the edit on a resource that isn't found via a revision slug
       content = [%{ "type" => "p", children: [%{ "text" => "A paragraph."}] }]
-      result = ResourceEditor.edit("some_missing_slug", "some_title", author.email, %{ content: content })
+      result = ResourceEditor.edit("some_missing_slug", "some_title", author.email, %{ "content" => content })
 
       assert {:error, {:not_found}} = result
     end
@@ -109,7 +109,7 @@ defmodule Oli.EditingTest do
       content = [%{ "type" => "p", children: [%{ "text" => "A paragraph."}] }]
       {:ok, author2} = Author.changeset(%Author{}, %{email: "test2@test.com", first_name: "First", last_name: "Last", provider: "foo", system_role_id: SystemRole.role_id.author}) |> Repo.insert
 
-      result = ResourceEditor.edit("title", "some_title", author2.email, %{ content: content })
+      result = ResourceEditor.edit("title", "some_title", author2.email, %{ "content" => content })
 
       assert {:error, {:not_authorized}} = result
     end

--- a/test/oli/registrar_test.exs
+++ b/test/oli/registrar_test.exs
@@ -14,8 +14,8 @@ defmodule Oli.RegistrarTest do
 
       assert r.title == "Multiple Choice"
       assert r.description == "A traditional multiple choice question with one correct answer"
-      assert r.authoring_script == "oli-multiple-choice-authoring.js"
-      assert r.delivery_script == "oli-multiple-choice-delivery.js"
+      assert r.authoring_script == "oli_multiple_choice_authoring.js"
+      assert r.delivery_script == "oli_multiple_choice_delivery.js"
       assert r.authoring_element == "oli-multiple-choice-authoring"
       assert r.delivery_element == "oli-multiple-choice-delivery"
 
@@ -27,9 +27,9 @@ defmodule Oli.RegistrarTest do
 
       assert (Map.keys(map) |> length) == 1
 
-      r = Map.get(map, "oli-multiple-choice")
+      r = Map.get(map, "oli_multiple_choice")
 
-      assert r.slug == "oli-multiple-choice"
+      assert r.slug == "oli_multiple_choice"
       assert r.description == "A traditional multiple choice question with one correct answer"
       assert r.friendlyName == "Multiple Choice"
       assert r.authoringElement == "oli-multiple-choice-authoring"


### PR DESCRIPTION
This PR includes the ability to now create instances of registered activities and embed references to them in a resource, end to end.  Specifically, changes here include:

1. Data driven editor drop down creation - the list of things you can insert is now driven from registered activities
2. Notion of an activity model factory - a creation function that our code can use to create new instances of activities.  This creation function is promise based, which would allow an activity to do something like reach out to a third party service as part of model creation 
3. Incorporated slugs for activity revision, that are based on the title from the registered activity or a direct title edit
4. Activity controller and a backing ActivityEditor.  Right now the ActivityEditor only supports creation of activities. Editing is next 
5. Changed the ResourceContext that is provided as JSON to the resource editing page to include an “Activity Map”. This is a snapshot of the current revisions for all activities that are embedded in a page. 
6. ResourceEditing changes to translate back and forth between the database representation of Resource content “activity-reference” objects and the front end.  The backend representation stores these use database activity ids, but we give the front end revision slugs.  

This is all leading up to the next step of building out the ability to edit these activities. 