### PR TITLE
[FEATURE] [MER-350] Instructors permissions based on communities

### DIFF
--- a/lib/oli/delivery/sections/blueprint.ex
+++ b/lib/oli/delivery/sections/blueprint.ex
@@ -354,7 +354,7 @@ defmodule Oli.Delivery.Sections.Blueprint do
       on:
         section.id ==
           community_visibility.section_id and community_visibility.community_id == ^community_id,
-      where: is_nil(community_visibility.id),
+      where: is_nil(community_visibility.id) and section.type == :blueprint,
       select: section
     )
     |> Repo.all()

--- a/lib/oli_web/live/delivery/remix_section.ex
+++ b/lib/oli_web/live/delivery/remix_section.ex
@@ -84,7 +84,7 @@ defmodule OliWeb.Delivery.RemixSection do
       |> Repo.preload(:institution)
 
     available_publications =
-      Publishing.available_publications(current_user.author, section.institution)
+      Sections.retrieve_visible_publications(current_user, section.institution)
 
     # only permit instructor or admin level access
 

--- a/test/oli_web/live/community_live_test.exs
+++ b/test/oli_web/live/community_live_test.exs
@@ -993,6 +993,7 @@ defmodule OliWeb.CommunityLiveTest do
 
       {:ok, view, _html} = live(conn, live_view_associated_index_route(community.id))
 
+      assert has_element?(view, "##{first_cv.id}")
       refute has_element?(view, "##{last_cv.id}")
 
       view

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -2,10 +2,11 @@ defmodule Oli.Factory do
   use ExMachina.Ecto, repo: Oli.Repo
 
   alias Oli.Accounts.{Author, User}
-  alias Oli.Authoring.Course.{Family, Project}
+  alias Oli.Authoring.Course.{Family, Project, ProjectVisibility}
   alias Oli.Delivery.Sections.Section
   alias Oli.Groups.{Community, CommunityAccount, CommunityInstitution, CommunityVisibility}
   alias Oli.Institutions.Institution
+  alias Oli.Publishing.Publication
 
   def author_factory() do
     %Author{
@@ -23,7 +24,8 @@ defmodule Oli.Factory do
       name: sequence("User name"),
       given_name: "User given name",
       family_name: "User family name",
-      sub: "#{sequence("usersub")}"
+      sub: "#{sequence("usersub")}",
+      author: insert(:author)
     }
   end
 
@@ -47,11 +49,19 @@ defmodule Oli.Factory do
     }
   end
 
-  def community_visibility_factory() do
+  def community_visibility_factory(), do: struct!(community_project_visibility_factory())
+
+  def community_project_visibility_factory() do
     %CommunityVisibility{
       community: insert(:community),
-      project: insert(:project),
-      section: nil
+      project: insert(:project)
+    }
+  end
+
+  def community_product_visibility_factory() do
+    %CommunityVisibility{
+      community: insert(:community),
+      section: insert(:section)
     }
   end
 
@@ -61,7 +71,40 @@ defmodule Oli.Factory do
       title: "Example Course",
       slug: sequence("examplecourse"),
       version: "1",
-      family: insert(:family)
+      family: insert(:family),
+      visibility: :global,
+      authors: insert_list(2, :author)
+    }
+  end
+
+  def project_visibility_factory(), do: struct!(project_author_visibility_factory())
+
+  def project_author_visibility_factory() do
+    project = insert(:project)
+    author = insert(:author)
+
+    %ProjectVisibility{
+      project_id: project.id,
+      author_id: author.id
+    }
+  end
+
+  def project_institution_visibility_factory() do
+    project = insert(:project)
+    institution = insert(:institution)
+
+    %ProjectVisibility{
+      project_id: project.id,
+      institution_id: institution.id
+    }
+  end
+
+  def publication_factory() do
+    {:ok, date, _timezone} = DateTime.from_iso8601("2019-05-22 20:30:00Z")
+
+    %Publication{
+      published: date,
+      project: insert(:project)
     }
   end
 


### PR DESCRIPTION
Story: https://eliterate.atlassian.net/browse/MER-350

This feature improves the instructor permissions to select projects and products based on communities logic. 

Places where things changed:
- LTI instructor in getting started create course section
- LMS Lite instructor in create new open and free sections
- Remix when editing a section (just listing projects)



Instructor will see projects and products when:
- They are part of a community assigned to their institution
- They are part of a community as a user
- If they have a linked author account
  - They are an author of content
  - An author has made content visible to their institution
  - Another author has shared content with them
- Global -> will see them when they are not associated to any community, or one of the associated communities allows it