### PR TITLE
[BUG FIX] Update schemas, remove ability to set width

### DIFF
--- a/assets/src/components/editing/elements/webpage/WebpageModal.tsx
+++ b/assets/src/components/editing/elements/webpage/WebpageModal.tsx
@@ -29,23 +29,6 @@ export const WebpageModal = ({ onDone, onCancel, model }: ModalProps) => {
           </span>
         </div>
 
-        <h4 className="mb-2">Size</h4>
-        <p className="mb-2">
-          You can manually set the embed width here and the height will scale automatically.
-        </p>
-        <div className="mb-4">
-          <span>
-            Width:{' '}
-            <input
-              type="number"
-              value={width}
-              onChange={(e) => {
-                const width = parseInt(e.target.value);
-                !Number.isNaN(width) && setWidth(width);
-              }}
-            />
-          </span>
-        </div>
         <h4 className="mb-2">Alternative Text</h4>
         <p className="mb-4">
           Write a short description of this image for visitors who are unable to see it.

--- a/assets/src/components/editing/elements/youtube/YoutubeModal.tsx
+++ b/assets/src/components/editing/elements/youtube/YoutubeModal.tsx
@@ -29,23 +29,6 @@ export const YouTubeModal = ({ onDone, onCancel, model }: ModalProps) => {
           </span>
         </div>
 
-        <h4 className="mb-2">Size</h4>
-        <p className="mb-2">
-          You can manually set the video width here and the height will scale automatically.
-        </p>
-        <div className="mb-4">
-          <span>
-            Width:{' '}
-            <input
-              type="number"
-              value={width}
-              onChange={(e) => {
-                const width = parseInt(e.target.value);
-                !Number.isNaN(width) && setWidth(width);
-              }}
-            />
-          </span>
-        </div>
         <h4 className="mb-2">Alternative Text</h4>
         <p className="mb-4">
           Write a short description of this image for visitors who are unable to see it.

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -64,7 +64,6 @@ defmodule Oli.Rendering.Content.Html do
     ["<h6>", next.(), "</h6>\n"]
   end
 
-
   def img(%Context{} = context, _, %{"src" => src} = attrs) do
     maybeAlt =
       case attrs do
@@ -105,7 +104,9 @@ defmodule Oli.Rendering.Content.Html do
     # If the width is hard-coded, do not display responsively.
     figure(context, attrs, [
       """
-      <iframe#{maybeWidth(attrs)}#{maybeAlt(attrs)} class="embed-responsive-item" allowfullscreen src="#{escape_xml!(src)}"></iframe>
+      <div class="embed-responsive embed-responsive-16by9">
+        <iframe#{maybeWidth(attrs)}#{maybeAlt(attrs)} class="embed-responsive-item" allowfullscreen src="#{escape_xml!(src)}"></iframe>
+      </div>
       """
     ])
   end
@@ -455,5 +456,4 @@ defmodule Oli.Rendering.Content.Html do
       _ -> ""
     end
   end
-
 end

--- a/priv/schemas/v0-1-0/content-element.schema.json
+++ b/priv/schemas/v0-1-0/content-element.schema.json
@@ -367,10 +367,10 @@
           "type": "string"
         },
         "height": {
-          "type": "string"
+          "type": ["string", "number"]
         },
         "width": {
-          "type": "string"
+          "type": ["string", "number"]
         },
         "alt": {
           "type": "string"
@@ -409,13 +409,13 @@
           "const": "iframe"
         },
         "src": {
-          "type": "string"
+          "type": ["string", "number"]
         },
         "height": {
-          "type": "string"
+          "type": ["string", "number"]
         },
         "width": {
-          "type": "string"
+          "type": ["string", "number"]
         },
         "alt": {
           "type": "string"


### PR DESCRIPTION
Closes #2497 

There were a couple of different problems here, most notably a mismatch between the content schema definition of `height` and `width` of some elements and the data types that their UI editing components were attempting to save in.  To resolve this, I expanded support for the various media elements to accept either a number or a string for height and width. 

Second, when `width` was present for a youtube video the delivery rendering code was not wrapping it in a bootstrap responsive embed.  This was causing it to render in really bad ways - basically if `width` was set to 1000 it would render as a really wide but really short "slice" of a youtube video that wasn't usuable. 

But I don't believe it makes sense to allow the width and height to be set for YouTube and for Iframe.  Rather, we want a responsive implementation that will scale those elements according to the screen/device size.   I can see no good use case for explicit sizes for these elements. In images, of course, it makes sense to allow setting width (and preserving aspect ratio).  Perhaps at most we would want to support is to allow selection of the desired aspect ratio for Webpages. 
So given this analysis, this PR also removes the "width" editor for both YouTube and WebPage elements. 