### PR TITLE
Restore history

### DIFF
--- a/lib/oli/accounts.ex
+++ b/lib/oli/accounts.ex
@@ -3,7 +3,7 @@ defmodule Oli.Accounts do
   import Ecto.Query, warn: false
 
   alias Oli.Repo
-  alias Oli.Accounts.{User, Author, Institution, LtiToolConsumer}
+  alias Oli.Accounts.{User, Author, Institution, LtiToolConsumer, SystemRole}
 
   @doc """
   Returns the list of users.
@@ -102,10 +102,18 @@ defmodule Oli.Accounts do
   end
 
   @doc """
-  Returns true if a author is signed in
+  Returns true if an author is signed in
   """
   def user_signed_in?(conn) do
     conn.assigns[:current_user]
+  end
+
+
+  @doc """
+  Returns true if an author is an administrator.
+  """
+  def is_admin?(%Author{system_role_id: system_role_id}) do
+    SystemRole.role_id.admin == system_role_id
   end
 
   @doc """

--- a/lib/oli/authoring/broadcaster.ex
+++ b/lib/oli/authoring/broadcaster.ex
@@ -1,0 +1,16 @@
+defmodule Oli.Authoring.Broadcaster do
+
+  alias Phoenix.PubSub
+
+  @doc """
+  Broadcasts resource and project specific message indicating the creation or editing
+  of a revision by an authoring component.
+  """
+  def broadcast_revision(revision, project_slug) do
+    PubSub.broadcast Oli.PubSub, "resource:" <> Integer.to_string(revision.resource_id),
+      {:updated, revision, project_slug}
+    PubSub.broadcast Oli.PubSub, "resource:" <> Integer.to_string(revision.resource_id) <> ":project:" <> project_slug,
+      {:updated, revision, project_slug}
+  end
+
+end

--- a/lib/oli/authoring/editing/container_editor.ex
+++ b/lib/oli/authoring/editing/container_editor.ex
@@ -15,7 +15,7 @@ defmodule Oli.Authoring.Editing.ContainerEditor do
   alias Oli.Publishing.ChangeTracker
   alias Oli.Authoring.Editing.PageEditor
   alias Oli.Repo
-  alias Phoenix.PubSub
+  alias Oli.Authoring.Broadcaster
 
   @spec edit_page(Oli.Authoring.Course.Project.t(), any, map) :: any
   def edit_page(%Project{} = project, revision_slug, change) do
@@ -38,10 +38,7 @@ defmodule Oli.Authoring.Editing.ContainerEditor do
       case Resources.update_revision(revision, change) do
         {:ok, revision} ->
 
-          PubSub.broadcast Oli.PubSub, "resource:" <> Integer.to_string(revision.resource_id),
-            {:updated, revision, project.slug}
-          PubSub.broadcast Oli.PubSub, "resource:" <> Integer.to_string(revision.resource_id) <> ":project:" <> project.slug,
-            {:updated, revision, project.slug}
+          Broadcaster.broadcast_revision(revision, project.slug)
 
           revision
 
@@ -115,11 +112,8 @@ defmodule Oli.Authoring.Editing.ContainerEditor do
   def broadcast_update(resource_id, project_slug) do
 
     updated_container = AuthoringResolver.from_resource_id(project_slug, resource_id)
+    Broadcaster.broadcast_revision(updated_container, project_slug)
 
-    PubSub.broadcast Oli.PubSub, "resource:" <> Integer.to_string(resource_id),
-      {:updated, updated_container, project_slug}
-    PubSub.broadcast Oli.PubSub, "resource:" <> Integer.to_string(resource_id) <> ":project:" <> project_slug,
-      {:updated, updated_container, project_slug}
   end
 
 
@@ -240,10 +234,7 @@ defmodule Oli.Authoring.Editing.ContainerEditor do
 
       updated_container = Oli.Repo.get(Oli.Resources.Revision, container.id)
 
-      PubSub.broadcast Oli.PubSub, "resource:" <> Integer.to_string(container.resource_id),
-        {:updated, updated_container, project.slug}
-      PubSub.broadcast Oli.PubSub, "resource:" <> Integer.to_string(container.resource_id) <> ":project:" <> project.slug,
-        {:updated, updated_container, project.slug}
+      Broadcaster.broadcast_revision(updated_container, project.slug)
 
       result
 

--- a/lib/oli/resources.ex
+++ b/lib/oli/resources.ex
@@ -273,7 +273,11 @@ defmodule Oli.Resources do
       resource_id: previous_revision.resource_id,
       previous_revision_id: previous_revision.id,
       resource_type_id: previous_revision.resource_type_id,
