### PR TITLE
prevent immediate save

### DIFF
--- a/assets/src/components/activities/multiple_choice/MultipleChoiceAuthoring.tsx
+++ b/assets/src/components/activities/multiple_choice/MultipleChoiceAuthoring.tsx
@@ -1,4 +1,4 @@
-import React, { useReducer, useEffect } from 'react';
+import React, { useReducer, useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { AuthoringElement, AuthoringElementProps } from '../AuthoringElement';
 import { MultipleChoiceModelSchema } from './schema';
@@ -16,10 +16,16 @@ const store = configureStore();
 
 const MultipleChoice = (props: AuthoringElementProps<MultipleChoiceModelSchema>) => {
   const [state, dispatch] = useReducer(MCReducer, props.model);
+  const [initialUpdate, setInitialUpate] = useState(true);
   const { projectSlug } = props;
 
   useEffect(() => {
-    props.onEdit(state);
+    // This prevents an immediate persistence call as this effect will
+    // view the [state] dependency as having changed on the initial update
+    if (!initialUpdate) {
+      props.onEdit(state);
+    }
+    setInitialUpate(false);
   }, [state]);
 
   const sharedProps = {

--- a/assets/src/components/activities/short_answer/ShortAnswerAuthoring.tsx
+++ b/assets/src/components/activities/short_answer/ShortAnswerAuthoring.tsx
@@ -1,4 +1,4 @@
-import React, { useReducer, useEffect } from 'react';
+import React, { useReducer, useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { AuthoringElement, AuthoringElementProps } from '../AuthoringElement';
 import { ShortAnswerModelSchema, InputType } from './schema';
@@ -48,9 +48,15 @@ export const InputTypeDropdown = ({ onChange, editMode, inputType }: InputTypeDr
 
 const ShortAnswer = (props: AuthoringElementProps<ShortAnswerModelSchema>) => {
   const [state, dispatch] = useReducer(ShortAnswerReducer, props.model);
+  const [initialUpdate, setInitialUpate] = useState(true);
 
   useEffect(() => {
-    props.onEdit(state);
+    // This prevents an immediate persistence call as this effect will
+    // view the [state] dependency as having changed on the initial update
+    if (!initialUpdate) {
+      props.onEdit(state);
+    }
+    setInitialUpate(false);
   }, [state]);
 
   const sharedProps = {


### PR DESCRIPTION
This PR fixes a problem where activity editors were posting an unnecessary, immediate save back to the server when they stood up.  The root cause was the effect driving this executes on the initial view of its dependency - not just when that dependency changes. 

Closes #286 