### PR TITLE
Fixed issue with rich text editor id overlap

### DIFF
--- a/assets/src/apps/delivery/components/ActivityRenderer.tsx
+++ b/assets/src/apps/delivery/components/ActivityRenderer.tsx
@@ -34,7 +34,7 @@ import {
   selectLastMutateTriggered,
 } from '../store/features/adaptivity/slice';
 import { selectCurrentActivityTree } from '../store/features/groups/selectors/deck';
-import { selectPreviewMode, selectUserId } from '../store/features/page/slice';
+import { selectPageSlug, selectPreviewMode, selectUserId } from '../store/features/page/slice';
 import { NotificationType } from './NotificationContext';
 
 interface ActivityRendererProps {
@@ -85,6 +85,7 @@ const ActivityRenderer: React.FC<ActivityRendererProps> = ({
 }) => {
   const isPreviewMode = useSelector(selectPreviewMode);
   const currentUserId = useSelector(selectUserId);
+  const currentLessonId = useSelector(selectPageSlug);
 
   const saveUserData = async (attemptGuid: string, partAttemptGuid: string, payload: any) => {
     const { simId, key, value } = payload;
@@ -461,6 +462,7 @@ const ActivityRenderer: React.FC<ActivityRendererProps> = ({
     const finalInitSnapshot = handleInitStateVars(initState, snapshot);
     ref.current.notify(NotificationType.CONTEXT_CHANGED, {
       currentActivityId,
+      currentLessonId,
       mode: historyModeNavigation ? contexts.REVIEW : contexts.VIEWER,
       snapshot,
       initStateFacts: finalInitSnapshot || {},

--- a/assets/src/apps/delivery/layouts/deck/DeckLayoutView.tsx
+++ b/assets/src/apps/delivery/layouts/deck/DeckLayoutView.tsx
@@ -27,11 +27,15 @@ import {
   selectCurrentActivityTree,
   selectCurrentActivityTreeAttemptState,
 } from '../../store/features/groups/selectors/deck';
-import { selectEnableHistory, selectUserName, setScore } from '../../store/features/page/slice';
+import {
+  selectEnableHistory,
+  selectPageSlug,
+  selectUserName,
+  setScore
+} from '../../store/features/page/slice';
 import { LayoutProps } from '../layouts';
 import DeckLayoutFooter from './DeckLayoutFooter';
 import DeckLayoutHeader from './DeckLayoutHeader';
-import { parseArray, parseNumString } from 'utils/common';
 import { getLocalizedCurrentStateSnapshot } from 'apps/delivery/store/features/adaptivity/actions/getLocalizedCurrentStateSnapshot';
 
 const InjectedStyles: React.FC<{ css?: string }> = (props) => {
@@ -50,6 +54,7 @@ const DeckLayoutView: React.FC<LayoutProps> = ({ pageTitle, pageContent, preview
   const fieldRef = React.useRef<HTMLInputElement>(null);
   const currentActivityTree = useSelector(selectCurrentActivityTree);
   const currentActivityAttemptTree = useSelector(selectCurrentActivityTreeAttemptState);
+  const currentLesson = useSelector(selectPageSlug);
   const currentUserName = useSelector(selectUserName);
   const historyModeNavigation = useSelector(selectHistoryNavigationActivity);
   const isEnd = useSelector(selectLessonEnd);
@@ -281,6 +286,7 @@ const DeckLayoutView: React.FC<LayoutProps> = ({ pageTitle, pageContent, preview
       sharedActivityPromise.resolve({
         snapshot: getLocalizedStateSnapshot(currentActivityIds),
         context: {
+          currentLesson,
           currentActivity: currentActivityTree[currentActivityTree.length - 1].id,
           mode: historyModeNavigation ? contexts.REVIEW : contexts.VIEWER,
         },

--- a/assets/src/apps/delivery/layouts/deck/DeckLayoutView.tsx
+++ b/assets/src/apps/delivery/layouts/deck/DeckLayoutView.tsx
@@ -31,7 +31,7 @@ import {
   selectEnableHistory,
   selectPageSlug,
   selectUserName,
-  setScore
+  setScore,
 } from '../../store/features/page/slice';
 import { LayoutProps } from '../layouts';
 import DeckLayoutFooter from './DeckLayoutFooter';

--- a/assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx
+++ b/assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx
@@ -48,8 +48,15 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
   const [simFrame, setSimFrame] = useState<HTMLIFrameElement>();
   const [frameSrc, setFrameSrc] = useState<string>('');
   const [frameCssClass, setFrameCssClass] = useState('');
+
+  const [questionId, setQuestionId] = useState('');
+  const [lessonId, setLessonId] = useState('');
+
   // these rely on being set every render and the "model" useState value being set
   const { src, title, allowScrolling, configData } = model;
+
+  // console.log('ExternalActivity', props, model);
+
   useEffect(() => {
     const styleChanges: any = {};
     if (frameWidth !== undefined) {
@@ -133,6 +140,8 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
         },
       ],
     });
+    setLessonId(initResult.context.currentLesson);
+    setQuestionId(initResult.context.currentActivity);
 
     // result of init has a state snapshot with latest (init state applied)
     writeCapiLog('INIT RESULT CAPI', initResult);
@@ -542,7 +551,6 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
               setInitStateBindToFacts(payload.initStateBindToFacts);
               setScreenContext(NotificationType.CONTEXT_CHANGED);
               processInitStateVariable(currentStateSnapshot, simLife.domain);
-
               setSimIsInitStatePassedOnce(false);
             }
             break;
@@ -632,7 +640,11 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
     simLife.handshake.requestToken = msgRequestToken;
 
     // taken from simcapi.js TODO move somewhere, use from settings
-    simLife.handshake.config = { context: context };
+    simLife.handshake.config = {
+      context: context,
+      lessonId,
+      questionId,
+    };
 
     // TODO: here in the handshake response we should send come config...
     sendFormedResponse(simLife.handshake, {}, JanusCAPIRequestTypes.HANDSHAKE_RESPONSE, []);

--- a/assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx
+++ b/assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx
@@ -544,10 +544,15 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
               simLife.handshake.config = {
                 context: payload.mode,
                 questionId: payload.currentActivityId,
+                lessonId: payload.currentLessonId,
               };
               notifyConfigChange();
               // we only send the Init state variables.
               const currentStateSnapshot = payload.initStateFacts;
+
+              setLessonId(payload.currentLessonId);
+              setQuestionId(payload.currentActivityId);
+
               setInitStateBindToFacts(payload.initStateBindToFacts);
               setScreenContext(NotificationType.CONTEXT_CHANGED);
               processInitStateVariable(currentStateSnapshot, simLife.domain);


### PR DESCRIPTION
This change fixes an issue where the rich text editor in capi iframes were sometimes getting ids set to undefined:undefined in local storage, which allowed them to stomp on each other when retrieving values from local storage.