### PR TITLE
Prevent one datashop export failure

### DIFF
--- a/lib/oli/analytics/datashop/elements/event_descriptor.ex
+++ b/lib/oli/analytics/datashop/elements/event_descriptor.ex
@@ -14,6 +14,7 @@ defmodule Oli.Analytics.Datashop.Elements.EventDescriptor do
   </event_descriptor>
   """
   import XmlBuilder
+  require Logger
   alias Oli.Analytics.Datashop.Utils
 
   def setup(%{ type: type, problem_name: problem_name, part_attempt: part_attempt }) do
@@ -33,28 +34,33 @@ defmodule Oli.Analytics.Datashop.Elements.EventDescriptor do
   end
 
   defp get_input(type, part_attempt) do
-    case type do
-      # Input for hint elements does not record student input
-      "HINT" -> "HINT"
-      "HINT_MSG" -> "HINT"
-      "ATTEMPT" ->
-        input = part_attempt.response["input"]
+    try do
+      case type do
+        # Input for hint elements does not record student input
+        "HINT" -> "HINT"
+        "HINT_MSG" -> "HINT"
+        "ATTEMPT" ->
+          input = part_attempt.response["input"]
 
-        case activity_type(part_attempt) do
-          # for short answer questions, the input is the text the student entered in the field
-          "oli_short_answer" -> input
-            |> Utils.parse_content
-          # for multiple choice questions, the input is a string id that refers to the selected choice
-          "oli_multiple_choice" ->
-            choices = part_attempt.activity_attempt.transformed_model["choices"]
-            Enum.find(choices, & &1["id"] == input)["content"]
-            |> Utils.parse_content
-          # fallback for future activity types
-          _unregistered -> "Input in unregistered activity type: " <> input
-        end
-      "RESULT" ->
-        part_attempt.feedback["content"]
-        |> Utils.parse_content
+          case activity_type(part_attempt) do
+            # for short answer questions, the input is the text the student entered in the field
+            "oli_short_answer" -> input
+              |> Utils.parse_content
+            # for multiple choice questions, the input is a string id that refers to the selected choice
+            "oli_multiple_choice" ->
+              choices = part_attempt.activity_attempt.transformed_model["choices"]
+              Enum.find(choices, & &1["id"] == input)["content"]
+              |> Utils.parse_content
+            # fallback for future activity types
+            _unregistered -> "Input in unregistered activity type: " <> input
+          end
+        "RESULT" ->
+          part_attempt.feedback["content"]
+          |> Utils.parse_content
+      end
+    rescue
+      _e -> Logger.error("Error in EventDescriptor.get_input. Type: #{type}, part attempt: #{Kernel.inspect(part_attempt)}")
+      "The input that created this event could not be found."
     end
   end
 


### PR DESCRIPTION
Add a try catch around the problem area that was causing a datashop export failure from not being able to parse activity content.

The logging will help us identify the root cause if this happens again, which should be an easy fix once we know the activity model content that is triggering it.