### PR TITLE
[CHORE] Make S3 bucket runtime configurable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,10 @@ jobs:
 
       - name: 🔧 Configure
         run: |
-          cp oli.example.env oli.env
           cp postgres.example.env postgres.env
-          sed -i 's/DB_HOST=/# DB_HOST=/g' oli.env
-          printf "\n\nDB_HOST=localhost" >> oli.env
+          cat > oli.env <<EOL
+          ${{ secrets.CI_OLI_ENV }}
+          EOL
 
       - name: 🗄 Start test database
         run: docker-compose up -d postgres

--- a/config/config.exs
+++ b/config/config.exs
@@ -7,6 +7,20 @@
 # General application configuration
 use Mix.Config
 
+s3_media_bucket_name =
+  System.get_env("S3_MEDIA_BUCKET_NAME") ||
+    raise """
+    environment variable S3_MEDIA_BUCKET_NAME is missing.
+    For example: torus-media
+    """
+
+media_url =
+  System.get_env("MEDIA_URL") ||
+    raise """
+    environment variable MEDIA_URL is missing.
+    For example: your_s3_media_bucket_url.s3.amazonaws.com
+    """
+
 world_universities_and_domains_json =
   case File.read("./priv/data/world_universities_and_domains.json") do
     {:ok, body} ->
@@ -19,6 +33,8 @@ world_universities_and_domains_json =
 default_sha = if Mix.env() == :dev, do: "DEV BUILD", else: "UNKNOWN BUILD"
 
 config :oli,
+  s3_media_bucket_name: s3_media_bucket_name,
+  media_url: media_url,
   node_js_pool_size: String.to_integer(System.get_env("NODE_JS_POOL_SIZE", "10")),
   load_testing_mode: :disabled,
   problematic_query_detection: :disabled,

--- a/config/config.exs
+++ b/config/config.exs
@@ -7,20 +7,6 @@
 # General application configuration
 use Mix.Config
 
-s3_media_bucket_name =
-  System.get_env("S3_MEDIA_BUCKET_NAME") ||
-    raise """
-    environment variable S3_MEDIA_BUCKET_NAME is missing.
-    For example: torus-media
-    """
-
-media_url =
-  System.get_env("MEDIA_URL") ||
-    raise """
-    environment variable MEDIA_URL is missing.
-    For example: your_s3_media_bucket_url.s3.amazonaws.com
-    """
-
 world_universities_and_domains_json =
   case File.read("./priv/data/world_universities_and_domains.json") do
     {:ok, body} ->
@@ -33,8 +19,8 @@ world_universities_and_domains_json =
 default_sha = if Mix.env() == :dev, do: "DEV BUILD", else: "UNKNOWN BUILD"
 
 config :oli,
-  s3_media_bucket_name: s3_media_bucket_name,
-  media_url: media_url,
+  s3_media_bucket_name: System.get_env("S3_MEDIA_BUCKET_NAME"),
+  media_url: System.get_env("MEDIA_URL"),
   node_js_pool_size: String.to_integer(System.get_env("NODE_JS_POOL_SIZE", "10")),
   load_testing_mode: :disabled,
   problematic_query_detection: :disabled,

--- a/config/config.exs
+++ b/config/config.exs
@@ -19,8 +19,6 @@ world_universities_and_domains_json =
 default_sha = if Mix.env() == :dev, do: "DEV BUILD", else: "UNKNOWN BUILD"
 
 config :oli,
-  s3_media_bucket_name: System.get_env("S3_MEDIA_BUCKET_NAME"),
-  media_url: System.get_env("MEDIA_URL"),
   node_js_pool_size: String.to_integer(System.get_env("NODE_JS_POOL_SIZE", "10")),
   load_testing_mode: :disabled,
   problematic_query_detection: :disabled,

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -11,6 +11,8 @@ end
 
 config :oli,
   env: :dev,
