### PR TITLE
[MER-937] Improve timezones handling

### DIFF
--- a/assets/styles/common/utils.scss
+++ b/assets/styles/common/utils.scss
@@ -5,3 +5,11 @@
 .search-input {
   max-width: 500px;
 }
+
+.dropdown-select {
+  width: 15rem !important;
+
+  &:hover {
+    cursor: pointer;
+  }
+}

--- a/lib/oli/automation_setup.ex
+++ b/lib/oli/automation_setup.ex
@@ -191,7 +191,6 @@ defmodule Oli.AutomationSetup do
         context_id: UUID.uuid4(),
         start_date: Timex.now(),
         end_date: Timex.add(Timex.now(), Timex.Duration.from_days(1)),
-        timezone: "US/Eastern",
         base_project_id: project.id,
         open_and_free: true
       })

--- a/lib/oli/delivery.ex
+++ b/lib/oli/delivery.ex
@@ -65,7 +65,6 @@ defmodule Oli.Delivery do
       {:ok, section} =
         Oli.Delivery.Sections.Blueprint.duplicate(blueprint, %{
           type: :enrollable,
-          timezone: institution.timezone,
           title: lti_params[@context_claims]["title"],
           context_id: lti_params[@context_claims]["id"],
           institution_id: institution.id,
@@ -91,7 +90,6 @@ defmodule Oli.Delivery do
       {:ok, section} =
         Sections.create_section(%{
           type: :enrollable,
-          timezone: institution.timezone,
           title: lti_params[@context_claims]["title"],
           context_id: lti_params[@context_claims]["id"],
           institution_id: institution.id,

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -15,6 +15,7 @@ defmodule Oli.Delivery.Sections do
   alias Oli.Delivery.Sections.SectionResource
   alias Oli.Publishing
   alias Oli.Publishing.Publication
+  alias Oli.Delivery.Paywall.Payment
   alias Oli.Delivery.Sections.SectionsProjectsPublications
   alias Oli.Resources.Numbering
   alias Oli.Authoring.Course.Project
@@ -89,7 +90,7 @@ defmodule Oli.Delivery.Sections do
     query =
       Enrollment
       |> join(:left, [e], u in User, on: u.id == e.user_id)
-      |> join(:left, [e, _], p in "payments", on: p.enrollment_id == e.id)
+      |> join(:left, [e, _], p in Payment, on: p.enrollment_id == e.id)
       |> where(^filter_by_text)
       |> where(^filter_by_role)
       |> where([e, _], e.section_id == ^section_id)

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -31,6 +31,7 @@ defmodule Oli.Delivery.Sections do
   alias Oli.Delivery.Updates.Broadcaster
   alias Oli.Delivery.Sections.EnrollmentBrowseOptions
   alias Oli.Utils.Slug
+  alias OliWeb.Common.FormatDateTime
 
   require Logger
 
@@ -1483,60 +1484,15 @@ defmodule Oli.Delivery.Sections do
   end
 
   @doc """
-  Parses a ISO 8601 formatted local timestamps to DateTimes if they are not empty or nil.
-
-  Returns a tuple containing the start and end datetimes in UTC: {utc_start_date, utc_end_date}
-  """
-  def parse_and_convert_start_end_dates_to_utc(start_date, end_date, from_timezone) do
-    section_timezone = Timex.Timezone.get(from_timezone)
-    utc_timezone = Timex.Timezone.get(:utc, Timex.now())
-
-    utc_start_date =
-      case start_date do
-        start_date when start_date == nil or start_date == "" or not is_binary(start_date) ->
-          start_date
-
-        start_date ->
-          start_date
-          |> Timex.parse!("{ISO:Extended}")
-          |> Timex.to_datetime(section_timezone)
-          |> Timex.Timezone.convert(utc_timezone)
-      end
-
-    utc_end_date =
-      case end_date do
-        end_date when end_date == nil or end_date == "" or not is_binary(end_date) ->
-          end_date
-
-        end_date ->
-          end_date
-          |> Timex.parse!("{ISO:Extended}")
-          |> Timex.to_datetime(section_timezone)
-          |> Timex.Timezone.convert(utc_timezone)
-      end
-
-    {utc_start_date, utc_end_date}
-  end
-
-  @doc """
-  Converts a section's start_date and end_date to the gievn timezone's local datetimes
+  Converts a section's start_date and end_date to the given timezone's local datetimes
   """
   def localize_section_start_end_datetimes(
-        %Section{start_date: start_date, end_date: end_date, timezone: timezone} = section
+        %Section{start_date: start_date, end_date: end_date} = section,
+        context
       ) do
-    timezone = Timex.Timezone.get(timezone, Timex.now())
 
-    start_date =
-      case start_date do
-        start_date when start_date == nil or start_date == "" -> start_date
-        start_date -> Timex.Timezone.convert(start_date, timezone)
-      end
-
-    end_date =
-      case end_date do
-        end_date when end_date == nil or end_date == "" -> end_date
-        end_date -> Timex.Timezone.convert(end_date, timezone)
-      end
+    start_date = FormatDateTime.convert_datetime(start_date, context)
+    end_date = FormatDateTime.convert_datetime(end_date, context)
 
     section
     |> Map.put(:start_date, start_date)

--- a/lib/oli/delivery/sections/blueprint.ex
+++ b/lib/oli/delivery/sections/blueprint.ex
@@ -148,7 +148,6 @@ defmodule Oli.Delivery.Sections.Blueprint do
             "requires_payment" => false,
             "pay_by_institution" => false,
             "registration_open" => false,
-            "timezone" => "America/New_York",
             "grace_period_days" => 1,
             "amount" => Money.new(:USD, "25.00"),
             "publisher_id" => project.publisher_id

--- a/lib/oli/delivery/sections/section.ex
+++ b/lib/oli/delivery/sections/section.ex
@@ -23,7 +23,6 @@ defmodule Oli.Delivery.Sections.Section do
     field(:registration_open, :boolean, default: false)
     field(:start_date, :utc_datetime)
     field(:end_date, :utc_datetime)
-    field(:timezone, :string)
     field(:title, :string)
     field(:description, :string)
     field(:context_id, :string)
@@ -109,7 +108,6 @@ defmodule Oli.Delivery.Sections.Section do
       :title,
       :start_date,
       :end_date,
-      :timezone,
       :registration_open,
       :description,
       :context_id,
@@ -147,7 +145,6 @@ defmodule Oli.Delivery.Sections.Section do
     |> validate_required([
       :type,
       :title,
-      :timezone,
       :registration_open,
       :base_project_id
     ])

--- a/lib/oli/interop/custom_activities/section.ex
+++ b/lib/oli/interop/custom_activities/section.ex
@@ -25,7 +25,6 @@ defmodule Oli.Interop.CustomActivities.Section do
         end,
         registration_closed: context.section.registration_open,
         start_date: context.section.start_date,
-        time_zone: context.section.timezone,
         title: context.section.title
       },
       [

--- a/lib/oli/utils/db_seeder.ex
+++ b/lib/oli/utils/db_seeder.ex
@@ -52,8 +52,7 @@ defmodule Oli.Seeder do
         name: "Example Institution",
         country_code: "US",
         institution_email: author.email,
-        institution_url: "example.edu",
-        timezone: "America/New_York"
+        institution_url: "example.edu"
       })
       |> Repo.insert()
 
@@ -169,7 +168,6 @@ defmodule Oli.Seeder do
         country_code: "some country_code",
         institution_email: "some institution_email",
         institution_url: "some institution_url",
-        timezone: "America/New_York",
         author_id: author.id
       })
       |> Repo.insert()
