### PR TITLE
Grade services

### DIFF
--- a/lib/oli/grading.ex
+++ b/lib/oli/grading.ex
@@ -27,12 +27,15 @@ defmodule Oli.Grading do
 
   If error encountered, returns {:error, error}
   """
-  def send_score_to_lms(lti_launch_params, %ResourceAccess{} = resource_access, access_token) do
+  def send_score_to_lms(lti_launch_params, %ResourceAccess{} = resource_access, access_token_provider) do
 
     # First check to see if grade passback is enabled
     if LTI_AGS.grade_passback_enabled?(lti_launch_params) do
 
-      send_score(lti_launch_params, resource_access, access_token)
+      case access_token_provider.() do
+        {:ok, access_token} -> send_score(lti_launch_params, resource_access, access_token)
+        e -> e
+      end
 
     else
       {:ok, :not_synced}

--- a/lib/oli/grading/line_item.ex
+++ b/lib/oli/grading/line_item.ex
@@ -1,0 +1,12 @@
+defmodule Oli.Grading.LineItem do
+
+  @enforce_keys [:scoreMaximum, :label, :resourceId]
+  defstruct [:id, :scoreMaximum, :label, :resourceId]
+
+  @type t() :: %__MODULE__{
+    id: String.t(),
+    scoreMaximum: float,
+    label: String.t(),
+    resourceId: String.t()
+  }
+end

--- a/lib/oli/grading/line_item.ex
+++ b/lib/oli/grading/line_item.ex
@@ -1,5 +1,7 @@
 defmodule Oli.Grading.LineItem do
 
+
+  @derive Jason.Encoder
   @enforce_keys [:scoreMaximum, :label, :resourceId]
   defstruct [:id, :scoreMaximum, :label, :resourceId]
 

--- a/lib/oli/grading/lti_ags.ex
+++ b/lib/oli/grading/lti_ags.ex
@@ -102,7 +102,10 @@ defmodule Oli.Grading.LTI_AGS do
 
     case Map.get(lti_launch_params, @lti_ags_claim_url) do
       nil -> false
-      config -> Map.has_key?(config, "lineitems") and has_scope?(config, @lineitem_scope_url) and has_scope?(config, @scores_scope_url)
+      config ->
+
+
+        Map.has_key?(config, "lineitems") and has_scope?(config, @lineitem_scope_url) and has_scope?(config, @scores_scope_url)
     end
 
   end
@@ -119,7 +122,7 @@ defmodule Oli.Grading.LTI_AGS do
   """
   def has_scope?(lti_ags_claim, scope_url) do
 
-    case Map.get(lti_ags_claim, "scopes", [])
+    case Map.get(lti_ags_claim, "scope", [])
     |> Enum.find(nil, fn url -> scope_url == url end) do
       nil -> false
       _ -> true

--- a/lib/oli/grading/lti_ags.ex
+++ b/lib/oli/grading/lti_ags.ex
@@ -91,7 +91,7 @@ defmodule Oli.Grading.LTI_AGS do
         label: Map.get(result, "label"),
       }}
     else
-      - -> {:error, "Error creating new line item"}
+      _ -> {:error, "Error creating new line item"}
     end
 
   end

--- a/lib/oli/grading/lti_ags.ex
+++ b/lib/oli/grading/lti_ags.ex
@@ -17,10 +17,14 @@ defmodule Oli.Grading.LTI_AGS do
   alias Oli.Grading.LineItem
   alias Oli.Lti_1p3.AccessToken
 
+  require Logger
+
   @doc """
-  Post a score to an existing line item.
+  Post a score to an existing line item, using an already acquired access token.
   """
   def post_score(%Score{} = score, %LineItem{} = line_item, %AccessToken{} = access_token) do
+
+    Logger.debug("Posting score for user #{score.userId} for line item '#{line_item.label}'")
 
     url = "#{line_item.id}/scores"
     body = score |> Jason.encode!()
@@ -30,7 +34,10 @@ defmodule Oli.Grading.LTI_AGS do
     do
       {:ok, result}
     else
