### PR TITLE
Fix CATA Feedback + Activity Hints

### DIFF
--- a/assets/jest-setup.ts
+++ b/assets/jest-setup.ts
@@ -1,0 +1,2 @@
+import '@testing-library/jest-dom'
+import '@testing-library/react'

--- a/assets/jest-setup.ts
+++ b/assets/jest-setup.ts
@@ -1,2 +1,0 @@
-import '@testing-library/jest-dom'
-import '@testing-library/react'

--- a/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyDelivery.tsx
+++ b/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyDelivery.tsx
@@ -93,8 +93,12 @@ const CheckAllThatApply = (props: DeliveryElementProps<CheckAllThatApplyModelSch
         response: { input: selectionToInput(undefined) },
       }])
       .then((response: EvaluationResponse) => {
-        if (response.evaluations.length > 0) {
-          const { score, out_of, feedback, error } = response.evaluations[0];
+        if (response.actions.length > 0) {
+
+          const action: ActivityTypes.FeedbackAction
+            = response.actions[0] as ActivityTypes.FeedbackAction;
+
+          const { score, out_of, feedback, error } = action;
           const parts = [Object.assign({}, attemptState.parts[0], { feedback, error })];
           const updated = Object.assign({}, attemptState, { score, outOf: out_of, parts });
           setAttemptState(updated);

--- a/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyDelivery.tsx
+++ b/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyDelivery.tsx
@@ -12,6 +12,7 @@ import { Stem } from '../common/DisplayedStem';
 import { Hints } from '../common/DisplayedHints';
 import { Reset } from '../common/Reset';
 import { Evaluation } from '../common/Evaluation';
+import { IconCorrect, IconIncorrect } from 'components/misc/Icons';
 
 type Evaluation = {
   score: number,
@@ -92,12 +93,8 @@ const CheckAllThatApply = (props: DeliveryElementProps<CheckAllThatApplyModelSch
         response: { input: selectionToInput(undefined) },
       }])
       .then((response: EvaluationResponse) => {
-        if (response.actions.length > 0) {
-
-          const action: ActivityTypes.FeedbackAction
-            = response.actions[0] as ActivityTypes.FeedbackAction;
-
-          const { score, out_of, feedback, error } = action;
+        if (response.evaluations.length > 0) {
+          const { score, out_of, feedback, error } = response.evaluations[0];
           const parts = [Object.assign({}, attemptState.parts[0], { feedback, error })];
           const updated = Object.assign({}, attemptState, { score, outOf: out_of, parts });
           setAttemptState(updated);
@@ -165,6 +162,17 @@ const CheckAllThatApply = (props: DeliveryElementProps<CheckAllThatApplyModelSch
     <Hints key="hints" onClick={onRequestHint} hints={hints}
       hasMoreHints={hasMoreHints} isEvaluated={isEvaluated} context={writerContext} />];
 
+  const gradedDetails = props.graded && props.progressState === 'in_review' ? [
+    evaluationSummary] : null;
+
+  const correctnessIcon = attemptState.score === 0 ? <IconIncorrect /> : <IconCorrect />;
+
+  const gradedPoints = props.graded && props.progressState === 'in_review' ? [
+    <div className="text-info font-italic">
+      {correctnessIcon}
+      <span>Points: </span><span>{attemptState.score + ' out of '
+        + attemptState.outOf}</span></div>] : null;
+
   const maybeSubmitButton = props.graded
     ? null
     : (
@@ -179,11 +187,13 @@ const CheckAllThatApply = (props: DeliveryElementProps<CheckAllThatApplyModelSch
       <div className="activity-content">
         <div>
           <Stem stem={stem} context={writerContext} />
+          {gradedPoints}
           <Choices choices={choices} selected={selected}
             onSelect={onSelect} isEvaluated={isEvaluated} context={writerContext} />
           {maybeSubmitButton}
         </div>
         {ungradedDetails}
+        {gradedDetails}
       </div>
       {reset}
     </div>

--- a/assets/src/components/resource/TestModeHandler.tsx
+++ b/assets/src/components/resource/TestModeHandler.tsx
@@ -2,25 +2,26 @@ import React from 'react';
 import { ActivityModelSchema, ClientEvaluation, PartResponse } from 'components/activities/types';
 import * as Persistence from 'data/persistence/activity';
 import { RequestHintResponse } from 'components/activities/DeliveryElement';
+import { removeEmpty } from 'utils/common';
 import produce from 'immer';
 
 
 export const defaultState = (model: ActivityModelSchema) => {
 
   const parts = model.authoring.parts.map((p: any) =>
-    ({
-      attemptNumber: 1,
-      attemptGuid: p.id,
-      dateEvaluated: null,
-      score: null,
-      outOf: null,
-      response: null,
-      feedback: null,
-      hints: [],
-      hasMoreHints: p.hints.length > 0,
-      hasMoreAttempts: true,
-      partId: p.id,
-    }));
+  ({
+    attemptNumber: 1,
+    attemptGuid: p.id,
+    dateEvaluated: null,
+    score: null,
+    outOf: null,
+    response: null,
+    feedback: null,
+    hints: [],
+    hasMoreHints: removeEmpty(p.hints).length > 0,
+    hasMoreAttempts: true,
+    partId: p.id,
+  }));
 
   return {
     attemptNumber: 1,
@@ -70,7 +71,7 @@ export class TestModeHandler extends React.Component<TestModelHandlerProps, Test
     this.ref = React.createRef();
   }
 
-  getPart(id: string) : any {
+  getPart(id: string): any {
     return this.state.model.authoring.parts.find((p: any) => p.id === id);
   }
 
@@ -87,7 +88,7 @@ export class TestModeHandler extends React.Component<TestModelHandlerProps, Test
     partId: string, payload: any) => void) {
 
     if (this.ref !== null) {
-      this.ref.current.addEventListener(name, (e : CustomEvent) => {
+      this.ref.current.addEventListener(name, (e: CustomEvent) => {
         e.preventDefault();
         e.stopPropagation();
         handler(e.detail.continuation, e.detail.partAttemptGuid, e.detail.payload);
@@ -99,28 +100,28 @@ export class TestModeHandler extends React.Component<TestModelHandlerProps, Test
   // we can handle individual part and activity submits in a unified manner
   handleSubmit(continuation: Continuation, partId: string, partInputs: PartResponse[]) {
     Persistence.evaluate(this.state.model, partInputs)
-    .then((result: Persistence.Evaluated) => {
+      .then((result: Persistence.Evaluated) => {
 
-      const actions = result.evaluations
-        .map((e: any) => {
-          return {
-            type: 'FeedbackAction',
-            error: e.error,
-            attempt_guid: e.part_id,
-            out_of: e.result.out_of,
-            score: e.result.score,
-            feedback: e.feedback,
-          };
-        });
+        const evaluations = result.evaluations
+          .map((e: any) => {
+            return {
+              type: 'EvaluatedPart',
+              error: e.error,
+              attempt_guid: e.part_id,
+              out_of: e.result.out_of,
+              score: e.result.score,
+              feedback: e.feedback,
+            };
+          });
 
-      continuation({ type: 'success', actions }, undefined);
-    });
+        continuation({ type: 'success', evaluations }, undefined);
+      });
   }
 
   handleSubmitEvaluations(continuation: Continuation, attemptGuid: any,
     clientEvaluations: ClientEvaluation[]) {
     const evaluatedParts = clientEvaluations
-      .map((e : any) => {
+      .map((e: any) => {
         return {
           type: 'EvaluatedPart',
           out_of: e.out_of,
@@ -129,14 +130,15 @@ export class TestModeHandler extends React.Component<TestModelHandlerProps, Test
         };
       });
 
-    continuation({ type: 'success', actions: evaluatedParts }, undefined);
+    continuation({ type: 'success', evaluations: evaluatedParts }, undefined);
   }
 
   handleHint(continuation: Continuation, partId: string) {
     const index = this.state.hints[partId];
-    const hasMoreHints = this.getPart(partId).hints.length > index + 1;
-    const hint = this.getPart(partId).hints[index];
-    const response : RequestHintResponse = {
+    const hints = removeEmpty(this.getPart(partId).hints);
+    const hasMoreHints = hints.length > index + 1;
+    const hint = hints[index];
+    const response: RequestHintResponse = {
       type: 'success',
       hint,
       hasMoreHints,
@@ -152,16 +154,16 @@ export class TestModeHandler extends React.Component<TestModelHandlerProps, Test
   handleReset(continuation: Continuation) {
 
     Persistence.transform(this.props.model)
-    .then((result: Persistence.Transformed) => {
-      const model = result.transformed === null ? this.props.model : result.transformed;
-      this.setState(produce(this.state, (draftState) => {
-        draftState.model = model;
-        draftState.hints = initHints(model);
-      }));
+      .then((result: Persistence.Transformed) => {
+        const model = result.transformed === null ? this.props.model : result.transformed;
+        this.setState(produce(this.state, (draftState) => {
+          draftState.model = model;
+          draftState.hints = initHints(model);
+        }));
 
-      const attemptState = defaultState(model);
-      continuation({ type: 'success', model, attemptState }, undefined);
-    });
+        const attemptState = defaultState(model);
+        continuation({ type: 'success', model, attemptState }, undefined);
+      });
   }
 
   render() {


### PR DESCRIPTION
Pulled out the bug fixes from a larger activity testing branch since I ran into some test setup problems that I need to fix.

Closts #912 

**Bug Fixes**
- Check all that apply: fix feedback/score not showing up in delivery
- Hints: fix hint requests and display in all activities when empty hints are present