### PR TITLE
[ENHANCEMENT] provide more context in tab content

### DIFF
--- a/lib/oli_web/controllers/activity_bank_controller.ex
+++ b/lib/oli_web/controllers/activity_bank_controller.ex
@@ -25,7 +25,8 @@ defmodule OliWeb.ActivityBankController do
           breadcrumbs: [Breadcrumb.new(%{full_title: "Activity Bank"})],
           project_slug: project_slug,
           is_admin?: is_admin?,
-          scripts: Oli.Activities.get_activity_scripts()
+          scripts: Oli.Activities.get_activity_scripts(),
+          title: "Activity Bank | " <> conn.assigns.project.title
         )
 
       _ ->

--- a/lib/oli_web/controllers/project_controller.ex
+++ b/lib/oli_web/controllers/project_controller.ex
@@ -31,7 +31,8 @@ defmodule OliWeb.ProjectController do
           Project.changeset(project)
         ),
       latest_published_publication: latest_published_publication,
-      publishers: Inventories.list_publishers()
+      publishers: Inventories.list_publishers(),
+      title: "Overview | " <> project.title
     }
 
     render(%{conn | assigns: Map.merge(conn.assigns, params)}, "overview.html")
@@ -124,7 +125,8 @@ defmodule OliWeb.ProjectController do
       tool_url: tool_url,
       initiate_login_url: initiate_login_url,
       public_keyset_url: public_keyset_url,
-      redirect_uris: redirect_uris
+      redirect_uris: redirect_uris,
+      title: "Publish | " <> project.title
     )
   end
 
@@ -184,7 +186,8 @@ defmodule OliWeb.ProjectController do
           changeset: changeset,
           latest_published_publication:
             Publishing.get_latest_published_publication_by_slug(project.slug),
-          publishers: Inventories.list_publishers()
+          publishers: Inventories.list_publishers(),
+          title: "Overview | " <> project.title
         }
 
         conn
@@ -257,7 +260,8 @@ defmodule OliWeb.ProjectController do
           changeset: changeset,
           latest_published_publication:
             Publishing.get_latest_published_publication_by_slug(project.slug),
-          publishers: Inventories.list_publishers()
+          publishers: Inventories.list_publishers(),
+          title: "Overview | " <> project.title
         }
 
         conn

--- a/lib/oli_web/controllers/resource_controller.ex
+++ b/lib/oli_web/controllers/resource_controller.ex
@@ -78,7 +78,8 @@ defmodule OliWeb.ResourceController do
       revision_slug: revision_slug,
       activity_types: Activities.activities_for_project(project),
       part_component_types: PartComponents.part_components_for_project(project),
-      graded: context.graded
+      graded: context.graded,
+      title: "Edit | " <> context.title
     )
   end
 

--- a/lib/oli_web/live/curriculum/container/container_live.ex
+++ b/lib/oli_web/live/curriculum/container/container_live.ex
@@ -95,7 +95,8 @@ defmodule OliWeb.Curriculum.ContainerLive do
            modal: nil,
            resources_being_edited: get_resources_being_edited(container.children, project.id),
            numberings: Numbering.number_full_tree(Oli.Publishing.AuthoringResolver, project_slug),
-           dragging: nil
+           dragging: nil,
+           page_title: "Curriculum | " <> project.title
          )}
     end
   end
@@ -150,7 +151,7 @@ defmodule OliWeb.Curriculum.ContainerLive do
 
   defp apply_action(socket, :index, _params) do
     socket
-    |> assign(:page_title, "Curriculum")
+    |> assign(:page_title, "Curriculum | " <> socket.assigns.project.title)
     |> assign(:revision, nil)
   end
 

--- a/lib/oli_web/live/insights/insights.ex
+++ b/lib/oli_web/live/insights/insights.ex
@@ -25,7 +25,8 @@ defmodule OliWeb.Insights do
        selected: :by_activity,
        query: "",
        sort_by: "title",
