### PR TITLE
[BUG FIX] Change impl to be robust to when title assign is missing

### DIFF
--- a/lib/oli_web/templates/layout/_account_header.html.eex
+++ b/lib/oli_web/templates/layout/_account_header.html.eex
@@ -18,7 +18,7 @@
 <% else %>
   <div class="workspace-header d-flex justify-content-between">
 
-    <h3><%= @title %></h3>
+    <h3><%= Map.get(@conn.assigns, :title, "") %></h3>
     <div class="page-controls">
       <%= link "Sign out", to: Routes.authoring_pow_session_path(@conn, :delete), method: :delete, class: "btn btn-sm btn-primary" %>
     </div>


### PR DESCRIPTION
This PR addresses an error that is being reported in AppSignal, where some combination of actions leads a user to a route that triggers:

`** (ArgumentError) assign @title not available in template. `

The error indicates it is from `_account_header.html.eex`.  From the AppSignal log and from looking at the code I am unable to pinpoint what is being rendered that doesn't have a template. So as a fallback, I've made this template robust to when the title is not present.  