### PR TITLE
Bugfix/pmp 1670

### DIFF
--- a/assets/src/adaptivity/rules-engine.ts
+++ b/assets/src/adaptivity/rules-engine.ts
@@ -228,7 +228,7 @@ export const check = async (
   const { env } = evalScript(janus_std);
 
   const { result: assignResults } = evalAssignScript(state, env);
-  console.log('RULES ENGINE CHECK', { assignResults, state, env });
+  console.log('RULES ENGINE STATE ASSIGN', { assignResults, state, env });
 
   // evaluate all rule conditions against context
   const enabledRules = rules.filter((r) => !r.disabled);

--- a/assets/src/adaptivity/rules-engine.ts
+++ b/assets/src/adaptivity/rules-engine.ts
@@ -16,7 +16,7 @@ import containsOperators from './operators/contains';
 import equalityOperators from './operators/equality';
 import mathOperators from './operators/math';
 import rangeOperators from './operators/range';
-import { bulkApplyState, evalScript, getAssignScript, getValue } from './scripting';
+import { bulkApplyState, evalAssignScript, evalScript, getValue } from './scripting';
 
 export interface JanusRuleProperties extends RuleProperties {
   id?: string;
@@ -226,12 +226,10 @@ export const check = async (
 ): Promise<CheckResult | string> => {
   // load the std lib
   const { env } = evalScript(janus_std);
-  // setup script env context
-  const assignScript = getAssignScript(state);
-  // $log.info('assign: ', assignScript);
-  const stateEvalResult = evalScript(assignScript, env);
-  // TODO: check result for errors
-  console.log('CHECK', { assignScript, stateEvalResult });
+
+  const { result: assignResults } = evalAssignScript(state, env);
+  console.log('RULES ENGINE CHECK', { assignResults, state, env });
+
   // evaluate all rule conditions against context
   const enabledRules = rules.filter((r) => !r.disabled);
   if (enabledRules.length === 0 || !enabledRules.find((r) => r.default && !r.correct)) {

--- a/assets/src/adaptivity/scripting.ts
+++ b/assets/src/adaptivity/scripting.ts
@@ -120,14 +120,26 @@ export const evalScript = (
   const program = parser.parseProgram();
   if (parser.errors.length) {
     /* console.error(`ERROR SCRIPT: ${script}`, { e: parser.errors }); */
-    throw new Error(parser.errors.join('\n'));
+    throw new Error(`Error in script: ${script}\n${parser.errors.join('\n')}`);
   }
   const result = evaluator.eval(program, globalEnv);
   const jsResult = result.toJS();
   return { env: globalEnv, result: jsResult };
 };
 
-export const getAssignScript = (state: Record<string, any>): string => {
+export const evalAssignScript = (
+  state: Record<string, any>,
+  env?: Environment,
+): { env: Environment; result: any } => {
+  const globalEnv = env || new Environment();
+  const assignStatements = getAssignStatements(state);
+  const results = assignStatements.map((assignStatement) => {
+    return evalScript(assignStatement, globalEnv).result;
+  });
+  return { env: globalEnv, result: results };
+};
+
+export const getAssignStatements = (state: Record<string, any>): string[] => {
   const vars = Object.keys(state).map((key) => {
     const val = state[key];
     let writeVal = { key, value: val, type: 0 };
@@ -146,6 +158,11 @@ export const getAssignScript = (state: Record<string, any>): string => {
     return writeVal;
   });
   const letStatements = vars.map((v) => `let {${v.key}} = ${getExpressionStringForValue(v)};`);
+  return letStatements;
+};
+
+export const getAssignScript = (state: Record<string, any>): string => {
+  const letStatements = getAssignStatements(state);
   return letStatements.join('');
 };
 

--- a/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
@@ -169,7 +169,14 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
                       # part_inputs are assumed to be from the current activity only
                       # so we strip out the sequence id from the path to get our "local"
                       # values for the rules
-                      local_path = Enum.at(Enum.take(String.split(path, "|"), -1), 0, path)
+                      # might look like this "q:1465253111364:752|stage.dragdrop.Drag and Drop.Body Fossil | Direct Evidence.Count"
+                      path_parts = String.split(path, "|stage")
+                      path_interested = List.last(path_parts)
+                      local_path = if String.starts_with?(path_interested, ".") do
+                        "stage" <> path_interested
+                      else
+                        path_interested
+                      end
                       value = Map.get(input, "value")
                       Map.put(acc1, local_path, value)
                     end


### PR DESCRIPTION
open and free evaluations were hitting an exception because splitting on | doesn't work when there are more pipes in the variable names.