### PR TITLE
[BUG FIX] Fix v1 codeblocks

### DIFF
--- a/assets/src/apps/page-editor/PageEditor.tsx
+++ b/assets/src/apps/page-editor/PageEditor.tsx
@@ -251,6 +251,9 @@ export class PageEditor extends React.Component<PageEditorProps, PageEditorState
   }
 
   onEditActivity(id: string, update: ActivityEditorUpdate): void {
+    // only update if editMode is active
+    if (!this.state.editMode) return;
+
     const model = this.adjustActivityForConstraints(
       this.state.activityContexts.get(id)?.typeSlug,
       update.content,
@@ -280,6 +283,9 @@ export class PageEditor extends React.Component<PageEditorProps, PageEditorState
   }
 
   onRemove(key: string) {
+    // only update if editMode is active
+    if (!this.state.editMode) return;
+
     const item = this.state.content.find(key);
     const index = this.state.content.findIndex((c) => c.id === key);
 
@@ -373,11 +379,17 @@ export class PageEditor extends React.Component<PageEditorProps, PageEditorState
   }
 
   update(update: Partial<EditorUpdate>) {
+    // only update if editMode is active
+    if (!this.state.editMode) return;
+
     const mergedState = Object.assign({}, this.state, update);
     this.setState(mergedState, () => this.save());
   }
 
   updateImmediate(update: Partial<EditorUpdate>) {
+    // only update if editMode is active
+    if (!this.state.editMode) return;
+
     const mergedState = Object.assign({}, this.state, update);
     this.setState(mergedState, () => this.saveImmediate());
   }
@@ -446,9 +458,7 @@ export class PageEditor extends React.Component<PageEditorProps, PageEditorState
 
     const { projectSlug, resourceSlug } = this.props;
 
-    const onEdit = (content: PageEditorContent) => {
-      this.update({ content });
-    };
+    const onEdit = (content: PageEditorContent) => this.update({ content });
 
     const onTitleEdit = (title: string) => {
       this.updateImmediate({ title });

--- a/assets/src/components/activity/InlineActivityEditor.tsx
+++ b/assets/src/components/activity/InlineActivityEditor.tsx
@@ -8,7 +8,6 @@ import { Tag } from 'data/content/tags';
 import { ResourceId } from 'data/types';
 import React from 'react';
 import { valueOr } from 'utils/common';
-import { TitleBar } from '../content/TitleBar';
 import { TextEditor } from 'components/TextEditor';
 import { DeleteButton } from 'components/misc/DeleteButton';
 

--- a/assets/src/components/common/ThreeStateToggle.tsx
+++ b/assets/src/components/common/ThreeStateToggle.tsx
@@ -17,13 +17,13 @@ export const ThreeStateToggle = ({
 interface ToggleOptionProps {
   id: string;
   checked?: boolean;
-  onClick?: React.MouseEventHandler<HTMLDivElement>;
+  onChange?: () => void;
 }
 export const ToggleOption = ({
   id,
   checked,
   children,
-  onClick,
+  onChange,
 }: PropsWithChildren<ToggleOptionProps>) => {
   return (
     <>
@@ -32,7 +32,7 @@ export const ToggleOption = ({
         id={id}
         className={styles.input}
         name="state"
-        onClick={onClick}
+        onChange={onChange}
         checked={checked}
       />
       <label htmlFor={id} className={styles.label}>

--- a/assets/src/components/editing/elements/blockcode/BlockcodeElement.tsx
+++ b/assets/src/components/editing/elements/blockcode/BlockcodeElement.tsx
@@ -1,38 +1,48 @@
-import React, { PropsWithChildren, useState, useEffect, useRef, Suspense } from 'react';
+import React, { PropsWithChildren, useEffect, useRef, Suspense, useState } from 'react';
 import { throttle } from 'lodash';
 import { onEditModel } from 'components/editing/elements/utils';
 import * as ContentModel from 'data/content/model/elements/types';
 import { EditorProps } from 'components/editing/elements/interfaces';
 import { CaptionEditor } from 'components/editing/elements/common/settings/CaptionEditor';
 import { CodeLanguages } from 'components/editing/elements/blockcode/codeLanguages';
-import { ReactEditor, useSlate } from 'slate-react';
-import { Editor } from 'slate';
 import * as monaco from 'monaco-editor';
 import { RefEditorInstance } from '@uiw/react-monacoeditor';
 import { isDarkMode, addDarkModeListener, removeDarkModeListener } from 'utils/browser';
 import { DropdownSelect, DropdownItem } from 'components/common/DropdownSelect';
-
 import './BlockcodeElement.scss';
 
 const MonacoEditor = React.lazy(() => import('@uiw/react-monacoeditor'));
 
-const getInitialModel = (model: ContentModel.Code) => {
-  const editor = useSlate();
-  // v2 -- code in code attr
-  if (model.code) return model.code;
+const isCodeV2Model = (model: any) => model.code !== undefined;
 
-  // v1 -- code is in code_line child elements
-  const code = Editor.string(editor, ReactEditor.findPath(editor, model));
-  return code;
+const migrateV1toV2 = (model: ContentModel.CodeV1) => {
+  const code = (model as ContentModel.CodeV1).children
+    .map((c) => c.children.map((t) => t.text).join(''))
+    .join('\n');
+
+  const updatedModel = model as any as ContentModel.CodeV2;
+  updatedModel.code = code;
+  updatedModel.children = [{ text: '' }];
+
+  return updatedModel;
+};
+
+const getInitialModel = (model: ContentModel.CodeV2 | ContentModel.CodeV1): ContentModel.CodeV2 => {
+  if (isCodeV2Model(model)) {
+    return model as ContentModel.CodeV2;
+  }
+
+  // v1 -- code is in code_line child elements, upgrade model to v2
+  return migrateV1toV2(model as ContentModel.CodeV1);
 };
 
 type CodeEditorProps = EditorProps<ContentModel.Code>;
 export const CodeEditor = (props: PropsWithChildren<CodeEditorProps>) => {
   const editorContainer = useRef<HTMLDivElement>(null);
   const editorRef = useRef<RefEditorInstance>(null);
-  const [value] = useState(getInitialModel(props.model));
+  const [model] = useState(getInitialModel(props.model));
 
-  const onEdit = onEditModel(props.model);
+  const onEdit = onEditModel(model);
 
   const updateSize = (editor?: monaco.editor.IStandaloneCodeEditor) => {
     if (editor && editorContainer.current) {
@@ -97,7 +107,7 @@ export const CodeEditor = (props: PropsWithChildren<CodeEditorProps>) => {
         <Suspense fallback={<div>Loading...</div>}>
           <MonacoEditor
             ref={editorRef}
-            value={value}
+            value={model.code}
             language={CodeLanguages.byPrettyName(props.model.language).monacoMode}
             options={{
               tabSize: 2,
@@ -105,9 +115,7 @@ export const CodeEditor = (props: PropsWithChildren<CodeEditorProps>) => {
               minimap: { enabled: false },
               theme: isDarkMode() ? 'vs-dark' : 'vs-light',
             }}
-            onChange={(code) => {
-              onEdit({ code });
-            }}
+            onChange={(code) => onEdit({ code })}
             editorDidMount={editorDidMount}
           />
         </Suspense>

--- a/assets/src/components/logic/ActivityTypeSelection.tsx
+++ b/assets/src/components/logic/ActivityTypeSelection.tsx
@@ -41,7 +41,6 @@ export const ActivityTypeSelection = (props: ActivityTypeSelectionProps) => {
       }}
       options={activities}
       allowNew={true}
-      selectHintOnEnter={true}
       labelKey="label"
       selected={asActivities}
       placeholder="Select activity types..."

--- a/assets/src/components/misc/DarkModeSelector.tsx
+++ b/assets/src/components/misc/DarkModeSelector.tsx
@@ -45,15 +45,15 @@ export const DarkModeSelector = ({ showLabels = true }: DarkModeSelectorProps) =
 
   return (
     <ThreeStateToggle>
-      <ToggleOption id="auto" checked={isChecked(mode, 'auto')} onClick={onSelect('auto')}>
+      <ToggleOption id="auto" checked={isChecked(mode, 'auto')} onChange={onSelect('auto')}>
         <i className="las la-adjust"></i>
         {maybeLabel('Auto', showLabels)}
       </ToggleOption>
-      <ToggleOption id="light" checked={isChecked(mode, 'light')} onClick={onSelect('light')}>
+      <ToggleOption id="light" checked={isChecked(mode, 'light')} onChange={onSelect('light')}>
         <i className="las la-sun"></i>
         {maybeLabel('Light', showLabels)}
       </ToggleOption>
-      <ToggleOption id="dark" checked={isChecked(mode, 'dark')} onClick={onSelect('dark')}>
+      <ToggleOption id="dark" checked={isChecked(mode, 'dark')} onChange={onSelect('dark')}>
         <i className="las la-moon"></i>
         {maybeLabel('Dark', showLabels)}
       </ToggleOption>

--- a/assets/src/components/resource/Tags.tsx
+++ b/assets/src/components/resource/Tags.tsx
@@ -78,7 +78,6 @@ export const Tags = (props: TagsProps) => {
           options={props.tags}
           allowNew={true}
           newSelectionPrefix="Create new tag: "
-          selectHintOnEnter={true}
           labelKey="title"
           selected={asTags}
           placeholder="Select tags..."

--- a/assets/src/components/resource/editors/Editors.scss
+++ b/assets/src/components/resource/editors/Editors.scss
@@ -4,6 +4,8 @@
 
 html.authoring {
   .editors {
+    flex: 1;
+    min-width: 0;
     border: 2px solid authoring.$gray-200;
     margin-top: 20px;
     padding: 20px 0px;

--- a/assets/src/components/resource/objectives/ObjectivesSelection.tsx
+++ b/assets/src/components/resource/objectives/ObjectivesSelection.tsx
@@ -81,7 +81,6 @@ export const ObjectivesSelection = (props: ObjectivesProps) => {
         options={props.objectives}
         allowNew={true}
         newSelectionPrefix="Create new objective: "
-        selectHintOnEnter={true}
         labelKey="title"
         selected={asObjectives}
         placeholder="Attach learning objectives..."

--- a/assets/src/data/content/model/elements/factories.ts
+++ b/assets/src/data/content/model/elements/factories.ts
@@ -8,7 +8,6 @@ import {
   Webpage,
   Hyperlink,
   Paragraph,
-  Code,
   InputRef,
   Popup,
   Table,
@@ -20,6 +19,7 @@ import {
   HeadingOne,
   HeadingTwo,
   ImageInline,
+  CodeV2,
 } from 'data/content/model/elements/types';
 import { Text } from 'slate';
 import guid from 'utils/guid';
@@ -72,10 +72,10 @@ export const Model = {
       type: 'blockquote',
     }),
 
-  code: (children = '') =>
-    create<Code>({
+  code: (code = '') =>
+    create<CodeV2>({
       type: 'code',
-      code: children,
+      code,
       language: 'Text',
     }),
 

--- a/assets/src/data/content/model/elements/types.ts
+++ b/assets/src/data/content/model/elements/types.ts
@@ -123,12 +123,14 @@ export interface CodeV1 extends SlateElement<CodeLine[]> {
   language: string;
   caption?: Caption;
 }
+
 export interface CodeV2 extends SlateElement<VoidChildren> {
   type: 'code';
   code: string;
   language: string;
   caption?: Caption;
 }
+
 export type Code = CodeV2;
 
 export interface Blockquote extends SlateElement<Paragraph[]> {

--- a/assets/src/data/content/writers/html.tsx
+++ b/assets/src/data/content/writers/html.tsx
@@ -230,7 +230,12 @@ export class HtmlParser implements WriterImpl {
     );
   }
   codeLine(context: WriterContext, next: Next, _x: CodeLine) {
-    return next();
+    return (
+      <>
+        {next()}
+        {'\n'}
+      </>
+    );
   }
   blockquote(context: WriterContext, next: Next, _x: Blockquote) {
     return <blockquote>{next()}</blockquote>;

--- a/lib/oli_web/templates/layout/authoring.html.leex
+++ b/lib/oli_web/templates/layout/authoring.html.leex
@@ -15,8 +15,13 @@
     <link id="authoring-theme" rel="stylesheet" href="/css/authoring_default.css" />
     <link id="delivery-theme" rel="stylesheet" href="/css/delivery_default.css" />
 
-    <script crossorigin src="https://unpkg.com/react@17.0.2/umd/react.production.min.js"></script>
-    <script crossorigin src="https://unpkg.com/react-dom@17.0.2/umd/react-dom.production.min.js"></script>
+    <%= if Mix.env() == :dev do %>
+      <script crossorigin src="https://unpkg.com/react@17.0.2/umd/react.development.js"></script>
+      <script crossorigin src="https://unpkg.com/react-dom@17.0.2/umd/react-dom.development.js"></script>
+    <% else %>
+      <script crossorigin src="https://unpkg.com/react@17.0.2/umd/react.production.min.js"></script>
+      <script crossorigin src="https://unpkg.com/react-dom@17.0.2/umd/react-dom.production.min.js"></script>
+    <% end %>
 
     <!-- jQuery first, then Popper.js, then Bootstrap JS -->
     <script src="https://code.jquery.com/jquery-3.5.0.slim.min.js" integrity="sha256-MlusDLJIP1GRgLrOflUQtshyP0TwT/RHXsI1wWGnQhs=" crossorigin="anonymous"></script>

--- a/lib/oli_web/templates/layout/delivery.html.eex
+++ b/lib/oli_web/templates/layout/delivery.html.eex
@@ -14,8 +14,13 @@
     <!-- Theme CSS (contains all bootstrap styles as well as custom styles for a specific theme) -->
     <link id="delivery-theme" rel="stylesheet" href="/css/delivery_default.css" />
 
-    <script crossorigin src="https://unpkg.com/react@17.0.2/umd/react.production.min.js"></script>
-    <script crossorigin src="https://unpkg.com/react-dom@17.0.2/umd/react-dom.production.min.js"></script>
+    <%= if Mix.env() == :dev do %>
+      <script crossorigin src="https://unpkg.com/react@17.0.2/umd/react.development.js"></script>
+      <script crossorigin src="https://unpkg.com/react-dom@17.0.2/umd/react-dom.development.js"></script>
+    <% else %>
+      <script crossorigin src="https://unpkg.com/react@17.0.2/umd/react.production.min.js"></script>
+      <script crossorigin src="https://unpkg.com/react-dom@17.0.2/umd/react-dom.production.min.js"></script>
+    <% end %>
 
     <!-- jQuery first, then Popper.js, then Bootstrap JS -->
     <script src="https://code.jquery.com/jquery-3.5.0.slim.min.js" integrity="sha256-MlusDLJIP1GRgLrOflUQtshyP0TwT/RHXsI1wWGnQhs=" crossorigin="anonymous"></script>


### PR DESCRIPTION
This PR fixes a few different high-priority issues including:

- Code elements were not properly being converted from v1 to v2 model rendering logic did not properly account for existing v1 code element newlines
    - We will want to add this sort of logic to the runtime content migration infrastructure once we finally spec out activity schemas
- Some editors may fire an edit event before the PageEditor has initializes the persistence strategy which crashes the page, specifically monaco editor repeating the value it was given on first render. This PR add logic to only allow the update functions to run if editMode is true.
- Torus was using React production libraries in development making it difficult to identify the issue. This re-enables development libraries in Mix.env() == :dev
- Re-enabling React developer messages uncovered a few different issues which were fixed as well (except for an issue cause by react-bootstrap, which has no fix available ((we are currently running the latest build for bs4)) )
- Code editor was overflowing the editors area when window was resized smaller and also when content outline preview text was larger than the initial rendering size. The fix included here fixes both of these issues

Tested by inserting the following v1 code element content directly into a revision record for an image coding activity:
```
        {
          "id": "1562499621",
          "type": "code",
          "children": [
            {
              "id": "1338353471",
              "type": "code_line",
              "children": [
                {
                  "text": "line 1"
                }
              ]
            },
            {
              "id": "1077992329",
              "type": "code_line",
              "children": [
                {
                  "text": "line 2"
                }
              ]
            },
            {
              "id": "2448590265",
              "type": "code_line",
              "children": [
                {
                  "text": "line 3"
                }
              ]
            }
          ],
          "language": "javascript"
        }
```

Closes: #2584
Closes: #2555