### PR TITLE
Extrinsic user state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - Add Open and Free section support
   - Feature flag support
   - Add research and cookie consent support
+  - Extrinsic user state endpoints
 
 ### Bug fixes
   - Fix analytics / insights to not show parent course analytics after duplication
@@ -17,7 +18,7 @@
   - Fix issue where long lines in code blocks in activities overflow
   - Change how ids are determined in ingestion to avoid problems with unicode characters
   - Scope lock messages to a specific project
-  - (Developer) Auto format Elixir code 
+  - (Developer) Auto format Elixir code
   - Fix attempts sort order
 
 ## 0.7.2 (2021-3-30)

--- a/assets/src/components/activities/DeliveryElement.ts
+++ b/assets/src/components/activities/DeliveryElement.ts
@@ -41,6 +41,7 @@ export interface DeliveryElementProps<T extends ActivityModelSchema> {
   preview: boolean;
   progressState: string;
   sectionSlug?: string;
+  userId: string;
 
   onSaveActivity: (attemptGuid: string, partResponses: PartResponse[]) => Promise<Success>;
   onSubmitActivity: (attemptGuid: string,
@@ -137,6 +138,7 @@ export abstract class DeliveryElement<T extends ActivityModelSchema> extends HTM
     const preview = valueOr(JSON.parse(this.getAttribute('preview') as any), false);
     const progressState = this.getAttribute('progress_state') as any;
     const sectionSlug = valueOr(this.getAttribute('section_slug'), undefined);
+    const userId = this.getAttribute('user_id') as any;
 
     this.progressState = progressState;
 
@@ -155,6 +157,7 @@ export abstract class DeliveryElement<T extends ActivityModelSchema> extends HTM
       onSubmitActivity: this.onSubmitActivity,
       onResetActivity: this.onResetActivity,
       onSubmitEvaluations: this.onSubmitEvaluations,
+      userId,
     };
   }
 

