### PR TITLE
[BUG FIX] replace history when query params are changed

### DIFF
--- a/lib/oli_web/live/common/sortable_table/table_handers.ex
+++ b/lib/oli_web/live/common/sortable_table/table_handers.ex
@@ -29,7 +29,8 @@ defmodule OliWeb.Common.SortableTable.TableHandlers do
                  socket.assigns.offset,
                  socket.assigns.filter
                )
-             )
+             ),
+           replace: true
          )}
       end
 
@@ -44,7 +45,8 @@ defmodule OliWeb.Common.SortableTable.TableHandlers do
                  socket.assigns.offset,
                  ""
                )
-             )
+             ),
+           replace: true
          )}
       end
 
@@ -59,7 +61,8 @@ defmodule OliWeb.Common.SortableTable.TableHandlers do
                  String.to_integer(offset),
                  socket.assigns.applied_filter
                )
-             )
+             ),
+           replace: true
          )}
       end
 
@@ -78,7 +81,8 @@ defmodule OliWeb.Common.SortableTable.TableHandlers do
              @table_push_patch_path.(
                socket,
                get_patch_params(table_model, offset, socket.assigns.applied_filter)
-             )
+             ),
+           replace: true
          )}
       end
 

--- a/lib/oli_web/live/grades/gradebook_view.ex
+++ b/lib/oli_web/live/grades/gradebook_view.ex
@@ -183,7 +183,8 @@ defmodule OliWeb.Grades.GradebookView do
              },
              changes
            )
-         )
+         ),
+       replace: true
      )}
   end
 

--- a/lib/oli_web/live/projects/projects_live.ex
+++ b/lib/oli_web/live/projects/projects_live.ex
@@ -261,7 +261,8 @@ defmodule OliWeb.Projects.ProjectsLive do
              },
              changes
            )
-         )
+         ),
+       replace: true
      )}
   end
 

--- a/lib/oli_web/live/qa/qa_live.ex
+++ b/lib/oli_web/live/qa/qa_live.ex
@@ -90,7 +90,8 @@ defmodule OliWeb.Qa.QaLive do
            OliWeb.Qa.QaLive,
            state.project.slug,
            State.to_params(filters, selected_id)
-         )
+         ),
+       replace: true
      )}
   end
 
@@ -105,7 +106,8 @@ defmodule OliWeb.Qa.QaLive do
            OliWeb.Qa.QaLive,
            socket.assigns.project.slug,
            State.to_params(filters, warning_id)
-         )
+         ),
+       replace: true
      )}
   end
 

--- a/lib/oli_web/live/sections/enrollments_view.ex
+++ b/lib/oli_web/live/sections/enrollments_view.ex
@@ -149,7 +149,8 @@ defmodule OliWeb.Sections.EnrollmentsView do
              },
              changes
            )
-         )
+         ),
+       replace: true
      )}
   end
 

--- a/lib/oli_web/live/sections/sections_view.ex
+++ b/lib/oli_web/live/sections/sections_view.ex
@@ -161,7 +161,8 @@ defmodule OliWeb.Sections.SectionsView do
              },
              changes
            )
-         )
+         ),
+       replace: true
      )}
   end
 

--- a/lib/oli_web/live/users/authors_view.ex
+++ b/lib/oli_web/live/users/authors_view.ex
@@ -145,7 +145,8 @@ defmodule OliWeb.Users.AuthorsView do
              },
              changes
            )
-         )
+         ),
+       replace: true
      )}
   end
 

--- a/lib/oli_web/live/users/users_view.ex
+++ b/lib/oli_web/live/users/users_view.ex
@@ -143,7 +143,8 @@ defmodule OliWeb.Users.UsersView do
              },
              changes
            )
-         )
+         ),
+       replace: true
      )}
   end
 


### PR DESCRIPTION
This PR changes push_params logic in the table views (and some others where it makes sense) to replace the browser state instead of pushing a new one to maintain a sensible browser history.