### PR TITLE
[PERF] only load the adaptive activity for now in advanced pages

### DIFF
--- a/lib/oli_web/templates/page_delivery/advanced_delivery.html.eex
+++ b/lib/oli_web/templates/page_delivery/advanced_delivery.html.eex
@@ -1,9 +1,14 @@
 
-<%= for script <- @part_scripts do %>
-  <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/" <> script) %>"></script>
+<!-- ACTIVITIES -->
+<%= for %{slug: slug, authoring_script: script} <- @activity_types do %>
+  <%= if slug == "oli_adaptive" do %>
+    <!-- <%= slug %> -->
+    <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/" <> script) %>"></script>
+  <% end %>
 <% end %>
 
-<%= for script <- @scripts do %>
+<!-- PARTS -->
+<%= for script <- @part_scripts do %>
   <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/" <> script) %>"></script>
 <% end %>
 

--- a/lib/oli_web/templates/resource/advanced_page_preview.html.eex
+++ b/lib/oli_web/templates/resource/advanced_page_preview.html.eex
@@ -1,8 +1,13 @@
-<%= for script <- @part_scripts do %>
-  <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/" <> script) %>"></script>
+<!-- ACTIVITIES -->
+<%= for %{slug: slug, authoring_script: script} <- @activity_types do %>
+  <%= if slug == "oli_adaptive" do %>
+    <!-- <%= slug %> -->
+    <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/" <> script) %>"></script>
+  <% end %>
 <% end %>
 
-<%= for script <- @scripts do %>
+<!-- PARTS -->
+<%= for script <- @part_scripts do %>
   <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/" <> script) %>"></script>
 <% end %>
 


### PR DESCRIPTION
this will make it so only the 'oli_adaptive' activity script will be loaded in the advanced delivery and preview;
technically we should determine based on what is used in the page rather than hard coding, but this will gain a small download perf bonus