### PR TITLE
[BUGFIX] [MER-1205] Product discounts fix

### DIFF
--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -774,7 +774,7 @@ defmodule OliWeb.PageDeliveryController do
 
   defp build_enrollments_text(enrollments) do
     ([["Student name", "Student email", "Enrolled on"]] ++
-      Enum.map(enrollments, fn record -> [record.user.name, record.user.email, NaiveDateTime.to_iso8601(record.inserted_at)] end))
+      Enum.map(enrollments, fn record -> [record.user.name, record.user.email, date(record.inserted_at)] end))
     |> CSV.encode()
     |> Enum.to_list()
     |> to_string()

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -774,9 +774,7 @@ defmodule OliWeb.PageDeliveryController do
 
   defp build_enrollments_text(enrollments) do
     ([["Student name", "Student email", "Enrolled on"]] ++
-       Enum.map(enrollments, fn record ->
-         [record.user.name, record.user.email, record.inserted_at]
-       end))
+      Enum.map(enrollments, fn record -> [record.user.name, record.user.email, NaiveDateTime.to_iso8601(record.inserted_at)] end))
     |> CSV.encode()
     |> Enum.to_list()
     |> to_string()

--- a/lib/oli_web/live/products/details/edit.ex
+++ b/lib/oli_web/live/products/details/edit.ex
@@ -76,13 +76,11 @@ defmodule OliWeb.Products.Details.Edit do
               <div><%= error_tag f, :amount %></div>
             </div>
 
-            <%= unless get_field(@changeset, :open_and_free) do %>
-              <div class="custom-control custom-switch fixed-width">
-                <%= checkbox f, :pay_by_institution, disabled: !@is_admin or !get_field(@changeset, :requires_payment), class: "custom-control-input" <> error_class(f, :pay_by_institution, "is-invalid"), autofocus: focusHelper(f, :pay_by_institution) %>
-                <%= label f, :pay_by_institution, "Pay by institution", class: "custom-control-label" %>
-                <%= error_tag f, :pay_by_institution %>
-              </div>
-            <% end %>
+            <div class="custom-control custom-switch fixed-width">
+              <%= checkbox f, :pay_by_institution, disabled: !@is_admin or !get_field(@changeset, :requires_payment), class: "custom-control-input" <> error_class(f, :pay_by_institution, "is-invalid"), autofocus: focusHelper(f, :pay_by_institution) %>
+              <%= label f, :pay_by_institution, "Pay by institution", class: "custom-control-label" %>
+              <%= error_tag f, :pay_by_institution %>
+            </div>
           </div>
 
           <div class="form-row">
@@ -112,8 +110,8 @@ defmodule OliWeb.Products.Details.Edit do
           </div>
 
           <div class="form-row float-right">
-            <%= if not get_field(@changeset, :open_and_free) and @is_admin and get_field(@changeset, :requires_payment) do %>
-              <a class="btn btn-link action-button" href={Routes.discount_path(OliWeb.Endpoint, :product, @product.slug)}>Manage Discounts</a>
+            <%= if @is_admin and get_field(@changeset, :requires_payment) do %>
+              <a class="btn btn-link action-button" href={Routes.live_path(OliWeb.Endpoint, OliWeb.Products.Payments.Discounts.ProductsIndexView, @product.slug)}>Manage Discounts</a>
             <% end %>
           </div>
 

--- a/lib/oli_web/live/products/payments/discounts/form.ex
+++ b/lib/oli_web/live/products/payments/discounts/form.ex
@@ -1,4 +1,4 @@
-defmodule OliWeb.Products.Payments.DiscountsForm do
+defmodule OliWeb.Products.Payments.Discounts.Form do
   use Surface.Component
 
   import Ecto.Changeset
@@ -11,13 +11,27 @@ defmodule OliWeb.Products.Payments.DiscountsForm do
   prop discount, :any, required: true
   prop save, :event, required: true
   prop change, :event, required: true
-  prop clear, :event, required: true
+  prop clear, :event
   prop institution_name, :string
+  prop live_action, :atom
+  prop institutions, :list
 
   def render(assigns) do
     ~F"""
       <Form for={@changeset} submit={@save} change={@change}>
-        <ReadOnly label="Institution" value={@institution_name}/>
+        {#if @live_action != :product_new}
+          <ReadOnly label="Institution" value={@institution_name}/>
+        {#else}
+          <Field name={:institution_id} class="form-group">
+            <Label/>
+            <Select
+              prompt="Select institution"
+              class="form-control"
+              options={Enum.map(@institutions, &{&1.name, &1.id})}
+              selected={get_field(@changeset, :institution_id)}/>
+            <ErrorTag/>
+          </Field>
+        {/if}
 
         <Field name={:type} class="form-group">
           <Label />
@@ -40,7 +54,9 @@ defmodule OliWeb.Products.Payments.DiscountsForm do
         <button class="form-button btn btn-md btn-primary btn-block mt-3" type="submit">Save</button>
       </Form>
 
-      <button class="btn btn-md btn-outline-danger float-right mt-3" phx-click="clear" disabled={is_nil(@discount)}>Clear</button>
+      {#if @live_action == :institution}
+        <button class="btn btn-md btn-outline-danger float-right mt-3" phx-click="clear" disabled={is_nil(@discount)}>Clear</button>
+      {/if}
     """
   end
 end

