### PR TITLE
Fix Accounts page issue and update version number

### DIFF
--- a/lib/oli_web/templates/workspace/account.html.eex
+++ b/lib/oli_web/templates/workspace/account.html.eex
@@ -53,7 +53,7 @@
           <div class="form-check mt-2">
             <%= checkbox f,
               :hide,
-              checked: @preferences[:live_preview_display] == "hidden",
+              checked: Map.get(@preferences, :live_preview_display) == "hidden",
               class: "form-check-input",
               onchange: "this.form.submit();" %>
             <%= label f, :id, "Hide Activity Previews", class: "form-check-label" %>

--- a/lib/oli_web/templates/workspace/account.html.eex
+++ b/lib/oli_web/templates/workspace/account.html.eex
@@ -50,10 +50,18 @@
         <% end %>
 
         <%= form_for @conn, Routes.workspace_path(@conn, :update_live_preview_display), fn f -> %>
+          <%
+          hide_previews_checked = case @preferences do
+            nil ->
+              true
+            %{live_preview_display: live_preview_display} ->
+              live_preview_display == "hidden"
+          end
+          %>
           <div class="form-check mt-2">
             <%= checkbox f,
               :hide,
-              checked: Map.get(@preferences, :live_preview_display) == "hidden",
+              checked: hide_previews_checked,
               class: "form-check-input",
               onchange: "this.form.submit();" %>
             <%= label f, :id, "Hide Activity Previews", class: "form-check-label" %>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Oli.MixProject do
   def project do
     [
       app: :oli,
-      version: "0.1.0",
+      version: "0.2.0",
       elixir: "~> 1.11",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),


### PR DESCRIPTION
This PR fixes an issue on accounts page where if AccountPreferences exist for a user, the page crashes with a fetch error. Instead of using [] notation to access the live_preview_display setting this uses Map.get.

Also updates the version number in mix.exs