### PR TITLE
[Feature] PMP-2264 JAN-1077 eval optimization

### DIFF
--- a/assets/src/adaptivity/scripting.ts
+++ b/assets/src/adaptivity/scripting.ts
@@ -305,7 +305,9 @@ export const applyState = (
   } else {
     result = evalScript(script, env);
   }
-  /* console.log('APPLY STATE RESULTS: ', { script, result }); */
+  if (result.result) {
+    console.log('APPLY STATE RESULTS: ', { script, result });
+  }
   return result;
 };
 
@@ -338,6 +340,38 @@ export const getLocalizedStateSnapshot = (
     Object.assign(finalState, activityState);
   });
   return finalState;
+};
+
+// function to select the content between only the outermost {}
+export const extractExpressionFromText = (text: string) => {
+  const firstCurly = text.indexOf('{');
+  let lastCurly = -1;
+  let counter = 1;
+  let opens = 1;
+  while (counter < text.length && lastCurly === -1) {
+    if (text[firstCurly + counter] === '{') {
+      opens++;
+    } else if (text[firstCurly + counter] === '}') {
+      opens--;
+      if (opens === 0) {
+        lastCurly = firstCurly + counter;
+      }
+    }
+    counter++;
+  }
+  return text.substring(firstCurly + 1, lastCurly);
+};
+
+// extract all expressions from a string
+export const extractAllExpressionsFromText = (text: string): string[] => {
+  const expressions = [];
+  if (text.indexOf('{') !== -1 && text.indexOf('}') !== -1) {
+    const expr = extractExpressionFromText(text);
+    const rest = text.substring(text.indexOf(expr) + expr.length + 1);
+    expressions.push(expr);
+    expressions.push(...extractAllExpressionsFromText(rest));
+  }
+  return expressions;
 };
 
 // for use by client side scripting evalution

--- a/assets/src/apps/authoring/store/groups/layouts/deck/actions/updateActivityRules.ts
+++ b/assets/src/apps/authoring/store/groups/layouts/deck/actions/updateActivityRules.ts
@@ -1,5 +1,7 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
+import { extractAllExpressionsFromText } from 'adaptivity/scripting';
 import { inferTypeFromOperatorAndValue } from 'apps/authoring/components/AdaptivityEditor/AdaptiveItemOptions';
+import { findInSequence } from 'apps/delivery/store/features/groups/actions/sequence';
 import { BulkActivityUpdate, bulkEdit } from 'data/persistence/activity';
 import { isEqual } from 'lodash';
 import { clone } from 'utils/common';
@@ -31,13 +33,40 @@ const updateNestedConditions = (conditions: any) => {
   });
 };
 
