### PR TITLE
Additional rollup work

### DIFF
--- a/assets/styles/delivery/page_delivery/page.scss
+++ b/assets/styles/delivery/page_delivery/page.scss
@@ -48,6 +48,19 @@
   }
 }
 
+.rolled-up-objectives {
+
+  margin: 10px;
+  margin-top: 20px;
+
+  .label {
+    font-size: 1.2em;
+  }
+  .title {
+    font-size: 1.1em;
+  }
+}
+
 .course-btn {
   max-width: 200px;
   overflow: hidden;

--- a/lib/oli/delivery/page/objectives_rollup.ex
+++ b/lib/oli/delivery/page/objectives_rollup.ex
@@ -1,0 +1,45 @@
+defmodule Oli.Delivery.Page.ObjectivesRollup do
+
+  # for a map of activity ids to latest attempt tuples (where the first tuple item is the activity attempt)
+  # return the parent objective revisions of all attached objectives
+  # if an attached objective is a parent, include that in the return list
+  def rollup_objectives(activity_revisions, resolver, context_id) do
+
+    attached_objective_ids = Enum.reduce(activity_revisions, MapSet.new(), fn %{objectives: objectives}, all ->
+        Enum.map(objectives, fn {_, ids} -> ids end)
+        |> List.flatten
+        |> MapSet.new
+        |> MapSet.union(all)
+      end)
+    |> MapSet.to_list
+
+    all = resolver.from_resource_id(context_id, attached_objective_ids)
+
+    parents = resolver.find_parent_objectives(context_id, attached_objective_ids)
+
+    # now we have revisions for all directly attached objectives and their parents (if they have parents)
+    # we want to only return the parents
+
+    # create a map set of all referenced children
+    referenced_children = Enum.reduce(parents, MapSet.new(), fn %{children: children}, m ->
+      Enum.reduce(children, m, fn id, m -> MapSet.put(m, id) end)
+    end)
+
+    # now look at all directly attached objectives.  If one does not exist within the set of referenced
+    # children that means that is a root objective that was directly attached, so we append it to
+    # the parents collection
+    Enum.reduce(all, parents, fn r, items ->
+      case MapSet.member?(referenced_children, r.resource_id) do
+        true -> items
+        false -> [r] ++ items
+      end
+    end)
+    |> Enum.map(fn r -> r.title end)
+    |> MapSet.new
+    |> MapSet.to_list()
+    |> Enum.sort
+
+  end
+
+
+end

--- a/lib/oli/delivery/page/page_context.ex
+++ b/lib/oli/delivery/page/page_context.ex
@@ -51,7 +51,7 @@ defmodule Oli.Delivery.Page.PageContext do
       page_revision
     end
 
-    {objectives, previous, next} = retrieve_objectives_previous_next(context_id, page_revision, container_id)
+    {previous, next} = retrieve_previous_next(context_id, page_revision, container_id)
 
     {:ok, summary} = Summary.get_summary(context_id, user)
 
@@ -61,7 +61,7 @@ defmodule Oli.Delivery.Page.PageContext do
       progress_state: progress_state,
       resource_attempts: resource_attempts,
       activities: activities,
-      objectives: objectives,
+      objectives: [],
       previous_page: previous,
       next_page: next
     }
@@ -70,7 +70,7 @@ defmodule Oli.Delivery.Page.PageContext do
   # We combine retrieve objective titles and previous next page
   # information in one step so that we can do all their revision
   # resolution in one step.
