### PR TITLE
[BUG FIX] Restore search functionality in Projects, Users views MER-889

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bug Fixes
 
+- Fix inability to search in projects and users view
+
 ### Enhancements
 
 - Allow for student-specific gating exceptions

--- a/assets/src/hooks/text_input_listener.ts
+++ b/assets/src/hooks/text_input_listener.ts
@@ -1,10 +1,10 @@
 export const TextInputListener = {
   mounted() {
     const change_event = this.el.getAttribute('phx-value-change') || 'change';
-    const target = this.el.getAttribute('phx-hook-target') || ':live_view';
-    console.log(target);
+    const target = this.el.getAttribute('phx-hook-target') || 'live_view';
+
     this.el.addEventListener('input', (e: any) => {
-      if (target === ':live_view') {
+      if (target === ':live_view' || target === 'live_view') {
         this.pushEvent(change_event, { id: e.target.id, value: e.target.value });
       } else {
         this.pushEventTo(target, change_event, { id: e.target.id, value: e.target.value });


### PR DESCRIPTION
Student Exceptions feature introduced a regression where it broke the ability to do text searches on the Projects and Users views. This was due to the `event_target` attribute not being handled properly.  In some cases what actually gets pushed down to the Phoenix JS Hook is `"live_view"` and not `":live_view"`.  This impl now handles both, which restores the search functionality. 