### PR TITLE
[BUG FIX] More robust recaptcha handling CMU-442 MER-524

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fix enrollments view rendering problem in sections that require payment
 - Ensure score can never exceed out of for graded pages
 - Ensure multiple payment attempts is handled correctly
+- Handle cases where recaptcha payload is missing
 
 ### Enhancements
 

--- a/lib/oli/utils/recaptcha.ex
+++ b/lib/oli/utils/recaptcha.ex
@@ -12,6 +12,10 @@ defmodule Oli.Utils.Recaptcha do
   ]
 
   @spec verify(String.t()) :: {:success, atom()}
+
+  def verify(""), do: {:success, false}
+  def verify(nil), do: {:success, false}
+
   def verify(response_string) do
     timeout = Application.fetch_env!(:oli, :recaptcha)[:timeout]
     url = Application.fetch_env!(:oli, :recaptcha)[:verify_url]

--- a/lib/oli_web/controllers/collaborator_controller.ex
+++ b/lib/oli_web/controllers/collaborator_controller.ex
@@ -9,11 +9,14 @@ defmodule OliWeb.CollaboratorController do
 
   @max_invitation_emails 20
 
-  def create(conn, %{
-        "collaborator_emails" => collaborator_emails,
-        "g-recaptcha-response" => g_recaptcha_response
-      }) do
+  def create(
+        conn,
+        %{
+          "collaborator_emails" => collaborator_emails
+        } = params
+      ) do
     project_id = conn.params["project_id"]
+    g_recaptcha_response = Map.get(params, "g-recaptcha-response", "")
 
     case Oli.Utils.Recaptcha.verify(g_recaptcha_response) do
       {:success, true} ->

--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -458,11 +458,12 @@ defmodule OliWeb.DeliveryController do
   end
 
   defp recaptcha_verified?(g_recaptcha_response) do
-    g_recaptcha_response != "" and
-      Oli.Utils.Recaptcha.verify(g_recaptcha_response) == {:success, true}
+    Oli.Utils.Recaptcha.verify(g_recaptcha_response) == {:success, true}
   end
 
-  def create_user(conn, %{"g-recaptcha-response" => g_recaptcha_response}) do
+  def create_user(conn, params) do
+    g_recaptcha_response = Map.get(params, "g-recaptcha-response", "")
+
     if Oli.Utils.LoadTesting.enabled?() or recaptcha_verified?(g_recaptcha_response) do
       section = conn.assigns.section
 

--- a/lib/oli_web/controllers/help_controller.ex
+++ b/lib/oli_web/controllers/help_controller.ex
@@ -8,7 +8,7 @@ defmodule OliWeb.HelpController do
   alias Oli.Help.HelpContent
 
   def create(conn, params) do
-    with {:ok, true} <- validate_recapture(Map.get(params, "g-recaptcha-response")),
+    with {:ok, true} <- validate_recapture(Map.get(params, "g-recaptcha-response", "")),
          {:ok, content_params} <- additional_help_context(conn, Map.get(params, "help")),
          {:ok, help_content} <- HelpContent.parse(content_params),
          {:ok, _} <-

--- a/lib/oli_web/controllers/invite_controller.ex
+++ b/lib/oli_web/controllers/invite_controller.ex
@@ -8,7 +8,9 @@ defmodule OliWeb.InviteController do
     render_invite_page(conn, "index.html", title: "Invite")
   end
 
-  def create(conn, %{"email" => email, "g-recaptcha-response" => g_recaptcha_response}) do
+  def create(conn, %{"email" => email} = params) do
+    g_recaptcha_response = Map.get(params, "g-recaptcha-response", "")
+
     case Oli.Utils.Recaptcha.verify(g_recaptcha_response) do
       {:success, true} ->
         invite_author(conn, email)

--- a/lib/oli_web/controllers/payment_controller.ex
+++ b/lib/oli_web/controllers/payment_controller.ex
@@ -133,12 +133,14 @@ defmodule OliWeb.PaymentController do
   @doc """
   Handles applying a user supplied code as a payment code.
   """
-  def apply_code(conn, %{
-        "g-recaptcha-response" => g_recaptcha_response,
-        "section_slug" => section_slug,
-        "code" => %{"value" => code}
-      }) do
-    if recaptcha_verified?(g_recaptcha_response) do
+  def apply_code(
+        conn,
+        %{
+          "section_slug" => section_slug,
+          "code" => %{"value" => code}
+        } = params
+      ) do
+    if Map.get(params, "g-recaptcha-response", "") |> recaptcha_verified?() do
       user = conn.assigns.current_user
 
       case Oli.Delivery.Paywall.redeem_code(code, user, section_slug) do
@@ -157,7 +159,6 @@ defmodule OliWeb.PaymentController do
   end
 
   defp recaptcha_verified?(g_recaptcha_response) do
-    g_recaptcha_response != "" and
-      Oli.Utils.Recaptcha.verify(g_recaptcha_response) == {:success, true}
+    Oli.Utils.Recaptcha.verify(g_recaptcha_response) == {:success, true}
   end
 end

--- a/lib/oli_web/templates/payment/code.html.eex
+++ b/lib/oli_web/templates/payment/code.html.eex
@@ -7,6 +7,15 @@
 
   <%= form_for @conn, Routes.payment_path(@conn, :apply_code, @section_slug), [as: :code], fn f -> %>
 
+    <div class="form-label-group mt-4">
+      <div class="g-recaptcha" data-sitekey="<%= Application.fetch_env!(:oli, :recaptcha)[:site_key] %>"></div>
+
+      <%= case assigns[:recaptcha_error] do %>
+        <% recaptcha_error -> %>
+          <span class="help-block text-danger"><%= recaptcha_error %></span>
+      <% end %>
+    </div>
+
     <div class="form-group" style="width: 30%;">
       <label>Enter your payment code</label>
       <%= text_input f, :value, class: "form-control"%>
@@ -17,15 +26,6 @@
       <% end %>
 
       <%= submit "Submit", class: "btn btn-primary mt-3" %>
-    </div>
-
-    <div class="form-label-group mt-4">
-      <div class="g-recaptcha" data-sitekey="<%= Application.fetch_env!(:oli, :recaptcha)[:site_key] %>"></div>
-
-      <%= case assigns[:recaptcha_error] do %>
-        <% recaptcha_error -> %>
-          <span class="help-block text-danger"><%= recaptcha_error %></span>
-      <% end %>
     </div>
 
   <% end %>


### PR DESCRIPTION
Production usage shows that there are cases where controller functions are invoked and there is no recaptcha payload.  Given the pattern matches in most of these impls, the server throws an error. 

This PR makes this more robust by removing the recaptcha payload from the pattern match, and instead pulls it out of the params. 

Also, it reorders the Recaptcha and the Submit form in the Payment Code application UI. 