### PR TITLE
fix admin banner and toolbar

### DIFF
--- a/lib/oli_web/templates/shared/_admin_edit_banner.html.eex
+++ b/lib/oli_web/templates/shared/_admin_edit_banner.html.eex
@@ -1,6 +1,6 @@
 
 <%= if @is_admin? do %>
-  <div class="alert alert-warning alert-dismissible fade show" style="position: sticky; top: 0px; z-index: 900;" role="alert">
+  <div class="alert alert-warning alert-dismissible fade show" role="alert">
   <strong>You are editing as an administrator</strong>
 
   <span style="float: right;">


### PR DESCRIPTION
This PR addresses the issue of the admin bar covering up the toolbar. The admin bar is now fixed at the top of the page so it doesn't interfere with the sticky toolbar Since users can be admins now, this could be an annoyance to anyone with an admin account.

Closes #497