### PR TITLE
[BUG FIX] Reduce the number of queries required for render

### DIFF
--- a/lib/oli/delivery/attempts/core.ex
+++ b/lib/oli/delivery/attempts/core.ex
@@ -96,23 +96,21 @@ defmodule Oli.Delivery.Attempts.Core do
   """
 
   @doc """
-  Creates or updates an access record for a given resource, section context id and user. When
+  Creates or updates an access record for a given resource, section id and user. When
   created the access count is set to 1, otherwise on updates the
   access count is incremented.
   ## Examples
-      iex> track_access(resource_id, section_slug, user_id)
+      iex> track_access(resource_id, section_id, user_id)
       {:ok, %ResourceAccess{}}
-      iex> track_access(resource_id, section_slug, user_id)
+      iex> track_access(resource_id, section_id, user_id)
       {:error, %Ecto.Changeset{}}
   """
-  def track_access(resource_id, section_slug, user_id) do
-    section = Sections.get_section_by(slug: section_slug)
-
+  def track_access(resource_id, section_id, user_id) do
     Oli.Repo.insert!(
       %ResourceAccess{
         access_count: 1,
         user_id: user_id,
-        section_id: section.id,
+        section_id: section_id,
         resource_id: resource_id
       },
       on_conflict: [inc: [access_count: 1]],
@@ -351,23 +349,23 @@ defmodule Oli.Delivery.Attempts.Core do
   """
   def get_latest_resource_attempt(resource_id, section_slug, user_id) do
     Repo.one(
-      from(a in ResourceAccess,
-        join: s in Section,
-        on: a.section_id == s.id,
-        join: ra1 in ResourceAttempt,
-        on: a.id == ra1.resource_access_id,
-        left_join: ra2 in ResourceAttempt,
+      ResourceAttempt
+      |> join(:left, [ra1], a in ResourceAccess, on: a.id == ra1.resource_access_id)
+      |> join(:left, [_, a], s in Section, on: a.section_id == s.id)
+      |> join(:left, [ra1, a, _], ra2 in ResourceAttempt,
         on:
           a.id == ra2.resource_access_id and ra1.id < ra2.id and
-            ra1.resource_access_id == ra2.resource_access_id,
-        where:
-          a.user_id == ^user_id and s.slug == ^section_slug and s.status != :deleted and
-            a.resource_id == ^resource_id and
-            is_nil(ra2),
-        select: ra1
+            ra1.resource_access_id == ra2.resource_access_id
       )
+      |> join(:left, [ra1, _, _, _], r in Revision, on: ra1.revision_id == r.id)
+      |> where(
+        [ra1, a, s, ra2, _],
+        a.user_id == ^user_id and s.slug == ^section_slug and s.status != :deleted and
+          a.resource_id == ^resource_id and
+          is_nil(ra2)
+      )
+      |> preload(:revision)
     )
-    |> Repo.preload([:revision])
   end
 
   @doc """

--- a/lib/oli/delivery/attempts/core.ex
+++ b/lib/oli/delivery/attempts/core.ex
@@ -4,7 +4,6 @@ defmodule Oli.Delivery.Attempts.Core do
   alias Oli.Repo
   require Logger
 
-  alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.Section
   alias Oli.Publishing.PublishedResource
   alias Oli.Resources.Revision

--- a/lib/oli/delivery/page/page_context.ex
+++ b/lib/oli/delivery/page/page_context.ex
@@ -29,6 +29,7 @@ defmodule Oli.Delivery.Page.PageContext do
   alias Oli.Publishing.DeliveryResolver
   alias Oli.Delivery.Attempts.Core, as: Attempts
   alias Oli.Delivery.Page.ObjectivesRollup
+  alias Oli.Delivery.Sections.Section
 
   @doc """
   Creates the page context required to render a page for reviewing a historical
@@ -77,13 +78,13 @@ defmodule Oli.Delivery.Page.PageContext do
   information is collected and then assembled in a fashion that can be given
   to a renderer.
   """
-  @spec create_for_visit(String.t(), String.t(), Oli.Accounts.User) ::
+  @spec create_for_visit(Section, String.t(), Oli.Accounts.User) ::
           %PageContext{}
-  def create_for_visit(section_slug, page_slug, user) do
+  def create_for_visit(%Section{slug: section_slug, id: section_id}, page_slug, user) do
     # resolve the page revision per section
     page_revision = DeliveryResolver.from_revision_slug(section_slug, page_slug)
 
-    Attempts.track_access(page_revision.resource_id, section_slug, user.id)
+    Attempts.track_access(page_revision.resource_id, section_id, user.id)
 
     activity_provider = &Oli.Delivery.ActivityProvider.provide/3
 

--- a/lib/oli/utils/db_seeder.ex
+++ b/lib/oli/utils/db_seeder.ex
@@ -532,7 +532,7 @@ defmodule Oli.Seeder do
     revision = Map.get(map, resource_tag).revision
     section = map.section
 
-    %ResourceAccess{id: id} = track_access(resource.id, section.slug, user.id)
+    %ResourceAccess{id: id} = track_access(resource.id, section.id, user.id)
 
     attrs =
       Map.merge(attrs, %{
@@ -557,7 +557,7 @@ defmodule Oli.Seeder do
     revision = Map.get(map, revision_tag)
     section = map.section
 
-    %ResourceAccess{id: id} = track_access(resource.id, section.slug, user.id)
+    %ResourceAccess{id: id} = track_access(resource.id, section.id, user.id)
 
     attrs =
       Map.merge(attrs, %{

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -60,9 +60,10 @@ defmodule OliWeb.PageDeliveryController do
 
   def index(conn, %{"section_slug" => section_slug}) do
     user = conn.assigns.current_user
+    section = conn.assigns.section
 
     if Sections.is_enrolled?(user.id, section_slug) do
-      case Sections.get_section_by(slug: section_slug)
+      case section
            |> Oli.Repo.preload([:base_project, :root_section_resource]) do
         nil ->
           render(conn, "error.html")
@@ -125,9 +126,10 @@ defmodule OliWeb.PageDeliveryController do
 
   def page(conn, %{"section_slug" => section_slug, "revision_slug" => revision_slug}) do
     user = conn.assigns.current_user
+    section = conn.assigns.section
 
     if Sections.is_enrolled?(user.id, section_slug) do
-      PageContext.create_for_visit(section_slug, revision_slug, user)
+      PageContext.create_for_visit(section, revision_slug, user)
       |> render_page(conn, section_slug, user, false)
     else
       render(conn, "not_authorized.html")
@@ -140,9 +142,10 @@ defmodule OliWeb.PageDeliveryController do
          %{content: %{"advancedDelivery" => true}} = revision
        ) do
     user = conn.assigns.current_user
+    section = conn.assigns.section
 
     if Sections.is_instructor?(user, section_slug) do
-      PageContext.create_for_visit(section_slug, revision.slug, user)
+      PageContext.create_for_visit(section, revision.slug, user)
       |> render_page(conn, section_slug, user, true)
     else
       render(conn, "not_authorized.html")
@@ -495,7 +498,7 @@ defmodule OliWeb.PageDeliveryController do
 
   def after_finalized(conn, section_slug, revision_slug, attempt_guid, user, grade_sync_result) do
     section = conn.assigns.section
-    context = PageContext.create_for_visit(section_slug, revision_slug, user)
+    context = PageContext.create_for_visit(section, revision_slug, user)
 
     message =
       if context.page.max_attempts == 0 do

--- a/test/oli/delivery/attempts_test.exs
+++ b/test/oli/delivery/attempts_test.exs
@@ -74,7 +74,7 @@ defmodule Oli.Delivery.AttemptsTest do
       a2: a2,
       publication: pub
     } do
-      Attempts.track_access(p1.resource.id, section.slug, user.id)
+      Attempts.track_access(p1.resource.id, section.id, user.id)
 
       activity_provider = &Oli.Delivery.ActivityProvider.provide/3
 
@@ -109,14 +109,14 @@ defmodule Oli.Delivery.AttemptsTest do
       section: section,
       p1: %{resource: resource}
     } do
-      Attempts.track_access(resource.id, section.slug, user1.id)
-      Attempts.track_access(resource.id, section.slug, user1.id)
+      Attempts.track_access(resource.id, section.id, user1.id)
+      Attempts.track_access(resource.id, section.id, user1.id)
 
       entries = Oli.Repo.all(Oli.Delivery.Attempts.Core.ResourceAccess)
       assert length(entries) == 1
       assert hd(entries).access_count == 2
 
-      Attempts.track_access(resource.id, section.slug, user2.id)
+      Attempts.track_access(resource.id, section.id, user2.id)
       entries = Oli.Repo.all(Oli.Delivery.Attempts.Core.ResourceAccess)
       assert length(entries) == 2
 
@@ -140,7 +140,7 @@ defmodule Oli.Delivery.AttemptsTest do
     } do
       activity_provider = &Oli.Delivery.ActivityProvider.provide/3
 
-      PageContext.create_for_visit(section.slug, revision.slug, user1)
+      PageContext.create_for_visit(section, revision.slug, user1)
 
       # Page 1
       {:ok, %AttemptState{resource_attempt: resource_attempt}} =
@@ -175,8 +175,8 @@ defmodule Oli.Delivery.AttemptsTest do
     } do
       activity_provider = &Oli.Delivery.ActivityProvider.provide/3
 
-      PageContext.create_for_visit(section.slug, revision.slug, user1)
-      PageContext.create_for_visit(section.slug, revision.slug, user2)
+      PageContext.create_for_visit(section, revision.slug, user1)
+      PageContext.create_for_visit(section, revision.slug, user2)
 
       # User1 - same as above
       {:ok, %AttemptState{resource_attempt: resource_attempt}} =
@@ -340,7 +340,7 @@ defmodule Oli.Delivery.AttemptsTest do
     } do
       activity_provider = &Oli.Delivery.ActivityProvider.provide/3
 
-      PageContext.create_for_visit(section.slug, revision.slug, user1)
+      PageContext.create_for_visit(section, revision.slug, user1)
 
       {:ok, %AttemptState{} = _} =
         PageLifecycle.start(
@@ -367,7 +367,7 @@ defmodule Oli.Delivery.AttemptsTest do
     } do
       activity_provider = &Oli.Delivery.ActivityProvider.provide/3
 
-      PageContext.create_for_visit(section.slug, revision.slug, user1)
+      PageContext.create_for_visit(section, revision.slug, user1)
 
       {:ok, %AttemptState{} = _} =
         PageLifecycle.start(
@@ -377,7 +377,7 @@ defmodule Oli.Delivery.AttemptsTest do
           activity_provider
         )
 
-      PageContext.create_for_visit(section.slug, revision.slug, user2)
+      PageContext.create_for_visit(section, revision.slug, user2)
 
       {:ok, %AttemptState{} = _} =
         PageLifecycle.start(
@@ -456,7 +456,7 @@ defmodule Oli.Delivery.AttemptsTest do
     } do
       activity_provider = &Oli.Delivery.ActivityProvider.provide/3
 
-      PageContext.create_for_visit(section.slug, revision.slug, user1)
+      PageContext.create_for_visit(section, revision.slug, user1)
 
       {:ok, %AttemptState{} = _} =
         PageLifecycle.start(

--- a/test/oli/delivery/page/page_context_test.exs
+++ b/test/oli/delivery/page/page_context_test.exs
@@ -71,7 +71,7 @@ defmodule Oli.Delivery.Page.PageContextTest do
 
       Seeder.rebuild_section_resources(%{section: section, publication: publication})
 
-      context = PageContext.create_for_visit(section.slug, p1.revision.slug, user)
+      context = PageContext.create_for_visit(section, p1.revision.slug, user)
 
       # verify activities map
       assert Map.get(context.activities, a1.resource.id).model != nil

--- a/test/oli/delivery/submission_test.exs
+++ b/test/oli/delivery/submission_test.exs
@@ -92,7 +92,7 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
       {:ok, _summary} = Summary.get_summary(section.slug, user1)
 
       # Open the graded page as user 1 to get the prologue
-      user1_page_context = PageContext.create_for_visit(section.slug, revision.slug, user1)
+      user1_page_context = PageContext.create_for_visit(section, revision.slug, user1)
       assert user1_page_context.progress_state == :not_started
       assert Enum.empty?(user1_page_context.resource_attempts)
 
@@ -129,7 +129,7 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
       assert user1_latest_resource_attempt.id == user1_resource_attempt.id
 
       # Make sure the progress state is correct for the latest resource attempt
-      assert PageContext.create_for_visit(section.slug, revision.slug, user1).progress_state ==
+      assert PageContext.create_for_visit(section, revision.slug, user1).progress_state ==
                :in_progress
 
       # Now we have an "in progress" resource attempt for student 1 with a saved student input,
@@ -141,7 +141,7 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
 
       # Access the graded page with user2
       assert is_nil(Attempts.get_latest_resource_attempt(resource.id, section.slug, user2.id))
-      user2_page_context = PageContext.create_for_visit(section.slug, revision.slug, user2)
+      user2_page_context = PageContext.create_for_visit(section, revision.slug, user2)
       assert user2_page_context.progress_state == :not_started
       assert Enum.count(user2_page_context.resource_attempts) == 0
 


### PR DESCRIPTION
This PR optimizes the render phase for section overview and page display by reducing the number of queries required. 

Specifically, it:
1. Reworks `Core.track_access` to only require one query, and not two.
2. Reworks `Core.get_latest_resource_attempt` to remove the "after the fact" manual preload.

The above eliminates two queries done during every page visit.

It also eliminates the redundant section fetch done in `PageDeliveryController.index`.

There's good unit test coverage here, and I tested manually in my dev environment, so I have high confidence with this change.