### PR TITLE
[BUG FIX] Fix some text editor / popup issues

### DIFF
--- a/assets/src/components/editing/models/link/DisplayLink.tsx
+++ b/assets/src/components/editing/models/link/DisplayLink.tsx
@@ -1,14 +1,14 @@
-import React, { useEffect } from 'react';
-import * as Persistence from 'data/persistence/resource';
+import { createButtonCommandDesc } from 'components/editing/commands/commands';
 import { CommandContext } from 'components/editing/commands/interfaces';
+import { FormattingToolbar } from 'components/editing/toolbars/formatting/Toolbar';
+import * as Persistence from 'data/persistence/resource';
+import React, { useEffect } from 'react';
 import {
-  toInternalLink,
-  LinkablePages,
   isInternalLink,
+  LinkablePages,
+  toInternalLink,
   translateDeliveryToAuthoring,
 } from './utils';
-import { createButtonCommandDesc } from 'components/editing/commands/commands';
-import { FormattingToolbar } from 'components/editing/toolbars/formatting/Toolbar';
 
 type Props = {
   setEditLink: React.Dispatch<React.SetStateAction<boolean>>;
@@ -90,7 +90,9 @@ export const DisplayLink = (props: Props) => {
       createButtonCommandDesc({
         icon: 'edit',
         description: 'Edit link',
-        execute: () => setEditLink(true),
+        execute: () => {
+          setEditLink(true);
+        },
       }),
     ],
   ];

--- a/assets/src/components/editing/models/link/EditLink.tsx
+++ b/assets/src/components/editing/models/link/EditLink.tsx
@@ -1,13 +1,15 @@
-import React, { useState } from 'react';
-import * as Persistence from 'data/persistence/resource';
 import { onEnterApply } from 'components/editing/models/settings/Settings';
-import { toInternalLink, normalizeHref, isInternalLink } from './utils';
+import { CloseButton } from 'components/misc/CloseButton';
+import * as Persistence from 'data/persistence/resource';
+import React, { useState } from 'react';
+import { isInternalLink, normalizeHref, toInternalLink } from './utils';
 
 type ExistingLinkEditorProps = {
   href: string;
   onEdit: (href: string) => void;
   pages: Persistence.PagesReceived;
 
+  setEditLink: React.Dispatch<React.SetStateAction<boolean>>;
   selectedPage: Persistence.Page;
   setSelectedPage: React.Dispatch<React.SetStateAction<Persistence.Page | null>>;
 };
