### PR TITLE
[BUG FIX] optimize part attempt creation

### DIFF
--- a/lib/oli/delivery/attempts/page_lifecycle/hierarchy.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/hierarchy.ex
@@ -109,10 +109,9 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Hierarchy do
   defp query_driven_part_attempt_creation(resource_attempt_id) do
     query = """
       INSERT INTO part_attempts(part_id, activity_attempt_id, attempt_guid, inserted_at, updated_at, hints, attempt_number)
-      SELECT trim('"' FROM p::text), a.id, gen_random_uuid(), now(), now(), '{}'::varchar[], 1
+      SELECT trim('"' FROM (jsonb_path_query(r.content, '$.authoring.parts[*].id'))::text), a.id, gen_random_uuid(), now(), now(), '{}'::varchar[], 1
       FROM activity_attempts as a
       LEFT JOIN revisions as r on a.revision_id = r.id
-      LEFT JOIN LATERAL jsonb_path_query(r.content, '$.authoring.parts[*].id') as p ON TRUE
       WHERE a.resource_attempt_id = $1;
     """
 

--- a/lib/oli/delivery/attempts/page_lifecycle/hierarchy.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/hierarchy.ex
@@ -13,7 +13,6 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Hierarchy do
   import Oli.Delivery.Attempts.Core
   alias Oli.Activities.Realizer.Query.Source
   alias Oli.Resources.Revision
-  alias Oli.Activities.Model
   alias Oli.Activities.Transformers
   alias Oli.Delivery.ActivityProvider.Result
   alias Oli.Delivery.Attempts.PageLifecycle.{VisitContext}
@@ -92,23 +91,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Hierarchy do
     |> optimize_transformed_model()
     |> bulk_create_activity_attempts(right_now, resource_attempt.id)
 
-    # Create the resource ID to attempt database ID mapping
-    id_mapping = create_resource_id_mapping(resource_attempt.id)
-
-    # Create the part attempts, in bulk
-    Enum.map(activity_revisions, fn r ->
-      {:ok, parsed_model} = Model.parse(r.content)
-      create_raw_part_attempts(parsed_model, Map.get(id_mapping, r.resource_id))
-    end)
-    |> List.flatten()
-    |> bulk_create_part_attempts(right_now)
-  end
-
-  defp create_resource_id_mapping(resource_attempt_id) do
-    get_attempt_resource_id_pair(resource_attempt_id)
-    |> Enum.reduce(%{}, fn %{id: id, resource_id: resource_id}, m ->
-      Map.put(m, resource_id, id)
-    end)
+    query_driven_part_attempt_creation(resource_attempt.id)
   end
 
   defp bulk_create_activity_attempts(raw_attempts, now, resource_attempt_id) do
@@ -121,14 +104,19 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Hierarchy do
     Repo.insert_all(ActivityAttempt, raw_attempts, placeholders: placeholders)
   end
 
-  defp bulk_create_part_attempts(raw_attempts, now) do
-    placeholders = %{
-      now: now,
-      attempt_number: 1,
-      hints: []
-    }
+  # This is the optimal way to bulk create part attempts: passing a query driven 'insert'
+  # to the database, instead of passing the raw payload of each record to create.
+  defp query_driven_part_attempt_creation(resource_attempt_id) do
+    query = """
+      INSERT INTO part_attempts(part_id, activity_attempt_id, attempt_guid, inserted_at, updated_at, hints, attempt_number)
+      SELECT trim('"' FROM p::text), a.id, gen_random_uuid(), now(), now(), '{}'::varchar[], 1
+      FROM activity_attempts as a
+      LEFT JOIN revisions as r on a.revision_id = r.id
+      LEFT JOIN LATERAL jsonb_path_query(r.content, '$.authoring.parts[*].id') as p ON TRUE
+      WHERE a.resource_attempt_id = $1;
+    """
 
-    Repo.insert_all(PartAttempt, raw_attempts, placeholders: placeholders)
+    Repo.query!(query, [resource_attempt_id])
   end
 
   # If all of the transformed_model attrs are nil, we do not need to include them in
@@ -161,20 +149,6 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Hierarchy do
       inserted_at: {:placeholder, :now},
       updated_at: {:placeholder, :now}
     }
