### PR TITLE
Fix Insights page to not show analytics data from parent course in a duplicated course

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - Fix an issue where publishing or duplicating courses would cause save errors in page and activity editors
   - Fix keyboard deletion with media items
   - Add extra newline after an iframe/webpage is inserted into an editor
+  - Fix analytics / insights to not show parent course analytics after duplication
 
 ## 0.7.1
 ### Bug fixes

--- a/lib/oli/analytics/by_activity.ex
+++ b/lib/oli/analytics/by_activity.ex
@@ -8,7 +8,7 @@ defmodule Oli.Analytics.ByActivity do
   def query_against_project_slug(project_slug) do
     Repo.all(
       from activity in subquery(Publishing.query_unpublished_revisions_by_type(project_slug, "activity")),
-      left_join: analytics in subquery(Common.analytics_by_activity()),
+      left_join: analytics in subquery(Common.analytics_by_activity(project_slug)),
       on: activity.resource_id == analytics.activity_id,
       select: %{
         slice: activity,

--- a/lib/oli/analytics/by_objective.ex
+++ b/lib/oli/analytics/by_objective.ex
@@ -5,9 +5,17 @@ defmodule Oli.Analytics.ByObjective do
   alias Oli.Repo
   alias Oli.Analytics.Common
   alias Oli.Publishing
+  alias Oli.Authoring.Course.Project
+  alias Oli.Delivery.Sections.Section
 
   def query_against_project_slug(project_slug) do
-    activity_objectives = from snapshot in Snapshot,
+
+    activity_objectives = from project in Project,
+      where: project.slug == ^project_slug,
+      join: section in Section,
+      on: section.project_id == project.id,
+      join: snapshot in Snapshot,
+      on: snapshot.section_id == section.id,
       group_by: [snapshot.activity_id, snapshot.objective_id],
       select: %{
         activity_id: snapshot.activity_id,
@@ -20,7 +28,7 @@ defmodule Oli.Analytics.ByObjective do
       on: objective.resource_id == pairing.objective_id,
       left_join: activity in subquery(Publishing.query_unpublished_revisions_by_type(project_slug, "activity")),
       on: pairing.activity_id == activity.resource_id,
-      left_join: analytics in subquery(Common.analytics_by_activity()),
+      left_join: analytics in subquery(Common.analytics_by_activity(project_slug)),
       on: pairing.activity_id == analytics.activity_id,
       select: %{
         slice: objective,

--- a/lib/oli/analytics/by_page.ex
+++ b/lib/oli/analytics/by_page.ex
@@ -5,9 +5,17 @@ defmodule Oli.Analytics.ByPage do
   alias Oli.Repo
   alias Oli.Analytics.Common
   alias Oli.Publishing
+  alias Oli.Authoring.Course.Project
+  alias Oli.Delivery.Sections.Section
 
   def query_against_project_slug(project_slug) do
-    activity_pages = from snapshot in Snapshot,
+
+    activity_pages = from project in Project,
+      where: project.slug == ^project_slug,
+      join: section in Section,
+      on: section.project_id == project.id,
+      join: snapshot in Snapshot,
+      on: snapshot.section_id == section.id,
       group_by: [snapshot.activity_id, snapshot.resource_id],
       select: %{
         activity_id: snapshot.activity_id,
@@ -20,7 +28,7 @@ defmodule Oli.Analytics.ByPage do
       on: page.resource_id == pairing.page_id,
       left_join: activity in subquery(Publishing.query_unpublished_revisions_by_type(project_slug, "activity")),
       on: pairing.activity_id == activity.resource_id,
-      left_join: analytics in subquery(Common.analytics_by_activity()),
+      left_join: analytics in subquery(Common.analytics_by_activity(project_slug)),
       on: pairing.activity_id == analytics.activity_id,
       select: %{
         slice: page,

--- a/lib/oli/analytics/common.ex
+++ b/lib/oli/analytics/common.ex
@@ -2,10 +2,17 @@ defmodule Oli.Analytics.Common do
 
   import Ecto.Query, warn: false
   alias Oli.Delivery.Attempts.Snapshot
+  alias Oli.Authoring.Course.Project
+  alias Oli.Delivery.Sections.Section
 
-  def analytics_by_activity() do
+  def analytics_by_activity(project_slug) do
 
-    activity_num_attempts_rel_difficulty = from snapshot in Snapshot,
+    activity_num_attempts_rel_difficulty = from project in Project,
+      where: project.slug == ^project_slug,
+      join: section in Section,
+      on: section.project_id == project.id,
+      join: snapshot in Snapshot,
+      on: snapshot.section_id == section.id,
       group_by: [snapshot.activity_id],
       select: %{
         activity_id: snapshot.activity_id,
@@ -14,7 +21,12 @@ defmodule Oli.Analytics.Common do
           snapshot.hints, snapshot.correct, snapshot.id)
       }
 
-    activity_correctness = from snapshot in Snapshot,
+    activity_correctness = from project in Project,
+      where: project.slug == ^project_slug,
+      join: section in Section,
+      on: section.project_id == project.id,
+      join: snapshot in Snapshot,
+      on: snapshot.section_id == section.id,
       group_by: [snapshot.activity_id, snapshot.user_id],
       select: %{
         activity_id: snapshot.activity_id,


### PR DESCRIPTION
The data analytics queries used on the insights page looked at all activity attempt snapshots for resources tied to a course, but the project duplication feature shares resources across projects. This was causing the Insights page to show analytics data for the parent project after duplication.

**Fix**:
- Change insights/analytics queries to only look at snapshots for sections tied to the project, rather than all snapshots for a project's resources.

Closes #877