### PR TITLE
PMP-2443 | JAN-1272

### DIFF
--- a/assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx
+++ b/assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx
@@ -541,6 +541,7 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
             formatted[variable].value,
             simLife.snapshot,
             scriptEnv,
+            true,
           );
         }
         sendFormedResponse(simLife.handshake, {}, JanusCAPIRequestTypes.VALUE_CHANGE, formatted);


### PR DESCRIPTION
the CSS contains multiple '{' brackets and when the value gets passed to textparser which evaluates the variables in text, was replacing the variables with '' value so fixed that.  The fix will not break anything.