### PR TITLE
[BUG FIX] fix deployment_id empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fix an issue where LTI 1.3 deployments should represent individual institutions
 - Move LTI 1.3 registrations listing to live view table with search, sorting and paging
 - Fix LMS course section creation to properly set the blueprint reference
+- Fix a bug where null deployment id results in empty string in pending registration form
 
 ### Enhancements
 

--- a/lib/oli_web/controllers/institution_controller.ex
+++ b/lib/oli_web/controllers/institution_controller.ex
@@ -166,7 +166,13 @@ defmodule OliWeb.InstitutionController do
       ) do
     issuer = pending_registration_attrs["issuer"]
     client_id = pending_registration_attrs["client_id"]
-    deployment_id = pending_registration_attrs["deployment_id"]
+
+    # handle the case where deployment_id is nil in the html form, causing this attr
+    # to be and empty string
+    deployment_id = case pending_registration_attrs["deployment_id"] do
+      "" -> nil
+      deployment_id -> deployment_id
+    end
 
     case Institutions.get_pending_registration(issuer, client_id, deployment_id) do
       nil ->


### PR DESCRIPTION
Fixes an issue where the deployment_id param from a pending registration form may be an empty string if the deployment_id is nil.

Closes #1992