### PR TITLE
[FEATURE] [MER-818] Move between accounts

### DIFF
--- a/assets/styles/authoring/layout/workspace.scss
+++ b/assets/styles/authoring/layout/workspace.scss
@@ -23,7 +23,7 @@ $workspace-sidebar-width: 65px;
     box-shadow: 0 2px 4px 0 rgba($black, 0.15);
 
     .header-bar {
-      height: 40px;
+      height: 2.5em;
       background-color: $workspace-logo-bg;
     }
 

--- a/assets/styles/authoring/layout/workspace.scss
+++ b/assets/styles/authoring/layout/workspace.scss
@@ -23,7 +23,7 @@ $workspace-sidebar-width: 65px;
     box-shadow: 0 2px 4px 0 rgba($black, 0.15);
 
     .header-bar {
-      height: 38px;
+      height: 40px;
       background-color: $workspace-logo-bg;
     }
 
@@ -128,7 +128,6 @@ $workspace-sidebar-width: 65px;
     padding-top: 2px;
     font-size: 0.9em;
     font-weight: 600;
-    margin-right: 10px;
   }
 
   .custom-breadcrumb {

--- a/assets/styles/common/user.scss
+++ b/assets/styles/common/user.scss
@@ -1,13 +1,21 @@
 nav .nav-item a.user {
   color: inherit;
   display: flex;
-}
 
-nav .nav-item a.user .role {
-  color: $gray-600;
-  font-size: 0.8em;
-  font-weight: 600;
-  text-transform: uppercase;
+  .role {
+    color: $gray-600;
+    font-size: 0.8em;
+    font-weight: 600;
+    text-transform: uppercase;
+
+    &.admin-color {
+      color: #2ecc71;
+    }
+
+    &.author-color {
+      color: #3498db;
+    }
+  }
 }
 
 nav .nav-item a.user .user-icon,

--- a/lib/oli_web/templates/layout/_account_header.html.eex
+++ b/lib/oli_web/templates/layout/_account_header.html.eex
@@ -1,6 +1,6 @@
 <%= if Map.has_key?(@conn.assigns, :breadcrumbs) and length(@breadcrumbs) > 0 do %>
 
-<div class="workspace-header-container d-flex flex-column w-100 overflow-hidden">
+<div class="workspace-header-container d-flex flex-column w-100">
 
 
   <div class="header-bar d-flex align-items-center justify-content-between px-3">
@@ -19,8 +19,9 @@
   <div class="workspace-header d-flex justify-content-between">
 
     <h3><%= Map.get(@conn.assigns, :title, "") %></h3>
-    <div class="page-controls">
-      <%= link "Sign out", to: Routes.authoring_session_path(@conn, :signout, type: :author), method: :delete, id: "signout-link", class: "btn btn-sm btn-primary" %>
+    <div class='d-flex flex-nowrap align-items-center'>
+      <%= render OliWeb.SharedView, "_help_button.html", conn: @conn %>
+      <%= account_link @conn %>
     </div>
 
   </div>

--- a/lib/oli_web/templates/layout/_account_header.html.eex
+++ b/lib/oli_web/templates/layout/_account_header.html.eex
@@ -7,7 +7,7 @@
     <h3 class="title mr-4" title='This is the page title'><%= hd(Enum.reverse(@breadcrumbs)).short_title %></h3>
     <div class='d-flex flex-nowrap align-items-center'>
       <%= render OliWeb.SharedView, "_help_button.html", conn: @conn %>
-      <%= account_link @conn %>
+      <%= account_dropdown @conn %>
     </div>
   </div>
   <nav class="breadcrumb-bar d-flex align-items-center px-3">
@@ -21,7 +21,7 @@
     <h3><%= Map.get(@conn.assigns, :title, "") %></h3>
     <div class='d-flex flex-nowrap align-items-center'>
       <%= render OliWeb.SharedView, "_help_button.html", conn: @conn %>
-      <%= account_link @conn %>
+      <%= account_dropdown @conn %>
     </div>
 
   </div>

--- a/lib/oli_web/templates/layout/_author_account_dropdown.html.eex
+++ b/lib/oli_web/templates/layout/_author_account_dropdown.html.eex
@@ -3,7 +3,7 @@
     <a class="user nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
       <div class="block lg:inline-block lg:mt-0 text-grey-darkest no-underline hover:underline mr-4">
         <div class="username"><%= @current_author.name %></div>
-        <div class="role text-right" style="color: <%= author_role_color @current_author %>;"><%= author_role_text @current_author %></div>
+        <div class="role text-right <%= author_role_color @current_author %>"><%= author_role_text @current_author %></div>
       </div>
       <div class="user-icon"><%= author_icon(assigns) %></div>
     </a>

--- a/lib/oli_web/templates/layout/_author_account_dropdown.html.eex
+++ b/lib/oli_web/templates/layout/_author_account_dropdown.html.eex
@@ -1,0 +1,28 @@
+<nav class="navbar p-0 small">
+  <div class="nav-item dropdown form-inline my-2 my-lg-0">
+    <a class="user nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <div class="block lg:inline-block lg:mt-0 text-grey-darkest no-underline hover:underline mr-4">
+        <div class="username"><%= @current_author.name %></div>
+        <div class="role text-right" style="color: <%= author_role_color @current_author %>;"><%= author_role_text @current_author %></div>
+      </div>
+      <div class="user-icon"><%= author_icon(assigns) %></div>
+    </a>
+
+    <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
+      <%= if author_account_linked?(@current_author) do %>
+        <h6 class="dropdown-header">Linked: <%= author_user_associated_email(@current_author) %></h6>
+        <a class="dropdown-item" href="<%= Routes.delivery_path(@conn, :open_and_free_index) %>" target="_blank">Go to My Courses<i class="fas fa-external-link-alt float-right" style="margin-top: 2px"></i></a>
+        <div class="dropdown-divider"></div>
+      <% end %>
+
+      <%= link "Edit Account", to: Routes.live_path(@conn, OliWeb.Workspace.AccountDetailsLive), class: "dropdown-item btn" %>
+      <div class="dropdown-item no-hover">
+        Dark Mode <div id="theme-toggle"></div>
+        <script>window.component.mount('DarkModeSelector', document.getElementById('theme-toggle'), {showLabels: false})</script>
+      </div>
+      <div class="dropdown-divider"></div>
+
+      <%= link "Sign out", to: Routes.session_path(@conn, :signout, type: :author), method: :delete, id: "signout-link", class: "dropdown-item btn" %>
+    </div>
+  </div>
+</nav>

--- a/lib/oli_web/templates/layout/_author_account_dropdown.html.eex
+++ b/lib/oli_web/templates/layout/_author_account_dropdown.html.eex
@@ -1,3 +1,5 @@
+<% user = author_linked_account(@current_author) %>
+
 <nav class="navbar p-0 small">
   <div class="nav-item dropdown form-inline my-2 my-lg-0">
     <a class="user nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -9,9 +11,11 @@
     </a>
 
     <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
-      <%= if author_account_linked?(@current_author) do %>
-        <h6 class="dropdown-header">Linked: <%= author_user_associated_email(@current_author) %></h6>
-        <a class="dropdown-item" href="<%= Routes.delivery_path(@conn, :open_and_free_index) %>" target="_blank">Go to My Courses<i class="fas fa-external-link-alt float-right" style="margin-top: 2px"></i></a>
+      <%= if not is_nil(user) do %>
+        <h6 class="dropdown-header">Linked: <%= user.email %></h6>
+        <%= if user_is_independent_learner?(user) or Sections.is_independent_instructor?(user) do %>
+          <a class="dropdown-item" href="<%= Routes.delivery_path(@conn, :open_and_free_index) %>" target="_blank">Go to My Courses<i class="fas fa-external-link-alt float-right" style="margin-top: 2px"></i></a>
+        <% end %>
         <div class="dropdown-divider"></div>
       <% end %>
 

--- a/lib/oli_web/templates/layout/_project_header.html.eex
+++ b/lib/oli_web/templates/layout/_project_header.html.eex
@@ -1,4 +1,4 @@
-<div class="workspace-header-container d-flex flex-column w-100 overflow-hidden">
+<div class="workspace-header-container d-flex flex-column w-100">
   <div class="header-bar d-flex align-items-center justify-content-between px-3">
     <h3 class="title mr-4" title='This is the page title'><%= hd(Enum.reverse(@breadcrumbs)).short_title %></h3>
     <div class='d-flex flex-nowrap align-items-center'>

--- a/lib/oli_web/templates/layout/_project_header.html.eex
+++ b/lib/oli_web/templates/layout/_project_header.html.eex
@@ -3,7 +3,7 @@
     <h3 class="title mr-4" title='This is the page title'><%= hd(Enum.reverse(@breadcrumbs)).short_title %></h3>
     <div class='d-flex flex-nowrap align-items-center'>
       <%= render OliWeb.SharedView, "_help_button.html", conn: @conn %>
-      <%= account_link @conn %>
+      <%= account_dropdown @conn %>
     </div>
   </div>
   <nav class="breadcrumb-bar d-flex align-items-center px-3">

--- a/lib/oli_web/templates/layout/_user_account_dropdown.html.eex
+++ b/lib/oli_web/templates/layout/_user_account_dropdown.html.eex
@@ -1,4 +1,4 @@
-<div class="nav-item dropdown form-inline my-2 my-lg-0">
+<div class="nav-item dropdown form-inline my-2 my-lg-0 small">
   <a class="user nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     <div class="block lg:inline-block lg:mt-0 text-grey-darkest no-underline hover:underline mr-4">
       <div class="username">
@@ -31,49 +31,33 @@
     </script>
   <% else %>
     <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
-      <%= if user_role_is_student(@conn, @current_user) or Sections.is_independent_instructor?(@current_user) do %>
-        <%= if user_is_independent_learner?(@current_user) do %>
-          <%= if Sections.is_independent_instructor?(@current_user) do %>
-            <%= if account_linked?(@current_user) do %>
-              <h6 class="dropdown-header">Linked: <%= @current_user.author.email %></h6>
-              <a class="dropdown-item" href="<%= Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.ProjectsLive) %>" target="_blank">Go to Course Author <i class="fas fa-external-link-alt float-right" style="margin-top: 2px"></i></a>
-              <a class="dropdown-item" href="<%= Routes.delivery_path(@conn, :link_account) %>" target="_blank">Link a different account</a>
-              <div class="dropdown-divider"></div>
-              <%= link "Sign out", to: Routes.session_path(@conn, :signout, type: :user), method: :delete, id: "signout-link", class: "dropdown-item btn" %>
-            <% else %>
-              <a class="dropdown-item" href="<%= Routes.delivery_path(@conn, :link_account) %>" target="_blank">Link Existing Account</a>
-            <% end %>
-          <% end %>
-          <%= link "Edit Account", to: Routes.pow_registration_path(@conn, :edit), class: "dropdown-item btn" %>
-          <%= link "My Courses", to: Routes.delivery_path(@conn, :open_and_free_index), class: "dropdown-item btn" %>
-          <div class="dropdown-divider"></div>
-          <div class="dropdown-item no-hover">
-            Dark Mode <div id="theme-toggle"></div>
-            <script>
-            window.component.mount('DarkModeSelector', document.getElementById('theme-toggle'), {showLabels: false})
-            </script>
-          </div>
-          <div class="dropdown-divider"></div>
-        <% end %>
-        <%= link "Sign out", to: Routes.session_path(@conn, :signout, type: :user), method: :delete, id: "signout-link", class: "dropdown-item btn" %>
-      <% else %>
+
+      <%= if (not user_role_is_student(@conn, @current_user)) or Sections.is_independent_instructor?(@current_user) do %>
         <%= if account_linked?(@current_user) do %>
           <h6 class="dropdown-header">Linked: <%= @current_user.author.email %></h6>
           <a class="dropdown-item" href="<%= Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.ProjectsLive) %>" target="_blank">Go to Course Author <i class="fas fa-external-link-alt float-right" style="margin-top: 2px"></i></a>
           <a class="dropdown-item" href="<%= Routes.delivery_path(@conn, :link_account) %>" target="_blank">Link a different account</a>
-          <div class="dropdown-divider"></div>
-          <div class="dropdown-item no-hover">
-            Dark Mode <div id="theme-toggle"></div>
-            <script>
-            window.component.mount('DarkModeSelector', document.getElementById('theme-toggle'), {showLabels: false})
-            </script>
-          </div>
-          <div class="dropdown-divider"></div>
-          <%= link "Sign out", to: Routes.session_path(@conn, :signout, type: :user), method: :delete, id: "signout-link", class: "dropdown-item btn" %>
         <% else %>
           <a class="dropdown-item" href="<%= Routes.delivery_path(@conn, :link_account) %>" target="_blank">Link Existing Account</a>
         <% end %>
+        <div class="dropdown-divider"></div>
       <% end %>
+
+      <%= if user_is_independent_learner?(@current_user) do %>
+        <%= link "Edit Account", to: Routes.pow_registration_path(@conn, :edit), class: "dropdown-item btn" %>
+        <div class="dropdown-item no-hover">
+          Dark Mode <div id="theme-toggle"></div>
+          <script>window.component.mount('DarkModeSelector', document.getElementById('theme-toggle'), {showLabels: false})</script>
+        </div>
+        <div class="dropdown-divider"></div>
+      <% end %>
+
+      <%= if user_is_independent_learner?(@current_user) or Sections.is_independent_instructor?(@current_user) do %>
+        <%= link "My Courses", to: Routes.delivery_path(@conn, :open_and_free_index), class: "dropdown-item btn" %>
+        <div class="dropdown-divider"></div>
+      <% end %>
+
+      <%= link "Sign out", to: Routes.session_path(@conn, :signout, type: :user), method: :delete, id: "signout-link", class: "dropdown-item btn" %>
     </div>
   <% end %>
 </div>

--- a/lib/oli_web/templates/layout/_workspace_header.html.eex
+++ b/lib/oli_web/templates/layout/_workspace_header.html.eex
@@ -1,6 +1,6 @@
 <div class="workspace-header d-flex justify-content-between">
   <h3><%= @title %></h3>
-  <div>
+  <div class='d-flex flex-nowrap align-items-center'>
     <%= render OliWeb.SharedView, "_help_button.html", conn: @conn %>
     <%= account_link @conn %>
   </div>

--- a/lib/oli_web/templates/layout/_workspace_header.html.eex
+++ b/lib/oli_web/templates/layout/_workspace_header.html.eex
@@ -2,6 +2,6 @@
   <h3><%= @title %></h3>
   <div class='d-flex flex-nowrap align-items-center'>
     <%= render OliWeb.SharedView, "_help_button.html", conn: @conn %>
-    <%= account_link @conn %>
+    <%= account_dropdown @conn %>
   </div>
 </div>

--- a/lib/oli_web/views/authoring_view.ex
+++ b/lib/oli_web/views/authoring_view.ex
@@ -1,0 +1,51 @@
+defmodule OliWeb.AuthoringView do
+  use OliWeb, :view
+  use Phoenix.Component
+
+  alias Oli.Accounts
+  alias Oli.Accounts.{Author, User}
+
+  def author_role_text(author) do
+    if Accounts.is_admin?(author),
+      do: "Admin",
+      else: "Author"
+  end
+
+  def author_role_color(author) do
+    if Accounts.is_admin?(author),
+      do: "#2ecc71",
+      else: "#3498db"
+  end
+
+  def author_account_linked?(%Author{} = author),
+    do: Accounts.get_user_by(author_id: author.id) != nil
+
+  def author_user_associated_email(author) do
+    %User{email: email} = Accounts.get_user_by(author_id: author.id)
+    email
+  end
+
+  def author_icon(%{current_autor: current_autor} = assigns) do
+    case current_autor.picture do
+      nil ->
+        author_icon(%{})
+
+      picture ->
+        ~H"""
+        <div class="user-icon">
+          <img src={picture} class="rounded-circle" />
+        </div>
+        """
+    end
+  end
+
+  def author_icon(assigns) do
+    ~H"""
+    <div class="user-icon">
+      <div class="user-img rounded-circle">
+        <span class="material-icons text-secondary">account_circle</span>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/oli_web/views/authoring_view.ex
+++ b/lib/oli_web/views/authoring_view.ex
@@ -3,7 +3,7 @@ defmodule OliWeb.AuthoringView do
   use Phoenix.Component
 
   alias Oli.Accounts
-  alias Oli.Accounts.{Author, User}
+  alias Oli.Accounts.Author
 
   def author_role_text(author) do
     if Accounts.is_admin?(author),

--- a/lib/oli_web/views/authoring_view.ex
+++ b/lib/oli_web/views/authoring_view.ex
@@ -13,8 +13,8 @@ defmodule OliWeb.AuthoringView do
 
   def author_role_color(author) do
     if Accounts.is_admin?(author),
-      do: "#2ecc71",
-      else: "#3498db"
+      do: "admin-color",
+      else: "author-color"
   end
 
   def author_account_linked?(%Author{} = author),
@@ -25,8 +25,8 @@ defmodule OliWeb.AuthoringView do
     email
   end
 
-  def author_icon(%{current_autor: current_autor} = assigns) do
-    case current_autor.picture do
+  def author_icon(%{current_author: current_author} = assigns) do
+    case current_author.picture do
       nil ->
         author_icon(%{})
 

--- a/lib/oli_web/views/authoring_view.ex
+++ b/lib/oli_web/views/authoring_view.ex
@@ -17,13 +17,8 @@ defmodule OliWeb.AuthoringView do
       else: "author-color"
   end
 
-  def author_account_linked?(%Author{} = author),
-    do: Accounts.get_user_by(author_id: author.id) != nil
-
-  def author_user_associated_email(author) do
-    %User{email: email} = Accounts.get_user_by(author_id: author.id)
-    email
-  end
+  def author_linked_account(%Author{} = author),
+    do: Accounts.get_user_by(author_id: author.id)
 
   def author_icon(%{current_author: current_author} = assigns) do
     case current_author.picture do

--- a/lib/oli_web/views/layout_view.ex
+++ b/lib/oli_web/views/layout_view.ex
@@ -14,10 +14,9 @@ defmodule OliWeb.LayoutView do
 
   import OliWeb.AuthoringView,
     only: [
-      author_account_linked?: 1,
+      author_linked_account: 1,
       author_role_text: 1,
       author_role_color: 1,
-      author_user_associated_email: 1,
       author_icon: 1
     ]
 

--- a/lib/oli_web/views/layout_view.ex
+++ b/lib/oli_web/views/layout_view.ex
@@ -119,9 +119,8 @@ defmodule OliWeb.LayoutView do
     end
   end
 
-  def account_link(%{:assigns => assigns} = conn) do
-    render(__MODULE__, "_author_account_dropdown.html", conn: conn, current_author: assigns.current_author)
-  end
+  def account_dropdown(%{assigns: %{current_author: current_author}} = conn),
+    do: render(__MODULE__, "_author_account_dropdown.html", conn: conn, current_author: current_author)
 
   def render_layout(layout, assigns, do: content) do
     render(layout, Map.put(assigns, :inner_layout, content))

--- a/lib/oli_web/views/layout_view.ex
+++ b/lib/oli_web/views/layout_view.ex
@@ -12,6 +12,15 @@ defmodule OliWeb.LayoutView do
       logo_link_path: 1
     ]
 
+  import OliWeb.AuthoringView,
+    only: [
+      author_account_linked?: 1,
+      author_role_text: 1,
+      author_role_color: 1,
+      author_user_associated_email: 1,
+      author_icon: 1
+    ]
+
   import Oli.Branding
 
   alias Oli.Accounts
@@ -111,41 +120,7 @@ defmodule OliWeb.LayoutView do
   end
 
   def account_link(%{:assigns => assigns} = conn) do
-    current_author = assigns.current_author
-
-    initials =
-      case current_author.name do
-        nil ->
-          "?"
-
-        name ->
-          name = String.trim(name)
-
-          cond do
-            # After trimming, if a name contains a space that space can only be between two other non-space characters
-            # so we guarantee that two initials can be extracted
-            String.contains?(name, " ") ->
-              name
-              |> String.split(~r{\s+})
-              |> Enum.map(&String.at(&1, 0))
-              |> Enum.take(2)
-
-            # If after trimming there is no space, but there is text, we simply take the first character as a singular
-            String.length(name) > 0 ->
-              String.at(name, 0)
-
-            # If after trimming, there is the empty string, we show the question mark
-            true ->
-              "?"
-          end
-      end
-
-    icon = raw("<div class=\"user-initials-icon\">#{initials}</div>")
-
-    link([icon],
-      to: Routes.live_path(conn, OliWeb.Workspace.AccountDetailsLive),
-      class: "#{active_class(active_or_nil(assigns), :account)} account-link"
-    )
+    render(__MODULE__, "_author_account_dropdown.html", conn: conn, current_author: assigns.current_author)
   end
 
   def render_layout(layout, assigns, do: content) do

--- a/test/oli_web/views/layout_view_test.exs
+++ b/test/oli_web/views/layout_view_test.exs
@@ -10,7 +10,7 @@ defmodule OliWeb.LayoutViewTest do
       author = insert(:author)
 
       assert AuthoringView.author_role_text(author) == "Author"
-      assert AuthoringView.author_role_color(author) == "#3498db"
+      assert AuthoringView.author_role_color(author) == "author-color"
       refute AuthoringView.author_account_linked?(author)
     end
 
@@ -18,7 +18,7 @@ defmodule OliWeb.LayoutViewTest do
       author = insert(:author, system_role_id: Oli.Accounts.SystemRole.role_id().admin)
 
       assert AuthoringView.author_role_text(author) == "Admin"
-      assert AuthoringView.author_role_color(author) == "#2ecc71"
+      assert AuthoringView.author_role_color(author) == "admin-color"
       refute AuthoringView.author_account_linked?(author)
     end
 

--- a/test/oli_web/views/layout_view_test.exs
+++ b/test/oli_web/views/layout_view_test.exs
@@ -1,3 +1,33 @@
 defmodule OliWeb.LayoutViewTest do
   use OliWeb.ConnCase, async: true
+
+  import Oli.Factory
+
+  alias OliWeb.AuthoringView
+
+  describe "authoring view" do
+    test "renders author info" do
+      author = insert(:author)
+
+      assert AuthoringView.author_role_text(author) == "Author"
+      assert AuthoringView.author_role_color(author) == "#3498db"
+      refute AuthoringView.author_account_linked?(author)
+    end
+
+    test "renders admin info" do
+      author = insert(:author, system_role_id: Oli.Accounts.SystemRole.role_id().admin)
+
+      assert AuthoringView.author_role_text(author) == "Admin"
+      assert AuthoringView.author_role_color(author) == "#2ecc71"
+      refute AuthoringView.author_account_linked?(author)
+    end
+
+    test "renders account linked info" do
+      author = insert(:author)
+      user_associated = insert(:user, author: author)
+
+      assert AuthoringView.author_account_linked?(author)
+      assert AuthoringView.author_user_associated_email(author) == user_associated.email
+    end
+  end
 end

--- a/test/oli_web/views/layout_view_test.exs
+++ b/test/oli_web/views/layout_view_test.exs
@@ -11,7 +11,7 @@ defmodule OliWeb.LayoutViewTest do
 
       assert AuthoringView.author_role_text(author) == "Author"
       assert AuthoringView.author_role_color(author) == "author-color"
-      refute AuthoringView.author_account_linked?(author)
+      refute AuthoringView.author_linked_account(author)
     end
 
     test "renders admin info" do
@@ -19,15 +19,16 @@ defmodule OliWeb.LayoutViewTest do
 
       assert AuthoringView.author_role_text(author) == "Admin"
       assert AuthoringView.author_role_color(author) == "admin-color"
-      refute AuthoringView.author_account_linked?(author)
+      refute AuthoringView.author_linked_account(author)
     end
 
     test "renders account linked info" do
       author = insert(:author)
       user_associated = insert(:user, author: author)
 
-      assert AuthoringView.author_account_linked?(author)
-      assert AuthoringView.author_user_associated_email(author) == user_associated.email
+      user = AuthoringView.author_linked_account(author)
+      assert user
+      assert user.id == user_associated.id
     end
   end
 end


### PR DESCRIPTION
[MER-818](https://eliterate.atlassian.net/browse/MER-818)

### Description
This PR adds a new dropdown in the authoring side for consistency. Having a signout and a way to jump into the linked user account.

Also take the opportunity to refactor the user dropdown to make it less repetitive code and clearer. Based on the logic, I ended with:
- Signout is always shown
- A user can edit its account if is independent learner 
  - Independent instructors are **not** marked as independent learners by default
- A user can see the My Courses if is independent learner or independent instructor
- A user can see the link account if it's not a student or is independent instructor
  - That last part because a user could be potentially both?

^^  Appreciate you let me know your thoughts and if I missed something or you think something is not taken into account.


**NOTE: This PR will be marked as "Ready for Review" and can be merged once it has 2 approvals.**