### PR TITLE
[MER-503] Invited authors can confirm email and resend confirmation link

### DIFF
--- a/lib/oli/accounts.ex
+++ b/lib/oli/accounts.ex
@@ -14,6 +14,7 @@ defmodule Oli.Accounts do
   alias Oli.Groups.CommunityAccount
   alias Oli.Repo
   alias Oli.Repo.{Paging, Sorting}
+  alias PowEmailConfirmation.Ecto.Context, as: EmailConfirmationContext
 
   def browse_users(
         %Paging{limit: limit, offset: offset},
@@ -612,5 +613,21 @@ defmodule Oli.Accounts do
         select: community
       )
     )
+  end
+
+  @doc """
+  Returns whether the user account is waiting for confirmation or not.
+
+  ## Examples
+
+      iex> user_confirmation_pending?(%{email_confirmation_token: "token", email_confirmed_at: nil})
+      true
+
+      iex> user_confirmation_pending?(%{email_confirmation_token: nil, email_confirmed_at: ~U[2022-01-11 16:54:00Z]})
+      false
+  """
+  def user_confirmation_pending?(user) do
+    EmailConfirmationContext.current_email_unconfirmed?(user, []) or
+      EmailConfirmationContext.pending_email_change?(user, [])
   end
 end

--- a/lib/oli_web/live/users/common.ex
+++ b/lib/oli_web/live/users/common.ex
@@ -1,6 +1,8 @@
 defmodule OliWeb.Users.Common do
   use Surface.LiveComponent
 
