### PR TITLE
[FEATURE] Course project export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+- Add ability to generate and download a course digest from existing course projects
+
 ## 0.11.1 (2021-6-16)
 
 ### Bug fixes

--- a/lib/oli/interop/export.ex
+++ b/lib/oli/interop/export.ex
@@ -1,0 +1,191 @@
+defmodule Oli.Interop.Export do
+  alias Oli.Publishing
+  alias Oli.Publishing.AuthoringResolver
+  alias Oli.Resources.ResourceType
+  alias Oli.Activities
+  alias Oli.Authoring.MediaLibrary
+  alias Oli.Authoring.MediaLibrary.ItemOptions
+
+  @doc """
+  Generates a course digest for an existing course project.
+  """
+  def export(project) do
+    publication = AuthoringResolver.publication(project.slug)
+    resources = fetch_all_resources(publication)
+
+    ([
+       create_project_file(project),
+       create_media_manifest_file(project),
+       create_hierarchy_file(resources, publication)
+     ] ++
+       objectives(resources) ++
+       activities(resources) ++
+       pages(resources))
+    |> zip
+  end
+
+  defp zip(filename_content_tuples) do
+    {:ok, {_filename, data}} =
+      :zip.create(
+        "export.zip",
+        filename_content_tuples,
+        [:memory]
+      )
+
+    data
+  end
+
+  defp objectives(resources) do
+    Enum.filter(resources, fn r ->
+      r.resource_type_id == ResourceType.get_id_by_type("objective")
+    end)
+    |> Enum.map(fn r ->
+      %{
+        type: "Objective",
+        id: Integer.to_string(r.resource_id, 10),
+        originalFile: "",
+        title: r.title,
+        tags: [],
+        unresolvedReferences: [],
+        content: %{},
+        objectives: [],
+        children: Enum.map(r.children, fn id -> "#{id}" end)
+      }
+      |> entry("#{r.resource_id}.json")
+    end)
+  end
+
+  defp activities(resources) do
+    registrations =
+      Activities.list_activity_registrations()
+      |> Enum.reduce(%{}, fn r, m -> Map.put(m, r.id, r) end)
+
+    Enum.filter(resources, fn r ->
+      r.resource_type_id == ResourceType.get_id_by_type("activity")
+    end)
+    |> Enum.map(fn r ->
+      %{
+        type: "Activity",
+        id: Integer.to_string(r.resource_id, 10),
+        originalFile: "",
+        title: r.title,
+        tags: [],
+        unresolvedReferences: [],
+        content: r.content,
+        objectives: to_string_ids(r.objectives),
+        subType: Map.get(registrations, r.activity_type_id).slug
+      }
+      |> entry("#{r.resource_id}.json")
+    end)
+  end
+
+  defp to_string_ids(attached_objectives) do
+    Map.keys(attached_objectives)
+    |> Enum.reduce(%{}, fn part_id, m ->
+      Map.put(m, part_id, Enum.map(attached_objectives[part_id], fn id -> "#{id}" end))
+    end)
+  end
+
+  defp pages(resources) do
+    Enum.filter(resources, fn r ->
+      r.resource_type_id == ResourceType.get_id_by_type("page")
+    end)
+    |> Enum.map(fn r ->
+      %{
+        type: "Page",
+        id: Integer.to_string(r.resource_id, 10),
+        originalFile: "",
+        title: r.title,
+        tags: [],
+        unresolvedReferences: [],
+        content: r.content,
+        objectives: Map.get(r.objectives, "attached", []) |> Enum.map(fn id -> "#{id}" end),
+        isGraded: r.graded
+      }
+      |> entry("#{r.resource_id}.json")
+    end)
+  end
+
+  defp fetch_all_resources(publication) do
+    Publishing.get_published_resources_by_publication(publication.id)
+    |> Enum.filter(fn mapping -> mapping.revision.deleted == false end)
+    |> Enum.map(fn mapping -> mapping.revision end)
+  end
+
+  defp create_project_file(project) do
+    %{
+      title: project.title,
+      description: project.description,
+      type: "Manifest"
+    }
+    |> entry("_project.json")
+  end
+
+  defp create_media_manifest_file(project) do
+    {:ok, {items, _}} =
+      MediaLibrary.items(project.slug, Map.merge(ItemOptions.default(), %{limit: nil}))
+
+    mediaItems =
+      Enum.map(items, fn item ->
+        %{
+          name: item.file_name,
+          file: "",
+          url: item.url,
+          fileSize: item.file_size,
+          mimeType: item.mime_type,
+          md5: item.md5_hash
+        }
+      end)
+
+    %{
+      mediaItems: mediaItems,
+      type: "MediaManifest"
+    }
+    |> entry("_media-manifest.json")
+  end
+
+  defp create_hierarchy_file(resources, publication) do
+    revisions_by_id = Enum.reduce(resources, %{}, fn r, m -> Map.put(m, r.resource_id, r) end)
+    root = Map.get(revisions_by_id, publication.root_resource_id)
+
+    %{
+      type: "Hierarchy",
+      id: "",
+      originalFile: "",
+      title: "",
+      tags: [],
+      children: Enum.map(root.children, fn id -> full_hierarchy(revisions_by_id, id) end)
+    }
+    |> entry("_hierarchy.json")
+  end
+
+  defp entry(contents, name) do
+    {String.to_charlist(name), pretty(contents)}
+  end
+
+  defp pretty(map) do
+    Jason.encode_to_iodata!(map)
+    |> Jason.Formatter.pretty_print()
+  end
+
+  def full_hierarchy(revisions_by_id, resource_id) do
+    revision = Map.get(revisions_by_id, resource_id)
+
+    case ResourceType.get_type_by_id(revision.resource_type_id) do
+      "container" ->
+        %{
+          type: "container",
+          id: "#{resource_id}",
+          title: revision.title,
+          children: Enum.map(revision.children, fn id -> full_hierarchy(revisions_by_id, id) end)
+        }
+
+      "page" ->
+        %{
+          type: "item",
+          children: [],
+          idref: "#{resource_id}"
+        }
+    end
+  end
+end

