### PR TITLE
Deploy loadtest

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -7,6 +7,7 @@ on:
     tags:
       - package           # manually trigger a package build (no deployment)
       - deploy-test       # manually trigger build and deploy to test
+      - deploy-loadtest   # manually trigger build and deploy to loadtest
 
 jobs:
   package-deploy:
@@ -20,7 +21,7 @@ jobs:
         run: |
           echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
           echo "::set-output name=app_version::$(cat mix.exs | grep version | sed -e 's/.*version: "\(.*\)",/\1/')"
-          echo "::set-output name=deploy_host::tokamak.oli.cmu.edu"
+          echo "::set-output name=deploy_host::$(if [[ ${{ github.event.ref }} =~ ^refs/tags/deploy-loadtest$ ]] ; then echo loadtest.oli.cmu.edu ; else echo tokamak.oli.cmu.edu ; fi)"
           echo "::set-output name=workspace::$GITHUB_WORKSPACE"
 
       - name: 📦 Package
@@ -47,7 +48,7 @@ jobs:
 
       - name: 🚢💰 Deploy to test using SSH
         uses: fifsky/ssh-action@master
-        if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/tags/deploy-test' }}
+        if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/tags/deploy-test' || github.ref == 'refs/tags/deploy-loadtest' }}
         with:
           command: |
             cd /torus

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -2,6 +2,15 @@
 # from environment variables at runtime
 import Config
 
+from_boolean_env = fn key, default ->
+  System.get_env(key, default)
+  |> String.downcase()
+  |> case do
+    "true" -> :enabled
+    _ -> :disabled
+  end
+end
+
 database_url =
   System.get_env("DATABASE_URL") ||
     raise """
@@ -42,7 +51,8 @@ config :oli,
   email_from_name: System.get_env("EMAIL_FROM_NAME", "OLI Torus"),
   email_from_address: System.get_env("EMAIL_FROM_ADDRESS", "admin@example.edu"),
   email_reply_to: System.get_env("EMAIL_REPLY_TO", "admin@example.edu"),
-  slack_webhook_url: System.get_env("SLACK_WEBHOOK_URL")
+  slack_webhook_url: System.get_env("SLACK_WEBHOOK_URL"),
+  load_testing_mode: from_boolean_env.("LOAD_TESTING_MODE", "false")
 
 # Configure reCAPTCHA
 config :oli, :recaptcha,

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,17 +1,7 @@
 use Mix.Config
 
-from_boolean_env = fn key, default ->
-  System.get_env(key, default)
-  |> String.downcase()
-  |> case do
-    "true" -> :enabled
-    _ -> :disabled
-  end
-end
-
 config :oli,
   env: :test,
-  load_testing_mode: from_boolean_env.("LOAD_TESTING_MODE", "false"),
   s3_media_bucket_name: "torus-media-test",
   media_url: "d1od6xouqrpl5k.cloudfront.net",
   http_client: Oli.Test.MockHTTP,


### PR DESCRIPTION
This PR adds a deployment task for the `deploy-loadtest` tag which will trigger a deployment of the tagged ref to loadtest.oli.cmu.edu.

This PR also includes a fix to the `load_testing_mode` config to make it runtime configurable.