### PR TITLE
[ENHANCEMENT] Improve UX for inserting new content items

### DIFF
--- a/assets/src/components/activities/adaptive/manifest.json
+++ b/assets/src/components/activities/adaptive/manifest.json
@@ -2,7 +2,9 @@
   "id": "oli_adaptive",
   "allowClientEvaluation": true,
   "friendlyName": "Adaptive Activity",
+  "petiteLabel": "Adaptive",
   "description": "Adaptive Activity",
+  "icon": "question-circle",
   "delivery": {
     "element": "oli-adaptive-delivery",
     "entry": "./delivery-entry.ts"

--- a/assets/src/components/activities/check_all_that_apply/manifest.json
+++ b/assets/src/components/activities/check_all_that_apply/manifest.json
@@ -1,8 +1,9 @@
 {
   "id": "oli_check_all_that_apply",
   "friendlyName": "Check All That Apply",
-  "description": "A traditional check all that apply question with one correct answer",
-  "icon": "check_box",
+  "petiteLabel": "CATA",
+  "description": "Choice-based question that allows multiple selections",
+  "icon": "list-alt",
   "delivery": {
     "element": "oli-check-all-that-apply-delivery",
     "entry": "./delivery-entry.ts"

--- a/assets/src/components/activities/file_upload/manifest.json
+++ b/assets/src/components/activities/file_upload/manifest.json
@@ -1,8 +1,9 @@
 {
   "id": "oli_file_upload",
   "friendlyName": "File Upload",
+  "petiteLabel": "Upload",
   "description": "A question that expects student submission via uploaded files",
-  "icon": "question_answer",
+  "icon": "file-upload",
   "delivery": {
     "element": "oli-file-upload-delivery",
     "entry": "./delivery-entry.ts"

--- a/assets/src/components/activities/image_coding/manifest.json
+++ b/assets/src/components/activities/image_coding/manifest.json
@@ -1,8 +1,9 @@
 {
   "id": "oli_image_coding",
   "friendlyName": "Image Coding",
+  "petiteLabel": "Coding",
   "description": "KTH Image Coding exercise",
-  "icon": "integration_instructions",
+  "icon": "image",
   "allowClientEvaluation": true,
   "delivery": {
     "element": "oli-image-coding-delivery",

--- a/assets/src/components/activities/likert/manifest.json
+++ b/assets/src/components/activities/likert/manifest.json
@@ -1,8 +1,9 @@
 {
   "id": "oli_likert",
   "friendlyName": "Likert",
-  "description": "Likert Scale question",
-  "icon": "integration_instructions",
+  "petiteLabel": "Likert",
+  "description": "A question type that collects input from one or more Likert scales",
+  "icon": "sliders-h",
   "allowClientEvaluation": false,
   "delivery": {
     "element": "oli-likert-delivery",

--- a/assets/src/components/activities/multi_input/manifest.json
+++ b/assets/src/components/activities/multi_input/manifest.json
@@ -1,8 +1,9 @@
 {
   "id": "oli_multi_input",
   "friendlyName": "Multi Input",
-  "description": "A question with a multiple inline inputs in the stem",
-  "icon": "input",
+  "petiteLabel": "Multi",
+  "description": "A question type with a multiple inline inputs in the question stem",
+  "icon": "check-double",
   "delivery": {
     "element": "oli-multi-input-delivery",
     "entry": "./delivery-entry.ts"
@@ -13,8 +14,6 @@
   },
   "schemaPruning": {
     "type": "keys",
-    "keys": [
-      "feedback"
-    ]
+    "keys": ["feedback"]
   }
 }

--- a/assets/src/components/activities/multiple_choice/manifest.json
+++ b/assets/src/components/activities/multiple_choice/manifest.json
@@ -1,8 +1,9 @@
 {
   "id": "oli_multiple_choice",
   "friendlyName": "Multiple Choice",
-  "description": "A traditional multiple choice question with one correct answer",
-  "icon": "radio_button_checked",
+  "petiteLabel": "MCQ",
+  "description": "Choice-based question type with single choice selection",
+  "icon": "list-ul",
   "delivery": {
     "element": "oli-multiple-choice-delivery",
     "entry": "./delivery-entry.ts"

--- a/assets/src/components/activities/oli_embedded/manifest.json
+++ b/assets/src/components/activities/oli_embedded/manifest.json
@@ -1,8 +1,9 @@
 {
   "id": "oli_embedded",
   "friendlyName": "OLI Embedded",
+  "petiteLabel": "Embed",
   "description": "OLI Embedded activity",
-  "icon": "integration_instructions",
+  "icon": "question-circle",
   "allowClientEvaluation": true,
   "delivery": {
     "element": "oli-embedded-delivery",

--- a/assets/src/components/activities/ordering/manifest.json
+++ b/assets/src/components/activities/ordering/manifest.json
@@ -1,8 +1,9 @@
 {
   "id": "oli_ordering",
   "friendlyName": "Ordering",
-  "description": "A ordering activity where answer options must be placed in the correct order",
-  "icon": "list_alt",
+  "petiteLabel": "Order",
+  "description": "A question type that expects students to place options in a correct order",
+  "icon": "sort-numeric-down",
   "delivery": {
     "element": "oli-ordering-delivery",
     "entry": "./delivery-entry.ts"

--- a/assets/src/components/activities/short_answer/manifest.json
+++ b/assets/src/components/activities/short_answer/manifest.json
@@ -1,8 +1,9 @@
 {
   "id": "oli_short_answer",
   "friendlyName": "Single Response",
-  "description": "A question with a single response input following the stem",
-  "icon": "question_answer",
+  "petiteLabel": "Input",
+  "description": "A question type with a single response input following the question stem",
+  "icon": "check",
   "delivery": {
     "element": "oli-short-answer-delivery",
     "entry": "./delivery-entry.ts"

--- a/assets/src/components/content/add_resource_content/AddActivity.tsx
+++ b/assets/src/components/content/add_resource_content/AddActivity.tsx
@@ -30,6 +30,7 @@ export const AddActivity: React.FC<Props> = ({
 
       return enabled ? (
         <ResourceChoice
+          key={editorDesc.id}
           onClick={() => {
             addActivity(editorDesc, resourceContext, onAddItem, editorMap, index);
             document.body.click();

--- a/assets/src/components/content/add_resource_content/AddActivity.tsx
+++ b/assets/src/components/content/add_resource_content/AddActivity.tsx
@@ -5,39 +5,50 @@ import { ActivityReference, ResourceContext } from 'data/content/resource';
 import React from 'react';
 import guid from 'utils/guid';
 import * as Persistence from 'data/persistence/activity';
+import { ResourceChoice } from './ResourceChoice';
 
 interface Props {
+  onSetTip: (tip: string) => void;
+  onResetTip: () => void;
   resourceContext: ResourceContext;
   onAddItem: AddCallback;
   editorMap: ActivityEditorMap;
   index: number[];
 }
-export const AddActivity: React.FC<Props> = ({ resourceContext, onAddItem, editorMap, index }) => {
+export const AddActivity: React.FC<Props> = ({
+  onSetTip,
+  onResetTip,
+  resourceContext,
+  onAddItem,
+  editorMap,
+  index,
+}) => {
   const activityEntries = Object.keys(editorMap)
     .map((k: string) => {
       const editorDesc: EditorDesc = editorMap[k];
       const enabled = editorDesc.globallyAvailable || editorDesc.enabledForProject;
 
       return enabled ? (
-        <button
-          key={editorDesc.slug}
-          className="list-group-item list-group-item-action flex-column align-items-start"
-          onClick={(_e) => {
+        <ResourceChoice
+          onClick={() => {
             addActivity(editorDesc, resourceContext, onAddItem, editorMap, index);
             document.body.click();
           }}
-        >
-          <div className="type-label"> {editorDesc.friendlyName}</div>
-          <div className="type-description"> {editorDesc.description}</div>
-        </button>
+          onHoverStart={() => onSetTip(editorDesc.description)}
+          onHoverEnd={() => onResetTip()}
+          disabled={false}
+          icon={editorDesc.icon}
+          label={editorDesc.petiteLabel}
+        />
       ) : null;
     })
     .filter((e) => e !== null);
 
   return (
-    <>
-      <div className="list-group">{activityEntries}</div>
-    </>
+    <div className="d-flex flex-column">
+      <div className="resource-choice-header ml-3">Question types</div>
+      <div className="resource-choices activities">{activityEntries}</div>
+    </div>
   );
 };
 

--- a/assets/src/components/content/add_resource_content/AddResourceContent.modules.scss
+++ b/assets/src/components/content/add_resource_content/AddResourceContent.modules.scss
@@ -91,8 +91,8 @@
 }
 
 .addResourcePopover {
-  max-width: 500px;
-  overflow-x: auto;
+  max-width: 375px;
+  overflow: hidden;
   width: fit-content;
   z-index: 500;
   border-radius: 6px;
@@ -103,23 +103,14 @@
 }
 
 .addResourcePopoverContent {
-  height: 400px;
-  width: 500px;
+  height: 215px;
+  width: 375px;
+  padding: 4px 2px;
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  background-color: authoring.$body-bg;
   border-radius: 2px;
-
-  :global(.list-group) {
-    padding-left: 6px;
-    padding-right: 6px;
-    border-bottom: 0;
-  }
-
-  :global(.list-group:not(:last-of-type)) {
-    margin-bottom: 1em;
-  }
+  overflow: hidden;
 
   :global(.header) {
     padding-left: 6px;
@@ -134,17 +125,49 @@
 
   :global(.type-label) {
     color: authoring.$body-color;
-    font-size: 1.1em;
-    font-weight: 600;
+    font-size: 0.8em;
+    font-weight: 300;
   }
-
-  :global(.list-group a) {
-    border: 0 none;
-    padding: 4px 6px;
-  }
-
-  :global(.type-description) {
+  :global(.resource-choice-header) {
     color: authoring.$body-color;
     font-size: 0.9em;
+    font-weight: 400;
+    text-transform: uppercase;
+  }
+
+  :global(.resource-choice) {
+    border: none;
+    max-height: 50px;
+    min-height: 50px;
+    max-width: 70px;
+    min-width: 70px;
+    background-color: white;
+
+    &:hover {
+      color: authoring.$primary;
+    }
+    &:active {
+      transform: translateY(4px);
+    }
+  }
+
+  :global(.resource-choices) {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-content: flex-start;
+  }
+
+  :global(.non-activities) {
+    max-width: 140px;
+    max-height: 170px;
+  }
+  :global(.activities) {
+    max-width: 210px;
+    max-height: 170px;
+  }
+  :global(.type-description) {
+    color: authoring.$body-color;
+    font-size: 0.8em;
   }
 }

--- a/assets/src/components/content/add_resource_content/AddResourceContent.modules.scss
+++ b/assets/src/components/content/add_resource_content/AddResourceContent.modules.scss
@@ -96,6 +96,7 @@
   width: fit-content;
   z-index: 500;
   border-radius: 6px;
+  border-color: authoring.$light !important;
 
   &:global(.popover) {
     max-width: unset !important;
@@ -111,6 +112,8 @@
   flex-direction: column;
   border-radius: 2px;
   overflow: hidden;
+  background-color: authoring.$body-bg;
+  border-color: authoring.$light;
 
   :global(.header) {
     padding-left: 6px;
@@ -141,7 +144,8 @@
     min-height: 50px;
     max-width: 70px;
     min-width: 70px;
-    background-color: white;
+    background-color: authoring.$body-bg;
+    color: authoring.$body-color;
 
     &:hover {
       color: authoring.$primary;
@@ -149,6 +153,22 @@
     &:active {
       transform: translateY(4px);
     }
+  }
+
+  :global(.resource-choice-icon) {
+    font-size: 24px;
+  }
+
+  :global(.resource-choices-divider) {
+    border-left-color: authoring.$light;
+    border-left-width: 1px;
+    border-left-style: solid;
+    max-height: 170px;
+  }
+
+  :global(.resource-choices-tip) {
+    font-size: 0.8em;
+    color: authoring.$body-color;
   }
 
   :global(.resource-choices) {

--- a/assets/src/components/content/add_resource_content/AddResourceContent.tsx
+++ b/assets/src/components/content/add_resource_content/AddResourceContent.tsx
@@ -61,27 +61,6 @@ export const AddResourceContent: React.FC<AddResourceContentProps> = ({
           )}
         </div>
       </OverlayTrigger>
-
-      {isLast && (
-        <OverlayTrigger
-          trigger="click"
-          placement="top"
-          rootClose={true}
-          overlay={
-            <Popover id="last-content-add-button" className={styles.addResourcePopover}>
-              <Popover.Content className={styles.addResourcePopoverContent}>
-                {children}
-              </Popover.Content>
-            </Popover>
-          }
-        >
-          <div className={classNames(styles.insertLabel, 'my-4 text-center')}>
-            <button disabled={!editMode} className="btn btn-sm btn-light">
-              Add Content or Activity
-            </button>
-          </div>
-        </OverlayTrigger>
-      )}
     </>
   );
 };

--- a/assets/src/components/content/add_resource_content/NonActivities.tsx
+++ b/assets/src/components/content/add_resource_content/NonActivities.tsx
@@ -1,0 +1,126 @@
+import { AddCallback } from 'components/content/add_resource_content/AddResourceContent';
+import { createDefaultStructuredContent, createGroup } from 'data/content/resource';
+
+import {
+  createDefaultSelection,
+  createBreak,
+  createSurvey,
+  ResourceContent,
+} from 'data/content/resource';
+import React from 'react';
+import { ResourceChoice } from './ResourceChoice';
+import { FeatureFlags } from 'apps/page-editor/types';
+
+// returns true if non of the parents are a survey element
+const canInsertSurvey = (parents: ResourceContent[], featureFlags: FeatureFlags) =>
+  featureFlags.survey && parents.every((p) => p.type !== 'survey');
+
+interface Props {
+  index: number[];
+  onAddItem: AddCallback;
+  parents: ResourceContent[];
+  featureFlags: FeatureFlags;
+  onSetTip: (tip: string) => void;
+  onResetTip: () => void;
+}
+
+export const NonActivities: React.FC<Props> = ({
+  onSetTip,
+  onResetTip,
+  onAddItem,
+  index,
+  parents,
+  featureFlags,
+}) => {
+  return (
+    <div className="d-flex flex-column">
+      <div className="resource-choice-header">Content types</div>
+
+      <div className="resource-choices non-activities">
+        <ResourceChoice
+          icon="edit"
+          label="Mixed"
+          onHoverStart={() =>
+            onSetTip(
+              'Author mixed, HTML-like content such as paragraphs, images, tables, YouTube, etc',
+            )
+          }
+          onHoverEnd={() => onResetTip()}
+          key={'static_html_content'}
+          disabled={false}
+          onClick={() => addContent(onAddItem, index)}
+        />
+        <ResourceChoice
+          icon="layer-group"
+          label="Group"
+          onHoverStart={() =>
+            onSetTip('Group related questions and content together to assign a purpose')
+          }
+          onHoverEnd={() => onResetTip()}
+          key={'group'}
+          disabled={false}
+          onClick={() => addGroup(onAddItem, index)}
+        />
+        <ResourceChoice
+          icon="random"
+          label="Bank"
+          onHoverStart={() => onSetTip('Randomnly select questions from the activity bank')}
+          onHoverEnd={() => onResetTip()}
+          key={'selection'}
+          disabled={false}
+          onClick={() => {
+            onAddItem(createDefaultSelection(), index);
+            document.body.click();
+          }}
+        />
+        <ResourceChoice
+          icon="columns"
+          label="Break"
+          onHoverStart={() => onSetTip('Separate items with a carousel-like paging mechanism')}
+          onHoverEnd={() => onResetTip()}
+          key={'static_html_break'}
+          disabled={false}
+          onClick={() => addPageBreak(onAddItem, index)}
+        />
+        <ResourceChoice
+          icon="poll"
+          label="Survey"
+          onHoverStart={() => onSetTip('Collect student feedback via no-stakes activities')}
+          onHoverEnd={() => onResetTip()}
+          key={'static_html_content'}
+          disabled={!canInsertSurvey(parents, featureFlags)}
+          onClick={() => addSurvey(onAddItem, index)}
+        />
+        <ResourceChoice
+          icon="vial"
+          label="A/B Test"
+          onHoverStart={() => onSetTip('A/B Testing is not yet supported')}
+          onHoverEnd={() => onResetTip()}
+          key={'ab-test'}
+          disabled={true}
+          onClick={() => true}
+        />
+      </div>
+    </div>
+  );
+};
+
+const addContent = (onAddItem: AddCallback, index: number[]) => {
+  onAddItem(createDefaultStructuredContent(), index);
+  document.body.click();
+};
+
+const addGroup = (onAddItem: AddCallback, index: number[]) => {
+  onAddItem(createGroup(), index);
+  document.body.click();
+};
+
+const addPageBreak = (onAddItem: AddCallback, index: number[]) => {
+  onAddItem(createBreak(), index);
+  document.body.click();
+};
+
+const addSurvey = (onAddItem: AddCallback, index: number[]) => {
+  onAddItem(createSurvey(), index);
+  document.body.click();
+};

--- a/assets/src/components/content/add_resource_content/NonActivities.tsx
+++ b/assets/src/components/content/add_resource_content/NonActivities.tsx
@@ -87,7 +87,7 @@ export const NonActivities: React.FC<Props> = ({
           label="Survey"
           onHoverStart={() => onSetTip('Collect student feedback via no-stakes activities')}
           onHoverEnd={() => onResetTip()}
-          key={'static_html_content'}
+          key={'survey'}
           disabled={!canInsertSurvey(parents, featureFlags)}
           onClick={() => addSurvey(onAddItem, index)}
         />

--- a/assets/src/components/content/add_resource_content/ResourceChoice.tsx
+++ b/assets/src/components/content/add_resource_content/ResourceChoice.tsx
@@ -24,7 +24,7 @@ export const ResourceChoice: React.FC<Props> = ({
       disabled={disabled}
       onClick={(_e) => onClick()}
     >
-      <i style={{ fontSize: '24px' }} className={`las la-${icon}`}></i>
+      <i className={`resource-choice-icon las la-${icon}`}></i>
       <div className="type-label">{label}</div>
     </button>
   );

--- a/assets/src/components/content/add_resource_content/ResourceChoice.tsx
+++ b/assets/src/components/content/add_resource_content/ResourceChoice.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+interface Props {
+  onClick: () => void;
+  onHoverStart: () => void;
+  onHoverEnd: () => void;
+  disabled: boolean;
+  label: string;
+  icon: string;
+}
+export const ResourceChoice: React.FC<Props> = ({
+  onClick,
+  disabled,
+  label,
+  icon,
+  onHoverStart,
+  onHoverEnd,
+}) => {
+  return (
+    <button
+      onMouseOver={() => onHoverStart()}
+      onMouseOut={() => onHoverEnd()}
+      className="resource-choice"
+      disabled={disabled}
+      onClick={(_e) => onClick()}
+    >
+      <i style={{ fontSize: '24px' }} className={`las la-${icon}`}></i>
+      <div className="type-label">{label}</div>
+    </button>
+  );
+};

--- a/assets/src/components/resource/editors/AddResource.tsx
+++ b/assets/src/components/resource/editors/AddResource.tsx
@@ -47,11 +47,11 @@ export const AddResource = (props: AddResourceProps) => {
     <AddResourceContent {...props}>
       <div className="d-flex flex-row">
         <NonActivities {...props} onSetTip={onChangeTip} onResetTip={onResetTip} />
-        <div style={{ borderLeft: '1px solid lightgray', maxHeight: 170 }} />
+        <div className="resource-choices-divider" />
         <AddActivity {...props} onSetTip={onChangeTip} onResetTip={onResetTip} />
       </div>
       <div className="mt-2 ml-2" style={{ lineHeight: 0.8 }}>
-        <small className="text-muted">{tip}</small>
+        <small className="resource-choices-tip">{tip}</small>
       </div>
     </AddResourceContent>
   );

--- a/assets/src/components/resource/editors/AddResource.tsx
+++ b/assets/src/components/resource/editors/AddResource.tsx
@@ -1,13 +1,12 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { AddActivity } from 'components/content/add_resource_content/AddActivity';
-import { AddContent } from 'components/content/add_resource_content/AddContent';
-import { AddOther } from 'components/content/add_resource_content/AddOther';
 import { AddResourceContent } from 'components/content/add_resource_content/AddResourceContent';
 import { ActivityEditContext } from 'data/content/activity';
 import { ActivityEditorMap } from 'data/content/editors';
 import { Objective } from 'data/content/objective';
 import { ResourceContent, ResourceContext } from 'data/content/resource';
 import { FeatureFlags } from 'apps/page-editor/types';
+import { NonActivities } from 'components/content/add_resource_content/NonActivities';
 
 export type AddResourceProps = {
   index: number[];
@@ -21,12 +20,39 @@ export type AddResourceProps = {
   onRegisterNewObjective: (objective: Objective) => void;
 };
 
+const DEFAULT_TIP = 'Insert a content item or an interactive, scorable question';
+
 export const AddResource = (props: AddResourceProps) => {
+  const [tip, setTip] = useState(DEFAULT_TIP);
+  const [timer, setTimer] = useState<NodeJS.Timeout | null>(null);
+
+  const onResetTip = () => {
+    setTip('');
+    if (timer !== null) {
+      clearTimeout(timer);
+    }
+    const handle = setTimeout(() => setTip(DEFAULT_TIP), 5000);
+    setTimer(handle);
+  };
+
+  const onChangeTip = (tip: string) => {
+    setTip(tip);
+    if (timer !== null) {
+      setTimer(null);
+      clearTimeout(timer);
+    }
+  };
+
   return (
     <AddResourceContent {...props}>
-      <AddContent {...props} />
-      <AddActivity {...props} />
-      <AddOther {...props} />
+      <div className="d-flex flex-row">
+        <NonActivities {...props} onSetTip={onChangeTip} onResetTip={onResetTip} />
+        <div style={{ borderLeft: '1px solid lightgray', maxHeight: 170 }} />
+        <AddActivity {...props} onSetTip={onChangeTip} onResetTip={onResetTip} />
+      </div>
+      <div className="mt-2 ml-2" style={{ lineHeight: 0.8 }}>
+        <small className="text-muted">{tip}</small>
+      </div>
     </AddResourceContent>
   );
 };

--- a/assets/src/data/content/editors.ts
+++ b/assets/src/data/content/editors.ts
@@ -7,6 +7,7 @@ export type EditorDesc = {
   icon: string;
   description: string;
   friendlyName: string;
+  petiteLabel: string;
   globallyAvailable: boolean;
   enabledForProject: boolean;
   id: number;

--- a/lib/oli/activities/activity_map_entry.ex
+++ b/lib/oli/activities/activity_map_entry.ex
@@ -9,6 +9,7 @@ defmodule Oli.Activities.ActivityMapEntry do
     :icon,
     :description,
     :friendlyName,
+    :petiteLabel,
     :slug,
     :globallyAvailable,
     enabledForProject: false
@@ -20,6 +21,7 @@ defmodule Oli.Activities.ActivityMapEntry do
         description: description,
         icon: icon,
         title: title,
+        petite_label: petite_label,
         authoring_element: authoring_element,
         delivery_element: delivery_element,
         globally_available: globally_available
@@ -30,6 +32,7 @@ defmodule Oli.Activities.ActivityMapEntry do
       friendlyName: title,
       description: description,
       authoringElement: authoring_element,
+      petiteLabel: petite_label,
       icon: icon,
       deliveryElement: delivery_element,
       globallyAvailable: globally_available,

--- a/lib/oli/activities/activity_registration.ex
+++ b/lib/oli/activities/activity_registration.ex
@@ -11,6 +11,7 @@ defmodule Oli.Activities.ActivityRegistration do
     field :delivery_element, :string
     field :icon, :string
     field :title, :string
+    field :petite_label, :string
     field :allow_client_evaluation, :boolean, default: false
     field :globally_available, :boolean, default: false
 
@@ -26,6 +27,7 @@ defmodule Oli.Activities.ActivityRegistration do
     |> cast(attrs, [
       :slug,
       :title,
+      :petite_label,
       :icon,
       :description,
       :delivery_element,
@@ -38,6 +40,7 @@ defmodule Oli.Activities.ActivityRegistration do
     |> validate_required([
       :slug,
       :title,
+      :petite_label,
       :icon,
       :description,
       :delivery_element,

--- a/lib/oli/activities/manifest.ex
+++ b/lib/oli/activities/manifest.ex
@@ -4,10 +4,12 @@ defmodule Oli.Activities.Manifest do
   defstruct [
     :id,
     :friendlyName,
+    :petiteLabel,
     :description,
     :delivery,
     :authoring,
     :allowClientEvaluation,
+    :icon,
     :global
   ]
 
@@ -15,20 +17,24 @@ defmodule Oli.Activities.Manifest do
         %{
           "id" => id,
           "friendlyName" => friendlyName,
+          "petiteLabel" => petiteLabel,
           "description" => description,
           "delivery" => delivery,
           "authoring" => authoring
         } = json
       ) do
-    {:ok, %Oli.Activities.Manifest{
-      id: id,
-      friendlyName: friendlyName,
-      description: description,
-      delivery: Oli.Activities.ModeSpecification.parse(delivery),
-      authoring: Oli.Activities.ModeSpecification.parse(authoring),
-      allowClientEvaluation: value_or(json["allowClientEvaluation"], false),
-      global: false
-    }}
+    {:ok,
+     %Oli.Activities.Manifest{
+       id: id,
+       friendlyName: friendlyName,
+       petiteLabel: petiteLabel,
+       description: description,
+       icon: Map.get(json, "icon", "question-circle"),
+       delivery: Oli.Activities.ModeSpecification.parse(delivery),
+       authoring: Oli.Activities.ModeSpecification.parse(authoring),
+       allowClientEvaluation: value_or(json["allowClientEvaluation"], false),
+       global: false
+     }}
   end
 
   def parse(_json) do

--- a/priv/repo/migrations/20220617195405_add_petite_label.exs
+++ b/priv/repo/migrations/20220617195405_add_petite_label.exs
@@ -1,0 +1,9 @@
+defmodule Oli.Repo.Migrations.AddPetiteLabel do
+  use Ecto.Migration
+
+  def change do
+    alter table(:activity_registrations) do
+      add :petite_label, :string, null: false, default: ""
+    end
+  end
+end

--- a/test/oli/delivery/attempts_test.exs
+++ b/test/oli/delivery/attempts_test.exs
@@ -493,6 +493,8 @@ defmodule Oli.Delivery.AttemptsTest do
           friendlyName: "Test Client Eval",
           description: "A test activity that allows client evaluation",
           delivery: %ModeSpecification{element: "test-client-eval", entry: "./delivery-entry.ts"},
+          icon: "nothing",
+          petiteLabel: "test",
           authoring: %ModeSpecification{
             element: "test-client-eval",
             entry: "./authoring-entry.ts"
@@ -598,6 +600,8 @@ defmodule Oli.Delivery.AttemptsTest do
           friendlyName: "Test Client Eval",
           description: "A test activity that allows client evaluation",
           delivery: %ModeSpecification{element: "test-client-eval", entry: "./delivery-entry.ts"},
+          icon: "nothing",
+          petiteLabel: "test",
           authoring: %ModeSpecification{
             element: "test-client-eval",
             entry: "./authoring-entry.ts"

--- a/test/oli/registrar_test.exs
+++ b/test/oli/registrar_test.exs
@@ -8,10 +8,17 @@ defmodule Oli.RegistrarTest do
       registrations = Activities.list_activity_registrations()
       assert length(registrations) > 5
 
-      catas = registrations |> Enum.filter(&match?(%{
-        slug: "oli_check_all_that_apply",
-        title: "Check All That Apply"
-      }, &1))
+      catas =
+        registrations
+        |> Enum.filter(
+          &match?(
+            %{
+              slug: "oli_check_all_that_apply",
+              title: "Check All That Apply"
+            },
+            &1
+          )
+        )
 
       assert catas |> length == 1
 
@@ -20,7 +27,7 @@ defmodule Oli.RegistrarTest do
       assert r.title == "Check All That Apply"
 
       assert r.description ==
-               "A traditional check all that apply question with one correct answer"
+               "Choice-based question that allows multiple selections"
 
       assert r.authoring_script == "oli_check_all_that_apply_authoring.js"
       assert r.delivery_script == "oli_check_all_that_apply_delivery.js"
@@ -39,7 +46,7 @@ defmodule Oli.RegistrarTest do
       assert r.slug == "oli_check_all_that_apply"
 
       assert r.description ==
-               "A traditional check all that apply question with one correct answer"
+               "Choice-based question that allows multiple selections"
 
       assert r.friendlyName == "Check All That Apply"
       assert r.authoringElement == "oli-check-all-that-apply-authoring"


### PR DESCRIPTION
This PR reworks the popup UI that allows inserting new content items and activities. 

https://user-images.githubusercontent.com/7431756/174826148-fed3920e-07ec-49c4-a45c-c76283242e95.mov

The above is a screen recording of the new UX in action.  On the left-hand side it presents a dedicated space for "non activities", and the right-hand side contains a panel for the activities present.  As the user mouses over the choices, there is some color changing during "hover" and a "tooltip" type string that displays for the "active" item.  This tip resets back to the default some seconds after it is cleared. 

This UX was designed with an eye towards future scalability as we add more and more activities.  When we reach the ability to display more than nine activities, we will augment this UX with a simple "paging" mechanism that allows the user to page forward and back through the "pages" of activities that are then available. 

This PR adds a new component to activity manifests, the "petite label", which is a very short label that is used in this display. 

This PR changes how the "icon" attr of activities is interpreted. It expects it to be a reference to a LineAwesome icon.  We will need to expand icon support in the near future to possibly allow activities to supply their own 24/24 icons for this UX. For now, though, using a LineAwesome icon should be sufficient.  

