### PR TITLE
[BUGFIX] [MER-1118] Materials order

### DIFF
--- a/lib/oli_web/live/common/hierarchy/hierarchy_picker.ex
+++ b/lib/oli_web/live/common/hierarchy/hierarchy_picker.ex
@@ -306,8 +306,8 @@ defmodule OliWeb.Common.Hierarchy.HierarchyPicker do
       Oli.Resources.ResourceType.get_type_by_id(a.resource_type_id),
       Oli.Resources.ResourceType.get_type_by_id(b.resource_type_id)
     } do
-      {"container", "container"} -> true
       {"container", _} -> true
+      {type_a, type_b} when type_a == type_b -> true
       _ -> false
     end
   end

--- a/lib/oli_web/live/common/hierarchy/hierarchy_picker.ex
+++ b/lib/oli_web/live/common/hierarchy/hierarchy_picker.ex
@@ -290,7 +290,7 @@ defmodule OliWeb.Common.Hierarchy.HierarchyPicker do
     end
   end
 
-  def sort_items(children, assigns) do
+  defp sort_items(children, assigns) do
     case assigns do
       %{sort_items_fn: sort_items_fn} when sort_items_fn != nil ->
         sort_items_fn.(children)

--- a/lib/oli_web/live/delivery/remix_section.ex
+++ b/lib/oli_web/live/delivery/remix_section.ex
@@ -635,4 +635,9 @@ defmodule OliWeb.Delivery.RemixSection do
     previous = Enum.at(breadcrumbs, length(breadcrumbs) - 2)
     previous.slug
   end
+
+  defp filter_items(children, dragging) do
+    Enum.with_index(children)
+    |> Enum.filter(fn {c, _i} -> c.uuid != dragging end)
+  end
 end

--- a/lib/oli_web/live/delivery/remix_section.ex
+++ b/lib/oli_web/live/delivery/remix_section.ex
@@ -637,7 +637,8 @@ defmodule OliWeb.Delivery.RemixSection do
   end
 
   defp filter_items(children, dragging) do
-    Enum.with_index(children)
+    children
+    |> Enum.with_index()
     |> Enum.filter(fn {c, _i} -> c.uuid != dragging end)
   end
 end

--- a/lib/oli_web/live/delivery/remix_section.ex
+++ b/lib/oli_web/live/delivery/remix_section.ex
@@ -21,7 +21,7 @@ defmodule OliWeb.Delivery.RemixSection do
   alias Oli.Delivery.Hierarchy
   alias OliWeb.Common.Breadcrumb
   alias OliWeb.Delivery.Remix.{RemoveModal, AddMaterialsModal}
-  alias OliWeb.Common.Hierarchy.{HierarchyPicker, MoveModal}
+  alias OliWeb.Common.Hierarchy.MoveModal
   alias Oli.Publishing
   alias Oli.Publishing.PublishedResource
   alias OliWeb.Sections.Mount
@@ -634,11 +634,5 @@ defmodule OliWeb.Delivery.RemixSection do
   defp previous_uuid(breadcrumbs) do
     previous = Enum.at(breadcrumbs, length(breadcrumbs) - 2)
     previous.slug
-  end
-
-  defp build_entries(items, assigns, selected) do
-    HierarchyPicker.sort_items(items, assigns)
-    |> Enum.with_index()
-    |> Enum.filter(fn {c, _i} -> c.uuid != selected end)
   end
 end

--- a/lib/oli_web/live/delivery/remix_section.html.heex
+++ b/lib/oli_web/live/delivery/remix_section.html.heex
@@ -28,7 +28,7 @@
             <p>There's nothing here.</p>
           </div>
         <% end %>
-        <%= for {node, index} <- Enum.with_index(@active.children) |> Enum.filter(fn {c, _i} -> c.uuid != @dragging end) do %>
+        <%= for {node, index} <- filter_items(@active.children, @dragging) do %>
           <DropTarget.droptarget id={index} index={index} />
           <Entry.entry
               index={index}

--- a/lib/oli_web/live/delivery/remix_section.html.heex
+++ b/lib/oli_web/live/delivery/remix_section.html.heex
@@ -28,7 +28,7 @@
             <p>There's nothing here.</p>
           </div>
         <% end %>
-        <%= for {node, index} <- build_entries(@active.children, assigns, @dragging) do %>
+        <%= for {node, index} <- Enum.with_index(@active.children) |> Enum.filter(fn {c, _i} -> c.uuid != @dragging end) do %>
           <DropTarget.droptarget id={index} index={index} />
           <Entry.entry
               index={index}

--- a/test/oli_web/live/remix_section_test.exs
+++ b/test/oli_web/live/remix_section_test.exs
@@ -142,57 +142,6 @@ defmodule OliWeb.RemixSectionLiveTest do
 
       assert_redirect(view, Routes.page_delivery_path(conn, :index, section.slug))
     end
