### PR TITLE
[BUG FIX] gracefully handle naive datetimes

### DIFF
--- a/lib/oli_web/common/format_date_time.ex
+++ b/lib/oli_web/common/format_date_time.ex
@@ -91,7 +91,12 @@ defmodule OliWeb.Common.FormatDateTime do
   Converts a datetime to a specific timezone based on a user's session. This
   session timezone information is set and updated on the timezone api call every
   time a page is loaded.
+
+  If NaiveDateTime is given it is assumed to be utc
   """
+  def maybe_localized_datetime(%NaiveDateTime{} = naive_date, nil),
+    do: Timex.to_datetime(naive_date, "Etc/UTC")
+
   def maybe_localized_datetime(%DateTime{} = datetime, nil), do: datetime
 
   def maybe_localized_datetime(%DateTime{} = datetime, %SessionContext{local_tz: local_tz}),

--- a/test/oli/delivery/sections/browse_test.exs
+++ b/test/oli/delivery/sections/browse_test.exs
@@ -8,12 +8,6 @@ defmodule Oli.Delivery.Sections.BrowseTest do
   alias Lti_1p3.Tool.ContextRoles
   import Ecto.Query, warn: false
 
-  def make_sections(project, institution, prefix, n, attrs) do
-    65..(65 + (n - 1))
-    |> Enum.map(fn value -> List.to_string([value]) end)
-    |> Enum.map(fn value -> make(project, institution, "#{prefix}-#{value}", attrs) end)
-  end
-
   def browse(offset, field, direction, text_search) do
     Browse.browse_sections(
       %Paging{offset: offset, limit: 3},
@@ -26,30 +20,6 @@ defmodule Oli.Delivery.Sections.BrowseTest do
         text_search: text_search
       }
     )
-  end
-
-  def make(project, institution, title, attrs) do
-    {:ok, section} =
-      Sections.create_section(
-        Map.merge(
-          %{
-            title: title,
-            timezone: "1",
-            registration_open: true,
-            context_id: UUID.uuid4(),
-            institution_id:
-              if is_nil(institution) do
-                nil
-              else
-                institution.id
-              end,
-            base_project_id: project.id
-          },
-          attrs
-        )
-      )
-
-    section
   end
 
   # For each section, enroll a different number of students. First section gets 1,

--- a/test/oli/delivery/sections/enrollments_browse_test.exs
+++ b/test/oli/delivery/sections/enrollments_browse_test.exs
@@ -1,17 +1,12 @@
 defmodule Oli.Delivery.Sections.EnrollmentsBrowseTest do
   use Oli.DataCase
 
+  import Ecto.Query, warn: false
+
   alias Oli.Delivery.Sections
   alias Oli.Repo.{Paging, Sorting}
   alias Oli.Delivery.Sections.{EnrollmentBrowseOptions}
   alias Lti_1p3.Tool.ContextRoles
-  import Ecto.Query, warn: false
-
-  def make_sections(project, institution, prefix, n, attrs) do
-    65..(65 + (n - 1))
-    |> Enum.map(fn value -> List.to_string([value]) end)
-    |> Enum.map(fn value -> make(project, institution, "#{prefix}-#{value}", attrs) end)
-  end
 
   def browse(section, offset, field, direction, text_search, is_student, is_instructor) do
     Sections.browse_enrollments(
@@ -24,34 +19,6 @@ defmodule Oli.Delivery.Sections.EnrollmentsBrowseTest do
         text_search: text_search
       }
     )
-  end
-
-  def make(project, institution, title, attrs) do
-    {:ok, section} =
-      Sections.create_section(
-        Map.merge(
-          %{
-            title: title,
-            timezone: "1",
-            registration_open: true,
-            context_id: UUID.uuid4(),
-            institution_id:
-              if is_nil(institution) do
-                nil
-              else
-                institution.id
-              end,
-            base_project_id: project.id,
-            requires_payment: true,
-            amount: "$100.00",
-            grace_period_days: 5,
-            has_grace_period: true
-          },
-          attrs
-        )
-      )
-
-    section
   end
 
   # Create and enroll 11 users, with 6 being students and 5 being instructors

--- a/test/oli_web/live/sections/enrollments_view_test.exs
+++ b/test/oli_web/live/sections/enrollments_view_test.exs
@@ -1,0 +1,101 @@
+defmodule OliWeb.Sections.EnrollmentsViewTest do
+  use OliWeb.ConnCase
+
+  import Phoenix.{ConnTest, LiveViewTest}
+
+  alias Oli.Seeder
+  alias Lti_1p3.Tool.ContextRoles
+  alias Oli.Delivery.Sections
+
+  @endpoint OliWeb.Endpoint
+
+  # Create and enroll 11 users, with 6 being students and 5 being instructors
+  def enroll(section) do
+    to_attrs = fn v ->
+      %{
+        sub: UUID.uuid4(),
+        name: "#{v}",
+        given_name: "#{v}",
+        family_name: "#{v}",
+        middle_name: "",
+        picture: "https://platform.example.edu/jane.jpg",
+        email: "test#{v}@example.edu",
+        locale: "en-US"
+      }
+    end
+
+    Enum.map(1..11, fn v -> to_attrs.(v) |> user_fixture() end)
+    |> Enum.with_index(fn user, index ->
+      roles =
+        case rem(index, 2) do
+          0 ->
+            [ContextRoles.get_role(:context_learner)]
+
+          _ ->
+            [ContextRoles.get_role(:context_learner), ContextRoles.get_role(:context_instructor)]
+        end
+
+      # Between the first two enrollments, delay enough that we get distinctly different
+      # enrollment times
+      case index do
+        1 -> :timer.sleep(1500)
+        _ -> true
+      end
+
+      {:ok, enrollment} = Sections.enroll(user.id, section.id, roles)
+
+      # Have the first enrolled student also have made a payment for this section
+      case index do
+        2 ->
+          Oli.Delivery.Paywall.create_payment(%{
+            type: :direct,
+            generation_date: DateTime.utc_now(),
+            application_date: DateTime.utc_now(),
+            amount: "$100.00",
+            provider_type: :stripe,
+            provider_id: "1",
+            provider_payload: %{},
+            pending_user_id: user.id,
+            pending_section_id: section.id,
+            enrollment_id: enrollment.id,
+            section_id: section.id
+          })
+
+        _ ->
+          true
+      end
+    end)
+  end
+
+  describe "gating and scheduling live test admin" do
+    setup [:setup_enrollments_view]
+
+    test "mount enrollments for admin", %{conn: conn, section: section} do
+      {:ok, _view, html} =
+        live(conn, Routes.live_path(@endpoint, OliWeb.Sections.EnrollmentsView, section.slug))
+
+      assert html =~ "Enrollments"
+    end
+  end
+
+  defp setup_enrollments_view(%{conn: conn}) do
+    map = Seeder.base_project_with_resource2()
+
+    section = make(map.project, map.institution, "a", %{})
+
+    enroll(section)
+
+    admin = author_fixture(%{system_role_id: Oli.Accounts.SystemRole.role_id().admin})
+
+    conn =
+      Plug.Test.init_test_session(conn, [])
+      |> Pow.Plug.assign_current_user(admin, OliWeb.Pow.PowHelpers.get_pow_config(:author))
+
+    map
+    |> Map.merge(%{
+      conn: conn,
+      section: section,
+      admin: admin
+    })
+  end
+end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -11,6 +11,7 @@ defmodule Oli.TestHelpers do
   alias Oli.Delivery.Sections.Section
   alias Oli.Publishing
   alias Oli.PartComponents
+  alias Oli.Delivery.Sections
 
   import Mox
 
@@ -351,5 +352,39 @@ defmodule Oli.TestHelpers do
   def latest_record_index(table) do
     from(r in table, order_by: [desc: r.id], limit: 1, select: r.id)
     |> Repo.one!()
+  end
+
+  def make_sections(project, institution, prefix, n, attrs) do
+    65..(65 + (n - 1))
+    |> Enum.map(fn value -> List.to_string([value]) end)
+    |> Enum.map(fn value -> make(project, institution, "#{prefix}-#{value}", attrs) end)
+  end
+
+  def make(project, institution, title, attrs) do
+    {:ok, section} =
+      Sections.create_section(
+        Map.merge(
+          %{
+            title: title,
+            timezone: "1",
+            registration_open: true,
+            context_id: UUID.uuid4(),
+            institution_id:
+              if is_nil(institution) do
+                nil
+              else
+                institution.id
+              end,
+            base_project_id: project.id,
+            requires_payment: true,
+            amount: "$100.00",
+            grace_period_days: 5,
+            has_grace_period: true
+          },
+          attrs
+        )
+      )
+
+    section
   end
 end


### PR DESCRIPTION
This PR adds better handling for naive datetimes when given to the formatter and adds a unit test for enrollments view to guarantee the fix.