### PR TITLE
[BUG FIX] redirect to guard, not the direct payment show MER-1124

### DIFF
--- a/lib/oli_web/templates/layout/_pay_early.html.eex
+++ b/lib/oli_web/templates/layout/_pay_early.html.eex
@@ -1,6 +1,6 @@
 <%= if show_pay_early(Map.get(@conn.assigns, :paywall_summary)) do %>
 <div class="system-banner alert alert-warning" role="alert">
   <%= pay_early_message(@conn.assigns.paywall_summary) %>
-  <a class="ml-3" href="<%= Routes.payment_path(@conn, :make_payment, @section.slug) %>">Pay Now</a>
+  <a class="ml-3" href="<%= Routes.payment_path(@conn, :guard, @section.slug) %>">Pay Now</a>
 </div>
 <% end %>


### PR DESCRIPTION
Root cause was the wrong route endpoint was linked from the "Pay Early" message.  Instead of the view that allows the student to pick either "Pay with Credit Card" or "Pay with Code" this view was taking the user directly to the "Pay with Credit Card" view. 