### PR TITLE
[FEATURE] Implement more efficient determination of Previous and Next links 

### DIFF
--- a/lib/oli/authoring/editing/page_editor.ex
+++ b/lib/oli/authoring/editing/page_editor.ex
@@ -19,7 +19,6 @@ defmodule Oli.Authoring.Editing.PageEditor do
   alias Oli.Delivery.Page.ActivityContext
   alias Oli.Rendering.Activity.ActivitySummary
   alias Oli.Activities
-  alias Oli.Delivery.Page.PageContext
   alias Oli.Authoring.Editing.ActivityEditor
 
   import Ecto.Query, warn: false
@@ -205,7 +204,9 @@ defmodule Oli.Authoring.Editing.PageEditor do
       # Create the resource editing context that we will supply to the client side editor
       hierarchy = AuthoringResolver.full_hierarchy(project_slug)
 
-      {previous, next} = PageContext.determine_previous_next(hierarchy, revision)
+      {:ok, {previous, next}} =
+        Oli.Delivery.Hierarchy.build_navigation_link_map(hierarchy)
+        |> Oli.Delivery.PreviousNextIndex.retrieve(revision.resource_id)
 
       activity_ids = activities_from_content(revision.content)
 

--- a/lib/oli/delivery/hierarchy.ex
+++ b/lib/oli/delivery/hierarchy.ex
@@ -1,13 +1,11 @@
 defmodule Oli.Delivery.Hierarchy do
   @moduledoc """
   A module for hierarchy and HierarchyNode operations and utilities
-
   A delivery hierarchy is the main structure in which a course curriculum is organized
   to be delivered. It is mainly persisted through section resource records. A hierarchy is
   also a generic in-memory representation of a curriculum which can be passed into
   delivery-centric functions from an authoring context, in which case the hierarchy could
   be ephemeral and section_resources are empty (e.g. course preview)
-
   See also HierarchyNode for more details
   """
   import Oli.Utils
@@ -226,46 +224,6 @@ defmodule Oli.Delivery.Hierarchy do
   end
 
   @doc """
-  Given a hierarchy node, this function "flattens" all nodes below into a list, in the order that
-  a student would encounter the resources working linearly through a course.
-
-  As an example, consider the followign hierarchy:
-
-  --Unit 1
-  ----Module 1
-  ------Page A
-  ------Page B
-  --Unit 2
-  ----Moudule 2
-  ------Page C
-
-  The above would be flattened to:
-  Unit 1
-  Module 1
-  Page A
-  Page B
-  Unit 2
-  Module 2
-  Page C
-
-  """
-  def flatten(%HierarchyNode{} = root) do
-    flatten_helper(root, [], [])
-    |> Enum.reverse()
-  end
-
-  defp flatten_helper(%HierarchyNode{children: children}, flattened_nodes, current_ancestors) do
-    Enum.reduce(children, flattened_nodes, fn node, acc ->
-      node = %{node | ancestors: current_ancestors}
-
-      case Oli.Resources.ResourceType.get_type_by_id(node.revision.resource_type_id) do
-        "container" -> flatten_helper(node, [node | acc], current_ancestors ++ [node])
-        _ -> [node | acc]
-      end
-    end)
-  end
-
-  @doc """
   Given a course section hierarchy, this function builds a "navigation link map" for a course section that is
   used during delivery to efficiently render the "Previous" and "Next" page links.
 
@@ -303,7 +261,136 @@ defmodule Oli.Delivery.Hierarchy do
   determining prev and next links.
   """
   def build_navigation_link_map(%HierarchyNode{} = root) do
+    {map, _} =
+      flatten(root)
+      |> Enum.filter(fn node ->
+        Oli.Resources.ResourceType.get_type_by_id(node.revision.resource_type_id) == "page"
+      end)
+      |> Enum.reduce({%{}, nil}, fn node, {map, previous} ->
+        this_id = Integer.to_string(node.revision.resource_id)
+
+        this_entry = %{
+          "slug" => node.revision.slug,
+          "title" => node.revision.title,
+          "prev" =>
+            case previous do
+              nil -> nil
+              _ -> previous
+            end,
+          "next" => nil
+        }
+
+        map =
+          case previous do
+            nil ->
+              map
+
+            id ->
+              previous_entry = Map.get(map, id)
+              updated = Map.merge(previous_entry, %{"next" => this_id})
+              Map.put(map, id, updated)
+          end
+
+        {Map.put(map, this_id, this_entry), this_id}
+      end)
+
+    map
   end
