### PR TITLE
Fix Datashop tests

### DIFF
--- a/lib/oli/analytics/datashop/elements/event_descriptor.ex
+++ b/lib/oli/analytics/datashop/elements/event_descriptor.ex
@@ -45,7 +45,8 @@ defmodule Oli.Analytics.Datashop.Elements.EventDescriptor do
 
           case activity_type(part_attempt) do
             # for short answer questions, the input is the text the student entered in the field
-            "oli_short_answer" -> input
+            "oli_short_answer" ->
+              input
               |> Utils.parse_content
             # for multiple choice questions, the input is a string id that refers to the selected choice
             "oli_multiple_choice" ->
@@ -57,13 +58,21 @@ defmodule Oli.Analytics.Datashop.Elements.EventDescriptor do
                 _ -> Utils.parse_content(content)
               end
             "oli_check_all_that_apply" ->
+              # CATA Input includes all selected choices as "id1 id2 id3"
+              selected_choices = String.split(input, " ")
               choices = part_attempt.activity_attempt.transformed_model["choices"]
-              content = Enum.find(choices, & &1["id"] == input)["content"]
+              contents = choices
+              |> Enum.filter(fn choice -> Enum.find(selected_choices,
+                fn selected_id -> choice["id"] == selected_id end)
+              end)
+              |> Enum.map(fn choice -> choice["content"] end)
 
-              case content do
-                %{"model" => model} -> Utils.parse_content(model)
-                _ -> Utils.parse_content(content)
-              end
+              contents
+              |> Enum.map(fn content_item -> case content_item do
+                  %{"model" => model} -> Utils.parse_content(model)
+                  _ -> Utils.parse_content(content_item)
+                end
+              end)
             # fallback for future activity types
             _unregistered -> "Input in unregistered activity type: " <> input
           end
@@ -75,8 +84,13 @@ defmodule Oli.Analytics.Datashop.Elements.EventDescriptor do
           end
       end
     rescue
-      _e -> Logger.error("Error in EventDescriptor.get_input. Type: #{type}, part attempt: #{Kernel.inspect(part_attempt)}")
-      "The input that created this event could not be found."
+      e ->
+        Logger.error(e)
+        Logger.error("""
+        Error in EventDescriptor.get_input.
+        Type: #{type}, part attempt: #{Kernel.inspect(part_attempt)}"
+        The input that created this event could not be found.
+        """)
     end
   end
 

--- a/lib/oli/lti/lti_ags.ex
+++ b/lib/oli/lti/lti_ags.ex
@@ -110,10 +110,6 @@ defmodule Oli.Lti.LTI_AGS do
     with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <- HTTPoison.get(url, headers(access_token)),
       {:ok, results} <- Jason.decode(body)
     do
-
-      IO.inspect headers(access_token)
-      IO.inspect results
-
       {:ok, Enum.map(results, fn r -> to_line_item(r) end)}
     else
       e ->

--- a/lib/oli/utils/db_seeder.ex
+++ b/lib/oli/utils/db_seeder.ex
@@ -5,6 +5,7 @@ defmodule Oli.Seeder do
   alias Oli.Institutions.Institution
   alias Oli.Delivery.Attempts
   alias Oli.Delivery.Attempts.{ResourceAccess}
+  alias Oli.Activities
   alias Oli.Activities.Model.Part
   alias Oli.Authoring.Authors.{AuthorProject, ProjectRole}
   alias Oli.Authoring.Course.{Project, Family}
@@ -385,7 +386,7 @@ defmodule Oli.Seeder do
 
     {:ok, resource} = Oli.Resources.Resource.changeset(%Oli.Resources.Resource{}, %{}) |> Repo.insert
 
-    attrs = Map.merge(%{activity_type_id: 1, author_id: author.id, objectives: %{ "attached" => []}, scoring_strategy_id: Oli.Resources.ScoringStrategy.get_id_by_type("best"), resource_type_id: Oli.Resources.ResourceType.get_id_by_type("activity"), children: [], content: %{}, deleted: false, title: "test", resource_id: resource.id}, attrs)
+    attrs = Map.merge(%{activity_type_id: Activities.get_registration_by_slug("oli_multiple_choice").id, author_id: author.id, objectives: %{ "attached" => []}, scoring_strategy_id: Oli.Resources.ScoringStrategy.get_id_by_type("best"), resource_type_id: Oli.Resources.ResourceType.get_id_by_type("activity"), children: [], content: %{}, deleted: false, title: "test", resource_id: resource.id}, attrs)
 
     {:ok, revision} = Oli.Resources.create_revision(attrs)
     {:ok, _} = Oli.Authoring.Course.ProjectResource.changeset(%Oli.Authoring.Course.ProjectResource{}, %{project_id: project.id, resource_id: resource.id}) |> Repo.insert
@@ -403,7 +404,7 @@ defmodule Oli.Seeder do
 
     {:ok, resource} = Oli.Resources.Resource.changeset(%Oli.Resources.Resource{}, %{}) |> Repo.insert
 
-    attrs = Map.merge(%{activity_type_id: 1, author_id: author.id, objectives: %{}, scoring_strategy_id: Oli.Resources.ScoringStrategy.get_id_by_type("best"), resource_type_id: Oli.Resources.ResourceType.get_id_by_type("activity"), children: [], content: %{}, deleted: false, title: "test", resource_id: resource.id}, attrs)
+    attrs = Map.merge(%{activity_type_id: Activities.get_registration_by_slug("oli_multiple_choice").id, author_id: author.id, objectives: %{}, scoring_strategy_id: Oli.Resources.ScoringStrategy.get_id_by_type("best"), resource_type_id: Oli.Resources.ResourceType.get_id_by_type("activity"), children: [], content: %{}, deleted: false, title: "test", resource_id: resource.id}, attrs)
 
     {:ok, revision} = Oli.Resources.create_revision(attrs)
     {:ok, _} = Oli.Authoring.Course.ProjectResource.changeset(%Oli.Authoring.Course.ProjectResource{}, %{project_id: project.id, resource_id: resource.id}) |> Repo.insert
