### PR TITLE
include delivery element name, resource attempt guid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   - Fix a crash when an existing logged-in user accesses the Register Institution page
   - Activity feedback fixes and unit tests
   - Remove support for image floating to fix display issues in text editors
+  - Change activity rule, outcome modeling for use in adaptive activities
 
 ## 0.8.0 (2021-4-12)
 

--- a/lib/oli/activities/model.ex
+++ b/lib/oli/activities/model.ex
@@ -7,17 +7,20 @@ defmodule Oli.Activities.Model do
   boxes.  It is also easier to represent as a struct in this manner.
   """
 
-  defstruct [:parts, :transformations, :delivery, :authoring]
+  defstruct [:parts, :transformations, :delivery, :authoring, :rules]
 
   def parse(%{"authoring" => authoring} = model) when is_map(authoring) do
     with {:ok, parts} <- Oli.Activities.Model.Part.parse(Map.get(authoring, "parts", [])),
+         {:ok, rules} <-
+           Oli.Activities.Model.ConditionalOutcome.parse(Map.get(authoring, "rules", [])),
          {:ok, transformations} <-
            Oli.Activities.Model.Transformation.parse(Map.get(authoring, "transformations", [])) do
       {:ok,
        %Oli.Activities.Model{
          parts: parts,
+         rules: rules,
          transformations: transformations,
-         authoring: Map.drop(authoring, ["parts", "transformations"]),
+         authoring: Map.drop(authoring, ["parts", "transformations", "rules"]),
          delivery: Map.drop(model, ["authoring"])
        }}
     else
@@ -29,6 +32,7 @@ defmodule Oli.Activities.Model do
     {:ok,
      %Oli.Activities.Model{
        parts: [],
+       rules: [],
        transformations: [],
        authoring: authoring,
        delivery: Map.drop(model, ["authoring"])
@@ -39,6 +43,7 @@ defmodule Oli.Activities.Model do
     {:ok,
      %Oli.Activities.Model{
        parts: [],
+       rules: [],
        transformations: [],
        authoring: %{},
        delivery: model

--- a/lib/oli/activities/model/part.ex
+++ b/lib/oli/activities/model/part.ex
@@ -1,27 +1,24 @@
 defmodule Oli.Activities.Model.Part do
-  defstruct [:id, :scoring_strategy, :responses, :outcomes, :hints, :parts]
+  defstruct [:id, :scoring_strategy, :responses, :hints, :parts]
 
   def parse(
         %{
           "id" => id,
-          "scoringStrategy" => scoring_strategy,
-          "responses" => responses
+          "scoringStrategy" => scoring_strategy
         } = part
       ) do
     hints = Map.get(part, "hints", [])
     parts = Map.get(part, "parts", [])
-    outcomes = Map.get(part, "outcomes", [])
+    responses = Map.get(part, "responses", [])
 
     with {:ok, responses} <- Oli.Activities.Model.Response.parse(responses),
          {:ok, hints} <- Oli.Activities.Model.Hint.parse(hints),
-         {:ok, outcomes} <- Oli.Activities.Model.ConditionalOutcome.parse(outcomes),
          {:ok, parts} <- Oli.Activities.Model.Part.parse(parts) do
       {:ok,
        %Oli.Activities.Model.Part{
          responses: responses,
          hints: hints,
          parts: parts,
-         outcomes: outcomes,
          id: id,
          scoring_strategy: scoring_strategy
        }}

--- a/lib/oli/delivery/page/activity_context.ex
+++ b/lib/oli/delivery/page/activity_context.ex
@@ -45,6 +45,29 @@ defmodule Oli.Delivery.Page.ActivityContext do
     |> Map.new()
   end
 
+  @doc """
+  Takes a full context map produced by create_context_map/2 and 'thins' it out to
+  leave only the id, the delivery element name and the attempt guid. This is to allow
+  a page implementation that wishes to avoid injecting a potentially large number of
+  activities (and their full state and model) into a server rendered document.
+  """
+  def to_thin_context_map(context_map) do
+    Enum.map(context_map, fn {k,
+                              %{
+                                id: id,
+                                attempt_guid: attempt_guid,
+                                delivery_element: delivery_element
+                              }} ->
+      {k,
+       %{
+         id: id,
+         attemptGuid: attempt_guid,
+         deliveryElement: delivery_element
+       }}
+    end)
+    |> Map.new()
+  end
+
   def prepare_model(model, opts \\ []) do
     model = if Keyword.get(opts, :prune, true), do: ModelPruner.prune(model), else: model
 

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -49,15 +49,15 @@ defmodule OliWeb.PageDeliveryController do
     conn = put_root_layout(conn, {OliWeb.LayoutView, "page.html"})
     user = conn.assigns.current_user
 
-    {:ok, resource_attempt_state} = Jason.encode(Enum.at(context.resource_attempts, 0).state)
+    resource_attempt = Enum.at(context.resource_attempts, 0)
+    {:ok, resource_attempt_state} = Jason.encode(resource_attempt.state)
 
     {:ok, activity_guid_mapping} =
-      context.activities
-      |> Map.keys()
-      |> Enum.map(fn activity_id -> Map.get(context.activities, activity_id).attempt_guid end)
+      Oli.Delivery.Page.ActivityContext.to_thin_context_map(context.activities)
       |> Jason.encode()
 
     render(conn, "delivery.html", %{
+      resource_attempt_guid: resource_attempt.attempt_guid,
       resource_attempt_state: resource_attempt_state,
       activity_guid_mapping: activity_guid_mapping,
       content: Jason.encode!(context.page.content),

--- a/lib/oli_web/templates/page_delivery/delivery.html.eex
+++ b/lib/oli_web/templates/page_delivery/delivery.html.eex
@@ -16,6 +16,7 @@
     pageSlug: "<%= @slug %>",
     content: "<%= Base.encode64(@content) %>",
     resourceAttemptState: <%= raw(@resource_attempt_state) %>,
+    resourceAttemptGuid: "<%= @resource_attempt_guid %>",
     activityGuidMapping: <%= raw(@activity_guid_mapping) %>,
   };
 


### PR DESCRIPTION
This PR:

1. Elevates "outcomes" attribute of a Part to be "rules" and places it at the top level of the authoring portion of the model
2. Makes "responses" an optional attribute of a Part. 
3. includes the resource attempt guid as a delivery param
4. Includes the delivery element name as part of the attempt id mapping that is available as a delivery param