### PR TITLE
[ENHANCEMENT] allow multiple comma separated collaborators

### DIFF
--- a/lib/oli_web/controllers/collaborator_controller.ex
+++ b/lib/oli_web/controllers/collaborator_controller.ex
@@ -4,13 +4,16 @@ defmodule OliWeb.CollaboratorController do
 
   require Logger
 
-  def create(conn, %{"email_text" => email_text, "g-recaptcha-response" => g_recaptcha_response}) do
+  def create(conn, %{
+        "collaborator_emails" => collaborator_emails,
+        "g-recaptcha-response" => g_recaptcha_response
+      }) do
     project_id = conn.params["project_id"]
 
     case Oli.Utils.Recaptcha.verify(g_recaptcha_response) do
       {:success, true} ->
         emails =
-          email_text
+          collaborator_emails
           |> String.split(",")
           |> Enum.map(&String.trim/1)
 

--- a/lib/oli_web/controllers/collaborator_controller.ex
+++ b/lib/oli_web/controllers/collaborator_controller.ex
@@ -2,12 +2,49 @@ defmodule OliWeb.CollaboratorController do
   use OliWeb, :controller
   alias Oli.Authoring.Collaborators
 
-  def create(conn, %{"email" => email, "g-recaptcha-response" => g_recaptcha_response}) do
+  require Logger
+
+  def create(conn, %{"email_text" => email_text, "g-recaptcha-response" => g_recaptcha_response}) do
     project_id = conn.params["project_id"]
 
     case Oli.Utils.Recaptcha.verify(g_recaptcha_response) do
       {:success, true} ->
-        add_collaborator(conn, email, project_id)
+        emails =
+          email_text
+          |> String.split(",")
+          |> Enum.map(&String.trim/1)
+
+        emails
+        |> Enum.reduce({conn, []}, fn email, {conn, failures} ->
+          add_collaborator(conn, email, project_id, failures)
+        end)
+        |> case do
+          {conn, []} ->
+            conn
+            |> put_flash(:info, "Collaborator invitations sent!")
+            |> redirect(to: Routes.project_path(conn, :overview, project_id))
+
+          {conn, failures} ->
+            failed_emails = Enum.map(failures, fn {email, _msg} -> email end)
+
+            Logger.error("Failed to add collaborators: #{Enum.join(failed_emails, ", ")}")
+
+            if Enum.count(failures) == Enum.count(emails) do
+              conn
+              |> put_flash(
+                :error,
+                "Failed to add collaborators. Please try again or contact support."
+              )
+              |> redirect(to: Routes.project_path(conn, :overview, project_id))
+            else
+              conn
+              |> put_flash(
+                :error,
+                "Failed to add some collaborators: #{Enum.join(failed_emails, ", ")}"
+              )
+              |> redirect(to: Routes.project_path(conn, :overview, project_id))
+            end
+        end
 
       {:success, false} ->
         conn
@@ -32,17 +69,13 @@ defmodule OliWeb.CollaboratorController do
     end
   end
 
-  defp add_collaborator(conn, email, project_id) do
+  defp add_collaborator(conn, email, project_id, failures) do
     case Collaborators.add_collaborator(conn, email, project_id) do
       {:ok, _results} ->
-        conn
-        |> put_flash(:info, "Collaborator invitation sent to #{email}!")
-        |> redirect(to: Routes.project_path(conn, :overview, project_id))
+        {conn, failures}
 
       {:error, message} ->
-        conn
-        |> put_flash(:error, "We couldn't add that author to the project. #{message}")
-        |> redirect(to: Routes.project_path(conn, :overview, project_id))
+        {conn, [{email, message} | failures]}
     end
   end
 end

--- a/lib/oli_web/templates/project/_collaborator.html.eex
+++ b/lib/oli_web/templates/project/_collaborator.html.eex
@@ -4,7 +4,6 @@
     <div class="text-muted"><%= "#{@collaborator.email}" %></div>
   </div>
   <div class="user-actions">
-  <% IO.inspect(@collaborator, label: "Collaborator") %>
     <%= link "Remove", to: Routes.collaborator_path(@conn, :delete, @project, @collaborator.email), method: :delete, class: "btn btn-link text-danger" %>
   </div>
 </div>

--- a/lib/oli_web/templates/project/overview.html.eex
+++ b/lib/oli_web/templates/project/overview.html.eex
@@ -26,7 +26,7 @@
 <div class="row py-5 border-bottom">
   <div class="col-md-4">
     <h4>Collaborators</h4>
-    <div class="text-muted">Invite other authors by email to contribute to your project.</div>
+    <div class="text-muted">Invite other authors by email to contribute to your project. Specify multiple separated by a comma.</div>
   </div>
   <div class="col-md-8">
     <script src="https://www.google.com/recaptcha/api.js"></script>
@@ -34,13 +34,13 @@
     <div class="form-group">
       <div class="input-group mb-3">
         <%= text_input f,
-            :email,
+            :email_text,
             class: "form-control" <> error_class(f, :title, "is-invalid"),
             placeholder: "collaborator@example.edu",
             id: "input-title",
             required: true,
-            autofocus: focusHelper(f, :email, default: false) %>
-        <%= error_tag f, :email %>
+            autofocus: focusHelper(f, :email_text, default: false) %>
+        <%= error_tag f, :email_text %>
         <div class="input-group-append">
           <%= submit "Send Invite",
               id: "button-create-collaborator",