+  s3_media_bucket_name: System.get_env("S3_MEDIA_BUCKET_NAME"),
+  media_url: System.get_env("MEDIA_URL"),
   problematic_query_detection:
     from_boolean_env.("DEV_PROBLEMATIC_QUERY_DETECTION_ENABLED", "false"),
   load_testing_mode: from_boolean_env.("LOAD_TESTING_MODE", "false"),

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -9,13 +9,27 @@ from_boolean_env = fn key, default ->
   end
 end
 
+s3_media_bucket_name =
+  System.get_env("S3_MEDIA_BUCKET_NAME") ||
+    raise """
+    environment variable S3_MEDIA_BUCKET_NAME is missing.
+    For example: host.example.com
+    """
+
+media_url =
+  System.get_env("MEDIA_URL") ||
+    raise """
+    environment variable MEDIA_URL is missing.
+    For example: host.example.com
+    """
+
 config :oli,
   env: :dev,
   problematic_query_detection:
     from_boolean_env.("DEV_PROBLEMATIC_QUERY_DETECTION_ENABLED", "false"),
   load_testing_mode: from_boolean_env.("LOAD_TESTING_MODE", "false"),
-  s3_media_bucket_name: "torus-media-dev",
-  media_url: "torus-media-dev.s3.amazonaws.com",
+  s3_media_bucket_name: s3_media_bucket_name,
+  media_url: media_url,
   slack_webhook_url: System.get_env("SLACK_WEBHOOK_URL")
 
 # Configure your database

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -9,27 +9,11 @@ from_boolean_env = fn key, default ->
   end
 end
 
-s3_media_bucket_name =
-  System.get_env("S3_MEDIA_BUCKET_NAME") ||
-    raise """
-    environment variable S3_MEDIA_BUCKET_NAME is missing.
-    For example: host.example.com
-    """
-
-media_url =
-  System.get_env("MEDIA_URL") ||
-    raise """
-    environment variable MEDIA_URL is missing.
-    For example: host.example.com
-    """
-
 config :oli,
   env: :dev,
   problematic_query_detection:
     from_boolean_env.("DEV_PROBLEMATIC_QUERY_DETECTION_ENABLED", "false"),
   load_testing_mode: from_boolean_env.("LOAD_TESTING_MODE", "false"),
-  s3_media_bucket_name: s3_media_bucket_name,
-  media_url: media_url,
   slack_webhook_url: System.get_env("SLACK_WEBHOOK_URL")
 
 # Configure your database

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,9 +1,7 @@
 use Mix.Config
 
 config :oli,
