### PR TITLE
[CHORE] Pass in github ref to deploy script for disable checks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           command: |
             cd /torus
-            sh deploy.sh ${{ steps.info.outputs.app_version }} ${{ steps.info.outputs.sha_short }}
+            sh deploy.sh -r ${{ github.ref }} ${{ steps.info.outputs.app_version }} ${{ steps.info.outputs.sha_short }}
           host: ${{ steps.info.outputs.deploy_host }}
           user: simon-bot
           key: ${{ secrets.SIMON_BOT_PRIVATE_KEY}}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           command: |
             cd /torus
-            sh deploy.sh ${{ steps.info.outputs.app_version }} ${{ steps.info.outputs.sha_short }}
+            sh deploy.sh -r ${{ github.ref }} ${{ steps.info.outputs.app_version }} ${{ steps.info.outputs.sha_short }}
           host: ${{ steps.info.outputs.deploy_host }}
           user: simon-bot
           key: ${{ secrets.SIMON_BOT_PRIVATE_KEY}}


### PR DESCRIPTION
This PR enables the ability to disable automatic deployments on certain targets using the `deploy.config` file.

To disable a deployment for a particular git ref (branch or tag), set the `DISABLE_DEPLOY_ON_REF` config accordingly.

For example, a `deploy.config` with
```
DISABLE_DEPLOY_ON_REF=refs/heads/master
```
Will prevent any deployments triggered by the `master` branch. See oli-torus-production for related deploy.sh changes.