### PR TITLE
[BUG FIX] Only use sections that allow guests in load testing

### DIFF
--- a/lib/oli_web/controllers/api/open_and_free_controller.ex
+++ b/lib/oli_web/controllers/api/open_and_free_controller.ex
@@ -8,7 +8,7 @@ defmodule OliWeb.Api.OpenAndFreeController do
   def index(conn, _params) do
     sections =
       Sections.list_open_and_free_sections()
-      |> Enum.filter(fn s -> s.registration_open end)
+      |> Enum.filter(fn s -> s.registration_open and !s.requires_enrollment end)
       |> Enum.map(fn section ->
         %{
           slug: section.slug,


### PR DESCRIPTION
This PR ensures that the load testing tool only uses open and free sections that allow guest access.  That tool currently does not support creation of actual users, therefore, sections that require enrollment will break a load test. 