### PR TITLE
fix mix test watch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
         run: set -a;source oli.env && mix clean && mix compile --warnings-as-errors
 
       - name: ▶️ Run tests
-        run: set -a;source oli.env && mix test
+        run: set -a;source oli.env && MIX_ENV=test mix ecto.reset && mix test
 
   ts-build-test:
     runs-on: ubuntu-latest

--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,7 @@ defmodule Oli.MixProject do
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [
         test: :test,
-        "test.watch": :test,
+        "test.ecto.reset": :test,
         coveralls: :test,
         "coveralls.detail": :test,
         "coveralls.post": :test,
@@ -132,17 +132,12 @@ defmodule Oli.MixProject do
   defp aliases do
     [
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
+
+      # resets the database
       "ecto.reset": ["ecto.drop", "ecto.setup"],
-      test: ["ecto.reset", "test"],
 
-      # runs tests and produces a coverage report
-      "test.coverage": ["ecto.reset", "coveralls.html"],
-
-      # runs tests and produces a coverage report
-      "test.coverage.xml": ["ecto.reset", "coveralls.xml"],
-
-      # runs tests in deterministic order, only shows one failure at a time and reruns tests if any changes are made
-      "test.watch": ["ecto.reset", "test.watch --stale --max-failures 1 --trace --seed 0"]
+      # resets the database in the :test env
+      "test.ecto.reset": ["ecto.reset"]
     ]
   end
 end


### PR DESCRIPTION
This PR fixes the `mix test.watch` task. The issue was the preferred_cli_env specified to use the test env, however this task appears to actually run in dev before entering test. The fix is to remove this as well as the ecto.reset command in test. See https://github.com/lpil/mix-test.watch/issues/124 for more details.

As a result, a database reset is no longer automatically executed before tests are run. This shouldn't be an issue unless tests are aborted halfway through leaving an invalid database state, in which case the `MIX_ENV=test mix ecto.reset` command can be used to reset the test database. The [wiki docs have also been updated](https://github.com/Simon-Initiative/oli-torus/wiki/Setup-Dev-Environment) to reflect this change.

With this fix, a developer will be able to use the command `mix test.watch --stale --max-failures 1 --trace --seed 0` to run tests and watch for changes, rerunning the stale tests while always executing tests in the same order.