### PR TITLE
MER-671 Update AWS REGION after deploy findings

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -138,7 +138,7 @@ config :lti_1p3,
 config :ex_aws,
   access_key_id: [{:system, "AWS_ACCESS_KEY_ID"}, :instance_role],
   secret_access_key: [{:system, "AWS_SECRET_ACCESS_KEY"}, :instance_role],
-  region: System.get_env("AWS_REGION", "us-east-1")
+  region: [{:system, "AWS_REGION"}, :instance_role]
 
 # Configures Elixir's Logger
 config :logger, :console,


### PR DESCRIPTION
Update to ExAWS specific syntax. Still defaults to us-east-1

`region =
      (Map.get(overrides, :region) ||
         Map.get(service_config, :region) ||
         Map.get(common_config, :region) ||
         "us-east-1")`