### PR TITLE
Slug alphanumeric fix

### DIFF
--- a/lib/oli/utils/slug.ex
+++ b/lib/oli/utils/slug.ex
@@ -123,7 +123,6 @@ defmodule Oli.Utils.Slug do
   defp unique_slug(_table, _, []) do "" end
 
   def alpha_numeric_only(str) do
-    # \W is the shorthand for the [^a-zA-Z0-9] pattern
-    String.replace(str, ~r/[\W]+/, "")
+    String.replace(str, ~r/[^A-Za-z0-9 -]+/, "")
   end
 end

--- a/lib/oli/utils/slug.ex
+++ b/lib/oli/utils/slug.ex
@@ -74,7 +74,10 @@ defmodule Oli.Utils.Slug do
     end
   end
 
-  defp generate(table, title) do
+  @doc """
+  Generates a unique slug for the table using the title provided
+  """
+  def generate(table, title) do
 
     suffixes = [
       fn -> "" end,
@@ -123,6 +126,6 @@ defmodule Oli.Utils.Slug do
   defp unique_slug(_table, _, []) do "" end
 
   def alpha_numeric_only(str) do
-    String.replace(str, ~r/[^A-Za-z0-9 -]+/, "")
+    String.replace(str, ~r/[^A-Za-z0-9_]+/, "")
   end
 end

--- a/priv/repo/migrations/20210325175834_slug_alphanumeric_only.exs
+++ b/priv/repo/migrations/20210325175834_slug_alphanumeric_only.exs
@@ -1,0 +1,27 @@
+defmodule Oli.Repo.Migrations.SlugAlphanumericOnly do
+  use Ecto.Migration
+  import Ecto.Query, warn: false
+
+  alias Oli.Resources.Revision
+  alias Oli.Utils.Slug
+
+  def change do
+    # nothing to do
+  end
+
+  def up do
+    # find all revisions with slugs that contain illegal chars (non-alphanumeric)
+    revisions = Oli.Repo.all(
+      from r in Revision,
+      where: fragment("slug ~* '[^A-Za-z0-9_]'"),
+      select: r
+    )
+
+    # regenerate all affected slugs
+    Enum.each(revisions, fn revision ->
+      revision
+      |> Revision.changeset(%{slug: Slug.generate(:revisions, revision.title)})
+      |> Oli.Repo.update()
+    end)
+  end
+end

--- a/test/oli/utils/slug_test.exs
+++ b/test/oli/utils/slug_test.exs
@@ -114,6 +114,22 @@ defmodule Oli.Utils.SlugTest do
       |> Changeset.get_change(:slug) == nil
     end
 
+    test "update_on_change/2 produces valid slug when the title contains non-alphanumeric and special characters", %{ revision1: r } do
+
+      {:ok, new_revision} = Revision.changeset(%Revision{}, %{
+        previous_revision_id: r.id,
+        title: "What’s in a Name?",   # apostrophe is a special character
+        resource_id: r.resource_id,
+        resource_type_id: r.resource_type_id,
+        author_id: r.author_id
+        })
+      |> Repo.insert()
+
+      refute new_revision.slug == r.slug
+      assert new_revision.slug == "whats_in_a_name"
+
+    end
+
   end
 
 


### PR DESCRIPTION
This PR fixes an issue with slug generation where illegal UTF-8 chars could slip through the \W regex. The fix is to change the regex to explicitly only allow alphanumeric chars and underscores (_).

This PR also includes a migration to fix any existing slugs by regenerating slugs for the affected records.

Closes #864