### PR TITLE
[BUGFIX] Fix preview

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -113,6 +113,10 @@ defmodule Oli.Delivery.Sections do
   @doc """
   Determines if a user is an instructor in a given section.
   """
+  def is_instructor?(nil, _) do
+    false
+  end
+
   def is_instructor?(%User{id: id} = user, section_slug) do
     is_enrolled?(id, section_slug) && has_instructor_role?(user, section_slug)
   end
@@ -131,6 +135,10 @@ defmodule Oli.Delivery.Sections do
   @doc """
   Determines if a user is an administrator in a given section.
   """
+  def is_admin?(nil, _) do
+    false
+  end
+
   def is_admin?(%User{} = user, section_slug) do
     PlatformRoles.has_roles?(
       user,

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -242,7 +242,7 @@ defmodule Oli.Rendering.Content.Html do
           # rewrite internal link using section slug and revision slug
           case mode do
             :instructor_preview ->
-              "/sections/#{section_slug}/page/#{revision_slug_from_course_link(href)}?mode=review"
+              "/sections/#{section_slug}/preview/page/#{revision_slug_from_course_link(href)}"
 
             _ ->
               "/sections/#{section_slug}/page/#{revision_slug_from_course_link(href)}"

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -22,7 +22,7 @@ defmodule OliWeb.PageDeliveryController do
   alias Oli.PartComponents
   alias Oli.Rendering.Activity.ActivitySummary
 
-  def index(conn, %{"section_slug" => section_slug, "mode" => "preview"}) do
+  def index_preview(conn, %{"section_slug" => section_slug}) do
     user = conn.assigns.current_user
     current_author = conn.assigns.current_author
     is_admin? = !is_nil(current_author) and Oli.Accounts.is_admin?(current_author)
@@ -88,10 +88,9 @@ defmodule OliWeb.PageDeliveryController do
     end
   end
 
-  def page(conn, %{
+  def page_preview(conn, %{
         "section_slug" => section_slug,
-        "revision_slug" => revision_slug,
-        "mode" => "preview"
+        "revision_slug" => revision_slug
       }) do
     user = conn.assigns.current_user
     current_author = conn.assigns.current_author

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -6,7 +6,6 @@ defmodule OliWeb.PageDeliveryController do
       is_section_instructor_or_admin?: 2
     ]
 
-  alias Oli.Delivery.Student.Summary
   alias Oli.Delivery.Page.PageContext
   alias Oli.Delivery.Sections
   alias Oli.Rendering.Context
@@ -33,16 +32,21 @@ defmodule OliWeb.PageDeliveryController do
 
     if is_admin? or Sections.is_enrolled?(user.id, section_slug) do
       if is_admin? or Sections.has_instructor_role?(user, section_slug) do
-        case Summary.get_summary(section_slug, user) do
-          {:ok, summary} ->
+        case Sections.get_section_by(slug: section_slug)
+             |> Oli.Repo.preload([:base_project, :root_section_resource]) do
+          nil ->
+            render(conn, "error.html")
+
+          section ->
+            hierarchy = Oli.Publishing.DeliveryResolver.full_hierarchy(section.slug)
+
             render(conn, "index.html",
+              title: section.title,
+              description: section.description,
               section_slug: section_slug,
-              summary: summary,
+              hierarchy: hierarchy,
               preview_mode: true
             )
-
-          {:error, _} ->
-            render(conn, "error.html")
         end
       else
         # Any attempt by a student to enter preview mode is simply ignored and redirect back to
@@ -58,16 +62,21 @@ defmodule OliWeb.PageDeliveryController do
     user = conn.assigns.current_user
 
     if Sections.is_enrolled?(user.id, section_slug) do
-      case Summary.get_summary(section_slug, user) do
-        {:ok, summary} ->
+      case Sections.get_section_by(slug: section_slug)
+           |> Oli.Repo.preload([:base_project, :root_section_resource]) do
+        nil ->
+          render(conn, "error.html")
+
+        section ->
+          hierarchy = Oli.Publishing.DeliveryResolver.full_hierarchy(section.slug)
+
           render(conn, "index.html",
+            title: section.title,
+            description: section.description,
             section_slug: section_slug,
-            summary: summary,
+            hierarchy: hierarchy,
             preview_mode: false
           )
-
-        {:error, _} ->
-          render(conn, "error.html")
       end
     else
       render(conn, "not_authorized.html")
@@ -102,7 +111,8 @@ defmodule OliWeb.PageDeliveryController do
 
     if is_admin? or Sections.is_enrolled?(user.id, section_slug) do
       if is_admin? or Sections.has_instructor_role?(user, section_slug) do
-        render_preview_mode(conn, section_slug, revision_slug)
+        revision = Oli.Publishing.DeliveryResolver.from_revision_slug(section_slug, revision_slug)
+        render_preview_mode(conn, section_slug, revision)
       else
         # Any attempt by a student to enter preview mode is simply ignored and redirect back to
         # regular delivery mode
@@ -118,16 +128,30 @@ defmodule OliWeb.PageDeliveryController do
 
     if Sections.is_enrolled?(user.id, section_slug) do
       PageContext.create_for_visit(section_slug, revision_slug, user)
-      |> render_page(conn, section_slug, user)
+      |> render_page(conn, section_slug, user, false)
     else
       render(conn, "not_authorized.html")
     end
   end
 
-  defp render_preview_mode(conn, section_slug, revision_slug) do
+  defp render_preview_mode(
+         conn,
+         section_slug,
+         %{content: %{"advancedDelivery" => true}} = revision
+       ) do
+    user = conn.assigns.current_user
+
+    if Sections.is_instructor?(user, section_slug) do
+      PageContext.create_for_visit(section_slug, revision.slug, user)
+      |> render_page(conn, section_slug, user, true)
+    else
+      render(conn, "not_authorized.html")
+    end
+  end
+
+  defp render_preview_mode(conn, section_slug, revision) do
     section = conn.assigns.section
 
-    revision = Oli.Publishing.DeliveryResolver.from_revision_slug(section_slug, revision_slug)
     page_model = Map.get(revision.content, "model")
 
     type_by_id =
@@ -201,6 +225,7 @@ defmodule OliWeb.PageDeliveryController do
          } = context,
          conn,
          section_slug,
+         _,
          _
        ) do
     # Only consider graded attempts
