### PR TITLE
[CHORE] only minimize in production

### DIFF
--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -87,9 +87,9 @@ const populateEntries = () => {
   if (
     Object.keys(merged).length !=
     Object.keys(initialEntries).length +
-      2 * foundActivities.length +
-      2 * foundParts.length +
-      foundThemes.length
+    2 * foundActivities.length +
+    2 * foundParts.length +
+    foundThemes.length
   ) {
     throw new Error(
       'Encountered a possible naming collision in activity or part manifests. Aborting.',
@@ -102,7 +102,7 @@ const populateEntries = () => {
 module.exports = (env, options) => ({
   devtool: 'source-map',
   optimization: {
-    minimize: true,
+    minimize: process.env.NODE_ENV == 'production',
     minimizer: [new TerserPlugin()],
   },
   entry: populateEntries(),


### PR DESCRIPTION
This PR changes the webpack config to only minimize in production. This eliminates the errors shown in the console during development: `You are currently using minified code outside of NODE_ENV === "production". This means...`