### PR TITLE
revamp project's code docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,44 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [https://contributor-covenant.org/version/1/4][version]
+
+[homepage]: https://contributor-covenant.org
+[version]: https://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,100 @@
+# Contributing to Torus
+
+The following is a set of guidelines for contributing to Torus development. These are mostly guidelines, not rules. Use your best judgment, and feel free to propose changes to this document in a pull request.
+
+#### Table Of Contents
+
+[Code of Conduct](#code-of-conduct)
+
+[What should I know before I get started?](#what-should-i-know-before-i-get-started)
+  * [Torus Design Decisions](#design-decisions)
+
+[How Can I Contribute?](#how-can-i-contribute)
+  * [Reporting Bugs](#reporting-bugs)
+  * [Suggesting Enhancements](#suggesting-enhancements)
+  * [Your First Code Contribution](#your-first-code-contribution)
+  * [Pull Requests](#pull-requests)
+
+## Code of Conduct
+
+This project and everyone participating in it is governed by the [Torus Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
+
+## What should I know before I get started?
+
+### Design Decisions
+
+Documentation regarding Torus architecture and relevant design decisions can be
+found in this project's Wiki.
+
+## How Can I Contribute?
+
+### Reporting Bugs
+
+This section guides you through submitting a bug report for Torus. Following these guidelines helps maintainers and the community understand your report, reproduce the behavior, and find related reports.
+
+Before creating bug reports, please check [this list](#before-submitting-a-bug-report) as you might find out that you don't need to create one. When you are creating a bug report, please [include as many details as possible](#how-do-i-submit-a-good-bug-report).
+
+> **Note:** If you find a **Closed** issue that seems like it is the same thing that you're experiencing, open a new issue and include a link to the original issue in the body of your new one.
+
+#### Before Submitting A Bug Report
+
+* You might be able to find the cause of the problem and fix things yourself. Most importantly, check if you can reproduce the problem on the `master` development branch, free from any other
+changes that you may have made.  Also, see if you can reproduce the
+problem [in the hosted version of Torus](https://proton.oli.cmu.edu), if applicable.
+* **Perform a cursory search** to see if the problem has already been reported. If it has **and the issue is still open**, add a comment to the existing issue instead of opening a new one.
+
+#### How Do I Submit A (Good) Bug Report?
+
+Bugs are tracked as [GitHub issues](https://guides.github.com/features/issues/).
+
+Explain the problem and include additional details to help maintainers reproduce the problem:
+
+* **Use a clear and descriptive title** for the issue to identify the problem.
+* **Describe the exact steps which reproduce the problem** in as many details as possible. For example, start by explaining how you are accessing Torus, e.g. whether via the hosted instance
+or via your own development environment. When listing steps, **don't just say what you did, but explain how you did it**. For example, if you saw a problem after inserting content into a page, explain how you inserted the content, whether you used a keyboard shortcut or used the
+mouse to click a toolbar insert button.
+* **Provide specific examples to demonstrate the steps**. Include links to files or GitHub projects, or copy/pasteable snippets, which you use in those examples. If you're providing snippets in the issue, use [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
+* **Describe the behavior you observed after following the steps** and point out what exactly is the problem with that behavior.
+* **Explain which behavior you expected to see instead and why.**
+* **Include screenshots and animated GIFs** which show you following the described steps and clearly demonstrate the problem.  You can use [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux.
+
+Include details about your configuration and environment:
+
+* **Which browser you are using?**
+* **What's the name and version of the OS you're using**?
+
+### Suggesting Enhancements
+
+This section guides you through submitting an enhancement suggestion for Torus, including completely new features and minor improvements to existing functionality. Following these guidelines helps maintainers and the community understand your suggestion and find related suggestions.
+
+#### How Do I Submit A (Good) Enhancement Suggestion?
+
+Enhancement suggestions are tracked as [GitHub issues](https://guides.github.com/features/issues/).
+
+* **Use a clear and descriptive title** for the issue to identify the suggestion.
+* **Provide a step-by-step description of the suggested enhancement** in as many details as possible.
+* **Provide specific examples to demonstrate the steps**. Include copy/pasteable snippets which you use in those examples, as [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
+* **Describe the current behavior** and **explain which behavior you expected to see instead** and why.
+* **Include screenshots and animated GIFs** which help you demonstrate the steps or point out the part of Torus which the suggestion is related to. You can use [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux.
+* **Explain why this enhancement would be useful** to most Torus users and isn't something that can or should be implemented as a third-party Torus learning activity.
+* **List some other platforms or applications where this enhancement exists.**
+
+### Your First Code Contribution
+
+#### Local development
+
+Torus can be developed locally. For instructions on how to set up a development environment
+see the documentation in the Torus Wiki.
+
+### Pull Requests
+
+Please follow these steps to have your contribution considered by the maintainers:
+
+1. Follow all instructions in the Torus pull request template found in the Torus Wiki
+2. Follow the coding conventions and style guide documentation found in the Torus Wiki
+3. After you submit your pull request, verify that all [status checks](https://help.github.com/articles/about-status-checks/) are passing <details><summary>What if the status checks are failing?</summary>If a status check is failing, and you believe that the failure is unrelated to your change, please leave a comment on the pull request explaining why you believe the failure is unrelated. A maintainer will re-run the status check for you. If we conclude that the failure was a false positive, then we will open an issue to track that problem with our status check suite.</details>
+
+While the prerequisites above must be satisfied prior to having your pull request reviewed, the reviewer(s) may ask you to complete additional design work, tests, or other changes before your pull request can be ultimately accepted.
+
+
+

--- a/README.md
+++ b/README.md
@@ -1,153 +1,29 @@
-# OLI Authoring and Delivery
+# Torus - Next Generation OLI
 
 [![Open Learning Initiative](https://oli.cmu.edu/wp-content/uploads/2018/10/oli-logo-78px-high-1.svg)](http://oli.cmu.edu/)
 
 [![Build & Test CI](https://github.com/Simon-Initiative/oli-torus/workflows/Build%20&%20Test%20CI/badge.svg?branch=master)](https://github.com/Simon-Initiative/oli-torus/actions?query=workflow%3A%22Build+%26+Test+CI%22)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/Simon-Initiative/authoring-client/blob/master/LICENSE)
 
-Full Documentation: [simon-initiative.github.io/oli-torus](https://simon-initiative.github.io/oli-torus/Oli.html)
+## Overview
 
-## Getting Started
+The Torus project is the next generation of the [Open Learning Initiative](https://www.cmu.edu/simon/open-simon/toolkit/tools/learning-tools/oli.html) - a data-driven, course authoring and delivery platform.
 
-### Setup
-#### (Quick Start) Run development server with docker-compose
+## Features
 
-1. Install dependencies:
-    - [Docker](https://www.docker.com/) and docker-compose
+- Integrated course authoring and delivery system supporting rich text, media and interactive activities
+- Learning engineering focused course design and instrumentation feeds a rich data-analytics dashboard to allow iterative course improvement
+- Publication and versioning system to track and migratte changes between a course and its derivatives
+- Extensible activity framework incorporates third-party developed learning activities
+- A standards oriented design pairs Torus with any LTI 1.3 compliant Learning Management System
+- A [managed instance](https://proton.oli.cmu.edu) of Torus is available, or run your own instance
 
-1. Initial setup
-    ```
-    $ docker-compose up -d postgres
-    $ docker-compose run app mix ecto.create
-    $ docker-compose run app mix ecto.migrate
-    $ docker-compose run app mix run priv/repo/seeds.exs
-    ```
+Visit our [product roadmap](https://github.com/Simon-Initiative/oli-torus/projects/4) for more details.
 
-1. Start Phoenix server
-    ```
-    $ docker-compose up -d && docker-compose logs -f
-    ```
-    > NOTE: Use Ctrl+c to exit log streaming and `docker-compose down` to stop the server.
+## Documentation
 
-1. Open your web browser to `https://localhost`
+See our [Wiki](https://github.com/Simon-Initiative/oli-torus/wiki) for Torus set up instructions, project contribution guidelines and processes, and system design information.
 
-#### Run development server natively
-
-1. Install dependencies:
-    - [Docker](https://www.docker.com/) and docker-compose
-    - [Elixir](https://elixir-lang.org/) (`$ brew install elixir`)
-    - [Phoenix](https://www.phoenixframework.org/) (`$ mix archive.install hex phx_new 1.5.3`)
-
-1. Optionally, use the provided `devmode.sh` script to automatically run all the following steps and get started
-   ```
-   $ sh ./devmode.sh
-   ```
-
-   Verify the configurations in oli.env are correct for your setup, or leave the defaults. For certain features
-   you will need to configure OAuth credentials for login providers and AWS credentials
-   with S3 permissions for media uploads to work properly.
-
-   Skip the remaining setup steps and use `mix phx.server` to run the server.
-
-1. Create configuration env files:
-    ```
-    $ cp oli.example.env oli.env
-    $ cp postgres.example.env postgres.env
-    ```
-
-1. Configure `oli.env` for running natively:
-    REPLACE:
-    ```
-    DB_HOST=postgres
-    ```
-
-    WITH:
-    ```
-    DB_HOST=localhost
-    ```
-
-1. Start dockerized postgres 12 via the included docker-compose file:
-    ```
-    $ docker-compose up -d postgres && docker-compose logs -f
-    ```
-
-1. Install server and client dependencies:
-    ```
-    $ mix deps.get
-    $ cd assets && yarn
-    ```
-
-1. Create database
-    ```
-    $ cd ../ && mix ecto.create
-    ```
-
-1. Run migration to create schema
-    ```
-    $ mix ecto.migrate
-    ```
-
-1. Seed the database
-    ```
-    $ mix run priv/repo/seeds.exs
-    ```
-
-1. Configure bash to properly source environment variable configurations
-   ```
-   $ set -a
-   ```
-
-1. Load phoenix app configuration from environment file. This step is necessary anytime you change a configuration variable
-    ```
-    $ source oli.env
-    ```
-
-1. Start Phoenix server
-    ```
-    $ mix phx.server
-    ```
-    > NOTE: Use Ctrl+c to stop the Phoenix server
-
-1. Open your web browser to `https://localhost`
+For full API Documentation: [simon-initiative.github.io/oli-torus](https://simon-initiative.github.io/oli-torus/Oli.html)
 
 
-### Running Tests
-
-If using docker-compose, you can start a bash session to execute any of the following commands using `docker-compose exec app bash`
-
-1. Run client tests
-    ```
-    $ cd assets && npm run test
-    ```
-
-1. Run server tests
-    ```
-    $ mix test
-    ```
-
-1. Run server tests for a specific file, watch for changes and automatically re-run tests
-    ```
-    $ mix test.watch lib/some_dir/file_to_watch.ex
-    ```
-
-1. Generate an html coverage report
-    ```
-    $ mix test.coverage
-    ```
-
-### Tunneling localhost connection for LTI development
-
-When making an LTI connection from an LMS such as Canvas, we need an internet accessible FQDN with SSL to properly configure a connection. The service ngrok offers an easy to use command line tool that does just this.
-
-1. [Download ngrok](https://ngrok.com/) and install using their instructions (Create a free account if required)
-1. Run ngrok locally to tunnel to phoenix app on port 4000
-        ```
-        ngrok http 4000
-        ```
-1. Access your running webapp using the generated https address (shown in console after `Forwarding`). This will be the same address used to configure the LMS LTI connection
-
-### Configuring an LTI 1.3 Connection
-
-Torus supports LTI 1.3 integration and leverages the Learning Management System for course delivery.
-
-To configure an LTI connection, refer to the [LTI 1.3 Integration document](./docs/LTI1.3.md).


### PR DESCRIPTION
This PR streamlines the project `README.md` file, adds a `CODE_OF_CONDUCT.md` and a `CONTRIBUTING.md`

For the `README.md`, It moves the setup instructions to the Wiki, and replaces that with a marketing oriented list of features and pointers to the product roadmap, Wiki, and API docs. 