### PR TITLE
paginate table display

### DIFF
--- a/lib/oli_web/live/history/pagination.ex
+++ b/lib/oli_web/live/history/pagination.ex
@@ -1,0 +1,37 @@
+defmodule OliWeb.RevisionHistory.Pagination do
+  use Phoenix.LiveComponent
+
+  alias OliWeb.RevisionHistory.PaginationLink
+  defp render_none(assigns) do
+    ~L"""
+    <div></div>
+    """
+  end
+
+  def render(assigns) do
+
+    count = length(assigns.revisions)
+    page_size = assigns.page_size
+
+    if count > page_size do
+
+      total_pages = div(count, page_size) + if rem(count, page_size) == 0 do 0 else 1 end
+      current_page = div(assigns.page_offset, page_size) + 1
+
+      ~L"""
+      <nav aria-label="table results paging">
+        <ul class="pagination justify-content-center">
+          <%= for page <- 1..total_pages do %>
+            <%= live_component @socket, PaginationLink, page_ordinal: page, active: current_page == page, page_offset: @page_offset %>
+          <% end %>
+        </ul>
+      </nav>
+      """
+
+    else
+      render_none(assigns)
+    end
+
+  end
+
+end

--- a/lib/oli_web/live/history/pagination_link.ex
+++ b/lib/oli_web/live/history/pagination_link.ex
@@ -1,0 +1,15 @@
+defmodule OliWeb.RevisionHistory.PaginationLink do
+  use Phoenix.LiveComponent
+
+  def render(assigns) do
+
+    str = Integer.to_string(assigns.page_ordinal)
+
+    ~L"""
+    <li class="page-item <%= if @active do "active" else "" end %>">
+      <a class="page-link" href="#" phx-click="page" phx-value-ordinal="<%= str %>"><%= str %></a>
+    </li>
+    """
+  end
+
+end

--- a/lib/oli_web/live/history/table.ex
+++ b/lib/oli_web/live/history/table.ex
@@ -2,13 +2,17 @@ defmodule OliWeb.RevisionHistory.Table do
   use Phoenix.LiveComponent
 
   def render(assigns) do
+
+    range = Range.new(assigns.page_offset, assigns.page_offset + assigns.page_size)
+    to_display = Enum.slice(assigns.revisions, range)
+
     ~L"""
     <table class="table table-hover table-bordered table-sm">
       <thead class="thead-dark">
         <tr><th>Id</th><th>Created</th><th>Updated</th><th>Author</th><th>Graded</th><th>Attempts</th><th>Slug</th></tr>
       </thead>
-      <tbody id="revisions" phx-update="prepend">
-      <%= for rev <- @revisions do %>
+      <tbody id="revisions">
+      <%= for rev <- to_display do %>
         <%= if rev == @selected do %>
         <tr id="<%= rev.id %>" class="table-active">
         <% else %>


### PR DESCRIPTION
This PR adds pagination support for the tabular display in the revision history tool. 

Pagination will be necessary in production where we could expect hundreds of revisions to be present for a resource. 