### PR TITLE
[BUG FIX] Fix popup content editing and image alt text rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Properly handle the case that a section invite link leads to an unavailable section
 - Fix empty hints showing up in delivery mode
 - Fix table styling when words overflow bounds
+- Fix popup content editing
+- Fix image alt text rendering
 
 ### Enhancements
 

--- a/assets/src/components/editing/elements/popup/PopupElement.tsx
+++ b/assets/src/components/editing/elements/popup/PopupElement.tsx
@@ -2,20 +2,55 @@ import { modalActions } from 'actions/modal';
 import { createButtonCommandDesc } from 'components/editing/elements/commands/commandFactories';
 import { EditorProps } from 'components/editing/elements/interfaces';
 import { PopupContentModal } from 'components/editing/elements/popup/PopupContentModal';
-import { InlineChromiumBugfix, onEditModel } from 'components/editing/elements/utils';
+import { InlineChromiumBugfix, updateModel } from 'components/editing/elements/utils';
 import { Toolbar } from 'components/editing/toolbar/Toolbar';
 import { HoverContainer } from 'components/editing/toolbar/HoverContainer';
 import * as ContentModel from 'data/content/model/elements/types';
 import React from 'react';
 import { CommandButton } from 'components/editing/toolbar/buttons/CommandButton';
 import { useCollapsedSelection } from 'data/content/utils';
+import { useSlate } from 'slate-react';
+
+const dismiss = () => window.oliDispatch(modalActions.dismiss());
+const display = (c: any) => window.oliDispatch(modalActions.display(c));
 
 interface Props extends EditorProps<ContentModel.Popup> {}
 export const PopupEditor = (props: Props) => {
+  const editor = useSlate();
+
   const collapsedSelection = useCollapsedSelection();
   const isOpen = React.useCallback(() => collapsedSelection, [collapsedSelection]);
 
-  const onEdit = (changes: Partial<ContentModel.Popup>) => onEditModel(props.model)(changes);
+  const onEdit = React.useCallback(
+    (changes: Partial<ContentModel.Popup>) => updateModel(editor, props.model, changes),
+    [props.model, editor],
+  );
+
+  const onDone = React.useCallback(
+    (changes: Partial<ContentModel.Popup>) => {
+      dismiss();
+      onEdit(changes);
+    },
+    [onEdit],
+  );
+
+  const onCancel = React.useCallback(() => {
+    dismiss();
+  }, []);
+
+  const execute = React.useCallback(
+    (_context, _editor, _params) => {
+      display(
+        <PopupContentModal
+          commandContext={props.commandContext}
+          model={props.model}
+          onDone={onDone}
+          onCancel={onCancel}
+        />,
+      );
+    },
+    [props.commandContext, props.model, onDone, onCancel],
+  );
 
   return (
     <HoverContainer
@@ -29,24 +64,7 @@ export const PopupEditor = (props: Props) => {
               description={createButtonCommandDesc({
                 icon: 'edit',
                 description: 'Edit content',
-                execute: (_context, _editor, _params) => {
-                  const dismiss = () => window.oliDispatch(modalActions.dismiss());
-                  const display = (c: any) => window.oliDispatch(modalActions.display(c));
-
-                  display(
-                    <PopupContentModal
-                      commandContext={props.commandContext}
-                      model={props.model}
-                      onDone={(changes) => {
-                        dismiss();
-                        onEdit(changes);
-                      }}
-                      onCancel={() => {
-                        dismiss();
-                      }}
-                    />,
-                  );
-                },
+                execute,
               })}
             />
           </Toolbar.Group>

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -67,7 +67,7 @@ defmodule Oli.Rendering.Content.Html do
   def img(%Context{} = _context, _, %{"src" => src} = attrs) do
     maybeAlt =
       case attrs do
-        %{"alt" => alt} -> " alt=#{escape_xml!(alt)}"
+        %{"alt" => alt} -> " alt=\"#{escape_xml!(alt)}\""
         _ -> ""
       end
 


### PR DESCRIPTION
The problem was calling a react hook to update the model from inside a modal.

When testing the other editors I noticed the image alt text did not display correctly.

Closes #2371