### PR TITLE
[BUG FIX] Execute in correct dir

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -99,7 +99,7 @@ jobs:
         run: npm install -g yarn && cd assets && yarn
 
       - name: Build client-side API markdown docs
-        run: npx typedoc --tsconfig tsconfig.sdk.json --plugin typedoc-plugin-markdown  --out typedocs src/components/activities/index.ts
+        run: cd assets && npx typedoc --tsconfig tsconfig.sdk.json --plugin typedoc-plugin-markdown  --out typedocs src/components/activities/index.ts
 
       - name: 🔨📄 Build Docs
         run: mix docs

--- a/test/oli_web/controllers/api/activity_registration_controller_test.exs
+++ b/test/oli_web/controllers/api/activity_registration_controller_test.exs
@@ -11,7 +11,7 @@ defmodule OliWeb.Api.ActivityRegistrationControllerTest do
       conn: conn
     } do
 
-      original_count = Oli.Activities.list_activity_registrations() |> Enum.count()
+      _original_count = Oli.Activities.list_activity_registrations() |> Enum.count()
 
       payload = %{"upload" => %{path: "./test/oli_web/controllers/api/activity/bundle.zip"}}
 
@@ -23,7 +23,7 @@ defmodule OliWeb.Api.ActivityRegistrationControllerTest do
       |> Plug.Conn.put_req_header("content-type", "multipart/form-data")
       |> ActivityRegistrationController.create(payload)
 
-      new_count = Oli.Activities.list_activity_registrations() |> Enum.count()
+      _new_count = Oli.Activities.list_activity_registrations() |> Enum.count()
 
       # This assertion succeeds when running the test locally, but fails when
       # run on the server as part of the build


### PR DESCRIPTION
Typedocs build step was being invoked at the root, and not within `assets`