### PR TITLE
[MER-1010] Move authoring sign in prompt above learner/educator sign in

### DIFF
--- a/lib/oli_web/templates/pow/session/user_new.html.eex
+++ b/lib/oli_web/templates/pow/session/user_new.html.eex
@@ -1,3 +1,21 @@
+<div class="container">
+  <div class="row">
+    <div class="col-sm-12 col-md-10 col-lg-8 col-xl-6 mx-auto">
+      <div class="callout callout-primary d-flex flex-column">
+        <h4><i class="las la-info-circle mr-2"></i>Looking for Authoring or your LMS?</h4>
+        <p>This sign in page is for <b>Independent Learner and Educator</b> accounts.</p>
+        <p>If your institution uses an LMS such as Canvas or Blackboard to access your course, please sign in through your LMS.</p>
+        <p>If you are trying to sign in as an author, please use the Authoring Sign In page.</p>
+        <p>
+          <%= link to: Routes.authoring_pow_session_path(@conn, :new), class: "btn btn-sm btn-outline-primary my-2 my-sm-0 float-right" do %>
+            Go to Authoring Sign In <i class="fa fa-arrow-right"></i>
+          <% end %>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+
 <%= render OliWeb.SharedView, "_box_form_container.html", Map.merge(assigns, %{title: value_or(assigns[:title], "Learner/Educator Sign In"), bs_col_class: "col-sm-10 col-md-8 col-lg-6 col-xl-5 mx-auto"}) do %>
   <%# social media sign in links %>
   <%= for link <- OliWeb.Pow.PowHelpers.provider_links(@conn), do: raw link %>
@@ -41,21 +59,3 @@
 
   <% end %>
 <% end %>
-
-<div class="container">
-  <div class="row">
-    <div class="col-sm-12 col-md-10 col-lg-8 col-xl-6 mx-auto">
-      <div class="callout callout-primary d-flex flex-column">
-        <h4><i class="las la-info-circle mr-2"></i>Looking for Authoring or your LMS?</h4>
-        <p>This sign in page is for <b>Independent Learner and Educator</b> accounts.</p>
-        <p>If your institution uses an LMS such as Canvas or Blackboard to access your course, please sign in through your LMS.</p>
-        <p>If you are trying to sign in as an author, please use the Authoring Sign In page.</p>
-        <p>
-          <%= link to: Routes.authoring_pow_session_path(@conn, :new), class: "btn btn-sm btn-outline-primary my-2 my-sm-0 float-right" do %>
-            Go to Authoring Sign In <i class="fa fa-arrow-right"></i>
-          <% end %>
-        </p>
-      </div>
-    </div>
-  </div>
-</div>


### PR DESCRIPTION
[MER-1010](https://eliterate.atlassian.net/browse/MER-1010)

### What does it change?

- Moves the ‘Looking for Authoring or your LMS?’ text box back to the top of the page

![image](https://user-images.githubusercontent.com/22042418/169898001-37d83e68-adfd-4902-9867-0280e26d90c4.png)
