### PR TITLE
[BUGFIX] Fix MultiInput and SingleResponse issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fix bug that prevented deletion of authors that have locked resource revisions
 - Fix an issue related to next previous page links that causes 500 internal server error on advanced authoring pages
+- Fix a bug that prevented MultiInput activities with dropdowns from evaluating correctly
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix bug that prevented deletion of authors that have locked resource revisions
 - Fix an issue related to next previous page links that causes 500 internal server error on advanced authoring pages
 - Fix a bug that prevented MultiInput activities with dropdowns from evaluating correctly
+- Fix a bug that prevented SingleResponse activities from properly restoring student state
 
 ### Enhancements
 

--- a/assets/src/components/activities/common/delivery/inputs/DropdownInput.tsx
+++ b/assets/src/components/activities/common/delivery/inputs/DropdownInput.tsx
@@ -2,11 +2,20 @@ import { SelectOption } from 'components/activities/common/authoring/InputTypeDr
 import React from 'react';
 
 interface Props {
+  selected: any;
   options: SelectOption[];
   onChange: React.ChangeEventHandler<HTMLSelectElement>;
   disabled?: boolean;
 }
 export const DropdownInput: React.FC<Props> = (props) => {
+  const options = [
+    {
+      value: '',
+      displayValue: '',
+    },
+    ...props.options,
+  ];
+
   return (
     <select
       onChange={props.onChange}
@@ -14,8 +23,8 @@ export const DropdownInput: React.FC<Props> = (props) => {
       className="custom-select"
       style={{ flexBasis: '160px', width: '160px' }}
     >
-      {props.options.map((option, i) => (
-        <option key={i} value={option.value}>
+      {options.map((option, i) => (
+        <option selected={option.value === props.selected} key={i} value={option.value}>
           {option.displayValue}
         </option>
       ))}

--- a/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
+++ b/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
@@ -16,7 +16,7 @@ import {
   resetAction,
 } from 'data/activities/DeliveryState';
 import { configureStore } from 'state/store';
-import { safelySelectInputs } from 'data/activities/utils';
+import { safelySelectStringInputs } from 'data/activities/utils';
 import { TextInput } from 'components/activities/common/delivery/inputs/TextInput';
 import { TextareaInput } from 'components/activities/common/delivery/inputs/TextareaInput';
 import { NumericInput } from 'components/activities/common/delivery/inputs/NumericInput';
@@ -74,7 +74,7 @@ export const ShortAnswerComponent: React.FC = () => {
         activityState,
         // Short answers only have one input, but the selection is modeled
         // as an array just to make it consistent with the other activity types
-        safelySelectInputs(activityState).caseOf({
+        safelySelectStringInputs(activityState).caseOf({
           just: (input) => input,
           nothing: () => ({
             [DEFAULT_PART_ID]: [''],

--- a/assets/src/data/activities/utils.ts
+++ b/assets/src/data/activities/utils.ts
@@ -34,6 +34,21 @@ export const safelySelectInputs = (activityState: ActivityState | undefined): Ma
   );
 };
 
+export const safelySelectStringInputs = (
+  activityState: ActivityState | undefined,
+): Maybe<PartInputs> => {
+  const partInputs = activityState?.parts.filter((part) => !!part?.response?.input);
+  if (!partInputs) return Maybe.nothing();
+
+  return Maybe.maybe(activityState).lift((state) =>
+    state.parts.reduce((acc, partState) => {
+      const input = partState.response?.input;
+      acc[String(partState.partId)] = [input];
+      return acc;
+    }, {} as PartInputs),
+  );
+};
+
 export const initialPartInputs = (
   activityState: ActivityState | undefined,
   defaultPartInputs: PartInputs = { [DEFAULT_PART_ID]: [] },

--- a/assets/src/data/content/writers/html.tsx
+++ b/assets/src/data/content/writers/html.tsx
@@ -235,7 +235,13 @@ export class HtmlParser implements WriterImpl {
       case 'text':
         return withHints(<TextInput {...shared} />);
       case 'dropdown':
-        return withHints(<DropdownInput {...shared} options={inputData.input.options} />);
+        return withHints(
+          <DropdownInput
+            {...shared}
+            options={inputData.input.options}
+            selected={inputData.value}
+          />,
+        );
       default:
         assertNever(inputData.input);
     }


### PR DESCRIPTION
Closes #1785 
Closes #1876 

This PR fixes two high priority Activity bugs

## 1. MultiInput: Correctness Issue

The bug here ultimately was because upon initial viewing, or after activity reset, the state of a user's "selected" choice for a dropdown part is the empty string.  This empty string gets sent to the server during submission, at which time the server correctly marks this as "wrong" and then returns the catch all feedback.  The UI, however, never displays an empty choice.  The UI is displaying upon first render - as a default - the first choice.  So if a user does not change choices (because why would they change a choice if they think that choice is the correct one?) the empty string is sent, but the user believes they have submitted an answer for the choice that is visible to them.

The easiest fix here is to simply introduce an "empty" choice that is the default choice.  This is a better UI since it then *forces* the student to review all choices via the dropdown and select one. 

## 2. Single Response: State restoration

The issue here is that the attempt to unify all aspects of the activity models has ended up treated the student text response for SingleResponse as an array (like an array of choices for ordering, for instance).  This is causing the restoration of the users state to only show the first word of their text (aka, the first element of an array where the array is created by splitting on spaces from a text string).  

I have fixed this by providing a special utility for those activity types that utilize pure strings as the student input. 

