### PR TITLE
[BUG FIX] Set blueprint reference for LMS course section creation from product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix Open and Free section creation when done through the admin panel
 - Fix an issue where LTI 1.3 deployments should represent individual institutions
 - Move LTI 1.3 registrations listing to live view table with search, sorting and paging
+- Fix LMS course section creation to properly set the blueprint reference
 
 ### Enhancements
 

--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -369,6 +369,7 @@ defmodule OliWeb.DeliveryController do
           context_id: lti_params["https://purl.imsglobal.org/spec/lti/claim/context"]["id"],
           institution_id: institution.id,
           lti_1p3_deployment_id: deployment.id,
+          blueprint_id: blueprint.id,
           amount: amount
         })
 


### PR DESCRIPTION
This PR sets the blueprint_id for a course section created from an LMS.  Without this, deferred payments cannot be made, instructors can disable payment settings, etc. 