-      activity_type_id: previous_revision.activity_type_id
+      activity_type_id: previous_revision.activity_type_id,
+      scoring_strategy_id: previous_revision.scoring_strategy_id,
+      max_attempts: previous_revision.max_attempts,
+      recommended_attempts: previous_revision.recommended_attempts,
+      time_limit: previous_revision.time_limit
     }, attrs)
 
     create_revision(attrs)

--- a/lib/oli/resources/revision.ex
+++ b/lib/oli/resources/revision.ex
@@ -6,6 +6,11 @@ defmodule Oli.Resources.Revision do
 
   schema "revisions" do
 
+    #
+    # NOTE: any field additions made here should be made also
+    # in `Oli.Resources.create_revision_from_previous`
+    #
+
     # fields that apply to all types
     field :title, :string
     field :slug, :string

--- a/lib/oli_web/controllers/activity_controller.ex
+++ b/lib/oli_web/controllers/activity_controller.ex
@@ -2,6 +2,7 @@ defmodule OliWeb.ActivityController do
   use OliWeb, :controller
 
   alias Oli.Authoring.Editing.ActivityEditor
+  alias Oli.Accounts
   alias Oli.Delivery.Attempts
   alias Oli.Delivery.Attempts.StudentInput
 
@@ -12,8 +13,11 @@ defmodule OliWeb.ActivityController do
 
   def edit(conn, %{"project_id" => project_slug, "revision_slug" => revision_slug, "activity_slug" => activity_slug}) do
 
-    case ActivityEditor.create_context(project_slug, revision_slug, activity_slug, conn.assigns[:current_author]) do
-      {:ok, context} -> render(conn, "edit.html", title: "Activity Editor", script: context.authoringScript, context: Jason.encode!(context))
+    author = conn.assigns[:current_author]
+    is_admin? = Accounts.is_admin?(author)
+
+    case ActivityEditor.create_context(project_slug, revision_slug, activity_slug, author) do
+      {:ok, context} -> render(conn, "edit.html", title: "Activity Editor", project_slug: project_slug, is_admin?: is_admin?, activity_slug: activity_slug, script: context.authoringScript, context: Jason.encode!(context))
       {:error, :not_found} -> render conn, OliWeb.SharedView, "_not_found.html"
     end
 

--- a/lib/oli_web/controllers/resource_controller.ex
+++ b/lib/oli_web/controllers/resource_controller.ex
@@ -4,6 +4,7 @@ defmodule OliWeb.ResourceController do
   alias Oli.Authoring.Editing.PageEditor
   alias Oli.Authoring.Editing.ContainerEditor
   alias Oli.Authoring.Course
+  alias Oli.Accounts
   alias Oli.Activities
   alias Oli.Publishing.AuthoringResolver
 
@@ -41,8 +42,11 @@ defmodule OliWeb.ResourceController do
 
   def edit(conn, %{"project_id" => project_slug, "revision_slug" => revision_slug}) do
 
-    case PageEditor.create_context(project_slug, revision_slug, conn.assigns[:current_author]) do
-      {:ok, context} -> render(conn, "edit.html", title: "Page Editor", context: Jason.encode!(context), scripts: get_scripts(), project_slug: project_slug, revision_slug: revision_slug)
+    author = conn.assigns[:current_author]
+    is_admin? = Accounts.is_admin?(author)
+
+    case PageEditor.create_context(project_slug, revision_slug, author) do
+      {:ok, context} -> render(conn, "edit.html", title: "Page Editor", is_admin?: is_admin?, context: Jason.encode!(context), scripts: get_scripts(), project_slug: project_slug, revision_slug: revision_slug)
       {:error, :not_found} ->
         conn
         |> put_view(OliWeb.SharedView)

--- a/lib/oli_web/live/history/details.ex
+++ b/lib/oli_web/live/history/details.ex
@@ -3,20 +3,44 @@ defmodule OliWeb.RevisionHistory.Details do
   import Phoenix.HTML
 
   def render(assigns) do
