### PR TITLE
Evaluation

### DIFF
--- a/assets/src/components/activities/DeliveryElement.ts
+++ b/assets/src/components/activities/DeliveryElement.ts
@@ -1,23 +1,47 @@
-import { ActivityModelSchema, ActivityState, StudentResponse, Hint, Success } from './types';
+import { ActivityModelSchema, ActivityState, StudentResponse, Hint, Success, PartState } from './types';
 
 export type PartResponse = {
   attemptGuid: string,
   response: StudentResponse,
 };
 
+export interface EvaluatedPart {
+  type: 'EvaluatedPart';
+  attempt_guid: string;
+  out_of: number;
+  score: number;
+  feedback: any;
+}
+
+export interface EvaluationResponse extends Success {
+  evaluations: EvaluatedPart[];
+}
+
+export interface ResetActivityResponse extends Success {
+  attemptState: ActivityState;
+  model: ActivityModelSchema;
+}
+
+
+export interface PartActivityResponse extends Success {
+  attemptState: PartState;
+}
+
 export interface DeliveryElementProps<T extends ActivityModelSchema> {
   model: T;
   state: ActivityState;
 
   onSaveActivity: (attemptGuid: string, partResponses: PartResponse[]) => Promise<Success>;
-  onSubmitActivity: (attemptGuid: string, partResponses: PartResponse[]) => void;
-  onResetActivity: (attemptGuid: string) => void;
+  onSubmitActivity: (attemptGuid: string,
+    partResponses: PartResponse[]) => Promise<EvaluationResponse>;
+  onResetActivity: (attemptGuid: string) => Promise<ResetActivityResponse>;
 
   onRequestHint: (attemptGuid: string, partAttemptGuid: string) => Promise<Hint>;
   onSavePart: (attemptGuid: string, partAttemptGuid: string,
     response: StudentResponse) => Promise<Success>;
-  onSubmitPart: (attemptGuid: string, partAttemptGuid: string, response: StudentResponse) => void;
-  onResetPart: (attemptGuid: string, partAttemptGuid: string) => void;
+  onSubmitPart: (attemptGuid: string, partAttemptGuid: string,
+    response: StudentResponse) => Promise<EvaluationResponse>;
+  onResetPart: (attemptGuid: string, partAttemptGuid: string) => Promise<PartActivityResponse>;
 }
 
 // An abstract delivery web component, designed to delegate to
@@ -32,13 +56,15 @@ export abstract class DeliveryElement<T extends ActivityModelSchema> extends HTM
   onRequestHint: (attemptGuid: string, partAttemptGuid: string) => Promise<Hint>;
 
   onSaveActivity: (attemptGuid: string, partResponses: PartResponse[]) => Promise<Success>;
-  onSubmitActivity: (attemptGuid: string, partResponses: PartResponse[]) => void;
-  onResetActivity: (attemptGuid: string) => void;
+  onSubmitActivity: (attemptGuid: string,
+    partResponses: PartResponse[]) => Promise<EvaluationResponse>;
+  onResetActivity: (attemptGuid: string) => Promise<ResetActivityResponse>;
 
   onSavePart: (attemptGuid: string, partAttemptGuid: string,
     response: StudentResponse) => Promise<Success>;
