### PR TITLE
Replace HTTPoison with Oli.HTTP

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -33,6 +33,9 @@ config :oli, Oli.Mailer,
 config :oli, OliWeb.Pow.Mailer,
   adapter: Bamboo.TestAdapter
 
+config :lti_1p3,
+  http_client: Oli.Test.MockHTTP
+
 # We don't run a server during test. If one is required,
 # you can enable the server option below.
 config :oli, OliWeb.Endpoint,

--- a/lib/oli/help/providers/freshdesk_help.ex
+++ b/lib/oli/help/providers/freshdesk_help.ex
@@ -2,6 +2,7 @@ defmodule Oli.Help.Providers.FreshdeskHelp do
   @behaviour Oli.Help.Dispatcher
 
   alias Oli.Help.HelpContent
+  import Oli.HTTP
 
   require Logger
 
@@ -27,7 +28,7 @@ defmodule Oli.Help.Providers.FreshdeskHelp do
         }
       )
 
-    case HTTPoison.post(url, body, @headers) do
+    case http().post(url, body, @headers) do
       {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
         {:ok, body}
       {:ok, %HTTPoison.Response{status_code: 201, body: body}} ->

--- a/lib/oli/lti/lti_ags.ex
+++ b/lib/oli/lti/lti_ags.ex
@@ -17,6 +17,8 @@ defmodule Oli.Lti.LTI_AGS do
   alias Oli.Lti.LineItem
   alias Lti_1p3.Tool.AccessToken
 
+  import Oli.HTTP
+
   require Logger
 
   @doc """
@@ -29,7 +31,7 @@ defmodule Oli.Lti.LTI_AGS do
     url = "#{line_item.id}/scores"
     body = score |> Jason.encode!()
 
-    with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <- HTTPoison.post(url, body, headers(access_token)),
+    with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <- http().post(url, body, headers(access_token)),
       {:ok, result} <- Jason.decode(body)
     do
       {:ok, result}
@@ -60,7 +62,7 @@ defmodule Oli.Lti.LTI_AGS do
     prefixed_resource_id = LineItem.to_resource_id(resource_id)
     request_url = "#{line_items_service_url}?resource_id=#{prefixed_resource_id}&limit=1"
 
-    with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <- HTTPoison.get(request_url, headers(access_token)),
+    with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <- http().get(request_url, headers(access_token)),
       {:ok, result} <- Jason.decode(body)
     do
       case result do
@@ -107,7 +109,7 @@ defmodule Oli.Lti.LTI_AGS do
     # a thousand gradebook entries.
     url = line_items_service_url <> "?limit=1000"
 
-    with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <- HTTPoison.get(url, headers(access_token)),
+    with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <- http().get(url, headers(access_token)),
       {:ok, results} <- Jason.decode(body)
     do
       {:ok, Enum.map(results, fn r -> to_line_item(r) end)}
@@ -135,7 +137,7 @@ defmodule Oli.Lti.LTI_AGS do
 
     body = line_item |> Jason.encode!()
 
-    with {:ok, %HTTPoison.Response{status_code: 201, body: body}} <- HTTPoison.post(line_items_service_url, body, headers(access_token)),
+    with {:ok, %HTTPoison.Response{status_code: 201, body: body}} <- http().post(line_items_service_url, body, headers(access_token)),
       {:ok, result} <- Jason.decode(body)
     do
       {:ok, to_line_item(result)}
@@ -168,7 +170,7 @@ defmodule Oli.Lti.LTI_AGS do
     # url to use is the id of the line item
     url = line_item.id
 
-    with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <- HTTPoison.put(url, body, headers(access_token)),
+    with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <- http().put(url, body, headers(access_token)),
       {:ok, result} <- Jason.decode(body)
     do
       {:ok, to_line_item(result)}

--- a/lib/oli/lti/lti_nrps.ex
+++ b/lib/oli/lti/lti_nrps.ex
@@ -15,6 +15,8 @@ defmodule Oli.Lti.LTI_NRPS do
   alias Oli.Lti.Membership
   alias Lti_1p3.Tool.AccessToken
 
+  import Oli.HTTP
+
   require Logger
 
   defp to_membership(raw) do
@@ -37,7 +39,7 @@ defmodule Oli.Lti.LTI_NRPS do
 
     url = context_memberships_url <> "?limit=1000"
 
-    with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <- HTTPoison.get(url, headers(access_token)),
+    with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <- http().get(url, headers(access_token)),
       {:ok, results} <- Jason.decode(body),
       members <- Map.get(results, "members")
     do

--- a/lib/oli/utils/recaptcha.ex
+++ b/lib/oli/utils/recaptcha.ex
@@ -4,6 +4,7 @@ defmodule Oli.Utils.Recaptcha do
     See the [documentation](https://developers.google.com/recaptcha/docs/verify)
     for more details.
   """
+  import Oli.HTTP
 
   @headers [
     {"Content-type", "application/x-www-form-urlencoded"},
@@ -20,7 +21,7 @@ defmodule Oli.Utils.Recaptcha do
     |> URI.encode_query()
 
     result =
-      with {:ok, response} <- HTTPoison.post(url, body, @headers, timeout: timeout),
+      with {:ok, response} <- http().post(url, body, @headers, timeout: timeout),
            {:ok, data} <- Jason.decode(response.body)
       do
         {:ok, data}

--- a/lib/oli_web/controllers/lti_controller.ex
+++ b/lib/oli_web/controllers/lti_controller.ex
@@ -42,7 +42,7 @@ defmodule OliWeb.LtiController do
       {:error, %{reason: :invalid_registration, msg: _msg, issuer: issuer, client_id: client_id}} ->
         handle_invalid_registration(conn, issuer, client_id)
       {:error, %{reason: :invalid_deployment, msg: _msg, registration_id: registration_id, deployment_id: deployment_id}} ->
-        handle_invalid_deployment(conn, registration_id, deployment_id)
+        handle_invalid_deployment(conn, params, registration_id, deployment_id)
       {:error, %{reason: _reason, msg: msg}} ->
         render(conn, "lti_error.html", reason: msg)
     end
@@ -270,11 +270,11 @@ defmodule OliWeb.LtiController do
     end
   end
 
-  defp handle_invalid_deployment(conn, registration_id, deployment_id) do
+  defp handle_invalid_deployment(conn, params, registration_id, deployment_id) do
     case Institutions.create_deployment(%{deployment_id: deployment_id, registration_id: registration_id}) do
       {:ok, _deployment} ->
         # try the LTI launch again now that deployment is created
-        launch(conn, conn.params)
+        launch(conn, params)
       _ ->
         render(conn, "lti_error.html", reason: "Failed to create deployment")
     end

--- a/test/oli_web/controllers/collaborator_controller_test.exs
+++ b/test/oli_web/controllers/collaborator_controller_test.exs
@@ -10,11 +10,15 @@ defmodule OliWeb.CollaboratorControllerTest do
 
   describe "create" do
     test "redirects to project path when data is valid", %{conn: conn, project: project} do
+      expect_recaptcha_http_post()
+
       conn = post(conn, Routes.collaborator_path(conn, :create, project), email: @admin_email, "g-recaptcha-response": "any")
       assert html_response(conn, 302) =~ "/project/"
     end
 
     test "redirects to project path when data is invalid", %{conn: conn, project: project} do
+      expect_recaptcha_http_post()
+
       conn = post(conn, Routes.collaborator_path(conn, :create, project), email: @invalid_email, "g-recaptcha-response": "any")
       assert html_response(conn, 302) =~ "/project/"
     end
@@ -22,6 +26,8 @@ defmodule OliWeb.CollaboratorControllerTest do
 
   describe "collaboration_invite" do
     test "accept new collaboration invitation", %{conn: conn, project: project} do
+      expect_recaptcha_http_post()
+
       conn = post(conn, Routes.collaborator_path(conn, :create, project), email: @invite_email, "g-recaptcha-response": "any")
       new_author = Accounts.get_author_by_email(@invite_email)
       token = PowInvitation.Plug.sign_invitation_token(conn, new_author)

--- a/test/oli_web/controllers/help_controller_test.exs
+++ b/test/oli_web/controllers/help_controller_test.exs
@@ -1,8 +1,22 @@
 defmodule OliWeb.HelpControllerTest do
   use OliWeb.ConnCase
 
+  alias Oli.Test.MockHTTP
+
+  import Mox
+
   describe "request_help" do
     test "send help request", %{conn: conn} do
+      expect_recaptcha_http_post()
+
+      freshdesk_url = System.get_env("FRESHDESK_API_URL", "example.edu")
+      MockHTTP
+      |> expect(:post, fn ^freshdesk_url, _body, _headers, _opts ->
+        {:ok, %HTTPoison.Response{
+          status_code: 200
+        }}
+      end)
+
       conn = conn
              |> put_req_header("accept", "text/html")
              |> put_req_header("accept-language", "en-US,en;q=0.9")

--- a/test/oli_web/controllers/invite_controller_test.exs
+++ b/test/oli_web/controllers/invite_controller_test.exs
@@ -10,6 +10,8 @@ defmodule OliWeb.InviteControllerTest do
 
   describe "accept_invite" do
     test "accept new author invitation", %{conn: conn} do
+      expect_recaptcha_http_post()
+
       conn = post(conn, Routes.invite_path(conn, :create), email: @invite_email, "g-recaptcha-response": "any")
       new_author = Accounts.get_author_by_email(@invite_email)
       token = PowInvitation.Plug.sign_invitation_token(conn, new_author)

--- a/test/oli_web/controllers/lti_controller_test.exs
+++ b/test/oli_web/controllers/lti_controller_test.exs
@@ -5,6 +5,8 @@ defmodule OliWeb.LtiControllerTest do
   alias Lti_1p3.Platform.LoginHint
   alias Lti_1p3.Platform.LoginHints
 
+  import Mox
+
   describe "lti_controller" do
     setup [:create_fixtures]
 
@@ -71,6 +73,93 @@ defmodule OliWeb.LtiControllerTest do
       assert html_response(conn, 200) =~ "Welcome to the Open Learning Initiative!"
       assert html_response(conn, 200) =~ "Register Your Institution"
 
+    end
+
+    test "launch successful for valid params and creates deployment on the fly", %{conn: conn, registration: registration} do
+      platform_jwk = jwk_fixture()
+
+      Oli.Test.MockHTTP
+      |> expect(:get, 2, fn "some key_set_url" ->
+        {:ok, %HTTPoison.Response{
+          status_code: 200,
+          body: Jason.encode!(%{
+            keys: [
+              platform_jwk.pem
+              |> JOSE.JWK.from_pem
+              |> JOSE.JWK.to_public
+              |> JOSE.JWK.to_map()
+              |> (fn {_kty, public_jwk} -> public_jwk end).()
+              |> Map.put("typ", platform_jwk.typ)
+              |> Map.put("alg", platform_jwk.alg)
+              |> Map.put("kid", platform_jwk.kid)
+              |> Map.put("use", "sig")
+            ]
+          })
+        }}  end)
+
+      state = "some-state"
+      conn = Plug.Test.init_test_session(conn, state: state)
+
+      custom_header = %{"kid" => platform_jwk.kid}
+      signer = Joken.Signer.create("RS256", %{"pem" => platform_jwk.pem}, custom_header)
+      claims = Oli.Lti_1p3.TestHelpers.all_default_claims()
+        |> Map.delete("iss")
+        |> Map.delete("aud")
+
+      {:ok, claims} = Joken.Config.default_claims(iss: registration.issuer, aud: registration.client_id)
+        |> Joken.generate_claims(claims)
+      {:ok, id_token, _claims} = Joken.encode_and_sign(claims, signer)
+
+      deployment_id = claims["https://purl.imsglobal.org/spec/lti/claim/deployment_id"]
+      registration_id = registration.id
+      assert nil == Lti_1p3.Tool.get_registration_deployment(registration.issuer, registration.client_id, deployment_id)
+
+      conn = post(conn, Routes.lti_path(conn, :launch, %{state: state, id_token: id_token}))
+
+      assert redirected_to(conn) == Routes.delivery_path(conn, :index)
+      assert {%Lti_1p3.Tool.Registration{}, %Lti_1p3.Tool.Deployment{deployment_id: ^deployment_id, registration_id: ^registration_id}}
+        = Lti_1p3.Tool.get_registration_deployment(registration.issuer, registration.client_id, deployment_id)
+    end
+
+    test "launch handles invalid registration and shows registration form", %{conn: conn } do
+      platform_jwk = jwk_fixture()
+
+      Oli.Test.MockHTTP
+      |> expect(:get, 2, fn "some key_set_url" ->
+        {:ok, %HTTPoison.Response{
+          status_code: 200,
+          body: Jason.encode!(%{
+            keys: [
+              platform_jwk.pem
+              |> JOSE.JWK.from_pem
+              |> JOSE.JWK.to_public
+              |> JOSE.JWK.to_map()
+              |> (fn {_kty, public_jwk} -> public_jwk end).()
+              |> Map.put("typ", platform_jwk.typ)
+              |> Map.put("alg", platform_jwk.alg)
+              |> Map.put("kid", platform_jwk.kid)
+              |> Map.put("use", "sig")
+            ]
+          })
+        }}  end)
+
+      state = "some-state"
+      conn = Plug.Test.init_test_session(conn, state: state)
+
+      custom_header = %{"kid" => platform_jwk.kid}
+      signer = Joken.Signer.create("RS256", %{"pem" => platform_jwk.pem}, custom_header)
+      claims = Oli.Lti_1p3.TestHelpers.all_default_claims()
+        |> Map.delete("iss")
+        |> Map.delete("aud")
+
+      {:ok, claims} = Joken.Config.default_claims(iss: "some different client_id", aud: "some different issuer")
+        |> Joken.generate_claims(claims)
+      {:ok, id_token, _claims} = Joken.encode_and_sign(claims, signer)
+
+      conn = post(conn, Routes.lti_path(conn, :launch, %{state: state, id_token: id_token}))
+
+      assert html_response(conn, 200) =~ "Welcome to the Open Learning Initiative!"
+      assert html_response(conn, 200) =~ "Register Your Institution"
     end
 
     test "authorize_redirect get successful for user", %{conn: conn} do
@@ -187,7 +276,7 @@ defmodule OliWeb.LtiControllerTest do
     registration = registration_fixture(%{institution_id: institution.id, tool_jwk_id: jwk.id})
     deployment = deployment_fixture(%{registration_id: registration.id})
 
-    %{conn: conn, deployment: deployment, registration: registration, institution: institution}
+    %{conn: conn, jwk: jwk, deployment: deployment, registration: registration, institution: institution}
   end
 
 end


### PR DESCRIPTION
This PR replaces all instances of HTTPoison with Oli.HTTP for better unit testing (remove 3rd party calls). It also includes some more LTI launch unit tests which were previously not possibly without a mock http setup.