### PR TITLE
revert to server driven slug generation, improve docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
   - Add the ability for an activity to submit client side evaluations
+  - Change project slug determiniation during course ingestion to be server driven
 
 ### Bug fixes
   - Fix an issue where activity text that contained HTML tags rendered actual HTML

--- a/lib/oli/authoring/course.ex
+++ b/lib/oli/authoring/course.ex
@@ -69,29 +69,6 @@ defmodule Oli.Authoring.Course do
   end
 
 
-  # Specialized project creation facility for ingested projects, where the course digest
-  # specifies the slug to be used for the project (as opposed to letting that slug be derived
-  # from the title).
-  def create_ingested_project(slug, title, author) do
-    Repo.transaction(fn ->
-      with {:ok, project_family} <- create_family(default_family(title)),
-           {:ok, project} <- create_project(default_project(title, project_family) |> Map.put(:slug, slug)),
-           {:ok, _} <- Collaborators.add_collaborator(author, project),
-           {:ok, %{resource: resource, revision: resource_revision}}
-              <- initial_resource_setup(author, project),
-           {:ok, _}
-              <- Publishing.initial_publication_setup(project, resource, resource_revision)
-      do
-        %{
-          project: project,
-          resource_revision: resource_revision
-        }
-      else
-        {:error, error} -> Repo.rollback(error)
-      end
-    end)
-  end
-
   def create_project(title, author) do
     Repo.transaction(fn ->
       with {:ok, project_family} <- create_family(default_family(title)),

--- a/lib/oli/interop/ingest.ex
+++ b/lib/oli/interop/ingest.ex
@@ -82,7 +82,7 @@ defmodule Oli.Interop.Ingest do
 
     case Map.get(project_details, "title") do
       nil -> {:error, "no project title found"}
-      title -> Oli.Authoring.Course.create_ingested_project(Map.get(project_details, "slug"), title, as_author)
+      title -> Oli.Authoring.Course.create_project(title, as_author)
     end
 
   end

--- a/lib/oli_web/templates/ingest/index.html.eex
+++ b/lib/oli_web/templates/ingest/index.html.eex
@@ -38,7 +38,8 @@
 
         <div id="collapseOne" class="collapse show" aria-labelledby="headingOne" data-parent="#accordionExample">
           <div class="card-body">
-              Only a second or two.  If the ingestion succeeds you will be redirected to the Project Overview of the new course project.
+              It depends on the size of the course described in the digest, but expect the ingestion to take anywhere from a
+              few seconds to a minute or two.  After the ingestion finishes you will be taken to the Project Overview of the new course project.
           </div>
         </div>
       </div>
@@ -75,15 +76,13 @@
         <div class="card-header" id="four">
           <h2 class="mb-0">
             <button class="btn btn-link btn-block text-left collapsed" type="button" data-toggle="collapse" data-target="#collapseFour" aria-expanded="false" aria-controls="collapseFour">
-              How does the ingestion process handle media items?
+              How can I learn more about the course ingest process and course digest format?
             </button>
           </h2>
         </div>
         <div id="collapseFour" class="collapse" aria-labelledby="four" data-parent="#accordionExample">
           <div class="card-body">
-            The course ingestion tool expects that media items referenced in the course material have already been
-            pre-positioned into a Torus AWS S3 bucket folder.  That bucket folder name must be specified in the
-            <code>s3-folder-name</code> top-level key in the <code>_media-manifest.json</code>.
+             The Torus GitHub WIKI has documentation regarding ingestion.
           </div>
         </div>
       </div>


### PR DESCRIPTION
This PR reverts the approach taken from letting a course digest specify its project slug, back to the the server owning that determination. 

Letting the digest decide was only necessary to allow "ahead of time" specification of media asset URLs in digest content that would match the project slug.  I realized that approach isn't strictly required as it really doesn't matter if the folder where a file is referenced in S3 differs from the actual slug, given that we track everything in the media assets relation in the DB. 

I also took a moment to improve some of the UI around documentation. 