### PR TITLE
[BUG FIX] Handle multiple payment attempts, fix payment_date sorting CMU-431 CMU-430 CMU-432

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Improve performance of initial page visits by introducing bulk insertions of attempts
 - Fix enrollments view rendering problem in sections that require payment
 - Ensure score can never exceed out of for graded pages
+- Ensure multiple payment attempts is handled correctly
 
 ### Enhancements
 

--- a/lib/oli/delivery/paywall.ex
+++ b/lib/oli/delivery/paywall.ex
@@ -260,7 +260,12 @@ defmodule Oli.Delivery.Paywall do
       %{id: id} ->
         case Repo.get_by(Payment, enrollment_id: id) do
           nil ->
-            update_payment(payment, %{enrollment_id: id, application_date: DateTime.utc_now()})
+            update_payment(payment, %{
+              enrollment_id: id,
+              pending_user_id: user.id,
+              pending_section_id: section.id,
+              application_date: DateTime.utc_now()
+            })
 
           _ ->
             {:error, {:already_paid}}
@@ -307,6 +312,42 @@ defmodule Oli.Delivery.Paywall do
       )
 
     Repo.one(query)
+  end
+
+  @doc """
+  Creates a new pending payment, ensuring that no other payments exists for this user
+  and section.
+  """
+  def create_pending_payment(%User{id: user_id}, %Section{id: section_id}, attrs) do
+    Oli.Repo.transaction(fn _ ->
+      query =
+        from(
+          p in Payment,
+          where: p.pending_section_id == ^section_id and p.pending_user_id == ^user_id
+        )
+
+      case Oli.Repo.one(query) do
+        # No payment record found for this user in this section
+        nil ->
+          case create_payment(
+                 Map.merge(attrs, %{pending_user_id: user_id, pending_section_id: section_id})
+               ) do
+            {:ok, r} -> r
+            {:error, e} -> Oli.Repo.rollback(e)
+          end
+
+        # A payment found, but this payment was never finalized. We will reuse this
+        # payment record.
+        %Payment{enrollment_id: nil, application_date: nil} = p ->
+          case update_payment(p, attrs) do
+            {:ok, r} -> r
+            {:error, e} -> Oli.Repo.rollback(e)
+          end
+
+        _ ->
+          Oli.Repo.rollback({:payment_already_exists})
+      end
+    end)
   end
 
   @doc """

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -104,6 +104,8 @@ defmodule Oli.Delivery.Sections do
     query =
       case field do
         :enrollment_date -> order_by(query, [e, _, _], {^direction, e.inserted_at})
+        :payment_date -> order_by(query, [_, _, p], {^direction, p.application_date})
+        :payment_id -> order_by(query, [_, _, p], {^direction, p.id})
         _ -> order_by(query, [_, u, _], {^direction, field(u, ^field)})
       end
 
@@ -1354,8 +1356,8 @@ defmodule Oli.Delivery.Sections do
   Converts a section's start_date and end_date to the gievn timezone's local datetimes
   """
   def localize_section_start_end_datetimes(
-         %Section{start_date: start_date, end_date: end_date, timezone: timezone} = section
-       ) do
+        %Section{start_date: start_date, end_date: end_date, timezone: timezone} = section
+      ) do
     timezone = Timex.Timezone.get(timezone, Timex.now())
 
     start_date =
@@ -1374,5 +1376,4 @@ defmodule Oli.Delivery.Sections do
     |> Map.put(:start_date, start_date)
     |> Map.put(:end_date, end_date)
   end
-
 end

--- a/test/oli/delivery/paywall/providers/stripe_test.exs
+++ b/test/oli/delivery/paywall/providers/stripe_test.exs
@@ -5,6 +5,9 @@ defmodule Oli.Delivery.Paywall.Providers.StripeTest do
   alias Oli.Delivery.{Sections, Paywall}
   alias Oli.Delivery.Paywall.Providers.Stripe
   alias Lti_1p3.Tool.ContextRoles
+  alias Oli.Delivery.Sections
+  alias Oli.Repo.{Paging, Sorting}
+  alias Oli.Delivery.Sections.{EnrollmentBrowseOptions}
 
   import Ecto.Query, warn: false
 
@@ -168,6 +171,21 @@ defmodule Oli.Delivery.Paywall.Providers.StripeTest do
       e = Oli.Repo.get!(Oli.Delivery.Sections.Enrollment, finalized.enrollment_id)
       assert e.user_id == user.id
       assert e.section_id == section.id
+
+      results =
+        Sections.browse_enrollments(
+          section,
+          %Paging{offset: 0, limit: 3},
+          %Sorting{field: :email, direction: :asc},
+          %EnrollmentBrowseOptions{
+            is_student: false,
+            is_instructor: false,
+            text_search: nil
+          }
+        )
+
+      assert Enum.count(results) == 1
+      refute is_nil(hd(results).payment_date)
     end
 
     test "double finalization fails", %{section: section, product: product, user1: user} do


### PR DESCRIPTION
This PR accomplishes the following:

1. Fixes the sorting of the "Paid On" column within the Enrollments view.  The browse enrollments query just wasn't handling this field explicitly.  Unit testing has been expanded to verify this.
2. Ensures that in order to initiate a Stripe payment intent, that the user in the session is actually enrolled in the course section.  Running in Prod revealed a case where a user with multiple accounts (one LMS and one Independent) ended up initializing a payment for one section with their wrong user.  
3. Explicitly handle the case that somehow a user initializes a second payment before the first has finalized.  Previous to this PR, it was possible for this to happen, resulting in two Payment records being created.  This impl now will identify this case and if the first payment is still pending, will re-use that record, thus preventing the second record from being created.  If the first record is finalized, a second intent attempt will be rejected.

Closes #2108 
Closes #2109 
Closes #2110 

