### PR TITLE
[BUG FIX] only add url base if one is not pre configured

### DIFF
--- a/lib/oli/branding.ex
+++ b/lib/oli/branding.ex
@@ -157,11 +157,13 @@ defmodule Oli.Branding do
   end
 
   def brand_logo_url(section \\ nil) do
-    Utils.get_base_url() <> brand_logo_path(section)
+    brand_logo_path(section)
+    |> Utils.ensure_absolute_url()
   end
 
   def brand_logo_url_dark(section \\ nil) do
-    Utils.get_base_url() <> brand_logo_path_dark(section)
+    brand_logo_path_dark(section)
+    |> Utils.ensure_absolute_url()
   end
 
   def brand_logo_path(section \\ nil) do

--- a/lib/oli/utils.ex
+++ b/lib/oli/utils.ex
@@ -175,6 +175,33 @@ defmodule Oli.Utils do
   end
 
   @doc """
+  Returns true if the given URL is absolute
+  """
+  def is_url_absolute(url) do
+    String.match?(url, ~r/^(?:[a-z]+:)?\/\//i)
+  end
+
+  @doc """
+  Returns the given url or path ensuring it is absolute. If a relative path is given, then
+  the configured base url will be prepended
+  """
+  def ensure_absolute_url(url) do
+    if is_url_absolute(url) do
+      url
+    else
+      get_base_url() <> ensure_prepended_slash(url)
+    end
+  end
+
+  defp ensure_prepended_slash(url) do
+    if String.starts_with?(url, "/") do
+      url
+    else
+      "/#{url}"
+    end
+  end
+
+  @doc """
   Generates a shortened v4 UUID encoded as base57
   """
   def uuid() do

--- a/test/oli/utils_test.exs
+++ b/test/oli/utils_test.exs
@@ -1,0 +1,34 @@
+defmodule Oli.UtilsTest do
+  use Oli.DataCase
+
+  alias Oli.Utils
+
+  describe "is_url_absolute" do
+    test "returns true if url is absolute" do
+      assert Utils.is_url_absolute("http://example.com") == true
+      assert Utils.is_url_absolute("HTTP://EXAMPLE.COM") == true
+      assert Utils.is_url_absolute("https://www.exmaple.com") == true
+      assert Utils.is_url_absolute("ftp://example.com/file.txt") == true
+      assert Utils.is_url_absolute("ftp://example.com/file.txt") == true
+      assert Utils.is_url_absolute("//cdn.example.com/lib.js") == true
+      assert Utils.is_url_absolute("/myfolder/test.txt") == false
+      assert Utils.is_url_absolute("test") == false
+    end
+  end
+
+  describe "ensure_absolute_url" do
+    test "returns an absolute url" do
+      assert Utils.ensure_absolute_url("test") == "https://localhost/test"
+      assert Utils.ensure_absolute_url("/test") == "https://localhost/test"
+
+      assert Utils.ensure_absolute_url("/keeps/path?and=all&params=true") ==
+               "https://localhost/keeps/path?and=all&params=true"
+
+      assert Utils.ensure_absolute_url("http://already-aboslute") == "http://already-aboslute"
+      assert Utils.ensure_absolute_url("https://already-aboslute") == "https://already-aboslute"
+
+      assert Utils.ensure_absolute_url("https://already-aboslute:8080/keeps/path?and=all&params=true") ==
+               "https://already-aboslute:8080/keeps/path?and=all&params=true"
+    end
+  end
+end


### PR DESCRIPTION
This PR ensures that email logo urls are absolute but only adds the url base if one is not configured.