### PR TITLE
cache the selection to use during insertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 ### Bug fixes
+  - Honor the current location when inserting block content (YouTube, images, etc)
   - Remove foreign key constraint that tied a user to an institution
 
 ## 0.5.1 (2021-1-13)

--- a/assets/src/components/editing/commands/AudioCmd.tsx
+++ b/assets/src/components/editing/commands/AudioCmd.tsx
@@ -42,8 +42,9 @@ export function selectAudio(projectSlug: string,
 
 const command: Command = {
   execute: (context, editor: ReactEditor) => {
+    const at = editor.selection as any;
     selectAudio(context.projectSlug, ContentModel.audio())
-      .then(img => Transforms.insertNodes(editor, img));
+      .then(img => Transforms.insertNodes(editor, img, { at }));
   },
   precondition: (editor: ReactEditor) => {
     return true;

--- a/assets/src/components/editing/commands/BlockcodeCmd.tsx
+++ b/assets/src/components/editing/commands/BlockcodeCmd.tsx
@@ -5,7 +5,7 @@ import { isActive } from '../utils';
 
 const command: Command = {
   execute: (context, editor) => {
-    Transforms.insertNodes(editor, ContentModel.code());
+    Transforms.insertNodes(editor, ContentModel.code(), { at: editor.selection as any });
   },
   precondition: (editor) => {
     return !isActive(editor, 'table');

--- a/assets/src/components/editing/commands/ImageCmd.tsx
+++ b/assets/src/components/editing/commands/ImageCmd.tsx
@@ -43,8 +43,9 @@ export function selectImage(projectSlug: string,
 
 const command: Command = {
   execute: (context, editor) => {
+    const at = editor.selection as any;
     selectImage(context.projectSlug, ContentModel.image())
-    .then(img => Transforms.insertNodes(editor, img));
+    .then(img => Transforms.insertNodes(editor, img, { at }));
   },
   precondition: (editor) => {
     return true;

--- a/assets/src/components/editing/commands/WebpageCmd.tsx
+++ b/assets/src/components/editing/commands/WebpageCmd.tsx
@@ -59,6 +59,9 @@ export function selectWebpage(): Promise<string | null> {
 
 const command: Command = {
   execute: (context, editor) => {
+
+    const at = editor.selection as any;
+
     selectWebpage()
       .then((selectedSrc) => {
         if (selectedSrc !== null) {
@@ -67,7 +70,7 @@ const command: Command = {
             src = 'https://' + src;
           }
 
-          Transforms.insertNodes(editor, ContentModel.webpage(src));
+          Transforms.insertNodes(editor, ContentModel.webpage(src), { at });
         }
       });
   },

--- a/assets/src/components/editing/commands/YoutubeCmd.tsx
+++ b/assets/src/components/editing/commands/YoutubeCmd.tsx
@@ -66,6 +66,9 @@ export function selectYouTube(): Promise<string | null> {
 
 const command: Command = {
   execute: (context, editor) => {
+
+    const at = editor.selection as any;
+
     selectYouTube()
       .then((selectedSrc) => {
         if (selectedSrc !== null) {
@@ -80,7 +83,8 @@ const command: Command = {
             src = src.substr(src.lastIndexOf('/') + 1);
           }
 
-          Transforms.insertNodes(editor, ContentModel.youtube(src));
+          Transforms.insertNodes(
+            editor, ContentModel.youtube(src), { at });
         }
       });
   },

--- a/assets/src/components/editing/commands/table/TableCmd.tsx
+++ b/assets/src/components/editing/commands/table/TableCmd.tsx
@@ -7,7 +7,7 @@ import { isTopLevel } from 'components/editing/utils';
 
 const command: Command = {
   execute: (context: any, editor: ReactEditor, params: any) => {
-
+    const at = editor.selection as any;
     const rows: any = [];
 
     for (let i = 0; i < params.rows; i += 1) {
@@ -19,7 +19,7 @@ const command: Command = {
     }
 
     const t = table(rows);
-    Transforms.insertNodes(editor, t);
+    Transforms.insertNodes(editor, t, { at });
     Transforms.deselect(editor);
   },
   precondition: (editor: ReactEditor) => {


### PR DESCRIPTION
Closes #710.  

This PR fixes the problem where certain block-level content types were now being inserted always at the bottom of the current structured content - and not at the location of the user's cursor.  I'm not sure whether this broke due to a change in Slate that we absorbed, or due to the refactoring of the UI/UX approach regarding toolbar and insertion.

The fix implemented here simply caches the editor selection prior to displaying any intermediate UI, and then using that cached selection for insertion.  