### PR TITLE
[BUG FIX] Read rules module from oli priv dir

### DIFF
--- a/lib/oli/application.ex
+++ b/lib/oli/application.ex
@@ -30,7 +30,12 @@ defmodule Oli.Application do
         id: NodeJS,
         start:
           {NodeJS, :start_link,
-           [[path: "./priv/node", pool_size: Application.fetch_env!(:oli, :node_js_pool_size)]]}
+           [
+             [
+               path: "#{:code.priv_dir(:oli)}/node",
+               pool_size: Application.fetch_env!(:oli, :node_js_pool_size)
+             ]
+           ]}
       },
 
       # Starts the nonce cleanup task, call Lti_1p3.Nonces.cleanup_nonce_store/0 at 1:01 UTC every day


### PR DESCRIPTION
This PR fixes the issue `[error] Error when processing submit_activity "Cannot find module 'rules'` by reading the nodejs rules module from oli priv dir.

Tested on tokamak, verified it fixes the issue.