-  onSubmitPart: (attemptGuid: string, partAttemptGuid: string, response: StudentResponse) => void;
-  onResetPart: (attemptGuid: string, partAttemptGuid: string) => void;
+  onSubmitPart: (attemptGuid: string, partAttemptGuid: string,
+    response: StudentResponse) => Promise<EvaluationResponse>;
+  onResetPart: (attemptGuid: string, partAttemptGuid: string) => Promise<PartActivityResponse>;
 
   constructor() {
     super();

--- a/assets/src/components/activity/ActivityEditor.tsx
+++ b/assets/src/components/activity/ActivityEditor.tsx
@@ -195,6 +195,7 @@ export class ActivityEditor extends React.Component<ActivityEditorProps, Activit
             canUndo={this.state.undoable.undoStack.size > 0}
             onUndo={this.undo} onRedo={this.redo}/>
         </TitleBar>
+
         <div ref={this.ref}>
           {React.createElement(authoringElement, webComponentProps as any)}
         </div>

--- a/lib/oli/activities/model/feedback.ex
+++ b/lib/oli/activities/model/feedback.ex
@@ -1,5 +1,6 @@
 defmodule Oli.Activities.Model.Feedback do
 
+  @derive Jason.Encoder
   defstruct [:id, :content]
 
   def parse(%{"id" => id, "content" => content }) do

--- a/lib/oli/authoring/editing/activity_editor.ex
+++ b/lib/oli/authoring/editing/activity_editor.ex
@@ -140,7 +140,7 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
          {:ok} <- authorize_user(author, project),
          {:ok, publication} <- Publishing.get_unpublished_publication_by_slug!(project_slug) |> trap_nil(),
          {:ok, activity_type} <- Activities.get_registration_by_slug(activity_type_slug) |> trap_nil(),
-         {:ok, activity} <- Activity.create_new(%{title: activity_type.title, objectives: %{}, author_id: author.id, content: model, activity_type_id: activity_type.id}),
+         {:ok, activity} <- Activity.create_new(%{title: activity_type.title, scoring_strategy_id: Oli.Resources.ScoringStrategy.get_id_by_type("average"), objectives: %{}, author_id: author.id, content: model, activity_type_id: activity_type.id}),
          {:ok, _} <- Course.create_project_resource(%{ project_id: project.id, resource_id: activity.resource_id}) |> trap_nil(),
          {:ok, _mapping} <- Publishing.create_resource_mapping(%{publication_id: publication.id, resource_id: activity.resource_id, revision_id: activity.id})
       do

--- a/lib/oli/db_seeder.ex
+++ b/lib/oli/db_seeder.ex
@@ -260,6 +260,25 @@ defmodule Oli.Seeder do
     end
   end
 
+  def add_page(map, attrs, resource_tag, revision_tag) do
+
+    author = map.author
+    project = map.project
+    publication = map.publication
+
+    {:ok, resource} = Oli.Resources.Resource.changeset(%Oli.Resources.Resource{}, %{}) |> Repo.insert
+
+    attrs = Map.merge(%{author_id: author.id, objectives: %{ "attached" => []}, resource_type_id: Oli.Resources.ResourceType.get_id_by_type("page"), children: [], content: %{ "model" => []}, deleted: false, title: "title", resource_id: resource.id}, attrs)
+    {:ok, revision} = Oli.Resources.create_revision(attrs)
+
+    {:ok, _} = Oli.Authoring.Course.ProjectResource.changeset(%Oli.Authoring.Course.ProjectResource{}, %{project_id: project.id, resource_id: resource.id}) |> Repo.insert
+
+    publish_resource(publication, resource, revision)
+
+    Map.put(map, resource_tag, resource)
+    |> Map.put(revision_tag, revision)
+  end
+
 
 
   def create_activity(attrs, publication, project, author) do

--- a/lib/oli/delivery/attempts/activity_attempt.ex
+++ b/lib/oli/delivery/attempts/activity_attempt.ex
@@ -7,8 +7,8 @@ defmodule Oli.Delivery.Attempts.ActivityAttempt do
     field :attempt_guid, :string
     field :attempt_number, :integer
     field :date_evaluated, :utc_datetime
-    field :score, :decimal
-    field :out_of, :decimal
+    field :score, :float
+    field :out_of, :float
     field :transformed_model, :map
 
     belongs_to :resource, Oli.Resources.Resource

--- a/lib/oli/delivery/attempts/part_attempt.ex
+++ b/lib/oli/delivery/attempts/part_attempt.ex
@@ -7,8 +7,8 @@ defmodule Oli.Delivery.Attempts.PartAttempt do
     field :attempt_guid, :string
     field :attempt_number, :integer
     field :date_evaluated, :utc_datetime
-    field :score, :decimal
-    field :out_of, :decimal
+    field :score, :float
+    field :out_of, :float
     field :response, :map
     field :feedback, :map
     field :hints, {:array, :string}, default: []

--- a/lib/oli/delivery/attempts/resource_attempt.ex
+++ b/lib/oli/delivery/attempts/resource_attempt.ex
@@ -7,8 +7,8 @@ defmodule Oli.Delivery.Attempts.ResourceAttempt do
     field :attempt_guid, :string
     field :attempt_number, :integer
     field :date_evaluated, :utc_datetime
-    field :score, :decimal
-    field :out_of, :decimal
+    field :score, :float
+    field :out_of, :float
 
     belongs_to :resource_access, Oli.Delivery.Attempts.ResourceAccess
     belongs_to :revision, Oli.Resources.Revision

--- a/lib/oli/delivery/attempts/snapshot.ex
+++ b/lib/oli/delivery/attempts/snapshot.ex
@@ -35,8 +35,8 @@ defmodule Oli.Delivery.Attempts.Snapshot do
     field :correct, :boolean
 
     # The raw score and out of points
-    field :score, :decimal
-    field :out_of, :decimal
+    field :score, :float
+    field :out_of, :float
 
     # Count of the number of hints received during this attempt
     field :hints, :integer

--- a/lib/oli/delivery/attempts/student_input.ex
+++ b/lib/oli/delivery/attempts/student_input.ex
@@ -1,6 +1,7 @@
 defmodule Oli.Delivery.Attempts.StudentInput do
 
   @enforce_keys [:input]
+  @derive Jason.Encoder
   defstruct [:input]
 
 end

--- a/lib/oli/delivery/evaluation/evaluator.ex
+++ b/lib/oli/delivery/evaluation/evaluator.ex
@@ -17,8 +17,8 @@ defmodule Oli.Delivery.Evaluation.Evaluator do
   def evaluate(%Part{evaluation_strategy: evaluation_strategy} = part, %StudentInput{} = input) do
 
     case evaluation_strategy do
-      :regex -> Numeric.evaluate(part, input)
-      :numeric -> Regex.evaluate(part, input)
+      :regex -> Regex.evaluate(part, input)
+      :numeric -> Numeric.evaluate(part, input)
     end
   end
 

--- a/lib/oli/resources.ex
+++ b/lib/oli/resources.ex
@@ -6,6 +6,7 @@ defmodule Oli.Resources do
   # should not have a dependency on a Project or Publication
   # or Page or Container or any other higher level construct
   alias Oli.Resources.Resource
+  alias Oli.Resources.ScoringStrategy
   alias Oli.Resources.Revision
   alias Oli.Resources.ResourceType
 
@@ -162,6 +163,21 @@ defmodule Oli.Resources do
     |> ResourceType.changeset(attrs)
     |> Repo.insert()
   end
+
+  @doc """
+  Creates a scoring strategy.
+  ## Examples
+      iex> create_scoring_strategy(%{field: value})
+      {:ok, %ScoringStrategy{}}
+      iex> create_scoring_strategy(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+  """
+  def create_scoring_strategy(attrs \\ %{}) do
+    %ScoringStrategy{}
+    |> ScoringStrategy.changeset(attrs)
+    |> Repo.insert()
+  end
+
 
   @doc """
   Updates a resource_type.

--- a/lib/oli/resources/scoring_strategy.ex
+++ b/lib/oli/resources/scoring_strategy.ex
@@ -4,7 +4,7 @@ defmodule Oli.Resources.ScoringStrategy do
 
   # It would be great to encapsulate all of this into a macro.
 
-  @types [%{id: 1, type: "average"}, %{id: 2, type: "best"}, %{id: 3, type: "most_recent"}]
+  @types [%{id: 1, type: "average"}, %{id: 2, type: "best"}, %{id: 3, type: "most_recent"}, %{id: 4, type: "total"}]
   @by_id Enum.reduce(@types, %{}, fn %{id: id, type: t}, m -> Map.put(m, id, t) end)
   @by_type Enum.reduce(@types, %{}, fn %{id: id, type: t}, m -> Map.put(m, t, id) end)
 
@@ -15,10 +15,12 @@ defmodule Oli.Resources.ScoringStrategy do
   def get_type_by_id(1), do: Map.get(@by_id, 1)
   def get_type_by_id(2), do: Map.get(@by_id, 2)
   def get_type_by_id(3), do: Map.get(@by_id, 3)
+  def get_type_by_id(4), do: Map.get(@by_id, 4)
 
   def get_id_by_type("average"), do: Map.get(@by_type, "average")
   def get_id_by_type("best"), do: Map.get(@by_type, "best")
   def get_id_by_type("most_recent"), do: Map.get(@by_type, "most_recent")
+  def get_id_by_type("total"), do: Map.get(@by_type, "total")
 
   schema "scoring_strategies" do
     field :type, :string

--- a/lib/oli_web/controllers/attempt_controller.ex
+++ b/lib/oli_web/controllers/attempt_controller.ex
@@ -2,6 +2,7 @@ defmodule OliWeb.AttemptController do
   use OliWeb, :controller
 
   alias Oli.Delivery.Attempts
+  alias Oli.Delivery.Attempts.StudentInput
 
   def save_part(conn, %{"activity_attempt_guid" => _attempt_guid, "part_attempt_guid" => part_attempt_guid, "response" => response}) do
 
@@ -12,9 +13,13 @@ defmodule OliWeb.AttemptController do
 
   end
 
-  def submit_part(conn, %{"activity_attempt_guid" => _, "part_attempt_guid" => _attempt_guid, "input" => _input}) do
+  def submit_part(conn, %{"activity_attempt_guid" => activity_attempt_guid, "part_attempt_guid" => attempt_guid, "input" => input}) do
 
-    json conn, %{ "type" => "success"}
+    case Attempts.submit_part_evaluations(activity_attempt_guid, [%{attempt_guid: attempt_guid, input: input}]) do
+      {:ok, evaluations} -> json conn, %{ "type" => "success", "evaluations" => evaluations}
+      {:error, _} -> json conn, %{ "type" => "failure"}
+    end
+
   end
 
   def new_part(conn, %{"activity_attempt_guid" => _, "part_attempt_guid" => _attempt_guid}) do
@@ -39,14 +44,27 @@ defmodule OliWeb.AttemptController do
 
   end
 
-  def submit_activity(conn, %{"activity_attempt_guid" => _attempt_guid, "partInputs" => _part_inputs}) do
+  def submit_activity(conn, %{"activity_attempt_guid" => activity_attempt_guid, "partInputs" => part_inputs}) do
 
-    json conn, %{ "type" => "success"}
+    parsed = Enum.map(part_inputs, fn %{"attemptGuid" => attempt_guid, "response" => input} ->
+      %{attempt_guid: attempt_guid, input: %StudentInput{input: Map.get(input, "input")}} end)
+
+    case Attempts.submit_part_evaluations(activity_attempt_guid, parsed) do
+      {:ok, evaluations} -> json conn, %{ "type" => "success", "evaluations" => evaluations}
+      {:error, _} -> json conn, %{ "type" => "failure"}
+    end
   end
 
-  def new_activity(conn, %{"activity_attempt_guid" => _attempt_guid}) do
+  def new_activity(conn, %{"activity_attempt_guid" => attempt_guid}) do
 
-    json conn, %{ "type" => "success"}
+    lti_params = Plug.Conn.get_session(conn, :lti_params)
+    context_id = lti_params["context_id"]
+
+    case Attempts.reset_activity(context_id, attempt_guid) do
+      {:ok, attempt_state, model} -> json conn, %{ "type" => "success", "attemptState" => attempt_state, "model" => model}
+      {:error, _} -> json conn, %{ "type" => "failure"}
+    end
+
   end
 
 

--- a/lib/oli_web/controllers/attempt_controller.ex
+++ b/lib/oli_web/controllers/attempt_controller.ex
@@ -3,31 +3,31 @@ defmodule OliWeb.AttemptController do
 
   alias Oli.Delivery.Attempts
 
-  def save_part(conn, %{"attempt_guid" => attempt_guid, "response" => response}) do
+  def save_part(conn, %{"activity_attempt_guid" => _attempt_guid, "part_attempt_guid" => part_attempt_guid, "response" => response}) do
 
-    case Attempts.save_student_input([%{attempt_guid: attempt_guid, response: response}]) do
+    case Attempts.save_student_input([%{attempt_guid: part_attempt_guid, response: response}]) do
       {:ok, _} -> json conn, %{ "type" => "success"}
       {:error, _} -> json conn, %{ "type" => "failure"}
     end
 
   end
 
-  def submit_part(conn, %{"attempt_guid" => _attempt_guid, "input" => _input}) do
+  def submit_part(conn, %{"activity_attempt_guid" => _, "part_attempt_guid" => _attempt_guid, "input" => _input}) do
 
     json conn, %{ "type" => "success"}
   end
 
-  def new_part(conn, %{"attempt_guid" => _attempt_guid}) do
+  def new_part(conn, %{"activity_attempt_guid" => _, "part_attempt_guid" => _attempt_guid}) do
 
     json conn, %{ "type" => "success"}
   end
 
-  def get_hint(conn, %{"attempt_guid" => _attempt_guid}) do
+  def get_hint(conn, %{"activity_attempt_guid" => _, "part_attempt_guid" => _attempt_guid}) do
 
     json conn, %{ "type" => "success"}
   end
 
-  def save_activity(conn, %{"attempt_guid" => _attempt_guid, "partInputs" => part_inputs}) do
+  def save_activity(conn, %{"activity_attempt_guid" => _attempt_guid, "partInputs" => part_inputs}) do
 
     parsed = Enum.map(part_inputs, fn %{"attemptGuid" => attempt_guid, "response" => response} ->
       %{attempt_guid: attempt_guid, response: response} end)
@@ -39,12 +39,12 @@ defmodule OliWeb.AttemptController do
 
   end
 
-  def submit_activity(conn, %{"attempt_guid" => _attempt_guid, "partInputs" => _part_inputs}) do
+  def submit_activity(conn, %{"activity_attempt_guid" => _attempt_guid, "partInputs" => _part_inputs}) do
 
     json conn, %{ "type" => "success"}
   end
 
-  def new_activity(conn, %{"attempt_guid" => _attempt_guid}) do
+  def new_activity(conn, %{"activity_attempt_guid" => _attempt_guid}) do
 
     json conn, %{ "type" => "success"}
   end

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -153,14 +153,14 @@ defmodule OliWeb.Router do
     # put to submit a response
     # patch to save response state
 
-    post "/part/:attempt_guid", AttemptController, :new_part
-    put "/part/:attempt_guid", AttemptController, :submit_part
-    patch "/part/:attempt_guid", AttemptController, :save_part
-    get "/part/:attempt_guid/hint", AttemptController, :get_hint
+    post "/activity/:activity_attempt_guid/part/:part_attempt_guid", AttemptController, :new_part
+    put "/activity/:activity_attempt_guid/part/:part_attempt_guid", AttemptController, :submit_part
+    patch "/activity/:activity_attempt_guid/part/:part_attempt_guid", AttemptController, :save_part
+    get "/activity/:activity_attempt_guid/part/:part_attempt_guid", AttemptController, :get_hint
 
-    post "/activity/:attempt_guid", AttemptController, :new_activity
-    put "/activity/:attempt_guid", AttemptController, :submit_activity
-    patch "/activity/:attempt_guid", AttemptController, :save_activity
+    post "/activity/:activity_attempt_guid", AttemptController, :new_activity
+    put "/activity/:activity_attempt_guid", AttemptController, :submit_activity
+    patch "/activity/:activity_attempt_guid", AttemptController, :save_activity
 
   end
 

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -147,7 +147,7 @@ defmodule OliWeb.Router do
   end
 
   scope "/api/v1/attempt", OliWeb do
-    pipe_through [:api, :protected]
+    pipe_through [:api]
 
     # post to create a new attempt
     # put to submit a response

--- a/lib/oli_web/templates/student_delivery/page.html.eex
+++ b/lib/oli_web/templates/student_delivery/page.html.eex
@@ -51,25 +51,25 @@
   div.addEventListener('savePart', function (e) {
     e.preventDefault();
     e.stopPropagation();
-    makeRequest('/api/v1/attempt/part/' + e.detail.attemptGuid, 'PATCH', { input: e.detail.payload }, e.detail.continuation);
+    makeRequest('/api/v1/attempt/part/' + e.detail.attemptGuid + '/part/' + e.detail.partAttemptGuid, 'PATCH', { input: e.detail.payload }, e.detail.continuation);
   }, false);
 
   div.addEventListener('submitPart', function (e) {
     e.preventDefault();
     e.stopPropagation();
-    makeRequest('/api/v1/attempt/part/' + e.detail.attemptGuid, 'PUT', { input: e.detail.payload }, e.detail.continuation);
+    makeRequest('/api/v1/attempt/part/' + e.detail.attemptGuid + '/part/' + e.detail.partAttemptGuid, 'PUT', { input: e.detail.payload }, e.detail.continuation);
   }, false);
 
   div.addEventListener('resetPart', function (e) {
     e.preventDefault();
     e.stopPropagation();
-    makeRequest('/api/v1/attempt/part/' + e.detail.attemptGuid, 'POST', {}, e.detail.continuation);
+    makeRequest('/api/v1/attempt/part/' + e.detail.attemptGuid + '/part/' + e.detail.partAttemptGuid, 'POST', {}, e.detail.continuation);
   }, false);
 
   div.addEventListener('requestHint', function (e) {
     e.preventDefault();
     e.stopPropagation();
-    makeRequest('/api/v1/attempt/part/' + e.detail.attemptGuid + '/hint', 'GET', {}, e.detail.continuation);
+    makeRequest('/api/v1/attempt/part/' + e.detail.attemptGuid + '/part/' + e.detail.partAttemptGuid + '/hint', 'GET', {}, e.detail.continuation);
   }, false);
 
 </script>

--- a/priv/repo/migrations/20200310193550_init_core_schemas.exs
+++ b/priv/repo/migrations/20200310193550_init_core_schemas.exs
@@ -250,8 +250,8 @@ defmodule Oli.Repo.Migrations.InitCoreSchemas do
       add :activity_type_id, references(:activity_registrations)
       add :attempt_number, :integer
       add :correct, :boolean
-      add :score, :decimal
-      add :out_of, :decimal
+      add :score, :float
+      add :out_of, :float
       add :hints, :integer
 
     end
@@ -260,8 +260,8 @@ defmodule Oli.Repo.Migrations.InitCoreSchemas do
       timestamps(type: :timestamptz)
 
       add :access_count, :integer, null: true
-      add :score, :decimal, null: true
-      add :out_of, :decimal, null: true
+      add :score, :float, null: true
+      add :out_of, :float, null: true
 
       add :user_id, references(:user)
       add :section_id, references(:sections)
@@ -279,8 +279,8 @@ defmodule Oli.Repo.Migrations.InitCoreSchemas do
       add :attempt_guid, :string
       add :attempt_number, :integer
       add :date_evaluated, :utc_datetime
-      add :score, :decimal
-      add :out_of, :decimal
+      add :score, :float
+      add :out_of, :float
 
       add :resource_access_id, references(:resource_accesses)
       add :revision_id, references(:revisions)
@@ -297,8 +297,8 @@ defmodule Oli.Repo.Migrations.InitCoreSchemas do
       add :attempt_guid, :string
       add :attempt_number, :integer
       add :date_evaluated, :utc_datetime
-      add :score, :decimal
-      add :out_of, :decimal
+      add :score, :float
+      add :out_of, :float
       add :transformed_model, :map
 
       add :resource_attempt_id, references(:resource_attempts)
@@ -316,8 +316,8 @@ defmodule Oli.Repo.Migrations.InitCoreSchemas do
       add :attempt_guid, :string
       add :attempt_number, :integer
       add :date_evaluated, :utc_datetime
-      add :score, :decimal
-      add :out_of, :decimal
+      add :score, :float
+      add :out_of, :float
       add :response, :map
       add :feedback, :map
       add :hints,  {:array, :string}

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -64,6 +64,14 @@ if !Oli.Repo.get_by(Oli.Resources.ResourceType, id: 1) do
 
 end
 
+# create scoring strategy types
+if !Oli.Repo.get_by(Oli.Resources.ScoringStrategy, id: 1) do
+
+  Oli.Resources.ScoringStrategy.get_types()
+  |> Enum.map(&Oli.Resources.create_scoring_strategy/1)
+
+end
+
 # Seed the database with the locally implemented activity types
 if Enum.empty?(Oli.Activities.list_activity_registrations()) do
   Oli.Registrar.register_local_activities()

--- a/test/oli/delivery/submission_test.exs
+++ b/test/oli/delivery/submission_test.exs
@@ -1,0 +1,211 @@
+defmodule Oli.Delivery.AttemptsSubmissionTest do
+
+  use Oli.DataCase
+
+  alias Oli.Delivery.Attempts
+  alias Oli.Activities.Model.Part
+  alias Oli.Delivery.Attempts.{ActivityAttempt, PartAttempt, StudentInput}
+
+  describe "processing a one part submission" do
+
+    setup do
+
+      content = %{
+        "stem" => "1",
+        "authoring" => %{
+          "parts" => [
+            %{"id" => "1", "responses" => [
+              %{"match" => "a", "score" => 10, "id" => "r1", "feedback" => %{"id" => "1", "content" => "yes"}},
+              %{"match" => "b", "score" => 1, "id" => "r2", "feedback" => %{"id" => "2", "content" => "almost"}},
+              %{"match" => "c", "score" => 0, "id" => "r3", "feedback" => %{"id" => "3", "content" => "no"}}
+            ], "scoringStrategy" => "best", "evaluationStrategy" => "regex"}
+          ]
+        }
+      }
+
+      map = Seeder.base_project_with_resource2()
+      |> Seeder.create_section()
+      |> Seeder.add_objective("objective one", :o1)
+      |> Seeder.add_activity(%{title: "one", content: content}, :publication, :project, :author, :activity_resource, :activity_revision)
+      |> Seeder.add_user(%{}, :user1)
+
+      attrs = %{
+        title: "page1",
+        content: %{
+          "model" => [
+            %{"type" => "activity-reference", "activity_id" => Map.get(map, :activity_revision).resource_id}
+          ]
+        },
+        objectives: %{"attached" => [Map.get(map, :o1).resource_id]}
+      }
+
+      Seeder.add_page(map, attrs, :page_resource, :page_revision)
+      |> Seeder.create_resource_attempt(%{attempt_number: 1}, :user1, :page_resource, :page_revision, :attempt1)
+      |> Seeder.create_activity_attempt(%{attempt_number: 1, transformed_model: content}, :activity_resource, :activity_revision, :attempt1, :activity_attempt1)
+      |> Seeder.create_part_attempt(%{attempt_number: 1}, %Part{id: "1", responses: [], hints: []}, :activity_attempt1, :part1_attempt1)
+
+    end
+
+    test "processing a submission", %{ part1_attempt1: part_attempt, activity_attempt1: activity_attempt} do
+
+      part_inputs = [%{attempt_guid: part_attempt.attempt_guid, input: %StudentInput{input: "a"}}]
+      {:ok, [%{attempt_guid: attempt_guid, out_of: out_of, score: score, feedback: %{id: id} }]} = Attempts.submit_part_evaluations(activity_attempt.attempt_guid, part_inputs)
+
+      # verify the returned feedback was what we expected
+      assert attempt_guid == part_attempt.attempt_guid
+      assert score == 10
+      assert out_of == 10
+      assert id == "1"
+
+      # verify the part attempt record was updated correctly
+      updated_attempt = Oli.Repo.get!(PartAttempt, part_attempt.id)
+      assert updated_attempt.score == 10
+      assert updated_attempt.out_of == 10
+      refute updated_attempt.date_evaluated == nil
+
+      # verify that the submission rolled up to the activity attempt
+      updated_attempt = Oli.Repo.get!(ActivityAttempt, activity_attempt.id)
+      assert updated_attempt.score == 10
+      assert updated_attempt.out_of == 10
+      refute updated_attempt.date_evaluated == nil
+
+    end
+
+    test "processing a different submission", %{ part1_attempt1: part_attempt, activity_attempt1: activity_attempt} do
+
+      part_inputs = [%{attempt_guid: part_attempt.attempt_guid, input: %StudentInput{input: "b"}}]
+      {:ok, [%{attempt_guid: attempt_guid, out_of: out_of, score: score, feedback: %{id: id} }]} = Attempts.submit_part_evaluations(activity_attempt.attempt_guid, part_inputs)
+
+      assert attempt_guid == part_attempt.attempt_guid
+      assert score == 1
+      assert out_of == 10
+      assert id == "2"
+
+    end
+
+    test "processing a submission whose input matches no response", %{ part1_attempt1: part_attempt, activity_attempt1: activity_attempt} do
+
+      part_inputs = [%{attempt_guid: part_attempt.attempt_guid, input: %StudentInput{input: "d"}}]
+      {:error, error} = Attempts.submit_part_evaluations(activity_attempt.attempt_guid, part_inputs)
+
+      assert error == "no matching response found"
+
+    end
+
+  end
+
+  describe "processing a multipart submission" do
+
+    setup do
+
+      content = %{
+        "stem" => "1",
+        "authoring" => %{
+          "parts" => [
+            %{"id" => "1", "responses" => [
+              %{"match" => "a", "score" => 10, "id" => "r1", "feedback" => %{"id" => "1", "content" => "yes"}},
+              %{"match" => "b", "score" => 1, "id" => "r2", "feedback" => %{"id" => "2", "content" => "almost"}},
+              %{"match" => "c", "score" => 0, "id" => "r3", "feedback" => %{"id" => "3", "content" => "no"}}
+            ], "scoringStrategy" => "best", "evaluationStrategy" => "regex"},
+            %{"id" => "2", "responses" => [
+              %{"match" => "a", "score" => 2, "id" => "r1", "feedback" => %{"id" => "4", "content" => "yes"}},
+              %{"match" => "b", "score" => 1, "id" => "r2", "feedback" => %{"id" => "5", "content" => "almost"}},
+              %{"match" => "c", "score" => 0, "id" => "r3", "feedback" => %{"id" => "6", "content" => "no"}}
+            ], "scoringStrategy" => "best", "evaluationStrategy" => "regex"}
+          ]
+        }
+      }
+
+      map = Seeder.base_project_with_resource2()
+      |> Seeder.create_section()
+      |> Seeder.add_objective("objective one", :o1)
+      |> Seeder.add_activity(%{title: "one", content: content}, :publication, :project, :author, :activity_resource, :activity_revision)
+      |> Seeder.add_user(%{}, :user1)
+
+      attrs = %{
+        title: "page1",
+        content: %{
+          "model" => [
+            %{"type" => "activity-reference", "activity_id" => Map.get(map, :activity_revision).resource_id}
+          ]
+        },
+        objectives: %{"attached" => [Map.get(map, :o1).resource_id]}
+      }
+
+      Seeder.add_page(map, attrs, :page_resource, :page_revision)
+      |> Seeder.create_resource_attempt(%{attempt_number: 1}, :user1, :page_resource, :page_revision, :attempt1)
+      |> Seeder.create_activity_attempt(%{attempt_number: 1, transformed_model: content}, :activity_resource, :activity_revision, :attempt1, :activity_attempt1)
+      |> Seeder.create_part_attempt(%{attempt_number: 1}, %Part{id: "1", responses: [], hints: []}, :activity_attempt1, :part1_attempt1)
+      |> Seeder.create_part_attempt(%{attempt_number: 1}, %Part{id: "2", responses: [], hints: []}, :activity_attempt1, :part2_attempt1)
+
+    end
+
+    test "processing a submission with just one of the parts submitted", %{ part1_attempt1: part_attempt, activity_attempt1: activity_attempt} do
+
+      part_inputs = [%{attempt_guid: part_attempt.attempt_guid, input: %StudentInput{input: "a"}}]
+      {:ok, [%{attempt_guid: attempt_guid, out_of: out_of, score: score, feedback: %{id: id} }]} = Attempts.submit_part_evaluations(activity_attempt.attempt_guid, part_inputs)
+
+      # verify the returned feedback was what we expected
+      assert attempt_guid == part_attempt.attempt_guid
+      assert score == 10
+      assert out_of == 10
+      assert id == "1"
+
+      # verify the part attempt record was updated correctly
+      updated_attempt = Oli.Repo.get!(PartAttempt, part_attempt.id)
+      assert updated_attempt.score == 10
+      assert updated_attempt.out_of == 10
+      refute updated_attempt.date_evaluated == nil
+
+      # verify that the submission did NOT roll up to the activity attempt
+      updated_attempt = Oli.Repo.get!(ActivityAttempt, activity_attempt.id)
+      assert updated_attempt.score == nil
+      assert updated_attempt.out_of == nil
+      assert updated_attempt.date_evaluated == nil
+
+    end
+
+    test "processing a submission with all parts submitted", %{ part1_attempt1: part_attempt, part2_attempt1: part2_attempt, activity_attempt1: activity_attempt} do
+
+      part_inputs = [
+        %{attempt_guid: part_attempt.attempt_guid, input: %StudentInput{input: "a"}},
+        %{attempt_guid: part2_attempt.attempt_guid, input: %StudentInput{input: "a"}},
+      ]
+      {:ok, [
+        %{attempt_guid: attempt_guid, out_of: out_of, score: score, feedback: %{id: id} },
+        %{attempt_guid: attempt_guid2, out_of: out_of2, score: score2, feedback: %{id: id2} },
+      ]} = Attempts.submit_part_evaluations(activity_attempt.attempt_guid, part_inputs)
+
+      # verify the returned feedback was what we expected
+      assert attempt_guid == part_attempt.attempt_guid
+      assert score == 10
+      assert out_of == 10
+      assert id == "1"
+
+      assert attempt_guid2 == part2_attempt.attempt_guid
+      assert score2 == 2
+      assert out_of2 == 2
+      assert id2 == "4"
+
+      # verify the part attempt record was updated correctly
+      updated_attempt = Oli.Repo.get!(PartAttempt, part_attempt.id)
+      assert updated_attempt.score == 10
+      assert updated_attempt.out_of == 10
+      refute updated_attempt.date_evaluated == nil
+
+      updated_attempt = Oli.Repo.get!(PartAttempt, part2_attempt.id)
+      assert updated_attempt.score == 2
+      assert updated_attempt.out_of == 2
+      refute updated_attempt.date_evaluated == nil
+
+      # verify that the submission did roll up to the activity attempt
+      updated_attempt = Oli.Repo.get!(ActivityAttempt, activity_attempt.id)
+      assert updated_attempt.score == 12
+      assert updated_attempt.out_of == 12
+      refute updated_attempt.date_evaluated == nil
+
+    end
+
+  end
+
+end

--- a/test/oli/delivery/submission_test.exs
+++ b/test/oli/delivery/submission_test.exs
@@ -6,6 +6,82 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
   alias Oli.Activities.Model.Part
   alias Oli.Delivery.Attempts.{ActivityAttempt, PartAttempt, StudentInput}
 
+
+  describe "resetting an activity" do
+
+    setup do
+
+      content = %{
+        "stem" => "1",
+        "authoring" => %{
+          "parts" => [
+            %{"id" => "1", "responses" => [
+              %{"match" => "a", "score" => 10, "id" => "r1", "feedback" => %{"id" => "1", "content" => "yes"}},
+              %{"match" => "b", "score" => 1, "id" => "r2", "feedback" => %{"id" => "2", "content" => "almost"}},
+              %{"match" => "c", "score" => 0, "id" => "r3", "feedback" => %{"id" => "3", "content" => "no"}}
+            ], "scoringStrategy" => "best", "evaluationStrategy" => "regex"}
+          ]
+        }
+      }
+
+      map = Seeder.base_project_with_resource2()
+      |> Seeder.create_section()
+      |> Seeder.add_objective("objective one", :o1)
+      |> Seeder.add_activity(%{title: "one", content: content}, :publication, :project, :author, :activity_resource, :activity_revision)
+      |> Seeder.add_user(%{}, :user1)
+
+      attrs = %{
+        title: "page1",
+        content: %{
+          "model" => [
+            %{"type" => "activity-reference", "activity_id" => Map.get(map, :activity_revision).resource_id}
+          ]
+        },
+        objectives: %{"attached" => [Map.get(map, :o1).resource_id]}
+      }
+
+      Seeder.add_page(map, attrs, :page_resource, :page_revision)
+      |> Seeder.create_resource_attempt(%{attempt_number: 1}, :user1, :page_resource, :page_revision, :attempt1)
+      |> Seeder.create_activity_attempt(%{attempt_number: 1, transformed_model: content}, :activity_resource, :activity_revision, :attempt1, :activity_attempt1)
+      |> Seeder.create_part_attempt(%{attempt_number: 1}, %Part{id: "1", responses: [], hints: []}, :activity_attempt1, :part1_attempt1)
+
+    end
+
+    test "processing a submission", %{ part1_attempt1: part_attempt, section: section, activity_attempt1: activity_attempt} do
+
+      part_inputs = [%{attempt_guid: part_attempt.attempt_guid, input: %StudentInput{input: "a"}}]
+      {:ok, [%{attempt_guid: attempt_guid, out_of: out_of, score: score, feedback: %{id: id} }]} = Attempts.submit_part_evaluations(activity_attempt.attempt_guid, part_inputs)
+
+      # verify the returned feedback was what we expected
+      assert attempt_guid == part_attempt.attempt_guid
+      assert score == 10
+      assert out_of == 10
+      assert id == "1"
+
+      # verify the part attempt record was updated correctly
+      updated_attempt = Oli.Repo.get!(PartAttempt, part_attempt.id)
+      assert updated_attempt.score == 10
+      assert updated_attempt.out_of == 10
+      refute updated_attempt.date_evaluated == nil
+
+      # verify that the submission rolled up to the activity attempt
+      updated_attempt = Oli.Repo.get!(ActivityAttempt, activity_attempt.id)
+      assert updated_attempt.score == 10
+      assert updated_attempt.out_of == 10
+      refute updated_attempt.date_evaluated == nil
+
+      # now reset the activity
+      {:ok, attempt_state, _} = Attempts.reset_activity(section.context_id, activity_attempt.attempt_guid)
+
+      assert attempt_state.dateEvaluated == nil
+      assert attempt_state.score == nil
+      assert attempt_state.outOf == nil
+      assert length(attempt_state.parts) == 1
+
+    end
+
+  end
+
   describe "processing a one part submission" do
 
     setup do


### PR DESCRIPTION
This PR adds support for activity and part submission - as well as activity (but not yet part) resetting. 

With this PR in place one can now:
1) Author and publish a page with a multiple choice activity.
2) Have a student LTI launch in and visit the page and submit a response for the question.
3) The student will receive immediate feedback and the question goes into a "read only" state.
4) The author can make a change to the activity (fix a typo, refine feedback) and publish the page
5) The student clicks "Retry" to try the question again. The question "resets", but the student now sees the updated version of the question.

  