### PR TITLE
[BUG FIX] Handle poorly formatted data during ingest

### DIFF
--- a/assets/src/components/resource/resourceEditor/ResourceEditor.tsx
+++ b/assets/src/components/resource/resourceEditor/ResourceEditor.tsx
@@ -43,6 +43,7 @@ import {
   unregisterWindowBlur,
 } from './listeners';
 import { loadPreferences } from 'state/preferences';
+import guid from 'utils/guid';
 
 export interface ResourceEditorProps extends ResourceContext {
   editorMap: ActivityEditorMap; // Map of activity types to activity elements
@@ -81,7 +82,14 @@ function prepareSaveFn(
 // of this resource is empty
 function withDefaultContent(content: ResourceContent[]): [string, ResourceContent][] {
   if (content.length > 0) {
-    return content.map((contentItem) => [contentItem.id, contentItem]);
+    return content.map((contentItem) => {
+      // There is the possibility that ingested course material did not specify the
+      // id attribute. If so, we will assign one here that will get persisted once the user
+      // edits the page.
+      contentItem =
+        contentItem.id === undefined ? Object.assign({}, contentItem, { id: guid() }) : contentItem;
+      return [contentItem.id, contentItem];
+    });
   }
   const defaultContent = createDefaultStructuredContent();
   return [[defaultContent.id, defaultContent]];

--- a/lib/oli/interop/rewire_links.ex
+++ b/lib/oli/interop/rewire_links.ex
@@ -1,0 +1,70 @@
+defmodule Oli.Ingest.RewireLinks do
+  alias Oli.Publishing.ChangeTracker
+
+  # Any internal hyperlinks have to be rewired to point to the new resource_id of the
+  # page being linked to.  This function takes all pages and rewires
+  # all links that it finds in their contents, only saving new revisions for those that
+  # have a rewired link.
+  def rewire_all_hyperlinks(page_map, project) do
+    Map.values(page_map)
+    |> Enum.map(fn revision ->
+      rewire_hyperlinks(revision, page_map, project.slug)
+    end)
+
+    {:ok, page_map}
+  end
+
+  defp rewire_hyperlinks(revision, page_map, course) do
+    link_builder = fn id ->
+      case Map.get(page_map, id) do
+        nil -> "/course/link/#{course}"
+        %{slug: slug} -> "/course/link/#{slug}"
+      end
+    end
+
+    case rewire(revision.content, link_builder) do
+      {true, content} ->
+        ChangeTracker.track_revision(course, revision, %{content: content})
+
+      {false, _} ->
+        {:ok, revision}
+    end
+  end
+
+  defp rewire(items, link_builder) when is_list(items) do
+    results = Enum.map(items, fn i -> rewire(i, link_builder) end)
+
+    children = Enum.map(results, fn {_, c} -> c end)
+
+    changed =
+      Enum.map(results, fn {changed, _} -> changed end) |> Enum.any?(fn c -> c == true end)
+
+    {changed, children}
+  end
+
+  defp rewire(%{"type" => "a", "idref" => idref, "children" => children}, link_builder) do
+    {true, %{"type" => "a", "children" => children, "href" => link_builder.(idref)}}
+  end
+
+  defp rewire(%{"model" => model} = item, link_builder) do
+    case rewire(model, link_builder) do
+      {true, model} -> {true, Map.put(item, "model", model)}
+      {false, _} -> {false, item}
+    end
+  end
+
+  defp rewire(%{"children" => children} = item, link_builder) do
+    results = Enum.map(children, fn i -> rewire(i, link_builder) end)
+
+    children = Enum.map(results, fn {_, c} -> c end)
+
+    changed =
+      Enum.map(results, fn {changed, _} -> changed end) |> Enum.any?(fn c -> c == true end)
+
+    {changed, Map.put(item, "children", children)}
+  end
+
+  defp rewire(item, _) do
+    {false, item}
+  end
+end

--- a/lib/oli/interop/scrub.ex
+++ b/lib/oli/interop/scrub.ex
@@ -1,0 +1,67 @@
+defmodule Oli.Interop.Scrub do
+  alias Oli.Resources.PageContent
+
+  @doc """
+  Content scrubbing routine to clean and adjust content found in ingested
+  pages and activities. Takes a input the content to scrub and returns
+  a tuple `{changes, scrubbed_content}` where `changes` is a list summarizing
+  all changes made and `scrubbed_content` is the mutated content.
+  """
+  def scrub(items) when is_list(items) do
+    {changes, items} =
+      Enum.map(items, fn i -> scrub(i) end)
+      |> Enum.unzip()
+
+    {List.flatten(changes), items}
+  end
+
+  # Ensure that code blocks only contain `code_line` as children.  If they contain
+  # anything else, extract all text from that child and convert the child to
+  # a code_line
+  def scrub(%{"type" => "code", "children" => children} = item) do
+    if Enum.any?(children, fn c ->
+         !Map.has_key?(c, "type") or Map.get(c, "type") != "code_line"
+       end) do
+      children = Enum.map(children, &to_code_line/1)
+      {["Adjusted code block contents"], Map.put(item, "children", children)}
+    else
+      {[], item}
+    end
+  end
+
+  def scrub(%{"model" => model} = item) do
+    {changes, model} = scrub(model)
+    {changes, Map.put(item, "model", model)}
+  end
+
+  def scrub(%{"children" => children} = item) do
+    {changes, children} = scrub(children)
+    {changes, Map.put(item, "children", children)}
+  end
+
+  def scrub(item) do
+    {[], item}
+  end
+
+  defp to_code_line(%{"type" => "code_line"} = item), do: item
+
+  defp to_code_line(item) do
+    %{
+      "type" => "code_line",
+      "children" => [
+        %{
+          "type" => "text",
+          "text" => extract_text(item)
+        }
+      ]
+    }
+  end
+
+  # From an arbitrary content element, recursively extract all "text" nodes, concatenating
+  # them together to form a singular string
+  defp extract_text(item) do
+    PageContent.map_reduce(item, "", fn e, text -> {e, text <> Map.get(e, "text", "")} end)
+    |> Tuple.to_list()
+    |> Enum.at(1)
+  end
+end

--- a/test/oli/delivery/attempts/scoring_test.exs
+++ b/test/oli/delivery/attempts/scoring_test.exs
@@ -1,5 +1,5 @@
 defmodule Oli.Delivery.Attempts.ScoringTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   alias Oli.Delivery.Attempts.Scoring
   alias Oli.Delivery.Attempts.Result
 

--- a/test/oli/interop/scrub_test.exs
+++ b/test/oli/interop/scrub_test.exs
@@ -1,0 +1,179 @@
+defmodule Oli.Interop.ScrubTest do
+  use ExUnit.Case, async: true
+
+  alias Oli.Interop.Scrub
+
+  # helper routine to traverse an arbitrary path through content
+  def traverse(content, path) do
+    String.split(path, " ")
+    |> Enum.reduce(content, fn step, current ->
+      case Integer.parse(step) do
+        {index, _} -> Enum.at(current, index)
+        :error -> Map.get(current, step)
+      end
+    end)
+  end
+
+  test "scrub with nothing to do" do
+    content = %{
+      "model" => [
+        %{
+          "type" => "content",
+          "children" => [%{"type" => "p", "children" => [%{"type" => "text", "text" => "Hello"}]}]
+        }
+      ]
+    }
+
+    {[], updated} = Scrub.scrub(content)
+
+    assert "Hello" == traverse(updated, "model 0 children 0 children 0 text")
+  end
+
+  test "scrub with a well formed code block" do
+    content = %{
+      "model" => [
+        %{
+          "type" => "content",
+          "children" => [
+            %{
+              "type" => "code",
+              "children" => [
+                %{"type" => "code_line", "children" => [%{"type" => "text", "text" => "Hello"}]},
+                %{"type" => "code_line", "children" => [%{"type" => "text", "text" => "There"}]}
+              ]
+            }
+          ]
+        }
+      ]
+    }
+
+    {[], updated} = Scrub.scrub(content)
+
+    assert "Hello" == traverse(updated, "model 0 children 0 children 0 children 0 text")
+    assert "There" == traverse(updated, "model 0 children 0 children 1 children 0 text")
+  end
+
+  test "scrub with report more than one change" do
+    content = %{
+      "model" => [
+        %{
+          "type" => "content",
+          "children" => [
+            %{
+              "type" => "code",
+              "children" => [
+                %{"type" => "p", "children" => [%{"type" => "text", "text" => "Hello"}]},
+                %{"type" => "code_line", "children" => [%{"type" => "text", "text" => "There"}]}
+              ]
+            },
+            %{
+              "type" => "code",
+              "children" => [
+                %{"type" => "p", "children" => [%{"type" => "text", "text" => "Hello"}]},
+                %{"type" => "code_line", "children" => [%{"type" => "text", "text" => "There"}]}
+              ]
+            }
+          ]
+        }
+      ]
+    }
+
+    {changes, _} = Scrub.scrub(content)
+
+    assert length(changes) == 2
+  end
+
+  test "scrub with a bad code block" do
+    content = %{
+      "model" => [
+        %{
+          "type" => "content",
+          "children" => [
+            %{
+              "type" => "code",
+              "children" => [
+                %{"type" => "p", "children" => [%{"type" => "text", "text" => "Hello"}]},
+                %{"type" => "p", "children" => [%{"type" => "text", "text" => "There"}]}
+              ]
+            }
+          ]
+        }
+      ]
+    }
+
+    {changes, updated} = Scrub.scrub(content)
+
+    assert length(changes) == 1
+    assert "Hello" == traverse(updated, "model 0 children 0 children 0 children 0 text")
+    assert "code_line" == traverse(updated, "model 0 children 0 children 0 type")
+    assert "There" == traverse(updated, "model 0 children 0 children 1 children 0 text")
+    assert "code_line" == traverse(updated, "model 0 children 0 children 1 type")
+  end
+
+  test "scrub with a one bad code block entry" do
+    content = %{
+      "model" => [
+        %{
+          "type" => "content",
+          "children" => [
+            %{
+              "type" => "code",
+              "children" => [
+                %{"type" => "code_line", "children" => [%{"type" => "text", "text" => "Hello"}]},
+                %{"type" => "p", "children" => [%{"type" => "text", "text" => "There"}]}
+              ]
+            }
+          ]
+        }
+      ]
+    }
+
+    {changes, updated} = Scrub.scrub(content)
+    assert length(changes) == 1
+    assert "Hello" == traverse(updated, "model 0 children 0 children 0 children 0 text")
+    assert "code_line" == traverse(updated, "model 0 children 0 children 0 type")
+    assert "There" == traverse(updated, "model 0 children 0 children 1 children 0 text")
+    assert "code_line" == traverse(updated, "model 0 children 0 children 1 type")
+  end
+
+  test "scrub deeply extracts text correctly" do
+    content = %{
+      "model" => [
+        %{
+          "type" => "content",
+          "children" => [
+            %{
+              "type" => "code",
+              "children" => [
+                %{
+                  "type" => "p",
+                  "children" => [
+                    %{"type" => "text", "text" => "This", "bold" => true},
+                    %{"type" => "text", "text" => " is "},
+                    %{
+                      "type" => "a",
+                      "children" => [
+                        %{"type" => "text", "text" => "deeply "},
+                        %{"type" => "text", "text" => "nested"},
+                        %{"type" => "text", "text" => " text"}
+                      ]
+                    },
+                    %{"type" => "text", "text" => " extracted correctly."}
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+
+    {changes, updated} = Scrub.scrub(content)
+    assert length(changes) == 1
+
+    assert "This is deeply nested text extracted correctly." ==
+             traverse(updated, "model 0 children 0 children 0 children 0 text")
+
+    assert "code_line" == traverse(updated, "model 0 children 0 children 0 type")
+  end
+end

--- a/test/oli/interop/scrub_test.exs
+++ b/test/oli/interop/scrub_test.exs
@@ -96,6 +96,15 @@ defmodule Oli.Interop.ScrubTest do
                updated,
                "model authoring parts 0 responses 0 feedback content 0 children 0 type"
              )
+
+    # verify that the nodes that did not specify ids had them assigned during scrubbing
+    assert traverse(updated, "model") |> Map.has_key?("id")
+    assert traverse(updated, "model stem") |> Map.has_key?("id")
+    assert traverse(updated, "model stem content 0") |> Map.has_key?("id")
+    assert traverse(updated, "model choices 0") |> Map.has_key?("id")
+    assert traverse(updated, "model authoring parts 0") |> Map.has_key?("id")
+    assert traverse(updated, "model authoring parts 0 responses 0") |> Map.has_key?("id")
+    assert traverse(updated, "model authoring parts 0 responses 0 feedback") |> Map.has_key?("id")
   end
 
   test "scrub with a well formed code block" do

--- a/test/oli/interop/scrub_test.exs
+++ b/test/oli/interop/scrub_test.exs
@@ -29,6 +29,75 @@ defmodule Oli.Interop.ScrubTest do
     assert "Hello" == traverse(updated, "model 0 children 0 children 0 text")
   end
 
+  test "scrub works on activities" do
+    content = %{
+      "model" => %{
+        "stem" => %{
+          "content" => [
+            %{
+              "type" => "code",
+              "children" => [
+                %{"type" => "p", "children" => [%{"type" => "text", "text" => "Hello"}]},
+                %{"type" => "code_line", "children" => [%{"type" => "text", "text" => "There"}]}
+              ]
+            }
+          ]
+        },
+        "choices" => [
+          %{
+            "content" => [
+              %{
+                "type" => "code",
+                "children" => [
+                  %{"type" => "p", "children" => [%{"type" => "text", "text" => "Hello"}]},
+                  %{"type" => "code_line", "children" => [%{"type" => "text", "text" => "There"}]}
+                ]
+              }
+            ]
+          }
+        ],
+        "authoring" => %{
+          "parts" => [
+            %{
+              "responses" => [
+                %{
+                  "feedback" => %{
+                    "content" => [
+                      %{
+                        "type" => "code",
+                        "children" => [
+                          %{
+                            "type" => "p",
+                            "children" => [%{"type" => "text", "text" => "Hello"}]
+                          },
+                          %{
+                            "type" => "code_line",
+                            "children" => [%{"type" => "text", "text" => "There"}]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+
+    {changes, updated} = Scrub.scrub(content)
+    assert length(changes) == 3
+    assert "code_line" == traverse(updated, "model stem content 0 children 0 type")
+    assert "code_line" == traverse(updated, "model choices 0 content 0 children 0 type")
+
+    assert "code_line" ==
+             traverse(
+               updated,
+               "model authoring parts 0 responses 0 feedback content 0 children 0 type"
+             )
+  end
+
   test "scrub with a well formed code block" do
     content = %{
       "model" => [


### PR DESCRIPTION
This PR adds support for cleaning data in course digests prior to ingest to ensure that it is structured properly.   It adds initially support or cleaning/adjusting two things:

1. Ensuring that code blocks only contain `code_line` instances as direct children. For code blocks that specify raw text or paragraphs (or anything else) it converts that to a `code_line`. 
2. Ensures that nodes that should have an `id` attribute get one assigned to it. 

The "scrubbing" support this PR adds can record and track the changes that it makes.  These changes are not yet exposed to the end user.  That will likely happen in future work when we expand ingest support.  

