### PR TITLE
List toggle

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -40,9 +40,9 @@
     "redux": "^4.0.5",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.3.0",
-    "slate": "^0.57.1",
-    "slate-history": "^0.57.1",
-    "slate-react": "^0.57.1",
+    "slate": "^0.58.1",
+    "slate-history": "^0.58.1",
+    "slate-react": "^0.58.1",
     "tsmonad": "^0.8.0",
     "typescript": "^3.7.5",
     "whatwg-fetch": "^3.0.0"

--- a/assets/src/components/editor/Editor.tsx
+++ b/assets/src/components/editor/Editor.tsx
@@ -36,7 +36,7 @@ const voidOnKeyDown = (editor: ReactEditor, e: KeyboardEvent) => {
 
       getRootOfText(editor).lift((node: Node) => {
 
-        if ((schema as any)[node.type].isVoid) {
+        if ((schema as any)[node.type as string].isVoid) {
           const path = ReactEditor.findPath(editor, node);
           Transforms.insertNodes(editor, create<Paragraph>(
             { type: 'p', children: [{ text: '' }], id: guid() }),
@@ -64,7 +64,7 @@ export const Editor = React.memo((props: EditorProps) => {
   // elements are void
   editor.isVoid = (element) => {
     try {
-      const result = (schema as any)[element.type].isVoid;
+      const result = (schema as any)[element.type as string].isVoid;
       return result;
     } catch (e) {
       return false;
@@ -74,7 +74,7 @@ export const Editor = React.memo((props: EditorProps) => {
 
   editor.isInline = (element) => {
     try {
-      const result = (schema as any)[element.type].isBlock;
+      const result = (schema as any)[element.type as string].isBlock;
       return !result;
     } catch (e) {
       return false;
@@ -107,8 +107,8 @@ export const Editor = React.memo((props: EditorProps) => {
       if (SlateEditor.isBlock(editor, node)) {
         const [parent] = SlateEditor.parent(editor, path);
         if (!SlateEditor.isEditor(parent)) {
-          const config : SchemaConfig = (schema as any)[parent.type];
-          if (!(config.validChildren as any)[node.type]) {
+          const config : SchemaConfig = (schema as any)[parent.type as string];
+          if (!(config.validChildren as any)[node.type as string]) {
             Transforms.removeNodes(editor, { at: path });
             return; // Return here is necessary to enable multi-pass normalization
           }
@@ -117,7 +117,7 @@ export const Editor = React.memo((props: EditorProps) => {
       }
 
       // Check the top-level constraints
-      if (SlateEditor.isBlock(editor, node) && !(schema as any)[node.type].isTopLevel) {
+      if (SlateEditor.isBlock(editor, node) && !(schema as any)[node.type as string].isTopLevel) {
         const [parent] = SlateEditor.parent(editor, path);
         if (SlateEditor.isEditor(parent)) {
           Transforms.removeNodes(editor, { at: path });

--- a/assets/src/components/editor/Editor.tsx
+++ b/assets/src/components/editor/Editor.tsx
@@ -84,6 +84,10 @@ export const Editor = React.memo((props: EditorProps) => {
   const { normalizeNode } = editor;
   editor.normalizeNode = (entry: NodeEntry<Node>) => {
 
+    if ((editor as any).suspendNormalization) {
+      normalizeNode(entry);
+      return;
+    }
 
     try {
       const [node, path] = entry;
@@ -131,6 +135,7 @@ export const Editor = React.memo((props: EditorProps) => {
     }
 
     normalizeNode(entry);
+
   };
 
   const renderElement = useCallback((props) => {

--- a/assets/src/components/editor/Toolbars.tsx
+++ b/assets/src/components/editor/Toolbars.tsx
@@ -188,13 +188,13 @@ const textOptions = [
 const TextFormatter = () => {
   const editor = useSlate();
   const selected = getRootOfText(editor).caseOf({
-    just: n => (parentTextTypes as any)[n.type] ? n.type : 'p',
+    just: n => (parentTextTypes as any)[n.type as string] ? n.type : 'p',
     nothing: () => 'p',
   });
 
   const onChange = (e: any) => {
     getRootOfText(editor).lift((n: Node) => {
-      if ((parentTextTypes as any)[n.type]) {
+      if ((parentTextTypes as any)[n.type as string]) {
         const path = ReactEditor.findPath(editor, n);
         const type = e.target.value;
         Transforms.setNodes(editor, { type }, { at: path });
@@ -206,7 +206,7 @@ const TextFormatter = () => {
   return (
     <select
       onChange={onChange}
-      value={selected}
+      value={selected  as string}
       className="custom-select custom-select-sm">
       {textOptions.map(o =>
         <option key={o.value} value={o.value}>{o.text}</option>)}

--- a/assets/src/components/editor/editors/Lists.tsx
+++ b/assets/src/components/editor/editors/Lists.tsx
@@ -17,25 +17,38 @@ const ul = () => ContentModel.create<ContentModel.UnorderedList>(
 
 const toggleList = (editor: ReactEditor, listType: string) => {
 
-  const isActive = isActiveList(editor);
+  try {
 
-  (editor as any).suspendNormalization = true;
+    // The edits here result in intermediate states that normalization
+    // would seek to correct.  So to allow this operation to succeed,
+    // we instruct our editor instance to suspend normalization.
+    (editor as any).suspendNormalization = true;
 
-  Transforms.unwrapNodes(editor, {
-    match: n => n.type === 'ul' || n.type === 'ol',
-    split: true,
-  });
+    const isActive = isActiveList(editor);
 
-  Transforms.setNodes(editor, {
-    type: isActive ? 'p' : 'li',
-  });
+    Transforms.unwrapNodes(editor, {
+      match: n => n.type === 'ul' || n.type === 'ol',
+      split: true,
+    });
 
-  if (!isActive) {
-    const block = { type: listType, children: [] };
-    Transforms.wrapNodes(editor, block);
+    Transforms.setNodes(editor, {
+      type: isActive ? 'p' : 'li',
+    });
+
+    if (!isActive) {
+      const block = { type: listType, children: [] };
+      Transforms.wrapNodes(editor, block);
+    }
+  } catch (error) {
+    // tslint:disable-next-line
+    console.log(error);
+
+  } finally {
+    // Whether the operation succeeded or failed, we restore
+    // normalization
+    (editor as any).suspendNormalization = false;
   }
 
-  (editor as any).suspendNormalization = false;
 };
 
 const isActiveList = (editor: ReactEditor) => {

--- a/assets/src/components/editor/editors/Lists.tsx
+++ b/assets/src/components/editor/editors/Lists.tsx
@@ -19,6 +19,8 @@ const toggleList = (editor: ReactEditor, listType: string) => {
 
   const isActive = isActiveList(editor);
 
+  (editor as any).suspendNormalization = true;
+
   Transforms.unwrapNodes(editor, {
     match: n => n.type === 'ul' || n.type === 'ol',
     split: true,
@@ -28,8 +30,12 @@ const toggleList = (editor: ReactEditor, listType: string) => {
     type: isActive ? 'p' : 'li',
   });
 
-  const block = { type: listType, children: [] };
-  Transforms.wrapNodes(editor, block);
+  if (!isActive) {
+    const block = { type: listType, children: [] };
+    Transforms.wrapNodes(editor, block);
+  }
+
+  (editor as any).suspendNormalization = false;
 };
 
 const isActiveList = (editor: ReactEditor) => {

--- a/assets/src/components/editor/utils.tsx
+++ b/assets/src/components/editor/utils.tsx
@@ -15,7 +15,7 @@ export function toSimpleText(node: Node): string {
 
 function toSimpleTextHelper(node: Node, text: string): string {
 
-  return node.children.reduce((p: string, c: any) => {
+  return (node.children as any).reduce((p: string, c: any) => {
     let updatedText = p;
     if (c.text) {
       updatedText += c.text;
@@ -38,8 +38,8 @@ export const getRootOfText = (editor: ReactEditor): Maybe<Node> => {
 
       if (node.text === undefined) {
         if (node.type !== undefined) {
-          if ((schema as any)[node.type] !== undefined) {
-            if ((schema as any)[node.type].isBlock) {
+          if ((schema as any)[node.type as string] !== undefined) {
+            if ((schema as any)[node.type as string].isBlock) {
               return Maybe.just(node);
             }
             if (Editor.isEditor(node)) {

--- a/assets/src/components/resource/Outline.tsx
+++ b/assets/src/components/resource/Outline.tsx
@@ -105,8 +105,8 @@ const OutlineEntry = (props: OutlineEntryProps) => {
 
     dt.setData('CodeEditors', resource);
     dt.setData('application/x-oli-resource-content', JSON.stringify(dragPayload));
-    dt.setData('text/html', toSimpleText(content));
-    dt.setData('text/plain', toSimpleText(content));
+    dt.setData('text/html', toSimpleText(content as any));
+    dt.setData('text/plain', toSimpleText(content as any));
     dt.effectAllowed = 'move';
 
   };

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -1503,11 +1503,6 @@
   resolved "https://registry.yarnpkg.com/@types/dateformat/-/dateformat-3.0.1.tgz#98d747a2e5e9a56070c6bf14e27bff56204e34cc"
   integrity sha512-KlPPdikagvL6ELjWsljbyDIPzNCeliYkqRpI+zea99vBBbCIA5JNshZAwQKTON139c87y9qvTFVgkFd14rtS4g==
 
-"@types/debounce@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@types/debounce/-/debounce-1.2.0.tgz#9ee99259f41018c640b3929e1bb32c3dcecdb192"
-  integrity sha512-bWG5wapaWgbss9E238T0R6bfo5Fh3OkeoSt245CM7JJwVwpw6MEBCbIxLq5z8KzsE3uJhzcIuQkyiZmzV3M/Dw==
-
 "@types/esrever@^0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@types/esrever/-/esrever-0.2.0.tgz#96404a2284b2c7527f08a1e957f8a31705f9880f"
@@ -1582,6 +1577,11 @@
   integrity sha512-UKoof2mnV/X1/Ix2g+V2Ny5sgHjV8nK/UJbiYxuo4zPwzGyFlZ/mp4KaePb2VqQrqJctmcDQNA57buU84/2uIw==
   dependencies:
     "@types/sizzle" "*"
+
+"@types/lodash@^4.14.149":
+  version "4.14.154"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.154.tgz#069e3c703fdb264e67be9e03b20a640bc0198ecc"
+  integrity sha512-VoDZIJmg3P8vPEnTldLvgA+q7RkIbVkbYX4k0cAVFzGAOQwUehVgRHgIr2/wepwivDst/rVRqaiBSjCXRnoWwQ==
 
 "@types/minimatch@*":
   version "3.0.3"
@@ -3274,11 +3274,6 @@ dateformat@3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.2.tgz#9a4df4bff158ac2f34bc637abdb15471607e1659"
   integrity sha1-mk30v/FYrC80vGN6vbFUcWB+Flk=
-
-debounce@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.0.tgz#44a540abc0ea9943018dc0eaa95cce87f65cd131"
-  integrity sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==
 
 debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
@@ -5631,7 +5626,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.0.0, lodash@^4.17.13, lodash@^4.17.15, lodash@^4.17.5, lodash@^4.2.1, lodash@~4.17.12:
+lodash@^4.0.0, lodash@^4.17.13, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@~4.17.12:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -7977,31 +7972,31 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
-slate-history@^0.57.1:
-  version "0.57.1"
-  resolved "https://registry.yarnpkg.com/slate-history/-/slate-history-0.57.1.tgz#2938537f3f95768a69460ec5035be0333216c278"
-  integrity sha512-pSUmGcIzFJ1ClaF2S5dFm7TBS30ZG3sqkwAowTxvD0+jafG/2I3N6M6M0anhkgBEGMU1rdNQqX4O6b/qKUJPgg==
+slate-history@^0.58.1:
+  version "0.58.1"
+  resolved "https://registry.yarnpkg.com/slate-history/-/slate-history-0.58.1.tgz#ffcfa99608bd725340ff57ece3016660c3144e47"
+  integrity sha512-a+6fk8B36virDLQeR33azOzJhXFuh7uEGBMXA7JMaX9yYT1I4bUuNu/hHQkzPiBPRUlFKKm2fIftsCBTE1lIig==
   dependencies:
     immer "^5.0.0"
     is-plain-object "^3.0.0"
 
-slate-react@^0.57.1:
-  version "0.57.1"
-  resolved "https://registry.yarnpkg.com/slate-react/-/slate-react-0.57.1.tgz#219a95b7caaea365a7f6fac5f3f5aa2e9da62295"
-  integrity sha512-W+M+YEcqBvuJD2xoU1gKgGbvhv6shwYJ5OOjPF8ZPEokUvGJh81Egxf65ZnnKxJejodsERdlwc2rRjpRphx2LQ==
+slate-react@^0.58.1:
+  version "0.58.2"
+  resolved "https://registry.yarnpkg.com/slate-react/-/slate-react-0.58.2.tgz#6c88542cd20cccf8c0f27d7c0451cb4716edce9c"
+  integrity sha512-wc2i8xZJ4THpgGa39FsiNsi72flZr17IgUuM5JlyIB6vO+1wGGpJNe6gh4IvuAqHM2H/oiT5wwNKpiikALfMOw==
   dependencies:
-    "@types/debounce" "^1.2.0"
     "@types/is-hotkey" "^0.1.1"
-    debounce "^1.2.0"
+    "@types/lodash" "^4.14.149"
     direction "^1.0.3"
     is-hotkey "^0.1.6"
     is-plain-object "^3.0.0"
+    lodash "^4.17.4"
     scroll-into-view-if-needed "^2.2.20"
 
-slate@^0.57.1:
-  version "0.57.1"
-  resolved "https://registry.yarnpkg.com/slate/-/slate-0.57.1.tgz#dc99d9a77840894c9e3d3bc1185b67ee36c17686"
-  integrity sha512-av95C0zbsi0+khfOuyQlpZy0Q3Pqqh0loCusGGi0Wlb/J8OUBAyK/a5EgTfE0zK4pmjtEBnPksfBuVilg5jrNg==
+slate@^0.58.1:
+  version "0.58.1"
+  resolved "https://registry.yarnpkg.com/slate/-/slate-0.58.1.tgz#3fdd9cb58d1b840b0361bbd01c32f3a0d31b5da2"
+  integrity sha512-2Vj1jfzHQ/X4t23iKaWoEw09iuIo1oYIsl2tZjZTEl61VNwFEIZkjzI5yuyGS4x0QnUMbNtMoOCeJQx8HxHvdw==
   dependencies:
     "@types/esrever" "^0.2.0"
     esrever "^0.2.0"


### PR DESCRIPTION
This PR allows the ordered and unordered list buttons to toggle the list state of the current selection.

The interesting aspect of this work (which was not obvious and hard to track down) was that our editor normalization code will seek to adjust the intermediate states that this code introduces.  I see no way in the Slate API to suspend normalization - so I have essentially added that by allowing client code to set `(editor as any).suspendNormalization = true` which suspends all custom normalization until set to `false`

I took this opportunity to upgraded us to the latest Slate version as well.

Closes #176 