### PR TITLE
[BUG FIX] fix the resolution of deleted activities

### DIFF
--- a/lib/oli/publishing.ex
+++ b/lib/oli/publishing.ex
@@ -662,7 +662,6 @@ defmodule Oli.Publishing do
     get_published_resources_by_publication(publication.id)
     |> Enum.map(&Repo.preload(&1, :revision))
     |> Enum.map(&Map.get(&1, :revision))
-    |> Enum.filter(&(!&1.deleted))
   end
 
   @doc """

--- a/priv/repo/migrations/20210823212647_advanced_section_creation.exs
+++ b/priv/repo/migrations/20210823212647_advanced_section_creation.exs
@@ -236,7 +236,7 @@ defmodule Oli.Repo.Migrations.AdvancedSection do
     from(p in "published_resources",
       join: r in "revisions",
       on: r.id == p.revision_id,
-      where: p.publication_id == ^publication_id and r.deleted == false,
+      where: p.publication_id == ^publication_id,
       select: %{
         resource_id: r.resource_id,
         resource_type_id: r.resource_type_id,


### PR DESCRIPTION
This PR fixes the issue of deleted activity resolution in the event that a deleted activity needs to be resolved in delivery by creating the section resource record for deleted records as well.

There are two places that need to be changed. First is the function used by the section creation logic `get_published_resources_by_publication`. This function is only used by section creation logic so this change shouldn't affect other functions. Second is the migration logic that transforms all existing sections into a collection of section resources.