### PR TITLE
[BUGFIX] enable SSL configuration at runtime

### DIFF
--- a/config/releases.exs
+++ b/config/releases.exs
@@ -158,6 +158,12 @@ config :oli, OliWeb.Endpoint,
     host: host,
     port: String.to_integer(System.get_env("PORT", "443"))
   ],
+  https: [
+    port: 443,
+    otp_app: :oli,
+    keyfile: System.get_env("SSL_CERT_PATH", "priv/ssl/localhost.key"),
+    certfile: System.get_env("SSL_KEY_PATH", "priv/ssl/localhost.crt")
+  ],
   secret_key_base: secret_key_base,
   live_view: [signing_salt: live_view_salt]
 


### PR DESCRIPTION
This PR is a result of the prod server setup document where enabling SSL configuration at runtime was not previously possible.