### PR TITLE
image coding: remove extra space at end of printed lines (problem for regexp grading)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug fixes
+
+- Image coding: remove extra space at end of printed lines (problem for regexp grading)
+
 ## 0.10.0 (2021-6-2)
 
 ### Enhancements

--- a/assets/src/components/activities/image_coding/Evaluator.ts
+++ b/assets/src/components/activities/image_coding/Evaluator.ts
@@ -43,18 +43,20 @@ export class Evaluator {
       toPrint = '[' + something.join(', ') + ']';
     }
 
-    const spacer = something === '\n' ? '' : ' ';
-
-    ctx.appendOutput(toPrint + spacer);
+    ctx.appendOutput(toPrint);
   }
 
   static myprint(ctx: EvalContext, ...args: any): void {
     for (let i = 0; i < args.length; i += 1) {
+      // add space between arguments
+      if (i > 0) {
+        this.printOne(' ', ctx)
+      }
       this.printOne(args[i], ctx);
     }
 
     const lastArg = args[args.length - 1];
-    const hasBreak = lastArg instanceof SimpleImageImpl || lastArg === '\n';
+    const hasBreak = lastArg instanceof SimpleImageImpl;
     if (!hasBreak) {
       this.printOne('\n', ctx);
     }


### PR DESCRIPTION
This fixes #1096, apparent problem with regex grading on image coding activities, which was due to the print function implementation printing a space at the end of each printed output line. The unexpected invisible space character prevented author from coming up with a working regexp for exact matching across output lines. Also fixes #1098 (a duplicate). 