### PR TITLE
[BUG FIX] Only enable SSL if SSL_CERT_PATH and SSL_KEY_PATH are configured

### DIFF
--- a/config/releases.exs
+++ b/config/releases.exs
@@ -158,14 +158,18 @@ config :oli, OliWeb.Endpoint,
     host: host,
     port: String.to_integer(System.get_env("PORT", "443"))
   ],
-  https: [
-    port: 443,
-    otp_app: :oli,
-    keyfile: System.get_env("SSL_CERT_PATH", "priv/ssl/localhost.key"),
-    certfile: System.get_env("SSL_KEY_PATH", "priv/ssl/localhost.crt")
-  ],
   secret_key_base: secret_key_base,
   live_view: [signing_salt: live_view_salt]
+
+if System.get_env("SSL_CERT_PATH") && System.get_env("SSL_KEY_PATH") do
+  config :oli, OliWeb.Endpoint,
+    https: [
+      port: 443,
+      otp_app: :oli,
+      keyfile: System.get_env("SSL_CERT_PATH", "priv/ssl/localhost.key"),
+      certfile: System.get_env("SSL_KEY_PATH", "priv/ssl/localhost.crt")
+    ]
+end
 
 # Configure Mnesia directory (used by pow persistent sessions)
 config :mnesia, :dir, to_charlist(System.get_env("MNESIA_DIR", ".mnesia"))

--- a/oli.example.env
+++ b/oli.example.env
@@ -15,9 +15,6 @@ ADMIN_PASSWORD=changeme
 ## Change DB_HOST to localhost if running app natively (development only)
 DB_HOST=localhost
 
-## Specify a subdomain for localtunnel (development only)
-# SUBDOMAIN=oli-torus
-
 ## Database url with credentials (required for production only)
 # DATABASE_URL=ecto://postgres:changeme@postgres/oli
 


### PR DESCRIPTION
This PR changes torus configuration to only enable SSL if SSL_CERT_PATH and SSL_KEY_PATH are configured. It fixes a production issue identified where torus raises :eaddrinuse on startup if an SSL termination proxy is already running on the same machine.