### PR TITLE
Full grade sync

### DIFF
--- a/lib/oli/delivery/attempts.ex
+++ b/lib/oli/delivery/attempts.ex
@@ -295,6 +295,20 @@ defmodule Oli.Delivery.Attempts do
   end
 
   @doc """
+  Retrieves all graded resource access for a given context
+
+  `[%ResourceAccess{}, ...]`
+  """
+  def get_resource_access_for_page(context_id, resource_id) do
+    Repo.all(from a in ResourceAccess,
+      join: s in Section, on: a.section_id == s.id,
+      join: p in PublishedResource, on: s.publication_id == p.publication_id,
+      join: r in Revision, on: p.revision_id == r.id,
+      where: s.context_id == ^context_id and r.graded == true and r.resource_id == ^resource_id,
+      select: a)
+  end
+
+  @doc """
   Retrieves all resource accesses for a given context and user
 
   `[%ResourceAccess{}, ...]`

--- a/lib/oli/delivery/attempts/scoring.ex
+++ b/lib/oli/delivery/attempts/scoring.ex
@@ -43,7 +43,7 @@ defmodule Oli.Delivery.Attempts.Scoring do
   def calculate_score("best", items) do
 
     {score, out_of, _} = Enum.reduce(items, {0, 0, 0.0}, fn p, {score, out_of, best} ->
-      if safe_percentage(p.score, p.out_of) > best do
+      if safe_percentage(p.score, p.out_of) >= best do
         {p.score, p.out_of, safe_percentage(p.score, p.out_of)}
       else
         {score, out_of, best}

--- a/lib/oli/grading.ex
+++ b/lib/oli/grading.ex
@@ -14,7 +14,7 @@ defmodule Oli.Grading do
   alias Oli.Grading.GradebookRow
   alias Oli.Grading.GradebookScore
   alias Oli.Lti_1p3.ContextRoles
-  alias Oli.Grading.LTI_AGS
+  alias Oli.Lti.LTI_AGS
   alias Oli.Resources.Revision
   alias Oli.Publishing.Publication
   alias Oli.Publishing.PublishedResource
@@ -53,7 +53,8 @@ defmodule Oli.Grading do
     [
       "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem",
       "https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly",
-      "https://purl.imsglobal.org/spec/lti-ags/scope/score"
+      "https://purl.imsglobal.org/spec/lti-ags/scope/score",
+      "https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly"
     ]
   end
 
@@ -92,7 +93,7 @@ defmodule Oli.Grading do
     {:ok, dt} = DateTime.now("Etc/UTC")
     timestamp = DateTime.to_iso8601(dt)
 
-    %Oli.Grading.Score{
+    %Oli.Lti.Score{
       timestamp: timestamp,
       scoreGiven: resource_access.score,
       scoreMaximum: resource_access.out_of,

--- a/lib/oli/grading.ex
+++ b/lib/oli/grading.ex
@@ -11,7 +11,6 @@ defmodule Oli.Grading do
   alias Oli.Delivery.Sections.Section
   alias Oli.Delivery.Attempts
   alias Oli.Delivery.Attempts.ResourceAccess
-  alias Oli.Publishing
   alias Oli.Grading.GradebookRow
   alias Oli.Grading.GradebookScore
   alias Oli.Lti_1p3.ContextRoles
@@ -162,8 +161,6 @@ defmodule Oli.Grading do
   `{[%GradebookRow{user: %User{}, scores: [%GradebookScore{}, ...]}, ...], ["Quiz 1", "Quiz 2"]}`
   """
   def generate_gradebook_for_section(%Section{} = section) do
-    # get publication for the section
-    publication = Sections.get_section_publication!(section.id)
 
     # get publication page resources, filtered by graded: true
     graded_pages = fetch_graded_pages(section.context_id)

--- a/lib/oli/grading.ex
+++ b/lib/oli/grading.ex
@@ -65,11 +65,8 @@ defmodule Oli.Grading do
     context_id = Map.get(lti_launch_params, @context_url) |> Map.get("id")
     label = DeliveryResolver.from_resource_id(context_id, resource_access.resource_id).title
 
-    # LTI AGS needs a resource identifier as a string
-    resource_id = Integer.to_string(resource_access.resource_id)
-
     # Next, fetch (and possibly create) the line item associated with this resource
-    case LTI_AGS.fetch_or_create_line_item(line_items_service_url, resource_id, 1, label, token) do
+    case LTI_AGS.fetch_or_create_line_item(line_items_service_url, resource_access.resource_id, 1, label, token) do
 
       # Finally, post the score for this line item
       {:ok, line_item} ->

--- a/lib/oli/grading/line_item.ex
+++ b/lib/oli/grading/line_item.ex
@@ -5,6 +5,9 @@ defmodule Oli.Grading.LineItem do
   @enforce_keys [:scoreMaximum, :label, :resourceId]
   defstruct [:id, :scoreMaximum, :label, :resourceId]
 
+  # The javascript naming convention here is important to match what the
+  # LTI AGS standard expects
+
   @type t() :: %__MODULE__{
     id: String.t(),
     scoreMaximum: float,

--- a/lib/oli/grading/line_item.ex
+++ b/lib/oli/grading/line_item.ex
@@ -11,4 +11,26 @@ defmodule Oli.Grading.LineItem do
     label: String.t(),
     resourceId: String.t()
   }
