### PR TITLE
[ENHANCEMENT] Allow deletion of institution, registration, and deployment

### DIFF
--- a/lib/oli/institutions.ex
+++ b/lib/oli/institutions.ex
@@ -305,6 +305,21 @@ defmodule Oli.Institutions do
   def get_deployment!(id), do: Repo.get!(Deployment, id)
 
   @doc """
+  Returns true if the institution with a given id has any associated deployments
+  """
+  def institution_has_deployments?(institution_id) do
+    count =
+      from(d in Deployment, where: d.institution_id == ^institution_id)
+      |> Repo.aggregate(:count)
+
+    if count > 0 do
+      true
+    else
+      false
+    end
+  end
+
+  @doc """
   Creates a deployment.
 
   ## Examples

--- a/lib/oli_web/live/sections/lti_settings.ex
+++ b/lib/oli_web/live/sections/lti_settings.ex
@@ -8,7 +8,7 @@ defmodule OliWeb.Sections.LtiSettings do
 
   def render(assigns) do
     ~F"""
-    <Group label="LTI Settings" description="Settings defined in the LMS that is launching students and instructors into this coruse section">
+    <Group label="LTI Settings" description="Settings defined in the LMS that is launching students and instructors into this course section">
       <ReadOnly label="Context ID" value={@section.context_id} />
       <ReadOnly label="Grade Passback Enabled" value={boolean(@section.grade_passback_enabled)} />
       <ReadOnly label="Line Items Service URL" value={@section.line_items_service_url} />

--- a/lib/oli_web/templates/institution/index.html.eex
+++ b/lib/oli_web/templates/institution/index.html.eex
@@ -83,7 +83,6 @@
 
               <td class="text-nowrap">
                 <%= link "Details", to: Routes.institution_path(@conn, :show, institution), class: "btn btn-sm btn-outline-primary" %>
-                <%# <%= link "Remove", to: Routes.institution_path(@conn, :delete, institution), method: :delete, data: [confirm: "Are you sure you want to permanently remove the institution \"#{institution.name}\"?"], class: "btn btn-sm btn-outline-danger ml-2" %>
               </td>
             </tr>
         <% end %>

--- a/lib/oli_web/templates/institution/show.html.eex
+++ b/lib/oli_web/templates/institution/show.html.eex
@@ -8,6 +8,7 @@
 
   <h3 class="my-3">
     <%= @institution.name %>
+    <%= link "Delete", to: Routes.institution_path(@conn, :delete, @institution), method: :delete, data: [confirm: "Are you sure you want to permanently delete the institution \"#{@institution.name}\"?"], class: "btn btn-sm btn-outline-danger ml-2 float-right" %>
     <%= link "Edit Details", to: Routes.institution_path(@conn, :edit, @institution), class: "btn btn-sm btn-outline-primary ml-2 float-right" %>
   </h3>
 

--- a/priv/repo/migrations/20220517211648_delete_inst_reg_depl.exs
+++ b/priv/repo/migrations/20220517211648_delete_inst_reg_depl.exs
@@ -1,0 +1,88 @@
+defmodule Oli.Repo.Migrations.DeleteInstRegDepl do
+  use Ecto.Migration
+  import Ecto.Query, warn: false
+
+  alias Oli.Repo
+
+  def up do
+    drop(constraint(:sections, "sections_lti_1p3_deployment_id_fkey"))
+
+    alter table(:sections) do
+      modify :lti_1p3_deployment_id, references(:lti_1p3_deployments, on_delete: :nilify_all)
+    end
+  end
+
+  def down do
+    drop(constraint(:sections, "sections_lti_1p3_deployment_id_fkey"))
+
+    # we need somewhere to put any orphaned registrations and deployments and sections
+    # so we create a new institution, registration and deployment to associate with
+    now = DateTime.utc_now()
+    today = Enum.join([now.year, now.month, now.day], "/")
+
+    {_, [%{id: institution_id}]} =
+      Repo.insert_all(
+        "institutions",
+        [
+          %{
+            name: "Migration Rollback Orphans #{today}",
+            country_code: "UNKNOWN",
+            institution_email: "UNKNOWN",
+            institution_url: "UNKNOWN",
+            timezone: "UNKNOWN",
+            inserted_at: now,
+            updated_at: now
+          }
+        ],
+        returning: [:id]
+      )
+
+    {:ok, %{id: jwk_id}} = Lti_1p3.get_active_jwk()
+
+    {_, [%{id: registration_id}]} =
+      Repo.insert_all(
+        "lti_1p3_registrations",
+        [
+          %{
+            tool_jwk_id: jwk_id,
+            issuer: "UNKNOWN",
+            client_id: "UNKNOWN",
+            key_set_url: "UNKNOWN",
+            auth_token_url: "UNKNOWN",
+            auth_login_url: "UNKNOWN",
+            auth_server: "UNKNOWN",
+            inserted_at: now,
+            updated_at: now
+          }
+        ],
+        returning: [:id]
+      )
+
+    {_, [%{id: deployment_id}]} =
+      Repo.insert_all(
+        "lti_1p3_deployments",
+        [
+          %{
+            deployment_id: "UNKNOWN",
+            registration_id: registration_id,
+            institution_id: institution_id,
+            inserted_at: now,
+            updated_at: now
+          }
+        ],
+        returning: [:id]
+      )
+
+    from(s in "sections",
+      where: is_nil(s.lti_1p3_deployment_id),
+      update: [set: [lti_1p3_deployment_id: ^deployment_id]]
+    )
+    |> Repo.update_all([])
+
+    flush()
+
+    alter table(:sections) do
+      modify :lti_1p3_deployment_id, references(:lti_1p3_deployments, on_delete: :nothing)
+    end
+  end
+end

--- a/priv/repo/migrations/20220517211648_delete_inst_reg_depl.exs
+++ b/priv/repo/migrations/20220517211648_delete_inst_reg_depl.exs
@@ -18,7 +18,7 @@ defmodule Oli.Repo.Migrations.DeleteInstRegDepl do
     # we need somewhere to put any orphaned registrations and deployments and sections
     # so we create a new institution, registration and deployment to associate with
     now = DateTime.utc_now()
-    today = Enum.join([now.year, now.month, now.day], "/")
+    today = Enum.join([now.month, now.day, now.year], "/")
 
     {_, [%{id: institution_id}]} =
       Repo.insert_all(
@@ -55,7 +55,9 @@ defmodule Oli.Repo.Migrations.DeleteInstRegDepl do
             updated_at: now
           }
         ],
-        returning: [:id]
+        returning: [:id],
+        conflict_target: [:issuer, :client_id],
+        on_conflict: {:replace, [:issuer, :client_id]}
       )
 
     {_, [%{id: deployment_id}]} =


### PR DESCRIPTION
This PR adds more capability to manage institutions, registrations, and deployments, specifically the ability to delete them. The behavior is implemented as follows:
- An institution can be deleted only when there are no attached deployments
- A registration can be deleted, which will cascade to a deletion of all attached deployments
- A deploy can be deleted, nullifying the deployment_id association from any sections that reference it
- Deletions are permanent and will require an institution to reregister (or manual reconfiguration) if a deletion is made at any level. This behavior is necessary in order to allow hard deletions while troubleshooting/resetting LTI connections.

These changes also include a migration rollback which will bucket any nullified sections into a non-functional generic migration institution, registration, and deployment to maintain the reinstated database constraint.