### PR TITLE
[MER-462] Add product image upload and make it accesible through API

### DIFF
--- a/assets/styles/authoring/image-upload.scss
+++ b/assets/styles/authoring/image-upload.scss
@@ -1,0 +1,37 @@
+@import 'delivery/variables';
+
+.drag-and-drop-zone {
+  background-image: url("data:image/svg+xml,%3csvg width='100%25' height='100%25' xmlns='http://www.w3.org/2000/svg'%3e%3crect width='100%25' height='100%25' fill='none' rx='13' ry='13' stroke='%23C8C8C8FF' stroke-width='3' stroke-dasharray='7%2c 16' stroke-dashoffset='0' stroke-linecap='square'/%3e%3c/svg%3e");
+  border-radius: 13px;
+  background-color: $body-bg;
+}
+
+.on-drag {
+  background-color: darken($color: $body-bg, $amount: 10%);
+}
+
+.btn-tertiary {
+  margin: auto;
+  display: block;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+}
+
+.img-input-file {
+	opacity: 0;
+	overflow: hidden;
+	z-index: 1;
+  cursor: pointer;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.input-file-form-group {
+  width: 100%;
+  max-height: 75%;
+  background-color: $body-bg;
+}

--- a/assets/styles/authoring/index.scss
+++ b/assets/styles/authoring/index.scss
@@ -2,6 +2,7 @@
 @import 'advanced-authoring.scss';
 @import 'community.scss';
 @import 'controls.scss';
+@import 'image-upload.scss';
 @import 'institutions.scss';
 @import 'main.scss';
 @import 'modal.scss';

--- a/lib/oli/delivery/sections/section.ex
+++ b/lib/oli/delivery/sections/section.ex
@@ -33,6 +33,7 @@ defmodule Oli.Delivery.Sections.Section do
     field(:status, Ecto.Enum, values: [:active, :deleted, :archived], default: :active)
     field(:invite_token, :string)
     field(:passcode, :string)
+    field(:cover_image, :string)
 
     field(:visibility, Ecto.Enum, values: [:selected, :global], default: :global)
     field(:requires_payment, :boolean, default: false)
@@ -117,6 +118,7 @@ defmodule Oli.Delivery.Sections.Section do
       :status,
       :invite_token,
       :passcode,
+      :cover_image,
       :visibility,
       :requires_payment,
       :pay_by_institution,

--- a/lib/oli/utils/s3_storage.ex
+++ b/lib/oli/utils/s3_storage.ex
@@ -1,0 +1,33 @@
+defmodule Oli.Utils.S3Storage do
+  # require Logger
+
+  alias ExAws.S3
+  alias Oli.HTTP
+
+  @doc """
+    Uploads a file to S3 given a bucket name, upload path, and current file path
+  """
+  @spec upload_file(binary, binary, binary | map) :: {:ok, any} | {:error, any}
+  def upload_file(bucket_name, upload_path, file_path) when is_map(file_path) do
+    upload_file(bucket_name, upload_path, file_path.path)
+  end
+
+  def upload_file(bucket_name, upload_path, file_path) do
+    media_url = Application.fetch_env!(:oli, :media_url)
+
+    full_upload_path = "http://#{media_url}/#{upload_path}"
+
+    contents = File.read!(file_path)
+
+    case upload(bucket_name, upload_path, contents) do
+      {:ok, %{status_code: 200}} -> {:ok, full_upload_path}
+      _ -> {:error, full_upload_path}
+    end
+
+  end
+
+  defp upload(bucket_name, upload_path, contents) do
+    S3.put_object(bucket_name, upload_path, contents, [{:acl, :public_read}])
+    |> HTTP.aws().request()
+  end
+end

--- a/lib/oli/utils/s3_storage.ex
+++ b/lib/oli/utils/s3_storage.ex
@@ -1,5 +1,4 @@
 defmodule Oli.Utils.S3Storage do
-  # require Logger
 
   alias ExAws.S3
   alias Oli.HTTP
@@ -21,7 +20,7 @@ defmodule Oli.Utils.S3Storage do
 
     case upload(bucket_name, upload_path, contents) do
       {:ok, %{status_code: 200}} -> {:ok, full_upload_path}
-      _ -> {:error, full_upload_path}
+      {_, payload} -> {:error, payload}
     end
 
   end

--- a/lib/oli_web/common/source_image.ex
+++ b/lib/oli_web/common/source_image.ex
@@ -1,0 +1,14 @@
+defmodule OliWeb.Common.SourceImage do
+  alias OliWeb.Router.Helpers, as: Routes
+
+  @doc """
+    Given a section or source, returns the cover_image for the given element, or a default one.
+  """
+  def cover_image(%{cover_image: url}) when not is_nil(url) do
+      url
+  end
+
+  def cover_image(_) do
+    Routes.static_path(OliWeb.Endpoint, "/images/course_default.jpg")
+  end
+end

--- a/lib/oli_web/controllers/api/product_controller.ex
+++ b/lib/oli_web/controllers/api/product_controller.ex
@@ -43,7 +43,8 @@ defmodule OliWeb.Api.ProductController do
             "has_grace_period" => true,
             "grace_period_days" => 10,
             "grace_period_strategy" => "relative_to_student",
-            "publisher_id" => 10
+            "publisher_id" => 10,
+            "cover_image" => "https://www.someurl.com/some-image.png"
           }
         ]
       }

