### PR TITLE
[FEATURE] [MER-761] Delivery breadcrumbs for some routes

### DIFF
--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -2,11 +2,6 @@ defmodule OliWeb.PageDeliveryController do
   use OliWeb, :controller
   require Logger
 
-  import OliWeb.ViewHelpers,
-    only: [
-      is_section_instructor_or_admin?: 2
-    ]
-
   import OliWeb.Common.FormatDateTime
   alias Oli.Delivery.Page.PageContext
   alias Oli.Delivery.Sections
@@ -172,20 +167,6 @@ defmodule OliWeb.PageDeliveryController do
         _ ->
           render(conn, "not_authorized.html")
       end
-    end
-  end
-
-  def updates(conn, %{"section_slug" => section_slug}) do
-    current_user = conn.assigns.current_user
-    current_author = conn.assigns.current_author
-
-    if Oli.Accounts.is_admin?(current_author) or
-         is_section_instructor_or_admin?(section_slug, current_user) do
-      section = Sections.get_section_by(slug: section_slug)
-
-      render(conn, "updates.html", section: section, title: "Manage Updates")
-    else
-      render(conn, "not_authorized.html")
     end
   end
 

--- a/lib/oli_web/controllers/session_controller.ex
+++ b/lib/oli_web/controllers/session_controller.ex
@@ -22,5 +22,5 @@ defmodule OliWeb.SessionController do
   end
 
   defp session_data_to_delete(type),
-    do: @shared_session_data_to_delete ++ [String.to_atom("current_#{type}_id")]
+    do: [String.to_atom("current_#{type}_id") | @shared_session_data_to_delete]
 end

--- a/lib/oli_web/controllers/session_controller.ex
+++ b/lib/oli_web/controllers/session_controller.ex
@@ -5,19 +5,22 @@ defmodule OliWeb.SessionController do
 
   plug :require_authenticated when action in [:signout]
 
-  @session_data_to_delete [:dismissed_messages]
+  @shared_session_data_to_delete [:dismissed_messages]
 
   def signout(conn, %{"type" => type}) do
     conn
     |> use_pow_config(String.to_atom(type))
     |> Pow.Plug.delete()
-    |> delete_session_data()
+    |> delete_session_data(type)
     |> redirect(to: Routes.static_page_path(conn, :index))
   end
 
-  defp delete_session_data(conn) do
-    Enum.reduce(@session_data_to_delete, conn, fn field, acc_conn ->
+  defp delete_session_data(conn, type) do
+    Enum.reduce(session_data_to_delete(type), conn, fn field, acc_conn ->
       delete_session(acc_conn, field)
     end)
   end
+
+  defp session_data_to_delete(type),
+    do: @shared_session_data_to_delete ++ [String.to_atom("current_#{type}_id")]
 end

--- a/lib/oli_web/live/delivery/manage_updates.ex
+++ b/lib/oli_web/live/delivery/manage_updates.ex
@@ -9,7 +9,23 @@ defmodule OliWeb.Delivery.ManageUpdates do
   alias Oli.Delivery.Updates.Worker
   alias OliWeb.Delivery.Updates.ApplyUpdateModal
   alias Oli.Delivery.Updates.Subscriber
+  alias OliWeb.Common.Breadcrumb
   alias OliWeb.Sections.Mount
+
+  def set_breadcrumbs(section, type) do
+    OliWeb.Sections.OverviewView.set_breadcrumbs(type, section)
+    |> breadcrumb(section)
+  end
+
+  def breadcrumb(previous, section) do
+    previous ++
+      [
+        Breadcrumb.new(%{
+          full_title: "Manage Updates",
+          link: Routes.live_path(OliWeb.Endpoint, __MODULE__, section.slug)
+        })
+      ]
+  end
 
   def mount(
         params,
@@ -26,19 +42,20 @@ defmodule OliWeb.Delivery.ManageUpdates do
       {:error, e} ->
         Mount.handle_error(socket, {:error, e})
 
-      {_, _, %Oli.Delivery.Sections.Section{type: :blueprint} = section} ->
+      {user_type, _, %Oli.Delivery.Sections.Section{type: :blueprint} = section} ->
         init_state(
           socket,
           section,
-          Routes.live_path(socket, OliWeb.Products.DetailsView, section.slug)
+          Routes.live_path(socket, OliWeb.Products.DetailsView, section.slug),
+          user_type
         )
 
-      {_, _, section} ->
-        init_state(socket, section, Map.get(session, "redirect_after_apply"))
+      {user_type, _, section} ->
+        init_state(socket, section, Map.get(session, "redirect_after_apply"), user_type)
     end
   end
 
-  def init_state(socket, section, redirect_after_apply) do
+  def init_state(socket, section, redirect_after_apply, user_type) do
     updates = Sections.check_for_available_publication_updates(section)
     updates_in_progress = Sections.check_for_updates_in_progress(section)
 
@@ -51,7 +68,9 @@ defmodule OliWeb.Delivery.ManageUpdates do
        updates: updates,
        modal: nil,
        updates_in_progress: updates_in_progress,
-       redirect_after_apply: redirect_after_apply
+       redirect_after_apply: redirect_after_apply,
+       delivery_breadcrumb: true,
+       breadcrumbs: set_breadcrumbs(section, user_type)
      )}
   end
 

--- a/lib/oli_web/live/delivery/manage_updates.ex
+++ b/lib/oli_web/live/delivery/manage_updates.ex
@@ -13,7 +13,8 @@ defmodule OliWeb.Delivery.ManageUpdates do
   alias OliWeb.Sections.Mount
 
   def set_breadcrumbs(section, type) do
-    OliWeb.Sections.OverviewView.set_breadcrumbs(type, section)
+    type
+    |> OliWeb.Sections.OverviewView.set_breadcrumbs(section)
     |> breadcrumb(section)
   end
 

--- a/lib/oli_web/live/delivery/remix_section.ex
+++ b/lib/oli_web/live/delivery/remix_section.ex
@@ -37,7 +37,7 @@ defmodule OliWeb.Delivery.RemixSection do
     previous ++
       [
         Breadcrumb.new(%{
-          full_title: "Cusomize Content",
+          full_title: "Customize Content",
           link: Routes.live_path(OliWeb.Endpoint, __MODULE__, section.slug)
         })
       ]
@@ -188,6 +188,7 @@ defmodule OliWeb.Delivery.RemixSection do
        selected: nil,
        has_unsaved_changes: false,
        modal: nil,
+       delivery_breadcrumb: true,
        breadcrumbs: breadcrumbs,
        redirect_after_save: redirect_after_save,
        available_publications: available_publications

--- a/lib/oli_web/live/delivery/remix_section.ex
+++ b/lib/oli_web/live/delivery/remix_section.ex
@@ -29,7 +29,8 @@ defmodule OliWeb.Delivery.RemixSection do
   alias OliWeb.Sections.Mount
 
   def set_breadcrumbs(type, section) do
-    OliWeb.Sections.OverviewView.set_breadcrumbs(type, section)
+    type
+    |> OliWeb.Sections.OverviewView.set_breadcrumbs(section)
     |> breadcrumb(section)
   end
 

--- a/lib/oli_web/live/grades/browse_updates_view.ex
+++ b/lib/oli_web/live/grades/browse_updates_view.ex
@@ -25,7 +25,8 @@ defmodule OliWeb.Grades.BrowseUpdatesView do
   data options, :any
 
   def set_breadcrumbs(type, section) do
