### PR TITLE
[BUGFIX] PMP-2499 lesson css classes in adaptive player are missing a space

### DIFF
--- a/assets/src/apps/delivery/layouts/deck/DeckLayoutView.tsx
+++ b/assets/src/apps/delivery/layouts/deck/DeckLayoutView.tsx
@@ -72,7 +72,7 @@ const DeckLayoutView: React.FC<LayoutProps> = ({ pageTitle, pageContent, preview
     if (currentActivityTree) {
       currentActivityTree.forEach((activity) => {
         if (activity?.content?.custom?.customCssClass) {
-          className += activity?.content?.custom?.customCssClass;
+          className += ' ' + activity?.content?.custom?.customCssClass;
         }
       });
     }


### PR DESCRIPTION
ensure there are spaces between classes