### PR TITLE
[BUG] MCQs not functioning when "array" is used

### DIFF
--- a/assets/src/adaptivity/operators/equality.ts
+++ b/assets/src/adaptivity/operators/equality.ts
@@ -20,7 +20,7 @@ export const isEqual = (factValue: any, value: any): boolean => {
     if (Array.isArray(value)) {
       // ** We are doing this for the cases where factValue comes [2 , 5] but the values comes as ['2','5'] */
       // ** DT - making sure that value is of array type else value.map() will throw error. */
-      compareValue = parseArrayString(factValue).sort();
+      compareValue = parseArrayString(value).sort();
     }
 
     // ** DT - Sorting both arrays. depending upon user selection in UI the array sometimes comes

--- a/assets/test/adaptivity/rules_engine_test.ts
+++ b/assets/test/adaptivity/rules_engine_test.ts
@@ -253,6 +253,20 @@ describe('Operators', () => {
     });
   });
 
+  describe('Equalto Operators', () => {
+    it('should return false if all the values are not equal', () => {
+      expect(isEqual(['1', '2', '3', '4', '5'], ['1', '2', '3', '4', '5'])).toEqual(true);
+      expect(isEqual(['1', '2', '3', '4', '5'], ['1', '2', '3', '4'])).toEqual(false);
+    });
+  });
+
+  describe('Not Equal to Operators', () => {
+    it('should return false if all the values are not equal', () => {
+      expect(notEqual(['1', '2', '3', '4', '5'], [])).toEqual(true);
+      expect(notEqual(['1', '2', '3', '4', '5'], ['1', '2', '3', '4', '5'])).toEqual(false);
+    });
+  });
+
   describe('Contains Operators', () => {
     it('should return false if either value is not provided', () => {
       expect(containsOperator(null, null)).toEqual(false);


### PR DESCRIPTION
-- by mistake I replace 'value' with 'factvalue' in the parsing method which caused this issue