### PR TITLE
[BUG FIX] MER-1125 improved guard to force new revision creation

### DIFF
--- a/lib/oli/authoring/editing/activity_editor.ex
+++ b/lib/oli/authoring/editing/activity_editor.ex
@@ -302,7 +302,7 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
 
           activity ->
             get_latest_revision(publication.id, activity.id)
-            |> maybe_create_new_revision(publication, activity, author.id, update)
+            |> maybe_create_new_revision(publication, project, activity, author.id, update)
             |> update_revision(update, project.slug)
         end
       end)
@@ -365,7 +365,7 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
             # to resolve this activity via the historical slugs would fail.
             {:updated} ->
               get_latest_revision(publication.id, activity.id)
-              |> maybe_create_new_revision(publication, activity, author.id, update)
+              |> maybe_create_new_revision(publication, project, activity, author.id, update)
               |> update_revision(update, project.slug)
               |> possibly_release_lock(project, publication, resource, author, update)
 
@@ -470,10 +470,12 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
   end
 
   # create a new revision only if the slug will change due to this update
-  defp maybe_create_new_revision(previous, publication, activity, author_id, update) do
+  defp maybe_create_new_revision(previous, publication, project, activity, author_id, update) do
     title = Map.get(update, "title", previous.title)
 
-    if title != previous.title do
+    needs_new_revision = Oli.Publishing.needs_new_revision_for_edit?(project.slug, previous.id)
+
+    if title != previous.title or needs_new_revision do
       create_new_revision(previous, publication, activity, author_id)
     else
       previous

--- a/test/oli/clone_test.exs
+++ b/test/oli/clone_test.exs
@@ -12,6 +12,23 @@ defmodule Oli.CloneTest do
   alias Oli.Authoring.Clone
   alias Oli.Authoring.Editing.PageEditor
 
+  describe "need for new revision checks" do
+    setup do
+      Oli.Seeder.base_project_with_resource2()
+    end
+
+    test "needs_new_revision_for_edit?/2", %{
+      project: project,
+      revision1: revision1,
+      author2: author2
+    } do
+      refute Oli.Publishing.needs_new_revision_for_edit?(project.slug, revision1.id)
+
+      {:ok, _} = Clone.clone_project(project.slug, author2)
+      assert Oli.Publishing.needs_new_revision_for_edit?(project.slug, revision1.id)
+    end
+  end
+
   describe "project duplication" do
     setup do
       project_map = Oli.Seeder.base_project_with_resource2()


### PR DESCRIPTION
This PR improves the logic to guard against edits made in duplicate projects affecting the upstream original. 

The root cause of these ongoing problems is reliance on the lock acquisition result (acquired or updated) to determine if a new revision is needed.  I believe there are cases with the bulk activity edit endpoint in the adaptive page where this strategy falls down. 

Rather than rework this lock based logic, I am replacing this with a much more straightforward approach.  This PR adds a check to see if any other PublishedResource records have the same `revision_id` as the id of the revision that is about to be edited.  For the project that we are editing within, if the only published resource record that contains this same revision id pertains to the "unpublished" publication, we are safe to proceed with editing the revision in place (assuming that the title hasn't changed or the lock wasn't just acquired).  More importantly, in all other cases, we force both the page and activity editor code to create a new revision.  

Imagine this scenario:

A course project containing one page is duplicated five times.  We would then have several `PublishedResource` records that all have the same `revision_id` for the single page in the course.  If we would attempt to edit this page in any of these projects, the `needs_new_revision_for_edit?` would return `true`, thus forcing a new revision to be created.  The new unit test in this PR exercises this exact scenario, albeit with just one clone. 

I've tested this interactively with the basic and adaptive editor, in addition to the unit test. 