### PR TITLE
Fix selection change causing slate crash

### DIFF
--- a/assets/src/components/content/AddResourceContent.scss
+++ b/assets/src/components/content/AddResourceContent.scss
@@ -59,7 +59,6 @@
 
       i {
         margin-left: 3px;
-        margin-top: 1px;
         vertical-align: text-top;
         color: $gray-500;
         transition: transform 200ms ease-in-out;

--- a/assets/src/components/editor/Editor.tsx
+++ b/assets/src/components/editor/Editor.tsx
@@ -42,7 +42,7 @@ export type EditorProps = {
 const voidOnKeyDown = (editor: ReactEditor, e: React.KeyboardEvent) => {
 
   if (e.key === 'Enter') {
-    if (editor.selection !== null && Range.isCollapsed(editor.selection)) {
+    if (editor.selection && Range.isCollapsed(editor.selection)) {
 
       getRootOfText(editor).lift((node: Node) => {
 
@@ -66,7 +66,7 @@ const voidOnKeyDown = (editor: ReactEditor, e: React.KeyboardEvent) => {
 
 // Handles exiting a header item via Enter key, setting the next block back to normal (p)
 function handleFormattingTermination(editor: SlateEditor, e: React.KeyboardEvent) {
-  if (e.key === 'Enter' && editor.selection !== null && Range.isCollapsed(editor.selection)) {
+  if (e.key === 'Enter' && editor.selection && Range.isCollapsed(editor.selection)) {
 
     const [match] = SlateEditor.nodes(editor, {
       match: n => n.type === 'h1' || n.type === 'h2'
@@ -159,7 +159,9 @@ export const Editor = React.memo((props: EditorProps) => {
     }
   };
 
-  editor.selection = props.selection;
+  if (props.selection !== undefined) {
+    editor.selection = props.selection;
+  }
 
   const renderElement = useCallback((props) => {
     const model = props.element as ModelElement;

--- a/assets/src/components/editor/Editor.tsx
+++ b/assets/src/components/editor/Editor.tsx
@@ -225,6 +225,7 @@ export const Editor = React.memo((props: EditorProps) => {
         <HoveringToolbar commandContext={props.commandContext}/>
 
         <Editable
+          className="slate-editor"
           readOnly={!props.editMode}
           renderElement={renderElement}
           renderLeaf={renderLeaf}

--- a/assets/src/components/editor/editors/Lists.tsx
+++ b/assets/src/components/editor/editors/Lists.tsx
@@ -91,7 +91,7 @@ const isList = (n: Node) => n.type === 'ul' || n.type === 'ol';
 
 // Handles a 'tab' key down event that may indent a list item.
 function handleIndent(editor: SlateEditor, e: KeyboardEvent) {
-  if (editor.selection !== null && Range.isCollapsed(editor.selection)) {
+  if (editor.selection && Range.isCollapsed(editor.selection)) {
 
     const [match] = SlateEditor.nodes(editor, {
       match: n => n.type === 'li',
@@ -143,7 +143,7 @@ function handleIndent(editor: SlateEditor, e: KeyboardEvent) {
 
 // Handles a shift+tab press to possibly outdent a list item
 function handleOutdent(editor: SlateEditor, e: KeyboardEvent) {
-  if (editor.selection !== null && Range.isCollapsed(editor.selection)) {
+  if (editor.selection && Range.isCollapsed(editor.selection)) {
 
     const [match] = SlateEditor.nodes(editor, {
       match: n => n.type === 'li',
@@ -178,7 +178,7 @@ function handleOutdent(editor: SlateEditor, e: KeyboardEvent) {
 // This handler should fail fast - given that every enter press
 // in the editor passes through it
 function handleTermination(editor: SlateEditor, e: KeyboardEvent) {
-  if (editor.selection !== null && Range.isCollapsed(editor.selection)) {
+  if (editor.selection && Range.isCollapsed(editor.selection)) {
 
     const [match] = SlateEditor.nodes(editor, {
       match: n => n.type === 'li',

--- a/assets/src/components/editor/utils.tsx
+++ b/assets/src/components/editor/utils.tsx
@@ -31,7 +31,7 @@ function toSimpleTextHelper(node: Node, text: string): string {
 // immediate block parent.
 export const getRootOfText = (editor: ReactEditor): Maybe<Node> => {
 
-  if (editor.selection !== null) {
+  if (editor.selection) {
     let [node, path] = Editor.node(editor, editor.selection);
 
     while (true) {

--- a/assets/src/components/resource/Editors.scss
+++ b/assets/src/components/resource/Editors.scss
@@ -12,6 +12,14 @@
       }
     }
 
+    .card-body {
+      padding: 0;
+
+      .slate-editor {
+        padding: 1.3em;
+      }
+    }
+
     .delivery {
       padding: 10px;
       color: delivery.$body-color;


### PR DESCRIPTION
This PR attempts to fix an issue where course content created with an older version of the editor would crash slate instances by only setting the editor selection if the prop is not undefined. It also changes all null checks to also check for undefined since selection can be null or undefined.

It also includes two style tweaks: 1) improve selection within a content resource frame by moving the container padding to the slate instance itself and 2) recenter the add content button icon. These 2 changes are strictly style changes so they are relatively low risk.