@@ -424,7 +425,7 @@ defmodule Oli.Seeder do
 
     {:ok, resource} = Oli.Resources.Resource.changeset(%Oli.Resources.Resource{}, %{}) |> Repo.insert
 
-    attrs = Map.merge(%{activity_type_id: 1, author_id: author.id, objectives: %{ "attached" => []}, scoring_strategy_id: Oli.Resources.ScoringStrategy.get_id_by_type("best"), resource_type_id: Oli.Resources.ResourceType.get_id_by_type("activity"), children: [], content: %{}, deleted: false, title: "test", resource_id: resource.id}, attrs)
+    attrs = Map.merge(%{activity_type_id: Activities.get_registration_by_slug("oli_multiple_choice").id, author_id: author.id, objectives: %{ "attached" => []}, scoring_strategy_id: Oli.Resources.ScoringStrategy.get_id_by_type("best"), resource_type_id: Oli.Resources.ResourceType.get_id_by_type("activity"), children: [], content: %{}, deleted: false, title: "test", resource_id: resource.id}, attrs)
 
     {:ok, revision} = Oli.Resources.create_revision(attrs)
     {:ok, _} = Oli.Authoring.Course.ProjectResource.changeset(%Oli.Authoring.Course.ProjectResource{}, %{project_id: project.id, resource_id: resource.id}) |> Repo.insert

--- a/test/oli/datashop_test.exs
+++ b/test/oli/datashop_test.exs
@@ -4,6 +4,7 @@ defmodule Oli.DatashopTest do
   alias Oli.Analytics.Datashop
   alias Oli.Activities.Model.Part
   alias Oli.Publishing
+  alias Oli.Activities
 
   describe "datashop" do
 
@@ -418,8 +419,8 @@ defmodule Oli.DatashopTest do
       |> Seeder.add_users_to_section(:section, [:user1, :user2, :user3])
 
       map = map
-      |> Seeder.add_activity(%{title: "one", content: mc_content, objectives: %{ "1" => [map.o1.resource.id] }}, :mc1)
-      |> Seeder.add_activity(%{title: "two", content: sa_content, objectives: %{ "1" => [map.o2.resource.id, map.o3.resource.id] }, activity_type_id: 2}, :sa1)
+      |> Seeder.add_activity(%{title: "one", content: mc_content, objectives: %{ "1" => [map.o1.resource.id] }, activity_type_id: Activities.get_registration_by_slug("oli_multiple_choice").id}, :mc1)
+      |> Seeder.add_activity(%{title: "two", content: sa_content, objectives: %{ "1" => [map.o2.resource.id, map.o3.resource.id] }, activity_type_id: Activities.get_registration_by_slug("oli_short_answer").id}, :sa1)
 
       Publishing.publish_project(map.project)
 

--- a/test/oli/delivery/page/activity_context_test.exs
+++ b/test/oli/delivery/page/activity_context_test.exs
@@ -38,8 +38,8 @@ defmodule Oli.Delivery.Page.ActivityContextTest do
 
       assert length(Map.keys(m)) == 1
       assert Map.get(m, a1.resource.id).model == "{&quot;stem&quot;:&quot;1&quot;}"
-      assert Map.get(m, a1.resource.id).delivery_element == "oli-check-all-that-apply-delivery"
-      assert Map.get(m, a1.resource.id).script == "oli_check_all_that_apply_delivery.js"
+      assert Map.get(m, a1.resource.id).delivery_element == "oli-multiple-choice-delivery"
+      assert Map.get(m, a1.resource.id).script == "oli_multiple_choice_delivery.js"
 
     end
 

--- a/test/oli/registrar_test.exs
+++ b/test/oli/registrar_test.exs
@@ -8,7 +8,7 @@ defmodule Oli.RegistrarTest do
     test "register_local_activities/0 registers", _ do
 
       registrations = Activities.list_activity_registrations()
-      assert length(registrations) == 3
+      assert length(registrations) == 4
 
       r = hd(registrations)
 
@@ -25,7 +25,7 @@ defmodule Oli.RegistrarTest do
 
       map = Activities.create_registered_activity_map()
 
-      assert (Map.keys(map) |> length) == 3
+      assert (Map.keys(map) |> length) == 4
 
       r = Map.get(map, "oli_check_all_that_apply")
 

--- a/test/oli/registrar_test.exs
+++ b/test/oli/registrar_test.exs
@@ -8,7 +8,7 @@ defmodule Oli.RegistrarTest do
     test "register_local_activities/0 registers", _ do
 
       registrations = Activities.list_activity_registrations()
-      assert length(registrations) == 4
+      assert length(registrations) == 3
 
       r = hd(registrations)
 
@@ -25,7 +25,7 @@ defmodule Oli.RegistrarTest do
 
       map = Activities.create_registered_activity_map()
 
-      assert (Map.keys(map) |> length) == 4
+      assert (Map.keys(map) |> length) == 3
 
       r = Map.get(map, "oli_check_all_that_apply")
 


### PR DESCRIPTION
The problem was that registering new activity types changed the order of ids, so anywhere that we had a hardcoded activity type id that expected an activity of a certain type to be created was failing.