### PR TITLE
[BUG FIX] Rework available_publications to be more robust

### DIFF
--- a/test/oli_web/live/project_visibility_test.exs
+++ b/test/oli_web/live/project_visibility_test.exs
@@ -31,7 +31,7 @@ defmodule OliWeb.ProjectVisibilityTest do
       assert updated_project.visibility == :global
 
       available_publications = Publishing.available_publications(author, institution)
-      assert available_publications == []
+      assert Enum.count(available_publications) == 0
 
       Publishing.publish_project(project, "some changes")
 


### PR DESCRIPTION
Closes #1933 

The root case was that the `Publishing.available_publications` impl was pattern matching in a way that did not allow it to accept `nil` for the author.  

This function has been reworked to both:
1. Accept `nil` for either argument
2. Consolidate logic to a single implementation