### PR TITLE
[BUGFIX] Avoid requiring title assign to be present

### DIFF
--- a/lib/oli_web/templates/layout/workspace.html.eex
+++ b/lib/oli_web/templates/layout/workspace.html.eex
@@ -10,8 +10,8 @@
       <%= render OliWeb.LayoutView,
         "_#{cond do
           @conn.params["project_id"] -> "project" #_project_header.html.eex   (template)
-          @title == "Projects" -> "workspace"     #_workspace_header.html.eex (template)
-          @title != "Projects" -> "account"       #_account_header.html.eex   (template)
+          Map.get(@conn.assigns, :title, "") == "Projects" -> "workspace"     #_workspace_header.html.eex (template)
+          true -> "account"       #_account_header.html.eex   (template)
       end}_header.html", assigns %>
     </div>
     <div class="d-flex flex-grow-1">


### PR DESCRIPTION
This PR makes the logic that varies which header is showing in authoring context more robust against instructor views that do not include a title. 