### PR TITLE
[BUGFIX] [MER-672] Fix footer overlap

### DIFF
--- a/assets/styles/authoring/layout/default.scss
+++ b/assets/styles/authoring/layout/default.scss
@@ -1,0 +1,6 @@
+.default {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  padding-bottom: 40px;
+}

--- a/assets/styles/authoring/layout/default.scss
+++ b/assets/styles/authoring/layout/default.scss
@@ -1,6 +1,7 @@
 .default {
   display: flex;
   flex-direction: column;
+  flex-grow: 1;
   position: relative;
   padding-bottom: 40px;
 }

--- a/lib/oli_web/templates/layout/default.html.eex
+++ b/lib/oli_web/templates/layout/default.html.eex
@@ -4,7 +4,7 @@
   Skip Navigation
 </a>
 
-<div>
+<div class="default">
   <%= render OliWeb.LayoutView, "_header.html", assigns %>
 
   <main role="main" id="main-content">


### PR DESCRIPTION
I lost that style when adding the changes here and it's necessary to keep the footer at the bottom when the page is pretty much empty

## Update 01/18
Original bug: https://eliterate.atlassian.net/browse/MER-672

The changes were reverted in master but adding the `flex-grow: 1` style fixes what those changes break.