### PR TITLE
[FEATURE] File Upload activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Enhancements
 
 - Add survey authoring support (behind feature flag)
+- Add File Upload activity
 
 ## 0.19.3 (2022-05-17)
 

--- a/assets/src/apps/authoring/store/groups/layouts/deck/actions/validate.ts
+++ b/assets/src/apps/authoring/store/groups/layouts/deck/actions/validate.ts
@@ -80,6 +80,11 @@ const mapErrorProblems = (list: any[], type: string, seq: any[], blackList: any[
   });
 
 const validateTarget = (target: string, activity: any, parts: any[]) => {
+  const isExpression = target.match(/{([^{^}]+)}/g);
+  if (isExpression) {
+    return false;
+  }
+
   const targetNameIdx = target.search(/app|variables|stage|session/);
   const split = target.slice(targetNameIdx).split('.');
   const type = split[0] as string;

--- a/assets/src/components/activities/file_upload/FileSpecConfiguration.tsx
+++ b/assets/src/components/activities/file_upload/FileSpecConfiguration.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+
+import { FileSpec as FileSpecType } from './schema';
+import { TextInput } from 'components/common/TextInput';
+
+export type FileSpecConfigurationProps = {
+  editMode: boolean;
+  fileSpec: FileSpecType;
+  onEdit: (fileSpec: FileSpecType) => void;
+};
+
+const commonAccepts = [
+  { label: 'Audio', value: 'audio/*' },
+  { label: 'Video', value: 'video/*' },
+  { label: 'Image', value: 'image/*' },
+  { label: 'PDF', value: '.pdf' },
+  { label: 'PDF or image', value: 'image/*,.pdf' },
+  { label: 'Microsoft Word', value: '.doc,.docx,application/msword' },
+  { label: 'Microsoft Excel', value: '.xls,.xlsx,application/msexcel' },
+  { label: 'Microsoft PowerPoint', value: '.ppt,.pptx,application/mspowerpoint' },
+  {
+    label: 'ZIP file',
+    value:
+      'zip,application/octet-stream,application/zip,application/x-zip,application/x-zip-compressed',
+  },
+];
+
+export const FileSpecConfiguration = (props: FileSpecConfigurationProps) => {
+  return (
+    <div>
+      <label>Maximum number of files student can upload</label>
+      <TextInput
+        editMode={props.editMode}
+        label=""
+        width="100px"
+        value={props.fileSpec.maxCount + ''}
+        type="number"
+        onEdit={(maxCount) => {
+          props.onEdit(Object.assign({}, props.fileSpec, { maxCount }));
+        }}
+      />
+      <label className="mt-4">Enter allowable file extension types (comma separated)</label>
+      <TextInput
+        editMode={props.editMode}
+        label=""
+        value={props.fileSpec.accept}
+        type="text"
+        onEdit={(accept) => {
+          props.onEdit(Object.assign({}, props.fileSpec, { accept }));
+        }}
+      />
+
+      <div className="btn-group btn-group-sm mt-3" role="group">
+        {commonAccepts.map((ca) => {
+          return (
+            <button
+              key={ca.value}
+              type="button"
+              className="btn btn-outline-secondary"
+              onClick={() => props.onEdit(Object.assign({}, props.fileSpec, { accept: ca.value }))}
+            >
+              {ca.label}
+            </button>
+          );
+        })}
+      </div>
+      <small className="mt-3 text-muted">Common file extension choices</small>
+    </div>
+  );
+};

--- a/assets/src/components/activities/file_upload/FileUploadAuthoring.tsx
+++ b/assets/src/components/activities/file_upload/FileUploadAuthoring.tsx
@@ -1,0 +1,61 @@
+import { Hints } from 'components/activities/common/hints/authoring/HintsAuthoringConnected';
+import { Stem } from 'components/activities/common/stem/authoring/StemAuthoringConnected';
+import { DEFAULT_PART_ID } from 'components/activities/common/utils';
+import { Manifest } from 'components/activities/types';
+import { TabbedNavigation } from 'components/tabbed_navigation/Tabs';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Provider } from 'react-redux';
+import { configureStore } from 'state/store';
+import { AuthoringElement, AuthoringElementProps } from '../AuthoringElement';
+import { AuthoringElementProvider, useAuthoringElementContext } from '../AuthoringElementProvider';
+import { FileSpecConfiguration } from './FileSpecConfiguration';
+import { FileUploadActions } from './actions';
+import { FileUploadSchema, FileSpec } from './schema';
+
+const store = configureStore();
+
+const FileUpload = () => {
+  const { dispatch, model, editMode } = useAuthoringElementContext<FileUploadSchema>();
+
+  const onEditFileSpec = (fileSpec: FileSpec) => dispatch(FileUploadActions.editFileSpec(fileSpec));
+
+  return (
+    <>
+      <TabbedNavigation.Tabs>
+        <TabbedNavigation.Tab label="Question">
+          <div className="d-flex flex-column flex-md-row mb-2">
+            <Stem />
+          </div>
+        </TabbedNavigation.Tab>
+        <TabbedNavigation.Tab label="Allowed Files">
+          <FileSpecConfiguration
+            editMode={editMode}
+            fileSpec={model.fileSpec}
+            onEdit={onEditFileSpec}
+          />
+        </TabbedNavigation.Tab>
+
+        <TabbedNavigation.Tab label="Hints">
+          <Hints partId={DEFAULT_PART_ID} />
+        </TabbedNavigation.Tab>
+      </TabbedNavigation.Tabs>
+    </>
+  );
+};
+
+export class FileUploadAuthoring extends AuthoringElement<FileUploadSchema> {
+  render(mountPoint: HTMLDivElement, props: AuthoringElementProps<FileUploadSchema>) {
+    ReactDOM.render(
+      <Provider store={store}>
+        <AuthoringElementProvider {...props}>
+          <FileUpload />
+        </AuthoringElementProvider>
+      </Provider>,
+      mountPoint,
+    );
+  }
+}
+// eslint-disable-next-line
+const manifest = require('./manifest.json') as Manifest;
+window.customElements.define(manifest.authoring.element, FileUploadAuthoring);