--- a/lib/oli_web/controllers/brand_controller.ex
+++ b/lib/oli_web/controllers/brand_controller.ex
@@ -6,10 +6,9 @@ defmodule OliWeb.BrandController do
   alias Oli.Branding
   alias Oli.Branding.Brand
   alias Oli.Repo
-  alias ExAws.S3
-  alias Oli.HTTP
   alias Oli.Institutions
   alias OliWeb.Common.{Breadcrumb}
+  alias Oli.Utils.S3Storage
 
   defp set_breadcrumbs() do
     OliWeb.Admin.AdminView.breadcrumb()
@@ -136,13 +135,14 @@ defmodule OliWeb.BrandController do
 
   defp upload_brand_assets(brand, brand_params) do
     brand_path = "brands/#{brand.slug}"
+    bucket_name = Application.fetch_env!(:oli, :s3_media_bucket_name)
 
     case brand_params["logo"] do
       nil ->
         nil
 
       logo ->
-        upload("#{brand_path}/#{logo.filename}", logo)
+        S3Storage.upload_file(bucket_name, "#{brand_path}/#{logo.filename}", logo)
     end
 
     valid_favicon_names = [
@@ -164,7 +164,7 @@ defmodule OliWeb.BrandController do
           Regex.replace(~r/\.[^.]+$/, f.filename, "") in valid_favicon_names
         end)
         |> Enum.each(fn f ->
-          upload("#{brand_path}/favicons/#{f.filename}", f)
+          S3Storage.upload_file(bucket_name, "#{brand_path}/favicons/#{f.filename}", f)
         end)
     end
 
@@ -174,26 +174,7 @@ defmodule OliWeb.BrandController do
         nil
 
       logo_dark ->
-        upload("#{brand_path}/#{logo_dark.filename}", logo_dark)
+        S3Storage.upload_file(bucket_name, "#{brand_path}/#{logo_dark.filename}", logo_dark)
     end
-  end
-
-  defp upload(path, file) do
-    contents = File.read!(file.path)
-
-    bucket_name = Application.fetch_env!(:oli, :s3_media_bucket_name)
-
-    case upload_file(bucket_name, path, contents) do
-      {:ok, %{status_code: 200}} ->
-        nil
-
-      _ ->
-        Logger.error("Failed to upload file to S3 '#{path}'", file)
-    end
-  end
-
-  defp upload_file(bucket, path, contents) do
-    S3.put_object(bucket, path, contents, [{:acl, :public_read}])
-    |> HTTP.aws().request()
   end
 end

--- a/lib/oli_web/controllers/brand_controller.ex
+++ b/lib/oli_web/controllers/brand_controller.ex
@@ -1,13 +1,11 @@
 defmodule OliWeb.BrandController do
   use OliWeb, :controller
 
-  require Logger
-
   alias Oli.Branding
   alias Oli.Branding.Brand
   alias Oli.Repo
   alias Oli.Institutions
-  alias OliWeb.Common.{Breadcrumb}
+  alias OliWeb.Common.Breadcrumb
   alias Oli.Utils.S3Storage
 
   defp set_breadcrumbs() do

--- a/lib/oli_web/live/common/card_listing.ex
+++ b/lib/oli_web/live/common/card_listing.ex
@@ -1,7 +1,8 @@
 defmodule OliWeb.Common.CardListing do
   use Surface.Component
 
-  alias OliWeb.Router.Helpers, as: Routes
+  import OliWeb.Common.SourceImage
+
   alias OliWeb.Common.FormatDateTime
   alias OliWeb.Delivery.SelectSource.TableModel
 
