### PR TITLE
remove keep-alive flag

### DIFF
--- a/assets/src/data/persistence/common.ts
+++ b/assets/src/data/persistence/common.ts
@@ -43,7 +43,6 @@ export function makeRequest<SuccessType>(
       method,
       headers,
       body,
-      keepalive: true,
     })
     .then((response: Response) => {
       if (!response.ok) {


### PR DESCRIPTION
Removes the `keep-alive` param from make requests.  This was added recently in the bug fix to allow requests to succeed when a page is closed.  This isn't needed to fix that problem - but , as we now discovered - it must be removed because it breaks certain types of HTTP requests. 

I tested making changes and quickly leaving the page and there is no data loss.  

Closes #467 