--- a/assets/src/components/activities/file_upload/FileUploadDelivery.tsx
+++ b/assets/src/components/activities/file_upload/FileUploadDelivery.tsx
@@ -1,0 +1,261 @@
+import React, { useEffect } from 'react';
+import ReactDOM from 'react-dom';
+import { StemDeliveryConnected } from 'components/activities/common/stem/delivery/StemDelivery';
+import { GradedPointsConnected } from 'components/activities/common/delivery/graded_points/GradedPointsConnected';
+import { ResetButtonConnected } from 'components/activities/common/delivery/reset_button/ResetButtonConnected';
+import { HintsDeliveryConnected } from 'components/activities/common/hints/delivery/HintsDeliveryConnected';
+import { EvaluationConnected } from 'components/activities/common/delivery/evaluation/EvaluationConnected';
+import { Provider, useDispatch, useSelector } from 'react-redux';
+import {
+  ActivityDeliveryState,
+  isEvaluated,
+  isSubmitted,
+  activityDeliverySlice,
+  initializeState,
+  resetAction,
+  savePart,
+  submitFiles,
+} from 'data/activities/DeliveryState';
+import { SubmitButton } from 'components/activities/common/delivery/submit_button/SubmitButton';
+import { safelySelectFiles } from 'data/activities/utils';
+import { ActivityState, StudentResponse } from 'components/activities/types';
+import { configureStore } from 'state/store';
+import { DeliveryElement, DeliveryElementProps } from 'components/activities/DeliveryElement';
+import { DeliveryElementProvider, useDeliveryElementContext } from '../DeliveryElementProvider';
+import { Manifest } from 'components/activities/types';
+import { FileSpec, FileUploadSchema } from 'components/activities/file_upload/schema';
+import { DEFAULT_PART_ID } from 'components/activities/common/utils';
+import { getReadableFileSizeString, fileName } from './utils';
+import { RemoveButton } from '../common/authoring/removeButton/RemoveButton';
+import { uploadActivityFile } from 'data/persistence/state/intrinsic';
+
+function onUploadClick(id: string) {
+  (window as any).$('#' + id).trigger('click');
+}
+
+const getFiles = (state: ActivityDeliveryState) => {
+  return state.partState[DEFAULT_PART_ID].studentInput === undefined
+    ? []
+    : (state.partState[DEFAULT_PART_ID].studentInput as any as FileMetaData[]);
+};
+
+type FileMetaData = {
+  url: string;
+  creationTime: number;
+  fileSize: number;
+};
+
+const Preview: React.FC<{ file: FileMetaData; fileSpec: FileSpec }> = ({ file }) => {
+  let preview = null;
+
+  const ext = file.url.substring(file.url.lastIndexOf('.') + 1).toLowerCase();
+
+  if (ext === 'jpg' || ext === 'png' || ext === 'gif' || ext === 'jpeg') {
+    preview = (
+      <img
+        src={file.url}
+        height="150"
+        width="200"
+        onClick={(e) => (e.target as any).requestFullscreen()}
+      />
+    );
+  } else if (ext === 'mp3' || ext === 'wav') {
+    preview = <audio src={file.url} />;
+  } else if (ext === 'mp4') {
+    preview = (
+      <video
+        src={file.url}
+        height="150"
+        width="200"
+        onClick={(e) => (e.target as any).requestFullscreen()}
+      />
+    );
+  }
+
+  return preview;
+};
+const SubmittedFile: React.FC<{
+  editMode: boolean;
+  file: FileMetaData;
+  onRemove: () => void;
+  fileSpec: FileSpec;
+}> = ({ file, editMode, onRemove, fileSpec }) => {
+  return (
+    <a className="list-group-item list-group-item-action">
+      <div className="d-flex w-100 justify-content-between">
+        <h5 className="mb-1">
+          <a href={file.url}>{fileName(file.url)}</a>
+        </h5>
+        <small>
+          <RemoveButton
+            editMode={editMode}
+            onClick={() => {
+              onRemove();
+            }}
+          />
+        </small>
+      </div>
+      <div className="d-flex w-100 justify-content-between">
+        <small>{getReadableFileSizeString(file.fileSize)}</small>
+        <Preview file={file} fileSpec={fileSpec} />
+      </div>
+    </a>
+  );
+};
+
+const FileSubmission: React.FC<{
+  sectionSlug: string;
+  model: FileUploadSchema;
+  state: ActivityState;
+  onSavePart: (attemptGuid: string, partAttemptGuid: string, response: StudentResponse) => void;
+}> = ({ sectionSlug, model, state, onSavePart }) => {
+  const uiState = useSelector((state: ActivityDeliveryState) => state);
+
+  const upload = (files: FileList) => {
+    uploadActivityFile(sectionSlug, state.attemptGuid, state.parts[0].attemptGuid, files[0]).then(
+      (result) => {
+        if (result.result === 'success') {
+          const newFiles = [
+            ...getFiles(uiState),
+            { url: result.url, creationDate: result.creationDate, fileSize: result.fileSize },
+          ];
+          onSavePart(state.attemptGuid, state.parts[0].attemptGuid, { files: newFiles, input: '' });
+        }
+      },
+    );
+  };
+
+  const files = getFiles(uiState).map((file: FileMetaData) => {
+    const onRemove = () => {
+      const newFiles = getFiles(uiState).filter((f: FileMetaData) => f.url !== file.url);
+      onSavePart(state.attemptGuid, state.parts[0].attemptGuid, { files: newFiles, input: '' });
+    };
+    return (
+      <SubmittedFile
+        key={file.url}
+        editMode={!isSubmitted(uiState) && !isEvaluated(uiState)}
+        file={file}
+        onRemove={onRemove}
+        fileSpec={model.fileSpec}
+      />
+    );
+  });
+
+  const allSubmitted =
+    files.length > 0 ? (
+      <div>
+        <div className="list-group">{files}</div>
+      </div>
+    ) : null;
+
+  const uploadAnother =
+    files.length >= model.fileSpec.maxCount ||
+    isSubmitted(uiState) ||
+    isEvaluated(uiState) ? null : (
+      <div>
+        <input
+          id={`upload-${uiState.attemptState.attemptGuid}`}
+          style={{ display: 'none' }}
+          accept={model.fileSpec.accept}
+          onChange={({ target: { files } }) => upload(files as FileList)}
+          type="file"
+        />
+        <div className="d-flex w-100 justify-content-between mt-3">
+          <p>
+            You can upload at most {model.fileSpec.maxCount - files.length} more file
+            {model.fileSpec.maxCount - files.length === 1 ? '' : 's'}
+          </p>
+          <button
+            className="btn btn-primary media-toolbar-item upload"
+            onClick={() => onUploadClick(`upload-${uiState.attemptState.attemptGuid}`)}
+          >
+            <i className="fa fa-upload" /> Upload
+          </button>
+        </div>
+      </div>
+    );
+
+  return (
+    <div>
+      <h4>Your Submission</h4>
+      {allSubmitted}
+      {uploadAnother}
+    </div>
+  );
+};
+
+export const FileUploadComponent: React.FC = () => {
+  const { model, state, onResetActivity, onSubmitActivity, onSavePart, sectionSlug, graded } =
+    useDeliveryElementContext<FileUploadSchema>();
+
+  const uiState = useSelector((state: ActivityDeliveryState) => state);
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(
+      initializeState(
+        state,
+        // Short answers only have one input, but the selection is modeled
+        // as an array just to make it consistent with the other activity types
+        safelySelectFiles(state).caseOf({
+          just: (input) => input,
+          nothing: () => ({
+            [DEFAULT_PART_ID]: [],
+          }),
+        }),
+      ),
+    );
+  }, []);
+
+  // First render initializes state
+  if (!uiState.partState) {
+    return null;
+  }
+
+  return (
+    <div className="activity cata-activity">
+      <div className="activity-content">
+        <StemDeliveryConnected />
+        <GradedPointsConnected />
+
+        <FileSubmission
+          sectionSlug={sectionSlug as any}
+          model={model}
+          state={state}
+          onSavePart={(a, p, s) => dispatch(savePart(DEFAULT_PART_ID, s, onSavePart))}
+        />
+
+        <ResetButtonConnected
+          onReset={() => dispatch(resetAction(onResetActivity, { [DEFAULT_PART_ID]: [] }))}
+        />
+        <SubmitButton
+          shouldShow={!isEvaluated(uiState) && !isSubmitted(uiState) && !graded}
+          disabled={getFiles(uiState).length === 0}
+          onClick={() => dispatch(submitFiles(onSubmitActivity, getFiles(uiState)))}
+        />
+        <HintsDeliveryConnected partId={DEFAULT_PART_ID} />
+        <EvaluationConnected />
+      </div>
+    </div>
+  );
+};
+
+// Defines the web component, a simple wrapper over our React component above
+export class FileUploadDelivery extends DeliveryElement<FileUploadSchema> {
+  render(mountPoint: HTMLDivElement, props: DeliveryElementProps<FileUploadSchema>) {
+    const store = configureStore({}, activityDeliverySlice.reducer);
+    ReactDOM.render(
+      <Provider store={store}>
+        <DeliveryElementProvider {...props}>
+          <FileUploadComponent />
+        </DeliveryElementProvider>
+      </Provider>,
+      mountPoint,
+    );
+  }
+}
+
+// Register the web component:
+// eslint-disable-next-line
+const manifest = require('./manifest.json') as Manifest;
+window.customElements.define(manifest.delivery.element, FileUploadDelivery);

