### PR TITLE
[CHORE] replace inspect statements with logger

### DIFF
--- a/lib/oli/delivery/attempts/page_lifecycle/hierarchy.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/hierarchy.ex
@@ -1,5 +1,8 @@
 defmodule Oli.Delivery.Attempts.PageLifecycle.Hierarchy do
   import Ecto.Query, warn: false
+
+  require Logger
+
   alias Oli.Repo
 
   alias Oli.Delivery.Attempts.Core.{
@@ -98,7 +101,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Hierarchy do
 
       {:ok, {Map.put(activity_attempt, :revision, revision), part_attempts}}
     else
-      e -> IO.inspect(e)
+      e -> Logger.error("failed to create full activity attempt: #{inspect(e)}")
     end
   end
 

--- a/lib/oli/delivery/hierarchy.ex
+++ b/lib/oli/delivery/hierarchy.ex
@@ -234,6 +234,7 @@ defmodule Oli.Delivery.Hierarchy do
     drop_keys = Keyword.get(opts, :drop_keys, [:revision, :section_resource])
 
     drop_r(hierarchy, drop_keys)
+    # credo:disable-for-next-line Credo.Check.Warning.IoInspect
     |> IO.inspect(label: label)
 
     hierarchy

--- a/lib/oli/delivery/paywall.ex
+++ b/lib/oli/delivery/paywall.ex
@@ -1,5 +1,8 @@
 defmodule Oli.Delivery.Paywall do
   import Ecto.Query, warn: false
+
+  require Logger
+
   alias Oli.Repo
   alias Oli.Accounts.User
   alias Oli.Delivery.Paywall.Payment
@@ -138,7 +141,8 @@ defmodule Oli.Delivery.Paywall do
         {:ok, List.flatten(rows) |> Enum.map(fn c -> trunc(c) end)}
 
       {:error, e} ->
-        IO.inspect(e)
+        Logger.error("could not generate random codes: #{inspect(e)}")
+
         {:error, "could not generate random codes"}
     end
   end

--- a/lib/oli/grading.ex
+++ b/lib/oli/grading.ex
@@ -3,6 +3,7 @@ defmodule Oli.Grading do
   Grading is responsible for compiling attempts into usable gradebook representation
   consumable by various tools such as Excel (CSV) or an LMS API.
   """
+  require Logger
 
   alias Oli.Publishing.DeliveryResolver
   alias Oli.Delivery.Sections
@@ -70,8 +71,8 @@ defmodule Oli.Grading do
           e -> e
         end
 
-      e ->
-        e |> IO.inspect()
+      {:error, e} ->
+        Logger.error(e)
     end
   end
 

--- a/lib/oli/qa/reviewers/pedagogy.ex
+++ b/lib/oli/qa/reviewers/pedagogy.ex
@@ -1,5 +1,8 @@
 defmodule Oli.Qa.Reviewers.Pedagogy do
   import Ecto.Query, warn: false
+
+  require Logger
+
   alias Oli.Publishing
   alias Oli.Authoring.Course
   alias Oli.Resources
@@ -18,8 +21,8 @@ defmodule Oli.Qa.Reviewers.Pedagogy do
         |> no_attached_activities(pages)
         |> Reviews.mark_review_done()
 
-      {:error, error} ->
-        IO.inspect(error)
+      {:error, e} ->
+        Logger.error("failed to create review: #{inspect(e)}")
     end
 
     project_slug

--- a/lib/oli_web/controllers/open_and_free_controller.ex
+++ b/lib/oli_web/controllers/open_and_free_controller.ex
@@ -33,8 +33,6 @@ defmodule OliWeb.OpenAndFreeController do
     source =
       case id do
         "product:" <> id ->
-          IO.inspect(id)
-
           Sections.get_section!(String.to_integer(id))
 
         "publication:" <> id ->


### PR DESCRIPTION
Removes inspect statements, replacing them with Logger where needed. This is not only best practice and enables these to be better analyzed when we have a better logging solution in place, but also allows these conditions to be caught in unit tests.