### PR TITLE
[FEATURE] pull forward download impl, fix formatting and other issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,25 +3,37 @@
 ## Unreleased
 
 ### Bug Fixes
+
 ### Enhancements
 
+## 0.13.6 (2021-10-04)
+
+### Bug Fixes
+
+- Add ability to download raw analytic data
+
 ## 0.13.5 (2021-10-04)
+
 ### Bug Fixes
 
 - Fix an issue where a selection fact change can break the page
 
 ## 0.13.4 (2021-10-03)
+
 ### Bug Fixes
 
 - Fix an issue where a page can be duplicated within a container
 
 ## 0.13.3 (2021-09-30)
+
 ### Bug Fixes
 
 - Fix an issue where generating resource links for tag types throws a server error
 
 ## 0.13.2 (2021-09-17)
+
 ### Bug Fixes
+
 - Fix activity choice icon selection in authoring
 - Fix targeted feedback not showing in delivery
 - Fix delivered activity choice input size changing with content

--- a/lib/oli/analytics/common.ex
+++ b/lib/oli/analytics/common.ex
@@ -5,6 +5,51 @@ defmodule Oli.Analytics.Common do
   alias Oli.Delivery.Sections.Section
   # alias Oli.Delivery.Sections.SectionsProjectsPublications
 
+  alias Oli.Resources.Revision
+  alias Oli.Repo
+  alias Oli.Delivery.Attempts.Core.PartAttempt
+
+  def snapshots_for_project(project_slug) do
+    Repo.all(
+      from(project in Project,
+        where: project.slug == ^project_slug,
+        join: section in Section,
+        on: section.base_project_id == project.id,
+        join: snapshot in Snapshot,
+        on: snapshot.section_id == section.id,
+        join: activity in Revision,
+        on: snapshot.revision_id == activity.id,
+        left_join: objective in Revision,
+        on: snapshot.objective_revision_id == objective.id,
+        join: pattempt in PartAttempt,
+        on: snapshot.part_attempt_id == pattempt.id,
+        select: [
+          snapshot.part_attempt_id,
+          snapshot.activity_id,
+          snapshot.resource_id,
+          objective.resource_id,
+          activity.title,
+          activity.activity_type_id,
+          objective.title,
+          snapshot.attempt_number,
+          snapshot.graded,
+          snapshot.correct,
+          snapshot.score,
+          snapshot.out_of,
+          snapshot.hints,
+          pattempt.score,
+          pattempt.out_of,
+          pattempt.response,
+          pattempt.feedback,
+          activity.content,
+          section.title,
+          section.slug,
+          snapshot.inserted_at
+        ]
+      )
+    )
+  end
+
   def analytics_by_activity(project_slug) do
     activity_num_attempts_rel_difficulty =
       from(project in Project,

--- a/lib/oli/interop/export.ex
+++ b/lib/oli/interop/export.ex
@@ -22,7 +22,7 @@ defmodule Oli.Interop.Export do
        objectives(resources) ++
        activities(resources) ++
        pages(resources))
-    |> Utils.zip()
+    |> Utils.zip("export.zip")
   end
 
   defp tags(resources) do

--- a/lib/oli/interop/export.ex
+++ b/lib/oli/interop/export.ex
@@ -4,6 +4,7 @@ defmodule Oli.Interop.Export do
   alias Oli.Activities
   alias Oli.Authoring.MediaLibrary
   alias Oli.Authoring.MediaLibrary.ItemOptions
