### PR TITLE
Curriculum rollup

### DIFF
--- a/assets/styles/authoring/curriculum.scss
+++ b/assets/styles/authoring/curriculum.scss
@@ -1,0 +1,28 @@
+@import "authoring/variables";
+
+.container-editor {
+
+  .targeted-objectives {
+
+    .objective {
+      margin-left: 20px;
+      color: $info;
+      font-size: 0.9em;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+  }
+
+  .no-objectives {
+    margin-left: 20px;
+    color: $warning;
+    font-size: 0.9em;
+
+  }
+
+  .resource-label {
+    font-size: 20pt;
+  }
+}

--- a/lib/oli_web/live/curriculum/container.ex
+++ b/lib/oli_web/live/curriculum/container.ex
@@ -355,7 +355,7 @@ defmodule OliWeb.Curriculum.Container do
 
         [] -> {activity_map, socket.assigns.objective_map}
 
-        activities ->
+        _ ->
 
           resolved_activities = AuthoringResolver.from_resource_id(socket.assigns.project.slug, added_activities)
 
@@ -377,7 +377,6 @@ defmodule OliWeb.Curriculum.Container do
   end
 
   defp handle_container(socket, revision) do
-    id = revision.resource_id
 
     # in the case of a change to the container, we simplify by just pulling a new view of
     # the container and its contents. This handles addition, removal, reordering from the

--- a/lib/oli_web/live/curriculum/entry.ex
+++ b/lib/oli_web/live/curriculum/entry.ex
@@ -6,13 +6,82 @@ defmodule OliWeb.Curriculum.Entry do
 
   use Phoenix.LiveComponent
 
-  alias OliWeb.Router.Helpers, as: Routes
+  # For the given list of activity ids, find and return the set of objective revisions
+  # that these activities have attached.
+  defp determine_objectives(activity_ids, activity_map, objective_map) do
+
+    Enum.map(activity_ids, fn id -> Map.get(activity_map, id) end)
+    |> Enum.reduce(MapSet.new(), fn %{objectives: objectives}, map_set ->
+
+      Enum.map(objectives, fn {_, ids} -> ids end)
+      |> List.flatten()
+      |> MapSet.new()
+      |> MapSet.union(map_set)
+
+    end)
+    |> MapSet.to_list()
+    |> Enum.map(fn id -> Map.get(objective_map, id) end)
+  end
+
+  defp render_objectives_count(assigns, objectives) do
+
+    count = length(objectives)
+
+    objs = if count == 1 do "objective" else "objectives" end
+    muted = if assigns.selected do "" else "text-muted" end
+
+    ~L"""
+    <%= count %> <%= objs %>
+    """
+  end
+
+  defp render_counts(assigns, objectives) do
+
+    count = length(assigns.activity_ids)
+
+    type = if assigns.page.graded do "summative" else "practice" end
+    activities = if count == 1 do "activity" else "activities" end
+    muted = if assigns.selected do "" else "text-muted" end
+
+    if (count > 0) do
+      ~L"""
+      <div><small class="<%= muted %>"><%= count %> <%= type %> <%= activities %> targeting
+        <%= render_objectives_count(assigns, objectives) %></small>
+      </div>
+      """
+    else
+      ~L"""
+      <small class="<%= muted %>">No <%= type %> activities</small>
+      """
+    end
+
+  end
+
+  defp render_objectives(assigns, objectives) do
+    ~L"""
+    <div class="targeted-objectives">
+
+      <%= for %{title: title} <- objectives do %>
+        <div class="objective"><%= title %></div>
+      <% end %>
+
+    </div>
+    """
+
+
+  end
 
   def render(assigns) do
 
     active = if assigns.selected do "background-color: #eee;" else "" end
-    type = if assigns.page.graded do "Assessment" else "Page" end
-    muted = if assigns.selected do "" else "text-muted" end
+
+    count = length(assigns.activity_ids)
+    objectives = if count > 0 do
+      determine_objectives(assigns.activity_ids, assigns.activity_map, assigns.objective_map)
+    else
+      []
+    end
+
 
     ~L"""
     <div
@@ -32,14 +101,17 @@ defmodule OliWeb.Curriculum.Entry do
         <div class="grip"></div>
       </div>
 
-      <div class="m-2 text-truncate" style="width: 100%;">
-        <div class="d-flex justify-content-between align-items-center">
-          <a
-            style="margin: 2px"
-            onClick="event.stopPropagation();"
-            href="<%= Routes.resource_path(OliWeb.Endpoint, :edit, @project.slug, @page.slug) %>"><%= @index + 1 %>. <%= @page.title %>
-          </a>
-          <small class="<%= muted %>"><%= type %></small>
+      <div class="mt-1 ml-2 mr-2 mb-2 text-truncate" style="width: 100%;">
+
+        <div class="d-flex justify-content-between align-items-top">
+          <div class="resource-label">
+            <%= @page.title %>
+          </div>
+          <%= render_counts(assigns, objectives) %>
+        </div>
+
+        <div>
+          <%= render_objectives(assigns, objectives) %>
         </div>
       </div>
 

--- a/lib/oli_web/live/curriculum/entry.ex
+++ b/lib/oli_web/live/curriculum/entry.ex
@@ -28,7 +28,6 @@ defmodule OliWeb.Curriculum.Entry do
     count = length(objectives)
 
     objs = if count == 1 do "objective" else "objectives" end
-    muted = if assigns.selected do "" else "text-muted" end
 
     ~L"""
     <%= count %> <%= objs %>

--- a/lib/oli_web/live/curriculum/settings.ex
+++ b/lib/oli_web/live/curriculum/settings.ex
@@ -8,6 +8,8 @@ defmodule OliWeb.Curriculum.Settings do
   use Phoenix.HTML
   alias Oli.Resources.ScoringStrategy
 
+  alias OliWeb.Router.Helpers, as: Routes
+
   defp selected_attr(item, item), do: "selected=\"selected\""
   defp selected_attr(_, _), do: ""
 
@@ -16,8 +18,19 @@ defmodule OliWeb.Curriculum.Settings do
 
   def render(assigns) do
 
+    type = if assigns.page.graded do "Assessment" else "Page" end
+
     ~L"""
     <%= _ = form_for @changeset, "#", [phx_change: :save] %>
+
+      <a
+        class="btn btn-primary"
+        onClick="event.stopPropagation();"
+        href="<%= Routes.resource_path(OliWeb.Endpoint, :edit, @project.slug, @page.slug) %>">
+        Edit <%= type %> Contents
+      </a>
+
+      <hr/>
 
       <div><small>Grading Type:</small></div>
 


### PR DESCRIPTION
This PR adds an activity and attached objective display rollup to the curriculum view.  

At first load, the view now looks at all embedded activities contained in the list of pages in the container.  It creates three maps to use in displaying the unique set of attached objectives for each page:

page_to_activity - a map of page resource ids to a list of activity ids 
activity_map - a map of activity resource ids to the actual revision for that activity 
objective_map - a map of objective resource ids to the actual revision for that objective

With these three maps it is straightforward (and efficient) to get the set of objective titles that are "attached" to a page, via its activities. 

The view now also keeps active subscriptions open to these activities and objectives so that it can respond to changing titles of objectives, and attachment/detachment of objectives within an activity.  For pages, it looks to see when new activities are added / removed, as well.

The code is optimized to prevent re-rendering on every edit of a page and an activity.  On pure content edits (which are probably 95% of edits) the code will not track the latest revision of a page or an activity - because it simply doesn't need to. It only needs to track updates when a title or a setting of a page updates, or when an activity is added/removed.  If a user is simply typing keystrokes in a paragraph this view ignores those changes so that unecessary re-rendering is avoided.  I have verified this using Chrome network debugger. 

Closes #411 

