### PR TITLE
[bug fix] small lms-lite updates

### DIFF
--- a/lib/oli_web/live/delivery/select_source.ex
+++ b/lib/oli_web/live/delivery/select_source.ex
@@ -172,6 +172,6 @@ defmodule OliWeb.Delivery.SelectSource do
 
   defp empty_institution(),
     do: %Institution{
-      id: "invalid id used only to fulfill query requirement"
+      id: -1
     }
 end

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -716,15 +716,20 @@ defmodule OliWeb.Router do
   end
 
   scope "/course", OliWeb do
-    pipe_through([:browser, :delivery_protected, :require_lti_params, :pow_email_layout])
-
-    get("/", DeliveryController, :index)
-    get("/select_project", DeliveryController, :select_project)
+    pipe_through([:browser, :delivery_protected, :pow_email_layout])
 
     get("/link_account", DeliveryController, :link_account)
     post("/link_account", DeliveryController, :process_link_account_user)
     get("/create_and_link_account", DeliveryController, :create_and_link_account)
     post("/create_and_link_account", DeliveryController, :process_create_and_link_account_user)
+  end
+
+  scope "/course", OliWeb do
+    pipe_through([:browser, :delivery_protected, :require_lti_params, :pow_email_layout])
+
+    get("/", DeliveryController, :index)
+    get("/select_project", DeliveryController, :select_project)
+
     post("/research_consent", DeliveryController, :research_consent)
 
     post("/", DeliveryController, :create_section)

--- a/lib/oli_web/templates/delivery/open_and_free_index.html.eex
+++ b/lib/oli_web/templates/delivery/open_and_free_index.html.eex
@@ -5,7 +5,7 @@
     <%= if Sections.is_independent_instructor?(@user) do %>
       <div class="d-flex flex-row mb-2">
         <div>
-          <%= link "New Open and Free", to: Routes.select_source_path(OliWeb.Endpoint, :independent_learner), class: "btn btn-md btn-outline-primary" %>
+          <%= link "New Independent Section", to: Routes.select_source_path(OliWeb.Endpoint, :independent_learner), class: "btn btn-md btn-outline-primary" %>
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
Came across a couple things that needed tweaked for lms-lite when making the demo video.

The main change here is moving the delivery "link account" routes outside of the `require_lti_params` scope. If You're linking through an LMS it should still work, but it doesn't require you to have LTI params. This is necessary because instructors creating independent sections may never be launching through LTI but still need to be able to access their authored courses.