--- a/assets/src/components/activities/DeliveryElement.ts
+++ b/assets/src/components/activities/DeliveryElement.ts
@@ -41,7 +41,7 @@ export interface DeliveryElementProps<T extends ActivityModelSchema> {
   preview: boolean;
   progressState: string;
   sectionSlug?: string;
-  userId: string;
+  userId: number;
 
   onSaveActivity: (attemptGuid: string, partResponses: PartResponse[]) => Promise<Success>;
   onSubmitActivity: (attemptGuid: string,

--- a/assets/src/components/activities/adaptive/AdaptiveDelivery.tsx
+++ b/assets/src/components/activities/adaptive/AdaptiveDelivery.tsx
@@ -10,19 +10,30 @@ import { useGlobalState } from 'components/hooks/global';
 import * as ActivityTypes from '../types';
 import * as Extrinsic from 'data/persistence/extrinsic';
 
+const randomInt = () => Math.floor(Math.random() * 100);
+
 const Adaptive = (props: DeliveryElementProps<AdaptiveModelSchema>) => {
 
   const [active, setActive] = useState(true);
   const [handle, setHandle] = useState(null as any);
+  const [local, setLocal] = useState(props.state.parts[0].response);
 
   const data = useGlobalState(props.userId, active);
 
   const scalar = () => {
-    Extrinsic.upsert_global({ test: 'hello', again: 'no' });
+    Extrinsic.upsert_global({ scalar: randomInt() });
   }
 
   const nested = () => {
-    Extrinsic.upsert_global({ apple: { orange: 1 }, banana: ['no', 'yes'] });
+    Extrinsic.upsert_global({ nested: { multiple: { levels: randomInt() } } });
+  }
+
+  const save = () => {
+    const local = randomInt();
+    props.onSaveActivity(props.state.attemptGuid, [{ attemptGuid: props.state.parts[0].attemptGuid, response: { input: { local } } }])
+      .then(result => {
+        setLocal({ input: { local } });
+      });
   }
 
   const timer = () => {
@@ -30,34 +41,49 @@ const Adaptive = (props: DeliveryElementProps<AdaptiveModelSchema>) => {
       clearInterval(handle);
       setHandle(null);
     } else {
-      setHandle(setInterval(() => Extrinsic.upsert_global({ randomValue: Math.random() }), 500));
+      setHandle(setInterval(() => Extrinsic.upsert_global({ randomValue: randomInt() }), 100));
     }
   }
 
   const toggle = () => setActive(!active);
 
   return (
-    <div>
+    <div style={{ border: '3px dashed lightgray', padding: '10px', margin: '10px' }}>
       <h3>Adaptive Activity</h3>
 
-      <h5>Global Data</h5>
+      <h5>Global State</h5>
 
-      <pre>
-        <code>
-          {JSON.stringify(data, undefined, 2)}
-        </code>
-      </pre>
+      <div className="m-3">
 
+        <pre>
+          <code>
+            {JSON.stringify(data, undefined, 2)}
+          </code>
+        </pre>
 
-      <div className="form-check">
-        <input className="form-check-input" type="checkbox" value="" checked={active} onChange={toggle} />
-        <label className="form-check-label">
-          Subscribe To Global State
-        </label>
+        <div className="form-check">
+          <input className="form-check-input" type="checkbox" value="" checked={active} onChange={toggle} />
+          <label className="form-check-label">
+            Subscribe To Global State
+          </label>
+        </div>
+        <button onClick={scalar} className="btn btn-primary btn-sm mr-2">Set Scalars</button>
+        <button onClick={nested} className="btn btn-primary btn-sm mr-2">Set Nested</button>
+        <button onClick={timer} className={`btn ${handle === null ? 'btn-primary' : 'btn-danger'} btn-sm`}>{handle === null ? 'Run Timer' : 'Stop Timer'}</button>
       </div>
-      <button onClick={scalar} className="btn btn-primary btn-sm mr-2">Set Scalars</button>
-      <button onClick={nested} className="btn btn-primary btn-sm mr-2">Set Nested</button>
-      <button onClick={timer} className={`btn ${handle === null ? 'btn-primary' : 'btn-danger'} btn-sm`}>{handle === null ? 'Run Timer' : 'Stop Timer'}</button>
+
+      <h5>Attempt State</h5>
+      <div className="m-3">
+
+        <pre>
+          <code>
+            {JSON.stringify(local, undefined, 2)}
+          </code>
+        </pre>
+
+        <button onClick={save} className="btn btn-primary btn-sm mr-2">Update State</button>
+
+      </div>
 
     </div>
   )

--- a/assets/src/components/activities/adaptive/AdaptiveDelivery.tsx
+++ b/assets/src/components/activities/adaptive/AdaptiveDelivery.tsx
@@ -21,11 +21,11 @@ const Adaptive = (props: DeliveryElementProps<AdaptiveModelSchema>) => {
   const data = useGlobalState(props.userId, active);
 
   const scalar = () => {
-    Extrinsic.upsert_global({ scalar: randomInt() });
+    Extrinsic.upsertGlobal({ scalar: randomInt() });
   };
 
   const nested = () => {
-    Extrinsic.upsert_global({ nested: { multiple: { levels: randomInt() } } });
+    Extrinsic.upsertGlobal({ nested: { multiple: { levels: randomInt() } } });
   };
 
   const save = () => {
@@ -42,7 +42,7 @@ const Adaptive = (props: DeliveryElementProps<AdaptiveModelSchema>) => {
       clearInterval(handle);
       setHandle(null);
     } else {
-      setHandle(setInterval(() => Extrinsic.upsert_global({ randomValue: randomInt() }), 100));
+      setHandle(setInterval(() => Extrinsic.upsertGlobal({ randomValue: randomInt() }), 100));
     }
   };
 

--- a/assets/src/components/activities/adaptive/AdaptiveDelivery.tsx
+++ b/assets/src/components/activities/adaptive/AdaptiveDelivery.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 import {
   DeliveryElement,
@@ -6,8 +6,53 @@ import {
 } from '../DeliveryElement';
 import { AdaptiveModelSchema } from './schema';
 import * as ActivityTypes from '../types';
+import * as Extrinsic from 'data/persistence/extrinsic';
 
-const Adaptive = (props: DeliveryElementProps<AdaptiveModelSchema>) => <p>Adaptive</p>;
+const Adaptive = (props: DeliveryElementProps<AdaptiveModelSchema>) => {
+
+  const [initialized, setInitialized] = useState(false);
+  const [data, setData] = useState({});
+
+  useEffect(() => {
+    if (!initialized) {
+      Extrinsic.read_global()
+        .then(result => {
+          setData(result);
+        })
+      setInitialized(true);
+    }
+  }, [initialized]);
+
+  const scalar = () => {
+    Extrinsic.upsert_global({ test: 'hello', again: 'no' })
+      .then(r => Extrinsic.read_global())
+      .then(r => setData(r));
+  }
+
+  const nested = () => {
+    Extrinsic.upsert_global({ apple: { orange: 1 }, banana: ['no', 'yes'] })
+      .then(r => Extrinsic.read_global())
+      .then(r => setData(r));
+  }
+
+  return (
+    <div>
+      <h3>Adaptive Activity</h3>
+
+      <h5>Global Data</h5>
+
+      <pre>
+        <code>
+          {JSON.stringify(data, undefined, 2)}
+        </code>
+      </pre>
+
+      <button onClick={scalar} className="btn btn-primary">Set Scalar</button>
+      <button onClick={nested} className="btn btn-primary">Set Nested</button>
+
+    </div>
+  )
+};
 
 // Defines the web component, a simple wrapper over our React component above
 export class AdaptiveDelivery extends DeliveryElement<AdaptiveModelSchema> {

--- a/assets/src/components/activities/adaptive/AdaptiveDelivery.tsx
+++ b/assets/src/components/activities/adaptive/AdaptiveDelivery.tsx
@@ -22,19 +22,20 @@ const Adaptive = (props: DeliveryElementProps<AdaptiveModelSchema>) => {
 
   const scalar = () => {
     Extrinsic.upsert_global({ scalar: randomInt() });
-  }
+  };
 
   const nested = () => {
     Extrinsic.upsert_global({ nested: { multiple: { levels: randomInt() } } });
-  }
+  };
 
   const save = () => {
     const local = randomInt();
-    props.onSaveActivity(props.state.attemptGuid, [{ attemptGuid: props.state.parts[0].attemptGuid, response: { input: { local } } }])
-      .then(result => {
+    props.onSaveActivity(props.state.attemptGuid,
+      [{ attemptGuid: props.state.parts[0].attemptGuid, response: { input: { local } } }])
+      .then((result: any) => {
         setLocal({ input: { local } });
       });
-  }
+  };
 
   const timer = () => {
     if (handle !== null) {
@@ -43,7 +44,7 @@ const Adaptive = (props: DeliveryElementProps<AdaptiveModelSchema>) => {
     } else {
       setHandle(setInterval(() => Extrinsic.upsert_global({ randomValue: randomInt() }), 100));
     }
-  }
+  };
 
   const toggle = () => setActive(!active);
 
@@ -62,14 +63,18 @@ const Adaptive = (props: DeliveryElementProps<AdaptiveModelSchema>) => {
         </pre>
 
         <div className="form-check">
-          <input className="form-check-input" type="checkbox" value="" checked={active} onChange={toggle} />
+          <input className="form-check-input" type="checkbox" value=""
+            checked={active} onChange={toggle} />
           <label className="form-check-label">
             Subscribe To Global State
           </label>
         </div>
         <button onClick={scalar} className="btn btn-primary btn-sm mr-2">Set Scalars</button>
         <button onClick={nested} className="btn btn-primary btn-sm mr-2">Set Nested</button>
-        <button onClick={timer} className={`btn ${handle === null ? 'btn-primary' : 'btn-danger'} btn-sm`}>{handle === null ? 'Run Timer' : 'Stop Timer'}</button>
+        <button onClick={timer} className={`btn ${handle === null
+          ? 'btn-primary' : 'btn-danger'} btn-sm`}>
+          {handle === null ? 'Run Timer' : 'Stop Timer'}
+        </button>
       </div>
 
       <h5>Attempt State</h5>
@@ -86,7 +91,7 @@ const Adaptive = (props: DeliveryElementProps<AdaptiveModelSchema>) => {
       </div>
 
     </div>
-  )
+  );
 };
 
 // Defines the web component, a simple wrapper over our React component above

--- a/assets/src/components/activities/adaptive/utils.ts
+++ b/assets/src/components/activities/adaptive/utils.ts
@@ -26,9 +26,7 @@ export const defaultModel: () => AdaptiveModelSchema = () => {
           fromText(''),
         ],
       }],
-      transformations: [
-        { id: guid(), path: 'choices', operation: Operation.shuffle },
-      ],
+      transformations: [],
       previewText: '',
     },
   };

--- a/assets/src/components/hooks/global.ts
+++ b/assets/src/components/hooks/global.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { initSocket } from '../../phoenix/socket';
 
-export function useGlobalState(user: string, active: boolean) {
+export function useGlobalState(userId: number, active: boolean) {
 
   const [init, setInit] = useState(false);
   const [channel, setChannel] = useState(null as any);
@@ -29,7 +29,7 @@ export function useGlobalState(user: string, active: boolean) {
   useEffect(() => {
 
     if (!init) {
-      const c = initSocket().channel('global:' + user, {});
+      const c = initSocket().channel('global:' + userId, {});
 
       setInit(true);
       setChannel(c);

--- a/assets/src/components/hooks/global.ts
+++ b/assets/src/components/hooks/global.ts
@@ -13,11 +13,27 @@ export function useGlobalState(userId: number, active: boolean) {
   if (channel !== null) {
 
     channel.off('delta');
+    channel.off('deletion');
     channel.off('state');
 
     if (active) {
       channel.on('delta', (delta: any) => {
-        const updated = Object.assign({}, data, delta)
+        const updated = Object.assign({}, data, delta);
+        setData(updated);
+      });
+      channel.on('deletion', (deleted: any) => {
+
+        const keys = deleted.reduce((m: any, k: any) => { m[k] = true; return m; }, {});
+        const updated = Object.keys(data)
+          .reduce(
+            (m: any, k: any) => {
+              if (!keys[k]) {
+                m[k] = (data as any)[k];
+              }
+              return m;
+            },
+            {},
+          );
         setData(updated);
       });
       channel.on('state', (state: any) => {
@@ -29,21 +45,21 @@ export function useGlobalState(userId: number, active: boolean) {
   useEffect(() => {
 
     if (!init) {
-      const c = initSocket().channel('global:' + userId, {});
+      const c = initSocket().channel('user_global_state:' + userId, {});
 
       setInit(true);
       setChannel(c);
 
-      c.join()
-        .receive('ok', (resp: any) => { console.log('Joined successfully', resp) })
-        .receive('error', (resp: any) => { console.log('Unable to join', resp) });
+      c.join();
+      // .receive('ok', (resp: any) => { console.log('Joined successfully', resp) })
+      // .receive('error', (resp: any) => { console.log('Unable to join', resp) });
     }
 
     return () => {
       if (channel !== null && init) {
         channel.leave();
       }
-    }
+    };
   }, [init]);
 
   return data;

--- a/assets/src/components/hooks/global.ts
+++ b/assets/src/components/hooks/global.ts
@@ -1,0 +1,50 @@
+import { useState, useEffect } from 'react';
+import { initSocket } from '../../phoenix/socket';
+
+export function useGlobalState(user: string, active: boolean) {
+
+  const [init, setInit] = useState(false);
+  const [channel, setChannel] = useState(null as any);
+  const [data, setData] = useState({});
+
+  // Note, tear down and setup of the delta and state listeners
+  // is necessary on every execution of this hook so that they have
+  // a closure view of the latest 'data'
+  if (channel !== null) {
+
+    channel.off('delta');
+    channel.off('state');
+
+    if (active) {
+      channel.on('delta', (delta: any) => {
+        const updated = Object.assign({}, data, delta)
+        setData(updated);
+      });
+      channel.on('state', (state: any) => {
+        setData(state);
+      });
+    }
+  }
+
+  useEffect(() => {
+
+    if (!init) {
+      const c = initSocket().channel('global:' + user, {});
+
+      setInit(true);
+      setChannel(c);
+
+      c.join()
+        .receive('ok', (resp: any) => { console.log('Joined successfully', resp) })
+        .receive('error', (resp: any) => { console.log('Unable to join', resp) });
+    }
+
+    return () => {
+      if (channel !== null && init) {
+        channel.leave();
+      }
+    }
+  }, [init]);
+
+  return data;
+}

--- a/assets/src/data/persistence/extrinsic.ts
+++ b/assets/src/data/persistence/extrinsic.ts
@@ -9,7 +9,7 @@ export type ExtrinsicDelete = {
   result: 'success',
 };
 
-export function read_global(keys: string[] | null = null) {
+export function readGlobal(keys: string[] | null = null) {
 
   const params = {
     method: 'GET',
@@ -19,7 +19,7 @@ export function read_global(keys: string[] | null = null) {
   return makeRequest<ExtrinsicRead>(params);
 }
 
-export function delete_global(keys: string[]) {
+export function deleteGlobal(keys: string[]) {
 
   const params = {
     method: 'DELETE',
@@ -29,7 +29,7 @@ export function delete_global(keys: string[]) {
   return makeRequest<ExtrinsicRead>(params);
 }
 
-export function upsert_global(keyValues: Object) {
+export function upsertGlobal(keyValues: Object) {
 
   const params = {
     method: 'PUT',
@@ -41,7 +41,7 @@ export function upsert_global(keyValues: Object) {
 }
 
 
-export function read_section(slug: SectionSlug, keys: string[] | null = null) {
+export function readSection(slug: SectionSlug, keys: string[] | null = null) {
 
   const params = {
     method: 'GET',
@@ -51,7 +51,7 @@ export function read_section(slug: SectionSlug, keys: string[] | null = null) {
   return makeRequest<ExtrinsicRead>(params);
 }
 
-export function delete_section(slug: SectionSlug, keys: string[]) {
+export function deleteSection(slug: SectionSlug, keys: string[]) {
 
   const params = {
     method: 'DELETE',
@@ -61,7 +61,7 @@ export function delete_section(slug: SectionSlug, keys: string[]) {
   return makeRequest<ExtrinsicRead>(params);
 }
 
-export function upsert_section(slug: SectionSlug, keyValues: Object) {
+export function upsertSection(slug: SectionSlug, keyValues: Object) {
 
   const params = {
     method: 'PUT',

--- a/assets/src/data/persistence/extrinsic.ts
+++ b/assets/src/data/persistence/extrinsic.ts
@@ -3,27 +3,17 @@ import { makeRequest } from './common';
 
 export type ExtrinsicRead = Object;
 export type ExtrinsicUpsert = {
-  result: "success"
+  result: 'success',
 };
 export type ExtrinsicDelete = {
-  result: "success"
+  result: 'success',
 };
 
 export function read_global(keys: string[] | null = null) {
 
-  // Phoenix handles arrays like foo[]=bar&foo[]=baz&foo[]=qux.
-  const keyParams = keys === null
-    ? ''
-    : '?' + keys.reduce(
-      (p, k) => {
-        return p + '&keys[]=' + k;
-      },
-      '',
-    ).substr(1);
-
   const params = {
     method: 'GET',
-    url: '/state' + keyParams,
+    url: '/state' + toKeyParams(keys),
   };
 
   return makeRequest<ExtrinsicRead>(params);
@@ -31,17 +21,9 @@ export function read_global(keys: string[] | null = null) {
 
 export function delete_global(keys: string[]) {
 
-  // Phoenix handles arrays like foo[]=bar&foo[]=baz&foo[]=qux.
-  const keyParams = '?' + keys.reduce(
-    (p, k) => {
-      return p + '&keys[]=' + k;
-    },
-    '',
-  ).substr(1);
-
   const params = {
     method: 'DELETE',
-    url: '/state' + keyParams,
+    url: '/state' + toKeyParams(keys),
   };
 
   return makeRequest<ExtrinsicRead>(params);
@@ -56,4 +38,50 @@ export function upsert_global(keyValues: Object) {
   };
 
   return makeRequest<ExtrinsicDelete>(params);
+}
+
+
+export function read_section(slug: SectionSlug, keys: string[] | null = null) {
+
+  const params = {
+    method: 'GET',
+    url: `/state/course/${slug}` + toKeyParams(keys),
+  };
+
+  return makeRequest<ExtrinsicRead>(params);
+}
+
+export function delete_section(slug: SectionSlug, keys: string[]) {
+
+  const params = {
+    method: 'DELETE',
+    url: `/state/course/${slug}` + toKeyParams(keys),
+  };
+
+  return makeRequest<ExtrinsicRead>(params);
+}
+
+export function upsert_section(slug: SectionSlug, keyValues: Object) {
+
+  const params = {
+    method: 'PUT',
+    body: JSON.stringify(keyValues),
+    url: `/state/course/${slug}`,
+  };
+
+  return makeRequest<ExtrinsicDelete>(params);
+}
+
+// Take a list of string key names and turn it into the form expected by
+// Phoenix: foo[]=bar&foo[]=baz&foo[]=qux.
+function toKeyParams(keys: string[] | null = null) {
+
+  keys === null
+    ? ''
+    : '?' + keys.reduce(
+      (p, k) => {
+        return p + '&keys[]=' + k;
+      },
+      '',
+    ).substr(1);
 }

--- a/assets/src/data/persistence/extrinsic.ts
+++ b/assets/src/data/persistence/extrinsic.ts
@@ -1,0 +1,59 @@
+import { SectionSlug } from 'data/types';
+import { makeRequest } from './common';
+
+export type ExtrinsicRead = Object;
+export type ExtrinsicUpsert = {
+  result: "success"
+};
+export type ExtrinsicDelete = {
+  result: "success"
+};
+
+export function read_global(keys: string[] | null = null) {
+
+  // Phoenix handles arrays like foo[]=bar&foo[]=baz&foo[]=qux.
+  const keyParams = keys === null
+    ? ''
+    : '?' + keys.reduce(
+      (p, k) => {
+        return p + '&keys[]=' + k;
+      },
+      '',
+    ).substr(1);
+
+  const params = {
+    method: 'GET',
+    url: '/state' + keyParams,
+  };
+
+  return makeRequest<ExtrinsicRead>(params);
+}
+
+export function delete_global(keys: string[]) {
+
+  // Phoenix handles arrays like foo[]=bar&foo[]=baz&foo[]=qux.
+  const keyParams = '?' + keys.reduce(
+    (p, k) => {
+      return p + '&keys[]=' + k;
+    },
+    '',
+  ).substr(1);
+
+  const params = {
+    method: 'DELETE',
+    url: '/state' + keyParams,
+  };
+
+  return makeRequest<ExtrinsicRead>(params);
+}
+
+export function upsert_global(keyValues: Object) {
+
+  const params = {
+    method: 'PUT',
+    body: JSON.stringify(keyValues),
+    url: '/state',
+  };
+
+  return makeRequest<ExtrinsicDelete>(params);
+}

--- a/assets/src/data/types.ts
+++ b/assets/src/data/types.ts
@@ -6,3 +6,4 @@ export type ActivitySlug = string;
 export type ActivityTypeSlug = string;
 export type ElementId = number;
 export type UserEmail = string;
+export type SectionSlug = string;

--- a/assets/src/phoenix/phoenix.d.ts
+++ b/assets/src/phoenix/phoenix.d.ts
@@ -1,0 +1,1 @@
+declare module 'phoenix';

--- a/assets/src/phoenix/socket.ts
+++ b/assets/src/phoenix/socket.ts
@@ -9,8 +9,6 @@
 
 import { Socket } from 'phoenix';
 
-const socket = new Socket('/socket', { params: { token: (window as any).userToken } });
-
 // When you connect, you'll often need to authenticate the client.
 // For example, imagine you have an authentication plug, `MyAuth`,
 // which authenticates the session and assigns a `:current_user`.
@@ -53,12 +51,12 @@ const socket = new Socket('/socket', { params: { token: (window as any).userToke
 //     end
 //
 // Finally, connect to the socket:
-socket.connect();
 
-// Now that you are connected, you can join channels with a topic:
-// let channel = socket.channel("topic:subtopic", {})
-// channel.join()
-//  .receive("ok", resp => { console.log("Joined successfully", resp) })
-//  .receive("error", resp => { console.log("Unable to join", resp) })
 
-export default socket;
+export function initSocket() {
+
+  const socket = new Socket('/v1/api/state', { params: { token: (window as any).userToken } });
+  socket.connect();
+
+  return socket;
+}

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -33,11 +33,11 @@ const populateEntries = () => {
   });
 
   const themePaths = [
-    ...glob.sync("./styles/themes/authoring/*.scss").map(p => ({prefix: 'authoring_theme_', themePath: p})),
-    ...glob.sync("./styles/themes/delivery/*.scss").map(p => ({prefix: 'delivery_theme_', themePath: p})),
+    ...glob.sync("./styles/themes/authoring/*.scss").map(p => ({ prefix: 'authoring_theme_', themePath: p })),
+    ...glob.sync("./styles/themes/delivery/*.scss").map(p => ({ prefix: 'delivery_theme_', themePath: p })),
   ];
 
-  const foundThemes = themePaths.map(({prefix, themePath}) => {
+  const foundThemes = themePaths.map(({ prefix, themePath }) => {
     const name = path.basename(themePath, '.scss');
     return {
       [prefix + name]: themePath,
@@ -61,17 +61,17 @@ module.exports = (env, options) => ({
   devtool: 'source-map',
   optimization: {
     chunkIds: "named",
-		splitChunks: {
-			cacheGroups: {
-				vendor: {
-					test: /node_modules/,
-					chunks: "initial",
-					name: "vendor",
-					priority: 10,
-					enforce: true
-				}
-			}
-		},
+    splitChunks: {
+      cacheGroups: {
+        vendor: {
+          test: /node_modules/,
+          chunks: "initial",
+          name: "vendor",
+          priority: 10,
+          enforce: true
+        }
+      }
+    },
     minimizer: [
       new UglifyJsPlugin({ cache: true, parallel: true, sourceMap: true }),
       new OptimizeCSSAssetsPlugin({})

--- a/lib/oli/accounts/schemas/user.ex
+++ b/lib/oli/accounts/schemas/user.ex
@@ -26,7 +26,7 @@ defmodule Oli.Accounts.User do
     field :phone_number_verified, :boolean
     field :address, :string
     field :research_opt_out, :boolean
-    field :state, :map
+    field :state, :map, default: %{}
 
     # A user may optionally be linked to an author account
     belongs_to :author, Oli.Accounts.Author

--- a/lib/oli/accounts/schemas/user.ex
+++ b/lib/oli/accounts/schemas/user.ex
@@ -26,6 +26,7 @@ defmodule Oli.Accounts.User do
     field :phone_number_verified, :boolean
     field :address, :string
     field :research_opt_out, :boolean
+    field :state, :map
 
     # A user may optionally be linked to an author account
     belongs_to :author, Oli.Accounts.Author
@@ -63,7 +64,8 @@ defmodule Oli.Accounts.User do
       :phone_number_verified,
       :address,
       :author_id,
-      :research_opt_out
+      :research_opt_out,
+      :state
     ])
     |> validate_required([:sub])
     |> maybe_name_from_given_and_family()

--- a/lib/oli/activities/model/conditional_outcome.ex
+++ b/lib/oli/activities/model/conditional_outcome.ex
@@ -2,6 +2,8 @@ defmodule Oli.Activities.Model.ConditionalOutcome do
   defstruct [:id, :rule, :actions]
 
   def parse(%{"id" => id, "rule" => rule, "actions" => actions}) do
+    IO.inspect(actions)
+
     case Enum.map(actions, &parse_action/1)
          |> Oli.Activities.ParseUtils.items_or_errors() do
       {:ok, parsed_actions} ->
@@ -26,12 +28,12 @@ defmodule Oli.Activities.Model.ConditionalOutcome do
     {:error, "invalid conditional outcome"}
   end
 
-  defp parse_action(%{"type" => "FeedbackAction"} = action),
+  defp parse_action(%{"type" => "FeedbackActionDesc"} = action),
     do: Oli.Activities.Model.FeedbackAction.parse(action)
 
-  defp parse_action(%{"type" => "NavigationAction"} = action),
+  defp parse_action(%{"type" => "NavigationActionDesc"} = action),
     do: Oli.Activities.Model.NavigationAction.parse(action)
 
-  defp parse_action(%{"type" => "StateUpdateAction"} = action),
+  defp parse_action(%{"type" => "StateUpdateActionDesc"} = action),
     do: Oli.Activities.Model.StateUpdateAction.parse(action)
 end

--- a/lib/oli/activities/model/conditional_outcome.ex
+++ b/lib/oli/activities/model/conditional_outcome.ex
@@ -2,8 +2,6 @@ defmodule Oli.Activities.Model.ConditionalOutcome do
   defstruct [:id, :rule, :actions]
 
   def parse(%{"id" => id, "rule" => rule, "actions" => actions}) do
-    IO.inspect(actions)
-
     case Enum.map(actions, &parse_action/1)
          |> Oli.Activities.ParseUtils.items_or_errors() do
       {:ok, parsed_actions} ->

--- a/lib/oli/activities/model/navigation_action.ex
+++ b/lib/oli/activities/model/navigation_action.ex
@@ -2,10 +2,11 @@ defmodule Oli.Activities.Model.NavigationAction do
   defstruct [:id, :to]
 
   def parse(%{"id" => id, "to" => to}) do
-    %Oli.Activities.Model.NavigationAction{
-      id: id,
-      to: to
-    }
+    {:ok,
+     %Oli.Activities.Model.NavigationAction{
+       id: id,
+       to: to
+     }}
   end
 
   def parse(_) do

--- a/lib/oli/activities/model/state_update_action.ex
+++ b/lib/oli/activities/model/state_update_action.ex
@@ -2,10 +2,11 @@ defmodule Oli.Activities.Model.StateUpdateAction do
   defstruct [:id, :update]
 
   def parse(%{"id" => id, "update" => update}) do
-    %Oli.Activities.Model.StateUpdateAction{
-      id: id,
-      update: update
-    }
+    {:ok,
+     %Oli.Activities.Model.StateUpdateAction{
+       id: id,
+       update: update
+     }}
   end
 
   def parse(_) do

--- a/lib/oli/activities/state.ex
+++ b/lib/oli/activities/state.ex
@@ -8,12 +8,7 @@ defmodule Oli.Activities.State do
   returning those in a map of activity ids to the state.
   """
   def from_attempts(latest_attempts) do
-    IO.inspect("HERE")
-    IO.inspect(latest_attempts)
-
     Enum.map(latest_attempts, fn {id, {activity_attempt, part_attempts}} ->
-      IO.inspect(activity_attempt)
-
       {:ok, model} = Map.get(activity_attempt, :transformed_model) |> Model.parse()
 
       {id, ActivityState.from_attempt(activity_attempt, Map.values(part_attempts), model)}

--- a/lib/oli/activities/state.ex
+++ b/lib/oli/activities/state.ex
@@ -8,7 +8,12 @@ defmodule Oli.Activities.State do
   returning those in a map of activity ids to the state.
   """
   def from_attempts(latest_attempts) do
+    IO.inspect("HERE")
+    IO.inspect(latest_attempts)
+
     Enum.map(latest_attempts, fn {id, {activity_attempt, part_attempts}} ->
+      IO.inspect(activity_attempt)
+
       {:ok, model} = Map.get(activity_attempt, :transformed_model) |> Model.parse()
 
       {id, ActivityState.from_attempt(activity_attempt, Map.values(part_attempts), model)}

--- a/lib/oli/authoring/editing/page_editor.ex
+++ b/lib/oli/authoring/editing/page_editor.ex
@@ -404,7 +404,7 @@ defmodule Oli.Authoring.Editing.PageEditor do
         end
       end
 
-      {:ok, Map.put(update, "content", %{"model" => Enum.map(content, convert)})}
+      {:ok, put_in(update, ["content", "model"], Enum.map(content, convert))}
     else
       {:error, :not_found}
     end

--- a/lib/oli/delivery/attempts.ex
+++ b/lib/oli/delivery/attempts.ex
@@ -626,6 +626,8 @@ defmodule Oli.Delivery.Attempts do
       # on activity attempt records is preloaded.
 
       {:ok, {Map.put(activity_attempt, :revision, revision), part_attempts}}
+    else
+      e -> IO.inspect(e)
     end
   end
 

--- a/lib/oli/delivery/extrinsic_state.ex
+++ b/lib/oli/delivery/extrinsic_state.ex
@@ -1,0 +1,74 @@
+defmodule Oli.Delivery.ExtrinsicState do
+  import Ecto.Query, warn: false
+
+  alias Oli.Accounts
+
+  def read_section(user_id, section_slug, keys \\ nil) do
+    {:ok, %{}}
+  end
+
+  def read_global(user_id, keys \\ nil) do
+    case Accounts.get_user_by(sub: user_id) do
+      nil -> {:error, {:not_found}}
+      user -> {:ok, filter_keys(user.state, keys)}
+    end
+  end
+
+  def upsert_section(user_id, section_slug, key_values) do
+    {:ok, %{}}
+  end
+
+  def upsert_global(user_id, key_values) do
+    case Accounts.get_user_by(sub: user_id) do
+      nil ->
+        {:error, {:not_found}}
+
+      user ->
+        case Accounts.update_user(user, %{state: Map.merge(user.state, key_values)}) do
+          {:ok, u} -> {:ok, u.state}
+          e -> e
+        end
+    end
+  end
+
+  def delete_global(user_id, keys) do
+    case Accounts.get_user_by(sub: user_id) do
+      nil ->
+        {:error, {:not_found}}
+
+      user ->
+        case Accounts.update_user(user, %{state: delete_keys(user.state, keys)}) do
+          {:ok, u} -> {:ok, u.state}
+          e -> e
+        end
+    end
+  end
+
+  def delete_section(_user_id, _keys, _section_slug) do
+    {:ok, %{}}
+  end
+
+  defp filter_keys(state, nil), do: state
+
+  defp filter_keys(state, keys) do
+    Map.keys(state)
+    |> Enum.reduce(%{}, fn k, m ->
+      if MapSet.member?(keys, k) do
+        Map.put(m, k, Map.get(state, k))
+      else
+        m
+      end
+    end)
+  end
+
+  defp delete_keys(state, keys) do
+    Map.keys(state)
+    |> Enum.reduce(%{}, fn k, m ->
+      if MapSet.member?(keys, k) do
+        m
+      else
+        Map.put(m, k, Map.get(state, k))
+      end
+    end)
+  end
+end

--- a/lib/oli/delivery/extrinsic_state.ex
+++ b/lib/oli/delivery/extrinsic_state.ex
@@ -1,4 +1,15 @@
 defmodule Oli.Delivery.ExtrinsicState do
+  @moduledoc """
+  Enables arbitrary key-value pair storage that is extrinsic to any specific activity attempt.
+
+  Extrinsic state exists either truly global for a user, or scoped to a course section for
+  a user. Leveraging this, activities can be built that share state across pages in a course, and
+  across courses.
+
+  The fundamental operations on extrinsic state are read, upsert, and deletion.  Each operation
+  works on a collection of keys (or key value pairs).
+  """
+
   import Ecto.Query, warn: false
 
   alias Oli.Accounts
@@ -6,29 +17,49 @@ defmodule Oli.Delivery.ExtrinsicState do
 
   alias Phoenix.PubSub
 
-  def read_section(user_sub, section_slug, keys \\ nil) do
-    case Sections.get_enrollment(section_slug, user_sub) do
+  @doc """
+  Reads extrinsic state for a user for a specific section.  Returns {:ok, map} of the keys and their
+  values.
+
+  The optional `keys` parameter is a MapSet of the string key names to retrieve. If this
+  argument is not specified then all keys are returned, otherwise the return value is a map of
+  key value pairs filtered to this MapSet.
+  """
+  def read_section(user_id, section_slug, keys \\ nil) do
+    case Sections.get_enrollment(section_slug, user_id) do
       nil -> {:error, {:not_found}}
       e -> {:ok, filter_keys(e.state, keys)}
     end
   end
 
-  def read_global(user_sub, keys \\ nil) do
-    case Accounts.get_user_by(sub: user_sub) do
+  @doc """
+  Reads extrinsic state for a user from the global context.  Returns {:ok, map} of the keys and their
+  values.
+
+  The optional `keys` parameter is a MapSet of the string key names to retrieve. If this
+  argument is not specified then all keys are returned, otherwise the return value is a map of
+  key value pairs filtered to this MapSet.
+  """
+  def read_global(user_id, keys \\ nil) do
+    case Accounts.get_user_by(id: user_id) do
       nil -> {:error, {:not_found}}
       user -> {:ok, filter_keys(user.state, keys)}
     end
   end
 
-  def upsert_section(user_sub, section_slug, key_values) do
-    case Sections.get_enrollment(section_slug, user_sub) do
+  @doc """
+  Updates or inserts key value pairs into the extrinsic state for a user for a particular section.
+  Returns {:ok, map} of the new updated state.
+  """
+  def upsert_section(user_id, section_slug, key_values) do
+    case Sections.get_enrollment(section_slug, user_id) do
       nil ->
         {:error, {:not_found}}
 
       e ->
         case Sections.update_enrollment(e, %{state: Map.merge(e.state, key_values)}) do
           {:ok, u} ->
-            notify_section(user_sub, section_slug, :delta, key_values)
+            notify_section(user_id, section_slug, :delta, key_values)
             {:ok, u.state}
 
           e ->
@@ -37,15 +68,19 @@ defmodule Oli.Delivery.ExtrinsicState do
     end
   end
 
-  def upsert_global(user_sub, key_values) do
-    case Accounts.get_user_by(sub: user_sub) do
+  @doc """
+  Updates or inserts key value pairs into the extrinsic state for a user for the global context.
+  Returns {:ok, map} of the new updated state.
+  """
+  def upsert_global(user_id, key_values) do
+    case Accounts.get_user_by(id: user_id) do
       nil ->
         {:error, {:not_found}}
 
       user ->
         case Accounts.update_user(user, %{state: Map.merge(user.state, key_values)}) do
           {:ok, u} ->
-            notify_global(user_sub, :delta, key_values)
+            notify_global(user_id, :delta, key_values)
             {:ok, u.state}
 
           e ->
@@ -54,15 +89,21 @@ defmodule Oli.Delivery.ExtrinsicState do
     end
   end
 
-  def delete_global(user_sub, keys) do
-    case Accounts.get_user_by(sub: user_sub) do
+  @doc """
+  Deletes one or more keys from the extrinsic state for a user for the global context. The
+  keys are specified as a MapSet of string key names.
+
+  Returns {:ok, map} of the new updated state.
+  """
+  def delete_global(user_id, keys) do
+    case Accounts.get_user_by(id: user_id) do
       nil ->
         {:error, {:not_found}}
 
       user ->
         case Accounts.update_user(user, %{state: delete_keys(user.state, keys)}) do
           {:ok, u} ->
-            notify_global(user_sub, :deletion, keys)
+            notify_global(user_id, :deletion, keys)
             {:ok, u.state}
 
           e ->
@@ -71,15 +112,21 @@ defmodule Oli.Delivery.ExtrinsicState do
     end
   end
 
-  def delete_section(user_sub, section_slug, keys) do
-    case Sections.get_enrollment(section_slug, user_sub) do
+  @doc """
+  Deletes one or more keys from the extrinsic state for a user for a particular section. The
+  keys are specified as a MapSet of string key names.
+
+  Returns {:ok, map} of the new updated state.
+  """
+  def delete_section(user_id, section_slug, keys) do
+    case Sections.get_enrollment(section_slug, user_id) do
       nil ->
         {:error, {:not_found}}
 
       e ->
-        case Sections.update_enrollment(e, %{state: delete_keys(user.state, keys)}) do
+        case Sections.update_enrollment(e, %{state: delete_keys(e.state, keys)}) do
           {:ok, u} ->
-            notify_section(user_sub, section_slug, :delta, key_values)
+            notify_section(user_id, section_slug, :deletion, keys)
             {:ok, u.state}
 
           e ->
@@ -112,18 +159,18 @@ defmodule Oli.Delivery.ExtrinsicState do
     end)
   end
 
-  defp notify_global(user_sub, action, payload) do
+  defp notify_global(user_id, action, payload) do
     PubSub.broadcast(
       Oli.PubSub,
-      "global:" <> user_sub,
+      "global:" <> Integer.to_string(user_id),
       {action, payload}
     )
   end
 
-  defp notify_section(user_sub, section_slug, action, payload) do
+  defp notify_section(user_id, section_slug, action, payload) do
     PubSub.broadcast(
       Oli.PubSub,
-      "section:" <> section_slug <> ":" <> user_sub,
+      "section:" <> section_slug <> ":" <> Integer.to_string(user_id),
       {action, payload}
     )
   end

--- a/lib/oli/delivery/extrinsic_state.ex
+++ b/lib/oli/delivery/extrinsic_state.ex
@@ -2,33 +2,33 @@ defmodule Oli.Delivery.ExtrinsicState do
   import Ecto.Query, warn: false
 
   alias Oli.Accounts
+  alias Oli.Delivery.Sections
 
   alias Phoenix.PubSub
 
-  def read_section(user_id, section_slug, keys \\ nil) do
-    {:ok, %{}}
+  def read_section(user_sub, section_slug, keys \\ nil) do
+    case Sections.get_enrollment(section_slug, user_sub) do
+      nil -> {:error, {:not_found}}
+      e -> {:ok, filter_keys(e.state, keys)}
+    end
   end
 
-  def read_global(user_id, keys \\ nil) do
-    case Accounts.get_user_by(sub: user_id) do
+  def read_global(user_sub, keys \\ nil) do
+    case Accounts.get_user_by(sub: user_sub) do
       nil -> {:error, {:not_found}}
       user -> {:ok, filter_keys(user.state, keys)}
     end
   end
 
-  def upsert_section(user_id, section_slug, key_values) do
-    {:ok, %{}}
-  end
-
-  def upsert_global(user_id, key_values) do
-    case Accounts.get_user_by(sub: user_id) do
+  def upsert_section(user_sub, section_slug, key_values) do
+    case Sections.get_enrollment(section_slug, user_sub) do
       nil ->
         {:error, {:not_found}}
 
-      user ->
-        case Accounts.update_user(user, %{state: Map.merge(user.state, key_values)}) do
+      e ->
+        case Sections.update_enrollment(e, %{state: Map.merge(e.state, key_values)}) do
           {:ok, u} ->
-            notify_global(user_id, u.state, key_values)
+            notify_section(user_sub, section_slug, :delta, key_values)
             {:ok, u.state}
 
           e ->
@@ -37,21 +37,55 @@ defmodule Oli.Delivery.ExtrinsicState do
     end
   end
 
-  def delete_global(user_id, keys) do
-    case Accounts.get_user_by(sub: user_id) do
+  def upsert_global(user_sub, key_values) do
+    case Accounts.get_user_by(sub: user_sub) do
+      nil ->
+        {:error, {:not_found}}
+
+      user ->
+        case Accounts.update_user(user, %{state: Map.merge(user.state, key_values)}) do
+          {:ok, u} ->
+            notify_global(user_sub, :delta, key_values)
+            {:ok, u.state}
+
+          e ->
+            e
+        end
+    end
+  end
+
+  def delete_global(user_sub, keys) do
+    case Accounts.get_user_by(sub: user_sub) do
       nil ->
         {:error, {:not_found}}
 
       user ->
         case Accounts.update_user(user, %{state: delete_keys(user.state, keys)}) do
-          {:ok, u} -> {:ok, u.state}
-          e -> e
+          {:ok, u} ->
+            notify_global(user_sub, :deletion, keys)
+            {:ok, u.state}
+
+          e ->
+            e
         end
     end
   end
 
-  def delete_section(_user_id, _keys, _section_slug) do
-    {:ok, %{}}
+  def delete_section(user_sub, section_slug, keys) do
+    case Sections.get_enrollment(section_slug, user_sub) do
+      nil ->
+        {:error, {:not_found}}
+
+      e ->
+        case Sections.update_enrollment(e, %{state: delete_keys(user.state, keys)}) do
+          {:ok, u} ->
+            notify_section(user_sub, section_slug, :delta, key_values)
+            {:ok, u.state}
+
+          e ->
+            e
+        end
+    end
   end
 
   defp filter_keys(state, nil), do: state
@@ -78,11 +112,19 @@ defmodule Oli.Delivery.ExtrinsicState do
     end)
   end
 
-  defp notify_global(user_id, state, delta) do
+  defp notify_global(user_sub, action, payload) do
     PubSub.broadcast(
       Oli.PubSub,
-      "global:" <> user_id,
-      {:delta, delta}
+      "global:" <> user_sub,
+      {action, payload}
+    )
+  end
+
+  defp notify_section(user_sub, section_slug, action, payload) do
+    PubSub.broadcast(
+      Oli.PubSub,
+      "section:" <> section_slug <> ":" <> user_sub,
+      {action, payload}
     )
   end
 end

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -79,6 +79,27 @@ defmodule Oli.Delivery.Sections do
     Repo.all(query)
   end
 
+  def get_enrollment(section_slug, user_sub) do
+    query =
+      from(
+        e in Enrollment,
+        join: s in Section,
+        on: e.section_id == s.id,
+        join: u in User,
+        on: e.user_id == u.id,
+        where: u.sub == ^user_sub and s.slug == ^section_slug,
+        select: e
+      )
+
+    Repo.one(query)
+  end
+
+  def update_enrollment(%Enrollment{} = e, attrs) do
+    e
+    |> Enrollment.changeset(attrs)
+    |> Repo.update()
+  end
+
   @doc """
   Returns a listing of all open and free sections for a given user.
   """

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -79,15 +79,13 @@ defmodule Oli.Delivery.Sections do
     Repo.all(query)
   end
 
-  def get_enrollment(section_slug, user_sub) do
+  def get_enrollment(section_slug, user_id) do
     query =
       from(
         e in Enrollment,
         join: s in Section,
         on: e.section_id == s.id,
-        join: u in User,
-        on: e.user_id == u.id,
-        where: u.sub == ^user_sub and s.slug == ^section_slug,
+        where: e.user_id == ^user_id and s.slug == ^section_slug,
         select: e
       )
 

--- a/lib/oli/delivery/sections/enrollment.ex
+++ b/lib/oli/delivery/sections/enrollment.ex
@@ -5,7 +5,7 @@ defmodule Oli.Delivery.Sections.Enrollment do
   schema "enrollments" do
     belongs_to :user, Oli.Accounts.User
     belongs_to :section, Oli.Delivery.Sections.Section
-    field :state, :map
+    field :state, :map, default: %{}
 
     many_to_many :context_roles, Lti_1p3.DataProviders.EctoProvider.ContextRole,
       join_through: "enrollments_context_roles",

--- a/lib/oli/delivery/sections/enrollment.ex
+++ b/lib/oli/delivery/sections/enrollment.ex
@@ -5,6 +5,7 @@ defmodule Oli.Delivery.Sections.Enrollment do
   schema "enrollments" do
     belongs_to :user, Oli.Accounts.User
     belongs_to :section, Oli.Delivery.Sections.Section
+    field :state, :map
 
     many_to_many :context_roles, Lti_1p3.DataProviders.EctoProvider.ContextRole,
       join_through: "enrollments_context_roles",
@@ -16,7 +17,7 @@ defmodule Oli.Delivery.Sections.Enrollment do
   @doc false
   def changeset(section, attrs) do
     section
-    |> cast(attrs, [:user_id, :section_id])
+    |> cast(attrs, [:user_id, :section_id, :state])
     |> validate_required([:user_id, :section_id])
   end
 end

--- a/lib/oli/rendering/activity/html.ex
+++ b/lib/oli/rendering/activity/html.ex
@@ -14,7 +14,8 @@ defmodule Oli.Rendering.Activity.Html do
           activity_map: activity_map,
           render_opts: render_opts,
           preview: preview,
-          progress_state: progress_state
+          progress_state: progress_state,
+          user: user
         } = context,
         %{"activity_id" => activity_id, "purpose" => purpose} = activity
       ) do
@@ -49,7 +50,7 @@ defmodule Oli.Rendering.Activity.Html do
         activity_html = [
           "<#{tag} class=\"activity-container\" graded=\"#{graded}\" state=\"#{state}\" model=\"#{
             model_json
-          }\" preview=\"#{preview}\" progress_state=\"#{progress_state}\" section_slug=\"#{
+          }\" preview=\"#{preview}\" user_id=\"#{user.sub}\" progress_state=\"#{progress_state}\" section_slug=\"#{
             section_slug
           }\"></#{tag}>\n"
         ]

--- a/lib/oli/rendering/activity/html.ex
+++ b/lib/oli/rendering/activity/html.ex
@@ -50,7 +50,7 @@ defmodule Oli.Rendering.Activity.Html do
         activity_html = [
           "<#{tag} class=\"activity-container\" graded=\"#{graded}\" state=\"#{state}\" model=\"#{
             model_json
-          }\" preview=\"#{preview}\" user_id=\"#{user.sub}\" progress_state=\"#{progress_state}\" section_slug=\"#{
+          }\" preview=\"#{preview}\" user_id=\"#{user.id}\" progress_state=\"#{progress_state}\" section_slug=\"#{
             section_slug
           }\"></#{tag}>\n"
         ]

--- a/lib/oli_web/channels/section_user_state_channel.ex
+++ b/lib/oli_web/channels/section_user_state_channel.ex
@@ -1,0 +1,42 @@
+defmodule OliWeb.SectionUserStateChannel do
+  use Phoenix.Channel
+
+  alias Oli.Delivery.ExtrinsicState
+  alias Phoenix.PubSub
+
+  def join("user_section_state:" <> section_user, _, socket) do
+    case String.split(section_user, ":") do
+      [section_slug, user_id] ->
+        send(self(), {:after_join, {section_slug, Integer.parse(user_id)}})
+        {:ok, socket}
+
+      _ ->
+        {:error, %{reason: "unauthorized"}}
+    end
+  end
+
+  def join(_, _params, _socket) do
+    {:error, %{reason: "unauthorized"}}
+  end
+
+  def handle_info({:delta, msg}, socket) do
+    push(socket, "delta", msg)
+    {:noreply, socket}
+  end
+
+  def handle_info({:deletion, msg}, socket) do
+    push(socket, "deletion", msg)
+    {:noreply, socket}
+  end
+
+  def handle_info({:after_join, {section_slug, user_id}}, socket) do
+    # Do an initial full read and push to the socket
+    {:ok, state} = ExtrinsicState.read_section(user_id, section_slug)
+    push(socket, "state", state)
+
+    # But after that, only send delta based updates
+    PubSub.subscribe(Oli.PubSub, "user_section_state:" <> section_slug <> ":" <> user_id)
+
+    {:noreply, socket}
+  end
+end

--- a/lib/oli_web/channels/user_socket.ex
+++ b/lib/oli_web/channels/user_socket.ex
@@ -4,6 +4,8 @@ defmodule OliWeb.UserSocket do
   ## Channels
   # channel "room:*", OliWeb.RoomChannel
 
+  channel "global:*", OliWeb.GlobalUserStateChannel
+
   # Socket params are passed from the client and can
   # be used to verify and authenticate a user. After
   # verification, you can put default assigns into
@@ -15,8 +17,15 @@ defmodule OliWeb.UserSocket do
   #
   # See `Phoenix.Token` documentation for examples in
   # performing token verification on connect.
-  def connect(_params, socket, _connect_info) do
-    {:ok, socket}
+  def connect(%{"token" => token}, socket, _connect_info) do
+    # max_age: 1209600 is equivalent to two weeks in seconds
+    case Phoenix.Token.verify(socket, "user socket", token, max_age: 1_209_600) do
+      {:ok, user_id} ->
+        {:ok, assign(socket, :user, user_id)}
+
+      {:error, reason} ->
+        :error
+    end
   end
 
   # Socket id's are topics that allow you to identify all sockets for a given user:

--- a/lib/oli_web/channels/user_socket.ex
+++ b/lib/oli_web/channels/user_socket.ex
@@ -23,7 +23,7 @@ defmodule OliWeb.UserSocket do
       {:ok, user_id} ->
         {:ok, assign(socket, :user, user_id)}
 
-      {:error, reason} ->
+      {:error, _} ->
         :error
     end
   end

--- a/lib/oli_web/channels/user_socket.ex
+++ b/lib/oli_web/channels/user_socket.ex
@@ -4,7 +4,8 @@ defmodule OliWeb.UserSocket do
   ## Channels
   # channel "room:*", OliWeb.RoomChannel
 
-  channel "global:*", OliWeb.GlobalUserStateChannel
+  channel "user_global_state:*", OliWeb.GlobalUserStateChannel
+  channel "user_section_state:*", OliWeb.SectionUserStateChannel
 
   # Socket params are passed from the client and can
   # be used to verify and authenticate a user. After

--- a/lib/oli_web/controllers/extrinsic_state_controller.ex
+++ b/lib/oli_web/controllers/extrinsic_state_controller.ex
@@ -1,0 +1,71 @@
+defmodule OliWeb.ExtrinsicStateController do
+  @moduledoc """
+  Provides user state service endpoints for extrinsic state.
+  """
+  use OliWeb, :controller
+
+  alias Oli.Delivery.ExtrinsicState
+
+  def read_global(conn, params) do
+    user = conn.assigns.current_user
+
+    keys =
+      case Map.get(params, "keys") do
+        nil -> nil
+        k -> MapSet.new(k)
+      end
+
+    case ExtrinsicState.read_global(user.sub, keys) do
+      {:ok, state} ->
+        json(conn, state)
+
+      _ ->
+        error(conn, 404, "not found")
+    end
+  end
+
+  def upsert_global(conn, %{"key_values" => key_values}) do
+    user = conn.assigns.current_user
+
+    case ExtrinsicState.upsert_global(user.sub, key_values) do
+      {:ok, _} ->
+        json(conn, %{"result" => "success"})
+
+      _ ->
+        error(conn, 404, "not found")
+    end
+  end
+
+  def delete_global(conn, params) do
+    user = conn.assigns.current_user
+
+    case Map.get(params, "keys") do
+      nil ->
+        error(conn, 400, "missing keyspec")
+
+      k ->
+        case ExtrinsicState.delete_global(user.sub, MapSet.new(k)) do
+          {:ok, _} ->
+            json(conn, %{"result" => "success"})
+
+          _ ->
+            error(conn, 404, "not found")
+        end
+    end
+  end
+
+  def read_section(conn, _params) do
+  end
+
+  def upsert_section(conn, _params) do
+  end
+
+  def delete_section(conn, _params) do
+  end
+
+  defp error(conn, code, reason) do
+    conn
+    |> send_resp(code, reason)
+    |> halt()
+  end
+end

--- a/lib/oli_web/controllers/extrinsic_state_controller.ex
+++ b/lib/oli_web/controllers/extrinsic_state_controller.ex
@@ -15,7 +15,7 @@ defmodule OliWeb.ExtrinsicStateController do
         k -> MapSet.new(k)
       end
 
-    case ExtrinsicState.read_global(user.sub, keys) do
+    case ExtrinsicState.read_global(user.id, keys) do
       {:ok, state} ->
         json(conn, state)
 
@@ -27,7 +27,7 @@ defmodule OliWeb.ExtrinsicStateController do
   def upsert_global(conn, key_values) do
     user = conn.assigns.current_user
 
-    case ExtrinsicState.upsert_global(user.sub, key_values) do
+    case ExtrinsicState.upsert_global(user.id, key_values) do
       {:ok, _} ->
         json(conn, %{"result" => "success"})
 
@@ -44,7 +44,7 @@ defmodule OliWeb.ExtrinsicStateController do
         error(conn, 400, "missing keyspec")
 
       k ->
-        case ExtrinsicState.delete_global(user.sub, MapSet.new(k)) do
+        case ExtrinsicState.delete_global(user.id, MapSet.new(k)) do
           {:ok, _} ->
             json(conn, %{"result" => "success"})
 
@@ -54,13 +54,52 @@ defmodule OliWeb.ExtrinsicStateController do
     end
   end
 
-  def read_section(conn, _params) do
+  def read_section(conn, %{"section_slug" => section_slug} = params) do
+    user = conn.assigns.current_user
+
+    keys =
+      case Map.get(params, "keys") do
+        nil -> nil
+        k -> MapSet.new(k)
+      end
+
+    case ExtrinsicState.read_section(user.id, section_slug, keys) do
+      {:ok, state} ->
+        json(conn, state)
+
+      _ ->
+        error(conn, 404, "not found")
+    end
   end
 
-  def upsert_section(conn, _params) do
+  def upsert_section(%Plug.Conn{body_params: key_values} = conn, %{"section_slug" => section_slug}) do
+    user = conn.assigns.current_user
+
+    case ExtrinsicState.upsert_section(user.id, section_slug, key_values) do
+      {:ok, _} ->
+        json(conn, %{"result" => "success"})
+
+      _ ->
+        error(conn, 404, "not found")
+    end
   end
 
-  def delete_section(conn, _params) do
+  def delete_section(conn, %{"section_slug" => section_slug} = params) do
+    user = conn.assigns.current_user
+
+    case Map.get(params, "keys") do
+      nil ->
+        error(conn, 400, "missing keyspec")
+
+      k ->
+        case ExtrinsicState.delete_section(user.id, section_slug, MapSet.new(k)) do
+          {:ok, _} ->
+            json(conn, %{"result" => "success"})
+
+          _ ->
+            error(conn, 404, "not found")
+        end
+    end
   end
 
   defp error(conn, code, reason) do

--- a/lib/oli_web/controllers/extrinsic_state_controller.ex
+++ b/lib/oli_web/controllers/extrinsic_state_controller.ex
@@ -24,7 +24,7 @@ defmodule OliWeb.ExtrinsicStateController do
     end
   end
 
-  def upsert_global(conn, %{"key_values" => key_values}) do
+  def upsert_global(conn, key_values) do
     user = conn.assigns.current_user
 
     case ExtrinsicState.upsert_global(user.sub, key_values) do

--- a/lib/oli_web/endpoint.ex
+++ b/lib/oli_web/endpoint.ex
@@ -9,7 +9,7 @@ defmodule OliWeb.Endpoint do
     secure: true
   ]
 
-  socket "/socket", OliWeb.UserSocket,
+  socket "/v1/api/state", OliWeb.UserSocket,
     websocket: true,
     longpoll: false
 

--- a/lib/oli_web/global_user_state_channel.ex
+++ b/lib/oli_web/global_user_state_channel.ex
@@ -1,0 +1,31 @@
+defmodule OliWeb.GlobalUserStateChannel do
+  use Phoenix.Channel
+
+  alias Oli.Delivery.ExtrinsicState
+  alias Phoenix.PubSub
+
+  def join("global:" <> user_id, _, socket) do
+    send(self(), {:after_join, user_id})
+    {:ok, socket}
+  end
+
+  def join(_, _params, _socket) do
+    {:error, %{reason: "unauthorized"}}
+  end
+
+  def handle_info({:delta, msg}, socket) do
+    push(socket, "delta", msg)
+    {:noreply, socket}
+  end
+
+  def handle_info({:after_join, user_id}, socket) do
+    # Do an initial full read and push to the socket
+    {:ok, state} = ExtrinsicState.read_global(user_id)
+    push(socket, "state", state)
+
+    # But after that, only send delta based updates
+    PubSub.subscribe(Oli.PubSub, "global:" <> user_id)
+
+    {:noreply, socket}
+  end
+end

--- a/lib/oli_web/plugs/set_user.ex
+++ b/lib/oli_web/plugs/set_user.ex
@@ -12,6 +12,7 @@ defmodule Oli.Plugs.SetCurrentUser do
     conn
     |> set_author
     |> set_user
+    |> set_user_token
   end
 
   def set_author(conn) do
@@ -43,6 +44,17 @@ defmodule Oli.Plugs.SetCurrentUser do
       end
     else
       conn
+    end
+  end
+
+  defp set_user_token(conn) do
+    case conn.assigns[:current_user] do
+      nil ->
+        conn
+
+      user ->
+        token = Phoenix.Token.sign(conn, "user socket", user.sub)
+        assign(conn, :user_token, token)
     end
   end
 end

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -348,6 +348,18 @@ defmodule OliWeb.Router do
     put "/activity/:activity_attempt_guid/evaluations", AttemptController, :submit_evaluations
   end
 
+  scope "/api/v1/state", OliWeb do
+    pipe_through [:api, :delivery_protected]
+
+    get "/", ExtrinsicStateController, :read_global
+    put "/", ExtrinsicStateController, :upsert_global
+    delete "/", ExtrinsicStateController, :delete_global
+
+    get "/course/:section_slug", ExtrinsicStateController, :read_section
+    put "/course/:section_slug", ExtrinsicStateController, :upsert_section
+    delete "/course/:section_slug", ExtrinsicStateController, :delete_section
+  end
+
   scope "/api/v1/lti", OliWeb, as: :api do
     pipe_through [:api, :authoring_protected]
 
@@ -423,7 +435,7 @@ defmodule OliWeb.Router do
     post "/link_account", DeliveryController, :process_link_account_user
     get "/create_and_link_account", DeliveryController, :create_and_link_account
     post "/create_and_link_account", DeliveryController, :process_create_and_link_account_user
-    post "/research_consent",  DeliveryController, :research_consent
+    post "/research_consent", DeliveryController, :research_consent
 
     post "/", DeliveryController, :create_section
   end

--- a/lib/oli_web/templates/page_delivery/delivery.html.eex
+++ b/lib/oli_web/templates/page_delivery/delivery.html.eex
@@ -1,11 +1,13 @@
 
 <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/delivery.js") %>"></script>
 
+
 <h1><%= @title %></h1>
 
 <div id="delivery_container" class="container"/>
 
 <script>
+  window.userToken = "<%= assigns[:user_token] %>";
 
   const params = {
     resourceId: <%= @resource_id %>,

--- a/lib/oli_web/templates/page_delivery/page.html.eex
+++ b/lib/oli_web/templates/page_delivery/page.html.eex
@@ -3,6 +3,10 @@
  (Review)
 <% end %></h1>
 
+<script>
+window.userToken = "<%= assigns[:user_token] %>";
+</script>
+
 <%= render "_objectives.html", objectives: @objectives %>
 
 <%= if @progress_state == :in_review do %>

--- a/priv/repo/migrations/20210408234517_user_state.exs
+++ b/priv/repo/migrations/20210408234517_user_state.exs
@@ -1,0 +1,13 @@
+defmodule Oli.Repo.Migrations.UserState do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :state, :map
+    end
+
+    alter table(:enrollments) do
+      add :state, :map
+    end
+  end
+end

--- a/test/oli_web/controllers/extrinsic_state_controller_test.exs
+++ b/test/oli_web/controllers/extrinsic_state_controller_test.exs
@@ -1,0 +1,162 @@
+defmodule OliWeb.ExtrinsicStateControllerTest do
+  use OliWeb.ConnCase
+
+  alias Oli.Delivery.Sections
+  alias Oli.Seeder
+  alias Lti_1p3.Tool.ContextRoles
+
+  defp again(conn, user) do
+    recycle(conn)
+    |> Pow.Plug.assign_current_user(
+      user,
+      OliWeb.Pow.PowHelpers.get_pow_config(:user)
+    )
+  end
+
+  describe "global extrinsic endpoints" do
+    setup [:setup_session]
+
+    test "can read and update", %{
+      conn: conn,
+      section: section,
+      user: user
+    } do
+      {:ok, _enrollment} =
+        Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+
+      conn = get(conn, Routes.extrinsic_state_path(conn, :read_global))
+
+      assert keys = json_response(conn, 200)
+      assert length(Map.keys(keys)) == 0
+
+      conn = again(conn, user)
+
+      conn =
+        put(conn, Routes.extrinsic_state_path(conn, :upsert_global), %{"one" => "1", "two" => 2})
+
+      assert _ = json_response(conn, 200)
+
+      conn = again(conn, user)
+      conn = get(conn, Routes.extrinsic_state_path(conn, :read_global))
+
+      assert keys = json_response(conn, 200)
+      assert length(Map.keys(keys)) == 2
+
+      assert Map.get(keys, "one") == "1"
+      assert Map.get(keys, "two") == 2
+
+      conn = again(conn, user)
+      conn = delete(conn, Routes.extrinsic_state_path(conn, :delete_global) <> "?keys[]=two")
+
+      assert _ = json_response(conn, 200)
+
+      conn = again(conn, user)
+      conn = get(conn, Routes.extrinsic_state_path(conn, :read_global))
+
+      assert keys = json_response(conn, 200)
+      assert length(Map.keys(keys)) == 1
+
+      assert Map.get(keys, "one") == "1"
+      assert Map.get(keys, "two") == nil
+    end
+  end
+
+  describe "section extrinsic endpoints" do
+    setup [:setup_session]
+
+    test "can read and update", %{
+      conn: conn,
+      section: section,
+      user: user
+    } do
+      {:ok, _enrollment} =
+        Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+
+      conn = get(conn, Routes.extrinsic_state_path(conn, :read_section, section.slug))
+
+      assert keys = json_response(conn, 200)
+      assert length(Map.keys(keys)) == 0
+
+      conn = again(conn, user)
+
+      conn =
+        put(
+          conn,
+          Routes.extrinsic_state_path(conn, :upsert_section, section.slug),
+          %{
+            "one" => "1",
+            "two" => 2
+          }
+        )
+
+      assert _ = json_response(conn, 200)
+
+      conn = again(conn, user)
+
+      conn = get(conn, Routes.extrinsic_state_path(conn, :read_section, section.slug))
+
+      assert keys = json_response(conn, 200)
+      assert length(Map.keys(keys)) == 2
+
+      assert Map.get(keys, "one") == "1"
+      assert Map.get(keys, "two") == 2
+
+      conn = again(conn, user)
+
+      conn =
+        delete(
+          conn,
+          Routes.extrinsic_state_path(conn, :delete_section, section.slug) <> "?keys[]=two"
+        )
+
+      assert _ = json_response(conn, 200)
+
+      conn = again(conn, user)
+      conn = get(conn, Routes.extrinsic_state_path(conn, :read_section, section.slug))
+
+      assert keys = json_response(conn, 200)
+      assert length(Map.keys(keys)) == 1
+
+      assert Map.get(keys, "one") == "1"
+      assert Map.get(keys, "two") == nil
+    end
+  end
+
+  defp setup_session(%{conn: conn}) do
+    user = user_fixture()
+    user2 = user_fixture()
+
+    map = Seeder.base_project_with_resource2()
+
+    section =
+      section_fixture(%{
+        context_id: "some-context-id",
+        project_id: map.project.id,
+        publication_id: map.publication.id,
+        institution_id: map.institution.id,
+        open_and_free: false
+      })
+
+    lti_params =
+      Oli.Lti_1p3.TestHelpers.all_default_claims()
+      |> put_in(["https://purl.imsglobal.org/spec/lti/claim/context", "id"], section.slug)
+
+    cache_lti_params("params-key", lti_params)
+
+    conn =
+      Plug.Test.init_test_session(conn, lti_session: nil)
+      |> Pow.Plug.assign_current_user(map.author, OliWeb.Pow.PowHelpers.get_pow_config(:author))
+      |> Pow.Plug.assign_current_user(user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
+
+    {:ok,
+     conn: conn,
+     map: map,
+     author: map.author,
+     institution: map.institution,
+     user: user,
+     user2: user2,
+     project: map.project,
+     publication: map.publication,
+     section: section}
+  end
+end


### PR DESCRIPTION
This is part 1 of work towards realizing the full set of user state changes in #641 

This PR adds support for the global and section-level "extrinsic state" endpoints.  These endpoints are accessible from `/api/v1/state` and `/api/v1/state/course/:section_slug` URLs, respectively, and allow an activity to read-write arbitrary key-value pairs from state tied to those contexts.  

In addition to basic CRUD operations, there is support for WebSocket based subscription to the state. This is currently implemented in a way that fires on every top-level key change.  We may want to adjust this in the future to have it be tied to a specific top-level key in a state context. 

To test this out interactively, create an instance of an Adaptive Activity in a regular page and use the temporary UIs there to exercise these endpoints. 

The next part of work here is to change the URL endpoints of the rest of the user state endpoints, and add OpenAPI docs to all of them (including these new extrinsic state endpoints). 

