### PR TITLE
[FEATURE] Allow for finalization without answering all questions or parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,15 @@
 ## Unreleased
 
 ### Bug Fixes
+
 ### Enhancements
+
+- Allow for submission of graded pages without answering all questions
 
 ## 0.12.8 (2021-08-11)
 
 ### Bug Fixes
+
 - Fix iframe rendering when elements contain captions (webpage, youtube)
 - Fix iframe rendering in activities
 - Fix an issue where mod key changes current selection

--- a/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
@@ -81,7 +81,9 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
         Logger.debug("EV: #{Jason.encode!(client_evaluations)}")
 
         case apply_client_evaluation(section_slug, activity_attempt_guid, client_evaluations) do
-          {:ok, _} -> {:ok, decodedResults}
+          {:ok, _} ->
+            {:ok, decodedResults}
+
           {:error, err} ->
             Logger.debug("Error in apply client results! #{err}")
             {:error, err}
@@ -172,11 +174,14 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
                       # might look like this "q:1465253111364:752|stage.dragdrop.Drag and Drop.Body Fossil | Direct Evidence.Count"
                       path_parts = String.split(path, "|stage")
                       path_interested = List.last(path_parts)
-                      local_path = if String.starts_with?(path_interested, ".") do
-                        "stage" <> path_interested
-                      else
-                        path_interested
-                      end
+
+                      local_path =
+                        if String.starts_with?(path_interested, ".") do
+                          "stage" <> path_interested
+                        else
+                          path_interested
+                        end
+
                       value = Map.get(input, "value")
                       Map.put(acc1, local_path, value)
                     end
@@ -285,29 +290,31 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
   def evaluate_from_stored_input(activity_attempt_guid) do
     part_attempts = get_latest_part_attempts(activity_attempt_guid)
 
-    if Enum.all?(part_attempts, fn pa -> pa.response != nil end) do
-      roll_up_fn = fn result ->
-        rollup_part_attempt_evaluations(activity_attempt_guid)
-        result
-      end
+    roll_up_fn = fn result ->
+      rollup_part_attempt_evaluations(activity_attempt_guid)
+      result
+    end
 
-      # derive the part_attempts from the currently saved state that we expect
-      # to find in the part_attempts
-      part_inputs =
-        Enum.map(part_attempts, fn p ->
-          %{
-            attempt_guid: p.attempt_guid,
-            input: %StudentInput{input: Map.get(p.response, "input")}
-          }
-        end)
+    # derive the part_attempts from the currently saved state that we expect
+    # to find in the part_attempts
+    part_inputs =
+      Enum.map(part_attempts, fn p ->
+        input =
+          case p.response do
+            nil -> nil
+            map -> Map.get(map, "input")
+          end
 
-      case evaluate_submissions(activity_attempt_guid, part_inputs, part_attempts)
-           |> persist_evaluations(part_inputs, roll_up_fn) do
-        {:ok, _} -> part_attempts
-        {:error, error} -> Repo.rollback(error)
-      end
-    else
-      Repo.rollback({:not_all_answered})
+        %{
+          attempt_guid: p.attempt_guid,
+          input: %StudentInput{input: input}
+        }
+      end)
+
+    case evaluate_submissions(activity_attempt_guid, part_inputs, part_attempts)
+         |> persist_evaluations(part_inputs, roll_up_fn) do
+      {:ok, _} -> part_attempts
+      {:error, error} -> Repo.rollback(error)
     end
   end
 

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -114,9 +114,7 @@ defmodule OliWeb.PageDeliveryController do
       if page.max_attempts == 0 do
         "You can take this assessment an unlimited number of times"
       else
-        "You have #{attempts_remaining} attempt#{plural(attempts_remaining)} remaining out of #{
-          page.max_attempts
-        } total attempt#{plural(page.max_attempts)}."
+        "You have #{attempts_remaining} attempt#{plural(attempts_remaining)} remaining out of #{page.max_attempts} total attempt#{plural(page.max_attempts)}."
       end
 
     conn = put_root_layout(conn, {OliWeb.LayoutView, "page.html"})
@@ -267,10 +265,6 @@ defmodule OliWeb.PageDeliveryController do
         grade_sync_result = send_one_grade(section, user, resource_access)
         after_finalized(conn, section_slug, revision_slug, attempt_guid, user, grade_sync_result)
 
-      {:error, {:not_all_answered}} ->
-        put_flash(conn, :error, "You have not answered all questions")
-        |> redirect(to: Routes.page_delivery_path(conn, :page, section_slug, revision_slug))
-
       {:error, {:already_submitted}} ->
         redirect(conn, to: Routes.page_delivery_path(conn, :page, section_slug, revision_slug))
 
@@ -295,9 +289,7 @@ defmodule OliWeb.PageDeliveryController do
         taken = length(context.resource_attempts)
         remaining = max(context.page.max_attempts - taken, 0)
 
-        "You have taken #{taken} attempt#{plural(taken)} and have #{remaining} more attempt#{
-          plural(remaining)
-        } remaining"
+        "You have taken #{taken} attempt#{plural(taken)} and have #{remaining} more attempt#{plural(remaining)} remaining"
       end
 
     grade_message =


### PR DESCRIPTION
Closes #1425 

This PR allows graded pages to be submitted without the student having answered all questions.   

The change to allow this was fairly straightforward: There was an explicit check in the activity lifecycle evaluation logic that would fail submission if a single part of any activity had no state available (aka, was `nil`).  I removed this and made the eval's handling of `nil` states robust.  