### PR TITLE
[BUG FIX] improve rendering robustness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   - Remove support for image floating to fix display issues in text editors
   - Change activity rule, outcome modeling for use in adaptive activities
   - Fix an issue when creating section allows multiple sections to be created
+  - Improved rendering robustness when content elements are missing key attributes
 
 ## 0.8.0 (2021-4-12)
 

--- a/lib/oli/rendering/content/plaintext.ex
+++ b/lib/oli/rendering/content/plaintext.ex
@@ -47,16 +47,32 @@ defmodule Oli.Rendering.Content.Plaintext do
     ["[image with src #{src}] "]
   end
 
+  def img(%Context{} = _context, _, _) do
+    ["[image with missing src] "]
+  end
+
   def youtube(%Context{} = _context, _, %{"src" => src}) do
     ["[youtube with src #{src}] "]
+  end
+
+  def youtube(%Context{} = _context, _, _) do
+    ["[youtube with missing src] "]
   end
 
   def iframe(%Context{} = _context, _, %{"src" => src}) do
     ["[iframe with src #{src}] "]
   end
 
+  def iframe(%Context{} = _context, _, _) do
+    ["[iframe with missing src] "]
+  end
+
   def audio(%Context{} = _context, _, %{"src" => src}) do
-    ["[audio with src #{src} "]
+    ["[audio with src #{src}] "]
+  end
+
+  def audio(%Context{} = _context, _, _) do
+    ["[audio with missing src] "]
   end
 
   def table(%Context{} = _context, next, _) do
@@ -95,9 +111,7 @@ defmodule Oli.Rendering.Content.Plaintext do
     [next.()]
   end
 
-  def code(%Context{} = _context, next, %{
-        "language" => _language
-      }) do
+  def code(%Context{} = _context, next, _) do
     ["[Code]: ", next.(), " "]
   end
 
@@ -110,7 +124,11 @@ defmodule Oli.Rendering.Content.Plaintext do
   end
 
   def a(%Context{} = _context, next, %{"href" => href}) do
-    ["[link to #{href}", next.(), " "]
+    ["[link to #{href} ", next.(), " "]
+  end
+
+  def a(%Context{} = _context, next, _) do
+    ["[link with missing href ", next.(), " "]
   end
 
   def definition(%Context{} = _context, next, _) do

