### PR TITLE
[BUGFIX] [MER-1067] Fix timezone issue when saving gating conditions

### DIFF
--- a/assets/src/phoenix/timezone.ts
+++ b/assets/src/phoenix/timezone.ts
@@ -1,18 +1,16 @@
 // update server session timezone if timezone has not already been set for this browser session
-if (!sessionStorage.getItem('local_tz')) {
-  const local_tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+const local_tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
-  fetch('/timezone', {
-    method: 'post',
-    headers: {
-      Accept: 'application/json, text/plain, */*',
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ local_tz }),
+fetch('/timezone', {
+  method: 'post',
+  headers: {
+    Accept: 'application/json, text/plain, */*',
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify({ local_tz }),
+})
+  .then((_res) => {
+    sessionStorage.setItem('local_tz', local_tz);
+    console.log('local timezone information updated', local_tz);
   })
-    .then((_res) => {
-      sessionStorage.setItem('local_tz', local_tz);
-      console.log('local timezone information updated', local_tz);
-    })
-    .catch((_res) => console.error('failed to update local timezone information', local_tz));
-}
+  .catch((_res) => console.error('failed to update local timezone information', local_tz));

--- a/lib/oli/utils/db_seeder.ex
+++ b/lib/oli/utils/db_seeder.ex
@@ -169,7 +169,7 @@ defmodule Oli.Seeder do
         country_code: "some country_code",
         institution_email: "some institution_email",
         institution_url: "some institution_url",
-        timezone: "some timezone",
+        timezone: "America/New_York",
         author_id: author.id
       })
       |> Repo.insert()
