### PR TITLE
[FEATURE] [PMP-860 / JAN-327]: Match Locking and Saving Lessons in Adv Authoring Tool to Torus Behaviors

### DIFF
--- a/assets/src/apps/authoring/Authoring.tsx
+++ b/assets/src/apps/authoring/Authoring.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { Alert, Button } from 'react-bootstrap';
 import { Provider, useDispatch, useSelector } from 'react-redux';
 import { BottomPanel } from './BottomPanel';
 import { AdaptivityEditor } from './components/AdaptivityEditor/AdaptivityEditor';
@@ -9,11 +10,16 @@ import LeftMenu from './components/LeftMenu/LeftMenu';
 import RightMenu from './components/RightMenu/RightMenu';
 import { SidePanel } from './components/SidePanel';
 import store from './store';
+import { acquireEditingLock, releaseEditingLock } from './store/app/actions/locking';
 import {
   selectBottomPanel,
   selectCurrentRule,
+  selectHasEditingLock,
   selectLeftPanel,
+  selectProjectSlug,
+  selectRevisionSlug,
   selectRightPanel,
+  selectshowEditingLockErrMsg,
   selectTopPanel,
   setInitialConfig,
   setPanelState,
@@ -34,22 +40,32 @@ export interface AuthoringProps {
 
 const Authoring: React.FC<AuthoringProps> = (props: AuthoringProps) => {
   const dispatch = useDispatch();
+  const requestEditLock = async () => await dispatch(acquireEditingLock());
 
   const authoringContainer = document.getElementById('advanced-authoring');
   const [isAppVisible, setIsAppVisible] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
 
+  const hasEditingLock = useSelector(selectHasEditingLock);
+  const showEditingLockErrMsg = useSelector(selectshowEditingLockErrMsg);
+  const projectSlug = useSelector(selectProjectSlug);
+  const revisionSlug = useSelector(selectRevisionSlug);
   const currentRule = useSelector(selectCurrentRule);
   const leftPanelState = useSelector(selectLeftPanel);
   const rightPanelState = useSelector(selectRightPanel);
   const topPanelState = useSelector(selectTopPanel);
   const bottomPanelState = useSelector(selectBottomPanel);
+
   const panelState = {
     left: leftPanelState,
     right: rightPanelState,
     top: topPanelState,
     bottom: bottomPanelState,
   };
+
+  const url = `/authoring/project/${projectSlug}/preview/${revisionSlug}`;
+  const windowName = `preview-${projectSlug}`;
+
   const handlePanelStateChange = ({
     top,
     right,
@@ -91,7 +107,7 @@ const Authoring: React.FC<AuthoringProps> = (props: AuthoringProps) => {
         authoringContainer?.classList.add('startup');
       }, 50);
     }
-    if (!isAppVisible) {
+    if (!isAppVisible || !hasEditingLock) {
       // reset forced light mode
       const darkModeCss: any = document.getElementById('authoring-theme-dark');
       darkModeCss.href = '/css/authoring_torus_dark.css';
@@ -104,15 +120,26 @@ const Authoring: React.FC<AuthoringProps> = (props: AuthoringProps) => {
     return () => {
       document.body.classList.remove('overflow-hidden');
     };
-  }, [isAppVisible]);
+  }, [isAppVisible, hasEditingLock]);
 
   useEffect(() => {
+    window.addEventListener('beforeunload', async () => await dispatch(releaseEditingLock()));
     setTimeout(() => {
-      setIsAppVisible(true);
+      if (hasEditingLock) {
+        setIsAppVisible(true);
+      }
     }, 500);
     setTimeout(() => {
       setIsLoading(false);
     }, 2000);
+
+    return () => {
+      window.removeEventListener('beforeunload', async () => await dispatch(releaseEditingLock()));
+    };
+  }, [hasEditingLock]);
+
+  useEffect(() => {
+    requestEditLock();
   }, []);
 
   return (
@@ -124,31 +151,55 @@ const Authoring: React.FC<AuthoringProps> = (props: AuthoringProps) => {
           </div>
         </div>
       )}
-      <div id="advanced-authoring" className={`advanced-authoring d-none`}>
-        <HeaderNav panelState={panelState} isVisible={panelState.top} />
-        <SidePanel
-          position="left"
-          panelState={panelState}
-          onToggle={() => handlePanelStateChange({ left: !panelState.left })}
-        >
-          <LeftMenu />
-        </SidePanel>
-        <EditingCanvas />
-        <BottomPanel
-          panelState={panelState}
-          onToggle={() => handlePanelStateChange({ bottom: !panelState.bottom })}
-        >
-          {currentRule === 'initState' && <InitStateEditor />}
-          {currentRule !== 'initState' && <AdaptivityEditor />}
-        </BottomPanel>
-        <SidePanel
-          position="right"
-          panelState={panelState}
-          onToggle={() => handlePanelStateChange({ right: !panelState.right })}
-        >
-          <RightMenu />
-        </SidePanel>
-      </div>
+      {hasEditingLock && (
+        <div id="advanced-authoring" className={`advanced-authoring d-none`}>
+          <HeaderNav panelState={panelState} isVisible={panelState.top} />
+          <SidePanel
+            position="left"
+            panelState={panelState}
+            onToggle={() => handlePanelStateChange({ left: !panelState.left })}
+          >
+            <LeftMenu />
+          </SidePanel>
+          <EditingCanvas />
+          <BottomPanel
+            panelState={panelState}
+            onToggle={() => handlePanelStateChange({ bottom: !panelState.bottom })}
+          >
+            {currentRule === 'initState' && <InitStateEditor />}
+            {currentRule !== 'initState' && <AdaptivityEditor />}
+          </BottomPanel>
+          <SidePanel
+            position="right"
+            panelState={panelState}
+            onToggle={() => handlePanelStateChange({ right: !panelState.right })}
+          >
+            <RightMenu />
+          </SidePanel>
+        </div>
+      )}
+      {!hasEditingLock && (
+        <Alert variant="warning">
+          <Alert.Heading>
+            {showEditingLockErrMsg ? 'Editing Session Timed Out' : 'Editing In Progress'}
+          </Alert.Heading>
+          <p>
+            {showEditingLockErrMsg
+              ? `Too much time passed since your last edit and now someone else is currently editing this page. `
+              : `Sorry, someone else is currently editing this page. `}
+            You can try refreshing the browser to see if the current editor is done, or you can use
+            the link below to open a preview of the page.
+          </p>
+          <hr />
+          <Button
+            variant="outline-warning"
+            className="text-dark"
+            onClick={() => window.open(url, windowName)}
+          >
+            Open Preview <i className="las la-external-link-alt ml-1"></i>
+          </Button>
+        </Alert>
+      )}
     </>
   );
 };

