### PR TITLE
User state refinements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Enhancements
+  - Add OpenAPI docs for user state service
+
 ### Bug fixes
   - Support page-to-page links during course ingestion
 

--- a/assets/src/components/activities/DeliveryElement.ts
+++ b/assets/src/components/activities/DeliveryElement.ts
@@ -167,6 +167,7 @@ export abstract class DeliveryElement<T extends ActivityModelSchema> extends HTM
       bubbles: true,
       detail: {
         payload,
+        sectionSlug: this.props().sectionSlug,
         attemptGuid,
         partAttemptGuid,
         continuation,

--- a/assets/src/phoenix/activity_bridge.ts
+++ b/assets/src/phoenix/activity_bridge.ts
@@ -8,19 +8,19 @@ type Continuation = (success: any, error: any) => void;
 
 export const defaultState = (model: ActivityModelSchema) => {
   const parts = model.authoring.parts.map((p: any) =>
-    ({
-      attemptNumber: 1,
-      attemptGuid: p.id,
-      dateEvaluated: null,
-      score: null,
-      outOf: null,
-      response: null,
-      feedback: null,
-      hints: [],
-      hasMoreHints: p.hints.length > 0,
-      hasMoreAttempts: true,
-      partId: p.id,
-    }));
+  ({
+    attemptNumber: 1,
+    attemptGuid: p.id,
+    dateEvaluated: null,
+    score: null,
+    outOf: null,
+    response: null,
+    feedback: null,
+    hints: [],
+    hasMoreHints: p.hints.length > 0,
+    hasMoreAttempts: true,
+    partId: p.id,
+  }));
 
   return {
     attemptNumber: 1,
@@ -52,21 +52,21 @@ export const initActivityBridge = (elementId: string) => {
   div.addEventListener('saveActivity', (e: any) => {
     e.preventDefault();
     e.stopPropagation();
-    makeRequest(`/api/v1/attempt/activity/${e.detail.attemptGuid}`,
+    makeRequest(`/api/v1/state/course/${e.detail.sectionSlug}/activity_attempt/${e.detail.attemptGuid}`,
       'PATCH', { partInputs: e.detail.payload }, e.detail.continuation);
   }, false);
 
   div.addEventListener('submitActivity', (e: any) => {
     e.preventDefault();
     e.stopPropagation();
-    makeRequest(`/api/v1/attempt/activity/${e.detail.attemptGuid}`,
+    makeRequest(`/api/v1/state/course/${e.detail.sectionSlug}/activity_attempt/${e.detail.attemptGuid}`,
       'PUT', { partInputs: e.detail.payload }, e.detail.continuation);
   }, false);
 
   div.addEventListener('resetActivity', (e: any) => {
     e.preventDefault();
     e.stopPropagation();
-    makeRequest(`/api/v1/attempt/activity/${e.detail.attemptGuid}`,
+    makeRequest(`/api/v1/state/course/${e.detail.sectionSlug}/activity_attempt/${e.detail.attemptGuid}`,
       'POST', {}, e.detail.continuation);
   }, false);
 
@@ -74,7 +74,7 @@ export const initActivityBridge = (elementId: string) => {
     e.preventDefault();
     e.stopPropagation();
     makeRequest(
-      `/api/v1/attempt/activity/${e.detail.attemptGuid}/part/${e.detail.attemptGuid}`,
+      `/api/v1/state/course/${e.detail.sectionSlug}/activity_attempt/${e.detail.attemptGuid}/part_attempt/${e.detail.attemptGuid}`,
       'PATCH', { input: e.detail.payload }, e.detail.continuation);
   }, false);
 
@@ -82,7 +82,7 @@ export const initActivityBridge = (elementId: string) => {
     e.preventDefault();
     e.stopPropagation();
     makeRequest(
-      `/api/v1/attempt/activity/${e.detail.attemptGuid}/part/${e.detail.attemptGuid}`,
+      `/api/v1/state/course/${e.detail.sectionSlug}/activity_attempt/${e.detail.attemptGuid}/part_attempt/${e.detail.attemptGuid}`,
       'PUT', { input: e.detail.payload }, e.detail.continuation);
   }, false);
 
@@ -90,7 +90,7 @@ export const initActivityBridge = (elementId: string) => {
     e.preventDefault();
     e.stopPropagation();
     makeRequest(
-      `/api/v1/attempt/activity/${e.detail.attemptGuid}/part/${e.detail.attemptGuid}`,
+      `/api/v1/state/course/${e.detail.sectionSlug}/activity_attempt/${e.detail.attemptGuid}/part_attempt/${e.detail.attemptGuid}`,
       'POST', {}, e.detail.continuation);
   }, false);
 
@@ -98,7 +98,7 @@ export const initActivityBridge = (elementId: string) => {
     e.preventDefault();
     e.stopPropagation();
     makeRequest(
-      `/api/v1/attempt/activity/${e.detail.attemptGuid}/part/${e.detail.partAttemptGuid}/hint`,
+      `/api/v1/state/course/${e.detail.sectionSlug}/activity_attempt/${e.detail.attemptGuid}/part_attempt/${e.detail.partAttemptGuid}/hint`,
       'GET', undefined, e.detail.continuation);
   }, false);
 
@@ -106,21 +106,21 @@ export const initActivityBridge = (elementId: string) => {
     e.preventDefault();
     e.stopPropagation();
     makeRequest(
-      `/api/v1/attempt/activity/${e.detail.attemptGuid}/evaluations`,
+      `/api/v1/state/course/${e.detail.sectionSlug}/activity_attempt/${e.detail.attemptGuid}/evaluations`,
       'PUT', { input: e.detail.payload }, e.detail.continuation);
   }, false);
 };
 