+
+  @doc """
+  Given a hierarchy node, this function "flattens" all nodes below into a list, in the order that
+  a student would encounter the resources working linearly through a course.
+  As an example, consider the following hierarchy:
+  --Unit 1
+  ----Module 1
+  ------Page A
+  ------Page B
+  --Unit 2
+  ----Moudule 2
+  ------Page C
+  The above would be flattened to:
+  Unit 1
+  Module 1
+  Page A
+  Page B
+  Unit 2
+  Module 2
+  Page C
+  """
+  def flatten(%HierarchyNode{} = root) do
+    flatten_helper(root, [], [])
+    |> Enum.reverse()
+  end
+
+  defp flatten_helper(%HierarchyNode{children: children}, flattened_nodes, current_ancestors) do
+    Enum.reduce(children, flattened_nodes, fn node, acc ->
+      node = %{node | ancestors: current_ancestors}
+
+      case Oli.Resources.ResourceType.get_type_by_id(node.revision.resource_type_id) do
+        "container" -> flatten_helper(node, [node | acc], current_ancestors ++ [node])
+        _ -> [node | acc]
+      end
+    end)
+  end
+
+  @doc """
+  Builds a map that contains a list of gated ancestor resource_ids for each node. The list will
+  contain the resource_id of the node itself, if that resource is gated.
+  The keys of the map will be returned as strings, but the list of resource_ids themselves
+  will be integers. This is done this way for consistency because when this map gets
+  persisted to a the Postgres JSON datatype, these keys will be stored to strings.
+  Takes 2 parameters. First is the root of the hierarchy. Second is a gated_resource_id_map
+  which is a map containing the resource_ids of gated resources as keys (the value is ignored)
+  For example, consider the following hierarchy:
+  --Unit 1 (gated: true, resource_id: 1)
+  ----Module 1 (gated: true, resource_id: 2)
+  ------Page A (gated: true, resource_id: 3)
+  ------Page B (gated: false, resource_id: 4)
+  --Unit 2 (gated: false, resource_id: 5)
+  ----Moudule 2 (gated: false, resource_id: 6)
+  ------Page C (gated: true, resource_id: 7)
+  The following ancestry map will be returned:
+  %{
+    "1" => [1],
+    "2" => [2, 1],
+    "3" => [3, 2 ,1],
+    "4" => [2, 1],
+    "7" => [7]
+  }
+  """
+  def gated_ancestry_map(%HierarchyNode{} = root, %{} = gated_resource_id_map) do
+    gated_ancestry_map(root, %{}, [], gated_resource_id_map)
+  end
+
+  defp gated_ancestry_map(
+         %HierarchyNode{resource_id: resource_id, children: children},
+         index_map,
+         gated_ancestors,
+         gated_resource_id_map
+       ) do
+    # if this node is gated, then we add it to the list of gated ancestors
+    gated_ancestors =
+      if Map.has_key?(gated_resource_id_map, resource_id) do
+        [resource_id | gated_ancestors]
+      else
+        gated_ancestors
+      end
+
+    # if any ancestors are gated (including the current node), then add it to the index
+    index_map =
+      if Enum.empty?(gated_ancestors) == false do
+        Map.put(index_map, ensure_string(resource_id), gated_ancestors)
+      else
+        index_map
+      end
+
+    Enum.reduce(children, index_map, fn node, acc ->
+      gated_ancestry_map(node, acc, gated_ancestors, gated_resource_id_map)
+    end)
+  end
+
+  defp ensure_string(maybe_str) when is_binary(maybe_str), do: maybe_str
+  defp ensure_string(maybe_str) when is_integer(maybe_str), do: Integer.to_string(maybe_str)
 
   @doc """
   Debugging utility to inspect a hierarchy without all the noise. Choose which keys

--- a/lib/oli/delivery/hierarchy.ex
+++ b/lib/oli/delivery/hierarchy.ex
@@ -295,10 +295,12 @@ defmodule Oli.Delivery.Hierarchy do
   }
   ```
 
-  The above construct is designed to allow a lightweight, constant time determination (and then rendering) of Previous and Next
-  links.  Given a resource id of the current page, at most three map lookups are required to gather all the information required to
-  render links.  It is expected that this map is already in memory, retrieved from the section record itself, which overall then
-  greatly improves the performane around determining prev and next links.
+  The above construct is designed to allow a lightweight, constant time determination
+  (and then rendering) of Previous and Next links.  Given a resource id of the current
+  page, at most three map lookups are required to gather all the information required to
+  render links.  It is expected that this map is already in memory, retrieved from the
+  section record itself, which overall then greatly improves the performance of
+  determining prev and next links.
   """
   def build_navigation_link_map(%HierarchyNode{} = root) do
   end

