### PR TITLE
[BUG FIX] Fix migrations, avoid code resuse which is breaking

### DIFF
--- a/priv/repo/migrations/20220308142458_attempt_states.exs
+++ b/priv/repo/migrations/20220308142458_attempt_states.exs
@@ -1,8 +1,6 @@
 defmodule Oli.Repo.Migrations.AttemptStates do
   use Ecto.Migration
 
-  alias Oli.Repo.Migrations.OptimizationInfra
-
   def change do
     alter table(:part_attempts) do
       add :lifecycle_state, :string, default: "active", null: false
@@ -39,64 +37,7 @@ defmodule Oli.Repo.Migrations.AttemptStates do
     execute "UPDATE activity_attempts SET date_submitted = date_evaluated;"
     execute "UPDATE resource_attempts SET date_submitted = date_evaluated;"
 
-    OptimizationInfra.drop_trigger()
-    drop_materialized_view()
-
-    user = OptimizationInfra.get_current_db_user()
-    create_materialized_view(user)
-    OptimizationInfra.create_trigger(user)
-    OptimizationInfra.refresh_materialized_view()
-
     flush()
   end
 
-  def drop_materialized_view() do
-    execute """
-    DROP INDEX IF EXISTS part_id_revision_id;
-    """
-
-    execute """
-    DROP INDEX IF EXISTS revision_id_index;
-    """
-
-    execute """
-    DROP MATERIALIZED VIEW IF EXISTS public.part_mapping;
-    """
-  end
-
-  def create_materialized_view(user) do
-    execute """
-    CREATE MATERIALIZED VIEW IF NOT EXISTS public.part_mapping
-    TABLESPACE pg_default
-    AS
-    SELECT DISTINCT btrim(jsonb_path_query(r.content, '$."authoring"."parts"[*]."id"'::jsonpath)::text, '"'::text) AS part_id,
-        r.id as revision_id,
-        btrim(jsonb_path_query(r.content, '$."authoring"."parts"[*]."gradingApproach"'::jsonpath)::text, '"'::text) AS grading_approach
-      FROM published_resources pr
-        LEFT JOIN publications p ON p.id = pr.publication_id
-        LEFT JOIN revisions r ON r.id = pr.revision_id
-      WHERE r.resource_type_id = 3 AND p.published IS NOT NULL
-      ORDER BY r.id, (btrim(jsonb_path_query(r.content, '$."authoring"."parts"[*]."id"'::jsonpath)::text, '"'::text))
-    WITH DATA;
-    """
-
-    execute """
-    ALTER TABLE IF EXISTS public.part_mapping
-    OWNER TO #{user};
-    """
-
-    execute """
-    CREATE UNIQUE INDEX part_id_revision_id
-    ON public.part_mapping USING btree
-    (part_id COLLATE pg_catalog."default", revision_id)
-    TABLESPACE pg_default;
-    """
-
-    execute """
-    CREATE INDEX revision_id_index
-    ON public.part_mapping USING btree
-    (revision_id)
-    TABLESPACE pg_default;
-    """
-  end
 end

