### PR TITLE
remove open and free selection

### DIFF
--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -55,17 +55,12 @@ defmodule OliWeb.DeliveryController do
   defp render_configure_section(conn, context_id, author) do
     publications = Publishing.available_publications(author)
     my_publications = publications |> Enum.filter(fn p -> !p.open_and_free && p.published end)
-    open_and_free_publications = publications |> Enum.filter(fn p -> p.open_and_free && p.published end)
-    render(conn, "configure_section.html", context_id: context_id, author: author, my_publications: my_publications, open_and_free_publications: open_and_free_publications)
+
+    render(conn, "configure_section.html", context_id: context_id, author: author, my_publications: my_publications)
   end
 
   defp redirect_to_page_delivery(conn, section) do
     redirect(conn, to: Routes.page_delivery_path(conn, :index, section.context_id))
-  end
-
-  def list_open_and_free(conn, _params) do
-    open_and_free_publications = Publishing.available_publications()
-    render(conn, "configure_section.html", open_and_free_publications: open_and_free_publications)
   end
 
   def link_account(conn, _params) do

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -306,7 +306,6 @@ defmodule OliWeb.Router do
 
     post "/section", DeliveryController, :create_section
     get "/signout", DeliveryController, :signout
-    get "/open_and_free", DeliveryController, :list_open_and_free
 
     get "/unauthorized", DeliveryController, :unauthorized
 

--- a/lib/oli_web/templates/delivery/configure_section.html.eex
+++ b/lib/oli_web/templates/delivery/configure_section.html.eex
@@ -59,35 +59,6 @@ $(function() {
       </div>
     <% end %>
 
-    <div class="my-5">
-      <h4>Open and Free</h4>
-        <%= if Enum.count(@open_and_free_publications) > 0 do %>
-          <table class="table table-hover">
-            <thead>
-              <tr>
-                <th scope="col" style="width: 5%"></th>
-                <th scope="col" style="width: 50%">Title</th>
-                <th scope="col" style="width: 15%">Version</th>
-                <th scope="col" style="width: 30%">Date Published</th>
-              </tr>
-            </thead>
-            <tbody>
-              <%= for pub <- @open_and_free_publications do %>
-                <tr>
-                  <td><input type="checkbox" name="publication_id" value="<%= pub.id %>"></td>
-                  <td><%= pub.project.title %></td>
-                  <td><%= pub.project.version %></td>
-                  <td><%= format_datetime(pub.inserted_at) %></td>
-                </tr>
-              <% end %>
-            </tbody>
-          </table>
-        <% else %>
-          <p class="my-3 text-center text-secondary">
-          There are no published open and free courses
-          </p>
-        <% end %>
-    </div>
     <div class="text-center">
       <%= submit "Select and Continue", id: "select-submit", class: "btn btn-primary", disabled: true %>
     </div>

--- a/lib/oli_web/templates/delivery/getting_started.html.eex
+++ b/lib/oli_web/templates/delivery/getting_started.html.eex
@@ -27,11 +27,5 @@ $(function() {
         <p class="card-text">If you have not previously created an account and would like to author your own course project, click here to create a new account</p>
       </div>
     </a>
-    <a style="pointer-events: none; background-color: #e9ecef; color: #495057;" href="<%= Routes.delivery_path(@conn, :list_open_and_free) %>" class="card btn-card">
-      <div class="card-body">
-        <h5 class="card-title">Select an Open and Free Course</h5>
-        <p class="card-text">If you would like to create a course section from an Open and Free course, click here</p>
-      </div>
-    </a>
   </div>
 </div>

--- a/test/oli_web/controllers/delivery_controller_test.exs
+++ b/test/oli_web/controllers/delivery_controller_test.exs
@@ -74,52 +74,6 @@ defmodule OliWeb.DeliveryControllerTest do
 
   end
 
-  describe "delivery_controller list_open_and_free" do
-    setup [:setup_session]
-
-    test "renders a list of all open and free courses", %{conn: conn, user: user, author: author} do
-
-      Oli.Accounts.link_user_author_account(user, author)
-
-      {:ok, _publication} = project_fixture(author, "Open and Free 1")
-        |> case do
-          %{project: project} -> project
-        end
-        |> Oli.Publishing.publish_project()
-        |> case do
-          {:ok, p} -> p
-        end
-        |> Oli.Publishing.update_publication(%{open_and_free: true})
-
-      {:ok, _publication} = project_fixture(author, "Open and Free 2")
-        |> case do
-          %{project: project} -> project
-        end
-        |> Oli.Publishing.publish_project()
-        |> case do
-          {:ok, p} -> p
-        end
-        |> Oli.Publishing.update_publication(%{open_and_free: true})
-
-      {:ok, _publication} = project_fixture(author, "Not Open and Free")
-        |> case do
-          %{project: project} -> project
-        end
-        |> Oli.Publishing.publish_project()
-        |> case do
-          {:ok, p} -> p
-        end
-        |> Oli.Publishing.update_publication(%{open_and_free: false})
-
-      conn = conn
-        |> get(Routes.delivery_path(conn, :list_open_and_free))
-
-      assert html_response(conn, 200) =~ "Open and Free 1"
-      assert html_response(conn, 200) =~ "Open and Free 2"
-      assert (html_response(conn, 200) =~ "Not Open and Free") == false
-    end
-  end
-
   describe "delivery_controller link_account" do
     setup [:setup_session]
 


### PR DESCRIPTION
This PR removes the display of "Open and Free" courses from both the "Getting Started" page and the "Create Section" page. 

It leaves the infrastructure (the db field and schema reference) in place in case we want to repurpose it once we figure out a longer term plan for how to handle open and free courses. 

Closes #281 