+
+    attrs = ~w"slug deleted author_id previous_revision_id resource_type_id graded max_attempts time_limit scoring_strategy_id activity_type_id"
+
     ~L"""
-    <p><strong>Title: </strong> &quot;<%= @revision.title %>&quot;</p>
-    <p><strong>Content: </strong></p>
-    <code>
-      <pre style="background-color: #EEEEEE;">
-      <%= raw(Jason.encode!(@revision.content) |> Jason.Formatter.pretty_print()) %>
-      </pre>
-    </code>
-    <p><strong>Objectives: </strong></p>
-    <code>
-      <pre style="background-color: #EEEEEE;">
-      <%= raw(Jason.encode!(@revision.objectives) |> Jason.Formatter.pretty_print()) %>
-      </pre>
-    </code>
+    <table class="table table-bordered table-sm">
+      <thead class="thead-dark">
+        <tr><th style="width:100px;">Attribute</th><th>Value</th></tr>
+      </thead>
+      <tbody>
+        <tr><td style="width:100px;"><strong>Title</strong></td><td><%= @revision.title %></td></tr>
+        <tr>
+          <td style="width:100px;"><strong>Objectives</strong></td>
+          <td>
+            <code>
+            <pre style="background-color: #EEEEEE;">
+            <%= raw(Jason.encode!(@revision.objectives) |> Jason.Formatter.pretty_print()) %>
+            </pre>
+            </code>
+          </td>
+        </tr>
+        <tr>
+          <td style="width:100px;"><strong>Content</strong></td>
+          <td>
+            <code>
+            <pre style="background-color: #EEEEEE;">
+            <%= raw(Jason.encode!(@revision.content) |> Jason.Formatter.pretty_print()) %>
+            </pre>
+            </code>
+          </td>
+        </tr>
+        <%= for k <- attrs do %>
+          <tr>
+          <td style="width:100px;"><strong><%= k %></strong></td>
+          <td><%= Map.get(@revision, String.to_atom(k)) %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
     """
   end
 end

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -254,7 +254,11 @@ defmodule OliWeb.Router do
   scope "/admin", OliWeb do
     pipe_through [:browser, :csrf_always, :protected, :admin]
     live_dashboard "/dashboard", metrics: OliWeb.Telemetry
-    live "/history/:slug", RevisionHistory
+  end
+
+  scope "/project", OliWeb do
+    pipe_through [:browser, :csrf_always, :protected, :workspace, :authoring, :authorize_project, :admin]
+    live "/:project_id/history/:slug", RevisionHistory
   end
 
   # routes only accessible to developers

--- a/lib/oli_web/templates/activity/edit.html.eex
+++ b/lib/oli_web/templates/activity/edit.html.eex
@@ -4,6 +4,7 @@
 
 <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/" <> @script) %>"></script>
 
+<%= render OliWeb.SharedView, "_admin_edit_banner.html", %{is_admin?: @is_admin?, project_slug: @project_slug, revision_slug: @activity_slug} %>
 
 <div id="editor" class="container"/>
 

--- a/lib/oli_web/templates/layout/authoring.html.leex
+++ b/lib/oli_web/templates/layout/authoring.html.leex
@@ -38,6 +38,9 @@
     <script>
     window.$ = $;
     $('.dropdown-toggle').dropdown();
+    $(function () {
+      $('[data-toggle="tooltip"]').tooltip();
+    });
     </script>
   </body>
 </html>

--- a/lib/oli_web/templates/resource/edit.html.eex
+++ b/lib/oli_web/templates/resource/edit.html.eex
@@ -5,6 +5,8 @@
   <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/" <> script) %>"></script>
 <% end %>
 
+<%= render OliWeb.SharedView, "_admin_edit_banner.html", %{is_admin?: @is_admin?, project_slug: @project_slug, revision_slug: @revision_slug} %>
+
 <div id="editor" class="container"/>
 
 <script>

--- a/lib/oli_web/templates/shared/_admin_edit_banner.html.eex
+++ b/lib/oli_web/templates/shared/_admin_edit_banner.html.eex
@@ -1,0 +1,17 @@
+
+<%= if @is_admin? do %>
+  <div class="alert alert-warning alert-dismissible fade show" style="position: sticky; top: 0px; z-index: 900;" role="alert">
+  <strong>You are editing as an administrator</strong>
+
+  <span style="float: right;">
+    <%= link class: "toolbar-link", to: Routes.live_path(OliWeb.Endpoint, OliWeb.RevisionHistory, @project_slug,@revision_slug) do %>
+      <span><i class="fas fa-history"></i></span> View History
+    <% end %>
+  </span>
+
+  <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+    <span aria-hidden="true">&times;</span>
+  </button>
+
+</div>
+<% end %>

--- a/test/oli/editing/activity_editor_test.exs
+++ b/test/oli/editing/activity_editor_test.exs
@@ -26,6 +26,7 @@ defmodule Oli.ActivityEditingTest do
 
       # Verify that we can issue a resource edit that attaches the activity
       update = %{ "content" => %{ "model" => [%{ "type" => "activity-reference", "id" => 1, "activitySlug" => slug, "purpose" => "none"}]}}
