### PR TITLE
[FEATURE] [MER-340] Add Community Members

### DIFF
--- a/lib/oli/groups.ex
+++ b/lib/oli/groups.ex
@@ -24,12 +24,6 @@ defmodule Oli.Groups do
   """
   def list_communities, do: Repo.all(Community)
 
-  defp filter_conditions(filter) do
-    Enum.reduce(filter, false, fn {field, value}, conditions ->
-      dynamic([entity], field(entity, ^field) == ^value or ^conditions)
-    end)
-  end
-
   @doc """
   Returns the list of communities that meets the criteria passed in the input.
 
@@ -379,5 +373,11 @@ defmodule Oli.Groups do
         select: member
       )
     )
+  end
+
+  defp filter_conditions(filter) do
+    Enum.reduce(filter, false, fn {field, value}, conditions ->
+      dynamic([entity], field(entity, ^field) == ^value or ^conditions)
+    end)
   end
 end

--- a/lib/oli/groups.ex
+++ b/lib/oli/groups.ex
@@ -364,13 +364,15 @@ defmodule Oli.Groups do
       iex> list_community_members(123)
       {:ok, []}
   """
-  def list_community_members(community_id) do
+  def list_community_members(community_id, limit \\ nil) do
     Repo.all(
       from(
         community_account in CommunityAccount,
         join: member in assoc(community_account, :user),
         where: community_account.community_id == ^community_id and not community_account.is_admin,
-        select: member
+        select: member,
+        order_by: [desc: :inserted_at],
+        limit: ^limit
       )
     )
   end

--- a/lib/oli_web/live/community_live/account_invitation.ex
+++ b/lib/oli_web/live/community_live/account_invitation.ex
@@ -4,7 +4,7 @@ defmodule OliWeb.CommunityLive.AccountInvitation do
   alias Surface.Components.Form
   alias Surface.Components.Form.{ErrorTag, Field, TextInput}
 
-  prop id, :string, required: true
+  prop list_id, :string, required: true
   prop invite, :event, required: true
   prop remove, :event, required: true
   prop suggest, :event
@@ -18,10 +18,10 @@ defmodule OliWeb.CommunityLive.AccountInvitation do
     ~F"""
       <Form for={@to_invite} submit={@invite} change={@suggest} class="d-flex mb-5">
         <Field name={:email} class="w-100">
