### PR TITLE
Snapshots

### DIFF
--- a/lib/oli/delivery/attempts.ex
+++ b/lib/oli/delivery/attempts.ex
@@ -49,7 +49,7 @@ defmodule Oli.Delivery.Attempts do
 
       attempt_count = count_activity_attempts(activity_attempt.resource_attempt_id, activity_attempt.resource_id)
 
-      if activity_attempt.revision.max_attempts <= attempt_count do
+      if activity_attempt.revision.max_attempts > 0 and activity_attempt.revision.max_attempts <= attempt_count do
         {:error, {:no_more_attempts}}
       else
         activity_attempt = activity_attempt |> Repo.preload([:part_attempts])

--- a/lib/oli/delivery/attempts/snapshot.ex
+++ b/lib/oli/delivery/attempts/snapshot.ex
@@ -53,11 +53,11 @@ defmodule Oli.Delivery.Attempts.Snapshot do
   @doc false
   def changeset(problem_step_rollup, attrs) do
     problem_step_rollup
-    |> cast(attrs, [:resource_id, :activity_id, :part_id, :user_id, :section_id,
+    |> cast(attrs, [:resource_id, :activity_id, :part_id, :user_id, :section_id, :graded,
       :score, :out_of, :part_attempt_id, :part_attempt_number, :resource_attempt_number,
       :objective_id, :objective_revision_id, :revision_id, :activity_type_id, :attempt_number, :correct, :hints])
     |> validate_required([:resource_id, :activity_id, :part_id, :user_id, :section_id,
       :score, :out_of, :part_attempt_id, :part_attempt_number, :resource_attempt_number,
-      :objective_id, :objective_revision_id, :revision_id, :activity_type_id, :attempt_number, :correct, :hints])
+      :revision_id, :activity_type_id, :attempt_number, :correct, :hints])
   end
 end

--- a/lib/oli/delivery/attempts/snapshot.ex
+++ b/lib/oli/delivery/attempts/snapshot.ex
@@ -10,6 +10,7 @@ defmodule Oli.Delivery.Attempts.Snapshot do
     belongs_to :resource, Oli.Resources.Resource
     belongs_to :activity, Oli.Resources.Resource
     field :part_id, :string
+    belongs_to :part_attempt, Oli.Delivery.Attempts.PartAttempt
 
     # Which user and section
     belongs_to :user, Oli.Accounts.User
@@ -17,8 +18,8 @@ defmodule Oli.Delivery.Attempts.Snapshot do
 
     # At the time of the attempt which objectives and their revisions
     # that were attached to this part
-    field :objectives, {:array, :id}
-    field :objective_revisions, {:array, :id}
+    belongs_to :objective, Oli.Resources.Resource
+    belongs_to :objective_revision, Oli.Resources.Revision
 
     # The exact revision of the activity at the time of this attempt
     belongs_to :revision, Oli.Resources.Revision
@@ -30,9 +31,14 @@ defmodule Oli.Delivery.Attempts.Snapshot do
     # The attempt number is useful to power a query like:
     # "What percentage of first attempts are correct?"
     field :attempt_number, :integer
+    field :part_attempt_number, :integer
+    field :resource_attempt_number, :integer
 
     # Whether or not this attempt was correct (true) or error (false)
     field :correct, :boolean
+
+    # Was this an attempt in a graded context
+    field :graded, :boolean
 
     # The raw score and out of points
     field :score, :float
