### PR TITLE
table fixes

### DIFF
--- a/assets/src/components/editor/Editor.tsx
+++ b/assets/src/components/editor/Editor.tsx
@@ -1,14 +1,14 @@
-import React, { useMemo, useCallback, KeyboardEvent } from 'react';
+import React, { useMemo, useCallback, useEffect, useState, KeyboardEvent } from 'react';
 import { Slate, Editable, withReact, ReactEditor } from 'slate-react';
-import { createEditor, Node, NodeEntry, Range, Editor as SlateEditor, Transforms, Path } from 'slate';
-import { create, Mark, ModelElement, schema, Paragraph, SchemaConfig } from 'data/content/model';
+import { createEditor, Node, Range, Transforms, Path } from 'slate';
+import { create, Mark, ModelElement, schema, Paragraph } from 'data/content/model';
 import { editorFor, markFor } from './editors';
 import { ToolbarItem, CommandContext } from './interfaces';
 import { FixedToolbar, HoveringToolbar } from './Toolbars';
 import { onKeyDown as listOnKeyDown } from './editors/Lists';
 import { onKeyDown as quoteOnKeyDown } from './editors/Blockquote';
 import { getRootOfText } from './utils';
-
+import { installNormalizer } from './normalizer';
 import guid from 'utils/guid';
 
 export type EditorProps = {
@@ -61,6 +61,15 @@ export const Editor = React.memo((props: EditorProps) => {
   const commandContext = props.commandContext;
 
   const editor = useMemo(() => withReact(createEditor()), []);
+  const [installed, setInstalled] = useState(false);
+
+  // Install the custom normalizer, only once
+  useEffect(() => {
+    if (!installed) {
+      installNormalizer(editor);
+      setInstalled(true);
+    }
+  }, [installed]);
 
   // Override isVoid to incorporate our schema's opinion on which
   // elements are void
@@ -81,63 +90,6 @@ export const Editor = React.memo((props: EditorProps) => {
     } catch (e) {
       return false;
     }
-  };
-
-  const { normalizeNode } = editor;
-  editor.normalizeNode = (entry: NodeEntry<Node>) => {
-
-    if ((editor as any).suspendNormalization) {
-      normalizeNode(entry);
-      return;
-    }
-
-    try {
-      const [node, path] = entry;
-
-      // Ensure that we always have a paragraph as the last node in
-      // the document, otherwise it can be impossible for a user
-      // to position their cursor after the last node
-      if (SlateEditor.isEditor(node)) {
-        const last = node.children[node.children.length - 1];
-
-        if (last.type !== 'p') {
-          Transforms.insertNodes(editor, create<Paragraph>(
-            { type: 'p', children: [{ text: '' }], id: guid() }),
-            { mode: 'highest', at: SlateEditor.end(editor, []) });
-        }
-        return; // Return here is necessary to enable multi-pass normalization
-
-      }
-
-      // Check this node's parent constraints
-      if (SlateEditor.isBlock(editor, node)) {
-        const [parent] = SlateEditor.parent(editor, path);
-        if (!SlateEditor.isEditor(parent)) {
-          const config : SchemaConfig = (schema as any)[parent.type as string];
-          if (!(config.validChildren as any)[node.type as string]) {
-            Transforms.removeNodes(editor, { at: path });
-            return; // Return here is necessary to enable multi-pass normalization
-          }
-
-        }
-      }
-
-      // Check the top-level constraints
-      if (SlateEditor.isBlock(editor, node) && !(schema as any)[node.type as string].isTopLevel) {
-        const [parent] = SlateEditor.parent(editor, path);
-        if (SlateEditor.isEditor(parent)) {
-          Transforms.removeNodes(editor, { at: path });
-          return; // Return here is necessary to enable multi-pass normalization
-        }
-      }
-
-    } catch (e) {
-      // tslint:disable-next-line
-      console.log(e);
-    }
-
-    normalizeNode(entry);
-
   };
 
   const renderElement = useCallback((props) => {

--- a/assets/src/components/editor/editors/SizePicker.tsx
+++ b/assets/src/components/editor/editors/SizePicker.tsx
@@ -7,10 +7,8 @@ type Size = {
 
 const initialSize: Size = { rows: 1, columns: 1 };
 
-const minRows = 6;
-const maxRows = 16;
-const minCols = 6;
-const maxCols = 16;
+const maxRows = 10;
+const maxCols = 8;
 
 const cellContainerStyle = {
   padding: '2px',
@@ -43,14 +41,14 @@ export const SizePicker = (props: SizePickerProps) => {
 
   const isHighlighted = (row: number, col: number) => size.rows >= row && size.columns >= col;
 
-  const numRows = Math.min(Math.max(size.rows, minRows) + 1, maxRows);
-  const numCols = Math.min(Math.max(size.columns, minCols) + 1, maxCols);
+  const numRows = maxRows;
+  const numCols = maxCols;
 
   const rows = range(numRows);
   const cols = range(numCols);
 
-  const width = (numCols * 19 + 10) + 'px';
-  const height = (numRows * 22 + 5) + 'px';
+  const width = (maxCols * 19 + 10) + 'px';
+  const height = (maxRows * 25 + 35) + 'px';
 
   const mapRow = (row: number) => {
     const cells = cols.map((col: number) => (

--- a/assets/src/components/editor/editors/Table.tsx
+++ b/assets/src/components/editor/editors/Table.tsx
@@ -57,6 +57,7 @@ export const normalize = (editor: ReactEditor, node: Node, path: Path) => {
         // Add as many empty td elements to bring this row back up to
         // the max td count
         while (count < max) {
+          console.log('Inserting cell')
           Transforms.insertNodes(editor, td(''), { at: thisPath });
           count = count + 1;
         }
@@ -150,29 +151,68 @@ const DropdownMenu = (props: any) => {
   };
 
   const onAddColumnBefore = () => {
-    const editor: ReactEditor = props.editor;
-    const path = ReactEditor.findPath(editor, props.model);
-    const [, parentPath] = Editor.parent(editor, path);
-    const [table] = Editor.parent(editor, parentPath);
 
-    const rows = table.children.length;
-    for (let i = 0; i < rows; i += 1) {
-      path[path.length - 2] = i;
-      Transforms.insertNodes(editor, td(''), { at: path });
+    const editor: ReactEditor = props.editor;
+
+    try {
+
+      // The edits here result in intermediate states that normalization
+      // would seek to correct.  So to allow this operation to succeed,
+      // we instruct our editor instance to suspend normalization.
+
+      (editor as any).suspendNormalization = true;
+
+      const path = ReactEditor.findPath(editor, props.model);
+      const [, parentPath] = Editor.parent(editor, path);
+      const [table] = Editor.parent(editor, parentPath);
+
+      const rows = table.children.length;
+      for (let i = 0; i < rows; i += 1) {
+        path[path.length - 2] = i;
+        Transforms.insertNodes(editor, td(''), { at: path });
+      }
+    } catch (error) {
+      // tslint:disable-next-line
+      console.log(error);
+
+    } finally {
+      // Whether the operation succeeded or failed, we restore
+      // normalization
+      (editor as any).suspendNormalization = false;
     }
+
   };
 
   const onAddColumnAfter = () => {
-    const editor: ReactEditor = props.editor;
-    const path = ReactEditor.findPath(editor, props.model);
-    const [, parentPath] = Editor.parent(editor, path);
-    const [table] = Editor.parent(editor, parentPath);
 
-    const rows = table.children.length;
-    for (let i = 0; i < rows; i += 1) {
-      path[path.length - 2] = i;
-      Transforms.insertNodes(editor, td(''), { at: Path.next(path) });
+    const editor: ReactEditor = props.editor;
+
+    try {
+
+      // The edits here result in intermediate states that normalization
+      // would seek to correct.  So to allow this operation to succeed,
+      // we instruct our editor instance to suspend normalization.
+      (editor as any).suspendNormalization = true;
+
+      const path = ReactEditor.findPath(editor, props.model);
+      const [, parentPath] = Editor.parent(editor, path);
+      const [table] = Editor.parent(editor, parentPath);
+
+      const rows = table.children.length;
+      for (let i = 0; i < rows; i += 1) {
+        path[path.length - 2] = i;
+        Transforms.insertNodes(editor, td(''), { at: Path.next(path) });
+      }
+    } catch (error) {
+      // tslint:disable-next-line
+      console.log(error);
+
+    } finally {
+      // Whether the operation succeeded or failed, we restore
+      // normalization
+      (editor as any).suspendNormalization = false;
     }
+
   };
 
   const onDeleteRow = () => {

--- a/assets/src/components/editor/editors/Table.tsx
+++ b/assets/src/components/editor/editors/Table.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { ReactEditor, useFocused, useSelected, useSlate } from 'slate-react';
-import { Transforms, Editor, Path } from 'slate';
+import { Transforms, Node, Editor, Path, Editor as SlateEditor } from 'slate';
 import { updateModel, getEditMode } from './utils';
 import * as ContentModel from 'data/content/model';
 import { Command, CommandDesc } from '../interfaces';
@@ -19,6 +19,54 @@ const tr = (children: ContentModel.TableData[]) => ContentModel.create<ContentMo
 
 const table = (children: ContentModel.TableRow[]) => ContentModel.create<ContentModel.Table>(
   { type: 'table', children, id: guid() });
+
+export const normalize = (editor: ReactEditor, node: Node, path: Path) => {
+
+  if (node.type === 'table') {
+    // Ensure that the number of cells in each row is the same
+
+    // First get max count of cells in any row, and see if any rows
+    // have a different amount of cells.
+    let max = -1;
+    let anyDiffer = false;
+    (node.children as any).forEach((row: Node) => {
+      const children = row.children as any;
+      const count = children.length;
+
+      if (max === -1) {
+        max = count;
+      } else if (count !== max) {
+        anyDiffer = true;
+
+        if (count > max) {
+          max = count;
+        }
+      }
+    });
+
+
+    if (anyDiffer) {
+
+      (node.children as any).forEach((row: Node, index: number) => {
+        const children = row.children as any;
+        let count = children.length;
+
+        // Get a path to the first td element in this row
+        const thisPath = [...path, index, 0];
+
+        // Add as many empty td elements to bring this row back up to
+        // the max td count
+        while (count < max) {
+          Transforms.insertNodes(editor, td(''), { at: thisPath });
+          count = count + 1;
+        }
+
+      });
+    }
+
+  }
+
+};
 
 
 // The UI command for creating tables
@@ -247,10 +295,6 @@ type TableSettingsProps = {
   commandContext: CommandContext,
   editMode: boolean,
 };
-
-const toLink = (src: string) =>
-  'https://www.youtube.com/embed/' + (src === '' ? 'zHIIzcWqsP0' : src);
-
 
 const TableSettings = (props: TableSettingsProps) => {
 

--- a/assets/src/components/editor/editors/Table.tsx
+++ b/assets/src/components/editor/editors/Table.tsx
@@ -57,7 +57,6 @@ export const normalize = (editor: ReactEditor, node: Node, path: Path) => {
         // Add as many empty td elements to bring this row back up to
         // the max td count
         while (count < max) {
-          console.log('Inserting cell')
           Transforms.insertNodes(editor, td(''), { at: thisPath });
           count = count + 1;
         }

--- a/assets/src/components/editor/normalizer.ts
+++ b/assets/src/components/editor/normalizer.ts
@@ -1,0 +1,70 @@
+
+import { ReactEditor } from 'slate-react';
+import { Node, NodeEntry, Editor as SlateEditor, Transforms } from 'slate';
+import { normalize as tableNormalize } from './editors/Table';
+import { create, schema, Paragraph, SchemaConfig } from 'data/content/model';
+import guid from 'utils/guid';
+
+export function installNormalizer(editor: SlateEditor & ReactEditor) {
+
+  const { normalizeNode } = editor;
+  editor.normalizeNode = (entry: NodeEntry<Node>) => {
+
+    if ((editor as any).suspendNormalization) {
+      normalizeNode(entry);
+      return;
+    }
+
+    try {
+      const [node, path] = entry;
+
+      // Ensure that we always have a paragraph as the last node in
+      // the document, otherwise it can be impossible for a user
+      // to position their cursor after the last node
+      if (SlateEditor.isEditor(node)) {
+        const last = node.children[node.children.length - 1];
+
+        if (last.type !== 'p') {
+          Transforms.insertNodes(editor, create<Paragraph>(
+            { type: 'p', children: [{ text: '' }], id: guid() }),
+            { mode: 'highest', at: SlateEditor.end(editor, []) });
+        }
+        return; // Return here is necessary to enable multi-pass normalization
+
+      }
+
+      // Check this node's parent constraints
+      if (SlateEditor.isBlock(editor, node)) {
+        const [parent] = SlateEditor.parent(editor, path);
+        if (!SlateEditor.isEditor(parent)) {
+          const config : SchemaConfig = (schema as any)[parent.type as string];
+          if (!(config.validChildren as any)[node.type as string]) {
+            Transforms.removeNodes(editor, { at: path });
+            return; // Return here is necessary to enable multi-pass normalization
+          }
+
+        }
+      }
+
+      // Check the top-level constraints
+      if (SlateEditor.isBlock(editor, node) && !(schema as any)[node.type as string].isTopLevel) {
+        const [parent] = SlateEditor.parent(editor, path);
+        if (SlateEditor.isEditor(parent)) {
+          Transforms.removeNodes(editor, { at: path });
+          return; // Return here is necessary to enable multi-pass normalization
+        }
+      }
+
+      // Run any element specific normalizers
+      tableNormalize(editor, node, path);
+
+    } catch (e) {
+      // tslint:disable-next-line
+      console.log(e);
+    }
+
+    normalizeNode(entry);
+
+  };
+
+}


### PR DESCRIPTION
Closes #397 
Closes #346 

This PR fixes three problems:

1) Deleting content in a cell can delete the cell, leaving the table in a weird state.  I have added table specific normalization to ensure that all rows always have the same number of cells, thus overriding a cell deletion

2) The auto-resizing table dropdown was hard to use when it was over certain elements (e.g. YouTube) and also rendered oddly when it pops up above the toolbar item (like when that toolbar item is at the bottom of the page).  I simply disabled the self-growing aspect of this size picker

3) In debugging the first issue, I caught a possibly SERIOUS performance issue with how our custom slate normalization was being installed.  Our custom `normalizeNode` function overrides the built-in one, but then calls the built in one to delegate to its core functionality.  This is a correct pattern, EXCEPT that it was doing this in the render phase of the component.  This means that every time the component would render, a new `normalizeNode` would get installed that would delegate back to the current one.  So after 100 character key presses you would now be going throw 100 levels of normalize calls.  That is very, very bad.  I reworked this to leverage state and an effect to install this exactly once.  