@@ -250,7 +275,8 @@ defmodule OliWeb.PageDeliveryController do
            context,
          conn,
          section_slug,
-         _
+         _,
+         preview_mode
        ) do
     layout =
       case Map.get(context.page.content, "displayApplicationChrome", true) do
@@ -287,16 +313,16 @@ defmodule OliWeb.PageDeliveryController do
       previous_page: context.previous_page,
       next_page: context.next_page,
       user_id: user.id,
-      preview_mode: is_preview_mode?(conn)
+      preview_mode: preview_mode
     })
   end
 
-  defp render_page(%PageContext{progress_state: :error}, conn, _, _) do
+  defp render_page(%PageContext{progress_state: :error}, conn, _, _, _) do
     render(conn, "error.html")
   end
 
   # This case handles :in_progress and :revised progress states
-  defp render_page(%PageContext{} = context, conn, section_slug, user) do
+  defp render_page(%PageContext{} = context, conn, section_slug, user, _) do
     render_context = %Context{
       user: user,
       section_slug: section_slug,
@@ -348,16 +374,6 @@ defmodule OliWeb.PageDeliveryController do
     )
   end
 
-  defp is_preview_mode?(conn) do
-    user = conn.assigns.current_user
-    current_author = conn.assigns.current_author
-    section_slug = Map.get(conn.path_params, "section_slug")
-    is_admin? = !is_nil(current_author) and Oli.Accounts.is_admin?(current_author)
-
-    Map.get(conn.query_params, "mode", "delivery") == "preview" and
-      (is_admin? or Sections.is_instructor?(user, section_slug))
-  end
-
   def start_attempt(conn, %{"section_slug" => section_slug, "revision_slug" => revision_slug}) do
     user = conn.assigns.current_user
 
