### PR TITLE
Path numbering

### DIFF
--- a/lib/oli/publishing/authoring_resolver.ex
+++ b/lib/oli/publishing/authoring_resolver.ex
@@ -91,6 +91,24 @@ defmodule Oli.Publishing.AuthoringResolver do
   end
 
   @impl Resolver
+  def hierarchy(project_slug) do
+
+    page_id = Oli.Resources.ResourceType.get_id_by_type("page")
+    container_id = Oli.Resources.ResourceType.get_id_by_type("container")
+
+    fn ->
+      Repo.all(from m in PublishedResource,
+        join: rev in Revision, on: rev.id == m.revision_id,
+        join: p in Publication, on: p.id == m.publication_id,
+        join: c in Project, on: p.project_id == c.id,
+        where: p.published == false and (rev.resource_type_id == ^page_id or rev.resource_type_id == ^container_id) and c.slug == ^project_slug,
+        select: rev)
+    end
+    |> run() |> emit([:oli, :resolvers, :authoring], :duration)
+
+  end
+
+  @impl Resolver
   def find_parent_objectives(_, []), do: []
   def find_parent_objectives(project_slug, resource_ids) do
 

--- a/lib/oli/publishing/delivery_resolver.ex
+++ b/lib/oli/publishing/delivery_resolver.ex
@@ -83,6 +83,24 @@ defmodule Oli.Publishing.DeliveryResolver do
   end
 
   @impl Resolver
+  def hierarchy(context_id) do
+
+    page_id = Oli.Resources.ResourceType.get_id_by_type("page")
+    container_id = Oli.Resources.ResourceType.get_id_by_type("container")
+
+    fn ->
+      Repo.all(from s in Section,
+        join: p in Publication, on: p.id == s.publication_id,
+        join: m in PublishedResource, on: m.publication_id == p.id,
+        join: rev in Revision, on: rev.id == m.revision_id,
+        where: (rev.resource_type_id == ^page_id or rev.resource_type_id == ^container_id) and s.context_id == ^context_id,
+        select: rev)
+    end
+    |> run() |> emit([:oli, :resolvers, :delivery], :duration)
+
+  end
+
+  @impl Resolver
   def find_parent_objectives(_, []), do: []
   def find_parent_objectives(context_id, resource_ids) do
 

--- a/lib/oli/publishing/resolver.ex
+++ b/lib/oli/publishing/resolver.ex
@@ -34,6 +34,12 @@ defmodule Oli.Publishing.Resolver do
   @callback root_resource(String.t) :: %Revision{}
 
   @doc """
+  Resolves the revisions of all containers and pages
+  """
+  @callback hierarchy(String.t) :: [%Revision{}]
+
+
+  @doc """
   Finds the parent objectives for a list of objective resource ids that
   might be child objectives.  Returns a map of the child objective resource id
   to the parent objective.  There will not be an entry in this map if

--- a/lib/oli/resources/numbering.ex
+++ b/lib/oli/resources/numbering.ex
@@ -1,0 +1,55 @@
+defmodule Oli.Resources.Numbering do
+
+  alias Oli.Resources.ResourceType
+
+  defstruct level: 0,
+    count: 0,
+    container: nil
+
+  def number_path(root_container, containers, node_to_path) do
+
+
+  end
+
+
+  @doc """
+  Generates a level-based numbering of the containers found in a course hierarchy.
+
+  This method returns a list of %Numbering structs.
+  """
+  def number_full_tree(root_container, resources) do
+
+    # for all resources, map them by their ids
+    by_id = Enum.filter(resources, fn r -> r.resource_type_id == ResourceType.get_id_by_type("container") end)
+      |> Enum.reduce(%{}, fn e, m -> Map.put(m, e.resource_id, e) end)
+
+    numberings = []
+
+    # now recursively walk the tree structure, tracking level based numbering as we go
+    level_counts = %{}
+    {_, numberings} = number_helper(root_container, by_id, 1, level_counts, numberings)
+
+    numberings
+  end
+
+  # recursive helper to assemble the numberings
+  defp number_helper(container, by_id, level, level_counts, numberings) do
+
+    Enum.filter(container.children, fn id -> Map.has_key?(by_id, id) end)
+    |> Enum.map(fn id -> Map.get(by_id, id) end)
+    |> Enum.reduce({level_counts, numberings}, fn container, {counts, nums} ->
+
+      {counts, count} = increment_count(counts, level)
+      numbering = %__MODULE__{level: level, count: count, container: container}
+
+      number_helper(container, by_id, level + 1, counts, [numbering | nums])
+    end)
+
+  end
+
+  defp increment_count(level_counts, level) do
+    count = Map.get(level_counts, level, 0) + 1
+    { Map.put(level_counts, level, count), count }
+  end
+
+end

--- a/lib/oli/resources/numbering.ex
+++ b/lib/oli/resources/numbering.ex
@@ -6,12 +6,6 @@ defmodule Oli.Resources.Numbering do
     count: 0,
     container: nil
 
-  def number_path(root_container, containers, node_to_path) do
-
-
-  end
-
-
   @doc """
   Generates a level-based numbering of the containers found in a course hierarchy.
 
