### PR TITLE
Fix review

### DIFF
--- a/lib/oli/qa/reviewers/pedagogy.ex
+++ b/lib/oli/qa/reviewers/pedagogy.ex
@@ -11,18 +11,26 @@ defmodule Oli.Qa.Reviewers.Pedagogy do
     activities = Publishing.get_unpublished_revisions_by_type(project_slug, "activity")
 
     # logic
-    {:ok, review} = Reviews.create_review(Course.get_project_by_slug(project_slug), "pedagogy")
-    review
-    |> no_attached_objectives(activities)
-    |> no_attached_activities(pages)
-    |> Reviews.mark_review_done
+    case Reviews.create_review(Course.get_project_by_slug(project_slug), "pedagogy") do
+      {:ok, review} ->
+
+        review
+        |> no_attached_objectives(activities)
+        |> no_attached_activities(pages)
+        |> Reviews.mark_review_done
+
+      {:error, error} -> IO.inspect error
+    end
 
     project_slug
   end
 
   def no_attached_objectives(review, revisions) do
+
     revisions
-    |> Enum.filter(fn r -> r.objectives == %{} end)
+    |> Enum.filter(fn r ->
+      Map.values(r.objectives) |> List.flatten == []
+    end)
     |> Enum.each(&Warnings.create_warning(%{
       review_id: review.id,
       revision_id: &1.id,

--- a/lib/oli/qa/uri_validator.ex
+++ b/lib/oli/qa/uri_validator.ex
@@ -30,7 +30,7 @@ defmodule Oli.Qa.UriValidator do
   # returns all uris as a map of lists grouped by :ok (valid), :error (invalid)
   # elements are of type %{ id, content }
   def validate_uris(elements, project_slug) when is_list(elements) do
-
+    IO.inspect elements
     verify_with_slug = fn e -> verify_link(e, project_slug) end
 
     elements
@@ -73,14 +73,7 @@ defmodule Oli.Qa.UriValidator do
     if !valid_uri?(uri)
     do {:error, element}
     else
-      try do
-        case HTTPoison.head(uri) do
-          {:ok, _} -> {:ok, element}
-          _ -> {:error, element}
-        end
-      rescue
-        _ -> {:error, element}
-      end
+      {:ok, element}
     end
   end
 

--- a/lib/oli/qa/uri_validator.ex
+++ b/lib/oli/qa/uri_validator.ex
@@ -30,7 +30,6 @@ defmodule Oli.Qa.UriValidator do
   # returns all uris as a map of lists grouped by :ok (valid), :error (invalid)
   # elements are of type %{ id, content }
   def validate_uris(elements, project_slug) when is_list(elements) do
-    IO.inspect elements
     verify_with_slug = fn e -> verify_link(e, project_slug) end
 
     elements


### PR DESCRIPTION
Closes #503 

This PR fixes a bug in the objective attachment check.  This was introduced when we removed this check from pages. 

I also ran in to a problem - more serious - with the URI validator code in the content review.  I just happened to have a link in my content erroneously set to `https://www.google.coms`. Notice the `s` at the end.  This link was breaking the URI validator in a way that prevented the rest of the reviews from running.  Here is the exception it threw:

```
[error] GenServer #PID<0.8609.0> terminating
** (stop) exited in: Task.Supervised.stream(5000)
    ** (EXIT) time out
    (elixir 1.10.2) lib/task/supervised.ex:303: Task.Supervised.stream_reduce/7
    (elixir 1.10.2) lib/stream.ex:1609: Enumerable.Stream.do_each/4
    (elixir 1.10.2) lib/enum.ex:3383: Enum.reverse/1
    (elixir 1.10.2) lib/enum.ex:1180: Enum.group_by/3
    (oli 0.1.0) lib/oli/qa/uri_validator.ex:26: Oli.Qa.UriValidator.invalid_uris/2
    (oli 0.1.0) lib/oli/qa/reviewers/content.ex:20: Oli.Qa.Reviewers.Content.broken_uris/2
    (oli 0.1.0) lib/oli/qa/reviewers/content.ex:11: Oli.Qa.Reviewers.Content.review/1
    (oli 0.1.0) lib/oli/qa.ex:37: Oli.Qa.review_project/1
    (oli 0.1.0) lib/oli_web/live/qa/qa_live.ex:83: OliWeb.Qa.QaLive.handle_event/3
    (phoenix_live_view 0.14.0) lib/phoenix_live_view/channel.ex:213: anonymous fn/3 in Phoenix.LiveView.Channel.view_handle_event/3
    (telemetry 0.4.2) /Users/darrensiegel/dev/oli-torus/deps/telemetry/src/telemetry.erl:262: :telemetry.span/3
    (phoenix_live_view 0.14.0) lib/phoenix_live_view/channel.ex:102: Phoenix.LiveView.Channel.handle_info/2
    (stdlib 3.12.1) gen_server.erl:637: :gen_server.try_dispatch/4
    (stdlib 3.12.1) gen_server.erl:711: :gen_server.handle_msg/6
    (stdlib 3.12.1) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Last message: %Phoenix.Socket.Message{event: "event", join_ref: "4", payload: %{"event" => "review", "type" => "click", "value" => %{"value" => ""}}, ref: "5", topic: "lv:phx-FiS8fNoK8BnfOUNC"}
State: %{components: {%{}, %{}, 1}, join_ref: "4", serializer: Phoenix.Socket.V2.JSONSerializer, socket: #Phoenix.LiveView.Socket<assigns: %{active: :review, author: %Oli.Accounts.Author{__meta__: #Ecto.Schema.Metadata<:loaded, "authors">, email: "admin@example.edu", email_verified: true, first_name: "Administrator", id: 1, ...}, breadcrumbs: [{"Review", nil}], filtered_warnings: [], filters: #MapSet<["accessibility", "content", ...]>, flash: %{}, live_action: nil, ...}, changed: %{}, endpoint: OliWeb.Endpoint, id: "phx-FiS8fNoK8BnfOUNC", parent_pid: nil, root_pid: #PID<0.8609.0>, router: OliWeb.Router, view: OliWeb.Qa.QaLive, ...>, topic: "lv:phx-FiS8fNoK8BnfOUNC", transport_pid: #PID<0.8603.0>}
```

I am going to file a separate bug for this, but until we fix that I am disable the live URL fetching as part of URI validation. 