### PR TITLE
prevent server error from invalid strings in stylesheets

### DIFF
--- a/lib/oli_web/views/layout_view.ex
+++ b/lib/oli_web/views/layout_view.ex
@@ -42,6 +42,7 @@ defmodule OliWeb.LayoutView do
   """
   def additional_stylesheets(assigns) do
     Map.get(assigns, :additional_stylesheets, [])
+    |> Enum.filter(fn url -> String.valid?(url) end)
     |> Enum.map(&URI.encode(&1))
     |> Enum.map(fn url -> "\n<link rel=\"stylesheet\" href=\"#{url}\">" end)
     |> raw()


### PR DESCRIPTION
if the editor writes null or some other non string value into the additional stylesheets somehow it will crash the server during URI encoding. while the authoring tool should prevent this, I think it's better to skip these values rather than allow it to crash and give the "Internal Server Error" message :)