### PR TITLE
[FEATURE] Non scoreable attempts

### DIFF
--- a/lib/oli/delivery/activity_provider.ex
+++ b/lib/oli/delivery/activity_provider.ex
@@ -3,6 +3,7 @@ defmodule Oli.Delivery.ActivityProvider do
   alias Oli.Activities.Realizer.Query.Result
   alias Oli.Activities.Realizer.Selection
   alias Oli.Resources.Revision
+  alias Oli.Delivery.ActivityProvider.Result
 
   @doc """
   Realizes and resolves activities in a page.
@@ -21,16 +22,16 @@ defmodule Oli.Delivery.ActivityProvider do
   selections.  The selection element from within the page must be replaced by static activity references
   (which later then drive rendering).
 
-  Returns a three element tuple, with the first element being a list of any errors encountered,
-  the second being the revisions of all provided activities, and the third being the transformed
-  content of the page revision.
+  Returns a %Oli.Delivery.ActivityProvider.Result{}, which contains a list of any errors, the provided
+  activity revisions, a MapSet of those revision resource ids that are to be unscored
+  activities and the transformed page model.
   """
   def provide(
         %Revision{content: %{"advancedDelivery" => true} = content},
         %Source{} = source,
         resolver
       ) do
-    activity_ids =
+    refs =
       Oli.Resources.PageContent.flat_filter(content, fn e ->
         case Map.get(e, "type", nil) do
           nil -> false
@@ -38,11 +39,31 @@ defmodule Oli.Delivery.ActivityProvider do
           _ -> false
         end
       end)
+
+    unscored =
+      refs
+      |> Enum.filter(fn ref ->
+        case Map.get(ref, "custom", %{}) do
+          %{"isLayer" => true} -> true
+          %{"isBank" => true} -> true
+          _ -> false
+        end
+      end)
+      |> Enum.map(fn %{"activity_id" => id} -> id end)
+      |> MapSet.new()
+
+    activity_ids =
+      refs
       |> Enum.map(fn %{"activity_id" => id} -> id end)
 
     revisions = resolver.from_resource_id(source.section_slug, activity_ids)
 
