### PR TITLE
Pair of Media Library fixes

### DIFF
--- a/assets/src/components/modal/ModalSelection.tsx
+++ b/assets/src/components/modal/ModalSelection.tsx
@@ -49,7 +49,7 @@ class ModalSelection extends React.PureComponent<ModalSelectionProps, {}> {
     return (
       <div ref={(modal) => { this.modal = modal; }}
         data-backdrop="true" className="modal">
-        <div className={`modal-dialog modal-${size}`} role="document">
+        <div className={`modal-dialog modal-dialog-centered modal-${size}`} role="document">
           <div className="modal-content">
             <div className="modal-header">
               <h5 className="modal-title">{this.props.title}</h5>

--- a/assets/styles/authoring/main.scss
+++ b/assets/styles/authoring/main.scss
@@ -7,6 +7,10 @@ body {
   font-size: $font-size-base;
 }
 
+body.modal-open {
+  overflow: visible;
+}
+
 body {
   h1 {
     font-size: $h1-font-size;

--- a/assets/styles/delivery/main.scss
+++ b/assets/styles/delivery/main.scss
@@ -8,6 +8,10 @@ body {
   font-size: $font-size-base;
 }
 
+body.modal-open {
+  overflow: visible;
+}
+
 .oli-logo {
   font-family: 'Open Sans', sans-serif;
 }

--- a/lib/oli/authoring/media_library/item_options.ex
+++ b/lib/oli/authoring/media_library/item_options.ex
@@ -19,7 +19,7 @@ defmodule Oli.Authoring.MediaLibrary.ItemOptions do
      mime_filter: nil,
      url_filter: nil,
      search_text: nil,
-     order_field: "file_name",
+     order_field: "fileName",
      order: "asc"
     }
   end
@@ -37,7 +37,7 @@ defmodule Oli.Authoring.MediaLibrary.ItemOptions do
       mime_filter: mime_filter,
       url_filter: Map.get(options, "urlFilter", nil),
       search_text: Map.get(options, "searchText", nil),
-      order_field:  Map.get(options, "orderBy", "file_name"),
+      order_field:  Map.get(options, "orderBy", "fileName"),
       order: Map.get(options, "order", "asc"),
     }
   end


### PR DESCRIPTION
Closes #383 

This was a simple fix, the default sort order field name was incorrect. 

Closes #368 

Also prevents the modal appearance from scrolling to the top of the page.  This was not obvious to me how to fix this, but the following SO question showed how: https://stackoverflow.com/questions/21604674/bootstrap-modal-background-jumps-to-top-on-toggle

I also added the class name to allow the Media Library to display vertically centered on the page. 