### PR TITLE
[BUGFIX] Allow choices to display

### DIFF
--- a/assets/src/components/activities/multi_input/sections/DropdownQuestionEditor.tsx
+++ b/assets/src/components/activities/multi_input/sections/DropdownQuestionEditor.tsx
@@ -21,7 +21,6 @@ export const DropdownQuestionEditor: React.FC<Props> = (props) => {
         setAll={(choices) => dispatch(MultiInputActions.reorderChoices(props.input.id, choices))}
         onEdit={(id, content) => dispatch(Choices.setContent(id, content))}
         onRemove={(id) => dispatch(MultiInputActions.removeChoice(props.input.id, id))}
-        simpleText
       />
     </>
   );


### PR DESCRIPTION
In conjunction with https://github.com/Simon-Initiative/course-digest/pull/34  closes #2454 

After fixing several migration issues related to the multi-input question in the migration tool, there was still a problem where the choices were not being displayed in their editors in the "Question" tab.  The issue seemed to be the assertion that choices all contain `simpleText`.  I removed that and things work fine now?



