### PR TITLE
[BUG FIX] wrap create section in db transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bug Fixes
 
+- Fix an issue where simultaneous section creations can result in 2 active sections for a given context
+
 ### Enhancements
 
 ## 0.14.3 (2021-11-01)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-- Fix an issue where simultaneous section creations can result in 2 active sections for a given context
+- Fix an issue where simultaneous section creations can result in more than one active sections for a given context
 
 ### Enhancements
 

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -384,7 +384,22 @@ defmodule Oli.Delivery.Sections do
         limit: 1,
         select: s
     )
-    |> List.first()
+    |> one_or_warn(context_id)
+  end
+
+  defp one_or_warn(result, context_id) do
+    case result do
+      [] ->
+        nil
+
+      [first] ->
+        first
+
+      [first | _] ->
+        Logger.warn("More than one active section was returned for context_id #{context_id}")
+
+        first
+    end
   end
 
   @doc """

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -30,6 +30,8 @@ defmodule Oli.Delivery.Sections do
   alias Oli.Delivery.Updates.Broadcaster
   alias Oli.Delivery.Sections.EnrollmentBrowseOptions
 
+  require Logger
+
   def browse_enrollments(
         %Section{id: section_id},
         %Paging{limit: limit, offset: offset},
@@ -369,7 +371,7 @@ defmodule Oli.Delivery.Sections do
     issuer = lti_params["iss"]
     client_id = lti_params["aud"]
 
-    Repo.one(
+    Repo.all(
       from s in Section,
         join: d in Deployment,
         on: s.lti_1p3_deployment_id == d.id,
@@ -378,8 +380,11 @@ defmodule Oli.Delivery.Sections do
         where:
           s.context_id == ^context_id and s.status != :deleted and r.issuer == ^issuer and
             r.client_id == ^client_id,
+        order_by: [asc: :id],
+        limit: 1,
         select: s
     )
+    |> List.first()
   end
 
   @doc """

--- a/lib/oli/delivery/sections/section.ex
+++ b/lib/oli/delivery/sections/section.ex
@@ -122,6 +122,7 @@ defmodule Oli.Delivery.Sections.Section do
     |> validate_required_if([:grace_period_days], &has_grace_period?/1)
     |> validate_positive_grace_period()
     |> Oli.Delivery.Utils.validate_positive_money(:amount)
+    |> unique_constraint(:context_id, name: :sections_active_context_id_unique_index)
     |> Slug.update_never("sections")
   end
 

--- a/lib/oli/utils/db_seeder.ex
+++ b/lib/oli/utils/db_seeder.ex
@@ -324,7 +324,7 @@ defmodule Oli.Seeder do
         title: "1",
         timezone: "1",
         registration_open: true,
-        context_id: "1",
+        context_id: UUID.uuid4(),
         institution_id: map.institution.id,
         base_project_id: map.project.id
       })
@@ -336,7 +336,7 @@ defmodule Oli.Seeder do
         title: "2",
         timezone: "1",
         registration_open: true,
-        context_id: "2",
+        context_id: UUID.uuid4(),
         institution_id: map.institution.id,
         base_project_id: map.project.id
       })
@@ -349,7 +349,7 @@ defmodule Oli.Seeder do
         timezone: "1",
         registration_open: true,
         open_and_free: true,
-        context_id: "3",
+        context_id: UUID.uuid4(),
         institution_id: map.institution.id,
         base_project_id: map.project.id
       })
@@ -381,7 +381,7 @@ defmodule Oli.Seeder do
       start_date: ~U[2010-04-17 00:00:00.000000Z],
       timezone: "some timezone",
       title: "some title",
-      context_id: "context_id",
+      context_id: UUID.uuid4(),
       base_project_id: map.project.id,
       institution_id: map.institution.id
     }
@@ -403,7 +403,7 @@ defmodule Oli.Seeder do
           start_date: ~U[2010-04-17 00:00:00.000000Z],
           timezone: "some timezone",
           title: "some title",
-          context_id: "context_id",
+          context_id: UUID.uuid4(),
           base_project_id: map.project.id,
           institution_id: map.institution.id
         },

--- a/priv/repo/migrations/20211102141706_ensure_unique_active_section.exs
+++ b/priv/repo/migrations/20211102141706_ensure_unique_active_section.exs
@@ -1,8 +1,0 @@
-defmodule Oli.Repo.Migrations.EnsureUniqueActiveSection do
-  use Ecto.Migration
-
-  def change do
-    # guarantee there is only ever one active section with a given context id
-    create unique_index(:sections, [:context_id], where: "status = 'active'", name: :sections_active_context_id_unique_index)
-  end
-end

