### PR TITLE
[BUGFIX] [MER-842] [MER-853] System Message Banner issues

### DIFF
--- a/lib/oli_web/live/system_message_live/show_view.ex
+++ b/lib/oli_web/live/system_message_live/show_view.ex
@@ -1,5 +1,5 @@
 defmodule OliWeb.SystemMessageLive.ShowView do
-  use Surface.LiveView, layout: {OliWeb.LayoutView, "live.html"}
+  use Surface.LiveView
 
   alias Oli.Notifications
   alias Oli.Notifications.PubSub

--- a/test/oli_web/live/system_message_live_test.exs
+++ b/test/oli_web/live/system_message_live_test.exs
@@ -48,6 +48,20 @@ defmodule OliWeb.SystemMessageLiveTest do
              |> render() =~ system_message.message
     end
 
+    test "uses UTC timezone by default when local timezone is not set", %{conn: conn} do
+      conn = delete_session(conn, :local_tz)
+
+      {:ok, view, _html} =
+        conn
+        |> delete_session(:local_tz)
+        |> live(@live_view_index_route)
+
+      assert view
+             |> element("div[class=\"alert alert-info\"]")
+             |> render() =~
+               "The local timezone is not set in your browser. UTC is used by default."
+    end
+
     test "creates new system message when data is valid", %{conn: conn} do
       {:ok, view, _html} = live(conn, @live_view_index_route)
 


### PR DESCRIPTION
[MER-853](https://eliterate.atlassian.net/browse/MER-853) & [MER-842](https://eliterate.atlassian.net/browse/MER-842)

Fix the following bugs:
- Internal Server Error being raised when an admin tries to manage system messages and the local timezone is not set (this is a separate issue: [MER-838](https://eliterate.atlassian.net/browse/MER-838)).
- Duplicate flash messages showing up.