### PR TITLE
[BUG FIX] Protect payment routes

### DIFF
--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -65,6 +65,10 @@ defmodule OliWeb.Router do
     plug(Oli.Plugs.SetDefaultPow, :user)
   end
 
+  pipeline :with_current_user do
+    plug(Oli.Plugs.SetCurrentUser)
+  end
+
   # set the layout to be workspace
   pipeline :workspace do
     plug(:put_root_layout, {OliWeb.LayoutView, "workspace.html"})
@@ -245,7 +249,7 @@ defmodule OliWeb.Router do
 
     # update session timezone information
     post("/timezone", StaticPageController, :timezone)
-    
+
     # general health check for application & db
     get "/healthz", HealthController, :index
   end
@@ -468,8 +472,12 @@ defmodule OliWeb.Router do
 
   scope "/api/v1/payments", OliWeb do
     pipe_through([:api])
-
+    # This endpoint is secured via an API token
     post("/", Api.PaymentController, :new)
+  end
+
+  scope "/api/v1/payments", OliWeb do
+    pipe_through([:api, :delivery_protected])
 
     # String payment intent creation
     post("/s/create-payment-intent", PaymentProviders.StripeController, :init_intent)

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -477,7 +477,7 @@ defmodule OliWeb.Router do
   end
 
   scope "/api/v1/payments", OliWeb do
-    pipe_through([:api, :delivery_protected])
+    pipe_through([:api, :delivery_protected, :with_current_user])
 
     # String payment intent creation
     post("/s/create-payment-intent", PaymentProviders.StripeController, :init_intent)


### PR DESCRIPTION
Stripe payment failures were being seen in AppSignal.  The root cause is that the pipeline used for these endpoints was not passing through the `SetCurrentUser` plug, which is responsible for setting the `conn.assigns.current_user`.  In digging into this, I also noticed that these endpoints were not POW protected either. 

This PR augments the pipeline for those routes to ensure they are both POW protected and that they set the `current_user` assign.  Note, only the payment provider routes are affected, the API endpoint to create payment codes CANNOT be protected in this way. It's authentication strategy is developer API key based. 