### PR TITLE
[RELEASE] Bug Fixes for 0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.18.1 (2021-12-17)
+
 ### Bug Fixes
 
 - Fix a bug where open and free sections could not be created from products

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 - Fix a bug where open and free sections could not be created from products
+- Fix a bug where payment codes were not displayed
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- Fix a bug where open and free sections could not be created from products
+
+### Enhancements
+
 ## 0.18.0 (2021-12-16)
 
 ### Bug Fixes

--- a/lib/oli_web/controllers/open_and_free_controller.ex
+++ b/lib/oli_web/controllers/open_and_free_controller.ex
@@ -96,7 +96,7 @@ defmodule OliWeb.OpenAndFreeController do
             Sections.change_independent_learner_section(%Section{})
             |> Ecto.Changeset.add_error(:title, "invalid settings")
 
-          source_id = section_params["source_id"]
+          source_id = section_params[:source_id]
           {source, source_label, source_param_name} = source_info(source_id)
 
           render(conn, "new.html",

--- a/lib/oli_web/live/products/payments/tabel_model.ex
+++ b/lib/oli_web/live/products/payments/tabel_model.ex
@@ -123,14 +123,14 @@ defmodule OliWeb.Products.Payments.TableModel do
   def render_gen_date_column(%{local_tz: local_tz}, %{payment: payment}, _) do
     case payment.generation_date do
       nil -> ""
-      d -> OliWeb.ViewHelpers.dt(d, local_tz)
+      d -> OliWeb.ViewHelpers.dt(d, local_tz: local_tz)
     end
   end
 
   def render_app_date_column(%{local_tz: local_tz}, %{payment: payment}, _) do
     case payment.application_date do
       nil -> ""
-      d -> OliWeb.ViewHelpers.dt(d, local_tz)
+      d -> OliWeb.ViewHelpers.dt(d, local_tz: local_tz)
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Oli.MixProject do
   def project do
     [
       app: :oli,
-      version: "0.18.0",
+      version: "0.18.1",
       elixir: "~> 1.12",
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: elixirc_options(Mix.env()),


### PR DESCRIPTION
Closes #2014 

This PR fixes two issues:

1. Inability to create an Open and Free section from a Product.  Cause was that section_params keys were converted to atoms, but the "source_id" was accessed as a string. 
2. Inability to view payment codes in the Payment code live view.  The `ViewHelpers.dt` function was being called without passing in a keyword list. 