### PR TITLE
[MER-754][MER-817][MER-819] Author and customize project flow for Portal

### DIFF
--- a/lib/oli/accounts.ex
+++ b/lib/oli/accounts.ex
@@ -635,6 +635,35 @@ defmodule Oli.Accounts do
   end
 
   @doc """
+  Finds or creates an author and user logged in via sso, adds the user as a member of the given community
+  and links both user and author.
+
+  ## Examples
+
+      iex> setup_sso_author(fields, community_id)
+      {:ok, %Author{}}    -> # Inserted or updated with success
+      {:error, changeset}         -> # Something went wrong
+
+  """
+  def setup_sso_author(fields, community_id) do
+    res =
+      Multi.new()
+      |> Multi.run(:user, &create_sso_user(&1, &2, fields))
+      |> Multi.run(:community_account, &create_community_account(&1, &2, community_id))
+      |> Multi.run(:author, &create_sso_author(&1, &2, fields))
+      |> Multi.run(:linked_user, &link_user_with_author(&1, &2))
+      |> Repo.transaction()
+
+    case res do
+      {:ok, %{author: author}} ->
+        {:ok, author}
+
+      {:error, _, changeset, _} ->
+        {:error, changeset}
+    end
+  end
+
+  @doc """
   Inserts or updates an user logged in via sso, and adds the user as a member of the given community.
 
   ## Examples
@@ -668,6 +697,25 @@ defmodule Oli.Accounts do
       name: Map.get(fields, "name"),
       can_create_sections: true
     })
+  end
+
+  defp create_sso_author(_repo, _changes, fields) do
+    email = Map.get(fields, "email")
+    username = Map.get(fields, "cognito:username")
+
+    case get_author_by_email(email) do
+      nil ->
+        %Author{}
+        |> Author.noauth_changeset(%{name: username, email: email})
+        |> Repo.insert()
+
+      author ->
+        {:ok, author}
+    end
+  end
+
+  defp link_user_with_author(_repo, %{user: user, author: author}) do
+    link_user_author_account(user, author)
   end
 
   defp create_community_account(_repo, %{user: %User{id: user_id}}, community_id) do

--- a/lib/oli/authoring/clone.ex
+++ b/lib/oli/authoring/clone.ex
@@ -103,7 +103,8 @@ defmodule Oli.Authoring.Clone do
   project specified by the given project slug.
   """
   def already_has_clone?(project_slug, author) do
-    existing_clones(project_slug, author)
+    project_slug
+    |> existing_clones(author)
     |> Enum.count() > 0
   end
 end

--- a/lib/oli/authoring/clone.ex
+++ b/lib/oli/authoring/clone.ex
@@ -6,8 +6,13 @@ defmodule Oli.Authoring.Clone do
   alias Oli.Authoring.{Collaborators, Locks}
   alias Oli.Repo
   alias Oli.Authoring.Course
+  alias Oli.Authoring.Course.Project
+  alias Oli.Authoring.Authors.AuthorProject
 
