### PR TITLE
Fixes the width of a rendered FillBlanks component

### DIFF
--- a/assets/src/components/parts/janus-fill-blanks/FillBlanks.tsx
+++ b/assets/src/components/parts/janus-fill-blanks/FillBlanks.tsx
@@ -91,11 +91,7 @@ const FillBlanks: React.FC<PartComponentProps<FIBModel>> = (props) => {
   );
   const [ready, setReady] = useState<boolean>(false);
   const wrapperStyles: CSSProperties = {
-    /* position: 'absolute',
-    top: y,
-    left: x,
     width,
-    zIndex: z, */
     height,
     borderRadius: '5px',
     fontFamily: 'revert',


### PR DESCRIPTION
This fixes an issue where the user entered value for the width on Fill in the Blanks components was not being respected in the preview mode.