### PR TITLE
remove help link in preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Bug fixes
  - Fix analytics / insights to not show parent course analytics after duplication
+ - Remove help link in preview mode
  - Fix security vulnerability
  - Account for ingested pages that have missing objectives
 

--- a/lib/oli_web/templates/layout/_delivery_header.html.eex
+++ b/lib/oli_web/templates/layout/_delivery_header.html.eex
@@ -5,9 +5,11 @@
       <img src="/images/oli-icon.png" width="30" height="30" class="d-inline-block align-top mr-2" alt="">
       Open Learning <span style="font-weight: 200">Initiative</span>
     </a>
-    <div class="nav-item my-2 my-lg-0 mr-2">
-      <a  href="<%= Routes.help_delivery_path(@conn, :index) %>">Help</a>
-    </div>
+    <%= if not preview_mode(@conn) do %>
+      <div class="nav-item my-2 my-lg-0 mr-2">
+        <a  href="<%= Routes.help_delivery_path(@conn, :index) %>">Help</a>
+      </div>
+    <% end %>
 
     <%= if assigns[:lti_params] && user_signed_in?(@conn) do %>
       <div class="nav-item dropdown form-inline my-2 my-lg-0">


### PR DESCRIPTION
This PR removes the "Help" link from page preview mode

Closes #886