--- a/lib/oli/interop/ingest.ex
+++ b/lib/oli/interop/ingest.ex
@@ -161,11 +161,23 @@ defmodule Oli.Interop.Ingest do
     end)
   end
 
+  # import / export can lead to situations where we need to consider first the key
+  # as an integer, and secondly the key as a string
+  defp retrieve(map, key) do
+    case Map.get(map, key) do
+      nil ->
+        Map.get(map, Integer.to_string(key, 10))
+
+      m ->
+        m
+    end
+  end
+
   defp rewire_activity_references(content, activity_map) do
     PageContent.map(content, fn e ->
       case e do
         %{"type" => "activity-reference", "activity_id" => original} = ref ->
-          Map.put(ref, "activity_id", Map.get(activity_map, original).resource_id)
+          Map.put(ref, "activity_id", retrieve(activity_map, original).resource_id)
 
         other ->
           other

--- a/lib/oli/interop/ingest.ex
+++ b/lib/oli/interop/ingest.ex
@@ -274,11 +274,15 @@ defmodule Oli.Interop.Ingest do
 
   # create the course hierarchy
   defp create_hierarchy(project, root_revision, page_map, hierarchy_details, as_author) do
-    # filter for the top-level containers, add recursively add them
+    # Process top-level items and containers, add recursively add containers
     children =
       Map.get(hierarchy_details, "children")
-      |> Enum.filter(fn c -> Map.get(c, "type") == "container" end)
-      |> Enum.map(fn c -> create_container(project, page_map, as_author, c) end)
+      |> Enum.map(fn c ->
+        case Map.get(c, "type") do
+          "item" -> Map.get(page_map, Map.get(c, "idref")).resource_id
+          "container" -> create_container(project, page_map, as_author, c)
+        end
+      end)
 
     # wire those newly created top-level containers into the root resource
     ChangeTracker.track_revision(project.slug, root_revision, %{children: children})

--- a/lib/oli/interop/ingest.ex
+++ b/lib/oli/interop/ingest.ex
@@ -277,6 +277,7 @@ defmodule Oli.Interop.Ingest do
     # Process top-level items and containers, add recursively add containers
     children =
       Map.get(hierarchy_details, "children")
+      |> Enum.filter(fn c -> c["type"] == "item" || c["type"] == "container" end)
       |> Enum.map(fn c ->
         case Map.get(c, "type") do
           "item" -> Map.get(page_map, Map.get(c, "idref")).resource_id

--- a/lib/oli_web/controllers/project_controller.ex
+++ b/lib/oli_web/controllers/project_controller.ex
@@ -188,6 +188,15 @@ defmodule OliWeb.ProjectController do
     )
   end
 
+  def download_export(conn, _project_params) do
+    project = conn.assigns.project
+
+    conn
+    |> send_download({:binary, Oli.Interop.Export.export(project)},
+      filename: "export_#{project.slug}.zip"
+    )
+  end
+
   def clone_project(conn, _project_params) do
     case Clone.clone_project(conn.assigns.project.slug, conn.assigns.current_author) do
       {:ok, project} ->

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -234,6 +234,7 @@ defmodule OliWeb.Router do
     get("/:project_id/publish", ProjectController, :publish)
     post("/:project_id/publish", ProjectController, :publish_active)
     post("/:project_id/datashop", ProjectController, :download_datashop)
+    post("/:project_id/export", ProjectController, :download_export)
     post("/:project_id/duplicate", ProjectController, :clone_project)
 
     # Project

--- a/lib/oli_web/templates/project/overview.html.eex
+++ b/lib/oli_web/templates/project/overview.html.eex
@@ -106,6 +106,14 @@
 
       <div class="row my-4">
         <div class="col-12">
+          <h4>Course export</h4>
+          <%= button("Export Course", to: Routes.project_path(@conn, :download_export, @project), method: :post, class: "btn btn-primary") %>
+        </div>
+      </div>
+
+
+      <div class="row my-4">
+        <div class="col-12">
           <h4>Datashop export</h4>
           <%= case Oli.Publishing.get_latest_published_publication_by_slug!(@project.slug) do %>
             <% nil -> %>

--- a/lib/oli_web/templates/project/overview.html.eex
+++ b/lib/oli_web/templates/project/overview.html.eex
@@ -1,3 +1,9 @@
+<style>
+  .action-button {
+    width: 100px;
+  }
+</style>
+
 <div class="overview container">
   <div class="row">
     <div class="col-12">
@@ -93,44 +99,50 @@
         </div>
       </div>
 
-      <div class="row my-4">
-        <div class="col-12">
-          <h4>Duplicate this course</h4>
-          <%= button("Duplicate Course",
-            to: Routes.project_path(@conn, :clone_project, @project),
-            method: :post,
-            class: "btn btn-primary",
-            data_confirm: "Are you sure you want to duplicate this project?") %>
-        </div>
-      </div>
+      <div class="card mt-4">
+        <div class="card-body">
+          <h4>Actions</h4>
 
-      <div class="row my-4">
-        <div class="col-12">
-          <h4>Course export</h4>
-          <%= button("Export Course", to: Routes.project_path(@conn, :download_export, @project), method: :post, class: "btn btn-primary") %>
-        </div>
-      </div>
+            <div style="margin: auto 0; width: 80%">
+              <div class="d-flex flex-row-reverse mt-3">
 
+                  <%= button("Duplicate",
+                    to: Routes.project_path(@conn, :clone_project, @project),
+                    method: :post,
+                    class: "btn btn-primary ml-5 action-button",
+                    data_confirm: "Are you sure you want to duplicate this project?") %>
 
-      <div class="row my-4">
-        <div class="col-12">
-          <h4>Datashop export</h4>
-          <%= case Oli.Publishing.get_latest_published_publication_by_slug!(@project.slug) do %>
-            <% nil -> %>
-              <p class="mb-2">
-                Project must be published to generate a datashop export file.
-              </p>
-              <button disabled class="btn btn-primary">Download Datashop Export</button>
-            <% _pub -> %>
-              <%= button("Download Datashop Export", to: Routes.project_path(@conn, :download_datashop, @project), method: :post, class: "btn btn-primary") %>
-          <% end %>
-        </div>
-      </div>
+                  <span>Create a complete <b>duplicate</b> of this course, with you as the owner</span>
 
-      <div class="row my-4">
-        <div class="col-12">
-          <h4>Delete this course</h4>
-          <button type="button" class="btn btn-danger" onclick="OLI.showModal('delete-package-modal')">Delete this Course</button>
+              </div>
+
+                <div class="d-flex flex-row-reverse mt-3">
+                  <%= button("Export", to: Routes.project_path(@conn, :download_export, @project), method: :post, class: "btn btn-primary ml-5 action-button") %>
+
+                  <span><b>Export</b> this course project as a downloadable <code>.zip</code> file</span>
+                  </div>
+
+                <div class="d-flex flex-row-reverse mt-3">
+
+                   <%= case Oli.Publishing.get_latest_published_publication_by_slug!(@project.slug) do %>
+                      <% nil -> %>
+                        <button disabled class="btn btn-primary ml-5 action-button"  data-toggle="tooltip" data-placement="top" title="Project must be published to generate a datashop export file.">Download</button>
+                      <% _pub -> %>
+                        <%= button("Download", to: Routes.project_path(@conn, :download_datashop, @project), method: :post, class: "btn btn-primary ml-5 action-button") %>
+                    <% end %>
+
+                    <span>Download a <b>Datashop</b> batch import <code>.xml</code> file</span>
+
+                </div>
+
+                <div class="d-flex flex-row-reverse mt-3">
+                  <button type="button" class="btn btn-danger ml-5 action-button" onclick="OLI.showModal('delete-package-modal')">Delete</button>
+
+                  <span>Permanently <b>delete</b> this course project. This cannot be undone.</span>
+                </div>
+
+            </div>
+
         </div>
       </div>
 

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -12,7 +12,6 @@
 
 alias Oli.Seeder
 alias Oli.Utils
-alias Oli.Snapshots.SnapshotSeeder
 alias Oli.Authoring.Collaborators
 alias Oli.Features
 
@@ -155,11 +154,7 @@ if Application.fetch_env!(:oli, :env) == :dev do
     admin_author =
       Oli.Accounts.get_author_by_email(System.get_env("ADMIN_EMAIL", "admin@example.edu"))
 
-    seeds =
-      Seeder.base_project_with_resource(admin_author)
-      |> Seeder.create_section()
-      |> Seeder.add_activity(%{title: "Activity with with no attempts"}, :activity_no_attempts)
-      |> SnapshotSeeder.setup_csv(Path.expand(__DIR__) <> "/test_snapshots.csv")
+    seeds = Seeder.base_project_with_resource(admin_author)
 
     Collaborators.add_collaborator(admin_author, seeds.project)
 


### PR DESCRIPTION
Closes #904 
Closes #1123 

This PR introduces course project export.  It is effectively the inverse operation of ingestion.  Course project export takes the current unpublished content and creates a downloadable .zip file containing a course digest. 

