### PR TITLE
[BUGFIX] Fix HTML special character client-side rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- Fix the rendering of HTML special characters within activities
+
+### Enhancements
+
 ## 0.14.5 (2021-11-05)
 
 ### Bug Fixes

--- a/assets/src/data/content/writers/html.tsx
+++ b/assets/src/data/content/writers/html.tsx
@@ -43,15 +43,6 @@ import { Next, WriterImpl } from './writer';
 // Important: any changes to this file must be replicated
 // in content/html.ex for non-activity rendering.
 
-function escapeHtml(unsafe: string): string {
-  return unsafe
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
-}
-
 export class HtmlParser implements WriterImpl {
   private escapeXml = (text: string) => decodeURI(encodeURI(text));
 
@@ -274,7 +265,7 @@ export class HtmlParser implements WriterImpl {
   }
 
   text(context: WriterContext, textEntity: Text) {
-    return this.wrapWithMarks(escapeHtml(textEntity.text), textEntity);
+    return this.wrapWithMarks(textEntity.text, textEntity);
   }
   unsupported(_context: WriterContext, x: ModelElement) {
     console.error('Content element ' + JSON.stringify(x) + ' is invalid and could not display.');

--- a/assets/test/writer/writer_test.ts
+++ b/assets/test/writer/writer_test.ts
@@ -37,7 +37,7 @@ describe('parser', () => {
         return (
           element?.tagName.toLowerCase() === 'p' &&
           content.startsWith(
-            'The American colonials proclaimed &quot;no taxation without representation',
+            'The American colonials proclaimed "no taxation without representation',
           )
         );
       }),


### PR DESCRIPTION
Closes #1825 

This PR removes the escaping of HTML special characters ( ' " & < > ) which was resulting in them rendering incorrectly. I'm not sure how this ended up getting broken, by my suspicion is that at some point this escaping was necessary given how we *used* to end up rendering the HTML around the raw text.  Given that we now are leveraging React to do this rendering around the text this escaping is simply not needed. 

To test this out, within a page editor create an activity.  Within that activity, place these special characters in the stem, hints, feedback and choices.  Create some code blocks and popups and place them there as well.  With this fix in place, the render correctly in all cases. 
