### PR TITLE
Fixed issue with history mode checking request

### DIFF
--- a/assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx
+++ b/assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx
@@ -970,11 +970,11 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
           break;
 
         case JanusCAPIRequestTypes.SET_DATA_REQUEST:
-          handleSetData(data);
+          if (context !== contexts.REVIEW) handleSetData(data);
           break;
 
         case JanusCAPIRequestTypes.CHECK_REQUEST:
-          handleCheckRequest(data);
+          if (context !== contexts.REVIEW) handleCheckRequest(data);
           break;
 
         case JanusCAPIRequestTypes.RESIZE_PARENT_CONTAINER_REQUEST:


### PR DESCRIPTION
This fixes an issue where in history mode, moving forward in time made the app still think it was in the history, resulting in some components disabling when they shouldn't.