### PR TITLE
create registrations in dev mode from json file if available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ postgres.env
 assets/yarn.lock
 lib/oli/analytics/test.xml
 .devcontainer
+registrations.json

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -10,3 +10,22 @@
 When the system generates email in production, generally it will be handed to an email service such as Amazon SES. Any email service supported by Bamboo can be configured in config/prod.exs. Refer to the Bamboo and Pow docs to see a list of all supported email adapters and how to configure them https://hexdocs.pm/pow/configuring_mailer.html#content, https://hexdocs.pm/bamboo/readme.html
 
 In development mode, the system will use the Bamboo.LocalAdapter mailer, which stores sent mail in memory and is accessible via web browser at `https://localhost/dev/sent_emails`. There is also a specific test adapter configured for unit testing.
+
+## Create Registrations from seed
+
+To ease the burden of creating a new registration after every database reset, there is the option to automatically create LTI registrations
+attached to the default institution in dev environment by creating a registrations.json file in the project root.
+
+Example:
+```
+[{
+  "issuer": "https://canvas.oli.cmu.edu",
+  "client_id": "XXXXXXXXXXXXX",
+  "key_set_url": "https://canvas.oli.cmu.edu/api/lti/security/jwks",
+  "auth_token_url": "https://canvas.oli.cmu.edu/login/oauth2/token",
+  "auth_login_url": "https://canvas.oli.cmu.edu/api/lti/authorize_redirect",
+  "auth_server": "https://canvas.oli.cmu.edu"
+}]
+```
+
+With this file, now when you run `mix ecto.seed` or `mix ecto.reset`, a registration with these details will be created for you.

--- a/lib/oli/utils.ex
+++ b/lib/oli/utils.ex
@@ -68,4 +68,10 @@ defmodule Oli.Utils do
         changeset
     end
   end
+
+  def read_json_file(filename) do
+    with {:ok, body} <- File.read(filename),
+        {:ok, json} <- Poison.decode(body), do: {:ok, json}
+  end
+
 end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -156,6 +156,7 @@ if Application.fetch_env!(:oli, :env) == :dev do
         end)
       _ ->
         # no registrations.json file, do nothing
+        nil
     end
   end
 

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -11,6 +11,7 @@
 # and so on) as they will fail if something goes wrong.
 
 alias Oli.Seeder
+alias Oli.Utils
 alias Oli.Snapshots.SnapshotSeeder
 alias Oli.Authoring.Collaborators
 
@@ -138,6 +139,24 @@ if Application.fetch_env!(:oli, :env) == :dev do
     Collaborators.add_collaborator(admin_author, seeds.project)
 
     Oli.Publishing.publish_project(seeds.project)
+
+    # create any registrations defined in registrations.json
+    case Utils.read_json_file("./registrations.json") do
+      {:ok, json} ->
+        %{id: jwk_id} = Oli.Lti_1p3.get_active_jwk()
+
+        json
+        |> Enum.each(fn attrs ->
+          attrs = attrs
+          |> Map.merge(%{"tool_jwk_id" => jwk_id, "institution_id" => 1})
+
+          %Oli.Lti_1p3.Registration{}
+          |> Oli.Lti_1p3.Registration.changeset(attrs)
+          |> Oli.Repo.insert()
+        end)
+      _ ->
+        # no registrations.json file, do nothing
+    end
   end
 
 end


### PR DESCRIPTION
This PR add the ability to automatically seed registrations in dev mode using a registrations.json file in the root of the project. If no file exists, no registration will be created.

Example registrations.json
```
[{
  "issuer": "https://canvas.oli.cmu.edu",
  "client_id": "XXXXXXXXXXXXX",
  "key_set_url": "https://canvas.oli.cmu.edu/api/lti/security/jwks",
  "auth_token_url": "https://canvas.oli.cmu.edu/login/oauth2/token",
  "auth_login_url": "https://canvas.oli.cmu.edu/api/lti/authorize_redirect",
  "auth_server": "https://canvas.oli.cmu.edu"
}]
```