### PR TITLE
[Feature] [PMP-2051 / JAN-844] Basic Theme Picker

### DIFF
--- a/assets/src/apps/authoring/components/PropertyEditor/schemas/lesson.ts
+++ b/assets/src/apps/authoring/components/PropertyEditor/schemas/lesson.ts
@@ -28,8 +28,15 @@ const lessonSchema: JSONSchema7 = {
           title: 'Lesson Appearance',
           properties: {
             theme: {
-              type: 'string',
-              title: 'Lesson Theme',
+              anyOf: [
+                {
+                  type: 'string',
+                  title: 'Default Theme',
+                  enum: ['/css/delivery_adaptive_themes_default_light.css'],
+                  default: '/css/delivery_adaptive_themes_default_light.css',
+                },
+                { type: 'string', title: 'Custom Theme' },
+              ],
             },
             customCssUrl: {
               type: 'string',

--- a/assets/src/apps/authoring/store/page/actions/initializeFromContext.ts
+++ b/assets/src/apps/authoring/store/page/actions/initializeFromContext.ts
@@ -33,7 +33,8 @@ export const initializeFromContext = createAsyncThunk(
       custom: params.context.content.custom || {},
     };
     if (!params.context.content.model.length && !pageState.custom.themeId) {
-      pageState.custom.themeId = 'torus-theme-1';
+      pageState.custom.themeId = 'torus-default-light';
+      pageState.additionalStylesheets = ['/css/delivery_adaptive_themes_default_light.css'];
     }
     dispatch(loadPage(pageState));
 


### PR DESCRIPTION
Adds default / custom theme picker to the lesson panel.  Auto-selects the new default theme for new lessons, as well as auto-selects custom theme for lessons with existing theme urls. 

![2021-11-16 14 21 16](https://user-images.githubusercontent.com/633004/142051574-733e2bab-a565-4264-aa1c-a5adc61f3173.gif)


