### PR TITLE
remove duplicate cookie script

### DIFF
--- a/lib/oli_web/templates/layout/_header.html.eex
+++ b/lib/oli_web/templates/layout/_header.html.eex
@@ -1,5 +1,3 @@
-<%= render OliWeb.SharedView, "_cookie_consent.html" %>
-
 <nav class="navbar navbar-expand">
   <div class="container">
     <a class="navbar-brand oli-logo mr-auto" href="<%= Routes.static_page_path(@conn, :index) %>">


### PR DESCRIPTION
PR to remove duplicate cookie consent script. Was in both the header and footer. Removed one from header

Closes #929