### PR TITLE
[FEATURE] Adjust logic that guards editing of payment settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Add support for configurable vendor properties
 - Allow default brand to be changed via release env var
 - Display course section and course project slug identifiers
+- Allow sections created from free products to have their payment settings edited
 
 ## 0.17.0 (2021-11-30)
 

--- a/lib/oli_web/live/sections/edit_view.ex
+++ b/lib/oli_web/live/sections/edit_view.ex
@@ -109,7 +109,7 @@ defmodule OliWeb.Sections.EditView do
     |> Map.put("end_date", utc_end_date)
   end
 
-  # An user can make paywall edits if any of the following are true:
+  # A user can make paywall edits if any of the following are true:
   # 1. They are logged in as an admin user
   # 2. The course section being edited was not created from a product
   # 3. The course section being edited was created from a product that does not require payment

--- a/lib/oli_web/live/sections/paywall_settings.ex
+++ b/lib/oli_web/live/sections/paywall_settings.ex
@@ -18,7 +18,6 @@ defmodule OliWeb.Sections.PaywallSettings do
 
   prop changeset, :any, required: true
   prop disabled, :boolean, required: true
-  prop is_admin, :boolean, required: true
 
   defp strategies do
     [


### PR DESCRIPTION
This PR adjusts the logic of when a user can edit the payment settings of a course section, now allowing admin users to always edit, and allowing non-admin users the ability to edit these settings when the product that was used is free. 