### PR TITLE
Remove support for image floating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Bug fixes
   - Support page-to-page links during course ingestion
   - Use section slugs instead of ids in storage service URLs for delivery endpoints
-
+  - Remove support for image floating to fix display issues in text editors
 ## 0.8.0 (2021-4-12)
 
 ### Enhancements

--- a/assets/src/components/editing/models/image/commands.tsx
+++ b/assets/src/components/editing/models/image/commands.tsx
@@ -57,38 +57,6 @@ export const initCommands = (
     [
       {
         type: 'CommandDesc',
-        icon: () => 'align_horizontal_left',
-        description: () => 'Float left',
-        active: e => model.display === 'float_left',
-        command: {
-          execute: (c, e, p) => setDisplay('float_left'),
-          precondition: () => true,
-        },
-      },
-      {
-        type: 'CommandDesc',
-        icon: () => 'align_horizontal_center',
-        description: () => 'Center image',
-        active: e => model.display === 'block',
-        command: {
-          execute: (c, e, p) => setDisplay('block'),
-          precondition: () => true,
-        },
-      },
-      {
-        type: 'CommandDesc',
-        icon: () => 'align_horizontal_right',
-        description: () => 'Float right',
-        active: e => model.display === 'float_right',
-        command: {
-          execute: (c, e, p) => setDisplay('float_right'),
-          precondition: () => true,
-        },
-      },
-    ],
-    [
-      {
-        type: 'CommandDesc',
         icon: () => '',
         description: () => 'Alt text',
         command: {

--- a/assets/src/data/content/model.ts
+++ b/assets/src/data/content/model.ts
@@ -35,6 +35,7 @@ export function mutate<ModelElement>(obj: ModelElement, changes: Object): ModelE
 
 export type Selection = Range | null;
 
+// float_left and float_right no longer available as options and will render as block
 export type MediaDisplayMode = 'float_left' | 'float_right' | 'block';
 
 export type ModelElement

--- a/assets/src/data/content/utils.tsx
+++ b/assets/src/data/content/utils.tsx
@@ -4,16 +4,17 @@ import { MediaDisplayMode } from './model';
 
 const textLimit = 25;
 
+// float_left and float_right no longer supported as options
 export function displayModelToClassName(display: MediaDisplayMode | undefined) {
   switch (display) {
-    case 'float_left': return 'float-md-left';
-    case 'float_right': return 'float-md-right';
+    case 'float_left':
+    case 'float_right':
     case 'block': return 'd-block';
     default: return 'd-block';
   }
 }
 
-export function getContentDescription(content: StructuredContent) : JSX.Element {
+export function getContentDescription(content: StructuredContent): JSX.Element {
 
   if (content.children.length > 0) {
 

--- a/assets/src/data/content/writers/html.ts
+++ b/assets/src/data/content/writers/html.ts
@@ -11,7 +11,7 @@ import { WriterContext } from './context';
 // Important: any changes to this file must be replicated
 // in content/html.ex for non-activity rendering.
 
-function escapeHtml(unsafe: string) : string {
+function escapeHtml(unsafe: string): string {
   return unsafe
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
@@ -41,11 +41,12 @@ export class HtmlParser implements WriterImpl {
       .reduce((acc, mark) => `<${mark}>${acc}</${mark}>`, text);
   }
 
+  // float_left and float_right no longer supported as options
   private displayClass(attrs: any) {
     if (attrs.display) {
       switch (attrs.display) {
-        case 'float_left': return 'float-md-left';
-        case 'float_right': return 'float-md-right';
+        case 'float_left':
+        case 'float_right':
         case 'block':
         default: return 'd-block';
       }

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -298,11 +298,9 @@ defmodule Oli.Rendering.Content.Html do
 
   defp display_class(%{"display" => display}), do: display_class(display)
 
+  # float_left and float_right no longer supported as options
   defp display_class(display) do
     case display do
-      "float_left" -> "float-md-left"
-      "float_right" -> "float-md-right"
-      "block" -> "d-block"
       _ -> "d-block"
     end
   end


### PR DESCRIPTION
Images currently support being floated left or right to sit alongside content. However, this causes display problems whenever the next `div` after the image doesn't clear the float. Originally I had a bunch of CSS fixes to clear floats everywhere, and then I realized as soon as people start writing new activities, they'll run into this problem if they don't follow the class name convention to clear the floats that could be present in page content.

Eventually I just decided to remove support for floating images since it seems like more trouble than it's worth. Existing floated images will be rendered as blocks.

Closes #963 