### PR TITLE
make user email unique index a partial index

### DIFF
--- a/priv/repo/migrations/20210603205146_pow_delivery_user.exs
+++ b/priv/repo/migrations/20210603205146_pow_delivery_user.exs
@@ -17,7 +17,7 @@ defmodule Oli.Repo.Migrations.PowDeliveryUser do
     create unique_index(:users, [:email_confirmation_token])
 
     # guarantee that independent learners have unique emails
-    create unique_index(:users, [:email, :independent_learner])
+    create unique_index(:users, [:email], where: "independent_learner = true", name: :users_email_independent_learner_index)
 
     # rename current user_identities to author_identities
     drop unique_index(:user_identities, [:uid, :provider])


### PR DESCRIPTION
This PR fixes an issue where the user independent learner index didn't work correctly. The fix is to change this to be a partial unique index, which only applies to records that have `independent_learner = true`