### PR TITLE
image coding: use ACE syntax highlighting code editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - Add sequential page navigation to editor and full course preview
   - Enable ecto repository stats in live dashboard
   - Add ability to unlink a course section from an LMS
+  - Image code activity: use syntax highlighting code editor
 
 ### Bug fixes
   - Support page-to-page links during course ingestion

--- a/assets/package.json
+++ b/assets/package.json
@@ -27,6 +27,7 @@
     "phoenix_html": "file:../deps/phoenix_html",
     "phoenix_live_view": "file:../deps/phoenix_live_view",
     "react": "^16.9.0",
+    "react-ace": "^9.4.0",
     "react-bootstrap-typeahead": "^5.0.0-alpha.1",
     "react-dom": "^16.9.0",
     "react-redux": "^7.1.3",

--- a/assets/src/components/activities/image_coding/ImageCodingAuthoring.tsx
+++ b/assets/src/components/activities/image_coding/ImageCodingAuthoring.tsx
@@ -20,6 +20,7 @@ import * as ContentModel from 'data/content/model';
 import { Feedback } from './sections/Feedback';
 import { lastPart } from './utils';
 import { CloseButton } from 'components/misc/CloseButton';
+import { ImageCodeEditor } from './sections/ImageCodeEditor';
 
 const store = configureStore();
 
