### PR TITLE
Save restore state

### DIFF
--- a/assets/src/components/activities/DeliveryElement.ts
+++ b/assets/src/components/activities/DeliveryElement.ts
@@ -3,12 +3,11 @@ import { ActivitySlug } from 'data/types';
 
 
 export type PartResponse = {
-  partId: string,
+  attemptGuid: string,
   response: StudentResponse,
 };
 
 export interface DeliveryElementProps<T extends ActivityModelSchema> {
-  activitySlug: ActivitySlug;
   model: T;
   state: ActivityState;
   onRequestHint: (partIds: string[]) => Promise<Hint>;
@@ -61,11 +60,9 @@ export abstract class DeliveryElement<T extends ActivityModelSchema> extends HTM
 
     const model = JSON.parse(this.getAttribute('model') as any);
     const state = JSON.parse(this.getAttribute('state') as any) as ActivityState;
-    const activitySlug = this.getAttribute('activitySlug') as any;
 
     return {
       model,
-      activitySlug,
       state,
       onRequestHint: this.onRequestHint,
       onSave: this.onSave,

--- a/assets/src/components/activities/DeliveryElement.ts
+++ b/assets/src/components/activities/DeliveryElement.ts
@@ -1,6 +1,4 @@
 import { ActivityModelSchema, ActivityState, StudentResponse, Hint, Success } from './types';
-import { ActivitySlug } from 'data/types';
-
 
 export type PartResponse = {
   attemptGuid: string,
@@ -10,11 +8,15 @@ export type PartResponse = {
 export interface DeliveryElementProps<T extends ActivityModelSchema> {
   model: T;
   state: ActivityState;
-  onRequestHint: (partIds: string[]) => Promise<Hint>;
-  onSave: (partResponses: PartResponse[]) => Promise<Success>;
-  onSubmit: (partResponses: PartResponse[]) => void;
-  onResetParts: (partIds: string[]) => void;
-  onReset: () => void;
+
+  onSaveActivity: (attemptGuid: string, partResponses: PartResponse[]) => Promise<Success>;
+  onSubmitActivity: (attemptGuid: string, partResponses: PartResponse[]) => void;
+  onResetActivity: (attemptGuid: string) => void;
+
+  onRequestHint: (attemptGuid: string) => Promise<Hint>;
+  onSavePart: (attemptGuid: string, response: StudentResponse) => Promise<Success>;
+  onSubmitPart: (attemptGuid: string, response: StudentResponse) => void;
+  onResetPart: (attemptGuid: string) => void;
 }
 
 // An abstract delivery web component, designed to delegate to
@@ -25,25 +27,38 @@ export abstract class DeliveryElement<T extends ActivityModelSchema> extends HTM
 
   mountPoint: HTMLDivElement;
   connected: boolean;
-  onRequestHint: (partIds: string[]) => Promise<Hint>;
-  onSave: (partResponses: PartResponse[]) => Promise<Success>;
-  onSubmit: (partResponses: PartResponse[]) => void;
-  onResetParts: (partIds: string[]) => void;
-  onReset: () => void;
+
+  onRequestHint: (attemptGuid: string) => Promise<Hint>;
+
+  onSaveActivity: (attemptGuid: string, partResponses: PartResponse[]) => Promise<Success>;
+  onSubmitActivity: (attemptGuid: string, partResponses: PartResponse[]) => void;
+  onResetActivity: (attemptGuid: string) => void;
+
+  onSavePart: (attemptGuid: string, response: StudentResponse) => Promise<Success>;
+  onSubmitPart: (attemptGuid: string, response: StudentResponse) => void;
+  onResetPart: (attemptGuid: string) => void;
 
   constructor() {
     super();
     this.mountPoint = document.createElement('div');
     this.connected = false;
 
-    this.onRequestHint = (partIds: string[]) => this.dispatch('onRequestHint', partIds);
-    this.onSave = (partResponses: PartResponse[]) => this.dispatch('onSave', partResponses);
-    this.onSubmit = (partResponses: PartResponse[]) => this.dispatch('onSubmit', partResponses);
-    this.onResetParts = (partIds: string[]) => this.dispatch('onResetParts', partIds);
-    this.onReset = () => this.dispatch('onReset');
+    this.onRequestHint = (attemptGuid: string) => this.dispatch('requestHint', attemptGuid);
+
+    this.onSaveActivity = (attemptGuid: string, partResponses: PartResponse[]) =>
+      this.dispatch('saveActivity', attemptGuid, partResponses);
+    this.onSubmitActivity = (attemptGuid: string, partResponses: PartResponse[]) =>
+      this.dispatch('submitActivity', attemptGuid, partResponses);
+    this.onResetActivity = (attemptGuid: string) => this.dispatch('resetActivity', attemptGuid);
+
+    this.onSavePart = (attemptGuid: string, response: StudentResponse) =>
+      this.dispatch('savePart', attemptGuid, response);
+    this.onSubmitPart = (attemptGuid: string, response: StudentResponse) =>
+      this.dispatch('submitPart', attemptGuid, response);
+    this.onResetPart = (attemptGuid: string) => this.dispatch('resetPart', attemptGuid);
   }
 
-  dispatch(name: string, payload?: any) : Promise<any> {
+  dispatch(name: string, attemptGuid: string, payload?: any) : Promise<any> {
     return new Promise((resolve, reject) => {
       const continuation = (result : any, error : any) => {
         if (error !== undefined) {
@@ -52,7 +67,7 @@ export abstract class DeliveryElement<T extends ActivityModelSchema> extends HTM
         }
         resolve(result);
       };
-      this.dispatchEvent(new CustomEvent(name, this.details(continuation, payload)));
+      this.dispatchEvent(new CustomEvent(name, this.details(continuation, attemptGuid, payload)));
     });
   }
 
@@ -65,19 +80,21 @@ export abstract class DeliveryElement<T extends ActivityModelSchema> extends HTM
       model,
       state,
       onRequestHint: this.onRequestHint,
-      onSave: this.onSave,
-      onSubmit: this.onSubmit,
-      onResetParts: this.onResetParts,
-      onReset: this.onReset,
+      onSavePart: this.onSavePart,
+      onSubmitPart: this.onSubmitPart,
+      onResetPart: this.onResetPart,
+      onSaveActivity: this.onSaveActivity,
+      onSubmitActivity: this.onSubmitActivity,
+      onResetActivity: this.onResetActivity,
     };
   }
 
-  details(continuation: (result: any, error: any) => void, payload? : any) {
+  details(continuation: (result: any, error: any) => void, attemptGuid: string, payload? : any) {
     return {
       bubbles: true,
       detail: {
-        activitySlug: this.getAttribute('activitySlug'),
         payload,
+        attemptGuid,
         continuation,
       },
     };

--- a/assets/src/components/activities/DeliveryElement.ts
+++ b/assets/src/components/activities/DeliveryElement.ts
@@ -1,4 +1,4 @@
-import { ActivityModelSchema, ActivityState, StudentResponse } from './types';
+import { ActivityModelSchema, ActivityState, StudentResponse, Hint, Success } from './types';
 import { ActivitySlug } from 'data/types';
 
 
@@ -11,8 +11,8 @@ export interface DeliveryElementProps<T extends ActivityModelSchema> {
   activitySlug: ActivitySlug;
   model: T;
   state: ActivityState;
-  onRequestHint: (partIds: string[]) => void;
-  onSave: (partResponses: PartResponse[]) => void;
+  onRequestHint: (partIds: string[]) => Promise<Hint>;
+  onSave: (partResponses: PartResponse[]) => Promise<Success>;
   onSubmit: (partResponses: PartResponse[]) => void;
   onResetParts: (partIds: string[]) => void;
   onReset: () => void;
@@ -26,8 +26,8 @@ export abstract class DeliveryElement<T extends ActivityModelSchema> extends HTM
 
   mountPoint: HTMLDivElement;
   connected: boolean;
-  onRequestHint: (partIds: string[]) => void;
-  onSave: (partResponses: PartResponse[]) => void;
+  onRequestHint: (partIds: string[]) => Promise<Hint>;
+  onSave: (partResponses: PartResponse[]) => Promise<Success>;
   onSubmit: (partResponses: PartResponse[]) => void;
   onResetParts: (partIds: string[]) => void;
   onReset: () => void;
@@ -44,7 +44,7 @@ export abstract class DeliveryElement<T extends ActivityModelSchema> extends HTM
     this.onReset = () => this.dispatch('onReset');
   }
 
-  dispatch(name: string, payload?: any) {
+  dispatch(name: string, payload?: any) : Promise<any> {
     return new Promise((resolve, reject) => {
       const continuation = (result : any, error : any) => {
         if (error !== undefined) {

--- a/assets/src/components/activities/DeliveryElement.ts
+++ b/assets/src/components/activities/DeliveryElement.ts
@@ -1,9 +1,10 @@
-import { ActivityModelSchema } from './types';
+import { ActivityModelSchema, ActivityState } from './types';
 import { ActivitySlug } from 'data/types';
 
 export interface DeliveryElementProps<T extends ActivityModelSchema> {
   activitySlug: ActivitySlug;
   model: T;
+  state: ActivityState;
 }
 
 // An abstract delivery web component, designed to delegate to
@@ -24,11 +25,15 @@ export abstract class DeliveryElement<T extends ActivityModelSchema> extends HTM
   props() : DeliveryElementProps<T> {
 
     const model = JSON.parse(this.getAttribute('model') as any);
+    const state = JSON.parse(this.getAttribute('state') as any) as ActivityState;
     const activitySlug = this.getAttribute('activitySlug') as any;
+
+    console.log(state);
 
     return {
       model,
       activitySlug,
+      state,
     };
   }
 
@@ -46,5 +51,5 @@ export abstract class DeliveryElement<T extends ActivityModelSchema> extends HTM
     }
   }
 
-  static get observedAttributes() { return ['model']; }
+  static get observedAttributes() { return ['model', 'state']; }
 }

--- a/assets/src/components/activities/multiple_choice/MultipleChoiceAuthoring.tsx
+++ b/assets/src/components/activities/multiple_choice/MultipleChoiceAuthoring.tsx
@@ -32,7 +32,7 @@ const MultipleChoice = (props: AuthoringElementProps<MultipleChoiceModelSchema>)
         onEditChoice={(id, content) => dispatch(MCActions.editChoice(id, content))}
         onRemoveChoice={id => dispatch(MCActions.removeChoice(id))} />
       <Feedback {...sharedProps}
-        onEditFeedback={(id, content) => dispatch(MCActions.editFeedback(id, content))} />
+        onEditResponse={(id, content) => dispatch(MCActions.editFeedback(id, content))} />
       <Hints {...sharedProps}
         onAddHint={() => dispatch(MCActions.addHint())}
         onEditHint={(id, content) => dispatch(MCActions.editHint(id, content))}

--- a/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
+++ b/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
@@ -4,7 +4,6 @@ import { DeliveryElement, DeliveryElementProps } from '../DeliveryElement';
 import { MultipleChoiceModelSchema, Stem } from './schema';
 import { Choice } from 'components/activities/multiple_choice/schema';
 import * as ActivityTypes from '../types';
-import { shuffle } from './utils';
 import { HtmlContentModelRenderer } from 'data/content/writers/renderer';
 interface StemProps {
   stem: Stem;
@@ -92,6 +91,7 @@ const Hints = ({}: HintsProps) => {
 
 const MultipleChoice = (props: DeliveryElementProps<MultipleChoiceModelSchema>) => {
   const { stem, choices } = props.model;
+  const { state } = props;
 
   return (
     <div style={{
@@ -102,7 +102,7 @@ const MultipleChoice = (props: DeliveryElementProps<MultipleChoiceModelSchema>) 
       gridGap: '8px',
     }}>
       <Stem stem={stem} />
-      <Choices choices={shuffle(choices)} />
+      <Choices choices={choices} />
       <Hints />
     </div>
   );

--- a/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
+++ b/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
@@ -117,7 +117,8 @@ const MultipleChoice = (props: DeliveryElementProps<MultipleChoiceModelSchema>) 
     setSelected(Maybe.just<string>(id));
 
     // Auto-save our student reponse
-    props.onSave([{ attemptGuid: state.parts[0].attemptGuid, response: { input: id } }]);
+    props.onSaveActivity(state.attemptGuid,
+      [{ attemptGuid: state.parts[0].attemptGuid, response: { input: id } }]);
   };
 
   return (

--- a/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
+++ b/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
@@ -113,7 +113,11 @@ const MultipleChoice = (props: DeliveryElementProps<MultipleChoiceModelSchema>) 
     : Maybe.just<string>(state.parts[0].response.input));
 
   const onSelect = (id: string) => {
+
+    // Update local state
     setSelected(Maybe.just<string>(id));
+
+    // Auto-save our student reponse
     props.onSave([{ partId: '1', response: { input: id } }]);
   };
 

--- a/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
+++ b/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
@@ -6,7 +6,6 @@ import { Choice } from 'components/activities/multiple_choice/schema';
 import * as ActivityTypes from '../types';
 import { HtmlContentModelRenderer } from 'data/content/writers/renderer';
 import { Maybe } from 'tsmonad';
-import { processUpdate } from 'components/resource/undo';
 
 interface StemProps {
   stem: Stem;
@@ -118,7 +117,7 @@ const MultipleChoice = (props: DeliveryElementProps<MultipleChoiceModelSchema>) 
     setSelected(Maybe.just<string>(id));
 
     // Auto-save our student reponse
-    props.onSave([{ partId: '1', response: { input: id } }]);
+    props.onSave([{ attemptGuid: state.parts[0].attemptGuid, response: { input: id } }]);
   };
 
   return (

--- a/assets/src/components/activities/multiple_choice/schema.ts
+++ b/assets/src/components/activities/multiple_choice/schema.ts
@@ -1,30 +1,16 @@
 
-import { ActivityModelSchema } from '../types';
-import { ModelElement, Identifiable } from 'data/content/model';
-
-export type RichText = ModelElement[];
-
-interface HasContent {
-  content: RichText;
-}
+import { HasContent, Part, Transformation, ActivityModelSchema } from '../types';
+import { Identifiable } from 'data/content/model';
 
 export interface Stem extends HasContent {}
 export interface Choice extends Identifiable, HasContent {}
-export interface Hint extends Identifiable, HasContent {}
-export interface Feedback extends Identifiable, HasContent {
-  // `match` corresponds to Choice::id. Later, it can be used
-  // for a catch-all and non 1:1 choice:feedback mappings
-  match: string | number;
-  // `score == 1` indicates the feedback corresponds to a matching choice
-  score: number;
-}
 
 export interface MultipleChoiceModelSchema extends ActivityModelSchema {
   stem: Stem;
   choices: Choice[];
   authoring: {
-    feedback: Feedback[];
-    hints: Hint[];
+    parts: Part[];
+    transformations: Transformation[];
   };
 }
 

--- a/assets/src/components/activities/multiple_choice/sections/Choices.tsx
+++ b/assets/src/components/activities/multiple_choice/sections/Choices.tsx
@@ -1,27 +1,33 @@
 import React from 'react';
 import { Heading } from 'components/misc/Heading';
 import { RichTextEditor } from 'components/editor/RichTextEditor';
-import { ModelEditorProps, Feedback, Choice, RichText } from '../schema';
+import { ModelEditorProps, Choice } from '../schema';
+import { Response, RichText } from '../../types';
 import { Description } from 'components/misc/Description';
 import { IconCorrect } from 'components/misc/IconCorrect';
 import { CloseButton } from 'components/misc/CloseButton';
 
 interface ChoicesProps extends ModelEditorProps {
   onAddChoice: () => void;
-  onEditChoice: (id: number, content: RichText) => void;
-  onRemoveChoice: (id: number) => void;
+  onEditChoice: (id: string, content: RichText) => void;
+  onRemoveChoice: (id: string) => void;
 }
 export const Choices = ({ onAddChoice, onEditChoice, onRemoveChoice, editMode, model }:
   ChoicesProps) => {
-  const { authoring: { feedback }, choices } = model;
-  const isCorrect = (feedback: Feedback) => feedback.score === 1;
+
+  const { authoring: { parts }, choices } = model;
+  const isCorrect = (response: Response) => response.score === 1;
 
   const correctChoice = choices.reduce((correct, choice) => {
-    const feedbackMatchesChoice = (feedback: Feedback, choice: Choice) =>
-      feedback.match === choice.id;
+
+    const responseMatchesChoice = (response: Response, choice: Choice) =>
+      response.match === choice.id;
     if (correct) return correct;
-    if (feedback.find(feedback =>
-      feedbackMatchesChoice(feedback, choice) && isCorrect(feedback))) return choice;
+
+    if (parts[0].responses.find(response =>
+      responseMatchesChoice(response, choice)
+      && isCorrect(response))) return choice;
+
     throw new Error('Correct choice could not be found:' + JSON.stringify(choices));
   });
 
@@ -31,7 +37,7 @@ export const Choices = ({ onAddChoice, onEditChoice, onRemoveChoice, editMode, m
     <div style={{ margin: '2rem 0' }}>
       <Heading title="Answer Choices"
         subtitle="One correct answer choice and as many incorrect answer choices as you like." id="choices" />
-      <RichTextEditor editMode={editMode} text={correctChoice.content}
+      <RichTextEditor key="correct" editMode={editMode} text={correctChoice.content}
         onEdit={content => onEditChoice(correctChoice.id, content)}>
         <Description><IconCorrect /> Correct Answer</Description>
       </RichTextEditor>

--- a/assets/src/components/activities/multiple_choice/sections/Feedback.tsx
+++ b/assets/src/components/activities/multiple_choice/sections/Feedback.tsx
@@ -1,35 +1,38 @@
 import React from 'react';
 import { Heading } from 'components/misc/Heading';
 import { RichTextEditor } from 'components/editor/RichTextEditor';
-import { ModelEditorProps, RichText } from '../schema';
+import { ModelEditorProps } from '../schema';
+import { RichText } from '../../types';
 import { Description } from 'components/misc/Description';
 import { IconCorrect } from 'components/misc/IconCorrect';
 
 interface FeedbackProps extends ModelEditorProps {
-  onEditFeedback: (id: number, content: RichText) => void;
+  onEditResponse: (id: string, content: RichText) => void;
 }
-export const Feedback = ({ onEditFeedback, model, editMode }: FeedbackProps) => {
-  const { authoring: { feedback } } = model;
+export const Feedback = ({ onEditResponse, model, editMode }: FeedbackProps) => {
 
-  const correctFeedback = feedback.find(f => f.score === 1);
-  if (!correctFeedback) {
-    throw new Error('Correct feedback could not be found:' + JSON.stringify(feedback));
+  const { authoring: { parts } } = model;
+
+  const correctResponse = parts[0].responses.find(r => r.score === 1);
+  if (!correctResponse) {
+    throw new Error('Correct response could not be found:' + JSON.stringify(parts));
   }
-  const incorrectFeedback = feedback.filter(feedback => feedback.id !== correctFeedback.id);
+  const incorrectResponses = parts[0].responses
+    .filter(r => r.id !== correctResponse.id);
 
   return (
     <div style={{ margin: '2rem 0' }}>
       <Heading title="Answer Choice Feedback" subtitle="Providing feedback when a student answers a
         question is one of the best ways to reinforce their understanding." id="feedback" />
-      <React.Fragment key={correctFeedback.id}>
-        <RichTextEditor editMode={editMode} text={correctFeedback.content}
-          onEdit={content => onEditFeedback(correctFeedback.id, content)}>
+      <React.Fragment key={correctResponse.id}>
+        <RichTextEditor editMode={editMode} text={correctResponse.feedback.content}
+          onEdit={content => onEditResponse(correctResponse.id, content)}>
             <Description><IconCorrect /> Feedback for Correct Answer</Description>
         </RichTextEditor>
       </React.Fragment>
-      {incorrectFeedback.map((feedback, index) =>
-        <RichTextEditor key={feedback.id} editMode={editMode} text={feedback.content}
-          onEdit={content => onEditFeedback(feedback.id, content)}>
+      {incorrectResponses.map((response, index) =>
+        <RichTextEditor key={response.id} editMode={editMode} text={response.feedback.content}
+          onEdit={content => onEditResponse(response.id, content)}>
           <Description>Feedback for Common Misconception {index + 1}</Description>
         </RichTextEditor>)}
     </div>

--- a/assets/src/components/activities/multiple_choice/sections/Hints.tsx
+++ b/assets/src/components/activities/multiple_choice/sections/Hints.tsx
@@ -1,20 +1,21 @@
 import React from 'react';
 import { Heading } from 'components/misc/Heading';
 import { RichTextEditor } from 'components/editor/RichTextEditor';
-import { ModelEditorProps, RichText } from '../schema';
+import { ModelEditorProps } from '../schema';
+import { RichText } from '../../types';
 import { Description } from 'components/misc/Description';
 import { CloseButton } from 'components/misc/CloseButton';
 
 interface HintsProps extends ModelEditorProps {
   onAddHint: () => void;
-  onEditHint: (id: number, content: RichText) => void;
-  onRemoveHint: (id: number) => void;
+  onEditHint: (id: string, content: RichText) => void;
+  onRemoveHint: (id: string) => void;
 }
 export const Hints = ({ onAddHint, onEditHint, onRemoveHint, model, editMode }: HintsProps) => {
-  const { authoring: { hints } } = model;
-  const deerInHeadlightsHint = hints[0];
-  const bottomOutHint = hints[hints.length - 1];
-  const cognitiveHints = hints.slice(1, hints.length - 1);
+  const { authoring: { parts } } = model;
+  const deerInHeadlightsHint = parts[0].hints[0];
+  const bottomOutHint = parts[0].hints[parts[0].hints.length - 1];
+  const cognitiveHints = parts[0].hints.slice(1, parts[0].hints.length - 1);
 
   return (
     <div style={{ margin: '2rem 0' }}>

--- a/assets/src/components/activities/multiple_choice/sections/Stem.tsx
+++ b/assets/src/components/activities/multiple_choice/sections/Stem.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { Heading } from 'components/misc/Heading';
 import { RichTextEditor } from 'components/editor/RichTextEditor';
-import { ModelEditorProps, RichText } from '../schema';
+import { ModelEditorProps } from '../schema';
+import { RichText } from '../../types';
 
 interface StemProps extends ModelEditorProps {
   onEditStem: (stem: RichText) => void;

--- a/assets/src/components/activities/multiple_choice/utils.ts
+++ b/assets/src/components/activities/multiple_choice/utils.ts
@@ -18,7 +18,7 @@ export const defaultMCModel : () => MultipleChoiceModelSchema = () => {
     ],
     authoring: {
       parts: [{
-        id: guid(),
+        id: '1', // an MCQ only has one part, so it is safe to hardcode the id
         scoringStrategy: ScoringStrategy.average,
         evaluationStrategy: EvaluationStrategy.regex,
         responses: [

--- a/assets/src/components/activities/multiple_choice/utils.ts
+++ b/assets/src/components/activities/multiple_choice/utils.ts
@@ -1,13 +1,14 @@
 import guid from 'utils/guid';
 import * as ContentModel from 'data/content/model';
-import { RichText, Choice, MultipleChoiceModelSchema } from './schema';
+import { Choice, MultipleChoiceModelSchema } from './schema';
+import { RichText, Operation, ScoringStrategy, EvaluationStrategy } from '../types';
+
+export const makeResponse = (match: string, score: number, text: '') =>
+  ({ id: guid(), match, score, feedback: fromText(text) });
 
 export const defaultMCModel : () => MultipleChoiceModelSchema = () => {
   const choiceA: Choice = fromText('Choice A');
   const choiceB: Choice = fromText('Choice B');
-
-  const feedbackA = feedback('', choiceA.id, 1);
-  const feedbackB = feedback('', choiceB.id, 0);
 
   return {
     stem: fromText(''),
@@ -16,27 +17,35 @@ export const defaultMCModel : () => MultipleChoiceModelSchema = () => {
       choiceB,
     ],
     authoring: {
-      feedback: [
-        feedbackA,
-        feedbackB,
-      ],
-      hints: [
-        fromText(''),
-        fromText(''),
-        fromText(''),
+      parts: [{
+        id: guid(),
+        scoringStrategy: ScoringStrategy.average,
+        evaluationStrategy: EvaluationStrategy.regex,
+        responses: [
+          makeResponse(choiceA.id, 1, ''),
+          makeResponse(choiceB.id, 0, ''),
+        ],
+        hints: [
+          fromText(''),
+          fromText(''),
+          fromText(''),
+        ],
+      }],
+      transformations: [
+        { id: guid(), path: 'choices', operation: Operation.shuffle },
       ],
     },
   };
 };
 
-export function fromText(text: string): { id: number, content: RichText } {
+export function fromText(text: string): { id: string, content: RichText } {
   return {
-    id: guid(),
+    id: guid() + '',
     content: [
       ContentModel.create<ContentModel.Paragraph>({
         type: 'p',
         children: [{ text }],
-        id: guid(),
+        id: guid() + '',
       }),
     ],
   };
@@ -47,21 +56,3 @@ export const feedback = (text: string, match: string | number, score: number = 0
   match,
   score,
 });
-
-// fisher-yates algo
-export function shuffle<T>(arr: T[]): T[] {
-  // inclusive min, max
-  const randomNumber = (min: number, max: number) =>
-    Math.floor(Math.random() * (Math.floor(max) - Math.ceil(min) + 1)) + Math.ceil(min);
-
-  const swap = (arr: T[], i: number, j: number) => {
-    const temp = arr[i];
-    arr[i] = arr[j];
-    arr[j] = temp;
-  };
-
-  for (let i = arr.length - 1; i > 0; i -= 1) {
-    swap(arr, i, randomNumber(0, i));
-  }
-  return arr;
-}

--- a/assets/src/components/activities/types.ts
+++ b/assets/src/components/activities/types.ts
@@ -1,4 +1,12 @@
 import { ResourceContext } from 'data/content/resource';
+import { Identifiable, ModelElement } from 'data/content/model';
+
+export type RichText = ModelElement[];
+
+export interface HasContent {
+  content: RichText;
+}
+
 
 export type ModeSpecification = {
   element: string,
@@ -17,6 +25,67 @@ export interface ActivityModelSchema {
   authoring?: any;
 }
 
+export interface PartState {
+  attemptNumber: number;
+  dateEvaluated: Date | null;
+  score: number | null;
+  outOf: number | null;
+  response: any;
+  feedback: any;
+  hints: [];
+  partId: number;
+  hasMoreAttempts: boolean;
+  hasMoreHints: boolean;
+}
+
+export interface ActivityState {
+  attemptNumber: number;
+  dateEvaluated: Date | null;
+  score: number | null;
+  outOf: number | null;
+  parts: PartState[];
+  hasMoreAttempts: boolean;
+  hasMoreHints: boolean;
+}
+
+export interface Hint extends Identifiable, HasContent {}
+export interface Feedback extends Identifiable, HasContent {}
+export interface Transformation extends Identifiable {
+  path: string;
+  operation: Operation;
+}
+
+export interface Response extends Identifiable {
+  // `match` corresponds to Choice::id. Later, it can be used
+  // for a catch-all and non 1:1 choice:feedback mappings
+  match: string | number;
+  // `score == 1` indicates the feedback corresponds to a matching choice
+  score: number;
+
+  feedback: Feedback;
+}
+
+export interface Part extends Identifiable {
+  responses: Response[];
+  hints: Hint[];
+  scoringStrategy: ScoringStrategy;
+  evaluationStrategy: EvaluationStrategy;
+}
+
+export enum ScoringStrategy {
+  'average',
+  'best',
+  'most_recent',
+}
+
+export enum EvaluationStrategy {
+  'regex',
+  'numeric',
+}
+
+export enum Operation {
+  'shuffle',
+}
 
 export interface CreationContext extends ResourceContext {
 

--- a/assets/src/components/activities/types.ts
+++ b/assets/src/components/activities/types.ts
@@ -3,6 +3,10 @@ import { Identifiable, ModelElement } from 'data/content/model';
 
 export type RichText = ModelElement[];
 
+export interface Success {
+  type: 'success';
+}
+
 export interface HasContent {
   content: RichText;
 }

--- a/assets/src/components/activities/types.ts
+++ b/assets/src/components/activities/types.ts
@@ -7,6 +7,9 @@ export interface HasContent {
   content: RichText;
 }
 
+export interface StudentResponse {
+  input: any;
+}
 
 export type ModeSpecification = {
   element: string,
@@ -73,18 +76,18 @@ export interface Part extends Identifiable {
 }
 
 export enum ScoringStrategy {
-  'average',
-  'best',
-  'most_recent',
+  'average' = 'average',
+  'best' = 'best',
+  'most_recent' = 'most_recent',
 }
 
 export enum EvaluationStrategy {
-  'regex',
-  'numeric',
+  'regex' = 'regex',
+  'numeric' = 'numeric',
 }
 
 export enum Operation {
-  'shuffle',
+  'shuffle' = 'shuffle',
 }
 
 export interface CreationContext extends ResourceContext {

--- a/assets/src/components/activities/types.ts
+++ b/assets/src/components/activities/types.ts
@@ -33,6 +33,7 @@ export interface ActivityModelSchema {
 }
 
 export interface PartState {
+  attemptGuid: string;
   attemptNumber: number;
   dateEvaluated: Date | null;
   score: number | null;
@@ -46,6 +47,7 @@ export interface PartState {
 }
 
 export interface ActivityState {
+  attemptGuid: string;
   attemptNumber: number;
   dateEvaluated: Date | null;
   score: number | null;

--- a/assets/src/components/editor/RichTextEditor.tsx
+++ b/assets/src/components/editor/RichTextEditor.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { RichText } from 'components/activities/multiple_choice/schema';
+import { RichText } from 'components/activities/types';
 import { Editor } from 'components/editor/Editor';
 import { getToolbarForResourceType } from 'components/resource/toolbar';
 

--- a/assets/src/components/editor/editors/Lists.tsx
+++ b/assets/src/components/editor/editors/Lists.tsx
@@ -172,7 +172,7 @@ function handleTermination(editor: SlateEditor, e: KeyboardEvent) {
           Transforms.removeNodes(editor, { at: path });
 
           const p = ContentModel.create<ContentModel.Paragraph>(
-            { type: 'p', children: [{ text: '' }], id: guid() });
+            { type: 'p', children: [{ text: '' }], id: guid() + ''  });
 
           // Insert it ahead of the next node
           Transforms.insertNodes(editor, p, { at: Path.next(parentPath) });

--- a/assets/src/components/resource/Editors.tsx
+++ b/assets/src/components/resource/Editors.tsx
@@ -20,6 +20,27 @@ export type EditorsProps = {
   resourceSlug: ResourceSlug,
 };
 
+const defaultState = () => {
+  return {
+    attemptNumber: 1,
+    dateEvaluated: null,
+    score: null,
+    outOf: null,
+    hasMoreAttempts: true,
+    parts: [{
+      attemptNumber: 1,
+      dateEvaluated: null,
+      score: null,
+      outOf: null,
+      response: null,
+      feedback: null,
+      hints: [],
+      hasMoreHints: true,
+      hasMoreAttempts: true,
+      partId: '1',
+    }],
+  };
+};
 
 // The list of editors
 export const Editors = (props: EditorsProps) => {
@@ -62,6 +83,8 @@ export const Editors = (props: EditorsProps) => {
 
       props = {
         model: JSON.stringify(activity !== undefined ? activity.model : {}),
+        activitySlug: activity.activitySlug,
+        state: JSON.stringify(defaultState()),
       };
 
     } else {

--- a/assets/src/components/resource/Objectives.tsx
+++ b/assets/src/components/resource/Objectives.tsx
@@ -17,7 +17,7 @@ export const Objectives = (props: ObjectivesProps) => {
 
   // Typeahed throws a bunch of warnings if it doesn't contain
   // a unique DOM id.  So we generate one for it.
-  const [id] = useState('' + guid);
+  const [id] = useState(guid());
 
   // Typeahead options MUST contain an 'id' field.  So we add one in, using
   // our slug as its contents.

--- a/assets/src/components/resource/Outline.tsx
+++ b/assets/src/components/resource/Outline.tsx
@@ -21,7 +21,7 @@ type DragPayload = StructuredContent | ActivityPayload | UnknownPayload;
 
 interface ActivityPayload {
   type: 'ActivityPayload';
-  id: number;
+  id: string;
   activity: Activity;
   reference: ActivityReference;
   project: ProjectSlug;
@@ -29,7 +29,7 @@ interface ActivityPayload {
 
 interface UnknownPayload {
   type: 'UnknownPayload';
-  id: number;
+  id: string;
   data: any;
 }
 

--- a/assets/src/data/content/model.ts
+++ b/assets/src/data/content/model.ts
@@ -15,7 +15,7 @@ export type ModelElement
   | ListItem | Math | MathLine | Code | CodeLine | Blockquote | Hyperlink;
 
 export interface Identifiable {
-  id: number;
+  id: string;
 }
 
 export interface Paragraph extends Element, Identifiable {

--- a/assets/src/data/content/resource.ts
+++ b/assets/src/data/content/resource.ts
@@ -64,14 +64,14 @@ export const createDefaultStructuredContent = () => {
 
 export interface StructuredContent {
   type: 'content';
-  id: number;
+  id: string;
   children: ModelElement[];
   purpose: ContentPurpose;
 }
 
 export interface ActivityReference {
   type: 'activity-reference';
-  id: number;
+  id: string;
   activitySlug: ActivitySlug;
   purpose: ActivityPurpose;
   children: [];

--- a/assets/src/data/content/writers/renderer.tsx
+++ b/assets/src/data/content/writers/renderer.tsx
@@ -1,6 +1,6 @@
 import { ContentWriter } from './writer';
 import { HtmlParser } from './html';
-import { RichText } from 'components/activities/multiple_choice/schema';
+import { RichText } from 'components/activities/types';
 import { defaultWriterContext } from './context';
 
 interface Props {

--- a/assets/src/data/messages/messages.ts
+++ b/assets/src/data/messages/messages.ts
@@ -22,7 +22,7 @@ export type MessageAction = {
 };
 
 export type Message = {
-  guid: number;
+  guid: string;
   severity: Severity;
   priority: Priority;
   content: JSX.Element | string;

--- a/assets/src/utils/guid.ts
+++ b/assets/src/utils/guid.ts
@@ -20,14 +20,14 @@ const schedule = () => setTimeout(() => { fillPool(); schedule(); }, 5000);
 schedule();
 
 // Request a guid
-export default function guid() : number {
+export default function guid() : string {
 
   // If we have a guid available, take it
   if (pool.length > 0) {
     hits = hits + 1;
     // pop() is the fastest way to do get an item.
     // It is O(1) relative to the size of the array
-    return pool.pop() as any;
+    return (pool.pop() as any) + '';
   }
 
   // The pool was empty so we need to create one
@@ -35,7 +35,7 @@ export default function guid() : number {
   misses = misses + 1;
   fillPool();
 
-  return pool.pop() as any;
+  return (pool.pop() as any) + '';
 }
 
 function createSome(count: number) {

--- a/assets/test/utils/multiple_choice_test.ts
+++ b/assets/test/utils/multiple_choice_test.ts
@@ -93,7 +93,7 @@ describe('multiple choice question', () => {
     const firstChoice = model.choices[0];
     const newModel = MCReducer(model, MCActions.removeChoice(firstChoice.id));
     expect(newModel.choices).toHaveLength(1);
-    expect(newModel.authoring.parts[0].responses[0].feedback).toHaveLength(1);
+    expect(newModel.authoring.parts[0].responses).toHaveLength(1);
   });
 
   it('has the same number of responses as choices', () => {

--- a/assets/test/utils/multiple_choice_test.ts
+++ b/assets/test/utils/multiple_choice_test.ts
@@ -1,23 +1,25 @@
 import { MCActions, MCReducer } from 'components/activities/multiple_choice/reducer';
 import * as ContentModel from 'data/content/model';
 import { MultipleChoiceModelSchema, Choice } from 'components/activities/multiple_choice/schema';
+import { EvaluationStrategy, ScoringStrategy } from 'components/activities/types';
 
 function testFromText(text: string) {
   return {
-    id: Math.random(),
+    id: Math.random() + '',
     content: [
       ContentModel.create<ContentModel.Paragraph>({
         type: 'p',
         children: [{ text }],
-        id: Math.random(),
+        id: Math.random() + '',
       }),
     ],
   };
 }
 
-function testFeedback(text: string, match: string | number, score: number = 0) {
+function testResponse(text: string, match: string | number, score: number = 0) {
   return {
-    ...testFromText(text),
+    id: Math.random() + '',
+    feedback: testFromText(text),
     match,
     score,
   };
@@ -27,8 +29,8 @@ function testDefaultModel(): MultipleChoiceModelSchema {
   const choiceA: Choice = testFromText('Choice A');
   const choiceB: Choice = testFromText('Choice B');
 
-  const feedbackA = testFeedback('', choiceA.id, 1);
-  const feedbackB = testFeedback('', choiceB.id, 0);
+  const responseA = testResponse('', choiceA.id, 1);
+  const responseB = testResponse('', choiceB.id, 0);
 
   return {
     stem: testFromText(''),
@@ -37,15 +39,20 @@ function testDefaultModel(): MultipleChoiceModelSchema {
       choiceB,
     ],
     authoring: {
-      feedback: [
-        feedbackA,
-        feedbackB,
+      parts: [
+        {
+          id: Math.random() + '',
+          evaluationStrategy: EvaluationStrategy.regex,
+          scoringStrategy: ScoringStrategy.average,
+          responses: [responseA, responseB],
+          hints: [
+            testFromText(''),
+            testFromText(''),
+            testFromText(''),
+          ],
+        },
       ],
-      hints: [
-        testFromText(''),
-        testFromText(''),
-        testFromText(''),
-      ],
+      transformations: [],
     },
   };
 }
@@ -86,40 +93,42 @@ describe('multiple choice question', () => {
     const firstChoice = model.choices[0];
     const newModel = MCReducer(model, MCActions.removeChoice(firstChoice.id));
     expect(newModel.choices).toHaveLength(1);
-    expect(newModel.authoring.feedback).toHaveLength(1);
+    expect(newModel.authoring.parts[0].responses[0].feedback).toHaveLength(1);
   });
 
-  it('has the same number of feedback as choices', () => {
-    expect(model.choices.length).toEqual(model.authoring.feedback.length);
+  it('has the same number of responses as choices', () => {
+    expect(model.choices.length).toEqual(model.authoring.parts[0].responses.length);
   });
 
   it('can edit feedback', () => {
     const newFeedbackContent = testFromText('new content').content;
-    const firstFeedback = model.authoring.feedback[0];
+    const firstFeedback = model.authoring.parts[0].responses[0];
     expect(MCReducer(model, MCActions.editFeedback(firstFeedback.id, newFeedbackContent))
-      .authoring.feedback[0])
+      .authoring.parts[0].responses[0].feedback)
       .toHaveProperty('content', newFeedbackContent);
   });
 
   it('has at least 3 hints', () => {
-    expect(model.authoring.hints.length).toBeGreaterThanOrEqual(3);
+    expect(model.authoring.parts[0].hints.length).toBeGreaterThanOrEqual(3);
   });
 
   // Creating guids causes failures
   xit('can add a cognitive hint before the end of the array', () => {
-    expect(MCReducer(model, MCActions.addHint()).authoring.hints.length)
-      .toBeGreaterThan(model.authoring.hints.length);
+    expect(MCReducer(model, MCActions.addHint()).authoring.parts[0].hints.length)
+      .toBeGreaterThan(model.authoring.parts[0].hints.length);
   });
 
   it('can edit a hint', () => {
     const newHintContent = testFromText('new content').content;
-    const firstHint = model.authoring.hints[0];
-    expect(MCReducer(model, MCActions.editHint(firstHint.id, newHintContent)).authoring.hints[0])
+    const firstHint = model.authoring.parts[0].hints[0];
+    expect(MCReducer(model,
+      MCActions.editHint(firstHint.id, newHintContent)).authoring.parts[0].hints[0])
     .toHaveProperty('content', newHintContent);
   });
 
   it('can remove a hint', () => {
-    const firstHint = model.authoring.hints[0];
-    expect(MCReducer(model, MCActions.removeHint(firstHint.id)).authoring.hints).toHaveLength(2);
+    const firstHint = model.authoring.parts[0].hints[0];
+    expect(MCReducer(model,
+      MCActions.removeHint(firstHint.id)).authoring.parts[0].hints).toHaveLength(2);
   });
 });

--- a/lib/oli/activities/realizer.ex
+++ b/lib/oli/activities/realizer.ex
@@ -1,0 +1,19 @@
+defmodule Oli.Activities.Realizer do
+  @moduledoc """
+  Realizes the activity instances from activity references from
+  within a page.  This can simply involve resolving a revision, or
+  involve fulfilling a pool, or drawing activities from a bank
+  using criteria, etc.
+
+  For now it simply resolves a revision for a specific referenced
+  activity.
+  """
+
+  alias Oli.Resources.Revision
+
+  def realize(%Revision{content: %{ "model" => model}}) do
+    Enum.filter(model, fn %{"type" => type} -> type == "activity-reference" end)
+    |> Enum.map(fn %{"activity_id" => id} -> id end)
+  end
+
+end

--- a/lib/oli/activities/state.ex
+++ b/lib/oli/activities/state.ex
@@ -4,26 +4,16 @@ defmodule Oli.Activities.State do
   alias Oli.Activities.Model
 
   @doc """
-  From a map of activity ids to their resolved revisions,
-  and a map of activity ids to their latest resource and part
-  attempts, produce the corresponding activity state representation,
+  From a map of activity ids to {%ActivityAttempt, PartAttemptMap},
+  produce the corresponding activity state representation,
   returning those in a map of activity ids to the state.
   """
-  def from_attempts(activity_ids, revision_map, latest_attempts) do
+  def from_attempts(latest_attempts) do
+    Enum.map(latest_attempts, fn {id, {activity_attempt, part_attempts}} ->
+      {:ok, model} = Map.get(activity_attempt, :transformed_model) |> Model.parse()
 
-    Enum.reduce(activity_ids, %{}, fn id, m ->
-
-      {:ok, model} = Map.get(revision_map, id) |> Map.get(:content) |> Model.parse()
-
-      state = case Map.get(latest_attempts, id) do
-        {attempt, part_attempts} -> ActivityState.from_attempt(attempt, Map.values(part_attempts), model)
-        nil -> ActivityState.default_state(model)
-      end
-
-      Map.put(m, id, state)
-
-    end)
-
+      {id, ActivityState.from_attempt(activity_attempt, Map.values(part_attempts), model)}
+    end) |> Map.new
   end
 
 end

--- a/lib/oli/activities/state.ex
+++ b/lib/oli/activities/state.ex
@@ -1,0 +1,30 @@
+defmodule Oli.Activities.State do
+
+  alias Oli.Activities.State.ActivityState
+  alias Oli.Activities.Model
+
+  @doc """
+  From a map of activity ids to their resolved revisions,
+  and a map of activity ids to their latest resource and part
+  attempts, produce the corresponding activity state representation,
+  returning those in a map of activity ids to the state.
+  """
+  def from_attempts(activity_ids, revision_map, latest_attempts) do
+
+    Enum.reduce(activity_ids, %{}, fn id, m ->
+
+      {:ok, model} = Map.get(revision_map, id) |> Map.get(:content) |> Model.parse()
+
+      state = case Map.get(latest_attempts, id) do
+        {attempt, part_attempts} -> ActivityState.from_attempt(attempt, Map.values(part_attempts), model)
+        nil -> ActivityState.default_state(model)
+      end
+
+      Map.put(m, id, state)
+
+    end)
+
+  end
+
+end
+

--- a/lib/oli/activities/state/activity_state.ex
+++ b/lib/oli/activities/state/activity_state.ex
@@ -1,0 +1,69 @@
+defmodule Oli.Activities.State.ActivityState do
+
+  alias Oli.Activities.State.PartState
+  alias Oli.Delivery.Attempts.ResourceAttempt
+  alias Oli.Activities.Model
+
+  @enforce_keys [
+    :attemptNumber,
+    :dateEvaluated,
+    :score,
+    :outOf,
+    :hasMoreAttempts,
+    :parts
+  ]
+
+  @derive Jason.Encoder
+  defstruct [
+    :attemptNumber,
+    :dateEvaluated,
+    :score,
+    :outOf,
+    :hasMoreAttempts,
+    :parts
+  ]
+
+  @spec from_attempt(Oli.Delivery.Attempts.ResourceAttempt.t(), [Oli.Delivery.Attempts.PartAttempt.t()], Oli.Activities.Model.t()) ::
+          %Oli.Activities.State.ActivityState{}
+  def from_attempt(%ResourceAttempt{} = attempt, part_attempts, %Model{} = model) do
+
+    # Create the part states, and where we encounter parts from the model
+    # that do not have an attempt we create the default state
+    attempt_map = Enum.reduce(part_attempts, %{}, fn p, m -> Map.put(m, p.part_id, p) end)
+
+    parts = Enum.map(model.parts, fn part ->
+      case Map.get(attempt_map, part.id) do
+        nil -> PartState.default_state(part)
+        attempt -> PartState.from_attempt(attempt, part)
+      end
+
+    end)
+
+
+    %Oli.Activities.State.ActivityState{
+      attemptNumber: attempt.attempt_number,
+      dateEvaluated: attempt.date_evaluated,
+      score: attempt.score,
+      outOf: attempt.out_of,
+      hasMoreAttempts: true,
+      parts: parts
+    }
+
+  end
+
+  def default_state(%Model{} = model) do
+
+    %Oli.Activities.State.ActivityState{
+      attemptNumber: 1,
+      dateEvaluated: nil,
+      score: nil,
+      outOf: nil,
+      hasMoreAttempts: true,
+      parts: Enum.map(model.parts, &PartState.default_state(&1))
+    }
+
+  end
+
+end
+
+

--- a/lib/oli/activities/state/activity_state.ex
+++ b/lib/oli/activities/state/activity_state.ex
@@ -1,10 +1,11 @@
 defmodule Oli.Activities.State.ActivityState do
 
   alias Oli.Activities.State.PartState
-  alias Oli.Delivery.Attempts.ResourceAttempt
+  alias Oli.Delivery.Attempts.ActivityAttempt
   alias Oli.Activities.Model
 
   @enforce_keys [
+    :attemptGuid,
     :attemptNumber,
     :dateEvaluated,
     :score,
@@ -15,6 +16,7 @@ defmodule Oli.Activities.State.ActivityState do
 
   @derive Jason.Encoder
   defstruct [
+    :attemptGuid,
     :attemptNumber,
     :dateEvaluated,
     :score,
@@ -23,24 +25,17 @@ defmodule Oli.Activities.State.ActivityState do
     :parts
   ]
 
-  @spec from_attempt(Oli.Delivery.Attempts.ResourceAttempt.t(), [Oli.Delivery.Attempts.PartAttempt.t()], Oli.Activities.Model.t()) ::
+  @spec from_attempt(Oli.Delivery.Attempts.ActivityAttempt.t(), [Oli.Delivery.Attempts.PartAttempt.t()], Oli.Activities.Model.t()) ::
           %Oli.Activities.State.ActivityState{}
-  def from_attempt(%ResourceAttempt{} = attempt, part_attempts, %Model{} = model) do
+  def from_attempt(%ActivityAttempt{} = attempt, part_attempts, %Model{} = model) do
 
     # Create the part states, and where we encounter parts from the model
     # that do not have an attempt we create the default state
     attempt_map = Enum.reduce(part_attempts, %{}, fn p, m -> Map.put(m, p.part_id, p) end)
-
-    parts = Enum.map(model.parts, fn part ->
-      case Map.get(attempt_map, part.id) do
-        nil -> PartState.default_state(part)
-        attempt -> PartState.from_attempt(attempt, part)
-      end
-
-    end)
-
+    parts = Enum.map(model.parts, fn part -> Map.get(attempt_map, part.id) |> PartState.from_attempt(part) end)
 
     %Oli.Activities.State.ActivityState{
+      attemptGuid: attempt.attempt_guid,
       attemptNumber: attempt.attempt_number,
       dateEvaluated: attempt.date_evaluated,
       score: attempt.score,
@@ -51,18 +46,6 @@ defmodule Oli.Activities.State.ActivityState do
 
   end
 
-  def default_state(%Model{} = model) do
-
-    %Oli.Activities.State.ActivityState{
-      attemptNumber: 1,
-      dateEvaluated: nil,
-      score: nil,
-      outOf: nil,
-      hasMoreAttempts: true,
-      parts: Enum.map(model.parts, &PartState.default_state(&1))
-    }
-
-  end
 
 end
 

--- a/lib/oli/activities/state/part_state.ex
+++ b/lib/oli/activities/state/part_state.ex
@@ -4,6 +4,7 @@ defmodule Oli.Activities.State.PartState do
   alias Oli.Activities.Model.Part
 
   @enforce_keys [
+    :attemptGuid,
     :attemptNumber,
     :dateEvaluated,
     :score,
@@ -18,6 +19,7 @@ defmodule Oli.Activities.State.PartState do
 
   @derive Jason.Encoder
   defstruct [
+    :attemptGuid,
     :attemptNumber,
     :dateEvaluated,
     :score,
@@ -39,6 +41,7 @@ defmodule Oli.Activities.State.PartState do
       |> Enum.filter(fn id -> !is_nil(id) end)
 
     %Oli.Activities.State.PartState{
+      attemptGuid: attempt.attempt_guid,
       attemptNumber: attempt.attempt_number,
       dateEvaluated: attempt.date_evaluated,
       score: attempt.score,
@@ -53,20 +56,6 @@ defmodule Oli.Activities.State.PartState do
 
   end
 
-  def default_state(%Part{} = part) do
-    %Oli.Activities.State.PartState{
-      attemptNumber: 1,
-      dateEvaluated: nil,
-      score: nil,
-      outOf: nil,
-      response: nil,
-      feedback: nil,
-      hints: [],
-      hasMoreHints: length(part.hints) > 0,
-      hasMoreAttempts: true,
-      partId: part.id
-    }
-  end
 
 end
 

--- a/lib/oli/activities/state/part_state.ex
+++ b/lib/oli/activities/state/part_state.ex
@@ -1,0 +1,73 @@
+defmodule Oli.Activities.State.PartState do
+
+  alias Oli.Delivery.Attempts.PartAttempt
+  alias Oli.Activities.Model.Part
+
+  @enforce_keys [
+    :attemptNumber,
+    :dateEvaluated,
+    :score,
+    :outOf,
+    :response,
+    :feedback,
+    :hints,
+    :hasMoreHints,
+    :hasMoreAttempts,
+    :partId
+  ]
+
+  @derive Jason.Encoder
+  defstruct [
+    :attemptNumber,
+    :dateEvaluated,
+    :score,
+    :outOf,
+    :response,
+    :feedback,
+    :hints,
+    :hasMoreHints,
+    :hasMoreAttempts,
+    :partId
+  ]
+
+  def from_attempt(%PartAttempt{} = attempt, %Part{} = part) do
+
+    # From the ids of hints displayed in the attempt, look up
+    # the hint content from the part
+    hint_map = Enum.reduce(part.hints, %{}, fn h, m -> Map.put(m, h.id, h) end)
+    hints = Enum.map(attempt.hints, fn id -> Map.get(hint_map, id, nil) end)
+      |> Enum.filter(fn id -> !is_nil(id) end)
+
+    %Oli.Activities.State.PartState{
+      attemptNumber: attempt.attempt_number,
+      dateEvaluated: attempt.date_evaluated,
+      score: attempt.score,
+      outOf: attempt.out_of,
+      response: attempt.response,
+      feedback: attempt.feedback,
+      hints: hints,
+      hasMoreHints: length(attempt.hints) < length(part.hints),
+      hasMoreAttempts: true,
+      partId: attempt.part_id
+    }
+
+  end
+
+  def default_state(%Part{} = part) do
+    %Oli.Activities.State.PartState{
+      attemptNumber: 1,
+      dateEvaluated: nil,
+      score: nil,
+      outOf: nil,
+      response: nil,
+      feedback: nil,
+      hints: [],
+      hasMoreHints: length(part.hints) > 0,
+      hasMoreAttempts: true,
+      partId: part.id
+    }
+  end
+
+end
+
+

--- a/lib/oli/db_seeder.ex
+++ b/lib/oli/db_seeder.ex
@@ -272,6 +272,25 @@ defmodule Oli.Seeder do
     %{resource: resource, revision: revision}
   end
 
+  def add_activity(map, attrs, publication_tag, project_tag, author_tag, resource_tag, revision_tag) do
+
+    author = Map.get(map, author_tag)
+    project = Map.get(map, project_tag)
+    publication = Map.get(map, publication_tag)
+
+    {:ok, resource} = Oli.Resources.Resource.changeset(%Oli.Resources.Resource{}, %{}) |> Repo.insert
+
+    attrs = Map.merge(%{activity_type_id: 1, author_id: author.id, objectives: %{ "attached" => []}, resource_type_id: Oli.Resources.ResourceType.get_id_by_type("activity"), children: [], content: %{}, deleted: false, title: "test", resource_id: resource.id}, attrs)
+
+    {:ok, revision} = Oli.Resources.create_revision(attrs)
+    {:ok, _} = Oli.Authoring.Course.ProjectResource.changeset(%Oli.Authoring.Course.ProjectResource{}, %{project_id: project.id, resource_id: resource.id}) |> Repo.insert
+
+    publish_resource(publication, resource, revision)
+
+    Map.put(map, resource_tag, resource)
+    |> Map.put(revision_tag, revision)
+  end
+
   def attach_pages_to(resources, container, container_revision, publication) do
 
     children = Enum.map(resources, fn r -> r.id end)

--- a/lib/oli/db_seeder.ex
+++ b/lib/oli/db_seeder.ex
@@ -3,9 +3,14 @@ defmodule Oli.Seeder do
   alias Oli.Publishing
   alias Oli.Repo
   alias Oli.Accounts.{SystemRole, ProjectRole, Institution, Author}
+  alias Oli.Delivery.Attempts
+  alias Oli.Delivery.Attempts.{ResourceAccess}
+  alias Oli.Activities.Model.Part
   alias Oli.Authoring.Authors.{AuthorProject, ProjectRole}
   alias Oli.Authoring.Course.{Project, Family}
   alias Oli.Publishing.Publication
+  alias Oli.Accounts.LtiToolConsumer
+  alias Oli.Accounts.User
   alias Oli.Delivery.Sections.Section
 
   def base_project_with_resource2() do
@@ -45,6 +50,7 @@ defmodule Oli.Seeder do
       |> Map.put(:page2, page2)
       |> Map.put(:revision1, revision1)
       |> Map.put(:revision2, revision2)
+      |> add_lti_consumer(%{}, :lti_consumer)
 
   end
 
@@ -101,7 +107,47 @@ defmodule Oli.Seeder do
       |> Map.put(:page2, page2)
       |> Map.put(:revision1, revision1)
       |> Map.put(:revision2, revision2)
+      |> add_lti_consumer(%{}, :lti_consumer)
 
+  end
+
+  def create_resource_attempt(map, attrs, user_tag, resource_tag, revision_tag, tag \\ nil) do
+
+    user = Map.get(map, user_tag)
+    resource = Map.get(map, resource_tag)
+    revision = Map.get(map, revision_tag)
+    section = map.section
+
+    %ResourceAccess{id: id} = Attempts.track_access(resource.id, section.id, user.id)
+
+    attrs = Map.merge(attrs, %{
+      resource_access_id: id,
+      revision_id: revision.id
+    })
+
+    {:ok, attempt} = Attempts.create_resource_attempt(attrs)
+
+    case tag do
+      nil -> map
+      t -> Map.put(map, t, attempt)
+    end
+  end
+
+  def create_part_attempt(map, attrs, %Part{} = part, attempt_tag, tag \\ nil) do
+
+    resource_attempt = Map.get(map, attempt_tag)
+
+    attrs = Map.merge(attrs, %{
+      resource_attempt_id: resource_attempt.id,
+      part_id: part.id
+    })
+
+    {:ok, attempt} = Attempts.create_part_attempt(attrs)
+
+    case tag do
+      nil -> map
+      t -> Map.put(map, t, attempt)
+    end
   end
 
   defp publish_resource(publication, resource, revision) do
@@ -117,6 +163,57 @@ defmodule Oli.Seeder do
     publish_resource(publication, resource, revision)
 
     %{resource: resource, revision: revision}
+  end
+
+  def add_user(map, attrs, tag \\ nil) do
+
+    consumer = map.lti_consumer
+    institution = map.institution
+
+    params =
+      attrs
+      |> Enum.into(%{
+        email: "ironman#{System.unique_integer([:positive])}@example.com",
+        first_name: "Tony",
+        last_name: "Stark",
+        user_id: "2u9dfh7979hfd",
+        user_image: "none",
+        roles: "none",
+        lti_tool_consumer_id: consumer.id,
+        institution_id: institution.id
+      })
+
+    {:ok, user} =
+      User.changeset(%User{}, params)
+      |> Repo.insert()
+
+    case tag do
+      nil -> map
+      t -> Map.put(map, t, user)
+    end
+  end
+
+  def add_lti_consumer(map, attrs, tag \\ nil) do
+    params =
+      attrs
+      |> Enum.into(%{
+        info_product_family_code: "code",
+        info_version: "1",
+        instance_contact_email: "example@example.com",
+        instance_guid: "2u9dfh7979hfd",
+        instance_name: "none",
+        institution_id: map.institution.id,
+        author_id: map.author.id
+      })
+
+    {:ok, consumer} =
+      LtiToolConsumer.changeset(%LtiToolConsumer{}, params)
+      |> Repo.insert()
+
+    case tag do
+      nil -> map
+      t -> Map.put(map, t, consumer)
+    end
   end
 
   def add_page(map, attrs, tag \\ nil) do

--- a/lib/oli/delivery/attempts.ex
+++ b/lib/oli/delivery/attempts.ex
@@ -2,71 +2,254 @@ defmodule Oli.Delivery.Attempts do
 
   import Ecto.Query, warn: false
   alias Oli.Repo
-  alias Oli.Delivery.Sections.Section
-  alias Oli.Delivery.Attempts.{PartAttempt, ResourceAccess, ResourceAttempt}
+  alias Oli.Delivery.Sections.{Section}
+  alias Oli.Delivery.Sections
+  alias Oli.Delivery.Attempts.{PartAttempt, ResourceAccess, ResourceAttempt, ActivityAttempt}
+  alias Oli.Resources.{Revision}
+  alias Oli.Activities.Model
+
+
 
   @doc """
-  Retrieves the state of the latest attempts of a collection of activity ids in a given
-  context_id for a given user_id.
+  Determine the attempt state of this resource, that has a given set of activities
+  and activity revisions present.
 
-  Returns value is a map of activity ids to a two element tuple.  The first
-  element is the latest resource attempt and the second is a map of part ids
+  Note that this method will create attempts. If a resource attempt can be started
+  without student intervention (aka an ungraded page) attempts for the resource and all
+  activities and all parts will be created. Transformations are applied at activity attempt creation time, and stored on the
+  the activity.
+
+  If a resource attempt is in progress, returns a tuple of the form:
+
+  `{:in_progress, {%ResourceAttempt{}, ActivityAttemptMap}}`
+
+  Where `%ResourceAttempt{}` is the in progress attempt and ActivityAttemptMap is a map
+  of activity ids to tuples of activity attempts to part maps. See `get_latest_attempts`
+  for more details on this map structure.
+
+  If the attempt has not started, returns a tuple of the form:
+
+  `{:not_started, {%ResourceAccess{}, [%ResourceAttempt{}]}`
+  """
+  @spec determine_resource_attempt_state(%Revision{}, String.t, number(), any) :: {:in_progress, {%ResourceAttempt{}, %{}}} | {:not_started, {%ResourceAccess{}, [%ResourceAttempt{}]}}
+  def determine_resource_attempt_state(resource_revision, context_id, user_id, activity_provider) do
+
+    # determine latest resource attempt and then derive the current resource state
+    get_latest_resource_attempt(resource_revision.resource_id, context_id, user_id)
+    |> get_resource_state(resource_revision, context_id, user_id, activity_provider)
+
+  end
+
+
+  def get_resource_state(resource_attempt, resource_revision, context_id, user_id, activity_provider) do
+
+    case resource_revision.graded do
+      true -> get_graded_resource_state(resource_attempt, resource_revision, context_id, user_id, activity_provider)
+      false -> get_ungraded_resource_state(resource_attempt, resource_revision, context_id, user_id, activity_provider)
+    end
+
+  end
+
+  def get_ungraded_resource_state(resource_attempt, resource_revision, context_id, user_id, activity_provider) do
+
+    if is_nil(resource_attempt) or resource_attempt.revision_id != resource_revision.id do
+      {:in_progress, create_new_attempt_tree(resource_attempt, resource_revision, context_id, user_id, activity_provider)}
+    else
+      {:in_progress, {resource_attempt, get_latest_attempts(resource_attempt.id)}}
+    end
+  end
+
+  def get_graded_resource_state(resource_attempt, resource_revision, context_id, user_id, activity_provider) do
+
+    if is_nil(resource_attempt) or !is_nil(resource_attempt.date_evalulated) do
+      {:not_started, get_resource_attempt_history(resource_revision.resource_id, context_id, user_id)}
+    else
+      if resource_attempt.revision_id != resource_revision.id do
+
+        # At some point we can optimize this case to allow curernt attempts for
+        # activities within this resource attempt whose activity revisions haven't
+        # changed to be pull forward to this new resource attempt.  This would allow
+        # a use case where - live during an exam - an instructor deletes an activity. Students
+        # would need to create a new resource attempt, but their exist work could be pulled
+        # forward.
+        {:in_progress, create_new_attempt_tree(resource_attempt, resource_revision, context_id, user_id, activity_provider)}
+      else
+
+        # Bonus optimizastion at some point: look at each activity attempt, if any are
+        # for an activity revision that differs from the
+        # the current activity revision - create a new attempt
+        # for that activity. This allows a use case where an instructor live publishes
+        # during the middle of a student resource attempt a fix for one specific activity.
+
+        {:in_progress, {resource_attempt, get_latest_attempts(resource_attempt.id)}}
+      end
+    end
+
+  end
+
+  @doc """
+  Retrieves the resource access record and all (if any) attempts related to it
+  in a two element tuple of the form:
+
+  `{%ResourceAccess, [%ResourceAttempt{}]}`
+
+  The empty list `[]` will be present if there are no resource attempts.
+  """
+  def get_resource_attempt_history(resource_id, context_id, user_id) do
+
+    access = get_resource_access(resource_id, context_id, user_id)
+
+    id = access.id
+
+    attempts = Repo.all(from ra in ResourceAttempt,
+      where: ra.resource_access_id == ^id,
+      select: ra)
+
+    attempt_representation = case attempts do
+      nil -> []
+      records -> records
+    end
+
+    {access, attempt_representation}
+  end
+
+  def get_resource_access(resource_id, context_id, user_id) do
+    Repo.one(from a in ResourceAccess,
+      join: s in Section, on: a.section_id == s.id,
+      where: a.user_id == ^user_id and s.context_id == ^context_id and a.resource_id == ^resource_id,
+      select: a)
+  end
+
+  def create_new_attempt_tree(old_resource_attempt, resource_revision, context_id, user_id, activity_provider) do
+
+    {resource_access_id, next_attempt_number} = case old_resource_attempt do
+      nil -> {get_resource_access(resource_revision.resource_id, context_id, user_id).id, 1}
+      attempt -> {attempt.resource_access_id, attempt.attempt_number + 1}
+    end
+
+    activity_revisions = activity_provider.(resource_revision)
+
+    {:ok, resource_attempt} = create_resource_attempt(%{
+      attempt_guid: UUID.uuid4(),
+      resource_access_id: resource_access_id,
+      attempt_number: next_attempt_number,
+      revision_id: resource_revision.id
+    })
+
+    {resource_attempt, Enum.reduce(activity_revisions, %{}, fn %Revision{resource_id: resource_id, id: id, content: model}, m ->
+
+        {:ok, parsed_model} = Model.parse(model)
+
+        # todo, apply transformations
+        transformed_model = model
+
+        {:ok, activity_attempt} = create_activity_attempt(%{
+          resource_attempt_id: resource_attempt.id,
+          attempt_guid: UUID.uuid4(),
+          attempt_number: 1,
+          revision_id: id,
+          resource_id: resource_id,
+          transformed_model: transformed_model
+        })
+        part_attempts = create_part_attempts(parsed_model, activity_attempt)
+
+        Map.put(m, resource_id, {activity_attempt, part_attempts})
+    end)}
+
+  end
+
+  defp create_part_attempts(parsed_model, activity_attempt) do
+    Enum.reduce(parsed_model.parts, %{}, fn p, m ->
+      {:ok, part_attempt} = create_part_attempt(%{
+        attempt_guid: UUID.uuid4(),
+        activity_attempt_id: activity_attempt.id,
+        attempt_number: 1,
+        part_id: p.part_id
+      })
+      Map.put(m, p.part_id, part_attempt)
+    end)
+  end
+
+  @doc """
+  Retrieves the state of the latest attempts for a given resource attempt id.
+
+  Return value is a map of activity ids to a two element tuple.  The first
+  element is the latest activity attempt and the second is a map of part ids
   to their part attempts. As an example:
 
   %{
-    232 => {%ResourceAttempt{}, %{ 1 => %PartAttempt{}, 2 => %PartAttempt{}}}
-    233 => {%ResourceAttempt{}, %{ 1 => %PartAttempt{}, 2 => %PartAttempt{}}}
+    232 => {%ActivityAttempt{}, %{ "1" => %PartAttempt{}, "2" => %PartAttempt{}}}
+    233 => {%ActivityAttempt{}, %{ "1" => %PartAttempt{}, "2" => %PartAttempt{}}}
   }
-
-  Activity ids that do not have any resource attempts will be omitted from
-  the top-level map.  Similarly, parts that do not have any part attempts will
-  be omitted from the second-level part attempt map
-
   """
-  def get_latest_attempts(activity_ids, context_id, user_id) do
+  def get_latest_attempts(resource_attempt_id) do
 
-    results = Repo.all(from a in ResourceAccess,
-      join: s in Section, on: a.section_id == s.id,
-      join: ra1 in ResourceAttempt, on: a.id == ra1.resource_access_id,
-      left_join: ra2 in ResourceAttempt, on: (a.id == ra2.resource_access_id and ra1.id < ra2.id),
-      join: pa1 in PartAttempt, on: ra1.id == pa1.resource_attempt_id,
-      left_join: pa2 in PartAttempt, on: (ra1.id == pa2.resource_attempt_id and pa1.part_id == pa2.part_id and pa1.id < pa2.id),
-      where: a.resource_id in ^activity_ids and s.context_id == ^context_id and a.user_id == ^user_id and is_nil(ra2.id) and is_nil(pa2.id),
-      select: {pa1, a, ra1})
+    results = Repo.all(from aa1 in ActivityAttempt,
+      join: r in assoc(aa1, :revision),
+      left_join: aa2 in ActivityAttempt, on: (aa2.resource_attempt_id == ^resource_attempt_id and aa1.id < aa2.id),
+      join: pa1 in PartAttempt, on: aa1.id == pa1.activity_attempt_id,
+      left_join: pa2 in PartAttempt, on: (aa1.id == pa2.activity_attempt_id and pa1.part_id == pa2.part_id and pa1.id < pa2.id),
+      where: aa1.resource_attempt_id == ^resource_attempt_id and is_nil(aa2.id) and is_nil(pa2.id),
+      preload: [revision: r],
+      select: {pa1, aa1})
 
-    Enum.reduce(results, %{}, fn {part_attempt, access, resource_attempt}, m ->
+    Enum.reduce(results, %{}, fn {part_attempt, activity_attempt}, m ->
 
-      resource_id = access.resource_id
+      activity_id = activity_attempt.activity_id
       part_id = part_attempt.part_id
 
       # ensure we have an entry for this resource
-      m = case Map.has_key?(m, resource_id) do
+      m = case Map.has_key?(m, activity_id) do
         true -> m
-        false -> Map.put(m, resource_id, {resource_attempt, %{}})
+        false -> Map.put(m, activity_id, {activity_attempt, %{}})
       end
 
-      activity_entry = case Map.get(m, resource_id) do
+      activity_entry = case Map.get(m, activity_id) do
         {current_attempt, part_map} -> {current_attempt, Map.put(part_map, part_id, part_attempt)}
       end
 
-      Map.put(m, resource_id, activity_entry)
+      Map.put(m, activity_id, activity_entry)
     end)
 
   end
 
   @doc """
-  Creates or updates an access record for a given resource, section and user. When
+  Retrieves the latest resource attempt for a given resource id,
+  context id and user id.  If no attempts exist, returns nil.
+  """
+  def get_latest_resource_attempt(resource_id, context_id, user_id) do
+
+    Repo.one(from a in ResourceAccess,
+      join: s in Section, on: a.section_id == s.id,
+      join: ra1 in ResourceAttempt, on: a.id == ra1.resource_access_id,
+      left_join: ra2 in ResourceAttempt, on: (a.id == ra2.resource_access_id and ra1.id < ra2.id),
+      where: a.user_id == ^user_id and s.context_id == ^context_id and a.resource_id == ^resource_id,
+      select: ra1)
+
+  end
+
+  def save_student_input(context_id, user_id, part_responses) do
+
+
+  end
+
+
+  @doc """
+  Creates or updates an access record for a given resource, section context id and user. When
   created the access count is set to 1, otherwise on updates the
   access count is incremented.
   ## Examples
-      iex> track_access(resource_id, section_id, user_id, parent_id)
+      iex> track_access(resource_id, context_id, user_id)
       {:ok, %ResourceAccess{}}
-      iex> track_access(resource_id, section_id, user_id, parent_id)
+      iex> track_access(resource_id, context_id, user_id)
       {:error, %Ecto.Changeset{}}
   """
-  def track_access(resource_id, section_id, user_id, parent_id \\ nil) do
+  def track_access(resource_id, context_id, user_id) do
+
+    section = Sections.get_section_by(context_id: context_id)
+
     Oli.Repo.insert!(
-      %ResourceAccess{access_count: 1, user_id: user_id, section_id: section_id, resource_id: resource_id, parent_id: parent_id},
+      %ResourceAccess{access_count: 1, user_id: user_id, section_id: section.id, resource_id: resource_id},
       on_conflict: [inc: [access_count: 1]],
       conflict_target: [:resource_id, :user_id, :section_id]
     )
@@ -110,6 +293,33 @@ defmodule Oli.Delivery.Attempts do
   def create_resource_attempt(attrs \\ %{}) do
     %ResourceAttempt{}
     |> ResourceAttempt.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates an activity attempt.
+  ## Examples
+      iex> update_activity_attempt(revision, %{field: new_value})
+      {:ok, %ActivityAttempt{}}
+      iex> update_activity_attempt(revision, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+  """
+  def update_activity_attempt(activity_attempt, attrs) do
+    ActivityAttempt.changeset(activity_attempt, attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Creates an activity attempt.
+  ## Examples
+      iex> create_activity_attempt(%{field: value})
+      {:ok, %ActivityAttempt{}}
+      iex> create_activity_attempt(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+  """
+  def create_activity_attempt(attrs \\ %{}) do
+    %ActivityAttempt{}
+    |> ActivityAttempt.changeset(attrs)
     |> Repo.insert()
   end
 

--- a/lib/oli/delivery/attempts.ex
+++ b/lib/oli/delivery/attempts.ex
@@ -1,0 +1,114 @@
+defmodule Oli.Delivery.Attempts do
+
+  import Ecto.Query, warn: false
+  alias Oli.Repo
+  alias Oli.Delivery.Sections.Section
+  alias Oli.Delivery.Attempts.{PartAttempt, ResourceAccess, ResourceAttempt}
+
+  @doc """
+  Retrieves the state of active attempts of a collection of activity ids in a given
+  context_id for a given user_id.  Returns them as a two-level map of activity ids to
+  part state map.
+
+  """
+  def get_latest_part_attempts(activity_ids, context_id, user_id) do
+
+    results = Repo.all(from a in ResourceAccess,
+      join: s in Section, on: a.section_id == s.id,
+      join: ra1 in ResourceAttempt, on: a.id == ra1.resource_access_id,
+      left_join: ra2 in ResourceAttempt, on: (a.id == ra2.resource_access_id and ra1.id < ra2.id),
+      join: pa1 in PartAttempt, on: ra1.id == pa1.resource_attempt_id,
+      left_join: pa2 in PartAttempt, on: (ra1.id == pa2.resource_attempt_id and pa1.part_id == pa2.part_id and pa1.id < pa2.id),
+      where: a.resource_id in ^activity_ids and s.context_id == ^context_id and a.user_id == ^user_id and is_nil(ra2.id) and is_nil(pa2.id),
+      select: {pa1, a})
+
+    Enum.reduce(results, %{}, fn {attempt, a}, m ->
+
+      resource_id = a.resource_id
+      part_id = attempt.part_id
+
+      m = case Map.has_key?(m, resource_id) do
+        true -> m
+        false -> Map.put(m, resource_id, %{})
+      end
+
+      activity_entry = Map.get(m, resource_id)
+      activity_entry = Map.put(activity_entry, part_id, attempt)
+
+      Map.put(m, resource_id, activity_entry)
+    end)
+
+  end
+
+  @doc """
+  Creates or updates an access record for a given resource, section and user. When
+  created the access count is set to 1, otherwise on updates the
+  access count is incremented.
+  ## Examples
+      iex> track_access(resource_id, section_id, user_id, parent_id)
+      {:ok, %ResourceAccess{}}
+      iex> track_access(resource_id, section_id, user_id, parent_id)
+      {:error, %Ecto.Changeset{}}
+  """
+  def track_access(resource_id, section_id, user_id, parent_id \\ nil) do
+    Oli.Repo.insert!(
+      %ResourceAccess{access_count: 1, user_id: user_id, section_id: section_id, resource_id: resource_id, parent_id: parent_id},
+      on_conflict: [inc: [access_count: 1]],
+      conflict_target: [:resource_id, :user_id, :section_id]
+    )
+  end
+
+  @doc """
+  Creates a part attempt.
+  ## Examples
+      iex> create_part_attempt(%{field: value})
+      {:ok, %PartAttempt{}}
+      iex> create_part_attempt(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+  """
+  def create_part_attempt(attrs \\ %{}) do
+    %PartAttempt{}
+    |> PartAttempt.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a part attempt.
+  ## Examples
+      iex> update_part_attempt(part_attempt, %{field: new_value})
+      {:ok, %PartAttempt{}}
+      iex> update_part_attempt(part_attempt, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+  """
+  def update_part_attempt(part_attempt, attrs) do
+    PartAttempt.changeset(part_attempt, attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Creates a resource attempt.
+  ## Examples
+      iex> create_resource_attempt(%{field: value})
+      {:ok, %ResourceAttempt{}}
+      iex> create_resource_attempt(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+  """
+  def create_resource_attempt(attrs \\ %{}) do
+    %ResourceAttempt{}
+    |> ResourceAttempt.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a resource attempt.
+  ## Examples
+      iex> update_resource_attempt(revision, %{field: new_value})
+      {:ok, %ResourceAttempt{}}
+      iex> update_resource_attempt(revision, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+  """
+  def update_resource_attempt(resource_attempt, attrs) do
+    ResourceAttempt.changeset(resource_attempt, attrs)
+    |> Repo.update()
+  end
+end

--- a/lib/oli/delivery/attempts/activity_attempt.ex
+++ b/lib/oli/delivery/attempts/activity_attempt.ex
@@ -1,0 +1,28 @@
+defmodule Oli.Delivery.Attempts.ActivityAttempt do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "activity_attempts" do
+
+    field :attempt_guid, :string
+    field :attempt_number, :integer
+    field :date_evaluated, :utc_datetime
+    field :score, :decimal
+    field :out_of, :decimal
+    field :transformed_model, :map
+
+    belongs_to :resource, Oli.Resources.Resource
+    belongs_to :revision, Oli.Resources.Revision
+    belongs_to :resource_attempt, Oli.Delivery.Attempts.ResourceAttempt
+    has_many :part_attempts, Oli.Delivery.Attempts.PartAttempt
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  def changeset(score, attrs) do
+    score
+    |> cast(attrs, [:attempt_guid, :attempt_number, :score, :out_of, :date_evaluated, :transformed_model, :resource_attempt_id, :resource_id, :revision_id])
+    |> validate_required([:attempt_guid, :attempt_number, :transformed_model, :resource_attempt_id, :resource_id, :revision_id])
+  end
+end

--- a/lib/oli/delivery/attempts/part_attempt.ex
+++ b/lib/oli/delivery/attempts/part_attempt.ex
@@ -10,8 +10,8 @@ defmodule Oli.Delivery.Attempts.PartAttempt do
     field :out_of, :decimal
     field :response, :map
     field :feedback, :map
-    field :hints, {:array, :id}, default: []
-    field :part_id, :id
+    field :hints, {:array, :string}, default: []
+    field :part_id, :string
 
     belongs_to :resource_attempt, Oli.Delivery.Attempts.ResourceAttempt
 

--- a/lib/oli/delivery/attempts/part_attempt.ex
+++ b/lib/oli/delivery/attempts/part_attempt.ex
@@ -4,6 +4,7 @@ defmodule Oli.Delivery.Attempts.PartAttempt do
 
   schema "part_attempts" do
 
+    field :attempt_guid, :string
     field :attempt_number, :integer
     field :date_evaluated, :utc_datetime
     field :score, :decimal
@@ -13,7 +14,7 @@ defmodule Oli.Delivery.Attempts.PartAttempt do
     field :hints, {:array, :string}, default: []
     field :part_id, :string
 
-    belongs_to :resource_attempt, Oli.Delivery.Attempts.ResourceAttempt
+    belongs_to :activity_attempt, Oli.Delivery.Attempts.ActivityAttempt
 
     timestamps(type: :utc_datetime)
   end
@@ -21,7 +22,7 @@ defmodule Oli.Delivery.Attempts.PartAttempt do
   @doc false
   def changeset(score, attrs) do
     score
-    |> cast(attrs, [:attempt_number, :date_evaluated, :score, :out_of, :response, :feedback, :hints, :part_id, :resource_attempt_id])
-    |> validate_required([:attempt_number, :part_id, :resource_attempt_id])
+    |> cast(attrs, [:attempt_guid, :attempt_number, :date_evaluated, :score, :out_of, :response, :feedback, :hints, :part_id, :activity_attempt_id])
+    |> validate_required([:attempt_guid, :attempt_number, :part_id, :activity_attempt_id])
   end
 end

--- a/lib/oli/delivery/attempts/resource_access.ex
+++ b/lib/oli/delivery/attempts/resource_access.ex
@@ -22,5 +22,7 @@ defmodule Oli.Delivery.Attempts.ResourceAccess do
     score
     |> cast(attrs, [:access_count, :score, :out_of, :user_id, :parent_id, :section_id, :resource_id])
     |> validate_required([:access_count, :user_id, :parent_id, :section_id, :resource_id])
+    |> unique_constraint(:entry, name: :resource_accesses_unique_index)
+
   end
 end

--- a/lib/oli/delivery/attempts/resource_access.ex
+++ b/lib/oli/delivery/attempts/resource_access.ex
@@ -9,7 +9,6 @@ defmodule Oli.Delivery.Attempts.ResourceAccess do
     field :out_of, :decimal
 
     belongs_to :user, Oli.Accounts.User
-    belongs_to :parent, Oli.Delivery.Attempts.ResourceAccess
     belongs_to :section, Oli.Delivery.Sections.Section
     belongs_to :resource, Oli.Resources.Resource
     has_many :resource_attempts, Oli.Delivery.Attempts.ResourceAttempt
@@ -20,8 +19,8 @@ defmodule Oli.Delivery.Attempts.ResourceAccess do
   @doc false
   def changeset(score, attrs) do
     score
-    |> cast(attrs, [:access_count, :score, :out_of, :user_id, :parent_id, :section_id, :resource_id])
-    |> validate_required([:access_count, :user_id, :parent_id, :section_id, :resource_id])
+    |> cast(attrs, [:access_count, :score, :out_of, :user_id, :section_id, :resource_id])
+    |> validate_required([:access_count, :user_id, :section_id, :resource_id])
     |> unique_constraint(:entry, name: :resource_accesses_unique_index)
 
   end

--- a/lib/oli/delivery/attempts/resource_attempt.ex
+++ b/lib/oli/delivery/attempts/resource_attempt.ex
@@ -4,6 +4,7 @@ defmodule Oli.Delivery.Attempts.ResourceAttempt do
 
   schema "resource_attempts" do
 
+    field :attempt_guid, :string
     field :attempt_number, :integer
     field :date_evaluated, :utc_datetime
     field :score, :decimal
@@ -11,7 +12,7 @@ defmodule Oli.Delivery.Attempts.ResourceAttempt do
 
     belongs_to :resource_access, Oli.Delivery.Attempts.ResourceAccess
     belongs_to :revision, Oli.Resources.Revision
-    has_many :part_attempts, Oli.Delivery.Attempts.PartAttempt
+    has_many :activity_attempts, Oli.Delivery.Attempts.ActivityAttempt
 
     timestamps(type: :utc_datetime)
   end
@@ -19,7 +20,7 @@ defmodule Oli.Delivery.Attempts.ResourceAttempt do
   @doc false
   def changeset(score, attrs) do
     score
-    |> cast(attrs, [:attempt_number, :score, :out_of, :date_evaluated, :resource_access_id, :revision_id])
-    |> validate_required([:attempt_number, :resource_access_id, :revision_id])
+    |> cast(attrs, [:attempt_guid, :attempt_number, :score, :out_of, :date_evaluated, :resource_access_id, :revision_id])
+    |> validate_required([:attempt_guid, :attempt_number, :resource_access_id, :revision_id])
   end
 end

--- a/lib/oli/delivery/attempts/snapshot.ex
+++ b/lib/oli/delivery/attempts/snapshot.ex
@@ -9,7 +9,7 @@ defmodule Oli.Delivery.Attempts.Snapshot do
     # The page, activity and part that this snapshot pertains to
     belongs_to :resource, Oli.Resources.Resource
     belongs_to :activity, Oli.Resources.Resource
-    field :part_id, :integer
+    field :part_id, :string
 
     # Which user and section
     belongs_to :user, Oli.Accounts.User

--- a/lib/oli/delivery/evaluation.ex
+++ b/lib/oli/delivery/evaluation.ex
@@ -9,6 +9,7 @@ defmodule Oli.Delivery.Evaluation  do
 
   @spec parse_strategy(String.t) :: {:ok, :regex | :numeric} | {:error, :invalid}
   def parse_strategy(strategy) do
+
     if Map.has_key?(@eval_strategies_from_string, strategy) do
       {:ok, Map.get(@eval_strategies_from_string, strategy)}
     else

--- a/lib/oli/delivery/page/activity_context.ex
+++ b/lib/oli/delivery/page/activity_context.ex
@@ -8,12 +8,12 @@ defmodule Oli.Delivery.Page.ActivityContext do
   alias Phoenix.HTML
 
   @doc """
-  Creates a mapping of activity id to an `%ActivityContext` struct, based
+  Creates a mapping of activity id to an `%ActivitySummary` struct, based
   off of the supplied list of activity ids and a map of resource ids to
   resolved revisions.
   """
-  @spec create_context_map([number], %{}, []) :: %{}
-  def create_context_map(activity_ids, revisions, registrations) do
+  @spec create_context_map([number], %{}, [], %{}) :: %{}
+  def create_context_map(activity_ids, revisions, registrations, active_attempt_states) do
 
     reg_map = Enum.reduce(registrations, %{}, fn r, m -> Map.put(m, r.id, r) end)
 
@@ -26,7 +26,7 @@ defmodule Oli.Delivery.Page.ActivityContext do
         id: id,
         slug: Map.get(revisions, id) |> Map.get(:slug),
         model: Map.get(revisions, id) |> prepare_model(),
-        state: prepare_state(%{"active" => true}),
+        state: Map.get(active_attempt_states, id, %{}) |> prepare_state(),
         delivery_element: type.delivery_element,
         script: type.delivery_script
       })

--- a/lib/oli/delivery/page/activity_context.ex
+++ b/lib/oli/delivery/page/activity_context.ex
@@ -17,10 +17,6 @@ defmodule Oli.Delivery.Page.ActivityContext do
   resolved revisions.
   """
   @spec create_context_map(%{}) :: %{}
-  def create_context_map(%{}) do
-    %{}
-  end
-
   def create_context_map(latest_attempts) do
 
     # get a view of all current registered activity types

--- a/lib/oli/delivery/page/activity_context.ex
+++ b/lib/oli/delivery/page/activity_context.ex
@@ -5,6 +5,7 @@ defmodule Oli.Delivery.Page.ActivityContext do
 
   alias Oli.Delivery.Page.ModelPruner
   alias Oli.Rendering.Activity.ActivitySummary
+  alias Oli.Activities.State
   alias Phoenix.HTML
 
   @doc """
@@ -13,9 +14,11 @@ defmodule Oli.Delivery.Page.ActivityContext do
   resolved revisions.
   """
   @spec create_context_map([number], %{}, [], %{}) :: %{}
-  def create_context_map(activity_ids, revisions, registrations, active_attempt_states) do
+  def create_context_map(activity_ids, revisions, registrations, latest_attempts) do
 
     reg_map = Enum.reduce(registrations, %{}, fn r, m -> Map.put(m, r.id, r) end)
+
+    activity_states = State.from_attempts(activity_ids, revisions, latest_attempts)
 
     Enum.reduce(activity_ids, %{}, fn id, m ->
 
@@ -26,7 +29,7 @@ defmodule Oli.Delivery.Page.ActivityContext do
         id: id,
         slug: Map.get(revisions, id) |> Map.get(:slug),
         model: Map.get(revisions, id) |> prepare_model(),
-        state: Map.get(active_attempt_states, id, %{}) |> prepare_state(),
+        state: Map.get(activity_states, id) |> prepare_state(),
         delivery_element: type.delivery_element,
         script: type.delivery_script
       })
@@ -51,6 +54,5 @@ defmodule Oli.Delivery.Page.ActivityContext do
     {:safe, encoded} = HTML.html_escape(s)
     IO.iodata_to_binary(encoded)
   end
-
 
 end

--- a/lib/oli/delivery/page/page_context.ex
+++ b/lib/oli/delivery/page/page_context.ex
@@ -55,8 +55,10 @@ defmodule Oli.Delivery.Page.PageContext do
     revisions = DeliveryResolver.from_resource_id(context_id, all_resources)
     |> Enum.reduce(%{}, fn r, m -> Map.put(m, r.resource_id, r) end)
 
+    # _active_attempt_states = retrieve_attempt_states(activity_ids, context_id, user_id)
+
     # create a mapping specifically for the activities
-    activities = ActivityContext.create_context_map(activity_ids, revisions, registrations)
+    activities = ActivityContext.create_context_map(activity_ids, revisions, registrations, %{})
 
     # create a mapping specifically for the objectives
     objectives = get_objective_titles(objective_ids, revisions)

--- a/lib/oli/delivery/page/page_context.ex
+++ b/lib/oli/delivery/page/page_context.ex
@@ -34,6 +34,7 @@ defmodule Oli.Delivery.Page.PageContext do
     # track access to this resource
     Attempts.track_access(page_revision.resource_id, context_id, user_id)
 
+    # this realizes and resolves activities that may be present in the page
     activity_provider = fn revision ->
       case Realizer.realize(revision) do
         [] -> []

--- a/lib/oli/delivery/page/page_context.ex
+++ b/lib/oli/delivery/page/page_context.ex
@@ -4,14 +4,14 @@ defmodule Oli.Delivery.Page.PageContext do
   Defines the context required to render a page in delivery mode.
   """
 
-  @enforce_keys [:page, :activities, :objectives, :previous_page, :next_page]
-  defstruct [:page, :activities, :objectives, :previous_page, :next_page]
+  @enforce_keys [:page, :progress_state, :activities, :objectives, :previous_page, :next_page]
+  defstruct [:page, :progress_state, :activities, :objectives, :previous_page, :next_page]
 
   alias Oli.Delivery.Page.ActivityContext
   alias Oli.Delivery.Page.PageContext
   alias Oli.Resources.Revision
   alias Oli.Publishing.DeliveryResolver
-  alias Oli.Activities
+  alias Oli.Activities.Realizer
   alias Oli.Delivery.Attempts
 
   @doc """
@@ -28,11 +28,42 @@ defmodule Oli.Delivery.Page.PageContext do
   @spec create_page_context(String.t, String.t, any) :: %PageContext{}
   def create_page_context(context_id, page_slug, user_id, container_id \\ nil) do
 
-    # get a view of all current registered activity types
-    registrations = Activities.list_activity_registrations()
-
     # resolve the page revision per context_id
     page_revision = DeliveryResolver.from_revision_slug(context_id, page_slug)
+
+    # track access to this resource
+    Attempts.track_access(page_revision.resource_id, context_id, user_id)
+
+    activity_provider = fn revision ->
+      case Realizer.realize(revision) do
+        [] -> []
+        ids -> DeliveryResolver.from_resource_id(context_id, ids)
+      end
+    end
+
+    {progress_state, activities} = case Attempts.determine_resource_attempt_state(page_revision, context_id, user_id, activity_provider) do
+      {:in_progress, {_, latest_attempts}} -> {:in_progress, ActivityContext.create_context_map(latest_attempts)}
+      {:not_started, _} -> {:not_started, nil}
+    end
+
+    {objectives, previous, next} =
+      retrieve_objectives_previous_next(context_id, page_revision, container_id)
+
+    %PageContext{
+      page: page_revision,
+      progress_state: progress_state,
+      activities: activities,
+      objectives: objectives,
+      previous_page: previous,
+      next_page: next
+    }
+  end
+
+  # We combine retrieve objective titles and previous next page
+  # information in one step so that we can do all their revision
+  # resolution in one step.
+  defp retrieve_objectives_previous_next(context_id,
+    %Revision{objectives: %{"attached" => objective_ids}} = page_revision, container_id) do
 
     # if container_id is nil we assume it is the root
     container = case container_id do
@@ -40,41 +71,24 @@ defmodule Oli.Delivery.Page.PageContext do
       id -> DeliveryResolver.from_resource_id(context_id, id)
     end
 
-    # determine previous and next pages, if any
-    previous_next = get_previous_next(container, page_revision.resource_id)
-
-    # collect all the objectives and activities
-    {objective_ids, activity_ids} = get_referenced_resources(page_revision)
+    previous_next = determine_previous_next(container, page_revision.resource_id)
 
     # resolve all of these references, all at once, storing
     # them in a map based on their resource_id as the key
-    all_resources =
-      objective_ids ++
-      activity_ids ++
-      Enum.filter(previous_next, fn a -> a != nil end)
+    all_resources = objective_ids ++ Enum.filter(previous_next, fn a -> a != nil end)
 
     revisions = DeliveryResolver.from_resource_id(context_id, all_resources)
     |> Enum.reduce(%{}, fn r, m -> Map.put(m, r.resource_id, r) end)
 
-    latest_attempts = Attempts.get_latest_attempts(activity_ids, context_id, user_id)
+    objective_titles = Enum.map(objective_ids, fn id -> Map.get(revisions, id).title end)
 
-    # create a mapping specifically for the activities
-    activities = ActivityContext.create_context_map(
-      activity_ids, revisions, registrations, latest_attempts)
+    previous = Map.get(revisions, Enum.at(previous_next, 0))
+    next = Map.get(revisions, Enum.at(previous_next, 1))
 
-    # create a mapping specifically for the objectives
-    objectives = get_objective_titles(objective_ids, revisions)
-
-    %PageContext{
-      page: page_revision,
-      activities: activities,
-      objectives: objectives,
-      previous_page: Map.get(revisions, Enum.at(previous_next, 0)),
-      next_page: Map.get(revisions, Enum.at(previous_next, 1))
-    }
+    {objective_titles, previous, next}
   end
 
-  defp get_previous_next(%{children: children}, page_resource_id) do
+  defp determine_previous_next(%{children: children}, page_resource_id) do
 
     index = Enum.find_index(children, fn id -> id == page_resource_id end)
 
@@ -84,19 +98,6 @@ defmodule Oli.Delivery.Page.PageContext do
       {a, a} -> [Enum.at(children, a - 1), nil]
       {a, _} -> [Enum.at(children, a - 1), Enum.at(children, a + 1)]
     end
-  end
-
-  defp get_objective_titles(objective_ids, revisions) do
-    Enum.map(objective_ids, fn id -> Map.get(revisions, id).title end)
-  end
-
-  defp get_referenced_resources(
-    %Revision{objectives: %{"attached" => objectives}, content: %{"model" => model}}) do
-
-    activities = Enum.filter(model, fn %{"type" => type} -> type == "activity-reference" end)
-      |> Enum.map(fn %{"activity_id" => id} -> id end)
-
-    {objectives, activities}
   end
 
 end

--- a/lib/oli/delivery/page/page_context.ex
+++ b/lib/oli/delivery/page/page_context.ex
@@ -12,6 +12,7 @@ defmodule Oli.Delivery.Page.PageContext do
   alias Oli.Resources.Revision
   alias Oli.Publishing.DeliveryResolver
   alias Oli.Activities
+  alias Oli.Delivery.Attempts
 
   @doc """
   Creates the page context required to render a page in delivery model, based
@@ -25,7 +26,7 @@ defmodule Oli.Delivery.Page.PageContext do
   to a renderer.
   """
   @spec create_page_context(String.t, String.t, any) :: %PageContext{}
-  def create_page_context(context_id, page_slug, container_id \\ nil) do
+  def create_page_context(context_id, page_slug, user_id, container_id \\ nil) do
 
     # get a view of all current registered activity types
     registrations = Activities.list_activity_registrations()
@@ -55,10 +56,11 @@ defmodule Oli.Delivery.Page.PageContext do
     revisions = DeliveryResolver.from_resource_id(context_id, all_resources)
     |> Enum.reduce(%{}, fn r, m -> Map.put(m, r.resource_id, r) end)
 
-    # _active_attempt_states = retrieve_attempt_states(activity_ids, context_id, user_id)
+    latest_attempts = Attempts.get_latest_attempts(activity_ids, context_id, user_id)
 
     # create a mapping specifically for the activities
-    activities = ActivityContext.create_context_map(activity_ids, revisions, registrations, %{})
+    activities = ActivityContext.create_context_map(
+      activity_ids, revisions, registrations, latest_attempts)
 
     # create a mapping specifically for the objectives
     objectives = get_objective_titles(objective_ids, revisions)

--- a/lib/oli/publishing/delivery_resolver.ex
+++ b/lib/oli/publishing/delivery_resolver.ex
@@ -52,6 +52,7 @@ defmodule Oli.Publishing.DeliveryResolver do
         join: rev2 in Revision, on: m.revision_id == rev2.id,
         join: s in Section, on: s.publication_id == m.publication_id,
         where: rev.slug == ^revision_slug and s.context_id == ^context_id,
+        limit: 1,
         select: rev2)
     end
     |> run() |> emit([:oli, :resolvers, :delivery], :duration)

--- a/lib/oli/rendering/activity/activity_summary.ex
+++ b/lib/oli/rendering/activity/activity_summary.ex
@@ -7,7 +7,6 @@ defmodule Oli.Rendering.Activity.ActivitySummary do
 
   @enforce_keys [
     :id,
-    :slug,
     :script,
     :state,
     :model,
@@ -15,7 +14,6 @@ defmodule Oli.Rendering.Activity.ActivitySummary do
   ]
   defstruct [
     :id,                # id of the activity
-    :slug,              # slug of the activity revision
     :script,            # path to the script
     :state,             # already encoded json of the state of the attempt
     :model,             # already encoded json of the model of the activity

--- a/lib/oli/rendering/activity/html.ex
+++ b/lib/oli/rendering/activity/html.ex
@@ -26,8 +26,9 @@ defmodule Oli.Rendering.Activity.Html do
       _ ->
         tag = activity_summary.delivery_element
         slug = activity_summary.slug
+        state = activity_summary.state
         model_json = activity_summary.model
-        activity_html = ["<#{tag} class=\"activity\" activitySlug=\"#{slug}\" model=\"#{model_json}\"></#{tag}>\n"]
+        activity_html = ["<#{tag} class=\"activity\" state=\"#{state}\" activitySlug=\"#{slug}\" model=\"#{model_json}\"></#{tag}>\n"]
 
         case purpose do
           "None" ->

--- a/lib/oli/rendering/activity/html.ex
+++ b/lib/oli/rendering/activity/html.ex
@@ -25,10 +25,9 @@ defmodule Oli.Rendering.Activity.Html do
         end
       _ ->
         tag = activity_summary.delivery_element
-        slug = activity_summary.slug
         state = activity_summary.state
         model_json = activity_summary.model
-        activity_html = ["<#{tag} class=\"activity\" state=\"#{state}\" activitySlug=\"#{slug}\" model=\"#{model_json}\"></#{tag}>\n"]
+        activity_html = ["<#{tag} class=\"activity\" state=\"#{state}\" model=\"#{model_json}\"></#{tag}>\n"]
 
         case purpose do
           "None" ->

--- a/lib/oli_web/controllers/attempt_controller.ex
+++ b/lib/oli_web/controllers/attempt_controller.ex
@@ -1,12 +1,9 @@
 defmodule OliWeb.AttemptController do
   use OliWeb, :controller
 
-  def save(conn, %{"contextId" => context_id, "resourceSlug" => resource_slug, "activitySlug" => activity_slug, "payload" => payload}) do
+  def save(conn, %{"payload" => payload}) do
 
     IO.inspect payload
-    IO.inspect context_id
-    IO.inspect resource_slug
-    IO.inspect activity_slug
 
     json conn, %{ "type" => "success"}
   end

--- a/lib/oli_web/controllers/attempt_controller.ex
+++ b/lib/oli_web/controllers/attempt_controller.ex
@@ -1,0 +1,15 @@
+defmodule OliWeb.AttemptController do
+  use OliWeb, :controller
+
+  def save(conn, %{"contextId" => context_id, "resourceSlug" => resource_slug, "activitySlug" => activity_slug, "payload" => payload}) do
+
+    # user_id = conn.assigns[:current_user_id]
+    IO.inspect payload
+    IO.inspect context_id
+    IO.inspect resource_slug
+    IO.inspect activity_slug
+
+    json conn, %{ "type" => "success"}
+  end
+
+end

--- a/lib/oli_web/controllers/attempt_controller.ex
+++ b/lib/oli_web/controllers/attempt_controller.ex
@@ -1,11 +1,53 @@
 defmodule OliWeb.AttemptController do
   use OliWeb, :controller
 
-  def save(conn, %{"payload" => payload}) do
+  alias Oli.Delivery.Attempts
 
-    IO.inspect payload
+  def save_part(conn, %{"attempt_guid" => attempt_guid, "response" => response}) do
+
+    case Attempts.save_student_input([%{attempt_guid: attempt_guid, response: response}]) do
+      {:ok, _} -> json conn, %{ "type" => "success"}
+      {:error, _} -> json conn, %{ "type" => "failure"}
+    end
+
+  end
+
+  def submit_part(conn, %{"attempt_guid" => _attempt_guid, "input" => _input}) do
 
     json conn, %{ "type" => "success"}
   end
+
+  def new_part(conn, %{"attempt_guid" => _attempt_guid}) do
+
+    json conn, %{ "type" => "success"}
+  end
+
+  def get_hint(conn, %{"attempt_guid" => _attempt_guid}) do
+
+    json conn, %{ "type" => "success"}
+  end
+
+  def save_activity(conn, %{"attempt_guid" => _attempt_guid, "partInputs" => part_inputs}) do
+
+    parsed = Enum.map(part_inputs, fn %{"attemptGuid" => attempt_guid, "response" => response} ->
+      %{attempt_guid: attempt_guid, response: response} end)
+
+    case Attempts.save_student_input(parsed) do
+      {:ok, _} -> json conn, %{ "type" => "success"}
+      {:error, _} -> json conn, %{ "type" => "failure"}
+    end
+
+  end
+
+  def submit_activity(conn, %{"attempt_guid" => _attempt_guid, "partInputs" => _part_inputs}) do
+
+    json conn, %{ "type" => "success"}
+  end
+
+  def new_activity(conn, %{"attempt_guid" => _attempt_guid}) do
+
+    json conn, %{ "type" => "success"}
+  end
+
 
 end

--- a/lib/oli_web/controllers/attempt_controller.ex
+++ b/lib/oli_web/controllers/attempt_controller.ex
@@ -3,7 +3,6 @@ defmodule OliWeb.AttemptController do
 
   def save(conn, %{"contextId" => context_id, "resourceSlug" => resource_slug, "activitySlug" => activity_slug, "payload" => payload}) do
 
-    # user_id = conn.assigns[:current_user_id]
     IO.inspect payload
     IO.inspect context_id
     IO.inspect resource_slug

--- a/lib/oli_web/controllers/instructor_delivery_controller.ex
+++ b/lib/oli_web/controllers/instructor_delivery_controller.ex
@@ -31,7 +31,7 @@ defmodule OliWeb.InstructorDeliveryController do
     user = conn.assigns.current_user
 
     if Sections.is_enrolled_as?(user.id, context_id, SectionRoles.get_by_type("instructor")) do
-      context = PageContext.create_page_context(context_id, revision_slug)
+      context = PageContext.create_page_context(context_id, revision_slug, user.id)
 
       render_context = %Context{user: user, activity_map: context.activities}
       page_model = Map.get(context.page.content, "model")

--- a/lib/oli_web/controllers/student_delivery_controller.ex
+++ b/lib/oli_web/controllers/student_delivery_controller.ex
@@ -42,6 +42,7 @@ defmodule OliWeb.StudentDeliveryController do
 
       render(conn, "page.html", %{
         context_id: context_id,
+        revision_slug: context.page.slug,
         scripts: get_scripts(),
         previous_page: context.previous_page,
         next_page: context.next_page,

--- a/lib/oli_web/controllers/student_delivery_controller.ex
+++ b/lib/oli_web/controllers/student_delivery_controller.ex
@@ -34,7 +34,7 @@ defmodule OliWeb.StudentDeliveryController do
 
     if Sections.is_enrolled_as?(user.id, context_id, SectionRoles.get_by_type("student")) do
 
-      context = PageContext.create_page_context(context_id, revision_slug)
+      context = PageContext.create_page_context(context_id, revision_slug, user.id)
 
       render_context = %Context{user: user, activity_map: context.activities}
       page_model = Map.get(context.page.content, "model")

--- a/lib/oli_web/controllers/student_delivery_controller.ex
+++ b/lib/oli_web/controllers/student_delivery_controller.ex
@@ -42,7 +42,6 @@ defmodule OliWeb.StudentDeliveryController do
 
       render(conn, "page.html", %{
         context_id: context_id,
-        revision_slug: context.page.slug,
         scripts: get_scripts(),
         previous_page: context.previous_page,
         next_page: context.next_page,

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -20,6 +20,10 @@ defmodule OliWeb.Router do
 
   # piplien for REST api endpoint routes
   pipeline :api do
+    plug :fetch_session
+    plug :fetch_flash
+    plug :put_secure_browser_headers
+    plug Plug.Telemetry, event_prefix: [:oli, :plug]
     plug :accepts, ["json"]
   end
 
@@ -139,6 +143,17 @@ defmodule OliWeb.Router do
 
     post "/:project/lock/:resource", LockController, :acquire
     delete "/:project/lock/:resource", LockController, :release
+
+  end
+
+  scope "/api/v1/attempt", OliWeb do
+    pipe_through [:api, :protected]
+
+    # post to create a new attempt
+    # put to submit a response
+    # patch to save response state
+
+    patch "/", AttemptController, :save
 
   end
 

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -153,7 +153,14 @@ defmodule OliWeb.Router do
     # put to submit a response
     # patch to save response state
 
-    patch "/", AttemptController, :save
+    post "/part/:attempt_guid", AttemptController, :new_part
+    put "/part/:attempt_guid", AttemptController, :submit_part
+    patch "/part/:attempt_guid", AttemptController, :save_part
+    get "/part/:attempt_guid/hint", AttemptController, :get_hint
+
+    post "/activity/:attempt_guid", AttemptController, :new_activity
+    put "/activity/:attempt_guid", AttemptController, :submit_activity
+    patch "/activity/:attempt_guid", AttemptController, :save_activity
 
   end
 

--- a/lib/oli_web/templates/student_delivery/page.html.eex
+++ b/lib/oli_web/templates/student_delivery/page.html.eex
@@ -23,6 +23,7 @@
       body: JSON.stringify(body),
     };
     window.fetch(url, params)
+      .then(response => response.json())
       .then(result => continuation(result))
       .catch(error => continuation(undefined, error));
   }

--- a/lib/oli_web/templates/student_delivery/page.html.eex
+++ b/lib/oli_web/templates/student_delivery/page.html.eex
@@ -7,7 +7,41 @@
 
 <%= render OliWeb.DeliveryView, "_objectives.html", objectives: @objectives %>
 
-<%= raw(@html) %>
+<div id="eventIntercept">
+  <%= raw(@html) %>
+</div>
 
 <%= render OliWeb.DeliveryView, "_previous_next_nav.html",
   conn: @conn, context_id: @context_id, previous_page: @previous_page, next_page: @next_page, linker: &OliWeb.StudentDeliveryView.page_link/3 %>
+
+<script>
+
+  function makeRequest(url, method, body, continuation) {
+    const params = {
+      method,
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify(body),
+    };
+    window.fetch(url, params)
+      .then(result => continuation(result))
+      .catch(error => continuation(undefined, error));
+  }
+
+  const div = document.getElementById('eventIntercept');
+
+  div.addEventListener('onSave', function (e) {
+
+    e.preventDefault();
+    e.stopPropagation();
+
+    const body = {
+      activitySlug: e.detail.activitySlug,
+      resourceSlug: '<%= @revision_slug %>',
+      contextId: '<%= @context_id %>',
+      payload: e.detail.payload,
+    };
+    makeRequest('/api/v1/attempt', 'PATCH', body, e.detail.continuation);
+
+  }, false);
+
+</script>

--- a/lib/oli_web/templates/student_delivery/page.html.eex
+++ b/lib/oli_web/templates/student_delivery/page.html.eex
@@ -31,18 +31,9 @@
   const div = document.getElementById('eventIntercept');
 
   div.addEventListener('onSave', function (e) {
-
     e.preventDefault();
     e.stopPropagation();
-
-    const body = {
-      activitySlug: e.detail.activitySlug,
-      resourceSlug: '<%= @revision_slug %>',
-      contextId: '<%= @context_id %>',
-      payload: e.detail.payload,
-    };
-    makeRequest('/api/v1/attempt', 'PATCH', body, e.detail.continuation);
-
+    makeRequest('/api/v1/attempt/', 'PATCH', { payload: e.detail.payload }, e.detail.continuation);
   }, false);
 
 </script>

--- a/lib/oli_web/templates/student_delivery/page.html.eex
+++ b/lib/oli_web/templates/student_delivery/page.html.eex
@@ -30,10 +30,46 @@
 
   const div = document.getElementById('eventIntercept');
 
-  div.addEventListener('onSave', function (e) {
+  div.addEventListener('saveActivity', function (e) {
     e.preventDefault();
     e.stopPropagation();
-    makeRequest('/api/v1/attempt/', 'PATCH', { payload: e.detail.payload }, e.detail.continuation);
+    makeRequest('/api/v1/attempt/activity/' + e.detail.attemptGuid, 'PATCH', { partInputs: e.detail.payload }, e.detail.continuation);
+  }, false);
+
+  div.addEventListener('submitActivity', function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+    makeRequest('/api/v1/attempt/activity/' + e.detail.attemptGuid, 'PUT', { partInputs: e.detail.payload }, e.detail.continuation);
+  }, false);
+
+  div.addEventListener('resetActivity', function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+    makeRequest('/api/v1/attempt/activity/' + e.detail.attemptGuid, 'POST', {}, e.detail.continuation);
+  }, false);
+
+  div.addEventListener('savePart', function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+    makeRequest('/api/v1/attempt/part/' + e.detail.attemptGuid, 'PATCH', { input: e.detail.payload }, e.detail.continuation);
+  }, false);
+
+  div.addEventListener('submitPart', function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+    makeRequest('/api/v1/attempt/part/' + e.detail.attemptGuid, 'PUT', { input: e.detail.payload }, e.detail.continuation);
+  }, false);
+
+  div.addEventListener('resetPart', function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+    makeRequest('/api/v1/attempt/part/' + e.detail.attemptGuid, 'POST', {}, e.detail.continuation);
+  }, false);
+
+  div.addEventListener('requestHint', function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+    makeRequest('/api/v1/attempt/part/' + e.detail.attemptGuid + '/hint', 'GET', {}, e.detail.continuation);
   }, false);
 
 </script>

--- a/priv/repo/migrations/20200310193550_init_core_schemas.exs
+++ b/priv/repo/migrations/20200310193550_init_core_schemas.exs
@@ -267,8 +267,6 @@ defmodule Oli.Repo.Migrations.InitCoreSchemas do
       add :section_id, references(:sections)
       add :resource_id, references(:resources)
 
-      add :parent_id, references(:resource_accesses)
-
     end
     create index(:resource_accesses, [:resource_id])
     create index(:resource_accesses, [:section_id])
@@ -278,6 +276,7 @@ defmodule Oli.Repo.Migrations.InitCoreSchemas do
     create table(:resource_attempts) do
       timestamps(type: :timestamptz)
 
+      add :attempt_guid, :string
       add :attempt_number, :integer
       add :date_evaluated, :utc_datetime
       add :score, :decimal
@@ -288,10 +287,33 @@ defmodule Oli.Repo.Migrations.InitCoreSchemas do
 
     end
 
+    create index(:resource_attempts, [:resource_access_id])
+    create unique_index(:resource_attempts, [:attempt_guid], name: :resource_attempt_guid_index)
+
+
+    create table(:activity_attempts) do
+      timestamps(type: :timestamptz)
+
+      add :attempt_guid, :string
+      add :attempt_number, :integer
+      add :date_evaluated, :utc_datetime
+      add :score, :decimal
+      add :out_of, :decimal
+      add :transformed_model, :map
+
+      add :resource_attempt_id, references(:resource_attempts)
+      add :revision_id, references(:revisions)
+      add :resource_id, references(:resources)
+
+    end
+
+    create unique_index(:activity_attempts, [:attempt_guid], name: :activity_attempt_guid_index)
+    create index(:activity_attempts, [:resource_attempt_id])
 
     create table(:part_attempts) do
       timestamps(type: :timestamptz)
 
+      add :attempt_guid, :string
       add :attempt_number, :integer
       add :date_evaluated, :utc_datetime
       add :score, :decimal
@@ -300,9 +322,12 @@ defmodule Oli.Repo.Migrations.InitCoreSchemas do
       add :feedback, :map
       add :hints,  {:array, :string}
       add :part_id, :string
-      add :resource_attempt_id, references(:resource_attempts)
+      add :activity_attempt_id, references(:activity_attempts)
 
     end
+
+    create index(:part_attempts, [:activity_attempt_id])
+    create unique_index(:part_attempts, [:attempt_guid], name: :attempt_guid_index)
 
   end
 end

--- a/priv/repo/migrations/20200310193550_init_core_schemas.exs
+++ b/priv/repo/migrations/20200310193550_init_core_schemas.exs
@@ -243,7 +243,7 @@ defmodule Oli.Repo.Migrations.InitCoreSchemas do
       add :activity_id, references(:resources)
       add :section_id, references(:sections)
       add :resource_id, references(:resources)
-      add :part_id, :id
+      add :part_id, :string
       add :objectives, {:array, :id}
       add :objective_revisions, {:array, :id}
       add :revision_id, references(:revisions)
@@ -298,8 +298,8 @@ defmodule Oli.Repo.Migrations.InitCoreSchemas do
       add :out_of, :decimal
       add :response, :map
       add :feedback, :map
-      add :hints,  {:array, :id}
-      add :part_id, :id
+      add :hints,  {:array, :string}
+      add :part_id, :string
       add :resource_attempt_id, references(:resource_attempts)
 
     end

--- a/priv/repo/migrations/20200310193550_init_core_schemas.exs
+++ b/priv/repo/migrations/20200310193550_init_core_schemas.exs
@@ -259,16 +259,21 @@ defmodule Oli.Repo.Migrations.InitCoreSchemas do
     create table(:resource_accesses) do
       timestamps(type: :timestamptz)
 
-      add :access_count, :integer
-      add :score, :decimal
-      add :out_of, :decimal
+      add :access_count, :integer, null: true
+      add :score, :decimal, null: true
+      add :out_of, :decimal, null: true
 
       add :user_id, references(:user)
-      add :parent_id, references(:resource_accesses)
       add :section_id, references(:sections)
       add :resource_id, references(:resources)
 
+      add :parent_id, references(:resource_accesses)
+
     end
+    create index(:resource_accesses, [:resource_id])
+    create index(:resource_accesses, [:section_id])
+    create index(:resource_accesses, [:user_id])
+    create unique_index(:resource_accesses, [:resource_id, :user_id, :section_id], name: :resource_accesses_unique_index)
 
     create table(:resource_attempts) do
       timestamps(type: :timestamptz)

--- a/test/oli/delivery/attempts_test.exs
+++ b/test/oli/delivery/attempts_test.exs
@@ -4,62 +4,140 @@ defmodule Oli.Delivery.AttemptsTest do
 
   alias Oli.Delivery.Attempts
   alias Oli.Activities.Model.Part
+  alias Oli.Publishing.DeliveryResolver
+  alias Oli.Activities.Realizer
 
-  describe "attempts context" do
+  describe "creating the attempt tree" do
+
+
+    setup do
+
+      content1 = %{
+        "stem" => "1",
+        "authoring" => %{
+          "parts" => [
+            %{"id" => "1", "responses" => [], "scoringStrategy" => "best", "evaluationStrategy" => "regex"}
+          ]
+        }
+      }
+      content2 = %{
+        "stem" => "2",
+        "authoring" => %{
+          "parts" => [
+            %{"id" => "1", "responses" => [], "scoringStrategy" => "best", "evaluationStrategy" => "regex"}
+          ]
+        }
+      }
+
+
+      map = Seeder.base_project_with_resource2()
+      |> Seeder.create_section()
+      |> Seeder.add_objective("objective one", :o1)
+      |> Seeder.add_activity(%{title: "one", content: content1}, :a1)
+      |> Seeder.add_activity(%{title: "two", content: content2}, :a2)
+      |> Seeder.add_user(%{}, :user1)
+
+      attrs = %{
+        title: "page1",
+        content: %{
+          "model" => [
+            %{"type" => "activity-reference", "activity_id" => Map.get(map, :a1).resource_id},
+            %{"type" => "activity-reference", "activity_id" => Map.get(map, :a2).resource_id}
+          ]
+        },
+        objectives: %{"attached" => [Map.get(map, :o1).resource_id]}
+      }
+
+      Seeder.add_page(map, attrs, :p1)
+
+    end
+
+    test "create the attempt tree", %{ p1: p1, user1: user, section: section, a1: a1, a2: a2} do
+
+      Attempts.track_access(p1.resource_id, section.context_id, user.id)
+
+      activity_provider = fn revision ->
+        case Realizer.realize(revision) do
+          [] -> []
+          ids -> DeliveryResolver.from_resource_id(section.context_id, ids)
+        end
+      end
+
+      # verify that creating the attempt tree returns both activity attempts
+      {resource_attempt, attempts} = Attempts.create_new_attempt_tree(nil, p1, section.context_id, user.id, activity_provider)
+      assert Map.has_key?(attempts, a1.resource_id)
+      assert Map.has_key?(attempts, a2.resource_id)
+
+      # verify that reading the latest attempts back from the db gives us
+      # the same results
+      attempts = Attempts.get_latest_attempts(resource_attempt.id)
+      assert Map.has_key?(attempts, a1.resource_id)
+      assert Map.has_key?(attempts, a2.resource_id)
+
+    end
+
+  end
+
+  describe "fetching existing attempts" do
 
     setup do
       Seeder.base_project_with_resource2()
       |> Seeder.create_section()
       |> Seeder.add_user(%{}, :user1)
       |> Seeder.add_user(%{}, :user2)
+      |> Seeder.add_activity(%{}, :publication, :project, :author, :activity_a, :revision_a)
 
       |> Seeder.create_resource_attempt(%{attempt_number: 1}, :user1, :page1, :revision1, :attempt1)
-      |> Seeder.create_part_attempt(%{attempt_number: 1}, %Part{id: "1", responses: [], hints: []}, :attempt1, :part1_attempt1)
+      |> Seeder.create_activity_attempt(%{attempt_number: 1, transformed_model: %{}}, :activity_a, :revision_a, :attempt1, :activity_attempt1)
+      |> Seeder.create_part_attempt(%{attempt_number: 1}, %Part{id: "1", responses: [], hints: []}, :activity_attempt1, :part1_attempt1)
 
       |> Seeder.create_resource_attempt(%{attempt_number: 2}, :user1, :page1, :revision1, :attempt2)
-      |> Seeder.create_part_attempt(%{attempt_number: 1}, %Part{id: "1", responses: [], hints: []}, :attempt2, :part1_attempt1)
-      |> Seeder.create_part_attempt(%{attempt_number: 2}, %Part{id: "1", responses: [], hints: []}, :attempt2, :part1_attempt2)
-      |> Seeder.create_part_attempt(%{attempt_number: 3}, %Part{id: "1", responses: [], hints: []}, :attempt2, :part1_attempt3)
-      |> Seeder.create_part_attempt(%{attempt_number: 1}, %Part{id: "2", responses: [], hints: []}, :attempt2, :part2_attempt1)
-      |> Seeder.create_part_attempt(%{attempt_number: 1}, %Part{id: "3", responses: [], hints: []}, :attempt2, :part3_attempt1)
-      |> Seeder.create_part_attempt(%{attempt_number: 2}, %Part{id: "3", responses: [], hints: []}, :attempt2, :part3_attempt2)
+      |> Seeder.create_activity_attempt(%{attempt_number: 1, transformed_model: %{}}, :activity_a, :revision_a, :attempt2, :activity_attempt2)
+      |> Seeder.create_part_attempt(%{attempt_number: 1}, %Part{id: "1", responses: [], hints: []}, :activity_attempt2, :part1_attempt1)
+      |> Seeder.create_part_attempt(%{attempt_number: 2}, %Part{id: "1", responses: [], hints: []}, :activity_attempt2, :part1_attempt2)
+      |> Seeder.create_part_attempt(%{attempt_number: 3}, %Part{id: "1", responses: [], hints: []}, :activity_attempt2, :part1_attempt3)
+      |> Seeder.create_part_attempt(%{attempt_number: 1}, %Part{id: "2", responses: [], hints: []}, :activity_attempt2, :part2_attempt1)
+      |> Seeder.create_part_attempt(%{attempt_number: 1}, %Part{id: "3", responses: [], hints: []}, :activity_attempt2, :part3_attempt1)
+      |> Seeder.create_part_attempt(%{attempt_number: 2}, %Part{id: "3", responses: [], hints: []}, :activity_attempt2, :part3_attempt2)
     end
 
     test "creating an access record", %{user1: user1, user2: user2, section: section, page1: page1} do
 
-      Attempts.track_access(page1.id, section.id, user1.id)
-      Attempts.track_access(page1.id, section.id, user1.id)
+      Attempts.track_access(page1.id, section.context_id, user1.id)
+      Attempts.track_access(page1.id, section.context_id, user1.id)
 
       entries = Oli.Repo.all(Oli.Delivery.Attempts.ResourceAccess)
       assert length(entries) == 1
       assert hd(entries).access_count == 4
 
-      Attempts.track_access(page1.id, section.id, user2.id)
+      Attempts.track_access(page1.id, section.context_id, user2.id)
       entries = Oli.Repo.all(Oli.Delivery.Attempts.ResourceAccess)
       assert length(entries) == 2
       assert hd(entries).access_count == 4
 
     end
 
-    test "fetching attempt records", %{attempt2: attempt2, user1: user1, section: section, page1: page1} do
+    test "fetching attempt records", %{attempt2: attempt2, activity_attempt2: activity_attempt2, activity_a: activity_a} do
 
-      results = Attempts.get_latest_attempts([page1.id], section.context_id, user1.id)
+      results = Attempts.get_latest_attempts(attempt2.id)
 
       assert length(Map.keys(results)) == 1
-      assert Map.has_key?(results, page1.id)
+      assert Map.has_key?(results, activity_a.id)
 
-      case results[page1.id] do
-        {^attempt2, map} -> assert map["1"].attempt_number == 3
+      id = activity_attempt2.id
+
+      case results[activity_a.id] do
+        {%{id: ^id}, map} -> assert map["1"].attempt_number == 3
         _ -> assert false
       end
 
-      case results[page1.id] do
-        {^attempt2, map} -> assert map["2"].attempt_number == 1
+      case results[activity_a.id] do
+        {%{id: ^id}, map} -> assert map["2"].attempt_number == 1
         _ -> assert false
       end
 
-      case results[page1.id] do
-        {^attempt2, map} -> assert map["3"].attempt_number == 2
+      case results[activity_a.id] do
+        {%{id: ^id}, map} -> assert map["3"].attempt_number == 2
         _ -> assert false
       end
 

--- a/test/oli/delivery/attempts_test.exs
+++ b/test/oli/delivery/attempts_test.exs
@@ -1,0 +1,58 @@
+defmodule Oli.Delivery.AttemptsTest do
+
+  use Oli.DataCase
+
+  alias Oli.Delivery.Attempts
+  alias Oli.Activities.Model.Part
+
+  describe "attempts context" do
+
+    setup do
+      Seeder.base_project_with_resource2()
+      |> Seeder.create_section()
+      |> Seeder.add_user(%{}, :user1)
+      |> Seeder.add_user(%{}, :user2)
+
+      |> Seeder.create_resource_attempt(%{attempt_number: 1}, :user1, :page1, :revision1, :attempt1)
+      |> Seeder.create_part_attempt(%{attempt_number: 1}, %Part{id: 1, responses: [], hints: []}, :attempt1, :part1_attempt1)
+
+      |> Seeder.create_resource_attempt(%{attempt_number: 2}, :user1, :page1, :revision1, :attempt2)
+      |> Seeder.create_part_attempt(%{attempt_number: 1}, %Part{id: 1, responses: [], hints: []}, :attempt2, :part1_attempt1)
+      |> Seeder.create_part_attempt(%{attempt_number: 2}, %Part{id: 1, responses: [], hints: []}, :attempt2, :part1_attempt2)
+      |> Seeder.create_part_attempt(%{attempt_number: 3}, %Part{id: 1, responses: [], hints: []}, :attempt2, :part1_attempt3)
+      |> Seeder.create_part_attempt(%{attempt_number: 1}, %Part{id: 2, responses: [], hints: []}, :attempt2, :part2_attempt1)
+      |> Seeder.create_part_attempt(%{attempt_number: 1}, %Part{id: 3, responses: [], hints: []}, :attempt2, :part3_attempt1)
+      |> Seeder.create_part_attempt(%{attempt_number: 2}, %Part{id: 3, responses: [], hints: []}, :attempt2, :part3_attempt2)
+    end
+
+    test "creating an access record", %{user1: user1, user2: user2, section: section, page1: page1} do
+
+      Attempts.track_access(page1.id, section.id, user1.id)
+      Attempts.track_access(page1.id, section.id, user1.id)
+
+      entries = Oli.Repo.all(Oli.Delivery.Attempts.ResourceAccess)
+      assert length(entries) == 1
+      assert hd(entries).access_count == 4
+
+      Attempts.track_access(page1.id, section.id, user2.id)
+      entries = Oli.Repo.all(Oli.Delivery.Attempts.ResourceAccess)
+      assert length(entries) == 2
+      assert hd(entries).access_count == 4
+
+    end
+
+    test "fetching attempt records", %{user1: user1, section: section, page1: page1} do
+
+      results = Attempts.get_latest_part_attempts([page1.id], section.context_id, user1.id)
+
+      assert length(Map.keys(results)) == 1
+      assert Map.has_key?(results, page1.id)
+
+      assert results[page1.id][1].attempt_number == 3
+      assert results[page1.id][2].attempt_number == 1
+      assert results[page1.id][3].attempt_number == 2
+    end
+
+  end
+
+end

--- a/test/oli/delivery/attempts_test.exs
+++ b/test/oli/delivery/attempts_test.exs
@@ -14,15 +14,15 @@ defmodule Oli.Delivery.AttemptsTest do
       |> Seeder.add_user(%{}, :user2)
 
       |> Seeder.create_resource_attempt(%{attempt_number: 1}, :user1, :page1, :revision1, :attempt1)
-      |> Seeder.create_part_attempt(%{attempt_number: 1}, %Part{id: 1, responses: [], hints: []}, :attempt1, :part1_attempt1)
+      |> Seeder.create_part_attempt(%{attempt_number: 1}, %Part{id: "1", responses: [], hints: []}, :attempt1, :part1_attempt1)
 
       |> Seeder.create_resource_attempt(%{attempt_number: 2}, :user1, :page1, :revision1, :attempt2)
-      |> Seeder.create_part_attempt(%{attempt_number: 1}, %Part{id: 1, responses: [], hints: []}, :attempt2, :part1_attempt1)
-      |> Seeder.create_part_attempt(%{attempt_number: 2}, %Part{id: 1, responses: [], hints: []}, :attempt2, :part1_attempt2)
-      |> Seeder.create_part_attempt(%{attempt_number: 3}, %Part{id: 1, responses: [], hints: []}, :attempt2, :part1_attempt3)
-      |> Seeder.create_part_attempt(%{attempt_number: 1}, %Part{id: 2, responses: [], hints: []}, :attempt2, :part2_attempt1)
-      |> Seeder.create_part_attempt(%{attempt_number: 1}, %Part{id: 3, responses: [], hints: []}, :attempt2, :part3_attempt1)
-      |> Seeder.create_part_attempt(%{attempt_number: 2}, %Part{id: 3, responses: [], hints: []}, :attempt2, :part3_attempt2)
+      |> Seeder.create_part_attempt(%{attempt_number: 1}, %Part{id: "1", responses: [], hints: []}, :attempt2, :part1_attempt1)
+      |> Seeder.create_part_attempt(%{attempt_number: 2}, %Part{id: "1", responses: [], hints: []}, :attempt2, :part1_attempt2)
+      |> Seeder.create_part_attempt(%{attempt_number: 3}, %Part{id: "1", responses: [], hints: []}, :attempt2, :part1_attempt3)
+      |> Seeder.create_part_attempt(%{attempt_number: 1}, %Part{id: "2", responses: [], hints: []}, :attempt2, :part2_attempt1)
+      |> Seeder.create_part_attempt(%{attempt_number: 1}, %Part{id: "3", responses: [], hints: []}, :attempt2, :part3_attempt1)
+      |> Seeder.create_part_attempt(%{attempt_number: 2}, %Part{id: "3", responses: [], hints: []}, :attempt2, :part3_attempt2)
     end
 
     test "creating an access record", %{user1: user1, user2: user2, section: section, page1: page1} do
@@ -41,16 +41,28 @@ defmodule Oli.Delivery.AttemptsTest do
 
     end
 
-    test "fetching attempt records", %{user1: user1, section: section, page1: page1} do
+    test "fetching attempt records", %{attempt2: attempt2, user1: user1, section: section, page1: page1} do
 
-      results = Attempts.get_latest_part_attempts([page1.id], section.context_id, user1.id)
+      results = Attempts.get_latest_attempts([page1.id], section.context_id, user1.id)
 
       assert length(Map.keys(results)) == 1
       assert Map.has_key?(results, page1.id)
 
-      assert results[page1.id][1].attempt_number == 3
-      assert results[page1.id][2].attempt_number == 1
-      assert results[page1.id][3].attempt_number == 2
+      case results[page1.id] do
+        {^attempt2, map} -> assert map["1"].attempt_number == 3
+        _ -> assert false
+      end
+
+      case results[page1.id] do
+        {^attempt2, map} -> assert map["2"].attempt_number == 1
+        _ -> assert false
+      end
+
+      case results[page1.id] do
+        {^attempt2, map} -> assert map["3"].attempt_number == 2
+        _ -> assert false
+      end
+
     end
 
   end

--- a/test/oli/delivery/page/activity_context_test.exs
+++ b/test/oli/delivery/page/activity_context_test.exs
@@ -4,22 +4,34 @@ defmodule Oli.Delivery.Page.ActivityContextTest do
 
   alias Oli.Delivery.Page.ActivityContext
   alias Oli.Activities
+  alias Oli.Activities.Model.Part
+  alias Oli.Delivery.Attempts
 
   describe "activity context" do
 
     setup do
-      map = Seeder.base_project_with_resource2()
 
-      %{revision: a1} = Seeder.create_activity(%{ content: %{ "stem" => "1", "authoring" => "a"}}, map.publication, map.project, map.author)
-      %{revision: a2} = Seeder.create_activity(%{ content: %{ "stem" => "2"}}, map.publication, map.project, map.author)
-      %{revision: a3} = Seeder.create_activity(%{ content: %{ "stem" => "3"}}, map.publication, map.project, map.author)
+      content = %{
+        "stem" => "1",
+        "authoring" => %{
+          "parts" => [
+            %{"id" => 1, "responses" => [], "scoringStrategy" => "best", "evaluationStrategy" => "regex"}
+          ]
+        }
+      }
 
-      Map.put(map, :a1, a1)
-      |> Map.put(:a2, a2)
-      |> Map.put(:a3, a3)
+      Seeder.base_project_with_resource2()
+      |> Seeder.create_section()
+      |> Seeder.add_user(%{}, :user1)
+      |> Seeder.add_activity(%{ content: content}, :publication, :project, :author, :resource_a, :a1)
+      |> Seeder.add_activity(%{ content: %{ "stem" => "2"}}, :publication, :project, :author, :resource_a, :a2)
+      |> Seeder.add_activity(%{ content: %{ "stem" => "3"}}, :publication, :project, :author, :resource_a, :a3)
+      |> Seeder.create_resource_attempt(%{attempt_number: 1}, :user1, :resource_a, :a1, :attempt1)
+      |> Seeder.create_part_attempt(%{attempt_number: 1}, %Part{id: "1", responses: [], hints: []}, :attempt1, :part1_attempt1)
+
     end
 
-    test "create_context_map/2 returns the activities mapped correctly", %{a1: a1, a2: a2, a3: a3} do
+    test "create_context_map/2 returns the activities mapped correctly", %{user1: user, a1: a1, a2: a2, a3: a3, section: section} do
 
       registrations = Activities.list_activity_registrations()
       resource_ids = [a1.resource_id, a2.resource_id, a3.resource_id]
@@ -28,19 +40,17 @@ defmodule Oli.Delivery.Page.ActivityContextTest do
       |> Map.put(a2.resource_id, a2)
       |> Map.put(a3.resource_id, a3)
 
-      states = Map.put(%{}, a1.resource_id, %{"active" => true})
+      attempts = Attempts.get_latest_attempts([a1.resource_id, a2.resource_id, a3.resource_id], section.context_id, user.id)
 
-      m = ActivityContext.create_context_map(resource_ids, revisions, registrations, states)
+      m = ActivityContext.create_context_map(resource_ids, revisions, registrations, attempts)
 
       assert length(Map.keys(m)) == 3
       assert Map.get(m, a1.resource_id).slug == a1.slug
       assert Map.get(m, a1.resource_id).model == "{&quot;stem&quot;:&quot;1&quot;}"
-      assert Map.get(m, a1.resource_id).state == "{&quot;active&quot;:true}"
       assert Map.get(m, a1.resource_id).delivery_element == "oli-multiple-choice-delivery"
       assert Map.get(m, a1.resource_id).script == "oli_multiple_choice_delivery.js"
-      assert Map.get(m, a2.resource_id).state == "{}"
+      assert Map.get(m, a2.resource_id).state == "{&quot;attemptNumber&quot;:1,&quot;dateEvaluated&quot;:null,&quot;hasMoreAttempts&quot;:true,&quot;outOf&quot;:null,&quot;parts&quot;:[],&quot;score&quot;:null}"
       assert Map.get(m, a2.resource_id).slug == a2.slug
-      assert Map.get(m, a3.resource_id).state == "{}"
       assert Map.get(m, a3.resource_id).slug == a3.slug
 
     end

--- a/test/oli/delivery/page/activity_context_test.exs
+++ b/test/oli/delivery/page/activity_context_test.exs
@@ -28,7 +28,9 @@ defmodule Oli.Delivery.Page.ActivityContextTest do
       |> Map.put(a2.resource_id, a2)
       |> Map.put(a3.resource_id, a3)
 
-      m = ActivityContext.create_context_map(resource_ids, revisions, registrations)
+      states = Map.put(%{}, a1.resource_id, %{"active" => true})
+
+      m = ActivityContext.create_context_map(resource_ids, revisions, registrations, states)
 
       assert length(Map.keys(m)) == 3
       assert Map.get(m, a1.resource_id).slug == a1.slug
@@ -36,7 +38,9 @@ defmodule Oli.Delivery.Page.ActivityContextTest do
       assert Map.get(m, a1.resource_id).state == "{&quot;active&quot;:true}"
       assert Map.get(m, a1.resource_id).delivery_element == "oli-multiple-choice-delivery"
       assert Map.get(m, a1.resource_id).script == "oli_multiple_choice_delivery.js"
+      assert Map.get(m, a2.resource_id).state == "{}"
       assert Map.get(m, a2.resource_id).slug == a2.slug
+      assert Map.get(m, a3.resource_id).state == "{}"
       assert Map.get(m, a3.resource_id).slug == a3.slug
 
     end

--- a/test/oli/delivery/page/page_context_test.exs
+++ b/test/oli/delivery/page/page_context_test.exs
@@ -12,6 +12,7 @@ defmodule Oli.Delivery.Page.PageContextTest do
       |> Seeder.add_objective("objective one", :o1)
       |> Seeder.add_activity(%{title: "one", content: %{"authoring" => "3"}}, :a1)
       |> Seeder.add_activity(%{title: "two", content: %{"stem" => "3"}}, :a2)
+      |> Seeder.add_user(%{}, :user1)
 
       attrs = %{
         title: "page1",
@@ -28,7 +29,7 @@ defmodule Oli.Delivery.Page.PageContextTest do
 
     end
 
-    test "create_context/2 returns the activities mapped correctly", %{section: section, p1: p1, a1: a1} = map do
+    test "create_context/2 returns the activities mapped correctly", %{section: section, p1: p1, a1: a1, user1: user} = map do
 
       page1 = Map.get(map, :page1)
       page2 = Map.get(map, :page2)
@@ -38,7 +39,7 @@ defmodule Oli.Delivery.Page.PageContextTest do
 
       Seeder.attach_pages_to([page1, %{id: p1.resource_id}, page2], container, container_revision, publication)
 
-      context = PageContext.create_page_context(section.context_id, p1.slug)
+      context = PageContext.create_page_context(section.context_id, p1.slug, user.id)
 
       # verify activities map
       assert Map.get(context.activities, a1.resource_id).slug == a1.slug
@@ -54,17 +55,17 @@ defmodule Oli.Delivery.Page.PageContextTest do
       # verify all other possible variants of prev and next:
 
       Seeder.attach_pages_to([%{id: p1.resource_id}, page2], container, container_revision, publication)
-      context = PageContext.create_page_context(section.context_id, p1.slug)
+      context = PageContext.create_page_context(section.context_id, p1.slug, user.id)
       assert context.previous_page == nil
       assert context.next_page.resource_id == page2.id
 
       Seeder.attach_pages_to([page2, %{id: p1.resource_id}], container, container_revision, publication)
-      context = PageContext.create_page_context(section.context_id, p1.slug)
+      context = PageContext.create_page_context(section.context_id, p1.slug, user.id)
       assert context.previous_page.resource_id == page2.id
       assert context.next_page == nil
 
       Seeder.attach_pages_to([%{id: p1.resource_id}], container, container_revision, publication)
-      context = PageContext.create_page_context(section.context_id, p1.slug)
+      context = PageContext.create_page_context(section.context_id, p1.slug, user.id)
       assert context.previous_page == nil
       assert context.next_page == nil
 

--- a/test/oli/delivery/page/page_context_test.exs
+++ b/test/oli/delivery/page/page_context_test.exs
@@ -42,7 +42,6 @@ defmodule Oli.Delivery.Page.PageContextTest do
       context = PageContext.create_page_context(section.context_id, p1.slug, user.id)
 
       # verify activities map
-      assert Map.get(context.activities, a1.resource_id).slug == a1.slug
       assert Map.get(context.activities, a1.resource_id).model == "{}"
 
       # verify objectives map

--- a/test/oli/rendering/activity/html_test.exs
+++ b/test/oli/rendering/activity/html_test.exs
@@ -17,7 +17,6 @@ defmodule Oli.Content.Activity.HtmlTest do
       activity_map = %{
         1 => %{
           id: 1,
-          slug: "test",
           state: "{ \"active\": true }",
           model: "{ \"choices\": [ \"A\", \"B\", \"C\", \"D\" ], \"feedback\": [ \"A\", \"B\", \"C\", \"D\" ], \"stem\": \"\"}",
           delivery_element: "oli-multiple-choice-delivery"
@@ -35,7 +34,7 @@ defmodule Oli.Content.Activity.HtmlTest do
       rendered_html = Activity.render(%Context{user: author, activity_map: activity_map}, element, Activity.Html)
       rendered_html_string = Phoenix.HTML.raw(rendered_html) |> Phoenix.HTML.safe_to_string
 
-      assert rendered_html_string =~ "<oli-multiple-choice-delivery class=\"activity\" activitySlug=\"test\" model=\"{ \"choices\": [ \"A\", \"B\", \"C\", \"D\" ], \"feedback\": [ \"A\", \"B\", \"C\", \"D\" ], \"stem\": \"\"}\""
+      assert rendered_html_string =~ "<oli-multiple-choice-delivery class=\"activity\" state=\"{ \"active\": true }\" model=\"{ \"choices\": [ \"A\", \"B\", \"C\", \"D\" ], \"feedback\": [ \"A\", \"B\", \"C\", \"D\" ], \"stem\": \"\"}\""
     end
 
     test "renders malformed activity gracefully", %{author: author} do


### PR DESCRIPTION
This PR introduces resource, activity, and part attempt generation on visit to a page that contains activities. Visiting an *ungraded* page now in Delivery mode via a student will create these attempts.  Clicking choices will auto-save the state of the question back to that attempt so that subsequent visit to the page will restore that state. 

More details as to the changes:

In introduces the `Oli.Delivery.Attempts` context that determines the state of the attempts present in a particular page, creating new attempts if necessary. 

It introduces the concept of "activity realization" - where the references to activities found in a page content blob can be dynamically created into actual activities. This hook is where we will enable activity banks and question pools.  Right now realization just looks for an "activity-reference" node and uses that exact activity.   

Also introduces concept of "model transformation".  This is client-side configured, but server side executed transformation of an activities model for things like shuffling choices in an MCQ or (eventually) for templated questions.  The transformed model is stored directly on the activity attempt - so that we can properly restore the exact model when revisiting active attempts. 

It introduces a structured server side representation of an activity's model in `Oli.Activities.Model` with robust parsing to handle errors to eventually use to reject attempts to client-side edit in a way that would violate core parts of the activity schema.  

Also converts over internal ids of content elements to be strings instead of numbers.  Numbers were going to be problematic for a couple of reasons - most notably as a mismatch between the DOM representation of IDs and a challenge for migrating existing OLI course content. 

Specs out the full WebComponent CustomEvent interface, implemented all the way back through the page.html.eex template back to an new `AttemptController`.  The fundamental operations are "save", "submit", "reset", and "request hint".  Save, submit, and reset attempt can all either be done to an individual part or to the activity as a whole. 

The next PR likely will target:
1. Implementation of the model transformation step (for 'shuffle' only for now)
2. Handling of activity submits for individual parts and for the activity as a whole
3. Request and display of hints. 

