### PR TITLE
finalize only those activities that are not evaluated

### DIFF
--- a/lib/oli/delivery/attempts.ex
+++ b/lib/oli/delivery/attempts.ex
@@ -733,7 +733,11 @@ defmodule Oli.Delivery.Attempts do
       if resource_attempt.date_evaluated == nil do
 
         Enum.each(resource_attempt.activity_attempts, fn a ->
-          submit_graded_page_activity(role, context_id, a.attempt_guid)
+          # some activities will finalize themselves ahead of a graded page
+          # submission.  so we only submit those that are still yet to be finalized.
+          if a.date_evaluated == nil do
+            submit_graded_page_activity(role, context_id, a.attempt_guid)
+          end
         end)
 
         case roll_up_activities_to_resource_attempt(resource_attempt_guid) do


### PR DESCRIPTION
This is a small adjustment to assessment submission logic necessary to support activities that directly submit outcomes (as opposed to using Torus server-side evaluations).   Currently this is only possible with code on the `iframe-activity` branch - but it makes sense to get this in place now (it would have prevented the problem that the long text single response caused during the alpha test, for example). 

The idea here is that activities that directly submit outcomes will be finalizing activity attempts before the student submits the assessment.  So the assertion in this code that all activity attempts are still "yet to be finalized" cannot hold.  