--- a/priv/repo/migrations/20211102141706_ensure_unique_active_section.exs
+++ b/priv/repo/migrations/20211102141706_ensure_unique_active_section.exs
@@ -1,0 +1,8 @@
+defmodule Oli.Repo.Migrations.EnsureUniqueActiveSection do
+  use Ecto.Migration
+
+  def change do
+    # guarantee there is only ever one active section with a given context id
+    create unique_index(:sections, [:context_id], where: "status = 'active'", name: :sections_active_context_id_unique_index)
+  end
+end

--- a/test/oli/accounts/user_browse_test.exs
+++ b/test/oli/accounts/user_browse_test.exs
@@ -27,7 +27,7 @@ defmodule Oli.Accounts.UserBrowseTest do
             title: title,
             timezone: "1",
             registration_open: true,
-            context_id: "1",
+            context_id: UUID.uuid4(),
             institution_id:
               if is_nil(institution) do
                 nil

--- a/test/oli/delivery/paywall/providers/stripe_test.exs
+++ b/test/oli/delivery/paywall/providers/stripe_test.exs
@@ -28,7 +28,7 @@ defmodule Oli.Delivery.Paywall.Providers.StripeTest do
           timezone: "1",
           registration_open: true,
           grace_period_days: 1,
-          context_id: "1",
+          context_id: UUID.uuid4(),
           institution_id: map.institution.id,
           base_project_id: map.project.id
         })
@@ -45,7 +45,7 @@ defmodule Oli.Delivery.Paywall.Providers.StripeTest do
           registration_open: true,
           has_grace_period: false,
           grace_period_days: 1,
-          context_id: "1",
+          context_id: UUID.uuid4(),
           start_date: DateTime.add(DateTime.utc_now(), -5),
           end_date: DateTime.add(DateTime.utc_now(), 5),
           institution_id: map.institution.id,

--- a/test/oli/delivery/paywall_test.exs
+++ b/test/oli/delivery/paywall_test.exs
@@ -24,7 +24,7 @@ defmodule Oli.Delivery.PaywallTest do
           title: "1",
           timezone: "1",
           registration_open: true,
-          context_id: "1",
+          context_id: UUID.uuid4(),
           institution_id: map.institution.id,
           base_project_id: map.project.id
         })
@@ -41,7 +41,7 @@ defmodule Oli.Delivery.PaywallTest do
           timezone: "1",
           registration_open: true,
           has_grace_period: false,
-          context_id: "1",
+          context_id: UUID.uuid4(),
           start_date: DateTime.add(DateTime.utc_now(), -5),
           end_date: DateTime.add(DateTime.utc_now(), 5),
           institution_id: map.institution.id,
@@ -157,7 +157,7 @@ defmodule Oli.Delivery.PaywallTest do
           title: "1",
           timezone: "1",
           registration_open: true,
-          context_id: "1",
+          context_id: UUID.uuid4(),
           institution_id: map.institution.id,
           base_project_id: map.project.id
         })
@@ -171,7 +171,7 @@ defmodule Oli.Delivery.PaywallTest do
           title: "1",
           timezone: "1",
           registration_open: true,
-          context_id: "1",
+          context_id: UUID.uuid4(),
           institution_id: map.institution.id,
           base_project_id: map.project.id
         })
@@ -189,7 +189,7 @@ defmodule Oli.Delivery.PaywallTest do
           title: "1",
           timezone: "1",
           registration_open: true,
-          context_id: "1",
+          context_id: UUID.uuid4(),
           start_date: DateTime.add(DateTime.utc_now(), -5),
           end_date: DateTime.add(DateTime.utc_now(), 5),
           institution_id: map.institution.id,
@@ -206,7 +206,7 @@ defmodule Oli.Delivery.PaywallTest do
           title: "1",
           timezone: "1",
           registration_open: true,
-          context_id: "1",
+          context_id: UUID.uuid4(),
           start_date: DateTime.add(DateTime.utc_now(), -5),
           end_date: DateTime.add(DateTime.utc_now(), 5),
           institution_id: map.institution.id,
@@ -319,7 +319,7 @@ defmodule Oli.Delivery.PaywallTest do
           title: "1",
           timezone: "1",
           registration_open: true,
-          context_id: "1",
+          context_id: UUID.uuid4(),
           institution_id: map.institution.id,
           base_project_id: map.project.id
         })
@@ -333,7 +333,7 @@ defmodule Oli.Delivery.PaywallTest do
           title: "1",
           timezone: "1",
           registration_open: true,
-          context_id: "1",
+          context_id: UUID.uuid4(),
           institution_id: map.institution.id,
           base_project_id: map.project.id
         })

