### PR TITLE
Set existing users in migration

### DIFF
--- a/lib/oli/accounts.ex
+++ b/lib/oli/accounts.ex
@@ -197,6 +197,19 @@ defmodule Oli.Accounts do
   end
 
   @doc """
+  Returns true if a user is signed in as an independent learner
+  """
+  def user_is_independent_learner?(current_user) do
+    case current_user do
+      %{independent_learner: true} ->
+        true
+
+      _ ->
+        false
+    end
+  end
+
+  @doc """
   Returns true if an author is an administrator.
   """
   def is_admin?(%Author{system_role_id: system_role_id}) do

--- a/lib/oli/utils/db_seeder.ex
+++ b/lib/oli/utils/db_seeder.ex
@@ -547,7 +547,7 @@ defmodule Oli.Seeder do
     {:ok, user} =
       User.noauth_changeset(
         %User{
-          sub: "a6d5c443-1f51-4783-ba1a-7686ffe3b54a",
+          sub: UUID.uuid4(),
           name: "Ms Jane Marie Doe",
           given_name: "Jane",
           family_name: "Doe",

--- a/lib/oli_web.ex
+++ b/lib/oli_web.ex
@@ -103,7 +103,14 @@ defmodule OliWeb do
       alias OliWeb.Router.Helpers, as: Routes
       import OliWeb.ViewHelpers
 
-      import Oli.Accounts, only: [author_signed_in?: 1, user_signed_in?: 1, user_is_guest?: 1]
+      import Oli.Accounts,
+        only: [
+          author_signed_in?: 1,
+          user_signed_in?: 1,
+          user_is_guest?: 1,
+          user_is_independent_learner?: 1
+        ]
+
       import Oli.Utils
       import Oli.Branding
     end

--- a/lib/oli_web/templates/layout/_delivery_header.html.eex
+++ b/lib/oli_web/templates/layout/_delivery_header.html.eex
@@ -54,8 +54,10 @@
           <% else %>
             <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
               <%= if user_role_is_student(@conn, @current_user) do %>
-                <%= link "My Courses", to: Routes.delivery_path(@conn, :open_and_free_index), class: "dropdown-item btn" %>
-                <div class="dropdown-divider"></div>
+                <%= if user_is_independent_learner?(@current_user) do %>
+                  <%= link "My Courses", to: Routes.delivery_path(@conn, :open_and_free_index), class: "dropdown-item btn" %>
+                  <div class="dropdown-divider"></div>
+                <% end %>
                 <%= link "Sign out", to: Routes.delivery_path(@conn, :signout), id: "signout-link", class: "dropdown-item btn" %>
               <% else %>
                 <%= if account_linked?(@current_user) do %>

--- a/priv/repo/migrations/20210603205146_pow_delivery_user.exs
+++ b/priv/repo/migrations/20210603205146_pow_delivery_user.exs
@@ -18,7 +18,7 @@ defmodule Oli.Repo.Migrations.PowDeliveryUser do
 
     flush()
 
-    from(u in "users")
+    from(_u in "users")
     |> Oli.Repo.update_all(set: [independent_learner: false])
 
     flush()

--- a/priv/repo/migrations/20210603205146_pow_delivery_user.exs
+++ b/priv/repo/migrations/20210603205146_pow_delivery_user.exs
@@ -1,6 +1,8 @@
 defmodule Oli.Repo.Migrations.PowDeliveryUser do
   use Ecto.Migration
 
+  import Ecto.Query, warn: false
+
   def change do
 
     alter table(:users) do
@@ -14,6 +16,14 @@ defmodule Oli.Repo.Migrations.PowDeliveryUser do
       add :independent_learner, :boolean, default: true
     end
 
+    flush()
+
+    from(u in "users")
+    |> Oli.Repo.update_all(set: [independent_learner: false])
+
+    flush()
+
+    create unique_index(:users, [:sub])
     create unique_index(:users, [:email_confirmation_token])
 
     # guarantee that independent learners have unique emails

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -47,7 +47,7 @@ defmodule Oli.TestHelpers do
     params =
       attrs
       |> Enum.into(%{
-        sub: "a6d5c443-1f51-4783-ba1a-7686ffe3b54a",
+        sub: UUID.uuid4(),
         name: "Ms Jane Marie Doe",
         given_name: "Jane",
         family_name: "Doe",


### PR DESCRIPTION
This PR fixes the pow delivery users migration by flushing the table changes and setting all existing users independent_learner fields to false. It also hides the "My Courses" link from non-independent learners.