-  env: :prod,
-  s3_media_bucket_name: "torus-media",
-  media_url: "d2xvti2irp4c7t.cloudfront.net"
+  env: :prod
 
 # For production, don't forget to configure the url host
 # to something meaningful, Phoenix uses this information

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -46,8 +46,24 @@ host =
     For example: host.example.com
     """
 
+s3_media_bucket_name =
+  System.get_env("S3_MEDIA_BUCKET_NAME") ||
+    raise """
+    environment variable S3_MEDIA_BUCKET_NAME is missing.
+    For example: torus-media
+    """
+
+media_url =
+  System.get_env("MEDIA_URL") ||
+    raise """
+    environment variable MEDIA_URL is missing.
+    For example: your_s3_media_bucket_url.s3.amazonaws.com
+    """
+
 # General OLI app config
 config :oli,
+  s3_media_bucket_name: s3_media_bucket_name,
+  media_url: media_url,
   email_from_name: System.get_env("EMAIL_FROM_NAME", "OLI Torus"),
   email_from_address: System.get_env("EMAIL_FROM_ADDRESS", "admin@example.edu"),
   email_reply_to: System.get_env("EMAIL_REPLY_TO", "admin@example.edu"),

--- a/config/test.exs
+++ b/config/test.exs
@@ -2,8 +2,8 @@ use Mix.Config
 
 config :oli,
   env: :test,
-  s3_media_bucket_name: "torus-media-test",
-  media_url: "d1od6xouqrpl5k.cloudfront.net",
+  s3_media_bucket_name: System.get_env("TEST_S3_MEDIA_BUCKET_NAME"),
+  media_url: System.get_env("TEST_MEDIA_URL"),
   http_client: Oli.Test.MockHTTP,
   aws_client: Oli.Test.MockAws,
   slack_webhook_url: nil,

--- a/oli.example.env
+++ b/oli.example.env
@@ -43,8 +43,10 @@ AWS_ACCESS_KEY_ID=your_aws_access_key
 AWS_SECRET_ACCESS_KEY=your_aws_secret_access_key
 
 ## S3 compatable storage service config used for storing and serving media (required for production and dev)
-S3_MEDIA_BUCKET_NAME="torus-media"
-MEDIA_URL="your_s3_media_bucket_url.s3.amazonaws.com"
+S3_MEDIA_BUCKET_NAME=torus-media
+MEDIA_URL=your_s3_media_bucket_url.s3.amazonaws.com
+TEST_S3_MEDIA_BUCKET_NAME=torus-media-test
+TEST_MEDIA_URL=your_s3_media_bucket_url.s3.amazonaws.com
 
 ## Google recaptcha key and secret (these values are for dev use only, change for production)
 RECAPTCHA_SITE_KEY=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI

--- a/oli.example.env
+++ b/oli.example.env
@@ -21,7 +21,7 @@ DB_HOST=postgres
 ## Database url with credentials (required for production only)
 # DATABASE_URL=ecto://postgres:changeme@postgres/oli
 
-## Email sending
+## Email sending (required for production and dev)
 EMAIL_FROM_NAME="OLI Torus"
 EMAIL_FROM_ADDRESS="no-reply@example.edu"
 EMAIL_REPLY_TO=admin@example.edu
@@ -31,16 +31,20 @@ EMAIL_REPLY_TO=admin@example.edu
 # FRESHDESK_API_KEY=example_api_key
 # FRESHDESK_API_URL=https://<domain>.freshdesk.com/api/v2/tickets
 
-## OAuth social login
+## OAuth social login (optional to enable social login providers)
 GOOGLE_CLIENT_ID=your_google_client_id
 GOOGLE_CLIENT_SECRET=your_google_client_secret
 
 GITHUB_CLIENT_ID=your_github_client_id
 GITHUB_CLIENT_SECRET=your_github_client_secret
 
-## Amazon AWS services
+## Amazon AWS services (required for production and dev)
 AWS_ACCESS_KEY_ID=your_aws_access_key
 AWS_SECRET_ACCESS_KEY=your_aws_secret_access_key
+
+## S3 compatable storage service config used for storing and serving media (required for production and dev)
+S3_MEDIA_BUCKET_NAME="torus-media"
+MEDIA_URL="your_s3_media_bucket_url.s3.amazonaws.com"
 
 ## Google recaptcha key and secret (these values are for dev use only, change for production)
 RECAPTCHA_SITE_KEY=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
@@ -67,7 +71,7 @@ RECAPTCHA_PRIVATE_KEY=6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
 # SSL_CERT_PATH=
 # SSL_KEY_PATH=
 
-## Enable query analyzer in development (compile-time config, only valid is dev environment)
+## Enable query analyzer in development (compile-time config, only valid in dev environment)
 # DEV_PROBLEMATIC_QUERY_DETECTION_ENABLED=false
 
 # Number of node instances the Elixir-NodeJS bridge will use, for development purposes, 1 should be fine

--- a/oli.example.env
+++ b/oli.example.env
@@ -13,7 +13,7 @@ ADMIN_PASSWORD=changeme
 # HTTP_PORT=80
 
 ## Change DB_HOST to localhost if running app natively (development only)
-DB_HOST=postgres
+DB_HOST=localhost
 
 ## Specify a subdomain for localtunnel (development only)
 # SUBDOMAIN=oli-torus


### PR DESCRIPTION
This PR allows an S3 bucket to be configured independently on development/production systems at runtime and removes the values which were hard coded.

In turn, it requires the following configs to be added to `oli.env` for a development environment to continue working:
```
S3_MEDIA_BUCKET_NAME="torus-media"
MEDIA_URL="your_s3_media_bucket_url.s3.amazonaws.com"
```

Of course, these values must correlate with the S3 bucket used for development.