### PR TITLE
Handle keyboard repeat event in ResourceEditor preview button

### DIFF
--- a/assets/src/components/resource/ResourceEditor.tsx
+++ b/assets/src/components/resource/ResourceEditor.tsx
@@ -82,7 +82,7 @@ function unregisterUnload(listener: any) {
 
 export function registerKeydown(self: ResourceEditor) {
   return window.addEventListener('keydown', (e: KeyboardEvent) => {
-    if (e.keyCode === toKeyCode('mod')) {
+    if (e.keyCode === toKeyCode('mod') && !e.repeat) {
       self.setState({ metaModifier: true });
     }
   });


### PR DESCRIPTION
Windows prevented the Preview Page link from opening in a new tab.

See https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key

Tested on tokamak. This fixes the issue.
Low risk.