-      _ -> {:error, "Error posting score"}
+      e ->
+        Logger.error("Error encountered posting score for user #{score.userId} for line item '#{line_item.label}' #{inspect e}")
+
+        {:error, "Error posting score"}
     end
 
   end
@@ -41,6 +48,8 @@ defmodule Oli.Grading.LTI_AGS do
   in a {:ok, line_item} tuple.  On error, returns a {:error, error} tuple.
   """
   def fetch_or_create_line_item(line_items_service_url, resource_id, score_maximum, label, %AccessToken{} = access_token) do
+
+    Logger.debug("Fetch or create line item for #{resource_id} #{label}")
 
     # Grade passback 2.0 lineitems endpoint allows a GET request with a query
     # param filter.  We use that to request only the lineitem that corresponds
@@ -62,7 +71,9 @@ defmodule Oli.Grading.LTI_AGS do
         }}
       end
     else
-      _ -> {:error, "Error retrieving existing line items"}
+      e ->
+        Logger.error("Error encountered fetching line item for #{resource_id} #{label}: #{inspect e}")
+        {:error, "Error retrieving existing line items"}
     end
 
   end
@@ -72,6 +83,8 @@ defmodule Oli.Grading.LTI_AGS do
   in a {:ok, line_item} tuple.  On error, returns a {:error, error} tuple.
   """
   def create_line_item(line_items_service_url, resource_id, score_maximum, label, %AccessToken{} = access_token) do
+
+    Logger.debug("Create line item for #{resource_id} #{label}")
 
     line_item = %LineItem{
       scoreMaximum: score_maximum,
@@ -91,7 +104,9 @@ defmodule Oli.Grading.LTI_AGS do
         label: Map.get(result, "label"),
       }}
     else
-      _ -> {:error, "Error creating new line item"}
+      e ->
+        Logger.error("Error encountered creating line item for #{resource_id} #{label}: #{inspect e}")
+        {:error, "Error creating new line item"}
     end
 
   end

--- a/lib/oli/grading/lti_ags.ex
+++ b/lib/oli/grading/lti_ags.ex
@@ -152,7 +152,7 @@ defmodule Oli.Grading.LTI_AGS do
       }}
     else
       e ->
-        Logger.error("Error encountered updating line item #{line_item.id} for changes #{inspect changes}")
+        Logger.error("Error encountered updating line item #{line_item.id} for changes #{inspect changes}: #{inspect e}")
         {:error, "Error updating existing line item"}
     end
 

