### PR TITLE
[ENHANCEMENT] MER-1162 allow unlimited attempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Enhancements
 
+- Allow for broader range of number of attempts, including unlimited, for scored pages
 - Add survey authoring support (behind feature flag)
 
 ## 0.19.3 (2022-05-17)

--- a/lib/oli_web/live/curriculum/entries/options_modal.ex
+++ b/lib/oli_web/live/curriculum/entries/options_modal.ex
@@ -19,6 +19,24 @@ defmodule OliWeb.Curriculum.OptionsModal do
   end
 
   def render(%{changeset: changeset, revision: revision} = assigns) do
+    attempt_options = [
+      "1": 1,
+      "2": 2,
+      "3": 3,
+      "4": 4,
+      "5": 5,
+      "6": 6,
+      "7": 7,
+      "8": 8,
+      "9": 9,
+      "10": 10,
+      "15": 15,
+      "25": 25,
+      "50": 50,
+      "100": 100,
+      Unlimited: 0
+    ]
+
     ~L"""
     <div class="modal fade show" style="display: block" id="options_<%= revision.slug %>" tabindex="-1" role="dialog" aria-hidden="true" phx-hook="ModalLaunch">
       <div class="modal-dialog modal-lg" role="document">
@@ -51,7 +69,7 @@ defmodule OliWeb.Curriculum.OptionsModal do
 
                   <div class="form-group">
                     <%= label f, "Number of Attempts" %>
-                    <%= select f, :max_attempts, 1..10, class: "custom-select", disabled: is_disabled(changeset, revision), class: "form-control", aria_describedby: "numberOfAttempts", placeholder: "Number of Attempts" %>
+                    <%= select f, :max_attempts, attempt_options, class: "custom-select", disabled: is_disabled(changeset, revision), class: "form-control", aria_describedby: "numberOfAttempts", placeholder: "Number of Attempts" %>
                     <small id="numberOfAttempts" class="form-text text-muted">Graded assessments allow a configurable number of attempts, while practice pages offer unlimited attempts.</small>
                   </div>
 

--- a/lib/oli_web/templates/page_delivery/after_finalized.html.eex
+++ b/lib/oli_web/templates/page_delivery/after_finalized.html.eex
@@ -2,7 +2,7 @@
 <div class="alert alert-success after-finalized" role="alert">
   <h4 class="alert-heading">Attempt Submitted</h4>
 
-  <p>You've completed this graded assessment attempt. </p>
+  <p>You've completed this scored attempt. </p>
 
   <p><%= @grade_message %></p>
 

--- a/lib/oli_web/templates/page_delivery/prologue.html.eex
+++ b/lib/oli_web/templates/page_delivery/prologue.html.eex
@@ -1,7 +1,7 @@
 <% prologue_class = "jumbotron prologue " <> if @allow_attempt?, do: "allow-attempt", else: "" %>
 <div class="<%= prologue_class %>">
   <h3 class="display-4"><%= @title %></h3>
-  <p class="lead" style="color: #c0392b;">This is a <strong>graded assessment</strong></p>
+  <p class="lead" style="color: #c0392b;">This is a <strong>scored</strong> page</p>
 
   <%= if has_submitted_attempt?(Map.get(@summary.access_map, @resource_id)) do %>
     <h4 class="mb-2">
@@ -14,7 +14,12 @@
   <div class="mb-2">
     <h5 class="mb-0">
       <%= link to: Routes.page_delivery_path(@conn, :review_attempt, @section_slug, @slug, resource_attempt.attempt_guid) do %>
-      <span>Attempt <%= resource_attempt.attempt_number %> of <%= @max_attempts %></span>
+
+      <%= if @max_attempts == 0 do %>
+        <span>Attempt <%= resource_attempt.attempt_number %></span>
+        <% else %>
+        <span>Attempt <%= resource_attempt.attempt_number %> of <%= @max_attempts %></span>
+        <% end %>
       <% end %>
     </h5>
     <div class="row justify-content-start">


### PR DESCRIPTION
This PR increases the choices for number of attempts for graded pages, including an "Unlimited" option. 

I also took this opportunity to soften some of the UX language around "graded assessment", using "scored page" instead. 

For some reason there are a bunch of formatting changes here, but mainly the changes were to customize the curriculum editor dropdown for more options, and to handle "unlimited" in a couple of places that students encounter (the prologue view)