### PR TITLE
[BUGFIX] [PMP-2238 / JAN-1053] Max Attempts

### DIFF
--- a/assets/src/adaptivity/scripting.ts
+++ b/assets/src/adaptivity/scripting.ts
@@ -331,7 +331,7 @@ export const getLocalizedStateSnapshot = (
   const finalState: any = { ...snapshot };
   activityIds.forEach((activityId: string) => {
     const activityState = Object.keys(snapshot)
-      .filter((key) => key.indexOf(`${activityId}|`) === 0)
+      .filter((key) => key.indexOf(`${activityId}|stage.`) === 0)
       .reduce((collect: any, key) => {
         const localizedKey = key.replace(`${activityId}|`, '');
         collect[localizedKey] = snapshot[key];

--- a/assets/src/apps/delivery/store/features/groups/actions/deck.ts
+++ b/assets/src/apps/delivery/store/features/groups/actions/deck.ts
@@ -77,16 +77,16 @@ export const initializeActivity = createAsyncThunk(
       operator: '=',
       value: false,
     };
-    const currentAttempNumber = 1;
+    const currentAttemptNumber = 1;
     const attemptNumberOp: ApplyStateOperation = {
       target: 'session.attemptNumber',
       operator: '=',
-      value: currentAttempNumber,
+      value: currentAttemptNumber,
     };
     const targettedAttemptNumberOp: ApplyStateOperation = {
       target: `${currentSequenceId}|session.attemptNumber`,
       operator: '=',
-      value: currentAttempNumber,
+      value: currentAttemptNumber,
     };
     const tutorialScoreOp: ApplyStateOperation = {
       target: 'session.tutorialScore',


### PR DESCRIPTION
`activityState` was stripping off `${activityId}|` ... and the other variable for `${activityId}|session.attemptNumber` was overwriting it in the `localizedSnapshot` so the fix was to mod the filter to only do it for `${activityId}|stage.`.

