### PR TITLE
[BUG FIX] remove incorrect gradebook link from manage grades page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fix an issue where changing the title of a page made the current slug invalid
 - Properly handle ordering activity submission when no student interaction has taken place
+- Fix an issue where the manage grades page displayed an incorrect grade book link
 
 ### Enhancements
 

--- a/lib/oli_web/live/grades/grades.ex
+++ b/lib/oli_web/live/grades/grades.ex
@@ -47,7 +47,6 @@ defmodule OliWeb.Grades.GradesLive do
   end
 
   def render(assigns) do
-    iss = assigns.registration.issuer
     has_tasks? = length(assigns.task_queue) > 0
 
     progress_visible =
@@ -73,7 +72,7 @@ defmodule OliWeb.Grades.GradesLive do
     <h2><%= dgettext("grades", "Manage Grades") %></h2>
 
     <p>
-      <%= dgettext("grades", "Grades for OLI graded pages for this course are accessed by students and instructors from the LMS gradebook at") %> <a href="<%= iss %>"><%= iss %></a>.
+      <%= dgettext("grades", "Grades for this section can be viewed by students and instructors using the LMS gradebook.") %>
     </p>
 
     <div class="card-group">


### PR DESCRIPTION
This PR fixes a confusing link to the LMS gradebook inferred by the registration iss, which in practice is usually a generic url to canvas.instructure.com. Given the information from the registration, it is difficult to actually determine what this link URL should be without explicitly asking for it upon registration. Therefore, the easiest fix here is to simply remove it since it wasnt providing any real value and it was confusing some instructors.

Closes #1414