### PR TITLE
[BUG FIX] Optimize attempt state fetch

### DIFF
--- a/lib/oli/delivery/attempts/core.ex
+++ b/lib/oli/delivery/attempts/core.ex
@@ -63,6 +63,22 @@ defmodule Oli.Delivery.Attempts.Core do
   end
 
   @doc """
+  For a given resource attempt id, this returns a list of three element tuples containing
+  the activity resource id, the activity attempt guid, and the id of the type of the
+  registered activity.
+  """
+  def get_thin_activity_context(resource_attempt_id) do
+    Repo.all(
+      from(a in ActivityAttempt,
+        join: r in Revision,
+        on: a.revision_id == r.id,
+        where: r.resource_attempt_id == ^resource_attempt_id,
+        select: {a.resource_id, a.attempt_guid, r.activity_type_id}
+      )
+    )
+  end
+
+  @doc """
   Retrieves all graded resource access for a given context
 
   `[%ResourceAccess{}, ...]`

--- a/lib/oli/delivery/attempts/core.ex
+++ b/lib/oli/delivery/attempts/core.ex
@@ -72,7 +72,7 @@ defmodule Oli.Delivery.Attempts.Core do
       from(a in ActivityAttempt,
         join: r in Revision,
         on: a.revision_id == r.id,
-        where: r.resource_attempt_id == ^resource_attempt_id,
+        where: a.resource_attempt_id == ^resource_attempt_id,
         select: {a.resource_id, a.attempt_guid, r.activity_type_id}
       )
     )

--- a/lib/oli/delivery/attempts/page_lifecycle/attempt_state.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/attempt_state.ex
@@ -4,19 +4,8 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.AttemptState do
 
   resource_attempt - The resource attempt record itself
 
-  attempt_hierarchy - The activity attempt and part attempt hierarchy in the form of
-  a map of activity resource id to tuples {%ActivityAttempt, part_attempt_map}, where part attempt
-  map is a map of part ids to part attempt records.
+  attempt_hierarchy - The state of the activity attempts required for rendering
 
-  A full example of the attempt_hierarchy for two activities each with two parts would
-  look like:
-
-  ```
-  %{
-    45 => {%ActivityAttempt{}, %{"1" => %PartAttempt{}, "2" => PartAttempt{}}},
-    67 => {%ActivityAttempt{}, %{"1" => %PartAttempt{}, "2" => PartAttempt{}}}
-  }
-  ```
   """
 
   alias Oli.Delivery.Attempts.Core.ResourceAttempt
@@ -38,6 +27,39 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.AttemptState do
           attempt_hierarchy: any()
         }
 
+  @doc """
+  The required attempt state for page rendering differs between basic and adaptive pages.
+  A basic page needs the "full attempt hierarchy", that is, the resource attempt, and then a
+  map of activity ids on that page to tuples of activity attempt and a part attempt mapping. For
+  example:
+
+  ```
+  %{
+    232 => {%ActivityAttempt{}, %{ "1" => %PartAttempt{}, "2" => %PartAttempt{}}},
+    233 => {%ActivityAttempt{}, %{ "1" => %PartAttempt{}, "2" => %PartAttempt{}}}
+  }
+  ```
+
+  The adaptive page requires less information, which is also arranged in a different format. It
+  uses simply a mapping of activity resource ids to a small set of data including the
+  attempt guid and the name of the delivery element to use rendering. That looks like:any()
+
+  ```
+  %{
+    232 => %{
+      id: 232,
+      attemptGuid: 2398298233,
+      deliveryElement: "oli-adaptive-delivery"
+
+    },
+    233 => %{
+      id: 233,
+      attemptGuid: 223923892389,
+      deliveryElement: "oli-adaptive-delivery"
+    }
+  }
+  ```
+  """
   def fetch_attempt_state(%ResourceAttempt{} = resource_attempt, %Revision{
         content: %{"advancedDelivery" => true}
       }) do

