### PR TITLE
[FEATURE] [MER-938] Improve admin sections view

### DIFF
--- a/assets/styles/delivery/layout/delivery.scss
+++ b/assets/styles/delivery/layout/delivery.scss
@@ -74,10 +74,3 @@ main.container {
     padding-right: 1em;
   }
 }
-
-@media (max-width: 992px) {
-  .filter-opts {
-    flex-direction: column;
-    gap: 1em;
-  }
-}

--- a/assets/styles/global.scss
+++ b/assets/styles/global.scss
@@ -18,3 +18,10 @@ html.delivery.dark {
     transition: all 0.5s ease-in-out;
   }
 }
+
+@media (max-width: 992px) {
+  .filter-opts {
+    flex-direction: column;
+    gap: 1em;
+  }
+}

--- a/lib/oli/delivery/sections/browse.ex
+++ b/lib/oli/delivery/sections/browse.ex
@@ -57,7 +57,7 @@ defmodule Oli.Delivery.Sections.Browse do
       end
 
     filter_by_date_active =
-      if options.active_date do
+      if options.active_today do
         today = DateTime.utc_now()
         dynamic([s, _], s.start_date <= ^today and s.end_date >= ^today)
       else
@@ -88,7 +88,7 @@ defmodule Oli.Delivery.Sections.Browse do
 
     query =
       Section
-      |> join(:left, [s], e in Enrollment, as: :enrollment, on: s.id == e.section_id)
+      |> join(:left, [s], e in Enrollment, on: s.id == e.section_id)
       |> join(:left, [s, _], i in Oli.Institutions.Institution, on: s.institution_id == i.id)
       |> join(:left, [s, _], proj in Oli.Authoring.Course.Project, on: s.base_project_id == proj.id)
       |> join(:left, [s, _], prod in Section, on: s.blueprint_id == prod.id)
@@ -104,7 +104,7 @@ defmodule Oli.Delivery.Sections.Browse do
       |> offset(^offset)
       |> preload([:institution, :base_project, :blueprint])
       |> group_by([s, _, i, proj, prod, u], [s.id, i.name, proj.title, prod.title, u.name])