--- a/lib/oli/delivery/page/page_context.ex
+++ b/lib/oli/delivery/page/page_context.ex
@@ -28,9 +28,7 @@ defmodule Oli.Delivery.Page.PageContext do
   alias Oli.Delivery.Page.PageContext
   alias Oli.Publishing.DeliveryResolver
   alias Oli.Delivery.Attempts.Core, as: Attempts
-  alias Oli.Delivery.Student.Summary
   alias Oli.Delivery.Page.ObjectivesRollup
-  alias Oli.Delivery.Hierarchy
 
   @doc """
   Creates the page context required to render a page for reviewing a historical
@@ -42,7 +40,7 @@ defmodule Oli.Delivery.Page.PageContext do
   to a renderer.
   """
   @spec create_for_review(String.t(), String.t(), Oli.Accounts.User) :: %PageContext{}
-  def create_for_review(section_slug, attempt_guid, user) do
+  def create_for_review(section_slug, attempt_guid, _) do
     {progress_state, resource_attempts, latest_attempts, activities, page_revision} =
       case PageLifecycle.review(attempt_guid) do
         {:ok,

--- a/lib/oli/delivery/previous_next_index.ex
+++ b/lib/oli/delivery/previous_next_index.ex
@@ -1,0 +1,78 @@
+defmodule Oli.Delivery.PreviousNextIndex do
+  alias Oli.Delivery.Sections.Section
+  alias Oli.Delivery.Sections
+  alias Oli.Publishing.DeliveryResolver
+  alias Oli.Delivery.Hierarchy
+  alias Oli.Repo
+
+  @doc """
+  For a given section slug and a resource id of a page within the section hiearchy, returns the
+  link descriptors for the previous and next pages.  This function will rebuild the previous_next_index
+  if it is nil.  This allows a just-in-time update for actions that invalidate this structure.
+
+  Returns a tuple of the form:
+  {:ok, {previous, next}} where previous and next are both link descriptors.  A link descriptor
+  is of the form:
+
+  %{
+    "prev" => "2",
+    "next" => "4",
+    "slug => "the_slug",
+    "title" => "The title"
+  }
+
+  Returns {:error, reason} if the index cannot be rebuilt.
+
+  """
+  def retrieve(%Section{previous_next_index: nil} = section, resource_id) do
+    case rebuild_if_not_nil(section) do
+      {:ok, section} -> retrieve(section, resource_id)
+      {:error, e} -> Repo.rollback(e)
+    end
+  end
+
+  def retrieve(%Section{previous_next_index: previous_next_index}, resource_id) do
+    case Map.get(previous_next_index, Integer.to_string(resource_id)) do
+      nil ->
+        {:ok, {nil, nil}}
+
+      %{"prev" => nil, "next" => next} ->
+        {:ok, {nil, Map.get(previous_next_index, next)}}
+
+      %{"prev" => prev, "next" => nil} ->
+        {:ok, {Map.get(previous_next_index, prev), nil}}
+
+      %{"prev" => prev, "next" => next} ->
+        {:ok, {Map.get(previous_next_index, prev), Map.get(previous_next_index, next)}}
+    end
+  end
+
+  # Allowing the section to be directly passed in from client code is problematic because it
+  # can lead to situations where client code is continually passing in a %Section{} with a
+  # previous_next_index that is nil, causing the "just in time" rebuild mechanism to execute
+  # over and over, when it does not need to.  So instead, when the index is nil we refetch the
+  # section to see if simply a stale section was given.  If the index is still nil, we then rebuild.
+  defp rebuild_if_not_nil(section) do
+    case Sections.get_section_by(slug: section.slug) do
+      %{previous_next_index: nil} -> rebuild(section)
+      section -> {:ok, section}
+    end
+  end
+
+  @doc """
+  Rebuilds the previous_next_index for the given %Section{}, updating the section
+  with the newly rebuilt index.
+  """
+  def rebuild(%Section{slug: slug} = section) do
+    case Repo.transaction(fn _ ->
+           DeliveryResolver.full_hierarchy(slug)
+           |> Hierarchy.build_navigation_link_map()
+           |> then(fn previous_next_index ->
+             Sections.update_section(section, %{previous_next_index: previous_next_index})
+           end)
+         end) do
+      {:ok, result} -> result
+      {:error, e} -> e
+    end
+  end
+end

--- a/lib/oli/delivery/previous_next_index.ex
+++ b/lib/oli/delivery/previous_next_index.ex
@@ -32,6 +32,10 @@ defmodule Oli.Delivery.PreviousNextIndex do
   end
 
   def retrieve(%Section{previous_next_index: previous_next_index}, resource_id) do
+    retrieve(previous_next_index, resource_id)
+  end
+
+  def retrieve(previous_next_index, resource_id) when is_map(previous_next_index) do
     case Map.get(previous_next_index, Integer.to_string(resource_id)) do
       nil ->
         {:ok, {nil, nil}}

--- a/lib/oli/delivery/sections/section.ex
+++ b/lib/oli/delivery/sections/section.ex
@@ -45,6 +45,7 @@ defmodule Oli.Delivery.Sections.Section do
     field(:nrps_context_memberships_url, :string)
 
     field(:resource_gating_index, :map, default: %{}, null: false)
+    field(:previous_next_index, :map, default: nil, null: true)
 
     belongs_to(:lti_1p3_deployment, Lti_1p3.DataProviders.EctoProvider.Deployment,
       foreign_key: :lti_1p3_deployment_id
@@ -108,6 +109,7 @@ defmodule Oli.Delivery.Sections.Section do
       :nrps_enabled,
       :nrps_context_memberships_url,
       :resource_gating_index,
+      :previous_next_index,
       :lti_1p3_deployment_id,
       :institution_id,
       :base_project_id,

--- a/lib/oli/delivery/student/summary.ex
+++ b/lib/oli/delivery/student/summary.ex
@@ -1,10 +1,9 @@
 defmodule Oli.Delivery.Student.Summary do
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Attempts.Core, as: Attempts
-  alias Oli.Publishing.DeliveryResolver
   alias Oli.Repo
 
-  defstruct [:title, :description, :access_map, :hierarchy, :updates]
+  defstruct [:title, :description, :access_map, :updates]
 
   def get_summary(section_slug, user) do
     with {:ok, section} <-
@@ -13,8 +12,6 @@ defmodule Oli.Delivery.Student.Summary do
            |> Oli.Utils.trap_nil(),
          resource_accesses <-
            Attempts.get_user_resource_accesses_for_context(section.slug, user.id),
-         hierarchy <-
-           DeliveryResolver.full_hierarchy(section.slug),
          updates <- Sections.check_for_available_publication_updates(section) do
       access_map =
         Enum.reduce(resource_accesses, %{}, fn ra, acc ->
@@ -26,7 +23,6 @@ defmodule Oli.Delivery.Student.Summary do
          title: section.title,
          description: section.base_project.description,
          access_map: access_map,
-         hierarchy: hierarchy,
          updates: updates
        }}
     else

--- a/lib/oli/delivery/updates/worker.ex
+++ b/lib/oli/delivery/updates/worker.ex
@@ -16,5 +16,7 @@ defmodule Oli.Delivery.Updates.Worker do
       section,
       publication_id
     )
