### PR TITLE
Fix locking

### DIFF
--- a/assets/src/components/resource/ResourceEditor.tsx
+++ b/assets/src/components/resource/ResourceEditor.tsx
@@ -201,9 +201,7 @@ export class ResourceEditor extends React.Component<ResourceEditorProps, Resourc
 
   componentWillUnmount() {
 
-    console.log('component unmounted');
     this.persistence.destroy();
-
 
     unregisterUnload(this.windowUnloadListener);
     unregisterUndoRedoHotkeys(this.undoRedoListener);

--- a/assets/src/components/resource/ResourceEditor.tsx
+++ b/assets/src/components/resource/ResourceEditor.tsx
@@ -66,7 +66,11 @@ function withDefaultContent(content: ResourceContent[]) {
 
 function registerUnload(strategy: PersistenceStrategy) {
   return window.addEventListener('beforeunload', (event) => {
-    strategy.destroy();
+
+    // Destroying the strategy is done in another execution context
+    // as running it inline fails in Firefox, as the release
+    // lock HTTP request does not get sent
+    setTimeout(() => strategy.destroy(), 0);
   });
 }
 
@@ -196,7 +200,11 @@ export class ResourceEditor extends React.Component<ResourceEditorProps, Resourc
   }
 
   componentWillUnmount() {
+
+    console.log('component unmounted');
     this.persistence.destroy();
+
+
     unregisterUnload(this.windowUnloadListener);
     unregisterUndoRedoHotkeys(this.undoRedoListener);
     unregisterKeydown(this.keydownListener);


### PR DESCRIPTION
Closes #438 

The issue here was browser specific.  For some reason Firefox suppresses the execution of HTTP requests from inlined code in a beforeunload window event.  Putting that same code in another execution context (via `setTimeout`) fixes the problem. 

I tested this and it still works in Chrome. 