### PR TITLE
[FEATURE] Allow policy driven review of gated graded resources MER-815

### DIFF
--- a/lib/oli/delivery/attempts/core.ex
+++ b/lib/oli/delivery/attempts/core.ex
@@ -24,6 +24,10 @@ defmodule Oli.Delivery.Attempts.Core do
     GradeUpdateBrowseOptions
   }
 
+  @doc """
+  For a given user, section, and resource id, determine whether any resource attempts are
+  present.
+  """
   def has_any_attempts?(%User{id: user_id}, %Section{id: section_id}, resource_id) do
     query =
       from access in ResourceAccess,

--- a/lib/oli/delivery/attempts/core.ex
+++ b/lib/oli/delivery/attempts/core.ex
@@ -24,6 +24,19 @@ defmodule Oli.Delivery.Attempts.Core do
     GradeUpdateBrowseOptions
   }
 
+  def has_any_attempts?(%User{id: user_id}, %Section{id: section_id}, resource_id) do
+    query =
+      from access in ResourceAccess,
+        join: attempt in ResourceAttempt,
+        on: access.id == attempt.resource_access_id,
+        select: count(attempt.id),
+        where:
+          access.user_id == ^user_id and access.section_id == ^section_id and
+            access.resource_id == ^resource_id
+
+    Repo.one(query) > 0
+  end
+
   def browse_lms_grade_updates(
         %Paging{limit: limit, offset: offset},
         %Sorting{field: field, direction: direction},
@@ -416,11 +429,15 @@ defmodule Oli.Delivery.Attempts.Core do
       from(aa in ActivityAttempt,
         left_join: aa2 in ActivityAttempt,
         on:
-        aa2.resource_id == ^resource_id and aa.resource_attempt_id == aa2.resource_attempt_id and aa.id < aa2.id,
-        where: aa.resource_id == ^resource_id and aa.resource_attempt_id == ^resource_attempt_id and is_nil(aa2),
+          aa2.resource_id == ^resource_id and aa.resource_attempt_id == aa2.resource_attempt_id and
+            aa.id < aa2.id,
+        where:
+          aa.resource_id == ^resource_id and aa.resource_attempt_id == ^resource_attempt_id and
+            is_nil(aa2),
         select: aa
       )
-    ) |> Repo.preload(revision: [:activity_type])
+    )
+    |> Repo.preload(revision: [:activity_type])
   end
 
   @doc """

--- a/lib/oli/delivery/gating/gating_condition.ex
+++ b/lib/oli/delivery/gating/gating_condition.ex
@@ -6,6 +6,12 @@ defmodule Oli.Delivery.Gating.GatingCondition do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @graded_resource_policies [
+    :allows_nothing,
+    :allows_review
+  ]
+  @default_graded_resource_policy :allows_review
+
   schema "gating_conditions" do
     field :type, Ecto.Enum,
       values: [
@@ -15,12 +21,15 @@ defmodule Oli.Delivery.Gating.GatingCondition do
         :finished
       ]
 
+    # The ways in which this gate affects access to graded resources
+    field :graded_resource_policy, Ecto.Enum,
+      values: @graded_resource_policies,
+      default: @default_graded_resource_policy
+
     # data used by the condition evaluator, e.g. start or end datetime, a list of
     # resource_ids, etc.
     embeds_one :data, Oli.Delivery.Gating.GatingConditionData, on_replace: :delete
-
     belongs_to :resource, Oli.Resources.Resource
-
     belongs_to :section, Oli.Delivery.Sections.Section
 
     # optionally, this condition can be associated with a specific user and a parent gating condition
@@ -33,11 +42,21 @@ defmodule Oli.Delivery.Gating.GatingCondition do
     timestamps(type: :utc_datetime)
   end
 
+  @spec graded_resource_policies :: [:allows_nothing | :allows_review, ...]
+  def graded_resource_policies, do: @graded_resource_policies
+
   @doc false
   def changeset(gating_condition, attrs) do
     gating_condition
-    |> cast(attrs, [:type, :resource_id, :section_id, :user_id, :parent_id])
+    |> cast(attrs, [
+      :type,
+      :resource_id,
+      :section_id,
+      :user_id,
+      :parent_id,
+      :graded_resource_policy
+    ])
     |> cast_embed(:data)
-    |> validate_required([:type, :resource_id, :section_id])
+    |> validate_required([:type, :resource_id, :section_id, :graded_resource_policy])
   end
 end

--- a/lib/oli/delivery/page/objectives_rollup.ex
+++ b/lib/oli/delivery/page/objectives_rollup.ex
@@ -3,7 +3,6 @@ defmodule Oli.Delivery.Page.ObjectivesRollup do
   # return the parent objective revisions of all attached objectives
   # if an attached objective is a parent, include that in the return list
   def rollup_objectives(page_revision, activity_revisions, resolver, section_slug) do
-
     rollup(
       # By default, a page's learning objectives are the rolled up objectives
       # from each of the page's activities. However, an author can override
@@ -13,7 +12,7 @@ defmodule Oli.Delivery.Page.ObjectivesRollup do
           get_attached_objective_ids(activity_revisions)
 
         _ ->
-          IO.inspect(page_revision.objectives["attached"])
+          page_revision.objectives["attached"]
       end,
       resolver,
       section_slug

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -337,7 +337,9 @@ defmodule OliWeb.PageDeliveryController do
     # number of attempts after a student has exhausted all attempts
     attempts_remaining = max(page.max_attempts - attempts_taken, 0)
 
-    blocking_gates = conn.assigns.blocking_gates
+    # The Oli.Plugs.MaybeGatedResource plug sets the blocking_gates assign if there is a blocking
+    # gate that prevents this learning from starting another attempt of this resource
+    blocking_gates = Map.get(conn.assigns, :blocking_gates, [])
     allow_attempt? = (attempts_remaining > 0 or page.max_attempts == 0) and blocking_gates == []
 
     message =

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -7,6 +7,7 @@ defmodule OliWeb.PageDeliveryController do
       is_section_instructor_or_admin?: 2
     ]
 
+  import OliWeb.Common.FormatDateTime
   alias Oli.Delivery.Page.PageContext
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.Section
@@ -336,13 +337,21 @@ defmodule OliWeb.PageDeliveryController do
     # number of attempts after a student has exhausted all attempts
     attempts_remaining = max(page.max_attempts - attempts_taken, 0)
 
-    allow_attempt? = attempts_remaining > 0 or page.max_attempts == 0
+    blocking_gates = conn.assigns.blocking_gates
+    allow_attempt? = (attempts_remaining > 0 or page.max_attempts == 0) and blocking_gates == []
 
     message =
-      if page.max_attempts == 0 do
-        "You can take this assessment an unlimited number of times"
-      else
-        "You have #{attempts_remaining} attempt#{plural(attempts_remaining)} remaining out of #{page.max_attempts} total attempt#{plural(page.max_attempts)}."
+      cond do
+        blocking_gates != [] ->
+          Oli.Delivery.Gating.details(blocking_gates,
+            format_datetime: format_datetime_fn(conn)
+          )
+
+        page.max_attempts == 0 ->
+          "You can take this assessment an unlimited number of times"
+
+        true ->
+          "You have #{attempts_remaining} attempt#{plural(attempts_remaining)} remaining out of #{page.max_attempts} total attempt#{plural(page.max_attempts)}."
       end
 
     conn = put_root_layout(conn, {OliWeb.LayoutView, "page.html"})
@@ -494,27 +503,47 @@ defmodule OliWeb.PageDeliveryController do
 
   def start_attempt(conn, %{"section_slug" => section_slug, "revision_slug" => revision_slug}) do
     user = conn.assigns.current_user
+    section = conn.assigns.section
 
     activity_provider = &Oli.Delivery.ActivityProvider.provide/3
 
     if Sections.is_enrolled?(user.id, section_slug) do
-      case PageLifecycle.start(
-             revision_slug,
-             section_slug,
-             user.id,
-             activity_provider
-           ) do
-        {:ok, _} ->
-          redirect(conn, to: Routes.page_delivery_path(conn, :page, section_slug, revision_slug))
+      # We must check gating conditions here to account for gates that activated after
+      # the prologue page was rendered, and for malicous/deliberate attempts to start an attempt via
+      # hitting this endpoint.
+      revision = Oli.Publishing.DeliveryResolver.from_revision_slug(section_slug, revision_slug)
 
-        {:error, {:active_attempt_present}} ->
-          redirect(conn, to: Routes.page_delivery_path(conn, :page, section_slug, revision_slug))
+      case Oli.Delivery.Gating.blocked_by(section, user, revision.resource_id) do
+        [] ->
+          case PageLifecycle.start(
+                 revision_slug,
+                 section_slug,
+                 user.id,
+                 activity_provider
+               ) do
+            {:ok, _} ->
+              redirect(conn,
+                to: Routes.page_delivery_path(conn, :page, section_slug, revision_slug)
+              )
 
-        {:error, {:no_more_attempts}} ->
-          redirect(conn, to: Routes.page_delivery_path(conn, :page, section_slug, revision_slug))
+            {:error, {:active_attempt_present}} ->
+              redirect(conn,
+                to: Routes.page_delivery_path(conn, :page, section_slug, revision_slug)
+              )
+
+            {:error, {:no_more_attempts}} ->
+              redirect(conn,
+                to: Routes.page_delivery_path(conn, :page, section_slug, revision_slug)
+              )
+
+            _ ->
+              render(conn, "error.html")
+          end
 
         _ ->
-          render(conn, "error.html")
+          # In the case where a gate exists we want to redirect to this page display, which will
+          # then pick up the gate and show that feedback to the user
+          redirect(conn, to: Routes.page_delivery_path(conn, :page, section_slug, revision_slug))
       end
     else
       render(conn, "not_authorized.html")
@@ -686,5 +715,11 @@ defmodule OliWeb.PageDeliveryController do
       child
     end)
     |> Enum.map(fn link_desc -> simulate_node(link_desc) end)
+  end
+
+  defp format_datetime_fn(conn) do
+    fn datetime ->
+      date(datetime, conn: conn, precision: :minutes)
+    end
   end
 end

--- a/lib/oli_web/live/sections/gating_and_scheduling/form.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling/form.ex
@@ -29,6 +29,15 @@ defmodule OliWeb.Sections.GatingAndScheduling.Form do
         </select>
       </div>
 
+      <div class="form-group">
+        <label for="gradingPolicySelect">Graded Resource Policy</label>
+        <select class="form-control" id="gradingPolicySelect" phx-hook="SelectListener" phx-value-change="select-grading-policy">
+          {#for policy <- Oli.Delivery.Gating.GatingCondition.graded_resource_policies()}
+            <option value={policy} {...policy_selected(assigns, policy)}>{policy_desc(policy)}</option>
+          {/for}
+        </select>
+      </div>
+
       {render_condition_options(assigns)}
 
       <div class="d-flex mb-5">
@@ -168,6 +177,14 @@ defmodule OliWeb.Sections.GatingAndScheduling.Form do
 
   def maybe_type_selected(_assigns, :default), do: [selected: true]
   def maybe_type_selected(_assigns, _), do: []
+
+  def policy_selected(%{gating_condition: %{graded_resource_policy: policy}}, p) when policy == p,
+    do: [selected: true]
+
+  def policy_selected(_, _), do: []
+
+  def policy_desc(:allows_nothing), do: "Allow no access at all to graded pages"
+  def policy_desc(:allows_review), do: "Allow the review of previously completed attempts"
 
   def render_condition_options(%{gating_condition: %{type: :schedule, data: data}} = assigns) do
     initial_start_date = Map.get(data, :start_datetime)

--- a/lib/oli_web/live/sections/gating_and_scheduling/gating_condition_store.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling/gating_condition_store.ex
@@ -53,7 +53,7 @@ defmodule OliWeb.Delivery.Sections.GatingAndScheduling.GatingConditionStore do
 
             gc =
               gc
-              |> Map.take([:id, :type, :section_id, :resource_id])
+              |> Map.take([:id, :type, :section_id, :resource_id, :graded_resource_policy])
               |> Map.put(
                 :resource_title,
                 resource_title
@@ -373,6 +373,21 @@ defmodule OliWeb.Delivery.Sections.GatingAndScheduling.GatingConditionStore do
          |> Map.put(:source_title, title)
      )
      |> hide_modal()}
+  end
+
+  def handle_event(
+        "select-grading-policy",
+        %{"value" => value},
+        socket
+      ) do
+    %{gating_condition: gating_condition} = socket.assigns
+
+    {:noreply,
+     assign(socket,
+       gating_condition:
+         gating_condition
+         |> Map.put(:graded_resource_policy, String.to_existing_atom(value))
+     )}
   end
 
   def handle_event(

--- a/lib/oli_web/plugs/maybe_gated_resource.ex
+++ b/lib/oli_web/plugs/maybe_gated_resource.ex
@@ -41,13 +41,14 @@ defmodule Oli.Plugs.MaybeGatedResource do
         # if there is at least one gate that has the `allows_nothing` policy we block access
         # to this graded resource
         if revision.graded do
-          if Enum.any?(blocking_gates, fn gc -> gc.graded_resource_policy == :allows_nothing end) do
+          if Enum.any?(blocking_gates, fn gc -> gc.graded_resource_policy == :allows_nothing end) or
+               !Core.has_any_attempts?(user, section, resource_id) do
             gated_resource_unavailable(conn, section, revision, blocking_gates)
           else
             # These are the gates that apply at a more granular level that "allows_nothing"
             blocking_gates =
               Enum.filter(blocking_gates, fn gc ->
-                gc.graded_resource_policy != :allows_nothing
+                gc.graded_resource_policy == :allows_review
               end)
 
             conn

--- a/lib/oli_web/plugs/maybe_gated_resource.ex
+++ b/lib/oli_web/plugs/maybe_gated_resource.ex
@@ -7,6 +7,7 @@ defmodule Oli.Plugs.MaybeGatedResource do
   alias Oli.Publishing.DeliveryResolver
   alias Oli.Resources.Revision
   alias Oli.Delivery.Gating
+  alias Oli.Delivery.Attempts.Core
 
   def init(opts), do: opts
 
@@ -15,12 +16,7 @@ defmodule Oli.Plugs.MaybeGatedResource do
          revision <- DeliveryResolver.from_revision_slug(section_slug, revision_slug) do
       case revision do
         %Revision{resource_id: resource_id} ->
-          %{section: section, current_user: user} = conn.assigns
-
-          case Gating.blocked_by(section, user, resource_id) do
-            [] -> conn
-            blocking_gates -> gated_resource_unavailable(conn, section, revision, blocking_gates)
-          end
+          enforce_gating(conn, resource_id, revision)
 
         _ ->
           conn
@@ -30,6 +26,36 @@ defmodule Oli.Plugs.MaybeGatedResource do
     else
       _ ->
         conn
+    end
+  end
+
+  defp enforce_gating(conn, resource_id, revision) do
+    %{section: section, current_user: user} = conn.assigns
+
+    case Gating.blocked_by(section, user, resource_id) do
+      [] ->
+        conn
+
+      blocking_gates ->
+        # Graded resources are governed by the graded_resource_policy of gates. At this level
+        # if there is at least one gate that has the `allows_nothing` policy we block access
+        # to this graded resource
+        if revision.graded do
+          if Enum.any?(blocking_gates, fn gc -> gc.graded_resource_policy == :allows_nothing end) do
+            gated_resource_unavailable(conn, section, revision, blocking_gates)
+          else
+            # These are the gates that apply at a more granular level that "allows_nothing"
+            blocking_gates =
+              Enum.filter(blocking_gates, fn gc ->
+                gc.graded_resource_policy != :allows_nothing
+              end)
+
+            conn
+            |> Plug.Conn.assign(:blocking_gates, blocking_gates)
+          end
+        else
+          gated_resource_unavailable(conn, section, revision, blocking_gates)
+        end
     end
   end
 

--- a/lib/oli_web/templates/page_delivery/advanced_delivery.html.eex
+++ b/lib/oli_web/templates/page_delivery/advanced_delivery.html.eex
@@ -41,7 +41,8 @@
     activityGuidMapping: <%= raw(@activity_guid_mapping) %>,
     previousPageURL,
     nextPageURL,
-    previewMode: false
+    previewMode: false,
+    reviewMode: <%= @review_mode %>
   };
 
   window.oliMountApplication(document.getElementById('delivery_container'), params);

--- a/priv/repo/migrations/20220306185035_gating_grading_policy.exs
+++ b/priv/repo/migrations/20220306185035_gating_grading_policy.exs
@@ -1,0 +1,15 @@
+defmodule Oli.Repo.Migrations.GatingGradingPolicy do
+  use Ecto.Migration
+  import Ecto.Query, warn: false
+
+  def change do
+    alter table(:gating_conditions) do
+      add :graded_resource_policy, :string, default: "allows_review", null: false
+    end
+
+    flush()
+
+    from("gating_conditions")
+    |> Oli.Repo.update_all(set: [graded_resource_policy: "allows_review"])
+  end
+end

--- a/test/oli/delivery/attempts_test.exs
+++ b/test/oli/delivery/attempts_test.exs
@@ -78,6 +78,8 @@ defmodule Oli.Delivery.AttemptsTest do
 
       activity_provider = &Oli.Delivery.ActivityProvider.provide/3
 
+      refute Attempts.has_any_attempts?(user, section, p1.revision.resource_id)
+
       {:ok, resource_attempt} =
         Hierarchy.create(%VisitContext{
           latest_resource_attempt: nil,
@@ -88,6 +90,8 @@ defmodule Oli.Delivery.AttemptsTest do
           blacklisted_activity_ids: [],
           publication_id: pub.id
         })
+
+      assert Attempts.has_any_attempts?(user, section, p1.revision.resource_id)
 
       # verify that creating the attempt tree returns both activity attempts
       {:ok, %AttemptState{resource_attempt: resource_attempt, attempt_hierarchy: attempts}} =

--- a/test/oli_web/plugs/maybe_gated_resource_test.exs
+++ b/test/oli_web/plugs/maybe_gated_resource_test.exs
@@ -4,8 +4,24 @@ defmodule Oli.Plugs.MaybeGatedResourceTest do
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Gating
   alias Oli.Seeder
+  alias Oli.Delivery.Attempts.Core
   alias Lti_1p3.Tool.ContextRoles
   alias OliWeb.Router.Helpers, as: Routes
+
+  def insert_resource_attempt(resource_access, revision_id, attrs) do
+    Core.create_resource_attempt(
+      Map.merge(
+        %{
+          attempt_guid: UUID.uuid4(),
+          attempt_number: 1,
+          content: %{},
+          resource_access_id: resource_access.id,
+          revision_id: revision_id
+        },
+        attrs
+      )
+    )
+  end
 
   describe "maybe_gated_resource plug" do
     setup [:setup_session]
@@ -74,6 +90,117 @@ defmodule Oli.Plugs.MaybeGatedResourceTest do
 
       assert html_response(conn, 403) =~
                "#{revision.title} is scheduled to end"
+    end
+
+    test "blocks access to gated graded resource when :allows_nothing is in a closed gating condition",
+         %{
+           conn: conn,
+           revision: revision,
+           user: user,
+           section: section
+         } do
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+
+      Oli.Resources.update_revision(revision, %{graded: true})
+
+      _gating_condition =
+        gating_condition_fixture(%{
+          graded_resource_policy: :allows_nothing,
+          section_id: section.id,
+          resource_id: revision.resource_id,
+          data: %{end_datetime: yesterday()}
+        })
+
+      {:ok, section} = Gating.update_resource_gating_index(section)
+
+      conn =
+        conn
+        |> get(Routes.page_delivery_path(conn, :page, section.slug, revision.slug))
+
+      assert html_response(conn, 403) =~
+               "You are trying to access a resource that is gated by the following condition"
+
+      assert html_response(conn, 403) =~
+               "#{revision.title} is scheduled to end"
+    end
+
+    test "blocks access to gated graded resource with :allows_nothing policy and attempts present",
+         %{
+           conn: conn,
+           revision: revision,
+           user: user,
+           section: section
+         } do
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+
+      Oli.Resources.update_revision(revision, %{graded: true})
+
+      ra = Core.track_access(revision.resource_id, section.id, user.id)
+      Core.update_resource_access(ra, %{score: 5, out_of: 10})
+
+      insert_resource_attempt(ra, revision.id, %{
+        date_evaluated: DateTime.utc_now(),
+        score: 5,
+        out_of: 10
+      })
+
+      _gating_condition =
+        gating_condition_fixture(%{
+          graded_resource_policy: :allows_nothing,
+          section_id: section.id,
+          resource_id: revision.resource_id,
+          data: %{end_datetime: yesterday()}
+        })
+
+      {:ok, section} = Gating.update_resource_gating_index(section)
+
+      conn =
+        conn
+        |> get(Routes.page_delivery_path(conn, :page, section.slug, revision.slug))
+
+      assert html_response(conn, 403) =~
+               "You are trying to access a resource that is gated by the following condition"
+
+      assert html_response(conn, 403) =~
+               "#{revision.title} is scheduled to end"
+    end
+
+    test "allows review with :allows_review policy and attempts present",
+         %{
+           conn: conn,
+           revision: revision,
+           user: user,
+           section: section
+         } do
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+
+      Oli.Resources.update_revision(revision, %{graded: true, max_attempts: 2})
+
+      ra = Core.track_access(revision.resource_id, section.id, user.id)
+      Core.update_resource_access(ra, %{score: 5, out_of: 10})
+
+      insert_resource_attempt(ra, revision.id, %{
+        date_evaluated: DateTime.utc_now(),
+        score: 5,
+        out_of: 10
+      })
+
+      _gating_condition =
+        gating_condition_fixture(%{
+          graded_resource_policy: :allows_review,
+          section_id: section.id,
+          resource_id: revision.resource_id,
+          data: %{end_datetime: yesterday()}
+        })
+
+      {:ok, section} = Gating.update_resource_gating_index(section)
+
+      conn =
+        conn
+        |> get(Routes.page_delivery_path(conn, :page, section.slug, revision.slug))
+
+      assert html_response(conn, 200) =~ "Attempt 1 of 2"
+      assert html_response(conn, 200) =~ "Page one is scheduled to end"
     end
   end
 


### PR DESCRIPTION
This PR adds the ability for the creator of a gate to determine whether the gate once active, when is guards a graded page, should allow the student to still be able to review already completed attempts for that graded page. 

This work introduces a new `:graded_resource_policy` enumeration attribute on the `GatingCondition` schema. It takes one of the following values:

1. `:allows_nothing` - When selected, an active gate guarding a graded page will not allow the student to start new attempts nor review existing attempts
2. `:allows_review` - When selected, an active gate guarding a graded page will not allow the student to start new attempts, but it will allow the review of already completed attempts.

Description of targeted use cases is here:

https://eliterate.atlassian.net/browse/MER-815