### PR TITLE
[BUG FIX] Properly handle unavailable sections MER-865

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 - Fix inability to search in projects and users view
+- Properly handle the case that a section invite link leads to an unavailable section
 
 ### Enhancements
 

--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -476,8 +476,8 @@ defmodule OliWeb.DeliveryController do
     end
   end
 
-  def enroll_independent(conn, %{"section_invite_slug" => _invite_slug}),
-    do: render(conn, "enroll.html", section: conn.assigns.section)
+  def enroll_independent(conn, %{"section_invite_slug" => _invite_slug} = params),
+    do: show_enroll(conn, params)
 
   defp recaptcha_verified?(g_recaptcha_response) do
     Oli.Utils.Recaptcha.verify(g_recaptcha_response) == {:success, true}


### PR DESCRIPTION
This PR fixes a problem that if a student which already has an account, attempts to use a section invite link to a section that either 1) Hasn't started or 2) Has already ended, the "Section Unavailable due to ...." page does not render. Instead, the Enroll view with the recaptcha renders, and when the student attempts to enroll they receive and error. 

The fix here was to simply run the `enroll_independent` endpoint function through the existing `show_enroll` function.  That picks up the logic of checking to see if the section is available prior to rendering the Enroll screen.