@@ -48,10 +54,10 @@ defmodule Oli.Delivery.Attempts.Snapshot do
   def changeset(problem_step_rollup, attrs) do
     problem_step_rollup
     |> cast(attrs, [:resource_id, :activity_id, :part_id, :user_id, :section_id,
-      :score, :out_of,
-      :objectives, :objective_revisions, :revision_id, :activity_type_id, :attempt_number, :correct, :hints])
+      :score, :out_of, :part_attempt_id, :part_attempt_number, :resource_attempt_number,
+      :objective_id, :objective_revision_id, :revision_id, :activity_type_id, :attempt_number, :correct, :hints])
     |> validate_required([:resource_id, :activity_id, :part_id, :user_id, :section_id,
-      :score, :out_of,
-      :objectives, :objective_revisions, :revision_id, :activity_type_id, :attempt_number, :correct, :hints])
+      :score, :out_of, :part_attempt_id, :part_attempt_number, :resource_attempt_number,
+      :objective_id, :objective_revision_id, :revision_id, :activity_type_id, :attempt_number, :correct, :hints])
   end
 end

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -15,6 +15,7 @@ defmodule Oli.Delivery.Sections do
 
   """
   def enroll(user_id, section_id, section_role_id) do
+  
     case Repo.one(from(e in Enrollment, where: e.user_id == ^user_id and e.section_id == ^section_id, select: e)) do
 
       # Enrollment doesn't exist, we are creating it

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -15,7 +15,7 @@ defmodule Oli.Delivery.Sections do
 
   """
   def enroll(user_id, section_id, section_role_id) do
-  
+
     case Repo.one(from(e in Enrollment, where: e.user_id == ^user_id and e.section_id == ^section_id, select: e)) do
 
       # Enrollment doesn't exist, we are creating it

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -15,7 +15,6 @@ defmodule Oli.Delivery.Sections do
 
   """
   def enroll(user_id, section_id, section_role_id) do
-\
     case Repo.one(from(e in Enrollment, where: e.user_id == ^user_id and e.section_id == ^section_id, select: e)) do
 
       # Enrollment doesn't exist, we are creating it

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -15,7 +15,7 @@ defmodule Oli.Delivery.Sections do
 
   """
   def enroll(user_id, section_id, section_role_id) do
-
+\
     case Repo.one(from(e in Enrollment, where: e.user_id == ^user_id and e.section_id == ^section_id, select: e)) do
 
       # Enrollment doesn't exist, we are creating it

--- a/lib/oli_web/controllers/attempt_controller.ex
+++ b/lib/oli_web/controllers/attempt_controller.ex
@@ -15,7 +15,10 @@ defmodule OliWeb.AttemptController do
 
   def submit_part(conn, %{"activity_attempt_guid" => activity_attempt_guid, "part_attempt_guid" => attempt_guid, "input" => input}) do
 
-    case Attempts.submit_part_evaluations(activity_attempt_guid, [%{attempt_guid: attempt_guid, input: input}]) do
+    lti_params = Plug.Conn.get_session(conn, :lti_params)
+    context_id = lti_params["context_id"]
+
+    case Attempts.submit_part_evaluations(context_id, activity_attempt_guid, [%{attempt_guid: attempt_guid, input: input}]) do
       {:ok, evaluations} -> json conn, %{ "type" => "success", "evaluations" => evaluations}
       {:error, _} -> error(conn, 500, "server error")
     end
@@ -52,10 +55,13 @@ defmodule OliWeb.AttemptController do
 
   def submit_activity(conn, %{"activity_attempt_guid" => activity_attempt_guid, "partInputs" => part_inputs}) do
 
+    lti_params = Plug.Conn.get_session(conn, :lti_params)
+    context_id = lti_params["context_id"]
+
     parsed = Enum.map(part_inputs, fn %{"attemptGuid" => attempt_guid, "response" => input} ->
       %{attempt_guid: attempt_guid, input: %StudentInput{input: Map.get(input, "input")}} end)
 
-    case Attempts.submit_part_evaluations(activity_attempt_guid, parsed) do
+    case Attempts.submit_part_evaluations(context_id, activity_attempt_guid, parsed) do
       {:ok, evaluations} -> json conn, %{ "type" => "success", "evaluations" => evaluations}
       {:error, _} -> error(conn, 500, "server error")
     end

--- a/lib/oli_web/controllers/attempt_controller.ex
+++ b/lib/oli_web/controllers/attempt_controller.ex
@@ -17,8 +17,9 @@ defmodule OliWeb.AttemptController do
 
     lti_params = Plug.Conn.get_session(conn, :lti_params)
     context_id = lti_params["context_id"]
+    role = Oli.Delivery.Lti.parse_lti_role(lti_params["roles"])
 
