### PR TITLE
[BUGFIX] Fix mount logic for remix

### DIFF
--- a/lib/oli_web/live/delivery/remix_section.ex
+++ b/lib/oli_web/live/delivery/remix_section.ex
@@ -96,6 +96,27 @@ defmodule OliWeb.Delivery.RemixSection do
     )
   end
 
+  def mount_as_instructor(socket, section, %{"current_author_id" => current_author_id} = _session) do
+    author = Accounts.get_author!(current_author_id)
+
+    redirect_after_save = Routes.page_delivery_path(OliWeb.Endpoint, :index, section.slug)
+
+    section =
+      section
+      |> Repo.preload(:institution)
+
+    available_publications = Publishing.available_publications(author, section.institution)
+
+    # only permit instructor or admin level access
+
+    init_state(socket,
+      breadcrumbs: set_breadcrumbs(:user, section),
+      section: section,
+      redirect_after_save: redirect_after_save,
+      available_publications: available_publications
+    )
+  end
+
   def mount_as_open_and_free(
         socket,
         section,


### PR DESCRIPTION
Closes #1809 

AppSignal details show the following for params:

```
{
  "section_slug": "eli_test_course"
}
```

And the following for session:

```
{
  "_csrf_token": "LHlW0uMmuUJeHm2MrP7GdXEm",
  "author_auth": "SFMyNTY.OWQwOTYyNWMtNWU3YS00YzU1LWJkM2EtZTUzMDczYzY2ODk4.POLFJIgJki2w9PYYm3h3zIIpPBm79zLlLda0YBCytfQ",
  "csrf_token": "BnAmE2lYISszHX0TCkAKdV88YwtcLDUeJ8JDY-lFFH7vB-88-lTL8tps",
  "current_author_id": 31,
  "section_slug": "eli_test_course"
}
```

The issue here appears that only an author id is present in session, and not a user id.  The fix adds another impl for `mount_as_instructor` that targets admin authors.   

I checked all other views that utilize `Mount.for` and none of them have any similar issues (they all handle mount logic in a more general, robust way)