--- a/lib/oli_web/live/products/payments/discounts/products_index_view.ex
+++ b/lib/oli_web/live/products/payments/discounts/products_index_view.ex
@@ -1,0 +1,100 @@
+defmodule OliWeb.Products.Payments.Discounts.ProductsIndexView do
+  use Surface.LiveView, layout: {OliWeb.LayoutView, "live.html"}
+  use OliWeb.Common.SortableTable.TableHandlers
+
+  alias Oli.Delivery.{Sections, Paywall}
+  alias Oli.Delivery.Sections.Section
+  alias OliWeb.Common.{Breadcrumb, Listing}
+  alias OliWeb.Products.Payments.Discounts.TableModel
+  alias OliWeb.Router.Helpers, as: Routes
+  alias Surface.Components.Link
+
+  data title, :string, default: "Discounts"
+  data breadcrumbs, :any
+  data query, :string, default: ""
+  data total_count, :integer, default: 0
+  data offset, :integer, default: 0
+  data limit, :integer, default: 20
+  data sort, :string, default: "sort"
+  data page_change, :string, default: "page_change"
+  data show_bottom_paging, :boolean, default: false
+  data additional_table_class, :string, default: ""
+
+  @table_filter_fn &__MODULE__.filter_rows/3
+  @table_push_patch_path &__MODULE__.live_path/2
+
+  def filter_rows(socket, _, _), do: socket.assigns.discounts
+  def live_path(socket, params), do: Routes.live_path(socket, __MODULE__, socket.assigns.product.slug, params)
+
+  def set_breadcrumbs(product) do
+    OliWeb.Products.DetailsView.set_breadcrumbs(product) ++
+      [
+        Breadcrumb.new(%{
+          full_title: "Discounts",
+          link: Routes.live_path(OliWeb.Endpoint, __MODULE__, product.slug)
+        })
+      ]
+  end
+
+  def mount(%{"product_id" => product_slug}, _, socket) do
+    case Sections.get_section_by_slug(product_slug) do
+      %Section{type: :blueprint} = product ->
+        discounts = Paywall.get_product_discounts(product.id)
+
+        {:ok, table_model} = TableModel.new(discounts)
+
+        {:ok, assign(socket,
+          breadcrumbs: set_breadcrumbs(product),
+          discounts: discounts,
+          table_model: table_model,
+          total_count: length(discounts),
+          product: product
+        )}
+
+      _ -> {:ok, Phoenix.LiveView.redirect(socket, to: Routes.static_page_path(OliWeb.Endpoint, :not_found))}
+    end
+  end
+
+  def render(assigns) do
+    ~F"""
+      <Link
+        to={Routes.discount_path(OliWeb.Endpoint, :product_new, @product.slug)}
+        class="btn btn-outline-primary float-right">
+        Create Discount
+      </Link>
+
+      <div id="discounts-table" class="p-4">
+        <Listing
+          filter={@query}
+          table_model={@table_model}
+          total_count={@total_count}
+          offset={@offset}
+          limit={@limit}
+          sort={@sort}
+          page_change={@page_change}
+          show_bottom_paging={@show_bottom_paging}
+          additional_table_class={@additional_table_class}/>
+      </div>
+    """
+  end
+
+  def handle_event("remove", %{"id" => id}, socket) do
+    socket = clear_flash(socket)
+
+    discount = Paywall.get_discount_by!(%{id: String.to_integer(id)})
+
+    case Paywall.delete_discount(discount) do
+      {:ok, _discount} ->
+        discounts = Paywall.get_product_discounts(socket.assigns.product.id)
+        {:ok, table_model} = TableModel.new(discounts)
+
+        {:noreply,
+          socket
+          |> put_flash(:info, "Discount successfully removed.")
+          |> assign(discounts: discounts, table_model: table_model, total_count: length(discounts))}
+
+      {:error, _error} ->
+        {:noreply, put_flash(socket, :error, "Discount couldn't be removed.")}
+    end
+  end
+end

--- a/lib/oli_web/live/products/payments/discounts/show_view.ex
+++ b/lib/oli_web/live/products/payments/discounts/show_view.ex
@@ -1,4 +1,4 @@
-defmodule OliWeb.Products.Payments.Discounts do
+defmodule OliWeb.Products.Payments.Discounts.ShowView do
   use Surface.LiveView, layout: {OliWeb.LayoutView, "live.html"}
 
   alias Oli.Delivery.{Paywall, Sections}
@@ -6,9 +6,8 @@ defmodule OliWeb.Products.Payments.Discounts do
   alias Oli.Delivery.Sections.Section
   alias Oli.Institutions
   alias Oli.Institutions.Institution
-  alias Oli.Lti.Tool.Deployment
   alias OliWeb.Common.{Breadcrumb, FormContainer}
-  alias OliWeb.Products.Payments.DiscountsForm
+  alias OliWeb.Products.Payments.Discounts.{Form, ProductsIndexView}
   alias OliWeb.InstitutionController
   alias OliWeb.Router.Helpers, as: Routes
 
@@ -16,71 +15,78 @@ defmodule OliWeb.Products.Payments.Discounts do
   data title, :string, default: "Manage Discount"
   data product, :any, default: nil
   data institution, :any, default: nil
+  data institutions, :any, default: []
   data discount, :any, default: nil
   data changeset, :changeset, default: nil
   data institution_name, :string, default: ""
 
-  defp set_breadcrumbs(:product = live_action, product) do
-    breadcrumb(
-      OliWeb.Products.DetailsView.set_breadcrumbs(product),
-      live_action,
-      product.slug
-    )
+  defp set_breadcrumbs(:product, product, discount_id) do
+    ProductsIndexView.set_breadcrumbs(product) ++
+      [
+        Breadcrumb.new(%{
+          full_title: "Manage Discount",
+          link: Routes.discount_path(OliWeb.Endpoint, :product, product.slug, discount_id)
+        })
+      ]
   end
 
-  defp set_breadcrumbs(:institution = live_action, institution) do
-    (InstitutionController.root_breadcrumbs() ++
+  defp set_breadcrumbs(:product_new, product) do
+    ProductsIndexView.set_breadcrumbs(product) ++
+      [Breadcrumb.new(%{full_title: "New Discount"})]
+  end
+
+  defp set_breadcrumbs(:institution, institution) do
+    InstitutionController.root_breadcrumbs() ++
       [
         Breadcrumb.new(%{
           full_title: "#{institution.name}",
           link: Routes.institution_path(OliWeb.Endpoint, :show, institution.id)
         })
-      ]
-    )
-    |> breadcrumb(live_action, institution.id)
+      ] ++
+        [
+          Breadcrumb.new(%{
+            full_title: "Discount",
+            link: Routes.discount_path(OliWeb.Endpoint, :institution, institution.id)
+          })
+        ]
   end
 
-  def breadcrumb(previous, live_action, entity_slug) do
-    previous ++
-      [
-        Breadcrumb.new(%{
-          full_title: "Discounts",
-          link: Routes.discount_path(OliWeb.Endpoint, live_action, entity_slug)
-        })
-      ]
-  end
-
-  def mount(params, _session, socket) do
-    # Discounts used in two routes.
-    # live_action is :institution or :product
-    live_action = socket.assigns.live_action
-
-    mount_for(live_action, params, socket)
-  end
-
-  defp mount_for(:product = live_action, %{"product_id" => product_slug}, socket) do
+  defp mount_for(:product_new = live_action, %{"product_id" => product_slug}, socket) do
     case Sections.get_section_by_slug(product_slug) do
-      %Section{
-        type: :blueprint,
-        lti_1p3_deployment: %Deployment{
-          institution: %Institution{id: institution_id, name: institution_name}
-        }
-      } = product ->
+      %Section{type: :blueprint} = product ->
+        institutions = Institutions.list_institutions()
+
+        {:ok, assign(socket,
+          title: "New Discount",
+          breadcrumbs: set_breadcrumbs(live_action, product),
+          institutions: institutions,
+          product: product,
+          discount: nil,
+          changeset: Paywall.change_discount(%Discount{}),
+          live_action: live_action
+        )}
+
+      _ -> {:ok, Phoenix.LiveView.redirect(socket, to: Routes.static_page_path(OliWeb.Endpoint, :not_found))}
+    end
+  end
+
+  defp mount_for(:product = live_action, %{"product_id" => product_slug, "discount_id" => discount_id}, socket) do
+    case Sections.get_section_by_slug(product_slug) do
+      %Section{type: :blueprint} = product ->
         {discount, changeset} =
