### PR TITLE
[BUG FIX] (Near) Optimal hierarchy creation

### DIFF
--- a/lib/oli/delivery/attempts/page_lifecycle/hierarchy.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/hierarchy.ex
@@ -37,6 +37,39 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Hierarchy do
           {attempt.resource_access_id, attempt.attempt_number + 1}
       end
 
+    case context.page_revision do
+      %{content: %{"advancedDelivery" => true}} ->
+        optimized_hierarchy_creation(
+          context,
+          resource_access_id,
+          next_attempt_number
+        )
+
+      _ ->
+        normal_hierarchy_creation(context, resource_access_id, next_attempt_number)
+    end
+  end
+
+  defp optimized_hierarchy_creation(context, resource_access_id, next_attempt_number) do
+    case create_resource_attempt(%{
+           content: context.page_revision.content,
+           errors: [],
+           attempt_guid: UUID.uuid4(),
+           resource_access_id: resource_access_id,
+           attempt_number: next_attempt_number,
+           revision_id: context.page_revision.id
+         }) do
+      {:ok, resource_attempt} ->
+        stored_procedure_driven_hierarchy_creation(resource_attempt.id, context.section_slug)
+
+        {:ok, resource_attempt}
+
+      error ->
+        error
+    end
+  end
+
+  defp normal_hierarchy_creation(context, resource_access_id, next_attempt_number) do
     %Result{
       errors: errors,
       revisions: activity_revisions,
@@ -62,7 +95,9 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Hierarchy do
            revision_id: context.page_revision.id
          }) do
       {:ok, resource_attempt} ->
+        # bulk_create_attempts(resource_attempt, activity_revisions, unscored)
         bulk_create_attempts(resource_attempt, activity_revisions, unscored)
+
         {:ok, resource_attempt}
 
       error ->
@@ -109,13 +144,21 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Hierarchy do
   defp query_driven_part_attempt_creation(resource_attempt_id) do
     query = """
       INSERT INTO part_attempts(part_id, activity_attempt_id, attempt_guid, inserted_at, updated_at, hints, attempt_number)
-      SELECT trim('"' FROM (jsonb_path_query(r.content, '$.authoring.parts[*].id'))::text), a.id, gen_random_uuid(), now(), now(), '{}'::varchar[], 1
+      SELECT pm.part_id, a.id, gen_random_uuid(), now(), now(), '{}'::varchar[], 1
       FROM activity_attempts as a
-      LEFT JOIN revisions as r on a.revision_id = r.id
+      LEFT JOIN part_mapping as pm on a.revision_id = pm.id
       WHERE a.resource_attempt_id = $1;
     """
 
     Repo.query!(query, [resource_attempt_id])
+  end
+
+  defp stored_procedure_driven_hierarchy_creation(resource_attempt_id, section_slug) do
+    query = """
+     CALL create_attempt_hierarchy($1, $2);
+    """
+
+    Repo.query!(query, [resource_attempt_id, section_slug])
   end
 
   # If all of the transformed_model attrs are nil, we do not need to include them in

--- a/lib/oli/delivery/attempts/page_lifecycle/hierarchy.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/hierarchy.ex
@@ -146,7 +146,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Hierarchy do
       INSERT INTO part_attempts(part_id, activity_attempt_id, attempt_guid, inserted_at, updated_at, hints, attempt_number)
       SELECT pm.part_id, a.id, gen_random_uuid(), now(), now(), '{}'::varchar[], 1
       FROM activity_attempts as a
