### PR TITLE
Edit render fix

### DIFF
--- a/assets/src/components/editor/Editor.tsx
+++ b/assets/src/components/editor/Editor.tsx
@@ -52,8 +52,7 @@ const voidOnKeyDown = (editor: ReactEditor, e: KeyboardEvent) => {
 function areEqual(prevProps: EditorProps, nextProps: EditorProps) {
   return prevProps.editMode === nextProps.editMode
     && prevProps.toolbarItems === nextProps.toolbarItems
-    && prevProps.value === nextProps.value
-    && prevProps.onEdit === nextProps.onEdit;
+    && prevProps.value === nextProps.value;
 }
 
 

--- a/assets/src/components/editor/Editor.tsx
+++ b/assets/src/components/editor/Editor.tsx
@@ -52,7 +52,8 @@ const voidOnKeyDown = (editor: ReactEditor, e: KeyboardEvent) => {
 function areEqual(prevProps: EditorProps, nextProps: EditorProps) {
   return prevProps.editMode === nextProps.editMode
     && prevProps.toolbarItems === nextProps.toolbarItems
-    && prevProps.value === nextProps.value;
+    && prevProps.value === nextProps.value
+    && prevProps.onEdit === nextProps.onEdit;
 }
 
 

--- a/assets/src/components/editor/RichTextEditor.tsx
+++ b/assets/src/components/editor/RichTextEditor.tsx
@@ -12,6 +12,9 @@ type RichTextEditorProps = {
 };
 export const RichTextEditor = ({ editMode, text, onEdit, children, projectSlug }:
   React.PropsWithChildren<RichTextEditorProps>) => {
+
+  const cached = React.useCallback(onEdit, []);
+
   return (
     <React.Fragment>
       {children}
@@ -24,7 +27,7 @@ export const RichTextEditor = ({ editMode, text, onEdit, children, projectSlug }
         fontSize: '11px',
         margin: '4px 0 10px 0',
       }}>
-        <Editor commandContext={{ projectSlug }} editMode={editMode} value={text} onEdit={onEdit}
+        <Editor commandContext={{ projectSlug }} editMode={editMode} value={text} onEdit={cached}
           toolbarItems={getToolbarForResourceType(1)} />
       </div>
     </React.Fragment>

--- a/assets/src/components/editor/RichTextEditor.tsx
+++ b/assets/src/components/editor/RichTextEditor.tsx
@@ -13,8 +13,6 @@ type RichTextEditorProps = {
 export const RichTextEditor = ({ editMode, text, onEdit, children, projectSlug }:
   React.PropsWithChildren<RichTextEditorProps>) => {
 
-  const cached = React.useCallback(onEdit, []);
-
   return (
     <React.Fragment>
       {children}
@@ -27,7 +25,7 @@ export const RichTextEditor = ({ editMode, text, onEdit, children, projectSlug }
         fontSize: '11px',
         margin: '4px 0 10px 0',
       }}>
-        <Editor commandContext={{ projectSlug }} editMode={editMode} value={text} onEdit={cached}
+        <Editor commandContext={{ projectSlug }} editMode={editMode} value={text} onEdit={onEdit}
           toolbarItems={getToolbarForResourceType(1)} />
       </div>
     </React.Fragment>

--- a/assets/src/components/editor/Toolbars.tsx
+++ b/assets/src/components/editor/Toolbars.tsx
@@ -52,7 +52,11 @@ type HoveringToolbarProps = {
   commandContext: CommandContext;
 };
 
-export const HoveringToolbar = (props: HoveringToolbarProps) => {
+function hoveringAreEqual(prevProps: HoveringToolbarProps, nextProps: HoveringToolbarProps) {
+  return prevProps.commandContext === nextProps.commandContext;
+}
+
+export const HoveringToolbar = React.memo((props: HoveringToolbarProps) => {
   const ref = useRef();
   const editor = useSlate();
 
@@ -89,7 +93,7 @@ export const HoveringToolbar = (props: HoveringToolbarProps) => {
       </div>
     </div>, document.body,
   );
-};
+}, hoveringAreEqual);
 
 function showToolbar(el: HTMLElement) {
   el.style.visibility = 'visible';
@@ -104,7 +108,12 @@ type FixedToolbarProps = {
   commandContext: CommandContext;
 };
 
-export const FixedToolbar = (props: FixedToolbarProps) => {
+function fixedAreEqual(prevProps: FixedToolbarProps, nextProps: FixedToolbarProps) {
+  return prevProps.commandContext === nextProps.commandContext
+    && prevProps.toolbarItems === nextProps.toolbarItems;
+}
+
+export const FixedToolbar = React.memo((props: FixedToolbarProps) => {
   const { toolbarItems } = props;
   const [collapsed, setCollapsed] = useState(false);
   const ref = useRef();
@@ -167,7 +176,7 @@ export const FixedToolbar = (props: FixedToolbarProps) => {
       </div>
     </div>
   );
-};
+}, fixedAreEqual);
 
 const Spacer = () => {
   return (

--- a/assets/src/components/resource/Editors.tsx
+++ b/assets/src/components/resource/Editors.tsx
@@ -12,14 +12,14 @@ import { TestModeHandler, defaultState } from './TestModeHandler';
 export type EditorsProps = {
   editMode: boolean,              // Whether or not we can edit
   content: Immutable.List<ResourceContent>,     // Content of the resource
-  onEdit: (content: Immutable.List<ResourceContent>) => void,
+  onEdit: (content: ResourceContent, index: number) => void,
+  onRemove: (index: number) => void,
   editorMap: ActivityEditorMap,   // Map of activity types to activity elements
   graded: boolean,
   activities: Immutable.Map<string, Activity>,
   projectSlug: ProjectSlug,
   resourceSlug: ResourceSlug,
 };
-
 
 
 // The list of editors
@@ -92,10 +92,11 @@ export const Editors = (props: EditorsProps) => {
 
   };
 
+
   const editors = content.map((c, index) => {
 
-    const onEdit = (u : ResourceContent) => props.onEdit(content.set(index, u));
-    const onRemove = () => props.onEdit(content.remove(index));
+    const onEdit = (u : ResourceContent) => props.onEdit(u, index);
+    const onRemove = () => props.onRemove(index);
 
     const [editor, label] = createEditor(c, onEdit);
 

--- a/assets/src/components/resource/ResourceEditor.tsx
+++ b/assets/src/components/resource/ResourceEditor.tsx
@@ -220,10 +220,14 @@ export class ResourceEditor extends React.Component<ResourceEditorProps, Resourc
         <div className="d-flex flex-row align-items-start">
           <Outline {...props} editMode={this.state.editMode}
             activities={this.state.activities}
-            onEdit={c => onEdit(c)} content={state.undoable.current.content}/>
+            onEdit={c => onEdit(c)} content={this.state.undoable.current.content}/>
           <Editors {...props} editMode={this.state.editMode}
             activities={this.state.activities}
-            onEdit={c => onEdit(c)} content={state.undoable.current.content}/>
+            onRemove={index => onEdit(this.state.undoable.current.content.delete(index))}
+            onEdit={(c, index) => {
+              onEdit(this.state.undoable.current.content.set(index, c));
+            }}
+            content={this.state.undoable.current.content}/>
         </div>
       </div>
     );


### PR DESCRIPTION
To reproduce this issue, follow these steps:

1. Edit a page that initially has just one Content item.
2. Add a new Content or MCQ item.
3. Attempt to edit the first Content item.

You will see the second item disappear.

This problem was a combination of referencing previous state at the `ResourceEditor` level and caching of state at the `Editors` level.  

To prevent re-rendering of toolbars I added in the `React.memo` wrappers around the fixed and hover toolbar. 