### PR TITLE
Cancel delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   - Add the ability for an activity to submit client side evaluations
 
 ### Bug fixes
-  - Fin an issue where cancelling a curriculum deletion operation still deleted the curriculum item
+  - Fix an issue where cancelling a curriculum deletion operation still deleted the curriculum item
   - Fix an issue where activity text that contained HTML tags rendered actual HTML
   - Fix an issue where pasting text containing newlines from an external source crashes the editor
   - Fix an issue with null section slugs and deployment id in existing sections
@@ -87,4 +87,3 @@
 ## 0.1.0 (2020-7-24)
 
   - Initial release
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - Add the ability for an activity to submit client side evaluations
 
 ### Bug fixes
+  - Fin an issue where cancelling a curriculum deletion operation still deleted the curriculum item
   - Fix an issue where activity text that contained HTML tags rendered actual HTML
   - Fix an issue where pasting text containing newlines from an external source crashes the editor
   - Fix an issue with null section slugs and deployment id in existing sections

--- a/lib/oli_web/live/curriculum/settings/settings.html.leex
+++ b/lib/oli_web/live/curriculum/settings/settings.html.leex
@@ -46,9 +46,7 @@
 <div class="mt-4">
   <button
     phx-target="<%= @myself %>"
-    phx-capture-click="delete"
-    phx-window-keydown="delete"
-    phx-key="enter"
+    phx-click="delete"
     phx-value-slug="<%= @revision.slug %>"
     data-confirm="Are you sure you want to delete this curriculum item?"
     class="btn btn-danger">

--- a/lib/oli_web/live/curriculum/settings/settings.html.leex
+++ b/lib/oli_web/live/curriculum/settings/settings.html.leex
@@ -47,6 +47,7 @@
   <button
     phx-target="<%= @myself %>"
     phx-click="delete"
+    phx-key="enter"
     phx-value-slug="<%= @revision.slug %>"
     data-confirm="Are you sure you want to delete this curriculum item?"
     class="btn btn-danger">


### PR DESCRIPTION
Closes #842 

This PR allows cancelling of a curriculum deletion request.  The `phx-capture-click` in conjunction with `phx-window-keydown` were firing the "delete" action immediately - instead of waiting until the `data-confirm` driven modal confirmation dialog was answered. 

