### PR TITLE
[CHORE] make recent migrations reversible

### DIFF
--- a/priv/repo/migrations/20220615133201_add_global_visibility.exs
+++ b/priv/repo/migrations/20220615133201_add_global_visibility.exs
@@ -6,8 +6,10 @@ defmodule Oli.Repo.Migrations.AddGlobalVisibility do
       add :globally_visible, :boolean, null: false, default: true
     end
 
-    flush()
+    if direction == :up do
+      flush()
 
-    execute "UPDATE activity_registrations SET globally_visible = true;"
+      execute "UPDATE activity_registrations SET globally_visible = true;"
+    end
   end
 end

--- a/priv/repo/migrations/20220616184621_add_project_to_snapshots.exs
+++ b/priv/repo/migrations/20220616184621_add_project_to_snapshots.exs
@@ -6,10 +6,12 @@ defmodule Oli.Repo.Migrations.AddProjectToSnapshots do
       add :project_id, references(:projects, on_delete: :nothing)
     end
 
-    flush()
+    if direction == :up do
+      flush()
 
-    execute """
-    UPDATE snapshots SET project_id = sect.base_project_id FROM snapshots snap LEFT JOIN sections sect ON snap.section_id = sect.id;
-    """
+      execute """
+      UPDATE snapshots SET project_id = sect.base_project_id FROM snapshots snap LEFT JOIN sections sect ON snap.section_id = sect.id;
+      """
+    end
   end
 end


### PR DESCRIPTION
This PR adds a condition to only run non-reversible migration code in a change block if the migration direction is up.