### PR TITLE
[BUG FIX] Only store and use transformed models when necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@
 ### Bug Fixes
 
 - Improve performance of initial page visits by introducing bulk insertions of attempts
-- FIx enrollments view rendering problem in sections that require payment
+- Fix enrollments view rendering problem in sections that require payment
+
+### Enhancements
+
+- Optimize rendering and storage by allowing attempts to only store transformed models when necessary
 
 ## 0.18.3 (2021-12-27)
 

--- a/lib/oli/activities/state.ex
+++ b/lib/oli/activities/state.ex
@@ -9,7 +9,7 @@ defmodule Oli.Activities.State do
   """
   def from_attempts(latest_attempts) do
     Enum.map(latest_attempts, fn {id, {activity_attempt, part_attempts}} ->
-      {:ok, model} = Map.get(activity_attempt, :transformed_model) |> Model.parse()
+      {:ok, model} = Oli.Delivery.Attempts.Core.select_model(activity_attempt) |> Model.parse()
 
       {id, ActivityState.from_attempt(activity_attempt, Map.values(part_attempts), model)}
     end)

--- a/lib/oli/activities/transformers.ex
+++ b/lib/oli/activities/transformers.ex
@@ -18,7 +18,7 @@ defmodule Oli.Activities.Transformers do
       {:ok, parsed_model} ->
         case Enum.count(parsed_model.transformations) do
           0 ->
-            {:no_effect, parsed_model}
+            {:no_effect, model}
 
           _ ->
             Enum.reduce_while(parsed_model.transformations, {:ok, model}, fn t, {:ok, model} ->

--- a/lib/oli/activities/transformers.ex
+++ b/lib/oli/activities/transformers.ex
@@ -5,17 +5,29 @@ defmodule Oli.Activities.Transformers do
 
   @doc """
   Transforms an unparsed activity model.
+
+  When no transformations exist, or the resulting transformations had no effect, returns {:no_effect, original_model_parsed}
+
+  Otherwise, this applies all transformations and returns {:ok, transformed_model} where
+  `transformed_model` is the parsed model after mutation from transformations.
+
+  If errors occur during parsing or transformation, returns {:error, e}
   """
-  @spec apply_transforms(map()) :: {:ok, map()} | {:error, any}
   def apply_transforms(model) do
     case Model.parse(model) do
       {:ok, parsed_model} ->
-        Enum.reduce_while(parsed_model.transformations, {:ok, model}, fn t, {:ok, model} ->
-          case apply_transform(model, t) do
-            {:ok, transformed_model} -> {:cont, {:ok, transformed_model}}
-            {:error, error} -> {:halt, {:error, error}}
-          end
-        end)
+        case Enum.count(parsed_model.transformations) do
+          0 ->
+            {:no_effect, parsed_model}
+
+          _ ->
+            Enum.reduce_while(parsed_model.transformations, {:ok, model}, fn t, {:ok, model} ->
+              case apply_transform(model, t) do
+                {:ok, transformed_model} -> {:cont, {:ok, transformed_model}}
+                {:error, error} -> {:halt, {:error, error}}
+              end
+            end)
+        end
 
       {:error, error} ->
         {:error, error}

--- a/lib/oli/activities/transformers.ex
+++ b/lib/oli/activities/transformers.ex
@@ -6,10 +6,12 @@ defmodule Oli.Activities.Transformers do
   @doc """
   Transforms an unparsed activity model.
 
-  When no transformations exist, or the resulting transformations had no effect, returns {:no_effect, original_model_parsed}
+  When no transformations exist, or the resulting transformations had no effect this
+  returns {:no_effect, original_model} where `original_model` is the original unparsed model
+  of the activity.
 
   Otherwise, this applies all transformations and returns {:ok, transformed_model} where
