### PR TITLE
fix typo

### DIFF
--- a/lib/oli_web/templates/project/_review.html.eex
+++ b/lib/oli_web/templates/project/_review.html.eex
@@ -132,7 +132,7 @@ a.review-dismiss:hover {
   <div class="row">
     <p>
       When the review was run <%= (hd @qa_reviews).inserted_at |> Timex.format!("{relative}", :relative) %>,
-      it found <strong><%= length @warnings %></strong> potential improvement opportunities<%= if (length @warnings) == 1 do "" else "s" end %>:
+      it found <strong><%= length @warnings %></strong> potential improvement <%= if (length @warnings) == 1 do "opportunity" else "opportunities" end %>:
     </p>
   </div>
 


### PR DESCRIPTION
I changed the wording on the qa review section of the publish page but didn't notice a typo before I made the pr