### PR TITLE
[BUG FIX] Remove extra checkbox for enabling LMS-lite section creation

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -147,10 +147,9 @@ defmodule Oli.Delivery.Sections do
 
   @doc """
   Can a user create independent, enrollable sections through OLI's LMS?
-  (user has the institution instructor platform role and user.can_create_sections is true)
   """
   def is_independent_instructor?(%User{} = user) do
-    is_institution_instructor?(user) && user.can_create_sections
+    user.can_create_sections
   end
 
   @doc """

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -133,19 +133,6 @@ defmodule Oli.Delivery.Sections do
   end
 
   @doc """
-  Determines if a user is a platform (institution) instructor.
-  """
-  def is_institution_instructor?(%User{} = user) do
-    PlatformRoles.has_roles?(
-      Repo.preload(user, :platform_roles),
-      [
-        PlatformRoles.get_role(:institution_instructor)
-      ],
-      :any
-    )
-  end
-
-  @doc """
   Can a user create independent, enrollable sections through OLI's LMS?
   """
   def is_independent_instructor?(%User{} = user) do

--- a/lib/oli_web/live/users/user_detail_view.ex
+++ b/lib/oli_web/live/users/user_detail_view.ex
@@ -87,7 +87,7 @@ defmodule OliWeb.Users.UsersDetailView do
             <section class="mb-2">
               <heading>
                 <p>Enable Independent Section Creation</p>
-                <small>This ability allows delivery users to create and deliver "Independent" sections through OLI without a connected LMS, either Open and Free or limited to students who enroll through an invitation link.</small>
+                <small>Allow this user to create "Independent" sections and enroll students via invitation link without an LMS</small>
               </heading>
               <div class="form-control">
                 <Field name={:can_create_sections}>

--- a/lib/oli_web/live/users/user_detail_view.ex
+++ b/lib/oli_web/live/users/user_detail_view.ex
@@ -3,7 +3,6 @@ defmodule OliWeb.Users.UsersDetailView do
   alias Surface.Components.Form
   alias Surface.Components.Form.{Checkbox, Label, Field, Submit}
   use OliWeb.Common.Modal
-  alias Oli.Delivery.Sections
 
   import OliWeb.Common.Properties.Utils
   import OliWeb.Common.Utils
@@ -16,8 +15,6 @@ defmodule OliWeb.Users.UsersDetailView do
   alias OliWeb.Router.Helpers, as: Routes
   alias OliWeb.Pow.UserContext
   alias OliWeb.Users.Actions
-  alias Lti_1p3.Tool.PlatformRoles
-  alias Lti_1p3.DataProviders.EctoProvider.Marshaler
 
   alias OliWeb.Accounts.Modals.{
     LockAccountModal,
@@ -25,8 +22,6 @@ defmodule OliWeb.Users.UsersDetailView do
     DeleteAccountModal,
     ConfirmEmailModal
   }
-
-  @institution_instructor PlatformRoles.get_role(:institution_instructor)
 
   prop author, :any
   data breadcrumbs, :any
@@ -82,35 +77,23 @@ defmodule OliWeb.Users.UsersDetailView do
             <ReadOnly label="Last Name" value={@user.family_name}/>
             <ReadOnly label="Email" value={@user.email}/>
             <ReadOnly label="Guest" value={boolean(@user.guest)}/>
-            <div class="form-control mb-2">
+            <div class="form-control mb-3">
               <Field name={:independent_learner}>
                 <Checkbox/>
                 <Label class="form-check-label mr-2">Independent Learner</Label>
               </Field>
             </div>
 
-            <section>
+            <section class="mb-2">
               <heading>
-                <p>Enable LMS-Lite Section Creation <small>(check both)</small></p>
+                <p>Enable Independent Section Creation</p>
+                <small>This ability allows delivery users to create and deliver "Independent" sections through OLI without a connected LMS, either Open and Free or limited to students who enroll through an invitation link.</small>
               </heading>
-              <div class="form-row align-items-center">
-                <div class="col-sm-6">
-                  <div class="form-control mb-2">
-                    <Field name={:can_create_sections}>
-                      <Checkbox />
-                      <Label class="form-check-label mr-2">Can Create Sections?</Label>
-                    </Field>
-                  </div>
-                </div>
-
-                <div class="col-sm-6">
-                  <div class="form-control mb-2">
-                    <Field name={:institution_instructor}>
-                      <Checkbox value={Sections.is_institution_instructor?(@user)} />
-                      <Label class="form-check-label mr-2">Institution Instructor</Label>
-                    </Field>
-                  </div>
-                </div>
+              <div class="form-control">
+                <Field name={:can_create_sections}>
+                  <Checkbox />
+                  <Label class="form-check-label mr-2">Can Create Sections</Label>
+                </Field>
               </div>
             </section>
 
@@ -262,30 +245,8 @@ defmodule OliWeb.Users.UsersDetailView do
     Accounts.get_user!(id, preload: [:platform_roles])
   end
 
-  def maybe_change_platform_roles(user_changeset, %{"institution_instructor" => "true"}) do
-    user_changeset
-    |> Ecto.Changeset.put_assoc(:platform_roles, [
-      Marshaler.to(@institution_instructor)
-      | user_changeset.data.platform_roles
-    ])
-  end
-
-  # Remove
-  def maybe_change_platform_roles(user_changeset, %{"institution_instructor" => "false"}) do
-    user_changeset
-    |> Ecto.Changeset.put_assoc(
-      :platform_roles,
-      Enum.filter(user_changeset.data.platform_roles, fn role ->
-        role.id != @institution_instructor.id
-      end)
-    )
-  end
-
-  def maybe_change_platform_roles(user_changeset, _), do: user_changeset
-
   def user_changeset(user, attrs \\ %{}) do
     User.noauth_changeset(user, attrs)
-    |> maybe_change_platform_roles(attrs)
     |> Map.put(:action, :update)
   end
 

--- a/lib/oli_web/templates/delivery/open_and_free_index.html.eex
+++ b/lib/oli_web/templates/delivery/open_and_free_index.html.eex
@@ -5,7 +5,7 @@
     <%= if Sections.is_independent_instructor?(@user) do %>
       <div class="d-flex flex-row mb-2">
         <div>
-          <%= link "New Independent Section", to: Routes.select_source_path(OliWeb.Endpoint, :independent_learner), class: "btn btn-md btn-outline-primary" %>
+          <%= link "New Section", to: Routes.select_source_path(OliWeb.Endpoint, :independent_learner), class: "btn btn-md btn-outline-primary" %>
         </div>
       </div>
     <% end %>

--- a/lib/oli_web/templates/layout/_user_account_dropdown.html.eex
+++ b/lib/oli_web/templates/layout/_user_account_dropdown.html.eex
@@ -24,8 +24,19 @@
     </script>
   <% else %>
     <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
-      <%= if user_role_is_student(@conn, @current_user) do %>
+      <%= if user_role_is_student(@conn, @current_user) or Sections.is_independent_instructor?(@current_user) do %>
         <%= if user_is_independent_learner?(@current_user) do %>
+          <%= if Sections.is_independent_instructor?(@current_user) do %>
+            <%= if account_linked?(@current_user) do %>
+              <h6 class="dropdown-header">Linked: <%= @current_user.author.email %></h6>
+              <a class="dropdown-item" href="<%= Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.ProjectsLive) %>" target="_blank">Go to Course Author <i class="fas fa-external-link-alt float-right" style="margin-top: 2px"></i></a>
+              <a class="dropdown-item" href="<%= Routes.delivery_path(@conn, :link_account) %>" target="_blank">Link a different account</a>
+              <div class="dropdown-divider"></div>
+              <%= link "Sign out", to: Routes.delivery_path(@conn, :signout), id: "signout-link", class: "dropdown-item btn" %>
+            <% else %>
+              <a class="dropdown-item" href="<%= Routes.delivery_path(@conn, :link_account) %>" target="_blank">Link Existing Account</a>
+            <% end %>
+          <% end %>
           <%= link "Edit Account", to: Routes.pow_registration_path(@conn, :edit), class: "dropdown-item btn" %>
           <%= link "My Courses", to: Routes.delivery_path(@conn, :open_and_free_index), class: "dropdown-item btn" %>
           <div class="dropdown-divider"></div>

--- a/lib/oli_web/templates/open_and_free/new.html.eex
+++ b/lib/oli_web/templates/open_and_free/new.html.eex
@@ -1,5 +1,5 @@
 <div class="container">
-  <%= render OliWeb.SharedView, "_box_form_container.html", Map.merge(assigns, %{title: "Create Open and Free Section", bs_col_class: "col-sm-12 col-md-8 col-lg-6 mx-auto"}) do %>
+  <%= render OliWeb.SharedView, "_box_form_container.html", Map.merge(assigns, %{title: "Create Section", bs_col_class: "col-sm-12 col-md-8 col-lg-6 mx-auto"}) do %>
     <%= render "form.html", Map.merge(assigns, %{action: get_path([@route, :create]), submit_text: "Create", cancel: index_path(@route)}) %>
   <% end %>
 </div>

--- a/lib/oli_web/views/delivery_view.ex
+++ b/lib/oli_web/views/delivery_view.ex
@@ -54,7 +54,7 @@ defmodule OliWeb.DeliveryView do
   def user_role_is_student(conn, user) do
     case user_role(conn.assigns[:section], user) do
       :open_and_free ->
-        true
+        !Sections.is_independent_instructor?(user)
 
       :student ->
         true
@@ -70,7 +70,7 @@ defmodule OliWeb.DeliveryView do
   def user_role_text(conn, user) do
     case user_role(conn.assigns[:section], user) do
       :open_and_free ->
-        "Open and Free"
+        "Independent"
 
       :administrator ->
         "Administrator"

--- a/lib/oli_web/views/layout_view.ex
+++ b/lib/oli_web/views/layout_view.ex
@@ -18,6 +18,7 @@ defmodule OliWeb.LayoutView do
   alias Oli.Accounts
   alias Oli.Publishing.AuthoringResolver
   alias OliWeb.Breadcrumb.BreadcrumbTrailLive
+  alias Oli.Delivery.Sections
 
   def container_slug(assigns) do
     if assigns[:container] do


### PR DESCRIPTION
Two changes:
- Remove second (institution instructor) checkbox from the admin panel when enabling delivery users to create lms-lite/independent sections. This was in place originally as a safety measure to work with some code that checked for the "institution instructor" platform role, but I realized it's not needed.
- Add a link in the delivery account dropdown menu to link an authoring account

No changelog since this is an unreleased feature.

Closes #1999