-    OliWeb.Sections.OverviewView.set_breadcrumbs(type, section)
+    type
+    |> OliWeb.Sections.OverviewView.set_breadcrumbs(section)
     |> breadcrumb(section)
   end
 

--- a/lib/oli_web/live/grades/gradebook_view.ex
+++ b/lib/oli_web/live/grades/gradebook_view.ex
@@ -74,6 +74,7 @@ defmodule OliWeb.Grades.GradebookView do
 
         {:ok,
          assign(socket,
+           delivery_breadcrumb: true,
            breadcrumbs: set_breadcrumbs(type, section),
            section: section,
            total_count: total_count,

--- a/lib/oli_web/live/grades/gradebook_view.ex
+++ b/lib/oli_web/live/grades/gradebook_view.ex
@@ -29,7 +29,8 @@ defmodule OliWeb.Grades.GradebookView do
   data options, :any
 
   def set_breadcrumbs(type, section) do
-    OliWeb.Sections.OverviewView.set_breadcrumbs(type, section)
+    type
+    |> OliWeb.Sections.OverviewView.set_breadcrumbs(section)
     |> breadcrumb(section)
   end
 

--- a/lib/oli_web/live/grades/observe_grade_updates.ex
+++ b/lib/oli_web/live/grades/observe_grade_updates.ex
@@ -20,7 +20,8 @@ defmodule OliWeb.Grades.ObserveGradeUpdatesView do
 
   @spec set_breadcrumbs(:admin | :user, atom | %{:slug => any, optional(any) => any}) :: [...]
   def set_breadcrumbs(type, section) do
-    OliWeb.Sections.OverviewView.set_breadcrumbs(type, section)
+    type
+    |> OliWeb.Sections.OverviewView.set_breadcrumbs(section)
     |> breadcrumb(section)
   end
 

--- a/lib/oli_web/live/products/details_view.ex
+++ b/lib/oli_web/live/products/details_view.ex
@@ -19,6 +19,12 @@ defmodule OliWeb.Products.DetailsView do
   prop author, :any
   prop is_admin, :boolean
 
+  def set_breadcrumbs(section),
+    do: [Breadcrumb.new(%{
+      full_title: section.title,
+      link: Routes.live_path(OliWeb.Endpoint, __MODULE__, section.slug)
+    })]
+
   def mount(
         %{"product_id" => product_slug},
         %{"current_author_id" => author_id} = session,

--- a/lib/oli_web/live/sections/edit_view.ex
+++ b/lib/oli_web/live/sections/edit_view.ex
@@ -43,6 +43,7 @@ defmodule OliWeb.Sections.EditView do
 
         {:ok,
          assign(socket,
+           delivery_breadcrumb: true,
            brands: available_brands,
            changeset: Sections.change_section(section),
            is_admin: type == :admin,

--- a/lib/oli_web/live/sections/enrollments/enrollments_view.ex
+++ b/lib/oli_web/live/sections/enrollments/enrollments_view.ex
@@ -61,6 +61,7 @@ defmodule OliWeb.Sections.EnrollmentsView do
          assign(socket,
            context: context,
            changeset: Sections.change_section(section),
+           delivery_breadcrumb: true,
            breadcrumbs: set_breadcrumbs(type, section),
            section: section,
            total_count: total_count,

--- a/lib/oli_web/live/sections/enrollments/enrollments_view.ex
+++ b/lib/oli_web/live/sections/enrollments/enrollments_view.ex
@@ -32,7 +32,8 @@ defmodule OliWeb.Sections.EnrollmentsView do
   data options, :any
 
   def set_breadcrumbs(type, section) do
-    OliWeb.Sections.OverviewView.set_breadcrumbs(type, section)
+    type
+    |> OliWeb.Sections.OverviewView.set_breadcrumbs(section)
     |> breadcrumb(section)
   end
 

--- a/lib/oli_web/live/sections/gating_and_scheduling.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling.ex
@@ -19,7 +19,8 @@ defmodule OliWeb.Sections.GatingAndScheduling do
   @limit 25
 
   def set_breadcrumbs(section, parent_gate, user_type) do
-    OliWeb.Sections.OverviewView.set_breadcrumbs(user_type, section)
+    user_type
+    |> OliWeb.Sections.OverviewView.set_breadcrumbs(section)
     |> breadcrumb(section)
     |> breadcrumb_exceptions(section, parent_gate)
   end

--- a/lib/oli_web/live/sections/gating_and_scheduling.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling.ex
@@ -96,9 +96,13 @@ defmodule OliWeb.Sections.GatingAndScheduling do
           {Gating.get_gating_condition!(int_id), "Student Exceptions"}
       end
 
-    {user_type, _user, section} = Mount.for(section_slug, session)
+    case Mount.for(section_slug, session) do
+      {:error, e} ->
+        Mount.handle_error(socket, {:error, e})
 
-    {:ok, assign_defaults(socket, section, session, parent_gate, title, user_type)}
+      {user_type, _user, section} ->
+        {:ok, assign_defaults(socket, section, session, parent_gate, title, user_type)}
+    end
   end
 
   def assign_defaults(socket, section, session, parent_gate, title, user_type) do

--- a/lib/oli_web/live/sections/gating_and_scheduling.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling.ex
@@ -19,31 +19,32 @@ defmodule OliWeb.Sections.GatingAndScheduling do
   @limit 25
 
   def set_breadcrumbs(section, parent_gate, user_type) do
+    first = case section do
+      %Section{type: :blueprint} ->
+        [
+          Breadcrumb.new(%{
+            full_title: "Products"
+          })
+        ]
+
+      _ -> []
+    end
+
     user_type
-    |> OliWeb.Sections.OverviewView.set_breadcrumbs(section)
+    |> intermediate_breadcrumb(first, section)
     |> breadcrumb(section)
     |> breadcrumb_exceptions(section, parent_gate)
   end
 
+  def intermediate_breadcrumb(_user_type, previous, %Section{type: :blueprint} = section),
+    do: previous ++ OliWeb.Products.DetailsView.set_breadcrumbs(section)
+
+  def intermediate_breadcrumb(user_type, previous, section),
+    do: previous ++  OliWeb.Sections.OverviewView.set_breadcrumbs(user_type, section)
+
   def breadcrumb(previous, section) do
-    intermediate =
-      case section do
-        %Section{type: :blueprint} ->
-          Breadcrumb.new(%{
-            full_title: section.title,
-            link: Routes.live_path(OliWeb.Endpoint, OliWeb.Products.DetailsView, section.slug)
-          })
-
-        _ ->
-          Breadcrumb.new(%{
-            full_title: section.title,
-            link: Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.OverviewView, section.slug)
-          })
-      end
-
     previous ++
       [
-        intermediate,
         Breadcrumb.new(%{
           full_title: "Gating and Scheduling",
           link: Routes.live_path(OliWeb.Endpoint, __MODULE__, section.slug)

--- a/lib/oli_web/live/sections/gating_and_scheduling.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling.ex
@@ -18,18 +18,8 @@ defmodule OliWeb.Sections.GatingAndScheduling do
 
   @limit 25
 
-  def set_breadcrumbs(section, parent_gate) do
-    case section do
-      %Section{type: :blueprint} ->
-        [
-          Breadcrumb.new(%{
-            full_title: "Products"
-          })
-        ]
-
-      _ ->
-        OliWeb.Sections.SectionsView.set_breadcrumbs()
-    end
+  def set_breadcrumbs(section, parent_gate, user_type) do
+    OliWeb.Sections.OverviewView.set_breadcrumbs(user_type, section)
     |> breadcrumb(section)
     |> breadcrumb_exceptions(section, parent_gate)
   end
@@ -106,13 +96,12 @@ defmodule OliWeb.Sections.GatingAndScheduling do
           {Gating.get_gating_condition!(int_id), "Student Exceptions"}
       end
 
-    case Mount.for(section_slug, session) do
-      {type, _author, section} when type in [:user, :author, :admin] ->
-        {:ok, assign_defaults(socket, section, session, parent_gate, title)}
-    end
+    {user_type, _user, section} = Mount.for(section_slug, session)
+
+    {:ok, assign_defaults(socket, section, session, parent_gate, title, user_type)}
   end
 
-  def assign_defaults(socket, section, session, parent_gate, title) do
+  def assign_defaults(socket, section, session, parent_gate, title, user_type) do
     context = SessionContext.init(session)
 
     rows =
@@ -136,7 +125,8 @@ defmodule OliWeb.Sections.GatingAndScheduling do
       title: title,
       context: context,
       section: section,
-      breadcrumbs: set_breadcrumbs(section, parent_gate),
+      delivery_breadcrumb: true,
+      breadcrumbs: set_breadcrumbs(section, parent_gate, user_type),
       table_model: table_model,
       total_count: total_count,
       parent_gate: parent_gate,

--- a/lib/oli_web/live/sections/gating_and_scheduling/edit.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling/edit.ex
@@ -13,29 +13,33 @@ defmodule OliWeb.Sections.GatingAndScheduling.Edit do
         %{"section_slug" => section_slug} = session,
         socket
       ) do
-    id = String.to_integer(gating_condition_id)
+    case Mount.for(section_slug, session) do
+      {:error, e} ->
+        Mount.handle_error(socket, {:error, e})
 
-    {parent_gate_id, title} =
-      case Gating.get_gating_condition!(id) do
-        %{parent_id: nil} -> {nil, "Edit Gating Condition"}
-        %{parent_id: parent_id} -> {parent_id, "Edit Student Exception"}
-      end
+      {user_type, _user, section} ->
+        id = String.to_integer(gating_condition_id)
 
-    context = SessionContext.init(session)
+        {parent_gate_id, title} =
+          case Gating.get_gating_condition!(id) do
+            %{parent_id: nil} -> {nil, "Edit Gating Condition"}
+            %{parent_id: parent_id} -> {parent_id, "Edit Student Exception"}
+          end
 
-    {user_type, _user, section} = Mount.for(section_slug, session)
+        context = SessionContext.init(session)
 
-    {:ok,
-     GatingConditionStore.init(
-       socket,
-       __MODULE__,
-       section,
-       context,
-       title,
-       parent_gate_id,
-       user_type,
-       id
-     )}
+        {:ok,
+         GatingConditionStore.init(
+           socket,
+           __MODULE__,
+           section,
+           context,
+           title,
+           parent_gate_id,
+           user_type,
+           id
+         )}
+    end
   end
 
   def render(assigns) do

--- a/lib/oli_web/live/sections/gating_and_scheduling/edit.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling/edit.ex
@@ -23,19 +23,19 @@ defmodule OliWeb.Sections.GatingAndScheduling.Edit do
 
     context = SessionContext.init(session)
 
-    case Mount.for(section_slug, session) do
-      {type, _author, section} when type in [:user, :author, :admin] ->
-        {:ok,
-         GatingConditionStore.init(
-           socket,
-           __MODULE__,
-           section,
-           context,
-           title,
-           parent_gate_id,
-           id
-         )}
-    end
+    {user_type, _user, section} = Mount.for(section_slug, session)
+
+    {:ok,
+     GatingConditionStore.init(
+       socket,
+       __MODULE__,
+       section,
+       context,
+       title,
+       parent_gate_id,
+       user_type,
+       id
+     )}
   end
 
   def render(assigns) do

--- a/lib/oli_web/live/sections/gating_and_scheduling/gating_condition_store.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling/gating_condition_store.ex
@@ -17,7 +17,16 @@ defmodule OliWeb.Delivery.Sections.GatingAndScheduling.GatingConditionStore do
     """
   end
 
-  def init(socket, module, section, context, title, parent_gate_id, gating_condition_id \\ nil) do
+  def init(
+        socket,
+        module,
+        section,
+        context,
+        title,
+        parent_gate_id,
+        user_type,
+        gating_condition_id \\ nil
+      ) do
     parent_gate =
       case parent_gate_id do
         nil -> nil
@@ -91,14 +100,15 @@ defmodule OliWeb.Delivery.Sections.GatingAndScheduling.GatingConditionStore do
       count_exceptions: count_exceptions(parent_gate_id, gating_condition_id),
       title: title,
       section: section,
-      breadcrumbs: set_breadcrumbs(section, module, title, parent_gate),
+      delivery_breadcrumb: true,
+      breadcrumbs: set_breadcrumbs(section, module, title, parent_gate, user_type),
       gating_condition: gating_condition,
       modal: nil
     )
   end
 
-  defp set_breadcrumbs(section, module, title, parent_gate) do
-    OliWeb.Sections.GatingAndScheduling.set_breadcrumbs(section, parent_gate)
+  defp set_breadcrumbs(section, module, title, parent_gate, user_type) do
+    OliWeb.Sections.GatingAndScheduling.set_breadcrumbs(section, parent_gate, user_type)
     |> breadcrumb(section, module, title)
   end
 

--- a/lib/oli_web/live/sections/gating_and_scheduling/new.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling/new.ex
@@ -12,26 +12,30 @@ defmodule OliWeb.Sections.GatingAndScheduling.New do
         %{"section_slug" => section_slug} = session,
         socket
       ) do
-    {parent_gate_id, title} =
-      case Map.get(params, "parent_gate_id") do
-        nil -> {nil, "Create Gating Condition"}
-        id -> {id, "Create Student Exception"}
-      end
+    case Mount.for(section_slug, session) do
+      {:error, e} ->
+        Mount.handle_error(socket, {:error, e})
 
-    context = SessionContext.init(session)
+      {user_type, _user, section} ->
+        {parent_gate_id, title} =
+          case Map.get(params, "parent_gate_id") do
+            nil -> {nil, "Create Gating Condition"}
+            id -> {id, "Create Student Exception"}
+          end
 
-    {user_type, _user, section} = Mount.for(section_slug, session)
+        context = SessionContext.init(session)
 
-    {:ok,
-     GatingConditionStore.init(
-       socket,
-       __MODULE__,
-       section,
-       context,
-       title,
-       parent_gate_id,
-       user_type
-     )}
+        {:ok,
+         GatingConditionStore.init(
+           socket,
+           __MODULE__,
+           section,
+           context,
+           title,
+           parent_gate_id,
+           user_type
+         )}
+    end
   end
 
   def render(assigns) do

--- a/lib/oli_web/live/sections/gating_and_scheduling/new.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling/new.ex
@@ -20,11 +20,18 @@ defmodule OliWeb.Sections.GatingAndScheduling.New do
 
     context = SessionContext.init(session)
 
-    case Mount.for(section_slug, session) do
-      {type, _author, section} when type in [:user, :author, :admin] ->
-        {:ok,
-         GatingConditionStore.init(socket, __MODULE__, section, context, title, parent_gate_id)}
-    end
+    {user_type, _user, section} = Mount.for(section_slug, session)
+
+    {:ok,
+     GatingConditionStore.init(
+       socket,
+       __MODULE__,
+       section,
+       context,
+       title,
+       parent_gate_id,
+       user_type
+     )}
   end
 
   def render(assigns) do

--- a/lib/oli_web/live/sections/invite_view.ex
+++ b/lib/oli_web/live/sections/invite_view.ex
@@ -39,6 +39,7 @@ defmodule OliWeb.Sections.InviteView do
       {type, _, section} ->
         {:ok,
          assign(socket,
+           delivery_breadcrumb: true,
            breadcrumbs: set_breadcrumbs(type, section),
            section: section,
            invitations: SectionInvites.list_section_invites(section.id)

--- a/lib/oli_web/live/sections/mount.ex
+++ b/lib/oli_web/live/sections/mount.ex
@@ -33,8 +33,9 @@ defmodule OliWeb.Sections.Mount do
             ensure_instructor(section, user_id)
 
           {user_id, author_id} ->
-            case ensure_instructor(section, user_id) do
-              {:error, _} -> ensure_admin(section, author_id)
+            # prioritize system admin over instructor
+            case ensure_admin(section, author_id) do
+              {:error, _} -> ensure_instructor(section, user_id)
               e -> e
             end
         end

--- a/lib/oli_web/live/sections/mount.ex
+++ b/lib/oli_web/live/sections/mount.ex
@@ -42,6 +42,8 @@ defmodule OliWeb.Sections.Mount do
     end
   end
 
+  defp ensure_author_of(_, nil), do: {:error, :unauthorized}
+
   defp ensure_author_of(section, author_id) do
     author = Oli.Accounts.get_author!(author_id)
 
@@ -50,6 +52,8 @@ defmodule OliWeb.Sections.Mount do
       _ -> {:error, :unauthorized}
     end
   end
+
+  defp ensure_admin(_, nil), do: {:error, :unauthorized}
 
   defp ensure_admin(section, author_id) do
     author = Oli.Accounts.get_author!(author_id)

--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -92,7 +92,7 @@ defmodule OliWeb.Sections.OverviewView do
         <li><a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Delivery.RemixSection, @section.slug)}>Customize Curriculum</a></li>
         <li><a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.GatingAndScheduling, @section.slug)}>Gating and Scheduling</a></li>
           <li>
-            <a disabled={@updates_count == 0} href={Routes.updates_path(OliWeb.Endpoint, OliWeb.Delivery.ManageUpdates, @section.slug)}>
+            <a disabled={@updates_count == 0} href={Routes.section_updates_path(OliWeb.Endpoint, OliWeb.Delivery.ManageUpdates, @section.slug)}>
               Manage Updates
               {#if @updates_count > 0}
                 <span class="badge badge-primary">{@updates_count} available</span>

--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -92,7 +92,7 @@ defmodule OliWeb.Sections.OverviewView do
         <li><a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Delivery.RemixSection, @section.slug)}>Customize Curriculum</a></li>
         <li><a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.GatingAndScheduling, @section.slug)}>Gating and Scheduling</a></li>
           <li>
-            <a disabled={@updates_count == 0} href={Routes.page_delivery_path(OliWeb.Endpoint, :updates, @section.slug)}>
+            <a disabled={@updates_count == 0} href={Routes.updates_path(OliWeb.Endpoint, OliWeb.Delivery.ManageUpdates, @section.slug)}>
               Manage Updates
               {#if @updates_count > 0}
                 <span class="badge badge-primary">{@updates_count} available</span>

--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -23,7 +23,7 @@ defmodule OliWeb.Sections.OverviewView do
     |> breadcrumb(section)
   end
 
-  def set_breadcrumbs(:user, section) do
+  def set_breadcrumbs(_, section) do
     breadcrumb([], section)
   end
 

--- a/lib/oli_web/plugs/layout_based_on_user.ex
+++ b/lib/oli_web/plugs/layout_based_on_user.ex
@@ -8,10 +8,10 @@ defmodule Oli.Plugs.LayoutBasedOnUser do
   def call(conn, _params) do
     admin_role_id = SystemRole.role_id().admin
 
-    # If someone is logged in *only* as an admin author, we set the root layout to
-    # to be workspace, since they obviously hit this route coming from an Admin UI.
+    # If someone is logged in as a system admin, prioritize that (although they
+    # might be logged in as instructor) and set the root layout to be workspace.
     case {conn.assigns.current_author, conn.assigns.current_user} do
-      {%Author{system_role_id: ^admin_role_id}, nil} ->
+      {%Author{system_role_id: ^admin_role_id}, _} ->
         Controller.put_root_layout(conn, {OliWeb.LayoutView, "workspace.html"})
 
       _ ->

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -725,7 +725,7 @@ defmodule OliWeb.Router do
     live("/:section_slug/progress/:user_id/:resource_id", Progress.StudentResourceView)
     live("/:section_slug/progress/:user_id", Progress.StudentView)
     get("/:section_slug/grades/export", PageDeliveryController, :export_gradebook)
-    get("/:section_slug/updates", PageDeliveryController, :updates)
+    live("/:section_slug/updates", Delivery.ManageUpdates, as: :updates)
     live("/:section_slug/remix", Delivery.RemixSection)
     live("/:section_slug/remix/:section_resource_slug", Delivery.RemixSection)
     live("/:section_slug/enrollments", Sections.EnrollmentsView)

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -725,7 +725,7 @@ defmodule OliWeb.Router do
     live("/:section_slug/progress/:user_id/:resource_id", Progress.StudentResourceView)
     live("/:section_slug/progress/:user_id", Progress.StudentView)
     get("/:section_slug/grades/export", PageDeliveryController, :export_gradebook)
-    live("/:section_slug/updates", Delivery.ManageUpdates, as: :updates)
+    live("/:section_slug/updates", Delivery.ManageUpdates, as: :section_updates)
     live("/:section_slug/remix", Delivery.RemixSection)
     live("/:section_slug/remix/:section_resource_slug", Delivery.RemixSection)
     live("/:section_slug/enrollments", Sections.EnrollmentsView)

--- a/lib/oli_web/templates/layout/_delivery_header.html.eex
+++ b/lib/oli_web/templates/layout/_delivery_header.html.eex
@@ -39,3 +39,12 @@
     <% end %>
   </div>
 </nav>
+
+<%= if (Map.has_key?(@conn.assigns, :delivery_breadcrumb) and @delivery_breadcrumb)
+  and (Map.has_key?(@conn.assigns, :breadcrumbs) and length(@breadcrumbs) > 0) do %>
+  <div class="container">
+    <nav class="breadcrumb-bar d-flex align-items-center px-3 mt-3 mb-1">
+      <%= live_render(@conn, BreadcrumbTrailLive, session: %{"breadcrumbs" => @breadcrumbs}) %>
+    </nav>
+  </div>
+<% end %>

--- a/lib/oli_web/templates/layout/_delivery_header.html.eex
+++ b/lib/oli_web/templates/layout/_delivery_header.html.eex
@@ -40,8 +40,7 @@
   </div>
 </nav>
 
-<%= if (Map.has_key?(@conn.assigns, :delivery_breadcrumb) and @delivery_breadcrumb)
-  and (Map.has_key?(@conn.assigns, :breadcrumbs) and length(@breadcrumbs) > 0) do %>
+<%= if delivery_breadcrumbs?(@conn) do %>
   <div class="container">
     <nav class="breadcrumb-bar d-flex align-items-center px-3 mt-3 mb-1">
       <%= live_render(@conn, BreadcrumbTrailLive, session: %{"breadcrumbs" => @breadcrumbs}) %>

--- a/lib/oli_web/views/view_helpers.ex
+++ b/lib/oli_web/views/view_helpers.ex
@@ -57,4 +57,10 @@ defmodule OliWeb.ViewHelpers do
         ""
     end
   end
+
+  def delivery_breadcrumbs?(%{assigns: assigns} = _conn),
+    do:
+      Map.has_key?(assigns, :delivery_breadcrumb) and
+        Map.get(assigns, :delivery_breadcrumb, false) and
+        (Map.has_key?(assigns, :breadcrumbs) and length(Map.get(assigns, :breadcrumbs, [])) > 0)
 end

--- a/test/oli_web/controllers/session_controller_test.exs
+++ b/test/oli_web/controllers/session_controller_test.exs
@@ -10,6 +10,7 @@ defmodule OliWeb.SessionControllerTest do
       conn = delete(conn, Routes.session_path(conn, :signout, type: :user))
 
       refute conn.assigns.current_user
+      refute conn.private.plug_session["current_user_id"]
       refute conn.private.plug_session["dismissed_messages"]
       assert redirected_to(conn, 302) == Routes.static_page_path(conn, :index)
     end
@@ -20,6 +21,7 @@ defmodule OliWeb.SessionControllerTest do
       conn = delete(conn, Routes.authoring_session_path(conn, :signout, type: :author))
 
       refute conn.assigns.current_author
+      refute conn.private.plug_session["current_author_id"]
       refute conn.private.plug_session["dismissed_messages"]
       assert redirected_to(conn, 302) == Routes.static_page_path(conn, :index)
     end

--- a/test/oli_web/live/admin_live_test.exs
+++ b/test/oli_web/live/admin_live_test.exs
@@ -101,11 +101,8 @@ defmodule OliWeb.AdminLiveTest do
              |> render() =~
                "All administrative actions taken in the system are logged for auditing purposes."
 
-      assert render(view) =~
-               "Account Management"
-
-      assert render(view) =~
-               "Access and manage all users and authors"
+      assert render(view) =~ "Account Management"
+      assert render(view) =~ "Access and manage all users and authors"
 
       assert has_element?(
                view,
@@ -136,11 +133,8 @@ defmodule OliWeb.AdminLiveTest do
     test "loads content management links correctly", %{conn: conn} do
       {:ok, view, _html} = live(conn, @live_view_route)
 
-      assert render(view) =~
-               "Content Management"
-
-      assert render(view) =~
-               "Access and manage created content"
+      assert render(view) =~ "Content Management"
+      assert render(view) =~ "Access and manage created content"
 
       assert has_element?(
                view,
@@ -176,11 +170,8 @@ defmodule OliWeb.AdminLiveTest do
     test "loads system management links correctly", %{conn: conn} do
       {:ok, view, _html} = live(conn, @live_view_route)
 
-      assert render(view) =~
-               "System Management"
-
-      assert render(view) =~
-               "Manage and support system level functionality"
+      assert render(view) =~ "System Management"
+      assert render(view) =~ "Manage and support system level functionality"
 
       assert has_element?(
                view,
@@ -249,8 +240,7 @@ defmodule OliWeb.AdminLiveTest do
 
       {:ok, view, _html} = live(conn, @live_view_users_route)
 
-      view
-      |> render_hook("text_search_change", %{value: "testing"})
+      render_hook(view, "text_search_change", %{value: "testing"})
 
       assert view
              |> element("tr:first-child > td:first-child")
@@ -262,14 +252,10 @@ defmodule OliWeb.AdminLiveTest do
              |> render() =~
                user_2.given_name
 
-      view
-      |> render_hook("text_search_change", %{value: ""})
+      render_hook(view, "text_search_change", %{value: ""})
 
-      assert render(view) =~
-               user_1.given_name
-
-      assert render(view) =~
-               user_2.given_name
+      assert render(view) =~ user_1.given_name
+      assert render(view) =~ user_2.given_name
     end
 
     test "applies sorting", %{conn: conn} do
@@ -376,7 +362,6 @@ defmodule OliWeb.AdminLiveTest do
       |> render_submit(%{user: new_attributes})
 
       %User{name: new_name} = Accounts.get_user!(id)
-
       assert new_attributes.name == new_name
     end
 
@@ -503,23 +488,15 @@ defmodule OliWeb.AdminLiveTest do
 
       {:ok, view, _html} = live(conn, @live_view_authors_route)
 
-      view
-      |> render_hook("text_search_change", %{value: "testing"})
+      render_hook(view, "text_search_change", %{value: "testing"})
 
-      assert render(view) =~
-               author_1.given_name
+      assert render(view) =~ author_1.given_name
+      refute render(view) =~ author_2.given_name
 
-      refute render(view) =~
-               author_2.given_name
+      render_hook(view, "text_search_change", %{value: ""})
 
-      view
-      |> render_hook("text_search_change", %{value: ""})
-
-      assert render(view) =~
-               author_1.given_name
-
-      assert render(view) =~
-               author_2.given_name
+      assert render(view) =~ author_1.given_name
+      assert render(view) =~ author_2.given_name
     end
 
     test "applies sorting", %{conn: conn} do
@@ -550,15 +527,13 @@ defmodule OliWeb.AdminLiveTest do
 
       {:ok, view, _html} = live(conn, @live_view_authors_route)
 
-      assert render(view) =~
-               first_author.given_name
+      assert render(view) =~ first_author.given_name
 
       view
       |> element("#header_paging a[phx-click=\"paged_table_page_change\"]", "2")
       |> render_click()
 
-      refute render(view) =~
-               first_author.given_name
+      refute render(view) =~ first_author.given_name
     end
 
     test "shows confirmation pending message when author account was created but not confirmed yet",

--- a/test/oli_web/live/community_live_test.exs
+++ b/test/oli_web/live/community_live_test.exs
@@ -206,7 +206,6 @@ defmodule OliWeb.CommunityLiveTest do
                "Community couldn&#39;t be created. Please check the errors below."
 
       assert has_element?(view, "span", "can't be blank")
-
       assert [] = Groups.list_communities()
     end
 
@@ -226,7 +225,6 @@ defmodule OliWeb.CommunityLiveTest do
                "Community couldn&#39;t be created. Please check the errors below."
 
       assert has_element?(view, "span", "has already been taken")
-
       assert 1 = Groups.list_communities() |> length()
     end
 
@@ -293,7 +291,6 @@ defmodule OliWeb.CommunityLiveTest do
                "Community couldn&#39;t be updated. Please check the errors below."
 
       assert has_element?(view, "span", "can't be blank")
-
       refute Groups.get_community(id).name == ""
     end
 
@@ -336,7 +333,6 @@ defmodule OliWeb.CommunityLiveTest do
                "Community couldn&#39;t be updated. Please check the errors below."
 
       assert has_element?(view, "span", "has already been taken")
-
       assert 2 = Groups.list_communities() |> length()
     end
 
@@ -431,7 +427,6 @@ defmodule OliWeb.CommunityLiveTest do
 
       flash = assert_redirected(view, @live_view_index_route)
       assert flash["info"] == "Community successfully deleted."
-
       assert nil == Groups.get_community(id)
     end
 
@@ -923,7 +918,6 @@ defmodule OliWeb.CommunityLiveTest do
                "Association successfully removed."
 
       refute has_element?(view, "##{cv1.id}")
-
       assert has_element?(view, "p", "None exist")
     end
 

--- a/test/oli_web/live/objectives_test.exs
+++ b/test/oli_web/live/objectives_test.exs
@@ -45,7 +45,6 @@ defmodule OliWeb.ObjectivesLiveTest do
       |> render_click()
 
       refute view |> element("##{objective1.revision.slug}") |> has_element?()
-
       assert view |> element("##{objective2.revision.slug}") |> has_element?()
     end
   end

--- a/test/oli_web/live/remix_section_test.exs
+++ b/test/oli_web/live/remix_section_test.exs
@@ -145,6 +145,49 @@ defmodule OliWeb.RemixSectionLiveTest do
     end
   end
 
+  describe "breadcrumbs" do
+    setup [:setup_session]
+
+    test "as instructor", %{
+      conn: conn,
+      map: %{
+        section_1: section_1
+      }
+    } do
+      conn =
+        get(conn, Routes.live_path(OliWeb.Endpoint, OliWeb.Delivery.RemixSection, section_1.slug))
+
+      {:ok, _view, html} = live(conn)
+
+      refute html =~
+               "Admin"
+
+      assert html =~
+               "Customize Content"
+    end
+
+    test "as admin", %{
+      conn: conn,
+      admin: admin,
+      map: %{
+        section_1: section_1
+      }
+    } do
+      conn =
+        Plug.Test.init_test_session(conn, %{})
+        |> Pow.Plug.assign_current_user(admin, OliWeb.Pow.PowHelpers.get_pow_config(:author))
+        |> get(Routes.live_path(OliWeb.Endpoint, OliWeb.Delivery.RemixSection, section_1.slug))
+
+      {:ok, _view, html} = live(conn)
+
+      assert html =~
+               "Admin"
+
+      assert html =~
+               "Customize Content"
+    end
+  end
+
   defp setup_session(%{conn: conn}) do
     map = Seeder.base_project_with_resource4()
 

--- a/test/oli_web/live/remix_section_test.exs
+++ b/test/oli_web/live/remix_section_test.exs
@@ -134,8 +134,7 @@ defmodule OliWeb.RemixSectionLiveTest do
 
       {:ok, view, _html} = live(conn)
 
-      view
-      |> render_hook("reorder", %{"sourceIndex" => "0", "dropIndex" => "2"})
+      render_hook(view, "reorder", %{"sourceIndex" => "0", "dropIndex" => "2"})
 
       view
       |> element("#save")
@@ -159,11 +158,8 @@ defmodule OliWeb.RemixSectionLiveTest do
 
       {:ok, _view, html} = live(conn)
 
-      refute html =~
-               "Admin"
-
-      assert html =~
-               "Customize Content"
+      refute html =~ "Admin"
+      assert html =~ "Customize Content"
     end
 
     test "as admin", %{
@@ -180,11 +176,8 @@ defmodule OliWeb.RemixSectionLiveTest do
 
       {:ok, _view, html} = live(conn)
 
-      assert html =~
-               "Admin"
-
-      assert html =~
-               "Customize Content"
+      assert html =~ "Admin"
+      assert html =~ "Customize Content"
     end
   end
 

--- a/test/oli_web/live/sections/edit_live_test.exs
+++ b/test/oli_web/live/sections/edit_live_test.exs
@@ -91,14 +91,11 @@ defmodule OliWeb.Sections.EditLiveTest do
       section = insert(:section, %{type: :enrollable})
       Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_instructor)])
 
-      {:ok, view, html} = live(conn, live_view_edit_route(section.slug))
+      {:ok, _view, html} = live(conn, live_view_edit_route(section.slug))
 
       refute html =~ "Admin"
-
       assert html =~ "Edit Section Details"
-
-      assert render(view) =~
-               "Settings"
+      assert html =~ "Settings"
     end
   end
 
@@ -117,15 +114,11 @@ defmodule OliWeb.Sections.EditLiveTest do
       {:ok, view, html} = live(conn, live_view_edit_route(section.slug))
 
       assert html =~ "Admin"
-
       assert html =~ "Edit Section Details"
-
       assert html =~ "Settings"
       assert html =~ "Manage the course section settings"
-
       assert html =~ "Direct Delivery"
       assert html =~ "Direct Delivery section settings"
-
       assert has_element?(view, "input[value=\"#{section.title}\"]")
       assert has_element?(view, "input[value=\"#{section.description}\"]")
 
@@ -141,8 +134,7 @@ defmodule OliWeb.Sections.EditLiveTest do
 
       {:ok, view, _html} = live(conn, live_view_edit_route(section.slug))
 
-      assert render(view) =~
-               "Settings"
+      assert render(view) =~ "Settings"
 
       assert view
              |> element("option[selected=\"selected\"][value=\"#{section.brand_id}\"]")

--- a/test/oli_web/live/sections/edit_live_test.exs
+++ b/test/oli_web/live/sections/edit_live_test.exs
@@ -91,7 +91,11 @@ defmodule OliWeb.Sections.EditLiveTest do
       section = insert(:section, %{type: :enrollable})
       Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_instructor)])
 
-      {:ok, view, _html} = live(conn, live_view_edit_route(section.slug))
+      {:ok, view, html} = live(conn, live_view_edit_route(section.slug))
+
+      refute html =~ "Admin"
+
+      assert html =~ "Edit Section Details"
 
       assert render(view) =~
                "Settings"
@@ -110,9 +114,11 @@ defmodule OliWeb.Sections.EditLiveTest do
     test "loads section data correctly", %{conn: conn} do
       section = insert(:section, open_and_free: true)
 
-      {:ok, view, _html} = live(conn, live_view_edit_route(section.slug))
+      {:ok, view, html} = live(conn, live_view_edit_route(section.slug))
 
-      html = render(view)
+      assert html =~ "Admin"
+
+      assert html =~ "Edit Section Details"
 
       assert html =~ "Settings"
       assert html =~ "Manage the course section settings"

--- a/test/oli_web/live/sections/enrollments_view_test.exs
+++ b/test/oli_web/live/sections/enrollments_view_test.exs
@@ -1,6 +1,7 @@
 defmodule OliWeb.Sections.EnrollmentsViewTest do
   use OliWeb.ConnCase
 
+  import Oli.Factory
   import Phoenix.{ConnTest, LiveViewTest}
 
   alias Oli.Seeder
@@ -73,6 +74,27 @@ defmodule OliWeb.Sections.EnrollmentsViewTest do
     test "mount enrollments for admin", %{conn: conn, section: section} do
       {:ok, _view, html} =
         live(conn, Routes.live_path(@endpoint, OliWeb.Sections.EnrollmentsView, section.slug))
+
+      assert html =~ "Admin"
+
+      assert html =~ "Enrollments"
+    end
+  end
+
+  describe "breadcrumbs" do
+    test "mount enrollments for instructor", %{conn: conn} do
+      section = insert(:section, %{type: :enrollable})
+      user = insert(:user)
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_instructor)])
+
+      conn =
+        Plug.Test.init_test_session(conn, lti_session: nil, section_slug: section.slug)
+        |> Pow.Plug.assign_current_user(user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
+
+      {:ok, _view, html} =
+        live(conn, Routes.live_path(@endpoint, OliWeb.Sections.EnrollmentsView, section.slug))
+
+      refute html =~ "Admin"
 
       assert html =~ "Enrollments"
     end

--- a/test/oli_web/live/sections/enrollments_view_test.exs
+++ b/test/oli_web/live/sections/enrollments_view_test.exs
@@ -76,7 +76,6 @@ defmodule OliWeb.Sections.EnrollmentsViewTest do
         live(conn, Routes.live_path(@endpoint, OliWeb.Sections.EnrollmentsView, section.slug))
 
       assert html =~ "Admin"
-
       assert html =~ "Enrollments"
     end
   end
@@ -95,7 +94,6 @@ defmodule OliWeb.Sections.EnrollmentsViewTest do
         live(conn, Routes.live_path(@endpoint, OliWeb.Sections.EnrollmentsView, section.slug))
 
       refute html =~ "Admin"
-
       assert html =~ "Enrollments"
     end
   end

--- a/test/oli_web/live/sections/gating_and_scheduling_test.exs
+++ b/test/oli_web/live/sections/gating_and_scheduling_test.exs
@@ -34,6 +34,8 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
       {:ok, _view, html} =
         live(conn, Routes.live_path(@endpoint, OliWeb.Sections.GatingAndScheduling, section.slug))
 
+      assert html =~ "Admin"
+
       assert html =~ "Gating and Scheduling"
     end
   end
@@ -44,6 +46,8 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
     test "mount listing for instructor", %{conn: conn, section_1: section} do
       {:ok, _view, html} =
         live(conn, Routes.live_path(@endpoint, OliWeb.Sections.GatingAndScheduling, section.slug))
+
+      refute html =~ "Admin"
 
       assert html =~ "Gating and Scheduling"
     end

--- a/test/oli_web/live/sections/gating_and_scheduling_test.exs
+++ b/test/oli_web/live/sections/gating_and_scheduling_test.exs
@@ -35,7 +35,6 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
         live(conn, Routes.live_path(@endpoint, OliWeb.Sections.GatingAndScheduling, section.slug))
 
       assert html =~ "Admin"
-
       assert html =~ "Gating and Scheduling"
     end
   end
@@ -48,7 +47,6 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
         live(conn, Routes.live_path(@endpoint, OliWeb.Sections.GatingAndScheduling, section.slug))
 
       refute html =~ "Admin"
-
       assert html =~ "Gating and Scheduling"
     end
 
@@ -89,20 +87,16 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
       gating_condition: gating_condition,
       revision: revision
     } do
-      {:ok, view, _html} =
+      {:ok, view, html} =
         live(
           conn,
           gating_condition_edit_route(section.slug, gating_condition.id)
         )
 
-      assert render(view) =~
-               "Edit Gating Condition"
-
+      assert html =~ "Edit Gating Condition"
       assert has_element?(view, "input[value=\"#{revision.title}\"]")
-
-      assert render(view) =~ Date.to_string(gating_condition.data.start_datetime)
-
-      assert render(view) =~ Date.to_string(gating_condition.data.end_datetime)
+      assert html =~ Date.to_string(gating_condition.data.start_datetime)
+      assert html =~ Date.to_string(gating_condition.data.end_datetime)
     end
 
     test "displays a confirm modal before deleting a gating condition", %{
@@ -169,11 +163,8 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
           gating_condition_edit_route(section.slug, gating_condition.id)
         )
 
-      view
-      |> render_hook("schedule_start_date_changed", %{value: "2022-01-12T13:48"})
-
-      view
-      |> render_hook("schedule_end_date_changed", %{value: "2022-01-10T13:48"})
+      render_hook(view, "schedule_start_date_changed", %{value: "2022-01-12T13:48"})
+      render_hook(view, "schedule_end_date_changed", %{value: "2022-01-10T13:48"})
 
       view
       |> element("button[phx-click=\"update_gate\"]")
@@ -196,11 +187,8 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
           gating_condition_edit_route(section.slug, gating_condition.id)
         )
 
-      view
-      |> render_hook("schedule_start_date_changed", %{value: "2022-01-12T13:48"})
-
-      view
-      |> render_hook("schedule_end_date_changed", %{value: "2022-01-13T13:48"})
+      render_hook(view, "schedule_start_date_changed", %{value: "2022-01-12T13:48"})
+      render_hook(view, "schedule_end_date_changed", %{value: "2022-01-13T13:48"})
 
       view
       |> element("button[phx-click=\"update_gate\"]")
@@ -250,17 +238,10 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
 
       uuid = Enum.at(element_splitted, prev_uuid_index + 1)
 
-      view
-      |> render_hook("select_resource", %{selection: "#{uuid}"})
-
-      view
-      |> render_hook("select-condition", %{value: "schedule"})
-
-      view
-      |> render_hook("schedule_start_date_changed", %{value: "2022-01-12T13:48"})
-
-      view
-      |> render_hook("schedule_end_date_changed", %{value: "2022-01-10T13:48"})
+      render_hook(view, "select_resource", %{selection: "#{uuid}"})
+      render_hook(view, "select-condition", %{value: "schedule"})
+      render_hook(view, "schedule_start_date_changed", %{value: "2022-01-12T13:48"})
+      render_hook(view, "schedule_end_date_changed", %{value: "2022-01-10T13:48"})
 
       view
       |> element("button[phx-click=\"create_gate\"]")
@@ -303,17 +284,10 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
 
       uuid = Enum.at(element_splitted, prev_uuid_index + 1)
 
-      view
-      |> render_hook("select_resource", %{selection: "#{uuid}"})
-
-      view
-      |> render_hook("select-condition", %{value: "schedule"})
-
-      view
-      |> render_hook("schedule_start_date_changed", %{value: "2022-01-12T13:48"})
-
-      view
-      |> render_hook("schedule_end_date_changed", %{value: "2022-01-13T13:48"})
+      render_hook(view, "select_resource", %{selection: "#{uuid}"})
+      render_hook(view, "select-condition", %{value: "schedule"})
+      render_hook(view, "schedule_start_date_changed", %{value: "2022-01-12T13:48"})
+      render_hook(view, "schedule_end_date_changed", %{value: "2022-01-13T13:48"})
 
       view
       |> element("button[phx-click=\"create_gate\"]")

--- a/test/oli_web/live/sections/overview_live_test.exs
+++ b/test/oli_web/live/sections/overview_live_test.exs
@@ -92,7 +92,30 @@ defmodule OliWeb.Sections.OverviewLiveTest do
       section = insert(:section, %{type: :enrollable})
       Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_instructor)])
 
-      {:ok, view, _html} = live(conn, live_view_overview_route(section.slug))
+      {:ok, view, html} = live(conn, live_view_overview_route(section.slug))
+
+      refute html =~
+               "<nav aria-label=\"breadcrumb"
+
+      assert render(view) =~
+               "Overview"
+    end
+  end
+
+  describe "admin is prioritized over instructor when both logged in" do
+    setup [:admin_conn, :user_conn]
+
+    test "loads correctly", %{
+      conn: conn,
+      user: user
+    } do
+      section = insert(:section, %{type: :enrollable})
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_instructor)])
+
+      {:ok, view, html} = live(conn, live_view_overview_route(section.slug))
+
+      assert html =~
+               "<nav aria-label=\"breadcrumb"
 
       assert render(view) =~
                "Overview"

--- a/test/oli_web/live/sections/overview_live_test.exs
+++ b/test/oli_web/live/sections/overview_live_test.exs
@@ -199,7 +199,7 @@ defmodule OliWeb.Sections.OverviewLiveTest do
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.updates_path(OliWeb.Endpoint, OliWeb.Delivery.ManageUpdates, section.slug)}\"]"
+               "a[href=\"#{Routes.section_updates_path(OliWeb.Endpoint, OliWeb.Delivery.ManageUpdates, section.slug)}\"]"
              )
 
       assert render(view) =~

--- a/test/oli_web/live/sections/overview_live_test.exs
+++ b/test/oli_web/live/sections/overview_live_test.exs
@@ -199,7 +199,7 @@ defmodule OliWeb.Sections.OverviewLiveTest do
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.page_delivery_path(OliWeb.Endpoint, :updates, section.slug)}\"]"
+               "a[href=\"#{Routes.updates_path(OliWeb.Endpoint, OliWeb.Delivery.ManageUpdates, section.slug)}\"]"
              )
 
       assert render(view) =~

--- a/test/oli_web/live/sections/overview_live_test.exs
+++ b/test/oli_web/live/sections/overview_live_test.exs
@@ -92,13 +92,10 @@ defmodule OliWeb.Sections.OverviewLiveTest do
       section = insert(:section, %{type: :enrollable})
       Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_instructor)])
 
-      {:ok, view, html} = live(conn, live_view_overview_route(section.slug))
+      {:ok, _view, html} = live(conn, live_view_overview_route(section.slug))
 
-      refute html =~
-               "<nav aria-label=\"breadcrumb"
-
-      assert render(view) =~
-               "Overview"
+      refute html =~ "<nav aria-label=\"breadcrumb"
+      assert html =~ "Overview"
     end
   end
 
@@ -112,13 +109,10 @@ defmodule OliWeb.Sections.OverviewLiveTest do
       section = insert(:section, %{type: :enrollable})
       Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_instructor)])
 
-      {:ok, view, html} = live(conn, live_view_overview_route(section.slug))
+      {:ok, _view, html} = live(conn, live_view_overview_route(section.slug))
 
-      assert html =~
-               "<nav aria-label=\"breadcrumb"
-
-      assert render(view) =~
-               "Overview"
+      assert html =~ "<nav aria-label=\"breadcrumb"
+      assert html =~ "Overview"
     end
   end
 
@@ -136,12 +130,8 @@ defmodule OliWeb.Sections.OverviewLiveTest do
 
       {:ok, view, _html} = live(conn, live_view_overview_route(section.slug))
 
-      assert render(view) =~
-               "Overview"
-
-      assert render(view) =~
-               "Overview of this course section"
-
+      assert render(view) =~ "Overview"
+      assert render(view) =~ "Overview of this course section"
       assert has_element?(view, "input[value=\"#{section.slug}\"]")
       assert has_element?(view, "input[value=\"#{section.title}\"]")
       assert has_element?(view, "input[value=\"Direct Delivery\"]")
@@ -155,27 +145,17 @@ defmodule OliWeb.Sections.OverviewLiveTest do
 
       {:ok, view, _html} = live(conn, live_view_overview_route(section.slug))
 
-      assert render(view) =~
-               "Instructors"
-
-      assert render(view) =~
-               "Manage the users with instructor level access"
-
-      assert render(view) =~
-               user_enrolled.given_name
-
-      refute render(view) =~
-               user_not_enrolled.given_name
+      assert render(view) =~ "Instructors"
+      assert render(view) =~ "Manage the users with instructor level access"
+      assert render(view) =~ user_enrolled.given_name
+      refute render(view) =~ user_not_enrolled.given_name
     end
 
     test "loads section links correctly", %{conn: conn, section: section} do
       {:ok, view, _html} = live(conn, live_view_overview_route(section.slug))
 
-      assert render(view) =~
-               "Curriculum"
-
-      assert render(view) =~
-               "Manage the content delivered to students"
+      assert render(view) =~ "Curriculum"
+      assert render(view) =~ "Manage the content delivered to students"
 
       assert has_element?(
                view,
@@ -202,11 +182,8 @@ defmodule OliWeb.Sections.OverviewLiveTest do
                "a[href=\"#{Routes.section_updates_path(OliWeb.Endpoint, OliWeb.Delivery.ManageUpdates, section.slug)}\"]"
              )
 
-      assert render(view) =~
-               "Manage"
-
-      assert render(view) =~
-               "Manage all aspects of course delivery"
+      assert render(view) =~ "Manage"
+      assert render(view) =~ "Manage all aspects of course delivery"
 
       assert has_element?(
                view,
@@ -218,11 +195,8 @@ defmodule OliWeb.Sections.OverviewLiveTest do
                "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.EditView, section.slug)}\"]"
              )
 
-      assert render(view) =~
-               "Grading"
-
-      assert render(view) =~
-               "View and manage student grades and progress"
+      assert render(view) =~ "Grading"
+      assert render(view) =~ "View and manage student grades and progress"
 
       assert has_element?(
                view,
@@ -243,11 +217,8 @@ defmodule OliWeb.Sections.OverviewLiveTest do
     test "unlink section from lms", %{conn: conn, section: section} do
       {:ok, view, _html} = live(conn, live_view_overview_route(section.slug))
 
-      assert render(view) =~
-               "LMS Admin"
-
-      assert render(view) =~
-               "Administrator LMS Connection"
+      assert render(view) =~ "LMS Admin"
+      assert render(view) =~ "Administrator LMS Connection"
 
       view
       |> element("button[phx-click=\"unlink\"]")

--- a/test/oli_web/live/system_message_live_test.exs
+++ b/test/oli_web/live/system_message_live_test.exs
@@ -35,7 +35,6 @@ defmodule OliWeb.SystemMessageLiveTest do
       {:ok, view, _html} = live(conn, @live_view_index_route)
 
       refute has_element?(view, "#system_message_active")
-
       assert render(view) =~ "Create"
     end
 


### PR DESCRIPTION
[MER-761](https://eliterate.atlassian.net/browse/MER-761)

At this time, there is no ability to return to the Manage Section view for an instructor who is viewing data from their sections. We reused what is done for the admin breadcrumbs and configuring with a boolean in the assigns if we want delivery breadcrumbs for that view.

Minor changes were also made to prioritize the sysadmin over the instructor when both sessions are started at the same time, and for cleaner code.

### Recommendation
Review changes by commits for simplicity