-    case Attempts.submit_part_evaluations(context_id, activity_attempt_guid, [%{attempt_guid: attempt_guid, input: input}]) do
+    case Attempts.submit_part_evaluations(role, context_id, activity_attempt_guid, [%{attempt_guid: attempt_guid, input: input}]) do
       {:ok, evaluations} -> json conn, %{ "type" => "success", "evaluations" => evaluations}
       {:error, _} -> error(conn, 500, "server error")
     end
@@ -57,11 +58,12 @@ defmodule OliWeb.AttemptController do
 
     lti_params = Plug.Conn.get_session(conn, :lti_params)
     context_id = lti_params["context_id"]
+    role = Oli.Delivery.Lti.parse_lti_role(lti_params["roles"])
 
     parsed = Enum.map(part_inputs, fn %{"attemptGuid" => attempt_guid, "response" => input} ->
       %{attempt_guid: attempt_guid, input: %StudentInput{input: Map.get(input, "input")}} end)
 
-    case Attempts.submit_part_evaluations(context_id, activity_attempt_guid, parsed) do
+    case Attempts.submit_part_evaluations(role, context_id, activity_attempt_guid, parsed) do
       {:ok, evaluations} -> json conn, %{ "type" => "success", "evaluations" => evaluations}
       {:error, _} -> error(conn, 500, "server error")
     end

--- a/priv/repo/migrations/20200310193550_init_core_schemas.exs
+++ b/priv/repo/migrations/20200310193550_init_core_schemas.exs
@@ -308,37 +308,39 @@ defmodule Oli.Repo.Migrations.InitCoreSchemas do
     create index(:part_attempts, [:activity_attempt_id])
     create unique_index(:part_attempts, [:attempt_guid], name: :attempt_guid_index)
 
+
+    create table(:snapshots) do
+      timestamps(type: :timestamptz)
+
+      add :resource_id, references(:resources)
+      add :activity_id, references(:resources)
+      add :part_id, :string
+      add :part_attempt_id, references(:part_attempts)
+      add :user_id, references(:user)
+      add :section_id, references(:sections)
+      add :objective_id, references(:resources)
+      add :objective_revision_id, references(:revisions)
+      add :revision_id, references(:revisions)
+      add :activity_type_id, references(:activity_registrations)
+      add :attempt_number, :integer
+      add :part_attempt_number, :integer
+      add :resource_attempt_number, :integer
+      add :correct, :boolean
+      add :graded, :boolean
+      add :score, :float
+      add :out_of, :float
+      add :hints, :integer
+
+    end
+
+    create index(:snapshots, [:objective_id])
+    create index(:snapshots, [:activity_id])
+    create index(:snapshots, [:section_id])
+
+    create unique_index(:snapshots, [:part_attempt_id, :objective_id], name: :snapshot_unique_part)
+
   end
 
-  create table(:snapshots) do
-    timestamps(type: :timestamptz)
-
-    add :resource_id, references(:resources)
-    add :activity_id, references(:resources)
-    add :part_id, :string
-    add :part_attempt_id, references(:part_attempts)
-    add :user_id, references(:user)
-    add :section_id, references(:sections)
-    add :objective_id, references(:resources)
-    add :objective_revision_id, references(:revisions)
-    add :revision_id, references(:revisions)
-    add :activity_type_id, references(:activity_registrations)
-    add :attempt_number, :integer
-    add :part_attempt_number, :integer
-    add :resource_attempt_number, :integer
-    add :correct, :boolean
-    add :graded, :boolean
-    add :score, :float
-    add :out_of, :float
-    add :hints, :integer
-
-  end
-
-  create index(:snapshots, [:objective_id])
-  create index(:snapshots, [:activity_id])
-  create index(:snapshots, [:section_id])
-
-  create unique_index(:snapshots, [:part_attempt_id, :objective_id], name: :snapshot_unique_part)
 
 
 end

--- a/priv/repo/migrations/20200310193550_init_core_schemas.exs
+++ b/priv/repo/migrations/20200310193550_init_core_schemas.exs
@@ -235,27 +235,6 @@ defmodule Oli.Repo.Migrations.InitCoreSchemas do
     create index(:projects_resources, [:project_id])
     create unique_index(:projects_resources, [:resource_id, :project_id], name: :index_project_resource)
 
