### PR TITLE
[BUGFIX] [PMP-1958] [DO NOT MERGE YET!] Fix FIB CSS bleeding into Authoring Env

### DIFF
--- a/assets/src/components/parts/janus-fill-blanks/FIBselect2.css
+++ b/assets/src/components/parts/janus-fill-blanks/FIBselect2.css
@@ -1,0 +1,762 @@
+div[data-janus-type='janus-fill-blanks'] .select2-container {
+  box-sizing: border-box;
+  display: inline-block;
+  margin: 0;
+  position: relative;
+  vertical-align: middle;
+}
+div[data-janus-type='janus-fill-blanks'] .select2-container .select2-selection--single {
+  box-sizing: border-box;
+  cursor: pointer;
+  display: block;
+  height: 28px;
+  user-select: none;
+  -webkit-user-select: none;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container
+  .select2-selection--single
+  .select2-selection__rendered {
+  display: block;
+  padding-left: 8px;
+  padding-right: 20px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container[dir='rtl']
+  .select2-selection--single
+  .select2-selection__rendered {
+  padding-right: 8px;
+  padding-left: 20px;
+}
+div[data-janus-type='janus-fill-blanks'] .select2-container .select2-selection--multiple {
+  box-sizing: border-box;
+  cursor: pointer;
+  display: block;
+  min-height: 32px;
+  user-select: none;
+  -webkit-user-select: none;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container
+  .select2-selection--multiple
+  .select2-selection__rendered {
+  display: inline-block;
+  overflow: hidden;
+  padding-left: 8px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+div[data-janus-type='janus-fill-blanks'] .select2-container .select2-search--inline {
+  float: left;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container
+  .select2-search--inline
+  .select2-search__field {
+  box-sizing: border-box;
+  border: none;
+  font-size: 100%;
+  margin-top: 5px;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container
+  .select2-search--inline
+  .select2-search__field::-webkit-search-cancel-button {
+  -webkit-appearance: none;
+}
+div[data-janus-type='janus-fill-blanks'] .select2-dropdown {
+  background-color: white;
+  border: 1px solid #aaa;
+  border-radius: 4px;
+  box-sizing: border-box;
+  display: block;
+  position: absolute;
+  left: -100000px;
+  width: 100%;
+  z-index: 1051;
+}
+div[data-janus-type='janus-fill-blanks'] .select2-results {
+  display: block;
+}
+div[data-janus-type='janus-fill-blanks'] .select2-results__options {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+div[data-janus-type='janus-fill-blanks'] .select2-results__option {
+  padding: 6px;
+  user-select: none;
+  -webkit-user-select: none;
+}
+div[data-janus-type='janus-fill-blanks'] .select2-results__option[aria-selected] {
+  cursor: pointer;
+}
+div[data-janus-type='janus-fill-blanks'] .select2-container--open .select2-dropdown {
+  left: 0;
+}
+div[data-janus-type='janus-fill-blanks'] .select2-container--open .select2-dropdown--above {
+  border-bottom: none;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+div[data-janus-type='janus-fill-blanks'] .select2-container--open .select2-dropdown--below {
+  border-top: none;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+div[data-janus-type='janus-fill-blanks'] .select2-search--dropdown {
+  display: block;
+  padding: 4px;
+}
+div[data-janus-type='janus-fill-blanks'] .select2-search--dropdown .select2-search__field {
+  padding: 4px;
+  width: 100%;
+  box-sizing: border-box;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-search--dropdown
+  .select2-search__field::-webkit-search-cancel-button {
+  -webkit-appearance: none;
+}
+div[data-janus-type='janus-fill-blanks'] .select2-search--dropdown.select2-search--hide {
+  display: none;
+}
+div[data-janus-type='janus-fill-blanks'] .select2-close-mask {
+  border: 0;
+  margin: 0;
+  padding: 0;
+  display: block;
+  position: fixed;
+  left: 0;
+  top: 0;
+  min-height: 100%;
+  min-width: 100%;
+  height: auto;
+  width: auto;
+  opacity: 0;
+  z-index: 99;
+  background-color: #fff;
+  filter: alpha(opacity=0);
+}
+div[data-janus-type='janus-fill-blanks'] .select2-hidden-accessible {
+  border: 0 !important;
+  clip: rect(0 0 0 0) !important;
+  height: 1px !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  padding: 0 !important;
+  position: absolute !important;
+  width: 1px !important;
+}
+div[data-janus-type='janus-fill-blanks'] .select2-container--default .select2-selection--single {
+  background-color: #fff;
+  border: 1px solid #aaa;
+  border-radius: 4px;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .select2-selection--single
+  .select2-selection__rendered {
+  color: #444;
+  line-height: 28px;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .select2-selection--single
+  .select2-selection__clear {
+  cursor: pointer;
+  float: right;
+  font-weight: bold;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .select2-selection--single
+  .select2-selection__placeholder {
+  color: #999;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .select2-selection--single
+  .select2-selection__arrow {
+  height: 26px;
+  position: absolute;
+  top: 1px;
+  right: 1px;
+  width: 20px;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .select2-selection--single
+  .select2-selection__arrow
+  b {
+  border-color: #888 transparent transparent transparent;
+  border-style: solid;
+  border-width: 5px 4px 0 4px;
+  height: 0;
+  left: 50%;
+  margin-left: -4px;
+  margin-top: -2px;
+  position: absolute;
+  top: 50%;
+  width: 0;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default[dir='rtl']
+  .select2-selection--single
+  .select2-selection__clear {
+  float: left;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default[dir='rtl']
+  .select2-selection--single
+  .select2-selection__arrow {
+  left: 1px;
+  right: auto;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default.select2-container--disabled
+  .select2-selection--single {
+  background-color: #eee;
+  cursor: default;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default.select2-container--disabled
+  .select2-selection--single
+  .select2-selection__clear {
+  display: none;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default.select2-container--open
+  .select2-selection--single
+  .select2-selection__arrow
+  b {
+  border-color: transparent transparent #888 transparent;
+  border-width: 0 4px 5px 4px;
+}
+div[data-janus-type='janus-fill-blanks'] .select2-container--default .select2-selection--multiple {
+  background-color: white;
+  border: 1px solid #aaa;
+  border-radius: 4px;
+  cursor: text;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .select2-selection--multiple
+  .select2-selection__rendered {
+  box-sizing: border-box;
+  list-style: none;
+  margin: 0;
+  padding: 0 5px;
+  width: 100%;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .select2-selection--multiple
+  .select2-selection__placeholder {
+  color: #999;
+  margin-top: 5px;
+  float: left;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .select2-selection--multiple
+  .select2-selection__clear {
+  cursor: pointer;
+  float: right;
+  font-weight: bold;
+  margin-top: 5px;
+  margin-right: 10px;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .select2-selection--multiple
+  .select2-selection__choice {
+  background-color: #e4e4e4;
+  border: 1px solid #aaa;
+  border-radius: 4px;
+  cursor: default;
+  float: left;
+  margin-right: 5px;
+  margin-top: 5px;
+  padding: 0 5px;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .select2-selection--multiple
+  .select2-selection__choice__remove {
+  color: #999;
+  cursor: pointer;
+  display: inline-block;
+  font-weight: bold;
+  margin-right: 2px;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .select2-selection--multiple
+  .select2-selection__choice__remove:hover {
+  color: #333;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default[dir='rtl']
+  .select2-selection--multiple
+  .select2-selection__choice,
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default[dir='rtl']
+  .select2-selection--multiple
+  .select2-selection__placeholder,
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default[dir='rtl']
+  .select2-selection--multiple
+  .select2-search--inline {
+  float: right;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default[dir='rtl']
+  .select2-selection--multiple
+  .select2-selection__choice {
+  margin-left: 5px;
+  margin-right: auto;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default[dir='rtl']
+  .select2-selection--multiple
+  .select2-selection__choice__remove {
+  margin-left: 2px;
+  margin-right: auto;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default.select2-container--focus
+  .select2-selection--multiple {
+  border: solid black 1px;
+  outline: 0;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default.select2-container--disabled
+  .select2-selection--multiple {
+  background-color: #eee;
+  cursor: default;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default.select2-container--disabled
+  .select2-selection__choice__remove {
+  display: none;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default.select2-container--open.select2-container--above
+  .select2-selection--single,
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default.select2-container--open.select2-container--above
+  .select2-selection--multiple {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default.select2-container--open.select2-container--below
+  .select2-selection--single,
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default.select2-container--open.select2-container--below
+  .select2-selection--multiple {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .select2-search--dropdown
+  .select2-search__field {
+  border: 1px solid #aaa;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .select2-search--inline
+  .select2-search__field {
+  background: transparent;
+  border: none;
+  outline: 0;
+  box-shadow: none;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .select2-results
+  > .select2-results__options {
+  max-height: 200px;
+  overflow-y: auto;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .select2-results__option[role='group'] {
+  padding: 0;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .select2-results__option[aria-disabled='true'] {
+  color: #999;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .select2-results__option[aria-selected='true'] {
+  background-color: #ddd;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .select2-results__option
+  .select2-results__option {
+  padding-left: 1em;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .select2-results__option
+  .select2-results__option
+  .select2-results__group {
+  padding-left: 0;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .select2-results__option
+  .select2-results__option
+  .select2-results__option {
+  margin-left: -1em;
+  padding-left: 2em;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .select2-results__option
+  .select2-results__option
+  .select2-results__option
+  .select2-results__option {
+  margin-left: -2em;
+  padding-left: 3em;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .select2-results__option
+  .select2-results__option
+  .select2-results__option
+  .select2-results__option
+  .select2-results__option {
+  margin-left: -3em;
+  padding-left: 4em;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .select2-results__option
+  .select2-results__option
+  .select2-results__option
+  .select2-results__option
+  .select2-results__option
+  .select2-results__option {
+  margin-left: -4em;
+  padding-left: 5em;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .select2-results__option
+  .select2-results__option
+  .select2-results__option
+  .select2-results__option
+  .select2-results__option
+  .select2-results__option
+  .select2-results__option {
+  margin-left: -5em;
+  padding-left: 6em;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .select2-results__option--highlighted[aria-selected] {
+  background-color: #5897fb;
+  color: white;
+}
+div[data-janus-type='janus-fill-blanks'] .select2-container--default .select2-results__group {
+  cursor: default;
+  display: block;
+  padding: 6px;
+}
+div[data-janus-type='janus-fill-blanks'] .select2-container--classic .select2-selection--single {
+  background-color: #f7f7f7;
+  border: 1px solid #aaa;
+  border-radius: 4px;
+  outline: 0;
+  background-image: -webkit-linear-gradient(top, white 50%, #eeeeee 100%);
+  background-image: -o-linear-gradient(top, white 50%, #eeeeee 100%);
+  background-image: linear-gradient(to bottom, white 50%, #eeeeee 100%);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#FFFFFFFF', endColorstr='#FFEEEEEE', GradientType=0);
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--classic
+  .select2-selection--single:focus {
+  border: 1px solid #5897fb;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--classic
+  .select2-selection--single
+  .select2-selection__rendered {
+  color: #444;
+  line-height: 28px;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--classic
+  .select2-selection--single
+  .select2-selection__clear {
+  cursor: pointer;
+  float: right;
+  font-weight: bold;
+  margin-right: 10px;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--classic
+  .select2-selection--single
+  .select2-selection__placeholder {
+  color: #999;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--classic
+  .select2-selection--single
+  .select2-selection__arrow {
+  background-color: #ddd;
+  border: none;
+  border-left: 1px solid #aaa;
+  border-top-right-radius: 4px;
+  border-bottom-right-radius: 4px;
+  height: 26px;
+  position: absolute;
+  top: 1px;
+  right: 1px;
+  width: 20px;
+  background-image: -webkit-linear-gradient(top, #eeeeee 50%, #cccccc 100%);
+  background-image: -o-linear-gradient(top, #eeeeee 50%, #cccccc 100%);
+  background-image: linear-gradient(to bottom, #eeeeee 50%, #cccccc 100%);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#FFEEEEEE', endColorstr='#FFCCCCCC', GradientType=0);
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--classic
+  .select2-selection--single
+  .select2-selection__arrow
+  b {
+  border-color: #888 transparent transparent transparent;
+  border-style: solid;
+  border-width: 5px 4px 0 4px;
+  height: 0;
+  left: 50%;
+  margin-left: -4px;
+  margin-top: -2px;
+  position: absolute;
+  top: 50%;
+  width: 0;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--classic[dir='rtl']
+  .select2-selection--single
+  .select2-selection__clear {
+  float: left;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--classic[dir='rtl']
+  .select2-selection--single
+  .select2-selection__arrow {
+  border: none;
+  border-right: 1px solid #aaa;
+  border-radius: 0;
+  border-top-left-radius: 4px;
+  border-bottom-left-radius: 4px;
+  left: 1px;
+  right: auto;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--classic.select2-container--open
+  .select2-selection--single {
+  border: 1px solid #5897fb;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--classic.select2-container--open
+  .select2-selection--single
+  .select2-selection__arrow {
+  background: transparent;
+  border: none;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--classic.select2-container--open
+  .select2-selection--single
+  .select2-selection__arrow
+  b {
+  border-color: transparent transparent #888 transparent;
+  border-width: 0 4px 5px 4px;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--classic.select2-container--open.select2-container--above
+  .select2-selection--single {
+  border-top: none;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  background-image: -webkit-linear-gradient(top, white 0%, #eeeeee 50%);
+  background-image: -o-linear-gradient(top, white 0%, #eeeeee 50%);
+  background-image: linear-gradient(to bottom, white 0%, #eeeeee 50%);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#FFFFFFFF', endColorstr='#FFEEEEEE', GradientType=0);
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--classic.select2-container--open.select2-container--below
+  .select2-selection--single {
+  border-bottom: none;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  background-image: -webkit-linear-gradient(top, #eeeeee 50%, white 100%);
+  background-image: -o-linear-gradient(top, #eeeeee 50%, white 100%);
+  background-image: linear-gradient(to bottom, #eeeeee 50%, white 100%);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#FFEEEEEE', endColorstr='#FFFFFFFF', GradientType=0);
+}
+div[data-janus-type='janus-fill-blanks'] .select2-container--classic .select2-selection--multiple {
+  background-color: white;
+  border: 1px solid #aaa;
+  border-radius: 4px;
+  cursor: text;
+  outline: 0;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--classic
+  .select2-selection--multiple:focus {
+  border: 1px solid #5897fb;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--classic
+  .select2-selection--multiple
+  .select2-selection__rendered {
+  list-style: none;
+  margin: 0;
+  padding: 0 5px;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--classic
+  .select2-selection--multiple
+  .select2-selection__clear {
+  display: none;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--classic
+  .select2-selection--multiple
+  .select2-selection__choice {
+  background-color: #e4e4e4;
+  border: 1px solid #aaa;
+  border-radius: 4px;
+  cursor: default;
+  float: left;
+  margin-right: 5px;
+  margin-top: 5px;
+  padding: 0 5px;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--classic
+  .select2-selection--multiple
+  .select2-selection__choice__remove {
+  color: #888;
+  cursor: pointer;
+  display: inline-block;
+  font-weight: bold;
+  margin-right: 2px;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--classic
+  .select2-selection--multiple
+  .select2-selection__choice__remove:hover {
+  color: #555;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--classic[dir='rtl']
+  .select2-selection--multiple
+  .select2-selection__choice {
+  float: right;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--classic[dir='rtl']
+  .select2-selection--multiple
+  .select2-selection__choice {
+  margin-left: 5px;
+  margin-right: auto;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--classic[dir='rtl']
+  .select2-selection--multiple
+  .select2-selection__choice__remove {
+  margin-left: 2px;
+  margin-right: auto;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--classic.select2-container--open
+  .select2-selection--multiple {
+  border: 1px solid #5897fb;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--classic.select2-container--open.select2-container--above
+  .select2-selection--multiple {
+  border-top: none;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--classic.select2-container--open.select2-container--below
+  .select2-selection--multiple {
+  border-bottom: none;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--classic
+  .select2-search--dropdown
+  .select2-search__field {
+  border: 1px solid #aaa;
+  outline: 0;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--classic
+  .select2-search--inline
+  .select2-search__field {
+  outline: 0;
+  box-shadow: none;
+}
+div[data-janus-type='janus-fill-blanks'] .select2-container--classic .select2-dropdown {
+  background-color: white;
+  border: 1px solid transparent;
+}
+div[data-janus-type='janus-fill-blanks'] .select2-container--classic .select2-dropdown--above {
+  border-bottom: none;
+}
+div[data-janus-type='janus-fill-blanks'] .select2-container--classic .select2-dropdown--below {
+  border-top: none;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--classic
+  .select2-results
+  > .select2-results__options {
+  max-height: 200px;
+  overflow-y: auto;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--classic
+  .select2-results__option[role='group'] {
+  padding: 0;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--classic
+  .select2-results__option[aria-disabled='true'] {
+  color: grey;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--classic
+  .select2-results__option--highlighted[aria-selected] {
+  background-color: #3875d7;
+  color: white;
+}
+div[data-janus-type='janus-fill-blanks'] .select2-container--classic .select2-results__group {
+  cursor: default;
+  display: block;
+  padding: 6px;
+}
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--classic.select2-container--open
+  .select2-dropdown {
+  border-color: #5897fb;
+}

--- a/assets/src/components/parts/janus-fill-blanks/FillBlanks.css
+++ b/assets/src/components/parts/janus-fill-blanks/FillBlanks.css
@@ -1,29 +1,24 @@
 @import url(https://fonts.googleapis.com/css?family=Roboto:300,400);
 
-/*** Dropdown ***/
-.dropdown-blot {
+div[data-janus-type='janus-fill-blanks'] .dropdown-blot {
   display: inline-block;
   vertical-align: top;
   margin: 0 1px;
 }
-
-.dropdown-container {
+div[data-janus-type='janus-fill-blanks'] .dropdown-container {
   display: inline-block;
   position: relative;
   vertical-align: top;
 }
-
-.dropdown-option-wrapper {
+div[data-janus-type='janus-fill-blanks'] .dropdown-option-wrapper {
   width: auto;
   padding: 5px;
   background: 0 0;
 }
-
-.dropdown-option {
+div[data-janus-type='janus-fill-blanks'] .dropdown-option {
   width: auto;
 }
-
-.dropdown-option-select {
+div[data-janus-type='janus-fill-blanks'] .dropdown-option-select {
   pointer-events: auto;
   width: 16px;
   height: 16px;
@@ -37,14 +32,12 @@
   cursor: pointer;
   transition: background-color 0.3s ease-in-out;
 }
-
-.dropdown-option-select:focus,
-.dropdown-option-select:hover {
+div[data-janus-type='janus-fill-blanks'] .dropdown-option-select:focus,
+div[data-janus-type='janus-fill-blanks'] .dropdown-option-select:hover {
   background-color: rgba(52, 210, 175, 0.3);
   outline: 0;
 }
-
-.dropdown-option__correct .dropdown-option-select {
+div[data-janus-type='janus-fill-blanks'] .dropdown-option__correct .dropdown-option-select {
   background-color: #34d2af;
   background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="8" height="6" viewBox="0 0 8 6">  <g fill="none" fill-rule="evenodd" transform="translate(-3 -4)">  <rect width="14" height="14" fill="#D8D8D8" opacity="0"/>  <polygon fill="#FFF" points="5.857 10 3 7.121 3.806 6.309 5.857 8.37 10.194 4 11 4.818"/>  </g>  </svg>');
   background-size: 50%;
@@ -52,12 +45,10 @@
   background-repeat: no-repeat;
   border: none;
 }
-
-.dropdown {
+div[data-janus-type='janus-fill-blanks'] .dropdown {
   display: none !important;
 }
-
-.dropdown-option-input {
+div[data-janus-type='janus-fill-blanks'] .dropdown-option-input {
   display: inline-block;
   word-wrap: normal;
   margin-right: 3px;
@@ -70,25 +61,20 @@
   min-height: 30px;
   padding: 0 5px 0 3px;
 }
-
-.dropdown-option-input:focus {
+div[data-janus-type='janus-fill-blanks'] .dropdown-option-input:focus {
   outline: 0;
   border-bottom: 1px solid #333;
 }
-
-.override-top {
+div[data-janus-type='janus-fill-blanks'] .override-top {
   top: auto !important;
 }
-
-.override-top .select2-dropdown {
+div[data-janus-type='janus-fill-blanks'] .override-top .select2-dropdown {
   box-shadow: 0 -1px 12px -5px #000;
 }
-
-.override-left {
+div[data-janus-type='janus-fill-blanks'] .override-left {
   left: auto !important;
 }
-
-.select2-container {
+div[data-janus-type='janus-fill-blanks'] .select2-container {
   width: auto !important;
   height: auto;
   min-height: 26px;
@@ -97,8 +83,7 @@
   vertical-align: top;
   display: initial !important;
 }
-
-.select2-dropdown {
+div[data-janus-type='janus-fill-blanks'] .select2-dropdown {
   min-width: 130px;
   width: auto !important;
   position: relative;
@@ -108,58 +93,74 @@
   border: none;
   overflow: hidden;
 }
-
-.selection:focus {
+div[data-janus-type='janus-fill-blanks'] .selection:focus {
   outline: 0;
 }
-
-.select2-container--default .select2-selection--single .select2-selection__arrow {
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .select2-selection--single
+  .select2-selection__arrow {
   pointer-events: none;
   top: 0;
   bottom: 0;
   margin: auto;
 }
-
-.select2-container--default .select2-selection--single .select2-selection__arrow b {
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .select2-selection--single
+  .select2-selection__arrow
+  b {
   border-color: #253445 transparent transparent transparent;
 }
-
-h3 .select2-container--default .select2-selection--single .select2-selection__arrow {
+div[data-janus-type='janus-fill-blanks']
+  h3
+  .select2-container--default
+  .select2-selection--single
+  .select2-selection__arrow {
   top: -8px;
 }
-
-p .select2-container--default .select2-selection--single .select2-selection__arrow {
+div[data-janus-type='janus-fill-blanks']
+  p
+  .select2-container--default
+  .select2-selection--single
+  .select2-selection__arrow {
   top: -3px;
 }
-
-code .select2-container--default .select2-selection--single .select2-selection__arrow {
+div[data-janus-type='janus-fill-blanks']
+  code
+  .select2-container--default
+  .select2-selection--single
+  .select2-selection__arrow {
   top: -5px;
 }
-
-blockquote .select2-container--default .select2-selection--single .select2-selection__arrow {
+div[data-janus-type='janus-fill-blanks']
+  blockquote
+  .select2-container--default
+  .select2-selection--single
+  .select2-selection__arrow {
   top: -5px;
 }
-
-.select2-container--default.select2-container--open
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default.select2-container--open
   .select2-selection--single
   .select2-selection__arrow
   b {
   border-color: transparent transparent #253445 transparent;
 }
-
-.select2-container--default .select2-selection--single {
+div[data-janus-type='janus-fill-blanks'] .select2-container--default .select2-selection--single {
   position: relative;
   border: none;
   width: auto;
   outline: 0;
   height: 35px !important;
 }
-
-.select2-container--default .select2-selection--single .select2-selection__rendered {
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .select2-selection--single
+  .select2-selection__rendered {
   padding-right: 25px;
 }
-
-.select2-selection__rendered {
+div[data-janus-type='janus-fill-blanks'] .select2-selection__rendered {
   min-height: 26px;
   min-width: 120px;
   width: auto;
@@ -173,73 +174,76 @@ blockquote .select2-container--default .select2-selection--single .select2-selec
   font-size: 1em;
   margin-top: -1px;
 }
-
-.select2-selection__rendered:focus,
-.select2-selection__rendered:hover {
+div[data-janus-type='janus-fill-blanks'] .select2-selection__rendered:focus,
+div[data-janus-type='janus-fill-blanks'] .select2-selection__rendered:hover {
   background-color: #d9d9de;
 }
-
-.select2-selection__rendered:focus .dropdown-menu {
+div[data-janus-type='janus-fill-blanks'] .select2-selection__rendered:focus .dropdown-menu {
   display: block;
+  /* .select2-container--focus .select2-selection__rendered {
+   border-bottom: 1px solid #2196f3;
+   } */
 }
-
-/* .select2-container--focus .select2-selection__rendered {
-  border-bottom: 1px solid #2196f3;
-} */
-
-.select2-container--disabled .select2-selection__rendered {
+div[data-janus-type='janus-fill-blanks'] .select2-container--disabled .select2-selection__rendered {
   background-color: rgba(0, 0, 0, 0.07);
   cursor: not-allowed;
   color: rgba(0, 0, 0, 0.8);
   border-bottom: none;
 }
-
-.select2-container .select2-selection--single .select2-selection__rendered {
+div[data-janus-type='janus-fill-blanks']
+  .select2-container
+  .select2-selection--single
+  .select2-selection__rendered {
   white-space: normal;
 }
-
-#scene_Configuration .select2-selection__rendered {
+div[data-janus-type='janus-fill-blanks'] #scene_Configuration .select2-selection__rendered {
   white-space: nowrap;
 }
-
-.select2-container--default.select2-container--disabled .select2-selection--single {
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default.select2-container--disabled
+  .select2-selection--single {
   background-color: transparent;
 }
-
-.select2-results {
+div[data-janus-type='janus-fill-blanks'] .select2-results {
   width: auto;
 }
-
-.config .select2-results {
+div[data-janus-type='janus-fill-blanks'] .config .select2-results {
   padding-bottom: 40px;
 }
-
-.select2-container--default .select2-results > .select2-results__options {
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .select2-results
+  > .select2-results__options {
   width: auto;
   max-width: 100%;
   padding: 0;
   max-height: 160px;
 }
-
-.select2-container--default .select2-results > .select2-results__options::-webkit-scrollbar {
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .select2-results
+  > .select2-results__options::-webkit-scrollbar {
   width: 14px;
   height: 14px;
   background: 0 0;
 }
-
-.select2-container--default .select2-results > .select2-results__options::-webkit-scrollbar-thumb {
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .select2-results
+  > .select2-results__options::-webkit-scrollbar-thumb {
   border-radius: 10px;
   background: #c1c1c1;
   border: 3px solid transparent;
   background-clip: padding-box;
 }
-
-.select2-container--default .select2-results > .select2-results__options::-webkit-scrollbar-track {
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .select2-results
+  > .select2-results__options::-webkit-scrollbar-track {
   background: 0 0;
   border-radius: 10px;
 }
-
-.select2-results__option {
+div[data-janus-type='janus-fill-blanks'] .select2-results__option {
   font-size: 1rem;
   line-height: 1;
   max-width: 100%;
@@ -247,47 +251,66 @@ blockquote .select2-container--default .select2-selection--single .select2-selec
   padding: 5px 10px;
   word-wrap: break-word;
 }
-
-.select2-results__option::before {
+div[data-janus-type='janus-fill-blanks'] .select2-results__option::before {
   display: none;
 }
-
-.select2-container--default .select2-results__option--highlighted[data-selected],
-.select2-container--default .select2-results__option--highlighted[aria-selected],
-.select2-container--default .select2-results__option--highlighted {
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .select2-results__option--highlighted[data-selected],
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .select2-results__option--highlighted[aria-selected],
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .select2-results__option--highlighted {
   background-color: #eee;
   color: rgba(0, 0, 0, 0.87);
 }
-
-.select2-container--default
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
   .select2-dropdown:not(.config)
   .select2-results__option[aria-selected='true'],
-.select2-container--default
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
   .select2-dropdown:not(.config)
   .select2-results__option[data-selected='true'] {
   background-color: rgba(0, 0, 0, 0.12);
   color: rgba(0, 0, 0, 0.87);
 }
-
-.select2-container--default .config .select2-results__option {
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .config
+  .select2-results__option {
   pointer-events: none;
 }
-
-.select2-container--default .config .select2-results__option:last-child {
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .config
+  .select2-results__option:last-child {
   position: absolute;
   bottom: 0;
   width: 100%;
 }
-
-.select2-container--default .config .select2-results__option--highlighted[aria-selected],
-.select2-container--default .config .select2-results__option[aria-selected='true'],
-.select2-container--default .config .select2-results__option--highlighted[data-selected],
-.select2-container--default .config .select2-results__option[data-selected='true'] {
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .config
+  .select2-results__option--highlighted[aria-selected],
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .config
+  .select2-results__option[aria-selected='true'],
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .config
+  .select2-results__option--highlighted[data-selected],
+div[data-janus-type='janus-fill-blanks']
+  .select2-container--default
+  .config
+  .select2-results__option[data-selected='true'] {
   background-color: transparent;
 }
-
-.select2-selection__rendered .incorrect-icon,
-.select2-selection__rendered::before {
+div[data-janus-type='janus-fill-blanks'] .select2-selection__rendered .incorrect-icon,
+div[data-janus-type='janus-fill-blanks'] .select2-selection__rendered::before {
   content: '';
   display: none;
   pointer-events: auto;
@@ -306,12 +329,17 @@ blockquote .select2-container--default .select2-selection--single .select2-selec
   margin-right: 5px;
   vertical-align: middle;
 }
-
-.dropdown.correct + .select2-container .select2-selection__rendered::before {
+div[data-janus-type='janus-fill-blanks']
+  .dropdown.correct
+  + .select2-container
+  .select2-selection__rendered::before {
   display: inline-block;
 }
-
-.dropdown.incorrect + .select2-container .select2-selection__rendered .incorrect-icon {
+div[data-janus-type='janus-fill-blanks']
+  .dropdown.incorrect
+  + .select2-container
+  .select2-selection__rendered
+  .incorrect-icon {
   display: inline-block;
   background-color: #f96155;
   background-image: none;
@@ -322,72 +350,104 @@ blockquote .select2-container--default .select2-selection--single .select2-selec
   box-sizing: border-box;
   text-align: left;
 }
-
-.dropdown.correct + .select2-container .select2-selection__rendered {
+div[data-janus-type='janus-fill-blanks']
+  .dropdown.correct
+  + .select2-container
+  .select2-selection__rendered {
   border-bottom: none;
   background-color: #daf6ee !important;
 }
-
-.dropdown.correct + .select2-container .select2-selection__rendered:hover {
+div[data-janus-type='janus-fill-blanks']
+  .dropdown.correct
+  + .select2-container
+  .select2-selection__rendered:hover {
   background-color: #b9eedf !important;
 }
-
-.dropdown.incorrect + .select2-container .select2-selection__rendered {
+div[data-janus-type='janus-fill-blanks']
+  .dropdown.incorrect
+  + .select2-container
+  .select2-selection__rendered {
   border-bottom: none;
   background-color: #fddfdd !important;
 }
-
-.dropdown.incorrect + .select2-container .select2-selection__rendered:hover {
+div[data-janus-type='janus-fill-blanks']
+  .dropdown.incorrect
+  + .select2-container
+  .select2-selection__rendered:hover {
   background-color: #fbb7b2 !important;
 }
-
-.dropdown.correct + .select2-container .select2-selection--single:focus {
+div[data-janus-type='janus-fill-blanks']
+  .dropdown.correct
+  + .select2-container
+  .select2-selection--single:focus {
   outline: -webkit-focus-ring-color auto 5px;
 }
-
-.dropdown.incorrect + .select2-container .select2-selection--single:focus {
+div[data-janus-type='janus-fill-blanks']
+  .dropdown.incorrect
+  + .select2-container
+  .select2-selection--single:focus {
   outline: -webkit-focus-ring-color auto 5px;
 }
-
-p .dropdown-blot .select2-container .select2-selection--single .select2-selection__rendered {
+div[data-janus-type='janus-fill-blanks']
+  p
+  .dropdown-blot
+  .select2-container
+  .select2-selection--single
+  .select2-selection__rendered {
   line-height: 1.85em;
   height: 30px !important;
   margin-top: 1px;
 }
-
-h1 .dropdown-blot .select2-container .select2-selection--single .select2-selection__rendered {
+div[data-janus-type='janus-fill-blanks']
+  h1
+  .dropdown-blot
+  .select2-container
+  .select2-selection--single
+  .select2-selection__rendered {
   line-height: 1.4em;
   min-height: 69px;
   margin-top: 16px;
 }
-
-h2 .dropdown-blot .select2-container .select2-selection--single .select2-selection__rendered {
+div[data-janus-type='janus-fill-blanks']
+  h2
+  .dropdown-blot
+  .select2-container
+  .select2-selection--single
+  .select2-selection__rendered {
   line-height: 1.5em;
   min-height: 49px;
   margin-top: 4px;
 }
-
-h3 .dropdown-blot .select2-container .select2-selection--single .select2-selection__rendered {
+div[data-janus-type='janus-fill-blanks']
+  h3
+  .dropdown-blot
+  .select2-container
+  .select2-selection--single
+  .select2-selection__rendered {
   line-height: 1.7em;
   min-height: 36px;
   margin-top: 3px;
 }
-
-h3
+div[data-janus-type='janus-fill-blanks']
+  h3
   .dropdown-blot
   .select2-container
   .select2-selection--single
   .select2-selection__rendered::before {
   margin-bottom: 2px;
 }
-
-code .dropdown-blot .select2-container .select2-selection--single .select2-selection__rendered {
+div[data-janus-type='janus-fill-blanks']
+  code
+  .dropdown-blot
+  .select2-container
+  .select2-selection--single
+  .select2-selection__rendered {
   line-height: 2em;
   min-height: 27px;
   margin-top: 0;
 }
-
-blockquote
+div[data-janus-type='janus-fill-blanks']
+  blockquote
   .dropdown-blot
   .select2-container
   .select2-selection--single
@@ -396,24 +456,36 @@ blockquote
   min-height: 30px;
   margin-top: -4px;
 }
-
-sup .dropdown-blot .select2-container .select2-selection--single .select2-selection__rendered {
+div[data-janus-type='janus-fill-blanks']
+  sup
+  .dropdown-blot
+  .select2-container
+  .select2-selection--single
+  .select2-selection__rendered {
   line-height: 1.6;
   min-height: 22px;
   margin-top: 4px;
 }
-
-sub .dropdown-blot .select2-container .select2-selection--single .select2-selection__rendered {
+div[data-janus-type='janus-fill-blanks']
+  sub
+  .dropdown-blot
+  .select2-container
+  .select2-selection--single
+  .select2-selection__rendered {
   line-height: 1.6;
   min-height: 22px;
   margin-top: 10px;
 }
-
-s .dropdown-blot .select2-container .select2-selection--single .select2-selection__rendered {
+div[data-janus-type='janus-fill-blanks']
+  s
+  .dropdown-blot
+  .select2-container
+  .select2-selection--single
+  .select2-selection__rendered {
   text-decoration: line-through;
 }
-
-p
+div[data-janus-type='janus-fill-blanks']
+  p
   .dropdown-blot
   .config
   + .select2-container
@@ -423,8 +495,8 @@ p
   min-height: 31px;
   margin-top: 1px;
 }
-
-h1
+div[data-janus-type='janus-fill-blanks']
+  h1
   .dropdown-blot
   .config
   + .select2-container
@@ -434,8 +506,8 @@ h1
   min-height: 70px;
   margin-top: 16px;
 }
-
-h2
+div[data-janus-type='janus-fill-blanks']
+  h2
   .dropdown-blot
   .config
   + .select2-container
@@ -445,8 +517,8 @@ h2
   min-height: 50px;
   margin-top: 4px;
 }
-
-h3
+div[data-janus-type='janus-fill-blanks']
+  h3
   .dropdown-blot
   .config
   + .select2-container
@@ -456,8 +528,8 @@ h3
   min-height: 37px;
   margin-top: -3px;
 }
-
-h3
+div[data-janus-type='janus-fill-blanks']
+  h3
   .dropdown-blot
   .config
   + .select2-container
@@ -465,8 +537,8 @@ h3
   .select2-selection__rendered::before {
   margin-bottom: 2px;
 }
-
-code
+div[data-janus-type='janus-fill-blanks']
+  code
   .dropdown-blot
   .config
   + .select2-container
@@ -476,8 +548,8 @@ code
   min-height: 28px;
   margin-top: 0;
 }
-
-blockquote
+div[data-janus-type='janus-fill-blanks']
+  blockquote
   .dropdown-blot
   .config
   + .select2-container
@@ -487,8 +559,8 @@ blockquote
   min-height: 31px;
   margin-top: -5px;
 }
-
-sup
+div[data-janus-type='janus-fill-blanks']
+  sup
   .dropdown-blot
   .config
   + .select2-container
@@ -498,8 +570,8 @@ sup
   min-height: 22px;
   margin-top: 2px;
 }
-
-sub
+div[data-janus-type='janus-fill-blanks']
+  sub
   .dropdown-blot
   .config
   + .select2-container
@@ -509,8 +581,8 @@ sub
   min-height: 22px;
   margin-top: 11px;
 }
-
-s
+div[data-janus-type='janus-fill-blanks']
+  s
   .dropdown-blot
   .config
   + .select2-container
@@ -518,20 +590,30 @@ s
   .select2-selection__rendered {
   text-decoration: line-through;
 }
-
-h1 sup .dropdown-blot .select2-container .select2-selection--single .select2-selection__rendered {
+div[data-janus-type='janus-fill-blanks']
+  h1
+  sup
+  .dropdown-blot
+  .select2-container
+  .select2-selection--single
+  .select2-selection__rendered {
   line-height: 1.2;
   min-height: 49px;
   margin-top: 16px;
 }
-
-h1 sub .dropdown-blot .select2-container .select2-selection--single .select2-selection__rendered {
+div[data-janus-type='janus-fill-blanks']
+  h1
+  sub
+  .dropdown-blot
+  .select2-container
+  .select2-selection--single
+  .select2-selection__rendered {
   line-height: 1.2;
   min-height: 49px;
   margin-top: 38px;
 }
-
-h1
+div[data-janus-type='janus-fill-blanks']
+  h1
   sup
   .dropdown-blot
   .config
@@ -542,8 +624,8 @@ h1
   min-height: 50px;
   margin-top: 16px;
 }
-
-h1
+div[data-janus-type='janus-fill-blanks']
+  h1
   sub
   .dropdown-blot
   .config
@@ -554,20 +636,30 @@ h1
   min-height: 50px;
   margin-top: 38px;
 }
-
-h2 sup .dropdown-blot .select2-container .select2-selection--single .select2-selection__rendered {
+div[data-janus-type='janus-fill-blanks']
+  h2
+  sup
+  .dropdown-blot
+  .select2-container
+  .select2-selection--single
+  .select2-selection__rendered {
   line-height: 1.2;
   min-height: 33px;
   margin-top: 7px;
 }
-
-h2 sub .dropdown-blot .select2-container .select2-selection--single .select2-selection__rendered {
+div[data-janus-type='janus-fill-blanks']
+  h2
+  sub
+  .dropdown-blot
+  .select2-container
+  .select2-selection--single
+  .select2-selection__rendered {
   line-height: 1.2;
   min-height: 33px;
   margin-top: 21px;
 }
-
-h2
+div[data-janus-type='janus-fill-blanks']
+  h2
   sup
   .dropdown-blot
   .config
@@ -578,8 +670,8 @@ h2
   min-height: 34px;
   margin-top: 7px;
 }
-
-h2
+div[data-janus-type='janus-fill-blanks']
+  h2
   sub
   .dropdown-blot
   .config
@@ -590,20 +682,30 @@ h2
   min-height: 34px;
   margin-top: 21px;
 }
-
-h3 sup .dropdown-blot .select2-container .select2-selection--single .select2-selection__rendered {
+div[data-janus-type='janus-fill-blanks']
+  h3
+  sup
+  .dropdown-blot
+  .select2-container
+  .select2-selection--single
+  .select2-selection__rendered {
   line-height: 1.2;
   min-height: 21px;
   margin-top: 8px;
 }
-
-h3 sub .dropdown-blot .select2-container .select2-selection--single .select2-selection__rendered {
+div[data-janus-type='janus-fill-blanks']
+  h3
+  sub
+  .dropdown-blot
+  .select2-container
+  .select2-selection--single
+  .select2-selection__rendered {
   line-height: 1.2;
   min-height: 21px;
   margin-top: 18px;
 }
-
-h3
+div[data-janus-type='janus-fill-blanks']
+  h3
   sup
   .dropdown-blot
   .config
@@ -614,8 +716,8 @@ h3
   min-height: 22px;
   margin-top: 8px;
 }
-
-h3
+div[data-janus-type='janus-fill-blanks']
+  h3
   sub
   .dropdown-blot
   .config
@@ -626,20 +728,30 @@ h3
   min-height: 22px;
   margin-top: 18px;
 }
-
-code sup .dropdown-blot .select2-container .select2-selection--single .select2-selection__rendered {
+div[data-janus-type='janus-fill-blanks']
+  code
+  sup
+  .dropdown-blot
+  .select2-container
+  .select2-selection--single
+  .select2-selection__rendered {
   line-height: 1.6;
   min-height: 19px;
   margin-top: 5px;
 }
-
-code sub .dropdown-blot .select2-container .select2-selection--single .select2-selection__rendered {
+div[data-janus-type='janus-fill-blanks']
+  code
+  sub
+  .dropdown-blot
+  .select2-container
+  .select2-selection--single
+  .select2-selection__rendered {
   line-height: 1.6;
   min-height: 19px;
   margin-top: 9px;
 }
-
-code
+div[data-janus-type='janus-fill-blanks']
+  code
   sup
   .dropdown-blot
   .config
@@ -650,8 +762,8 @@ code
   min-height: 20px;
   margin-top: 5px;
 }
-
-code
+div[data-janus-type='janus-fill-blanks']
+  code
   sub
   .dropdown-blot
   .config
@@ -662,8 +774,8 @@ code
   min-height: 20px;
   margin-top: 9px;
 }
-
-blockquote
+div[data-janus-type='janus-fill-blanks']
+  blockquote
   sup
   .dropdown-blot
   .select2-container
@@ -673,8 +785,8 @@ blockquote
   min-height: 22px;
   margin-top: 0;
 }
-
-blockquote
+div[data-janus-type='janus-fill-blanks']
+  blockquote
   sub
   .dropdown-blot
   .select2-container
@@ -684,8 +796,8 @@ blockquote
   min-height: 22px;
   margin-top: 5px;
 }
-
-blockquote
+div[data-janus-type='janus-fill-blanks']
+  blockquote
   sup
   .dropdown-blot
   .config
@@ -696,8 +808,8 @@ blockquote
   min-height: 22px;
   margin-top: 0;
 }
-
-blockquote
+div[data-janus-type='janus-fill-blanks']
+  blockquote
   sub
   .dropdown-blot
   .config
@@ -708,28 +820,24 @@ blockquote
   min-height: 22px;
   margin-top: 5px;
 }
-
 @media only screen and (max-width: 440px) {
-  .select2-container {
+  /*** End Dropdown ***/
+  /*** Text Input ***/
+  div[data-janus-type='janus-fill-blanks'] .select2-container {
     max-width: calc(100vw - 40px);
   }
 }
-/*** End Dropdown ***/
-
-/*** Text Input ***/
-.text-input-blot {
+div[data-janus-type='janus-fill-blanks'] .text-input-blot {
   display: inline;
   margin: 0 1px;
 }
-
-.text-input-container {
+div[data-janus-type='janus-fill-blanks'] .text-input-container {
   position: relative;
   display: inline-block;
   vertical-align: top;
   border-radius: 3px;
 }
-
-.text-input {
+div[data-janus-type='janus-fill-blanks'] .text-input {
   height: auto;
   width: auto;
   border: 0;
@@ -743,43 +851,38 @@ blockquote
   position: relative;
   min-width: 120px;
 }
-
-.text-input:focus {
+div[data-janus-type='janus-fill-blanks'] .text-input:focus {
   outline: 0;
   border-bottom: 1px solid #2196f3;
 }
-.text-input:disabled {
+div[data-janus-type='janus-fill-blanks'] .text-input:disabled {
   cursor: not-allowed;
 }
-
-.text-input.force-inline-block {
+div[data-janus-type='janus-fill-blanks'] .text-input.force-inline-block {
   display: inline-block !important;
   padding: 0 5px;
   line-height: 1.9em;
   height: 30px;
   margin-top: 1px;
 }
-
-.text-input[contenteditable='false'] {
+div[data-janus-type='janus-fill-blanks'] .text-input[contenteditable='false'] {
   border-bottom: none;
 }
-
-.text-input[contenteditable='false'][placeholder]:empty::after {
+div[data-janus-type='janus-fill-blanks']
+  .text-input[contenteditable='false'][placeholder]:empty::after {
   display: none;
 }
-
-.text-input.disabled {
+div[data-janus-type='janus-fill-blanks'] .text-input.disabled {
   background-color: rgba(0, 0, 0, 0.07);
   cursor: not-allowed;
   color: rgba(0, 0, 0, 0.8);
 }
-
-.text-input[contenteditable][placeholder]:after {
+div[data-janus-type='janus-fill-blanks'] .text-input[contenteditable][placeholder]:after {
   padding: 0 5px;
   display: inline-block;
 }
-
-.text-input.config[contenteditable][placeholder]:empty::after {
+div[data-janus-type='janus-fill-blanks']
+  .text-input.config[contenteditable][placeholder]:empty::after {
   content: attr(placeholder);
   display: inline-block;
   opacity: 0.5;
@@ -790,12 +893,11 @@ blockquote
   color: rgba(0, 0, 0, 0.6);
   pointer-events: none;
 }
-
-.text-input[contenteditable][placeholder]:focus:empty::after {
+div[data-janus-type='janus-fill-blanks']
+  .text-input[contenteditable][placeholder]:focus:empty::after {
   display: none;
 }
-
-.text-input-container::before {
+div[data-janus-type='janus-fill-blanks'] .text-input-container::before {
   content: '';
   display: none;
   pointer-events: auto;
@@ -813,23 +915,21 @@ blockquote
   margin: auto 5px 1px 0;
   vertical-align: middle;
 }
-.text-input-container:focus {
+div[data-janus-type='janus-fill-blanks'] .text-input-container:focus {
   outline: none;
 }
-
-.text-input-container.correct,
-.text-input-container.correct .text-input {
+div[data-janus-type='janus-fill-blanks'] .text-input-container.correct,
+div[data-janus-type='janus-fill-blanks'] .text-input-container.correct .text-input {
   background-color: #daf6ee !important;
 }
-.text-input-container.correct::before {
+div[data-janus-type='janus-fill-blanks'] .text-input-container.correct::before {
   display: inline-block;
 }
-
-.text-input-container.incorrect,
-.text-input-container.incorrect .text-input {
+div[data-janus-type='janus-fill-blanks'] .text-input-container.incorrect,
+div[data-janus-type='janus-fill-blanks'] .text-input-container.incorrect .text-input {
   background-color: #fddfdd !important;
 }
-.text-input-container.incorrect::before {
+div[data-janus-type='janus-fill-blanks'] .text-input-container.incorrect::before {
   display: inline-block;
   background-color: #f96155;
   background-image: none;
@@ -841,284 +941,320 @@ blockquote
   box-sizing: border-box;
   text-align: left;
 }
-
-.text-input.config[contenteditable][placeholder]:empty::before {
+div[data-janus-type='janus-fill-blanks']
+  .text-input.config[contenteditable][placeholder]:empty::before {
   display: none;
 }
-
-.text-input.config[contenteditable][placeholder]::before {
+div[data-janus-type='janus-fill-blanks'] .text-input.config[contenteditable][placeholder]::before {
   display: inline-block;
 }
-
-.text-input.config[contenteditable][placeholder] {
+div[data-janus-type='janus-fill-blanks'] .text-input.config[contenteditable][placeholder] {
   border-bottom: 2px solid transparent;
   background-color: #daf6ee;
 }
-
-.text-input.config[contenteditable][placeholder]:focus {
+div[data-janus-type='janus-fill-blanks'] .text-input.config[contenteditable][placeholder]:focus {
   outline: 0;
   border-bottom: 2px solid #4ad3ad;
 }
-
-.text-input.config[contenteditable][placeholder]:empty {
+div[data-janus-type='janus-fill-blanks'] .text-input.config[contenteditable][placeholder]:empty {
   border-bottom: 1px solid #253445;
   margin-right: 0;
 }
-
-.text-input.correct {
+div[data-janus-type='janus-fill-blanks'] .text-input.correct {
   border-bottom: none;
   background-color: rgba(74, 211, 173, 0.2);
 }
-
-.text-input.incorrect {
+div[data-janus-type='janus-fill-blanks'] .text-input.incorrect {
   border-bottom: none;
   background-color: rgba(249, 97, 85, 0.2);
 }
-
-h1 .text-input-blot .text-input.force-inline-block {
+div[data-janus-type='janus-fill-blanks'] h1 .text-input-blot .text-input.force-inline-block {
   line-height: 1.45em;
   height: 69px;
   margin-top: 15px;
 }
-
-h2 .text-input-blot .text-input.force-inline-block {
+div[data-janus-type='janus-fill-blanks'] h2 .text-input-blot .text-input.force-inline-block {
   line-height: 1.55em;
   height: 49px;
   margin-top: 3px;
 }
-
-h3 .text-input-blot .text-input.force-inline-block {
+div[data-janus-type='janus-fill-blanks'] h3 .text-input-blot .text-input.force-inline-block {
   line-height: 1.7em;
   height: 36px;
   margin-top: 3px;
 }
-
-code .text-input-blot .text-input.force-inline-block {
+div[data-janus-type='janus-fill-blanks'] code .text-input-blot .text-input.force-inline-block {
   line-height: 2em;
   height: 27px;
   margin-top: 0;
 }
-
-blockquote .text-input-blot .text-input.force-inline-block {
+div[data-janus-type='janus-fill-blanks']
+  blockquote
+  .text-input-blot
+  .text-input.force-inline-block {
   line-height: 1.9em;
   height: 30px;
   margin-top: -4px;
 }
-
-s .text-input-blot .text-input.force-inline-block {
+div[data-janus-type='janus-fill-blanks'] s .text-input-blot .text-input.force-inline-block {
   text-decoration: line-through;
 }
-
-p .text-input-blot .text-input.config.force-inline-block {
+div[data-janus-type='janus-fill-blanks'] p .text-input-blot .text-input.config.force-inline-block {
   line-height: 1.9em;
   height: 31px;
   margin-top: 1px;
 }
-
-h1 .text-input-blot .text-input.config.force-inline-block {
+div[data-janus-type='janus-fill-blanks'] h1 .text-input-blot .text-input.config.force-inline-block {
   line-height: 1.45em;
   height: 70px;
   margin-top: 15px;
 }
-
-h2 .text-input-blot .text-input.config.force-inline-block {
+div[data-janus-type='janus-fill-blanks'] h2 .text-input-blot .text-input.config.force-inline-block {
   line-height: 1.55em;
   height: 50px;
   margin-top: 3px;
 }
-
-h3 .text-input-blot .text-input.config.force-inline-block {
+div[data-janus-type='janus-fill-blanks'] h3 .text-input-blot .text-input.config.force-inline-block {
   line-height: 1.7em;
   height: 37px;
   margin-top: 3px;
 }
-
-code .text-input-blot .text-input.config.force-inline-block {
+div[data-janus-type='janus-fill-blanks']
+  code
+  .text-input-blot
+  .text-input.config.force-inline-block {
   line-height: 2em;
   height: 28px;
   margin-top: 0;
 }
-
-blockquote .text-input-blot .text-input.config.force-inline-block {
+div[data-janus-type='janus-fill-blanks']
+  blockquote
+  .text-input-blot
+  .text-input.config.force-inline-block {
   line-height: 1.9em;
   height: 31px;
   margin-top: -4px;
 }
-
-s .text-input-blot .text-input.config.force-inline-block {
+div[data-janus-type='janus-fill-blanks'] s .text-input-blot .text-input.config.force-inline-block {
   text-decoration: line-through;
 }
-
-sub .text-input-blot .text-input.force-inline-block,
-sup .text-input-blot .text-input.force-inline-block {
+div[data-janus-type='janus-fill-blanks'] sub .text-input-blot .text-input.force-inline-block,
+div[data-janus-type='janus-fill-blanks'] sup .text-input-blot .text-input.force-inline-block {
   line-height: initial;
   height: 22px;
   padding: 2px 5px 0 5px;
 }
-
-sub .text-input-blot .text-input.config.force-inline-block,
-sup .text-input-blot .text-input.config.force-inline-block {
+div[data-janus-type='janus-fill-blanks'] sub .text-input-blot .text-input.config.force-inline-block,
+div[data-janus-type='janus-fill-blanks']
+  sup
+  .text-input-blot
+  .text-input.config.force-inline-block {
   line-height: initial;
   height: 22px;
   padding: 2px 5px 0 5px;
 }
-
-sub .text-input-blot .text-input,
-sup .text-input-blot .text-input {
+div[data-janus-type='janus-fill-blanks'] sub .text-input-blot .text-input,
+div[data-janus-type='janus-fill-blanks'] sup .text-input-blot .text-input {
   padding: 2px 5px 3px 5px;
 }
-
-sub .text-input-blot .text-input.config,
-sup .text-input-blot .text-input.config {
+div[data-janus-type='janus-fill-blanks'] sub .text-input-blot .text-input.config,
+div[data-janus-type='janus-fill-blanks'] sup .text-input-blot .text-input.config {
   padding: 2px 5px 2px 5px;
 }
-
-h1 sub .text-input-blot .text-input,
-h1 sup .text-input-blot .text-input,
-h2 sub .text-input-blot .text-input,
-h2 sup .text-input-blot .text-input,
-h3 sub .text-input-blot .text-input,
-h3 sup .text-input-blot .text-input {
+div[data-janus-type='janus-fill-blanks'] h1 sub .text-input-blot .text-input,
+div[data-janus-type='janus-fill-blanks'] h1 sup .text-input-blot .text-input,
+div[data-janus-type='janus-fill-blanks'] h2 sub .text-input-blot .text-input,
+div[data-janus-type='janus-fill-blanks'] h2 sup .text-input-blot .text-input,
+div[data-janus-type='janus-fill-blanks'] h3 sub .text-input-blot .text-input,
+div[data-janus-type='janus-fill-blanks'] h3 sup .text-input-blot .text-input {
   padding: 0 5px 0 5px;
 }
-
-h1 sub .text-input-blot .text-input.config,
-h1 sup .text-input-blot .text-input.config,
-h2 sub .text-input-blot .text-input.config,
-h2 sup .text-input-blot .text-input.config,
-h3 sub .text-input-blot .text-input.config,
-h3 sup .text-input-blot .text-input.config {
+div[data-janus-type='janus-fill-blanks'] h1 sub .text-input-blot .text-input.config,
+div[data-janus-type='janus-fill-blanks'] h1 sup .text-input-blot .text-input.config,
+div[data-janus-type='janus-fill-blanks'] h2 sub .text-input-blot .text-input.config,
+div[data-janus-type='janus-fill-blanks'] h2 sup .text-input-blot .text-input.config,
+div[data-janus-type='janus-fill-blanks'] h3 sub .text-input-blot .text-input.config,
+div[data-janus-type='janus-fill-blanks'] h3 sup .text-input-blot .text-input.config {
   padding: 0 5px;
 }
-
-h1 sub .text-input-blot .text-input.force-inline-block,
-h1 sup .text-input-blot .text-input.force-inline-block,
-h2 sub .text-input-blot .text-input.force-inline-block,
-h2 sup .text-input-blot .text-input.force-inline-block,
-h3 sub .text-input-blot .text-input.force-inline-block,
-h3 sup .text-input-blot .text-input.force-inline-block {
+div[data-janus-type='janus-fill-blanks'] h1 sub .text-input-blot .text-input.force-inline-block,
+div[data-janus-type='janus-fill-blanks'] h1 sup .text-input-blot .text-input.force-inline-block,
+div[data-janus-type='janus-fill-blanks'] h2 sub .text-input-blot .text-input.force-inline-block,
+div[data-janus-type='janus-fill-blanks'] h2 sup .text-input-blot .text-input.force-inline-block,
+div[data-janus-type='janus-fill-blanks'] h3 sub .text-input-blot .text-input.force-inline-block,
+div[data-janus-type='janus-fill-blanks'] h3 sup .text-input-blot .text-input.force-inline-block {
   padding: 0 5px 0 5px;
 }
-
-h1 sub .text-input-blot .text-input.config.force-inline-block,
-h1 sup .text-input-blot .text-input.config.force-inline-block,
-h2 sub .text-input-blot .text-input.config.force-inline-block,
-h2 sup .text-input-blot .text-input.config.force-inline-block,
-h3 sub .text-input-blot .text-input.config.force-inline-block,
-h3 sup .text-input-blot .text-input.config.force-inline-block {
+div[data-janus-type='janus-fill-blanks']
+  h1
+  sub
+  .text-input-blot
+  .text-input.config.force-inline-block,
+div[data-janus-type='janus-fill-blanks']
+  h1
+  sup
+  .text-input-blot
+  .text-input.config.force-inline-block,
+div[data-janus-type='janus-fill-blanks']
+  h2
+  sub
+  .text-input-blot
+  .text-input.config.force-inline-block,
+div[data-janus-type='janus-fill-blanks']
+  h2
+  sup
+  .text-input-blot
+  .text-input.config.force-inline-block,
+div[data-janus-type='janus-fill-blanks']
+  h3
+  sub
+  .text-input-blot
+  .text-input.config.force-inline-block,
+div[data-janus-type='janus-fill-blanks']
+  h3
+  sup
+  .text-input-blot
+  .text-input.config.force-inline-block {
   padding: 0 5px;
 }
-
-h1 sub .text-input-blot .text-input.force-inline-block,
-h1 sup .text-input-blot .text-input.force-inline-block {
+div[data-janus-type='janus-fill-blanks'] h1 sub .text-input-blot .text-input.force-inline-block,
+div[data-janus-type='janus-fill-blanks'] h1 sup .text-input-blot .text-input.force-inline-block {
   line-height: initial;
   height: 49px;
 }
-
-h1 sub .text-input-blot .text-input.config.force-inline-block,
-h1 sup .text-input-blot .text-input.config.force-inline-block {
+div[data-janus-type='janus-fill-blanks']
+  h1
+  sub
+  .text-input-blot
+  .text-input.config.force-inline-block,
+div[data-janus-type='janus-fill-blanks']
+  h1
+  sup
+  .text-input-blot
+  .text-input.config.force-inline-block {
   height: 50px;
 }
-
-h2 sub .text-input-blot .text-input.force-inline-block,
-h2 sup .text-input-blot .text-input.force-inline-block {
+div[data-janus-type='janus-fill-blanks'] h2 sub .text-input-blot .text-input.force-inline-block,
+div[data-janus-type='janus-fill-blanks'] h2 sup .text-input-blot .text-input.force-inline-block {
   line-height: initial;
   height: 33px;
 }
-
-h2 sub .text-input-blot .text-input.config.force-inline-block,
-h2 sup .text-input-blot .text-input.config.force-inline-block {
+div[data-janus-type='janus-fill-blanks']
+  h2
+  sub
+  .text-input-blot
+  .text-input.config.force-inline-block,
+div[data-janus-type='janus-fill-blanks']
+  h2
+  sup
+  .text-input-blot
+  .text-input.config.force-inline-block {
   height: 34px;
 }
-
-h3 sub .text-input-blot .text-input.force-inline-block,
-h3 sup .text-input-blot .text-input.force-inline-block {
+div[data-janus-type='janus-fill-blanks'] h3 sub .text-input-blot .text-input.force-inline-block,
+div[data-janus-type='janus-fill-blanks'] h3 sup .text-input-blot .text-input.force-inline-block {
   line-height: initial;
   height: 21px;
 }
-
-h3 sub .text-input-blot .text-input.config.force-inline-block,
-h3 sup .text-input-blot .text-input.config.force-inline-block {
+div[data-janus-type='janus-fill-blanks']
+  h3
+  sub
+  .text-input-blot
+  .text-input.config.force-inline-block,
+div[data-janus-type='janus-fill-blanks']
+  h3
+  sup
+  .text-input-blot
+  .text-input.config.force-inline-block {
   height: 22px;
 }
-
-code sub .text-input-blot .text-input.force-inline-block,
-code sup .text-input-blot .text-input.force-inline-block {
+div[data-janus-type='janus-fill-blanks'] code sub .text-input-blot .text-input.force-inline-block,
+div[data-janus-type='janus-fill-blanks'] code sup .text-input-blot .text-input.force-inline-block {
   line-height: initial;
   height: 19px;
 }
-
-code sub .text-input-blot .text-input.config.force-inline-block,
-code sup .text-input-blot .text-input.config.force-inline-block {
+div[data-janus-type='janus-fill-blanks']
+  code
+  sub
+  .text-input-blot
+  .text-input.config.force-inline-block,
+div[data-janus-type='janus-fill-blanks']
+  code
+  sup
+  .text-input-blot
+  .text-input.config.force-inline-block {
   height: 20px;
   padding: 1px 5px 3px 5px;
 }
-
-code sub .text-input-blot .text-input.config,
-code sup .text-input-blot .text-input.config {
+div[data-janus-type='janus-fill-blanks'] code sub .text-input-blot .text-input.config,
+div[data-janus-type='janus-fill-blanks'] code sup .text-input-blot .text-input.config {
   padding: 2px 5px 3px 5px;
 }
-
-blockquote sub .text-input-blot .text-input.force-inline-block,
-blockquote sup .text-input-blot .text-input.force-inline-block {
+div[data-janus-type='janus-fill-blanks']
+  blockquote
+  sub
+  .text-input-blot
+  .text-input.force-inline-block,
+div[data-janus-type='janus-fill-blanks']
+  blockquote
+  sup
+  .text-input-blot
+  .text-input.force-inline-block {
   line-height: initial;
   height: 22px;
 }
-
-blockquote sub .text-input-blot .text-input.config.force-inline-block,
-blockquote sup .text-input-blot .text-input.config.force-inline-block {
+div[data-janus-type='janus-fill-blanks']
+  blockquote
+  sub
+  .text-input-blot
+  .text-input.config.force-inline-block,
+div[data-janus-type='janus-fill-blanks']
+  blockquote
+  sup
+  .text-input-blot
+  .text-input.config.force-inline-block {
   height: 22px;
+  /*** End Text Input ***/
+  /*** Quill Overrides ***/
 }
-/*** End Text Input ***/
-
-/*** Quill Overrides ***/
-.editor {
+div[data-janus-type='janus-fill-blanks'] .editor {
   counter-reset: code-line-count 0;
 }
-
-.ql-snow .ql-editor code {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-editor code {
   padding-top: 0;
   padding-bottom: 0;
 }
-
-.editor.ql-container.ql-snow {
+div[data-janus-type='janus-fill-blanks'] .editor.ql-container.ql-snow {
   height: 100%;
 }
-
-.ql-snow .ql-editor {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-editor {
   font-size: 1rem;
   overflow-y: auto;
 }
-
-.ql-snow .ql-editor::-webkit-scrollbar {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-editor::-webkit-scrollbar {
   width: 14px;
   height: 14px;
   background: 0 0;
 }
-
-.ql-snow .ql-editor::-webkit-scrollbar-thumb {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-editor::-webkit-scrollbar-thumb {
   border-radius: 10px;
   background: #c1c1c1;
   border: 3px solid transparent;
   background-clip: padding-box;
 }
-
-.ql-snow .ql-editor::-webkit-scrollbar-track {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-editor::-webkit-scrollbar-track {
   background: 0 0;
   border-radius: 10px;
 }
-
-.ql-editor.ql-blank::before {
+div[data-janus-type='janus-fill-blanks'] .ql-editor.ql-blank::before {
   line-height: 2em;
   font-family: Roboto, sans-serif;
   color: rgba(0, 0, 0, 0.4);
 }
-
-.ql-editor.ql-blank::before.ql-blank::before {
+div[data-janus-type='janus-fill-blanks'] .ql-editor.ql-blank::before.ql-blank::before {
   line-height: 2em;
 }
-
-.ql-snow .ql-editor code {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-editor code {
   line-height: 2em;
   font-family: monospace;
   background-color: #ccc;
@@ -1126,63 +1262,55 @@ blockquote sup .text-input-blot .text-input.config.force-inline-block {
   display: block;
   border-radius: 0;
 }
-
-.ql-snow .ql-editor h1 {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-editor h1 {
   font-weight: 300;
   font-size: 3rem;
   line-height: 2;
   letter-spacing: -1.5px;
 }
-
-.ql-snow .ql-editor h2 {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-editor h2 {
   font-weight: 300;
   font-size: 2rem;
   line-height: 1.7;
   letter-spacing: -0.5px;
 }
-
-.ql-snow .ql-editor h3 {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-editor h3 {
   font-weight: 400;
   font-size: 1.3rem;
   line-height: 2;
   letter-spacing: 0;
 }
-
-.ql-snow .ql-editor p {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-editor p {
   font-weight: 400;
   font-size: 1rem;
   line-height: 2;
   letter-spacing: 0.5px;
+  /*** End Quill Overrides ***/
+  /*** Custom ***/
 }
-/*** End Quill Overrides ***/
-
-/*** Custom ***/
-.scene,
-body,
-html {
+div[data-janus-type='janus-fill-blanks'] .scene,
+div[data-janus-type='janus-fill-blanks'] body,
+div[data-janus-type='janus-fill-blanks'] html {
   font-family: Roboto, sans-serif;
   font-size: 16px;
   height: 100%;
   margin: 0;
   color: #333;
 }
-
-.app {
+div[data-janus-type='janus-fill-blanks'] .app {
   height: 100%;
 }
-
-.error {
+div[data-janus-type='janus-fill-blanks'] .error {
   text-align: center;
   color: #ab0000;
 }
-.accessibility-instructions {
+div[data-janus-type='janus-fill-blanks'] .accessibility-instructions {
   position: fixed;
   top: -100%;
   font-size: 1px;
 }
-
-.dropdown-instructions,
-.text-input-instructions {
+div[data-janus-type='janus-fill-blanks'] .dropdown-instructions,
+div[data-janus-type='janus-fill-blanks'] .text-input-instructions {
   position: absolute;
   top: 0;
   left: 0;

--- a/assets/src/components/parts/janus-fill-blanks/FillBlanks.tsx
+++ b/assets/src/components/parts/janus-fill-blanks/FillBlanks.tsx
@@ -13,8 +13,10 @@ import { FIBModel } from './schema';
 const css = require('./FillBlanks.css');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const quill = require('./Quill.css');
+// const select2Styles = require('react-select2-wrapper/css/select2.css');
+// FIB specifically-scoped select2 styles. OG lives here ☝️.
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const select2Styles = require('react-select2-wrapper/css/select2.css');
+const select2Styles = require('./FIBselect2.css');
 export const parseBool = (val: any) => {
   // cast value to number
   const num: number = +val;

--- a/assets/src/components/parts/janus-fill-blanks/Quill.css
+++ b/assets/src/components/parts/janus-fill-blanks/Quill.css
@@ -1,4 +1,4 @@
-.ql-container {
+div[data-janus-type='janus-fill-blanks'] .ql-container {
   box-sizing: border-box;
   font-family: Helvetica, Arial, sans-serif;
   font-size: 13px;
@@ -6,29 +6,28 @@
   margin: 0;
   position: relative;
 }
-
-.ql-container.ql-disabled .ql-tooltip {
+div[data-janus-type='janus-fill-blanks'] .ql-container.ql-disabled .ql-tooltip {
   visibility: hidden;
 }
-
-.ql-container.ql-disabled .ql-editor ul[data-checked] > li::before {
+div[data-janus-type='janus-fill-blanks']
+  .ql-container.ql-disabled
+  .ql-editor
+  ul[data-checked]
+  > li::before {
   pointer-events: none;
 }
-
-.ql-clipboard {
+div[data-janus-type='janus-fill-blanks'] .ql-clipboard {
   left: -100000px;
   height: 1px;
   overflow-y: hidden;
   position: absolute;
   top: 50%;
 }
-
-.ql-clipboard p {
+div[data-janus-type='janus-fill-blanks'] .ql-clipboard p {
   margin: 0;
   padding: 0;
 }
-
-.ql-editor {
+div[data-janus-type='janus-fill-blanks'] .ql-editor {
   box-sizing: border-box;
   line-height: 1.42;
   height: 100%;
@@ -41,457 +40,351 @@
   white-space: pre-wrap;
   word-wrap: break-word;
 }
-
-.ql-editor > * {
+div[data-janus-type='janus-fill-blanks'] .ql-editor > * {
   cursor: text;
 }
-
-.ql-editor blockquote,
-.ql-editor h1,
-.ql-editor h2,
-.ql-editor h3,
-.ql-editor h4,
-.ql-editor h5,
-.ql-editor h6,
-.ql-editor ol,
-.ql-editor p,
-.ql-editor pre,
-.ql-editor ul {
+div[data-janus-type='janus-fill-blanks'] .ql-editor blockquote,
+div[data-janus-type='janus-fill-blanks'] .ql-editor h1,
+div[data-janus-type='janus-fill-blanks'] .ql-editor h2,
+div[data-janus-type='janus-fill-blanks'] .ql-editor h3,
+div[data-janus-type='janus-fill-blanks'] .ql-editor h4,
+div[data-janus-type='janus-fill-blanks'] .ql-editor h5,
+div[data-janus-type='janus-fill-blanks'] .ql-editor h6,
+div[data-janus-type='janus-fill-blanks'] .ql-editor ol,
+div[data-janus-type='janus-fill-blanks'] .ql-editor p,
+div[data-janus-type='janus-fill-blanks'] .ql-editor pre,
+div[data-janus-type='janus-fill-blanks'] .ql-editor ul {
   margin: 0;
   padding: 0;
   counter-reset: list-1 list-2 list-3 list-4 list-5 list-6 list-7 list-8 list-9;
 }
-
-.ql-editor ol,
-.ql-editor ul {
+div[data-janus-type='janus-fill-blanks'] .ql-editor ol,
+div[data-janus-type='janus-fill-blanks'] .ql-editor ul {
   padding-left: 1.5em;
 }
-
-.ql-editor ol > li,
-.ql-editor ul > li {
+div[data-janus-type='janus-fill-blanks'] .ql-editor ol > li,
+div[data-janus-type='janus-fill-blanks'] .ql-editor ul > li {
   list-style-type: none;
 }
-
-.ql-editor ul > li::before {
+div[data-janus-type='janus-fill-blanks'] .ql-editor ul > li::before {
   content: '\2022';
 }
-
-.ql-editor ul[data-checked='false'],
-.ql-editor ul[data-checked='true'] {
+div[data-janus-type='janus-fill-blanks'] .ql-editor ul[data-checked='false'],
+div[data-janus-type='janus-fill-blanks'] .ql-editor ul[data-checked='true'] {
   pointer-events: none;
 }
-
-.ql-editor ul[data-checked='false'] > li *,
-.ql-editor ul[data-checked='true'] > li * {
+div[data-janus-type='janus-fill-blanks'] .ql-editor ul[data-checked='false'] > li *,
+div[data-janus-type='janus-fill-blanks'] .ql-editor ul[data-checked='true'] > li * {
   pointer-events: all;
 }
-
-.ql-editor ul[data-checked='false'] > li::before,
-.ql-editor ul[data-checked='true'] > li::before {
+div[data-janus-type='janus-fill-blanks'] .ql-editor ul[data-checked='false'] > li::before,
+div[data-janus-type='janus-fill-blanks'] .ql-editor ul[data-checked='true'] > li::before {
   color: #777;
   cursor: pointer;
   pointer-events: all;
 }
-
-.ql-editor ul[data-checked='true'] > li::before {
+div[data-janus-type='janus-fill-blanks'] .ql-editor ul[data-checked='true'] > li::before {
   content: '\2611';
 }
-
-.ql-editor ul[data-checked='false'] > li::before {
+div[data-janus-type='janus-fill-blanks'] .ql-editor ul[data-checked='false'] > li::before {
   content: '\2610';
 }
-
-.ql-editor li::before {
+div[data-janus-type='janus-fill-blanks'] .ql-editor li::before {
   display: inline-block;
   white-space: nowrap;
   width: 1.2em;
 }
-
-.ql-editor li:not(.ql-direction-rtl)::before {
+div[data-janus-type='janus-fill-blanks'] .ql-editor li:not(.ql-direction-rtl)::before {
   margin-left: -1.5em;
   margin-right: 0.3em;
   text-align: right;
 }
-
-.ql-editor li.ql-direction-rtl::before {
+div[data-janus-type='janus-fill-blanks'] .ql-editor li.ql-direction-rtl::before {
   margin-left: 0.3em;
   margin-right: -1.5em;
 }
-
-.ql-editor ol li:not(.ql-direction-rtl),
-.ql-editor ul li:not(.ql-direction-rtl) {
+div[data-janus-type='janus-fill-blanks'] .ql-editor ol li:not(.ql-direction-rtl),
+div[data-janus-type='janus-fill-blanks'] .ql-editor ul li:not(.ql-direction-rtl) {
   padding-left: 1.5em;
 }
-
-.ql-editor ol li.ql-direction-rtl,
-.ql-editor ul li.ql-direction-rtl {
+div[data-janus-type='janus-fill-blanks'] .ql-editor ol li.ql-direction-rtl,
+div[data-janus-type='janus-fill-blanks'] .ql-editor ul li.ql-direction-rtl {
   padding-right: 1.5em;
 }
-
-.ql-editor ol li {
+div[data-janus-type='janus-fill-blanks'] .ql-editor ol li {
   counter-reset: list-1 list-2 list-3 list-4 list-5 list-6 list-7 list-8 list-9;
   counter-increment: list-0;
 }
-
-.ql-editor ol li:before {
+div[data-janus-type='janus-fill-blanks'] .ql-editor ol li:before {
   content: counter(list-0, decimal) '. ';
 }
-
-.ql-editor ol li.ql-indent-1 {
+div[data-janus-type='janus-fill-blanks'] .ql-editor ol li.ql-indent-1 {
   counter-increment: list-1;
 }
-
-.ql-editor ol li.ql-indent-1:before {
+div[data-janus-type='janus-fill-blanks'] .ql-editor ol li.ql-indent-1:before {
   content: counter(list-1, lower-alpha) '. ';
 }
-
-.ql-editor ol li.ql-indent-1 {
+div[data-janus-type='janus-fill-blanks'] .ql-editor ol li.ql-indent-1 {
   counter-reset: list-2 list-3 list-4 list-5 list-6 list-7 list-8 list-9;
 }
-
-.ql-editor ol li.ql-indent-2 {
+div[data-janus-type='janus-fill-blanks'] .ql-editor ol li.ql-indent-2 {
   counter-increment: list-2;
 }
-
-.ql-editor ol li.ql-indent-2:before {
+div[data-janus-type='janus-fill-blanks'] .ql-editor ol li.ql-indent-2:before {
   content: counter(list-2, lower-roman) '. ';
 }
-
-.ql-editor ol li.ql-indent-2 {
+div[data-janus-type='janus-fill-blanks'] .ql-editor ol li.ql-indent-2 {
   counter-reset: list-3 list-4 list-5 list-6 list-7 list-8 list-9;
 }
-
-.ql-editor ol li.ql-indent-3 {
+div[data-janus-type='janus-fill-blanks'] .ql-editor ol li.ql-indent-3 {
   counter-increment: list-3;
 }
-
-.ql-editor ol li.ql-indent-3:before {
+div[data-janus-type='janus-fill-blanks'] .ql-editor ol li.ql-indent-3:before {
   content: counter(list-3, decimal) '. ';
 }
-
-.ql-editor ol li.ql-indent-3 {
+div[data-janus-type='janus-fill-blanks'] .ql-editor ol li.ql-indent-3 {
   counter-reset: list-4 list-5 list-6 list-7 list-8 list-9;
 }
-
-.ql-editor ol li.ql-indent-4 {
+div[data-janus-type='janus-fill-blanks'] .ql-editor ol li.ql-indent-4 {
   counter-increment: list-4;
 }
-
-.ql-editor ol li.ql-indent-4:before {
+div[data-janus-type='janus-fill-blanks'] .ql-editor ol li.ql-indent-4:before {
   content: counter(list-4, lower-alpha) '. ';
 }
-
-.ql-editor ol li.ql-indent-4 {
+div[data-janus-type='janus-fill-blanks'] .ql-editor ol li.ql-indent-4 {
   counter-reset: list-5 list-6 list-7 list-8 list-9;
 }
-
-.ql-editor ol li.ql-indent-5 {
+div[data-janus-type='janus-fill-blanks'] .ql-editor ol li.ql-indent-5 {
   counter-increment: list-5;
 }
-
-.ql-editor ol li.ql-indent-5:before {
+div[data-janus-type='janus-fill-blanks'] .ql-editor ol li.ql-indent-5:before {
   content: counter(list-5, lower-roman) '. ';
 }
-
-.ql-editor ol li.ql-indent-5 {
+div[data-janus-type='janus-fill-blanks'] .ql-editor ol li.ql-indent-5 {
   counter-reset: list-6 list-7 list-8 list-9;
 }
-
-.ql-editor ol li.ql-indent-6 {
+div[data-janus-type='janus-fill-blanks'] .ql-editor ol li.ql-indent-6 {
   counter-increment: list-6;
 }
-
-.ql-editor ol li.ql-indent-6:before {
+div[data-janus-type='janus-fill-blanks'] .ql-editor ol li.ql-indent-6:before {
   content: counter(list-6, decimal) '. ';
 }
-
-.ql-editor ol li.ql-indent-6 {
+div[data-janus-type='janus-fill-blanks'] .ql-editor ol li.ql-indent-6 {
   counter-reset: list-7 list-8 list-9;
 }
-
-.ql-editor ol li.ql-indent-7 {
+div[data-janus-type='janus-fill-blanks'] .ql-editor ol li.ql-indent-7 {
   counter-increment: list-7;
 }
-
-.ql-editor ol li.ql-indent-7:before {
+div[data-janus-type='janus-fill-blanks'] .ql-editor ol li.ql-indent-7:before {
   content: counter(list-7, lower-alpha) '. ';
 }
-
-.ql-editor ol li.ql-indent-7 {
+div[data-janus-type='janus-fill-blanks'] .ql-editor ol li.ql-indent-7 {
   counter-reset: list-8 list-9;
 }
-
-.ql-editor ol li.ql-indent-8 {
+div[data-janus-type='janus-fill-blanks'] .ql-editor ol li.ql-indent-8 {
   counter-increment: list-8;
 }
-
-.ql-editor ol li.ql-indent-8:before {
+div[data-janus-type='janus-fill-blanks'] .ql-editor ol li.ql-indent-8:before {
   content: counter(list-8, lower-roman) '. ';
 }
-
-.ql-editor ol li.ql-indent-8 {
+div[data-janus-type='janus-fill-blanks'] .ql-editor ol li.ql-indent-8 {
   counter-reset: list-9;
 }
-
-.ql-editor ol li.ql-indent-9 {
+div[data-janus-type='janus-fill-blanks'] .ql-editor ol li.ql-indent-9 {
   counter-increment: list-9;
 }
-
-.ql-editor ol li.ql-indent-9:before {
+div[data-janus-type='janus-fill-blanks'] .ql-editor ol li.ql-indent-9:before {
   content: counter(list-9, decimal) '. ';
 }
-
-.ql-editor .ql-indent-1:not(.ql-direction-rtl) {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-indent-1:not(.ql-direction-rtl) {
   padding-left: 3em;
 }
-
-.ql-editor li.ql-indent-1:not(.ql-direction-rtl) {
+div[data-janus-type='janus-fill-blanks'] .ql-editor li.ql-indent-1:not(.ql-direction-rtl) {
   padding-left: 4.5em;
 }
-
-.ql-editor .ql-indent-1.ql-direction-rtl.ql-align-right {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-indent-1.ql-direction-rtl.ql-align-right {
   padding-right: 3em;
 }
-
-.ql-editor li.ql-indent-1.ql-direction-rtl.ql-align-right {
+div[data-janus-type='janus-fill-blanks'] .ql-editor li.ql-indent-1.ql-direction-rtl.ql-align-right {
   padding-right: 4.5em;
 }
-
-.ql-editor .ql-indent-2:not(.ql-direction-rtl) {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-indent-2:not(.ql-direction-rtl) {
   padding-left: 6em;
 }
-
-.ql-editor li.ql-indent-2:not(.ql-direction-rtl) {
+div[data-janus-type='janus-fill-blanks'] .ql-editor li.ql-indent-2:not(.ql-direction-rtl) {
   padding-left: 7.5em;
 }
-
-.ql-editor .ql-indent-2.ql-direction-rtl.ql-align-right {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-indent-2.ql-direction-rtl.ql-align-right {
   padding-right: 6em;
 }
-
-.ql-editor li.ql-indent-2.ql-direction-rtl.ql-align-right {
+div[data-janus-type='janus-fill-blanks'] .ql-editor li.ql-indent-2.ql-direction-rtl.ql-align-right {
   padding-right: 7.5em;
 }
-
-.ql-editor .ql-indent-3:not(.ql-direction-rtl) {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-indent-3:not(.ql-direction-rtl) {
   padding-left: 9em;
 }
-
-.ql-editor li.ql-indent-3:not(.ql-direction-rtl) {
+div[data-janus-type='janus-fill-blanks'] .ql-editor li.ql-indent-3:not(.ql-direction-rtl) {
   padding-left: 10.5em;
 }
-
-.ql-editor .ql-indent-3.ql-direction-rtl.ql-align-right {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-indent-3.ql-direction-rtl.ql-align-right {
   padding-right: 9em;
 }
-
-.ql-editor li.ql-indent-3.ql-direction-rtl.ql-align-right {
+div[data-janus-type='janus-fill-blanks'] .ql-editor li.ql-indent-3.ql-direction-rtl.ql-align-right {
   padding-right: 10.5em;
 }
-
-.ql-editor .ql-indent-4:not(.ql-direction-rtl) {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-indent-4:not(.ql-direction-rtl) {
   padding-left: 12em;
 }
-
-.ql-editor li.ql-indent-4:not(.ql-direction-rtl) {
+div[data-janus-type='janus-fill-blanks'] .ql-editor li.ql-indent-4:not(.ql-direction-rtl) {
   padding-left: 13.5em;
 }
-
-.ql-editor .ql-indent-4.ql-direction-rtl.ql-align-right {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-indent-4.ql-direction-rtl.ql-align-right {
   padding-right: 12em;
 }
-
-.ql-editor li.ql-indent-4.ql-direction-rtl.ql-align-right {
+div[data-janus-type='janus-fill-blanks'] .ql-editor li.ql-indent-4.ql-direction-rtl.ql-align-right {
   padding-right: 13.5em;
 }
-
-.ql-editor .ql-indent-5:not(.ql-direction-rtl) {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-indent-5:not(.ql-direction-rtl) {
   padding-left: 15em;
 }
-
-.ql-editor li.ql-indent-5:not(.ql-direction-rtl) {
+div[data-janus-type='janus-fill-blanks'] .ql-editor li.ql-indent-5:not(.ql-direction-rtl) {
   padding-left: 16.5em;
 }
-
-.ql-editor .ql-indent-5.ql-direction-rtl.ql-align-right {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-indent-5.ql-direction-rtl.ql-align-right {
   padding-right: 15em;
 }
-
-.ql-editor li.ql-indent-5.ql-direction-rtl.ql-align-right {
+div[data-janus-type='janus-fill-blanks'] .ql-editor li.ql-indent-5.ql-direction-rtl.ql-align-right {
   padding-right: 16.5em;
 }
-
-.ql-editor .ql-indent-6:not(.ql-direction-rtl) {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-indent-6:not(.ql-direction-rtl) {
   padding-left: 18em;
 }
-
-.ql-editor li.ql-indent-6:not(.ql-direction-rtl) {
+div[data-janus-type='janus-fill-blanks'] .ql-editor li.ql-indent-6:not(.ql-direction-rtl) {
   padding-left: 19.5em;
 }
-
-.ql-editor .ql-indent-6.ql-direction-rtl.ql-align-right {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-indent-6.ql-direction-rtl.ql-align-right {
   padding-right: 18em;
 }
-
-.ql-editor li.ql-indent-6.ql-direction-rtl.ql-align-right {
+div[data-janus-type='janus-fill-blanks'] .ql-editor li.ql-indent-6.ql-direction-rtl.ql-align-right {
   padding-right: 19.5em;
 }
-
-.ql-editor .ql-indent-7:not(.ql-direction-rtl) {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-indent-7:not(.ql-direction-rtl) {
   padding-left: 21em;
 }
-
-.ql-editor li.ql-indent-7:not(.ql-direction-rtl) {
+div[data-janus-type='janus-fill-blanks'] .ql-editor li.ql-indent-7:not(.ql-direction-rtl) {
   padding-left: 22.5em;
 }
-
-.ql-editor .ql-indent-7.ql-direction-rtl.ql-align-right {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-indent-7.ql-direction-rtl.ql-align-right {
   padding-right: 21em;
 }
-
-.ql-editor li.ql-indent-7.ql-direction-rtl.ql-align-right {
+div[data-janus-type='janus-fill-blanks'] .ql-editor li.ql-indent-7.ql-direction-rtl.ql-align-right {
   padding-right: 22.5em;
 }
-
-.ql-editor .ql-indent-8:not(.ql-direction-rtl) {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-indent-8:not(.ql-direction-rtl) {
   padding-left: 24em;
 }
-
-.ql-editor li.ql-indent-8:not(.ql-direction-rtl) {
+div[data-janus-type='janus-fill-blanks'] .ql-editor li.ql-indent-8:not(.ql-direction-rtl) {
   padding-left: 25.5em;
 }
-
-.ql-editor .ql-indent-8.ql-direction-rtl.ql-align-right {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-indent-8.ql-direction-rtl.ql-align-right {
   padding-right: 24em;
 }
-
-.ql-editor li.ql-indent-8.ql-direction-rtl.ql-align-right {
+div[data-janus-type='janus-fill-blanks'] .ql-editor li.ql-indent-8.ql-direction-rtl.ql-align-right {
   padding-right: 25.5em;
 }
-
-.ql-editor .ql-indent-9:not(.ql-direction-rtl) {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-indent-9:not(.ql-direction-rtl) {
   padding-left: 27em;
 }
-
-.ql-editor li.ql-indent-9:not(.ql-direction-rtl) {
+div[data-janus-type='janus-fill-blanks'] .ql-editor li.ql-indent-9:not(.ql-direction-rtl) {
   padding-left: 28.5em;
 }
-
-.ql-editor .ql-indent-9.ql-direction-rtl.ql-align-right {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-indent-9.ql-direction-rtl.ql-align-right {
   padding-right: 27em;
 }
-
-.ql-editor li.ql-indent-9.ql-direction-rtl.ql-align-right {
+div[data-janus-type='janus-fill-blanks'] .ql-editor li.ql-indent-9.ql-direction-rtl.ql-align-right {
   padding-right: 28.5em;
 }
-
-.ql-editor .ql-video {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-video {
   display: block;
   max-width: 100%;
 }
-
-.ql-editor .ql-video.ql-align-center {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-video.ql-align-center {
   margin: 0 auto;
 }
-
-.ql-editor .ql-video.ql-align-right {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-video.ql-align-right {
   margin: 0 0 0 auto;
 }
-
-.ql-editor .ql-bg-black {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-bg-black {
   background-color: #000;
 }
-
-.ql-editor .ql-bg-red {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-bg-red {
   background-color: #e60000;
 }
-
-.ql-editor .ql-bg-orange {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-bg-orange {
   background-color: #f90;
 }
-
-.ql-editor .ql-bg-yellow {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-bg-yellow {
   background-color: #ff0;
 }
-
-.ql-editor .ql-bg-green {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-bg-green {
   background-color: #008a00;
 }
-
-.ql-editor .ql-bg-blue {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-bg-blue {
   background-color: #06c;
 }
-
-.ql-editor .ql-bg-purple {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-bg-purple {
   background-color: #93f;
 }
-
-.ql-editor .ql-color-white {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-color-white {
   color: #fff;
 }
-
-.ql-editor .ql-color-red {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-color-red {
   color: #e60000;
 }
-
-.ql-editor .ql-color-orange {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-color-orange {
   color: #f90;
 }
-
-.ql-editor .ql-color-yellow {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-color-yellow {
   color: #ff0;
 }
-
-.ql-editor .ql-color-green {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-color-green {
   color: #008a00;
 }
-
-.ql-editor .ql-color-blue {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-color-blue {
   color: #06c;
 }
-
-.ql-editor .ql-color-purple {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-color-purple {
   color: #93f;
 }
-
-.ql-editor .ql-font-serif {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-font-serif {
   font-family: Georgia, Times New Roman, serif;
 }
-
-.ql-editor .ql-font-monospace {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-font-monospace {
   font-family: Monaco, Courier New, monospace;
 }
-
-.ql-editor .ql-size-small {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-size-small {
   font-size: 0.75em;
 }
-
-.ql-editor .ql-size-large {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-size-large {
   font-size: 1.5em;
 }
-
-.ql-editor .ql-size-huge {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-size-huge {
   font-size: 2.5em;
 }
-
-.ql-editor .ql-direction-rtl {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-direction-rtl {
   direction: rtl;
   text-align: inherit;
 }
-
-.ql-editor .ql-align-center {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-align-center {
   text-align: center;
 }
-
-.ql-editor .ql-align-justify {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-align-justify {
   text-align: justify;
 }
-
-.ql-editor .ql-align-right {
+div[data-janus-type='janus-fill-blanks'] .ql-editor .ql-align-right {
   text-align: right;
 }
-
-.ql-editor.ql-blank::before {
+div[data-janus-type='janus-fill-blanks'] .ql-editor.ql-blank::before {
   color: rgba(0, 0, 0, 0.6);
   content: attr(data-placeholder);
   font-style: italic;
@@ -500,164 +393,131 @@
   position: absolute;
   right: 15px;
 }
-
-.ql-snow {
+div[data-janus-type='janus-fill-blanks'] .ql-snow {
   box-sizing: border-box;
 }
-
-.ql-snow * {
+div[data-janus-type='janus-fill-blanks'] .ql-snow * {
   box-sizing: border-box;
 }
-
-.ql-snow .ql-hidden {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-hidden {
   display: none;
 }
-
-.ql-snow .ql-out-bottom,
-.ql-snow .ql-out-top {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-out-bottom,
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-out-top {
   visibility: hidden;
 }
-
-.ql-snow .ql-tooltip {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-tooltip {
   position: absolute;
   -webkit-transform: translateY(10px);
   transform: translateY(10px);
 }
-
-.ql-snow .ql-tooltip a {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-tooltip a {
   cursor: pointer;
   text-decoration: none;
 }
-
-.ql-snow .ql-tooltip.ql-flip {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-tooltip.ql-flip {
   -webkit-transform: translateY(-10px);
   transform: translateY(-10px);
 }
-
-.ql-snow .ql-formats {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-formats {
   display: inline-block;
   vertical-align: middle;
 }
-
-.ql-snow .ql-formats:after {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-formats:after {
   clear: both;
   content: '';
   display: table;
 }
-
-.ql-snow .ql-stroke {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-stroke {
   fill: none;
   stroke: #444;
   stroke-linecap: round;
   stroke-linejoin: round;
   stroke-width: 2;
 }
-
-.ql-snow .ql-stroke-miter {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-stroke-miter {
   fill: none;
   stroke: #444;
   stroke-miterlimit: 10;
   stroke-width: 2;
 }
-
-.ql-snow .ql-fill,
-.ql-snow .ql-stroke.ql-fill {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-fill,
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-stroke.ql-fill {
   fill: #444;
 }
-
-.ql-snow .ql-empty {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-empty {
   fill: none;
 }
-
-.ql-snow .ql-even {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-even {
   fill-rule: evenodd;
 }
-
-.ql-snow .ql-stroke.ql-thin,
-.ql-snow .ql-thin {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-stroke.ql-thin,
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-thin {
   stroke-width: 1;
 }
-
-.ql-snow .ql-transparent {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-transparent {
   opacity: 0.4;
 }
-
-.ql-snow .ql-direction svg:last-child {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-direction svg:last-child {
   display: none;
 }
-
-.ql-snow .ql-direction.ql-active svg:last-child {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-direction.ql-active svg:last-child {
   display: inline;
 }
-
-.ql-snow .ql-direction.ql-active svg:first-child {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-direction.ql-active svg:first-child {
   display: none;
 }
-
-.ql-snow .ql-editor h1 {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-editor h1 {
   font-size: 2em;
 }
-
-.ql-snow .ql-editor h2 {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-editor h2 {
   font-size: 1.5em;
 }
-
-.ql-snow .ql-editor h3 {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-editor h3 {
   font-size: 1.17em;
 }
-
-.ql-snow .ql-editor h4 {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-editor h4 {
   font-size: 1em;
 }
-
-.ql-snow .ql-editor h5 {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-editor h5 {
   font-size: 0.83em;
 }
-
-.ql-snow .ql-editor h6 {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-editor h6 {
   font-size: 0.67em;
 }
-
-.ql-snow .ql-editor a {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-editor a {
   text-decoration: underline;
 }
-
-.ql-snow .ql-editor blockquote {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-editor blockquote {
   border-left: 4px solid #ccc;
   margin-bottom: 5px;
   margin-top: 5px;
   padding-left: 16px;
 }
-
-.ql-snow .ql-editor code,
-.ql-snow .ql-editor pre {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-editor code,
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-editor pre {
   background-color: #f0f0f0;
   border-radius: 3px;
 }
-
-.ql-snow .ql-editor pre {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-editor pre {
   white-space: pre-wrap;
   margin-bottom: 5px;
   margin-top: 5px;
   padding: 5px 10px;
 }
-
-.ql-snow .ql-editor code {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-editor code {
   font-size: 85%;
   padding: 2px 4px;
 }
-
-.ql-snow .ql-editor pre.ql-syntax {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-editor pre.ql-syntax {
   background-color: #23241f;
   color: #f8f8f2;
   overflow: visible;
 }
-
-.ql-snow .ql-editor img {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-editor img {
   max-width: 100%;
 }
-
-.ql-snow .ql-picker {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-picker {
   color: #444;
   display: inline-block;
   float: left;
@@ -667,8 +527,7 @@
   position: relative;
   vertical-align: middle;
 }
-
-.ql-snow .ql-picker-label {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-picker-label {
   cursor: pointer;
   display: inline-block;
   height: 100%;
@@ -677,13 +536,11 @@
   position: relative;
   width: 100%;
 }
-
-.ql-snow .ql-picker-label::before {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-picker-label::before {
   display: inline-block;
   line-height: 22px;
 }
-
-.ql-snow .ql-picker-options {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-picker-options {
   background-color: #fff;
   display: none;
   min-width: 100%;
@@ -691,65 +548,57 @@
   position: absolute;
   white-space: nowrap;
 }
-
-.ql-snow .ql-picker-options .ql-picker-item {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-picker-options .ql-picker-item {
   cursor: pointer;
   display: block;
   padding-bottom: 5px;
   padding-top: 5px;
 }
-
-.ql-snow .ql-picker.ql-expanded .ql-picker-label {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-picker.ql-expanded .ql-picker-label {
   color: #ccc;
   z-index: 2;
 }
-
-.ql-snow .ql-picker.ql-expanded .ql-picker-label .ql-fill {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-picker.ql-expanded .ql-picker-label .ql-fill {
   fill: #ccc;
 }
-
-.ql-snow .ql-picker.ql-expanded .ql-picker-label .ql-stroke {
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-expanded
+  .ql-picker-label
+  .ql-stroke {
   stroke: #ccc;
 }
-
-.ql-snow .ql-picker.ql-expanded .ql-picker-options {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-picker.ql-expanded .ql-picker-options {
   display: block;
   margin-top: -1px;
   top: 100%;
   z-index: 1;
 }
-
-.ql-snow .ql-color-picker,
-.ql-snow .ql-icon-picker {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-color-picker,
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-icon-picker {
   width: 28px;
 }
-
-.ql-snow .ql-color-picker .ql-picker-label,
-.ql-snow .ql-icon-picker .ql-picker-label {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-color-picker .ql-picker-label,
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-icon-picker .ql-picker-label {
   padding: 2px 4px;
 }
-
-.ql-snow .ql-color-picker .ql-picker-label svg,
-.ql-snow .ql-icon-picker .ql-picker-label svg {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-color-picker .ql-picker-label svg,
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-icon-picker .ql-picker-label svg {
   right: 4px;
 }
-
-.ql-snow .ql-icon-picker .ql-picker-options {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-icon-picker .ql-picker-options {
   padding: 4px 0;
 }
-
-.ql-snow .ql-icon-picker .ql-picker-item {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-icon-picker .ql-picker-item {
   height: 24px;
   width: 24px;
   padding: 2px 4px;
 }
-
-.ql-snow .ql-color-picker .ql-picker-options {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-color-picker .ql-picker-options {
   padding: 3px 5px;
   width: 152px;
 }
-
-.ql-snow .ql-color-picker .ql-picker-item {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-color-picker .ql-picker-item {
   border: 1px solid transparent;
   float: left;
   height: 16px;
@@ -757,162 +606,248 @@
   padding: 0;
   width: 16px;
 }
-
-.ql-snow .ql-picker:not(.ql-color-picker):not(.ql-icon-picker) svg {
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker:not(.ql-color-picker):not(.ql-icon-picker)
+  svg {
   position: absolute;
   margin-top: -9px;
   right: 0;
   top: 50%;
   width: 18px;
 }
-
-.ql-snow .ql-picker.ql-font .ql-picker-item[data-label]:not([data-label=''])::before,
-.ql-snow .ql-picker.ql-font .ql-picker-label[data-label]:not([data-label=''])::before,
-.ql-snow .ql-picker.ql-header .ql-picker-item[data-label]:not([data-label=''])::before,
-.ql-snow .ql-picker.ql-header .ql-picker-label[data-label]:not([data-label=''])::before,
-.ql-snow .ql-picker.ql-size .ql-picker-item[data-label]:not([data-label=''])::before,
-.ql-snow .ql-picker.ql-size .ql-picker-label[data-label]:not([data-label=''])::before {
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-font
+  .ql-picker-item[data-label]:not([data-label=''])::before,
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-font
+  .ql-picker-label[data-label]:not([data-label=''])::before,
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-header
+  .ql-picker-item[data-label]:not([data-label=''])::before,
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-header
+  .ql-picker-label[data-label]:not([data-label=''])::before,
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-size
+  .ql-picker-item[data-label]:not([data-label=''])::before,
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-size
+  .ql-picker-label[data-label]:not([data-label=''])::before {
   content: attr(data-label);
 }
-
-.ql-snow .ql-picker.ql-header {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-picker.ql-header {
   width: 98px;
 }
-
-.ql-snow .ql-picker.ql-header .ql-picker-item::before,
-.ql-snow .ql-picker.ql-header .ql-picker-label::before {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-picker.ql-header .ql-picker-item::before,
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-picker.ql-header .ql-picker-label::before {
   content: 'Normal';
 }
-
-.ql-snow .ql-picker.ql-header .ql-picker-item[data-value='1']::before,
-.ql-snow .ql-picker.ql-header .ql-picker-label[data-value='1']::before {
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-header
+  .ql-picker-item[data-value='1']::before,
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-header
+  .ql-picker-label[data-value='1']::before {
   content: 'Heading 1';
 }
-
-.ql-snow .ql-picker.ql-header .ql-picker-item[data-value='2']::before,
-.ql-snow .ql-picker.ql-header .ql-picker-label[data-value='2']::before {
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-header
+  .ql-picker-item[data-value='2']::before,
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-header
+  .ql-picker-label[data-value='2']::before {
   content: 'Heading 2';
 }
-
-.ql-snow .ql-picker.ql-header .ql-picker-item[data-value='3']::before,
-.ql-snow .ql-picker.ql-header .ql-picker-label[data-value='3']::before {
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-header
+  .ql-picker-item[data-value='3']::before,
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-header
+  .ql-picker-label[data-value='3']::before {
   content: 'Heading 3';
 }
-
-.ql-snow .ql-picker.ql-header .ql-picker-item[data-value='4']::before,
-.ql-snow .ql-picker.ql-header .ql-picker-label[data-value='4']::before {
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-header
+  .ql-picker-item[data-value='4']::before,
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-header
+  .ql-picker-label[data-value='4']::before {
   content: 'Heading 4';
 }
-
-.ql-snow .ql-picker.ql-header .ql-picker-item[data-value='5']::before,
-.ql-snow .ql-picker.ql-header .ql-picker-label[data-value='5']::before {
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-header
+  .ql-picker-item[data-value='5']::before,
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-header
+  .ql-picker-label[data-value='5']::before {
   content: 'Heading 5';
 }
-
-.ql-snow .ql-picker.ql-header .ql-picker-item[data-value='6']::before,
-.ql-snow .ql-picker.ql-header .ql-picker-label[data-value='6']::before {
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-header
+  .ql-picker-item[data-value='6']::before,
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-header
+  .ql-picker-label[data-value='6']::before {
   content: 'Heading 6';
 }
-
-.ql-snow .ql-picker.ql-header .ql-picker-item[data-value='1']::before {
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-header
+  .ql-picker-item[data-value='1']::before {
   font-size: 2em;
 }
-
-.ql-snow .ql-picker.ql-header .ql-picker-item[data-value='2']::before {
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-header
+  .ql-picker-item[data-value='2']::before {
   font-size: 1.5em;
 }
-
-.ql-snow .ql-picker.ql-header .ql-picker-item[data-value='3']::before {
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-header
+  .ql-picker-item[data-value='3']::before {
   font-size: 1.17em;
 }
-
-.ql-snow .ql-picker.ql-header .ql-picker-item[data-value='4']::before {
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-header
+  .ql-picker-item[data-value='4']::before {
   font-size: 1em;
 }
-
-.ql-snow .ql-picker.ql-header .ql-picker-item[data-value='5']::before {
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-header
+  .ql-picker-item[data-value='5']::before {
   font-size: 0.83em;
 }
-
-.ql-snow .ql-picker.ql-header .ql-picker-item[data-value='6']::before {
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-header
+  .ql-picker-item[data-value='6']::before {
   font-size: 0.67em;
 }
-
-.ql-snow .ql-picker.ql-font {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-picker.ql-font {
   width: 108px;
 }
-
-.ql-snow .ql-picker.ql-font .ql-picker-item::before,
-.ql-snow .ql-picker.ql-font .ql-picker-label::before {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-picker.ql-font .ql-picker-item::before,
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-picker.ql-font .ql-picker-label::before {
   content: 'Sans Serif';
 }
-
-.ql-snow .ql-picker.ql-font .ql-picker-item[data-value='serif']::before,
-.ql-snow .ql-picker.ql-font .ql-picker-label[data-value='serif']::before {
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-font
+  .ql-picker-item[data-value='serif']::before,
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-font
+  .ql-picker-label[data-value='serif']::before {
   content: 'Serif';
 }
-
-.ql-snow .ql-picker.ql-font .ql-picker-item[data-value='monospace']::before,
-.ql-snow .ql-picker.ql-font .ql-picker-label[data-value='monospace']::before {
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-font
+  .ql-picker-item[data-value='monospace']::before,
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-font
+  .ql-picker-label[data-value='monospace']::before {
   content: 'Monospace';
 }
-
-.ql-snow .ql-picker.ql-font .ql-picker-item[data-value='serif']::before {
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-font
+  .ql-picker-item[data-value='serif']::before {
   font-family: Georgia, Times New Roman, serif;
 }
-
-.ql-snow .ql-picker.ql-font .ql-picker-item[data-value='monospace']::before {
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-font
+  .ql-picker-item[data-value='monospace']::before {
   font-family: Monaco, Courier New, monospace;
 }
-
-.ql-snow .ql-picker.ql-size {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-picker.ql-size {
   width: 98px;
 }
-
-.ql-snow .ql-picker.ql-size .ql-picker-item::before,
-.ql-snow .ql-picker.ql-size .ql-picker-label::before {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-picker.ql-size .ql-picker-item::before,
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-picker.ql-size .ql-picker-label::before {
   content: 'Normal';
 }
-
-.ql-snow .ql-picker.ql-size .ql-picker-item[data-value='small']::before,
-.ql-snow .ql-picker.ql-size .ql-picker-label[data-value='small']::before {
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-size
+  .ql-picker-item[data-value='small']::before,
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-size
+  .ql-picker-label[data-value='small']::before {
   content: 'Small';
 }
-
-.ql-snow .ql-picker.ql-size .ql-picker-item[data-value='large']::before,
-.ql-snow .ql-picker.ql-size .ql-picker-label[data-value='large']::before {
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-size
+  .ql-picker-item[data-value='large']::before,
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-size
+  .ql-picker-label[data-value='large']::before {
   content: 'Large';
 }
-
-.ql-snow .ql-picker.ql-size .ql-picker-item[data-value='huge']::before,
-.ql-snow .ql-picker.ql-size .ql-picker-label[data-value='huge']::before {
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-size
+  .ql-picker-item[data-value='huge']::before,
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-size
+  .ql-picker-label[data-value='huge']::before {
   content: 'Huge';
 }
-
-.ql-snow .ql-picker.ql-size .ql-picker-item[data-value='small']::before {
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-size
+  .ql-picker-item[data-value='small']::before {
   font-size: 10px;
 }
-
-.ql-snow .ql-picker.ql-size .ql-picker-item[data-value='large']::before {
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-size
+  .ql-picker-item[data-value='large']::before {
   font-size: 18px;
 }
-
-.ql-snow .ql-picker.ql-size .ql-picker-item[data-value='huge']::before {
+div[data-janus-type='janus-fill-blanks']
+  .ql-snow
+  .ql-picker.ql-size
+  .ql-picker-item[data-value='huge']::before {
   font-size: 32px;
 }
-
-.ql-snow .ql-color-picker.ql-background .ql-picker-item {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-color-picker.ql-background .ql-picker-item {
   background-color: #fff;
 }
-
-.ql-snow .ql-color-picker.ql-color .ql-picker-item {
+div[data-janus-type='janus-fill-blanks'] .ql-snow .ql-color-picker.ql-color .ql-picker-item {
   background-color: #000;
 }
-
-.ql-snow a {
+div[data-janus-type='janus-fill-blanks'] .ql-snow a {
   color: #06c;
 }
-
-.ql-container.ql-snow {
+div[data-janus-type='janus-fill-blanks'] .ql-container.ql-snow {
   border: 1px solid #ccc;
 }


### PR DESCRIPTION
## 🚨🚨🚨 DO NOT MERGE YET 🚨🚨🚨

This tightly scopes all FIB css to itself to prevent bleed-thru in Authoring or Delivery. This requires updates to any lessons using native FIB with inlined css (currently PT & Seasons). I still need to confirm w/ LDs the following list of all instances of FIBs in both lessons so we don't miss any.

### FIBs found in Plate Tectonics 
1. Boundary Intro Describe Surface 2
2. PT Summary 1
3. Explore Cross Same Direction
4. PT Summary 3
5. PT Summary 2
6. Boundary Intro Describe Surface

### FIBs found in Seasons
1. Describe Temperature Pattern
2. Different Patterns LO
3. Explain Tilt in Experiment
4. Summary of Tilt
