### PR TITLE
[FEATURE] allow course navigation placement to be disabled by default

### DIFF
--- a/lib/oli_web/controllers/lti_controller.ex
+++ b/lib/oli_web/controllers/lti_controller.ex
@@ -119,7 +119,7 @@ defmodule OliWeb.LtiController do
     end
   end
 
-  def developer_key_json(conn, _params) do
+  def developer_key_json(conn, params) do
     {:ok, active_jwk} = Lti_1p3.get_active_jwk()
 
     public_jwk =
@@ -156,10 +156,20 @@ defmodule OliWeb.LtiController do
                 "message_type" => "LtiResourceLinkRequest",
                 "icon_url" => Oli.VendorProperties.normalized_workspace_logo(host)
               },
-              %{
-                "placement" => "course_navigation",
-                "message_type" => "LtiResourceLinkRequest"
-              }
+              case Map.get(params, "course_navigation_default") do
+                "disabled" ->
+                  %{
+                    "default" => "disabled",
+                    "placement" => "course_navigation",
+                    "message_type" => "LtiResourceLinkRequest"
+                  }
+
+                _ ->
+                  %{
+                    "placement" => "course_navigation",
+                    "message_type" => "LtiResourceLinkRequest"
+                  }
+              end
               ## TODO: add support for more placement types in the future, possibly configurable by LMS admin
               # %{
               #   "placement" => "assignment_selection",

--- a/lib/oli_web/templates/project/_lti_connect_instructions.html.eex
+++ b/lib/oli_web/templates/project/_lti_connect_instructions.html.eex
@@ -10,6 +10,25 @@
 
 </script>
 
+
+<script>
+$(function() {
+  const canvas_developer_key_url = "<%= @canvas_developer_key_url %>";
+
+  const course_navigation_default_checkbox = document.querySelector('input#course_navigation_default');
+  const canvas_developer_key_url_input = document.querySelector('input#canvas_developer_key_url');
+
+  course_navigation_default_checkbox.addEventListener('change', function() {
+    if (course_navigation_default_checkbox.checked) {
+      canvas_developer_key_url_input.value = canvas_developer_key_url + '?course_navigation_default=disabled';
+    } else {
+      canvas_developer_key_url_input.value = canvas_developer_key_url;
+    }
+  });
+
+})
+</script>
+
 <div class="row justify-content-md-center mt-5">
   <div class="col-8">
     <div class="card">
@@ -62,6 +81,10 @@
                       <i class="lar la-clipboard"></i> Copy
                     </button>
                   </div>
+                </div>
+                <div class="mt-1"><b>Options</b></div>
+                <div>
+                  <input id="course_navigation_default" type="checkbox"> <label for="course_navigation_default">Disable course navigation placement by default</label>
                 </div>
               </p>
             </div>


### PR DESCRIPTION
This PR allows a user (canvas admin during LTI integration step) to select whether they wish for torus to be displayed in course navigation by default or not. The option defaults to unchecked, which means torus will *NOT* be disabled by default unless a user explicitly checks the box.

<img width="805" alt="Screen Shot 2022-01-06 at 5 40 41 PM" src="https://user-images.githubusercontent.com/6248894/148463444-5e3a5fc3-a25e-4b5f-9a32-72e56928444f.png">
<img width="777" alt="Screen Shot 2022-01-06 at 5 40 45 PM" src="https://user-images.githubusercontent.com/6248894/148463443-e42ee651-044d-4c1d-ac02-0014a7e5c6c0.png">


Closes #1444