### PR TITLE
revert section lookup back to using context_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.1 (2021-3-3)
+
+### Bug fixes
+  - Fixes an issue where existing sections might not be found on LTI launch
+
 ## 0.6.0 (2021-3-3)
 ### Enhancements
   - Add LTI 1.3 platform launch support

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -10,8 +10,8 @@ defmodule Oli.Delivery.Sections do
   alias Oli.Delivery.Sections.Enrollment
   alias Lti_1p3.Tool.ContextRole
   alias Lti_1p3.DataProviders.EctoProvider
-  alias Lti_1p3.DataProviders.EctoProvider.Deployment
-  alias Oli.Lti_1p3.Tool.Registration
+  # alias Lti_1p3.DataProviders.EctoProvider.Deployment
+  # alias Oli.Lti_1p3.Tool.Registration
 
   @doc """
   Enrolls a user in a course section.
@@ -116,15 +116,19 @@ defmodule Oli.Delivery.Sections do
       nil
   """
   def get_section_from_lti_params(lti_params) do
-    issuer = lti_params["iss"]
-    client_id = lti_params["aud"]
+    ## TODO: disabled for now, but issuer and client_id need to be re-enabled in the future to fully qualify a section
+    ## after null lti_1p3_deployment_id is fixed for all existing sections
+
+    # issuer = lti_params["iss"]
+    # client_id = lti_params["aud"]
     context_id = Map.get(lti_params, "https://purl.imsglobal.org/spec/lti/claim/context")
       |> Map.get("id")
 
     Repo.one(from s in Section,
-      join: d in Deployment, on: s.lti_1p3_deployment_id == d.id,
-      join: r in Registration, on: d.registration_id == r.id,
-      where: s.context_id == ^context_id and r.issuer == ^issuer and r.client_id == ^client_id,
+      # join: d in Deployment, on: s.lti_1p3_deployment_id == d.id,
+      # join: r in Registration, on: d.registration_id == r.id,
+      # where: s.context_id == ^context_id and r.issuer == ^issuer and r.client_id == ^client_id,
+      where: s.context_id == ^context_id,
       select: s)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Oli.MixProject do
   def project do
     [
       app: :oli,
-      version: "0.6.0",
+      version: "0.6.1",
       elixir: "~> 1.11",
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: elixirc_options(Mix.env()),


### PR DESCRIPTION
Fixes an issue where existing sections have null `lti_1p3_deployment_id`. Reverts to simply using context_id.