### PR TITLE
hide submit button

### DIFF
--- a/lib/oli/delivery/page/page_context.ex
+++ b/lib/oli/delivery/page/page_context.ex
@@ -4,8 +4,8 @@ defmodule Oli.Delivery.Page.PageContext do
   Defines the context required to render a page in delivery mode.
   """
 
-  @enforce_keys [:summary, :page, :progress_state, :resource_attempts, :activities, :objectives, :previous_page, :next_page, :activity_count]
-  defstruct [:summary, :page, :progress_state, :resource_attempts, :activities, :objectives, :previous_page, :next_page, :activity_count]
+  @enforce_keys [:summary, :page, :progress_state, :resource_attempts, :activities, :objectives, :previous_page, :next_page]
+  defstruct [:summary, :page, :progress_state, :resource_attempts, :activities, :objectives, :previous_page, :next_page]
 
   alias Oli.Delivery.Page.ActivityContext
   alias Oli.Delivery.Page.PageContext
@@ -51,8 +51,6 @@ defmodule Oli.Delivery.Page.PageContext do
       page_revision
     end
 
-    activity_count = activity_reference_count(Map.get(page_revision.content, "model"))
-
     {objectives, previous, next} = retrieve_objectives_previous_next(context_id, page_revision, container_id)
 
     {:ok, summary} = Summary.get_summary(context_id, user)
@@ -65,18 +63,8 @@ defmodule Oli.Delivery.Page.PageContext do
       activities: activities,
       objectives: objectives,
       previous_page: previous,
-      next_page: next,
-      activity_count: activity_count
+      next_page: next
     }
-  end
-
-  defp activity_reference_count(content) do
-    case content do
-      nil -> 0
-      [] -> 0
-      _ -> Enum.filter(content, fn %{"type" => type} -> type == "activity-reference" end)
-           |> Enum.count
-    end
   end
 
   # We combine retrieve objective titles and previous next page

--- a/lib/oli/delivery/page/page_context.ex
+++ b/lib/oli/delivery/page/page_context.ex
@@ -4,8 +4,8 @@ defmodule Oli.Delivery.Page.PageContext do
   Defines the context required to render a page in delivery mode.
   """
 
-  @enforce_keys [:summary, :page, :progress_state, :resource_attempts, :activities, :objectives, :previous_page, :next_page]
-  defstruct [:summary, :page, :progress_state, :resource_attempts, :activities, :objectives, :previous_page, :next_page]
+  @enforce_keys [:summary, :page, :progress_state, :resource_attempts, :activities, :objectives, :previous_page, :next_page, :activity_count]
+  defstruct [:summary, :page, :progress_state, :resource_attempts, :activities, :objectives, :previous_page, :next_page, :activity_count]
 
   alias Oli.Delivery.Page.ActivityContext
   alias Oli.Delivery.Page.PageContext
@@ -51,6 +51,8 @@ defmodule Oli.Delivery.Page.PageContext do
       page_revision
     end
 
+    activity_count = activity_reference_count(Map.get(page_revision.content, "model"))
+
     {objectives, previous, next} = retrieve_objectives_previous_next(context_id, page_revision, container_id)
 
     {:ok, summary} = Summary.get_summary(context_id, user)
@@ -63,8 +65,18 @@ defmodule Oli.Delivery.Page.PageContext do
       activities: activities,
       objectives: objectives,
       previous_page: previous,
-      next_page: next
+      next_page: next,
+      activity_count: activity_count
     }
+  end
+
+  defp activity_reference_count(content) do
+    case content do
+      nil -> 0
+      [] -> 0
+      _ -> Enum.filter(content, fn %{"type" => type} -> type == "activity-reference" end)
+           |> Enum.count
+    end
   end
 
   # We combine retrieve objective titles and previous next page

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -107,6 +107,7 @@ defmodule OliWeb.PageDeliveryController do
       next_page: context.next_page,
       title: context.page.title,
       graded: context.page.graded,
+      activity_count: context.activity_count,
       html: html,
       objectives: context.objectives,
       slug: context.page.slug,

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -107,7 +107,7 @@ defmodule OliWeb.PageDeliveryController do
       next_page: context.next_page,
       title: context.page.title,
       graded: context.page.graded,
-      activity_count: context.activity_count,
+      activity_count: map_size(context.activities),
       html: html,
       objectives: context.objectives,
       slug: context.page.slug,

--- a/lib/oli_web/templates/page_delivery/page.html.eex
+++ b/lib/oli_web/templates/page_delivery/page.html.eex
@@ -11,6 +11,6 @@
   OLI.initActivityBridge('eventIntercept');
 </script>
 
-<%= if @graded do %>
+<%= if @graded && @activity_count > 0 do %>
   <%= link "Submit Assessment", to: Routes.page_delivery_path(@conn, :finalize_attempt, @context_id, @slug, @attempt_guid), class: "btn btn-primary btn-lg" %>
 <% end %>


### PR DESCRIPTION
On delivery mode; disables the "Submit Assessment" button if the assessment page has zero activities