### PR TITLE
fix an issue with indices on reorder item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Fix problem with difficulty selecting and focusing in Firefox
 - Fix problem where containers with no children were rendered as pages in delivery
 - Fix some style inconsistencies in delivery and dark mode
+- Fix an issue where reordering a curriculum item could result in incorrect n-1 position
 
 ## 0.9.0 (2021-4-22)
 

--- a/lib/oli_web/live/curriculum/container/container_live.html.leex
+++ b/lib/oli_web/live/curriculum/container/container_live.html.leex
@@ -60,7 +60,7 @@
             <p>There's nothing here.</p>
           </div>
         <% end %>
-        <%= for {child, index} <- Enum.filter(@children, fn c -> c.slug != @dragging end) |> Enum.with_index() do %>
+        <%= for {child, index} <- Enum.with_index(@children) |> Enum.filter(fn {c, _i} -> c.slug != @dragging end) do %>
           <%= live_component @socket, DropTarget, id: index, index: index %>
           <%= live_component @socket, EntryLive, %{
                   id: child.slug,


### PR DESCRIPTION
This PR fixes an issue where reordering an item to a greater position resulted in incorrect placement one less than desired index. This was because the item being moved was being filtered out before assigning an index. The fix here is to assign item indices before filtering out the item being moved.

![2021-05-18 14-31-07 2021-05-18 14_31_54 2021-05-18 14_36_47](https://user-images.githubusercontent.com/6248894/118720231-9b40ac00-b7e6-11eb-9ad8-42f39dd69556.gif)
