### PR TITLE
[BUG FIX] Relax purpose constraint on selections

### DIFF
--- a/lib/oli/activities/realizer/selection.ex
+++ b/lib/oli/activities/realizer/selection.ex
@@ -23,9 +23,11 @@ defmodule Oli.Activities.Realizer.Selection do
           type: String.t()
         }
 
-  def parse(%{"count" => count, "id" => id, "logic" => logic, "purpose" => purpose}) do
+  def parse(%{"count" => count, "id" => id, "logic" => logic} = json) do
     case Logic.parse(logic) do
       {:ok, logic} ->
+        purpose = Map.get(json, "purpose", "none")
+
         {:ok, %Selection{id: id, count: count, logic: logic, purpose: purpose, type: "selection"}}
 
       e ->

--- a/priv/schemas/v0-1-0/activity-bank-selection.schema.json
+++ b/priv/schemas/v0-1-0/activity-bank-selection.schema.json
@@ -18,21 +18,10 @@
       "type": "integer"
     },
     "purpose": {
-      "enum": [
-        "none",
-        "checkpoint",
-        "didigetthis",
-        "learnbydoing"
-      ]
+      "enum": ["none", "checkpoint", "didigetthis", "learnbydoing"]
     }
   },
-  "required": [
-    "type",
-    "id",
-    "logic",
-    "count",
-    "purpose"
-  ],
+  "required": ["type", "id", "logic", "count"],
   "$defs": {
     "logic": {
       "type": "object",
@@ -56,39 +45,22 @@
       "type": "object",
       "properties": {
         "fact": {
-          "enum": [
-            "objectives",
-            "tags",
-            "text",
-            "type"
-          ]
+          "enum": ["objectives", "tags", "text", "type"]
         },
         "operator": {
-          "enum": [
-            "contains",
-            "does_not_contain",
-            "equals",
-            "does_not_equal"
-          ]
+          "enum": ["contains", "does_not_contain", "equals", "does_not_equal"]
         },
         "value": {
           "$ref": "#/$defs/value"
         }
       },
-      "required": [
-        "fact",
-        "operator",
-        "value"
-      ]
+      "required": ["fact", "operator", "value"]
     },
     "clause": {
       "type": "object",
       "properties": {
         "operator": {
-          "enum": [
-            "all",
-            "any"
-          ]
+          "enum": ["all", "any"]
         },
         "children": {
           "oneOf": [
@@ -107,10 +79,7 @@
           ]
         }
       },
-      "required": [
-        "operator",
-        "children"
-      ]
+      "required": ["operator", "children"]
     },
     "value": {
       "anyOf": [


### PR DESCRIPTION
This PR fixes a problem where one cannot edit selections, due to purpose type being required. 

I've also allowed purpose type to be missing from the server perspective when it attempts to parse an existing one. 

