### PR TITLE
[BUG FIX] use atom based key to restore O+F creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- Fix a bug where open and free sections could not be created from products
+
+### Enhancements
+
 ## 0.18.0 (2021-12-16)
 
 ### Bug Fixes

--- a/lib/oli_web/controllers/open_and_free_controller.ex
+++ b/lib/oli_web/controllers/open_and_free_controller.ex
@@ -96,7 +96,7 @@ defmodule OliWeb.OpenAndFreeController do
             Sections.change_independent_learner_section(%Section{})
             |> Ecto.Changeset.add_error(:title, "invalid settings")
 
-          source_id = section_params["source_id"]
+          source_id = section_params[:source_id]
           {source, source_label, source_param_name} = source_info(source_id)
 
           render(conn, "new.html",


### PR DESCRIPTION
Open and Free sections cannot be created from products.  There is code just ahead of this change that converts all params to atom based keys, but then line 99 tries fetching "source_id" as a string key, which returns `nil`.

