### PR TITLE
[BUG FIX] fix an issue where users with social logins have null subs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix iframe rendering in activities
 - Fix an issue where mod key changes current selection
 - Standardize padding and headers across all pages
+- Fix an issue where users with social logins have null sub
 
 ### Enhancements
 

--- a/lib/oli/accounts/schemas/user.ex
+++ b/lib/oli/accounts/schemas/user.ex
@@ -139,6 +139,7 @@ defmodule Oli.Accounts.User do
   def user_identity_changeset(user_or_changeset, user_identity, attrs, user_id_attrs) do
     user_or_changeset
     |> Ecto.Changeset.cast(attrs, [:name, :given_name, :family_name, :picture])
+    |> maybe_create_unique_sub()
     |> pow_assent_user_identity_changeset(user_identity, attrs, user_id_attrs)
   end
 

--- a/priv/repo/migrations/20210804173741_generate_sub.exs
+++ b/priv/repo/migrations/20210804173741_generate_sub.exs
@@ -1,0 +1,20 @@
+defmodule Oli.Repo.Migrations.GenerateSub do
+  use Ecto.Migration
+  import Ecto.Query, warn: false
+
+  alias Oli.Repo
+  alias Oli.Accounts.User
+
+  def change do
+    # generate a sub uuid for all users that have a null sub
+    from(u in "users",
+      where: is_nil(u.sub),
+      select: u.id
+    )
+    |> Repo.all()
+    |> Enum.each(fn id ->
+      user = from(u in "users", where: u.id == ^id)
+      Oli.Repo.update_all(user, set: [sub: UUID.uuid4()])
+    end)
+  end
+end


### PR DESCRIPTION
This fixes an issue/inconsistency where users who create accounts using a social login provider have null values for subs.