--- a/assets/src/components/activities/file_upload/actions.ts
+++ b/assets/src/components/activities/file_upload/actions.ts
@@ -1,0 +1,9 @@
+import { FileUploadSchema, FileSpec } from './schema';
+
+export const FileUploadActions = {
+  editFileSpec(fileSpec: FileSpec) {
+    return (model: FileUploadSchema) => {
+      model.fileSpec = fileSpec;
+    };
+  },
+};

--- a/assets/src/components/activities/file_upload/authoring-entry.ts
+++ b/assets/src/components/activities/file_upload/authoring-entry.ts
@@ -1,0 +1,16 @@
+export { FileUploadDelivery } from './FileUploadDelivery';
+export { FileUploadAuthoring } from './FileUploadAuthoring';
+
+// Registers the creation function:
+import { Manifest, CreationContext } from '../types';
+import { registerCreationFunc } from '../creation';
+import { FileUploadSchema } from './schema';
+import { defaultModel } from './utils';
+// eslint-disable-next-line
+const manifest: Manifest = require('./manifest.json');
+
+function createFn(_context: CreationContext): Promise<FileUploadSchema> {
+  return Promise.resolve(Object.assign({}, defaultModel()));
+}
+
+registerCreationFunc(manifest, createFn);

--- a/assets/src/components/activities/file_upload/delivery-entry.ts
+++ b/assets/src/components/activities/file_upload/delivery-entry.ts
@@ -1,0 +1,1 @@
+export { FileUploadDelivery } from './FileUploadDelivery';

