### PR TITLE
Activity scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
   - Add the ability for an activity to submit client side evaluations
+  - Add the ability to limit what activities are available for use in particular course projects
 
 ### Bug fixes
   - Fix an issue where activity text that contained HTML tags rendered actual HTML

--- a/assets/src/components/content/AddResourceContent.tsx
+++ b/assets/src/components/content/AddResourceContent.tsx
@@ -141,11 +141,17 @@ export const AddResourceContent = (
     .keys(editorMap)
     .map((k: string) => {
       const editorDesc: EditorDesc = editorMap[k];
+      const enabled = editorDesc.globallyAvailable || editorDesc.enabledForProject;
       return (
-        <button className="btn btn-sm insert-activity-btn" key={editorDesc.slug}
-          onClick={handleAdd.bind(this, editorDesc)}>
-          {editorDesc.friendlyName}
-        </button>
+        <React.Fragment>
+          {enabled &&
+            (
+              <button className="btn btn-sm insert-activity-btn" key={editorDesc.slug}
+                      onClick={handleAdd.bind(this, editorDesc)}>
+                {editorDesc.friendlyName}
+              </button>)
+          }
+        </React.Fragment>
       );
     });
 

--- a/assets/src/components/resource/ResourceEditorApp.tsx
+++ b/assets/src/components/resource/ResourceEditorApp.tsx
@@ -12,7 +12,6 @@ let store = configureStore();
 (window as any).oliMountApplication
   = (mountPoint: any, paramString : any) => {
     const params = JSON.parse(b64DecodeUnicode(paramString));
-  console.log("Parameters from backend " + JSON.stringify(params))
 
     ReactDOM.render(
       <Provider store={store}>

--- a/assets/src/components/resource/ResourceEditorApp.tsx
+++ b/assets/src/components/resource/ResourceEditorApp.tsx
@@ -12,6 +12,7 @@ let store = configureStore();
 (window as any).oliMountApplication
   = (mountPoint: any, paramString : any) => {
     const params = JSON.parse(b64DecodeUnicode(paramString));
+  console.log("Parameters from backend " + JSON.stringify(params))
 
     ReactDOM.render(
       <Provider store={store}>

--- a/assets/src/components/resource/editors/createEditor.tsx
+++ b/assets/src/components/resource/editors/createEditor.tsx
@@ -19,7 +19,8 @@ const unsupported: EditorDesc = {
   description: 'Not supported',
   friendlyName: 'Not supported',
   slug: 'unknown',
-  globallyAvailable: false,
+  globallyAvailable: true,
+  enabledForProject: true,
 };
 
 // content or referenced activities

--- a/assets/src/components/resource/editors/createEditor.tsx
+++ b/assets/src/components/resource/editors/createEditor.tsx
@@ -19,6 +19,7 @@ const unsupported: EditorDesc = {
   description: 'Not supported',
   friendlyName: 'Not supported',
   slug: 'unknown',
+  globallyAvailable: false,
 };
 
 // content or referenced activities

--- a/assets/src/data/content/editors.ts
+++ b/assets/src/data/content/editors.ts
@@ -7,6 +7,7 @@ export type EditorDesc = {
   icon: string;
   description: string;
   friendlyName: string;
+  globallyAvailable: boolean;
 };
 
 export interface ActivityEditorMap {

--- a/assets/src/data/content/editors.ts
+++ b/assets/src/data/content/editors.ts
@@ -8,6 +8,7 @@ export type EditorDesc = {
   description: string;
   friendlyName: string;
   globallyAvailable: boolean;
+  enabledForProject: boolean;
 };
 
 export interface ActivityEditorMap {

--- a/lib/oli/activities.ex
+++ b/lib/oli/activities.ex
@@ -134,6 +134,17 @@ defmodule Oli.Activities do
     Enum.sort_by(activities_enabled, & &1.global, :desc)
   end
 
+  def set_global_status(activity_slug, status) do
+    with {:ok, activity_registration} <-
+           get_registration_by_slug(activity_slug)
+           |> trap_nil("An activity with that slug was not found.")
+      do
+      update_registration(activity_registration, %{globally_available: status})
+    else
+      {:error, {message}} -> {:error, message}
+    end
+  end
+
   def get_registration_by_slug(slug) do
     Repo.one(from p in ActivityRegistration, where: p.slug == ^slug)
   end

--- a/lib/oli/activities.ex
+++ b/lib/oli/activities.ex
@@ -17,6 +17,7 @@ defmodule Oli.Activities do
       delivery_script: manifest.id <> "_delivery.js",
       delivery_element: manifest.delivery.element,
       allow_client_evaluation: manifest.allowClientEvaluation,
+      globally_available: manifest.global,
       description: manifest.description,
       title: manifest.friendlyName,
       icon: "nothing",

--- a/lib/oli/activities/activity_map_entry.ex
+++ b/lib/oli/activities/activity_map_entry.ex
@@ -3,12 +3,14 @@ defmodule Oli.Activities.ActivityMapEntry do
   alias Oli.Activities.ActivityRegistration
 
   @derive Jason.Encoder
-  defstruct [:deliveryElement, :authoringElement, :icon, :description, :friendlyName, :slug, :globallyAvailable]
+  defstruct [:deliveryElement, :authoringElement, :icon, :description, :friendlyName, :slug, :globallyAvailable,
+    enabledForProject: false]
 
   def from_registration(%ActivityRegistration{slug: slug, description: description, icon: icon, title: title,
     authoring_element: authoring_element, delivery_element: delivery_element, globally_available: globally_available}) do
     %Oli.Activities.ActivityMapEntry{slug: slug, friendlyName: title, description: description,
-      authoringElement: authoring_element, icon: icon, deliveryElement: delivery_element, globallyAvailable: globally_available}
+      authoringElement: authoring_element, icon: icon, deliveryElement: delivery_element,
+      globallyAvailable: globally_available, enabledForProject: globally_available}
   end
 
 end

--- a/lib/oli/activities/activity_map_entry.ex
+++ b/lib/oli/activities/activity_map_entry.ex
@@ -1,11 +1,11 @@
 defmodule Oli.Activities.ActivityMapEntry do
 
-  alias Oli.Activities.Registration
+  alias Oli.Activities.ActivityRegistration
 
   @derive Jason.Encoder
   defstruct [:deliveryElement, :authoringElement, :icon, :description, :friendlyName, :slug, :globallyAvailable]
 
-  def from_registration(%Registration{slug: slug, description: description, icon: icon, title: title,
+  def from_registration(%ActivityRegistration{slug: slug, description: description, icon: icon, title: title,
     authoring_element: authoring_element, delivery_element: delivery_element, globally_available: globally_available}) do
     %Oli.Activities.ActivityMapEntry{slug: slug, friendlyName: title, description: description,
       authoringElement: authoring_element, icon: icon, deliveryElement: delivery_element, globallyAvailable: globally_available}

--- a/lib/oli/activities/activity_map_entry.ex
+++ b/lib/oli/activities/activity_map_entry.ex
@@ -3,10 +3,12 @@ defmodule Oli.Activities.ActivityMapEntry do
   alias Oli.Activities.Registration
 
   @derive Jason.Encoder
-  defstruct [:deliveryElement, :authoringElement, :icon, :description, :friendlyName, :slug]
+  defstruct [:deliveryElement, :authoringElement, :icon, :description, :friendlyName, :slug, :globallyAvailable]
 
-  def from_registration(%Registration{slug: slug, description: description, icon: icon, title: title, authoring_element: authoring_element, delivery_element: delivery_element}) do
-    %Oli.Activities.ActivityMapEntry{slug: slug, friendlyName: title, description: description, authoringElement: authoring_element, icon: icon, deliveryElement: delivery_element}
+  def from_registration(%Registration{slug: slug, description: description, icon: icon, title: title,
+    authoring_element: authoring_element, delivery_element: delivery_element, globally_available: globally_available}) do
+    %Oli.Activities.ActivityMapEntry{slug: slug, friendlyName: title, description: description,
+      authoringElement: authoring_element, icon: icon, deliveryElement: delivery_element, globallyAvailable: globally_available}
   end
 
 end

--- a/lib/oli/activities/activity_registration.ex
+++ b/lib/oli/activities/activity_registration.ex
@@ -1,4 +1,4 @@
-defmodule Oli.Activities.Registration do
+defmodule Oli.Activities.ActivityRegistration do
   use Ecto.Schema
   import Ecto.Changeset
 
@@ -13,6 +13,7 @@ defmodule Oli.Activities.Registration do
     field :title, :string
     field :allow_client_evaluation, :boolean, default: false
     field :globally_available, :boolean, default: false
+    many_to_many :projects, Oli.Authoring.Course.Project, join_through: Oli.Activities.ActivityRegistrationProject
 
     timestamps(type: :utc_datetime)
   end

--- a/lib/oli/activities/activity_registration_project.ex
+++ b/lib/oli/activities/activity_registration_project.ex
@@ -1,0 +1,19 @@
+defmodule Oli.Activities.ActivityRegistrationProject do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key false
+  schema "activity_registration_projects" do
+    timestamps(type: :utc_datetime)
+    field :activity_registration_id, :integer, primary_key: true
+    field :project_id, :integer, primary_key: true
+  end
+
+  @doc false
+  def changeset(author_project, attrs \\ %{}) do
+    author_project
+    |> cast(attrs, [:activity_registration_id, :project_id])
+    |> validate_required([:activity_registration_id, :project_id])
+    |> unique_constraint(:activity_registration_id, name: :index_activity_registration_project)
+  end
+end

--- a/lib/oli/activities/manifest.ex
+++ b/lib/oli/activities/manifest.ex
@@ -1,7 +1,7 @@
 defmodule Oli.Activities.Manifest do
   import Oli.Utils
 
-  defstruct [:id, :friendlyName, :description, :delivery, :authoring, :allowClientEvaluation]
+  defstruct [:id, :friendlyName, :description, :delivery, :authoring, :allowClientEvaluation, :global]
 
   def parse(%{"id" => id, "friendlyName" => friendlyName, "description" => description, "delivery" => delivery, "authoring" => authoring} = json) do
     %Oli.Activities.Manifest{
@@ -11,6 +11,7 @@ defmodule Oli.Activities.Manifest do
       delivery: Oli.Activities.ModeSpecification.parse(delivery),
       authoring: Oli.Activities.ModeSpecification.parse(authoring),
       allowClientEvaluation: value_or(json["allowClientEvaluation"], false),
+      global: false,
     }
   end
 

--- a/lib/oli/activities/registration.ex
+++ b/lib/oli/activities/registration.ex
@@ -12,6 +12,7 @@ defmodule Oli.Activities.Registration do
     field :icon, :string
     field :title, :string
     field :allow_client_evaluation, :boolean, default: false
+    field :globally_available, :boolean, default: false
 
     timestamps(type: :utc_datetime)
   end
@@ -19,7 +20,8 @@ defmodule Oli.Activities.Registration do
   @doc false
   def changeset(registration, attrs) do
     registration
-    |> cast(attrs, [:slug, :title, :icon, :description, :delivery_element, :authoring_element, :delivery_script, :authoring_script, :allow_client_evaluation])
+    |> cast(attrs, [:slug, :title, :icon, :description, :delivery_element, :authoring_element, :delivery_script,
+      :authoring_script, :allow_client_evaluation, :globally_available])
     |> validate_required([:slug, :title, :icon, :description, :delivery_element, :authoring_element, :delivery_script, :authoring_script])
     |> unique_constraint(:slug)
     |> unique_constraint(:authoring_element)

--- a/lib/oli/authoring/course/project.ex
+++ b/lib/oli/authoring/course/project.ex
@@ -16,6 +16,7 @@ defmodule Oli.Authoring.Course.Project do
     belongs_to :family, Oli.Authoring.Course.Family
     many_to_many :authors, Oli.Accounts.Author, join_through: Oli.Authoring.Authors.AuthorProject
     many_to_many :resources, Oli.Resources.Resource, join_through: Oli.Authoring.Course.ProjectResource
+    many_to_many :activity_registrations, Oli.Activities.ActivityRegistration, join_through: Oli.Activities.ActivityRegistrationProject
     has_many :publications, Oli.Publishing.Publication
 
     timestamps(type: :utc_datetime)

--- a/lib/oli/authoring/editing/page_editor.ex
+++ b/lib/oli/authoring/editing/page_editor.ex
@@ -43,53 +43,59 @@ defmodule Oli.Authoring.Editing.PageEditor do
   .`{:error, {:not_authorized}}` if the user is not authorized to edit this resource
   .`{:error, {:error}}` unknown error
   """
-  @spec edit(String.t, String.t, String.t, %{})
-    :: {:ok, %Revision{}} | {:error, {:not_found}} | {:error, {:error}} | {:error, {:lock_not_acquired}} | {:error, {:not_authorized}}
+  @spec edit(String.t(), String.t(), String.t(), %{}) ::
+          {:ok, %Revision{}}
+          | {:error, {:not_found}}
+          | {:error, {:error}}
+          | {:error, {:lock_not_acquired}}
+          | {:error, {:not_authorized}}
   def edit(project_slug, revision_slug, author_email, update) do
+    result =
+      with {:ok, author} <- Accounts.get_author_by_email(author_email) |> trap_nil(),
+           {:ok, project} <- Course.get_project_by_slug(project_slug) |> trap_nil(),
+           {:ok} <- authorize_user(author, project),
+           {:ok, publication} <-
+             Publishing.get_unpublished_publication_by_slug!(project_slug) |> trap_nil(),
+           {:ok, resource} <- Resources.get_resource_from_slug(revision_slug) |> trap_nil(),
+           {:ok, converted_update} <- convert_to_activity_ids(update) do
+        Repo.transaction(fn ->
+          case Locks.update(publication.id, resource.id, author.id) do
+            # If we acquired the lock, we must first create a new revision
+            {:acquired} ->
+              get_latest_revision(publication, resource)
+              |> resurrect_or_delete_activity_references(converted_update, project.slug)
+              |> create_new_revision(publication, resource, author.id)
+              |> update_revision(converted_update, project.slug)
+              |> possibly_release_lock(publication, resource, author, update)
 
-    result = with {:ok, author} <- Accounts.get_author_by_email(author_email) |> trap_nil(),
-         {:ok, project} <- Course.get_project_by_slug(project_slug) |> trap_nil(),
-         {:ok} <- authorize_user(author, project),
-         {:ok, publication} <- Publishing.get_unpublished_publication_by_slug!(project_slug) |> trap_nil(),
-         {:ok, resource} <- Resources.get_resource_from_slug(revision_slug) |> trap_nil(),
-         {:ok, converted_update} <- convert_to_activity_ids(update)
-    do
-      Repo.transaction(fn ->
+            # A successful lock update means we can safely edit the existing revision
+            {:updated} ->
+              get_latest_revision(publication, resource)
+              |> resurrect_or_delete_activity_references(converted_update, project.slug)
+              |> maybe_create_new_revision(publication, resource, author.id, converted_update)
+              |> update_revision(converted_update, project.slug)
+              |> possibly_release_lock(publication, resource, author, update)
 
-        case Locks.update(publication.id, resource.id, author.id) do
-
-          # If we acquired the lock, we must first create a new revision
-          {:acquired} -> get_latest_revision(publication, resource)
-            |> resurrect_or_delete_activity_references(converted_update, project.slug)
-            |> create_new_revision(publication, resource, author.id)
-            |> update_revision(converted_update, project.slug)
-            |> possibly_release_lock(publication, resource, author, update)
-
-          # A successful lock update means we can safely edit the existing revision
-          {:updated} -> get_latest_revision(publication, resource)
-            |> resurrect_or_delete_activity_references(converted_update, project.slug)
-            |> maybe_create_new_revision(publication, resource, author.id, converted_update)
-            |> update_revision(converted_update, project.slug)
-            |> possibly_release_lock(publication, resource, author, update)
-
-          # error or not able to lock results in a failed edit
-          result -> Repo.rollback(result)
-        end
-
-      end)
-
-    else
-      error -> error
-    end
+            # error or not able to lock results in a failed edit
+            result ->
+              Repo.rollback(result)
+          end
+        end)
+      else
+        error -> error
+      end
 
     case result do
       {:ok, {revision, activity_revisions}} ->
-        Enum.each(activity_revisions ++ [revision], fn r -> Broadcaster.broadcast_revision(r, project_slug) end)
+        Enum.each(activity_revisions ++ [revision], fn r ->
+          Broadcaster.broadcast_revision(r, project_slug)
+        end)
+
         {:ok, revision}
-      e -> e
 
+      e ->
+        e
     end
-
   end
 
   defp possibly_release_lock(previous, publication, resource, author, update) do
@@ -114,30 +120,29 @@ defmodule Oli.Authoring.Editing.PageEditor do
   .`{:error, {:not_authorized}}` if the user is not authorized to edit this resource
   .`{:error, {:error}}` unknown error
   """
-  @spec acquire_lock(String.t, String.t, String.t)
-    :: {:acquired} | {:lock_not_acquired, String.t} | {:error, {:not_found}} | {:error, {:error}} | {:error, {:not_authorized}}
+  @spec acquire_lock(String.t(), String.t(), String.t()) ::
+          {:acquired}
+          | {:lock_not_acquired, String.t()}
+          | {:error, {:not_found}}
+          | {:error, {:error}}
+          | {:error, {:not_authorized}}
   def acquire_lock(project_slug, revision_slug, author_email) do
-
     with {:ok, author} <- Accounts.get_author_by_email(author_email) |> trap_nil(),
          {:ok, project} <- Course.get_project_by_slug(project_slug) |> trap_nil(),
          {:ok} <- authorize_user(author, project),
-         {:ok, publication} <- Publishing.get_unpublished_publication_by_slug!(project_slug) |> trap_nil(),
-         {:ok, resource} <- Resources.get_resource_from_slug(revision_slug) |> trap_nil()
-    do
+         {:ok, publication} <-
+           Publishing.get_unpublished_publication_by_slug!(project_slug) |> trap_nil(),
+         {:ok, resource} <- Resources.get_resource_from_slug(revision_slug) |> trap_nil() do
       case Locks.acquire(publication.id, resource.id, author.id) do
-
         # If we reacquired the lock, we must first create a new revision
         {:acquired} -> {:acquired}
-
         # error or not able to lock results in a failed edit
         {:lock_not_acquired, {locked_by, _}} -> {:lock_not_acquired, locked_by}
-
         error -> {:error, error}
       end
     else
       error -> error
     end
-
   end
 
   @doc """
@@ -150,16 +155,18 @@ defmodule Oli.Authoring.Editing.PageEditor do
   .`{:error, {:not_found}}` if the project, resource, or user cannot be found
   .`{:error, {:not_authorized}}` if the user is not authorized to edit this resource
   """
-  @spec release_lock(String.t, String.t, String.t)
-    :: {:ok, {:released}} | {:error, {:not_found}} | {:error, {:not_authorized}} | {:error, {:error}}
+  @spec release_lock(String.t(), String.t(), String.t()) ::
+          {:ok, {:released}}
+          | {:error, {:not_found}}
+          | {:error, {:not_authorized}}
+          | {:error, {:error}}
   def release_lock(project_slug, revision_slug, author_email) do
-
     with {:ok, author} <- Accounts.get_author_by_email(author_email) |> trap_nil(),
          {:ok, project} <- Course.get_project_by_slug(project_slug) |> trap_nil(),
          {:ok} <- authorize_user(author, project),
-         {:ok, publication} <- Publishing.get_unpublished_publication_by_slug!(project_slug) |> trap_nil(),
-         {:ok, resource} <- Resources.get_resource_from_slug(revision_slug) |> trap_nil()
-    do
+         {:ok, publication} <-
+           Publishing.get_unpublished_publication_by_slug!(project_slug) |> trap_nil(),
+         {:ok, resource} <- Resources.get_resource_from_slug(revision_slug) |> trap_nil() do
       case Locks.release(publication.id, resource.id, author.id) do
         {:error} -> {:error, {:error}}
         _ -> {:ok, {:released}}
@@ -167,7 +174,6 @@ defmodule Oli.Authoring.Editing.PageEditor do
     else
       error -> error
     end
-
   end
 
   @doc """
@@ -175,28 +181,54 @@ defmodule Oli.Authoring.Editing.PageEditor do
   for a specific resource / revision.
   """
   def create_context(project_slug, revision_slug, author) do
-
     editor_map = Oli.Activities.create_registered_activity_map()
 
-    with {:ok, publication} <- Publishing.get_unpublished_publication_by_slug!(project_slug) |> trap_nil(),
-         {:ok, %{content: content } = revision} <- AuthoringResolver.from_revision_slug(project_slug, revision_slug) |> trap_nil(),
-         {:ok, objectives} <- Publishing.get_published_objective_details(publication.id) |> trap_nil(),
-         {:ok, objectives_with_parent_reference} <- construct_parent_references(objectives) |> trap_nil(),
-         {:ok, activities} <- create_activities_map(project_slug, publication.id, content)
-    do
-      {:ok, create(publication.id, revision, project_slug, revision_slug, author, objectives_with_parent_reference, revision.objectives, activities, editor_map)}
+    editor_map = Enum.reduce(editor_map, %{}, fn {key, a}, m ->
+      if a.globallyAvailable === true do
+        Map.put(m, key, a)
+      else
+        m
+      end
+    end)
+
+    with {:ok, publication} <-
+           Publishing.get_unpublished_publication_by_slug!(project_slug) |> trap_nil(),
+         {:ok, %{content: content} = revision} <-
+           AuthoringResolver.from_revision_slug(project_slug, revision_slug) |> trap_nil(),
+         {:ok, objectives} <-
+           Publishing.get_published_objective_details(publication.id) |> trap_nil(),
+         {:ok, objectives_with_parent_reference} <-
+           construct_parent_references(objectives) |> trap_nil(),
+         {:ok, activities} <- create_activities_map(project_slug, publication.id, content) do
+      {:ok,
+       create(
+         publication.id,
+         revision,
+         project_slug,
+         revision_slug,
+         author,
+         objectives_with_parent_reference,
+         revision.objectives,
+         activities,
+         editor_map
+       )}
     else
       _ -> {:error, :not_found}
     end
   end
 
   def render_page_html(project_slug, revision_slug, author, options \\ []) do
-    with {:ok, publication} <- Publishing.get_unpublished_publication_by_slug!(project_slug) |> trap_nil(),
+    with {:ok, publication} <-
+           Publishing.get_unpublished_publication_by_slug!(project_slug) |> trap_nil(),
          {:ok, resource} <- Resources.get_resource_from_slug(revision_slug) |> trap_nil(),
-         {:ok, %{content: content} = _revision} <- get_latest_revision(publication, resource) |> trap_nil(),
+         {:ok, %{content: content} = _revision} <-
+           get_latest_revision(publication, resource) |> trap_nil(),
          {:ok, activities} <- create_activity_summary_map(publication.id, content),
-         render_context <- %Rendering.Context{user: author, preview: Keyword.get(options, :preview, false), activity_map: activities}
-    do
+         render_context <- %Rendering.Context{
+           user: author,
+           preview: Keyword.get(options, :preview, false),
+           activity_map: activities
+         } do
       Rendering.Page.render(render_context, content["model"], Rendering.Page.Html)
     else
       _ -> {:error, :not_found}
@@ -205,81 +237,92 @@ defmodule Oli.Authoring.Editing.PageEditor do
 
   defp create_activity_summary_map(publication_id, %{"model" => content}) do
     # Now see if we even have any activities that need to be mapped
-    found_activities = Enum.filter(content, fn c -> Map.get(c, "type") == "activity-reference" end)
+    found_activities =
+      Enum.filter(content, fn c -> Map.get(c, "type") == "activity-reference" end)
       |> Enum.map(fn c -> Map.get(c, "activity_id") end)
 
-    if (length(found_activities) != 0) do
+    if length(found_activities) != 0 do
       # get a view of all current registered activity types
       registrations = Activities.list_activity_registrations()
       reg_map = Enum.reduce(registrations, %{}, fn r, m -> Map.put(m, r.id, r) end)
 
       # find the published revisions for these activities, and convert them
       # to a form suitable for front-end consumption
-      {:ok, Publishing.get_published_activity_revisions(publication_id, found_activities)
-        |> Enum.map(fn %Revision{resource_id: resource_id, activity_type_id: activity_type_id, content: content, graded: graded} ->
+      {:ok,
+       Publishing.get_published_activity_revisions(publication_id, found_activities)
+       |> Enum.map(fn %Revision{
+                        resource_id: resource_id,
+                        activity_type_id: activity_type_id,
+                        content: content,
+                        graded: graded
+                      } ->
+         # To support 'test mode' in the editor, we give the editor an initial transformed
+         # version of the model that it can immediately use for display purposes. If it fails
+         # to transform, nil will be handled by the client and the raw model will be used
+         # instead
+         transformed =
+           case Transformers.apply_transforms(content) do
+             {:ok, t} -> t
+             _ -> nil
+           end
 
-          # To support 'test mode' in the editor, we give the editor an initial transformed
-          # version of the model that it can immediately use for display purposes. If it fails
-          # to transform, nil will be handled by the client and the raw model will be used
-          # instead
-          transformed = case Transformers.apply_transforms(content) do
-            {:ok, t} -> t
-            _ -> nil
-          end
+         # the activity type this revision pertains to
+         type = Map.get(reg_map, activity_type_id)
 
-          # the activity type this revision pertains to
-          type = Map.get(reg_map, activity_type_id)
+         state = ActivityState.create_preview_state(transformed)
 
-          state = ActivityState.create_preview_state(transformed)
-
-          %ActivitySummary{
-            id: resource_id,
-            model: ActivityContext.prepare_model(transformed, prune: false),
-            state: ActivityContext.prepare_state(state),
-            delivery_element: type.delivery_element,
-            script: type.delivery_script,
-            graded: graded
-          }
-        end)
-        |> Enum.reduce(%{}, fn summary, acc -> Map.put(acc, summary.id, summary) end)
-      }
+         %ActivitySummary{
+           id: resource_id,
+           model: ActivityContext.prepare_model(transformed, prune: false),
+           state: ActivityContext.prepare_state(state),
+           delivery_element: type.delivery_element,
+           script: type.delivery_script,
+           graded: graded
+         }
+       end)
+       |> Enum.reduce(%{}, fn summary, acc -> Map.put(acc, summary.id, summary) end)}
     else
       {:ok, %{}}
     end
-
   end
 
   # From the array of maps found in a resource revision content, produce a
   # map of the content of the activity revisions that pertain to the
   # current publication
-  defp create_activities_map(_, publication_id, %{ "model" => content}) do
-
+  defp create_activities_map(_, publication_id, %{"model" => content}) do
     # Now see if we even have any activities that need to be mapped
-    found_activities = Enum.filter(content, fn c -> Map.get(c, "type") == "activity-reference" end)
+    found_activities =
+      Enum.filter(content, fn c -> Map.get(c, "type") == "activity-reference" end)
       |> Enum.map(fn c -> Map.get(c, "activity_id") end)
 
-    if (length(found_activities) != 0) do
-
+    if length(found_activities) != 0 do
       # create a mapping of registered activity type id to the registered activity slug
-      id_to_slug = Activities.list_activity_registrations() |> Enum.reduce(%{}, fn e, m -> Map.put(m, Map.get(e, :id), Map.get(e, :slug)) end)
+      id_to_slug =
+        Activities.list_activity_registrations()
+        |> Enum.reduce(%{}, fn e, m -> Map.put(m, Map.get(e, :id), Map.get(e, :slug)) end)
 
       # find the published revisions for these activities, and convert them
       # to a form suitable for front-end consumption
-      {:ok, Publishing.get_published_activity_revisions(publication_id, found_activities)
-        |> Enum.map(fn %Revision{activity_type_id: activity_type_id, objectives: objectives, slug: slug, content: content} ->
-
-          %{
-          type: "activity",
-          typeSlug: Map.get(id_to_slug, activity_type_id),
-          activitySlug: slug,
-          model: content,
-          objectives: objectives
-        } end)
-        |> Enum.reduce(%{}, fn e, m -> Map.put(m, Map.get(e, :activitySlug), e) end)}
+      {:ok,
+       Publishing.get_published_activity_revisions(publication_id, found_activities)
+       |> Enum.map(fn %Revision{
+                        activity_type_id: activity_type_id,
+                        objectives: objectives,
+                        slug: slug,
+                        content: content
+                      } ->
+         %{
+           type: "activity",
+           typeSlug: Map.get(id_to_slug, activity_type_id),
+           activitySlug: slug,
+           model: content,
+           objectives: objectives
+         }
+       end)
+       |> Enum.reduce(%{}, fn e, m -> Map.put(m, Map.get(e, :activitySlug), e) end)}
     else
       {:ok, %{}}
     end
-
   end
 
   # Look to see what activity references this change would add or remove and
@@ -288,7 +331,6 @@ defmodule Oli.Authoring.Editing.PageEditor do
   # and remove it, then bring it back using 'Undo' - all while keeping the
   # deleted state of the activity revision correct.
   defp resurrect_or_delete_activity_references(revision, change, project_slug) do
-
     if Map.get(change, :deleted) do
       content = Map.get(revision.content, "model")
       deletions = activity_references(content)
@@ -296,8 +338,8 @@ defmodule Oli.Authoring.Editing.PageEditor do
     else
       # Handle the case where this change does not include content
       case Map.get(change, "content") do
-
-        nil -> {revision, []}
+        nil ->
+          {revision, []}
 
         map ->
           # First calculate the difference, if any, between the current revision and the
@@ -315,17 +357,21 @@ defmodule Oli.Authoring.Editing.PageEditor do
   # If there are activity-reference changes, resolve those activity ids to
   # revisions and set their deleted flag appropriately
   defp delete_activity_references(project_slug, revision, additions, deletions) do
-
     case MapSet.union(additions, deletions) |> MapSet.to_list() do
-
-      [] -> {revision, []}
+      [] ->
+        {revision, []}
 
       activity_ids ->
-        activity_revisions = AuthoringResolver.from_resource_id(project_slug, activity_ids)
-                             |> Enum.map(fn revision ->
-          {:ok, updated} = Oli.Resources.update_revision(revision, %{deleted: MapSet.member?(deletions, revision.resource_id)})
-          updated
-        end)
+        activity_revisions =
+          AuthoringResolver.from_resource_id(project_slug, activity_ids)
+          |> Enum.map(fn revision ->
+            {:ok, updated} =
+              Oli.Resources.update_revision(revision, %{
+                deleted: MapSet.member?(deletions, revision.resource_id)
+              })
+
+            updated
+          end)
 
         {revision, activity_revisions}
     end
@@ -334,20 +380,26 @@ defmodule Oli.Authoring.Editing.PageEditor do
   # Reverse references found in a resource update for activites. They will
   # come from the client as activity revision slugs, we store them internally
   # as activity ids.
-  defp convert_to_activity_ids(%{ "content" => %{ "model" => content}} = update) do
-
-    found_activities = Enum.filter(content, fn c -> Map.get(c, "type") == "activity-reference" end)
+  defp convert_to_activity_ids(%{"content" => %{"model" => content}} = update) do
+    found_activities =
+      Enum.filter(content, fn c -> Map.get(c, "type") == "activity-reference" end)
       |> Enum.map(fn c -> Map.get(c, "activitySlug") end)
 
-    slug_to_id = case found_activities do
-      [] -> %{}
-      activity_slugs -> Oli.Resources.map_resource_ids_from_slugs(activity_slugs)
-        |> Enum.reduce(%{}, fn e, m -> Map.put(m, Map.get(e, :slug), Map.get(e, :resource_id)) end)
-    end
+    slug_to_id =
+      case found_activities do
+        [] ->
+          %{}
+
+        activity_slugs ->
+          Oli.Resources.map_resource_ids_from_slugs(activity_slugs)
+          |> Enum.reduce(%{}, fn e, m ->
+            Map.put(m, Map.get(e, :slug), Map.get(e, :resource_id))
+          end)
+      end
 
     if Enum.all?(found_activities, fn slug -> Map.has_key?(slug_to_id, slug) end) do
       convert = fn c ->
-        if (Map.get(c, "type") == "activity-reference") do
+        if Map.get(c, "type") == "activity-reference" do
           slug = Map.get(c, "activitySlug")
           Map.delete(c, "activitySlug") |> Map.put("activity_id", Map.get(slug_to_id, slug))
         else
@@ -355,11 +407,10 @@ defmodule Oli.Authoring.Editing.PageEditor do
         end
       end
 
-      {:ok, Map.put(update, "content", %{ "model" => Enum.map(content, convert) })}
+      {:ok, Map.put(update, "content", %{"model" => Enum.map(content, convert)})}
     else
       {:error, :not_found}
     end
-
   end
 
   # This version of this function handles the case where there is no content
@@ -369,19 +420,25 @@ defmodule Oli.Authoring.Editing.PageEditor do
   end
 
   # For the activity ids found in content, convert them to activity revision slugs
-  defp convert_to_activity_slugs(%{ "model" => content}, publication_id) do
-
-    found_activities = Enum.filter(content, fn c -> Map.get(c, "type") == "activity-reference" end)
+  defp convert_to_activity_slugs(%{"model" => content}, publication_id) do
+    found_activities =
+      Enum.filter(content, fn c -> Map.get(c, "type") == "activity-reference" end)
       |> Enum.map(fn c -> Map.get(c, "activity_id") end)
 
-    id_to_slug = case found_activities do
-      [] -> %{}
-      activities -> Publishing.get_published_activity_revisions(publication_id, activities)
-        |> Enum.reduce(%{}, fn e, m -> Map.put(m, Map.get(e, :resource_id), Map.get(e, :slug)) end)
-    end
+    id_to_slug =
+      case found_activities do
+        [] ->
+          %{}
+
+        activities ->
+          Publishing.get_published_activity_revisions(publication_id, activities)
+          |> Enum.reduce(%{}, fn e, m ->
+            Map.put(m, Map.get(e, :resource_id), Map.get(e, :slug))
+          end)
+      end
 
     convert = fn c ->
-      if (Map.get(c, "type") == "activity-reference") do
+      if Map.get(c, "type") == "activity-reference" do
         id = Map.get(c, "activity_id")
         Map.delete(c, "activity_id") |> Map.put("activitySlug", Map.get(id_to_slug, id))
       else
@@ -389,8 +446,7 @@ defmodule Oli.Authoring.Editing.PageEditor do
       end
     end
 
-    %{ "model" => Enum.map(content, convert)}
-
+    %{"model" => Enum.map(content, convert)}
   end
 
   # Take a list of maps containing the title, resource_id, and children (as a list of resource_ids)
@@ -403,13 +459,13 @@ defmodule Oli.Authoring.Editing.PageEditor do
   # }
   #
   def construct_parent_references(revisions) do
-
-     # create a map of ids to their parent ids
-     parents = Enum.reduce(revisions, %{}, fn r, m ->
-      Enum.reduce(r.children, m, fn c, n ->
-        Map.put(n, c, r.resource_id)
+    # create a map of ids to their parent ids
+    parents =
+      Enum.reduce(revisions, %{}, fn r, m ->
+        Enum.reduce(r.children, m, fn c, n ->
+          Map.put(n, c, r.resource_id)
+        end)
       end)
-    end)
 
     # now just transform the revision list to pair it down to including
     # id, title, and the new parent_id
@@ -420,11 +476,20 @@ defmodule Oli.Authoring.Editing.PageEditor do
         parentId: Map.get(parents, r.resource_id)
       }
     end)
-
   end
 
   # Create the resource editing context that we will supply to the client side editor
-  defp create(publication_id, revision, project_slug, revision_slug, author, all_objectives, objectives, activities, editor_map) do
+  defp create(
+         publication_id,
+         revision,
+         project_slug,
+         revision_slug,
+         author,
+         all_objectives,
+         objectives,
+         activities,
+         editor_map
+       ) do
     %Oli.Authoring.Editing.ResourceContext{
       authorEmail: author.email,
       projectSlug: project_slug,
@@ -446,34 +511,46 @@ defmodule Oli.Authoring.Editing.PageEditor do
   end
 
   # create a new revision only if the slug will change due to this update
-  defp maybe_create_new_revision({previous, changed_activity_revisions}, publication, resource, author_id, update) do
-
+  defp maybe_create_new_revision(
+         {previous, changed_activity_revisions},
+         publication,
+         resource,
+         author_id,
+         update
+       ) do
     title = Map.get(update, "title", previous.title)
 
-    if (title != previous.title) do
-      create_new_revision({previous, changed_activity_revisions}, publication, resource, author_id)
+    if title != previous.title do
+      create_new_revision(
+        {previous, changed_activity_revisions},
+        publication,
+        resource,
+        author_id
+      )
     else
       {previous, changed_activity_revisions}
     end
   end
 
   # Creates a new resource revision and updates the publication mapping
-  def create_new_revision({previous, changed_activity_revisions}, publication, resource, author_id) do
-
+  def create_new_revision(
+        {previous, changed_activity_revisions},
+        publication,
+        resource,
+        author_id
+      ) do
     attrs = %{author_id: author_id}
     {:ok, revision} = Resources.create_revision_from_previous(previous, attrs)
 
     mapping = Publishing.get_resource_mapping!(publication.id, resource.id)
-    {:ok, _mapping} = Publishing.update_resource_mapping(mapping, %{ revision_id: revision.id })
+    {:ok, _mapping} = Publishing.update_resource_mapping(mapping, %{revision_id: revision.id})
 
     {revision, changed_activity_revisions}
   end
 
   # Applies the update to the revision
   defp update_revision({revision, activity_revisions}, update, _) do
-
     {:ok, updated} = Oli.Resources.update_revision(revision, update)
     {updated, activity_revisions}
   end
-
 end

--- a/lib/oli/authoring/editing/page_editor.ex
+++ b/lib/oli/authoring/editing/page_editor.ex
@@ -183,8 +183,6 @@ defmodule Oli.Authoring.Editing.PageEditor do
   def create_context(project_slug, revision_slug, author) do
     editor_map = Activities.create_registered_activity_map(project_slug)
 
-    IO.inspect editor_map
-
     with {:ok, publication} <-
            Publishing.get_unpublished_publication_by_slug!(project_slug) |> trap_nil(),
          {:ok, %{content: content} = revision} <-

--- a/lib/oli/authoring/editing/page_editor.ex
+++ b/lib/oli/authoring/editing/page_editor.ex
@@ -181,15 +181,9 @@ defmodule Oli.Authoring.Editing.PageEditor do
   for a specific resource / revision.
   """
   def create_context(project_slug, revision_slug, author) do
-    editor_map = Oli.Activities.create_registered_activity_map()
+    editor_map = Activities.create_registered_activity_map(project_slug)
 
-    editor_map = Enum.reduce(editor_map, %{}, fn {key, a}, m ->
-      if a.globallyAvailable === true do
-        Map.put(m, key, a)
-      else
-        m
-      end
-    end)
+    IO.inspect editor_map
 
     with {:ok, publication} <-
            Publishing.get_unpublished_publication_by_slug!(project_slug) |> trap_nil(),

--- a/lib/oli/delivery/attempts.ex
+++ b/lib/oli/delivery/attempts.ex
@@ -797,7 +797,7 @@ defmodule Oli.Delivery.Attempts do
     activity_attempt = get_activity_attempt_by(attempt_guid: activity_attempt_guid)
     activity_registration_slug = activity_attempt.revision.activity_type.slug
     case Oli.Activities.get_registration_by_slug(activity_registration_slug) do
-      %Activities.Registration{allow_client_evaluation: true} ->
+      %Activities.ActivityRegistration{allow_client_evaluation: true} ->
         Repo.transaction(fn ->
 
           part_attempts = get_latest_part_attempts(activity_attempt_guid)

--- a/lib/oli/registrar.ex
+++ b/lib/oli/registrar.ex
@@ -1,17 +1,23 @@
 defmodule Oli.Registrar do
-
   alias Oli.Activities
   alias Oli.Activities.Manifest
 
-  def register_local_activities() do
+  def register_local_activities(%MapSet{} = global \\ MapSet.new) do
     Application.fetch_env!(:oli, :local_activity_manifests)
-      |> Enum.map(fn body ->
-        case Jason.decode(body) do
-          {:ok, json} -> json
+    |> Enum.map(fn body ->
+      case Jason.decode(body) do
+        {:ok, json} -> json
+      end
+    end)
+    |> Enum.map(&Manifest.parse/1)
+    |> Enum.map(fn m ->
+      m =
+        if(MapSet.member?(global, m.id)) do
+          Map.merge(m, %{global: true})
+        else
+          m
         end
-      end)
-      |> Enum.map(&Manifest.parse/1)
-      |> Enum.map(fn m -> Activities.register_activity(m) end)
+      Activities.register_activity(m)
+    end)
   end
-
 end

--- a/lib/oli/resources/revision.ex
+++ b/lib/oli/resources/revision.ex
@@ -29,7 +29,7 @@ defmodule Oli.Resources.Revision do
     field :recommended_attempts, :integer, default: 0
     field :time_limit, :integer, default: 0
     belongs_to :scoring_strategy, Oli.Resources.ScoringStrategy
-    belongs_to :activity_type, Oli.Activities.Registration
+    belongs_to :activity_type, Oli.Activities.ActivityRegistration
     belongs_to :primary_resource, Oli.Resources.Resource
 
     has_many :warnings, Oli.Qa.Warning

--- a/lib/oli/utils/db_seeder.ex
+++ b/lib/oli/utils/db_seeder.ex
@@ -15,6 +15,7 @@ defmodule Oli.Seeder do
   alias Oli.Delivery.Sections.Section
   alias Oli.Delivery.Attempts.Snapshot
   alias Oli.Qa.Reviews
+  alias Oli.Activities
 
   def base_project_with_resource(author) do
 

--- a/lib/oli_web/controllers/activity_manage_controller.ex
+++ b/lib/oli_web/controllers/activity_manage_controller.ex
@@ -1,0 +1,51 @@
+defmodule OliWeb.ActivityManageController do
+  use OliWeb, :controller
+
+  alias Oli.Activities
+
+  @spec index(Plug.Conn.t(), any) :: Plug.Conn.t()
+  def index(conn, _params) do
+    registered_activities =
+      Enum.sort_by(Activities.list_activity_registrations(), & &1.globally_available, :desc)
+
+    params = %{
+      registered_activities: registered_activities
+    }
+
+    render(
+      %{conn | assigns: Map.merge(conn.assigns, params)},
+      "index.html",
+      Keyword.put_new([title: "Manage"], :active, :activity_manage)
+    )
+  end
+
+  def make_global(conn, %{"activity_slug" => activity_slug}) do
+    case Activities.set_global_status(activity_slug, true) do
+      {:ok, _} ->
+        redirect(conn, to: Routes.activity_manage_path(conn, :index))
+
+      {:error, message} ->
+        conn
+        |> put_flash(
+          :error,
+          "We couldn't switch registered activity to globally available. #{message}"
+        )
+        |> redirect(to: Routes.activity_manage_path(conn, :index))
+    end
+  end
+
+  def make_private(conn, %{"activity_slug" => activity_slug}) do
+    case Activities.set_global_status(activity_slug, false) do
+      {:ok, _} ->
+        redirect(conn, to: Routes.activity_manage_path(conn, :index))
+
+      {:error, message} ->
+        conn
+        |> put_flash(
+          :error,
+          "We couldn't switch registered activity to privately available. #{message}"
+        )
+        |> redirect(to: Routes.activity_manage_path(conn, :index))
+    end
+  end
+end

--- a/lib/oli_web/controllers/activity_manage_controller.ex
+++ b/lib/oli_web/controllers/activity_manage_controller.ex
@@ -6,7 +6,7 @@ defmodule OliWeb.ActivityManageController do
   @spec index(Plug.Conn.t(), any) :: Plug.Conn.t()
   def index(conn, _params) do
     registered_activities =
-      Enum.sort_by(Activities.list_activity_registrations(), & &1.globally_available, :desc)
+      Enum.sort_by(Activities.list_activity_registrations(), & &1.title, :asc)
 
     params = %{
       registered_activities: registered_activities

--- a/lib/oli_web/controllers/project_activity_controller.ex
+++ b/lib/oli_web/controllers/project_activity_controller.ex
@@ -1,0 +1,28 @@
+defmodule OliWeb.ProjectActivityController do
+  use OliWeb, :controller
+
+  alias Oli.Activities
+
+  def enable_activity(conn, %{"project_id" => project_id, "activity_slug" => activity_slug}) do
+     case Activities.enable_activity_in_project(project_id, activity_slug) do
+      {:ok, _} ->
+        redirect conn, to: Routes.project_path(conn, :overview, project_id)
+      {:error, message} ->
+        conn
+        |> put_flash(:error, "We couldn't enable activity for the project. #{message}")
+        |> redirect(to: Routes.project_path(conn, :overview, project_id))
+    end
+  end
+
+  def disable_activity(conn, %{"project_id" => project_id, "activity_slug" => activity_slug}) do
+    case Activities.disable_activity_in_project(project_id, activity_slug) do
+      {:ok, _} ->
+        redirect conn, to: Routes.project_path(conn, :overview, project_id)
+      {:error, message} ->
+        conn
+        |> put_flash(:error, "We couldn't disable activity from the project. #{message}")
+        |> redirect(to: Routes.project_path(conn, :overview, project_id))
+    end
+  end
+
+end

--- a/lib/oli_web/controllers/project_controller.ex
+++ b/lib/oli_web/controllers/project_controller.ex
@@ -9,52 +9,74 @@ defmodule OliWeb.ProjectController do
   alias Oli.Qa
   alias Oli.Analytics.Datashop
   alias OliWeb.Common.Breadcrumb
+  alias Oli.Activities
+
+  alias Oli.Repo
 
   def overview(conn, project_params) do
     project = conn.assigns.project
+
     params = %{
       breadcrumbs: [Breadcrumb.new(%{full_title: "Overview"})],
       active: :overview,
       collaborators: Accounts.project_authors(project),
-      changeset: Utils.value_or(
-        Map.get(project_params, :changeset),
-        Project.changeset(project)),
+      activities_enabled: Activities.activities_for_project(project),
+      changeset:
+        Utils.value_or(
+          Map.get(project_params, :changeset),
+          Project.changeset(project)
+        )
     }
-    render %{conn | assigns: Map.merge(conn.assigns, params)}, "overview.html"
+
+    render(%{conn | assigns: Map.merge(conn.assigns, params)}, "overview.html")
   end
 
   def unpublished(pub), do: pub.published == false
 
   def resource_editor(conn, _project_params) do
-    render conn, "resource_editor.html", title: "Resource Editor", active: :resource_editor
+    render(conn, "resource_editor.html", title: "Resource Editor", active: :resource_editor)
   end
 
   def publish(conn, _) do
     project = conn.assigns.project
-    latest_published_publication = Publishing.get_latest_published_publication_by_slug!(project.slug)
+
+    latest_published_publication =
+      Publishing.get_latest_published_publication_by_slug!(project.slug)
+
     active_publication = Publishing.get_unpublished_publication_by_slug!(project.slug)
 
     # publish
-    {has_changes, active_publication_changes, parent_pages} = case latest_published_publication do
-      nil -> {true, nil, %{}}
-      _ ->
-        changes = Publishing.diff_publications(latest_published_publication, active_publication)
-          |> (&(:maps.filter fn _, v -> v != :identical end, &1)).()
-        has_changes = Map.values(changes)
-          |> Enum.any?(fn {status, _} -> status != :identical end)
+    {has_changes, active_publication_changes, parent_pages} =
+      case latest_published_publication do
+        nil ->
+          {true, nil, %{}}
 
-        parent_pages = if has_changes do
-          Map.values(changes)
-          |> Enum.filter(fn {status, _} -> status != :identical end)
-          |> Enum.map(fn {_, %{revision: revision}} -> revision end)
-          |> Enum.filter(fn r -> r.resource_type_id == Oli.Resources.ResourceType.get_id_by_type("activity") end)
-          |> Enum.map(fn r -> r.resource_id end)
-          |> Oli.Publishing.determine_parent_pages(Oli.Publishing.AuthoringResolver.publication(project.slug).id)
-        else
-          %{}
-        end
+        _ ->
+          changes =
+            Publishing.diff_publications(latest_published_publication, active_publication)
+            |> (&:maps.filter(fn _, v -> v != :identical end, &1)).()
 
-        {has_changes, changes, parent_pages}
+          has_changes =
+            Map.values(changes)
+            |> Enum.any?(fn {status, _} -> status != :identical end)
+
+          parent_pages =
+            if has_changes do
+              Map.values(changes)
+              |> Enum.filter(fn {status, _} -> status != :identical end)
+              |> Enum.map(fn {_, %{revision: revision}} -> revision end)
+              |> Enum.filter(fn r ->
+                r.resource_type_id == Oli.Resources.ResourceType.get_id_by_type("activity")
+              end)
+              |> Enum.map(fn r -> r.resource_id end)
+              |> Oli.Publishing.determine_parent_pages(
+                Oli.Publishing.AuthoringResolver.publication(project.slug).id
+              )
+            else
+              %{}
+            end
+
+          {has_changes, changes, parent_pages}
       end
 
     base_url = Oli.Utils.get_base_url()
@@ -65,7 +87,7 @@ defmodule OliWeb.ProjectController do
     public_keyset_url = "#{base_url}/.well-known/jwks.json"
     redirect_uris = "#{base_url}/lti/launch"
 
-    render conn, "publish.html",
+    render(conn, "publish.html",
       # page
       breadcrumbs: [Breadcrumb.new(%{full_title: "Publish"})],
       active: :publish,
@@ -80,7 +102,7 @@ defmodule OliWeb.ProjectController do
       initiate_login_url: initiate_login_url,
       public_keyset_url: public_keyset_url,
       redirect_uris: redirect_uris
-
+    )
   end
 
   def review_project(conn, _params) do
@@ -90,7 +112,6 @@ defmodule OliWeb.ProjectController do
     conn
     |> redirect(to: Routes.project_path(conn, :publish, project))
   end
-
 
   def publish_active(conn, _params) do
     project = conn.assigns.project
@@ -102,22 +123,27 @@ defmodule OliWeb.ProjectController do
   end
 
   def insights(conn, _project_params) do
-    render conn, "insights.html", breadcrumbs: [Breadcrumb.new(%{full_title: "Insights"})], active: :insights
+    render(conn, "insights.html",
+      breadcrumbs: [Breadcrumb.new(%{full_title: "Insights"})],
+      active: :insights
+    )
   end
 
   def create(conn, %{"project" => %{"title" => title} = _project_params}) do
     case Course.create_project(title, conn.assigns.current_author) do
       {:ok, %{project: project}} ->
-        redirect conn, to: Routes.project_path(conn, :overview, project)
+        redirect(conn, to: Routes.project_path(conn, :overview, project))
+
       {:error, _changeset} ->
         conn
-          |> put_flash(:error, "Could not create project. Please try again")
-          |> redirect(to: Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.ProjectsLive))
+        |> put_flash(:error, "Could not create project. Please try again")
+        |> redirect(to: Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.ProjectsLive))
     end
   end
 
   def update(conn, %{"project" => project_params}) do
     project = conn.assigns.project
+
     case Course.update_project(project, project_params) do
       {:ok, project} ->
         conn
@@ -129,8 +155,10 @@ defmodule OliWeb.ProjectController do
           breadcrumbs: [Breadcrumb.new(%{full_title: "Overview"})],
           active: :overview,
           collaborators: Accounts.project_authors(project),
+          activities_enabled: Activities.activities_for_project(project),
           changeset: changeset
         }
+
         conn
         |> Map.put(:assigns, Map.merge(conn.assigns, overview_params))
         |> put_flash(:error, "Project could not be updated.")
@@ -140,7 +168,11 @@ defmodule OliWeb.ProjectController do
 
   def download_datashop(conn, _project_params) do
     project = conn.assigns.project
+
     conn
-    |> send_download({:binary, Datashop.export(project.id)}, filename: "Datashop_#{project.slug}.xml")
+    |> send_download({:binary, Datashop.export(project.id)},
+      filename: "Datashop_#{project.slug}.xml"
+    )
   end
+
 end

--- a/lib/oli_web/controllers/project_controller.ex
+++ b/lib/oli_web/controllers/project_controller.ex
@@ -11,8 +11,6 @@ defmodule OliWeb.ProjectController do
   alias OliWeb.Common.Breadcrumb
   alias Oli.Activities
 
-  alias Oli.Repo
-
   def overview(conn, project_params) do
     project = conn.assigns.project
 

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -223,6 +223,10 @@ defmodule OliWeb.Router do
     put "/:project_id/collaborators/:author_email", CollaboratorController, :update
     delete "/:project_id/collaborators/:author_email", CollaboratorController, :delete
 
+    # Activities
+    put "/:project_id/activities/enable/:activity_slug", ProjectActivityController, :enable_activity
+    put "/:project_id/activities/disable/:activity_slug", ProjectActivityController, :disable_activity
+
     # Insights
     get "/:project_id/insights", ProjectController, :insights
     # Ideally, analytics should be live-routed to preserve forward/back button when toggling

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -399,6 +399,10 @@ defmodule OliWeb.Router do
     get "/invite", InviteController, :index
     post "/invite", InviteController, :create
 
+    get "/manage_activities", ActivityManageController, :index
+    put "/manage_activities/make_global/:activity_slug", ActivityManageController, :make_global
+    put "/manage_activities/make_private/:activity_slug", ActivityManageController, :make_private
+
     put "/approve_registration", InstitutionController, :approve_registration
     delete "/pending_registration/:id", InstitutionController, :remove_registration
   end

--- a/lib/oli_web/templates/activity_manage/index.html.eex
+++ b/lib/oli_web/templates/activity_manage/index.html.eex
@@ -1,0 +1,29 @@
+<div class="card mt-4">
+  <div class="card-body">
+    <h4>Activities</h4>
+    <table class="table table-sm">
+      <thead class="thead-light">
+        <tr>
+          <th>Title</th>
+          <th>Global</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <%= for activity <- @registered_activities do %>
+          <tr>
+            <td><%= "#{activity.title}"%></td>
+            <td><%= "#{activity.globally_available}"%></td>
+            <td>
+              <%= if activity.globally_available do %>
+                <%= link "Make Private", to: Routes.activity_manage_path(@conn, :make_private, activity.slug), method: :put, class: "text-danger" %>
+              <% else %>
+                <%= link "Make Global", to: Routes.activity_manage_path(@conn, :make_global,activity.slug), method: :put, class: "text-success" %>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/lib/oli_web/templates/activity_manage/index.html.eex
+++ b/lib/oli_web/templates/activity_manage/index.html.eex
@@ -5,6 +5,9 @@
       <thead class="thead-light">
         <tr>
           <th>Title</th>
+          <th>Slug</th>
+          <th>Description</th>
+          <th>Eval Method</th>
           <th>Global</th>
           <th></th>
         </tr>
@@ -13,6 +16,9 @@
         <%= for activity <- @registered_activities do %>
           <tr>
             <td><%= "#{activity.title}"%></td>
+            <td><%= "#{activity.slug}"%></td>
+            <td><%= "#{activity.description}"%></td>
+            <td><%= "#{if activity.allow_client_evaluation do "Client" else "Server" end}"%></td>
             <td><%= "#{activity.globally_available}"%></td>
             <td>
               <%= if activity.globally_available do %>

--- a/lib/oli_web/templates/layout/_admin_sidebar.html.eex
+++ b/lib/oli_web/templates/layout/_admin_sidebar.html.eex
@@ -7,3 +7,4 @@
 
 <%= sidebar_link @conn, "Ingest", :ingest, to: Routes.ingest_path(@conn, :index) %>
 <%= sidebar_link @conn, "Invite", :invite, to: Routes.invite_path(@conn, :index) %>
+<%= sidebar_link @conn, "Activities", :activity_manage, to: Routes.activity_manage_path(@conn, :index) %>

--- a/lib/oli_web/templates/project/_tr_activities_available.html.eex
+++ b/lib/oli_web/templates/project/_tr_activities_available.html.eex
@@ -1,0 +1,15 @@
+<tr>
+  <td><%= "#{@activity_enabled.title}"%></td>
+  <td><%= "#{@activity_enabled.enabled}"%></td>
+  <td class="user-actions text-center">
+    <%= if @activity_enabled.global do %>
+      <%= "---"%>
+    <% else %>
+    <%= if @activity_enabled.enabled do %>
+    <%= link "Remove", to: Routes.project_activity_path(@conn, :disable_activity, @project, @activity_enabled.slug), method: :put, class: "text-danger" %>
+    <% else %>
+    <%= link "Add", to: Routes.project_activity_path(@conn, :enable_activity, @project, @activity_enabled.slug), method: :put, class: "text-success" %>
+    <% end %>
+    <% end %>
+  </td>
+</tr>

--- a/lib/oli_web/templates/project/_tr_activities_available.html.eex
+++ b/lib/oli_web/templates/project/_tr_activities_available.html.eex
@@ -5,11 +5,11 @@
     <%= if @activity_enabled.global do %>
       <%= "---"%>
     <% else %>
-    <%= if @activity_enabled.enabled do %>
-    <%= link "Remove", to: Routes.project_activity_path(@conn, :disable_activity, @project, @activity_enabled.slug), method: :put, class: "text-danger" %>
-    <% else %>
-    <%= link "Add", to: Routes.project_activity_path(@conn, :enable_activity, @project, @activity_enabled.slug), method: :put, class: "text-success" %>
-    <% end %>
+      <%= if @activity_enabled.enabled do %>
+        <%= link "Remove", to: Routes.project_activity_path(@conn, :disable_activity, @project, @activity_enabled.slug), method: :put, class: "text-danger" %>
+      <% else %>
+        <%= link "Add", to: Routes.project_activity_path(@conn, :enable_activity, @project, @activity_enabled.slug), method: :put, class: "text-success" %>
+      <% end %>
     <% end %>
   </td>
 </tr>

--- a/lib/oli_web/templates/project/overview.html.eex
+++ b/lib/oli_web/templates/project/overview.html.eex
@@ -22,7 +22,9 @@
 
       <% end %>
 
-      <h2>Collaborators</h2>
+      <div class="card mt-4">
+        <div class="card-body">
+      <h4>Collaborators</h4>
       <script src="https://www.google.com/recaptcha/api.js"></script>
       <%= form_for @conn, Routes.collaborator_path(@conn, :create, @project), [id: "form-add-collaborator"], fn f -> %>
         <div class="form-group">
@@ -63,7 +65,25 @@
           <%= render_many @collaborators, OliWeb.ProjectView, "_tr_collaborator.html", %{conn: @conn, as: :collaborator, project: @project} %>
         </tbody>
       </table>
-
+        </div>
+      </div>
+      <div class="card mt-4">
+        <div class="card-body">
+          <h4>Activities Enabled</h4>
+          <table class="table table-sm">
+            <thead class="thead-light">
+            <tr>
+              <th>Title</th>
+              <th>Enabled</th>
+              <th></th>
+            </tr>
+            </thead>
+            <tbody>
+            <%= render_many @activities_enabled, OliWeb.ProjectView, "_tr_activities_available.html", %{conn: @conn, as: :activity_enabled, project: @project} %>
+            </tbody>
+          </table>
+        </div>
+      </div>
       <div class="row my-4">
         <div class="col-12">
           <%= live_render @conn, OliWeb.Projects.VisibilityLive, session: %{ "project_slug" => @project.slug } %>

--- a/lib/oli_web/views/activity_manage_view.ex
+++ b/lib/oli_web/views/activity_manage_view.ex
@@ -1,0 +1,3 @@
+defmodule OliWeb.ActivityManageView do
+  use OliWeb, :view
+end

--- a/priv/repo/migrations/20210312181346_mark_activity_global_status.exs
+++ b/priv/repo/migrations/20210312181346_mark_activity_global_status.exs
@@ -1,0 +1,9 @@
+defmodule Oli.Repo.Migrations.MarkActivityGlobalStatus do
+  use Ecto.Migration
+
+  def change do
+    alter table(:activity_registrations) do
+      add :globally_available, :boolean, default: false, null: false
+    end
+  end
+end

--- a/priv/repo/migrations/20210312181346_mark_activity_global_status.exs
+++ b/priv/repo/migrations/20210312181346_mark_activity_global_status.exs
@@ -1,9 +1,21 @@
 defmodule Oli.Repo.Migrations.MarkActivityGlobalStatus do
   use Ecto.Migration
+  import Ecto.Query, warn: false
 
   def change do
     alter table(:activity_registrations) do
       add :globally_available, :boolean, default: false, null: false
     end
+
+    flush()
+
+    from(a in "activity_registrations", where: a.slug in [
+      "oli_multiple_choice",
+      "oli_check_all_that_apply",
+      "oli_short_answer",
+      "oli_ordering"
+    ])
+    |> Oli.Repo.update_all(set: [globally_available: true])
+
   end
 end

--- a/priv/repo/migrations/20210312220005_add_registrations_projects.exs
+++ b/priv/repo/migrations/20210312220005_add_registrations_projects.exs
@@ -1,0 +1,15 @@
+defmodule Oli.Repo.Migrations.AddRegistrationsProjects do
+  use Ecto.Migration
+
+  def change do
+    create table(:activity_registration_projects, primary_key: false) do
+      timestamps(type: :timestamptz)
+      add :activity_registration_id, references(:activity_registrations), primary_key: true
+      add :project_id, references(:projects), primary_key: true
+    end
+
+    create index(:activity_registration_projects, [:activity_registration_id])
+    create index(:activity_registration_projects, [:project_id])
+    create unique_index(:activity_registration_projects, [:activity_registration_id, :project_id], name: :index_activity_registration_project)
+  end
+end

--- a/priv/repo/migrations/20210312220005_create_activity_registrations_projects.exs
+++ b/priv/repo/migrations/20210312220005_create_activity_registrations_projects.exs
@@ -1,4 +1,4 @@
-defmodule Oli.Repo.Migrations.AddRegistrationsProjects do
+defmodule Oli.Repo.Migrations.CreateActivityRegistrationsProjects do
   use Ecto.Migration
 
   def change do

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -17,28 +17,31 @@ alias Oli.Authoring.Collaborators
 
 # create system roles
 if !Oli.Repo.get_by(Oli.Accounts.SystemRole, id: 1) do
-  Oli.Repo.insert! %Oli.Accounts.SystemRole{
+  Oli.Repo.insert!(%Oli.Accounts.SystemRole{
     id: 1,
     type: "author"
-  }
+  })
 
-  Oli.Repo.insert! %Oli.Accounts.SystemRole{
+  Oli.Repo.insert!(%Oli.Accounts.SystemRole{
     id: 2,
     type: "admin"
-  }
+  })
 end
 
 # create admin author
 if !Oli.Repo.get_by(Oli.Accounts.Author, email: System.get_env("ADMIN_EMAIL", "admin@example.edu")) do
-  case Pow.Ecto.Context.create(%{
-    email: System.get_env("ADMIN_EMAIL", "admin@example.edu"),
-    name: "Administrator",
-    given_name: "Administrator",
-    family_name: "",
-    password: System.get_env("ADMIN_PASSWORD", "changeme"),
-    password_confirmation: System.get_env("ADMIN_PASSWORD", "changeme"),
-    system_role_id: Oli.Accounts.SystemRole.role_id.admin
-  }, otp_app: :oli) do
+  case Pow.Ecto.Context.create(
+         %{
+           email: System.get_env("ADMIN_EMAIL", "admin@example.edu"),
+           name: "Administrator",
+           given_name: "Administrator",
+           family_name: "",
+           password: System.get_env("ADMIN_PASSWORD", "changeme"),
+           password_confirmation: System.get_env("ADMIN_PASSWORD", "changeme"),
+           system_role_id: Oli.Accounts.SystemRole.role_id().admin
+         },
+         otp_app: :oli
+       ) do
     {:ok, user} ->
       PowEmailConfirmation.Ecto.Context.confirm_email(user, %{}, otp_app: :oli)
   end
@@ -46,80 +49,89 @@ end
 
 # create project roles
 if !Oli.Repo.get_by(Oli.Authoring.Authors.ProjectRole, id: 1) do
-  Oli.Repo.insert! %Oli.Authoring.Authors.ProjectRole{
+  Oli.Repo.insert!(%Oli.Authoring.Authors.ProjectRole{
     id: 1,
     type: "owner"
-  }
+  })
 
-  Oli.Repo.insert! %Oli.Authoring.Authors.ProjectRole{
+  Oli.Repo.insert!(%Oli.Authoring.Authors.ProjectRole{
     id: 2,
     type: "contributor"
-  }
+  })
 end
 
 # create resource types
-existing_rts = Oli.Resources.list_resource_types()
-|> Enum.map(fn %{id: id} -> id end)
-|> MapSet.new()
+existing_rts =
+  Oli.Resources.list_resource_types()
+  |> Enum.map(fn %{id: id} -> id end)
+  |> MapSet.new()
 
 Oli.Resources.ResourceType.get_types()
 |> Enum.each(fn rt ->
-
   if !MapSet.member?(existing_rts, rt.id) do
     Oli.Resources.create_resource_type(rt)
   end
-
 end)
 
 # create scoring strategy types
 if !Oli.Repo.get_by(Oli.Resources.ScoringStrategy, id: 1) do
-
   Oli.Resources.ScoringStrategy.get_types()
   |> Enum.map(&Oli.Resources.create_scoring_strategy/1)
-
 end
 
 # Seed the database with the locally implemented activity types
-Oli.Registrar.register_local_activities()
+Oli.Registrar.register_local_activities(
+  MapSet.new([
+    "oli_multiple_choice",
+    "oli_check_all_that_apply",
+    "oli_short_answer",
+    "oli_ordering"
+  ])
+)
 
 # create themes
-[%Oli.Authoring.Theme{
-  id: 1,
-  name: "Automatic",
-  url: nil,
-  default: true
-},
-%Oli.Authoring.Theme{
-  id: 2,
-  name: "Light",
-  url: "/css/authoring_theme_light.css",
-  default: false
-},
-%Oli.Authoring.Theme{
-  id: 3,
-  name: "Dark",
-  url: "/css/authoring_theme_dark.css",
-  default: false
-}]
+[
+  %Oli.Authoring.Theme{
+    id: 1,
+    name: "Automatic",
+    url: nil,
+    default: true
+  },
+  %Oli.Authoring.Theme{
+    id: 2,
+    name: "Light",
+    url: "/css/authoring_theme_light.css",
+    default: false
+  },
+  %Oli.Authoring.Theme{
+    id: 3,
+    name: "Dark",
+    url: "/css/authoring_theme_dark.css",
+    default: false
+  }
+]
 |> Enum.map(&Oli.Authoring.Theme.changeset/1)
 |> Enum.map(fn t -> Oli.Repo.insert!(t, on_conflict: :replace_all, conflict_target: :id) end)
 
 # create a default active lti_1p3 jwk
 if !Oli.Repo.get_by(Lti_1p3.DataProviders.EctoProvider.Jwk, id: 1) do
   %{private_key: private_key} = Lti_1p3.KeyGenerator.generate_key_pair()
+
   Lti_1p3.create_jwk(%Lti_1p3.Jwk{
     pem: private_key,
     typ: "JWT",
     alg: "RS256",
     kid: UUID.uuid4(),
-    active: true,
+    active: true
   })
 end
 
 # create lti_1p3 platform roles
 if !Oli.Repo.get_by(Lti_1p3.DataProviders.EctoProvider.PlatformRole, id: 1) do
   Lti_1p3.Tool.PlatformRoles.list_roles()
-  |> Enum.map(fn t -> struct(Lti_1p3.DataProviders.EctoProvider.PlatformRole, Map.from_struct(t)) end)
+  |> Enum.map(fn t ->
+    struct(Lti_1p3.DataProviders.EctoProvider.PlatformRole, Map.from_struct(t))
+  end)
   |> Enum.map(&Lti_1p3.DataProviders.EctoProvider.PlatformRole.changeset/1)
   |> Enum.map(fn t -> Oli.Repo.insert!(t, on_conflict: :replace_all, conflict_target: :id) end)
 end
@@ -127,7 +139,9 @@ end
 # create lti_1p3 context roles
 if !Oli.Repo.get_by(Lti_1p3.DataProviders.EctoProvider.ContextRole, id: 1) do
   Lti_1p3.Tool.ContextRoles.list_roles()
-  |> Enum.map(fn t -> struct(Lti_1p3.DataProviders.EctoProvider.ContextRole, Map.from_struct(t)) end)
+  |> Enum.map(fn t ->
+    struct(Lti_1p3.DataProviders.EctoProvider.ContextRole, Map.from_struct(t))
+  end)
   |> Enum.map(&Lti_1p3.DataProviders.EctoProvider.ContextRole.changeset/1)
   |> Enum.map(fn t -> Oli.Repo.insert!(t, on_conflict: :replace_all, conflict_target: :id) end)
 end
@@ -136,12 +150,15 @@ end
 if Application.fetch_env!(:oli, :env) == :dev do
   if !Oli.Repo.get_by(Oli.Authoring.Course.Project, id: 1) do
     # create an example package and publication
-    admin_author = Oli.Accounts.get_author_by_email(System.get_env("ADMIN_EMAIL", "admin@example.edu"))
+    admin_author =
+      Oli.Accounts.get_author_by_email(System.get_env("ADMIN_EMAIL", "admin@example.edu"))
 
-    seeds = Seeder.base_project_with_resource(admin_author)
-    |> Seeder.create_section()
-    |> Seeder.add_activity(%{title: "Activity with with no attempts"}, :activity_no_attempts)
-    |> SnapshotSeeder.setup_csv(Path.expand(__DIR__) <> "/test_snapshots.csv")
+    seeds =
+      Seeder.base_project_with_resource(admin_author)
+      |> Seeder.create_section()
+      |> Seeder.add_activity(%{title: "Activity with with no attempts"}, :activity_no_attempts)
+      |> SnapshotSeeder.setup_csv(Path.expand(__DIR__) <> "/test_snapshots.csv")
+
     Collaborators.add_collaborator(admin_author, seeds.project)
 
     Oli.Publishing.publish_project(seeds.project)
@@ -153,17 +170,18 @@ if Application.fetch_env!(:oli, :env) == :dev do
 
         json
         |> Enum.each(fn attrs ->
-          attrs = attrs
-          |> Map.merge(%{"tool_jwk_id" => jwk_id, "institution_id" => 1})
+          attrs =
+            attrs
+            |> Map.merge(%{"tool_jwk_id" => jwk_id, "institution_id" => 1})
 
           %Oli.Lti_1p3.Tool.Registration{}
           |> Oli.Lti_1p3.Tool.Registration.changeset(attrs)
           |> Oli.Repo.insert()
         end)
+
       _ ->
         # no registrations.json file, do nothing
         nil
     end
   end
-
 end

--- a/test/oli/activities_test.exs
+++ b/test/oli/activities_test.exs
@@ -1,0 +1,58 @@
+defmodule Oli.ActivitiesTest do
+  use Oli.DataCase
+  alias Oli.Activities
+  alias Oli.Repo
+  alias Oli.Authoring.Course.Project
+  alias Oli.Activities.ActivityRegistrationProject
+  import ExUnit.Assertions
+
+  setup [:author_project_fixture]
+
+    describe "add activity to project" do
+      test "adding a custom registered activity to a project", %{project: project} do
+        custom_activity = Activities.get_registration_by_slug("oli_image_coding")
+
+        Activities.enable_activity_in_project(project.slug, custom_activity.slug)
+        project_activities =  Activities.activities_for_project(project)
+
+        assert Enum.member?(project_activities, %{
+          enabled: true,
+          global: false,
+          slug: "oli_image_coding",
+          title: "Image Coding"
+        })
+      end
+
+      test "removing a custom registered activity from a project", %{project: project} do
+        custom_activity = Activities.get_registration_by_slug("oli_image_coding")
+
+        Activities.enable_activity_in_project(project.slug, custom_activity.slug)
+        Activities.disable_activity_in_project(project.slug, custom_activity.slug)
+        project_activities =  Activities.activities_for_project(project)
+
+        assert Enum.member?(project_activities, %{
+          enabled: false,
+          global: false,
+          slug: "oli_image_coding",
+          title: "Image Coding"
+        })
+      end
+
+      test "default editor menu should not include custom activity", %{project: project} do
+        editor_menu_items =  Activities.create_registered_activity_map(project.slug)
+
+        assert !Map.has_key?(editor_menu_items, "oli_image_coding")
+      end
+
+      test "editor menu with custom activity included", %{project: project} do
+        custom_activity = Activities.get_registration_by_slug("oli_image_coding")
+
+        Activities.enable_activity_in_project(project.slug, custom_activity.slug)
+        editor_menu_items =  Activities.create_registered_activity_map(project.slug)
+
+        assert Map.has_key?(editor_menu_items, "oli_image_coding")
+      end
+
+    end
+
+end

--- a/test/oli/activities_test.exs
+++ b/test/oli/activities_test.exs
@@ -1,9 +1,6 @@
 defmodule Oli.ActivitiesTest do
   use Oli.DataCase
   alias Oli.Activities
-  alias Oli.Repo
-  alias Oli.Authoring.Course.Project
-  alias Oli.Activities.ActivityRegistrationProject
   import ExUnit.Assertions
 
   setup [:author_project_fixture]

--- a/test/oli/activities_test.exs
+++ b/test/oli/activities_test.exs
@@ -38,7 +38,8 @@ defmodule Oli.ActivitiesTest do
       test "default editor menu should not include custom activity", %{project: project} do
         editor_menu_items =  Activities.create_registered_activity_map(project.slug)
 
-        assert !Map.has_key?(editor_menu_items, "oli_image_coding")
+        image_coding = Map.get(editor_menu_items, "oli_image_coding")
+        assert !image_coding.globallyAvailable and !image_coding.enabledForProject
       end
 
       test "editor menu with custom activity included", %{project: project} do
@@ -47,7 +48,9 @@ defmodule Oli.ActivitiesTest do
         Activities.enable_activity_in_project(project.slug, custom_activity.slug)
         editor_menu_items =  Activities.create_registered_activity_map(project.slug)
 
-        assert Map.has_key?(editor_menu_items, "oli_image_coding")
+        image_coding = Map.get(editor_menu_items, "oli_image_coding")
+        assert !image_coding.globallyAvailable and image_coding.enabledForProject
+
       end
 
     end

--- a/test/oli/delivery/attempts_test.exs
+++ b/test/oli/delivery/attempts_test.exs
@@ -258,13 +258,14 @@ defmodule Oli.Delivery.AttemptsTest do
 
     test "processes a set of client evaluations for an activity that permits client evaluation" do
       # create mock activity which allows client evaluation
-      {:ok, %Activities.Registration{}} = Activities.register_activity(%Manifest{
+      {:ok, %Activities.ActivityRegistration{}} = Activities.register_activity(%Manifest{
         id: "test_allow_client_eval",
         friendlyName: "Test Client Eval",
         description: "A test activity that allows client evaluation",
         delivery: %ModeSpecification{element: "test-client-eval", entry: "./delivery-entry.ts"},
         authoring: %ModeSpecification{element: "test-client-eval", entry: "./authoring-entry.ts"},
         allowClientEvaluation: true,
+        global: true,
       })
 
       # create an example project with the activity in a graded page
@@ -304,13 +305,14 @@ defmodule Oli.Delivery.AttemptsTest do
 
     test "fails to process a set of client evaluations for an activity that does not permit client evaluation" do
       # create mock activity which does not allow client evaluation
-      {:ok, %Activities.Registration{}} = Activities.register_activity(%Manifest{
+      {:ok, %Activities.ActivityRegistration{}} = Activities.register_activity(%Manifest{
         id: "test_refuse_client_eval",
         friendlyName: "Test Client Eval",
         description: "A test activity that allows client evaluation",
         delivery: %ModeSpecification{element: "test-client-eval", entry: "./delivery-entry.ts"},
         authoring: %ModeSpecification{element: "test-client-eval", entry: "./authoring-entry.ts"},
         allowClientEvaluation: false,
+        global: true,
       })
 
       # create an example project with the activity in a graded page

--- a/test/oli/registrar_test.exs
+++ b/test/oli/registrar_test.exs
@@ -18,6 +18,7 @@ defmodule Oli.RegistrarTest do
       assert r.delivery_script == "oli_check_all_that_apply_delivery.js"
       assert r.authoring_element == "oli-check-all-that-apply-authoring"
       assert r.delivery_element == "oli-check-all-that-apply-delivery"
+      assert r.globally_available == true
 
     end
 
@@ -34,6 +35,7 @@ defmodule Oli.RegistrarTest do
       assert r.friendlyName == "Check All That Apply"
       assert r.authoringElement == "oli-check-all-that-apply-authoring"
       assert r.deliveryElement == "oli-check-all-that-apply-delivery"
+      assert r.globallyAvailable == true
 
     end
 

--- a/test/oli_web/controllers/project_controller_test.exs
+++ b/test/oli_web/controllers/project_controller_test.exs
@@ -36,6 +36,7 @@ defmodule OliWeb.ProjectControllerTest do
            }
          ) |> Repo.insert
       conn = get(conn, Routes.project_path(conn, :overview, project.slug))
+
       assert html_response(conn, 200) =~ "Overview"
     end
   end

--- a/test/oli_web/controllers/project_controller_test.exs
+++ b/test/oli_web/controllers/project_controller_test.exs
@@ -2,6 +2,8 @@ defmodule OliWeb.ProjectControllerTest do
   use OliWeb.ConnCase
   alias Oli.Repo
   alias Oli.Authoring.Course.Project
+  alias Oli.Activities
+  alias Oli.Activities.ActivityRegistrationProject
 
   @basic_get_routes [:overview, :publish, :insights]
   setup [:author_project_conn]
@@ -25,6 +27,14 @@ defmodule OliWeb.ProjectControllerTest do
 
   describe "overview" do
     test "displays the page", %{conn: conn, project: project} do
+      custom_act = Activities.get_registration_by_slug("oli_image_coding")
+      %ActivityRegistrationProject{}
+      |> ActivityRegistrationProject.changeset(
+           %{
+             activity_registration_id: custom_act.id,
+             project_id: project.id,
+           }
+         ) |> Repo.insert
       conn = get(conn, Routes.project_path(conn, :overview, project.slug))
       assert html_response(conn, 200) =~ "Overview"
     end


### PR DESCRIPTION
This PR adds the following features

- New "globally_available" field in the activity_registration table that helps track whether an activity is by default available for use in all course packages or whether it is private
- New table tracking package to activity mapping
- New UI in package overview that allows authors to opt into "private" activities
- New admin only UI that allows admins to promote or demote activities to global status