### PR TITLE
Fix result score box styling issue in delivery

### DIFF
--- a/assets/src/components/activities/common/Evaluation.tsx
+++ b/assets/src/components/activities/common/Evaluation.tsx
@@ -24,7 +24,8 @@ export const Evaluation = ({ attemptState } : { attemptState : ActivityTypes.Act
     <div className={`evaluation feedback ${resultClass} my-1`}>
         <div className="result">
           <span className="score">{score}</span>
-          <span className="out-of">{` / ${outOf}`}</span>
+          <span className="result-divider">/</span>
+          <span className="out-of">{outOf}</span>
         </div>
       <HtmlContentModelRenderer text={error ? errorText : feedback} />
     </div>

--- a/assets/styles/delivery/activity.scss
+++ b/assets/styles/delivery/activity.scss
@@ -121,17 +121,21 @@
 
     .result {
       display: inline-flex;
+      flex-shrink: 0;
       align-items: center;
       justify-content: center;
       border: 1px solid $gray-500;
       border-radius: 2px;
       color: $gray-600;
       height: 24px;
-      width: 50px;
+      flex-basis: 50px;
       margin-right: 16px;
       font-weight: bold;
+      padding-left: 3px;
+      padding-right: 3px;
 
-      .score {
+      .result-divider {
+        margin-left: 3px;
         margin-right: 3px;
       }
     }


### PR DESCRIPTION
Styling fixes for two issues:
1) When feedback spanned multiple lines or the score was more than one digit, it shrunk the result score box, pushing the numbers outside of the box. Handled by changing `width` to `flex-basis` and adding a `flex-shrink`
2) The `/` divider was not completely centered. Removed the spaces and added margins around it.

Closes #560 
