### PR TITLE
[BUG FIX] Allow clearing of text search to work properly MER-889

### DIFF
--- a/lib/oli_web/live/common/text_search.ex
+++ b/lib/oli_web/live/common/text_search.ex
@@ -13,7 +13,7 @@ defmodule OliWeb.Common.TextSearch do
         <input id={"#{id}-input"} type="text" class="form-control" placeholder="Search..." value={@text} phx-hook="TextInputListener" phx-hook-target={@event_target} phx-value-change={@change}>
         {#if @text != ""}
           <div class="input-group-append">
-            <button class="btn btn-outline-secondary" :on-click={@reset} phx-value-id={@id}><i class="las la-times"></i></button>
+            <button class="btn btn-outline-secondary" phx-click={@reset} phx-value-id={@id}><i class="las la-times"></i></button>
           </div>
         {/if}
       </div>


### PR DESCRIPTION
Student exceptions work introduced a regression where the clear button ("X") for the text search component was no longer working in situations where the LiveView needed to handle the event.  The fix here was to bypass the Surface event handler, which must be pinning it to the component (since that component is a stateful component).  This change allows it to work in situations where the LV needs to handle the event 

Tested with various uses (Projects view, Users view, All Sections View) as well as the EnrollmentPicker LiveComponent. 
