### PR TITLE
[BUG FIX] Adjust contrast of outline toggle

### DIFF
--- a/assets/src/components/resource/editors/ContentOutline.modules.scss
+++ b/assets/src/components/resource/editors/ContentOutline.modules.scss
@@ -32,7 +32,7 @@
   .contentOutlineToggleButton {
     width: 30px;
     height: 30px;
-    color: authoring.$gray-600;
+    color: authoring.$body-color;
     font-size: 16px;
     font-weight: 800;
     border: 2px solid authoring.$gray-400;


### PR DESCRIPTION
Closes #2542 

Adjusts the contrast of the innermost portion of the outline toggle button, making it black in light mode, and white in dark mode.  

<img width="846" alt="Screen Shot 2022-06-15 at 8 03 39 AM" src="https://user-images.githubusercontent.com/7431756/173822822-dd03a6b3-3136-4d26-8ccf-99d4b127802c.png">

