### PR TITLE
[ENHANCEMENT] Improve styling of learning objectives portion of delivery page

### DIFF
--- a/assets/styles/delivery/page_delivery/page.scss
+++ b/assets/styles/delivery/page_delivery/page.scss
@@ -104,9 +104,14 @@ h1.title {
 .rolled-up-objectives {
   margin: 10px;
   margin-top: 20px;
+  padding: 10px;
+  background-color: $objectives-background;
+  color: $objectives-text;
+  border-radius: 3px;
 
   .label {
     font-size: 1.2em;
+    font-weight: 600;
   }
   .title {
     font-size: 1.1em;

--- a/assets/styles/themes/delivery/default.scss
+++ b/assets/styles/themes/delivery/default.scss
@@ -41,6 +41,9 @@ html.authoring .content-block .delivery {
   $body-bg: $white;
   $body-color: $gray-900;
 
+  $objectives-text: black;
+  $objectives-background: hsl(178, 70%, 79%);
+
   // Auth providers buttons
 
   $google-button-background-color: $white;
@@ -262,6 +265,9 @@ html.authoring.dark .content-block .delivery {
 
   $hints-color: $gray-200;
   $hints-bg: $gray-700;
+
+  $objectives-text: white;
+  $objectives-background: hsl(178, 64%, 27%);
 
   // Auth providers buttons
 


### PR DESCRIPTION
Closes #2631 

This PR improves light and dark mode styling of the LO section at the top of a page.  

Sample screen shot of this styling:

<img width="1260" alt="Screen Shot 2022-06-15 at 7 49 22 AM" src="https://user-images.githubusercontent.com/7431756/173820657-61546e0e-50b6-40c1-bb38-e534ce085033.png">

