### PR TITLE
Display captions in delivery/preview mode

### DIFF
--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -46,27 +46,22 @@ defmodule Oli.Rendering.Content.Html do
   def img(%Context{} = _context, _, %{"src" => src} = attrs) do
 
     height_width = case attrs do
-      %{"height" => height, "width" => width} -> ["height=#{height} width=#{width}"]
+      %{"height" => height, "width" => width} -> [" height=#{height} width=#{width}"]
       _ -> []
     end
 
-    ["<img "]
+    ["<img"]
       ++ height_width
+      ++ [" class=\"img-fluid img-thumbnail\""]
       ++ [" style=\"display: block; max-height: 500px; margin-left: auto; margin-right: auto;\" src=\"", src, "\"/>\n"]
   end
 
   def youtube(%Context{} = _context, _, %{"src" => src} = attrs) do
-    default_width = 640
-
-    wrap_with_figure(Map.merge(attrs, %{"width" => default_width}), [
+    wrap_with_figure(attrs, [
     """
-    <div className="embed-responsive embed-responsive-16by9">
-      <iframe
-        class="embed-responsive-item"
-        id="#{src}"
-        allowfullscreen
-        src="https://www.youtube.com/embed/#{src}"
-      ></iframe>
+    <div class="embed-responsive embed-responsive-16by9 img-thumbnail">
+      <iframe class="embed-responsive-item" id="#{src}" allowfullscreen src="https://www.youtube.com/embed/#{src}">
+      </iframe>
     </div>
     """])
   end
@@ -191,10 +186,8 @@ defmodule Oli.Rendering.Content.Html do
 
 
   # Accessible captions are created using a combination of the <figure /> and <figcaption /> elements.
-  defp wrap_with_figure(%{"caption" => caption} = attrs, content) do
-    ["<figure#{figure_width(attrs)}>"] ++ content ++ ["<figcaption>#{caption}</figcaption></figure>"]
-  end
+  defp wrap_with_figure(%{"caption" => caption}, content) do
+    ["<figure>"] ++ content ++ ["<figcaption>#{caption}</figcaption></figure>"]
+end
   defp wrap_with_figure(_attrs, content), do: content
-  defp figure_width(%{"width" => width}), do: " style=\"width: #{width}px; margin-left: auto; margin-right: auto;\""
-  defp figure_width(_), do: ""
 end

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -57,9 +57,9 @@ defmodule Oli.Rendering.Content.Html do
 
   def youtube(%Context{} = _context, _, %{"src" => src} = attrs) do
     default_width = 640
-    default_height = 476
 
-    wrap_with_figure(Map.merge(attrs, %{"width" => default_width}), ["""
+    wrap_with_figure(Map.merge(attrs, %{"width" => default_width}), [
+    """
     <div className="embed-responsive embed-responsive-16by9">
       <iframe
         class="embed-responsive-item"

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -50,10 +50,10 @@ defmodule Oli.Rendering.Content.Html do
       _ -> []
     end
 
-    ["<img"]
+    wrap_with_figure(attrs, ["<img"]
       ++ height_width
       ++ [" class=\"img-fluid img-thumbnail\""]
-      ++ [" style=\"display: block; max-height: 500px; margin-left: auto; margin-right: auto;\" src=\"", src, "\"/>\n"]
+      ++ [" style=\"display: block; max-height: 500px; margin-left: auto; margin-right: auto;\" src=\"", src, "\"/>\n"])
   end
 
   def youtube(%Context{} = _context, _, %{"src" => src} = attrs) do
@@ -188,6 +188,6 @@ defmodule Oli.Rendering.Content.Html do
   # Accessible captions are created using a combination of the <figure /> and <figcaption /> elements.
   defp wrap_with_figure(%{"caption" => caption}, content) do
     ["<figure>"] ++ content ++ ["<figcaption>#{caption}</figcaption></figure>"]
-end
+  end
   defp wrap_with_figure(_attrs, content), do: content
 end

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -60,14 +60,14 @@ defmodule Oli.Rendering.Content.Html do
     default_height = 476
 
     wrap_with_figure(Map.merge(attrs, %{"width" => default_width}), ["""
-    <iframe
-      id="#{src}"
-      width="#{default_width}"
-      height="#{default_height}"
-      src="https://www.youtube.com/embed/#{src}"
-      frameBorder="0"
-      style="display: block; margin-left: auto; margin-right: auto;"
-    ></iframe>
+    <div className="embed-responsive embed-responsive-16by9">
+      <iframe
+        class="embed-responsive-item"
+        id="#{src}"
+        allowfullscreen
+        src="https://www.youtube.com/embed/#{src}"
+      ></iframe>
+    </div>
     """])
   end
 

--- a/test/oli/rendering/content/html_test.exs
+++ b/test/oli/rendering/content/html_test.exs
@@ -21,13 +21,13 @@ defmodule Oli.Content.Content.HtmlTest do
       rendered_html_string = Phoenix.HTML.raw(rendered_html) |> Phoenix.HTML.safe_to_string
 
       assert rendered_html_string =~ "<h3>Introduction</h3>"
-      assert rendered_html_string =~ "<img  style=\"display: block; max-height: 500px; margin-left: auto; margin-right: auto;\" src=\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f9/Declaration_of_Independence_%281819%29%2C_by_John_Trumbull.jpg/480px-Declaration_of_Independence_%281819%29%2C_by_John_Trumbull.jpg\"/>"
+      assert rendered_html_string =~ "<img class=\"img-fluid img-thumbnail\" style=\"display: block; max-height: 500px; margin-left: auto; margin-right: auto;\" src=\"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f9/Declaration_of_Independence_%281819%29%2C_by_John_Trumbull.jpg/480px-Declaration_of_Independence_%281819%29%2C_by_John_Trumbull.jpg\"/>"
       assert rendered_html_string =~ "<p>The American colonials proclaimed &quot;no taxation without representation"
       assert rendered_html_string =~ "<a href=\"https://en.wikipedia.org/wiki/Stamp_Act_Congress\">Stamp Act Congress</a>"
       assert rendered_html_string =~ "<h3>1651–1748: Early seeds</h3>"
       assert rendered_html_string =~ "<ol><li>one</li>\n<li><em>two</em></li>\n<li><em><strong>three</strong></em></li>\n</ol>"
       assert rendered_html_string =~ "<ul><li>alpha</li>\n<li>beta</li>\n<li>gamma</li>\n</ul>"
-      assert rendered_html_string =~ "<iframe\n  id=\"fhdCslFcKFU\"\n  width=\"640\"\n  height=\"476\"\n  src=\"https://www.youtube.com/embed/fhdCslFcKFU\"\n  frameBorder=\"0\"\n  style=\"display: block; margin-left: auto; margin-right: auto;\"\n></iframe>"
+      assert rendered_html_string =~ "<div class=\"embed-responsive embed-responsive-16by9 img-thumbnail\">\n  <iframe class=\"embed-responsive-item\" id=\"fhdCslFcKFU\" allowfullscreen src=\"https://www.youtube.com/embed/fhdCslFcKFU\">\n  </iframe>\n</div>"
       assert rendered_html_string =~ "<pre><code>import fresh-pots\n</code></pre>"
     end
 


### PR DESCRIPTION
* Audio
* Image
* Code
* Table
* Youtube

The accessible solution was to wrap the elements in a `<figure>` and use `<figcaption>` to display the caption. Tables are a little different in that they use a `<caption>` element within the table itself.