+  alias Oli.Utils
 
   @doc """
   Generates a course digest for an existing course project.
@@ -21,19 +22,7 @@ defmodule Oli.Interop.Export do
        objectives(resources) ++
        activities(resources) ++
        pages(resources))
-    |> zip
-  end
-
-  # zip up the given filename and content tuples
-  defp zip(filename_content_tuples) do
-    {:ok, {_filename, data}} =
-      :zip.create(
-        "export.zip",
-        filename_content_tuples,
-        [:memory]
-      )
-
-    data
+    |> Utils.zip()
   end
 
   defp tags(resources) do
@@ -190,13 +179,7 @@ defmodule Oli.Interop.Export do
 
   # helper to create a zip entry tuple
   defp entry(contents, name) do
-    {String.to_charlist(name), pretty(contents)}
-  end
-
-  # ensure that the JSON that we write to files is nicely formatted
-  defp pretty(map) do
-    Jason.encode_to_iodata!(map)
-    |> Jason.Formatter.pretty_print()
+    {String.to_charlist(name), Utils.pretty(contents)}
   end
 
   # recursive impl to build out the nested, digest specific representation of the course hierarchy

--- a/lib/oli/utils.ex
+++ b/lib/oli/utils.ex
@@ -138,4 +138,24 @@ defmodule Oli.Utils do
     {:ok, uuid} = ShortUUID.encode(UUID.uuid4())
     uuid
   end
+
+  @doc """
+  Zip up the given filename and content tuples
+  """
+  def zip(filename_content_tuples, zip_filename) do
+    {:ok, {_filename, data}} =
+      :zip.create(
+        zip_filename,
+        filename_content_tuples,
+        [:memory]
+      )
+
+    data
+  end
+
+  # ensure that the JSON that we write to files is nicely formatted
+  def pretty(map) do
+    Jason.encode_to_iodata!(map)
+    |> Jason.Formatter.pretty_print()
+  end
 end

--- a/lib/oli_web/controllers/project_controller.ex
+++ b/lib/oli_web/controllers/project_controller.ex
@@ -11,6 +11,7 @@ defmodule OliWeb.ProjectController do
   alias OliWeb.Common.Breadcrumb
   alias Oli.Authoring.Clone
   alias Oli.Activities
+  alias OliWeb.Insights
 
   def overview(conn, project_params) do
     project = conn.assigns.project
@@ -38,6 +39,15 @@ defmodule OliWeb.ProjectController do
 
   def resource_editor(conn, _project_params) do
     render(conn, "resource_editor.html", title: "Resource Editor", active: :resource_editor)
+  end
+
+  def download_analytics(conn, _project_params) do
+    project = conn.assigns.project
+
+    conn
+    |> send_download({:binary, Insights.export(project)},
+      filename: "analytics_#{project.slug}.zip"
+    )
   end
 
   def publish(conn, _) do
@@ -86,10 +96,11 @@ defmodule OliWeb.ProjectController do
     public_keyset_url = "#{base_url}/.well-known/jwks.json"
     redirect_uris = "#{base_url}/lti/launch"
 
-    has_changes = case version_change do
-      {:no_changes, _} -> false
-      _ -> true
-    end
+    has_changes =
+      case version_change do
+        {:no_changes, _} -> false
+        _ -> true
+      end
 
     render(conn, "publish.html",
       # page
@@ -165,7 +176,8 @@ defmodule OliWeb.ProjectController do
           collaborators: Accounts.project_authors(project),
           activities_enabled: Activities.advanced_activities(project),
           changeset: changeset,
-          latest_published_publication: Publishing.get_latest_published_publication_by_slug(project.slug)
+          latest_published_publication:
+            Publishing.get_latest_published_publication_by_slug(project.slug)
         }
 
         conn
@@ -236,7 +248,8 @@ defmodule OliWeb.ProjectController do
           collaborators: Accounts.project_authors(project),
           activities_enabled: Activities.advanced_activities(project),
           changeset: changeset,
-          latest_published_publication: Publishing.get_latest_published_publication_by_slug(project.slug)
+          latest_published_publication:
+            Publishing.get_latest_published_publication_by_slug(project.slug)
         }
 
         conn

--- a/lib/oli_web/live/insights/insights.ex
+++ b/lib/oli_web/live/insights/insights.ex
@@ -2,6 +2,9 @@ defmodule OliWeb.Insights do
   use Phoenix.LiveView
   alias OliWeb.Insights.{TableHeader, TableRow}
   alias Oli.Authoring.Course
+  alias Oli.Utils
+  alias CSV
+  alias Oli.Activities
 
   def mount(_params, %{"project_slug" => project_slug} = _session, socket) do
     by_activity_rows = Oli.Analytics.ByActivity.query_against_project_slug(project_slug)
@@ -141,4 +144,139 @@ defmodule OliWeb.Insights do
       ""
     end
   end
+
+  def export(project) do
+    filenames =
+      ["raw_analytics.tsv", "by_page.tsv", "by_activity.tsv", "by_objective.tsv"]
+      # CSV Encoder expects charlists for filenames, not strings
+      |> Enum.map(&String.to_charlist(&1))
+
+    analytics =
+      raw_snapshot_data(project.slug)
+      |> Enum.concat(derived_analytics_data(project.slug))
+      |> Enum.map(&CSV.encode(&1, separator: ?\t))
+      |> Enum.map(&Enum.join(&1, ""))
+
+    Enum.zip(filenames, analytics)
+    # Convert to tuples of {filename, CSV table rows}
+    |> Enum.map(&{elem(&1, 0), elem(&1, 1)})
+    |> Utils.zip("analytics.zip")
+  end
+
+  def raw_snapshot_data(project_slug) do
+    snapshots_title_row = [
+      "Part Attempt ID",
+      "Activity ID",
+      "Page ID",
+      "Objective ID",
+      "Activity Title",
+      "Activity Type",
+      "Objective Title",
+      "Attempt Number",
+      "Graded?",
+      "Correct?",
+      "Activity Score",
+      "Activity Out Of",
+      "Hints Requested",
+      "Part Score",
+      "Part Out Of",
+      "Student Response",
+      "Feedback",
+      "Activity Content",
+      "Section Title",
+      "Section Slug",
+      "Date Created"
+    ]
+
+    [
+      [
+        snapshots_title_row
+        | Oli.Analytics.Common.snapshots_for_project(project_slug)
+          |> Enum.map(
+            &(&1
+              # Query returns a list of fields
+              # Get activity type
+              |> List.replace_at(5, Activities.get_registration!(Enum.at(&1, 5)).title)
+              # JSON format student response
+              |> List.replace_at(15, Jason.encode_to_iodata!(Enum.at(&1, 15)))
+              # JSON format feedback
+              |> List.replace_at(16, Jason.encode_to_iodata!(Enum.at(&1, 16)))
+              |> List.replace_at(17, Jason.encode_to_iodata!(Enum.at(&1, 17)))
+              # JSON format date
+              |> List.replace_at(20, Utils.format_datetime(Enum.at(&1, 20))))
+          )
+      ]
+    ]
+  end
+
+  def derived_analytics_data(project_slug) do
+    analytics_title_row = [
+      "Resource Title",
+      "Activity Title",
+      "Number of Attempts",
+      "Relative Difficulty",
+      "Eventually Correct",
+      "First Try Correct"
+    ]
+
+    [
+      Oli.Analytics.ByPage.query_against_project_slug(project_slug),
+      Oli.Analytics.ByActivity.query_against_project_slug(project_slug),
+      Oli.Analytics.ByObjective.query_against_project_slug(project_slug)
+    ]
+    |> Enum.map(&[analytics_title_row | extract_analytics(&1)])
+  end
+
+  def extract_analytics([
+        %{
+          slice: slice,
+          number_of_attempts: number_of_attempts,
+          relative_difficulty: relative_difficulty,
+          eventually_correct: eventually_correct,
+          first_try_correct: first_try_correct
+        } = h
+        | t
+      ]) do
+    [
+      [
+        slice.title,
+        if !Map.has_key?(h, :activity) do
+          slice.title
+        else
+          h.activity.title
+        end,
+        if is_nil(number_of_attempts) do
+          "No attempts"
+        else
+          Integer.to_string(number_of_attempts)
+        end,
+        if is_nil(relative_difficulty) do
+          ""
+        else
+          Float.to_string(truncate(relative_difficulty))
+        end,
+        if is_nil(eventually_correct) do
+          ""
+        else
+          format_percent(eventually_correct)
+        end,
+        if is_nil(first_try_correct) do
+          ""
+        else
+          format_percent(first_try_correct)
+        end
+      ]
+      | extract_analytics(t)
+    ]
+  end
+
+  def extract_analytics([]), do: []
+
+  def truncate(float_or_nil) when is_nil(float_or_nil), do: nil
+  def truncate(float_or_nil) when is_float(float_or_nil), do: Float.round(float_or_nil, 2)
+
+  def format_percent(float_or_nil) when is_nil(float_or_nil), do: nil
+
+  def format_percent(float_or_nil) when is_float(float_or_nil),
+    do: "#{round(100 * float_or_nil)}%"
 end

--- a/lib/oli_web/live/insights/table_row.ex
+++ b/lib/oli_web/live/insights/table_row.ex
@@ -1,6 +1,7 @@
 defmodule OliWeb.Insights.TableRow do
   use Phoenix.LiveComponent
   alias OliWeb.Common.Links
+  alias OliWeb.Insights
 
   def render(assigns) do
     # slice is a page, activity, or objective revision
@@ -9,7 +10,7 @@ defmodule OliWeb.Insights.TableRow do
       number_of_attempts: number_of_attempts,
       relative_difficulty: relative_difficulty,
       eventually_correct: eventually_correct,
-      first_try_correct: first_try_correct,
+      first_try_correct: first_try_correct
     } = assigns.row
 
     ~L"""
