### PR TITLE
[BUG FIX] Fix adaptive page rendering issue MER-906

### DIFF
--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -438,7 +438,9 @@ defmodule OliWeb.PageDeliveryController do
       next_page: next,
       user_id: user.id,
       preview_mode: preview_mode,
-      section: section
+      section: section,
+      page_link_url: &Routes.page_delivery_path(conn, :page, section_slug, &1),
+      container_link_url: &Routes.page_delivery_path(conn, :container, section_slug, &1)
     })
   end
 


### PR DESCRIPTION
This PR fixes an issue where the rendering of adaptive pages that do use application chrome (i.e., they render `page.html.eex` as the root layout) was broken.  The reason was that the new `page_link_url` and `container_link_url` assigns were missing.  Chromeless display doesn't use these, but the chrome based display does (in order to render the "Previous" and "Next" links).

The fix here is to add them. 

Error from AppSignal:

```
** (KeyError) key :container_link_url not found in: %{activity_guid_mapping: "{\"18029\":{\"attemptGuid\":\"3740b4bc-67ce-4a2e-9842-f695583b30e6\",\"deliveryElement\":\"oli-adaptive-delivery\",\"id\":18029},\"18051\":
```