### PR TITLE
[BUGFIX] Fix activity deletion issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix popup content editing
 - Fix image alt text rendering
 - Change ordering question interaction after activity is submitted
+- Fix cross-project activity deletion bug
 
 ### Enhancements
 

--- a/lib/oli/authoring/editing/page_editor.ex
+++ b/lib/oli/authoring/editing/page_editor.ex
@@ -398,16 +398,14 @@ defmodule Oli.Authoring.Editing.PageEditor do
         {revision, []}
 
       activity_ids ->
-        activity_revisions =
-          AuthoringResolver.from_resource_id(project_slug, activity_ids)
-          |> Enum.map(fn revision ->
-            {:ok, updated} =
-              Oli.Resources.update_revision(revision, %{
-                deleted: MapSet.member?(deletions, revision.resource_id)
-              })
+        AuthoringResolver.from_resource_id(project_slug, activity_ids)
+        |> Enum.each(fn revision ->
+          Oli.Publishing.ChangeTracker.track_revision(project_slug, revision, %{
+            deleted: MapSet.member?(deletions, revision.resource_id)
+          })
+        end)
 
-            updated
-          end)
+        activity_revisions = AuthoringResolver.from_resource_id(project_slug, activity_ids)
 
         {revision, activity_revisions}
     end


### PR DESCRIPTION
Several times we have seen issues where activities have seemingly "gone missing" and resolution ends up returning `nil`.

The root cause is in the page editor code that deletes and resurrects activities.  It was doing this directly on the revision, which is problematic in the case where a duplicate project is using the same revision.  The safe and correct impl here is to create a new revision, always, against the resolved revision. 

Fixing this exposed a flaw in a related test (publishing_test.exs), which I fixed.  

Closes #2434 
