### PR TITLE
Fix typo with html client-side rendering

### DIFF
--- a/assets/src/data/content/writers/html.ts
+++ b/assets/src/data/content/writers/html.ts
@@ -51,7 +51,7 @@ export class HtmlParser implements WriterImpl {
   frameBorder="0"
   style="display: block; margin-left: auto; margin-right: auto;"></iframe>`
   audio = (context: WriterContext, next: Next, { src }: Audio) => `<audio src="${src}"/>\n`;
-  table = (context: WriterContext, next: Next, x: Table) => `<table>${next()}</table>\n`;
+  table = (context: WriterContext, next: Next, x: Table) => `<table class=\"table table-bordered\">${next()}</table>\n`;
   tr = (context: WriterContext, next: Next, x: TableRow) => `<tr>${next()}</tr>\n`;
   th = (context: WriterContext, next: Next, x: TableHeader) => `<th>${next()}</th>\n`;
   td = (context: WriterContext, next: Next, x: TableData) => `<td>${next()}</td>\n`;

--- a/assets/src/data/content/writers/html.ts
+++ b/assets/src/data/content/writers/html.ts
@@ -52,7 +52,7 @@ export class HtmlParser implements WriterImpl {
   style="display: block; margin-left: auto; margin-right: auto;"></iframe>`
   audio = (context: WriterContext, next: Next, { src }: Audio) => `<audio src="${src}"/>\n`;
   table = (context: WriterContext, next: Next, x: Table) => `<table>${next()}</table>\n`;
-  tr = (context: WriterContext, next: Next, x: TableRow) => `<tr>'${next()}</tr>\n`;
+  tr = (context: WriterContext, next: Next, x: TableRow) => `<tr>${next()}</tr>\n`;
   th = (context: WriterContext, next: Next, x: TableHeader) => `<th>${next()}</th>\n`;
   td = (context: WriterContext, next: Next, x: TableData) => `<td>${next()}</td>\n`;
   ol = (context: WriterContext, next: Next, x: OrderedList) => `<ol>${next()}</ol>\n`;


### PR DESCRIPTION
There is an extra quote being inserted before tables when rendered client-side, and borders are not showing up. The second issue is a class name that was added to server-side rendering but not replicated client-side.

Risk: very low