### PR TITLE
[FEATURE] Limit paywall editing to admins MER-840

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Handle cases where recaptcha payload is missing
 - Ensure user_id is unique in DataShop export
 - Only highlight failed grade sync cells when section is an LMS section
+- Only allow admins to edit paywall settings
 
 ### Enhancements
 
@@ -20,8 +21,8 @@
 ### Release Notes
 
 - Set up support for Legacy OLI activities as follows:
-  - Check out a copy of the repo https://github.com/Simon-Initiative/torus_superactivity to a local folder 
-  - Configure torus oli.env file to include a variable named SUPER_ACTIVITY_FOLDER and set the variable to point to the folder above, e.g. SUPER_ACTIVITY_FOLDER=torus/superactivity 
+  - Check out a copy of the repo https://github.com/Simon-Initiative/torus_superactivity to a local folder
+  - Configure torus oli.env file to include a variable named SUPER_ACTIVITY_FOLDER and set the variable to point to the folder above, e.g. SUPER_ACTIVITY_FOLDER=torus/superactivity
   - Ensure the folder is readable to the running torus instance
 - The following environment configs are now available:
 

--- a/lib/oli_web/live/products/details/edit.ex
+++ b/lib/oli_web/live/products/details/edit.ex
@@ -8,6 +8,7 @@ defmodule OliWeb.Products.Details.Edit do
   prop product, :any, default: nil
   prop changeset, :any, default: nil
   prop available_brands, :any, default: nil
+  prop is_admin, :boolean
 
   defp statuses do
     [{"Active", "active"}, {"Disabled", "deleted"}]
@@ -53,14 +54,14 @@ defmodule OliWeb.Products.Details.Edit do
           <div class="form-row">
 
             <div class="custom-control custom-switch" style="width: 200px;">
-              <%= checkbox f, :requires_payment, class: "custom-control-input" <> error_class(f, :requires_payment, "is-invalid"), autofocus: focusHelper(f, :requires_payment) %>
+              <%= checkbox f, :requires_payment, disabled: !@is_admin, class: "custom-control-input" <> error_class(f, :requires_payment, "is-invalid"), autofocus: focusHelper(f, :requires_payment) %>
               <%= label f, :requires_payment, "Requires Payment", class: "custom-control-label" %>
               <%= error_tag f, :requires_payment %>
             </div>
 
             <div class="form-group">
               <%= label f, :amount %>
-              <%= text_input f, :amount, class: "form-control", disabled: !get_field(@changeset, :requires_payment)%>
+              <%= text_input f, :amount, class: "form-control", disabled: !@is_admin or !get_field(@changeset, :requires_payment)%>
               <div><%= error_tag f, :amount %></div>
             </div>
 
@@ -70,7 +71,7 @@ defmodule OliWeb.Products.Details.Edit do
 
             <div class="custom-control custom-switch" style="width: 200px;">
               <%= checkbox f, :has_grace_period,
-                disabled: !get_field(@changeset, :requires_payment),
+                disabled: !@is_admin or !get_field(@changeset, :requires_payment),
                 class: "custom-control-input" <> error_class(f, :has_grace_period, "is-invalid"), autofocus: focusHelper(f, :requires_payment) %>
               <%= label f, :has_grace_period, "Has Grace Period", class: "custom-control-label" %>
               <%= error_tag f, :has_grace_period %>
@@ -78,13 +79,13 @@ defmodule OliWeb.Products.Details.Edit do
 
             <div class="form-group" style="max-width: 200px;">
               <%= label f, :grace_period_days %>
-              <%= text_input f, :grace_period_days, type: :number, class: "form-control", disabled: !get_field(@changeset, :requires_payment) or !get_field(@changeset, :has_grace_period) %>
+              <%= text_input f, :grace_period_days, type: :number, class: "form-control", disabled: !@is_admin or !get_field(@changeset, :requires_payment) or !get_field(@changeset, :has_grace_period) %>
               <div><%= error_tag f, :grace_period_days %></div>
             </div>
 
             <div class="form-group ml-3" style="max-width: 230px;">
               <%= label f, :grace_period_strategy %>
-              <%= select f, :grace_period_strategy, strategies(), disabled: !get_field(@changeset, :requires_payment) or !get_field(@changeset, :has_grace_period),
+              <%= select f, :grace_period_strategy, strategies(), disabled: !@is_admin or !get_field(@changeset, :requires_payment) or !get_field(@changeset, :has_grace_period),
                 class: "form-control " <> error_class(f, :grace_period_strategy, "is-invalid"),
                 autofocus: focusHelper(f, :grace_period_strategy) %>
               <div><%= error_tag f, :grace_period_strategy %></div>

--- a/lib/oli_web/live/products/details_view.ex
+++ b/lib/oli_web/live/products/details_view.ex
@@ -60,7 +60,7 @@ defmodule OliWeb.Products.DetailsView do
           </div>
         </div>
         <div class="col-md-8">
-          <Edit product={@product} changeset={@changeset} available_brands={@available_brands}/>
+          <Edit product={@product} changeset={@changeset} available_brands={@available_brands} is_admin={@is_admin}/>
         </div>
       </div>
       <div class="row py-5 border-bottom">

--- a/lib/oli_web/live/sections/edit_view.ex
+++ b/lib/oli_web/live/sections/edit_view.ex
@@ -109,11 +109,8 @@ defmodule OliWeb.Sections.EditView do
     |> Map.put("end_date", utc_end_date)
   end
 
-  # A user can make paywall edits if any of the following are true:
-  # 1. They are logged in as an admin user
-  # 2. The course section being edited was not created from a product
-  # 3. The course section being edited was created from a product that does not require payment
-  defp can_change_payment?(section, is_admin?) do
-    is_admin? or is_nil(section.blueprint_id) or !section.blueprint.requires_payment
+  # A user can make paywall edits only if they are logged in as an admin user
+  defp can_change_payment?(_section, is_admin?) do
+    is_admin?
   end
 end


### PR DESCRIPTION
This PR limits paywall settings editing to author admin accounts only. 

This is a relatively low risk change. I've tested it interactively to ensure that only an admin can edit these settings now.