### PR TITLE
[ENHANCEMENT] Improve lo dropdown

### DIFF
--- a/assets/src/components/resource/objectives/ObjectivesSelection.tsx
+++ b/assets/src/components/resource/objectives/ObjectivesSelection.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import * as Immutable from 'immutable';
 import {
+  Token,
   Typeahead,
   TypeaheadResult,
   TypeaheadMenuProps,
@@ -73,31 +74,16 @@ export const ObjectivesSelection = (props: ObjectivesProps) => {
     setById(createMapById(objectives));
   }, [objectives]);
 
-  // Custom menu item renderer fn for the Typeahead, so that we can render
-  // a checkbox indicating selected state and the parent label for child objectives
   const renderMenuItemChildren = (
     option: TypeaheadResult<Objective>,
     _props: TypeaheadMenuProps<Objective>,
     _index: number,
   ) => {
-    const buildCombinedTitle = (parent: string, child: string) => {
-      return (
-        <>
-          {withEllipse(parent)}
-          <span className="ml-2 mr-2">
-            <strong>/</strong>
-          </span>
-          {withEllipse(child)}
-        </>
-      );
-    };
-
     return (
       <div>
+        {option.parentId !== null ? <span className="ml-3">&nbsp;</span> : null}
         <input className="mr-2" type="checkbox" readOnly checked={allSelected[option.id]}></input>
-        {option.parentId === null
-          ? option.title
-          : buildCombinedTitle(byId[option.parentId].title, option.title)}
+        {option.title}
       </div>
     );
   };

--- a/assets/src/components/resource/objectives/ObjectivesSelection.tsx
+++ b/assets/src/components/resource/objectives/ObjectivesSelection.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import * as Immutable from 'immutable';
 import {
-  Token,
   Typeahead,
   TypeaheadResult,
   TypeaheadMenuProps,
@@ -22,18 +21,6 @@ export type ObjectivesProps = {
   projectSlug: ProjectSlug;
   onEdit: (objectives: ResourceId[]) => void;
   onRegisterNewObjective: (objective: Objective) => void;
-};
-
-const MAX_LENGTH = 40;
-
-const withEllipse = (label: string) => {
-  return label.length > MAX_LENGTH ? (
-    <span data-toggle="tooltip" data-placement="top" title={label}>
-      {label.substring(0, MAX_LENGTH - 3) + '...'}
-    </span>
-  ) : (
-    <span>{label}</span>
-  );
 };
 
 // Custom filterBy function for the Typeahead. This allows searches to


### PR DESCRIPTION
This PR makes another incremental improvement in the learning objectives picker.  It indents the child objectives, thus removing the need to display the parent label within the child (which is removed also).

The net gain is a much more "tree-like" display:

![Screen Shot 2022-06-16 at 1 04 34 PM](https://user-images.githubusercontent.com/7431756/174126748-541825e2-cbfa-448e-ac71-777b437a78dd.png)

