### PR TITLE
[BUGFIX][MER-1203] Institution link must only appear for admins in the sections overview page

### DIFF
--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -50,7 +50,8 @@ defmodule OliWeb.Sections.OverviewView do
 
         {:ok,
          assign(socket,
-           is_admin: Mount.is_lms_or_system_admin?(user, section),
+           is_system_admin: type == :admin,
+           is_lms_or_system_admin: Mount.is_lms_or_system_admin?(user, section),
            breadcrumbs: set_breadcrumbs(type, section),
            instructors: fetch_instructors(section),
            user: user,
@@ -86,7 +87,16 @@ defmodule OliWeb.Sections.OverviewView do
         <ReadOnly label="Course Section Type" value={type_to_string(@section)}/>
         <ReadOnly label="URL" value={Routes.page_delivery_url(OliWeb.Endpoint, :index, @section.slug)}/>
         {#unless is_nil(deployment)}
-          <ReadOnly label="Institution" type="link" link_label={deployment.institution.name} value={Routes.institution_path(OliWeb.Endpoint, :show, deployment.institution_id)}/>
+          <ReadOnly
+            label="Institution"
+            type={if @is_system_admin, do: "link"}
+            link_label={deployment.institution.name}
+            value={
+              if @is_system_admin,
+                do: Routes.institution_path(OliWeb.Endpoint, :show, deployment.institution_id),
+                else: deployment.institution.name
+            }
+          />
         {/unless}
       </Group>
       <Group label="Instructors" description="Manage the users with instructor level access">
@@ -133,7 +143,7 @@ defmodule OliWeb.Sections.OverviewView do
           <li><a href={Routes.page_delivery_path(OliWeb.Endpoint, :export_gradebook, @section.slug)}>Download Gradebook as <code>.csv</code> file</a></li>
           {#if !@section.open_and_free}
             <li><a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Grades.GradesLive, @section.slug)}>Manage LMS Gradebook</a></li>
-            {#if @is_admin}
+            {#if @is_lms_or_system_admin}
               <li><a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Grades.ObserveGradeUpdatesView, @section.slug)}>Observe grade updates in real-time</a></li>
             {/if}
             <li><a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Grades.BrowseUpdatesView, @section.slug)}>Browse LMS Grade Update Log</a></li>
@@ -141,7 +151,7 @@ defmodule OliWeb.Sections.OverviewView do
           </ul>
       </Group>
 
-      {#if @is_admin and !@section.open_and_free}
+      {#if @is_lms_or_system_admin and !@section.open_and_free}
         <Group label="LMS Admin" description="Administrator LMS Connection">
           <UnlinkSection unlink="unlink" section={@section}/>
         </Group>

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -265,7 +265,7 @@ defmodule Oli.TestHelpers do
       |> Plug.Test.init_test_session(lti_session: nil)
       |> Pow.Plug.assign_current_user(instructor, OliWeb.Pow.PowHelpers.get_pow_config(:user))
 
-    {:ok, conn: conn}
+    {:ok, conn: conn, instructor: instructor}
   end
 
   def lms_instructor_conn(%{conn: conn}) do


### PR DESCRIPTION
[MER-1203](https://eliterate.atlassian.net/browse/MER-1203)

Before these changes, the institution link was appearing for both admins and instructors in the sections overview page, but only admins are allowed to access to an institution page.

With the new behavior:
- Show the section institution name and a link to the institution page when accessing as an **admin**.
- Show only the section institution name when accessing as an **instructor**.