### PR TITLE
Html escape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - Add the ability for an activity to submit client side evaluations
 
 ### Bug fixes
+  - Fix an issue where activity text that contained HTML tags rendered actual HTML
   - Fix an issue where pasting text containing newlines from an external source crashes the editor
 
 ## 0.6.1 (2021-3-3)

--- a/assets/src/data/content/writers/html.ts
+++ b/assets/src/data/content/writers/html.ts
@@ -13,11 +13,11 @@ import { WriterContext } from './context';
 
 function escapeHtml(unsafe: string) : string {
   return unsafe
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;");
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
 }
 
 export class HtmlParser implements WriterImpl {

--- a/assets/src/data/content/writers/html.ts
+++ b/assets/src/data/content/writers/html.ts
@@ -11,6 +11,15 @@ import { WriterContext } from './context';
 // Important: any changes to this file must be replicated
 // in content/html.ex for non-activity rendering.
 
+function escapeHtml(unsafe: string) : string {
+  return unsafe
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
 export class HtmlParser implements WriterImpl {
   private escapeXml = (text: string) => decodeURI(encodeURI(text));
 
@@ -106,7 +115,7 @@ export class HtmlParser implements WriterImpl {
   a = (context: WriterContext, next: Next, { href }: Hyperlink) =>
     `<a href="${this.escapeXml(href)}">${next()}</a>\n`
   text = (context: WriterContext, textEntity: Text) =>
-    this.wrapWithMarks(this.escapeXml(textEntity.text), textEntity)
+    this.wrapWithMarks(escapeHtml(textEntity.text), textEntity)
 
   unsupported = (context: WriterContext, { type }: ModelElement) =>
     '<div class="content invalid">Content element is invalid</div>\n'

--- a/assets/test/utils/writer_test.ts
+++ b/assets/test/utils/writer_test.ts
@@ -14,7 +14,7 @@ describe('parser', () => {
     const htmlString = parse(exampleContent);
     expect(htmlString).toContain('<h3>Introduction</h3>');
     expect(htmlString).toMatch(new RegExp('<img.* src="https://upload.wikimedia.org/wikipedia/commons/thumb/f/f9/Declaration_of_Independence_%281819%29%2C_by_John_Trumbull.jpg/480px-Declaration_of_Independence_%281819%29%2C_by_John_Trumbull.jpg"/>'));
-    expect(htmlString).toContain('<p>The American colonials proclaimed \"no taxation without representation');
+    expect(htmlString).toContain('<p>The American colonials proclaimed &quot;no taxation without representation');
     expect(htmlString).toContain('<a href="https://en.wikipedia.org/wiki/Stamp_Act_Congress">Stamp Act Congress</a>');
     expect(htmlString).toContain('<h3>1651–1748: Early seeds</h3>');
     expect(htmlString).toContain('<ol><li>one</li>\n<li><em>two</em></li>\n<li><em><strong>three</strong></em></li>\n</ol>');


### PR DESCRIPTION
Closes #824 

This PR fixes the client-side HTML rendering code to escape HTML special characters within text nodes.