+      PageEditor.acquire_lock(project.slug, revision.slug, author.email)
       assert {:ok, updated_revision} =  PageEditor.edit(project.slug, revision.slug, author.email, update)
 
       # Verify that the slug was translated to the correct activity id
@@ -57,6 +58,7 @@ defmodule Oli.ActivityEditingTest do
 
       # Verify that we can issue a resource edit that attaches the activity
       update = %{ "content" => %{ "model" => [%{ "type" => "activity-reference", "id" => 1, "activitySlug" => slug, "purpose" => "none"}]}}
+      PageEditor.acquire_lock(project.slug, revision.slug, author.email)
       assert {:ok, _} =  PageEditor.edit(project.slug, revision.slug, author.email, update)
 
       update = %{ "title" => "edited title"}
@@ -81,6 +83,7 @@ defmodule Oli.ActivityEditingTest do
 
       # attach the activity
       update = %{ "content" => %{ "model" => [%{ "type" => "activity-reference", "id" => 1, "activitySlug" => slug_1, "purpose" => "none"}]}}
+      PageEditor.acquire_lock(project.slug, revision.slug, author.email)
       assert {:ok, %{slug: revision_slug}} =  PageEditor.edit(project.slug, revision.slug, author.email, update)
 
       # create the activity context
@@ -109,6 +112,7 @@ defmodule Oli.ActivityEditingTest do
 
       # attach just one activity
       update = %{ "content" => %{ "model" => [%{ "type" => "activity-reference", "id" => 1, "activitySlug" => slug_1, "purpose" => "none"}]}}
+      PageEditor.acquire_lock(project.slug, revision.slug, author.email)
       assert {:ok, _} =  PageEditor.edit(project.slug, revision.slug, author.email, update)
 
       # create the activity context
@@ -215,6 +219,7 @@ defmodule Oli.ActivityEditingTest do
     test "attaching an unknown activity to a resource fails", %{author: author, project: project, revision1: revision } do
 
       update = %{ "content" => %{ "model" => [%{ "type" => "activity-reference", "id" => 1, "activitySlug" => "missing", "purpose" => "none"}]}}
+      PageEditor.acquire_lock(project.slug, revision.slug, author.email)
       assert {:error, :not_found} =  PageEditor.edit(project.slug, revision.slug, author.email, update)
 
     end
@@ -232,6 +237,7 @@ defmodule Oli.ActivityEditingTest do
       # Delete one of the activity parts
       update = %{ "objectives" => %{ "1" => [ ob1.slug ], "2" => [ ob2.slug ]  },
         "content" => %{"authoring" => %{"parts" => [%{"id" => "1" }]}}}
+      PageEditor.acquire_lock(project.slug, revision.slug, author.email)
       {:ok, updated} = ActivityEditor.edit(project.slug, revision.slug, revision.slug, author.email, update)
 
       # Verify that the objective tied to that part has been removed as well

--- a/test/oli/editing/page_editor_test.exs
+++ b/test/oli/editing/page_editor_test.exs
@@ -18,6 +18,7 @@ defmodule Oli.EditingTest do
     test "edit/4 creates a new revision when no lock in place", %{author: author, revision1: revision1, project: project } do
 
       content = %{ "model" => [%{"type" => "p", children: [%{ "text" => "A paragraph."}] }]}
+      PageEditor.acquire_lock(project.slug, revision1.slug, author.email)
       {:ok, updated_revision} = PageEditor.edit(project.slug, revision1.slug, author.email, %{ "content" => content })
 
       assert revision1.id != updated_revision.id
@@ -27,7 +28,7 @@ defmodule Oli.EditingTest do
 
       content = %{ "model" => [%{ "type" => "p", children: [%{ "text" => "A paragraph."}] }] }
       title = "a new title"
-
+      PageEditor.acquire_lock(project.slug, revision1.slug, author.email)
       {:ok, updated_revision} = PageEditor.edit(project.slug, revision1.slug, author.email, %{ "title" => title, "content" => content })
 
       # read it back from the db and verify both edits were made
@@ -40,7 +41,7 @@ defmodule Oli.EditingTest do
     test "edit/4 can handle string keys in the update map", %{author: author, revision1: revision1, project: project} do
 
       title = "a new title"
-
+      PageEditor.acquire_lock(project.slug, revision1.slug, author.email)
       {:ok, updated_revision} = PageEditor.edit(project.slug, revision1.slug, author.email, %{ "title" => title })
 
       # read it back from the db and verify both edits were made