-const key = (activityAttemptGuid : string,
-  partAttemptGuid : string) => activityAttemptGuid + '|' + partAttemptGuid;
+const key = (activityAttemptGuid: string,
+  partAttemptGuid: string) => activityAttemptGuid + '|' + partAttemptGuid;
 
 export const initPreviewActivityBridge = (elementId: string) => {
   // map to keep track the number of hints requested for each part
-  const hintRequestCounts: {[key: string]: number} = {};
+  const hintRequestCounts: { [key: string]: number } = {};
 
   const div = document.getElementById(elementId) as any;
 
-  function getPart(model: any, id: string) : any {
+  function getPart(model: any, id: string): any {
     return model.authoring.parts.find((p: any) => p.id === id);
   }
 
@@ -130,22 +130,22 @@ export const initPreviewActivityBridge = (elementId: string) => {
     const partInputs: PartResponse[] = e.detail.payload;
 
     Persistence.evaluate(props.model, partInputs)
-    .then((result: Persistence.Evaluated) => {
+      .then((result: Persistence.Evaluated) => {
 
-      const actions = result.evaluations
-        .map((e: any) => {
-          return {
-            type: 'FeedbackAction',
-            error: e.error,
-            attempt_guid: e.part_id,
-            out_of: e.result.out_of,
-            score: e.result.score,
-            feedback: e.feedback,
-          };
-        });
+        const actions = result.evaluations
+          .map((e: any) => {
+            return {
+              type: 'FeedbackAction',
+              error: e.error,
+              attempt_guid: e.part_id,
+              out_of: e.result.out_of,
+              score: e.result.score,
+              feedback: e.feedback,
+            };
+          });
 
-      continuation({ type: 'success', actions }, undefined);
-    });
+        continuation({ type: 'success', actions }, undefined);
+      });
   }
 
   // IMPLEMENT THESE HANDLERS LATER IF NEEDED IN THE FUTURE
@@ -169,16 +169,16 @@ export const initPreviewActivityBridge = (elementId: string) => {
     const partId = e.detail.partAttemptGuid;
 
     Persistence.transform(props.model)
-    .then((result: Persistence.Transformed) => {
-      const model = result.transformed === null ? props.model : result.transformed;
+      .then((result: Persistence.Transformed) => {
+        const model = result.transformed === null ? props.model : result.transformed;
 
-      // reset the number of hints requested for this part
-      hintRequestCounts[key(
-        e.detail.attemptGuid, e.detail.partAttemptGuid)] = 0;
+        // reset the number of hints requested for this part
+        hintRequestCounts[key(
+          e.detail.attemptGuid, e.detail.partAttemptGuid)] = 0;
 
-      const attemptState = defaultState(model);
-      continuation({ type: 'success', model, attemptState }, undefined);
-    });
+        const attemptState = defaultState(model);
+        continuation({ type: 'success', model, attemptState }, undefined);
+      });
   }, false);
 
   div.addEventListener('submitPart', (e: any) => {
@@ -202,10 +202,10 @@ export const initPreviewActivityBridge = (elementId: string) => {
     const model = props.model;
     const hints = removeEmpty(getPart(model, partId).hints);
 
-    const nextHintIndex =  valueOr(hintRequestCounts[hintKey], 0);
+    const nextHintIndex = valueOr(hintRequestCounts[hintKey], 0);
     const hasMoreHints = hints.length > nextHintIndex + 1;
     const hint = hints[nextHintIndex];
-    const response : RequestHintResponse = {
+    const response: RequestHintResponse = {
       type: 'success',
       hint,
       hasMoreHints,

--- a/lib/oli_web/controllers/attempt_controller.ex
+++ b/lib/oli_web/controllers/attempt_controller.ex
@@ -5,7 +5,218 @@ defmodule OliWeb.AttemptController do
   alias Oli.Delivery.Attempts
   alias Oli.Delivery.Attempts.StudentInput
   alias Oli.Delivery.Attempts.ClientEvaluation
+  alias OpenApiSpex.Schema
 
+  @moduledoc tags: ["User State Service"]
+
+  defmodule UserStateUpdateResponse do
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "Response from updating user state",
+      description: "The server response for a successful user state update",
+      type: :object,
+      properties: %{
+        result: %Schema{type: :string, description: "Success"}
+      },
+      required: [:result],
+      example: %{
+        "result" => "success"
+      }
+    })
+  end
+
+  defmodule NewActivityAttemptResponse do
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "Response from creating a new activity attempt",
+      description:
+        "The server has created a new activity attempt and is delivering its new state and model to the client",
+      type: :object,
+      properties: %{
+        result: %Schema{type: :string, description: "Success"},
+        attemptState: %Schema{
+          type: :object,
+          description: "The activity attempt state for the new attempt"
+        },
+        model: %Schema{
+          type: :string,
+          description: "The transformed activity model for the new attempt"
+        }
+      },
+      required: [:result, :attemptState, :model],
+      example: %{
+        "result" => "success",
+        "attemptState" => %{},
+        "model" => %{"stem" => "What is 3 + 4?"}
+      }
+    })
+  end
+
+  defmodule HintResponse do
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "Response from updating user state",
+      description: "The server response for a successful user state update",
+      type: :object,
+      properties: %{
+        result: %Schema{type: :string, description: "Success"},
+        hasMoreHints: %Schema{
+          type: :boolean,
+          description: "Whether or not there are more hints beyond this one"
+        },
+        hint: %Schema{type: :object, description: "The hint structured content"}
+      },
+      required: [:result, :hasMoreHints, :hint],
+      example: %{
+        "result" => "success",
+        "hasMoreHints" => false,
+        "hint" => %{
+          "content" => [
+            %{"type" => "p", "children" => [%{"text" => "Reread the course material"}]}
+          ]
+        }
+      }
+    })
+  end
+
+  defmodule EvaluationResponse do
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "Response from updating user state",
+      description: "The server response for a successful user state update",
+      type: :object,
+      properties: %{
+        result: %Schema{type: :string, description: "Success"},
+        actions: %Schema{
+          type: :list,
+          description: "The collection of actions as a result of the evaluation"
+        }
+      },
+      required: [:result],
+      example: %{
+        "result" => "success",
+        "actions" => [
+          %{"type" => "ShowFeedbackAction", "feedback" => "Correct", "score" => 1, "outOf" => 1}
+        ]
+      }
+    })
+  end
+
+  defmodule UserStateUpdateBody do
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "User state",
+      description: "The request body representing a student's state for a part or attempt",
+      type: :object,
+      properties: %{
+        response: %Schema{
+          type: :object,
+          description: "JSON object representing the users state"
+        }
+      },
+      required: [:response],
+      example: %{
+        "response" => %{"selected" => "A"}
+      }
+    })
+  end
+
+  defmodule ActivityEvaluationBody do
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "Activity driven evaluation body",
+      description: "Activity driven evaluation parameters",
+      type: :object,
+      properties: %{
+        evaluations: %Schema{
+          type: :list,
+          description: "Collection of evaluation results, one per part in the activity"
+        }
+      },
+      required: [:evaluations],
+      example: %{
+        "evaluations" => [
+          %{
+            "attemptGuid" => "part1_guid",
+            "response" => "A",
+            "score" => 0,
+            "outOf" => 1,
+            "feedback" => "Wrong"
+          }
+        ]
+      }
+    })
+  end
+
+  defmodule ActivityAttemptBody do
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "User state",
+      description: "The state to save or evaluate for all parts for the activity",
+      type: :object,
+      properties: %{
+        partInputs: %Schema{
+          type: :list,
+          description: "Collection of part inputs, one for each part present in the activity"
+        }
+      },
+      required: [:partInputs],
+      example: %{
+        "partInputs" => [
+          %{
+            "attemptGuid" => "part1_guid",
+            "response" => "A"
+          },
+          %{
+            "attemptGuid" => "part2_guid",
+            "response" => "B"
+          }
+        ]
+      }
+    })
+  end
+
+  @activity_attempt_parameters [
+    section_slug: [
+      in: :url,
+      schema: %OpenApiSpex.Schema{type: :string},
+      required: true,
+      description: "The course section identifier"
+    ],
+    activity_attempt_guid: [
+      in: :url,
+      schema: %OpenApiSpex.Schema{type: :string},
+      required: true,
+      description: "The activity attempt identifier"
+    ]
+  ]
+
+  @part_attempt_parameters @activity_attempt_parameters ++
+                             [
+                               part_attempt_guid: [
+                                 in: :url,
+                                 schema: %OpenApiSpex.Schema{type: :string},
+                                 required: true,
+                                 description: "The part attempt identifier"
+                               ]
+                             ]
+
+  @doc """
+  Saves user state for a specific part attempt.
+
+  """
+  @doc parameters: @part_attempt_parameters,
+       request_body: {"User state", "application/json", UserStateUpdateBody, required: true},
+       responses: %{
+         200 => {"Update Response", "application/json", UserStateUpdateResponse}
+       }
   def save_part(conn, %{
         "activity_attempt_guid" => _attempt_guid,
         "part_attempt_guid" => part_attempt_guid,
@@ -17,6 +228,19 @@ defmodule OliWeb.AttemptController do
     end
   end
 
+  @doc """
+  Submit user state for server-side evaluation for a single part.
+
+  If this evaluation completes the activity attempt, a rolled up score will be calculdated
+  across all parts and captured in the activity attempt, thus finalizing the activity
+  attempt.
+
+  """
+  @doc parameters: @part_attempt_parameters,
+       request_body: {"User state", "application/json", UserStateUpdateBody, required: true},
+       responses: %{
+         200 => {"Evaluation response", "application/json", EvaluationResponse}
+       }
   def submit_part(conn, %{
         "section_slug" => section_slug,
         "activity_attempt_guid" => activity_attempt_guid,
@@ -31,10 +255,26 @@ defmodule OliWeb.AttemptController do
     end
   end
 
+  @doc """
+  Requests a new attempt for a specific part of an activity. NOT IMPLEMENTED.
+  """
+  @doc parameters: @part_attempt_parameters,
+       request_body: {"User state", "application/json", UserStateUpdateBody, required: true},
+       responses: %{
+         200 => {"Evaluation response", "application/json", UserStateUpdateResponse}
+       }
   def new_part(conn, %{"activity_attempt_guid" => _, "part_attempt_guid" => _attempt_guid}) do
     json(conn, %{"type" => "success"})
   end
 
+  @doc """
+  Requests a new hint for a specific part attempt.
+
+  """
+  @doc parameters: @part_attempt_parameters,
+       responses: %{
+         200 => {"Evaluation response", "application/json", HintResponse}
+       }
   def get_hint(conn, %{
         "activity_attempt_guid" => activity_attempt_guid,
         "part_attempt_guid" => part_attempt_guid
@@ -54,6 +294,15 @@ defmodule OliWeb.AttemptController do
     end
   end
 
+  @doc """
+  Saves user state for all parts for a specific activity attempt.
+
+  """
+  @doc parameters: @activity_attempt_parameters,
+       request_body: {"User state", "application/json", ActivityAttemptBody, required: true},
+       responses: %{
+         200 => {"Update Response", "application/json", UserStateUpdateResponse}
+       }
   def save_activity(conn, %{"activity_attempt_guid" => _attempt_guid, "partInputs" => part_inputs}) do
     parsed =
       Enum.map(part_inputs, fn %{"attemptGuid" => attempt_guid, "response" => response} ->
@@ -66,6 +315,15 @@ defmodule OliWeb.AttemptController do
     end
   end
 
+  @doc """
+  Evaluates user state for all parts for a specific activity attempt.
+
+  """
+  @doc parameters: @activity_attempt_parameters,
+       request_body: {"User state", "application/json", ActivityAttemptBody, required: true},
+       responses: %{
+         200 => {"Update Response", "application/json", EvaluationResponse}
+       }
   def submit_activity(conn, %{
         "section_slug" => section_slug,
         "activity_attempt_guid" => activity_attempt_guid,
@@ -85,6 +343,16 @@ defmodule OliWeb.AttemptController do
     end
   end
 
+  @doc """
+  Finalizes an activity attempt from the result of an activity driven evaluation.
+  """
+  @doc parameters: @activity_attempt_parameters,
+       request_body:
+         {"Activity driven evaluation body", "application/json", ActivityEvaluationBody,
+          required: true},
+       responses: %{
+         200 => {"Evaluation Response", "application/json", EvaluationResponse}
+       }
   def submit_evaluations(conn, %{
         "section_slug" => section_slug,
         "activity_attempt_guid" => activity_attempt_guid,
@@ -121,6 +389,13 @@ defmodule OliWeb.AttemptController do
     end
   end
 
+  @doc """
+  Creates a new attempt for an activity.
+  """
+  @doc parameters: @activity_attempt_parameters,
+       responses: %{
+         200 => {"New Attempt Response", "application/json", NewActivityAttemptResponse}
+       }
   def new_activity(conn, %{
         "section_slug" => section_slug,
         "activity_attempt_guid" => activity_attempt_guid

--- a/lib/oli_web/controllers/attempt_controller.ex
+++ b/lib/oli_web/controllers/attempt_controller.ex
@@ -7,7 +7,7 @@ defmodule OliWeb.AttemptController do
   alias Oli.Delivery.Attempts.ClientEvaluation
   alias OpenApiSpex.Schema
 
-  @moduledoc tags: ["User State Service"]
+  @moduledoc tags: ["User State Service: Intrinsic State"]
 
   defmodule UserStateUpdateResponse do
     require OpenApiSpex

--- a/lib/oli_web/controllers/extrinsic_state_controller.ex
+++ b/lib/oli_web/controllers/extrinsic_state_controller.ex
@@ -3,9 +3,99 @@ defmodule OliWeb.ExtrinsicStateController do
   Provides user state service endpoints for extrinsic state.
   """
   use OliWeb, :controller
+  use OpenApiSpex.Controller
 
   alias Oli.Delivery.ExtrinsicState
 
+  alias OpenApiSpex.Schema
+
+  @moduledoc tags: ["User State Service: Extrinsic State"]
+
+  @global_parameters []
+
+  @section_parameters [
+    section_slug: [
+      in: :url,
+      schema: %Schema{type: :string},
+      required: true,
+      description: "The course section identifier"
+    ]
+  ]
+
+  @keys [
+    keys: [
+      in: :query,
+      schema: %Schema{type: :list},
+      required: true,
+      description: "A collection of key names"
+    ]
+  ]
+
+  defmodule ExtrinsicReadResponse do
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "Response from reading a collection of key-values",
+      description: "The read top-level keys and their nested values",
+      type: :object,
+      required: [],
+      example: %{
+        "userActionDone" => true
+      }
+    })
+  end
+
+  defmodule ExtrinsicUpsertDeleteResponse do
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "Upsert Delete Response",
+      description: "Response from updating or deleting a collection of key-values",
+      type: :object,
+      properties: %{
+        result: %Schema{type: :string, description: "Success"}
+      },
+      required: [:result],
+      example: %{
+        "result" => "success"
+      }
+    })
+  end
+
+  defmodule ExtrinsicUpsertBody do
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "Upsert action body",
+      description: "The request body representing the key values to insert or update",
+      type: :object,
+      properties: %{},
+      required: [:response],
+      example: %{
+        "response" => %{"selected" => "A"}
+      }
+    })
+  end
+
+  @doc """
+  Reads state from the user's global context. State exists as key-value pairs. The
+  values can be nested JSON structures or simple scalar attributes.
+
+  The optional `keys` query parameter allows one to read a subset of the top-level
+  keys present in this context.  Omitting this parameter returns all top-level keys.
+
+  An example request, showing how to structure the keys parameter to contain the key names
+  "one", "two" and "three":
+
+  ```
+  /api/v1/state?keys[]=one&keys[]=two&keys=three
+  ```
+
+  """
+  @doc parameters: @global_parameters,
+       responses: %{
+         200 => {"Update Response", "application/json", ExtrinsicReadResponse}
+       }
   def read_global(conn, params) do
     user = conn.assigns.current_user
 
@@ -24,6 +114,14 @@ defmodule OliWeb.ExtrinsicStateController do
     end
   end
 
+  @doc """
+  Inserts or updates top-level keys into the user's global context.
+  """
+  @doc parameters: @global_parameters,
+       request_body: {"Global Upsert", "application/json", ExtrinsicUpsertBody, required: true},
+       responses: %{
+         200 => {"Update Response", "application/json", ExtrinsicUpsertDeleteResponse}
+       }
   def upsert_global(conn, key_values) do
     user = conn.assigns.current_user
 
@@ -36,6 +134,20 @@ defmodule OliWeb.ExtrinsicStateController do
     end
   end
 
+  @doc """
+  Deletes one or more keys from a user's global context.
+
+  An example request, showing how to structure the keys parameter to contain the key names
+  "one", "two" and "three":
+
+  ```
+  /api/v1/state?keys[]=one&keys[]=two&keys=three
+  ```
+  """
+  @doc parameters: @global_parameters ++ @keys,
+       responses: %{
+         200 => {"Delete Response", "application/json", ExtrinsicUpsertDeleteResponse}
+       }
   def delete_global(conn, params) do
     user = conn.assigns.current_user
 
@@ -54,6 +166,27 @@ defmodule OliWeb.ExtrinsicStateController do
     end
   end
 
+  @doc """
+  Reads state from the section context for a particular section for this user.
+
+  State exists as key-value pairs. The
+  values can be nested JSON structures or simple scalar attributes.
+
+  The optional `keys` query parameter allows one to read a subset of the top-level
+  keys present in this context.  Omitting this parameter returns all top-level keys.
+
+  An example request, showing how to structure the keys parameter to contain the key names
+  "one", "two" and "three":
+
+  ```
+  /api/v1/state/course/:section_slug?keys[]=one&keys[]=two&keys=three
+  ```
+
+  """
+  @doc parameters: @section_parameters,
+       responses: %{
+         200 => {"Update Response", "application/json", ExtrinsicReadResponse}
+       }
   def read_section(conn, %{"section_slug" => section_slug} = params) do
     user = conn.assigns.current_user
 
@@ -72,6 +205,14 @@ defmodule OliWeb.ExtrinsicStateController do
     end
   end
 
+  @doc """
+  Inserts or updates top-level keys into a section specific context for the user.
+  """
+  @doc parameters: @section_parameters,
+       request_body: {"Section Upsert", "application/json", ExtrinsicUpsertBody, required: true},
+       responses: %{
+         200 => {"Update Response", "application/json", ExtrinsicUpsertDeleteResponse}
+       }
   def upsert_section(%Plug.Conn{body_params: key_values} = conn, %{"section_slug" => section_slug}) do
     user = conn.assigns.current_user
 
@@ -84,6 +225,20 @@ defmodule OliWeb.ExtrinsicStateController do
     end
   end
 
+  @doc """
+  Deletes one or more keys from a section specific context for the user.
+
+  An example request, showing how to structure the keys parameter to contain the key names
+  "one", "two" and "three":
+
+  ```
+  /api/v1/state/course/:section_slug?keys[]=one&keys[]=two&keys=three
+  ```
+  """
+  @doc parameters: @section_parameters ++ @keys,
+       responses: %{
+         200 => {"Delete Response", "application/json", ExtrinsicUpsertDeleteResponse}
+       }
   def delete_section(conn, %{"section_slug" => section_slug} = params) do
     user = conn.assigns.current_user
 

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -320,34 +320,22 @@ defmodule OliWeb.Router do
     put "/objective/:objective", ObjectivesController, :update
   end
 
-  scope "/api/v1/attempt", OliWeb do
+  # User State Service, instrinsic state
+  scope "/api/v1/state/course/:section_slug/activity_attempt/:activity_attempt_guid", OliWeb do
     pipe_through [:api, :delivery_protected]
 
-    # post to create a new attempt
-    # put to submit a response
-    # patch to save response state
+    post "/", AttemptController, :new_activity
+    put "/", AttemptController, :submit_activity
+    patch "/", AttemptController, :save_activity
+    put "/evaluations", AttemptController, :submit_evaluations
 
-    post "/activity/:activity_attempt_guid/part/:part_attempt_guid", AttemptController, :new_part
-
-    put "/activity/:activity_attempt_guid/part/:part_attempt_guid",
-        AttemptController,
-        :submit_part
-
-    patch "/activity/:activity_attempt_guid/part/:part_attempt_guid",
-          AttemptController,
-          :save_part
-
-    get "/activity/:activity_attempt_guid/part/:part_attempt_guid/hint",
-        AttemptController,
-        :get_hint
-
-    post "/activity/:activity_attempt_guid", AttemptController, :new_activity
-    put "/activity/:activity_attempt_guid", AttemptController, :submit_activity
-    patch "/activity/:activity_attempt_guid", AttemptController, :save_activity
-
-    put "/activity/:activity_attempt_guid/evaluations", AttemptController, :submit_evaluations
+    post "/part_attempt/:part_attempt_guid", AttemptController, :new_part
+    put "/part_attempt/:part_attempt_guid", AttemptController, :submit_part
+    patch "/part_attempt/:part_attempt_guid", AttemptController, :save_part
+    get "/part_attempt/:part_attempt_guid/hint", AttemptController, :get_hint
   end
 
+  # User State Service, extrinsic state
   scope "/api/v1/state", OliWeb do
     pipe_through [:api, :delivery_protected]
 


### PR DESCRIPTION
This PR accomplishes two things:

1. Updates the user state endpoints to align their URL structures to match the rest of the service endpoints. This involves inserting `state` and also the `course` section slug into the URL.  
2. Adds OpenAPI documentation to the full set of user state endpoints, categorized between "intrinsic" and "extrinsic" state (relative to the attempt). 

