### PR TITLE
improve reordering, fix deletion, add unit tests

### DIFF
--- a/lib/oli_web/controllers/curriculum_controller.ex
+++ b/lib/oli_web/controllers/curriculum_controller.ex
@@ -28,6 +28,7 @@ defmodule OliWeb.CurriculumController do
 
       {:ok, _resource} ->
         conn
+        |> put_flash(:info, "Page created")
         |> redirect(to: Routes.curriculum_path(conn, :index, project))
 
       {:error, %Ecto.Changeset{} = _changeset} ->
@@ -40,17 +41,27 @@ defmodule OliWeb.CurriculumController do
   def update(conn, %{"sourceSlug" => source, "index" => index}) do
     %{project: project, current_author: author} = conn.assigns
 
-    case ContainerEditor.reorder_children(project, author, source, index) do
+    case ContainerEditor.reorder_child(project, author, source, index) do
+      {:ok, _resource} -> json(conn, %{ "success" => "true"})
+      {:error, _} -> json(conn, %{ "success" => "false"})
+    end
+  end
+
+  def delete(conn, %{"id" => page_slug}) do
+    %{project: project, current_author: author} = conn.assigns
+
+    case ContainerEditor.remove_child(project, author, page_slug) do
       {:ok, _resource} ->
-        render(conn, "index.html",
-        pages: ContainerEditor.list_all_pages(conn.assigns.project),
-        title: "Curriculum")
+        conn
+        |> put_flash(:info, "Page deleted.")
+        |> redirect(to: Routes.curriculum_path(conn, :index, project))
 
       {:error, _} ->
-        render(conn, "index.html",
-        pages: ContainerEditor.list_all_pages(conn.assigns.project),
-        title: "Curriculum")
+        conn
+        |> put_flash(:error, "Page not deleted.")
+        |> redirect(to: Routes.curriculum_path(conn, :index, project))
     end
+
   end
 
 end

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -90,7 +90,7 @@ defmodule OliWeb.Router do
     delete "/:project_id/objectives/:objective_slug", ObjectiveController, :delete
 
     # Curriculum
-    resources "/:project_id/curriculum", CurriculumController, only: [:index, :create]
+    resources "/:project_id/curriculum", CurriculumController, only: [:index, :create, :delete]
     put "/:project_id/curriculum", CurriculumController, :update
 
     # Editors

--- a/lib/oli_web/templates/curriculum/index.html.eex
+++ b/lib/oli_web/templates/curriculum/index.html.eex
@@ -12,6 +12,21 @@
   margin: 0px;
   margin-left: 30px;
 }
+
+li.page {
+  height: 50px;
+}
+
+li.over {
+  background: #DDDDDD;
+}
+
+li.page:hover{
+  background: #EEEEEE;
+}
+li.page:last-child:hover{
+  background: transparent;
+}
 </style>
 
 <%# Wait until live-view to re-add keyboard reordering? %>
@@ -30,11 +45,14 @@
 <ol id="list" style="list-style-type: none; margin-top: 40px;">
   <%= for {page, index} <- Enum.with_index(@pages) do %>
     <li
+      class="page"
       draggable="true"
+      ondragenter="dragEnter(event)"
+      ondragend="dragEnd(event)"
       ondragstart="itemDragStarted(event, '<%= page.slug %>', <%= index %>)"
       ondragover="itemDraggingOver(event)"
       id="<%= page.slug %>"
-      ondrop="itemDropped(event, '<%= page.slug %>', <%= index %>)"
+      ondrop="itemDropped(event, <%= index %>)"
     >
       <div class="d-flex p-1" style="align-items: center;">
         <span style="margin-top: 4px;"><%= case page.graded do
@@ -43,11 +61,19 @@
         end %></span>
         <span class="p-2" style="text-align: top;"><%= index + 1 %>. </span>
         <%= link page.title, to: Routes.resource_path(@conn, :edit, @project, page.slug), class: "link-page" %>
-        <%= link "Delete", to: Routes.resource_path(@conn, :delete, @project, page.slug), method: :delete, data: [confirm: "Are you sure?"], class: "link-delete" %>
+        <%= link "Delete", to: Routes.curriculum_path(@conn, :delete, @project, page.slug), method: :delete, data: [confirm: "Are you sure?"], class: "link-delete" %>
 
       </div>
     </li>
   <% end %>
+  <li
+    class="page"
+    ondragenter="dragEnter(event)"
+    ondragover="itemDraggingOver(event)"
+    ondrop="itemDropped(event, <%= length(@pages) %>)"
+    >
+
+  </li>
 </ol>
 
 </div>
@@ -60,6 +86,23 @@
       target = target.parentNode;
     }
     return target
+  }
+
+  function dragEnter(event) {
+
+    const t = event.currentTarget;
+
+    if (t.nodeName === 'LI') {
+      event.stopPropagation();
+      event.preventDefault();
+
+      $(".page").removeClass("over");
+      t.className = "page over"
+    }
+  }
+
+  function dragEnd(event) {
+    $(".page").removeClass("over");
   }
 
   function insertAfter(newNode, existingNode) {
@@ -84,7 +127,7 @@
     e.dataTransfer.dropEffect = 'move'
   }
 
