### PR TITLE
[BUG FIX] fix an issue with update line items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 ### Bug Fixes
+- Fix an issue where Update Line Items was failing
+
+### Bug Fixes
 - Fix iframe rendering when elements contain captions (webpage, youtube)
 - Fix iframe rendering in activities
 - Fix an issue where mod key changes current selection

--- a/lib/oli_web/live/grades/grades.ex
+++ b/lib/oli_web/live/grades/grades.ex
@@ -209,7 +209,7 @@ defmodule OliWeb.Grades.GradesLive do
 
     case fetch_line_items(registration, socket.assigns.line_items_url) do
       {:ok, line_items, access_token} ->
-        graded_pages = Grading.fetch_graded_pages(socket.assigns.section)
+        graded_pages = Grading.fetch_graded_pages(socket.assigns.section.slug)
 
         case determine_line_item_tasks(graded_pages, line_items) do
           [] ->


### PR DESCRIPTION
This PR fixes an issue where the "Update Line Items" action was failing. The issue was a section was being passed to the `fetch_graded_pages` function, but it needed a section slug.