### PR TITLE
[BUGFIX] [MER-666] Redirect to Overview page

### DIFF
--- a/assets/src/apps/delivery/layouts/deck/LessonFinishedDialog.tsx
+++ b/assets/src/apps/delivery/layouts/deck/LessonFinishedDialog.tsx
@@ -29,7 +29,7 @@ const LessonFinishedDialog: React.FC<LessonFinishedDialogProps> = ({
       if (graded) {
         window.location.href = `${currentUrl}/attempt/${resourceAttemptGuid}`;
       } else {
-        const overviewURL = currentUrl.split('/page')[0];
+        const overviewURL = currentUrl.split('/page')[0] + '/overview';
         window.location.href = overviewURL;
       }
     }


### PR DESCRIPTION
MER-666: redirect to the `/overview` page after finishing an ungraded lesson.