@@ -424,7 +424,7 @@ defmodule Oli.Seeder do
     {:ok, section_1} =
       Sections.create_section(%{
         title: "1",
-        timezone: "1",
+        timezone: "America/New_York",
         registration_open: true,
         context_id: UUID.uuid4(),
         institution_id: map.institution.id,
@@ -436,7 +436,7 @@ defmodule Oli.Seeder do
     {:ok, section_2} =
       Sections.create_section(%{
         title: "2",
-        timezone: "1",
+        timezone: "America/New_York",
         registration_open: true,
         context_id: UUID.uuid4(),
         institution_id: map.institution.id,
@@ -448,7 +448,7 @@ defmodule Oli.Seeder do
     {:ok, oaf_section_1} =
       Sections.create_section(%{
         title: "3",
-        timezone: "1",
+        timezone: "America/New_York",
         registration_open: true,
         open_and_free: true,
         context_id: UUID.uuid4(),
@@ -481,7 +481,7 @@ defmodule Oli.Seeder do
       open_and_free: false,
       registration_open: true,
       start_date: ~U[2010-04-17 00:00:00.000000Z],
-      timezone: "some timezone",
+      timezone: "America/New_York",
       title: "some title",
       context_id: UUID.uuid4(),
       base_project_id: map.project.id,
@@ -503,7 +503,7 @@ defmodule Oli.Seeder do
           type: :blueprint,
           registration_open: true,
           start_date: ~U[2010-04-17 00:00:00.000000Z],
-          timezone: "some timezone",
+          timezone: "America/New_York",
           title: "some title",
           description: "a description",
           context_id: UUID.uuid4(),

--- a/lib/oli_web/common/format_date_time.ex
+++ b/lib/oli_web/common/format_date_time.ex
@@ -182,6 +182,23 @@ defmodule OliWeb.Common.FormatDateTime do
     end
   end
 
+  @doc """
+  Converts a datestring to a UTC datetime, assuming the input date is in the given timezone.
+
+  ## Examples
+      iex> datestring_to_utc_datetime("2022-05-18T12:35", "US/Arizona")
+      ~U[2022-05-18 19:35:00Z]
+  """
+  def datestring_to_utc_datetime("", _), do: nil
+
+  def datestring_to_utc_datetime(date_string, local_tz) do
+    date_string
+    |> Timex.parse!("{ISO:Extended}")
+    |> Timex.to_datetime(local_tz)
+    |> DateTime.shift_zone("Etc/UTC")
+    |> elem(1)
+  end
+
   defp author_format_preference(nil), do: nil
 
   defp author_format_preference(author) do

--- a/lib/oli_web/live/sections/gating_and_scheduling/edit.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling/edit.ex
@@ -48,7 +48,7 @@ defmodule OliWeb.Sections.GatingAndScheduling.Edit do
     <div class="container">
       <h3>{@title}</h3>
 
-      <Form id="new_gating_contition" section={@section} gating_condition={@gating_condition} parent_gate={@parent_gate} count_exceptions={@count_exceptions} create_or_update={:update} />
+      <Form id="new_gating_contition" section={@section} gating_condition={@gating_condition} parent_gate={@parent_gate} count_exceptions={@count_exceptions} create_or_update={:update} timezone={@context.local_tz}/>
     </div>
     """
   end

--- a/lib/oli_web/live/sections/gating_and_scheduling/gating_condition_store.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling/gating_condition_store.ex
@@ -9,7 +9,7 @@ defmodule OliWeb.Delivery.Sections.GatingAndScheduling.GatingConditionStore do
   alias Oli.Delivery.Hierarchy
   alias Oli.Delivery.Hierarchy.HierarchyNode
   alias Oli.Resources.Revision
-  alias OliWeb.Common.{Breadcrumb, DeleteModalNoConfirmation}
+  alias OliWeb.Common.{Breadcrumb, DeleteModalNoConfirmation, FormatDateTime}
 
   def render(assigns) do
     ~F"""
@@ -173,10 +173,12 @@ defmodule OliWeb.Delivery.Sections.GatingAndScheduling.GatingConditionStore do
           fn items ->
             Enum.filter(
               items,
-              &(&1.uuid != root.uuid and
-                  (&1.revision.resource_type_id ==
-                    Oli.Resources.ResourceType.get_id_by_type("page") and
-                  &1.revision.graded) or (&1.revision.resource_type_id == Oli.Resources.ResourceType.get_id_by_type("container")))
+              &((&1.uuid != root.uuid and
+                   (&1.revision.resource_type_id ==
+                      Oli.Resources.ResourceType.get_id_by_type("page") and
+                      &1.revision.graded)) or
+                  &1.revision.resource_type_id ==
+                    Oli.Resources.ResourceType.get_id_by_type("container"))
             )
           end
 
@@ -184,11 +186,13 @@ defmodule OliWeb.Delivery.Sections.GatingAndScheduling.GatingConditionStore do
           fn items ->
             Enum.filter(
               items,
-              &(&1.uuid != root.uuid and
-                  &1.revision.resource_id != resource_id and
-                  (&1.revision.resource_type_id ==
-                    Oli.Resources.ResourceType.get_id_by_type("page") and
-                  &1.revision.graded) or (&1.revision.resource_type_id == Oli.Resources.ResourceType.get_id_by_type("container")))
+              &((&1.uuid != root.uuid and
+                   &1.revision.resource_id != resource_id and
+                   (&1.revision.resource_type_id ==
+                      Oli.Resources.ResourceType.get_id_by_type("page") and
+                      &1.revision.graded)) or
+                  &1.revision.resource_type_id ==
+                    Oli.Resources.ResourceType.get_id_by_type("container"))
             )
           end
       end
@@ -366,24 +370,27 @@ defmodule OliWeb.Delivery.Sections.GatingAndScheduling.GatingConditionStore do
       modal: %{assigns: %{hierarchy: hierarchy}}
     } = socket.assigns
 
-    %HierarchyNode{resource_id: resource_id, revision: %Revision{title: title, resource_type_id: resource_type_id}} =
-      Hierarchy.find_in_hierarchy(hierarchy, selection)
+    %HierarchyNode{
+      resource_id: resource_id,
+      revision: %Revision{title: title, resource_type_id: resource_type_id}
+    } = Hierarchy.find_in_hierarchy(hierarchy, selection)
 
     container_type_id = Oli.Resources.ResourceType.get_id_by_type("container")
 
     case {resource_type_id, gating_condition.type} do
       {^container_type_id, type} when type in [:finished, :started] ->
-        {:noreply, put_flash(
-          socket,
-          :error,
-          "Only pages can be selected for this type of gating condition"
-        ) |> hide_modal()}
-      _ ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           "Only pages can be selected for this type of gating condition"
+         )
+         |> hide_modal()}
 
+      _ ->
         data = Map.put(gating_condition.data, :resource_id, resource_id)
 
         {:noreply,
-
          assign(socket,
            gating_condition:
              gating_condition
@@ -393,7 +400,6 @@ defmodule OliWeb.Delivery.Sections.GatingAndScheduling.GatingConditionStore do
          |> put_flash(:error, nil)
          |> hide_modal()}
     end
-
   end
 
   def handle_event(
@@ -433,9 +439,14 @@ defmodule OliWeb.Delivery.Sections.GatingAndScheduling.GatingConditionStore do
         %{"value" => value},
         socket
       ) do
-    %{gating_condition: %{data: data} = gating_condition} = socket.assigns
+    %{
+      gating_condition: %{data: data} = gating_condition,
+      context: %{local_tz: local_tz},
+      section: section
+    } = socket.assigns
 
-    data = Map.put(data, :start_datetime, Timex.parse!(value, "{ISO:Extended}"))
+    utc_datetime = FormatDateTime.datestring_to_utc_datetime(value, local_tz || section.timezone)
+    data = Map.put(data, :start_datetime, utc_datetime)
 
     {:noreply, assign(socket, gating_condition: %{gating_condition | data: data})}
   end
@@ -445,9 +456,14 @@ defmodule OliWeb.Delivery.Sections.GatingAndScheduling.GatingConditionStore do
         %{"value" => value},
         socket
       ) do
-    %{gating_condition: %{data: data} = gating_condition} = socket.assigns
+    %{
+      gating_condition: %{data: data} = gating_condition,
+      context: %{local_tz: local_tz},
+      section: section
+    } = socket.assigns
 
-    data = Map.put(data, :end_datetime, Timex.parse!(value, "{ISO:Extended}"))
+    utc_datetime = FormatDateTime.datestring_to_utc_datetime(value, local_tz || section.timezone)
+    data = Map.put(data, :end_datetime, utc_datetime)
 
     {:noreply, assign(socket, gating_condition: %{gating_condition | data: data})}
   end

--- a/lib/oli_web/live/sections/gating_and_scheduling/new.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling/new.ex
@@ -44,7 +44,7 @@ defmodule OliWeb.Sections.GatingAndScheduling.New do
     <div class="container">
       <h3>{@title}</h3>
 
-      <Form id="new_gating_contition" section={@section} gating_condition={@gating_condition} parent_gate={@parent_gate} count_exceptions={@count_exceptions} />
+      <Form id="new_gating_contition" section={@section} gating_condition={@gating_condition} parent_gate={@parent_gate} count_exceptions={@count_exceptions} timezone={@context.local_tz}/>
     </div>
     """
   end

--- a/lib/oli_web/live/system_message_live/index_view.ex
+++ b/lib/oli_web/live/system_message_live/index_view.ex
@@ -5,7 +5,7 @@ defmodule OliWeb.SystemMessageLive.IndexView do
 
   alias Oli.Notifications
   alias Oli.Notifications.{PubSub, SystemMessage}
-  alias OliWeb.Common.{Breadcrumb, Confirm}
+  alias OliWeb.Common.{Breadcrumb, Confirm, FormatDateTime}
   alias OliWeb.Router.Helpers, as: Routes
   alias OliWeb.SystemMessageLive.EditMessage
   alias Surface.Components.Form
@@ -116,8 +116,16 @@ defmodule OliWeb.SystemMessageLive.IndexView do
     new_message_attrs =
       attrs
       |> Oli.Utils.atomize_keys()
-      |> Map.update(:start, "", &datestring_to_utc_datetime(&1, socket.assigns.local_timezone))
-      |> Map.update(:end, "", &datestring_to_utc_datetime(&1, socket.assigns.local_timezone))
+      |> Map.update(
+        :start,
+        "",
+        &FormatDateTime.datestring_to_utc_datetime(&1, socket.assigns.local_timezone)
+      )
+      |> Map.update(
+        :end,
+        "",
+        &FormatDateTime.datestring_to_utc_datetime(&1, socket.assigns.local_timezone)
+      )
       |> Map.put(:active, active)
       |> Map.put(:id, id)
 
@@ -246,16 +254,6 @@ defmodule OliWeb.SystemMessageLive.IndexView do
 
   defp message_displayed?(%{active: active} = attrs) do
     active and message_in_date_range(attrs)
-  end
-
-  defp datestring_to_utc_datetime("", _), do: nil
-
-  defp datestring_to_utc_datetime(date_string, local_tz) do
-    date_string
-    |> Timex.parse!("{ISO:Extended}")
-    |> Timex.to_datetime(local_tz)
-    |> DateTime.shift_zone("Etc/UTC")
-    |> elem(1)
   end
 
   defp show_confirm_modal?(old_system_message, new_system_message) do

--- a/lib/oli_web/templates/layout/authoring.html.leex
+++ b/lib/oli_web/templates/layout/authoring.html.leex
@@ -71,7 +71,9 @@
     <%= csrf_meta_tag() %>
     <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/app.js") %>"></script>
     <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/components.js") %>"></script>
-    <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/timezone.js") %>"></script>
+    <%= unless Plug.Conn.get_session(@conn, "local_tz") do %>
+      <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/timezone.js") %>"></script>
+    <% end %>
     <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/dark.js") %>"></script>
   </head>
   <body>

--- a/lib/oli_web/templates/layout/delivery.html.eex
+++ b/lib/oli_web/templates/layout/delivery.html.eex
@@ -62,7 +62,9 @@
     <%= csrf_meta_tag() %>
     <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/app.js") %>"></script>
     <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/components.js") %>"></script>
-    <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/timezone.js") %>"></script>
+    <%= unless Plug.Conn.get_session(@conn, "local_tz") do %>
+      <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/timezone.js") %>"></script>
+    <% end %>
     <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/dark.js") %>"></script>
   </head>
   <body>

--- a/test/oli_web/controllers/static_page_controller_test.exs
+++ b/test/oli_web/controllers/static_page_controller_test.exs
@@ -24,4 +24,20 @@ defmodule OliWeb.StaticPageControllerTest do
       assert get_session(conn, :dismissed_messages) == [1, 2]
     end
   end
+
+  describe "local timezone" do
+    test "loads timezone script when local timezone is not set", %{conn: conn} do
+      conn = get(conn, "/")
+
+      assert html_response(conn, 200) =~ "/js/timezone.js"
+    end
+
+    test "does not load timezone script when local timezone is set", context do
+      {:ok, conn: conn} = set_timezone(context)
+
+      conn = get(conn, "/")
+
+      refute html_response(conn, 200) =~ "/js/timezone.js"
+    end
+  end
 end

--- a/test/oli_web/live/sections/gating_and_scheduling_test.exs
+++ b/test/oli_web/live/sections/gating_and_scheduling_test.exs
@@ -1,12 +1,14 @@
 defmodule OliWeb.Sections.GatingAndSchedulingTest do
   use OliWeb.ConnCase
 
+  import Ecto.Query, warn: false
   import Oli.Factory
   import Phoenix.{ConnTest, LiveViewTest}
 
   alias Lti_1p3.Tool.ContextRoles
   alias Oli.Delivery.{Gating, Sections}
-  alias Oli.Seeder
+  alias Oli.Delivery.Gating.GatingCondition
+  alias Oli.{Repo, Seeder}
 
   @endpoint OliWeb.Endpoint
 
@@ -26,6 +28,46 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
         OliWeb.Sections.GatingAndScheduling.New,
         section_slug
       )
+
+  defp utc_datetime_to_localized_datestring(utc_datetime, timezone) do
+    utc_datetime
+    |> Timex.to_datetime(timezone)
+    |> DateTime.to_naive()
+    |> NaiveDateTime.to_iso8601()
+    |> String.replace_suffix(":00", "")
+  end
+
+  defp create_gating_condition(view, type, start_date, end_date) do
+    view
+    |> element("button[phx-click=\"show-resource-picker\"]")
+    |> render_click()
+
+    # Since Oli.Publishing.DeliveryResolver.find_in_hierarchy generates dynamic uuids every
+    # time is called, and that is what is used to select one resource, is necessary to parse the
+    # HTML element to get the actual uuid :(
+
+    element_splitted =
+      view
+      |> element("div[phx-click=\"HierarchyPicker.select\"]", "Page one")
+      |> render()
+      |> String.split("\"")
+
+    prev_uuid_index =
+      Enum.with_index(element_splitted)
+      |> Enum.find(fn elem -> elem(elem, 0) == " phx-value-uuid=" end)
+      |> elem(1)
+
+    uuid = Enum.at(element_splitted, prev_uuid_index + 1)
+
+    render_hook(view, "select_resource", %{selection: "#{uuid}"})
+    render_hook(view, "select-condition", %{value: type})
+    render_hook(view, "schedule_start_date_changed", %{value: start_date})
+    render_hook(view, "schedule_end_date_changed", %{value: end_date})
+
+    view
+    |> element("button[phx-click=\"create_gate\"]")
+    |> render_click()
+  end
 
   describe "gating and scheduling live test admin" do
     setup [:setup_admin_session]
@@ -81,22 +123,70 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
   describe "gating and scheduling edit live test" do
     setup [:setup_admin_session, :create_gating_condition]
 
-    test "displays gating condition info correctly", %{
-      conn: conn,
-      section_1: section,
-      gating_condition: gating_condition,
-      revision: revision
-    } do
+    test "displays gating condition info correctly using the section timezone when local timezone is not set",
+         %{
+           conn: conn,
+           section_1: section,
+           gating_condition: gating_condition,
+           revision: revision
+         } do
       {:ok, view, html} =
         live(
           conn,
           gating_condition_edit_route(section.slug, gating_condition.id)
         )
 
+      timezone = section.timezone
+
       assert html =~ "Edit Gating Condition"
       assert has_element?(view, "input[value=\"#{revision.title}\"]")
-      assert html =~ Date.to_string(gating_condition.data.start_datetime)
-      assert html =~ Date.to_string(gating_condition.data.end_datetime)
+
+      assert view
+             |> element("#start_date")
+             |> render() =~
+               utc_datetime_to_localized_datestring(
+                 gating_condition.data.start_datetime,
+                 timezone
+               )
+
+      assert view
+             |> element("#end_date")
+             |> render() =~
+               utc_datetime_to_localized_datestring(gating_condition.data.end_datetime, timezone)
+
+      assert html =~
+               "Your local timezone is not set in the browser. #{timezone} (section timezone) is used by default."
+    end
+
+    test "displays gating condition dates correctly using the local timezone when it is set", %{
+      conn: conn,
+      section_1: section,
+      gating_condition: gating_condition
+    } do
+      {:ok, conn: conn} = set_timezone(%{conn: conn})
+
+      {:ok, view, html} =
+        live(
+          conn,
+          gating_condition_edit_route(section.slug, gating_condition.id)
+        )
+
+      timezone = Plug.Conn.get_session(conn, :local_tz)
+
+      assert view
+             |> element("#start_date")
+             |> render() =~
+               utc_datetime_to_localized_datestring(
+                 gating_condition.data.start_datetime,
+                 timezone
+               )
+
+      assert view
+             |> element("#end_date")
+             |> render() =~
+               utc_datetime_to_localized_datestring(gating_condition.data.end_datetime, timezone)
+
+      refute html =~ "Your local timezone is not set in the browser"
     end
 
     test "displays a confirm modal before deleting a gating condition", %{
@@ -202,6 +292,79 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
 
       assert flash["info"] == "Gating condition successfully updated."
     end
+
+    test "shifts input datestring to utc using the section timezone when local timezone is not set",
+         %{
+           conn: conn,
+           section_1: section,
+           gating_condition: gating_condition
+         } do
+      {:ok, view, _html} =
+        live(
+          conn,
+          gating_condition_edit_route(section.slug, gating_condition.id)
+        )
+
+      input_start_date = "2022-01-12T13:48"
+      input_end_date = "2022-01-13T13:48"
+
+      render_hook(view, "schedule_start_date_changed", %{value: input_start_date})
+      render_hook(view, "schedule_end_date_changed", %{value: input_end_date})
+
+      view
+      |> element("button[phx-click=\"update_gate\"]")
+      |> render_click()
+
+      updated_gating_condition = Gating.get_gating_condition!(gating_condition.id)
+
+      assert utc_datetime_to_localized_datestring(
+               updated_gating_condition.data.start_datetime,
+               section.timezone
+             ) == input_start_date
+
+      assert utc_datetime_to_localized_datestring(
+               updated_gating_condition.data.end_datetime,
+               section.timezone
+             ) == input_end_date
+    end
+
+    test "shifts input datestring to utc using the local timezone when it is set", %{
+      conn: conn,
+      section_1: section,
+      gating_condition: gating_condition
+    } do
+      {:ok, conn: conn} = set_timezone(%{conn: conn})
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          gating_condition_edit_route(section.slug, gating_condition.id)
+        )
+
+      timezone = Plug.Conn.get_session(conn, :local_tz)
+
+      input_start_date = "2022-01-12T13:48"
+      input_end_date = "2022-01-13T13:48"
+
+      render_hook(view, "schedule_start_date_changed", %{value: input_start_date})
+      render_hook(view, "schedule_end_date_changed", %{value: input_end_date})
+
+      view
+      |> element("button[phx-click=\"update_gate\"]")
+      |> render_click()
+
+      updated_gating_condition = Gating.get_gating_condition!(gating_condition.id)
+
+      assert utc_datetime_to_localized_datestring(
+               updated_gating_condition.data.start_datetime,
+               timezone
+             ) == input_start_date
+
+      assert utc_datetime_to_localized_datestring(
+               updated_gating_condition.data.end_datetime,
+               timezone
+             ) == input_end_date
+    end
   end
 
   describe "gating and scheduling new live test" do
@@ -217,35 +380,7 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
           gating_condition_new_route(section.slug)
         )
 
-      view
-      |> element("button[phx-click=\"show-resource-picker\"]")
-      |> render_click()
-
-      # Since Oli.Publishing.DeliveryResolver.find_in_hierarchy generates dynamic uuids every
-      # time is called, and that is what is used to select one resource, is necessary to parse the
-      # HTML element to get the actual uuid :(
-
-      element_splitted =
-        view
-        |> element("div[phx-click=\"HierarchyPicker.select\"]", "Page one")
-        |> render()
-        |> String.split("\"")
-
-      prev_uuid_index =
-        Enum.with_index(element_splitted)
-        |> Enum.find(fn elem -> elem(elem, 0) == " phx-value-uuid=" end)
-        |> elem(1)
-
-      uuid = Enum.at(element_splitted, prev_uuid_index + 1)
-
-      render_hook(view, "select_resource", %{selection: "#{uuid}"})
-      render_hook(view, "select-condition", %{value: "schedule"})
-      render_hook(view, "schedule_start_date_changed", %{value: "2022-01-12T13:48"})
-      render_hook(view, "schedule_end_date_changed", %{value: "2022-01-10T13:48"})
-
-      view
-      |> element("button[phx-click=\"create_gate\"]")
-      |> render_click()
+      create_gating_condition(view, "schedule", "2022-01-12T13:48", "2022-01-10T13:48")
 
       assert view
              |> element("div.alert.alert-danger")
@@ -257,41 +392,16 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
       conn: conn,
       section_1: section
     } do
-      {:ok, view, _html} =
+      {:ok, view, html} =
         live(
           conn,
           gating_condition_new_route(section.slug)
         )
 
-      view
-      |> element("button[phx-click=\"show-resource-picker\"]")
-      |> render_click()
+      assert html =~
+               "Your local timezone is not set in the browser. #{section.timezone} (section timezone) is used by default."
 
-      # Since Oli.Publishing.DeliveryResolver.find_in_hierarchy generates dynamic uuids every
-      # time is called, and that is what is used to select one resource, is necessary to parse the
-      # HTML element to get the actual uuid :(
-
-      element_splitted =
-        view
-        |> element("div[phx-click=\"HierarchyPicker.select\"]", "Page one")
-        |> render()
-        |> String.split("\"")
-
-      prev_uuid_index =
-        Enum.with_index(element_splitted)
-        |> Enum.find(fn elem -> elem(elem, 0) == " phx-value-uuid=" end)
-        |> elem(1)
-
-      uuid = Enum.at(element_splitted, prev_uuid_index + 1)
-
-      render_hook(view, "select_resource", %{selection: "#{uuid}"})
-      render_hook(view, "select-condition", %{value: "schedule"})
-      render_hook(view, "schedule_start_date_changed", %{value: "2022-01-12T13:48"})
-      render_hook(view, "schedule_end_date_changed", %{value: "2022-01-13T13:48"})
-
-      view
-      |> element("button[phx-click=\"create_gate\"]")
-      |> render_click()
+      create_gating_condition(view, "schedule", "2022-01-12T13:48", "2022-01-13T13:48")
 
       flash =
         assert_redirected(
@@ -300,6 +410,79 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
         )
 
       assert flash["info"] == "Gating condition successfully created."
+    end
+
+    test "shifts input datestring to utc using the section timezone when local timezone is not set",
+         %{
+           conn: conn,
+           section_1: section
+         } do
+      {:ok, view, _html} =
+        live(
+          conn,
+          gating_condition_new_route(section.slug)
+        )
+
+      input_start_date = "2022-01-12T13:48"
+      input_end_date = "2022-01-13T13:48"
+
+      create_gating_condition(view, "schedule", input_start_date, input_end_date)
+
+      created_gating_condition =
+        Repo.one(
+          from g in GatingCondition,
+            where: g.section_id == ^section.id,
+            order_by: [desc: g.id],
+            limit: 1
+        )
+
+      assert utc_datetime_to_localized_datestring(
+               created_gating_condition.data.start_datetime,
+               section.timezone
+             ) == input_start_date
+
+      assert utc_datetime_to_localized_datestring(
+               created_gating_condition.data.end_datetime,
+               section.timezone
+             ) == input_end_date
+    end
+
+    test "shifts input datestring to utc using the local timezone when it is set", %{
+      conn: conn,
+      section_1: section
+    } do
+      {:ok, conn: conn} = set_timezone(%{conn: conn})
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          gating_condition_new_route(section.slug)
+        )
+
+      timezone = Plug.Conn.get_session(conn, :local_tz)
+
+      input_start_date = "2022-01-12T13:48"
+      input_end_date = "2022-01-13T13:48"
+
+      create_gating_condition(view, "schedule", input_start_date, input_end_date)
+
+      created_gating_condition =
+        Repo.one(
+          from g in GatingCondition,
+            where: g.section_id == ^section.id,
+            order_by: [desc: g.id],
+            limit: 1
+        )
+
+      assert utc_datetime_to_localized_datestring(
+               created_gating_condition.data.start_datetime,
+               timezone
+             ) == input_start_date
+
+      assert utc_datetime_to_localized_datestring(
+               created_gating_condition.data.end_datetime,
+               timezone
+             ) == input_end_date
     end
   end
 

--- a/test/oli_web/live/sections/gating_and_scheduling_test.exs
+++ b/test/oli_web/live/sections/gating_and_scheduling_test.exs
@@ -37,7 +37,7 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
     |> String.replace_suffix(":00", "")
   end
 
-  defp create_gating_condition(view, type, start_date, end_date) do
+  defp create_gating_condition_through_ui(view, type, start_date, end_date) do
     view
     |> element("button[phx-click=\"show-resource-picker\"]")
     |> render_click()
@@ -380,7 +380,7 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
           gating_condition_new_route(section.slug)
         )
 
-      create_gating_condition(view, "schedule", "2022-01-12T13:48", "2022-01-10T13:48")
+      create_gating_condition_through_ui(view, "schedule", "2022-01-12T13:48", "2022-01-10T13:48")
 
       assert view
              |> element("div.alert.alert-danger")
@@ -401,7 +401,7 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
       assert html =~
                "Your local timezone is not set in the browser. #{section.timezone} (section timezone) is used by default."
 
-      create_gating_condition(view, "schedule", "2022-01-12T13:48", "2022-01-13T13:48")
+      create_gating_condition_through_ui(view, "schedule", "2022-01-12T13:48", "2022-01-13T13:48")
 
       flash =
         assert_redirected(
@@ -426,7 +426,7 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
       input_start_date = "2022-01-12T13:48"
       input_end_date = "2022-01-13T13:48"
 
-      create_gating_condition(view, "schedule", input_start_date, input_end_date)
+      create_gating_condition_through_ui(view, "schedule", input_start_date, input_end_date)
 
       created_gating_condition =
         Repo.one(
@@ -464,7 +464,7 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
       input_start_date = "2022-01-12T13:48"
       input_end_date = "2022-01-13T13:48"
 
-      create_gating_condition(view, "schedule", input_start_date, input_end_date)
+      create_gating_condition_through_ui(view, "schedule", input_start_date, input_end_date)
 
       created_gating_condition =
         Repo.one(


### PR DESCRIPTION
[MER-1067](https://eliterate.atlassian.net/browse/MER-1067)

### Context
Users create scheduled gating conditions selecting start and end date, but after saving, the times are shifted and inconsistent with what the user selected.

### Problem
The logic isn't considering the local timezone when saving the datetimes in the database.

### Solution
1. Before saving the gating condition, convert the input dates to UTC assuming they are in the user local timezone.
2. It is not related to this specific bug, but sometimes happens that the local timezone in the server session gets cleared and out of synch with the one set in the browser session storage, causing the session not to update accordingly. Therefore we may end up in a scenario where the browser has a timezone set but the server doesn't, causing the app to fail in some flows.
The fix was to only load the `timezone.js` script in the browser if it is not set in the session, instead of loading it always but only calling the update timezone endpoint when the local timezone isn't set in the session storage.