### PR TITLE
[Bugfix][PMP-2472 / JAN-1304] Image carousel not functioning in popup

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -65,7 +65,7 @@
     "slate-history": "^0.66.0",
     "slate-hyperscript": "^0.67.0",
     "slate-react": "^0.72.1",
-    "swiper": "^6.4.7",
+    "swiper": "^8.0.6",
     "terser-webpack-plugin": "^5.2.4",
     "tsmonad": "^0.8.0",
     "typescript": "^4.4.4",

--- a/assets/src/components/parts/janus-Carousel/Carousel.css
+++ b/assets/src/components/parts/janus-Carousel/Carousel.css
@@ -1,14 +1,13 @@
-@import '~swiper/swiper-bundle.css';
-
 .janus-image-carousel div {
   display: unset;
   margin-top: unset;
 }
-.janus-image-carousel .swiper-container {
+.janus-image-carousel .swiper {
   width: 100%;
   height: 100%;
 }
-.janus-image-carousel .swiper-container,
+
+.janus-image-carousel .swiper,
 .janus-image-carousel .swiper-pagination,
 .janus-image-carousel .swiper-wrapper {
   display: flex;

--- a/assets/src/components/parts/janus-Carousel/Carousel.tsx
+++ b/assets/src/components/parts/janus-Carousel/Carousel.tsx
@@ -1,5 +1,5 @@
 import React, { createRef, CSSProperties, useCallback, useEffect, useState } from 'react';
-import SwiperCore, { A11y, Keyboard, Navigation, Pagination, Zoom } from 'swiper';
+import { A11y, Keyboard, Navigation, Pagination, Zoom } from 'swiper';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { CapiVariableTypes } from '../../../adaptivity/capi';
 import {
@@ -7,8 +7,13 @@ import {
   subscribeToNotification,
 } from '../../../apps/delivery/components/NotificationContext';
 import { PartComponentProps } from '../types/parts';
-import './Carousel.css';
 import { CarouselModel } from './schema';
+import 'swiper/css';
+import 'swiper/css/navigation';
+import 'swiper/css/pagination';
+import 'swiper/css/scrollbar';
+import 'swiper/css/zoom';
+import './Carousel.css';
 
 interface CarouselImageModel {
   url: string;
@@ -29,7 +34,6 @@ const Carousel: React.FC<PartComponentProps<CarouselModel>> = (props) => {
   const [swiper, setSwiper] = useState<any>(null);
 
   // initialize the swiper
-  SwiperCore.use([Navigation, Pagination, A11y, Keyboard, Zoom]);
   const initialize = useCallback(async (pModel) => {
     // set defaults
     const dZoom = typeof pModel.zoom === 'boolean' ? pModel.zoom : carouselZoom;
@@ -229,6 +233,7 @@ const Carousel: React.FC<PartComponentProps<CarouselModel>> = (props) => {
     <div data-janus-type={tagName} className={`janus-image-carousel`} style={styles}>
       {images.length > 0 && (
         <Swiper
+          modules={[Navigation, Pagination, A11y, Keyboard, Zoom]}
           slidesPerView={1}
           loop
           navigation

--- a/assets/src/components/parts/janus-Carousel/Carousel.tsx
+++ b/assets/src/components/parts/janus-Carousel/Carousel.tsx
@@ -229,23 +229,31 @@ const Carousel: React.FC<PartComponentProps<CarouselModel>> = (props) => {
     setCurrentSlide(currentSlide);
   };
 
+  // useeffect that destroys swiper when component unmounts
+  useEffect(() => {
+    return () => {
+      swiper.destroy(true, true);
+    };
+  }, []);
+
   return ready ? (
     <div data-janus-type={tagName} className={`janus-image-carousel`} style={styles}>
       {images.length > 0 && (
         <Swiper
           modules={[Navigation, Pagination, A11y, Keyboard, Zoom]}
           slidesPerView={1}
-          loop
-          navigation
+          loop={true}
+          navigation={true}
           zoom={carouselZoom ? { maxRatio: 3 } : false}
           keyboard={{ enabled: true }}
           pagination={{ clickable: true }}
           onSwiper={(swiper) => {
             setSwiper(swiper);
-            swiper.slideTo(currentSlide);
+            swiper.slideTo(1);
           }}
           onSlideChange={(swiper) => {
             handleSlideChange(swiper.realIndex);
+            swiper.update();
           }}
           onImagesReady={() => {
             setImagesLoaded(true);

--- a/assets/src/components/parts/janus-popup/Popup.tsx
+++ b/assets/src/components/parts/janus-popup/Popup.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, useCallback, useEffect, useState } from 'react';
+import React, { CSSProperties, useCallback, useEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { parseBool } from 'utils/common';
 import { CapiVariableTypes } from '../../../adaptivity/capi';
@@ -226,6 +226,12 @@ const Popup: React.FC<PartComponentProps<PopupModel>> = (props) => {
   // Toggle popup open/close
   const handleToggleIcon = (toggleVal: boolean) => {
     setShowPopup(toggleVal);
+    if (toggleVal === false) {
+      // set focus on inputRef
+      if (inputRef.current) {
+        inputRef.current.focus();
+      }
+    }
     // optimistically write state
     props.onSave({
       id,
@@ -256,10 +262,13 @@ const Popup: React.FC<PartComponentProps<PopupModel>> = (props) => {
     return activityHost && ReactDOM.createPortal(<PopupWindow {...windowProps} />, activityHost);
   };
 
+  const inputRef = useRef<HTMLInputElement>(null);
+
   return ready ? (
     <React.Fragment>
       {popupVisible ? (
         <input
+          ref={inputRef}
           data-janus-type={tagName}
           role="button"
           {...(iconSrc

--- a/assets/src/components/parts/janus-popup/PopupWindow.tsx
+++ b/assets/src/components/parts/janus-popup/PopupWindow.tsx
@@ -1,6 +1,6 @@
 import chroma from 'chroma-js';
 import PartsLayoutRenderer from 'components/activities/adaptive/components/delivery/PartsLayoutRenderer';
-import React, { CSSProperties } from 'react';
+import React, { CSSProperties, useEffect, useRef } from 'react';
 import { ContextProps, InitResultProps } from './types';
 
 interface PopupWindowProps {
@@ -112,23 +112,32 @@ const PopupWindow: React.FC<PopupWindowProps> = ({
     return result;
   };
 
+  const closeBtnRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (closeBtnRef.current) {
+      closeBtnRef.current.focus();
+    }
+  }, []);
+
   return (
     <div
       className={`info-icon-popup ${config?.customCssClass ? config.customCssClass : ''}`}
       style={popupModalStyles}
     >
       <div className="popup-background" style={popupBGStyles}>
-        <PartsLayoutRenderer onPartInit={handlePartInit} parts={parts}></PartsLayoutRenderer>
         <button
           aria-label="Close"
           className="close"
           style={popupCloseStyles}
           onClick={handleCloseIconClick}
+          ref={closeBtnRef}
         >
           <span aria-hidden={true} style={closeButtonSpanStyles}>
             x
           </span>
         </button>
+        <PartsLayoutRenderer onPartInit={handlePartInit} parts={parts}></PartsLayoutRenderer>
       </div>
     </div>
   );

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -4355,12 +4355,12 @@ dom-serializer@^1.0.1:
     domhandler "^4.2.0"
     entities "^2.0.0"
 
-dom7@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/dom7/-/dom7-3.0.0.tgz#b861ce5d67a6becd7aaa3ad02942ff14b1240331"
-  integrity sha512-oNlcUdHsC4zb7Msx7JN3K0Nro1dzJ48knvBOnDPKJ2GV9wl1i5vydJZUSyOfrkKFDZEud/jBsTk92S/VGSAe/g==
+dom7@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/dom7/-/dom7-4.0.4.tgz#8b68c5d8e5e2ed0fddb1cb93e433bc9060c8f3fb"
+  integrity sha512-DSSgBzQ4rJWQp1u6o+3FVwMNnT5bzQbMb+o31TjYYeRi05uAcpF8koxdfzeoe5ElzPmua7W7N28YJhF7iEKqIw==
   dependencies:
-    ssr-window "^3.0.0-alpha.1"
+    ssr-window "^4.0.0"
 
 domelementtype@^2.0.1, domelementtype@^2.2.0:
   version "2.2.0"
@@ -9072,10 +9072,10 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-ssr-window@^3.0.0, ssr-window@^3.0.0-alpha.1:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ssr-window/-/ssr-window-3.0.0.tgz#fd5b82801638943e0cc704c4691801435af7ac37"
-  integrity sha512-q+8UfWDg9Itrg0yWK7oe5p/XRCJpJF9OBtXfOPgSJl+u3Xd5KI328RUEvUqSMVM9CiQUEf1QdBzJMkYGErj9QA==
+ssr-window@^4.0.0, ssr-window@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/ssr-window/-/ssr-window-4.0.2.tgz#dc6b3ee37be86ac0e3ddc60030f7b3bc9b8553be"
+  integrity sha512-ISv/Ch+ig7SOtw7G2+qkwfVASzazUnvlDTwypdLoPoySv+6MqlOV10VwPSE6EWkGjhW50lUmghPmpYZXMu/+AQ==
 
 stable@^0.1.8:
   version "0.1.8"
@@ -9294,13 +9294,13 @@ swap-case@^1.1.0:
     lower-case "^1.1.1"
     upper-case "^1.1.1"
 
-swiper@^6.4.7:
-  version "6.7.1"
-  resolved "https://registry.yarnpkg.com/swiper/-/swiper-6.7.1.tgz#bfea8b9262a9898740dc64390ca681b131223fb7"
-  integrity sha512-r5Xr0WdQ7CuQiomb/8A+j9QsIl2ClQk5KoJU1jWp8/OP4OS/0ZJf5tKLWlJMPRHafy1oRsmv1lSSyzJad6XoRg==
+swiper@^8.0.6:
+  version "8.0.6"
+  resolved "https://registry.yarnpkg.com/swiper/-/swiper-8.0.6.tgz#3996d3212cb73b93e9f274e18ea58c029340c7c7"
+  integrity sha512-Ssyu1+FeNATF/G8e84QG+ZUNtUOAZ5vngdgxzczh0oWZPhGUVgkdv+BoePUuaCXLAFXnwVpNjgLIcGnxMdmWPA==
   dependencies:
-    dom7 "^3.0.0"
-    ssr-window "^3.0.0"
+    dom7 "^4.0.4"
+    ssr-window "^4.0.2"
 
 symbol-tree@^3.2.4:
   version "3.2.4"


### PR DESCRIPTION
- Fixes unresponsive carousel navigation in popups. 
- Fixes incorrect initial carousel slide in popups.
- Upgrades `Swiper.js` to the latest version.
- Enhances focus management for popups.