### PR TITLE
[FEATURE] Centralize API error handling

### DIFF
--- a/lib/oli/utils/error_logger.ex
+++ b/lib/oli/utils/error_logger.ex
@@ -1,0 +1,7 @@
+defmodule Oli.Utils.ErrorLogger do
+  require Logger
+
+  def log_error(e, label \\ "Unexpected error") do
+    Logger.error(label <> ": " <> Kernel.inspect(e))
+  end
+end

--- a/lib/oli_web/controllers/api/activity_controller.ex
+++ b/lib/oli_web/controllers/api/activity_controller.ex
@@ -161,7 +161,8 @@ defmodule OliWeb.Api.ActivityController do
       {:error, {:not_authorized}} ->
         error(conn, 403, "unauthorized")
 
-      _ ->
+      e ->
+        Oli.Utils.ErrorLogger.log_error(e, "Could not create secondary activity document")
         error(conn, 500, "server error")
     end
   end
@@ -198,7 +199,8 @@ defmodule OliWeb.Api.ActivityController do
       {:error, {:not_authorized}} ->
         error(conn, 403, "unauthorized")
 
-      _ ->
+      e ->
+        Oli.Utils.ErrorLogger.log_error(e, "Could not create activity")
         error(conn, 500, "server error")
     end
   end
@@ -259,9 +261,15 @@ defmodule OliWeb.Api.ActivityController do
     author = conn.assigns[:current_author]
 
     case ActivityEditor.retrieve(project_slug, activity_id, author) do
-      {:ok, rev} -> json(conn, document_to_result(rev))
-      {:error, {:not_found}} -> error(conn, 404, "not found")
-      _ -> error(conn, 500, "server error")
+      {:ok, rev} ->
+        json(conn, document_to_result(rev))
+
+      {:error, {:not_found}} ->
+        error(conn, 404, "not found")
+
+      e ->
+        Oli.Utils.ErrorLogger.log_error(e, "Could not retrieve activity")
+        error(conn, 500, "server error")
     end
   end
 
@@ -302,7 +310,8 @@ defmodule OliWeb.Api.ActivityController do
       {:error, {:not_found}} ->
         error(conn, 404, "not found")
 
-      _ ->
+      e ->
+        Oli.Utils.ErrorLogger.log_error(e, "Could not bulk retrieve activities")
         error(conn, 500, "server error")
     end
   end
@@ -475,12 +484,24 @@ defmodule OliWeb.Api.ActivityController do
     update = conn.body_params
 
     case ActivityEditor.edit(project_slug, lock_id, activity_id, author.email, update) do
-      {:ok, _} -> json(conn, %{"result" => "success"})
-      {:error, {:invalid_update_field}} -> error(conn, 400, "invalid update field")
-      {:error, {:not_found}} -> error(conn, 404, "not found")
-      {:error, {:not_authorized}} -> error(conn, 403, "unauthorized")
-      {:error, {:lock_not_acquired}} -> error(conn, 400, "lock not acquired")
-      _ -> error(conn, 500, "server error")
+      {:ok, _} ->
+        json(conn, %{"result" => "success"})
+
+      {:error, {:invalid_update_field}} ->
+        error(conn, 400, "invalid update field")
+
+      {:error, {:not_found}} ->
+        error(conn, 404, "not found")
+
+      {:error, {:not_authorized}} ->
+        error(conn, 403, "unauthorized")
+
+      {:error, {:lock_not_acquired}} ->
+        error(conn, 400, "lock not acquired")
+
+      e ->
+        Oli.Utils.ErrorLogger.log_error(e, "Could not edit activity")
+        error(conn, 500, "server error")
     end
   end
 
@@ -522,12 +543,24 @@ defmodule OliWeb.Api.ActivityController do
     updates = conn.body_params["updates"]
 
     case ActivityEditor.bulk_edit(project_slug, lock_id, author.email, updates) do
