### PR TITLE
(JAN-1577 | PMP-2729) Multiple lessons - lesson variables display too many digits after decimal

### DIFF
--- a/assets/src/adaptivity/scripting.ts
+++ b/assets/src/adaptivity/scripting.ts
@@ -565,7 +565,7 @@ export const templatizeText = (
     } else if (typeof stateValue === 'object') {
       strValue = JSON.stringify(stateValue);
     } else if (typeof stateValue === 'number') {
-      strValue = parseFloat(parseFloat(strValue).toString());
+      strValue = parseFloat(parseFloat(strValue).toFixed(2));
     }
     return strValue;
   });

--- a/assets/test/adaptivity/scripting_test.ts
+++ b/assets/test/adaptivity/scripting_test.ts
@@ -265,9 +265,9 @@ describe('Scripting Interface', () => {
       expect(result).toBe('stage.foo.value =  1; stage.foo1.value =  80;');
 
       text = 'Lets try with variables {variables.foo}';
-      evalScript('let {variables.foo} = 0.529', environment);
+      evalScript('let {variables.foo} = 0.52', environment);
       result = templatizeText(text, environment, environment);
-      expect(result).toBe('Lets try with variables 0.529');
+      expect(result).toBe('Lets try with variables 0.52');
 
       text = 'Lets try with variables {variables.foo';
       result = templatizeText(text, environment);


### PR DESCRIPTION
display float number up to 2 decimal points