### PR TITLE
set deleted flag on activity revision during page edits

### DIFF
--- a/lib/oli/authoring/editing/util.ex
+++ b/lib/oli/authoring/editing/util.ex
@@ -15,4 +15,28 @@ defmodule Oli.Authoring.Editing.Utils do
       _ -> {:ok, result}
     end
   end
+
+  @doc """
+  Calculates the difference in the activities references between
+  two pieces of content.
+
+  Returns a two element tuple, the first element being a mapset of
+  the resource ids of activities are present in content2 but were
+  not found in content1, and the second being a mapset of the resource
+  ids of activities not found in content2 but there were found in content1
+  """
+  def diff_activity_references(content1, content2) do
+
+    get_activities = fn content -> Enum.filter(content, fn %{"type" => type} -> type == "activity-reference" end)
+    |> Enum.map(fn %{"activity_id" => id} -> id end)
+    |> MapSet.new() end
+
+    activities1 = get_activities.(content1)
+    activities2 = get_activities.(content2)
+
+    {MapSet.difference(activities2, activities1), MapSet.difference(activities1, activities2)}
+  end
+
+
+
 end

--- a/test/oli/delivery/evaluation/parser_test.exs
+++ b/test/oli/delivery/evaluation/parser_test.exs
@@ -1,6 +1,6 @@
 defmodule Oli.Delivery.Evaluation.ParserTest do
 
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   defp parse(input), do: Oli.Delivery.Evaluation.Rule.parse(input)
 

--- a/test/oli/delivery/evaluation/rule_eval_test.exs
+++ b/test/oli/delivery/evaluation/rule_eval_test.exs
@@ -1,6 +1,6 @@
 defmodule Oli.Delivery.Evaluation.RuleEvalTest do
 
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias Oli.Delivery.Evaluation.Rule
   alias Oli.Delivery.Evaluation.EvaluationContext

--- a/test/oli/editing/utils_test.exs
+++ b/test/oli/editing/utils_test.exs
@@ -1,0 +1,69 @@
+defmodule Oli.Authoring.Editing.UtilsTest do
+
+  use ExUnit.Case, async: true
+  alias Oli.Authoring.Editing.Utils
+
+  describe "diffing content for activity reference changes" do
+
+    test "diff_activity_references/2 finds additions and removals", _ do
+
+      content1 =  [
+        %{"type" => "content", children: [%{ "text" => "A paragraph."}] },
+        %{"type" => "activity-reference", "activity_id" => 1 }
+      ]
+
+      content2 =  [
+        %{"type" => "content", children: [%{ "text" => "A paragraph."}] },
+        %{"type" => "activity-reference", "activity_id" => 2 }
+      ]
+
+      {additions, deletions} = Utils.diff_activity_references(content1, content2)
+
+      assert MapSet.size(additions) == 1
+      assert MapSet.member?(additions, 2)
+
+      assert MapSet.size(deletions) == 1
+      assert MapSet.member?(deletions, 1)
+    end
+
+    test "diff_activity_references/2 finds no changes", _ do
+
+      content1 =  [
+        %{"type" => "content", children: [%{ "text" => "A paragraph."}] },
+        %{"type" => "activity-reference", "activity_id" => 2 }
+      ]
+
+      content2 =  [
+        %{"type" => "content", children: [%{ "text" => "A paragraph."}] },
+        %{"type" => "activity-reference", "activity_id" => 2 }
+      ]
+
+      {additions, deletions} = Utils.diff_activity_references(content1, content2)
+
+      assert MapSet.size(additions) == 0
+      assert MapSet.size(deletions) == 0
+    end
+
+    test "diff_activity_references/2 finds several additions", _ do
+
+      content1 =  [
+        %{"type" => "content", children: [%{ "text" => "A paragraph."}] }
+      ]
+
+      content2 =  [
+        %{"type" => "content", children: [%{ "text" => "A paragraph."}] },
+        %{"type" => "activity-reference", "activity_id" => 1 },
+        %{"type" => "activity-reference", "activity_id" => 2 },
+        %{"type" => "activity-reference", "activity_id" => 3 },
+        %{"type" => "activity-reference", "activity_id" => 4 },
+      ]
+
+      {additions, deletions} = Utils.diff_activity_references(content1, content2)
+
+      assert MapSet.size(additions) == 4
+      assert MapSet.size(deletions) == 0
+    end
+
+  end
+
+end


### PR DESCRIPTION
This implements server-side handling of deletion and undeletion for when activity references are found to be inserted or removed in a front-end initiated change through the `PageEditor`

