### PR TITLE
Sticky warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Bug fixes
   - Remove foreign key constraint that tied a user to an institution
+  - Ensure error messages always visible in page and activity editors
 
 ## 0.5.1 (2021-1-13)
 ### Bug fixes

--- a/assets/src/components/activity/ActivityEditor.tsx
+++ b/assets/src/components/activity/ActivityEditor.tsx
@@ -154,19 +154,26 @@ class ActivityEditor extends React.Component<ActivityEditorProps, ActivityEditor
 
   editingLockedMessage(email: string) {
     const message = createMessage({
+      guid: 'readonly-error',
       canUserDismiss: false,
       content: 'Read Only. User ' + email + ' is currently editing this page.',
       severity: Severity.Information,
     });
-    this.setState({ messages: [...this.state.messages, message] });
+    this.addAsUnique(message);
   }
 
   publishErrorMessage(failure: any) {
     const message = createMessage({
+      guid: 'general-error',
       canUserDismiss: true,
       content: 'A problem occurred while saving your changes',
     });
-    this.setState({ messages: [...this.state.messages, message] });
+    this.addAsUnique(message);
+  }
+
+  addAsUnique(message: Message) {
+    const messages = this.state.messages.filter(m => m.guid !== message.guid);
+    this.setState({ messages: [...messages, message] });
   }
 
   update(update: Partial<Undoable>) {

--- a/assets/src/components/messages/Banner.tsx
+++ b/assets/src/components/messages/Banner.tsx
@@ -41,7 +41,7 @@ export class Banner
     const messages = [...errors, ...warnings, ...infos, ...tasks];
 
     return (
-      <div className="banner">
+      <div className="banner sticky-top">
         <TransitionGroup>
           {messages.map(m => <CSSTransition key={m.guid} timeout={{ enter: 200, exit: 200 }}>
             <Message key={m.guid} {...this.props} message={m} />

--- a/assets/src/components/resource/resourceEditor/ResourceEditor.tsx
+++ b/assets/src/components/resource/resourceEditor/ResourceEditor.tsx
@@ -1,4 +1,3 @@
-
 import React from 'react';
 import { connect } from 'react-redux';
 import { State, Dispatch } from 'state';
@@ -176,28 +175,36 @@ export class ResourceEditor extends React.Component<ResourceEditorProps, Resourc
 
   editingLockedMessage(email: string) {
     const message = createMessage({
+      guid: 'readonly-error',
       canUserDismiss: false,
       content: 'Read Only. User ' + email + ' is currently editing this page.',
       severity: Severity.Information,
     });
-    this.setState({ messages: [...this.state.messages, message] });
+    this.addAsUnique(message);
   }
 
   publishErrorMessage(failure: any) {
     const message = createMessage({
+      guid: 'general-error',
       canUserDismiss: true,
       content: 'A problem occurred while saving your changes',
     });
-    this.setState({ messages: [...this.state.messages, message] });
+    this.addAsUnique(message);
   }
 
   createObjectiveErrorMessage(failure: any) {
     const message = createMessage({
+      guid: 'objective-error',
       canUserDismiss: true,
       content: 'A problem occurred while creating your new objective',
       severity: Severity.Error,
     });
-    this.setState({ messages: [...this.state.messages, message] });
+    this.addAsUnique(message);
+  }
+
+  addAsUnique(message: Message) {
+    const messages = this.state.messages.filter(m => m.guid !== message.guid);
+    this.setState({ messages: [...messages, message] });
   }
 
   showPreviewMessage(isGraded: boolean) {


### PR DESCRIPTION
This PR closes #544 by ensuring the message banners in page and activity editing are always visible even if the page is scrolled.  It does so by set them to be "sticky".  

Also, in testing this I discovered that the messages for the various types of failures were not being de-duped by failure type (so if you get ten failures for bad content, you get ten messages).  I ensured that there is only one message instance per category of failure.

To test out the sticky-ness of the banner, go to the "update" function in `resource_controller.ex` and comment out the actual impl and have it simply return `error(conn, 500, "server error")`

