### PR TITLE
highlight objective link when active

### DIFF
--- a/lib/oli_web/live/objectives/objective_render.ex
+++ b/lib/oli_web/live/objectives/objective_render.ex
@@ -15,7 +15,7 @@ defmodule OliWeb.Objectives.ObjectiveRender do
     ~L"""
     <%= cond do %>
     <% @mode == :show -> %>
-    <div class="pt-1 mb-1"><span class="mr-1"><i class="fas fa-crosshairs fa-lg"></i></span><%= @objective_mapping.revision.title %></div>
+    <div class="pt-1 mb-1"><%= @objective_mapping.revision.title %></div>
     <%= if length(@children) != 0 do  %>
     <div class="list-group list-group-flush w-100">
        <%= for child <- @children do %>

--- a/lib/oli_web/live/objectives/objectives.ex
+++ b/lib/oli_web/live/objectives/objectives.ex
@@ -31,6 +31,7 @@ defmodule OliWeb.Objectives.Objectives do
     objectives_tree = to_objective_tree(objective_mappings)
 
     {:ok, assign(socket,
+      active: :objectives,
       objective_mappings: objective_mappings,
       objectives_tree: objectives_tree,
       title: "Objectives",


### PR DESCRIPTION
This PR allows the "Objectives" link in the sidebar to highlight when that view is active.

It also removes the crosshairs image as a prefix from the objective rendering. 

Closes #254 