### PR TITLE
Fix Youtube modal insert button

### DIFF
--- a/assets/src/components/editor/editors/YouTube.tsx
+++ b/assets/src/components/editor/editors/YouTube.tsx
@@ -16,6 +16,8 @@ import { modalActions } from 'actions/modal';
 const dismiss = () => (window as any).oliDispatch(modalActions.dismiss());
 const display = (c: any) => (window as any).oliDispatch(modalActions.display(c));
 
+const YOUTUBE_PLACEHOLDER = 'zHIIzcWqsP0';
+
 export function selectYouTube(): Promise<string | null> {
 
   return new Promise((resolve, reject) => {
@@ -24,7 +26,10 @@ export function selectYouTube(): Promise<string | null> {
 
     const mediaLibrary =
         <ModalSelection title="Insert YouTube video"
-          onInsert={() => { dismiss(); resolve(selected.src as any); }}
+          onInsert={() => {
+            dismiss();
+            resolve(selected.src ? selected.src : YOUTUBE_PLACEHOLDER);
+          }}
           onCancel={() => dismiss()}
         >
           <YouTubeCreation
@@ -102,7 +107,7 @@ type YouTubeSettingsProps = {
 };
 
 const toLink = (src: string) =>
-  'https://www.youtube.com/embed/' + (src === '' ? 'zHIIzcWqsP0' : src);
+  'https://www.youtube.com/embed/' + (src === '' ? YOUTUBE_PLACEHOLDER : src);
 
 
 const YouTubeSettings = (props: YouTubeSettingsProps) => {

--- a/assets/src/components/editor/editors/YouTube.tsx
+++ b/assets/src/components/editor/editors/YouTube.tsx
@@ -16,7 +16,7 @@ import { modalActions } from 'actions/modal';
 const dismiss = () => (window as any).oliDispatch(modalActions.dismiss());
 const display = (c: any) => (window as any).oliDispatch(modalActions.display(c));
 
-const YOUTUBE_PLACEHOLDER = 'zHIIzcWqsP0';
+const CUTE_OTTERS = 'zHIIzcWqsP0';
 
 export function selectYouTube(): Promise<string | null> {
 
@@ -28,7 +28,7 @@ export function selectYouTube(): Promise<string | null> {
         <ModalSelection title="Insert YouTube video"
           onInsert={() => {
             dismiss();
-            resolve(selected.src ? selected.src : YOUTUBE_PLACEHOLDER);
+            resolve(selected.src ? selected.src : CUTE_OTTERS);
           }}
           onCancel={() => dismiss()}
         >
@@ -107,7 +107,7 @@ type YouTubeSettingsProps = {
 };
 
 const toLink = (src: string) =>
-  'https://www.youtube.com/embed/' + (src === '' ? YOUTUBE_PLACEHOLDER : src);
+  'https://www.youtube.com/embed/' + (src === '' ? CUTE_OTTERS : src);
 
 
 const YouTubeSettings = (props: YouTubeSettingsProps) => {


### PR DESCRIPTION
The `insert` button in the bootstrap modal is difficult to disable with the way we handle the `selected` state. Instead of disabling it with no URL entered, I'm just keeping it enabled but inserting the youtube placeholder video when a URL is not entered.

Closes #556 