### PR TITLE
[JAN-1089 | PMP-2276] variables are not correctly populating

### DIFF
--- a/assets/src/apps/delivery/components/TextParser.ts
+++ b/assets/src/apps/delivery/components/TextParser.ts
@@ -73,7 +73,7 @@ export const templatizeText = (
     } else if (typeof stateValue === 'object') {
       strValue = JSON.stringify(stateValue);
     } else if (typeof stateValue === 'number') {
-      strValue = parseFloat(parseFloat(strValue).toFixed(4));
+      strValue = parseFloat(parseFloat(strValue).toString());
     }
     return strValue;
   });


### PR DESCRIPTION
.toFixed() converts the exponential value to 0. so all the exponential values are displayed as 0.