### PR TITLE
chore: increase type coverage

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -11,7 +11,7 @@
     "build": "npm run clean && npm run lint && npm run test && npm run deploy",
     "clean": "del --force coverage/** ../priv/static",
     "lint": "eslint --quiet \"src/**/*.ts*\"",
-    "test": "jest",
+    "test": "jest && type-coverage",
     "test:watch": "jest --watch -o"
   },
   "dependencies": {
@@ -109,7 +109,13 @@
     "sass-loader": "^11.1.1",
     "ts-jest": "^26.5.4",
     "ts-loader": "^9.2.1",
+    "type-coverage": "^2.18.0",
     "webpack": "^5.36.0",
     "webpack-cli": "^4.7.0"
+  },
+  "typeCoverage": {
+    "atLeast": 84.5,
+    "detail": true,
+    "strict": true
   }
 }

--- a/assets/src/actions/media.ts
+++ b/assets/src/actions/media.ts
@@ -4,8 +4,6 @@ import { ProjectSlug } from 'data/types';
 import * as persistence from 'data/persistence/media';
 import { Maybe } from 'tsmonad';
 import { MediaItem, MediaRef } from 'types/media';
-// import * as messageActions from 'actions/messages';
-// import * as Messages from 'data/messages/messages';
 import guid from 'utils/guid';
 
 const MEDIA_PAGE_SIZE = 60;
