### PR TITLE
[BUG FIX] fix error in multiple choice submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fix an issue preventing deletion of projects whose names contain special characters
 - Fix an issue related to persisting sessions across server restarts
 - Fix an issue where modals and rearrange were broken in curriculum view
+- Fix an issue where toggling multiple choice answer correctness could cause submission failures
 
 ## 0.11.0 (2021-6-15)
 

--- a/assets/src/components/activities/common/delivery/evaluation/Evaluation.tsx
+++ b/assets/src/components/activities/common/delivery/evaluation/Evaluation.tsx
@@ -39,7 +39,7 @@ export const Evaluation: React.FC<Props> = ({ shouldShow = true, attemptState, c
         </span>
       </div>
       <HtmlContentModelRenderer
-        text={error ? errorText : feedback ? feedback : makeFeedback('')}
+        text={error ? errorText.content : feedback ? feedback : makeFeedback('').content}
         context={context}
       />
     </div>

--- a/assets/src/components/activities/multiple_choice/MultipleChoiceAuthoring.tsx
+++ b/assets/src/components/activities/multiple_choice/MultipleChoiceAuthoring.tsx
@@ -46,7 +46,7 @@ const MultipleChoice = (props: AuthoringElementProps<MultipleChoiceModelSchema>)
           <ChoicesAuthoringConnected
             icon={<Radio.Unchecked />}
             choices={props.model.choices}
-            addOne={() => dispatch(Actions.addChoice(ActivityTypes.makeChoice('')))}
+            addOne={() => dispatch(ChoiceActions.addChoice(ActivityTypes.makeChoice('')))}
             setAll={(choices: ActivityTypes.Choice[]) =>
               dispatch(ChoiceActions.setAllChoices(choices))
             }

--- a/assets/src/components/activities/multiple_choice/actions.ts
+++ b/assets/src/components/activities/multiple_choice/actions.ts
@@ -1,32 +1,22 @@
 import { MultipleChoiceModelSchema } from './schema';
-import { Choice, makeResponse } from '../types';
 import { PostUndoable } from 'components/activities/types';
 import { ChoiceActions } from 'components/activities/common/choices/authoring/choiceActions';
-import { getCorrectResponse } from 'components/activities/multiple_choice/utils';
-import {
-  createMatchRule,
-  getResponses,
-} from 'components/activities/common/responses/authoring/responseUtils';
 import { getChoice, getChoices } from 'components/activities/common/choices/authoring/choiceUtils';
+import { createMatchRule } from 'components/activities/common/responses/authoring/responseUtils';
+import { getCorrectResponse } from 'components/activities/multiple_choice/utils';
 
 export const MCActions = {
-  addChoice(choice: Choice) {
-    return (model: MultipleChoiceModelSchema, post: PostUndoable) => {
-      ChoiceActions.addChoice(choice)(model, post);
-
-      model.authoring.parts[0].responses.push(makeResponse(`input like {${choice.id}}`, 0, ''));
-    };
-  },
-
   removeChoice(id: string) {
     return (model: MultipleChoiceModelSchema, post: PostUndoable) => {
       const choice = getChoice(model, id);
       const index = getChoices(model).findIndex((c) => c.id === id);
       ChoiceActions.removeChoice(id)(model, post);
 
-      model.authoring.parts[0].responses = getResponses(model).filter(
-        (r) => r.rule !== createMatchRule(id),
-      );
+      // if the choice being removed is the correct choice, a new correct choice
+      // must be set
+      if (getCorrectResponse(model).rule === createMatchRule(id)) {
+        MCActions.toggleChoiceCorrectness(model.choices[0].id)(model, post);
+      }
 
       post({
         description: 'Removed a choice',

--- a/assets/src/phoenix/activity_bridge.ts
+++ b/assets/src/phoenix/activity_bridge.ts
@@ -189,12 +189,13 @@ export const initPreviewActivityBridge = (elementId: string) => {
 
     Persistence.evaluate(props.model, partInputs).then((result: Persistence.Evaluated) => {
       const actions: FeedbackAction[] = result.evaluations.map((e: any) => {
+        // Persistence.evaluate returns a list of valid or error evaluations, so it may not have all properties
         return {
           type: 'FeedbackAction',
           error: e.error,
           attempt_guid: e.part_id,
-          out_of: e.result.out_of,
-          score: e.result.score,
+          out_of: e.result?.out_of,
+          score: e.result?.score,
           feedback: e.feedback,
         };
       });

--- a/assets/test/multiple_choice/mc_authoring_test.ts
+++ b/assets/test/multiple_choice/mc_authoring_test.ts
@@ -104,7 +104,7 @@ describe('multiple choice question', () => {
     const firstChoice = model.choices[0];
     const newModel = applyAction(model, MCActions.removeChoice(firstChoice.id));
     expect(newModel.choices).toHaveLength(1);
-    expect(newModel.authoring.parts[0].responses).toHaveLength(1);
+    expect(newModel.authoring.parts[0].responses).toHaveLength(2);
   });
 
   it('has the same number of responses as choices', () => {

--- a/assets/test/multiple_choice/mc_authoring_test.ts
+++ b/assets/test/multiple_choice/mc_authoring_test.ts
@@ -86,9 +86,9 @@ describe('multiple choice question', () => {
   });
 
   it('can add a choice', () => {
-    expect(applyAction(model, MCActions.addChoice(makeChoice(''))).choices.length).toBeGreaterThan(
-      model.choices.length,
-    );
+    expect(
+      applyAction(model, ChoiceActions.addChoice(makeChoice(''))).choices.length,
+    ).toBeGreaterThan(model.choices.length);
   });
 
   it('can edit a choice', () => {


### PR DESCRIPTION
Anders noticed a problem with multiple choice questions not evaluating correctly in preview mode. There were two issues:

1. The MC "add choice" logic was wrong. It created new feedback for each added choice, when they should just fall under the catch-all response.
2. The `activity_bridge` wasn't handling evaluation errors and threw instead of passing the evaluation error to the activity evaluation renderer which already handles these errors. 

To test:
1. Create a MCQ
2. Toggle the second choice to "Correct" under the answer key tab
3. Preview question, select the first choice (the incorrect choice which was correct originally when the question was created)
4. The submission should work (it didn't before).