### PR TITLE
[BUGFIX] Fix selection changing types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Bug Fixes
 ### Enhancements
 
+## 0.13.5 (2021-10-04)
+### Bug Fixes
+
+- Fix an issue where a selection fact change can break the page
+
 ## 0.13.4 (2021-10-03)
 ### Bug Fixes
 

--- a/assets/src/components/logic/ActivityTypeSelection.tsx
+++ b/assets/src/components/logic/ActivityTypeSelection.tsx
@@ -19,7 +19,7 @@ export type ActivityTypeSelectionProps = {
 export const ActivityTypeSelection = (props: ActivityTypeSelectionProps) => {
   const { activities, editMode, selected, onEdit } = props;
 
-  // Typeahed throws a bunch of warnings if it doesn't contain
+  // Typeahead throws a bunch of warnings if it doesn't contain
   // a unique DOM id.  So we generate one for it.
   const [id] = useState(guid());
 

--- a/assets/src/components/logic/Expression.tsx
+++ b/assets/src/components/logic/Expression.tsx
@@ -66,10 +66,10 @@ const textFact = { value: 'text', label: 'Activity Content' };
 
 export const Expression: React.FC<ExpressionProps> = (props: ExpressionProps) => {
   const onChangeFact = (fact: string) => {
-    const updated = Object.assign({}, props.expression, { fact });
+    // change fact and reset the value list
+    const updated = Object.assign({}, props.expression, { fact, value: [] });
 
     // As facts are changed, ensure the operator remains valid for that fact
-
     if (
       operatorsByFact[fact].filter((fo) => fo.operator === props.expression.operator).length === 0
     ) {

--- a/assets/src/components/resource/Objectives.tsx
+++ b/assets/src/components/resource/Objectives.tsx
@@ -18,7 +18,7 @@ export type ObjectivesProps = {
 export const Objectives = (props: ObjectivesProps) => {
   const { objectives, editMode, selected, onEdit, onRegisterNewObjective } = props;
 
-  // Typeahed throws a bunch of warnings if it doesn't contain
+  // Typeahead throws a bunch of warnings if it doesn't contain
   // a unique DOM id.  So we generate one for it.
   const [id] = useState(guid());
 

--- a/assets/src/components/resource/Tags.tsx
+++ b/assets/src/components/resource/Tags.tsx
@@ -19,7 +19,7 @@ export type TagsProps = {
 export const Tags = (props: TagsProps) => {
   const { tags, editMode, selected, onEdit, onRegisterNewTag } = props;
 
-  // Typeahed throws a bunch of warnings if it doesn't contain
+  // Typeahead throws a bunch of warnings if it doesn't contain
   // a unique DOM id.  So we generate one for it.
   const [id] = useState(guid());
 

--- a/assets/src/components/resource/editors/Editors.tsx
+++ b/assets/src/components/resource/editors/Editors.tsx
@@ -23,6 +23,7 @@ import { dragStartHandler } from './dragndrop/handlers/dragStart';
 import { EditorUpdate } from 'components/activity/InlineActivityEditor';
 import { Undoable } from 'components/activities/types';
 import { Tag } from 'data/content/tags';
+import { EditorErrorBoundary } from './editor_error_boundary';
 
 export type EditorsProps = {
   editMode: boolean; // Whether or not we can edit
@@ -165,7 +166,7 @@ export const Editors = (props: EditorsProps) => {
           aria-describedby="content-list-operation"
           tabIndex={index + 1}
         >
-          {editor}
+          <EditorErrorBoundary id={contentKey}>{editor}</EditorErrorBoundary>
         </div>
       </div>
     );

--- a/assets/src/components/resource/editors/editor_error_boundary.tsx
+++ b/assets/src/components/resource/editors/editor_error_boundary.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+type EditorErrorBoundaryProps = {
+  id: string;
+  children: unknown;
+};
+
+interface EditorErrorBoundaryState {
+  hasError: boolean;
+  error: unknown;
+}
+
+export class EditorErrorBoundary extends React.Component<
+  EditorErrorBoundaryProps,
+  EditorErrorBoundaryState
+> {
+  constructor(props: EditorErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: undefined };
+  }
+
+  static getDerivedStateFromError(error: unknown) {
+    // Update state so the next render will show the fallback UI.
+    return { hasError: true, error: error };
+  }
+
+  componentDidCatch(error: unknown, errorInfo: unknown) {
+    // You can also log the error to an error reporting service
+    // for now just log it to the console
+    console.error(error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="alert alert-danger" role="alert">
+          Something went wrong. This item could not be displayed.
+          <span className="float-right">
+            <small>
+              <b>ID:</b> {this.props.id}
+            </small>
+          </span>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/lib/oli_web/live/objectives/actions.ex
+++ b/lib/oli_web/live/objectives/actions.ex
@@ -24,7 +24,9 @@ defmodule OliWeb.Objectives.Actions do
 
         <button
           id="delete_<%= @slug %>"
-          <%= if @can_delete? do "" else "disabled" end %>
+          disabled
+          <% # disable the ability to delete until #1616 is resolved %>
+          <% # if @can_delete? do "" else "disabled" end %>
           phx-click="prepare_delete"
           phx-value-slug="<%= @slug %>"
           data-backdrop="static"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Oli.MixProject do
   def project do
     [
       app: :oli,
-      version: "0.13.4",
+      version: "0.13.5",
       elixir: "~> 1.12",
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: elixirc_options(Mix.env()),

--- a/test/oli_web/live/objectives_test.exs
+++ b/test/oli_web/live/objectives_test.exs
@@ -20,6 +20,20 @@ defmodule OliWeb.ObjectivesLiveTest do
       # the container should have two objectives
       assert view |> element("##{objective1.revision.slug}") |> has_element?()
       assert view |> element("##{objective2.revision.slug}") |> has_element?()
+    end
+
+    @tag :skip
+    test "can delete objective", %{conn: conn, project: project, map: map} do
+      conn = get(conn, "/authoring/project/#{project.slug}/objectives")
+
+      {:ok, view, _} = live(conn)
+
+      objective1 = Map.get(map, :objective1)
+      objective2 = Map.get(map, :objective2)
+
+      # the container should have two objectives
+      assert view |> element("##{objective1.revision.slug}") |> has_element?()
+      assert view |> element("##{objective2.revision.slug}") |> has_element?()
 
       # delete the selected objective, which requires first clicking the delete button
       # which will display the modal, then we click the "Delete" button in the modal
@@ -32,6 +46,7 @@ defmodule OliWeb.ObjectivesLiveTest do
       |> render_click()
 
       refute view |> element("##{objective1.revision.slug}") |> has_element?()
+
       assert view |> element("##{objective2.revision.slug}") |> has_element?()
     end
   end


### PR DESCRIPTION
This PR fixes an issue related to changing fact types in an activity selection where the old value remained in place breaking the page. It fixes the issue by resetting value to an empty list on fact change. It also introduces a react error boundary to prevent the entire page from breaking.

This PR also disables objective deletion and is expected to be followed up with a fix to #1616.