### PR TITLE
Objective removal

### DIFF
--- a/assets/src/hooks/index.ts
+++ b/assets/src/hooks/index.ts
@@ -2,9 +2,11 @@
 
 import { GraphNavigation } from './graph';
 import { DropTarget, DragSource } from './dragdrop';
+import { ModalLaunch } from './modal';
 
 export const Hooks = {
   GraphNavigation,
   DropTarget,
   DragSource,
+  ModalLaunch,
 };

--- a/assets/src/hooks/modal.ts
+++ b/assets/src/hooks/modal.ts
@@ -1,0 +1,7 @@
+
+export const ModalLaunch = {
+  mounted() {
+    const id = this.el.getAttribute('id');
+    ($('#' + id) as any).modal({});
+  },
+};

--- a/lib/oli/authoring/editing/objective_editor.ex
+++ b/lib/oli/authoring/editing/objective_editor.ex
@@ -106,8 +106,12 @@ defmodule Oli.Authoring.Editing.ObjectiveEditor do
 
         {:ok, %{objectives: objectives}} = PageEditor.create_context(project_slug, page_slug, author)
 
+        # it is important to resolve the latest objective, so that we get the correct
+        # slug that the PageEditor will give us.
+        objective = AuthoringResolver.from_revision_slug(project_slug, objective_slug)
+
         update = %{"objectives" =>
-          %{"attached" => Enum.filter(Map.get(objectives, :attached), fn s -> s != objective_slug end)}}
+          %{"attached" => Enum.filter(Map.get(objectives, :attached), fn s -> s != objective.slug end)}}
 
         case PageEditor.edit(project_slug, page_slug, author.email, update) do
           {:ok, _} ->
@@ -128,6 +132,8 @@ defmodule Oli.Authoring.Editing.ObjectiveEditor do
       {:acquired} ->
         {:ok, %{objectives: objectives}} = ActivityEditor.create_context(project_slug, page_slug, activity_slug, author)
 
