### PR TITLE
[MER-612] fixing the formatting of the Display Name in the email addr…

### DIFF
--- a/lib/oli/email.ex
+++ b/lib/oli/email.ex
@@ -15,7 +15,7 @@ defmodule Oli.Email do
           Bamboo.Email.t()
   def help_desk_email(name, from_email, help_desk_email, subject, view, assigns) do
     base_email()
-    |> from(name <> "<" <> from_email <> ">")
+    |> from(name <> " <" <> from_email <> ">")
     |> put_header("Reply-To", name <> " <" <> from_email <> ">")
     |> put_layout({OliWeb.LayoutView, :help_email})
     |> to(help_desk_email)


### PR DESCRIPTION
…ess - there was a space missing between the display name and the angle-bracketed address: Changing “Firstname Lastname<addr@my.domain>” to “Firstname Lastname <addr@my.domain>”