--- a/assets/src/components/activities/file_upload/manifest.json
+++ b/assets/src/components/activities/file_upload/manifest.json
@@ -1,0 +1,18 @@
+{
+  "id": "oli_file_upload",
+  "friendlyName": "File Upload",
+  "description": "A question that expects student submission via uploaded files",
+  "icon": "question_answer",
+  "delivery": {
+    "element": "oli-file-upload-delivery",
+    "entry": "./delivery-entry.ts"
+  },
+  "authoring": {
+    "element": "oli-file-upload-authoring",
+    "entry": "./authoring-entry.ts"
+  },
+  "schemaPruning": {
+    "type": "keys",
+    "keys": ["feedback"]
+  }
+}

--- a/assets/src/components/activities/file_upload/schema.ts
+++ b/assets/src/components/activities/file_upload/schema.ts
@@ -1,0 +1,16 @@
+import { Part, Transformation, ActivityModelSchema, Stem } from '../types';
+
+export interface FileSpec {
+  accept: string;
+  maxCount: number;
+}
+
+export interface FileUploadSchema extends ActivityModelSchema {
+  stem: Stem;
+  fileSpec: FileSpec;
+  authoring: {
+    parts: Part[];
+    transformations: Transformation[];
+    previewText: string;
+  };
+}

