### PR TITLE
add transaction support where needed

### DIFF
--- a/lib/oli/delivery/page/page_context.ex
+++ b/lib/oli/delivery/page/page_context.ex
@@ -36,8 +36,9 @@ defmodule Oli.Delivery.Page.PageContext do
     activity_provider = &Oli.Delivery.ActivityProvider.provide/2
 
     {progress_state, resource_attempts, activities} = case Attempts.determine_resource_attempt_state(page_revision, context_id, user_id, activity_provider) do
-      {:in_progress, {resource_attempt, latest_attempts}} -> {:in_progress, [resource_attempt], ActivityContext.create_context_map(page_revision.graded, latest_attempts)}
-      {:not_started, {_, resource_attempts}} -> {:not_started, resource_attempts, nil}
+      {:ok, {:in_progress, {resource_attempt, latest_attempts}}} -> {:in_progress, [resource_attempt], ActivityContext.create_context_map(page_revision.graded, latest_attempts)}
+      {:ok, {:not_started, {_, resource_attempts}}} -> {:not_started, resource_attempts, nil}
+      {:error, _} -> {:error, [], %{}}
     end
 
     {objectives, previous, next} =

--- a/lib/oli_web/controllers/attempt_controller.ex
+++ b/lib/oli_web/controllers/attempt_controller.ex
@@ -34,7 +34,7 @@ defmodule OliWeb.AttemptController do
   def get_hint(conn, %{"activity_attempt_guid" => activity_attempt_guid, "part_attempt_guid" => part_attempt_guid}) do
 
     case Attempts.request_hint(activity_attempt_guid, part_attempt_guid) do
-      {:ok, hint, has_more_hints} -> json conn, %{ "type" => "success", "hint" => hint, "hasMoreHints" => has_more_hints}
+      {:ok, {hint, has_more_hints}} -> json conn, %{ "type" => "success", "hint" => hint, "hasMoreHints" => has_more_hints}
       {:error, {:not_found}} -> error(conn, 404, "not found")
       {:error, {:no_more_hints}} -> json conn, %{ "type" => "success", "hasMoreHints" => false}
       {:error, _} -> error(conn, 500, "server error")
@@ -75,7 +75,7 @@ defmodule OliWeb.AttemptController do
     context_id = lti_params["context_id"]
 
     case Attempts.reset_activity(context_id, attempt_guid) do
-      {:ok, attempt_state, model} -> json conn, %{ "type" => "success", "attemptState" => attempt_state, "model" => model}
+      {:ok, {attempt_state, model}} -> json conn, %{ "type" => "success", "attemptState" => attempt_state, "model" => model}
       {:error, _} -> error(conn, 500, "server error")
     end
 

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -43,6 +43,7 @@ defmodule OliWeb.PageDeliveryController do
 
   end
 
+
   defp render_page(%PageContext{progress_state: :not_started, page: page, resource_attempts: resource_attempts} = context,
     conn, context_id, _) do
 
@@ -78,6 +79,10 @@ defmodule OliWeb.PageDeliveryController do
       slug: context.page.slug,
       attempt_guid: hd(context.resource_attempts).attempt_guid
     })
+  end
+
+  defp render_page(%PageContext{progress_state: :error}, conn, _, _) do
+    render(conn, "error.html")
   end
 
   def start_attempt(conn, %{"context_id" => context_id, "revision_slug" => revision_slug}) do

--- a/test/oli/delivery/attempts_test.exs
+++ b/test/oli/delivery/attempts_test.exs
@@ -57,7 +57,7 @@ defmodule Oli.Delivery.AttemptsTest do
       activity_provider = &Oli.Delivery.ActivityProvider.provide/2
 
       # verify that creating the attempt tree returns both activity attempts
-      {resource_attempt, attempts} = Attempts.create_new_attempt_tree(nil, p1, section.context_id, user.id, activity_provider)
+      {:ok, {resource_attempt, attempts}} = Attempts.create_new_attempt_tree(nil, p1, section.context_id, user.id, activity_provider)
       assert Map.has_key?(attempts, a1.resource_id)
       assert Map.has_key?(attempts, a2.resource_id)
 

--- a/test/oli/delivery/hints_test.exs
+++ b/test/oli/delivery/hints_test.exs
@@ -51,13 +51,13 @@ defmodule Oli.Delivery.HintsTest do
 
     test "exhaust all three hints", %{ part1_attempt1: part_attempt, activity_attempt1: activity_attempt} do
 
-      assert {:ok, %Hint{id: "h1", content: [%{"type" => "p", "children" => [%{"text" => "hint one"}]}]}, true}
+      assert {:ok, {%Hint{id: "h1", content: [%{"type" => "p", "children" => [%{"text" => "hint one"}]}]}, true}}
         == Attempts.request_hint(activity_attempt.attempt_guid, part_attempt.attempt_guid)
 
-      assert {:ok, %Hint{id: "h2", content: [%{"type" => "p", "children" => [%{"text" => "hint two"}]}]}, true}
+      assert {:ok, {%Hint{id: "h2", content: [%{"type" => "p", "children" => [%{"text" => "hint two"}]}]}, true}}
         == Attempts.request_hint(activity_attempt.attempt_guid, part_attempt.attempt_guid)
 
-      assert {:ok, %Hint{id: "h3", content: [%{"type" => "p", "children" => [%{"text" => "hint three"}]}]}, false}
+      assert {:ok, {%Hint{id: "h3", content: [%{"type" => "p", "children" => [%{"text" => "hint three"}]}]}, false}}
         == Attempts.request_hint(activity_attempt.attempt_guid, part_attempt.attempt_guid)
 
       assert {:error, {:no_more_hints}}

--- a/test/oli/delivery/submission_test.exs
+++ b/test/oli/delivery/submission_test.exs
@@ -74,7 +74,7 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
       refute updated_attempt.date_evaluated == nil
 
       # now reset the activity
-      {:ok, attempt_state, _} = Attempts.reset_activity(section.context_id, activity_attempt.attempt_guid)
+      {:ok, {attempt_state, _}} = Attempts.reset_activity(section.context_id, activity_attempt.attempt_guid)
 
       assert attempt_state.dateEvaluated == nil
       assert attempt_state.score == nil
@@ -118,7 +118,7 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
 
       # now reset the activity, this is a simulation of the student
       # opening the resource in tab B.
-      {:ok, attempt_state, _} = Attempts.reset_activity(section.context_id, activity_attempt.attempt_guid)
+      {:ok, {attempt_state, _}} = Attempts.reset_activity(section.context_id, activity_attempt.attempt_guid)
       assert attempt_state.hasMoreAttempts == false
 
       # now try to reset the guid from the first attempt, simulating the


### PR DESCRIPTION
This PR adds transaction support for high-level `Attempts` functions were they were missing. 