### PR TITLE
use section slugs instead of ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug fixes
   - Support page-to-page links during course ingestion
+  - Use section slugs instead of ids in storage service URLs for delivery endpoints
 
 ## 0.8.0 (2021-4-12)
 

--- a/lib/oli_web/controllers/activity_controller.ex
+++ b/lib/oli_web/controllers/activity_controller.ex
@@ -314,11 +314,11 @@ defmodule OliWeb.ActivityController do
   document, for a particular course section.
   """
   @doc parameters: [
-         course: [
+         section_slug: [
            in: :url,
            schema: %OpenApiSpex.Schema{type: :string},
            required: true,
-           description: "The course identifier"
+           description: "The course section slug"
          ],
          resource: [
            in: :url,
@@ -333,18 +333,18 @@ defmodule OliWeb.ActivityController do
             OliWeb.ActivityController.DocumentAttributes}
        }
   def retrieve_delivery(conn, %{
-        "course" => course,
+        "section_slug" => section_slug,
         "resource" => activity_id
       }) do
     user = conn.assigns.current_user
 
-    case Sections.get_section_by(id: course) do
+    case Sections.get_section_by(slug: section_slug) do
       nil ->
         error(conn, 404, "not found")
 
-      section ->
-        if Sections.is_enrolled?(user.id, section.slug) do
-          case DeliveryResolver.from_resource_id(section.slug, activity_id) do
+      _ ->
+        if Sections.is_enrolled?(user.id, section_slug) do
+          case DeliveryResolver.from_resource_id(section_slug, activity_id) do
             nil -> error(conn, 404, "not found")
             rev -> json(conn, document_to_delivery_result(rev))
           end
@@ -361,11 +361,11 @@ defmodule OliWeb.ActivityController do
   document, for a particular course section.
   """
   @doc parameters: [
-         course: [
+         section_slug: [
            in: :url,
            schema: %OpenApiSpex.Schema{type: :string},
            required: true,
-           description: "The course identifier"
+           description: "The course section slug"
          ]
        ],
        responses: %{
@@ -374,18 +374,18 @@ defmodule OliWeb.ActivityController do
             OliWeb.ActivityController.BulkDocumentResponse}
        }
   def bulk_retrieve_delivery(conn, %{
-        "course" => course,
+        "section_slug" => section_slug,
         "resourceIds" => activity_ids
       }) do
     user = conn.assigns.current_user
 
-    case Sections.get_section_by(id: course) do
+    case Sections.get_section_by(slug: section_slug) do
       nil ->
         error(conn, 404, "not found")
 
-      section ->
-        if Sections.is_enrolled?(user.id, section.slug) do
-          case DeliveryResolver.from_resource_id(section.slug, activity_ids) do
+      _ ->
+        if Sections.is_enrolled?(user.id, section_slug) do
+          case DeliveryResolver.from_resource_id(section_slug, activity_ids) do
             nil ->
               error(conn, 404, "not found")
 

--- a/lib/oli_web/controllers/activity_controller.ex
+++ b/lib/oli_web/controllers/activity_controller.ex
@@ -338,19 +338,13 @@ defmodule OliWeb.ActivityController do
       }) do
     user = conn.assigns.current_user
 
-    case Sections.get_section_by(slug: section_slug) do
-      nil ->
-        error(conn, 404, "not found")
-
-      _ ->
-        if Sections.is_enrolled?(user.id, section_slug) do
-          case DeliveryResolver.from_resource_id(section_slug, activity_id) do
-            nil -> error(conn, 404, "not found")
-            rev -> json(conn, document_to_delivery_result(rev))
-          end
-        else
-          error(conn, 403, "unauthorized")
-        end
+    if Sections.is_enrolled?(user.id, section_slug) do
+      case DeliveryResolver.from_resource_id(section_slug, activity_id) do
+        nil -> error(conn, 404, "not found")
+        rev -> json(conn, document_to_delivery_result(rev))
+      end
+    else
+      error(conn, 403, "unauthorized")
     end
   end
 
@@ -379,25 +373,19 @@ defmodule OliWeb.ActivityController do
       }) do
     user = conn.assigns.current_user
 
-    case Sections.get_section_by(slug: section_slug) do
-      nil ->
-        error(conn, 404, "not found")
+    if Sections.is_enrolled?(user.id, section_slug) do
+      case DeliveryResolver.from_resource_id(section_slug, activity_ids) do
+        nil ->
+          error(conn, 404, "not found")
 
-      _ ->
-        if Sections.is_enrolled?(user.id, section_slug) do
-          case DeliveryResolver.from_resource_id(section_slug, activity_ids) do
-            nil ->
-              error(conn, 404, "not found")
-
-            revisions ->
-              json(conn, %{
-                "result" => "success",
-                "results" => Enum.map(revisions, &document_to_delivery_result/1)
-              })
-          end
-        else
-          error(conn, 403, "unauthorized")
-        end
+        revisions ->
+          json(conn, %{
+            "result" => "success",
+            "results" => Enum.map(revisions, &document_to_delivery_result/1)
+          })
+      end
+    else
+      error(conn, 403, "unauthorized")
     end
   end
 

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -302,7 +302,7 @@ defmodule OliWeb.Router do
     post "/:resource", ActivityController, :create_secondary
   end
 
-  scope "/api/v1/storage/course/:course/resource", OliWeb do
+  scope "/api/v1/storage/course/:section_slug/resource", OliWeb do
     pipe_through [:api, :delivery_protected]
 
     get "/:resource", ActivityController, :retrieve_delivery

--- a/test/oli_web/controllers/delivery_retrieve_test.exs
+++ b/test/oli_web/controllers/delivery_retrieve_test.exs
@@ -13,7 +13,7 @@ defmodule OliWeb.DeliveryRetrieveTest do
       section: section,
       activity_id: activity_id
     } do
-      conn = get(conn, Routes.activity_path(conn, :retrieve_delivery, section.id, activity_id))
+      conn = get(conn, Routes.activity_path(conn, :retrieve_delivery, section.slug, activity_id))
 
       assert %{"content" => %{"stem" => "1"}} = json_response(conn, 200)
     end
@@ -27,7 +27,7 @@ defmodule OliWeb.DeliveryRetrieveTest do
       page_revision2: rev2
     } do
       conn =
-        post(conn, Routes.activity_path(conn, :bulk_retrieve_delivery, section.id), %{
+        post(conn, Routes.activity_path(conn, :bulk_retrieve_delivery, section.slug), %{
           "resourceIds" => [rev1.resource_id, rev2.resource_id]
         })
 


### PR DESCRIPTION
This PR fixes a couple of endpoints in the activity "storage service" that were using section database ids in their URLs, instead of section slugs.   

After these endpoints migrated over to having the section slug present in them, it was no longer necessary to fetch the entire section to get that slug so that we can check enrollment.  Instead, the endpoints just now directly check enrollment.  