### PR TITLE
[BUG FIX] Allow multiselect to work in remix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 - Fix a bug that prevented editing internal links when only one other page exists
+- Fix a bug that prevented content from being added during remix
 
 ### Enhancements
 

--- a/lib/oli_web/live/common/hierarchy/hierarchy_picker.ex
+++ b/lib/oli_web/live/common/hierarchy/hierarchy_picker.ex
@@ -148,6 +148,27 @@ defmodule OliWeb.Common.Hierarchy.HierarchyPicker do
     """
   end
 
+  def render_child(
+        %{
+          select_mode: :multiple,
+          selection: selection,
+          selected_publication: pub
+        } = assigns,
+        %{uuid: uuid, revision: revision} = child
+      ) do
+    ~L"""
+    <div id="hierarchy_item_<%= uuid %>" phx-click="HierarchyPicker.select" phx-value-uuid="<%= uuid %>">
+      <div class="flex-1 mx-2">
+        <span class="align-middle">
+          <input type="checkbox" <%= maybe_checked(selection, pub.id, revision.resource_id) %>></input>
+          <%= OliWeb.Curriculum.EntryLive.icon(%{child: revision}) %>
+        </span>
+        <%= resource_link assigns, child %>
+      </div>
+    </div>
+    """
+  end
+
   def render_child(assigns, child) do
     ~L"""
     <div id="hierarchy_item_<%= child.uuid %>">

--- a/lib/oli_web/live/delivery/remix/add_materials_modal.ex
+++ b/lib/oli_web/live/delivery/remix/add_materials_modal.ex
@@ -28,6 +28,7 @@ defmodule OliWeb.Delivery.Remix.AddMaterialsModal do
             <div class="modal-body">
             <%= live_component HierarchyPicker,
               id: "hierarchy_picker",
+              select_mode: :multiple,
               hierarchy: hierarchy,
               active: active,
               selection: selection,

--- a/lib/oli_web/live/delivery/remix_section.ex
+++ b/lib/oli_web/live/delivery/remix_section.ex
@@ -488,17 +488,31 @@ defmodule OliWeb.Delivery.RemixSection do
 
   def handle_event(
         "HierarchyPicker.select",
-        %{"publication_id" => publication_id, "resource_id" => resource_id},
+        %{"uuid" => uuid},
         socket
       ) do
-    %{modal: %{assigns: %{selection: selection}} = modal} = socket.assigns
+    %{
+      modal:
+        %{
+          assigns: %{
+            selection: selection,
+            hierarchy: hierarchy,
+            selected_publication: publication
+          }
+        } = modal
+    } = socket.assigns
+
+    item = Hierarchy.find_in_hierarchy(hierarchy, uuid)
 
     modal = %{
       modal
       | assigns: %{
           modal.assigns
           | selection:
-              xor(selection, {String.to_integer(publication_id), String.to_integer(resource_id)})
+              xor(
+                selection,
+                {publication.id, item.revision.resource_id}
+              )
         }
     }
 


### PR DESCRIPTION
This PR fully implements multiselect mode in the hierarchy picker, in the context of remix.  
 
To test this out:
1. Create and publish two projects.
2. Create a product from the first.
3. From that product, enter Remix and attempt to add pages from the second project.

Without this fix there is no way to select pages