@@ -23,18 +24,10 @@ defmodule OliWeb.Insights.TableRow do
         </td>
       <% end %>
       <td><%= if number_of_attempts == nil do "No attempts" else number_of_attempts end %></td>
-      <td><%= truncate(relative_difficulty) %></td>
-      <td><%= format_percent(eventually_correct) %></td>
-      <td><%= format_percent(first_try_correct) %></td>
+      <td><%= Insights.truncate(relative_difficulty) %></td>
+      <td><%= Insights.format_percent(eventually_correct) %></td>
+      <td><%= Insights.format_percent(first_try_correct) %></td>
     </tr>
     """
   end
-
-  defp truncate(float_or_nil) when is_nil(float_or_nil), do: nil
-  defp truncate(float_or_nil) when is_float(float_or_nil), do: Float.round(float_or_nil, 2)
-
-  defp format_percent(float_or_nil) when is_nil(float_or_nil), do: nil
-
-  defp format_percent(float_or_nil) when is_float(float_or_nil),
-    do: "#{round(100 * float_or_nil)}%"
 end

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -238,6 +238,7 @@ defmodule OliWeb.Router do
     post("/:project_id/publish", ProjectController, :publish_active)
     post("/:project_id/datashop", ProjectController, :download_datashop)
     post("/:project_id/export", ProjectController, :download_export)
+    post("/:project_id/insights", ProjectController, :download_analytics)
     post("/:project_id/duplicate", ProjectController, :clone_project)
 
     # Project

--- a/lib/oli_web/templates/project/insights.html.eex
+++ b/lib/oli_web/templates/project/insights.html.eex
@@ -5,6 +5,9 @@
       Insights can help you improve your course by providing a statistical analysis of
       the skills covered by each question to find areas where students are struggling.
       </p>
+      <div class="d-flex align-items-center">
+        <%= button("Download Raw Data", to: Routes.project_path(@conn, :download_analytics, @project), method: :post, class: "btn btn-link action-button") %>
+      </div>
     </div>
   </div>
   <div class="row mt-4">


### PR DESCRIPTION
This PR pulls forward the raw data analytics download feature, but fixes a few things along the way:

1. Snapshot records with no objectives attached were not included. The fix here is to use a left_join on Objectives.
2. The pretty printing of JSON was breaking the file by introducing spurious newlines.  
3. More fields were added, ids of the part attempt, activity, page and objective, as well as the entire content of the activity

I'm going to file a follow on bug to fix the impl of the formatting in lines 199-206 of the `Insights` LV.  This repeated use of `Enum.at` and `List.replace_at` on every row is not the most effecient way of doing this and could lead to performance problems as the data sets get larger and larger.  This can be replaced with an approach that does two passes over the fields, not two passes per formatting.

