### PR TITLE
[BUGFIX][PMP-1924 / JAN-736] Support the Ability to pick the Variables for a CAPI Sim that is on a Layer

### DIFF
--- a/assets/src/apps/authoring/components/AdaptivityEditor/ConditionsBlockEditor.tsx
+++ b/assets/src/apps/authoring/components/AdaptivityEditor/ConditionsBlockEditor.tsx
@@ -258,7 +258,7 @@ const ConditionsBlockEditor: React.FC<CondtionsBlockEditorProps> = (props) => {
           data-toggle="dropdown"
           aria-haspopup="true"
           aria-expanded="false"
-          onClick={(e) => {
+          onClick={() => {
             ($(`#cb-editor-add-context-trigger`) as any).dropdown('toggle');
           }}
         >
@@ -333,8 +333,7 @@ const ConditionsBlockEditor: React.FC<CondtionsBlockEditorProps> = (props) => {
                   data-toggle="dropdown"
                   aria-haspopup="true"
                   aria-expanded="false"
-                  onClick={(e) => {
-                    // e.stopPropagation();
+                  onClick={() => {
                     ($(`#add-condition-${id}-context-trigger-${index}`) as any).dropdown('toggle');
                   }}
                 >

--- a/assets/src/components/parts/janus-capi-iframe/schema.ts
+++ b/assets/src/components/parts/janus-capi-iframe/schema.ts
@@ -1,3 +1,4 @@
+import { CapiVariableTypes } from '../../../adaptivity/capi';
 import { JSONSchema7Object } from 'json-schema';
 import { JanusAbsolutePositioned, JanusCustomCss } from '../types/parts';
 
@@ -38,13 +39,36 @@ export const adaptivitySchema = ({
   const configData: any = currentModel?.custom?.configData;
   if (configData && Array.isArray(configData)) {
     adaptivitySchema = configData.reduce((acc: any, typeToAdaptivitySchemaMap: any) => {
-      if (typeToAdaptivitySchemaMap.type) {
+      let finalType: CapiVariableTypes = typeToAdaptivitySchemaMap.type;
+      if (finalType) {
+        if (isNaN(finalType)) {
+          console.warn('Type is not a valid CapiVariableType', typeToAdaptivitySchemaMap);
+          // attempt to fix the bad type
+          if (finalType.toString().toLowerCase() === 'number') {
+            finalType = CapiVariableTypes.NUMBER;
+          } else if (finalType.toString().toLowerCase() === 'string') {
+            finalType = CapiVariableTypes.STRING;
+          } else if (finalType.toString().toLowerCase() === 'array') {
+            finalType = CapiVariableTypes.ARRAY;
+          } else if (finalType.toString().toLowerCase() === 'boolean') {
+            finalType = CapiVariableTypes.BOOLEAN;
+          } else if (finalType.toString().toLowerCase() === 'enum') {
+            finalType = CapiVariableTypes.ENUM;
+          } else if (finalType.toString().toLowerCase() === 'math_expr') {
+            finalType = CapiVariableTypes.MATH_EXPR;
+          } else if (finalType.toString().toLowerCase() === 'array_point') {
+            finalType = CapiVariableTypes.ARRAY_POINT;
+          } else {
+            // couldn't fix it, so just remove it
+            return acc;
+          }
+        }
         if (context === 'mutate') {
           if (!typeToAdaptivitySchemaMap.readonly) {
-            acc[typeToAdaptivitySchemaMap.key] = typeToAdaptivitySchemaMap.type;
+            acc[typeToAdaptivitySchemaMap.key] = finalType;
           }
         } else {
-          acc[typeToAdaptivitySchemaMap.key] = typeToAdaptivitySchemaMap.type;
+          acc[typeToAdaptivitySchemaMap.key] = finalType;
         }
       }
       return acc;


### PR DESCRIPTION
Fixes an issue where a bad CAPI sim type value was crashing the variable picker.

![2021-10-06 17 35 54](https://user-images.githubusercontent.com/633004/136286776-717e322a-0f19-44d3-9622-062afd297c5c.gif)


