### PR TITLE
fix an issue where codeblock overflows inside activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
  - Fix analytics / insights to not show parent course analytics after duplication
  - Fix security vulnerability
  - Account for ingested pages that have missing objectives
+ - Fix issue where long lines in code blocks in activities overflow
 
 ## 0.7.2 (2021-3-30)
 

--- a/assets/styles/delivery/activity.scss
+++ b/assets/styles/delivery/activity.scss
@@ -44,17 +44,14 @@
   }
 
   .activity-content {
-    display: grid;
+    display: flex;
+    flex-direction: column;
     flex: 1;
-    align-items: center;
-    grid-template-rows: min-content 1fr;
-    grid-gap: 8px;
   }
 
   .choices {
-    display: grid;
-    grid-gap: 8px;
-    grid-template-columns: 1fr;
+    display: flex;
+    flex-direction: column;
   }
 
   .choice {
@@ -62,6 +59,7 @@
     align-items: top;
     border-width: 1px;
     padding: 12px 16px;
+    margin-bottom: 8px;
     border-style: solid;
     border-color: #e5e5e5;
     cursor: pointer;


### PR DESCRIPTION
This PR fixes an issue where certain element might overflow out of an activity in the editor.

Closes #839