### PR TITLE
[BUG FIX] Remix renumbering

### DIFF
--- a/lib/oli/delivery/hierarchy/hierarchy_node.ex
+++ b/lib/oli/delivery/hierarchy/hierarchy_node.ex
@@ -20,5 +20,6 @@ defmodule Oli.Delivery.Hierarchy.HierarchyNode do
             project_id: nil,
             revision: nil,
             section_resource: nil,
-            ancestors: []
+            ancestors: [],
+            finalized: true
 end

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -933,10 +933,15 @@ defmodule Oli.Delivery.Sections do
       hierarchy = Hierarchy.purge_duplicate_resources(hierarchy)
 
       # ensure hierarchy numberings are all up to date
-      {hierarchy, _numberings} = Numbering.renumber_hierarchy(hierarchy)
+      {hierarchy, numberings} = Numbering.renumber_hierarchy(hierarchy)
+
+      Hierarchy.inspect(hierarchy)
+      IO.inspect(numberings)
 
       # generate a new set of section resources based on the hierarchy
       {section_resources, _} = collapse_section_hierarchy(hierarchy, section_id)
+
+      IO.inspect(section_resources)
 
       # upsert all hierarchical section resources. some of these records will have
       # just been created, but that's okay we will just update them again
@@ -949,6 +954,8 @@ defmodule Oli.Delivery.Sections do
           SectionResource.to_map(section_resource)
           | inserted_at: {:placeholder, :timestamp},
             updated_at: {:placeholder, :timestamp}
+            # numbering_index: section_resource.numbering.index,
+            # numbering_level: section_resource.numbering.level
         }
       end)
       |> then(

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -920,116 +920,113 @@ defmodule Oli.Delivery.Sections do
         %HierarchyNode{} = hierarchy,
         project_publications
       ) do
