### PR TITLE
[BUG FIX] remove @socket from all live components as of phoenix 0.15.6

### DIFF
--- a/lib/oli_web/live/breadcrumb/breadcrumb_trail_live.ex
+++ b/lib/oli_web/live/breadcrumb/breadcrumb_trail_live.ex
@@ -29,8 +29,7 @@ defmodule OliWeb.Breadcrumb.BreadcrumbTrailLive do
     <nav aria-label="breadcrumb">
       <ol class="breadcrumb custom-breadcrumb">
 
-        <%= live_component @socket,
-          BreadcrumbLive,
+        <%= live_component BreadcrumbLive,
           id: "breadcrumb-project",
           breadcrumb: Breadcrumb.new(%{
             full_title: @project.title,
@@ -41,8 +40,7 @@ defmodule OliWeb.Breadcrumb.BreadcrumbTrailLive do
         %>
 
         <%= for {breadcrumb, index} <- Enum.with_index(@breadcrumbs) do %>
-          <%= live_component @socket,
-            BreadcrumbLive,
+          <%= live_component BreadcrumbLive,
             id: "breadcrumb-#{index}",
             breadcrumb: breadcrumb,
             project: @project,

--- a/lib/oli_web/live/common/manual_modal.ex
+++ b/lib/oli_web/live/common/manual_modal.ex
@@ -12,7 +12,7 @@ defmodule OliWeb.Common.ManualModal do
   Minimal example usage specifying only the required properties:
 
   ```
-  <%= live_component @socket, ManualModal, title: "Confirm your request", modal_id: "my_unique_modal_id", ok_action: "confirm" do %>
+  <%= live_component ManualModal, title: "Confirm your request", modal_id: "my_unique_modal_id", ok_action: "confirm" do %>
     <p class="mb-4">Are you sure you want to do this?</p>
   <% end %>
   ```

--- a/lib/oli_web/live/common/modal.ex
+++ b/lib/oli_web/live/common/modal.ex
@@ -5,7 +5,7 @@ defmodule OliWeb.Common.Modal do
   Minimal example usage specifying only the required properties:
 
   ```
-  <%= live_component @socket, Modal, title: "Confirm your request", modal_id: "my_unique_modal_id", ok_action: "confirm" do %>
+  <%= live_component Modal, title: "Confirm your request", modal_id: "my_unique_modal_id", ok_action: "confirm" do %>
     <p class="mb-4">Are you sure you want to do this?</p>
   <% end %>
   ```

--- a/lib/oli_web/live/curriculum/container/container_live.html.leex
+++ b/lib/oli_web/live/curriculum/container/container_live.html.leex
@@ -3,7 +3,7 @@
   <% nil -> %>
 
   <% %{component: component, assigns: assigns} -> %>
-    <%= live_component @socket, component, assigns %>
+    <%= live_component component, assigns %>
 <% end %>
 <div id="curriculum-container" class="container container-editor">
   <div class="row">
@@ -61,8 +61,8 @@
           </div>
         <% end %>
         <%= for {child, index} <- Enum.with_index(@children) |> Enum.filter(fn {c, _i} -> c.slug != @dragging end) do %>
-          <%= live_component @socket, DropTarget, id: index, index: index %>
-          <%= live_component @socket, EntryLive, %{
+          <%= live_component DropTarget, id: index, index: index %>
+          <%= live_component EntryLive, %{
                   id: child.slug,
                   editor: Map.get(@resources_being_edited, child.resource_id),
                   author: @author,
@@ -78,7 +78,7 @@
                   numberings: @numberings
                 } %>
         <% end %>
-        <%= live_component @socket, DropTarget, id: "last", index: length(@children) %>
+        <%= live_component DropTarget, id: "last", index: length(@children) %>
       </div>
       <div class="mt-5">
         <span class="text-secondary mr-2">Add new</span>

--- a/lib/oli_web/live/curriculum/entries/entry.ex
+++ b/lib/oli_web/live/curriculum/entries/entry.ex
@@ -39,9 +39,9 @@ defmodule OliWeb.Curriculum.EntryLive do
         <div>
           <%= case @view do
             "Detailed" ->
-              live_component @socket, DetailsLive, assigns
+              live_component DetailsLive, assigns
             "Learning Summary" ->
-              live_component @socket, LearningSummaryLive, assigns
+              live_component LearningSummaryLive, assigns
             _ ->
               nil
           end %>
@@ -50,7 +50,7 @@ defmodule OliWeb.Curriculum.EntryLive do
 
       <%# prevent dragging of actions menu and modals using this draggable wrapper %>
       <div draggable="true" ondragstart="event.preventDefault(); event.stopPropagation();">
-        <%= live_component @socket, Actions, assigns %>
+        <%= live_component Actions, assigns %>
       </div>
     </div>
     """

--- a/lib/oli_web/live/curriculum/entries/move_modal.ex
+++ b/lib/oli_web/live/curriculum/entries/move_modal.ex
@@ -18,7 +18,7 @@ defmodule OliWeb.Curriculum.MoveModal do
               </button>
             </div>
             <div class="modal-body">
-            <%= live_component @socket, HierarchyPicker,
+            <%= live_component HierarchyPicker,
               id: "hierarchy_picker_#{@revision.slug}",
               project: @project,
               container: @container,

--- a/lib/oli_web/live/grades/grades.ex
+++ b/lib/oli_web/live/grades/grades.ex
@@ -72,9 +72,9 @@ defmodule OliWeb.Grades.GradesLive do
 
     <div class="card-group">
 
-      <%= live_component @socket, OliWeb.Grades.LineItems, assigns %>
-      <%= live_component @socket, OliWeb.Grades.GradeSync, assigns %>
-      <%= live_component @socket, OliWeb.Grades.Export, assigns %>
+      <%= live_component OliWeb.Grades.LineItems, assigns %>
+      <%= live_component OliWeb.Grades.GradeSync, assigns %>
+      <%= live_component OliWeb.Grades.Export, assigns %>
 
     </div>
 

--- a/lib/oli_web/live/history/pagination.ex
+++ b/lib/oli_web/live/history/pagination.ex
@@ -28,7 +28,7 @@ defmodule OliWeb.RevisionHistory.Pagination do
       <nav aria-label="table results paging">
         <ul class="pagination justify-content-center">
           <%= for page <- 1..total_pages do %>
-            <%= live_component @socket, PaginationLink, page_ordinal: page, active: current_page == page, page_offset: @page_offset %>
+            <%= live_component PaginationLink, page_ordinal: page, active: current_page == page, page_offset: @page_offset %>
           <% end %>
         </ul>
       </nav>

--- a/lib/oli_web/live/history/revision_history.ex
+++ b/lib/oli_web/live/history/revision_history.ex
@@ -145,10 +145,10 @@ defmodule OliWeb.RevisionHistory do
           </div>
           <div class="card-body">
             <%= if @view == "graph" do %>
-              <%= live_component @socket, Graph, tree: @tree, root: @root, selected: @selected, project: @project, initial_size: @initial_size %>
+              <%= live_component Graph, tree: @tree, root: @root, selected: @selected, project: @project, initial_size: @initial_size %>
             <% else %>
-              <%= live_component @socket, Pagination, revisions: @revisions, page_offset: @page_offset, page_size: size %>
-              <%= live_component @socket, Table, tree: @tree, publication: @publication, mappings: @mappings, revisions: @revisions, selected: @selected, page_offset: @page_offset, page_size: size %>
+              <%= live_component Pagination, revisions: @revisions, page_offset: @page_offset, page_size: size %>
+              <%= live_component Table, tree: @tree, publication: @publication, mappings: @mappings, revisions: @revisions, selected: @selected, page_offset: @page_offset, page_size: size %>
             <% end %>
           </div>
         </div>
@@ -166,7 +166,7 @@ defmodule OliWeb.RevisionHistory do
             </div>
           </div>
           <div class="card-body">
-            <%= live_component @socket, Details, revision: @selected %>
+            <%= live_component Details, revision: @selected %>
           </div>
         </div>
       </div>

--- a/lib/oli_web/live/insights/insights.ex
+++ b/lib/oli_web/live/insights/insights.ex
@@ -58,10 +58,10 @@ defmodule OliWeb.Insights do
           _ -> "activity"
         end %></h5>
         <table class="table">
-          <%= live_component @socket, TableHeader, assigns %>
+          <%= live_component TableHeader, assigns %>
           <tbody>
             <%= for row <- active_rows(assigns) do %>
-              <%= live_component @socket, TableRow, row: row, parent_pages: assigns.parent_pages, project: assigns.project %>
+              <%= live_component TableRow, row: row, parent_pages: assigns.parent_pages, project: assigns.project %>
             <% end %>
           </tbody>
         </table>

--- a/lib/oli_web/live/objectives/objective_entry.ex
+++ b/lib/oli_web/live/objectives/objective_entry.ex
@@ -13,7 +13,7 @@ defmodule OliWeb.Objectives.ObjectiveEntry do
   defp render_children(assigns) do
     ~L"""
       <%= for child <- @children do %>
-        <%= live_component @socket, ObjectiveEntry, changeset: @changeset, objective_mapping: child.mapping,
+        <%= live_component ObjectiveEntry, changeset: @changeset, objective_mapping: child.mapping,
               children: [], depth: @depth + 1, project: @project, can_delete?: @can_delete?, edit: @edit, breakdown: @breakdown %>
       <% end %>
 
@@ -24,7 +24,7 @@ defmodule OliWeb.Objectives.ObjectiveEntry do
             <div class="col-12 pb-2">
               <div style="margin-left: <%= @depth * 40 %>px">
 
-              <%= live_component @socket, ObjectiveForm, changeset: @changeset,
+              <%= live_component ObjectiveForm, changeset: @changeset,
                 project: @project, title_value: "", slug_value: "", parent_slug_value: @objective_mapping.revision.slug, depth: @depth,
                 form_id: "create-sub-objective", place_holder: "", phx_disable_with: "Creating Sub-Objective...", button_text: "Create", method: "new" %>
 
@@ -64,14 +64,14 @@ defmodule OliWeb.Objectives.ObjectiveEntry do
         <%= cond do %>
           <% @edit == @objective_mapping.revision.slug -> %>
             <div class="py-2">
-              <%= live_component @socket, ObjectiveRender, changeset: @changeset, objective_mapping: @objective_mapping, children: @children,
+              <%= live_component ObjectiveRender, changeset: @changeset, objective_mapping: @objective_mapping, children: @children,
                 project: @project, slug: @objective_mapping.revision.slug, form_id: "edit-objective", place_holder: @objective_mapping.revision.title,
                 phx_disable_with: "Updating Objective...", button_text: "Save", parent_slug_value: "", depth: @depth,
                 title_value: @objective_mapping.revision.title, can_delete?: @can_delete?,
                 edit: @edit, method: "edit", mode: :edit %>
             </div>
           <% true -> %>
-            <%= live_component @socket, ObjectiveRender, changeset: @changeset, objective_mapping: @objective_mapping, children: @children,
+            <%= live_component ObjectiveRender, changeset: @changeset, objective_mapping: @objective_mapping, children: @children,
             project: @project, slug: @objective_mapping.revision.slug, depth: @depth, mode: :show, can_delete?: @can_delete?, edit: @edit %>
         <% end %>
       </div>

--- a/lib/oli_web/live/objectives/objective_render.ex
+++ b/lib/oli_web/live/objectives/objective_render.ex
@@ -15,12 +15,12 @@ defmodule OliWeb.Objectives.ObjectiveRender do
     <% :show -> %>
       <div class="d-flex flex-row">
         <div class="p-2 my-1 flex-grow-1 objective-title"><%= @objective_mapping.revision.title %></div>
-        <%= live_component @socket, Actions, slug: @slug, has_children: Enum.count(@objective_mapping.revision.children) > 0,
+        <%= live_component Actions, slug: @slug, has_children: Enum.count(@objective_mapping.revision.children) > 0,
           can_delete?: @can_delete?, depth: @depth %>
       </div>
 
     <% :edit -> %>
-      <%= live_component @socket, ObjectiveForm, changeset: @changeset,
+      <%= live_component ObjectiveForm, changeset: @changeset,
           project: @project, title_value: @title_value, slug_value: @objective_mapping.revision.slug, parent_slug_value: @parent_slug_value, depth: @depth,
           form_id: @form_id, place_holder: @place_holder, phx_disable_with: @phx_disable_with, button_text: @button_text, method: @method %>
 

--- a/lib/oli_web/live/projects/cards.ex
+++ b/lib/oli_web/live/projects/cards.ex
@@ -14,7 +14,7 @@ defmodule OliWeb.Projects.Cards do
           <% else %>
             <div class="row row-cols-1 row-cols-sm-2 row-cols-md-2 row-cols-lg-3 g-4">
               <%= for project <- @projects do %>
-                <%= live_component @socket, Card, project: project, author_count: length(Map.get(@authors, project.id)) %>
+                <%= live_component Card, project: project, author_count: length(Map.get(@authors, project.id)) %>
               <% end %>
             </div>
           <% end %>

--- a/lib/oli_web/live/projects/projects_live.ex
+++ b/lib/oli_web/live/projects/projects_live.ex
@@ -17,10 +17,18 @@ defmodule OliWeb.Projects.ProjectsLive do
   def mount(_, %{"current_author_id" => author_id}, socket) do
     author = Repo.get(Author, author_id)
     is_admin = Accounts.is_admin?(author)
-    projects = Course.get_projects_for_author(author) |> Enum.filter(fn p -> is_admin || p.status === :active end)
+
+    projects =
+      Course.get_projects_for_author(author)
+      |> Enum.filter(fn p -> is_admin || p.status === :active end)
+
     author_projects = Accounts.project_authors(Enum.map(projects, fn %{id: id} -> id end))
 
-    {:ok, assign(socket, Map.merge(State.initialize_state(author, projects, author_projects), %{is_admin: is_admin}))}
+    {:ok,
+     assign(
+       socket,
+       Map.merge(State.initialize_state(author, projects, author_projects), %{is_admin: is_admin})
+     )}
   end
 
   def handle_params(params, _, socket) do
@@ -80,12 +88,12 @@ defmodule OliWeb.Projects.ProjectsLive do
     </div>
     <%= case @display_mode do %>
       <% "cards" -> %>
-        <%= live_component @socket, Cards, projects: @projects, authors: @authors %>
+        <%= live_component Cards, projects: @projects, authors: @authors %>
       <% "table" -> %>
         <div class="container">
           <div class="row">
             <div class="col-12">
-              <%= live_component @socket, Table, projects: @projects, authors: @authors, sort_by: @sort_by, sort_order: @sort_order, is_admin: @is_admin %>
+              <%= live_component Table, projects: @projects, authors: @authors, sort_by: @sort_by, sort_order: @sort_order, is_admin: @is_admin %>
             </div>
           </div>
         </div>

--- a/lib/oli_web/live/qa/qa_live.ex
+++ b/lib/oli_web/live/qa/qa_live.ex
@@ -155,19 +155,19 @@ defmodule OliWeb.Qa.QaLive do
             <%= if !Enum.empty?(@warnings_by_type) do %>
               <div class="d-flex">
                 <%= for type <- @warning_types do %>
-                  <%= live_component @socket, WarningFilter, active: MapSet.member?(@filters, type), type: type, warnings: Map.get(@warnings_by_type, type) %>
+                  <%= live_component WarningFilter, active: MapSet.member?(@filters, type), type: type, warnings: Map.get(@warnings_by_type, type) %>
                 <% end %>
               </div>
 
               <div class="reviews">
                 <ul class="review-links">
                   <%= for warning <- @filtered_warnings do %>
-                    <%= live_component @socket, WarningSummary, warning: warning, selected: @selected %>
+                    <%= live_component WarningSummary, warning: warning, selected: @selected %>
                   <% end %>
                 </ul>
                 <div class="review-cards">
                   <%= if @selected != nil do %>
-                    <%= live_component @socket, WarningDetails,
+                    <%= live_component WarningDetails,
                       parent_pages: @parent_pages,
                       selected: @selected,
                       author: @author,


### PR DESCRIPTION
I noticed that modals are broken on the curriculum view, and after looking further it seems as thought live_component no longer takes @socket argument as of LiveView 0.15.6.

This PR removes @socket from all live_components and fixes the issues in curriculum view