--- a/assets/src/apps/authoring/store/activities/actions/saveActivity.ts
+++ b/assets/src/apps/authoring/store/activities/actions/saveActivity.ts
@@ -6,7 +6,6 @@ import {
   IActivity,
   upsertActivity,
 } from '../../../../delivery/store/features/activities/slice';
-import { acquireEditingLock, releaseEditingLock } from '../../app/actions/locking';
 import { selectProjectSlug } from '../../app/slice';
 import { selectResourceId } from '../../page/slice';
 
@@ -18,7 +17,6 @@ export const saveActivity = createAsyncThunk(
     const projectSlug = selectProjectSlug(rootState);
     const resourceId = selectResourceId(rootState);
 
-    await dispatch(acquireEditingLock());
     const changeData: ActivityUpdate = {
       title: activity.title as string,
       objectives: activity.objectives as ObjectiveMap,
@@ -34,7 +32,6 @@ export const saveActivity = createAsyncThunk(
       false,
     );
     console.log('EDIT SAVE RESULTS', { editResults });
-    await dispatch(releaseEditingLock());
     await dispatch(upsertActivity({ activity }));
     return;
   },

--- a/assets/src/apps/authoring/store/groups/layouts/deck/actions/updateActivityPartInheritance.ts
+++ b/assets/src/apps/authoring/store/groups/layouts/deck/actions/updateActivityPartInheritance.ts
@@ -1,5 +1,5 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
-import { ActivityUpdate, BulkActivityUpdate, bulkEdit, edit } from 'data/persistence/activity';
+import { BulkActivityUpdate, bulkEdit } from 'data/persistence/activity';
 import { isEqual } from 'lodash';
 import {
   selectActivityById,
@@ -10,7 +10,6 @@ import {
   DeckLayoutGroup,
   GroupsSlice,
 } from '../../../../../../delivery/store/features/groups/slice';
-import { acquireEditingLock, releaseEditingLock } from '../../../../app/actions/locking';
 import { selectProjectSlug } from '../../../../app/slice';
 import { selectResourceId } from '../../../../page/slice';
 
@@ -62,8 +61,6 @@ export const updateActivityPartInheritance = createAsyncThunk(
       }
     });
     if (activitiesToUpdate.length) {
-      await dispatch(acquireEditingLock());
-      /* console.log('UPDATE: ', { activitiesToUpdate }); */
       dispatch(upsertActivities({ activities: activitiesToUpdate }));
       // TODO: write to server
       const projectSlug = selectProjectSlug(rootState);
@@ -79,7 +76,6 @@ export const updateActivityPartInheritance = createAsyncThunk(
         return changeData;
       });
       await bulkEdit(projectSlug, pageResourceId, updates);