--- a/assets/src/components/activities/file_upload/utils.ts
+++ b/assets/src/components/activities/file_upload/utils.ts
@@ -1,0 +1,50 @@
+import { DEFAULT_PART_ID } from 'components/activities/common/utils';
+import { FileUploadSchema, FileSpec } from 'components/activities/file_upload/schema';
+import { Responses } from 'data/activities/model/responses';
+import { GradingApproach, makeHint, makeStem, ScoringStrategy } from '../types';
+
+export const defaultModel: () => FileUploadSchema = () => {
+  return {
+    stem: makeStem(''),
+    fileSpec: createDefaultFileSpec(),
+    authoring: {
+      parts: [
+        {
+          id: DEFAULT_PART_ID,
+          scoringStrategy: ScoringStrategy.average,
+          gradingApproach: GradingApproach.manual,
+          responses: Responses.forTextInput(),
+          hints: [makeHint(''), makeHint(''), makeHint('')],
+        },
+      ],
+      transformations: [],
+      previewText: '',
+    },
+  };
+};
+
+export const createDefaultFileSpec: () => FileSpec = () =>
+  ({
+    maxCount: 1,
+    accept: '',
+  } as FileSpec);
+
+export function fileName(url: string) {
+  return url.substring(url.lastIndexOf('/') + 1);
+}
+
+export function toDate(ms: number) {
+  const date = new Date(ms);
+  return date.toLocaleString();
+}
+
+export function getReadableFileSizeString(fileSizeInBytes: number) {
+  let i = -1;
+  const byteUnits = [' kB', ' MB', ' GB', ' TB', 'PB', 'EB', 'ZB', 'YB'];
+  do {
+    fileSizeInBytes = fileSizeInBytes / 1024;
+    i++;
+  } while (fileSizeInBytes > 1024);
+
+  return Math.max(fileSizeInBytes, 0.1).toFixed(1) + byteUnits[i];
+}