+
+    Oli.Delivery.PreviousNextIndex.rebuild(section)
   end
 end

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -274,8 +274,7 @@ defmodule OliWeb.PageDeliveryController do
       resource_id: page.resource_id,
       slug: context.page.slug,
       max_attempts: page.max_attempts,
-      section: section,
-      summary: summary
+      section: section
     })
   end
 

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -164,8 +164,8 @@ defmodule OliWeb.PageDeliveryController do
       end)
       |> Enum.map(fn %{"activity_id" => id} -> id end)
 
-    hierarchy = Oli.Publishing.DeliveryResolver.full_hierarchy(section_slug)
-    {previous, next} = Oli.Delivery.Page.PageContext.determine_previous_next(hierarchy, revision)
+    {:ok, {previous, next}} =
+      Oli.Delivery.PreviousNextIndex.retrieve(section, revision.resource_id)
 
     activity_map =
       Oli.Publishing.DeliveryResolver.from_resource_id(section_slug, activity_ids)
@@ -211,14 +211,14 @@ defmodule OliWeb.PageDeliveryController do
         next_page: next,
         title: revision.title,
         html: html,
-        objectives: []
+        objectives: [],
+        section: section
       }
     )
   end
 
   defp render_page(
          %PageContext{
-           summary: summary,
            progress_state: :not_started,
            page: page,
            resource_attempts: resource_attempts
@@ -228,6 +228,8 @@ defmodule OliWeb.PageDeliveryController do
          _,
          _
        ) do
+    section = conn.assigns.section
+
     # Only consider graded attempts
     resource_attempts = Enum.filter(resource_attempts, fn a -> a.revision.graded == true end)
 
@@ -254,30 +256,38 @@ defmodule OliWeb.PageDeliveryController do
         r1.date_evaluated <= r2.date_evaluated
       end)
 
