### PR TITLE
breadcrumb trail navigation support

### DIFF
--- a/assets/src/components/activity/Navigation.tsx
+++ b/assets/src/components/activity/Navigation.tsx
@@ -1,5 +1,6 @@
 import { ProjectSlug, ResourceSlug } from 'data/types';
 import { SiblingActivity, ActivityContext } from 'data/content/activity';
+import { BreadcrumbTrail } from 'components/common/BreadcrumbTrail';
 
 const Sibling = ({ sibling, children, projectSlug, resourceSlug }
   : { sibling: SiblingActivity | null, children: any,
@@ -25,32 +26,21 @@ const Sibling = ({ sibling, children, projectSlug, resourceSlug }
 
 export const Navigation = (props: ActivityContext) => {
 
-  const { projectSlug, resourceSlug, previousActivity, nextActivity } = props;
+  const { projectSlug, resourceSlug, resourceTitle,
+    activitySlug, title, previousActivity, nextActivity } = props;
+
+  const page = {
+    slug: resourceSlug,
+    title: resourceTitle,
+  };
+  const activity = {
+    slug: activitySlug,
+    title,
+  };
 
   return (
     <div className="d-flex justify-content-between">
-      <nav aria-label="navigation">
-        <ul className="pagination">
-          <li className="page-item">
-            <a className="btn btn-outline-primary"
-              href={`/project/${projectSlug}/resource/${resourceSlug}`}>
-              <i className="fas fa-arrow-left"></i> Return to Page
-            </a>
-          </li>
-        </ul>
-      </nav>
-      <nav aria-label="navigation">
-        <ul className="pagination">
-          <Sibling projectSlug={projectSlug} resourceSlug={resourceSlug}
-            sibling={previousActivity}>
-            <i className="fas fa-arrow-circle-left"></i> Previous Activity
-          </Sibling>
-          <Sibling projectSlug={projectSlug} resourceSlug={resourceSlug}
-            sibling={nextActivity}>
-            Next Activity <i className="fas fa-arrow-circle-right"></i>
-          </Sibling>
-        </ul>
-      </nav>
+      <BreadcrumbTrail projectSlug={projectSlug} page={page} activity={activity}/>
     </div>
   );
 

--- a/assets/src/components/common/BreadcrumbTrail.tsx
+++ b/assets/src/components/common/BreadcrumbTrail.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+
+import { ProjectSlug } from 'data/types';
+
+export type BreadcrumbResource = {
+  slug: string,
+  title: string,
+};
+
+export interface BreadcrumbTrailProps {
+  projectSlug: ProjectSlug;
+  page: BreadcrumbResource;
+  activity?: BreadcrumbResource;
+}
+
+const curriculumPath = (projectSlug: string) => `/project/${projectSlug}/curriculum`;
+const pagePath = (projectSlug: string, pageSlug: string) => `/project/${projectSlug}/resource/${pageSlug}`;
+const link = (label: string, path: string) => <a href={path}>{label}</a>;
+
+export const BreadcrumbTrail = (props: BreadcrumbTrailProps) => {
+
+  let pageActivityLinks = null;
+
+  if (props.activity === undefined) {
+    pageActivityLinks = [
+      <li key="page" className="breadcrumb-item active" aria-current="page">{props.page.title}</li>,
+    ];
+  } else {
+    pageActivityLinks = [
+      <li key="page" className="breadcrumb-item">
+        {link(props.page.title, pagePath(props.projectSlug, props.page.slug))}
+      </li>,
+      <li key="activity" className="breadcrumb-item active" aria-current="page">
+        {props.activity.title}
+        </li>,
+    ];
+  }
+
+  return (
+    <nav aria-label="breadcrumb">
+      <ol className="breadcrumb">
+        <li key="project" className="breadcrumb-item">
+          {link('Curriculum', curriculumPath(props.projectSlug))}
+        </li>
+        {pageActivityLinks}
+      </ol>
+    </nav>
+  );
+
+};

--- a/assets/src/components/resource/ResourceEditor.tsx
+++ b/assets/src/components/resource/ResourceEditor.tsx
@@ -20,6 +20,7 @@ import { UndoableState, processRedo, processUndo, processUpdate, init } from './
 import { releaseLock, acquireLock } from 'data/persistence/lock';
 import { Message, createMessage } from 'data/messages/messages';
 import { Banner } from '../messages/Banner';
+import { BreadcrumbTrail } from 'components/common/BreadcrumbTrail';
 
 export interface ResourceEditorProps extends ResourceContext {
   editorMap: ActivityEditorMap;   // Map of activity types to activity elements
@@ -168,6 +169,12 @@ export class ResourceEditor extends React.Component<ResourceEditorProps, Resourc
     const props = this.props;
     const state = this.state;
 
+    const { projectSlug, resourceSlug, title } = this.props;
+    const page = {
+      slug: resourceSlug,
+      title,
+    };
+
     const onEdit = (content: Immutable.List<ResourceContent>) => {
       this.update({ content });
     };
@@ -196,6 +203,7 @@ export class ResourceEditor extends React.Component<ResourceEditorProps, Resourc
             executeAction={() => true}
             messages={this.state.messages}
           />
+          <BreadcrumbTrail projectSlug={projectSlug} page={page} />
           <TitleBar
             title={state.undoable.current.title}
             onTitleEdit={onTitleEdit}

--- a/assets/src/data/content/activity.ts
+++ b/assets/src/data/content/activity.ts
@@ -20,7 +20,8 @@ export type ActivityContext = {
   description: string,            // Activity type description
   authorEmail: string,            // The current author
   projectSlug: ProjectSlug,       // The current project
-  resourceSlug: ResourceSlug,     // The current resource
+  resourceSlug: ResourceSlug,     // The slug of parent resource
+  resourceTitle: string,          // The title of the parent resource
   activitySlug: ActivitySlug,     // The current resource
   title: string,                  // The title of the resource
   model: ActivityModelSchema,     // Content of the resource

--- a/lib/oli/authoring/editing/activity_context.ex
+++ b/lib/oli/authoring/editing/activity_context.ex
@@ -9,6 +9,7 @@ defmodule Oli.Authoring.Editing.ActivityContext do
     :authorEmail,
     :projectSlug,
     :resourceSlug,
+    :resourceTitle,
     :activitySlug,
     :title,
     :model,

--- a/lib/oli/authoring/editing/activity_editor.ex
+++ b/lib/oli/authoring/editing/activity_editor.ex
@@ -233,7 +233,7 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
          {:ok, resource} <- Resources.get_resource_from_slug(revision_slug) |> trap_nil(),
          {:ok, all_objectives} <- Publishing.get_published_objective_details(publication.id) |> trap_nil(),
          {:ok, objectives_without_ids} <- PageEditor.strip_ids(all_objectives) |> trap_nil(),
-         {:ok, %{content: content}} <- PageEditor.get_latest_revision(publication, resource) |> trap_nil(),
+         {:ok, %{content: content, title: resource_title}} <- PageEditor.get_latest_revision(publication, resource) |> trap_nil(),
          {:ok, %{id: activity_id}} <- Resources.get_resource_from_slug(activity_slug) |> trap_nil(),
          {:ok, %{activity_type: activity_type, content: model, title: title, objectives: objectives}} <- get_latest_revision(publication.id, activity_id) |> trap_nil()
     do
@@ -248,6 +248,7 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
         authorEmail: author.email,
         projectSlug: project_slug,
         resourceSlug: revision_slug,
+        resourceTitle: resource_title,
         activitySlug: activity_slug,
         title: title,
         model: model,

--- a/lib/oli_web/controllers/activity_controller.ex
+++ b/lib/oli_web/controllers/activity_controller.ex
@@ -17,7 +17,7 @@ defmodule OliWeb.ActivityController do
     is_admin? = Accounts.is_admin?(author)
 
     case ActivityEditor.create_context(project_slug, revision_slug, activity_slug, author) do
-      {:ok, context} -> render(conn, "edit.html", title: "Activity Editor", project_slug: project_slug, is_admin?: is_admin?, activity_slug: activity_slug, script: context.authoringScript, context: Jason.encode!(context))
+      {:ok, context} -> render(conn, "edit.html", active: :curriculum, title: "Activity Editor", project_slug: project_slug, is_admin?: is_admin?, activity_slug: activity_slug, script: context.authoringScript, context: Jason.encode!(context))
       {:error, :not_found} -> render conn, OliWeb.SharedView, "_not_found.html"
     end
 

--- a/lib/oli_web/controllers/resource_controller.ex
+++ b/lib/oli_web/controllers/resource_controller.ex
@@ -46,7 +46,7 @@ defmodule OliWeb.ResourceController do
     is_admin? = Accounts.is_admin?(author)
 
     case PageEditor.create_context(project_slug, revision_slug, conn.assigns[:current_author]) do
-      {:ok, context} -> render(conn, "edit.html", title: "Page Editor", is_admin?: is_admin?, context: Jason.encode!(context), scripts: Activities.get_activity_scripts(), project_slug: project_slug, revision_slug: revision_slug)
+      {:ok, context} -> render(conn, "edit.html", active: :curriculum, title: "Page Editor", is_admin?: is_admin?, context: Jason.encode!(context), scripts: Activities.get_activity_scripts(), project_slug: project_slug, revision_slug: revision_slug)
 
       {:error, :not_found} ->
         conn

--- a/lib/oli_web/live/curriculum/container.ex
+++ b/lib/oli_web/live/curriculum/container.ex
@@ -50,7 +50,15 @@ defmodule OliWeb.Curriculum.Container do
 
     ~L"""
       <div class="container">
-        <h2>Course Curriculum</h2>
+        <div class="row">
+          <div class="col-12">
+            <nav aria-label="breadcrumb">
+              <ol class="breadcrumb">
+                <li class="breadcrumb-item active" aria-current="page">Curriculum</li>
+              </ol>
+            </nav>
+          </div>
+        </div>
         <div class="row">
           <div class="col-12">
             <p class="text-secondary">


### PR DESCRIPTION
This PR adds breadcrumb trail navigation for the curriculum, page, and activitiy editors 

It also allows the left-hand nav "Curriculum" link to remain active when a page or activity editor is in view. 

I removed the Prev and Next activity navigation buttons from the activity editor. With the breadcrumb trail in place it just seemed like too much in the UI. 

Closes #287 
