### PR TITLE
Adaptive activity impl

### DIFF
--- a/assets/src/components/activities/DeliveryElement.ts
+++ b/assets/src/components/activities/DeliveryElement.ts
@@ -7,7 +7,7 @@ import {
   StudentResponse,
   ClientEvaluation,
   Action,
-  Success
+  Success,
 } from './types';
 import { valueOr } from 'utils/common';
 

--- a/assets/src/components/activities/DeliveryElement.ts
+++ b/assets/src/components/activities/DeliveryElement.ts
@@ -1,25 +1,18 @@
-import { ActivityModelSchema,
+import {
+  ActivityModelSchema,
   ActivityState,
   Hint,
   PartResponse,
   PartState,
   StudentResponse,
   ClientEvaluation,
-  Success } from './types';
+  ActionResult,
+  Success
+} from './types';
 import { valueOr } from 'utils/common';
 
-
-export interface EvaluatedPart {
-  type: 'EvaluatedPart';
-  attempt_guid: string;
-  out_of: number;
-  score: number;
-  feedback: any;
-  error?: string;
-}
-
 export interface EvaluationResponse extends Success {
-  evaluations: EvaluatedPart[];
+  actions: ActionResult[];
 }
 
 // Notice that the hint attribute here is optional.  If a

--- a/assets/src/components/activities/DeliveryElement.ts
+++ b/assets/src/components/activities/DeliveryElement.ts
@@ -6,13 +6,13 @@ import {
   PartState,
   StudentResponse,
   ClientEvaluation,
-  ActionResult,
+  Action,
   Success
 } from './types';
 import { valueOr } from 'utils/common';
 
 export interface EvaluationResponse extends Success {
-  actions: ActionResult[];
+  actions: Action[];
 }
 
 // Notice that the hint attribute here is optional.  If a

--- a/assets/src/components/activities/adaptive/AdaptiveAuthoring.tsx
+++ b/assets/src/components/activities/adaptive/AdaptiveAuthoring.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { AdaptiveModelSchema } from './schema';
+import * as ActivityTypes from '../types';
+import { AuthoringElement, AuthoringElementProps } from '../AuthoringElement';
+
+const Adaptive = (props: AuthoringElementProps<AdaptiveModelSchema>) => <p>Adaptive</p>;
+
+export class AdaptiveAuthoring extends AuthoringElement<AdaptiveModelSchema> {
+  render(mountPoint: HTMLDivElement, props: AuthoringElementProps<AdaptiveModelSchema>) {
+    ReactDOM.render(<Adaptive {...props} />, mountPoint);
+  }
+}
+
+const manifest = require('./manifest.json') as ActivityTypes.Manifest;
+window.customElements.define(manifest.authoring.element, AdaptiveAuthoring);

--- a/assets/src/components/activities/adaptive/AdaptiveDelivery.tsx
+++ b/assets/src/components/activities/adaptive/AdaptiveDelivery.tsx
@@ -1,0 +1,21 @@
+import React, { useState } from 'react';
+import ReactDOM from 'react-dom';
+import {
+  DeliveryElement,
+  DeliveryElementProps,
+} from '../DeliveryElement';
+import { AdaptiveModelSchema } from './schema';
+import * as ActivityTypes from '../types';
+
+const Adaptive = (props: DeliveryElementProps<AdaptiveModelSchema>) => <p>Adaptive</p>;
+
+// Defines the web component, a simple wrapper over our React component above
+export class AdaptiveDelivery extends DeliveryElement<AdaptiveModelSchema> {
+  render(mountPoint: HTMLDivElement, props: DeliveryElementProps<AdaptiveModelSchema>) {
+    ReactDOM.render(<Adaptive {...props} />, mountPoint);
+  }
+}
+
+// Register the web component:
+const manifest = require('./manifest.json') as ActivityTypes.Manifest;
+window.customElements.define(manifest.delivery.element, AdaptiveDelivery);

