### PR TITLE
Youtube placement

### DIFF
--- a/assets/src/components/editor/editors/YouTube.tsx
+++ b/assets/src/components/editor/editors/YouTube.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { ReactEditor, useSelected, useFocused } from 'slate-react';
-import { Transforms, Range } from 'slate';
+import { Transforms } from 'slate';
 
 import { updateModel, getEditMode } from './utils';
 import * as ContentModel from 'data/content/model';

--- a/assets/src/components/editor/editors/YouTube.tsx
+++ b/assets/src/components/editor/editors/YouTube.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { ReactEditor, useSelected, useFocused } from 'slate-react';
-import { Transforms } from 'slate';
+import { Transforms, Range } from 'slate';
 
 import { updateModel, getEditMode } from './utils';
 import * as ContentModel from 'data/content/model';
@@ -38,6 +38,8 @@ export function selectYouTube(): Promise<string | null> {
 const command: Command = {
   execute: (context, editor: ReactEditor) => {
 
+    const selection = editor.selection;
+
     selectYouTube()
     .then((selectedSrc) => {
       if (selectedSrc !== null) {
@@ -52,7 +54,13 @@ const command: Command = {
 
         const youtube = ContentModel.create<ContentModel.YouTube>(
           { type: 'youtube', src, children: [{ text: '' }], id: guid() });
-        Transforms.insertNodes(editor, youtube);
+
+        if (selection !== null) {
+          Transforms.insertNodes(editor, youtube, { at: selection });
+        } else {
+          Transforms.insertNodes(editor, youtube);
+        }
+
       }
     });
 


### PR DESCRIPTION
Closes #471 

A simple fix to allow YouTube insertion to occur at the last selection.  This was failing since the introduction of the modal selection for input of YouTube video id will cause the underlying Editor to lose its selection.