### PR TITLE
[BUG FIX] Flush changes prior to activity removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fix an issue where LTI 1.3 deployments should represent individual institutions
 - Move LTI 1.3 registrations listing to live view table with search, sorting and paging
 - Fix LMS course section creation to properly set the blueprint reference
+- Fix a bug where immediately removing a new activity leaves it visible to the system
 
 ### Enhancements
 

--- a/assets/src/apps/page-editor/PageEditor.tsx
+++ b/assets/src/apps/page-editor/PageEditor.tsx
@@ -307,6 +307,14 @@ export class PageEditor extends React.Component<PageEditorProps, PageEditorState
         item,
       };
 
+      // If what we are removing is an activity reference, we need to flush any
+      // pending saves to force the server to see the addition of this activity,
+      // in the case where this removal hits in the same deferred persistence
+      // window.
+      if (item.type === 'activity-reference') {
+        this.persistence.flushPendingChanges(false);
+      }
+
       const content = this.state.content.delete(key);
       this.update({ content });
       this.onPostUndoable(key, undoable);

--- a/assets/src/data/persistence/AbstractPersistenceStrategy.ts
+++ b/assets/src/data/persistence/AbstractPersistenceStrategy.ts
@@ -70,7 +70,7 @@ export abstract class AbstractPersistenceStrategy implements PersistenceStrategy
    */
   abstract doDestroy(): boolean;
 
-  abstract flushPendingChanges(): void;
+  abstract flushPendingChanges(releaseLock: boolean): void;
 
   /**
    * Indicate to the persistence strategy that it is being shutdown and that it

--- a/assets/src/data/persistence/AbstractPersistenceStrategy.ts
+++ b/assets/src/data/persistence/AbstractPersistenceStrategy.ts
@@ -70,6 +70,8 @@ export abstract class AbstractPersistenceStrategy implements PersistenceStrategy
    */
   abstract doDestroy(): boolean;
 
+  abstract flushPendingChanges(): void;
+
   /**
    * Indicate to the persistence strategy that it is being shutdown and that it
    * should clean up any resources and flush any pending changes immediately.

--- a/assets/src/data/persistence/DeferredPersistenceStrategy.ts
+++ b/assets/src/data/persistence/DeferredPersistenceStrategy.ts
@@ -124,14 +124,14 @@ export class DeferredPersistenceStrategy extends AbstractPersistenceStrategy {
     return false;
   }
 
-  flushPendingChanges(): boolean {
+  flushPendingChanges(releaseLock = true): boolean {
     if (this.timer !== null) {
       clearTimeout(this.timer);
     }
 
     // Handle the case where we have a pending change
     if (this.pending !== null) {
-      this.pending(true);
+      this.pending(releaseLock);
       return true;
     }
     return false;

--- a/assets/src/data/persistence/PersistenceStrategy.ts
+++ b/assets/src/data/persistence/PersistenceStrategy.ts
@@ -38,4 +38,6 @@ export interface PersistenceStrategy {
   destroy: () => void;
 
   getLockResult: () => LockResult;
+
+  flushPendingChanges: (releaseLock: boolean) => void;
 }


### PR DESCRIPTION
Closes #1340 

This PR adds a call to flush any pending saves when a request has been made to remove an activity from the page.  This allows proper handling of the case where this activity was added just prior - but that addition change hasn't been seen by the server due to still being deferred.  

To test:
1. While editing a page, add an activity and IMMEDIATLEY remove it. 
2. Then go to the Publish page.  Without this change you will see that activity listed as being new.  With this change the activity does not appear. 