@@ -395,7 +411,7 @@ defmodule OliWeb.PageDeliveryController do
 
     if Sections.is_enrolled?(user.id, section_slug) do
       PageContext.create_for_review(section_slug, attempt_guid, user)
-      |> render_page(conn, section_slug, user)
+      |> render_page(conn, section_slug, user, false)
     else
       render(conn, "not_authorized.html")
     end

--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -83,7 +83,7 @@ defmodule OliWeb.Sections.OverviewView do
       </Group>
       <Group label="Curriculum" description="Manage the content delivered to students">
         <ul class="link-list">
-        <li><a href={Routes.page_delivery_path(OliWeb.Endpoint, :index, @section.slug, mode: "preview")}>Preview Course Content</a></li>
+        <li><a href={Routes.page_delivery_path(OliWeb.Endpoint, :index_preview, @section.slug)}>Preview Course Content</a></li>
         <li><a href={Routes.page_delivery_path(OliWeb.Endpoint, :index, @section.slug)}>Enter Course as a Student</a></li>
         <li><a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Delivery.RemixSection, @section.slug)}>Customize Curriculum</a></li>
           <li>

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -594,7 +594,7 @@ defmodule OliWeb.Router do
       :browser,
       :delivery,
       :require_section,
-      :delivery_protected,
+      :delivery_and_admin,
       :pow_email_layout
     ])
 

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -589,6 +589,19 @@ defmodule OliWeb.Router do
     )
   end
 
