### PR TITLE
[BUG FIX] fix an issue where multiple user accounts linked to an author results in error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 ### Enhancements
 
+## 0.19.1 (2022-05-03)
+
+### Bug Fixes
+
+- Fix an issue where multiple user accounts linked to a single author results in an internal server error
+
 ## 0.19.0 (2022-05-03)
 
 ### Bug Fixes

--- a/lib/oli_web/templates/layout/_author_account_dropdown.html.eex
+++ b/lib/oli_web/templates/layout/_author_account_dropdown.html.eex
@@ -1,5 +1,3 @@
-<% user = author_linked_account(@current_author) %>
-
 <nav class="navbar p-0 small">
   <div class="nav-item dropdown form-inline my-2 my-lg-0">
     <a class="user nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -11,14 +9,6 @@
     </a>
 
     <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
-      <%= if not is_nil(user) do %>
-        <h6 class="dropdown-header">Linked: <%= user.email %></h6>
-        <%= if user_is_independent_learner?(user) or Sections.is_independent_instructor?(user) do %>
-          <a class="dropdown-item" href="<%= Routes.delivery_path(@conn, :open_and_free_index) %>" target="_blank">Go to My Courses<i class="fas fa-external-link-alt float-right" style="margin-top: 2px"></i></a>
-        <% end %>
-        <div class="dropdown-divider"></div>
-      <% end %>
-
       <%= link "Edit Account", to: Routes.live_path(@conn, OliWeb.Workspace.AccountDetailsLive), class: "dropdown-item btn" %>
       <div class="dropdown-item no-hover">
         Dark Mode <div id="theme-toggle"></div>

--- a/lib/oli_web/views/layout_view.ex
+++ b/lib/oli_web/views/layout_view.ex
@@ -14,7 +14,6 @@ defmodule OliWeb.LayoutView do
 
   import OliWeb.AuthoringView,
     only: [
-      author_linked_account: 1,
       author_role_text: 1,
       author_role_color: 1,
       author_icon: 1

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Oli.MixProject do
   def project do
     [
       app: :oli,
-      version: "0.19.0",
+      version: "0.19.1",
       elixir: "~> 1.13.2",
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: elixirc_options(Mix.env()),

--- a/test/oli_web/controllers/project_controller_test.exs
+++ b/test/oli_web/controllers/project_controller_test.exs
@@ -5,6 +5,8 @@ defmodule OliWeb.ProjectControllerTest do
   alias Oli.Activities
   alias Oli.Activities.ActivityRegistrationProject
 
+  import Oli.Factory
+
   @basic_get_routes [:overview, :publish, :insights]
   setup [:author_project_conn]
   @valid_attrs %{title: "default title"}
@@ -25,6 +27,19 @@ defmodule OliWeb.ProjectControllerTest do
 
     @basic_get_routes
     |> Enum.each(fn path -> unauthorized_redirect(conn, path, project2.slug) end)
+  end
+
+  describe "projects" do
+    # this test demonstrates the valid case where an author has multiple user accounts associated
+    # which will result in an error (consider an authoring account shared across lms or independent instructor accounts)
+    test "multiple linked user accounts still renders properly", %{conn: conn, author: author} do
+      _user_associated = insert(:user, author: author)
+      _user2_associated = insert(:user, author: author)
+
+      conn = get(conn, Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.ProjectsLive))
+
+      assert html_response(conn, 200) =~ "<h3>Projects</h3>"
+    end
   end
 
   describe "overview" do

--- a/test/oli_web/controllers/project_controller_test.exs
+++ b/test/oli_web/controllers/project_controller_test.exs
@@ -31,7 +31,7 @@ defmodule OliWeb.ProjectControllerTest do
 
   describe "projects" do
     # this test demonstrates the valid case where an author has multiple user accounts associated
-    # which will result in an error (consider an authoring account shared across lms or independent instructor accounts)
+    # (consider an authoring account shared across lms or independent instructor accounts)
     test "multiple linked user accounts still renders properly", %{conn: conn, author: author} do
       _user_associated = insert(:user, author: author)
       _user2_associated = insert(:user, author: author)


### PR DESCRIPTION
This PR fixes an issue related to the discussion in https://github.com/Simon-Initiative/oli-torus/pull/2424#issuecomment-1098317873

The unit test included recreates the problem discussed in the related PR discussion above. To recreate the issue, one must link multiple user accounts (possibly across different LMS) to a single authoring account.

Author accounts can have more than one user account associated with them, and therefore it is not possible have a single "Go to my courses" link from the author account dropdown, due the one:many relationship. This is because a single author account may be used across multiple LMS and independent instructor accounts. This fix is high priority, as it resolves a production issue where this situation crashes the server. A larger discussion will be necessary to determine how to accommodate the intended use case of the original PR.

Closes #2492