### PR TITLE
[BUG FIX] Allow previous digests with lists of objectives to still process

### DIFF
--- a/lib/oli/interop/ingest.ex
+++ b/lib/oli/interop/ingest.ex
@@ -426,7 +426,10 @@ defmodule Oli.Interop.Ingest do
       list when is_list(list) ->
         activity["content"]["authoring"]["parts"]
         |> Enum.map(fn %{"id" => id} -> id end)
-        |> Enum.reduce(%{}, fn e, m -> Map.put(m, e, []) end)
+        |> Enum.reduce(%{}, fn e, m ->
+          objectives = Enum.map(list, fn id -> Map.get(objective_map, id).resource_id end)
+          Map.put(m, e, objectives)
+        end)
     end
   end
 


### PR DESCRIPTION
This PR restores the original behavior of ingest regarding handling of objectives attached to activities. Previously, the `objectives` attr was assumed to be a list, but recent change now expects it to be a map of the part ids to lists of objective identifiers.  Changing this without backwards compatibility broke existing digest files.  This PR handles both cases: a map and a list. 