### PR TITLE
[BUG FIX] Fix datashop issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Bug Fixes
 - Fix a style issue with the workspace footer
+- Fix datashop export dataset name, missing skills
 
 ### Enhancements
 - Add multi input activity

--- a/lib/oli/analytics/datashop.ex
+++ b/lib/oli/analytics/datashop.ex
@@ -52,6 +52,7 @@ defmodule Oli.Analytics.Datashop do
   defp create_messages(project_id) do
     project = Course.get_project!(project_id)
     publication = Publishing.get_latest_published_publication_by_slug(project.slug)
+    dataset_name = Utils.make_dataset_name(project.slug)
 
     Attempts.get_part_attempts_and_users_for_publication(publication.id)
     |> group_part_attempts_by_user_and_part
@@ -61,7 +62,7 @@ defmodule Oli.Analytics.Datashop do
         email: email,
         context_message_id: Utils.make_unique_id(activity_slug, part_id),
         problem_name: Utils.make_problem_name(activity_slug, part_id),
-        dataset_name: Utils.make_dataset_name(project.slug),
+        dataset_name: dataset_name,
         part_attempt: hd(part_attempts),
         publication: publication,
         # a map of resource ids to published revision
@@ -82,8 +83,7 @@ defmodule Oli.Analytics.Datashop do
                   transaction_id: Utils.make_unique_id(activity_slug, part_id),
                   part_attempt: part_attempt,
                   skill_ids:
-                    part_attempt.activity_attempt.revision.objectives[part_attempt.part_id] ||
-                      [],
+                    part_attempt.activity_attempt.revision.objectives[part_attempt.part_id] || [],
                   total_hints_available:
                     Utils.total_hints_available(get_part_from_attempt(part_attempt))
                 }

--- a/lib/oli/delivery/attempts/core.ex
+++ b/lib/oli/delivery/attempts/core.ex
@@ -137,7 +137,7 @@ defmodule Oli.Delivery.Attempts.Core do
         join: user in Oli.Accounts.User,
         on: enrollment.user_id == user.id,
         join: raccess in ResourceAccess,
-        on: user.id == raccess.user_id,
+        on: user.id == raccess.user_id and section.id == raccess.section_id,
         join: rattempt in ResourceAttempt,
         on: raccess.id == rattempt.resource_access_id,
         join: aattempt in ActivityAttempt,
@@ -158,7 +158,6 @@ defmodule Oli.Delivery.Attempts.Core do
         select: %{part_attempt: pattempt, user: user}
       )
     )
-    # TODO: This should be done in the query, but can't get the syntax right
     |> Enum.map(
       &%{
         user: &1.user,


### PR DESCRIPTION
Fix 2 datashop export issues:
1. Dataset name was not consistent across context messages
2. Exports created messages with missing skills because of a bug in the analytics query. `ResourceAccess`es from the wrong sections were being included in the datashop download because the join did not include the section specified by the project publication, so the skills for part attempts from those `ResourceAccess`es could not be found in the project.

Closes #1620 
Closes #1371 