### PR TITLE
[BUGFIX] popup window

### DIFF
--- a/assets/src/components/activities/DeliveryElement.tsx
+++ b/assets/src/components/activities/DeliveryElement.tsx
@@ -46,6 +46,7 @@ export interface DeliveryElementProps<T extends ActivityModelSchema> {
   sectionSlug?: string;
   userId: number;
   notify?: EventEmitter;
+  mountPoint: HTMLElement;
 
   onSaveActivity: (attemptGuid: string, partResponses: PartResponse[]) => Promise<Success>;
   onSubmitActivity: (
@@ -204,6 +205,7 @@ export abstract class DeliveryElement<T extends ActivityModelSchema> extends HTM
       onResize: this.onResize,
       userId,
       notify: this._notify,
+      mountPoint: this.mountPoint,
     };
   }
 

--- a/assets/src/components/activities/DeliveryElement.tsx
+++ b/assets/src/components/activities/DeliveryElement.tsx
@@ -46,7 +46,7 @@ export interface DeliveryElementProps<T extends ActivityModelSchema> {
   sectionSlug?: string;
   userId: number;
   notify?: EventEmitter;
-  mountPoint: HTMLElement;
+  mountPoint?: HTMLElement;
 
   onSaveActivity: (attemptGuid: string, partResponses: PartResponse[]) => Promise<Success>;
   onSubmitActivity: (

--- a/assets/src/components/activities/adaptive/AdaptiveDelivery.tsx
+++ b/assets/src/components/activities/adaptive/AdaptiveDelivery.tsx
@@ -164,12 +164,16 @@ const Adaptive = (props: DeliveryElementProps<AdaptiveModelSchema>) => {
           /* console.log('ACTIVITY READY RESULTS', readyResults); */
           partsInitDeferred.resolve({
             snapshot: readyResults.snapshot || {},
-            context: readyResults.context,
+            context: { ...readyResults.context, host: props.mountPoint },
             env,
           });
         } else {
           // if for some reason this isn't defined, don't leave it hanging
-          partsInitDeferred.resolve({ snapshot: {}, context: { mode: 'VIEWER' }, env: scriptEnv });
+          partsInitDeferred.resolve({
+            snapshot: {},
+            context: { mode: 'VIEWER', host: props.mountPoint },
+            env: scriptEnv,
+          });
         }
       }
       return partsInitDeferred.promise;

--- a/assets/src/components/activities/adaptive/components/authoring/LayoutEditor.tsx
+++ b/assets/src/components/activities/adaptive/components/authoring/LayoutEditor.tsx
@@ -6,9 +6,10 @@ import {
 } from 'apps/delivery/components/NotificationContext';
 import { AnyPartComponent, defaultCapabilities } from 'components/parts/types/parts';
 import EventEmitter from 'events';
-import React, { useCallback, useContext, useEffect, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import Draggable from 'react-draggable';
 import { clone } from 'utils/common';
+import { contexts } from '../../../../../types/applicationContext';
 import PartComponent from '../common/PartComponent';
 
 interface LayoutEditorProps {
@@ -365,9 +366,22 @@ const LayoutEditor: React.FC<LayoutEditorProps> = (props) => {
     };
   }, [pusher]);
 
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const handlePartInit = async ({ id, responses }: { id: string; responses: any[] }) => {
+    console.log('LE:PartInit', { id, responses });
+    return {
+      snapshot: {},
+      context: {
+        mode: contexts.AUTHOR,
+        host: containerRef.current,
+      },
+    };
+  };
+
   return parts && parts.length ? (
     <NotificationContext.Provider value={pusher}>
-      <div className="activity-content">
+      <div ref={containerRef} className="activity-content">
         <style>
           {`
           .activity-content {
@@ -490,7 +504,7 @@ const LayoutEditor: React.FC<LayoutEditorProps> = (props) => {
             configureMode: part.id === configurePartId,
             editMode: true,
             portal: portalId,
-            onInit: defaultHandler,
+            onInit: handlePartInit,
             onReady: defaultHandler,
             onSave: defaultHandler,
             onSubmit: defaultHandler,

--- a/assets/src/components/parts/janus-popup/Popup.tsx
+++ b/assets/src/components/parts/janus-popup/Popup.tsx
@@ -229,16 +229,6 @@ const Popup: React.FC<PartComponentProps<PopupModel>> = (props) => {
     });
   };
 
-  useEffect(() => {
-    const popupModalZ = config?.z || 1000;
-    const zIndexIcon = z || 0;
-    const finalZIndex = showPopup ? Math.max(zIndexIcon + popupModalZ, popupModalZ) : zIndexIcon;
-    const modifiedData = { zIndex: { value: finalZIndex } };
-    if (finalZIndex) {
-      props.onResize({ id: `${id}`, settings: modifiedData });
-    }
-  }, [showPopup, model]);
-
   const partComponents = popup?.partsLayout;
   const config = popup?.custom ? popup.custom : null;
 

--- a/assets/src/components/parts/janus-popup/PopupWindow.tsx
+++ b/assets/src/components/parts/janus-popup/PopupWindow.tsx
@@ -50,7 +50,7 @@ const PopupWindow: React.FC<PopupWindowProps> = ({
   // position is an offset from the parent element now
   popupModalStyles.left = config.x || 0;
   popupModalStyles.top = config.y || 0;
-  popupModalStyles.zIndex = config.z || 0;
+  popupModalStyles.zIndex = config.z || 1000;
   popupModalStyles.height = config.height || 0;
   popupModalStyles.overflow = 'hidden';
   popupModalStyles.position = 'absolute';
@@ -58,7 +58,7 @@ const PopupWindow: React.FC<PopupWindowProps> = ({
   const popupCloseStyles: CSSProperties = {
     position: 'absolute',
     padding: 0,
-    zIndex: (config.z || 0) + 1,
+    zIndex: (config.z || 1000) + 1,
     background: 'transparent',
     textDecoration: 'none',
     width: '25px',
@@ -107,7 +107,7 @@ const PopupWindow: React.FC<PopupWindowProps> = ({
       context,
     };
 
-    console.log('PopupWindow.handlePartInit', { result, id, responses });
+    /*   console.log('PopupWindow.handlePartInit', { result, id, responses }); */
 
     return result;
   };

--- a/assets/src/components/parts/janus-popup/PopupWindow.tsx
+++ b/assets/src/components/parts/janus-popup/PopupWindow.tsx
@@ -7,10 +7,17 @@ interface PopupWindowProps {
   config: any;
   parts: any[];
   context: ContextProps;
+  snapshot?: Record<string, unknown>;
   onClose?: () => void;
 }
 
-const PopupWindow: React.FC<PopupWindowProps> = ({ config, parts, context, onClose }) => {
+const PopupWindow: React.FC<PopupWindowProps> = ({
+  config,
+  parts,
+  context,
+  onClose,
+  snapshot = {},
+}) => {
   const popupModalStyles: CSSProperties = {
     width: config?.width || 300,
   };
@@ -74,17 +81,33 @@ const PopupWindow: React.FC<PopupWindowProps> = ({ config, parts, context, onClo
     height: '100%',
   };
 
+  const closeButtonSpanStyles: CSSProperties = {
+    marginLeft: 12,
+    padding: 0,
+    textShadow: 'none',
+    top: 0,
+    left: 0,
+    bottom: 0,
+    fontWeight: 'bold',
+    fontFamily: 'Arial',
+    marginTop: -6,
+    position: 'absolute',
+    right: 0,
+  };
+
   const handleCloseIconClick = (e: any) => {
     if (onClose) {
       onClose();
     }
   };
 
-  const handlePartInit = () => {
+  const handlePartInit = async ({ id, responses }: { id: string; responses: any[] }) => {
     const result: InitResultProps = {
-      snapshot: {},
+      snapshot,
       context,
     };
+
+    console.log('PopupWindow.handlePartInit', { result, id, responses });
 
     return result;
   };
@@ -102,7 +125,7 @@ const PopupWindow: React.FC<PopupWindowProps> = ({ config, parts, context, onClo
           style={popupCloseStyles}
           onClick={handleCloseIconClick}
         >
-          <span>x</span>
+          <span style={closeButtonSpanStyles}>x</span>
         </button>
       </div>
     </div>

--- a/assets/src/components/parts/janus-popup/delivery-entry.ts
+++ b/assets/src/components/parts/janus-popup/delivery-entry.ts
@@ -13,4 +13,9 @@ const customEvents: any = { ...apiCustomEvents };
 register(Popup, manifest.delivery.element, observedAttributes, {
   customEvents,
   shadow: false,
+  attrs: {
+    model: {
+      json: true,
+    },
+  },
 });

--- a/assets/src/components/parts/janus-popup/types.ts
+++ b/assets/src/components/parts/janus-popup/types.ts
@@ -1,9 +1,11 @@
 export interface ContextProps {
   currentActivity: string;
   mode: string;
+  host?: HTMLElement;
 }
 
 export interface InitResultProps {
   snapshot: Record<string, unknown>;
   context: ContextProps;
+  env?: any;
 }


### PR DESCRIPTION
enable popup to render its window within the context of the activity;
having both the window and icon live within the bounds of the same web component proved to be problematic.
these changes send a reference to the container element that the activity renders its contents into all the way down to the part level. this allows a part to render secondary content (popup's window) within the confines of the activity along side of other parts. this way the window and the icon can have different z indexes and positions.