### PR TITLE
[BUG FIX] Fix update platform roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bug Fixes
 
+- Fix an issue where platform roles were failing to update on LTI launch
+
 ### Enhancements
 
 ## 0.13.0 (2021-09-07)

--- a/lib/oli/accounts.ex
+++ b/lib/oli/accounts.ex
@@ -42,6 +42,8 @@ defmodule Oli.Accounts do
   """
   def get_user!(id), do: Repo.get!(User, id)
 
+  def get_user!(id, preload: preloads), do: Repo.get!(User, id) |> Repo.preload(preloads)
+
   @doc """
   Gets a single user by query parameter
   ## Examples
@@ -112,16 +114,6 @@ defmodule Oli.Accounts do
   end
 
   @doc """
-  Returns an `%Ecto.Changeset{}` for tracking user changes.
-  ## Examples
-      iex> change_user(user)
-      %Ecto.Changeset{source: %User{}}
-  """
-  def change_user(%User{} = user, attrs \\ %{}) do
-    User.changeset(user, attrs)
-  end
-
-  @doc """
   Returns user details if a record matches sub, or creates and returns a new user
 
   ## Examples
@@ -154,7 +146,7 @@ defmodule Oli.Accounts do
 
     user
     |> Repo.preload([:platform_roles])
-    |> User.changeset()
+    |> User.noauth_changeset()
     |> Ecto.Changeset.put_assoc(:platform_roles, roles)
     |> Repo.update()
   end

--- a/lib/oli_web/live/delivery/manage_section.ex
+++ b/lib/oli_web/live/delivery/manage_section.ex
@@ -22,7 +22,7 @@ defmodule OliWeb.Delivery.ManageSection do
     current_user = Accounts.get_user!(current_user_id) |> Repo.preload([:platform_roles, :author])
 
     # only permit instructor level access
-    if is_admin?(%{assigns: %{current_author: current_user}}) or
+    if is_admin?(%{assigns: %{current_author: current_user.author}}) or
          ContextRoles.has_role?(
            current_user,
            section.slug,


### PR DESCRIPTION
This PR fixes an issue where a user's platform role were failing to update on LTI launch