### PR TITLE
[BUG FIX] Remove setting of project_id during migration

### DIFF
--- a/priv/repo/migrations/20220616184621_add_project_to_snapshots.exs
+++ b/priv/repo/migrations/20220616184621_add_project_to_snapshots.exs
@@ -3,13 +3,7 @@ defmodule Oli.Repo.Migrations.AddProjectToSnapshots do
 
   def change do
     alter table(:snapshots) do
-      add :project_id, references(:projects, on_delete: :nothing)
+      add :project_id, references(:projects, on_delete: :nothing), null: true, default: nil
     end
-
-    flush()
-
-    execute """
-    UPDATE snapshots SET project_id = sect.base_project_id FROM snapshots snap LEFT JOIN sections sect ON snap.section_id = sect.id;
-    """
   end
 end


### PR DESCRIPTION
I verified that analytics queries do not break when `project_id` field contains nil values.  They don't work, but they don't break. 