### PR TITLE
[BUGFIX] [MER-759] [MER-740] Invite section link issues

### DIFF
--- a/lib/oli/delivery/sections/section_invites.ex
+++ b/lib/oli/delivery/sections/section_invites.ex
@@ -43,8 +43,13 @@ defmodule Oli.Delivery.Sections.SectionInvites do
   Gets the attached section when given a section invite slug.
   """
   def get_section_by_invite_slug(section_invite_slug) when is_binary(section_invite_slug) do
-    section_invite = get_section_invite(section_invite_slug)
-    Sections.get_section!(section_invite.section_id)
+    case get_section_invite(section_invite_slug) do
+      nil ->
+        nil
+
+      section_invite ->
+        Sections.get_section!(section_invite.section_id)
+    end
   end
 
   @doc """
@@ -58,8 +63,10 @@ defmodule Oli.Delivery.Sections.SectionInvites do
   end
 
   @doc """
-  Determines if a user is an administrator in a given section.
+  Determines if a section invite link is expired
   """
+  def link_expired?(nil), do: true
+
   def link_expired?(%SectionInvite{} = section_invite) do
     NaiveDateTime.compare(now(), section_invite.date_expires) == :gt
   end

--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -2,7 +2,7 @@ defmodule OliWeb.DeliveryController do
   use OliWeb, :controller
 
   alias Oli.Delivery.Sections
-  alias Oli.Delivery.Sections.{Section, SectionInvites}
+  alias Oli.Delivery.Sections.Section
   alias Oli.Publishing
   alias Oli.Institutions
   alias Lti_1p3.Tool.{PlatformRoles, ContextRoles}
@@ -476,17 +476,8 @@ defmodule OliWeb.DeliveryController do
     end
   end
 
-  def enroll_independent(conn, %{"section_invite_slug" => invite_slug}) do
-    section_invite = SectionInvites.get_section_invite(invite_slug)
-
-    if !SectionInvites.link_expired?(section_invite) do
-      section = SectionInvites.get_section_by_invite_slug(invite_slug)
-      render(conn, "enroll.html", section: section)
-    else
-      conn
-      |> redirect(to: Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.InvalidSectionInviteView))
-    end
-  end
+  def enroll_independent(conn, %{"section_invite_slug" => _invite_slug}),
+    do: render(conn, "enroll.html", section: conn.assigns.section)
 
   defp recaptcha_verified?(g_recaptcha_response) do
     Oli.Utils.Recaptcha.verify(g_recaptcha_response) == {:success, true}

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -616,6 +616,17 @@ defmodule OliWeb.Router do
     get("/", DeliveryController, :open_and_free_index)
 
     live("/join/invalid", Sections.InvalidSectionInviteView)
+  end
+
+  scope "/sections", OliWeb do
+    pipe_through([
+      :browser,
+      :delivery,
+      :require_section,
+      :delivery_protected,
+      :pow_email_layout
+    ])
+
     get("/join/:section_invite_slug", DeliveryController, :enroll_independent)
   end
 

--- a/test/oli/section_invites_test.exs
+++ b/test/oli/section_invites_test.exs
@@ -69,9 +69,14 @@ defmodule Oli.SectionInvitesTest do
 
       assert SectionInvites.link_expired?(invite) == true
       assert SectionInvites.link_expired?(invite.slug) == true
+
+      assert SectionInvites.link_expired?(nil) == true
     end
 
     test "getters work", %{section_invite: section_invite, section: section} do
+      refute SectionInvites.get_section_invite("other_invite")
+      refute SectionInvites.get_section_by_invite_slug("other_invite")
+
       assert SectionInvites.get_section_invite(section_invite.slug) == section_invite
       assert SectionInvites.get_section_by_invite_slug(section_invite.slug).id == section.id
     end

