### PR TITLE
[FEATURE] Instructor "Preview" mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+### Enhancements
+
+- Instructor "Preview" mode
+
 ## 0.14.5 (2021-11-05)
 
 ### Bug Fixes

--- a/assets/src/components/activities/DeliveryElement.tsx
+++ b/assets/src/components/activities/DeliveryElement.tsx
@@ -11,6 +11,7 @@ import {
   PartState,
   StudentResponse,
   Success,
+  DeliveryMode,
 } from './types';
 import React, { useContext } from 'react';
 import { defaultWriterContext, WriterContext } from 'data/content/writers/context';
@@ -41,8 +42,7 @@ export interface DeliveryElementProps<T extends ActivityModelSchema> {
   graded: boolean;
   model: T;
   state: ActivityState;
-  preview: boolean;
-  review: boolean;
+  mode: DeliveryMode;
   sectionSlug?: string;
   userId: number;
   notify?: EventEmitter;
@@ -84,7 +84,7 @@ export interface DeliveryElementProps<T extends ActivityModelSchema> {
 export abstract class DeliveryElement<T extends ActivityModelSchema> extends HTMLElement {
   mountPoint: HTMLDivElement;
   connected: boolean;
-  review: string;
+  review: boolean;
   onGetData?: (attemptGuid: string, partAttemptGuid: string, payload: any) => Promise<any>;
   onSetData?: (attemptGuid: string, partAttemptGuid: string, payload: any) => Promise<any>;
 
@@ -189,19 +189,17 @@ export abstract class DeliveryElement<T extends ActivityModelSchema> extends HTM
     const model = JSON.parse(this.getAttribute('model') as any);
     const graded = JSON.parse(this.getAttribute('graded') as any);
     const state = JSON.parse(this.getAttribute('state') as any) as ActivityState;
-    const preview = valueOr(JSON.parse(this.getAttribute('preview') as any), false);
-    const review = valueOr(JSON.parse(this.getAttribute('review') as any), false);
+    const mode = valueOr(this.getAttribute('mode'), 'delivery') as DeliveryMode;
     const sectionSlug = valueOr(this.getAttribute('section_slug'), undefined);
     const userId = this.getAttribute('user_id') as any;
 
-    this.review = review;
+    this.review = mode === 'review';
 
     return {
       graded,
       model,
       state,
-      preview,
-      review,
+      mode,
       sectionSlug,
       onWriteUserState: this.onSetData,
       onReadUserState: this.onGetData,

--- a/assets/src/components/activities/common/delivery/evaluation/EvaluationConnected.tsx
+++ b/assets/src/components/activities/common/delivery/evaluation/EvaluationConnected.tsx
@@ -5,11 +5,11 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 
 export const EvaluationConnected: React.FC = () => {
-  const { graded, review, writerContext } = useDeliveryElementContext();
+  const { graded, mode, writerContext } = useDeliveryElementContext();
   const uiState = useSelector((state: ActivityDeliveryState) => state);
   return (
     <Evaluation
-      shouldShow={isEvaluated(uiState) && (!graded || review)}
+      shouldShow={isEvaluated(uiState) && (!graded || mode === 'review')}
       attemptState={uiState.attemptState}
       context={writerContext}
     />

--- a/assets/src/components/activities/common/delivery/graded_points/GradedPointsConnected.tsx
+++ b/assets/src/components/activities/common/delivery/graded_points/GradedPointsConnected.tsx
@@ -8,11 +8,11 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 
 export const GradedPointsConnected: React.FC = () => {
-  const { graded, review } = useDeliveryElementContext();
+  const { graded, mode } = useDeliveryElementContext();
   const uiState = useSelector((state: ActivityDeliveryState) => state);
   return (
     <GradedPoints
-      shouldShow={graded && review}
+      shouldShow={graded && mode === 'review'}
       icon={isCorrect(uiState.attemptState) ? <Checkmark /> : <Cross />}
       attemptState={uiState.attemptState}
     />

--- a/assets/src/components/activities/types.ts
+++ b/assets/src/components/activities/types.ts
@@ -6,6 +6,8 @@ import { PathOperation } from 'utils/pathOperations';
 
 export type PostUndoable = (undoable: Undoable) => void;
 
+export type DeliveryMode = 'delivery' | 'review' | 'preview';
+
 export type MediaItemRequest = {
   type: 'MediaItemRequest';
   mimeTypes: string[];

--- a/assets/styles/delivery/page_delivery/page.scss
+++ b/assets/styles/delivery/page_delivery/page.scss
@@ -1,4 +1,4 @@
-@import "delivery/variables";
+@import 'delivery/variables';
 
 h1.title {
   font-weight: 300;
@@ -73,6 +73,42 @@ h1.title {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.selection {
+  border-top: 1px solid $gray-400;
+  border-bottom: 1px solid $gray-400;
+  padding: 10px;
+
+  .title {
+    font-size: 1.2em;
+    font-weight: 600;
+  }
+
+  .tag {
+    background-color: #007bff2c;
+    padding: 4px;
+    outline: none;
+    border-radius: 2px;
+  }
+
+  .objective {
+    background-color: #007bff2c;
+    padding: 4px;
+    outline: none;
+    border-radius: 2px;
+  }
+
+  .activity-name {
+    background-color: #007bff2c;
+    padding: 4px;
+    outline: none;
+    border-radius: 2px;
+  }
+
+  .operator {
+    font-weight: 600;
+  }
 }
 
 #content {

--- a/assets/test/utils/activity_mocks.ts
+++ b/assets/test/utils/activity_mocks.ts
@@ -5,6 +5,7 @@ import {
   ActivityState,
   makeFeedback,
   makeHint,
+  DeliveryMode,
   PartState,
 } from 'components/activities/types';
 
@@ -71,7 +72,7 @@ export const defaultDeliveryElementProps = {
   onResetPart,
   onSubmitEvaluations,
   state: attemptState,
-  review: false,
+  mode: 'delivery' as DeliveryMode,
   userId: 1,
 };
 

--- a/lib/oli/authoring/editing/page_editor.ex
+++ b/lib/oli/authoring/editing/page_editor.ex
@@ -234,12 +234,19 @@ defmodule Oli.Authoring.Editing.PageEditor do
   end
 
   def render_page_html(project_slug, content, author, options \\ []) do
+    mode =
+      if Keyword.get(options, :preview, false) do
+        :author_preview
+      else
+        :delivery
+      end
+
     with {:ok, publication} <-
            Publishing.project_working_publication(project_slug) |> trap_nil(),
          {:ok, activities} <- create_activity_summary_map(publication.id, content),
          render_context <- %Rendering.Context{
            user: author,
-           preview: Keyword.get(options, :preview, false),
+           mode: mode,
            activity_map: activities,
            project_slug: project_slug
          } do
@@ -293,6 +300,7 @@ defmodule Oli.Authoring.Editing.PageEditor do
            model: ActivityContext.prepare_model(transformed, prune: false),
            state: ActivityContext.prepare_state(state),
            delivery_element: type.delivery_element,
+           authoring_element: type.authoring_element,
            script: type.delivery_script,
            graded: graded
          }

--- a/lib/oli/delivery/page/activity_context.ex
+++ b/lib/oli/delivery/page/activity_context.ex
@@ -38,6 +38,7 @@ defmodule Oli.Delivery.Page.ActivityContext do
          model: prepare_model(model),
          state: prepare_state(state),
          delivery_element: type.delivery_element,
+         authoring_element: type.authoring_element,
          script: type.delivery_script,
          graded: graded
        }}
@@ -84,7 +85,7 @@ defmodule Oli.Delivery.Page.ActivityContext do
     end
   end
 
-  defp encode(s) do
+  def encode(s) do
     {:safe, encoded} = HTML.html_escape(s)
     IO.iodata_to_binary(encoded)
   end

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -114,12 +114,18 @@ defmodule Oli.Delivery.Sections do
   Determines if a user is an instructor in a given section.
   """
   def is_instructor?(%User{id: id} = user, section_slug) do
-    is_enrolled?(id, section_slug) &&
-      ContextRoles.has_role?(
-        user,
-        section_slug,
-        ContextRoles.get_role(:context_instructor)
-      )
+    is_enrolled?(id, section_slug) && has_instructor_role?(user, section_slug)
+  end
+
+  @doc """
+  Determines if user has instructor role.
+  """
+  def has_instructor_role?(%User{} = user, section_slug) do
+    ContextRoles.has_role?(
+      user,
+      section_slug,
+      ContextRoles.get_role(:context_instructor)
+    )
   end
 
   @doc """

--- a/lib/oli/rendering/activity/activity_summary.ex
+++ b/lib/oli/rendering/activity/activity_summary.ex
@@ -12,6 +12,7 @@ defmodule Oli.Rendering.Activity.ActivitySummary do
     :state,
     :model,
     :delivery_element,
+    :authoring_element,
     :graded
   ]
   defstruct [
@@ -25,8 +26,9 @@ defmodule Oli.Rendering.Activity.ActivitySummary do
     :state,
     # already encoded json of the model of the activity
     :model,
-    # the webcomponent element
+    # the webcomponent elements
     :delivery_element,
+    :authoring_element,
     # whether or not the activity is rendering in a graded context
     :graded
   ]

--- a/lib/oli/rendering/activity/html.ex
+++ b/lib/oli/rendering/activity/html.ex
@@ -8,12 +8,21 @@ defmodule Oli.Rendering.Activity.Html do
 
   @behaviour Oli.Rendering.Activity
 
+  @spec activity(
+          %Oli.Rendering.Context{
+            :activity_map => nil | maybe_improper_list | map,
+            :mode => any,
+            :render_opts => any,
+            :user => any,
+            optional(any) => any
+          },
+          map
+        ) :: [binary | [<<_::64, _::_*8>>, ...]]
   def activity(
         %Context{
           activity_map: activity_map,
           render_opts: render_opts,
-          preview: preview,
-          review_mode: review_mode,
+          mode: mode,
           user: user
         } = context,
         %{"activity_id" => activity_id, "purpose" => purpose} = activity
@@ -35,15 +44,29 @@ defmodule Oli.Rendering.Activity.Html do
         end
 
       _ ->
-        tag = activity_summary.delivery_element
+        tag =
+          case mode do
+            :instructor_preview -> activity_summary.authoring_element
+            _ -> activity_summary.delivery_element
+          end
+
         state = activity_summary.state
         graded = activity_summary.graded
         model_json = activity_summary.model
         section_slug = context.section_slug
 
-        activity_html = [
-          "<#{tag} class=\"activity-container\" graded=\"#{graded}\" state=\"#{state}\" model=\"#{model_json}\" preview=\"#{preview}\" user_id=\"#{user.id}\" review=\"#{review_mode}\" section_slug=\"#{section_slug}\"></#{tag}>\n"
-        ]
+        activity_html =
+          case mode do
+            :instructor_preview ->
+              [
+                "<#{tag} model=\"#{model_json}\" editmode=\"false\" projectSlug=\"#{section_slug}\"></#{tag}>\n"
+              ]
+
+            _ ->
+              [
+                "<#{tag} class=\"activity-container\" graded=\"#{graded}\" state=\"#{state}\" model=\"#{model_json}\" mode=\"#{mode}\" user_id=\"#{user.id}\" section_slug=\"#{section_slug}\"></#{tag}>\n"
+              ]
+          end
 
         case purpose do
           "none" ->

--- a/lib/oli/rendering/activity/html.ex
+++ b/lib/oli/rendering/activity/html.ex
@@ -8,16 +8,6 @@ defmodule Oli.Rendering.Activity.Html do
 
   @behaviour Oli.Rendering.Activity
 
-  @spec activity(
-          %Oli.Rendering.Context{
-            :activity_map => nil | maybe_improper_list | map,
-            :mode => any,
-            :render_opts => any,
-            :user => any,
-            optional(any) => any
-          },
-          map
-        ) :: [binary | [<<_::64, _::_*8>>, ...]]
   def activity(
         %Context{
           activity_map: activity_map,

--- a/lib/oli/rendering/content.ex
+++ b/lib/oli/rendering/content.ex
@@ -40,6 +40,8 @@ defmodule Oli.Rendering.Content do
   @callback blockquote(%Context{}, next, %{}) :: [any()]
   @callback a(%Context{}, next, %{}) :: [any()]
   @callback popup(%Context{}, next, %{}) :: [any()]
+  @callback selection(%Context{}, next, %{}) :: [any()]
+
   @callback error(%Context{}, %{}, {Atom.t(), String.t(), String.t()}) :: [any()]
 
   @doc """
@@ -182,6 +184,10 @@ defmodule Oli.Rendering.Content do
           []
         end
     end
+  end
+
+  def render(%Context{} = context, %{"type" => "selection"} = selection, writer) do
+    writer.selection(context, fn -> true end, selection)
   end
 
   # Renders an error message if none of the signatures above match. Logging and rendering of errors

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -223,22 +223,30 @@ defmodule Oli.Rendering.Content.Html do
   end
 
   defp internal_link(
-         %Context{section_slug: section_slug, preview: preview, project_slug: project_slug},
+         %Context{section_slug: section_slug, mode: mode, project_slug: project_slug},
          next,
          href
        ) do
     href =
       case section_slug do
         nil ->
-          if preview do
-            "/authoring/project/#{project_slug}/preview/#{revision_slug_from_course_link(href)}"
-          else
-            "#"
+          case mode do
+            :author_preview ->
+              "/authoring/project/#{project_slug}/preview/#{revision_slug_from_course_link(href)}"
+
+            _ ->
+              "#"
           end
 
         section_slug ->
           # rewrite internal link using section slug and revision slug
-          "/sections/#{section_slug}/page/#{revision_slug_from_course_link(href)}"
+          case mode do
+            :instructor_preview ->
+              "/sections/#{section_slug}/page/#{revision_slug_from_course_link(href)}"
+
+            _ ->
+              "/sections/#{section_slug}/page/#{revision_slug_from_course_link(href)}"
+          end
       end
 
     [~s|<a class="internal-link" href="#{escape_xml!(href)}">|, next.(), "</a>\n"]

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -242,7 +242,7 @@ defmodule Oli.Rendering.Content.Html do
           # rewrite internal link using section slug and revision slug
           case mode do
             :instructor_preview ->
-              "/sections/#{section_slug}/page/#{revision_slug_from_course_link(href)}"
+              "/sections/#{section_slug}/page/#{revision_slug_from_course_link(href)}?mode=review"
 
             _ ->
               "/sections/#{section_slug}/page/#{revision_slug_from_course_link(href)}"

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -291,6 +291,10 @@ defmodule Oli.Rendering.Content.Html do
     ]
   end
 
+  def selection(%Context{} = context, _, selection) do
+    Oli.Rendering.Content.Selection.render(context, selection)
+  end
+
   defp revision_slug_from_course_link(href) do
     href
     |> String.replace_prefix("/course/link/", "")

--- a/lib/oli/rendering/content/plaintext.ex
+++ b/lib/oli/rendering/content/plaintext.ex
@@ -147,6 +147,10 @@ defmodule Oli.Rendering.Content.Plaintext do
     text
   end
 
+  def selection(%Context{} = _context, _, _selection) do
+    ["[Activity Bank Selection]"]
+  end
+
   def error(%Context{} = _context, element, error) do
     case error do
       {:unsupported, error_id, _error_msg} ->

--- a/lib/oli/rendering/content/selection.ex
+++ b/lib/oli/rendering/content/selection.ex
@@ -1,0 +1,125 @@
+defmodule Oli.Rendering.Content.Selection do
+  def render(
+        %Oli.Rendering.Context{
+          section_slug: section_slug,
+          activity_types_map: activity_types_map
+        },
+        %{"logic" => logic, "count" => count} = selection
+      ) do
+    titles = titles_from_selection(section_slug, selection)
+
+    prefix =
+      case count do
+        1 -> "<p>Selecting 1 activity from:</p>"
+        _ -> "<p>Selecting #{count} activities from:</p>"
+      end
+
+    [
+      "<div class=\"selection\"><div class=\"title\">Activity Bank Selection</div>",
+      [prefix, render_html(logic, titles, activity_types_map)],
+      "</div>"
+    ]
+  end
+
+  defp render_html(items, titles, activity_types_map) when is_list(items) do
+    Enum.map(items, fn item -> render_html(item, titles, activity_types_map) end)
+  end
+
+  defp render_html(%{"conditions" => nil}, _, _) do
+    ["<div>All activities</div>"]
+  end
+
+  defp render_html(%{"conditions" => conditions}, titles, activity_types_map) do
+    ["<ul>", render_html(conditions, titles, activity_types_map), "</ul>\n"]
+  end
+
+  defp render_html(%{"children" => children, "operator" => operator}, titles, activity_types_map) do
+    [
+      "<li>#{operator} of the following:<ul>",
+      render_html(children, titles, activity_types_map),
+      "</ul></li>\n"
+    ]
+  end
+
+  defp render_html(
+         %{"fact" => fact, "operator" => operator, "value" => value},
+         title_map,
+         activity_types_map
+       ) do
+    case fact do
+      "text" ->
+        [
+          "<li>Activity <span class=\"operator\">#{desc(operator)}</strong> &quot;#{value}&quot;</li>"
+        ]
+
+      "type" ->
+        [
+          "<li>Type of activity <span class=\"operator\">#{desc(operator)}</span> #{activity_names(value, activity_types_map)}</li>"
+        ]
+
+      "objectives" ->
+        [
+          "<li>Learning objectives <span class=\"operator\">#{desc(operator)}</span> #{titles(value, title_map, "objective")}</li>"
+        ]
+
+      "tags" ->
+        [
+          "<li>Tags <span class=\"operator\">#{desc(operator)}</span> #{titles(value, title_map, "tag")}</li>"
+        ]
+    end
+  end
+
+  defp titles_from_selection(section_slug, %{
+         "logic" => logic
+       }) do
+    case resource_ids(logic) do
+      [] ->
+        %{}
+
+      ids ->
+        Oli.Publishing.DeliveryResolver.from_resource_id(section_slug, ids)
+        |> Enum.reduce(%{}, fn rev, m -> Map.put(m, rev.resource_id, rev.title) end)
+    end
+  end
+
+  defp resource_ids(%{"conditions" => nil}) do
+    []
+  end
+
+  defp resource_ids(%{"conditions" => conditions}) do
+    resource_ids(conditions, [])
+  end
+
+  defp resource_ids(%{"children" => children}, all) do
+    Enum.reduce(children, all, fn c, ids -> resource_ids(c, ids) end)
+  end
+
+  defp resource_ids(%{"value" => value, "fact" => fact}, all) do
+    case fact do
+      "tags" -> value ++ all
+      "objectives" -> value ++ all
+      _ -> all
+    end
+  end
+
+  defp desc("contains"), do: "contains"
+  defp desc("does_not_contain"), do: "does not contain"
+  defp desc("equals"), do: "equals"
+  defp desc("does_not_equal"), do: "does not equal"
+
+  defp activity_names(ids, activity_types_map) when is_list(ids) do
+    Enum.map(ids, fn id -> activity_names(id, activity_types_map) end)
+    |> Enum.join(" ")
+  end
+
+  defp activity_names(id, activity_types_map),
+    do: "<span class=\"activity-name\">#{Map.get(activity_types_map, id).title}</span>"
+
+  defp titles(ids, title_map, class) when is_list(ids) do
+    Enum.map(ids, fn id -> titles(id, title_map, class) end)
+    |> Enum.join(" ")
+  end
+
+  defp titles(id, title_map, class),
+    do: "<span class=\"#{class}\">#{Map.get(title_map, id)}</span>"
+end

--- a/lib/oli/rendering/context.ex
+++ b/lib/oli/rendering/context.ex
@@ -9,8 +9,8 @@ defmodule Oli.Rendering.Context do
             render_opts: %{
               render_errors: true
             },
-            preview: false,
-            review_mode: false,
+            # Mode can be one of  [:delivery, :review, :author_preview, :instructor_preview]
+            mode: :delivery,
             section_slug: nil,
             project_slug: nil
 end

--- a/lib/oli/rendering/context.ex
+++ b/lib/oli/rendering/context.ex
@@ -12,5 +12,6 @@ defmodule Oli.Rendering.Context do
             # Mode can be one of  [:delivery, :review, :author_preview, :instructor_preview]
             mode: :delivery,
             section_slug: nil,
-            project_slug: nil
+            project_slug: nil,
+            activity_types_map: %{}
 end

--- a/lib/oli/rendering/page.ex
+++ b/lib/oli/rendering/page.ex
@@ -26,6 +26,11 @@ defmodule Oli.Rendering.Page do
           %{"type" => "content"} ->
             {element, output ++ writer.content(context, element)}
 
+          # Activity bank selections only are rendered during an instructor preview, otherwise
+          # they have already been realized into specific activity-references
+          %{"type" => "selection"} ->
+            {element, output ++ writer.content(context, element)}
+
           %{"type" => "activity-reference"} ->
             {element, output ++ writer.activity(context, element)}
 

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -125,18 +125,19 @@ defmodule OliWeb.PageDeliveryController do
       end)
       |> Enum.reduce(%{}, fn r, m -> Map.put(m, r.id, r) end)
 
+    all_activities = Activities.list_activity_registrations()
+
     render_context = %Context{
       user: conn.assigns.current_user,
       section_slug: section_slug,
       mode: :instructor_preview,
-      activity_map: activity_map
+      activity_map: activity_map,
+      activity_types_map: Enum.reduce(all_activities, %{}, fn a, m -> Map.put(m, a.id, a) end)
     }
 
     html = Page.render(render_context, page_model, Page.Html)
 
     conn = put_root_layout(conn, {OliWeb.LayoutView, "page.html"})
-
-    all_activities = Activities.list_activity_registrations()
 
     render(
       conn,

--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -83,7 +83,8 @@ defmodule OliWeb.Sections.OverviewView do
       </Group>
       <Group label="Curriculum" description="Manage the content delivered to students">
         <ul class="link-list">
-        <li><a href={Routes.page_delivery_path(OliWeb.Endpoint, :index, @section.slug)}>Enter Course</a></li>
+        <li><a href={Routes.page_delivery_path(OliWeb.Endpoint, :index, @section.slug, mode: "preview")}>Preview Course Content</a></li>
+        <li><a href={Routes.page_delivery_path(OliWeb.Endpoint, :index, @section.slug)}>Enter Course as a Student</a></li>
         <li><a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Delivery.RemixSection, @section.slug)}>Customize Curriculum</a></li>
           <li>
             <a disabled={@updates_count == 0} href={Routes.page_delivery_path(OliWeb.Endpoint, :updates, @section.slug)}>

--- a/lib/oli_web/templates/layout/page.html.eex
+++ b/lib/oli_web/templates/layout/page.html.eex
@@ -4,8 +4,15 @@
     <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/" <> script) %>"></script>
   <% end %>
 
+  <% url =
+    if @conn.assigns.preview_mode do
+      Routes.page_delivery_path(@conn, :index, @section_slug, mode: "preview")
+    else
+      Routes.page_delivery_path(@conn, :index, @section_slug)
+    end
+  %>
   <div class="my-2">
-    <a href="<%= Routes.page_delivery_path(@conn, :index, @section_slug) %>" class="btn btn-link course-btn">
+    <a href="<%= url %>" class="btn btn-link course-btn">
       <i class="fa fa-arrow-left mr-1" aria-hidden="true"></i> Course Overview
     </a>
   </div>

--- a/lib/oli_web/templates/layout/page.html.eex
+++ b/lib/oli_web/templates/layout/page.html.eex
@@ -5,7 +5,7 @@
   <% end %>
 
   <% url =
-    if @conn.assigns.preview_mode do
+    if Map.get(@conn.assigns, :preview_mode, false) do
       Routes.page_delivery_path(@conn, :index, @section_slug, mode: "preview")
     else
       Routes.page_delivery_path(@conn, :index, @section_slug)

--- a/lib/oli_web/templates/page_delivery/_link_assessment.html.eex
+++ b/lib/oli_web/templates/page_delivery/_link_assessment.html.eex
@@ -1,5 +1,13 @@
 <% link_class = "page-link graded-page-link list-group-item list-group-item-action flex-column align-items-start " <> if @active_page == @node.revision.slug, do: "active", else: "" %>
-<%= link to: Routes.page_delivery_path(@conn, :page, @section_slug, @node.revision.slug), class: link_class do %>
+<% url =
+  if @preview_mode do
+    Routes.page_delivery_path(@conn, :page, @section_slug, @node.revision.slug, mode: "preview")
+  else
+    Routes.page_delivery_path(@conn, :page, @section_slug, @node.revision.slug)
+  end
+%>
+
+<%= link to: url, class: link_class do %>
   <div class="d-flex w-100 justify-content-between">
     <span class="page-title">
       <i class="far fa-check-circle mr-2"></i> <%= @node.revision.title %>

--- a/lib/oli_web/templates/page_delivery/_link_page.html.eex
+++ b/lib/oli_web/templates/page_delivery/_link_page.html.eex
@@ -1,5 +1,12 @@
 <% link_class = "page-link ungraded-page-link list-group-item list-group-item-action " <> if @active_page == @node.revision.slug, do: "active", else: "" %>
-<%= link to: Routes.page_delivery_path(@conn, :page, @section_slug, @node.revision.slug), class: link_class do %>
+<% url =
+  if @preview_mode do
+    Routes.page_delivery_path(@conn, :page, @section_slug, @node.revision.slug, mode: "preview")
+  else
+    Routes.page_delivery_path(@conn, :page, @section_slug, @node.revision.slug)
+  end
+%>
+<%= link to: url, class: link_class do %>
   <div class="d-flex w-100 justify-content-between">
     <span class="page-title">
       <i class="far fa-file mr-2"></i> <%= @node.revision.title %>

--- a/lib/oli_web/templates/page_delivery/_outline.html.eex
+++ b/lib/oli_web/templates/page_delivery/_outline.html.eex
@@ -3,9 +3,9 @@
     <%= render "container.html", node: node, conn: @conn, section_slug: @section_slug, summary: @summary, active_page: @active_page %>
   <% else %>
     <%= if node.revision.graded do %>
-      <%= render "_link_assessment.html", node: node, conn: @conn, section_slug: @section_slug, summary: @summary, active_page: @active_page %>
+      <%= render "_link_assessment.html", preview_mode: @preview_mode, node: node, conn: @conn, section_slug: @section_slug, summary: @summary, active_page: @active_page %>
     <% else %>
-      <%= render "_link_page.html", node: node, conn: @conn, section_slug: @section_slug, summary: @summary, active_page: @active_page %>
+      <%= render "_link_page.html", preview_mode: @preview_mode, node: node, conn: @conn, section_slug: @section_slug, summary: @summary, active_page: @active_page %>
     <% end %>
   <% end %>
 <% end %>

--- a/lib/oli_web/templates/page_delivery/_previous_next_nav.html.eex
+++ b/lib/oli_web/templates/page_delivery/_previous_next_nav.html.eex
@@ -1,7 +1,7 @@
 <nav class="previous-next-nav d-flex flex-row" aria-label="Page navigation">
 
   <%= if @previous_page != nil do %>
-    <%= link to: Routes.page_delivery_path(@conn, :page, @section_slug, @previous_page.slug), class: "page-nav-link btn" do %>
+    <%= link to: previous_url(@conn), class: "page-nav-link btn" do %>
       <div class="d-flex flex-row">
         <div>
           <i class="fas fa-arrow-left nav-icon"></i>
@@ -19,7 +19,7 @@
   <div class="flex-grow-1"></div>
 
   <%= if @next_page != nil do %>
-    <%= link to: Routes.page_delivery_path(@conn, :page, @section_slug, @next_page.slug), class: "page-nav-link btn" do %>
+    <%= link to: next_url(@conn), class: "page-nav-link btn" do %>
       <div class="d-flex flex-row">
         <div class="d-flex flex-column flex-fill flex-ellipsize-fix text-left">
           <div class="nav-label">Next</div>

--- a/lib/oli_web/templates/page_delivery/index.html.eex
+++ b/lib/oli_web/templates/page_delivery/index.html.eex
@@ -16,7 +16,7 @@
   <div id="index-container" class="course-outline list-group">
     <h5 class="text-primary border-bottom border-primary mb-2">Course Overview</h5>
 
-    <%= render "_outline.html", conn: @conn, section_slug: @section_slug, summary: @summary, nodes: @summary.hierarchy.children, active_page: nil %>
+    <%= render "_outline.html", conn: @conn, preview_mode: @preview_mode, section_slug: @section_slug, summary: @summary, nodes: @summary.hierarchy.children, active_page: nil %>
   </div>
 
 </div>

--- a/lib/oli_web/templates/page_delivery/instructor_preview.html.eex
+++ b/lib/oli_web/templates/page_delivery/instructor_preview.html.eex
@@ -1,0 +1,11 @@
+<h1 class="title"><%= @title %> (Preview)</h1>
+
+<script>
+window.userToken = "<%= assigns[:user_token] %>";
+</script>
+
+<%= render "_objectives.html", objectives: @objectives %>
+
+<div>
+  <%= raw(@html) %>
+</div>

--- a/lib/oli_web/views/page_delivery_view.ex
+++ b/lib/oli_web/views/page_delivery_view.ex
@@ -4,6 +4,7 @@ defmodule OliWeb.PageDeliveryView do
   alias Oli.Resources.ResourceType
   alias Oli.Resources.Numbering
   alias Oli.Delivery.Hierarchy.HierarchyNode
+  alias OliWeb.Router.Helpers, as: Routes
 
   def show_score(score, out_of) do
     cond do
@@ -14,6 +15,44 @@ defmodule OliWeb.PageDeliveryView do
         (score / out_of * 100)
         |> round
         |> Integer.to_string()
+    end
+  end
+
+  def previous_url(conn) do
+    if Map.get(conn.assigns, :preview_mode, false) do
+      Routes.page_delivery_path(
+        conn,
+        :page,
+        conn.assigns.section_slug,
+        conn.assigns.previous_page.slug,
+        mode: "preview"
+      )
+    else
+      Routes.page_delivery_path(
+        conn,
+        :page,
+        conn.assigns.section_slug,
+        conn.assigns.previous_page.slug
+      )
+    end
+  end
+
+  def next_url(conn) do
+    if Map.get(conn.assigns, :preview_mode, false) do
+      Routes.page_delivery_path(
+        conn,
+        :page,
+        conn.assigns.section_slug,
+        conn.assigns.next_page.slug,
+        mode: "preview"
+      )
+    else
+      Routes.page_delivery_path(
+        conn,
+        :page,
+        conn.assigns.section_slug,
+        conn.assigns.next_page.slug
+      )
     end
   end
 


### PR DESCRIPTION
Closes #1818 
Closes #1819 

This PR implements PR1 and PR2 from https://docs.google.com/document/d/1-zG0RBoZETN2jYUtfPRwRamzopATrEhu9YaVl-xFEls/edit#heading=h.armgq2vqmkmg.   Once I dug into it, it didn't make sense to split this work into two distinct PRs. 

1. Eliminates separate boolean flags for "review" "preview" modes for the `DeliveryElement` webcomponent in favor of a singular `mode` attribute that can take values as defined in `DeliveryMode` ("preview", "review", "delivery"). 
2. Creates a singular "mode" attribute on the server-side HTML rendering framework which can take values [:delivery, :review, :author_preview, :instructor_preview]
2. Changes the HTML activity render to render the Authoring component of an activity when the rendering mode is "instructor_preview". 
3. Implements instructor review mode by appending a "mode=preview" query param to a rendered page (or the outline).
4. Within `page_delivery_controller` specifically handles page render requests where "mode=preview" is set, bypassing the normal flow for an optimal collection of required context to render the page in preview mode. 
5. Adds a new "Preview this Course" link on the course section overview page