### PR TITLE
Ingest ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
  - Fix security vulnerability
  - Account for ingested pages that have missing objectives
  - Fix issue where long lines in code blocks in activities overflow
+ - Change how ids are determined in ingestion to avoid problems with unicode characters
 
 ## 0.7.2 (2021-3-30)
 


### PR DESCRIPTION
This PR adjusts how the ingest logic gets the id for a resource to ingest.  Previously it simply parsed the id from the file name in the "in memory" unzipped digest.  This proved to be problematic for file names that contained unicode characters.  To account for this, ids are now simply extracted from the attribute of the JSON content.  But, since the three "special" files in a digest (manifest, project, hierarchy) do not use ids, a fallback exists to parse the id from the file name.
