### PR TITLE
[FEATURE] Manual grading UI

### DIFF
--- a/assets/src/components/activities/common/authoring/GradingApproachDropdown.tsx
+++ b/assets/src/components/activities/common/authoring/GradingApproachDropdown.tsx
@@ -29,7 +29,7 @@ export const GradingApproachDropdown = <K extends string>({
       <span>Grading Approach:</span>
       <select
         style={{ width: 250 }}
-        disabled={!editMode || true} // Remove ' || true` to enable for testing
+        disabled={!editMode}
         className="form-control ml-1"
         value={selected}
         onChange={handleChange}

--- a/assets/src/components/activities/types.ts
+++ b/assets/src/components/activities/types.ts
@@ -5,6 +5,7 @@ import { ResourceId } from 'data/types';
 import guid from 'utils/guid';
 import { PathOperation } from 'utils/pathOperations';
 import { Model } from 'data/content/model/elements/factories';
+import { NIL } from 'uuid';
 
 export type PostUndoable = (undoable: Undoable) => void;
 
@@ -238,6 +239,7 @@ export interface Part extends Identifiable {
   hints: Hint[];
   scoringStrategy: ScoringStrategy;
   gradingApproach?: GradingApproach;
+  outOf?: null | number;
 }
 
 export const makePart = (
@@ -249,6 +251,7 @@ export const makePart = (
 ): Part => ({
   id: id ? id : guid(),
   gradingApproach: GradingApproach.automatic,
+  outOf: null,
   scoringStrategy: ScoringStrategy.average,
   responses,
   hints,

--- a/assets/src/hooks/before_unload.ts
+++ b/assets/src/hooks/before_unload.ts
@@ -1,0 +1,13 @@
+const listener = (e: any) => {
+  e.preventDefault();
+  e.returnValue = '';
+};
+
+export const BeforeUnloadListener = {
+  mounted() {
+    window.addEventListener('beforeunload', listener);
+  },
+  destroyed() {
+    window.removeEventListener('beforeunload', listener);
+  },
+};

--- a/assets/src/hooks/index.ts
+++ b/assets/src/hooks/index.ts
@@ -11,6 +11,7 @@ import { CopyListener } from './copy_listener';
 import { SystemMessage } from './system_message';
 import { MonacoEditor } from './monaco_editor';
 import { TooltipInit } from './tooltip';
+import { BeforeUnloadListener } from './before_unload';
 
 export const Hooks = {
   GraphNavigation,
@@ -27,4 +28,5 @@ export const Hooks = {
   SystemMessage,
   MonacoEditor,
   TooltipInit,
+  BeforeUnloadListener
 };

--- a/assets/src/hooks/index.ts
+++ b/assets/src/hooks/index.ts
@@ -28,5 +28,5 @@ export const Hooks = {
   SystemMessage,
   MonacoEditor,
   TooltipInit,
-  BeforeUnloadListener
+  BeforeUnloadListener,
 };

--- a/assets/src/hooks/index.ts
+++ b/assets/src/hooks/index.ts
@@ -10,6 +10,7 @@ import { DateTimeLocalInputListener } from './datetimelocal_input_listener';
 import { CopyListener } from './copy_listener';
 import { SystemMessage } from './system_message';
 import { MonacoEditor } from './monaco_editor';
+import { TooltipInit } from './tooltip';
 
 export const Hooks = {
   GraphNavigation,
@@ -25,4 +26,5 @@ export const Hooks = {
   CopyListener,
   SystemMessage,
   MonacoEditor,
+  TooltipInit,
 };

--- a/assets/src/hooks/tooltip.ts
+++ b/assets/src/hooks/tooltip.ts
@@ -1,5 +1,12 @@
 export const TooltipInit = {
   mounted() {
-    ($(this.el) as any).tooltip();
+    console.log('tooltip init')
+    const id = this.el.getAttribute('id');
+    ($('#' + id) as any).tooltip();
+  },
+  updated() {
+    console.log('tooltip init')
+    const id = this.el.getAttribute('id');
+    ($('#' + id) as any).tooltip();
   }
 };

--- a/assets/src/hooks/tooltip.ts
+++ b/assets/src/hooks/tooltip.ts
@@ -1,8 +1,5 @@
 export const TooltipInit = {
   mounted() {
     ($(this.el) as any).tooltip();
-  },
-  updated() {
-    ($(this.el) as any).tooltip();
-  },
+  }
 };

--- a/assets/src/hooks/tooltip.ts
+++ b/assets/src/hooks/tooltip.ts
@@ -1,12 +1,10 @@
 export const TooltipInit = {
   mounted() {
-    console.log('tooltip init')
     const id = this.el.getAttribute('id');
     ($('#' + id) as any).tooltip();
   },
   updated() {
-    console.log('tooltip init')
     const id = this.el.getAttribute('id');
     ($('#' + id) as any).tooltip();
-  }
+  },
 };

--- a/assets/src/hooks/tooltip.ts
+++ b/assets/src/hooks/tooltip.ts
@@ -1,0 +1,8 @@
+export const TooltipInit = {
+  mounted() {
+    ($(this.el) as any).tooltip();
+  },
+  updated() {
+    ($(this.el) as any).tooltip();
+  },
+};

--- a/lib/oli/activities/model/part.ex
+++ b/lib/oli/activities/model/part.ex
@@ -1,5 +1,5 @@
 defmodule Oli.Activities.Model.Part do
-  defstruct [:id, :scoring_strategy, :responses, :hints, :parts, :grading_approach]
+  defstruct [:id, :scoring_strategy, :responses, :hints, :parts, :grading_approach, :out_of]
 
   def parse(%{"id" => id} = part) do
     scoring_strategy =
@@ -13,6 +13,8 @@ defmodule Oli.Activities.Model.Part do
       Map.get(part, "gradingApproach", "automatic")
       |> String.to_existing_atom()
 
+    out_of = Map.get(part, "outOf")
+
     with {:ok, responses} <- Oli.Activities.Model.Response.parse(responses),
          {:ok, hints} <- Oli.Activities.Model.Hint.parse(hints),
          {:ok, parts} <- Oli.Activities.Model.Part.parse(parts) do
@@ -23,7 +25,8 @@ defmodule Oli.Activities.Model.Part do
          parts: parts,
          id: id,
          scoring_strategy: scoring_strategy,
-         grading_approach: grading_approach
+         grading_approach: grading_approach,
+         out_of: out_of
        }}
     else
       error -> error

--- a/lib/oli/delivery/attempts/activity_lifecycle.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle.ex
@@ -150,6 +150,7 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle do
                             attempt_guid: UUID.uuid4(),
                             attempt_number: 1,
                             part_id: p.part_id,
+                            grading_approach: p.grading_approach,
                             response: response,
                             activity_attempt_id: new_activity_attempt.id
                           }) do

--- a/lib/oli/delivery/attempts/core/activity_attempt.ex
+++ b/lib/oli/delivery/attempts/core/activity_attempt.ex
@@ -21,6 +21,8 @@ defmodule Oli.Delivery.Attempts.Core.ActivityAttempt do
     belongs_to(:resource_attempt, Oli.Delivery.Attempts.Core.ResourceAttempt)
     has_many(:part_attempts, Oli.Delivery.Attempts.Core.PartAttempt)
 
+    field :resource_access_id, :integer, virtual: true
+    field :resource_attempt_guid, :string, virtual: true
     field :activity_type_id, :integer, virtual: true
     field :activity_title, :string, virtual: true
     field :page_title, :string, virtual: true

--- a/lib/oli/delivery/attempts/core/activity_attempt.ex
+++ b/lib/oli/delivery/attempts/core/activity_attempt.ex
@@ -23,6 +23,8 @@ defmodule Oli.Delivery.Attempts.Core.ActivityAttempt do
 
     field :resource_access_id, :integer, virtual: true
     field :resource_attempt_guid, :string, virtual: true
+    field :resource_attempt_number, :integer, virtual: true
+    field :page_id, :integer, virtual: true
     field :activity_type_id, :integer, virtual: true
     field :activity_title, :string, virtual: true
     field :page_title, :string, virtual: true

--- a/lib/oli/delivery/attempts/manual_grading.ex
+++ b/lib/oli/delivery/attempts/manual_grading.ex
@@ -130,7 +130,8 @@ defmodule Oli.Delivery.Attempts.ManualGrading do
           activity_title: activity_revision.title,
           page_title: resource_revision.title,
           graded: resource_revision.graded,
-          user: user
+          user: user,
+          revision: activity_revision
         }
       )
 

--- a/lib/oli/delivery/attempts/manual_grading.ex
+++ b/lib/oli/delivery/attempts/manual_grading.ex
@@ -15,9 +15,19 @@ defmodule Oli.Delivery.Attempts.ManualGrading do
   alias Oli.Delivery.Attempts.Core.{
     ResourceAccess,
     ResourceAttempt,
-    ActivityAttempt,
-    PartAttempt
+    ActivityAttempt
   }
