### PR TITLE
[BUGFIX] PMP-2289 text flow should not assume opaque white is transparent

### DIFF
--- a/assets/src/components/parts/janus-text-flow/TextFlow.tsx
+++ b/assets/src/components/parts/janus-text-flow/TextFlow.tsx
@@ -232,10 +232,6 @@ const TextFlow: React.FC<PartComponentProps<TextFlowModel>> = (props: any) => {
         bgColor = chroma(palette.fillColor || 0)
           .alpha(palette.fillAlpha || 0)
           .css();
-        // rgb(255,255,255)' means it's transparent so instead of rgb, we need to use 'rgba'. SS does the same. 'rgb' make it white brackground on the screen
-        if (bgColor === 'rgb(255,255,255)') {
-          bgColor = 'rgba(255,255,255,0)';
-        }
       }
       styles.backgroundColor = bgColor;
     }


### PR DESCRIPTION
@dtiwarATS FYI this will break PMP-2158 again. it seems like we maybe can *only* assume that opaque white really means transparent white for feedbacks. though, I am a little worried there are some other special reasons hiding... I am trying to think of a better way, maybe we can do a one time conversion of all text when we open the author based on those rules and just remove all the legacy palette code instead .... hmmm