### PR TITLE
MER-312 Communities bugfixes

### DIFF
--- a/lib/oli/groups.ex
+++ b/lib/oli/groups.ex
@@ -206,6 +206,40 @@ defmodule Oli.Groups do
   end
 
   @doc """
+  Creates community accounts from user type and emails.
+
+  ## Examples
+
+      iex> create_community_accounts_from_emails("admin", ["foo@foo.com", "bar@bar.com"], %{field: new_value})
+      {:ok, [%CommunityAccount{}, %CommunityAccount{}]}
+
+      iex> create_community_accounts_from_emails("member", ["example@foo.com"], %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+
+  def create_community_accounts_from_emails(user_type, emails, attrs) do
+    {created_accounts, errors} =
+      Enum.reduce(emails, {[], []}, fn email, {created, errors} ->
+        case create_community_account_from_email(user_type, email, attrs) do
+          {:ok, community_account} ->
+            {[community_account | created], errors}
+
+          {:error, error} ->
+            {created, [error | errors]}
+        end
+      end)
+
+    case errors do
+      [error | _errors] ->
+        {:error, error}
+
+      _errors ->
+        {:ok, created_accounts}
+    end
+  end
+
+  @doc """
   Gets a community account by id.
 
   ## Examples

--- a/lib/oli/groups.ex
+++ b/lib/oli/groups.ex
@@ -234,7 +234,7 @@ defmodule Oli.Groups do
       [error | _errors] ->
         {:error, error}
 
-      _errors ->
+      [] ->
         {:ok, created_accounts}
     end
   end

--- a/lib/oli/groups/community.ex
+++ b/lib/oli/groups/community.ex
@@ -2,6 +2,8 @@ defmodule Oli.Groups.Community do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @string_field_limit 256
+
   schema "communities" do
     field :name, :string
     field :description, :string
@@ -29,5 +31,7 @@ defmodule Oli.Groups.Community do
     |> cast(attrs, [:name, :description, :key_contact, :global_access, :status])
     |> validate_required([:name, :global_access, :status])
     |> unique_constraint(:name)
+    |> validate_length(:name, max: @string_field_limit)
+    |> validate_length(:key_contact, max: @string_field_limit)
   end
 end

--- a/lib/oli_web/common/params.ex
+++ b/lib/oli_web/common/params.ex
@@ -50,4 +50,10 @@ defmodule OliWeb.Common.Params do
         end
     end
   end
+
+  def trim(params) do
+    Enum.reduce(params, %{}, fn {field, value}, acc ->
+      Map.put(acc, field, String.trim(value))
+    end)
+  end
 end

--- a/lib/oli_web/live/community_live/account_invitation.ex
+++ b/lib/oli_web/live/community_live/account_invitation.ex
@@ -13,6 +13,7 @@ defmodule OliWeb.CommunityLive.AccountInvitation do
   prop to_invite, :any, default: :collaborator
   prop placeholder, :string, default: "collaborator@example.edu"
   prop button_text, :string, default: "Send invite"
+  prop allow_removal, :boolean, default: true
 
   def render(assigns) do
     ~F"""
@@ -34,9 +35,11 @@ defmodule OliWeb.CommunityLive.AccountInvitation do
             <div>{collaborator.name}</div>
             <div class="text-muted">{collaborator.email}</div>
           </div>
-          <div class="user-actions">
-            <button class="btn btn-link text-danger" :on-click={@remove} phx-value-collaborator-id={collaborator.id}>Remove</button>
-          </div>
+          {#if @allow_removal}
+            <div class="user-actions">
+              <button class="btn btn-link text-danger" :on-click={@remove} phx-value-collaborator-id={collaborator.id}>Remove</button>
+            </div>
+          {/if}
         </div>
       {/for}
     """

--- a/lib/oli_web/live/community_live/associated/new_view.ex
+++ b/lib/oli_web/live/community_live/associated/new_view.ex
@@ -114,7 +114,7 @@ defmodule OliWeb.CommunityLive.Associated.NewView do
 
     case Groups.create_community_visibility(attrs) do
       {:ok, _community_visibility} ->
-        socket = put_flash(socket, :info, "Association to #{type} succesfully added.")
+        socket = put_flash(socket, :info, "Association to #{type} successfully added.")
 
         sources = retrieve_all_sources(socket.assigns.community_id)
         {:ok, table_model} = TableModel.new(sources)