+
+  @oli_prefix "oli-torus-"
+
+
+  def is_oli?(%__MODULE__{} = line_item) do
+    case line_item.resourceId do
+      @oli_prefix <> _ -> true
+      _ -> false
+    end
+  end
+
+  def parse_resource_id(%__MODULE__{} = line_item) do
+    case line_item.resourceId do
+      @oli_prefix <> resource_id -> resource_id
+      _ -> nil
+    end
+  end
+
+  def to_resource_id(resource_id) do
+    @oli_prefix <> Integer.to_string(resource_id)
+  end
+
 end

--- a/lib/oli/grading/lti_ags.ex
+++ b/lib/oli/grading/lti_ags.ex
@@ -56,7 +56,9 @@ defmodule Oli.Grading.LTI_AGS do
     # to this particular resource_id.  "resource_id", from grade passback 2.0
     # perspective is simply an identifier that the tool uses for a lineitem and its use
     # here as a Torus "resource_id" is strictly coincidence.
-    request_url = "#{line_items_service_url}?resource_id=#{resource_id}"
+
+    prefixed_resource_id = LineItem.to_resource_id(resource_id)
+    request_url = "#{line_items_service_url}?resource_id=#{prefixed_resource_id}"
 
     with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <- HTTPoison.get(request_url, headers(access_token)),
       {:ok, result} <- Jason.decode(body)
@@ -118,7 +120,7 @@ defmodule Oli.Grading.LTI_AGS do
 
     line_item = %LineItem{
       scoreMaximum: score_maximum,
-      resourceId: resource_id,
+      resourceId: LineItem.to_resource_id(resource_id),
       label: label
     }
 
@@ -147,7 +149,7 @@ defmodule Oli.Grading.LTI_AGS do
     updated_line_item = %LineItem{
       id: line_item.id,
       scoreMaximum: Map.get(changes, :scoreMaximum, line_item.scoreMaximum),
-      resourceId: Map.get(changes, :resourceId, line_item.resourceId),
+      resourceId: line_item.resourceId,
       label: Map.get(changes, :label, line_item.label)
     }
 

--- a/lib/oli/grading/score.ex
+++ b/lib/oli/grading/score.ex
@@ -4,6 +4,9 @@ defmodule Oli.Grading.Score do
   @enforce_keys [:timestamp, :scoreGiven, :scoreMaximum, :comment, :activityProgress, :gradingProgress, :userId]
   defstruct [:timestamp, :scoreGiven, :scoreMaximum, :comment, :activityProgress, :gradingProgress, :userId]
 
