### PR TITLE
Add ability to unlink course section

### DIFF
--- a/lib/oli/accounts/schemas/user.ex
+++ b/lib/oli/accounts/schemas/user.ex
@@ -1,7 +1,7 @@
 defmodule Oli.Accounts.User do
   use Ecto.Schema
   import Ecto.Changeset
-  import Oli.Utils, only: [maybe_name_from_given_and_family: 1]
+  import Oli.Utils
 
   schema "users" do
     # user fields are based on the openid connect core standard, most of which are provided via LTI 1.3
@@ -94,7 +94,7 @@ defimpl Lti_1p3.Tool.Lti_1p3_User, for: Oli.Accounts.User do
         preload: [:context_roles],
         join: s in Section,
         on: e.section_id == s.id,
-        where: e.user_id == ^user_id and s.slug == ^section_slug,
+        where: e.user_id == ^user_id and s.slug == ^section_slug and s.status != :deleted,
         select: e
 
     case Repo.one(query) do

--- a/lib/oli/delivery/attempts.ex
+++ b/lib/oli/delivery/attempts.ex
@@ -456,7 +456,7 @@ defmodule Oli.Delivery.Attempts do
         on: s.publication_id == p.publication_id,
         join: r in Revision,
         on: p.revision_id == r.id,
-        where: s.slug == ^section_slug and r.graded == true,
+        where: s.slug == ^section_slug and s.status != :deleted and r.graded == true,
         select: a
     )
   end
@@ -475,7 +475,7 @@ defmodule Oli.Delivery.Attempts do
         on: s.publication_id == p.publication_id,
         join: r in Revision,
         on: p.revision_id == r.id,
-        where: s.slug == ^section_slug and r.graded == true and r.resource_id == ^resource_id,
+        where: s.slug == ^section_slug and s.status != :deleted and r.graded == true and r.resource_id == ^resource_id,
         select: a
     )
   end
@@ -494,7 +494,7 @@ defmodule Oli.Delivery.Attempts do
         on: s.publication_id == p.publication_id,
         join: r in Revision,
         on: p.revision_id == r.id,
-        where: s.slug == ^section_slug and a.user_id == ^user_id,
+        where: s.slug == ^section_slug and s.status != :deleted and a.user_id == ^user_id,
         distinct: a.id,
         select: a
     )
@@ -506,7 +506,7 @@ defmodule Oli.Delivery.Attempts do
         join: s in Section,
         on: a.section_id == s.id,
         where:
-          a.user_id == ^user_id and s.slug == ^section_slug and a.resource_id == ^resource_id,
+          a.user_id == ^user_id and s.slug == ^section_slug and s.status != :deleted and a.resource_id == ^resource_id,
         select: a
     )
   end
@@ -715,7 +715,7 @@ defmodule Oli.Delivery.Attempts do
           a.id == ra2.resource_access_id and ra1.id < ra2.id and
             ra1.resource_access_id == ra2.resource_access_id,
         where:
-          a.user_id == ^user_id and s.slug == ^section_slug and a.resource_id == ^resource_id and
+          a.user_id == ^user_id and s.slug == ^section_slug and s.status != :deleted and a.resource_id == ^resource_id and
             is_nil(ra2),
         select: ra1
     )

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -52,7 +52,7 @@ defmodule Oli.Delivery.Sections do
         e in Enrollment,
         join: s in Section,
         on: e.section_id == s.id,
-        where: e.user_id == ^user_id and s.slug == ^section_slug
+        where: e.user_id == ^user_id and s.slug == ^section_slug and s.status != :deleted
       )
 
     case Repo.one(query) do
@@ -71,7 +71,7 @@ defmodule Oli.Delivery.Sections do
         e in Enrollment,
         join: s in Section,
         on: e.section_id == s.id,
-        where: s.slug == ^section_slug,
+        where: s.slug == ^section_slug and s.status != :deleted,
         preload: [:user, :context_roles],
         select: e
       )
@@ -85,7 +85,7 @@ defmodule Oli.Delivery.Sections do
         e in Enrollment,
         join: s in Section,
         on: e.section_id == s.id,
-        where: e.user_id == ^user_id and s.slug == ^section_slug,
+        where: e.user_id == ^user_id and s.slug == ^section_slug and s.status != :deleted,
         select: e
       )
 
@@ -107,7 +107,7 @@ defmodule Oli.Delivery.Sections do
         s in Section,
         join: e in Enrollment,
         on: e.section_id == s.id,