-          <TextInput class="form-control" opts={placeholder: @placeholder, autocomplete: "off", list: @id <> "_matches"}/>
-          <datalist id={@id <> "_matches"}>
+          <TextInput class="form-control" opts={placeholder: @placeholder, autocomplete: "off", list: @list_id}/>
+          <datalist id={@list_id}>
             {#for match <- @matches}
-              <option value={match.email} >{match.name}</option>
+              <option value={match.email}>{match.name}</option>
             {/for}
           </datalist>
           <ErrorTag/>

--- a/lib/oli_web/live/community_live/account_invitation.ex
+++ b/lib/oli_web/live/community_live/account_invitation.ex
@@ -4,24 +4,30 @@ defmodule OliWeb.CommunityLive.AccountInvitation do
   alias Surface.Components.Form
   alias Surface.Components.Form.{ErrorTag, Field, TextInput}
 
+  prop id, :string, required: true
   prop invite, :event, required: true
   prop remove, :event, required: true
+  prop suggest, :event
   prop collaborators, :any, default: []
+  prop matches, :any, default: []
   prop to_invite, :any, default: :collaborator
   prop placeholder, :string, default: "collaborator@example.edu"
   prop button_text, :string, default: "Send invite"
 
   def render(assigns) do
     ~F"""
-      <Form for={@to_invite} submit={@invite} class="d-flex mb-5">
+      <Form for={@to_invite} submit={@invite} change={@suggest} class="d-flex mb-5">
         <Field name={:email} class="w-100">
-          <TextInput class="form-control" opts={placeholder: @placeholder}/>
+          <TextInput class="form-control" opts={placeholder: @placeholder, autocomplete: "off", list: @id <> "_matches"}/>
+          <datalist id={@id <> "_matches"}>
+            {#for match <- @matches}
+              <option value={match.email} >{match.name}</option>
+            {/for}
+          </datalist>
           <ErrorTag/>
         </Field>
-
         <button class="form-button btn btn-outline-primary" type="submit">{@button_text}</button>
       </Form>
-
       {#for collaborator <- @collaborators}
         <div class="d-flex justify-content-between align-items-center mb-3">
           <div class="d-flex flex-column">

--- a/lib/oli_web/live/community_live/members_index_view.ex
+++ b/lib/oli_web/live/community_live/members_index_view.ex
@@ -1,0 +1,109 @@
+defmodule OliWeb.CommunityLive.MembersIndexView do
+  use Surface.LiveView, layout: {OliWeb.LayoutView, "live.html"}
+  use OliWeb.Common.SortableTable.TableHandlers
+
+  alias Oli.Groups
+  alias OliWeb.Common.{Breadcrumb, Filter, Listing}
+  alias OliWeb.CommunityLive.{ShowView, MembersTableModel}
+  alias OliWeb.Router.Helpers, as: Routes
+
+  data title, :string, default: "Community Members"
+  data breadcrumbs, :any
+
+  data query, :string, default: ""
+  data total_count, :integer, default: 0
+  data offset, :integer, default: 0
+  data limit, :integer, default: 20
+  data sort, :string, default: "sort"
+  data page_change, :string, default: "page_change"
+  data show_bottom_paging, :boolean, default: false
+  data additional_table_class, :string, default: ""
+
+  @table_filter_fn &__MODULE__.filter_rows/3
+  @table_push_patch_path &__MODULE__.live_path/2
+
+  def filter_rows(socket, query, _filter) do
+    Enum.filter(socket.assigns.members, fn m ->
+      String.contains?(String.downcase(m.name), String.downcase(query)) or
+        String.contains?(String.downcase(m.email), String.downcase(query))
+    end)
+  end
+
+  def live_path(socket, params) do
+    Routes.live_path(socket, __MODULE__, socket.assigns.community_id, params)
+  end
+
+  def breadcrumb(community_id) do
+    ShowView.breadcrumb(community_id) ++
+      [
+        Breadcrumb.new(%{
+          full_title: "Members",
+          link: Routes.live_path(OliWeb.Endpoint, __MODULE__, community_id)
+        })
+      ]
+  end
+
+  def mount(%{"community_id" => community_id}, _session, socket) do
+    members = Groups.list_community_members(community_id)
+    {:ok, table_model} = MembersTableModel.new(members)
+
+    {:ok,
+     assign(socket,
+       breadcrumbs: breadcrumb(community_id),
+       members: members,
+       community_id: community_id,
+       table_model: table_model,
+       total_count: length(members)
+     )}
+  end
+
+  def render(assigns) do
+    ~F"""
+      <div class="d-flex p-3 justify-content-between">
+        <Filter
+          change="change_search"
+          reset="reset_search"
+          apply="apply_search"
+          query={@query}/>
+      </div>
+
+      <div class="p-4">
+        <Listing
+          filter={@query}
+          table_model={@table_model}
+          total_count={@total_count}
+          offset={@offset}
+          limit={@limit}
+          sort={@sort}
+          page_change={@page_change}
+          show_bottom_paging={@show_bottom_paging}
+          additional_table_class={@additional_table_class}/>
+      </div>
+    """
+  end
+
+  def handle_event("remove", %{"id" => id}, socket) do
+    socket = clear_flash(socket)
+
+    case Groups.delete_community_account(%{
+           community_id: socket.assigns.community_id,
+           user_id: id
+         }) do
+      {:ok, _community_account} ->
+        socket = put_flash(socket, :info, "Community member successfully removed.")
+
+        members = Groups.list_community_members(socket.assigns.community_id)
+        {:ok, table_model} = MembersTableModel.new(members)
+
+        {:noreply,
+         assign(socket,
+           members: members,
+           table_model: table_model,
+           total_count: length(members)
+         )}
+
+      {:error, _error} ->
+        {:noreply, put_flash(socket, :error, "Community member couldn't be removed.")}
+    end
+  end
+end

--- a/lib/oli_web/live/community_live/members_table_model.ex
+++ b/lib/oli_web/live/community_live/members_table_model.ex
@@ -1,0 +1,40 @@
+defmodule OliWeb.CommunityLive.MembersTableModel do
+  use Surface.LiveComponent
+
+  alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
+
+  def new(members) do
+    SortableTableModel.new(
+      rows: members,
+      column_specs: [
+        %ColumnSpec{
+          name: :name,
+          label: "Name"
+        },
+        %ColumnSpec{
+          name: :email,
+          label: "Email"
+        },
+        %ColumnSpec{
+          name: :actions,
+          label: "Actions",
+          render_fn: &__MODULE__.render_remove_button/3
+        }
+      ],
+      event_suffix: "",
+      id_field: [:id]
+    )
+  end
+
+  def render_remove_button(assigns, item, _) do
+    ~F"""
+      <button class="btn btn-primary" phx-click="remove" phx-value-id={item.id}>Remove</button>
+    """
+  end
+
+  def render(assigns) do
+    ~F"""
+      <div>nothing</div>
+    """
+  end
+end

--- a/lib/oli_web/live/community_live/show_view.ex
+++ b/lib/oli_web/live/community_live/show_view.ex
@@ -14,10 +14,12 @@ defmodule OliWeb.CommunityLive.ShowView do
     Form,
     IndexView,
     AccountInvitation,
-    ShowSection
+    ShowSection,
+    MembersIndexView
   }
 
   alias OliWeb.Router.Helpers, as: Routes
+  alias Surface.Components.Link
 
   data title, :string, default: "Edit Community"
   data community, :struct
@@ -55,7 +57,7 @@ defmodule OliWeb.CommunityLive.ShowView do
         community ->
           changeset = Groups.change_community(community)
           community_admins = Groups.list_community_admins(community_id)
-          community_members = Groups.list_community_members(community_id)
+          community_members = Groups.list_community_members(community_id, 3)
 
           assign(socket,
             community: community,
@@ -74,7 +76,10 @@ defmodule OliWeb.CommunityLive.ShowView do
     ~F"""
       {render_modal(assigns)}
       <div id="community-overview" class="overview container">
-        <ShowSection section_title="Details" section_description="Main community fields that will be shown to system admins and community admins.">
+        <ShowSection
+          section_title="Details"
+          section_description="Main community fields that will be shown to system admins and community admins."
+        >
           <Form changeset={@changeset} save="save"/>
         </ShowSection>
 
@@ -95,7 +100,7 @@ defmodule OliWeb.CommunityLive.ShowView do
 
         <ShowSection
           section_title="Community Members"
-          section_description="Add users by email to be members of the community."
+          section_description="Add users by email as members of the community. Only showing the last 3 additions here."
         >
           <AccountInvitation
             list_id="member_matches"
@@ -106,6 +111,10 @@ defmodule OliWeb.CommunityLive.ShowView do
             placeholder="user@example.edu"
             button_text="Add"
             collaborators={@community_members}/>
+
+          <Link class="btn btn-link float-right mt-4" to={Routes.live_path(@socket, MembersIndexView, @community.id)}>
+            See all >
+          </Link>
         </ShowSection>
 
         <ShowSection
@@ -265,7 +274,7 @@ defmodule OliWeb.CommunityLive.ShowView do
     do: [community_admins: Groups.list_community_admins(community_id)]
 
   defp community_accounts_assigns("member", community_id),
-    do: [community_members: Groups.list_community_members(community_id)]
+    do: [community_members: Groups.list_community_members(community_id, 3)]
 
   defp community_accounts_assigns(_user_type, _community_id), do: []
 

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -276,6 +276,7 @@ defmodule OliWeb.Router do
         pipe_through [:authorize_community]
 
         live("/", CommunityLive.ShowView)
+        live("/members", CommunityLive.MembersIndexView)
 
         scope "/associated" do
           live("/", CommunityLive.Associated.IndexView)

--- a/test/oli/groups_test.exs
+++ b/test/oli/groups_test.exs
@@ -252,13 +252,18 @@ defmodule Oli.GroupsTest do
       assert 2 = length(admins)
     end
 
-    test "list_community_members/1 returns the members for a community" do
+    test "list_community_members/2 returns the members for a community" do
       insert(:community_admin_account)
-      %CommunityAccount{community_id: community_id} = insert(:community_member_account)
+      %CommunityAccount{community: community} = insert(:community_member_account)
+      insert(:community_member_account, %{community: community})
 
-      members = Groups.list_community_members(community_id)
+      members = Groups.list_community_members(community.id)
 
-      assert [%User{}] = members
+      assert [%User{} | _tail] = members
+      assert 2 = length(members)
+
+      members_limited = Groups.list_community_members(community.id, 1)
+      assert [%User{}] = members_limited
     end
 
     test "get_community_account_by!/1 returns a community account when meets the clauses" do

--- a/test/oli_web/live/community_live_test.exs
+++ b/test/oli_web/live/community_live_test.exs
@@ -498,6 +498,33 @@ defmodule OliWeb.CommunityLiveTest do
       assert 1 == length(Groups.list_community_admins(community.id))
     end
 
+    test "suggests community admin correctly", %{
+      conn: conn,
+      community: community
+    } do
+      author = insert(:author)
+
+      {:ok, view, _html} = live(conn, live_view_show_route(community.id))
+
+      view
+      |> element("form[phx-change=\"suggest_admin\"")
+      |> render_change(%{collaborator: %{email: author.name}})
+
+      assert view
+             |> element("#admin_matches")
+             |> render() =~
+               author.email
+
+      view
+      |> element("form[phx-change=\"suggest_admin\"")
+      |> render_change(%{collaborator: %{email: "other_name"}})
+
+      refute view
+             |> element("#admin_matches")
+             |> render() =~
+               author.email
+    end
+
     test "adds community member correctly", %{
       conn: conn,
       community: community
@@ -595,6 +622,33 @@ defmodule OliWeb.CommunityLiveTest do
                "Community member couldn&#39;t be removed."
 
       assert 1 == length(Groups.list_community_members(community.id))
+    end
+
+    test "suggests community member correctly", %{
+      conn: conn,
+      community: community
+    } do
+      user = insert(:user)
+
+      {:ok, view, _html} = live(conn, live_view_show_route(community.id))
+
+      view
+      |> element("form[phx-change=\"suggest_member\"")
+      |> render_change(%{collaborator: %{email: user.name}})
+
+      assert view
+             |> element("#member_matches")
+             |> render() =~
+               user.email
+
+      view
+      |> element("form[phx-change=\"suggest_member\"")
+      |> render_change(%{collaborator: %{email: "other_name"}})
+
+      refute view
+             |> element("#member_matches")
+             |> render() =~
+               user.email
     end
   end
 

--- a/test/oli_web/live/community_live_test.exs
+++ b/test/oli_web/live/community_live_test.exs
@@ -411,13 +411,13 @@ defmodule OliWeb.CommunityLiveTest do
       assert 1 == length(Groups.list_community_admins(community.id))
 
       view
-      |> element("form[phx-submit=\"add_collaborator\"")
+      |> element("form[phx-submit=\"add_admin\"")
       |> render_submit(%{collaborator: %{email: author.email}})
 
       assert view
              |> element("div.alert.alert-info")
              |> render() =~
-               "Admin successfully added."
+               "Community admin successfully added."
 
       assert 2 == length(Groups.list_community_admins(community.id))
     end
@@ -432,16 +432,16 @@ defmodule OliWeb.CommunityLiveTest do
       {:ok, view, _html} = live(conn, live_view_show_route(community.id))
 
       view
-      |> element("form[phx-submit=\"add_collaborator\"")
+      |> element("form[phx-submit=\"add_admin\"")
       |> render_submit(%{collaborator: %{email: author.email}})
 
       assert view
              |> element("div.alert.alert-danger")
              |> render() =~
-               "Community admin couldn&#39;t be added. Author is already an admin or an unexpected error occurred."
+               "Community user couldn&#39;t be added. It is already associated to the community or an unexpected error occurred."
 
       view
-      |> element("form[phx-submit=\"add_collaborator\"")
+      |> element("form[phx-submit=\"add_admin\"")
       |> render_submit(%{collaborator: %{email: "wrong@example.com"}})
 
       assert view
@@ -464,13 +464,13 @@ defmodule OliWeb.CommunityLiveTest do
       assert 1 == length(Groups.list_community_admins(community.id))
 
       view
-      |> element("button[phx-click=\"remove_collaborator\"")
+      |> element("button[phx-click=\"remove_admin\"")
       |> render_click(%{"collaborator-id" => author.id})
 
       assert view
              |> element("div.alert.alert-info")
              |> render() =~
-               "Admin successfully removed."
+               "Community admin successfully removed."
 
       assert 0 == length(Groups.list_community_admins(community.id))
     end
@@ -487,7 +487,7 @@ defmodule OliWeb.CommunityLiveTest do
       assert 1 == length(Groups.list_community_admins(community.id))
 
       view
-      |> element("button[phx-click=\"remove_collaborator\"")
+      |> element("button[phx-click=\"remove_admin\"")
       |> render_click(%{"collaborator-id" => 12345})
 
       assert view
@@ -496,6 +496,105 @@ defmodule OliWeb.CommunityLiveTest do
                "Community admin couldn&#39;t be removed."
 
       assert 1 == length(Groups.list_community_admins(community.id))
+    end
+
+    test "adds community member correctly", %{
+      conn: conn,
+      community: community
+    } do
+      user = insert(:user)
+      insert(:community_member_account, %{community: community})
+
+      {:ok, view, _html} = live(conn, live_view_show_route(community.id))
+
+      assert 1 == length(Groups.list_community_members(community.id))
+
+      view
+      |> element("form[phx-submit=\"add_member\"")
+      |> render_submit(%{collaborator: %{email: user.email}})
+
+      assert view
+             |> element("div.alert.alert-info")
+             |> render() =~
+               "Community member successfully added."
+
+      assert 2 == length(Groups.list_community_members(community.id))
+    end
+
+    test "displays error messages when adding community member fails", %{
+      conn: conn,
+      community: community
+    } do
+      user = build(:user)
+      insert(:community_member_account, %{community: community, user: user})
+
+      {:ok, view, _html} = live(conn, live_view_show_route(community.id))
+
+      view
+      |> element("form[phx-submit=\"add_member\"")
+      |> render_submit(%{collaborator: %{email: user.email}})
+
+      assert view
+             |> element("div.alert.alert-danger")
+             |> render() =~
+               "Community user couldn&#39;t be added. It is already associated to the community or an unexpected error occurred."
+
+      view
+      |> element("form[phx-submit=\"add_member\"")
+      |> render_submit(%{collaborator: %{email: "wrong@example.com"}})
+
+      assert view
+             |> element("div.alert.alert-danger")
+             |> render() =~
+               "Community member couldn&#39;t be added. User does not exist."
+
+      assert 1 == length(Groups.list_community_members(community.id))
+    end
+
+    test "removes community member correctly", %{
+      conn: conn,
+      community: community
+    } do
+      user = insert(:user)
+      insert(:community_member_account, %{community: community, user: user})
+
+      {:ok, view, _html} = live(conn, live_view_show_route(community.id))
+
+      assert 1 == length(Groups.list_community_members(community.id))
+
+      view
+      |> element("button[phx-click=\"remove_member\"")
+      |> render_click(%{"collaborator-id" => user.id})
+
+      assert view
+             |> element("div.alert.alert-info")
+             |> render() =~
+               "Community member successfully removed."
+
+      assert 0 == length(Groups.list_community_admins(community.id))
+    end
+
+    test "displays error messages when removing community member fails", %{
+      conn: conn,
+      community: community
+    } do
+      user = insert(:user)
+      insert(:community_member_account, %{community: community, user: user})
+
+      {:ok, view, _html} = live(conn, live_view_show_route(community.id))
+
+      assert 1 == length(Groups.list_community_members(community.id))
+
+      view
+      |> element("button[phx-click=\"remove_member\"")
+      |> render_click(%{"collaborator-id" => 12345})
+
+      assert view
+             |> element("div.alert.alert-danger")
+             |> render() =~
+               "Community member couldn&#39;t be removed."
+
+      assert 1 == length(Groups.list_community_members(community.id))
     end
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -20,7 +20,7 @@ defmodule Oli.Factory do
   def user_factory() do
     %User{
       email: "#{sequence("user")}@example.edu",
-      name: "User name",
+      name: sequence("User name"),
       given_name: "User given name",
       family_name: "User family name",
       sub: "#{sequence("usersub")}"

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -37,11 +37,12 @@ defmodule Oli.Factory do
     }
   end
 
-  def community_account_factory() do
+  def community_account_factory(), do: struct!(community_admin_account_factory())
+
+  def community_admin_account_factory() do
     %CommunityAccount{
       community: insert(:community),
       author: insert(:author),
-      user: insert(:user),
       is_admin: true
     }
   end
@@ -91,6 +92,14 @@ defmodule Oli.Factory do
       institution_email: "ins@example.edu",
       institution_url: "example.edu",
       timezone: "America/New_York"
+    }
+  end
+
+  def community_member_account_factory() do
+    %CommunityAccount{
+      community: insert(:community),
+      user: insert(:user),
+      is_admin: false
     }
   end
 end


### PR DESCRIPTION
Story: MER-340

This feature allows system and community admins to add and remove members to a community.



### Update 11/29
Merged MER-366 which adds a members index for system and community admins to see a list and be able to remove any of them.