### PR TITLE
[BUGFIX][MER-1117] Fix performance issues on remix page

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -1431,7 +1431,13 @@ defmodule Oli.Delivery.Sections do
         end
       end)
 
-    Map.merge(prs_by_non_uniq_slug, prs_by_uniq_slug)
+    unless Enum.empty?(prs_by_non_uniq_slug) do
+      throw(
+        "Cannot rebuild section curriculum. After several attempts it was not possible to generate unique slugs for new nonstructural section resources. See Oli.Delivery.Sections.create_nonstructural_section_resources/3 for details."
+      )
+    end
+
+    prs_by_uniq_slug
   end
 
   @doc """

--- a/lib/oli/publishing.ex
+++ b/lib/oli/publishing.ex
@@ -565,15 +565,22 @@ defmodule Oli.Publishing do
       when is_list(publication_ids) do
     preload = Keyword.get(opts, :preload, [:resource, :revision, :publication])
 
-    from(pr in PublishedResource,
-      where: pr.publication_id in ^publication_ids,
-      preload: ^preload
-    )
+    PublishedResource
+    |> where([pr], pr.publication_id in ^publication_ids)
+    |> maybe_preload(preload)
     |> Repo.all()
   end
 
   def get_published_resources_by_publication(publication_id, opts) do
     get_published_resources_by_publication([publication_id], opts)
+  end
+
+  defp maybe_preload(query, preload) do
+    Enum.reduce(preload, query, fn rel_table, acc_query ->
+      acc_query
+      |> join(:left, [pr, ...], rel in assoc(pr, ^rel_table))
+      |> preload([pr, ..., rel], [{^rel_table, rel}])
+    end)
   end
 
   @doc """

--- a/priv/repo/migrations/20220512182638_add_section_resources_slug_index.exs
+++ b/priv/repo/migrations/20220512182638_add_section_resources_slug_index.exs
@@ -1,0 +1,7 @@
+defmodule Oli.Repo.Migrations.AddSectionResourcesSlugIndex do
+  use Ecto.Migration
+
+  def change do
+    create index(:section_resources, [:slug])
+  end
+end

--- a/test/oli/publishing_test.exs
+++ b/test/oli/publishing_test.exs
@@ -486,6 +486,26 @@ defmodule Oli.PublishingTest do
       assert Publishing.available_publications(author3, institution) |> length == 2
       assert Publishing.available_publications(author2, institution) |> length == 2
     end
+
+    test "get_published_resources_by_publication/2 returns all the published resources of a given publication",
+         %{publication: publication} do
+      # mappings should be retained in the original published publication
+      mappings = Publishing.get_published_resources_by_publication(publication.id)
+
+      assert Enum.count(mappings) == 3
+      assert Enum.all?(mappings, &(&1.publication.id == publication.id))
+    end
+
+    test "get_published_resources_by_publication/2 only preloads the given assocations",
+         %{publication: publication} do
+      # mappings should be retained in the original published publication
+      mappings =
+        Publishing.get_published_resources_by_publication(publication.id, preload: [:resource])
+
+      assert Enum.all?(mappings, &Ecto.assoc_loaded?(&1.resource))
+      refute Enum.all?(mappings, &Ecto.assoc_loaded?(&1.publication))
+      refute Enum.all?(mappings, &Ecto.assoc_loaded?(&1.revision))
+    end
   end
 
   describe "publishing retrieve visible publications" do

--- a/test/oli/sections_test.exs
+++ b/test/oli/sections_test.exs
@@ -355,6 +355,19 @@ defmodule Oli.SectionsTest do
       assert Enum.find(section_resources, &(&1.resource_id == latest4.id)) == nil
       assert Enum.find(section_resources, &(&1.resource_id == parent4.id)) == nil
     end
