### PR TITLE
Eliminate user inst fkey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
+## Unreleased
 ### Bug fixes
   - Fix missing status 201 handling on Freshdesk API call
+  - Remove foreign key constraint that tied a user to an institution
 
 ## 0.5.0 (2021-1-12)
 ### Enhancements

--- a/lib/oli/accounts/schemas/user.ex
+++ b/lib/oli/accounts/schemas/user.ex
@@ -29,7 +29,6 @@ defmodule Oli.Accounts.User do
     # A user may optionally be linked to an author account
     belongs_to :author, Oli.Accounts.Author
 
-    belongs_to :institution, Oli.Institutions.Institution
     has_many :enrollments, Oli.Delivery.Sections.Enrollment
     many_to_many :platform_roles, Oli.Lti_1p3.PlatformRole, join_through: "users_platform_roles", on_replace: :delete
 
@@ -60,7 +59,6 @@ defmodule Oli.Accounts.User do
       :phone_number_verified,
       :address,
       :author_id,
-      :institution_id,
     ])
     |> validate_required([:sub])
     |> maybe_name_from_given_and_family()

--- a/lib/oli/institutions/institution.ex
+++ b/lib/oli/institutions/institution.ex
@@ -12,7 +12,6 @@ defmodule Oli.Institutions.Institution do
     # LTI 1.3 Deployments
     has_many :registrations, Oli.Lti_1p3.Registration
     has_many :sections, Oli.Delivery.Sections.Section
-    has_many :users, Oli.Accounts.User
 
     timestamps(type: :utc_datetime)
   end

--- a/lib/oli/utils/db_seeder.ex
+++ b/lib/oli/utils/db_seeder.ex
@@ -283,8 +283,6 @@ defmodule Oli.Seeder do
   end
 
   def add_user(map, attrs, tag \\ nil) do
-    institution = map.institution
-
     {:ok, user} =
       User.changeset(%User{
         sub: "a6d5c443-1f51-4783-ba1a-7686ffe3b54a",
@@ -295,7 +293,6 @@ defmodule Oli.Seeder do
         picture: "https://platform.example.edu/jane.jpg",
         email: "jane#{System.unique_integer([:positive])}@platform.example.edu",
         locale: "en-US",
-        institution_id: institution.id
       }, attrs)
       |> Repo.insert
 

--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -3,7 +3,6 @@ defmodule OliWeb.DeliveryController do
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.Section
   alias Oli.Publishing
-  alias Oli.Institutions
   alias Oli.Lti_1p3.ContextRoles
   alias Oli.Accounts
   alias Oli.Accounts.Author

--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -193,14 +193,17 @@ defmodule OliWeb.DeliveryController do
   def create_section(conn, %{"publication_id" => publication_id}) do
     lti_params = conn.assigns.lti_params
     user = conn.assigns.current_user
-    institution = Institutions.get_institution!(user.institution_id)
+
+    deployment_id = lti_params["https://purl.imsglobal.org/spec/lti/claim/deployment_id"];
+    {institution, _registration, _deployment} = Oli.Lti_1p3.get_ird_by_deployment_id(deployment_id)
+
     publication = Publishing.get_publication!(publication_id)
 
     {:ok, %Section{id: section_id}} = Sections.create_section(%{
       time_zone: institution.timezone,
       title: lti_params["https://purl.imsglobal.org/spec/lti/claim/context"]["title"],
       context_id: lti_params["https://purl.imsglobal.org/spec/lti/claim/context"]["id"],
-      institution_id: user.institution_id,
+      institution_id: institution.id,
       project_id: publication.project_id,
       publication_id: publication_id,
     })

--- a/lib/oli_web/templates/layout/help_email.text.eex
+++ b/lib/oli_web/templates/layout/help_email.text.eex
@@ -1,1 +1,1 @@
-<%= render @view_module, @view_template, assigns %>
+<%= @inner_content %>

--- a/priv/repo/migrations/20210113153906_eliminate_user_inst_fkey.exs
+++ b/priv/repo/migrations/20210113153906_eliminate_user_inst_fkey.exs
@@ -1,0 +1,9 @@
+defmodule Oli.Repo.Migrations.EliminateUserInstFkey do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      remove :institution_id, references(:institutions)
+    end
+  end
+end

--- a/test/oli/sections_test.exs
+++ b/test/oli/sections_test.exs
@@ -21,9 +21,9 @@ defmodule Oli.SectionsTest do
         |> Map.put(:project_id, project.id)
         |> Map.put(:publication_id, publication.id)
 
-      user1 = user_fixture(%{institution_id: institution.id})
-      user2 = user_fixture(%{institution_id: institution.id})
-      user3 = user_fixture(%{institution_id: institution.id})
+      user1 = user_fixture()
+      user2 = user_fixture()
+      user3 = user_fixture()
 
       {:ok, section} = valid_attrs |> Sections.create_section()
 

--- a/test/oli_web/controllers/delivery_controller_test.exs
+++ b/test/oli_web/controllers/delivery_controller_test.exs
@@ -132,8 +132,12 @@ defmodule OliWeb.DeliveryControllerTest do
       password: "password123",
       password_confirmation: "password123",
     })
+
+    tool_jwk = jwk_fixture()
     institution = institution_fixture(%{ author_id: author.id })
-    user = user_fixture(%{institution_id: institution.id})
+    registration = registration_fixture(%{institution_id: institution.id, tool_jwk_id: tool_jwk.id})
+    deployment = deployment_fixture(%{registration_id: registration.id})
+    user = user_fixture()
 
     %{ project: project, publication: publication } = project_fixture(author)
 
@@ -147,6 +151,7 @@ defmodule OliWeb.DeliveryControllerTest do
       "https://purl.imsglobal.org/spec/lti/claim/roles" => [
         "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner",
       ],
+      "https://purl.imsglobal.org/spec/lti/claim/deployment_id" => deployment.deployment_id,
     })
     Oli.Lti_1p3.cache_lti_params!("instructor-sub", %{
       "sub" => "instructor-sub",
@@ -158,6 +163,7 @@ defmodule OliWeb.DeliveryControllerTest do
       "https://purl.imsglobal.org/spec/lti/claim/roles" => [
         "http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor",
       ],
+      "https://purl.imsglobal.org/spec/lti/claim/deployment_id" => deployment.deployment_id,
     })
     Oli.Lti_1p3.cache_lti_params!("student-instructor-sub", %{
       "sub" => "instructor-sub",
@@ -170,6 +176,7 @@ defmodule OliWeb.DeliveryControllerTest do
         "http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor",
         "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner",
       ],
+      "https://purl.imsglobal.org/spec/lti/claim/deployment_id" => deployment.deployment_id,
     })
 
     conn = Plug.Test.init_test_session(conn, lti_1p3_sub: "student-sub")


### PR DESCRIPTION
This PR removes the relationship between individual users and institutions, and instead uses the deployment ⟶ registration ⟶ institution relationship to create a section. Once enrolled, a user's institution relationship can be identified through the user's section enrollment ⟶ section ⟶ institution relationship.

This is a more correct way of modeling these relationships, removing the tight coupling of users and institutions as well as eliminating the possibility of a user's institution being out of sync with one or more section institution fkeys.

Closes #767