### PR TITLE
PMP-2860 | JAN-1709

### DIFF
--- a/assets/src/components/parts/janus-mcq/MultipleChoiceQuestion.tsx
+++ b/assets/src/components/parts/janus-mcq/MultipleChoiceQuestion.tsx
@@ -462,13 +462,13 @@ const MultipleChoiceQuestion: React.FC<PartComponentProps<McqModel>> = (props) =
       .sort((a, b) => a.value - b.value)
       .map((item) => item.value);
 
-    const newSelectedChoice = newSelectedChoices[0];
+    const newSelectedChoice = newSelectedChoices.length ? newSelectedChoices[0] : -1;
 
     const newSelectedChoicesText = modifiedSelections
       .sort((a, b) => a.value - b.value)
       .map((item) => item.textValue);
 
-    const newSelectedChoiceText = newSelectedChoicesText[0];
+    const newSelectedChoiceText = newSelectedChoicesText.length ? newSelectedChoicesText[0] : '';
 
     setNumberOfSelectedChoices(newCount);
     setSelectedChoice(newSelectedChoice);


### PR DESCRIPTION
for Multiple Selection MCQ, if nothing was selected by default, then undefined was getting set for 'SelectedChoice' & 'SelectedChoiceText'. They should be set to '-1' and '' respectively. 

We were already setting this to  '-1' and '' on props.onInit but later during 'handleMultipleItemSelection()', it was getting overriden.