### PR TITLE
[BUG FIX] set all project statuses to active

### DIFF
--- a/priv/repo/migrations/20210506203507_fix_project_status.exs
+++ b/priv/repo/migrations/20210506203507_fix_project_status.exs
@@ -1,0 +1,14 @@
+defmodule Oli.Repo.Migrations.FixPackageStatus do
+  use Ecto.Migration
+
+  import Ecto.Query, warn: false
+
+  def change do
+    flush()
+
+    from(p in "projects",
+      where: is_nil(p.status)
+    )
+    |> Oli.Repo.update_all(set: [status: "active"])
+  end
+end


### PR DESCRIPTION
This PR fixes a problem where the migration from the Delete Package PR did not account for existing project records, whose status fields are now null.  This is breaking project access for those projects since that plug explicitly checks for the value of `:active` in that field. 