### PR TITLE
[FEATURE] Allow bulk activity editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,15 @@
 ## Unreleased
 
 ### Bug Fixes
+
 ### Enhancements
+
+- Add API support for bulk activity updating
 
 ## 0.12.8 (2021-08-11)
 
 ### Bug Fixes
+
 - Fix iframe rendering when elements contain captions (webpage, youtube)
 - Fix iframe rendering in activities
 - Fix an issue where mod key changes current selection

--- a/lib/oli/authoring/editing/activity_editor.ex
+++ b/lib/oli/authoring/editing/activity_editor.ex
@@ -184,6 +184,130 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
     Resources.create_revision(with_type)
   end
 
+  defp authorize_edit(project_slug, author_email, updates) do
+    with {:ok, _} <- validate_request(updates),
+         {:ok, author} <- Accounts.get_author_by_email(author_email) |> trap_nil(),
+         {:ok, project} <- Course.get_project_by_slug(project_slug) |> trap_nil(),
+         {:ok} <- authorize_user(author, project),
+         {:ok, publication} <-
+           Publishing.get_unpublished_publication_by_slug!(project_slug) |> trap_nil() do
+      {:ok, {author, project, publication}}
+    else
+      error -> error
+    end
+  end
+
+  @doc """
+  Attempts to process a collection of edits for an activity specified by a given
+  project and revision slug and activity slug for the author specified by email.
+
+  The updates parameter is a list of maps containing key-value pairs of the
+  attributes of a Revision that are to be edited, including the resource id. It can
+  contain any number of key-value pairs, but the keys must match
+  the schema of `%Revision{}` struct.
+
+  Not acquiring the lock here is considered a failure, as it is
+  not an expected condition that a client would encounter. The client
+  should have first acquired the lock via `acquire_lock`.
+
+  Returns:
+
+  .`{:ok, [%Revision{}]}` when the edit processes successfully
+  .`{:error, {:lock_not_acquired, {user_email, updated_at}}}` if the lock could not be acquired or updated
+  .`{:error, {:not_found}}` if the project, resource, activity, or user cannot be found
+  .`{:error, {:not_authorized}}` if the user is not authorized to edit this activity
+  .`{:error, {:invalid_update_field}}` if the update contains an invalid field
+  .`{:error, {:error}}` unknown error
+  """
+  @spec bulk_edit(String.t(), String.t(), String.t(), %{}) ::
+          {:ok, %Revision{}}
+          | {:error, {:not_found}}
+          | {:error, {:error}}
+          | {:error, {:lock_not_acquired, any()}}
+          | {:error, {:not_authorized}}
+  def bulk_edit(project_slug, lock_id, author_email, updates) do
+    result =
+      with {:ok, {author, project, publication}} <-
+             authorize_edit(project_slug, author_email, updates),
+           {:ok, resource} <- Resources.get_resource(lock_id) |> trap_nil() do
+        Repo.transaction(fn ->
+          case Locks.update(project.slug, publication.id, resource.id, author.id) do
+            # If we acquired the lock, we must first create a new revision
+            {:acquired} ->
+              case process_with_new_revision(updates, publication, author, project) do
+                {:ok, revisions} -> revisions
+                {:error, e} -> Repo.rollback(e)
+              end
+
+            # A successful lock update means we can safely edit the existing revision
+            # unless, that is, if the update would change the corresponding slug.
+            # In that case we need to create a new revision. Otherwise, future attempts
+            # to resolve this activity via the historical slugs would fail.
+            {:updated} ->
+              case process_with_maybe_new_revision(updates, publication, author, project) do
+                {:ok, revisions} -> revisions
+                {:error, e} -> Repo.rollback(e)
+              end
+
+            # error or not able to lock results in a failed edit
+            result ->
+              Repo.rollback(result)
+          end
+        end)
+      else
+        error -> error
+      end
+
+    case result do
+      {:ok, revisions} ->
+        Enum.each(revisions, fn r -> Broadcaster.broadcast_revision(r, project_slug) end)
+        {:ok, revisions}
+
+      e ->
+        e
+    end
+  end
+
+  defp process_with_new_revision(updates, publication, author, project) do
+    results =
+      Enum.map(updates, fn update ->
+        case Resources.get_resource(Map.get(update, "resource_id")) do
+          nil ->
+            nil
+
+          activity ->
+            get_latest_revision(publication.id, activity.id)
+            |> create_new_revision(publication, activity, author.id)
+            |> update_revision(update, project.slug)
+        end
+      end)
+
+    case Enum.all?(results, fn r -> r != nil end) do
+      true -> {:ok, results}
+      false -> {:error, {:not_found}}
+    end
+  end
+
+  defp process_with_maybe_new_revision(updates, publication, author, project) do
+    results =
+      Enum.map(updates, fn update ->
+        case Resources.get_resource(Map.get(update, "resource_id")) do
+          nil ->
+            nil
+
+          activity ->
+            get_latest_revision(publication.id, activity.id)
+            |> maybe_create_new_revision(publication, activity, author.id, update)
+            |> update_revision(update, project.slug)
+        end
+      end)
+
+    case Enum.all?(results, fn r -> r != nil end) do
+      true -> {:ok, results}
+      false -> {:error, {:not_found}}
+    end
+  end
+
   @doc """
   Attempts to process an edit for an activity specified by a given
   project and revision slug and activity slug for the author specified by email.
@@ -214,13 +338,9 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
           | {:error, {:not_authorized}}
   def edit(project_slug, lock_id, activity_id, author_email, update) do
     result =
-      with {:ok, _} <- validate_request(update),
-           {:ok, author} <- Accounts.get_author_by_email(author_email) |> trap_nil(),
-           {:ok, project} <- Course.get_project_by_slug(project_slug) |> trap_nil(),
-           {:ok} <- authorize_user(author, project),
+      with {:ok, {author, project, publication}} <-
+             authorize_edit(project_slug, author_email, update),
            {:ok, activity} <- Resources.get_resource(activity_id) |> trap_nil(),
-           {:ok, publication} <-
-             Publishing.get_unpublished_publication_by_slug!(project_slug) |> trap_nil(),
            {:ok, resource} <- Resources.get_resource(lock_id) |> trap_nil() do
         Repo.transaction(fn ->
           case Locks.update(project.slug, publication.id, resource.id, author.id) do
@@ -361,15 +481,35 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
     parts = update["content"]["authoring"]["parts"]
     update = sync_objectives_to_parts(objectives, update, parts)
 
+    # do not allow resource_id, if present, to be editable.  resource_id is only allowed to be
+    # present in bulk update situations so that the server knows which resource we are editing
+    update = Map.delete(update, "resource_id")
+
     {:ok, updated} = Resources.update_revision(revision, update)
 
     updated
   end
 
   # Check to see if this update is valid
+  defp validate_request(update) when is_list(update) do
+    all_valid? =
+      Enum.map(update, fn u -> validate_request(u) end)
+      |> Enum.all?(fn result ->
+        case result do
+          {:ok, _} -> true
+          _ -> false
+        end
+      end)
+
+    case all_valid? do
+      true -> {:ok, update}
+      _ -> {:error, {:invalid_update_field}}
+    end
+  end
+
   defp validate_request(update) do
     # Ensure that only these top-level keys are present
-    allowed = MapSet.new(~w"objectives title content authoring releaseLock")
+    allowed = MapSet.new(~w"objectives title content authoring releaseLock resource_id")
 
     case Map.keys(update)
          |> Enum.all?(fn k -> MapSet.member?(allowed, k) end) do

--- a/lib/oli_web/controllers/api/activity_controller.ex
+++ b/lib/oli_web/controllers/api/activity_controller.ex
@@ -28,6 +28,10 @@ defmodule OliWeb.Api.ActivityController do
       type: :object,
       properties: %{
         title: %Schema{type: :string, description: "Title of this document"},
+        resource_id: %Schema{
+          type: :integer,
+          description: "Resource id of the document, not editable"
+        },
         objectives: %Schema{type: :object, description: "Per part objective mapping"},
         content: %Schema{type: :object, description: "Delivery specific content"},
         authoring: %Schema{
@@ -40,6 +44,30 @@ defmodule OliWeb.Api.ActivityController do
         "title" => "Adaptive Activity Ensemble C",
         "objectives" => %{},
         "content" => %{"items" => ["1", "2"]}
+      }
+    })
+  end
+
+  defmodule BulkDocuments do
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "Bulk document attributes",
+      description: "The structure of the body of a request for bulk update",
+      type: :object,
+      properties: %{
+        updates: %Schema{type: :list, description: "An array of DocumentAttribute instances"}
+      },
+      required: [],
+      example: %{
+        "updates" => [
+          %{
+            "title" => "Adaptive Activity Ensemble C",
+            "resource_id" => 43223,
+            "objectives" => %{},
+            "content" => %{"items" => ["1", "2"]}
+          }
+        ]
       }
     })
   end
@@ -412,6 +440,53 @@ defmodule OliWeb.Api.ActivityController do
     update = conn.body_params
 
     case ActivityEditor.edit(project_slug, lock_id, activity_id, author.email, update) do
+      {:ok, _} -> json(conn, %{"result" => "success"})
+      {:error, {:invalid_update_field}} -> error(conn, 400, "invalid update field")
+      {:error, {:not_found}} -> error(conn, 404, "not found")
+      {:error, {:not_authorized}} -> error(conn, 403, "unauthorized")
+      {:error, {:lock_not_acquired}} -> error(conn, 400, "lock not acquired")
+      _ -> error(conn, 500, "server error")
+    end
+  end
+
+  @doc """
+  Bulk activity edit endpoint.
+
+  This operation will update one or more of the top-level document attributes (`title`, `objectives`, `content`, `authoring`) for
+  a collection of activity documents.
+
+  This operation must be performed in the context of an exclusive write lock to avoid concurrent updates. The identifier of the
+  lock must be specificed via the `lock` query parameter.
+  """
+  @doc parameters: [
+         project: [
+           in: :url,
+           schema: %OpenApiSpex.Schema{type: :string},
+           required: true,
+           description: "The project identifier"
+         ],
+         lock: [
+           in: :query,
+           schema: %OpenApiSpex.Schema{type: :string},
+           required: true,
+           description: "The lock identifier that this operation will be performed within"
+         ]
+       ],
+       request_body:
+         {"Attributes for the document", "application/json",
+          OliWeb.Api.ActivityController.BulkDocuments, required: true},
+       responses: %{
+         200 => {"Update Response", "application/json", ApiSchemas.UpdateResponse}
+       }
+  def bulk_update(conn, %{
+        "project" => project_slug,
+        "lock" => lock_id
+      }) do
+    author = conn.assigns[:current_author]
+
+    updates = conn.body_params["updates"]
+
+    case ActivityEditor.bulk_edit(project_slug, lock_id, author.email, updates) do
       {:ok, _} -> json(conn, %{"result" => "success"})
       {:error, {:invalid_update_field}} -> error(conn, 400, "invalid update field")
       {:error, {:not_found}} -> error(conn, 404, "not found")

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -352,6 +352,7 @@ defmodule OliWeb.Router do
 
     get("/:resource", Api.ActivityController, :retrieve)
     post("/", Api.ActivityController, :bulk_retrieve)
+    put("/", Api.ActivityController, :bulk_update)
     delete("/:resource", Api.ActivityController, :delete)
     put("/:resource", Api.ActivityController, :update)
     post("/:resource", Api.ActivityController, :create_secondary)

--- a/test/oli_web/controllers/activity_controller_test.exs
+++ b/test/oli_web/controllers/activity_controller_test.exs
@@ -221,6 +221,50 @@ defmodule OliWeb.ActivityControllerTest do
       assert length(r.content["authoring"]["parts"]) == 1
     end
 
+    test "bulk update", %{
+      conn: conn,
+      project: project,
+      activity_id: activity_id,
+      activity_id2: activity_id2,
+      revision1: revision
+    } do
+      updates = %{
+        "updates" => [
+          %{
+            "resource_id" => activity_id,
+            "title" => "updated title1",
+            "content" => %{"1" => "2"}
+          },
+          %{
+            "resource_id" => activity_id2,
+            "title" => "updated title2",
+            "content" => %{"1" => "2"}
+          }
+        ]
+      }
+
+      conn =
+        put(
+          conn,
+          Routes.activity_path(conn, :bulk_update, project.slug, %{
+            "lock" => revision.resource_id
+          }),
+          updates
+        )
+
+      assert %{"result" => "success"} = json_response(conn, 200)
+
+      r = AuthoringResolver.from_resource_id(project.slug, activity_id)
+      assert r.title == "updated title1"
+      assert r.content["1"] == "2"
+      assert length(r.content["authoring"]["parts"]) == 1
+
+      r = AuthoringResolver.from_resource_id(project.slug, activity_id2)
+      assert r.title == "updated title2"
+      assert r.content["1"] == "2"
+      assert length(r.content["authoring"]["parts"]) == 1
+    end
+
     test "updates authoring, but not content", %{
       conn: conn,
       project: project,
@@ -337,7 +381,10 @@ defmodule OliWeb.ActivityControllerTest do
     {:ok, {%{slug: slug, resource_id: activity_id}, _}} =
       ActivityEditor.create(project.slug, "oli_multiple_choice", author, content, [])
 
-    seeds = Map.put(seeds, :activity_id, activity_id)
+    {:ok, {%{slug: slug2, resource_id: activity_id2}, _}} =
+      ActivityEditor.create(project.slug, "oli_multiple_choice", author, content, [])
+
+    seeds = Map.put(seeds, :activity_id, activity_id) |> Map.put(:activity_id2, activity_id2)
 
     update = %{
       "content" => %{
@@ -346,6 +393,12 @@ defmodule OliWeb.ActivityControllerTest do
             "type" => "activity-reference",
             "id" => 1,
             "activitySlug" => slug,
+            "purpose" => "none"
+          },
+          %{
+            "type" => "activity-reference",
+            "id" => 2,
+            "activitySlug" => slug2,
             "purpose" => "none"
           }
         ]


### PR DESCRIPTION
Closes #1424 

This PR adds an endpoint to allow a client to pass many activity documents to be edited at once. The body of the PUT operation must contain a top-level `"updates"` key whose value is an array of document attribute objects representing the change to make. Each of these objects must contain a `"resource_id"` key to allow the server to know which activity, by resource id, is to be edited. 