### PR TITLE
Trust LMS/SIS have verified email prior to Torus.

### DIFF
--- a/lib/oli_web/controllers/lti_controller.ex
+++ b/lib/oli_web/controllers/lti_controller.ex
@@ -350,7 +350,7 @@ defmodule OliWeb.LtiController do
                picture: lti_params["picture"],
                website: lti_params["website"],
                email: lti_params["email"],
-               email_verified: lti_params["email_verified"],
+               email_verified: true,
                gender: lti_params["gender"],
                birthdate: lti_params["birthdate"],
                zoneinfo: lti_params["zoneinfo"],


### PR DESCRIPTION
The `email_verified` attribute is from an IMS proctoring LTI extension and will never be reliably received - if ever at all.

When we QA, there is often fictions or non-valid emails however in production the LMS/SIS have typically verified emails or their source, so it's appropriate to trust that they are already verified for LMS integrations.