--- a/lib/oli_web/templates/project/overview.html.eex
+++ b/lib/oli_web/templates/project/overview.html.eex
@@ -34,13 +34,13 @@
     <div class="form-group">
       <div class="input-group mb-3">
         <%= text_input f,
-            :email_text,
+            :collaborator_emails,
             class: "form-control" <> error_class(f, :title, "is-invalid"),
             placeholder: "collaborator@example.edu",
             id: "input-title",
             required: true,
-            autofocus: focusHelper(f, :email_text, default: false) %>
-        <%= error_tag f, :email_text %>
+            autofocus: focusHelper(f, :collaborator_emails, default: false) %>
+        <%= error_tag f, :collaborator_emails %>
         <div class="input-group-append">
           <%= submit "Send Invite",
               id: "button-create-collaborator",

--- a/test/oli/part_components_test.exs
+++ b/test/oli/part_components_test.exs
@@ -16,19 +16,18 @@ defmodule Oli.PartComponentsTest do
       project_parts = PartComponents.part_components_for_project(project)
 
       assert Enum.member?(project_parts, %{
-                enabled: true,
-                global: false,
-                authoring_script: "test_part_component_authoring.js",
-                authoring_element: "test-part-component-authoring",
-                delivery_script: "test_part_component_delivery.js",
-                delivery_element: "test-part-component-delivery",
-                description: "test part component for testing",
-                title: "Test Part Component",
-                icon: "nothing",
-                author: "Test McTesterson",
-                slug: "test_part_component",
-                title: "Test Part Component"
-              })
+               enabled: true,
+               global: false,
+               authoring_script: "test_part_component_authoring.js",
+               authoring_element: "test-part-component-authoring",
+               delivery_script: "test_part_component_delivery.js",
+               delivery_element: "test-part-component-delivery",
+               description: "test part component for testing",
+               title: "Test Part Component",
+               icon: "nothing",
+               author: "Test McTesterson",
+               slug: "test_part_component"
+             })
     end
 
     test "removing a custom registered part component from a project", %{project: project} do
@@ -39,19 +38,18 @@ defmodule Oli.PartComponentsTest do
       project_parts = PartComponents.part_components_for_project(project)
 
       assert Enum.member?(project_parts, %{
-                enabled: false,
-                global: false,
-                authoring_script: "test_part_component_authoring.js",
-                authoring_element: "test-part-component-authoring",
-                delivery_script: "test_part_component_delivery.js",
-                delivery_element: "test-part-component-delivery",
-                description: "test part component for testing",
-                title: "Test Part Component",
-                icon: "nothing",
-                author: "Test McTesterson",
-                slug: "test_part_component",
-                title: "Test Part Component"
-              })
+               enabled: false,
+               global: false,
+               authoring_script: "test_part_component_authoring.js",
+               authoring_element: "test-part-component-authoring",
+               delivery_script: "test_part_component_delivery.js",
+               delivery_element: "test-part-component-delivery",
+               description: "test part component for testing",
+               title: "Test Part Component",
+               icon: "nothing",
+               author: "Test McTesterson",
+               slug: "test_part_component"
+             })
     end
   end
 end

--- a/test/oli_web/controllers/collaborator_controller_test.exs
+++ b/test/oli_web/controllers/collaborator_controller_test.exs
@@ -16,7 +16,7 @@ defmodule OliWeb.CollaboratorControllerTest do
 
       conn =
         post(conn, Routes.collaborator_path(conn, :create, project),
-          email_text: @admin_email,
+          collaborator_emails: @admin_email,
           "g-recaptcha-response": "any"
         )
 
@@ -29,7 +29,7 @@ defmodule OliWeb.CollaboratorControllerTest do
 
       conn =
         post(conn, Routes.collaborator_path(conn, :create, project),
-          email_text: "#{@admin_email}, #{@invite_email},someotheremail@example.edu",
+          collaborator_emails: "#{@admin_email}, #{@invite_email},someotheremail@example.edu",
           "g-recaptcha-response": "any"
         )
 
@@ -43,7 +43,7 @@ defmodule OliWeb.CollaboratorControllerTest do
       assert capture_log(fn ->
                conn =
                  post(conn, Routes.collaborator_path(conn, :create, project),
-                   email_text: "#{@admin_email}, notevenan_email",
+                   collaborator_emails: "#{@admin_email}, notevenan_email",
                    "g-recaptcha-response": "any"
                  )
 
@@ -59,7 +59,7 @@ defmodule OliWeb.CollaboratorControllerTest do
 
       conn =
         post(conn, Routes.collaborator_path(conn, :create, project),
-          email_text: @invalid_email,
+          collaborator_emails: @invalid_email,
           "g-recaptcha-response": "any"
         )
 
@@ -73,7 +73,7 @@ defmodule OliWeb.CollaboratorControllerTest do
 
       conn =
         post(conn, Routes.collaborator_path(conn, :create, project),
-          email_text: @invite_email,
+          collaborator_emails: @invite_email,
           "g-recaptcha-response": "any"
         )
 


### PR DESCRIPTION
This PR adds the ability to specify multiple collaborator invites at once separated by comma. It also remove a rogue IO.inspect call, fixes some test warnings.