### PR TITLE
[BUG FIX] Fix publish LTI instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 ### Enhancements
 
+## 0.19.2 (2022-05-13)
+
+### Bug Fixes
+
+- Fix an issue where get connected button on publish page doesn't work
+
 ## 0.19.1 (2022-05-03)
 
 ### Bug Fixes

--- a/lib/oli_web/templates/project/_lti_connect_instructions.html.eex
+++ b/lib/oli_web/templates/project/_lti_connect_instructions.html.eex
@@ -26,6 +26,13 @@ $(function() {
     }
   });
 
+  const lms_config_details = document.querySelector('#lms-config-details');
+  const lms_config_details_toggle = document.querySelector('a#lms-config-details-toggle');
+
+  lms_config_details_toggle.addEventListener('click', function() {
+    lms_config_details.classList.toggle('d-none');
+  })
+
 })
 </script>
 
@@ -40,9 +47,9 @@ $(function() {
           Click the button below to get started.
         </p>
 
-        <a href="#" class="btn btn-primary mt-3" data-toggle="collapse" data-target="#lms-config-details">Get Connected</a>
+        <a id="lms-config-details-toggle" href="#" class="btn btn-primary mt-3" data-toggle="collapse" data-target="#lms-config-details">Get Connected</a>
 
-        <div class="collapse" id="lms-config-details">
+        <div id="lms-config-details" class="d-none">
           <hr class="my-3" />
 
           <p class="my-3 text-secondary">

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Oli.MixProject do
   def project do
     [
       app: :oli,
-      version: "0.19.1",
+      version: "0.19.2",
       elixir: "~> 1.13.2",
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: elixirc_options(Mix.env()),


### PR DESCRIPTION
This hotfix PR fixes an issue where LTI Get Connected button was not working due to incorrect jquery version. The changes here simply remove the bootstrap collapse component and replace it was regular javascript.

Closes #2339