### PR TITLE
Chrome free pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
         run: set -a;source oli.env && mix clean && mix compile --warnings-as-errors
 
       - name: ▶️ Run tests
-        run: set -a;source oli.env && mix coveralls.github
+        run: set -a;source oli.env && mix test
 
   ts-build-test:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Enhancements
 
+- Allow adaptive pages to render without application chrome
+
 ### Bug fixes
 
 ## 0.9.0 (2021-4-22)

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -47,7 +47,13 @@ defmodule OliWeb.PageDeliveryController do
          section_slug,
          _
        ) do
-    conn = put_root_layout(conn, {OliWeb.LayoutView, "page.html"})
+    layout =
+      case Map.get(context.page.content, "displayApplicationChrome", true) do
+        true -> "page.html"
+        false -> "chromeless.html"
+      end
+
+    conn = put_root_layout(conn, {OliWeb.LayoutView, layout})
     user = conn.assigns.current_user
 
     resource_attempt = Enum.at(context.resource_attempts, 0)
@@ -58,6 +64,7 @@ defmodule OliWeb.PageDeliveryController do
       |> Jason.encode()
 
     render(conn, "advanced_delivery.html", %{
+      additional_stylesheets: Map.get(context.page.content, "additionalStylesheets", []),
       resource_attempt_guid: resource_attempt.attempt_guid,
       resource_attempt_state: resource_attempt_state,
       activity_guid_mapping: activity_guid_mapping,
@@ -86,7 +93,6 @@ defmodule OliWeb.PageDeliveryController do
          section_slug,
          _
        ) do
-
     # Only consider graded attempts
     resource_attempts = Enum.filter(resource_attempts, fn a -> a.revision.graded == true end)
 

--- a/lib/oli_web/live/curriculum/container/container_live.ex
+++ b/lib/oli_web/live/curriculum/container/container_live.ex
@@ -234,8 +234,16 @@ defmodule OliWeb.Curriculum.ContainerLive do
       children: [],
       content:
         case type do
-          "Adaptive" -> %{"model" => [], "advancedAuthoring" => true, "advancedDelivery" => true}
-          _ -> %{"model" => []}
+          "Adaptive" ->
+            %{
+              "model" => [],
+              "advancedAuthoring" => true,
+              "advancedDelivery" => true,
+              "displayApplicationChrome" => false
+            }
+
+          _ ->
+            %{"model" => []}
         end,
       title:
         case type do

--- a/lib/oli_web/templates/layout/chromeless.html.eex
+++ b/lib/oli_web/templates/layout/chromeless.html.eex
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en" class="delivery">
+  <head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <%= get_title(assigns) %>
+    <%= additional_stylesheets(assigns) %>
+    <%= csrf_meta_tag() %>
+    <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/app.js") %>"></script>
+  </head>
+  <body>
+      <%= Map.get(assigns, :inner_layout) || @inner_content %>
+  </body>
+</html>

--- a/lib/oli_web/views/layout_view.ex
+++ b/lib/oli_web/views/layout_view.ex
@@ -41,6 +41,7 @@ defmodule OliWeb.LayoutView do
   """
   def additional_stylesheets(assigns) do
     Map.get(assigns, :additional_stylesheets, [])
+    |> URI.encode()
     |> Enum.map(fn url -> "\n<link rel=\"stylesheet\" href=\"#{url}\">" end)
     |> raw()
   end

--- a/lib/oli_web/views/layout_view.ex
+++ b/lib/oli_web/views/layout_view.ex
@@ -35,6 +35,16 @@ defmodule OliWeb.LayoutView do
     )
   end
 
+  @doc """
+  Allows a delivery content template to specify any number of additional stylesheets, via URLs,
+  to be included in the head portion of the document.
+  """
+  def additional_stylesheets(assigns) do
+    Map.get(assigns, :additional_stylesheets, [])
+    |> Enum.map(fn url -> "\n<link rel=\"stylesheet\" href=\"#{url}\">" end)
+    |> raw()
+  end
+
   def active_or_nil(assigns) do
     get_in(assigns, [Access.key(:active, nil)])
   end


### PR DESCRIPTION
Some Adaptive Pages need to exercise full control over the CSS of the page, and to have nothing else rendered as "application chrome" by Torus.  These types of pages may provide their own page-to-page navigation. 

This PR introduces a top-level page content attribute `displayApplicationChrome`, that if set to `false` will allow the adaptive page to render without any Torus application chrome around it.  This attribute defaults to `true` if not set. 

Another top-level attribute `additionalStylesheets` is a collection of arbitrary style sheet URLs, that if set, will get injected into the `<head>` portion of the rendered page. 