-  def clone_project(project_slug, author) do
+  def clone_project(project_slug, author, opts \\ []) do
+    new_project_title_suffix =
+      if opts[:author_in_project_title], do: " <#{author.email}>", else: " Copy"
+
     Repo.transaction(fn ->
       with {:ok, base_project} <-
              Course.get_project_by_slug(project_slug) |> Repo.preload(:family) |> trap_nil(),
@@ -18,7 +23,7 @@ defmodule Oli.Authoring.Clone do
              }),
            {:ok, cloned_project} <-
              Course.create_project(%{
-               title: base_project.title <> " Copy",
+               title: base_project.title <> new_project_title_suffix,
                version: "1.0.0",
                family_id: cloned_family.id,
                project_id: base_project.id
@@ -73,5 +78,32 @@ defmodule Oli.Authoring.Clone do
     """
 
     Repo.query!(query, [cloned_project_id, base_project_id])
+  end
+
+  @doc """
+  Returns the existing clones from a parent project that an author might have.
+  """
+  def existing_clones(project_slug, author) do
+    from(
+      project in Project,
+      join: p in Project,
+      on: project.id == p.project_id,
+      join: ap in AuthorProject,
+      on:
+        p.id ==
+          ap.project_id and ap.author_id == ^author.id,
+      where: project.slug == ^project_slug and p.status == :active,
+      select: p
+    )
+    |> Repo.all()
+  end
+
+  @doc """
+  Returns true if the given author already is a collaborator on a project that was cloned from the
+  project specified by the given project slug.
+  """
+  def already_has_clone?(project_slug, author) do
+    existing_clones(project_slug, author)
+    |> Enum.count() > 0
   end
 end

--- a/lib/oli/authoring/course/project.ex
+++ b/lib/oli/authoring/course/project.ex
@@ -12,6 +12,7 @@ defmodule Oli.Authoring.Course.Project do
     field :version, :string
     field :visibility, Ecto.Enum, values: [:authors, :selected, :global], default: :authors
     field :status, Ecto.Enum, values: [:active, :deleted], default: :active
+    field :allow_duplication, :boolean, default: false
 
     belongs_to :parent_project, Oli.Authoring.Course.Project, foreign_key: :project_id
     belongs_to :family, Oli.Authoring.Course.Family
@@ -47,7 +48,8 @@ defmodule Oli.Authoring.Course.Project do
       :family_id,
       :project_id,
       :visibility,
-      :status
+      :status,
+      :allow_duplication
     ])
     |> validate_required([:title, :version, :family_id])
     |> Slug.update_never("projects")

--- a/lib/oli_web/controllers/cognito_controller.ex
+++ b/lib/oli_web/controllers/cognito_controller.ex
@@ -2,9 +2,10 @@ defmodule OliWeb.CognitoController do
   use OliWeb, :controller
 
   import OliWeb.ViewHelpers, only: [redirect_with_error: 3]
+  import Oli.Utils
 
   alias Oli.{Repo, Sections, Accounts}
-  alias Oli.Authoring.Course
+  alias Oli.Authoring.{Clone, Course}
   alias Oli.Authoring.Course.Project
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.Section
@@ -60,6 +61,59 @@ defmodule OliWeb.CognitoController do
     redirect_with_error(conn, get_error_url(params), "Missing parameters")
   end
 
+  def launch_clone(
+        conn,
+        %{
+          "cognito_id_token" => _jwt,
+          "error_url" => _error_url,
+          "community_id" => community_id
+        } = params
+      ) do
+    with anchor when not is_nil(anchor) <- fetch_product_or_project(params),
+         {:ok, author} <- Accounts.setup_sso_author(conn.assigns.claims, community_id) do
+      conn
+      |> use_pow_config(:author)
+      |> Pow.Plug.create(author)
+      |> clone_or_prompt(author, anchor, get_error_url(params))
+    else
+      nil ->
+        redirect_with_error(conn, get_error_url(params), "Invalid product or project")
+
+      {:error, %Ecto.Changeset{}} ->
+        redirect_with_error(conn, get_error_url(params), "Invalid parameters")
+    end
+  end
+
+  def launch_clone(conn, params) do
+    redirect_with_error(conn, get_error_url(params), "Missing parameters")
+  end
+
+  def prompt(conn, %{"project_slug" => project_slug}) do
+    author = conn.assigns.current_author
+    projects = Clone.existing_clones(project_slug, author)
+
+    render(conn, "index.html", projects: projects, project_slug: project_slug)
+  end
+
+  def clone(conn, %{"project_slug" => project_slug}) do
+    author = conn.assigns.current_author
+
+    case Course.get_project_by_slug(project_slug) do
+      %Project{allow_duplication: true} ->
+        clone_project(conn, project_slug, author, get_error_url(%{}))
+
+      %Project{} ->
+        redirect_with_error(conn, get_error_url(%{}), "This project does not allow duplication")
+
+      _ ->
+        redirect_with_error(conn, get_error_url(%{}), "Invalid product or project")
+    end
+  end
+
+  def clone(conn, params) do
+    redirect_with_error(conn, get_error_url(params), "Missing parameters")
+  end
+
   defp get_error_url(%{"error_url" => error_url}), do: error_url
   defp get_error_url(_params), do: "/unauthorized"
 
@@ -87,5 +141,29 @@ defmodule OliWeb.CognitoController do
 
   defp create_section_url(conn, %Section{} = product) do
     Routes.independent_sections_path(conn, :new, source_id: "product:#{product.id}")
+  end
+
+  defp clone_or_prompt(conn, _author, %Project{allow_duplication: false}, error_url),
+    do: redirect_with_error(conn, error_url, "This project does not allow duplication")
+
+  defp clone_or_prompt(conn, _author, %Section{} = _product, error_url),
+    do: redirect_with_error(conn, error_url, "This is not supported")
+
+  defp clone_or_prompt(conn, author, %Project{slug: project_slug}, error_url) do
+    if Clone.already_has_clone?(project_slug, author) do
+      redirect(conn, to: Routes.cognito_path(conn, :prompt, project_slug))
+    else
+      clone_project(conn, project_slug, author, error_url)
+    end
+  end
+
+  defp clone_project(conn, project_slug, author, error_url) do
+    case Clone.clone_project(project_slug, author, author_in_project_title: true) do
+      {:ok, dupe} ->
+        redirect(conn, to: Routes.project_path(conn, :overview, dupe.slug))
+
+      {:error, error} ->
+        redirect_with_error(conn, error_url, snake_case_to_friendly(error))
+    end
   end
 end

--- a/lib/oli_web/live/projects/visibility.ex
+++ b/lib/oli_web/live/projects/visibility.ex
@@ -30,6 +30,25 @@ defmodule OliWeb.Projects.VisibilityLive do
     ~L"""
     <div class="row py-5 border-bottom">
       <div class="col-md-4">
+        <h4>Allow Duplication</h4>
+        <div class="text-muted">Control whether other users can create duplicates of your projects for their own development.</div>
+      </div>
+      <div class="col-md-8">
+        <form phx-change="duplication" id="duplication_option">
+          <div class="form-check">
+            <%= label class: "form-check-label" do %>
+              <%= checkbox :duplication, :allow_duplication, id: "dupe_check", class: "form-check-input", checked: @project.allow_duplication %>
+              Allow duplication by non-collaborators
+            <% end %>
+          </div>
+        </form>
+        <div class="alert alert-info mt-5" role="alert">
+          <strong>Note:</strong> Edits made to duplicates created by other users will not affect your course project in any way.
+        </div>
+      </div>
+    </div>
+    <div class="row py-5 border-bottom">
+      <div class="col-md-4">
         <h4>Publishing Visibility</h4>
         <div class="text-muted">Control who can create course sections for this project once it is published.</div>
       </div>
@@ -236,6 +255,11 @@ defmodule OliWeb.Projects.VisibilityLive do
 
   def handle_event("option", %{"visibility" => %{"option" => option}}, socket) do
     {:ok, project} = Course.update_project(socket.assigns.project, %{visibility: option})
+    {:noreply, assign(socket, :project, project)}
+  end
+
+  def handle_event("duplication", %{"duplication" => %{"allow_duplication" => value}}, socket) do
+    {:ok, project} = Course.update_project(socket.assigns.project, %{allow_duplication: value})
     {:noreply, assign(socket, :project, project)}
   end
 

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -920,6 +920,26 @@ defmodule OliWeb.Router do
     get("/launch", CognitoController, :index)
     get("/launch/products/:product_slug", CognitoController, :launch)
     get("/launch/projects/:project_slug", CognitoController, :launch)
+
+    get("/launch_clone/products/:product_slug", CognitoController, :launch_clone,
+      as: :product_clone
+    )
+
+    get("/launch_clone/projects/:project_slug", CognitoController, :launch_clone,
+      as: :project_clone
+    )
+  end
+
+  scope "/cognito", OliWeb do
+    pipe_through([
+      :browser,
+      :authoring_protected,
+      :workspace,
+      :authoring
+    ])
+
+    get("/prompt/:project_slug", CognitoController, :prompt)
+    get("/clone/:project_slug", CognitoController, :clone)
   end
 
   # routes only accessible when load testing mode is enabled. These routes exist solely

--- a/lib/oli_web/templates/cognito/index.html.eex
+++ b/lib/oli_web/templates/cognito/index.html.eex
@@ -1,0 +1,18 @@
+<div>
+
+  <h3>Access Course Project</h3>
+
+  <p>You have already created one or more copies of this course.</p>
+
+  <p>Would you like to
+    <%= link "create another copy", to: Routes.cognito_path(@conn, :clone, @project_slug) %>
+    or access one of your existing copies?
+  </p>
+
+  <ul>
+    <%= for p <- @projects do %>
+      <li><%= link p.title, to: Routes.project_path(@conn, :overview, p.slug) %></li>
+    <% end %>
+  </ul>
+
+</div>

--- a/lib/oli_web/views/cognito_view.ex
+++ b/lib/oli_web/views/cognito_view.ex
@@ -1,0 +1,3 @@
+defmodule OliWeb.CognitoView do
+  use OliWeb, :view
+end

--- a/priv/repo/migrations/20220328192150_allow_projects_duplication.exs
+++ b/priv/repo/migrations/20220328192150_allow_projects_duplication.exs
@@ -1,0 +1,9 @@
+defmodule Oli.Repo.Migrations.AllowProjectsDuplication do
+  use Ecto.Migration
+
+  def change do
+    alter table(:projects) do
+      add :allow_duplication, :boolean, default: false, null: false
+    end
+  end
+end

--- a/test/oli/accounts_test.exs
+++ b/test/oli/accounts_test.exs
@@ -231,6 +231,41 @@ defmodule Oli.AccountsTest do
 
       refute Accounts.get_user_by(%{sub: "sub", email: "email"})
     end
+
+    test "setup_sso_author/2 creates author and user if do not exist and associates user to the given community" do
+      community = insert(:community)
+      fields = %{"sub" => "sub", "cognito:username" => "username", "email" => "email"}
+      {:ok, author} = Accounts.setup_sso_author(fields, community.id)
+
+      assert author.name == "username"
+      assert author.email == "email"
+
+      user = Accounts.get_user_by(%{email: "email"})
+      assert user.sub == "sub"
+      assert user.preferred_username == "username"
+      assert user.email == "email"
+      assert user.can_create_sections
+
+      assert %CommunityAccount{} =
+               Groups.get_community_account_by!(%{user_id: user.id, community_id: community.id})
+
+      assert user.author_id == author.id
+    end
+
+    test "setup_sso_author/2 links user with author when they have the same email" do
+      community = insert(:community)
+      user = insert(:user)
+      author = insert(:author, email: user.email)
+
+      fields = %{"sub" => user.sub, "cognito:username" => "username", "email" => user.email}
+      {:ok, returned_author} = Accounts.setup_sso_author(fields, community.id)
+
+      assert returned_author == author
+
+      returned_user = Accounts.get_user_by(%{email: user.email})
+      assert returned_user.email == user.email
+      assert returned_user.author_id == returned_author.id
+    end
   end
 
   describe "communities accounts" do

--- a/test/oli/clone_test.exs
+++ b/test/oli/clone_test.exs
@@ -34,6 +34,28 @@ defmodule Oli.CloneTest do
       )
     end
 
+    test "already_has_clone?/2 and existing_clones/2 works", %{
+      project: project,
+      author2: author2,
+      author: author
+    } do
+      assert Clone.already_has_clone?(project.slug, author2)
+      refute Clone.already_has_clone?(project.slug, author)
+
+      # Clone the project again for author2
+      Clone.clone_project(project.slug, author2)
+      assert Clone.already_has_clone?(project.slug, author2)
+      refute Clone.already_has_clone?(project.slug, author)
+
+      assert Clone.existing_clones(project.slug, author2) |> Enum.count() == 2
+
+      # Now clone it for the original author
+      {:ok, %{id: id}} = Clone.clone_project(project.slug, author)
+      assert Clone.already_has_clone?(project.slug, author)
+
+      assert [%{id: ^id}] = Clone.existing_clones(project.slug, author)
+    end
+
     test "clone_project/2 creates a new family", %{family: family, duplicated: duplicated} do
       assert %Family{} = duplicated.family
       assert family.title <> " Copy" == duplicated.family.title
@@ -96,6 +118,14 @@ defmodule Oli.CloneTest do
 
       assert Enum.count([head | tail]) == 3
       assert head.publication_id == cloned_publication.id
+    end
+
+    test "clone_project/2 creates a new project with the author email in the name when optional field is passed in",
+         %{project: project, author2: author2} do
+      {:ok, duplicated} =
+        Clone.clone_project(project.slug, author2, author_in_project_title: true)
+
+      assert project.title <> " <#{author2.email}>" == duplicated.title
     end
 
     test "clone_all_media_items/2 works", %{project: project, duplicated: duplicated} do

--- a/test/oli_web/controllers/cognito_controller_test.exs
+++ b/test/oli_web/controllers/cognito_controller_test.exs
@@ -5,14 +5,24 @@ defmodule OliWeb.CognitoControllerTest do
   import Mox
 
   alias Oli.{Accounts, Groups}
+  alias Oli.Authoring.{Clone, Course}
   alias Oli.Delivery.Sections
 
   setup do
     community = insert(:community, name: "Infiniscope")
     section = insert(:section, %{slug: "open_section", open_and_free: true})
     email = build(:user).email
+    author = insert(:author)
+    project = insert(:project, allow_duplication: true)
+    resource = insert(:resource)
+    revision = insert(:revision, resource: resource)
 
-    [community: community, section: section, email: email]
+    publication =
+      insert(:publication, project: project, root_resource_id: resource.id, published: nil)
+
+    insert(:published_resource, publication: publication, resource: resource, revision: revision)
+
+    [community: community, section: section, email: email, author: author, project: project]
   end
 
   describe "index" do
@@ -402,84 +412,308 @@ defmodule OliWeb.CognitoControllerTest do
              |> html_response(302) =~
                "<html><body>You are being <a href=\"https://www.example.com/lesson/34?error=Unable to verify credentials\">redirected</a>.</body></html>"
     end
+  end
 
-    defp mock_jwks_endpoint(url, jwk, :ok) do
-      fn ^url ->
-        {:ok,
-         %HTTPoison.Response{
-           status_code: 200,
-           body:
-             Jason.encode!(%{
-               keys: [
-                 jwk.pem
-                 |> JOSE.JWK.from_pem()
-                 |> JOSE.JWK.to_public()
-                 |> JOSE.JWK.to_map()
-                 |> (fn {_kty, public_jwk} -> public_jwk end).()
-                 |> Map.put("typ", jwk.typ)
-                 |> Map.put("alg", jwk.alg)
-                 |> Map.put("kid", jwk.kid)
-                 |> Map.put("use", "sig")
-               ]
-             })
-         }}
-      end
+  describe "launch_clone" do
+    test "allows a user to clone a project they do not already have cloned",
+         %{
+           conn: conn,
+           community: community,
+           email: email,
+           project: project
+         } do
+      {id_token, jwk, issuer} = generate_token(email)
+      jwks_url = issuer <> "/.well-known/jwks.json"
+
+      expect(Oli.Test.MockHTTP, :get, 2, mock_jwks_endpoint(jwks_url, jwk, :ok))
+
+      params =
+        community.id
+        |> valid_params(id_token)
+        |> Map.put("project_slug", project.slug)
+
+      assert conn
+             |> get(Routes.project_clone_path(conn, :launch_clone, project.slug, params))
+             |> html_response(302) =~
+               "<html><body>You are being <a href=\"/authoring/project"
+
+      # creates new author and links it with user
+      author = Accounts.get_author_by_email(email)
+      assert author
+      assert author.id == Accounts.get_user_by(%{email: email}).author_id
+
+      assert length(Clone.existing_clones(project.slug, author)) == 1
     end
 
-    defp mock_jwks_endpoint(url, _jwk, :error) do
-      fn ^url ->
-        {:ok, %HTTPoison.Response{status_code: 404, body: "jwks not present"}}
-      end
+    test "properly redirects to an intermediate page to prompt if they really want to clone again",
+         %{
+           conn: conn,
+           community: community,
+           author: author,
+           project: project
+         } do
+      {id_token, jwk, issuer} = generate_token(author.email)
+      jwks_url = issuer <> "/.well-known/jwks.json"
+
+      expect(Oli.Test.MockHTTP, :get, 2, mock_jwks_endpoint(jwks_url, jwk, :ok))
+
+      Clone.clone_project(project.slug, author)
+
+      params =
+        community.id
+        |> valid_params(id_token)
+        |> Map.put("project_slug", project.slug)
+
+      assert conn
+             |> get(Routes.project_clone_path(conn, :launch_clone, project.slug, params))
+             |> html_response(302) =~
+               "<html><body>You are being <a href=\"/cognito/prompt"
     end
 
-    defp generate_token(email, alg \\ "RS256") do
-      jwk = build(:sso_jwk, alg: alg)
-      signer = Joken.Signer.create(alg, %{"pem" => jwk.pem}, %{"kid" => jwk.kid})
-      claims = build_claims(email)
+    test "forbids a user with an authoring account to clone a project that does not allow duplication",
+         %{
+           conn: conn,
+           community: community,
+           author: author,
+           project: project
+         } do
+      {id_token, jwk, issuer} = generate_token(author.email)
+      jwks_url = issuer <> "/.well-known/jwks.json"
 
-      {:ok, claims} =
-        Joken.Config.default_claims()
-        |> Joken.generate_claims(claims)
+      expect(Oli.Test.MockHTTP, :get, 2, mock_jwks_endpoint(jwks_url, jwk, :ok))
 
-      {:ok, id_token, _claims} = Joken.encode_and_sign(claims, signer)
+      params =
+        community.id
+        |> valid_params(id_token)
+        |> Map.put("project_slug", project.slug)
 
-      {id_token, jwk, claims["iss"]}
+      Course.update_project(project, %{allow_duplication: false})
+
+      assert conn
+             |> get(Routes.project_clone_path(conn, :launch_clone, project.slug, params))
+             |> html_response(302) =~
+               "<html><body>You are being <a href=\"https://www.example.com/lesson/34?error=This project does not allow duplication"
     end
 
-    defp build_claims(email) do
-      %{
-        "at_hash" => UUID.uuid4(),
-        "sub" => "user999",
-        "email_verified" => true,
-        "iss" => "issuer",
-        "cognito:username" => "user999",
-        "name" => "tester user",
-        "origin_jti" => UUID.uuid4(),
-        "aud" => UUID.uuid4(),
-        "event_id" => UUID.uuid4(),
-        "token_use" => "id",
-        "auth_time" => 1_642_608_077,
-        "exp" => 1_642_611_677,
-        "iat" => 1_642_608_077,
-        "jti" => UUID.uuid4(),
-        "email" => email
-      }
+    test "forbids a user with an authoring account to clone a product",
+         %{
+           conn: conn,
+           community: community,
+           author: author,
+           section: section
+         } do
+      {id_token, jwk, issuer} = generate_token(author.email)
+      jwks_url = issuer <> "/.well-known/jwks.json"
+
+      expect(Oli.Test.MockHTTP, :get, 2, mock_jwks_endpoint(jwks_url, jwk, :ok))
+
+      params =
+        community.id
+        |> valid_params(id_token)
+        |> Map.put("product_slug", section.slug)
+
+      assert conn
+             |> get(Routes.product_clone_path(conn, :launch_clone, section.slug, params))
+             |> html_response(302) =~
+               "<html><body>You are being <a href=\"https://www.example.com/lesson/34?error=This is not supported"
     end
 
-    defp valid_params(community_id, id_token) do
-      %{
-        "community_id" => community_id,
-        "cognito_id_token" => id_token,
-        "error_url" => "https://www.example.com/lesson/34"
-      }
+    test "fails if the project does not exist given the supplied slug",
+         %{
+           conn: conn,
+           community: community,
+           author: author
+         } do
+      {id_token, jwk, issuer} = generate_token(author.email)
+      jwks_url = issuer <> "/.well-known/jwks.json"
+
+      expect(Oli.Test.MockHTTP, :get, 2, mock_jwks_endpoint(jwks_url, jwk, :ok))
+
+      params =
+        community.id
+        |> valid_params(id_token)
+        |> Map.put("project_slug", "this_project_slug_does_not_exist")
+
+      assert conn
+             |> get(
+               Routes.product_clone_path(
+                 conn,
+                 :launch_clone,
+                 "this_project_slug_does_not_exist",
+                 params
+               )
+             )
+             |> html_response(302) =~
+               "<html><body>You are being <a href=\"https://www.example.com/lesson/34?error=Invalid product or project"
     end
 
-    defp valid_index_params(community_id, id_token) do
-      %{
-        "community_id" => community_id,
-        "id_token" => id_token,
-        "error_url" => "https://www.example.com/lesson/34"
-      }
+    test "fails if there are missing parameters",
+         %{
+           conn: conn,
+           community: community,
+           author: author,
+           project: project
+         } do
+      {id_token, jwk, issuer} = generate_token(author.email)
+      jwks_url = issuer <> "/.well-known/jwks.json"
+
+      expect(Oli.Test.MockHTTP, :get, 2, mock_jwks_endpoint(jwks_url, jwk, :ok))
+
+      params =
+        community.id
+        |> valid_params(id_token)
+        |> Map.put("project_slug", project.slug)
+        |> Map.delete("error_url")
+
+      assert conn
+             |> get(Routes.product_clone_path(conn, :launch_clone, project.slug, params))
+             |> html_response(302) =~
+               "<html><body>You are being <a href=\"/unauthorized?error=Missing parameters"
     end
+  end
+
+  describe "clone" do
+    setup [:admin_conn]
+
+    test "allows a user to clone a project when it allows duplication",
+         %{
+           conn: conn,
+           project: project
+         } do
+      assert conn
+             |> get(Routes.cognito_path(conn, :clone, project.slug))
+             |> html_response(302) =~
+               "<html><body>You are being <a href=\"/authoring/project"
+    end
+
+    test "fails if the project does not allow duplication",
+         %{
+           conn: conn,
+           project: project
+         } do
+      Course.update_project(project, %{allow_duplication: false})
+
+      assert conn
+             |> get(Routes.cognito_path(conn, :clone, project.slug))
+             |> html_response(302) =~
+               "<html><body>You are being <a href=\"/unauthorized?error=This project does not allow duplication"
+    end
+
+    test "fails if the project does not exist given the supplied slug",
+         %{
+           conn: conn,
+           author: author
+         } do
+      {_id_token, jwk, issuer} = generate_token(author.email)
+      jwks_url = issuer <> "/.well-known/jwks.json"
+
+      expect(Oli.Test.MockHTTP, :get, 2, mock_jwks_endpoint(jwks_url, jwk, :ok))
+
+      assert conn
+             |> get(Routes.cognito_path(conn, :clone, "this_project_slug_does_not_exist"))
+             |> html_response(302) =~
+               "<html><body>You are being <a href=\"/unauthorized?error=Invalid product or project"
+    end
+  end
+
+  describe "prompt" do
+    setup [:admin_conn]
+
+    test "allows user to select between creating a new project copy and selecting an existing one",
+         %{
+           conn: conn,
+           project: project,
+           admin: admin
+         } do
+      {:ok, duplicated} = Clone.clone_project(project.slug, admin)
+
+      html =
+        conn
+        |> get(Routes.cognito_path(conn, :prompt, project.slug))
+        |> html_response(200)
+
+      assert html =~
+               "Would you like to\n<a href=\"/cognito/clone/#{project.slug}\">create another copy</a>"
+
+      assert html =~ "<a href=\"/authoring/project/#{duplicated.slug}\">#{duplicated.title}</a>"
+    end
+  end
+
+  defp mock_jwks_endpoint(url, jwk, :ok) do
+    fn ^url ->
+      {:ok,
+       %HTTPoison.Response{
+         status_code: 200,
+         body:
+           Jason.encode!(%{
+             keys: [
+               jwk.pem
+               |> JOSE.JWK.from_pem()
+               |> JOSE.JWK.to_public()
+               |> JOSE.JWK.to_map()
+               |> (fn {_kty, public_jwk} -> public_jwk end).()
+               |> Map.put("typ", jwk.typ)
+               |> Map.put("alg", jwk.alg)
+               |> Map.put("kid", jwk.kid)
+               |> Map.put("use", "sig")
+             ]
+           })
+       }}
+    end
+  end
+
+  defp mock_jwks_endpoint(url, _jwk, :error) do
+    fn ^url ->
+      {:ok, %HTTPoison.Response{status_code: 404, body: "jwks not present"}}
+    end
+  end
+
+  defp generate_token(email, alg \\ "RS256") do
+    jwk = build(:sso_jwk, alg: alg)
+    signer = Joken.Signer.create(alg, %{"pem" => jwk.pem}, %{"kid" => jwk.kid})
+    claims = build_claims(email)
+
+    {:ok, claims} =
+      Joken.Config.default_claims()
+      |> Joken.generate_claims(claims)
+
+    {:ok, id_token, _claims} = Joken.encode_and_sign(claims, signer)
+
+    {id_token, jwk, claims["iss"]}
+  end
+
+  defp build_claims(email) do
+    %{
+      "at_hash" => UUID.uuid4(),
+      "sub" => "user999",
+      "email_verified" => true,
+      "iss" => "issuer",
+      "cognito:username" => "user999",
+      "origin_jti" => UUID.uuid4(),
+      "aud" => UUID.uuid4(),
+      "event_id" => UUID.uuid4(),
+      "token_use" => "id",
+      "auth_time" => 1_642_608_077,
+      "exp" => 1_642_611_677,
+      "iat" => 1_642_608_077,
+      "jti" => UUID.uuid4(),
+      "email" => email
+    }
+  end
+
+  defp valid_params(community_id, id_token) do
+    %{
+      "community_id" => community_id,
+      "cognito_id_token" => id_token,
+      "error_url" => "https://www.example.com/lesson/34"
+    }
+  end
+
+  defp valid_index_params(community_id, id_token) do
+    %{
+      "community_id" => community_id,
+      "id_token" => id_token,
+      "error_url" => "https://www.example.com/lesson/34"
+    }
   end
 end

--- a/test/oli_web/live/project_visibility_test.exs
+++ b/test/oli_web/live/project_visibility_test.exs
@@ -75,6 +75,23 @@ defmodule OliWeb.ProjectVisibilityTest do
              |> element("#user_submit select")
              |> render() =~ author.email
     end
+
+    test "succesfully updates the allow duplication flag", %{
+      conn: conn,
+      project: project
+    } do
+      {:ok, view, _} =
+        live_isolated(conn, OliWeb.Projects.VisibilityLive,
+          session: %{"project_slug" => project.slug}
+        )
+
+      view
+      |> element("#duplication_option")
+      |> render_change(%{"duplication" => %{"allow_duplication" => true}})
+
+      updated_project = Course.get_project!(project.id)
+      assert updated_project.allow_duplication
+    end
   end
 
   defp setup_session(%{conn: conn}) do


### PR DESCRIPTION
This PR implements the core functionalities for the [MER-770 Infiniscope Post Launch epic](https://eliterate.atlassian.net/browse/MER-770), which includes:

- [MER-754](https://eliterate.atlassian.net/browse/MER-754): Portal user ability to make a project copy in Torus and log in with an author account.
- [MER-817](https://eliterate.atlassian.net/browse/MER-817): Allow authors control if their projects can be duplicated by non-collaborators.
- [MER-819](https://eliterate.atlassian.net/browse/MER-819): Guide portal instructors when they want to clone a project, to choose between an existing duplicate project or creating a new one.
