### PR TITLE
Image coding: disable submit until run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug fixes
+
+- Image coding: remove extra space at end of printed lines (problem for regexp grading)
+
 ## 0.10.0 (2021-6-2)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased
 
-### Bug fixes
+### Enhancements 
 
-- Image coding: remove extra space at end of printed lines (problem for regexp grading)
+- Image coding: disable submit button before code is run
 
 ## 0.10.0 (2021-6-2)
 

--- a/assets/src/components/activities/image_coding/Evaluator.ts
+++ b/assets/src/components/activities/image_coding/Evaluator.ts
@@ -43,18 +43,20 @@ export class Evaluator {
       toPrint = '[' + something.join(', ') + ']';
     }
 
-    const spacer = something === '\n' ? '' : ' ';
-
-    ctx.appendOutput(toPrint + spacer);
+    ctx.appendOutput(toPrint);
   }
 
   static myprint(ctx: EvalContext, ...args: any): void {
     for (let i = 0; i < args.length; i += 1) {
+      // add space between arguments
+      if (i > 0) {
+        this.printOne(' ', ctx)
+      }
       this.printOne(args[i], ctx);
     }
 
     const lastArg = args[args.length - 1];
-    const hasBreak = lastArg instanceof SimpleImageImpl || lastArg === '\n';
+    const hasBreak = lastArg instanceof SimpleImageImpl;
     if (!hasBreak) {
       this.printOne('\n', ctx);
     }

--- a/assets/src/components/activities/image_coding/Evaluator.ts
+++ b/assets/src/components/activities/image_coding/Evaluator.ts
@@ -43,20 +43,18 @@ export class Evaluator {
       toPrint = '[' + something.join(', ') + ']';
     }
 
-    ctx.appendOutput(toPrint);
+    const spacer = something === '\n' ? '' : ' ';
+
+    ctx.appendOutput(toPrint + spacer);
   }
 
   static myprint(ctx: EvalContext, ...args: any): void {
     for (let i = 0; i < args.length; i += 1) {
-      // add space between arguments
-      if (i > 0) {
-        this.printOne(' ', ctx)
-      }
       this.printOne(args[i], ctx);
     }
 
     const lastArg = args[args.length - 1];
-    const hasBreak = lastArg instanceof SimpleImageImpl;
+    const hasBreak = lastArg instanceof SimpleImageImpl || lastArg === '\n';
     if (!hasBreak) {
       this.printOne('\n', ctx);
     }

--- a/assets/src/components/activities/image_coding/ImageCodingDelivery.tsx
+++ b/assets/src/components/activities/image_coding/ImageCodingDelivery.tsx
@@ -60,6 +60,7 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
   // runtime evaluation state:
   const [output, setOutput] = useState('');
   const [error, setError] = useState('');
+  const [ranCode, setRanCode] = useState(false);
   let currentOutput = output;
 
   const isEvaluated = attemptState.score !== null;
@@ -159,6 +160,7 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
       // Do we want reset to reload starter code, discarding changes?
       // setInput(model.starterCode);
       clearOutput();
+      setRanCode(false);
     });
   };
 
@@ -197,6 +199,8 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
     if (e != null) {
       setError(e.message);
     }
+
+    setRanCode(true);
   };
 
   const usesImages = () => {
@@ -302,7 +306,7 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
     model.isExample || props.graded ? null : (
       <button
         className="btn btn-primary mt-2 float-right"
-        disabled={isEvaluated}
+        disabled={isEvaluated || !ranCode}
         onClick={onSubmit}
       >
         Submit


### PR DESCRIPTION
Resolves #1099, enhancement request to disable the submit button on image coding activities before user code is run. 

It is necessary to run the user-written code to generate the output which is checked by the evaluation. Clicking SUBMIT before running will always lead to an incorrect evaluation due to empty output. There is no reason to allow this error. 