### PR TITLE
Ordering submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bug Fixes
 
+- Properly handle ordering activity submission when no student interaction has taken place
+
 ### Enhancements
 
 - Enable banked activity creation and editing

--- a/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyDelivery.tsx
+++ b/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyDelivery.tsx
@@ -39,6 +39,17 @@ export const CheckAllThatApplyComponent: React.FC = () => {
 
   useEffect(() => {
     dispatch(initializeState(activityState, initialSelection(activityState)));
+
+    setTimeout(() => {
+      if (activityState.parts[0].response === null) {
+        onSaveActivity(activityState.attemptGuid, [
+          {
+            attemptGuid: activityState.parts[0].attemptGuid,
+            response: { input: '' },
+          },
+        ]);
+      }
+    }, 0);
   }, []);
 
   // First render initializes state

--- a/assets/src/components/activities/ordering/OrderingDelivery.tsx
+++ b/assets/src/components/activities/ordering/OrderingDelivery.tsx
@@ -57,6 +57,18 @@ export const OrderingComponent: React.FC = () => {
         ),
       ),
     );
+    setTimeout(() => {
+      if (activityState.parts[0].response === null) {
+        const selection = model.choices.map((choice) => choice.id);
+        const input = selectionToInput(selection);
+        onSaveActivity(activityState.attemptGuid, [
+          {
+            attemptGuid: activityState.parts[0].attemptGuid,
+            response: { input },
+          },
+        ]);
+      }
+    }, 0);
   }, []);
 
   // First render initializes state


### PR DESCRIPTION
Closes #1327 

This PR allows Ordering activities that have not had any student interaction to be evaluated correctly. It does so by initiating a state save when the state is null.  The state saved is the current choice ordering - so if the student submits without interacting at all the server will indeed evaluate it correctly. 

Tested in both graded and ungraded contexts (and in the latter with a "resetting" of attempts)