### PR TITLE
[BUG FIX] Provide specific impl to realize activities from adaptive page content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Properly handle ordering activity submission when no student interaction has taken place
 - Fix various UI issues such as showing outline in LMS iframe, email templates and dark mode feedback
 - Fix an issue where the manage grades page displayed an incorrect grade book link
+- Restore ability to realize deeply nested activity references within adaptive page content
 
 ### Enhancements
 


### PR DESCRIPTION
This PR fixes an issue introduced by the new `ActivityProvider` implementation, namely that deeply nested activity references within adaptive page content were no longer being realized. The core issue was that the new impl only looks at the top-level `model` list.  A singular implementation was going to be fairly complex (due to content transformation requirements from bank selections), so instead I pattern matched and just do a `flat_filter` to find all activity references in the adaptive page case. 

