### PR TITLE
[BUGFIX] fix product remix access by supplying breadcrumb attribute for LV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 ### Enhancements
 
+## 0.14.3 (2021-11-01)
+
+### Bug Fixes
+
+- Fix problem with accessing course product remix
+
 ## 0.14.2 (2021-10-28)
 
 ### Bug Fixes

--- a/lib/oli_web/live/delivery/remix_section.ex
+++ b/lib/oli_web/live/delivery/remix_section.ex
@@ -124,6 +124,7 @@ defmodule OliWeb.Delivery.RemixSection do
     if Oli.Delivery.Sections.Blueprint.is_author_of_blueprint?(section.slug, current_author_id) or
          Accounts.is_admin?(current_author) do
       init_state(socket,
+        breadcrumbs: set_breadcrumbs(:user, section),
         section: section,
         redirect_after_save: redirect_after_save,
         available_publications: Publishing.all_available_publications()

--- a/lib/oli_web/live/sections/mount.ex
+++ b/lib/oli_web/live/sections/mount.ex
@@ -19,7 +19,10 @@ defmodule OliWeb.Sections.Mount do
         {:error, :not_found}
 
       %Oli.Delivery.Sections.Section{type: :blueprint} = section ->
-        ensure_author_of(section, author_id)
+        case ensure_author_of(section, author_id) do
+          {:error, _} -> ensure_admin(section, author_id)
+          result -> result
+        end
 
       section ->
         case {user_id, author_id} do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Oli.MixProject do
   def project do
     [
       app: :oli,
-      version: "0.14.2",
+      version: "0.14.3",
       elixir: "~> 1.12",
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: elixirc_options(Mix.env()),


### PR DESCRIPTION
This core issue here was that `breadcrumbs` was not set within a particular mount sublogic, which resulted in a failure of a static template render that expected it to be there: 

Nov  1 18:47:41 proton oli: ** (exit) an exception was raised:
Nov  1 18:47:41 proton oli: ** (ArgumentError) errors were found at the given arguments:
Nov  1 18:47:41 proton oli: * 1st argument: not a list
Nov  1 18:47:41 proton oli: :erlang.length(nil)
Nov  1 18:47:41 proton oli: (oli 0.14.2) lib/oli_web/templates/layout/_account_header.html.eex:1: OliWeb.LayoutView."_account_header.html"/1
Nov  1 18:47:41 proton oli: (oli 0.14.2) lib/oli_web/templates/layout/workspace.html.eex:10: OliWeb.LayoutView."workspace.html"/1