--- a/priv/repo/migrations/20220317164007_fix_previous_migration.exs
+++ b/priv/repo/migrations/20220317164007_fix_previous_migration.exs
@@ -1,0 +1,137 @@
+defmodule Oli.Repo.Migrations.FixPreviousMigration do
+  use Ecto.Migration
+
+  def change do
+
+    flush()
+
+    drop_trigger()
+    drop_materialized_view()
+
+    user = get_current_db_user()
+    create_materialized_view(user)
+    create_trigger(user)
+    refresh_materialized_view()
+
+    flush()
+
+  end
+
+
+  def drop_materialized_view() do
+    execute """
+    DROP INDEX IF EXISTS part_id_revision_id;
+    """
+
+    execute """
+    DROP INDEX IF EXISTS revision_id_index;
+    """
+
+    execute """
+    DROP MATERIALIZED VIEW IF EXISTS public.part_mapping;
+    """
+  end
+
+  def create_materialized_view(user) do
+    execute """
+    CREATE MATERIALIZED VIEW IF NOT EXISTS public.part_mapping
+    TABLESPACE pg_default
+    AS
+    SELECT DISTINCT btrim(jsonb_path_query(r.content, '$."authoring"."parts"[*]."id"'::jsonpath)::text, '"'::text) AS part_id,
+        r.id as revision_id,
+        btrim(jsonb_path_query(r.content, '$."authoring"."parts"[*]."gradingApproach"'::jsonpath)::text, '"'::text) AS grading_approach
+      FROM published_resources pr
+        LEFT JOIN publications p ON p.id = pr.publication_id
+        LEFT JOIN revisions r ON r.id = pr.revision_id
+      WHERE r.resource_type_id = 3 AND p.published IS NOT NULL
+      ORDER BY r.id, (btrim(jsonb_path_query(r.content, '$."authoring"."parts"[*]."id"'::jsonpath)::text, '"'::text))
+    WITH DATA;
+    """
+
+    execute """
+    ALTER TABLE IF EXISTS public.part_mapping
+    OWNER TO #{user};
+    """
+
+    execute """
+    CREATE UNIQUE INDEX part_id_revision_id
+    ON public.part_mapping USING btree
+    (part_id COLLATE pg_catalog."default", revision_id)
+    TABLESPACE pg_default;
+    """
+
+    execute """
+    CREATE INDEX revision_id_index
+    ON public.part_mapping USING btree
+    (revision_id)
+    TABLESPACE pg_default;
+    """
+  end
+
+
+  def get_current_db_user() do
+    case System.get_env("DATABASE_URL", nil) do
+      nil -> "postgres"
+      url -> parse_user_from_db_url(url, "postgres")
+    end
+  end
+
+  def parse_user_from_db_url(url, default) do
+    case url do
+      "ecto://" <> rest ->
+        split = String.split(rest, ":")
+
+        case Enum.count(split) do
+          0 -> default
+          1 -> default
+          _ -> Enum.at(split, 0)
+        end
+
+      _ ->
+        default
+    end
+  end
+
+  def drop_trigger() do
+    execute """
+    DROP TRIGGER IF EXISTS published_resources_tr ON public.published_resources;
+    """
+
+    execute "DROP FUNCTION IF EXISTS public.refresh_part_mapping() CASCADE;"
+  end
+
+  def create_trigger(user) do
+    execute """
+    CREATE OR REPLACE FUNCTION public.refresh_part_mapping()
+        RETURNS trigger
+        LANGUAGE 'plpgsql'
+        COST 100
+        VOLATILE NOT LEAKPROOF
+    AS $BODY$
+    BEGIN
+        REFRESH MATERIALIZED VIEW CONCURRENTLY part_mapping;
+        RETURN NULL;
+    END;
+    $BODY$;
+    """
+
+    execute """
+    ALTER FUNCTION public.refresh_part_mapping()
+    OWNER TO #{user};
+    """
+
+    execute """
+    CREATE TRIGGER publications_tr
+        AFTER UPDATE OR DELETE
+        ON public.publications
+        FOR EACH STATEMENT
+        EXECUTE FUNCTION public.refresh_part_mapping();
+    """
+  end
+
+  def refresh_materialized_view() do
+    execute """
+    REFRESH MATERIALIZED VIEW part_mapping;
+    """
+  end
+end


### PR DESCRIPTION
Adds a new migration to address problems from the previous one, when it is used in an existing database it is having problems resolving the "reused" functions from the `alias Oli.Repo.Migrations.OptimizationInfra` migration.

I simply duplicate the needed code from this earlier migration.  

