### PR TITLE
prevent datashop download from being clicked with no publications

### DIFF
--- a/lib/oli_web/templates/project/overview.html.eex
+++ b/lib/oli_web/templates/project/overview.html.eex
@@ -59,10 +59,20 @@
         </tbody>
       </table>
 
-
-      <br /> <br /> <br />
-      <%= button("Download Datashop Export", to: Routes.project_path(@conn, :download_datashop, @project), method: :post, class: "btn btn-primary") %>
-
+      <div class="row my-4">
+        <div class="col-12">
+          <h4>Datashop Export</h4>
+          <%= case Oli.Publishing.get_latest_published_publication_by_slug!(@project.slug) do %>
+            <% nil -> %>
+              <p class="mb-2">
+                Project must be published to generate a datashop export file.
+              </p>
+              <button disabled class="btn btn-primary">Download Datashop Export</button>
+            <% _pub -> %>
+              <%= button("Download Datashop Export", to: Routes.project_path(@conn, :download_datashop, @project), method: :post, class: "btn btn-primary") %>
+          <% end %>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/lib/oli_web/views/project_view.ex
+++ b/lib/oli_web/views/project_view.ex
@@ -1,6 +1,5 @@
 defmodule OliWeb.ProjectView do
   use OliWeb, :view
-  alias Oli.Publishing
 
   def resource_link(activity_map, slug, title, conn, project) do
     if Map.get(activity_map, slug) do

--- a/lib/oli_web/views/project_view.ex
+++ b/lib/oli_web/views/project_view.ex
@@ -1,5 +1,6 @@
 defmodule OliWeb.ProjectView do
   use OliWeb, :view
+  alias Oli.Publishing
 
   def resource_link(activity_map, slug, title, conn, project) do
     if Map.get(activity_map, slug) do


### PR DESCRIPTION
Datashop export throws error for projects with no publications

Should move this to admin after learnlab