### PR TITLE
[BUGFIX] Allow deletion of authors when they have resources locked for editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bug Fixes
 
+- Fix bug that prevented deletion of authors that have locked resource revisions
+
 ### Enhancements
 
 - Instructor "Preview" mode
@@ -11,6 +13,7 @@
 ## 0.14.6 (2021-11-08)
 
 ### Bug Fixes
+
 - Fix the rendering of HTML special characters within activities
 - Fix an issue where email was always being required regardless of independent_learner and guest status
 

--- a/priv/repo/migrations/20211116151722_nilify_published_resource_author.exs
+++ b/priv/repo/migrations/20211116151722_nilify_published_resource_author.exs
@@ -1,0 +1,19 @@
+defmodule Oli.Repo.Migrations.NilifyPublishedResourceAuthor do
+  use Ecto.Migration
+
+
+  def up do
+    drop(constraint(:published_resources, "published_resources_locked_by_id_fkey"))
+    alter table(:published_resources) do
+      modify(:locked_by_id, references(:authors, on_delete: :nilify_all))
+    end
+  end
+
+  def down() do
+
+    drop(constraint(:published_resources, "published_resources_locked_by_id_fkey"))
+    alter table(:published_resources) do
+      modify(:locked_by_id, references(:authors, on_delete: :nothing))
+    end
+  end
+end


### PR DESCRIPTION
Closes #1800 

The issue here was that the foreign key constraint from "published_resources" to authors prevented this hard delete.  This PR adds a migration that updates that constraint to nilify that entry when an authors record is deleted.  

I tested this by:
1. Create a new authoring account, create a project, create a page
2. Go into the page editor, which sets the author reference from that "published_resource" record.
3. Then, in a another browser logged in as admin, delete the user.  Without this PR this step fails, with this PR it succeeds.