-      |> select_merge([p, e, i, proj, _, u], %{
+      |> select_merge([_, e, i, _, _, u], %{
         enrollments_count: count(e.id),
         total_count: fragment("count(*) OVER()"),
         institution_name: i.name,

--- a/lib/oli/delivery/sections/browse.ex
+++ b/lib/oli/delivery/sections/browse.ex
@@ -5,87 +5,92 @@ defmodule Oli.Delivery.Sections.Browse do
   alias Oli.Delivery.Sections.{Section, Enrollment, BrowseOptions}
 
   @doc """
-  Paged, sorted, filterable queries for course sections. Joins the institution
-  and counts the number of enrollments.
+    Paged, sorted, filterable queries for course sections. Joins the institution,
+    the base product or project and counts the number of enrollments.
   """
   def browse_sections(
         %Paging{limit: limit, offset: offset},
         %Sorting{direction: direction, field: field},
         %BrowseOptions{} = options
       ) do
-    filter_by_status =
-      if options.show_deleted do
-        true
-      else
-        dynamic([s, _], s.status == :active)
-      end
-
+    # text search
     filter_by_text =
       if options.text_search == "" or is_nil(options.text_search) do
         true
       else
         dynamic(
-          [s, _],
-          ilike(s.title, ^"%#{options.text_search}%")
+          [s, _, i, proj, prod],
+          ilike(s.title, ^"%#{options.text_search}%") or
+          ilike(i.name, ^"%#{options.text_search}%") or
+          ilike(proj.title, ^"%#{options.text_search}%") or
+          ilike(prod.title, ^"%#{options.text_search}%")
         )
       end
 
-    filter_by_institution =
-      if is_nil(options.institution_id) do
-        true
+    # filters
+    filter_by_status =
+      if options.filter_status,
+        do: dynamic([s, _], s.status == ^options.filter_status),
+        else: true
+
+    filter_by_type =
+      if options.filter_type do
+        is_open = options.filter_type == :open
+        dynamic([s, _], s.open_and_free == ^is_open)
       else
-        dynamic(
-          [s, _],
-          s.institution_id == ^options.institution_id
-        )
+        true
       end
+
+    filter_by_date_active =
+      if options.active_date do
+        today = DateTime.utc_now()
+        dynamic([s, _], s.start_date <= ^today and s.end_date >= ^today)
+      else
+        true
+      end
+
+    # relationship filters
+    filter_by_institution =
+      if is_nil(options.institution_id),
+        do: true,
+        else: dynamic([s, _], s.institution_id == ^options.institution_id)
 
     filter_by_blueprint =
-      if is_nil(options.blueprint_id) do
-        true
-      else
-        dynamic(
-          [s, _],
-          s.blueprint_id == ^options.blueprint_id
-        )
-      end
-
-    filter_by_active_only =
-      if !options.active_only do
-        true
-      else
-        today = DateTime.utc_now()
-
-        dynamic(
-          [s, _],
-          s.start_date <= ^today and s.end_date >= ^today
-        )
-      end
+      if is_nil(options.blueprint_id),
+        do: true,
+        else: dynamic([s, _], s.blueprint_id == ^options.blueprint_id)
 
     query =
       Section
       |> join(:left, [s], e in Enrollment, on: s.id == e.section_id)
       |> join(:left, [s, _], i in Oli.Institutions.Institution, on: s.institution_id == i.id)
+      |> join(:left, [s, _], proj in Oli.Authoring.Course.Project, on: s.base_project_id == proj.id)
+      |> join(:left, [s, _], prod in Section, on: s.blueprint_id == prod.id)
       |> where([s, _], s.type == :enrollable)
       |> where(^filter_by_status)
+      |> where(^filter_by_type)
+      |> where(^filter_by_date_active)
       |> where(^filter_by_text)
       |> where(^filter_by_institution)
       |> where(^filter_by_blueprint)
-      |> where(^filter_by_active_only)
       |> limit(^limit)
       |> offset(^offset)
-      |> preload(:institution)
-      |> group_by([s, _, i], [s.id, i.name])
-      |> select_merge([p, e, i], %{
+      |> preload([:institution, :base_project, :blueprint])
+      |> group_by([s, _, i, proj, prod], [s.id, i.name, proj.title, prod.title])
+      |> select_merge([p, e, i, proj], %{
         enrollments_count: count(e.id),
         total_count: fragment("count(*) OVER()"),
         institution_name: i.name
       })
 
+    # sorting
     query =
       case field do
         :enrollments_count -> order_by(query, [_, e], {^direction, count(e.id)})
         :institution -> order_by(query, [_, _, i], {^direction, i.name})
+        :requires_payment -> order_by(query, [s, _, _], {^direction, s.amount})
+        :type -> order_by(query, [s, _, _], {^direction, s.open_and_free})
+        :base -> order_by(query, [_, _, _, proj, prod], [{^direction, prod.title}, {^direction, proj.title}])
         _ -> order_by(query, [p, _], {^direction, field(p, ^field)})
       end
 

--- a/lib/oli/delivery/sections/browse_options.ex
+++ b/lib/oli/delivery/sections/browse_options.ex
@@ -4,26 +4,29 @@ defmodule Oli.Delivery.Sections.BrowseOptions do
   """
 
   @enforce_keys [
-    :show_deleted,
     :institution_id,
     :blueprint_id,
-    :active_only,
-    :text_search
+    :text_search,
+    :active_date,
+    :filter_status,
+    :filter_type
   ]
 
   defstruct [
-    :show_deleted,
     :institution_id,
     :blueprint_id,
-    :active_only,
-    :text_search
+    :text_search,
+    :active_date,
+    :filter_status,
+    :filter_type
   ]
 
   @type t() :: %__MODULE__{
-          show_deleted: boolean(),
           institution_id: integer(),
           blueprint_id: integer(),
-          active_only: boolean(),
-          text_search: String.t()
+          text_search: String.t(),
+          active_date: boolean(),
+          filter_status: atom(),
+          filter_type: atom()
         }
 end

--- a/lib/oli/delivery/sections/browse_options.ex
+++ b/lib/oli/delivery/sections/browse_options.ex
@@ -7,7 +7,7 @@ defmodule Oli.Delivery.Sections.BrowseOptions do
     :institution_id,
     :blueprint_id,
     :text_search,
-    :active_date,
+    :active_today,
     :filter_status,
     :filter_type
   ]
@@ -16,7 +16,7 @@ defmodule Oli.Delivery.Sections.BrowseOptions do
     :institution_id,
     :blueprint_id,
     :text_search,
-    :active_date,
+    :active_today,
     :filter_status,
     :filter_type
   ]
@@ -25,7 +25,7 @@ defmodule Oli.Delivery.Sections.BrowseOptions do
           institution_id: integer(),
           blueprint_id: integer(),
           text_search: String.t(),
-          active_date: boolean(),
+          active_today: boolean(),
           filter_status: atom(),
           filter_type: atom()
         }

--- a/lib/oli/delivery/sections/section.ex
+++ b/lib/oli/delivery/sections/section.ex
@@ -89,6 +89,7 @@ defmodule Oli.Delivery.Sections.Section do
     field(:enrollments_count, :integer, virtual: true)
     field(:total_count, :integer, virtual: true)
     field(:institution_name, :string, virtual: true)
+    field(:instructor_name, :string, virtual: true)
 
     many_to_many(:communities, Oli.Groups.Community, join_through: Oli.Groups.CommunityVisibility)
 

--- a/lib/oli_web/common/params.ex
+++ b/lib/oli_web/common/params.ex
@@ -44,8 +44,9 @@ defmodule OliWeb.Common.Params do
         default_value
 
       value ->
+        value = String.to_existing_atom(value)
         case MapSet.new(valid) |> MapSet.member?(value) do
-          true -> String.to_existing_atom(value)
+          true -> value
           _ -> default_value
         end
     end

--- a/lib/oli_web/live/common/listing.ex
+++ b/lib/oli_web/live/common/listing.ex
@@ -18,24 +18,35 @@ defmodule OliWeb.Common.Listing do
 
   def render(assigns) do
     ~F"""
-    <div class="pb-5">
-      {#if @filter != ""}
-      <strong>Results filtered on &quot;{@filter}&quot;</strong>
-      {/if}
-      {#if @total_count > 0}
-        <Paging id="header_paging" total_count={@total_count} offset={@offset} limit={@limit} click={@page_change}/>
-        {#if @cards_view}
-          <CardListing model={@table_model} selected={@selected} context={@context}/>
+      <div class="pb-5">
+        {#if @filter != ""}
+          <strong>Results filtered on &quot;{@filter}&quot;</strong>
+        {/if}
+
+        {#if @total_count > 0 and @total_count > @limit}
+          <Paging id="header_paging" total_count={@total_count} offset={@offset} limit={@limit} click={@page_change}/>
+          {render_table(assigns)}
+          {#if @show_bottom_paging}
+            <Paging id="footer_paging" total_count={@total_count} offset={@offset} limit={@limit} click={@page_change}/>
+          {/if}
+        {#elseif @total_count > 0}
+          <div>Showing all results ({@total_count} total)</div>
+          <br>
+          {render_table(assigns)}
         {#else}
-          <Table model={@table_model} sort={@sort} additional_table_class={@additional_table_class} context={@context}/>
+          <p>None exist</p>
         {/if}
-        {#if @show_bottom_paging}
-          <Paging id="footer_paging" total_count={@total_count} offset={@offset} limit={@limit} click={@page_change}/>
-        {/if}
-      {#else}
-        <p>None exist</p>
-      {/if}
       </div>
+    """
+  end
+
+  defp render_table(assigns) do
+    ~F"""
+      {#if @cards_view}
+        <CardListing model={@table_model} selected={@selected} context={@context}/>
+      {#else}
+        <Table model={@table_model} sort={@sort} additional_table_class={@additional_table_class} context={@context}/>
+      {/if}
     """
   end
 end

--- a/lib/oli_web/live/common/paged_table.ex
+++ b/lib/oli_web/live/common/paged_table.ex
@@ -21,12 +21,16 @@ defmodule OliWeb.Common.PagedTable do
           <strong>Results filtered on &quot;{@filter}&quot;</strong>
         {/if}
 
-        {#if @total_count > 0}
+        {#if @total_count > 0 and @total_count > @limit}
           <Paging id="header_paging" total_count={@total_count} offset={@offset} limit={@limit} click={@page_change}/>
           {render_table(assigns)}
           {#if @show_bottom_paging}
             <Paging id="footer_paging" total_count={@total_count} offset={@offset} limit={@limit} click={@page_change}/>
           {/if}
+        {#elseif @total_count > 0}
+          <div>Showing all results ({@total_count} total)</div>
+          <br>
+          {render_table(assigns)}
         {#else}
           <p>None exist</p>
         {/if}

--- a/lib/oli_web/live/common/paged_table.ex
+++ b/lib/oli_web/live/common/paged_table.ex
@@ -12,23 +12,24 @@ defmodule OliWeb.Common.PagedTable do
   prop sort, :event, default: "paged_table_sort"
   prop page_change, :event, default: "paged_table_page_change"
   prop selection_change, :event, default: "paged_table_selection_change"
+  prop show_bottom_paging, :boolean, default: true
 
   def render(assigns) do
     ~F"""
-    <div>
-      {#if @filter != ""}
-      <strong>Results filtered on &quot;{@filter}&quot;</strong>
-      {/if}
-      {#if @total_count > 0 and @total_count < @limit}
-        <div>Showing all results ({@total_count} total)</div>
-        {render_table(assigns)}
-      {#elseif @total_count > 0}
-        <Paging id="header_paging" total_count={@total_count} offset={@offset} limit={@limit} click={@page_change}/>
-        {render_table(assigns)}
-        <Paging id="footer_paging" total_count={@total_count} offset={@offset} limit={@limit} click={@page_change}/>
-      {#else}
-        <p>None exist</p>
-      {/if}
+      <div>
+        {#if @filter != ""}
+          <strong>Results filtered on &quot;{@filter}&quot;</strong>
+        {/if}
+
+        {#if @total_count > 0}
+          <Paging id="header_paging" total_count={@total_count} offset={@offset} limit={@limit} click={@page_change}/>
+          {render_table(assigns)}
+          {#if @show_bottom_paging}
+            <Paging id="footer_paging" total_count={@total_count} offset={@offset} limit={@limit} click={@page_change}/>
+          {/if}
+        {#else}
+          <p>None exist</p>
+        {/if}
       </div>
     """
   end

--- a/lib/oli_web/live/projects/projects_live.ex
+++ b/lib/oli_web/live/projects/projects_live.ex
@@ -205,7 +205,7 @@ defmodule OliWeb.Projects.ProjectsLive do
           <%= live_component PagedTable, page_change: "paged_table_page_change", sort: "paged_table_sort",
             total_count: @total_count, filter: @text_search,
             selection_change: nil, allow_selection: false,
-            limit: @limit, offset: @offset, table_model: @table_model %>
+            limit: @limit, offset: @offset, table_model: @table_model, show_bottom_paging: true %>
         </div>
       </div>
     </div>

--- a/lib/oli_web/live/sections/sections_view.ex
+++ b/lib/oli_web/live/sections/sections_view.ex
@@ -16,7 +16,7 @@ defmodule OliWeb.Sections.SectionsView do
     institution_id: nil,
     blueprint_id: nil,
     text_search: "",
-    active_date: false,
+    active_today: false,
     filter_status: nil,
     filter_type: nil,
   }
@@ -77,7 +77,7 @@ defmodule OliWeb.Sections.SectionsView do
     offset = get_int_param(params, "offset", 0)
     options = %BrowseOptions{
       text_search: get_param(params, "text_search", ""),
-      active_date: get_boolean_param(params, "active_date", false),
+      active_today: get_boolean_param(params, "active_today", false),
       filter_status: get_atom_param(params, "filter_status", Ecto.Enum.values(Section, :status), nil),
       filter_type: get_atom_param(params, "filter_type", @type_opts, nil),
       # This view is currently for all institutions and all root products
@@ -120,7 +120,7 @@ defmodule OliWeb.Sections.SectionsView do
           <TextSearch id="text-search" text={@options.text_search}/>
 
           <:extra_opts>
-            <Check checked={@options.active_date} click="active_date">Only active by date</Check>
+            <Check checked={@options.active_today} click="active_today">Active today (between start/end dates)</Check>
 
             <form :on-change="change_type" class="d-flex">
               <select name="type" id="select_type" class="custom-select custom-select mr-2">
@@ -155,8 +155,8 @@ defmodule OliWeb.Sections.SectionsView do
     """
   end
 
-  def handle_event("active_date", _, socket),
-    do: patch_with(socket, %{active_date: !socket.assigns.options.active_date})
+  def handle_event("active_today", _, socket),
+    do: patch_with(socket, %{active_today: !socket.assigns.options.active_today})
 
   def handle_event("change_status", %{"status" => status}, socket),
     do: patch_with(socket, %{filter_status: status})
@@ -188,7 +188,7 @@ defmodule OliWeb.Sections.SectionsView do
                sort_order: socket.assigns.table_model.sort_order,
                offset: socket.assigns.offset,
                text_search: socket.assigns.options.text_search,
-               active_date: socket.assigns.options.active_date,
+               active_today: socket.assigns.options.active_today,
                filter_status: socket.assigns.options.filter_status,
                filter_type: socket.assigns.options.filter_type
              },

--- a/lib/oli_web/live/sections/sections_view.ex
+++ b/lib/oli_web/live/sections/sections_view.ex
@@ -1,32 +1,31 @@
 defmodule OliWeb.Sections.SectionsView do
   use Surface.LiveView, layout: {OliWeb.LayoutView, "live.html"}
 
-  alias Oli.Repo.{Paging, Sorting}
-  alias OliWeb.Common.{TextSearch, PagedTable, Breadcrumb, Check}
-  alias OliWeb.Common.SessionContext
-  alias Oli.Delivery.Sections.{Browse, BrowseOptions}
-  alias OliWeb.Common.Table.SortableTableModel
-  alias OliWeb.Router.Helpers, as: Routes
-  alias OliWeb.Sections.SectionsTableModel
-
-  import OliWeb.DelegatedEvents
   import OliWeb.Common.Params
+  import OliWeb.DelegatedEvents
+
+  alias Oli.Repo.{Paging, Sorting}
+  alias Oli.Delivery.Sections.{Browse, BrowseOptions, Section}
+  alias OliWeb.Common.{Breadcrumb, Check, FilterBox, PagedTable, TextSearch, SessionContext}
+  alias OliWeb.Common.Table.SortableTableModel
+  alias OliWeb.Sections.SectionsTableModel
+  alias OliWeb.Router.Helpers, as: Routes
 
   @limit 25
   @default_options %BrowseOptions{
-    show_deleted: false,
     institution_id: nil,
     blueprint_id: nil,
-    active_only: false,
-    text_search: ""
+    text_search: "",
+    active_date: false,
+    filter_status: nil,
+    filter_type: nil,
   }
+  @type_opts [:open, :lms]
 
   prop author, :any
   data breadcrumbs, :any
   data title, :string, default: "All Course Sections"
-
   data sections, :list, default: []
-
   data tabel_model, :struct
   data total_count, :integer, default: 0
   data offset, :integer, default: 0
@@ -38,7 +37,7 @@ defmodule OliWeb.Sections.SectionsView do
     |> breadcrumb()
   end
 
-  def breadcrumb(previous) do
+  defp breadcrumb(previous) do
     previous ++
       [
         Breadcrumb.new(%{
@@ -59,7 +58,6 @@ defmodule OliWeb.Sections.SectionsView do
       )
 
     total_count = determine_total(sections)
-
     {:ok, table_model} = SectionsTableModel.new(context, sections)
 
     {:ok,
@@ -74,26 +72,14 @@ defmodule OliWeb.Sections.SectionsView do
      )}
   end
 
-  defp determine_total(projects) do
-    case(projects) do
-      [] -> 0
-      [hd | _] -> hd.total_count
-    end
-  end
-
   def handle_params(params, _, socket) do
-    table_model =
-      SortableTableModel.update_from_params(
-        socket.assigns.table_model,
-        params
-      )
-
+    table_model = SortableTableModel.update_from_params(socket.assigns.table_model, params)
     offset = get_int_param(params, "offset", 0)
-
     options = %BrowseOptions{
       text_search: get_param(params, "text_search", ""),
-      show_deleted: get_boolean_param(params, "show_deleted", false),
-      active_only: get_boolean_param(params, "active_only", false),
+      active_date: get_boolean_param(params, "active_date", false),
+      filter_status: get_atom_param(params, "filter_status", Ecto.Enum.values(Section, :status), nil),
+      filter_type: get_atom_param(params, "filter_type", @type_opts, nil),
       # This view is currently for all institutions and all root products
       institution_id: nil,
       blueprint_id: nil
@@ -120,28 +106,73 @@ defmodule OliWeb.Sections.SectionsView do
   end
 
   def render(assigns) do
+    # can't use @ notation inside sigil
+    type_opts = @type_opts
+
     ~F"""
-    <div>
+      <div>
+        <FilterBox
+          card_header_text="Browse Course Sections"
+          card_body_text=""
+          table_model={@table_model}
+          show_sort={false}
+          show_more_opts={true}>
+          <TextSearch id="text-search" text={@options.text_search}/>
 
-      <Check class="mr-4" checked={@options.show_deleted} click="show_deleted">Show deleted/archived sections</Check>
-      <Check checked={@options.active_only} click="active_only">Show only active sections</Check>
+          <:extra_opts>
+            <Check checked={@options.active_date} click="active_date">Only active by date</Check>
 
-      <div class="mb-3"/>
+            <form :on-change="change_type" class="d-flex">
+              <select name="type" id="select_type" class="custom-select custom-select mr-2">
+                <option value="" selected>Type</option>
+                {#for type_opt <- type_opts}
+                  <option value={type_opt} selected={@options.filter_type == type_opt}>{Phoenix.Naming.humanize(type_opt)}</option>
+                {/for}
+              </select>
+            </form>
 
-      <TextSearch id="text-search" text={@options.text_search} />
+            <form :on-change="change_status" class="d-flex">
+              <select name="status" id="select_status" class="custom-select custom-select mr-2">
+                <option value="" selected>Status</option>
+                {#for status_opt <- Ecto.Enum.values(Section, :status)}
+                  <option value={status_opt} selected={@options.filter_status == status_opt}>{Phoenix.Naming.humanize(status_opt)}</option>
+                {/for}
+              </select>
+            </form>
+          </:extra_opts>
+        </FilterBox>
 
-      <div class="mb-3"/>
+        <div class="mb-5"/>
 
-      <PagedTable
-        filter={@options.text_search}
-        table_model={@table_model}
-        total_count={@total_count}
-        offset={@offset}
-        limit={@limit}/>
-
-    </div>
-
+        <PagedTable
+          filter={@options.text_search}
+          table_model={@table_model}
+          total_count={@total_count}
+          offset={@offset}
+          limit={@limit}
+          show_bottom_paging={false}/>
+      </div>
     """
+  end
+
+  def handle_event("active_date", _, socket),
+    do: patch_with(socket, %{active_date: !socket.assigns.options.active_date})
+
+  def handle_event("change_status", %{"status" => status}, socket),
+    do: patch_with(socket, %{filter_status: status})
+
+  def handle_event("change_type", %{"type" => type}, socket),
+    do: patch_with(socket, %{filter_type: type})
+
+  def handle_event(event, params, socket),
+    do: delegate_to({event, params, socket, &__MODULE__.patch_with/2},
+        [&TextSearch.handle_delegated/4, &PagedTable.handle_delegated/4])
+
+  defp determine_total(projects) do
+    case projects do
+      [] -> 0
+      [hd | _] -> hd.total_count
+    end
   end
 
   def patch_with(socket, changes) do
@@ -157,27 +188,14 @@ defmodule OliWeb.Sections.SectionsView do
                sort_order: socket.assigns.table_model.sort_order,
                offset: socket.assigns.offset,
                text_search: socket.assigns.options.text_search,
-               show_deleted: socket.assigns.options.show_deleted,
-               active_only: socket.assigns.options.active_only
+               active_date: socket.assigns.options.active_date,
+               filter_status: socket.assigns.options.filter_status,
+               filter_type: socket.assigns.options.filter_type
              },
              changes
            )
          ),
        replace: true
      )}
-  end
-
-  def handle_event("show_deleted", _, socket),
-    do: patch_with(socket, %{show_deleted: !socket.assigns.options.show_deleted})
-
-  def handle_event("active_only", _, socket),
-    do: patch_with(socket, %{active_only: !socket.assigns.options.active_only})
-
-  def handle_event(event, params, socket) do
-    {event, params, socket, &__MODULE__.patch_with/2}
-    |> delegate_to([
-      &TextSearch.handle_delegated/4,
-      &PagedTable.handle_delegated/4
-    ])
   end
 end

--- a/lib/oli_web/live/sections/table_model.ex
+++ b/lib/oli_web/live/sections/table_model.ex
@@ -90,7 +90,7 @@ defmodule OliWeb.Sections.SectionsTableModel do
   end
 
   def custom_render(_assigns, section, %ColumnSpec{name: :institution}),
-    do: if section.open_and_free, do: "", else: section.institution.name
+    do: if section.open_and_free or is_nil(section.institution), do: "", else: section.institution.name
 
   def custom_render(_assigns, section, %ColumnSpec{name: :status}),
     do: Phoenix.Naming.humanize(section.status)

--- a/lib/oli_web/live/sections/table_model.ex
+++ b/lib/oli_web/live/sections/table_model.ex
@@ -1,8 +1,12 @@
 defmodule OliWeb.Sections.SectionsTableModel do
+  use Surface.LiveComponent
+
+  alias Oli.Delivery.Sections
+  alias Oli.Delivery.Sections.EnrollmentBrowseOptions
+  alias Oli.Repo.{Paging, Sorting}
   alias OliWeb.Common.SessionContext
   alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
   alias OliWeb.Router.Helpers, as: Routes
-  use Surface.LiveComponent
 
   def new(%SessionContext{} = context, sections) do
     SortableTableModel.new(
@@ -16,8 +20,7 @@ defmodule OliWeb.Sections.SectionsTableModel do
         %ColumnSpec{
           name: :type,
           label: "Type",
-          render_fn: &__MODULE__.custom_render/3,
-          sort_fn: &__MODULE__.custom_sort/2
+          render_fn: &__MODULE__.custom_render/3
         },
         %ColumnSpec{
           name: :enrollments_count,
@@ -25,9 +28,8 @@ defmodule OliWeb.Sections.SectionsTableModel do
         },
         %ColumnSpec{
           name: :requires_payment,
-          label: "Paid",
-          render_fn: &__MODULE__.custom_render/3,
-          sort_fn: &__MODULE__.custom_sort/2
+          label: "Cost",
+          render_fn: &__MODULE__.custom_render/3
         },
         %ColumnSpec{
           name: :start_date,
@@ -42,10 +44,24 @@ defmodule OliWeb.Sections.SectionsTableModel do
           sort_fn: &OliWeb.Common.Table.Common.sort_date/2
         },
         %ColumnSpec{
+          name: :status,
+          label: "Status",
+          render_fn: &__MODULE__.custom_render/3
+        },
+        %ColumnSpec{
+          name: :base,
+          label: "Base",
+          render_fn: &__MODULE__.custom_render/3
+        },
+        %ColumnSpec{
+          name: :instructor,
+          label: "Instructor",
+          render_fn: &__MODULE__.custom_render/3
+        },
+        %ColumnSpec{
           name: :institution,
           label: "Institution",
-          render_fn: &__MODULE__.custom_render/3,
-          sort_fn: &__MODULE__.custom_sort/2
+          render_fn: &__MODULE__.custom_render/3
         }
       ],
       event_suffix: "",
@@ -56,49 +72,14 @@ defmodule OliWeb.Sections.SectionsTableModel do
     )
   end
 
-  def custom_sort(direction, %ColumnSpec{name: name}) do
-    {fn r ->
-       case name do
-         :type ->
-           if r.open_and_free do
-             "Open"
-           else
-             "LMS"
-           end
-
-         :requires_payment ->
-           if r.requires_payment do
-             case Money.to_string(r.amount) do
-               {:ok, m} -> m
-               _ -> "Yes"
-             end
-           else
-             "None"
-           end
-
-         :institution ->
-           if is_nil(r.institution) do
-             ""
-           else
-             r.institution.name
-           end
-       end
-     end, direction}
-  end
-
   def custom_render(assigns, section, %ColumnSpec{name: :title}) do
     ~F"""
-    <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.OverviewView, section.slug)}>{section.title}</a>
+      <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.OverviewView, section.slug)}>{section.title}</a>
     """
   end
 
-  def custom_render(_assigns, section, %ColumnSpec{name: :type}) do
-    if section.open_and_free do
-      "Open"
-    else
-      "LMS"
-    end
-  end
+  def custom_render(_assigns, section, %ColumnSpec{name: :type}),
+    do: if section.open_and_free, do: "Open", else: "LMS"
 
   def custom_render(_assigns, section, %ColumnSpec{name: :requires_payment}) do
     if section.requires_payment do
@@ -111,17 +92,40 @@ defmodule OliWeb.Sections.SectionsTableModel do
     end
   end
 
-  def custom_render(_assigns, section, %ColumnSpec{name: :institution}) do
-    if section.open_and_free do
-      ""
+  def custom_render(_assigns, section, %ColumnSpec{name: :institution}),
+    do: if section.open_and_free, do: "", else: section.institution.name
+
+  def custom_render(_assigns, section, %ColumnSpec{name: :status}),
+    do: Phoenix.Naming.humanize(section.status)
+
+  def custom_render(assigns, section, %ColumnSpec{name: :base}) do
+    if section.blueprint do
+      route_path = Routes.live_path(OliWeb.Endpoint, OliWeb.Products.DetailsView, section.blueprint.slug)
+      SortableTableModel.render_link_column(assigns, section.blueprint.title, route_path)
     else
-      section.institution.name
+      route_path = Routes.project_path(OliWeb.Endpoint, :overview, section.base_project.slug)
+      SortableTableModel.render_link_column(assigns, section.base_project.title, route_path)
     end
+  end
+
+  def custom_render(_assigns, section, %ColumnSpec{name: :instructor}) do
+    Sections.browse_enrollments(
+      section,
+      %Paging{offset: 0, limit: 1},
+      %Sorting{direction: :asc, field: :inserted_at},
+      %EnrollmentBrowseOptions{
+        is_student: false,
+        is_instructor: true,
+        text_search: nil
+      }
+    )
+    |> List.first(%{})
+    |> Map.get(:name, "")
   end
 
   def render(assigns) do
     ~F"""
-    <div>nothing</div>
+      <div>nothing</div>
     """
   end
 end

--- a/lib/oli_web/live/sections/table_model.ex
+++ b/lib/oli_web/live/sections/table_model.ex
@@ -1,9 +1,6 @@
 defmodule OliWeb.Sections.SectionsTableModel do
   use Surface.LiveComponent
 
-  alias Oli.Delivery.Sections
-  alias Oli.Delivery.Sections.EnrollmentBrowseOptions
-  alias Oli.Repo.{Paging, Sorting}
   alias OliWeb.Common.SessionContext
   alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
   alias OliWeb.Router.Helpers, as: Routes
@@ -108,20 +105,8 @@ defmodule OliWeb.Sections.SectionsTableModel do
     end
   end
 
-  def custom_render(_assigns, section, %ColumnSpec{name: :instructor}) do
-    Sections.browse_enrollments(
-      section,
-      %Paging{offset: 0, limit: 1},
-      %Sorting{direction: :asc, field: :inserted_at},
-      %EnrollmentBrowseOptions{
-        is_student: false,
-        is_instructor: true,
-        text_search: nil
-      }
-    )
-    |> List.first(%{})
-    |> Map.get(:name, "")
-  end
+  def custom_render(_assigns, section, %ColumnSpec{name: :instructor}),
+    do: Map.get(section, :instructor_name, "")
 
   def render(assigns) do
     ~F"""

--- a/priv/repo/migrations/20220422144507_add_sections_search_indexes.exs
+++ b/priv/repo/migrations/20220422144507_add_sections_search_indexes.exs
@@ -1,0 +1,47 @@
+defmodule Oli.Repo.Migrations.AddSectionsSearchIndexes do
+  use Ecto.Migration
+
+  def up do
+    execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+
+    # enrollments - to order by inserted at
+    create index(:enrollments, [:inserted_at])
+
+    # enrollments context roles - index in foreign keys
+    create index(:enrollments_context_roles, [:enrollment_id])
+    create index(:enrollments_context_roles, [:context_role_id])
+
+    # sections - index in foreign keys
+    create index(:sections, [:institution_id])
+    create index(:sections, [:base_project_id])
+    create index(:sections, [:blueprint_id])
+
+    # sections - index to compare dates
+    create index(:sections, [:start_date])
+    create index(:sections, [:end_date])
+
+    # full text search indexes
+    execute("CREATE INDEX sections_title_trgm_idx ON sections USING GIN (to_tsvector('english', title))")
+    execute("CREATE INDEX institutions_name_trgm_idx ON institutions USING GIN (to_tsvector('english', name))")
+    execute("CREATE INDEX projects_title_trgm_idx ON projects USING GIN (to_tsvector('english', title))")
+    execute("CREATE INDEX users_name_trgm_idx ON users USING GIN (to_tsvector('english', name))")
+  end
+
+  def down do
+    drop index(:enrollments, [:inserted_at])
+    drop index(:enrollments_context_roles, [:enrollment_id])
+    drop index(:enrollments_context_roles, [:context_role_id])
+    drop index(:sections, [:institution_id])
+    drop index(:sections, [:base_project_id])
+    drop index(:sections, [:blueprint_id])
+    drop index(:sections, [:start_date])
+    drop index(:sections, [:end_date])
+
+    execute("DROP INDEX sections_title_trgm_idx")
+    execute("DROP INDEX institutions_name_trgm_idx")
+    execute("DROP INDEX projects_title_trgm_idx")
+    execute("DROP INDEX users_name_trgm_idx")
+
+    execute("DROP EXTENSION pg_trgm")
+  end
+end

--- a/priv/repo/migrations/20220422144507_add_sections_search_indexes.exs
+++ b/priv/repo/migrations/20220422144507_add_sections_search_indexes.exs
@@ -7,9 +7,8 @@ defmodule Oli.Repo.Migrations.AddSectionsSearchIndexes do
     # enrollments - to order by inserted at
     create index(:enrollments, [:inserted_at])
 
-    # enrollments context roles - index in foreign keys
-    create index(:enrollments_context_roles, [:enrollment_id])
-    create index(:enrollments_context_roles, [:context_role_id])
+    # enrollments context roles - composite index in foreign keys
+    create index(:enrollments_context_roles, [:enrollment_id, :context_role_id])
 
     # sections - index in foreign keys
     create index(:sections, [:institution_id])
@@ -17,8 +16,7 @@ defmodule Oli.Repo.Migrations.AddSectionsSearchIndexes do
     create index(:sections, [:blueprint_id])
 
     # sections - index to compare dates
-    create index(:sections, [:start_date])
-    create index(:sections, [:end_date])
+    create index(:sections, [:start_date, :end_date])
 
     # full text search indexes
     execute("CREATE INDEX sections_title_trgm_idx ON sections USING GIN (to_tsvector('english', title))")
@@ -29,13 +27,11 @@ defmodule Oli.Repo.Migrations.AddSectionsSearchIndexes do
 
   def down do
     drop index(:enrollments, [:inserted_at])
-    drop index(:enrollments_context_roles, [:enrollment_id])
-    drop index(:enrollments_context_roles, [:context_role_id])
+    drop index(:enrollments_context_roles, [:enrollment_id, :context_role_id])
     drop index(:sections, [:institution_id])
     drop index(:sections, [:base_project_id])
     drop index(:sections, [:blueprint_id])
-    drop index(:sections, [:start_date])
-    drop index(:sections, [:end_date])
+    drop index(:sections, [:start_date, :end_date])
 
     execute("DROP INDEX sections_title_trgm_idx")
     execute("DROP INDEX institutions_name_trgm_idx")

--- a/test/oli/delivery/sections/browse_test.exs
+++ b/test/oli/delivery/sections/browse_test.exs
@@ -2,29 +2,210 @@ defmodule Oli.Delivery.Sections.BrowseTest do
   use Oli.DataCase
 
   alias Oli.Delivery.Sections
-  alias Oli.Repo.{Paging, Sorting}
   alias Oli.Delivery.Sections.{Browse, BrowseOptions}
   alias Oli.Institutions.Institution
+  alias Oli.Repo.{Paging, Sorting}
   alias Lti_1p3.Tool.ContextRoles
+
   import Ecto.Query, warn: false
 
-  def browse(offset, field, direction, text_search) do
+  @default_opts %BrowseOptions{
+    institution_id: nil,
+    blueprint_id: nil,
+    text_search: "",
+    active_date: false,
+    filter_status: nil,
+    filter_type: nil,
+  }
+
+  describe "basic browsing" do
+    setup [:setup_session]
+
+    test "sorting" do
+      results = browse(0, :title, :asc, @default_opts)
+      assert length(results) == 3
+      assert hd(results).total_count == 30
+      assert hd(results).title == "aA"
+
+      results = browse(0, :title, :desc, @default_opts)
+      assert length(results) == 3
+      assert hd(results).total_count == 30
+      assert hd(results).title == "zzzDeleted"
+
+      results = browse(0, :type, :asc, @default_opts)
+      assert length(results) == 3
+      assert hd(results).total_count == 30
+      refute hd(results).title == "aA"
+
+      results = browse(0, :type, :desc, @default_opts)
+      assert length(results) == 3
+      assert hd(results).total_count == 30
+      assert hd(results).title == "aA"
+
+      results = browse(0, :requires_payment, :asc, @default_opts)
+      assert length(results) == 3
+      assert hd(results).total_count == 30
+      refute hd(results).title == "aA"
+
+      results = browse(0, :requires_payment, :desc, @default_opts)
+      assert length(results) == 3
+      assert hd(results).total_count == 30
+      assert hd(results).title == "aA"
+
+      results = browse(0, :base, :asc, @default_opts)
+      assert length(results) == 3
+      assert hd(results).total_count == 30
+      assert hd(results).title == "aB"
+
+      results = browse(0, :base, :desc, @default_opts)
+      assert length(results) == 3
+      assert hd(results).total_count == 30
+      refute hd(results).title == "aB"
+
+      results = browse(0, :institution, :asc, @default_opts)
+      assert length(results) == 3
+      assert hd(results).total_count == 30
+      assert hd(results).institution_name == "CMU"
+
+      results = browse(12, :institution, :asc, @default_opts)
+      assert length(results) == 3
+      assert hd(results).total_count == 30
+      assert hd(results).institution_name == "ZZZ"
+
+      results = browse(0, :enrollments_count, :desc, @default_opts)
+      assert length(results) == 3
+      assert hd(results).total_count == 30
+      assert hd(results).enrollments_count == 28
+
+      results = browse(0, :enrollments_count, :asc, @default_opts)
+      assert length(results) == 3
+      assert hd(results).total_count == 30
+      assert hd(results).enrollments_count == 0
+    end
+
+    test "searching" do
+      # there are three sections with H in the title
+      results = browse(0, :title, :asc, Map.merge(@default_opts, %{text_search: "G"}))
+      assert length(results) == 3
+      assert hd(results).total_count == 3
+
+      # there are ten sections associated with the insitution titled "ZZZ", and two with
+      # zzz in the title
+      results = browse(0, :title, :asc, Map.merge(@default_opts, %{text_search: "ZZZ"}))
+      assert length(results) == 3
+      assert hd(results).total_count == 12
+
+      # there is one section with base on a-A (apart from itself)
+      results = browse(0, :title, :asc, Map.merge(@default_opts, %{text_search: "aA"}))
+      assert length(results) == 2
+      assert hd(results).total_count == 2
+
+      # all created sections are with base on project titled "Example..."
+      results = browse(0, :title, :asc, Map.merge(@default_opts, %{text_search: "Example"}))
+      assert length(results) == 3
+      assert hd(results).total_count == 30
+    end
+
+    test "filtering", %{second: second, sections: sections} do
+      # by institution
+      results = browse(0, :title, :asc, Map.merge(@default_opts, %{institution_id: second.id}))
+      assert length(results) == 3
+      assert hd(results).total_count == 10
+      assert hd(results).institution_name == "ZZZ"
+
+      # by active date: finds the one section with start and end dates that overlap today
+      results = browse(0, :title, :asc, Map.merge(@default_opts, %{active_date: true}))
+      assert length(results) == 1
+      assert hd(results).total_count == 1
+      assert hd(results).title == "aA"
+
+      # by status
+      results = browse(0, :title, :asc, Map.merge(@default_opts, %{filter_status: :deleted}))
+      assert length(results) == 1
+      assert hd(results).total_count == 1
+      assert hd(results).title == "zzzDeleted"
+
+      results = browse(0, :title, :asc, Map.merge(@default_opts, %{filter_status: :archived}))
+      assert length(results) == 1
+      assert hd(results).total_count == 1
+      assert hd(results).title == "zzzArchived"
+
+      # by type
+      results = browse(0, :title, :asc, Map.merge(@default_opts, %{filter_type: :open}))
+      assert length(results) == 1
+      assert hd(results).total_count == 1
+      assert hd(results).title == "aA"
+
+      results = browse(0, :title, :asc, Map.merge(@default_opts, %{filter_type: :lms}))
+      assert length(results) == 3
+      assert hd(results).total_count == 29
+      refute hd(results).title == "aA"
+
+      # by blueprint
+      results = browse(0, :title, :asc, Map.merge(@default_opts, %{blueprint_id: hd(sections).id}))
+      assert length(results) == 1
+      assert hd(results).total_count == 1
+    end
+  end
+
+  defp browse(offset, field, direction, browse_options) do
     Browse.browse_sections(
       %Paging{offset: offset, limit: 3},
       %Sorting{field: field, direction: direction},
-      %BrowseOptions{
-        show_deleted: false,
-        institution_id: nil,
-        blueprint_id: nil,
-        active_only: false,
-        text_search: text_search
-      }
+      browse_options
     )
+  end
+
+  defp setup_session(_conn) do
+    map = Seeder.base_project_with_resource2()
+
+    {:ok, institution2} =
+      Institution.changeset(%Institution{}, %{
+        name: "ZZZ",
+        country_code: "US",
+        institution_email: "noone",
+        institution_url: "example.edu",
+        timezone: "America/New_York"
+      })
+      |> Repo.insert()
+
+    sections =
+      (make_sections(map.project, map.institution, "a", 10, %{}) ++
+         make_sections(map.project, institution2, "b", 10, %{}) ++
+         make_sections(map.project, nil, "c", 8, %{}))
+      |> enroll
+
+    # There is only one section that is "active" in that the start and end dates overlap today
+    Sections.update_section(hd(sections), %{
+      start_date: yesterday(),
+      end_date: tomorrow(),
+      open_and_free: true,
+      amount: Money.new(:USD, 10000000)
+    })
+
+    Sections.update_section(Enum.at(sections, 1), %{
+      start_date: yesterday(),
+      end_date: yesterday(),
+      blueprint_id: hd(sections).id
+    })
+
+    Sections.update_section(Enum.at(sections, 2), %{
+      start_date: tomorrow(),
+      end_date: tomorrow()
+    })
+
+    # Add one section that is deleted
+    make(map.project, map.institution, "zzzDeleted", %{status: :deleted})
+
+    # Add one section that is archived
+    make(map.project, map.institution, "zzzArchived", %{status: :archived})
+
+    Map.put(map, :sections, sections) |> Map.put(:second, institution2)
   end
 
   # For each section, enroll a different number of students. First section gets 1,
   # section gets 2, then third gets 3, etc
-  def enroll(sections) do
+  defp enroll(sections) do
     map =
       Enum.map(1..32, fn _ -> user_fixture() end)
       |> Enum.map(fn u -> u.id end)
@@ -38,174 +219,5 @@ defmodule Oli.Delivery.Sections.BrowseTest do
     end)
 
     sections
-  end
-
-  describe "basic browsing" do
-    setup do
-      map = Seeder.base_project_with_resource2()
-
-      {:ok, institution2} =
-        Institution.changeset(%Institution{}, %{
-          name: "ZZZ",
-          country_code: "US",
-          institution_email: "noone",
-          institution_url: "example.edu",
-          timezone: "America/New_York"
-        })
-        |> Repo.insert()
-
-      sections =
-        (make_sections(map.project, map.institution, "a", 10, %{}) ++
-           make_sections(map.project, institution2, "b", 10, %{}) ++
-           make_sections(map.project, nil, "c", 10, %{}))
-        |> enroll
-
-      # There is only one section that is "active" in that the start and end dates overlap today
-      Sections.update_section(hd(sections), %{start_date: yesterday(), end_date: tomorrow()})
-
-      Sections.update_section(Enum.at(sections, 1), %{
-        start_date: yesterday(),
-        end_date: yesterday(),
-        blueprint_id: hd(sections).id
-      })
-
-      Sections.update_section(Enum.at(sections, 2), %{
-        start_date: tomorrow(),
-        end_date: tomorrow()
-      })
-
-      # Finally, add one section that is deleted
-      make(map.project, map.institution, "DELETED", %{status: :deleted})
-
-      Map.put(map, :sections, sections) |> Map.put(:second, institution2)
-    end
-
-    test "basic sorting", %{second: second, sections: sections} do
-      # Verify that sorting works:
-      results = browse(0, :title, :asc, nil)
-      assert length(results) == 3
-      assert hd(results).total_count == 30
-      assert hd(results).title == "a-A"
-
-      results = browse(0, :title, :desc, nil)
-      assert length(results) == 3
-      assert hd(results).total_count == 30
-      assert hd(results).title == "c-J"
-
-      results = browse(0, :institution, :asc, nil)
-      assert length(results) == 3
-      assert hd(results).total_count == 30
-      assert hd(results).institution_name == "CMU"
-
-      results = browse(12, :institution, :asc, nil)
-      assert length(results) == 3
-      assert hd(results).total_count == 30
-      assert hd(results).institution_name == "ZZZ"
-
-      results = browse(0, :enrollments_count, :desc, nil)
-      assert length(results) == 3
-      assert hd(results).total_count == 30
-      assert hd(results).enrollments_count == 30
-
-      results = browse(0, :enrollments_count, :asc, nil)
-      assert length(results) == 3
-      assert hd(results).total_count == 30
-      assert hd(results).enrollments_count == 1
-
-      # Verify that text search works. There are three sections with J in the title
-      results = browse(0, :title, :asc, "J")
-      assert length(results) == 3
-      assert hd(results).total_count == 3
-
-      # Verify we can filter by institution
-      results =
-        Browse.browse_sections(
-          %Paging{offset: 0, limit: 3},
-          %Sorting{field: :title, direction: :asc},
-          %BrowseOptions{
-            show_deleted: false,
-            institution_id: second.id,
-            blueprint_id: nil,
-            active_only: false,
-            text_search: nil
-          }
-        )
-
-      assert length(results) == 3
-      assert hd(results).total_count == 10
-      assert hd(results).institution_name == "ZZZ"
-
-      # Verify that we can filter by institution AND do a text search. There is
-      # exactly one section with H in the title and pinned to the second institution
-      results =
-        Browse.browse_sections(
-          %Paging{offset: 0, limit: 3},
-          %Sorting{field: :title, direction: :asc},
-          %BrowseOptions{
-            show_deleted: false,
-            institution_id: second.id,
-            blueprint_id: nil,
-            active_only: false,
-            text_search: "H"
-          }
-        )
-
-      assert length(results) == 1
-      assert hd(results).total_count == 1
-      assert hd(results).title == "b-H"
-
-      # Verify that "active only" finds the one section with start and
-      # end dates that overlap today
-      results =
-        Browse.browse_sections(
-          %Paging{offset: 0, limit: 3},
-          %Sorting{field: :title, direction: :asc},
-          %BrowseOptions{
-            show_deleted: false,
-            institution_id: nil,
-            blueprint_id: nil,
-            active_only: true,
-            text_search: nil
-          }
-        )
-
-      assert length(results) == 1
-      assert hd(results).total_count == 1
-      assert hd(results).title == "a-A"
-
-      # Verify that "show deleted" works
-      results =
-        Browse.browse_sections(
-          %Paging{offset: 0, limit: 3},
-          %Sorting{field: :title, direction: :asc},
-          %BrowseOptions{
-            show_deleted: true,
-            institution_id: nil,
-            blueprint_id: nil,
-            active_only: false,
-            text_search: nil
-          }
-        )
-
-      assert length(results) == 3
-      assert hd(results).total_count == 31
-
-      # Verify we can filter by blueprint
-      results =
-        Browse.browse_sections(
-          %Paging{offset: 0, limit: 3},
-          %Sorting{field: :title, direction: :asc},
-          %BrowseOptions{
-            show_deleted: false,
-            institution_id: nil,
-            blueprint_id: hd(sections).id,
-            active_only: false,
-            text_search: nil
-          }
-        )
-
-      assert length(results) == 1
-      assert hd(results).total_count == 1
-    end
   end
 end

--- a/test/oli/delivery/sections/browse_test.exs
+++ b/test/oli/delivery/sections/browse_test.exs
@@ -14,7 +14,7 @@ defmodule Oli.Delivery.Sections.BrowseTest do
     institution_id: nil,
     blueprint_id: nil,
     text_search: "",
-    active_date: false,
+    active_today: false,
     filter_status: nil,
     filter_type: nil,
   }
@@ -130,7 +130,7 @@ defmodule Oli.Delivery.Sections.BrowseTest do
       assert hd(results).institution_name == "ZZZ"
 
       # by active date: finds the one section with start and end dates that overlap today
-      results = browse(0, :title, :asc, Map.merge(@default_opts, %{active_date: true}))
+      results = browse(0, :title, :asc, Map.merge(@default_opts, %{active_today: true}))
       assert length(results) == 1
       assert hd(results).total_count == 1
       assert hd(results).title == "aA"

--- a/test/oli/delivery/sections/browse_test.exs
+++ b/test/oli/delivery/sections/browse_test.exs
@@ -95,10 +95,10 @@ defmodule Oli.Delivery.Sections.BrowseTest do
     end
 
     test "searching" do
-      # there are three sections with H in the title
-      results = browse(0, :title, :asc, Map.merge(@default_opts, %{text_search: "G"}))
-      assert length(results) == 3
-      assert hd(results).total_count == 3
+      # there is one section with cB as title
+      results = browse(0, :title, :asc, Map.merge(@default_opts, %{text_search: "cB"}))
+      assert length(results) == 1
+      assert hd(results).total_count == 1
 
       # there are ten sections associated with the insitution titled "ZZZ", and two with
       # zzz in the title
@@ -106,7 +106,7 @@ defmodule Oli.Delivery.Sections.BrowseTest do
       assert length(results) == 3
       assert hd(results).total_count == 12
 
-      # there is one section with base on a-A (apart from itself)
+      # there is one section with base on aA (apart from itself)
       results = browse(0, :title, :asc, Map.merge(@default_opts, %{text_search: "aA"}))
       assert length(results) == 2
       assert hd(results).total_count == 2

--- a/test/oli_web/live/sections/admin_index_live_test.exs
+++ b/test/oli_web/live/sections/admin_index_live_test.exs
@@ -112,7 +112,7 @@ defmodule OliWeb.Sections.AdminIndexLiveTest do
     test "applies searching", %{conn: conn} do
       project = insert(:project, title: "Project", authors: [])
       other_project = insert(:project, title: "OtherProj", authors: [])
-      institution = insert(:institution, name: "TestInsti")
+      institution = insert(:institution, name: "OtherInsti")
       blueprint = insert(:section, title: "TestSection")
 
       s1 = insert(:section, type: :enrollable, base_project: other_project, title: "Testing", blueprint: blueprint)
@@ -127,7 +127,7 @@ defmodule OliWeb.Sections.AdminIndexLiveTest do
       refute has_element?(view, "td", s2.title)
 
       # by institution
-      render_hook(view, "text_search_change", %{value: "testinsti"})
+      render_hook(view, "text_search_change", %{value: "otherins"})
 
       refute has_element?(view, "td", s1.title)
       assert has_element?(view, "td", s2.title)

--- a/test/oli_web/live/sections/admin_index_live_test.exs
+++ b/test/oli_web/live/sections/admin_index_live_test.exs
@@ -2,6 +2,9 @@ defmodule OliWeb.Sections.AdminIndexLiveTest do
   use ExUnit.Case
   use OliWeb.ConnCase
 
+  alias Lti_1p3.Tool.ContextRoles
+  alias Oli.Delivery.Sections
+
   import Phoenix.LiveViewTest
   import Oli.Factory
 
@@ -140,6 +143,15 @@ defmodule OliWeb.Sections.AdminIndexLiveTest do
 
       refute has_element?(view, "td", s1.title)
       assert has_element?(view, "td", s2.title)
+
+      # by instructor
+      user = insert(:user, name: "Instructor")
+      Sections.enroll(user.id, s1.id, [ContextRoles.get_role(:context_instructor)])
+
+      render_hook(view, "text_search_change", %{value: "instructor"})
+
+      assert has_element?(view, "td", s1.title)
+      refute has_element?(view, "td", s2.title)
     end
 
     test "applies sorting", %{conn: conn} do
@@ -178,6 +190,26 @@ defmodule OliWeb.Sections.AdminIndexLiveTest do
       assert view
       |> element("tr:first-child > td:first-child")
       |> render() =~ s1.title
+
+      # by instructor
+      user = insert(:user, name: "Instructor")
+      Sections.enroll(user.id, s1.id, [ContextRoles.get_role(:context_instructor)])
+
+      view
+      |> element("th[phx-click=\"paged_table_sort\"]", "Instructor")
+      |> render_click(%{sort_by: "instructor"})
+
+      assert view
+      |> element("tr:first-child > td:first-child")
+      |> render() =~ s1.title
+
+      view
+      |> element("th[phx-click=\"paged_table_sort\"]", "Instructor")
+      |> render_click(%{sort_by: "instructor"})
+
+      assert view
+      |> element("tr:first-child > td:first-child")
+      |> render() =~ s2.title
     end
 
     test "applies paging", %{conn: conn} do

--- a/test/oli_web/live/sections/admin_index_live_test.exs
+++ b/test/oli_web/live/sections/admin_index_live_test.exs
@@ -1,0 +1,200 @@
+defmodule OliWeb.Sections.AdminIndexLiveTest do
+  use ExUnit.Case
+  use OliWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+  import Oli.Factory
+
+  @live_view_index_route Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.SectionsView)
+
+  describe "user cannot access when is not logged in" do
+    test "redirects to new session when accessing the index view", %{conn: conn} do
+      {:error,
+       {:redirect, %{to: "/authoring/session/new?request_path=%2Fadmin%2Fsections"}}} =
+        live(conn, @live_view_index_route)
+    end
+  end
+
+  describe "user cannot access when is logged in as an author but is not a system admin" do
+    setup [:author_conn]
+
+    test "returns forbidden when accessing the index view", %{conn: conn} do
+      conn = get(conn, @live_view_index_route)
+
+      assert response(conn, 403)
+    end
+  end
+
+  describe "index" do
+    setup [:admin_conn]
+
+    test "loads correctly when there are no sections", %{conn: conn} do
+      {:ok, view, _html} = live(conn, @live_view_index_route)
+
+      assert has_element?(view, "h3", "Browse Course Sections")
+      assert has_element?(view, "p", "None exist")
+    end
+
+    test "applies filtering", %{conn: conn} do
+      s1 = insert(:section,
+        type: :enrollable,
+        open_and_free: true,
+        start_date: yesterday(),
+        end_date: tomorrow()
+      )
+      s2 = insert(:section, type: :enrollable, status: :deleted)
+
+      {:ok, view, _html} = live(conn, @live_view_index_route)
+
+      assert has_element?(view, "td", s1.title)
+      assert has_element?(view, "td", s2.title)
+
+      # by active date
+      view
+      |> element("input[phx-click=\"active_date\"]")
+      |> render_click()
+
+      assert has_element?(view, "td", s1.title)
+      refute has_element?(view, "td", s2.title)
+
+      # reset filter active date
+      view
+      |> element("input[phx-click=\"active_date\"]")
+      |> render_click()
+
+      # by type
+      view
+      |> element("form[phx-change=\"change_type\"]")
+      |> render_change(%{"type" => "open"})
+
+      assert has_element?(view, "td", s1.title)
+      refute has_element?(view, "td", s2.title)
+
+      view
+      |> element("form[phx-change=\"change_type\"]")
+      |> render_change(%{"type" => "lms"})
+
+      refute has_element?(view, "td", s1.title)
+      assert has_element?(view, "td", s2.title)
+
+      # reset filter type
+      view
+      |> element("form[phx-change=\"change_type\"]")
+      |> render_change(%{"type" => ""})
+
+      # by status
+      view
+      |> element("form[phx-change=\"change_status\"]")
+      |> render_change(%{"status" => "active"})
+
+      assert has_element?(view, "td", s1.title)
+      refute has_element?(view, "td", s2.title)
+
+      view
+      |> element("form[phx-change=\"change_status\"]")
+      |> render_change(%{"status" => "deleted"})
+
+      refute has_element?(view, "td", s1.title)
+      assert has_element?(view, "td", s2.title)
+
+      view
+      |> element("form[phx-change=\"change_status\"]")
+      |> render_change(%{"status" => "archived"})
+
+      refute has_element?(view, "td", s1.title)
+      refute has_element?(view, "td", s2.title)
+      assert has_element?(view, "p", "None exist")
+    end
+
+    test "applies searching", %{conn: conn} do
+      project = insert(:project, title: "Project", authors: [])
+      other_project = insert(:project, title: "OtherProj", authors: [])
+      institution = insert(:institution, name: "TestInsti")
+      blueprint = insert(:section, title: "TestSection")
+
+      s1 = insert(:section, type: :enrollable, base_project: other_project, title: "Testing", blueprint: blueprint)
+      s2 = insert(:section, type: :enrollable, base_project: project, institution: institution)
+
+      {:ok, view, _html} = live(conn, @live_view_index_route)
+
+      # by title
+      render_hook(view, "text_search_change", %{value: "testing"})
+
+      assert has_element?(view, "td", s1.title)
+      refute has_element?(view, "td", s2.title)
+
+      # by institution
+      render_hook(view, "text_search_change", %{value: "testinsti"})
+
+      refute has_element?(view, "td", s1.title)
+      assert has_element?(view, "td", s2.title)
+
+      # by product
+      render_hook(view, "text_search_change", %{value: "testsection"})
+
+      assert has_element?(view, "td", s1.title)
+      refute has_element?(view, "td", s2.title)
+
+      # by project
+      render_hook(view, "text_search_change", %{value: "project"})
+
+      refute has_element?(view, "td", s1.title)
+      assert has_element?(view, "td", s2.title)
+    end
+
+    test "applies sorting", %{conn: conn} do
+      project = insert(:project, title: "Project", authors: [])
+      s1 = insert(:section, type: :enrollable, amount: Money.new(:USD, 100000))
+      s2 = insert(:section, type: :enrollable, base_project: project)
+
+      {:ok, view, _html} = live(conn, @live_view_index_route)
+
+      # by title
+      assert view
+      |> element("tr:first-child > td:first-child")
+      |> render() =~ s1.title
+
+      view
+      |> element("th[phx-click=\"paged_table_sort\"]", "Title")
+      |> render_click(%{sort_by: "title"})
+
+      assert view
+      |> element("tr:first-child > td:first-child")
+      |> render() =~ s2.title
+
+      # by cost
+      view
+      |> element("th[phx-click=\"paged_table_sort\"]", "Cost")
+      |> render_click(%{sort_by: "requires_payment"})
+
+      assert view
+      |> element("tr:first-child > td:first-child")
+      |> render() =~ s2.title
+
+      view
+      |> element("th[phx-click=\"paged_table_sort\"]", "Cost")
+      |> render_click(%{sort_by: "requires_payment"})
+
+      assert view
+      |> element("tr:first-child > td:first-child")
+      |> render() =~ s1.title
+    end
+
+    test "applies paging", %{conn: conn} do
+      [first_s | tail] = insert_list(26, :section, type: :enrollable) |> Enum.sort_by(& &1.title)
+      last_s = List.last(tail)
+
+      {:ok, view, _html} = live(conn, @live_view_index_route)
+
+      assert has_element?(view, "td", first_s.title)
+      refute has_element?(view, "td", last_s.title)
+
+      view
+      |> element("a[phx-click=\"paged_table_page_change\"]", "2")
+      |> render_click()
+
+      refute has_element?(view, "td", first_s.title)
+      assert has_element?(view, "td", last_s.title)
+    end
+  end
+end

--- a/test/oli_web/live/sections/admin_index_live_test.exs
+++ b/test/oli_web/live/sections/admin_index_live_test.exs
@@ -54,7 +54,7 @@ defmodule OliWeb.Sections.AdminIndexLiveTest do
 
       # by active date
       view
-      |> element("input[phx-click=\"active_date\"]")
+      |> element("input[phx-click=\"active_today\"]")
       |> render_click()
 
       assert has_element?(view, "td", s1.title)
@@ -62,7 +62,7 @@ defmodule OliWeb.Sections.AdminIndexLiveTest do
 
       # reset filter active date
       view
-      |> element("input[phx-click=\"active_date\"]")
+      |> element("input[phx-click=\"active_today\"]")
       |> render_click()
 
       # by type

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -411,7 +411,7 @@ defmodule Oli.TestHelpers do
   def make_sections(project, institution, prefix, n, attrs) do
     65..(65 + (n - 1))
     |> Enum.map(fn value -> List.to_string([value]) end)
-    |> Enum.map(fn value -> make(project, institution, "#{prefix}-#{value}", attrs) end)
+    |> Enum.map(fn value -> make(project, institution, "#{prefix}#{value}", attrs) end)
   end
 
   def make(project, institution, title, attrs) do


### PR DESCRIPTION
[MER-938](https://eliterate.atlassian.net/browse/MER-938)

Improve the admin sections index so they are able to find them easier (specially if there a lot).
 
Changes include:
- Added some columns
- Sort by all columns
- Search by some more columns
- Filter by status, type or active by date

<img width="1439" alt="image" src="https://user-images.githubusercontent.com/42446726/164288660-477a297c-b8d2-4145-a058-cafd3f36b639.png">

Any feedback/suggestion/thought is welcome 😄 

**NOTE: This PR will be marked as "Ready for Review" and can be merged once it has 2 approvals.**