### PR TITLE
convert dropdown button to use popover

### DIFF
--- a/assets/src/components/editor/Toolbars.tsx
+++ b/assets/src/components/editor/Toolbars.tsx
@@ -5,6 +5,7 @@ import { Editor as SlateEditor, Node, Range, Transforms } from 'slate';
 import { hoverMenuCommands } from './editors';
 import { ToolbarItem, gutterWidth, CommandContext } from './interfaces';
 import { getRootOfText } from './utils';
+import Popover from 'react-tiny-popover';
 
 const parentTextTypes = {
   p: true,
@@ -263,32 +264,37 @@ const ToolbarButton = ({ icon, command, style, context, tooltip }: any) => {
   );
 };
 
+
 const DropdownToolbarButton = ({ icon, command, style, context, tooltip }: any) => {
+
   const editor = useSlate();
+  const [isPopoverOpen, setIsPopoverOpen] = React.useState(false);
 
-  const ref = useRef();
-
-  useEffect(() => {
-    if (ref !== null && ref.current !== null) {
-      ((window as any).$('.dropdown-toggle') as any).dropdown();
-    }
-  });
-
-  const onDone = (params: any) => command.execute(context, editor, params);
-  const onCancel = () => {};
+  const onDone = (params: any) => {
+    setIsPopoverOpen(false);
+    command.execute(context, editor, params);
+  };
+  const onCancel = () => setIsPopoverOpen(false);
 
   return (
-    <div ref={ref as any} className="dropdown"
-      data-toggle="tooltip" data-placement="top" title={tooltip}>
-      <button
-        className={`btn btn-sm dropdown-toggle ${style}`}
-        data-toggle={'dropdown'}
+    <Popover
+      onClickOutside={() => {
+        setIsPopoverOpen(false);
+      }}
+      isOpen={isPopoverOpen}
+      padding={5}
+      position={['bottom', 'top', 'left', 'right']}
+      content={() => (command as any).obtainParameters(editor, onDone, onCancel)}>
+      {ref => <button
+        ref={ref}
+        data-toggle="tooltip" data-placement="top" title={tooltip}
+        className={`btn btn-sm ${style}`}
+        onClick={() => setIsPopoverOpen(!isPopoverOpen)}
         type="button">
         <i className={icon}></i>
-      </button>
-      <div className="dropdown-menu dropdown-menu-right">
-        {(command as any).obtainParameters(editor, onDone, onCancel)}
-      </div>
-    </div>
+      </button>}
+    </Popover>
   );
+
 };
+

--- a/assets/src/components/editor/editors/SizePicker.tsx
+++ b/assets/src/components/editor/editors/SizePicker.tsx
@@ -78,16 +78,14 @@ export const SizePicker = (props: SizePickerProps) => {
   const gridStyle = {
     height,
     width,
-    paddingLeft: '10px',
-    zIndex: 999,
-    opacity: .99,
+    paddingLeft: '5px',
+    backgroundColor: '#f0f0f0',
   } as any;
 
   const labelStyle = {
     width,
-    color: '#DDDDDD',
+    color: '#808080',
     textAlign: 'center',
-
   } as any;
 
 

--- a/assets/src/components/editor/editors/Table.tsx
+++ b/assets/src/components/editor/editors/Table.tsx
@@ -8,6 +8,7 @@ import { EditorProps } from './interfaces';
 import guid from 'utils/guid';
 import { LabelledTextEditor } from 'components/TextEditor';
 import { SizePicker } from './SizePicker';
+import Popover from 'react-tiny-popover';
 
 // Helper functions for creating tables and its parts
 const td = (text: string) => ContentModel.create<ContentModel.TableData>(
@@ -44,6 +45,7 @@ const command: Command = {
 
   obtainParameters: (editor: ReactEditor,
     onDone: (params: any) => void, onCancel: () => void) => {
+
     return <SizePicker onHide={onCancel}
       onTableCreate={(rows, columns) => onDone({ rows, columns })} />;
   },

--- a/assets/src/components/resource/toolbar.ts
+++ b/assets/src/components/resource/toolbar.ts
@@ -10,6 +10,10 @@ import { commandDesc as tableCommandDesc } from '../editor/editors/Table';
 import { ResourceType } from 'data/content/resource';
 
 const toolbarItems: ToolbarItem[] = [
+  tableCommandDesc,
+  {
+    type: 'GroupDivider',
+  },
   quoteCommandDesc,
   {
     type: 'GroupDivider',
@@ -26,7 +30,6 @@ const toolbarItems: ToolbarItem[] = [
     type: 'GroupDivider',
   },
   codeCommandDesc,
-  tableCommandDesc,
 ];
 
 export function getToolbarForResourceType(resourceType: ResourceType) : ToolbarItem[] {


### PR DESCRIPTION
This PR fixes the table creation size picker z-index problem.  

Unfortunately, the only solution I could come up with was to replace the bootstrap dropdown with a react-tiny-popover instance. 

Closes #232 

