### PR TITLE
Disallow the rendering of raw html in image captions

### DIFF
--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -288,7 +288,7 @@ defmodule Oli.Rendering.Content.Html do
           end
         }>"
       ] ++
-      [caption] ++
+      [escape_xml!(caption)] ++
       ["</figcaption>"] ++
       ["</figure>"] ++
       ["</div>"]

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -60,7 +60,9 @@ defmodule Oli.Rendering.Content.Html do
         _ -> ""
       end
 
-    figure(attrs, [~s|<img class="#{display_class(attrs)}"#{maybeAlt} src="#{escape_xml!(src)}"/>\n|])
+    figure(attrs, [
+      ~s|<img class="#{display_class(attrs)}"#{maybeAlt} src="#{escape_xml!(src)}"/>\n|
+    ])
   end
 
   def youtube(%Context{} = _context, _, %{"src" => src} = attrs) do
@@ -69,8 +71,8 @@ defmodule Oli.Rendering.Content.Html do
     figure(Map.put(attrs, "full-width", true), [
       """
       <div class="youtube-wrapper">
-        <iframe id="#{src}" class="#{display_class(attrs)}" allowfullscreen src="https://www.youtube.com/embed/#{
-          escape_xml!(src)
+        <iframe id="#{escape_xml!(src)}" class="#{display_class(attrs)}" allowfullscreen src="https://www.youtube.com/embed/#{
+        escape_xml!(src)
       }"></iframe>
       </div>
       """
@@ -152,7 +154,11 @@ defmodule Oli.Rendering.Content.Html do
           "language" => language
         } = attrs
       ) do
-    figure(attrs, [~s|<pre><code class="language-#{escape_xml!(language)}">|, next.(), "</code></pre>\n"])
+    figure(attrs, [
+      ~s|<pre><code class="language-#{escape_xml!(language)}">|,
+      next.(),
+      "</code></pre>\n"
+    ])
   end
 
   def code_line(%Context{} = _context, next, _) do

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -54,16 +54,13 @@ defmodule Oli.Rendering.Content.Html do
   end
 
   def img(%Context{} = _context, _, %{"src" => src} = attrs) do
-    alt =
+    maybeAlt =
       case attrs do
-        %{"alt" => alt} -> " alt=#{alt}"
+        %{"alt" => alt} -> " alt=#{escape_xml!(alt)}"
         _ -> ""
       end
 
-    # if attrs["caption"]
-    figure(attrs, [~s|<img class="#{display_class(attrs)}"#{alt} src="#{src}"/>\n|])
-    # else [~s|<img class="#{display_class(attrs)}"#{alt} src="#{src}"/>\n|]
-    # end
+    figure(attrs, [~s|<img class="#{display_class(attrs)}"#{maybeAlt} src="#{escape_xml!(src)}"/>\n|])
   end
 
   def youtube(%Context{} = _context, _, %{"src" => src} = attrs) do
@@ -73,7 +70,7 @@ defmodule Oli.Rendering.Content.Html do
       """
       <div class="youtube-wrapper">
         <iframe id="#{src}" class="#{display_class(attrs)}" allowfullscreen src="https://www.youtube.com/embed/#{
-        src
+          escape_xml!(src)
       }"></iframe>
       </div>
       """
@@ -94,14 +91,14 @@ defmodule Oli.Rendering.Content.Html do
     figure(Map.put(attrs, "full-width", true), [
       """
       <div class="webpage-wrapper">
-        <iframe class="#{display_class(attrs)}" allowfullscreen src="#{src}"></iframe>
+        <iframe class="#{display_class(attrs)}" allowfullscreen src="#{escape_xml!(src)}"></iframe>
       </div>
       """
     ])
   end
 
   def audio(%Context{} = _context, _, %{"src" => src} = attrs) do
-    figure(attrs, [~s|<audio controls src="#{src}">
+    figure(attrs, [~s|<audio controls src="#{escape_xml!(src)}">
       Your browser does not support the <code>audio</code> element.
     </audio>\n|])
   end
@@ -109,7 +106,7 @@ defmodule Oli.Rendering.Content.Html do
   def table(%Context{} = _context, next, attrs) do
     caption =
       case attrs do
-        %{"caption" => caption} -> "<caption>#{caption}</caption>"
+        %{"caption" => caption} -> "<caption>#{escape_xml!(caption)}</caption>"
         _ -> ""
       end
 
@@ -155,7 +152,7 @@ defmodule Oli.Rendering.Content.Html do
           "language" => language
         } = attrs
       ) do
-    figure(attrs, [~s|<pre><code class="language-#{language}">|, next.(), "</code></pre>\n"])
+    figure(attrs, [~s|<pre><code class="language-#{escape_xml!(language)}">|, next.(), "</code></pre>\n"])
   end
 
   def code_line(%Context{} = _context, next, _) do

--- a/test/oli/rendering/content/example_content.json
+++ b/test/oli/rendering/content/example_content.json
@@ -38,7 +38,7 @@
         }
       ],
       "id": 1856577103,
-      "caption": "John Trumbull's Declaration of Independence, showing the Committee of Five presenting its draft for approval by Second Continental Congress on June 28, 1776",
+      "caption": "John Trumbull's <b>Declaration of Independence</b>, showing the Committee of Five presenting its draft for approval by Second Continental Congress on June 28, 1776",
       "alt": "American Revolution"
     },
     {

--- a/test/oli/rendering/content/html_test.exs
+++ b/test/oli/rendering/content/html_test.exs
@@ -26,6 +26,9 @@ defmodule Oli.Content.Content.HtmlTest do
                ~r/<img.*src="https:\/\/upload.wikimedia.org\/wikipedia\/commons\/thumb\/f\/f9\/Declaration_of_Independence_%281819%29%2C_by_John_Trumbull.jpg\/480px-Declaration_of_Independence_%281819%29%2C_by_John_Trumbull.jpg"\/>/
 
       assert rendered_html_string =~
+               ~r/<figcaption>John Trumbull&#39;s &lt;b&gt;Declaration of Independence&lt;\/b&gt;,/
+
+      assert rendered_html_string =~
                "<p>The American colonials proclaimed &quot;no taxation without representation"
 
       assert rendered_html_string =~


### PR DESCRIPTION
This PR disallows the rendering of raw html in image captions.

Closes #951