### PR TITLE
[BUG FIX] make image coding edits persist 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 - Fix an issue with image coding activity in preview
+- Persist student code in image coding activity
 
 ### Enhancements
 

--- a/assets/src/components/activities/image_coding/ImageCodingDelivery.tsx
+++ b/assets/src/components/activities/image_coding/ImageCodingDelivery.tsx
@@ -55,7 +55,9 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
   const [attemptState, setAttemptState] = useState(props.state);
   const [hints, setHints] = useState(props.state.parts[0].hints);
   const [hasMoreHints, setHasMoreHints] = useState(props.state.parts[0].hasMoreHints);
-  const [input, setInput] = useState(valueOr(model.starterCode, ''));
+  const [input, setInput] = useState(
+    attemptState.parts[0].response ? attemptState.parts[0].response.input : model.starterCode,
+  );
   const { stem, resourceURLs } = model;
   // runtime evaluation state:
   const [output, setOutput] = useState('');

--- a/assets/src/components/activities/image_coding/sections/ImageCodeEditor.tsx
+++ b/assets/src/components/activities/image_coding/sections/ImageCodeEditor.tsx
@@ -3,6 +3,7 @@ import AceEditor from 'react-ace';
 import 'ace-builds/src-noconflict/mode-javascript';
 import 'ace-builds/src-noconflict/theme-xcode';
 
+
 export type ImageCodeEditorProps = {
   value: string;
   onChange: (newValue: string) => void;
@@ -29,6 +30,7 @@ export const ImageCodeEditor = (props: ImageCodeEditorProps) => {
         showGutter: false,
         highlightActiveLine: false,
         fontSize: 14,
+        useWorker: false   // background worker script causes problems
       }}
     />
   );


### PR DESCRIPTION
Image coding activities were incorrectly initializing with starter code on every page reload, so were not persisting student edits. This fixes to restore prior edits in an image coding activity so contents persist across page reloads.

This could motivate a need to add some way to discard students' edits and reload the starter code, in order to start afresh from the instructor-written paradigm. In the original KTH course that function was provided by a button labelled "reset", but in Torus the "reset" button does something different.

Fixes #1191