### PR TITLE
improve header layout

### DIFF
--- a/assets/styles/authoring/layout/workspace.scss
+++ b/assets/styles/authoring/layout/workspace.scss
@@ -23,29 +23,15 @@
   }
 
   .workspace-header {
-    display: flex;
-    flex-direction: row;
     border-bottom: 1px solid $gray-400;
     padding: 20px;
     position: relative;
     background-color: $workspace-header-bg;
+    width: 100%;
 
     .page-title {
       font-weight: bold;
-      width: 150px;
     }
-
-    .page-controls {
-      width: 150px;
-      display: flex;
-      flex-direction: row-reverse;
-    }
-
-    .project-title {
-      flex: 1;
-      text-align: center;
-    }
-
 
   }
 

--- a/lib/oli_web/templates/layout/_account_header.html.eex
+++ b/lib/oli_web/templates/layout/_account_header.html.eex
@@ -1,6 +1,5 @@
-<div class="workspace-header">
+<div class="workspace-header d-flex justify-content-between">
   <div class="page-title"><%= @title %></div>
-  <div class="flex-fill"></div>
   <div class="page-controls">
     <%= link "Sign out", to: Routes.auth_path(@conn, :signout), class: "btn btn-sm btn-primary" %>
   </div>

--- a/lib/oli_web/templates/layout/_project_header.html.eex
+++ b/lib/oli_web/templates/layout/_project_header.html.eex
@@ -1,5 +1,4 @@
-<div class="workspace-header">
+<div class="workspace-header d-flex justify-content-between">
   <div class="page-title"><%= @title %></div>
   <div class="project-title"><%= @project.title %></div>
-  <div class="page-controls"></div>
 </div>

--- a/lib/oli_web/templates/layout/_workspace_header.html.eex
+++ b/lib/oli_web/templates/layout/_workspace_header.html.eex
@@ -33,9 +33,8 @@
   </div>
 </div>
 
-<div class="workspace-header">
+<div class="workspace-header d-flex justify-content-between">
   <div class="page-title"><%= @title %></div>
-  <div class="flex-fill"></div>
   <div class="page-controls">
     <button id="button-new-project"
       class="btn btn-sm btn-primary"


### PR DESCRIPTION
This PR cleans up the header display, right-aligning the project name where it was centered.

Given that the active project can be switched via the projects page, we do not need a dropdown in the header to switch. 

Closes #211 

