### PR TITLE
pass along correct arguments

### DIFF
--- a/lib/oli/authoring/editing/page_editor.ex
+++ b/lib/oli/authoring/editing/page_editor.ex
@@ -387,7 +387,7 @@ defmodule Oli.Authoring.Editing.PageEditor do
     title = Map.get(update, "title", previous.title)
 
     if (title != previous.title) do
-      create_new_revision(previous, publication, resource, author_id)
+      create_new_revision({previous, changed_activity_revisions}, publication, resource, author_id)
     else
       {previous, changed_activity_revisions}
     end


### PR DESCRIPTION
Pass along the correct arguments, otherwise any time a title edit is made the user receives a persistence error. 