+  scope "/sections/:section_slug/preview/", OliWeb do
+    pipe_through([
+      :browser,
+      :delivery,
+      :require_section,
+      :delivery_protected,
+      :pow_email_layout
+    ])
+
+    get("/overview", PageDeliveryController, :index_preview)
+    get("/page/:revision_slug", PageDeliveryController, :page_preview)
+  end
+
   scope "/sections", OliWeb do
     pipe_through([
       :browser,

--- a/lib/oli_web/templates/layout/page.html.eex
+++ b/lib/oli_web/templates/layout/page.html.eex
@@ -6,7 +6,7 @@
 
   <% url =
     if Map.get(@conn.assigns, :preview_mode, false) do
-      Routes.page_delivery_path(@conn, :index, @section_slug, mode: "preview")
+      Routes.page_delivery_path(@conn, :index_preview, @section_slug)
     else
       Routes.page_delivery_path(@conn, :index, @section_slug)
     end

--- a/lib/oli_web/templates/page_delivery/_link_assessment.html.eex
+++ b/lib/oli_web/templates/page_delivery/_link_assessment.html.eex
@@ -12,8 +12,5 @@
     <span class="page-title">
       <i class="far fa-check-circle mr-2"></i> <%= @node.revision.title %>
     </span>
-    <%= if Map.has_key?(@summary.access_map, @node.revision.resource_id) do %>
-      <small class="text-secondary"><%= calculate_score_percentage(Map.get(@summary.access_map, @node.revision.resource_id)) %></small>
-    <% end %>
   </div>
 <% end %>

--- a/lib/oli_web/templates/page_delivery/_link_assessment.html.eex
+++ b/lib/oli_web/templates/page_delivery/_link_assessment.html.eex
@@ -1,7 +1,7 @@
 <% link_class = "page-link graded-page-link list-group-item list-group-item-action flex-column align-items-start " <> if @active_page == @node.revision.slug, do: "active", else: "" %>
 <% url =
-  if @preview_mode do
-    Routes.page_delivery_path(@conn, :page, @section_slug, @node.revision.slug, mode: "preview")
+  if Map.get(@conn.assigns, :preview_mode, false) do
+    Routes.page_delivery_path(@conn, :page_preview, @section_slug, @node.revision.slug)
   else
     Routes.page_delivery_path(@conn, :page, @section_slug, @node.revision.slug)
   end

--- a/lib/oli_web/templates/page_delivery/_link_page.html.eex
+++ b/lib/oli_web/templates/page_delivery/_link_page.html.eex
@@ -1,7 +1,7 @@
 <% link_class = "page-link ungraded-page-link list-group-item list-group-item-action " <> if @active_page == @node.revision.slug, do: "active", else: "" %>
 <% url =
-  if @preview_mode do
-    Routes.page_delivery_path(@conn, :page, @section_slug, @node.revision.slug, mode: "preview")
+  if Map.get(@conn.assigns, :preview_mode, false) do
+    Routes.page_delivery_path(@conn, :page_preview, @section_slug, @node.revision.slug)
   else
     Routes.page_delivery_path(@conn, :page, @section_slug, @node.revision.slug)
   end

--- a/lib/oli_web/templates/page_delivery/_link_page.html.eex
+++ b/lib/oli_web/templates/page_delivery/_link_page.html.eex
@@ -11,8 +11,5 @@
     <span class="page-title">
       <i class="far fa-file mr-2"></i> <%= @node.revision.title %>
     </span>
-    <%= if Map.has_key?(@summary.access_map, @node.revision.resource_id) do %>
-      <small class="text-secondary"><i class="fa fa-check"></i></small>
-    <% end %>
   </div>
 <% end %>

--- a/lib/oli_web/templates/page_delivery/_outline.html.eex
+++ b/lib/oli_web/templates/page_delivery/_outline.html.eex
@@ -1,11 +1,11 @@
 <%= for node <- @nodes do %>
   <%= if container?(node.revision) do %>
-    <%= render "container.html", node: node, conn: @conn, section_slug: @section_slug, summary: @summary, active_page: @active_page %>
+    <%= render "container.html", node: node, conn: @conn, section_slug: @section_slug, nodes: @nodes, active_page: @active_page %>
   <% else %>
     <%= if node.revision.graded do %>
-      <%= render "_link_assessment.html", preview_mode: @preview_mode, node: node, conn: @conn, section_slug: @section_slug, summary: @summary, active_page: @active_page %>
+      <%= render "_link_assessment.html", preview_mode: @preview_mode, node: node, conn: @conn, section_slug: @section_slug, active_page: @active_page %>
     <% else %>
-      <%= render "_link_page.html", preview_mode: @preview_mode, node: node, conn: @conn, section_slug: @section_slug, summary: @summary, active_page: @active_page %>
+      <%= render "_link_page.html", preview_mode: @preview_mode, node: node, conn: @conn, section_slug: @section_slug, active_page: @active_page %>
     <% end %>
   <% end %>
 <% end %>

--- a/lib/oli_web/templates/page_delivery/_outline.html.eex
+++ b/lib/oli_web/templates/page_delivery/_outline.html.eex
@@ -1,6 +1,6 @@
 <%= for node <- @nodes do %>
   <%= if container?(node.revision) do %>
-    <%= render "container.html", node: node, conn: @conn, section_slug: @section_slug, nodes: @nodes, active_page: @active_page %>
+    <%= render "container.html", preview_mode: @preview_mode, node: node, conn: @conn, section_slug: @section_slug, nodes: node.children, active_page: @active_page %>
   <% else %>
     <%= if node.revision.graded do %>
       <%= render "_link_assessment.html", preview_mode: @preview_mode, node: node, conn: @conn, section_slug: @section_slug, active_page: @active_page %>

--- a/lib/oli_web/templates/page_delivery/container.html.eex
+++ b/lib/oli_web/templates/page_delivery/container.html.eex
@@ -4,6 +4,6 @@
   <%= if Enum.empty?(@node.children) do %>
     <span class="text-secondary">There are no items</span>
   <% else %>
-    <%= render "_outline.html", nodes: @node.children, conn: @conn, section_slug: @section_slug, nodes: @nodes, active_page: nil %>
+    <%= render "_outline.html", preview_mode: @preview_mode, nodes: @node.children, conn: @conn, section_slug: @section_slug, nodes: @nodes, active_page: nil %>
   <% end %>
 </div>

--- a/lib/oli_web/templates/page_delivery/container.html.eex
+++ b/lib/oli_web/templates/page_delivery/container.html.eex
@@ -4,6 +4,6 @@
   <%= if Enum.empty?(@node.children) do %>
     <span class="text-secondary">There are no items</span>
   <% else %>
-    <%= render "_outline.html", nodes: @node.children, conn: @conn, section_slug: @section_slug, summary: @summary, active_page: nil %>
+    <%= render "_outline.html", nodes: @node.children, conn: @conn, section_slug: @section_slug, nodes: @nodes, active_page: nil %>
   <% end %>
 </div>

--- a/lib/oli_web/templates/page_delivery/index.html.eex
+++ b/lib/oli_web/templates/page_delivery/index.html.eex
@@ -1,6 +1,6 @@
 <div class="content mt-3 mb-5">
-  <h1><%= @summary.title %></h1>
-  <p class="text-secondary"><%= @summary.description %></p>
+  <h1><%= @title %></h1>
+  <p class="text-secondary"><%= @description %></p>
 
   <%= if is_section_instructor_or_admin?(@section_slug, @current_user) do %>
 
@@ -16,7 +16,7 @@
   <div id="index-container" class="course-outline list-group">
     <h5 class="text-primary border-bottom border-primary mb-2">Course Overview</h5>
 
-    <%= render "_outline.html", conn: @conn, preview_mode: @preview_mode, section_slug: @section_slug, summary: @summary, nodes: @summary.hierarchy.children, active_page: nil %>
+    <%= render "_outline.html", conn: @conn, preview_mode: @preview_mode, section_slug: @section_slug, nodes: @hierarchy.children, active_page: nil %>
   </div>
 
 </div>

--- a/lib/oli_web/views/page_delivery_view.ex
+++ b/lib/oli_web/views/page_delivery_view.ex
@@ -22,14 +22,14 @@ defmodule OliWeb.PageDeliveryView do
     if Map.get(conn.assigns, :preview_mode, false) do
       Routes.page_delivery_path(
         conn,
-        :page,
+        :page_preview,
         conn.assigns.section_slug,
         conn.assigns.previous_page.slug
       )
     else
       Routes.page_delivery_path(
         conn,
-        :page_preview,
+        :page,
         conn.assigns.section_slug,
         conn.assigns.previous_page.slug
       )
@@ -40,14 +40,14 @@ defmodule OliWeb.PageDeliveryView do
     if Map.get(conn.assigns, :preview_mode, false) do
       Routes.page_delivery_path(
         conn,
-        :page,
+        :page_preview,
         conn.assigns.section_slug,
         conn.assigns.next_page.slug
       )
     else
       Routes.page_delivery_path(
         conn,
-        :page_preview,
+        :page,
         conn.assigns.section_slug,
         conn.assigns.next_page.slug
       )

--- a/lib/oli_web/views/page_delivery_view.ex
+++ b/lib/oli_web/views/page_delivery_view.ex
@@ -24,13 +24,12 @@ defmodule OliWeb.PageDeliveryView do
         conn,
         :page,
         conn.assigns.section_slug,
-        conn.assigns.previous_page.slug,
-        mode: "preview"
+        conn.assigns.previous_page.slug
       )
     else
       Routes.page_delivery_path(
         conn,
-        :page,
+        :page_preview,
         conn.assigns.section_slug,
         conn.assigns.previous_page.slug
       )
@@ -43,13 +42,12 @@ defmodule OliWeb.PageDeliveryView do
         conn,
         :page,
         conn.assigns.section_slug,
-        conn.assigns.next_page.slug,
-        mode: "preview"
+        conn.assigns.next_page.slug
       )
     else
       Routes.page_delivery_path(
         conn,
-        :page,
+        :page_preview,
         conn.assigns.section_slug,
         conn.assigns.next_page.slug
       )


### PR DESCRIPTION
This PR introduces are more explicit routing approach for instructor preview mode, one that allows a specific scope to be in place for the overview and page rendering routes that bypasses gating, paywall, and auto-enrollment for open and free. 

