### PR TITLE
limit the amount of author invite emails at a time to 20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Bug Fixes
+- Fix an issue where unlimited collaborator emails could be sent at once
 ### Enhancements
 
 ## 0.12.8 (2021-08-11)

--- a/assets/src/apps/authoring/Authoring.tsx
+++ b/assets/src/apps/authoring/Authoring.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Provider, useDispatch, useSelector } from 'react-redux';
 import { BottomPanel } from './BottomPanel';
 import { AdaptivityEditor } from './components/AdaptivityEditor/AdaptivityEditor';
@@ -34,7 +34,8 @@ const Authoring: React.FC<AuthoringProps> = (props: AuthoringProps) => {
   const dispatch = useDispatch();
 
   const authoringContainer = document.getElementById('advanced-authoring');
-  const isAppVisible = true;
+  const [isAppVisible, setIsAppVisible] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
 
   const leftPanelState = useSelector(selectLeftPanel);
   const rightPanelState = useSelector(selectRightPanel);
@@ -102,31 +103,49 @@ const Authoring: React.FC<AuthoringProps> = (props: AuthoringProps) => {
     };
   }, [isAppVisible]);
 
+  useEffect(() => {
+    setTimeout(() => {
+      setIsAppVisible(true);
+    }, 500);
+    setTimeout(() => {
+      setIsLoading(false);
+    }, 2000);
+  }, []);
+
   return (
-    <div id="advanced-authoring" className={`advanced-authoring startup`}>
-      <HeaderNav panelState={panelState} isVisible={panelState.top} />
-      <SidePanel
-        position="left"
-        panelState={panelState}
-        onToggle={() => handlePanelStateChange({ left: !panelState.left })}
-      >
-        <LeftMenu />
-      </SidePanel>
-      <EditingCanvas />
-      <BottomPanel
-        panelState={panelState}
-        onToggle={() => handlePanelStateChange({ bottom: !panelState.bottom })}
-      >
-        <AdaptivityEditor />
-      </BottomPanel>
-      <SidePanel
-        position="right"
-        panelState={panelState}
-        onToggle={() => handlePanelStateChange({ right: !panelState.right })}
-      >
-        <RightMenu />
-      </SidePanel>
-    </div>
+    <>
+      {isLoading && (
+        <div id="aa-loading">
+          <div className="loader spinner-border text-primary" role="status">
+            <span className="sr-only">Loading...</span>
+          </div>
+        </div>
+      )}
+      <div id="advanced-authoring" className={`advanced-authoring d-none`}>
+        <HeaderNav panelState={panelState} isVisible={panelState.top} />
+        <SidePanel
+          position="left"
+          panelState={panelState}
+          onToggle={() => handlePanelStateChange({ left: !panelState.left })}
+        >
+          <LeftMenu />
+        </SidePanel>
+        <EditingCanvas />
+        <BottomPanel
+          panelState={panelState}
+          onToggle={() => handlePanelStateChange({ bottom: !panelState.bottom })}
+        >
+          <AdaptivityEditor />
+        </BottomPanel>
+        <SidePanel
+          position="right"
+          panelState={panelState}
+          onToggle={() => handlePanelStateChange({ right: !panelState.right })}
+        >
+          <RightMenu />
+        </SidePanel>
+      </div>
+    </>
   );
 };
 

--- a/assets/styles/authoring/advanced-authoring.scss
+++ b/assets/styles/authoring/advanced-authoring.scss
@@ -10,6 +10,29 @@ $ui-border-color: #ccc;
 $panel-section-title-bar-height: 39px;
 $panel-section-title-bar-color: #e8ebed;
 
