### PR TITLE
move cookie prefs render to footer

### DIFF
--- a/lib/oli_web/controllers/static_page_controller.ex
+++ b/lib/oli_web/controllers/static_page_controller.ex
@@ -2,15 +2,7 @@ defmodule OliWeb.StaticPageController do
   use OliWeb, :controller
 
   def index(conn, _params) do
-#    my_cookie = fetch_cookies(conn)
-    IO.inspect "request cookies #{inspect(conn.req_cookies["_cky_opt_in"])}"
-#    if(my_cookie === nil)do
-
-#      put_resp_cookie(conn, "_consent_opt_in", Jason.encode!(%{awaiting_consent: true}))
-      render(conn, "index.html")
-#    end
-
-
+    render(conn, "index.html")
   end
 
   def unauthorized(conn, _params) do

--- a/lib/oli_web/templates/layout/_delivery_footer.html.eex
+++ b/lib/oli_web/templates/layout/_delivery_footer.html.eex
@@ -1,3 +1,5 @@
+<%= render OliWeb.SharedView, "_cookie_consent.html" %>
+
 <footer>
   <div class="container">
     <div class="row">

--- a/lib/oli_web/templates/layout/_delivery_header.html.eex
+++ b/lib/oli_web/templates/layout/_delivery_header.html.eex
@@ -1,5 +1,3 @@
-<%= render OliWeb.SharedView, "_cookie_consent.html" %>
-
 <nav class="navbar navbar-expand">
   <div class="container">
     <a class="navbar-brand oli-logo mr-auto" href="<%= logo_link_path(@conn) %>">

--- a/lib/oli_web/templates/layout/_footer.html.eex
+++ b/lib/oli_web/templates/layout/_footer.html.eex
@@ -1,3 +1,5 @@
+<%= render OliWeb.SharedView, "_cookie_consent.html" %>
+
 <footer>
   <div class="container">
     <div class="row">


### PR DESCRIPTION
This PR fixes an issue where cookie preferences link doesn't work in authoring workspace layout.