### PR TITLE
[BUGFIX] #NOISSUE strip out resourceId from model before persist

### DIFF
--- a/assets/src/apps/authoring/store/page/actions/savePage.ts
+++ b/assets/src/apps/authoring/store/page/actions/savePage.ts
@@ -1,6 +1,7 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import { ResourceContent } from 'data/content/resource';
 import { edit, Edited, ResourceUpdate } from 'data/persistence/resource';
+import { clone } from 'utils/common';
 import { selectAll as selectAllGroups } from '../../../../delivery/store/features/groups/slice';
 import { selectProjectSlug } from '../../app/slice';
 import { RootState } from '../../rootReducer';
@@ -29,11 +30,25 @@ export const savePage = createAsyncThunk(
         : currentPage.displayApplicationChrome;
 
     // the API expects to overwrite all the properties every time
+
+    // need to strip out resourceId from the model items and their children
+    // we don't want to persist that value
+    const updatedModel = clone(model);
+    const removeResourceId = (items: any[]) => {
+      items.forEach((item) => {
+        delete item.resourceId;
+        if (item.children) {
+          removeResourceId(item.children);
+        }
+      });
+    };
+    removeResourceId(updatedModel);
+
     const update: ResourceUpdate = {
       title: payload.title || currentPage.title,
       objectives: payload.objectives || currentPage.objectives,
       content: {
-        model: model as ResourceContent[],
+        model: updatedModel as ResourceContent[],
         advancedAuthoring,
         advancedDelivery,
         displayApplicationChrome,


### PR DESCRIPTION
persisting the resourceId will cause issues when reading it back after ingesting to a new system