--- a/test/oli_web/controllers/delivery_controller_test.exs
+++ b/test/oli_web/controllers/delivery_controller_test.exs
@@ -8,6 +8,8 @@ defmodule OliWeb.DeliveryControllerTest do
   alias Lti_1p3.Tool.ContextRoles
   alias Oli.Delivery.Sections
 
+  import Oli.Factory
+
   describe "delivery_controller index" do
     setup [:setup_lti_session]
 
@@ -291,6 +293,51 @@ defmodule OliWeb.DeliveryControllerTest do
       conn = get(conn, Routes.delivery_path(conn, :show_enroll, section.slug))
 
       assert html_response(conn, 403) =~ "Section Has Not Started"
+    end
+  end
+
+  @moduletag :capture_log
+  describe "enroll independent (without user logged in)" do
+    test "redirects to invalid join when invite slug does not exist", %{conn: conn} do
+      conn = get(conn, Routes.delivery_path(conn, :enroll_independent, "some_invitation"))
+
+      assert html_response(conn, 302) =~
+               "You are being <a href=\"/sections/join/invalid\">redirected"
+    end
+
+    test "redirects to login form with section slug as query param", %{conn: conn} do
+      section = insert(:section)
+      section_invite = insert(:section_invite, %{section: section})
+
+      conn = get(conn, Routes.delivery_path(conn, :enroll_independent, section_invite.slug))
+
+      assert html_response(conn, 302) =~
+               "You are being <a href=\"/session/new?request_path=%2Fsections%2Fjoin%2F#{section_invite.slug}&amp;section=#{section.slug}\">redirected"
+    end
+  end
+
+  @moduletag :capture_log
+  describe "enroll independent (with user logged in)" do
+    setup [:user_conn]
+
+    test "redirects to invalid join view", %{conn: conn} do
+      section = insert(:section)
+      date_expires = DateTime.add(DateTime.utc_now(), -3600)
+      section_invite = insert(:section_invite, %{section: section, date_expires: date_expires})
+
+      conn = get(conn, Routes.delivery_path(conn, :enroll_independent, section_invite.slug))
+
+      assert html_response(conn, 302) =~
+               "You are being <a href=\"/sections/join/invalid\">redirected"
+    end
+
+    test "shows enroll view", %{conn: conn} do
+      section = insert(:section)
+      section_invite = insert(:section_invite, %{section: section})
+
+      conn = get(conn, Routes.delivery_path(conn, :enroll_independent, section_invite.slug))
+
+      assert html_response(conn, 200) =~ "Enroll in Course Section"
     end
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -4,7 +4,15 @@ defmodule Oli.Factory do
   alias Oli.Accounts.{Author, User}
   alias Oli.Authoring.Course.{Family, Project, ProjectVisibility}
   alias Oli.Delivery.Gating.GatingCondition
-  alias Oli.Delivery.Sections.{Enrollment, Section, SectionsProjectsPublications, SectionResource}
+
+  alias Oli.Delivery.Sections.{
+    Enrollment,
+    Section,
+    SectionsProjectsPublications,
+    SectionResource,
+    SectionInvite
+  }
+
   alias Oli.Delivery.Paywall.Payment
   alias Oli.Groups.{Community, CommunityAccount, CommunityInstitution, CommunityVisibility}
   alias Oli.Institutions.{Institution, SsoJwk}
@@ -270,6 +278,16 @@ defmodule Oli.Factory do
       active: true,
       start: start_date,
       end: end_date
+    }
+  end
+
+  def section_invite_factory() do
+    date_expires = DateTime.add(DateTime.utc_now(), 3600)
+
+    %SectionInvite{
+      section: insert(:section),
+      slug: sequence("exampleinvite"),
+      date_expires: date_expires
     }
   end
 end


### PR DESCRIPTION
[MER-759](https://eliterate.atlassian.net/browse/MER-759) and [MER-740](https://eliterate.atlassian.net/browse/MER-740)

Fix two issues:
- Section metadata not being stored when attempting to create an account accessing the app through a section invite link
- Render view correctly after invite link is deleted