+#aa-loading {
+  transition-timing-function: ease-in-out;
+  transition-duration: 0.3s;
+  transition-property: opacity;
+  opacity: 1;
+  position: fixed;
+  height: 100vh;
+  width: 100vw;
+  top: $nav-height;
+  bottom: 0;
+  left: $nav-height;
+  right: 0;
+  background-color: $workspace-bg;
+  z-index: 99999;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  .loader {
+    margin-left: -$nav-height;
+    margin-top: -$nav-height;
+  }
+}
 .advanced-authoring {
   position: relative;
   opacity: 0;

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -97,6 +97,13 @@ config :oli, OliWeb.Endpoint,
 # Configure Mnesia directory (used by pow persistent sessions)
 config :mnesia, :dir, to_charlist(System.get_env("MNESIA_DIR", ".mnesia"))
 
+# Configure logger if LOG_LEVEL is set
+case System.get_env("LOG_LEVEL", nil) do
+  nil ->
+  log_level ->
+    config :logger, level: String.to_atom(log_level)
+end
+
 # ## Using releases (Elixir v1.9+)
 #
 # If you are doing OTP releases, you need to instruct Phoenix

--- a/lib/oli/rendering/activity.ex
+++ b/lib/oli/rendering/activity.ex
@@ -25,11 +25,11 @@ defmodule Oli.Rendering.Activity do
   # Renders an error message if the signature above does not match. Logging and rendering of errors
   # can be configured using the render_opts in context
   def render(%Context{render_opts: render_opts} = context, element, writer) do
-    error_id = Utils.random_string(8)
+    error_id = Utils.generate_error_id()
     error_msg = "Activity error: #{Kernel.inspect(element)}"
 
     if render_opts.log_errors,
-      do: Logger.error("Render Error ##{error_id} #{error_msg}"),
+      do: Logger.error("##{error_id} Render Error: #{error_msg}"),
       else: nil
 
     if render_opts.render_errors do

--- a/lib/oli/rendering/activity/html.ex
+++ b/lib/oli/rendering/activity/html.ex
@@ -23,15 +23,13 @@ defmodule Oli.Rendering.Activity.Html do
 
     case activity_summary do
       nil ->
-        error_id = Utils.random_string(8)
+        error_id = Utils.generate_error_id()
 
         error_msg =
-          "ActivitySummary with id #{activity_id} missing from activity_map: #{
-            Kernel.inspect({activity, activity_map})
-          }"
+          "ActivitySummary with id #{activity_id} missing from activity_map: #{Kernel.inspect({activity, activity_map})}"
 
         if render_opts.log_errors,
-          do: Logger.error("Render Error ##{error_id} #{error_msg}"),
+          do: Logger.error("##{error_id} Render Error: #{error_msg}"),
           else: nil
 
         if render_opts.render_errors do
@@ -48,11 +46,7 @@ defmodule Oli.Rendering.Activity.Html do
         section_slug = context.section_slug
 
         activity_html = [
-          "<#{tag} class=\"activity-container\" graded=\"#{graded}\" state=\"#{state}\" model=\"#{
-            model_json
-          }\" preview=\"#{preview}\" user_id=\"#{user.id}\" review=\"#{review_mode}\" section_slug=\"#{
-            section_slug
-          }\"></#{tag}>\n"
+          "<#{tag} class=\"activity-container\" graded=\"#{graded}\" state=\"#{state}\" model=\"#{model_json}\" preview=\"#{preview}\" user_id=\"#{user.id}\" review=\"#{review_mode}\" section_slug=\"#{section_slug}\"></#{tag}>\n"
         ]
 
         case purpose do
@@ -76,16 +70,12 @@ defmodule Oli.Rendering.Activity.Html do
     case error do
       {:invalid, error_id, _error_msg} ->
         [
-          "<div class=\"activity invalid alert alert-danger\">Activity error. Please contact support with issue <strong>##{
-            error_id
-          }</strong></div>\n"
+          "<div class=\"activity invalid alert alert-danger\">Activity error. Please contact support with issue <strong>##{error_id}</strong></div>\n"
         ]
 
       {_, error_id, _error_msg} ->
         [
-          "<div class=\"activity error alert alert-danger\">An error occurred and this activity could not be shown. Please contact support with issue <strong>##{
-            error_id
-          }</strong></div>\n"
+          "<div class=\"activity error alert alert-danger\">An error occurred and this activity could not be shown. Please contact support with issue <strong>##{error_id}</strong></div>\n"
         ]
     end
   end