--- a/test/oli/rendering/page/audio_missing_src.json
+++ b/test/oli/rendering/page/audio_missing_src.json
@@ -1,0 +1,21 @@
+[
+  {
+    "type": "content",
+    "id": 2635423624,
+    "children": [
+      {
+        "type": "audio",
+        "id": 2652513352,
+        "children": []
+      },
+      {
+        "type": "p",
+        "children": [
+          {
+            "text": "some specific content"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/test/oli/rendering/page/html_test.exs
+++ b/test/oli/rendering/page/html_test.exs
@@ -105,5 +105,68 @@ defmodule Oli.Content.Page.HtmlTest do
                         "<div class=\"page-item unsupported\">Page item of type 'some-unsupported-page-item' is not supported"
              end) =~ "Page item is not supported"
     end
+
+    test "handles missing language attributes on codeblocks gracefully", %{author: author} do
+      robustnesss_test(
+        author,
+        "./test/oli/rendering/page/missing_language.json",
+        "this is text from the code block"
+      )
+    end
+
+    test "handles links that are missing hrefs", %{author: author} do
+      robustnesss_test(
+        author,
+        "./test/oli/rendering/page/link_missing_href.json",
+        "website"
+      )
+    end
+
+    test "renders malformed images robustly", %{author: author} do
+      robustnesss_test(
+        author,
+        "./test/oli/rendering/page/image_missing_src.json",
+        "some specific content"
+      )
+    end
+
+    test "renders malformed youtube videos robustly", %{author: author} do
+      robustnesss_test(
+        author,
+        "./test/oli/rendering/page/youtube_missing_src.json",
+        "some specific content"
+      )
+    end
+
+    test "renders malformed audio robustly", %{author: author} do
+      robustnesss_test(
+        author,
+        "./test/oli/rendering/page/audio_missing_src.json",
+        "some specific content"
+      )
+    end
+
+    test "renders malformed iframe robustly", %{author: author} do
+      robustnesss_test(
+        author,
+        "./test/oli/rendering/page/iframe_missing_src.json",
+        "some specific content"
+      )
+    end
+
+    defp robustnesss_test(author, file, to_check) do
+      {:ok, page_content} = read_json_file(file)
+
+      assert capture_log(fn ->
+               context = %Context{user: author, activity_map: %{}}
+               rendered_html = Page.render(context, page_content, Page.Html)
+
+               rendered_html_string =
+                 Phoenix.HTML.raw(rendered_html) |> Phoenix.HTML.safe_to_string()
+
+               # ensure unsupported page item doesnt prevent rendering over other valid items
+               assert rendered_html_string =~ to_check
+             end) =~ "Render Error"
+    end
   end
 end

--- a/test/oli/rendering/page/iframe_missing_src.json
+++ b/test/oli/rendering/page/iframe_missing_src.json
@@ -1,0 +1,21 @@
+[
+  {
+    "type": "content",
+    "id": 2635423624,
+    "children": [
+      {
+        "type": "iframe",
+        "id": 2652513352,
+        "children": []
+      },
+      {
+        "type": "p",
+        "children": [
+          {
+            "text": "some specific content"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/test/oli/rendering/page/image_missing_src.json
+++ b/test/oli/rendering/page/image_missing_src.json
@@ -1,0 +1,21 @@
+[
+  {
+    "type": "content",
+    "id": 2635423624,
+    "children": [
+      {
+        "type": "img",
+        "id": 2652513352,
+        "children": []
+      },
+      {
+        "type": "p",
+        "children": [
+          {
+            "text": "some specific content"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/test/oli/rendering/page/link_missing_href.json
+++ b/test/oli/rendering/page/link_missing_href.json
@@ -1,0 +1,24 @@
+[
+  {
+    "type": "content",
+    "id": 2635423624,
+    "children": [
+      {
+        "type": "p",
+        "children": [
+          {
+            "text": "Here is a link to "
+          },
+          {
+            "type": "a",
+            "children": [
+              {
+                "text": "a website"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/test/oli/rendering/page/missing_language.json
+++ b/test/oli/rendering/page/missing_language.json
@@ -1,0 +1,22 @@
+[
+  {
+    "type": "content",
+    "id": 2635423624,
+    "children": [
+      {
+        "type": "code",
+        "id": 2652513352,
+        "children": [
+          {
+            "type": "code_line",
+            "children": [
+              {
+                "text": "this is text from the code block"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/test/oli/rendering/page/youtube_missing_src.json
+++ b/test/oli/rendering/page/youtube_missing_src.json
@@ -1,0 +1,21 @@
+[
+  {
+    "type": "content",
+    "id": 2635423624,
+    "children": [
+      {
+        "type": "youtube",
+        "id": 2652513352,
+        "children": []
+      },
+      {
+        "type": "p",
+        "children": [
+          {
+            "text": "some specific content"
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Closes #993 

This PR improves the robustness of server side content rendering. The root cause of this brittleness was the strict pattern matching for certain content elements in the content HTML renderer.  For instance the following was the only definition of the `code` function:

```
def code(
        %Context{} = _context,
        next,
        %{
          "language" => language
        } = attrs
      ) do
    figure(attrs, [
      ~s|<pre><code class="language-#{escape_xml!(language)}">|,
      next.(),
      "</code></pre>\n"
    ])
  end
```

So if some poorly formatted `code` element somehow gets into the system that does not have a `language` attribute (perhaps via ingestion, or a bug) the entire page rendering breaks, since no `code` function match can be made at run time. 

This PR addresses this by providing fallback implementations for all the functions that had this type of restrictive pattern match.  They were `a`, `code`, `img`, `audio`, `youtube`, `iframe`.  The fallback impl renders an error message and a log message, and most importantly, allows the rest of the page to render.   In the case of `a` and `code` it still renders what it can, but also logs the rendering error. 

Unit test coverage expanded to prove all of the above works. 