-        where: e.user_id == ^user_id and s.open_and_free == true,
+        where: e.user_id == ^user_id and s.open_and_free == true and s.status != :deleted,
         preload: [:project, :publication],
         select: s
       )
@@ -135,7 +135,7 @@ defmodule Oli.Delivery.Sections do
     Repo.all(
       from(
         s in Section,
-        where: s.open_and_free == true,
+        where: s.open_and_free == true and s.status != :deleted,
         select: s
       )
     )
@@ -198,7 +198,7 @@ defmodule Oli.Delivery.Sections do
         on: s.lti_1p3_deployment_id == d.id,
         join: r in Registration,
         on: d.registration_id == r.id,
-        where: s.context_id == ^context_id and r.issuer == ^issuer and r.client_id == ^client_id,
+        where: s.context_id == ^context_id and s.status != :deleted and r.issuer == ^issuer and r.client_id == ^client_id,
         select: s
     )
   end
@@ -235,7 +235,7 @@ defmodule Oli.Delivery.Sections do
       ** (Ecto.NoResultsError)
   """
   def get_sections_by_publication(publication) do
-    from(s in Section, where: s.publication_id == ^publication.id) |> Repo.all()
+    from(s in Section, where: s.publication_id == ^publication.id and s.status != :deleted) |> Repo.all()
   end
 
   @doc """
@@ -249,7 +249,7 @@ defmodule Oli.Delivery.Sections do
       ** (Ecto.NoResultsError)
   """
   def get_sections_by_project(project) do
-    from(s in Section, where: s.project_id == ^project.id) |> Repo.all()
+    from(s in Section, where: s.project_id == ^project.id and s.status != :deleted) |> Repo.all()
   end
 
   @doc """
@@ -281,15 +281,15 @@ defmodule Oli.Delivery.Sections do
   end
 
   @doc """
-  Deletes a section.
+  Deletes a section by marking the record as deleted.
   ## Examples
-      iex> delete_section(section)
+      iex> soft_delete_section(section)
       {:ok, %Section{}}
-      iex> delete_section(section)
+      iex> soft_delete_section(section)
       {:error, %Ecto.Changeset{}}
   """
