### PR TITLE
Fix filetype accept filter for Firefox

### DIFF
--- a/assets/src/components/media/manager/MediaManager.tsx
+++ b/assets/src/components/media/manager/MediaManager.tsx
@@ -556,8 +556,8 @@ export class MediaManager extends React.PureComponent<MediaManagerProps, MediaMa
           <input
             id={id}
             style={{ display: 'none' }}
-            accept={mimeFilter && `${mimeFilter}/*`}
-            multiple={true}
+            accept={`${mimeFilter}`}
+            multiple
             onChange={({ target: { files } }) => this.onFileUpload(files as FileList)}
             type="file" />
           <button

--- a/assets/src/components/media/manager/MediaManager.tsx
+++ b/assets/src/components/media/manager/MediaManager.tsx
@@ -556,7 +556,7 @@ export class MediaManager extends React.PureComponent<MediaManagerProps, MediaMa
           <input
             id={id}
             style={{ display: 'none' }}
-            accept={mimeFilter === undefined ? undefined : `${mimeFilter}`}
+            accept={mimeFilter && `${mimeFilter}`}
             multiple
             onChange={({ target: { files } }) => this.onFileUpload(files as FileList)}
             type="file" />

--- a/assets/src/components/media/manager/MediaManager.tsx
+++ b/assets/src/components/media/manager/MediaManager.tsx
@@ -556,7 +556,7 @@ export class MediaManager extends React.PureComponent<MediaManagerProps, MediaMa
           <input
             id={id}
             style={{ display: 'none' }}
-            accept={`${mimeFilter}`}
+            accept={mimeFilter === undefined ? undefined : `${mimeFilter}`}
             multiple
             onChange={({ target: { files } }) => this.onFileUpload(files as FileList)}
             type="file" />


### PR DESCRIPTION
Firefox was not respecting the file upload mimetype filter we had in place because we had an invalid `/*` at the end of the mimetype list. 

On a separate note - the `mimeFilter` variable is a `string[] | undefined`, where undefined indicates "all" media is allowed. We don't use the "all" mimeFilter anywhere at the moment, but I tested it in chrome to make sure using `undefined` allows all media type uploads.

I also just changed the `multiple` attribute to remove the `true`. Apparently, `multiple` doesn't accept a parameter, it's just a tag.
Closes #519 