### PR TITLE
[BUGFIX/FEATURE] PMP-1979 JAN-779 screen size

### DIFF
--- a/assets/src/apps/authoring/components/PropertyEditor/schemas/lesson.ts
+++ b/assets/src/apps/authoring/components/PropertyEditor/schemas/lesson.ts
@@ -168,7 +168,8 @@ export const transformSchemaToModel = (schema: any) => {
   try {
     variables = JSON.parse(schema.CustomLogic.variables);
   } catch (e) {
-    console.warn('could not parse variables', e);
+    // console.warn('could not parse variables', e);
+    // most likely just empty string
   }
 
   return {

--- a/assets/src/apps/authoring/components/PropertyEditor/schemas/screen.ts
+++ b/assets/src/apps/authoring/components/PropertyEditor/schemas/screen.ts
@@ -28,8 +28,14 @@ const screenSchema: JSONSchema7 = {
       type: 'object',
       title: 'Dimensions',
       properties: {
-        width: { type: 'number' },
-        height: { type: 'number' },
+        width: { type: 'number', title: 'Width' },
+        height: { type: 'number', title: 'Height' },
+        applyScreenHeight: {
+          type: 'boolean',
+          title: 'Apply Height',
+          default: false,
+          description: 'If checked, the height will be applied, otherwise auto.',
+        },
       },
     },
     palette: {
@@ -165,7 +171,7 @@ export const transformScreenModeltoSchema = (activity?: IActivity) => {
     return {
       ...data,
       title: activity?.title || '',
-      Size: { width: data.width, height: data.height },
+      Size: { width: data.width, height: data.height, applyScreenHeight: !!data.applyScreenHeight },
       checkButton: { showCheckBtn: data.showCheckBtn, checkButtonLabel: data.checkButtonLabel },
       max: { maxAttempt: data.maxAttempt, maxScore: data.maxScore },
       palette: data.palette.useHtmlProps ? data.palette : schemaPalette,
@@ -178,6 +184,7 @@ export const transformScreenSchematoModel = (schema: any): Partial<ScreenModel> 
     title: schema.title,
     width: schema.Size.width,
     height: schema.Size.height,
+    applyScreenHeight: schema.Size.applyScreenHeight,
     customCssClass: schema.customCssClass,
     combineFeedback: schema.combineFeedback,
     showCheckBtn: schema.checkButton.showCheckBtn,

--- a/assets/src/apps/delivery/layouts/deck/DeckLayoutView.tsx
+++ b/assets/src/apps/delivery/layouts/deck/DeckLayoutView.tsx
@@ -203,6 +203,21 @@ const DeckLayoutView: React.FC<LayoutProps> = ({ pageTitle, pageContent, preview
       return;
     }
 
+    const screenWidth =
+      currentActivity.content.custom.width || pageContent.custom.defaultScreenWidth;
+    const screenHeight =
+      currentActivity.content.custom.height || pageContent.custom.defaultScreenHeight;
+    const applyScreenHeight = currentActivity.content.custom.applyScreenHeight;
+    setContentStyles(() => {
+      const styles: any = {
+        width: screenWidth,
+      };
+      if (applyScreenHeight) {
+        styles.height = screenHeight;
+      }
+      return styles;
+    });
+
     // set loaded and userRole class when currentActivity is loaded
     let customClasses = currentActivity.content?.custom?.customCssClass || '';
 
@@ -234,7 +249,7 @@ const DeckLayoutView: React.FC<LayoutProps> = ({ pageTitle, pageContent, preview
       clearTimeout(timeout);
       sharedActivityPromise = null;
     };
-  }, [currentActivityTree]);
+  }, [currentActivityTree, pageContent]);
 
   useEffect(() => {
     // clear the body classes in prep for the real classes


### PR DESCRIPTION
in delivery the screen should use the size settings if they have been defined for the screen rather than always the lesson default.
in authoring allow for screens to have a fixed height (default false)