### PR TITLE
[BUG FIX] Fix error handling in stripe controller finalization

### DIFF
--- a/lib/oli_web/controllers/payment_providers/stripe_controller.ex
+++ b/lib/oli_web/controllers/payment_providers/stripe_controller.ex
@@ -75,8 +75,8 @@ defmodule OliWeb.PaymentProviders.StripeController do
           reason: reason
         })
 
-      e ->
-        Logger.error("StripeController could not finalize payment", e)
+      _ ->
+        Logger.error("StripeController could not finalize payment")
 
         json(conn, %{
           result: "failure",

--- a/lib/oli_web/controllers/payment_providers/stripe_controller.ex
+++ b/lib/oli_web/controllers/payment_providers/stripe_controller.ex
@@ -67,12 +67,20 @@ defmodule OliWeb.PaymentProviders.StripeController do
           url: Routes.page_delivery_path(conn, :index, slug)
         })
 
-      {:error, reason} ->
-        Logger.error("StripeController could not finalize payment", reason)
+      {:error, reason} when is_binary(reason) ->
+        Logger.error("StripeController could not finalize payment: #{reason}")
 
         json(conn, %{
           result: "failure",
           reason: reason
+        })
+
+      e ->
+        Logger.error("StripeController could not finalize payment", e)
+
+        json(conn, %{
+          result: "failure",
+          reason: "Could not finalize payment"
         })
     end
   end

--- a/lib/oli_web/controllers/payment_providers/stripe_controller.ex
+++ b/lib/oli_web/controllers/payment_providers/stripe_controller.ex
@@ -128,9 +128,13 @@ defmodule OliWeb.PaymentProviders.StripeController do
 
             json(conn, %{clientSecret: client_secret})
 
-          {:error, reason} ->
-            Logger.error("StripeController:init_intent failed", reason)
+          {:error, reason} when is_binary(reason) ->
+            Logger.error("StripeController:init_intent failed. #{reason}")
             error(conn, 500, reason)
+
+          _ ->
+            Logger.error("StripeController:init_intent failed.")
+            error(conn, 500, "Intent creation failed")
         end
       else
         e ->


### PR DESCRIPTION
AppSignal reports:

```
** (Protocol.UndefinedError) protocol Enumerable not implemented for "Payment already finalized" of type BitString. This protocol is implemented for the following type(s): Ecto.Adapters.SQL.Stream, Postgrex.Stream, DBConnection.Stream, DBConnection.PrepareStream, Timex.Interval, Floki.HTMLTree, File.Stream, Map, Date.Range, Function, HashSet, Range, IO.Stream, List, MapSet, HashDict, GenEvent.Stream, Stream
```

