### PR TITLE
fix an issue with attempt submission lti_params missing

### DIFF
--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -73,6 +73,8 @@ defmodule OliWeb.Router do
   pipeline :delivery_protected do
     plug Pow.Plug.RequireAuthenticated,
       error_handler: OliWeb.Pow.UserAuthErrorHandler
+    plug Oli.Plugs.SetDefaultPow, :user
+    plug Oli.Plugs.LoadLtiParams
   end
 
   # Ensure that we have a logged in user
@@ -248,7 +250,7 @@ defmodule OliWeb.Router do
   end
 
   scope "/api/v1/attempt", OliWeb do
-    pipe_through [:api]
+    pipe_through [:api, :delivery_protected]
 
     # post to create a new attempt
     # put to submit a response


### PR DESCRIPTION
When submitting an activity in delivery, the server would throw a missing lti_params error. This PR fixes that by running these requests through a delivery_protected plug, ensuring the user is authenticated and these lti_params are added to assigns