### PR TITLE
[ENHANCEMENT] Hide subsequent purpose type decorations for activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Display containers as pages with a table of contents
 - Logic-based gating
 - Allow learning objective attachment to pages
+- Hide subsequent purpose types for activities when the same purpose type is used in a series
 
 ## 0.18.4 (2022-02-24)
 

--- a/assets/styles/delivery/purpose.scss
+++ b/assets/styles/delivery/purpose.scss
@@ -57,6 +57,21 @@
   color: white;
   border-radius: 4px;
 
+  // Only display purpose type decorations for the first elem of that type
+  // in a series.
+  // HTML looks like:
+  // <h4 class="{purpose-type}" />
+  // <activity class="activity-container" />
+  // <h4 class="{purpose-type}" />
+  // <activity class="activity-container" />
+  // So, we use the sibling selector to hide duplicate purpose types
+  // that occur after an activity element.
+  &.checkpoint + .activity-container + .checkpoint,
+  &.didigetthis + .activity-container + .didigetthis,
+  &.learnbydoing + .activity-container + .learnbydoing {
+    display: none;
+  }
+
   &.checkpoint {
     background-color: $activity-purpose-checkpoint-color;
 


### PR DESCRIPTION
Closes #2270 

Hides purpose type decorations after the first if the same purpose type is used "in a series" for activities on a page. This is only done for activities, not page content items.

It will not hide the decoration if the series is "broken" by a different purpose type. That is, if you have two series of the same purpose type (Purpose Type 1) separated by a different one (Purpose Type 2), the decoration for Purpose Type 1 will show on the first activity in each series.