### PR TITLE
Update section information

### DIFF
--- a/lib/oli_web/live/objectives/objectives.ex
+++ b/lib/oli_web/live/objectives/objectives.ex
@@ -141,7 +141,7 @@ defmodule OliWeb.Objectives.Objectives do
           acc
         end
       end)
-
+      |> Enum.sort(fn e1, e2 -> e1.mapping.resource.inserted_at <= e2.mapping.resource.inserted_at end)
 
     end
   end


### PR DESCRIPTION
Closes #479 

This PR adds a step in the LTI process to detect that if a section exists for this launch, we update the section title based on the LTI launch param