### PR TITLE
PMP-1877 - Alignment issues of textflow elements

### DIFF
--- a/assets/src/components/parts/janus-text-flow/Markup.tsx
+++ b/assets/src/components/parts/janus-text-flow/Markup.tsx
@@ -131,10 +131,7 @@ const Markup: React.FC<any> = ({
     // empty elements in HTML don't stay in the flow
     // add a non breaking space instead of nothing
 
-    processedText =
-      processedText.length < 2 && !processedText.trim()
-        ? '\u00a0'
-        : processedText.replace(/ \s/g, '\u00a0 ');
+    processedText = processedText.length < 2 && !processedText.trim() ? '\u00a0' : processedText;
   }
   if (processedText.length !== processedText.trimLeft().length) {
     const noOfleadingSpaces = processedText.length - processedText.trimLeft().length;


### PR DESCRIPTION
This fix basically handles the leading spaces in the text of tag textflow. Multiple sccenarios were there i.e. having one or multiple leading spaces, having multiple spaces in between words.
I tried using regex but its not returning the leading spaces as we want so i have to go with this workaround. Let me konw if there is any modifications need to be done.