### PR TITLE
fix project sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - Add the ability for an activity to submit client side evaluations
 
 ### Bug fixes
+  - Fix an issue where the projects table did not sort by created date correctly
   - Fix an issue where activity text that contained HTML tags rendered actual HTML
   - Fix an issue where pasting text containing newlines from an external source crashes the editor
   - Fix an issue with null section slugs and deployment id in existing sections


### PR DESCRIPTION
This PR fixes project sorting.  Sorting by date was broken and sorting by author was never really implemented. 

The issue with date sorting was that we were simply trying to compare dates using the < operator, but they need to be semantically compared using the 'compare' function.

Closes #802 