--- a/lib/oli/grading/lti_ags.ex
+++ b/lib/oli/grading/lti_ags.ex
@@ -1,0 +1,131 @@
+defmodule Oli.Grading.LTI_AGS do
+
+  @moduledoc """
+  Implementation of LTI Assignment and Grading Services (LTI AGS) version 2.0.
+
+  For information on the standard, see:
+  https://www.imsglobal.org/spec/lti-ags/v2p0/
+
+  This module contains no dependencies on attempts, resources, or any other delivery specific construct.
+  """
+
+  @lti_ags_claim_url "https://purl.imsglobal.org/spec/lti-ags/claim/endpoint"
+  @lineitem_scope_url "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem"
+  @scores_scope_url "https://purl.imsglobal.org/spec/lti-ags/scope/score"
+
+  alias Oli.Grading.Score
+  alias Oli.Grading.LineItem
+
+  @doc """
+  Post a score to an existing line item.
+  """
+  def post_score(%Score{} = score, %LineItem{} = line_item) do
+
+    url = "#{line_item.id}/scores"
+    body = Jason.encode(score)
+    headers = [{"Content-Type", "application/json"}]
+
+    with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <- HTTPoison.post(url, body, headers),
+      {:ok, result} -> Jason.decode(body)
+    do
+      {:ok, result}
+    else
+      {:error, "Error posting score"}
+    end
+
+  end
+
+  @doc """
+  Creates a line item for a resource id, if one does not exist.  Whether or not the
+  line item is created or already exists, this function returns a line item struct wrapped
+  in a {:ok, line_item} tuple.  On error, returns a {:error, error} tuple.
+  """
+  def fetch_or_create_line_item(line_items_service_url, resource_id, score_maximum, label) do
+
+    # Grade passback 2.0 lineitems endpoint allows a GET request with a query
+    # param filter.  We use that to request only the lineitem that corresponds
+    # to this particular resource_id.  "resource_id", from grade passback 2.0
+    # perspective is simply an identifier that the tool uses for a lineitem and its use
+    # here as a Torus "resource_id" is strictly coincidence.
+    request_url = "#{line_items_service_url}?resource_id=#{resource_id}"
+
+    with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <- HTTPoison.get(request_url),
+      {:ok, result} -> Jason.decode(body)
+    do
+      case result do
+        [] -> create_line_item(context_id, line_items_service_url, resource_access)
+        [line_item] -> {:ok, line_item}
+      end
+    else
+      {:error, "Error retrieving existing line items"}
+    end
+
+  end
+
+  @doc """
+  Creates a line item for a resource id. Tthis function returns a line item struct wrapped
+  in a {:ok, line_item} tuple.  On error, returns a {:error, error} tuple.
+  """
+  defp create_line_item(line_items_service_url, resource_id, score_maximum, label) do
+
+    line_item = %LineItem{
+      scoreMaximum: score_maximum,
+      resource_id: resource_id,
+      label: label
+    }
+
+    body = Jason.encode([line_item])
+    headers = [{"Content-Type", "application/json"}]
+
+    with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <- HTTPoison.post(line_items_service_url, body, headers)
+      {:ok, result} -> Jason.decode(body)
+    do
+      {:ok, %LineItem{
+        id: Map.get(result, "id"),
+        scoreMaximum: Map.get(result, "scoreMaximum"),
+        resource_id: Map.get(result, "resource_id"),
+        label: Map.get(result, "label"),
+      }}
+    else
+      {:error, "Error creating new line item"}
+    end
+
+  end
+
+  @doc """
+  Returns true if grade passback service is enabled with the necessary scopes. The
+  necessary scopes are the lineitem scope to read all lineitems and create new ones
+  and the scores scope, to be able to post new scores. Also verifies that the lineitems
+  endpoint is present.
+  """
+  def grade_passback_enabled?(lti_launch_params) do
+
+    case Map.get(lti_launch_params, @lti_ags_claim_url) do
+      nil -> false
+      config -> Map.has_key?(config, "lineitems") and has_scope?(config, @lineitem_scope_url) and has_scope?(config, @scores_scope_url)
+    end
+
+  end
+
+  @doc """
+  Returns the lineitems URL from LTI launch params. If not present returns nil.
+  """
+  def get_line_items_url(lti_launch_params) do
+    Map.get(lti_launch_params, @lti_ags_claim_url, %{}) |> Map.get("lineitems")
+  end
+
+  @doc """
+  Returns true if the LTI AGS claim has a particular scope url, false if it does not.
+  """
+  def has_scope?(lti_ags_claim, scope_url) do
+
+    case Map.get(lti_ags_claim, "scopes", [])
+    |> Enum.find(nil, fn url -> scope_url == url end) do
+      nil -> false
+      _ -> true
+    end
+
+  end
+
+
+end

--- a/lib/oli/grading/score.ex
+++ b/lib/oli/grading/score.ex
@@ -1,7 +1,8 @@
 defmodule Oli.Grading.Score do
 
-  @enforce_keys [:timestamp, :scoreGiven, :scoreMaximum, :comment, :activityProgress, :gradingProgess, :userId]
-  defstruct [:timestamp, :scoreGiven, :scoreMaximum, :comment, :activityProgress, :gradingProgess, :userId]
+  @derive Jason.Encoder
+  @enforce_keys [:timestamp, :scoreGiven, :scoreMaximum, :comment, :activityProgress, :gradingProgress, :userId]
+  defstruct [:timestamp, :scoreGiven, :scoreMaximum, :comment, :activityProgress, :gradingProgress, :userId]
 
   @type t() :: %__MODULE__{
     timestamp: String.t(),
@@ -9,7 +10,7 @@ defmodule Oli.Grading.Score do
     scoreMaximum: float,
     comment: String.t(),
     activityProgress: String.t(),
-    gradingProgess: String.t(),
+    gradingProgress: String.t(),
     userId: String.t()
   }
 end