+    {:ok, {previous, next}} = Oli.Delivery.PreviousNextIndex.retrieve(section, page.resource_id)
+
+    {:ok, summary} =
+      Oli.Delivery.Student.Summary.get_summary(section_slug, conn.assigns.current_user)
+
     render(conn, "prologue.html", %{
+      summary: summary,
       section_slug: section_slug,
       scripts: Activities.get_activity_scripts(),
       resource_attempts: resource_attempts,
-      summary: summary,
-      previous_page: context.previous_page,
-      next_page: context.next_page,
+      previous_page: previous,
+      next_page: next,
       title: context.page.title,
       allow_attempt?: allow_attempt?,
       message: message,
       resource_id: page.resource_id,
       slug: context.page.slug,
-      max_attempts: page.max_attempts
+      max_attempts: page.max_attempts,
+      section: section,
+      summary: summary
     })
   end
 
   defp render_page(
-         %PageContext{summary: summary, page: %{content: %{"advancedDelivery" => true}}} =
-           context,
+         %PageContext{page: %{content: %{"advancedDelivery" => true}}} = context,
          conn,
          section_slug,
          _,
          preview_mode
        ) do
+    section = conn.assigns.section
+
     layout =
       case Map.get(context.page.content, "displayApplicationChrome", true) do
         true -> "page.html"
@@ -294,6 +304,9 @@ defmodule OliWeb.PageDeliveryController do
       Oli.Delivery.Page.ActivityContext.to_thin_context_map(context.activities)
       |> Jason.encode()
 
+    {:ok, {previous, next}} =
+      Oli.Delivery.PreviousNextIndex.retrieve(section, context.page.resource_id)
+
     render(conn, "advanced_delivery.html", %{
       review_mode: context.review_mode,
       graded: context.page.graded,
@@ -302,7 +315,6 @@ defmodule OliWeb.PageDeliveryController do
       resource_attempt_state: resource_attempt_state,
       activity_guid_mapping: activity_guid_mapping,
       content: Jason.encode!(context.page.content),
-      summary: summary,
       activity_types: Activities.activities_for_section(),
       scripts: Activities.get_activity_scripts(:delivery_script),
       part_scripts: PartComponents.get_part_component_scripts(:delivery_script),
@@ -310,10 +322,11 @@ defmodule OliWeb.PageDeliveryController do
       title: context.page.title,
       resource_id: context.page.resource_id,
       slug: context.page.slug,
-      previous_page: context.previous_page,
-      next_page: context.next_page,
+      previous_page: previous,
+      next_page: next,
       user_id: user.id,
-      preview_mode: preview_mode
+      preview_mode: preview_mode,
+      section: section
     })
   end
 
@@ -323,6 +336,8 @@ defmodule OliWeb.PageDeliveryController do
 
   # This case handles :in_progress and :revised progress states
   defp render_page(%PageContext{} = context, conn, section_slug, user, _) do
+    section = conn.assigns.section
+
     render_context = %Context{
       user: user,
       section_slug: section_slug,
@@ -343,6 +358,9 @@ defmodule OliWeb.PageDeliveryController do
 
     all_activities = Activities.list_activity_registrations()
 
+    {:ok, {previous, next}} =
+      Oli.Delivery.PreviousNextIndex.retrieve(section, context.page.resource_id)
+
     render(
       conn,
       if ResourceType.get_type_by_id(context.page.resource_type_id) == "container" do
@@ -358,9 +376,8 @@ defmodule OliWeb.PageDeliveryController do
         scripts: Enum.map(all_activities, fn a -> a.delivery_script end),
         activity_type_slug_mapping:
           Enum.reduce(all_activities, %{}, fn a, m -> Map.put(m, a.id, a.slug) end),
-        summary: context.summary,
-        previous_page: context.previous_page,
-        next_page: context.next_page,
+        previous_page: previous,
+        next_page: next,
         title: context.page.title,
         graded: context.page.graded,
         activity_count: map_size(context.activities),
@@ -369,7 +386,8 @@ defmodule OliWeb.PageDeliveryController do
         slug: context.page.slug,
         resource_attempt: hd(context.resource_attempts),
         attempt_guid: hd(context.resource_attempts).attempt_guid,
-        latest_attempts: context.latest_attempts
+        latest_attempts: context.latest_attempts,
+        section: section
       }
     )
   end
@@ -462,6 +480,7 @@ defmodule OliWeb.PageDeliveryController do
   end
 
   def after_finalized(conn, section_slug, revision_slug, attempt_guid, user, grade_sync_result) do
+    section = conn.assigns.section
     context = PageContext.create_for_visit(section_slug, revision_slug, user)
 
     message =
@@ -483,17 +502,20 @@ defmodule OliWeb.PageDeliveryController do
 
     conn = put_root_layout(conn, {OliWeb.LayoutView, "page.html"})
 