+  # The javascript naming convention here is important to match what the
+  # LTI AGS standard expects
+
   @type t() :: %__MODULE__{
     timestamp: String.t(),
     scoreGiven: float,

--- a/lib/oli/lti/line_item.ex
+++ b/lib/oli/lti/line_item.ex
@@ -1,4 +1,4 @@
-defmodule Oli.Grading.LineItem do
+defmodule Oli.Lti.LineItem do
 
 
   @derive Jason.Encoder

--- a/lib/oli/lti/lti_ags.ex
+++ b/lib/oli/lti/lti_ags.ex
@@ -1,4 +1,4 @@
-defmodule Oli.Grading.LTI_AGS do
+defmodule Oli.Lti.LTI_AGS do
 
   @moduledoc """
   Implementation of LTI Assignment and Grading Services (LTI AGS) version 2.0.
@@ -13,8 +13,8 @@ defmodule Oli.Grading.LTI_AGS do
   @lineitem_scope_url "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem"
   @scores_scope_url "https://purl.imsglobal.org/spec/lti-ags/scope/score"
 
-  alias Oli.Grading.Score
-  alias Oli.Grading.LineItem
+  alias Oli.Lti.Score
+  alias Oli.Lti.LineItem
   alias Oli.Lti_1p3.AccessToken
 
   require Logger
@@ -110,6 +110,10 @@ defmodule Oli.Grading.LTI_AGS do
     with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <- HTTPoison.get(url, headers(access_token)),
       {:ok, results} <- Jason.decode(body)
     do
+
+      IO.inspect headers(access_token)
+      IO.inspect results
+
       {:ok, Enum.map(results, fn r -> to_line_item(r) end)}
     else
       e ->

--- a/lib/oli/lti/lti_nrps.ex
+++ b/lib/oli/lti/lti_nrps.ex
@@ -1,0 +1,74 @@
+defmodule Oli.Lti.LTI_NRPS do
+
+  @moduledoc """
+  Implementation of LTI Names and Roles Provisioning Service
+
+  For information on the standard, see:
+  https://www.imsglobal.org/spec/lti-nrps/v2p0
+
+  This module contains no dependencies on attempts, resources, or any other delivery specific construct.
+  """
+
+  @lti_nrps_claim_url "https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice"
+  @context_memberships_url_key "context_memberships_url"
+
+  alias Oli.Lti.Membership
+  alias Oli.Lti_1p3.AccessToken
+
+  require Logger
+
+  defp to_membership(raw) do
+    %Membership{
+      status: Map.get(raw, "status"),
+      name: Map.get(raw, "name"),
+      picture: Map.get(raw, "picture"),
+      given_name: Map.get(raw, "given_name"),
+      middle_name: Map.get(raw, "middle_name"),
+      family_name: Map.get(raw, "family_name"),
+      email: Map.get(raw, "email"),
+      user_id: Map.get(raw, "user_id"),
+      roles: Map.get(raw, "roles"),
+    }
+  end
+
+  def fetch_memberships(context_memberships_url, %AccessToken{} = access_token) do
+
+    Logger.debug("Fetch memberships from #{context_memberships_url}")
+
+    url = context_memberships_url <> "?limit=1000"
+
+    with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <- HTTPoison.get(url, headers(access_token)),
+      {:ok, results} <- Jason.decode(body),
+      members <- Map.get(results, "members")
+    do
+      {:ok, Enum.map(members, fn r -> to_membership(r) end)}
+    else
+      e ->
+        Logger.error("Error encountered fetching memberships from #{url} #{inspect e}")
+        {:error, "Error retrieving memberships"}
+    end
+
+  end
+
+  @doc """
+  Returns true if nrps is enabled (that is, to allow a context membership query).
+  """
+  def nrps_enabled?(lti_launch_params) do
+    case Map.get(lti_launch_params, @lti_nrps_claim_url) do
+      nil -> false
+      config -> Map.has_key?(config, @context_memberships_url_key)
+    end
+  end
+
+  @doc """
+  Returns the context memberships URL from LTI launch params. If not present returns nil.
+  """
+  def get_context_memberships_url(lti_launch_params) do
+    Map.get(lti_launch_params, @lti_nrps_claim_url, %{}) |> Map.get(@context_memberships_url_key)
+  end
+
+  defp headers(%AccessToken{} = access_token) do
+    [{"Content-Type", "application/json"}, {"Authorization", "Bearer #{access_token.access_token}"}]
+  end
+
+end

--- a/lib/oli/lti/membership.ex
+++ b/lib/oli/lti/membership.ex
@@ -1,0 +1,20 @@
+defmodule Oli.Lti.Membership do
+
+  # See https://www.imsglobal.org/spec/lti-nrps/v2p0#context-membership
+
+  @derive Jason.Encoder
+  @enforce_keys [:status, :name, :picture, :given_name, :middle_name, :family_name, :email, :user_id, :roles]
+  defstruct [:status, :name, :picture, :given_name, :middle_name, :family_name, :email, :user_id, :roles]
+
+  @type t() :: %__MODULE__{
+    status: String.t(),
+    name: String.t(),
+    picture: String.t(),
+    given_name: String.t(),
+    middle_name: String.t(),
+    family_name: String.t(),
+    email: String.t(),
+    user_id: String.t(),
+    roles: [String.t()]
+  }
+end

--- a/lib/oli/lti/score.ex
+++ b/lib/oli/lti/score.ex
@@ -1,4 +1,4 @@
-defmodule Oli.Grading.Score do
+defmodule Oli.Lti.Score do
 
   @derive Jason.Encoder
   @enforce_keys [:timestamp, :scoreGiven, :scoreMaximum, :comment, :activityProgress, :gradingProgress, :userId]

--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -157,6 +157,10 @@ defmodule OliWeb.DeliveryController do
     |> render_create_and_link_form()
   end
 
+  def unauthorized(conn, _params) do
+    render conn, "unauthorized.html"
+  end
+
   def process_create_and_link_account_user(conn, %{"user" => user_params}) do
     conn
     |> use_pow_config(:author)

--- a/lib/oli_web/live/grades/export.ex
+++ b/lib/oli_web/live/grades/export.ex
@@ -1,0 +1,24 @@
+defmodule OliWeb.Grades.Export do
+  use Phoenix.LiveComponent
+
+  use Phoenix.HTML
+  alias OliWeb.Router.Helpers, as: Routes
+
+  def render(assigns) do
+    ~L"""
+    <div class="card">
+      <div class="card-body">
+        <h5 class="card-title">Export Grades</h5>
+
+        <p class="card-text">The current grades for all students and all graded pages can be exported as a <code>.csv</code> file.</p>
+
+      </div>
+
+      <div class="card-footer">
+       <%= link "Export and Download Gradebook", to: Routes.page_delivery_path(OliWeb.Endpoint, :export_gradebook, @context_id), class: "btn btn-primary" %>
+      </div>
+    </div>
+    """
+  end
+
+end

--- a/lib/oli_web/live/grades/grade_sync.ex
+++ b/lib/oli_web/live/grades/grade_sync.ex
@@ -3,8 +3,7 @@ defmodule OliWeb.Grades.GradeSync do
 
   def render(assigns) do
 
-    has_tasks? = length(assigns.task_queue) > 0
-    disabled = if has_tasks? do "disabled" else "" end
+    disabled = if length(assigns.task_queue) > 0 do "disabled" else "" end
 
     ~L"""
 

--- a/lib/oli_web/live/grades/grade_sync.ex
+++ b/lib/oli_web/live/grades/grade_sync.ex
@@ -3,7 +3,7 @@ defmodule OliWeb.Grades.GradeSync do
 
   def render(assigns) do
 
-    disabled = if length(assigns.task_queue) > 0 do "disabled" else "" end
+    disabled = if length(assigns.task_queue) > 0 or assigns.selected_page == nil do "disabled" else "" end
 
     ~L"""
 
@@ -13,7 +13,18 @@ defmodule OliWeb.Grades.GradeSync do
 
         <p class="card-text">
         If an instructor changes the maximum score for an LMS gradebook line item <b>after</b> students
-        have submitted an attempt, it is necessary to synchronize the OLI grades and the LMS gradebook.</p>
+        have submitted an attempt, it is necessary to synchronize the OLI grades for that LMS gradebook item.</p>
+
+        <div class="alert alert-danger" role="alert">
+          <strong>Warning!</strong> This operation will overwrite any grades in the LMS gradebook that
+          were manually adjusted or overridden by the instructor.
+        </div>
+
+        <select class="custom-select custom-select-lg mb-3">
+          <%= for page <- @graded_pages do %>
+            <option value="<%= page.resource_id %>" phx-click="select_page" phx-value-page="<%= page.resource_id %>"><%= page.title %></option>
+          <% end %>
+        </select>
 
       </div>
 

--- a/lib/oli_web/live/grades/grade_sync.ex
+++ b/lib/oli_web/live/grades/grade_sync.ex
@@ -1,0 +1,31 @@
+defmodule OliWeb.Grades.GradeSync do
+  use Phoenix.LiveComponent
+
+  def render(assigns) do
+
+    has_tasks? = length(assigns.task_queue) > 0
+    disabled = if has_tasks? do "disabled" else "" end
+
+    ~L"""
+
+    <div class="card">
+      <div class="card-body">
+        <h5 class="card-title">Synchronize LMS Grades</h5>
+
+        <p class="card-text">
+        If an instructor changes the maximum score for an LMS gradebook line item <b>after</b> students
+        have submitted an attempt, it is necessary to synchronize the OLI grades and the LMS gradebook.</p>
+
+      </div>
+
+      <div class="card-footer">
+
+        <a class="btn btn-primary" phx-click="send_grades" <%= disabled %>>Synchronize LMS Grades</a>
+
+      </div>
+    </div>
+
+    """
+  end
+
+end

--- a/lib/oli_web/live/grades/grades.ex
+++ b/lib/oli_web/live/grades/grades.ex
@@ -163,7 +163,10 @@ defmodule OliWeb.Grades.GradesLive do
 
         {:ok, memberships} ->
 
-          subs = Enum.map(memberships, fn m -> m.user_id end) |> MapSet.new()
+          # get a set of the subs corresponding to Active students
+          subs = Enum.filter(memberships, fn m -> m.status == "Active" end)
+          |> Enum.map(fn m -> m.user_id end) |> MapSet.new()
+
           Enum.filter(students, fn s -> MapSet.member?(subs, s.sub) end)
 
         _ -> students

--- a/lib/oli_web/live/grades/grades.ex
+++ b/lib/oli_web/live/grades/grades.ex
@@ -3,7 +3,6 @@ defmodule OliWeb.Grades.GradesLive do
   use Phoenix.LiveView, layout: {OliWeb.LayoutView, "live.html"}
   use Phoenix.HTML
 
-  alias Oli.Delivery.Sections.Section
   alias Oli.Grading
   alias Oli.Grading.LTI_AGS
   alias Oli.Grading.LineItem
@@ -110,13 +109,19 @@ defmodule OliWeb.Grades.GradesLive do
 
                 # Here we preprend a function that when invoked will
                 # post the score to the AGS endpoint
-                [fn assigns ->
-                  line_item = Map.get(assigns.cached_line_items, LineItem.to_resource_id(revision.resource_id))
+                if (score != nil and out_of != nil) do
 
-                  Grading.to_score(sub, student_resource_accesses)
-                  |> LTI_AGS.post_score(line_item, assigns.access_token)
+                  [fn assigns ->
+                    line_item = Map.get(assigns.cached_line_items, LineItem.to_resource_id(revision.resource_id))
 
-                end | acc]
+                    Grading.to_score(sub, student_resource_accesses)
+                    |> LTI_AGS.post_score(line_item, assigns.access_token)
+
+                  end | acc]
+
+                else
+                  acc
+                end
 
               _ -> acc
             end

--- a/lib/oli_web/live/grades/grades.ex
+++ b/lib/oli_web/live/grades/grades.ex
@@ -1,0 +1,179 @@
+defmodule OliWeb.Grades.GradesLive do
+
+  use Phoenix.LiveView, layout: {OliWeb.LayoutView, "live.html"}
+  use Phoenix.HTML
+
+  alias Oli.Grading
+  alias Oli.Grading.LTI_AGS
+  alias Oli.Lti_1p3.AccessToken
+  alias Oli.Lti_1p3.ContextRoles
+
+  def mount(%{"context_id" => context_id}, %{"lti_params" => lti_params, "current_user" => current_user}, socket) do
+
+    if ContextRoles.has_role?(current_user, context_id, ContextRoles.get_role(:context_instructor)) do
+
+      line_items_url = LTI_AGS.get_line_items_url(lti_params)
+
+      {:ok, assign(socket,
+        line_items_url: line_items_url,
+        access_token: nil,
+        cancelled: false,
+        task_description: "",
+        task_queue: [],
+        progress_current: 0,
+        progress_max: 0,
+        context_id: context_id,
+        lti_params: lti_params)
+      }
+    else
+      {:ok, redirect(socket, to: "/unauthorized")}
+    end
+  end
+
+  def render(assigns) do
+
+    iss = assigns.lti_params["iss"]
+    has_tasks? = length(assigns.task_queue) > 0
+    progress_visible = if has_tasks? do "visible" else "invisible" end
+
+    percent_progress = case assigns.progress_max do
+      0 -> 0
+      v -> (assigns.progress_current / v) * 100
+    end
+
+    ~L"""
+    <h2>Manage Grades</h2>
+
+    <p>Grades for OLI graded pages for this course are accessed by students and instructors from the LMS gradebook at <a href="<%= iss %>"><%= iss %></a>.</p>
+
+    <div class="card-group">
+
+      <%= live_component @socket, OliWeb.Grades.LineItems, assigns %>
+      <%= live_component @socket, OliWeb.Grades.GradeSync, assigns %>
+      <%= live_component @socket, OliWeb.Grades.Export, assigns %>
+
+    </div>
+
+    <div class="mt-4">
+      <p>Do not leave this page until this operation completes.</p>
+      <div class="progress <%= progress_visible %>">
+        <div class="progress-bar" role="progressbar" style="width: <%= percent_progress %>%;" aria-valuenow="<%= percent_progress %>" aria-valuemin="0" aria-valuemax="100">
+      </div>
+    </div>
+
+    """
+  end
+
+  defp determine_line_item_tasks(graded_pages, line_items) do
+
+    line_item_map = Enum.reduce(line_items, %{}, fn i, m -> Map.put(m, i.resourceId, i) end)
+
+    # tasks to create line items for graded pages that do not have them
+    creation_tasks = Enum.filter(graded_pages, fn p -> !Map.has_key?(line_item_map, Integer.to_string(p.resource_id)) end)
+    |> Enum.map(fn p ->
+      fn line_items_url, access_token ->
+        resource_id = Integer.to_string(p.resource_id)
+        LTI_AGS.create_line_item(line_items_url, resource_id, 1, p.title, access_token)
+      end
+    end)
+
+    # tasks to update the labels of line items whose corresponding graded page's title has changed
+    update_tasks = Enum.filter(graded_pages, fn p -> Map.has_key?(line_item_map, Integer.to_string(p.resource_id)) and Map.get(line_item_map, Integer.to_string(p.resource_id)).label != p.title end)
+    |> Enum.map(fn p ->
+      fn _, access_token ->
+        line_item = Map.get(line_item_map, Integer.to_string(p.resource_id))
+        LTI_AGS.update_line_item(line_item, %{label: p.title}, access_token)
+      end
+    end)
+
+    creation_tasks ++ update_tasks
+  end
+
+  defp host() do
+    Application.get_env(:oli, OliWeb.Endpoint)
+    |> Keyword.get(:url)
+    |> Keyword.get(:host)
+  end
+
+  defp access_token_provider(lti_launch_params) do
+    deployment_id = Oli.Lti_1p3.get_deployment_id_from_launch(lti_launch_params)
+    AccessToken.fetch_access_token(deployment_id, Grading.ags_scopes(), host())
+  end
+
+  def handle_event("cancel", _, socket) do
+    {:noreply, assign(socket, :cancelled, true)}
+  end
+
+  def handle_event("send_line_items", _, socket) do
+
+    case fetch_line_items(socket.assigns.lti_params, socket.assigns.line_items_url) do
+
+      {:ok, line_items, access_token} ->
+
+        graded_pages = Grading.fetch_graded_pages(socket.assigns.context_id)
+
+        case determine_line_item_tasks(graded_pages, line_items) do
+
+          [] -> {:noreply, put_flash(socket, :info, "LMS line items already up to date")}
+
+          task_queue ->
+            send(self(), :pop_task_queue)
+            {:noreply, assign(socket, task_description: "Update LMS Line Items", access_token: access_token,
+              task_queue: task_queue, progress_max: length(task_queue), progress_current: 0, cancelled: false)}
+
+        end
+
+      {:error, e} -> {:noreply, put_flash(socket, :error, e)}
+
+    end
+
+  end
+
+  defp fetch_line_items(lti_params, line_items_url) do
+
+    case access_token_provider(lti_params) do
+
+      {:ok, access_token} ->
+
+        case LTI_AGS.fetch_line_items(line_items_url, access_token) do
+
+          {:ok, line_items} -> {:ok, line_items, access_token}
+          _ -> {:error, "Error accessing LMS line items"}
+        end
+
+      _ -> {:error, "Error getting LMS access token"}
+
+    end
+
+  end
+
+  def handle_info(:pop_task_queue, socket) do
+
+    if socket.assigns.cancelled do
+      socket = put_flash(socket, :info, "Operation cancelled")
+      {:noreply, assign(socket, task_queue: [])}
+    else
+
+      [task | task_queue] = socket.assigns.task_queue
+
+      case task.(socket.assigns.line_items_url, socket.assigns.access_token) do
+        {:ok, _} ->
+
+          socket = if length(task_queue) > 0 do
+            send(self(), :pop_task_queue)
+            socket
+          else
+            socket |> put_flash(:info, "LMS line items up to date")
+          end
+
+          {:noreply, assign(socket, task_queue: task_queue, progress_current: socket.assigns.progress_current + 1)}
+
+        {:error, e} ->
+          socket = socket |> put_flash(:error, e)
+          {:noreply, assign(socket, task_queue: [])}
+      end
+    end
+
+  end
+
+end

--- a/lib/oli_web/live/grades/grades.ex
+++ b/lib/oli_web/live/grades/grades.ex
@@ -3,11 +3,13 @@ defmodule OliWeb.Grades.GradesLive do
   use Phoenix.LiveView, layout: {OliWeb.LayoutView, "live.html"}
   use Phoenix.HTML
 
+  alias Oli.Delivery.Sections.Section
   alias Oli.Grading
   alias Oli.Grading.LTI_AGS
   alias Oli.Grading.LineItem
   alias Oli.Lti_1p3.AccessToken
   alias Oli.Lti_1p3.ContextRoles
+  alias Oli.Delivery.Attempts.ResourceAccess
 
   def mount(%{"context_id" => context_id}, %{"lti_params" => lti_params, "current_user" => current_user}, socket) do
 
@@ -16,6 +18,7 @@ defmodule OliWeb.Grades.GradesLive do
       line_items_url = LTI_AGS.get_line_items_url(lti_params)
 
       {:ok, assign(socket,
+        cached_line_items: %{},
         line_items_url: line_items_url,
         access_token: nil,
         task_queue: [],
@@ -53,9 +56,9 @@ defmodule OliWeb.Grades.GradesLive do
 
     </div>
 
-    <div class="mt-4">
+    <div class="mt-4 <%= progress_visible %>">
       <p>Do not leave this page until this operation completes.</p>
-      <div class="progress <%= progress_visible %>">
+      <div class="progress">
         <div class="progress-bar" role="progressbar" style="width: <%= percent_progress %>%;" aria-valuenow="<%= percent_progress %>" aria-valuemin="0" aria-valuemax="100">
       </div>
     </div>
@@ -70,21 +73,59 @@ defmodule OliWeb.Grades.GradesLive do
     # tasks to create line items for graded pages that do not have them
     creation_tasks = Enum.filter(graded_pages, fn p -> !Map.has_key?(line_item_map, LineItem.to_resource_id(p.resource_id)) end)
     |> Enum.map(fn p ->
-      fn line_items_url, access_token ->
-        LTI_AGS.create_line_item(line_items_url, p.resource_id, 1, p.title, access_token)
+      fn assigns ->
+        LTI_AGS.create_line_item(assigns.line_items_url, p.resource_id, 1, p.title, assigns.access_token)
       end
     end)
 
     # tasks to update the labels of line items whose corresponding graded page's title has changed
-    update_tasks = Enum.filter(graded_pages, fn p -> Map.has_key?(line_item_map, LineItem.to_resource_id(p.resource_id)) and Map.get(line_item_map, Integer.to_string(p.resource_id)).label != p.title end)
+    update_tasks = Enum.filter(graded_pages, fn p -> Map.has_key?(line_item_map, LineItem.to_resource_id(p.resource_id)) and Map.get(line_item_map, LineItem.to_resource_id(p.resource_id)).label != p.title end)
     |> Enum.map(fn p ->
-      fn _, access_token ->
+      fn assigns ->
         line_item = Map.get(line_item_map, LineItem.to_resource_id(p.resource_id))
-        LTI_AGS.update_line_item(line_item, %{label: p.title}, access_token)
+        LTI_AGS.update_line_item(line_item, %{label: p.title}, assigns.access_token)
       end
     end)
 
     creation_tasks ++ update_tasks
+  end
+
+  defp determine_grade_sync_tasks(context_id, graded_pages) do
+
+    # get students enrolled in the section, filter by role: student
+    students = Grading.fetch_students(context_id)
+
+    # create a map of all resource accesses, keyed off resource id
+    resource_accesses = Grading.fetch_resource_accesses(context_id)
+
+    # create a task to post a score for each student's resource_access record
+    Enum.reduce(students, [], fn %{id: user_id, sub: sub}, tasks ->
+
+      Enum.reduce(graded_pages, tasks, fn revision, acc ->
+
+        case resource_accesses[revision.resource_id] do
+          %{^user_id => student_resource_accesses} ->
+            case student_resource_accesses do
+              %ResourceAccess{score: score, out_of: out_of} ->
+
+                # Here we preprend a function that when invoked will
+                # post the score to the AGS endpoint
+                [fn assigns ->
+                  line_item = Map.get(assigns.cached_line_items, LineItem.to_resource_id(revision.resource_id))
+
+                  Grading.to_score(sub, student_resource_accesses)
+                  |> LTI_AGS.post_score(line_item, assigns.access_token)
+
+                end | acc]
+
+              _ -> acc
+            end
+          _ -> acc
+        end
+
+      end)
+    end)
+
   end
 
   defp host() do
@@ -111,11 +152,46 @@ defmodule OliWeb.Grades.GradesLive do
           [] -> {:noreply, put_flash(socket, :info, "LMS line items already up to date")}
 
           task_queue ->
+
+            # Kick off the serial processing of the queue by popping the first item
             send(self(), :pop_task_queue)
-            {:noreply, assign(socket, task_description: "Update LMS Line Items", access_token: access_token,
-              task_queue: task_queue, progress_max: length(task_queue), progress_current: 0, cancelled: false)}
+
+            {:noreply, assign(socket, access_token: access_token,
+              task_queue: task_queue, progress_max: length(task_queue), progress_current: 0)}
 
         end
+
+      {:error, e} -> {:noreply, put_flash(socket, :error, e)}
+
+    end
+
+  end
+
+  def handle_event("send_grades", _, socket) do
+
+    case fetch_line_items(socket.assigns.lti_params, socket.assigns.line_items_url) do
+
+      {:ok, line_items, access_token} ->
+
+        # cache all existing line items, we will need these to be able to
+        # support a full grade sync
+        cached_line_items = Enum.reduce(line_items, %{}, fn i, m -> Map.put(m, i.resourceId, i) end)
+
+        # determine the line item and score posting tasks
+        graded_pages = Grading.fetch_graded_pages(socket.assigns.context_id)
+        line_item_tasks = determine_line_item_tasks(graded_pages, line_items)
+        score_tasks = determine_grade_sync_tasks(socket.assigns.context_id, graded_pages)
+
+        # assemble the full queue of tasks and pop the first one to kick off
+        # the serial processing of these
+        task_queue = line_item_tasks ++ score_tasks
+        send(self(), :pop_task_queue)
+
+        {:noreply, assign(socket,
+          cached_line_items: cached_line_items,
+          access_token: access_token,
+          task_queue: task_queue,
+          progress_max: length(task_queue), progress_current: 0)}
 
       {:error, e} -> {:noreply, put_flash(socket, :error, e)}
 
@@ -143,19 +219,31 @@ defmodule OliWeb.Grades.GradesLive do
 
   def handle_info(:pop_task_queue, socket) do
 
+    # take the first item off the queue
     [task | task_queue] = socket.assigns.task_queue
 
-    case task.(socket.assigns.line_items_url, socket.assigns.access_token) do
-      {:ok, _} ->
+    # and invoke the task, providing the current socket assigns
+    # as context
+    case task.(socket.assigns) do
+      {:ok, result} ->
 
+        # When we process a line item creation or update, we cache the result
+        # because a full grade sync will need these line items to issue the score post
+        cached_line_items = case result do
+          %LineItem{} = line_item -> Map.put(socket.assigns.cached_line_items, line_item.resourceId, line_item)
+          _ -> socket.assigns.cached_line_items
+        end
+
+        # See if there is another item in the queue to pop
         socket = if length(task_queue) > 0 do
           send(self(), :pop_task_queue)
           socket
         else
-          socket |> put_flash(:info, "LMS line items up to date")
+          socket |> put_flash(:info, "LMS up to date")
         end
 
-        {:noreply, assign(socket, task_queue: task_queue, progress_current: socket.assigns.progress_current + 1)}
+        {:noreply, assign(socket, cached_line_items: cached_line_items,
+          task_queue: task_queue, progress_current: socket.assigns.progress_current + 1)}
 
       {:error, e} ->
         socket = socket |> put_flash(:error, e)

--- a/lib/oli_web/live/grades/line_items.ex
+++ b/lib/oli_web/live/grades/line_items.ex
@@ -3,8 +3,7 @@ defmodule OliWeb.Grades.LineItems do
 
   def render(assigns) do
 
-    has_tasks? = length(assigns.task_queue) > 0
-    disabled = if has_tasks? do "disabled" else "" end
+    disabled = if length(assigns.task_queue) > 0 do "disabled" else "" end
 
     ~L"""
 

--- a/lib/oli_web/live/grades/line_items.ex
+++ b/lib/oli_web/live/grades/line_items.ex
@@ -1,0 +1,29 @@
+defmodule OliWeb.Grades.LineItems do
+  use Phoenix.LiveComponent
+
+  def render(assigns) do
+
+    has_tasks? = length(assigns.task_queue) > 0
+    disabled = if has_tasks? do "disabled" else "" end
+
+    ~L"""
+
+    <div class="card">
+      <div class="card-body">
+        <h5 class="card-title">Update LMS Line Items</h5>
+
+        <p class="card-text">
+        While OLI automatically will create LMS gradebook line items as students complete assignments,
+        in some circumstances an instructor may want to explicitly create gradebook line items or update them.</p>
+
+      </div>
+
+      <div class="card-footer">
+        <a class="btn btn-primary" phx-click="send_line_items" <%= disabled %>>Update LMS Line Items</a>
+      </div>
+    </div>
+
+    """
+  end
+
+end

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -110,6 +110,10 @@ defmodule OliWeb.Router do
     %{"current_author_id" => conn.assigns.current_author.id}
   end
 
+  def with_delivery(conn) do
+    %{"lti_params" => conn.assigns.lti_params, "current_user" => conn.assigns.current_user}
+  end
+
   defp put_pow_mailer_layout(conn, layout), do: put_private(conn, :pow_mailer_layout, layout)
 
   ### ROUTES ###
@@ -273,6 +277,8 @@ defmodule OliWeb.Router do
     get "/signout", DeliveryController, :signout
     get "/open_and_free", DeliveryController, :list_open_and_free
 
+    get "/unauthorized", DeliveryController, :unauthorized
+
     # course link resolver
     get "/link/:revision_slug", PageDeliveryController, :link
 
@@ -281,7 +287,9 @@ defmodule OliWeb.Router do
     get "/:context_id/page/:revision_slug/attempt", PageDeliveryController, :start_attempt
     get "/:context_id/page/:revision_slug/attempt/:attempt_guid", PageDeliveryController, :finalize_attempt
 
+    live "/:context_id/grades", Grades.GradesLive, session: {__MODULE__, :with_delivery, []}
     get "/:context_id/grades/export", PageDeliveryController, :export_gradebook
+
   end
 
   scope "/admin", OliWeb do

--- a/lib/oli_web/templates/delivery/unauthorized.html.eex
+++ b/lib/oli_web/templates/delivery/unauthorized.html.eex
@@ -1,0 +1,16 @@
+
+<div class="my-3">
+
+  <div class="alert alert-danger" role="alert">
+    <h4 class="alert-heading">Not authorized</h4>
+    <p>You do not have access to this page.</p>
+    <hr>
+    <p>If you should have access to this page, here are a few things that you can try:</p>
+    <ul>
+      <li>Refreshing your browser</li>
+      <li>Returning to your LMS to try accessing OLI again</li>
+      <li>Contacting your instructor for help</li>
+    </ul>
+  </div>
+
+</div>

--- a/lib/oli_web/templates/layout/live.html.leex
+++ b/lib/oli_web/templates/layout/live.html.leex
@@ -1,14 +1,26 @@
 
 <%= if live_flash(@flash, :info) do %>
-<p class="alert alert-info" role="alert"
-  phx-click="lv:clear-flash"
-  phx-value-key="info"><%= live_flash(@flash, :info) %></p>
+<div class="alert alert-info" role="alert">
+
+  <%= live_flash(@flash, :info) %>
+
+  <button type="button" class="close" data-dismiss="alert" aria-label="Close" phx-click="lv:clear-flash" phx-value-key="info">
+    <span aria-hidden="true">&times;</span>
+  </button>
+
+  </div>
 <% end %>
 
 <%= if live_flash(@flash, :error) do %>
-<p class="alert alert-danger" role="alert"
-  phx-click="lv:clear-flash"
-  phx-value-key="error"><%= live_flash(@flash, :error) %></p>
+<div class="alert alert-danger" role="alert">
+
+  <%= live_flash(@flash, :error) %>
+
+  <button type="button" class="close" data-dismiss="alert" aria-label="Close" phx-click="lv:clear-flash" phx-value-key="error">
+    <span aria-hidden="true">&times;</span>
+  </button>
+
+</div>
 <% end %>
 
 <script>

--- a/lib/oli_web/templates/page_delivery/index.html.eex
+++ b/lib/oli_web/templates/page_delivery/index.html.eex
@@ -3,37 +3,14 @@
   <p class="text-secondary"><%= @summary.description %></p>
 
   <%= if is_instructor?(@conn, @context_id) do %>
+
   <div class="d-flex flex-row">
     <div class="flex-fill"></div>
     <div>
-      <%= link "Download Gradebook (.csv)", to: Routes.page_delivery_path(@conn, :export_gradebook, @context_id), class: "btn btn-link btn-sm" %>
-    </div>
-
-    <div class="modal fade" id="configure-token-modal" data-backdrop="static" tabindex="-1">
-      <div class="modal-dialog" role="document">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h5 class="modal-title" id="staticBackdropLabel">Update Token</h5>
-            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-              <span aria-hidden="true">&times;</span>
-            </button>
-          </div>
-          <div class="modal-body">
-            <div class="input-group mb-3">
-              <div class="input-group-prepend">
-                <span class="input-group-text" id="basic-addon3">Token</span>
-              </div>
-              <input id="token" type="text" class="form-control">
-            </div>
-          </div>
-          <div class="modal-footer">
-            <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
-            <button id="save-token" type="button" class="btn btn-primary">Save</button>
-          </div>
-        </div>
-      </div>
+      <%= link "Manage Grades", to: Routes.live_path(OliWeb.Endpoint, OliWeb.Grades.GradesLive, @context_id), class: "btn btn-link btn-sm" %>
     </div>
   </div>
+
   <% end %>
 
   <h5>Course Outline</h5>

--- a/test/oli/delivery/attempts/scoring_test.exs
+++ b/test/oli/delivery/attempts/scoring_test.exs
@@ -33,6 +33,9 @@ defmodule Oli.Delivery.Attempts.ScoringTest do
 
   test "best" do
 
+    items = [%{score: 0, out_of: 1}]
+    assert %Result{score: 0, out_of: 1} = Scoring.calculate_score("best", items)
+
     items = [%{score: 5, out_of: 10}]
     assert %Result{score: 5, out_of: 10} = Scoring.calculate_score("best", items)
 

--- a/test/oli/delivery/submission_test.exs
+++ b/test/oli/delivery/submission_test.exs
@@ -292,7 +292,7 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
 
       part_inputs = [
         %{attempt_guid: part_attempt.attempt_guid, input: %StudentInput{input: "a"}},
-        %{attempt_guid: part2_attempt.attempt_guid, input: %StudentInput{input: "a"}},
+        %{attempt_guid: part2_attempt.attempt_guid, input: %StudentInput{input: "b"}},
       ]
       {:ok, [
         %{attempt_guid: attempt_guid, out_of: out_of, score: score, feedback: %{id: id} },
@@ -306,9 +306,9 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
       assert id == "1"
 
       assert attempt_guid2 == part2_attempt.attempt_guid
-      assert score2 == 2
+      assert score2 == 1
       assert out_of2 == 2
-      assert id2 == "4"
+      assert id2 == "5"
 
       # verify the part attempt record was updated correctly
       updated_attempt = Oli.Repo.get!(PartAttempt, part_attempt.id)
@@ -317,7 +317,7 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
       refute updated_attempt.date_evaluated == nil
 
       updated_attempt = Oli.Repo.get!(PartAttempt, part2_attempt.id)
-      assert updated_attempt.score == 2
+      assert updated_attempt.score == 1
       assert updated_attempt.out_of == 2
       refute updated_attempt.date_evaluated == nil
 

--- a/test/oli/grading/lti_ags_test.exs
+++ b/test/oli/grading/lti_ags_test.exs
@@ -2,7 +2,7 @@ defmodule Oli.Grading.LTI_AGS_Test do
 
   use ExUnit.Case, async: true
 
-  alias Oli.Grading.LTI_AGS
+  alias Oli.Lti.LTI_AGS
 
   @lti_params %{
     "aud" => "10000000000041",


### PR DESCRIPTION
Adds a "Grades Management" UI that instructors can use to update line items, sync grades, and export gradebook.

The UI is LiveView driven and allows the serial execution of a collection of tasks related to creating, updating line items and posting scores.  After completion of each "task" a progress bar in the UI is updated.

A key change that was also made was to introduce a prefix to the resourceId attribute that we are populating in the LMS created line item.  This helps to guarantee that another, non-Torus tool populating line items and setting resource_ids does not conflict with Torus. 

This feature uses LTI Names and Roles Provisioning service to determine all currently enrolled students so that we do not attempt to post scores for students that have been removed from the LMS section. 

A key limitation of the grade sync feature is that there is no way for it to know if a grade has been overridden in the LMS by an instructor (at least based on Canvas and the LTI_AGS testing I did).  Therefore, I changed this feature page specific and to include a warning regarding loss of custom grade adjustments. 

To access this new "Grades Management" UI, launch in from the LMS as an instructor.  On the Overview page at the top-right you will see a "Grades Management" link. 