### PR TITLE
remove ability to cancel activity creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Bug fixes
   - Remove foreign key constraint that tied a user to an institution
+  - Remove ability to cancel activity creation during objective selection
 
 ## 0.5.1 (2021-1-13)
 ### Bug fixes

--- a/assets/src/components/content/AddResourceContent.tsx
+++ b/assets/src/components/content/AddResourceContent.tsx
@@ -48,6 +48,7 @@ const promptForObjectiveSelection
 
       display(<ModalSelection title="Target learning objectives with this activity"
         hideOkButton={true}
+        hideDialogCloseButton={true}
         cancelLabel="Skip this step"
         onInsert={() => { dismiss(); resolve([]); }}
         onCancel={() => { dismiss(); resolve([]); }}>

--- a/assets/src/components/modal/ModalSelection.tsx
+++ b/assets/src/components/modal/ModalSelection.tsx
@@ -16,6 +16,7 @@ export interface ModalSelectionProps {
   okClassName?: string;
   cancelLabel?: string;
   disableInsert?: boolean;
+  hideDialogCloseButton?: boolean;
   title: string;
   hideOkButton?: boolean;
   onInsert: () => void;
@@ -62,12 +63,15 @@ class ModalSelection extends React.PureComponent<ModalSelectionProps, ModalSelec
           <div className="modal-content">
             <div className="modal-header">
               <h5 className="modal-title">{this.props.title}</h5>
+              {this.props.hideDialogCloseButton === true
+              ? null
+              :
               <button
                 type="button"
                 className="close"
                 onClick={this.onCancel}>
                 <span aria-hidden="true">&times;</span>
-              </button>
+              </button>}
             </div>
             <div className="modal-body">
               {React.Children.map(this.props.children, child =>


### PR DESCRIPTION
Closes #492 

This PR fixes the problem where the use clicks the "X" button in the upper right corner of the objective selection dialog, thinking that they can cancel activity creation - but the activity gets added anyways.

The fix here is to simply remove the "X" button from the dialog.  This is really the only possible solution that doesn't involve a fair bit of rework because of how the "Cancel" action is overridden in this modal usage.  This "X" button is only removed for *this* instance of the modal usage, not all usages. 