@@ -138,7 +136,7 @@ export const fetchCourseMedia = (
         const items = List<MediaItem>(response.results);
 
         // check if the response is for the latest request
-        if ((getState() as any).media.lastReqId === reqId) {
+        if (getState().media.lastReqId === reqId) {
           // request is latest, update state
           dispatch(receiveMediaPage(courseId, items, response.totalResults));
           // dispatch(fetchMediaReferences(courseId) as any);
@@ -148,7 +146,7 @@ export const fetchCourseMedia = (
       }
       return Maybe.nothing<List<MediaItem>>();
     })
-    .catch((err) => {
+    .catch(() => {
       return Maybe.nothing<List<MediaItem>>();
     });
 };
@@ -161,10 +159,10 @@ export const fetchCourseMediaNextPage = (
   order?: string,
 ) => (dispatch: Dispatch, getState: () => State): Promise<Maybe<List<MediaItem>>> => {
   const limit = MEDIA_PAGE_SIZE;
-  const offset = (getState() as any).media.items.size || 0;
+  const offset = getState().media.items.size || 0;
 
   return dispatch(
-    fetchCourseMedia(courseId, offset, limit, mimeFilter, searchText, orderBy, order) as any,
+    fetchCourseMedia(courseId, offset, limit, mimeFilter, searchText, orderBy, order),
   );
 };
 

--- a/assets/src/components/messages/Message.tsx
+++ b/assets/src/components/messages/Message.tsx
@@ -16,20 +16,20 @@ const classesForSeverity = {
 };
 // eslint-disable-next-line
 export class Message extends React.PureComponent<MessageProps, {}> {
-  nav: any;
+  nav: HTMLDivElement | null;
 
   constructor(props: MessageProps) {
     super(props);
   }
 
-  onDismiss(e: any) {
+  onDismiss(e: React.MouseEvent<HTMLButtonElement>) {
     e.preventDefault();
 
     this.props.dismissMessage(this.props.message);
   }
 
   componentDidMount() {
-    this.nav.scrollIntoView(true);
+    this.nav?.scrollIntoView(true);
   }
 
   renderMessageAction(message: Messages.Message, action: Messages.MessageAction) {

--- a/assets/src/components/parts/janus-multi-line-text/MultiLineTextInput.tsx
+++ b/assets/src/components/parts/janus-multi-line-text/MultiLineTextInput.tsx
@@ -4,10 +4,8 @@ import {
   subscribeToNotification,
 } from '../../../apps/delivery/components/NotificationContext';
 import debounce from 'lodash/debounce';
-import React, { CSSProperties, useCallback, useEffect, useRef, useState } from 'react';
-import { parseBool } from 'utils/common';
+import React, { ChangeEvent, CSSProperties, useCallback, useEffect, useRef, useState } from 'react';
 import { CapiVariableTypes } from '../../../adaptivity/capi';
-import { CapiVariable } from '../types/parts';
 
 const MultiLineTextInput: React.FC<any> = (props) => {
   const [state, setState] = useState<any[]>(Array.isArray(props.state) ? props.state : []);
@@ -15,7 +13,7 @@ const MultiLineTextInput: React.FC<any> = (props) => {
   const [ready, setReady] = useState<boolean>(false);
   const id: string = props.id;
 
-  const characterCounterRef = useRef<any>(null);
+  const characterCounterRef = useRef<HTMLSpanElement>(null);
   const [text, setText] = useState<string>('');
   const [enabled, setEnabled] = useState(true);
   const [cssClass, setCssClass] = useState('');
@@ -224,9 +222,9 @@ const MultiLineTextInput: React.FC<any> = (props) => {
     });
   };
 
-  const handleOnChange = (event: any) => {
+  const handleOnChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
     const val = event.target.value;
-    characterCounterRef.current.innerText = val.length;
+    if (characterCounterRef.current) characterCounterRef.current.innerText = val.length.toString();
     setText(val);
     // Wait until user has stopped typing to save the new value
     debounceInputText(val);

--- a/assets/src/components/parts/janus-popup/Popup.tsx
+++ b/assets/src/components/parts/janus-popup/Popup.tsx
@@ -46,7 +46,7 @@ const Popup: React.FC<any> = (props) => {
     /* console.log('POPUP INIT', initResult); */
     // result of init has a state snapshot with latest (init state applied)
     const currentStateSnapshot = initResult.snapshot;
-    const isOpen = currentStateSnapshot[`stage.${id}.isOpen`];
+    const isOpen: boolean | undefined = currentStateSnapshot[`stage.${id}.isOpen`];
     if (isOpen !== undefined) {
       setShowPopup(isOpen);
     }

--- a/assets/src/components/parts/janus-slider/Slider.tsx
+++ b/assets/src/components/parts/janus-slider/Slider.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import React, { CSSProperties, useCallback, useEffect, useRef, useState } from 'react';
+import React, { ChangeEvent, CSSProperties, useCallback, useEffect, useRef, useState } from 'react';
 import { CapiVariableTypes } from '../../../adaptivity/capi';
 import {
   NotificationType,
@@ -13,8 +13,8 @@ const Slider: React.FC<any> = (props) => {
   const [ready, setReady] = useState<boolean>(false);
 
   const id: string = props.id;
-  const [inputInnerWidth, setInputInnerWidth] = useState<any>(0);
-  const [spanInnerWidth, setSpanInnerWidth] = useState<any>(0);
+  const [inputInnerWidth, setInputInnerWidth] = useState<number>(0);
+  const [spanInnerWidth, setSpanInnerWidth] = useState<number>(0);
 
   const [sliderValue, setSliderValue] = useState(0);
   const [isSliderEnabled, setIsSliderEnabled] = useState(true);
@@ -166,8 +166,6 @@ const Slider: React.FC<any> = (props) => {
     z,
     width,
     height,
-    src,
-    alt,
     customCssClass,
     label,
     maximum,
@@ -175,11 +173,8 @@ const Slider: React.FC<any> = (props) => {
     snapInterval,
     showDataTip,
     showValueLabels,
-    showThumbByDefault,
     showLabel,
-    showTicks,
     invertScale,
-    value,
   } = model;
 
   const styles: CSSProperties = {
@@ -203,9 +198,9 @@ const Slider: React.FC<any> = (props) => {
     flexDirection: 'row',
   };
 
-  const inputWidth: any = inputInnerWidth;
-  const thumbWidth: any = spanInnerWidth;
-  const thumbHalfWidth: any = thumbWidth / 2;
+  const inputWidth = inputInnerWidth;
+  const thumbWidth = spanInnerWidth;
+  const thumbHalfWidth = thumbWidth / 2;
   const thumbPosition =
     ((Number(sliderValue) - minimum) / (maximum - minimum)) *
     (inputWidth - thumbWidth + thumbHalfWidth);
@@ -229,9 +224,10 @@ const Slider: React.FC<any> = (props) => {
     });
   };
 
-  const handleSliderChange = (e: any) => {
-    setSliderValue(e.target.value);
-    saveState({ sliderVal: e.target.value, userModified: true });
+  const handleSliderChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const sliderVal = parseInt(e.target.value, 10);
+    setSliderValue(sliderVal);
+    saveState({ sliderVal, userModified: true });
   };
   const inputTargetRef = useRef<HTMLInputElement>(null);
   useEffect(() => {

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -3931,6 +3931,17 @@ fast-deep-equal@3.1.3, fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
+fast-glob@3:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.7.tgz#fd6cb7a2d7e9aa7a7846111e85a196d6b2f766a1"
+  integrity sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
 fast-glob@^3.0.3, fast-glob@^3.1.1, fast-glob@^3.2.5:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.6.tgz#434dd9529845176ea049acc9343e8282765c6e1a"
@@ -5995,7 +6006,7 @@ mini-css-extract-plugin@^1.6.0:
     schema-utils "^3.0.0"
     webpack-sources "^1.1.0"
 
-minimatch@^3.0.4:
+minimatch@3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -6011,7 +6022,7 @@ minimist-options@^4.0.2:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
+minimist@1, minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -6188,17 +6199,17 @@ normalize-package-data@^2.5.0:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
+normalize-path@3, normalize-path@^3.0.0, normalize-path@~3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
+  integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
+
 normalize-path@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
   integrity sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=
   dependencies:
     remove-trailing-separator "^1.0.1"
-
-normalize-path@^3.0.0, normalize-path@~3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
-  integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
 normalize-url@^6.0.1:
   version "6.1.0"
@@ -8454,6 +8465,11 @@ ts-loader@^9.2.1:
     micromatch "^4.0.0"
     semver "^7.3.4"
 
+"tslib@1 || 2":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
+  integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
+
 tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -8464,7 +8480,7 @@ tsmonad@^0.8.0:
   resolved "https://registry.yarnpkg.com/tsmonad/-/tsmonad-0.8.0.tgz#ce3cf13192f323db8f78c81f54a5f5bc4a2130fc"
   integrity sha1-zjzxMZLzI9uPeMgfVKX1vEohMPw=
 
-tsutils@^3.21.0:
+tsutils@3, tsutils@^3.21.0:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
   integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
@@ -8496,6 +8512,25 @@ type-check@~0.3.2:
   integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
   dependencies:
     prelude-ls "~1.1.2"
+
+type-coverage-core@^2.17.5:
+  version "2.17.5"
+  resolved "https://registry.yarnpkg.com/type-coverage-core/-/type-coverage-core-2.17.5.tgz#c5fd423be515c9207c82d7fa529847fefed19e6a"
+  integrity sha512-FfkH2kIgQkkgC47V2WHJZWBbjYjMw2ZpQRdRGTcMBAnkijmRCp9I1LpOuI+Gv4MDtniRLnkAo8htGGt2iExFgA==
+  dependencies:
+    fast-glob "3"
+    minimatch "3"
+    normalize-path "3"
+    tslib "1 || 2"
+    tsutils "3"
+
+type-coverage@^2.18.0:
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/type-coverage/-/type-coverage-2.18.0.tgz#ed2fc6d23a4517bae0bb7ee54863e6c77461165a"
+  integrity sha512-SAyrR6Xl7GfHNcXU8Y3wSnJfGftdCvf/b2JlJJtt7gt74T0dCF077/ukhlLjI/MsWmRCxW8k8x/d4AjrFiLSpQ==
+  dependencies:
+    minimist "1"
+    type-coverage-core "^2.17.5"
 
 type-detect@4.0.8, type-detect@^4.0.8:
   version "4.0.8"


### PR DESCRIPTION
builds on #1249 

replaces `any` with a specific type, and addresses warning/errors that arise.

increases coverage from 84.68%. with 47215 of 55753 identifiers covered, to 84.78%  with 47273 of 55755 identifiers covered.