@@ -16,7 +17,7 @@ defmodule OliWeb.Common.CardListing do
         {#for item <- @model.rows}
           <a :on-click={@selected} phx-value-id={action_id(item)}>
             <div class="card mb-2 mr-1 ml-1">
-              <img src={Routes.static_path(OliWeb.Endpoint, "/images/course_default.jpg")} class="card-img-top" alt="course image">
+              <img src={cover_image(item)} class="card-img-top" alt="course image">
               <div class="card-body">
                 <h5 class="card-title text-primary">{render_title_column(item)}</h5>
                 <div class="fade-text"><p class="card-text small">{render_description(item)}</p></div>

--- a/lib/oli_web/live/products/details/image_upload.ex
+++ b/lib/oli_web/live/products/details/image_upload.ex
@@ -31,7 +31,7 @@ defmodule OliWeb.Products.Details.ImageUpload do
                 <div class="col-6 d-flex justify-content-center">
 
                   <div class="form-group input-file-form-group">
-                    <LiveFileInput upload={@uploads.cover_image} class="img-input-file" opts={[disaled: @uploads.cover_image.entries != []]}/>
+                    <LiveFileInput upload={@uploads.cover_image} class="img-input-file"/>
                     <label class="btn btn-dark btn-tertiary js-labelFile">
                       <i class={"#{if @uploads.cover_image.entries != [], do: "fa-check", else: "fa-upload"} icon fa"}></i>
                       <span class="js-fileName">
@@ -55,46 +55,44 @@ defmodule OliWeb.Products.Details.ImageUpload do
           </section>
 
             <section class="row mb-2" id="img-preview">
-            {#if @uploads.cover_image.entries != []}
-              {#for entry <- @uploads.cover_image.entries}
-                <article class="upload-entry col-12">
-                  {#if !entry_has_errors?(@uploads.cover_image, entry)}
-                  <figure>
-                    { live_img_preview entry, class: "img-fluid w-75"}
-                    <figcaption class="text-muted">{ entry.client_name }</figcaption>
-                  </figure>
+              {#if @uploads.cover_image.entries != []}
+                {#for entry <- @uploads.cover_image.entries}
+                  <article class="upload-entry col-12">
+                    {#if !entry_has_errors?(@uploads.cover_image, entry)}
+                      <figure>
+                        { live_img_preview entry, class: "img-fluid w-75"}
+                        <figcaption class="text-muted">{ entry.client_name }</figcaption>
+                      </figure>
 
-                  <div class="row d-flex">
-                    <div class="col-8 align-self-center h-100">
-                      <div class="progress">
-                        <div role="progressbar" class="progress-bar w-100" style={"width:#{entry.progress} !important"} value={entry.progress} max="100" aria-valuemin="0" aria-valuemax="100"> { entry.progress }% </div>
+                      <div class="row d-flex">
+                        <div class="col-8 align-self-center h-100">
+                          <div class="progress">
+                            <div role="progressbar" class="progress-bar w-100" style={"width:#{entry.progress} !important"} value={entry.progress} max="100" aria-valuemin="0" aria-valuemax="100"> { entry.progress }% </div>
+                          </div>
+                        </div>
+                        <div class="col-4 align-self-center h-100">
+                          <button class="btn btn-secondary btn-sm" phx-click="cancel_upload" phx-value-ref={entry.ref} aria-label="cancel">&times;</button>
+                        </div>
                       </div>
-                    </div>
-                    <div class="col-4 align-self-center h-100">
-                      <button class="btn btn-secondary btn-sm" phx-click="cancel_upload" phx-value-ref={entry.ref} aria-label="cancel">&times;</button>
-                    </div>
-                  </div>
+                    {/if}
 
-                  {/if}
+                    {#for err <- upload_errors(@uploads.cover_image, entry)}
+                      <div class="alert danger">{ upload_error(err) }</div>
+                    {/for}
 
-                  {#for err <- upload_errors(@uploads.cover_image, entry)}
-                    <div class="alert danger">{ upload_error(err) }</div>
-                  {/for}
-
-                </article>
-              {/for}
-            {#else}
+                  </article>
+                {/for}
+              {#else}
                 <article class="col-12">
-                    <img id="current-product-img" src={@product.cover_image} class="img-fluid w-75" />
+                  <img id="current-product-img" src={@product.cover_image} class="img-fluid w-75" />
                 </article>
-            {/if}
+              {/if}
             </section>
 
             <Submit class="btn btn-primary mt-3" label="Save" opts={ [disabled: !upload_has_entries?(@uploads.cover_image) or upload_has_errors?(@uploads.cover_image)] }/>
           </Form>
         </div>
       </div>
-
     </div>
 
     <script type="text/javascript">
@@ -125,4 +123,5 @@ defmodule OliWeb.Products.Details.ImageUpload do
   defp upload_error(:too_large), do: "Image too large, try again with a image lower than 5 MB."
   defp upload_error(:too_many_files), do: "Too many files, try again with a single file"
   defp upload_error(:not_accepted), do: "Unacceptable file type, try again with a .jpg .jpeg or .png file"
+  defp upload_error(error), do: Phoenix.Naming.humanize(error)
 end

--- a/lib/oli_web/live/products/details/image_upload.ex
+++ b/lib/oli_web/live/products/details/image_upload.ex
@@ -1,0 +1,128 @@
+defmodule OliWeb.Products.Details.ImageUpload do
+  use Surface.Component
+
+  alias Surface.Components.{Form, LiveFileInput}
+  alias Surface.Components.Form.{
+    Label,
+    Submit
+  }
+
+  prop product, :any, required: true
+  prop updates, :any, required: true
+  prop changeset, :any, default: nil
+  prop uploads, :map, required: true
+  prop upload_event, :event, required: true
+  prop change, :event, required: true
+  prop cancel_upload, :event, required: true
+
+  @spec render(any) :: Phoenix.LiveView.Rendered.t()
+  def render(assigns) do
+    ~F"""
+    <div class="container">
+
+      <div class="row">
+        <div class="col-12">
+          <Form for={@changeset} submit={@upload_event} change="validate_image" opts={[id: "img-upload-form"]}>
+
+          <section>
+            <div id="drag-and-drop-zone" class="drag-and-drop-zone mb-2 py-4 w-75" phx-drop-target={@uploads.cover_image.ref}>
+
+            <div class="row d-flex justify-content-center">
+                <div class="col-6 d-flex justify-content-center">
+
+                  <div class="form-group input-file-form-group">
+                    <LiveFileInput upload={@uploads.cover_image} class="img-input-file" opts={[disaled: @uploads.cover_image.entries != []]}/>
+                    <label class="btn btn-dark btn-tertiary js-labelFile">
+                      <i class={"#{if @uploads.cover_image.entries != [], do: "fa-check", else: "fa-upload"} icon fa"}></i>
+                      <span class="js-fileName">
+                        {#if @uploads.cover_image.entries != [] and !upload_has_errors?(@uploads.cover_image)}
+                          File choosen
+                        {#else}
+                          Browse
+                        {/if}
+                      </span>
+                    </label>
+                  </div>
+
+                </div>
+              </div>
+              <div class="row">
+                <div class="col-12 d-flex justify-content-center">
+                  <Label class="text-muted" text="or drag and drop here"/>
+                </div>
+              </div>
+            </div>
+          </section>
+
+            <section class="row mb-2" id="img-preview">
+            {#if @uploads.cover_image.entries != []}
+              {#for entry <- @uploads.cover_image.entries}
+                <article class="upload-entry col-12">
+                  {#if !entry_has_errors?(@uploads.cover_image, entry)}
+                  <figure>
+                    { live_img_preview entry, class: "img-fluid w-75"}
+                    <figcaption class="text-muted">{ entry.client_name }</figcaption>
+                  </figure>
+
+                  <div class="row d-flex">
+                    <div class="col-8 align-self-center h-100">
+                      <div class="progress">
+                        <div role="progressbar" class="progress-bar w-100" style={"width:#{entry.progress} !important"} value={entry.progress} max="100" aria-valuemin="0" aria-valuemax="100"> { entry.progress }% </div>
+                      </div>
+                    </div>
+                    <div class="col-4 align-self-center h-100">
+                      <button class="btn btn-secondary btn-sm" phx-click="cancel_upload" phx-value-ref={entry.ref} aria-label="cancel">&times;</button>
+                    </div>
+                  </div>
+
+                  {/if}
+
+                  {#for err <- upload_errors(@uploads.cover_image, entry)}
+                    <div class="alert danger">{ upload_error(err) }</div>
+                  {/for}
+
+                </article>
+              {/for}
+            {#else}
+                <article class="col-12">
+                    <img id="current-product-img" src={@product.cover_image} class="img-fluid w-75" />
+                </article>
+            {/if}
+            </section>
+
+            <Submit class="btn btn-primary mt-3" label="Save" opts={ [disabled: !upload_has_entries?(@uploads.cover_image) or upload_has_errors?(@uploads.cover_image)] }/>
+          </Form>
+        </div>
+      </div>
+
+    </div>
+
+    <script type="text/javascript">
+      $(document).ready(function(){
+        $('#drag-and-drop-zone').bind('dragover', function(){
+          $(this).addClass('on-drag');
+        });
+        $('#drag-and-drop-zone').bind('dragleave', function(){
+          $(this).removeClass('on-drag');
+        });
+      });
+    </script>
+    """
+  end
+
+  defp upload_has_entries?(upload) do
+    upload.entries != []
+  end
+
+  defp upload_has_errors?(upload) do
+    Enum.any?(upload.entries, &entry_has_errors?(upload, &1))
+  end
+
+  defp entry_has_errors?(upload, entry) do
+    upload_errors(upload, entry) != []
+  end
+
+  defp upload_error(:too_large), do: "Image too large, try again with a image lower than 5 MB."
+  defp upload_error(:too_many_files), do: "Too many files, try again with a single file"
+  defp upload_error(:not_accepted), do: "Unacceptable file type, try again with a .jpg .jpeg or .png file"
+end

--- a/lib/oli_web/live/products/details_view.ex
+++ b/lib/oli_web/live/products/details_view.ex
@@ -189,13 +189,18 @@ defmodule OliWeb.Products.DetailsView do
       end)
 
     with {:ok, uploaded_path} <- Enum.at(uploaded_files, 0),
-        {:ok, section} <- Sections.update_section(socket.assigns.product, %{cover_image: uploaded_path})
-        do
-          socket = put_flash(socket, :info, "Product changes saved")
-          {:noreply, assign(socket, product: section, changeset: Section.changeset(section, %{}))}
-        else
-          _ ->
-          Logger.error("Error uploading product image to S3: #{Enum.at(uploaded_files, 0)}")
+      {:ok, section} <- Sections.update_section(socket.assigns.product, %{cover_image: uploaded_path})
+      do
+        socket = put_flash(socket, :info, "Product changes saved")
+        {:noreply, assign(socket, product: section, changeset: Section.changeset(section, %{}))}
+      else
+
+        {:error, %Ecto.Changeset{} = changeset} ->
+          socket = put_flash(socket, :info, "Couldn't update product image")
+          {:noreply, assign(socket, changeset: changeset)}
+
+        {:error, payload} ->
+          Logger.error("Error uploading product image to S3: #{inspect(payload)}")
           socket = put_flash(socket, :info, "Couldn't update product image")
           {:noreply, socket}
     end

--- a/lib/oli_web/live/products/details_view.ex
+++ b/lib/oli_web/live/products/details_view.ex
@@ -12,7 +12,10 @@ defmodule OliWeb.Products.DetailsView do
   alias OliWeb.Router.Helpers, as: Routes
   alias OliWeb.Common.Confirm
   alias OliWeb.Sections.Mount
-  alias OliWeb.Products.Details.{Actions, Edit, Content}
+  alias OliWeb.Products.Details.{Actions, Edit, Content, ImageUpload}
+  alias Oli.Utils.S3Storage
+
+  require Logger
 
   data breadcrumbs, :any, default: [Breadcrumb.new(%{full_title: "Product Overview"})]
   data product, :any, default: nil
@@ -21,10 +24,12 @@ defmodule OliWeb.Products.DetailsView do
   prop is_admin, :boolean
 
   def set_breadcrumbs(section),
-    do: [Breadcrumb.new(%{
-      full_title: section.title,
-      link: Routes.live_path(OliWeb.Endpoint, __MODULE__, section.slug)
-    })]
+    do: [
+      Breadcrumb.new(%{
+        full_title: section.title,
+        link: Routes.live_path(OliWeb.Endpoint, __MODULE__, section.slug)
+      })
+    ]
 
   def mount(
         %{"product_id" => product_slug},
@@ -54,6 +59,12 @@ defmodule OliWeb.Products.DetailsView do
            is_admin: Oli.Accounts.is_admin?(author),
            changeset: Section.changeset(product, %{}),
            title: "Edit Product"
+         )
+         |> Phoenix.LiveView.allow_upload(:cover_image,
+           accept: ~w(.jpg .jpeg .png),
+           max_entries: 1,
+           auto_upload: true,
+           max_file_size: 5_000_000
          )}
     end
   end
@@ -84,6 +95,19 @@ defmodule OliWeb.Products.DetailsView do
           <Content product={@product} changeset={@changeset} save="save" updates={@updates}/>
         </div>
       </div>
+
+      <div class="row py-5 border-bottom">
+        <div class="col-md-4">
+          <h4>Cover Image</h4>
+          <div class="text-muted">
+            Manage the cover image for this product. Max file size is 5 MB.
+          </div>
+        </div>
+        <div class="col-md-8">
+          <ImageUpload product={@product} uploads={@uploads} changeset={@changeset} upload_event="update_image" change="change" cancel_upload="cancel_upload" updates={@updates}/>
+        </div>
+      </div>
+
       <div class="row py-5">
         <div class="col-md-4">
           <h4>Actions</h4>
@@ -144,5 +168,45 @@ defmodule OliWeb.Products.DetailsView do
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply, assign(socket, changeset: changeset)}
     end
+  end
+
+  def handle_event("validate_image", _, socket) do
+    {:noreply, socket}
+  end
+
+  def handle_event("update_image", _, socket) do
+    bucket_name = Application.fetch_env!(:oli, :s3_media_bucket_name)
+
+    uploaded_files =
+      consume_uploaded_entries(socket, :cover_image, fn meta, entry ->
+
+        temp_file_path = meta.path
+        section_path = "sections/#{socket.assigns.product.slug}"
+        image_file_name = "#{entry.uuid}.#{ext(entry)}"
+        upload_path = "#{section_path}/#{image_file_name}"
+
+        S3Storage.upload_file(bucket_name, upload_path, temp_file_path)
+      end)
+
+    with {:ok, uploaded_path} <- Enum.at(uploaded_files, 0),
+        {:ok, section} <- Sections.update_section(socket.assigns.product, %{cover_image: uploaded_path})
+        do
+          socket = put_flash(socket, :info, "Product changes saved")
+          {:noreply, assign(socket, product: section, changeset: Section.changeset(section, %{}))}
+        else
+          _ ->
+          Logger.error("Error uploading product image to S3: #{Enum.at(uploaded_files, 0)}")
+          socket = put_flash(socket, :info, "Couldn't update product image")
+          {:noreply, socket}
+    end
+  end
+
+  def handle_event("cancel_upload", %{"ref" => ref}, socket) do
+    {:noreply, cancel_upload(socket, :cover_image, ref)}
+  end
+
+  defp ext(entry) do
+    [ext | _] = MIME.extensions(entry.client_type)
+    ext
   end
 end

--- a/lib/oli_web/templates/delivery/enroll.html.eex
+++ b/lib/oli_web/templates/delivery/enroll.html.eex
@@ -4,7 +4,7 @@
   <%= render OliWeb.SharedView, "_box_form_container.html", Map.merge(assigns, %{title: "Enroll in Course Section", bs_col_class: "col-sm-10 col-md-8 col-lg-6 col-xl-5 mx-auto"}) do %>
 
     <div class="course-card-link card h-100 mb-4">
-      <img src="<%= Routes.static_path(@conn, "/images/course_default.jpg") %>" class="card-img-top" alt="course image">
+      <img src="<%= cover_image(@section) %>" class="card-img-top" alt="course image">
       <div class="card-body">
         <h5 class="card-title"><%= @section.title %></h5>
         <p class="card-text"><%= @section.description %></p>

--- a/lib/oli_web/templates/delivery/open_and_free_index.html.eex
+++ b/lib/oli_web/templates/delivery/open_and_free_index.html.eex
@@ -17,7 +17,7 @@
         <%= for section <- @sections do %>
           <div class="col my-1">
             <a href="<%= Routes.page_delivery_path(@conn, :index, section.slug) %>" class="course-card-link card h-100">
-              <img src="<%= Routes.static_path(@conn, "/images/course_default.jpg") %>" class="card-img-top" alt="course image">
+              <img src="<%= cover_image(section) %>" class="card-img-top" alt="course image">
               <div class="card-body">
                 <h5 class="card-title"><%= section.title %></h5>
                 <p class="card-text"><%= section.description %></p>

--- a/lib/oli_web/views/api/product_view.ex
+++ b/lib/oli_web/views/api/product_view.ex
@@ -25,7 +25,8 @@ defmodule OliWeb.Api.ProductView do
       has_grace_period: product.has_grace_period,
       grace_period_days: product.grace_period_days,
       grace_period_strategy: product.grace_period_strategy,
-      publisher_id: product.publisher_id
+      publisher_id: product.publisher_id,
+      cover_image: product.cover_image
     }
   end
 

--- a/lib/oli_web/views/delivery_view.ex
+++ b/lib/oli_web/views/delivery_view.ex
@@ -9,7 +9,6 @@ defmodule OliWeb.DeliveryView do
   alias Oli.Accounts.User
   alias Lti_1p3.Tool.ContextRoles
   alias Lti_1p3.Tool.PlatformRoles
-  alias OliWeb.Router.Helpers, as: Routes
 
   def source_id(source) do
     case Map.get(source, :type, nil) do

--- a/lib/oli_web/views/delivery_view.ex
+++ b/lib/oli_web/views/delivery_view.ex
@@ -2,11 +2,14 @@ defmodule OliWeb.DeliveryView do
   use OliWeb, :view
   use Phoenix.Component
 
+  import OliWeb.Common.SourceImage
+
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.Section
   alias Oli.Accounts.User
   alias Lti_1p3.Tool.ContextRoles
   alias Lti_1p3.Tool.PlatformRoles
+  alias OliWeb.Router.Helpers, as: Routes
 
   def source_id(source) do
     case Map.get(source, :type, nil) do

--- a/priv/repo/migrations/20220524233403_update_sections_add_cover_image.exs
+++ b/priv/repo/migrations/20220524233403_update_sections_add_cover_image.exs
@@ -3,7 +3,7 @@ defmodule Oli.Repo.Migrations.UpdateSectionsAddCoverImage do
 
   def change do
     alter table(:sections) do
-      add :cover_image, :string, null: true
+      add :cover_image, :string, null: true, default: nil
     end
   end
 end

--- a/priv/repo/migrations/20220524233403_update_sections_add_cover_image.exs
+++ b/priv/repo/migrations/20220524233403_update_sections_add_cover_image.exs
@@ -1,0 +1,9 @@
+defmodule Oli.Repo.Migrations.UpdateSectionsAddCoverImage do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sections) do
+      add :cover_image, :string, null: true
+    end
+  end
+end

--- a/test/oli_web/controllers/api/product_controller_test.exs
+++ b/test/oli_web/controllers/api/product_controller_test.exs
@@ -39,7 +39,8 @@ defmodule OliWeb.ProductControllerTest do
                  "slug" => prod1.slug,
                  "status" => Atom.to_string(prod1.status),
                  "title" => prod1.title,
-                 "publisher_id" => publisher_id
+                 "publisher_id" => publisher_id,
+                 "cover_image" => "https://someurl.com/some-image.png"
                }
              end)
 
@@ -56,7 +57,8 @@ defmodule OliWeb.ProductControllerTest do
                  "slug" => prod2.slug,
                  "status" => Atom.to_string(prod2.status),
                  "title" => prod2.title,
-                 "publisher_id" => publisher_id
+                 "publisher_id" => publisher_id,
+                 "cover_image" => nil
                }
              end)
     end
@@ -98,7 +100,8 @@ defmodule OliWeb.ProductControllerTest do
           title: "My 1st product",
           amount: Money.new(:USD, 100),
           requires_payment: true,
-          grace_period_days: 14
+          grace_period_days: 14,
+          cover_image: "https://someurl.com/some-image.png"
         },
         :prod1
       )

