### PR TITLE
account for youtu.be style URLs

### DIFF
--- a/assets/src/components/editor/editors/YouTube.tsx
+++ b/assets/src/components/editor/editors/YouTube.tsx
@@ -50,6 +50,8 @@ const command: Command = {
         if (hasParams) {
           const queryString = src.substr(src.indexOf('?') + 1);
           src = getQueryVariableFromString('v', queryString);
+        } else if (src.indexOf('/youtu.be/') !== -1) {
+          src = src.substr(src.lastIndexOf('/') + 1);
         }
 
         const youtube = ContentModel.create<ContentModel.YouTube>(


### PR DESCRIPTION
This PR now allows the youtube creation logic to account for URLs of the form: "https://youtu.be/RbZ13TEHuOs"