### PR TITLE
Fix an issue where admin roles cant configure course section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.2
+### Bug fixes
+  - Fix an issue where administrators cannot configure a section without instructor role
+
 ## 0.7.1
 ### Bug fixes
   - Fix an issue where slug creation allowed some non-alphanumeric chars

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,13 @@
 ## 0.7.2
 ### Bug fixes
   - Fix an issue where administrators cannot configure a section without instructor role
+  - Fix an issue where publishing or duplicating courses would cause save errors in page and activity editors
+  - Fix keyboard deletion with media items
+  - Add extra newline after an iframe/webpage is inserted into an editor
 
 ## 0.7.1
 ### Bug fixes
   - Fix an issue where slug creation allowed some non-alphanumeric chars
-  - Fix an issue where publishing or duplicating courses would cause save errors in page and activity editors
-  - Fix keyboard deletion with media items
-  - Add extra newline after an iframe/webpage is inserted into an editor
 
 ## 0.7.0 (2021-3-23)
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Oli.MixProject do
   def project do
     [
       app: :oli,
-      version: "0.7.1",
+      version: "0.7.2",
       elixir: "~> 1.11",
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: elixirc_options(Mix.env()),


### PR DESCRIPTION
This PR fixes an issue where an admin could not configure a course section without being an instructor in that course.

Closes #871