+    {:ok, {previous, next}} =
+      Oli.Delivery.PreviousNextIndex.retrieve(section, context.page.resource_id)
+
     render(conn, "after_finalized.html",
       grade_message: grade_message,
       section_slug: section_slug,
       attempt_guid: attempt_guid,
       scripts: Activities.get_activity_scripts(),
-      summary: context.summary,
-      previous_page: context.previous_page,
-      next_page: context.next_page,
+      previous_page: previous,
+      next_page: next,
       title: context.page.title,
       message: message,
-      slug: context.page.slug
+      slug: context.page.slug,
+      section: section
     )
   end
 

--- a/lib/oli_web/live/delivery/remix_section.ex
+++ b/lib/oli_web/live/delivery/remix_section.ex
@@ -325,6 +325,7 @@ defmodule OliWeb.Delivery.RemixSection do
     } = socket.assigns
 
     Sections.rebuild_section_curriculum(section, hierarchy, pinned_project_publications)
+    Oli.Delivery.PreviousNextIndex.rebuild(section)
 
     {:noreply, redirect(socket, to: redirect_after_save)}
   end

--- a/lib/oli_web/templates/layout/page.html.eex
+++ b/lib/oli_web/templates/layout/page.html.eex
@@ -25,7 +25,7 @@
         <%= @inner_content %>
 
         <%= render OliWeb.PageDeliveryView, "_previous_next_nav.html",
-          conn: @conn, section_slug: @section_slug, summary: @summary, previous_page: @previous_page, next_page: @next_page %>
+          conn: @conn, section_slug: @section_slug, previous_page: @previous_page, next_page: @next_page, section: @section %>
 
       </div>
 

--- a/lib/oli_web/templates/page_delivery/_previous_next_nav.html.eex
+++ b/lib/oli_web/templates/page_delivery/_previous_next_nav.html.eex
@@ -8,7 +8,7 @@
         </div>
         <div class="d-flex flex-column flex-fill flex-ellipsize-fix text-right">
           <div class="nav-label">Previous</div>
-          <div class="nav-title"><%= @previous_page.title %></div>
+          <div class="nav-title"><%= @previous_page["title"] %></div>
         </div>
       </div>
     <% end %>
@@ -23,7 +23,7 @@
       <div class="d-flex flex-row">
         <div class="d-flex flex-column flex-fill flex-ellipsize-fix text-left">
           <div class="nav-label">Next</div>
-          <div class="nav-title"><%= @next_page.title %></div>
+          <div class="nav-title"><%= @next_page["title"] %></div>
         </div>
         <div>
           <i class="fas fa-arrow-right nav-icon"></i>
@@ -35,7 +35,7 @@
       <div class="d-flex flex-row">
         <div class="d-flex flex-column flex-fill flex-ellipsize-fix text-left">
           <div class="nav-label">Complete</div>
-          <div class="nav-title"><%= @summary.title %></div>
+          <div class="nav-title"><%= @section.title %></div>
         </div>
         <div>
           <i class="fas fa-check nav-icon"></i>

--- a/lib/oli_web/templates/page_delivery/index.html.eex
+++ b/lib/oli_web/templates/page_delivery/index.html.eex
@@ -23,6 +23,6 @@
 
 <%= if Oli.Utils.LoadTesting.enabled?() do %>
 <!--
-__OVERVIEW_PAGES__<%= encode_pages(@conn, @section_slug, @summary.hierarchy) %>__OVERVIEW_PAGES__
+__OVERVIEW_PAGES__<%= encode_pages(@conn, @section_slug, @hierarchy) %>__OVERVIEW_PAGES__
 -->
 <% end %>

--- a/lib/oli_web/templates/resource/_preview_previous_next_nav.html.eex
+++ b/lib/oli_web/templates/resource/_preview_previous_next_nav.html.eex
@@ -1,14 +1,14 @@
 <nav class="previous-next-nav d-flex flex-row" aria-label="Page navigation">
 
   <%= if @context.previous_page != nil do %>
-    <%= link to: Routes.resource_path(@conn, @action, @context.projectSlug, @context.previous_page.slug), class: "page-nav-link btn" do %>
+    <%= link to: Routes.resource_path(@conn, @action, @context.projectSlug, @context.previous_page["slug"]), class: "page-nav-link btn" do %>
       <div class="d-flex flex-row">
         <div>
           <i class="fas fa-arrow-left nav-icon"></i>
         </div>
         <div class="d-flex flex-column flex-fill flex-ellipsize-fix text-right">
           <div class="nav-label">Previous</div>
-          <div class="nav-title"><%= @context.previous_page.title %></div>
+          <div class="nav-title"><%= @context.previous_page["title"] %></div>
         </div>
       </div>
     <% end %>
