### PR TITLE
add outline highlight for selected image and youtube

### DIFF
--- a/assets/src/components/editor/Editor.tsx
+++ b/assets/src/components/editor/Editor.tsx
@@ -52,6 +52,8 @@ const voidOnKeyDown = (editor: ReactEditor, e: React.KeyboardEvent) => {
           Transforms.insertNodes(editor, create<Paragraph>(
             { type: 'p', children: [{ text: '' }], id: guid() }),
             { at: Path.next(path) });
+
+          Transforms.select(editor, Path.next(path));
         }
       });
 

--- a/assets/src/components/editor/editors/Image.tsx
+++ b/assets/src/components/editor/editors/Image.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect, useState } from 'react';
-import { ReactEditor } from 'slate-react';
+import { ReactEditor, useFocused, useSelected } from 'slate-react';
 import { Transforms } from 'slate';
 import { updateModel, getEditMode } from './utils';
 import * as ContentModel from 'data/content/model';
@@ -163,6 +163,9 @@ export const ImageEditor = (props: ImageProps) => {
   const { attributes, children, editor } = props;
   const { model } = props;
 
+  const focused = useFocused();
+  const selected = useSelected();
+
   const editMode = getEditMode(editor);
 
   const onEdit = (updated: ContentModel.Image) => {
@@ -186,6 +189,9 @@ export const ImageEditor = (props: ImageProps) => {
     onRemove={onRemove}
     onEdit={onEdit}/>;
 
+  const imageStyle = focused && selected
+  ? { border: 'solid 2px lightblue' } : {};
+
   // Note that it is important that any interactive portions of a void editor
   // must be enclosed inside of a "contentEditable=false" container. Otherwise,
   // slate does some weird things that non-deterministically interface with click
@@ -197,6 +203,7 @@ export const ImageEditor = (props: ImageProps) => {
       <div contentEditable={false} style={{ userSelect: 'none' }}>
         <div className="ml-4 mr-4">
           <img
+            style={imageStyle}
             className="img-fluid img-thumbnail"
             src={model.src}
             draggable={false}

--- a/assets/src/components/editor/editors/YouTube.tsx
+++ b/assets/src/components/editor/editors/YouTube.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { ReactEditor } from 'slate-react';
+import { ReactEditor, useSelected, useFocused } from 'slate-react';
 import { Transforms } from 'slate';
 
 import { updateModel, getEditMode } from './utils';
@@ -135,6 +135,9 @@ export const YouTubeEditor = (props: YouTubeProps) => {
 
   const editMode = getEditMode(editor);
 
+  const focused = useFocused();
+  const selected = useSelected();
+
   // Note that it is important that any interactive portions of a void editor
   // must be enclosed inside of a "contentEditable=false" container. Otherwise,
   // slate does some weird things that non-deterministically interface with click
@@ -165,13 +168,19 @@ export const YouTubeEditor = (props: YouTubeProps) => {
     onRemove={onRemove}
     onEdit={onEdit}/>;
 
+
+  const borderStyle = focused && selected
+    ? { border: 'solid 2px lightblue' } : {};
+
+
   return (
     <div {...attributes} className="ml-4 mr-4">
 
-      <div contentEditable={false} style={{ userSelect: 'none' }} className="youtube-editor">
+      <div contentEditable={false} style={{ userSelect: 'none' }}
+        className="youtube-editor">
 
         <div className="embed-responsive embed-responsive-16by9 img-thumbnail">
-          <iframe className="embed-responsive-item"
+          <iframe className="embed-responsive-item" style={borderStyle}
             src={fullSrc} allowFullScreen></iframe>
         </div>
         <Settings.ToolPopupButton


### PR DESCRIPTION
Closes #347 

This PR simply adds a highlight border when an image or youtube video is selected, indicating to the user (perhaps) that pressing enter adds more content.  

This isn't a perfect solution, but it is a step in the right direction.  