### PR TITLE
[FEATURE] Implement remaining command-driven undos for activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add ability to generate and download a course digest from existing course projects
 - Redesign check all that apply activity
 - Merge activity editing into the page editor
+- Support undo operation for destructive edits in all activity types
 
 ## 0.11.1 (2021-6-16)
 

--- a/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyAuthoring.tsx
+++ b/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyAuthoring.tsx
@@ -35,7 +35,12 @@ import { TargetedFeedback } from 'components/activities/common/feedback/Targeted
 const store = configureStore();
 
 const CheckAllThatApply = (props: AuthoringElementProps<CheckAllThatApplyModelSchema>) => {
-  const dispatch = (action: any) => props.onEdit(produce(props.model, action));
+  const dispatch = (action: any) => {
+    const nextModel = produce(props.model, (draftState) =>
+      action(draftState, props.onPostUndoable),
+    );
+    props.onEdit(nextModel);
+  };
 
   return (
     <>

--- a/assets/src/components/activities/check_all_that_apply/actions.ts
+++ b/assets/src/components/activities/check_all_that_apply/actions.ts
@@ -27,7 +27,8 @@ import {
   makeHint,
 } from '../types';
 import { toSimpleText } from 'data/content/text';
-import { PostUndoable, makeUndoable, clone } from 'components/activities/types';
+import { PostUndoable, makeUndoable } from 'components/activities/types';
+import { clone } from 'utils/common';
 
 export class Actions {
   static toggleType() {

--- a/assets/src/components/activities/image_coding/ImageCodingAuthoring.tsx
+++ b/assets/src/components/activities/image_coding/ImageCodingAuthoring.tsx
@@ -26,7 +26,9 @@ const store = configureStore();
 
 const ImageCoding = (props: AuthoringElementProps<ImageCodingModelSchema>) => {
   const dispatch = (action: any) => {
-    const nextModel = produce(props.model, (draftState) => action(draftState));
+    const nextModel = produce(props.model, (draftState) =>
+      action(draftState, props.onPostUndoable),
+    );
     props.onEdit(nextModel);
   };
 

--- a/assets/src/components/activities/image_coding/actions.ts
+++ b/assets/src/components/activities/image_coding/actions.ts
@@ -4,6 +4,7 @@ import { RichText, Hint as HintType, Choice } from '../types';
 import { Maybe } from 'tsmonad';
 import { toSimpleText } from 'data/content/text';
 import { Identifiable } from 'data/content/model';
+import { PostUndoable, makeUndoable, clone } from 'components/activities/types';
 
 export class ICActions {
   private static getById<T extends Identifiable>(slice: T[], id: string): Maybe<T> {
@@ -14,7 +15,7 @@ export class ICActions {
     ICActions.getById(draftState.authoring.parts[0].hints, id);
 
   static editStem(content: RichText) {
-    return (draftState: ImageCodingModelSchema) => {
+    return (draftState: ImageCodingModelSchema, post: PostUndoable) => {
       draftState.stem.content = content;
       const previewText = toSimpleText({ children: content.model } as any);
       draftState.authoring.previewText = previewText;
@@ -22,25 +23,25 @@ export class ICActions {
   }
 
   static editStarterCode(text: string) {
-    return (draftState: ImageCodingModelSchema) => {
+    return (draftState: ImageCodingModelSchema, post: PostUndoable) => {
       draftState.starterCode = text;
     };
   }
 
   static editSolutionCode(text: string) {
-    return (draftState: ImageCodingModelSchema) => {
+    return (draftState: ImageCodingModelSchema, post: PostUndoable) => {
       draftState.solutionCode = text;
     };
   }
 
   static editIsExample(value: boolean) {
-    return (draftState: ImageCodingModelSchema) => {
+    return (draftState: ImageCodingModelSchema, post: PostUndoable) => {
       draftState.isExample = value;
     };
   }
 
   static addResourceURL(value: string) {
-    return (draftState: ImageCodingModelSchema) => {
+    return (draftState: ImageCodingModelSchema, post: PostUndoable) => {
       if (draftState.resourceURLs.indexOf(value) === -1) {
         draftState.resourceURLs.push(value);
       }
@@ -48,31 +49,37 @@ export class ICActions {
   }
 
   static removeResourceURL(value: string) {
-    return (draftState: ImageCodingModelSchema) => {
+    return (draftState: ImageCodingModelSchema, post: PostUndoable) => {
+
+      const index = draftState.resourceURLs.findIndex((url) => url === value);
+      const item = draftState.resourceURLs[index];
+      post(makeUndoable('Removed a file',
+        [{ type: 'InsertOperation', path: '$.resourceURLs', index, item: clone(item)}]));
+
       draftState.resourceURLs = draftState.resourceURLs.filter((url) => url !== value);
     };
   }
 
   static editTolerance(value: number) {
-    return (draftState: ImageCodingModelSchema) => {
+    return (draftState: ImageCodingModelSchema, post: PostUndoable) => {
       draftState.tolerance = value;
     };
   }
 
   static editRegex(value: string) {
-    return (draftState: ImageCodingModelSchema) => {
+    return (draftState: ImageCodingModelSchema, post: PostUndoable) => {
       draftState.regex = value;
     };
   }
 
   static editFeedback(score: number, content: RichText) {
-    return (draftState: ImageCodingModelSchema) => {
+    return (draftState: ImageCodingModelSchema, post: PostUndoable) => {
       draftState.feedback[score].content = content;
     };
   }
 
   static addHint() {
-    return (draftState: ImageCodingModelSchema) => {
+    return (draftState: ImageCodingModelSchema, post: PostUndoable) => {
       const newHint: HintType = fromText('');
       // new hints are always cognitive hints. they should be inserted
       // right before the bottomOut hint at the end of the list
@@ -82,13 +89,19 @@ export class ICActions {
   }
 
   static editHint(id: string, content: RichText) {
-    return (draftState: ImageCodingModelSchema) => {
+    return (draftState: ImageCodingModelSchema, post: PostUndoable) => {
       ICActions.getHint(draftState, id).lift((hint) => (hint.content = content));
     };
   }
 
   static removeHint(id: string) {
-    return (draftState: ImageCodingModelSchema) => {
+    return (draftState: ImageCodingModelSchema, post: PostUndoable) => {
+
+      const hint = draftState.authoring.parts[0].hints.find((h) => h.id === id);
+      const index = draftState.authoring.parts[0].hints.findIndex((h) => h.id === id);
+      post(makeUndoable('Removed a hint',
+        [{ type: 'InsertOperation', path: '$.authoring.parts[0].hints', index, item: clone(hint)}]));
+
       draftState.authoring.parts[0].hints = draftState.authoring.parts[0].hints.filter(
         (h) => h.id !== id,
       );

--- a/assets/src/components/activities/image_coding/actions.ts
+++ b/assets/src/components/activities/image_coding/actions.ts
@@ -4,7 +4,8 @@ import { RichText, Hint as HintType, Choice } from '../types';
 import { Maybe } from 'tsmonad';
 import { toSimpleText } from 'data/content/text';
 import { Identifiable } from 'data/content/model';
-import { PostUndoable, makeUndoable, clone } from 'components/activities/types';
+import { PostUndoable, makeUndoable } from 'components/activities/types';
+import { clone } from 'utils/common';
 
 export class ICActions {
   private static getById<T extends Identifiable>(slice: T[], id: string): Maybe<T> {

--- a/assets/src/components/activities/multiple_choice/actions.ts
+++ b/assets/src/components/activities/multiple_choice/actions.ts
@@ -4,7 +4,8 @@ import { RichText, Hint as HintType, Choice } from '../types';
 import { Maybe } from 'tsmonad';
 import { toSimpleText } from 'data/content/text';
 import { Identifiable } from 'data/content/model';
-import { PostUndoable, makeUndoable, clone } from 'components/activities/types';
+import { PostUndoable, makeUndoable } from 'components/activities/types';
+import { clone } from 'utils/common';
 
 export class MCActions {
   private static getById<T extends Identifiable>(slice: T[], id: string): Maybe<T> {

--- a/assets/src/components/activities/ordering/OrderingAuthoring.tsx
+++ b/assets/src/components/activities/ordering/OrderingAuthoring.tsx
@@ -20,7 +20,7 @@ const store = configureStore();
 
 const Ordering = (props: AuthoringElementProps<OrderingModelSchema>) => {
   const dispatch = (action: any) =>
-    props.onEdit(produce(props.model, (draftState) => action(draftState)));
+    props.onEdit(produce(props.model, (draftState) => action(draftState, props.onPostUndoable)));
 
   const sharedProps = {
     model: props.model,

--- a/assets/src/components/activities/ordering/actions.ts
+++ b/assets/src/components/activities/ordering/actions.ts
@@ -23,7 +23,8 @@ import {
 } from './utils';
 import { RichText, Hint as HintType, ChoiceId, Choice, ResponseId } from '../types';
 import { toSimpleText } from 'data/content/text';
-import { PostUndoable, makeUndoable, clone } from 'components/activities/types';
+import { PostUndoable, makeUndoable } from 'components/activities/types';
+import { clone } from 'utils/common';
 
 export class Actions {
   static toggleType() {

--- a/assets/src/components/activities/ordering/actions.ts
+++ b/assets/src/components/activities/ordering/actions.ts
@@ -65,15 +65,15 @@ export class Actions {
 
   static removeChoice(id: ChoiceId) {
     return (model: Ordering, post: PostUndoable) => {
+
+      post(makeUndoable('Removed choice',
+      [{ type: 'ReplaceOperation', path: '$.authoring', item: clone(model.authoring) },
+       { type: 'ReplaceOperation', path: '$.choices', item: clone(model.choices) }
+      ]));
+
       const removeIdFrom = (list: ChoiceId[]) => removeFromList(id, list);
       model.choices = model.choices.filter((choice) => choice.id !== id);
       removeIdFrom(getChoiceIds(model.authoring.correct));
-
-      post(makeUndoable('Removed choice',
-        [{ type: 'ReplaceOperation', path: '$.authoring', item: clone(model.authoring) },
-         { type: 'ReplaceOperation', path: '$.choices', item: clone(model.choices) }
-        ]));
-
 
       switch (model.type) {
         case 'SimpleOrdering':

--- a/assets/src/components/activities/short_answer/ShortAnswerAuthoring.tsx
+++ b/assets/src/components/activities/short_answer/ShortAnswerAuthoring.tsx
@@ -53,10 +53,8 @@ export const InputTypeDropdown = ({ onChange, editMode, inputType }: InputTypeDr
 };
 
 const ShortAnswer = (props: AuthoringElementProps<ShortAnswerModelSchema>) => {
-  const dispatch = (action: any) => {
-    const nextModel = produce(props.model, (draftState) => action(draftState));
-    props.onEdit(nextModel);
-  };
+  const dispatch = (action: any) =>
+    props.onEdit(produce(props.model, (draftState) => action(draftState, props.onPostUndoable)));
 
   const sharedProps = {
     model: props.model,

--- a/assets/src/components/activities/short_answer/actions.ts
+++ b/assets/src/components/activities/short_answer/actions.ts
@@ -5,7 +5,8 @@ import { RichText, Hint as HintType, Response } from '../types';
 import { Maybe } from 'tsmonad';
 import { toSimpleText } from 'data/content/text';
 import { Identifiable } from 'data/content/model';
-import { PostUndoable, makeUndoable, clone } from 'components/activities/types';
+import { PostUndoable, makeUndoable } from 'components/activities/types';
+import { clone } from 'utils/common';
 
 export class ShortAnswerActions {
   private static getById<T extends Identifiable>(slice: T[], id: string): Maybe<T> {

--- a/assets/src/components/activities/short_answer/actions.ts
+++ b/assets/src/components/activities/short_answer/actions.ts
@@ -66,9 +66,10 @@ export class ShortAnswerActions {
     return (draftState: ShortAnswerModelSchema, post: PostUndoable) => {
 
       const index = draftState.authoring.parts[0].responses.findIndex(
-        (r) => r.rule === `input like {${id}}`,
+        (r) => r.id === id,
       );
       const response = draftState.authoring.parts[0].responses[index];
+
       post(makeUndoable('Removed a response',
         [{ type: 'InsertOperation', path: '$.authoring.parts[0].responses', index, item: clone(response)}]));
 

--- a/assets/src/components/activities/types.ts
+++ b/assets/src/components/activities/types.ts
@@ -1,7 +1,7 @@
 import { create, ID, Identifiable, ModelElement, Selection } from 'data/content/model';
 import { ResourceContext } from 'data/content/resource';
 import { ResourceId } from 'data/types';
-import { InsertOperation } from 'utils/undo';
+import { UndoOperation } from 'utils/undo';
 import guid from 'utils/guid';
 
 export type PostUndoable = (undoable: Undoable) => void;
@@ -9,9 +9,20 @@ export type PostUndoable = (undoable: Undoable) => void;
 export type Undoable = {
   type: 'Undoable';
   description: string;
-  operations: InsertOperation[];
+  operations: UndoOperation[];
 }
 
+export function makeUndoable(description: string, operations: UndoOperation[]) : Undoable {
+  return {
+    type: 'Undoable',
+    description,
+    operations
+  };
+}
+
+export function clone(o : any) {
+  return JSON.parse(JSON.stringify(o));
+}
 
 export type ChoiceId = ID;
 export type ResponseId = ID;

--- a/assets/src/utils/common.ts
+++ b/assets/src/utils/common.ts
@@ -1,3 +1,14 @@
+
+/**
+ * Performs a deep copy, or clone, of an object.
+ *
+ * @param o the object to clone
+ * @returns the cloned object
+ */
+export function clone(o : any) {
+  return JSON.parse(JSON.stringify(o));
+}
+
 /**
  * Returns the given value if it is not null or undefined. Otherwise, it returns
  * the default value. The return value will always be a defined value of the type given

--- a/assets/src/utils/undo.ts
+++ b/assets/src/utils/undo.ts
@@ -20,10 +20,13 @@ export function applyOperations(json: Record<string, any>, ops: UndoOperation[])
 
     jp.apply(json, op.path, function(result: any) {
       if (op.type === 'InsertOperation') {
+        // Impl of 'InsertOperation' is to insert at a specific index an item
+        // into an array
         result.splice(op.index, 0, op.item);
         return result;
       } else {
-        console.log(op.item);
+        // Impl of 'ReplaceOperation' is simply returning the value of item
+        // that will then replace the item matched via 'path'
         return op.item;
       }
     });

--- a/assets/src/utils/undo.ts
+++ b/assets/src/utils/undo.ts
@@ -1,16 +1,30 @@
 import jp from 'jsonpath';
 
+export type UndoOperation = InsertOperation | ReplaceOperation;
+
 export type InsertOperation = {
+  type: 'InsertOperation',
   path: string;
   index: number;
   item: Record<string, unknown>;
 }
 
-export function applyOperations(json: Record<string, any>, ops: InsertOperation[]) : void {
+export type ReplaceOperation = {
+  type: 'ReplaceOperation',
+  path: string;
+  item: Record<string, unknown>;
+}
+
+export function applyOperations(json: Record<string, any>, ops: UndoOperation[]) : void {
   ops.forEach((op) => {
+
     jp.apply(json, op.path, function(result: any) {
-      result.splice(op.index, 0, op.item);
-      return result;
+      if (op.type === 'InsertOperation') {
+        result.splice(op.index, 0, op.item);
+        return result;
+      } else {
+        return op.item;
+      }
     });
   });
 }

--- a/assets/src/utils/undo.ts
+++ b/assets/src/utils/undo.ts
@@ -12,7 +12,7 @@ export type InsertOperation = {
 export type ReplaceOperation = {
   type: 'ReplaceOperation',
   path: string;
-  item: Record<string, unknown>;
+  item: any;
 }
 
 export function applyOperations(json: Record<string, any>, ops: UndoOperation[]) : void {
@@ -23,6 +23,7 @@ export function applyOperations(json: Record<string, any>, ops: UndoOperation[])
         result.splice(op.index, 0, op.item);
         return result;
       } else {
+        console.log(op.item);
         return op.item;
       }
     });

--- a/assets/test/check_all_that_apply/cata_authoring_test.ts
+++ b/assets/test/check_all_that_apply/cata_authoring_test.ts
@@ -13,7 +13,7 @@ const applyAction = (
   model: CheckAllThatApplyModelSchema,
   action: any) => {
 
-  return produce(model, draftState => action(draftState));
+  return produce(model, draftState => action(draftState, () => { return; }));
 };
 
 function testFromText(text: string) {

--- a/assets/test/ordering/ordering_authoring_test.ts
+++ b/assets/test/ordering/ordering_authoring_test.ts
@@ -15,7 +15,7 @@ const applyAction = (
   model: OrderingModelSchema,
   action: any) => {
 
-  return produce(model, draftState => action(draftState));
+  return produce(model, draftState => action(draftState, () => { return; }));
 };
 
 function testFromText(text: string) {

--- a/assets/test/short_answer/short_answer_authoring_test.ts
+++ b/assets/test/short_answer/short_answer_authoring_test.ts
@@ -8,7 +8,7 @@ const applyAction = (
   model: ShortAnswerModelSchema,
   action: any) => {
 
-  return produce(model, draftState => action(draftState));
+  return produce(model, draftState => action(draftState, () => { return; }));
 };
 
 function testFromText(text: string) {
@@ -27,7 +27,7 @@ function testFromText(text: string) {
   };
 }
 
-function testResponse(text: string, rule: string, score: number = 0) {
+function testResponse(text: string, rule: string, score = 0) {
   return {
     id: Math.random() + '',
     feedback: testFromText(text),

--- a/assets/test/utils/undo_test.ts
+++ b/assets/test/utils/undo_test.ts
@@ -1,4 +1,4 @@
-import { applyOperations, InsertOperation } from 'utils/undo';
+import { applyOperations, InsertOperation, ReplaceOperation } from 'utils/undo';
 
 const model = () =>  ({
   authoring: {
@@ -23,6 +23,7 @@ it('restores choices', () => {
   const copy = Object.assign({}, model());
 
   const op : InsertOperation = {
+    type: 'InsertOperation',
     item: { id: 4},
     index: 0,
     path: '$.choices'
@@ -35,10 +36,28 @@ it('restores choices', () => {
 });
 
 
+
+it('replaces items', () => {
+  const copy = Object.assign({}, model());
+
+  const op : ReplaceOperation = {
+    type: 'ReplaceOperation',
+    item: [{ id: 4}],
+    path: '$.choices'
+  };
+
+  applyOperations(copy, [op]);
+  expect(copy.choices.length).toEqual(1);
+  expect(copy.choices[0].id).toEqual(4);
+
+});
+
+
 it('restores choices robust to size of array', () => {
   const copy = Object.assign({}, model());
 
   const op : InsertOperation = {
+    type: 'InsertOperation',
     item: { id: 4},
     index: 10,
     path: '$.choices'
@@ -55,11 +74,13 @@ it('restores items in parallel arrays', () => {
   const copy = Object.assign({}, model());
 
   const choices : InsertOperation = {
+    type: 'InsertOperation',
     item: { id: 4},
     index: 0,
     path: '$.choices'
   };
   const responses : InsertOperation = {
+    type: 'InsertOperation',
     item: { id: 4},
     index: 0,
     path: '$.authoring.parts[0].responses'


### PR DESCRIPTION
Closes #1197 

This PR adds in generation of Undoables for all the rest of the activities, in all the places that they introduce destructive edits. 

Undoing removal of choices in CATA and Ordering is complex due to the post processing that occurs in these action impls. To simplify this, I added a new undo operation type: `ReplaceOperation` that simply replaces a matched node with another.  This allows these undos to simply restore entire sub-trees of the activity model.  There is some potential weirdness that can occur, however, with this approach.  Imagine this scenario, with a CATA:

1. User deletes a choice (A).  An undo is generated that restores the state of choices prior to this deletion. 
2. User deletes another choice (B). An undo is generated that restores the state of choices prior to this deletion. 
3. User clicks "Undo" on the undo from A... which then restores both choice A and B. 

This is a bit of an edge case, and isn't terrible in the grand scheme of things, but it is worth acknowleding. 

We could eliminate this by introducing a "scrubbing" step that the `ResourceEditor` would perform.  It could work like this: any time that a new undo is posted, the editor looks to see if there are any other undos for that same activity.  If there is, and either of these undos (the existing and the new) contain at least one `ReplaceOperation`, then the existing one is removed so that it cannot be invoked "out of order" and lead to unexpected results.  For now I think it makes sense to ship this without this optimization. 