### PR TITLE
[ENHANCEMENT] [MER-1113] Fixed auth on swagger docs

### DIFF
--- a/lib/oli_web/api_spec.ex
+++ b/lib/oli_web/api_spec.ex
@@ -1,5 +1,5 @@
 defmodule OliWeb.ApiSpec do
-  alias OpenApiSpex.{Info, OpenApi, Paths, Server}
+  alias OpenApiSpex.{Info, OpenApi, Paths, Server, SecurityScheme, Components}
   alias OliWeb.{Endpoint, Router}
   @behaviour OpenApi
 
@@ -13,6 +13,11 @@ defmodule OliWeb.ApiSpec do
       info: %Info{
         title: "OLI",
         version: "1.0"
+      },
+      components: %Components{
+        securitySchemes: %{
+          "bearer-authorization" => %SecurityScheme{type: "http", scheme: "bearer"}
+        }
       },
 
       # Populate the paths from a phoenix router

--- a/lib/oli_web/controllers/api/activity_registration_controller.ex
+++ b/lib/oli_web/controllers/api/activity_registration_controller.ex
@@ -14,7 +14,6 @@ defmodule OliWeb.Api.ActivityRegistrationController do
 
   alias OpenApiSpex.Schema
 
-
   defmodule RegistrationResponse do
     require OpenApiSpex
 
@@ -53,19 +52,24 @@ defmodule OliWeb.Api.ActivityRegistrationController do
   Uploads an activity bundle for registation or update.
   """
   @doc parameters: [],
-  request_body:
+       security: [%{"bearer-authorization" => []}],
+       request_body:
          {"File upload", "multipart/form-data",
-         OliWeb.Api.ActivityRegistrationController.RegistrationUploadBody, required: true},
-  responses: %{
-    200 =>
-      {"Retrieval Response", "application/json",
-       OliWeb.Api.ActivityRegistrationController.RegistrationResponse}
-  }
+          OliWeb.Api.ActivityRegistrationController.RegistrationUploadBody, required: true},
+       responses: %{
+         200 =>
+           {"Retrieval Response", "application/json",
+            OliWeb.Api.ActivityRegistrationController.RegistrationResponse}
+       }
+
   def create(conn, %{"upload" => upload}) do
     if is_valid_api_key?(conn, &Oli.Interop.validate_for_registration/1) do
       expected_namespace = get_api_namespace(conn)
+
       case Activities.register_from_bundle(upload.path, expected_namespace) do
-        {:ok, _} -> json(conn, %{result: :success})
+        {:ok, _} ->
+          json(conn, %{result: :success})
+
         e ->
           error(conn, 400, Kernel.inspect(e))
       end
@@ -73,5 +77,4 @@ defmodule OliWeb.Api.ActivityRegistrationController do
       error(conn, 400, "invalid key")
     end
   end
-
 end

--- a/lib/oli_web/controllers/api/payment_controller.ex
+++ b/lib/oli_web/controllers/api/payment_controller.ex
@@ -71,6 +71,7 @@ defmodule OliWeb.Api.PaymentController do
   Create a batch of payment codes for a specific product.
   """
   @doc parameters: [],
+       security: [%{"bearer-authorization" => []}],
        request_body:
          {"Request body for making a payment code batch request", "application/json",
           OliWeb.Api.PaymentController.BatchPaymentCodeRequest, required: true},

--- a/lib/oli_web/controllers/api/product_controller.ex
+++ b/lib/oli_web/controllers/api/product_controller.ex
@@ -55,6 +55,7 @@ defmodule OliWeb.Api.ProductController do
   Access the list of available products.
   """
   @doc parameters: [],
+       security: [%{"bearer-authorization" => []}],
        responses: %{
          200 =>
            {"Product Listing Response", "application/json",


### PR DESCRIPTION
Small developer quality-of-life update:

The api docs at /api/v1/docs for the calls protected by api keys, authentication wasn't set correctly.

Now, you can use that interface to call the API methods by pasting in a base-64 encoded api key. That UI is only available in :dev or :test mix environments.

Example:

![swagger-auth](https://user-images.githubusercontent.com/333265/166479559-321cb668-e5de-44b9-97f2-0118d230e52d.gif)

