### PR TITLE
[ENHANCEMENT] Allow payment during grace period CMU-417

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Instructor review of completed graded attempts
 - Allow gates to be defined in products
 - Hide subsequent purpose types for activities when the same purpose type is used in a series
+- Allow students to pay and apply codes during a grace period
 
 ## 0.18.4 (2022-02-24)
 

--- a/lib/oli/delivery/paywall/access_summary.ex
+++ b/lib/oli/delivery/paywall/access_summary.ex
@@ -1,0 +1,64 @@
+defmodule Oli.Delivery.Paywall.AccessSummary do
+
+  alias Oli.Delivery.Paywall.AccessSummary
+
+  defstruct [
+    :available, # Boolean indicating whether access is available
+    :reason, # For available, one of:     [:not_paywalled, :instructor, :paid, :within_grace_period]
+             # For not-available, one of: [:not_enrolled, :not_paid]
+    :grace_period_remaining
+  ]
+
+  def build_no_paywall() do
+    %AccessSummary{
+      available: true,
+      reason: :not_paywalled,
+      grace_period_remaining: nil
+    }
+  end
+
+  def instructor() do
+    %AccessSummary{
+      available: true,
+      reason: :instructor,
+      grace_period_remaining: nil
+    }
+  end
+
+  def not_enrolled() do
+    %AccessSummary{
+      available: false,
+      reason: :not_enrolled,
+      grace_period_remaining: nil
+    }
+  end
+
+  def paid() do
+    %AccessSummary{
+      available: true,
+      reason: :paid,
+      grace_period_remaining: nil
+    }
+  end
+
+  def not_paid() do
+    %AccessSummary{
+      available: false,
+      reason: :not_paid,
+      grace_period_remaining: nil
+    }
+  end
+
+  def within_grace(grace_period_remaining) do
+    %AccessSummary{
+      available: true,
+      reason: :within_grace_period,
+      grace_period_remaining: grace_period_remaining
+    }
+  end
+
+  def as_days(grace_period_remaining) do
+    grace_period_remaining / (60 * 60 * 24)
+  end
+
+end

--- a/lib/oli_web/plugs/enforce_paywall.ex
+++ b/lib/oli_web/plugs/enforce_paywall.ex
@@ -11,8 +11,11 @@ defmodule Oli.Plugs.EnforcePaywall do
     section = conn.assigns.section
     user = conn.assigns.current_user
 
-    if Paywall.can_access?(user, section) do
+    summary = Paywall.summarize_access(user, section)
+
+    if summary.available do
       conn
+      |> Plug.Conn.assign(:paywall_summary, summary)
     else
       conn
       |> redirect(to: Routes.payment_path(conn, :guard, section.slug))

--- a/lib/oli_web/templates/layout/_pay_early.html.eex
+++ b/lib/oli_web/templates/layout/_pay_early.html.eex
@@ -1,0 +1,6 @@
+<%= if show_pay_early(Map.get(@conn.assigns, :paywall_summary)) do %>
+<div class="system-banner alert alert-warning" role="alert">
+  <%= pay_early_message(@conn.assigns.paywall_summary) %>
+  <a class="ml-3" href="<%= Routes.payment_path(@conn, :make_payment, @section.slug) %>">Pay Now</a>
+</div>
+<% end %>

--- a/lib/oli_web/templates/layout/delivery.html.eex
+++ b/lib/oli_web/templates/layout/delivery.html.eex
@@ -70,7 +70,7 @@
   <body>
 
     <%= live_render(@conn, OliWeb.SystemMessageLive.ShowView) %>
-
+    <%= render OliWeb.LayoutView, "_pay_early.html", assigns %>
     <%= render OliWeb.LayoutView, "_delivery_header.html", assigns %>
 
     <main role="main" class="container">

--- a/lib/oli_web/views/layout_view.ex
+++ b/lib/oli_web/views/layout_view.ex
@@ -17,7 +17,24 @@ defmodule OliWeb.LayoutView do
   alias Oli.Accounts
   alias Oli.Publishing.AuthoringResolver
   alias OliWeb.Breadcrumb.BreadcrumbTrailLive
+  alias Oli.Delivery.Paywall.AccessSummary
   alias Oli.Delivery.Sections
+
+
+  def show_pay_early(%AccessSummary{reason: :within_grace_period}), do: true
+  def show_pay_early(_), do: false
+
+  def pay_early_message(%AccessSummary{reason: :within_grace_period, grace_period_remaining: seconds_remaining}) do
+
+    fractional_days_remaining = AccessSummary.as_days(seconds_remaining)
+
+    cond do
+      fractional_days_remaining < 1.0 -> "Today is the last day of your grace period access for this course"
+      fractional_days_remaining < 2.0 -> "Tomorrow is the last day remaining in your grace period access of this course"
+      true -> "You have #{round(fractional_days_remaining)} more days remaining in your grace period access of this course"
+    end
+  end
+  def pay_early_message(_), do: ""
 
   def container_slug(assigns) do
     if assigns[:container] do

--- a/test/oli_web/controllers/payment_providers/stripe_controller_test.exs
+++ b/test/oli_web/controllers/payment_providers/stripe_controller_test.exs
@@ -31,9 +31,12 @@ defmodule OliWeb.PaymentProviders.StripeControllerTest do
   describe "user cannot direct pay when stripe is not configured" do
     setup [:user_conn, :create_section]
 
-    test "displays not enabled message", %{conn: conn, section: section} do
+    test "displays not enabled message", %{conn: conn, user: user, section: section} do
       Config.Reader.read!("test/config/config.exs")
       |> Application.put_all_env()
+
+      insert(:enrollment, %{user: user, section: section})
+
 
       conn = get(conn, Routes.payment_path(conn, :make_payment, section.slug))
 
@@ -87,6 +90,9 @@ defmodule OliWeb.PaymentProviders.StripeControllerTest do
     end
 
     test "displays stripe form", %{conn: conn, section: section, user: user} do
+
+      insert(:enrollment, %{user: user, section: section})
+
       {:ok, amount} = Money.to_string(section.amount)
 
       conn = get(conn, Routes.payment_path(conn, :make_payment, section.slug))


### PR DESCRIPTION
This PR implements the ability for a student that is accessing a paywalled course during the grace period to:
1. See and understand how much time they have left remaining in the grace period
2. Proceed forward with making a payment or applying an access code

The changes here are:
1. Provide a `summarize_access` method in the `Paywall` context that returns a struct that details not only whether or not a user can access a course section, but also the reason why (`:not_paid`, `:within_grace_period`, `:instructor`, etc). 
2. Adjust the `EnforcePaywall` plug to insert the `AccessSummary` struct into the connection assigns for later use in a banner display
3. Add a banner display when the user is accessing the course in the grace period.  

To test this out:
1. Create a paywalled course section, that doesn't require enrollment, with an active grace period.
2. Access the course as a student. You should now see a warning banner that details the time remaining in the grace period and that provides a link to initiate payment

