### PR TITLE
[Bug]PMP-1645

### DIFF
--- a/assets/src/components/parts/janus-mcq/MultipleChoiceQuestion.tsx
+++ b/assets/src/components/parts/janus-mcq/MultipleChoiceQuestion.tsx
@@ -179,7 +179,7 @@ const MultipleChoiceQuestion: React.FC<JanusMultipleChoiceQuestionItemProperties
         {
           key: 'selectedChoice',
           type: CapiVariableTypes.NUMBER,
-          value: selectedChoice,
+          value: -1,
         },
         {
           key: 'selectedChoiceText',


### PR DESCRIPTION
-- making changes only in props.init call and that will resolve the issue.
-- I thought of changing the value to -1 in below line of code but It seems that Curtis changed that from -1 to 0 in Janus so there must be a reason behind that hence not touching that code.

`const [selectedChoice, setSelectedChoice] = useState<number>(0);`