### PR TITLE
[FEATURE] allow for env var driven provider changes

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -52,7 +52,7 @@ config :oli,
       ),
     favicons: System.get_env("BRANDING_FAVICONS_DIR", "/favicons")
   ],
-  payment_provider: OliWeb.PaymentProviders.StripeController
+  payment_provider: System.get_env("PAYMENT_PROVIDER", "stripe")
 
 config :oli, :stripe_provider,
   public_secret: System.get_env("STRIPE_PUBLIC_SECRET"),

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -53,6 +53,14 @@ s3_media_bucket_name =
     For example: torus-media
     """
 
+if System.get_env("PAYMENT_PROVIDER") == "stripe" &&
+     (!System.get_env("STRIPE_PUBLIC_SECRET") || !System.get_env("STRIPE_PRIVATE_SECRET")) do
+  raise """
+  Stripe payment provider not configured correctly. Both STRIPE_PUBLIC_SECRET
+  and STRIPE_PRIVATE_SECRET values must be set.
+  """
+end
+
 media_url =
   System.get_env("MEDIA_URL") ||
     raise """
@@ -68,7 +76,12 @@ config :oli,
   email_from_address: System.get_env("EMAIL_FROM_ADDRESS", "admin@example.edu"),
   email_reply_to: System.get_env("EMAIL_REPLY_TO", "admin@example.edu"),
   slack_webhook_url: System.get_env("SLACK_WEBHOOK_URL"),
-  load_testing_mode: from_boolean_env.("LOAD_TESTING_MODE", "false")
+  load_testing_mode: from_boolean_env.("LOAD_TESTING_MODE", "false"),
+  payment_provider: System.get_env("PAYMENT_PROVIDER", "none")
+
+config :oli, :stripe_provider,
+  public_secret: System.get_env("STRIPE_PUBLIC_SECRET"),
+  private_secret: System.get_env("STRIPE_PRIVATE_SECRET")
 
 # Configure reCAPTCHA
 config :oli, :recaptcha,

--- a/lib/oli_web/controllers/payment_providers/no_provider_controller.ex
+++ b/lib/oli_web/controllers/payment_providers/no_provider_controller.ex
@@ -1,0 +1,10 @@
+defmodule OliWeb.PaymentProviders.NoProviderController do
+  use OliWeb, :controller
+
+  def show(conn, _, _, _) do
+    conn
+    # This is necessary since this controller has been delegated by PaymentController
+    |> Phoenix.Controller.put_view(OliWeb.PaymentProviders.NoProviderView)
+    |> render("index.html")
+  end
+end

--- a/lib/oli_web/templates/payment/guard.html.eex
+++ b/lib/oli_web/templates/payment/guard.html.eex
@@ -6,12 +6,14 @@
   </p>
 
   <div class="card-deck mt-5">
+    <%= if @direct_payments_enabled do %>
     <a href="<%= Routes.payment_path(@conn, :make_payment, @section_slug) %>" class="card btn-card">
       <div class="card-body">
         <h5 class="card-title">Pay now</h5>
         <p class="card-text">Make a payment now, through our secure payment provider.</p>
       </div>
     </a>
+    <% end %>
     <a href="<%= Routes.payment_path(@conn, :use_code, @section_slug) %>" class="card btn-card">
       <div class="card-body">
         <h5 class="card-title">Use a payment code</h5>

--- a/lib/oli_web/templates/payment_providers/no_provider/index.html.eex
+++ b/lib/oli_web/templates/payment_providers/no_provider/index.html.eex
@@ -1,0 +1,1 @@
+<h3>Direct payments are not enabled</h3>

--- a/lib/oli_web/views/payment_providers/no_provider_view.ex
+++ b/lib/oli_web/views/payment_providers/no_provider_view.ex
@@ -1,0 +1,3 @@
+defmodule OliWeb.PaymentProviders.NoProviderView do
+  use OliWeb, :view
+end


### PR DESCRIPTION
This PR adjusts how the system allows configuration of the payment provider.  Previously, a recompile was necessary to change providers. This PR allows the `PAYMENT_PROVIDER` env variable to determine the payment provider.  The valid values are `"stripe"` or `"none"`.  The default is `"stripe"` and any other value besides stripe or none defaults to `"none"`.  

When the payment provider is set to `"none"`, no link to initiate a direct payment is shown, only a link to redeem a payment code. 
