### PR TITLE
[BUG FIX] Allow course project deletion when title contains special characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug fixes
+
+- Fix an issue preventing deletion of projects whose names contain special characters
+
 ## 0.11.0 (2021-6-15)
 
 ### Enhancements

--- a/assets/src/phoenix/package_delete.ts
+++ b/assets/src/phoenix/package_delete.ts
@@ -1,9 +1,11 @@
 
 // Listens for user input in the text input identified by 'inputSelector', and keeps the submit
-// button identified by 'submitSelector' disabled until the user's input matches the text of 'title'.
+// button identified by 'submitSelector' disabled until the user's base 64 encode
+// input matches the text of 'encodedTitle'.  Comparison of base 64 encodings instead of the raw
+// strings is a robust way to circumvent a confusting array of server/client encoding/decoding challenges.
 //
 // This is used during confirmation of package deletion.
-export function enableSubmitWhenTitleMatches(inputSelector: string, submitSelector: string, title: string) : void {
+export function enableSubmitWhenTitleMatches(inputSelector: string, submitSelector: string, encodedTitle: string) : void {
 
   const deleteTitleInput = document.querySelector(inputSelector);
   if (deleteTitleInput) {
@@ -11,7 +13,8 @@ export function enableSubmitWhenTitleMatches(inputSelector: string, submitSelect
       const value = e.target.value;
       const deleteSubmitButton : HTMLInputElement | null = document.querySelector(submitSelector);
       if (deleteSubmitButton !== null) {
-        if (value === title) {
+        // Base 64 encode the user's input and compare it to the encoded title
+        if (btoa(value) === encodedTitle) {
           deleteSubmitButton.disabled = false;
         } else {
           deleteSubmitButton.disabled = true;

--- a/lib/oli_web/templates/project/overview.html.eex
+++ b/lib/oli_web/templates/project/overview.html.eex
@@ -162,5 +162,5 @@
 </div>
 
 <script>
-  OLI.onReady(() => OLI.enableSubmitWhenTitleMatches('#delete-confirm-title', '#delete-modal-submit', '<%= @project.title %>'));
+  OLI.onReady(() => OLI.enableSubmitWhenTitleMatches('#delete-confirm-title', '#delete-modal-submit', '<%= Base.encode64(@project.title) %>'));
 </script>


### PR DESCRIPTION
Closes #1131 

There was a collection of encoding/decoding issues, both in the server code and client, preventing this from working.  The most robust way to allow it to work is to have both input and title strings be base 64 encoded - from the server rendering through to the comparison in TS code. 

