### PR TITLE
Rearrange last drop area should be bigger

### DIFF
--- a/assets/src/components/content/AddResourceContent.scss
+++ b/assets/src/components/content/AddResourceContent.scss
@@ -1,6 +1,8 @@
 @import 'authoring/variables';
+@import 'authoring/mixins';
 
 .add-resource-content {
+  @include disable-select;
   position: relative;
   padding: 10px 0;
   cursor: pointer;
@@ -33,6 +35,10 @@
     .insert-adornment {
       opacity: 1;
       background-color: $primary;
+    }
+
+    .insert-label {
+      opacity: 0;
     }
   }
 
@@ -71,6 +77,9 @@
     transition: opacity 200ms ease-out;
   }
 
+  .insert-label {
+    transition: opacity 200ms ease-out;
+  }
 }
 
 

--- a/assets/src/components/content/AddResourceContent.tsx
+++ b/assets/src/components/content/AddResourceContent.tsx
@@ -166,6 +166,14 @@ export const AddResourceContent = (
               </Popover>
             </div>
             <div className="insert-adornment"></div>
+
+            {isLast && (
+              <div className="insert-label mt-4 text-center">
+                <div className="btn btn-sm btn-light">
+                  Add Content or Activity
+                </div>
+              </div>
+            )}
           </React.Fragment>
         }
 

--- a/assets/src/components/resource/Editors.scss
+++ b/assets/src/components/resource/Editors.scss
@@ -68,12 +68,16 @@
         background-image: url("data:image/svg+xml,%3csvg width='100%25' height='100%25' xmlns='http://www.w3.org/2000/svg'%3e%3crect width='100%25' height='100%25' fill='none' rx='8' ry='8' stroke='%23DEDEDEFF' stroke-width='4' stroke-dasharray='6%2c 14' stroke-dashoffset='0' stroke-linecap='square'/%3e%3c/svg%3e");
         border-radius: 8px;
         width: 100%;
-        margin: auto;
+        height: 64px;
         text-align: center;
         text-transform: uppercase;
         font-weight: 600;
         color: $gray-300;
       }
+    }
+
+    &.is-last {
+      height: 200px;
     }
   }
 

--- a/assets/src/components/resource/Editors.tsx
+++ b/assets/src/components/resource/Editors.tsx
@@ -57,7 +57,7 @@ interface UnknownPayload {
 type DragPayload = StructuredContent | ActivityPayload | UnknownPayload;
 
 // @ts-ignore
-const DropTarget = ({ id, index, onDrop }) => {
+const DropTarget = ({ id, index, isLast, onDrop }) => {
   const [hovered, setHovered] = useState(false);
 
   const handleDragEnter = (e: React.DragEvent<HTMLDivElement>) => setHovered(true);
@@ -74,7 +74,7 @@ const DropTarget = ({ id, index, onDrop }) => {
 
   return (
     <div key={id + '-drop'}
-      className={classNames(['drop-target ', hovered ? 'hovered' : ''])}
+      className={classNames(['drop-target ', hovered ? 'hovered' : '', isLast ? 'is-last' : ''])}
       onDragEnter={handleDragEnter}
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
@@ -111,7 +111,7 @@ const AddResourceOrDropTarget = ({
   onRegisterNewObjective,
 }: AddResourceOrDropTargetProps) => isReorderMode
   ? (
-    <DropTarget id={id} index={index} onDrop={onDrop}/>
+    <DropTarget id={id} index={index} isLast={id === 'last'} onDrop={onDrop}/>
   )
   : (
     <AddResourceContent


### PR DESCRIPTION
This PR expands the last drop area in content drag and drop mode to enable easier rearranging. It also addresses another point made in the alpha test by adding a pseudo button increasing the discoverability of how to add content and activities to a page.

Closes #401