### PR TITLE
[FEATURE] Allow previewing for advanced authoring into chromeless view

### DIFF
--- a/assets/src/apps/authoring/Authoring.tsx
+++ b/assets/src/apps/authoring/Authoring.tsx
@@ -1,13 +1,31 @@
 import React from 'react';
 
 export interface AuthoringProps {
-  content?: any;
+  isAdmin: boolean;
+  projectSlug: string;
+  revisionSlug: string;
+  content: any;
 }
 
+
 export const Authoring : React.FC<AuthoringProps> = (props: AuthoringProps) => {
+
+  const url = `/project/${props.projectSlug}/preview/${props.revisionSlug}`;
+  const windowName = `preview-${props.projectSlug}`;
+
+  const PreviewButton = () => (
+    <a
+      className="btn btn-sm btn-outline-primary ml-3"
+      onClick={() => window.open(url, windowName)}
+    >
+      Preview <i className="las la-external-link-alt ml-1"></i>
+    </a>
+  );
+
   return (
     <div>
       <h3>Advanced Authoring Mode</h3>
+      <PreviewButton/>
       <div>{JSON.stringify(props.content)}</div>
     </div>
   );

--- a/lib/oli_web/templates/layout/chromeless.html.eex
+++ b/lib/oli_web/templates/layout/chromeless.html.eex
@@ -7,7 +7,6 @@
     <%= get_title(assigns) %>
     <%= additional_stylesheets(assigns) %>
     <%= csrf_meta_tag() %>
-    <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/app.js") %>"></script>
   </head>
   <body>
       <%= Map.get(assigns, :inner_layout) || @inner_content %>

--- a/lib/oli_web/templates/page_delivery/advanced_delivery.html.eex
+++ b/lib/oli_web/templates/page_delivery/advanced_delivery.html.eex
@@ -34,6 +34,7 @@
     activityGuidMapping: <%= raw(@activity_guid_mapping) %>,
     previousPageURL,
     nextPageURL,
+    previewMode: false
   };
 
   window.oliMountApplication(document.getElementById('delivery_container'), params);

--- a/lib/oli_web/templates/resource/advanced_page_preview.html.eex
+++ b/lib/oli_web/templates/resource/advanced_page_preview.html.eex
@@ -1,0 +1,27 @@
+<script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/delivery.js") %>"></script>
+
+<%= for script <- @scripts do %>
+  <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/" <> script) %>"></script>
+<% end %>
+
+<div id="delivery_container" class="container"></div>
+
+<script>
+  window.userToken = "<%= assigns[:user_token] %>";
+
+  const params = {
+    resourceId: <%= @revision.resource_id %>,
+    sectionSlug: "<%= @project_slug %>",
+    userId: <%= @user.id %>,
+    pageSlug: "<%= @revision.slug %>",
+    content: "<%= Jason.encode!(@revision.content) |> Base.encode64() %>",
+    resourceAttemptState: null,
+    resourceAttemptGuid: null,
+    activityGuidMapping: null,
+    previousPageURL: null,
+    nextPageURL: null,
+    previewMode: true,
+  };
+
+  window.oliMountApplication(document.getElementById('delivery_container'), params);
+</script>

--- a/lib/oli_web/views/layout_view.ex
+++ b/lib/oli_web/views/layout_view.ex
@@ -11,6 +11,7 @@ defmodule OliWeb.LayoutView do
       account_linked?: 1,
       logo_link_path: 1
     ]
+
   import Oli.Branding
 
   alias Oli.Publishing.AuthoringResolver
@@ -40,7 +41,7 @@ defmodule OliWeb.LayoutView do
   """
   def additional_stylesheets(assigns) do
     Map.get(assigns, :additional_stylesheets, [])
-    |> URI.encode()
+    |> Enum.map(&URI.encode(&1))
     |> Enum.map(fn url -> "\n<link rel=\"stylesheet\" href=\"#{url}\">" end)
     |> raw()
   end
@@ -92,5 +93,4 @@ defmodule OliWeb.LayoutView do
   def render_layout(layout, assigns, do: content) do
     render(layout, Map.put(assigns, :inner_layout, content))
   end
-
 end


### PR DESCRIPTION
This PR adds the ability for advanced authoring to preview a lesson by launching a chromeless window that bootstraps the Delivery app, with a new `previewMode` attribute present and set to `true`. 

To exercise this functionality, open the authoring app for an adaptive page.  There is now a "Preview" button on it that when clicked will open the preview in a named window tab.  

I fixed a problem with how the `additional_stylesheets` was implemented. 