### PR TITLE
[BUG FIX] fix an issue where mod key changes selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 - Fix iframe rendering when elements contain captions (webpage, youtube)
 - Fix iframe rendering in activities
+- Fix an issue where mod key changes current selection
 
 ### Enhancements
 

--- a/assets/src/components/resource/resourceEditor/ResourceEditor.tsx
+++ b/assets/src/components/resource/resourceEditor/ResourceEditor.tsx
@@ -29,9 +29,6 @@ import { create } from 'data/persistence/objective';
 import { Undoable as ActivityUndoable } from 'components/activities/types';
 import {
   registerUnload,
-  registerKeydown,
-  registerKeyup,
-  registerWindowBlur,
   unregisterUnload,
   unregisterKeydown,
   unregisterKeyup,
@@ -67,7 +64,6 @@ type ResourceEditorState = {
   childrenObjectives: Immutable.Map<ResourceId, Immutable.List<Objective>>;
   editMode: boolean;
   persistence: 'idle' | 'pending' | 'inflight';
-  metaModifier: boolean;
   undoables: Undoables;
 };
 
@@ -146,7 +142,6 @@ export class ResourceEditor extends React.Component<ResourceEditorProps, Resourc
       persistence: 'idle',
       allObjectives: Immutable.List<Objective>(allObjectives),
       childrenObjectives: mapChildrenObjectives(allObjectives),
-      metaModifier: false,
       undoables: empty(),
     };
 
@@ -168,7 +163,7 @@ export class ResourceEditor extends React.Component<ResourceEditorProps, Resourc
         acquireLock.bind(undefined, projectSlug, resourceSlug),
         releaseLock.bind(undefined, projectSlug, resourceSlug),
         // eslint-disable-next-line
-        () => {},
+        () => { },
         (failure) => this.publishErrorMessage(failure),
         (persistence) => this.setState({ persistence }),
       )
@@ -177,9 +172,6 @@ export class ResourceEditor extends React.Component<ResourceEditorProps, Resourc
         if (editMode) {
           this.initActivityPersistence();
           this.windowUnloadListener = registerUnload(this.persistence);
-          this.keydownListener = registerKeydown(this);
-          this.keyupListener = registerKeyup(this);
-          this.windowBlurListener = registerWindowBlur(this);
         } else if (this.persistence.getLockResult().type === 'not_acquired') {
           const notAcquired: NotAcquired = this.persistence.getLockResult() as NotAcquired;
           this.editingLockedMessage(notAcquired.user);
@@ -191,9 +183,6 @@ export class ResourceEditor extends React.Component<ResourceEditorProps, Resourc
     this.persistence.destroy();
 
     unregisterUnload(this.windowUnloadListener);
-    unregisterKeydown(this.keydownListener);
-    unregisterKeyup(this.keyupListener);
-    unregisterWindowBlur(this.windowBlurListener);
   }
 
   initActivityPersistence() {
@@ -208,7 +197,7 @@ export class ResourceEditor extends React.Component<ResourceEditorProps, Resourc
           () => Promise.resolve({ type: 'acquired' }),
           () => Promise.resolve({ type: 'acquired' }),
           // eslint-disable-next-line
-          () => {},
+          () => { },
           (failure) => this.publishErrorMessage(failure),
           (persistence) => this.setState({ persistence }),
         );
@@ -412,7 +401,7 @@ export class ResourceEditor extends React.Component<ResourceEditorProps, Resourc
           () => Promise.resolve({ type: 'acquired' }),
           () => Promise.resolve({ type: 'acquired' }),
           // eslint-disable-next-line
-          () => {},
+          () => { },
           (failure) => this.publishErrorMessage(failure),
           (persistence) => this.setState({ persistence }),
         );
@@ -490,7 +479,7 @@ export class ResourceEditor extends React.Component<ResourceEditorProps, Resourc
 }
 
 // eslint-disable-next-line
-interface StateProps {}
+interface StateProps { }
 
 interface DispatchProps {
   onLoadPreferences: () => void;

--- a/assets/src/components/resource/resourceEditor/listeners.ts
+++ b/assets/src/components/resource/resourceEditor/listeners.ts
@@ -1,6 +1,6 @@
 import { PersistenceStrategy } from 'data/persistence/PersistenceStrategy';
 import { isFirefox } from 'utils/browser';
-import { toKeyCode } from 'is-hotkey';
+import isHotkey from 'is-hotkey';
 import { ResourceEditor } from './ResourceEditor';
 
 export function registerUnload(strategy: PersistenceStrategy) {
@@ -17,34 +17,12 @@ export function unregisterUnload(listener: any) {
   window.removeEventListener('beforeunload', listener);
 }
 
-export function registerKeydown(self: ResourceEditor) {
-  return window.addEventListener('keydown', (e: KeyboardEvent) => {
-    if (e.keyCode === toKeyCode('mod') && !e.repeat) {
-      self.setState({ metaModifier: true });
-    }
-  });
-}
-
 export function unregisterKeydown(listener: any) {
   window.removeEventListener('keydown', listener);
 }
 
-export function registerKeyup(self: ResourceEditor) {
-  return window.addEventListener('keyup', (e: KeyboardEvent) => {
-    if (e.keyCode === toKeyCode('mod')) {
-      self.setState({ metaModifier: false });
-    }
-  });
-}
-
 export function unregisterKeyup(listener: any) {
   window.removeEventListener('keyup', listener);
-}
-
-export function registerWindowBlur(self: ResourceEditor) {
-  return window.addEventListener('blur', (e) => {
-    self.setState({ metaModifier: false });
-  });
 }
 
 export function unregisterWindowBlur(listener: any) {


### PR DESCRIPTION
This PR fixes an issue where pressing the mod key (Ctrl or Cmd) unselects the currently selected text. The issue appears to be related to a component state update where metaModifier state was causing a rerender which would reset the selection state. Since metaModifier state is no longer used anywhere, I simply removed it which fixes the issue.

Closes #1347