### PR TITLE
[FEATURE] Allow history navigation via resource_id

### DIFF
--- a/lib/oli_web/live/history/details.ex
+++ b/lib/oli_web/live/history/details.ex
@@ -38,9 +38,10 @@ defmodule OliWeb.RevisionHistory.Details do
               <td style="width:200px;"><strong>Objectives</strong></td>
               <td>
                 {#case Map.get(@revision.objectives, "attached")}
+                  {#match nil}
+                      <em>None</em>
                   {#match []}
-                    <em>None</em>
-
+                      <em>None</em>
                   {#match objectives}
                     <ul>
                       {#for objective <- objectives}

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -902,7 +902,8 @@ defmodule OliWeb.Router do
       :admin
     ])
 
-    live("/:project_id/history/:slug", RevisionHistory)
+    live("/:project_id/history/slug/:slug", RevisionHistory)
+    live("/:project_id/history/resource_id/:resource_id", RevisionHistory, as: :history_by_resource_id)
   end
 
   # Support for cognito JWT auth currently used by Infiniscope


### PR DESCRIPTION
Introduces support in the Revision History tool to load the history of a resource by its "resource id".  This is very useful in that when looking at the history of a page you often want to dig into the history of a reference activity, but all you have is the activity's resource id. 

