### PR TITLE
fix reordering csrf problem

### DIFF
--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -117,7 +117,7 @@ defmodule OliWeb.Router do
 
     # Curriculum
     resources "/:project_id/curriculum", CurriculumController, only: [:index, :create, :delete]
-    put "/:project_id/curriculum", CurriculumController, :update
+
 
     # Editors
     get "/:project_id/resource/:revision_slug", ResourceController, :edit
@@ -140,7 +140,7 @@ defmodule OliWeb.Router do
 
   scope "/api/v1/project", OliWeb do
     pipe_through [:api, :protected]
-
+    put "/:project_id/curriculum", CurriculumController, :update
     put "/:project/resource/:resource", ResourceController, :update
 
     post "/:project/activity/:activity_type", ActivityController, :create

--- a/lib/oli_web/templates/curriculum/index.html.eex
+++ b/lib/oli_web/templates/curriculum/index.html.eex
@@ -141,7 +141,7 @@ li.page:last-child:hover{
   }
 
   function triggerReorderOnServer(project_slug, sourceSlug, index) {
-    const url = `/project/${project_slug}/curriculum`
+    const url = `/api/v1/project/${project_slug}/curriculum`
     const params = {
       method: 'PUT',
       headers: {'Content-Type': 'application/json'},


### PR DESCRIPTION
curriculum reordering fails due to presence of CSRF. Solution is to move this endpoint to an API pipeline