--- a/lib/oli_web/live/community_live/form.ex
+++ b/lib/oli_web/live/community_live/form.ex
@@ -15,7 +15,7 @@ defmodule OliWeb.CommunityLive.Form do
         {#if @display_labels}
           <Label class="control-label">Community Name</Label>
         {/if}
-        <TextInput class="form-control" opts={placeholder: "Name"}/>
+        <TextInput class="form-control" opts={placeholder: "Name", maxlength: "256"}/>
         <ErrorTag/>
       </Field>
 
@@ -30,7 +30,8 @@ defmodule OliWeb.CommunityLive.Form do
         {#if @display_labels}
           <Label class="control-label">Community Contact</Label>
         {/if}
-        <TextInput class="form-control" opts={placeholder: "Key Contact"}/>
+        <TextInput class="form-control" opts={placeholder: "Key Contact", maxlength: "256"}/>
+        <ErrorTag/>
       </Field>
 
       <Field name={:global_access} class="form-check">

--- a/lib/oli_web/live/community_live/new_view.ex
+++ b/lib/oli_web/live/community_live/new_view.ex
@@ -39,10 +39,7 @@ defmodule OliWeb.CommunityLive.NewView do
   def handle_event("save", %{"community" => params}, socket) do
     socket = clear_flash(socket)
 
-    params
-    |> Params.trim()
-    |> Groups.create_community()
-    |> case do
+    case Groups.create_community(Params.trim(params)) do
       {:ok, _community} ->
         {:noreply,
          socket

--- a/lib/oli_web/live/community_live/new_view.ex
+++ b/lib/oli_web/live/community_live/new_view.ex
@@ -37,6 +37,8 @@ defmodule OliWeb.CommunityLive.NewView do
   end
 
   def handle_event("save", %{"community" => params}, socket) do
+    socket = clear_flash(socket)
+
     params
     |> Params.trim()
     |> Groups.create_community()

--- a/lib/oli_web/live/community_live/new_view.ex
+++ b/lib/oli_web/live/community_live/new_view.ex
@@ -3,7 +3,7 @@ defmodule OliWeb.CommunityLive.NewView do
 
   alias Oli.Groups
   alias Oli.Groups.Community
-  alias OliWeb.Common.{Breadcrumb, FormContainer}
+  alias OliWeb.Common.{Breadcrumb, FormContainer, Params}
   alias OliWeb.CommunityLive.{Form, IndexView}
   alias OliWeb.Router.Helpers, as: Routes
 
@@ -37,7 +37,10 @@ defmodule OliWeb.CommunityLive.NewView do
   end
 
   def handle_event("save", %{"community" => params}, socket) do
-    case Groups.create_community(params) do
+    params
+    |> Params.trim()
+    |> Groups.create_community()
+    |> case do
       {:ok, _community} ->
         {:noreply,
          socket

--- a/lib/oli_web/live/community_live/show_view.ex
+++ b/lib/oli_web/live/community_live/show_view.ex
@@ -6,7 +6,7 @@ defmodule OliWeb.CommunityLive.ShowView do
   alias Oli.Accounts.{AuthorBrowseOptions, UserBrowseOptions}
   alias Oli.Groups
   alias Oli.Repo.{Paging, Sorting}
-  alias OliWeb.Common.{Breadcrumb, DeleteModal}
+  alias OliWeb.Common.{Breadcrumb, DeleteModal, Params}
   alias OliWeb.CommunityLive.Associated.IndexView, as: IndexAssociated
   alias Surface.Components.Link
 
@@ -137,7 +137,7 @@ defmodule OliWeb.CommunityLive.ShowView do
   end
 
   def handle_event("save", %{"community" => params}, socket) do
-    case Groups.update_community(socket.assigns.community, params) do
+    case Groups.update_community(socket.assigns.community, Params.trim(params)) do
       {:ok, community} ->
         socket = put_flash(socket, :info, "Community successfully updated.")
 

--- a/lib/oli_web/live/community_live/show_view.ex
+++ b/lib/oli_web/live/community_live/show_view.ex
@@ -231,18 +231,9 @@ defmodule OliWeb.CommunityLive.ShowView do
         {:ok, _community_accounts} ->
           put_flash(socket, :info, "Community #{user_type}(s) successfully added.")
 
-        {:error, error} ->
+        {:error, _error} ->
           message =
-            case error do
-              :author_not_found ->
-                "Community admin couldn't be added. Author does not exist."
-
-              :user_not_found ->
-                "Community member couldn't be added. User does not exist."
-
-              %Ecto.Changeset{} ->
-                "Community user couldn't be added. It is already associated to the community or an unexpected error occurred."
-            end
+            "Some of the community #{user_type}s couldn't be added because the users don't exist in the system or are already associated."
 
           put_flash(socket, :error, message)
       end

--- a/lib/oli_web/live/community_live/show_view.ex
+++ b/lib/oli_web/live/community_live/show_view.ex
@@ -46,7 +46,7 @@ defmodule OliWeb.CommunityLive.ShowView do
       ]
   end
 
-  def mount(%{"community_id" => community_id}, _session, socket) do
+  def mount(%{"community_id" => community_id}, %{"is_system_admin" => is_system_admin}, socket) do
     socket =
       case Groups.get_community(community_id) do
         nil ->
@@ -65,7 +65,8 @@ defmodule OliWeb.CommunityLive.ShowView do
             breadcrumbs: breadcrumb(community_id),
             community_admins: community_admins,
             community_id: community_id,
-            community_members: community_members
+            community_members: community_members,
+            is_system_admin: is_system_admin
           )
       end
 
@@ -95,7 +96,8 @@ defmodule OliWeb.CommunityLive.ShowView do
             matches={@matches["admin"]}
             placeholder="admin@example.edu"
             button_text="Add"
-            collaborators={@community_admins}/>
+            collaborators={@community_admins}
+            allow_removal={@is_system_admin}/>
         </ShowSection>
 
         <ShowSection

--- a/lib/oli_web/live/community_live/show_view.ex
+++ b/lib/oli_web/live/community_live/show_view.ex
@@ -137,6 +137,8 @@ defmodule OliWeb.CommunityLive.ShowView do
   end
 
   def handle_event("save", %{"community" => params}, socket) do
+    socket = clear_flash(socket)
+
     case Groups.update_community(socket.assigns.community, Params.trim(params)) do
       {:ok, community} ->
         socket = put_flash(socket, :info, "Community successfully updated.")
@@ -157,6 +159,8 @@ defmodule OliWeb.CommunityLive.ShowView do
   end
 
   def handle_event("delete", _params, socket) do
+    socket = clear_flash(socket)
+
     socket =
       case Groups.delete_community(socket.assigns.community) do
         {:ok, _community} ->

--- a/test/oli_web/live/community_live_test.exs
+++ b/test/oli_web/live/community_live_test.exs
@@ -857,7 +857,7 @@ defmodule OliWeb.CommunityLiveTest do
       assert view
              |> element("div.alert.alert-info")
              |> render() =~
-               "Association to project succesfully added."
+               "Association to project successfully added."
 
       assert 1 == length(Groups.list_community_visibilities(id))
     end

--- a/test/oli_web/live/community_live_test.exs
+++ b/test/oli_web/live/community_live_test.exs
@@ -480,10 +480,12 @@ defmodule OliWeb.CommunityLiveTest do
       |> element("form[phx-submit=\"add_admin\"")
       |> render_submit(%{collaborator: %{email: author.email}})
 
+      error_message =
+        "Some of the community admins couldn&#39;t be added because the users don&#39;t exist in the system or are already associated."
+
       assert view
              |> element("div.alert.alert-danger")
-             |> render() =~
-               "Community user couldn&#39;t be added. It is already associated to the community or an unexpected error occurred."
+             |> render() =~ error_message
 
       view
       |> element("form[phx-submit=\"add_admin\"")
@@ -491,8 +493,7 @@ defmodule OliWeb.CommunityLiveTest do
 
       assert view
              |> element("div.alert.alert-danger")
-             |> render() =~
-               "Community admin couldn&#39;t be added. Author does not exist."
+             |> render() =~ error_message
 
       assert 1 == length(Groups.list_community_admins(community.id))
     end
@@ -629,10 +630,12 @@ defmodule OliWeb.CommunityLiveTest do
       |> element("form[phx-submit=\"add_member\"")
       |> render_submit(%{collaborator: %{email: user.email}})
 
+      error_message =
+        "Some of the community members couldn&#39;t be added because the users don&#39;t exist in the system or are already associated."
+
       assert view
              |> element("div.alert.alert-danger")
-             |> render() =~
-               "Community user couldn&#39;t be added. It is already associated to the community or an unexpected error occurred."
+             |> render() =~ error_message
 
       view
       |> element("form[phx-submit=\"add_member\"")
@@ -640,8 +643,7 @@ defmodule OliWeb.CommunityLiveTest do
 
       assert view
              |> element("div.alert.alert-danger")
-             |> render() =~
-               "Community member couldn&#39;t be added. User does not exist."
+             |> render() =~ error_message
 
       assert 1 == length(Groups.list_community_members(community.id))
     end

--- a/test/oli_web/live/community_live_test.exs
+++ b/test/oli_web/live/community_live_test.exs
@@ -462,7 +462,7 @@ defmodule OliWeb.CommunityLiveTest do
       assert view
              |> element("div.alert.alert-info")
              |> render() =~
-               "Community admin successfully added."
+               "Community admin(s) successfully added."
 
       assert 2 == length(Groups.list_community_admins(community.id))
     end
@@ -495,6 +495,29 @@ defmodule OliWeb.CommunityLiveTest do
                "Community admin couldn&#39;t be added. Author does not exist."
 
       assert 1 == length(Groups.list_community_admins(community.id))
+    end
+
+    test "adds more than one community admin correctly", %{
+      conn: conn,
+      community: community
+    } do
+      emails = insert_pair(:author) |> Enum.map(& &1.email)
+      insert(:community_account, %{community: community})
+
+      {:ok, view, _html} = live(conn, live_view_show_route(community.id))
+
+      assert 1 == length(Groups.list_community_admins(community.id))
+
+      view
+      |> element("form[phx-submit=\"add_admin\"")
+      |> render_submit(%{collaborator: %{email: Enum.join(emails, ",")}})
+
+      assert view
+             |> element("div.alert.alert-info")
+             |> render() =~
+               "Community admin(s) successfully added."
+
+      assert 3 == length(Groups.list_community_admins(community.id))
     end
 
     test "removes community admin correctly", %{
@@ -588,7 +611,7 @@ defmodule OliWeb.CommunityLiveTest do
       assert view
              |> element("div.alert.alert-info")
              |> render() =~
-               "Community member successfully added."
+               "Community member(s) successfully added."
 
       assert 2 == length(Groups.list_community_members(community.id))
     end
@@ -621,6 +644,29 @@ defmodule OliWeb.CommunityLiveTest do
                "Community member couldn&#39;t be added. User does not exist."
 
       assert 1 == length(Groups.list_community_members(community.id))
+    end
+
+    test "adds more than one community member correctly", %{
+      conn: conn,
+      community: community
+    } do
+      emails = insert_pair(:user) |> Enum.map(& &1.email)
+      insert(:community_member_account, %{community: community})
+
+      {:ok, view, _html} = live(conn, live_view_show_route(community.id))
+
+      assert 1 == length(Groups.list_community_members(community.id))
+
+      view
+      |> element("form[phx-submit=\"add_member\"")
+      |> render_submit(%{collaborator: %{email: Enum.join(emails, ",")}})
+
+      assert view
+             |> element("div.alert.alert-info")
+             |> render() =~
+               "Community member(s) successfully added."
+
+      assert 3 == length(Groups.list_community_members(community.id))
     end
 
     test "removes community member correctly", %{


### PR DESCRIPTION
This PR addresses the following bugs, introduced by #1866 ([MER-312](https://eliterate.atlassian.net/browse/MER-312)):
- [MER-490](https://eliterate.atlassian.net/browse/MER-490) Clear flash messages
- [MER-491](https://eliterate.atlassian.net/browse/MER-491) Fix typo
- [MER-492](https://eliterate.atlassian.net/browse/MER-492) Community admins can delete other community admins
- [MER-494](https://eliterate.atlassian.net/browse/MER-494) Community not created when Name is too long
- [MER-496](https://eliterate.atlassian.net/browse/MER-496) Community not created when Key Contact is too long
- [MER-497](https://eliterate.atlassian.net/browse/MER-497) Can create a community with a duplicate name with surrounding whitespaces.
- [MER-498](https://eliterate.atlassian.net/browse/MER-498) Can only add community admins one at a time

[MER-312]: https://eliterate.atlassian.net/browse/MER-312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MER-490]: https://eliterate.atlassian.net/browse/MER-490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MER-491]: https://eliterate.atlassian.net/browse/MER-491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MER-492]: https://eliterate.atlassian.net/browse/MER-492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MER-494]: https://eliterate.atlassian.net/browse/MER-494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MER-496]: https://eliterate.atlassian.net/browse/MER-496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MER-497]: https://eliterate.atlassian.net/browse/MER-497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MER-498]: https://eliterate.atlassian.net/browse/MER-498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