### PR TITLE
fix timezone support in certain schemas

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -40,6 +40,10 @@ config :oli,
   world_universities_and_domains_json: world_universities_and_domains_json,
   countries_json: countries_json
 
+# Configure database
+config :oli, Oli.Repo,
+  migration_timestamps: [type: :timestamptz]
+
 # Configures the endpoint
 config :oli, OliWeb.Endpoint,
   live_view: [signing_salt: System.get_env("LIVE_VIEW_SALT", "LIVE_VIEW_SALT")],

--- a/lib/oli/delivery/sections/enrollment.ex
+++ b/lib/oli/delivery/sections/enrollment.ex
@@ -8,7 +8,7 @@ defmodule Oli.Delivery.Sections.Enrollment do
 
     many_to_many :context_roles, Lti_1p3.DataProviders.EctoProvider.ContextRole, join_through: "enrollments_context_roles", on_replace: :delete
 
-    timestamps()
+    timestamps(type: :utc_datetime)
   end
 
   @doc false

--- a/lib/oli/user_identities/user_identity.ex
+++ b/lib/oli/user_identities/user_identity.ex
@@ -5,6 +5,6 @@ defmodule Oli.UserIdentities.UserIdentity do
   schema "user_identities" do
     pow_assent_user_identity_fields()
 
-    timestamps()
+    timestamps(type: :utc_datetime)
   end
 end


### PR DESCRIPTION
This PR fixes timezone support in some schemas that didn't specify. It also sets a configuration that all migrations should use `type: :timestamptz` by default for `timestamps()`. It appears that no migration is necessary for existing timestamps that didnt explicitly specify `:timestamptz` since they utilize the same underlying storage type and the timezone conversion is simply done at the DB layer, but the configuration was added for consistency and documentation purposes.

Related Posts:
- https://elixirforum.com/t/why-cant-timestamptz-be-set-up-as-default-timestamp-for-migrations-in-config/25778/2
- http://www.creativedeletion.com/2019/06/17/utc-timestamps-in-ecto.html

Closes #779