### PR TITLE
[MER-1086] Fix curriculum numbering visibility not applied at item level

### DIFF
--- a/lib/oli_web/templates/page_delivery/_link_shallow_container.html.eex
+++ b/lib/oli_web/templates/page_delivery/_link_shallow_container.html.eex
@@ -1,6 +1,6 @@
 <%= link to: @container_link_url.(@node.revision.slug),
   class: resource_link_class(@active_page == @node.revision.slug) do %>
   <span class="container-title my-2">
-    <%= container_title(@node) %>
+    <%= container_title(@node, @display_curriculum_item_numbering) %>
   </span>
 <% end %>

--- a/lib/oli_web/templates/page_delivery/container.html.eex
+++ b/lib/oli_web/templates/page_delivery/container.html.eex
@@ -1,5 +1,5 @@
 <h5 class="text-primary border-bottom border-primary mb-2">
-  <%= container_title(@container) %>
+  <%= container_title(@container,  @display_curriculum_item_numbering) %>
 </h5>
 
 

--- a/test/oli_web/controllers/page_delivery_controller_test.exs
+++ b/test/oli_web/controllers/page_delivery_controller_test.exs
@@ -609,7 +609,23 @@ defmodule OliWeb.PageDeliveryControllerTest do
           OliWeb.Pow.PowHelpers.get_pow_config(:user)
         )
 
+      # Check visibility in the section overview
       conn = get(conn, Routes.page_delivery_path(conn, :index, section.slug))
+
+      response = html_response(conn, 200)
+
+      refute response =~ "Unit 1:"
+      assert response =~ "Unit: The first unit"
+
+      conn =
+        recycle(conn)
+        |> Pow.Plug.assign_current_user(
+          user,
+          OliWeb.Pow.PowHelpers.get_pow_config(:user)
+        )
+
+      # Check visibility at the unit level
+      conn = get(conn, Routes.page_delivery_path(conn, :container, section.slug, "first_unit"))
 
       response = html_response(conn, 200)
 
@@ -637,7 +653,22 @@ defmodule OliWeb.PageDeliveryControllerTest do
           OliWeb.Pow.PowHelpers.get_pow_config(:user)
         )
 
+      # Check visibility in the section overview
       conn = get(conn, Routes.page_delivery_path(conn, :index, section.slug))
+
+      response = html_response(conn, 200)
+
+      assert response =~ "Unit 1: The first unit"
+
+      conn =
+        recycle(conn)
+        |> Pow.Plug.assign_current_user(
+          user,
+          OliWeb.Pow.PowHelpers.get_pow_config(:user)
+        )
+
+      # Check visibility at the unit level
+      conn = get(conn, Routes.page_delivery_path(conn, :container, section.slug, "first_unit"))
 
       response = html_response(conn, 200)
 

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -520,7 +520,8 @@ defmodule Oli.TestHelpers do
         content: %{"model" => []},
         deleted: false,
         title: "The first unit",
-        resource: unit_one_resource
+        resource: unit_one_resource,
+        slug: "first_unit"
       })
 
     # root container


### PR DESCRIPTION
[MER-1086](https://eliterate.atlassian.net/browse/MER-1086)

### What does it change?
Fixes curriculum item numbering always showing at the item level.

#### Bug

When set to false, numbering doesn't show in the section overview:
![image](https://user-images.githubusercontent.com/22042418/170241077-e59dc6f1-8c36-48fd-8d8c-5311a85c29d9.png)

However it did show in each unit's overview:
![image](https://user-images.githubusercontent.com/22042418/170241228-aa37df04-7edf-4dfb-9089-1a7c1d5e7c6f.png)


#### Fix

Section overview
<img width="461" alt="image" src="https://user-images.githubusercontent.com/22042418/170241417-07ece482-b9d7-49b5-add4-d07e50520679.png">

Unit overview
<img width="507" alt="image" src="https://user-images.githubusercontent.com/22042418/170241568-fe53b1de-10cf-4773-b96e-4961aff58838.png">



