### PR TITLE
[BUG FIX] enable reauthorization plug handler for social login persistent sessions

### DIFF
--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -89,6 +89,9 @@ defmodule OliWeb.Router do
     plug(Oli.Plugs.SetDefaultPow, :user)
     plug(Oli.Plugs.SetCurrentUser)
 
+    plug PowAssent.Plug.Reauthorization,
+      handler: PowAssent.Phoenix.ReauthorizationPlugHandler
+
     plug(Pow.Plug.RequireAuthenticated,
       error_handler: Pow.Phoenix.PlugErrorHandler
     )
@@ -100,6 +103,9 @@ defmodule OliWeb.Router do
   pipeline :authoring_protected do
     plug(Oli.Plugs.SetDefaultPow, :author)
     plug(Oli.Plugs.SetCurrentUser)
+
+    plug PowAssent.Plug.Reauthorization,
+      handler: PowAssent.Phoenix.ReauthorizationPlugHandler
 
     plug(Pow.Plug.RequireAuthenticated,
       error_handler: Pow.Phoenix.PlugErrorHandler


### PR DESCRIPTION
This PR add the reauthorization plug handler which according to the documentation https://github.com/pow-auth/pow_assent#powpersistentsession, this allows identity providers to mange persistent sessions for social login users.