### PR TITLE
[ENHANCEMENT] Add multi input model validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Enhancements
 
 - Add multi input activity
+- Add multi input model validation
 
 ## 0.13.2 (2021-09-17)
 

--- a/assets/src/apps/bank/ActivityBank.tsx
+++ b/assets/src/apps/bank/ActivityBank.tsx
@@ -1,38 +1,42 @@
-import React from 'react';
-import { connect } from 'react-redux';
-import { State, Dispatch } from 'state';
+import { modalActions } from 'actions/modal';
+import { ActivityUndoables, ActivityUndoAction } from 'apps/page-editor/types';
+import { MultiInputSchema } from 'components/activities/multi_input/schema';
+import { guaranteeMultiInputValidity } from 'components/activities/multi_input/utils';
+import { ActivityModelSchema, Undoable as ActivityUndoable } from 'components/activities/types';
+import {
+  EditorUpdate as ActivityEditorUpdate,
+  InlineActivityEditor,
+} from 'components/activity/InlineActivityEditor';
+import { PersistenceStatus } from 'components/content/PersistenceStatus';
+import { Banner } from 'components/messages/Banner';
+import ModalSelection from 'components/modal/ModalSelection';
+import { UndoToasts } from 'components/resource/undo/UndoToasts';
+import { ActivityEditContext } from 'data/content/activity';
+import * as BankTypes from 'data/content/bank';
+import { ActivityEditorMap, EditorDesc } from 'data/content/editors';
+import { Objective } from 'data/content/objective';
+import { ActivityMap } from 'data/content/resource';
+import { Tag } from 'data/content/tags';
+import { createMessage, Message, Severity } from 'data/messages/messages';
+import * as ActivityPersistence from 'data/persistence/activity';
+import * as BankPersistence from 'data/persistence/bank';
+import { DeferredPersistenceStrategy } from 'data/persistence/DeferredPersistenceStrategy';
+import * as Lock from 'data/persistence/lock';
+import { PersistenceStrategy } from 'data/persistence/PersistenceStrategy';
 import { ProjectSlug } from 'data/types';
 import * as Immutable from 'immutable';
-import { EditorUpdate as ActivityEditorUpdate } from 'components/activity/InlineActivityEditor';
-import { PersistenceStrategy } from 'data/persistence/PersistenceStrategy';
-import { DeferredPersistenceStrategy } from 'data/persistence/DeferredPersistenceStrategy';
-import { InlineActivityEditor } from 'components/activity/InlineActivityEditor';
-import { ActivityMap } from 'data/content/resource';
-import { Objective } from 'data/content/objective';
-import { ActivityEditorMap, EditorDesc } from 'data/content/editors';
-import { PersistenceStatus } from 'components/content/PersistenceStatus';
-import * as ActivityPersistence from 'data/persistence/activity';
-import { Message, Severity, createMessage } from 'data/messages/messages';
-import { Banner } from 'components/messages/Banner';
-import { ActivityEditContext } from 'data/content/activity';
-import { Undoable as ActivityUndoable } from 'components/activities/types';
-import * as BankTypes from 'data/content/bank';
-import * as BankPersistence from 'data/persistence/bank';
+import React from 'react';
+import { connect } from 'react-redux';
+import { Dispatch, State } from 'state';
 import { loadPreferences } from 'state/preferences';
-import guid from 'utils/guid';
-import { ActivityUndoables, ActivityUndoAction } from 'apps/page-editor/types';
-import { UndoToasts } from 'components/resource/undo/UndoToasts';
-import { CreateActivity } from './CreateActivity';
 import { Maybe } from 'tsmonad';
-import { EditingLock } from './EditingLock';
-import { Paging } from './Paging';
-import * as Lock from 'data/persistence/lock';
-import { LogicFilter } from './LogicFilter';
-import { DeleteActivity } from './DeleteActivity';
-import { Tag } from 'data/content/tags';
-import { modalActions } from 'actions/modal';
-import ModalSelection from 'components/modal/ModalSelection';
+import guid from 'utils/guid';
 import { Operations } from 'utils/pathOperations';
+import { CreateActivity } from './CreateActivity';
+import { DeleteActivity } from './DeleteActivity';
+import { EditingLock } from './EditingLock';
+import { LogicFilter } from './LogicFilter';
+import { Paging } from './Paging';
 
 const PAGE_SIZE = 5;
 