-  def delete_section(%Section{} = section) do
-    Repo.delete(section)
+  def soft_delete_section(%Section{} = section) do
+    update_section(section, %{status: :deleted})
   end
 
   @doc """

--- a/lib/oli/delivery/sections/section.ex
+++ b/lib/oli/delivery/sections/section.ex
@@ -13,6 +13,7 @@ defmodule Oli.Delivery.Sections.Section do
     field :context_id, :string
     field :slug, :string
     field :open_and_free, :boolean, default: false
+    field :status, Ecto.Enum, values: [:active, :deleted], default: :active
 
     field :grade_passback_enabled, :boolean, default: false
     field :line_items_service_url, :string
@@ -43,6 +44,7 @@ defmodule Oli.Delivery.Sections.Section do
       :context_id,
       :slug,
       :open_and_free,
+      :status,
       :grade_passback_enabled,
       :line_items_service_url,
       :nrps_enabled,

--- a/lib/oli/grading.ex
+++ b/lib/oli/grading.ex
@@ -245,7 +245,8 @@ defmodule Oli.Grading do
           rev.deleted == false and
             rev.graded == true and
             rev.resource_type_id == ^resource_type_id and
-            s.slug == ^section_slug,
+            s.slug == ^section_slug and
+            s.status != :deleted,
         select: rev
     )
   end

--- a/lib/oli/publishing/delivery_resolver.ex
+++ b/lib/oli/publishing/delivery_resolver.ex
@@ -21,7 +21,7 @@ defmodule Oli.Publishing.DeliveryResolver do
             on: m.publication_id == s.publication_id,
             join: rev in Revision,
             on: rev.id == m.revision_id,
-            where: s.slug == ^section_slug and m.resource_id in ^resource_ids,
+            where: s.slug == ^section_slug and s.status != :deleted and m.resource_id in ^resource_ids,
             select: rev
         )
 
@@ -42,7 +42,7 @@ defmodule Oli.Publishing.DeliveryResolver do
           on: m.publication_id == s.publication_id,
           join: rev in Revision,
           on: rev.id == m.revision_id,
-          where: s.slug == ^section_slug and m.resource_id == ^resource_id,
+          where: s.slug == ^section_slug and s.status != :deleted and m.resource_id == ^resource_id,
           select: rev
       )
     end
@@ -63,7 +63,7 @@ defmodule Oli.Publishing.DeliveryResolver do
           on: m.revision_id == rev2.id,
           join: s in Section,
           on: s.publication_id == m.publication_id,
-          where: rev.slug == ^revision_slug and s.slug == ^section_slug,
+          where: rev.slug == ^revision_slug and s.slug == ^section_slug and s.status != :deleted,
           limit: 1,
           select: rev2
       )
@@ -79,7 +79,7 @@ defmodule Oli.Publishing.DeliveryResolver do
         from p in Publication,
           join: s in Section,
           on: p.id == s.publication_id,
-          where: s.slug == ^section_slug,
+          where: s.slug == ^section_slug and s.status != :deleted,
           select: p
       )
     end
@@ -98,7 +98,7 @@ defmodule Oli.Publishing.DeliveryResolver do
           on: m.publication_id == p.id,
           join: rev in Revision,
           on: rev.id == m.revision_id,
-          where: m.resource_id == p.root_resource_id and s.slug == ^section_slug,
+          where: m.resource_id == p.root_resource_id and s.slug == ^section_slug and s.status != :deleted,
           select: rev
       )
     end
@@ -122,7 +122,7 @@ defmodule Oli.Publishing.DeliveryResolver do
           on: rev.id == m.revision_id,
           where:
             (rev.resource_type_id == ^page_id or rev.resource_type_id == ^container_id) and
-              s.slug == ^section_slug,
+              s.slug == ^section_slug and s.status != :deleted,
           select: rev
       )
     end

--- a/lib/oli_web/live/delivery/manage_section.ex
+++ b/lib/oli_web/live/delivery/manage_section.ex
@@ -1,0 +1,77 @@
+defmodule OliWeb.Delivery.ManageSection do
+  use OliWeb, :live_view
+
+  import OliWeb.ViewHelpers,
+    only: [
+      user_role: 2,
+    ]
+
+  alias Oli.Delivery.Sections
+  alias OliWeb.Router.Helpers, as: Routes
+
+  def mount(_params, session, socket) do
+    %{
+      "section" => section,
+      "current_user" => current_user,
+    } = session
+
+    socket = socket
+      |> assign(:section, section)
+      |> assign(:current_user, current_user)
+
+    {:ok, socket}
+  end
+
+  def render(assigns) do
+    # link_text = dgettext("grades", "Download Gradebook")
+
+    ~L"""
+      <h2><%= dgettext("section", "Manage Section") %></h2>
+
+      <%= if user_role(@section, @current_user) == :administrator do %>
+        <div class="card border-warning my-4">
+          <h6 class="card-header">
+            Admin Tools
+          </h6>
+          <div class="card-body border-warning">
+            <h5 class="card-title">Unlink this Section</h5>
+            <p class="card-text">If your section was created from the wrong project or you simply wish to start over, you can unlink this section.</p>
+            <button type="button" class="btn btn-sm btn-outline-danger float-right" data-toggle="modal" data-target="#deleteSectionModal">Unlink Section</button>
+          </div>
+        </div>
+
+        <!-- delete section modal -->
+        <div class="modal fade" id="deleteSectionModal" tabindex="-1" role="dialog" aria-labelledby="deleteSectionModal" aria-hidden="true">
+          <div class="modal-dialog" role="document">
+            <div class="modal-content">
+              <div class="modal-header">
+                <h5 class="modal-title" id="deleteSectionModal">Confirm Unlink Section</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                  <span aria-hidden="true">&times;</span>
+                </button>
+              </div>
+              <div class="modal-body">
+                Are you sure you want to unlink this section?
+                <div class="alert alert-danger my-2" role="alert">
+                  <b>Warning:</b> This action cannot be undone
+                </div>
+              </div>
+              <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-danger" phx-click="unlink_section" phx-disable-with="Unlinking...">Confirm Unlink Section</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    """
+  end
+
+  def handle_event("unlink_section", _, socket) do
+    %{section: section} = socket.assigns
+
+    {:ok, _deleted} = Sections.soft_delete_section(section)
+
+    {:noreply, push_redirect(socket, to: Routes.delivery_path(socket, :index))}
+  end
+end

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -432,6 +432,7 @@ defmodule OliWeb.Router do
         :review_attempt
 
     live "/:section_slug/grades", Grades.GradesLive, session: {__MODULE__, :with_section_user, []}
+    live "/:section_slug/manage", Delivery.ManageSection, session: {__MODULE__, :with_section_user, []}
     get "/:section_slug/grades/export", PageDeliveryController, :export_gradebook
   end
 

