### PR TITLE
[BUG FIX] Make has_paid? more robust AOPS-408

### DIFF
--- a/lib/oli/delivery/paywall.ex
+++ b/lib/oli/delivery/paywall.ex
@@ -38,10 +38,14 @@ defmodule Oli.Delivery.Paywall do
       from(
         p in Payment,
         where: p.enrollment_id == ^id,
+        limit: 1,
         select: p
       )
 
-    !is_nil(Repo.one(query))
+    case Repo.all(query) do
+      [] -> false
+      _ -> true
+    end
   end
 
   defp within_grace_period?(_, %Section{has_grace_period: false}), do: false


### PR DESCRIPTION
A problem with Stripe provider has allowed more than one Payment record to exist for one Enrollment.  While this problem has been prevented with an earlier PR, any system with these "double payments" fails the `Paywall.can_access?` check due to the inner `has_paid?` use of `Repo.one`.   This fix makes the `can_access?` more robust, using `Repo.all` inside of `has_paid?`

There is excellent unit test coverage here, so a high degree of confidence that this works and doesn't cause any side effects. 