### PR TITLE
Account link and workspace sidebar/header fixes

### DIFF
--- a/assets/styles/authoring/layout/workspace.scss
+++ b/assets/styles/authoring/layout/workspace.scss
@@ -9,6 +9,7 @@
   }
 
   .workspace-right {
+    width: calc(100vw - 200px);
     display: flex;
     flex-direction: column;
     flex-grow: 1;
@@ -23,14 +24,24 @@
   }
 
   .workspace-header {
+    width: 100%;
     border-bottom: 1px solid $gray-400;
-    padding: 20px;
+    height: 48px;
+    line-height: 48px;
+    padding: 0 32px;
     position: relative;
     background-color: $workspace-header-bg;
-    width: 100%;
+
+    display: flex;
 
     .page-title {
       font-weight: bold;
+    }
+
+    .project-title {
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      overflow: hidden;
     }
 
   }
@@ -45,7 +56,7 @@
     a {
       display: flex;
       flex-direction: columns;
-      margin: 20px 0;
+      margin: 10px 0;
       color: $workspace-sidebar-link-color;
     }
 
@@ -54,11 +65,12 @@
     }
 
     .category {
-      font-size: 12px;
+      padding: 0;
+      font-size: 16px;
       color: $gray-500;
       user-select: none;
-      margin-top: 20px;
-      margin-bottom: 10px;
+      margin-top: 36px;
+      margin-bottom: 0px;
     }
 
     .active {
@@ -70,9 +82,9 @@
       height: 48px;
       display: inline-block;
       margin: 0;	      margin: 0;
+      width: 100%;
       white-space: nowrap;
       text-overflow: ellipsis;
-      width: 100%;
       overflow: hidden;
     }
   }

--- a/assets/styles/authoring/layout/workspace.scss
+++ b/assets/styles/authoring/layout/workspace.scss
@@ -67,7 +67,13 @@
     }
 
     .account-link {
-      margin: 0;
+      height: 48px;
+      display: inline-block;
+      margin: 0;	      margin: 0;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      width: 100%;
+      overflow: hidden;
     }
   }
 }

--- a/lib/oli_web/templates/layout/_project_sidebar.html.eex
+++ b/lib/oli_web/templates/layout/_project_sidebar.html.eex
@@ -8,12 +8,10 @@
   <%= sidebar_link @conn, "Objectives", :objectives, to: Routes.live_path(OliWeb.Endpoint, OliWeb.Objectives.Objectives, @project.slug) %>
   <%= sidebar_link @conn, "Curriculum", :curriculum, to: Routes.live_path(OliWeb.Endpoint, OliWeb.Curriculum.Container, @project.slug) %>
 
-  <hr>
   <p class="category">Publish<p>
   <%= sidebar_link @conn, "Review", :review, to: Routes.live_path(OliWeb.Endpoint, OliWeb.Qa.QaLive, @project.slug) %>
   <%= sidebar_link @conn, "Publish", :publish, to: Routes.project_path(@conn, :publish, @project) %>
 
-  <hr>
   <p class="category">Improve</p>
   <%= sidebar_link @conn, "Insights", :insights, to: Routes.project_path(@conn, :insights, @project) %>
 

--- a/lib/oli_web/templates/project/overview.html.eex
+++ b/lib/oli_web/templates/project/overview.html.eex
@@ -59,10 +59,20 @@
         </tbody>
       </table>
 
-
-      <br /> <br /> <br />
-      <%= button("Download Datashop Export", to: Routes.project_path(@conn, :download_datashop, @project), method: :post, class: "btn btn-primary") %>
-
+      <div class="row my-4">
+        <div class="col-12">
+          <h4>Datashop Export</h4>
+          <%= case Oli.Publishing.get_latest_published_publication_by_slug!(@project.slug) do %>
+            <% nil -> %>
+              <p class="mb-2">
+                Project must be published to generate a datashop export file.
+              </p>
+              <button disabled class="btn btn-primary">Download Datashop Export</button>
+            <% _pub -> %>
+              <%= button("Download Datashop Export", to: Routes.project_path(@conn, :download_datashop, @project), method: :post, class: "btn btn-primary") %>
+          <% end %>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/lib/oli_web/templates/workspace/account.html.eex
+++ b/lib/oli_web/templates/workspace/account.html.eex
@@ -25,14 +25,16 @@
     </div>
   </div>
 
-  <hr />
-
-  <div class="row">
+  <div class="row my-4">
     <div class="col-12">
-      <h2 class="mb-4">My Institutions</h2>
+      <h4 class="mb-3">My Institutions</h4>
+
+      <%= link to: Routes.institution_path(@conn, :new), class: "d-flex align-items-center mb-2" do %>
+        <%= link "Register an Institution", to: Routes.institution_path(@conn, :new), class: "btn btn-md btn-outline-primary mb-2" %>
+      <% end %>
 
       <%= if Enum.count(@institutions) == 0 do %>
-        <div class="my-5 text-center">
+        <div class="my-5">
           <%= "#{@current_author.first_name} #{@current_author.last_name}" %> has no registered institutions
         </div>
       <% else %>
@@ -70,21 +72,20 @@
           </tbody>
         </table>
       <% end %>
+    </div>
+  </div>
 
-      <span><%= link "Register an Institution", to: Routes.institution_path(@conn, :new), class: "btn btn-md btn-outline-primary" %></span>
-
-      <h2 class="mt-5">Preferences</h2>
-
-      <div class="my-4">
+  <div class="row my-4">
+    <div class="col-3">
+      <h4 class="mb-3">Editor Theme</h4>
         <%= form_for @conn, Routes.workspace_path(@conn, :update_theme), fn f -> %>
-          <%= label f, "Editor theme", class: "control-label" %>
-          <div class="input-group mb-3">
-            <%= select f, :id, Enum.map(@themes, fn t -> if t.default, do: {"#{t.name} (Default)", t.id}, else: {t.name, t.id} end), value: @active_theme.id, class: "form-control" %>
-          </div>
-          <%= submit "Save Theme", class: "btn btn-sm btn-primary", phx_disable_with: "Saving..." %>
-
+          <%= select f,
+            :id,
+            Enum.map(@themes, fn t -> if t.default, do: {"#{t.name} (Default)", t.id}, else: {t.name, t.id} end),
+            value: @active_theme.id,
+            class: "form-control",
+            onchange: "this.form.submit();" %>
         <% end %>
-      </div>
     </div>
   </div>
 </div>

--- a/lib/oli_web/views/project_view.ex
+++ b/lib/oli_web/views/project_view.ex
@@ -1,6 +1,5 @@
 defmodule OliWeb.ProjectView do
   use OliWeb, :view
-  alias Oli.Publishing
 
   def resource_link(activity_map, slug, title, conn, project) do
     if Map.get(activity_map, slug) do

--- a/lib/oli_web/views/project_view.ex
+++ b/lib/oli_web/views/project_view.ex
@@ -1,5 +1,6 @@
 defmodule OliWeb.ProjectView do
   use OliWeb, :view
+  alias Oli.Publishing
 
   def resource_link(activity_map, slug, title, conn, project) do
     if Map.get(activity_map, slug) do


### PR DESCRIPTION
I accidentally branched off of one of the other open styling PRs, so the others should be merged first to hide those changes in this PR.

 
- Prevent workspace header from expanding horizontally with long project titles. We'll want to add a project title max size.
- Prevent long name from overflowing page
- Change styling in sidebar to get rid of the horizontal lines that blended in with the page