### PR TITLE
[BUG FIX] Increase mnesia log write threshold

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -154,7 +154,9 @@ if Mix.env() == :dev do
 end
 
 # Configure Mnesia directory (used by pow persistent sessions)
-config :mnesia, :dir, to_charlist(System.get_env("MNESIA_DIR", ".mnesia"))
+config :mnesia,
+  dir: to_charlist(System.get_env("MNESIA_DIR", ".mnesia")),
+  dump_log_write_threshold: 10000
 
 config :appsignal, :config, revision: System.get_env("SHA", default_sha)
 


### PR DESCRIPTION
Performance tests saw these warnings in the logs:

```
Dec 22 23:06:47 ip-10-8-215-102 oli: 23:06:47.459 [warn] Mnesia(:"oli@ip-10-8-215-102"): ** WARNING ** Mnesia is overloaded: {:dump_log, :write_threshold}
```

A bit of online research at:
https://streamhacker.com/2008/12/10/how-to-eliminate-mnesia-overload-events/
and:
https://stackoverflow.com/questions/24406633/rabbitmq-warning-mnesia-is-overloaded/50113675

The warning indicates that log flushing to disc is being overloaded.  This PR addresses it by increasing the log write threshold via the `:dump_log_write_threshold` parameter.   This will increase the time in between log dumps, thus avoiding this warning.

I verified that this configuration change is picked up correctly by `mnesia` by outputing from a controller (this was uncommited, local only code):

```
IO.inspect(:mnesia.system_info(:all))
```

The output, with the `10000` properly set was:

```
[
  access_module: :mnesia,
  auto_repair: true,
  backend_types: [:ram_copies, :disc_copies, :disc_only_copies],
  backup_module: :mnesia_backup,
  checkpoints: [],
  db_nodes: [:nonode@nohost],
  debug: :none,
  directory: '/Users/darrensiegel/dev/oli-torus/.mnesia',
  dump_log_load_regulation: false,
  dump_log_time_threshold: 180000,
  dump_log_update_in_place: true,
  dump_log_write_threshold: 10000,
  event_module: :mnesia_event,
  extra_db_nodes: [],
  fallback_activated: false,
  held_locks: [],
  ignore_fallback_at_startup: false,
  fallback_error_function: {:mnesia, :lkill},
  is_running: :yes,
  local_tables: [:schema, Pow.Store.Backend.MnesiaCache],
  lock_queue: [],
  log_version: '4.3',
  master_node_tables: [],
  max_wait_for_decision: :infinity,
  protocol_version: {8, 5},
  running_db_nodes: [:nonode@nohost],
  schema_location: :opt_disc,
  schema_version: {3, 0},
  subscribers: [#PID<0.4410.0>],
  tables: [:schema, Pow.Store.Backend.MnesiaCache],
  transaction_commits: 3,
  transaction_failures: 2,
  transaction_log_writes: 0,
  transaction_restarts: 0,
  transactions: [],
  use_dir: true,
  core_dir: false,
  no_table_loaders: 2,
  dc_dump_limit: 4,
  send_compressed: 0,
  version: '4.19.1'
]
```