### PR TITLE
[FEATURE] Ingestion support for selections

### DIFF
--- a/assets/src/components/activities/ordering/OrderingAuthoring.tsx
+++ b/assets/src/components/activities/ordering/OrderingAuthoring.tsx
@@ -30,6 +30,12 @@ const store = configureStore();
 
 export const Ordering: React.FC = () => {
   const { dispatch, model } = useAuthoringElementContext<OrderingSchema>();
+
+  const choices = model.choices.reduce((m: any, c) => {
+    m[c.id] = c;
+    return m;
+  }, {});
+
   return (
     <TabbedNavigation.Tabs>
       <TabbedNavigation.Tab label="Question">
@@ -46,7 +52,7 @@ export const Ordering: React.FC = () => {
 
       <TabbedNavigation.Tab label="Answer Key">
         <ResponseChoices
-          choices={getCorrectChoiceIds(model).map((id) => Choices.getOne(model, id))}
+          choices={getCorrectChoiceIds(model).map((id) => choices[id])}
           setChoices={(choices) => dispatch(Actions.setCorrectChoices(choices))}
         />
         <SimpleFeedback partId={DEFAULT_PART_ID} />

--- a/assets/src/data/activities/model/list.ts
+++ b/assets/src/data/activities/model/list.ts
@@ -1,6 +1,6 @@
 import { Operations } from 'utils/pathOperations';
 
-const ID_PATH = (id: string) => `[?(@.id==${id})]`;
+const ID_PATH = (id: string) => `[?(@.id=='${id}')]`;
 
 type Predicate<T> = (x: T) => boolean;
 export interface List<T> {

--- a/assets/test/data/activities/model/choices_test.ts
+++ b/assets/test/data/activities/model/choices_test.ts
@@ -4,12 +4,13 @@ describe('choices test', () => {
   const model = {
     stem: { content: { model: [{ type: 'p', children: [{ text: 'test' }] }] } },
     choices: [
-      { id: 'yes', content: { model: [{ type: 'p', children: [{ text: 'test' }] }] } },
+      { id: '111', content: { model: [{ type: 'p', children: [{ text: 'test' }] }] } },
       { id: 'no', content: { model: [{ type: 'p', children: [{ text: 'test' }] }] } },
     ],
   };
 
   it('finds one', () => {
     expect(Choices.getOne(model, 'no')).toEqual(model.choices[1]);
+    expect(Choices.getOne(model, '111')).toEqual(model.choices[0]);
   });
 });

--- a/assets/test/data/activities/model/choices_test.ts
+++ b/assets/test/data/activities/model/choices_test.ts
@@ -1,0 +1,15 @@
+import { Choices } from 'data/activities/model/choices';
+
+describe('choices test', () => {
+  const model = {
+    stem: { content: { model: [{ type: 'p', children: [{ text: 'test' }] }] } },
+    choices: [
+      { id: 'yes', content: { model: [{ type: 'p', children: [{ text: 'test' }] }] } },
+      { id: 'no', content: { model: [{ type: 'p', children: [{ text: 'test' }] }] } },
+    ],
+  };
+
+  it('finds one', () => {
+    expect(Choices.getOne(model, 'no')).toEqual(model.choices[1]);
+  });
+});

--- a/lib/oli/interop/ingest.ex
+++ b/lib/oli/interop/ingest.ex
@@ -39,7 +39,7 @@ defmodule Oli.Interop.Ingest do
     Map.has_key?(map, @project_key) && Map.has_key?(map, @hierarchy_key) &&
       Map.has_key?(map, @media_key)
   end
-  
+
   # Process the unzipped entries of the archive
   def process(entries, as_author) do
     {resource_map, _error_map} = to_map(entries)
@@ -220,11 +220,36 @@ defmodule Oli.Interop.Ingest do
     end)
   end
 
+  defp rewire_bank_selections(content, tag_map) do
+    PageContent.map(content, fn e ->
+      case e do
+        %{"type" => "selection", "logic" => logic} = ref ->
+          case logic do
+            %{"conditions" => %{"children" => [%{"fact" => "tags", "value" => originals}]}} ->
+              ids = Enum.map(originals, fn o -> retrieve(tag_map, o).resource_id end)
+
+              children = [%{"fact" => "tags", "value" => ids, "operator" => "equals"}]
+              conditions = Map.put(logic["conditions"], "children", children)
+              logic = Map.put(logic, "conditions", conditions)
+
+              Map.put(ref, "logic", logic)
+
+            _ ->
+              ref
+          end
+
+        other ->
+          other
+      end
+    end)
+  end
+
   # Create one page
   defp create_page(project, page, activity_map, objective_map, tag_map, as_author) do
     content =
       Map.get(page, "content")
       |> rewire_activity_references(activity_map)
+      |> rewire_bank_selections(tag_map)
 
     %{
       tags: transform_tags(page, tag_map),
@@ -261,7 +286,14 @@ defmodule Oli.Interop.Ingest do
         title -> title
       end
 
+    scope =
+      case Map.get(activity, "scope", "embedded") do
+        str when str in ~w(embedded banked) -> String.to_existing_atom(str)
+        _ -> :embedded
+      end
+
     %{
+      scope: scope,
       tags: transform_tags(activity, tag_map),
       title: title,
       content: Map.get(activity, "content"),


### PR DESCRIPTION
This PR adds a step during ingestion to handle selections, specifically to rewire the tag reference within them to reflect the database id of the newly created tag. 

Also, I found and fixed a problem in the activities model support code, where `Lists.getOne` does not work for keys that are not numeric. 

Also, in OrderingAuthoring, I removed an n^2 lookup (`Choices.getOne` is linear)