### PR TITLE
[BUG FIX] Change session id to be anonymous

### DIFF
--- a/lib/oli/analytics/datashop/elements/meta.ex
+++ b/lib/oli/analytics/datashop/elements/meta.ex
@@ -2,19 +2,20 @@ defmodule Oli.Analytics.Datashop.Elements.Meta do
   @moduledoc """
   <meta>
     <user_id>t.stark+0@avengers.com</user_id>
-    <session_id>t.stark+0@avengers.com 2020-06-29 13:34</session_id>
+    <session_id>6c6d381e-1598-4924-9b60-30dce843e417</session_id>
     <time>2020-06-29 13:34</time>
     <time_zone>GMT</time_zone>
   </meta>
   """
   import XmlBuilder
+  import Oli.Utils
 
   def setup(%{date: date, email: nil}), do: setup(%{date: date, email: "Anonymous"})
 
   def setup(%{date: date, email: email}) do
     element(:meta, %{}, [
       element(:user_id, email),
-      element(:session_id, email <> " " <> format_date(date)),
+      element(:session_id, uuid()),
       element(:time, format_date(date)),
       element(:time_zone, "GMT")
     ])

--- a/lib/oli/analytics/datashop/messages/context.ex
+++ b/lib/oli/analytics/datashop/messages/context.ex
@@ -3,7 +3,7 @@ defmodule Oli.Analytics.Datashop.Messages.Context do
   <context_message context_message_id="t.stark+0@avengers.com-one-part1" name="START_PROBLEM">
     <meta>
       <user_id>t.stark+0@avengers.com</user_id>
-      <session_id>t.stark+0@avengers.com 2020-06-30 00:18</session_id>
+      <session_id>6c6d381e-1598-4924-9b60-30dce843e417</session_id>
       <time>2020-06-30 00:18</time>
       <time_zone>GMT</time_zone>
     </meta>

--- a/lib/oli/analytics/datashop/messages/tool.ex
+++ b/lib/oli/analytics/datashop/messages/tool.ex
@@ -3,7 +3,7 @@ defmodule Oli.Analytics.Datashop.Messages.Tool do
     <tool_message context_message_id="student-p1-MAJOR-ARC-BFD-2-0">
       <meta>
         <user_id anonFlag="true">student-p1</user_id>
-        <session_id>student-p1-2006-07-22</session_id>
+        <session_id>6c6d381e-1598-4924-9b60-30dce843e417</session_id>
         <time>2006-07-22 12:59:47 EST</time>
         <time_zone>EST</time_zone>
       </meta>

--- a/lib/oli/analytics/datashop/messages/tutor.ex
+++ b/lib/oli/analytics/datashop/messages/tutor.ex
@@ -3,7 +3,7 @@ defmodule Oli.Analytics.Datashop.Messages.Tutor do
     <tutor_message context_message_id="mary-smith-MAJOR-ARC-BFD-2-0">
       <meta>
        <user_id>mary-smith</user_id>
-        <session_id>mary-smith-2006-07-22</session_id>
+        <session_id>6c6d381e-1598-4924-9b60-30dce843e417</session_id>
         <time>2006-07-22 12:58:50 EST</time>
         <time_zone>EST</time_zone>
       </meta>


### PR DESCRIPTION
Datashop only anonymizes the `<user_id>` tag, but the `<session_id>` tag used the student's email, so it has been anonymized with a guid.