### PR TITLE
[BUGFIX] truncate datetime microseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+### Enhancements
+
+## 0.12.6 (2021-07-29)
+
+### Bug Fixes
+
+- Fix an issue with timestamps containing microseconds
 ## 0.12.5 (2021-07-29)
 
 ### Bug Fixes

--- a/lib/oli/delivery/snapshots/worker.ex
+++ b/lib/oli/delivery/snapshots/worker.ex
@@ -100,7 +100,9 @@ defmodule Oli.Delivery.Snapshots.Worker do
         objective_id,
         revision_id
       ) do
-    now = DateTime.utc_now()
+    now =
+      DateTime.utc_now()
+      |> DateTime.truncate(:second)
 
     %{
       resource_id: resource_access.resource_id,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Oli.MixProject do
   def project do
     [
       app: :oli,
-      version: "0.12.5",
+      version: "0.12.6",
       elixir: "~> 1.12",
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: elixirc_options(Mix.env()),


### PR DESCRIPTION
Fix an issue with timestamps in snapshots by truncating datetime microseconds