### PR TITLE
convert to to_existing_atom where possible

### DIFF
--- a/lib/oli_web/live/curriculum/container.ex
+++ b/lib/oli_web/live/curriculum/container.ex
@@ -126,7 +126,7 @@ defmodule OliWeb.Curriculum.Container do
     params = Enum.reduce(params, %{}, fn {k, v}, m ->
       case MapSet.member?(MapSet.new(["_csrf_token", "_target"]), k) do
         true -> m
-        false -> Map.put(m, String.to_atom(k), v)
+        false -> Map.put(m, String.to_existing_atom(k), v)
       end
     end)
 

--- a/lib/oli_web/live/history/details.ex
+++ b/lib/oli_web/live/history/details.ex
@@ -36,7 +36,7 @@ defmodule OliWeb.RevisionHistory.Details do
         <%= for k <- attrs do %>
           <tr>
           <td style="width:100px;"><strong><%= k %></strong></td>
-          <td><%= Map.get(@revision, String.to_atom(k)) %></td>
+          <td><%= Map.get(@revision, String.to_existing_atom(k)) %></td>
           </tr>
         <% end %>
       </tbody>

--- a/lib/oli_web/live/objectives/objectives.ex
+++ b/lib/oli_web/live/objectives/objectives.ex
@@ -175,7 +175,7 @@ defmodule OliWeb.Objectives.Objectives do
   # process form submission to save page settings
   def handle_event("edit", %{"revision" => objective_params}, socket) do
     with_atom_keys = Map.keys(objective_params)
-                     |> Enum.reduce(%{}, fn k, m -> Map.put(m, String.to_atom(k), Map.get(objective_params, k)) end)
+                     |> Enum.reduce(%{}, fn k, m -> Map.put(m, String.to_existing_atom(k), Map.get(objective_params, k)) end)
     socket = case ObjectiveEditor.edit(Map.get(with_atom_keys,:slug), with_atom_keys, socket.assigns.author, socket.assigns.project) do
       {:ok, _} -> socket
       {:error, _} -> socket
@@ -214,7 +214,7 @@ defmodule OliWeb.Objectives.Objectives do
   # handle clicking of the add objective
   def handle_event("new", %{"revision" => objective_params}, socket) do
     with_atom_keys = Map.keys(objective_params)
-                     |> Enum.reduce(%{}, fn k, m -> Map.put(m, String.to_atom(k), Map.get(objective_params, k)) end)
+                     |> Enum.reduce(%{}, fn k, m -> Map.put(m, String.to_existing_atom(k), Map.get(objective_params, k)) end)
 
     container_slug = Map.get(objective_params, "parent_slug")
 


### PR DESCRIPTION
I performed an audit on all uses of `String.to_atom`. 

Where possible I replaced with `String.to_existing_atom`

The only place where user input is converted to atoms is in the `./lib/oli/utils/snapshots/snapshot_seeder.ex` code that processes an external CSV to generate test data.  While this is primarily a test tool, it is being used right now to seed production data when a database is created.  It only triggers a dozen or so new atom creations, so I don't believe that it poses an risk. 

Moving forward we need to include in our code reviews a review of usages of `String.to_atom`

Closes #282 