### PR TITLE
fix an issue where editor crashes on paste

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+  - Fix an issue where pasting text containing newlines from an external source crashes the editor
+
 ## 0.6.0 (2021-3-3)
 ### Enhancements
   - Add LTI 1.3 platform launch support

--- a/assets/src/components/editing/editor/Editor.tsx
+++ b/assets/src/components/editing/editor/Editor.tsx
@@ -112,7 +112,17 @@ export const Editor = React.memo((props: EditorProps) => {
       <Slate
         editor={editor}
         value={props.value}
-        onChange={onChange}>
+        onChange={onChange}
+        onPaste={async (
+          e: React.ClipboardEvent<HTMLDivElement>,
+          editor: SlateEditor,
+          next: Function,
+        ) => {
+          setIsPerformingAsyncAction(true);
+          await onPaste(editor, e, props.commandContext.projectSlug);
+          setIsPerformingAsyncAction(false);
+          next();
+        }}>
 
         <InsertionToolbar
           isPerformingAsyncAction={isPerformingAsyncAction}
@@ -133,12 +143,7 @@ export const Editor = React.memo((props: EditorProps) => {
           renderElement={renderElement}
           renderLeaf={renderLeaf}
           placeholder="Enter some content here..."
-          onKeyDown={onKeyDown}
-          onPaste={async (e) => {
-            setIsPerformingAsyncAction(true);
-            await onPaste(editor, e, props.commandContext.projectSlug);
-            setIsPerformingAsyncAction(false);
-          }} />
+          onKeyDown={onKeyDown} />
       </Slate>
     </React.Fragment>
   );


### PR DESCRIPTION
This PR fixes an issue where the editor crashes when content that contains newlines is pasted from an external source. It also fixes the issue with editor selection being outdated when a paste is performed, causing the pasted text to paste into an unexpected location. The fix was to move the onPaste callback to the Slate editor and use the latest editor provided to the callback.

Closes #801