### PR TITLE
[FEATURE] Manual grade sync for one student, one page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@
 
 ### Enhancements
 
+## 0.16.0 (2021-11-19)
+
+### Bug Fixes
+
+- Fix issue with bulk line item grade sync
+
+### Enhancements
+
+- Allow instructors to manually send one student grade to LMS
+
 ## 0.15.0 (2021-11-18)
 
 ### Bug Fixes

--- a/lib/oli_web/live/grades/grades.ex
+++ b/lib/oli_web/live/grades/grades.ex
@@ -207,7 +207,7 @@ defmodule OliWeb.Grades.GradesLive do
   end
 
   defp send_grades(students, access_token, section, page, line_item, socket) do
-    task_queue = determine_grade_sync_tasks(section.slug, page, line_item, students)
+    task_queue = determine_grade_sync_tasks(section, page, line_item, students)
 
     send(self(), :pop_task_queue)
 

--- a/lib/oli_web/live/progress/passback.ex
+++ b/lib/oli_web/live/progress/passback.ex
@@ -1,0 +1,45 @@
+defmodule OliWeb.Progress.Passback do
+  use Surface.Component
+  prop grade_sync_result, :any, required: true
+  prop click, :event, required: true
+
+  def render(assigns) do
+    ~F"""
+    <div>
+      <button class="btn btn-primary mb-4" phx-disable-with="Sending..." :on-click={@click}>Send Grade to LMS</button>
+      {render_result(assigns, @grade_sync_result)}
+    </div>
+    """
+  end
+
+  def render_result(assigns, result) do
+    case result do
+      nil ->
+        ""
+
+      {:ok, :synced} ->
+        ~F"""
+        <div class="alert alert-success" role="alert">
+          Grade successfully sent to the LMS.
+        </div>
+        """
+
+      {:ok, :not_synced} ->
+        ~F"""
+        <div class="alert alert-info" role="alert">
+          Grade passback is not enabled.
+        </div>
+        """
+
+      {:error, e} ->
+        ~F"""
+        <div class="alert alert-danger" role="alert">
+          <p>The following error was encountered:</p>
+
+          <hr>
+          <p class="mb-0">{e}</p>
+        </div>
+        """
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Oli.MixProject do
   def project do
     [
       app: :oli,
-      version: "0.15.0",
+      version: "0.16.0",
       elixir: "~> 1.12",
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: elixirc_options(Mix.env()),


### PR DESCRIPTION
This PR adds the ability for an instructor to sync one grade, for one student and page. 

It also fixes an issue with the bulk line item sync. 

This was tested locally in my dev env with our Canvas instance, so i have a high degree of confidence that this all works (unlike the last two PRs)