### PR TITLE
expose graded flag so that authoring and delivery can use when necessary

### DIFF
--- a/assets/src/apps/app.tsx
+++ b/assets/src/apps/app.tsx
@@ -38,7 +38,7 @@ export function defineApplication<T extends State>(Component: React.FunctionComp
       partComponentTypes: parsedPartComponentTypes,
     };
 
-    console.log('MOUNT UP', { props, params, mountPoint });
+    // console.log('MOUNT UP', { props, params, mountPoint });
 
     ReactDOM.render(
       <Provider store={store}>

--- a/assets/src/apps/app.tsx
+++ b/assets/src/apps/app.tsx
@@ -38,6 +38,8 @@ export function defineApplication<T extends State>(Component: React.FunctionComp
       partComponentTypes: parsedPartComponentTypes,
     };
 
+    console.log('MOUNT UP', { props, params, mountPoint });
+
     ReactDOM.render(
       <Provider store={store}>
         <Component {...props} />

--- a/assets/src/apps/delivery/Delivery.tsx
+++ b/assets/src/apps/delivery/Delivery.tsx
@@ -26,6 +26,7 @@ export interface DeliveryProps {
   previewMode?: boolean;
   enableHistory?: boolean;
   activityTypes?: any[];
+  graded: boolean;
 }
 
 const Delivery: React.FC<DeliveryProps> = ({
@@ -42,6 +43,7 @@ const Delivery: React.FC<DeliveryProps> = ({
   activityTypes = [],
   previewMode = false,
   enableHistory = false,
+  graded = false,
 }) => {
   const dispatch = useDispatch();
   const currentGroup = useSelector(selectCurrentGroup);
@@ -72,6 +74,7 @@ const Delivery: React.FC<DeliveryProps> = ({
         activityTypes,
         enableHistory,
         score: 0,
+        graded,
       }),
     );
   };

--- a/assets/src/apps/delivery/store/features/page/slice.ts
+++ b/assets/src/apps/delivery/store/features/page/slice.ts
@@ -17,6 +17,7 @@ export interface PageState {
   enableHistory: boolean;
   activityTypes: any[];
   score: number;
+  graded: boolean;
 }
 
 const initialState: PageState = {
@@ -34,6 +35,7 @@ const initialState: PageState = {
   enableHistory: false,
   activityTypes: [],
   score: 0,
+  graded: false,
 };
 
 const pageSlice = createSlice({
@@ -57,6 +59,7 @@ const pageSlice = createSlice({
       state.activityGuidMapping = action.payload.activityGuidMapping;
       state.previewMode = !!action.payload.previewMode;
       state.activityTypes = action.payload.activityTypes;
+      state.graded = !!action.payload.graded;
 
       if (state.previewMode && !state.resourceAttemptGuid) {
         state.resourceAttemptGuid = `preview_${guid()}`;
@@ -96,5 +99,7 @@ export const selectActivityGuidMapping = createSelector(
 export const selectUserName = createSelector(selectState, (state) => state.userName);
 
 export const selectScore = createSelector(selectState, (state) => state.score);
+
+export const selectIsGraded = createSelector(selectState, (state) => state.graded);
 
 export default pageSlice.reducer;

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -141,6 +141,7 @@ defmodule OliWeb.PageDeliveryController do
 
     render(conn, "advanced_delivery.html", %{
       review_mode: context.review_mode,
+      graded: context.page.graded,
       additional_stylesheets: Map.get(context.page.content, "additionalStylesheets", []),
       resource_attempt_guid: resource_attempt.attempt_guid,
       resource_attempt_state: resource_attempt_state,

--- a/lib/oli_web/controllers/resource_controller.ex
+++ b/lib/oli_web/controllers/resource_controller.ex
@@ -33,7 +33,8 @@ defmodule OliWeb.ResourceController do
           project_slug: project_slug,
           revision_slug: revision_slug,
           activity_types: Activities.activities_for_project(project),
-          part_component_types: PartComponents.part_components_for_project(project)
+          part_component_types: PartComponents.part_components_for_project(project),
+          graded: context.graded,
         )
 
       {:error, :not_found} ->

--- a/lib/oli_web/templates/page_delivery/advanced_delivery.html.eex
+++ b/lib/oli_web/templates/page_delivery/advanced_delivery.html.eex
@@ -34,6 +34,7 @@
     userName: "<%= @current_user.name %>",
     pageTitle: "<%= @title %>",
     pageSlug: "<%= @slug %>",
+    graded: <%= @graded %>,
     content: "<%= Base.encode64(@content) %>",
     resourceAttemptState: <%= raw(@resource_attempt_state) %>,
     resourceAttemptGuid: "<%= @resource_attempt_guid %>",

--- a/lib/oli_web/templates/resource/advanced.html.eex
+++ b/lib/oli_web/templates/resource/advanced.html.eex
@@ -15,6 +15,7 @@
     isAdmin: <%= @is_admin? %>,
     revisionSlug: "<%= @revision_slug %>",
     projectSlug: "<%= @project_slug %>",
+    graded: <%= @graded %>,
     content: "<%= Base.encode64(@context) %>",
     paths: {
       images: "<%= Routes.static_path(@conn, "/images") %>"

--- a/lib/oli_web/templates/resource/advanced_page_preview.html.eex
+++ b/lib/oli_web/templates/resource/advanced_page_preview.html.eex
@@ -21,6 +21,7 @@
     pageSlug: "<%= @revision.slug %>",
     pageTitle: "<%= @title %>",
     content: "<%= Jason.encode!(@revision.content) |> Base.encode64() %>",
+    graded: <%= @revision.graded %>,
     resourceAttemptState: null,
     resourceAttemptGuid: null,
     activityGuidMapping: null,


### PR DESCRIPTION
this is mostly needed so that delivery can tell whether to send to the finalization page or overview page at the end of the lesson