### PR TITLE
[BUG FIX] Allow completed attempts for adaptive graded pages to be reviewed CMU-429

### DIFF
--- a/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
@@ -464,6 +464,8 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
     # find the latest part attempts
     part_attempts = get_latest_part_attempts(activity_attempt_guid)
 
+    IO.inspect(part_attempts)
+
     # apply the scoring strategy and set the evaluation on the activity
     activity_attempt = get_activity_attempt_by(attempt_guid: activity_attempt_guid)
 

--- a/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
@@ -464,8 +464,6 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
     # find the latest part attempts
     part_attempts = get_latest_part_attempts(activity_attempt_guid)
 
-    IO.inspect(part_attempts)
-
     # apply the scoring strategy and set the evaluation on the activity
     activity_attempt = get_activity_attempt_by(attempt_guid: activity_attempt_guid)
 

--- a/lib/oli/delivery/attempts/page_lifecycle/common.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/common.ex
@@ -1,7 +1,6 @@
 defmodule Oli.Delivery.Attempts.PageLifecycle.Common do
   alias Oli.Delivery.Attempts.PageLifecycle.{
     ReviewContext,
-    Hierarchy,
     AttemptState
   }
 
@@ -17,11 +16,8 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Common do
         _ -> :finalized
       end
 
-    {:ok,
-     {status,
-      %AttemptState{
-        resource_attempt: resource_attempt,
-        attempt_hierarchy: Hierarchy.get_latest_attempts(resource_attempt.id)
-      }}}
+    {:ok, state} = AttemptState.fetch_attempt_state(resource_attempt, resource_attempt.revision)
+
+    {:ok, {status, state}}
   end
 end

--- a/lib/oli/delivery/attempts/scoring.ex
+++ b/lib/oli/delivery/attempts/scoring.ex
@@ -16,7 +16,26 @@ defmodule Oli.Delivery.Attempts.Scoring do
   Returns a `%Result{}` struct with the calculated score.
   """
   def calculate_score(strategy_id, items) when is_number(strategy_id) do
-    calculate_score(ScoringStrategy.get_type_by_id(strategy_id), items)
+    calculate_score(ScoringStrategy.get_type_by_id(strategy_id), translate_nils(items))
+  end
+
+  defp translate_nils(items) do
+    Enum.map(items, fn p ->
+      %{
+        score:
+          if is_nil(p.score) do
+            0
+          else
+            p.score
+          end,
+        out_of:
+          if is_nil(p.out_of) do
+            0
+          else
+            p.out_of
+          end
+      }
+    end)
   end
 
   # The average calculated here is normalized out of 100%, but then


### PR DESCRIPTION
The rendering pipeline for "review mode" was not assembling the correct shape of state needed to render the adaptive page. 

It testing this out, I created a very simple adaptive page, then published and exercised it as a graded page.  I ran into problems where `nil` was present as the `score` of a part.  I added logic that converts (in memory) these `nil` instances to a `0` to allow scoring calculations to succeed. 