### PR TITLE
[JAN-947 | PMP-2144]   [JAN-679 | PMP-1964] - Wrong trap states firing

### DIFF
--- a/assets/src/adaptivity/rules-engine.ts
+++ b/assets/src/adaptivity/rules-engine.ts
@@ -306,6 +306,8 @@ export const check = async (
   }
 
   let score = 0;
+  //below condition make sure the score calculation will happen only if the answer is correct and
+  //in case of incorrect answer if negative scoring is allowed then calculation will proceed.
   if (isCorrect || scoringContext.negativeScoreAllowed) {
     if (scoringContext.trapStateScoreScheme) {
       // apply all the actions from the resultEvents that mutate the state

--- a/assets/src/adaptivity/rules-engine.ts
+++ b/assets/src/adaptivity/rules-engine.ts
@@ -306,31 +306,34 @@ export const check = async (
   }
 
   let score = 0;
-  if (scoringContext.trapStateScoreScheme) {
-    // apply all the actions from the resultEvents that mutate the state
-    // then check the session.currentQuestionScore and clamp it against the maxScore
-    // setting that value to score
-    const mutations = resultEvents.reduce((acc, evt) => {
-      const { actions } = evt.params as Record<string, any>;
-      const mActions = actions.filter(
-        (action: any) =>
-          action.type === 'mutateState' && action.params.target === 'session.currentQuestionScore',
-      );
-      return acc.concat(...acc, mActions);
-    }, []);
-    if (mutations.length) {
-      const mutApplies = mutations.map(({ params }) => params);
-      bulkApplyState(mutApplies, env);
-      score = getValue('session.currentQuestionScore', env) || 0;
+  if (isCorrect || scoringContext.negativeScoreAllowed) {
+    if (scoringContext.trapStateScoreScheme) {
+      // apply all the actions from the resultEvents that mutate the state
+      // then check the session.currentQuestionScore and clamp it against the maxScore
+      // setting that value to score
+      const mutations = resultEvents.reduce((acc, evt) => {
+        const { actions } = evt.params as Record<string, any>;
+        const mActions = actions.filter(
+          (action: any) =>
+            action.type === 'mutateState' &&
+            action.params.target === 'session.currentQuestionScore',
+        );
+        return acc.concat(...acc, mActions);
+      }, []);
+      if (mutations.length) {
+        const mutApplies = mutations.map(({ params }) => params);
+        bulkApplyState(mutApplies, env);
+        score = getValue('session.currentQuestionScore', env) || 0;
+      }
+    } else {
+      const { maxScore, maxAttempt, currentAttemptNumber } = scoringContext;
+      const scorePerAttempt = maxScore / maxAttempt;
+      score = maxScore - scorePerAttempt * (currentAttemptNumber - 1);
     }
-  } else {
-    const { maxScore, maxAttempt, currentAttemptNumber } = scoringContext;
-    const scorePerAttempt = maxScore / maxAttempt;
-    score = maxScore - scorePerAttempt * (currentAttemptNumber - 1);
-  }
-  score = Math.min(score, scoringContext.maxScore);
-  if (!scoringContext.negativeScoreAllowed) {
-    score = Math.max(0, score);
+    score = Math.min(score, scoringContext.maxScore);
+    if (!scoringContext.negativeScoreAllowed) {
+      score = Math.max(0, score);
+    }
   }
 
   const finalResults = {

--- a/assets/src/apps/delivery/store/features/adaptivity/actions/triggerCheck.ts
+++ b/assets/src/apps/delivery/store/features/adaptivity/actions/triggerCheck.ts
@@ -297,8 +297,11 @@ export const triggerCheck = createAsyncThunk(
     }
 
     // TODO: get score back from check result
-    applyState(
-      { target: 'session.currentQuestionScore', operator: '=', value: score },
+    bulkApplyState(
+      [
+        { target: 'session.currentQuestionScore', operator: '=', value: score },
+        { target: `session.visits.${currentActivity.id}`, operator: '=', value: 1 },
+      ],
       defaultGlobalEnv,
     );
 

--- a/assets/src/apps/delivery/store/features/groups/actions/deck.ts
+++ b/assets/src/apps/delivery/store/features/groups/actions/deck.ts
@@ -65,7 +65,7 @@ export const initializeActivity = createAsyncThunk(
     const visitOperation: ApplyStateOperation = {
       target: `session.visits.${currentSequenceId}`,
       operator: '+',
-      value: 1,
+      value: 0,
     };
     const timeOnQuestion: ApplyStateOperation = {
       target: 'session.timeOnQuestion',

--- a/assets/src/apps/delivery/store/features/groups/actions/deck.ts
+++ b/assets/src/apps/delivery/store/features/groups/actions/deck.ts
@@ -62,11 +62,6 @@ export const initializeActivity = createAsyncThunk(
       operator: '=',
       value: currentSequenceId,
     };
-    const visitOperation: ApplyStateOperation = {
-      target: `session.visits.${currentSequenceId}`,
-      operator: '+',
-      value: 0,
-    };
     const timeOnQuestion: ApplyStateOperation = {
       target: 'session.timeOnQuestion',
       operator: '=',
@@ -106,7 +101,6 @@ export const initializeActivity = createAsyncThunk(
 
     const sessionOps = [
       resumeTarget,
-      visitOperation,
       timeStartOp,
       timeOnQuestion,
       timeExceededOp,


### PR DESCRIPTION
PMP-2144 - sessons.visit variable for the page is getting set to 1 as soon as we come on the page which is causing the trapstate to be wrong as the criteria is sessions.visit should be 0.

PMP-1964 - The score was getting calculated for wrong attempts also when the negativescoring is not allowed, so that condition is added.