### PR TITLE
[BUG] PMP-1741 | JAN-563

### DIFF
--- a/assets/src/utils/common.ts
+++ b/assets/src/utils/common.ts
@@ -142,5 +142,5 @@ export const parseBool = (val: any) => {
 export const parseNumString = (item: string): string | number => {
   if (!item?.length) return item;
   // check if items are strings or numbers and converts if number
-  return Number.isNaN(Number(item)) === true ? item : parseFloat(item);
+  return !Number.isNaN(Number(item)) ? parseFloat(item) : item;
 };

--- a/assets/src/utils/common.ts
+++ b/assets/src/utils/common.ts
@@ -140,6 +140,7 @@ export const parseBool = (val: any) => {
 };
 
 export const parseNumString = (item: string): string | number => {
+  if (!item?.length) return item;
   // check if items are strings or numbers and converts if number
-  return !Number.isNaN(parseFloat(item)) ? parseFloat(item) : item;
+  return Number.isNaN(Number(item)) === true ? item : parseFloat(item);
 };

--- a/assets/test/utils/common_test.ts
+++ b/assets/test/utils/common_test.ts
@@ -98,8 +98,8 @@ describe('common parseArray', () => {
   });
 
   it('should parse an array-like string into a valid array', () => {
-    const str = '["some", "thing", "silly"]';
-    const expected = ['some', 'thing', 'silly'];
+    const str = '["some", "thing", "silly","-56.5/-13/70"]';
+    const expected = ['some', 'thing', 'silly', '-56.5/-13/70'];
     expect(parseArray(str)).toEqual(expected);
   });
 


### PR DESCRIPTION
-- Number.isNaN(parseFloat(item)) was causing trouble in parsing '56.5/-13/7'. It was returning '-56.5' instead 'NaN'.