### PR TITLE
transformers impl

### DIFF
--- a/lib/oli/activities/model/transformations.ex
+++ b/lib/oli/activities/model/transformations.ex
@@ -11,7 +11,7 @@ defmodule Oli.Activities.Model.Transformation do
           path: path,
           operation: :shuffle
         }}
-      error -> error
+      _ -> {:error, "invalid operation"}
     end
 
   end

--- a/lib/oli/activities/transformers.ex
+++ b/lib/oli/activities/transformers.ex
@@ -1,0 +1,34 @@
+defmodule Oli.Activities.Transformers do
+
+
+  alias Oli.Activities.Model
+  alias Oli.Activities.Model.Transformation
+  alias Oli.Activities.Transformers.Shuffle
+
+  @doc """
+  Transforms an unparsed activity model.
+  """
+  @spec apply_transforms(map()) :: {:ok, map()} | {:error, any}
+  def apply_transforms(model) do
+
+    case Model.parse(model) do
+      {:ok, parsed_model} -> Enum.reduce_while(parsed_model.transformations, {:ok, model}, fn t, {:ok, model} ->
+        case apply_transform(model, t) do
+          {:ok, transformed_model} -> {:cont, {:ok, transformed_model}}
+          {:error, error} -> {:halt, {:error, error}}
+        end
+      end)
+      {:error, error} -> {:error, error}
+    end
+
+  end
+
+  defp apply_transform(model, %Transformation{operation: :shuffle} = transformation) do
+    Shuffle.transform(model, transformation)
+  end
+
+  defp apply_transform(_, _) do
+    {:error, :transformation_not_implemented}
+  end
+
+end

--- a/lib/oli/activities/transformers/shuffle.ex
+++ b/lib/oli/activities/transformers/shuffle.ex
@@ -1,0 +1,16 @@
+defmodule  Oli.Activities.Transformers.Shuffle do
+
+  alias Oli.Activities.Model.Transformation
+  alias Oli.Activities.Transformers.Transformer
+
+  @behaviour Transformer
+
+  @impl Transformer
+  def transform(model, %Transformation{path: path}) do
+    case Map.get(model, path) do
+      nil -> {:error, :path_not_found}
+      collection -> {:ok, Map.put(model, path, Enum.shuffle(collection))}
+    end
+  end
+
+end

--- a/lib/oli/activities/transformers/transformer.ex
+++ b/lib/oli/activities/transformers/transformer.ex
@@ -1,0 +1,7 @@
+defmodule Oli.Activities.Transformers.Transformer do
+
+  alias Oli.Activities.Model.Transformation
+
+  @callback transform(map(), %Transformation{}) :: {:ok, map()} | {:error, any}
+
+end

--- a/lib/oli/delivery/attempts.ex
+++ b/lib/oli/delivery/attempts.ex
@@ -7,7 +7,7 @@ defmodule Oli.Delivery.Attempts do
   alias Oli.Delivery.Attempts.{PartAttempt, ResourceAccess, ResourceAttempt, ActivityAttempt}
   alias Oli.Resources.{Revision}
   alias Oli.Activities.Model
-
+  alias Oli.Activities.Transformers
 
 
   @doc """
@@ -138,10 +138,9 @@ defmodule Oli.Delivery.Attempts do
 
     {resource_attempt, Enum.reduce(activity_revisions, %{}, fn %Revision{resource_id: resource_id, id: id, content: model} = revision, m ->
 
+        # Todo, handle and propagate upwards failures in parsing and transformation
         {:ok, parsed_model} = Model.parse(model)
-
-        # todo, apply transformations
-        transformed_model = model
+        {:ok, transformed_model} = Transformers.apply_transforms(model)
 
         {:ok, activity_attempt} = create_activity_attempt(%{
           resource_attempt_id: resource_attempt.id,

--- a/test/oli/activities/transformers_test.exs
+++ b/test/oli/activities/transformers_test.exs
@@ -1,0 +1,83 @@
+defmodule Oli.Activities.TransformersTest do
+
+  use ExUnit.Case, async: true
+
+  alias Oli.Activities.Transformers
+
+  test "applying shuffle" do
+
+    model = %{
+      "stem" => "this is the stem",
+      "choices" => [
+        %{ id: "1", content: []},
+        %{ id: "2", content: []},
+        %{ id: "3", content: []},
+        %{ id: "4", content: []}
+      ],
+      "authoring" => %{
+        "parts" => [
+          %{"id" => "1", "responses" => [], "scoringStrategy" => "best", "evaluationStrategy" => "regex"}
+        ],
+        "transformations" => [
+          %{"id" => "1", "path" => "choices", "operation" => "shuffle"}
+        ]
+      }
+    }
+
+    # Shuffle fifty times.  If none of the shuffles result in
+    # the first element changing - we likely have a broken shuffle impl.
+    assert Enum.any?(1..50, fn _ ->
+      {:ok, transformed} = Transformers.apply_transforms(model)
+      transformed["choices"] |> Enum.at(0) |> Map.get("id") != "1"
+    end)
+
+  end
+
+  test "catching invalid transformer" do
+
+    model = %{
+      "stem" => "this is the stem",
+      "choices" => [
+        %{ id: "1", content: []},
+        %{ id: "2", content: []},
+        %{ id: "3", content: []},
+        %{ id: "4", content: []}
+      ],
+      "authoring" => %{
+        "parts" => [
+          %{"id" => "1", "responses" => [], "scoringStrategy" => "best", "evaluationStrategy" => "regex"}
+        ],
+        "transformations" => [
+          %{"id" => "1", "path" => "choices", "operation" => "shuffled"}
+        ]
+      }
+    }
+
+    assert {:error, ["invalid operation"] } = Transformers.apply_transforms(model)
+  end
+
+  test "catching case where path cannot be found" do
+
+    model = %{
+      "stem" => "this is the stem",
+      "choices" => [
+        %{ id: "1", content: []},
+        %{ id: "2", content: []},
+        %{ id: "3", content: []},
+        %{ id: "4", content: []}
+      ],
+      "authoring" => %{
+        "parts" => [
+          %{"id" => "1", "responses" => [], "scoringStrategy" => "best", "evaluationStrategy" => "regex"}
+        ],
+        "transformations" => [
+          %{"id" => "1", "path" => "choicess", "operation" => "shuffle"}
+        ]
+      }
+    }
+
+    assert {:error, :path_not_found } = Transformers.apply_transforms(model)
+  end
+
+
+end


### PR DESCRIPTION
The shell of the transformers implementation.  Complete enough to get us thru learnlab release as it supports shuffling of top-level keys (choices is what we will use it for).  We will eventually want to expand support for deeper path navigation and add other transformers (for template questions, in particular).