-  defp retrieve_objectives_previous_next(context_id,
+  defp retrieve_previous_next(context_id,
     %Revision{objectives: %{"attached" => objective_ids}} = page_revision, container_id) do
 
     # if container_id is nil we assume it is the root
@@ -83,17 +83,29 @@ defmodule Oli.Delivery.Page.PageContext do
 
     # resolve all of these references, all at once, storing
     # them in a map based on their resource_id as the key
-    all_resources = objective_ids ++ Enum.filter(previous_next, fn a -> a != nil end)
+    all_resources = Enum.filter(previous_next, fn a -> a != nil end)
 
     revisions = DeliveryResolver.from_resource_id(context_id, all_resources)
     |> Enum.reduce(%{}, fn r, m -> Map.put(m, r.resource_id, r) end)
 
-    objective_titles = Enum.map(objective_ids, fn id -> Map.get(revisions, id).title end)
-
     previous = Map.get(revisions, Enum.at(previous_next, 0))
     next = Map.get(revisions, Enum.at(previous_next, 1))
 
-    {objective_titles, previous, next}
+    {previous, next}
+  end
+
+  defp rollup_objectives(activities, resolver) do
+
+    all_attached_objectives = Enum.reduce(activities, MapSet.new(), fn {_, %{objectives: objectives}}, all ->
+      Enum.map(objectives, fn {_, ids} -> ids end)
+      |> List.flatten
+      |> MapSet.new
+      |> MapSet.union(all)
+    end)
+    |> MapSet.to_list
+
+
+
   end
 
   defp determine_previous_next(%{children: children}, page_resource_id) do

--- a/lib/oli/publishing/resolver.ex
+++ b/lib/oli/publishing/resolver.ex
@@ -33,4 +33,9 @@ defmodule Oli.Publishing.Resolver do
   """
   @callback root_resource(String.t) :: %Revision{}
 
+  @doc """
+  Finds the top-level objectives and resolves their revisions
+  """
+  @callback top_level_objectives(String.t) :: [%Revision]
+
 end

--- a/lib/oli/publishing/resolver.ex
+++ b/lib/oli/publishing/resolver.ex
@@ -34,8 +34,11 @@ defmodule Oli.Publishing.Resolver do
   @callback root_resource(String.t) :: %Revision{}
 
   @doc """
-  Finds the top-level objectives and resolves their revisions
+  Finds the parent objectives for a list of objective resource ids that
+  might be child objectives.  Returns a map of the child objective resource id
+  to the parent objective.  There will not be an entry in this map if
+  a given objective resource id is a root objective
   """
-  @callback top_level_objectives(String.t) :: [%Revision]
+  @callback find_parent_objectives(String.t, [number]) :: map()
 
 end

--- a/lib/oli_web/templates/page_delivery/_objectives.html.eex
+++ b/lib/oli_web/templates/page_delivery/_objectives.html.eex
@@ -1,1 +1,14 @@
-<%# RENDER OBJECTIVES %>
+
+<%= if length(@objectives) > 0 do %>
+
+  <div class="rolled-up-objectives">
+
+    <div class="label">Learning Objectives</div>
+    <ul>
+    <%= for title <- @objectives do %>
+      <li class="title"><%= title %></li>
+    <% end %>
+    </ul>
+  </div>
+
+<% end %>

--- a/lib/oli_web/templates/resource/page_preview.html.eex
+++ b/lib/oli_web/templates/resource/page_preview.html.eex
@@ -5,6 +5,8 @@
 
 <h1><%= @context.title %></h1>
 
+<%= render OliWeb.PageDeliveryView, "_objectives.html", objectives: @objectives %>
+
 <div id="eventIntercept">
   <%= raw(@content_html) %>
 </div>

--- a/test/oli/delivery/page/page_context_test.exs
+++ b/test/oli/delivery/page/page_context_test.exs
@@ -7,10 +7,23 @@ defmodule Oli.Delivery.Page.PageContextTest do
   describe "page context" do
 
     setup do
+
+      content = %{
+        "stem" => "1",
+        "authoring" => %{
+          "parts" => [
+            %{"id" => "1", "responses" => [], "scoringStrategy" => "best", "evaluationStrategy" => "regex"}
+          ]
+        }
+      }
+
       map = Seeder.base_project_with_resource2()
       |> Seeder.create_section()
       |> Seeder.add_objective("objective one", :o1)
-      |> Seeder.add_activity(%{title: "one", content: %{"authoring" => "3"}}, :a1)
+
+      o = Map.get(map, :o1).revision.resource_id
+
+      map = Seeder.add_activity(map, %{title: "one", objectives: %{"1" => [o]}, content: content}, :a1)
       |> Seeder.add_activity(%{title: "two", content: %{"stem" => "3"}}, :a2)
       |> Seeder.add_user(%{}, :user1)
 
@@ -22,7 +35,7 @@ defmodule Oli.Delivery.Page.PageContextTest do
             %{"type" => "activity-reference", "activity_id" => Map.get(map, :a2).resource.id}
           ]
         },
-        objectives: %{"attached" => [Map.get(map, :o1).resource.id]}
+        objectives: %{"attached" => []}
       }
 
       Seeder.add_page(map, attrs, :p1)
@@ -40,7 +53,7 @@ defmodule Oli.Delivery.Page.PageContextTest do
       context = PageContext.create_page_context(section.context_id, p1.revision.slug, user)
 
       # verify activities map
-      assert Map.get(context.activities, a1.resource.id).model == "{}"
+      assert Map.get(context.activities, a1.resource.id).model != nil
 
       # verify objectives map
       assert context.objectives == ["objective one"]

--- a/test/oli/publishing/authoring_resolver_test.exs
+++ b/test/oli/publishing/authoring_resolver_test.exs
@@ -9,6 +9,12 @@ defmodule Oli.Publishing.AuthoringResolverTest do
     setup do
 
       map = Seeder.base_project_with_resource2()
+      |> Seeder.add_objective("child1", :child1)
+      |> Seeder.add_objective("child2", :child2)
+      |> Seeder.add_objective("child3", :child3)
+      |> Seeder.add_objective("child4", :child4)
+      |> Seeder.add_objective_with_children("parent1", [:child1, :child2, :child3], :parent1)
+      |> Seeder.add_objective_with_children("parent2", [:child4], :parent2)
 
       # Create another project with resources and revisions
       Seeder.another_project(map.author, map.institution)
@@ -31,6 +37,21 @@ defmodule Oli.Publishing.AuthoringResolverTest do
 
       Map.put(map, :latest1, latest1)
       |> Map.put(:latest2, latest2)
+    end
+
+    test "find_parent_objectives/2 returns parents", %{ project: project,
+      child1: child1, child2: child2, child3: child3, child4: child4, parent1: parent1, parent2: parent2 } do
+
+      # find one
+      assert [parent1.revision] == AuthoringResolver.find_parent_objectives(project.slug, [child1.resource.id])
+
+      # find both
+      assert [parent1.revision, parent2.revision] == AuthoringResolver.find_parent_objectives(project.slug, [child1.resource.id, child4.resource.id])
+      assert [parent1.revision, parent2.revision] == AuthoringResolver.find_parent_objectives(project.slug, [child1.resource.id, child2.resource.id, child3.resource.id, child4.resource.id])
+
+      # find none
+      assert [] == AuthoringResolver.find_parent_objectives(project.slug, [parent1.resource.id, parent2.resource.id])
+
     end
 
     test "from_resource_id/2 returns correct revision", %{ revision1: revision, latest1: latest1, project: project } do

--- a/test/oli/qa/pedagogy_test.exs
+++ b/test/oli/qa/pedagogy_test.exs
@@ -32,17 +32,11 @@ defmodule Oli.Qa.PedagogyTest do
       |> Map.put(:activities, Publishing.get_unpublished_revisions_by_type(Map.get(map, :project).slug, "activity"))
     end
 
-    test "no attached objectives", %{project: project, review: review, pages: pages, activities: activities,
-      page_no_objectives: page_no_objectives, page_has_objectives: page_has_objectives,
+    test "no attached objectives", %{project: project, review: review, activities: activities,
       activity_no_objectives: activity_no_objectives, activity_has_objectives: activity_has_objectives } do
 
-      Pedagogy.no_attached_objectives(review, pages)
       Pedagogy.no_attached_objectives(review, activities)
       warnings = Warnings.list_active_warnings(project.id)
-
-      # pages
-      assert Enum.find(warnings, & &1.revision.id == page_no_objectives.revision.id)
-      assert !Enum.find(warnings, & &1.revision.id == page_has_objectives.revision.id)
 
       # activities
       assert Enum.find(warnings, & &1.revision.id == activity_no_objectives.revision.id)

--- a/test/oli_web/live/qa_logic_test.exs
+++ b/test/oli_web/live/qa_logic_test.exs
@@ -58,14 +58,15 @@ defmodule OliWeb.Qa.StateLogicTest do
         }
       }, :page_has_activities)
       |> Seeder.add_activity(%{objectives: %{}}, :activity_no_objectives)
+      |> Seeder.add_activity(%{objectives: %{}}, :activity_no_objectives)
+      |> Seeder.add_activity(%{objectives: %{}}, :activity_no_objectives)
       |> Seeder.add_activity(%{objectives: %{"1" => [Map.get(map, :o1).resource.id]}}, :activity_has_objectives)
       |> Map.put(:pages, Publishing.get_unpublished_revisions_by_type(Map.get(map, :project).slug, "page"))
       |> Map.put(:activities, Publishing.get_unpublished_revisions_by_type(Map.get(map, :project).slug, "activity"))
     end
 
-    test "filtering", %{project: project, review: review, content: content, pages: pages, activities: activities, author: author} do
+    test "filtering", %{project: project, review: review, content: content, activities: activities, author: author} do
 
-      Pedagogy.no_attached_objectives(review, pages)
       Pedagogy.no_attached_objectives(review, activities)
       Content.broken_uris(content, project.slug)
 
@@ -104,9 +105,8 @@ defmodule OliWeb.Qa.StateLogicTest do
     end
 
 
-    test "dismissal when the item is first selected", %{project: project, review: review, content: content, pages: pages, activities: activities, author: author} do
+    test "dismissal when the item is first selected", %{project: project, review: review, content: content, activities: activities, author: author} do
 
-      Pedagogy.no_attached_objectives(review, pages)
       Pedagogy.no_attached_objectives(review, activities)
       Content.broken_uris(content, project.slug)
 
@@ -125,9 +125,8 @@ defmodule OliWeb.Qa.StateLogicTest do
 
     end
 
-    test "dismissal when the item is last selected", %{project: project, review: review, content: content, pages: pages, activities: activities, author: author} do
+    test "dismissal when the item is last selected", %{project: project, review: review, content: content, activities: activities, author: author} do
 
-      Pedagogy.no_attached_objectives(review, pages)
       Pedagogy.no_attached_objectives(review, activities)
       Content.broken_uris(content, project.slug)
 
@@ -146,9 +145,8 @@ defmodule OliWeb.Qa.StateLogicTest do
 
     end
 
-    test "dismissal when the item is not first or last, but selected", %{project: project, review: review, content: content, pages: pages, activities: activities, author: author} do
+    test "dismissal when the item is not first or last, but selected", %{project: project, review: review, content: content, activities: activities, author: author} do
 
-      Pedagogy.no_attached_objectives(review, pages)
       Pedagogy.no_attached_objectives(review, activities)
       Content.broken_uris(content, project.slug)
 
@@ -167,9 +165,8 @@ defmodule OliWeb.Qa.StateLogicTest do
 
     end
 
-    test "dismissal when the dismissed is not selected", %{project: project, review: review, content: content, pages: pages, activities: activities, author: author} do
+    test "dismissal when the dismissed is not selected", %{project: project, review: review, content: content, activities: activities, author: author} do
 
-      Pedagogy.no_attached_objectives(review, pages)
       Pedagogy.no_attached_objectives(review, activities)
       Content.broken_uris(content, project.slug)
 
@@ -189,9 +186,8 @@ defmodule OliWeb.Qa.StateLogicTest do
     end
 
     test "dismissing the last warning in a filtered state should not select a new warning for display",
-      %{project: project, review: review, content: content, pages: pages, activities: activities, author: author} do
+      %{project: project, review: review, content: content, activities: activities, author: author} do
 
-      Pedagogy.no_attached_objectives(review, pages)
       Pedagogy.no_attached_objectives(review, activities)
       Content.broken_uris(content, project.slug)
 


### PR DESCRIPTION
Closes #371 

This PR does two things:

1) Removes the "attached objectives to a page" qa warning check

2) Displays a roll up of attached objectives to page delivery and page preview.  This roll up is designed to only show "top level objectives".  So if a user attaches a child objective to an activity - this rollup will display the title of the parent objective to that child objective on the page.  

Note, this is the first part of the system that takes the approach of having the resolver passed down into it.  This allows this rollup logic to work correctly when it is used in a delivery or authoring context, since it isn't directly depending on either of those resolvers.  