### PR TITLE
BUGFIX: Fix issue with question bank data overwriting other layers on select

### DIFF
--- a/assets/src/apps/authoring/components/PropertyEditor/PropertyEditor.tsx
+++ b/assets/src/apps/authoring/components/PropertyEditor/PropertyEditor.tsx
@@ -13,7 +13,7 @@ interface PropertyEditorProps {
   uiSchema: UiSchema;
   onChangeHandler: (changes: unknown) => void;
   value: unknown;
-  triggerOnChange?: boolean;
+  triggerOnChange?: boolean | string[];
 }
 
 const widgets: any = {
@@ -51,11 +51,14 @@ const PropertyEditor: React.FC<PropertyEditorProps> = ({
         const updatedData = e.formData;
         const changedProp = diff(formData, updatedData);
         const changedPropType = findDiffType(changedProp);
+        const shouldTriggerChange =
+          typeof triggerOnChange === 'boolean'
+            ? triggerOnChange
+            : Object.keys(changedProp).some((v) => triggerOnChange.indexOf(v) > -1);
 
         setFormData(updatedData);
-        if (triggerOnChange || changedPropType === 'boolean' || changedPropType === 'undefined') {
+        if (shouldTriggerChange || changedPropType === 'boolean') {
           // because 'id' is used to maintain selection, it MUST be onBlur or else bad things happen
-          // undefined means it is an item in an array that has been deleted
           if (updatedData.id === formData.id) {
             /* console.log('ONCHANGE P EDITOR TRIGGERED', {
               e,

--- a/assets/src/apps/authoring/components/RightMenu/RightMenu.tsx
+++ b/assets/src/apps/authoring/components/RightMenu/RightMenu.tsx
@@ -24,10 +24,7 @@ import {
 } from '../../../delivery/store/features/groups/selectors/deck';
 import { selectCurrentGroup } from '../../../delivery/store/features/groups/slice';
 import { saveActivity } from '../../store/activities/actions/saveActivity';
-import {
-  updateSequenceItem,
-  updateSequenceItemFromActivity,
-} from '../../store/groups/layouts/deck/actions/updateSequenceItemFromActivity';
+import { updateSequenceItem } from '../../store/groups/layouts/deck/actions/updateSequenceItemFromActivity';
 import { savePage } from '../../store/page/actions/savePage';
 import { selectState as selectPageState, updatePage } from '../../store/page/slice';
 import { selectCurrentSelection, setCurrentSelection } from '../../store/parts/slice';
@@ -434,6 +431,7 @@ const RightMenu: React.FC<any> = () => {
             schema={lessonSchema as JSONSchema7}
             uiSchema={lessonUiSchema}
             value={lessonData}
+            triggerOnChange={['CustomLogic']}
             onChangeHandler={lessonPropertyChangeHandler}
           />
         </div>


### PR DESCRIPTION
This change fixes an issue in authoring where a user would select a question bank, then another layer, and the properties of the question bank would overwrite the data of the other layer they selected.