### PR TITLE
[MER-1223] Improve publishing a project waiting time

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -109,6 +109,9 @@ config :oli, OliWeb.Endpoint,
 # configured to run both http and https servers on
 # different ports.
 
+# Config adapter for refreshing part_mapping
+config :oli, Oli.Publishing, refresh_adapter: Oli.Publishing.PartMappingRefreshAsync
+
 # Watch static and templates for browser reloading.
 config :oli, OliWeb.Endpoint,
   live_reload: [

--- a/config/test.exs
+++ b/config/test.exs
@@ -56,6 +56,9 @@ config :oli, OliWeb.Endpoint,
   http: [port: 4002],
   server: false
 
+# Config adapter for refreshing part_mapping
+config :oli, Oli.Publishing, refresh_adapter: Oli.PublishingTest.PartMappingMockAdapter
+
 # Print only warnings and errors during test
 config :logger, level: :warn
 

--- a/lib/oli/publishing.ex
+++ b/lib/oli/publishing.ex
@@ -1133,7 +1133,7 @@ defmodule Oli.Publishing do
 
   @doc """
     Refreshes the part_mapping materialized view.
-    Since this operation is expensive, do not use perform it synchrnously unless neccesary.
+    Since this operation is expensive, do not use perform it synchronously unless neccesary.
   """
   def refresh_part_mapping() do
     Repo.query("REFRESH MATERIALIZED VIEW CONCURRENTLY part_mapping")

--- a/lib/oli/publishing.ex
+++ b/lib/oli/publishing.ex
@@ -18,8 +18,6 @@ defmodule Oli.Publishing do
   alias Oli.Delivery.Sections.Blueprint
   alias Oli.Groups
 
-  require Logger
-
   @doc """
   Returns true if editing this revision requires the creation of a new revision first.
 
@@ -541,7 +539,8 @@ defmodule Oli.Publishing do
       {:error, %Ecto.Changeset{}}
   """
   def delete_publication(%Publication{} = publication) do
-    Repo.delete(publication)
+    publication
+      |> Repo.delete()
       |> refresh_adapter().maybe_refresh_part_mapping()
   end
 
@@ -1137,12 +1136,12 @@ defmodule Oli.Publishing do
   """
   def refresh_part_mapping() do
     Repo.query("REFRESH MATERIALIZED VIEW CONCURRENTLY part_mapping")
-    Logger.info("Refreshed part_mapping view")
   end
 
   @spec refresh_adapter() :: PartMappingRefreshAdapter
   defp refresh_adapter() do
-    Application.get_env(:oli, Oli.Publishing)
+    :oli
+      |> Application.get_env(Oli.Publishing)
       |> Keyword.get(:refresh_adapter, PartMappingRefreshAsync)
   end
 end

--- a/lib/oli/publishing/part_mapping_refresh_adapter.ex
+++ b/lib/oli/publishing/part_mapping_refresh_adapter.ex
@@ -1,0 +1,13 @@
+defmodule Oli.Publishing.PartMappingRefreshAdapter do
+  alias Oli.Publishing.Publication
+
+  @moduledoc """
+    Behaviour for spawning a function that freshes the part_mapping materialized view:
+  """
+
+  @doc """
+  Defines a callback to be used by refresh adapters
+  """
+  @callback maybe_refresh_part_mapping({:ok, %Publication{}} | {:error, %Ecto.Changeset{}}) ::
+              {:ok, %Publication{}} | {:error, %Ecto.Changeset{}}
+end

--- a/lib/oli/publishing/part_mapping_refresh_adapter.ex
+++ b/lib/oli/publishing/part_mapping_refresh_adapter.ex
@@ -5,9 +5,10 @@ defmodule Oli.Publishing.PartMappingRefreshAdapter do
     Behaviour for spawning a function that freshes the part_mapping materialized view:
   """
 
+  @type ecto_publication_operation :: {:ok, %Publication{}} | {:error, %Ecto.Changeset{}}
+
   @doc """
   Defines a callback to be used by refresh adapters
   """
-  @callback maybe_refresh_part_mapping({:ok, %Publication{}} | {:error, %Ecto.Changeset{}}) ::
-              {:ok, %Publication{}} | {:error, %Ecto.Changeset{}}
+  @callback maybe_refresh_part_mapping(ecto_publication_operation) :: ecto_publication_operation
 end

--- a/lib/oli/publishing/part_mapping_refresh_async.ex
+++ b/lib/oli/publishing/part_mapping_refresh_async.ex
@@ -1,11 +1,12 @@
 defmodule Oli.Publishing.PartMappingRefreshAsync do
-  alias Oli.Publishing.Publication
+  alias Oli.Publishing.PartMappingRefreshAdapter
 
-  @behaviour Oli.Publishing.PartMappingRefreshAdapter
+  @type ecto_publication_operation :: PartMappingRefreshAdapter.ecto_publication_operation
 
-  @impl Oli.Publishing.PartMappingRefreshAdapter
-  @spec maybe_refresh_part_mapping({:ok, %Publication{}} | {:error, %Ecto.Changeset{}}) ::
-          {:ok, %Publication{}} | {:error, %Ecto.Changeset{}}
+  @behaviour PartMappingRefreshAdapter
+
+  @impl PartMappingRefreshAdapter
+  @spec maybe_refresh_part_mapping(ecto_publication_operation) :: ecto_publication_operation
   def maybe_refresh_part_mapping({:ok, _publication} = operation_result) do
     Task.async(fn -> Oli.Publishing.refresh_part_mapping() end)
     operation_result

--- a/lib/oli/publishing/part_mapping_refresh_async.ex
+++ b/lib/oli/publishing/part_mapping_refresh_async.ex
@@ -1,0 +1,15 @@
+defmodule Oli.Publishing.PartMappingRefreshAsync do
+  alias Oli.Publishing.Publication
+
+  @behaviour Oli.Publishing.PartMappingRefreshAdapter
+
+  @impl Oli.Publishing.PartMappingRefreshAdapter
+  @spec maybe_refresh_part_mapping({:ok, %Publication{}} | {:error, %Ecto.Changeset{}}) ::
+          {:ok, %Publication{}} | {:error, %Ecto.Changeset{}}
+  def maybe_refresh_part_mapping({:ok, _publication} = operation_result) do
+    Task.async(fn -> Oli.Publishing.refresh_part_mapping() end)
+    operation_result
+  end
+
+  def maybe_refresh_part_mapping(result), do: result
+end

--- a/lib/oli/utils/db_seeder.ex
+++ b/lib/oli/utils/db_seeder.ex
@@ -729,12 +729,6 @@ defmodule Oli.Seeder do
       %Publication{published: nil} = p ->
         Oli.Publishing.update_publication(p, %{published: DateTime.utc_now()})
     end
-
-    query = """
-    REFRESH MATERIALIZED VIEW part_mapping;
-    """
-
-    Oli.Repo.query!(query, [])
   end
 
   defp create_published_resource(publication, resource, revision) do

--- a/priv/repo/migrations/20220615201219_remove_part_mapping_refresh_trigger.exs
+++ b/priv/repo/migrations/20220615201219_remove_part_mapping_refresh_trigger.exs
@@ -1,0 +1,81 @@
+defmodule Oli.Repo.Migrations.RemovePartMappingRefreshTrigger do
+  use Ecto.Migration
+
+  def up do
+    drop_trigger()
+  end
+
+  def down do
+    drop_trigger()
+
+    user = get_current_db_user()
+    create_trigger(user)
+    refresh_materialized_view()
+  end
+
+  def get_current_db_user() do
+    case System.get_env("DATABASE_URL", nil) do
+      nil -> "postgres"
+      url -> parse_user_from_db_url(url, "postgres")
+    end
+  end
+
+  def parse_user_from_db_url(url, default) do
+    case url do
+      "ecto://" <> rest ->
+        split = String.split(rest, ":")
+
+        case Enum.count(split) do
+          0 -> default
+          1 -> default
+          _ -> Enum.at(split, 0)
+        end
+
+      _ ->
+        default
+    end
+  end
+
+  def drop_trigger() do
+    execute """
+    DROP TRIGGER IF EXISTS published_resources_tr ON public.published_resources;
+    """
+
+    execute "DROP FUNCTION IF EXISTS public.refresh_part_mapping() CASCADE;"
+  end
+
+  def create_trigger(user) do
+    execute """
+    CREATE OR REPLACE FUNCTION public.refresh_part_mapping()
+        RETURNS trigger
+        LANGUAGE 'plpgsql'
+        COST 100
+        VOLATILE NOT LEAKPROOF
+    AS $BODY$
+    BEGIN
+        REFRESH MATERIALIZED VIEW CONCURRENTLY part_mapping;
+        RETURN NULL;
+    END;
+    $BODY$;
+    """
+
+    execute """
+    ALTER FUNCTION public.refresh_part_mapping()
+    OWNER TO #{user};
+    """
+
+    execute """
+    CREATE TRIGGER publications_tr
+        AFTER UPDATE OR DELETE
+        ON public.publications
+        FOR EACH STATEMENT
+        EXECUTE FUNCTION public.refresh_part_mapping();
+    """
+  end
+
+  def refresh_materialized_view() do
+    execute """
+    REFRESH MATERIALIZED VIEW part_mapping;
+    """
+  end
+end

--- a/test/oli/publishing_test.exs
+++ b/test/oli/publishing_test.exs
@@ -3,7 +3,6 @@ defmodule Oli.PublishingTest do
 
   import Oli.Factory
   import Ecto.Query
-  import ExUnit.CaptureLog
 
   alias Oli.Accounts.{SystemRole, Author}
   alias Oli.Authoring.{Course, Locks}
@@ -368,9 +367,7 @@ defmodule Oli.PublishingTest do
     test "publish_project/1 refreshes part_mapping materialized view with published information" do
       %{activity: %{revision: revision}, project: project} = project_with_activity()
 
-      capture_log(fn ->
-        Publishing.publish_project(project, "Some description")
-      end) =~ "Refreshed part_mapping view"
+      Publishing.publish_project(project, "Some description")
 
       assert Repo.all(from pm in "part_mapping",
       where: pm.revision_id == ^revision.id,

--- a/test/support/part_mapping_mock_adapter.ex
+++ b/test/support/part_mapping_mock_adapter.ex
@@ -1,20 +1,20 @@
 defmodule Oli.PublishingTest.PartMappingMockAdapter do
-  alias Oli.Publishing.Publication
+  alias Oli.Publishing.PartMappingRefreshAdapter
 
-  @behaviour Oli.Publishing.PartMappingRefreshAdapter
+  @type ecto_publication_operation :: PartMappingRefreshAdapter.ecto_publication_operation
+
+  @behaviour PartMappingRefreshAdapter
 
   @doc """
     Mock implementation of the refresh adapter,
     the refresh operation is ran synchronously to simplify testing
   """
-  @impl Oli.Publishing.PartMappingRefreshAdapter
-  @spec maybe_refresh_part_mapping({:ok, %Publication{}} | {:error, %Ecto.Changeset{}}) ::
-          {:ok, %Publication{}} | {:error, %Ecto.Changeset{}}
+  @impl PartMappingRefreshAdapter
+  @spec maybe_refresh_part_mapping(ecto_publication_operation) :: ecto_publication_operation
   def maybe_refresh_part_mapping({:ok, _publication} = operation_result) do
     Oli.Publishing.refresh_part_mapping()
     operation_result
   end
 
-  @impl Oli.Publishing.PartMappingRefreshAdapter
   def maybe_refresh_part_mapping(result), do: result
 end

--- a/test/support/part_mapping_mock_adapter.ex
+++ b/test/support/part_mapping_mock_adapter.ex
@@ -1,0 +1,20 @@
+defmodule Oli.PublishingTest.PartMappingMockAdapter do
+  alias Oli.Publishing.Publication
+
+  @behaviour Oli.Publishing.PartMappingRefreshAdapter
+
+  @doc """
+    Mock implementation of the refresh adapter,
+    the refresh operation is ran synchronously to simplify testing
+  """
+  @impl Oli.Publishing.PartMappingRefreshAdapter
+  @spec maybe_refresh_part_mapping({:ok, %Publication{}} | {:error, %Ecto.Changeset{}}) ::
+          {:ok, %Publication{}} | {:error, %Ecto.Changeset{}}
+  def maybe_refresh_part_mapping({:ok, _publication} = operation_result) do
+    Oli.Publishing.refresh_part_mapping()
+    operation_result
+  end
+
+  @impl Oli.Publishing.PartMappingRefreshAdapter
+  def maybe_refresh_part_mapping(result), do: result
+end


### PR DESCRIPTION
[MER-1223](https://eliterate.atlassian.net/browse/MER-1223)

### What does it change

- Reduces significantly the user wait time when publishing a project. The triggers that updated the `part_mapping` materialized view are dropped, in favor of running them asynchronously through spawning in elixir.
 
This does not completely fix the performance issue in regards to scaling optimizations, since the update will still occur and take the same database execution time. However we decided to fix that separately by tackling how we handle the revision content. 
The user wait time for a publication of a single new graded page goes down from ~ 4000ms to ~ 5ms when ran locally. 