--- a/lib/oli/delivery/attempts/page_lifecycle/attempt_state.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/attempt_state.ex
@@ -19,6 +19,10 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.AttemptState do
   ```
   """
 
+  alias Oli.Delivery.Attempts.Core.ResourceAttempt
+  alias Oli.Resources.Revision
+  alias Oli.Delivery.Attempts.PageLifecycle.Hierarchy
+
   @enforce_keys [
     :resource_attempt,
     :attempt_hierarchy
@@ -33,4 +37,22 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.AttemptState do
           resource_attempt: any(),
           attempt_hierarchy: any()
         }
+
+  def fetch_attempt_state(%ResourceAttempt{} = resource_attempt, %Revision{
+        content: %{"advancedDelivery" => true}
+      }) do
+    {:ok,
+     %__MODULE__{
+       resource_attempt: resource_attempt,
+       attempt_hierarchy: Hierarchy.thin_hierarchy(resource_attempt)
+     }}
+  end
+
+  def fetch_attempt_state(%ResourceAttempt{} = resource_attempt, _) do
+    {:ok,
+     %__MODULE__{
+       resource_attempt: resource_attempt,
+       attempt_hierarchy: Hierarchy.full_hierarchy(resource_attempt)
+     }}
+  end
 end

--- a/lib/oli/delivery/attempts/page_lifecycle/hierarchy.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/hierarchy.ex
@@ -16,13 +16,13 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Hierarchy do
   alias Oli.Activities.Model
   alias Oli.Activities.Transformers
   alias Oli.Delivery.ActivityProvider.Result
-  alias Oli.Delivery.Attempts.PageLifecycle.{VisitContext, AttemptState}
+  alias Oli.Delivery.Attempts.PageLifecycle.{VisitContext}
 
   @doc """
   Creates an attempt hierarchy for a given resource visit context, optimized to
   use a constant number of queries relative to the number of activities and parts.
 
-  Returns {:ok, %AttemptState{}}
+  Returns {:ok, %ResourceAttempt{}}
   """
   def create(%VisitContext{} = context) do
     {resource_access_id, next_attempt_number} =
@@ -63,19 +63,8 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Hierarchy do
            revision_id: context.page_revision.id
          }) do
       {:ok, resource_attempt} ->
-        activity_ids = Enum.map(activity_revisions, fn r -> r.resource_id end)
-
-        # This requires exactly three queries
         bulk_create_attempts(resource_attempt, activity_revisions, unscored)
-
-        # One more to fetch and assemble the full atempt hierarchy
-        hierarchy = get_latest_attempts(resource_attempt.id, activity_ids)
-
-        {:ok,
-         %AttemptState{
-           resource_attempt: resource_attempt,
-           attempt_hierarchy: hierarchy
-         }}
+        {:ok, resource_attempt}
 
       error ->
         error
@@ -86,7 +75,8 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Hierarchy do
   # every activity attempt, this implementation does the same with exactly three queries:
   #
   # 1. Bulk activity attempt creation (regardless of the number of attempts)
-  # 2. A query
+  # 2. A query to fetch the newly created IDs and their corresponding resource_ids
+  # 3. A final bulk insert query to create the part attempts
   #
   defp bulk_create_attempts(resource_attempt, activity_revisions, unscored) do
     # Use a common timestamp for all insertions
@@ -198,6 +188,28 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Hierarchy do
     |> results_to_activity_map
   end
 
+  def full_hierarchy(resource_attempt) do
+    get_latest_attempts(resource_attempt.id)
+    |> results_to_activity_map()
+  end
+
+  def thin_hierarchy(resource_attempt) do
+    map =
+      Oli.Activities.list_activity_registrations()
+      |> Enum.reduce(%{}, fn r, m -> Map.put(m, r.id, r) end)
+
+    get_thin_activity_context(resource_attempt.id)
+    |> Enum.map(fn {id, guid, type_id} ->
+      {id,
+       %{
+         id: id,
+         attemptGuid: guid,
+         deliveryElement: Map.get(map, type_id).delivery_element
+       }}
+    end)
+    |> Map.new()
+  end
+
   @doc """
   Retrieves the state of the latest attempts for a given resource attempt id and
   a given list of activity ids.
@@ -211,7 +223,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Hierarchy do
     233 => {%ActivityAttempt{}, %{ "1" => %PartAttempt{}, "2" => %PartAttempt{}}}
   }
   """
-  def get_latest_attempts(resource_attempt_id, activity_ids) do
+  def get_latest_attempts(resource_attempt_id) do
     Repo.all(
       from(aa1 in ActivityAttempt,
         join: r in assoc(aa1, :revision),
@@ -226,8 +238,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Hierarchy do
           aa1.id == pa2.activity_attempt_id and pa1.part_id == pa2.part_id and pa1.id < pa2.id and
             pa1.activity_attempt_id == pa2.activity_attempt_id,
         where:
-          aa1.resource_id in ^activity_ids and
-            aa1.resource_attempt_id == ^resource_attempt_id and is_nil(aa2.id) and
+          aa1.resource_attempt_id == ^resource_attempt_id and is_nil(aa2.id) and
             is_nil(pa2.id),
         preload: [revision: r],
         select: {pa1, aa1}

--- a/lib/oli/delivery/attempts/page_lifecycle/hierarchy.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/hierarchy.ex
@@ -188,9 +188,32 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Hierarchy do
     |> results_to_activity_map
   end
 
+  def get_latest_attempts(resource_attempt_id, activity_ids) do
+    Repo.all(
+      from(aa1 in ActivityAttempt,
+        join: r in assoc(aa1, :revision),
+        left_join: aa2 in ActivityAttempt,
+        on:
+          aa1.resource_id == aa2.resource_id and aa1.id < aa2.id and
+            aa1.resource_attempt_id == aa2.resource_attempt_id,
+        join: pa1 in PartAttempt,
+        on: aa1.id == pa1.activity_attempt_id,
+        left_join: pa2 in PartAttempt,
+        on:
+          aa1.id == pa2.activity_attempt_id and pa1.part_id == pa2.part_id and pa1.id < pa2.id and
+            pa1.activity_attempt_id == pa2.activity_attempt_id,
+        where:
+          aa1.resource_id in ^activity_ids and
+            aa1.resource_attempt_id == ^resource_attempt_id and is_nil(aa2.id) and is_nil(pa2.id),
+        preload: [revision: r],
+        select: {pa1, aa1}
+      )
+    )
+    |> results_to_activity_map
+  end
+
   def full_hierarchy(resource_attempt) do
     get_latest_attempts(resource_attempt.id)
-    |> results_to_activity_map()
   end
 
   def thin_hierarchy(resource_attempt) do
@@ -208,43 +231,6 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Hierarchy do
        }}
     end)
     |> Map.new()
-  end
-
-  @doc """
-  Retrieves the state of the latest attempts for a given resource attempt id and
-  a given list of activity ids.
-
-  Return value is a map of activity ids to a two element tuple.  The first
-  element is the latest activity attempt and the second is a map of part ids
-  to their part attempts. As an example:
-
-  %{
-    232 => {%ActivityAttempt{}, %{ "1" => %PartAttempt{}, "2" => %PartAttempt{}}}
-    233 => {%ActivityAttempt{}, %{ "1" => %PartAttempt{}, "2" => %PartAttempt{}}}
-  }
-  """
-  def get_latest_attempts(resource_attempt_id) do
-    Repo.all(
-      from(aa1 in ActivityAttempt,
-        join: r in assoc(aa1, :revision),
-        left_join: aa2 in ActivityAttempt,
-        on:
-          aa1.resource_id == aa2.resource_id and aa1.id < aa2.id and
-            aa1.resource_attempt_id == aa2.resource_attempt_id,
-        join: pa1 in PartAttempt,
-        on: aa1.id == pa1.activity_attempt_id,
-        left_join: pa2 in PartAttempt,
-        on:
-          aa1.id == pa2.activity_attempt_id and pa1.part_id == pa2.part_id and pa1.id < pa2.id and
-            pa1.activity_attempt_id == pa2.activity_attempt_id,
-        where:
-          aa1.resource_attempt_id == ^resource_attempt_id and is_nil(aa2.id) and
-            is_nil(pa2.id),
-        preload: [revision: r],
-        select: {pa1, aa1}
-      )
-    )
-    |> results_to_activity_map
   end
 
   # Take results in the form of a list of {part attempt, activity attempt} tuples

--- a/lib/oli/delivery/attempts/page_lifecycle/ungraded.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/ungraded.ex
@@ -11,7 +11,6 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Ungraded do
   }
 
   alias Oli.Delivery.Attempts.PageLifecycle.Common
-  alias Oli.Resources.Revision
 
   @moduledoc """
   Implementation of a page Lifecycle behaviour for ungraded pages.

--- a/lib/oli/delivery/attempts/page_lifecycle/ungraded.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/ungraded.ex
@@ -11,6 +11,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Ungraded do
   }
 
   alias Oli.Delivery.Attempts.PageLifecycle.Common
+  alias Oli.Resources.Revision
 
   @moduledoc """
   Implementation of a page Lifecycle behaviour for ungraded pages.
@@ -40,12 +41,10 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Ungraded do
           error
       end
     else
-      {:ok,
-       {:in_progress,
-        %AttemptState{
-          resource_attempt: latest_resource_attempt,
-          attempt_hierarchy: Hierarchy.get_latest_attempts(latest_resource_attempt.id)
-        }}}
+      {:ok, attempt_state} =
+        AttemptState.fetch_attempt_state(latest_resource_attempt, page_revision)
+
+      {:ok, {:in_progress, attempt_state}}
     end
   end
 
@@ -65,6 +64,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Ungraded do
 
   @impl Lifecycle
   def start(%VisitContext{} = context) do
-    Hierarchy.create(context)
+    {:ok, resource_attempt} = Hierarchy.create(context)
+    AttemptState.fetch_attempt_state(resource_attempt, context.page_revision)
   end
 end

--- a/lib/oli/delivery/page/page_context.ex
+++ b/lib/oli/delivery/page/page_context.ex
@@ -99,8 +99,7 @@ defmodule Oli.Delivery.Page.PageContext do
         {:ok,
          {state,
           %AttemptState{resource_attempt: resource_attempt, attempt_hierarchy: latest_attempts}}} ->
-          {state, [resource_attempt], latest_attempts,
-           ActivityContext.create_context_map(page_revision.graded, latest_attempts)}
+          assemble_final_context(state, resource_attempt, latest_attempts, page_revision)
 
         {:error, _} ->
           {:error, [], %{}}
@@ -125,6 +124,17 @@ defmodule Oli.Delivery.Page.PageContext do
       objectives: rollup_objectives(latest_attempts, DeliveryResolver, section_slug),
       latest_attempts: latest_attempts
     }
+  end
+
+  defp assemble_final_context(state, resource_attempt, latest_attempts, %{
+         content: %{"advancedDelivery" => true}
+       }) do
+    {state, [resource_attempt], latest_attempts, latest_attempts}
+  end
+
+  defp assemble_final_context(state, resource_attempt, latest_attempts, page_revision) do
+    {state, [resource_attempt], latest_attempts,
+     ActivityContext.create_context_map(page_revision.graded, latest_attempts)}
   end
 
   # for a map of activity ids to latest attempt tuples (where the first tuple item is the activity attempt)

--- a/lib/oli/delivery/page/page_context.ex
+++ b/lib/oli/delivery/page/page_context.ex
@@ -62,7 +62,8 @@ defmodule Oli.Delivery.Page.PageContext do
       progress_state: progress_state,
       resource_attempts: resource_attempts,
       activities: activities,
-      objectives: rollup_objectives(latest_attempts, DeliveryResolver, section_slug),
+      objectives:
+        rollup_objectives(page_revision, latest_attempts, DeliveryResolver, section_slug),
       latest_attempts: latest_attempts
     }
   end
@@ -121,7 +122,8 @@ defmodule Oli.Delivery.Page.PageContext do
       progress_state: progress_state,
       resource_attempts: resource_attempts,
       activities: activities,
-      objectives: rollup_objectives(latest_attempts, DeliveryResolver, section_slug),
+      objectives:
+        rollup_objectives(page_revision, latest_attempts, DeliveryResolver, section_slug),
       latest_attempts: latest_attempts
     }
   end
@@ -140,7 +142,11 @@ defmodule Oli.Delivery.Page.PageContext do
   # for a map of activity ids to latest attempt tuples (where the first tuple item is the activity attempt)
   # return the parent objective revisions of all attached objectives
   # if an attached objective is a parent, include that in the return list
-  defp rollup_objectives(latest_attempts, resolver, section_slug) do
+  defp rollup_objectives(%{content: %{"advancedDelivery" => true}}, _, _, _) do
+    []
+  end
+
+  defp rollup_objectives(_, latest_attempts, resolver, section_slug) do
     Enum.map(latest_attempts, fn {_, {%{revision: revision}, _}} -> revision end)
     |> ObjectivesRollup.rollup_objectives(resolver, section_slug)
   end

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -301,7 +301,7 @@ defmodule OliWeb.PageDeliveryController do
     {:ok, resource_attempt_state} = Jason.encode(resource_attempt.state)
 
     {:ok, activity_guid_mapping} =
-      Oli.Delivery.Page.ActivityContext.to_thin_context_map(context.activities)
+      context.activities
       |> Jason.encode()
 
     {:ok, {previous, next}} =

--- a/test/oli/delivery/attempts_test.exs
+++ b/test/oli/delivery/attempts_test.exs
@@ -78,8 +78,7 @@ defmodule Oli.Delivery.AttemptsTest do
 
       activity_provider = &Oli.Delivery.ActivityProvider.provide/3
 
-      # verify that creating the attempt tree returns both activity attempts
-      {:ok, %AttemptState{resource_attempt: resource_attempt, attempt_hierarchy: attempts}} =
+      {:ok, resource_attempt} =
         Hierarchy.create(%VisitContext{
           latest_resource_attempt: nil,
           page_revision: p1.revision,
@@ -89,6 +88,10 @@ defmodule Oli.Delivery.AttemptsTest do
           blacklisted_activity_ids: [],
           publication_id: pub.id
         })
+
+      # verify that creating the attempt tree returns both activity attempts
+      {:ok, %AttemptState{resource_attempt: resource_attempt, attempt_hierarchy: attempts}} =
+        AttemptState.fetch_attempt_state(resource_attempt, p1.revision)
 
       assert Map.has_key?(attempts, a1.resource.id)
       assert Map.has_key?(attempts, a2.resource.id)


### PR DESCRIPTION
Additional perf testing revealed that the full attempt hierarchy retrieval present in `Hierarchy.get_latest_attempts` is yielding huge amounts of data for adaptive pages, and thus taking 20 to 30 seconds to fulfill. 

Upon investigation, the rendering of the adaptive page doesn't actually use much of this fetched information, in fact it explicitly "thins" it out in the controller.  

This PR extends this "thinning" out all the way back to the database call, so that just the minimal amount of information is requested.  

The full hierarchy is fetched still for basic pages, as that rendering requires all that data. 