--- a/test/oli_web/controllers/delivery_controller_test.exs
+++ b/test/oli_web/controllers/delivery_controller_test.exs
@@ -252,6 +252,24 @@ defmodule OliWeb.DeliveryControllerTest do
 
       assert html_response(conn, 403) =~ "Section Has Not Started"
     end
+
+    test "renders product image in sections index", %{
+      conn: conn,
+      oaf_section_1: section
+    } do
+      user = user_fixture()
+      enroll_user_to_section(user, section, :context_learner)
+
+      cover_image = "https://example.com/some-image-url.png"
+      Sections.update_section(section, %{cover_image: cover_image})
+
+      conn =
+        Plug.Test.init_test_session(conn, lti_session: nil)
+        |> Pow.Plug.assign_current_user(user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
+      conn = get(conn, Routes.delivery_path(conn, :open_and_free_index))
+
+      assert html_response(conn, 200) =~ "<img src=\"#{cover_image}\" class=\"card-img-top\" alt=\"course image\""
+    end
   end
 
   @moduletag :capture_log

--- a/test/oli_web/controllers/delivery_controller_test.exs
+++ b/test/oli_web/controllers/delivery_controller_test.exs
@@ -270,6 +270,42 @@ defmodule OliWeb.DeliveryControllerTest do
 
       assert html_response(conn, 200) =~ "<img src=\"#{cover_image}\" class=\"card-img-top\" alt=\"course image\""
     end
+
+    test "renders product's cover image in enrollment page", %{
+      conn: conn,
+      oaf_section_1: section
+    } do
+      user = insert(:user)
+
+      cover_image = "https://example.com/some-image-url.png"
+
+      Sections.update_section(section, %{cover_image: cover_image})
+
+      conn =
+        Plug.Test.init_test_session(conn, lti_session: nil)
+        |> Pow.Plug.assign_current_user(user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
+
+      conn = get(conn, Routes.delivery_path(conn, :show_enroll, section.slug))
+
+      assert html_response(conn, 200) =~ "<img src=\"#{cover_image}\" class=\"card-img-top\" alt=\"course image\""
+    end
+
+    test "if no cover image is set, renders default image in enrollment page", %{
+      conn: conn,
+      oaf_section_1: section
+    } do
+      user = user_fixture()
+
+      cover_image = Routes.static_path(OliWeb.Endpoint, "/images/course_default.jpg")
+
+      conn =
+        Plug.Test.init_test_session(conn, lti_session: nil)
+        |> Pow.Plug.assign_current_user(user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
+
+      conn = get(conn, Routes.delivery_path(conn, :show_enroll, section.slug))
+
+      assert html_response(conn, 200) =~ "<img src=\"#{cover_image}\" class=\"card-img-top\" alt=\"course image\""
+    end
   end
 
   @moduletag :capture_log

--- a/test/oli_web/controllers/page_delivery_controller_test.exs
+++ b/test/oli_web/controllers/page_delivery_controller_test.exs
@@ -678,42 +678,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert html_response(conn, 302) =~
         "You are being <a href=\"#{Routes.payment_path(conn, :guard, section.slug)}\">redirected"
     end
-
-    test "renders product's cover image in enrollment page", %{
-      conn: conn,
-      section: section
-    } do
-      user = user_fixture()
-
-      cover_image = "https://example.com/some-image-url.png"
-
-      Sections.update_section(section, %{cover_image: cover_image})
-
-      conn =
-        Plug.Test.init_test_session(conn, lti_session: nil)
-        |> Pow.Plug.assign_current_user(user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
-
-      conn = get(conn, Routes.delivery_path(conn, :show_enroll, section.slug))
-
-      assert html_response(conn, 200) =~ "<img src=\"#{cover_image}\" class=\"card-img-top\" alt=\"course image\""
-    end
-
-    test "if no cover image is set, renders default image in enrollment page", %{
-      conn: conn,
-      section: section
-    } do
-      user = user_fixture()
-
-      cover_image = Routes.static_path(OliWeb.Endpoint, "/images/course_default.jpg")
-
-      conn =
-        Plug.Test.init_test_session(conn, lti_session: nil)
-        |> Pow.Plug.assign_current_user(user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
-
-      conn = get(conn, Routes.delivery_path(conn, :show_enroll, section.slug))
-
-      assert html_response(conn, 200) =~ "<img src=\"#{cover_image}\" class=\"card-img-top\" alt=\"course image\""
-    end
   end
 
   describe "displaying unit numbers" do

--- a/test/oli_web/controllers/page_delivery_controller_test.exs
+++ b/test/oli_web/controllers/page_delivery_controller_test.exs
@@ -678,6 +678,42 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert html_response(conn, 302) =~
         "You are being <a href=\"#{Routes.payment_path(conn, :guard, section.slug)}\">redirected"
     end
+
+    test "renders product's cover image in enrollment page", %{
+      conn: conn,
+      section: section
+    } do
+      user = user_fixture()
+
+      cover_image = "https://example.com/some-image-url.png"
+
+      Sections.update_section(section, %{cover_image: cover_image})
+
+      conn =
+        Plug.Test.init_test_session(conn, lti_session: nil)
+        |> Pow.Plug.assign_current_user(user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
+
+      conn = get(conn, Routes.delivery_path(conn, :show_enroll, section.slug))
+
+      assert html_response(conn, 200) =~ "<img src=\"#{cover_image}\" class=\"card-img-top\" alt=\"course image\""
+    end
+
+    test "if no cover image is set, renders default image in enrollment page", %{
+      conn: conn,
+      section: section
+    } do
+      user = user_fixture()
+
+      cover_image = Routes.static_path(OliWeb.Endpoint, "/images/course_default.jpg")
+
+      conn =
+        Plug.Test.init_test_session(conn, lti_session: nil)
+        |> Pow.Plug.assign_current_user(user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
+
+      conn = get(conn, Routes.delivery_path(conn, :show_enroll, section.slug))
+
+      assert html_response(conn, 200) =~ "<img src=\"#{cover_image}\" class=\"card-img-top\" alt=\"course image\""
+    end
   end
 
   describe "displaying unit numbers" do

--- a/test/oli_web/live/products_test.exs
+++ b/test/oli_web/live/products_test.exs
@@ -4,8 +4,10 @@ defmodule OliWeb.ProductsLiveTest do
 
   import Phoenix.LiveViewTest
   import Oli.Factory
+  import Mox
 
   alias Oli.Delivery.Sections
+  alias OliWeb.Router.Helpers, as: Routes
 
   defp live_view_details_route(product_slug) do
     Routes.live_path(OliWeb.Endpoint, OliWeb.Products.DetailsView, product_slug)
@@ -13,7 +15,6 @@ defmodule OliWeb.ProductsLiveTest do
 
   defp create_product(_conn) do
     product = insert(:section, type: :blueprint, requires_payment: true, amount: Money.new(:USD, 10))
-
     [product: product]
   end
 
@@ -91,6 +92,94 @@ defmodule OliWeb.ProductsLiveTest do
       assert has_element?(view, "input[value=\"#{product.title}\"]")
       assert has_element?(view, "input[name=\"section[pay_by_institution]\"]")
       assert has_element?(view, "a[href=\"#{Routes.discount_path(OliWeb.Endpoint, :product, product.slug)}\"]")
+    end
+  end
+
+  describe "product overview image upload" do
+    setup [:admin_conn, :create_product]
+
+    test "displays the current image", %{conn: conn, product: product} do
+      Sections.update_section(product, %{cover_image: "https://example.com/some-image-url.png"})
+      {:ok, view, _html} = live(conn, live_view_details_route(product.slug))
+
+      assert view
+      |> element("#img-preview img")
+      |> render() =~ "src=\"https://example.com/some-image-url.png\""
+
+    end
+
+    test "submit button is not rendered if no file has been uploaded", %{conn: conn, product: product} do
+      {:ok, view, _html} = live(conn, live_view_details_route(product.slug))
+
+      assert view
+      |> element("#img-upload-form button[type=\"submit\"]")
+      |> render() =~ "disabled"
+
+    end
+
+    test "file is uploaded", %{conn: conn, product: product} do
+      Oli.Test.MockAws
+      |> expect(:request, 1, fn %ExAws.Operation.S3{} ->
+        {:ok, %{status_code: 200}}
+      end)
+
+      {:ok, view, _html} = live(conn, live_view_details_route(product.slug))
+
+      path = "assets/static/images/course_default.jpg"
+
+      image = file_input(view, "#img-upload-form", :cover_image, [
+        %{
+          last_modified: 1_594_171_879_000,
+          name: "myfile.jpeg",
+          content: File.read!(path),
+          type: "image/jpeg"
+        }
+      ])
+
+      assert render_upload(image, "myfile.jpeg") =~ "100%"
+
+      # submit button is enabled if a file has been uploaded
+      refute view
+      |> element("#img-upload-form button[type=\"submit\"]")
+      |> render() =~ "disabled"
+
+      # submitting displays new image
+      assert view
+      |> element("#img-upload-form")
+      |> render_submit(%{})
+
+      assert view
+      |> render() =~ "<img id=\"current-product-img\""
+    end
+
+    test "canceling an upload restores previous rendered image", %{conn: conn, product: product} do
+      current_image = "https://example.com/some-image-url.png"
+      Sections.update_section(product, %{cover_image: current_image})
+
+      {:ok, view, _html} = live(conn, live_view_details_route(product.slug))
+
+      path = "assets/static/images/course_default.jpg"
+
+      image = file_input(view, "#img-upload-form", :cover_image, [
+        %{
+          last_modified: 1_594_171_879_000,
+          name: "myfile.jpeg",
+          content: File.read!(path),
+          type: "image/jpeg"
+        }
+      ])
+
+      assert render_upload(image, "myfile.jpeg") =~ "100%"
+
+      assert view
+      |> has_element?("#img-upload-form div[role=\"progressbar\"")
+
+      view
+      |> element("button[phx-click=\"cancel_upload\"]")
+      |> render_click()
+
+      assert view
+      |> render() =~ "<img id=\"current-product-img\" src=\"#{current_image}\""
     end
   end
 end

--- a/test/oli_web/live/products_test.exs
+++ b/test/oli_web/live/products_test.exs
@@ -98,17 +98,17 @@ defmodule OliWeb.ProductsLiveTest do
   describe "product overview image upload" do
     setup [:admin_conn, :create_product]
 
-    test "displays the current image", %{conn: conn, product: product} do
-      Sections.update_section(product, %{cover_image: "https://example.com/some-image-url.png"})
+    test "displays the current image", %{conn: conn} do
+      product = insert(:section, type: :blueprint, cover_image: "https://example.com/some-image-url.png")
+
       {:ok, view, _html} = live(conn, live_view_details_route(product.slug))
 
       assert view
       |> element("#img-preview img")
       |> render() =~ "src=\"https://example.com/some-image-url.png\""
-
     end
 
-    test "submit button is not rendered if no file has been uploaded", %{conn: conn, product: product} do
+    test "submit button is disabled if no file has been uploaded", %{conn: conn, product: product} do
       {:ok, view, _html} = live(conn, live_view_details_route(product.slug))
 
       assert view
@@ -152,9 +152,9 @@ defmodule OliWeb.ProductsLiveTest do
       |> render() =~ "<img id=\"current-product-img\""
     end
 
-    test "canceling an upload restores previous rendered image", %{conn: conn, product: product} do
+    test "canceling an upload restores previous rendered image", %{conn: conn} do
       current_image = "https://example.com/some-image-url.png"
-      Sections.update_section(product, %{cover_image: current_image})
+      product = insert(:section, type: :blueprint, cover_image: current_image)
 
       {:ok, view, _html} = live(conn, live_view_details_route(product.slug))
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -171,7 +171,8 @@ defmodule Oli.Factory do
       description: "A description",
       brand: insert(:brand),
       publisher: insert(:publisher),
-      lti_1p3_deployment: deployment
+      lti_1p3_deployment: deployment,
+      has_grace_period: false
     }
   end
 


### PR DESCRIPTION
[MER-462](https://eliterate.atlassian.net/browse/MER-462)

### What does it change?

- Adds an image section in the product overview page, for uploading/updating the product image. At
 this moment, this is only available at the product level. New sections inherit the image from the parting product.
- When a user-uploaded image is provided, it replaces the default `/images/course_default.jpg` image.

### Screenshots

#### New product overview section

Default - for all products that have no current image

![image](https://user-images.githubusercontent.com/22042418/171704922-3fa58554-13ea-4860-951e-fae2b60bff26.png)

Once an image is uploaded

![image](https://user-images.githubusercontent.com/22042418/171707215-941ce648-7cb1-4f41-846d-8ec46b678a40.png)

#### Upload example - success

![ezgif-5-a21614fd52](https://user-images.githubusercontent.com/22042418/171689683-3325698b-76cd-4190-ae89-f8eae9d7db7d.gif)

#### Upload example - error handling

![ezgif-5-a21614fd523](https://user-images.githubusercontent.com/22042418/171690158-542d5a3f-31d1-4d21-8eab-d6a63141cf4a.gif)


#### /sections as independent learner 

![image](https://user-images.githubusercontent.com/22042418/171688916-e6f29863-16ba-4e4e-b5a3-13a00f8adbd6.png)


#### Enroll page

![image](https://user-images.githubusercontent.com/22042418/171689163-3ecf4e38-8ec7-43a3-8c33-95073162ad87.png)