@@ -20,11 +20,11 @@
 
   <%= cond do %>
     <% @context.next_page != nil -> %>
-        <%= link to: Routes.resource_path(@conn, @action, @context.projectSlug, @context.next_page.slug), class: "page-nav-link btn" do %>
+        <%= link to: Routes.resource_path(@conn, @action, @context.projectSlug, @context.next_page["slug"]), class: "page-nav-link btn" do %>
           <div class="d-flex flex-row">
             <div class="d-flex flex-column flex-fill flex-ellipsize-fix text-left">
               <div class="nav-label">Next</div>
-              <div class="nav-title"><%= @context.next_page.title %></div>
+              <div class="nav-title"><%= @context.next_page["title"] %></div>
             </div>
             <div>
               <i class="fas fa-arrow-right nav-icon"></i>

--- a/lib/oli_web/views/page_delivery_view.ex
+++ b/lib/oli_web/views/page_delivery_view.ex
@@ -24,14 +24,14 @@ defmodule OliWeb.PageDeliveryView do
         conn,
         :page_preview,
         conn.assigns.section_slug,
-        conn.assigns.previous_page.slug
+        conn.assigns.previous_page["slug"]
       )
     else
       Routes.page_delivery_path(
         conn,
         :page,
         conn.assigns.section_slug,
-        conn.assigns.previous_page.slug
+        conn.assigns.previous_page["slug"]
       )
     end
   end
@@ -42,14 +42,14 @@ defmodule OliWeb.PageDeliveryView do
         conn,
         :page_preview,
         conn.assigns.section_slug,
-        conn.assigns.next_page.slug
+        conn.assigns.next_page["slug"]
       )
     else
       Routes.page_delivery_path(
         conn,
         :page,
         conn.assigns.section_slug,
-        conn.assigns.next_page.slug
+        conn.assigns.next_page["slug"]
       )
     end
   end

--- a/priv/repo/migrations/20211111003243_add_section_link_map.exs
+++ b/priv/repo/migrations/20211111003243_add_section_link_map.exs
@@ -1,0 +1,9 @@
+defmodule Oli.Repo.Migrations.AddSectionLinkMap do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sections) do
+      add :previous_next_index, :map, default: nil, null: true
+    end
+  end
+end

--- a/test/oli/delivery/hierarchy_test.exs
+++ b/test/oli/delivery/hierarchy_test.exs
@@ -27,6 +27,43 @@ defmodule Oli.Delivery.HierarchyTest do
       |> Map.put(:nested_page_two_node, nested_page_two_node)
     end
 
+    test "build_navigation_link_map/1", %{
+      hierarchy: hierarchy,
+      page_one_node: node1,
+      page_two_node: node2,
+      nested_page_one_node: node3,
+      nested_page_two_node: node4
+    } do
+      link_map = Hierarchy.build_navigation_link_map(hierarchy)
+
+      get = fn n -> Map.get(link_map, n.revision.resource_id |> Integer.to_string()) end
+
+      # verify that all four pages exist within the link map
+      assert 4 == Map.keys(link_map) |> Enum.count()
+
+      # verify that the links are set up correctly and that the slugs and titles
+      # are present and correct
+      assert get.(node1)["prev"] == nil
+      assert get.(node1)["next"] == Integer.to_string(node2.revision.resource_id)
+      assert get.(node1)["slug"] == node1.revision.slug
+      assert get.(node1)["title"] == node1.revision.title
+
+      assert get.(node2)["prev"] == Integer.to_string(node1.revision.resource_id)
+      assert get.(node2)["next"] == Integer.to_string(node3.revision.resource_id)
+      assert get.(node2)["slug"] == node2.revision.slug
+      assert get.(node2)["title"] == node2.revision.title
+
+      assert get.(node3)["prev"] == Integer.to_string(node2.revision.resource_id)
+      assert get.(node3)["next"] == Integer.to_string(node4.revision.resource_id)
+      assert get.(node3)["slug"] == node3.revision.slug
+      assert get.(node3)["title"] == node3.revision.title
+
+      assert get.(node4)["prev"] == Integer.to_string(node3.revision.resource_id)
+      assert get.(node4)["next"] == nil
+      assert get.(node4)["slug"] == node4.revision.slug
+      assert get.(node4)["title"] == node4.revision.title
+    end
+
     test "flatten_pages/1", %{hierarchy: hierarchy} do
       flattened = Hierarchy.flatten_pages(hierarchy)
 