--- a/lib/oli/grading/score.ex
+++ b/lib/oli/grading/score.ex
@@ -1,0 +1,15 @@
+defmodule Oli.Grading.Score do
+
+  @enforce_keys [:timestamp, :scoreGiven, :scoreMaximum, :comment, :activityProgress, :gradingProgess, :userId]
+  defstruct [:timestamp, :scoreGiven, :scoreMaximum, :comment, :activityProgress, :gradingProgess, :userId]
+
+  @type t() :: %__MODULE__{
+    timestamp: String.t(),
+    scoreGiven: float,
+    scoreMaximum: float,
+    comment: String.t(),
+    activityProgress: String.t(),
+    gradingProgess: String.t(),
+    userId: String.t()
+  }
+end

--- a/lib/oli/lti_1p3.ex
+++ b/lib/oli/lti_1p3.ex
@@ -7,6 +7,12 @@ defmodule Oli.Lti_1p3 do
   alias Oli.Lti_1p3.Jwk
   alias Oli.Lti_1p3.LtiParams
 
+  @deployment_id_key "https://purl.imsglobal.org/spec/lti/claim/deployment_id"
+
+  def get_deployment_id_from_launch(lti_launch_params) do
+    Map.get(lti_launch_params, @deployment_id_key)
+  end
+
   def create_new_registration(attrs) do
     %Registration{}
     |> Registration.changeset(attrs)

--- a/lib/oli/lti_1p3/access_token.ex
+++ b/lib/oli/lti_1p3/access_token.ex
@@ -1,0 +1,88 @@
+defmodule Oli.Lti_1p3.AccessToken do
+
+  import Ecto.Query, warn: false
+
+  @enforce_keys [:access_token, :token_type, :expires_in, :scope]
+  defstruct [:access_token, :token_type, :expires_in, :scope]
+
+  @type t() :: %__MODULE__{
+    access_token: String.t(),
+    token_type: String.t(),
+    expires_in: integer(),
+    scope: String.t()
+  }
+
+  @doc """
+  Requests an OAuth2 access token. Returns {:ok, %AccessToken{}} on success, {:error, error}
+  otherwise.
+
+  Expects the host name of this instance of Torus, the deployment id of the
+  registration from which an access token is being requested, and a list of
+  scopes being requested.
+  """
+
+  def fetch_access_token(nil, _, _), do: {:error, "bad deployment id"}
+
+  def fetch_access_token(deployment_id, scopes, host) do
+
+    host = "https://c51bd1ea5000.ngrok.io"
+
+    case Oli.Lti_1p3.get_ird_by_deployment_id(deployment_id) do
+
+      nil -> {:error, "bad deployment id"}
+
+      {_, registration, _} ->
+
+        client_assertion = create_client_assertion(host, registration)
+        issue_request(registration.auth_token_url, client_assertion, scopes)
+
+    end
+
+  end
+
+  defp issue_request(url, client_assertion, scopes) do
+
+    body = [
+      grant_type: "client_credentials",
+      client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+      client_assertion: client_assertion,
+      scope: Enum.join(scopes, " ")
+    ] |> URI.encode_query()
+
+    headers = %{"Content-Type" => "application/x-www-form-urlencoded"}
+
+    with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <- HTTPoison.post(url, body, headers),
+      {:ok, result} <- Jason.decode(body)
+    do
+      {:ok, %__MODULE__{
+        access_token: Map.get(result, "access_token"),
+        token_type: Map.get(result, "token_type"),
+        expires_in: Map.get(result, "expires_in"),
+        scope: Map.get(result, "scope"),
+      }}
+    else
+      e -> {:error, "Error fetching access token"}
+    end
+
+  end
+
+  defp create_client_assertion(host, registration) do
+
+    # Get the active private key
+    active_jwk = Oli.Lti_1p3.get_active_jwk()
+
+    # Sign and return the JWT
+    signer = Joken.Signer.create("RS256", %{"pem" => active_jwk.pem})
+
+    custom_claims = %{
+      "iss" => host,
+      "aud" => registration.auth_token_url,
+      "kid" => active_jwk.kid,
+      "sub" => registration.client_id
+    }
+    {:ok, token, details} = Oli.Lti_1p3.JokenConfig.generate_and_sign(custom_claims, signer)
+
+    token
+  end
+
+end