@@ -32,7 +26,7 @@ defmodule Oli.Resources.Numbering do
     numberings
   end
 
-  # recursive helper to assemble the numberings
+  # recursive helper to assemble the full hierarchy numberings
   defp number_helper(container, by_id, level, level_counts, numberings) do
 
     Enum.filter(container.children, fn id -> Map.has_key?(by_id, id) end)

--- a/lib/oli/utils/hierarchy_node.ex
+++ b/lib/oli/utils/hierarchy_node.ex
@@ -1,0 +1,6 @@
+defmodule Oli.Utils.HierarchyNode do
+
+  defstruct title: nil,
+    children: []
+
+end

--- a/test/oli/publishing/authoring_resolver_test.exs
+++ b/test/oli/publishing/authoring_resolver_test.exs
@@ -119,6 +119,13 @@ defmodule Oli.Publishing.AuthoringResolverTest do
 
     end
 
+    test "hierarchy/1 resolves the all hierarchy nodes", %{ project: project } do
+
+      nodes = AuthoringResolver.hierarchy(project.slug)
+      assert length(nodes) == 3
+
+    end
+
     test "root_resource/1 resolves the root revision", %{ container: %{ revision: container_revision }, project: project } do
 
       assert AuthoringResolver.root_resource(project.slug) == container_revision

--- a/test/oli/publishing/delivery_resolver_test.exs
+++ b/test/oli/publishing/delivery_resolver_test.exs
@@ -158,6 +158,13 @@ defmodule Oli.Publishing.DeliveryResolverTest do
 
     end
 
+    test "hierarchy/1 resolves the all hierarchy nodes", %{} do
+
+      nodes = DeliveryResolver.hierarchy("1")
+      assert length(nodes) == 3
+
+    end
+
     test "root_resource/1 resolves the root revision", %{ container: %{ revision: container_revision } } do
 
       assert DeliveryResolver.root_resource("1") == container_revision

--- a/test/oli/resources/numbering_test.exs
+++ b/test/oli/resources/numbering_test.exs
@@ -1,0 +1,78 @@
+defmodule Oli.Resources.NumberingTest do
+  use Oli.DataCase
+
+  alias Oli.Resources.Revision
+  alias Oli.Resources.Numbering
+  alias Oli.Utils.HierarchyNode
+  alias Oli.Repo
+
+  def fetch_hierarchy(project_slug) do
+
+    page_id = Oli.Resources.ResourceType.get_id_by_type("page")
+    container_id = Oli.Resources.ResourceType.get_id_by_type("container")
+
+    Repo.all(from m in "published_resources",
+      join: rev in Revision, on: rev.id == m.revision_id,
+      join: p in "publications", on: p.id == m.publication_id,
+      join: c in "projects", on: p.project_id == c.id,
+      where: p.published == false and (rev.resource_type_id == ^page_id or rev.resource_type_id == ^container_id) and c.slug == ^project_slug,
+      select: rev)
+
+  end
+
+  describe "container numbering" do
+
+    setup do
+      Seeder.base_project_with_resource2()
+        |> Seeder.create_hierarchy([%HierarchyNode{
+          title: "unit 1",
+          children: [
+            %HierarchyNode{
+              title: "module 1",
+              children: [
+                %HierarchyNode{title: "section 1"},
+                %HierarchyNode{title: "section 2"},
+                %HierarchyNode{title: "section 3"},
+              ]
+            },
+            %HierarchyNode{
+              title: "module 2",
+              children: [
+                %HierarchyNode{title: "section 4"},
+                %HierarchyNode{title: "section 5"},
+                %HierarchyNode{title: "section 6"},
+              ]
+            }
+          ]
+        },
+        %HierarchyNode{
+          title: "unit 2"
+        }])
+
+    end
+
+
+    test "number_full_tree/2 numbers the containers correctly", %{project: project, container: %{revision: root}} do
+
+      hierarchy_nodes = fetch_hierarchy(project.slug)
+
+      # do the numbering, then programatically compare it to the titles of the
+      # containers, which contain the correct numbering and level names
+      Numbering.number_full_tree(root, hierarchy_nodes)
+      |> Enum.each(fn n ->
+
+        level = case n.level do
+          1 -> "unit"
+          2 -> "module"
+          3 -> "section"
+        end
+
+        assert n.container.title == "#{level} #{n.count}"
+
+      end)
+
+    end
+
+  end
+
+end


### PR DESCRIPTION
This PR introduces the following:

1. `Oli.Resources.Numbering` - a module to use to calculate the levels and level-based numbering of containers in a course hierarchy.  It only offers full hierarchy calculation.  I intended to support path-specific, but after consideration this is an optimization that really doesn't buy us all that much. This currently only numbers containers, but we can expand it in the future to number pages. 

2. `hierarchy` resolution function in the `Resolver` behavior - a new resolver function to retrieve all the pages and containers in  a course hierarchy.  This can be used in conjunction with numbering to provide specialized hierarchy UIs
