### PR TITLE
[BUG FIX] Improve course outline rendering

### DIFF
--- a/lib/oli_web/templates/page_delivery/_link_assessment.html.eex
+++ b/lib/oli_web/templates/page_delivery/_link_assessment.html.eex
@@ -1,8 +1,6 @@
 <%= link to: @page_link_url.(@node.revision.slug),
   class: resource_link_class(@active_page == @node.revision.slug) <> " graded-page-link" do %>
-  <div class="d-flex w-100 justify-content-between">
-    <span class="page-title">
-      <i class="far fa-check-circle mr-2"></i> <%= @node.revision.title %>
-    </span>
-  </div>
+  <span class="page-title">
+    <i class="far fa-check-circle mr-2"></i> <%= @node.revision.title %>
+  </span>
 <% end %>

--- a/lib/oli_web/templates/page_delivery/_link_assessment.html.eex
+++ b/lib/oli_web/templates/page_delivery/_link_assessment.html.eex
@@ -1,5 +1,5 @@
 <%= link to: @page_link_url.(@node.revision.slug),
-  class: resource_link_class(@active_page == @node.revision.slug) <> " graded-page-link" do %>
+  class: resource_link_class(@active_page == @node.revision.slug) do %>
   <span class="page-title">
     <i class="far fa-check-circle mr-2"></i> <%= @node.revision.title %>
   </span>

--- a/lib/oli_web/templates/page_delivery/_link_container.html.eex
+++ b/lib/oli_web/templates/page_delivery/_link_container.html.eex
@@ -1,19 +1,20 @@
-<%= link to: @container_link_url.(@node.revision.slug),
-  class: resource_link_class(@active_page == @node.revision.slug) <> " ungraded-page-link" do %>
-  <div class="d-flex w-100 justify-content-between">
+
+<h5 class="text-primary border-primary mb-2">
+  <%= link to: @container_link_url.(@node.revision.slug),
+    class: resource_link_class(@active_page == @node.revision.slug) <> " container-page-link" do %>
     <span class="container-title my-2">
       <%= container_title(@node) %>
     </span>
-  </div>
-<% end %>
+  <% end %>
+</h5>
 
-<div style="padding-left: <%= @node.numbering.level * 20 %>px">
-  <%= if Enum.empty?(@node.children) do %>
-    <span class="text-secondary">There are no items</span>
-  <% else %>
+<%= if Enum.empty?(@node.children) do %>
+  <span class="text-secondary">There are no items</span>
+<% else %>
+  <ol style="list-style: none;">
     <%= render"_outline.html", Map.merge(assigns, %{
       nodes: @node.children,
       active_page: nil,
     }) %>
-  <% end %>
-</div>
+  </ol>
+<% end %>

--- a/lib/oli_web/templates/page_delivery/_link_container.html.eex
+++ b/lib/oli_web/templates/page_delivery/_link_container.html.eex
@@ -1,7 +1,7 @@
 
 <h5 class="text-primary border-primary mb-2">
   <%= link to: @container_link_url.(@node.revision.slug),
-    class: resource_link_class(@active_page == @node.revision.slug) <> " container-page-link" do %>
+    class: resource_link_class(@active_page == @node.revision.slug) do %>
     <span class="container-title my-2">
       <%= container_title(@node) %>
     </span>

--- a/lib/oli_web/templates/page_delivery/_link_page.html.eex
+++ b/lib/oli_web/templates/page_delivery/_link_page.html.eex
@@ -1,5 +1,5 @@
 <%= link to: @page_link_url.(@node.revision.slug),
-  class: resource_link_class(@active_page == @node.revision.slug) <> " ungraded-page-link" do %>
+  class: resource_link_class(@active_page == @node.revision.slug) do %>
   <span class="page-title">
     <i class="far fa-file mr-2"></i> <%= @node.revision.title %>
   </span>

--- a/lib/oli_web/templates/page_delivery/_link_page.html.eex
+++ b/lib/oli_web/templates/page_delivery/_link_page.html.eex
@@ -1,8 +1,6 @@
 <%= link to: @page_link_url.(@node.revision.slug),
   class: resource_link_class(@active_page == @node.revision.slug) <> " ungraded-page-link" do %>
-  <div class="d-flex w-100 justify-content-between">
-    <span class="page-title">
-      <i class="far fa-file mr-2"></i> <%= @node.revision.title %>
-    </span>
-  </div>
+  <span class="page-title">
+    <i class="far fa-file mr-2"></i> <%= @node.revision.title %>
+  </span>
 <% end %>

--- a/lib/oli_web/templates/page_delivery/_link_shallow_container.html.eex
+++ b/lib/oli_web/templates/page_delivery/_link_shallow_container.html.eex
@@ -1,8 +1,6 @@
 <%= link to: @container_link_url.(@node.revision.slug),