Errors reported look like:
```
[2022-03-17 16:05:56.712] [d-CL7B34SIG][stderr]warning: Oli.Repo.Migrations.OptimizationInfra.create_trigger/1 is undefined (module Oli.Repo.Migrations.OptimizationInfra is not available or is yet to be defined)
[2022-03-17 16:05:56.712] [d-CL7B34SIG][stderr]  oli/lib/oli-0.18.4/priv/repo/migrations/20220308142458_attempt_states.exs:47: Oli.Repo.Migrations.AttemptStates.change/0
[2022-03-17 16:05:56.712] [d-CL7B34SIG][stderr]
[2022-03-17 16:05:56.712] [d-CL7B34SIG][stderr]warning: Oli.Repo.Migrations.OptimizationInfra.drop_trigger/0 is undefined (module Oli.Repo.Migrations.OptimizationInfra is not available or is yet to be defined)
[2022-03-17 16:05:56.712] [d-CL7B34SIG][stderr]  oli/lib/oli-0.18.4/priv/repo/migrations/20220308142458_attempt_states.exs:42: Oli.Repo.Migrations.AttemptStates.change/0
[2022-03-17 16:05:56.712] [d-CL7B34SIG][stderr]
[2022-03-17 16:05:56.712] [d-CL7B34SIG][stderr]warning: Oli.Repo.Migrations.OptimizationInfra.get_current_db_user/0 is undefined (module Oli.Repo.Migrations.OptimizationInfra is not available or is yet to be defined)
[2022-03-17 16:05:56.712] [d-CL7B34SIG][stderr]  oli/lib/oli-0.18.4/priv/repo/migrations/20220308142458_attempt_states.exs:45: Oli.Repo.Migrations.AttemptStates.change/0
[2022-03-17 16:05:56.712] [d-CL7B34SIG][stderr]
[2022-03-17 16:05:56.713] [d-CL7B34SIG][stderr]warning: Oli.Repo.Migrations.OptimizationInfra.refresh_materialized_view/0 is undefined (module Oli.Repo.Migrations.OptimizationInfra is not available or is yet to be defined)
[2022-03-17 16:05:56.713] [d-CL7B34SIG][stderr]  oli/lib/oli-0.18.4/priv/repo/migrations/20220308142458_attempt_states.exs:48: Oli.Repo.Migrations.AttemptStates.change/0
[2022-03-17 16:05:56.713] [d-CL7B34SIG][stderr]
[2022-03-17 16:05:56.734] [d-CL7B34SIG][stdout]16:05:56.731 [info] == Running 20220308142458 Oli.Repo.Migrations.AttemptStates.change/0 forward
[2022-03-17 16:05:56.734] [d-CL7B34SIG][stdout]16:05:56.734 [info] alter table part_attempts
[2022-03-17 16:05:56.737] [d-CL7B34SIG][stdout]16:05:56.737 [info] alter table activity_attempts
[2022-03-17 16:05:56.740] [d-CL7B34SIG][stdout]16:05:56.739 [info] alter table resource_attempts
[2022-03-17 16:05:56.751] [d-CL7B34SIG][stderr]** (UndefinedFunctionError) function Oli.Repo.Migrations.OptimizationInfra.drop_trigger/0 is undefined (module Oli.Repo.Migrations.OptimizationInfra is not available)
[2022-03-17 16:05:56.751] [d-CL7B34SIG][stderr]    Oli.Repo.Migrations.OptimizationInfra.drop_trigger()
[2022-03-17 16:05:56.752] [d-CL7B34SIG][stderr]    oli/lib/oli-0.18.4/priv/repo/migrations/20220308142458_attempt_states.exs:42: Oli.Repo.Migrations.AttemptStates.change/0
[2022-03-17 16:05:56.752] [d-CL7B34SIG][stderr]    (ecto_sql 3.7.1) lib/ecto/migration/runner.ex:279: Ecto.Migration.Runner.perform_operation/3
[2022-03-17 16:05:56.752] [d-CL7B34SIG][stderr]    (stdlib 3.15) timer.erl:166: :timer.tc/1
[2022-03-17 16:05:56.752] [d-CL7B34SIG][stderr]    (ecto_sql 3.7.1) lib/ecto/migration/runner.ex:25: Ecto.Migration.Runner.run/8
[2022-03-17 16:05:56.752] [d-CL7B34SIG][stderr]    (ecto_sql 3.7.1) lib/ecto/migrator.ex:348: Ecto.Migrator.attempt/8
[2022-03-17 16:05:56.752] [d-CL7B34SIG][stderr]    (ecto_sql 3.7.1) lib/ecto/migrator.ex:263: anonymous fn/5 in Ecto.Migrator.do_up/5
[2022-03-17 16:05:56.752] [d-CL7B34SIG][stderr]    (ecto_sql 3.7.1) lib/ecto/migrator.ex:319: anonymous fn/6 in Ecto.Migrator.async_migrate_maybe_in_transaction/7
```
