### PR TITLE
[MER-1022] Fix ordering issue in sections test

### DIFF
--- a/test/oli/sections_test.exs
+++ b/test/oli/sections_test.exs
@@ -55,8 +55,6 @@ defmodule Oli.SectionsTest do
 
       enrollments = Sections.list_enrollments(section.slug)
 
-      assert length(enrollments) == 3
-
       assert enrollments |> Enum.map(& &1.user_id) |> Enum.sort() ==
                [user1, user2, user3] |> Enum.map(& &1.id) |> Enum.sort()
 

--- a/test/oli/sections_test.exs
+++ b/test/oli/sections_test.exs
@@ -53,17 +53,14 @@ defmodule Oli.SectionsTest do
       Sections.enroll(user2.id, section.id, [ContextRoles.get_role(:context_learner)])
       Sections.enroll(user3.id, section.id, [ContextRoles.get_role(:context_learner)])
 
-      assert length(Sections.list_enrollments(section.slug)) == 3
+      enrollments = Sections.list_enrollments(section.slug)
 
-      [one, two, three] = Sections.list_enrollments(section.slug)
+      assert length(enrollments) == 3
 
-      assert one.user_id == user1.id
-      assert two.user_id == user2.id
-      assert three.user_id == user3.id
+      assert enrollments |> Enum.map(& &1.user_id) |> Enum.sort() ==
+               [user1, user2, user3] |> Enum.map(& &1.id) |> Enum.sort()
 
-      assert one.section_id == section.id
-      assert two.section_id == section.id
-      assert three.section_id == section.id
+      assert enrollments |> Enum.map(& &1.section_id) |> Enum.uniq() == [section.id]
 
       assert ContextRoles.has_role?(
                user1,


### PR DESCRIPTION
[MER-1022](https://eliterate.atlassian.net/browse/MER-1022)

Fix flaky test in `sections_test.exs` due to an ordering issue when retrieving enrollments for a given section.