### PR TITLE
Project slug

### DIFF
--- a/lib/oli/authoring/course/family.ex
+++ b/lib/oli/authoring/course/family.ex
@@ -2,6 +2,8 @@ defmodule Oli.Authoring.Course.Family do
   use Ecto.Schema
   import Ecto.Changeset
 
+  alias Oli.Utils.Slug
+
   @derive {Phoenix.Param, key: :slug}
   schema "families" do
     field :description, :string
@@ -15,7 +17,8 @@ defmodule Oli.Authoring.Course.Family do
   def changeset(family, attrs \\ %{}) do
     family
     |> cast(attrs, [:title, :slug, :description])
-    |> validate_required([:title, :slug])
+    |> validate_required([:title])
+    |> Slug.update_never("families")
   end
 
 end

--- a/lib/oli/authoring/course/project.ex
+++ b/lib/oli/authoring/course/project.ex
@@ -24,8 +24,8 @@ defmodule Oli.Authoring.Course.Project do
   def changeset(project, attrs \\ %{}) do
     project
       |> cast(attrs, [:title, :slug, :description, :version, :family_id, :project_id])
-      |> validate_required([:title, :slug, :version, :family_id])
-      |> Slug.maybe_update_slug("projects")
+      |> validate_required([:title, :version, :family_id])
+      |> Slug.update_never("projects")
   end
 
 end

--- a/lib/oli/db_seeder.ex
+++ b/lib/oli/db_seeder.ex
@@ -10,8 +10,8 @@ defmodule Oli.Seeder do
 
   def base_project_with_resource2() do
 
-    {:ok, family} = Family.changeset(%Family{}, %{description: "description", slug: "slug", title: "title"}) |> Repo.insert
-    {:ok, project} = Project.changeset(%Project{}, %{description: "description", slug: "slug", title: "title", version: "1", family_id: family.id}) |> Repo.insert
+    {:ok, family} = Family.changeset(%Family{}, %{description: "description", title: "title"}) |> Repo.insert
+    {:ok, project} = Project.changeset(%Project{}, %{description: "description", title: "title", version: "1", family_id: family.id}) |> Repo.insert
     {:ok, author} = Author.changeset(%Author{}, %{email: "test@test.com", first_name: "First", last_name: "Last", provider: "foo", system_role_id: SystemRole.role_id.author}) |> Repo.insert
     {:ok, author2} = Author.changeset(%Author{}, %{email: "test2@test.com", first_name: "First", last_name: "Last", provider: "foo", system_role_id: SystemRole.role_id.author}) |> Repo.insert
 
@@ -72,8 +72,8 @@ defmodule Oli.Seeder do
 
   def another_project(author, institution) do
 
-    {:ok, family} = Family.changeset(%Family{}, %{description: "description", slug: "slug", title: "title"}) |> Repo.insert
-    {:ok, project} = Project.changeset(%Project{}, %{description: "description", slug: "slug", title: "title", version: "1", family_id: family.id}) |> Repo.insert
+    {:ok, family} = Family.changeset(%Family{}, %{description: "description", title: "title"}) |> Repo.insert
+    {:ok, project} = Project.changeset(%Project{}, %{description: "description", title: "title", version: "1", family_id: family.id}) |> Repo.insert
 
     {:ok, _} = AuthorProject.changeset(%AuthorProject{}, %{author_id: author.id, project_id: project.id, project_role_id: ProjectRole.role_id.owner}) |> Repo.insert
 

--- a/lib/oli/resources/revision.ex
+++ b/lib/oli/resources/revision.ex
@@ -12,7 +12,7 @@ defmodule Oli.Resources.Revision do
     field :deleted, :boolean, default: false
     belongs_to :author, Oli.Accounts.Author
     belongs_to :resource, Oli.Resources.Resource
-    belongs_to :previous_revision, Oli.Resources.ResourceRevision
+    belongs_to :previous_revision, Oli.Resources.Revision
     belongs_to :resource_type, Oli.Resources.ResourceType
 
     # fields that apply to only a subset of the types

--- a/lib/oli/resources/revision.ex
+++ b/lib/oli/resources/revision.ex
@@ -30,7 +30,7 @@ defmodule Oli.Resources.Revision do
     resource_revision
     |> cast(attrs, [:title, :slug, :deleted, :author_id, :resource_id, :previous_revision_id, :resource_type_id, :content, :children, :objectives, :graded, :activity_type_id])
     |> validate_required([:title, :deleted, :author_id, :resource_id, :resource_type_id])
-    |> Slug.maybe_update_slug("revisions")
+    |> Slug.update_on_change("revisions")
   end
 
 end

--- a/lib/oli/utils/slug.ex
+++ b/lib/oli/utils/slug.ex
@@ -2,15 +2,32 @@ defmodule Oli.Utils.Slug do
 
   @chars "abcdefghijklmnopqrstuvwxyz1234567890" |> String.split("")
 
-  def maybe_update_slug(changeset, table) do
+  @doc """
+  Updates the slug from the title for a table if the title has not
+  been set or if it has changed.
+  """
+  def update_on_change(changeset, table) do
     case changeset.valid? do
       true ->
         case Ecto.Changeset.get_change(changeset, :title) do
