### PR TITLE
adjust length of various strings to allow them to exceed 255 chars

### DIFF
--- a/priv/repo/migrations/20200710120811_adjust_string_lengths.exs
+++ b/priv/repo/migrations/20200710120811_adjust_string_lengths.exs
@@ -1,0 +1,22 @@
+defmodule Oli.Repo.Migrations.AdjustStringLengths do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sections) do
+      modify :lti_lineitems_url, :text
+      modify :canvas_url, :text
+    end
+    alter table(:activity_registrations) do
+      modify :description, :text
+    end
+    alter table(:revisions) do
+      modify :title, :text
+    end
+    alter table(:media_items) do
+      modify :url, :text
+    end
+    alter table(:themes) do
+      modify :url, :text
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a migration to adjust the lengths of a handful of fields in our schema that are currently set to a max of 255 characters. 

I tested this locally via `mix ecto.migrate` and it worked great. 

Closes #355 

