### PR TITLE
[BUGFIX] AOPS-568 Cannot get the start point in the node at the path [16] because it has no start text nod

### DIFF
--- a/assets/src/components/content/SlateFixer.ts
+++ b/assets/src/components/content/SlateFixer.ts
@@ -1,0 +1,15 @@
+import { StructuredContent } from 'data/content/resource';
+import { clone } from 'utils/common';
+
+// recursively ensure that all children are not empty and at least have a {text: ''}
+export const slateFixer = (content: StructuredContent) => {
+  const result = clone(content);
+  if (result.children) {
+    if (result.children.length === 0) {
+      result.children = [{ text: '' }];
+    } else {
+      result.children = result.children.map(slateFixer);
+    }
+  }
+  return result;
+};

--- a/assets/src/components/content/StructuredContentEditor.tsx
+++ b/assets/src/components/content/StructuredContentEditor.tsx
@@ -1,10 +1,11 @@
+import { ErrorBoundary } from 'components/common/ErrorBoundary';
+import { Editor } from 'components/editing/editor/Editor';
+import { CommandDescription } from 'components/editing/elements/commands/interfaces';
+import { StructuredContent } from 'data/content/resource';
+import { ProjectSlug } from 'data/types';
 import React from 'react';
 import { Descendant } from 'slate';
-import { StructuredContent } from 'data/content/resource';
-import { Editor } from 'components/editing/editor/Editor';
-import { ProjectSlug } from 'data/types';
-import { ErrorBoundary } from 'components/common/ErrorBoundary';
-import { CommandDescription } from 'components/editing/elements/commands/interfaces';
+import { slateFixer } from './SlateFixer';
 
 export type StructuredContentEditor = {
   editMode: boolean; // Whether or not we can edit
@@ -23,13 +24,15 @@ export const StructuredContentEditor = (props: StructuredContentEditor) => {
     [props.content, props.onEdit],
   );
 
+  const [value, setValue] = React.useState(slateFixer(props.content));
+
   return (
     <ErrorBoundary>
       <Editor
         className="structured-content"
         commandContext={{ projectSlug: props.projectSlug }}
         editMode={props.editMode}
-        value={props.content.children}
+        value={value.children}
         onEdit={onEdit}
         toolbarInsertDescs={props.toolbarInsertDescs}
       />


### PR DESCRIPTION
fix content before passing to slate
it looked like an issue already was merged for this, but updating slate did not seem to fix it (we may already be on the updated minor version)
https://github.com/ianstormtaylor/slate/issues/3625
https://github.com/ianstormtaylor/slate/pull/4208