-          nil -> case Ecto.Changeset.get_field(changeset, :title) do
-            nil -> changeset
-            title -> Ecto.Changeset.put_change(changeset, :slug, generate(table, title))
-          end
+          nil -> changeset
           title -> Ecto.Changeset.put_change(changeset, :slug, generate(table, title))
+        end
+
+      _ -> changeset
+    end
+  end
+
+  @doc """
+  Generates a slug once, but then guarantee that it never changes
+  on future title changes.
+  """
+  def update_never(changeset, table) do
+    case changeset.valid? do
+      true ->
+        case Ecto.Changeset.get_field(changeset, :slug) do
+          nil -> Ecto.Changeset.put_change(changeset, :slug, generate(table, Ecto.Changeset.get_field(changeset, :title)))
+          _ -> changeset
         end
 
       _ -> changeset

--- a/priv/repo/migrations/20200310193550_init_core_schemas.exs
+++ b/priv/repo/migrations/20200310193550_init_core_schemas.exs
@@ -92,6 +92,7 @@ defmodule Oli.Repo.Migrations.InitCoreSchemas do
 
       timestamps(type: :timestamptz)
     end
+    create unique_index(:families, [:slug], name: :index_slug_families)
 
     create table(:projects) do
       add :title, :string
@@ -103,6 +104,7 @@ defmodule Oli.Repo.Migrations.InitCoreSchemas do
 
       timestamps(type: :timestamptz)
     end
+    create unique_index(:projects, [:slug], name: :index_slug_projects)
 
     create table(:resources) do
       timestamps(type: :timestamptz)

--- a/test/oli/course_test.exs
+++ b/test/oli/course_test.exs
@@ -6,14 +6,14 @@ defmodule Oli.CourseTest do
 
   describe "projects basic" do
 
-    @valid_attrs %{description: "some description", slug: "some slug", version: "1", title: "some title"}
-    @update_attrs %{description: "some updated description", version: "1", slug: "some updated slug", title: "some updated title"}
+    @valid_attrs %{description: "some description", version: "1", title: "some title"}
+    @update_attrs %{description: "some updated description", version: "1", title: "some updated title"}
     @invalid_attrs %{description: nil, slug: nil, title: nil}
 
     setup do
 
       {:ok, family} = Family.changeset(%Family{}, %{description: "description", slug: "slug", title: "title"}) |> Repo.insert
-      {:ok, project} = Project.changeset(%Project{}, %{description: "description", slug: "slug", title: "title", version: "1", family_id: family.id}) |> Repo.insert
+      {:ok, project} = Project.changeset(%Project{}, %{description: "description", title: "title", version: "1", family_id: family.id}) |> Repo.insert
 
       valid_attrs = Map.put(@valid_attrs, :family_id, family.id)
         |> Map.put(:project_id, project.id)
@@ -49,7 +49,7 @@ defmodule Oli.CourseTest do
     test "update_project/2 with valid data updates the project", %{project: project}  do
       assert {:ok, %Project{} = project} = Course.update_project(project, @update_attrs)
       assert project.description == "some updated description"
-      assert project.slug == "some_updated_title"
+      assert project.slug == "title"   # The slug should never change
       assert project.title == "some updated title"
     end
 

--- a/test/oli/utils/slug_test.exs
+++ b/test/oli/utils/slug_test.exs
@@ -1,0 +1,56 @@
+defmodule Oli.Utils.SlugTest do
+
+  use Oli.DataCase
+
+  alias Oli.Utils.Slug
+
+  alias Oli.Authoring.Course.Project
+  alias Oli.Resources.Revision
+
+  alias Ecto.Changeset
+
+  describe "resources" do
+
+    setup do
+      map = Seeder.base_project_with_resource2()
+
+      # Create another project with resources and revisions
+      Seeder.another_project(map.author, map.institution)
+
+      map
+    end
+
+    test "update_on_change/2 updates the slug when the title changes", %{ revision1: r } do
+
+      # clearly a change that doesn't involve the title
+      assert Revision.changeset(r, %{graded: true})
+      |> Slug.update_on_change("revisions")
+      |> Changeset.get_change(:slug) == nil
+
+      # a change involving the title, but not actually changing it
+      assert Revision.changeset(r, %{title: r.title})
+      |> Slug.update_on_change("revisions")
+      |> Changeset.get_change(:slug) == nil
+
+      # changing the title
+      refute Revision.changeset(r, %{title: "a changed title"})
+      |> Slug.update_on_change("revisions")
+      |> Changeset.get_change(:slug) == nil
+
+    end
+
+    test "update_never/2 does not update the slug when the title changes", %{ project: p } do
+
+      assert Project.changeset(p, %{version: "2"})
+      |> Slug.update_never("projects")
+      |> Changeset.get_change(:slug) == nil
+
+      assert Project.changeset(p, %{title: "a changed title"})
+      |> Slug.update_never("projects")
+      |> Changeset.get_change(:slug) == nil
+    end
+
+  end
+
+
+end


### PR DESCRIPTION
This PR adjusts the slug logic for projects to ensure that slugs never change once they are set. 

There were a few other things that were wrong here.  Indices for families and projects were missing.  The logic in the revision slugging was backwards. 

I also added unit tests for the slugging logic. 

Closes #111 
