### PR TITLE
[BUGFIX] adaptive author setting the wrong type in case of invalid value

### DIFF
--- a/assets/src/apps/authoring/store/groups/layouts/deck/actions/updateActivityRules.ts
+++ b/assets/src/apps/authoring/store/groups/layouts/deck/actions/updateActivityRules.ts
@@ -37,13 +37,17 @@ const updateNestedConditions = async (conditions: any, activityTree: IActivity[]
       }
       const presumedType = inferTypeFromOperatorAndValue(condition.operator, condition.value);
       if (condition.type && presumedType !== condition.type) {
-        console.warn('updateNestedConditions: type mismatch, forcing presumed', {
+        // this is likely to happen repeatedly especially in some cases with numbers looking like strings
+        // TODO: deeper analysis of the values considering all factors
+        // TODO: add to diagnostics instead of trying to auto correct? (the value, which currently not doing)
+        /* console.warn('updateNestedConditions: type mismatch, need to infer correct type', {
           type: condition.type,
           presumedType,
           operator: condition.operator,
-        });
-        // we should go ahead and change the type to the presumed type because type rarely matters compared to operator
-        condition.type = presumedType;
+          condition,
+        }); */
+        // set the type to null so that it will go through the slightly more complex logic below
+        condition.type = null;
       }
       if (condition.fact && !condition.type) {
         // because there might not be a type from an import, and the value might not actually be the type of the fact,
@@ -60,10 +64,16 @@ const updateNestedConditions = async (conditions: any, activityTree: IActivity[]
             }
             return result;
           }, null);
-          /* console.log('INFERRING', { condition, targetPart, componentId, targetKey }); */
           if (targetPart) {
             inferredType = await inferTypeFromComponentType(targetPart.type, targetKey, targetPart);
           }
+          /* console.log('INFERRING FROM COMPONENT SCHEMA', {
+            inferredType,
+            condition,
+            targetPart,
+            componentId,
+            targetKey,
+          }); */
         }
         if (inferredType === CapiVariableTypes.UNKNOWN) {
           /* console.log('INFERRING 2', { condition, inferredType }); */


### PR DESCRIPTION
use the component schema as the source of truth always about the value type of the variable