### PR TITLE
do not display submit button, adjust error capture

### DIFF
--- a/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
+++ b/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
@@ -118,6 +118,15 @@ const ShortAnswer = (props: DeliveryElementProps<ShortAnswerModelSchema>) => {
     <Hints key="hints" onClick={onRequestHint} hints={hints}
       hasMoreHints={hasMoreHints} isEvaluated={isEvaluated}/>];
 
+  const maybeSubmitButton = props.graded
+  ? null
+  : (
+    <button
+      className="btn btn-primary mt-2" disabled={isEvaluated} onClick={onSubmit}>
+      Submit
+    </button>
+  );
+
   return (
     <div className="activity short-answer-activity">
       <div className="activity-content">
@@ -125,11 +134,7 @@ const ShortAnswer = (props: DeliveryElementProps<ShortAnswerModelSchema>) => {
 
         <div className="">
           <Input inputType={model.inputType} input={input} onChange={onInputChange}/>
-
-          <button
-            className="btn btn-primary mt-2" disabled={isEvaluated} onClick={onSubmit}>
-            Submit
-          </button>
+          {maybeSubmitButton}
         </div>
 
         {ungradedDetails}

--- a/lib/oli/delivery/attempts.ex
+++ b/lib/oli/delivery/attempts.ex
@@ -573,9 +573,10 @@ defmodule Oli.Delivery.Attempts do
 
     case Repo.update_all(from(p in PartAttempt, where: p.attempt_guid == ^attempt_guid and is_nil(p.date_evaluated)),
       set: [response: input, date_evaluated: now, score: score, out_of: out_of, feedback: feedback]) do
-      nil -> {:halt, :error}
+      nil -> {:halt, {:error, :error}}
       {1, _} -> {:cont, {:ok, results ++ [%{attempt_guid: attempt_guid, feedback: feedback, score: score, out_of: out_of}]}}
-      _ -> {:halt, :error}
+      e ->
+        {:halt, {:error, :error}}
     end
 
   end
@@ -715,6 +716,7 @@ defmodule Oli.Delivery.Attempts do
 
         {:ok, results} -> results
         {:error, error} -> Repo.rollback(error)
+        _ -> Repo.rollback("unknown error")
       end
 
     end)

--- a/lib/oli/delivery/attempts.ex
+++ b/lib/oli/delivery/attempts.ex
@@ -575,7 +575,7 @@ defmodule Oli.Delivery.Attempts do
       set: [response: input, date_evaluated: now, score: score, out_of: out_of, feedback: feedback]) do
       nil -> {:halt, {:error, :error}}
       {1, _} -> {:cont, {:ok, results ++ [%{attempt_guid: attempt_guid, feedback: feedback, score: score, out_of: out_of}]}}
-      e ->
+      _ ->
         {:halt, {:error, :error}}
     end
 

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -126,7 +126,7 @@ defmodule OliWeb.PageDeliveryController do
         {:ok, _} -> redirect(conn, to: Routes.page_delivery_path(conn, :page, context_id, revision_slug))
         {:error, {:active_attempt_present}} -> redirect(conn, to: Routes.page_delivery_path(conn, :page, context_id, revision_slug))
         {:error, {:no_more_attempts}} -> redirect(conn, to: Routes.page_delivery_path(conn, :page, context_id, revision_slug))
-        {:error, {:not_found}} -> render(conn, "error.html")
+        _ -> render(conn, "error.html")
       end
 
     else
@@ -153,7 +153,7 @@ defmodule OliWeb.PageDeliveryController do
         {:error, {:already_submitted}} -> redirect(conn, to: Routes.page_delivery_path(conn, :page, context_id, revision_slug))
         {:error, {:active_attempt_present}} -> redirect(conn, to: Routes.page_delivery_path(conn, :page, context_id, revision_slug))
         {:error, {:no_more_attempts}} -> redirect(conn, to: Routes.page_delivery_path(conn, :page, context_id, revision_slug))
-        {:error, {:not_found}} -> render(conn, "error.html")
+        _ -> render(conn, "error.html")
       end
 
     else


### PR DESCRIPTION
This PR hides the "Submit" button for single response quesions in a graded context.

In a graded context, all part attempts should be "not evaluated" at the time that the user clicks "Submit Assessment"

Having this button visible allowed a user to Submit a part, which broke assessment submission.

I'm filing a follow up bug to make Assessment submission more robust to this situation - because there will eventually be activity implementations that we do not control that submit ahead of time in a graded context. 

Closes #377 
Closes #295 