+
+    test "get_existing_slugs/1 returns an empty list when passing no slugs" do
+      assert Sections.get_existing_slugs([]) == []
+    end
+
+    test "get_existing_slugs/1 returns the existing slugs from the input list" do
+      slugs =
+        insert_pair(:section_resource)
+        |> Enum.map(& &1.slug)
+        |> Enum.sort()
+
+      assert Sections.get_existing_slugs(["another_slug" | slugs]) |> Enum.sort() == slugs
+    end
   end
 
   describe "section updates" do
@@ -839,7 +852,8 @@ defmodule Oli.SectionsTest do
           destination_index
         )
 
-      hierarchy = Hierarchy.find_and_update_node(hierarchy, updated)
+      hierarchy =
+        Hierarchy.find_and_update_node(hierarchy, updated)
         |> Hierarchy.finalize()
 
       project_publications = Sections.get_pinned_project_publications(section.id)

--- a/test/oli/utils/slug_test.exs
+++ b/test/oli/utils/slug_test.exs
@@ -1,10 +1,12 @@
 defmodule Oli.Utils.SlugTest do
   use Oli.DataCase
 
+  import Ecto.Query, warn: false
+
   alias Oli.Utils.Slug
 
   alias Oli.Authoring.Course.Project
-  alias Oli.Delivery.Sections.SectionInvite
+  alias Oli.Delivery.Sections.{SectionInvite, SectionResource}
   alias Oli.Delivery.Sections
   alias Oli.Resources.Revision
   alias Oli.Repo
@@ -175,6 +177,24 @@ defmodule Oli.Utils.SlugTest do
         |> Repo.update!()
 
       assert slug == updated_section_invite.slug
+    end
+
+    test "generate_nth/2 generates a slug with no suffix in the first attempt" do
+      assert Slug.generate_nth("Hello World", 0) == "hello_world"
+    end
+
+    test "generate_nth/2 generates a slug with a 5-chars-long suffix before the fifth attempt" do
+      assert Slug.generate_nth("Hello World", Enum.random(1..4)) =~ ~r/hello_world_\w{5,5}/
+    end
+
+    test "generate_nth/2 generates a slug with a 10-chars-long suffix after the fifth attempt" do
+      assert Slug.generate_nth("Hello World", Enum.random(5..10)) =~ ~r/hello_world_\w{10,10}/
+    end
+
+    test "generate/2 generates a unique slug using the title provided", %{revision1: r} do
+      slug = Slug.generate("section_resources", r.title)
+
+      refute Repo.exists?(from sr in SectionResource, where: sr.slug == ^slug)
     end
   end
 end


### PR DESCRIPTION
[MER-1117](https://eliterate.atlassian.net/browse/MER-1117)

### Context
Some users are experiencing long response times when saving an updated curriculum in the Remix Section Page, even sometimes causing a timeout and the materials not being added.

### Problem
The main issue was that when creating new section resources, in order to ensure that these have unique slugs, the logic was querying the `section_resources` table `n` times causing very slow responses.

### Solution
Instead of making `n` queries to ensure the slugs are unique, the logic now creates a set of slug candidates for the section resources that will be created, and makes only one query to reduce this set to only include the candidates that already exist in the db (and therefore aren't unique yet). It repeats this process until all slugs are unique.

This reduced the response time from **~20 seconds** to less than **2 seconds** in some cases.

### More improvements
Besides this performance issue, there are some other parts of the logic that could be improved:
1. [`create_section_resource`](https://github.com/Simon-Initiative/oli-torus/blob/master/lib/oli/delivery/sections.ex#L731) function iterates recursively and calls `Slug.generate/2`, which is making `n` queries to ensure slug uniqueness. Same happens with [`collapse_section_hierarchy`](https://github.com/Simon-Initiative/oli-torus/blob/master/lib/oli/delivery/sections.ex#L1296) function.
2. [`Publishing.get_published_resources_by_publication/2`](https://github.com/Simon-Initiative/oli-torus/blob/master/lib/oli/publishing.ex#L588) is taking `~2s` when running locally, and this is because of the preload clause that is making a separate query for each association. The `revision` association is the slowest and I was able to confirm that it's making a sequential scan through the whole table. Adding an index didn't solve it.