+
+  def count_submitted_attempts(%Section{} = section) do
+    case browse_submitted_attempts(
+      section,
+      %Paging{limit: 1, offset: 0},
+      %Sorting{field: :date_submitted, direction: :asc},
+      %BrowseOptions{user_id: nil, activity_id: nil, text_search: nil, page_id: nil, graded: nil}) do
+      [] -> 0
+      [item] -> item.total_count
+    end
+  end
 
   @doc """
   Browsing-based query support for activity attempts that require manual grading.

--- a/lib/oli/delivery/attempts/manual_grading.ex
+++ b/lib/oli/delivery/attempts/manual_grading.ex
@@ -79,13 +79,30 @@ defmodule Oli.Delivery.Attempts.ManualGrading do
         )
       end
 
+    filter_by_page =
+      if is_nil(options.page_id) do
+        true
+      else
+        dynamic(
+          [
+            _aa,
+            _resource_attempt,
+            resource_access,
+            _user,
+            _activity_revision,
+            _resource_revision
+          ],
+          resource_access.resource_id == ^options.page_id
+        )
+      end
+
     filter_by_text =
       if options.text_search == "" or is_nil(options.text_search) do
         true
       else
         dynamic(
           [_aa, _resource_attempt, _resource_access, user, activity_revision, resource_revision],
-          ilike(user.name, ^"%#{options.text_search}%") or
+            ilike(user.name, ^"%#{options.text_search}%") or
             ilike(user.email, ^"%#{options.text_search}%") or
             ilike(user.given_name, ^"%#{options.text_search}%") or
             ilike(user.family_name, ^"%#{options.text_search}%") or
@@ -93,8 +110,8 @@ defmodule Oli.Delivery.Attempts.ManualGrading do
             ilike(user.email, ^"#{options.text_search}") or
             ilike(user.given_name, ^"#{options.text_search}") or
             ilike(user.family_name, ^"#{options.text_search}") or
-            ilike(resource_revision.title, ^"#{options.text_search}") or
-            ilike(activity_revision.title, ^"#{options.text_search}")
+            ilike(resource_revision.title, ^"%#{options.text_search}%") or
+            ilike(activity_revision.title, ^"%#{options.text_search}%")
         )
       end
 
@@ -115,11 +132,12 @@ defmodule Oli.Delivery.Attempts.ManualGrading do
       )
       |> where(^filter_by_user)
       |> where(^filter_by_activity)
+      |> where(^filter_by_page)
       |> where(^filter_by_graded)
       |> where(^filter_by_text)
       |> where(
         [aa, _resource_attempt, resource_access, _u, _activity_revision, _resource_revision],
-        resource_access.section_id == ^section_id and aa.lifecycle_state == :submitted
+        (resource_access.section_id == ^section_id and aa.lifecycle_state == :submitted)
       )
       |> limit(^limit)
       |> offset(^offset)
@@ -131,6 +149,8 @@ defmodule Oli.Delivery.Attempts.ManualGrading do
           activity_type_id: activity_revision.activity_type_id,
           activity_title: activity_revision.title,
           page_title: resource_revision.title,
+          page_id: resource_revision.resource_id,
+          resource_attempt_number: resource_attempt.attempt_number,
           graded: resource_revision.graded,
           user: user,
           revision: activity_revision,
@@ -161,6 +181,12 @@ defmodule Oli.Delivery.Attempts.ManualGrading do
             [_aa, _resource_attempt, _resource_access, _u, _activity_revision, resource_revision],
             {^direction, resource_revision.title}
           )
+        :resource_attempt_number ->
+          order_by(
+            query,
+            [_aa, resource_attempt, _resource_access, _u, _activity_revision, _resource_revision],
+            {^direction, resource_attempt.attempt_number}
+          )
 
         :graded ->
           order_by(
@@ -177,40 +203,50 @@ defmodule Oli.Delivery.Attempts.ManualGrading do
           )
 
         _ ->
-          order_by(query, [_, u, _], {^direction, field(u, ^field)})
+          order_by(query, [aa, _, _, _, _, _], {^direction, field(aa, ^field)})
       end
-
     Repo.all(query)
   end
 
-  def evaluate(%Section{slug: section_slug}, activity_attempt, score_feedbacks_map) do
+  @doc """
+  Applies a collection of manual scores and feedbacks to the part attempts of a given activity attempt.
+
+  The activity attempt is assumed to be fully populated with virtual attributes delivered from the
+  `browse_submitted_attempts` query from this module.
+
+  The `score_feedbacks_map` is a map of part attempt guids to `ScoreFeedback` structs that contain the
+  instructor score, feedback, and the out_of value.
+
+  If this activity is the last activity remaining in a graded page, this will finalize that graded page attempt,
+  recalculate a resource access level score, and trigger LMS grade passback (if this is an LMS section and that
+  section has gradepassback enabled)
+  """
+  def apply_manual_scoring(%Section{slug: section_slug} = section, activity_attempt, score_feedbacks_map) do
 
     graded = activity_attempt.graded
     resource_attempt_guid = activity_attempt.resource_attempt_guid
 
     Oli.Repo.transaction(fn _ ->
-
-      with {:ok, {all_part_attempts, finalized_part_attempts}} <- finalize_part_attempts(activity_attempt, score_feedbacks_map),
-        {:ok, activity_attempt} <- Evaluate.rollup_part_attempt_evaluations(activity_attempt.attempt_guid, :normalize),
+      with {:ok, finalized_part_attempts} <- finalize_part_attempts(activity_attempt, score_feedbacks_map),
+        {:ok, _} <- Evaluate.rollup_part_attempt_evaluations(activity_attempt.attempt_guid, :normalize),
         {:ok, _} <- to_attempt_guid(finalized_part_attempts) |> Oli.Delivery.Snapshots.queue_or_create_snapshot(section_slug),
-        {:ok, _} <- maybe_finalize_resource_attempt(graded, resource_attempt_guid) do
+        {:ok, _} <- maybe_finalize_resource_attempt(section, graded, resource_attempt_guid) do
+          finalized_part_attempts
       else
         e -> Repo.rollback(e)
       end
-
     end)
   end
 
   defp finalize_part_attempts(activity_attempt, score_feedbacks_map) do
     part_attempts = Core.get_latest_part_attempts(activity_attempt.attempt_guid)
 
-
     Enum.filter(part_attempts, fn pa -> pa.grading_approach == :manual and pa.lifecycle_state == :submitted end)
-    |> Enum.reduce_while({part_attempts, []}, fn pa, {:ok, {all, updated}} ->
+    |> Enum.reduce_while({:ok, []}, fn pa, {:ok, updated} ->
       case Map.get(score_feedbacks_map, pa.attempt_guid) do
         %{score: score, out_of: out_of, feedback: feedback} ->
           case Core.update_part_attempt(pa, %{score: score, out_of: out_of, feedback: %{content: wrap_in_paragraphs(feedback)}}) do
-            {:ok, updated_part_attempt} -> {:cont, {:ok, {all, [updated_part_attempt | updated]}}}
+            {:ok, updated_part_attempt} -> {:cont, {:ok, [updated_part_attempt | updated]}}
             e -> {:halt, e}
           end
         _ -> {:halt, {:error, "scoring feedback not found for attempt #{pa.attempt_guid}"}}
@@ -219,10 +255,23 @@ defmodule Oli.Delivery.Attempts.ManualGrading do
 
   end
 
-  defp maybe_finalize_resource_attempt(false, resource_attempt_guid), do: {:ok, resource_attempt_guid}
+  defp maybe_finalize_resource_attempt(_, false, resource_attempt_guid), do: {:ok, resource_attempt_guid}
 
-  defp maybe_finalize_resource_attempt(true, resource_attempt_guid) do
+  defp maybe_finalize_resource_attempt(section, true, resource_attempt_guid) do
     Oli.Delivery.Attempts.PageLifecycle.Graded.roll_up_activities_to_resource_attempt(resource_attempt_guid)
+    |> maybe_initiate_grade_passback(section)
+  end
+
+  defp maybe_initiate_grade_passback({:ok, %ResourceAttempt{resource_access_id: resource_access_id}}, %Section{id: section_id, grade_passback_enabled: true}) do
+    Oli.Delivery.Attempts.PageLifecycle.GradeUpdateWorker.create(
+      section_id,
+      resource_access_id,
+      :inline
+    )
+  end
+
+  defp maybe_initiate_grade_passback(other, _) do
+    other
   end
 
   defp to_attempt_guid(part_attempts) do

--- a/lib/oli/delivery/attempts/manual_grading/browse_options.ex
+++ b/lib/oli/delivery/attempts/manual_grading/browse_options.ex
@@ -6,6 +6,7 @@ defmodule Oli.Delivery.Attempts.ManualGrading.BrowseOptions do
   @enforce_keys [
     :user_id,
     :activity_id,
+    :page_id,
     :graded,
     :text_search
   ]
@@ -13,6 +14,7 @@ defmodule Oli.Delivery.Attempts.ManualGrading.BrowseOptions do
   defstruct [
     :user_id,       # Filter attempts for a specific user id
     :activity_id,   # Filter attempts for a specific activity resource id
+    :page_id,       # Filter attempts for a specific page resource id
     :graded,        # Filter attempts for graded, ungraded attempts (nil shows all)
     :text_search    # Text search across user, page, and activity information
   ]
@@ -20,6 +22,7 @@ defmodule Oli.Delivery.Attempts.ManualGrading.BrowseOptions do
   @type t() :: %__MODULE__{
           user_id: integer(),
           activity_id: integer(),
+          page_id: integer(),
           graded: boolean(),
           text_search: String.t()
         }

--- a/lib/oli/delivery/page/activity_context.ex
+++ b/lib/oli/delivery/page/activity_context.ex
@@ -18,7 +18,7 @@ defmodule Oli.Delivery.Page.ActivityContext do
   resolved revisions.
   """
   @spec create_context_map(boolean(), %{}) :: %{}
