### PR TITLE
refactor and split workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,69 @@
+name: Package & Deploy
+
+on:
+  push:
+    branches:
+      - test
+      # - production
+    tags:
+      - deploy-test
+
+jobs:
+  package-and-deploy:
+    runs-on: ubuntu-latest
+
+    # only release and deploy if the workflow is running on the test branch
+    # or a commit is tagged with 'deploy-test'
+    # TODO: add support for production deployments
+    if: github.ref == 'refs/heads/test' || github.ref == 'refs/tags/deploy-test'
+
+    steps:
+      - name: 🛎️ Checkout
+        uses: actions/checkout@v2
+
+      - name: 🧾 Build info
+        id: info
+        run: |
+          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+          echo "::set-output name=app_version::$(cat mix.exs | grep version | sed -e 's/.*version: "\(.*\)",/\1/')"
+
+      - name: 📦💽 Package release
+        uses: ./.github/actions/phoenix-builder
+        with:
+          build-sha: ${{ steps.info.outputs.sha_short }}
+
+      - name: 💽⬆️ Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: oli-${{ steps.info.outputs.app_version }}-${{ steps.info.outputs.sha_short }}
+          path: _build/prod/rel/oli
+
+      # TODO: add S3 archive support
+      # - name: 💽⬆️ Upload release to S3 archive
+      #   uses: jakejarvis/s3-sync-action@master
+      #   with:
+      #     args: --acl public-read --follow-symlinks --delete
+      #   env:
+      #     AWS_S3_BUCKET: 'oli-torus-releases'
+      #     AWS_ACCESS_KEY_ID: ${{ secrets.SIMON_BOT_AWS_ACCESS_KEY_ID }}
+      #     AWS_SECRET_ACCESS_KEY: ${{ secrets.SIMON_BOT_AWS_SECRET_ACCESS_KEY }}
+      #     AWS_REGION: 'us-east-2'
+      #     SOURCE_DIR: 'oli-${{ steps.info.outputs.app_version }}-${{ steps.info.outputs.sha_short }}'
+
+      - name: 🗜️🚢 Zip it & ship it
+        run: |
+          zip -r oli-${{ steps.info.outputs.app_version }}-${{ steps.info.outputs.sha_short }}.zip _build/prod/rel/oli
+          mkdir ~/.ssh
+          echo "${{ secrets.SIMON_BOT_PRIVATE_KEY}}" > ~/.ssh/simon-bot
+          chmod 600 ~/.ssh/simon-bot
+          sftp -i ~/.ssh/simon-bot -o StrictHostKeyChecking=no simon-bot@tokamak.oli.cmu.edu  <<< $'cd /torus\n put oli-${{ steps.info.outputs.app_version }}-${{ steps.info.outputs.sha_short }}.zip'
+
+      - name: 💰 Deploy using SSH
+        uses: fifsky/ssh-action@master
+        with:
+          command: |
+            cd /torus
+            sh deploy.sh ${{ steps.info.outputs.app_version }} ${{ steps.info.outputs.sha_short }}
+          host: tokamak.oli.cmu.edu
+          user: simon-bot
+          key: ${{ secrets.SIMON_BOT_PRIVATE_KEY}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Build & Test CI
+name: Build & Test PR
 
 on:
   pull_request:
@@ -6,13 +6,6 @@ on:
       - master
       - test
       - production
-  push:
-    branches:
-      - master
-      - test
-      - production
-    tags:
-      - deploy-test
 
 jobs:
   elixir-build-test:
@@ -78,63 +71,3 @@ jobs:
 
       - name: ⚙️ Test
         run: cd assets && npm run test
-
-  release-and-deploy:
-    runs-on: ubuntu-latest
-    needs: [elixir-build-test, ts-build-test]
-
-    # only release and deploy if the workflow is running on the test branch
-    # or a commit is tagged with 'deploy-test'
-    # TODO: add support for production deployments
-    if: github.ref == 'refs/heads/test' || github.ref == 'refs/tags/deploy-test'
-
-    steps:
-      - name: 🛎️ Checkout
-        uses: actions/checkout@v2
-
-      - name: 🧾 Build info
-        id: info
-        run: |
-          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-          echo "::set-output name=app_version::$(cat mix.exs | grep version | sed -e 's/.*version: "\(.*\)",/\1/')"
-
-      - name: 📦💽 Package release
-        uses: ./.github/actions/phoenix-builder
-        with:
-          build-sha: ${{ steps.info.outputs.sha_short }}
-
-      - name: 💽⬆️ Upload artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: oli-${{ steps.info.outputs.app_version }}-${{ steps.info.outputs.sha_short }}
-          path: _build/prod/rel/oli
-
-      # TODO: add S3 archive support
-      # - name: 💽⬆️ Upload release to S3 archive
-      #   uses: jakejarvis/s3-sync-action@master
-      #   with:
-      #     args: --acl public-read --follow-symlinks --delete
-      #   env:
-      #     AWS_S3_BUCKET: 'oli-torus-releases'
-      #     AWS_ACCESS_KEY_ID: ${{ secrets.SIMON_BOT_AWS_ACCESS_KEY_ID }}
-      #     AWS_SECRET_ACCESS_KEY: ${{ secrets.SIMON_BOT_AWS_SECRET_ACCESS_KEY }}
-      #     AWS_REGION: 'us-east-2'
-      #     SOURCE_DIR: 'oli-${{ steps.info.outputs.app_version }}-${{ steps.info.outputs.sha_short }}'
-
-      - name: 🗜️🚢 Zip it & ship it
-        run: |
-          zip -r oli-${{ steps.info.outputs.app_version }}-${{ steps.info.outputs.sha_short }}.zip _build/prod/rel/oli
-          mkdir ~/.ssh
-          echo "${{ secrets.SIMON_BOT_PRIVATE_KEY}}" > ~/.ssh/simon-bot
-          chmod 600 ~/.ssh/simon-bot
-          sftp -i ~/.ssh/simon-bot -o StrictHostKeyChecking=no simon-bot@tokamak.oli.cmu.edu  <<< $'cd /torus\n put oli-${{ steps.info.outputs.app_version }}-${{ steps.info.outputs.sha_short }}.zip'
-
-      - name: 💰 Deploy using SSH
-        uses: fifsky/ssh-action@master
-        with:
-          command: |
-            cd /torus
-            sh deploy.sh ${{ steps.info.outputs.app_version }} ${{ steps.info.outputs.sha_short }}
-          host: tokamak.oli.cmu.edu
-          user: simon-bot
-          key: ${{ secrets.SIMON_BOT_PRIVATE_KEY}}


### PR DESCRIPTION
Splits CI/CD workflows so that we aren't repeating jobs on PR and push. To ensure all code that is pushed to test and production (including merges) is actually run through build and test, the github repo setting is updated to ensure branches have the latest before push.