### PR TITLE
Filter stale locks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Bug fixes
   - Remove foreign key constraint that tied a user to an institution
+  - Do not display stale locks in Curriculum view
 
 ## 0.5.1 (2021-1-13)
 ### Bug fixes

--- a/lib/oli/publishing.ex
+++ b/lib/oli/publishing.ex
@@ -596,14 +596,12 @@ defmodule Oli.Publishing do
   """
   def retrieve_lock_info(resource_ids, publication_id) do
 
-    mappings = Repo.all(from mapping in PublishedResource,
+    Repo.all(from mapping in PublishedResource,
       where: mapping.publication_id == ^publication_id and mapping.resource_id in ^resource_ids,
       select: mapping,
       preload: [:author])
 
     |> Enum.filter(fn m -> !Locks.expired_or_empty?(m) end)
-
-    Enum.reduce(%{}, mappings, fn e, m -> Map.put(m, e.resource_id, e) end)
 
   end
 


### PR DESCRIPTION
This PR fixes an issue where stale locks were being considered when displaying the list of actively edited resources in the curriculum view. 

The fix here is to filter out expired locks in `Publishing.retrieve_lock_info`.  

Interesting, this function was trying to return a map, but was implemented incorrectly and was returning a list.  I have removed that as it wasn't necessary anyways. 

Closes #773 
