### PR TITLE
open link in new tab

### DIFF
--- a/lib/oli_web/templates/open_and_free/index.html.eex
+++ b/lib/oli_web/templates/open_and_free/index.html.eex
@@ -36,7 +36,7 @@
                 <%= section.title %>
               </div>
               <div class="text-nowrap">
-                <%= link Routes.page_delivery_url(@conn, :index, section.slug), to: Routes.page_delivery_url(@conn, :index, section.slug), target: "_blank", id: "section_link_#{section.slug}", class: "mr-2" %>
+                <%= external_link Routes.page_delivery_url(@conn, :index, section.slug), to: Routes.page_delivery_url(@conn, :index, section.slug), id: "section_link_#{section.slug}", class: "mr-2" %>
                 <button class="clipboardjs btn btn-xs btn-primary" data-clipboard-target="#<%= "section_link_#{section.slug}" %>">
                   <i class="lar la-clipboard"></i> Copy
                 </button>

--- a/lib/oli_web/templates/open_and_free/show.html.eex
+++ b/lib/oli_web/templates/open_and_free/show.html.eex
@@ -15,7 +15,7 @@
     <tbody>
       <tr>
         <td><strong>URL:</strong></td>
-        <td><%= link Routes.page_delivery_url(@conn, :index, @section.slug), to: Routes.page_delivery_url(@conn, :index, @section.slug) %></td>
+        <td><%= external_link Routes.page_delivery_url(@conn, :index, @section.slug), to: Routes.page_delivery_url(@conn, :index, @section.slug) %></td>
       </tr>
 
       <tr>

--- a/lib/oli_web/views/view_helpers.ex
+++ b/lib/oli_web/views/view_helpers.ex
@@ -1,4 +1,6 @@
 defmodule OliWeb.ViewHelpers do
+  use Phoenix.HTML
+
   def is_admin?(%{:assigns => assigns}) do
     admin_role_id = Oli.Accounts.SystemRole.role_id().admin
     assigns.current_author.system_role_id == admin_role_id
@@ -6,5 +8,14 @@ defmodule OliWeb.ViewHelpers do
 
   def preview_mode(%{assigns: assigns} = _conn) do
     Map.get(assigns, :preview_mode, false)
+  end
+
+  @doc """
+  Renders a link with text and an external icon which opens in a new tab
+  """
+  def external_link(text, opts \\ []) do
+    link Keyword.merge([target: "_blank"], opts) do
+      [text, content_tag("i", "", class: "las la-external-link-alt ml-1")]
+    end
   end
 end


### PR DESCRIPTION
This PR fixes the open and free section url in details to open in a new tab.

Since this work is part of open and free and is cosmetic, I didn't add a new change log entry for it.