### PR TITLE
Add guest flag to user

### DIFF
--- a/lib/oli/accounts/schemas/user.ex
+++ b/lib/oli/accounts/schemas/user.ex
@@ -25,6 +25,7 @@ defmodule Oli.Accounts.User do
     field :phone_number, :string
     field :phone_number_verified, :boolean
     field :address, :string
+    field :guest, :boolean
     field :research_opt_out, :boolean
     field :state, :map, default: %{}
 
@@ -64,6 +65,7 @@ defmodule Oli.Accounts.User do
       :phone_number_verified,
       :address,
       :author_id,
+      :guest,
       :research_opt_out,
       :state
     ])

--- a/lib/oli/accounts/schemas/user.ex
+++ b/lib/oli/accounts/schemas/user.ex
@@ -25,7 +25,7 @@ defmodule Oli.Accounts.User do
     field :phone_number, :string
     field :phone_number_verified, :boolean
     field :address, :string
-    field :guest, :boolean
+    field :guest, :boolean, default: false
     field :research_opt_out, :boolean
     field :state, :map, default: %{}
 

--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -334,7 +334,8 @@ defmodule OliWeb.DeliveryController do
              Accounts.create_user(%{
                # generate a unique sub identifier which is also used so a user can access
                # their progress in the future or using a different browser
-               sub: UUID.uuid4()
+               sub: UUID.uuid4(),
+               guest: true,
              }) do
         Accounts.update_user_platform_roles(user, [
           PlatformRoles.get_role(:institution_learner)

--- a/priv/repo/migrations/20210412213517_user_guest_flag.exs
+++ b/priv/repo/migrations/20210412213517_user_guest_flag.exs
@@ -1,0 +1,21 @@
+defmodule Oli.Repo.Migrations.UserGuestFlag do
+  use Ecto.Migration
+  import Ecto.Query, warn: false
+
+  def up do
+    alter table(:users) do
+      add :guest, :boolean, default: false, null: false
+    end
+
+    flush()
+
+    from(u in "users")
+    |> Oli.Repo.update_all(set: [guest: false])
+  end
+
+  def down do
+    alter table(:users) do
+      remove :guest, :boolean
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a flag to the user schema for tracking whether a user is a guest or not.

It falls under the Open and Free section support functionality in Enhancements, so there is no new change log entry for this PR.