### PR TITLE
[BUG FIX] Fix docs build, add detailed logging

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -70,7 +70,7 @@
     "terser-webpack-plugin": "^5.2.4",
     "tsmonad": "^0.8.0",
     "typedoc": "^0.22.15",
-    "typedoc-plugin-markdown": "^3.12.0",
+    "typedoc-plugin-markdown": "^3.12.1",
     "typescript": "^4.4.4",
     "uuid": "^8.3.2",
     "vm-browserify": "^1.1.2",

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -4103,11 +4103,6 @@ csstype@^3.0.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.8.tgz#d2266a792729fb227cd216fb572f43728e1ad340"
   integrity sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==
 
-custom-elements-native-shim@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/custom-elements-native-shim/-/custom-elements-native-shim-1.1.0.tgz#2be7c6389bbff3e6bb1d950d49b18307b8dbc513"
-  integrity sha512-jx7J58mgj2ldf194LJaO/SfBKd40ogxHgIAPnu+q1eAltnsbaX47x/vYD0W6fniQjZjIxYdWQog+FrCcLWKyvw==
-
 data-urls@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-2.0.0.tgz#156485a72963a970f5d5821aaf642bef2bf2db9b"
@@ -5269,26 +5264,6 @@ glob@^7.2.0:
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
-
-global-modules@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-1.0.0.tgz#6d770f0eb523ac78164d72b5e71a8877265cc3ea"
-  integrity sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==
-  dependencies:
-    global-prefix "^1.0.1"
-    is-windows "^1.0.1"
-    resolve-dir "^1.0.0"
-
-global-prefix@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-1.0.2.tgz#dbf743c6c14992593c655568cb66ed32c0122ebe"
-  integrity sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=
-  dependencies:
-    expand-tilde "^2.0.2"
-    homedir-polyfill "^1.0.1"
-    ini "^1.3.4"
-    is-windows "^1.0.1"
-    which "^1.2.14"
 
 globals@^11.1.0:
   version "11.12.0"
@@ -9508,10 +9483,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typedoc-plugin-markdown@^3.12.0:
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.12.0.tgz#d801c88b437435041f09e88f3bb300c76f46d7ed"
-  integrity sha512-yKl7/KWD8nP6Ot6OzMLLc8wBzN3CmkBoI/YQzxT62a9xmDgxyeTxGbHbkUoSzhKFqMI3SR0AqV6prAhVKbYnxw==
+typedoc-plugin-markdown@^3.12.1:
+  version "3.12.1"
+  resolved "https://registry.yarnpkg.com/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.12.1.tgz#2a33ca0018bdd7ed512e29960d3eb344ecb65f4a"
+  integrity sha512-gMntJq7+JlGJZ5sVjrkzO/rG2dsmNBbWk5ZkcKvYu6QOeBwGcK5tzEyS0aqnFTJj9GCHCB+brAnTuKtAyotNwA==
   dependencies:
     handlebars "^4.7.7"
 

--- a/lib/oli/activities.ex
+++ b/lib/oli/activities.ex
@@ -12,6 +12,7 @@ defmodule Oli.Activities do
   alias Oli.Activities.ActivityRegistrationProject
   alias Oli.Activities.ActivityMapEntry
   import Oli.Utils
+  require Logger
 
   def register_activity(%Manifest{} = manifest, subdirectory \\ "") do
     attrs = %{
@@ -42,17 +43,19 @@ defmodule Oli.Activities do
             if String.starts_with?(manifest.id, "#{expected_namespace}_") do
               process_register_from_bundle(manifest, entries)
             else
+              Logger.info("Invalid namespace")
               {:error, :invalid_namespace}
             end
-          e -> e
+          e ->
+            e
         end
       _ ->
+        Logger.info("Invalid archive")
         {:error, :invalid_archive}
     end
   end
 
   defp locate_manifest(entries) do
-
     case Enum.find(entries, fn {name, _} ->  List.to_string(name) == "manifest.json" end) do
       nil -> {nil, %{}}
       manifest -> manifest
@@ -61,13 +64,16 @@ defmodule Oli.Activities do
 
 
   defp parse_manifest({nil, _}) do
+    Logger.info("Missing manifest")
     {:error, :missing_manifest}
   end
 
   defp parse_manifest({_, content}) do
     case Poison.decode(content) do
       {:ok, json} -> Manifest.parse(json)
-      e -> e
+      e ->
+        Logger.info("Could not parse manifest")
+        e
     end
   end
 
@@ -81,7 +87,9 @@ defmodule Oli.Activities do
             e -> {:halt, e}
           end
         end)
-      e -> e
+      e ->
+        Logger.info("Error encountered during unbundling")
+        e
     end
 
     case result do

--- a/lib/oli_web/controllers/api/activity_registration_controller.ex
+++ b/lib/oli_web/controllers/api/activity_registration_controller.ex
@@ -66,12 +66,11 @@ defmodule OliWeb.Api.ActivityRegistrationController do
       expected_namespace = get_api_namespace(conn)
       case Activities.register_from_bundle(upload.path, expected_namespace) do
         {:ok, _} -> json(conn, %{result: :success})
-        _ ->
-          error(conn, 400, "error")
+        e ->
+          error(conn, 400, Kernel.inspect(e))
       end
     else
       error(conn, 400, "invalid key")
-
     end
   end
 


### PR DESCRIPTION
This PR attempts to fix the docs building by ensuring that the `typedoc-plugin-markdown` package is installed.  

It also adds some logging server-side to the registration process and passes back the specific error to the client code. 