-      await dispatch(releaseEditingLock());
       return;
     }
   },

--- a/assets/src/apps/authoring/store/groups/layouts/deck/actions/updateActivityRules.ts
+++ b/assets/src/apps/authoring/store/groups/layouts/deck/actions/updateActivityRules.ts
@@ -8,7 +8,6 @@ import {
   upsertActivities,
 } from '../../../../../../delivery/store/features/activities/slice';
 import { GroupsSlice } from '../../../../../../delivery/store/features/groups/slice';
-import { acquireEditingLock, releaseEditingLock } from '../../../../app/actions/locking';
 import { selectProjectSlug } from '../../../../app/slice';
 import { selectResourceId } from '../../../../page/slice';
 
@@ -68,12 +67,6 @@ export const updateActivityRules = createAsyncThunk(
       }
     });
     if (activitiesToUpdate.length) {
-      /* console.log(
-        '🚀🚀🚀 > file: updateActivityRules.ts > line 64 > activitiesToUpdate',
-        activitiesToUpdate,
-      ); */
-      await dispatch(acquireEditingLock());
-      /* console.log('UPDATE: ', { activitiesToUpdate }); */
       dispatch(upsertActivities({ activities: activitiesToUpdate }));
       // TODO: write to server
       const projectSlug = selectProjectSlug(rootState);
@@ -89,7 +82,6 @@ export const updateActivityRules = createAsyncThunk(
         return changeData;
       });
       await bulkEdit(projectSlug, pageResourceId, updates);
-      await dispatch(releaseEditingLock());
     }
     return;
   },

--- a/assets/src/apps/authoring/store/page/actions/savePage.ts
+++ b/assets/src/apps/authoring/store/page/actions/savePage.ts
@@ -2,7 +2,6 @@ import { createAsyncThunk } from '@reduxjs/toolkit';
 import { ResourceContent } from 'data/content/resource';
 import { edit, Edited, ResourceUpdate } from 'data/persistence/resource';
 import { selectAll as selectAllGroups } from '../../../../delivery/store/features/groups/slice';
-import { acquireEditingLock, releaseEditingLock } from '../../app/actions/locking';
 import { selectProjectSlug } from '../../app/slice';
 import { RootState } from '../../rootReducer';
 import { PageSlice, PageState, selectRevisionSlug, selectState, setRevisionSlug } from '../slice';
@@ -45,11 +44,7 @@ export const savePage = createAsyncThunk(
       releaseLock: false,
     };
 
-    await dispatch(acquireEditingLock());
-
     const saveResult = await edit(projectSlug, revisionSlug, update, false);
-
-    await dispatch(releaseEditingLock());
 
     if (saveResult.type === 'ServerError') {
       throw new Error(saveResult.message);


### PR DESCRIPTION
### **Includes:** 
* PMP-1635: Add lock status flag to app
* PMP-1636: Ensure that all saving mechanisms use the lock
* PMP-1809: Release lock

### **Instructions to test locked status:**
You'll need access to two separate local accounts, opened in two separate windows and logged in at the same time (one regular, one incognito). In both windows, navigate to the "Curriculum" view of a project that contains an adaptive page. Click on "Edit" in the regular window to load Advanced Authoring, then switch to the incognito window and wait for a locked message to appear next to the "Edit" button. 

![image](https://user-images.githubusercontent.com/633004/136097140-2228e23a-7ac4-41af-a1d3-8c1593b753f9.png)

Next, click "Edit" in the incognito window and verify you see the "Editing in Progress" message and not the Advanced Authoring tool itself.

![image](https://user-images.githubusercontent.com/633004/136097447-011dbf31-eda5-41a9-8422-2d6cb3519573.png)

### **Instructions to test timed-out status:**
If you don't want to wait the full 10 minutes that the server is set to release the lock, you can modify the `@ttl` value on line `38` of `lib/oli/authoring/locks.ex`, then restart your server (don't forget to reset it when you're done).  Same deal as above with the two accounts in two separate windows. In the regular window, click "Edit" to launch the Advanced Authoring tool and acquire the lock. **DO NOT MAKE ANY CHANGES YET**. Wait the full amount of `@ttl` before opening the incognito window and clicking on "Edit", which should acquire the lock. Quickly switch back to the regular window and make a change to the data. You should be redirected to the following screen: 

![image](https://user-images.githubusercontent.com/633004/136098877-06eaece2-e509-4224-84ed-83adf62b5c82.png)
