### PR TITLE
Change datashop download method

### DIFF
--- a/lib/oli/analytics/datashop.ex
+++ b/lib/oli/analytics/datashop.ex
@@ -1,10 +1,10 @@
 defmodule Oli.Analytics.Datashop do
   @moduledoc """
+  For documentation on DataShop logging message formats, see:
+
   https://pslcdatashop.web.cmu.edu/dtd/guide/tutor_message_dtd_guide_v4.pdf
   https://pslcdatashop.web.cmu.edu/help?page=logging
   https://pslcdatashop.web.cmu.edu/help?page=importFormatTd
-
-  QA: https://pslc-qa.andrew.cmu.edu/datashop/Project?id=250
   """
 
   import XmlBuilder
@@ -14,13 +14,12 @@ defmodule Oli.Analytics.Datashop do
   alias Oli.Analytics.Datashop.Messages.{Context, Tool, Tutor}
   alias Oli.Analytics.Datashop.Utils
 
-  def export(project_id, filename \\ "test") do
+  def export(project_id) do
     project_id
     |> create_messages
     |> wrap_with_tutor_related_message
     |> document
     |> generate
-    |> write_file(filename)
   end
 
   defp create_messages(project_id) do
@@ -158,15 +157,4 @@ defmodule Oli.Analytics.Datashop do
       },
       children)
   end
-
-  defp write_file(xml, file_name) do
-    file_name = file_name <> ".xml"
-    path = Path.expand(__DIR__) <> "/"
-
-    case File.write(path <> file_name, xml) do
-      :ok -> {:ok, path <> file_name, file_name}
-      {:error, posix} -> {:error, posix}
-    end
-  end
-
 end

--- a/lib/oli/analytics/datashop/utils.ex
+++ b/lib/oli/analytics/datashop/utils.ex
@@ -2,6 +2,17 @@ defmodule Oli.Analytics.Datashop.Utils do
   alias Oli.Rendering.Context
   alias Oli.Rendering.Content
 
+  # For internal use and testing only, not for production file creation.
+  def write_file(xml, file_name) do
+    file_name = file_name <> ".xml"
+    path = Path.expand(__DIR__) <> "/"
+
+    case File.write(path <> file_name, xml) do
+      :ok -> {:ok, path <> file_name, file_name}
+      {:error, posix} -> {:error, posix}
+    end
+  end
+
   # for making ids unique
   def uuid() do
     {:ok, uuid} = ShortUUID.encode(UUID.uuid4())

--- a/lib/oli_web/controllers/project_controller.ex
+++ b/lib/oli_web/controllers/project_controller.ex
@@ -53,8 +53,6 @@ defmodule OliWeb.ProjectController do
           %{}
         end
 
-        IO.inspect parent_pages
-
         {has_changes, changes, parent_pages}
       end
 

--- a/lib/oli_web/controllers/project_controller.ex
+++ b/lib/oli_web/controllers/project_controller.ex
@@ -128,17 +128,7 @@ defmodule OliWeb.ProjectController do
 
   def download_datashop(conn, _project_params) do
     project = conn.assigns.project
-
-    case Datashop.export(project.id, "Datashop Export - #{project.slug}") do
-      {:ok, path, filename} ->
-        {_, 0} = System.cmd "rm", [path]
-
-        conn
-          |> put_resp_header("content-disposition",
-                              ~s(attachment; filename="#{filename}"))
-          |> send_file(200, path)
-
-      _ -> send_resp(conn, 500, "Error generating export")
-    end
+    conn
+    |> send_download({:binary, Datashop.export(project.id)}, filename: "Datashop_#{project.slug}.xml")
   end
 end

--- a/test/oli/datashop_test.exs
+++ b/test/oli/datashop_test.exs
@@ -587,10 +587,7 @@ defmodule Oli.DatashopTest do
         hints: ["1137320916"]
       }, %Part{id: "1", responses: [], hints: []}, :sa_user2_attempt1, :sa_user2_part_attempt1)
 
-      {:ok, path, _file_name} = Datashop.export(map.project.id)
-      {:ok, datashop_file} = File.read(path)
-
-      Map.put(map, :datashop_file, datashop_file)
+      Map.put(map, :datashop_file, Datashop.export(map.project.id))
     end
 
     test "tool message should be well formed for hint requests", %{ datashop_file: datashop_file } do


### PR DESCRIPTION
After some googling, I found this Phoenix controller method for sending file attachments from memory rather than the local file storage.

https://hexdocs.pm/phoenix/Phoenix.Controller.html#send_download/3

This works locally, but hasn't been tested on test/production. I'll need to test this with a deployed canvas course on tokamak/proton that has student attempts to make sure it works the same way.