-  function itemDropped(e, slug, index) {
+  function itemDropped(e, index) {
     e.preventDefault()
     e.stopPropagation()
 

--- a/test/oli/editing/container_editor_test.exs
+++ b/test/oli/editing/container_editor_test.exs
@@ -64,6 +64,7 @@ defmodule Oli.Authoring.Editing.ContainerEditorTest do
 
       {:acquired} = Locks.acquire(publication.id, page1.id, author2.id)
 
+      # Verify that the remove failed due to the lock
       case ContainerEditor.remove_child(project, author, revision1.slug) do
         {:ok, _} -> assert false
         {:error, {:lock_not_acquired, _}} -> assert true

--- a/test/oli/editing/container_editor_test.exs
+++ b/test/oli/editing/container_editor_test.exs
@@ -1,0 +1,125 @@
+defmodule Oli.Authoring.Editing.ContainerEditorTest do
+  use Oli.DataCase
+
+  alias Oli.Authoring.Editing.ContainerEditor
+  alias Oli.Publishing.AuthoringResolver
+  alias Oli.Authoring.Locks
+
+  describe "container editing" do
+
+    setup do
+      Seeder.base_project_with_resource2()
+    end
+
+    test "list_all_pages/1 returns the pages", %{project: project, revision2: revision2, revision1: revision1 } do
+
+      pages = ContainerEditor.list_all_pages(project)
+
+      assert length(pages) == 2
+      assert hd(pages).id == revision1.id
+      assert hd(tl(pages)).id == revision2.id
+
+    end
+
+    test "add_new/3 creates a new page and attaches it to the root", %{author: author, project: project } do
+
+      page = %{
+        objectives: %{ "attached" => []},
+        children: [],
+        content: %{ "model" => []},
+        title: "New Page",
+        graded: true,
+        resource_type_id: Oli.Resources.ResourceType.get_id_by_type("page")
+      }
+
+      {:ok, revision} = ContainerEditor.add_new(page, author, project)
+
+      assert revision.title == "New Page"
+
+      container = AuthoringResolver.root_resource(project.slug)
+
+      # Ensure that the edit has inserted the new page reference
+      # first in the collection
+      assert length(container.children) == 3
+      assert Enum.find_index(container.children, fn c -> revision.resource_id == c end) == 0
+
+    end
+
+    test "remove_child/3 removes correctly", %{author: author, project: project, revision1: revision1 } do
+
+      {:ok, _} = ContainerEditor.remove_child(project, author, revision1.slug)
+
+      # Verify we have removed it from the container
+      container = AuthoringResolver.root_resource(project.slug)
+      assert length(container.children) == 1
+      assert Enum.find_index(container.children, fn c -> revision1.resource_id == c end) == nil
+
+      # Verify that we have marked the resource as being deleted
+      updated = AuthoringResolver.from_resource_id(project.slug, revision1.resource_id)
+      assert updated.deleted == true
+
+    end
+
+    test "remove_child/3 fails when target resource is locked", %{publication: publication, author2: author2, author: author, project: project, page1: page1, revision1: revision1 } do
+
+      {:acquired} = Locks.acquire(publication.id, page1.id, author2.id)
+
+      case ContainerEditor.remove_child(project, author, revision1.slug) do
+        {:ok, _} -> assert false
+        {:error, {:lock_not_acquired, _}} -> assert true
+      end
+
+    end
+
+    test "remove_child/3 succeeds when target resource is locked by same user", %{publication: publication, author: author, project: project, page1: page1, revision1: revision1 } do
+
+      {:acquired} = Locks.acquire(publication.id, page1.id, author.id)
+
+      case ContainerEditor.remove_child(project, author, revision1.slug) do
+        {:ok, _} -> assert true
+        {:error, {:lock_not_acquired, _}} -> assert false
+      end
+
+    end
+
+    test "reorder_child/3 reorders correctly", %{author: author, project: project } do
+
+      page = %{
+        objectives: %{ "attached" => []},
+        children: [],
+        content: %{ "model" => []},
+        title: "New Page",
+        graded: true,
+        resource_type_id: Oli.Resources.ResourceType.get_id_by_type("page")
+      }
+
+      {:ok, revision} = ContainerEditor.add_new(page, author, project)
+
+      # we now have three pages to reorder with:
+
+      {:ok, _} = ContainerEditor.reorder_child(project, author, revision.slug, 2)
+      container = AuthoringResolver.root_resource(project.slug)
+      assert length(container.children) == 3
+      assert Enum.find_index(container.children, fn c -> revision.resource_id == c end) == 1
+
+      {:ok, _} = ContainerEditor.reorder_child(project, author, revision.slug, 3)
+      container = AuthoringResolver.root_resource(project.slug)
+      assert length(container.children) == 3
+      assert Enum.find_index(container.children, fn c -> revision.resource_id == c end) == 2
+
+      {:ok, _} = ContainerEditor.reorder_child(project, author, revision.slug, 100)
+      container = AuthoringResolver.root_resource(project.slug)
+      assert length(container.children) == 3
+      assert Enum.find_index(container.children, fn c -> revision.resource_id == c end) == 2
+
+      {:ok, _} = ContainerEditor.reorder_child(project, author, revision.slug, 0)
+      container = AuthoringResolver.root_resource(project.slug)
+      assert length(container.children) == 3
+      assert Enum.find_index(container.children, fn c -> revision.resource_id == c end) == 0
+
+
+    end
+
+  end
+
+end


### PR DESCRIPTION
This PR wraps up initial curriculum support by:

* Improving the look and feel of drag and drop ui 
* Fixing deletion to remove the item from the container and to mark it as deleted
* Adds units tests for module `ContainerEditor`

