### PR TITLE
[BUGFIX] update janus scripting to take changes for JAN-1639

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -32,7 +32,7 @@
     "immer": "^9.0.5",
     "immutable": "^4.0.0-rc.12",
     "is-hotkey": "^0.1.6",
-    "janus-script": "^1.9.2",
+    "janus-script": "1.9.3",
     "jquery": "^3.5.0",
     "json-rules-engine": "^6.0.1",
     "json-schema": "^0.4.0",

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -5990,10 +5990,10 @@ istanbul-reports@^3.0.2:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
-janus-script@^1.9.2:
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/janus-script/-/janus-script-1.9.2.tgz#e3ce01d070ce4b009652c9b88c185fb2de75300c"
-  integrity sha512-mSDRxFAhFEs2ScJSERMAZQbDg/PiT+PLvY0qgNeDwO8ACvTPhK7VPgfIlk3ha8PXp1FvSRaXy2SEMNlIUvmanw==
+janus-script@1.9.3:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/janus-script/-/janus-script-1.9.3.tgz#3ab072f0fa3adeb437def4b390b80e30aa29263e"
+  integrity sha512-wtuKM9ewrUTyQhvwpH+yN9JqfHWc1qHnjqLn1hDSU69V6kakIKxXR23SOgqHG/Jq4yOPELUe9HI5KOODOiOPcA==
   dependencies:
     eventemitter3 "^4.0.7"
     mathjs "^9.3.2"


### PR DESCRIPTION
just aliasing `Math.max` to `max` and `Math.min` to `min` ... did it at the library level however because janus script does not support rest arguments