### PR TITLE
fixes an issue with windows modifier key and preview

### DIFF
--- a/assets/src/components/resource/ResourceEditor.tsx
+++ b/assets/src/components/resource/ResourceEditor.tsx
@@ -1,5 +1,6 @@
 import * as Immutable from 'immutable';
 import React from 'react';
+import { toKeyCode } from 'is-hotkey';
 import { PersistenceStrategy } from 'data/persistence/PersistenceStrategy';
 import { DeferredPersistenceStrategy } from 'data/persistence/DeferredPersistenceStrategy';
 import { ResourceContent, ResourceContext,
@@ -81,9 +82,7 @@ function unregisterUnload(listener: any) {
 
 export function registerKeydown(self: ResourceEditor) {
   return window.addEventListener('keydown', (e: KeyboardEvent) => {
-    const isShiftkey = e.keyCode === 91;
-
-    if (isShiftkey) {
+    if (e.keyCode === toKeyCode('mod')) {
       self.setState({ metaModifier: true });
     }
   });
@@ -95,9 +94,7 @@ export function unregisterKeydown(listener: any) {
 
 export function registerKeyup(self: ResourceEditor) {
   return window.addEventListener('keyup', (e: KeyboardEvent) => {
-    const isShiftkey = e.keyCode === 91;
-
-    if (isShiftkey) {
+    if (e.keyCode === toKeyCode('mod')) {
       self.setState({ metaModifier: false });
     }
   });
@@ -278,15 +275,12 @@ export class ResourceEditor extends React.Component<ResourceEditorProps, Resourc
   }
 
   onPreviewClick = () => {
-    const { previewMode, metaModifier } = this.state;
+    const { previewMode } = this.state;
     const { projectSlug, resourceSlug, graded } = this.props;
 
     const enteringPreviewMode = !previewMode;
 
-    if (metaModifier && enteringPreviewMode) {
-      // if shift key is down, open in a new window
-      window.open(`/project/${projectSlug}/resource/${resourceSlug}/preview`, 'page-preview');
-    } else if (enteringPreviewMode) {
+    if (enteringPreviewMode) {
       // otherwise, switch the current view to preview mode
       this.setState({ previewMode: !previewMode, previewHtml: '' });
       this.showPreviewMessage(graded);
@@ -397,16 +391,22 @@ export class ResourceEditor extends React.Component<ResourceEditorProps, Resourc
     const isSaving =
       (this.state.persistence === 'inflight' || this.state.persistence === 'pending');
 
-    const PreviewButton = () => (
+
+    const PreviewButton = () => state.metaModifier
+    ? (
+      <a
+        className={`btn btn-sm btn-outline-primary ml-3 ${isSaving ? 'disabled' : ''}`}
+        onClick={() => window.open(`/project/${projectSlug}/resource/${resourceSlug}/preview`, 'page-preview')}>
+        Preview Page <i className="las la-external-link-alt ml-1"></i>
+      </a>
+    )
+    : (
       <button
         role="button"
         className="btn btn-sm btn-outline-primary ml-3"
         onClick={this.onPreviewClick}
         disabled={isSaving}>
         Preview Page
-        {state.metaModifier &&
-          <i className="las la-external-link-alt ml-1"></i>
-        }
       </button>
     );
 


### PR DESCRIPTION
This PR fixes an issue where the modifier key in windows was the Windows key, which wasn't allowing users to actually click on anything and inadvertently popped up the start menu. This changes to use the system 'mod' key which on mac is CMD and windows is Ctrl

**Risk**: Low, only affects preview button
**Stability**: Tested on Mac and Windows and is stable. However, my windows instance only allowed about a second of time to click the button when Ctrl is down but I am wondering if that is something specific to my install.