### PR TITLE
Vendor script

### DIFF
--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -105,7 +105,7 @@ module.exports = (env, options) => ({
     minimize: process.env.NODE_ENV == 'production',
     minimizer: [new TerserPlugin(), new CssMinimizerPlugin()],
     chunkIds: "named",
-		splitChunks: {
+    splitChunks: {
       chunks: 'async',
       minSize: 20000,
       minRemainingSize: 0,

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -103,7 +103,29 @@ module.exports = (env, options) => ({
   devtool: 'source-map',
   optimization: {
     minimize: process.env.NODE_ENV == 'production',
-    minimizer: [new TerserPlugin()],
+    minimizer: [new TerserPlugin(), new CssMinimizerPlugin()],
+    chunkIds: "named",
+		splitChunks: {
+      chunks: 'async',
+      minSize: 20000,
+      minRemainingSize: 0,
+      minChunks: 1,
+      maxAsyncRequests: 30,
+      maxInitialRequests: 30,
+      enforceSizeThreshold: 50000,
+      cacheGroups: {
+        defaultVendors: {
+          test: /[\\/]node_modules[\\/]/,
+          priority: -10,
+          reuseExistingChunk: true,
+        },
+        default: {
+          minChunks: 2,
+          priority: -20,
+          reuseExistingChunk: true,
+        },
+      },
+    },
   },
   entry: populateEntries(),
   output: {


### PR DESCRIPTION
This restores the generation of `vendor.js`.  Oddly, though, I had to leave in the `shared.js` which bundles just `react` and `react-dom`.  As soon as I removed it I got the React hook error again that complained that multiple copies of React were loaded. 