### PR TITLE
[FEATURE] Display slugs as ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - LMS Lite functionality. Admins can allow delivery users to create sections through OLI by toggling their ability to "create sections" and adding the "independent learner" role in the admin interface. These "independent instructors" can then create sections with a start/end date that are private and require an invitation to join. Instructors can invite students by creating an invite link from the section management portal -- any student with this link can enroll automatically.
 - Add support for configurable vendor properties
+- Display course section and course project slug identifiers
 
 ## 0.17.0 (2021-11-30)
 

--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -75,6 +75,7 @@ defmodule OliWeb.Sections.OverviewView do
     ~F"""
     <Groups>
       <Group label="Overview" description="Overview of this course section">
+        <ReadOnly label="Course Section ID" value={@section.slug}/>
         <ReadOnly label="Title" value={@section.title}/>
         <ReadOnly label="Course Section Type" value={type_to_string(@section)}/>
       </Group>

--- a/lib/oli_web/templates/project/overview.html.eex
+++ b/lib/oli_web/templates/project/overview.html.eex
@@ -12,6 +12,10 @@
     <div class="col-md-8">
       <%= form_for @changeset, Routes.project_path(@conn, :update, @project), fn f -> %>
       <div class="form-label-group mb-3">
+        <%= label f, :title, "Course Project ID", class: "control-label" %>
+        <%= text_input f, :slug, class: "form-control", disabled: true %>
+      </div>
+      <div class="form-label-group mb-3">
         <%= label f, :title, "Course Title", class: "control-label" %>
         <%= text_input f, :title, class: "form-control", placeholder: "The title of your course...", required: false %>
       </div>


### PR DESCRIPTION
Closes #1959 

This PR simply adds a display of the course project and course section slug, referring to them as "IDs".  This is needed for community admin users to copy into external portal systems. 