+        # it is important to resolve the latest objective, so that we get the correct
+        # slug that the ActivityEditor will give us.
         objective = AuthoringResolver.from_revision_slug(project_slug, objective_slug)
 
         update = %{"objectives" => Enum.reduce(objectives, %{}, fn {p, a}, m ->

--- a/lib/oli/authoring/editing/objective_editor.ex
+++ b/lib/oli/authoring/editing/objective_editor.ex
@@ -32,15 +32,14 @@ defmodule Oli.Authoring.Editing.ObjectiveEditor do
 
         Broadcaster.broadcast_resource(revision, project.slug)
 
-        {:ok,
-          %{
-            resource: resource,
-            revision: revision,
-            project: project,
-            mapping: mapping,
-            container: container
-          }
+        %{
+          resource: resource,
+          revision: revision,
+          project: project,
+          mapping: mapping,
+          container: container
         }
+
       else
         error -> Repo.rollback(error)
       end
@@ -65,7 +64,7 @@ defmodule Oli.Authoring.Editing.ObjectiveEditor do
 
         Broadcaster.broadcast_revision(new_revision, project.slug)
 
-        {:ok, new_revision}
+        new_revision
       else
         error -> Repo.rollback(error)
       end
@@ -281,7 +280,6 @@ defmodule Oli.Authoring.Editing.ObjectiveEditor do
   end
 
   defp append_to_container(container_slug, publication, revision_to_attach, project_slug, author) do
-
     with {:ok, resource} <- Resources.get_resource_from_slug(container_slug) |> trap_nil(),
         {:ok, revision} <- Publishing.get_published_revision(publication.id, resource.id) |> trap_nil()
     do

--- a/lib/oli/authoring/locks.ex
+++ b/lib/oli/authoring/locks.ex
@@ -175,7 +175,7 @@ defmodule Oli.Authoring.Locks do
     NaiveDateTime.diff(now(), to_use) > @ttl
   end
 
-  defp expired_or_empty?(%{ lock_updated_at: lock_updated_at} = mapping) do
+  def expired_or_empty?(%{ lock_updated_at: lock_updated_at} = mapping) do
     lock_updated_at == nil or expired?(mapping)
   end
 

--- a/lib/oli/authoring/locks.ex
+++ b/lib/oli/authoring/locks.ex
@@ -175,8 +175,8 @@ defmodule Oli.Authoring.Locks do
     NaiveDateTime.diff(now(), to_use) > @ttl
   end
 
-  def expired_or_empty?(%{ lock_updated_at: lock_updated_at} = mapping) do
-    lock_updated_at == nil or expired?(mapping)
+  def expired_or_empty?(%{ locked_by_id: locked_by_id} = mapping) do
+    locked_by_id == nil or expired?(mapping)
   end
 
   defp release_lock(mapping) do

--- a/lib/oli/authoring/locks.ex
+++ b/lib/oli/authoring/locks.ex
@@ -112,7 +112,7 @@ defmodule Oli.Authoring.Locks do
 
       # Acquire the lock if held already by this user and the lock is expired or its last_updated_date is empty
       # otherwise, simply update it
-      %{locked_by_id: ^user_id} = mapping -> lock_action(mapping, user_id, &expired_or_empty?/1, {:acquired}, {:updated}, now())
+      %{locked_by_id: ^user_id} = mapping -> lock_action(mapping, user_id, &expired_or_empty_predicate?/1, {:acquired}, {:updated}, now())
 
       # Otherwise, another user may have this locked, or it was locked by this
       # user and it expired and an interleaving lock, redit, release by another user
@@ -177,6 +177,10 @@ defmodule Oli.Authoring.Locks do
 
   def expired_or_empty?(%{ locked_by_id: locked_by_id} = mapping) do
     locked_by_id == nil or expired?(mapping)
+  end
+
+  def expired_or_empty_predicate?(%{ lock_updated_at: lock_updated_at} = mapping) do
+    lock_updated_at == nil or expired?(mapping)
   end
 
   defp release_lock(mapping) do

--- a/lib/oli/publishing.ex
+++ b/lib/oli/publishing.ex
@@ -535,9 +535,6 @@ defmodule Oli.Publishing do
     page_id = ResourceType.get_id_by_type("page")
     activity_id = ResourceType.get_id_by_type("activity")
 
-    IO.puts "RESOURCE ID find obj"
-    IO.inspect resource_id
-
     sql =
       """
       select

--- a/lib/oli/publishing.ex
+++ b/lib/oli/publishing.ex
@@ -599,7 +599,7 @@ defmodule Oli.Publishing do
     sql =
       """
       select
-        rev.id,
+        rev.resource_id,
         jsonb_path_query(content, '$.model[*] ? (@.type == "activity-reference")')
       from published_resources as mapping
       join revisions as rev

--- a/lib/oli_web/live/common/manual_modal.ex
+++ b/lib/oli_web/live/common/manual_modal.ex
@@ -1,12 +1,19 @@
 defmodule OliWeb.Common.ManualModal do
 
   @moduledoc """
-  A reusable LivewComponent for a Bootstrap modal, one that is manually controlled via JavaScript.
+  A reusable LivewComponent for a Bootstrap modal, one that is manually controlled via JavaScript, and that
+  must be added and removed from a parent LiveView programmatically when it needs to be shown.
+
+  This component should be used in place of `OliWeb.Common.Modal` when there is a need to programmatically
+  vary the content that the modal displays from invocation to invocation.  The only way to do this
+  is to completely remove the component from the DOM and remount it with the new content.  Doing this, however,
+  forces the launching of the modal to be done via JavaScript (notice the phx-hook that is present on
+  the root div of this modal)
 
   Minimal example usage specifying only the required properties:
 
   ```
-  <%= live_component @socket, Modal, title: "Confirm your request", modal_id: "my_unique_modal_id", ok_action: "confirm" do %>
+  <%= live_component @socket, ManualModal, title: "Confirm your request", modal_id: "my_unique_modal_id", ok_action: "confirm" do %>
     <p class="mb-4">Are you sure you want to do this?</p>
   <% end %>
   ```

--- a/lib/oli_web/live/common/manual_modal.ex
+++ b/lib/oli_web/live/common/manual_modal.ex
@@ -1,0 +1,61 @@
+defmodule OliWeb.Common.ManualModal do
+
+  @moduledoc """
+  A reusable LivewComponent for a Bootstrap modal, one that is manually controlled via JavaScript.
+
+  Minimal example usage specifying only the required properties:
+
+  ```
+  <%= live_component @socket, Modal, title: "Confirm your request", modal_id: "my_unique_modal_id", ok_action: "confirm" do %>
+    <p class="mb-4">Are you sure you want to do this?</p>
+  <% end %>
+  ```
+
+  Required properties:
+
+  `title`: The string title that the modal will display
+  `modal_id`: The DOM id that will be attached to this modal. This is the id that another part of the UI needs
+              to target to trigger the modal
+  'ok_action': The phx-click action to invoke upon clicking the 'Ok' button
+
+  Optional properties:
+
+  `ok_label`: The label to use for the 'Ok' button, defaults to 'Ok'
+  `ok_style`: The Bootstrap button style to use for the 'Ok' button, defaults to `btn-primary`
+
+  """
+
+  use Phoenix.LiveComponent
+
+  def mount(socket) do
+    # Default property values
+    {:ok, assign(socket,
+      ok_label: "Ok",
+      ok_style: "btn-primary")
+    }
+  end
+
+  def render(assigns) do
+    ~L"""
+    <div class="modal fade show" id="<%= @modal_id %>" tabindex="-1" role="dialog" aria-hidden="true" phx-hook="ModalLaunch">
+      <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title"><%= @title %></h5>
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+          <div class="modal-body">
+            <%= @inner_content.([]) %>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-dismiss="modal" phx-click="cancel_modal">Cancel</button>
+            <button type="button" class="btn <%= @ok_style %>" data-dismiss="modal" phx-click="<%= @ok_action %>"><%= @ok_label %></button>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/oli_web/live/common/modal.ex
+++ b/lib/oli_web/live/common/modal.ex
@@ -1,0 +1,61 @@
+defmodule OliWeb.Common.Modal do
+
+  @moduledoc """
+  A reusable LivewComponent for a Bootstrap modal.
+
+  Minimal example usage specifying only the required properties:
+
+  ```
+  <%= live_component @socket, Modal, title: "Confirm your request", modal_id: "my_unique_modal_id", ok_action: "confirm" do %>
+    <p class="mb-4">Are you sure you want to do this?</p>
+  <% end %>
+  ```
+
+  Required properties:
+
+  `title`: The string title that the modal will display
+  `modal_id`: The DOM id that will be attached to this modal. This is the id that another part of the UI needs
+              to target to trigger the modal
+  'ok_action': The phx-click action to invoke upon clicking the 'Ok' button
+
+  Optional properties:
+
+  `ok_label`: The label to use for the 'Ok' button, defaults to 'Ok'
+  `ok_style`: The Bootstrap button style to use for the 'Ok' button, defaults to `btn-primary`
+
+  """
+
+  use Phoenix.LiveComponent
+
+  def mount(socket) do
+    # Default property values
+    {:ok, assign(socket,
+      ok_label: "Ok",
+      ok_style: "btn-primary")
+    }
+  end
+
+  def render(assigns) do
+    ~L"""
+    <div class="modal fade" id="<%= @modal_id %>" tabindex="-1" role="dialog" aria-hidden="true">
+      <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title"><%= @title %></h5>
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+          <div class="modal-body">
+            <%= @inner_content.([]) %>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+            <button type="button" class="btn <%= @ok_style %>" data-dismiss="modal" phx-click="<%= @ok_action %>"><%= @ok_label %></button>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/oli_web/live/history/revision_history.ex
+++ b/lib/oli_web/live/history/revision_history.ex
@@ -12,6 +12,7 @@ defmodule OliWeb.RevisionHistory do
   alias OliWeb.RevisionHistory.Details
   alias OliWeb.RevisionHistory.Graph
   alias OliWeb.RevisionHistory.Table
+  alias OliWeb.Common.Modal
 
   alias Oli.Publishing.AuthoringResolver
 
@@ -99,26 +100,13 @@ defmodule OliWeb.RevisionHistory do
       </div>
     </div>
 
-    <div class="modal fade" id="restoreModal" tabindex="-1" role="dialog" aria-hidden="true">
-      <div class="modal-dialog modal-dialog-centered" role="document">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h5 class="modal-title" id="exampleModalLongTitle">Restore this Revision</h5>
-            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-              <span aria-hidden="true">&times;</span>
-            </button>
-          </div>
-          <div class="modal-body">
-            <p clsas="mb-4">Are you sure you want to restore this revision?</p>
-            <p>This will end any active editing session for other users and will create a new revision to restore the title, content and objectives and other settings of this selected revision.</p>
-          </div>
-          <div class="modal-footer">
-            <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
-            <button type="button" class="btn btn-danger" data-dismiss="modal" phx-click="restore">Proceed</button>
-          </div>
-        </div>
-      </div>
-    </div>
+    <%= live_component @socket, Modal, title: "Restore this Revision", modal_id: "restoreModal", ok_action: "restore", ok_label: "Proceed", ok_style: "btn-danger" do %>
+      <p class="mb-4">Are you sure you want to restore this revision?</p>
+
+      <p>This will end any active editing session for other users and will create a
+         new revision to restore the title, content and objectives and other settings
+         of this selected revision.</p>
+    <% end %>
     """
   end
 

--- a/lib/oli_web/live/objectives/attachments.ex
+++ b/lib/oli_web/live/objectives/attachments.ex
@@ -2,16 +2,24 @@ defmodule OliWeb.Objectives.Attachments do
 
   use Phoenix.LiveComponent
 
-  defp locked_by_email(parent_pages, locked_by, id) do
+  alias OliWeb.Router.Helpers, as: Routes
 
+  defp locked_by_email(parent_pages, locked_by, id) do
     case Map.get(parent_pages, id) do
       nil -> Map.get(locked_by, id).author.email
-      parent_id -> Map.get(locked_by, parent_id).author.email
+      %{id: parent_id} -> Map.get(locked_by, parent_id).author.email
     end
   end
 
   defp get_type(r) do
     if Map.get(r, :part) == "attached" do "Page" else "Activity" end
+  end
+
+  defp link_route(project_slug, parent_pages, id, revision_slug) do
+    case Map.get(parent_pages, id) do
+      nil -> Routes.resource_path(OliWeb.Endpoint, :edit, project_slug, revision_slug)
+      %{slug: slug} -> Routes.resource_path(OliWeb.Endpoint, :edit, project_slug, slug)
+    end
   end
 
   def render(%{attachment_summary: %{attachments: {pages, activities}, locked_by: locked_by, parent_pages: parent_pages}} = assigns) do
@@ -21,9 +29,10 @@ defmodule OliWeb.Objectives.Attachments do
     is_locked? = fn id ->
       case Map.get(parent_pages, id) do
         nil -> Map.get(locked_by, id) != nil
-        parent_id -> Map.get(locked_by, parent_id) != nil
+        %{id: parent_id} -> Map.get(locked_by, parent_id) != nil
       end
     end
+
     resources_locked = Enum.filter(all, fn r -> is_locked?.(r.resource_id) end)
     resources_not_locked = Enum.filter(all, fn r -> !is_locked?.(r.resource_id) end)
 
@@ -38,28 +47,35 @@ defmodule OliWeb.Objectives.Attachments do
         <p class="mb-4">Proceeding will automatically remove this objective from the following resources:</p>
 
         <table class="table table-sm table-bordered">
-          <thead>
+          <thead class="thead-dark">
             <tr><th>Resource</th><th>Title</th></tr>
           </thead>
           <tbody>
           <%= for r <- resources_not_locked do %>
-            <tr><td><%= get_type(r) %></td><td><%= r.title %></td></tr>
+            <tr>
+              <td><%= get_type(r) %></td>
+              <td><a href="<%= link_route(@project.slug, parent_pages, r.resource_id, r.slug) %>"><%= r.title %></a></td>
+            </tr>
           <% end %>
           </tbody>
         </table>
       <% end %>
 
       <%= if length(resources_locked) > 0 do %>
-        <p class="mb-4">Deleting this objective is blocked because the following resources that have this objective
+        <p class="mb-4">Deleting this objective is <strong>blocked</strong> because the following resources that have this objective
         attached to it are currently being edited:</p>
 
         <table class="table table-sm table-bordered">
-          <thead>
+          <thead class="thead-dark">
             <tr><th>Resource</th><th>Title</th><th>Edited By</th></tr>
           </thead>
           <tbody>
           <%= for r <- resources_locked do %>
-            <tr><td><%= get_type(r) %></td><td><%= r.title %></td><td><%= locked_by_email(parent_pages, locked_by, r.resource_id) %></td></tr>
+            <tr><td><%= get_type(r) %></td>
+            <td>
+              <a href="<%= link_route(@project.slug, parent_pages, r.resource_id, r.slug) %>"><%= r.title %></a>
+            </td>
+            <td><%= locked_by_email(parent_pages, locked_by, r.resource_id) %></td></tr>
           <% end %>
           </tbody>
         </table>

--- a/lib/oli_web/live/objectives/attachments.ex
+++ b/lib/oli_web/live/objectives/attachments.ex
@@ -2,10 +2,11 @@ defmodule OliWeb.Objectives.Attachments do
 
   use Phoenix.LiveComponent
 
-  defp locked_by_email(locked_by, id) do
-    case Map.get(locked_by, id) do
-      nil -> ""
-      m -> if m.locked_by_id != nil do m.locked_by_id else "" end
+  defp locked_by_email(parent_pages, locked_by, id) do
+
+    case Map.get(parent_pages, id) do
+      nil -> Map.get(locked_by, id).author.email
+      parent_id -> Map.get(locked_by, parent_id).author.email
     end
   end
 
@@ -13,11 +14,16 @@ defmodule OliWeb.Objectives.Attachments do
     if Map.get(r, :part) == "attached" do "Page" else "Activity" end
   end
 
-  def render(%{attachment_summary: %{attachments: {pages, activities}, locked_by: locked_by}} = assigns) do
-    is_locked? = fn id -> Map.get(locked_by, id) != nil end
+  def render(%{attachment_summary: %{attachments: {pages, activities}, locked_by: locked_by, parent_pages: parent_pages}} = assigns) do
 
     all = pages ++ activities
 
+    is_locked? = fn id ->
+      case Map.get(parent_pages, id) do
+        nil -> Map.get(locked_by, id) != nil
+        parent_id -> Map.get(locked_by, parent_id) != nil
+      end
+    end
     resources_locked = Enum.filter(all, fn r -> is_locked?.(r.resource_id) end)
     resources_not_locked = Enum.filter(all, fn r -> !is_locked?.(r.resource_id) end)
 
@@ -45,7 +51,7 @@ defmodule OliWeb.Objectives.Attachments do
 
       <%= if length(resources_locked) > 0 do %>
         <p class="mb-4">Deleting this objective is blocked because the following resources that have this objective
-        attached to it are currently being edited.</p>
+        attached to it are currently being edited:</p>
 
         <table class="table table-sm table-bordered">
           <thead>
@@ -53,7 +59,7 @@ defmodule OliWeb.Objectives.Attachments do
           </thead>
           <tbody>
           <%= for r <- resources_locked do %>
-            <tr><td><%= get_type(r) %></td><td><%= r.title %></td><td><%= locked_by_email(locked_by, r.resource_id) %></td></tr>
+            <tr><td><%= get_type(r) %></td><td><%= r.title %></td><td><%= locked_by_email(parent_pages, locked_by, r.resource_id) %></td></tr>
           <% end %>
           </tbody>
         </table>

--- a/lib/oli_web/live/objectives/attachments.ex
+++ b/lib/oli_web/live/objectives/attachments.ex
@@ -15,6 +15,9 @@ defmodule OliWeb.Objectives.Attachments do
     if Map.get(r, :part) == "attached" do "Page" else "Activity" end
   end
 
+  # Helper to formulate link to edit a resource. It is intentional that
+  # activities link to the parent page.  That is how the user will gain
+  # a lock to be able to then edit an activity.
   defp link_route(project_slug, parent_pages, id, revision_slug) do
     case Map.get(parent_pages, id) do
       nil -> Routes.resource_path(OliWeb.Endpoint, :edit, project_slug, revision_slug)

--- a/lib/oli_web/live/objectives/attachments.ex
+++ b/lib/oli_web/live/objectives/attachments.ex
@@ -1,0 +1,65 @@
+defmodule OliWeb.Objectives.Attachments do
+
+  use Phoenix.LiveComponent
+
+  defp locked_by_email(locked_by, id) do
+    case Map.get(locked_by, id) do
+      nil -> ""
+      m -> if m.locked_by_id != nil do m.locked_by_id else "" end
+    end
+  end
+
+  defp get_type(r) do
+    if Map.get(r, :part) == "attached" do "Page" else "Activity" end
+  end
+
+  def render(%{attachment_summary: %{attachments: {pages, activities}, locked_by: locked_by}} = assigns) do
+    is_locked? = fn id -> Map.get(locked_by, id) != nil end
+
+    all = pages ++ activities
+
+    resources_locked = Enum.filter(all, fn r -> is_locked?.(r.resource_id) end)
+    resources_not_locked = Enum.filter(all, fn r -> !is_locked?.(r.resource_id) end)
+
+    ~L"""
+    <div>
+
+      <%= if length(resources_not_locked) == 0 and length(resources_locked) == 0 do %>
+        <p class="mb-4">Are you sure you wish to delete this objective?</p>
+      <% end %>
+
+      <%= if length(resources_not_locked) > 0 do %>
+        <p class="mb-4">Proceeding will automatically remove this objective from the following resources:</p>
+
+        <table class="table table-sm table-bordered">
+          <thead>
+            <tr><th>Resource</th><th>Title</th></tr>
+          </thead>
+          <tbody>
+          <%= for r <- resources_not_locked do %>
+            <tr><td><%= get_type(r) %></td><td><%= r.title %></td></tr>
+          <% end %>
+          </tbody>
+        </table>
+      <% end %>
+
+      <%= if length(resources_locked) > 0 do %>
+        <p class="mb-4">Deleting this objective is blocked because the following resources that have this objective
+        attached to it are currently being edited.</p>
+
+        <table class="table table-sm table-bordered">
+          <thead>
+            <tr><th>Resource</th><th>Title</th><th>Edited By</th></tr>
+          </thead>
+          <tbody>
+          <%= for r <- resources_locked do %>
+            <tr><td><%= get_type(r) %></td><td><%= r.title %></td><td><%= locked_by_email(locked_by, r.resource_id) %></td></tr>
+          <% end %>
+          </tbody>
+        </table>
+      <% end %>
+    </div>
+    """
+  end
+
+end

--- a/lib/oli_web/live/objectives/objective_entry.ex
+++ b/lib/oli_web/live/objectives/objective_entry.ex
@@ -71,7 +71,10 @@ defmodule OliWeb.Objectives.ObjectiveEntry do
         <button
           id=<%= "delete_#{@objective_mapping.resource.id}" %>
           title="Delete"
-          class="ml-1 btn btn-sm btn-outline-danger" data-toggle="modal" data-target="#exampleModalCenter"
+          phx-click="prepare_delete"
+          data-backdrop="static"
+          data-keyboard="false"
+          class="ml-1 btn btn-sm btn-outline-danger"
          >
          <i class="fas fa-trash fa-lg"></i>
         </button>

--- a/lib/oli_web/live/objectives/objectives.ex
+++ b/lib/oli_web/live/objectives/objectives.ex
@@ -195,10 +195,16 @@ defmodule OliWeb.Objectives.Objectives do
 
   # handle processing deletion of item
   def handle_event("delete", _, socket) do
-    socket = case ObjectiveEditor.edit(socket.assigns.selected, %{ deleted: true }, socket.assigns.author, socket.assigns.project) do
-      {:ok, _} -> socket
-      {:error, _} -> socket
-      |> put_flash(:error, "Could not remove objective")
+
+    ObjectiveEditor.detach_objective(socket.assigns.selected, socket.assigns.project, socket.assigns.author)
+
+    socket = case ObjectiveEditor.preview_objective_detatchment(socket.assigns.selected, socket.assigns.project) do
+      %{attachments: {[], []}} -> case ObjectiveEditor.edit(socket.assigns.selected, %{ deleted: true }, socket.assigns.author, socket.assigns.project) do
+        {:ok, _} -> socket
+        {:error, _} -> socket
+        |> put_flash(:error, "Could not remove objective")
+      end
+      _ -> socket
     end
 
     {:noreply, assign(socket, modal_shown: false)}

--- a/lib/oli_web/live/objectives/objectives.ex
+++ b/lib/oli_web/live/objectives/objectives.ex
@@ -90,7 +90,7 @@ defmodule OliWeb.Objectives.Objectives do
 
       <%= if @modal_shown do %>
         <%= live_component @socket, ManualModal, title: "Delete Objective", modal_id: "deleteModal", ok_action: "delete", ok_label: "Delete", ok_style: "btn-danger" do %>
-          <%= live_component @socket, Attachments, attachment_summary: @attachment_summary %>
+          <%= live_component @socket, Attachments, attachment_summary: @attachment_summary, project: @project %>
         <% end %>
       <% end %>
 

--- a/lib/oli_web/live/objectives/objectives.ex
+++ b/lib/oli_web/live/objectives/objectives.ex
@@ -9,6 +9,8 @@ defmodule OliWeb.Objectives.Objectives do
   alias Oli.Authoring.Editing.ObjectiveEditor
   alias OliWeb.Objectives.ObjectiveEntry
   alias OliWeb.Objectives.ObjectiveRender
+  alias OliWeb.Objectives.Attachments
+  alias OliWeb.Common.ManualModal
   alias Oli.Publishing.ObjectiveMappingTransfer
   alias Oli.Authoring.Course
   alias Oli.Accounts.Author
@@ -18,6 +20,8 @@ defmodule OliWeb.Objectives.Objectives do
   alias Oli.Resources.ResourceType
   alias Oli.Repo
   alias Phoenix.PubSub
+
+  @default_attachment_summary %{attachments: {[], []}, locked_by: %{}, parent_pages: %{}}
 
   def mount(params, %{"current_author_id" => author_id}, socket) do
 
@@ -37,69 +41,60 @@ defmodule OliWeb.Objectives.Objectives do
       changeset: Resources.change_revision(%Revision{}),
       project: project,
       subscriptions: subscriptions,
+      attachment_summary: @default_attachment_summary,
+      modal_shown: false,
       author: author,
+      force_render: 0,
       selected: nil,
       edit: :none)
     }
   end
 
   def render(assigns) do
-
     ~L"""
-    <div style="margin: 20px;">
-      <div class="container">
-      <div class="mb-2 row">
-        <h2>Course Objectives</h2>
-        <p class="text-secondary">
-         Learning objectives help you to organize course content and determine appropriate assessments and instructional strategies.
-         Visit the <a href="https://www.cmu.edu/teaching/designteach/design/learningobjectives.html" target="_blank">CMU Eberly Center guide on learning objectives</a> to learn more about the importance of attaching learning objectives to pages and activities.
-        </p>
-        <p class="text-secondary">At the end of the course my students should be able to...</p>
-      </div>
+    <div>
+      <div style="margin: 20px;">
+        <div class="container">
         <div class="mb-2 row">
-          <%= live_component @socket, ObjectiveRender, changeset: @changeset, project: @project, form_id: "create-objective",
-            place_holder: "New Learning Objective", title_value: "", slug_value: "", parent_slug_value: "",
-            edit: @edit, method: "new", mode: :new_objective, phx_disable_with: "Adding Objective...", button_text: "Create" %>
+          <h2>Course Objectives</h2>
+          <p class="text-secondary">
+          Learning objectives help you to organize course content and determine appropriate assessments and instructional strategies.
+          Visit the <a href="https://www.cmu.edu/teaching/designteach/design/learningobjectives.html" target="_blank">CMU Eberly Center guide on learning objectives</a> to learn more about the importance of attaching learning objectives to pages and activities.
+          </p>
+          <p class="text-secondary">At the end of the course my students should be able to...</p>
         </div>
-        <%= if Enum.count(@objective_mappings) == 0 do %>
-        <div class="row">
-          <div class="my-5 text-center">
-            No objectives
+          <div class="mb-2 row">
+            <%= live_component @socket, ObjectiveRender, changeset: @changeset, project: @project, form_id: "create-objective",
+              place_holder: "New Learning Objective", title_value: "", slug_value: "", parent_slug_value: "",
+              edit: @edit, method: "new", mode: :new_objective, phx_disable_with: "Adding Objective...", button_text: "Create" %>
           </div>
-        </div>
-        <% else %>
-        <div class="row">
-          <div class="border border-light list-group list-group-flush w-100">
-              <%= for {objective_tree, index} <- Enum.with_index(@objectives_tree) do %>
-                <%= live_component @socket, ObjectiveEntry, changeset: @changeset, objective_mapping: objective_tree.mapping,
-                    children: objective_tree.children, depth: 1, index: index, project: @project, selected: @selected, edit: @edit %>
-              <% end %>
+          <%= if Enum.count(@objective_mappings) == 0 do %>
+          <div class="row">
+            <div class="my-5 text-center">
+              No objectives
+            </div>
           </div>
-      <div class="modal fade" id="exampleModalCenter" tabindex="-1" role="dialog" aria-labelledby="exampleModalCenterTitle" aria-hidden="true">
-      <div class="modal-dialog modal-dialog-centered" role="document">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h5 class="modal-title" id="exampleModalLongTitle">Delete Objective</h5>
-            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-              <span aria-hidden="true">&times;</span>
-            </button>
+          <% else %>
+          <div class="row">
+            <div class="border border-light list-group list-group-flush w-100">
+                <%= for {objective_tree, index} <- Enum.with_index(@objectives_tree) do %>
+                  <%= live_component @socket, ObjectiveEntry, changeset: @changeset, objective_mapping: objective_tree.mapping,
+                      children: objective_tree.children, depth: 1, index: index, project: @project, selected: @selected, edit: @edit %>
+                <% end %>
+            </div>
           </div>
-          <div class="modal-body">
-            <p>Are you sure you want to delete this objective?</p>
-            <p>This is an operation that cannot be undone.</p>
-          </div>
-          <div class="modal-footer">
-            <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
-            <button type="button" class="btn btn-danger" data-dismiss="modal" phx-click="delete">Delete</button>
+          <% end %>
           </div>
         </div>
       </div>
-    </div>
-        </div>
+
+      <%= if @modal_shown do %>
+        <%= live_component @socket, ManualModal, title: "Delete Objective", modal_id: "deleteModal", ok_action: "delete", ok_label: "Delete", ok_style: "btn-danger" do %>
+          <%= live_component @socket, Attachments, attachment_summary: @attachment_summary %>
         <% end %>
-        </div>
-      </div>
-    </div>
+      <% end %>
+
+    <div>
     """
   end
 
@@ -164,7 +159,7 @@ defmodule OliWeb.Objectives.Objectives do
 
   # handle change of selection
   def handle_event("select", %{"slug" => slug}, socket) do
-    {:noreply, assign(socket, :selected, slug)}
+    {:noreply, assign(socket, selected: slug, attachment_summary: @default_attachment_summary)}
   end
 
   # handle change of edit
@@ -189,6 +184,15 @@ defmodule OliWeb.Objectives.Objectives do
     {:noreply, socket}
   end
 
+  def handle_event("prepare_delete", _, socket) do
+    attachment_summary = ObjectiveEditor.preview_objective_detatchment(socket.assigns.selected, socket.assigns.project)
+    {:noreply, assign(socket, modal_shown: true, attachment_summary: attachment_summary, force_render: socket.assigns.force_render + 1)}
+  end
+
+  def handle_event("cancel_modal", _, socket) do
+    {:noreply, assign(socket, modal_shown: false)}
+  end
+
   # handle processing deletion of item
   def handle_event("delete", _, socket) do
     socket = case ObjectiveEditor.edit(socket.assigns.selected, %{ deleted: true }, socket.assigns.author, socket.assigns.project) do
@@ -197,7 +201,7 @@ defmodule OliWeb.Objectives.Objectives do
       |> put_flash(:error, "Could not remove objective")
     end
 
-    {:noreply, socket}
+    {:noreply, assign(socket, modal_shown: false)}
   end
 
   # handle clicking of the add objective

--- a/test/oli/editing/activity_editor_test.exs
+++ b/test/oli/editing/activity_editor_test.exs
@@ -225,8 +225,8 @@ defmodule Oli.ActivityEditingTest do
     end
 
     test "can sync objectives to parts", %{author: author, project: project } do
-      {:ok, {:ok, %{revision: ob1}}} = ObjectiveEditor.add_new(%{title: "this is an objective"}, author, project)
-      {:ok, {:ok, %{revision: ob2}}}  = ObjectiveEditor.add_new(%{title: "this is another objective"}, author, project)
+      {:ok, %{revision: ob1}} = ObjectiveEditor.add_new(%{title: "this is an objective"}, author, project)
+      {:ok, %{revision: ob2}}  = ObjectiveEditor.add_new(%{title: "this is another objective"}, author, project)
 
       # Create a two part activity where each part is tied to one of the objectives above
       content = %{ "objectives" => %{ "1" => [ ob1.slug ], "2" => [ ob2.slug ]  },

--- a/test/oli/editing/objective_editor_test.exs
+++ b/test/oli/editing/objective_editor_test.exs
@@ -1,0 +1,122 @@
+defmodule Oli.Authoring.Editing.ObjectiveEditorTest do
+  use Oli.DataCase
+
+  alias Oli.Authoring.Editing.ObjectiveEditor
+  alias Oli.Authoring.Editing.PageEditor
+  alias Oli.Authoring.Editing.ActivityEditor
+  alias Oli.Publishing.AuthoringResolver
+
+  describe "objective editing" do
+
+    setup do
+      Seeder.base_project_with_resource2()
+    end
+
+    test "add_new/3 can add an objetive", %{author: author, project: project } do
+
+      {:ok, %{revision: revision}} = ObjectiveEditor.add_new(%{title: "Test Objective"}, author, project)
+      assert revision.title == "Test Objective"
+    end
+
+    test "add_new/4 can add an objetive to a parent objective", %{author: author, project: project } do
+
+      {:ok, %{revision: parent}} = ObjectiveEditor.add_new(%{title: "Test Objective"}, author, project)
+      {:ok, %{revision: child}} = ObjectiveEditor.add_new(%{title: "Sub Objective"}, author, project, parent.slug)
+
+      parent = AuthoringResolver.from_resource_id(project.slug, parent.resource_id)
+      assert parent.children == [child.resource_id]
+
+    end
+
+    test "edit/4 edits the title of an objective", %{author: author, project: project } do
+
+      {:ok, %{revision: revision}} = ObjectiveEditor.add_new(%{title: "Test Objective"}, author, project)
+      {:ok, edited} = ObjectiveEditor.edit(revision.slug, %{title: "Edited"}, author, project)
+
+      assert edited.title == "Edited"
+      refute edited.id == revision.id
+
+    end
+
+    test "detach_objective/3 removes an objective from pages", %{author: author, project: project, revision1: revision} do
+
+      {:ok, %{revision: objective}} = ObjectiveEditor.add_new(%{title: "Test Objective"}, author, project)
+
+      # attach it to a page and release the lock
+      objectives = %{"attached" => [objective.slug] }
+      PageEditor.acquire_lock(project.slug, revision.slug, author.email)
+      {:ok, updated_revision} = PageEditor.edit(project.slug, revision.slug, author.email, %{ "objectives" => objectives })
+      PageEditor.release_lock(project.slug, revision.slug, author.email)
+
+      ObjectiveEditor.detach_objective(objective.slug, project, author)
+
+      updated_page = AuthoringResolver.from_resource_id(project.slug, updated_revision.resource_id)
+      assert updated_page.objectives == %{"attached" => []}
+
+    end
+
+    test "detach_objective/3 does not remove when locked", %{author: author, project: project, revision1: revision} do
+
+      {:ok, %{revision: objective}} = ObjectiveEditor.add_new(%{title: "Test Objective"}, author, project)
+
+      # attach it to a page and release the lock
+      objectives = %{"attached" => [objective.slug] }
+      PageEditor.acquire_lock(project.slug, revision.slug, author.email)
+      {:ok, updated_revision} = PageEditor.edit(project.slug, revision.slug, author.email, %{ "objectives" => objectives })
+
+      ObjectiveEditor.detach_objective(objective.slug, project, author)
+
+      updated_page = AuthoringResolver.from_resource_id(project.slug, updated_revision.resource_id)
+      assert updated_page.objectives == %{"attached" => [objective.resource_id]}
+
+    end
+
+    test "detach_objective/3 removes an objective from an activity", %{author: author, project: project, revision1: revision} do
+
+      {:ok, %{revision: objective}} = ObjectiveEditor.add_new(%{title: "Test Objective"}, author, project)
+
+      # attach it to a page and release the lock
+      content = %{ "stem" => "one" }
+      {:ok, {%{slug: slug, resource_id: activity_id}, _}} = ActivityEditor.create(project.slug, "oli_multiple_choice", author, content)
+
+      update = %{ "content" => %{ "model" => [%{ "type" => "activity-reference", "id" => 1, "activitySlug" => slug, "purpose" => "none"}]}}
+      PageEditor.acquire_lock(project.slug, revision.slug, author.email)
+      assert {:ok, updated_revision} = PageEditor.edit(project.slug, revision.slug, author.email, update)
+      attachment = %{ "objectives" => %{ "1" => [ objective.slug ] },
+        "content" => %{"authoring" => %{"parts" => [%{"id" => "1" }]}}}
+
+      ActivityEditor.edit(project.slug, revision.slug, slug, author.email, attachment)
+      PageEditor.release_lock(project.slug, revision.slug, author.email)
+
+      ObjectiveEditor.detach_objective(objective.slug, project, author)
+
+      updated_activity = AuthoringResolver.from_resource_id(project.slug, activity_id)
+      assert updated_activity.objectives == %{"1" => []}
+
+    end
+
+    test "detach_objective/3 does not remove an objective from an activity that is locked", %{author: author, project: project, revision1: revision} do
+
+      {:ok, %{revision: objective}} = ObjectiveEditor.add_new(%{title: "Test Objective"}, author, project)
+
+      # attach it to a page and release the lock
+      content = %{ "stem" => "one" }
+      {:ok, {%{slug: slug, resource_id: activity_id}, _}} = ActivityEditor.create(project.slug, "oli_multiple_choice", author, content)
+
+      update = %{ "content" => %{ "model" => [%{ "type" => "activity-reference", "id" => 1, "activitySlug" => slug, "purpose" => "none"}]}}
+      PageEditor.acquire_lock(project.slug, revision.slug, author.email)
+      assert {:ok, updated_revision} = PageEditor.edit(project.slug, revision.slug, author.email, update)
+      attachment = %{ "objectives" => %{ "1" => [ objective.slug ] },
+        "content" => %{"authoring" => %{"parts" => [%{"id" => "1" }]}}}
+
+      ActivityEditor.edit(project.slug, revision.slug, slug, author.email, attachment)
+      ObjectiveEditor.detach_objective(objective.slug, project, author)
+
+      updated_activity = AuthoringResolver.from_resource_id(project.slug, activity_id)
+      refute updated_activity.objectives == %{"1" => []}
+
+    end
+
+  end
+
+end

--- a/test/oli/editing/page_editor_test.exs
+++ b/test/oli/editing/page_editor_test.exs
@@ -18,6 +18,7 @@ defmodule Oli.EditingTest do
     test "edit/4 creates a new revision when no lock in place", %{author: author, revision1: revision1, project: project } do
 
       content = %{ "model" => [%{"type" => "p", children: [%{ "text" => "A paragraph."}] }]}
+
       PageEditor.acquire_lock(project.slug, revision1.slug, author.email)
       {:ok, updated_revision} = PageEditor.edit(project.slug, revision1.slug, author.email, %{ "content" => content })
 
@@ -70,7 +71,7 @@ defmodule Oli.EditingTest do
       |> Publishing.update_resource_mapping(%{lock_updated_at: yesterday(), locked_by_id: author.id})
 
       content = %{ "model" => [%{ "type" => "p", children: [%{ "text" => "A paragraph."}] }] }
-      PageEditor.acquire_lock(project.slug, revision1.slug, author.email)
+
       {:ok, updated_revision} = PageEditor.edit(project.slug, revision1.slug, author.email, %{ "content" => content })
 
       assert revision1.id != updated_revision.id

--- a/test/oli/publishing_test.exs
+++ b/test/oli/publishing_test.exs
@@ -71,6 +71,9 @@ defmodule Oli.PublishingTest do
       # the page has it attached as well
       assert (Enum.filter(results, fn r -> r.resource_id == revision.resource_id end) |> length) == 1
 
+      parent_pages = Publishing.determine_parent_pages([activity4.resource_id], publication.id)
+      assert Map.has_key?(parent_pages, activity4.resource_id)
+
     end
 
   end

--- a/test/oli/publishing_test.exs
+++ b/test/oli/publishing_test.exs
@@ -45,9 +45,9 @@ defmodule Oli.PublishingTest do
 
     test "find_objective_attachments/2 returns the objective revisions", %{author: author, project: project, publication: publication, revision1: revision} do
 
-      {:ok, {:ok, %{revision: obj1}}} = ObjectiveEditor.add_new(%{title: "one"}, author, project)
-      {:ok, {:ok, %{revision: obj2}}}  = ObjectiveEditor.add_new(%{title: "two"}, author, project)
-      {:ok, {:ok, %{revision: obj3}}}  = ObjectiveEditor.add_new(%{title: "three"}, author, project)
+      {:ok, %{revision: obj1}} = ObjectiveEditor.add_new(%{title: "one"}, author, project)
+      {:ok, %{revision: obj2}}  = ObjectiveEditor.add_new(%{title: "two"}, author, project)
+      {:ok, %{revision: obj3}}  = ObjectiveEditor.add_new(%{title: "three"}, author, project)
 
       activity1 = create_activity([{"1", [obj1.slug]}, {"2", []}], author, project, revision, obj1.slug)
       activity2 = create_activity([{"1", [obj1.slug]}, {"2", [obj1.slug]}], author, project, revision, obj1.slug)

--- a/test/oli_web/live/objectives_test.exs
+++ b/test/oli_web/live/objectives_test.exs
@@ -28,7 +28,12 @@ defmodule OliWeb.ObjectivesLiveTest do
       |> element("##{Integer.to_string(objective1.resource.id)}")
       |> render_click()
 
-      # delete the selected objective
+      # delete the selected objective, which requires first clicking the delete button
+      # which will display the modal, then we click the "Delete" button in the modal
+      view
+       |> element("#delete_#{Integer.to_string(objective1.resource.id)}")
+       |> render_click()
+
       view
        |> element(".btn-danger")
        |> render_click()


### PR DESCRIPTION
This PR adds support for detaching objectives from resources when an objective is deleted. 

It does not allow detachment when the attaching resource is locked for editing. 

Closes #251 
