### PR TITLE
Rewire links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+  - Support page-to-page links during course ingestion
+
 ## 0.8.0 (2021-4-12)
 
 ### Enhancements

--- a/lib/oli/interop/ingest.ex
+++ b/lib/oli/interop/ingest.ex
@@ -58,7 +58,8 @@ defmodule Oli.Interop.Ingest do
                create_pages(project, resource_map, activity_map, objective_map, as_author),
              {:ok, _} <- create_media(project, media_details),
              {:ok, _} <-
-               create_hierarchy(project, root_revision, page_map, hierarchy_details, as_author) do
+               create_hierarchy(project, root_revision, page_map, hierarchy_details, as_author),
+             {:ok, _} <- rewire_all_hyperlinks(page_map, project) do
           project
         else
           error -> Repo.rollback(error)
@@ -121,6 +122,73 @@ defmodule Oli.Interop.Ingest do
         map -> map
       end
     end)
+  end
+
+  # Any internal hyperlinks have to be rewired to point to the new resource_id of the
+  # page being linked to.  This function takes all pages and activities and rewires
+  # all links that it finds in their contents, only saving new revisions for those that
+  # have a rewired link.
+  defp rewire_all_hyperlinks(page_map, project) do
+    Map.values(page_map)
+    |> Enum.map(fn revision ->
+      rewire_hyperlinks(revision, page_map, project.slug)
+    end)
+
+    {:ok, page_map}
+  end
+
+  defp rewire_hyperlinks(revision, page_map, course) do
+    link_builder = fn id ->
+      case Map.get(page_map, id) do
+        nil -> "/course/link/#{course}"
+        %{slug: slug} -> "/course/link/#{slug}"
+      end
+    end
+
+    case rewire(revision.content, link_builder) do
+      {true, content} ->
+        ChangeTracker.track_revision(course, revision, %{content: content})
+
+      {false, _} ->
+        {:ok, revision}
+    end
+  end
+
+  defp rewire(items, link_builder) when is_list(items) do
+    results = Enum.map(items, fn i -> rewire(i, link_builder) end)
+
+    children = Enum.map(results, fn {_, c} -> c end)
+
+    changed =
+      Enum.map(results, fn {changed, _} -> changed end) |> Enum.any?(fn c -> c == true end)
+
+    {changed, children}
+  end
+
+  defp rewire(%{"type" => "a", "idref" => idref}, link_builder) do
+    {true, %{"type" => "a", "href" => link_builder.(idref)}}
+  end
+
+  defp rewire(%{"model" => model} = item, link_builder) do
+    case rewire(model, link_builder) do
+      {true, model} -> {true, Map.put(item, "model", model)}
+      {false, _} -> {false, item}
+    end
+  end
+
+  defp rewire(%{"children" => children} = item, link_builder) do
+    results = Enum.map(children, fn i -> rewire(i, link_builder) end)
+
+    children = Enum.map(results, fn {_, c} -> c end)
+
+    changed =
+      Enum.map(results, fn {changed, _} -> changed end) |> Enum.any?(fn c -> c == true end)
+
+    {changed, Map.put(item, "children", children)}
+  end
+
+  defp rewire(item, _) do
+    {false, item}
   end
 
   defp create_objectives(project, resource_map, as_author) do

--- a/lib/oli/interop/ingest.ex
+++ b/lib/oli/interop/ingest.ex
@@ -165,8 +165,8 @@ defmodule Oli.Interop.Ingest do
     {changed, children}
   end
 
-  defp rewire(%{"type" => "a", "idref" => idref}, link_builder) do
-    {true, %{"type" => "a", "href" => link_builder.(idref)}}
+  defp rewire(%{"type" => "a", "idref" => idref, "children" => children}, link_builder) do
+    {true, %{"type" => "a", "children" => children, "href" => link_builder.(idref)}}
   end
 
   defp rewire(%{"model" => model} = item, link_builder) do

--- a/test/oli/interop/digest/u-analog_and_digital-m-analog_and_digital-p-analog_and_digital.json
+++ b/test/oli/interop/digest/u-analog_and_digital-m-analog_and_digital-p-analog_and_digital.json
@@ -74,6 +74,10 @@
               {
                 "type": "text",
                 "text": "are used a lot, but what do they mean? In this section, we look at those two worlds, which you use every day."
+              },
+              {
+                "type": "a",
+                "idref": "u-analog_and_digital-m-contents_analog_and_digital-p-contents_analog_and_digital"
               }
             ],
             "id": "fde4b83671d84cedb41b94fdc5de578a"

--- a/test/oli/interop/digest/u-analog_and_digital-m-analog_and_digital-p-analog_and_digital.json
+++ b/test/oli/interop/digest/u-analog_and_digital-m-analog_and_digital-p-analog_and_digital.json
@@ -77,7 +77,13 @@
               },
               {
                 "type": "a",
-                "idref": "u-analog_and_digital-m-contents_analog_and_digital-p-contents_analog_and_digital"
+                "idref": "u-analog_and_digital-m-contents_analog_and_digital-p-contents_analog_and_digital",
+                "children": [
+                  {
+                    "type": "text",
+                    "text": "the link text"
+                  }
+                ]
               }
             ],
             "id": "fde4b83671d84cedb41b94fdc5de578a"

--- a/test/oli/interop/ingest_test.exs
+++ b/test/oli/interop/ingest_test.exs
@@ -67,6 +67,22 @@ defmodule Oli.Interop.IngestTest do
       # verify that every practice page has a content attribute with a model
       assert Enum.all?(practice_pages, fn p -> Map.has_key?(p.content, "model") end)
 
+      # verify that the page that had a link to another page had that link rewired correctly
+      src = Enum.filter(practice_pages, fn p -> p.title == "Analog and Digital Page" end) |> hd
+
+      dest =
+        Enum.filter(practice_pages, fn p -> p.title == "Contents: Analog and Digital Page" end)
+        |> hd
+
+      link =
+        Enum.at(src.content["model"], 0)
+        |> Map.get("children")
+        |> Enum.at(1)
+        |> Map.get("children")
+        |> Enum.at(5)
+
+      assert link["href"] == "/course/link/#{dest.slug}"
+
       # spot check some elements to ensure that they were correctly constructed:
 
       # check an internal hierarchy node, one that contains references to only


### PR DESCRIPTION
This PR adds ingestion support for detecting "internal" links in page content of the form: `%{"type" => "a", "idref" => id }` where the `idref` value is the original idref from the course digest.  This PR "rewires" that link to use an "href" attribute that correctly points to the slug of the revision that got created for that resource identified by `idref`. 

This rewiring works by essentially making a second pass through all pages, and recursively parses their contents, looking for "a" elements.  If it finds one of the form that contains an `idref` it does the rewiring and tracks a new revision for that resource.  There is an optimization in place that only tracks a new revision when a link has been rewired.  If no links are rewired in a page, then no new revision is created.

There is a unit test that proves this works, but if one wants to see it operate on a larger scale one can ingest the full KTH course and see it in action. 

