### PR TITLE
PMP-2580 | JAN-1417

### DIFF
--- a/assets/src/adaptivity/operators/equality.ts
+++ b/assets/src/adaptivity/operators/equality.ts
@@ -51,6 +51,9 @@ export const isEqual = (factValue: any, value: any): boolean => {
     return value.toString().toLowerCase() === 'true' ? true === factValue : false === factValue;
   }
   if (typeOfValue === 'boolean') {
+    if (typeOfFactValue === 'number') {
+      return factValue === 1 ? true : false;
+    }
     return factValue.toString().toLowerCase() === 'true' ? true === value : false === value;
   }
   if (typeOfValue === 'string' && (value === 'true' || value === 'false')) {

--- a/assets/src/adaptivity/operators/equality.ts
+++ b/assets/src/adaptivity/operators/equality.ts
@@ -51,10 +51,9 @@ export const isEqual = (factValue: any, value: any): boolean => {
     return value.toString().toLowerCase() === 'true' ? true === factValue : false === factValue;
   }
   if (typeOfValue === 'boolean') {
-    if (typeOfFactValue === 'number') {
-      return factValue === 1 ? true : false;
-    }
-    return factValue.toString().toLowerCase() === 'true' ? true === value : false === value;
+    return factValue.toString().toLowerCase() === 'true' || factValue > 0
+      ? true === value
+      : false === value;
   }
   if (typeOfValue === 'string' && (value === 'true' || value === 'false')) {
     return parseBoolean(value) === parseBoolean(factValue);

--- a/assets/test/adaptivity/rules_engine_test.ts
+++ b/assets/test/adaptivity/rules_engine_test.ts
@@ -233,6 +233,9 @@ describe('Operators', () => {
       expect(isEqual('a', 'a')).toEqual(true);
       expect(isEqual(9, 9)).toEqual(true);
       expect(isEqual([1, 2], [1, 2])).toEqual(true);
+      expect(isEqual(1, true)).toEqual(true);
+      expect(isEqual(0, false)).toEqual(true);
+      expect(isEqual(1, false)).toEqual(false);
       expect(notEqual(9, 3)).toEqual(true);
       expect(notEqual('a', 'c')).toEqual(true);
       expect(notEqual([3, 2], [1, 2])).toEqual(true);


### PR DESCRIPTION
The correct trap state has codition 'session.visits.q:1484171837224:1023 = true'. Currently the value of 'session.visits.q:1484171837224:1023' gets set to numeric value i.e. 1; so made changes to fix this. We could compare that with '1==true' but since we are checking with '===', need the code to handle this.