### PR TITLE
Resource link

### DIFF
--- a/lib/oli/authoring/course.ex
+++ b/lib/oli/authoring/course.ex
@@ -60,7 +60,7 @@ defmodule Oli.Authoring.Course do
   def initial_resource_setup(author, project) do
 
     attrs = %{
-      title: project.title <> " Curriculum",
+      title: "Curriculum",
       author_id: author.id,
       resource_type_id: Oli.Resources.ResourceType.get_id_by_type("container")
     }

--- a/lib/oli/authoring/course.ex
+++ b/lib/oli/authoring/course.ex
@@ -60,7 +60,7 @@ defmodule Oli.Authoring.Course do
   def initial_resource_setup(author, project) do
 
     attrs = %{
-      title: project.title <> " root container",
+      title: project.title <> " Curriculum",
       author_id: author.id,
       resource_type_id: Oli.Resources.ResourceType.get_id_by_type("container")
     }

--- a/lib/oli_web/common/links.ex
+++ b/lib/oli_web/common/links.ex
@@ -8,6 +8,7 @@ defmodule OliWeb.Common.Links do
       "objective" -> link revision.title, to: Routes.live_path(OliWeb.Endpoint, OliWeb.Objectives.Objectives, project.slug)
       "page" -> link revision.title, to: Routes.resource_path(OliWeb.Endpoint, :edit, project, revision.slug)
       "activity" -> link revision.title, to: Routes.resource_path(OliWeb.Endpoint, :edit, project, Map.get(parent_pages, revision.resource_id).slug)
+      "container" -> link revision.title, to: Routes.live_path(OliWeb.Endpoint, OliWeb.Curriculum.Container, project.slug)
     end
 
   end

--- a/test/oli/course_test.exs
+++ b/test/oli/course_test.exs
@@ -129,12 +129,12 @@ defmodule Oli.CourseTest do
     end
 
     test "creates a new container resource", %{resource_revision: revision} do
-      assert revision.slug =~ "root_container"
+      assert revision.slug =~ "curriculum"
     end
 
     test "creates a new resource revision for the container", %{resource: resource, resource_revision: resource_revision} do
       revision = Repo.preload(resource_revision, [:resource])
-      assert revision.slug =~ "root_container"
+      assert revision.slug =~ "curriculum"
       assert revision.resource == resource
     end
 


### PR DESCRIPTION
This PR fixes an issue when the root container changes and a user clicks the "Publish" tab.  Root cause was that that type of change was considered as valid when constructing links.

I also adjusted the title of that root container to instead just be "Curriculum".  It was previously displaying the original title of the course with " root container" appended.  That title could get out of date as soon as a user edits the title.  

Closes #310 
