### PR TITLE
[BUG FIX] fix title editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bug Fixes
 
+- Restore ability to edit title of basic pages
+
 ### Enhancements
 
 ## 0.19.4 (2022-06-09)

--- a/assets/src/apps/page-editor/PageEditor.tsx
+++ b/assets/src/apps/page-editor/PageEditor.tsx
@@ -445,7 +445,7 @@ export class PageEditor extends React.Component<PageEditorProps, PageEditorState
     const toSave: Persistence.ResourceUpdate = {
       objectives: { attached: this.state.objectives.toArray() },
       title: this.state.title,
-      content: { model: this.state.content.model.toJS() },
+      content: this.state.content.toPersistence(),
       releaseLock: false,
     };
 


### PR DESCRIPTION
Closes #2628 

This PR fixes the ability to edit the title of the basic page.  Title editing takes a different client-side event path, and also kicks off the save request in a different spot than content editing. Recent changes that added the "version" prop were not being included in this title editing path. 