--- a/lib/oli/lti_1p3/access_token.ex
+++ b/lib/oli/lti_1p3/access_token.ex
@@ -71,13 +71,14 @@ defmodule Oli.Lti_1p3.AccessToken do
     # Get the active private key
     active_jwk = Oli.Lti_1p3.get_active_jwk()
 
-    # Sign and return the JWT
-    signer = Joken.Signer.create("RS256", %{"pem" => active_jwk.pem})
+    # Sign and return the JWT, include the kid of the key we are using
+    # in the header.
+    custom_header = %{"kid" => active_jwk.kid}
+    signer = Joken.Signer.create("RS256", %{"pem" => active_jwk.pem}, custom_header)
 
     custom_claims = %{
       "iss" => host,
       "aud" => registration.auth_token_url,
-      "kid" => active_jwk.kid,
       "sub" => registration.client_id
     }
     {:ok, token, details} = Oli.Lti_1p3.JokenConfig.generate_and_sign(custom_claims, signer)

--- a/lib/oli/lti_1p3/joken_config.ex
+++ b/lib/oli/lti_1p3/joken_config.ex
@@ -1,0 +1,5 @@
+defmodule Oli.Lti_1p3.JokenConfig do
+  use Joken.Config
+
+  # other functions here...
+end

--- a/lib/oli_web/controllers/lti_controller.ex
+++ b/lib/oli_web/controllers/lti_controller.ex
@@ -130,6 +130,7 @@ defmodule OliWeb.LtiController do
         |> Map.put("typ", typ)
         |> Map.put("alg", alg)
         |> Map.put("kid", kid)
