### PR TITLE
Resize images, fix element query post processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   - Fix an issue where activity text that contained HTML tags rendered actual HTML
   - Fix an issue where pasting text containing newlines from an external source crashes the editor
   - Fix an issue with null section slugs and deployment id in existing sections
+  - Fix an issue where large images can obscure the Review mode UI
+  - Fix an issue where accessibility warnings for pages with multiple images only show the first image
 
 ## 0.6.1 (2021-3-3)
 

--- a/lib/oli/qa/utils.ex
+++ b/lib/oli/qa/utils.ex
@@ -32,12 +32,44 @@ defmodule Oli.Qa.Utils do
 
     {:ok, %{rows: results }} = Ecto.Adapters.SQL.query(Oli.Repo, sql, [])
 
-    results
-    |> Enum.take_every(2)
+    dedupe(results)
     |> Enum.map(& %{
       id: Enum.at(&1, 0),
       content: Enum.at(&1, 2)
     })
+  end
+
+    # The jsonb_path_query for elements, for some reason, duplicates results on a revision by
+    # revision basis.  So if a particular page has one matching element it will
+    # appear duplicated in the results.  If a revision has two matching elements they
+    # appear duplicated, but the entire group is duplicated. Consider two pages, one with
+    # a single matching element (an image) and another page with two matching image elements.
+    #
+    # Page1
+    # --image1
+    # Page2
+    # --image2
+    # --image3
+    #
+    # The jsonb_path_query above yields results like this:
+    # Page1, image1
+    # Page1, image1
+    # Page2, image2
+    # Page2, image3
+    # Page2, image2
+    # Page2, image3
+    #
+    # We need to split the results into groups according to the revision id,
+    # then take only the first half of results for each revision
+  defp dedupe(results) do
+    groups = Enum.group_by(results, fn [id, _, _] -> id end)
+
+    Map.keys(groups)
+    |> Enum.reduce([], fn k, all ->
+      items = Map.get(groups, k)
+      all ++ Enum.take(items, div(length(items), 2))
+    end)
+
   end
 
 end

--- a/lib/oli_web/live/qa/warning_details.ex
+++ b/lib/oli_web/live/qa/warning_details.ex
@@ -5,6 +5,14 @@ defmodule OliWeb.Qa.WarningDetails do
 
   def render(assigns) do
     ~L"""
+    <style>
+      .delivery-container img {
+        max-width: 300px;
+      }
+      .delivery-container iframe {
+        max-width: 300px;
+      }
+    </style>
     <div class="review-card active" id="<%= @selected.id %>">
       <h4 class="d-flex">
         <div>
@@ -22,8 +30,10 @@ defmodule OliWeb.Qa.WarningDetails do
       <div class="alert alert-info">
         <strong>Action item</strong> <%= action_item(@selected.subtype, %{ graded: @selected.revision.graded }) %>
         <%= if @selected.content do %>
-          <%= Phoenix.HTML.raw(Oli.Rendering.Content.render(%Oli.Rendering.Context{user: @author}, @selected.content, Oli.Rendering.Content.Html)) %>
-        <% end %>
+          <div class="delivery-container">
+            <%= Phoenix.HTML.raw(Oli.Rendering.Content.render(%Oli.Rendering.Context{user: @author}, @selected.content, Oli.Rendering.Content.Html)) %>
+          </div>
+          <% end %>
       </div>
     </div>
     """

--- a/test/oli/qa/accessibility_test.exs
+++ b/test/oli/qa/accessibility_test.exs
@@ -44,21 +44,26 @@ defmodule Oli.Qa.AccessibilityTest do
             %{
               "children" => [
                 %{
+                  "type" => "img",
+                  "src" => "https://upload.wikimedia.org/wikipedia/commons/8/86/Map_of_territorial_growth_1775.jpg",
                   "children" => [
                     %{
-                      "type" => "img",
-                      "src" => "https://upload.wikimedia.org/wikipedia/commons/8/86/Map_of_territorial_growth_1775.jpg",
-                      "children" => [
-                        %{
-                          "text" => ""
-                        }
-                      ],
-                      "id" => 2607239386,
-                      "caption" => "Eastern North America in 1775. The British Province of Quebec, the Thirteen Colonies on the Atlantic coast, and the Indian Reserve as defined by the Royal Proclamation of 1763. The border between the red and pink areas represents the 1763 \"Proclamation line\", while the orange area represents the Spanish claim.",
-                    },
+                      "text" => ""
+                    }
                   ],
-                  "id" => "3636822762",
-                  "type" => "p"
+                  "id" => "1",
+                  "caption" => "Eastern North America in 1775. The British Province of Quebec, the Thirteen Colonies on the Atlantic coast, and the Indian Reserve as defined by the Royal Proclamation of 1763. The border between the red and pink areas represents the 1763 \"Proclamation line\", while the orange area represents the Spanish claim.",
+                },
+                %{
+                  "type" => "img",
+                  "src" => "https://upload.wikimedia.org/wikipedia/commons/f/ff/Wikipedia_logo_593.jpg",
+                  "children" => [
+                    %{
+                      "text" => ""
+                    }
+                  ],
+                  "id" => "2",
+                  "caption" => "Wikipedia logo",
                 }
               ],
               "id" => "481882791",
@@ -80,6 +85,10 @@ defmodule Oli.Qa.AccessibilityTest do
       assert Enum.find(warnings, & &1.revision.id == image_no_alt.revision.id)
       # has alt text
       assert !Enum.find(warnings, & &1.revision.id == image_has_alt.revision.id)
+
+      assert Enum.any?(warnings, & &1.content["id"] == "1")
+      assert Enum.any?(warnings, & &1.content["id"] == "2")
+
     end
 
   end


### PR DESCRIPTION
This PR fixes two problems related to QA mode:

1. Large images in accessibility warnings obscure the rest of the UI.  This was fixed by constraining their (and iframe) sizes.
2. In the course of fixing the above, I noticed that pages that contained multiple images that didn't have ALT text were not correctly showing up in accessibility warnings.  Specifically, the first image was repeated and the second image wasn't shown.  I tracked this down to the post processing we do to remove duplicates from the element in content JSONB path query.  Comments in that code explain the exact structure of the query results and what we need to do to properly dedupe.

Closes #834 


