### PR TITLE
[CHORE] [MER-1089] Dependency cache during builds.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,26 @@ jobs:
       - name: 🗄 Start test database
         run: docker-compose up -d postgres
 
+      - name: 💾 Restore the deps cache
+        id: mix-deps-cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-
+
+      - name: 💾 Restore the node cache
+        id: yarn-cache
+        uses: actions/cache@v3
+        with:
+          path: assets/node_modules
+          key: ${{ runner.os }}-yarn-${{ hashFiles('assets/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
       - name: 🧪 Setup elixir
         uses: erlef/setup-elixir@v1
         with:
@@ -40,8 +60,12 @@ jobs:
       - name: 🔨 Build dependencies
         run: mix deps.compile
 
+      - name: 🧹 Clean on master
+        if: github.ref == 'refs/heads/master'
+        run: set -a;source oli.env && mix clean
+
       - name: 🔨 Build project
-        run: set -a;source oli.env && mix clean && mix compile --warnings-as-errors
+        run: set -a;source oli.env && mix compile --warnings-as-errors
 
       - name: ▶️ Run unit tests
         run: set -a;source oli.env && MIX_ENV=test mix ecto.reset && mix test

--- a/README.md
+++ b/README.md
@@ -29,5 +29,3 @@ Visit our [product roadmap](https://github.com/Simon-Initiative/oli-torus/projec
 See our [Wiki](https://github.com/Simon-Initiative/oli-torus/wiki) for Torus set up instructions, project contribution guidelines and processes, and system design information.
 
 For full API Documentation: [simon-initiative.github.io/oli-torus](https://simon-initiative.github.io/oli-torus/Oli.html)
-
-


### PR DESCRIPTION
This tweaks the GA builds to cache dependencies and not run mix.clean on non-master branches.

Non-scientific test sees build times go from ~14m to ~8m with the dependency caching to ~6m with the mix.clean removal.

![image](https://user-images.githubusercontent.com/333265/171237487-0353fac3-741c-4cb9-a954-deabcc189698.png)

Removing the mix.clean seemed safe since I don't see where we use any actual artifacts from these builds, but I kept it in place for master branch to be absolutely safe.

We had talked about doing this back in https://github.com/Simon-Initiative/oli-torus/pull/2481 but never got back around to doing it until now.