### PR TITLE
register new local activities during seeding, update existing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.1 (2021-1-4)
+### Bug fixes
+  - Fix an issue where new local activities were not being registered on deployment
+
 ## 0.4.0 (2021-1-4)
 ### Enhancements
   - Add support for check all that apply activity

--- a/lib/oli/activities.ex
+++ b/lib/oli/activities.ex
@@ -10,7 +10,8 @@ defmodule Oli.Activities do
   alias Oli.Activities.Registration
 
   def register_activity(%Manifest{} = manifest) do
-    create_registration(%{
+
+    attrs = %{
       authoring_script: manifest.id <> "_authoring.js",
       authoring_element: manifest.authoring.element,
       delivery_script: manifest.id <> "_delivery.js",
@@ -19,7 +20,13 @@ defmodule Oli.Activities do
       title: manifest.friendlyName,
       icon: "nothing",
       slug: manifest.id,
-    })
+    }
+
+    case get_registration_by_slug(attrs.slug) do
+      nil -> create_registration(attrs)
+      registration -> update_registration(registration, attrs)
+    end
+
   end
 
   def create_registered_activity_map() do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Oli.MixProject do
   def project do
     [
       app: :oli,
-      version: "0.4.0",
+      version: "0.4.1",
       elixir: "~> 1.11",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -74,9 +74,7 @@ if !Oli.Repo.get_by(Oli.Resources.ScoringStrategy, id: 1) do
 end
 
 # Seed the database with the locally implemented activity types
-if Enum.empty?(Oli.Activities.list_activity_registrations()) do
-  Oli.Registrar.register_local_activities()
-end
+Oli.Registrar.register_local_activities()
 
 # create themes
 [%Oli.Authoring.Theme{


### PR DESCRIPTION
This PR turns the `Oli.Registrar.register_local_activities()` function into an operation that is safe to run during every seeding. It will create new local activity registrations for new activities that are present and update records for existing ones that may have changed.