### PR TITLE
[BUG FIX] Override pow get_by to only query independent learner users

### DIFF
--- a/lib/oli_web/pow/pow_helpers.ex
+++ b/lib/oli_web/pow/pow_helpers.ex
@@ -15,6 +15,7 @@ defmodule OliWeb.Pow.PowHelpers do
       routes_backend: OliWeb.Pow.UserRoutes,
       extensions: [PowResetPassword, PowEmailConfirmation, PowPersistentSession, PowInvitation],
       controller_callbacks: Pow.Extension.Phoenix.ControllerCallbacks,
+      users_context: OliWeb.Pow.UsersContext,
       mailer_backend: OliWeb.Pow.Mailer,
       web_mailer_module: OliWeb,
       pow_assent: [

--- a/lib/oli_web/pow/users_context.ex
+++ b/lib/oli_web/pow/users_context.ex
@@ -8,7 +8,7 @@ defmodule OliWeb.Pow.UsersContext do
     user: Oli.Accounts.User
 
   @doc """
-  Overrides the existing pow get_by/2 and ensures only
+  Overrides the existing pow get_by/1 and ensures only
   independent learners are queried
   """
   @impl true

--- a/lib/oli_web/pow/users_context.ex
+++ b/lib/oli_web/pow/users_context.ex
@@ -1,0 +1,20 @@
+defmodule OliWeb.Pow.UsersContext do
+  @moduledoc """
+  Custom module that handles pow users context for user.
+  """
+
+  use Pow.Ecto.Context,
+    repo: Oli.Repo,
+    user: Oli.Accounts.User
+
+  @doc """
+  Overrides the existing pow get_by/2 and ensures only
+  independent learners are queried
+  """
+  @impl true
+  def get_by(clauses) do
+    clauses = Keyword.put_new(clauses, :independent_learner, true)
+
+    pow_get_by(clauses)
+  end
+end

--- a/test/oli_web/pow/users_context_test.exs
+++ b/test/oli_web/pow/users_context_test.exs
@@ -1,0 +1,43 @@
+defmodule OliWeb.Pow.UsersContextTest do
+  use OliWeb.ConnCase
+
+  alias OliWeb.Router.Helpers, as: Routes
+
+  describe "users context" do
+    setup [:setup_users]
+
+    test "only queries independent learners for pow authentication", %{
+      conn: conn,
+      independent_user: independent_user
+    } do
+      # sign in independent user with same email address as existing lti user
+      conn =
+        recycle(conn)
+        |> post(Routes.pow_session_path(conn, :create),
+          user: %{email: independent_user.email, password: "password123"}
+        )
+
+      assert html_response(conn, 302) =~
+               Routes.delivery_path(conn, :open_and_free_index)
+    end
+  end
+
+  defp setup_users(_) do
+    user =
+      user_fixture(%{
+        email: "same@example.edu",
+        password: "password123",
+        password_confirmation: "password123",
+        independent_learner: false
+      })
+
+    independent_user =
+      user_fixture(%{
+        email: "same@example.edu",
+        password: "password123",
+        password_confirmation: "password123"
+      })
+
+    %{user: user, independent_user: independent_user}
+  end
+end


### PR DESCRIPTION
This PR fixes an issue where authenticating with an email that already exists for non-independent user throws an error.