### PR TITLE
[BUG-FIX] [MER-1126] Fix product image breaking card in instructor's new section view

### DIFF
--- a/assets/styles/common/card-link.scss
+++ b/assets/styles/common/card-link.scss
@@ -86,8 +86,8 @@ a.card-link {
 
 .course-card-link {
   img.card-img-top {
-    height: 150px;
-    width: auto;
+    height: 20vh;
+    width: 100%;
     object-fit: cover;
   }
 

--- a/assets/styles/delivery/layout/delivery.scss
+++ b/assets/styles/delivery/layout/delivery.scss
@@ -14,13 +14,18 @@ body {
 
   .card-title {
     text-overflow: ellipsis;
-    overflow: hidden;
+    overflow: auto;
     white-space: nowrap;
   }
 
   .fade-text {
-    height: 4em;
-    overflow: scroll;
+    overflow: auto;
+    max-height: 10vh;
+    text-overflow: ellipsis;
+    color: $body-color;
+    .card-text {
+      overflow: auto;
+    }
   }
 
   .small-date {

--- a/lib/oli_web/live/common/card_listing.ex
+++ b/lib/oli_web/live/common/card_listing.ex
@@ -15,16 +15,16 @@ defmodule OliWeb.Common.CardListing do
     <div class="select-sources">
       <div class="card-deck mr-0 ml-0">
         {#for item <- @model.rows}
-          <a :on-click={@selected} phx-value-id={action_id(item)}>
-            <div class="card mb-2 mr-1 ml-1">
+          <a :on-click={@selected} class="course-card-link mb-2" phx-value-id={action_id(item)}>
+            <div class="card mb-2 mr-1 ml-1 h-100">
               <img src={cover_image(item)} class="card-img-top" alt="course image">
               <div class="card-body">
-                <h5 class="card-title text-primary">{render_title_column(item)}</h5>
+                <h5 class="card-title text-primary" title={render_title_column(item)}>{render_title_column(item)}</h5>
                 <div class="fade-text"><p class="card-text small">{render_description(item)}</p></div>
-                <div class="d-flex justify-content-between align-items-center pt-2">
-                  <div class="badge badge-success mr-5">{TableModel.render_payment_column(assigns, item, nil)}</div>
-                  <div class="small-date text-muted">{render_date(item, @context)}</div>
-                </div>
+              </div>
+              <div class="card-footer bg-transparent d-flex justify-content-between align-items-center border-0">
+                <div class="badge badge-success mr-5">{TableModel.render_payment_column(assigns, item, nil)}</div>
+                <div class="small-date text-muted">{render_date(item, @context)}</div>
               </div>
             </div>
           </a>


### PR DESCRIPTION
[MER-1126](https://eliterate.atlassian.net/browse/MER-1126)

## What does it change?

- Fixes large vertical product images breaking the product card in the instructors' new section view

### Before fix

![image](https://user-images.githubusercontent.com/22042418/172912223-c8fd56b1-5685-4a37-ba48-756c8f9ad742.png)

![image](https://user-images.githubusercontent.com/22042418/172912253-d4d0ed11-b268-4108-92a2-37d89778f791.png)


### After fix

Using images: 

https://upload.wikimedia.org/wikipedia/commons/thumb/4/4d/Ma_Lin_010.jpg/640px-Ma_Lin_010.jpg
https://images-na.ssl-images-amazon.com/images/I/91TrrZRURSS.jpg

![image](https://user-images.githubusercontent.com/22042418/172912386-3fe99ffc-c9a4-4564-93ef-33f6975aa9e2.png)

It  now behaves just like the other pages that show the product image did:

![image](https://user-images.githubusercontent.com/22042418/172912568-8681bdb5-889b-4b7f-95ef-aaefeaf87df5.png)

![image](https://user-images.githubusercontent.com/22042418/172912624-f585be53-4ca3-42cf-8c68-10f3ad187d49.png)