-  end
-
-  defp create_raw_part_attempts(parsed_model, activity_attempt_id) do
-    Enum.map(parsed_model.parts, fn p ->
-      %{
-        hints: {:placeholder, :hints},
-        attempt_guid: UUID.uuid4(),
-        activity_attempt_id: activity_attempt_id,
-        attempt_number: {:placeholder, :attempt_number},
-        part_id: p.id,
-        inserted_at: {:placeholder, :now},
-        updated_at: {:placeholder, :now}
-      }
-    end)
   end
 
   @doc """

--- a/test/oli/delivery/attempts/hiearchy_test.exs
+++ b/test/oli/delivery/attempts/hiearchy_test.exs
@@ -1,0 +1,134 @@
+defmodule Oli.Delivery.Attempts.PageLifecycle.HierarchyTest do
+  use Oli.DataCase
+
+  alias Oli.Delivery.Attempts.Core, as: Attempts
+  alias Oli.Delivery.Attempts.PageLifecycle.{Hierarchy, VisitContext, AttemptState}
+
+  describe "creating the attempt tree records" do
+    setup do
+      content1 = %{
+        "stem" => "1",
+        "authoring" => %{
+          "parts" => [
+            %{
+              "id" => "1",
+              "responses" => [],
+              "scoringStrategy" => "best",
+              "evaluationStrategy" => "regex"
+            }
+          ]
+        }
+      }
+
+      content2 = %{
+        "stem" => "2",
+        "authoring" => %{
+          "parts" => [
+            %{
+              "id" => "some_key",
+              "responses" => [],
+              "scoringStrategy" => "best",
+              "evaluationStrategy" => "regex"
+            },
+            %{
+              "id" => "some_other_key",
+              "responses" => [],
+              "scoringStrategy" => "best",
+              "evaluationStrategy" => "regex"
+            }
+          ]
+        }
+      }
+
+      map =
+        Seeder.base_project_with_resource2()
+        |> Seeder.create_section()
+        |> Seeder.add_objective("objective one", :o1)
+        |> Seeder.add_activity(%{title: "one", content: content1}, :a1)
+        |> Seeder.add_activity(%{title: "two", content: content2}, :a2)
+        |> Seeder.add_user(%{}, :user1)
+        |> Seeder.add_user(%{}, :user2)
+
+      attrs = %{
+        title: "page1",
+        content: %{
+          "model" => [
+            %{"type" => "activity-reference", "activity_id" => Map.get(map, :a1).resource.id},
+            %{"type" => "activity-reference", "activity_id" => Map.get(map, :a2).resource.id}
+          ]
+        },
+        objectives: %{"attached" => [Map.get(map, :o1).resource.id]},
+        graded: true
+      }
+
+      Seeder.add_page(map, attrs, :p1)
+      |> Seeder.create_section_resources()
+    end
+
+    test "create the attempt tree", %{
+      p1: p1,
+      user1: user,
+      section: section,
+      a1: a1,
+      a2: a2,
+      publication: pub
+    } do
+      Attempts.track_access(p1.resource.id, section.id, user.id)
+
+      activity_provider = &Oli.Delivery.ActivityProvider.provide/3
+
+      {:ok, resource_attempt} =
+        Hierarchy.create(%VisitContext{
+          latest_resource_attempt: nil,
+          page_revision: p1.revision,
+          section_slug: section.slug,
+          user_id: user.id,
+          activity_provider: activity_provider,
+          blacklisted_activity_ids: [],
+          publication_id: pub.id
+        })
+
+      # verify that creating the attempt tree returns both activity attempts
+      {:ok, %AttemptState{resource_attempt: resource_attempt, attempt_hierarchy: attempts}} =
+        AttemptState.fetch_attempt_state(resource_attempt, p1.revision)
+
+      assert Map.has_key?(attempts, a1.resource.id)
+      assert Map.has_key?(attempts, a2.resource.id)
+
+      # verify that reading the latest attempts back from the db gives us
+      # the same results
+      attempts = Hierarchy.get_latest_attempts(resource_attempt.id)
+      assert Map.has_key?(attempts, a1.resource.id)
+      assert Map.has_key?(attempts, a2.resource.id)
+
+      {act_attempt1, part_map1} = Map.get(attempts, a1.resource.id)
+      {act_attempt2, part_map2} = Map.get(attempts, a2.resource.id)
+
+      pa1 = Map.get(part_map1, "1")
+      pa2 = Map.get(part_map2, "some_key")
+      pa3 = Map.get(part_map2, "some_other_key")
+
+      assert pa1.activity_attempt_id == act_attempt1.id
+      assert pa2.activity_attempt_id == act_attempt2.id
+      assert pa3.activity_attempt_id == act_attempt2.id
+
+      assert %{attempt_number: 1, part_id: "1", hints: []} = pa1
+
+      assert %{
+               attempt_number: 1,
+               part_id: "some_key",
+               hints: []
+             } = pa2
+
+      assert %{
+               attempt_number: 1,
+               part_id: "some_other_key",
+               hints: []
+             } = pa3
+
+      assert pa1.attempt_guid != pa2.attempt_guid
+      assert pa3.attempt_guid != pa2.attempt_guid
+      assert pa3.attempt_guid != pa1.attempt_guid
+    end
+  end
+end


### PR DESCRIPTION
Recent performance tests show that "first attempt renders" of large adaptive pages, particularly under system load, can result in the bulk part attempt creation insert query taking 15-20 seconds.  This, of course, ruins the end user experience and greatly impacts the system under load. 

This PR eliminates the "payload" based insert in favor of a query driven bulk insert.  Testing this out initially via PgAdmin, I see even for an adaptive page with 800 or so part attempts that this insert query takes around `53ms` to execute.  
