### PR TITLE
Added vertical gap when set to vertical layout for MCQ component

### DIFF
--- a/assets/src/components/parts/janus-mcq/McqAuthor.tsx
+++ b/assets/src/components/parts/janus-mcq/McqAuthor.tsx
@@ -39,6 +39,7 @@ const McqAuthor: React.FC<AuthorPartComponentProps<McqModel>> = (props) => {
     width,
     multipleSelection,
     mcqItems,
+    verticalGap,
     customCssClass,
     layoutType,
     overrideHeight = false,
@@ -268,7 +269,7 @@ const McqAuthor: React.FC<AuthorPartComponentProps<McqModel>> = (props) => {
           <style>
             {`
           .mcq-input>div {
-            margin: 1px 6px 10px 0 !important;
+            margin: 1px 6px 10px 0;
             display: block;
             position: static !important;
             min-height: 20px;
@@ -295,6 +296,7 @@ const McqAuthor: React.FC<AuthorPartComponentProps<McqModel>> = (props) => {
               {...item}
               x={0}
               y={0}
+              verticalGap={verticalGap}
               overrideHeight={overrideHeight}
               disabled={false}
               multipleSelection={multipleSelection}

--- a/assets/src/components/parts/janus-mcq/MultipleChoiceQuestion.tsx
+++ b/assets/src/components/parts/janus-mcq/MultipleChoiceQuestion.tsx
@@ -66,6 +66,7 @@ export const MCQItem: React.FC<JanusMultipleChoiceQuestionProperties> = ({
   onConfigOptionClick,
   index,
   configureMode,
+  verticalGap = 0,
 }) => {
   const mcqItemStyles: CSSProperties = {};
   if (layoutType === 'horizontalLayout') {
@@ -83,6 +84,9 @@ export const MCQItem: React.FC<JanusMultipleChoiceQuestionProperties> = ({
   }
   if (layoutType === 'verticalLayout' && overrideHeight) {
     mcqItemStyles.height = `calc(${100 / totalItems}%)`;
+  }
+  if (layoutType === 'verticalLayout' && verticalGap && index > 0) {
+    mcqItemStyles.marginTop = `${verticalGap}px`;
   }
 
   const textValue = getNodeText(nodes);

--- a/assets/src/components/parts/janus-mcq/MultipleChoiceQuestionType.ts
+++ b/assets/src/components/parts/janus-mcq/MultipleChoiceQuestionType.ts
@@ -20,4 +20,5 @@ export interface JanusMultipleChoiceQuestionItemProperties extends JanusCustomCs
   overrideHeight: boolean;
   onConfigOptionClick?: any;
   configureMode?: boolean;
+  verticalGap: number;
 }


### PR DESCRIPTION
Allows the UI to respect the setting "verticalGap" when the layout is set to "verticalLayout"