### PR TITLE
[ENHANCEMENT] introduce activity type visibility

### DIFF
--- a/lib/oli/activities/activity_registration.ex
+++ b/lib/oli/activities/activity_registration.ex
@@ -13,6 +13,7 @@ defmodule Oli.Activities.ActivityRegistration do
     field :title, :string
     field :allow_client_evaluation, :boolean, default: false
     field :globally_available, :boolean, default: false
+    field :globally_visible, :boolean, default: true
 
     many_to_many :projects, Oli.Authoring.Course.Project,
       join_through: Oli.Activities.ActivityRegistrationProject
@@ -33,7 +34,8 @@ defmodule Oli.Activities.ActivityRegistration do
       :delivery_script,
       :authoring_script,
       :allow_client_evaluation,
-      :globally_available
+      :globally_available,
+      :globally_visible
     ])
     |> validate_required([
       :slug,

--- a/lib/oli_web/controllers/activity_manage_controller.ex
+++ b/lib/oli_web/controllers/activity_manage_controller.ex
@@ -50,6 +50,36 @@ defmodule OliWeb.ActivityManageController do
     end
   end
 
+  def make_globally_visible(conn, %{"activity_slug" => activity_slug}) do
+    case Activities.set_global_visibility(activity_slug, true) do
+      {:ok, _} ->
+        redirect(conn, to: Routes.activity_manage_path(conn, :index))
+
+      {:error, message} ->
+        conn
+        |> put_flash(
+          :error,
+          "We couldn't switch registered activity to globally visible. #{message}"
+        )
+        |> redirect(to: Routes.activity_manage_path(conn, :index))
+    end
+  end
+
+  def make_admin_visible(conn, %{"activity_slug" => activity_slug}) do
+    case Activities.set_global_visibility(activity_slug, false) do
+      {:ok, _} ->
+        redirect(conn, to: Routes.activity_manage_path(conn, :index))
+
+      {:error, message} ->
+        conn
+        |> put_flash(
+          :error,
+          "We couldn't switch registered activity to admin only visible. #{message}"
+        )
+        |> redirect(to: Routes.activity_manage_path(conn, :index))
+    end
+  end
+
   def root_breadcrumbs() do
     OliWeb.Admin.AdminView.breadcrumb() ++
       [

--- a/lib/oli_web/controllers/project_controller.ex
+++ b/lib/oli_web/controllers/project_controller.ex
@@ -17,6 +17,9 @@ defmodule OliWeb.ProjectController do
   def overview(conn, project_params) do
     project = conn.assigns.project
 
+    author = conn.assigns[:current_author]
+    is_admin? = Accounts.is_admin?(author)
+
     latest_published_publication =
       Publishing.get_latest_published_publication_by_slug(project.slug)
 
@@ -24,7 +27,7 @@ defmodule OliWeb.ProjectController do
       breadcrumbs: [Breadcrumb.new(%{full_title: "Project Overview"})],
       active: :overview,
       collaborators: Accounts.project_authors(project),
-      activities_enabled: Activities.advanced_activities(project),
+      activities_enabled: Activities.advanced_activities(project, is_admin?),
       changeset:
         Utils.value_or(
           Map.get(project_params, :changeset),
@@ -169,6 +172,9 @@ defmodule OliWeb.ProjectController do
   def update(conn, %{"project" => project_params}) do
     project = conn.assigns.project
 
+    author = conn.assigns[:current_author]
+    is_admin? = Accounts.is_admin?(author)
+
     case Course.update_project(project, project_params) do
       {:ok, project} ->
         conn
@@ -180,7 +186,7 @@ defmodule OliWeb.ProjectController do
           breadcrumbs: [Breadcrumb.new(%{full_title: "Project Overview"})],
           active: :overview,
           collaborators: Accounts.project_authors(project),
-          activities_enabled: Activities.advanced_activities(project),
+          activities_enabled: Activities.advanced_activities(project, is_admin?),
           changeset: changeset,
           latest_published_publication:
             Publishing.get_latest_published_publication_by_slug(project.slug),
@@ -243,6 +249,9 @@ defmodule OliWeb.ProjectController do
   end
 
   defp delete_project(conn, project) do
+    author = conn.assigns[:current_author]
+    is_admin? = Accounts.is_admin?(author)
+
     case Course.update_project(project, %{status: :deleted}) do
       {:ok, _project} ->
         conn
@@ -253,7 +262,7 @@ defmodule OliWeb.ProjectController do
           breadcrumbs: [Breadcrumb.new(%{full_title: "Project Overview"})],
           active: :overview,
           collaborators: Accounts.project_authors(project),
-          activities_enabled: Activities.advanced_activities(project),
+          activities_enabled: Activities.advanced_activities(project, is_admin?),
           changeset: changeset,
           latest_published_publication:
             Publishing.get_latest_published_publication_by_slug(project.slug),

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -59,7 +59,11 @@ defmodule OliWeb.Router do
 
   pipeline :authoring do
     plug(Oli.Plugs.SetDefaultPow, :author)
-    plug(PowPersistentSession.Plug.Cookie, persistent_session_cookie_key: @author_persistent_session_cookie_key)
+
+    plug(PowPersistentSession.Plug.Cookie,
+      persistent_session_cookie_key: @author_persistent_session_cookie_key
+    )
+
     plug(Oli.Plugs.SetCurrentUser)
 
     # Disable caching of resources in authoring
@@ -68,7 +72,11 @@ defmodule OliWeb.Router do
 
   pipeline :delivery do
     plug(Oli.Plugs.SetDefaultPow, :user)
-    plug(PowPersistentSession.Plug.Cookie, persistent_session_cookie_key: @user_persistent_session_cookie_key)
+
+    plug(PowPersistentSession.Plug.Cookie,
+      persistent_session_cookie_key: @user_persistent_session_cookie_key
+    )
+
     plug(Oli.Plugs.SetCurrentUser)
   end
 
@@ -860,8 +868,20 @@ defmodule OliWeb.Router do
     live("/api_keys", ApiKeys.ApiKeysLive)
     live("/products", Products.ProductsView)
     live("/products/:product_id/discounts", Products.Payments.Discounts.ProductsIndexView)
-    live("/products/:product_id/discounts/new", Products.Payments.Discounts.ShowView, :product_new, as: :discount)
-    live("/products/:product_id/discounts/:discount_id", Products.Payments.Discounts.ShowView, :product, as: :discount)
+
+    live(
+      "/products/:product_id/discounts/new",
+      Products.Payments.Discounts.ShowView,
+      :product_new,
+      as: :discount
+    )
+
+    live(
+      "/products/:product_id/discounts/:discount_id",
+      Products.Payments.Discounts.ShowView,
+      :product,
+      as: :discount
+    )
 
     # Section Management (+ Open and Free)
     live("/sections", Sections.SectionsView)
@@ -871,7 +891,13 @@ defmodule OliWeb.Router do
 
     # Institutions, LTI Registrations and Deployments
     resources("/institutions", InstitutionController)
-    live("/institutions/:institution_id/discount", Products.Payments.Discounts.ShowView, :institution, as: :discount)
+
+    live(
+      "/institutions/:institution_id/discount",
+      Products.Payments.Discounts.ShowView,
+      :institution,
+      as: :discount
+    )
 
     live("/registrations", Admin.RegistrationsView)
 
@@ -900,6 +926,18 @@ defmodule OliWeb.Router do
     get("/manage_activities", ActivityManageController, :index)
     put("/manage_activities/make_global/:activity_slug", ActivityManageController, :make_global)
     put("/manage_activities/make_private/:activity_slug", ActivityManageController, :make_private)
+
+    put(
+      "/manage_activities/make_globally_visible/:activity_slug",
+      ActivityManageController,
+      :make_globally_visible
+    )
+
+    put(
+      "/manage_activities/make_admin_visible/:activity_slug",
+      ActivityManageController,
+      :make_admin_visible
+    )
 
     # Branding
     resources("/brands", BrandController)

--- a/lib/oli_web/templates/activity_manage/index.html.eex
+++ b/lib/oli_web/templates/activity_manage/index.html.eex
@@ -8,8 +8,21 @@
             <th>Title</th>
             <th>Slug</th>
             <th>Description</th>
-            <th>Eval Method</th>
-            <th>Global</th>
+            <th>
+              <span data-toggle="tooltip" data-placement="top" title="Where this activity performs attempt evaluation. This is configurable only within the activity implementation.">
+                Eval Method
+              </span>
+            </th>
+            <th>
+              <span data-toggle="tooltip" data-placement="top" title="Determines whether the activity type is automatically available to all projects or whether an author must opt-in to having access to it">
+                Availability
+              </span>
+            </th>
+            <th>
+              <span data-toggle="tooltip" data-placement="top" title="Determines which users the activity type is visible to as a choice in a project">
+                Visibiilty
+              </span>
+            </th>
             <th></th>
           </tr>
         </thead>
@@ -20,13 +33,31 @@
               <td><%= "#{activity.slug}"%></td>
               <td><%= "#{activity.description}"%></td>
               <td><%= "#{if activity.allow_client_evaluation do "Client" else "Server" end}"%></td>
-              <td><%= "#{activity.globally_available}"%></td>
+              <td><%= "#{if activity.globally_available do "Global" else "Opt-In" end}"%></td>
+              <td><%= "#{if activity.globally_visible do "All Users" else "Admins only" end}"%></td>
               <td>
-                <%= if activity.globally_available do %>
-                  <%= link "Make Private", to: Routes.activity_manage_path(@conn, :make_private, activity.slug), method: :put, class: "text-danger" %>
-                <% else %>
-                  <%= link "Make Global", to: Routes.activity_manage_path(@conn, :make_global,activity.slug), method: :put, class: "text-success" %>
-                <% end %>
+                <div class="btn-group">
+                  <button type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    Actions
+                  </button>
+                  <div class="dropdown-menu">
+                    <h6 class="dropdown-header">Change Availability</h6>
+                    <%= if activity.globally_available do %>
+                      <%= link "Change to 'Opt-In'", class: "dropdown-item", to: Routes.activity_manage_path(@conn, :make_private, activity.slug), method: :put, class: "text-danger" %>
+                    <% else %>
+                      <%= link "Change to 'Global'", class: "dropdown-item", to: Routes.activity_manage_path(@conn, :make_global, activity.slug), method: :put, class: "text-success" %>
+                    <% end %>
+
+                    <div class="dropdown-divider"></div>
+
+                    <h6 class="dropdown-header">Change Visibility</h6>
+                    <%= if activity.globally_visible do %>
+                      <%= link "Change to 'Admins Only'", class: "dropdown-item", to: Routes.activity_manage_path(@conn, :make_admin_visible, activity.slug), method: :put, class: "text-danger" %>
+                    <% else %>
+                      <%= link "Change to 'All Users'", class: "dropdown-item", to: Routes.activity_manage_path(@conn, :make_globally_visible, activity.slug), method: :put, class: "text-success" %>
+                    <% end %>
+                  </div>
+                </div>
               </td>
             </tr>
           <% end %>

--- a/priv/repo/migrations/20220615133201_add_global_visibility.exs
+++ b/priv/repo/migrations/20220615133201_add_global_visibility.exs
@@ -1,0 +1,13 @@
+defmodule Oli.Repo.Migrations.AddGlobalVisibility do
+  use Ecto.Migration
+
+  def change do
+    alter table(:activity_registrations) do
+      add :globally_visible, :boolean, null: false, default: true
+    end
+
+    flush()
+
+    execute "UPDATE activity_registrations SET globally_visible = true;"
+  end
+end


### PR DESCRIPTION
Closes #2632 

This PR introduces a new "Global Visibility" flag for registered activities.  This boolean controls whether or not an activity type is visible to all authors (aka "globally visible") from the list of "Advanced Activities" in an author's Project Overview.  If set to `false` the activity will only be visible to admins. 

With this mechanism, we can hide the "Adaptive Activity", the "OLI Embedded" for all courses.  We can also hide "Image Coding" activity, but allow an admin to perform the "opt-in" and change the availability on a case by case basis.

