### PR TITLE
[BUG FIX] fix ex_aws configuration issue

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -135,11 +135,6 @@ config :lti_1p3,
     ]
   ]
 
-config :ex_aws,
-  access_key_id: [{:system, "AWS_ACCESS_KEY_ID"}, :instance_role],
-  secret_access_key: [{:system, "AWS_SECRET_ACCESS_KEY"}, :instance_role],
-  region: [{:system, "AWS_REGION"}, :instance_role]
-
 # Configures Elixir's Logger
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -153,3 +153,7 @@ config :phoenix, :plug_init_mode, :runtime
 config :joken, default_signer: "secret"
 
 config :appsignal, :config, active: false
+
+# Configure AWS
+config :ex_aws,
+  region: System.get_env("AWS_REGION", "us-east-1")

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -186,6 +186,10 @@ config :oli, :footer,
   link_2_location: System.get_env("FOOTER_LINK_2_LOCATION", ""),
   link_2_text: System.get_env("FOOTER_LINK_2_TEXT", "")
 
+# Configure AWS
+config :ex_aws,
+  region: System.get_env("AWS_REGION", "us-east-1")
+
 # ## Using releases (Elixir v1.9+)
 #
 # If you are doing OTP releases, you need to instruct Phoenix

--- a/lib/oli_web/controllers/api/media_controller.ex
+++ b/lib/oli_web/controllers/api/media_controller.ex
@@ -205,11 +205,15 @@ defmodule OliWeb.Api.MediaController do
     case Base.decode64(file) do
       {:ok, contents} ->
         case MediaLibrary.add(project_slug, name, contents) do
-          {:ok, %MediaItem{} = item} -> json(conn, %{type: "success", url: item.url})
-          {:error, error} -> error(conn, 400, error)
+          {:ok, %MediaItem{} = item} ->
+            json(conn, %{type: "success", url: item.url})
+
+          {:error, error} ->
+            {_id, err_msg} = Oli.Utils.log_error("failed to add media", error)
+            error(conn, 400, err_msg)
         end
 
-      :error ->
+      _ ->
         error(conn, 400, "invalid encoded file")
     end
   end


### PR DESCRIPTION
This PR fixes an issue where email SES and media uploads not working due to ex_aws configuration issue. The configurations have been move from compile-time to dev.exs and releases.exs.

According to the ex_aws [docs](https://github.com/ex-aws/ex_aws), ExAws by default does the equivalent of:
```
config :ex_aws,
  access_key_id: [{:system, "AWS_ACCESS_KEY_ID"}, :instance_role],
  secret_access_key: [{:system, "AWS_SECRET_ACCESS_KEY"}, :instance_role]
```

So these values are unnecessary in the config (verified by testing torus without them). In order to support regions, the region config remains configurable via AWS_REGION env variable in dev and release environments.