### PR TITLE
[CHORE] upgrade typescript and set modules to es2020

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -73,7 +73,7 @@
     "tsmonad": "^0.8.0",
     "typedoc": "^0.22.15",
     "typedoc-plugin-markdown": "^3.12.1",
-    "typescript": "^4.4.4",
+    "typescript": "^4.6.4",
     "uuid": "^8.3.2",
     "vm-browserify": "^1.1.2",
     "whatwg-fetch": "^3.0.0"

--- a/assets/tsconfig.json
+++ b/assets/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
     "lib": ["es2019", "DOM"],
-    "module": "ES2022",
+    "module": "es2020",
     "target": "es6",
     "jsx": "preserve",
     "moduleResolution": "node",
@@ -19,22 +19,11 @@
     "outDir": "./dev",
     "baseUrl": ".",
     "paths": {
-      "*": [
-        "src/*"
-      ]
+      "*": ["src/*"]
     },
-    "types": [
-      "node",
-      "jest",
-      "jquery"
-    ],
+    "types": ["node", "jest", "jquery"],
     "esModuleInterop": true
   },
-  "include": [
-    "src/**/*",
-    "test/**/*"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -9509,10 +9509,10 @@ typedoc@^0.22.15:
     minimatch "^5.0.1"
     shiki "^0.10.1"
 
-typescript@^4.4.4:
-  version "4.5.5"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz"
-  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
+typescript@^4.6.4:
+  version "4.6.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
+  integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
 
 uglify-js@^3.1.4:
   version "3.15.4"


### PR DESCRIPTION
This PR upgrades typescript to version 4.6.4 and set modules to es2020