### PR TITLE
[BUG FIX] Cast array to allow flatMap to work

### DIFF
--- a/assets/src/utils/common.ts
+++ b/assets/src/utils/common.ts
@@ -33,7 +33,7 @@ function hasContent(item: any): boolean {
     if (Array.isArray(item)) return item.some(hasContent);
     if (item.text) return item.text?.trim();
 
-    return [item?.children, item?.content, item?.content?.model]
+    return ([item?.children, item?.content, item?.content?.model] as any)
       .flatMap(hasContent)
       .some((x: any) => !!x);
   } catch (e) {


### PR DESCRIPTION
TS compiler was throwing an error only when compiling the Node library for the rules engine.  

Solution seems to be to just cast as `any` and the compilation now works.