### PR TITLE
[BUGFIX] PMP-2592 JAN-1432 incorrect states containing any/all block combos are not triggering

### DIFF
--- a/assets/src/adaptivity/rules-engine.ts
+++ b/assets/src/adaptivity/rules-engine.ts
@@ -320,7 +320,7 @@ export const getReferencedKeysInConditions = (conditions: any) => {
       });
     }
     if (condition.any || condition.all) {
-      const childRefs = findReferencedActivitiesInConditions(condition.any || condition.all);
+      const childRefs = getReferencedKeysInConditions(condition.any || condition.all);
       childRefs.forEach((ref) => references.add(ref));
     }
   });


### PR DESCRIPTION
wrong recursion from copy pasta