-
-    create table(:snapshots) do
-      timestamps(type: :timestamptz)
-
-      add :user_id, references(:user)
-      add :activity_id, references(:resources)
-      add :section_id, references(:sections)
-      add :resource_id, references(:resources)
-      add :part_id, :string
-      add :objectives, {:array, :id}
-      add :objective_revisions, {:array, :id}
-      add :revision_id, references(:revisions)
-      add :activity_type_id, references(:activity_registrations)
-      add :attempt_number, :integer
-      add :correct, :boolean
-      add :score, :float
-      add :out_of, :float
-      add :hints, :integer
-
-    end
-
     create table(:resource_accesses) do
       timestamps(type: :timestamptz)
 
@@ -330,4 +309,36 @@ defmodule Oli.Repo.Migrations.InitCoreSchemas do
     create unique_index(:part_attempts, [:attempt_guid], name: :attempt_guid_index)
 
   end
+
+  create table(:snapshots) do
+    timestamps(type: :timestamptz)
+
+    add :resource_id, references(:resources)
+    add :activity_id, references(:resources)
+    add :part_id, :string
+    add :part_attempt_id, references(:part_attempts)
+    add :user_id, references(:user)
+    add :section_id, references(:sections)
+    add :objective_id, references(:resources)
+    add :objective_revision_id, references(:revisions)
+    add :revision_id, references(:revisions)
+    add :activity_type_id, references(:activity_registrations)
+    add :attempt_number, :integer
+    add :part_attempt_number, :integer
+    add :resource_attempt_number, :integer
+    add :correct, :boolean
+    add :graded, :boolean
+    add :score, :float
+    add :out_of, :float
+    add :hints, :integer
+
+  end
+
+  create index(:snapshots, [:objective_id])
+  create index(:snapshots, [:activity_id])
+  create index(:snapshots, [:section_id])
+
+  create unique_index(:snapshots, [:part_attempt_id, :objective_id], name: :snapshot_unique_part)
+
+
 end

--- a/test/oli/delivery/submission_test.exs
+++ b/test/oli/delivery/submission_test.exs
@@ -50,7 +50,7 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
     test "processing a submission", %{ part1_attempt1: part_attempt, section: section, activity_attempt1: activity_attempt} do
 
       part_inputs = [%{attempt_guid: part_attempt.attempt_guid, input: %StudentInput{input: "a"}}]
-      {:ok, [%{attempt_guid: attempt_guid, out_of: out_of, score: score, feedback: %{id: id} }]} = Attempts.submit_part_evaluations(activity_attempt.attempt_guid, part_inputs)
+      {:ok, [%{attempt_guid: attempt_guid, out_of: out_of, score: score, feedback: %{id: id} }]} = Attempts.submit_part_evaluations(section.context_id, activity_attempt.attempt_guid, part_inputs)
 
       # verify the returned feedback was what we expected
       assert attempt_guid == part_attempt.attempt_guid
@@ -95,7 +95,7 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
 
       # Submit in tab A:
       part_inputs = [%{attempt_guid: part_attempt.attempt_guid, input: %StudentInput{input: "a"}}]
-      {:ok, _} = Attempts.submit_part_evaluations(activity_attempt.attempt_guid, part_inputs)
+      {:ok, _} = Attempts.submit_part_evaluations(section.context_id, activity_attempt.attempt_guid, part_inputs)
 
       # now reset the activity, this is a simulation of the student
       # opening the resource in tab B.
@@ -150,10 +150,10 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
 
     end
 
-    test "processing a submission", %{ part1_attempt1: part_attempt, activity_attempt1: activity_attempt} do
+    test "processing a submission", %{ part1_attempt1: part_attempt, section: section, activity_attempt1: activity_attempt} do
 
       part_inputs = [%{attempt_guid: part_attempt.attempt_guid, input: %StudentInput{input: "a"}}]
-      {:ok, [%{attempt_guid: attempt_guid, out_of: out_of, score: score, feedback: %{id: id} }]} = Attempts.submit_part_evaluations(activity_attempt.attempt_guid, part_inputs)
+      {:ok, [%{attempt_guid: attempt_guid, out_of: out_of, score: score, feedback: %{id: id} }]} = Attempts.submit_part_evaluations(section.context_id, activity_attempt.attempt_guid, part_inputs)
 
       # verify the returned feedback was what we expected
       assert attempt_guid == part_attempt.attempt_guid