-      {:ok, _} -> json(conn, %{"result" => "success"})
-      {:error, {:invalid_update_field}} -> error(conn, 400, "invalid update field")
-      {:error, {:not_found}} -> error(conn, 404, "not found")
-      {:error, {:not_authorized}} -> error(conn, 403, "unauthorized")
-      {:error, {:lock_not_acquired}} -> error(conn, 400, "lock not acquired")
-      _ -> error(conn, 500, "server error")
+      {:ok, _} ->
+        json(conn, %{"result" => "success"})
+
+      {:error, {:invalid_update_field}} ->
+        error(conn, 400, "invalid update field")
+
+      {:error, {:not_found}} ->
+        error(conn, 404, "not found")
+
+      {:error, {:not_authorized}} ->
+        error(conn, 403, "unauthorized")
+
+      {:error, {:lock_not_acquired}} ->
+        error(conn, 400, "lock not acquired")
+
+      e ->
+        Oli.Utils.ErrorLogger.log_error(e, "Could not bulk update activities")
+        error(conn, 500, "server error")
     end
   end
 
@@ -539,17 +572,27 @@ defmodule OliWeb.Api.ActivityController do
       end)
 
     case ActivityEvaluation.evaluate_from_preview(model, parsed) do
-      {:ok, evaluations} -> json(conn, %{"result" => "success", "evaluations" => evaluations})
-      {:error, _} -> error(conn, 500, "server error")
+      {:ok, evaluations} ->
+        json(conn, %{"result" => "success", "evaluations" => evaluations})
+
+      e ->
+        Oli.Utils.ErrorLogger.log_error(e, "Could not evaluate for preview")
+        error(conn, 500, "server error")
     end
   end
 
   @doc false
   def transform(conn, %{"model" => model}) do
     case ActivityLifecycle.perform_test_transformation(model) do
-      {:ok, transformed} -> json(conn, %{"result" => "success", "transformed" => transformed})
-      {:no_effect, original} -> json(conn, %{"result" => "success", "transformed" => original})
-      {:error, _} -> error(conn, 500, "server error")
+      {:ok, transformed} ->
+        json(conn, %{"result" => "success", "transformed" => transformed})
+
+      {:no_effect, original} ->
+        json(conn, %{"result" => "success", "transformed" => original})
+
+      e ->
+        Oli.Utils.ErrorLogger.log_error(e, "Could not apply transforms")
+        error(conn, 500, "server error")
     end
   end
 
@@ -588,12 +631,24 @@ defmodule OliWeb.Api.ActivityController do
     author = conn.assigns[:current_author]
 
     case ActivityEditor.delete(project_slug, lock_id, resource_id, author) do
-      {:ok, _} -> json(conn, %{"result" => "success"})
-      {:error, {:lock_not_acquired, _}} -> error(conn, 423, "locked")
-      {:error, {:not_applicable}} -> error(conn, 400, "not applicable to this resource")
-      {:error, {:not_found}} -> error(conn, 404, "not found")
-      {:error, {:not_authorized}} -> error(conn, 403, "unauthorized")
-      _ -> error(conn, 500, "server error")
+      {:ok, _} ->
+        json(conn, %{"result" => "success"})
+
+      {:error, {:lock_not_acquired, _}} ->
+        error(conn, 423, "locked")
+
+      {:error, {:not_applicable}} ->
+        error(conn, 400, "not applicable to this resource")
+
+      {:error, {:not_found}} ->
+        error(conn, 404, "not found")
+
+      {:error, {:not_authorized}} ->
+        error(conn, 403, "unauthorized")
+
+      e ->
+        Oli.Utils.ErrorLogger.log_error(e, "Could not delete activity")
+        error(conn, 500, "server error")
     end
   end
 

--- a/lib/oli_web/controllers/api/attempt_controller.ex
+++ b/lib/oli_web/controllers/api/attempt_controller.ex
@@ -382,8 +382,12 @@ defmodule OliWeb.Api.AttemptController do
     case Activity.save_student_input([
            %{attempt_guid: part_attempt_guid, response: response}
          ]) do
