### PR TITLE
Temporarily disable theme switching for LearnLab

### DIFF
--- a/lib/oli_web/templates/workspace/account.html.eex
+++ b/lib/oli_web/templates/workspace/account.html.eex
@@ -77,19 +77,20 @@
     </div>
   </div>
 
-  <div class="row my-4">
-    <div class="col-3">
-      <h4 class="mb-3">Editor Theme</h4>
-        <%= form_for @conn, Routes.workspace_path(@conn, :update_theme), fn f -> %>
-          <%= select f,
-            :id,
-            Enum.map(@themes, fn t -> if t.default, do: {"#{t.name} (Default)", t.id}, else: {t.name, t.id} end),
-            value: @active_theme.id,
-            class: "form-control",
-            onchange: "this.form.submit();" %>
-        <% end %>
-    </div>
-  </div>
+  <%# Custom theming disabled %>
+  <%# <div class="row my-4"> %>
+    <%# <div class="col-3"> %>
+      <%# <h4 class="mb-3">Editor Theme</h4> %>
+        <%# <%= form_for @conn, Routes.workspace_path(@conn, :update_theme), fn f -> %>
+          <%# <%= select f, %>
+            <%# :id, %>
+            <%# Enum.map(@themes, fn t -> if t.default, do: {"#{t.name} (Default)", t.id}, else: {t.name, t.id} end), %>
+            <%# value: @active_theme.id, %>
+            <%# class: "form-control", %>
+            <%# onchange: "this.form.submit();" %>
+        <%# <% end %>
+    <%# </div> %>
+  <%# </div> %>
 </div>
 
 <div class="modal fade" id="modal-change-name" tabindex="-1" role="dialog" aria-labelledby="change-name-modal" aria-hidden="true">

--- a/lib/oli_web/views/layout_view.ex
+++ b/lib/oli_web/views/layout_view.ex
@@ -37,20 +37,25 @@ defmodule OliWeb.LayoutView do
     render(layout, Map.put(assigns, :inner_layout, content))
   end
 
-  def theme_url(%{:assigns => assigns} = _conn, :authoring) do
-    case assigns do
-      %{current_author: current_author} ->
-        case current_author do
-          %{preferences: %AuthorPreferences{theme: url}} ->
-            url
-          _ ->
-            Authoring.get_default_theme!().url
-        end
-
-      _ ->
-        Authoring.get_default_theme!().url
-    end
+  def theme_url(_conn, :authoring) do
+    Authoring.get_default_theme!().url
   end
+
+  # Custom theming disabled in authoring
+  # def theme_url(%{:assigns => assigns} = _conn, :authoring) do
+  #   case assigns do
+  #     %{current_author: current_author} ->
+  #       case current_author do
+  #         %{preferences: %AuthorPreferences{theme: url}} ->
+  #           url
+  #         _ ->
+  #           Authoring.get_default_theme!().url
+  #       end
+
+  #     _ ->
+  #       Authoring.get_default_theme!().url
+  #   end
+  # end
 
   def theme_url(conn, :delivery) do
     Routes.static_path(conn, "/css/delivery_theme.css")

--- a/lib/oli_web/views/layout_view.ex
+++ b/lib/oli_web/views/layout_view.ex
@@ -3,7 +3,7 @@ defmodule OliWeb.LayoutView do
 
   import OliWeb.DeliveryView, only: [user_role: 1, user_role_text: 1, user_role_color: 1, account_linked?: 1]
   alias Oli.Authoring
-  alias Oli.Accounts.AuthorPreferences
+  # alias Oli.Accounts.AuthorPreferences
 
   def get_title(assigns) do
     live_title_tag assigns[:page_title] || assigns[:title] || "Open Learning Initiative", suffix: ""


### PR DESCRIPTION
- Remove theme selection from account view
- Change theme lookup logic to always use "default" (light) theme