### PR TITLE
Fixed issue with booleans passed to rules checking strings

### DIFF
--- a/assets/src/adaptivity/operators/equality.ts
+++ b/assets/src/adaptivity/operators/equality.ts
@@ -47,8 +47,13 @@ export const isEqual = (factValue: any, value: any): boolean => {
   }
   // for boolean values,  factValue comes as true and value comes as 'true'
   // and some factValue comes as 'true' and value comes as true
-  if (typeOfFactValue === 'boolean') {
-    return value.toString().toLowerCase() === 'true' ? true === factValue : false === factValue;
+
+  const stringifiedValue = value.toString().toLowerCase();
+  if (
+    typeOfFactValue === 'boolean' &&
+    (stringifiedValue === 'true' || stringifiedValue === 'false')
+  ) {
+    return stringifiedValue === 'true' ? true === factValue : false === factValue;
   }
   if (typeOfValue === 'boolean') {
     return factValue.toString().toLowerCase() === 'true' || factValue > 0

--- a/assets/src/adaptivity/operators/equality.ts
+++ b/assets/src/adaptivity/operators/equality.ts
@@ -48,7 +48,7 @@ export const isEqual = (factValue: any, value: any): boolean => {
   // for boolean values,  factValue comes as true and value comes as 'true'
   // and some factValue comes as 'true' and value comes as true
 
-  const stringifiedValue = value.toString().toLowerCase();
+  const stringifiedValue = value?.toString().toLowerCase();
   if (
     typeOfFactValue === 'boolean' &&
     (stringifiedValue === 'true' || stringifiedValue === 'false')

--- a/assets/test/adaptivity/rules_engine_test.ts
+++ b/assets/test/adaptivity/rules_engine_test.ts
@@ -242,6 +242,12 @@ describe('Rules Engine', () => {
 describe('Operators', () => {
   describe('Equality Operators', () => {
     it('should be able to test basic equality', () => {
+      expect(isEqual(false, 'NULL')).toEqual(false);
+      expect(isEqual(false, null)).toEqual(false);
+      expect(isEqual(false, 'false')).toEqual(true);
+      expect(isEqual(true, 'true')).toEqual(true);
+      expect(isEqual(false, 'true')).toEqual(false);
+      expect(isEqual(true, 'false')).toEqual(false);
       expect(isEqual('a', 'a')).toEqual(true);
       expect(isEqual(9, 9)).toEqual(true);
       expect(isEqual([1, 2], [1, 2])).toEqual(true);


### PR DESCRIPTION
This fixes an issue where is a fact value is a boolean, but a rule is checking for a string, it would not get past this section of the rules engine.