### PR TITLE
[FEATURE] add some basic ingestion error checks

### DIFF
--- a/lib/oli_web/templates/ingest/error.html.eex
+++ b/lib/oli_web/templates/ingest/error.html.eex
@@ -1,4 +1,0 @@
-
-<p>Course Ingest Error:</p>
-
-<%= @error %>

--- a/lib/oli_web/templates/ingest/index.html.eex
+++ b/lib/oli_web/templates/ingest/index.html.eex
@@ -3,6 +3,15 @@
   <p class="lead">Upload a course digest archive and convert into a Torus course project.</p>
   <hr class="my-4">
 
+    <%= case assigns[:error] do %>
+      <% nil -> %>
+
+      <% error -> %>
+        <div class="alert alert-danger" role="alert">
+          <%= error %>
+        </div>
+    <% end %>
+
     <%= form_for @conn, "ingest", [as: :upload, multipart: true], fn f -> %>
 
       <div class="form-group">

--- a/test/oli/interop/ingest_test.exs
+++ b/test/oli/interop/ingest_test.exs
@@ -153,5 +153,68 @@ defmodule Oli.Interop.IngestTest do
       tagged_activity = Enum.filter(activities, fn p -> p.title == "CATA" end) |> hd
       assert tagged_activity.tags == [tag.resource_id]
     end
+
+    test "returns :invalid_digest error when digest is invalid", %{author: author} do
+      assert [] |> Ingest.process(author) == {:error, :invalid_digest}
+
+      assert [
+               {'file1', "some content"},
+               {'_media-manifest', "{}"},
+               {'_hierarchy', "{}"}
+             ]
+             |> Ingest.process(author) == {:error, :invalid_digest}
+
+      assert [
+               {'_project', "{}"},
+               {'file1', "some content"},
+               {'_hierarchy', "{}"}
+             ]
+             |> Ingest.process(author) == {:error, :invalid_digest}
+
+      assert [
+               {'_project', "{}"},
+               {'_media-manifest', "{}"},
+               {'file1', "some content"}
+             ]
+             |> Ingest.process(author) == {:error, :invalid_digest}
+    end
+
+    test "returns :missing_project_title error when project title is missing", %{author: author} do
+      assert simulate_unzipping()
+             |> Enum.map(fn item ->
+               case item do
+                 {'_project.json', contents} ->
+                   without_title =
+                     Jason.decode!(contents)
+                     |> Map.delete("title")
+                     |> Jason.encode!()
+
+                   {'_project.json', without_title}
+
+                 _ ->
+                   item
+               end
+             end)
+             |> Ingest.process(author) == {:error, :missing_project_title}
+    end
+
+    test "returns :empty_project_title error when project title is empty", %{author: author} do
+      assert simulate_unzipping()
+             |> Enum.map(fn item ->
+               case item do
+                 {'_project.json', contents} ->
+                   without_title =
+                     Jason.decode!(contents)
+                     |> Map.put("title", "")
+                     |> Jason.encode!()
+
+                   {'_project.json', without_title}
+
+                 _ ->
+                   item
+               end
+             end)
+             |> Ingest.process(author) == {:error, :empty_project_title}
+    end
   end
 end


### PR DESCRIPTION
This PR adds some more useful basic error handling to course ingestion. This is the first of a couple PRs related to improving ingestion error handling. Follow-on PRs will address verifying idrefs, adding json validation and introducing resource warning support.