-    Repo.transaction(fn ->
-      previous_section_resource_ids =
+    if Hierarchy.finalized?(hierarchy) do
+      Repo.transaction(fn ->
+        previous_section_resource_ids =
+          from(sr in SectionResource,
+            where: sr.section_id == ^section_id,
+            select: sr.id
+          )
+          |> Repo.all()
+
+        # ensure there are no duplicate resources so as to not violate the
+        # section_resource [section_id, resource_id] database constraint
+        hierarchy = Hierarchy.purge_duplicate_resources(hierarchy)
+          |> Hierarchy.finalize()
+
+        # generate a new set of section resources based on the hierarchy
+        {section_resources, _} = collapse_section_hierarchy(hierarchy, section_id)
+
+        # upsert all hierarchical section resources. some of these records will have
+        # just been created, but that's okay we will just update them again
+        now = DateTime.utc_now() |> DateTime.truncate(:second)
+        placeholders = %{timestamp: now}
+
+        section_resources
+        |> Enum.map(fn section_resource ->
+          %{
+            SectionResource.to_map(section_resource)
+            | inserted_at: {:placeholder, :timestamp},
+              updated_at: {:placeholder, :timestamp}
+              # numbering_index: section_resource.numbering.index,
+              # numbering_level: section_resource.numbering.level
+          }
+        end)
+        |> then(
+          &Repo.insert_all(SectionResource, &1,
+            placeholders: placeholders,
+            on_conflict: {:replace_all_except, [:inserted_at]},
+            conflict_target: [:section_id, :resource_id]
+          )
+        )
+
+        # cleanup any deleted or non-hierarchical section resources
+        processed_section_resources_by_id =
+          section_resources
+          |> Enum.reduce(%{}, fn sr, acc -> Map.put_new(acc, sr.id, sr) end)
+
+        section_resource_ids_to_delete =
+          previous_section_resource_ids
+          |> Enum.filter(fn sr_id -> !Map.has_key?(processed_section_resources_by_id, sr_id) end)
+
         from(sr in SectionResource,
-          where: sr.section_id == ^section_id,
-          select: sr.id
+          where: sr.id in ^section_resource_ids_to_delete
         )
-        |> Repo.all()
+        |> Repo.delete_all()
 
-      # ensure there are no duplicate resources so as to not violate the
-      # section_resource [section_id, resource_id] database constraint
-      hierarchy = Hierarchy.purge_duplicate_resources(hierarchy)
-
-      # ensure hierarchy numberings are all up to date
-      {hierarchy, numberings} = Numbering.renumber_hierarchy(hierarchy)
-
-      Hierarchy.inspect(hierarchy)
-      IO.inspect(numberings)
-
-      # generate a new set of section resources based on the hierarchy
-      {section_resources, _} = collapse_section_hierarchy(hierarchy, section_id)
-
-      IO.inspect(section_resources)
-
-      # upsert all hierarchical section resources. some of these records will have
-      # just been created, but that's okay we will just update them again
-      now = DateTime.utc_now() |> DateTime.truncate(:second)
-      placeholders = %{timestamp: now}
-
-      section_resources
-      |> Enum.map(fn section_resource ->
-        %{
-          SectionResource.to_map(section_resource)
-          | inserted_at: {:placeholder, :timestamp},
+        # upsert section project publications ensure section project publication mappings are up to date
+        project_publications
+        |> Enum.map(fn {project_id, pub} ->
+          %{
+            section_id: section_id,
+            project_id: project_id,
+            publication_id: pub.id,
+            inserted_at: {:placeholder, :timestamp},
             updated_at: {:placeholder, :timestamp}
-            # numbering_index: section_resource.numbering.index,
-            # numbering_level: section_resource.numbering.level
-        }
-      end)
-      |> then(
-        &Repo.insert_all(SectionResource, &1,
-          placeholders: placeholders,
-          on_conflict: {:replace_all_except, [:inserted_at]},
-          conflict_target: [:section_id, :resource_id]
-        )
-      )
-
-      # cleanup any deleted or non-hierarchical section resources
-      processed_section_resources_by_id =
-        section_resources
-        |> Enum.reduce(%{}, fn sr, acc -> Map.put_new(acc, sr.id, sr) end)
-
-      section_resource_ids_to_delete =
-        previous_section_resource_ids
-        |> Enum.filter(fn sr_id -> !Map.has_key?(processed_section_resources_by_id, sr_id) end)
-
-      from(sr in SectionResource,
-        where: sr.id in ^section_resource_ids_to_delete
-      )
-      |> Repo.delete_all()
-
-      # upsert section project publications ensure section project publication mappings are up to date
-      project_publications
-      |> Enum.map(fn {project_id, pub} ->
-        %{
-          section_id: section_id,
-          project_id: project_id,
-          publication_id: pub.id,
-          inserted_at: {:placeholder, :timestamp},
-          updated_at: {:placeholder, :timestamp}
-        }
-      end)
-      |> then(
-        &Repo.insert_all(SectionsProjectsPublications, &1,
-          placeholders: placeholders,
-          on_conflict: {:replace_all_except, [:inserted_at]},
-          conflict_target: [:section_id, :project_id]
-        )
-      )
-
-      # cleanup any unused project publication mappings
-      section_project_ids =
-        section_resources
-        |> Enum.reduce(%{}, fn sr, acc ->
-          Map.put_new(acc, sr.project_id, true)
+          }
         end)
-        |> Enum.map(fn {project_id, _} -> project_id end)
+        |> then(
+          &Repo.insert_all(SectionsProjectsPublications, &1,
+            placeholders: placeholders,
+            on_conflict: {:replace_all_except, [:inserted_at]},
+            conflict_target: [:section_id, :project_id]
+          )
+        )
 
-      from(spp in SectionsProjectsPublications,
-        where: spp.section_id == ^section_id and spp.project_id not in ^section_project_ids
-      )
-      |> Repo.delete_all()
+        # cleanup any unused project publication mappings
+        section_project_ids =
+          section_resources
+          |> Enum.reduce(%{}, fn sr, acc ->
+            Map.put_new(acc, sr.project_id, true)
+          end)
+          |> Enum.map(fn {project_id, _} -> project_id end)
 
-      # finally, create all non-hierarchical section resources for all projects used in the section
-      publication_ids =
-        section_project_ids
-        |> Enum.map(fn project_id ->
-          project_publications[project_id]
-          |> then(fn %{id: publication_id} -> publication_id end)
-        end)
+        from(spp in SectionsProjectsPublications,
+          where: spp.section_id == ^section_id and spp.project_id not in ^section_project_ids
+        )
+        |> Repo.delete_all()
 
-      processed_resource_ids =
-        processed_section_resources_by_id
-        |> Enum.map(fn {_id, %{resource_id: resource_id}} -> resource_id end)
+        # finally, create all non-hierarchical section resources for all projects used in the section
+        publication_ids =
+          section_project_ids
+          |> Enum.map(fn project_id ->
+            project_publications[project_id]
+            |> then(fn %{id: publication_id} -> publication_id end)
+          end)
 
-      create_nonstructural_section_resources(section_id, publication_ids,
-        skip_resource_ids: processed_resource_ids
-      )
+        processed_resource_ids =
+          processed_section_resources_by_id
+          |> Enum.map(fn {_id, %{resource_id: resource_id}} -> resource_id end)
 
-      section_resources
-    end)
+        create_nonstructural_section_resources(section_id, publication_ids,
+          skip_resource_ids: processed_resource_ids
+        )
+
+        section_resources
+      end)
+    else
+      throw "Cannot rebuild section curriculum with a hierarchy that has unfinalized changes. See Oli.Delivery.Hierarchy.finalize/1 for details."
+    end
   end
 
   @doc """
@@ -1098,6 +1095,8 @@ defmodule Oli.Delivery.Sections do
                   )
                 end
               )
+
+            updated_hierarchy = Hierarchy.finalize(updated_hierarchy)
 
             # rebuild the section curriculum based on the updated hierarchy
             project_publications = get_pinned_project_publications(section_id)
@@ -1296,6 +1295,7 @@ defmodule Oli.Delivery.Sections do
   # updated collapsed list of section resources
   defp collapse_section_hierarchy(
          %HierarchyNode{
+           finalized: true,
            numbering: numbering,
            children: children,
            resource_id: resource_id,
@@ -1337,7 +1337,13 @@ defmodule Oli.Delivery.Sections do
           )
 
         %SectionResource{} ->
-          %SectionResource{section_resource | children: Enum.reverse(children_sr_ids)}
+          # section resource record already exists, so we reuse it and update the fields which may have changed
+          %SectionResource{
+            section_resource
+            | children: Enum.reverse(children_sr_ids),
+              numbering_index: numbering.index,
+              numbering_level: numbering.level
+          }
       end
 
     {[section_resource | section_resources], section_resource}

--- a/lib/oli_web/live/delivery/remix_section.ex
+++ b/lib/oli_web/live/delivery/remix_section.ex
@@ -18,9 +18,7 @@ defmodule OliWeb.Delivery.RemixSection do
   }
 
   alias Oli.Publishing.DeliveryResolver
-  alias Oli.Resources.Numbering
   alias Oli.Delivery.Hierarchy
-  alias Oli.Delivery.Hierarchy.HierarchyNode
   alias OliWeb.Common.Breadcrumb
   alias OliWeb.Delivery.Remix.{RemoveModal, AddMaterialsModal}
   alias OliWeb.Common.Hierarchy.MoveModal
@@ -282,18 +280,16 @@ defmodule OliWeb.Delivery.RemixSection do
 
     node = Enum.at(active.children, source_index)
 
-    children =
+    updated =
       Hierarchy.reorder_children(
-        active.children,
+        active,
         node,
         source_index,
         destination_index
       )
 
-    updated = %HierarchyNode{active | children: children}
     hierarchy = Hierarchy.find_and_update_node(hierarchy, updated)
-
-    {hierarchy, _numberings} = Numbering.renumber_hierarchy(hierarchy)
+      |> Hierarchy.finalize()
 
     {:noreply, assign(socket, hierarchy: hierarchy, active: updated, has_unsaved_changes: true)}
   end
@@ -410,6 +406,7 @@ defmodule OliWeb.Delivery.RemixSection do
         selection,
         published_resources_by_resource_id_by_pub
       )
+      |> Hierarchy.finalize()
 
     # update pinned project publications
     pinned_project_publications =
@@ -528,6 +525,7 @@ defmodule OliWeb.Delivery.RemixSection do
 
     node = Hierarchy.find_in_hierarchy(hierarchy, uuid)
     hierarchy = Hierarchy.move_node(hierarchy, node, to_uuid)
+        |> Hierarchy.finalize()
 
     # refresh active node
     active = Hierarchy.find_in_hierarchy(hierarchy, active.uuid)
@@ -562,6 +560,7 @@ defmodule OliWeb.Delivery.RemixSection do
     %{hierarchy: hierarchy, active: active} = socket.assigns
 
     hierarchy = Hierarchy.find_and_remove_node(hierarchy, uuid)
+      |> Hierarchy.finalize()
 
     # refresh active node
     active = Hierarchy.find_in_hierarchy(hierarchy, active.uuid)

--- a/test/oli/delivery/hierarchy_test.exs
+++ b/test/oli/delivery/hierarchy_test.exs
@@ -123,6 +123,7 @@ defmodule Oli.Delivery.HierarchyTest do
       assert Hierarchy.find_in_hierarchy(hierarchy, nested_page_one_node.uuid) != nil
 
       hierarchy = Hierarchy.find_and_remove_node(hierarchy, nested_page_one_node.uuid)
+        |> Hierarchy.finalize()
 
       assert Hierarchy.find_in_hierarchy(hierarchy, nested_page_one_node.uuid) == nil
     end
@@ -131,9 +132,10 @@ defmodule Oli.Delivery.HierarchyTest do
       node = Hierarchy.find_in_hierarchy(hierarchy, nested_page_one_node.uuid)
 
       hierarchy = Hierarchy.move_node(hierarchy, node, hierarchy.uuid)
+        |> Hierarchy.finalize()
 
       assert Hierarchy.find_in_hierarchy(hierarchy, nested_page_one_node.uuid) != nil
-      assert node in hierarchy.children
+      assert Enum.find(hierarchy.children, fn c -> c.uuid == node.uuid end) != nil
     end
 
     test "add_materials_to_hierarchy/4", %{
@@ -163,6 +165,7 @@ defmodule Oli.Delivery.HierarchyTest do
           selection,
           published_resources_by_resource_id_by_pub
         )
+        |> Hierarchy.finalize()
 
       assert hierarchy.children |> Enum.count() == 3
       assert hierarchy.children |> Enum.at(2) |> Map.get(:children) |> Enum.count() == 4
@@ -193,6 +196,7 @@ defmodule Oli.Delivery.HierarchyTest do
       }
 
       hierarchy = Hierarchy.find_and_update_node(hierarchy, unit_node_with_duplicate_page_one)
+        |> Hierarchy.finalize()
 
       assert hierarchy.children
              |> Enum.at(2)
@@ -212,6 +216,7 @@ defmodule Oli.Delivery.HierarchyTest do
              |> Map.get(:resource_id) == nested_page1.id
 
       hierarchy = Hierarchy.purge_duplicate_resources(hierarchy)
+        |> Hierarchy.finalize()
 
       assert hierarchy.children
              |> Enum.at(2)

--- a/test/oli/resources/numbering_test.exs
+++ b/test/oli/resources/numbering_test.exs
@@ -6,6 +6,8 @@ defmodule Oli.Resources.NumberingTest do
   alias Oli.Delivery.Sections
   alias Oli.Publishing
   alias Oli.Publishing.DeliveryResolver
+  alias Oli.Delivery.Hierarchy
+  alias Oli.Delivery.Hierarchy.HierarchyNode
 
   describe "container numbering" do
     setup do
@@ -107,6 +109,27 @@ defmodule Oli.Resources.NumberingTest do
       path_titles = Enum.map(path_nodes, fn n -> n.revision.title end)
 
       assert path_titles == ["Root Container", "Unit 1", "Module 2", "Section 1", "Page 2"]
+    end
+
+    test "renumber_hierarchy/1", %{project: project, institution: institution} do
+      # Publish the current state of our test project
+      {:ok, pub1} = Publishing.publish_project(project, "some changes")
+
+      {:ok, section} =
+        Sections.create_section(%{
+          title: "1",
+          timezone: "1",
+          registration_open: true,
+          context_id: UUID.uuid4(),
+          institution_id: institution.id,
+          base_project_id: project.id
+        })
+        |> then(fn {:ok, section} -> section end)
+        |> Sections.create_section_resources(pub1)
+
+      hierarchy = DeliveryResolver.full_hierarchy(section.slug)
+
+      Hierarchy.inspect hierarchy
     end
   end
 end

--- a/test/oli/resources/numbering_test.exs
+++ b/test/oli/resources/numbering_test.exs
@@ -7,7 +7,6 @@ defmodule Oli.Resources.NumberingTest do
   alias Oli.Publishing
   alias Oli.Publishing.DeliveryResolver
   alias Oli.Delivery.Hierarchy
-  alias Oli.Delivery.Hierarchy.HierarchyNode
 
   describe "container numbering" do
     setup do
@@ -129,7 +128,47 @@ defmodule Oli.Resources.NumberingTest do
 
       hierarchy = DeliveryResolver.full_hierarchy(section.slug)
 
-      Hierarchy.inspect hierarchy
+      page_1_node = hierarchy.children |> Enum.at(0) |> Map.get(:children) |> Enum.at(0)
+      section_2_node = hierarchy.children |> Enum.at(0) |> Map.get(:children) |> Enum.at(1) |> Map.get(:children) |> Enum.at(1)
+
+      hierarchy = Hierarchy.move_node(hierarchy, page_1_node, section_2_node.uuid)
+
+      module_2_node = hierarchy.children |> Enum.at(0) |> Map.get(:children) |> Enum.at(0)
+      unit_2_node = hierarchy.children |> Enum.at(1)
+
+      hierarchy = Hierarchy.move_node(hierarchy, module_2_node, unit_2_node.uuid)
+        |> Hierarchy.finalize()
+
+      assert hierarchy.numbering.level == 0
+      assert hierarchy.numbering.index == 1
+
+      assert (hierarchy.children |> Enum.at(0)).numbering.level == 1
+      assert (hierarchy.children |> Enum.at(0)).numbering.index == 1
+
+      assert (hierarchy.children |> Enum.at(0) |> Map.get(:children) |> Enum.at(0)).numbering.level == 2
+      assert (hierarchy.children |> Enum.at(0) |> Map.get(:children) |> Enum.at(0)).numbering.index == 1
+
+      assert (hierarchy.children |> Enum.at(0) |> Map.get(:children) |> Enum.at(0) |> Map.get(:children) |> Enum.at(0)).numbering.level == 3
+      assert (hierarchy.children |> Enum.at(0) |> Map.get(:children) |> Enum.at(0) |> Map.get(:children) |> Enum.at(0)).numbering.index == 1
+      assert (hierarchy.children |> Enum.at(0) |> Map.get(:children) |> Enum.at(0) |> Map.get(:children) |> Enum.at(1)).numbering.level == 3
+      assert (hierarchy.children |> Enum.at(0) |> Map.get(:children) |> Enum.at(0) |> Map.get(:children) |> Enum.at(1)).numbering.index == 2
+      assert (hierarchy.children |> Enum.at(0) |> Map.get(:children) |> Enum.at(0) |> Map.get(:children) |> Enum.at(2)).numbering.level == 3
+      assert (hierarchy.children |> Enum.at(0) |> Map.get(:children) |> Enum.at(0) |> Map.get(:children) |> Enum.at(2)).numbering.index == 3
+
+      assert (hierarchy.children |> Enum.at(1)).numbering.level == 1
+      assert (hierarchy.children |> Enum.at(1)).numbering.index == 2
+
+      assert (hierarchy.children |> Enum.at(1) |> Map.get(:children) |> Enum.at(0) |> Map.get(:children) |> Enum.at(0)).numbering.level == 3
+      assert (hierarchy.children |> Enum.at(1) |> Map.get(:children) |> Enum.at(0) |> Map.get(:children) |> Enum.at(0)).numbering.index == 4
+
+      assert (hierarchy.children |> Enum.at(1) |> Map.get(:children) |> Enum.at(0) |> Map.get(:children) |> Enum.at(0) |> Map.get(:children) |> Enum.at(0)).numbering.level == 4
+      assert (hierarchy.children |> Enum.at(1) |> Map.get(:children) |> Enum.at(0) |> Map.get(:children) |> Enum.at(0) |> Map.get(:children) |> Enum.at(0)).numbering.index == 1
+
+      assert (hierarchy.children |> Enum.at(1) |> Map.get(:children) |> Enum.at(0) |> Map.get(:children) |> Enum.at(1)).numbering.level == 3
+      assert (hierarchy.children |> Enum.at(1) |> Map.get(:children) |> Enum.at(0) |> Map.get(:children) |> Enum.at(1)).numbering.index == 5
+      assert (hierarchy.children |> Enum.at(1) |> Map.get(:children) |> Enum.at(0) |> Map.get(:children) |> Enum.at(2)).numbering.level == 3
+      assert (hierarchy.children |> Enum.at(1) |> Map.get(:children) |> Enum.at(0) |> Map.get(:children) |> Enum.at(2)).numbering.index == 6
+
     end
   end
 end


### PR DESCRIPTION
This PR fixes an issue where remixing content results in incorrect numberings. It also adds a safety net to all hierarchy operations by requiring a finalization step before rebuilding section curriculum, which ensures that the hierarchy numbering is up to date after any modifications.

Closes #2298