### PR TITLE
[ENHANCEMENT] orient toolbar vertically

### DIFF
--- a/assets/src/components/editing/editor/Editor.tsx
+++ b/assets/src/components/editing/editor/Editor.tsx
@@ -113,7 +113,11 @@ export const Editor: React.FC<EditorProps> = React.memo((props: EditorProps) => 
       >
         {props.children}
 
-        <EditorToolbar context={props.commandContext} insertOptions={props.toolbarInsertDescs} />
+        <EditorToolbar
+          orientation="vertical"
+          context={props.commandContext}
+          insertOptions={props.toolbarInsertDescs}
+        />
 
         <Editable
           style={props.style}

--- a/assets/src/components/editing/elements/cite/CiteElement.tsx
+++ b/assets/src/components/editing/elements/cite/CiteElement.tsx
@@ -76,7 +76,7 @@ export const CiteEditor = (props: Props) => {
         position="bottom"
         align="start"
         content={
-          <Toolbar context={props.commandContext}>
+          <Toolbar context={props.commandContext} orientation={'horizontal'}>
             <Toolbar.Group>
               <CommandButton
                 description={createButtonCommandDesc({

--- a/assets/src/components/editing/elements/image/ImageSettings.tsx
+++ b/assets/src/components/editing/elements/image/ImageSettings.tsx
@@ -17,7 +17,7 @@ interface SettingsProps {
 }
 export const ImageSettings = (props: SettingsProps) => {
   return (
-    <Toolbar context={props.commandContext}>
+    <Toolbar context={props.commandContext} orientation="horizontal">
       <Toolbar.Group>
         <SelectImageButton model={props.model} onEdit={props.onEdit} />
       </Toolbar.Group>

--- a/assets/src/components/editing/elements/inputref/InputrefElement.tsx
+++ b/assets/src/components/editing/elements/inputref/InputrefElement.tsx
@@ -67,7 +67,7 @@ export const InputRefEditor = (props: InputRefProps) => {
     >
       <HoverContainer
         content={
-          <Toolbar context={props.commandContext}>
+          <Toolbar context={props.commandContext} orientation="horizontal">
             <Toolbar.Group>
               {initCommands(input, inputRefContext.setInputType).map((desc, i) => (
                 <CommandButton description={desc} key={i} />

--- a/assets/src/components/editing/elements/link/LinkElement.tsx
+++ b/assets/src/components/editing/elements/link/LinkElement.tsx
@@ -50,7 +50,7 @@ interface SettingsProps {
 }
 const Settings = (props: SettingsProps) => {
   return (
-    <Toolbar context={props.commandContext}>
+    <Toolbar context={props.commandContext} orientation="horizontal">
       <Toolbar.Group>
         <SettingsButton
           model={props.model}

--- a/assets/src/components/editing/elements/popup/PopupElement.tsx
+++ b/assets/src/components/editing/elements/popup/PopupElement.tsx
@@ -60,7 +60,7 @@ export const PopupEditor = (props: Props) => {
       align="start"
       isOpen={isOpen}
       content={
-        <Toolbar context={props.commandContext}>
+        <Toolbar context={props.commandContext} orientation="horizontal">
           <Toolbar.Group>
             <CommandButton
               description={createButtonCommandDesc({

--- a/assets/src/components/editing/elements/webpage/WebpageSettings.tsx
+++ b/assets/src/components/editing/elements/webpage/WebpageSettings.tsx
@@ -15,7 +15,7 @@ interface SettingsProps {
 }
 export const WebpageSettings = (props: SettingsProps) => {
   return (
-    <Toolbar context={props.commandContext}>
+    <Toolbar context={props.commandContext} orientation="horizontal">
       <Toolbar.Group>
         <CommandButton
           description={createButtonCommandDesc({

--- a/assets/src/components/editing/elements/youtube/YoutubeElement.tsx
+++ b/assets/src/components/editing/elements/youtube/YoutubeElement.tsx
@@ -98,7 +98,7 @@ interface SettingsProps {
 }
 const Settings = (props: SettingsProps) => {
   return (
-    <Toolbar context={props.commandContext}>
+    <Toolbar context={props.commandContext} orientation="horizontal">
       <Toolbar.Group>
         <CommandButton
           description={createButtonCommandDesc({

--- a/assets/src/components/editing/toolbar/Toolbar.tsx
+++ b/assets/src/components/editing/toolbar/Toolbar.tsx
@@ -4,6 +4,7 @@ import { ToolbarContext, ToolbarContextT } from 'components/editing/toolbar/hook
 
 interface Props {
   context: CommandContext;
+  orientation: 'vertical' | 'horizontal';
 }
 export const Toolbar = (props: PropsWithChildren<Props>) => {
   const [submenu, setSubmenu] = React.useState<React.MutableRefObject<HTMLButtonElement> | null>(
@@ -22,7 +23,7 @@ export const Toolbar = (props: PropsWithChildren<Props>) => {
 
   return (
     <ToolbarContext.Provider value={context}>
-      <div className="editorToolbar">{props.children}</div>
+      <div className={'editorToolbar__' + props.orientation}>{props.children}</div>
     </ToolbarContext.Provider>
   );
 };
@@ -32,3 +33,8 @@ const Group = (props: PropsWithChildren<GroupProps>) => (
   <div className="editorToolbar__group">{props.children}</div>
 );
 Toolbar.Group = Group;
+
+const VerticalGroup = (props: PropsWithChildren<GroupProps>) => (
+  <div className="editorToolbar__verticalGroup">{props.children}</div>
+);
+Toolbar.VerticalGroup = VerticalGroup;

--- a/assets/src/components/editing/toolbar/buttons/DropdownButton.tsx
+++ b/assets/src/components/editing/toolbar/buttons/DropdownButton.tsx
@@ -30,7 +30,7 @@ export const DropdownButton = (props: PropsWithChildren<Props>) => {
       onClickOutside={toolbar.closeSubmenus}
       isOpen={isOpen}
       padding={8}
-      positions={['bottom']}
+      positions={['right']}
       reposition={true}
       align={'start'}
       content={<div className="editorToolbar__dropdownGroup">{props.children}</div>}

--- a/assets/src/components/editing/toolbar/editorToolbar/EditorToolbar.tsx
+++ b/assets/src/components/editing/toolbar/editorToolbar/EditorToolbar.tsx
@@ -16,6 +16,7 @@ import { BlockSettings } from 'components/editing/toolbar/editorToolbar/blocks/B
 interface Props {
   context: CommandContext;
   insertOptions: CommandDescription[];
+  orientation: 'horizontal' | 'vertical';
 }
 export const EditorToolbar = (props: Props) => {
   const editor = useSlate();
@@ -23,7 +24,7 @@ export const EditorToolbar = (props: Props) => {
   return (
     <HoverContainer
       isOpen={isOpen}
-      position="top"
+      position="left"
       align="start"
       relativeTo={() =>
         getHighestTopLevel(editor)
@@ -31,7 +32,7 @@ export const EditorToolbar = (props: Props) => {
           .valueOr<any>(undefined)
       }
       content={
-        <Toolbar context={props.context}>
+        <Toolbar context={props.context} orientation={props.orientation}>
           <BlockToggle blockInsertOptions={props.insertOptions} />
           <BlockSettings />
           <Inlines />

--- a/assets/src/components/editing/toolbar/editorToolbar/Inlines.tsx
+++ b/assets/src/components/editing/toolbar/editorToolbar/Inlines.tsx
@@ -24,20 +24,20 @@ export const Inlines = (_props: Props) => {
   const moreInlineOptions = additionalFormattingOptions.concat(inlineInsertions);
 
   const seeMoreInlineOptions = createButtonCommandDesc({
-    icon: 'expand_more',
+    icon: 'more_horiz',
     description: 'More',
     execute: () => {},
     active: (e) => moreInlineOptions.some(({ active }) => active?.(e)),
   });
 
   return (
-    <Toolbar.Group>
+    <Toolbar.VerticalGroup>
       {basicFormattingOptions}
       <DropdownButton description={seeMoreInlineOptions}>
         {moreInlineOptions.map((desc, i) => (
           <DescriptiveButton key={i} description={desc} />
         ))}
       </DropdownButton>
-    </Toolbar.Group>
+    </Toolbar.VerticalGroup>
   );
 };

--- a/assets/src/components/editing/toolbar/editorToolbar/blocks/BlockInsertMenu.tsx
+++ b/assets/src/components/editing/toolbar/editorToolbar/blocks/BlockInsertMenu.tsx
@@ -21,7 +21,7 @@ export const BlockInsertMenu = ({ blockInsertOptions }: Props) => {
   if (blockInsertOptions.length === 0) return null;
 
   return (
-    <Toolbar.Group>
+    <Toolbar.VerticalGroup>
       <DropdownButton description={insertItemDropdown}>
         {blockInsertOptions
           .filter((desc) => desc.command.precondition(editor))
@@ -29,6 +29,6 @@ export const BlockInsertMenu = ({ blockInsertOptions }: Props) => {
             <DescriptiveButton key={i} description={desc} />
           ))}
       </DropdownButton>
-    </Toolbar.Group>
+    </Toolbar.VerticalGroup>
   );
 };

--- a/assets/src/components/editing/toolbar/editorToolbar/blocks/BlockSettings.tsx
+++ b/assets/src/components/editing/toolbar/editorToolbar/blocks/BlockSettings.tsx
@@ -27,7 +27,10 @@ export const BlockSettings = (_props: BlockSettingProps) => {
     'Code (Block)': CodeBlock,
   };
 
-  return <Toolbar.Group>{component[type]}</Toolbar.Group>;
+  if (component[type] !== undefined) {
+    return <Toolbar.VerticalGroup>{(component[type] as any)()}</Toolbar.VerticalGroup>;
+  }
+  return null;
 };
 
 function List() {

--- a/assets/src/components/editing/toolbar/editorToolbar/blocks/BlockToggle.tsx
+++ b/assets/src/components/editing/toolbar/editorToolbar/blocks/BlockToggle.tsx
@@ -21,7 +21,7 @@ export const BlockToggle = ({ blockInsertOptions }: BlockToggleProps) => {
 
   if (blockInsertOptions.length === 0) return null;
   return (
-    <Toolbar.Group>
+    <Toolbar.VerticalGroup>
       <DropdownButton description={activeBlockDesc}>
         {toggleTextTypes
           .filter((type) => !type.active?.(editor))
@@ -29,6 +29,6 @@ export const BlockToggle = ({ blockInsertOptions }: BlockToggleProps) => {
             <DescriptiveButton key={i} description={desc} />
           ))}
       </DropdownButton>
-    </Toolbar.Group>
+    </Toolbar.VerticalGroup>
   );
 };

--- a/assets/styles/authoring/toolbar.scss
+++ b/assets/styles/authoring/toolbar.scss
@@ -6,14 +6,27 @@
 
 .editorToolbar {
   display: inline-flex;
-  border-top: 1px solid black;
-  border-bottom: 1px solid black;
+
   background: white;
+
+  &__horizontal {
+    flex-direction: row;
+    display: inline-flex;
+    border-top: 1px solid black;
+    border-bottom: 1px solid black;
+  }
+  &__vertical {
+    flex-direction: column;
+    display: inline-flex;
+    border-right: 1px solid black;
+    border-left: 1px solid black;
+  }
 
   &__group {
     background: white;
     border-left: 1px solid black;
-
+    display: flex;
+    flex-direction: row;
     .editorToolbar__button:first-of-type,
     .editorToolbar__button:last-of-type {
       flex-basis: 42px;
@@ -21,6 +34,21 @@
   }
   &__group:last-of-type {
     border-right: 1px solid black;
+  }
+
+  &__verticalGroup {
+    background: white;
+    border-top: 1px solid black;
+
+    display: flex;
+    flex-direction: column;
+    .editorToolbar__button:first-of-type,
+    .editorToolbar__button:last-of-type {
+      flex-basis: 42px;
+    }
+  }
+  &__verticalGroup:last-of-type {
+    border-bottom: 1px solid black;
   }
 
   &__dropdownGroup {


### PR DESCRIPTION
Closes #2613 

This PR introduces vertical orientation support for the popup toolbar infrastructure.  It uses this vertical orientation for the core toolbar, so that when it appears it never hides user content. 

I also detected a bug and fixed the ability to show the "context specific" portion of the toolbar.  For Lists, Headings and CodeBlocks the toolbar was supposed to show more buttons for those items.  That now works again. 

![Screen Shot 2022-06-15 at 11 43 26 AM](https://user-images.githubusercontent.com/7431756/173869694-bd7fbfde-fb8c-422b-8cb1-b88d7c19a443.png)

