### PR TITLE
[BUG FIX] Prevent editing of paywall settings when paid product seeded section MER-580

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Fix a bug that prevented editing internal links when only one other page exists
 - Fix a bug that prevented content from being added during remix
+- Fix a bug that allowed paid status of a section to be toggled off
+- Fix a bug that resulted in products being able to be created with invalid grace period days
 
 ### Enhancements
 

--- a/lib/oli/delivery/sections/blueprint.ex
+++ b/lib/oli/delivery/sections/blueprint.ex
@@ -148,6 +148,7 @@ defmodule Oli.Delivery.Sections.Blueprint do
             "requires_payment" => false,
             "registration_open" => false,
             "timezone" => "America/New_York",
+            "grace_period_days" => 1,
             "amount" => Money.new(:USD, "25.00")
           }
 

--- a/lib/oli_web/live/sections/paywall_settings.ex
+++ b/lib/oli_web/live/sections/paywall_settings.ex
@@ -31,7 +31,7 @@ defmodule OliWeb.Sections.PaywallSettings do
     ~F"""
     <Group label="Payment Settings" description="Settings related to requried student fee and optional grace periody">
       <Field name={:requires_payment} class="form-check">
-        <Checkbox class="form-check-input" value={get_field(@changeset, :requires_payment)}/>
+        <Checkbox class="form-check-input" value={get_field(@changeset, :requires_payment)} opts={disabled: @disabled}/>
         <Label class="form-check-label"/>
       </Field>
       <Field name={:amount} class="mt-2 form-label-group">


### PR DESCRIPTION
This closes https://eliterate.atlassian.net/browse/MER-580

The core issue was that the first checkbox "Requires Payment" was never disabled when the `disabled` prop was set to true.  

In testing this out I caught another issue, namely that blueprints were being created with a default grace period of 0 days, which is invalid (the number of days needs to be 1 or greater).  This was causing a downstream issue during section creation - as the section inherits that grade period day setting - but then fails to save.  