@@ -268,11 +272,15 @@ export class ActivityBank extends React.Component<ActivityBankProps, ActivityBan
   }
 
   onActivityEdit(key: string, update: ActivityEditorUpdate): void {
+    const model = this.adjustActivityForConstraints(
+      this.state.activityContexts.get(key)?.typeSlug,
+      update.content,
+    );
     const withModel = {
-      title: update.title !== undefined ? update.title : undefined,
-      model: update.content !== undefined ? update.content : undefined,
-      objectives: update.objectives !== undefined ? update.objectives : undefined,
-      tags: update.tags !== undefined ? update.tags : undefined,
+      model: update.content,
+      title: update.title,
+      objectives: update.objectives,
+      tags: update.tags,
     };
 
     // apply the edit
@@ -286,12 +294,22 @@ export class ActivityBank extends React.Component<ActivityBankProps, ActivityBan
           this.props.projectSlug,
           merged.activityId,
           merged.activityId,
-          update as any,
+          { ...update, content: model },
           releaseLock,
         );
 
       this.persistence.lift((p) => p.save(saveFn));
     });
+  }
+
+  adjustActivityForConstraints(
+    activityType: string | undefined,
+    model: ActivityModelSchema,
+  ): ActivityModelSchema {
+    if (activityType === 'oli_multi_input') {
+      return guaranteeMultiInputValidity(model as MultiInputSchema);
+    }
+    return model;
   }
 
   onPostUndoable(key: string, undoable: ActivityUndoable) {

--- a/assets/src/components/activities/common/utils.tsx
+++ b/assets/src/components/activities/common/utils.tsx
@@ -1,5 +1,5 @@
-import { makeTransformation, Transform, Transformation } from '../types';
 import React from 'react';
+import { makeTransformation, Transform, Transformation } from '../types';
 
 // Activities with one part have a hard-coded ID. This makes some lookup logic simpler.
 export const DEFAULT_PART_ID = '1';
@@ -58,4 +58,8 @@ export function remove<T>(item: T, list: T[]) {
 
 export function setDifference<T>(subtractedFrom: T[], toSubtract: T[]) {
   return subtractedFrom.filter((x) => !toSubtract.includes(x));
+}
+
+export function setUnion<T>(list1: T[], list2: T[]) {
+  return [...list2.reduce((acc, curr) => acc.add(curr), new Set(list1))];
 }

--- a/assets/src/components/activities/multi_input/MultiInputAuthoring.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputAuthoring.tsx
@@ -45,8 +45,6 @@ export const MultiInputComponent = () => {
   const input = model.inputs.find((input) => input.id === selectedInputRef?.id);
   const index = model.inputs.findIndex((input) => input.id === selectedInputRef?.id);
 
-  console.log('model', model);
-
   return (
     <>
       <MultiInputStem

--- a/assets/src/components/activities/multi_input/MultiInputAuthoring.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputAuthoring.tsx
@@ -45,6 +45,8 @@ export const MultiInputComponent = () => {
   const input = model.inputs.find((input) => input.id === selectedInputRef?.id);
   const index = model.inputs.findIndex((input) => input.id === selectedInputRef?.id);
 
+  console.log('model', model);
+
   return (
     <>
       <MultiInputStem

--- a/assets/src/components/activities/multi_input/actions.ts
+++ b/assets/src/components/activities/multi_input/actions.ts
@@ -38,6 +38,16 @@ export const MultiInputActions = {
   ) {
     return (model: MultiInputSchema, post: PostUndoable) => {
       const removedInputRefs = elementsRemoved<InputRef>(operations, 'input_ref');
+
+      // Handle error condition - removing an extra input ref that is not present in the model
+      if (
+        removedInputRefs.length > 0 &&
+        removedInputRefs.every((ref) => !model.inputs.find((input) => input.id === ref.id))
+      ) {
+        StemActions.editStemAndPreviewText(content)(model);
+        return;
+      }
+
       if (getParts(model).length - removedInputRefs.length < 1) {
         return;
       }

--- a/assets/src/components/activities/multi_input/utils.tsx
+++ b/assets/src/components/activities/multi_input/utils.tsx
@@ -1,14 +1,24 @@
 import { SelectOption } from 'components/activities/common/authoring/InputTypeDropdown';
-import { DEFAULT_PART_ID } from 'components/activities/common/utils';
+import { DEFAULT_PART_ID, setDifference, setUnion } from 'components/activities/common/utils';
 import {
   MultiInput,
   MultiInputSchema,
   MultiInputType,
 } from 'components/activities/multi_input/schema';
-import { makeHint, makePart, makeTransformation, Transform } from 'components/activities/types';
+import {
+  makeChoice,
+  makeHint,
+  makePart,
+  makeTransformation,
+  Part,
+  Transform,
+} from 'components/activities/types';
 import { Responses } from 'data/activities/model/responses';
+import { isTextRule } from 'data/activities/model/rules';
 import { InputRef, inputRef, Paragraph } from 'data/content/model';
+import { elementsOfType } from 'data/content/utils';
 import React from 'react';
+import { clone } from 'utils/common';
 import guid from 'utils/guid';
 
 export const multiInputOptions: SelectOption<'text' | 'numeric'>[] = [
@@ -59,3 +69,185 @@ export const partTitle = (input: MultiInput, index: number) => (
     <span className="text-muted">{friendlyType(input.inputType)}</span>
   </div>
 );
+
+export function guaranteeMultiInputValidity(model: MultiInputSchema): MultiInputSchema {
+  // Check whether model is valid first to save unnecessarily cloning the model
+  if (isValidModel(model)) {
+    return model;
+  }
+
+  // Model must be cloned before being passed to these mutable functions.
+  return ensureHasInput(
+    matchInputsToChoices(matchInputsToParts(matchInputsToInputRefs(clone(model)))),
+  );
+}
+
+function inputsMatchInputRefs(model: MultiInputSchema) {
+  const inputRefs = elementsOfType(model.stem.content.model, 'input_ref');
+  const union = setUnion(
+    inputRefs.map(({ id }) => id),
+    model.inputs.map(({ id }) => id),
+  );
+  return union.length === inputRefs.length && union.length === model.inputs.length;
+}
+
+function inputsMatchParts(model: MultiInputSchema) {
+  const parts = model.authoring.parts;
+  const union = setUnion(
+    model.inputs.map(({ partId }) => partId),
+    parts.map(({ id }) => id),
+  );
+  return union.length === model.inputs.length && union.length === parts.length;
+}
+
+function inputsMatchChoices(model: MultiInputSchema) {
+  const inputChoiceIds = model.inputs.reduce(
+    (acc, curr) => (curr.inputType === 'dropdown' ? acc.concat(curr.choiceIds) : acc),
+    [] as string[],
+  );
+  const union = setUnion(
+    model.choices.map(({ id }) => id),
+    inputChoiceIds,
+  );
+  return union.length === model.choices.length && union.length === inputChoiceIds.length;
+}
+
+function hasAnInput(model: MultiInputSchema) {
+  return model.inputs.length > 0;
+}
+
+function isValidModel(model: MultiInputSchema): boolean {
+  return (
+    hasAnInput(model) &&
+    inputsMatchInputRefs(model) &&
+    inputsMatchParts(model) &&
+    inputsMatchChoices(model)
+  );
+}
+
+function ensureHasInput(model: MultiInputSchema) {
+  if (hasAnInput(model)) {
+    return model;
+  }
+
+  // Make new input ref, add to first paragraph of stem, add new input to model.inputs,
+  // add new part.
+  const ref = inputRef();
+  const part = makePart(Responses.forTextInput(), [makeHint('')]);
+  const input: MultiInput = { id: ref.id, inputType: 'text', partId: part.id };
+
+  const firstParagraph = model.stem.content.model.find((elem) => elem.type === 'p');
+  firstParagraph?.children.push(ref);
+  firstParagraph?.children.push({ text: '' });
+
+  model.inputs.push(input);
+  model.authoring.parts.push(part);
+
+  return model;
+}
+
+function matchInputsToChoices(model: MultiInputSchema) {
+  if (inputsMatchChoices(model)) {
+    return model;
+  }
+
+  const choiceIds = model.choices.map(({ id }) => id);
+  const inputChoiceIds = model.inputs.reduce(
+    (acc, curr) => (curr.inputType === 'dropdown' ? acc.concat(curr.choiceIds) : acc),
+    [] as string[],
+  );
+
+  const unmatchedInputChoiceIds = setDifference(inputChoiceIds, choiceIds);
+
+  const unmatchedChoices = setDifference(choiceIds, inputChoiceIds).map((id) =>
+    model.choices.find((c) => c.id === id),
+  );
+
+  unmatchedInputChoiceIds.forEach((id) => {
+    model.choices.push(makeChoice('Choice', id));
+  });
+
+  model.choices = model.choices.filter((choice) => !unmatchedChoices.includes(choice));
+
+  return model;
+}
+
+function matchInputsToParts(model: MultiInputSchema) {
+  if (inputsMatchParts(model)) {
+    return model;
+  }
+
+  const inputIds = model.inputs.map(({ id }) => id);
+  const partIds = model.authoring.parts.map(({ id }) => id);
+
+  const unmatchedInputs = setDifference(inputIds, partIds).map((id) =>
+    model.inputs.find((input) => input.id === id),
+  );
+
+  const unmatchedParts = setDifference(inputIds, partIds).map((id) =>
+    model.authoring.parts.find((part) => part.id === id),
+  );
+
+  unmatchedInputs.forEach((input: MultiInput) => {
+    const choices = [makeChoice('Choice A'), makeChoice('Choice B')];
+    const part = makePart(
+      input.inputType === 'dropdown'
+        ? Responses.forMultipleChoice(choices[0].id)
+        : input.inputType === 'numeric'
+        ? Responses.forNumericInput()
+        : Responses.forTextInput(),
+    );
+    model.authoring.parts.push(part);
+  });
+
+  unmatchedParts.forEach((part: Part) => {
+    const rule = part.responses[0].rule;
+    const type = rule.match(/{\d+}/) ? 'dropdown' : isTextRule(rule) ? 'text' : 'numeric';
+    const ref = inputRef();
+    // If it's a dropdown, change the part to a text input.
+    model.inputs.push({
+      id: ref.id,
+      inputType: type === 'dropdown' ? 'text' : type,
+      partId: part.id,
+    });
+    part.responses = type === 'dropdown' ? Responses.forTextInput() : part.responses;
+    // add inputRef to end of first paragraph in stem
+    const firstParagraph = model.stem.content.model.find((elem) => elem.type === 'p');
+    firstParagraph?.children.push(ref);
+    firstParagraph?.children.push({ text: '' });
+  });
+
+  return model;
+}
+
+function matchInputsToInputRefs(model: MultiInputSchema) {
+  if (inputsMatchInputRefs(model)) {
+    return model;
+  }
+
+  const inputRefIds = elementsOfType(model.stem.content.model, 'input_ref').map(({ id }) => id);
+  const inputIds = model.inputs.map(({ id }) => id);
+
+  const unmatchedInputs = setDifference(inputIds, inputRefIds).map((id) =>
+    model.inputs.find((input) => input.id === id),
+  );
+
+  const unmatchedInputRefs = setDifference(inputRefIds, inputIds).map(
+    (id) => ({ id, type: 'input_ref' } as InputRef),
+  );
+
+  unmatchedInputs.forEach((input: MultiInput) => {
+    // add inputRef to end of first paragraph in stem
+    const firstParagraph = model.stem.content.model.find((elem) => elem.type === 'p');
+    firstParagraph?.children.push({ ...inputRef(), id: input.id });
+    firstParagraph?.children.push({ text: '' });
+  });
+
+  unmatchedInputRefs.forEach((ref) => {
+    // create new input and part for the input ref in the stem
+    const part = makePart(Responses.forTextInput(), [makeHint('')]);
+    model.inputs.push({ id: ref.id, inputType: 'text', partId: part.id } as MultiInput);
+    model.authoring.parts.push(part);
+  });
+  return model;
+}

--- a/assets/src/components/activity/InlineActivityEditor.tsx
+++ b/assets/src/components/activity/InlineActivityEditor.tsx
@@ -1,15 +1,14 @@
-import React from 'react';
+import { ActivityModelSchema, Undoable } from 'components/activities/types';
+import { PartObjectives } from 'components/activity/PartObjectives';
+import { selectImage } from 'components/editing/commands/ImageCmd';
+import { Tags } from 'components/resource/Tags';
 import { ActivityEditContext, ObjectiveMap } from 'data/content/activity';
 import { Objective } from 'data/content/objective';
-import { TitleBar } from '../content/TitleBar';
-import { ActivityModelSchema } from 'components/activities/types';
-import { PartObjectives } from 'components/activity/PartObjectives';
-import { Tags } from 'components/resource/Tags';
-import { valueOr } from 'utils/common';
-import { Undoable } from 'components/activities/types';
 import { Tag } from 'data/content/tags';
-import { selectImage } from 'components/editing/commands/ImageCmd';
 import { ResourceId } from 'data/types';
+import React from 'react';
+import { valueOr } from 'utils/common';
+import { TitleBar } from '../content/TitleBar';
 
 export interface ActivityEditorProps extends ActivityEditContext {
   onEdit: (state: EditorUpdate) => void;

--- a/assets/src/components/editing/models/inputref/Editor.tsx
+++ b/assets/src/components/editing/models/inputref/Editor.tsx
@@ -19,16 +19,28 @@ export const InputRefEditor = (props: InputRefProps) => {
 
   const input = inputRefContext?.inputs.get(props.model.id);
 
-  if (!inputRefContext || !input) {
-    return <span style={{ border: '1px solid black' }}>Input Ref {props.children}</span>;
-  }
-
-  const commands = initCommands(input, inputRefContext.setInputType);
-
   const borderStyle =
     focused && selected
       ? { border: 'solid 3px lightblue', borderRadius: '0.25rem' }
       : { border: 'solid 3px transparent' };
+
+  if (!inputRefContext || !input) {
+    return (
+      <span
+        {...props.attributes}
+        contentEditable={false}
+        style={Object.assign(borderStyle, {
+          border: '1px solid black',
+          borderRadius: 3,
+          padding: 4,
+        })}
+      >
+        Missing Input Ref (delete){props.children}
+      </span>
+    );
+  }
+
+  const commands = initCommands(input, inputRefContext.setInputType);
 
   const activeStyle =
     inputRefContext.selectedInputRef?.id === props.model.id

--- a/assets/src/components/editing/models/inputref/Editor.tsx
+++ b/assets/src/components/editing/models/inputref/Editor.tsx
@@ -29,11 +29,14 @@ export const InputRefEditor = (props: InputRefProps) => {
       <span
         {...props.attributes}
         contentEditable={false}
-        style={Object.assign(borderStyle, {
-          border: '1px solid black',
-          borderRadius: 3,
-          padding: 4,
-        })}
+        style={Object.assign(
+          {
+            border: '1px solid black',
+            borderRadius: 3,
+            padding: 4,
+          },
+          borderStyle,
+        )}
       >
         Missing Input Ref (delete){props.children}
       </span>

--- a/assets/src/data/activities/model/rules.ts
+++ b/assets/src/data/activities/model/rules.ts
@@ -147,6 +147,9 @@ export const parseOperatorFromRule = (rule: string): RuleOperator => {
   }
 };
 
+export const isTextRule = (rule: string): boolean =>
+  !!rule.match(/contains/) || !!rule.match(/like/);
+
 // Explicitly match all ids in `toMatch` and do not match any ids in `allChoiceIds` \ `toMatch`
 export const matchListRule = (all: string[], toMatch: string[]) => {
   const notToMatch = setDifference(all, toMatch);

--- a/assets/src/data/content/bank.ts
+++ b/assets/src/data/content/bank.ts
@@ -1,5 +1,5 @@
-import { ObjectiveMap } from './activity';
 import { ResourceId } from 'data/types';
+import { ObjectiveMap } from './activity';
 
 export interface Logic {
   conditions: null | Expression | Clause;
@@ -76,7 +76,7 @@ function isEmptyValue(value: any) {
 
 // The idea here is to take a logic expression and adjust it to guarantee that it
 // will not produce an error when executed on the server.  Any expression whose value
-// is empty (an empty array or zero length string) will cause an erorr, so this impl
+// is empty (an empty array or zero length string) will cause an error, so this impl
 // seeks to find them and adjust to account for their removal.
 //
 // We leverage the fact that the UI is restricting logic to only contain one

--- a/assets/src/data/content/model.ts
+++ b/assets/src/data/content/model.ts
@@ -1,6 +1,6 @@
-import { Element, Range } from 'slate';
-import guid from 'utils/guid';
 import { normalizeHref } from 'components/editing/models/link/utils';
+import { Element, Node, Range } from 'slate';
+import guid from 'utils/guid';
 
 export function create<ModelElement>(params: Partial<ModelElement>): ModelElement {
   return Object.assign(
@@ -71,6 +71,9 @@ export type ModelElement =
   | Blockquote
   | Hyperlink
   | InputRef;
+
+export const isModelElement = (n: Node): n is ModelElement =>
+  Element.isElement(n) && typeof n.type === 'string' && n.type in schema;
 
 export type TextElement =
   | Paragraph

--- a/assets/src/data/content/utils.tsx
+++ b/assets/src/data/content/utils.tsx
@@ -1,7 +1,9 @@
+import { ContentItem, ContentTypes } from 'data/content/writers/writer';
 import * as React from 'react';
+import { Text } from 'slate';
+import { isModelElement, MediaDisplayMode, ModelElement } from './model';
 import { StructuredContent } from './resource';
 import { toSimpleText } from './text';
-import { MediaDisplayMode } from './model';
 
 // float_left and float_right no longer supported as options
 export function displayModelToClassName(display: MediaDisplayMode | undefined) {
@@ -71,4 +73,29 @@ export const centeredAbove = ({
     top: childRect.top + window.pageYOffset - 50,
     left: childRect.left + window.pageXOffset + childRect.width / 2 - popoverRect.width / 2,
   };
+};
+
+const contentBfs = (
+  content: ContentTypes,
+  cb: (c: ContentItem | ModelElement | Text) => any,
+): void => {
+  if (Array.isArray(content)) {
+    return content.forEach((c) => contentBfs(c, cb));
+  }
+
+  cb(content);
+
+  if (Array.isArray(content.children)) {
+    return contentBfs(content.children, cb);
+  }
+};
+
+export const elementsOfType = (content: ContentTypes, type: string): ModelElement[] => {
+  const elements: ModelElement[] = [];
+  contentBfs(content, (elem) => {
+    if (isModelElement(elem) && elem.type === type) {
+      elements.push(elem);
+    }
+  });
+  return elements;
 };

--- a/assets/src/data/content/utils.tsx
+++ b/assets/src/data/content/utils.tsx
@@ -80,7 +80,7 @@ const contentBfs = (
   cb: (c: ContentItem | ModelElement | Text) => any,
 ): void => {
   if (Array.isArray(content)) {
-    return content.forEach((c) => contentBfs(c, cb));
+    return content.forEach((c: ContentItem | ModelElement) => contentBfs(c, cb));
   }
 
   cb(content);

--- a/assets/src/data/content/writers/writer.tsx
+++ b/assets/src/data/content/writers/writer.tsx
@@ -1,7 +1,7 @@
-import { WriterContext } from './context';
-import { ModelElement } from '../model';
-import { Text } from 'slate';
 import React from 'react';
+import { Text } from 'slate';
+import { ModelElement } from '../model';
+import { WriterContext } from './context';
 
 export type Next = () => React.ReactElement;
 type ElementWriter = (ctx: WriterContext, next: Next, text: ModelElement) => React.ReactElement;
@@ -36,12 +36,12 @@ export interface WriterImpl {
   unsupported: (ctx: WriterContext, element: ModelElement) => React.ReactElement;
 }
 
-type ContentItem = { type: 'content'; children: ModelElement[] };
+export type ContentItem = { type: 'content'; children: ModelElement[] };
 function isContentItem(value: any): value is ContentItem {
   return value && value.type === 'content' && value.children !== undefined;
 }
 
-type ContentTypes = ContentItem[] | ContentItem | ModelElement[] | ModelElement | Text;
+export type ContentTypes = ContentItem[] | ContentItem | ModelElement[] | ModelElement | Text;
 
 export class ContentWriter {
   render(context: WriterContext, content: ContentItem[], impl: WriterImpl): React.ReactElement;


### PR DESCRIPTION
Add model validation for multi input activities in `PageEditor` and `ActivityBank`. This should prevent an invalid model (missing/extra `InputRef`s, `Input`s, `Part`s) from saving. I tested this by triggering the issue Darren noticed where adding multiple inputs to an activity, selecting all, deleting, and then undoing with `cmd+z` could trigger missing input refs.

Closes #1532 