### PR TITLE
[MER-1072] Wire lesson finish urls from backend

### DIFF
--- a/assets/src/apps/delivery/Delivery.tsx
+++ b/assets/src/apps/delivery/Delivery.tsx
@@ -28,6 +28,8 @@ export interface DeliveryProps {
   enableHistory?: boolean;
   activityTypes?: any[];
   graded: boolean;
+  overviewURL: string;
+  finalizeGradedURL: string;
 }
 
 const Delivery: React.FC<DeliveryProps> = ({
@@ -45,6 +47,8 @@ const Delivery: React.FC<DeliveryProps> = ({
   previewMode = false,
   enableHistory = false,
   graded = false,
+  overviewURL = '',
+  finalizeGradedURL = '',
 }) => {
   const dispatch = useDispatch();
   const currentGroup = useSelector(selectCurrentGroup);
@@ -85,6 +89,8 @@ const Delivery: React.FC<DeliveryProps> = ({
         score: 0,
         graded,
         activeEverapp: 'none',
+        overviewURL,
+        finalizeGradedURL,
       }),
     );
   };

--- a/assets/src/apps/delivery/layouts/deck/LessonFinishedDialog.tsx
+++ b/assets/src/apps/delivery/layouts/deck/LessonFinishedDialog.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { selectPreviewMode, selectResourceAttemptGuid } from '../../store/features/page/slice';
+import {
+  selectPreviewMode,
+  selectOverviewURL,
+  selectFinalizeGradedURL,
+} from '../../store/features/page/slice';
 import { selectIsGraded } from 'apps/authoring/store/page/slice';
 
 interface LessonFinishedDialogProps {
@@ -17,19 +21,18 @@ const LessonFinishedDialog: React.FC<LessonFinishedDialogProps> = ({
 }) => {
   const [isOpen, setIsOpen] = useState(true);
   const isPreviewMode = useSelector(selectPreviewMode);
-  const resourceAttemptGuid = useSelector(selectResourceAttemptGuid);
   const graded = useSelector(selectIsGraded);
+  const overviewURL = useSelector(selectOverviewURL);
+  const finalizeGradedURL = useSelector(selectFinalizeGradedURL);
 
   const handleCloseModalClick = () => {
     setIsOpen(false);
     if (isPreviewMode) {
       window.location.reload();
     } else {
-      const currentUrl = window.location.href;
       if (graded) {
-        window.location.href = `${currentUrl}/attempt/${resourceAttemptGuid}`;
+        window.location.href = finalizeGradedURL;
       } else {
-        const overviewURL = currentUrl.split('/page')[0] + '/overview';
         window.location.href = overviewURL;
       }
     }

--- a/assets/src/apps/delivery/store/features/page/slice.ts
+++ b/assets/src/apps/delivery/store/features/page/slice.ts
@@ -21,6 +21,8 @@ export interface PageState {
   score: number;
   graded: boolean;
   activeEverapp: string;
+  overviewURL: string;
+  finalizeGradedURL: string;
 }
 
 const initialState: PageState = {
@@ -41,6 +43,8 @@ const initialState: PageState = {
   score: 0,
   graded: false,
   activeEverapp: '',
+  overviewURL: '',
+  finalizeGradedURL: '',
 };
 
 const pageSlice = createSlice({
@@ -65,6 +69,8 @@ const pageSlice = createSlice({
       state.previewMode = !!action.payload.previewMode;
       state.activityTypes = action.payload.activityTypes;
       state.graded = !!action.payload.graded;
+      state.overviewURL = action.payload.overviewURL;
+      state.finalizeGradedURL = action.payload.finalizeGradedURL;
 
       if (state.previewMode && !state.resourceAttemptGuid) {
         state.resourceAttemptGuid = `preview_${guid()}`;
@@ -119,6 +125,15 @@ export const selectActiveEverapp = createSelector(selectState, (state) => state.
 export const selectIsLegacyTheme = createSelector(
   selectState,
   (state) => !state.content?.custom?.themeId,
+);
+
+export const selectOverviewURL = createSelector(
+  selectState,
+  (state: PageState) => state.overviewURL,
+);
+export const selectFinalizeGradedURL = createSelector(
+  selectState,
+  (state: PageState) => state.finalizeGradedURL,
 );
 
 export default pageSlice.reducer;

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -429,7 +429,9 @@ defmodule OliWeb.PageDeliveryController do
         previousPageURL: previous_url,
         nextPageURL: next_url,
         previewMode: preview_mode,
-        reviewMode: context.review_mode
+        reviewMode: context.review_mode,
+        overviewURL: Routes.page_delivery_path(conn, :index, section.slug),
+        finalizeGradedURL: Routes.page_delivery_path(conn, :finalize_attempt, section.slug, context.page.slug, resource_attempt.attempt_guid)
       },
       activity_type_slug_mapping: %{},
       activity_types: activity_types,


### PR DESCRIPTION
[MER-1072](https://eliterate.atlassian.net/browse/MER-1072)

## What's changed?

The urls that the lessons were redirecting to after finishing them when closing the congrats modal were wrong as they were hardcoded and calculated given the current url of window.

In the use case of reviewing again the lesson and "re-submitting" it, the  `/attempt/${resourceAttemptGuid}` path was being appended twice. 

With this change, the urls are sent from the phoenix app, so no matter where it comes from it will redirect just fine. Also, if tomorrow the path of those route changes, it's not necessary to update anything in the JS code.