-  `transformed_model` is the parsed model after mutation from transformations.
+  `transformed_model` is the raw model after mutation from transformations.
 
   If errors occur during parsing or transformation, returns {:error, e}
   """

--- a/lib/oli/analytics/datashop.ex
+++ b/lib/oli/analytics/datashop.ex
@@ -150,7 +150,7 @@ defmodule Oli.Analytics.Datashop do
   end
 
   defp get_part_from_attempt(part_attempt) do
-    part_attempt.activity_attempt.transformed_model["authoring"]["parts"]
+    Attempts.select_model(part_attempt.activity_attempt)["authoring"]["parts"]
     |> Enum.find(%{}, &(&1["id"] == part_attempt.part_id))
   end
 end

--- a/lib/oli/analytics/datashop/elements/event_descriptor.ex
+++ b/lib/oli/analytics/datashop/elements/event_descriptor.ex
@@ -17,6 +17,7 @@ defmodule Oli.Analytics.Datashop.Elements.EventDescriptor do
   alias Oli.Analytics.Datashop.Utils
   alias Oli.Rendering.Utils, as: RenderUtils
   alias Oli.Delivery.Attempts.Core.PartAttempt
+  alias Oli.Delivery.Attempts.Core
 
   def setup(type, %{problem_name: problem_name, part_attempt: part_attempt}) do
     element(:event_descriptor, [
@@ -147,8 +148,8 @@ defmodule Oli.Analytics.Datashop.Elements.EventDescriptor do
     |> RenderUtils.parse_html_content()
   end
 
-  defp all_choices(part_attempt), do: part_attempt.activity_attempt.transformed_model["choices"]
-  defp all_inputs(part_attempt), do: part_attempt.activity_attempt.transformed_model["inputs"]
+  defp all_choices(part_attempt), do: Core.select_model(part_attempt.activity_attempt)["choices"]
+  defp all_inputs(part_attempt), do: Core.select_model(part_attempt.activity_attempt)["inputs"]
 
   defp selected_choice_ids(input), do: String.split(input, " ")
 

--- a/lib/oli/authoring/editing/activity_editor.ex
+++ b/lib/oli/authoring/editing/activity_editor.ex
@@ -552,7 +552,7 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
 
   Returns:
 
-  .`{:ok, %Activity{}}` when the creation processes succeeds
+  .`{:ok, {%Activity{}, transformed_content}}` when the creation processes succeeds
   .`{:error, {:not_found}}` if the project, resource, or user cannot be found
   .`{:error, {:not_authorized}}` if the user is not authorized to create this activity
   .`{:error, {:error}}` unknown error
@@ -598,6 +598,7 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
              }) do
         case Transformers.apply_transforms(content) do
           {:ok, transformed} -> {activity, transformed}
+          {:no_effect, original} -> {activity, original}
           _ -> {activity, nil}
         end
       else

--- a/lib/oli/authoring/editing/page_editor.ex
+++ b/lib/oli/authoring/editing/page_editor.ex
@@ -287,6 +287,7 @@ defmodule Oli.Authoring.Editing.PageEditor do
          transformed =
            case Transformers.apply_transforms(content) do
              {:ok, t} -> t
+             {:no_effect, t} -> t
              _ -> nil
            end
 

--- a/lib/oli/delivery/attempts/activity_lifecycle.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle.ex
@@ -41,7 +41,7 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle do
            {:ok, part_attempt} <-
              get_part_attempt_by(attempt_guid: part_attempt_guid)
              |> Oli.Utils.trap_nil(:not_found),
-           {:ok, model} <- Model.parse(activity_attempt.transformed_model),
+           {:ok, model} <- select_model(activity_attempt) |> Model.parse(),
            {:ok, part} <-
              Enum.find(model.parts, fn p -> p.id == part_attempt.part_id end)
              |> Oli.Utils.trap_nil(:not_found) do
@@ -115,14 +115,20 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle do
           # Resolve the revision to pick up the latest
           revision = DeliveryResolver.from_resource_id(section_slug, activity_attempt.resource_id)
 
+          {model_to_store, working_model} =
+            case Transformers.apply_transforms(revision.content) do
+              {:ok, transformed_model} -> {transformed_model, transformed_model}
+              {:no_effect, original} -> {nil, original}
+              _ -> {nil, nil}
+            end
+
           # parse and transform
           with {:ok, model} <- Model.parse(revision.content),
-               {:ok, transformed_model} <- Transformers.apply_transforms(revision.content),
                {:ok, new_activity_attempt} <-
                  create_activity_attempt(%{
                    attempt_guid: UUID.uuid4(),
                    attempt_number: attempt_count + 1,
-                   transformed_model: transformed_model,
+                   transformed_model: model_to_store,
                    resource_id: activity_attempt.resource_id,
                    revision_id: revision.id,
                    resource_attempt_id: activity_attempt.resource_attempt_id
@@ -155,7 +161,7 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle do
               end
 
             {ActivityState.from_attempt(new_activity_attempt, new_part_attempts, model),
-             ModelPruner.prune(transformed_model)}
+             ModelPruner.prune(working_model)}
           else
             {:error, error} -> Repo.rollback(error)
           end

--- a/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
@@ -16,15 +16,18 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
   require Logger
 
   def evaluate_activity(section_slug, activity_attempt_guid, part_inputs) do
-    %ActivityAttempt{
-      transformed_model: transformed_model,
-      resource_attempt: resource_attempt,
-      attempt_number: attempt_number
-    } =
+    activity_attempt =
       get_activity_attempt_by(attempt_guid: activity_attempt_guid)
       |> Repo.preload([:resource_attempt])
 
-    case Model.parse(transformed_model) do
+    %ActivityAttempt{
+      resource_attempt: resource_attempt,
+      attempt_number: attempt_number
+    } = activity_attempt
+
+    activity_model = select_model(activity_attempt)
+
+    case Model.parse(activity_model) do
       {:ok, %Model{rules: []}} ->
         evaluate_from_input(section_slug, activity_attempt_guid, part_inputs)
 
@@ -475,15 +478,18 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
   defp evaluate_submissions(_, [], _), do: {:error, "nothing to process"}
 
   defp evaluate_submissions(activity_attempt_guid, part_inputs, part_attempts) do
-    %ActivityAttempt{
-      transformed_model: transformed_model,
-      attempt_number: attempt_number,
-      resource_attempt: resource_attempt
-    } =
+    activity_attempt =
       get_activity_attempt_by(attempt_guid: activity_attempt_guid)
       |> Repo.preload([:resource_attempt])
 
-    {:ok, %Model{parts: parts}} = Model.parse(transformed_model)
+    %ActivityAttempt{
+      resource_attempt: resource_attempt,
+      attempt_number: attempt_number
+    } = activity_attempt
+
+    activity_model = select_model(activity_attempt)
+
+    {:ok, %Model{parts: parts}} = Model.parse(activity_model)
 
     # We need to tie the attempt_guid from the part_inputs to the attempt_guid
     # from the %PartAttempt, and then the part id from the %PartAttempt to the

--- a/lib/oli/delivery/attempts/core.ex
+++ b/lib/oli/delivery/attempts/core.ex
@@ -435,7 +435,7 @@ defmodule Oli.Delivery.Attempts.Core do
       Repo.all(
         from(activity_attempt in ActivityAttempt,
           where: activity_attempt.attempt_guid in ^activity_attempt_guids,
-          preload: [:part_attempts]
+          preload: [:part_attempts, :revision]
         )
       )
 

--- a/lib/oli/delivery/attempts/core.ex
+++ b/lib/oli/delivery/attempts/core.ex
@@ -21,6 +21,24 @@ defmodule Oli.Delivery.Attempts.Core do
     ActivityAttempt
   }
 
+  @doc """
+  Select the model to use to power all aspects of an activity.  If an activity utilizes
+  transformations, the transformed model will be stored on the activity attempt in the
+  `transformed_model` attribute.  Otherwise, that field will be `nil` indicating that the
+  original model from the revision of the activity should be used.  Allowing the
+  `transformed_model` to be nil is a significant storage and performance optimization,
+  particularly when the size and number of activities within a page becomes large.
+
+  This variant of this function allows the activity attempt and the revision to be passed
+  as separate arguments to support workflows where the revision is not expected to be
+  preloaded in the activity attempt. In situations where that revision is expected to be
+  preloaded, `select_model/1` can be used instead.
+
+  In both variants, a robustness feature exists that will inline retrieve the revision,
+  if needed and not specified.  This is clearly to prevent functional problems, but it can
+  lead to performance issues if done across a collection.  A warning is logged in this
+  case.
+  """
   def select_model(%ActivityAttempt{transformed_model: nil, revision_id: revision_id}, nil) do
     perform_inline_fetch(revision_id)
   end

--- a/lib/oli/delivery/attempts/core/activity_attempt.ex
+++ b/lib/oli/delivery/attempts/core/activity_attempt.ex
@@ -9,7 +9,7 @@ defmodule Oli.Delivery.Attempts.Core.ActivityAttempt do
     field(:scoreable, :boolean, default: true)
     field(:score, :float)
     field(:out_of, :float)
-    field(:transformed_model, :map)
+    field(:transformed_model, :map, default: nil)
 
     belongs_to(:resource, Oli.Resources.Resource)
     belongs_to(:revision, Oli.Resources.Revision)
@@ -37,7 +37,6 @@ defmodule Oli.Delivery.Attempts.Core.ActivityAttempt do
     |> validate_required([
       :attempt_guid,
       :attempt_number,
-      :transformed_model,
       :resource_attempt_id,
       :resource_id,
       :revision_id

--- a/lib/oli/delivery/attempts/page_lifecycle/hierarchy.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/hierarchy.ex
@@ -124,7 +124,11 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Hierarchy do
          scoreable,
          now
        ) do
-    {:ok, transformed_model} = Transformers.apply_transforms(model)
+    transformed_model =
+      case Transformers.apply_transforms(model) do
+        {:ok, transformed_model} -> transformed_model
+        _ -> nil
+      end
 
     %{
       resource_attempt_id: resource_attempt.id,

--- a/lib/oli/delivery/page/activity_context.ex
+++ b/lib/oli/delivery/page/activity_context.ex
@@ -6,6 +6,7 @@ defmodule Oli.Delivery.Page.ActivityContext do
   alias Oli.Delivery.Page.ModelPruner
   alias Oli.Rendering.Activity.ActivitySummary
   alias Oli.Delivery.Attempts.Core.ActivityAttempt
+  alias Oli.Delivery.Attempts.Core
   alias Oli.Activities.State
   alias Oli.Activities.State.ActivityState
   alias Oli.Activities
@@ -25,8 +26,9 @@ defmodule Oli.Delivery.Page.ActivityContext do
     activity_states = State.from_attempts(latest_attempts)
 
     Enum.map(latest_attempts, fn {id,
-                                  {%ActivityAttempt{transformed_model: model, revision: revision},
-                                   _}} ->
+                                  {%ActivityAttempt{revision: revision} = activity_attempt, _}} ->
+      model = Core.select_model(activity_attempt)
+
       # the activity type this revision pertains to
       type = Map.get(reg_map, revision.activity_type_id)
       state = Map.get(activity_states, id)

--- a/lib/oli_web/controllers/api/activity_controller.ex
+++ b/lib/oli_web/controllers/api/activity_controller.ex
@@ -548,6 +548,7 @@ defmodule OliWeb.Api.ActivityController do
   def transform(conn, %{"model" => model}) do
     case ActivityLifecycle.perform_test_transformation(model) do
       {:ok, transformed} -> json(conn, %{"result" => "success", "transformed" => transformed})
+      {:no_effect, original} -> json(conn, %{"result" => "success", "transformed" => original})
       {:error, _} -> error(conn, 500, "server error")
     end
   end

--- a/lib/oli_web/controllers/api/attempt_controller.ex
+++ b/lib/oli_web/controllers/api/attempt_controller.ex
@@ -324,7 +324,7 @@ defmodule OliWeb.Api.AttemptController do
       score: attempt.score,
       outOf: attempt.out_of,
       dateEvaluated: attempt.date_evaluated,
-      model: Oli.Delivery.Page.ModelPruner.prune(attempt.transformed_model),
+      model: Attempts.select_model(attempt, revision) |> Oli.Delivery.Page.ModelPruner.prune(),
       partAttempts:
         Map.values(latest_part_attempt_by_part)
         |> Enum.map(fn pa ->

--- a/lib/oli_web/controllers/api/attempt_controller.ex
+++ b/lib/oli_web/controllers/api/attempt_controller.ex
@@ -313,18 +313,16 @@ defmodule OliWeb.Api.AttemptController do
         end
       end)
 
-    revision = Oli.Resources.get_revision!(attempt.revision_id)
-
     %{
       activityId: attempt.resource_id,
-      activityType: revision.activity_type_id,
+      activityType: attempt.revision.activity_type_id,
       revisionId: attempt.revision_id,
       attemptGuid: attempt.attempt_guid,
       attemptNumber: attempt.attempt_number,
       score: attempt.score,
       outOf: attempt.out_of,
       dateEvaluated: attempt.date_evaluated,
-      model: Attempts.select_model(attempt, revision) |> Oli.Delivery.Page.ModelPruner.prune(),
+      model: Attempts.select_model(attempt) |> Oli.Delivery.Page.ModelPruner.prune(),
       partAttempts:
         Map.values(latest_part_attempt_by_part)
         |> Enum.map(fn pa ->

--- a/lib/oli_web/views/page_delivery_view.ex
+++ b/lib/oli_web/views/page_delivery_view.ex
@@ -5,6 +5,7 @@ defmodule OliWeb.PageDeliveryView do
   alias Oli.Resources.Numbering
   alias Oli.Delivery.Hierarchy.HierarchyNode
   alias OliWeb.Router.Helpers, as: Routes
+  alias Oli.Delivery.Attempts.Core
 
   def show_score(score, out_of) do
     cond do
@@ -111,7 +112,7 @@ defmodule OliWeb.PageDeliveryView do
   # the second argument. These entries will be in the shape
   # of two element tuples.
   defp encode_attempt(registered_activity_slug_map, {activity_attempt, part_attempts_map}) do
-    {:ok, model} = Oli.Activities.Model.parse(activity_attempt.transformed_model)
+    {:ok, model} = Core.select_model(activity_attempt) |> Oli.Activities.Model.parse()
 
     state =
       Oli.Activities.State.ActivityState.from_attempt(
@@ -129,7 +130,7 @@ defmodule OliWeb.PageDeliveryView do
       :answers,
       Oli.Utils.LoadTesting.provide_answers(
         activity_type_slug,
-        activity_attempt.transformed_model
+        Core.select_model(activity_attempt)
       )
     )
   end

--- a/test/oli/activities/transformers_test.exs
+++ b/test/oli/activities/transformers_test.exs
@@ -3,6 +3,31 @@ defmodule Oli.Activities.TransformersTest do
 
   alias Oli.Activities.Transformers
 
+  test "no transformers results in no effect" do
+    model = %{
+      "stem" => "this is the stem",
+      "choices" => [
+        %{id: "1", content: []},
+        %{id: "2", content: []},
+        %{id: "3", content: []},
+        %{id: "4", content: []}
+      ],
+      "authoring" => %{
+        "parts" => [
+          %{
+            "id" => "1",
+            "responses" => [],
+            "scoringStrategy" => "best",
+            "evaluationStrategy" => "regex"
+          }
+        ],
+        "transformations" => []
+      }
+    }
+
+    assert {:no_effect, _} = Transformers.apply_transforms(model)
+  end
+
   test "applying shuffle" do
     model = %{
       "stem" => "this is the stem",

--- a/test/oli/delivery/attempts_test.exs
+++ b/test/oli/delivery/attempts_test.exs
@@ -242,7 +242,7 @@ defmodule Oli.Delivery.AttemptsTest do
         :attempt1
       )
       |> Seeder.create_activity_attempt(
-        %{attempt_number: 1, transformed_model: %{}},
+        %{attempt_number: 1, transformed_model: nil},
         :activity_a,
         :attempt1,
         :activity_attempt1
@@ -261,7 +261,7 @@ defmodule Oli.Delivery.AttemptsTest do
         :attempt2
       )
       |> Seeder.create_activity_attempt(
-        %{attempt_number: 1, transformed_model: %{}},
+        %{attempt_number: 1, transformed_model: nil},
         :activity_a,
         :attempt2,
         :activity_attempt2
@@ -490,7 +490,7 @@ defmodule Oli.Delivery.AttemptsTest do
           :attempt1
         )
         |> Seeder.create_activity_attempt(
-          %{attempt_number: 1, transformed_model: %{}},
+          %{attempt_number: 1, transformed_model: nil},
           :activity_a,
           :attempt1,
           :activity_attempt1
@@ -509,7 +509,7 @@ defmodule Oli.Delivery.AttemptsTest do
           :attempt2
         )
         |> Seeder.create_activity_attempt(
-          %{attempt_number: 1, transformed_model: %{}},
+          %{attempt_number: 1, transformed_model: nil},
           :activity_a,
           :attempt2,
           :activity_attempt2
@@ -595,7 +595,7 @@ defmodule Oli.Delivery.AttemptsTest do
           :attempt1
         )
         |> Seeder.create_activity_attempt(
-          %{attempt_number: 1, transformed_model: %{}},
+          %{attempt_number: 1, transformed_model: nil},
           :activity_a,
           :attempt1,
           :activity_attempt1
@@ -614,7 +614,7 @@ defmodule Oli.Delivery.AttemptsTest do
           :attempt2
         )
         |> Seeder.create_activity_attempt(
-          %{attempt_number: 1, transformed_model: %{}},
+          %{attempt_number: 1, transformed_model: nil},
           :activity_a,
           :attempt2,
           :activity_attempt2

--- a/test/oli/delivery/attempts_test.exs
+++ b/test/oli/delivery/attempts_test.exs
@@ -9,7 +9,7 @@ defmodule Oli.Delivery.AttemptsTest do
 
   alias Oli.Activities.Model.{Part, Feedback}
   alias Oli.Delivery.Page.PageContext
-  alias Oli.Delivery.Attempts.Core.{ClientEvaluation, StudentInput}
+  alias Oli.Delivery.Attempts.Core.{ClientEvaluation, StudentInput, ActivityAttempt}
 
   describe "creating the attempt tree records" do
     setup do
@@ -242,7 +242,7 @@ defmodule Oli.Delivery.AttemptsTest do
         :attempt1
       )
       |> Seeder.create_activity_attempt(
-        %{attempt_number: 1, transformed_model: nil},
+        %{attempt_number: 1, transformed_model: %{some: :thing}},
         :activity_a,
         :attempt1,
         :activity_attempt1
@@ -302,6 +302,35 @@ defmodule Oli.Delivery.AttemptsTest do
         :activity_attempt2,
         :part3_attempt2
       )
+    end
+
+    test "model selection", %{
+      activity_a: activity,
+      activity_attempt1: activity_attempt1,
+      activity_attempt2: activity_attempt2
+    } do
+      revision = activity.revision
+
+      # Directly loading attempts will not preload the revision, which makes it suitable
+      # to feed into select_model/2
+
+      assert %{"some" => "thing"} ==
+               Oli.Repo.get(ActivityAttempt, activity_attempt1.id)
+               |> Attempts.select_model(revision)
+
+      assert revision.content ==
+               Oli.Repo.get(ActivityAttempt, activity_attempt2.id)
+               |> Attempts.select_model(revision)
+
+      # Using get_activity_attempt_by does preload, therefore we can use select_model/1
+
+      assert %{"some" => "thing"} ==
+               Attempts.get_activity_attempt_by(attempt_guid: activity_attempt1.attempt_guid)
+               |> Attempts.select_model()
+
+      assert revision.content ==
+               Attempts.get_activity_attempt_by(attempt_guid: activity_attempt2.attempt_guid)
+               |> Attempts.select_model()
     end
 
     test "get graded resource access", %{

--- a/test/oli_web/controllers/api/attempt_controller_test.exs
+++ b/test/oli_web/controllers/api/attempt_controller_test.exs
@@ -62,7 +62,7 @@ defmodule OliWeb.AttemptControllerTest do
         :attempt1
       )
       |> Seeder.create_activity_attempt(
-        %{attempt_number: 1, transformed_model: %{}},
+        %{attempt_number: 1, transformed_model: nil},
         :activity_a,
         :attempt1,
         :activity_attempt1
@@ -81,7 +81,7 @@ defmodule OliWeb.AttemptControllerTest do
         :attempt2
       )
       |> Seeder.create_activity_attempt(
-        %{attempt_number: 1, transformed_model: %{}},
+        %{attempt_number: 1, transformed_model: nil},
         :activity_a,
         :attempt2,
         :activity_attempt2


### PR DESCRIPTION
This PR implements an optimization to improve the first attempt rendering of both basic and adaptive pages.  

### The Problem

Performance testing data showed very long query times for the bulk activity attempt insertion query that is now present in `Oli.Delivery.Attempts.PageLifecycle.Hierarchy`.  The reason that even this bulk insertion query can take sometimes 20 seconds to execute is that each and every record in that bulk insert contains one full copy of the corresponding activity's model (to populate the `transformed_model` attribute of the activity attempt).  Some adaptive pages contain hundreds and hundreds of activities and some (most?) of their JSON content can be quite large. 

### The Solution

The solution here is to change the implementation to only store `transformed_model` when it actually needs to. In other words, when an attempt is created for an activity, if that activity uses no transformations, then we simply store `nil` in the transformed model.  By allowing this to be nil, this greatly reduces the payload size of the bulk insertion query.

The implication here is that at hint request, activity reset, activity evaluation, and other lifecycle actions we must determine where to get the model that we need to use.  We can no longer just take the `transformed_model` and use it at it can be `nil`.  A `select_model` function has be added that encapsulates that selection logic.

I've tested this locally with basic and adaptive pages and everything seems to be working well.  The initial loads of adaptive pages does seem significantly quicker, so I am cautiously optimistic that this fix will yield some nice results in the next round of performance tests. 