### PR TITLE
[BUGFIX] [MER-631] Remove static_url for email header logo src

### DIFF
--- a/lib/oli_web/templates/email/_header.html.eex
+++ b/lib/oli_web/templates/email/_header.html.eex
@@ -1,7 +1,7 @@
 <tr>
     <a class="navbar-brand torus-logo" href="<%= Routes.static_page_url(OliWeb.Endpoint, :index) %>">
         <td style="padding: 20px 0; text-align: center">
-            <img src="<%= Routes.static_url(OliWeb.Endpoint, Oli.Branding.brand_logo_url()) %>" width="277" height="100" alt="torus-logo" border="0" style="height: auto;">
+            <img src="<%=Oli.Branding.brand_logo_url()%>" width="277" height="100" alt="torus-logo" border="0" style="height: auto;">
         </td>
     </a>
 </tr>


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-631

Works for relative paths (default) and for absolute paths (as configured in QA env)