### PR TITLE
[BUG FIX] Redirect to overview view after creation CMU-441

### DIFF
--- a/lib/oli_web/controllers/open_and_free_controller.ex
+++ b/lib/oli_web/controllers/open_and_free_controller.ex
@@ -9,6 +9,7 @@ defmodule OliWeb.OpenAndFreeController do
   alias OliWeb.Common.{Breadcrumb}
   alias Lti_1p3.Tool.{ContextRoles}
   alias Oli.Branding
+  alias OliWeb.Router.Helpers, as: Routes
 
   plug :add_assigns
 
@@ -89,7 +90,9 @@ defmodule OliWeb.OpenAndFreeController do
         {:ok, section} ->
           conn
           |> put_flash(:info, "Section created successfully.")
-          |> redirect(to: OliWeb.OpenAndFreeView.get_path([conn.assigns.route, :show, section]))
+          |> redirect(
+            to: Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.OverviewView, section.slug)
+          )
 
         _ ->
           changeset =
@@ -158,7 +161,9 @@ defmodule OliWeb.OpenAndFreeController do
         {:ok, section} ->
           conn
           |> put_flash(:info, "Section created successfully.")
-          |> redirect(to: OliWeb.OpenAndFreeView.get_path([conn.assigns.route, :show, section]))
+          |> redirect(
+            to: Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.OverviewView, section.slug)
+          )
 
         {:error, changeset} ->
           source_id = section_params["source_id"]

--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -78,6 +78,7 @@ defmodule OliWeb.Sections.OverviewView do
         <ReadOnly label="Course Section ID" value={@section.slug}/>
         <ReadOnly label="Title" value={@section.title}/>
         <ReadOnly label="Course Section Type" value={type_to_string(@section)}/>
+        <ReadOnly label="URL" value={Routes.page_delivery_url(OliWeb.Endpoint, :index, @section.slug)}/>
       </Group>
       <Group label="Instructors" description="Manage the users with instructor level access">
         <Instructors users={@instructors}/>

--- a/test/oli_web/controllers/open_and_free_controller_test.exs
+++ b/test/oli_web/controllers/open_and_free_controller_test.exs
@@ -55,16 +55,13 @@ defmodule OliWeb.OpenAndFreeControllerTest do
           section: Enum.into(@create_attrs, %{project_slug: project.slug})
         )
 
-      assert %{id: id} = redirected_params(conn)
-      assert redirected_to(conn) == Routes.admin_open_and_free_path(conn, :show, id)
+      assert %{section_slug: slug} = redirected_params(conn)
+      assert redirected_to(conn) == Routes.live_path(conn, OliWeb.Sections.OverviewView, slug)
 
       conn = recycle_author_session(conn, admin)
 
-      conn = get(conn, Routes.admin_open_and_free_path(conn, :show, id))
-      assert html_response(conn, 200) =~ "Section"
-
       # can access open and free index and pages
-      section = Sections.get_section!(id)
+      section = Sections.get_section_by(slug: slug)
 
       conn =
         conn


### PR DESCRIPTION
This fixes an aspect of LMS-Lite corse section creation, where after creation the user is taken to a view that expects an authoring account.  

A better solution is to redirect the user to the "Overview" view for their newly created section. 