+  alias Oli.Accounts
+
   def render(assigns) do
     ~F"""
     <div>nothing</div>
@@ -9,7 +11,12 @@ defmodule OliWeb.Users.Common do
 
   def render_email_column(
         assigns,
-        %{email: email, email_confirmed_at: email_confirmed_at, locked_at: locked_at} = row,
+        %{
+          email: email,
+          email_confirmed_at: email_confirmed_at,
+          invitation_accepted_at: invitation_accepted_at,
+          locked_at: locked_at
+        } = row,
         _
       ) do
     checkmark =
@@ -18,18 +25,34 @@ defmodule OliWeb.Users.Common do
           nil
 
         _ ->
-          if email_confirmed_at == nil do
-            ~F"""
-            <span data-toggle="tooltip" data-html="true" title={"<b>Confirmation Pending</b> sent to #{email}"}>
-              <i class="las la-paper-plane text-secondary"></i>
-            </span>
-            """
-          else
-            ~F"""
-            <span data-toggle="tooltip" data-html="true" title={"<b>Email Confirmed</b> on #{Timex.format!(email_confirmed_at, "{YYYY}-{M}-{D}")}"}>
-              <i class="las la-check text-success"></i>
-            </span>
-            """
+          cond do
+            Accounts.user_confirmation_pending?(row) ->
+              ~F"""
+              <span data-toggle="tooltip" data-html="true" title={"<b>Confirmation Pending</b> sent to #{email}"}>
+                <i class="las la-paper-plane text-secondary"></i>
+              </span>
+              """
+
+            not is_nil(email_confirmed_at) ->
+              ~F"""
+              <span data-toggle="tooltip" data-html="true" title={"<b>Email Confirmed</b> on #{Timex.format!(email_confirmed_at, "{YYYY}-{M}-{D}")}"}>
+                <i class="las la-check text-success"></i>
+              </span>
+              """
+
+            not is_nil(invitation_accepted_at) ->
+              ~F"""
+              <span data-toggle="tooltip" data-html="true" title={"<b>Invitation Accepted</b> on #{Timex.format!(invitation_accepted_at, "{YYYY}-{M}-{D}")}"}>
+                <i class="las la-check text-success"></i>
+              </span>
+              """
+
+            true ->
+              ~F"""
+              <span data-toggle="tooltip" data-html="true" title={"<b>Invitation Pending</b> sent to #{email}"}>
+                <i class="las la-paper-plane text-secondary"></i>
+              </span>
+              """
           end
       end
 

--- a/lib/oli_web/live/users/user_actions.ex
+++ b/lib/oli_web/live/users/user_actions.ex
@@ -1,5 +1,7 @@
 defmodule OliWeb.Users.Actions do
   use Surface.Component
+
+  alias Oli.Accounts
   alias Oli.Accounts.SystemRole
   alias OliWeb.Router.Helpers, as: Routes
 
@@ -28,7 +30,7 @@ defmodule OliWeb.Users.Actions do
           <input type="hidden" name="id" value={@user.id} />
         </form>
 
-        {#if is_nil(@user.email_confirmed_at)}
+        {#if Accounts.user_confirmation_pending?(@user)}
           <button type="submit" class="btn btn-primary" form={"resend-confirmation-#{@user.id}"}>Resend confirmation link</button>
           <button class="btn btn-primary" phx-click="show_confirm_email_modal" phx-value-id={@user.id}>Confirm email</button>
 

--- a/test/oli/accounts_test.exs
+++ b/test/oli/accounts_test.exs
@@ -54,6 +54,16 @@ defmodule Oli.AccountsTest do
       author = insert(:author)
       assert [] == Accounts.search_authors_matching(String.slice(author.email, 0..3))
     end
+
+    test "user_confirmation_pending?/1 returns true when author has not a confirmed account" do
+      non_confirmed_author = insert(:author, email_confirmation_token: "token")
+      assert Accounts.user_confirmation_pending?(non_confirmed_author)
+    end
+
+    test "user_confirmation_pending?/1 returns false when author has a confirmed account" do
+      confirmed_author = insert(:author, email_confirmed_at: Timex.now())
+      refute Accounts.user_confirmation_pending?(confirmed_author)
+    end
   end
 
   describe "users" do

--- a/test/oli_web/live/user_actions_test.exs
+++ b/test/oli_web/live/user_actions_test.exs
@@ -1,0 +1,96 @@
+defmodule OliWeb.UserActionsTest do
+  use OliWeb.ConnCase
+  use Surface.LiveViewTest
+
+  import Oli.Factory
+
+  alias OliWeb.Users.Actions
+
+  describe "email confirmation" do
+    @author_assigns %{csrf_token: "token", for_author: true}
+
+    test "shows email confirmation buttons when author account was created but not confirmed yet" do
+      non_confirmed_author = insert(:author, email_confirmation_token: "token")
+      assigns = %{user: non_confirmed_author, csrf_token: "token", for_author: true}
+
+      html = render_actions(assigns)
+
+      assert html =~ "Resend confirmation link"
+      assert html =~ "Confirm email"
+    end
+
+    test "does not show email confirmation buttons when author account was created and confirmed" do
+      confirmed_author = insert(:author, email_confirmed_at: Timex.now())
+      assigns = Map.put(@author_assigns, :user, confirmed_author)
+
+      html = render_actions(assigns)
+
+      refute html =~ "Resend confirmation link"
+      refute html =~ "Confirm email"
+    end
+
+    test "does not show email confirmation buttons when author was invited by an admin and has not accepted yet" do
+      invited_and_not_accepted_author = insert(:author, invitation_token: "token")
+      assigns = Map.put(@author_assigns, :user, invited_and_not_accepted_author)
+
+      html = render_actions(assigns)
+
+      refute html =~ "Resend confirmation link"
+      refute html =~ "Confirm email"
+    end
+
+    test "does not show email confirmation buttons when author was invited by an admin and accepted" do
+      invited_author =
+        insert(:author, invitation_token: "token", invitation_accepted_at: Timex.now())
+
+      assigns = Map.put(@author_assigns, :user, invited_author)
+
+      html = render_actions(assigns)
+
+      refute html =~ "Resend confirmation link"
+      refute html =~ "Confirm email"
+    end
+
+    test "shows email confirmation buttons when author was invited by an admin and accepted with a different email, but has not confirmed yet" do
+      accepted_with_different_email_author =
+        insert(:author,
+          email_confirmation_token: "token",
+          unconfirmed_email: "other_email",
+          invitation_token: "token",
+          invitation_accepted_at: Timex.now()
+        )
+
+      assigns = Map.put(@author_assigns, :user, accepted_with_different_email_author)
+
+      html = render_actions(assigns)
+
+      assert html =~ "Resend confirmation link"
+      assert html =~ "Confirm email"
+    end
+
+    test "does not show email confirmation buttons when author was invited by an admin and accepted with a different email, and has confirmed his account" do
+      accepted_and_confirmed_with_different_email_author =
+        insert(:author,
+          email_confirmed_at: Timex.now(),
+          invitation_token: "token",
+          invitation_accepted_at: Timex.now()
+        )
+
+      assigns =
+        Map.put(@author_assigns, :user, accepted_and_confirmed_with_different_email_author)
+
+      html = render_actions(assigns)
+
+      refute html =~ "Resend confirmation link"
+      refute html =~ "Confirm email"
+    end
+  end
+
+  defp render_actions(assigns) do
+    render_surface do
+      ~F"""
+      <Actions user={@user} csrf_token={@csrf_token} for_author={@for_author}/>
+      """
+    end
+  end
+end

--- a/test/oli_web/live/user_live_test.exs
+++ b/test/oli_web/live/user_live_test.exs
@@ -1,0 +1,121 @@
+defmodule OliWeb.UserLiveTest do
+  use ExUnit.Case
+  use OliWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+  import Oli.Factory
+
+  @live_view_author_index_route Routes.live_path(OliWeb.Endpoint, OliWeb.Users.AuthorsView)
+
+  describe "user cannot access when is not logged in" do
+    test "redirects to new session when accessing the index view", %{conn: conn} do
+      {:error, {:redirect, %{to: "/authoring/session/new?request_path=%2Fadmin%2Fauthors"}}} =
+        live(conn, @live_view_author_index_route)
+    end
+  end
+
+  describe "user cannot access when is logged in as an author but is not a system admin" do
+    setup [:author_conn]
+
+    test "returns forbidden when accessing the index view", %{conn: conn} do
+      conn = get(conn, @live_view_author_index_route)
+
+      assert response(conn, 403)
+    end
+  end
+
+  describe "index" do
+    setup [:admin_conn]
+
+    test "lists all authors", %{conn: conn, admin: admin} do
+      {:ok, view, _html} = live(conn, @live_view_author_index_route)
+
+      # returns 2 because of the admin account created in the seeds
+      assert render(view) =~ "Showing all results (2 total)"
+
+      assert has_element?(view, "tr, ##{admin.id}")
+    end
+
+    test "shows confirmation pending message when author account was created but not confirmed yet",
+         %{conn: conn} do
+      non_confirmed_author = insert(:author, email_confirmation_token: "token")
+
+      {:ok, view, _html} = live(conn, @live_view_author_index_route)
+
+      assert view
+             |> element("##{non_confirmed_author.id} span[data-toggle=\"tooltip\"")
+             |> render() =~ "Confirmation Pending"
+    end
+
+    test "shows email confirmed message when author account was created and confirmed", %{
+      conn: conn
+    } do
+      confirmed_author = insert(:author, email_confirmed_at: Timex.now())
+      {:ok, view, _html} = live(conn, @live_view_author_index_route)
+
+      assert view
+             |> element("##{confirmed_author.id} span[data-toggle=\"tooltip\"")
+             |> render() =~ "Email Confirmed"
+    end
+
+    test "shows invitation pending message when author was invited by an admin and has not accepted yet",
+         %{conn: conn} do
+      invited_and_not_accepted_author = insert(:author, invitation_token: "token")
+      {:ok, view, _html} = live(conn, @live_view_author_index_route)
+
+      assert view
+             |> element("##{invited_and_not_accepted_author.id} span[data-toggle=\"tooltip\"")
+             |> render() =~ "Invitation Pending"
+    end
+
+    test "shows invitation accepted message when author was invited by an admin and accepted", %{
+      conn: conn
+    } do
+      invited_author =
+        insert(:author, invitation_token: "token", invitation_accepted_at: Timex.now())
+
+      {:ok, view, _html} = live(conn, @live_view_author_index_route)
+
+      assert view
+             |> element("##{invited_author.id} span[data-toggle=\"tooltip\"")
+             |> render() =~ "Invitation Accepted"
+    end
+
+    test "shows confirmation pending message when author was invited by an admin and accepted with a different email, but has not confirmed yet",
+         %{conn: conn} do
+      accepted_with_different_email_author =
+        insert(:author,
+          email_confirmation_token: "token",
+          unconfirmed_email: "other_email",
+          invitation_token: "token",
+          invitation_accepted_at: Timex.now()
+        )
+
+      {:ok, view, _html} = live(conn, @live_view_author_index_route)
+
+      assert view
+             |> element(
+               "##{accepted_with_different_email_author.id} span[data-toggle=\"tooltip\""
+             )
+             |> render() =~ "Confirmation Pending"
+    end
+
+    test "shows email confirmed message when author was invited by an admin and accepted with a different email, and has confirmed his account",
+         %{conn: conn} do
+      accepted_and_confirmed_with_different_email_author =
+        insert(:author,
+          email_confirmed_at: Timex.now(),
+          invitation_token: "token",
+          invitation_accepted_at: Timex.now()
+        )
+
+      {:ok, view, _html} = live(conn, @live_view_author_index_route)
+
+      assert view
+             |> element(
+               "##{accepted_and_confirmed_with_different_email_author.id} span[data-toggle=\"tooltip\""
+             )
+             |> render() =~ "Email Confirmed"
+    end
+  end
+end


### PR DESCRIPTION
[MER-503](https://eliterate.atlassian.net/browse/MER-503)

### Description
There are different states where an author could be depending on if it was invited by an admin or if it created an account by himself. These states are translated into different combinations of the following author fields added by the Pow library: `email_confirmation_token`, `email_confirmed_at`, `unconfirmed_email`, `invitation_token`, `invitation_accepted_at`.

There are some cases where an author is not waiting for email confirmation, and the author details view still allows a sys admin to Resend a confirmation link or to Confirm an author email manually, causing an Internal Server Error when attempting to perform these actions.

**Note**:
The original description in the Jira ticket is not a bug. It is a decision of Pow devs not to send a confirmation link via email when an author was invited by an admin and he accepted the invitation using the same email as the one sent by the admin. A different case is when an author receives an admin invitation and he accepts it but using a different email. In that case he receives another email with a confirmation link.