### PR TITLE
[BUG FIX] fix an issue where table caption rendering throws an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Improve performance of DataShop export
 - Fix an issue where multi-input activity inputs were being duplicated
+- Fix an issue where table caption rendering throws an internal server error
 
 ### Enhancements
 

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -121,10 +121,10 @@ defmodule Oli.Rendering.Content.Html do
     missing_media_src(context, e)
   end
 
-  def table(%Context{} = _context, next, attrs) do
+  def table(%Context{} = context, next, attrs) do
     caption =
       case attrs do
-        %{"caption" => caption} -> "<caption>#{escape_xml!(caption)}</caption>"
+        %{"caption" => c} -> caption(context, c)
         _ -> ""
       end
 

--- a/test/oli/rendering/content/example_content.json
+++ b/test/oli/rendering/content/example_content.json
@@ -21,6 +21,95 @@
       ]
     },
     {
+      "caption": [
+        {
+          "children": [
+            {
+              "text": "sample table"
+            }
+          ],
+          "id": "540144016",
+          "type": "p"
+        }
+      ],
+      "children": [
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "text": "table"
+                    }
+                  ],
+                  "id": "1786276003",
+                  "type": "p"
+                }
+              ],
+              "id": "2472685940",
+              "type": "td"
+            },
+            {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "text": "sample"
+                    }
+                  ],
+                  "id": "2803247573",
+                  "type": "p"
+                }
+              ],
+              "id": "2644924984",
+              "type": "td"
+            }
+          ],
+          "id": "309803507",
+          "type": "tr"
+        },
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "text": "sample"
+                    }
+                  ],
+                  "id": "2154695715",
+                  "type": "p"
+                }
+              ],
+              "id": "4047592048",
+              "type": "td"
+            },
+            {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "text": "table"
+                    }
+                  ],
+                  "id": "332341714",
+                  "type": "p"
+                }
+              ],
+              "id": "3231662655",
+              "type": "td"
+            }
+          ],
+          "id": "4237041410",
+          "type": "tr"
+        }
+      ],
+      "id": "1013436953",
+      "type": "table"
+    },
+    {
       "type": "p",
       "id": 2652513352,
       "children": [


### PR DESCRIPTION
This PR fixes an issue where table caption rendering throws an internal server error.

The problem here is table is directly rendering the caption content as text and not accounting for a richer content elements such as "p". The solution is to use the caption rendering function already implemented in the module.

Closes #2615
Closes #2562