### PR TITLE
[BUG FIX] fix an issue where lti app configs were not loaded in release tasks

### DIFF
--- a/.github/actions/phoenix-builder/entrypoint.sh
+++ b/.github/actions/phoenix-builder/entrypoint.sh
@@ -12,6 +12,6 @@ MIX_ENV=prod SHA=$RELEASE_SHA mix compile
 yarn --cwd ./assets
 npm run deploy --prefix ./assets
 npm run deploy-node --prefix ./assets
-mix phx.digest
 
+MIX_ENV=prod mix phx.digest
 MIX_ENV=prod SHA=$RELEASE_SHA mix release

--- a/lib/oli/release.ex
+++ b/lib/oli/release.ex
@@ -121,6 +121,7 @@ defmodule Oli.ReleaseTasks do
   @spec load_app() :: :ok | {:error, term()}
   defp load_app do
     Application.load(@app)
+    Application.load(:lti_1p3)
   end
 
   @spec eval_seed(Ecto.Repo.t(), String.t()) :: any()


### PR DESCRIPTION
This PR fixes an issue where lti app configs were not loaded in release tasks that require them. It also set the mix env to prod for digest command.