### PR TITLE
enable mathjax 3 in delivery only

### DIFF
--- a/lib/oli_web/templates/layout/delivery.html.eex
+++ b/lib/oli_web/templates/layout/delivery.html.eex
@@ -25,6 +25,26 @@
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined"
       rel="stylesheet">
 
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+    <script>
+    window.MathJax = {
+      tex: {
+        inlineMath: [ ["\\(","\\)"] ],
+        displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
+        processEscapes: true,
+        packages: ['base', 'ams', 'noerrors', 'noundefined']
+      },
+      options: {
+        ignoreHtmlClass: 'tex2jax_ignore',
+        processHtmlClass: 'tex2jax_process'
+      },
+      loader: {
+        load: ['[tex]/noerrors']
+      }
+    };
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" id="MathJax-script"></script>
+
     <%= csrf_meta_tag() %>
     <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/app.js") %>"></script>
   </head>


### PR DESCRIPTION
This PR enables LaTex rendering in delivery mode, via MathJax v3.  

It pulls forward the same MathJax configuration, using \(   \) to delimit inline math, and $$ $$ and \[ \] to delimit block math.

Closes #308 

