### PR TITLE
[BUGFIX] Determine authors initials in more robust manner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,19 @@
 # Changelog
 
 ## Unreleased
+
+## 0.14.5 (2021-11-05)
+
 ### Bug Fixes
+
+- Determine author's initials in a more robust manner
+
 ### Enhancements
+
 - New Popup page element
-### Release Notes
 
 ## 0.14.4 (2021-11-04)
+
 ### Bug Fixes
 
 - Fix an issue where simultaneous section creations can result in more than one active sections for a given context

--- a/lib/oli_web/views/layout_view.ex
+++ b/lib/oli_web/views/layout_view.ex
@@ -99,13 +99,28 @@ defmodule OliWeb.LayoutView do
     initials =
       case current_author.name do
         nil ->
-          ""
+          "?"
 
         name ->
-          name
-          |> String.split(~r{\s+})
-          |> Enum.map(&String.at(&1, 0))
-          |> Enum.take(2)
+          name = String.trim(name)
+
+          cond do
+            # After trimming, if a name contains a space that space can only be between two other non-space characters
+            # so we guarantee that two initials can be extracted
+            String.contains?(name, " ") ->
+              name
+              |> String.split(~r{\s+})
+              |> Enum.map(&String.at(&1, 0))
+              |> Enum.take(2)
+
+            # If after trimming there is no space, but there is text, we simply take the first character as a singular
+            String.length(name) > 0 ->
+              String.at(name, 0)
+
+            # If after trimming, there is the empty string, we show the question mark
+            true ->
+              "?"
+          end
       end
 
     icon = raw("<div class=\"user-initials-icon\">#{initials}</div>")

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Oli.MixProject do
   def project do
     [
       app: :oli,
-      version: "0.14.4",
+      version: "0.14.5",
       elixir: "~> 1.12",
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: elixirc_options(Mix.env()),


### PR DESCRIPTION
This handles a problem where the logic to extract initials for the authoring account name fails.  The problem I believe is the handling of both the empty string, and names where there is no space between the first and last name.  