### PR TITLE
[BUGFIX] enable activity json to be edited in revision history tool

### DIFF
--- a/lib/oli_web/live/history/revision_history.ex
+++ b/lib/oli_web/live/history/revision_history.ex
@@ -62,6 +62,16 @@ defmodule OliWeb.RevisionHistory do
 
     selected = fetch_revision(hd(revisions).id)
 
+    resource_schema = case Oli.Resources.ResourceType.get_type_by_id(selected.resource_type_id) do
+      "page" -> SchemaResolver.schema("page-content.schema.json")
+      "activity" ->
+        case selected.activity_type_id do
+          1 -> SchemaResolver.schema("adaptive-activity-content.schema.json")
+          _ -> SchemaResolver.schema("activity-content.schema.json")
+        end
+      _ -> SchemaResolver.schema("page-content.schema.json")
+    end
+
     {:ok,
      socket
      |> assign(
@@ -85,7 +95,7 @@ defmodule OliWeb.RevisionHistory do
        edit_errors: [],
        upload_errors: [],
        edited_json: nil,
-       resource_schema: SchemaResolver.schema("page-content.schema.json")
+       resource_schema: resource_schema
      )
      |> allow_upload(:json, accept: ~w(.json), max_entries: 1)}
   end

--- a/priv/schemas/v0-1-0/adaptive-activity-content.schema.json
+++ b/priv/schemas/v0-1-0/adaptive-activity-content.schema.json
@@ -1,0 +1,62 @@
+{
+  "$id": "http://torus.oli.cmu.edu/schemas/v0-1-0/adaptive-activity-content.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "title": "Adaptive Activity Content",
+  "description": "Adaptive Activity content",
+  "type": "object",
+  "properties": {
+    "authoring": {
+      "type": "object",
+      "properties": {
+        "parts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "rules": {
+          "type": "array",
+          "items": {}
+        }
+      }
+    },
+    "partsLayout": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "janus-audio",
+              "janus-capi-iframe",
+              "janus-image-carousel",
+              "janus-dropdown",
+              "janus-fill-blanks",
+              "janus-image",
+              "janus-input-number",
+              "janus-input-text",
+              "janus-mcq",
+              "janus-multi-line-text",
+              "janus-navigation-button",
+              "janus-popup",
+              "janus-slider",
+              "janus-text-flow",
+              "janus-video"
+            ]
+          },
+          "custom": {}
+        }
+      }
+    },
+    "custom": {}
+  },
+  "required": ["authoring", "partsLayout"]
+}

--- a/priv/schemas/v0-1-0/adaptive-activity.schema.json
+++ b/priv/schemas/v0-1-0/adaptive-activity.schema.json
@@ -18,65 +18,7 @@
       "type": "string"
     },
     "content": {
-      "type": "object",
-      "properties": {
-        "authoring": {
-          "type": "object",
-          "properties": {
-            "parts": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "string"
-                  }
-                }
-              }
-            },
-            "rules": {
-              "type": "array",
-              "items": {}
-            }
-          }
-        },
-        "partsLayout": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string"
-              },
-              "type": {
-                "enum": [
-                  "janus-audio",
-                  "janus-capi-iframe",
-                  "janus-image-carousel",
-                  "janus-dropdown",
-                  "janus-fill-blanks",
-                  "janus-image",
-                  "janus-input-number",
-                  "janus-input-text",
-                  "janus-mcq",
-                  "janus-multi-line-text",
-                  "janus-navigation-button",
-                  "janus-popup",
-                  "janus-slider",
-                  "janus-text-flow",
-                  "janus-video"
-                ]
-              },
-              "custom": {}
-            }
-          }
-        },
-        "custom": {}
-      },
-      "required": [
-        "authoring",
-        "partsLayout"
-      ]
+      "$ref": "http://torus.oli.cmu.edu/schemas/v0-1-0/adaptive-activity-content.schema.json"
     }
   },
   "required": [


### PR DESCRIPTION
previously the revision history tool was limited to being able to edit a page due to the schema settings; this should enable activities (I honestly only tried adaptive) to be edited as well.

also note in `details.ex` there is another schema reference, but I am not sure how to change that.
```
validate_schema_uri="http://torus.oli.cmu.edu/schemas/v0-1-0/page-content.schema.json"
```
as far as I can tell it will only affect the Monaco client schema validation, not the actual validation.
suggestions on how to do that are welcome :)