### PR TITLE
[FEATURE] Authoring/Clone Portal flow. WORK-IN-PROGRESS-DO-NOT-MERGE

### DIFF
--- a/lib/oli/authoring/clone.ex
+++ b/lib/oli/authoring/clone.ex
@@ -78,8 +78,7 @@ defmodule Oli.Authoring.Clone do
   end
 
   @doc """
-  Returns true if the given author already is a collaborator on a project that was cloned from the
-  project specified by the given project slug.
+  Returns the existing clones from a parent project that an author might have.
   """
   def existing_clones(project_slug, author) do
     from(
@@ -96,6 +95,10 @@ defmodule Oli.Authoring.Clone do
     |> Repo.all()
   end
 
+  @doc """
+  Returns true if the given author already is a collaborator on a project that was cloned from the
+  project specified by the given project slug.
+  """
   def already_has_clone?(project_slug, author) do
     existing_clones(project_slug, author)
     |> Enum.count() > 0

--- a/lib/oli/authoring/course/project.ex
+++ b/lib/oli/authoring/course/project.ex
@@ -12,6 +12,7 @@ defmodule Oli.Authoring.Course.Project do
     field :version, :string
     field :visibility, Ecto.Enum, values: [:authors, :selected, :global], default: :authors
     field :status, Ecto.Enum, values: [:active, :deleted], default: :active
+    field :allow_duplication, :boolean, default: false
 
     belongs_to :parent_project, Oli.Authoring.Course.Project, foreign_key: :project_id
     belongs_to :family, Oli.Authoring.Course.Family
@@ -47,7 +48,8 @@ defmodule Oli.Authoring.Course.Project do
       :family_id,
       :project_id,
       :visibility,
-      :status
+      :status,
+      :allow_duplication
     ])
     |> validate_required([:title, :version, :family_id])
     |> Slug.update_never("projects")

--- a/lib/oli/groups.ex
+++ b/lib/oli/groups.ex
@@ -157,6 +157,40 @@ defmodule Oli.Groups do
   end
 
   @doc """
+  Finds or creates a community account for an author. More efficient than using
+  many-to-many assoc.
+
+  ## Examples
+
+      iex> find_or_create_community_author_account(author_id, community_id)
+      {:ok, %CommunityAccount{}}
+
+      iex> find_or_create_community_author_account(bad_author_id, community_id)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def find_or_create_community_author_account(author_id, community_id) do
+    Repo.transaction(fn _ ->
+      case Repo.one(
+             from(account in CommunityAccount,
+               where:
+                 account.author_id == ^author_id and
+                   account.community_id == ^community_id
+             )
+           ) do
+        nil ->
+          {:ok, account} =
+            create_community_account(%{author_id: author_id, community_id: community_id})
+
+          account
+
+        account ->
+          account
+      end
+    end)
+  end
+
+  @doc """
   Creates a community account.
 
   ## Examples

--- a/lib/oli_web/controllers/cognito_controller.ex
+++ b/lib/oli_web/controllers/cognito_controller.ex
@@ -122,19 +122,25 @@ defmodule OliWeb.CognitoController do
     render(conn, "index.html", projects: projects, project_slug: project_slug)
   end
 
-  def create(conn, %{"project_slug" => project_slug}) do
+  def clone(conn, %{"project_slug" => project_slug}) do
     author = conn.assigns.current_author
 
-    case Oli.Authoring.Clone.clone_project(project_slug, author) do
-      {:ok, dupe} ->
-        redirect(conn, to: Routes.project_path(conn, :overview, dupe.slug))
+    case Oli.Authoring.Course.get_project_by_slug(project_slug) do
+      %Project{allow_duplication: true} ->
+        case Oli.Authoring.Clone.clone_project(project_slug, author) do
+          {:ok, dupe} ->
+            redirect(conn, to: Routes.project_path(conn, :overview, dupe.slug))
 
-      {:error, error} ->
-        redirect_with_error(conn, %{}, snake_case_to_friendly(error))
+          {:error, error} ->
+            redirect_with_error(conn, %{}, snake_case_to_friendly(error))
+        end
+
+      _ ->
+        redirect_with_error(conn, %{}, "This is not supported")
     end
   end
 
-  def create(conn, params) do
+  def clone(conn, params) do
     redirect_with_error(conn, params, "Missing parameters")
   end
 

--- a/lib/oli_web/controllers/cognito_controller.ex
+++ b/lib/oli_web/controllers/cognito_controller.ex
@@ -267,7 +267,7 @@ defmodule OliWeb.CognitoController do
   defp clone_or_prompt(conn, author, %Project{} = project) do
     if project.allow_duplication do
       if Oli.Authoring.Clone.already_has_clone?(project.slug, author) do