@@ -56,6 +57,7 @@ defmodule Oli.EditingTest do
       |> Publishing.update_resource_mapping(%{lock_updated_at: Time.now(), locked_by_id: author.id})
 
       content = %{ "model" => [%{ "type" => "p", children: [%{ "text" => "A paragraph."}] }] }
+
       {:ok, updated_revision} = PageEditor.edit(project.slug, revision1.slug, author.email, %{ "content" => content })
 
       assert revision1.id == updated_revision.id
@@ -68,6 +70,7 @@ defmodule Oli.EditingTest do
       |> Publishing.update_resource_mapping(%{lock_updated_at: yesterday(), locked_by_id: author.id})
 
       content = %{ "model" => [%{ "type" => "p", children: [%{ "text" => "A paragraph."}] }] }
+      PageEditor.acquire_lock(project.slug, revision1.slug, author.email)
       {:ok, updated_revision} = PageEditor.edit(project.slug, revision1.slug, author.email, %{ "content" => content })
 
       assert revision1.id != updated_revision.id
@@ -80,6 +83,7 @@ defmodule Oli.EditingTest do
 
       # now try to make the edit with the original user
       content = %{ "model" => [%{ "type" => "p", children: [%{ "text" => "A paragraph."}] }] }
+      PageEditor.acquire_lock(project.slug, revision1.slug, author.email)
       result = PageEditor.edit(project.slug, revision1.slug, author.email, %{ "content" => content })
 
       id = author2.id

--- a/test/oli/publishing_test.exs
+++ b/test/oli/publishing_test.exs
@@ -69,6 +69,7 @@ defmodule Oli.PublishingTest do
 
       # further edits to the locked resource should occur in a new revision
       content = %{"model" => [%{ "type" => "p", children: [%{ "text" => "A paragraph."}] }] }
+      PageEditor.acquire_lock(project.slug, revision.slug, author.email)
       {:ok, updated_revision} = PageEditor.edit(project.slug, revision.slug, author.email, %{ content: content })
       assert revision.id != updated_revision.id
 
@@ -138,6 +139,7 @@ defmodule Oli.PublishingTest do
 
         # make some edits
         content = %{"model" => [%{ "type" => "p", children: [%{ "text" => "A paragraph."}] }]}
+        PageEditor.acquire_lock(project.slug, revision.slug, author.email)
         {:ok, _updated_revision} = PageEditor.edit(project.slug, revision.slug, author.email, %{content: content})
 
         # add another resource
@@ -153,6 +155,7 @@ defmodule Oli.PublishingTest do
         Publishing.upsert_published_resource(p2, r4_revision)
 
         # delete a resource
+        PageEditor.acquire_lock(project.slug, r3_revision.slug, author.email)
         {:ok, _updated_revision} = PageEditor.edit(project.slug, r3_revision.slug, author.email, %{deleted: true})
 
         # generate diff

--- a/test/oli_web/controllers/resource_controller_test.exs
+++ b/test/oli_web/controllers/resource_controller_test.exs
@@ -1,6 +1,8 @@
 defmodule OliWeb.ResourceControllerTest do
   use OliWeb.ConnCase
 
+  alias Oli.Authoring.Editing.PageEditor
+
   setup [:project_seed]
 
   describe "edit" do
@@ -17,7 +19,9 @@ defmodule OliWeb.ResourceControllerTest do
   end
 
   describe "update resource" do
-    test "valid response on valid update", %{conn: conn, project: project, revision1: revision} do
+    test "valid response on valid update", %{conn: conn, project: project, revision1: revision, author: author} do
+
+      PageEditor.acquire_lock(project.slug, revision.slug, author.email)
       conn = put(conn, Routes.resource_path(conn, :update, project.slug, revision.slug, %{ "update" => %{"title" => "new title" }}))
       assert %{ "type" => "success" } = json_response(conn, 200)
     end


### PR DESCRIPTION
This PR adds functionality to restore a previous revision from the history viewer. It also adjusts the display of the history viewer to make it more easily accessible for an administrator. 

I caught a bug also that new revisions were not correctly setting the previous_revision_id.  This is fixed in this PR. 

NOTE, this PR changes a core assumption about resource locking via the `PageEditor`.  With this change in place a call to `edit` in the `PageEditor` will now fail if the lock is absent (nil).  Previously the logic will silently reacquire the lock.  This is dangerous behavior since this state could exist because user A was editing and lost the lock due to inactivity, then user B gains the lock and makes an edit and releases the lock.  That would leave the lock empty and the next edit made by A would OVERWRITE the most recent changes made by B.  The `PageEditor` now returns a failure message to the client in this case - which forces them to refresh to see the latest content. 