-       sort_order: :asc
+       sort_order: :asc,
+       title: "Insights | " <> project.title
      )}
   end
 

--- a/lib/oli_web/live/objectives/objectives.ex
+++ b/lib/oli_web/live/objectives/objectives.ex
@@ -53,7 +53,8 @@ defmodule OliWeb.Objectives.Objectives do
        author: author,
        force_render: 0,
        can_delete?: true,
-       edit: :none
+       edit: :none,
+       title: "Objectives | " <> project.title
      )}
   end
 

--- a/lib/oli_web/live/products/products_view.ex
+++ b/lib/oli_web/live/products/products_view.ex
@@ -79,17 +79,25 @@ defmodule OliWeb.Products.ProductsView do
     project = Course.get_project_by_slug(project_slug)
     products = Blueprint.list_for_project(project)
 
-    mount_as(author, false, products, project, breadcrumb([]), socket)
+    mount_as(
+      author,
+      false,
+      products,
+      project,
+      breadcrumb([]),
+      "Products | " <> project.title,
+      socket
+    )
   end
 
   def mount(_, %{"current_author_id" => author_id}, socket) do
     author = Repo.get(Author, author_id)
 
     products = Blueprint.list()
-    mount_as(author, true, products, nil, admin_breadcrumbs(), socket)
+    mount_as(author, true, products, nil, admin_breadcrumbs(), "Products", socket)
   end
 
-  defp mount_as(author, is_admin_view, products, project, breadcrumbs, socket) do
+  defp mount_as(author, is_admin_view, products, project, breadcrumbs, title, socket) do
     total_count = length(products)
 
     {:ok, table_model} = OliWeb.Products.ProductsTableModel.new(products)
@@ -102,7 +110,8 @@ defmodule OliWeb.Products.ProductsView do
        project: project,
        products: products,
        total_count: total_count,
-       table_model: table_model
+       table_model: table_model,
+       title: title
      )}
   end
 
@@ -140,9 +149,9 @@ defmodule OliWeb.Products.ProductsView do
     case Blueprint.create_blueprint(socket.assigns.project.slug, socket.assigns.creation_title) do
       {:ok, blueprint} ->
         {:noreply,
-          socket
-          |> put_flash(:info, "Product successfully created.")
-          |> redirect(to: Routes.live_path(socket, OliWeb.Products.DetailsView, blueprint.slug))}
+         socket
+         |> put_flash(:info, "Product successfully created.")
+         |> redirect(to: Routes.live_path(socket, OliWeb.Products.DetailsView, blueprint.slug))}
 
       {:error, _} ->
         {:noreply, put_flash(socket, :error, "Could not create product")}

--- a/lib/oli_web/live/qa/state.ex
+++ b/lib/oli_web/live/qa/state.ex
@@ -60,7 +60,8 @@ defmodule OliWeb.Qa.State do
         [
           project: project,
           author: author,
-          context: context
+          context: context,
+          title: "Review | " <> project.title
         ],
         new_review_ran(@default_state, initial_review)
       )


### PR DESCRIPTION
Closes #2626 

This PR sets the `<head><title/></head>` with text that provides more context, so that browser tabs can be more easily navigable.  

Prior to this change, the following screens used text:

Project Overview: OLI Torus
Objectives: OLI Torus
Activity Bank: OLI Torus
Curriculum: Curriculum
Editing a page: OLI Torus
Review: OLI Torus
Products: Products
Publish: OLI Torus
Insights: OLI Torus

After this change, these use:

Project Overview: Overview | Project Title
Objectives: Objectives | Project Title
Activity Bank: Activity Bank | Project Title
Curriculum: Curriculum | Project Title
Editing a page: Edit | Page Title
Review: Review | Project Title
Products: Products | Project Title
Publish: Publish | Project Title
Insights: Insights | Project Title

