### PR TITLE
[MER-555] Make privacy policies url an env var

### DIFF
--- a/assets/src/components/cookies/CookieConsent.tsx
+++ b/assets/src/components/cookies/CookieConsent.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import ModalSelection from 'components/modal/ModalSelection';
 import { consentOptions, setCookies } from 'components/cookies/utils';
-import { selectCookiePreferences } from 'components/cookies/CookiePreferences';
+import {
+  selectCookiePreferences,
+  CookiePreferencesProps,
+} from 'components/cookies/CookiePreferences';
 import ReactDOM from 'react-dom';
 
-export const CookieConsent = () => {
+export const CookieConsent = (cookiePreferences: CookiePreferencesProps) => {
   return (
     <div className="form-inline">
       <p>
@@ -14,13 +17,13 @@ export const CookieConsent = () => {
         Preferences&quot;
       </p>
       <p>
-        <a href="https://www.cmu.edu/legal/privacy-notice.html">Privacy Notice</a>
+        <a href={cookiePreferences.privacyPoliciesUrl}>Privacy Notice</a>
       </p>
     </div>
   );
 };
 
-export function selectCookieConsent(): void {
+export function selectCookieConsent(cookiePreferences: CookiePreferencesProps): void {
   const footer = (
     <>
       <button
@@ -38,7 +41,7 @@ export function selectCookieConsent(): void {
         className="btn btn-outline-primary"
         onClick={() => {
           dismiss();
-          selectCookiePreferences();
+          selectCookiePreferences(cookiePreferences);
         }}
       >
         Cookie Preferences
@@ -53,7 +56,7 @@ export function selectCookieConsent(): void {
         dismiss();
       }}
     >
-      <CookieConsent />
+      <CookieConsent privacyPoliciesUrl={cookiePreferences.privacyPoliciesUrl} />
     </ModalSelection>
   );
 

--- a/assets/src/components/cookies/CookiePreferences.tsx
+++ b/assets/src/components/cookies/CookiePreferences.tsx
@@ -5,7 +5,11 @@ import ReactDOM from 'react-dom';
 
 const userOptions = consentOptions();
 
-export const CookiePreferences = () => {
+export interface CookiePreferencesProps {
+  privacyPoliciesUrl: string;
+}
+
+export const CookiePreferences = (props: CookiePreferencesProps) => {
   const [functionalActive, setFunctionalActive] = useState(true);
   const [analyticsActive, setAnalyticActive] = useState(true);
   const [targetingActive, setTargetingActive] = useState(false);
@@ -51,7 +55,7 @@ export const CookiePreferences = () => {
           purpose for which it has been collected.
         </p>
         <p>
-          <a href="https://www.cmu.edu/legal/privacy-notice.html">Privacy Notice</a>
+          <a href={props.privacyPoliciesUrl}>Privacy Notice</a>
         </p>
       </div>
       <div className="accordion" id="preferenceAccordion">
@@ -384,7 +388,7 @@ const savePreferences = () => {
   ]);
 };
 
-export function selectCookiePreferences(): void {
+export function selectCookiePreferences(props: CookiePreferencesProps): void {
   const cookiePreference = (
     <ModalSelection
       title="Cookie Preferences"
@@ -398,7 +402,7 @@ export function selectCookiePreferences(): void {
       okLabel="Save my preferences"
       cancelLabel="Cancel"
     >
-      <CookiePreferences />
+      <CookiePreferences privacyPoliciesUrl={props.privacyPoliciesUrl} />
     </ModalSelection>
   );
 

--- a/assets/src/components/cookies/utils.ts
+++ b/assets/src/components/cookies/utils.ts
@@ -1,4 +1,5 @@
 import { selectCookieConsent } from 'components/cookies/CookieConsent';
+import { CookiePreferencesProps } from 'components/cookies/CookiePreferences';
 
 export type CookieDetails = {
   name: string;
@@ -57,7 +58,7 @@ const getCookie = (cname: string) => {
   return '';
 };
 
-const processConsent = () => {
+const processConsent = (cookiePreferences: CookiePreferencesProps) => {
   let optInCookie = getCookie('_cky_opt_in');
   const dismissOptIn = getCookie('_cky_opt_in_dismiss');
   if (optInCookie === '') {
@@ -69,7 +70,7 @@ const processConsent = () => {
   if (optInCookie === 'false' && dismissOptIn === '') {
     const minutes = 60 * 60 * 1000;
     setCookies([{ name: '_cky_opt_in_dismiss', value: 'true', duration: minutes }]);
-    selectCookieConsent();
+    selectCookieConsent(cookiePreferences);
   }
 };
 
@@ -91,7 +92,7 @@ const persistCookie = (cookies: CookieDetails[]) => {
     });
 };
 
-export const retrieveCookies = (url: string) => {
+export const retrieveCookies = (url: string, cookiePreferences: CookiePreferencesProps) => {
   const optInCookie = getCookie('_cky_opt_in');
   if (optInCookie === '') {
     fetch(url, {
@@ -115,7 +116,7 @@ export const retrieveCookies = (url: string) => {
             }
           });
         }
-        processConsent();
+        processConsent(cookiePreferences);
         return json;
       })
       .catch((error) => {

--- a/config/config.exs
+++ b/config/config.exs
@@ -157,6 +157,10 @@ config :surface, :components, [
   }
 ]
 
+# Configure Privacy Policies link
+config :oli, :privacy_policies,
+  url: System.get_env("PRIVACY_POLICIES_URL", "https://www.cmu.edu/legal/privacy-notice.html")
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -167,6 +167,10 @@ truncate =
 
 config :logger, truncate: truncate
 
+# Configure Privacy Policies link
+config :oli, :privacy_policies,
+  url: System.get_env("PRIVACY_POLICIES_URL", "https://www.cmu.edu/legal/privacy-notice.html")
+
 # ## Using releases (Elixir v1.9+)
 #
 # If you are doing OTP releases, you need to instruct Phoenix

--- a/lib/oli_web/templates/layout/_delivery_footer.html.eex
+++ b/lib/oli_web/templates/layout/_delivery_footer.html.eex
@@ -1,10 +1,11 @@
 <%= render OliWeb.SharedView, "_help.html", conn: @conn %>
+<% privacy_policies_url = Application.fetch_env!(:oli, :privacy_policies)[:url]  %>
 
 <footer class="footer">
   <div class="container">
     <div class="row">
       <div class="col-sm text-left">
-        <a href='javascript:;' onclick="OLI.selectCookiePreferences()">Cookie Preferences</a>
+        <a href='javascript:;' onclick="OLI.selectCookiePreferences({privacyPoliciesUrl: '<%= privacy_policies_url %>'})">Cookie Preferences</a>
       </div>
       <div class="col-sm text-center">
       </div>
@@ -13,6 +14,6 @@
     </div>
   </div>
   <script>
-    OLI.onReady(() => OLI.retrieveCookies('<%= Routes.cookie_consent_path(@conn, :retrieve) %>'));
+    OLI.onReady(() => OLI.retrieveCookies('<%= Routes.cookie_consent_path(@conn, :retrieve) %>', {privacyPoliciesUrl: '<%= privacy_policies_url %>'}));
   </script>
 </footer>

--- a/lib/oli_web/templates/layout/_footer.html.eex
+++ b/lib/oli_web/templates/layout/_footer.html.eex
@@ -1,10 +1,11 @@
 <%= render OliWeb.SharedView, "_help.html", conn: @conn %>
+<% privacy_policies_url = Application.fetch_env!(:oli, :privacy_policies)[:url]  %>
 
 <footer>
   <div class="container">
     <div class="row">
       <div class="col-sm text-left">
-        <a href='javascript:;' onclick="OLI.selectCookiePreferences()">Cookie Preferences</a>
+        <a href='javascript:;' onclick="OLI.selectCookiePreferences({privacyPoliciesUrl: '<%= privacy_policies_url %>'})">Cookie Preferences</a>
       </div>
       <div class="col-sm text-center">
       </div>
@@ -14,6 +15,6 @@
     </div>
   </div>
   <script>
-    OLI.onReady(() => OLI.retrieveCookies('<%= Routes.cookie_consent_path(@conn, :retrieve) %>'));
+    OLI.onReady(() => OLI.retrieveCookies('<%= Routes.cookie_consent_path(@conn, :retrieve) %>', {privacyPoliciesUrl: '<%= privacy_policies_url %>'}));
   </script>
 </footer>

--- a/oli.example.env
+++ b/oli.example.env
@@ -108,3 +108,6 @@ BRANDING_FAVICONS_DIR="/favicons"
 
 ## Blackboard application Client ID
 #BLACKBOARD_APPLICATION_CLIENT_ID=some-client-id
+
+## Configure Privacy Policies
+#PRIVACY_POLICIES_URL=https://www.cmu.edu/legal/privacy-notice.html


### PR DESCRIPTION
[MER-555](https://eliterate.atlassian.net/browse/MER-555)

Make "Privacy Notice" link a configurable and dynamic env variable.

### Release Notes (important)
Ensure `PRIVACY_POLICIES_URL` env variable is added to each Torus instance with the corresponding value:
- `PRIVACY_POLICIES_URL={INSERT A COMPLETE URL HERE}`.

It is important that the url must include the protocol (`https://www.example.com` instead of `www.example.com`) in order to work.