### PR TITLE
Make reply-to consistent to avoid hackney parsing issues with bracket / string.

### DIFF
--- a/lib/oli/email.ex
+++ b/lib/oli/email.ex
@@ -11,11 +11,11 @@ defmodule Oli.Email do
     |> html_text_body()
   end
 
-  @spec help_desk_email(String.t(), String.t(), String.t(), String.t(), atom(), map()) ::
+  @spec help_desk_email(String.t(), String.t(), String.t(), atom(), map()) ::
           Bamboo.Email.t()
-  def help_desk_email(name, from_email, help_desk_email, subject, view, assigns) do
+  def help_desk_email(from_email, help_desk_email, subject, view, assigns) do
     base_email()
-    |> put_header("Reply-To", name <> " <" <> from_email <> ">")
+    |> put_header("Reply-To", from_email)
     |> put_layout({OliWeb.LayoutView, :help_email})
     |> to(help_desk_email)
     |> subject(subject)

--- a/lib/oli/help/providers/email_help.ex
+++ b/lib/oli/help/providers/email_help.ex
@@ -9,7 +9,6 @@ defmodule Oli.Help.Providers.EmailHelp do
 
     email =
       Oli.Email.help_desk_email(
-        contents.full_name,
         contents.email,
         help_desk_email,
         HelpContent.get_subject(contents.subject),


### PR DESCRIPTION
We saw this a while back with other emails and we updated them so this makes is consistent + should remove the hackney parsing issue.