-          case Paywall.get_discount_by!(%{
-            section_id: product.id,
-            institution_id: institution_id
-          }) do
-            nil -> {nil, Paywall.change_discount(%Discount{})}
+          case Paywall.get_discount_by!(%{id: discount_id}) do
+            nil -> {:ok, Phoenix.LiveView.redirect(socket, to: Routes.static_page_path(OliWeb.Endpoint, :not_found))}
             discount -> {discount, Paywall.change_discount(discount)}
           end
 
         {:ok, assign(socket,
-          breadcrumbs: set_breadcrumbs(live_action, product),
-          institution_name: institution_name,
+          breadcrumbs: set_breadcrumbs(live_action, product, discount.id),
+          institution: discount.institution,
+          institution_name: discount.institution.name,
           product: product,
           discount: discount,
-          changeset: changeset
+          changeset: changeset,
+          live_action: live_action
         )}
 
       _ -> {:ok, Phoenix.LiveView.redirect(socket, to: Routes.static_page_path(OliWeb.Endpoint, :not_found))}
@@ -101,22 +107,33 @@ defmodule OliWeb.Products.Payments.Discounts do
           institution_name: name,
           institution: institution,
           discount: discount,
-          changeset: changeset
+          changeset: changeset,
+          live_action: live_action
         )}
 
       _ -> {:ok, Phoenix.LiveView.redirect(socket, to: Routes.static_page_path(OliWeb.Endpoint, :not_found))}
     end
   end
 
+  def mount(params, _session, socket) do
+    # Discounts show view used in three routes.
+    # live_action is :institution, :product or :product_new
+    live_action = socket.assigns.live_action
+
+    mount_for(live_action, params, socket)
+  end
+
   def render(assigns) do
     ~F"""
       <FormContainer title={@title}>
-        <DiscountsForm
+        <Form
           institution_name={@institution_name}
+          institutions={@institutions}
           discount={@discount}
           changeset={@changeset}
           save="save"
           change="change"
+          live_action={@live_action}
           clear="clear" />
       </FormContainer>
     """
@@ -125,10 +142,9 @@ defmodule OliWeb.Products.Payments.Discounts do
   def handle_event("save", %{"discount" => params}, socket) do
     socket = clear_flash(socket)
 
