### PR TITLE
[CHORE] Restore docs build

### DIFF
--- a/.github/actions/phoenix-builder/entrypoint.sh
+++ b/.github/actions/phoenix-builder/entrypoint.sh
@@ -4,7 +4,7 @@ RELEASE_SHA=$1
 
 mix local.hex --force
 mix local.rebar --force
-mix archive.install hex phx_new 1.5.6
+mix archive.install hex phx_new 1.5.9
 
 mix deps.get --only prod
 MIX_ENV=prod SHA=$RELEASE_SHA mix compile

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -3,11 +3,11 @@ on:
   push:
     branches:
       - master
-      - hotfix-*          # include hotfix branches
+      - hotfix-* # include hotfix branches
     tags:
-      - package           # manually trigger a package build (no deployment)
-      - deploy-test       # manually trigger build and deploy to test
-      - deploy-loadtest   # manually trigger build and deploy to loadtest
+      - package # manually trigger a package build (no deployment)
+      - deploy-test # manually trigger build and deploy to test
+      - deploy-loadtest # manually trigger build and deploy to loadtest
 
 jobs:
   package-deploy:
@@ -40,11 +40,11 @@ jobs:
         with:
           args: --acl public-read --follow-symlinks
         env:
-          AWS_S3_BUCKET: 'oli-torus-releases'
+          AWS_S3_BUCKET: "oli-torus-releases"
           AWS_ACCESS_KEY_ID: ${{ secrets.SIMON_BOT_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.SIMON_BOT_AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: 'us-east-2'
-          SOURCE_DIR: 'oli-torus-releases'
+          AWS_REGION: "us-east-2"
+          SOURCE_DIR: "oli-torus-releases"
 
       - name: 🚢💰 Deploy to test using SSH
         uses: fifsky/ssh-action@master
@@ -56,7 +56,6 @@ jobs:
           host: ${{ steps.info.outputs.deploy_host }}
           user: simon-bot
           key: ${{ secrets.SIMON_BOT_PRIVATE_KEY}}
-
 
   docs:
     runs-on: ubuntu-latest
@@ -75,8 +74,8 @@ jobs:
       - name: 🧪 Setup Elixir
         uses: erlef/setup-elixir@v1
         with:
-          elixir-version: 1.11.1 # Define the elixir version [required]
-          otp-version: 23.1 # Define the OTP version [required]
+          elixir-version: 1.12.0 # Define the elixir version [required]
+          otp-version: 24.0 # Define the OTP version [required]
 
       - name: ⬇️ Install Elixir Dependencies
         run: mix deps.get


### PR DESCRIPTION
Attempt to restore tokamak deployment.  This PR changes phoenix build in the `entrypoint.sh` and the versions of Elxiir and Erlang used in Docs build step (which is what appears to be failing). 

There are some other whitespace and single quote to double quote changes that VSCode insisted on making.  