-  def create_context_map(graded, latest_attempts) do
+  def create_context_map(graded, latest_attempts, opts \\ []) do
     # get a view of all current registered activity types
     registrations = Activities.list_activity_registrations()
     reg_map = Enum.reduce(registrations, %{}, fn r, m -> Map.put(m, r.id, r) end)
@@ -37,7 +37,7 @@ defmodule Oli.Delivery.Page.ActivityContext do
        %ActivitySummary{
          id: id,
          attempt_guid: state.attemptGuid,
-         model: prepare_model(model),
+         model: prepare_model(model, opts),
          state: prepare_state(state),
          delivery_element: type.delivery_element,
          authoring_element: type.authoring_element,

--- a/lib/oli_web/live/common/sortable_table/table.ex
+++ b/lib/oli_web/live/common/sortable_table/table.ex
@@ -5,6 +5,7 @@ defmodule OliWeb.Common.SortableTable.Table do
 
   prop model, :struct, required: true
   prop sort, :event, required: true
+  prop select, :event
   prop additional_table_class, :string, default: "table-sm"
 
   @spec id_field(any, %{:id_field => any, optional(any) => any}) :: any
@@ -48,14 +49,14 @@ defmodule OliWeb.Common.SortableTable.Table do
 
   defp render_row(assigns, row) do
     row_class =
-      if row == assigns.model.selected do
+      if id_field(row, assigns.model) == assigns.model.selected do
         "table-active"
       else
         ""
       end
 
     ~F"""
-    <tr id={id_field(row, @model)} class={row_class}>
+    <tr id={id_field(row, @model)} class={row_class} :on-click={@select} phx-value-id={id_field(row, @model)}>
     {#for column_spec <- @model.column_specs}
       <td>
       {#if is_nil(column_spec.render_fn)}

--- a/lib/oli_web/live/manual_grading/apply.ex
+++ b/lib/oli_web/live/manual_grading/apply.ex
@@ -1,0 +1,15 @@
+defmodule OliWeb.ManualGrading.Apply do
+  use Surface.Component
+
+  prop disabled, :boolean, required: true
+  prop apply, :event, required: true
+
+  def render(assigns) do
+    ~F"""
+    <div class="d-flex justify-content-center">
+      <button class="btn btn-primary" disabled={@disabled} :on-click={@apply}>Apply Score and Feedback</button>
+    </div>
+    """
+  end
+
+end

--- a/lib/oli_web/live/manual_grading/filter_button.ex
+++ b/lib/oli_web/live/manual_grading/filter_button.ex
@@ -1,21 +1,32 @@
 defmodule OliWeb.ManualGrading.FilterButton do
-  use Surface.LiveComponent
+  use Surface.Component
 
   prop clicked, :event, required: true
   prop label, :string, required: true
   prop active, :boolean, required: true
   prop tooltip, :string, required: true
+  prop selection, :boolean, required: true
   prop key, :any, required: true
 
   def render(%{active: true} = assigns) do
-    ~F"""
-    <button id={@id} phx-hook="TooltipInit" data-toggle="tooltip" data-placement="bottom" title={@tooltip} type="button" class="btn btn-info" :on-click={@clicked} phx-value-key={@key} phx-value-active={"false"}>{@label}</button>
-    """
+    do_render(assigns, "btn btn-info", "false")
   end
 
   def render(assigns) do
+    do_render(assigns, "btn btn-outline-secondary", "true")
+  end
+
+  def do_render(assigns, classes, active) do
     ~F"""
-    <button  id={@id} phx-hook="TooltipInit" data-toggle="tooltip" data-placement="bottom" title={@tooltip} type="button" class="btn btn-outline-secondary" :on-click={@clicked} phx-value-key={@key} phx-value-active={"true"}>{@label}</button>
+      <button
+        disabled={!@selection}
+        type="button"
+        data-toggle="tooltip"
+        title={@tooltip}
+        class={classes}
+        :on-click={@clicked} phx-value-key={@key} phx-value-active={active}>
+        {@label}
+      </button>
     """
   end
 end

--- a/lib/oli_web/live/manual_grading/filter_button.ex
+++ b/lib/oli_web/live/manual_grading/filter_button.ex
@@ -4,17 +4,18 @@ defmodule OliWeb.ManualGrading.FilterButton do
   prop clicked, :event, required: true
   prop label, :string, required: true
   prop active, :boolean, required: true
+  prop tooltip, :string, required: true
   prop key, :any, required: true
 
   def render(%{active: true} = assigns) do
     ~F"""
-    <button type="button" class="btn btn-info" :on-click={@clicked} phx-value-key={@key} phx-value-active={"false"}>{@label}</button>
+    <button phx-hook="TooltipInit" data-toggle="tooltip" data-placement="bottom" title={@tooltip} type="button" class="btn btn-info" :on-click={@clicked} phx-value-key={@key} phx-value-active={"false"}>{@label}</button>
     """
   end
 
   def render(assigns) do
     ~F"""
-    <button type="button" class="btn btn-outline-info" :on-click={@clicked} phx-value-key={@key} phx-value-active={"true"}>{@label}</button>
+    <button phx-hook="TooltipInit" data-toggle="tooltip" data-placement="bottom" title={@tooltip} type="button" class="btn btn-outline-secondary" :on-click={@clicked} phx-value-key={@key} phx-value-active={"true"}>{@label}</button>
     """
   end
 end

--- a/lib/oli_web/live/manual_grading/filter_button.ex
+++ b/lib/oli_web/live/manual_grading/filter_button.ex
@@ -1,5 +1,5 @@
 defmodule OliWeb.ManualGrading.FilterButton do
-  use Surface.Component
+  use Surface.LiveComponent
 
   prop clicked, :event, required: true
   prop label, :string, required: true
@@ -9,13 +9,13 @@ defmodule OliWeb.ManualGrading.FilterButton do
 
   def render(%{active: true} = assigns) do
     ~F"""
-    <button phx-hook="TooltipInit" data-toggle="tooltip" data-placement="bottom" title={@tooltip} type="button" class="btn btn-info" :on-click={@clicked} phx-value-key={@key} phx-value-active={"false"}>{@label}</button>
+    <button id={@id} phx-hook="TooltipInit" data-toggle="tooltip" data-placement="bottom" title={@tooltip} type="button" class="btn btn-info" :on-click={@clicked} phx-value-key={@key} phx-value-active={"false"}>{@label}</button>
     """
   end
 
   def render(assigns) do
     ~F"""
-    <button phx-hook="TooltipInit" data-toggle="tooltip" data-placement="bottom" title={@tooltip} type="button" class="btn btn-outline-secondary" :on-click={@clicked} phx-value-key={@key} phx-value-active={"true"}>{@label}</button>
+    <button  id={@id} phx-hook="TooltipInit" data-toggle="tooltip" data-placement="bottom" title={@tooltip} type="button" class="btn btn-outline-secondary" :on-click={@clicked} phx-value-key={@key} phx-value-active={"true"}>{@label}</button>
     """
   end
 end

--- a/lib/oli_web/live/manual_grading/filter_button.ex
+++ b/lib/oli_web/live/manual_grading/filter_button.ex
@@ -1,0 +1,20 @@
+defmodule OliWeb.ManualGrading.FilterButton do
+  use Surface.Component
+
+  prop clicked, :event, required: true
+  prop label, :string, required: true
+  prop active, :boolean, required: true
+  prop key, :any, required: true
+
+  def render(%{active: true} = assigns) do
+    ~F"""
+    <button type="button" class="btn btn-info" :on-click={@clicked} phx-value-key={@key} phx-value-active={"false"}>{@label}</button>
+    """
+  end
+
+  def render(assigns) do
+    ~F"""
+    <button type="button" class="btn btn-outline-info" :on-click={@clicked} phx-value-key={@key} phx-value-active={"true"}>{@label}</button>
+    """
+  end
+end

--- a/lib/oli_web/live/manual_grading/filters.ex
+++ b/lib/oli_web/live/manual_grading/filters.ex
@@ -3,13 +3,19 @@ defmodule OliWeb.ManualGrading.Filters do
   alias OliWeb.ManualGrading.FilterButton
 
   prop options, :struct, required: true
+  prop selection, :boolean, required: true
 
   def render(assigns) do
     ~F"""
     <div style="display: inline;">
-      <FilterButton id="user_filter" tooltip="Only show attempts from this same user" label="User" key={:user_id} active={is_active(assigns, :user_id)} clicked={"filters_changed"}/>
-      <FilterButton id="activity_filter" tooltip="Only show attempts for this same activity" label="Activity" key={:activity_id} active={is_active(assigns, :activity_id)} clicked={"filters_changed"}/>
-      <FilterButton id="purpose_filter" tooltip="Only show attempts of this same purpose" label="Purpose" key={:graded} active={is_active(assigns, :graded)} clicked={"filters_changed"}/>
+      <FilterButton selection={@selection} tooltip="Only show attempts from this same user"
+        label="User" key={:user_id} active={is_active(assigns, :user_id)} clicked={"filters_changed"}/>
+      <FilterButton selection={@selection} tooltip="Only show attempts for this same activity"
+        label="Activity" key={:activity_id} active={is_active(assigns, :activity_id)} clicked={"filters_changed"}/>
+      <FilterButton selection={@selection} tooltip="Only show attempts for this same page"
+        label="Page" key={:page_id} active={is_active(assigns, :page_id)} clicked={"filters_changed"}/>
+      <FilterButton selection={@selection} tooltip="Only show attempts of this same purpose"
+        label="Purpose" key={:graded} active={is_active(assigns, :graded)} clicked={"filters_changed"}/>
     </div>
     """
   end
@@ -30,6 +36,7 @@ defmodule OliWeb.ManualGrading.Filters do
     value = case key do
       "user_id" -> socket.assigns.attempt.user.id
       "activity_id" -> socket.assigns.attempt.resource_id
+      "page_id" -> socket.assigns.attempt.page_id
       "graded" -> socket.assigns.attempt.graded
     end
 

--- a/lib/oli_web/live/manual_grading/filters.ex
+++ b/lib/oli_web/live/manual_grading/filters.ex
@@ -7,9 +7,9 @@ defmodule OliWeb.ManualGrading.Filters do
   def render(assigns) do
     ~F"""
     <div style="display: inline;">
-      <FilterButton tooltip="Only show attempts from this same user" label="User" key={:user_id} active={is_active(assigns, :user_id)} clicked={"filters_changed"}/>
-      <FilterButton tooltip="Only show attempts for this same activity" label="Activity" key={:activity_id} active={is_active(assigns, :activity_id)} clicked={"filters_changed"}/>
-      <FilterButton tooltip="Only show attempts of this same purpose" label="Purpose" key={:graded} active={is_active(assigns, :graded)} clicked={"filters_changed"}/>
+      <FilterButton id="user_filter" tooltip="Only show attempts from this same user" label="User" key={:user_id} active={is_active(assigns, :user_id)} clicked={"filters_changed"}/>
+      <FilterButton id="activity_filter" tooltip="Only show attempts for this same activity" label="Activity" key={:activity_id} active={is_active(assigns, :activity_id)} clicked={"filters_changed"}/>
+      <FilterButton id="purpose_filter" tooltip="Only show attempts of this same purpose" label="Purpose" key={:graded} active={is_active(assigns, :graded)} clicked={"filters_changed"}/>
     </div>
     """
   end

--- a/lib/oli_web/live/manual_grading/filters.ex
+++ b/lib/oli_web/live/manual_grading/filters.ex
@@ -1,0 +1,43 @@
+defmodule OliWeb.ManualGrading.Filters do
+  use Surface.Component
+  alias OliWeb.ManualGrading.FilterButton
+
+  prop options, :struct, required: true
+
+  def render(assigns) do
+    ~F"""
+    <div style="display: inline;">
+      <FilterButton label="User" key={:user_id} active={is_active(assigns, :user_id)} clicked={"filters_changed"}/>
+      <FilterButton label="Activity" key={:activity_id} active={is_active(assigns, :activity_id)} clicked={"filters_changed"}/>
+      <FilterButton label="Page Type" key={:graded} active={is_active(assigns, :graded)} clicked={"filters_changed"}/>
+    </div>
+    """
+  end
+
+  def is_active(assigns, key), do: !(Map.get(assigns.options, key) |> is_nil)
+
+  def handle_delegated(event, params, socket, patch_fn) do
+    delegate_handle_event(event, params, socket, patch_fn)
+  end
+
+  def delegate_handle_event("filters_changed", %{"key" => key, "active" => "false"}, socket, patch_fn) do
+    changes = Map.put(%{}, String.to_existing_atom(key), nil)
+    patch_fn.(socket, changes)
+  end
+
+  def delegate_handle_event("filters_changed", %{"key" => key}, socket, patch_fn) do
+
+    value = case key do
+      "user_id" -> socket.assigns.attempt.user.id
+      "activity_id" -> socket.assigns.attempt.resource_id
+      "graded" -> socket.assigns.attempt.graded
+    end
+
+    changes = Map.put(%{}, String.to_existing_atom(key), value)
+    patch_fn.(socket, changes)
+  end
+
+  def delegate_handle_event(_, _, _, _) do
+    :not_handled
+  end
+end

--- a/lib/oli_web/live/manual_grading/filters.ex
+++ b/lib/oli_web/live/manual_grading/filters.ex
@@ -7,9 +7,9 @@ defmodule OliWeb.ManualGrading.Filters do
   def render(assigns) do
     ~F"""
     <div style="display: inline;">
-      <FilterButton label="User" key={:user_id} active={is_active(assigns, :user_id)} clicked={"filters_changed"}/>
-      <FilterButton label="Activity" key={:activity_id} active={is_active(assigns, :activity_id)} clicked={"filters_changed"}/>
-      <FilterButton label="Page Type" key={:graded} active={is_active(assigns, :graded)} clicked={"filters_changed"}/>
+      <FilterButton tooltip="Only show attempts from this same user" label="User" key={:user_id} active={is_active(assigns, :user_id)} clicked={"filters_changed"}/>
+      <FilterButton tooltip="Only show attempts for this same activity" label="Activity" key={:activity_id} active={is_active(assigns, :activity_id)} clicked={"filters_changed"}/>
+      <FilterButton tooltip="Only show attempts of this same purpose" label="Purpose" key={:graded} active={is_active(assigns, :graded)} clicked={"filters_changed"}/>
     </div>
     """
   end

--- a/lib/oli_web/live/manual_grading/group.ex
+++ b/lib/oli_web/live/manual_grading/group.ex
@@ -1,0 +1,14 @@
+defmodule OliWeb.ManualGrading.Group do
+  use Surface.Component
+
+  slot default, required: true
+
+  def render(assigns) do
+    ~F"""
+    <div style="padding: 20px; border: 2px inset rgba(28,110,164,0.17); border-radius: 12px;" class="mb-3">
+      <#slot />
+    </div>
+    """
+  end
+
+end

--- a/lib/oli_web/live/manual_grading/manual_grading_view.ex
+++ b/lib/oli_web/live/manual_grading/manual_grading_view.ex
@@ -1,0 +1,198 @@
+defmodule OliWeb.ManualGrading.ManualGradingView do
+  use Surface.LiveView, layout: {OliWeb.LayoutView, "live.html"}
+
+  alias Oli.Repo.{Paging, Sorting}
+  alias OliWeb.Common.{TextSearch, PagedTable, Breadcrumb}
+  alias Oli.Delivery.Sections.{EnrollmentBrowseOptions}
+  alias OliWeb.Common.Table.SortableTableModel
+  alias OliWeb.Router.Helpers, as: Routes
+  alias Oli.Delivery.Sections
+  import OliWeb.DelegatedEvents
+  import OliWeb.Common.Params
+  alias OliWeb.Sections.Mount
+  alias OliWeb.Grades.GradebookTableModel
+
+  @limit 10
+  @default_options %EnrollmentBrowseOptions{
+    is_student: true,
+    is_instructor: false,
+    text_search: nil
+  }
+
+  data breadcrumbs, :any
+  data title, :string, default: "Instructor Manual Scoring"
+  data section, :any, default: nil
+  data tabel_model, :struct
+  data total_count, :integer, default: 0
+  data offset, :integer, default: 0
+  data limit, :integer, default: @limit
+  data options, :any
+
+  def set_breadcrumbs(type, section) do
+    OliWeb.Sections.OverviewView.set_breadcrumbs(type, section)
+    |> breadcrumb(section)
+  end
+
+  def breadcrumb(previous, section) do
+    previous ++
+      [
+        Breadcrumb.new(%{
+          full_title: "Gradebook",
+          link: Routes.live_path(OliWeb.Endpoint, __MODULE__, section.slug)
+        })
+      ]
+  end
+
+  def mount(%{"section_slug" => section_slug}, session, socket) do
+    case Mount.for(section_slug, session) do
+      {:error, e} ->
+        Mount.handle_error(socket, {:error, e})
+
+      {type, _, section} ->
+        enrollments =
+          Sections.browse_enrollments(
+            section,
+            %Paging{offset: 0, limit: @limit},
+            %Sorting{direction: :asc, field: :name},
+            @default_options
+          )
+
+        total_count = determine_total(enrollments)
+
+        hierarchy = Oli.Publishing.DeliveryResolver.full_hierarchy(section.slug)
+
+        graded_pages =
+          hierarchy
+          |> Oli.Delivery.Hierarchy.flatten()
+          |> Enum.filter(fn node -> node.revision.graded end)
+          |> Enum.map(fn node -> node.revision end)
+
+        resource_accesses = fetch_resource_accesses(enrollments, section)
+
+        {:ok, table_model} =
+          GradebookTableModel.new(enrollments, graded_pages, resource_accesses, section)
+
+        {:ok,
+         assign(socket,
+           breadcrumbs: set_breadcrumbs(type, section),
+           section: section,
+           total_count: total_count,
+           table_model: table_model,
+           graded_pages: graded_pages,
+           options: @default_options
+         )}
+    end
+  end
+
+  defp determine_total(projects) do
+    case(projects) do
+      [] -> 0
+      [hd | _] -> hd.total_count
+    end
+  end
+
+  defp fetch_resource_accesses(enrollments, section) do
+    # retrieve all graded resource accesses, but only for this slice of students
+    student_ids = Enum.map(enrollments, fn user -> user.id end)
+
+    Oli.Delivery.Attempts.Core.get_graded_resource_access_for_context(
+      section.slug,
+      student_ids
+    )
+  end
+
+  def handle_params(params, _, socket) do
+    table_model =
+      SortableTableModel.update_from_params(
+        socket.assigns.table_model,
+        params
+      )
+
+    offset = get_int_param(params, "offset", 0)
+
+    options = %EnrollmentBrowseOptions{
+      text_search: get_param(params, "text_search", ""),
+      is_student: true,
+      is_instructor: false
+    }
+
+    enrollments =
+      Sections.browse_enrollments(
+        socket.assigns.section,
+        %Paging{offset: offset, limit: @limit},
+        # We cannot support sorting by columns other than the user name, so ignore any
+        # attempt to do that
+        %Sorting{direction: table_model.sort_order, field: :name},
+        options
+      )
+
+    resource_accesses = fetch_resource_accesses(enrollments, socket.assigns.section)
+
+    {:ok, table_model} =
+      GradebookTableModel.new(
+        enrollments,
+        socket.assigns.graded_pages,
+        resource_accesses,
+        socket.assigns.section
+      )
+
+    total_count = determine_total(enrollments)
+
+    {:noreply,
+     assign(
+       socket,
+       offset: offset,
+       table_model: table_model,
+       total_count: total_count,
+       options: options
+     )}
+  end
+
+  def render(assigns) do
+    ~F"""
+    <div>
+
+      <TextSearch id="text-search"/>
+
+      <div class="mb-3"/>
+
+      <PagedTable
+        filter={@options.text_search}
+        table_model={@table_model}
+        total_count={@total_count}
+        offset={@offset}
+        limit={@limit}/>
+    </div>
+    """
+  end
+
+  def patch_with(socket, changes) do
+    {:noreply,
+     push_patch(socket,
+       to:
+         Routes.live_path(
+           socket,
+           __MODULE__,
+           socket.assigns.section.slug,
+           Map.merge(
+             %{
+               sort_by: socket.assigns.table_model.sort_by_spec.name,
+               sort_order: socket.assigns.table_model.sort_order,
+               offset: socket.assigns.offset,
+               text_search: socket.assigns.options.text_search
+             },
+             changes
+           )
+         ),
+       replace: true
+     )}
+  end
+
+  def handle_event(event, params, socket) do
+    {event, params, socket, &__MODULE__.patch_with/2}
+    |> delegate_to([
+      &TextSearch.handle_delegated/4,
+      &PagedTable.handle_delegated/4
+    ])
+  end
+end

--- a/lib/oli_web/live/manual_grading/manual_grading_view.ex
+++ b/lib/oli_web/live/manual_grading/manual_grading_view.ex
@@ -15,8 +15,6 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
   part attempt.  That would enable a user to visit this view, enter feedback and scores for a student (but not
   apply them) and then navigate away, return to the view and still see that work.
 
-
-
   """
 
   use Surface.LiveView, layout: {OliWeb.LayoutView, "live.html"}

--- a/lib/oli_web/live/manual_grading/manual_grading_view.ex
+++ b/lib/oli_web/live/manual_grading/manual_grading_view.ex
@@ -185,7 +185,6 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
         <div style="padding: 20px; border: 2px inset rgba(28,110,164,0.17); border-radius: 22px;">
 
           <Tabs active={@active_tab} changed="change_tab"/>
-
           {#if @active_tab == :review}
             <RenderedActivity id={@attempt.attempt_guid} rendered_activity={@review_rendered}/>
           {#else}

--- a/lib/oli_web/live/manual_grading/manual_grading_view.ex
+++ b/lib/oli_web/live/manual_grading/manual_grading_view.ex
@@ -147,8 +147,10 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
     ~F"""
     <div>
 
-      <TextSearch id="text-search"/>
-      <Filters options={@options}/>
+      <div class="d-flex justify-content-between">
+        <TextSearch id="text-search"/>
+        <Filters options={@options}/>
+      </div>
 
       <div class="mb-3"/>
 

--- a/lib/oli_web/live/manual_grading/manual_grading_view.ex
+++ b/lib/oli_web/live/manual_grading/manual_grading_view.ex
@@ -1,4 +1,24 @@
 defmodule OliWeb.ManualGrading.ManualGradingView do
+
+  @moduledoc """
+  Implements instructor manual scoring of those activity attempts that are in a "submitted"
+  state.
+
+  Allows "point" based scoring, where the maximum possible points can be driven from the part specification
+  of an activity via the "out_of" attribute.  This optional attribute of a part, if not specified, defaults
+  to `nil`, which this view interprets as the value of 1.
+
+  This view allows a user to navigate through the items that are awaiting scoring, and to enter scores
+  and feedback, but not actually apply these changes.  This "temporary" state is ephemeral in the sense that
+  it is scoped to this view only as it is simply held in a state attribute of this view (`score_feedbacks`).
+  We can consider expanding the functionality here by having this "temporary" state be stored directly in the
+  part attempt.  That would enable a user to visit this view, enter feedback and scores for a student (but not
+  apply them) and then navigate away, return to the view and still see that work.
+
+
+
+  """
+
   use Surface.LiveView, layout: {OliWeb.LayoutView, "live.html"}
 
   alias Oli.Repo.{Paging, Sorting}
@@ -25,6 +45,7 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
   @default_options %BrowseOptions{
     user_id: nil,
     activity_id: nil,
+    page_id: nil,
     graded: nil,
     text_search: nil
   }
@@ -106,7 +127,43 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
     end
   end
 
+  defp is_apply_transition?(params) do
+    selected = get_param(params, "selected", nil)
+    cond do
+      is_nil(selected) -> false
+      selected == "none" -> true
+      selected == "0" -> true
+      String.starts_with?(selected, "-") -> true
+      true -> false
+    end
+  end
+
   def handle_params(params, _, socket) do
+    if is_apply_transition?(params) do
+      handle_transition_after_apply(params, socket)
+    else
+      handle_regular_param_update(params, socket)
+    end
+  end
+
+  # After a score has been applied, special handling of the "selected" key
+  # in the params update exists.  This "selected" key normally contains the
+  # literal database Id of the attempt that is selected.  In this case, however,
+  # "selected" contains the index within the page that is about to be returned
+  # of the item to select next.  This index is encoded as a negative number so
+  # that this impl can distinguish it between Id references.  We need to encode
+  # the index because there are cases where we do not know the exact attempt that should
+  # be next 'selected'.  Consider the case that 11 attempts exist, and attempts 1
+  # through 10 are displayed in the first page.  If the user has selected item 10
+  # (the last item in this page) and applies scoring, the next item that should be
+  # selected is item 11, which then should also appear as the new, last item in the
+  # first page. However, we don't know what that attempt at the time that this
+  # param update is patched.  This "index" mode allows the view to basically operate in
+  # a "just select the next item that appears in this index after the query is rerun"
+  # mode.
+  defp handle_transition_after_apply(params, socket) do
+
+    selected = get_param(params, "selected", nil)
     table_model =
       SortableTableModel.update_from_params(
         socket.assigns.table_model,
@@ -114,25 +171,76 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
       )
 
     offset = get_int_param(params, "offset", 0)
-    selected = get_param(params, "selected", nil)
+    options = %BrowseOptions{
+      text_search: get_param(params, "text_search", ""),
+      user_id: get_int_param(params, "user_id", nil),
+      activity_id: get_int_param(params, "activity_id", nil),
+      page_id: get_int_param(params, "page_id", nil),
+      graded: get_boolean_param(params, "graded", nil)
+    }
+    attempts =
+      ManualGrading.browse_submitted_attempts(
+        socket.assigns.section,
+        %Paging{offset: offset, limit: @limit},
+        %Sorting{direction: table_model.sort_order, field: table_model.sort_by_spec.name},
+        options
+      )
 
+    selected = case selected do
+      "none" -> nil
+      n ->
+        index = String.to_integer(n) * -1
+        case Enum.at(attempts, index) do
+          nil -> nil
+          item -> item.id |> Integer.to_string()
+        end
+    end
+
+    table_model = Map.put(table_model, :rows, attempts)
+    |> Map.put(:selected, selected)
+
+    total_count = determine_total(attempts)
+
+    {:noreply,
+    assign(
+      socket,
+      offset: offset,
+      table_model: table_model,
+      total_count: total_count,
+      options: options)
+    |> assign(build_state_for_selection(table_model, socket.assigns))}
+  end
+
+  defp handle_regular_param_update(params, socket) do
+
+    selected = get_param(params, "selected", nil)
+    table_model =
+      SortableTableModel.update_from_params(
+        socket.assigns.table_model,
+        params
+      )
+
+    offset = get_int_param(params, "offset", 0)
     table_model =  Map.put(table_model, :selected, selected)
 
     options = %BrowseOptions{
       text_search: get_param(params, "text_search", ""),
       user_id: get_int_param(params, "user_id", nil),
       activity_id: get_int_param(params, "activity_id", nil),
+      page_id: get_int_param(params, "page_id", nil),
       graded: get_boolean_param(params, "graded", nil)
     }
 
+    # This is an optimization, if the only thing that has changed is the selection
+    # we do not need to re-run the query.  Just update the selected attempt.
     if only_selection_changed(socket.assigns, table_model, options, offset) do
       table_model = Map.put(socket.assigns.table_model, :selected, selected)
 
       {:noreply,
-       assign(
-         socket,
-         table_model: table_model
-       )
+      assign(
+        socket,
+        table_model: table_model
+      )
       |> assign(build_state_for_selection(table_model, socket.assigns))
       }
     else
@@ -145,8 +253,13 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
           options
         )
 
+      selected = case Enum.find(attempts, fn r -> Integer.to_string(r.id) == selected end) do
+        nil -> nil
+        attempt -> attempt.id |> Integer.to_string()
+      end
+
       table_model = Map.put(table_model, :rows, attempts)
-      |> Map.put(:selected, socket.assigns.table_model.selected)
+      |> Map.put(:selected, selected)
 
       total_count = determine_total(attempts)
 
@@ -162,14 +275,6 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
 
   end
 
-  def render(%{total_count: 0} = assigns) do
-    ~F"""
-    <div style="margin-top: 200px;" class="d-flex justify-content-center">
-      Currently, there are no student activity attempts that require manual scoring.
-    </div>
-    """
-  end
-
   def render(assigns) do
     ~F"""
     <div>
@@ -181,7 +286,7 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
       <Group>
         <div class="d-flex justify-content-between">
           <TextSearch id="text-search"/>
-          <Filters options={@options}/>
+          <Filters options={@options} selection={!is_nil(@attempt)}/>
         </div>
 
         <div class="mb-3"/>
@@ -214,6 +319,10 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
         </div>
       {/if}
 
+      {#if pending_changes(assigns)}
+        <div id="before_unload" phx-hook="BeforeUnloadListener"/>
+      {/if}
+
     </div>
     """
   end
@@ -227,9 +336,28 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
     """
   end
 
+  # Determines if any scoring or feedbacks remain to be entered for the part attempts
+  # of the currently selected activity attempt
   defp scoring_remains(assigns) do
+
+    attempt_guids = Enum.filter(assigns.part_attempts, fn pa -> pa.grading_approach == :manual end)
+    |> Enum.map(fn pa -> pa.attempt_guid end)
+    |> MapSet.new()
+
+    Map.keys(assigns.score_feedbacks)
+    |> Enum.filter(fn guid -> MapSet.member?(attempt_guids, guid) end)
+    |> Enum.any?(fn guid ->
+      sf = Map.get(assigns.score_feedbacks, guid)
+      is_nil(sf.score) or is_nil(sf.feedback)
+    end)
+  end
+
+  # Determines if there are *any* pending changes
+  defp pending_changes(assigns) do
     Map.values(assigns.score_feedbacks)
-    |> Enum.any?(fn sf -> is_nil(sf.score) or is_nil(sf.feedback) end)
+    |> Enum.any?(fn sf ->
+      !is_nil(sf.score) or !is_nil(sf.feedback)
+    end)
   end
 
   defp determine_out_of(%Oli.Delivery.Attempts.Core.PartAttempt{part_id: part_id}, parts_map) do
@@ -257,6 +385,7 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
                text_search: socket.assigns.options.text_search,
                user_id: socket.assigns.options.user_id,
                activity_id: socket.assigns.options.activity_id,
+               page_id: socket.assigns.options.page_id,
                graded: socket.assigns.options.graded,
                selected: socket.assigns.table_model.selected
              },
@@ -268,6 +397,7 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
   end
 
   defp build_state_for_selection(%{selected: nil}, _), do: [attempt: nil, part_attempts: nil, review_rendered: nil, preview_rendered: nil]
+  defp build_state_for_selection(%{selected: ""}, _), do: [attempt: nil, part_attempts: nil, review_rendered: nil, preview_rendered: nil]
 
   defp build_state_for_selection(table_model, assigns) do
 
@@ -319,6 +449,7 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
     assigns.options.text_search == options_after.text_search and
     assigns.options.user_id == options_after.user_id and
     assigns.options.activity_id == options_after.activity_id and
+    assigns.options.page_id == options_after.page_id and
     assigns.options.graded == options_after.graded and
     assigns.offset == offset_after
   end
@@ -340,7 +471,25 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
   end
 
   def handle_event("apply", _, socket) do
-    {:noreply, socket}
+
+    %{
+      section: section,
+      attempt: attempt,
+      score_feedbacks: score_feedbacks
+    } = socket.assigns
+
+    case ManualGrading.apply_manual_scoring(section, attempt, score_feedbacks) do
+      {:ok, finalized_part_attempts} ->
+
+        pid = self()
+        send(pid, {:purge_score_feedbacks, Enum.map(finalized_part_attempts, fn pa -> pa.attempt_guid end)})
+
+        put_flash(socket, :info, "Student attempt scored.")
+        |> pick_next()
+      _ ->
+        {:noreply,  put_flash(socket, :error, "There was a problem encountered while scoring this attempt.")}
+    end
+
   end
 
   def handle_event("feedback_changed", %{"id" => "feedback_" <> attempt_guid, "value" => feedback}, socket) do
@@ -377,7 +526,6 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
 
   end
 
-
   def handle_event(event, params, socket) do
     {event, params, socket, &__MODULE__.patch_with/2}
     |> delegate_to([
@@ -385,5 +533,35 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
       &TextSearch.handle_delegated/4,
       &PagedTable.handle_delegated/4
     ])
+  end
+
+  def handle_info({:purge_score_feedbacks, guids}, socket) do
+
+    score_feedbacks = Enum.reduce(guids, socket.assigns.score_feedbacks, fn guid, sfs ->
+      Map.delete(sfs, guid)
+    end)
+
+    {:noreply, assign(socket, score_feedbacks: score_feedbacks)}
+  end
+
+  # After a score is applied for an attempt, we need to determine what is the next
+  # attempt that should be selected.  We want this to emulate a 'queue' of sorts, so
+  # that the next item after the selected item becomes the next selected item. We
+  # must encode this index based selection in some way that is distinguishable from a
+  # normal Id reference, so we do that be encoding it as a negative number, with a special
+  # case of "none" for when there should not be a selection (i.e. the user has evaluated)
+  # the last attempt.
+  defp pick_next(socket) do
+
+    index = Enum.find_index(socket.assigns.table_model.rows, fn r -> Integer.to_string(r.id) == socket.assigns.table_model.selected end)
+
+    selected = cond do
+      is_nil(index) -> "none"
+      socket.assigns.total_count == 1 -> "none"
+      socket.assigns.total_count == index + 1 -> (index - 1) * -1
+      true -> index * -1
+    end
+
+    patch_with(socket, %{selected: selected})
   end
 end

--- a/lib/oli_web/live/manual_grading/part_scoring.ex
+++ b/lib/oli_web/live/manual_grading/part_scoring.ex
@@ -1,0 +1,89 @@
+defmodule OliWeb.ManualGrading.PartScoring do
+  use Surface.Component
+
+  prop part_attempt, :any, required: true
+  prop part_scoring, :struct, required: true
+  prop feedback_changed, :event, required: true
+  prop score_changed, :event, required: true
+
+  def render(%{part_attempt: %{lifecycle_state: :evaluated}} = assigns) do
+    ~F"""
+    <form>
+      <div class="form-row">
+        <div class="col-11">
+          {feedback(assigns)}
+        </div>
+        <div class="col">
+
+          <div class="input-group mb-3">
+            <div class="input-group-prepend">
+              <span class="input-group-text">Score</span>
+            </div>
+            <input type="text" disabled class="form-control" value={@part_attempt.score}>
+
+          </div>
+
+          <div class="input-group mb-3">
+            <div class="input-group-prepend">
+              <span class="input-group-text">Out Of</span>
+            </div>
+            <input type="text" disabled class="form-control" value={@part_attempt.out_of}>
+          </div>
+        </div>
+      </div>
+    </form>
+    """
+  end
+
+  def render(assigns) do
+    ~F"""
+    <form>
+      <div class="form-row">
+        <div class="col-10">
+          <textarea id={"feedback_" <> @part_attempt.attempt_guid} phx-hook="TextInputListener" phx-value-change={@feedback_changed.name}
+            class="form-control" placeholder="Enter feedback for the student..." autocomplete="on" wrap="soft" maxlength="2000">{@part_scoring.feedback}</textarea>
+        </div>
+        <div class="col">
+
+          <div class="input-group mb-3">
+            <div class="input-group-prepend">
+              <span class="input-group-text">Score</span>
+            </div>
+            <input id={"score_" <> @part_attempt.attempt_guid} phx-hook="TextInputListener" phx-value-change={@score_changed.name}
+              type="number" class="form-control" step="1" min="0" max={@part_scoring.out_of} value={@part_scoring.score}>
+
+          </div>
+
+          <div class="input-group mb-3">
+            <div class="input-group-prepend">
+              <span class="input-group-text">Out Of</span>
+            </div>
+            <input type="text" disabled class="form-control" value={@part_scoring.out_of}>
+          </div>
+
+          <div class="btn-group" role="group" aria-label="Scoring shortcut group">
+            <button type="button" class="btn btn-sm btn-secondary" :on-click={@score_changed} phx-value-id={"score_" <> @part_attempt.attempt_guid} phx-value-score={0}>0%</button>
+            <button type="button" class="btn btn-sm btn-secondary" :on-click={@score_changed} phx-value-id={"score_" <> @part_attempt.attempt_guid} phx-value-score={@part_scoring.out_of / 2}>50%</button>
+            <button type="button" class="btn btn-sm btn-secondary" :on-click={@score_changed} phx-value-id={"score_" <> @part_attempt.attempt_guid} phx-value-score={@part_scoring.out_of}>100%</button>
+          </div>
+
+        </div>
+
+      </div>
+    </form>
+    """
+  end
+
+  defp feedback(%{part_attempt: %{grading_approach: :automatic}} = assigns) do
+    ~F"""
+    <p>This part was automatically graded by the system</p>
+    """
+  end
+
+  defp feedback(assigns) do
+    ~F"""
+    <textarea id={@part_attempt.attempt_guid} disabled class="form-control" wrap="soft" maxlength="2000">{@part_scoring.feedback}</textarea>
+    """
+  end
+
+end

--- a/lib/oli_web/live/manual_grading/rendered_activity.ex
+++ b/lib/oli_web/live/manual_grading/rendered_activity.ex
@@ -11,8 +11,7 @@ defmodule OliWeb.ManualGrading.RenderedActivity do
 
   def render(assigns) do
     ~F"""
-    <hr class="mb-3 mt-3"/>
-    <div id={@id} phx-update="none">{raw(@rendered_activity)}</div>
+    <div class="mt-5" id={@id} phx-update="none">{raw(@rendered_activity)}</div>
     """
   end
 

--- a/lib/oli_web/live/manual_grading/rendered_activity.ex
+++ b/lib/oli_web/live/manual_grading/rendered_activity.ex
@@ -1,0 +1,19 @@
+defmodule OliWeb.ManualGrading.RenderedActivity do
+  use Surface.LiveComponent
+
+  prop rendered_activity, :any, required: true
+
+  def render(%{rendered_activity: nil} = assigns) do
+    ~F"""
+      <div/>
+    """
+  end
+
+  def render(assigns) do
+    ~F"""
+    <hr class="mb-3 mt-3"/>
+    <div id={@id} phx-update="none">{raw(@rendered_activity)}</div>
+    """
+  end
+
+end

--- a/lib/oli_web/live/manual_grading/rendering.ex
+++ b/lib/oli_web/live/manual_grading/rendering.ex
@@ -1,0 +1,27 @@
+defmodule OliWeb.ManualGrading.Rendering do
+
+  alias Oli.Delivery.Sections.Section
+  alias Oli.Rendering.Context
+  alias Oli.Rendering.Activity.Html
+
+  def create_rendering_context(attempt, part_attempts, activity_types_map, %Section{slug: section_slug}) do
+
+    part_attempts_map = Enum.reduce(part_attempts, %{}, fn pa, m -> Map.put(m, pa.part_id, pa) end)
+    attempt_parts = Map.put(%{}, attempt.resource_id, {attempt, part_attempts_map})
+
+    %Context{
+      user: attempt.user,
+      section_slug: section_slug,
+      revision_slug: attempt.revision.slug,
+      mode: :review,
+      activity_map: Oli.Delivery.Page.ActivityContext.create_context_map(attempt.graded, attempt_parts, prune: false),
+      activity_types_map: activity_types_map
+    }
+
+  end
+
+  def render(%Context{} = context, mode) do
+    Html.activity(%{context | mode: mode}, %{"purpose" => "none", "activity_id" => Map.keys(context.activity_map) |> hd})
+  end
+
+end

--- a/lib/oli_web/live/manual_grading/score_feedback.ex
+++ b/lib/oli_web/live/manual_grading/score_feedback.ex
@@ -1,0 +1,16 @@
+defmodule OliWeb.ManualGrading.ScoreFeedback do
+
+  alias OliWeb.ManualGrading.ScoreFeedback
+
+  @enforce_keys [
+    :score,
+    :out_of,
+    :feedback
+  ]
+  defstruct [
+    :score,
+    :out_of,
+    :feedback
+  ]
+
+end

--- a/lib/oli_web/live/manual_grading/score_feedback.ex
+++ b/lib/oli_web/live/manual_grading/score_feedback.ex
@@ -1,7 +1,5 @@
 defmodule OliWeb.ManualGrading.ScoreFeedback do
 
-  alias OliWeb.ManualGrading.ScoreFeedback
-
   @enforce_keys [
     :score,
     :out_of,

--- a/lib/oli_web/live/manual_grading/table_model.ex
+++ b/lib/oli_web/live/manual_grading/table_model.ex
@@ -16,15 +16,22 @@ defmodule OliWeb.ManualGrading.TableModel do
           label: "Activity"
         },
         %ColumnSpec{
+          name: :attempt_number,
+          label: "Attempt"
+        },
+        %ColumnSpec{
           name: :page_title,
           label: "Page"
+        },
+        %ColumnSpec{
+          name: :resource_attempt_number,
+          label: "Attempt"
         },
         date_submitted_spec(),
         %ColumnSpec{
           name: :activity_type_id,
           label: "Activity Type",
           render_fn: &__MODULE__.render_activity_type/3
-
         },
         %ColumnSpec{
           name: :graded,

--- a/lib/oli_web/live/manual_grading/table_model.ex
+++ b/lib/oli_web/live/manual_grading/table_model.ex
@@ -1,0 +1,65 @@
+defmodule OliWeb.ManualGrading.TableModel do
+  alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
+  use Surface.LiveComponent
+
+  def new(attempts) do
+    SortableTableModel.new(
+      rows: attempts,
+      column_specs: [
+        %ColumnSpec{
+          name: :user,
+          label: "Student",
+          render_fn: &__MODULE__.render_student/3
+        },
+        %ColumnSpec{
+          name: :activity_title,
+          label: "Activity"
+        },
+        %ColumnSpec{
+          name: :page_title,
+          label: "Page"
+        },
+        %ColumnSpec{
+          name: :details,
+          label: "Date Submitted",
+          render_fn: &OliWeb.Common.Table.Common.render_date/3
+        },
+        %ColumnSpec{
+          name: :activity_type_id,
+          label: "Activity Type",
+          render_fn: &__MODULE__.render_activity_type/3
+
+        },
+        %ColumnSpec{
+          name: :graded,
+          label: "Purpose",
+          render_fn: &__MODULE__.render_purpose/3
+        }
+      ],
+      event_suffix: "",
+      id_field: [:index]
+    )
+  end
+
+  def render_student(_, row, _) do
+    OliWeb.Common.Utils.name(row.user)
+  end
+
+  def render_purpose(_, row, _) do
+    if row.graded do
+      "Graded"
+    else
+      "Practice"
+    end
+  end
+
+  def render_activity_type(_, row, _) do
+
+  end
+
+  def render(assigns) do
+    ~F"""
+    <div>nothing</div>
+    """
+  end
+end

--- a/lib/oli_web/live/manual_grading/table_model.ex
+++ b/lib/oli_web/live/manual_grading/table_model.ex
@@ -19,11 +19,7 @@ defmodule OliWeb.ManualGrading.TableModel do
           name: :page_title,
           label: "Page"
         },
-        %ColumnSpec{
-          name: :details,
-          label: "Date Submitted",
-          render_fn: &OliWeb.Common.Table.Common.render_date/3
-        },
+        date_submitted_spec(),
         %ColumnSpec{
           name: :activity_type_id,
           label: "Activity Type",
@@ -44,6 +40,14 @@ defmodule OliWeb.ManualGrading.TableModel do
     )
   end
 
+  def date_submitted_spec() do
+    %ColumnSpec{
+      name: :date_submitted,
+      label: "Date Submitted",
+      render_fn: &OliWeb.Common.Table.Common.render_date/3
+    }
+  end
+
   def render_student(_, row, _) do
     OliWeb.Common.Utils.name(row.user)
   end
@@ -56,7 +60,7 @@ defmodule OliWeb.ManualGrading.TableModel do
     end
   end
 
-  def render_activity_type(_, row, %{activity_types_map: activity_types_map}) do
+  def render_activity_type(%{activity_types_map: activity_types_map}, row, _) do
     Map.get(activity_types_map, row.activity_type_id).title
   end
 

--- a/lib/oli_web/live/manual_grading/table_model.ex
+++ b/lib/oli_web/live/manual_grading/table_model.ex
@@ -2,7 +2,7 @@ defmodule OliWeb.ManualGrading.TableModel do
   alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
   use Surface.LiveComponent
 
-  def new(attempts) do
+  def new(attempts, activity_types_map) do
     SortableTableModel.new(
       rows: attempts,
       column_specs: [
@@ -37,7 +37,10 @@ defmodule OliWeb.ManualGrading.TableModel do
         }
       ],
       event_suffix: "",
-      id_field: [:index]
+      id_field: [:id],
+      data: %{
+        activity_types_map: activity_types_map
+      }
     )
   end
 
@@ -53,8 +56,8 @@ defmodule OliWeb.ManualGrading.TableModel do
     end
   end
 
-  def render_activity_type(_, row, _) do
-
+  def render_activity_type(_, row, %{activity_types_map: activity_types_map}) do
+    Map.get(activity_types_map, row.activity_type_id).title
   end
 
   def render(assigns) do

--- a/lib/oli_web/live/manual_grading/tabs.ex
+++ b/lib/oli_web/live/manual_grading/tabs.ex
@@ -6,7 +6,7 @@ defmodule OliWeb.ManualGrading.Tabs do
 
   def render(assigns) do
     ~F"""
-    <ul class="nav nav-pills">
+    <ul class="nav nav-tabs">
       <li class="nav-item">
         <a class={active(assigns, :review)} :on-click={@changed} phx-value-tab={:review}>Student Submission</a>
       </li>

--- a/lib/oli_web/live/manual_grading/tabs.ex
+++ b/lib/oli_web/live/manual_grading/tabs.ex
@@ -1,0 +1,24 @@
+defmodule OliWeb.ManualGrading.Tabs do
+  use Surface.Component
+
+  prop active, :atom, required: true
+  prop changed, :event, required: true
+
+  def render(assigns) do
+    ~F"""
+    <ul class="nav nav-pills">
+      <li class="nav-item">
+        <a class={active(assigns, :review)} :on-click={@changed} phx-value-tab={:review}>Student Submission</a>
+      </li>
+      <li class="nav-item">
+        <a class={active(assigns, :preview)} :on-click={@changed} phx-value-tab={:preview}>Activity Details</a>
+      </li>
+    </ul>
+    """
+  end
+
+  def active(assigns, key) do
+    if assigns.active == key do "nav-link active" else "nav-link" end
+  end
+
+end

--- a/lib/oli_web/live/projects/projects_live.ex
+++ b/lib/oli_web/live/projects/projects_live.ex
@@ -204,6 +204,7 @@ defmodule OliWeb.Projects.ProjectsLive do
         <div class="col-12">
           <%= live_component PagedTable, page_change: "paged_table_page_change", sort: "paged_table_sort",
             total_count: @total_count, filter: @text_search,
+            selection_change: nil, allow_selection: false,
             limit: @limit, offset: @offset, table_model: @table_model %>
         </div>
       </div>

--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -115,6 +115,7 @@ defmodule OliWeb.Sections.OverviewView do
       </Group>
       <Group label="Grading" description="View and manage student grades and progress">
         <ul class="link-list">
+          <li><a href={Routes.live_path(OliWeb.Endpoint, OliWeb.ManualGrading.ManualGradingView, @section.slug)}>Score Manually Graded Activities</a></li>
           <li><a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Grades.GradebookView, @section.slug)}>View Grades</a></li>
           <li><a href={Routes.page_delivery_path(OliWeb.Endpoint, :export_gradebook, @section.slug)}>Download Gradebook as <code>.csv</code> file</a></li>
           {#if !@section.open_and_free}

--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -16,6 +16,7 @@ defmodule OliWeb.Sections.OverviewView do
   data section, :any, default: nil
   data instructors, :list, default: []
   data updates_count, :integer
+  data submission_count, :integer
   data section_has_student_data, :boolean
 
   def set_breadcrumbs(:admin, section) do
@@ -54,7 +55,8 @@ defmodule OliWeb.Sections.OverviewView do
            instructors: fetch_instructors(section),
            user: user,
            section: section,
-           updates_count: updates_count
+           updates_count: updates_count,
+           submission_count: Oli.Delivery.Attempts.ManualGrading.count_submitted_attempts(section)
          )}
     end
   end
@@ -115,7 +117,13 @@ defmodule OliWeb.Sections.OverviewView do
       </Group>
       <Group label="Grading" description="View and manage student grades and progress">
         <ul class="link-list">
-          <li><a href={Routes.live_path(OliWeb.Endpoint, OliWeb.ManualGrading.ManualGradingView, @section.slug)}>Score Manually Graded Activities</a></li>
+          <li><a href={Routes.live_path(OliWeb.Endpoint, OliWeb.ManualGrading.ManualGradingView, @section.slug)}>
+            Score Manually Graded Activities
+            {#if @submission_count > 0}
+                <span class="badge badge-primary">{@submission_count}</span>
+              {/if}
+            </a>
+          </li>
           <li><a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Grades.GradebookView, @section.slug)}>View Grades</a></li>
           <li><a href={Routes.page_delivery_path(OliWeb.Endpoint, :export_gradebook, @section.slug)}>Download Gradebook as <code>.csv</code> file</a></li>
           {#if !@section.open_and_free}

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -722,6 +722,7 @@ defmodule OliWeb.Router do
     live("/:section_slug/grades/lms_grade_updates", Grades.BrowseUpdatesView)
     live("/:section_slug/grades/observe", Grades.ObserveGradeUpdatesView)
     live("/:section_slug/grades/gradebook", Grades.GradebookView)
+    live("/:section_slug/scoring", ManualGrading.ManualGradingView)
     live("/:section_slug/progress/:user_id/:resource_id", Progress.StudentResourceView)
     live("/:section_slug/progress/:user_id", Progress.StudentView)
     get("/:section_slug/grades/export", PageDeliveryController, :export_gradebook)


### PR DESCRIPTION
This PR introduces the UI allowing an instructor to perform manual scoring for the submitted attempts of their students.

In addition to the LiveView (and components) that implement the UI, there were a few other changes necessary:
1. Introduction of a new `outOf` attribute for parts within an activity model. This attribute specifies the maximum points available for a part, and if not present defaults to `1.0`.  No activities currently allow setting this attribute, so all parts will use the default value (for now).
2. Enable the ability to set the grading approach of the `ShortAnswer` activity. 
3. Add a new `apply_manual_scoring` function to the `ManualGrading` infrastructure context. This function allows the application of an instructor assigned score and feedback to an activity attempt.  
4. Added the ability to browse submitted attempt by page resource id. 
5. Added the ability for `PagedTable` to have a selected item. 

The LiveView itself is fairly straightforward and consists of three main pieces:
1. The table-based browsing/filtering portion.  Here is where the instructor searches, sorts through activity attempts to essentially create a "work queue" for scoring.
2. The second portion is the attempt display portion.  For the selected attempt in portion 1, this part of the UI renders the students submitted attempt and the instructor preview version of the activity.
3. The third portion is the scoring portion.  Here we display a UI for all parts, allowing the instructor to enter a score and feedback.  There is a facility for "shortcut" scoring, where 0%, 50%, or 100% can quickly be set.  When all parts have been "scored", the "Apply Score and Feedback" button enables, and when clicked transitions this attempt from submitted to evaluated, possibly rolling up the score to the resource attempt (if graded).

The implementation of the LiveView allows an instructor to keep selecting between different attempts, and entering scores and feedback - all without actually applying the score and feedback.  This is to support a workflow where an instructor makes a pass through all submissions, entering "candidate" scores and feedbacks, and perhaps then refining some of these.  When they are satisfied, then can then make one pass back through and "Apply" each.  This "temporary" state is not database backed, so an approach is taken here to warn the user before navigating away when they have pending work.  This is done via a window `beforeunload` listener via a hook.  

There is some more work to this UI coming soon in a future PR, including direct support for the adaptive page and adaptive activity. 

Note: I tried to get Bootstrap tooltips working in this UI, even by introducing a new `TooltipInit` hook.  But nothing worked.  