### PR TITLE
[BUG FIX] temporary payload dump to disk HOLD ON MERGE

### DIFF
--- a/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
@@ -45,8 +45,7 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
         activitiesRequiredForEvaluation =
           Map.get(authoring, "activitiesRequiredForEvaluation", [])
 
-          variablesRequiredForEvaluation =
-            Map.get(authoring, "variablesRequiredForEvaluation", nil)
+        variablesRequiredForEvaluation = Map.get(authoring, "variablesRequiredForEvaluation", nil)
 
         # Logger.debug("SCORE CONTEXT: #{Jason.encode!(scoringContext)}")
         evaluate_from_rules(
@@ -75,16 +74,33 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
         activitiesRequiredForEvaluation,
         variablesRequiredForEvaluation
       ) do
-    state = case variablesRequiredForEvaluation do
-      nil -> assemble_full_adaptive_state(resource_attempt, activitiesRequiredForEvaluation, part_inputs)
-      _ ->
-        assemble_full_adaptive_state(resource_attempt, activitiesRequiredForEvaluation, part_inputs)
-        |> Map.take(variablesRequiredForEvaluation)
-    end
+    state =
+      case variablesRequiredForEvaluation do
+        nil ->
+          assemble_full_adaptive_state(
+            resource_attempt,
+            activitiesRequiredForEvaluation,
+            part_inputs
+          )
+
+        _ ->
+          assemble_full_adaptive_state(
+            resource_attempt,
+            activitiesRequiredForEvaluation,
+            part_inputs
+          )
+          |> Map.take(variablesRequiredForEvaluation)
+      end
 
     encodeResults = true
-
     Logger.debug("Sending State to Node #{Jason.encode!(state)}")
+
+    File.write("./#{activity_attempt_guid}-state.json", Poison.encode!(state), [:binary])
+    File.write("./#{activity_attempt_guid}-rules.json", Poison.encode!(rules), [:binary])
+
+    File.write("./#{activity_attempt_guid}-scoring.json", Poison.encode!(scoringContext), [
+      :binary
+    ])
 
     case NodeJS.call({"rules", :check}, [state, rules, scoringContext, encodeResults]) do
       {:ok, check_results} ->


### PR DESCRIPTION
Temporary measure to dump NodeJS payloads to disk in order to troubleshoot badarg problem. 

The other changes are auto-format changes. 