-    rels_params = get_rels_params(socket.assigns)
     attrs = %{
-      section_id: rels_params.section_id,
-      institution_id: rels_params.institution_id,
+      section_id: (if socket.assigns.live_action == :institution, do: nil, else: socket.assigns.product.id),
+      institution_id: (if socket.assigns.live_action == :product_new, do: get_institution_id(params["institution_id"]), else: socket.assigns.institution.id),
       percentage: params["percentage"],
       amount: params["amount"],
       type: params["type"]
@@ -176,17 +192,6 @@ defmodule OliWeb.Products.Payments.Discounts do
     {:noreply, assign(socket, changeset: Paywall.change_discount(socket.assigns.changeset.data, params))}
   end
 
-  defp get_rels_params(%{live_action: :product} = assigns) do
-    %{
-      section_id: assigns.product.id,
-      institution_id: assigns.product.lti_1p3_deployment.institution.id
-    }
-  end
-
-  defp get_rels_params(%{live_action: :institution} = assigns) do
-    %{
-      section_id: nil,
-      institution_id: assigns.institution.id,
-    }
-  end
+  defp get_institution_id(""), do: nil
+  defp get_institution_id(id), do: id
 end

--- a/lib/oli_web/live/products/payments/discounts/table_model.ex
+++ b/lib/oli_web/live/products/payments/discounts/table_model.ex
@@ -20,12 +20,10 @@ defmodule OliWeb.Products.Payments.Discounts.TableModel do
           render_fn: &__MODULE__.render_type_column/3
         },
         %ColumnSpec{
-          name: :percentage,
-          label: "Percentage"
-        },
-        %ColumnSpec{
-          name: :amount,
-          label: "Amount"
+          name: :value,
+          label: "Value",
+          render_fn: &__MODULE__.render_value_column/3,
+          sort_fn: &__MODULE__.sort_value_column/2
         },
         %ColumnSpec{
           name: :inserted_at,
@@ -46,6 +44,17 @@ defmodule OliWeb.Products.Payments.Discounts.TableModel do
   def render_institution_column(_assigns, item, _), do: item.institution.name
 
   def render_type_column(_assigns, item, _), do: Phoenix.Naming.humanize(item.type)
+
+  def render_value_column(_assigns, %{type: :percentage} = item, _), do: item.percentage
+  def render_value_column(_assigns, %{type: :fixed_amount} = item, _), do: item.amount
+
+  def sort_value_column(sort_order, sort_spec) do
+    {fn
+      %{type: :percentage} = item -> %{value: item.percentage}
+      %{type: :fixed_amount} = item -> %{value: item.amount}
+    end,
+    ColumnSpec.default_sort_fn(sort_order, sort_spec)}
+  end
 
   def render_actions_column(assigns, item, _) do
     ~F"""

--- a/lib/oli_web/live/products/payments/discounts/table_model.ex
+++ b/lib/oli_web/live/products/payments/discounts/table_model.ex
@@ -1,0 +1,66 @@
+defmodule OliWeb.Products.Payments.Discounts.TableModel do
+  use Surface.LiveComponent
+
+  alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
+  alias OliWeb.Router.Helpers, as: Routes
+  alias Surface.Components.Link
+
+  def new(discounts) do
+    SortableTableModel.new(
+      rows: discounts,
+      column_specs: [
+        %ColumnSpec{
+          name: :institution,
+          label: "Institution",
+          render_fn: &__MODULE__.render_institution_column/3
+        },
+        %ColumnSpec{
+          name: :type,
+          label: "Type",
+          render_fn: &__MODULE__.render_type_column/3
+        },
+        %ColumnSpec{
+          name: :percentage,
+          label: "Percentage"
+        },
+        %ColumnSpec{
+          name: :amount,
+          label: "Amount"
+        },
+        %ColumnSpec{
+          name: :inserted_at,
+          label: "Created",
+          render_fn: &SortableTableModel.render_inserted_at_column/3
+        },
+        %ColumnSpec{
+          name: :actions,
+          label: "Actions",
+          render_fn: &__MODULE__.render_actions_column/3
+        }
+      ],
+      event_suffix: "",
+      id_field: [:id]
+    )
+  end
+
+  def render_institution_column(_assigns, item, _), do: item.institution.name
+
+  def render_type_column(_assigns, item, _), do: Phoenix.Naming.humanize(item.type)
+
+  def render_actions_column(assigns, item, _) do
+    ~F"""
+      <Link
+        to={Routes.discount_path(OliWeb.Endpoint, :product, item.section.slug, item.id)}
+        class="btn btn-outline-primary">
+        Edit
+      </Link>
+      <button class="btn btn-outline-danger" phx-click="remove" phx-value-id={item.id}>Remove</button>
+    """
+  end
+
+  def render(assigns) do
+    ~F"""
+      <div>nothing</div>
+    """
+  end
+end

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -859,7 +859,9 @@ defmodule OliWeb.Router do
     live("/features", Features.FeaturesLive)
     live("/api_keys", ApiKeys.ApiKeysLive)
     live("/products", Products.ProductsView)
-    live("/products/:product_id/discounts", Products.Payments.Discounts, :product, as: :discount)
+    live("/products/:product_id/discounts", Products.Payments.Discounts.ProductsIndexView)
+    live("/products/:product_id/discounts/new", Products.Payments.Discounts.ShowView, :product_new, as: :discount)
+    live("/products/:product_id/discounts/:discount_id", Products.Payments.Discounts.ShowView, :product, as: :discount)
 
     # Section Management (+ Open and Free)
     live("/sections", Sections.SectionsView)
@@ -869,10 +871,7 @@ defmodule OliWeb.Router do
 
     # Institutions, LTI Registrations and Deployments
     resources("/institutions", InstitutionController)
-
-    live("/institutions/:institution_id/discounts", Products.Payments.Discounts, :institution,
-      as: :discount
-    )
+    live("/institutions/:institution_id/discount", Products.Payments.Discounts.ShowView, :institution, as: :discount)
 
     live("/registrations", Admin.RegistrationsView)
 

--- a/lib/oli_web/templates/institution/show.html.eex
+++ b/lib/oli_web/templates/institution/show.html.eex
@@ -11,7 +11,7 @@
     <div class="float-right">
       <%= link "Delete", to: Routes.institution_path(@conn, :delete, @institution), method: :delete, data: [confirm: "Are you sure you want to permanently delete the institution \"#{@institution.name}\"?"], class: "btn btn-sm btn-outline-danger" %>
       <%= link "Edit Details", to: Routes.institution_path(@conn, :edit, @institution), class: "btn btn-sm btn-outline-primary ml-2" %>
-      <%= link "Manage Discounts", to: Routes.discount_path(@conn, :institution, @institution.id), class: "btn btn-sm btn-outline-primary ml-2" %>
+      <%= link "Manage Discount", to: Routes.discount_path(@conn, :institution, @institution.id), class: "btn btn-sm btn-outline-primary ml-2" %>
     </div>
   </h3>
 

--- a/test/oli/delivery/paywall_test.exs
+++ b/test/oli/delivery/paywall_test.exs
@@ -563,10 +563,10 @@ defmodule Oli.Delivery.PaywallTest do
 
     test "get_product_discounts/1 returns the discounts associated with one product" do
       %Discount{id: first_discount_id} = first_discount = insert(:discount)
-      %Discount{id: second_discount_id} = insert(:discount, section: first_discount.section)
+      %Discount{id: second_discount_id} = insert(:discount, section: first_discount.section, percentage: 90)
 
       assert [%Discount{id: ^first_discount_id}, %Discount{id: ^second_discount_id}]
-        = Paywall.get_product_discounts(first_discount.section.id)
+        = Paywall.get_product_discounts(first_discount.section.id) |> Enum.sort_by(& &1.percentage)
     end
 
     test "update_discount/2 updates the discount successfully" do

--- a/test/oli/delivery/paywall_test.exs
+++ b/test/oli/delivery/paywall_test.exs
@@ -557,6 +557,18 @@ defmodule Oli.Delivery.PaywallTest do
                   fn -> Paywall.get_institution_wide_discount!(discount.institution_id) end
     end
 
+    test "get_product_discounts/1 returns empty if a discount does not exist for the product" do
+      assert [] == Paywall.get_product_discounts(123)
+    end
+
+    test "get_product_discounts/1 returns the discounts associated with one product" do
+      %Discount{id: first_discount_id} = first_discount = insert(:discount)
+      %Discount{id: second_discount_id} = insert(:discount, section: first_discount.section)
+
+      assert [%Discount{id: ^first_discount_id}, %Discount{id: ^second_discount_id}]
+        = Paywall.get_product_discounts(first_discount.section.id)
+    end
+
     test "update_discount/2 updates the discount successfully" do
       discount = insert(:discount)
 
@@ -637,6 +649,22 @@ defmodule Oli.Delivery.PaywallTest do
       assert updated_discount.type == :fixed_amount
       assert updated_discount.amount == Money.new(:USD, 25)
       refute updated_discount.percentage
+    end
+
+    test "create_or_update_discount/1 returns error if no institution is specified" do
+      params = %{
+        institution_id: nil,
+        section_id: nil,
+        type: :fixed_amount,
+        amount: Money.new(:USD, 25),
+        percentage: nil
+      }
+
+      {:error, changeset} = Paywall.create_or_update_discount(params)
+      {error, _} = changeset.errors[:institution_id]
+
+      refute changeset.valid?
+      assert error =~ "can't be blank"
     end
   end
 end

--- a/test/oli_web/controllers/page_delivery_controller_test.exs
+++ b/test/oli_web/controllers/page_delivery_controller_test.exs
@@ -781,7 +781,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       conn = post(conn, Routes.page_delivery_path(OliWeb.Endpoint, :export_enrollments, section.slug))
 
       assert response(conn, 200) =~
-        "Cost: Free\r\nDiscount N/A\r\n\r\nStudent name,Student email,Enrolled on\r\n#{user.name},#{user.email},#{enrollment.inserted_at}\r\n"
+        "Cost: Free\r\nDiscount N/A\r\n\r\nStudent name,Student email,Enrolled on\r\n#{user.name},#{user.email},#{NaiveDateTime.to_iso8601(enrollment.inserted_at)}\r\n"
     end
 
     test "export enrollments as csv with discount info - percentage", %{conn: conn} do
@@ -800,7 +800,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       conn = post(conn, Routes.page_delivery_path(OliWeb.Endpoint, :export_enrollments, section.slug))
 
       assert response(conn, 200) =~
-        "Cost: Free\r\nDiscount By Product-Institution: 10.0%\r\n\r\nStudent name,Student email,Enrolled on\r\n#{user.name},#{user.email},#{enrollment.inserted_at}\r\n"
+        "Cost: Free\r\nDiscount By Product-Institution: 10.0%\r\n\r\nStudent name,Student email,Enrolled on\r\n#{user.name},#{user.email},#{NaiveDateTime.to_iso8601(enrollment.inserted_at)}\r\n"
     end
 
     test "export enrollments as csv with discount info - amount", %{conn: conn} do
@@ -819,7 +819,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       conn = post(conn, Routes.page_delivery_path(OliWeb.Endpoint, :export_enrollments, section.slug))
 
       assert response(conn, 200) =~
-        "Cost: Free\r\nDiscount By Product-Institution: $100.00\r\n\r\nStudent name,Student email,Enrolled on\r\n#{user.name},#{user.email},#{enrollment.inserted_at}\r\n"
+        "Cost: Free\r\nDiscount By Product-Institution: $100.00\r\n\r\nStudent name,Student email,Enrolled on\r\n#{user.name},#{user.email},#{NaiveDateTime.to_iso8601(enrollment.inserted_at)}\r\n"
     end
 
     test "export enrollments as csv with discount info - institution wide", %{conn: conn} do
@@ -838,7 +838,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       conn = post(conn, Routes.page_delivery_path(OliWeb.Endpoint, :export_enrollments, section.slug))
 
       assert response(conn, 200) =~
-        "Cost: Free\r\nDiscount By Institution: 10.0%\r\n\r\nStudent name,Student email,Enrolled on\r\n#{user.name},#{user.email},#{enrollment.inserted_at}\r\n"
+        "Cost: Free\r\nDiscount By Institution: 10.0%\r\n\r\nStudent name,Student email,Enrolled on\r\n#{user.name},#{user.email},#{NaiveDateTime.to_iso8601(enrollment.inserted_at)}\r\n"
     end
   end
 

--- a/test/oli_web/controllers/page_delivery_controller_test.exs
+++ b/test/oli_web/controllers/page_delivery_controller_test.exs
@@ -8,6 +8,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
   alias Oli.Seeder
   alias Oli.Delivery.Attempts.Core.{ResourceAttempt, PartAttempt, ResourceAccess}
   alias Lti_1p3.Tool.ContextRoles
+  alias OliWeb.Common.FormatDateTime
   alias OliWeb.Router.Helpers, as: Routes
 
   describe "page_delivery_controller index" do
@@ -781,7 +782,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       conn = post(conn, Routes.page_delivery_path(OliWeb.Endpoint, :export_enrollments, section.slug))
 
       assert response(conn, 200) =~
-        "Cost: Free\r\nDiscount N/A\r\n\r\nStudent name,Student email,Enrolled on\r\n#{user.name},#{user.email},#{NaiveDateTime.to_iso8601(enrollment.inserted_at)}\r\n"
+        "Cost: Free\r\nDiscount N/A\r\n\r\nStudent name,Student email,Enrolled on\r\n#{user.name},#{user.email},\"#{FormatDateTime.date(enrollment.inserted_at)}\"\r\n"
     end
 
     test "export enrollments as csv with discount info - percentage", %{conn: conn} do
@@ -800,7 +801,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       conn = post(conn, Routes.page_delivery_path(OliWeb.Endpoint, :export_enrollments, section.slug))
 
       assert response(conn, 200) =~
-        "Cost: Free\r\nDiscount By Product-Institution: 10.0%\r\n\r\nStudent name,Student email,Enrolled on\r\n#{user.name},#{user.email},#{NaiveDateTime.to_iso8601(enrollment.inserted_at)}\r\n"
+        "Cost: Free\r\nDiscount By Product-Institution: 10.0%\r\n\r\nStudent name,Student email,Enrolled on\r\n#{user.name},#{user.email},\"#{FormatDateTime.date(enrollment.inserted_at)}\"\r\n"
     end
 
     test "export enrollments as csv with discount info - amount", %{conn: conn} do
@@ -819,7 +820,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       conn = post(conn, Routes.page_delivery_path(OliWeb.Endpoint, :export_enrollments, section.slug))
 
       assert response(conn, 200) =~
-        "Cost: Free\r\nDiscount By Product-Institution: $100.00\r\n\r\nStudent name,Student email,Enrolled on\r\n#{user.name},#{user.email},#{NaiveDateTime.to_iso8601(enrollment.inserted_at)}\r\n"
+        "Cost: Free\r\nDiscount By Product-Institution: $100.00\r\n\r\nStudent name,Student email,Enrolled on\r\n#{user.name},#{user.email},\"#{FormatDateTime.date(enrollment.inserted_at)}\"\r\n"
     end
 
     test "export enrollments as csv with discount info - institution wide", %{conn: conn} do
@@ -838,7 +839,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       conn = post(conn, Routes.page_delivery_path(OliWeb.Endpoint, :export_enrollments, section.slug))
 
       assert response(conn, 200) =~
-        "Cost: Free\r\nDiscount By Institution: 10.0%\r\n\r\nStudent name,Student email,Enrolled on\r\n#{user.name},#{user.email},#{NaiveDateTime.to_iso8601(enrollment.inserted_at)}\r\n"
+        "Cost: Free\r\nDiscount By Institution: 10.0%\r\n\r\nStudent name,Student email,Enrolled on\r\n#{user.name},#{user.email},\"#{FormatDateTime.date(enrollment.inserted_at)}\"\r\n"
     end
   end
 

--- a/test/oli_web/live/discounts_live_test.exs
+++ b/test/oli_web/live/discounts_live_test.exs
@@ -8,127 +8,185 @@ defmodule OliWeb.DiscountsLiveTest do
   alias Oli.Delivery.Paywall
   alias Oli.Delivery.Paywall.Discount
 
-  defp live_view_route(type, entity_slug) do
-    Routes.discount_path(OliWeb.Endpoint, type, entity_slug)
+  defp live_view_products_index_route(product_slug),
+    do: Routes.live_path(OliWeb.Endpoint, OliWeb.Products.Payments.Discounts.ProductsIndexView, product_slug)
+
+  defp live_view_product_show_route(product_slug, discount_id),
+    do: Routes.discount_path(OliWeb.Endpoint, :product, product_slug, discount_id)
+
+  defp live_view_product_new_show_route(product_slug),
+    do: Routes.discount_path(OliWeb.Endpoint, :product_new, product_slug)
+
+  defp live_view_institution_show_route(institution_id),
+    do: Routes.discount_path(OliWeb.Endpoint, :institution, institution_id)
+
+  defp create_product(_conn) do
+    product = insert(:section, type: :blueprint)
+
+    [product: product]
   end
 
   describe "user cannot access when is not logged in" do
-    test "redirects to new session when accessing the view - product", %{conn: conn} do
-      product = insert(:section, type: :blueprint, lti_1p3_deployment: insert(:lti_deployment))
+    test "redirects to new session when accessing the products index view", %{conn: conn} do
+      product = insert(:section, type: :blueprint)
 
       redirect_path =
         "/authoring/session/new?request_path=%2Fadmin%2Fproducts%2F#{product.slug}%2Fdiscounts"
 
       {:error, {:redirect, %{to: ^redirect_path}}} =
-        live(conn, live_view_route(:product, product.slug))
+        live(conn, live_view_products_index_route(product.slug))
     end
 
-    test "redirects to new session when accessing the view - institution", %{conn: conn} do
+    test "redirects to new session when accessing the new show view - product", %{conn: conn} do
+      product = insert(:section, type: :blueprint)
+
+      redirect_path =
+        "/authoring/session/new?request_path=%2Fadmin%2Fproducts%2F#{product.slug}%2Fdiscounts%2Fnew"
+
+      {:error, {:redirect, %{to: ^redirect_path}}} =
+        live(conn, live_view_product_new_show_route(product.slug))
+    end
+
+    test "redirects to new session when accessing the show view - product", %{conn: conn} do
+      product = insert(:section, type: :blueprint)
+      discount = insert(:discount, section: product)
+
+      redirect_path =
+        "/authoring/session/new?request_path=%2Fadmin%2Fproducts%2F#{product.slug}%2Fdiscounts%2F#{discount.id}"
+
+      {:error, {:redirect, %{to: ^redirect_path}}} =
+        live(conn, live_view_product_show_route(product.slug, discount.id))
+    end
+
+    test "redirects to new session when accessing the show view - institution", %{conn: conn} do
       institution = insert(:institution)
 
       redirect_path =
-        "/authoring/session/new?request_path=%2Fadmin%2Finstitutions%2F#{institution.id}%2Fdiscounts"
+        "/authoring/session/new?request_path=%2Fadmin%2Finstitutions%2F#{institution.id}%2Fdiscount"
 
       {:error, {:redirect, %{to: ^redirect_path}}} =
-        live(conn, live_view_route(:institution, institution.id))
+        live(conn, live_view_institution_show_route(institution.id))
     end
   end
 
   describe "user cannot access when is logged in as an author but is not a system admin" do
     setup [:author_conn]
 
-    test "returns forbidden when accessing the view - product", %{conn: conn} do
-      product = insert(:section, type: :blueprint, lti_1p3_deployment: insert(:lti_deployment))
+    test "returns forbidden when accessing the products index view", %{conn: conn} do
+      product = insert(:section, type: :blueprint)
 
-      conn = get(conn, live_view_route(:product, product.slug))
+      conn = get(conn, live_view_products_index_route(product.slug))
 
       assert response(conn, 403)
     end
 
-    test "returns forbidden when accessing the view - institution", %{conn: conn} do
+    test "returns forbidden when accessing the new show view - product", %{conn: conn} do
+      product = insert(:section, type: :blueprint)
+
+      conn = get(conn, live_view_product_new_show_route(product.slug))
+
+      assert response(conn, 403)
+    end
+
+    test "returns forbidden when accessing the show view - product", %{conn: conn} do
+      product = insert(:section, type: :blueprint)
+      discount = insert(:discount, section: product)
+
+      conn = get(conn, live_view_product_show_route(product.slug, discount.id))
+
+      assert response(conn, 403)
+    end
+
+    test "returns forbidden when accessing the show view - institution", %{conn: conn} do
       institution = insert(:institution)
 
-      conn = get(conn, live_view_route(:institution, institution.id))
+      conn = get(conn, live_view_institution_show_route(institution.id))
 
       assert response(conn, 403)
     end
   end
 
-  describe "discount view" do
-    setup [:admin_conn]
+  describe "products discounts index view" do
+    setup [:admin_conn, :create_product]
 
-    test "redirects to not found when not exists - product", %{conn: conn} do
-      # section without lti deployment
-      product = insert(:section, type: :blueprint, lti_1p3_deployment: nil)
+    test "loads correctly when there are no discounts updates", %{conn: conn, product: product} do
+      {:ok, view, _html} = live(conn, live_view_products_index_route(product.slug))
 
-      {:error, {:redirect, %{to: "/not_found"}}} = live(conn, live_view_route(:product, product.slug))
+      assert has_element?(view, "#discounts-table")
+      assert has_element?(view, "p", "None exist")
+      assert has_element?(view, "a[href=\"#{live_view_product_new_show_route(product.slug)}\"]")
+      refute has_element?(view, "button[phx-click=\"clear\"")
     end
 
-    test "redirects to not found when not exists - institution", %{conn: conn} do
-      {:error, {:redirect, %{to: "/not_found"}}} = live(conn, live_view_route(:institution, 000000123))
+    test "applies sorting", %{conn: conn, product: product} do
+      first_discount = insert(:discount, section: product)
+      second_discount = insert(:discount, section: product, percentage: 20)
+
+      {:ok, view, _html} = live(conn, live_view_products_index_route(product.slug))
+
+      view
+      |> element("th[phx-click=\"sort\"]:first-of-type")
+      |> render_click(%{sort_by: "percentage"})
+
+      assert has_element?(view, "tbody tr:first-child.##{first_discount.id}")
+
+      view
+      |> element("th[phx-click=\"sort\"]:first-of-type")
+      |> render_click(%{sort_by: "percentage"})
+
+      assert has_element?(view, "tbody tr:first-child.##{second_discount.id}")
     end
 
-    test "loads correctly with no discount - product", %{conn: conn} do
-      deployment = insert(:lti_deployment)
-      product = insert(:section, type: :blueprint, lti_1p3_deployment: deployment)
+    test "applies paging", %{conn: conn, product: product} do
+      first_discount = insert(:discount, section: product, inserted_at: DateTime.utc_now() |> DateTime.add(-3600, :second))
+      [_head | tail] = insert_list(21, :discount, section: product) |> Enum.sort_by(& &1.inserted_at)
+      last_discount = List.last(tail)
 
-      {:ok, view, _html} = live(conn, live_view_route(:product, product.slug))
+      {:ok, view, _html} = live(conn, live_view_products_index_route(product.slug))
+
+      view
+      |> element("th[phx-click=\"sort\"]:first-of-type")
+      |> render_click(%{sort_by: "inserted_at"})
+
+      assert has_element?(view, "##{first_discount.id}")
+      refute has_element?(view, "##{last_discount.id}")
+
+      view
+      |> element("a[phx-click=\"page_change\"]", "2")
+      |> render_click()
+
+      refute has_element?(view, "##{first_discount.id}")
+      assert has_element?(view, "##{last_discount.id}")
+    end
+  end
+
+  describe "discount show view - product" do
+    setup [:admin_conn, :create_product]
+
+    test "redirects to not found when not exists", %{conn: conn} do
+      product = insert(:section, type: :enrollable)
+      discount = insert(:discount)
+
+      {:error, {:redirect, %{to: "/not_found"}}} = live(conn, live_view_product_show_route(product.slug, discount.id))
+    end
+
+    test "loads correctly", %{conn: conn, product: product} do
+      discount = insert(:discount, section: product)
+
+      {:ok, view, _html} = live(conn, live_view_product_show_route(product.slug, discount.id))
 
       assert has_element?(view, "h5", "Manage Discount")
       assert has_element?(view, "form[phx-submit=\"save\"")
-      assert has_element?(view, "input[value=\"#{deployment.institution.name}\"")
-    end
-
-    test "loads correctly with no discount - institution", %{conn: conn} do
-      institution = insert(:institution)
-
-      {:ok, view, _html} = live(conn, live_view_route(:institution, institution.id))
-
-      assert has_element?(view, "h5", "Manage Discount")
-      assert has_element?(view, "form[phx-submit=\"save\"")
-      assert has_element?(view, "input[value=\"#{institution.name}\"")
-    end
-
-    test "loads correctly with discount - product", %{conn: conn} do
-      deployment = insert(:lti_deployment)
-      product = insert(:section, type: :blueprint, lti_1p3_deployment: deployment)
-      discount = insert(:discount, section: product, institution: deployment.institution)
-
-      {:ok, view, _html} = live(conn, live_view_route(:product, product.slug))
-
-      assert has_element?(view, "h5", "Manage Discount")
-      assert has_element?(view, "form[phx-submit=\"save\"")
-      assert has_element?(view, "input[value=\"#{deployment.institution.name}\"")
+      assert has_element?(view, "input[value=\"#{discount.institution.name}\"")
       # type is percentage
       assert has_element?(view, "input[name=\"discount[amount]\"][disabled=\"disabled\"]")
       assert has_element?(view, "input[value=\"#{discount.percentage}\"")
     end
 
-    test "loads correctly with discount - institution", %{conn: conn} do
-      institution = insert(:institution)
-      discount = insert(:discount,
-        type: :fixed_amount,
-        amount: Money.new(:USD, 25),
-        percentage: nil,
-        section: nil,
-        institution: institution
-      )
+    test "displays error message when data is invalid", %{conn: conn, product: product} do
+      discount = insert(:discount, section: product)
 
-      {:ok, view, _html} = live(conn, live_view_route(:institution, institution.id))
-
-      assert has_element?(view, "h5", "Manage Discount")
-      assert has_element?(view, "form[phx-submit=\"save\"")
-      assert has_element?(view, "input[value=\"#{institution.name}\"")
-      assert has_element?(view, "input[value=\"#{discount.amount}\"")
-      # type is fixed_amount
-      assert has_element?(view, "input[name=\"discount[percentage]\"][disabled=\"disabled\"]")
-    end
-
-    test "displays error message when data is invalid - product", %{conn: conn} do
-      deployment = insert(:lti_deployment)
-      product = insert(:section, type: :blueprint, lti_1p3_deployment: deployment)
-
-      {:ok, view, _html} = live(conn, live_view_route(:product, product.slug))
+      {:ok, view, _html} = live(conn, live_view_product_show_route(product.slug, discount.id))
 
       view
       |> element("form[phx-submit=\"save\"")
@@ -139,35 +197,17 @@ defmodule OliWeb.DiscountsLiveTest do
              |> render() =~
                "Discount couldn&#39;t be created/updated. Please check the errors below."
       assert has_element?(view, "span", "can't be blank")
-      refute Paywall.get_discount_by!(%{
+      refute %Discount{type: :fixed_amount} == Paywall.get_discount_by!(%{
         section_id: product.id,
-        institution_id: deployment.institution.id
+        institution_id: discount.institution.id
       })
     end
 
-    test "displays error message when data is invalid - institution", %{conn: conn} do
-      institution = insert(:institution)
-
-      {:ok, view, _html} = live(conn, live_view_route(:institution, institution.id))
-
-      view
-      |> element("form[phx-submit=\"save\"")
-      |> render_submit(%{discount: %{type: "fixed_amount"}})
-
-      assert view
-            |> element("div.alert.alert-danger")
-            |> render() =~
-              "Discount couldn&#39;t be created/updated. Please check the errors below."
-      assert has_element?(view, "span", "can't be blank")
-      refute Paywall.get_institution_wide_discount!(institution.id)
-    end
-
-    test "saves discount when data is valid - product", %{conn: conn} do
-      deployment = insert(:lti_deployment)
-      product = insert(:section, type: :blueprint, lti_1p3_deployment: deployment)
+    test "saves discount when data is valid", %{conn: conn, product: product} do
+      discount = insert(:discount, section: product)
       params = params_for(:discount)
 
-      {:ok, view, _html} = live(conn, live_view_route(:product, product.slug))
+      {:ok, view, _html} = live(conn, live_view_product_show_route(product.slug, discount.id))
 
       view
       |> element("form[phx-submit=\"save\"")
@@ -182,18 +222,129 @@ defmodule OliWeb.DiscountsLiveTest do
 
       %Discount{type: type, percentage: percentage} = Paywall.get_discount_by!(%{
         section_id: product.id,
-        institution_id: deployment.institution.id
+        institution_id: discount.institution.id
       })
 
       assert type == params.type
       assert percentage == params.percentage
     end
+  end
 
-    test "saves discount when data is valid - institution", %{conn: conn} do
+  describe "discount show view - new product" do
+    setup [:admin_conn, :create_product]
+
+    test "redirects to not found when not exists", %{conn: conn} do
+      product = insert(:section, type: :enrollable)
+
+      {:error, {:redirect, %{to: "/not_found"}}} = live(conn, live_view_product_new_show_route(product.slug))
+    end
+
+    test "loads correctly", %{conn: conn, product: product} do
+      institution = insert(:institution)
+
+      {:ok, view, _html} = live(conn, live_view_product_new_show_route(product.slug))
+
+      assert has_element?(view, "h5", "New Discount")
+      assert has_element?(view, "form[phx-submit=\"save\"")
+      assert has_element?(view, "option[value=\"#{institution.id}\"", "#{institution.name}")
+      refute has_element?(view, "button[phx-click=\"clear\"")
+    end
+
+    test "displays error message when data is invalid", %{conn: conn, product: product} do
+      {:ok, view, _html} = live(conn, live_view_product_new_show_route(product.slug))
+
+      view
+      |> element("form[phx-submit=\"save\"")
+      |> render_submit(%{discount: %{type: "fixed_amount"}})
+
+      assert view
+             |> element("div.alert.alert-danger")
+             |> render() =~
+               "Discount couldn&#39;t be created/updated. Please check the errors below."
+      assert [] = Paywall.get_product_discounts(product.id)
+    end
+
+    test "saves discount when data is valid", %{conn: conn, product: product} do
+      params = params_for(:discount)
+
+      {:ok, view, _html} = live(conn, live_view_product_new_show_route(product.slug))
+
+      view
+      |> element("form[phx-submit=\"save\"")
+      |> render_submit(%{
+        discount: params
+      })
+
+      assert view
+            |> element("div.alert.alert-info")
+            |> render() =~
+              "Discount successfully created/updated."
+
+      [%Discount{type: type, percentage: percentage}] = Paywall.get_product_discounts(product.id)
+      assert type == params.type
+      assert percentage == params.percentage
+    end
+  end
+
+  describe "discount show view - institution" do
+    setup [:admin_conn]
+
+    test "redirects to not found when not exists", %{conn: conn} do
+      {:error, {:redirect, %{to: "/not_found"}}} = live(conn, live_view_institution_show_route(000123))
+    end
+
+    test "loads correctly with no discount", %{conn: conn} do
+      institution = insert(:institution)
+
+      {:ok, view, _html} = live(conn, live_view_institution_show_route(institution.id))
+
+      assert has_element?(view, "h5", "Manage Discount")
+      assert has_element?(view, "form[phx-submit=\"save\"")
+      assert has_element?(view, "input[value=\"#{institution.name}\"")
+    end
+
+    test "loads correctly with discount", %{conn: conn} do
+      institution = insert(:institution)
+      discount = insert(:discount,
+        type: :fixed_amount,
+        amount: Money.new(:USD, 25),
+        percentage: nil,
+        section: nil,
+        institution: institution
+      )
+
+      {:ok, view, _html} = live(conn, live_view_institution_show_route(institution.id))
+
+      assert has_element?(view, "h5", "Manage Discount")
+      assert has_element?(view, "form[phx-submit=\"save\"")
+      assert has_element?(view, "input[value=\"#{institution.name}\"")
+      assert has_element?(view, "input[value=\"#{discount.amount}\"")
+      # type is fixed_amount
+      assert has_element?(view, "input[name=\"discount[percentage]\"][disabled=\"disabled\"]")
+    end
+
+    test "displays error message when data is invalid", %{conn: conn} do
+      institution = insert(:institution)
+
+      {:ok, view, _html} = live(conn, live_view_institution_show_route(institution.id))
+
+      view
+      |> element("form[phx-submit=\"save\"")
+      |> render_submit(%{discount: %{type: "fixed_amount"}})
+
+      assert view
+            |> element("div.alert.alert-danger")
+            |> render() =~
+              "Discount couldn&#39;t be created/updated. Please check the errors below."
+      assert has_element?(view, "span", "can't be blank")
+      refute Paywall.get_institution_wide_discount!(institution.id)
+    end
+
+    test "saves discount when data is valid", %{conn: conn} do
       institution = insert(:institution)
       params = params_for(:discount)
 
-      {:ok, view, _html} = live(conn, live_view_route(:institution, institution.id))
+      {:ok, view, _html} = live(conn, live_view_institution_show_route(institution.id))
 
       view
       |> element("form[phx-submit=\"save\"")
@@ -213,33 +364,11 @@ defmodule OliWeb.DiscountsLiveTest do
       assert percentage == params.percentage
     end
 
-    test "clears discount correctly - product", %{conn: conn} do
-      deployment = insert(:lti_deployment)
-      product = insert(:section, type: :blueprint, lti_1p3_deployment: deployment)
-      insert(:discount, section: product, institution: deployment.institution)
-
-      {:ok, view, _html} = live(conn, live_view_route(:product, product.slug))
-
-      view
-      |> element("button[phx-click=\"clear\"")
-      |> render_click()
-
-      assert view
-            |> element("div.alert.alert-info")
-            |> render() =~
-              "Discount successfully cleared."
-
-      refute Paywall.get_discount_by!(%{
-        section_id: product.id,
-        institution_id: deployment.institution.id
-      })
-    end
-
     test "clears discount correctly - institution", %{conn: conn} do
       institution = insert(:institution)
       insert(:discount, section: nil, institution: institution)
 
-      {:ok, view, _html} = live(conn, live_view_route(:institution, institution.id))
+      {:ok, view, _html} = live(conn, live_view_institution_show_route(institution.id))
 
       view
       |> element("button[phx-click=\"clear\"")

--- a/test/oli_web/live/discounts_live_test.exs
+++ b/test/oli_web/live/discounts_live_test.exs
@@ -126,13 +126,13 @@ defmodule OliWeb.DiscountsLiveTest do
 
       view
       |> element("th[phx-click=\"sort\"]:first-of-type")
-      |> render_click(%{sort_by: "percentage"})
+      |> render_click(%{sort_by: "value"})
 
       assert has_element?(view, "tbody tr:first-child.##{first_discount.id}")
 
       view
       |> element("th[phx-click=\"sort\"]:first-of-type")
-      |> render_click(%{sort_by: "percentage"})
+      |> render_click(%{sort_by: "value"})
 
       assert has_element?(view, "tbody tr:first-child.##{second_discount.id}")
     end
@@ -215,10 +215,8 @@ defmodule OliWeb.DiscountsLiveTest do
         discount: params
       })
 
-      assert view
-            |> element("div.alert.alert-info")
-            |> render() =~
-              "Discount successfully created/updated."
+      flash = assert_redirected(view, live_view_products_index_route(product.slug))
+      assert flash["info"] == "Discount successfully created/updated."
 
       %Discount{type: type, percentage: percentage} = Paywall.get_discount_by!(%{
         section_id: product.id,
@@ -265,7 +263,7 @@ defmodule OliWeb.DiscountsLiveTest do
     end
 
     test "saves discount when data is valid", %{conn: conn, product: product} do
-      params = params_for(:discount)
+      params = params_with_assocs(:discount)
 
       {:ok, view, _html} = live(conn, live_view_product_new_show_route(product.slug))
 
@@ -275,10 +273,8 @@ defmodule OliWeb.DiscountsLiveTest do
         discount: params
       })
 
-      assert view
-            |> element("div.alert.alert-info")
-            |> render() =~
-              "Discount successfully created/updated."
+      flash = assert_redirected(view, live_view_products_index_route(product.slug))
+      assert flash["info"] == "Discount successfully created/updated."
 
       [%Discount{type: type, percentage: percentage}] = Paywall.get_product_discounts(product.id)
       assert type == params.type
@@ -352,10 +348,8 @@ defmodule OliWeb.DiscountsLiveTest do
         discount: params
       })
 
-      assert view
-            |> element("div.alert.alert-info")
-            |> render() =~
-              "Discount successfully created/updated."
+      flash = assert_redirected(view, Routes.institution_path(OliWeb.Endpoint, :show, institution.id))
+      assert flash["info"] == "Discount successfully created/updated."
 
       %Discount{type: type, percentage: percentage} =
         Paywall.get_institution_wide_discount!(institution.id)

--- a/test/oli_web/live/products_test.exs
+++ b/test/oli_web/live/products_test.exs
@@ -91,7 +91,7 @@ defmodule OliWeb.ProductsLiveTest do
       assert render(view) =~ "The Product title and description"
       assert has_element?(view, "input[value=\"#{product.title}\"]")
       assert has_element?(view, "input[name=\"section[pay_by_institution]\"]")
-      assert has_element?(view, "a[href=\"#{Routes.discount_path(OliWeb.Endpoint, :product, product.slug)}\"]")
+      assert has_element?(view, "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Products.Payments.Discounts.ProductsIndexView, product.slug)}\"]")
     end
   end
 


### PR DESCRIPTION
[MER-1205](https://eliterate.atlassian.net/browse/MER-1205)

When did the suppress paywall feature, I **wrongly** assumed that a product could only have one discount. This changes fix that, being able to create more than one discount for the same product (but different institution). 

Added an index view to list the discounts for a product, and tweak the discounts show view + form to contemplate this new scenario as well. Also fixed some date format on the enrollments csv export.

![image](https://user-images.githubusercontent.com/42446726/171685087-3403df99-085a-4ca0-90bd-04b06a835b1d.png)