### PR TITLE
[BUGFIX] [PMP-1949 / JAN-757] Multiline text input does not appear in the variable picker.

### DIFF
--- a/assets/src/components/parts/janus-multi-line-text/authoring-entry.ts
+++ b/assets/src/components/parts/janus-multi-line-text/authoring-entry.ts
@@ -6,7 +6,7 @@ import {
   observedAttributes as apiObservedAttributes,
 } from '../partsApi';
 import MultiLineTextInputAuthor from './MultiLineTextInputAuthor';
-import { createSchema, schema, uiSchema } from './schema';
+import { adaptivitySchema, createSchema, schema, uiSchema } from './schema';
 
 const observedAttributes: string[] = [...apiObservedAttributes];
 const customEvents: any = { ...apiCustomEvents };
@@ -23,5 +23,6 @@ register(MultiLineTextInputAuthor, manifest.authoring.element, observedAttribute
     getSchema: () => schema,
     getUiSchema: () => uiSchema,
     createSchema,
+    getAdaptivitySchema: async () => adaptivitySchema,
   },
 });

--- a/assets/src/components/parts/janus-multi-line-text/schema.ts
+++ b/assets/src/components/parts/janus-multi-line-text/schema.ts
@@ -1,3 +1,4 @@
+import { CapiVariableTypes } from '../../../adaptivity/capi';
 import { JSONSchema7Object } from 'json-schema';
 import { JanusAbsolutePositioned, JanusCustomCss } from '../types/parts';
 
@@ -50,6 +51,12 @@ export const schema: JSONSchema7Object = {
 };
 
 export const uiSchema = {};
+
+export const adaptivitySchema = {
+  enabled: CapiVariableTypes.BOOLEAN,
+  text: CapiVariableTypes.STRING,
+  textLength: CapiVariableTypes.NUMBER,
+};
 
 export const createSchema = (): Partial<MultiLineTextModel> => ({
   enabled: true,


### PR DESCRIPTION
adds missing adaptivitySchema for `janus-multi-line-text`

![image](https://user-images.githubusercontent.com/633004/136413698-9bcbc76d-5051-47ae-a5af-d056f981ea45.png)