-      {:ok, _} -> json(conn, %{"type" => "success"})
-      {:error, _} -> error(conn, 500, "server error")
+      {:ok, _} ->
+        json(conn, %{"type" => "success"})
+
+      {:error, e} ->
+        Oli.Utils.ErrorLogger.log_error(e, "Could not save part")
+        error(conn, 500, "server error")
     end
   end
 
@@ -409,8 +413,12 @@ defmodule OliWeb.Api.AttemptController do
     case ActivityEvaluation.evaluate_from_input(section_slug, activity_attempt_guid, [
            %{attempt_guid: attempt_guid, input: input}
          ]) do
-      {:ok, evaluations} -> json(conn, %{"type" => "success", "actions" => evaluations})
-      {:error, _} -> error(conn, 500, "server error")
+      {:ok, evaluations} ->
+        json(conn, %{"type" => "success", "actions" => evaluations})
+
+      {:error, e} ->
+        Oli.Utils.ErrorLogger.log_error(e, "Could not submit part")
+        error(conn, 500, "server error")
     end
   end
 
@@ -448,7 +456,8 @@ defmodule OliWeb.Api.AttemptController do
       {:error, {:no_more_hints}} ->
         json(conn, %{"type" => "success", "hasMoreHints" => false})
 
-      {:error, _} ->
+      {:error, e} ->
+        Oli.Utils.ErrorLogger.log_error(e, "Could not get hint")
         error(conn, 500, "server error")
     end
   end
@@ -469,8 +478,12 @@ defmodule OliWeb.Api.AttemptController do
       end)
 
     case Activity.save_student_input(parsed) do
-      {:ok, _} -> json(conn, %{"type" => "success"})
-      {:error, _} -> error(conn, 500, "server error")
+      {:ok, _} ->
+        json(conn, %{"type" => "success"})
+
+      {:error, e} ->
+        Oli.Utils.ErrorLogger.log_error(e, "Could not save activity")
+        error(conn, 500, "server error")
     end
   end
 
@@ -498,7 +511,7 @@ defmodule OliWeb.Api.AttemptController do
         json(conn, %{"type" => "success", "actions" => evaluations})
 
       {:error, message} ->
-        Logger.error("Error when processing submit_activity #{inspect(message)}")
+        Oli.Utils.ErrorLogger.log_error(message, "Could not submit activity")
         error(conn, 500, "server error")
     end
   end
@@ -544,8 +557,12 @@ defmodule OliWeb.Api.AttemptController do
            activity_attempt_guid,
            client_evaluations
          ) do
-      {:ok, evaluations} -> json(conn, %{"type" => "success", "actions" => evaluations})
-      {:error, _} -> error(conn, 500, "server error")
+      {:ok, evaluations} ->
+        json(conn, %{"type" => "success", "actions" => evaluations})
+
+      {:error, e} ->
+        Oli.Utils.ErrorLogger.log_error(e, "Could not process activity evaluations")
+        error(conn, 500, "server error")
     end
   end
 
@@ -569,7 +586,8 @@ defmodule OliWeb.Api.AttemptController do
       {:ok, {attempt_state, model}} ->
         json(conn, %{"type" => "success", "attemptState" => attempt_state, "model" => model})
 
-      {:error, _} ->
+      {:error, e} ->
+        Oli.Utils.ErrorLogger.log_error(e, "Could not reset activity")
         error(conn, 500, "server error")
     end
   end

--- a/lib/oli_web/controllers/api/lock_controller.ex
+++ b/lib/oli_web/controllers/api/lock_controller.ex
@@ -43,7 +43,8 @@ defmodule OliWeb.Api.LockController do
       {:error, {:not_authorized}} ->
         error(conn, 403, "unauthorized")
 
-      {:error, {:error}} ->
+      e ->
+        Oli.Utils.ErrorLogger.log_error(e, "Could not acquire lock")
         error(conn, 500, "server error")
     end
   end
