### PR TITLE
PMP-1864 | JAN-680

### DIFF
--- a/assets/src/apps/delivery/store/features/groups/actions/deck.ts
+++ b/assets/src/apps/delivery/store/features/groups/actions/deck.ts
@@ -1,4 +1,5 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
+import { handleValueExpression } from 'apps/delivery/layouts/deck/DeckLayoutFooter';
 import { ActivityState } from 'components/activities/types';
 import { getBulkActivitiesForAuthoring } from 'data/persistence/activity';
 import {
@@ -146,12 +147,13 @@ export const initializeActivity = createAsyncThunk(
       const ownerActivity = currentActivityTree?.find(
         (activity) => !!activity.content.partsLayout.find((p: any) => p.id === targetPart),
       );
+      const modifiedValue = handleValueExpression(currentActivityTree, s.value);
       if (!ownerActivity) {
         // shouldn't happen, but ignore I guess
-        return { ...s };
+        return { ...s, value: modifiedValue };
       }
       arrInitFacts.push(`${ownerActivity.id}|${s.target}`);
-      return { ...s, target: `${ownerActivity.id}|${s.target}` };
+      return { ...s, target: `${ownerActivity.id}|${s.target}`, value: modifiedValue };
     });
 
     const results = bulkApplyState([...sessionOps, ...globalizedInitState], defaultGlobalEnv);


### PR DESCRIPTION
-- if the value field in init state has {stage.iCardTracker.Deck.Cards.4.Visible} then it needs to appended with it's part owner Id i.e. {e:1616710898203:1|stage.iCardTracker.Deck.Cards.4.Visible}. The 'bindTo' operator was not working if the value field is set to {stage.iCardTracker.Deck.Cards.4.Visible}.

-- Also, the init state variable was not wrapped inside '{}' bracket so I have mentioned that in the ticket.