### PR TITLE
[BUGFIX][MER-1144] Create Publisher field validation too restrictive

### DIFF
--- a/lib/oli/inventories/publisher.ex
+++ b/lib/oli/inventories/publisher.ex
@@ -24,7 +24,7 @@ defmodule Oli.Inventories.Publisher do
     publisher
     |> cast(attrs, [:name, :email, :address, :main_contact, :website_url, :default])
     |> validate_required([:name, :email, :default])
-    |> validate_format(:email, Oli.Utils.email_regex())
+    |> validate_format(:email, ~r/@/)
     |> unique_constraint(:name)
     |> unique_constraint_if([:default], &is_default?/1,
       name: :publisher_default_true_index,

--- a/lib/oli/utils.ex
+++ b/lib/oli/utils.ex
@@ -4,7 +4,6 @@ defmodule Oli.Utils do
   import Ecto.Changeset
 
   @url_regex ~r/(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/i
-  @email_regex ~r/^[\w-\.]+@([\w-]+\.)+[\w-]+$/
 
   @doc """
   Generates a random hex string of the given length
@@ -305,9 +304,4 @@ defmodule Oli.Utils do
       "<a href=\"#{absolute_url}\" target=\"_blank\">#{url}</a>"
     end)
   end
-
-  @doc """
-  Returns email regex
-  """
-  def email_regex, do: @email_regex
 end

--- a/lib/oli/utils.ex
+++ b/lib/oli/utils.ex
@@ -3,8 +3,8 @@ defmodule Oli.Utils do
 
   import Ecto.Changeset
 
-  @urlRegex ~r/(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/i
-  @emailRegex ~r/^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/
+  @url_regex ~r/(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/i
+  @email_regex ~r/^[\w-\.]+@([\w-]+\.)+[\w-]+$/
 
   @doc """
   Generates a random hex string of the given length
@@ -294,7 +294,7 @@ defmodule Oli.Utils do
   Detects all urls in a string and replaces them with hyperlinks.
   """
   def find_and_linkify_urls_in_string(string) do
-    Regex.replace(@urlRegex, string, fn _, url ->
+    Regex.replace(@url_regex, string, fn _, url ->
       absolute_url =
         if is_url_absolute(url) do
           url
@@ -309,5 +309,5 @@ defmodule Oli.Utils do
   @doc """
   Returns email regex
   """
-  def email_regex, do: @emailRegex
+  def email_regex, do: @email_regex
 end

--- a/lib/oli_web/live/publisher_live/form.ex
+++ b/lib/oli_web/live/publisher_live/form.ex
@@ -2,7 +2,7 @@ defmodule OliWeb.PublisherLive.Form do
   use Surface.Component
 
   alias Surface.Components.Form
-  alias Surface.Components.Form.{ErrorTag, Field, Label, TextInput}
+  alias Surface.Components.Form.{EmailInput, ErrorTag, Field, Label, TextInput}
 
   prop(changeset, :changeset, required: true)
   prop(save, :event, required: true)
@@ -26,7 +26,7 @@ defmodule OliWeb.PublisherLive.Form do
         {#if @display_labels}
           <Label class="control-label">Publisher Email</Label>
         {/if}
-        <TextInput class="form-control" opts={placeholder: "Email", maxlength: "255"}/>
+        <EmailInput class="form-control" opts={placeholder: "Email", maxlength: "255"}/>
         <ErrorTag/>
       </Field>
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -435,7 +435,7 @@ defmodule Oli.Factory do
   def publisher_factory() do
     %Publisher{
       name: sequence("Publisher"),
-      email: "#{sequence("publisher")}@example.edu",
+      email: "#{sequence("publisher")}@example.education",
       address: "Publisher Address",
       main_contact: "Publisher Contact",
       website_url: "mypublisher.com",


### PR DESCRIPTION
[MER-1144](https://eliterate.atlassian.net/browse/MER-1144)

Update email regex to be less restrictive and consider emails such as `support@argos.education`.