+const findReferencedActivitiesInConditions = (conditions: any) => {
+  const referencedActivities: Set<string> = new Set();
+
+  conditions.forEach((condition: any) => {
+    if (condition.fact && condition.fact.indexOf('|stage.') !== -1) {
+      const referencedSequenceId = condition.fact.split('|stage.')[0];
+      referencedActivities.add(referencedSequenceId);
+    }
+    if (typeof condition.value === 'string' && condition.value.indexOf('|stage.') !== -1) {
+      // value could have more than one reference inside it
+      const exprs = extractAllExpressionsFromText(condition.value);
+      exprs.forEach((expr: string) => {
+        if (expr.indexOf('|stage.') !== -1) {
+          const referencedSequenceId = expr.split('|stage.')[0];
+          referencedActivities.add(referencedSequenceId);
+        }
+      });
+    }
+    if (condition.any || condition.all) {
+      const childRefs = findReferencedActivitiesInConditions(condition.any || condition.all);
+      childRefs.forEach((ref) => referencedActivities.add(ref));
+    }
+  });
+
+  return Array.from(referencedActivities);
+};
+
 export const updateActivityRules = createAsyncThunk(
   `${GroupsSlice}/updateActivityRules`,
   async (deck: any, { dispatch, getState }) => {
     const rootState = getState() as any;
     const activitiesToUpdate: any[] = [];
 
-    /* console.log('RULE UPDATE', deck); */
+    console.log(`UPDATE RULES for ${deck.children.length} activities`, deck);
     deck.children.forEach((child: any) => {
       const childActivity = selectActivityById(rootState, child.resourceId);
 
@@ -51,6 +80,8 @@ export const updateActivityRules = createAsyncThunk(
       const activityRules = childActivity?.authoring.rules || [];
       const activityRulesClone = clone(activityRules);
 
+      const referencedSequenceIds: string[] = [];
+
       // ensure that all conditions and condition blocks are assigned an id
       activityRulesClone.forEach((rule: any) => {
         const { conditions } = rule;
@@ -61,17 +92,49 @@ export const updateActivityRules = createAsyncThunk(
           rootCondition.id = `b:${guid()}`;
         }
         updateNestedConditions(conditionsToUpdate);
+        referencedSequenceIds.push(...findReferencedActivitiesInConditions(conditionsToUpdate));
         rule.conditions = rootCondition;
       });
 
       const childActivityClone = clone(childActivity);
+      const referencedActivityIds: number[] = Array.from(new Set(referencedSequenceIds))
+        .map((id) => {
+          const sequenceItem = findInSequence(deck.children, id);
+          if (sequenceItem) {
+            return sequenceItem.resourceId;
+          } else {
+            console.warn(
+              `[updateActivityRules] could not find referenced activity ${id} in sequence`,
+              deck,
+            );
+          }
+        })
+        .filter((id) => id) as number[];
+      if (!referencedActivityIds.includes(childActivity.id as number)) {
+        referencedActivityIds.unshift(childActivity.id as number);
+      }
+      if (
+        !isEqual(
+          childActivityClone.authoring.activitiesRequiredForEvaluation,
+          referencedActivityIds,
+        )
+      ) {
+        console.log('RULE REFS: ', referencedActivityIds);
+        childActivityClone.authoring.activitiesRequiredForEvaluation = referencedActivityIds;
+        activitiesToUpdate.push(childActivityClone);
+      }
       childActivityClone.authoring.rules = activityRulesClone;
       /* console.log('CLONE RULES', { childActivityClone, childActivity }); */
       if (!isEqual(childActivity.authoring.rules, childActivityClone.authoring.rules)) {
         /* console.log('CLONE IS DIFFERENT!'); */
-        activitiesToUpdate.push(childActivityClone);
+        if (activitiesToUpdate.indexOf(childActivityClone) === -1) {
+          activitiesToUpdate.push(childActivityClone);
+        }
       }
     });
+
+    console.log(`${activitiesToUpdate.length} ACTIVITIES TO UPDATE: `, activitiesToUpdate);
+
     if (activitiesToUpdate.length) {
       dispatch(upsertActivities({ activities: activitiesToUpdate }));
       // TODO: write to server

--- a/assets/src/apps/authoring/store/groups/layouts/deck/actions/updateActivityRules.ts
+++ b/assets/src/apps/authoring/store/groups/layouts/deck/actions/updateActivityRules.ts
@@ -110,9 +110,6 @@ export const updateActivityRules = createAsyncThunk(
           }
         })
         .filter((id) => id) as number[];
-      if (!referencedActivityIds.includes(childActivity.id as number)) {
-        referencedActivityIds.unshift(childActivity.id as number);
-      }
       if (
         !isEqual(
           childActivityClone.authoring.activitiesRequiredForEvaluation,

--- a/assets/src/apps/delivery/components/TextParser.ts
+++ b/assets/src/apps/delivery/components/TextParser.ts
@@ -1,35 +1,7 @@
-import { defaultGlobalEnv, evalScript, getAssignScript, getValue } from 'adaptivity/scripting';
+import { evalScript, extractAllExpressionsFromText, getAssignScript } from 'adaptivity/scripting';
 import { Environment } from 'janus-script';
 // function to select the content between only the outermost {}
-const getExpression = (text: string) => {
-  const firstCurly = text.indexOf('{');
-  let lastCurly = -1;
-  let counter = 1;
-  let opens = 1;
-  while (counter < text.length && lastCurly === -1) {
-    if (text[firstCurly + counter] === '{') {
-      opens++;
-    } else if (text[firstCurly + counter] === '}') {
-      opens--;
-      if (opens === 0) {
-        lastCurly = firstCurly + counter;
-      }
-    }
-    counter++;
-  }
-  return text.substring(firstCurly + 1, lastCurly);
-};
-// extract all expressions from a string
-const extractExpressions = (text: string): string[] => {
-  const expressions = [];
-  if (text.indexOf('{') !== -1 && text.indexOf('}') !== -1) {
-    const expr = getExpression(text);
-    const rest = text.substring(text.indexOf(expr) + expr.length + 1);
-    expressions.push(expr);
-    expressions.push(...extractExpressions(rest));
-  }
-  return expressions;
-};
+
 export const templatizeText = (
   text: string,
   state: any,
@@ -37,7 +9,7 @@ export const templatizeText = (
   isFromTrapStates = false,
 ): string => {
   let innerEnv = env;
-  const vars = extractExpressions(text);
+  const vars = extractAllExpressionsFromText(text);
   /* console.log('templatizeText call: ', { text, vars, state, env }); */
   if (!vars) {
     return text;

--- a/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
@@ -79,7 +79,7 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
         # Logger.debug("Decoded: #{decoded}")
         decodedResults = Poison.decode!(decoded)
         dbg = decodedResults["debug"]
-        Logger.debug("Results #{Jason.encode!(dbg)}")
+        # Logger.debug("Results #{Jason.encode!(dbg)}")
 
         score = decodedResults["score"]
         out_of = decodedResults["out_of"]

--- a/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
@@ -79,7 +79,7 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
         # Logger.debug("Decoded: #{decoded}")
         decodedResults = Poison.decode!(decoded)
         dbg = decodedResults["debug"]
-        # Logger.debug("Results #{Jason.encode!(dbg)}")
+        Logger.debug("Results #{Jason.encode!(dbg)}")
 
         score = decodedResults["score"]
         out_of = decodedResults["out_of"]


### PR DESCRIPTION
first on author initial load will reconcile the activitiesRequiredForEvaluation, it will also update as conditions are edited
on the server when evaluating (open & free), if that list is empty will *not* pull state from all the others
the list might contain *some* references to other activities, it will only pull the needed items
