### PR TITLE
[BUG FIX] Allow input refs to be found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 - Improve performance of DataShop export
+- Fix an issue where multi-input activity inputs were being duplicated
 
 ### Enhancements
 

--- a/assets/src/data/content/utils.tsx
+++ b/assets/src/data/content/utils.tsx
@@ -134,12 +134,7 @@ export const elementsOfType = (content: ContentTypes, type: string): ModelElemen
     cb(content);
 
     if ((isContentItem(content) || Element.isElement(content)) && Array.isArray(content.children))
-      return contentBfs(
-        (content.children as Array<ModelElement>).filter(
-          (c: ModelElement) => c.type !== 'input_ref',
-        ),
-        cb,
-      );
+      return contentBfs(content.children as Array<ModelElement>, cb);
   };
 
   const elements: ModelElement[] = [];


### PR DESCRIPTION
Closes #2505 

Inputs in a multi-input activity were being duplicated.  Root case was code that adding input_refs when they could not be found used a method that explicitly excluded input_refs from being found. 