### PR TITLE
[BUGFIX] hack the part component types onto the window pending a better fix

### DIFF
--- a/assets/src/apps/authoring/store/app/slice.ts
+++ b/assets/src/apps/authoring/store/app/slice.ts
@@ -100,6 +100,10 @@ const slice: Slice<AppState> = createSlice({
       state.revisionSlug = action.payload.revisionSlug || initialState.revisionSlug;
       state.partComponentTypes =
         action.payload.partComponentTypes || initialState.partComponentTypes;
+
+      // HACK! AddPartToolbar needs partComponentTypes on the window for now
+      (window as any)['partComponentTypes'] = state.partComponentTypes;
+
       state.activityTypes = action.payload.activityTypes || initialState.activityTypes;
       state.copiedPart = action.payload.copiedPart || initialState.copiedPart;
     },


### PR DESCRIPTION
the screen editor for Feedback and Popups was using a hack on the window object because of the nested web components. this went away when we changed how apps were launched/registered. putting it back for now