### PR TITLE
[FEATURE] Ingest second level objectives (aka 'skills'), process objectives attached to activities

### DIFF
--- a/lib/oli/interop/ingest.ex
+++ b/lib/oli/interop/ingest.ex
@@ -48,8 +48,7 @@ defmodule Oli.Interop.Ingest do
   # Returns {:ok} if all refs are valid and {:error, [...invalid_refs]} if invalid idrefs are found.
   defp validate_idrefs(map) do
     all_id_refs =
-      Enum.reduce(map, [], fn {file, content}, acc ->
-        IO.inspect(file)
+      Enum.reduce(map, [], fn {_file, content}, acc ->
         find_all_id_refs(content) ++ acc
       end)
 
@@ -73,8 +72,6 @@ defmodule Oli.Interop.Ingest do
 
   defp idrefs_recursive_desc(el, idrefs) do
     # if this element contains an idref, add it to the list
-
-    IO.inspect(el)
 
     idrefs =
       case el["idref"] do

--- a/lib/oli/interop/ingest.ex
+++ b/lib/oli/interop/ingest.ex
@@ -48,7 +48,8 @@ defmodule Oli.Interop.Ingest do
   # Returns {:ok} if all refs are valid and {:error, [...invalid_refs]} if invalid idrefs are found.
   defp validate_idrefs(map) do
     all_id_refs =
-      Enum.reduce(map, [], fn {_file, content}, acc ->
+      Enum.reduce(map, [], fn {file, content}, acc ->
+        IO.inspect(file)
         find_all_id_refs(content) ++ acc
       end)
 
@@ -72,6 +73,9 @@ defmodule Oli.Interop.Ingest do
 
   defp idrefs_recursive_desc(el, idrefs) do
     # if this element contains an idref, add it to the list
+
+    IO.inspect(el)
+
     idrefs =
       case el["idref"] do
         nil ->
@@ -169,7 +173,7 @@ defmodule Oli.Interop.Ingest do
     end)
   end
 
-  defp create_activities(project, resource_map, _, tag_map, as_author) do
+  defp create_activities(project, resource_map, objective_map, tag_map, as_author) do
     registration_map = get_registration_map()
 
     {changes, activities} =
@@ -180,7 +184,14 @@ defmodule Oli.Interop.Ingest do
 
     Repo.transaction(fn ->
       case Enum.reduce_while(activities, %{}, fn {id, activity}, map ->
-             case create_activity(project, activity, as_author, registration_map, tag_map) do
+             case create_activity(
+                    project,
+                    activity,
+                    as_author,
+                    registration_map,
+                    tag_map,
+                    objective_map
+                  ) do
                {:ok, revision} -> {:cont, Map.put(map, id, revision)}
                {:error, e} -> {:halt, {:error, e}}
              end
@@ -232,9 +243,15 @@ defmodule Oli.Interop.Ingest do
       |> Enum.map(fn k -> {k, Map.get(resource_map, k)} end)
       |> Enum.filter(fn {_, content} -> Map.get(content, "type") == "Objective" end)
 
+    with_children =
+      Enum.filter(objectives, fn {_, o} -> Map.get(o, "objectives", []) |> Enum.count() > 0 end)
+
+    without_children =
+      Enum.filter(objectives, fn {_, o} -> Map.get(o, "objectives", []) |> Enum.count() == 0 end)
+
     Repo.transaction(fn ->
-      case Enum.reduce_while(objectives, %{}, fn {id, o}, map ->
-             case create_objective(project, o, tag_map, as_author) do
+      case Enum.reduce_while(without_children ++ with_children, %{}, fn {id, o}, map ->
+             case create_objective(project, o, tag_map, as_author, map) do
                {:ok, revision} -> {:cont, Map.put(map, id, revision)}
                {:error, e} -> {:halt, {:error, e}}
              end
@@ -330,11 +347,24 @@ defmodule Oli.Interop.Ingest do
     |> create_resource(project)
   end
 
-  defp create_activity(project, activity, as_author, registration_by_subtype, tag_map) do
+  defp create_activity(
+         project,
+         activity,
+         as_author,
+         registration_by_subtype,
+         tag_map,
+         objective_map
+       ) do
     objectives =
-      activity["content"]["authoring"]["parts"]
-      |> Enum.map(fn %{"id" => id} -> id end)
-      |> Enum.reduce(%{}, fn e, m -> Map.put(m, e, []) end)
+      Map.get(activity, "objectives")
+      |> Map.keys()
+      |> Enum.reduce(%{}, fn k, m ->
+        mapped =
+          Map.get(activity, "objectives")[k]
+          |> Enum.map(fn id -> Map.get(objective_map, id).resource_id end)
+
+        Map.put(m, k, mapped)
+      end)
 
     title =
       case Map.get(activity, "title") do
@@ -375,7 +405,7 @@ defmodule Oli.Interop.Ingest do
     |> create_resource(project)
   end
 
-  defp create_objective(project, objective, tag_map, as_author) do
+  defp create_objective(project, objective, tag_map, as_author, objective_map) do
     title =
       case Map.get(objective, "title") do
         nil -> "Empty"
@@ -389,6 +419,9 @@ defmodule Oli.Interop.Ingest do
       content: %{},
       author_id: as_author.id,
       objectives: %{},
+      children:
+        Map.get(objective, "objectives", [])
+        |> Enum.map(fn id -> Map.get(objective_map, id).resource_id end),
       resource_type_id: Oli.Resources.ResourceType.get_id_by_type("objective")
     }
     |> create_resource(project)

--- a/test/oli/interop/digest/cata.json
+++ b/test/oli/interop/digest/cata.json
@@ -263,7 +263,7 @@
       "previewText": ""
     }
   },
-  "objectives": [],
+  "objectives": {"1": []},
   "legacyId": "a_90d6f87478a24b5cbf508a59c6fd62a7",
   "subType": "oli_check_all_that_apply"
 }

--- a/test/oli/interop/digest/mcq.json
+++ b/test/oli/interop/digest/mcq.json
@@ -120,7 +120,7 @@
     }
 
   },
-  "objectives": [],
+  "objectives": {"1": []},
   "legacyId": "a_fd13a924cebc4be1be0915b498e86d22",
   "subType": "oli_multiple_choice"
 }

--- a/test/oli/interop/digest/single_response.json
+++ b/test/oli/interop/digest/single_response.json
@@ -82,7 +82,7 @@
       "previewText": ""
     }
   },
-  "objectives": [],
+  "objectives": {"1": []},
   "legacyId": "a_c0e9e0a69cba4931967143bf72ac2dd8",
   "subType": "oli_short_answer"
 }


### PR DESCRIPTION
This PR adds support for ingesting a hierarchy of objectives (at most two levels).

It also expects the `objectives` attr of an activity resource to be populated with a map of part ids to a list of original objective ids.  It replaces those ids with database resource ids. Effectively allowing the parts of an activity that have attached skills to ingest. 