### PR TITLE
[BUG FIX] Fix enrollment table rendering problem with nil dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ## Unreleased
 
-## 0.18.4 (2022-01-06)
+## 0.18.4 (2022-01-11)
 
 ### Bug Fixes
 
 - Improve performance of initial page visits by introducing bulk insertions of attempts
+- FIx enrollments view rendering problem in sections that require payment
 
 ## 0.18.3 (2021-12-27)
 

--- a/lib/oli_web/views/view_helpers.ex
+++ b/lib/oli_web/views/view_helpers.ex
@@ -94,6 +94,8 @@ defmodule OliWeb.ViewHelpers do
   """
   def dt(datetime, opts \\ [])
 
+  def dt(nil, _), do: ""
+
   def dt(datetime, %Plug.Conn{assigns: assigns} = conn) do
     case Map.get(assigns, :current_author) do
       %Author{} = author ->


### PR DESCRIPTION
 The table rendering with the "View Enrollments" view is breaking with sections that require payment are displayed.  In those cases, an extra column (the Payment date column) is rendered, and many of those records have `nil` as the payment date, which simply means the student hasn't paid yet. 

This PR makes the `dt` helper function robust to the case that the first arg is `nil`. 