### PR TITLE
[BUG FIX] Remove redundant table header 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Improve performance of DataShop export
 - Fix an issue where multi-input activity inputs were being duplicated
+- Fix an issue where table headers were misaligned in the insights view
 
 ### Enhancements
 

--- a/lib/oli_web/live/insights/table_header.ex
+++ b/lib/oli_web/live/insights/table_header.ex
@@ -25,16 +25,6 @@ defmodule OliWeb.Insights.TableHeader do
     ~L"""
     <thead>
       <tr>
-        <%= th(assigns,
-          "title",
-          case @selected do
-            :by_page -> "Page Title"
-            :by_activity -> "Activity Title"
-            :by_objective -> "Objective"
-            _ -> "Objective"
-          end,
-          false)
-        %>
         <th
           tabindex="0"
           style="cursor: pointer"
@@ -50,9 +40,6 @@ defmodule OliWeb.Insights.TableHeader do
           end %>
           <%= sort_order_icon("title", @sort_by, @sort_order) %>
         </th>
-        <%= if @selected == :by_page || @selected == :by_objective do %>
-          <th scope="col">Activity Title</th>
-        <% end %>
         <%= th(assigns,
           "number_of_attempts",
           "Number of Attempts",


### PR DESCRIPTION
Closes #2571 

This PR fixes the heading alignment problem.  There were some redundant `<th>` elements being added, I think maybe from a bad merge.  Tested locally and it resolves the problem. 