--- a/test/oli/delivery/page/page_context_test.exs
+++ b/test/oli/delivery/page/page_context_test.exs
@@ -78,51 +78,6 @@ defmodule Oli.Delivery.Page.PageContextTest do
 
       # verify objectives map
       assert context.objectives == ["objective one"]
-
-      # verify previous and next are correct
-      assert context.previous_page.resource_id == page1.id
-      assert context.next_page.resource_id == page2.id
-
-      # verify all other possible variants of prev and next:
-
-      Seeder.replace_pages_with(
-        [p1.resource, page2],
-        container_resource,
-        container_revision,
-        publication
-      )
-
-      Seeder.rebuild_section_resources(%{section: section, publication: publication})
-
-      context = PageContext.create_for_visit(section.slug, p1.revision.slug, user)
-      assert context.previous_page == nil
-      assert context.next_page.resource_id == page2.id
-
-      Seeder.replace_pages_with(
-        [page2, p1.resource],
-        container_resource,
-        container_revision,
-        publication
-      )
-
-      Seeder.rebuild_section_resources(%{section: section, publication: publication})
-
-      context = PageContext.create_for_visit(section.slug, p1.revision.slug, user)
-      assert context.previous_page.resource_id == page2.id
-      assert context.next_page == nil
-
-      Seeder.replace_pages_with(
-        [p1.resource],
-        container_resource,
-        container_revision,
-        publication
-      )
-
-      Seeder.rebuild_section_resources(%{section: section, publication: publication})
-
-      context = PageContext.create_for_visit(section.slug, p1.revision.slug, user)
-      assert context.previous_page == nil
-      assert context.next_page == nil
     end
   end
 end

--- a/test/oli/delivery/previous_next_index_test.exs
+++ b/test/oli/delivery/previous_next_index_test.exs
@@ -1,0 +1,49 @@
+defmodule Oli.Delivery.PreviousNextIndexTest do
+  use Oli.DataCase
+
+  alias Oli.Delivery.Sections
+  alias Oli.Delivery.PreviousNextIndex
+  alias Oli.Publishing.DeliveryResolver
+
+  describe "previous next index" do
+    setup do
+      map = Seeder.base_project_with_resource4()
+
+      hierarchy = DeliveryResolver.full_hierarchy(map.section_1.slug)
+
+      page_one_node = hierarchy.children |> Enum.at(0)
+      page_two_node = hierarchy.children |> Enum.at(1)
+      unit_node = hierarchy.children |> Enum.at(2)
+      nested_page_one_node = hierarchy.children |> Enum.at(2) |> Map.get(:children) |> Enum.at(0)
+      nested_page_two_node = hierarchy.children |> Enum.at(2) |> Map.get(:children) |> Enum.at(1)
+
+      map
+      |> Map.put(:hierarchy, hierarchy)
+      |> Map.put(:page_one_node, page_one_node)
+      |> Map.put(:page_two_node, page_two_node)
+      |> Map.put(:unit_node, unit_node)
+      |> Map.put(:nested_page_one_node, nested_page_one_node)
+      |> Map.put(:nested_page_two_node, nested_page_two_node)
+    end
+
+    test "build_navigation_link_map/1", %{
+      page_two_node: node2,
+      nested_page_one_node: node3,
+      nested_page_two_node: node4,
+      section_1: section
+    } do
+      assert is_nil(section.previous_next_index)
+
+      {:ok, {previous, next}} = PreviousNextIndex.retrieve(section, node3.revision.resource_id)
+
+      # verify that the links are set up correctly and that the slugs and titles
+      # are present and correct
+      assert previous["slug"] == node2.revision.slug
+      assert next["slug"] == node4.revision.slug
+
+      section = Sections.get_section_by_slug(section.slug)
+
+      refute is_nil(section.previous_next_index)
+    end
+  end
+end


### PR DESCRIPTION
Closes #1837

During the instructor preview work, it was remembered/discovered that the implementation of the determination of the "Previous" and "Next" pages in delivery was a potentially expensive operation.  This calculation was relying on the full delivery hierarchy being queried (returning all revisions of all resources in the section) and then reconstructed, then traversed to determine the preview and next pages. This was happening on every single page access in delivery. 

This PR significantly streamlines this by precalculating the "previous" and "next" pages link information in a new `previous_next_index` field in the `sections` schema.  With the section already being in the `conn.assigns` all that has to be done is at most three (likely constant time, maybe log n) lookups into this map.  One for the current page, and one each for the previous and next. 

Notice that the migration to add this field does nothing to set its content for existing sections. This is handled, just in time, by the `Oli.Delivery.PreviousNextIndex.retrieve` method that will detect when this field is `nil` and automatically build the index.  

The index is updated after every "remix" operation and every "apply course updates" operation. 