### PR TITLE
[ENHANCEMENT] Manage users

### DIFF
--- a/assets/styles/authoring/main.scss
+++ b/assets/styles/authoring/main.scss
@@ -25,7 +25,7 @@ body.modal-open {
   padding-right: 0;
 }
 
-.oli-logo {
+.torus-logo {
   font-family: "Open Sans", sans-serif;
 }
 

--- a/assets/styles/delivery/main.scss
+++ b/assets/styles/delivery/main.scss
@@ -45,7 +45,7 @@ body.modal-open {
   overflow: visible;
 }
 
-.oli-logo {
+.torus-logo {
   font-family: "Open Sans", sans-serif;
 }
 

--- a/lib/oli/accounts.ex
+++ b/lib/oli/accounts.ex
@@ -11,7 +11,10 @@ defmodule Oli.Accounts do
       [%User{}, ...]
   """
   def list_users do
-    Repo.all(User)
+    from(u in User,
+      where: u.guest == false
+    )
+    |> Repo.all()
   end
 
   @doc """

--- a/lib/oli/accounts.ex
+++ b/lib/oli/accounts.ex
@@ -12,7 +12,10 @@ defmodule Oli.Accounts do
   """
   def list_users do
     from(u in User,
-      where: u.guest == false
+      left_join: a in Author,
+      on: a.id == u.author_id,
+      where: u.guest == false,
+      preload: [author: a]
     )
     |> Repo.all()
   end
@@ -288,8 +291,9 @@ defmodule Oli.Accounts do
     q = "%" <> q <> "%"
 
     Repo.all(
-      from author in Author,
+      from(author in Author,
         where: ilike(author.email, ^q)
+      )
     )
   end
 
@@ -322,11 +326,12 @@ defmodule Oli.Accounts do
       # in case the author has many projects
       _ ->
         Repo.one(
-          from assoc in "authors_projects",
+          from(assoc in "authors_projects",
             where:
               assoc.author_id == ^author.id and
                 assoc.project_id == ^project.id,
             select: count(assoc)
+          )
         ) != 0
     end
   end
@@ -343,50 +348,54 @@ defmodule Oli.Accounts do
       # in case the author has many projects
       _ ->
         Repo.one(
-          from assoc in "authors_projects",
+          from(assoc in "authors_projects",
             join: p in "projects",
             on: assoc.project_id == p.id,
             where:
               assoc.author_id == ^author.id and
                 p.slug == ^project_slug,
             select: count(assoc)
+          )
         ) != 0
     end
   end
 
   def project_author_count(project) do
     Repo.one(
-      from assoc in "authors_projects",
+      from(assoc in "authors_projects",
         join: author in Author,
         on: assoc.author_id == author.id,
         where:
           assoc.project_id in ^project.id and
             (is_nil(author.invitation_token) or not is_nil(author.invitation_accepted_at)),
         select: count(author)
+      )
     )
   end
 
   def project_authors(project_ids) when is_list(project_ids) do
     Repo.all(
-      from assoc in "authors_projects",
+      from(assoc in "authors_projects",
         join: author in Author,
         on: assoc.author_id == author.id,
         where:
           assoc.project_id in ^project_ids and
             (is_nil(author.invitation_token) or not is_nil(author.invitation_accepted_at)),
         select: [author, assoc.project_id]
+      )
     )
   end
 
   def project_authors(project) do
     Repo.all(
-      from assoc in "authors_projects",
+      from(assoc in "authors_projects",
         join: author in Author,
         on: assoc.author_id == author.id,
         where:
           assoc.project_id == ^project.id and
             (is_nil(author.invitation_token) or not is_nil(author.invitation_accepted_at)),
         select: author
+      )
     )
   end
 end

--- a/lib/oli/accounts/schemas/author.ex
+++ b/lib/oli/accounts/schemas/author.ex
@@ -53,7 +53,8 @@ defmodule Oli.Accounts.Author do
       :family_name,
       :picture,
       :system_role_id,
-      :locked_at
+      :locked_at,
+      :email_confirmed_at
     ])
     |> cast_embed(:preferences)
     |> default_system_role()
@@ -74,7 +75,8 @@ defmodule Oli.Accounts.Author do
       :family_name,
       :picture,
       :system_role_id,
-      :locked_at
+      :locked_at,
+      :email_confirmed_at
     ])
     |> cast_embed(:preferences)
     |> default_system_role()

--- a/lib/oli/accounts/schemas/user.ex
+++ b/lib/oli/accounts/schemas/user.ex
@@ -91,7 +91,8 @@ defmodule Oli.Accounts.User do
       :independent_learner,
       :research_opt_out,
       :state,
-      :locked_at
+      :locked_at,
+      :email_confirmed_at
     ])
     |> validate_required_if([:email], &is_independent_learner_not_guest/1)
     |> unique_constraint(:email, name: :users_email_independent_learner_index)
@@ -131,7 +132,8 @@ defmodule Oli.Accounts.User do
       :independent_learner,
       :research_opt_out,
       :state,
-      :locked_at
+      :locked_at,
+      :email_confirmed_at
     ])
     |> validate_required_if([:email], &is_independent_learner_not_guest/1)
     |> maybe_create_unique_sub()

--- a/lib/oli/accounts/schemas/user.ex
+++ b/lib/oli/accounts/schemas/user.ex
@@ -38,6 +38,7 @@ defmodule Oli.Accounts.User do
     field :independent_learner, :boolean, default: true
     field :research_opt_out, :boolean
     field :state, :map, default: %{}
+    field :locked_at, :utc_datetime
 
     has_many :user_identities,
              Oli.UserIdentities.UserIdentity,
@@ -89,7 +90,8 @@ defmodule Oli.Accounts.User do
       :guest,
       :independent_learner,
       :research_opt_out,
-      :state
+      :state,
+      :locked_at
     ])
     |> validate_required_if([:email], &is_independent_learner_not_guest/1)
     |> unique_constraint(:email, name: :users_email_independent_learner_index)
@@ -128,7 +130,8 @@ defmodule Oli.Accounts.User do
       :guest,
       :independent_learner,
       :research_opt_out,
-      :state
+      :state,
+      :locked_at
     ])
     |> validate_required_if([:email], &is_independent_learner_not_guest/1)
     |> maybe_create_unique_sub()
@@ -140,6 +143,17 @@ defmodule Oli.Accounts.User do
     user_or_changeset
     |> Ecto.Changeset.cast(attrs, [:name, :given_name, :family_name, :picture])
     |> pow_assent_user_identity_changeset(user_identity, attrs, user_id_attrs)
+  end
+
+  @spec lock_changeset(Ecto.Schema.t() | Ecto.Changeset.t()) :: Ecto.Changeset.t()
+  def lock_changeset(user_or_changeset) do
+    changeset = Ecto.Changeset.change(user_or_changeset)
+    locked_at = DateTime.truncate(DateTime.utc_now(), :second)
+
+    case Ecto.Changeset.get_field(changeset, :locked_at) do
+      nil -> Ecto.Changeset.change(changeset, locked_at: locked_at)
+      _any -> Ecto.Changeset.add_error(changeset, :locked_at, "already set")
+    end
   end
 
   def is_independent_learner_not_guest(changeset) do

--- a/lib/oli_web/controllers/pow.ex
+++ b/lib/oli_web/controllers/pow.ex
@@ -1,0 +1,32 @@
+defmodule OliWeb.PowController do
+  use OliWeb, :controller
+
+  alias Oli.Repo
+  alias Oli.Accounts.User
+  alias Oli.Accounts.Author
+
+  def resend_user_confirmation_link(conn, %{"id" => id}) do
+    user = Repo.get(User, id)
+
+    conn
+    |> use_pow_config(:user)
+    |> resend_user_confirmation_email(user)
+    |> put_flash(:info, "Confirmation link sent to user #{user.email}.")
+    |> redirect(to: Routes.live_path(conn, OliWeb.Accounts.AccountsLive, %{active_tab: :users}))
+  end
+
+  def resend_author_confirmation_link(conn, %{"id" => id}) do
+    author = Repo.get(Author, id)
+
+    conn
+    |> use_pow_config(:author)
+    |> resend_user_confirmation_email(author)
+    |> put_flash(:info, "Confirmation link sent to admin #{author.email}.")
+    |> redirect(to: Routes.live_path(conn, OliWeb.Accounts.AccountsLive, %{active_tab: :author}))
+  end
+
+  defp resend_user_confirmation_email(conn, user) do
+    PowEmailConfirmation.Phoenix.ControllerCallbacks.send_confirmation_email(user, conn)
+    conn
+  end
+end

--- a/lib/oli_web/controllers/pow.ex
+++ b/lib/oli_web/controllers/pow.ex
@@ -5,6 +5,47 @@ defmodule OliWeb.PowController do
   alias Oli.Accounts.User
   alias Oli.Accounts.Author
 
+  def send_user_password_reset_link(conn, %{"id" => id}) do
+    user = Repo.get(User, id)
+
+    conn
+    |> use_pow_config(:user)
+    |> PowResetPassword.Phoenix.ResetPasswordController.process_create(%{
+      "user" => %{"email" => user.email}
+    })
+    |> password_reset_respond_create()
+    |> put_flash(:info, "Password reset link sent to user #{user.email}.")
+    |> redirect(to: Routes.live_path(conn, OliWeb.Accounts.AccountsLive, %{active_tab: :users}))
+  end
+
+  def send_author_password_reset_link(conn, %{"id" => id}) do
+    author = Repo.get(Author, id)
+
+    conn
+    |> use_pow_config(:author)
+    |> PowResetPassword.Phoenix.ResetPasswordController.process_create(%{
+      "user" => %{"email" => author.email}
+    })
+    |> password_reset_respond_create()
+    |> put_flash(:info, "Password reset link sent to user #{author.email}.")
+    |> redirect(to: Routes.live_path(conn, OliWeb.Accounts.AccountsLive, %{active_tab: :authors}))
+  end
+
+  defp password_reset_respond_create({:ok, %{token: token, user: user}, conn}) do
+    url =
+      Pow.Phoenix.Controller.routes(conn, Pow.Phoenix.Routes).url_for(
+        conn,
+        PowResetPassword.Phoenix.ResetPasswordController,
+        :edit,
+        [token]
+      )
+
+    email = PowResetPassword.Phoenix.Mailer.reset_password(conn, user, url)
+    Pow.Phoenix.Mailer.deliver(conn, email)
+
+    conn
+  end
+
   def resend_user_confirmation_link(conn, %{"id" => id}) do
     user = Repo.get(User, id)
 
@@ -22,7 +63,7 @@ defmodule OliWeb.PowController do
     |> use_pow_config(:author)
     |> resend_user_confirmation_email(author)
     |> put_flash(:info, "Confirmation link sent to admin #{author.email}.")
-    |> redirect(to: Routes.live_path(conn, OliWeb.Accounts.AccountsLive, %{active_tab: :author}))
+    |> redirect(to: Routes.live_path(conn, OliWeb.Accounts.AccountsLive, %{active_tab: :authors}))
   end
 
   defp resend_user_confirmation_email(conn, user) do

--- a/lib/oli_web/live/common/table/sortable_table.ex
+++ b/lib/oli_web/live/common/table/sortable_table.ex
@@ -14,6 +14,27 @@ defmodule OliWeb.Common.Table.SortableTable do
     """
   end
 
+  def id_field(row, %{id_field: id_field}) when is_list(id_field) do
+    id_field
+    |> Enum.reduce("", fn field, acc ->
+      cond do
+        is_atom(field) ->
+          "#{acc}-#{Map.get(row, field)}"
+
+        is_binary(field) ->
+          "#{acc}-#{field}"
+
+        true ->
+          acc
+      end
+    end)
+    |> String.trim("-")
+  end
+
+  def id_field(row, %{id_field: id_field}) do
+    Map.get(row, id_field)
+  end
+
   def render(assigns) do
     ~L"""
     <table class="table table-striped table-bordered">
@@ -27,9 +48,9 @@ defmodule OliWeb.Common.Table.SortableTable do
       <tbody>
         <%= for row <- @model.rows do %>
           <%= if row == @model.selected do %>
-          <tr id="<%= Map.get(row, @model.id_field) %>" class="table-active">
+          <tr id="<%= id_field(row, @model) %>" class="table-active">
           <% else %>
-          <tr id="<%= Map.get(row, @model.id_field) %>">
+          <tr id="<%= id_field(row, @model) %>">
           <% end %>
             <%= for column_spec <- @model.column_specs do %>
               <td>

--- a/lib/oli_web/live/common/table/sortable_table.ex
+++ b/lib/oli_web/live/common/table/sortable_table.ex
@@ -16,7 +16,7 @@ defmodule OliWeb.Common.Table.SortableTable do
 
   def render(assigns) do
     ~L"""
-    <table class="table table-striped table-bordered table-hover">
+    <table class="table table-striped table-bordered">
       <thead>
         <tr>
           <%= for column_spec <- @model.column_specs do %>
@@ -29,7 +29,7 @@ defmodule OliWeb.Common.Table.SortableTable do
           <%= if row == @model.selected do %>
           <tr id="<%= Map.get(row, @model.id_field) %>" class="table-active">
           <% else %>
-          <tr id="<%= Map.get(row, @model.id_field) %>" style="cursor: pointer;" phx-click="select<%= @model.event_suffix %>" phx-value-id="<%= Map.get(row, @model.id_field) %>">
+          <tr id="<%= Map.get(row, @model.id_field) %>">
           <% end %>
             <%= for column_spec <- @model.column_specs do %>
               <td>

--- a/lib/oli_web/live/users/accounts_live.ex
+++ b/lib/oli_web/live/users/accounts_live.ex
@@ -56,7 +56,7 @@ defmodule OliWeb.Accounts.AccountsLive do
         }
       ],
       event_suffix: "_authors",
