### PR TITLE
MER-679 Add general application + db health check end point.

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -55,3 +55,5 @@ config :oli, OliWeb.Pow.Mailer, adapter: Bamboo.SesAdapter
 #       force_ssl: [hsts: true]
 #
 # Check `Plug.SSL` for all available options in `force_ssl`.
+
+config :appsignal, :config, ignore_actions: ["OliWeb.HealthController#index"]

--- a/lib/oli_web/controllers/api/health_controller.ex
+++ b/lib/oli_web/controllers/api/health_controller.ex
@@ -1,0 +1,11 @@
+defmodule OliWeb.HealthController do
+  use OliWeb, :controller
+
+  action_fallback OliWeb.FallbackController
+
+  def index(conn, _params) do
+    with {:ok, _} <- Ecto.Adapters.SQL.query(Oli.Repo, "select 1", []) do
+      render(conn, "index.json", status: "Ayup!")
+    end
+  end
+end

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -245,6 +245,9 @@ defmodule OliWeb.Router do
 
     # update session timezone information
     post("/timezone", StaticPageController, :timezone)
+    
+    # general health check for application & db
+    get "/healthz", HealthController, :index
   end
 
   scope "/.well-known", OliWeb do

--- a/lib/oli_web/views/api/health_view.ex
+++ b/lib/oli_web/views/api/health_view.ex
@@ -1,0 +1,7 @@
+defmodule OliWeb.HealthView do
+  use OliWeb, :view
+
+  def render("index.json", %{status: status}) do
+    %{status: status}
+  end
+end

--- a/test/oli_web/controllers/api/health_controller_test.exs
+++ b/test/oli_web/controllers/api/health_controller_test.exs
@@ -1,0 +1,13 @@
+defmodule OliWeb.HealthControllerTest do
+  @moduledoc false
+
+  use OliWeb.ConnCase
+
+  describe "index" do
+    test "index", %{conn: conn} do
+      conn = get(conn, Routes.health_path(conn, :index))
+
+      assert json_response(conn, 200) == %{"status" => "Ayup!"}
+    end
+  end
+end


### PR DESCRIPTION
Purpose is for liveness, readiness and general monitoring based on kubernetes standard. We could later add  livez and readyz if needed, however this generally works for those as well.