### PR TITLE
MER-1158 Add assignment selection to developer key

### DIFF
--- a/lib/oli_web/controllers/lti_controller.ex
+++ b/lib/oli_web/controllers/lti_controller.ex
@@ -171,6 +171,10 @@ defmodule OliWeb.LtiController do
                 "message_type" => "LtiResourceLinkRequest",
                 "icon_url" => Oli.VendorProperties.normalized_workspace_logo(host)
               },
+              %{
+                "placement" => "assignment_selection",
+                "message_type" => "LtiResourceLinkRequest"
+              },
               case Map.get(params, "course_navigation_default") do
                 "disabled" ->
                   %{
@@ -186,9 +190,13 @@ defmodule OliWeb.LtiController do
                   }
               end
               ## TODO: add support for more placement types in the future, possibly configurable by LMS admin
+              # assignment_selection when we support deep linking
               # %{
               #   "placement" => "assignment_selection",
-              #   "message_type" => "LtiResourceLinkRequest"
+              #   "message_type" => "LtiDeepLinkingRequest",
+              #   "custom_fields" => %{
+              #     "assignment_id" => "$Canvas.assignment.id"
+              #   }
               # },
               # %{
               #   "placement" => "homework_submission",

--- a/test/oli_web/controllers/lti_controller_test.exs
+++ b/test/oli_web/controllers/lti_controller_test.exs
@@ -425,10 +425,54 @@ defmodule OliWeb.LtiControllerTest do
                "https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly"
              ]
 
+      %{"extensions" => [%{"settings" => %{"placements" => placements}} | _]} =
+        json_response(conn, 200)
+
+      assert placements == [
+               %{
+                 "icon_url" => "https://localhost/images/torus-icon.png",
+                 "message_type" => "LtiResourceLinkRequest",
+                 "placement" => "link_selection"
+               },
+               %{
+                 "message_type" => "LtiResourceLinkRequest",
+                 "placement" => "assignment_selection"
+               },
+               %{"message_type" => "LtiResourceLinkRequest", "placement" => "course_navigation"}
+             ]
+
       assert json_response(conn, 200) |> Map.get("public_jwk") |> Map.get("kid") ==
                public_jwk["kid"]
 
       assert json_response(conn, 200) |> Map.get("public_jwk") |> Map.get("n") == public_jwk["n"]
+    end
+
+    test "returns developer key json with course navigation disabled", %{conn: conn} do
+      conn =
+        get(
+          conn,
+          Routes.lti_path(conn, :developer_key_json, course_navigation_default: "disabled")
+        )
+
+      %{"extensions" => [%{"settings" => %{"placements" => placements}} | _]} =
+        json_response(conn, 200)
+
+      assert placements == [
+               %{
+                 "icon_url" => "https://localhost/images/torus-icon.png",
+                 "message_type" => "LtiResourceLinkRequest",
+                 "placement" => "link_selection"
+               },
+               %{
+                 "message_type" => "LtiResourceLinkRequest",
+                 "placement" => "assignment_selection"
+               },
+               %{
+                 "message_type" => "LtiResourceLinkRequest",
+                 "placement" => "course_navigation",
+                 "default" => "disabled"
+               }
+             ]
     end
   end
 


### PR DESCRIPTION
Multiple customers have requested the assignment selection placement to be enabled in Canvas. Eventually this should be updated trigger the Deep Linking flow. Left a note towards that goal.