-  class: resource_link_class(@active_page == @node.revision.slug) <> " ungraded-page-link" do %>
-  <div class="d-flex w-100 justify-content-between">
-    <span class="container-title my-2">
-      <%= container_title(@node) %>
-    </span>
-  </div>
+  class: resource_link_class(@active_page == @node.revision.slug) <> " container-page-link" do %>
+  <span class="container-title my-2">
+    <%= container_title(@node) %>
+  </span>
 <% end %>

--- a/lib/oli_web/templates/page_delivery/_link_shallow_container.html.eex
+++ b/lib/oli_web/templates/page_delivery/_link_shallow_container.html.eex
@@ -1,5 +1,5 @@
 <%= link to: @container_link_url.(@node.revision.slug),
-  class: resource_link_class(@active_page == @node.revision.slug) <> " container-page-link" do %>
+  class: resource_link_class(@active_page == @node.revision.slug) do %>
   <span class="container-title my-2">
     <%= container_title(@node) %>
   </span>

--- a/lib/oli_web/templates/page_delivery/_outline.html.eex
+++ b/lib/oli_web/templates/page_delivery/_outline.html.eex
@@ -1,4 +1,5 @@
 <%= for node <- @nodes do %>
+  <li>
   <% props = Map.merge(assigns, %{
     node: node,
     nodes: node.children,
@@ -11,4 +12,5 @@
     <% true -> %>
       <%= render "_link_page.html", props %>
   <% end %>
+  </li>
 <% end %>

--- a/lib/oli_web/templates/page_delivery/container.html.eex
+++ b/lib/oli_web/templates/page_delivery/container.html.eex
@@ -2,26 +2,31 @@
   <%= container_title(@container) %>
 </h5>
 
-<div class="course-outline list-group list-group-root well">
-  <%= if Enum.empty?(@children) do %>
-    <span class="text-secondary">
-      There are no items
-    </span>
-  <% else %>
 
-    <%= for child <- @children do %>
-      <% props = Map.merge(assigns, %{
-        node: child,
-      }) %>
-      <%= cond do %>
-        <% container?(child.revision) -> %>
-          <%= render "_link_shallow_container.html", props %>
-        <% child.revision.graded -> %>
-          <%= render "_link_assessment.html", props %>
-        <% true -> %>
-          <%= render "_link_page.html", props %>
-      <% end %>
+<%= if Enum.empty?(@children) do %>
+  <span class="text-secondary">
+    There are no items
+  </span>
+<% else %>
+
+  <ol class="course-outline well" style="list-style: none;">
+
+  <%= for child <- @children do %>
+    <% props = Map.merge(assigns, %{
+      node: child,
+    }) %>
+    <li>
+    <%= cond do %>
+      <% container?(child.revision) -> %>
+        <%= render "_link_shallow_container.html", props %>
+      <% child.revision.graded -> %>
+        <%= render "_link_assessment.html", props %>
+      <% true -> %>
+        <%= render "_link_page.html", props %>
     <% end %>
- <% end %>
+    </li>
+  <% end %>
 
-</div>
+  </ol>
+
+ <% end %>

--- a/lib/oli_web/templates/page_delivery/index.html.eex
+++ b/lib/oli_web/templates/page_delivery/index.html.eex
@@ -12,12 +12,12 @@
   <h5 class="text-primary border-bottom border-primary mb-2">
     Course Overview
   </h5>
-  <div id="index-container" class="course-outline list-group list-group-root well">
+  <ol id="index-container" class="course-outline well" style="list-style: none;">
     <%= render "_outline.html", Map.merge(assigns, %{
       nodes: @hierarchy.children,
       active_page: nil,
     }) %>
-  </div>
+  </ol>
 </div>
 <%= if Oli.Utils.LoadTesting.enabled?() do %>
   <!--

--- a/lib/oli_web/views/page_delivery_view.ex
+++ b/lib/oli_web/views/page_delivery_view.ex
@@ -141,7 +141,7 @@ defmodule OliWeb.PageDeliveryView do
     end
   end
 
-  def base_resource_link_class(), do: "page-link list-group-item list-group-item-action"
+  def base_resource_link_class(), do: ""
   def resource_link_class(_active = true), do: base_resource_link_class() <> " active"
   def resource_link_class(_active = false), do: base_resource_link_class()
 end


### PR DESCRIPTION
This PR improves the display of the top-level "Course Overview" full tree and the intermediate, single-level "Container" pages. 

It replaces the use of Bootstrap "list-group" and nested `<div>` elements that contain `style` attributes with a calculated margin (to get an indentation effect) with nested `<ol>` elements.  This achieves the same indentation and is more semantically correct. 

Also removes the use of the Bootstrap `page-link` class from all links.  This is a Bootstrap class that is used in pagination displays and was responsible for adding the borders around the outline elements.

The net effect is a much cleaner index display. 