### PR TITLE
[BUG FIX] allow integers for group ids

### DIFF
--- a/priv/schemas/v0-1-0/activity-reference.schema.json
+++ b/priv/schemas/v0-1-0/activity-reference.schema.json
@@ -9,7 +9,10 @@
       "const": "activity-reference"
     },
     "activity_id": {
-      "type": ["integer", "string"]
+      "type": [
+        "integer",
+        "string"
+      ]
     },
     "purpose": {
       "enum": [

--- a/priv/schemas/v0-1-0/group-content.schema.json
+++ b/priv/schemas/v0-1-0/group-content.schema.json
@@ -6,7 +6,10 @@
   "type": "object",
   "properties": {
     "id": {
-      "type": "string"
+      "type": [
+        "integer",
+        "string"
+      ]
     },
     "type": {
       "const": "group"

--- a/priv/schemas/v0-1-0/structured-content.schema.json
+++ b/priv/schemas/v0-1-0/structured-content.schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "http://torus.oli.cmu.edu/schemas/v0-1-0/group-content.schema.json",
+  "$id": "http://torus.oli.cmu.edu/schemas/v0-1-0/structured-content.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema",
   "title": "Structured Content",
   "description": "An ordered set of structured content",


### PR DESCRIPTION
This PR fixes the following issues related to schemas
- reduce constraint to allow integers for group ids
- fix structured content schema id
- formatting