### PR TITLE
Add AWS region as env_variable, but defaults to us-east-1

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -137,7 +137,8 @@ config :lti_1p3,
 
 config :ex_aws,
   access_key_id: [{:system, "AWS_ACCESS_KEY_ID"}, :instance_role],
-  secret_access_key: [{:system, "AWS_SECRET_ACCESS_KEY"}, :instance_role]
+  secret_access_key: [{:system, "AWS_SECRET_ACCESS_KEY"}, :instance_role],
+  region: System.get_env("AWS_REGION", "us-east-1")
 
 # Configures Elixir's Logger
 config :logger, :console,

--- a/oli.example.env
+++ b/oli.example.env
@@ -49,6 +49,7 @@ GITHUB_CLIENT_SECRET=your_github_client_secret
 ## Amazon AWS services (required for production and dev)
 AWS_ACCESS_KEY_ID=your_aws_access_key
 AWS_SECRET_ACCESS_KEY=your_aws_secret_access_key
+AWS_REGION=your_aws_region
 
 ## S3 compatable storage service config used for storing and serving media (required for production and dev)
 S3_MEDIA_BUCKET_NAME=torus-media


### PR DESCRIPTION
I was slightly unsure whether this should use the packages custom system option as well, but looking at packages example - doesn't seem instance role applies to region (which makes sense).

https://github.com/ex-aws/ex_aws/blob/main/config/dev.exs