### PR TITLE
Fixed initstateeditor to use value instead of defaultValue

### DIFF
--- a/assets/src/apps/authoring/components/AdaptivityEditor/InitStateEditor.tsx
+++ b/assets/src/apps/authoring/components/AdaptivityEditor/InitStateEditor.tsx
@@ -38,6 +38,7 @@ const InitStateItem: React.FC<InitStateItemProps> = ({ state, onChange, onDelete
   const typeRef = useRef<HTMLSelectElement>(null);
 
   const [target, setTarget] = useState(state.target);
+  const [value, setValue] = useState(state.value);
 
   const [showConfirmDelete, setShowConfirmDelete] = useState<boolean>(false);
 
@@ -58,6 +59,10 @@ const InitStateItem: React.FC<InitStateItemProps> = ({ state, onChange, onDelete
   React.useEffect(() => {
     setTarget(state.target);
   }, [state.target]);
+
+  React.useEffect(() => {
+    setValue(state.value);
+  }, [state.value]);
 
   return (
     <div
@@ -148,8 +153,9 @@ const InitStateItem: React.FC<InitStateItemProps> = ({ state, onChange, onDelete
           className="form-control form-control-sm flex-grow-1"
           key={`value-${state.id}`}
           id={`value-${state.id}`}
-          defaultValue={state.value}
+          value={value}
           placeholder="Value"
+          onChange={(e) => setValue(e.target.value)}
           onBlur={(e) => onChange(state.id, 'value', e.target.value)}
           title={state.value}
           tabIndex={0}


### PR DESCRIPTION
This fixes an issue where if the user selects between screens that are part of a layer, the init state value would not update as expected.