### PR TITLE
make api docs available in all environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
   - Add OpenAPI docs for user state service
+  - Enable OpenAPI docs on all environments at /api/v1/docs
 
 ### Bug fixes
   - Support page-to-page links during course ingestion

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -257,6 +257,12 @@ defmodule OliWeb.Router do
     # live "/:project_id/insights", Insights, session: {__MODULE__, :with_session, []}
   end
 
+  scope "/api/v1/docs" do
+    pipe_through [:browser]
+
+    get "/", OpenApiSpex.Plug.SwaggerUI, path: "/api/v1/openapi"
+  end
+
   scope "/api/v1" do
     pipe_through [:api]
 
@@ -488,12 +494,6 @@ defmodule OliWeb.Router do
       pipe_through [:browser]
 
       get "/uipalette", UIPaletteController, :index
-    end
-
-    scope "/dev" do
-      pipe_through [:browser]
-
-      get "/swaggerui", OpenApiSpex.Plug.SwaggerUI, path: "/api/v1/openapi"
     end
 
     scope "/test", OliWeb do


### PR DESCRIPTION
This PR makes OpenAPI docs available in all environments at /api/v1/docs.

Closes #941