@@ -52,10 +53,18 @@ defmodule OliWeb.Api.LockController do
     author = conn.assigns[:current_author]
 
     case PageEditor.release_lock(project_slug, resource_slug, author.email) do
-      {:ok, {:released}} -> json(conn, %{"type" => "released"})
-      {:error, {:not_found}} -> error(conn, 404, "not found")
-      {:error, {:not_authorized}} -> error(conn, 403, "unauthorized")
-      _ -> error(conn, 500, "server error")
+      {:ok, {:released}} ->
+        json(conn, %{"type" => "released"})
+
+      {:error, {:not_found}} ->
+        error(conn, 404, "not found")
+
+      {:error, {:not_authorized}} ->
+        error(conn, 403, "unauthorized")
+
+      e ->
+        Oli.Utils.ErrorLogger.log_error(e, "Could not release lock")
+        error(conn, 500, "server error")
     end
   end
 

--- a/lib/oli_web/controllers/api/objectives_controller.ex
+++ b/lib/oli_web/controllers/api/objectives_controller.ex
@@ -155,8 +155,12 @@ defmodule OliWeb.Api.ObjectivesController do
              {:ok, _} <- ObjectiveEditor.edit(slug, %{title: title}, author, project) do
           json(conn, %{"result" => "success"})
         else
-          {:error, {:not_found}} -> error(conn, 404, "Not found")
-          _ -> error(conn, 500, "Objective could not be updated")
+          {:error, {:not_found}} ->
+            error(conn, 404, "Not found")
+
+          e ->
+            Oli.Utils.ErrorLogger.log_error(e, "Could not update objective")
+            error(conn, 500, "Objective could not be updated")
         end
     end
   end
@@ -227,7 +231,8 @@ defmodule OliWeb.Api.ObjectivesController do
             |> put_status(:created)
             |> json(%{"result" => "success", "resourceId" => revision.resource_id})
 
-          _ ->
+          e ->
+            Oli.Utils.ErrorLogger.log_error(e, "Could not create objective")
             error(conn, 500, "Objective could not be created")
         end
     end

--- a/lib/oli_web/controllers/api/payment_controller.ex
+++ b/lib/oli_web/controllers/api/payment_controller.ex
@@ -91,7 +91,8 @@ defmodule OliWeb.Api.PaymentController do
         {:error, {:invalid_batch_size}} ->
           error(conn, 400, "invalid batch size")
 
-        _ ->
+        e ->
+          Oli.Utils.ErrorLogger.log_error(e, "Could not create payment code batch")
           error(conn, 500, "server error")
       end
     else

--- a/lib/oli_web/controllers/payment_providers/stripe_controller.ex
+++ b/lib/oli_web/controllers/payment_providers/stripe_controller.ex
@@ -75,8 +75,8 @@ defmodule OliWeb.PaymentProviders.StripeController do
           reason: reason
         })
 
-      _ ->
-        Logger.error("StripeController could not finalize payment")
+      e ->
+        Oli.Utils.ErrorLogger.log_error(e, "Could not finalize stripe payment.")
 
         json(conn, %{
           result: "failure",
@@ -128,12 +128,8 @@ defmodule OliWeb.PaymentProviders.StripeController do
 
             json(conn, %{clientSecret: client_secret})
 
-          {:error, reason} when is_binary(reason) ->
-            Logger.error("StripeController:init_intent failed. #{reason}")
-            error(conn, 500, reason)
-
-          _ ->
-            Logger.error("StripeController:init_intent failed.")
+          e ->
+            Oli.Utils.ErrorLogger.log_error(e, "StripeController:init_intent failed.")
             error(conn, 500, "Intent creation failed")
         end
       else


### PR DESCRIPTION
This PR creates a centralized place where API endpoint errors (typically anything that we trap and then return as a `500` error) can be handled and logged.  

The logging of error details is needed in order to troubleshoot and identify the root causes. 

The introduction of the centralized `log_error` method is to provide a future place for extensibility.  In the future we may want to, for example, post an AppSignal error in addition to just logging the error. 