### PR TITLE
[BUG FIX] fix an issue with modals on accounts page

### DIFF
--- a/lib/oli_web/live/common/modal.ex
+++ b/lib/oli_web/live/common/modal.ex
@@ -37,7 +37,7 @@ defmodule OliWeb.Common.Modal do
 
   def render(assigns) do
     ~L"""
-    <div class="modal fade" id="<%= @modal_id %>" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal fade" id="<%= @modal_id %>" tabindex="-1" role="dialog" aria-hidden="true" phx-update="ignore">
       <div class="modal-dialog modal-dialog-centered" role="document">
         <div class="modal-content">
           <div class="modal-header">

--- a/lib/oli_web/live/users/accounts_live.ex
+++ b/lib/oli_web/live/users/accounts_live.ex
@@ -43,8 +43,7 @@ defmodule OliWeb.Accounts.AccountsLive do
     SortableTableModel.new(
       rows: Accounts.list_authors(),
       column_specs: [
-        %ColumnSpec{name: :given_name, label: "First Name"},
-        %ColumnSpec{name: :family_name, label: "Last Name"},
+        %ColumnSpec{name: :name, label: "Name"},
         %ColumnSpec{
           name: :email,
           label: "Email",
@@ -72,8 +71,7 @@ defmodule OliWeb.Accounts.AccountsLive do
     SortableTableModel.new(
       rows: Accounts.list_users(),
       column_specs: [
-        %ColumnSpec{name: :given_name, label: "First Name"},
-        %ColumnSpec{name: :family_name, label: "Last Name"},
+        %ColumnSpec{name: :name, label: "Name"},
         %ColumnSpec{
           name: :email,
           label: "Email",

--- a/lib/oli_web/views/layout_view.ex
+++ b/lib/oli_web/views/layout_view.ex
@@ -95,21 +95,17 @@ defmodule OliWeb.LayoutView do
   def account_link(%{:assigns => assigns} = conn) do
     current_author = assigns.current_author
 
-    safe_initial = fn s ->
-      case s do
+    initials =
+      case current_author.name do
         nil ->
           ""
 
-        _ ->
-          case String.length(s) do
-            0 -> ""
-            _ -> String.at(s, 0) |> String.upcase()
-          end
+        name ->
+          name
+          |> String.split(~r{\s+})
+          |> Enum.map(&String.at(&1, 0))
+          |> Enum.take(2)
       end
-    end
-
-    initials =
-      safe_initial.(current_author.given_name) <> safe_initial.(current_author.family_name)
 
     icon = raw("<div class=\"user-initials-icon\">#{initials}</div>")
 


### PR DESCRIPTION
This PR fixes an admin facing issue where modals on the accounts page unexpectedly disappear due to phoenix re-rendering. It also addresses another issue where some names aren't displayed correctly because certain login providers only provide the name (instead of first and last name). Logic in our schemas will generate a full name based on first and last in none is provided but has no good way to go the other way. For this reason, we should use the name field in the interface since it is the only one guaranteed to be present.