### PR TITLE
fix an issue were empty containers show as pages in overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Fix projects view project card styling
 - Fix problem with inputs causing clipping in Firefox
 - Fix problem with difficulty selecting and focusing in Firefox
+- Fix problem where containers with no children were rendered as pages in delivery
 
 ## 0.9.0 (2021-4-22)
 

--- a/assets/styles/delivery/main.scss
+++ b/assets/styles/delivery/main.scss
@@ -15,13 +15,30 @@ body {
   font-size: $font-size-base;
   padding-bottom: $footer-height;
 
-  h1, .h1 { @include font-size($h1-font-size); }
-  h2, .h2 { @include font-size($h2-font-size); }
-  h3, .h3 { @include font-size($h3-font-size); }
-  h4, .h4 { @include font-size($h4-font-size); }
-  h5, .h5 { @include font-size($h5-font-size); }
-  h6, .h6 { @include font-size($h6-font-size); }
-
+  h1,
+  .h1 {
+    @include font-size($h1-font-size);
+  }
+  h2,
+  .h2 {
+    @include font-size($h2-font-size);
+  }
+  h3,
+  .h3 {
+    @include font-size($h3-font-size);
+  }
+  h4,
+  .h4 {
+    @include font-size($h4-font-size);
+  }
+  h5,
+  .h5 {
+    @include font-size($h5-font-size);
+  }
+  h6,
+  .h6 {
+    @include font-size($h6-font-size);
+  }
 }
 
 body.modal-open {
@@ -29,7 +46,7 @@ body.modal-open {
 }
 
 .oli-logo {
-  font-family: 'Open Sans', sans-serif;
+  font-family: "Open Sans", sans-serif;
 }
 
 form .form-label-group .help-block {
@@ -38,4 +55,26 @@ form .form-label-group .help-block {
 
 .custom-select {
   -webkit-appearance: none;
+}
+
+.course-outline {
+  .container-title {
+    font-weight: 500;
+  }
+
+  .page {
+    border-bottom: none;
+  }
+
+  .page:first-child {
+    border-top-left-radius: $list-group-border-radius;
+    border-top-right-radius: $list-group-border-radius;
+  }
+
+  .page:last-child {
+    border-bottom-left-radius: $list-group-border-radius;
+    border-bottom-right-radius: $list-group-border-radius;
+    margin-bottom: 20px;
+    border-bottom: $list-group-border-width solid $list-group-border-color;
+  }
 }

--- a/lib/oli_web/templates/page_delivery/_link_assessment.html.eex
+++ b/lib/oli_web/templates/page_delivery/_link_assessment.html.eex
@@ -1,4 +1,4 @@
-<% link_class = "list-group-item list-group-item-action flex-column align-items-start " <> if @active_page == @node.revision.slug, do: "active", else: "" %>
+<% link_class = "page list-group-item list-group-item-action flex-column align-items-start " <> if @active_page == @node.revision.slug, do: "active", else: "" %>
 <%= link to: Routes.page_delivery_path(@conn, :page, @section_slug, @node.revision.slug), class: link_class do %>
   <div class="d-flex w-100 justify-content-between">
     <span class="page-title">

--- a/lib/oli_web/templates/page_delivery/_link_page.html.eex
+++ b/lib/oli_web/templates/page_delivery/_link_page.html.eex
@@ -1,4 +1,4 @@
-<% link_class = "list-group-item list-group-item-action " <> if @active_page == @node.revision.slug, do: "active", else: "" %>
+<% link_class = "page list-group-item list-group-item-action " <> if @active_page == @node.revision.slug, do: "active", else: "" %>
 <%= link to: Routes.page_delivery_path(@conn, :page, @section_slug, @node.revision.slug), class: link_class do %>
   <div class="d-flex w-100 justify-content-between">
     <span class="page-title">

--- a/lib/oli_web/templates/page_delivery/_outline.html.eex
+++ b/lib/oli_web/templates/page_delivery/_outline.html.eex
@@ -1,10 +1,11 @@
 <%= for node <- @nodes do %>
-  <%= if !Enum.empty?(node.children) do
-    render "container.html", node: node, conn: @conn, section_slug: @section_slug, summary: @summary, active_page: @active_page
-  else
-    case node.revision.graded do
-      false -> render "_link_page.html", node: node, conn: @conn, section_slug: @section_slug, summary: @summary, active_page: @active_page
-      true -> render "_link_assessment.html", node: node, conn: @conn, section_slug: @section_slug, summary: @summary, active_page: @active_page
-    end
-  end %>
+  <%= if container?(node.revision) do %>
+    <%= render "container.html", node: node, conn: @conn, section_slug: @section_slug, summary: @summary, active_page: @active_page %>
+  <% else %>
+    <%= if node.revision.graded do %>
+      <%= render "_link_assessment.html", node: node, conn: @conn, section_slug: @section_slug, summary: @summary, active_page: @active_page %>
+    <% else %>
+      <%= render "_link_page.html", node: node, conn: @conn, section_slug: @section_slug, summary: @summary, active_page: @active_page %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/lib/oli_web/templates/page_delivery/container.html.eex
+++ b/lib/oli_web/templates/page_delivery/container.html.eex
@@ -1,5 +1,9 @@
-<div class="mb-2 mt-2"><%= container_title(@node) %></div>
+<div class="container-title mb-2"><%= container_title(@node) %></div>
 
 <div class="course-outline" style="padding-left: <%= @node.numbering.level * 20 %>px">
-  <%= render "_outline.html", nodes: @node.children, conn: @conn, section_slug: @section_slug, summary: @summary, active_page: nil %>
+  <%= if Enum.empty?(@node.children) do %>
+    <span class="text-secondary">There are no items</span>
+  <% else %>
+    <%= render "_outline.html", nodes: @node.children, conn: @conn, section_slug: @section_slug, summary: @summary, active_page: nil %>
+  <% end %>
 </div>

--- a/lib/oli_web/views/page_delivery_view.ex
+++ b/lib/oli_web/views/page_delivery_view.ex
@@ -10,8 +10,8 @@ defmodule OliWeb.PageDeliveryView do
     ContextRoles.has_role?(user, section_slug, ContextRoles.get_role(:context_instructor))
   end
 
-  def container?(page) do
-    ResourceType.get_type_by_id(page.resource_type_id) == "container"
+  def container?(rev) do
+    ResourceType.get_type_by_id(rev.resource_type_id) == "container"
   end
 
   def container_title(hierarchy_node) do


### PR DESCRIPTION
This PR fixes an issue were empty containers show as pages in overview. This is a non-obvious issue since most containers usually have children, but in the case which they don't, they were being rendered as pages. This PR fixes the issue by properly checking the resource type instead of for children.

Closes #1054