### PR TITLE
PMP-1942 | JAN-750

### DIFF
--- a/assets/src/components/parts/janus-text-flow/Markup.tsx
+++ b/assets/src/components/parts/janus-text-flow/Markup.tsx
@@ -100,7 +100,7 @@ const Markup: React.FC<any> = ({
   }
 
   // eslint-disable-next-line
-  if (!children.length && !processedText.trim()) {
+  if (!children.length) {
     // empty elements in HTML don't stay in the flow
     // add a non breaking space instead of nothing
 
@@ -146,12 +146,6 @@ const Markup: React.FC<any> = ({
   // TODO: support MathJax
   // TODO: support templating in text
   // TODO: support tables, quotes, definition lists?? form elements???
-
-  // replace all recurring spaces with &nbsp; but not the first one
-  processedText = processedText.replace(
-    /  +/g,
-    (txt: string) => ' ' + Array(txt.length).join('\u00A0'),
-  );
 
   switch (renderTag) {
     case 'a':


### PR DESCRIPTION
Since in smart sparrow, recurring spaces have been replaced by '&sbsp;' so that's why I went with this approach, or else we can fix this by using CSS i.e by adding ` whiteSpace: 'pre-wrap' ` in `renderStyles` style variable.