### PR TITLE
Fix user can have multiple lti roles

### DIFF
--- a/docs/LTI1.3.md
+++ b/docs/LTI1.3.md
@@ -58,6 +58,8 @@ To configure an LTI 1.3 integration in Torus, we need to gather some important L
 
 #### Create LTI 1.3 Developer Key
 
+Canvas Docs: https://community.canvaslms.com/t5/Admin-Guide/How-do-I-configure-an-LTI-key-for-an-account/ta-p/140
+
 Canvas requires elevated privledges to configure LTI 1.3 Developer Keys and Apps. Canvas administrators should have the necessary privledges. If you don't see the options mentioned below, you may not have proper privledges or your canvas instance may be an older version which does not support LTI 1.3. In either case, you should check with your LMS administrator.
 
 1. In Canvas using the left main menu, select Admin > [Admin Account Name].
@@ -98,6 +100,8 @@ Canvas requires elevated privledges to configure LTI 1.3 Developer Keys and Apps
     <img src="./images/client_id.png" width="200px" />
 
 #### Add Torus as an External Tool link in your Canvas course
+
+Canvas Docs: https://community.canvaslms.com/t5/Admin-Guide/How-do-I-configure-an-external-app-for-an-account-using-a-client/ta-p/202
 
 1.  Navigate to your course and click "Settings" > "Apps"
 

--- a/lib/oli/lti_1p3/context_roles.ex
+++ b/lib/oli/lti_1p3/context_roles.ex
@@ -44,7 +44,7 @@ defmodule Oli.Lti_1p3.ContextRoles do
     uri: "http://purl.imsglobal.org/vocab/lis/v2/membership#Officer"
   }
 