--- a/lib/oli/rendering/content.ex
+++ b/lib/oli/rendering/content.ex
@@ -161,11 +161,11 @@ defmodule Oli.Rendering.Content do
         writer.a(context, next, element)
 
       _ ->
-        error_id = Utils.random_string(8)
+        error_id = Utils.generate_error_id()
         error_msg = "Content element is not supported: #{Kernel.inspect(element)}"
 
         if render_opts.log_errors,
-          do: Logger.error("Render Error ##{error_id} #{error_msg}"),
+          do: Logger.error("##{error_id} Render Error: #{error_msg}"),
           else: nil
 
         if render_opts.render_errors do
@@ -179,11 +179,11 @@ defmodule Oli.Rendering.Content do
   # Renders an error message if none of the signatures above match. Logging and rendering of errors
   # can be configured using the render_opts in context
   def render(%Context{render_opts: render_opts} = context, element, writer) do
-    error_id = Utils.random_string(8)
+    error_id = Utils.generate_error_id()
     error_msg = "Content element is invalid: #{Kernel.inspect(element)}"
 
     if render_opts.log_errors,
-      do: Logger.error("Render Error ##{error_id} #{error_msg}"),
+      do: Logger.error("##{error_id} Render Error: #{error_msg}"),
       else: nil
 
     if render_opts.render_errors do

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -322,11 +322,11 @@ defmodule Oli.Rendering.Content.Html do
   defp figure(_attrs, content), do: content
 
   defp missing_media(%Context{render_opts: render_opts} = context, element) do
-    error_id = Utils.random_string(8)
+    error_id = Utils.generate_error_id()
     error_msg = "Rendering error: #{Kernel.inspect(element)}"
 
     if render_opts.log_errors,
-      do: Logger.error("Render Error ##{error_id} #{error_msg}"),
+      do: Logger.error("##{error_id} Render Error: #{error_msg}"),
       else: nil
 
     if render_opts.render_errors do
@@ -337,11 +337,11 @@ defmodule Oli.Rendering.Content.Html do
   end
 
   defp maybe_log_error(%Context{render_opts: render_opts}, element) do
-    error_id = Utils.random_string(8)
+    error_id = Utils.generate_error_id()
     error_msg = "Rendering error: #{Kernel.inspect(element)}"
 
     if render_opts.log_errors,
-      do: Logger.error("Render Error ##{error_id} #{error_msg}"),
+      do: Logger.error("##{error_id} Render Error: #{error_msg}"),
       else: nil
   end
 end

--- a/lib/oli/rendering/page.ex
+++ b/lib/oli/rendering/page.ex
@@ -34,11 +34,11 @@ defmodule Oli.Rendering.Page do
             {element, output}
 
           _ ->
-            error_id = Utils.random_string(8)
+            error_id = Utils.generate_error_id()
             error_msg = "Page item is not supported: #{Kernel.inspect(element)}"
 
             if render_opts.log_errors,
-              do: Logger.error("Render Error ##{error_id} #{error_msg}"),
+              do: Logger.error("##{error_id} Render Error: #{error_msg}"),
               else: nil
 
             if render_opts.render_errors do
@@ -56,11 +56,11 @@ defmodule Oli.Rendering.Page do
   # Renders an error message if the signature above does not match. Logging and rendering of errors
   # can be configured using the render_opts in context
   def render(%Context{render_opts: render_opts} = context, page_model, writer) do
-    error_id = Utils.random_string(8)
+    error_id = Utils.generate_error_id()
     error_msg = "Page model is invalid: #{Kernel.inspect(page_model)}"
 
     if render_opts.log_errors,
