### PR TITLE
[BUG FIX] Allow use of image coding in graded pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Restore ability to realize deeply nested activity references within adaptive page content
 - Fix an issue in admin accounts interface where manage options sometimes appear twice
 - Allow graded adaptive pages to render the prologue page
+- Allow Image Coding activity to work properly within graded pages
 
 ### Enhancements
 

--- a/assets/src/components/activities/image_coding/ImageCodingDelivery.tsx
+++ b/assets/src/components/activities/image_coding/ImageCodingDelivery.tsx
@@ -283,16 +283,15 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
     return solution ? solnRef.current : resultRef.current;
   };
 
-  const maybeSubmitButton =
-    model.isExample || props.graded ? null : (
-      <button
-        className="btn btn-primary mt-2 float-right"
-        disabled={isEvaluated || !ranCode}
-        onClick={onSubmit}
-      >
-        Submit
-      </button>
-    );
+  const maybeSubmitButton = model.isExample ? null : (
+    <button
+      className="btn btn-primary mt-2 float-right"
+      disabled={isEvaluated || !ranCode}
+      onClick={onSubmit}
+    >
+      Submit
+    </button>
+  );
 
   const runButton = (
     <button className="btn btn-primary mt-2 float-left" disabled={isEvaluated} onClick={onRun}>

--- a/lib/oli/delivery/attempts/page_lifecycle/graded.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/graded.ex
@@ -161,8 +161,13 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Graded do
       # future we do allow this to be configured
       {score, out_of} =
         Enum.reduce(resource_attempt.activity_attempts, {0, 0}, fn p, {score, out_of} ->
+          IO.inspect("act attempt")
+          IO.inspect(p.out_of)
           {score + p.score, out_of + p.out_of}
         end)
+
+      IO.inspect("rolled up")
+      IO.inspect(out_of)
 
       update_resource_attempt(resource_attempt, %{
         score: score,

--- a/lib/oli/delivery/attempts/page_lifecycle/graded.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/graded.ex
@@ -161,13 +161,8 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Graded do
       # future we do allow this to be configured
       {score, out_of} =
         Enum.reduce(resource_attempt.activity_attempts, {0, 0}, fn p, {score, out_of} ->
-          IO.inspect("act attempt")
-          IO.inspect(p.out_of)
           {score + p.score, out_of + p.out_of}
         end)
-
-      IO.inspect("rolled up")
-      IO.inspect(out_of)
 
       update_resource_attempt(resource_attempt, %{
         score: score,

--- a/lib/oli/delivery/evaluation/evaluator.ex
+++ b/lib/oli/delivery/evaluation/evaluator.ex
@@ -15,7 +15,19 @@ defmodule Oli.Delivery.Evaluation.Evaluator do
 
       # No matching response found - mark incorrect
       {_, nil, _, out_of} ->
-        {:ok, {ParseUtils.default_content_item("Incorrect"), %Result{score: 0, out_of: out_of}}}
+        # this guarantees that all activities, even unanswered client-side
+        # evaluated ones, that have no matching responses get 0 out of
+        # a non-zero maximum value
+        adjusted_out_of =
+          if out_of == 0 do
+            1
+          else
+            out_of
+          end
+
+        {:ok,
+         {ParseUtils.default_content_item("Incorrect"),
+          %Result{score: 0, out_of: adjusted_out_of}}}
 
       _ ->
         {:error, "Error in evaluation"}

--- a/lib/oli/delivery/evaluation/evaluator.ex
+++ b/lib/oli/delivery/evaluation/evaluator.ex
@@ -9,7 +9,7 @@ defmodule Oli.Delivery.Evaluation.Evaluator do
   evaluation, returns the feedback and a scoring result.
   """
   def evaluate(%Part{} = part, %EvaluationContext{} = context) do
-    case Enum.reduce(part.responses, {context, nil, -1, -1}, &consider_response/2) do
+    case Enum.reduce(part.responses, {context, nil, 0, 0}, &consider_response/2) do
       {_, %Response{feedback: feedback, score: score}, _, out_of} ->
         {:ok, {feedback, %Result{score: score, out_of: out_of}}}
 

--- a/lib/oli_web/templates/page_delivery/page.html.eex
+++ b/lib/oli_web/templates/page_delivery/page.html.eex
@@ -21,8 +21,7 @@ window.userToken = "<%= assigns[:user_token] %>";
  </div>
  <div class="row">
   <div class="col-sm-3">Score:</div>
-  <div><%=  (@resource_attempt.score / @resource_attempt.out_of) * 100 |> round
-            |> Integer.to_string  %>%</div>
+  <div><%= show_score(@resource_attempt.score, @resource_attempt.out_of) %>%</div>
  </div>
  <div class="row">
   <div class="col-sm-3">Points:</div>

--- a/lib/oli_web/templates/page_delivery/prologue.html.eex
+++ b/lib/oli_web/templates/page_delivery/prologue.html.eex
@@ -27,8 +27,7 @@
     </div>
     <div class="row">
       <div class="col-sm-3">Score:</div>
-      <div><%=  (resource_attempt.score / resource_attempt.out_of) * 100 |> round
-            |> Integer.to_string  %>%</div>
+      <div><%= show_score(resource_attempt.score, resource_attempt.out_of) %>%</div>
     </div>
     <div class="row">
       <div class="col-sm-3">Points:</div>

--- a/lib/oli_web/views/page_delivery_view.ex
+++ b/lib/oli_web/views/page_delivery_view.ex
@@ -6,6 +6,18 @@ defmodule OliWeb.PageDeliveryView do
   alias Oli.Resources.Numbering
   alias Oli.Publishing.HierarchyNode
 
+  def show_score(score, out_of) do
+    case out_of do
+      0.0 ->
+        "0"
+
+      _ ->
+        (score / out_of * 100)
+        |> round
+        |> Integer.to_string()
+    end
+  end
+
   def is_instructor?(conn, section_slug) do
     user = conn.assigns.current_user
     ContextRoles.has_role?(user, section_slug, ContextRoles.get_role(:context_instructor))

--- a/lib/oli_web/views/page_delivery_view.ex
+++ b/lib/oli_web/views/page_delivery_view.ex
@@ -7,11 +7,11 @@ defmodule OliWeb.PageDeliveryView do
   alias Oli.Publishing.HierarchyNode
 
   def show_score(score, out_of) do
-    case out_of do
-      0.0 ->
+    cond do
+      out_of <= 0.0 ->
         "0"
 
-      _ ->
+      true ->
         (score / out_of * 100)
         |> round
         |> Integer.to_string()


### PR DESCRIPTION
This PR fixes a couple of problems around use of Image Coding in graded contexts. 

1. It enables the "Submit" button for the activity even when graded.  This is the only way that a student can actually answer the question, given that it is a client-side evaluated activity. 
2. The PR adjusts evaluation logic to ensure that even unanswered questions will be counted as "0 out of 1" in evaluation and subsequent roll-up.  
3. It makes some page rendering logic robust against any existing or future cases where invalid values exist as the "out of" for a resource attempt, specifically any value less than or equal to 0
