### PR TITLE
[BUG FIX] Allow manually scored graded attempts to roll up to resource access

### DIFF
--- a/lib/oli/delivery/attempts/page_lifecycle/graded.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/graded.ex
@@ -262,9 +262,11 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Graded do
     ensure_valid_grade({score, out_of})
   end
 
-  defp roll_up_resource_attempts_to_access(section_slug, resource_access_id) do
+  def roll_up_resource_attempts_to_access(section_slug, resource_access_id) do
     access = Oli.Repo.get(ResourceAccess, resource_access_id)
+
     graded_attempts = get_graded_attempts_from_access(access.id)
+    |> Enum.filter(fn ra -> ra.lifecycle_state == :evaluated end)
 
     %{scoring_strategy_id: strategy_id} =
       DeliveryResolver.from_resource_id(section_slug, access.resource_id)

--- a/test/oli/delivery/attempts/manual_grading_test.exs
+++ b/test/oli/delivery/attempts/manual_grading_test.exs
@@ -141,6 +141,11 @@ defmodule Oli.Delivery.Attempts.ManualGradingTest do
       ra = Core.get_resource_attempt_by(attempt_guid: attempt.resource_attempt_guid)
       assert ra.lifecycle_state == :evaluated
 
+      # Verify that manual scoring of the last activity triggers grade roll up to the resource access
+      resource_access = Oli.Repo.get!(Oli.Delivery.Attempts.Core.ResourceAccess, ra.resource_access_id)
+      assert resource_access.out_of == 2.0
+      assert resource_access.score == 2.0
+
     end
   end
 


### PR DESCRIPTION
This PR fixes an issue where grading of the last manually graded activity in a graded page was not resulting in the grade rolling up to the resource access. 