-      LEFT JOIN part_mapping as pm on a.revision_id = pm.id
+      LEFT JOIN part_mapping as pm on a.revision_id = pm.revision_id
       WHERE a.resource_attempt_id = $1;
     """
 

--- a/lib/oli/utils/db_seeder.ex
+++ b/lib/oli/utils/db_seeder.ex
@@ -615,6 +615,22 @@ defmodule Oli.Seeder do
     end
   end
 
+  def ensure_published(publication_id) do
+    case Repo.get(Publication, publication_id) do
+      nil ->
+        true
+
+      %Publication{published: nil} = p ->
+        Oli.Publishing.update_publication(p, %{published: DateTime.utc_now()})
+    end
+
+    query = """
+    REFRESH MATERIALIZED VIEW part_mapping;
+    """
+
+    Oli.Repo.query!(query, [])
+  end
+
   defp create_published_resource(publication, resource, revision) do
     Publishing.create_published_resource(%{
       publication_id: publication.id,

--- a/priv/repo/migrations/20220119121119_optimization_infra.exs
+++ b/priv/repo/migrations/20220119121119_optimization_infra.exs
@@ -1,0 +1,162 @@
+defmodule Oli.Repo.Migrations.OptimizationInfra do
+  use Ecto.Migration
+
+  def up do
+    # drop these items if they somehow happen to exist
+    drop_stored_procedure()
+    drop_trigger()
+    drop_materialized_view()
+
+    create_materialized_view()
+    create_trigger()
+    create_stored_procedure()
+
+    refresh_materialized_view()
+  end
+
+  def down do
+    drop_stored_procedure()
+    drop_trigger()
+    drop_materialized_view()
+  end
+
+  def drop_materialized_view() do
+    execute """
+    DROP MATERIALIZED VIEW IF EXISTS public.part_mapping;
+    """
+  end
+
+  def drop_trigger() do
+    execute """
+    DROP TRIGGER IF EXISTS published_resources_tr ON public.published_resources;
+    """
+
+    execute "DROP FUNCTION IF EXISTS public.refresh_part_mapping() CASCADE;"
+  end
+
+  def drop_stored_procedure() do
+    execute """
+    DROP PROCEDURE IF EXISTS public.create_attempt_hierarchy(integer, character varying);
+    """
+  end
+
+  def create_materialized_view() do
+    execute """
+    CREATE MATERIALIZED VIEW IF NOT EXISTS public.part_mapping
+    TABLESPACE pg_default
+    AS
+    SELECT DISTINCT btrim(jsonb_path_query(r.content, '$."authoring"."parts"[*]."id"'::jsonpath)::text, '"'::text) AS part_id,
+        r.id as revision_id
+      FROM published_resources pr
+        LEFT JOIN publications p ON p.id = pr.publication_id
+        LEFT JOIN revisions r ON r.id = pr.revision_id
+      WHERE r.resource_type_id = 3 AND p.published IS NOT NULL
+      ORDER BY r.id, (btrim(jsonb_path_query(r.content, '$."authoring"."parts"[*]."id"'::jsonpath)::text, '"'::text))
+    WITH DATA;
+    """
+
+    execute """
+    ALTER TABLE IF EXISTS public.part_mapping
+    OWNER TO postgres;
+    """
+
+    execute """
+    CREATE UNIQUE INDEX part_id_revision_id
+    ON public.part_mapping USING btree
+    (part_id COLLATE pg_catalog."default", revision_id)
+    TABLESPACE pg_default;
+    """
+
+    execute """
+    CREATE INDEX revision_id_index
+    ON public.part_mapping USING btree
+    (revision_id)
+    TABLESPACE pg_default;
+    """
+  end
+
+  def create_trigger() do
+    execute """
+    CREATE OR REPLACE FUNCTION public.refresh_part_mapping()
+        RETURNS trigger
+        LANGUAGE 'plpgsql'
+        COST 100
+        VOLATILE NOT LEAKPROOF
+    AS $BODY$
+    BEGIN
+        REFRESH MATERIALIZED VIEW CONCURRENTLY part_mapping;
+        RETURN NULL;
+    END;
+    $BODY$;
+    """
+
+    execute """
+    ALTER FUNCTION public.refresh_part_mapping()
+    OWNER TO postgres;
+    """
+
+    execute """
+    CREATE TRIGGER publications_tr
+        AFTER UPDATE OR DELETE
+        ON public.publications
+        FOR EACH STATEMENT
+        EXECUTE FUNCTION public.refresh_part_mapping();
+    """
+  end
+
+  def create_stored_procedure() do
+    execute """
+    CREATE OR REPLACE PROCEDURE public.create_attempt_hierarchy(
+      resource_attempt_id integer,
+      section_slug character varying)
+    LANGUAGE 'sql'
+    AS $BODY$
+    INSERT INTO activity_attempts(resource_attempt_id, attempt_guid, attempt_number, revision_id, resource_id, scoreable, inserted_at, updated_at)
+    SELECT resource_attempt_id, gen_random_uuid(), 1, sr.id, sr.resource_id, true, now(), now()
+    FROM resource_attempts as r
+    LEFT JOIN LATERAL jsonb_path_query(r.content, '$.** ? (@.type == "activity-reference" && (!(@.custom.isLayer == true || @.custom.isGroup == true)))."activity_id"') as p ON TRUE
+    LEFT JOIN section_resources as secr on secr.resource_id = CAST(p as int)
+    LEFT JOIN sections as s on s.id = secr.section_id
+    LEFT JOIN sections_projects_publications as spp on spp.section_id = s.id
+    LEFT JOIN published_resources as pr on pr.publication_id = spp.publication_id and pr.resource_id = CAST(p as int) and pr.publication_id = spp.publication_id
+    LEFT JOIN revisions as sr on sr.id = pr.revision_id
+    WHERE r.id = resource_attempt_id and s.slug = section_slug
+    UNION
+    SELECT resource_attempt_id, gen_random_uuid(), 1, sr.id, sr.resource_id, false, now(), now()
+    FROM resource_attempts as r
+    LEFT JOIN LATERAL jsonb_path_query(r.content, '$.** ? (@.type == "activity-reference" && (@.custom.isLayer == true || @.custom.isGroup == true))."activity_id"') as p ON TRUE
+    LEFT JOIN section_resources as secr on secr.resource_id = CAST(p as int)
+    LEFT JOIN sections as s on s.id = secr.section_id
+    LEFT JOIN sections_projects_publications as spp on spp.section_id = s.id
+    LEFT JOIN published_resources as pr on pr.publication_id = spp.publication_id and pr.resource_id = CAST(p as int) and pr.publication_id = spp.publication_id
+    LEFT JOIN revisions as sr on sr.id = pr.revision_id
+    WHERE r.id = resource_attempt_id and s.slug = section_slug;
+
+    INSERT INTO part_attempts(part_id, activity_attempt_id, attempt_guid, inserted_at, updated_at, hints, attempt_number)
+    SELECT pm.part_id, a.id, gen_random_uuid(), now(), now(), '{}'::varchar[], 1
+    FROM activity_attempts as a
+    LEFT JOIN part_mapping as pm on a.revision_id = pm.revision_id
+    WHERE a.resource_attempt_id = resource_attempt_id;
+    $BODY$;
+    """
+
+    execute """
+    ALTER PROCEDURE public.create_attempt_hierarchy(integer, character varying)
+        OWNER TO postgres;
+    """
+
+    execute """
+    GRANT EXECUTE ON PROCEDURE public.create_attempt_hierarchy(integer, character varying) TO postgres;
+    """
+
+    execute """
+    GRANT EXECUTE ON PROCEDURE public.create_attempt_hierarchy(integer, character varying) TO PUBLIC;
+    """
+  end
+
+  def refresh_materialized_view() do
+    execute """
+    REFRESH MATERIALIZED VIEW part_mapping;
+    """
+  end
+end

--- a/test/oli/delivery/attempts/hiearchy_test.exs
+++ b/test/oli/delivery/attempts/hiearchy_test.exs
@@ -61,6 +61,8 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.HierarchyTest do
         graded: true
       }
 
+      Seeder.ensure_published(map.publication.id)
+
       Seeder.add_page(map, attrs, :p1)
       |> Seeder.create_section_resources()
     end
@@ -98,6 +100,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.HierarchyTest do
       # verify that reading the latest attempts back from the db gives us
       # the same results
       attempts = Hierarchy.get_latest_attempts(resource_attempt.id)
+
       assert Map.has_key?(attempts, a1.resource.id)
       assert Map.has_key?(attempts, a2.resource.id)
 

--- a/test/oli/delivery/attempts/optimized_hiearchy_test.exs
+++ b/test/oli/delivery/attempts/optimized_hiearchy_test.exs
@@ -1,0 +1,211 @@
+defmodule Oli.Delivery.Attempts.PageLifecycle.OptimizedHierarchyTest do
+  use Oli.DataCase
+
+  alias Oli.Delivery.Attempts.Core, as: Attempts
+  alias Oli.Delivery.Attempts.PageLifecycle.{Hierarchy, VisitContext, AttemptState}
+
+  describe "creating the attempt tree records for adaptive pages" do
+    setup do
+      content1 = %{
+        "stem" => "1",
+        "authoring" => %{
+          "parts" => [
+            %{
+              "id" => "1",
+              "responses" => [],
+              "scoringStrategy" => "best",
+              "evaluationStrategy" => "regex"
+            }
+          ]
+        }
+      }
+
+      content2 = %{
+        "stem" => "2",
+        "authoring" => %{
+          "parts" => [
+            %{
+              "id" => "some_key",
+              "responses" => [],
+              "scoringStrategy" => "best",
+              "evaluationStrategy" => "regex"
+            },
+            %{
+              "id" => "some_other_key",
+              "responses" => [],
+              "scoringStrategy" => "best",
+              "evaluationStrategy" => "regex"
+            }
+          ]
+        }
+      }
+
+      content3 = %{
+        "stem" => "2",
+        "authoring" => %{
+          "parts" => [
+            %{
+              "id" => "final_key",
+              "responses" => [],
+              "scoringStrategy" => "best",
+              "evaluationStrategy" => "regex"
+            }
+          ]
+        }
+      }
+
+      map =
+        Seeder.base_project_with_resource2()
+        |> Seeder.create_section()
+        |> Seeder.add_activity(%{title: "one", content: content1}, :a1)
+        |> Seeder.add_activity(%{title: "two", content: content2}, :a2)
+        |> Seeder.add_activity(%{title: "three", content: content3}, :a3)
+        |> Seeder.add_activity(%{title: "four", content: content3}, :a4)
+        |> Seeder.add_activity(%{title: "five", content: content3}, :a5)
+        |> Seeder.add_activity(%{title: "six", content: content3}, :a6)
+        |> Seeder.add_user(%{}, :user1)
+        |> Seeder.add_user(%{}, :user2)
+
+      attrs = %{
+        title: "page1",
+        content: %{
+          "model" => [
+            %{
+              "type" => "activity-reference",
+              "activity_id" => Map.get(map, :a1).resource.id,
+              "custom" => %{"isLayer" => true}
+            },
+            %{
+              "type" => "activity-reference",
+              "activity_id" => Map.get(map, :a2).resource.id,
+              "custom" => %{"isLayer" => false}
+            },
+            %{"type" => "activity-reference", "activity_id" => Map.get(map, :a3).resource.id},
+            %{
+              "type" => "activity-reference",
+              "activity_id" => Map.get(map, :a4).resource.id,
+              "custom" => %{}
+            },
+            %{
+              "type" => "activity-reference",
+              "activity_id" => Map.get(map, :a5).resource.id,
+              "custom" => %{"isGroup" => true},
+              "children" => [
+                %{
+                  "type" => "activity-reference",
+                  "activity_id" => Map.get(map, :a6).resource.id,
+                  "custom" => %{"isGroup" => false}
+                }
+              ]
+            }
+          ],
+          "advancedDelivery" => true
+        },
+        graded: true
+      }
+
+      Seeder.ensure_published(map.publication.id)
+
+      Seeder.add_page(map, attrs, :p1)
+      |> Seeder.create_section_resources()
+    end
+
+    test "create the attempt tree", %{
+      p1: p1,
+      user1: user,
+      section: section,
+      a1: a1,
+      a2: a2,
+      a3: a3,
+      a4: a4,
+      a5: a5,
+      a6: a6,
+      publication: pub
+    } do
+      Attempts.track_access(p1.resource.id, section.id, user.id)
+
+      activity_provider = &Oli.Delivery.ActivityProvider.provide/3
+
+      {:ok, resource_attempt} =
+        Hierarchy.create(%VisitContext{
+          latest_resource_attempt: nil,
+          page_revision: p1.revision,
+          section_slug: section.slug,
+          user_id: user.id,
+          activity_provider: activity_provider,
+          blacklisted_activity_ids: [],
+          publication_id: pub.id
+        })
+
+      # verify that creating the attempt tree returns both activity attempts
+      {:ok, %AttemptState{resource_attempt: resource_attempt, attempt_hierarchy: attempts}} =
+        AttemptState.fetch_attempt_state(resource_attempt, p1.revision)
+
+      assert Map.has_key?(attempts, a1.resource.id)
+      assert Map.has_key?(attempts, a2.resource.id)
+      assert Map.has_key?(attempts, a3.resource.id)
+      assert Map.has_key?(attempts, a4.resource.id)
+      assert Map.has_key?(attempts, a5.resource.id)
+      assert Map.has_key?(attempts, a6.resource.id)
+
+      # verify that reading the latest attempts back from the db gives us
+      # the same results
+      attempts = Hierarchy.get_latest_attempts(resource_attempt.id)
+
+      assert Map.has_key?(attempts, a1.resource.id)
+      assert Map.has_key?(attempts, a2.resource.id)
+      assert Map.has_key?(attempts, a3.resource.id)
+      assert Map.has_key?(attempts, a4.resource.id)
+      assert Map.has_key?(attempts, a5.resource.id)
+      assert Map.has_key?(attempts, a6.resource.id)
+
+      {act_attempt1, part_map1} = Map.get(attempts, a1.resource.id)
+      {act_attempt2, part_map2} = Map.get(attempts, a2.resource.id)
+      {act_attempt3, part_map3} = Map.get(attempts, a3.resource.id)
+      {act_attempt4, part_map4} = Map.get(attempts, a4.resource.id)
+      {act_attempt5, part_map5} = Map.get(attempts, a5.resource.id)
+      {act_attempt6, part_map6} = Map.get(attempts, a6.resource.id)
+
+      # This is perhaps the most important aspect of this test, as it guarantees that the logic
+      # within the optimized create_attempt_hierarchy stored procedure correctly identifies
+      # all activity references (even nested ones) and correctly categorizes the activity ref
+      # as scoreable or non-scoreable
+      assert act_attempt1.scoreable == false
+      assert act_attempt2.scoreable == true
+      assert act_attempt3.scoreable == true
+      assert act_attempt4.scoreable == true
+      assert act_attempt5.scoreable == false
+      assert act_attempt6.scoreable == true
+
+      pa1 = Map.get(part_map1, "1")
+      pa2a = Map.get(part_map2, "some_key")
+      pa2b = Map.get(part_map2, "some_other_key")
+      pa3 = Map.get(part_map3, "final_key")
+      pa4 = Map.get(part_map4, "final_key")
+      pa5 = Map.get(part_map5, "final_key")
+      pa6 = Map.get(part_map6, "final_key")
+
+      assert pa1.activity_attempt_id == act_attempt1.id
+      assert pa2a.activity_attempt_id == act_attempt2.id
+      assert pa2b.activity_attempt_id == act_attempt2.id
+      assert pa3.activity_attempt_id == act_attempt3.id
+      assert pa4.activity_attempt_id == act_attempt4.id
+      assert pa5.activity_attempt_id == act_attempt5.id
+      assert pa6.activity_attempt_id == act_attempt6.id
+
+      assert %{attempt_number: 1, part_id: "1", hints: []} = pa1
+
+      assert %{
+               attempt_number: 1,
+               part_id: "some_key",
+               hints: []
+             } = pa2a
+
+      assert %{
+               attempt_number: 1,
+               part_id: "some_other_key",
+               hints: []
+             } = pa2b
+    end
+  end
+end

--- a/test/oli/delivery/page/page_context_test.exs
+++ b/test/oli/delivery/page/page_context_test.exs
@@ -46,6 +46,8 @@ defmodule Oli.Delivery.Page.PageContextTest do
         objectives: %{"attached" => []}
       }
 
+      Seeder.ensure_published(map.publication.id)
+
       Seeder.add_page(map, attrs, :p1)
       |> Seeder.create_section_resources()
     end

--- a/test/oli/delivery/submission_test.exs
+++ b/test/oli/delivery/submission_test.exs
@@ -56,6 +56,8 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
         |> Seeder.add_user(%{}, :user1)
         |> Seeder.add_user(%{}, :user2)
 
+      Seeder.ensure_published(map.publication.id)
+
       Seeder.add_page(
         map,
         %{
@@ -232,6 +234,8 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
         |> Seeder.add_activity(%{title: "one", max_attempts: 2, content: content}, :activity)
         |> Seeder.add_user(%{}, :user1)
         |> Seeder.add_user(%{}, :user2)
+
+      Seeder.ensure_published(map.publication.id)
 
       Seeder.add_page(
         map,
@@ -722,6 +726,8 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
         |> Seeder.add_activity(%{title: "one", content: content}, :activity)
         |> Seeder.add_user(%{}, :user1)
 
+      Seeder.ensure_published(map.publication.id)
+
       attrs = %{
         title: "page1",
         content: %{
@@ -888,6 +894,8 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
           :activity
         )
         |> Seeder.add_user(%{}, :user1)
+
+      Seeder.ensure_published(map.publication.id)
 
       attrs = %{
         title: "page1",

--- a/test/oli_web/controllers/page_delivery_controller_test.exs
+++ b/test/oli_web/controllers/page_delivery_controller_test.exs
@@ -229,7 +229,9 @@ defmodule OliWeb.PageDeliveryControllerTest do
         map.author.email
       )
 
-      Oli.Publishing.publish_project(project, "some changes")
+      {:ok, pub} = Oli.Publishing.publish_project(project, "some changes")
+      Sections.update_section_project_publication(section, project.id, pub.id)
+      Oli.Delivery.Sections.rebuild_section_resources(section: section, publication: pub)
 
       # now visit the page again, verifying that we are able to resume the original graded attempt
       # even through the page has been changed to ungraded
@@ -300,7 +302,9 @@ defmodule OliWeb.PageDeliveryControllerTest do
         map.author.email
       )
 
-      Oli.Publishing.publish_project(project, "some changes")
+      {:ok, pub} = Oli.Publishing.publish_project(project, "some changes")
+      Sections.update_section_project_publication(section, project.id, pub.id)
+      Oli.Delivery.Sections.rebuild_section_resources(section: section, publication: pub)
 
       # Visit the page in its ungraded state, thus generating a resource attempt
       conn = get(conn, Routes.page_delivery_path(conn, :page, section.slug, page_revision.slug))
@@ -330,6 +334,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       )
 
       {:ok, latest_pub} = Oli.Publishing.publish_project(project, "some changes")
+
       Sections.update_section_project_publication(section, project.id, latest_pub.id)
       Sections.rebuild_section_resources(section: section, publication: latest_pub)
 
@@ -649,6 +654,10 @@ defmodule OliWeb.PageDeliveryControllerTest do
     }
 
     map = Seeder.add_page(map, attrs, :page)
+
+    {:ok, publication} = Oli.Publishing.publish_project(map.project, "some changes")
+
+    map = Map.put(map, :publication, publication)
 
     map =
       map


### PR DESCRIPTION
This PR streamlines the page attempt hierarchy creation by:

1. Creating and leveraging a materialized view to "cache" the part id to activity mapping.
2. Special case handling of adaptive pages to combine delivery resolution and activity attempt creation into one query-driven INSERT

While I was in here I saw an opportunity to significantly improve the performance of course publishing and course project cloning by migrating parts of these impls to query-driven bulk INSERTS. 

For the full background and more details on this implementation, see:
https://docs.google.com/document/d/1gW_ZEzUyKD0ZyM4xwQfuhCxkMXTfx3vsOHfy94uZVMg/edit#

