### PR TITLE
prevent multiple clicks on create section button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   - Activity feedback fixes and unit tests
   - Remove support for image floating to fix display issues in text editors
   - Change activity rule, outcome modeling for use in adaptive activities
+  - Fix an issue when creating section allows multiple sections to be created
 
 ## 0.8.0 (2021-4-12)
 

--- a/lib/oli_web/templates/delivery/configure_section.html.eex
+++ b/lib/oli_web/templates/delivery/configure_section.html.eex
@@ -15,10 +15,15 @@ $(function() {
       $('#select-submit').prop('disabled', true);
     }
   });
+
+  $('#select-project-form').on('submit', function() {
+    $('#select-submit').prop('disabled', true);
+    $('#select-submit').html('Creating section...')
+  });
 })
 </script>
 
-<%= form_for @conn, Routes.delivery_path(@conn, :create_section), fn _f -> %>
+<%= form_for @conn, Routes.delivery_path(@conn, :create_section), [id: "select-project-form"], fn _f -> %>
   <div class="text-center">
     <h3>Select a Project</h3>
     <p class="mt-3">


### PR DESCRIPTION
This PR fixes an issue where clicking the "Select and Continue" button on section creation form would submit twice, creating two different sections and forcing the application into an invalid state. Subsequent requests would throw a database error.

Closes #874