### PR TITLE
[PMP-1947 | JAN-755] DEFECT: Component Panel not always populating

### DIFF
--- a/assets/src/components/activities/adaptive/AdaptiveAuthoring.tsx
+++ b/assets/src/components/activities/adaptive/AdaptiveAuthoring.tsx
@@ -37,7 +37,7 @@ const Adaptive = (
 
   const handlePartSelect = useCallback(
     async (partId: string) => {
-      if (!props.editMode || selectedPartId === partId) {
+      if (!props.editMode) {
         return;
       }
       setSelectedPartId(partId);


### PR DESCRIPTION
Not sure why but selectedPartId was getting set to the newPartId on clicking the part after clicking on the blank part of the screen, while it should be blank.
Anyways, so this check is there in the layereditor so I don't see any harm in removing this from here.