### PR TITLE
Fix editor media item deletion / webpage embed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ### Bug fixes
   - Fix an issue where slug creation allowed some non-alphanumeric chars
   - Fix an issue where publishing or duplicating courses would cause save errors in page and activity editors
+  - Fix keyboard deletion with media items
+  - Add extra newline after an iframe/webpage is inserted into an editor
 
 ## 0.7.0 (2021-3-23)
 

--- a/assets/src/components/editing/editor/handlers/void.ts
+++ b/assets/src/components/editing/editor/handlers/void.ts
@@ -1,4 +1,4 @@
-import { Transforms, Range, Node, Path, Editor } from 'slate';
+import { Transforms, Range, Node, Path } from 'slate';
 import * as ContentModel from 'data/content/model';
 import { KeyboardEvent } from 'react';
 import { getNearestBlock } from 'components/editing/utils';

--- a/assets/src/components/editing/editor/handlers/void.ts
+++ b/assets/src/components/editing/editor/handlers/void.ts
@@ -1,4 +1,4 @@
-import { Transforms, Range, Node, Path } from 'slate';
+import { Transforms, Range, Node, Path, Editor } from 'slate';
 import * as ContentModel from 'data/content/model';
 import { KeyboardEvent } from 'react';
 import { getNearestBlock } from 'components/editing/utils';

--- a/assets/src/components/editing/editor/normalizers/normalizer.ts
+++ b/assets/src/components/editing/editor/normalizers/normalizer.ts
@@ -5,7 +5,7 @@ import { Node, NodeEntry, Editor as SlateEditor, Transforms, Path, Element } fro
 import { p, schema, SchemaConfig } from 'data/content/model';
 import { normalize as tableNormalize } from 'components/editing/editor/normalizers/tables';
 
-const spacesRequiredBetween = Immutable.Set<string>(['image', 'youtube', 'audio', 'blockquote', 'code', 'table']);
+const spacesRequiredBetween = Immutable.Set<string>(['image', 'youtube', 'audio', 'blockquote', 'code', 'table', 'iframe']);
 
 export function installNormalizer(editor: SlateEditor & ReactEditor) {
 

--- a/assets/src/components/editing/models/audio/Editor.tsx
+++ b/assets/src/components/editing/models/audio/Editor.tsx
@@ -31,9 +31,9 @@ export const AudioEditor = (props: AudioProps) => {
 
   return (
     <div {...attributes} className="ml-4 mr-4">
-      <div contentEditable={false} style={{ overflow: 'auto', userSelect: 'none' }}>
+      <div style={{ overflow: 'auto', userSelect: 'none' }}>
         <div className="ml-4 mr-4 text-center">
-          <figure>
+          <figure contentEditable={false}>
             <audio style={{ margin: 'auto' }} src={src} controls />
             <figcaption contentEditable={false} style={{ userSelect: 'none' }}>
               <Settings.Input

--- a/assets/src/components/editing/models/image/Editor.tsx
+++ b/assets/src/components/editing/models/image/Editor.tsx
@@ -44,10 +44,9 @@ export const ImageEditor = (props: ImageProps) => {
   return (
     <div
       {...attributes}
-      contentEditable={false}
       style={{ userSelect: 'none' }}
       className={'image-editor text-center ' + displayModelToClassName(model.display)}>
-      <figure>
+      <figure contentEditable={false}>
         <HoveringToolbar
           isOpen={e => focused && selected}
           showArrow

--- a/assets/src/components/editing/models/webpage/Editor.tsx
+++ b/assets/src/components/editing/models/webpage/Editor.tsx
@@ -41,10 +41,10 @@ export const WebpageEditor = (props: WebpageProps) => {
   return (
     <div
       {...attributes}
-      contentEditable={false}
       style={{ userSelect: 'none' }}
       className={'Webpage-editor ' + displayModelToClassName(model.display)}>
       <div
+        contentEditable={false}
         onClick={(e) => {
           ReactEditor.focus(editor);
           Transforms.select(editor, ReactEditor.findPath(editor, model));

--- a/assets/src/components/editing/models/youtube/Editor.tsx
+++ b/assets/src/components/editing/models/youtube/Editor.tsx
@@ -46,10 +46,10 @@ export const YouTubeEditor = (props: YouTubeProps) => {
   return (
     <div
       {...attributes}
-      contentEditable={false}
       style={{ userSelect: 'none' }}
       className={'youtube-editor ' + displayModelToClassName(model.display)}>
       <div
+        contentEditable={false}
         onClick={e => Transforms.select(editor, ReactEditor.findPath(editor, model))}
         className="embed-responsive embed-responsive-16by9 img-thumbnail" style={borderStyle}>
         <iframe className="embed-responsive-item"

--- a/assets/src/data/content/model.ts
+++ b/assets/src/data/content/model.ts
@@ -279,6 +279,7 @@ export const schema = {
   img: media,
   youtube: media,
   audio: media,
+  iframe: media,
   table: {
     isVoid: false,
     isBlock: true,


### PR DESCRIPTION
Fix deleting media items in editors when using the backspace/delete keys. This ended up being a simple fix for as long as it took to figure out what the problem was. Slate void nodes must have a `content-editable=false` node INSIDE them to work properly. The `content-editable` attribute apparently can't be on the void node itself.

Closes #832 

**Fixes**
- Handle keyboard deletion for `image`, `youtube`, `audio`, `webpage` elements
- Fix several errors on webpage/iframe embeds (normalizer failing, deletion, extra newline not being inserted after iframes) that had to do with `iframe` not being a `schema` type recognizable to slate.

