### PR TITLE
handle slug generation properly across revisions

### DIFF
--- a/lib/oli/publishing/authoring_resolver.ex
+++ b/lib/oli/publishing/authoring_resolver.ex
@@ -59,6 +59,7 @@ defmodule Oli.Publishing.AuthoringResolver do
         join: p in Publication, on: p.id == m.publication_id,
         join: c in Project, on: p.project_id == c.id,
         where: p.published == false and rev.slug == ^revision_slug and c.slug == ^project_slug,
+        limit: 1,
         select: rev2)
     end
     |> run() |> emit([:oli, :resolvers, :authoring], :duration)


### PR DESCRIPTION
This PR expands the logic for handling slugs - there was a gap in that it didn't properly handle preserving a slug across new revision creation. 

This change then exposed a bug in an authoring resolver method that wasn't considering that multiple revisions could have the same slug. 

Closes #142 