@@ -62,7 +63,7 @@ const ImageCoding = (props: AuthoringElementProps<ImageCodingModelSchema>) => {
           <MediaManager
             projectSlug={projectSlug}
             // eslint-disable-next-line
-            onEdit={() => { }}
+            onEdit={() => {}}
             mimeFilter={MIMETYPE_FILTERS.IMAGE}
             selectionType={SELECTION_TYPES.SINGLE}
             initialSelectionPaths={model.src ? [model.src] : [selected.img as any]}
@@ -98,7 +99,7 @@ const ImageCoding = (props: AuthoringElementProps<ImageCodingModelSchema>) => {
           <MediaManager
             projectSlug={projectSlug}
             // eslint-disable-next-line
-            onEdit={() => { }}
+            onEdit={() => {}}
             mimeFilter={MIMETYPE_FILTERS.CSV}
             selectionType={SELECTION_TYPES.SINGLE}
             initialSelectionPaths={model.src ? [model.src] : [selected.file as any]}
@@ -139,13 +140,10 @@ const ImageCoding = (props: AuthoringElementProps<ImageCodingModelSchema>) => {
         <Heading title="Solution" id="solution-code" />
 
         <p>Image problems: Solution Code {!usesImage() ? '-- add image to enable' : ''}</p>
-        <textarea
+        <ImageCodeEditor
           disabled={!usesImage()}
-          rows={5}
-          cols={80}
-          className="form-control"
           value={model.solutionCode}
-          onChange={(e: any) => dispatch(ICActions.editSolutionCode(e.target.value))}
+          onChange={(newValue: string) => dispatch(ICActions.editSolutionCode(newValue))}
         />
         <br />
         <p>
@@ -209,12 +207,10 @@ const ImageCoding = (props: AuthoringElementProps<ImageCodingModelSchema>) => {
       <br />
 
       <Heading title="Starter Code" id="starter-code" />
-      <textarea
-        rows={5}
-        cols={80}
-        className="form-control"
+      <ImageCodeEditor
+        disabled={false}
         value={model.starterCode}
-        onChange={(e: any) => dispatch(ICActions.editStarterCode(e.target.value))}
+        onChange={(newValue: string) => dispatch(ICActions.editStarterCode(newValue))}
       />
       <br />
 

--- a/assets/src/components/activities/image_coding/ImageCodingDelivery.tsx
+++ b/assets/src/components/activities/image_coding/ImageCodingDelivery.tsx
@@ -17,6 +17,7 @@ import { valueOr } from 'utils/common';
 import { Evaluator, EvalContext } from './Evaluator';
 import { lastPart } from './utils';
 import { defaultWriterContext } from 'data/content/writers/context';
+import { ImageCodeEditor } from './sections/ImageCodeEditor';
 
 type Evaluation = {
   score: number;
@@ -248,16 +249,16 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
   const ungradedDetails = props.graded
     ? null
     : [
-      evaluationSummary,
-      <Hints
-        key="hints"
-        onClick={onRequestHint}
-        hints={hints}
-        context={writerContext}
-        hasMoreHints={hasMoreHints}
-        isEvaluated={isEvaluated}
-      />,
-    ];
+        evaluationSummary,
+        <Hints
+          key="hints"
+          onClick={onRequestHint}
+          hints={hints}
+          context={writerContext}
+          hasMoreHints={hasMoreHints}
+          isEvaluated={isEvaluated}
+        />,
+      ];
 
   const renderOutput = () => {
     if (output === '') {
@@ -320,8 +321,8 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
       <div className="activity-content">
         <Stem stem={stem} context={writerContext} />
 
-        <div className="">
-          <Input input={input} isEvaluated={isEvaluated} onChange={onInputChange} />
+        <div>
+          <ImageCodeEditor value={input} disabled={isEvaluated} onChange={onInputChange} />
           {runButton} {maybeSubmitButton}
         </div>
 

--- a/assets/src/components/activities/image_coding/sections/ImageCodeEditor.tsx
+++ b/assets/src/components/activities/image_coding/sections/ImageCodeEditor.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import AceEditor from 'react-ace';
+import 'ace-builds/src-noconflict/mode-javascript';
+import 'ace-builds/src-noconflict/theme-xcode';
+
+export type ImageCodeEditorProps = {
+  value: string;
+  onChange: (newValue: string) => void;
+  disabled: boolean;
+};
+
+export const ImageCodeEditor = (props: ImageCodeEditorProps) => {
+  const value = props.value === null ? '' : props.value;
+  return (
+    <AceEditor
+      className="form-control"
+      mode="javascript"
+      theme="xcode"
+      minLines={7}
+      maxLines={40}
+      width="parent"
+      value={value}
+      onChange={props.onChange}
+      readOnly={props.disabled}
+      style={props.disabled ? { background: '#ECF0F1' } : {}}
+      setOptions={{
+        showLineNumbers: false,
+        tabSize: 4,
+        showGutter: false,
+        highlightActiveLine: false,
+        fontSize: 14,
+      }}
+    />
+  );
+};

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -2620,6 +2620,11 @@ abab@^2.0.3, abab@^2.0.5:
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.5.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a"
   integrity sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==
 
+ace-builds@^1.4.12:
+  version "1.4.12"
+  resolved "https://registry.yarnpkg.com/ace-builds/-/ace-builds-1.4.12.tgz#888efa386e36f4345f40b5233fcc4fe4c588fae7"
+  integrity sha512-G+chJctFPiiLGvs3+/Mly3apXTcfgE45dT5yp12BcWZ1kUs+gm0qd3/fv4gsz6fVag4mM0moHVpjHDIgph6Psg==
+
 acorn-globals@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-6.0.0.tgz#46cdd39f0f8ff08a876619b55f5ac8a6dc770b45"
@@ -4258,6 +4263,11 @@ detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
+
+diff-match-patch@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/diff-match-patch/-/diff-match-patch-1.0.5.tgz#abb584d5f10cd1196dfc55aa03701592ae3f7b37"
+  integrity sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==
 
 diff-sequences@^25.2.6:
   version "25.2.6"
@@ -6779,6 +6789,11 @@ lodash.get@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
+
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
@@ -8305,6 +8320,17 @@ randomfill@^1.0.3:
   dependencies:
     randombytes "^2.0.5"
     safe-buffer "^5.1.0"
+
+react-ace@^9.4.0:
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/react-ace/-/react-ace-9.4.0.tgz#5c68423b5c7d4bc9332fc8b651187799c0bc97f6"
+  integrity sha512-fpY3AGViE1OglXThgn3wZWcPoAxr0bqRYqeG3jY3m1L7OIHo0GfZ3bJI0grhrADDy2i9jQoip9xZfpOFupQCsw==
+  dependencies:
+    ace-builds "^1.4.12"
+    diff-match-patch "^1.0.4"
+    lodash.get "^4.4.2"
+    lodash.isequal "^4.5.0"
+    prop-types "^15.7.2"
 
 react-bootstrap-typeahead@^5.0.0-alpha.1:
   version "5.1.2"


### PR DESCRIPTION
Adds a syntax coloring, auto-indenting code editor for image code activity and authoring, using the react-ace version of the ACE code editor. It's configured to use a 14 point fixed width font and the "xcode" theme; available themes can be viewed at https://manubb.github.io/react-ace-builds/ . Other options have been set to emulate a plain text box: no line numbering, gutter, current line highlighting, or auto completion. The background is set to grey when disabled like our other other text input boxes. However it does not get the focus highlight border our other text boxes do.