### PR TITLE
[BUG FIX] Add missing database indexes, infra for flagging problematic queries 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### Enhancements
 
+- Add support for detecting problematic database queries
+
 ### Bug fixes
+
+- Add missing database indexes, rework resolver queries
 
 ## 0.9.0 (2021-4-22)
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -19,6 +19,8 @@ world_universities_and_domains_json =
 default_sha = if Mix.env() == :dev, do: "DEV BUILD", else: "UNKNOWN BUILD"
 
 config :oli,
+  problematic_query_detection: :disabled,
+  problematic_query_cost_threshold: 150,
   ecto_repos: [Oli.Repo],
   build: %{
     version: Mix.Project.config()[:version],

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -2,7 +2,12 @@ use Mix.Config
 
 config :oli,
   env: :dev,
-  problematic_query_detection: :disabled,
+  problematic_query_detection: System.get_env("DEV_PROBLEMATIC_QUERY_DETECTION_ENABLED", "false")
+    |> String.downcase()
+    |> (case do
+      "true" -> :enabled
+      _ -> :disabled
+    end),
   s3_media_bucket_name: "torus-media-dev",
   media_url: "torus-media-dev.s3.amazonaws.com",
   slack_webhook_url: System.get_env("SLACK_WEBHOOK_URL")

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -2,6 +2,7 @@ use Mix.Config
 
 config :oli,
   env: :dev,
+  problematic_query_detection: :disabled,
   s3_media_bucket_name: "torus-media-dev",
   media_url: "torus-media-dev.s3.amazonaws.com",
   slack_webhook_url: System.get_env("SLACK_WEBHOOK_URL")

--- a/lib/oli/publishing/authoring_resolver.ex
+++ b/lib/oli/publishing/authoring_resolver.ex
@@ -15,18 +15,15 @@ defmodule Oli.Publishing.AuthoringResolver do
   def from_resource_id(project_slug, resource_ids) when is_list(resource_ids) do
     fn ->
       revisions =
-        Repo.all(
-          from m in PublishedResource,
-            join: rev in Revision,
-            on: rev.id == m.revision_id,
-            join: p in Publication,
-            on: p.id == m.publication_id,
-            join: c in Project,
-            on: p.project_id == c.id,
-            where:
-              p.published == false and m.resource_id in ^resource_ids and c.slug == ^project_slug,
-            select: rev
+        from(m in PublishedResource,
+          join: rev in Revision,
+          on: rev.id == m.revision_id,
+          where:
+            m.publication_id in subquery(unpublished_publication(project_slug)) and
+              m.resource_id in ^resource_ids,
+          select: rev
         )
+        |> Repo.all()
 
       # order them according to the resource_ids
       map = Enum.reduce(revisions, %{}, fn e, m -> Map.put(m, e.resource_id, e) end)
@@ -43,12 +40,9 @@ defmodule Oli.Publishing.AuthoringResolver do
         from m in PublishedResource,
           join: rev in Revision,
           on: rev.id == m.revision_id,
-          join: p in Publication,
-          on: p.id == m.publication_id,
-          join: c in Project,
-          on: p.project_id == c.id,
           where:
-            p.published == false and m.resource_id == ^resource_id and c.slug == ^project_slug,
+            m.publication_id in subquery(unpublished_publication(project_slug)) and
+              m.resource_id == ^resource_id,
           select: rev
       )
     end
@@ -59,22 +53,20 @@ defmodule Oli.Publishing.AuthoringResolver do
   @impl Resolver
   def from_revision_slug(project_slug, revision_slug) do
     fn ->
-      Repo.one(
-        from rev in Revision,
-          join: r in Resource,
-          on: r.id == rev.resource_id,
-          join: m in PublishedResource,
-          on: m.resource_id == r.id,
-          join: rev2 in Revision,
-          on: m.revision_id == rev2.id,
-          join: p in Publication,
-          on: p.id == m.publication_id,
-          join: c in Project,
-          on: p.project_id == c.id,
-          where: p.published == false and rev.slug == ^revision_slug and c.slug == ^project_slug,
-          limit: 1,
-          select: rev2
+      from(rev in Revision,
+        join: r in Resource,
+        on: r.id == rev.resource_id,
+        join: m in PublishedResource,
+        on: m.resource_id == r.id,
+        join: rev2 in Revision,
+        on: m.revision_id == rev2.id,
+        where:
+          m.publication_id in subquery(unpublished_publication(project_slug)) and
+            rev.slug == ^revision_slug,
+        limit: 1,
+        select: rev2
       )
+      |> Repo.one()
     end
     |> run()
     |> emit([:oli, :resolvers, :authoring], :duration)
@@ -98,19 +90,19 @@ defmodule Oli.Publishing.AuthoringResolver do
   @impl Resolver
   def root_container(project_slug) do
     fn ->
-      Repo.one(
-        from m in PublishedResource,
-          join: rev in Revision,
-          on: rev.id == m.revision_id,
-          join: p in Publication,
-          on: p.id == m.publication_id,
-          join: c in Project,
-          on: p.project_id == c.id,
-          where:
-            p.published == false and m.resource_id == p.root_resource_id and
-              c.slug == ^project_slug,
-          select: rev
+      from(m in PublishedResource,
+        join: rev in Revision,
+        on: rev.id == m.revision_id,
+        join: p in Publication,
+        on: p.id == m.publication_id,
+        join: c in Project,
+        on: p.project_id == c.id,
+        where:
+          p.published == false and m.resource_id == p.root_resource_id and
+            c.slug == ^project_slug,
+        select: rev
       )
+      |> Repo.one()
     end
     |> run()
     |> emit([:oli, :resolvers, :authoring], :duration)
@@ -125,20 +117,15 @@ defmodule Oli.Publishing.AuthoringResolver do
     container_id = Oli.Resources.ResourceType.get_id_by_type("container")
 
     fn ->
-      Repo.all(
-        from m in PublishedResource,
-          join: rev in Revision,
-          on: rev.id == m.revision_id,
-          join: p in Publication,
-          on: p.id == m.publication_id,
-          join: c in Project,
-          on: p.project_id == c.id,
-          where:
-            p.published == false and
-              (rev.resource_type_id == ^page_id or rev.resource_type_id == ^container_id) and
-              c.slug == ^project_slug,
-          select: rev
+      from(m in PublishedResource,
+        join: rev in Revision,
+        on: rev.id == m.revision_id,
+        where:
+          m.publication_id in subquery(unpublished_publication(project_slug)) and
+            (rev.resource_type_id == ^page_id or rev.resource_type_id == ^container_id),
+        select: rev
       )
+      |> Repo.all()
     end
     |> run()
     |> emit([:oli, :resolvers, :authoring], :duration)
@@ -169,5 +156,14 @@ defmodule Oli.Publishing.AuthoringResolver do
     end
     |> run()
     |> emit([:oli, :resolvers, :authoring], :duration)
+  end
+
+  defp unpublished_publication(project_slug) do
+    from(p in Publication,
+      join: c in Project,
+      on: p.project_id == c.id,
+      where: p.published == false and c.slug == ^project_slug,
+      select: p.id
+    )
   end
 end

--- a/lib/oli/repo.ex
+++ b/lib/oli/repo.ex
@@ -2,4 +2,22 @@ defmodule Oli.Repo do
   use Ecto.Repo,
     otp_app: :oli,
     adapter: Ecto.Adapters.Postgres
+
+  @impl true
+  def prepare_query(:update_all, query, opts) do
+    # queries that are "update_all" operations cannot be explained with this current impl
+    {query, opts}
+  end
+
+  @impl true
+  def prepare_query(_operation, query, opts) do
+    # Attempt to guarantee that we do not ever enable problematic query detection in production
+    if Application.fetch_env!(:oli, :env) != :prod and
+         Application.fetch_env!(:oli, :problematic_query_detection) == :enabled do
+      threshold = Application.fetch_env!(:oli, :problematic_query_cost_threshold)
+      Oli.Utils.Database.flag_problem_queries(query, threshold)
+    end
+
+    {query, opts}
+  end
 end

--- a/lib/oli/utils/database.ex
+++ b/lib/oli/utils/database.ex
@@ -68,7 +68,7 @@ defmodule Oli.Utils.Database do
 
   @doc """
   Logs as a warning the query and stacktrace of the caller if the query contains a sequential
-  table scan or if the query exceeds a maxiumum cost threshold.
+  table scan or if the query equals or exceeds a cost threshold.
   """
   def flag_problem_queries(query, cost_threshold) do
     result = explain(query, log_output: false)

--- a/lib/oli/utils/database.ex
+++ b/lib/oli/utils/database.ex
@@ -7,12 +7,9 @@ defmodule Oli.Utils.Database do
 
     sql = "EXPLAIN (#{analyze_to_sql(opts[:analyze])}, #{format_to_sql(opts[:format])}) #{query}"
 
-    {:error, explain} =
-      Repo.transaction(fn ->
-        Repo
-        |> Ecto.Adapters.SQL.query!(sql, params)
-        |> Repo.rollback()
-      end)
+    explain =
+      Repo
+      |> Ecto.Adapters.SQL.query!(sql, params)
 
     if opts[:log_output] do
       log_output(explain, opts[:format])

--- a/lib/oli/utils/db_seeder.ex
+++ b/lib/oli/utils/db_seeder.ex
@@ -547,7 +547,7 @@ defmodule Oli.Seeder do
     {:ok, container_revision} =
       Oli.Resources.update_revision(container_revision, %{children: children})
 
-    create_published_resource(publication, container_resource, container_revision)
+    Publishing.upsert_published_resource(publication, container_revision)
 
     Map.put(map, :container, %{resource: container_resource, revision: container_revision})
   end

--- a/lib/oli/utils/explain.ex
+++ b/lib/oli/utils/explain.ex
@@ -1,0 +1,63 @@
+defmodule Oli.Utils.Database do
+  alias Oli.Repo
+  require Logger
+
+  def explain(query, opts \\ []) do
+    opts = put_defaults(opts)
+
+    {sql, params} = Ecto.Adapters.SQL.to_sql(opts[:op], Repo, query)
+
+    sql = "EXPLAIN (#{analyze_to_sql(opts[:analyze])}, #{format_to_sql(opts[:format])}) #{sql}"
+
+    {:error, explain} =
+      Repo.transaction(fn ->
+        Repo
+        |> Ecto.Adapters.SQL.query!(sql, params)
+        |> Repo.rollback()
+      end)
+
+    if opts[:log_output] do
+      log_output(explain, opts[:format])
+      query
+    else
+      explain
+    end
+  end
+
+  defp put_defaults(opts) do
+    opts
+    |> Keyword.put_new(:op, :all)
+    |> Keyword.put_new(:format, :json)
+    |> Keyword.put_new(:analyze, false)
+    |> Keyword.put_new(:log_output, true)
+  end
+
+  defp log_output(results, :text) do
+    results
+    |> Map.get(:rows)
+    |> Enum.join("\n")
+    |> Logger.warn()
+  end
+
+  defp log_output(results, :json) do
+    results
+    |> Map.get(:rows)
+    |> List.first()
+    |> Jason.encode!(pretty: true)
+    |> Logger.warn()
+  end
+
+  defp log_output(results, :yaml) do
+    results
+    |> Map.get(:rows)
+    |> List.first()
+    |> Logger.warn()
+  end
+
+  defp format_to_sql(:text), do: "FORMAT TEXT"
+  defp format_to_sql(:json), do: "FORMAT JSON"
+  defp format_to_sql(:yaml), do: "FORMAT YAML"
+
+  defp analyze_to_sql(true), do: "ANALYZE true"
+  defp analyze_to_sql(false), do: "ANALYZE false"
+end

--- a/oli.example.env
+++ b/oli.example.env
@@ -66,3 +66,6 @@ SLACK_WEBHOOK_URL=your_slack_webhook_url
 ## Path to custom SSL crt and key files. If omitted, a default non-secure one will be used (compile-time config)
 # SSL_CERT_PATH=
 # SSL_KEY_PATH=
+
+## Enable query analyzer in development (compile-time config, only valid is dev environment)
+# DEV_PROBLEMATIC_QUERY_DETECTION_ENABLED=false

--- a/priv/repo/migrations/20210423011451_add_indices.exs
+++ b/priv/repo/migrations/20210423011451_add_indices.exs
@@ -1,0 +1,10 @@
+defmodule Oli.Repo.Migrations.AddIndices do
+  use Ecto.Migration
+
+  def change do
+    create index(:publications, [:published, :project_id])
+    create index(:published_resources, [:publication_id])
+    create index(:published_resources, [:resource_id])
+    create unique_index(:published_resources, [:publication_id, :resource_id, :revision_id], name: :index_published_resources)
+  end
+end


### PR DESCRIPTION
This PR does two things:

1. It addresses the problem of a large amount of sequential scans being performed on the `published_resources` table by adding some necessary database indexes and by optimizing the queries in `DeliveryResolver` and `AuthoringResolver`.
2. It adds developer-oriented support for flagging as a log warning "problematic queries".   

The problematic query detection impl works by intercepting all queries flowing through `Oli.Repo` via the `prepare_query` override.  If the `:problematic_query_detection` flag is set to `:enabled` (and you are not running in production), the query will first be explained and analyzed using the `"EXPLAIN ANALYZE true (...sql)"` sql. After explained, that JSON structure is traversed to find two different problems: 
1. Steps that involve sequential table scans
2. Any query whose total compute cost exceeds some threshold value (currently set to 150).

The guts of the explain impl was lifted from `revelrylabs/ecto_explain`, after I was unable to get it to work in its intended fashion (via `use Ecto.Explain` macro)

Running Torus with problematic query detection enabled, one can see many queries that are performing full scans.  We should follow up this work with work to address some of those. 
