### PR TITLE
[BUG FIX] Allow editing of internal links when only one page exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bug Fixes
 
+- Fix a bug that prevented editing internal links when only one other page exists
+
 ### Enhancements
 
 ## 0.17.0 (2021-11-30)

--- a/assets/src/components/editing/models/link/EditLink.tsx
+++ b/assets/src/components/editing/models/link/EditLink.tsx
@@ -24,6 +24,8 @@ export const EditLink = (props: ExistingLinkEditorProps) => {
     const value = e.target.value;
     if (value === 'url') {
       setHref('');
+    } else if (pages.pages.length > 1) {
+      setHref(toInternalLink(pages.pages[0]));
     }
     setSource(value === 'page' ? 'page' : 'url');
   };


### PR DESCRIPTION
This PR fixes a bug where when there is only one other page in a course, the link editor does not allow a user to "change" pages, thus preventing them from triggering the edit path in the code. The fix here is to simply set the default to be the first selectable page. 

To test, using a course with only two pages, attempt to create an internal link in one page to the other. 