### PR TITLE
[BUG FIX] Use bulk insertion queries for attempt hierarchy creation MER-684

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.18.4 (2022-01-06)
+
+### Bug Fixes
+
+- Improve performance of initial page visits by introducing bulk insertions of attempts
+
 ## 0.18.3 (2021-12-27)
 
 ### Bug Fixes

--- a/lib/oli/delivery/attempts/core.ex
+++ b/lib/oli/delivery/attempts/core.ex
@@ -50,6 +50,19 @@ defmodule Oli.Delivery.Attempts.Core do
   end
 
   @doc """
+  For a given resource attempt id, this returns a list of the id and resource_id
+  for all activity attempt records that pertain to this resource attempt id.
+  """
+  def get_attempt_resource_id_pair(resource_attempt_id) do
+    Repo.all(
+      from(r in ActivityAttempt,
+        where: r.resource_attempt_id == ^resource_attempt_id,
+        select: map(r, [:id, :resource_id])
+      )
+    )
+  end
+
+  @doc """
   Retrieves all graded resource access for a given context
 
   `[%ResourceAccess{}, ...]`

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Oli.MixProject do
   def project do
     [
       app: :oli,
-      version: "0.18.3",
+      version: "0.18.4",
       elixir: "~> 1.12",
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: elixirc_options(Mix.env()),


### PR DESCRIPTION
Performance testing (and perhaps real world usage) shows dramatically long page loads.  Investigation yields the culprit to be the logic that creates the activity and part attempt hierarchy (done one time, upon first page visit).  These inserts were being done in serial, so a large adaptive page with say 100 activities (screens) with 3 parts each would require 300 insertion queries, executed serially and incurring the DB latency requests in aggregate.  

The solution in this PR is to rework this logic to use a constant number of bulk insertion queries.

This should fix MER-683 as well.