### PR TITLE
fix tooltip issue with phx-update ignore

### DIFF
--- a/assets/src/hooks/index.ts
+++ b/assets/src/hooks/index.ts
@@ -3,12 +3,10 @@
 import { GraphNavigation } from './graph';
 import { DropTarget, DragSource } from './dragdrop';
 import { ModalLaunch } from './modal';
-import { TooltipInit } from './tooltip';
 
 export const Hooks = {
   GraphNavigation,
   DropTarget,
   DragSource,
   ModalLaunch,
-  TooltipInit,
 };

--- a/assets/src/hooks/tooltip.ts
+++ b/assets/src/hooks/tooltip.ts
@@ -1,6 +1,0 @@
-export const TooltipInit = {
-  mounted() {
-    const id = this.el.getAttribute('id');
-    ($('#' + id) as any).tooltip();
-  },
-};

--- a/lib/oli_web/live/objectives/actions.ex
+++ b/lib/oli_web/live/objectives/actions.ex
@@ -8,7 +8,7 @@ defmodule OliWeb.Objectives.Actions do
     ~L"""
 
     <div style="min-width: 50px">
-      <div>
+      <div phx-update="ignore">
         <button
           title="Edit the selected objecive"
           id="action_edit"

--- a/lib/oli_web/live/objectives/actions.ex
+++ b/lib/oli_web/live/objectives/actions.ex
@@ -8,7 +8,7 @@ defmodule OliWeb.Objectives.Actions do
     ~L"""
 
     <div style="min-width: 50px">
-      <div phx-update="ignore">
+      <div id="objective-actions" phx-update="ignore">
         <button
           title="Edit the selected objecive"
           id="action_edit"

--- a/lib/oli_web/live/objectives/actions.ex
+++ b/lib/oli_web/live/objectives/actions.ex
@@ -12,7 +12,6 @@ defmodule OliWeb.Objectives.Actions do
         <button
           title="Edit the selected objecive"
           id="action_edit"
-          phx-hook="TooltipInit"
           <%= if @selected != nil do "" else "disabled" end %>
           data-toggle="tooltip"
           class="ml-1 btn btn-sm btn-outline-primary"
@@ -25,7 +24,6 @@ defmodule OliWeb.Objectives.Actions do
         <button
           title="Add a new child objective"
           id="action_sub"
-          phx-hook="TooltipInit"
           data-toggle="tooltip"
           <%= if @is_root? and @selected != nil do "" else "disabled" end %>
           class="ml-1 btn btn-sm btn-outline-primary"
@@ -38,7 +36,6 @@ defmodule OliWeb.Objectives.Actions do
         <button
           title="Delete the selected objective"
           id="action_delete"
-          phx-hook="TooltipInit"
           <%= if @selected != nil and @can_delete? do "" else "disabled" end %>
           data-toggle="tooltip"
           phx-click="prepare_delete"


### PR DESCRIPTION
This PR fixes an issue where tooltips were not rendering in the objectives page Phoenix LiveView. The root cause was that LiveView changes the DOM out from under the Popper.js library. The solution to add `phx-update="ignore"` was suggested by an elixir forum member https://elixirforum.com/t/phoenix-liveview-and-bootstrap-tooltips/33401

Closes #528