### PR TITLE
[BUGFIX] [PMP-1809 / JAN-729] Release lock

### DIFF
--- a/assets/src/apps/authoring/Authoring.tsx
+++ b/assets/src/apps/authoring/Authoring.tsx
@@ -1,3 +1,4 @@
+import { isFirefox } from 'utils/browser';
 import React, { useEffect, useState } from 'react';
 import { Alert, Button } from 'react-bootstrap';
 import { Provider, useDispatch, useSelector } from 'react-redux';
@@ -123,7 +124,14 @@ const Authoring: React.FC<AuthoringProps> = (props: AuthoringProps) => {
   }, [isAppVisible, hasEditingLock]);
 
   useEffect(() => {
-    window.addEventListener('beforeunload', async () => await dispatch(releaseEditingLock()));
+    window.addEventListener('beforeunload', async () =>
+      isFirefox
+        ? setTimeout(async () => {
+            await dispatch(releaseEditingLock());
+          })
+        : await dispatch(releaseEditingLock()),
+    );
+
     setTimeout(() => {
       if (hasEditingLock) {
         setIsAppVisible(true);


### PR DESCRIPTION
FF was not properly releasing the lock. Utilize the same method as Torus from `assets/src/apps/page-editor/listeners.ts`