### PR TITLE
implement previous and next links, cleanup objectives display

### DIFF
--- a/lib/oli_web/controllers/instructor_delivery_controller.ex
+++ b/lib/oli_web/controllers/instructor_delivery_controller.ex
@@ -37,7 +37,15 @@ defmodule OliWeb.InstructorDeliveryController do
       page_model = Map.get(context.page.content, "model")
       html = Page.render(render_context, page_model, Page.Html)
 
-      render(conn, "page.html", %{scripts: get_scripts(), title: context.page.title, html: html, objectives: context.objectives})
+      render(conn, "page.html", %{
+        context_id: context_id,
+        scripts: get_scripts(),
+        previous_page: context.previous_page,
+        next_page: context.next_page,
+        title: context.page.title,
+        html: html,
+        objectives: context.objectives
+      })
 
     else
       render(conn, "not_authorized.html")

--- a/lib/oli_web/controllers/student_delivery_controller.ex
+++ b/lib/oli_web/controllers/student_delivery_controller.ex
@@ -40,7 +40,15 @@ defmodule OliWeb.StudentDeliveryController do
       page_model = Map.get(context.page.content, "model")
       html = Page.render(render_context, page_model, Page.Html)
 
-      render(conn, "page.html", %{scripts: get_scripts(), title: context.page.title, html: html, objectives: context.objectives})
+      render(conn, "page.html", %{
+        context_id: context_id,
+        scripts: get_scripts(),
+        previous_page: context.previous_page,
+        next_page: context.next_page,
+        title: context.page.title,
+        html: html,
+        objectives: context.objectives
+      })
     else
       render(conn, "not_authorized.html")
     end

--- a/lib/oli_web/templates/delivery/_objectives.html.eex
+++ b/lib/oli_web/templates/delivery/_objectives.html.eex
@@ -1,0 +1,15 @@
+<%= if length(@objectives) > 0 do %>
+
+  <div class="card" style="width: 100%; margin: 20px;">
+    <div class="card-body">
+      <h5 class="card-title">Learning Objectives</h5>
+      <h6 class="card-subtitle mb-2 text-muted">By the end of this page you should be able to:</h6>
+      <ul>
+      <%= for o <- @objectives do %>
+        <li><%= o %></li>
+      <% end %>
+      </ul>
+    </div>
+  </div>
+
+<% end %>

--- a/lib/oli_web/templates/delivery/_previous_next_nav.html.eex
+++ b/lib/oli_web/templates/delivery/_previous_next_nav.html.eex
@@ -1,0 +1,14 @@
+<ul class="nav justify-content-end">
+
+  <%= if @previous_page != nil do %>
+  <li class="nav-item">
+    <%= link "<< " <> @previous_page.title, to: @linker.(@conn, @context_id, @previous_page.slug), class: "nav-link" %>
+  </li>
+  <% end %>
+
+  <%= if @next_page != nil do %>
+  <li class="nav-item">
+    <%= link @next_page.title <> " >>", to: @linker.(@conn, @context_id, @next_page.slug), class: "nav-link" %>
+  </li>
+  <% end %>
+</ul>

--- a/lib/oli_web/templates/instructor_delivery/index.html.eex
+++ b/lib/oli_web/templates/instructor_delivery/index.html.eex
@@ -8,6 +8,6 @@
   <hr class="my-4"/>
 
   <h5>Course Outline</h5>
-  <%= render OliWeb.DeliveryView, "_course_outline.html", context_id: @context_id, pages: @pages, conn: @conn, path_route: &OliWeb.InstructorDeliveryView.page_route/3 %>
+  <%= render OliWeb.DeliveryView, "_course_outline.html", context_id: @context_id, pages: @pages, conn: @conn, path_route: &OliWeb.InstructorDeliveryView.page_link/3 %>
   </div>
 </div>

--- a/lib/oli_web/templates/instructor_delivery/page.html.eex
+++ b/lib/oli_web/templates/instructor_delivery/page.html.eex
@@ -3,20 +3,15 @@
   <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/" <> script) %>"></script>
 <% end %>
 
