### PR TITLE
Slug special chars

### DIFF
--- a/lib/oli/authoring/course.ex
+++ b/lib/oli/authoring/course.ex
@@ -103,7 +103,6 @@ defmodule Oli.Authoring.Course do
   defp default_project(title, family) do
     %{
       title: title,
-      slug: Utils.generate_slug("projects", title),
       version: "1.0.0",
       family_id: family.id
     }

--- a/lib/oli/utils/slug.ex
+++ b/lib/oli/utils/slug.ex
@@ -103,6 +103,7 @@ defmodule Oli.Utils.Slug do
     String.downcase(title, :default)
       |> String.trim()
       |> String.replace(" ", "_")
+      |> alpha_numeric_only()
       |> URI.encode_www_form()
       |> String.slice(0, 30)
   end
@@ -121,4 +122,8 @@ defmodule Oli.Utils.Slug do
   end
   defp unique_slug(_table, _, []) do "" end
 
+  def alpha_numeric_only(str) do
+    # \W is the shorthand for the [^a-zA-Z0-9] pattern
+    String.replace(str, ~r/[\W]+/, "")
+  end
 end

--- a/test/oli/utils/slug_test.exs
+++ b/test/oli/utils/slug_test.exs
@@ -20,6 +20,12 @@ defmodule Oli.Utils.SlugTest do
       map
     end
 
+    test "alpha numeric only", _ do
+
+      alpha_numeric = Slug.alpha_numeric_only("My_Test Project ~!@#$%^&*()--+=[]{}\|;:'<>,./?")
+      assert alpha_numeric == "My_TestProject"
+    end
+
     test "update_on_change/2 does not update the slug when the previous revision title matches", %{ revision1: r } do
 
       {:ok, new_revision} = Revision.changeset(%Revision{}, %{

--- a/test/oli/utils/slug_test.exs
+++ b/test/oli/utils/slug_test.exs
@@ -24,6 +24,7 @@ defmodule Oli.Utils.SlugTest do
 
       alpha_numeric = Slug.alpha_numeric_only("My_Test Project ~!@#$%^&*()--+=[]{}\|;:'<>,./?")
       assert alpha_numeric == "My_TestProject"
+
     end
 
     test "update_on_change/2 does not update the slug when the previous revision title matches", %{ revision1: r } do


### PR DESCRIPTION
This PR adjusts slug generation to remove all non alpha numeric characters.  Some of these characters, when encoded as a URL were causing problems in routing, which breaks all LiveViews that include slugs in their URL 

[error] GenServer #PID<0.5095.0> terminating
** (ArgumentError) cannot invoke handle_params nor live_redirect/live_patch to "http://localhost:4000/project/my_test_project_%60~%21%40%23%24%25%5E%26%2A%28%29--%2B%3D%5B%5D%7B%7D%5C%7C%3B%3A%27%22%3C%3E%2C.%2F%3F/curriculum" because it isn't defined in OliWeb.Router

I have tested this locally and it fixes the problem 

Closes #334 
