### PR TITLE
fix migration script

### DIFF
--- a/lib/oli_web/controllers/lti_controller.ex
+++ b/lib/oli_web/controllers/lti_controller.ex
@@ -205,7 +205,7 @@ defmodule OliWeb.LtiController do
         })
 
         conn
-        |> render("registration_pending.html")
+        |> render("registration_pending.html", pending_registration: pending_registration)
 
       {:error, changeset} ->
         conn
@@ -237,9 +237,9 @@ defmodule OliWeb.LtiController do
           issuer: issuer,
           client_id: client_id)
 
-      _registration ->
+      pending_registration ->
         conn
-        |> render("registration_pending.html")
+        |> render("registration_pending.html", pending_registration: pending_registration)
     end
   end
 

--- a/lib/oli_web/templates/email/registration_approved.html.eex
+++ b/lib/oli_web/templates/email/registration_approved.html.eex
@@ -40,7 +40,7 @@
                         <br />
 
                         <p style="margin: 0;">
-                          You can now access course materials from OLI <a href="<%= @registration.issuer %>" target="_blank">using your institution's LMS</a>.
+                          You can now access OLI course materials from <a href="<%= @registration.issuer %>" target="_blank">your institution's LMS</a>.
                         </p>
 
                     </td>

--- a/lib/oli_web/templates/lti/registration_pending.html.eex
+++ b/lib/oli_web/templates/lti/registration_pending.html.eex
@@ -2,13 +2,40 @@
 
 <div class="container form-container">
   <div class="row my-3">
-    <h2>Registration is pending approval</h2>
+    <h2>Registration Requested</h2>
   </div>
 
   <div class="row">
     <p>
-      Your institution's registration is currently pending approval. Your LMS administrator will receive an email once your registration has been approved by the Open Learning Initiative.
+      Your institution's registration is pending approval. You will receive an email once your request has been approved by the Open Learning Initiative.
     </p>
+
+    <div class="row justify-content-md-center my-3">
+      <div class="col col-8">
+        <table class="table table-sm text-center">
+            <tr>
+                <td>
+                    <b><%= @pending_registration.name %></b>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <%= @pending_registration.institution_url %>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <%= @pending_registration.institution_email %>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <%= @pending_registration.country_code %> - <%= @pending_registration.timezone %>
+                </td>
+            </tr>
+        </table>
+      </div>
+    </div>
 
     <p>For more help and information regarding your request, please <a href="https://oli.cmu.edu/jcourse/webui/help.do" target="_blank">contact OLI Support</a>.</p>
   </div>


### PR DESCRIPTION
This PR fixes 2 database migration script issues:

1. The migration didn't properly add the `on_delete: :delete_all` rules to the tables. The old method lost the foreign key in the process, this PR keeps it.
2. The migration was not reversible. However, since foreign keys are ultimately being lost in the migration, the rollback has no way of restoring them. Therefore, even though this PR properly accounts for the `down` portion of the migration, this release is not easily reversible and a database restore will be the preferred method of rollback.

Also included is some wording changes and request details on the request pending page.

This PR is critical for the 0.5.0 release.