### PR TITLE
Objective modal

### DIFF
--- a/assets/src/components/content/AddResourceContent.tsx
+++ b/assets/src/components/content/AddResourceContent.tsx
@@ -48,8 +48,8 @@ const promptForObjectiveSelection
       display(<ModalSelection title="Target learning objectives with this activity"
         hideOkButton={true}
         cancelLabel="Skip this step"
-        onInsert={() => { dismiss(); }}
-        onCancel={() => { dismiss(); }}>
+        onInsert={() => { dismiss(); resolve([]); }}
+        onCancel={() => { dismiss(); resolve([]); }}>
 
         <ObjectiveSelection objectives={objectives}
           childrenObjectives={childrenObjectives}

--- a/assets/src/components/modal/ModalSelection.tsx
+++ b/assets/src/components/modal/ModalSelection.tsx
@@ -17,6 +17,7 @@ export interface ModalSelectionProps {
   cancelLabel?: string;
   disableInsert?: boolean;
   title: string;
+  hideOkButton?: boolean;
   onInsert: () => void;
   onCancel: () => void;
   size?: sizes;
@@ -64,11 +65,13 @@ class ModalSelection extends React.PureComponent<ModalSelectionProps, {}> {
               {this.props.children}
             </div>
             <div className="modal-footer">
-              <button
-                disabled={disableInsert}
-                type="button"
-                onClick={this.onInsert}
-                className={`btn btn-${okClassName}`}>{okLabel}</button>
+              {this.props.hideOkButton === true
+                ? null
+                : <button
+                    disabled={disableInsert}
+                    type="button"
+                    onClick={this.onInsert}
+                    className={`btn btn-${okClassName}`}>{okLabel}</button>}
               <button type="button" className="btn btn-link"
                 onClick={this.onCancel}
                 data-dismiss="modal">{cancelLabel}</button>

--- a/assets/src/components/resource/ObjectiveSelection.scss
+++ b/assets/src/components/resource/ObjectiveSelection.scss
@@ -1,0 +1,41 @@
+@import "authoring/variables";
+
+.objective-selection {
+
+  padding-top: 5px;
+  padding-bottom: 10px;
+
+  .existing-objectives {
+    background-color: $gray-100;
+    max-height: 500px;
+    margin-left: 15px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+    padding-right: 10px;
+    margin-bottom: 30px;
+    overflow-y: scroll;
+
+
+    .title {
+      border-radius: 3px;
+      cursor: pointer;
+      padding: 5px;
+      margin-top: 4px;
+      white-space: nowrap;
+      overflow-x: hidden;
+      text-overflow: ellipsis;
+      border: 1px solid $gray-100;
+
+      &:hover{
+        border: 1px solid $gray-600;
+      }
+
+    }
+
+    .selected {
+      background-color: $gray-300;
+    }
+
+  }
+
+}

--- a/assets/src/components/resource/ObjectiveSelection.tsx
+++ b/assets/src/components/resource/ObjectiveSelection.tsx
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+import * as Immutable from 'immutable';
+import { Objective, ObjectiveSlug } from 'data/content/objective';
+import { ProjectSlug } from 'data/types';
+import { create } from 'data/persistence/objective';
+import guid from 'utils/guid';
+import './Objectives.scss';
+import { valueOr } from 'utils/common';
+
+export type ObjectiveSelectionProps = {
+  objectives: Immutable.Map<ObjectiveSlug, Objective>;
+  projectSlug: ProjectSlug;
+  onEdit: (objectives: Immutable.List<ObjectiveSlug>) => void;
+  onRegisterNewObjective: (objective: Objective) => void;
+};
+
+const ObjectiveTree = ({ objectives: Immutable.Map<ObjectiveSlug, Objective> }) => {
+
+};
+
+export const ObjectiveSelection = (props: ObjectiveSelectionProps) => {
+
+  const { objectives, editMode, selected, onEdit, onRegisterNewObjective } = props;
+
+
+  return (
+    <div className="flex-grow-1 objectives">
+
+    </div>
+  );
+};

--- a/assets/src/components/resource/ObjectiveSelection.tsx
+++ b/assets/src/components/resource/ObjectiveSelection.tsx
@@ -1,30 +1,116 @@
 import React, { useState } from 'react';
 import * as Immutable from 'immutable';
 import { Objective, ObjectiveSlug } from 'data/content/objective';
-import { ProjectSlug } from 'data/types';
-import { create } from 'data/persistence/objective';
-import guid from 'utils/guid';
-import './Objectives.scss';
-import { valueOr } from 'utils/common';
+import './ObjectiveSelection.scss';
 
 export type ObjectiveSelectionProps = {
-  objectives: Immutable.Map<ObjectiveSlug, Objective>;
-  projectSlug: ProjectSlug;
-  onEdit: (objectives: Immutable.List<ObjectiveSlug>) => void;
-  onRegisterNewObjective: (objective: Objective) => void;
+  objectives: Immutable.List<Objective>;
+  childrenObjectives: Immutable.Map<ObjectiveSlug, Immutable.List<Objective>>;
+  onRegisterNewObjective: (title: string) => Promise<Objective>;
+  onUseSelected: (objectives: Immutable.List<ObjectiveSlug>) => void;
 };
 
-const ObjectiveTree = ({ objectives: Immutable.Map<ObjectiveSlug, Objective> }) => {
+type ObjectNodeProps = {
+  objective: Objective,
+  childrenObjectives: Immutable.Map<ObjectiveSlug, Immutable.List<Objective>>,
+  level: number,
+  selected: Object,
+  toggleSelected: (slug: ObjectiveSlug) => void,
+};
 
+const indentPerLevel = (level: number) => ({ marginLeft: (level * 15) + 'px' });
+
+const ObjectiveNode = (props: ObjectNodeProps) => {
+
+  const { objective, childrenObjectives, level } = props;
+
+  const myChildren = childrenObjectives.get(objective.slug);
+  const renderedChildren = myChildren === undefined
+    ? null
+    : myChildren.toArray().map(o => <ObjectiveNode
+       key={o.slug}
+       selected={props.selected}
+       toggleSelected={props.toggleSelected}
+       objective={o}
+       childrenObjectives={childrenObjectives} level={level + 1}/>);
+
+  return (
+    <div key={objective.slug}>
+      <div
+        key="title"
+        onClick={() => props.toggleSelected(objective.slug)}
+        className={`title ${(props.selected as any)[objective.slug] === true ? 'selected' : ''}`}
+        style={indentPerLevel(level)}>
+        {objective.title}
+      </div>
+      {renderedChildren}
+    </div>
+  );
+};
+
+const ObjectiveTree = (props: ObjectiveSelectionProps &
+  { selected: Object, toggleSelected: (slug: ObjectiveSlug) => void}) => {
+  return (
+    <React.Fragment>
+      {props.objectives.toArray()
+        .filter(o => o.parentSlug === null)
+        .map(o => <ObjectiveNode key={o.slug} objective={o} selected={props.selected}
+          toggleSelected={props.toggleSelected}
+          childrenObjectives={props.childrenObjectives} level={1}/>)}
+    </React.Fragment>
+  );
 };
 
 export const ObjectiveSelection = (props: ObjectiveSelectionProps) => {
 
-  const { objectives, editMode, selected, onEdit, onRegisterNewObjective } = props;
+  const [selected, setSelected] = useState({});
+  const [text, setText] = useState('');
 
+  const toList = () =>
+    props.objectives.filter(o => (selected as any)[o.slug] === true).map(o => o.slug);
+
+  const toggleSelected = (slug: ObjectiveSlug) => {
+    if ((selected as any)[slug] === true) {
+      setSelected(Object.assign({}, selected, { [slug]: false }));
+    } else {
+      setSelected(Object.assign({}, selected, { [slug]: true }));
+    }
+
+  };
+
+  const selectedCount = Object.keys(selected).filter(k => (selected as any)[k] === true).length;
+  const selectedLabel = selectedCount > 0
+    ? <span>Use Selected <span className="badge badge-pill badge-light">
+      {selectedCount}</span></span>
+    : 'Use Selected';
 
   return (
-    <div className="flex-grow-1 objectives">
+    <div className="objective-selection">
+
+      <div className="d-flex justify-content-between mb-2">
+        <h4>Select from existing objectives:</h4>
+        <button className="btn btn-primary" type="button"
+            disabled={Object.keys(selected).length === 0}
+            onClick={() => props.onUseSelected(toList())}>{selectedLabel}</button>
+      </div>
+
+      <div className="existing-objectives">
+        <ObjectiveTree {...props} selected={selected} toggleSelected={toggleSelected}/>
+      </div>
+
+
+      <h4>Or create a new objective:</h4>
+
+      <small className="muted">At the end of the course, my students should be able to...</small>
+      <div className="input-group mb-3">
+        <input type="text" className="form-control"
+          value={text} onChange={e => setText(e.target.value)}/>
+        <div className="input-group-append">
+          <button className="btn btn-primary" type="button"
+            disabled={text.trim() === ''}
+            onClick={() => props.onRegisterNewObjective(text)}>Create</button>
+        </div>
+      </div>
 
     </div>
   );

--- a/assets/src/components/resource/Objectives.tsx
+++ b/assets/src/components/resource/Objectives.tsx
@@ -50,6 +50,7 @@ export const Objectives = (props: ObjectivesProps) => {
                   onRegisterNewObjective({
                     slug: result.revisionSlug,
                     title: createdObjective.title,
+                    parentSlug: null,
                   });
 
                   // the newly created objective will be the only one that has null as it's slug,

--- a/assets/src/data/content/objective.ts
+++ b/assets/src/data/content/objective.ts
@@ -4,4 +4,5 @@ export { ObjectiveSlug } from 'data/types';
 export type Objective = {
   slug: ObjectiveSlug,
   title: string,
+  parentSlug: ObjectiveSlug | null,
 };

--- a/assets/src/data/persistence/activity.ts
+++ b/assets/src/data/persistence/activity.ts
@@ -29,11 +29,12 @@ export type Evaluated = {
 export type Edited = { type: 'success', revisionSlug: string };
 
 export function create(
-  project: ProjectSlug, activityTypeSlug: ActivityTypeSlug, model: ActivityModelSchema) {
+  project: ProjectSlug, activityTypeSlug: ActivityTypeSlug,
+  model: ActivityModelSchema, objectives: string[]) {
 
   const params = {
     method: 'POST',
-    body: JSON.stringify({ model }),
+    body: JSON.stringify({ model, objectives }),
     url: `/project/${project}/activity/${activityTypeSlug}`,
   };
 

--- a/lib/oli/activities/model/part.ex
+++ b/lib/oli/activities/model/part.ex
@@ -33,7 +33,7 @@ defmodule Oli.Activities.Model.Part do
     |> Oli.Activities.ParseUtils.items_or_errors()
   end
 
-  def parse(_) do
+  def parse() do
     {:error, "invalid part"}
   end
 

--- a/lib/oli/authoring/editing/activity_editor.ex
+++ b/lib/oli/authoring/editing/activity_editor.ex
@@ -93,6 +93,25 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
 
   end
 
+  # takes the model of the activity to be created and a list of objective slugs and
+  # creates a map of all part ids to objective resource ids
+  defp attach_objectives_to_all_parts(model, objectives) do
+
+    result = case Oli.Activities.Model.parse(model) do
+      {:ok, %{parts: parts}} ->
+
+        %{"objectives" => Enum.reduce(parts, %{}, fn %{id: id}, m -> Map.put(m, id, objectives) end)}
+        |> translate_objective_slugs_to_ids()
+        |> Map.get("objectives")
+
+      {:error, e} ->
+        IO.inspect e
+        %{}
+    end
+
+    {:ok, result}
+  end
+
   defp translate_objective_slugs_to_ids(%{"objectives" => objectives} = update) do
 
     map = Map.values(objectives)
@@ -196,9 +215,9 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
   .`{:error, {:not_authorized}}` if the user is not authorized to create this activity
   .`{:error, {:error}}` unknown error
   """
-  @spec create(String.t, String.t, %Author{}, %{})
+  @spec create(String.t, String.t, %Author{}, %{}, [])
     :: {:ok, %Revision{}} | {:error, {:not_found}} | {:error, {:error}} | {:error, {:not_authorized}}
-  def create(project_slug, activity_type_slug, author, model) do
+  def create(project_slug, activity_type_slug, author, model, objectives) do
 
     Repo.transaction(fn ->
 
@@ -206,7 +225,8 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
          {:ok} <- authorize_user(author, project),
          {:ok, publication} <- Publishing.get_unpublished_publication_by_slug!(project_slug) |> trap_nil(),
          {:ok, activity_type} <- Activities.get_registration_by_slug(activity_type_slug) |> trap_nil(),
-         {:ok, %{content: content} = activity} <- Activity.create_new(%{title: activity_type.title, scoring_strategy_id: Oli.Resources.ScoringStrategy.get_id_by_type("total"), objectives: %{}, author_id: author.id, content: model, activity_type_id: activity_type.id}),
+         {:ok, attached_objectives} <- attach_objectives_to_all_parts(model, objectives),
+         {:ok, %{content: content} = activity} <- Activity.create_new(%{title: activity_type.title, scoring_strategy_id: Oli.Resources.ScoringStrategy.get_id_by_type("total"), objectives: attached_objectives, author_id: author.id, content: model, activity_type_id: activity_type.id}),
          {:ok, _} <- Course.create_project_resource(%{ project_id: project.id, resource_id: activity.resource_id}) |> trap_nil(),
          {:ok, _mapping} <- Publishing.create_resource_mapping(%{publication_id: publication.id, resource_id: activity.resource_id, revision_id: activity.id})
       do
@@ -232,7 +252,6 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
     with {:ok, publication} <- Publishing.get_unpublished_publication_by_slug!(project_slug) |> trap_nil(),
          {:ok, resource} <- Resources.get_resource_from_slug(revision_slug) |> trap_nil(),
          {:ok, all_objectives} <- Publishing.get_published_objective_details(publication.id) |> trap_nil(),
-         {:ok, objectives_without_ids} <- PageEditor.strip_ids(all_objectives) |> trap_nil(),
          {:ok, %{content: content, title: resource_title}} <- PageEditor.get_latest_revision(publication, resource) |> trap_nil(),
          {:ok, %{id: activity_id}} <- Resources.get_resource_from_slug(activity_slug) |> trap_nil(),
          {:ok, %{activity_type: activity_type, content: model, title: title, objectives: objectives}} <- get_latest_revision(publication.id, activity_id) |> trap_nil()
@@ -253,7 +272,7 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
         title: title,
         model: model,
         objectives: translate_ids_to_slugs(project_slug, objectives),
-        allObjectives: objectives_without_ids,
+        allObjectives: all_objectives,
         previousActivity: previous,
         nextActivity: next
       }

--- a/lib/oli/authoring/editing/page_editor.ex
+++ b/lib/oli/authoring/editing/page_editor.ex
@@ -347,9 +347,10 @@ defmodule Oli.Authoring.Editing.PageEditor do
   #
   def construct_parent_references(objectives) do
 
-    by_resource_id = Enum.reduce(objectives, %{}, fn o, m -> Map.put(m, o.resource_id, o) end)
+    by_resource_id = Enum.reduce(objectives, %{}, fn o, m -> Map.put(m, o.resource_id, o.slug) end)
+
     parent_slug = Enum.reduce(objectives, %{}, fn o, m ->
-      Enum.reduce(o.children, m, fn id -> Map.put(m, Map.get(by_resource_id, id), Map.get(by_resource_id, o.id)) end)
+      Enum.reduce(o.children, m, fn child, m -> Map.put(m, Map.get(by_resource_id, child), Map.get(by_resource_id, o.resource_id)) end)
     end)
 
     Enum.map(objectives, fn o ->

--- a/lib/oli/authoring/editing/page_editor.ex
+++ b/lib/oli/authoring/editing/page_editor.ex
@@ -168,11 +168,11 @@ defmodule Oli.Authoring.Editing.PageEditor do
     with {:ok, publication} <- Publishing.get_unpublished_publication_by_slug!(project_slug) |> trap_nil(),
          {:ok, %{content: content} = revision} <- AuthoringResolver.from_revision_slug(project_slug, revision_slug) |> trap_nil(),
          {:ok, objectives} <- Publishing.get_published_objective_details(publication.id) |> trap_nil(),
-         {:ok, objectives_without_ids} <- strip_ids(objectives) |> trap_nil(),
+         {:ok, objectives_with_parent_reference} <- construct_parent_references(objectives) |> trap_nil(),
          {:ok, attached_objectives} <- id_to_slug(revision.objectives, objectives) |> trap_nil(),
          {:ok, activities} <- create_activities_map(publication.id, content)
     do
-      {:ok, create(publication.id, revision, project_slug, revision_slug, author, objectives_without_ids, attached_objectives, activities, editor_map)}
+      {:ok, create(publication.id, revision, project_slug, revision_slug, author, objectives_with_parent_reference, attached_objectives, activities, editor_map)}
     else
       _ -> {:error, :not_found}
     end
@@ -336,9 +336,29 @@ defmodule Oli.Authoring.Editing.PageEditor do
 
   end
 
-  # removes the objective_id from the maps contained with a list of objectives
-  def strip_ids(objectives) do
-    Enum.map(objectives, fn o -> Map.delete(o, :objective_id) end)
+  # Take a list of maps containing the title, slug, resource_id, and children (as a list of resource_ids)
+  # and turn it into a list of maps of this form:
+  #
+  # %{
+  #   slug: the slug of the objective
+  #   title: the title of the objective
+  #   parentSlug: the slug of the parent objective, nil if no parent objective
+  # }
+  #
+  def construct_parent_references(objectives) do
+
+    by_resource_id = Enum.reduce(objectives, %{}, fn o, m -> Map.put(m, o.resource_id, o) end)
+    parent_slug = Enum.reduce(objectives, %{}, fn o, m ->
+      Enum.reduce(o.children, m, fn id -> Map.put(m, Map.get(by_resource_id, id), Map.get(by_resource_id, o.id)) end)
+    end)
+
+    Enum.map(objectives, fn o ->
+    %{
+      slug: o.slug,
+      title: o.title,
+      parentSlug: Map.get(parent_slug, o.slug)
+    }
+    end)
   end
 
   # takes the attached objectives in the form of a map of "attached" to a list of objective ids
@@ -359,7 +379,7 @@ defmodule Oli.Authoring.Editing.PageEditor do
     %{attached: attached}
   end
 
-  # Create the resource editing content that we will supply to the client side editor
+  # Create the resource editing context that we will supply to the client side editor
   defp create(publication_id, revision, project_slug, revision_slug, author, all_objectives, objectives, activities, editor_map) do
     %Oli.Authoring.Editing.ResourceContext{
       authorEmail: author.email,

--- a/lib/oli/publishing.ex
+++ b/lib/oli/publishing.ex
@@ -256,7 +256,7 @@ defmodule Oli.Publishing do
     Repo.all from mapping in PublishedResource,
       join: rev in Revision, on: mapping.revision_id == rev.id,
       where: rev.deleted == false and rev.resource_type_id == ^objective and mapping.publication_id == ^publication_id,
-      select: map(rev, [:slug, :title, :resource_id])
+      select: map(rev, [:slug, :title, :resource_id, :children])
   end
 
   @doc """

--- a/lib/oli_web/controllers/activity_controller.ex
+++ b/lib/oli_web/controllers/activity_controller.ex
@@ -23,11 +23,11 @@ defmodule OliWeb.ActivityController do
 
   end
 
-  def create(conn, %{"project" => project_slug, "activity_type" => activity_type_slug, "model" => model }) do
+  def create(conn, %{"project" => project_slug, "activity_type" => activity_type_slug, "model" => model, "objectives" => objectives}) do
 
     author = conn.assigns[:current_author]
 
-    case ActivityEditor.create(project_slug, activity_type_slug, author, model) do
+    case ActivityEditor.create(project_slug, activity_type_slug, author, model, objectives) do
       {:ok, {%{slug: slug}, transformed}} -> json conn, %{ "type" => "success", "revisionSlug" => slug, "transformed" => transformed}
       {:error, {:not_found}} -> error(conn, 404, "not found")
       {:error, {:not_authorized}} -> error(conn, 403, "unauthorized")

--- a/test/oli/editing/objective_editor_test.exs
+++ b/test/oli/editing/objective_editor_test.exs
@@ -77,7 +77,7 @@ defmodule Oli.Authoring.Editing.ObjectiveEditorTest do
 
       # attach it to a page and release the lock
       content = %{ "stem" => "one" }
-      {:ok, {%{slug: slug, resource_id: activity_id}, _}} = ActivityEditor.create(project.slug, "oli_multiple_choice", author, content)
+      {:ok, {%{slug: slug, resource_id: activity_id}, _}} = ActivityEditor.create(project.slug, "oli_multiple_choice", author, content, [])
 
       update = %{ "content" => %{ "model" => [%{ "type" => "activity-reference", "id" => 1, "activitySlug" => slug, "purpose" => "none"}]}}
       PageEditor.acquire_lock(project.slug, revision.slug, author.email)
@@ -101,7 +101,7 @@ defmodule Oli.Authoring.Editing.ObjectiveEditorTest do
 
       # attach it to a page and release the lock
       content = %{ "stem" => "one" }
-      {:ok, {%{slug: slug, resource_id: activity_id}, _}} = ActivityEditor.create(project.slug, "oli_multiple_choice", author, content)
+      {:ok, {%{slug: slug, resource_id: activity_id}, _}} = ActivityEditor.create(project.slug, "oli_multiple_choice", author, content, [])
 
       update = %{ "content" => %{ "model" => [%{ "type" => "activity-reference", "id" => 1, "activitySlug" => slug, "purpose" => "none"}]}}
       PageEditor.acquire_lock(project.slug, revision.slug, author.email)

--- a/test/oli/publishing_test.exs
+++ b/test/oli/publishing_test.exs
@@ -23,7 +23,7 @@ defmodule Oli.PublishingTest do
     parts = Enum.map(parts, fn {part_id, _} -> part_id end)
     content = %{ "content" => %{"authoring" => %{"parts" => parts}}}
 
-    {:ok, {revision, _}} = ActivityEditor.create(project.slug, "oli_multiple_choice", author, content)
+    {:ok, {revision, _}} = ActivityEditor.create(project.slug, "oli_multiple_choice", author, content, [])
 
     # attach just one activity
     update = %{ "objectives" => %{ "attached" => [obj_slug]}, "content" => %{ "model" => [%{ "type" => "activity-reference", "id" => 1, "activitySlug" => revision.slug, "purpose" => "none"}]}}
@@ -227,4 +227,3 @@ defmodule Oli.PublishingTest do
   end
 
 end
-


### PR DESCRIPTION
This PR introduces an explicit step for the selection (and optionally the creation) of objectives prior to the creation of an activity. 

I explicitly avoided an implementation that allowed creation of an objective as a separate step, since it seemed like it was going to be challenging for the user to understand that they then have to "select" that objective.  

So the approach taken here is to allow a user ability to *either* select any number of existing objectives, or the create and use a new one, or to simply skip attachment altogether.  

Closes #410 