-<div class="my-3">
-  <h3><%= @title %></h3>
-
-  <%= if length(@objectives) > 0 do %>
-    <h4>Learning Objectives</h4>
-    <ul>
-    <%= for o <- @objectives do %>
-      <li><%= o %></li>
-    <% end %>
-    </ul>
-    <hr class="my-4"/>
-  <% end %>
-
+<div class="alert alert-warning" role="alert">
   <h4>Instructor View of Content</h4>
-
-  <%= raw(@html) %>
 </div>
+
+<h3><%= @title %></h3>
+
+<%= render OliWeb.DeliveryView, "_objectives.html", objectives: @objectives %>
+
+<%= raw(@html) %>
+
+<%= render OliWeb.DeliveryView, "_previous_next_nav.html",
+  conn: @conn, context_id: @context_id, previous_page: @previous_page, next_page: @next_page, linker: &OliWeb.InstructorDeliveryView.page_link/3 %>

--- a/lib/oli_web/templates/student_delivery/index.html.eex
+++ b/lib/oli_web/templates/student_delivery/index.html.eex
@@ -9,6 +9,6 @@
   <hr class="my-4"/>
 
   <h5>Course Outline</h5>
-  <%= render OliWeb.DeliveryView, "_course_outline.html", conn: @conn, context_id: @context_id, pages: @pages, path_route: &OliWeb.StudentDeliveryView.page_route/3 %>
+  <%= render OliWeb.DeliveryView, "_course_outline.html", conn: @conn, context_id: @context_id, pages: @pages, path_route: &OliWeb.StudentDeliveryView.page_link/3 %>
   </div>
 </div>

--- a/lib/oli_web/templates/student_delivery/page.html.eex
+++ b/lib/oli_web/templates/student_delivery/page.html.eex
@@ -3,21 +3,11 @@
   <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/" <> script) %>"></script>
 <% end %>
 
-<div class="my-3">
-  <h3><%= @title %></h3>
+<h3><%= @title %></h3>
 
-  <%= if length(@objectives) > 0 do %>
-    <h4>Learning Objectives</h4>
-    <ul>
-    <%= for o <- @objectives do %>
-      <li><%= o %></li>
-    <% end %>
-    </ul>
-    <hr class="my-4"/>
-  <% end %>
+<%= render OliWeb.DeliveryView, "_objectives.html", objectives: @objectives %>
 
-  <h4>Content</h4>
+<%= raw(@html) %>
 
-  <%= raw(@html) %>
-
-</div>
+<%= render OliWeb.DeliveryView, "_previous_next_nav.html",
+  conn: @conn, context_id: @context_id, previous_page: @previous_page, next_page: @next_page, linker: &OliWeb.StudentDeliveryView.page_link/3 %>

--- a/lib/oli_web/views/instructor_delivery_view.ex
+++ b/lib/oli_web/views/instructor_delivery_view.ex
@@ -1,7 +1,7 @@
 defmodule OliWeb.InstructorDeliveryView do
   use OliWeb, :view
 
-  def page_route(conn, context_id, slug) do
+  def page_link(conn, context_id, slug) do
     Routes.instructor_delivery_path(conn, :page, context_id, slug)
   end
 end

--- a/lib/oli_web/views/student_delivery_view.ex
+++ b/lib/oli_web/views/student_delivery_view.ex
@@ -1,7 +1,7 @@
 defmodule OliWeb.StudentDeliveryView do
   use OliWeb, :view
 
-  def page_route(conn, context_id, slug) do
+  def page_link(conn, context_id, slug) do
     Routes.student_delivery_path(conn, :page, context_id, slug)
   end
 end

--- a/test/oli_web/controllers/student_delivery_controller_test.exs
+++ b/test/oli_web/controllers/student_delivery_controller_test.exs
@@ -25,7 +25,8 @@ defmodule OliWeb.StudentDeliveryControllerTest do
       conn = conn
       |> get(Routes.student_delivery_path(conn, :page, section.context_id, revision.slug))
 
-      assert html_response(conn, 200) =~ "<h4>Content</h4>"
+      assert html_response(conn, 200) =~ "<h3>"
+      refute html_response(conn, 200) =~ "<h4>Instructor View of Content</h4>"
     end
 
 


### PR DESCRIPTION
This PR implements the display of previous page and next pages for page navigation.

It also improves the code sharing situation a bit between instructor and student delivery controllers, as well as cleans up the objectives display.

Closes #65 