@@ -175,10 +175,10 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
 
     end
 
-    test "processing a different submission", %{ part1_attempt1: part_attempt, activity_attempt1: activity_attempt} do
+    test "processing a different submission", %{ part1_attempt1: part_attempt, section: section, activity_attempt1: activity_attempt} do
 
       part_inputs = [%{attempt_guid: part_attempt.attempt_guid, input: %StudentInput{input: "b"}}]
-      {:ok, [%{attempt_guid: attempt_guid, out_of: out_of, score: score, feedback: %{id: id} }]} = Attempts.submit_part_evaluations(activity_attempt.attempt_guid, part_inputs)
+      {:ok, [%{attempt_guid: attempt_guid, out_of: out_of, score: score, feedback: %{id: id} }]} = Attempts.submit_part_evaluations(section.context_id, activity_attempt.attempt_guid, part_inputs)
 
       assert attempt_guid == part_attempt.attempt_guid
       assert score == 1
@@ -187,10 +187,10 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
 
     end
 
-    test "processing a submission whose input matches no response", %{ part1_attempt1: part_attempt, activity_attempt1: activity_attempt} do
+    test "processing a submission whose input matches no response", %{ section: section, part1_attempt1: part_attempt, activity_attempt1: activity_attempt} do
 
       part_inputs = [%{attempt_guid: part_attempt.attempt_guid, input: %StudentInput{input: "d"}}]
-      {:error, error} = Attempts.submit_part_evaluations(activity_attempt.attempt_guid, part_inputs)
+      {:error, error} = Attempts.submit_part_evaluations(section.context_id, activity_attempt.attempt_guid, part_inputs)
 
       assert error == "no matching response found"
 
@@ -244,10 +244,10 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
 
     end
 
-    test "processing a submission with just one of the parts submitted", %{ part1_attempt1: part_attempt, activity_attempt1: activity_attempt} do
+    test "processing a submission with just one of the parts submitted", %{ section: section, part1_attempt1: part_attempt, activity_attempt1: activity_attempt} do
 
       part_inputs = [%{attempt_guid: part_attempt.attempt_guid, input: %StudentInput{input: "a"}}]
-      {:ok, [%{attempt_guid: attempt_guid, out_of: out_of, score: score, feedback: %{id: id} }]} = Attempts.submit_part_evaluations(activity_attempt.attempt_guid, part_inputs)
+      {:ok, [%{attempt_guid: attempt_guid, out_of: out_of, score: score, feedback: %{id: id} }]} = Attempts.submit_part_evaluations(section.context_id, activity_attempt.attempt_guid, part_inputs)
 
       # verify the returned feedback was what we expected
       assert attempt_guid == part_attempt.attempt_guid
@@ -269,7 +269,7 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
 
     end
 
-    test "processing a submission with all parts submitted", %{ part1_attempt1: part_attempt, part2_attempt1: part2_attempt, activity_attempt1: activity_attempt} do
+    test "processing a submission with all parts submitted", %{ section: section, part1_attempt1: part_attempt, part2_attempt1: part2_attempt, activity_attempt1: activity_attempt} do
 
       part_inputs = [
         %{attempt_guid: part_attempt.attempt_guid, input: %StudentInput{input: "a"}},
@@ -278,7 +278,7 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
       {:ok, [
         %{attempt_guid: attempt_guid, out_of: out_of, score: score, feedback: %{id: id} },
         %{attempt_guid: attempt_guid2, out_of: out_of2, score: score2, feedback: %{id: id2} },
-      ]} = Attempts.submit_part_evaluations(activity_attempt.attempt_guid, part_inputs)
+      ]} = Attempts.submit_part_evaluations(section.context_id, activity_attempt.attempt_guid, part_inputs)
 
       # verify the returned feedback was what we expected
       assert attempt_guid == part_attempt.attempt_guid


### PR DESCRIPTION
This PR adds support for generation of snapshot records on successful part attempt submission. 

Snapshots are only generated for students, not for instructors or admins. 

