### PR TITLE
[BUG FIX] Fix firefox selection, focus problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fix internal links in page preview mode
 - Fix projects view project card styling
 - Fix problem with inputs causing clipping in Firefox
+- Fix problem with difficulty selecting and focusing in Firefox
 
 ## 0.9.0 (2021-4-22)
 

--- a/assets/src/components/editing/editor/Editor.tsx
+++ b/assets/src/components/editing/editor/Editor.tsx
@@ -36,6 +36,12 @@ export type EditorProps = {
   className?: string;
 };
 
+// Necessary to work around FireFox focus and selection issues with Slate
+// https://github.com/ianstormtaylor/slate/issues/1984
+function emptyOnFocus() {
+  return;
+}
+
 function areEqual(prevProps: EditorProps, nextProps: EditorProps) {
   return (
     prevProps.editMode === nextProps.editMode &&
@@ -112,6 +118,7 @@ export const Editor = React.memo((props: EditorProps) => {
         editor={editor}
         value={props.value}
         onChange={onChange}
+        onFocus={emptyOnFocus}
         onPaste={async (
           e: React.ClipboardEvent<HTMLDivElement>,
           editor: SlateEditor,


### PR DESCRIPTION
In attempting to reproduce another issue, I discovered an issue that when using Firefox, one is almost unable to do basic focus changes via mouse clicks in Slate editors.  Some quick research turned up a solution in the Slate GH: https://github.com/ianstormtaylor/slate/issues/1984#issuecomment-466992295

This PR applies that workaround. I've interactively tested editing with Firefox, Chrome and Safari and everything this to be working. 

Note, this PR does not address https://github.com/Simon-Initiative/oli-torus/issues/520