--- a/assets/src/components/activities/adaptive/AdaptiveDelivery.tsx
+++ b/assets/src/components/activities/adaptive/AdaptiveDelivery.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import ReactDOM from 'react-dom';
 import {
   DeliveryElement,

--- a/assets/src/components/activities/adaptive/authoring-entry.ts
+++ b/assets/src/components/activities/adaptive/authoring-entry.ts
@@ -1,0 +1,31 @@
+// This is the entry point for the multiple choice authoring
+// component, as specified in the manifest.json
+
+// An authoring component entry point must expose the following
+// three things:
+//
+// 1. The web component specified to use for authoring.
+// 2. The web component specified to use for delivery. Delivery
+//    component must be exposed to allow the resource editor to
+//    operate activites of this type in 'test mode'
+// 3. A 'creation function'.  A function that when invoked will
+//    asynchronously delivery a new model instance for this
+//    activity type. This is to allow the activity author to have
+//    full control over populating a new activity.
+
+// Fulfills 1. and 2. from above by exporting these components:
+export { AdaptiveDelivery } from './AdaptiveDelivery';
+export { AdaptiveAuthoring } from './AdaptiveAuthoring';
+
+// Registers the creation function:
+import { Manifest, CreationContext } from '../types';
+import { registerCreationFunc } from '../creation';
+import { AdaptiveModelSchema } from './schema';
+import { defaultMCModel } from './utils';
+const manifest: Manifest = require('./manifest.json');
+
+function createFn(content: CreationContext): Promise<AdaptiveModelSchema> {
+  return Promise.resolve(Object.assign({}, defaultMCModel()));
+}
+
+registerCreationFunc(manifest, createFn);

--- a/assets/src/components/activities/adaptive/authoring-entry.ts
+++ b/assets/src/components/activities/adaptive/authoring-entry.ts
@@ -21,11 +21,11 @@ export { AdaptiveAuthoring } from './AdaptiveAuthoring';
 import { Manifest, CreationContext } from '../types';
 import { registerCreationFunc } from '../creation';
 import { AdaptiveModelSchema } from './schema';
-import { defaultMCModel } from './utils';
+import { defaultModel } from './utils';
 const manifest: Manifest = require('./manifest.json');
 
 function createFn(content: CreationContext): Promise<AdaptiveModelSchema> {
-  return Promise.resolve(Object.assign({}, defaultMCModel()));
+  return Promise.resolve(Object.assign({}, defaultModel()));
 }
 
 registerCreationFunc(manifest, createFn);

--- a/assets/src/components/activities/adaptive/delivery-entry.ts
+++ b/assets/src/components/activities/adaptive/delivery-entry.ts
@@ -1,0 +1,5 @@
+// This is the entry point for the delivery component for
+// the multiple choice activitity.  All that needs to be exposed
+// is the actual delivery web component.
+
+export { AdaptiveDelivery } from './AdaptiveDelivery';

--- a/assets/src/components/activities/adaptive/manifest.json
+++ b/assets/src/components/activities/adaptive/manifest.json
@@ -1,0 +1,19 @@
+{
+  "id": "oli_adaptive",
+  "friendlyName": "Adaptive Activity",
+  "description": "Adaptive Activity",
+  "delivery": {
+    "element": "oli-adaptive-delivery",
+    "entry": "./delivery-entry.ts"
+  },
+  "authoring": {
+    "element": "oli-adaptive-authoring",
+    "entry": "./authoring-entry.ts"
+  },
+  "schemaPruning": {
+    "type": "keys",
+    "keys": [
+      "feedback"
+    ]
+  }
+}

--- a/assets/src/components/activities/adaptive/schema.ts
+++ b/assets/src/components/activities/adaptive/schema.ts
@@ -1,0 +1,16 @@
+
+import { Part, Transformation, ActivityModelSchema } from '../types';
+
+export interface AdaptiveModelSchema extends ActivityModelSchema {
+  content: Object;
+  authoring: {
+    parts: Part[];
+    transformations: Transformation[];
+    previewText: string;
+  };
+}
+
+export interface ModelEditorProps {
+  model: AdaptiveModelSchema;
+  editMode: boolean;
+}

--- a/assets/src/components/activities/adaptive/utils.ts
+++ b/assets/src/components/activities/adaptive/utils.ts
@@ -1,25 +1,25 @@
 import guid from 'utils/guid';
 import * as ContentModel from 'data/content/model';
 import { AdaptiveModelSchema } from './schema';
-import { RichText, Operation, ScoringStrategy, Choice } from '../types';
+import { RichText, Operation, ScoringStrategy } from '../types';
 
-export const makeResponse = (rule: string, score: number, text: '') =>
-  ({ id: guid(), rule, score, feedback: fromText(text) });
 
 export const defaultMCModel: () => AdaptiveModelSchema = () => {
-  const choiceA: Choice = fromText('Choice A');
-  const choiceB: Choice = fromText('Choice B');
 
   return {
     content: {},
     authoring: {
       parts: [{
-        id: '1', // an MCQ only has one part, so it is safe to hardcode the id
+        id: '1', // One part for now
         scoringStrategy: ScoringStrategy.average,
-        responses: [
-          makeResponse(`input like {${choiceA.id}}`, 1, ''),
-          makeResponse(`input like {${choiceB.id}}`, 0, ''),
-        ],
+        responses: [],
+        outcomes: [{
+          id: 'outcome1',
+          rule: [],
+          actions: [
+            { id: 'action1', type: 'StateUpdateActionDesc', update: {} }
+          ]
+        }],
         hints: [
           fromText(''),
           fromText(''),

--- a/assets/src/components/activities/adaptive/utils.ts
+++ b/assets/src/components/activities/adaptive/utils.ts
@@ -1,0 +1,57 @@
+import guid from 'utils/guid';
+import * as ContentModel from 'data/content/model';
+import { AdaptiveModelSchema } from './schema';
+import { RichText, Operation, ScoringStrategy, Choice } from '../types';
+
+export const makeResponse = (rule: string, score: number, text: '') =>
+  ({ id: guid(), rule, score, feedback: fromText(text) });
+
+export const defaultMCModel: () => AdaptiveModelSchema = () => {
+  const choiceA: Choice = fromText('Choice A');
+  const choiceB: Choice = fromText('Choice B');
+
+  return {
+    content: {},
+    authoring: {
+      parts: [{
+        id: '1', // an MCQ only has one part, so it is safe to hardcode the id
+        scoringStrategy: ScoringStrategy.average,
+        responses: [
+          makeResponse(`input like {${choiceA.id}}`, 1, ''),
+          makeResponse(`input like {${choiceB.id}}`, 0, ''),
+        ],
+        hints: [
+          fromText(''),
+          fromText(''),
+          fromText(''),
+        ],
+      }],
+      transformations: [
+        { id: guid(), path: 'choices', operation: Operation.shuffle },
+      ],
+      previewText: '',
+    },
+  };
+};
+
+export function fromText(text: string): { id: string, content: RichText } {
+  return {
+    id: guid() + '',
+    content: {
+      model: [
+        ContentModel.create<ContentModel.Paragraph>({
+          type: 'p',
+          children: [{ text }],
+          id: guid() + '',
+        }),
+      ],
+      selection: null,
+    },
+  };
+}
+
+export const feedback = (text: string, match: string | number, score: number = 0) => ({
+  ...fromText(text),
+  match,
+  score,
+});

--- a/assets/src/components/activities/adaptive/utils.ts
+++ b/assets/src/components/activities/adaptive/utils.ts
@@ -4,7 +4,7 @@ import { AdaptiveModelSchema } from './schema';
 import { RichText, Operation, ScoringStrategy } from '../types';
 
 
-export const defaultMCModel: () => AdaptiveModelSchema = () => {
+export const defaultModel: () => AdaptiveModelSchema = () => {
 
   return {
     content: {},

--- a/assets/src/components/activities/adaptive/utils.ts
+++ b/assets/src/components/activities/adaptive/utils.ts
@@ -17,8 +17,8 @@ export const defaultModel: () => AdaptiveModelSchema = () => {
           id: 'outcome1',
           rule: [],
           actions: [
-            { id: 'action1', type: 'StateUpdateActionDesc', update: {} }
-          ]
+            { id: 'action1', type: 'StateUpdateActionDesc', update: {} },
+          ],
         }],
         hints: [
           fromText(''),

--- a/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyDelivery.tsx
+++ b/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyDelivery.tsx
@@ -92,8 +92,11 @@ const CheckAllThatApply = (props: DeliveryElementProps<CheckAllThatApplyModelSch
         response: { input: selectionToInput(undefined) },
       }])
       .then((response: EvaluationResponse) => {
-        if (response.evaluations.length > 0) {
-          const { score, out_of, feedback, error } = response.evaluations[0];
+        if (response.actions.length > 0) {
+
+          const action: ActivityTypes.FeedbackActionResult = response.actions[0] as ActivityTypes.FeedbackActionResult;
+
+          const { score, out_of, feedback, error } = action;
           const parts = [Object.assign({}, attemptState.parts[0], { feedback, error })];
           const updated = Object.assign({}, attemptState, { score, outOf: out_of, parts });
           setAttemptState(updated);

--- a/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyDelivery.tsx
+++ b/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyDelivery.tsx
@@ -94,7 +94,7 @@ const CheckAllThatApply = (props: DeliveryElementProps<CheckAllThatApplyModelSch
       .then((response: EvaluationResponse) => {
         if (response.actions.length > 0) {
 
-          const action: ActivityTypes.FeedbackActionResult = response.actions[0] as ActivityTypes.FeedbackActionResult;
+          const action: ActivityTypes.FeedbackAction = response.actions[0] as ActivityTypes.FeedbackAction;
 
           const { score, out_of, feedback, error } = action;
           const parts = [Object.assign({}, attemptState.parts[0], { feedback, error })];

--- a/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyDelivery.tsx
+++ b/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyDelivery.tsx
@@ -94,7 +94,8 @@ const CheckAllThatApply = (props: DeliveryElementProps<CheckAllThatApplyModelSch
       .then((response: EvaluationResponse) => {
         if (response.actions.length > 0) {
 
-          const action: ActivityTypes.FeedbackAction = response.actions[0] as ActivityTypes.FeedbackAction;
+          const action: ActivityTypes.FeedbackAction
+            = response.actions[0] as ActivityTypes.FeedbackAction;
 
           const { score, out_of, feedback, error } = action;
           const parts = [Object.assign({}, attemptState.parts[0], { feedback, error })];

--- a/assets/src/components/activities/common/Evaluation.tsx
+++ b/assets/src/components/activities/common/Evaluation.tsx
@@ -5,7 +5,7 @@ import { fromText } from './utils';
 import { WriterContext } from 'data/content/writers/context';
 
 export const Evaluation = ({ attemptState, context }:
-  {attemptState : ActivityTypes.ActivityState, context: WriterContext}) => {
+  { attemptState: ActivityTypes.ActivityState, context: WriterContext }) => {
 
   const { score, outOf, parts } = attemptState;
   const error = parts[0].error;
@@ -14,7 +14,7 @@ export const Evaluation = ({ attemptState, context }:
   const errorText = fromText('There was an error processing this response');
 
   let resultClass = 'incorrect';
-  if (error !== undefined) {
+  if (error !== undefined && error !== null) {
     resultClass = 'error';
   } else if (score === outOf) {
     resultClass = 'correct';
@@ -24,11 +24,11 @@ export const Evaluation = ({ attemptState, context }:
 
   return (
     <div className={`evaluation feedback ${resultClass} my-1`}>
-        <div className="result">
-          <span className="score">{score}</span>
-          <span className="result-divider">/</span>
-          <span className="out-of">{outOf}</span>
-        </div>
+      <div className="result">
+        <span className="score">{score}</span>
+        <span className="result-divider">/</span>
+        <span className="out-of">{outOf}</span>
+      </div>
       <HtmlContentModelRenderer text={error ? errorText : feedback} context={context} />
     </div>
   );

--- a/assets/src/components/activities/image_coding/ImageCodingDelivery.tsx
+++ b/assets/src/components/activities/image_coding/ImageCodingDelivery.tsx
@@ -127,7 +127,7 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
       .then((response: EvaluationResponse) => {
         if (response.actions.length > 0) {
 
-          const action: ActivityTypes.FeedbackActionResult = response.actions[0] as ActivityTypes.FeedbackActionResult;
+          const action: ActivityTypes.FeedbackAction = response.actions[0] as ActivityTypes.FeedbackAction;
           const { error } = action;
           const parts = [Object.assign({}, partState, { feedback, error })];
           const updated = Object.assign({}, attemptState, { score, outOf, parts });

--- a/assets/src/components/activities/image_coding/ImageCodingDelivery.tsx
+++ b/assets/src/components/activities/image_coding/ImageCodingDelivery.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import ReactDOM from 'react-dom';
 import {
   DeliveryElement, DeliveryElementProps,
-  EvaluationResponse, ResetActivityResponse, RequestHintResponse
+  EvaluationResponse, ResetActivityResponse, RequestHintResponse,
 } from '../DeliveryElement';
 import { ImageCodingModelSchema } from './schema';
 import * as ActivityTypes from '../types';
@@ -127,7 +127,8 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
       .then((response: EvaluationResponse) => {
         if (response.actions.length > 0) {
 
-          const action: ActivityTypes.FeedbackAction = response.actions[0] as ActivityTypes.FeedbackAction;
+          const action: ActivityTypes.FeedbackAction
+            = response.actions[0] as ActivityTypes.FeedbackAction;
           const { error } = action;
           const parts = [Object.assign({}, partState, { feedback, error })];
           const updated = Object.assign({}, attemptState, { score, outOf, parts });
@@ -185,7 +186,7 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
 
     const ctx: EvalContext = {
       getCanvas, getResource, getResult, appendOutput,
-      solutionRun: false
+      solutionRun: false,
     };
     const e = Evaluator.execute(input, ctx);
     if (e != null) {
@@ -210,7 +211,7 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
     // only needs to be done once, setting solnCanvas.width > 0
     const ctx: EvalContext = {
       getCanvas, getResource, getResult, appendOutput,
-      solutionRun: true
+      solutionRun: true,
     };
     const solnCanvas = getResult(true);
     if (solnCanvas && solnCanvas.width === 0) {

--- a/assets/src/components/activities/image_coding/ImageCodingDelivery.tsx
+++ b/assets/src/components/activities/image_coding/ImageCodingDelivery.tsx
@@ -1,7 +1,9 @@
 import React, { useState, useEffect, useRef } from 'react';
 import ReactDOM from 'react-dom';
-import { DeliveryElement, DeliveryElementProps,
-  EvaluationResponse, ResetActivityResponse, RequestHintResponse } from '../DeliveryElement';
+import {
+  DeliveryElement, DeliveryElementProps,
+  EvaluationResponse, ResetActivityResponse, RequestHintResponse
+} from '../DeliveryElement';
 import { ImageCodingModelSchema } from './schema';
 import * as ActivityTypes from '../types';
 import { Stem } from '../common/DisplayedStem';
@@ -37,7 +39,7 @@ const Input = (props: InputProps) => {
       className="form-control"
       onChange={(e: any) => props.onChange(e.target.value)}
       value={input}
-      disabled={props.isEvaluated}/>
+      disabled={props.isEvaluated} />
   );
 };
 
@@ -63,7 +65,7 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
   const writerContext = defaultWriterContext({ sectionSlug: props.sectionSlug });
 
   // tslint:disable-next-line:prefer-array-literal
-  const resourceRefs = useRef<(HTMLImageElement|String)[]>(new Array(resourceURLs.length));
+  const resourceRefs = useRef<(HTMLImageElement | String)[]>(new Array(resourceURLs.length));
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const canvasRef2 = useRef<HTMLCanvasElement>(null);
   const resultRef = useRef<HTMLCanvasElement>(null);
@@ -71,15 +73,15 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
 
   const loadCSV = (url: string, i: number) => {
     fetch(url, { mode: 'cors' })
-      .then ((resp) => {
-        if (! resp.ok) {
+      .then((resp) => {
+        if (!resp.ok) {
           throw new Error('failed to load ' + lastPart(url) + ': '
-              + resp.statusText);
+            + resp.statusText);
         }
         return resp.text();
       })
-      .then (text => resourceRefs.current[i] = text)
-      .catch ((e) => {
+      .then(text => resourceRefs.current[i] = text)
+      .catch((e) => {
         throw new Error('failed to load ' + lastPart(url) + ': ' + e);
       });
   };
@@ -116,15 +118,17 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
 
     // get attributes for a ClientEvaluation
     const score = isCorrect ? 1 : 0;
-    const outOf =  1;
+    const outOf = 1;
     const feedback = model.feedback[score];
 
     const partState = attemptState.parts[0];
     props.onSubmitEvaluations(attemptState.attemptGuid,
       [{ attemptGuid: partState.attemptGuid, score, outOf, feedback }])
       .then((response: EvaluationResponse) => {
-        if (response.evaluations.length > 0) {
-          const { error } = response.evaluations[0];
+        if (response.actions.length > 0) {
+
+          const action: ActivityTypes.FeedbackActionResult = response.actions[0] as ActivityTypes.FeedbackActionResult;
+          const { error } = action;
           const parts = [Object.assign({}, partState, { feedback, error })];
           const updated = Object.assign({}, attemptState, { score, outOf, parts });
           setAttemptState(updated);
@@ -134,28 +138,28 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
 
   const onRequestHint = () => {
     props.onRequestHint(attemptState.attemptGuid, attemptState.parts[0].attemptGuid)
-    .then((state: RequestHintResponse) => {
-      if (state.hint !== undefined) {
-        setHints([...hints, state.hint] as any);
-      }
-      setHasMoreHints(state.hasMoreHints);
-    });
+      .then((state: RequestHintResponse) => {
+        if (state.hint !== undefined) {
+          setHints([...hints, state.hint] as any);
+        }
+        setHasMoreHints(state.hasMoreHints);
+      });
   };
 
   const onReset = () => {
     props.onResetActivity(attemptState.attemptGuid)
-    .then((state: ResetActivityResponse) => {
-      setAttemptState(state.attemptState);
-      setModel(state.model as ImageCodingModelSchema);
-      setHints([]);
-      setHasMoreHints(props.state.parts[0].hasMoreHints);
-      // Do we want reset to reload starter code, discarding changes?
-      // setInput(model.starterCode);
-      clearOutput();
-    });
+      .then((state: ResetActivityResponse) => {
+        setAttemptState(state.attemptState);
+        setModel(state.model as ImageCodingModelSchema);
+        setHints([]);
+        setHasMoreHints(props.state.parts[0].hasMoreHints);
+        // Do we want reset to reload starter code, discarding changes?
+        // setInput(model.starterCode);
+        clearOutput();
+      });
   };
 
-  const updateOutput = (s:string) => {
+  const updateOutput = (s: string) => {
     // update local var so we can use it until next render
     currentOutput = s;
     setOutput(s);
@@ -179,8 +183,10 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
     // clear output for new run
     clearOutput();
 
-    const ctx : EvalContext = { getCanvas, getResource, getResult, appendOutput,
-      solutionRun: false };
+    const ctx: EvalContext = {
+      getCanvas, getResource, getResult, appendOutput,
+      solutionRun: false
+    };
     const e = Evaluator.execute(input, ctx);
     if (e != null) {
       setError(e.message);
@@ -188,7 +194,7 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
   };
 
   const usesImages = () => {
-    return resourceURLs.some(url => ! url.endsWith('csv'));
+    return resourceURLs.some(url => !url.endsWith('csv'));
   };
 
   const solutionCorrect = () => {
@@ -202,8 +208,10 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
   const imageCorrect = () => {
     // evaluate solution code if needed to "print" result image to solnCanvas.
     // only needs to be done once, setting solnCanvas.width > 0
-    const ctx : EvalContext = { getCanvas, getResource, getResult, appendOutput,
-      solutionRun: true };
+    const ctx: EvalContext = {
+      getCanvas, getResource, getResult, appendOutput,
+      solutionRun: true
+    };
     const solnCanvas = getResult(true);
     if (solnCanvas && solnCanvas.width === 0) {
       const e = Evaluator.execute(model.solutionCode, ctx);
@@ -218,21 +226,21 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
   };
 
   const evaluationSummary = isEvaluated
-    ? <Evaluation key="evaluation" attemptState={attemptState} context={writerContext}/>
+    ? <Evaluation key="evaluation" attemptState={attemptState} context={writerContext} />
     : null;
 
   const reset = isEvaluated && !props.graded
     ? (<div className="d-flex">
-        <div className="flex-fill"></div>
-        <Reset hasMoreAttempts={attemptState.hasMoreAttempts} onClick={onReset} />
-      </div>
+      <div className="flex-fill"></div>
+      <Reset hasMoreAttempts={attemptState.hasMoreAttempts} onClick={onReset} />
+    </div>
     )
     : null;
 
   const ungradedDetails = props.graded ? null : [
     evaluationSummary,
     <Hints key="hints" onClick={onRequestHint} hints={hints} context={writerContext}
-      hasMoreHints={hasMoreHints} isEvaluated={isEvaluated}/>];
+      hasMoreHints={hasMoreHints} isEvaluated={isEvaluated} />];
 
   const renderOutput = () => {
     if (output === '') {
@@ -250,8 +258,8 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
   };
 
   const getCanvas = (n: number = 0) => {
-     // we currently only need exactly two temp canvases, one for src and
-     // one for destination of offscreen transformation.
+    // we currently only need exactly two temp canvases, one for src and
+    // one for destination of offscreen transformation.
     return n === 0 ? canvasRef.current : canvasRef2.current;
   };
 
@@ -269,15 +277,15 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
   };
 
   const maybeSubmitButton = (model.isExample || props.graded)
-  ? null
-  : (
-    <button
-      className="btn btn-primary mt-2 float-right" disabled={isEvaluated} onClick={onSubmit}>
-      Submit
-    </button>
-  );
+    ? null
+    : (
+      <button
+        className="btn btn-primary mt-2 float-right" disabled={isEvaluated} onClick={onSubmit}>
+        Submit
+      </button>
+    );
 
-  const runButton  = (
+  const runButton = (
     <button
       className="btn btn-primary mt-2 float-left" disabled={isEvaluated} onClick={onRun}>
       Run
@@ -293,21 +301,21 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
           <Input
             input={input}
             isEvaluated={isEvaluated}
-            onChange={onInputChange}/>
+            onChange={onInputChange} />
           {runButton} {maybeSubmitButton}
         </div>
 
         {/* implementation relies on 2 hidden canvases for image operations */}
-         <canvas ref={canvasRef} style={{ display: 'none' }}/>
-         <canvas ref={canvasRef2} style={{ display: 'none' }}/>
+        <canvas ref={canvasRef} style={{ display: 'none' }} />
+        <canvas ref={canvasRef2} style={{ display: 'none' }} />
 
         <div style={{ whiteSpace: 'pre-wrap' }}>
           <h5>Output:</h5>
           {renderOutput()}
           {errorMsg()}
           {/* output canvases for student and (hidden) correct solution */}
-          <canvas ref={resultRef} height="0" width="0"/>
-          <canvas ref={solnRef} style={{ display: 'none' }} height="0" width="0"/>
+          <canvas ref={resultRef} height="0" width="0" />
+          <canvas ref={solnRef} style={{ display: 'none' }} height="0" width="0" />
         </div>
 
         {!model.isExample && ungradedDetails}

--- a/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
+++ b/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
@@ -103,7 +103,8 @@ const MultipleChoice = (props: DeliveryElementProps<MultipleChoiceModelSchema>) 
         .then((response: EvaluationResponse) => {
           if (response.actions.length > 0) {
 
-            const action: ActivityTypes.FeedbackAction = response.actions[0] as ActivityTypes.FeedbackAction;
+            const action: ActivityTypes.FeedbackAction
+              = response.actions[0] as ActivityTypes.FeedbackAction;
 
             const { score, out_of, feedback, error } = action;
             const parts = [Object.assign({}, attemptState.parts[0], { feedback, error })];

--- a/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
+++ b/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
@@ -103,7 +103,7 @@ const MultipleChoice = (props: DeliveryElementProps<MultipleChoiceModelSchema>) 
         .then((response: EvaluationResponse) => {
           if (response.actions.length > 0) {
 
-            const action: ActivityTypes.FeedbackActionResult = response.actions[0] as ActivityTypes.FeedbackActionResult;
+            const action: ActivityTypes.FeedbackAction = response.actions[0] as ActivityTypes.FeedbackAction;
 
             const { score, out_of, feedback, error } = action;
             const parts = [Object.assign({}, attemptState.parts[0], { feedback, error })];

--- a/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
+++ b/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
@@ -101,8 +101,11 @@ const MultipleChoice = (props: DeliveryElementProps<MultipleChoiceModelSchema>) 
       props.onSubmitActivity(attemptState.attemptGuid,
         [{ attemptGuid: attemptState.parts[0].attemptGuid, response: { input: id } }])
         .then((response: EvaluationResponse) => {
-          if (response.evaluations.length > 0) {
-            const { score, out_of, feedback, error } = response.evaluations[0];
+          if (response.actions.length > 0) {
+
+            const action: ActivityTypes.FeedbackActionResult = response.actions[0] as ActivityTypes.FeedbackActionResult;
+
+            const { score, out_of, feedback, error } = action;
             const parts = [Object.assign({}, attemptState.parts[0], { feedback, error })];
             const updated = Object.assign({}, attemptState, { score, outOf: out_of, parts });
             setAttemptState(updated);
@@ -158,7 +161,7 @@ const MultipleChoice = (props: DeliveryElementProps<MultipleChoiceModelSchema>) 
     <div className="text-info font-italic">
       {correctnessIcon}
       <span>Points: </span><span>{attemptState.score + ' out of '
-    + attemptState.outOf}</span></div>] : null;
+        + attemptState.outOf}</span></div>] : null;
 
   return (
     <div className={`activity multiple-choice-activity ${isEvaluated ? 'evaluated' : ''}`}>

--- a/assets/src/components/activities/ordering/OrderingDelivery.tsx
+++ b/assets/src/components/activities/ordering/OrderingDelivery.tsx
@@ -121,8 +121,10 @@ const Ordering = (props: DeliveryElementProps<OrderingModelSchema>) => {
         response: { input: orderedChoiceIds(undefined) },
       }])
       .then((response: EvaluationResponse) => {
-        if (response.evaluations.length > 0) {
-          const { score, out_of, feedback, error } = response.evaluations[0];
+        if (response.actions.length > 0) {
+
+          const action: ActivityTypes.FeedbackActionResult = response.actions[0] as ActivityTypes.FeedbackActionResult;
+          const { score, out_of, feedback, error } = action;
           const parts = [Object.assign({}, attemptState.parts[0], { feedback, error })];
           const updated = Object.assign({}, attemptState, { score, outOf: out_of, parts });
           setAttemptState(updated);

--- a/assets/src/components/activities/ordering/OrderingDelivery.tsx
+++ b/assets/src/components/activities/ordering/OrderingDelivery.tsx
@@ -123,7 +123,7 @@ const Ordering = (props: DeliveryElementProps<OrderingModelSchema>) => {
       .then((response: EvaluationResponse) => {
         if (response.actions.length > 0) {
 
-          const action: ActivityTypes.FeedbackActionResult = response.actions[0] as ActivityTypes.FeedbackActionResult;
+          const action: ActivityTypes.FeedbackAction = response.actions[0] as ActivityTypes.FeedbackAction;
           const { score, out_of, feedback, error } = action;
           const parts = [Object.assign({}, attemptState.parts[0], { feedback, error })];
           const updated = Object.assign({}, attemptState, { score, outOf: out_of, parts });

--- a/assets/src/components/activities/ordering/OrderingDelivery.tsx
+++ b/assets/src/components/activities/ordering/OrderingDelivery.tsx
@@ -123,7 +123,8 @@ const Ordering = (props: DeliveryElementProps<OrderingModelSchema>) => {
       .then((response: EvaluationResponse) => {
         if (response.actions.length > 0) {
 
-          const action: ActivityTypes.FeedbackAction = response.actions[0] as ActivityTypes.FeedbackAction;
+          const action: ActivityTypes.FeedbackAction
+            = response.actions[0] as ActivityTypes.FeedbackAction;
           const { score, out_of, feedback, error } = action;
           const parts = [Object.assign({}, attemptState.parts[0], { feedback, error })];
           const updated = Object.assign({}, attemptState, { score, outOf: out_of, parts });

--- a/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
+++ b/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
@@ -89,8 +89,10 @@ const ShortAnswer = (props: DeliveryElementProps<ShortAnswerModelSchema>) => {
     props.onSubmitActivity(attemptState.attemptGuid,
       [{ attemptGuid: attemptState.parts[0].attemptGuid, response: { input } }])
       .then((response: EvaluationResponse) => {
-        if (response.evaluations.length > 0) {
-          const { score, out_of, feedback, error } = response.evaluations[0];
+        if (response.actions.length > 0) {
+
+          const action: ActivityTypes.FeedbackActionResult = response.actions[0] as ActivityTypes.FeedbackActionResult;
+          const { score, out_of, feedback, error } = action;
           const parts = [Object.assign({}, attemptState.parts[0], { feedback, error })];
           const updated = Object.assign({}, attemptState, { score, outOf: out_of, parts });
           setAttemptState(updated);
@@ -145,7 +147,7 @@ const ShortAnswer = (props: DeliveryElementProps<ShortAnswerModelSchema>) => {
     <div className="text-info font-italic">
       {correctnessIcon}
       <span>Points: </span><span>{attemptState.score + ' out of '
-    + attemptState.outOf}</span></div>] : null;
+        + attemptState.outOf}</span></div>] : null;
 
   const maybeSubmitButton = props.graded
     ? null

--- a/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
+++ b/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
@@ -91,7 +91,8 @@ const ShortAnswer = (props: DeliveryElementProps<ShortAnswerModelSchema>) => {
       .then((response: EvaluationResponse) => {
         if (response.actions.length > 0) {
 
-          const action: ActivityTypes.FeedbackAction = response.actions[0] as ActivityTypes.FeedbackAction;
+          const action: ActivityTypes.FeedbackAction
+            = response.actions[0] as ActivityTypes.FeedbackAction;
           const { score, out_of, feedback, error } = action;
           const parts = [Object.assign({}, attemptState.parts[0], { feedback, error })];
           const updated = Object.assign({}, attemptState, { score, outOf: out_of, parts });

--- a/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
+++ b/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
@@ -91,7 +91,7 @@ const ShortAnswer = (props: DeliveryElementProps<ShortAnswerModelSchema>) => {
       .then((response: EvaluationResponse) => {
         if (response.actions.length > 0) {
 
-          const action: ActivityTypes.FeedbackActionResult = response.actions[0] as ActivityTypes.FeedbackActionResult;
+          const action: ActivityTypes.FeedbackAction = response.actions[0] as ActivityTypes.FeedbackAction;
           const { score, out_of, feedback, error } = action;
           const parts = [Object.assign({}, attemptState.parts[0], { feedback, error })];
           const updated = Object.assign({}, attemptState, { score, outOf: out_of, parts });

--- a/assets/src/components/activities/types.ts
+++ b/assets/src/components/activities/types.ts
@@ -98,16 +98,16 @@ export interface Response extends Identifiable {
 
 export interface ConditionalOutcome extends Identifiable {
   rule: Object;
-  actions: Action[];
+  actions: ActionDesc[];
 }
 
-export interface IsActionResult {
+export interface IsAction {
   attempt_guid: string;
   error?: string;
 }
 
 export type Action = NavigationAction | FeedbackAction | StateUpdateAction;
-export type ActionResult = NavigationActionResult | FeedbackActionResult | StateUpdateActionResult;
+export type ActionDesc = NavigationActionDesc | FeedbackActionDesc | StateUpdateActionDesc;
 
 export interface FeedbackActionCore {
   score: number;
@@ -122,29 +122,29 @@ export interface StateUpdateActionCore {
   update: Object;
 }
 
-export interface NavigationAction extends Identifiable, NavigationActionCore {
+export interface NavigationActionDesc extends Identifiable, NavigationActionCore {
+  type: 'NavigationActionDesc';
+}
+
+export interface NavigationAction extends NavigationActionCore, IsAction {
   type: 'NavigationAction';
 }
 
-export interface NavigationActionResult extends NavigationActionCore, IsActionResult {
-  type: 'NavigationActionResult';
+export interface FeedbackActionDesc extends Identifiable, FeedbackActionCore {
+  type: 'FeedbackActionDesc';
 }
 
-export interface FeedbackAction extends Identifiable, FeedbackActionCore {
+export interface FeedbackAction extends FeedbackActionCore, IsAction {
   type: 'FeedbackAction';
-}
-
-export interface FeedbackActionResult extends FeedbackActionCore, IsActionResult {
-  type: 'FeedbackActionResult';
   out_of: number;
 }
 
-export interface StateUpdateAction extends Identifiable, StateUpdateActionCore {
-  type: 'StateUpdateAction';
+export interface StateUpdateActionDesc extends Identifiable, StateUpdateActionCore {
+  type: 'StateUpdateActionDesc';
 }
 
-export interface StateUpdateActionResult extends StateUpdateActionCore, IsActionResult {
-  type: 'StateUpdateActionResult';
+export interface StateUpdateAction extends StateUpdateActionCore, IsAction {
+  type: 'StateUpdateAction';
 }
 
 

--- a/assets/src/components/activities/types.ts
+++ b/assets/src/components/activities/types.ts
@@ -76,10 +76,10 @@ export interface ActivityState {
   hasMoreHints: boolean;
 }
 
-export interface Choice extends Identifiable, HasContent {}
-export interface Stem extends Identifiable, HasContent {}
-export interface Hint extends Identifiable, HasContent {}
-export interface Feedback extends Identifiable, HasContent {}
+export interface Choice extends Identifiable, HasContent { }
+export interface Stem extends Identifiable, HasContent { }
+export interface Hint extends Identifiable, HasContent { }
+export interface Feedback extends Identifiable, HasContent { }
 export interface Transformation extends Identifiable {
   path: string;
   operation: Operation;
@@ -96,8 +96,61 @@ export interface Response extends Identifiable {
   feedback: Feedback;
 }
 
+export interface ConditionalOutcome extends Identifiable {
+  rule: Object;
+  actions: Action[];
+}
+
+export interface IsActionResult {
+  attempt_guid: string;
+  error?: string;
+}
+
+export type Action = NavigationAction | FeedbackAction | StateUpdateAction;
+export type ActionResult = NavigationActionResult | FeedbackActionResult | StateUpdateActionResult;
+
+export interface FeedbackActionCore {
+  score: number;
+  feedback: Feedback;
+}
+
+export interface NavigationActionCore {
+  to: string;
+}
+
+export interface StateUpdateActionCore {
+  update: Object;
+}
+
+export interface NavigationAction extends Identifiable, NavigationActionCore {
+  type: 'NavigationAction';
+}
+
+export interface NavigationActionResult extends NavigationActionCore, IsActionResult {
+  type: 'NavigationActionResult';
+}
+
+export interface FeedbackAction extends Identifiable, FeedbackActionCore {
+  type: 'FeedbackAction';
+}
+
+export interface FeedbackActionResult extends FeedbackActionCore, IsActionResult {
+  type: 'FeedbackActionResult';
+  out_of: number;
+}
+
+export interface StateUpdateAction extends Identifiable, StateUpdateActionCore {
+  type: 'StateUpdateAction';
+}
+
+export interface StateUpdateActionResult extends StateUpdateActionCore, IsActionResult {
+  type: 'StateUpdateActionResult';
+}
+
+
 export interface Part extends Identifiable {
   responses: Response[];
+  outcomes?: ConditionalOutcome[];
   hints: Hint[];
   scoringStrategy: ScoringStrategy;
 }

--- a/lib/oli/activities/model/conditional_outcome.ex
+++ b/lib/oli/activities/model/conditional_outcome.ex
@@ -1,0 +1,37 @@
+defmodule Oli.Activities.Model.ConditionalOutome do
+  defstruct [:id, :rule, :actions]
+
+  def parse(%{"id" => id, "rule" => rule, "actions" => actions}) do
+    case Enum.map(actions, &parse_action/1)
+         |> Oli.Activities.ParseUtils.items_or_errors() do
+      {:ok, parsed_actions} ->
+        {:ok,
+         %Oli.Activities.Model.ConditionalOutome{
+           id: id,
+           rule: rule,
+           actions: parsed_actions
+         }}
+
+      {:error, _} ->
+        {:error, "invalid action definition in outcome #{id}"}
+    end
+  end
+
+  def parse(outcomes) when is_list(outcomes) do
+    Enum.map(outcomes, &parse/1)
+    |> Oli.Activities.ParseUtils.items_or_errors()
+  end
+
+  def parse(_) do
+    {:error, "invalid conditional outcome"}
+  end
+
+  defp parse_action(%{"type" => "FeedbackAction"} = action),
+    do: Oli.Activities.Model.FeedbackAction.parse(action)
+
+  defp parse_action(%{"type" => "NavigationAction"} = action),
+    do: Oli.Activities.Model.NavigationAction.parse(action)
+
+  defp parse_action(%{"type" => "StateUpdateAction"} = action),
+    do: Oli.Activities.Model.StateUpdateAction.parse(action)
+end

--- a/lib/oli/activities/model/conditional_outcome.ex
+++ b/lib/oli/activities/model/conditional_outcome.ex
@@ -1,4 +1,4 @@
-defmodule Oli.Activities.Model.ConditionalOutome do
+defmodule Oli.Activities.Model.ConditionalOutcome do
   defstruct [:id, :rule, :actions]
 
   def parse(%{"id" => id, "rule" => rule, "actions" => actions}) do
@@ -6,7 +6,7 @@ defmodule Oli.Activities.Model.ConditionalOutome do
          |> Oli.Activities.ParseUtils.items_or_errors() do
       {:ok, parsed_actions} ->
         {:ok,
-         %Oli.Activities.Model.ConditionalOutome{
+         %Oli.Activities.Model.ConditionalOutcome{
            id: id,
            rule: rule,
            actions: parsed_actions

--- a/lib/oli/activities/model/feedback_action.ex
+++ b/lib/oli/activities/model/feedback_action.ex
@@ -1,0 +1,22 @@
+defmodule Oli.Activities.Model.FeedbackAction do
+  defstruct [:id, :score, :feedback]
+
+  def parse(%{"id" => id, "score" => score, "feedback" => feedback}) do
+    case Oli.Activities.Model.Feedback.parse(feedback) do
+      {:ok, feedback} ->
+        {:ok,
+         %Oli.Activities.Model.FeedbackAction{
+           id: id,
+           score: score,
+           feedback: feedback
+         }}
+
+      error ->
+        error
+    end
+  end
+
+  def parse(_) do
+    {:error, "invalid feedback action"}
+  end
+end

--- a/lib/oli/activities/model/navigation_action.ex
+++ b/lib/oli/activities/model/navigation_action.ex
@@ -1,0 +1,14 @@
+defmodule Oli.Activities.Model.NavigationAction do
+  defstruct [:id, :to]
+
+  def parse(%{"id" => id, "to" => to}) do
+    %Oli.Activities.Model.NavigationAction{
+      id: id,
+      to: to
+    }
+  end
+
+  def parse(_) do
+    {:error, "invalid navigation action"}
+  end
+end

--- a/lib/oli/activities/model/part.ex
+++ b/lib/oli/activities/model/part.ex
@@ -1,5 +1,5 @@
 defmodule Oli.Activities.Model.Part do
-  defstruct [:id, :scoring_strategy, :responses, :hints, :parts]
+  defstruct [:id, :scoring_strategy, :responses, :outcomes, :hints, :parts]
 
   def parse(
         %{
@@ -10,15 +10,18 @@ defmodule Oli.Activities.Model.Part do
       ) do
     hints = Map.get(part, "hints", [])
     parts = Map.get(part, "parts", [])
+    outcomes = Map.get(part, "outcomes", [])
 
     with {:ok, responses} <- Oli.Activities.Model.Response.parse(responses),
          {:ok, hints} <- Oli.Activities.Model.Hint.parse(hints),
+         {:ok, outcomes} <- Oli.Activities.Model.ConditionalOutcome.parse(outcomes),
          {:ok, parts} <- Oli.Activities.Model.Part.parse(parts) do
       {:ok,
        %Oli.Activities.Model.Part{
          responses: responses,
          hints: hints,
          parts: parts,
+         outcomes: outcomes,
          id: id,
          scoring_strategy: scoring_strategy
        }}

--- a/lib/oli/activities/model/state_update_action.ex
+++ b/lib/oli/activities/model/state_update_action.ex
@@ -1,0 +1,14 @@
+defmodule Oli.Activities.Model.StateUpdateAction do
+  defstruct [:id, :update]
+
+  def parse(%{"id" => id, "update" => update}) do
+    %Oli.Activities.Model.StateUpdateAction{
+      id: id,
+      update: update
+    }
+  end
+
+  def parse(_) do
+    {:error, "invalid state update action"}
+  end
+end

--- a/lib/oli/delivery/attempts.ex
+++ b/lib/oli/delivery/attempts.ex
@@ -19,6 +19,7 @@ defmodule Oli.Delivery.Attempts do
   alias Oli.Resources.{Revision}
   alias Oli.Activities.Model
   alias Oli.Activities.Model.Feedback
+  alias Oli.Activities.Model.Part
   alias Oli.Activities.Transformers
   alias Oli.Delivery.Attempts.{StudentInput, Result, Scoring, ClientEvaluation}
   alias Oli.Publishing.{PublishedResource, DeliveryResolver}
@@ -858,18 +859,89 @@ defmodule Oli.Delivery.Attempts do
           input: input.input
         }
 
-        Oli.Delivery.Evaluation.Evaluator.evaluate(part, context)
+        if is_adaptive_eval?(part) do
+          # Stub for the future adaptive rule engine evaluation
+          perform_adaptive_eval(attempt_guid, context, part)
+        else
+          perform_standard_eval(attempt_guid, context, part)
+        end
       end)
 
     {:ok, evaluations}
+  end
+
+  defp is_adaptive_eval?(%Part{} = part) do
+    case Map.get(part, :outcomes) do
+      nil -> false
+      [] -> false
+      _ -> true
+    end
+  end
+
+  defp perform_standard_eval(
+         attempt_guid,
+         %EvaluationContext{} = evaluation_context,
+         %Part{} = part
+       ) do
+    case Oli.Delivery.Evaluation.Evaluator.evaluate(part, evaluation_context) do
+      {:ok, {feedback, %Result{score: score, out_of: out_of}}} ->
+        %Oli.Delivery.Attempts.FeedbackActionResult{
+          type: "FeedbackActionResult",
+          attempt_guid: attempt_guid,
+          feedback: feedback,
+          score: score,
+          out_of: out_of
+        }
+
+      {:error, e} ->
+        %Oli.Delivery.Attempts.FeedbackActionResult{
+          type: "FeedbackActionResult",
+          attempt_guid: attempt_guid,
+          feedback: %{},
+          score: 0,
+          out_of: 0,
+          error: e
+        }
+    end
+  end
+
+  defp perform_adaptive_eval(
+         attempt_guid,
+         %EvaluationContext{} = _,
+         %Part{} = _
+       ) do
+    %Oli.Delivery.Attempts.StateUpdateActionResult{
+      type: "StateUpdateActionResult",
+      attempt_guid: attempt_guid,
+      update: %{}
+    }
   end
 
   # Persist the result of a single evaluation for a single part_input submission.
   defp persist_single_evaluation({_, {:error, error}}, _), do: {:halt, {:error, error}}
 
   defp persist_single_evaluation(
+         {_, {:ok, %Oli.Delivery.Attempts.NavigationActionResult{} = action_result}},
+         {:ok, results}
+       ) do
+    {:cont, {:ok, results ++ [action_result]}}
+  end
+
+  defp persist_single_evaluation(
+         {_, {:ok, %Oli.Delivery.Attempts.StateUpdateActionResult{} = action_result}},
+         {:ok, results}
+       ) do
+    {:cont, {:ok, results ++ [action_result]}}
+  end
+
+  defp persist_single_evaluation(
          {%{attempt_guid: attempt_guid, input: input},
-          {:ok, {%Feedback{} = feedback, %Result{out_of: out_of, score: score}}}},
+          {:ok,
+           %Oli.Delivery.Attempts.FeedbackActionResult{
+             feedback: feedback,
+             score: score,
+             out_of: out_of
+           } = feedback_action}},
          {:ok, results}
        ) do
     now = DateTime.utc_now()
@@ -890,10 +962,7 @@ defmodule Oli.Delivery.Attempts do
         {:halt, {:error, :error}}
 
       {1, _} ->
-        {:cont,
-         {:ok,
-          results ++
-            [%{attempt_guid: attempt_guid, feedback: feedback, score: score, out_of: out_of}]}}
+        {:cont, {:ok, results ++ [feedback_action]}}
 
       _ ->
         {:halt, {:error, :error}}

--- a/lib/oli/delivery/attempts.ex
+++ b/lib/oli/delivery/attempts.ex
@@ -921,14 +921,14 @@ defmodule Oli.Delivery.Attempts do
   defp persist_single_evaluation({_, {:error, error}}, _), do: {:halt, {:error, error}}
 
   defp persist_single_evaluation(
-         {_, {:ok, %Oli.Delivery.Attempts.NavigationActionResult{} = action_result}},
+         {_, %Oli.Delivery.Attempts.NavigationActionResult{} = action_result},
          {:ok, results}
        ) do
     {:cont, {:ok, results ++ [action_result]}}
   end
 
   defp persist_single_evaluation(
-         {_, {:ok, %Oli.Delivery.Attempts.StateUpdateActionResult{} = action_result}},
+         {_, %Oli.Delivery.Attempts.StateUpdateActionResult{} = action_result},
          {:ok, results}
        ) do
     {:cont, {:ok, results ++ [action_result]}}
@@ -936,12 +936,11 @@ defmodule Oli.Delivery.Attempts do
 
   defp persist_single_evaluation(
          {%{attempt_guid: attempt_guid, input: input},
-          {:ok,
-           %Oli.Delivery.Attempts.FeedbackActionResult{
-             feedback: feedback,
-             score: score,
-             out_of: out_of
-           } = feedback_action}},
+          %Oli.Delivery.Attempts.FeedbackActionResult{
+            feedback: feedback,
+            score: score,
+            out_of: out_of
+          } = feedback_action},
          {:ok, results}
        ) do
     now = DateTime.utc_now()

--- a/lib/oli/delivery/attempts.ex
+++ b/lib/oli/delivery/attempts.ex
@@ -18,7 +18,6 @@ defmodule Oli.Delivery.Attempts do
   alias Oli.Activities.State.ActivityState
   alias Oli.Resources.{Revision}
   alias Oli.Activities.Model
-  alias Oli.Activities.Model.Feedback
   alias Oli.Activities.Model.Part
   alias Oli.Activities.Transformers
   alias Oli.Delivery.Attempts.{StudentInput, Result, Scoring, ClientEvaluation}

--- a/lib/oli/delivery/attempts/feedback_action_result.ex
+++ b/lib/oli/delivery/attempts/feedback_action_result.ex
@@ -1,0 +1,4 @@
+defmodule Oli.Delivery.Attempts.FeedbackActionResult do
+  @derive Jason.Encoder
+  defstruct [:type, :score, :out_of, :feedback, :error, :attempt_guid]
+end

--- a/lib/oli/delivery/attempts/navigation_action_result.ex
+++ b/lib/oli/delivery/attempts/navigation_action_result.ex
@@ -1,0 +1,4 @@
+defmodule Oli.Delivery.Attempts.NavigationActionResult do
+  @derive Jason.Encoder
+  defstruct [:type, :to, :error, :attempt_guid]
+end

--- a/lib/oli/delivery/attempts/state_update_action_result.ex
+++ b/lib/oli/delivery/attempts/state_update_action_result.ex
@@ -1,0 +1,4 @@
+defmodule Oli.Delivery.Attempts.StateUpdateActionResult do
+  @derive Jason.Encoder
+  defstruct [:type, :update, :error, :attempt_guid]
+end

--- a/lib/oli_web/controllers/attempt_controller.ex
+++ b/lib/oli_web/controllers/attempt_controller.ex
@@ -26,7 +26,7 @@ defmodule OliWeb.AttemptController do
     case Attempts.submit_part_evaluations(section.slug, activity_attempt_guid, [
            %{attempt_guid: attempt_guid, input: input}
          ]) do
-      {:ok, evaluations} -> json(conn, %{"type" => "success", "evaluations" => evaluations})
+      {:ok, evaluations} -> json(conn, %{"type" => "success", "actions" => evaluations})
       {:error, _} -> error(conn, 500, "server error")
     end
   end
@@ -78,8 +78,11 @@ defmodule OliWeb.AttemptController do
       end)
 
     case Attempts.submit_part_evaluations(section.slug, activity_attempt_guid, parsed) do
-      {:ok, evaluations} -> json(conn, %{"type" => "success", "evaluations" => evaluations})
-      {:error, _} -> error(conn, 500, "server error")
+      {:ok, evaluations} ->
+        json(conn, %{"type" => "success", "actions" => evaluations})
+
+      {:error, _} ->
+        error(conn, 500, "server error")
     end
   end
 
@@ -115,7 +118,7 @@ defmodule OliWeb.AttemptController do
            activity_attempt_guid,
            client_evaluations
          ) do
-      {:ok, evaluations} -> json(conn, %{"type" => "success", "evaluations" => evaluations})
+      {:ok, evaluations} -> json(conn, %{"type" => "success", "actions" => evaluations})
       {:error, _} -> error(conn, 500, "server error")
     end
   end

--- a/test/oli/delivery/attempts_test.exs
+++ b/test/oli/delivery/attempts_test.exs
@@ -488,11 +488,13 @@ defmodule Oli.Delivery.AttemptsTest do
              ) ==
                {:ok,
                 [
-                  %{
+                  %Oli.Delivery.Attempts.FeedbackActionResult{
                     attempt_guid: part1_attempt1.attempt_guid,
                     feedback: %Oli.Activities.Model.Feedback{content: "some-feedback", id: "1"},
                     out_of: 1,
-                    score: 1
+                    score: 1,
+                    error: nil,
+                    type: "FeedbackActionResult"
                   }
                 ]}
     end

--- a/test/oli/delivery/submission_test.exs
+++ b/test/oli/delivery/submission_test.exs
@@ -739,7 +739,7 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
     } do
       part_inputs = [%{attempt_guid: part_attempt.attempt_guid, input: %StudentInput{input: "d"}}]
 
-      {:error, error} =
+      {:error, %{error: error}} =
         Attempts.submit_part_evaluations(section.slug, activity_attempt.attempt_guid, part_inputs)
 
       assert error == "no matching response found"

--- a/test/oli/registrar_test.exs
+++ b/test/oli/registrar_test.exs
@@ -6,9 +6,9 @@ defmodule Oli.RegistrarTest do
   describe "activity registration" do
     test "register_local_activities/0 registers", _ do
       registrations = Activities.list_activity_registrations()
-      assert length(registrations) == 5
+      assert length(registrations) == 6
 
-      r = hd(registrations)
+      r = Enum.at(registrations, 1)
 
       assert r.title == "Check All That Apply"
 
@@ -25,7 +25,7 @@ defmodule Oli.RegistrarTest do
     test "create_registered_activity_map/0 creates correctly", _ do
       map = Activities.create_registered_activity_map()
 
-      assert Map.keys(map) |> length == 5
+      assert Map.keys(map) |> length == 6
 
       r = Map.get(map, "oli_check_all_that_apply")
 


### PR DESCRIPTION
This PR introduces the following:

1. Adaptive Activity type. This is largely a stub for now, but necessary to get in place to support ingestion. 
2. Refinements to the Attempts eval infrastructure to allow parts to define a collection of `ConditionalOutcome` instances - each with a rule and a resultant set of actions that would be triggered if the rule is evaluated to true.  The presence of one or more `ConditionalOutcome` instances is what allows Torus to know whether or not to route that eval to the "adaptive eval engine" (which is a hardcoded stub for now).   

Closes #918