-
-    test "remix section items order is equal to shown in add materials", %{
-      conn: conn,
-      admin: admin,
-      map: %{
-        oaf_section_1: oaf_section_1,
-        unit1_container: unit1_container,
-        latest1: latest1,
-        latest2: latest2,
-      }
-    } do
-      conn =
-        Plug.Test.init_test_session(conn, %{})
-        |> Pow.Plug.assign_current_user(admin, OliWeb.Pow.PowHelpers.get_pow_config(:author))
-
-      {:ok, view, _html} = live(conn, Routes.live_path(OliWeb.Endpoint, OliWeb.Delivery.RemixSection, oaf_section_1.slug))
-
-      # finding by two because we have a droptarget component between each entry
-      assert view
-        |> element(".curriculum-entries > div:nth-child(2)")
-        |> render() =~ "#{unit1_container.revision.title}"
-
-      assert view
-        |> element(".curriculum-entries > div:nth-child(4)")
-        |> render() =~ "#{latest2.title}"
-
-      assert view
-        |> element(".curriculum-entries > div:nth-child(6)")
-        |> render() =~ "#{latest1.title}"
-
-      # click add materials and assert is listing in same order
-      view
-      |> element("button[phx-click=\"show_add_materials_modal\"]")
-      |> render_click()
-
-      view
-      |> element(".hierarchy > div:first-child > button[phx-click=\"HierarchyPicker.select_publication\"]")
-      |> render_click()
-
-      assert view
-        |> element(".hierarchy > div[id^=\"hierarchy_item_\"]:nth-child(1)")
-        |> render() =~ "#{unit1_container.revision.title}"
-
-      assert view
-        |> element(".hierarchy > div[id^=\"hierarchy_item_\"]:nth-child(2)")
-        |> render() =~ "#{latest2.title}"
-
-      assert view
-        |> element(".hierarchy > div[id^=\"hierarchy_item_\"]:nth-child(3)")
-        |> render() =~ "#{latest1.title}"
-    end
   end
 
   describe "breadcrumbs" do

--- a/test/oli_web/live/remix_section_test.exs
+++ b/test/oli_web/live/remix_section_test.exs
@@ -142,6 +142,47 @@ defmodule OliWeb.RemixSectionLiveTest do
 
       assert_redirect(view, Routes.page_delivery_path(conn, :index, section.slug))
     end
+
+    test "remix section items and add materials items are ordered correctly", %{
+      conn: conn,
+      admin: admin,
+      map: %{
+        oaf_section_1: oaf_section_1,
+        unit1_container: unit1_container,
+        latest2: latest2
+      }
+    } do
+      conn =
+        Plug.Test.init_test_session(conn, %{})
+        |> Pow.Plug.assign_current_user(admin, OliWeb.Pow.PowHelpers.get_pow_config(:author))
+
+      {:ok, view, _html} = live(conn, Routes.live_path(OliWeb.Endpoint, OliWeb.Delivery.RemixSection, oaf_section_1.slug))
+
+      assert view
+        |> element(".curriculum-entries > div:nth-child(2)")
+        |> render() =~ "#{latest2.title}"
+
+      assert view
+        |> element(".curriculum-entries > div:nth-child(6)")
+        |> render() =~ "#{unit1_container.revision.title}"
+
+      # click add materials and assert is listing units first
+      view
+      |> element("button[phx-click=\"show_add_materials_modal\"]")
+      |> render_click()
+
+      view
+      |> element(".hierarchy > div:first-child > button[phx-click=\"HierarchyPicker.select_publication\"]")
+      |> render_click()
+
+      assert view
+        |> element(".hierarchy > div[id^=\"hierarchy_item_\"]:nth-child(1)")
+        |> render() =~ "#{unit1_container.revision.title}"
+
+      assert view
+        |> element(".hierarchy > div[id^=\"hierarchy_item_\"]:nth-child(2)")
+        |> render() =~ "#{latest2.title}"
+    end
   end
 
   describe "breadcrumbs" do

--- a/test/oli_web/live/remix_section_test.exs
+++ b/test/oli_web/live/remix_section_test.exs
@@ -149,6 +149,7 @@ defmodule OliWeb.RemixSectionLiveTest do
       map: %{
         oaf_section_1: oaf_section_1,
         unit1_container: unit1_container,
+        latest1: latest1,
         latest2: latest2
       }
     } do
@@ -160,6 +161,10 @@ defmodule OliWeb.RemixSectionLiveTest do
 
       assert view
         |> element(".curriculum-entries > div:nth-child(2)")
+        |> render() =~ "#{latest1.title}"
+
+      assert view
+        |> element(".curriculum-entries > div:nth-child(4)")
         |> render() =~ "#{latest2.title}"
 
       assert view
@@ -181,6 +186,10 @@ defmodule OliWeb.RemixSectionLiveTest do
 
       assert view
         |> element(".hierarchy > div[id^=\"hierarchy_item_\"]:nth-child(2)")
+        |> render() =~ "#{latest1.title}"
+
+      assert view
+        |> element(".hierarchy > div[id^=\"hierarchy_item_\"]:nth-child(3)")
         |> render() =~ "#{latest2.title}"
     end
   end


### PR DESCRIPTION
[MER-1118](https://eliterate.atlassian.net/browse/MER-1118)

Reverted changes did in https://github.com/Simon-Initiative/oli-torus/pull/2472

Expected
- In remix section view and student section view, order from db is respected
- In add materials modal, units are placed first for all lessons