-      do: Logger.error("Render Error ##{error_id} #{error_msg}"),
+      do: Logger.error("##{error_id} Render Error: #{error_msg}"),
       else: nil
 
     if render_opts.render_errors do

--- a/lib/oli/utils.ex
+++ b/lib/oli/utils.ex
@@ -6,6 +6,10 @@ defmodule Oli.Utils do
     :crypto.strong_rand_bytes(length) |> Base.encode16() |> binary_part(0, length)
   end
 
+  def generate_error_id() do
+    random_string(8)
+  end
+
   @doc """
   Returns the specified value if not nil, otherwise returns the default value
   """

--- a/lib/oli_web/controllers/collaborator_controller.ex
+++ b/lib/oli_web/controllers/collaborator_controller.ex
@@ -41,7 +41,10 @@ defmodule OliWeb.CollaboratorController do
             {conn, failures} ->
               failed_emails = Enum.map(failures, fn {email, _msg} -> email end)
 
-              Logger.error("Failed to add collaborators: #{Enum.join(failed_emails, ", ")}")
+              Logger.error(
+                "Failed to add collaborators: #{Enum.join(failed_emails, ", ")}",
+                failures
+              )
 
               if Enum.count(failures) == Enum.count(emails) do
                 conn

--- a/lib/oli_web/controllers/collaborator_controller.ex
+++ b/lib/oli_web/controllers/collaborator_controller.ex
@@ -40,24 +40,22 @@ defmodule OliWeb.CollaboratorController do
 
             {conn, failures} ->
               failed_emails = Enum.map(failures, fn {email, _msg} -> email end)
+              error_id = Oli.Utils.generate_error_id()
 
-              Logger.error(
-                "Failed to add collaborators: #{Enum.join(failed_emails, ", ")}",
-                failures
-              )
+              Logger.error("##{error_id} Failed to add collaborators: #{inspect(failures)}")
 
               if Enum.count(failures) == Enum.count(emails) do
                 conn
                 |> put_flash(
                   :error,
-                  "Failed to add collaborators. Please try again or contact support."
+                  "Failed to add collaborators. Please try again or contact support with issue ##{error_id}."
                 )
                 |> redirect(to: Routes.project_path(conn, :overview, project_id))
               else
                 conn
                 |> put_flash(
                   :error,
-                  "Failed to add some collaborators: #{Enum.join(failed_emails, ", ")}"
+                  "Failed to add some collaborators: #{Enum.join(failed_emails, ", ")}. Please try again or contact support with issue ##{error_id}."
                 )
                 |> redirect(to: Routes.project_path(conn, :overview, project_id))
               end

--- a/lib/oli_web/templates/project/overview.html.eex
+++ b/lib/oli_web/templates/project/overview.html.eex
@@ -39,6 +39,7 @@
             placeholder: "collaborator@example.edu",
             id: "input-title",
             required: true,
+            autocomplete: "off",
             autofocus: focusHelper(f, :collaborator_emails, default: false) %>
         <%= error_tag f, :collaborator_emails %>
         <div class="input-group-append">

--- a/test/oli_web/controllers/collaborator_controller_test.exs
+++ b/test/oli_web/controllers/collaborator_controller_test.exs
@@ -49,9 +49,9 @@ defmodule OliWeb.CollaboratorControllerTest do
 
                assert html_response(conn, 302) =~ "/project/"
 
-               assert assert get_flash(conn, :error) ==
+               assert assert get_flash(conn, :error) =~
                                "Failed to add some collaborators: notevenan_email"
-             end) =~ "Failed to add collaborators: notevenan_email"
+             end) =~ "Failed to add collaborators"
     end
 
     test "redirects to project path when data is invalid", %{conn: conn, project: project} do


### PR DESCRIPTION
This PR introduces a limit to the amount of comma-separated collaborator emails that can be sent at a time. This is a security measure to limit the capability of blasting unlimited emails from the system without reverifying the captcha.

Also includes some richer logging of errors for collaborator invitations.