### PR TITLE
PMP-1942 | JAN-750 (updated)

### DIFF
--- a/assets/src/components/parts/janus-text-flow/Markup.tsx
+++ b/assets/src/components/parts/janus-text-flow/Markup.tsx
@@ -104,7 +104,10 @@ const Markup: React.FC<any> = ({
     // empty elements in HTML don't stay in the flow
     // add a non breaking space instead of nothing
 
-    processedText = processedText.length < 2 ? '\u00a0' : processedText.replace(/ \s/g, '\u00a0 ');
+    processedText =
+      processedText.length < 2 && !processedText.trim()
+        ? '\u00a0'
+        : processedText.replace(/ \s/g, '\u00a0 ');
   } else if (processedText.length !== processedText.trim().length) {
     // check if text has leading and trailing spaces.
     //handling the leading blank spacecs in the span


### PR DESCRIPTION
HTML tags having only a single character were replaced by &nbsp, so handled that as well in this. Since the previous PR [#1678](https://github.com/Simon-Initiative/oli-torus/pull/1678) has been merged therefore creating new PR.