+        |> Map.put("use", "sig")
       end)
 
     key_map = %{
@@ -138,6 +139,7 @@ defmodule OliWeb.LtiController do
 
     conn
     |> json(key_map)
+
   end
 
   defp handle_no_deployment(conn, deployment_id) do

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -145,16 +145,12 @@ defmodule OliWeb.PageDeliveryController do
 
   defp sync_grades(lti_launch_params, resource_access) do
 
-    # Fetch an access token, then sync the grade
-    deployment_id = Oli.Lti_1p3.get_deployment_id_from_launch(lti_launch_params)
-
-    case Oli.Lti_1p3.AccessToken.fetch_access_token(deployment_id, Oli.Grading.ags_scopes(), host()) do
-
-      {:ok, token} -> Oli.Grading.send_score_to_lms(lti_launch_params, resource_access, token)
-
-      e -> e |> IO.inspect
-
+    access_token_provider = fn ->
+      deployment_id = Oli.Lti_1p3.get_deployment_id_from_launch(lti_launch_params)
+      Oli.Lti_1p3.AccessToken.fetch_access_token(deployment_id, Oli.Grading.ags_scopes(), host())
     end
+
+    Oli.Grading.send_score_to_lms(lti_launch_params, resource_access, access_token_provider)
 
   end
 

--- a/lib/oli_web/templates/page_delivery/after_finalized.html.eex
+++ b/lib/oli_web/templates/page_delivery/after_finalized.html.eex
@@ -1,7 +1,11 @@
 
 <div class="alert alert-success after-finalized" role="alert">
   <h4 class="alert-heading">Attempt Submitted</h4>
+
   <p>You've succesffully completed this graded assessment attempt. </p>
+
+  <p><%= @grade_message %></p>
+
   <hr>
   <p class="mb-0"><%= @message %></p>
  </div>

--- a/test/oli/grading/lti_ags_test.exs
+++ b/test/oli/grading/lti_ags_test.exs
@@ -1,0 +1,93 @@
+defmodule Oli.Grading.LTI_AGS_Test do
+
+  use ExUnit.Case, async: true
+
+  alias Oli.Grading.LTI_AGS
+
+  @lti_params %{
+    "aud" => "10000000000041",
+    "azp" => "10000000000041",
+    "email" => "test@cmu.edu",
+    "errors" => %{"errors" => %{}},
+    "exp" => 1604329486,
+    "family_name" => "Last",
+    "given_name" => "First",
+    "https://purl.imsglobal.org/spec/lti-ags/claim/endpoint" => %{
+      "errors" => %{"errors" => %{}},
+      "lineitems" => "https://canvas.oli.cmu.edu/api/lti/courses/8/line_items",
+      "scope" => ["https://purl.imsglobal.org/spec/lti-ags/scope/lineitem",
+       "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem.readonly",
+       "https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly",
+       "https://purl.imsglobal.org/spec/lti-ags/scope/score"],
+      "validation_context" => nil
+    },
+    "https://purl.imsglobal.org/spec/lti/claim/context" => %{
+      "errors" => %{"errors" => %{}},
+      "id" => "07fee64bb0ab0c942859fe07b87f03ea8fefb07b",
+      "label" => "Course",
+      "title" => "Introduction to the Cuisine of Northern Spain",
+      "type" => ["http://purl.imsglobal.org/vocab/lis/v2/course#CourseOffering"],
+      "validation_context" => nil
+    },
+    "https://purl.imsglobal.org/spec/lti/claim/custom" => %{},
+    "https://purl.imsglobal.org/spec/lti/claim/deployment_id" => "77:07fee64bb0ab0c942859fe07b87f03ea8fefb07b",
+    "https://purl.imsglobal.org/spec/lti/claim/launch_presentation" => %{
+      "document_target" => "iframe",
+      "errors" => %{"errors" => %{}},
+      "height" => 400,
+      "locale" => "en",
+      "return_url" => "https://canvas.oli.cmu.edu/courses/8/external_content/success/external_tool_dialog",
+      "validation_context" => nil,
+      "width" => 800
+    },
+    "https://purl.imsglobal.org/spec/lti/claim/lis" => %{
+      "course_offering_sourcedid" => nil,
+      "errors" => %{"errors" => %{}},
+      "person_sourcedid" => nil,
+      "validation_context" => nil
+    },
+    "https://purl.imsglobal.org/spec/lti/claim/message_type" => "LtiResourceLinkRequest",
+    "https://purl.imsglobal.org/spec/lti/claim/resource_link" => %{
+      "description" => nil,
+      "errors" => %{"errors" => %{}},
+      "id" => "07fee64bb0ab0c942859fe07b87f03ea8fefb07b",
+      "title" => nil,
+      "validation_context" => nil
+    },
+    "https://purl.imsglobal.org/spec/lti/claim/roles" => ["http://purl.imsglobal.org/vocab/lis/v2/institution/person#Instructor",
+     "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Student",
+     "http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor",
+     "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner",
+     "http://purl.imsglobal.org/vocab/lis/v2/system/person#User"],
+    "https://purl.imsglobal.org/spec/lti/claim/target_link_uri" => "https://5af12c1dbcd4.ngrok.io/lti/launch",
+    "https://purl.imsglobal.org/spec/lti/claim/tool_platform" => %{
+      "errors" => %{"errors" => %{}},
+      "guid" => "8865aa05b4b79b64a91a86042e43af5ea8ae79eb.canvas.oli.cmu.edu",
+      "name" => "Open Learning Initiative Admin",
+      "product_family_code" => "canvas",
+      "validation_context" => nil,
+      "version" => "cloud"
+    },
+    "https://purl.imsglobal.org/spec/lti/claim/version" => "1.3.0",
+    "iat" => 1604325886,
+    "iss" => "https://canvas.oli.cmu.edu",
+    "locale" => "en",
+    "name" => "Test Person",
+    "nonce" => "67d025e8-f3ca-439f-bad2-a4ef450f23a4",
+    "picture" => "https://canvas.oli.cmu.edu/images/messages/avatar-50.png",
+    "sub" => "c36c3c87-993f-4d2e-9e22-e47d5d2637ae"
+  }
+
+  test "basic helpers" do
+
+    assert LTI_AGS.grade_passback_enabled?(@lti_params)
+    assert LTI_AGS.get_line_items_url(@lti_params) == "https://canvas.oli.cmu.edu/api/lti/courses/8/line_items"
+
+    lti_ags_claim = Map.get(@lti_params, "https://purl.imsglobal.org/spec/lti-ags/claim/endpoint")
+    assert LTI_AGS.has_scope?(lti_ags_claim, "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem.readonly")
+    refute LTI_AGS.has_scope?(lti_ags_claim, "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem.fake")
+
+  end
+
+
+end

--- a/test/support/lti_1p3_test_helpers.ex
+++ b/test/support/lti_1p3_test_helpers.ex
@@ -114,8 +114,7 @@ defmodule Oli.TestHelpers.Lti_1p3 do
       "https://purl.imsglobal.org/spec/lti-ags/claim/endpoint" => %{
         "lineitems" => "https://lti-ri.imsglobal.org/platforms/1237/contexts/10337/line_items",
         "scope" => ["https://purl.imsglobal.org/spec/lti-ags/scope/lineitem",
-        "https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly",
-        "https://purl.imsglobal.org/spec/lti-ags/scope/score"]
+        "https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly"]
       },
       "https://purl.imsglobal.org/spec/lti-ces/claim/caliper-endpoint-service" => %{
         "caliper_endpoint_url" => "https://lti-ri.imsglobal.org/platforms/1237/sensors",


### PR DESCRIPTION
This PR adds support for LMS grade passback via LTI Assignment and Grade Services (LTI AGS) 2.0. 

## The approach

1. A student submits a graded page attempt.
2. The system finalizes that attempt and rolls up a score to the `resource_access` record for that resource and student.
3. If the LTI Launch params have LTI AGS enabled, the system requests from the LMS an access token.
4. Using the access token as a Bearer token, the system queries the AGS endpoint to determine if a line item for this resource exists.  
5. If the line item does not exist, the system uses the access token to invoke another AGS endpoint to create that line item.
6. If the line item does exist, but it's label or max score relative to the current score is out of date, the system will issue a request to an AGS endpoint to update the line item. 
7. Finally, the system uses the access token and the /scores AGS endpoint to send the score for this student to this line item

## Implications

1. Line items will not appear in the LMS gradebook until the first student completes one attempt.  
2. Publications that change graded page titles will not be reflected in the grade book until a student completes an attempt.  
3. The line item max score will be updated to reflect the state of the max of the most recently posted score - for any student. But this could be problematic if an instructor makes a change to an assessment to add a new question, after one student has already finalized an attempt with the original number of questions. 

The first two from above are okay for now, but we may want to add a feature to allow an instructor to do a full update of line items in the gradebook, at any time.  The third one requires more investigation to understand what LMSes do with the line item max score, as compared to individual student scores which may have a different max.  I am going to do this investigation over the next day and then possibly issue a follow up PR to adjust this score maximum handling. 

Closes #594 

## Testing This

1. Create an LTI developer key in Canvas as usual.
2. Enable AGS access (the first five or so permissions under the LTI Advantage options) in the Developer Key in Canvas
3. Update your `oli.env` environment variables to set your `HOST` to be the full protocol and host of your ngrok served local Torus instance. For example: `HOST=https://c51bd1ea5000.ngrok.io`.  Restart your Dev environment.
4. Publish a course with a graded page.
5. Launch into it from Canvas, and take the graded assignment.  You should immediately see the grade appear back in the Canvas gradebook

