### PR TITLE
[MER-1171] Display institution link in sections overview page

### DIFF
--- a/assets/styles/common/controls.scss
+++ b/assets/styles/common/controls.scss
@@ -32,3 +32,7 @@
 .list-group .list-group-item:last-child {
   border-bottom: $list-group-border-width solid $list-group-border-color;
 }
+
+a.form-control {
+  color: $blue;
+}

--- a/lib/oli_web/live/common/properties/read_only.ex
+++ b/lib/oli_web/live/common/properties/read_only.ex
@@ -1,16 +1,31 @@
 defmodule OliWeb.Common.Properties.ReadOnly do
   use Surface.Component
 
+  alias Surface.Components.Link
+
   prop label, :string, required: true
   prop value, :string, required: true
   prop type, :string, default: "text"
+  prop link_label, :string
 
   def render(assigns) do
     ~F"""
     <div class="form-group">
       <label>{@label}</label>
-      <input class="form-control" type={@type} disabled value={@value}/>
+      {render_property(assigns)}
     </div>
+    """
+  end
+
+  defp render_property(%{type: "link"} = assigns) do
+    ~F"""
+    <Link label={@link_label} to={@value} class="form-control"/>
+    """
+  end
+
+  defp render_property(assigns) do
+    ~F"""
+    <input class="form-control" type={@type} disabled value={@value}/>
     """
   end
 end

--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -75,6 +75,8 @@ defmodule OliWeb.Sections.OverviewView do
   end
 
   def render(assigns) do
+    deployment = assigns.section.lti_1p3_deployment
+
     ~F"""
     {render_modal(assigns)}
     <Groups>
@@ -83,6 +85,9 @@ defmodule OliWeb.Sections.OverviewView do
         <ReadOnly label="Title" value={@section.title}/>
         <ReadOnly label="Course Section Type" value={type_to_string(@section)}/>
         <ReadOnly label="URL" value={Routes.page_delivery_url(OliWeb.Endpoint, :index, @section.slug)}/>
+        {#unless is_nil(deployment)}
+          <ReadOnly label="Institution" type="link" link_label={deployment.institution.name} value={Routes.institution_path(OliWeb.Endpoint, :show, deployment.institution_id)}/>
+        {/unless}
       </Group>
       <Group label="Instructors" description="Manage the users with instructor level access">
         <Instructors users={@instructors}/>

--- a/test/oli_web/live/sections/overview_live_test.exs
+++ b/test/oli_web/live/sections/overview_live_test.exs
@@ -135,6 +135,9 @@ defmodule OliWeb.Sections.OverviewLiveTest do
       assert has_element?(view, "input[value=\"#{section.slug}\"]")
       assert has_element?(view, "input[value=\"#{section.title}\"]")
       assert has_element?(view, "input[value=\"Direct Delivery\"]")
+
+      assert view |> element("a.form-control") |> render() =~
+               section.lti_1p3_deployment.institution.name
     end
 
     test "loads section instructors correctly", %{conn: conn, section: section} do

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -148,19 +148,22 @@ defmodule Oli.Factory do
   end
 
   def section_factory() do
+    deployment = insert(:lti_deployment)
+
     %Section{
       title: sequence("Section"),
       timezone: "America/New_York",
       registration_open: true,
       context_id: UUID.uuid4(),
-      institution: insert(:institution),
+      institution: deployment.institution,
       base_project: insert(:project),
       slug: sequence("examplesection"),
       type: :blueprint,
       open_and_free: false,
       description: "A description",
       brand: insert(:brand),
-      publisher: insert(:publisher)
+      publisher: insert(:publisher),
+      lti_1p3_deployment: deployment
     }
   end
 


### PR DESCRIPTION
[MER-1171](https://eliterate.atlassian.net/browse/MER-1171)

Show institution name and link under the "Details" section in the Course Overview page.