### PR TITLE
Restore ability to edit activities

### DIFF
--- a/assets/src/apps/authoring/store/page/actions/initializeFromContext.ts
+++ b/assets/src/apps/authoring/store/page/actions/initializeFromContext.ts
@@ -21,7 +21,7 @@ export const initializeFromContext = createAsyncThunk(
       objectives: params.objectives,
       title: params.title,
       revisionSlug: params.resourceSlug,
-      resourceId: params.resource_id,
+      resourceId: params.resourceId,
     };
     dispatch(loadPage(pageState));
 

--- a/assets/src/apps/authoring/types.ts
+++ b/assets/src/apps/authoring/types.ts
@@ -21,6 +21,6 @@ export interface PageContext {
   editorMap?: any;
   projectSlug?: string;
   resourceSlug?: string;
-  resource_id?: ResourceId;
+  resourceId?: ResourceId;
   activities?: any;
 }

--- a/assets/src/components/resource/resourceEditor/ResourceEditor.tsx
+++ b/assets/src/components/resource/resourceEditor/ResourceEditor.tsx
@@ -266,7 +266,7 @@ export class ResourceEditor extends React.Component<ResourceEditorProps, Resourc
     // apply the edit
     const merged = Object.assign({}, this.state.activityContexts.get(key), withModel);
     const activityContexts = this.state.activityContexts.set(key, merged);
-    console.log(this.props.resourceId);
+
     this.setState({ activityContexts }, () => {
       const saveFn = (releaseLock: boolean) =>
         ActivityPersistence.edit(

--- a/assets/src/components/resource/resourceEditor/ResourceEditor.tsx
+++ b/assets/src/components/resource/resourceEditor/ResourceEditor.tsx
@@ -266,7 +266,7 @@ export class ResourceEditor extends React.Component<ResourceEditorProps, Resourc
     // apply the edit
     const merged = Object.assign({}, this.state.activityContexts.get(key), withModel);
     const activityContexts = this.state.activityContexts.set(key, merged);
-
+    console.log(this.props.resourceId);
     this.setState({ activityContexts }, () => {
       const saveFn = (releaseLock: boolean) =>
         ActivityPersistence.edit(

--- a/lib/oli/authoring/editing/page_context.ex
+++ b/lib/oli/authoring/editing/page_context.ex
@@ -5,7 +5,6 @@ defmodule Oli.Authoring.Editing.ResourceContext do
     :authorEmail,
     :projectSlug,
     :resourceSlug,
-    :resourceId,
     :title,
     :content,
     :objectives,

--- a/lib/oli/authoring/editing/page_context.ex
+++ b/lib/oli/authoring/editing/page_context.ex
@@ -5,7 +5,7 @@ defmodule Oli.Authoring.Editing.ResourceContext do
     :authorEmail,
     :projectSlug,
     :resourceSlug,
-    :resource_id,
+    :resourceId,
     :title,
     :content,
     :objectives,

--- a/lib/oli/authoring/editing/page_editor.ex
+++ b/lib/oli/authoring/editing/page_editor.ex
@@ -217,7 +217,7 @@ defmodule Oli.Authoring.Editing.PageEditor do
          authorEmail: author.email,
          projectSlug: project_slug,
          resourceSlug: revision_slug,
-         resource_id: revision.resource_id,
+         resourceId: revision.resource_id,
          editorMap: editor_map,
          objectives: revision.objectives,
          allObjectives: objectives_with_parent_reference,


### PR DESCRIPTION
Recent changes to master broke all activity editing from within a "basic page".  The cause was the removal of the `resourceId` property of the `ResourceContext` in favor of `resource_id`.  This PR restores that attribute, and allows it to be used where `resource_id` was expected. 
