### PR TITLE
Add MathJax latex rendering to preview

### DIFF
--- a/lib/oli_web/templates/layout/authoring.html.leex
+++ b/lib/oli_web/templates/layout/authoring.html.leex
@@ -44,6 +44,10 @@
         ignoreHtmlClass: 'tex2jax_ignore',
         processHtmlClass: 'tex2jax_process'
       },
+      // Disable MathJax by default. Startup must be called explicitly to run MathJax transformations.
+      startup: {
+        ready: () => {}
+      },
       loader: {
         load: ['[tex]/noerrors']
       }
@@ -56,9 +60,7 @@
   </head>
   <body>
 
-    <div class="tex2jax_ignore">
-      <%= Map.get(assigns, :inner_layout) || @inner_content %>
-    </div>
+    <%= Map.get(assigns, :inner_layout) || @inner_content %>
 
     <script>
     window.$ = $;

--- a/lib/oli_web/templates/layout/authoring.html.leex
+++ b/lib/oli_web/templates/layout/authoring.html.leex
@@ -32,12 +32,33 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/atom-one-light.min.css" integrity="sha512-11xYl5MU0/AMaYnuBOXDDQdZnl5WGtLVidxqa0XUAXYf6cGnJShNpgtbmB/0MW6ypeev+9Bwj7I/J8wexX8ePw==" crossorigin="anonymous" />
     <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js"></script>
 
+    <script>
+    window.MathJax = {
+      tex: {
+        inlineMath: [ ["\\(","\\)"] ],
+        displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
+        processEscapes: true,
+        packages: ['base', 'ams', 'noerrors', 'noundefined']
+      },
+      options: {
+        ignoreHtmlClass: 'tex2jax_ignore',
+        processHtmlClass: 'tex2jax_process'
+      },
+      loader: {
+        load: ['[tex]/noerrors']
+      }
+    };
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" id="MathJax-script"></script>
+
     <%= csrf_meta_tag() %>
     <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/app.js") %>"></script>
   </head>
   <body>
 
-    <%= Map.get(assigns, :inner_layout) || @inner_content %>
+    <div class="tex2jax_ignore">
+      <%= Map.get(assigns, :inner_layout) || @inner_content %>
+    </div>
 
     <script>
     window.$ = $;

--- a/lib/oli_web/templates/layout/delivery.html.eex
+++ b/lib/oli_web/templates/layout/delivery.html.eex
@@ -31,7 +31,7 @@
 
     <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
     <script>
-    window.MathJax = {
+    window.MathJax = window.MathJax || {
       tex: {
         inlineMath: [ ["\\(","\\)"] ],
         displayMath: [ ['$$','$$'], ["\\[","\\]"] ],

--- a/lib/oli_web/templates/resource/page_preview.html.eex
+++ b/lib/oli_web/templates/resource/page_preview.html.eex
@@ -7,10 +7,11 @@
 
 <%= render OliWeb.PageDeliveryView, "_objectives.html", objectives: @objectives %>
 
-<div id="eventIntercept">
+<div id="eventIntercept" class="tex2jax_process">
   <%= raw(@content_html) %>
 </div>
 
 <script>
+  MathJax && MathJax.typeset && MathJax.typeset();
   OLI.initPreviewActivityBridge('eventIntercept');
 </script>

--- a/lib/oli_web/templates/resource/page_preview.html.eex
+++ b/lib/oli_web/templates/resource/page_preview.html.eex
@@ -7,11 +7,11 @@
 
 <%= render OliWeb.PageDeliveryView, "_objectives.html", objectives: @objectives %>
 
-<div id="eventIntercept" class="tex2jax_process">
+<div id="eventIntercept">
   <%= raw(@content_html) %>
 </div>
 
 <script>
-  MathJax && MathJax.typeset && MathJax.typeset();
+  MathJax && MathJax.startup && MathJax.startup.defaultReady && MathJax.startup.defaultReady();
   OLI.initPreviewActivityBridge('eventIntercept');
 </script>


### PR DESCRIPTION
**Issue**: Latex was not properly rendering in page preview mode.
**Cause**: When the `ResourceEditor` swaps to preview mode, the MathJax delivery script is re-initialized with a new window variable but not executed to compile the Latex and render it. It works when opening the preview in a new tab, but not when it swaps out the current editor view.
**Solution**: This is more of a workaround than anything -- I would like to find a way to get the script to execute when loading the delivery file in preview mode -- but I added the MathJax script to the authoring template so that it can run in the author. I wrapped the authoring HTML in a div with an `ignore` class name, and then white listed the `delivery` preview mode HTML for MathJax to render it.
**Risk**: Moderate. This change is to the high level authoring/delivery templates, and could cause a problem. I haven't seen any issues, but the templates are used everywhere.