### PR TITLE
[FEATURE] [MER-318] - Added support for underline formatting.

### DIFF
--- a/assets/src/components/editing/editor/modelEditorDispatch.tsx
+++ b/assets/src/components/editing/editor/modelEditorDispatch.tsx
@@ -106,6 +106,8 @@ export function markFor(mark: ContentModel.Mark, children: any): JSX.Element {
       return <sub>{children}</sub>;
     case 'sup':
       return <sup>{children}</sup>;
+    case 'u':
+      return <u>{children}</u>;
     default:
       return <span>{children}</span>;
   }

--- a/assets/src/components/editing/toolbars/formatting/items.ts
+++ b/assets/src/components/editing/toolbars/formatting/items.ts
@@ -12,6 +12,7 @@ export const formatMenuCommands = [
   [
     format({ icon: 'format_bold', mark: 'strong', description: 'Bold (⌘B)' }),
     format({ icon: 'format_italic', mark: 'em', description: 'Italic (⌘I)' }),
+    format({ icon: 'format_underline', mark: 'u', description: 'Underline (⌘U)' }),
     linkCmd,
     format({
       icon: 'code',

--- a/assets/src/components/parts/janus-text-flow/Markup.tsx
+++ b/assets/src/components/parts/janus-text-flow/Markup.tsx
@@ -184,6 +184,13 @@ const Markup: React.FC<any> = ({
           {children}
         </em>
       );
+    case 'u':
+      return (
+        <u ref={el} key={key} className={customCssClass} style={renderStyles}>
+          {processedText}
+          {children}
+        </u>
+      );
     case 'div':
       return (
         <div ref={el} key={key} className={customCssClass} style={renderStyles}>

--- a/assets/src/data/content/model.ts
+++ b/assets/src/data/content/model.ts
@@ -219,7 +219,7 @@ export interface InputRef extends Element, Identifiable {
   type: 'input_ref';
 }
 
-export type Mark = 'em' | 'strong' | 'mark' | 'del' | 'var' | 'code' | 'sub' | 'sup';
+export type Mark = 'em' | 'strong' | 'mark' | 'del' | 'var' | 'code' | 'sub' | 'sup' | 'u';
 
 export enum Marks {
   'em',
@@ -230,6 +230,7 @@ export enum Marks {
   'code',
   'sub',
   'sup',
+  'u'
 }
 
 export enum CodeLanguages {

--- a/assets/src/data/content/writers/html.tsx
+++ b/assets/src/data/content/writers/html.tsx
@@ -62,6 +62,7 @@ export class HtmlParser implements WriterImpl {
       code: (e) => <code>{e}</code>,
       sub: (e) => <sub>{e}</sub>,
       sup: (e) => <sup>{e}</sup>,
+      u: (e) => <u>{e}</u>,
     };
     return Object.keys(textEntity)
       .filter((attr) => textEntity[attr] === true)

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -284,7 +284,8 @@ defmodule Oli.Rendering.Content.Html do
       "var" => "var",
       "code" => "code",
       "sub" => "sub",
-      "sup" => "sup"
+      "sup" => "sup",
+      "u" => "u"
     }
 
     marks =


### PR DESCRIPTION
This PR adds support for underlining text within the editor as well as displaying the underlined text.

- Added ability to underline selected code in the editor either using the toolbar or standard cmd+U key shortcut
- Added underline rendering to editor and preview

To Test:

1. Login as Author and create new project or use existing.
2. Add a new practice page. 
3. Within this page add some text then highlight it. When the toolbar appears, click the U button to underline the content.
4. Press the Preview button to confirm that text is underlined then exit preview mode.
5. Select the underlined text. Press the {cmd|ctrl}+U keyboard shortcut to remove underline.
