### PR TITLE
[BUGFIX] Fix tag resource links

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+      - hotfix-*
 
 jobs:
   elixir-build-test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ## 0.13.3 (2021-09-30)
 ### Bug Fixes
-- Fix an issue where generating resource links for tags throws a server error
+- Fix an issue where generating resource links for tag types throws a server error
 
 ## 0.13.2 (2021-09-17)
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Bug Fixes
 ### Enhancements
 
+## 0.13.3 (2021-09-30)
+### Bug Fixes
+- Fix an issue where generating resource links for tags throws a server error
+
 ## 0.13.2 (2021-09-17)
 ### Bug Fixes
 - Fix activity choice icon selection in authoring

--- a/lib/oli_web/common/links.ex
+++ b/lib/oli_web/common/links.ex
@@ -3,6 +3,10 @@ defmodule OliWeb.Common.Links do
   alias OliWeb.Router.Helpers, as: Routes
   alias Oli.Resources.Numbering
 
+  @doc """
+  Returns a path uri for a given revision. If the revision type is not
+  routable or of a known type, returns nil
+  """
   def resource_path(revision, parent_pages, project_slug) do
     case Oli.Resources.ResourceType.get_type_by_id(revision.resource_type_id) do
       "objective" ->
@@ -41,6 +45,16 @@ defmodule OliWeb.Common.Links do
           project_slug,
           revision.slug
         )
+
+      "tag" ->
+        Routes.activity_bank_path(
+          OliWeb.Endpoint,
+          :index,
+          project_slug
+        )
+
+      _ ->
+        nil
     end
   end
 
@@ -73,10 +87,16 @@ defmodule OliWeb.Common.Links do
           link(title, to: path, class: class)
 
         _ ->
-          link(revision.title,
-            to: path,
-            class: class
-          )
+          case path do
+            nil ->
+              revision.title
+
+            _ ->
+              link(revision.title,
+                to: path,
+                class: class
+              )
+          end
       end
     end
   end


### PR DESCRIPTION
This PR fixes an issue where generating resource links for tags throws a server error. It now handles tags and guards against unknown types.