### PR TITLE
[BUG FIX] Cascade deletion of objectives to banked activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix an issue where multi-input activity inputs were being duplicated
 - Fix an issue where table headers were misaligned in the insights view
 - Fix an issue where table caption rendering throws an internal server error
+- Allow deletion of objective to cascade through to banked activities
 
 ### Enhancements
 

--- a/lib/oli/publishing.ex
+++ b/lib/oli/publishing.ex
@@ -984,6 +984,7 @@ defmodule Oli.Publishing do
     title: the title of the resource
     slug: the slug of the revision
     part: the part name, or "attached" if pertaining to a page
+    scope: the scope of the activity
   }
   """
   def find_objective_attachments(resource_id, publication_id) do
@@ -992,7 +993,7 @@ defmodule Oli.Publishing do
 
     sql = """
     select
-      revisions.id, revisions.resource_id, revisions.title, revisions.slug, part
+      revisions.scope, revisions.id, revisions.resource_id, revisions.title, revisions.slug, part
     FROM revisions, jsonb_object_keys(revisions.objectives) p(part)
     WHERE
       revisions.id IN (SELECT revision_id
@@ -1008,13 +1009,14 @@ defmodule Oli.Publishing do
     {:ok, %{rows: results}} = Ecto.Adapters.SQL.query(Oli.Repo, sql, [])
 
     results
-    |> Enum.map(fn [id, resource_id, title, slug, part] ->
+    |> Enum.map(fn [scope, id, resource_id, title, slug, part] ->
       %{
         id: id,
         resource_id: resource_id,
         title: title,
         slug: slug,
-        part: part
+        part: part,
+        scope: scope
       }
     end)
   end


### PR DESCRIPTION
Might close #2625 

This PR adds special handling of cascading an objective deletion to banked activities.   This impl was never updated to account for banked activities when they were introduced. 
