### PR TITLE
[BUG FIX] Only highlight failures for LMS sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## Unreleased
-
-- Ensure user_id is unique in DataShop export
-
 ## 0.18.4 (2022-01-11)
 
 ### Bug Fixes
@@ -13,6 +9,8 @@
 - Ensure score can never exceed out of for graded pages
 - Ensure multiple payment attempts is handled correctly
 - Handle cases where recaptcha payload is missing
+- Ensure user_id is unique in DataShop export
+- Only highlight failed grade sync cells when section is an LMS section
 
 ### Enhancements
 

--- a/lib/oli_web/live/grades/gradebook_table_model.ex
+++ b/lib/oli_web/live/grades/gradebook_table_model.ex
@@ -4,7 +4,7 @@ defmodule OliWeb.Grades.GradebookTableModel do
   alias Oli.Delivery.Attempts.Core.ResourceAccess
   alias OliWeb.Router.Helpers, as: Routes
 
-  def new(enrollments, graded_pages, resource_accesses, section_slug) do
+  def new(enrollments, graded_pages, resource_accesses, section) do
     by_user =
       Enum.reduce(resource_accesses, %{}, fn ra, m ->
         case Map.has_key?(m, ra.user_id) do
@@ -20,7 +20,7 @@ defmodule OliWeb.Grades.GradebookTableModel do
     rows =
       Enum.map(enrollments, fn user ->
         Map.get(by_user, user.id, %{})
-        |> Map.merge(%{user: user, id: user.id, section_slug: section_slug})
+        |> Map.merge(%{user: user, id: user.id, section: section})
       end)
 
     column_specs =
@@ -77,7 +77,7 @@ defmodule OliWeb.Grades.GradebookTableModel do
          } = resource_access
        ) do
     link_type =
-      if ResourceAccess.last_grade_update_failed?(resource_access) do
+      if !row.section.open_and_free and ResourceAccess.last_grade_update_failed?(resource_access) do
         "badge badge-danger"
       else
         "badge badge-light"
@@ -85,7 +85,7 @@ defmodule OliWeb.Grades.GradebookTableModel do
 
     if out_of == 0 or out_of == 0.0 do
       ~F"""
-      <a class={link_type} href={Routes.live_path(OliWeb.Endpoint, OliWeb.Progress.StudentResourceView, row.section_slug, row.id, resource_id)}>
+      <a class={link_type} href={Routes.live_path(OliWeb.Endpoint, OliWeb.Progress.StudentResourceView, row.section.slug, row.id, resource_id)}>
         <span>{score}/{out_of} 0%</span>
       </a>
       """
@@ -116,7 +116,7 @@ defmodule OliWeb.Grades.GradebookTableModel do
         end
 
       ~F"""
-      <a class={link_type} href={Routes.live_path(OliWeb.Endpoint, OliWeb.Progress.StudentResourceView, row.section_slug, row.id, resource_id)}>
+      <a class={link_type} href={Routes.live_path(OliWeb.Endpoint, OliWeb.Progress.StudentResourceView, row.section.slug, row.id, resource_id)}>
       {safe_score}/{safe_out_of} <small class="text-muted">{percentage}</small>
       </a>
       """

--- a/lib/oli_web/live/grades/gradebook_view.ex
+++ b/lib/oli_web/live/grades/gradebook_view.ex
@@ -70,7 +70,7 @@ defmodule OliWeb.Grades.GradebookView do
         resource_accesses = fetch_resource_accesses(enrollments, section)
 
         {:ok, table_model} =
-          GradebookTableModel.new(enrollments, graded_pages, resource_accesses, section.slug)
+          GradebookTableModel.new(enrollments, graded_pages, resource_accesses, section)
 
         {:ok,
          assign(socket,
@@ -133,7 +133,7 @@ defmodule OliWeb.Grades.GradebookView do
         enrollments,
         socket.assigns.graded_pages,
         resource_accesses,
-        socket.assigns.section.slug
+        socket.assigns.section
       )
 
     total_count = determine_total(enrollments)


### PR DESCRIPTION
Closes #2207 

The fix here was to simply check the `open_and_free` flag on the section. 