### PR TITLE
[BUG FIX] Fix table styling to break words that overflow bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fix inability to search in projects and users view
 - Properly handle the case that a section invite link leads to an unavailable section
+- Fix table styling when words overflow bounds
 
 ### Enhancements
 

--- a/assets/styles/authoring/model-editors.scss
+++ b/assets/styles/authoring/model-editors.scss
@@ -13,6 +13,8 @@
     table {
       position: relative;
       margin-bottom: 0;
+      word-wrap: break-word;
+      overflow: hidden;
 
       .table-dropdown {
         position: absolute;

--- a/assets/styles/common/elements.scss
+++ b/assets/styles/common/elements.scss
@@ -40,6 +40,8 @@
     @extend .table;
     border-collapse: collapse;
     table-layout: fixed;
+    word-wrap: break-word;
+    overflow: hidden;
 
     th {
       background-color: rgba($blue, 15%);


### PR DESCRIPTION
Fixes #2271

The issue was that tables didn't have a css option set for `word-wrap`, so when the word was too long for the cell, it overflowed.

Before:
<img width="616" alt="image" src="https://user-images.githubusercontent.com/16868015/157351503-bce34d8e-1ea7-456f-9a14-930fe10f1a11.png">


After:
<img width="630" alt="image" src="https://user-images.githubusercontent.com/16868015/157351465-b865a951-42d7-4467-a974-890f9267f8c3.png">
