### PR TITLE
PMP-2430: fixes history navigation arrows missing, feedback displaced

### DIFF
--- a/assets/src/apps/delivery/layouts/deck/DeckLayoutFooter.tsx
+++ b/assets/src/apps/delivery/layouts/deck/DeckLayoutFooter.tsx
@@ -525,8 +525,6 @@ const DeckLayoutFooter: React.FC = () => {
   const containerWidth =
     currentActivity?.custom?.width || currentPage?.custom?.defaultScreenWidth || 1100;
 
-  const containerClasses = ['checkContainer', 'rowRestriction', 'columnRestriction'];
-
   // effects
   useEffect(() => {
     // legacy usage expects the feedback header to be handled
@@ -559,7 +557,10 @@ const DeckLayoutFooter: React.FC = () => {
 
   return (
     <>
-      <div className={containerClasses.join(' ')} style={{ width: containerWidth }}>
+      <div
+        className={`checkContainer rowRestriction columnRestriction`}
+        style={{ width: containerWidth }}
+      >
         <NextButton
           isLoading={isLoading || !initPhaseComplete}
           text={nextButtonText}
@@ -569,16 +570,33 @@ const DeckLayoutFooter: React.FC = () => {
           isFeedbackIconDisplayed={displayFeedbackIcon}
           showCheckBtn={currentActivity?.custom?.showCheckBtn}
         />
-        <FeedbackContainer
-          minimized={!displayFeedback}
-          showIcon={displayFeedbackIcon}
-          showHeader={displayFeedbackHeader}
-          onMinimize={() => setDisplayFeedback(false)}
-          onMaximize={() => setDisplayFeedback(true)}
-          feedbacks={currentFeedbacks}
-        />
-        <HistoryNavigation />
+        {!isLegacyTheme && (
+          <>
+            <FeedbackContainer
+              minimized={!displayFeedback}
+              showIcon={displayFeedbackIcon}
+              showHeader={displayFeedbackHeader}
+              onMinimize={() => setDisplayFeedback(false)}
+              onMaximize={() => setDisplayFeedback(true)}
+              feedbacks={currentFeedbacks}
+            />
+            <HistoryNavigation />
+          </>
+        )}
+        {isLegacyTheme && <HistoryNavigation />}
       </div>
+      {isLegacyTheme && (
+        <>
+          <FeedbackContainer
+            minimized={!displayFeedback}
+            showIcon={displayFeedbackIcon}
+            showHeader={displayFeedbackHeader}
+            onMinimize={() => setDisplayFeedback(false)}
+            onMaximize={() => setDisplayFeedback(true)}
+            feedbacks={currentFeedbacks}
+          />
+        </>
+      )}
       <EverappContainer apps={currentPage?.custom?.everApps || []} />
     </>
   );

--- a/assets/src/apps/delivery/layouts/deck/DeckLayoutFooter.tsx
+++ b/assets/src/apps/delivery/layouts/deck/DeckLayoutFooter.tsx
@@ -571,19 +571,16 @@ const DeckLayoutFooter: React.FC = () => {
           showCheckBtn={currentActivity?.custom?.showCheckBtn}
         />
         {!isLegacyTheme && (
-          <>
-            <FeedbackContainer
-              minimized={!displayFeedback}
-              showIcon={displayFeedbackIcon}
-              showHeader={displayFeedbackHeader}
-              onMinimize={() => setDisplayFeedback(false)}
-              onMaximize={() => setDisplayFeedback(true)}
-              feedbacks={currentFeedbacks}
-            />
-            <HistoryNavigation />
-          </>
+          <FeedbackContainer
+            minimized={!displayFeedback}
+            showIcon={displayFeedbackIcon}
+            showHeader={displayFeedbackHeader}
+            onMinimize={() => setDisplayFeedback(false)}
+            onMaximize={() => setDisplayFeedback(true)}
+            feedbacks={currentFeedbacks}
+          />
         )}
-        {isLegacyTheme && <HistoryNavigation />}
+        <HistoryNavigation />
       </div>
       {isLegacyTheme && (
         <>

--- a/assets/src/apps/delivery/layouts/deck/DeckLayoutFooter.tsx
+++ b/assets/src/apps/delivery/layouts/deck/DeckLayoutFooter.tsx
@@ -569,33 +569,16 @@ const DeckLayoutFooter: React.FC = () => {
           isFeedbackIconDisplayed={displayFeedbackIcon}
           showCheckBtn={currentActivity?.custom?.showCheckBtn}
         />
-        {!isLegacyTheme && (
-          <>
-            <FeedbackContainer
-              minimized={!displayFeedback}
-              showIcon={displayFeedbackIcon}
-              showHeader={displayFeedbackHeader}
-              onMinimize={() => setDisplayFeedback(false)}
-              onMaximize={() => setDisplayFeedback(true)}
-              feedbacks={currentFeedbacks}
-            />
-            <HistoryNavigation />
-          </>
-        )}
+        <FeedbackContainer
+          minimized={!displayFeedback}
+          showIcon={displayFeedbackIcon}
+          showHeader={displayFeedbackHeader}
+          onMinimize={() => setDisplayFeedback(false)}
+          onMaximize={() => setDisplayFeedback(true)}
+          feedbacks={currentFeedbacks}
+        />
+        <HistoryNavigation />
       </div>
-      {isLegacyTheme && (
-        <>
-          <FeedbackContainer
-            minimized={!displayFeedback}
-            showIcon={displayFeedbackIcon}
-            showHeader={displayFeedbackHeader}
-            onMinimize={() => setDisplayFeedback(false)}
-            onMaximize={() => setDisplayFeedback(true)}
-            feedbacks={currentFeedbacks}
-          />
-          <HistoryNavigation />
-        </>
-      )}
       <EverappContainer apps={currentPage?.custom?.everApps || []} />
     </>
   );

--- a/assets/src/apps/delivery/layouts/deck/components/FeedbackContainer.tsx
+++ b/assets/src/apps/delivery/layouts/deck/components/FeedbackContainer.tsx
@@ -1,5 +1,6 @@
 import { getLocalizedStateSnapshot } from 'adaptivity/scripting';
 import { selectCurrentActivityTree } from 'apps/delivery/store/features/groups/selectors/deck';
+import { selectIsLegacyTheme } from 'apps/delivery/store/features/page/slice';
 import React from 'react';
 import { useSelector } from 'react-redux';
 import FeedbackRenderer from './FeedbackRenderer';
@@ -24,6 +25,8 @@ const FeedbackContainer: React.FC<FeedbackContainerProps> = ({
   const currentActivityTree = useSelector(selectCurrentActivityTree);
   const currentActivityIds = (currentActivityTree || []).map((activity) => activity.id);
 
+  const isLegacyTheme = useSelector(selectIsLegacyTheme);
+
   const handleToggleFeedback = () => {
     if (minimized) {
       onMaximize();
@@ -37,7 +40,10 @@ const FeedbackContainer: React.FC<FeedbackContainerProps> = ({
   };
 
   return (
-    <div className="feedbackContainer rowRestriction" style={{ top: 525 }}>
+    <div
+      className={`feedbackContainer rowRestriction ${isLegacyTheme ? 'columnRestriction' : ''}`}
+      style={{ top: '525px' }}
+    >
       <div className={`bottomContainer fixed ${minimized ? 'minimized' : ''}`}>
         <button
           onClick={handleToggleFeedback}


### PR DESCRIPTION
Problem was due to the way `legacyLessons` did not nest the feedback, history, and nav containers within `checkContainer`. Tested in a few lessons where `isLegacyLesson` is `true`. 

![image](https://user-images.githubusercontent.com/633004/149839611-594f2148-488b-431a-9bbd-1be419433dc6.png)
