### PR TITLE
[BUG FIX] Cap score to out of

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Improve performance of initial page visits by introducing bulk insertions of attempts
 - Fix enrollments view rendering problem in sections that require payment
+- Ensure score can never exceed out of for graded pages
 
 ### Enhancements
 

--- a/lib/oli/delivery/attempts/page_lifecycle/graded.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/graded.ex
@@ -171,6 +171,9 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Graded do
       # out_of
       out_of = override_out_of(out_of, resource_attempt.revision.content)
 
+      # cap the score to not exceed the out of
+      score = min(score, out_of)
+
       update_resource_attempt(resource_attempt, %{
         score: score,
         out_of: out_of,
@@ -211,6 +214,9 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Graded do
       DeliveryResolver.from_resource_id(section_slug, access.resource_id)
 
     %Result{score: score, out_of: out_of} = Scoring.calculate_score(strategy_id, graded_attempts)
+
+    # Again, cap the score to never exceed the out_of.
+    score = min(score, out_of)
 
     update_resource_access(access, %{
       score: score,

--- a/test/oli/delivery/attempts/graded_test.exs
+++ b/test/oli/delivery/attempts/graded_test.exs
@@ -1,0 +1,14 @@
+defmodule Oli.Delivery.Attempts.GradingTest do
+  use ExUnit.Case, async: true
+  alias Oli.Delivery.Attempts.PageLifecycle.Graded
+  alias Oli.Delivery.Evaluation.Result
+
+  test "ensure valid grade" do
+    assert {0.0, 1.0} == Graded.ensure_valid_grade({-1, -1})
+    assert {1.0, 1.0} == Graded.ensure_valid_grade({10, -1})
+    assert {9.0, 9.0} == Graded.ensure_valid_grade({10, 9})
+    assert {0.0, 1.0} == Graded.ensure_valid_grade({0.0, 0.0})
+
+    assert {0.0, 1.0} = %Result{score: -1.0, out_of: 0.0} |> Graded.ensure_valid_grade()
+  end
+end


### PR DESCRIPTION
Background:

Many reports of "grade passback" problems were being fielded.  In a video demonstrating this failure, a student attempts to finalize a graded adaptive page but the result is the server rendered "Something went wrong" error page (the `error.html` template rendered from `PageDeliveryController` within the `finalize_attempt` function).   The key piece of information from this video, however, was the score that was sent.  Just as the student clicks to submit the assessment, the UI increments their score from `109` to `110`.  Inspection of the other grades in the gradebook show that the maximum of all other student attempts was `109`. 

So the root cause of this failure is the validation logic present in the `ResourceAccess` schema, where it ensures that the `score` can never exceed the `out_of`.  While this is never a problem for basic pages because of the stricter way that the `out_of` is calculated, the adaptive pages simply take a value from the page content to use as the `out_of`. 

Solution:

This PR ensures, for all page types, during finalization that the `score` can never exceed the `out_of` for both resource attempts and overall resource accesses.