### PR TITLE
[BUG FIX] Fixes logo in email templates

### DIFF
--- a/lib/oli/branding.ex
+++ b/lib/oli/branding.ex
@@ -12,6 +12,7 @@ defmodule Oli.Branding do
   alias Oli.Delivery.Sections.Section
   alias Oli.Lti_1p3.Tool.Deployment
   alias Oli.Institutions.Institution
+  alias Oli.Utils
 
   @doc """
   Returns the list of brands.
@@ -156,11 +157,19 @@ defmodule Oli.Branding do
   end
 
   def brand_logo_url(section \\ nil) do
+    Utils.get_base_url() <> brand_logo_path(section)
+  end
+
+  def brand_logo_url_dark(section \\ nil) do
+    Utils.get_base_url() <> brand_logo_path_dark(section)
+  end
+
+  def brand_logo_path(section \\ nil) do
     brand_with_defaults(section)
     |> Map.get(:logo)
   end
 
-  def brand_logo_url_dark(section \\ nil) do
+  def brand_logo_path_dark(section \\ nil) do
     brand_with_defaults(section)
     |> Map.get(:logo_dark)
   end

--- a/lib/oli_web/templates/email/_header.html.eex
+++ b/lib/oli_web/templates/email/_header.html.eex
@@ -1,7 +1,7 @@
 <tr>
     <a class="navbar-brand torus-logo" href="<%= Routes.static_page_url(OliWeb.Endpoint, :index) %>">
         <td style="padding: 20px 0; text-align: center">
-            <img src="<%=Oli.Branding.brand_logo_url()%>" width="277" height="100" alt="torus-logo" border="0" style="height: auto;">
+            <img src="<%= Oli.Branding.brand_logo_url() %>" width="277" height="100" alt="torus-logo" border="0" style="height: auto;">
         </td>
     </a>
 </tr>

--- a/test/oli/branding_test.exs
+++ b/test/oli/branding_test.exs
@@ -8,15 +8,15 @@ defmodule Oli.BrandingTest do
     alias Oli.Branding.Brand
 
     @valid_attrs %{
-      favicons: "some favicons",
-      logo: "some logo",
-      logo_dark: "some logo_dark",
+      favicons: "/some_favicons",
+      logo: "/some_logo",
+      logo_dark: "/some_logo_dark",
       name: "some name"
     }
     @update_attrs %{
-      favicons: "some updated favicons",
-      logo: "some updated logo",
-      logo_dark: "some updated logo_dark",
+      favicons: "/some_updated_favicons",
+      logo: "/some_updated_logo",
+      logo_dark: "/some_updated_logo_dark",
       name: "some updated name"
     }
     @invalid_attrs %{favicons: nil, logo: nil, logo_dark: nil, name: nil}
@@ -42,9 +42,9 @@ defmodule Oli.BrandingTest do
 
     test "create_brand/1 with valid data creates a brand" do
       assert {:ok, %Brand{} = brand} = Branding.create_brand(@valid_attrs)
-      assert brand.favicons == "some favicons"
-      assert brand.logo == "some logo"
-      assert brand.logo_dark == "some logo_dark"
+      assert brand.favicons == "/some_favicons"
+      assert brand.logo == "/some_logo"
+      assert brand.logo_dark == "/some_logo_dark"
       assert brand.name == "some name"
     end
 
@@ -55,9 +55,9 @@ defmodule Oli.BrandingTest do
     test "update_brand/2 with valid data updates the brand" do
       brand = brand_fixture()
       assert {:ok, %Brand{} = brand} = Branding.update_brand(brand, @update_attrs)
-      assert brand.favicons == "some updated favicons"
-      assert brand.logo == "some updated logo"
-      assert brand.logo_dark == "some updated logo_dark"
+      assert brand.favicons == "/some_updated_favicons"
+      assert brand.logo == "/some_updated_logo"
+      assert brand.logo_dark == "/some_updated_logo_dark"
       assert brand.name == "some updated name"
     end
 
@@ -160,13 +160,33 @@ defmodule Oli.BrandingTest do
     end
 
     @tag capture_log: true
+    test "brand_logo_path returns brand logo path", %{section: section} do
+      section_brand = brand_fixture()
+
+      {:ok, section} =
+        Oli.Delivery.Sections.update_section(section, %{brand_id: section_brand.id})
+
+      assert Branding.brand_logo_path(section) == "/some_logo"
+    end
+
+    @tag capture_log: true
+    test "brand_logo_path_dark returns dark mode brand logo path", %{section: section} do
+      section_brand = brand_fixture()
+
+      {:ok, section} =
+        Oli.Delivery.Sections.update_section(section, %{brand_id: section_brand.id})
+
+      assert Branding.brand_logo_path_dark(section) == "/some_logo_dark"
+    end
+
+    @tag capture_log: true
     test "brand_logo_url returns brand logo url", %{section: section} do
       section_brand = brand_fixture()
 
       {:ok, section} =
         Oli.Delivery.Sections.update_section(section, %{brand_id: section_brand.id})
 
-      assert Branding.brand_logo_url(section) == "some logo"
+      assert Branding.brand_logo_url(section) == "#{Oli.Utils.get_base_url()}/some_logo"
     end
 
     @tag capture_log: true
@@ -176,7 +196,7 @@ defmodule Oli.BrandingTest do
       {:ok, section} =
         Oli.Delivery.Sections.update_section(section, %{brand_id: section_brand.id})
 
-      assert Branding.brand_logo_url_dark(section) == "some logo_dark"
+      assert Branding.brand_logo_url_dark(section) == "#{Oli.Utils.get_base_url()}/some_logo_dark"
     end
 
     @tag capture_log: true
@@ -186,7 +206,7 @@ defmodule Oli.BrandingTest do
       {:ok, section} =
         Oli.Delivery.Sections.update_section(section, %{brand_id: section_brand.id})
 
-      assert Branding.favicons("icon.png", section) == "some favicons/icon.png"
+      assert Branding.favicons("icon.png", section) == "/some_favicons/icon.png"
     end
   end
 end


### PR DESCRIPTION
This PR fixes an issue where the url for the logo isn't fully qualified and therefore doesn't appear in emails

Closes #2118