-  def list_roles(), do: [
+  def list_roles(:unloaded), do: [
     @context_administrator,
     @context_content_developer,
     @context_instructor,
@@ -54,6 +54,8 @@ defmodule Oli.Lti_1p3.ContextRoles do
     @context_member,
     @context_officer,
   ]
+
+  def list_roles(), do: Enum.map list_roles(:unloaded), &role_as_loaded/1
 
   @doc """
   Returns a role from a given atom if it is valid, otherwise returns nil
@@ -101,6 +103,16 @@ defmodule Oli.Lti_1p3.ContextRoles do
   end
 
   @doc """
+  Returns the highest level role from a list of roles. This function assumes roles have an
+  ordinality which is defined by list_roles()
+  """
+  @spec get_highest_role([ContextRole.t()]) :: ContextRole.t()
+  def get_highest_role(roles) when is_list(roles) do
+    roles_map = context_roles_as_map(roles)
+    Enum.find(list_roles(), fn r -> roles_map[r.uri] == true end)
+  end
+
+  @doc """
   Returns true if a user has a given role
   """
   @spec has_role?(Lti_1p3_User.t(), String.t(), ContextRole.t()) :: boolean()
@@ -114,7 +126,8 @@ defmodule Oli.Lti_1p3.ContextRoles do
   """
   @spec has_roles?(Lti_1p3_User.t(), String.t(), [ContextRole.t()], :any) :: boolean()
   def has_roles?(user, context_id, roles, :any) when is_struct(user) and is_list(roles) do
-    context_roles_map = get_context_roles_map(user, context_id)
+    context_roles = Lti_1p3_User.get_context_roles(user, context_id)
+    context_roles_map = context_roles_as_map(context_roles)
     Enum.any?(roles, fn r -> context_roles_map[r.uri] == true end)
   end
 
@@ -123,13 +136,13 @@ defmodule Oli.Lti_1p3.ContextRoles do
   """
   @spec has_roles?(Lti_1p3_User.t(), String.t(), [ContextRole.t()], :all) :: boolean()
   def has_roles?(user, context_id, roles, :all) when is_struct(user) and is_list(roles) do
-    context_roles_map = get_context_roles_map(user, context_id)
+    context_roles = Lti_1p3_User.get_context_roles(user, context_id)
+    context_roles_map = context_roles_as_map(context_roles)
     Enum.all?(roles, fn r -> context_roles_map[r.uri] == true end)
   end
 
   # Returns a map with keys of all role uris with value true if the user has the role, false otherwise
-  defp get_context_roles_map(user, context_id) do
-    context_roles = Lti_1p3_User.get_context_roles(user, context_id)
+  defp context_roles_as_map(context_roles) do
     Enum.reduce(list_roles(), %{}, fn r, acc -> Map.put_new(acc, r.uri, Enum.any?(context_roles, &(&1.uri == r.uri))) end)
   end
 

--- a/lib/oli/lti_1p3/platform_roles.ex
+++ b/lib/oli/lti_1p3/platform_roles.ex
@@ -81,7 +81,7 @@ defmodule Oli.Lti_1p3.PlatformRoles do
     uri: "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Alumni"
   }
 
-  @institution_instrcutor %PlatformRole{
+  @institution_instructor %PlatformRole{
     id: 16,
     uri: "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Instructor"
   }
@@ -107,7 +107,7 @@ defmodule Oli.Lti_1p3.PlatformRoles do
     uri: "http://purl.imsglobal.org/vocab/lis/v2/institution/person#ProspectiveStudent"
   }
 
-  def list_roles(), do: [
+  def list_roles(:unloaded), do: [
     @system_administrator,
     @system_none,
     @system_account_admin,
@@ -123,13 +123,15 @@ defmodule Oli.Lti_1p3.PlatformRoles do
     @institution_staff,
     @institution_student,
     @institution_alumni,
-    @institution_instrcutor,
+    @institution_instructor,
     @institution_learner,
     @institution_member,
     @institution_mentor,
     @institution_observer,
     @institution_prospective_student,
   ]
+
+  def list_roles(), do: Enum.map list_roles(:unloaded), &role_as_loaded/1
 
   @doc """
   Returns a role from a given atom if it is valid, otherwise returns nil
@@ -149,7 +151,7 @@ defmodule Oli.Lti_1p3.PlatformRoles do
   def get_role(:institution_staff), do: @institution_staff |> role_as_loaded
   def get_role(:institution_student), do: @institution_student |> role_as_loaded
   def get_role(:institution_alumni), do: @institution_alumni |> role_as_loaded
-  def get_role(:institution_instrcutor), do: @institution_instrcutor |> role_as_loaded
+  def get_role(:institution_instructor), do: @institution_instructor |> role_as_loaded
   def get_role(:institution_learner), do: @institution_learner |> role_as_loaded
   def get_role(:institution_member), do: @institution_member |> role_as_loaded
   def get_role(:institution_mentor), do: @institution_mentor |> role_as_loaded
@@ -175,7 +177,7 @@ defmodule Oli.Lti_1p3.PlatformRoles do
   def get_role_by_uri("http://purl.imsglobal.org/vocab/lis/v2/institution/person#Staff"), do: @institution_staff |> role_as_loaded
   def get_role_by_uri("http://purl.imsglobal.org/vocab/lis/v2/institution/person#Student"), do: @institution_student |> role_as_loaded
   def get_role_by_uri("http://purl.imsglobal.org/vocab/lis/v2/institution/person#Alumni"), do: @institution_alumni |> role_as_loaded
-  def get_role_by_uri("http://purl.imsglobal.org/vocab/lis/v2/institution/person#Instructor"), do: @institution_instrcutor |> role_as_loaded
+  def get_role_by_uri("http://purl.imsglobal.org/vocab/lis/v2/institution/person#Instructor"), do: @institution_instructor |> role_as_loaded
   def get_role_by_uri("http://purl.imsglobal.org/vocab/lis/v2/institution/person#Learner"), do: @institution_learner |> role_as_loaded
   def get_role_by_uri("http://purl.imsglobal.org/vocab/lis/v2/institution/person#Member"), do: @institution_member |> role_as_loaded
   def get_role_by_uri("http://purl.imsglobal.org/vocab/lis/v2/institution/person#Mentor"), do: @institution_mentor |> role_as_loaded
@@ -203,6 +205,16 @@ defmodule Oli.Lti_1p3.PlatformRoles do
   end
 
   @doc """
+  Returns the highest level role from a list of roles. This function assumes roles have an
+  ordinality which is defined by list_roles()
+  """
+  @spec get_highest_role([PlatformRole.t()]) :: PlatformRole.t()
+  def get_highest_role(roles) when is_list(roles) do
+    roles_map = platform_roles_as_map(roles)
+    Enum.find(list_roles(), fn r -> roles_map[r.uri] == true end)
+  end
+
+  @doc """
   Returns true if a user has a given role
   """
   @spec has_role?(Lti_1p3_User.t(), PlatformRole.t()) :: boolean()
@@ -216,7 +228,8 @@ defmodule Oli.Lti_1p3.PlatformRoles do
   """
   @spec has_roles?(Lti_1p3_User.t(), [PlatformRole.t()], :any) :: boolean()
   def has_roles?(user, roles, :any) when is_list(roles) do
-    user_roles_map = get_user_roles_map(user)
+    user_roles = Lti_1p3_User.get_platform_roles(user)
+    user_roles_map = platform_roles_as_map(user_roles)
     Enum.any?(roles, fn r -> user_roles_map[r.uri] == true end)
   end
 
@@ -225,13 +238,13 @@ defmodule Oli.Lti_1p3.PlatformRoles do
   """
   @spec has_roles?(Lti_1p3_User.t(), [PlatformRole.t()], :all) :: boolean()
   def has_roles?(user, roles, :all) when is_list(roles) do
-    user_roles_map = get_user_roles_map(user)
+    user_roles = Lti_1p3_User.get_platform_roles(user)
+    user_roles_map = platform_roles_as_map(user_roles)
     Enum.all?(roles, fn r -> user_roles_map[r.uri] == true end)
   end
 
   # Returns a map with keys of all role uris with value true if the user has the role, false otherwise
-  defp get_user_roles_map(user) do
-    user_roles = Lti_1p3_User.get_platform_roles(user)
+  defp platform_roles_as_map(user_roles) do
     Enum.reduce(list_roles(), %{}, fn r, acc -> Map.put_new(acc, r.uri, Enum.any?(user_roles, &(&1.uri == r.uri))) end)
   end
 

--- a/test/oli/lti_1p3/context_roles_test.exs
+++ b/test/oli/lti_1p3/context_roles_test.exs
@@ -1,0 +1,125 @@
+
+defmodule Oli.Lti_1p3.ContextRolesTest do
+  use Oli.DataCase
+
+  alias Oli.Lti_1p3.ContextRoles
+  alias Oli.Lti_1p3.Lti_1p3_User
+
+  describe "context roles" do
+
+    test "list_roles returns an ordered list of all roles that match values returned by get_role with the corresponding atom" do
+      assert ContextRoles.list_roles() == [
+        ContextRoles.get_role(:context_administrator),
+        ContextRoles.get_role(:context_content_developer),
+        ContextRoles.get_role(:context_instructor),
+        ContextRoles.get_role(:context_learner),
+        ContextRoles.get_role(:context_mentor),
+        ContextRoles.get_role(:context_manager),
+        ContextRoles.get_role(:context_member),
+        ContextRoles.get_role(:context_officer),
+      ]
+    end
+
+    test "get_role returns a role with state: :loaded" do
+      role = ContextRoles.get_role(:context_administrator)
+
+      assert Ecto.get_meta(role, :state) == :loaded
+    end
+
+    test "get_role_by_uri returns a role with state: :loaded" do
+      role = ContextRoles.get_role_by_uri("http://purl.imsglobal.org/vocab/lis/v2/membership#Administrator")
+
+      assert Ecto.get_meta(role, :state) == :loaded
+    end
+
+    test "get_role returns nil for invalid role atom" do
+      role = ContextRoles.get_role(:unknown)
+
+      assert role == nil
+    end
+
+    test "get_role_by_uri returns nil for invalid role uri" do
+      role = ContextRoles.get_role_by_uri("http://purl.imsglobal.org/vocab/lis/v2/membership#SomeUknownRole")
+
+      assert role == nil
+    end
+
+    test "get_roles_by_uris returns all valid roles from a list of uris" do
+      roles = ContextRoles.get_roles_by_uris([
+        "http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor",
+        "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner"])
+
+      assert roles == [
+        ContextRoles.get_role(:context_instructor),
+        ContextRoles.get_role(:context_learner)
+      ]
+    end
+
+    test "contains_role? returns true if a list of roles contains a given role" do
+      roles = ContextRoles.get_roles_by_uris([
+        "http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor",
+        "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner"])
+
+      assert ContextRoles.contains_role?(roles, ContextRoles.get_role(:context_instructor)) == true
+      assert ContextRoles.contains_role?(roles, ContextRoles.get_role(:context_learner)) == true
+      assert ContextRoles.contains_role?(roles, ContextRoles.get_role(:context_mentor)) == false
+    end
+
+    test "get_highest_role returns the highest level role from a list of roles" do
+      roles = ContextRoles.get_roles_by_uris([
+        "http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor",
+        "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner"])
+
+      assert ContextRoles.get_highest_role(roles) == ContextRoles.get_role(:context_instructor)
+
+      roles = ContextRoles.get_roles_by_uris(["http://purl.imsglobal.org/vocab/lis/v2/membership#Learner"])
+
+      assert ContextRoles.get_highest_role(roles) == ContextRoles.get_role(:context_learner)
+
+      roles = []
+
+      assert ContextRoles.get_highest_role(roles) == nil
+    end
+
+    test "has_role? returns true if a user has a given role" do
+      user = struct(Lti_1p3_User.Mock, %{
+        platform_role_uris: [],
+        context_role_uris: [
+          "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner",
+        ],
+      })
+
+      assert ContextRoles.has_role?(user, "context-id", ContextRoles.get_role(:context_instructor)) == false
+      assert ContextRoles.has_role?(user, "context-id", ContextRoles.get_role(:context_learner)) == true
+    end
+
+    test "has_roles? with :any returns true if a user has any of the given roles" do
+      user = struct(Lti_1p3_User.Mock, %{
+        platform_role_uris: [],
+        context_role_uris: [
+          "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner",
+        ],
+      })
+
+      assert ContextRoles.has_roles?(user, "context-id", [ContextRoles.get_role(:context_instructor)], :any) == false
+      assert ContextRoles.has_roles?(user, "context-id", [ContextRoles.get_role(:context_instructor), ContextRoles.get_role(:context_learner)], :any) == true
+      assert ContextRoles.has_roles?(user, "context-id", [ContextRoles.get_role(:context_learner)], :any) == true
+      assert ContextRoles.has_roles?(user, "context-id", [], :any) == false
+    end
+
+    test "has_roles? with :all returns true if a user has all of the given roles" do
+      user = struct(Lti_1p3_User.Mock, %{
+        platform_role_uris: [],
+        context_role_uris: [
+          "http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor",
+          "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner",
+        ],
+      })
+
+      assert ContextRoles.has_roles?(user, "context-id", [ContextRoles.get_role(:context_instructor)], :all) == true
+      assert ContextRoles.has_roles?(user, "context-id", [ContextRoles.get_role(:context_instructor), ContextRoles.get_role(:context_learner)], :all) == true
+      assert ContextRoles.has_roles?(user, "context-id", [ContextRoles.get_role(:context_learner), ContextRoles.get_role(:context_mentor)], :all) == false
+      assert ContextRoles.has_roles?(user, "context-id", [], :all) == true
+    end
+  end
+end

--- a/test/oli/lti_1p3/platform_roles_test.exs
+++ b/test/oli/lti_1p3/platform_roles_test.exs
@@ -1,0 +1,138 @@
+
+defmodule Oli.Lti_1p3.PlatformRolesTest do
+  use Oli.DataCase
+
+  alias Oli.Lti_1p3.PlatformRoles
+  alias Oli.Lti_1p3.Lti_1p3_User
+
+  describe "platform roles" do
+
+    test "list_roles returns an ordered list of all roles that match values returned by get_role with the corresponding atom" do
+      assert PlatformRoles.list_roles() == [
+        PlatformRoles.get_role(:system_administrator),
+        PlatformRoles.get_role(:system_none),
+        PlatformRoles.get_role(:system_account_admin),
+        PlatformRoles.get_role(:system_creator),
+        PlatformRoles.get_role(:system_sys_admin),
+        PlatformRoles.get_role(:system_sys_support),
+        PlatformRoles.get_role(:system_user),
+        PlatformRoles.get_role(:institution_administrator),
+        PlatformRoles.get_role(:institution_faculty),
+        PlatformRoles.get_role(:institution_guest),
+        PlatformRoles.get_role(:institution_none),
+        PlatformRoles.get_role(:institution_other),
+        PlatformRoles.get_role(:institution_staff),
+        PlatformRoles.get_role(:institution_student),
+        PlatformRoles.get_role(:institution_alumni),
+        PlatformRoles.get_role(:institution_instructor),
+        PlatformRoles.get_role(:institution_learner),
+        PlatformRoles.get_role(:institution_member),
+        PlatformRoles.get_role(:institution_mentor),
+        PlatformRoles.get_role(:institution_observer),
+        PlatformRoles.get_role(:institution_prospective_student),
+      ]
+    end
+
+    test "get_role returns a role with state: :loaded" do
+      role = PlatformRoles.get_role(:institution_learner)
+
+      assert Ecto.get_meta(role, :state) == :loaded
+    end
+
+    test "get_role_by_uri returns a role with state: :loaded" do
+      role = PlatformRoles.get_role_by_uri("http://purl.imsglobal.org/vocab/lis/v2/institution/person#Learner")
+
+      assert Ecto.get_meta(role, :state) == :loaded
+    end
+
+    test "get_role returns nil for invalid role atom" do
+      role = PlatformRoles.get_role(:unknown)
+
+      assert role == nil
+    end
+
+    test "get_role_by_uri returns nil for invalid role uri" do
+      role = PlatformRoles.get_role_by_uri("http://purl.imsglobal.org/vocab/lis/v2/institution/person#SomeUknownRole")
+
+      assert role == nil
+    end
+
+    test "get_roles_by_uris returns all valid roles from a list of uris" do
+      roles = PlatformRoles.get_roles_by_uris([
+        "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Instructor",
+        "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Learner"])
+
+      assert roles == [
+        PlatformRoles.get_role(:institution_instructor),
+        PlatformRoles.get_role(:institution_learner)
+      ]
+    end
+
+    test "contains_role? returns true if a list of roles contains a given role" do
+      roles = PlatformRoles.get_roles_by_uris([
+        "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Instructor",
+        "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Learner"])
+
+      assert PlatformRoles.contains_role?(roles, PlatformRoles.get_role(:institution_instructor)) == true
+      assert PlatformRoles.contains_role?(roles, PlatformRoles.get_role(:institution_learner)) == true
+      assert PlatformRoles.contains_role?(roles, PlatformRoles.get_role(:institution_mentor)) == false
+    end
+
+    test "get_highest_role returns the highest level role from a list of roles" do
+      roles = PlatformRoles.get_roles_by_uris([
+        "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Instructor",
+        "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Learner"])
+
+      assert PlatformRoles.get_highest_role(roles) == PlatformRoles.get_role(:institution_instructor)
+
+      roles = PlatformRoles.get_roles_by_uris(["http://purl.imsglobal.org/vocab/lis/v2/institution/person#Learner"])
+
+      assert PlatformRoles.get_highest_role(roles) == PlatformRoles.get_role(:institution_learner)
+
+      roles = []
+
+      assert PlatformRoles.get_highest_role(roles) == nil
+    end
+
+    test "has_role? returns true if a user has a given role" do
+      user = struct(Lti_1p3_User.Mock, %{
+        platform_role_uris: [
+          "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Learner",
+        ],
+        context_role_uris: [],
+      })
+
+      assert PlatformRoles.has_role?(user, PlatformRoles.get_role(:institution_instructor)) == false
+      assert PlatformRoles.has_role?(user, PlatformRoles.get_role(:institution_learner)) == true
+    end
+
+    test "has_roles? with :any returns true if a user has any of the given roles" do
+      user = struct(Lti_1p3_User.Mock, %{
+        platform_role_uris: [
+          "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Learner",
+        ],
+        context_role_uris: [],
+      })
+
+      assert PlatformRoles.has_roles?(user, [PlatformRoles.get_role(:institution_instructor)], :any) == false
+      assert PlatformRoles.has_roles?(user, [PlatformRoles.get_role(:institution_instructor), PlatformRoles.get_role(:institution_learner)], :any) == true
+      assert PlatformRoles.has_roles?(user, [PlatformRoles.get_role(:institution_learner)], :any) == true
+      assert PlatformRoles.has_roles?(user, [], :any) == false
+    end
+
+    test "has_roles? with :all returns true if a user has all of the given roles" do
+      user = struct(Lti_1p3_User.Mock, %{
+        platform_role_uris: [
+          "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Instructor",
+          "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Learner",
+        ],
+        context_role_uris: [],
+      })
+
+      assert PlatformRoles.has_roles?(user, [PlatformRoles.get_role(:institution_instructor)], :all) == true
+      assert PlatformRoles.has_roles?(user, [PlatformRoles.get_role(:institution_instructor), PlatformRoles.get_role(:institution_learner)], :all) == true
+      assert PlatformRoles.has_roles?(user, [PlatformRoles.get_role(:institution_learner), PlatformRoles.get_role(:institution_mentor)], :all) == false
+      assert PlatformRoles.has_roles?(user, [], :all) == true
+    end
+  end
+end

--- a/test/oli_web/controllers/delivery_controller_test.exs
+++ b/test/oli_web/controllers/delivery_controller_test.exs
@@ -14,6 +14,16 @@ defmodule OliWeb.DeliveryControllerTest do
       assert html_response(conn, 200) =~ "Your instructor has not configured this course section. Please check back soon."
     end
 
+    test "handles user with student and instructor roles with no section", %{conn: conn} do
+      conn = conn
+      |> put_session(:lti_1p3_sub, "student-instructor-sub")
+      |> get(Routes.delivery_path(conn, :index))
+
+      assert html_response(conn, 200) =~ "<h3>Getting Started</h3>"
+      assert html_response(conn, 200) =~ "Let's get started by creating a section for your course."
+      assert html_response(conn, 200) =~ "Link an Existing Account"
+    end
+
     test "handles student with section", %{conn: conn, project: project, publication: publication} do
       conn = conn
       |> put_session(:lti_1p3_sub, "student-sub")
@@ -29,6 +39,7 @@ defmodule OliWeb.DeliveryControllerTest do
       |> get(Routes.delivery_path(conn, :index))
 
       assert html_response(conn, 200) =~ "<h3>Getting Started</h3>"
+      assert html_response(conn, 200) =~ "Let's get started by creating a section for your course."
       assert html_response(conn, 200) =~ "Link an Existing Account"
     end
 
@@ -80,6 +91,18 @@ defmodule OliWeb.DeliveryControllerTest do
       },
       "https://purl.imsglobal.org/spec/lti/claim/roles" => [
         "http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor",
+      ],
+    })
+    Oli.Lti_1p3.cache_lti_params("student-instructor-sub", %{
+      "sub" => "instructor-sub",
+      "exp" => Timex.now |> Timex.add(Timex.Duration.from_hours(1)) |> Timex.to_unix,
+      "https://purl.imsglobal.org/spec/lti/claim/context" => %{
+        "id" => "some-context-id",
+        "title" => "some-title",
+      },
+      "https://purl.imsglobal.org/spec/lti/claim/roles" => [
+        "http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor",
+        "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner",
       ],
     })
 

