### PR TITLE
[BUG FIX] fix select source checkbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Move LTI 1.3 registrations listing to live view table with search, sorting and paging
 - Fix LMS course section creation to properly set the blueprint reference
 - Fix a bug where null deployment id results in empty string in pending registration form
+- Fix an issue where selecting the actual checkbox in select source list doesn't work
 
 ### Enhancements
 

--- a/lib/oli_web/templates/delivery/select_project.html.eex
+++ b/lib/oli_web/templates/delivery/select_project.html.eex
@@ -21,6 +21,11 @@ $(function() {
     checkbox.trigger("change")
   });
 
+  // prevent clicking of actual checkbox to fire tr.source click event
+  $('input[name="source_id"]').on('click', function(e) {
+    e.stopPropagation();
+  });
+
   // handle selection change
   $('input[name="source_id"]').on('change', function() {
     $('input[name="source_id"]').not(this).prop('checked', false);

--- a/lib/oli_web/templates/delivery/select_project.html.eex
+++ b/lib/oli_web/templates/delivery/select_project.html.eex
@@ -21,7 +21,7 @@ $(function() {
     checkbox.trigger("change")
   });
 
-  // prevent clicking of actual checkbox to fire tr.source click event
+  // prevent clicking of actual checkbox from firing the tr.source click event
   $('input[name="source_id"]').on('click', function(e) {
     e.stopPropagation();
   });


### PR DESCRIPTION
This PR fixes an issue where selection of the actual checkbox in "Select Source" was cause the change to fire twice, ultimately leaving the item unselected.
<img width="801" alt="Screen Shot 2021-12-15 at 11 05 13 AM" src="https://user-images.githubusercontent.com/6248894/146222100-74582dba-d29a-4647-8695-bf68f758803b.png">