@@ -424,7 +422,6 @@ defmodule Oli.Seeder do
     {:ok, section_1} =
       Sections.create_section(%{
         title: "1",
-        timezone: "America/New_York",
         registration_open: true,
         context_id: UUID.uuid4(),
         institution_id: map.institution.id,
@@ -436,7 +433,6 @@ defmodule Oli.Seeder do
     {:ok, section_2} =
       Sections.create_section(%{
         title: "2",
-        timezone: "America/New_York",
         registration_open: true,
         context_id: UUID.uuid4(),
         institution_id: map.institution.id,
@@ -448,7 +444,6 @@ defmodule Oli.Seeder do
     {:ok, oaf_section_1} =
       Sections.create_section(%{
         title: "3",
-        timezone: "America/New_York",
         registration_open: true,
         open_and_free: true,
         context_id: UUID.uuid4(),
@@ -481,7 +476,6 @@ defmodule Oli.Seeder do
       open_and_free: false,
       registration_open: true,
       start_date: ~U[2010-04-17 00:00:00.000000Z],
-      timezone: "America/New_York",
       title: "some title",
       context_id: UUID.uuid4(),
       base_project_id: map.project.id,
@@ -503,7 +497,6 @@ defmodule Oli.Seeder do
           type: :blueprint,
           registration_open: true,
           start_date: ~U[2010-04-17 00:00:00.000000Z],
-          timezone: "America/New_York",
           title: "some title",
           description: "a description",
           context_id: UUID.uuid4(),

--- a/lib/oli/utils/db_seeder.ex
+++ b/lib/oli/utils/db_seeder.ex
@@ -52,7 +52,8 @@ defmodule Oli.Seeder do
         name: "Example Institution",
         country_code: "US",
         institution_email: author.email,
-        institution_url: "example.edu"
+        institution_url: "example.edu",
+        timezone: "America/New_York"
       })
       |> Repo.insert()
 
@@ -168,6 +169,7 @@ defmodule Oli.Seeder do
         country_code: "some country_code",
         institution_email: "some institution_email",
         institution_url: "some institution_url",
+        timezone: "America/New_York",
         author_id: author.id
       })
       |> Repo.insert()

--- a/lib/oli_web/common/format_date_time.ex
+++ b/lib/oli_web/common/format_date_time.ex
@@ -188,7 +188,7 @@ defmodule OliWeb.Common.FormatDateTime do
       iex> datestring_to_utc_datetime("2022-05-18T12:35", "US/Arizona")
       ~U[2022-05-18 19:35:00Z]
   """
-  def datestring_to_utc_datetime("", _), do: nil
+  def datestring_to_utc_datetime(date, _) when is_nil(date) or date == "" or not is_binary(date), do: nil
 
   def datestring_to_utc_datetime(date_string, %SessionContext{local_tz: local_tz}) do
     datestring_to_utc_datetime(date_string, local_tz)
@@ -202,7 +202,7 @@ defmodule OliWeb.Common.FormatDateTime do
     |> elem(1)
   end
 
-  def convert_datetime(nil, _timezone), do: nil
+  def convert_datetime(date, _) when is_nil(date) or date == "", do: nil
   def convert_datetime(datetime, %SessionContext{local_tz: local_tz}), do: convert_datetime(datetime, local_tz)
   def convert_datetime(datetime, timezone), do: Timex.to_datetime(datetime, timezone)
 

--- a/lib/oli_web/common/format_date_time.ex
+++ b/lib/oli_web/common/format_date_time.ex
@@ -145,8 +145,7 @@ defmodule OliWeb.Common.FormatDateTime do
   def format_datetime(nil, _opts), do: ""
 
   def format_datetime({:localized, %DateTime{} = datetime}, opts) do
-    # default to showing no timezone if the datetime has been localized
-    format_datetime(datetime, Keyword.put_new(opts, :show_timezone, false))
+    format_datetime(datetime, opts)
   end
 
   def format_datetime(%DateTime{} = datetime, opts) do

--- a/lib/oli_web/common/format_date_time.ex
+++ b/lib/oli_web/common/format_date_time.ex
@@ -97,6 +97,9 @@ defmodule OliWeb.Common.FormatDateTime do
   def maybe_localized_datetime(%NaiveDateTime{} = naive_date, nil),
     do: Timex.to_datetime(naive_date, "Etc/UTC")
 
+  def maybe_localized_datetime(%NaiveDateTime{} = naive_date, %SessionContext{local_tz: local_tz}),
+    do: Timex.to_datetime(naive_date, "Etc/UTC") |> maybe_localized_datetime(local_tz)
+
   def maybe_localized_datetime(%DateTime{} = datetime, nil), do: datetime
 
   def maybe_localized_datetime(%DateTime{} = datetime, %SessionContext{local_tz: local_tz}),

--- a/lib/oli_web/common/format_date_time.ex
+++ b/lib/oli_web/common/format_date_time.ex
@@ -190,6 +190,10 @@ defmodule OliWeb.Common.FormatDateTime do
   """
   def datestring_to_utc_datetime("", _), do: nil
 
+  def datestring_to_utc_datetime(date_string, %SessionContext{local_tz: local_tz}) do
+    datestring_to_utc_datetime(date_string, local_tz)
+  end
+
   def datestring_to_utc_datetime(date_string, local_tz) do
     date_string
     |> Timex.parse!("{ISO:Extended}")
@@ -197,6 +201,10 @@ defmodule OliWeb.Common.FormatDateTime do
     |> DateTime.shift_zone("Etc/UTC")
     |> elem(1)
   end
+
+  def convert_datetime(nil, _timezone), do: nil
+  def convert_datetime(datetime, %SessionContext{local_tz: local_tz}), do: convert_datetime(datetime, local_tz)
+  def convert_datetime(datetime, timezone), do: Timex.to_datetime(datetime, timezone)
 
   defp author_format_preference(nil), do: nil
 

--- a/lib/oli_web/common/select_timezone.ex
+++ b/lib/oli_web/common/select_timezone.ex
@@ -19,7 +19,7 @@ defmodule OliWeb.Common.SelectTimezone do
       <%= form_for @conn, Routes.static_page_path(@conn, :update_timezone), [id: "timezone-form"], fn f -> %>
         <%= hidden_input f, :redirect_to, id: "hidden-redirect-to" %>
         <div class="form-label-group">
-          <%= select f, :timezone, Predefined.timezones(), onchange: "submitForm()", selected: @selected || "Etc/Greenwich", prompt: "Select Timezone", class: "form-control dropdown-select", required: true %>
+          <%= select f, :timezone, Predefined.timezones(), onchange: "submitForm()", selected: @selected || "Etc/Greenwich", class: "form-control dropdown-select", required: true %>
         </div>
       <% end %>
     """

--- a/lib/oli_web/common/select_timezone.ex
+++ b/lib/oli_web/common/select_timezone.ex
@@ -8,10 +8,18 @@ defmodule OliWeb.Common.SelectTimezone do
 
   def render(assigns) do
     ~H"""
-      <%= form_for @conn, Routes.static_page_path(@conn, :update_timezone), fn f -> %>
-        <%= hidden_input f, :redirect_to, value: @conn.request_path %>
+      <script>
+        function submitForm(){
+          const relativePath = window.location.pathname+window.location.search;
+          $('#hidden-redirect-to').val(relativePath);
+          $('#timezone-form').submit()
+        }
+      </script>
+
+      <%= form_for @conn, Routes.static_page_path(@conn, :update_timezone), [id: "timezone-form"], fn f -> %>
+        <%= hidden_input f, :redirect_to, id: "hidden-redirect-to" %>
         <div class="form-label-group">
-          <%= select f, :timezone, Predefined.timezones(), onchange: "this.form.submit()", selected: @selected || "Etc/Greenwich", prompt: "Select Timezone", class: "form-control dropdown-select", required: true %>
+          <%= select f, :timezone, Predefined.timezones(), onchange: "submitForm()", selected: @selected || "Etc/Greenwich", prompt: "Select Timezone", class: "form-control dropdown-select", required: true %>
         </div>
       <% end %>
     """

--- a/lib/oli_web/common/select_timezone.ex
+++ b/lib/oli_web/common/select_timezone.ex
@@ -1,0 +1,19 @@
+defmodule OliWeb.Common.SelectTimezone do
+  use Phoenix.Component
+
+  import Phoenix.HTML.Form
+
+  alias Oli.Predefined
+  alias OliWeb.Router.Helpers, as: Routes
+
+  def render(assigns) do
+    ~H"""
+      <%= form_for @conn, Routes.static_page_path(@conn, :update_timezone), fn f -> %>
+        <%= hidden_input f, :redirect_to, value: @conn.request_path %>
+        <div class="form-label-group">
+          <%= select f, :timezone, Predefined.timezones(), onchange: "this.form.submit()", selected: @selected || "Etc/Greenwich", prompt: "Select Timezone", class: "form-control dropdown-select", required: true %>
+        </div>
+      <% end %>
+    """
+  end
+end

--- a/lib/oli_web/common/session_context.ex
+++ b/lib/oli_web/common/session_context.ex
@@ -13,6 +13,8 @@ defmodule OliWeb.Common.SessionContext do
     :user
   ]
 
+  @default_timezone "Etc/UTC"
+
   defstruct [
     :local_tz,
     :author,
@@ -34,7 +36,7 @@ defmodule OliWeb.Common.SessionContext do
   end
 
   def init(%Plug.Conn{assigns: assigns} = conn) do
-    local_tz = Plug.Conn.get_session(conn, "local_tz")
+    local_tz = Plug.Conn.get_session(conn, "local_tz") || @default_timezone
     author = Map.get(assigns, :current_author)
     user = Map.get(assigns, :current_user)
 
@@ -46,7 +48,7 @@ defmodule OliWeb.Common.SessionContext do
   end
 
   def init(%{} = session) do
-    local_tz = Map.get(session, "local_tz")
+    local_tz = Map.get(session, "local_tz", @default_timezone)
 
     author =
       case Map.get(session, "current_author_id") do

--- a/lib/oli_web/common/session_context.ex
+++ b/lib/oli_web/common/session_context.ex
@@ -6,14 +6,13 @@ defmodule OliWeb.Common.SessionContext do
   alias Oli.Accounts
   alias Oli.Accounts.Author
   alias Oli.Accounts.User
+  alias OliWeb.Common.FormatDateTime
 
   @enforce_keys [
     :local_tz,
     :author,
     :user
   ]
-
-  @default_timezone "Etc/UTC"
 
   defstruct [
     :local_tz,
@@ -36,7 +35,7 @@ defmodule OliWeb.Common.SessionContext do
   end
 
   def init(%Plug.Conn{assigns: assigns} = conn) do
-    local_tz = Plug.Conn.get_session(conn, "local_tz") || @default_timezone
+    local_tz = Plug.Conn.get_session(conn, "local_tz") || FormatDateTime.default_timezone()
     author = Map.get(assigns, :current_author)
     user = Map.get(assigns, :current_user)
 
@@ -48,7 +47,7 @@ defmodule OliWeb.Common.SessionContext do
   end
 
   def init(%{} = session) do
-    local_tz = Map.get(session, "local_tz", @default_timezone)
+    local_tz = Map.get(session, "local_tz", FormatDateTime.default_timezone())
 
     author =
       case Map.get(session, "current_author_id") do

--- a/lib/oli_web/controllers/help_controller.ex
+++ b/lib/oli_web/controllers/help_controller.ex
@@ -1,7 +1,7 @@
 defmodule OliWeb.HelpController do
   use OliWeb, :controller
 
-  import OliWeb.Common.FormatDateTime
+  alias OliWeb.Common.{SessionContext, Utils}
 
   require Logger
 
@@ -72,6 +72,7 @@ defmodule OliWeb.HelpController do
       email = if current_user.email == nil, do: " ", else: " "
       given_name = if current_user.given_name == nil, do: " ", else: " "
       family_name = if current_user.family_name == nil, do: " ", else: " "
+      context = SessionContext.init(conn)
 
       {
         :ok,
@@ -80,7 +81,7 @@ defmodule OliWeb.HelpController do
           %{
             "account_email" => email,
             "account_name" => given_name <> " " <> family_name,
-            "account_created" => date(current_user.inserted_at)
+            "account_created" => Utils.render_precise_date(current_user, :inserted_at, context)
           }
         )
       }

--- a/lib/oli_web/controllers/institution_controller.ex
+++ b/lib/oli_web/controllers/institution_controller.ex
@@ -7,7 +7,7 @@ defmodule OliWeb.InstitutionController do
   alias Oli.Institutions.Institution
   alias Oli.Predefined
   alias Oli.Slack
-  alias OliWeb.Common.{Breadcrumb}
+  alias OliWeb.Common.{Breadcrumb, SessionContext}
   alias Oli.Branding
 
   require Logger
@@ -61,6 +61,7 @@ defmodule OliWeb.InstitutionController do
     pending_registrations = Institutions.list_pending_registrations()
 
     render_institution_page(conn, "index.html",
+      context: SessionContext.init(conn),
       breadcrumbs: root_breadcrumbs(),
       institutions: institutions,
       pending_registrations: pending_registrations,

--- a/lib/oli_web/controllers/lti_controller.ex
+++ b/lib/oli_web/controllers/lti_controller.ex
@@ -2,7 +2,6 @@ defmodule OliWeb.LtiController do
   use OliWeb, :controller
 
   import Oli.Utils
-  import OliWeb.Common.FormatDateTime
 
   alias Oli.Accounts
   alias Oli.Delivery.Sections
@@ -11,7 +10,7 @@ defmodule OliWeb.LtiController do
   alias Lti_1p3
   alias Oli.Predefined
   alias Oli.Slack
-  alias OliWeb.Common.LtiSession
+  alias OliWeb.Common.{LtiSession, SessionContext, Utils}
   alias Oli.Lti.LtiParams
   alias Lti_1p3.Tool.ContextRoles
   alias Lti_1p3.Tool.PlatformRoles
@@ -251,6 +250,7 @@ defmodule OliWeb.LtiController do
       ) do
     case Institutions.create_pending_registration(pending_registration_attrs) do
       {:ok, pending_registration} ->
+        context = SessionContext.init(conn)
         # send a Slack notification regarding the new registration request
         Slack.send(%{
           "username" => "Torus Bot",
@@ -286,7 +286,7 @@ defmodule OliWeb.LtiController do
                 },
                 %{
                   "type" => "mrkdwn",
-                  "text" => "*Date:*\n#{pending_registration.inserted_at |> date()}"
+                  "text" => "*Date:*\n#{Utils.render_precise_date(pending_registration, :inserted_at, context)}"
                 }
               ]
             },

--- a/lib/oli_web/controllers/open_and_free_controller.ex
+++ b/lib/oli_web/controllers/open_and_free_controller.ex
@@ -1,7 +1,7 @@
 defmodule OliWeb.OpenAndFreeController do
   use OliWeb, :controller
 
-  alias Oli.{Repo, Predefined, Publishing, Branding}
+  alias Oli.{Repo, Publishing, Branding}
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.Section
   alias Oli.Authoring.Course
@@ -260,6 +260,7 @@ defmodule OliWeb.OpenAndFreeController do
 
       {:error, %Ecto.Changeset{} = changeset} ->
         render(conn, "edit.html",
+          context: context,
           breadcrumbs: set_breadcrumbs() |> edit_breadcrumb(),
           section: section,
           changeset: changeset,

--- a/lib/oli_web/controllers/open_and_free_controller.ex
+++ b/lib/oli_web/controllers/open_and_free_controller.ex
@@ -54,14 +54,14 @@ defmodule OliWeb.OpenAndFreeController do
     {source, source_label, source_param_name} = source_info(source_id)
 
     render(conn, "new.html",
+      context: SessionContext.init(conn),
       breadcrumbs: set_breadcrumbs() |> new_breadcrumb(),
       changeset: Sections.change_independent_learner_section(%Section{registration_open: true}),
       source_id: source_id,
       source: source,
       source_label: source_label,
       source_param_name: source_param_name,
-      available_brands: available_brands(),
-      timezones: Predefined.timezones()
+      available_brands: available_brands()
     )
   end
 
@@ -69,8 +69,7 @@ defmodule OliWeb.OpenAndFreeController do
     with %{
            "product_slug" => product_slug,
            "start_date" => start_date,
-           "end_date" => end_date,
-           "timezone" => timezone
+           "end_date" => end_date
          } <-
            section_params,
          blueprint <- Sections.get_section_by_slug(product_slug) do
@@ -87,8 +86,7 @@ defmodule OliWeb.OpenAndFreeController do
           open_and_free: true,
           context_id: UUID.uuid4(),
           start_date: utc_start_date,
-          end_date: utc_end_date,
-          timezone: timezone
+          end_date: utc_end_date
         })
 
       case create_from_product(conn, blueprint, section_params) do
@@ -114,8 +112,7 @@ defmodule OliWeb.OpenAndFreeController do
             source: source,
             source_label: source_label,
             source_param_name: source_param_name,
-            available_brands: available_brands(),
-            timezones: Predefined.timezones()
+            available_brands: available_brands()
           )
       end
     else
@@ -134,8 +131,7 @@ defmodule OliWeb.OpenAndFreeController do
           source: source,
           source_label: source_label,
           source_param_name: source_param_name,
-          available_brands: available_brands(),
-          timezones: Predefined.timezones()
+          available_brands: available_brands()
         )
     end
   end
@@ -144,8 +140,7 @@ defmodule OliWeb.OpenAndFreeController do
     with %{
            "project_slug" => project_slug,
            "start_date" => start_date,
-           "end_date" => end_date,
-           "timezone" => timezone
+           "end_date" => end_date
          } <-
            section_params,
          %{id: project_id} <- Course.get_project_by_slug(project_slug),
@@ -184,8 +179,7 @@ defmodule OliWeb.OpenAndFreeController do
             source: source,
             source_label: source_label,
             source_param_name: source_param_name,
-            available_brands: available_brands(),
-            timezones: Predefined.timezones()
+            available_brands: available_brands()
           )
       end
     else
@@ -204,8 +198,7 @@ defmodule OliWeb.OpenAndFreeController do
           source: source,
           source_label: source_label,
           source_param_name: source_param_name,
-          available_brands: available_brands(),
-          timezones: Predefined.timezones()
+          available_brands: available_brands()
         )
     end
   end
@@ -233,18 +226,18 @@ defmodule OliWeb.OpenAndFreeController do
       |> Sections.localize_section_start_end_datetimes(context)
 
     render(conn, "edit.html",
+      context: context,
       breadcrumbs: set_breadcrumbs() |> edit_breadcrumb(),
       section: section,
       changeset: Sections.change_section(section),
-      available_brands: available_brands(),
-      timezones: Predefined.timezones()
+      available_brands: available_brands()
     )
   end
 
   def update(conn, %{
         "id" => id,
         "section" =>
-          %{"start_date" => start_date, "end_date" => end_date, "timezone" => timezone} =
+          %{"start_date" => start_date, "end_date" => end_date} =
             section_params
       }) do
     section = Sections.get_section_preloaded!(id)
@@ -270,8 +263,7 @@ defmodule OliWeb.OpenAndFreeController do
           breadcrumbs: set_breadcrumbs() |> edit_breadcrumb(),
           section: section,
           changeset: changeset,
-          available_brands: available_brands(),
-          timezones: Predefined.timezones()
+          available_brands: available_brands()
         )
     end
   end

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -22,6 +22,7 @@ defmodule OliWeb.PageDeliveryController do
   alias Oli.Publishing.DeliveryResolver, as: Resolver
   alias Oli.Resources.Revision
   alias Oli.Utils.BibUtils
+  alias OliWeb.Common.SessionContext
 
   plug(Oli.Plugs.AuthorizeSection when action in [:export_enrollments, :export_gradebook])
 
@@ -342,6 +343,8 @@ defmodule OliWeb.PageDeliveryController do
          _,
          _
        ) do
+    session_context = SessionContext.init(conn)
+
     section = conn.assigns.section
 
     # Only consider graded attempts
@@ -389,6 +392,7 @@ defmodule OliWeb.PageDeliveryController do
       Oli.Delivery.Student.Summary.get_summary(section_slug, conn.assigns.current_user)
 
     render(conn, "prologue.html", %{
+      session_context: session_context,
       summary: summary,
       section_slug: section_slug,
       scripts: Activities.get_activity_scripts(),
@@ -508,6 +512,7 @@ defmodule OliWeb.PageDeliveryController do
   # This case handles :in_progress and :revised progress states, in addition to
   # handling review mode
   defp render_page(%PageContext{} = context, conn, section_slug, user, _) do
+    session_context = SessionContext.init(conn)
     section = conn.assigns.section
 
     preview_mode = Map.get(conn.assigns, :preview_mode, false)
@@ -545,6 +550,7 @@ defmodule OliWeb.PageDeliveryController do
       conn,
       "page.html",
       %{
+        session_context: session_context,
         context: context,
         page: context.page,
         review_mode: context.review_mode,

--- a/lib/oli_web/controllers/project_controller.ex
+++ b/lib/oli_web/controllers/project_controller.ex
@@ -3,13 +3,13 @@ defmodule OliWeb.ProjectController do
 
   alias Oli.Accounts
   alias Oli.Utils
-  alias Oli.Authoring.{Course}
+  alias Oli.Authoring.Course
   alias Oli.Authoring.Course.Project
   alias Oli.Inventories
   alias Oli.Publishing
   alias Oli.Qa
   alias Oli.Analytics.Datashop
-  alias OliWeb.Common.Breadcrumb
+  alias OliWeb.Common.{Breadcrumb, SessionContext}
   alias Oli.Authoring.Clone
   alias Oli.Activities
   alias OliWeb.Insights
@@ -117,6 +117,7 @@ defmodule OliWeb.ProjectController do
       active: :publish,
 
       # publish
+      context: SessionContext.init(conn),
       unpublished: active_publication_changes == nil,
       latest_published_publication: latest_published_publication,
       active_publication_changes: active_publication_changes,

--- a/lib/oli_web/controllers/static_page_controller.ex
+++ b/lib/oli_web/controllers/static_page_controller.ex
@@ -57,4 +57,16 @@ defmodule OliWeb.StaticPageController do
     |> put_session(:dismissed_messages, [id | dismissed_messages])
     |> send_resp(200, "Ok")
   end
+
+  def update_timezone(conn, %{"timezone" => timezone, "redirect_to" => redirect_to}) do
+    redirect_to = validate_path(conn, redirect_to)
+
+    conn
+    |> put_session("local_tz", timezone)
+    |> put_flash(:info, "Timezone updated successfully.")
+    |> redirect(to: redirect_to)
+  end
+
+  defp validate_path(_, "/" <> _ = path), do: path
+  defp validate_path(conn, _), do: Routes.static_page_path(conn, :index)
 end

--- a/lib/oli_web/live/admin/registrations/registrations_table_model.ex
+++ b/lib/oli_web/live/admin/registrations/registrations_table_model.ex
@@ -1,7 +1,7 @@
 defmodule OliWeb.Admin.RegistrationsTableModel do
   use Surface.LiveComponent
 
-  alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
+  alias OliWeb.Common.Table.{ColumnSpec, Common, SortableTableModel}
   alias OliWeb.Router.Helpers, as: Routes
   alias Surface.Components.Link
 
@@ -11,7 +11,7 @@ defmodule OliWeb.Admin.RegistrationsTableModel do
     """
   end
 
-  def new(authors) do
+  def new(authors, context) do
     SortableTableModel.new(
       rows: authors,
       column_specs: [
@@ -26,7 +26,7 @@ defmodule OliWeb.Admin.RegistrationsTableModel do
         %ColumnSpec{
           name: :inserted_at,
           label: "Created",
-          render_fn: &SortableTableModel.render_inserted_at_column/3
+          render_fn: &Common.render_date/3
         },
         %ColumnSpec{
           name: :deployments_count,
@@ -39,7 +39,10 @@ defmodule OliWeb.Admin.RegistrationsTableModel do
         }
       ],
       event_suffix: "",
-      id_field: [:id]
+      id_field: [:id],
+      data: %{
+        context: context
+      }
     )
   end
 

--- a/lib/oli_web/live/admin/registrations/registrations_view.ex
+++ b/lib/oli_web/live/admin/registrations/registrations_view.ex
@@ -4,7 +4,7 @@ defmodule OliWeb.Admin.RegistrationsView do
   alias Oli.Repo
   alias Oli.Repo.{Paging, Sorting}
   alias Oli.Accounts.Author
-  alias OliWeb.Common.{TextSearch, PagedTable, Breadcrumb}
+  alias OliWeb.Common.{TextSearch, PagedTable, Breadcrumb, SessionContext}
   alias OliWeb.Common.Table.SortableTableModel
   alias OliWeb.Router.Helpers, as: Routes
   alias OliWeb.Admin.RegistrationsTableModel
@@ -48,7 +48,8 @@ defmodule OliWeb.Admin.RegistrationsView do
       ]
   end
 
-  def mount(_, %{"current_author_id" => author_id}, socket) do
+  def mount(_, %{"current_author_id" => author_id} = session, socket) do
+    context = SessionContext.init(session)
     author = Repo.get(Author, author_id)
 
     registrations =
@@ -60,7 +61,7 @@ defmodule OliWeb.Admin.RegistrationsView do
 
     total_count = determine_total(registrations)
 
-    {:ok, table_model} = RegistrationsTableModel.new(registrations)
+    {:ok, table_model} = RegistrationsTableModel.new(registrations, context)
 
     {:ok,
      assign(socket,

--- a/lib/oli_web/live/common/card_listing.ex
+++ b/lib/oli_web/live/common/card_listing.ex
@@ -3,7 +3,6 @@ defmodule OliWeb.Common.CardListing do
 
   import OliWeb.Common.SourceImage
 
-  alias OliWeb.Router.Helpers, as: Routes
   alias OliWeb.Common.Utils
   alias OliWeb.Delivery.SelectSource.TableModel
 

--- a/lib/oli_web/live/common/card_listing.ex
+++ b/lib/oli_web/live/common/card_listing.ex
@@ -23,7 +23,7 @@ defmodule OliWeb.Common.CardListing do
               </div>
               <div class="card-footer bg-transparent d-flex justify-content-between align-items-center border-0">
                 <div class="badge badge-success mr-5">{TableModel.render_payment_column(assigns, item, nil)}</div>
-                <div class="small-date text-muted">{render_date(item, with_data(assigns, @model.data))}</div>
+                <div class="small-date text-muted">{render_date(item, Map.merge(assigns, @model.data))}</div>
               </div>
             </div>
           </a>
@@ -53,9 +53,5 @@ defmodule OliWeb.Common.CardListing do
     if TableModel.is_product?(item),
       do: "product:#{item.id}",
       else: "publication:#{item.id}"
-  end
-
-  defp with_data(assigns, data) do
-    Map.merge(assigns, data)
   end
 end

--- a/lib/oli_web/live/common/card_listing.ex
+++ b/lib/oli_web/live/common/card_listing.ex
@@ -3,12 +3,12 @@ defmodule OliWeb.Common.CardListing do
 
   import OliWeb.Common.SourceImage
 
-  alias OliWeb.Common.FormatDateTime
+  alias OliWeb.Router.Helpers, as: Routes
+  alias OliWeb.Common.Utils
   alias OliWeb.Delivery.SelectSource.TableModel
 
   prop model, :struct, required: true
   prop selected, :event, required: true
-  prop context, :any
 
   def render(assigns) do
     ~F"""
@@ -24,7 +24,7 @@ defmodule OliWeb.Common.CardListing do
               </div>
               <div class="card-footer bg-transparent d-flex justify-content-between align-items-center border-0">
                 <div class="badge badge-success mr-5">{TableModel.render_payment_column(assigns, item, nil)}</div>
-                <div class="small-date text-muted">{render_date(item, @context)}</div>
+                <div class="small-date text-muted">{render_date(item, with_data(assigns, @model.data))}</div>
               </div>
             </div>
           </a>
@@ -46,12 +46,17 @@ defmodule OliWeb.Common.CardListing do
       else:  item.project.description
   end
 
-  defp render_date(item, context),
-    do: FormatDateTime.date(Map.get(item, :inserted_at), context)
+  defp render_date(item, assigns) do
+    Utils.render_date(item, :inserted_at, Map.get(assigns, :context))
+  end
 
   defp action_id(item) do
     if TableModel.is_product?(item),
       do: "product:#{item.id}",
       else: "publication:#{item.id}"
+  end
+
+  defp with_data(assigns, data) do
+    Map.merge(assigns, data)
   end
 end

--- a/lib/oli_web/live/common/enrollment_browser/table_model.ex
+++ b/lib/oli_web/live/common/enrollment_browser/table_model.ex
@@ -19,18 +19,16 @@ defmodule OliWeb.Common.EnrollmentBrowser.TableModel do
       }
     ]
 
-    {:ok, model} =
-      SortableTableModel.new(
-        rows: users,
-        column_specs: column_specs,
-        event_suffix: "",
-        id_field: [:id],
-        data: %{
-          context: context
-        }
-      )
-
-    {:ok, Map.put(model, :data, %{section_slug: section.slug})}
+    SortableTableModel.new(
+      rows: users,
+      column_specs: column_specs,
+      event_suffix: "",
+      id_field: [:id],
+      data: %{
+        context: context,
+        section_slug: section.slug
+      }
+    )
   end
 
   def render_name_column(

--- a/lib/oli_web/live/common/listing.ex
+++ b/lib/oli_web/live/common/listing.ex
@@ -14,7 +14,6 @@ defmodule OliWeb.Common.Listing do
   prop additional_table_class, :string, default: "table-sm"
   prop cards_view, :boolean, default: false
   prop selected, :event
-  prop context, :any
 
   def render(assigns) do
     ~F"""
@@ -43,9 +42,9 @@ defmodule OliWeb.Common.Listing do
   defp render_table(assigns) do
     ~F"""
       {#if @cards_view}
-        <CardListing model={@table_model} selected={@selected} context={@context}/>
+        <CardListing model={@table_model} selected={@selected}/>
       {#else}
-        <Table model={@table_model} sort={@sort} additional_table_class={@additional_table_class} context={@context}/>
+        <Table model={@table_model} sort={@sort} additional_table_class={@additional_table_class}/>
       {/if}
     """
   end

--- a/lib/oli_web/live/common/sortable_table/table.ex
+++ b/lib/oli_web/live/common/sortable_table/table.ex
@@ -7,7 +7,6 @@ defmodule OliWeb.Common.SortableTable.Table do
   prop sort, :event, required: true
   prop select, :event
   prop additional_table_class, :string, default: "table-sm"
-  prop context, :any
 
   @spec id_field(any, %{:id_field => any, optional(any) => any}) :: any
   def id_field(row, %{id_field: id_field}) when is_list(id_field) do

--- a/lib/oli_web/live/common/table/common.ex
+++ b/lib/oli_web/live/common/table/common.ex
@@ -1,9 +1,6 @@
 defmodule OliWeb.Common.Table.Common do
-  import OliWeb.Common.FormatDateTime
-
-  alias Oli.Accounts
-  alias Oli.Accounts.Author
   alias OliWeb.Common.Table.ColumnSpec
+  alias OliWeb.Common.Utils
 
   def sort_date(direction, spec) do
     {fn r ->
@@ -17,21 +14,7 @@ defmodule OliWeb.Common.Table.Common do
      end, direction}
   end
 
-  def render_relative_date(_, item, %ColumnSpec{name: name}) do
-    date(Map.get(item, name), precision: :relative)
-  end
-
   def render_date(assigns, item, %ColumnSpec{name: name}) do
-    date(Map.get(item, name), Map.get(assigns, :context))
-  end
-
-  def author_preference_date_renderer(%Author{} = author) do
-    show_relative_dates = Accounts.get_author_preference(author, :show_relative_dates)
-
-    if show_relative_dates do
-      &render_relative_date/3
-    else
-      &render_date/3
-    end
+    Utils.render_date(item, name, Map.get(assigns, :context))
   end
 end

--- a/lib/oli_web/live/common/table/sortable_table_model.ex
+++ b/lib/oli_web/live/common/table/sortable_table_model.ex
@@ -228,9 +228,6 @@ defmodule OliWeb.Common.Table.SortableTableModel do
     end
   end
 
-  def render_inserted_at_column(assigns, %{inserted_at: inserted_at}, _),
-    do: date(inserted_at, Map.get(assigns, :context))
-
   def render_link_column(assigns, label, route_path, class \\ "") do
     ~F"""
       <Link

--- a/lib/oli_web/live/common/utils.ex
+++ b/lib/oli_web/live/common/utils.ex
@@ -25,6 +25,11 @@ defmodule OliWeb.Common.Utils do
     date(Map.get(item, attr_name), opts)
   end
 
+  def render_relative_date(item, attr_name, context) do
+    opts = [context: context, precision: :relative]
+    date(Map.get(item, attr_name), opts)
+  end
+
   def render_precise_date(item, attr_name, context) do
     opts = [context: context, precision: :minutes]
     date(Map.get(item, attr_name), opts)

--- a/lib/oli_web/live/common/utils.ex
+++ b/lib/oli_web/live/common/utils.ex
@@ -1,4 +1,6 @@
 defmodule OliWeb.Common.Utils do
+  import OliWeb.Common.FormatDateTime
+
   alias Oli.Accounts.{User, Author}
 
   def name(%User{} = user) do
@@ -16,6 +18,16 @@ defmodule OliWeb.Common.Utils do
       {true, _, _} -> name
       _ -> "Unknown"
     end
+  end
+
+  def render_date(item, attr_name, context) do
+    opts = [context: context, show_timezone: false]
+    date(Map.get(item, attr_name), opts)
+  end
+
+  def render_precise_date(item, attr_name, context) do
+    opts = [context: context, precision: :minutes]
+    date(Map.get(item, attr_name), opts)
   end
 
   defp has_value(v) do

--- a/lib/oli_web/live/community_live/associated/index_view.ex
+++ b/lib/oli_web/live/community_live/associated/index_view.ex
@@ -3,7 +3,7 @@ defmodule OliWeb.CommunityLive.Associated.IndexView do
   use OliWeb.Common.SortableTable.TableHandlers
 
   alias Oli.Groups
-  alias OliWeb.Common.{Breadcrumb, Filter, Listing}
+  alias OliWeb.Common.{Breadcrumb, Filter, Listing, SessionContext}
   alias OliWeb.CommunityLive.ShowView
   alias OliWeb.CommunityLive.Associated.{NewView, TableModel}
   alias OliWeb.Router.Helpers, as: Routes
@@ -42,12 +42,15 @@ defmodule OliWeb.CommunityLive.Associated.IndexView do
       ]
   end
 
-  def mount(%{"community_id" => community_id}, _session, socket) do
+  def mount(%{"community_id" => community_id}, session, socket) do
+    context = SessionContext.init(session)
+
     associations = Groups.list_community_visibilities(community_id)
-    {:ok, table_model} = TableModel.new(associations, :id, "remove")
+    {:ok, table_model} = TableModel.new(associations, context, :id, "remove")
 
     {:ok,
      assign(socket,
+       context: context,
        breadcrumbs: breadcrumb(community_id),
        associations: associations,
        community_id: community_id,
@@ -91,7 +94,7 @@ defmodule OliWeb.CommunityLive.Associated.IndexView do
     case Groups.delete_community_visibility(id) do
       {:ok, _community_visibility} ->
         associations = Groups.list_community_visibilities(socket.assigns.community_id)
-        {:ok, table_model} = TableModel.new(associations, :id, "remove")
+        {:ok, table_model} = TableModel.new(associations, socket.assigns.context, :id, "remove")
 
         socket =
           put_flash(socket, :info, "Association successfully removed.")

--- a/lib/oli_web/live/community_live/associated/new_view.ex
+++ b/lib/oli_web/live/community_live/associated/new_view.ex
@@ -4,7 +4,7 @@ defmodule OliWeb.CommunityLive.Associated.NewView do
 
   alias Oli.Authoring.Course
   alias Oli.Groups
-  alias OliWeb.Common.{Breadcrumb, Filter, Listing}
+  alias OliWeb.Common.{Breadcrumb, Filter, Listing, SessionContext}
   alias OliWeb.CommunityLive.Associated.{IndexView, TableModel}
   alias Oli.Delivery.Sections.Blueprint
   alias OliWeb.Router.Helpers, as: Routes
@@ -59,12 +59,14 @@ defmodule OliWeb.CommunityLive.Associated.NewView do
     end)
   end
 
-  def mount(%{"community_id" => community_id}, _session, socket) do
+  def mount(%{"community_id" => community_id}, session, socket) do
+    context = SessionContext.init(session)
     sources = retrieve_all_sources(community_id)
-    {:ok, table_model} = TableModel.new(sources)
+    {:ok, table_model} = TableModel.new(sources, context)
 
     {:ok,
      assign(socket,
+       context: context,
        breadcrumbs: breadcrumb(community_id),
        sources: sources,
        table_model: table_model,
@@ -115,7 +117,7 @@ defmodule OliWeb.CommunityLive.Associated.NewView do
     case Groups.create_community_visibility(attrs) do
       {:ok, _community_visibility} ->
         sources = retrieve_all_sources(socket.assigns.community_id)
-        {:ok, table_model} = TableModel.new(sources)
+        {:ok, table_model} = TableModel.new(sources, socket.assigns.context)
 
         socket =
           put_flash(socket, :info, "Association to #{type} successfully added.")

--- a/lib/oli_web/live/community_live/associated/table_model.ex
+++ b/lib/oli_web/live/community_live/associated/table_model.ex
@@ -2,7 +2,7 @@ defmodule OliWeb.CommunityLive.Associated.TableModel do
   use Surface.LiveComponent
 
   alias Oli.Groups.CommunityVisibility
-  alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
+  alias OliWeb.Common.Table.{ColumnSpec, Common, SortableTableModel}
   alias OliWeb.Router.Helpers, as: Routes
 
   def get_field(field, association) do
@@ -13,7 +13,7 @@ defmodule OliWeb.CommunityLive.Associated.TableModel do
     end
   end
 
-  def new(associations, id_field \\ :unique_id, action \\ "select") do
+  def new(associations, context, id_field \\ :unique_id, action \\ "select") do
     action =
       case action do
         "select" -> &__MODULE__.render_select_column/3
@@ -37,7 +37,7 @@ defmodule OliWeb.CommunityLive.Associated.TableModel do
         %ColumnSpec{
           name: :inserted_at,
           label: "Created",
-          render_fn: &SortableTableModel.render_inserted_at_column/3
+          render_fn: &Common.render_date/3
         },
         %ColumnSpec{
           name: :action,
@@ -46,7 +46,10 @@ defmodule OliWeb.CommunityLive.Associated.TableModel do
         }
       ],
       event_suffix: "",
-      id_field: [id_field]
+      id_field: [id_field],
+      data: %{
+        context: context
+      }
     )
   end
 

--- a/lib/oli_web/live/community_live/index_view.ex
+++ b/lib/oli_web/live/community_live/index_view.ex
@@ -4,7 +4,7 @@ defmodule OliWeb.CommunityLive.IndexView do
 
   alias Oli.Accounts
   alias Oli.Groups
-  alias OliWeb.Common.{Breadcrumb, Filter, Listing}
+  alias OliWeb.Common.{Breadcrumb, Filter, Listing, SessionContext}
   alias OliWeb.CommunityLive.{NewView, TableModel}
   alias OliWeb.Router.Helpers, as: Routes
   alias Surface.Components.Form
@@ -52,7 +52,7 @@ defmodule OliWeb.CommunityLive.IndexView do
 
   def mount(
         _,
-        %{"is_system_admin" => is_system_admin, "current_author_id" => author_id},
+        %{"is_system_admin" => is_system_admin, "current_author_id" => author_id} = session,
         socket
       ) do
     communities =
@@ -62,7 +62,9 @@ defmodule OliWeb.CommunityLive.IndexView do
         Accounts.list_admin_communities(author_id)
       end
 
-    {:ok, table_model} = TableModel.new(communities)
+    context = SessionContext.init(session)
+
+    {:ok, table_model} = TableModel.new(communities, context)
 
     {:ok,
      assign(socket,

--- a/lib/oli_web/live/community_live/table_model.ex
+++ b/lib/oli_web/live/community_live/table_model.ex
@@ -1,9 +1,9 @@
 defmodule OliWeb.CommunityLive.TableModel do
   alias Oli.Groups.Community
-  alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
+  alias OliWeb.Common.Table.{ColumnSpec, Common, SortableTableModel}
   alias OliWeb.Router.Helpers, as: Routes
 
-  def new(communities) do
+  def new(communities, context) do
     SortableTableModel.new(
       rows: communities,
       column_specs: [
@@ -22,7 +22,7 @@ defmodule OliWeb.CommunityLive.TableModel do
         %ColumnSpec{
           name: :inserted_at,
           label: "Created",
-          render_fn: &SortableTableModel.render_inserted_at_column/3
+          render_fn: &Common.render_date/3
         },
         %ColumnSpec{
           name: :actions,
@@ -36,7 +36,10 @@ defmodule OliWeb.CommunityLive.TableModel do
         }
       ],
       event_suffix: "",
-      id_field: [:id]
+      id_field: [:id],
+      data: %{
+        context: context
+      }
     )
   end
 

--- a/lib/oli_web/live/curriculum/entries/details.ex
+++ b/lib/oli_web/live/curriculum/entries/details.ex
@@ -5,14 +5,16 @@ defmodule OliWeb.Curriculum.DetailsLive do
 
   use OliWeb, :live_component
 
+  alias OliWeb.Common.Utils
+
   def render(assigns) do
     ~L"""
     <div class="entry-section d-flex flex-column col-4">
       <small class="text-muted">
-        Created <%= date(@child.resource.inserted_at, @context) %>
+        Created <%= Utils.render_date(@child.resource, :inserted_at, @context) %>
       </small>
       <small class="text-muted">
-        Updated <%= date(@child.inserted_at, @context) %> by <%= @child.author.name %>
+        Updated <%= Utils.render_date(@child, :updated_at, @context) %> by <%= @child.author.name %>
       </small>
     </div>
     """

--- a/lib/oli_web/live/delivery/select_source.ex
+++ b/lib/oli_web/live/delivery/select_source.ex
@@ -107,11 +107,10 @@ defmodule OliWeb.Delivery.SelectSource do
       retrieve_all_sources(live_action, %{user: user, lti_params: lti_params})
       |> Enum.with_index(fn element, index -> Map.put(element, :unique_id, index) end)
 
-    {:ok, table_model} = OliWeb.Delivery.SelectSource.TableModel.new(sources)
+    {:ok, table_model} = OliWeb.Delivery.SelectSource.TableModel.new(sources, context)
 
     {:ok,
       assign(socket,
-        context: context,
         breadcrumbs: breadcrumbs(live_action),
         delivery_breadcrumb: true,
         total_count: length(sources),
@@ -158,7 +157,7 @@ defmodule OliWeb.Delivery.SelectSource do
           page_change="page_change"
           show_bottom_paging={false}
           cards_view={is_cards_view?(@live_action, @view_type)}
-          context={@context}/>
+        />
 
         {#if is_lms_instructor?(@live_action) and is_nil(@user.author)}
           <div class="row mb-5">

--- a/lib/oli_web/live/delivery/table_model.ex
+++ b/lib/oli_web/live/delivery/table_model.ex
@@ -1,10 +1,10 @@
 defmodule OliWeb.Delivery.SelectSource.TableModel do
   use Surface.LiveComponent
 
-  alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
+  alias OliWeb.Common.Table.{ColumnSpec, Common, SortableTableModel}
   alias OliWeb.Router.Helpers, as: Routes
 
-  def new(products) do
+  def new(products, context) do
     SortableTableModel.new(
       rows: products,
       column_specs: [
@@ -33,12 +33,15 @@ defmodule OliWeb.Delivery.SelectSource.TableModel do
         %ColumnSpec{
           name: :inserted_at,
           label: "Created",
-          render_fn: &SortableTableModel.render_inserted_at_column/3,
+          render_fn: &Common.render_date/3,
           sort_fn: &OliWeb.Common.Table.Common.sort_date/2
         }
       ],
       event_suffix: "",
-      id_field: [:unique_id]
+      id_field: [:unique_id],
+      data: %{
+        context: context
+      }
     )
   end
 

--- a/lib/oli_web/live/history/revision_history.ex
+++ b/lib/oli_web/live/history/revision_history.ex
@@ -17,7 +17,7 @@ defmodule OliWeb.RevisionHistory do
   alias Oli.Authoring.Broadcaster
   alias Oli.Publishing.AuthoringResolver
   alias Oli.Authoring.Broadcaster.Subscriber
-  alias OliWeb.Common.Breadcrumb
+  alias OliWeb.Common.{Breadcrumb, SessionContext}
   alias OliWeb.History.RestoreRevisionModal
   alias Oli.Utils.SchemaResolver
   alias OliWeb.Router.Helpers, as: Routes
@@ -26,24 +26,26 @@ defmodule OliWeb.RevisionHistory do
   @page_size 15
 
   @impl Phoenix.LiveView
-  def mount(%{"slug" => slug, "project_id" => project_slug}, _, socket) do
+  def mount(%{"slug" => slug, "project_id" => project_slug}, session, socket) do
+    context = SessionContext.init(session)
     case AuthoringResolver.from_revision_slug(project_slug, slug) do
       nil -> {:ok, LiveView.redirect(socket, to: Routes.static_page_path(OliWeb.Endpoint, :not_found))}
       revision ->
-        do_mount(revision, project_slug, socket)
+        do_mount(revision, project_slug, socket, context)
     end
 
   end
 
-  def mount(%{"resource_id" => resource_id_str, "project_id" => project_slug}, _, socket) do
+  def mount(%{"resource_id" => resource_id_str, "project_id" => project_slug}, session, socket) do
+    context = SessionContext.init(session)
     case AuthoringResolver.from_resource_id(project_slug, String.to_integer(resource_id_str)) do
       nil -> {:ok, LiveView.redirect(socket, to: Routes.static_page_path(OliWeb.Endpoint, :not_found))}
       revision ->
-        do_mount(revision, project_slug, socket)
+        do_mount(revision, project_slug, socket, context)
     end
   end
 
-  defp do_mount(revision, project_slug, socket) do
+  defp do_mount(revision, project_slug, socket, context) do
     project = Course.get_project_by_slug(project_slug)
     resource_id = revision.resource_id
     slug = revision.slug
@@ -75,6 +77,7 @@ defmodule OliWeb.RevisionHistory do
     {:ok,
      socket
      |> assign(
+       context: context,
        breadcrumbs: Breadcrumb.trail_to(project_slug, slug, Oli.Publishing.AuthoringResolver) ++
         [Breadcrumb.new(%{full_title: "Revision History"})],
        view: "table",

--- a/lib/oli_web/live/history/revision_history.sface
+++ b/lib/oli_web/live/history/revision_history.sface
@@ -15,7 +15,7 @@
             { live_component Graph, tree: @tree, root: @root, selected: @selected, project: @project, initial_size: @initial_size }
           </div>
           { live_component Pagination, revisions: @revisions, page_offset: @page_offset, page_size: @page_size }
-          { live_component Table, tree: @tree, publication: @publication, mappings: @mappings, revisions: @revisions, selected: @selected, page_offset: @page_offset, page_size: @page_size }
+          { live_component Table, tree: @tree, publication: @publication, mappings: @mappings, revisions: @revisions, selected: @selected, page_offset: @page_offset, page_size: @page_size, context: @context }
         </div>
       </div>
     </div>

--- a/lib/oli_web/live/history/table.ex
+++ b/lib/oli_web/live/history/table.ex
@@ -1,6 +1,8 @@
 defmodule OliWeb.RevisionHistory.Table do
   use OliWeb, :surface_component
 
+  alias OliWeb.Common.Utils
+
   prop selected, :string
   prop revisions, :any
   prop publication, :any
@@ -8,6 +10,7 @@ defmodule OliWeb.RevisionHistory.Table do
   prop tree, :any
   prop page_offset, :number
   prop page_size, :number
+  prop context, :struct
 
   defp publication_state(assigns, revision_id) do
     publication = assigns.publication
@@ -52,8 +55,8 @@ defmodule OliWeb.RevisionHistory.Table do
         <tr id="{ rev.id }" {...tr_props.(rev.id)}>
           <td>{ rev.id }</td>
           <td>{ Map.get(@tree, rev.id).project_id }</td>
-          <td>{ date(rev.inserted_at) }</td>
-          <td>{ date(rev.updated_at) }</td>
+          <td>{ Utils.render_date(rev, :inserted_at, @context) }</td>
+          <td>{ Utils.render_date(rev, :updated_at, @context) }</td>
           <td>{ rev.author.email }</td>
           <td>{ rev.slug }</td>
           <td>{ publication_state(assigns, rev.id) }</td>

--- a/lib/oli_web/live/manual_grading/manual_grading_view.ex
+++ b/lib/oli_web/live/manual_grading/manual_grading_view.ex
@@ -20,7 +20,7 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
   use Surface.LiveView, layout: {OliWeb.LayoutView, "live.html"}
 
   alias Oli.Repo.{Paging, Sorting}
-  alias OliWeb.Common.{TextSearch, PagedTable, Breadcrumb}
+  alias OliWeb.Common.{TextSearch, PagedTable, Breadcrumb, SessionContext}
   alias Oli.Activities.Model.Part
   alias Oli.Delivery.Attempts.ManualGrading
   alias Oli.Delivery.Attempts.ManualGrading.BrowseOptions
@@ -100,7 +100,8 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
 
         activity_types_map = Enum.reduce(activities, %{}, fn e, m -> Map.put(m, e.id, e) end)
 
-        {:ok, table_model} = TableModel.new(attempts, activity_types_map)
+        context = SessionContext.init(session)
+        {:ok, table_model} = TableModel.new(attempts, activity_types_map, context)
 
         table_model = Map.put(table_model, :sort_order, :desc)
         |> Map.put(:sort_by_spec, TableModel.date_submitted_spec())

--- a/lib/oli_web/live/manual_grading/table_model.ex
+++ b/lib/oli_web/live/manual_grading/table_model.ex
@@ -2,7 +2,7 @@ defmodule OliWeb.ManualGrading.TableModel do
   alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
   use Surface.LiveComponent
 
-  def new(attempts, activity_types_map) do
+  def new(attempts, activity_types_map, context) do
     SortableTableModel.new(
       rows: attempts,
       column_specs: [
@@ -42,7 +42,8 @@ defmodule OliWeb.ManualGrading.TableModel do
       event_suffix: "",
       id_field: [:id],
       data: %{
-        activity_types_map: activity_types_map
+        activity_types_map: activity_types_map,
+        context: context
       }
     )
   end

--- a/lib/oli_web/live/products/payments/discounts/products_index_view.ex
+++ b/lib/oli_web/live/products/payments/discounts/products_index_view.ex
@@ -45,6 +45,7 @@ defmodule OliWeb.Products.Payments.Discounts.ProductsIndexView do
         {:ok, table_model} = TableModel.new(discounts, context)
 
         {:ok, assign(socket,
+          context: context,
           breadcrumbs: set_breadcrumbs(product),
           discounts: discounts,
           table_model: table_model,
@@ -87,7 +88,7 @@ defmodule OliWeb.Products.Payments.Discounts.ProductsIndexView do
     case Paywall.delete_discount(discount) do
       {:ok, _discount} ->
         discounts = Paywall.get_product_discounts(socket.assigns.product.id)
-        {:ok, table_model} = TableModel.new(discounts)
+        {:ok, table_model} = TableModel.new(discounts, socket.assigns.context)
 
         {:noreply,
           socket

--- a/lib/oli_web/live/products/payments/discounts/products_index_view.ex
+++ b/lib/oli_web/live/products/payments/discounts/products_index_view.ex
@@ -4,7 +4,7 @@ defmodule OliWeb.Products.Payments.Discounts.ProductsIndexView do
 
   alias Oli.Delivery.{Sections, Paywall}
   alias Oli.Delivery.Sections.Section
-  alias OliWeb.Common.{Breadcrumb, Listing}
+  alias OliWeb.Common.{Breadcrumb, Listing, SessionContext}
   alias OliWeb.Products.Payments.Discounts.TableModel
   alias OliWeb.Router.Helpers, as: Routes
   alias Surface.Components.Link
@@ -36,12 +36,13 @@ defmodule OliWeb.Products.Payments.Discounts.ProductsIndexView do
       ]
   end
 
-  def mount(%{"product_id" => product_slug}, _, socket) do
+  def mount(%{"product_id" => product_slug}, session, socket) do
     case Sections.get_section_by_slug(product_slug) do
       %Section{type: :blueprint} = product ->
         discounts = Paywall.get_product_discounts(product.id)
+        context = SessionContext.init(session)
 
-        {:ok, table_model} = TableModel.new(discounts)
+        {:ok, table_model} = TableModel.new(discounts, context)
 
         {:ok, assign(socket,
           breadcrumbs: set_breadcrumbs(product),

--- a/lib/oli_web/live/products/payments/discounts/table_model.ex
+++ b/lib/oli_web/live/products/payments/discounts/table_model.ex
@@ -28,7 +28,7 @@ defmodule OliWeb.Products.Payments.Discounts.TableModel do
         %ColumnSpec{
           name: :inserted_at,
           label: "Created",
-          render_fn: &SortableTableModel.render_inserted_at_column/3
+          render_fn: &OliWeb.Common.Table.Common.render_date/3
         },
         %ColumnSpec{
           name: :actions,

--- a/lib/oli_web/live/products/payments/discounts/table_model.ex
+++ b/lib/oli_web/live/products/payments/discounts/table_model.ex
@@ -5,7 +5,7 @@ defmodule OliWeb.Products.Payments.Discounts.TableModel do
   alias OliWeb.Router.Helpers, as: Routes
   alias Surface.Components.Link
 
-  def new(discounts) do
+  def new(discounts, context) do
     SortableTableModel.new(
       rows: discounts,
       column_specs: [
@@ -37,7 +37,10 @@ defmodule OliWeb.Products.Payments.Discounts.TableModel do
         }
       ],
       event_suffix: "",
-      id_field: [:id]
+      id_field: [:id],
+      data: %{
+        context: context
+      }
     )
   end
 

--- a/lib/oli_web/live/products/payments/tabel_model.ex
+++ b/lib/oli_web/live/products/payments/tabel_model.ex
@@ -2,6 +2,7 @@ defmodule OliWeb.Products.Payments.TableModel do
   use OliWeb, :surface_component
 
   alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
+  alias OliWeb.Common.Utils
 
   def new(payments, context) do
     SortableTableModel.new(
@@ -16,13 +17,13 @@ defmodule OliWeb.Products.Payments.TableModel do
         %ColumnSpec{
           name: :generation_date,
           label: "Created Date",
-          render_fn: &__MODULE__.render_gen_date_column/3,
+          render_fn: &__MODULE__.render_date_column/3,
           sort_fn: &__MODULE__.sort_date/2
         },
         %ColumnSpec{
           name: :application_date,
           label: "Application Date",
-          render_fn: &__MODULE__.render_app_date_column/3,
+          render_fn: &__MODULE__.render_date_column/3,
           sort_fn: &__MODULE__.sort_date/2
         },
         %ColumnSpec{
@@ -120,12 +121,8 @@ defmodule OliWeb.Products.Payments.TableModel do
      end, direction}
   end
 
-  def render_gen_date_column(%{context: context}, %{payment: payment}, _) do
-    date(payment.generation_date, context)
-  end
-
-  def render_app_date_column(%{context: context}, %{payment: payment}, _) do
-    date(payment.application_date, context)
+  def render_date_column(%{context: context}, %{payment: payment}, %ColumnSpec{name: name}) do
+    Utils.render_date(payment, name, context)
   end
 
   def render(assigns) do

--- a/lib/oli_web/live/products/products_tabel_model.ex
+++ b/lib/oli_web/live/products/products_tabel_model.ex
@@ -1,8 +1,8 @@
 defmodule OliWeb.Products.ProductsTableModel do
-  alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
+  alias OliWeb.Common.Table.{ColumnSpec, Common, SortableTableModel}
   alias OliWeb.Router.Helpers, as: Routes
 
-  def new(products) do
+  def new(products, context) do
     SortableTableModel.new(
       rows: products,
       column_specs: [
@@ -25,11 +25,14 @@ defmodule OliWeb.Products.ProductsTableModel do
         %ColumnSpec{
           name: :inserted_at,
           label: "Created",
-          render_fn: &SortableTableModel.render_inserted_at_column/3
+          render_fn: &Common.render_date/3
         }
       ],
       event_suffix: "",
-      id_field: [:id]
+      id_field: [:id],
+      data: %{
+        context: context
+      }
     )
   end
 

--- a/lib/oli_web/live/progress/attempt_history.ex
+++ b/lib/oli_web/live/progress/attempt_history.ex
@@ -4,12 +4,13 @@ defmodule OliWeb.Progress.AttemptHistory do
 
   prop resource_attempts, :list, required: true
   prop section, :struct, required: true
+  prop context, :struct, required: true
 
   def render(assigns) do
     ~F"""
     <div class="list-group">
       {#for attempt <- @resource_attempts}
-        <PageAttemptSummary id={attempt.id} attempt={attempt} section={@section}/>
+        <PageAttemptSummary id={attempt.id} attempt={attempt} section={@section} {=@context}/>
       {/for}
     </div>
     """

--- a/lib/oli_web/live/progress/page_attempt_summary.ex
+++ b/lib/oli_web/live/progress/page_attempt_summary.ex
@@ -1,8 +1,11 @@
 defmodule OliWeb.Progress.PageAttemptSummary do
   use OliWeb, :surface_component
   alias OliWeb.Router.Helpers, as: Routes
+  alias OliWeb.Common.Utils
+
   prop attempt, :struct, required: true
   prop section, :struct, required: true
+  prop context, :struct, required: true
 
   @spec render(
           atom
@@ -20,7 +23,7 @@ defmodule OliWeb.Progress.PageAttemptSummary do
         <h5 class="mb-1">Attempt {@attempt.attempt_number}</h5>
         <span>Not Submitted Yet</span>
       </div>
-      <p class="mb-1">Started: {date(@attempt.inserted_at)}</p>
+      <p class="mb-1">Started: {Utils.render_date(@attempt, :inserted_at, @context)}</p>
       <small class="text-muted">Time elapsed: {duration(@attempt.inserted_at, DateTime.utc_now())}.</small>
     </li>
     """

--- a/lib/oli_web/live/progress/page_attempt_summary.ex
+++ b/lib/oli_web/live/progress/page_attempt_summary.ex
@@ -37,7 +37,7 @@ defmodule OliWeb.Progress.PageAttemptSummary do
           <h5 class="mb-1">Attempt {@attempt.attempt_number}</h5>
           <span>{@attempt.score} / {@attempt.out_of}</span>
         </div>
-        <p class="mb-1 text-muted">Submitted: {date(@attempt.date_evaluated)} ({date(@attempt.date_evaluated, precision: :relative)})</p>
+        <p class="mb-1 text-muted">Submitted: {Utils.render_date(@attempt, :date_evaluated, @context)} ({Utils.render_relative_date(@attempt, :date_evaluated, @context)})</p>
         <small class="text-muted">Time elapsed: {duration(@attempt.inserted_at, @attempt.date_evaluated)}.</small>
       </a>
     </li>
@@ -51,7 +51,7 @@ defmodule OliWeb.Progress.PageAttemptSummary do
         <h5 class="mb-1">Attempt {@attempt.attempt_number}</h5>
         <span>Submitted</span>
       </div>
-      <p class="mb-1 text-muted">Submitted: {date(@attempt.date_submitted)} ({date(@attempt.date_submitted, precision: :relative)})</p>
+      <p class="mb-1 text-muted">Submitted: {Utils.render_date(@attempt, :date_submitted, @context)} ({Utils.render_relative_date(@attempt, :date_submitted, @context)})</p>
       <small class="text-muted">Time elapsed: {duration(@attempt.inserted_at, @attempt.date_submitted)}.</small>
     </li>
     """

--- a/lib/oli_web/live/progress/student_resource_view.ex
+++ b/lib/oli_web/live/progress/student_resource_view.ex
@@ -1,9 +1,9 @@
 defmodule OliWeb.Progress.StudentResourceView do
   use Surface.LiveView, layout: {OliWeb.LayoutView, "live.html"}
-  alias OliWeb.Common.{Breadcrumb}
+  alias OliWeb.Common.{Breadcrumb, SessionContext}
   alias OliWeb.Common.Properties.{Groups, Group, ReadOnly}
   alias Oli.Delivery.Attempts.Core.ResourceAccess
-  alias Surface.Components.{Form}
+  alias Surface.Components.Form
   alias Surface.Components.Form.{Field, Label, NumberInput, ErrorTag}
   alias OliWeb.Progress.AttemptHistory
   alias OliWeb.Sections.Mount
@@ -52,6 +52,7 @@ defmodule OliWeb.Progress.StudentResourceView do
             Mount.handle_error(socket, {:error, e})
 
           {type, _, section} ->
+            context = SessionContext.init(session)
             resource_access = get_resource_access(resource_id, section_slug, user_id)
 
             changeset =
@@ -62,6 +63,7 @@ defmodule OliWeb.Progress.StudentResourceView do
 
             {:ok,
              assign(socket,
+               context: context,
                changeset: changeset,
                breadcrumbs: set_breadcrumbs(type, section, user_id),
                delivery_breadcrumb: true,
@@ -156,7 +158,7 @@ defmodule OliWeb.Progress.StudentResourceView do
       </Group>
       {/if}
       <Group label="Attempt History" description="">
-        <AttemptHistory section={@section} resource_attempts={@resource_access.resource_attempts}/>
+        <AttemptHistory section={@section} resource_attempts={@resource_access.resource_attempts} {=@context}/>
       </Group>
     </Groups>
     """

--- a/lib/oli_web/live/progress/student_table_model.ex
+++ b/lib/oli_web/live/progress/student_table_model.ex
@@ -73,7 +73,6 @@ defmodule OliWeb.Progress.StudentTabelModel do
         }
       end)
 
-    {:ok, model} =
       SortableTableModel.new(
         rows: rows,
         column_specs: [
@@ -107,7 +106,7 @@ defmodule OliWeb.Progress.StudentTabelModel do
             render_fn: &__MODULE__.custom_render/3
           },
           %ColumnSpec{
-            name: :updated_at,
+            name: :inserted_at,
             label: "First Visited",
             render_fn: &OliWeb.Common.Table.Common.render_date/3,
             sort_fn: &OliWeb.Common.Table.Common.sort_date/2
@@ -122,11 +121,11 @@ defmodule OliWeb.Progress.StudentTabelModel do
         event_suffix: "",
         id_field: [:index],
         data: %{
-          context: context
+          context: context,
+          section_slug: section.slug,
+          user_id: user.id
         }
       )
-
-    {:ok, Map.put(model, :data, %{section_slug: section.slug, user_id: user.id})}
   end
 
   def custom_sort(direction, %ColumnSpec{name: name}) do

--- a/lib/oli_web/live/publisher_live/index_view.ex
+++ b/lib/oli_web/live/publisher_live/index_view.ex
@@ -2,7 +2,7 @@ defmodule OliWeb.PublisherLive.IndexView do
   use Surface.LiveView, layout: {OliWeb.LayoutView, "live.html"}
   use OliWeb.Common.SortableTable.TableHandlers
 
-  alias OliWeb.Common.{Breadcrumb, Filter, Listing}
+  alias OliWeb.Common.{Breadcrumb, Filter, Listing, SessionContext}
   alias OliWeb.PublisherLive.{NewView, TableModel}
   alias OliWeb.Router.Helpers, as: Routes
   alias Oli.Inventories
@@ -45,10 +45,11 @@ defmodule OliWeb.PublisherLive.IndexView do
     ]
   end
 
-  def mount(_, _, socket) do
+  def mount(_, session, socket) do
+    context = SessionContext.init(session)
     publishers = Inventories.list_publishers()
 
-    {:ok, table_model} = TableModel.new(publishers)
+    {:ok, table_model} = TableModel.new(publishers, context)
 
     {:ok,
      assign(socket,

--- a/lib/oli_web/live/publisher_live/table_model.ex
+++ b/lib/oli_web/live/publisher_live/table_model.ex
@@ -2,10 +2,10 @@ defmodule OliWeb.PublisherLive.TableModel do
   use Surface.LiveComponent
 
   alias Oli.Inventories.Publisher
-  alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
+  alias OliWeb.Common.Table.{ColumnSpec, Common, SortableTableModel}
   alias OliWeb.Router.Helpers, as: Routes
 
-  def new(publishers) do
+  def new(publishers, context) do
     SortableTableModel.new(
       rows: publishers,
       column_specs: [
@@ -33,7 +33,7 @@ defmodule OliWeb.PublisherLive.TableModel do
         %ColumnSpec{
           name: :inserted_at,
           label: "Created",
-          render_fn: &SortableTableModel.render_inserted_at_column/3
+          render_fn: &Common.render_date/3
         },
         %ColumnSpec{
           name: :actions,
@@ -42,7 +42,10 @@ defmodule OliWeb.PublisherLive.TableModel do
         }
       ],
       event_suffix: "",
-      id_field: [:id]
+      id_field: [:id],
+      data: %{
+        context: context
+      }
     )
   end
 

--- a/lib/oli_web/live/qa/qa_live.ex
+++ b/lib/oli_web/live/qa/qa_live.ex
@@ -6,7 +6,7 @@ defmodule OliWeb.Qa.QaLive do
 
   import Phoenix.HTML.Link
 
-  alias OliWeb.Common.SessionContext
+  alias OliWeb.Common.{SessionContext, Utils}
   alias Oli.Authoring.Course
   alias Oli.Qa
   alias OliWeb.Qa.WarningFilter
@@ -159,7 +159,7 @@ defmodule OliWeb.Qa.QaLive do
         <div class="row mt-4">
           <div class="col-12">
             <p class="mb-3">
-              Last reviewed <strong><%= (hd @qa_reviews).inserted_at |> date(@context) %></strong>,
+              Last reviewed <strong><%= Utils.render_date(hd(@qa_reviews), :inserted_at, @context) %></strong>,
               with <strong><%= length @warnings %></strong> potential improvement <%= if (length @warnings) == 1 do "opportunity" else "opportunities" end %> found.
             </p>
             <%= if !Enum.empty?(@warnings_by_type) do %>

--- a/lib/oli_web/live/sections/enrollments_table_model.ex
+++ b/lib/oli_web/live/sections/enrollments_table_model.ex
@@ -44,18 +44,16 @@ defmodule OliWeb.Delivery.Sections.EnrollmentsTableModel do
         base_columns
       end
 
-    {:ok, model} =
-      SortableTableModel.new(
-        rows: users,
-        column_specs: column_specs,
-        event_suffix: "",
-        id_field: [:id],
-        data: %{
-          context: context
-        }
-      )
-
-    {:ok, Map.put(model, :data, %{section_slug: section.slug})}
+    SortableTableModel.new(
+      rows: users,
+      column_specs: column_specs,
+      event_suffix: "",
+      id_field: [:id],
+      data: %{
+        context: context,
+        section_slug: section.slug
+      }
+    )
   end
 
   def render_name_column(

--- a/lib/oli_web/live/sections/gating_and_scheduling/edit.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling/edit.ex
@@ -48,7 +48,7 @@ defmodule OliWeb.Sections.GatingAndScheduling.Edit do
     <div class="container">
       <h3>{@title}</h3>
 
-      <Form id="new_gating_contition" section={@section} gating_condition={@gating_condition} parent_gate={@parent_gate} count_exceptions={@count_exceptions} create_or_update={:update} timezone={@context.local_tz}/>
+      <Form id="new_gating_contition" section={@section} gating_condition={@gating_condition} parent_gate={@parent_gate} count_exceptions={@count_exceptions} create_or_update={:update} {=@context}/>
     </div>
     """
   end

--- a/lib/oli_web/live/sections/gating_and_scheduling/gating_condition_store.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling/gating_condition_store.ex
@@ -441,11 +441,10 @@ defmodule OliWeb.Delivery.Sections.GatingAndScheduling.GatingConditionStore do
       ) do
     %{
       gating_condition: %{data: data} = gating_condition,
-      context: %{local_tz: local_tz},
-      section: section
+      context: context
     } = socket.assigns
 
-    utc_datetime = FormatDateTime.datestring_to_utc_datetime(value, local_tz || section.timezone)
+    utc_datetime = FormatDateTime.datestring_to_utc_datetime(value, context)
     data = Map.put(data, :start_datetime, utc_datetime)
 
     {:noreply, assign(socket, gating_condition: %{gating_condition | data: data})}
@@ -458,11 +457,10 @@ defmodule OliWeb.Delivery.Sections.GatingAndScheduling.GatingConditionStore do
       ) do
     %{
       gating_condition: %{data: data} = gating_condition,
-      context: %{local_tz: local_tz},
-      section: section
+      context: context
     } = socket.assigns
 
-    utc_datetime = FormatDateTime.datestring_to_utc_datetime(value, local_tz || section.timezone)
+    utc_datetime = FormatDateTime.datestring_to_utc_datetime(value, context)
     data = Map.put(data, :end_datetime, utc_datetime)
 
     {:noreply, assign(socket, gating_condition: %{gating_condition | data: data})}

--- a/lib/oli_web/live/sections/gating_and_scheduling/new.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling/new.ex
@@ -44,7 +44,7 @@ defmodule OliWeb.Sections.GatingAndScheduling.New do
     <div class="container">
       <h3>{@title}</h3>
 
-      <Form id="new_gating_contition" section={@section} gating_condition={@gating_condition} parent_gate={@parent_gate} count_exceptions={@count_exceptions} timezone={@context.local_tz}/>
+      <Form id="new_gating_contition" section={@section} gating_condition={@gating_condition} parent_gate={@parent_gate} count_exceptions={@count_exceptions} {=@context}/>
     </div>
     """
   end

--- a/lib/oli_web/live/sections/gating_and_scheduling/table_model.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling/table_model.ex
@@ -1,8 +1,9 @@
 defmodule OliWeb.Delivery.Sections.GatingAndScheduling.TableModel do
   use OliWeb, :surface_component
 
-  alias Surface.Components.{Link}
+  alias Surface.Components.Link
   alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
+  alias OliWeb.Common.Utils
   alias Oli.Resources.Revision
   alias Oli.Delivery.Gating.{GatingCondition, GatingConditionData}
   alias OliWeb.Common.SessionContext
@@ -89,16 +90,16 @@ defmodule OliWeb.Delivery.Sections.GatingAndScheduling.TableModel do
           data: %GatingConditionData{
             start_datetime: start_datetime,
             end_datetime: end_datetime
-          }
+          } = data
         },
         _
       ) do
     ~F"""
       <div :if={start_datetime}>
-        <b>Start:</b> {date(start_datetime, context: context, precision: :minutes)}
+        <b>Start:</b> {Utils.render_precise_date(data, :start_datetime, context)}
       </div>
       <div :if={end_datetime}>
-        <b>End:</b> {date(end_datetime, context: context, precision: :minutes)}
+        <b>End:</b> {Utils.render_precise_date(data, :end_datetime, context)}
       </div>
     """
   end

--- a/lib/oli_web/live/sections/invite/invitation.ex
+++ b/lib/oli_web/live/sections/invite/invitation.ex
@@ -1,9 +1,11 @@
 defmodule OliWeb.Sections.Invites.Invitation do
   use OliWeb, :surface_component
   alias OliWeb.Router.Helpers, as: Routes
+  alias OliWeb.Common.Utils
 
   prop invitation, :struct, required: true
   prop delete, :event, required: true
+  prop context, :struct, required: true
 
   def render(assigns) do
     assigns
@@ -27,10 +29,10 @@ defmodule OliWeb.Sections.Invites.Invitation do
         </div>
       </div>
       {#if active}
-        <p class="mb-1">Expires: {date(@invitation.date_expires)}</p>
+        <p class="mb-1">Expires: {Utils.render_precise_date(@invitation, :date_expires, @context)}</p>
         <small class="text-muted">Time remaining: {duration(@invitation.date_expires, DateTime.utc_now())}.</small>
       {#else}
-        <p class="mb-1">Expired: {date(@invitation.date_expires)}</p>
+        <p class="mb-1">Expired: {Utils.render_precise_date(@invitation, :date_expires, @context)}</p>
       {/if}
     </li>
     """

--- a/lib/oli_web/live/sections/invite_view.ex
+++ b/lib/oli_web/live/sections/invite_view.ex
@@ -3,11 +3,10 @@ defmodule OliWeb.Sections.InviteView do
 
   import Oli.Utils.Time
 
-  alias OliWeb.Common.{Breadcrumb}
   alias Oli.Delivery.Sections.SectionInvites
   alias OliWeb.Sections.Invites.Invitation
   alias OliWeb.Router.Helpers, as: Routes
-  alias OliWeb.Common.Confirm
+  alias OliWeb.Common.{Breadcrumb, Confirm, SessionContext}
   alias OliWeb.Sections.Mount
 
   data breadcrumbs, :any
@@ -39,6 +38,7 @@ defmodule OliWeb.Sections.InviteView do
       {type, _, section} ->
         {:ok,
          assign(socket,
+           context: SessionContext.init(session),
            delivery_breadcrumb: true,
            breadcrumbs: set_breadcrumbs(type, section),
            section: section,
@@ -65,7 +65,7 @@ defmodule OliWeb.Sections.InviteView do
     {#if length(@invitations) > 0}
       <div class="list-group">
       {#for invitation <- @invitations}
-        <Invitation id={invitation.id} invitation={invitation} delete="request_delete"/>
+        <Invitation id={invitation.id} invitation={invitation} delete="request_delete" {=@context}/>
       {/for}
       </div>
     {/if}

--- a/lib/oli_web/live/sections/open_free_settings.ex
+++ b/lib/oli_web/live/sections/open_free_settings.ex
@@ -41,11 +41,6 @@ defmodule OliWeb.Sections.OpenFreeSettings do
         <Label class="form-check-label">Omit student email verification</Label>
       </Field>
 
-      <Field name={:timezone} class="mt-2">
-        <Label/>
-        <Select class="form-control" form="section" field="timezone" options={Predefined.timezones()} selected={get_field(@changeset, :timezone)}/>
-      </Field>
-
       <div class="form-row mt-4">
         <Field name={:start_date} class="mr-3 form-label-group">
           <div class="d-flex justify-content-between"><Label/><ErrorTag class="help-block"/></div>
@@ -55,6 +50,11 @@ defmodule OliWeb.Sections.OpenFreeSettings do
           <div class="d-flex justify-content-between"><Label/><ErrorTag class="help-block"/></div>
           <DateTimeLocalInput class="form-control" value={end_date} opts={disabled: @disabled}/>
         </Field>
+      </div>
+      <div class="form-row">
+        <small class="text-nowrap form-text text-muted">
+          Timezone: {@context.local_tz}
+        </small>
       </div>
 
       <button class="btn btn-primary mt-3" type="submit">Save</button>

--- a/lib/oli_web/live/sections/open_free_settings.ex
+++ b/lib/oli_web/live/sections/open_free_settings.ex
@@ -3,27 +3,27 @@ defmodule OliWeb.Sections.OpenFreeSettings do
 
   alias Surface.Components.{Field, Select}
   alias Surface.Components.Form.{Field, Label, DateTimeLocalInput, Select, Checkbox, ErrorTag}
-  alias OliWeb.Common.Properties.{Group}
+  alias OliWeb.Common.FormatDateTime
+  alias OliWeb.Common.Properties.Group
   alias Oli.Predefined
   import Ecto.Changeset
 
   prop changeset, :any, required: true
   prop disabled, :boolean, required: true
   prop is_admin, :boolean, required: true
-
-  def timezone_localized_datetime(nil, _timezone), do: nil
-
-  def timezone_localized_datetime(%DateTime{} = datetime, timezone) do
-    case maybe_localized_datetime(datetime, timezone) do
-      {:localized, datetime} ->
-        datetime
-
-      datetime ->
-        datetime
-    end
-  end
+  prop context, :struct, required: true
 
   def render(assigns) do
+    start_date =
+      assigns.changeset
+      |> Ecto.Changeset.get_field(:start_date)
+      |> FormatDateTime.convert_datetime(assigns.context)
+
+    end_date =
+      assigns.changeset
+      |> Ecto.Changeset.get_field(:end_date)
+      |> FormatDateTime.convert_datetime(assigns.context)
+
     ~F"""
     <Group label="Direct Delivery" description="Direct Delivery section settings">
       <Field name={:registration_open} class="form-check">
@@ -49,11 +49,11 @@ defmodule OliWeb.Sections.OpenFreeSettings do
       <div class="form-row mt-4">
         <Field name={:start_date} class="mr-3 form-label-group">
           <div class="d-flex justify-content-between"><Label/><ErrorTag class="help-block"/></div>
-          <DateTimeLocalInput class="form-control" value={timezone_localized_datetime(get_field(@changeset, :start_date), get_field(@changeset, :timezone))} opts={disabled: @disabled}/>
+          <DateTimeLocalInput class="form-control" value={start_date} opts={disabled: @disabled}/>
         </Field>
         <Field name={:end_date} class="form-label-group">
           <div class="d-flex justify-content-between"><Label/><ErrorTag class="help-block"/></div>
-          <DateTimeLocalInput class="form-control" value={timezone_localized_datetime(get_field(@changeset, :end_date), get_field(@changeset, :timezone))} opts={disabled: @disabled}/>
+          <DateTimeLocalInput class="form-control" value={end_date} opts={disabled: @disabled}/>
         </Field>
       </div>
 

--- a/lib/oli_web/live/sections/open_free_settings.ex
+++ b/lib/oli_web/live/sections/open_free_settings.ex
@@ -1,11 +1,10 @@
 defmodule OliWeb.Sections.OpenFreeSettings do
   use OliWeb, :surface_component
 
-  alias Surface.Components.{Field, Select}
-  alias Surface.Components.Form.{Field, Label, DateTimeLocalInput, Select, Checkbox, ErrorTag}
+  alias Surface.Components.Field
+  alias Surface.Components.Form.{Field, Label, DateTimeLocalInput, Checkbox, ErrorTag}
   alias OliWeb.Common.FormatDateTime
   alias OliWeb.Common.Properties.Group
-  alias Oli.Predefined
   import Ecto.Changeset
 
   prop changeset, :any, required: true

--- a/lib/oli_web/live/system_message_live/edit_message.ex
+++ b/lib/oli_web/live/system_message_live/edit_message.ex
@@ -16,11 +16,21 @@ defmodule OliWeb.SystemMessageLive.EditMessage do
   }
 
   prop system_message, :struct, required: true
-  prop timezone, :string, required: true
+  prop context, :struct, required: true
   prop save, :event, required: true
 
   def render(assigns) do
     changeset = Notifications.change_system_message(assigns.system_message)
+
+    start_date =
+      changeset
+      |> Ecto.Changeset.get_field(:start)
+      |> FormatDateTime.convert_datetime(assigns.context)
+
+    end_date =
+      changeset
+      |> Ecto.Changeset.get_field(:end)
+      |> FormatDateTime.convert_datetime(assigns.context)
 
     ~F"""
       <Form for={changeset} submit={@save} class="d-flex align-items-center">
@@ -38,12 +48,12 @@ defmodule OliWeb.SystemMessageLive.EditMessage do
         <div class="flex-grow-1 py-2 px-3">
           <Field name={:start} class="form-group d-flex align-items-center">
             <Label class="control-label pr-4 flex-basis-20" text="Start"/>
-            <DateTimeLocalInput class="form-control w-75" value={timezone_localized_datetime(Ecto.Changeset.get_field(changeset, :start), @timezone)}/>
+            <DateTimeLocalInput class="form-control w-75" value={start_date}/>
             <ErrorTag/>
           </Field>
           <Field name={:end} class="form-group d-flex align-items-center">
             <Label class="control-label pr-4 flex-basis-20" text="End"/>
-            <DateTimeLocalInput class="form-control w-75" value={timezone_localized_datetime(Ecto.Changeset.get_field(changeset, :end), @timezone)}/>
+            <DateTimeLocalInput class="form-control w-75" value={end_date}/>
             <ErrorTag/>
           </Field>
         </div>
@@ -59,17 +69,5 @@ defmodule OliWeb.SystemMessageLive.EditMessage do
         </div>
       </Form>
     """
-  end
-
-  defp timezone_localized_datetime(nil, _timezone), do: nil
-
-  defp timezone_localized_datetime(datetime, timezone) do
-    case FormatDateTime.maybe_localized_datetime(datetime, timezone) do
-      {:localized, datetime} ->
-        datetime
-
-      datetime ->
-        datetime
-    end
   end
 end

--- a/lib/oli_web/live/users/authors_table_model.ex
+++ b/lib/oli_web/live/users/authors_table_model.ex
@@ -13,7 +13,7 @@ defmodule OliWeb.Users.AuthorsTableModel do
     """
   end
 
-  def new(authors) do
+  def new(authors, context) do
     SortableTableModel.new(
       rows: authors,
       column_specs: [
@@ -38,7 +38,10 @@ defmodule OliWeb.Users.AuthorsTableModel do
         }
       ],
       event_suffix: "",
-      id_field: [:id]
+      id_field: [:id],
+      data: %{
+        context: context
+      }
     )
   end
 

--- a/lib/oli_web/live/users/authors_view.ex
+++ b/lib/oli_web/live/users/authors_view.ex
@@ -7,7 +7,7 @@ defmodule OliWeb.Users.AuthorsView do
   alias Oli.Accounts
   alias Oli.Accounts.AuthorBrowseOptions
   alias Oli.Repo.{Paging, Sorting}
-  alias OliWeb.Common.{Breadcrumb, PagedTable, TextSearch}
+  alias OliWeb.Common.{Breadcrumb, PagedTable, SessionContext, TextSearch}
   alias OliWeb.Common.Table.SortableTableModel
   alias OliWeb.Router.Helpers, as: Routes
   alias OliWeb.Users.AuthorsTableModel
@@ -42,7 +42,7 @@ defmodule OliWeb.Users.AuthorsView do
       ]
   end
 
-  def mount(_, %{"current_author_id" => author_id}, socket) do
+  def mount(_, %{"current_author_id" => author_id} = session, socket) do
     author = Accounts.get_author(author_id)
 
     authors =
@@ -52,8 +52,9 @@ defmodule OliWeb.Users.AuthorsView do
         @default_options
       )
 
+    context = SessionContext.init(session)
     total_count = SortableTableModel.determine_total(authors)
-    {:ok, table_model} = AuthorsTableModel.new(authors)
+    {:ok, table_model} = AuthorsTableModel.new(authors, context)
 
     {:ok,
      assign(socket,

--- a/lib/oli_web/live/users/common.ex
+++ b/lib/oli_web/live/users/common.ex
@@ -2,6 +2,7 @@ defmodule OliWeb.Users.Common do
   use OliWeb, :surface_component
 
   alias Oli.Accounts
+  alias OliWeb.Common.Utils
 
   def render(assigns) do
     ~F"""
@@ -28,28 +29,28 @@ defmodule OliWeb.Users.Common do
           cond do
             Accounts.user_confirmation_pending?(row) ->
               ~F"""
-              <span data-toggle="tooltip" data-html="true" title={"<b>Confirmation Pending</b> sent to #{email}"}>
+              <span data-toggle="tooltip" data-html="true" title={"Confirmation Pending sent to #{email}"}>
                 <i class="las la-paper-plane text-secondary"></i>
               </span>
               """
 
             not is_nil(email_confirmed_at) ->
               ~F"""
-              <span data-toggle="tooltip" data-html="true" title={"<b>Email Confirmed</b> on #{date(email_confirmed_at)}"}>
+              <span data-toggle="tooltip" data-html="true" title={"Email Confirmed on #{Utils.render_precise_date(row, :email_confirmed_at, @context)}"}>
                 <i class="las la-check text-success"></i>
               </span>
               """
 
             not is_nil(invitation_accepted_at) ->
               ~F"""
-              <span data-toggle="tooltip" data-html="true" title={"<b>Invitation Accepted</b> on #{date(invitation_accepted_at)}"}>
+              <span data-toggle="tooltip" data-html="true" title={"Invitation Accepted on #{Utils.render_precise_date(row, :invitation_accepted_at, @context)}"}>
                 <i class="las la-check text-success"></i>
               </span>
               """
 
             true ->
               ~F"""
-              <span data-toggle="tooltip" data-html="true" title={"<b>Invitation Pending</b> sent to #{email}"}>
+              <span data-toggle="tooltip" data-html="true" title={"Invitation Pending sent to #{email}"}>
                 <i class="las la-paper-plane text-secondary"></i>
               </span>
               """

--- a/lib/oli_web/live/users/user_detail_view.ex
+++ b/lib/oli_web/live/users/user_detail_view.ex
@@ -16,7 +16,7 @@ defmodule OliWeb.Users.UsersDetailView do
     ConfirmEmailModal
   }
 
-  alias OliWeb.Common.Breadcrumb
+  alias OliWeb.Common.{Breadcrumb, SessionContext}
   alias OliWeb.Common.Properties.{Groups, Group, ReadOnly}
   alias OliWeb.Pow.UserContext
   alias OliWeb.Router.Helpers, as: Routes
@@ -50,9 +50,10 @@ defmodule OliWeb.Users.UsersDetailView do
 
   def mount(
         %{"user_id" => user_id},
-        %{"csrf_token" => csrf_token},
+        %{"csrf_token" => csrf_token} = session,
         socket
       ) do
+    context = SessionContext.init(session)
     user = user_with_platform_roles(user_id)
 
     case user do
@@ -62,6 +63,7 @@ defmodule OliWeb.Users.UsersDetailView do
       user ->
         {:ok,
          assign(socket,
+           context: context,
            breadcrumbs: set_breadcrumbs(user),
            user: user,
            csrf_token: csrf_token,
@@ -107,8 +109,8 @@ defmodule OliWeb.Users.UsersDetailView do
             </section>
             <ReadOnly label="Research Opt Out" value={boolean(@user.research_opt_out)}/>
             <ReadOnly label="Email Confirmed" value={date(@user.email_confirmed_at)}/>
-            <ReadOnly label="Created" value={date(@user.inserted_at)}/>
-            <ReadOnly label="Last Updated" value={date(@user.updated_at)}/>
+            <ReadOnly label="Created" value={render_date(@user, :inserted_at, @context)}/>
+            <ReadOnly label="Last Updated" value={render_date(@user, :updated_at, @context)}/>
             <Submit class="float-right btn btn-md btn-primary mt-2">Save</Submit>
           </Form>
         </Group>
@@ -119,7 +121,7 @@ defmodule OliWeb.Users.UsersDetailView do
                 <li class="list-group-item">
                   <div class="d-flex pb-2 mb-2 border-bottom">
                     <div class="flex-grow-1">{lti_params.issuer}</div>
-                    <div>Last Updated: {date(lti_params.updated_at)}</div>
+                    <div>Last Updated: {render_date(lti_params, :updated_at, @context)}</div>
                   </div>
                   <div style="max-height: 400px; overflow: scroll;">
                     <pre> <code

--- a/lib/oli_web/live/users/user_detail_view.ex
+++ b/lib/oli_web/live/users/user_detail_view.ex
@@ -108,7 +108,7 @@ defmodule OliWeb.Users.UsersDetailView do
               </div>
             </section>
             <ReadOnly label="Research Opt Out" value={boolean(@user.research_opt_out)}/>
-            <ReadOnly label="Email Confirmed" value={date(@user.email_confirmed_at)}/>
+            <ReadOnly label="Email Confirmed" value={render_date(@user, :email_confirmed_at, @context)}/>
             <ReadOnly label="Created" value={render_date(@user, :inserted_at, @context)}/>
             <ReadOnly label="Last Updated" value={render_date(@user, :updated_at, @context)}/>
             <Submit class="float-right btn btn-md btn-primary mt-2">Save</Submit>

--- a/lib/oli_web/live/users/users_table_model.ex
+++ b/lib/oli_web/live/users/users_table_model.ex
@@ -12,7 +12,7 @@ defmodule OliWeb.Users.UsersTableModel do
     """
   end
 
-  def new(users) do
+  def new(users, context) do
     SortableTableModel.new(
       rows: users,
       column_specs: [
@@ -34,7 +34,10 @@ defmodule OliWeb.Users.UsersTableModel do
         }
       ],
       event_suffix: "",
-      id_field: [:id]
+      id_field: [:id],
+      data: %{
+        context: context
+      }
     )
   end
 

--- a/lib/oli_web/live/users/users_view.ex
+++ b/lib/oli_web/live/users/users_view.ex
@@ -7,7 +7,7 @@ defmodule OliWeb.Users.UsersView do
   alias Oli.Accounts
   alias Oli.Accounts.UserBrowseOptions
   alias Oli.Repo.{Paging, Sorting}
-  alias OliWeb.Common.{Breadcrumb, Check, PagedTable, TextSearch}
+  alias OliWeb.Common.{Breadcrumb, Check, PagedTable, SessionContext, TextSearch}
   alias OliWeb.Common.Table.SortableTableModel
   alias OliWeb.Router.Helpers, as: Routes
   alias OliWeb.Users.UsersTableModel
@@ -41,7 +41,7 @@ defmodule OliWeb.Users.UsersView do
       ]
   end
 
-  def mount(_, _, socket) do
+  def mount(_, session, socket) do
     users =
       Accounts.browse_users(
         %Paging{offset: 0, limit: @limit},
@@ -50,7 +50,9 @@ defmodule OliWeb.Users.UsersView do
       )
 
     total_count = SortableTableModel.determine_total(users)
-    {:ok, table_model} = UsersTableModel.new(users)
+
+    context = SessionContext.init(session)
+    {:ok, table_model} = UsersTableModel.new(users, context)
 
     {:ok,
      assign(socket,

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -276,6 +276,9 @@ defmodule OliWeb.Router do
     get("/", StaticPageController, :index)
     get("/unauthorized", StaticPageController, :unauthorized)
     get("/not_found", StaticPageController, :not_found)
+
+    # update session timezone information
+    post("/update_timezone", StaticPageController, :update_timezone)
   end
 
   scope "/", OliWeb do

--- a/lib/oli_web/templates/institution/index.html.eex
+++ b/lib/oli_web/templates/institution/index.html.eex
@@ -114,7 +114,7 @@
               <td><%= pending_registration.name %></td>
               <td><%= pending_registration.institution_url %></td>
               <td><%= pending_registration.institution_email %></td>
-              <td><%= pending_registration.inserted_at |> date(@conn) %></td>
+              <td><%= OliWeb.Common.Utils.render_date(pending_registration, :inserted_at, @context) %></td>
 
               <td class="text-nowrap">
                 <a href="#review-<%= pending_registration.id %>" class="btn btn-sm btn-outline-primary ml-2" data-toggle="modal" data-target="#review-<%= pending_registration.id %>">Review</button>

--- a/lib/oli_web/templates/layout/_author_account_dropdown.html.heex
+++ b/lib/oli_web/templates/layout/_author_account_dropdown.html.heex
@@ -15,7 +15,7 @@
         <%= ReactPhoenix.ClientSide.react_component("Components.DarkModeSelector", %{showLabels: false}) %>
       </div>
       <div class="dropdown-item no-hover">
-        Update timezone
+        Timezone
         <br>
         <OliWeb.Common.SelectTimezone.render selected={Plug.Conn.get_session(@conn, "local_tz")} conn={@conn}/>
       </div>

--- a/lib/oli_web/templates/layout/_author_account_dropdown.html.heex
+++ b/lib/oli_web/templates/layout/_author_account_dropdown.html.heex
@@ -3,7 +3,7 @@
     <a class="user nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
       <div class="block lg:inline-block lg:mt-0 text-grey-darkest no-underline hover:underline mr-4">
         <div class="username"><%= @current_author.name %></div>
-        <div class="role text-right <%= author_role_color @current_author %>"><%= author_role_text @current_author %></div>
+        <div class={"role text-right #{author_role_color(@current_author)}"}><%= author_role_text @current_author %></div>
       </div>
       <div class="user-icon"><%= author_icon(assigns) %></div>
     </a>
@@ -13,6 +13,11 @@
       <div class="dropdown-item no-hover">
         Dark Mode
         <%= ReactPhoenix.ClientSide.react_component("Components.DarkModeSelector", %{showLabels: false}) %>
+      </div>
+      <div class="dropdown-item no-hover">
+        Update timezone
+        <br>
+        <OliWeb.Common.SelectTimezone.render selected={Plug.Conn.get_session(@conn, "local_tz")} conn={@conn}/>
       </div>
       <div class="dropdown-divider"></div>
 

--- a/lib/oli_web/templates/layout/_user_account_dropdown.html.heex
+++ b/lib/oli_web/templates/layout/_user_account_dropdown.html.heex
@@ -49,7 +49,7 @@
         </div>
       <% end %>
       <div class="dropdown-item no-hover">
-        Update timezone
+        Timezone
         <br>
         <OliWeb.Common.SelectTimezone.render selected={Plug.Conn.get_session(@conn, "local_tz")} conn={@conn}/>
       </div>

--- a/lib/oli_web/templates/layout/_user_account_dropdown.html.heex
+++ b/lib/oli_web/templates/layout/_user_account_dropdown.html.heex
@@ -4,7 +4,7 @@
       <div class="username">
         <%= user_name @current_user %>
       </div>
-      <div class="role text-right" style="color: <%= user_role_color @conn, @current_user %>;">
+      <div class="role text-right" style={"color: #{user_role_color(@conn, @current_user)};"}>
         <%= user_role_text @conn, @current_user %>
       </div>
     </div>
@@ -33,10 +33,10 @@
       <%= if (not user_role_is_student(@conn, @current_user)) or Sections.is_independent_instructor?(@current_user) do %>
         <%= if account_linked?(@current_user) do %>
           <h6 class="dropdown-header">Linked: <%= @current_user.author.email %></h6>
-          <a class="dropdown-item" href="<%= Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.ProjectsLive) %>" target="_blank">Go to Course Author <i class="fas fa-external-link-alt float-right" style="margin-top: 2px"></i></a>
-          <a class="dropdown-item" href="<%= Routes.delivery_path(@conn, :link_account) %>" target="_blank">Link a different account</a>
+          <a class="dropdown-item" href={Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.ProjectsLive)} target="_blank">Go to Course Author <i class="fas fa-external-link-alt float-right" style="margin-top: 2px"></i></a>
+          <a class="dropdown-item" href={Routes.delivery_path(@conn, :link_account)} target="_blank">Link a different account</a>
         <% else %>
-          <a class="dropdown-item" href="<%= Routes.delivery_path(@conn, :link_account) %>" target="_blank">Link Existing Account</a>
+          <a class="dropdown-item" href={Routes.delivery_path(@conn, :link_account)} target="_blank">Link Existing Account</a>
         <% end %>
         <div class="dropdown-divider"></div>
       <% end %>
@@ -47,14 +47,18 @@
           Dark Mode
           <%= ReactPhoenix.ClientSide.react_component("Components.DarkModeSelector", %{showLabels: false}) %>
         </div>
-        <div class="dropdown-divider"></div>
       <% end %>
+      <div class="dropdown-item no-hover">
+        Update timezone
+        <br>
+        <OliWeb.Common.SelectTimezone.render selected={Plug.Conn.get_session(@conn, "local_tz")} conn={@conn}/>
+      </div>
+      <div class="dropdown-divider"></div>
 
       <%= if user_is_independent_learner?(@current_user) or Sections.is_independent_instructor?(@current_user) do %>
         <%= link "My Courses", to: Routes.delivery_path(@conn, :open_and_free_index), class: "dropdown-item btn" %>
         <div class="dropdown-divider"></div>
       <% end %>
-
       <%= link "Sign out", to: Routes.session_path(@conn, :signout, type: :user), method: :delete, id: "signout-link", class: "dropdown-item btn" %>
     </div>
   <% end %>

--- a/lib/oli_web/templates/open_and_free/form.html.eex
+++ b/lib/oli_web/templates/open_and_free/form.html.eex
@@ -31,6 +31,11 @@
         <%= datetime_local_input f, :start_date, class: "form-control " <> error_class(f, :start_date, "is-invalid"),
           autofocus: focusHelper(f, :start_date) %>
       </div>
+      <div>
+        <small class="text-nowrap form-text text-muted">
+          Timezone: <%= @context.local_tz %>
+        </small>
+      </div>
       <%= error_tag f, :start_date %>
     </div>
     <div class="form-group col-md-6">
@@ -41,13 +46,6 @@
       </div>
       <%= error_tag f, :end_date %>
     </div>
-  </div>
-
-  <div class="text-secondary my-1">Time Zone</div>
-  <div class="form-label-group">
-    <%= select f, :timezone, @timezones, prompt: "Select Timezone", class: "form-control " <> error_class(f, :timezone, "is-invalid"),
-      required: true, autofocus: focusHelper(f, :timezone) %>
-    <%= error_tag f, :timezone %>
   </div>
 
   <div class="text-secondary my-2">Brand</div>

--- a/lib/oli_web/templates/open_and_free/show.html.eex
+++ b/lib/oli_web/templates/open_and_free/show.html.eex
@@ -44,10 +44,6 @@
         </td>
       </tr>
       <tr>
-        <td><strong>Timezone:</strong></td>
-        <td><%= @section.timezone %></td>
-      </tr>
-      <tr>
         <td><strong>Registration:</strong></td>
         <td>
           <%= if @section.registration_open do %>

--- a/lib/oli_web/templates/open_and_free/show.html.eex
+++ b/lib/oli_web/templates/open_and_free/show.html.eex
@@ -26,22 +26,20 @@
       <tr>
         <td><strong>Start Date:</strong></td>
         <td>
-          <%= case @section.start_date do %>
-            <% nil -> %>
-              <span class="text-secondary font-italic">None</span>
-            <% start_date -> %>
-              <%= date(start_date, show_timezone: true) %>
+          <%= if is_nil(@section.start_date) do %>
+            <span class="text-secondary font-italic">None</span>
+          <% else %>
+            <%= Utils.render_precise_date(@section, :start_date, @context) %>
           <% end %>
         </td>
       </tr>
       <tr>
         <td><strong>End Date:</strong></td>
         <td>
-          <%= case @section.end_date do %>
-            <% nil -> %>
-              <span class="text-secondary font-italic">None</span>
-            <% end_date -> %>
-              <%= date(end_date, show_timezone: true) %>
+          <%= if is_nil(@section.end_date) do %>
+            <span class="text-secondary font-italic">None</span>
+          <% else %>
+            <%= Utils.render_precise_date(@section, :end_date, @context) %>
           <% end %>
         </td>
       </tr>

--- a/lib/oli_web/templates/page_delivery/page.html.eex
+++ b/lib/oli_web/templates/page_delivery/page.html.eex
@@ -14,7 +14,7 @@ window.userToken = "<%= assigns[:user_token] %>";
     <div class="mb-2">
     <div class="row justify-content-start">
       <div class="col-sm-3">Started:</div>
-      <div><%= date(@resource_attempt.inserted_at, @conn) %></div>
+      <div><%= OliWeb.Common.Utils.render_date(@resource_attempt, :inserted_at, @session_context) %></div>
     </div>
     <div class="row">
       <div class="col-sm-3">Submitted:</div>
@@ -35,7 +35,7 @@ window.userToken = "<%= assigns[:user_token] %>";
     <h3>Awaiting Instructor Grading</h3>
     <div class="row justify-content-start">
       <div class="col-sm-3">Started:</div>
-      <div><%= date(@resource_attempt.inserted_at, @conn) %></div>
+      <div><%= OliWeb.Common.Utils.render_date(@resource_attempt, :inserted_at, @session_context) %></div>
     </div>
     <div class="row">
       <div class="col-sm-3">Submitted:</div>

--- a/lib/oli_web/templates/page_delivery/page.html.eex
+++ b/lib/oli_web/templates/page_delivery/page.html.eex
@@ -18,7 +18,7 @@ window.userToken = "<%= assigns[:user_token] %>";
     </div>
     <div class="row">
       <div class="col-sm-3">Submitted:</div>
-      <div><%= date(@resource_attempt.date_evaluated, @conn) %></div>
+      <div><%= OliWeb.Common.Utils.render_date(@resource_attempt, :date_evaluated, @session_context) %></div>
     </div>
     <div class="row">
       <div class="col-sm-3">Score:</div>
@@ -39,7 +39,7 @@ window.userToken = "<%= assigns[:user_token] %>";
     </div>
     <div class="row">
       <div class="col-sm-3">Submitted:</div>
-      <div><%= date(@resource_attempt.date_submitted, @conn) %></div>
+      <div><%= OliWeb.Common.Utils.render_date(@resource_attempt, :date_submitted, @session_context) %></div>
     </div>
     </div>
   <% end %>

--- a/lib/oli_web/templates/page_delivery/prologue.html.eex
+++ b/lib/oli_web/templates/page_delivery/prologue.html.eex
@@ -28,7 +28,7 @@
     </div>
     <div class="row">
       <div class="col-sm-3">Submitted:</div>
-      <div><%= date(resource_attempt.date_evaluated, @conn) %></div>
+      <div><%= OliWeb.Common.Utils.render_date(resource_attempt, :date_evaluated, @session_context) %></div>
     </div>
     <div class="row">
       <div class="col-sm-3">Score:</div>

--- a/lib/oli_web/templates/page_delivery/prologue.html.eex
+++ b/lib/oli_web/templates/page_delivery/prologue.html.eex
@@ -24,7 +24,7 @@
     </h5>
     <div class="row justify-content-start">
       <div class="col-sm-3">Started:</div>
-      <div><%= date(resource_attempt.inserted_at, @conn) %></div>
+      <div><%= OliWeb.Common.Utils.render_date(resource_attempt, :inserted_at, @session_context) %></div>
     </div>
     <div class="row">
       <div class="col-sm-3">Submitted:</div>

--- a/lib/oli_web/templates/project/publish.html.eex
+++ b/lib/oli_web/templates/project/publish.html.eex
@@ -10,11 +10,11 @@
           </div>
         <% {false, _} -> %>
           <div class="my-3">
-            Last published <strong><%= @latest_published_publication.published |> date(@conn) %></strong>.
+            Last published <strong><%= Utils.render_date(@latest_published_publication, :published, @context) %></strong>.
             There are <strong>no changes</strong> since the latest publication.
           </div>
         <% {true, changes} -> %>
-          <div class="my-3">Last published <strong><%= @latest_published_publication.published |> date(@conn) %></strong>.
+          <div class="my-3">Last published <strong><%= Utils.render_date(@latest_published_publication, :published, @context) %></strong>.
           <% change_count =  Map.values(changes) |> Enum.count %>
             There <%= if change_count == 1 do "is" else "are" end %> <strong><%= change_count %></strong> pending <%= if change_count == 1 do "change" else "changes" end %> since last publish:</div>
           <%= for {status, %{revision: revision}}  <- Map.values(changes) do %>

--- a/lib/oli_web/views/open_and_free_view.ex
+++ b/lib/oli_web/views/open_and_free_view.ex
@@ -1,6 +1,8 @@
 defmodule OliWeb.OpenAndFreeView do
   use OliWeb, :view
 
+  alias OliWeb.Common.Utils
+
   def index_path(:admin), do: Routes.admin_open_and_free_path(OliWeb.Endpoint, :index)
 
   def index_path(:independent_learner),

--- a/lib/oli_web/views/project_view.ex
+++ b/lib/oli_web/views/project_view.ex
@@ -1,6 +1,8 @@
 defmodule OliWeb.ProjectView do
   use OliWeb, :view
 
+  alias OliWeb.Common.Utils
+
   def resource_link(activity_map, slug, title, conn, project) do
     if Map.get(activity_map, slug) do
       link(title,

--- a/priv/repo/migrations/20220617134522_remove_timezone_from_sections.exs
+++ b/priv/repo/migrations/20220617134522_remove_timezone_from_sections.exs
@@ -1,0 +1,9 @@
+defmodule Oli.Repo.Migrations.RemoveTimezoneFromSections do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sections) do
+      remove :timezone, :string, default: "Etc/Greenwich"
+    end
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -172,7 +172,6 @@ if Application.fetch_env!(:oli, :env) == :dev do
       |> Map.put("base_project_id", seeds.project.id)
       |> Map.put("open_and_free", true)
       |> Map.put("context_id", UUID.uuid4())
-      |> Map.put("timezone", "US/Mountain")
 
     section =
       with {:ok, section} <- Oli.Delivery.Sections.create_section(section_params),

--- a/test/oli/sections_test.exs
+++ b/test/oli/sections_test.exs
@@ -17,7 +17,6 @@ defmodule Oli.SectionsTest do
       open_and_free: true,
       registration_open: true,
       start_date: ~U[2010-04-17 00:00:00.000000Z],
-      timezone: "some timezone",
       title: "some title",
       context_id: "context_id"
     }
@@ -150,7 +149,6 @@ defmodule Oli.SectionsTest do
       open_and_free: true,
       registration_open: true,
       start_date: ~U[2010-04-17 00:00:00.000000Z],
-      timezone: "some timezone",
       title: "some title",
       context_id: "some context_id"
     }
@@ -159,7 +157,6 @@ defmodule Oli.SectionsTest do
       open_and_free: false,
       registration_open: false,
       start_date: ~U[2011-05-18 00:00:00.000000Z],
-      timezone: "some updated timezone",
       title: "some updated title",
       context_id: "some updated context_id"
     }
@@ -168,7 +165,6 @@ defmodule Oli.SectionsTest do
       open_and_free: nil,
       registration_open: nil,
       start_date: nil,
-      timezone: nil,
       title: nil,
       context_id: nil
     }
@@ -196,7 +192,6 @@ defmodule Oli.SectionsTest do
       assert section.end_date == ~U[2010-04-17 00:00:00Z]
       assert section.registration_open == true
       assert section.start_date == ~U[2010-04-17 00:00:00Z]
-      assert section.timezone == "some timezone"
       assert section.title == "some title"
       refute section.pay_by_institution
     end
@@ -255,7 +250,6 @@ defmodule Oli.SectionsTest do
       assert section.end_date == ~U[2011-05-18 00:00:00Z]
       assert section.registration_open == false
       assert section.start_date == ~U[2011-05-18 00:00:00Z]
-      assert section.timezone == "some updated timezone"
       assert section.title == "some updated title"
     end
 
@@ -388,7 +382,6 @@ defmodule Oli.SectionsTest do
       {:ok, section} =
         Sections.create_section(%{
           title: "1",
-          timezone: "1",
           registration_open: true,
           context_id: UUID.uuid4(),
           institution_id: institution.id,
@@ -443,7 +436,6 @@ defmodule Oli.SectionsTest do
       {:ok, section} =
         Sections.create_section(%{
           title: "1",
-          timezone: "1",
           registration_open: true,
           context_id: UUID.uuid4(),
           institution_id: institution.id,
@@ -558,7 +550,6 @@ defmodule Oli.SectionsTest do
       {:ok, section} =
         Sections.create_section(%{
           title: "1",
-          timezone: "1",
           registration_open: true,
           context_id: UUID.uuid4(),
           institution_id: institution.id,
@@ -705,7 +696,6 @@ defmodule Oli.SectionsTest do
       {:ok, section} =
         Sections.create_section(%{
           title: "1",
-          timezone: "1",
           registration_open: true,
           context_id: UUID.uuid4(),
           institution_id: institution.id,

--- a/test/oli_web/controllers/institution_controller_test.exs
+++ b/test/oli_web/controllers/institution_controller_test.exs
@@ -150,6 +150,27 @@ defmodule OliWeb.InstitutionControllerTest do
                assert Institutions.count_pending_registrations() == 0
              end) =~ "This message cannot be sent because SLACK_WEBHOOK_URL is not configured"
     end
+
+    test "displays pending registration data", context do
+      {:ok, conn: conn, context: session_context} = set_timezone(context)
+
+      pending_registration = pending_registration_fixture()
+
+      conn = get(conn, Routes.institution_path(conn, :index))
+
+      assert html_response(conn, 200) =~ pending_registration.name
+      assert html_response(conn, 200) =~ pending_registration.institution_url
+      assert html_response(conn, 200) =~ pending_registration.institution_email
+
+      assert html_response(conn, 200) =~
+               OliWeb.Common.Utils.render_date(
+                 pending_registration,
+                 :inserted_at,
+                 session_context
+               )
+
+      assert html_response(conn, 200) =~ "Decline"
+    end
   end
 
   defp create_institution(%{conn: conn}) do

--- a/test/oli_web/controllers/open_and_free_controller_test.exs
+++ b/test/oli_web/controllers/open_and_free_controller_test.exs
@@ -8,7 +8,6 @@ defmodule OliWeb.OpenAndFreeControllerTest do
     open_and_free: true,
     registration_open: true,
     start_date: ~U[2010-04-17 00:00:00.000000Z],
-    timezone: "America/Los_Angeles",
     title: "some title",
     context_id: "some context_id"
   }
@@ -17,7 +16,6 @@ defmodule OliWeb.OpenAndFreeControllerTest do
     open_and_free: true,
     registration_open: false,
     start_date: ~U[2010-05-18 00:00:00.000000Z],
-    timezone: "US/Mountain",
     title: "some updated title",
     context_id: "some updated context_id"
   }
@@ -26,7 +24,6 @@ defmodule OliWeb.OpenAndFreeControllerTest do
     open_and_free: nil,
     registration_open: nil,
     start_date: nil,
-    timezone: nil,
     title: nil,
     context_id: nil
   }

--- a/test/oli_web/controllers/open_and_free_controller_test.exs
+++ b/test/oli_web/controllers/open_and_free_controller_test.exs
@@ -38,9 +38,9 @@ defmodule OliWeb.OpenAndFreeControllerTest do
   end
 
   describe "new" do
-    setup [:create_fixtures]
+    setup [:create_fixtures, :set_timezone]
 
-    test "renders form from product", %{conn: conn, section: section} do
+    test "renders form from product", %{conn: conn, section: section, context: session_context} do
       conn =
         get(conn, Routes.admin_open_and_free_path(conn, :new, source_id: "product:#{section.id}"))
 
@@ -54,9 +54,15 @@ defmodule OliWeb.OpenAndFreeControllerTest do
 
       assert conn.resp_body =~
                ~r/<input .* id="section_requires_enrollment" .* value="true"/
+
+      assert html_response(conn, 200) =~ "Timezone: " <> session_context.local_tz
     end
 
-    test "renders form from publication", %{conn: conn, publication: publication} do
+    test "renders form from publication", %{
+      conn: conn,
+      publication: publication,
+      context: session_context
+    } do
       conn =
         get(
           conn,
@@ -73,9 +79,11 @@ defmodule OliWeb.OpenAndFreeControllerTest do
 
       assert conn.resp_body =~
                ~r/<input .* id="section_requires_enrollment" .* value="true"/
+
+      assert html_response(conn, 200) =~ "Timezone: " <> session_context.local_tz
     end
 
-    test "renders form from project", %{conn: conn, project: project} do
+    test "renders form from project", %{conn: conn, project: project, context: session_context} do
       conn =
         get(conn, Routes.admin_open_and_free_path(conn, :new, source_id: "project:#{project.id}"))
 
@@ -89,6 +97,8 @@ defmodule OliWeb.OpenAndFreeControllerTest do
 
       assert conn.resp_body =~
                ~r/<input .* id="section_requires_enrollment" .* value="true"/
+
+      assert html_response(conn, 200) =~ "Timezone: " <> session_context.local_tz
     end
   end
 
@@ -140,6 +150,22 @@ defmodule OliWeb.OpenAndFreeControllerTest do
       conn = get(conn, Routes.admin_open_and_free_path(conn, :edit, section))
       assert html_response(conn, 200) =~ "Edit Section"
     end
+
+    test "displays start and end dates using the local timezone", %{section: section} = context do
+      {:ok, conn: conn, context: session_context} = set_timezone(context)
+
+      conn = get(conn, Routes.admin_open_and_free_path(conn, :edit, section))
+
+      timezone = session_context.local_tz
+
+      assert html_response(conn, 200) =~
+               utc_datetime_to_localized_datestring(section.start_date, timezone)
+
+      assert html_response(conn, 200) =~
+               utc_datetime_to_localized_datestring(section.end_date, timezone)
+
+      assert html_response(conn, 200) =~ "Timezone: " <> timezone
+    end
   end
 
   describe "update open_and_free section" do
@@ -179,7 +205,9 @@ defmodule OliWeb.OpenAndFreeControllerTest do
         institution_id: institution.id,
         base_project_id: project.id,
         context_id: UUID.uuid4(),
-        open_and_free: true
+        open_and_free: true,
+        start_date: DateTime.utc_now(),
+        end_date: DateTime.add(DateTime.utc_now(), 3600)
       })
 
     %{

--- a/test/oli_web/controllers/page_delivery_controller_test.exs
+++ b/test/oli_web/controllers/page_delivery_controller_test.exs
@@ -8,7 +8,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
   alias Oli.Seeder
   alias Oli.Delivery.Attempts.Core.{ResourceAttempt, PartAttempt, ResourceAccess}
   alias Lti_1p3.Tool.ContextRoles
-  alias OliWeb.Common.FormatDateTime
+  alias OliWeb.Common.{FormatDateTime, Utils}
   alias OliWeb.Router.Helpers, as: Routes
 
   describe "page_delivery_controller index" do
@@ -79,40 +79,56 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert html_response(conn, 200) =~ "Not authorized"
     end
 
-    test "handles student access who is not enrolled when section requires enrollment", %{conn: conn, section: section} do
-      {:ok, section} = Sections.update_section(section, %{
-        requires_payment: true,
-        amount: Money.new(:USD, 100),
-        has_grace_period: false,
-        requires_enrollment: true
-      })
+    test "handles student access who is not enrolled when section requires enrollment", %{
+      conn: conn,
+      section: section
+    } do
+      {:ok, section} =
+        Sections.update_section(section, %{
+          requires_payment: true,
+          amount: Money.new(:USD, 100),
+          has_grace_period: false,
+          requires_enrollment: true
+        })
 
       conn = get(conn, Routes.page_delivery_path(conn, :index, section.slug))
 
       assert html_response(conn, 200) =~ "Not authorized"
     end
 
-    test "handles student access who is enrolled but has not paid", %{conn: conn, user: user, section: section} do
-      {:ok, section} = Sections.update_section(section, %{
-        requires_payment: true,
-        amount: Money.new(:USD, 100),
-        has_grace_period: false
-      })
+    test "handles student access who is enrolled but has not paid", %{
+      conn: conn,
+      user: user,
+      section: section
+    } do
+      {:ok, section} =
+        Sections.update_section(section, %{
+          requires_payment: true,
+          amount: Money.new(:USD, 100),
+          has_grace_period: false
+        })
+
       Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
 
       conn = get(conn, Routes.page_delivery_path(conn, :index, section.slug))
 
       assert html_response(conn, 302) =~
-        "You are being <a href=\"#{Routes.payment_path(conn, :guard, section.slug)}\">redirected"
+               "You are being <a href=\"#{Routes.payment_path(conn, :guard, section.slug)}\">redirected"
     end
 
-    test "handles student access who is enrolled, has not paid but is pay by institution", %{conn: conn, user: user, section: section} do
-      {:ok, section} = Sections.update_section(section, %{
-        requires_payment: true,
-        amount: Money.new(:USD, 100),
-        has_grace_period: false,
-        pay_by_institution: true
-      })
+    test "handles student access who is enrolled, has not paid but is pay by institution", %{
+      conn: conn,
+      user: user,
+      section: section
+    } do
+      {:ok, section} =
+        Sections.update_section(section, %{
+          requires_payment: true,
+          amount: Money.new(:USD, 100),
+          has_grace_period: false,
+          pay_by_institution: true
+        })
+
       Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
 
       conn = get(conn, Routes.page_delivery_path(conn, :index, section.slug))
@@ -193,11 +209,17 @@ defmodule OliWeb.PageDeliveryControllerTest do
         recycle(conn)
         |> Pow.Plug.assign_current_user(user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
 
+      {:ok, conn: conn, context: session_context} = set_timezone(%{conn: conn})
+
       conn = get(conn, Routes.page_delivery_path(conn, :page, section.slug, page_revision.slug))
 
       assert html_response(conn, 200) =~ "You have 0 attempts remaining out of 1 total attempt"
 
       assert html_response(conn, 200) =~ "Attempt 1 of 1"
+      assert html_response(conn, 200) =~ Utils.render_date(attempt, :inserted_at, session_context)
+
+      assert html_response(conn, 200) =~
+               Utils.render_date(attempt, :date_evaluated, session_context)
 
       # visit assessment review page
       conn =
@@ -627,13 +649,18 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert html_response(conn, 200) =~ "Course Overview"
     end
 
-    test "handles student access who has not paid when section not requires enrollment", %{conn: conn, section: section} do
+    test "handles student access who has not paid when section not requires enrollment", %{
+      conn: conn,
+      section: section
+    } do
       user = insert(:user)
-      {:ok, section} = Sections.update_section(section, %{
-        requires_payment: true,
-        amount: Money.new(:USD, 100),
-        has_grace_period: false
-      })
+
+      {:ok, section} =
+        Sections.update_section(section, %{
+          requires_payment: true,
+          amount: Money.new(:USD, 100),
+          has_grace_period: false
+        })
 
       conn =
         recycle(conn)
@@ -641,17 +668,20 @@ defmodule OliWeb.PageDeliveryControllerTest do
         |> get(Routes.page_delivery_path(conn, :index, section.slug))
 
       assert html_response(conn, 302) =~
-        "You are being <a href=\"#{Routes.payment_path(conn, :guard, section.slug)}\">redirected"
+               "You are being <a href=\"#{Routes.payment_path(conn, :guard, section.slug)}\">redirected"
     end
 
-    test "handles student access who is not enrolled and has not paid when section requires enrollment", %{conn: conn, section: section} do
+    test "handles student access who is not enrolled and has not paid when section requires enrollment",
+         %{conn: conn, section: section} do
       user = insert(:user)
-      {:ok, section} = Sections.update_section(section, %{
-        requires_payment: true,
-        amount: Money.new(:USD, 100),
-        has_grace_period: false,
-        requires_enrollment: true
-      })
+
+      {:ok, section} =
+        Sections.update_section(section, %{
+          requires_payment: true,
+          amount: Money.new(:USD, 100),
+          has_grace_period: false,
+          requires_enrollment: true
+        })
 
       conn =
         recycle(conn)
@@ -661,14 +691,20 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert html_response(conn, 200) =~ "Not authorized"
     end
 
-    test "handles student access who is enrolled but has not paid", %{conn: conn, section: section} do
+    test "handles student access who is enrolled but has not paid", %{
+      conn: conn,
+      section: section
+    } do
       user = insert(:user)
-      {:ok, section} = Sections.update_section(section, %{
-        requires_payment: true,
-        amount: Money.new(:USD, 100),
-        has_grace_period: false,
-        requires_enrollment: true
-      })
+
+      {:ok, section} =
+        Sections.update_section(section, %{
+          requires_payment: true,
+          amount: Money.new(:USD, 100),
+          has_grace_period: false,
+          requires_enrollment: true
+        })
+
       Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
 
       conn =
@@ -677,7 +713,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
         |> get(Routes.page_delivery_path(conn, :index, section.slug))
 
       assert html_response(conn, 302) =~
-        "You are being <a href=\"#{Routes.payment_path(conn, :guard, section.slug)}\">redirected"
+               "You are being <a href=\"#{Routes.payment_path(conn, :guard, section.slug)}\">redirected"
     end
   end
 
@@ -777,69 +813,119 @@ defmodule OliWeb.PageDeliveryControllerTest do
     test "export enrollments as csv", %{conn: conn} do
       user = insert(:user)
       section = insert(:section, open_and_free: true)
-      {:ok, enrollment} = Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
 
-      conn = post(conn, Routes.page_delivery_path(OliWeb.Endpoint, :export_enrollments, section.slug))
+      {:ok, enrollment} =
+        Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+
+      conn =
+        post(conn, Routes.page_delivery_path(OliWeb.Endpoint, :export_enrollments, section.slug))
 
       assert response(conn, 200) =~
-        "Cost: Free\r\nDiscount N/A\r\n\r\nStudent name,Student email,Enrolled on\r\n#{user.name},#{user.email},\"#{FormatDateTime.date(enrollment.inserted_at)}\"\r\n"
+               "Cost: Free\r\nDiscount N/A\r\n\r\nStudent name,Student email,Enrolled on\r\n#{user.name},#{user.email},\"#{FormatDateTime.date(enrollment.inserted_at)}\"\r\n"
     end
 
     test "export enrollments as csv with discount info - percentage", %{conn: conn} do
       institution = insert(:institution)
-      product = insert(:section, %{type: :blueprint, institution: institution, requires_payment: true, amount: Money.new(:USD, 100)})
+
+      product =
+        insert(:section, %{
+          type: :blueprint,
+          institution: institution,
+          requires_payment: true,
+          amount: Money.new(:USD, 100)
+        })
+
       insert(:discount, section: product, institution: institution)
 
       tool_jwk = jwk_fixture()
       registration = insert(:lti_registration, %{tool_jwk_id: tool_jwk.id})
-      deployment = insert(:lti_deployment, %{institution: institution, registration: registration})
+
+      deployment =
+        insert(:lti_deployment, %{institution: institution, registration: registration})
+
       section = insert(:section, blueprint: product, lti_1p3_deployment: deployment)
 
       user = insert(:user)
-      {:ok, enrollment} = Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
 
-      conn = post(conn, Routes.page_delivery_path(OliWeb.Endpoint, :export_enrollments, section.slug))
+      {:ok, enrollment} =
+        Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+
+      conn =
+        post(conn, Routes.page_delivery_path(OliWeb.Endpoint, :export_enrollments, section.slug))
 
       assert response(conn, 200) =~
-        "Cost: Free\r\nDiscount By Product-Institution: 10.0%\r\n\r\nStudent name,Student email,Enrolled on\r\n#{user.name},#{user.email},\"#{FormatDateTime.date(enrollment.inserted_at)}\"\r\n"
+               "Cost: Free\r\nDiscount By Product-Institution: 10.0%\r\n\r\nStudent name,Student email,Enrolled on\r\n#{user.name},#{user.email},\"#{FormatDateTime.date(enrollment.inserted_at)}\"\r\n"
     end
 
     test "export enrollments as csv with discount info - amount", %{conn: conn} do
       institution = insert(:institution)
-      product = insert(:section, %{type: :blueprint, institution: institution, requires_payment: true, amount: Money.new(:USD, 100)})
-      insert(:discount, section: product, institution: institution, type: :fixed_amount, amount: Money.new(:USD, 100))
+
+      product =
+        insert(:section, %{
+          type: :blueprint,
+          institution: institution,
+          requires_payment: true,
+          amount: Money.new(:USD, 100)
+        })
+
+      insert(:discount,
+        section: product,
+        institution: institution,
+        type: :fixed_amount,
+        amount: Money.new(:USD, 100)
+      )
 
       tool_jwk = jwk_fixture()
       registration = insert(:lti_registration, %{tool_jwk_id: tool_jwk.id})
-      deployment = insert(:lti_deployment, %{institution: institution, registration: registration})
+
+      deployment =
+        insert(:lti_deployment, %{institution: institution, registration: registration})
+
       section = insert(:section, blueprint: product, lti_1p3_deployment: deployment)
 
       user = insert(:user)
-      {:ok, enrollment} = Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
 
-      conn = post(conn, Routes.page_delivery_path(OliWeb.Endpoint, :export_enrollments, section.slug))
+      {:ok, enrollment} =
+        Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+
+      conn =
+        post(conn, Routes.page_delivery_path(OliWeb.Endpoint, :export_enrollments, section.slug))
 
       assert response(conn, 200) =~
-        "Cost: Free\r\nDiscount By Product-Institution: $100.00\r\n\r\nStudent name,Student email,Enrolled on\r\n#{user.name},#{user.email},\"#{FormatDateTime.date(enrollment.inserted_at)}\"\r\n"
+               "Cost: Free\r\nDiscount By Product-Institution: $100.00\r\n\r\nStudent name,Student email,Enrolled on\r\n#{user.name},#{user.email},\"#{FormatDateTime.date(enrollment.inserted_at)}\"\r\n"
     end
 
     test "export enrollments as csv with discount info - institution wide", %{conn: conn} do
       institution = insert(:institution)
-      product = insert(:section, %{type: :blueprint, institution: institution, requires_payment: true, amount: Money.new(:USD, 100)})
+
+      product =
+        insert(:section, %{
+          type: :blueprint,
+          institution: institution,
+          requires_payment: true,
+          amount: Money.new(:USD, 100)
+        })
+
       insert(:discount, institution: institution, section: nil)
 
       tool_jwk = jwk_fixture()
       registration = insert(:lti_registration, %{tool_jwk_id: tool_jwk.id})
-      deployment = insert(:lti_deployment, %{institution: institution, registration: registration})
+
+      deployment =
+        insert(:lti_deployment, %{institution: institution, registration: registration})
+
       section = insert(:section, blueprint: product, lti_1p3_deployment: deployment)
 
       user = insert(:user)
-      {:ok, enrollment} = Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
 
-      conn = post(conn, Routes.page_delivery_path(OliWeb.Endpoint, :export_enrollments, section.slug))
+      {:ok, enrollment} =
+        Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+
+      conn =
+        post(conn, Routes.page_delivery_path(OliWeb.Endpoint, :export_enrollments, section.slug))
 
       assert response(conn, 200) =~
-        "Cost: Free\r\nDiscount By Institution: 10.0%\r\n\r\nStudent name,Student email,Enrolled on\r\n#{user.name},#{user.email},\"#{FormatDateTime.date(enrollment.inserted_at)}\"\r\n"
+               "Cost: Free\r\nDiscount By Institution: 10.0%\r\n\r\nStudent name,Student email,Enrolled on\r\n#{user.name},#{user.email},\"#{FormatDateTime.date(enrollment.inserted_at)}\"\r\n"
     end
   end
 

--- a/test/oli_web/controllers/project_controller_test.exs
+++ b/test/oli_web/controllers/project_controller_test.exs
@@ -68,6 +68,18 @@ defmodule OliWeb.ProjectControllerTest do
       conn = get(conn, Routes.project_path(conn, :publish, project.slug))
       assert html_response(conn, 200) =~ "Publish"
     end
+
+    test "displays the published date", %{project: project} = context do
+      {:ok, conn: conn, context: session_context} = set_timezone(context)
+      {:ok, publication} = Oli.Publishing.publish_project(project, "New publication")
+
+      conn = get(conn, Routes.project_path(conn, :publish, project.slug))
+      assert html_response(conn, 200) =~ "Publish"
+
+      assert html_response(conn, 200) =~
+               "Last published <strong>" <>
+                 OliWeb.Common.Utils.render_date(publication, :published, session_context)
+    end
   end
 
   describe "insights" do

--- a/test/oli_web/live/admin_live_test.exs
+++ b/test/oli_web/live/admin_live_test.exs
@@ -321,7 +321,7 @@ defmodule OliWeb.AdminLiveTest do
     setup [:admin_conn, :create_user]
 
     test "loads correctly with user data", %{conn: conn, user: user} do
-      {:ok, view, _html} = live(conn, live_view_user_detail_route(user.id))
+      {:ok, view, _} = live(conn, live_view_user_detail_route(user.id))
 
       assert has_element?(view, "input[value=\"#{user.sub}\"]")
       assert has_element?(view, "input[value=\"#{user.name}\"]")
@@ -332,9 +332,9 @@ defmodule OliWeb.AdminLiveTest do
       assert has_element?(view, "#user_independent_learner")
       assert has_element?(view, "#user_can_create_sections")
       assert has_element?(view, "input[value=\"#{user.research_opt_out}\"]")
-      assert has_element?(view, "input[value=\"#{user.email_confirmed_at}\"]")
-      assert has_element?(view, "input[value=\"#{date(user.inserted_at)}\"]")
-      assert has_element?(view, "input[value=\"#{date(user.updated_at)}\"]")
+      assert has_element?(view, "input[value=\"#{date(user.email_confirmed_at, precision: :relative)}\"]")
+      assert has_element?(view, "input[value=\"#{date(user.inserted_at, precision: :relative)}\"]")
+      assert has_element?(view, "input[value=\"#{date(user.updated_at, precision: :relative)}\"]")
     end
 
     test "displays error message when submit fails", %{

--- a/test/oli_web/live/community_live_test.exs
+++ b/test/oli_web/live/community_live_test.exs
@@ -181,6 +181,20 @@ defmodule OliWeb.CommunityLiveTest do
       refute has_element?(view, "##{first_c.id}")
       assert has_element?(view, "##{last_c.id}")
     end
+
+    test "renders datetimes using the local timezone", context do
+      {:ok, conn: conn, context: session_context} = set_timezone(context)
+
+      c1 = insert(:community)
+
+      {:ok, view, _html} = live(conn, @live_view_index_route)
+
+      assert has_element?(
+               view,
+               "tr##{c1.id}",
+               OliWeb.Common.Utils.render_date(c1, :inserted_at, session_context)
+             )
+    end
   end
 
   describe "new" do
@@ -972,7 +986,8 @@ defmodule OliWeb.CommunityLiveTest do
 
     test "applies paging", %{conn: conn, community: community} do
       [first_cv | tail] =
-        insert_list(26, :community_visibility, %{community: community}) |> Enum.sort_by(& &1.project.title)
+        insert_list(26, :community_visibility, %{community: community})
+        |> Enum.sort_by(& &1.project.title)
 
       last_cv = List.last(tail)
 
@@ -987,6 +1002,20 @@ defmodule OliWeb.CommunityLiveTest do
 
       refute has_element?(view, "##{first_cv.id}")
       assert has_element?(view, "##{last_cv.id}")
+    end
+
+    test "renders datetimes using the local timezone", %{community: community} = context do
+      {:ok, conn: conn, context: session_context} = set_timezone(context)
+
+      cv1 = insert(:community_visibility, %{community: community})
+
+      {:ok, view, _html} = live(conn, live_view_associated_index_route(community.id))
+
+      assert has_element?(
+               view,
+               "tr##{cv1.id}",
+               OliWeb.Common.Utils.render_date(cv1, :inserted_at, session_context)
+             )
     end
   end
 
@@ -1116,12 +1145,12 @@ defmodule OliWeb.CommunityLiveTest do
       assert view
              |> element("tr:first-child > td:first-child")
              |> render() =~
-              first_p.title
+               first_p.title
 
       refute view
              |> element("tr:last-child > td:first-child")
              |> render() =~
-              last_p.title
+               last_p.title
 
       view
       |> element("a[phx-click=\"page_change\"]", "2")
@@ -1130,7 +1159,21 @@ defmodule OliWeb.CommunityLiveTest do
       assert view
              |> element("tr:first-child > td:first-child")
              |> render() =~
-              last_p.title
+               last_p.title
+    end
+
+    test "renders datetimes using the local timezone", %{community: community} = context do
+      s = insert(:section)
+
+      {:ok, conn: conn, context: session_context} = set_timezone(context)
+
+      {:ok, view, _html} = live(conn, live_view_associated_new_route(community.id))
+
+      assert element(
+               view,
+               "tbody",
+               OliWeb.Common.Utils.render_date(s, :inserted_at, session_context)
+             )
     end
   end
 

--- a/test/oli_web/live/discounts_live_test.exs
+++ b/test/oli_web/live/discounts_live_test.exs
@@ -158,6 +158,18 @@ defmodule OliWeb.DiscountsLiveTest do
       refute has_element?(view, "##{first_discount.id}")
       assert has_element?(view, "##{last_discount.id}")
     end
+
+    test "renders datetimes using the local timezone", %{product: product} = context do
+      {:ok, conn: conn, context: session_context} = set_timezone(context)
+
+      discount = insert(:discount, section: product)
+
+      {:ok, view, _html} = live(conn, live_view_products_index_route(product.slug))
+
+      assert view
+        |> element("tbody tr:first-child.##{discount.id}")
+        |> render() =~ OliWeb.Common.Utils.render_date(discount, :inserted_at, session_context)
+    end
   end
 
   describe "discount show view - product" do

--- a/test/oli_web/live/publisher_live_test.exs
+++ b/test/oli_web/live/publisher_live_test.exs
@@ -149,6 +149,18 @@ defmodule OliWeb.PublisherLiveTest do
       refute has_element?(view, "##{first_p.id}")
       assert has_element?(view, "##{last_p.id}")
     end
+
+    test "renders datetimes using the local timezone", context do
+      {:ok, conn: conn, context: session_context} = set_timezone(context)
+      publisher = Inventories.default_publisher()
+
+      {:ok, view, _html} = live(conn, @live_view_index_route)
+
+      assert view
+             |> element("tr##{publisher.id}")
+             |> render() =~
+               OliWeb.Common.Utils.render_date(publisher, :inserted_at, session_context)
+    end
   end
 
   describe "new" do

--- a/test/oli_web/live/sections/edit_live_test.exs
+++ b/test/oli_web/live/sections/edit_live_test.exs
@@ -138,6 +138,29 @@ defmodule OliWeb.Sections.EditLiveTest do
                "None"
     end
 
+    test "loads open and free section datetimes correctly using the local timezone", context do
+      {:ok, conn: conn, context: _} = set_timezone(context)
+      timezone = Plug.Conn.get_session(conn, :local_tz)
+
+      section = insert(:section_with_dates, open_and_free: true)
+
+      {:ok, view, _html} = live(conn, live_view_edit_route(section.slug))
+
+      assert view
+             |> element("#section_start_date")
+             |> render() =~
+               utc_datetime_to_localized_datestring(section.start_date, timezone)
+
+      assert view
+             |> element("#section_end_date")
+             |> render() =~
+               utc_datetime_to_localized_datestring(section.end_date, timezone)
+
+      assert view
+             |> element("small")
+             |> render() =~ "Timezone: " <> timezone
+    end
+
     test "loads section data correctly when is created with a brand", %{conn: conn} do
       brand = insert(:brand)
       section = insert(:section, %{brand: brand})
@@ -161,10 +184,10 @@ defmodule OliWeb.Sections.EditLiveTest do
              |> render() =~ "checked"
 
       view
-        |> element("form[phx-submit=\"save\"")
-        |> render_submit(%{
-          "section" => %{"display_curriculum_item_numbering" => "false"}
-        })
+      |> element("form[phx-submit=\"save\"")
+      |> render_submit(%{
+        "section" => %{"display_curriculum_item_numbering" => "false"}
+      })
 
       updated_section = Sections.get_section!(section.id)
       refute updated_section.display_curriculum_item_numbering

--- a/test/oli_web/live/sections/enrollments_view_test.exs
+++ b/test/oli_web/live/sections/enrollments_view_test.exs
@@ -71,13 +71,18 @@ defmodule OliWeb.Sections.EnrollmentsViewTest do
   describe "gating and scheduling live test admin" do
     setup [:setup_enrollments_view]
 
-    test "mount enrollments for admin", %{conn: conn, section: section} do
+    test "mount enrollments for admin", %{section: section} = context do
+      {:ok, conn: conn, context: session_context} = set_timezone(context)
+
       {:ok, _view, html} =
         live(conn, Routes.live_path(@endpoint, OliWeb.Sections.EnrollmentsView, section.slug))
+
+      [e | _] = Oli.Delivery.Sections.list_enrollments(section.slug)
 
       assert html =~ "Admin"
       assert html =~ "Enrollments"
       assert html =~ "Download as .CSV"
+      assert html =~ OliWeb.Common.Utils.render_date(e, :inserted_at, session_context)
     end
   end
 
@@ -106,7 +111,12 @@ defmodule OliWeb.Sections.EnrollmentsViewTest do
 
     enroll(section)
 
-    admin = author_fixture(%{system_role_id: Oli.Accounts.SystemRole.role_id().admin})
+    admin =
+      author_fixture(%{
+        system_role_id: Oli.Accounts.SystemRole.role_id().admin,
+        preferences:
+          %Oli.Accounts.AuthorPreferences{show_relative_dates: false} |> Map.from_struct()
+      })
 
     conn =
       Plug.Test.init_test_session(conn, [])

--- a/test/oli_web/live/sections/gating_and_scheduling_test.exs
+++ b/test/oli_web/live/sections/gating_and_scheduling_test.exs
@@ -123,7 +123,7 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
   describe "gating and scheduling edit live test" do
     setup [:setup_admin_session, :create_gating_condition]
 
-    test "displays gating condition info correctly using the section timezone when local timezone is not set",
+    test "displays gating condition info correctly using UTC when local timezone is not set",
          %{
            conn: conn,
            section_1: section,
@@ -136,7 +136,7 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
           gating_condition_edit_route(section.slug, gating_condition.id)
         )
 
-      timezone = section.timezone
+      timezone = "Etc/UTC"
 
       assert html =~ "Edit Gating Condition"
       assert has_element?(view, "input[value=\"#{revision.title}\"]")
@@ -153,9 +153,6 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
              |> element("#end_date")
              |> render() =~
                utc_datetime_to_localized_datestring(gating_condition.data.end_datetime, timezone)
-
-      assert html =~
-               "Your local timezone is not set in the browser. #{timezone} (section timezone) is used by default."
     end
 
     test "displays gating condition dates correctly using the local timezone when it is set", %{
@@ -293,7 +290,7 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
       assert flash["info"] == "Gating condition successfully updated."
     end
 
-    test "shifts input datestring to utc using the section timezone when local timezone is not set",
+    test "shifts input datestring to utc when local timezone is not set",
          %{
            conn: conn,
            section_1: section,
@@ -319,12 +316,12 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
 
       assert utc_datetime_to_localized_datestring(
                updated_gating_condition.data.start_datetime,
-               section.timezone
+               "Etc/UTC"
              ) == input_start_date
 
       assert utc_datetime_to_localized_datestring(
                updated_gating_condition.data.end_datetime,
-               section.timezone
+               "Etc/UTC"
              ) == input_end_date
     end
 
@@ -392,14 +389,11 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
       conn: conn,
       section_1: section
     } do
-      {:ok, view, html} =
+      {:ok, view, _html} =
         live(
           conn,
           gating_condition_new_route(section.slug)
         )
-
-      assert html =~
-               "Your local timezone is not set in the browser. #{section.timezone} (section timezone) is used by default."
 
       create_gating_condition_through_ui(view, "schedule", "2022-01-12T13:48", "2022-01-13T13:48")
 
@@ -412,7 +406,7 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
       assert flash["info"] == "Gating condition successfully created."
     end
 
-    test "shifts input datestring to utc using the section timezone when local timezone is not set",
+    test "shifts input datestring to utc when local timezone is not set",
          %{
            conn: conn,
            section_1: section
@@ -438,12 +432,12 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
 
       assert utc_datetime_to_localized_datestring(
                created_gating_condition.data.start_datetime,
-               section.timezone
+               "Etc/UTC"
              ) == input_start_date
 
       assert utc_datetime_to_localized_datestring(
                created_gating_condition.data.end_datetime,
-               section.timezone
+               "Etc/UTC"
              ) == input_end_date
     end
 

--- a/test/oli_web/live/sections/gating_and_scheduling_test.exs
+++ b/test/oli_web/live/sections/gating_and_scheduling_test.exs
@@ -29,14 +29,6 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
         section_slug
       )
 
-  defp utc_datetime_to_localized_datestring(utc_datetime, timezone) do
-    utc_datetime
-    |> Timex.to_datetime(timezone)
-    |> DateTime.to_naive()
-    |> NaiveDateTime.to_iso8601()
-    |> String.replace_suffix(":00", "")
-  end
-
   defp create_gating_condition_through_ui(view, type, start_date, end_date) do
     view
     |> element("button[phx-click=\"show-resource-picker\"]")
@@ -160,7 +152,7 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
       section_1: section,
       gating_condition: gating_condition
     } do
-      {:ok, conn: conn} = set_timezone(%{conn: conn})
+      {:ok, conn: conn, context: _} = set_timezone(%{conn: conn})
 
       {:ok, view, html} =
         live(
@@ -330,7 +322,7 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
       section_1: section,
       gating_condition: gating_condition
     } do
-      {:ok, conn: conn} = set_timezone(%{conn: conn})
+      {:ok, conn: conn, context: _} = set_timezone(%{conn: conn})
 
       {:ok, view, _html} =
         live(
@@ -445,7 +437,7 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
       conn: conn,
       section_1: section
     } do
-      {:ok, conn: conn} = set_timezone(%{conn: conn})
+      {:ok, conn: conn, context: _} = set_timezone(%{conn: conn})
 
       {:ok, view, _html} =
         live(

--- a/test/oli_web/live/system_message_live_test.exs
+++ b/test/oli_web/live/system_message_live_test.exs
@@ -47,6 +47,24 @@ defmodule OliWeb.SystemMessageLiveTest do
              |> render() =~ system_message.message
     end
 
+    test "displays start and end datetimes using the local timezone", %{
+      conn: conn,
+      context: context
+    } do
+      system_message = insert(:system_message)
+      {:ok, view, _html} = live(conn, @live_view_index_route)
+
+      assert view
+             |> element("#system_message_start")
+             |> render() =~
+               utc_datetime_to_localized_datestring(system_message.start, context.local_tz)
+
+      assert view
+             |> element("#system_message_end")
+             |> render() =~
+               utc_datetime_to_localized_datestring(system_message.end, context.local_tz)
+    end
+
     test "uses UTC timezone by default when local timezone is not set", %{conn: conn} do
       conn = delete_session(conn, :local_tz)
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -160,7 +160,6 @@ defmodule Oli.Factory do
 
     %Section{
       title: sequence("Section"),
-      timezone: "America/New_York",
       registration_open: true,
       context_id: UUID.uuid4(),
       institution: deployment.institution,

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -580,9 +580,7 @@ defmodule Oli.TestHelpers do
   end
 
   def set_timezone(%{conn: conn}) do
-    timezone = DateTime.utc_now().time_zone
-
-    conn = Plug.Test.init_test_session(conn, %{local_tz: timezone})
+    conn = Plug.Test.init_test_session(conn, %{local_tz: "America/New_York"})
 
     {:ok, conn: conn}
   end


### PR DESCRIPTION
[MER-937](https://eliterate.atlassian.net/browse/MER-937)

### Context
Currently, there are different sources of truth in Torus for timezones (browser timezone, section timezone, institution timezone). Different datetimes might be displayed using different timezones depending on the page in Torus. This is causing confusion to some users since it is not clear how this setting is leveraged in the system today.

### Description
This PR adds the following changes:
- Add a new timezone setting to the user/author dropdown in the header, to update the timezone globally for the users during the session. (see screenshot 1)
- Update every page in Torus that renders a datetime, to properly use this global timezone. (see screenshot 1)
- Disambiguate the source of truth for timezones used when handling sections (remove timezones column from `sections` table). (see screenshot 2).
- Display the timezone as part of the rendered date for crucial datetimes (assignment due dates, section start end dates, etc) (see screenshot 3).

**1)**


https://user-images.githubusercontent.com/26532202/175106327-e8866491-c001-451d-b360-6317fff3303f.mov


**2)**
<img width="545" alt="Screen Shot 2022-06-22 at 3 00 51 PM" src="https://user-images.githubusercontent.com/26532202/175105668-9836767f-6d46-4fb4-9c02-5857a2689120.png">

**3)**
<img width="1143" alt="Screen Shot 2022-06-22 at 3 52 54 PM" src="https://user-images.githubusercontent.com/26532202/175114704-96a0fb02-ccd5-4340-ade0-87313e490527.png">


### Notes
- I know this PR is big and not easy to review (even though most of the changes are similar and repetitive), but I think it makes sense to fix the timezones throughout the whole app at once, instead of having steps in between where the app is inconsistent and shows dates in different timezones.
- There are many improvements that can be done, but decided to do them in a separate story.

### Questions
- Both `institutions` and `pending_registrations` tables have a `timezone` field that is only displayed but not used in the logic. Should we remove them too?

