### PR TITLE
[BUGFIX] [PMP-1924 / JAN-736] Variable Picker Nested Selection

### DIFF
--- a/assets/src/apps/authoring/components/AdaptivityEditor/VariablePicker.tsx
+++ b/assets/src/apps/authoring/components/AdaptivityEditor/VariablePicker.tsx
@@ -337,9 +337,7 @@ export const VariablePicker: React.FC<VariablePickerProps> = ({
   useEffect(() => {
     const someParts = (
       activeFilter.includes(FilterItems.SCREEN) ? currentActivityTree : specificActivityTree || []
-    )
-      .slice(-1)
-      .reduce((acc: any, activity: any) => acc.concat(activity.content.partsLayout || []), []);
+    ).reduce((acc: any, activity: any) => acc.concat(activity.content.partsLayout || []), []);
     setAllParts(someParts);
   }, [currentActivityTree, specificActivityTree, activeFilter]);
 


### PR DESCRIPTION
VariablePicker can access any components on nested parents (layers or screens) while viewing "This Screen". Previously you would have to select the layer or sub-screen from the "Other Screens" section.

![2021-10-07 15 00 06](https://user-images.githubusercontent.com/633004/136449292-2b3d4319-bf34-490a-99cf-680b7f37f825.gif)