-        redirect(conn, to: Routes.cognito_path(conn, :prompt, project_slug: project.slug))
+        redirect(conn, to: Routes.cognito_path(conn, :prompt, project.slug))
       else
         case Oli.Authoring.Clone.clone_project(project.slug, author) do
           {:ok, dupe} ->

--- a/lib/oli_web/live/projects/visibility.ex
+++ b/lib/oli_web/live/projects/visibility.ex
@@ -30,6 +30,26 @@ defmodule OliWeb.Projects.VisibilityLive do
     ~L"""
     <div class="row py-5 border-bottom">
       <div class="col-md-4">
+        <h4>Allow Duplication</h4>
+        <div class="text-muted">Control whether other users can create duplicates of your projects for their own development.</div>
+      </div>
+      <div class="col-md-8">
+        <form phx-change="duplication" id="duplication_option">
+          <div class="form-check">
+            <%= label class: "form-check-label" do %>
+              <%= checkbox :duplication, :allow_duplication, id: "dupe_check", class: "form-check-input", checked: @project.allow_duplication %>
+              Allow other users to create full copies of this course project for their own editing and development.
+            <% end %>
+          </div>
+        </form>
+
+        <div class="alert alert-info mt-5" role="alert">
+          <strong>Note:</strong> Edits made to duplicates created by other users will not affect your course project in any way.
+        </div>
+      </div>
+    </div>
+    <div class="row py-5 border-bottom">
+      <div class="col-md-4">
         <h4>Publishing Visibility</h4>
         <div class="text-muted">Control who can create course sections for this project once it is published.</div>
       </div>
@@ -236,6 +256,11 @@ defmodule OliWeb.Projects.VisibilityLive do
 
   def handle_event("option", %{"visibility" => %{"option" => option}}, socket) do
     {:ok, project} = Course.update_project(socket.assigns.project, %{visibility: option})
+    {:noreply, assign(socket, :project, project)}
+  end
+
+  def handle_event("duplication", %{"duplication" => %{"allow_duplication" => value}}, socket) do
+    {:ok, project} = Course.update_project(socket.assigns.project, %{allow_duplication: value})
     {:noreply, assign(socket, :project, project)}
   end
 

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -898,7 +898,7 @@ defmodule OliWeb.Router do
     ])
 
     get("/prompt", CognitoController, :prompt)
-    get("/clone", CognitoController, :clone)
+    get("/clone/:project_slug", CognitoController, :clone)
   end
 
   # routes only accessible when load testing mode is enabled. These routes exist solely

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -879,6 +879,26 @@ defmodule OliWeb.Router do
     get("/launch", CognitoController, :index)
     get("/launch/products/:product_slug", CognitoController, :launch)
     get("/launch/projects/:project_slug", CognitoController, :launch)
+
+    get("/launch_clone/products/:product_slug", CognitoController, :launch_clone,
+      as: :product_clone
+    )
+
+    get("/launch_clone/projects/:project_slug", CognitoController, :launch_clone,
+      as: :project_clone
+    )
+  end
+
+  scope "/cognito", OliWeb do
+    pipe_through([
+      :browser,
+      :authoring_protected,
+      :workspace,
+      :authoring
+    ])
+
+    get("/prompt", CognitoController, :prompt)
+    get("/clone", CognitoController, :clone)
   end
 
   # routes only accessible when load testing mode is enabled. These routes exist solely

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -897,7 +897,7 @@ defmodule OliWeb.Router do
       :authoring
     ])
 
-    get("/prompt", CognitoController, :prompt)
+    get("/prompt/:project_slug", CognitoController, :prompt)
     get("/clone/:project_slug", CognitoController, :clone)
   end
 

--- a/lib/oli_web/templates/cognito/index.html.eex
+++ b/lib/oli_web/templates/cognito/index.html.eex
@@ -1,0 +1,18 @@
+<div>
+
+  <h3>Access Course Project</h3>
+
+  <p>You have already created one or more copies of this course.</p>
+
+  <p>Would you like to
+    <%= link "create another copy", to: Routes.cognito_path(@conn, :another_copy, @project_slug) %>
+    or access one of your existing copies?
+  </p>
+
+  <ul>
+    <% for p <- @projects do %>
+      <li><%= link p.title, to: Routes.project_path(@conn, :overview, @project_slug) %></li>
+    <% end %>
+  </ul>
+
+</div>

--- a/lib/oli_web/templates/cognito/index.html.eex
+++ b/lib/oli_web/templates/cognito/index.html.eex
@@ -5,7 +5,7 @@
   <p>You have already created one or more copies of this course.</p>
 
   <p>Would you like to
-    <%= link "create another copy", to: Routes.cognito_path(@conn, :create, @project_slug) %>
+    <%= link "create another copy", to: Routes.cognito_path(@conn, :clone, @project_slug) %>
     or access one of your existing copies?
   </p>
 

--- a/lib/oli_web/templates/cognito/index.html.eex
+++ b/lib/oli_web/templates/cognito/index.html.eex
@@ -10,7 +10,7 @@
   </p>
 
   <ul>
-    <% for p <- @projects do %>
+    <%= for p <- @projects do %>
       <li><%= link p.title, to: Routes.project_path(@conn, :overview, @project_slug) %></li>
     <% end %>
   </ul>

--- a/lib/oli_web/templates/cognito/index.html.eex
+++ b/lib/oli_web/templates/cognito/index.html.eex
@@ -5,7 +5,7 @@
   <p>You have already created one or more copies of this course.</p>
 
   <p>Would you like to
-    <%= link "create another copy", to: Routes.cognito_path(@conn, :another_copy, @project_slug) %>
+    <%= link "create another copy", to: Routes.cognito_path(@conn, :create, @project_slug) %>
     or access one of your existing copies?
   </p>
 

--- a/lib/oli_web/views/cognito_view.ex
+++ b/lib/oli_web/views/cognito_view.ex
@@ -1,0 +1,3 @@
+defmodule OliWeb.CognitoView do
+  use OliWeb, :view
+end

--- a/priv/repo/migrations/20220216150213_allow_duplication.exs
+++ b/priv/repo/migrations/20220216150213_allow_duplication.exs
@@ -1,0 +1,15 @@
+defmodule Oli.Repo.Migrations.AllowDuplication do
+  use Ecto.Migration
+
+  def change do
+    alter table(:projects) do
+      add :allow_duplication, :boolean, default: false, null: false
+    end
+
+    flush()
+
+    execute "UPDATE projects SET allow_duplication = false;"
+
+    flush()
+  end
+end

--- a/test/oli/clone_test.exs
+++ b/test/oli/clone_test.exs
@@ -34,6 +34,28 @@ defmodule Oli.CloneTest do
       )
     end
 
+    test "already_has_clone/2 and existing_clones/2 works", %{
+      project: project,
+      author2: author2,
+      author: author
+    } do
+      assert Clone.already_has_clone?(project.slug, author2)
+      refute Clone.already_has_clone?(project.slug, author)
+
+      # Clone the project again for author2
+      Clone.clone_project(project.slug, author2)
+      assert Clone.already_has_clone?(project.slug, author2)
+      refute Clone.already_has_clone?(project.slug, author)
+
+      assert Clone.existing_clones(project.slug, author2) |> Enum.count() == 2
+
+      # Now clone it for the original author
+      {:ok, %{id: id}} = Clone.clone_project(project.slug, author)
+      assert Clone.already_has_clone?(project.slug, author)
+
+      assert [%{id: ^id}] = Clone.existing_clones(project.slug, author)
+    end
+
     test "clone_project/2 creates a new family", %{family: family, duplicated: duplicated} do
       assert %Family{} = duplicated.family
       assert family.title <> " Copy" == duplicated.family.title

--- a/test/oli_web/controllers/cognito_controller_test.exs
+++ b/test/oli_web/controllers/cognito_controller_test.exs
@@ -425,7 +425,7 @@ defmodule OliWeb.CognitoControllerTest do
                "<html><body>You are being <a href=\"/authoring/project/"
     end
 
-    test "properly redirects to the intersitial page to prompt if they really want to clone again",
+    test "properly redirects to the interstitial page to prompt if they really want to clone again",
          %{
            conn: conn,
            community: community,
@@ -448,7 +448,7 @@ defmodule OliWeb.CognitoControllerTest do
       assert conn
              |> get(Routes.project_clone_path(conn, :launch_clone, project.slug, params))
              |> html_response(302) =~
-               "<html><body>You are being <a href=\"/cognito/prompt?project_slug="
+               "<html><body>You are being <a href=\"/cognito/prompt"
     end
 
     test "forbids a user with an authoring account to clone a project that does not allow duplication",


### PR DESCRIPTION
This PR implements 95% of what I believe that we need to support a Cognito user launching into Torus to obtain an authoring account, join a community, and get their own cloned copy of a specific *Project*

The missing piece is how to implement support for creating the Cognito based authoring account.  This would take place in the cognito controller: 

```
  defp find_or_create_author(fields, _communit_id) do
    case Accounts.get_author_by_email(fields["email"]) do
      nil -> {:ok, nil}
      author -> {:ok, author}
    end
  end
```

You can see above that when the account does not exist, the implementation of the creation is stubbed out (returning `{:ok, nil}`. 

The catch here to properly support adding Cognito based author accounts is that we need to configure and add a new `PowAssent` provider (similar to what exists right now for Google and GitHub) to support Cognito.  I suspect an Oauth2 or perhaps an OIDC based provider would work - but I don't have all the details on Cognito to attempt this, or to test it out. 

[https://github.com/pow-auth/pow_assent/blob/master/README.md](https://github.com/pow-auth/pow_assent/blob/master/README.md) contains an example OIDC configuration. 