--- a/test/oli/delivery/sections/blueprint_test.exs
+++ b/test/oli/delivery/sections/blueprint_test.exs
@@ -25,7 +25,7 @@ defmodule Oli.Delivery.Sections.BlueprintTest do
           title: "1",
           timezone: "1",
           registration_open: true,
-          context_id: "1",
+          context_id: UUID.uuid4(),
           institution_id: institution.id,
           base_project_id: project.id
         })
@@ -54,7 +54,7 @@ defmodule Oli.Delivery.Sections.BlueprintTest do
           title: "1",
           timezone: "1",
           registration_open: true,
-          context_id: "1",
+          context_id: UUID.uuid4(),
           institution_id: institution.id,
           base_project_id: project.id
         })
@@ -134,7 +134,7 @@ defmodule Oli.Delivery.Sections.BlueprintTest do
           title: "1",
           timezone: "1",
           registration_open: true,
-          context_id: "1",
+          context_id: UUID.uuid4(),
           institution_id: institution.id,
           base_project_id: another.project.id
         })
@@ -148,7 +148,7 @@ defmodule Oli.Delivery.Sections.BlueprintTest do
           title: "1",
           timezone: "1",
           registration_open: true,
-          context_id: "1",
+          context_id: UUID.uuid4(),
           institution_id: institution.id,
           base_project_id: project.id
         })

--- a/test/oli/delivery/sections/browse_test.exs
+++ b/test/oli/delivery/sections/browse_test.exs
@@ -36,7 +36,7 @@ defmodule Oli.Delivery.Sections.BrowseTest do
             title: title,
             timezone: "1",
             registration_open: true,
-            context_id: "1",
+            context_id: UUID.uuid4(),
             institution_id:
               if is_nil(institution) do
                 nil

--- a/test/oli/delivery/sections/enrollments_browse_test.exs
+++ b/test/oli/delivery/sections/enrollments_browse_test.exs
@@ -34,7 +34,7 @@ defmodule Oli.Delivery.Sections.EnrollmentsBrowseTest do
             title: title,
             timezone: "1",
             registration_open: true,
-            context_id: "1",
+            context_id: UUID.uuid4(),
             institution_id:
               if is_nil(institution) do
                 nil

--- a/test/oli/resources/numbering_test.exs
+++ b/test/oli/resources/numbering_test.exs
@@ -87,7 +87,7 @@ defmodule Oli.Resources.NumberingTest do
           title: "1",
           timezone: "1",
           registration_open: true,
-          context_id: "1",
+          context_id: UUID.uuid4(),
           institution_id: institution.id,
           base_project_id: project.id
         })

--- a/test/oli/sections_test.exs
+++ b/test/oli/sections_test.exs
@@ -150,8 +150,7 @@ defmodule Oli.SectionsTest do
        Map.merge(map, %{section: section, institution: institution, valid_attrs: valid_attrs})}
     end
 
-    test "create_section/1 with valid data creates a section", %{valid_attrs: valid_attrs} do
-      assert {:ok, %Section{} = section} = Sections.create_section(valid_attrs)
+    test "create_section/1 with valid data creates a section", %{section: section} do
       assert section.end_date == ~U[2010-04-17 00:00:00Z]
       assert section.registration_open == true
       assert section.start_date == ~U[2010-04-17 00:00:00Z]
@@ -318,7 +317,7 @@ defmodule Oli.SectionsTest do
           title: "1",
           timezone: "1",
           registration_open: true,
-          context_id: "1",
+          context_id: UUID.uuid4(),
           institution_id: institution.id,
           base_project_id: project.id
         })
@@ -373,7 +372,7 @@ defmodule Oli.SectionsTest do
           title: "1",
           timezone: "1",
           registration_open: true,
-          context_id: "1",
+          context_id: UUID.uuid4(),
           institution_id: institution.id,
           base_project_id: project.id
         })
@@ -488,7 +487,7 @@ defmodule Oli.SectionsTest do
           title: "1",
           timezone: "1",
           registration_open: true,
-          context_id: "1",
+          context_id: UUID.uuid4(),
           institution_id: institution.id,
           base_project_id: project.id
         })
@@ -635,7 +634,7 @@ defmodule Oli.SectionsTest do
           title: "1",
           timezone: "1",
           registration_open: true,
-          context_id: "1",
+          context_id: UUID.uuid4(),
           institution_id: institution.id,
           base_project_id: project.id
         })


### PR DESCRIPTION
This PR fixes an issue that allows multiple active sections to be simultaneously created with the same context id. It also adds a database unique constraint on the `context_id and status = 'active'` so that future sections cannot get caught in this state. Adding this constraint required updating some unit tests.

Closes #1790