### PR TITLE
[BUGFIX/NOJIRA] Hide popup window "X" from screen readers

### DIFF
--- a/assets/src/components/parts/janus-popup/PopupWindow.tsx
+++ b/assets/src/components/parts/janus-popup/PopupWindow.tsx
@@ -125,7 +125,9 @@ const PopupWindow: React.FC<PopupWindowProps> = ({
           style={popupCloseStyles}
           onClick={handleCloseIconClick}
         >
-          <span style={closeButtonSpanStyles}>x</span>
+          <span aria-hidden={true} style={closeButtonSpanStyles}>
+            x
+          </span>
         </button>
       </div>
     </div>


### PR DESCRIPTION
Hides the popup window X icon from screen-readers, based on 11/15 CSS theme check in discussions.