### PR TITLE
[BUG FIX] Fix paging when there is an active filter in Activity Bank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bug Fixes
 
+- Fix an issue where paging in Activity Bank did not preserve filtered logic
+
 ### Enhancements
 
 ## 0.19.1 (2022-05-03)

--- a/assets/src/apps/bank/ActivityBank.tsx
+++ b/assets/src/apps/bank/ActivityBank.tsx
@@ -524,6 +524,7 @@ export class ActivityBank extends React.Component<ActivityBankProps, ActivityBan
         this.setState({
           activityContexts: Immutable.OrderedMap<string, ActivityEditContext>(contexts as any),
           paging,
+          logic,
           totalCount: result.queryResult.totalCount,
         });
         result.queryResult.rows;


### PR DESCRIPTION
Closes #2496 

Root cause was that the bank filter was not being preserved when paging controls were used.  Simple fix, tested locally and works now. 