### PR TITLE
[ENHANCEMENT] simplify and improve UX around objectives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Allow for broader range of number of attempts, including unlimited, for scored pages
 - Add survey authoring support (behind feature flag)
 - Add File Upload activity
+- Simplify objective creation, improve attachment UX
 
 ## 0.19.3 (2022-05-17)
 

--- a/assets/src/apps/bank/ActivityBank.tsx
+++ b/assets/src/apps/bank/ActivityBank.tsx
@@ -39,6 +39,7 @@ import { LogicFilter } from './LogicFilter';
 import { Paging } from './Paging';
 
 import '../ResourceEditor.scss';
+import { arrangeObjectives } from 'components/resource/objectives/sort';
 
 const PAGE_SIZE = 5;
 
@@ -193,7 +194,7 @@ export class ActivityBank extends React.Component<ActivityBankProps, ActivityBan
       activityContexts: Immutable.OrderedMap<string, ActivityEditContext>(),
       messages: [],
       persistence: 'idle',
-      allObjectives: Immutable.List<Objective>(props.allObjectives),
+      allObjectives: arrangeObjectives(props.allObjectives),
       allTags: Immutable.List<Tag>(props.allTags),
       metaModifier: false,
       undoables: Immutable.OrderedMap<string, ActivityUndoAction>(),
@@ -492,6 +493,8 @@ export class ActivityBank extends React.Component<ActivityBankProps, ActivityBan
             onRegisterNewObjective={this.onRegisterNewObjective}
             onRegisterNewTag={this.onRegisterNewTag}
             banked={true}
+            canRemove={false}
+            onRemove={() => {}}
             {...context}
           />
         </div>

--- a/assets/src/apps/page-editor/PageEditor.tsx
+++ b/assets/src/apps/page-editor/PageEditor.tsx
@@ -8,6 +8,7 @@ import { Banner } from 'components/messages/Banner';
 import { Editors } from 'components/resource/editors/Editors';
 import { Objectives } from 'components/resource/objectives/Objectives';
 import { ObjectivesSelection } from 'components/resource/objectives/ObjectivesSelection';
+import { arrangeObjectives } from 'components/resource/objectives/sort';
 import { UndoToasts } from 'components/resource/undo/UndoToasts';
 import { ActivityEditContext } from 'data/content/activity';
 import { guaranteeValididty } from 'data/content/bank';
@@ -135,7 +136,7 @@ export class PageEditor extends React.Component<PageEditorProps, PageEditorState
       objectives: Immutable.List<ResourceId>(objectives.attached),
       content: PageEditorContent.fromPersistence(content),
       persistence: 'idle',
-      allObjectives: Immutable.List<Objective>(allObjectives),
+      allObjectives: arrangeObjectives(allObjectives),
       childrenObjectives: mapChildrenObjectives(allObjectives),
       undoables: empty(),
     };

--- a/assets/src/components/resource/objectives/sort.ts
+++ b/assets/src/components/resource/objectives/sort.ts
@@ -1,0 +1,38 @@
+import { Objective } from 'data/content/objective';
+import * as Immutable from 'immutable';
+
+/**
+ * Takes an array of objectives and arranges them in a list so that child
+ * objectives immediately follow their parent.
+ *
+ * @param objectives an array of objectives to arrange
+ * @returns the arranged objectives as an immutable list
+ */
+export function arrangeObjectives(objectives: Objective[]): Immutable.List<Objective> {
+  // Bucket objectives by parent
+
+  const byId = objectives.reduce((m: any, o: any) => {
+    m[o.id] = o;
+    return m;
+  }, {});
+
+  const bucketed = objectives.reduce((m: any, o: any) => {
+    if (o.parentId !== null && byId[o.parentId] !== undefined) {
+      if (m[o.parentId] === undefined) {
+        m[o.parentId] = [o.id];
+      } else {
+        m[o.parentId] = [...m[o.parentId], o.id];
+      }
+    } else if (m[o.id] === undefined) {
+      m[o.id] = [];
+    }
+    return m;
+  }, {});
+
+  const inOrder = Object.keys(bucketed).reduce((all: any, key: any) => {
+    const parentWithChildren = [byId[key], ...bucketed[key].map((k: any) => byId[k])];
+    return [...all, ...parentWithChildren];
+  }, []);
+
+  return Immutable.List<Objective>(inOrder);
+}

--- a/lib/oli_web/live/objectives/actions.ex
+++ b/lib/oli_web/live/objectives/actions.ex
@@ -6,15 +6,6 @@ defmodule OliWeb.Objectives.Actions do
     ~L"""
       <div class="objective-actions p-2">
 
-        <%= if !@has_children and @depth < 2 do %>
-          <button
-            class="ml-1 btn btn-sm btn-light"
-            phx-click="show_breakdown_modal"
-            phx-value-slug="<%= @slug %>">
-            <i class="las la-sitemap"></i> Break down
-          </button>
-        <% end %>
-
         <button
           class="ml-1 btn btn-sm btn-light"
           phx-click="modify"

--- a/lib/oli_web/live/objectives/objective_entry.ex
+++ b/lib/oli_web/live/objectives/objective_entry.ex
@@ -32,7 +32,7 @@ defmodule OliWeb.Objectives.ObjectiveEntry do
             </div>
           </div>
 
-        <% Enum.count(@children) > 0 -> %>
+        <% @depth < 2 -> %>
           <% # this objective has one or more children, it is a container objective and more sub-objectives can be created %>
           <div class="row create-sub-objective py-1">
             <div class="col-12 pb-2">
@@ -48,8 +48,8 @@ defmodule OliWeb.Objectives.ObjectiveEntry do
               </div>
             </div>
           </div>
-
         <% true -> %>
+
       <% end %>
     """
   end


### PR DESCRIPTION
This PR removes the "Break down" feature, allowing sub objectives to be immediately added.   It also improves the UI for attaching, to preserve the tree structure in its rendering. 

Closes #1859 