--- a/lib/oli_web/templates/delivery/configure_section.html.eex
+++ b/lib/oli_web/templates/delivery/configure_section.html.eex
@@ -33,7 +33,7 @@ $(function() {
   <div>
     <%= if assigns[:author] != nil do %>
       <div class="my-5">
-        <h4>My Projects</h4>
+        <h4>Available Projects</h4>
         <%= if Enum.count(@my_publications) > 0 do %>
           <table class="table table-hover">
             <thead>

--- a/lib/oli_web/templates/page_delivery/index.html.eex
+++ b/lib/oli_web/templates/page_delivery/index.html.eex
@@ -4,11 +4,16 @@
 
   <%= if is_instructor?(@conn, @section_slug) do %>
 
-  <div class="d-flex flex-row">
+  <div class="d-flex flex-row my-2">
     <div class="flex-fill"></div>
     <div>
       <%= link "Manage Grades", to: Routes.live_path(OliWeb.Endpoint, OliWeb.Grades.GradesLive, @section_slug), class: "btn btn-link btn-sm" %>
     </div>
+    <%= if user_role(@section, @current_user) == :administrator do %>
+      <div>
+        <%= link "Manage Section", to: Routes.live_path(OliWeb.Endpoint, OliWeb.Delivery.ManageSection, @section_slug), class: "btn btn-warning btn-sm" %>
+      </div>
+    <% end %>
   </div>
 
   <% end %>
@@ -18,6 +23,7 @@
 
     <%= render "_outline.html", conn: @conn, section_slug: @section_slug, summary: @summary, nodes: @summary.hierarchy, active_page: nil %>
   </div>
+
 </div>
 
 <script>
@@ -28,7 +34,7 @@
     const button = document.createElement("button");
     button.onclick = (_e) =>
       window.open(window.location.href, "_blank");
-    button.innerHTML = "Open with full window";
+    button.innerHTML = "Open in new window <i class='fas fa-external-link-alt'></i>";
     button.className = "btn btn-primary"
     const container = document.getElementById("index-container");
     container.innerHTML = "";

--- a/lib/oli_web/views/delivery_view.ex
+++ b/lib/oli_web/views/delivery_view.ex
@@ -2,65 +2,6 @@ defmodule OliWeb.DeliveryView do
   use OliWeb, :view
 
   alias Oli.Delivery.Sections.Section
-  alias Lti_1p3.Tool.ContextRoles
-  alias Lti_1p3.Tool.PlatformRoles
-
-  @admin_roles [
-    PlatformRoles.get_role(:system_administrator),
-    PlatformRoles.get_role(:institution_administrator),
-    ContextRoles.get_role(:context_administrator)
-  ]
-
-  @instructor_roles [
-    PlatformRoles.get_role(:institution_instructor),
-    ContextRoles.get_role(:context_instructor)
-  ]
-
-  @student_roles [
-    PlatformRoles.get_role(:institution_student),
-    PlatformRoles.get_role(:institution_learner),
-    ContextRoles.get_role(:context_learner)
-  ]
-
-  defp user_role(conn, user) do
-    case conn.assigns[:section] do
-      %Section{open_and_free: open_and_free, slug: section_slug} ->
-        cond do
-          open_and_free ->
-            :open_and_free
-
-          PlatformRoles.has_roles?(user, @admin_roles, :any) ||
-              ContextRoles.has_roles?(user, section_slug, @admin_roles, :any) ->
-            :administrator
-
-          PlatformRoles.has_roles?(user, @instructor_roles, :any) ||
-              ContextRoles.has_roles?(user, section_slug, @instructor_roles, :any) ->
-            :instructor
-
-          PlatformRoles.has_roles?(user, @student_roles, :any) ||
-              ContextRoles.has_roles?(user, section_slug, @student_roles, :any) ->
-            :student
-
-          true ->
-            :other
-        end
-
-      _ ->
-        cond do
-          PlatformRoles.has_roles?(user, @admin_roles, :any) ->
-            :administrator
-
-          PlatformRoles.has_roles?(user, @instructor_roles, :any) ->
-            :instructor
-
-          PlatformRoles.has_roles?(user, @student_roles, :any) ->
-            :student
-
-          true ->
-            :other
-        end
-    end
-  end
 
   defp is_preview_mode?(conn) do
     conn.assigns[:preview_mode] == true
@@ -90,7 +31,7 @@ defmodule OliWeb.DeliveryView do
   end
 
   def user_role_is_student(conn, user) do
-    case user_role(conn, user) do
+    case user_role(conn.assigns[:section], user) do
       :open_and_free ->
         true
 
@@ -103,7 +44,7 @@ defmodule OliWeb.DeliveryView do
   end
 
   def user_role_text(conn, user) do
-    case user_role(conn, user) do
+    case user_role(conn.assigns[:section], user) do
       :open_and_free ->
         "Open and Free"
 
@@ -122,7 +63,7 @@ defmodule OliWeb.DeliveryView do
   end
 
   def user_role_color(conn, user) do
-    case user_role(conn, user) do
+    case user_role(conn.assigns[:section], user) do
       :open_and_free ->
         "#2C67C4"
 

--- a/lib/oli_web/views/view_helpers.ex
+++ b/lib/oli_web/views/view_helpers.ex
@@ -1,6 +1,10 @@
 defmodule OliWeb.ViewHelpers do
   use Phoenix.HTML
 
+  alias Lti_1p3.Tool.ContextRoles
+  alias Lti_1p3.Tool.PlatformRoles
+  alias Oli.Delivery.Sections.Section
+
   def is_admin?(%{:assigns => assigns}) do
     admin_role_id = Oli.Accounts.SystemRole.role_id().admin
     assigns.current_author.system_role_id == admin_role_id
@@ -18,4 +22,62 @@ defmodule OliWeb.ViewHelpers do
       [text, content_tag("i", "", class: "las la-external-link-alt ml-1")]
     end
   end
+
+  @admin_roles [
+    PlatformRoles.get_role(:system_administrator),
+    PlatformRoles.get_role(:institution_administrator),
+    ContextRoles.get_role(:context_administrator)
+  ]
+
+  @instructor_roles [
+    PlatformRoles.get_role(:institution_instructor),
+    ContextRoles.get_role(:context_instructor)
+  ]
+
+  @student_roles [
+    PlatformRoles.get_role(:institution_student),
+    PlatformRoles.get_role(:institution_learner),
+    ContextRoles.get_role(:context_learner)
+  ]
+
+  def user_role(section, user) do
+    case section do
+      %Section{open_and_free: open_and_free, slug: section_slug} ->
+        cond do
+          open_and_free ->
+            :open_and_free
+
+          PlatformRoles.has_roles?(user, @admin_roles, :any) ||
+              ContextRoles.has_roles?(user, section_slug, @admin_roles, :any) ->
+            :administrator
+
+          PlatformRoles.has_roles?(user, @instructor_roles, :any) ||
+              ContextRoles.has_roles?(user, section_slug, @instructor_roles, :any) ->
+            :instructor
+
+          PlatformRoles.has_roles?(user, @student_roles, :any) ||
+              ContextRoles.has_roles?(user, section_slug, @student_roles, :any) ->
+            :student
+
+          true ->
+            :other
+        end
+
+      _ ->
+        cond do
+          PlatformRoles.has_roles?(user, @admin_roles, :any) ->
+            :administrator
+
+          PlatformRoles.has_roles?(user, @instructor_roles, :any) ->
+            :instructor
+
+          PlatformRoles.has_roles?(user, @student_roles, :any) ->
+            :student
+
+          true ->
+            :other
+        end
+    end
+  end
+
 end

--- a/priv/repo/migrations/20210420175605_section_status.exs
+++ b/priv/repo/migrations/20210420175605_section_status.exs
@@ -1,0 +1,9 @@
+defmodule Oli.Repo.Migrations.SectionStatus do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sections) do
+      add :status, :string, default: "active"
+    end
+  end
+end

--- a/test/oli/sections_test.exs
+++ b/test/oli/sections_test.exs
@@ -209,9 +209,9 @@ defmodule Oli.SectionsTest do
       assert section == Sections.get_section!(section.id)
     end
 
-    test "delete_section/1 deletes the section", %{section: section} do
-      assert {:ok, %Section{}} = Sections.delete_section(section)
-      assert_raise Ecto.NoResultsError, fn -> Sections.get_section!(section.id) end
+    test "soft_delete_section/1 marks the section as deleted", %{section: section} do
+      assert {:ok, %Section{}} = Sections.soft_delete_section(section)
+      assert Sections.get_section!(section.id).status == :deleted
     end
 
     test "change_section/1 returns a section changeset", %{section: section} do


### PR DESCRIPTION
This PR add functionality to "unlink" a section from an LTI context by marking the section as deleted.

There is some future UI refactoring that should be done to clean up the Instructor and Admin facing features on the index page. For now, it is simply represented as two buttons, "Manage Grades" and "Manage Section"

Closes #976