### PR TITLE
[BUGFIX] downcase normalized url to find existing institutions

### DIFF
--- a/lib/oli/institutions.ex
+++ b/lib/oli/institutions.ex
@@ -502,6 +502,7 @@ defmodule Oli.Institutions do
   def find_or_create_institution_by_normalized_url(institution_attrs) do
     normalized_url =
       institution_attrs[:institution_url]
+      |> String.downcase()
       |> String.replace(~r/^https?\:\/\//i, "")
       |> String.replace_trailing("/", "")
 

--- a/test/oli/institutions_test.exs
+++ b/test/oli/institutions_test.exs
@@ -393,6 +393,22 @@ defmodule Oli.InstitutionsTest do
       assert result_institution.id == first_institution.id
     end
 
+    test "find_or_create_institution_by_normalized_url/1 finds existing institution if mixed casing is used",
+         %{institution: first_institution} do
+      _second_institution = institution_fixture()
+
+      {:ok, result_institution} =
+        Institutions.find_or_create_institution_by_normalized_url(%{
+          country_code: "US",
+          institution_email: "institution@example.edu",
+          institution_url: "https://institution.ExAmPle.EDU/",
+          name: "Example Institution",
+          timezone: "US/Eastern"
+        })
+
+      assert result_institution.id == first_institution.id
+    end
+
     test "approve_pending_registration/1 creates a new institution and registration and removes pending registration" do
       {:ok, %PendingRegistration{} = pending_registration} =
         Institutions.create_pending_registration(%{


### PR DESCRIPTION
This PR fixes an issue where different casings of an institution URL resulted in duplicate institutions being created when the UI says it will be added to an existing institution (the UI javascript already did the right thing here, which is downcase before comparing the url)

Closes #2265