### PR TITLE
Gettext

### DIFF
--- a/assets/src/components/activities/multiple_choice/sections/Choices.tsx
+++ b/assets/src/components/activities/multiple_choice/sections/Choices.tsx
@@ -7,6 +7,7 @@ import { Description } from 'components/misc/Description';
 import { IconCorrect, IconIncorrect } from 'components/misc/Icons';
 import { CloseButton } from 'components/misc/CloseButton';
 import { ProjectSlug } from 'data/types';
+import * as Lang from 'utils/lang';
 
 interface ChoicesProps extends ModelEditorProps {
   onAddChoice: () => void;
@@ -37,10 +38,10 @@ export const Choices = ({ onAddChoice, onEditChoice, onRemoveChoice, editMode, m
 
   return (
     <div className="my-5">
-      <Heading title="Answer Choices"
-        subtitle="One correct answer choice and as many incorrect answer choices as you like." id="choices" />
+      <Heading title={Lang.dgettext('mcq', 'Answer Choices')}
+        subtitle={Lang.dgettext('mcq', 'One correct answer choice and as many incorrect answer choices as you like.')} id="choices" />
       <Description>
-        <IconCorrect /> Correct Choice
+        <IconCorrect /> {Lang.dgettext('mcq', 'Correct Choice')}
       </Description>
       <RichTextEditor
         className="mb-3"
@@ -50,7 +51,7 @@ export const Choices = ({ onAddChoice, onEditChoice, onRemoveChoice, editMode, m
       {incorrectChoices.map((choice, index) =>
         <React.Fragment key={choice.id}>
           <Description>
-            <IconIncorrect /> Incorrect Choice {index + 1}
+            <IconIncorrect /> {Lang.dgettext('mcq', 'Incorrect Choice')} {index + 1}
           </Description>
           <div className="d-flex mb-3">
             <RichTextEditor
@@ -68,7 +69,7 @@ export const Choices = ({ onAddChoice, onEditChoice, onRemoveChoice, editMode, m
       <button
         className="btn btn-sm btn-primary my-2"
         disabled={!editMode}
-        onClick={onAddChoice}>Add incorrect answer choice
+        onClick={onAddChoice}>{Lang.dgettext('mcq', 'Add incorrect answer choice')}
       </button>
     </div>
   );

--- a/assets/src/utils/i18n.ts
+++ b/assets/src/utils/i18n.ts
@@ -1,0 +1,246 @@
+/*! gettext.js - Guillaume Potier - MIT Licensed */
+
+  // default values that could be overriden in i18n() construct
+const defaults = {
+  domain: 'messages',
+  locale: (document !== undefined
+    ? document.documentElement.getAttribute('lang') : false) || 'en',
+  plural_func: (n: any) => {
+    return { nplurals: 2, plural: (n !== 1) ? 1 : 0 };
+  },
+  ctxt_delimiter: String.fromCharCode(4), // \u0004
+};
+
+// handy mixins taken from underscode.js
+const _ = {
+  isObject: (obj: any) => {
+    const type = typeof obj;
+    return type === 'function' || type === 'object' && !!obj;
+  },
+  isArray: (obj: any) => {
+    return toString.call(obj) === '[object Array]';
+  },
+};
+
+const pluralFuncs: any = {};
+let locale = defaults.locale;
+let domain = defaults.domain;
+const dictionary: any = {};
+const pluralForms: any = {};
+const ctxtDelimiter = defaults.ctxt_delimiter;
+
+  // sprintf equivalent, takes a string and some arguments to make a computed string
+  // eg: strfmt("%1 dogs are in %2", 7, "the kitchen"); => "7 dogs are in the kitchen"
+  // eg: strfmt("I like %1, bananas and %1", "apples"); => "I like apples, bananas and apples"
+  // NB: removes msg context if there is one present
+const strfmt = function (fmt: any) {
+  const args = arguments;
+
+  return fmt
+  // put space after double % to prevent placeholder replacement of such matches
+  .replace(/%%/g, '%% ')
+  // replace placeholders
+  .replace(/%(\d+)/g, (str: any, p1: any) => {
+    return args[p1];
+  })
+  // replace double % and space with single %
+  .replace(/%% /g, '%');
+};
+
+const removeContext = function (str: any) {
+  // if there is context, remove it
+  if (str.indexOf(ctxtDelimiter) !== -1) {
+    const parts = str.split(ctxtDelimiter);
+    return parts[1];
+  }
+
+  return str;
+};
+
+const expandLocale = function (localeParam: any) {
+  let locale = localeParam;
+  const locales = [locale];
+  let i = locale.lastIndexOf('-');
+  while (i > 0) {
+    locale = locale.slice(0, i);
+    locales.push(locale);
+    i = locale.lastIndexOf('-');
+  }
+  return locales;
+};
+
+const getPluralFunc = function (pluralForm: any) {
+  // Plural form string regexp
+  // taken from https://github.com/Orange-OpenSource/gettext.js/blob/master/lib.gettext.js
+  // plural forms list available here
+  // http://localization-guide.readthedocs.org/en/latest/l10n/pluralforms.html
+  const pfRe = new RegExp('^\\s*nplurals\\s*=\\s*[0-9]+\\s*;\\s*plural\\s*=\\s*(?:\\s|[-\\?\\|&=!<>+*/%:;n0-9_\(\)])+');
+
+  if (!pfRe.test(pluralForm)) {
+    throw new Error(`The plural form "${pluralForm}" is not valid`);
+  }
+
+  // Careful here, that is a hidden eval() equivalent..
+  // Risk should be reasonable though since we test the plural_form through regex before
+  // taken from https://github.com/Orange-OpenSource/gettext.js/blob/master/lib.gettext.js
+  // TODO: should test if https://github.com/soney/jsep present and use it if so
+  // tslint:disable-next-line
+  return new Function('n',
+    'var plural, nplurals; ' + pluralForm +
+    ' return { nplurals: nplurals, plural: (plural === true ? 1 : (plural ? plural : 0)) };');
+};
+
+  // Proper translation function that handle plurals and directives
+  // Contains juicy parts of
+  // https://github.com/Orange-OpenSource/gettext.js/blob/master/lib.gettext.js
+const t = function (messages: any, n: any, options: any) {
+  // Singular is very easy, just pass dictionnary message through strfmt
+  if (!options.plural_form) {
+    return strfmt.apply(undefined,
+      [removeContext(messages[0])].concat(Array.prototype.slice.call(arguments, 3)));
+  }
+  let plural;
+
+  // if a plural func is given, use that one
+  if (options.plural_func) {
+    plural = options.plural_func(n);
+
+  // if plural form never interpreted before, do it now and store it
+  } else if (!pluralFuncs[locale]) {
+    pluralFuncs[locale] = getPluralFunc(pluralForms[locale]);
+    plural = pluralFuncs[locale](n);
+
+  // we have the plural function, compute the plural result
+  } else {
+    plural = pluralFuncs[locale](n);
+  }
+
+  // If there is a problem with plurals, fallback to singular one
+  if (plural.plural === undefined || plural.plural > plural.nplurals
+    || messages.length <= plural.plural) {
+    plural.plural = 0;
+  }
+
+  return strfmt.apply(undefined,
+    [removeContext(messages[plural.plural]), n].concat(Array.prototype.slice.call(arguments, 3)));
+};
+
+export function setMessages(domain: any, locale: any, messages: any, pf: any) {
+  if (!domain || !locale || !messages) {
+    throw new Error('You must provide a domain, a locale and messages');
+  }
+
+  if ('string' !== typeof domain || 'string' !== typeof locale || !_.isObject(messages)) {
+    throw new Error('Invalid arguments');
+  }
+
+  if (pf) {
+    pluralForms[locale] = pf;
+  }
+
+  if (!dictionary[domain]) {
+    dictionary[domain] = {};
+  }
+
+  dictionary[domain][locale] = messages;
+}
+
+export function loadJSON(jsonDataP: any, domain: any) {
+  let jsonData;
+  if (!_.isObject(jsonDataP)) {
+    jsonData = JSON.parse(jsonDataP);
+  } else {
+    jsonData = jsonDataP;
+  }
+
+  if (!jsonData[''] || !jsonData['']['language'] || !jsonData['']['plural-forms']) {
+    throw new Error('Wrong JSON, it must have an empty key ("") with "language" and "plural-forms" information');
+  }
+
+  const headers = jsonData[''];
+  delete jsonData[''];
+
+  return setMessages(domain || defaults.domain, headers['language'], jsonData, headers['plural-forms']);
+}
+
+export function setLocale(loc: any) {
+  locale = loc;
+}
+export function getLocale() {
+  return locale;
+}
+  // getter/setter for domain
+export function textdomain(d: any) {
+  if (!d) {
+    return domain;
+  }
+  domain = d;
+}
+
+export function gettext(msgid: any) {
+  return dcnpgettext.apply(undefined,
+    [undefined, undefined, msgid, undefined, undefined].concat(
+      Array.prototype.slice.call(arguments, 1)));
+}
+
+export function ngettext(msgid: any, msgidPlural: any, n: any) {
+  return dcnpgettext.apply(undefined,
+    [undefined, undefined, msgid, msgidPlural, n].concat(
+      Array.prototype.slice.call(arguments, 3)));
+}
+
+export function pgettext(msgctxt: any, msgid: any) {
+  return dcnpgettext.apply(undefined,
+    [undefined, msgctxt, msgid, undefined, undefined].concat(
+      Array.prototype.slice.call(arguments, 2)));
+}
+
+export function dcnpgettext(d: any, msgctxt: any, msgid: any, msgidPlural: any, n: any) {
+  domain = d || domain;
+
+  if ('string' !== typeof msgid) {
+    throw new Error(`Msgid "${msgid}" is not a valid translatable string`);
+  }
+
+  let translation;
+  const options : any = { plural_form: false };
+  const key = msgctxt ? msgctxt + ctxtDelimiter + msgid : msgid;
+  let exist;
+  const locales = expandLocale(locale);
+
+  for (const i in locales) {
+    locale = locales[i];
+    exist = dictionary[domain] && dictionary[domain][locale] && dictionary[domain][locale][key];
+
+    // because it's not possible to define both a singular and a plural form of the same msgid,
+    // we need to check that the stored form is the same as the expected one.
+    // if not, we'll just ignore the translation and consider it as not translated.
+    if (msgidPlural) {
+      exist = exist && 'string' !== typeof dictionary[domain][locale][key];
+    } else {
+      exist = exist && 'string' === typeof dictionary[domain][locale][key];
+    }
+    if (exist) {
+      break;
+    }
+  }
+
+  if (!exist) {
+    translation = msgid;
+    options.plural_func = defaults.plural_func;
+  } else {
+    translation = dictionary[domain][locale][key];
+  }
+
+  // Singular form
+  if (!msgidPlural) {
+    return t.apply(undefined, [[translation], n, options].concat(
+      Array.prototype.slice.call(arguments, 5)));
+  }
+
+  // Plural one
+  options.plural_form = true;
+  return t.apply(undefined,
+    [exist ? translation : [msgid, msgidPlural], n, options].concat(
+      Array.prototype.slice.call(arguments, 5)));
+}

--- a/assets/src/utils/lang.ts
+++ b/assets/src/utils/lang.ts
@@ -1,0 +1,15 @@
+import * as i18n from './i18n';
+
+export function gettext(msgid: string) : string {
+  i18n.textdomain('default');
+  return i18n.gettext(msgid);
+}
+
+export function dgettext(domain: string, msgid: string) : string {
+  i18n.textdomain(domain);
+  return i18n.gettext(msgid);
+}
+
+export function ngettext(msgid: string, msgidPlural: any, n: any) : string {
+  return i18n.ngettext(msgid, msgidPlural, n);
+}

--- a/lib/oli_web/live/grades/export.ex
+++ b/lib/oli_web/live/grades/export.ex
@@ -1,10 +1,10 @@
 defmodule OliWeb.Grades.Export do
-  use Phoenix.LiveComponent
-
-  use Phoenix.HTML
-  alias OliWeb.Router.Helpers, as: Routes
+  use OliWeb, :live_component
 
   def render(assigns) do
+
+    link_text = dgettext("grades", "Export and Download Gradebook")
+
     ~L"""
     <div class="card">
       <div class="card-body">
@@ -15,7 +15,7 @@ defmodule OliWeb.Grades.Export do
       </div>
 
       <div class="card-footer">
-       <%= link "Export and Download Gradebook", to: Routes.page_delivery_path(OliWeb.Endpoint, :export_gradebook, @context_id), class: "btn btn-primary" %>
+       <%= link link_text, to: Routes.page_delivery_path(OliWeb.Endpoint, :export_gradebook, @context_id), class: "btn btn-primary" %>
       </div>
     </div>
     """

--- a/lib/oli_web/live/grades/grade_sync.ex
+++ b/lib/oli_web/live/grades/grade_sync.ex
@@ -1,5 +1,6 @@
 defmodule OliWeb.Grades.GradeSync do
-  use Phoenix.LiveComponent
+
+  use OliWeb, :live_component
 
   def render(assigns) do
 
@@ -9,15 +10,18 @@ defmodule OliWeb.Grades.GradeSync do
 
     <div class="card">
       <div class="card-body">
-        <h5 class="card-title">Synchronize LMS Grades</h5>
+        <h5 class="card-title"><%= dgettext("grades", "Synchronize LMS Grades") %></h5>
 
         <p class="card-text">
-        If an instructor changes the maximum score for an LMS gradebook line item <b>after</b> students
-        have submitted an attempt, it is necessary to synchronize the OLI grades for that LMS gradebook item.</p>
+          <%= dgettext("grades", "If an instructor changes the maximum score for an LMS gradebook line item after students
+          have submitted an attempt, it is necessary to synchronize the OLI grades for that LMS gradebook item.") %>
+        </p>
 
         <div class="alert alert-danger" role="alert">
-          <strong>Warning!</strong> This operation will overwrite any grades in the LMS gradebook that
-          were manually adjusted or overridden by the instructor.
+          <strong><%= dgettext("grades", "Warning!") %></strong>
+
+          <%= dgettext("grades", "This operation will overwrite any grades in the LMS gradebook that
+          were manually adjusted or overridden by the instructor.") %>
         </div>
 
         <select class="custom-select custom-select-lg mb-3">
@@ -30,7 +34,7 @@ defmodule OliWeb.Grades.GradeSync do
 
       <div class="card-footer">
 
-        <a class="btn btn-primary" phx-click="send_grades" <%= disabled %>>Synchronize LMS Grades</a>
+        <a class="btn btn-primary" phx-click="send_grades" <%= disabled %>><%= dgettext("grades", "Synchronize LMS Grades") %></a>
 
       </div>
     </div>

--- a/lib/oli_web/live/grades/grades.ex
+++ b/lib/oli_web/live/grades/grades.ex
@@ -1,7 +1,6 @@
 defmodule OliWeb.Grades.GradesLive do
 
-  use Phoenix.LiveView, layout: {OliWeb.LayoutView, "live.html"}
-  use Phoenix.HTML
+  use OliWeb, :live_view
 
   alias Oli.Grading
   alias Oli.Lti.LTI_AGS
@@ -48,9 +47,11 @@ defmodule OliWeb.Grades.GradesLive do
     end
 
     ~L"""
-    <h2>Manage Grades</h2>
+    <h2><%= dgettext("grades", "Manage Grades") %></h2>
 
-    <p>Grades for OLI graded pages for this course are accessed by students and instructors from the LMS gradebook at <a href="<%= iss %>"><%= iss %></a>.</p>
+    <p>
+      <%= dgettext("grades", "Grades for OLI graded pages for this course are accessed by students and instructors from the LMS gradebook at") %> <a href="<%= iss %>"><%= iss %></a>.
+    </p>
 
     <div class="card-group">
 
@@ -61,7 +62,7 @@ defmodule OliWeb.Grades.GradesLive do
     </div>
 
     <div class="mt-4 <%= progress_visible %>">
-      <p>Do not leave this page until this operation completes.</p>
+      <p><%= dgettext("grades", "Do not leave this page until this operation completes.") %></p>
       <div class="progress">
         <div class="progress-bar" role="progressbar" style="width: <%= percent_progress %>%;" aria-valuenow="<%= percent_progress %>" aria-valuemin="0" aria-valuemax="100">
       </div>
@@ -189,7 +190,7 @@ defmodule OliWeb.Grades.GradesLive do
 
         case determine_line_item_tasks(graded_pages, line_items) do
 
-          [] -> {:noreply, put_flash(socket, :info, "LMS line items already up to date")}
+          [] -> {:noreply, put_flash(socket, :info, dgettext("grades", "LMS line items already up to date"))}
 
           task_queue ->
 
@@ -246,10 +247,10 @@ defmodule OliWeb.Grades.GradesLive do
         case LTI_AGS.fetch_line_items(line_items_url, access_token) do
 
           {:ok, line_items} -> {:ok, line_items, access_token}
-          _ -> {:error, "Error accessing LMS line items"}
+          _ -> {:error, dgettext("grades", "Error accessing LMS line items")}
         end
 
-      _ -> {:error, "Error getting LMS access token"}
+      _ -> {:error, dgettext("grades", "Error getting LMS access token")}
 
     end
 
@@ -273,7 +274,7 @@ defmodule OliWeb.Grades.GradesLive do
           send(self(), :pop_task_queue)
           socket
         else
-          socket |> put_flash(:info, "LMS up to date")
+          socket |> put_flash(:info, dgettext("grades", "LMS up to date"))
         end
 
         {:noreply, assign(socket, task_queue: task_queue, progress_current: socket.assigns.progress_current + 1)}

--- a/lib/oli_web/live/grades/line_items.ex
+++ b/lib/oli_web/live/grades/line_items.ex
@@ -1,5 +1,5 @@
 defmodule OliWeb.Grades.LineItems do
-  use Phoenix.LiveComponent
+  use OliWeb, :live_component
 
   def render(assigns) do
 
@@ -9,16 +9,19 @@ defmodule OliWeb.Grades.LineItems do
 
     <div class="card">
       <div class="card-body">
-        <h5 class="card-title">Update LMS Line Items</h5>
+        <h5 class="card-title"><%= dgettext("grades", "Update LMS Line Items") %></h5>
 
         <p class="card-text">
-        While OLI automatically will create LMS gradebook line items as students complete assignments,
-        in some circumstances an instructor may want to explicitly create gradebook line items or update them.</p>
+
+        <%= dgettext("grades", "While OLI automatically will create LMS gradebook line items as students complete assignments,
+        in some circumstances an instructor may want to explicitly create gradebook line items or update them.") %>
+
+        </p>
 
       </div>
 
       <div class="card-footer">
-        <a class="btn btn-primary" phx-click="send_line_items" <%= disabled %>>Update LMS Line Items</a>
+        <a class="btn btn-primary" phx-click="send_line_items" <%= disabled %>><%= dgettext("grades", "Update LMS Line Items") %></a>
       </div>
     </div>
 

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -1,0 +1,21 @@
+## This file is a PO Template file.
+##
+## "msgid"s here are often extracted from source code.
+## Add new translations manually only if they're dynamic
+## translations that can't be statically extracted.
+##
+## Run "mix gettext.extract" to bring this file up to
+## date. Leave "msgstr"s empty as changing them here as no
+## effect: edit them in PO (.po) files instead.
+msgid ""
+msgstr ""
+
+#, elixir-format
+#: lib/oli_web/templates/static_page/index.html.eex:4
+msgid "Welcome back %{name}!"
+msgstr ""
+
+#, elixir-format
+#: lib/oli_web/templates/static_page/index.html.eex:7
+msgid "Welcome to %{name}!"
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -1,0 +1,22 @@
+## "msgid"s in this file come from POT (.pot) files.
+##
+## Do not add, change, or remove "msgid"s manually here as
+## they're tied to the ones in the corresponding POT file
+## (with the same domain).
+##
+## Use "mix gettext.extract --merge" or "mix gettext.merge"
+## to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: en\n"
+"Plural-Forms: nplurals=2\n"
+
+#, elixir-format
+#: lib/oli_web/templates/static_page/index.html.eex:4
+msgid "Welcome back %{name}!"
+msgstr ""
+
+#, elixir-format
+#: lib/oli_web/templates/static_page/index.html.eex:7
+msgid "Welcome to %{name}!"
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/grades.po
+++ b/priv/gettext/en/LC_MESSAGES/grades.po
@@ -1,0 +1,84 @@
+## "msgid"s in this file come from POT (.pot) files.
+##
+## Do not add, change, or remove "msgid"s manually here as
+## they're tied to the ones in the corresponding POT file
+## (with the same domain).
+##
+## Use "mix gettext.extract --merge" or "mix gettext.merge"
+## to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: en\n"
+"Plural-Forms: nplurals=2\n"
+
+#, elixir-format
+#: lib/oli_web/live/grades/grade_sync.ex:13
+#: lib/oli_web/live/grades/grade_sync.ex:37
+msgid "Synchronize LMS Grades"
+msgstr ""
+
+#, elixir-format
+#: lib/oli_web/live/grades/grades.ex:65
+msgid "Do not leave this page until this operation completes."
+msgstr ""
+
+#, elixir-format
+#: lib/oli_web/live/grades/grades.ex:250
+msgid "Error accessing LMS line items"
+msgstr ""
+
+#, elixir-format
+#: lib/oli_web/live/grades/grades.ex:253
+msgid "Error getting LMS access token"
+msgstr ""
+
+#, elixir-format
+#: lib/oli_web/live/grades/export.ex:6
+msgid "Export and Download Gradebook"
+msgstr ""
+
+#, elixir-format
+#: lib/oli_web/live/grades/grades.ex:53
+msgid "Grades for OLI graded pages for this course are accessed by students and instructors from the LMS gradebook at"
+msgstr ""
+
+#, elixir-format
+#: lib/oli_web/live/grades/grade_sync.ex:16
+msgid "If an instructor changes the maximum score for an LMS gradebook line item after students\n      have submitted an attempt, it is necessary to synchronize the OLI grades for that LMS gradebook item."
+msgstr ""
+
+#, elixir-format
+#: lib/oli_web/live/grades/grades.ex:193
+msgid "LMS line items already up to date"
+msgstr ""
+
+#, elixir-format
+#: lib/oli_web/live/grades/grades.ex:277
+msgid "LMS up to date"
+msgstr ""
+
+#, elixir-format
+#: lib/oli_web/live/grades/grades.ex:50
+msgid "Manage Grades"
+msgstr ""
+
+#, elixir-format
+#: lib/oli_web/live/grades/grade_sync.ex:23
+msgid "This operation will overwrite any grades in the LMS gradebook that\n      were manually adjusted or overridden by the instructor."
+msgstr ""
+
+#, elixir-format
+#: lib/oli_web/live/grades/line_items.ex:12
+#: lib/oli_web/live/grades/line_items.ex:24
+msgid "Update LMS Line Items"
+msgstr ""
+
+#, elixir-format
+#: lib/oli_web/live/grades/grade_sync.ex:21
+msgid "Warning!"
+msgstr ""
+
+#, elixir-format
+#: lib/oli_web/live/grades/line_items.ex:16
+msgid "While OLI automatically will create LMS gradebook line items as students complete assignments,\n    in some circumstances an instructor may want to explicitly create gradebook line items or update them."
+msgstr ""

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -7,7 +7,6 @@
 ## Run `mix gettext.extract` to bring this file up to
 ## date. Leave `msgstr`s empty as changing them here has no
 ## effect: edit them in PO (`.po`) files instead.
-
 ## From Ecto.Changeset.cast/4
 msgid "can't be blank"
 msgstr ""

--- a/priv/gettext/grades.pot
+++ b/priv/gettext/grades.pot
@@ -1,0 +1,83 @@
+## This file is a PO Template file.
+##
+## "msgid"s here are often extracted from source code.
+## Add new translations manually only if they're dynamic
+## translations that can't be statically extracted.
+##
+## Run "mix gettext.extract" to bring this file up to
+## date. Leave "msgstr"s empty as changing them here as no
+## effect: edit them in PO (.po) files instead.
+msgid ""
+msgstr ""
+
+#, elixir-format
+#: lib/oli_web/live/grades/grade_sync.ex:13
+#: lib/oli_web/live/grades/grade_sync.ex:37
+msgid "Synchronize LMS Grades"
+msgstr ""
+
+#, elixir-format
+#: lib/oli_web/live/grades/grades.ex:65
+msgid "Do not leave this page until this operation completes."
+msgstr ""
+
+#, elixir-format
+#: lib/oli_web/live/grades/grades.ex:250
+msgid "Error accessing LMS line items"
+msgstr ""
+
+#, elixir-format
+#: lib/oli_web/live/grades/grades.ex:253
+msgid "Error getting LMS access token"
+msgstr ""
+
+#, elixir-format
+#: lib/oli_web/live/grades/export.ex:6
+msgid "Export and Download Gradebook"
+msgstr ""
+
+#, elixir-format
+#: lib/oli_web/live/grades/grades.ex:53
+msgid "Grades for OLI graded pages for this course are accessed by students and instructors from the LMS gradebook at"
+msgstr ""
+
+#, elixir-format
+#: lib/oli_web/live/grades/grade_sync.ex:16
+msgid "If an instructor changes the maximum score for an LMS gradebook line item after students\n      have submitted an attempt, it is necessary to synchronize the OLI grades for that LMS gradebook item."
+msgstr ""
+
+#, elixir-format
+#: lib/oli_web/live/grades/grades.ex:193
+msgid "LMS line items already up to date"
+msgstr ""
+
+#, elixir-format
+#: lib/oli_web/live/grades/grades.ex:277
+msgid "LMS up to date"
+msgstr ""
+
+#, elixir-format
+#: lib/oli_web/live/grades/grades.ex:50
+msgid "Manage Grades"
+msgstr ""
+
+#, elixir-format
+#: lib/oli_web/live/grades/grade_sync.ex:23
+msgid "This operation will overwrite any grades in the LMS gradebook that\n      were manually adjusted or overridden by the instructor."
+msgstr ""
+
+#, elixir-format
+#: lib/oli_web/live/grades/line_items.ex:12
+#: lib/oli_web/live/grades/line_items.ex:24
+msgid "Update LMS Line Items"
+msgstr ""
+
+#, elixir-format
+#: lib/oli_web/live/grades/grade_sync.ex:21
+msgid "Warning!"
+msgstr ""
+
+#, elixir-format
+#: lib/oli_web/live/grades/line_items.ex:16
+msgid "While OLI automatically will create LMS gradebook line items as students complete assignments,\n    in some circumstances an instructor may want to explicitly create gradebook line items or update them."
+msgstr ""


### PR DESCRIPTION
This PR introduces just enough i18n infrastructure so that we can begin converting wrapping static strings inside of `gettext` function calls. 

The server side of this impl is straightforward usage of the elixir gettext lib. 

The client side, however, is more convoluted. The gettext.js library was not usable out of the box as an ES6 module within our app.  I tried all sorts of approaches, but in the end I punted and simply "cloned and owned" the 200 or so lines of source of the lib into our codebase.  Even that required a few hours of rework.  Also, it's API doesn't match the server side gettext exactly, so I introduced a thin layer on top of it (found in `utils/lang.ts`) to match the server side API.

This PR includes example usage in UIs in both the client and server side.

Future work will need to be done if and when we actually want to do a translation. We will need to detect the locale from user agent header and pass that along through to the UIs on the server side. In addition, that detected UI, if supported, has to be written as the `lang` attr of the page `html` element. Also, of course, the `.po` files for all supported languages have to be generated and authored.  Finally, for the client-side domains, JSON files have to be generated from the `.po` files using the tool found in the gettext.js lib.  