-    {[], revisions, content}
+    %Result{
+      errors: [],
+      revisions: revisions,
+      transformed_content: content,
+      unscored: unscored
+    }
   end
 
   def provide(
@@ -55,7 +76,12 @@ defmodule Oli.Delivery.ActivityProvider do
     only_revisions =
       resolve_activity_ids(source.section_slug, activities, resolver) |> Enum.reverse()
 
-    {errors, only_revisions, Map.put(content, "model", Enum.reverse(model))}
+    %Result{
+      errors: errors,
+      revisions: only_revisions,
+      transformed_content: Map.put(content, "model", Enum.reverse(model)),
+      unscored: MapSet.new()
+    }
   end
 
   # Make a pass through the revision content model to gather all statically referenced activity ids

--- a/lib/oli/delivery/activity_provider.ex
+++ b/lib/oli/delivery/activity_provider.ex
@@ -3,7 +3,7 @@ defmodule Oli.Delivery.ActivityProvider do
   alias Oli.Activities.Realizer.Query.Result
   alias Oli.Activities.Realizer.Selection
   alias Oli.Resources.Revision
-  alias Oli.Delivery.ActivityProvider.Result
+  alias Oli.Delivery.ActivityProvider.Result, as: ProviderResult
 
   @doc """
   Realizes and resolves activities in a page.
@@ -58,7 +58,7 @@ defmodule Oli.Delivery.ActivityProvider do
 
     revisions = resolver.from_resource_id(source.section_slug, activity_ids)
 
-    %Result{
+    %ProviderResult{
       errors: [],
       revisions: revisions,
       transformed_content: content,
@@ -76,7 +76,7 @@ defmodule Oli.Delivery.ActivityProvider do
     only_revisions =
       resolve_activity_ids(source.section_slug, activities, resolver) |> Enum.reverse()
 
-    %Result{
+    %ProviderResult{
       errors: errors,
       revisions: only_revisions,
       transformed_content: Map.put(content, "model", Enum.reverse(model)),

--- a/lib/oli/delivery/activity_provider/result.ex
+++ b/lib/oli/delivery/activity_provider/result.ex
@@ -1,0 +1,8 @@
+defmodule Oli.Delivery.ActivityProvider.Result do
+  defstruct [
+    :errors,
+    :revisions,
+    :unscored,
+    :transformed_content
+  ]
+end

--- a/lib/oli/delivery/attempts/core/activity_attempt.ex
+++ b/lib/oli/delivery/attempts/core/activity_attempt.ex
@@ -6,6 +6,7 @@ defmodule Oli.Delivery.Attempts.Core.ActivityAttempt do
     field(:attempt_guid, :string)
     field(:attempt_number, :integer)
     field(:date_evaluated, :utc_datetime)
+    field(:scoreable, :boolean, default: true)
     field(:score, :float)
     field(:out_of, :float)
     field(:transformed_model, :map)
@@ -27,6 +28,7 @@ defmodule Oli.Delivery.Attempts.Core.ActivityAttempt do
       :score,
       :out_of,
       :date_evaluated,
+      :scoreable,
       :transformed_model,
       :resource_attempt_id,
       :resource_id,

--- a/lib/oli_web/controllers/resource_controller.ex
+++ b/lib/oli_web/controllers/resource_controller.ex
@@ -74,7 +74,10 @@ defmodule OliWeb.ResourceController do
         )
 
       revision ->
-        {_, activity_revisions, transformed_content} =
+        %Oli.Delivery.ActivityProvider.Result{
+          revisions: activity_revisions,
+          transformed_content: transformed_content
+        } =
           Oli.Delivery.ActivityProvider.provide(
             revision,
             %Source{
@@ -120,7 +123,6 @@ defmodule OliWeb.ResourceController do
 
     case pages do
       [first | _] ->
-
         conn
         |> redirect(to: Routes.resource_path(conn, :preview, project_slug, first.revision.slug))
 

--- a/priv/repo/migrations/20211117160940_add_scoreable.exs
+++ b/priv/repo/migrations/20211117160940_add_scoreable.exs
@@ -1,0 +1,15 @@
+defmodule Oli.Repo.Migrations.AddScoreable do
+  use Ecto.Migration
+
+  def change do
+    alter table(:activity_attempts) do
+      add :scoreable, :boolean, default: true
+    end
+
+    flush()
+
+    execute "UPDATE activity_attempts SET scoreable = true;"
+
+    flush()
+  end
+end

--- a/test/oli/delivery/activity_provider_test.exs
+++ b/test/oli/delivery/activity_provider_test.exs
@@ -3,6 +3,7 @@ defmodule Oli.Delivery.ActivityProviderTest do
 
   alias Oli.Delivery.ActivityProvider
   alias Oli.Activities.Realizer.Query.Source
+  alias Oli.Delivery.ActivityProvider.Result
 
   describe "fulfilling static activity references with adaptive page" do
     setup do
@@ -96,7 +97,7 @@ defmodule Oli.Delivery.ActivityProviderTest do
         section_slug: section.slug
       }
 
-      {errors, activity_revisions, _} =
+      %{errors: errors, revisions: activity_revisions} =
         ActivityProvider.provide(
           page.revision,
           source,
@@ -237,7 +238,11 @@ defmodule Oli.Delivery.ActivityProviderTest do
         section_slug: section.slug
       }
 
-      {errors, activity_revisions, transformed_content} =
+      %Result{
+        errors: errors,
+        revisions: activity_revisions,
+        transformed_content: transformed_content
+      } =
         ActivityProvider.provide(
           %{page.revision | content: content},
           source,
@@ -324,7 +329,11 @@ defmodule Oli.Delivery.ActivityProviderTest do
         section_slug: section.slug
       }
 
-      {errors, activity_revisions, transformed_content} =
+      %Result{
+        errors: errors,
+        revisions: activity_revisions,
+        transformed_content: transformed_content
+      } =
         ActivityProvider.provide(
           %{page.revision | content: content},
           source,
@@ -413,7 +422,11 @@ defmodule Oli.Delivery.ActivityProviderTest do
         section_slug: section.slug
       }
 
-      {errors, activity_revisions, transformed_content} =
+      %Result{
+        errors: errors,
+        revisions: activity_revisions,
+        transformed_content: transformed_content
+      } =
         ActivityProvider.provide(
           %{page.revision | content: content},
           source,

--- a/test/oli/delivery/activity_provider_test.exs
+++ b/test/oli/delivery/activity_provider_test.exs
@@ -520,7 +520,11 @@ defmodule Oli.Delivery.ActivityProviderTest do
         section_slug: section.slug
       }
 
-      {errors, activity_revisions, transformed_content} =
+      %Result{
+        errors: errors,
+        revisions: activity_revisions,
+        transformed_content: transformed_content
+      } =
         ActivityProvider.provide(
           %{page.revision | content: content},
           source,

--- a/test/oli/delivery/activity_provider_test.exs
+++ b/test/oli/delivery/activity_provider_test.exs
@@ -97,7 +97,7 @@ defmodule Oli.Delivery.ActivityProviderTest do
         section_slug: section.slug
       }
 
-      %{errors: errors, revisions: activity_revisions} =
+      %Result{errors: errors, revisions: activity_revisions} =
         ActivityProvider.provide(
           page.revision,
           source,


### PR DESCRIPTION
This PR adds a new aspect to the attempt hierarchy: the ability for activity attempts to be "unscoreable".  An unscoreable activity attempt will not be auto finalized and will not factor into score rollup to the resource attempt.

This exists initially to support the adaptive page and its use of layers and banks activities. 

There is no way, yet, to designate an activity instance in a basic page as "unscoreable". 