### PR TITLE
[BUG FIX] Fix load testing of adaptive pages

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -15,7 +15,7 @@ config :oli,
   media_url: System.get_env("MEDIA_URL"),
   problematic_query_detection:
     from_boolean_env.("DEV_PROBLEMATIC_QUERY_DETECTION_ENABLED", "false"),
-  load_testing_mode: from_boolean_env.("LOAD_TESTING_MODE", "false"),
+  load_testing_mode: System.get_env("LOAD_TESTING_MODE", "disabled") |> String.to_existing_atom(),
   slack_webhook_url: System.get_env("SLACK_WEBHOOK_URL"),
   blackboard_application_client_id: System.get_env("BLACKBOARD_APPLICATION_CLIENT_ID")
 

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -76,7 +76,7 @@ config :oli,
   email_from_address: System.get_env("EMAIL_FROM_ADDRESS", "admin@example.edu"),
   email_reply_to: System.get_env("EMAIL_REPLY_TO", "admin@example.edu"),
   slack_webhook_url: System.get_env("SLACK_WEBHOOK_URL"),
-  load_testing_mode: from_boolean_env.("LOAD_TESTING_MODE", "false"),
+  load_testing_mode: System.get_env("LOAD_TESTING_MODE", "disabled") |> String.to_existing_atom(),
   payment_provider: System.get_env("PAYMENT_PROVIDER", "none"),
   blackboard_application_client_id: System.get_env("BLACKBOARD_APPLICATION_CLIENT_ID"),
   branding: [

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -312,6 +312,8 @@ defmodule OliWeb.PageDeliveryController do
       graded: context.page.graded,
       additional_stylesheets: Map.get(context.page.content, "additionalStylesheets", []),
       resource_attempt_guid: resource_attempt.attempt_guid,
+      latest_attempts: %{},
+      activity_type_slug_mapping: %{},
       resource_attempt_state: resource_attempt_state,
       activity_guid_mapping: activity_guid_mapping,
       content: Jason.encode!(context.page.content),

--- a/lib/oli_web/templates/page_delivery/advanced_delivery.html.eex
+++ b/lib/oli_web/templates/page_delivery/advanced_delivery.html.eex
@@ -46,3 +46,11 @@
 
   window.oliMountApplication(document.getElementById('delivery_container'), params);
 </script>
+
+<%= if Oli.Utils.LoadTesting.enabled?() do %>
+<!--
+__FINALIZATION_URL__<%= encode_url(Routes.page_delivery_path(@conn, :finalize_attempt, @section_slug, @slug, @resource_attempt_guid)) %>__FINALIZATION_URL__
+
+__ACTIVITY_ATTEMPTS__<%= encode_activity_attempts(@activity_type_slug_mapping, @latest_attempts) %>__ACTIVITY_ATTEMPTS__
+-->
+<% end %>


### PR DESCRIPTION
This PR fixes a couple of things with load testing mode:

1. The `load_testing_mode` configuration param was not being read from environment variables correctly.  This param needs to be set to either the `:enabled` or `:disabled` atoms, yet was being read as a boolean parameter. 
2. The load testing meta-data for finalization URL and activity attempts was not being written into the page that rendered adaptive pages.  Note, though, the activity attempts is being set as an empty list, on purpose, because there is no way (yet) for the load test client tool to exercise adaptive pages. 

I have tested and run this locally to confirm that load tests that encounter adaptive pages work correctly. 