--- a/assets/src/components/activities/types.ts
+++ b/assets/src/components/activities/types.ts
@@ -138,6 +138,7 @@ export function makeContent(text: string, id?: string): { id: string; content: R
  */
 export interface StudentResponse {
   input: any;
+  files?: any;
 }
 
 export type ModeSpecification = {

--- a/assets/src/data/activities/utils.ts
+++ b/assets/src/data/activities/utils.ts
@@ -49,6 +49,19 @@ export const safelySelectStringInputs = (
   );
 };
 
+export const safelySelectFiles = (activityState: ActivityState | undefined): Maybe<PartInputs> => {
+  const partInputs = activityState?.parts.filter((part) => !!part?.response?.files);
+  if (!partInputs) return Maybe.nothing();
+
+  return Maybe.maybe(activityState).lift((state) =>
+    state.parts.reduce((acc, partState) => {
+      const files = partState.response?.files;
+      acc[String(partState.partId)] = files;
+      return acc;
+    }, {} as PartInputs),
+  );
+};
+
 export const initialPartInputs = (
   activityState: ActivityState | undefined,
   defaultPartInputs: PartInputs = { [DEFAULT_PART_ID]: [] },

--- a/assets/src/data/persistence/media.ts
+++ b/assets/src/data/persistence/media.ts
@@ -7,7 +7,7 @@ export type MediaItemCreated = {
   url: string;
 };
 
-function getFileName(file: File) {
+export function getFileName(file: File) {
   const fileNameWithDot = file.name.slice(
     0,
     file.name.indexOf('.') !== -1 ? file.name.indexOf('.') + 1 : file.name.length,
@@ -18,7 +18,7 @@ function getFileName(file: File) {
   return fileNameWithDot + extension;
 }
 
-function encodeFile(file: File): Promise<string> {
+export function encodeFile(file: File): Promise<string> {
   const reader = new FileReader();
 
   if (file) {

--- a/assets/src/data/persistence/state/intrinsic.ts
+++ b/assets/src/data/persistence/state/intrinsic.ts
@@ -1,4 +1,5 @@
 import { makeRequest } from '../common';
+import { encodeFile, getFileName } from 'data/persistence/media';
 
 export type BulkAttemptRetrieved = {
   result: 'success';
@@ -108,3 +109,34 @@ export const evalActivityAttempt = async (
   });
   return { result };
 };
+
+export type AttemptFileCreated = {
+  result: 'success';
+  url: string;
+  creationDate: number;
+  fileSize: number;
+};
+
+export function uploadActivityFile(
+  sectionSlug: string,
+  activityAttemptGuid: string,
+  partAttemptGuid: string,
+  file: File,
+) {
+  const fileName = getFileName(file);
+  const url = `/state/course/${sectionSlug}/activity_attempt/${activityAttemptGuid}/part_attempt/${partAttemptGuid}/upload`;
+
+  return encodeFile(file).then((encoding: string) => {
+    const body = {
+      file: encoding,
+      name: fileName,
+    };
+    const params = {
+      method: 'POST',
+      body: JSON.stringify(body),
+      url,
+    };
+
+    return makeRequest<AttemptFileCreated>(params);
+  });
+}

--- a/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
@@ -339,9 +339,15 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
             map -> Map.get(map, "input")
           end
 
+        files =
+          case p.response do
+            nil -> nil
+            map -> Map.get(map, "files", [])
+          end
+
         %{
           attempt_guid: p.attempt_guid,
-          input: %StudentInput{input: input}
+          input: %StudentInput{input: input, files: files}
         }
       end)
 
@@ -540,7 +546,6 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
     {:ok, %Model{parts: parts}} = Model.parse(activity_model)
 
     evaluations =
-
       case Model.parse(activity_model) do
         {:ok, %Model{rules: []}} ->
           # We need to tie the attempt_guid from the part_inputs to the attempt_guid

--- a/lib/oli/delivery/attempts/activity_lifecycle/persistence.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle/persistence.ex
@@ -134,9 +134,6 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Persistence do
         query
       end
 
-    IO.inspect("HEREREREREREE")
-    IO.inspect(input)
-
     case Repo.update_all(
            query,
            set: [

--- a/lib/oli/delivery/attempts/activity_lifecycle/persistence.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle/persistence.ex
@@ -134,6 +134,9 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Persistence do
         query
       end
 
+    IO.inspect("HEREREREREREE")
+    IO.inspect(input)
+
     case Repo.update_all(
            query,
            set: [

--- a/lib/oli/delivery/attempts/artifact.ex
+++ b/lib/oli/delivery/attempts/artifact.ex
@@ -1,0 +1,24 @@
+defmodule Oli.Delivery.Attempts.Artifact do
+  alias ExAws.S3
+  alias ExAws
+
+  defp upload_file(bucket, file_name, contents) do
+    S3.put_object(bucket, file_name, contents, [{:acl, :public_read}]) |> ExAws.request()
+  end
+
+  def upload(section_slug, activity_attempt_guid, part_attempt_guid, file_name, file_contents) do
+    path = "artifacts/#{section_slug}/#{activity_attempt_guid}/#{part_attempt_guid}/#{file_name}"
+    bucket_name = Application.fetch_env!(:oli, :s3_media_bucket_name)
+
+    media_url = Application.fetch_env!(:oli, :media_url)
+
+    case upload_file(bucket_name, path, file_contents) do
+      {:ok, %{status_code: 200}} ->
+        {:ok, "https://#{media_url}/#{path}"}
+
+      e ->
+        IO.inspect(e)
+        {:error, {:persistence}}
+    end
+  end
+end

--- a/lib/oli/delivery/attempts/core/student_input.ex
+++ b/lib/oli/delivery/attempts/core/student_input.ex
@@ -1,5 +1,5 @@
 defmodule Oli.Delivery.Attempts.Core.StudentInput do
   @enforce_keys [:input]
   @derive Jason.Encoder
-  defstruct [:input]
+  defstruct [:input, :files]
 end

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -548,6 +548,12 @@ defmodule OliWeb.Router do
       :new_part
     )
 
+    post(
+      "/:activity_attempt_guid/part_attempt/:part_attempt_guid/upload",
+      Api.AttemptController,
+      :file_upload
+    )
+
     put(
       "/:activity_attempt_guid/part_attempt/:part_attempt_guid",
       Api.AttemptController,
@@ -863,7 +869,10 @@ defmodule OliWeb.Router do
 
     # Institutions, LTI Registrations and Deployments
     resources("/institutions", InstitutionController)
-    live("/institutions/:institution_id/discounts", Products.Payments.Discounts, :institution, as: :discount)
+
+    live("/institutions/:institution_id/discounts", Products.Payments.Discounts, :institution,
+      as: :discount
+    )
 
     live("/registrations", Admin.RegistrationsView)
 

--- a/test/oli/delivery/submission_test.exs
+++ b/test/oli/delivery/submission_test.exs
@@ -649,7 +649,7 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
       {:ok, {%{parts: [part_attempt]}, _}} =
         ActivityLifecycle.reset_activity(section.slug, activity_attempt.attempt_guid, true)
 
-      assert part_attempt.response == %{"input" => "a"}
+      assert part_attempt.response == %{"input" => "a", "files" => nil}
     end
 
     # This test case ensures that the following scenario works correctly:


### PR DESCRIPTION
This PR adds a new activity type, the "File Upload" Activity, which expects a student to upload one or more files as their submission. 

It basically works by allowing files to be uploaded into a folder structure of "section slug" / "activity attempt guid" / "part attempt guid", and recording uploaded file meta data in the part attempt `response` attribute. 

The large bulk of the PR is the client-side impl of the activity, with a new state service endpoint for uploading files. 

Given time constraints, there are a couple of rough edges here that we will eventually want to improve upon. These include:
1. Allowing author to specify a max file size per file (or perhaps as a total quota)
2. An atomic method for uploading files and tracking their state in the student response. Right now these are two separate operations where first the file is uploaded, then an entry for it is saved in the student response. 
3. Removal of files that are deleted prior to submission.  Right now the uploaded file stays in the bucket folder, only the reference to it is removed from the student response in the part attempt. 