### PR TITLE
[BUGFIX] PMP-2858 JAN-1707 don't auto round any numbers

### DIFF
--- a/assets/src/adaptivity/scripting.ts
+++ b/assets/src/adaptivity/scripting.ts
@@ -595,8 +595,6 @@ export const templatizeText = (
         strValue = stateValue.map((v) => `"${v}"`).join(', ');
       } else if (typeof stateValue === 'object') {
         strValue = JSON.stringify(stateValue);
-      } else if (typeof stateValue === 'number') {
-        strValue = parseFloat(parseFloat(strValue).toFixed(4));
       }
     } else {
       if (typeof stateValue === 'object' && !Array.isArray(stateValue)) {


### PR DESCRIPTION
previously it was thought that 4 decimal places would be fine for a universal rounding when displaying numbers as text in text flows, but this was problematic with things like 1e-10 showing up as 0 . There are other cases, too many, so the best thing to do is *not* do it at all automatically, and require the author to specifically do it when printing using `{round(stage.foo.value, 4)}`