### PR TITLE
[BUG FIX] fix an issue with persistent sessions config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ docker-compose.override.yml
 supervisord.log
 supervisord.pid
 stacks.out
+.mnesia

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug fixes
+
+- Fix an issue related to persisting sessions across server restarts
+
 ## 0.11.0 (2021-6-15)
 
 ### Enhancements

--- a/config/config.exs
+++ b/config/config.exs
@@ -99,6 +99,9 @@ config :logger, :console,
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
 
+# Configure Mnesia directory (used by pow persistent sessions)
+config :mnesia, :dir, './.mnesia'
+
 if Mix.env() == :dev do
   config :mix_test_watch,
     clear: true

--- a/lib/oli/application.ex
+++ b/lib/oli/application.ex
@@ -22,6 +22,9 @@ defmodule Oli.Application do
       # Start the Oban background job processor
       {Oban, oban_config()},
 
+      # Start the Pow MnesiaCache to persist session across server restarts
+      Pow.Store.Backend.MnesiaCache,
+
       # Start the NodeJS bridge
       %{
         id: NodeJS,

--- a/lib/oli_web/endpoint.ex
+++ b/lib/oli_web/endpoint.ex
@@ -60,8 +60,7 @@ defmodule OliWeb.Endpoint do
 
   plug(Pow.Plug.Session, OliWeb.Pow.PowHelpers.get_pow_config(:user))
   plug(Pow.Plug.Session, OliWeb.Pow.PowHelpers.get_pow_config(:author))
-  plug(Pow.Plug.Session, otp_app: :oli)
-  plug(PowPersistentSession.Plug.Cookie)
+  plug(PowPersistentSession.Plug.Cookie, persistent_session_cookie_key: "oli_persistent_session")
 
   plug(OliWeb.Router)
 end

--- a/lib/oli_web/pow/pow_helpers.ex
+++ b/lib/oli_web/pow/pow_helpers.ex
@@ -15,6 +15,7 @@ defmodule OliWeb.Pow.PowHelpers do
       routes_backend: OliWeb.Pow.UserRoutes,
       extensions: [PowResetPassword, PowEmailConfirmation, PowPersistentSession, PowInvitation],
       controller_callbacks: Pow.Extension.Phoenix.ControllerCallbacks,
+      cache_store_backend: Pow.Store.Backend.MnesiaCache,
       users_context: OliWeb.Pow.UsersContext,
       mailer_backend: OliWeb.Pow.Mailer,
       web_mailer_module: OliWeb,
@@ -53,6 +54,7 @@ defmodule OliWeb.Pow.PowHelpers do
       routes_backend: OliWeb.Pow.AuthorRoutes,
       extensions: [PowResetPassword, PowEmailConfirmation, PowPersistentSession, PowInvitation],
       controller_callbacks: Pow.Extension.Phoenix.ControllerCallbacks,
+      cache_store_backend: Pow.Store.Backend.MnesiaCache,
       mailer_backend: OliWeb.Pow.Mailer,
       web_mailer_module: OliWeb,
       pow_assent: [

--- a/test/oli_web/pow/pow_test.exs
+++ b/test/oli_web/pow/pow_test.exs
@@ -1,4 +1,4 @@
-defmodule OliWeb.Common.PowSessionTest do
+defmodule OliWeb.Common.PowTest do
   use OliWeb.ConnCase
 
   alias Oli.Seeder


### PR DESCRIPTION
This PR fixes an issue where checking the "Remember me" checkbox crashed the server for that user. It also introduces the proper configuration in order to persist session across server restarts/deployments per pow production checklist: https://hexdocs.pm/pow/1.0.14/production_checklist.html#content