@@ -27,37 +29,40 @@ export const EditLink = (props: ExistingLinkEditorProps) => {
   };
 
   return (
-    <div className="settings-editor-wrapper">
+    <div className="settings-editor-wrapper" onFocus={(e) => e.preventDefault()}>
       <div className="settings-editor">
-        <div className="mb-2">
-          <div className="form-check">
-            <input
-              className="form-check-input"
-              defaultChecked={source === 'page'}
-              onChange={onChangeSource}
-              type="radio"
-              name="inlineRadioOptions"
-              id="inlineRadio1"
-              value="page"
-            />
-            <label className="form-check-label" htmlFor="inlineRadio1">
-              Link to Page in the Course
-            </label>
+        <div className="mb-2 d-flex justify-content-between">
+          <div className="d-flex flex-column">
+            <div className="form-check">
+              <input
+                className="form-check-input"
+                defaultChecked={source === 'page'}
+                onChange={onChangeSource}
+                type="radio"
+                name="inlineRadioOptions"
+                id="inlineRadio1"
+                value="page"
+              />
+              <label className="form-check-label" htmlFor="inlineRadio1">
+                Link to Page in the Course
+              </label>
+            </div>
+            <div className="form-check">
+              <input
+                className="form-check-input"
+                defaultChecked={source === 'url'}
+                onChange={onChangeSource}
+                type="radio"
+                name="inlineRadioOptions"
+                id="inlineRadio2"
+                value="url"
+              />
+              <label className="form-check-label" htmlFor="inlineRadio2">
+                Link to External Web Page
+              </label>
+            </div>
           </div>
-          <div className="form-check">
-            <input
-              className="form-check-input"
-              defaultChecked={source === 'url'}
-              onChange={onChangeSource}
-              type="radio"
-              name="inlineRadioOptions"
-              id="inlineRadio2"
-              value="url"
-            />
-            <label className="form-check-label" htmlFor="inlineRadio2">
-              Link to External Web Page
-            </label>
-          </div>
+          <CloseButton editMode={true} onClick={() => props.setEditLink(false)} />
         </div>
         <form className="form-inline">
           <label className="sr-only">Link</label>
@@ -85,6 +90,7 @@ export const EditLink = (props: ExistingLinkEditorProps) => {
             <input
               type="text"
               value={href}
+              placeholder="www.google.com"
               onChange={(e) => setHref(e.target.value)}
               onKeyPress={(e) => onEnterApply(e, () => props.onEdit(normalizeHref(href)))}
               className={'form-control mr-sm-2'}

--- a/assets/src/components/editing/models/link/Editor.tsx
+++ b/assets/src/components/editing/models/link/Editor.tsx
@@ -1,17 +1,22 @@
-import React, { useState } from 'react';
-import { Popover } from 'react-tiny-popover';
-import * as ContentModel from 'data/content/model';
-import { updateModel } from 'components/editing/models/utils';
 import { EditorProps } from 'components/editing/models/interfaces';
-import { LinkablePages } from 'components/editing/models/link/utils';
-import { EditLink } from 'components/editing/models/link/EditLink';
 import { DisplayLink } from 'components/editing/models/link/DisplayLink';
+import { EditLink } from 'components/editing/models/link/EditLink';
+import { LinkablePages } from 'components/editing/models/link/utils';
+import { updateModel } from 'components/editing/models/utils';
+import { HoveringToolbar } from 'components/editing/toolbars/HoveringToolbar';
+import * as ContentModel from 'data/content/model';
+import { centeredAbove } from 'data/content/utils';
 import * as Persistence from 'data/persistence/resource';
-// eslint-disable-next-line
+import React, { useState } from 'react';
+import { Range } from 'slate';
+import { useFocused, useSelected } from 'slate-react';
+
 export interface Props extends EditorProps<ContentModel.Hyperlink> {}
 
 export const LinkEditor = (props: Props) => {
-  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const focused = useFocused();
+  const selected = useSelected();
+
   const [editLink, setEditLink] = useState(false);
 
   // All of the pages that we have available in the course
@@ -21,33 +26,52 @@ export const LinkEditor = (props: Props) => {
   // The selected page, when in link from page mode
   const [selectedPage, setSelectedPage] = useState(null as Persistence.Page | null);
 
+  const isEditButton = editLink && selectedPage && pages.type === 'success';
+
   const { attributes, children, editor, model } = props;
 
   const onEdit = (href: string) => {
     if (href !== '' && href !== model.href) {
       updateModel<ContentModel.Hyperlink>(editor, model, { href });
     }
-    setIsPopoverOpen(false);
+    setEditLink(false);
   };
 
+  const toolbarYOffset = isEditButton ? 132 : 50;
+  const isToolbarOpen =
+    (focused && selected && !!editor.selection && Range.isCollapsed(editor.selection)) || editLink;
+
   return (
-    <Popover
-      onClickOutside={() => setIsPopoverOpen(false)}
-      isOpen={isPopoverOpen}
-      padding={25}
-      content={() => {
-        if (editLink && selectedPage && pages.type === 'success') {
-          return (
-            <EditLink
-              href={model.href}
-              onEdit={onEdit}
-              pages={pages}
-              selectedPage={selectedPage}
-              setSelectedPage={setSelectedPage}
-            />
-          );
-        }
-        return (
+    <HoveringToolbar
+      isOpen={() => isToolbarOpen}
+      showArrow
+      target={
+        <a
+          id={props.model.id}
+          href="#"
+          className="inline-link"
+          {...attributes}
+          onClick={() => {
+            setEditLink(false);
+          }}
+        >
+          {children}
+        </a>
+      }
+      contentLocation={(loc) => centeredAbove(loc, toolbarYOffset)}
+    >
+      <>
+        {isEditButton && (
+          <EditLink
+            setEditLink={setEditLink}
+            href={model.href}
+            onEdit={onEdit}
+            pages={pages}
+            selectedPage={selectedPage}
+            setSelectedPage={setSelectedPage}
+          />
+        )}
+        {!isEditButton && (
           <DisplayLink
             setEditLink={setEditLink}
             commandContext={props.commandContext}
@@ -57,21 +81,8 @@ export const LinkEditor = (props: Props) => {
             selectedPage={selectedPage}
             setSelectedPage={setSelectedPage}
           />
-        );
-      }}
-    >
-      <a
-        id={props.model.id}
-        href="#"
-        className="inline-link"
-        {...attributes}
-        onClick={() => {
-          setIsPopoverOpen(true);
-          setEditLink(false);
-        }}
-      >
-        {children}
-      </a>
-    </Popover>
+        )}
+      </>
+    </HoveringToolbar>
   );
 };

--- a/assets/src/components/misc/resizer/Resizer.tsx
+++ b/assets/src/components/misc/resizer/Resizer.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, ReactElement, useEffect, useState } from 'react';
+import { BoundingRect, Position } from 'components/misc/resizer/types';
 import { useMousePosition } from 'components/misc/resizer/useMousePosition';
 import {
   boundingRectFromMousePosition,
@@ -6,7 +6,7 @@ import {
   offsetBoundingRect,
   resizeHandleStyles,
 } from 'components/misc/resizer/utils';
-import { BoundingRect, Position } from 'components/misc/resizer/types';
+import React, { ReactElement, useEffect, useState } from 'react';
 
 interface Props {
   onResize: (boundingRect: BoundingRect) => void;

--- a/assets/src/components/misc/resizer/utils.ts
+++ b/assets/src/components/misc/resizer/utils.ts
@@ -215,7 +215,7 @@ const boundingRectHelper = (
         height: offsetHeight,
       };
     case dragHandle === 'e':
-      dw = x - (clientLeft + clientWidth);
+      dw = clientLeft + clientWidth - x;
       dh = 0;
 
       return {
@@ -243,6 +243,9 @@ const boundingRectHelper = (
     case dragHandle === 's':
       dw = 0;
       dh = clientTop + clientHeight - y;
+      console.log(dh);
+
+      console.log('prev height', offsetHeight, 'new height', offsetHeight - dh);
 
       return {
         left: offsetLeft,

--- a/assets/src/data/content/utils.tsx
+++ b/assets/src/data/content/utils.tsx
@@ -1,5 +1,6 @@
 import { ContentItem, ContentTypes } from 'data/content/writers/writer';
 import * as React from 'react';
+import { PopoverState } from 'react-tiny-popover';
 import { Text } from 'slate';
 import { isModelElement, MediaDisplayMode, ModelElement } from './model';
 import { StructuredContent } from './resource';
@@ -62,15 +63,9 @@ export function getContentDescription(content: StructuredContent): JSX.Element {
   return <i>Empty</i>;
 }
 
-export const centeredAbove = ({
-  popoverRect,
-  childRect,
-}: {
-  popoverRect: ClientRect;
-  childRect: ClientRect;
-}) => {
+export const centeredAbove = ({ popoverRect, childRect }: PopoverState, yOffset = 50) => {
   return {
-    top: childRect.top + window.pageYOffset - 50,
+    top: childRect.top + window.pageYOffset - yOffset,
     left: childRect.left + window.pageXOffset + childRect.width / 2 - popoverRect.width / 2,
   };
 };


### PR DESCRIPTION
- Fix image resizing drag handle
- Fix link editing tooltip overlapping with text formatting tooltip that opens when dragging a selection with the link editing tooltip open

The tooltips are still not perfect, there's still that issue where it sometimes jumps to the top left corner of the page after closing (from a react-tiny-popover weirdness I can't pin down), and dragging selections of text can be weird (something to do with slate).