### PR TITLE
[BUG FIX] Fix restoring "in progress" activity state from persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 - Fix an issue where deleting multiple choice answers could put the question in a state where no incorrect answer is found
+- Fix an issue where activities do not correctly restore their "in-progress" state from student work
 
 ### Enhancements
 

--- a/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyDelivery.tsx
+++ b/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyDelivery.tsx
@@ -1,6 +1,6 @@
 import { Checkbox } from 'components/misc/icons/checkbox/Checkbox';
-import { ChoiceId, Manifest } from 'components/activities/types';
-import { isCorrect } from 'data/content/activities/activityUtils';
+import { Manifest } from 'components/activities/types';
+import { initialSelection, isCorrect } from 'data/content/activities/utils';
 import {
   ActivityDeliveryState,
   initializeState,
@@ -26,10 +26,7 @@ import { EvaluationConnected } from 'components/activities/common/delivery/evalu
 import { GradedPointsConnected } from 'components/activities/common/delivery/gradedPoints/GradedPointsConnected';
 import { StemDeliveryConnected } from 'components/activities/common/stem/delivery/StemDeliveryConnected';
 import { ChoicesDeliveryConnected } from 'components/activities/common/choices/delivery/ChoicesDeliveryConnected';
-import { valueOr } from 'utils/common';
 import { CATASchema } from 'components/activities/check_all_that_apply/schema';
-import { Maybe } from 'tsmonad';
-import { cataV1toV2 } from 'components/activities/check_all_that_apply/transformations/v2';
 
 export const CheckAllThatApplyComponent: React.FC = () => {
   const {
@@ -41,17 +38,7 @@ export const CheckAllThatApplyComponent: React.FC = () => {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    dispatch(
-      initializeState(
-        activityState,
-        valueOr(
-          activityState.parts[0]?.response?.input
-            ?.split(' ')
-            .reduce((ids: string[], id: string) => ids.concat([id]), [] as ChoiceId[]),
-          [],
-        ),
-      ),
-    );
+    dispatch(initializeState(activityState, initialSelection(activityState)));
   }, []);
 
   // First render initializes state

--- a/assets/src/components/activities/common/delivery/gradedPoints/GradedPointsConnected.tsx
+++ b/assets/src/components/activities/common/delivery/gradedPoints/GradedPointsConnected.tsx
@@ -2,7 +2,7 @@ import { GradedPoints } from 'components/activities/common/delivery/gradedPoints
 import { useDeliveryElementContext } from 'components/activities/DeliveryElement';
 import { Checkmark } from 'components/misc/icons/Checkmark';
 import { Cross } from 'components/misc/icons/Cross';
-import { isCorrect } from 'data/content/activities/activityUtils';
+import { isCorrect } from 'data/content/activities/utils';
 import { ActivityDeliveryState } from 'data/content/activities/DeliveryState';
 import React from 'react';
 import { useSelector } from 'react-redux';

--- a/assets/src/components/activities/image_coding/ImageCodingDelivery.tsx
+++ b/assets/src/components/activities/image_coding/ImageCodingDelivery.tsx
@@ -13,7 +13,6 @@ import { Stem } from '../common/DisplayedStem';
 import { Hints } from '../common/DisplayedHints';
 import { Reset } from '../common/Reset';
 import { Evaluation } from '../common/delivery/evaluation/Evaluation';
-import { valueOr } from 'utils/common';
 import { Evaluator, EvalContext } from './Evaluator';
 import { lastPart } from './utils';
 import { defaultWriterContext } from 'data/content/writers/context';
@@ -25,26 +24,6 @@ type Evaluation = {
   feedback: ActivityTypes.RichText;
 };
 
-type InputProps = {
-  input: any;
-  onChange: (input: any) => void;
-  isEvaluated: boolean;
-};
-
-const Input = (props: InputProps) => {
-  const input = props.input === null ? '' : props.input;
-
-  return (
-    <textarea
-      rows={7}
-      cols={80}
-      className="form-control"
-      onChange={(e: any) => props.onChange(e.target.value)}
-      value={input}
-      disabled={props.isEvaluated}
-    />
-  );
-};
 // eslint-disable-next-line
 export interface ImageCodingDeliveryProps extends DeliveryElementProps<ImageCodingModelSchema> {
   // output: string;

--- a/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
+++ b/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
@@ -19,7 +19,7 @@ import {
   resetAction,
 } from 'data/content/activities/DeliveryState';
 import { Radio } from 'components/misc/icons/radio/Radio';
-import { isCorrect } from 'data/content/activities/activityUtils';
+import { initialSelection, isCorrect } from 'data/content/activities/utils';
 import { EvaluationConnected } from 'components/activities/common/delivery/evaluation/EvaluationConnected';
 import { HintsDeliveryConnected } from 'components/activities/common/hints/delivery/HintsDeliveryConnected';
 import { SubmitButtonConnected } from 'components/activities/common/delivery/submitButton/SubmitButtonConnected';
@@ -27,7 +27,6 @@ import { ResetButtonConnected } from 'components/activities/common/delivery/rese
 import { GradedPointsConnected } from 'components/activities/common/delivery/gradedPoints/GradedPointsConnected';
 import { StemDeliveryConnected } from 'components/activities/common/stem/delivery/StemDeliveryConnected';
 import { ChoicesDeliveryConnected } from 'components/activities/common/choices/delivery/ChoicesDeliveryConnected';
-import { valueOr } from 'utils/common';
 
 export const MultipleChoiceComponent: React.FC = () => {
   const {
@@ -39,7 +38,7 @@ export const MultipleChoiceComponent: React.FC = () => {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    dispatch(initializeState(activityState, valueOr(activityState?.parts[0]?.response?.input, [])));
+    dispatch(initializeState(activityState, initialSelection(activityState)));
   }, []);
 
   // First render initializes state

--- a/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
+++ b/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
@@ -24,6 +24,7 @@ import {
   resetAction,
 } from 'data/content/activities/DeliveryState';
 import { configureStore } from 'state/store';
+import { safelySelectInput } from 'data/content/activities/utils';
 
 type InputProps = {
   input: string;
@@ -84,7 +85,17 @@ export const ShortAnswerComponent: React.FC = () => {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    dispatch(initializeState(activityState, valueOr(uiState.attemptState?.parts[0].response, '')));
+    dispatch(
+      initializeState(
+        activityState,
+        // Short answers only have one input, but the selection is modeled
+        // as an array just to make it consistent with the other activity types
+        safelySelectInput(activityState).caseOf({
+          just: (input) => [input],
+          nothing: () => [''],
+        }),
+      ),
+    );
   }, []);
 
   // First render initializes state
@@ -108,6 +119,8 @@ export const ShortAnswerComponent: React.FC = () => {
 
         <Input
           inputType={model.inputType}
+          // Short answers only have one selection, but are modeled as an array.
+          // Select the first element.
           input={uiState.selection[0]}
           isEvaluated={isEvaluated(uiState)}
           onChange={onInputChange}

--- a/assets/src/data/content/activities/DeliveryState.ts
+++ b/assets/src/data/content/activities/DeliveryState.ts
@@ -11,6 +11,7 @@ import {
   PartResponse,
   Success,
 } from 'components/activities/types';
+import { selectionToInput } from 'data/content/activities/utils';
 import { Maybe } from 'tsmonad';
 
 export type AppThunk<ReturnType = void> = ThunkAction<
@@ -84,7 +85,6 @@ export const requestHint =
     dispatch(slice.actions.setHasMoreHints(response.hasMoreHints));
   };
 
-export const selectedChoicesToInput = (state: ActivityDeliveryState) => state.selection.join(' ');
 export const selectAttemptState = (state: ActivityDeliveryState) => state.attemptState;
 export const isEvaluated = (state: ActivityDeliveryState) =>
   selectAttemptState(state).score !== null;
@@ -113,7 +113,7 @@ export const submit =
     const response = await onSubmitActivity(getState().attemptState.attemptGuid, [
       {
         attemptGuid: getState().attemptState.parts[0].attemptGuid,
-        response: { input: selectedChoicesToInput(getState()) },
+        response: { input: selectionToInput(getState().selection) },
       },
     ]);
     dispatch(slice.actions.activitySubmissionReceived(response));
@@ -149,7 +149,7 @@ export const setSelection =
     return onSaveActivity(getState().attemptState.attemptGuid, [
       {
         attemptGuid: getState().attemptState.parts[0].attemptGuid,
-        response: { input: selectedChoicesToInput(getState()) },
+        response: { input: selectionToInput(getState().selection) },
       },
     ]);
   };

--- a/assets/src/data/content/activities/activityUtils.ts
+++ b/assets/src/data/content/activities/activityUtils.ts
@@ -1,3 +1,0 @@
-import { ActivityState } from 'components/activities/types';
-
-export const isCorrect = (activityState: ActivityState) => activityState.score !== 0;

--- a/assets/src/data/content/activities/utils.ts
+++ b/assets/src/data/content/activities/utils.ts
@@ -1,0 +1,25 @@
+import { ActivityState, ChoiceId } from 'components/activities/types';
+import { Maybe } from 'tsmonad';
+
+// Activity delivery components have an `input` string which is the persisted value
+// of a student's entry saved with `onSaveActivity` or submitted with
+// `onSubmitActivity`. These functions convert between the `input` string and the
+// `selection` which is a `ChoiceId[]` that is used directly by the delivery components.
+export const selectionToInput = (selection: ChoiceId[]) => selection.join(' ');
+export const inputToSelection = (input: string): ChoiceId[] =>
+  input.split(' ').reduce((ids, id) => ids.concat([id]), [] as ChoiceId[]);
+// An `ActivityState` only has an input if it has been saved or submitted
+export const safelySelectInput = (activityState: ActivityState | undefined): Maybe<string> =>
+  Maybe.maybe(activityState?.parts[0]?.response?.input);
+
+export const initialSelection = (
+  activityState: ActivityState | undefined,
+  defaultSelection: ChoiceId[] = [],
+): ChoiceId[] =>
+  safelySelectInput(activityState).caseOf({
+    just: inputToSelection,
+    nothing: () => defaultSelection,
+  });
+
+// Is an activity evaluation correct? This does not support partial credit.
+export const isCorrect = (activityState: ActivityState) => activityState.score !== 0;

--- a/assets/test/activities/redux_delivery_test.ts
+++ b/assets/test/activities/redux_delivery_test.ts
@@ -1,0 +1,63 @@
+import { defaultCATAModel } from 'components/activities/check_all_that_apply/utils';
+import { defaultDeliveryElementProps } from '../utils/activity_mocks';
+import '@testing-library/jest-dom';
+import { configureStore } from 'state/store';
+import { activityDeliverySlice, setSelection } from 'data/content/activities/DeliveryState';
+import { defaultState } from 'phoenix/activity_bridge';
+import { makeHint } from 'components/activities/types';
+import { Dispatch, Store } from 'redux';
+import { ActivityDeliveryState, initializeState } from 'data/content/activities/DeliveryState';
+import {
+  initialSelection,
+  inputToSelection,
+  selectionToInput,
+} from 'data/content/activities/utils';
+
+describe('activity delivery state management', () => {
+  const model = defaultCATAModel();
+  model.authoring.parts[0].hints.push(makeHint('Hint 1'));
+  const defaultActivityState = defaultState(model);
+  const props = {
+    model,
+    activitySlug: 'activity-slug',
+    state: Object.assign(defaultActivityState, { hasMoreHints: false }),
+    graded: false,
+    preview: false,
+  };
+  const { onSaveActivity } = defaultDeliveryElementProps;
+  const store: Store<ActivityDeliveryState> = configureStore({}, activityDeliverySlice.reducer);
+  const dispatch: Dispatch<any> = store.dispatch;
+
+  it('can initialize state', () => {
+    dispatch(initializeState(props.state, initialSelection(props.state)));
+    expect(store.getState().attemptState).toEqual(props.state);
+    expect(store.getState().hints).toEqual(props.state.parts[0].hints);
+    expect(store.getState().hasMoreHints).toBe(true);
+    expect(store.getState().selection).toEqual([]);
+  });
+
+  it('can select single choices', () => {
+    dispatch(initializeState(props.state, initialSelection(props.state)));
+    dispatch(setSelection(model.choices[0].id, onSaveActivity, 'single'));
+    expect(store.getState().selection).toEqual([model.choices[0].id]);
+  });
+
+  it('can select multiple choices', () => {
+    dispatch(initializeState(props.state, initialSelection(props.state)));
+    dispatch(setSelection(model.choices[0].id, onSaveActivity, 'multiple'));
+    dispatch(setSelection(model.choices[1].id, onSaveActivity, 'multiple'));
+    expect(store.getState().selection).toEqual([model.choices[0].id, model.choices[1].id]);
+  });
+
+  it('can convert input to selections used by components and back', () => {
+    let selection = [model.choices[0].id];
+    expect(selectionToInput(selection)).toEqual(model.choices[0].id);
+    selection = model.choices.map((c) => c.id);
+    expect(selectionToInput(selection)).toEqual(`${model.choices[0].id} ${model.choices[1].id}`);
+
+    let input = '123';
+    expect(inputToSelection(input)).toEqual(['123']);
+    input = '123 456';
+    expect(inputToSelection(input)).toEqual(['123', '456']);
+  });
+});

--- a/assets/test/check_all_that_apply/cata_delivery_test.tsx
+++ b/assets/test/check_all_that_apply/cata_delivery_test.tsx
@@ -16,7 +16,7 @@ describe('check all that apply delivery', () => {
   it('renders ungraded correctly', async () => {
     const model = defaultCATAModel();
     model.authoring.parts[0].hints.push(makeHint('Hint 1'));
-    const defaultActivityState = defaultState(model);;
+    const defaultActivityState = defaultState(model);
     const props = {
       model,
       activitySlug: 'activity-slug',
@@ -26,7 +26,6 @@ describe('check all that apply delivery', () => {
     };
     const { onSaveActivity, onSubmitActivity } = defaultDeliveryElementProps;
     const store = configureStore({}, activityDeliverySlice.reducer);
-
     render(
       <Provider store={store}>
         <DeliveryElementProvider {...defaultDeliveryElementProps} {...props}>


### PR DESCRIPTION
Short answer and ordering activities did not correctly restore their state when students typed in inputs or re-arrange choices and refresh the page. Ordering activities were not calling `onSaveActivity` after reordering, and there was a type error in Short Answer activities because the input is marked as `any` and was not being stored in an array when restored from persistence.

To test:
- Publish open and free course with short answer / ordering questions
- Preview in O&F mode
- Enter an input for a short answer and rearrange choices options for ordering
- Refresh page and ensure the submissions restore