--- a/test/support/lti_1p3_test_helpers.ex
+++ b/test/support/lti_1p3_test_helpers.ex
@@ -173,3 +173,24 @@ defmodule Oli.TestHelpers.Lti_1p3 do
   end
 
 end
+
+# notice: this protocol mock implementation must reside in this support directory
+# because of protocol consolidation. See https://hexdocs.pm/elixir/master/Protocol.html#module-consolidation
+defmodule Oli.Lti_1p3.Lti_1p3_User.Mock do
+  alias Oli.Lti_1p3.Lti_1p3_User
+  alias Oli.Lti_1p3.PlatformRoles
+  alias Oli.Lti_1p3.ContextRoles
+
+  defstruct [:platform_role_uris, :context_role_uris]
+
+  defimpl Lti_1p3_User do
+    def get_platform_roles(mock_user) do
+      mock_user.platform_role_uris |> PlatformRoles.get_roles_by_uris()
+    end
+
+    def get_context_roles(mock_user, _context_id) do
+      mock_user.context_role_uris |> ContextRoles.get_roles_by_uris()
+    end
+  end
+
+end


### PR DESCRIPTION
This PR addresses an issue where users can have multiple roles on LTI launch and torus should use the role with the highest permissions, such as Instructor over Student.

This PR also includes unit tests for the ContextRoles and PlatformRoles modules.

Closes #609