### PR TITLE
[BUG] [MER-1100] Author creation ignores captcha

### DIFF
--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -238,6 +238,30 @@ defmodule OliWeb.DeliveryController do
     end
   end
 
+  def render_create_form(conn, opts \\ []) do
+    # This is currently used when an author is registering, and they failed the captcha. They are sent here from
+    # Oli.Plugs.RegistrationCaptcha.render_captcha_error
+    changeset = Keyword.get(opts, :changeset, Author.noauth_changeset(%Author{}))
+
+    action =
+      Keyword.get(
+        opts,
+        :action,
+        Routes.authoring_pow_registration_path(conn, :create)
+      )
+
+    sign_in_path = Keyword.get(opts, :sign_in_path, Routes.authoring_pow_session_path(conn, :new))
+    cancel_path = Keyword.get(opts, :cancel_path, Routes.delivery_path(conn, :index))
+
+    conn
+    |> assign(:changeset, changeset)
+    |> assign(:action, action)
+    |> assign(:sign_in_path, sign_in_path)
+    |> assign(:cancel_path, cancel_path)
+    |> put_view(OliWeb.Pow.RegistrationView)
+    |> render("new.html")
+  end
+
   def render_create_and_link_form(conn, opts \\ []) do
     title = Keyword.get(opts, :title, "Create and Link Account")
     changeset = Keyword.get(opts, :changeset, Author.noauth_changeset(%Author{}))

--- a/lib/oli_web/plugs/registration_captcha.ex
+++ b/lib/oli_web/plugs/registration_captcha.ex
@@ -25,7 +25,7 @@ defmodule Oli.Plugs.RegistrationCaptcha do
     case conn do
       %Plug.Conn{method: "POST", request_path: ^author_register_path}
       when author_register_path != nil ->
-        verify_captcha(conn, :register)
+        verify_captcha(conn, :register_author)
 
       %Plug.Conn{method: "POST", request_path: ^register_path} when register_path != nil ->
         verify_captcha(conn, :register)
@@ -68,6 +68,15 @@ defmodule Oli.Plugs.RegistrationCaptcha do
     changeset = Ecto.Changeset.add_error(changeset, :captcha, "failed, please try again")
 
     case purpose do
+      :register_author ->
+        conn
+        |> OliWeb.DeliveryController.render_create_form(
+          changeset: %{changeset | action: :insert},
+          sign_in_path: Routes.authoring_pow_session_path(conn, :new),
+          cancel_path: Routes.static_page_path(conn, :index)
+        )
+        |> halt()
+
       :register ->
         conn
         |> OliWeb.DeliveryController.render_create_and_link_form(

--- a/lib/oli_web/plugs/registration_captcha.ex
+++ b/lib/oli_web/plugs/registration_captcha.ex
@@ -8,6 +8,8 @@ defmodule Oli.Plugs.RegistrationCaptcha do
     # plug is only applicable to registration POSTs
     register_path = Routes.pow_registration_path(conn, :create)
 
+    author_register_path = Routes.authoring_pow_registration_path(conn, :create)
+
     register_and_link_provider_path =
       case conn do
         %{params: %{"provider" => provider}} ->
@@ -21,6 +23,10 @@ defmodule Oli.Plugs.RegistrationCaptcha do
       Routes.delivery_path(conn, :process_create_and_link_account_user)
 
     case conn do
+      %Plug.Conn{method: "POST", request_path: ^author_register_path}
+      when author_register_path != nil ->
+        verify_captcha(conn, :register)
+
       %Plug.Conn{method: "POST", request_path: ^register_path} when register_path != nil ->
         verify_captcha(conn, :register)
 


### PR DESCRIPTION
Bug:

Go to the author registration page: /authoring/registration/new
Fill out the form
Do not check the captcha
Click the register button

Expected: We see a captcha error since it wasn’t filled out

Actual: The user is allowed to register.