-      id_field: :email
+      id_field: ["author", :id]
     )
     |> then(fn {:ok, authors_model} -> authors_model end)
     |> Map.put(:author, current_author)
@@ -90,7 +90,7 @@ defmodule OliWeb.Accounts.AccountsLive do
         }
       ],
       event_suffix: "_users",
-      id_field: :email
+      id_field: ["user", :id]
     )
   end
 

--- a/lib/oli_web/live/users/accounts_live.ex
+++ b/lib/oli_web/live/users/accounts_live.ex
@@ -52,7 +52,6 @@ defmodule OliWeb.Accounts.AccountsLive do
         },
         %ColumnSpec{
           name: :actions,
-          label: "",
           render_fn: &__MODULE__.render_author_actions_column/3
         }
       ],
@@ -76,14 +75,14 @@ defmodule OliWeb.Accounts.AccountsLive do
           render_fn: &__MODULE__.render_email_column/3
         },
         %ColumnSpec{
+          name: :independent_learner,
+          label: "Account Type",
+          render_fn: &__MODULE__.render_learner_column/3
+        },
+        %ColumnSpec{
           name: :author,
           label: "Linked Author",
           render_fn: &__MODULE__.render_author_column/3
-        },
-        %ColumnSpec{
-          name: :independent_learner,
-          label: "Learner",
-          render_fn: &__MODULE__.render_learner_column/3
         },
         %ColumnSpec{
           name: :actions,
@@ -162,6 +161,8 @@ defmodule OliWeb.Accounts.AccountsLive do
     resend_confirmation_link_path =
       Routes.pow_path(OliWeb.Endpoint, :resend_user_confirmation_link)
 
+    reset_password_link_path = Routes.pow_path(OliWeb.Endpoint, :send_user_password_reset_link)
+
     if independent_learner do
       ~L"""
         <div class="dropdown">
@@ -179,7 +180,10 @@ defmodule OliWeb.Accounts.AccountsLive do
               <div class="dropdown-divider"></div>
             <% end %>
 
-            <button class="dropdown-item">Send password reset</button>
+            <form method="post" action="<%= reset_password_link_path %>">
+              <input type="hidden" name="id" value="<%= id %>" />
+              <button type="submit" class="dropdown-item">Send password reset link</button>
+            </form>
 
             <div class="dropdown-divider"></div>
 
@@ -217,6 +221,8 @@ defmodule OliWeb.Accounts.AccountsLive do
     resend_confirmation_link_path =
       Routes.pow_path(OliWeb.Endpoint, :resend_author_confirmation_link)
 
+    reset_password_link_path = Routes.pow_path(OliWeb.Endpoint, :send_author_password_reset_link)
+
     if row != assigns.model.author and
          row.email != System.get_env("ADMIN_EMAIL", "admin@example.edu") do
       ~L"""
@@ -235,7 +241,11 @@ defmodule OliWeb.Accounts.AccountsLive do
               <div class="dropdown-divider"></div>
             <% end %>
 
-            <button class="dropdown-item">Send password reset</button>
+            <form method="post" action="<%= reset_password_link_path %>">
+              <input type="hidden" name="id" value="<%= id %>" />
+              <button type="submit" class="dropdown-item">Send password reset link</button>
+            </form>
+
 
             <div class="dropdown-divider"></div>
 

--- a/lib/oli_web/live/users/accounts_live.ex
+++ b/lib/oli_web/live/users/accounts_live.ex
@@ -192,8 +192,6 @@ defmodule OliWeb.Accounts.AccountsLive do
             <% else %>
               <button class="dropdown-item text-warning" data-toggle="modal" data-target="#lock_user" phx-click="select_user" phx-value-id="<%= id %>">Lock Account</button>
             <% end %>
-
-            <button class="dropdown-item text-danger" data-toggle="modal" data-target="#delete_user" phx-click="select_user" phx-value-id="<%= id %>">Delete</button>
           </div>
         </div>
       """
@@ -265,8 +263,6 @@ defmodule OliWeb.Accounts.AccountsLive do
             <% else %>
               <button class="dropdown-item text-warning" data-toggle="modal" data-target="#lock_user" phx-click="select_author" phx-value-id="<%= id %>">Lock Account</button>
             <% end %>
-
-            <button class="dropdown-item text-danger" data-toggle="modal" data-target="#delete_user" phx-click="select_author" phx-value-id="<%= id %>">Delete</button>
           </div>
         </div>
       """
@@ -382,12 +378,6 @@ defmodule OliWeb.Accounts.AccountsLive do
     {:noreply, assign(socket, model: model, selected_user: nil)}
   end
 
-  def handle_event("delete_user_users", _, socket) do
-    IO.inspect("TODO: delete_user_users")
-
-    {:noreply, assign(socket, selected_user: nil)}
-  end
-
   def handle_event("confirm_email_users", _, socket) do
     email_confirmed_at = DateTime.truncate(DateTime.utc_now(), :second)
 
@@ -417,12 +407,6 @@ defmodule OliWeb.Accounts.AccountsLive do
     model = Map.merge(socket.assigns.model, %{authors_model: authors_model})
 
     {:noreply, assign(socket, model: model, selected_author: nil)}
-  end
-
-  def handle_event("delete_user_authors", _, socket) do
-    IO.inspect("TODO: delete_user_authors")
-
-    {:noreply, assign(socket, selected_author: nil)}
   end
 
   def handle_event("confirm_email_authors", _, socket) do

--- a/lib/oli_web/plugs/ensure_user_not_locked_plug.ex
+++ b/lib/oli_web/plugs/ensure_user_not_locked_plug.ex
@@ -1,0 +1,47 @@
+defmodule OliWeb.EnsureUserNotLockedPlug do
+  @moduledoc """
+  This plug ensures that a user isn't locked.
+
+  ## Example
+
+      plug MyAppWeb.EnsureUserNotLockedPlug
+  """
+  import Plug.Conn, only: [halt: 1]
+
+  alias OliWeb.Router.Helpers, as: Routes
+  alias Phoenix.Controller
+  alias Plug.Conn
+  alias Pow.Plug
+
+  @doc false
+  @spec init(any()) :: any()
+  def init(opts), do: opts
+
+  @doc false
+  @spec call(Conn.t(), any()) :: Conn.t()
+  def call(conn, _opts) do
+    conn
+    |> Plug.current_user()
+    |> locked?()
+    |> maybe_halt(conn)
+  end
+
+  defp locked?(%{locked_at: locked_at}) when not is_nil(locked_at), do: true
+  defp locked?(_user), do: false
+
+  defp maybe_halt(true, conn) do
+    conn
+    |> Plug.delete()
+    |> Controller.put_flash(:error, "Sorry, your account is locked. Please contact support.")
+    |> then(fn conn ->
+      if conn.private.pow_config |> Keyword.get(:user) == Oli.Accounts.Author do
+        Controller.redirect(conn, to: Routes.authoring_pow_session_path(conn, :new))
+      else
+        Controller.redirect(conn, to: Routes.pow_session_path(conn, :new))
+      end
+    end)
+    |> halt()
+  end
+
+  defp maybe_halt(_any, conn), do: conn
+end

--- a/lib/oli_web/pow/author_context.ex
+++ b/lib/oli_web/pow/author_context.ex
@@ -1,0 +1,26 @@
+defmodule OliWeb.Pow.AuthorContext do
+  @moduledoc """
+  Custom module that handles pow users context for author.
+  """
+
+  use Pow.Ecto.Context,
+    repo: Oli.Repo,
+    user: Oli.Accounts.Author
+
+  alias Oli.Repo
+  alias Oli.Accounts.Author
+
+  @spec lock(map()) :: {:ok, map()} | {:error, map()}
+  def lock(user) do
+    user
+    |> Author.lock_changeset()
+    |> Repo.update()
+  end
+
+  @spec lock(map()) :: {:ok, map()} | {:error, map()}
+  def unlock(user) do
+    user
+    |> Author.noauth_changeset(%{locked_at: nil})
+    |> Repo.update()
+  end
+end

--- a/lib/oli_web/pow/pow_helpers.ex
+++ b/lib/oli_web/pow/pow_helpers.ex
@@ -16,7 +16,7 @@ defmodule OliWeb.Pow.PowHelpers do
       extensions: [PowResetPassword, PowEmailConfirmation, PowPersistentSession, PowInvitation],
       controller_callbacks: Pow.Extension.Phoenix.ControllerCallbacks,
       cache_store_backend: Pow.Store.Backend.MnesiaCache,
-      users_context: OliWeb.Pow.UsersContext,
+      users_context: OliWeb.Pow.UserContext,
       mailer_backend: OliWeb.Pow.Mailer,
       web_mailer_module: OliWeb,
       pow_assent: [
@@ -47,6 +47,7 @@ defmodule OliWeb.Pow.PowHelpers do
       extensions: [PowResetPassword, PowEmailConfirmation, PowPersistentSession, PowInvitation],
       controller_callbacks: Pow.Extension.Phoenix.ControllerCallbacks,
       cache_store_backend: Pow.Store.Backend.MnesiaCache,
+      users_context: OliWeb.Pow.AuthorContext,
       mailer_backend: OliWeb.Pow.Mailer,
       web_mailer_module: OliWeb,
       pow_assent: [

--- a/lib/oli_web/pow/user_context.ex
+++ b/lib/oli_web/pow/user_context.ex
@@ -1,4 +1,4 @@
-defmodule OliWeb.Pow.UsersContext do
+defmodule OliWeb.Pow.UserContext do
   @moduledoc """
   Custom module that handles pow users context for user.
   """
@@ -6,6 +6,9 @@ defmodule OliWeb.Pow.UsersContext do
   use Pow.Ecto.Context,
     repo: Oli.Repo,
     user: Oli.Accounts.User
+
+  alias Oli.Repo
+  alias Oli.Accounts.User
 
   @doc """
   Overrides the existing pow get_by/1 and ensures only
@@ -16,5 +19,19 @@ defmodule OliWeb.Pow.UsersContext do
     clauses = Keyword.put_new(clauses, :independent_learner, true)
 
     pow_get_by(clauses)
+  end
+
+  @spec lock(map()) :: {:ok, map()} | {:error, map()}
+  def lock(user) do
+    user
+    |> User.lock_changeset()
+    |> Repo.update()
+  end
+
+  @spec lock(map()) :: {:ok, map()} | {:error, map()}
+  def unlock(user) do
+    user
+    |> User.noauth_changeset(%{locked_at: nil})
+    |> Repo.update()
   end
 end

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -96,6 +96,8 @@ defmodule OliWeb.Router do
       error_handler: Pow.Phoenix.PlugErrorHandler
     )
 
+    plug(OliWeb.EnsureUserNotLockedPlug)
+
     plug(Oli.Plugs.RemoveXFrameOptions)
     plug(:put_root_layout, {OliWeb.LayoutView, "delivery.html"})
   end
@@ -110,6 +112,8 @@ defmodule OliWeb.Router do
     plug(Pow.Plug.RequireAuthenticated,
       error_handler: Pow.Phoenix.PlugErrorHandler
     )
+
+    plug(OliWeb.EnsureUserNotLockedPlug)
   end
 
   # Ensure that the user logged in is an admin user
@@ -568,6 +572,7 @@ defmodule OliWeb.Router do
 
   scope "/admin", OliWeb do
     pipe_through([:browser, :authoring_protected, :workspace, :authoring, :admin])
+
     live("/accounts", Accounts.AccountsLive, session: {__MODULE__, :with_session, []})
     live("/features", Features.FeaturesLive)
 
@@ -595,6 +600,14 @@ defmodule OliWeb.Router do
 
     # Branding
     resources("/brands", BrandController)
+
+    post("/accounts/resend_user_confirmation_link", PowController, :resend_user_confirmation_link)
+
+    post(
+      "/accounts/resend_author_confirmation_link",
+      PowController,
+      :resend_author_confirmation_link
+    )
   end
 
   scope "/project", OliWeb do

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -615,6 +615,14 @@ defmodule OliWeb.Router do
       PowController,
       :resend_author_confirmation_link
     )
+
+    post("/accounts/send_user_password_reset_link", PowController, :send_user_password_reset_link)
+
+    post(
+      "/accounts/send_author_password_reset_link",
+      PowController,
+      :send_author_password_reset_link
+    )
   end
 
   scope "/project", OliWeb do

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -571,7 +571,14 @@ defmodule OliWeb.Router do
   end
 
   scope "/admin", OliWeb do
-    pipe_through([:browser, :authoring_protected, :workspace, :authoring, :admin])
+    pipe_through([
+      :browser,
+      :authoring_protected,
+      :workspace,
+      :authoring,
+      :admin,
+      :pow_email_layout
+    ])
 
     live("/accounts", Accounts.AccountsLive, session: {__MODULE__, :with_session, []})
     live("/features", Features.FeaturesLive)

--- a/lib/oli_web/templates/email/_header.html.eex
+++ b/lib/oli_web/templates/email/_header.html.eex
@@ -1,7 +1,7 @@
 <tr>
-    <a class="navbar-brand oli-logo" href="<%= Routes.static_page_url(OliWeb.Endpoint, :index) %>">
+    <a class="navbar-brand torus-logo" href="<%= Routes.static_page_url(OliWeb.Endpoint, :index) %>">
         <td style="padding: 20px 0; text-align: center">
-            <img src="<%= Routes.static_url(OliWeb.Endpoint, "/images/oli-logo.png") %>" width="277" height="100" alt="oli-logo" border="0" style="height: auto;">
+            <img src="<%= Routes.static_url(OliWeb.Endpoint, Oli.Branding.brand_logo_url()) %>" width="277" height="100" alt="torus-logo" border="0" style="height: auto;">
         </td>
     </a>
 </tr>

--- a/lib/oli_web/templates/layout/_delivery_header.html.eex
+++ b/lib/oli_web/templates/layout/_delivery_header.html.eex
@@ -1,7 +1,7 @@
 <nav class="navbar navbar-expand">
   <div class="container">
 
-    <a class="navbar-brand oli-logo mr-auto" href="<%= if Map.get(assigns, :block_logo_link) !== nil and
+    <a class="navbar-brand torus-logo mr-auto" href="<%= if Map.get(assigns, :block_logo_link) !== nil and
      Map.get(assigns, :block_logo_link) === true, do: "#", else: logo_link_path(@conn) %>">
       <%= brand_logo_html(@conn, class: "d-inline-block align-top mr-2") %>
     </a>

--- a/lib/oli_web/templates/layout/_header.html.eex
+++ b/lib/oli_web/templates/layout/_header.html.eex
@@ -2,7 +2,7 @@
 <nav class="navbar navbar-expand">
 
     <div class="container">
-        <a class="navbar-brand oli-logo mr-auto" href="<%= Routes.static_page_path(@conn, :index) %>">
+        <a class="navbar-brand torus-logo mr-auto" href="<%= Routes.static_page_path(@conn, :index) %>">
             <%= brand_logo_html(@conn, class: "d-inline-block align-top mr-2") %>
         </a>
 

--- a/lib/oli_web/templates/project/_collaborator.html.eex
+++ b/lib/oli_web/templates/project/_collaborator.html.eex
@@ -4,7 +4,6 @@
     <div class="text-muted"><%= "#{@collaborator.email}" %></div>
   </div>
   <div class="user-actions">
-  <% IO.inspect(@collaborator, label: "Collaborator") %>
     <%= link "Remove", to: Routes.collaborator_path(@conn, :delete, @project, @collaborator.email), method: :delete, class: "btn btn-link text-danger" %>
   </div>
 </div>

--- a/lib/oli_web/templates/project/publish.html.eex
+++ b/lib/oli_web/templates/project/publish.html.eex
@@ -17,11 +17,13 @@
 
       <%= case {@has_changes, @active_publication_changes} do %>
         <% {true, nil} -> %>
-          This project has not been published yet
+          <div class="my-3">
+            <b>This project has not been published yet</b>
+          </div>
         <% {false, _} -> %>
           <div class="my-3">
-          Last published <strong><%= @latest_published_publication.updated_at |> Timex.format!("{relative}", :relative) %></strong>.
-          There are <strong>no changes</strong> since last publish.
+            Last published <strong><%= @latest_published_publication.updated_at |> Timex.format!("{relative}", :relative) %></strong>.
+            There are <strong>no changes</strong> since last publish.
           </div>
         <% {true, changes} -> %>
           <div class="my-3">Last published <strong><%= @latest_published_publication.updated_at |> Timex.format!("{relative}", :relative) %></strong>.

--- a/priv/repo/migrations/20210809142945_lock_users.exs
+++ b/priv/repo/migrations/20210809142945_lock_users.exs
@@ -1,0 +1,13 @@
+defmodule Oli.Repo.Migrations.LockUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :locked_at, :utc_datetime
+    end
+
+    alter table(:authors) do
+      add :locked_at, :utc_datetime
+    end
+  end
+end

--- a/test/oli_web/live/users/accounts_live_test.exs
+++ b/test/oli_web/live/users/accounts_live_test.exs
@@ -1,0 +1,38 @@
+defmodule OliWeb.AccountsLiveTest do
+  use OliWeb.ConnCase
+  alias Oli.Seeder
+
+  import Phoenix.ConnTest
+  import Phoenix.LiveViewTest
+  @endpoint OliWeb.Endpoint
+
+  describe "accounts live test" do
+    setup [:setup_session]
+
+    test "accounts mount", %{conn: conn, project: project, map: map} do
+      # TODO
+    end
+  end
+
+  defp setup_session(%{conn: conn}) do
+    map =
+      Seeder.base_project_with_resource2()
+      |> Seeder.add_user(%{name: "user1"}, :user1)
+      |> Seeder.add_user(%{name: "user2"}, :user2)
+
+    conn =
+      Plug.Test.init_test_session(conn, lti_session: nil)
+      |> Pow.Plug.assign_current_user(map.author, OliWeb.Pow.PowHelpers.get_pow_config(:author))
+
+    {:ok,
+     conn: conn,
+     map: map,
+     author: map.author,
+     author2: map.author2,
+     user1: map.user1,
+     user2: map.user2,
+     institution: map.institution,
+     project: map.project,
+     publication: map.publication}
+  end
+end

--- a/test/oli_web/live/users/accounts_live_test.exs
+++ b/test/oli_web/live/users/accounts_live_test.exs
@@ -1,20 +1,44 @@
 defmodule OliWeb.AccountsLiveTest do
   use OliWeb.ConnCase
-  alias Oli.Seeder
 
   import Phoenix.ConnTest
   import Phoenix.LiveViewTest
-  @endpoint OliWeb.Endpoint
+
+  alias Oli.Seeder
+  alias Oli.Accounts
 
   describe "accounts live test" do
     setup [:setup_session]
 
-    test "accounts mount", %{conn: conn, project: project, map: map} do
-      # TODO
+    test "accounts mount", %{conn: conn, admin: _admin, map: map} do
+      conn = get(conn, Routes.live_path(conn, OliWeb.Accounts.AccountsLive))
+
+      {:ok, view, _} = live(conn)
+
+      author1 = Map.get(map, :author)
+      author2 = Map.get(map, :author2)
+
+      user1 = Map.get(map, :user1)
+      user2 = Map.get(map, :user2)
+
+      # the table should have two authors
+      assert view |> element("tr#author-#{author1.id}") |> has_element?()
+      assert view |> element("tr#author-#{author2.id}") |> has_element?()
+
+      # select users view
+      view
+      |> element("a[href=\"#users\"]")
+      |> render_click()
+
+      # the table should have two users
+      assert view |> element("tr#user-#{user1.id}") |> has_element?()
+      assert view |> element("tr#user-#{user2.id}") |> has_element?()
     end
   end
 
   defp setup_session(%{conn: conn}) do
+    admin = author_fixture(%{system_role_id: Accounts.SystemRole.role_id().admin})
+
     map =
       Seeder.base_project_with_resource2()
       |> Seeder.add_user(%{name: "user1"}, :user1)
@@ -22,11 +46,12 @@ defmodule OliWeb.AccountsLiveTest do
 
     conn =
       Plug.Test.init_test_session(conn, lti_session: nil)
-      |> Pow.Plug.assign_current_user(map.author, OliWeb.Pow.PowHelpers.get_pow_config(:author))
+      |> Pow.Plug.assign_current_user(admin, OliWeb.Pow.PowHelpers.get_pow_config(:author))
 
     {:ok,
      conn: conn,
      map: map,
+     admin: admin,
      author: map.author,
      author2: map.author2,
      user1: map.user1,

--- a/test/oli_web/pow/users_context_test.exs
+++ b/test/oli_web/pow/users_context_test.exs
@@ -1,4 +1,4 @@
-defmodule OliWeb.Pow.UsersContextTest do
+defmodule OliWeb.Pow.UserContextTest do
   use OliWeb.ConnCase
 
   alias OliWeb.Router.Helpers, as: Routes


### PR DESCRIPTION
Adds some more advanced functionality to managing authors and users as an admin including the ability to resend email confirmation, manually confirm email, send a reset password link, lock/unlock an account as well as show some other important information such as whether or not an author/user has verified their email, whether a user is an independent learner, LTI user and what admin account they have linked.

 
<img width="1160" alt="Screen Shot 2021-08-09 at 4 54 36 PM" src="https://user-images.githubusercontent.com/6248894/128781368-e2bb5184-a80b-4b58-873c-99e9590e51e4.png">

<img width="517" alt="Screen Shot 2021-08-09 at 4 54 58 PM" src="https://user-images.githubusercontent.com/6248894/128781383-31b2d924-8969-4b1e-bd82-6300c9400c85.png">


Also includes a fix to filter out guest accounts from the Users view and fixes the logo sent in emails.