### PR TITLE
[MER-1201] Formula editing

### DIFF
--- a/assets/src/components/common/Formula.tsx
+++ b/assets/src/components/common/Formula.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { MathJaxLatexFormula, MathJaxMathMLFormula } from './MathJaxFormula';
+
+export const Formula: React.FC<{
+  type?: string;
+  subtype: string;
+  src: string;
+  onClick?: () => void;
+  style?: Record<string, string>;
+}> = ({ type, subtype, src, style, onClick }) => {
+  switch (subtype) {
+    case 'latex':
+      return (
+        <MathJaxLatexFormula
+          onClick={onClick}
+          style={style}
+          inline={type === 'formula_inline'}
+          src={src}
+        />
+      );
+    case 'mathml':
+      return (
+        <MathJaxMathMLFormula
+          onClick={onClick}
+          style={style}
+          inline={type === 'formula_inline'}
+          src={src}
+        />
+      );
+    default:
+      return <div>Error: Unknown formula type {subtype}</div>;
+  }
+};
+
+Formula.defaultProps = {
+  style: {},
+  type: 'formula',
+};

--- a/assets/src/components/common/MathJaxFormula.tsx
+++ b/assets/src/components/common/MathJaxFormula.tsx
@@ -93,7 +93,6 @@ MathJaxLatexFormula.defaultProps = { style: {} };
 // Add some types to window to satisfy our minimal needs instead of loading the full mathjax type definitions.
 interface MathJaxMinimal {
   typesetPromise: (nodes: HTMLElement[]) => Promise<void>;
-  tex2mml: (tex: string) => string;
   startup: {
     promise: Promise<void>;
     load?: () => void;

--- a/assets/src/components/common/MathJaxFormula.tsx
+++ b/assets/src/components/common/MathJaxFormula.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { sanitizeMathML } from '../../utils/mathmlSanitizer';
 
 /**
@@ -48,12 +48,21 @@ const useMathJax = (src: string) => {
 interface MathJaxFormulaProps {
   src: string;
   inline: boolean;
+  style?: Record<string, string>;
+  onClick?: () => void;
 }
 
-export const MathJaxMathMLFormula: React.FC<MathJaxFormulaProps> = ({ src, inline }) => {
+export const MathJaxMathMLFormula: React.FC<MathJaxFormulaProps> = ({
+  src,
+  inline,
+  style,
+  onClick,
+}) => {
   const ref = useMathJax(src);
   return (
     <span
+      onClick={onClick}
+      style={style}
       className={cssClass(inline)}
       ref={ref}
       dangerouslySetInnerHTML={{ __html: sanitizeMathML(src) }}
@@ -61,22 +70,33 @@ export const MathJaxMathMLFormula: React.FC<MathJaxFormulaProps> = ({ src, inlin
   );
 };
 
-export const MathJaxLatexFormula: React.FC<MathJaxFormulaProps> = ({ src, inline }) => {
+MathJaxMathMLFormula.defaultProps = { style: {} };
+
+export const MathJaxLatexFormula: React.FC<MathJaxFormulaProps> = ({
+  src,
+  inline,
+  style,
+  onClick,
+}) => {
   const ref = useMathJax(src);
   const wrapped = inline ? `\\(${src}\\)` : `\\[${src}\\]`;
 
   return (
-    <span className={cssClass(inline)} ref={ref}>
+    <span onClick={onClick} style={style} className={cssClass(inline)} ref={ref}>
       {wrapped}
     </span>
   );
 };
 
+MathJaxLatexFormula.defaultProps = { style: {} };
+
 // Add some types to window to satisfy our minimal needs instead of loading the full mathjax type definitions.
 interface MathJaxMinimal {
   typesetPromise: (nodes: HTMLElement[]) => Promise<void>;
+  tex2mml: (tex: string) => string;
   startup: {
     promise: Promise<void>;
+    load?: () => void;
   };
 }
 

--- a/assets/src/components/editing/editor/modelEditorDispatch.tsx
+++ b/assets/src/components/editing/editor/modelEditorDispatch.tsx
@@ -19,6 +19,8 @@ import { CommandContext } from '../elements/commands/interfaces';
 import { ImageEditor } from '../elements/image/block/ImageElement';
 import { EditorProps } from '../elements/interfaces';
 import { ImageInlineEditor } from '../elements/image/inline/ImageInlineElement';
+import { FormulaEditor } from '../elements/formula/FormulaEditor';
+import { CalloutEditor, InlineCalloutEditor } from '../elements/callout/CalloutElement';
 
 export function editorFor(
   model: ContentModel.ModelElement,
@@ -59,6 +61,10 @@ export function editorFor(
       return <ul {...attributes}>{children}</ul>;
     case 'li':
       return <li {...attributes}>{children}</li>;
+    case 'callout':
+      return <CalloutEditor {...(editorProps as EditorProps<ContentModel.Callout>)} />;
+    case 'callout_inline':
+      return <InlineCalloutEditor {...(editorProps as EditorProps<ContentModel.CalloutInline>)} />;
     case 'blockquote':
       return <BlockQuoteEditor {...(editorProps as EditorProps<ContentModel.Blockquote>)} />;
     case 'youtube':
@@ -90,6 +96,14 @@ export function editorFor(
       return <span {...attributes}>Not implemented</span>;
     case 'input_ref':
       return <InputRefEditor {...(editorProps as EditorProps<ContentModel.InputRef>)} />;
+    case 'formula':
+    case 'formula_inline':
+      return (
+        <FormulaEditor
+          {...(editorProps as EditorProps<ContentModel.FormulaInline | ContentModel.FormulaBlock>)}
+        />
+      );
+
     default:
       return <span>{children}</span>;
   }

--- a/assets/src/components/editing/elements/callout/CalloutElement.tsx
+++ b/assets/src/components/editing/elements/callout/CalloutElement.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import * as ContentModel from 'data/content/model/elements/types';
+import { EditorProps } from 'components/editing/elements/interfaces';
+
+export const CalloutEditor = (props: EditorProps<ContentModel.Callout>) => {
+  return (
+    <div className="callout-block" {...props.attributes}>
+      {props.children}
+    </div>
+  );
+};
+
+export const InlineCalloutEditor = (props: EditorProps<ContentModel.CalloutInline>) => {
+  return (
+    <span className="callout-inline" {...props.attributes}>
+      {props.children}
+    </span>
+  );
+};

--- a/assets/src/components/editing/elements/callout/calloutActions.ts
+++ b/assets/src/components/editing/elements/callout/calloutActions.ts
@@ -15,7 +15,7 @@ export const insertCallout = createButtonCommandDesc({
     const at = editor.selection;
     if (!at) return;
 
-    Transforms.insertNodes(editor, Model.callout(), { at });
+    Transforms.insertNodes(editor, Model.callout(), { at, select: true });
   },
 });
 

--- a/assets/src/components/editing/elements/callout/calloutActions.ts
+++ b/assets/src/components/editing/elements/callout/calloutActions.ts
@@ -1,0 +1,31 @@
+import { toggleCodeblock } from 'components/editing/elements/blockcode/codeblockActions';
+import { toggleBlockquote } from 'components/editing/elements/blockquote/blockquoteActions';
+import { createButtonCommandDesc } from 'components/editing/elements/commands/commandFactories';
+import { switchType } from 'components/editing/elements/commands/toggleTextTypes';
+import { toggleHeading } from 'components/editing/elements/heading/headingActions';
+import { toggleUnorderedList } from 'components/editing/elements/list/listActions';
+import { isActive } from 'components/editing/slateUtils';
+import { Transforms } from 'slate';
+import { Model } from '../../../../data/content/model/elements/factories';
+
+export const insertCallout = createButtonCommandDesc({
+  icon: 'web_asset',
+  description: 'Callout',
+  execute: (_context, editor) => {
+    const at = editor.selection;
+    if (!at) return;
+
+    Transforms.insertNodes(editor, Model.callout(), { at });
+  },
+});
+
+export const insertInlineCallout = createButtonCommandDesc({
+  icon: 'web_asset',
+  description: 'Callout',
+  execute: (_context, editor) => {
+    const at = editor.selection;
+    if (!at) return;
+
+    Transforms.insertNodes(editor, Model.calloutInline(), { at, select: true });
+  },
+});

--- a/assets/src/components/editing/elements/formula/FormulaEditor.tsx
+++ b/assets/src/components/editing/elements/formula/FormulaEditor.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { onEditModel } from 'components/editing/elements/utils';
+import * as ContentModel from 'data/content/model/elements/types';
+import { EditorProps } from 'components/editing/elements/interfaces';
+import { Formula } from '../../../common/Formula';
+
+import { FormulaModal } from './FormulaModal';
+import { modalActions } from '../../../../actions/modal';
+
+interface Props extends EditorProps<ContentModel.FormulaBlock | ContentModel.FormulaInline> {}
+export const FormulaEditor = (props: Props) => {
+  const onEdit = onEditModel(props.model);
+
+  if (props.model.src === undefined)
+    return (
+      <div {...props.attributes} contentEditable={false}>
+        FORMULA PLACEHOLDER
+      </div>
+    );
+
+  interface EditableProps {
+    subtype: ContentModel.FormulaSubTypes;
+    src: string;
+  }
+
+  const onFormulaClick = () => {
+    window.oliDispatch(
+      modalActions.display(
+        <FormulaModal
+          model={props.model}
+          onDone={({ src, subtype }: Partial<EditableProps>) => {
+            window.oliDispatch(modalActions.dismiss());
+            onEdit({ src, subtype });
+          }}
+          onCancel={() => window.oliDispatch(modalActions.dismiss())}
+        />,
+      ),
+    );
+  };
+
+  return (
+    <span {...props.attributes} contentEditable={false}>
+      {props.children}
+
+      <Formula
+        onClick={onFormulaClick}
+        style={{ cursor: 'pointer' }}
+        type={props.model.type}
+        subtype={props.model.subtype}
+        src={props.model.src}
+      />
+    </span>
+  );
+};

--- a/assets/src/components/editing/elements/formula/FormulaModal.tsx
+++ b/assets/src/components/editing/elements/formula/FormulaModal.tsx
@@ -1,0 +1,64 @@
+import { FullScreenModal } from 'components/editing/toolbar/FullScreenModal';
+import React, { Suspense, useState } from 'react';
+import * as ContentModel from 'data/content/model/elements/types';
+import * as monaco from 'monaco-editor';
+import { Formula } from '../../../common/Formula';
+import { isDarkMode } from '../../../../utils/browser';
+import { FormulaToolbar } from './FormulaToolbar';
+
+const MonacoEditor = React.lazy(() => import('@uiw/react-monacoeditor'));
+
+type AllFormulaType = ContentModel.FormulaBlock | ContentModel.FormulaInline;
+
+interface ModalProps {
+  onDone: (x: any) => void;
+  onCancel: () => void;
+  model: AllFormulaType;
+}
+
+const languageForSubtype = (subtype: ContentModel.FormulaSubTypes) =>
+  subtype === 'mathml' ? 'xml' : 'text';
+
+export const FormulaModal = ({ onDone, onCancel, model }: ModalProps) => {
+  const [src, setSrc] = useState(model.src);
+  const [subtype, setSubtype] = useState(model.subtype);
+
+  const editorDidMount = (e: monaco.editor.IStandaloneCodeEditor) => {
+    e.layout({
+      width: 600,
+      height: 300,
+    });
+  };
+
+  return (
+    <FullScreenModal onCancel={(_e) => onCancel()} onDone={() => onDone({ src, subtype })}>
+      <div className="formula-editor">
+        <h3 className="mb-2">Formula Editor</h3>
+        <div className="split-editor">
+          <div className="editor">
+            <FormulaToolbar setSubtype={setSubtype} subtype={subtype} />
+            <Suspense fallback={<div>Loading...</div>}>
+              <MonacoEditor
+                value={model.src}
+                language={languageForSubtype(subtype)}
+                key={subtype}
+                options={{
+                  tabSize: 2,
+                  scrollBeyondLastLine: false,
+                  minimap: { enabled: false },
+                  theme: isDarkMode() ? 'vs-dark' : 'vs-light',
+                }}
+                onChange={setSrc}
+                editorDidMount={editorDidMount}
+              />
+            </Suspense>
+          </div>
+          <div className="preview">
+            <h4>Preview</h4>
+            <Formula src={src} subtype={subtype} />
+          </div>
+        </div>
+      </div>
+    </FullScreenModal>
+  );
+};

--- a/assets/src/components/editing/elements/formula/FormulaToolbar.tsx
+++ b/assets/src/components/editing/elements/formula/FormulaToolbar.tsx
@@ -1,0 +1,56 @@
+import React, { Dispatch, SetStateAction } from 'react';
+import { FormulaSubTypes } from '../../../../data/content/model/elements/types';
+
+const markups: Array<{ label: string; code: FormulaSubTypes; reference?: string }> = [
+  {
+    label: 'Latex',
+    code: 'latex',
+    reference: 'https://en.wikibooks.org/wiki/LaTeX/Mathematics',
+  },
+  {
+    label: 'MathML',
+    code: 'mathml',
+    reference: 'https://developer.mozilla.org/en-US/docs/Web/MathML/Element',
+  },
+];
+
+const getToolbarClass = (buttonType: string, activeType: string) =>
+  buttonType === activeType ? 'language-active' : 'language';
+
+interface Props {
+  setSubtype: Dispatch<SetStateAction<FormulaSubTypes>>;
+  subtype: string;
+}
+
+export const FormulaToolbar: React.FC<Props> = ({ setSubtype, subtype }) => {
+  const onClickSubtype = React.useCallback(
+    (newSubType: FormulaSubTypes) => (_event: any) => {
+      setSubtype(newSubType);
+    },
+    [subtype],
+  );
+
+  const active = markups.find((m) => m.code === subtype);
+
+  return (
+    <div className="toolbar">
+      <div className="buttons">
+        {markups.map((m) => (
+          <button
+            key={m.code}
+            onClick={onClickSubtype(m.code)}
+            className={getToolbarClass(m.code, subtype)}
+          >
+            {m.label}
+          </button>
+        ))}
+      </div>
+
+      {active?.reference && (
+        <a target="_blank" rel="noreferrer" href={active.reference}>
+          {active.label} Reference
+        </a>
+      )}
+    </div>
+  );
+};

--- a/assets/src/components/editing/elements/formula/formulaActions.tsx
+++ b/assets/src/components/editing/elements/formula/formulaActions.tsx
@@ -1,0 +1,26 @@
+import { Transforms } from 'slate';
+
+import { Model } from 'data/content/model/elements/factories';
+import { createButtonCommandDesc } from 'components/editing/elements/commands/commandFactories';
+
+export const insertFormula = createButtonCommandDesc({
+  icon: 'functions',
+  description: 'Formula',
+  execute: (_context, editor) => {
+    const at = editor.selection;
+    if (!at) return;
+
+    Transforms.insertNodes(editor, Model.formula(), { at });
+  },
+});
+
+export const insertInlineFormula = createButtonCommandDesc({
+  icon: 'functions',
+  description: 'Formula',
+  execute: (_context, editor) => {
+    const at = editor.selection;
+    if (!at) return;
+
+    Transforms.insertNodes(editor, Model.formulaInline(), { at });
+  },
+});

--- a/assets/src/components/editing/toolbar/editorToolbar/Inlines.tsx
+++ b/assets/src/components/editing/toolbar/editorToolbar/Inlines.tsx
@@ -11,6 +11,8 @@ import React from 'react';
 import { commandDesc as linkCmd } from 'components/editing/elements/link/LinkCmd';
 import { popupCmdDesc as insertPopup } from 'components/editing/elements/popup/PopupCmd';
 import { insertImageInline } from 'components/editing/elements/image/imageActions';
+import { insertInlineFormula } from '../../elements/formula/formulaActions';
+import { insertInlineCallout } from '../../elements/callout/calloutActions';
 
 interface Props {}
 export const Inlines = (_props: Props) => {
@@ -20,7 +22,12 @@ export const Inlines = (_props: Props) => {
     linkCmd,
   ].map((desc, i) => <CommandButton key={i} description={desc} />);
 
-  const inlineInsertions = [insertPopup, insertImageInline];
+  const inlineInsertions = [
+    insertPopup,
+    insertImageInline,
+    insertInlineFormula,
+    insertInlineCallout,
+  ];
   const moreInlineOptions = additionalFormattingOptions.concat(inlineInsertions);
 
   const seeMoreInlineOptions = createButtonCommandDesc({

--- a/assets/src/components/editing/toolbar/editorToolbar/blocks/blockInsertOptions.ts
+++ b/assets/src/components/editing/toolbar/editorToolbar/blocks/blockInsertOptions.ts
@@ -10,6 +10,8 @@ import { ContentModelMode } from 'data/content/model/elements/types';
 import { insertTable } from 'components/editing/elements/table/commands/insertTable';
 import { insertWebpage } from 'components/editing/elements/webpage/webpageActions';
 import { insertYoutube } from 'components/editing/elements/youtube/youtubeActions';
+import { insertFormula } from '../../../elements/formula/formulaActions';
+import { insertCallout } from '../../../elements/callout/calloutActions';
 
 export const allBlockInsertActions = (onRequestMedia: any) => [
   insertTable,
@@ -18,6 +20,8 @@ export const allBlockInsertActions = (onRequestMedia: any) => [
   insertYoutube,
   insertAudio(onRequestMedia),
   insertWebpage,
+  insertFormula,
+  insertCallout,
 ];
 
 interface Opts {
@@ -36,7 +40,14 @@ export function blockInsertOptions(opts: Opts): CommandDescription[] {
     case 'inline':
       return [];
     case 'small':
-      return [insertCodeblock, insertImage(onRequestMedia), ytCmdDesc, insertAudio(onRequestMedia)];
+      return [
+        insertCodeblock,
+        insertImage(onRequestMedia),
+        ytCmdDesc,
+        insertAudio(onRequestMedia),
+        insertFormula,
+        insertCallout,
+      ];
     case 'all':
       return allBlockInsertActions(onRequestMedia);
     default:

--- a/assets/src/data/content/model/elements/factories.ts
+++ b/assets/src/data/content/model/elements/factories.ts
@@ -22,6 +22,11 @@ import {
   Citation,
   ImageInline,
   CodeV2,
+  FormulaBlock,
+  FormulaInline,
+  FormulaSubTypes,
+  Callout,
+  CalloutInline,
 } from 'data/content/model/elements/types';
 import { Text } from 'slate';
 import guid from 'utils/guid';
@@ -52,6 +57,16 @@ export const Model = {
   ul: () => create<UnorderedList>({ type: 'ul', children: [Model.li()] }),
 
   youtube: (src?: string) => create<YouTube>({ type: 'youtube', src }),
+
+  callout: (text = '') => create<Callout>({ type: 'callout', children: [Model.p(text)] }),
+  calloutInline: (text = '') =>
+    create<CalloutInline>({ type: 'callout_inline', children: [{ text }] }),
+
+  formula: (subtype: FormulaSubTypes = 'latex', src = '1 + 2 = 3') =>
+    create<FormulaBlock>({ type: 'formula', src, subtype }),
+
+  formulaInline: (subtype: FormulaSubTypes = 'latex', src = '1 + 2 = 3') =>
+    create<FormulaInline>({ type: 'formula_inline', src, subtype }),
 
   webpage: (src?: string) => create<Webpage>({ type: 'iframe', src }),
 

--- a/assets/src/data/content/model/elements/types.ts
+++ b/assets/src/data/content/model/elements/types.ts
@@ -19,9 +19,11 @@ type TopLevel =
   | Math
   | (CodeV1 | CodeV2)
   | Blockquote
-  | FormulaBlock;
-type Block = TableRow | TableCell | ListItem | MathLine | CodeLine | FormulaBlock;
-type Inline = Hyperlink | Popup | InputRef | ImageInline | Citation | FormulaInline;
+  | FormulaBlock
+  | Callout;
+
+type Block = TableRow | TableCell | ListItem | MathLine | CodeLine | FormulaBlock | Callout;
+type Inline = Hyperlink | Popup | InputRef | ImageInline | Citation | FormulaInline | CalloutInline;
 
 type TextBlock = Paragraph | Heading;
 type Heading = HeadingOne | HeadingTwo | HeadingThree | HeadingFour | HeadingFive | HeadingSix;
@@ -32,6 +34,14 @@ type TableCell = TableHeader | TableData;
 type HeadingChildren = Text[];
 export interface Paragraph extends SlateElement<(InputRef | Text | ImageBlock)[]> {
   type: 'p';
+}
+
+export interface Callout extends SlateElement<Paragraph[]> {
+  type: 'callout';
+}
+
+export interface CalloutInline extends SlateElement<(InputRef | Text | ImageInline)[]> {
+  type: 'callout_inline';
 }
 
 export interface HeadingOne extends SlateElement<HeadingChildren> {
@@ -86,22 +96,16 @@ export interface ImageInline extends BaseImage {
   type: 'img_inline';
 }
 
-interface FormulaChildren<typeIdentifier>
+export type FormulaSubTypes = 'mathml' | 'latex';
+interface Formula<typeIdentifier>
   extends SlateElement<(ImageInline | Hyperlink | Popup | InputRef)[]> {
   type: typeIdentifier;
-  subtype: 'richtext';
-  src: never;
-}
-
-interface FormulaSrc<typeIdentifier> extends SlateElement<VoidChildren> {
-  type: typeIdentifier;
-  subtype: 'mathml' | 'latex';
+  subtype: FormulaSubTypes;
   src: string;
-  children: never;
 }
 
-export type FormulaBlock = FormulaSrc<'formula'> | FormulaChildren<'formula'>;
-export type FormulaInline = FormulaSrc<'formula_inline'> | FormulaChildren<'formula_inline'>;
+export type FormulaBlock = Formula<'formula'>;
+export type FormulaInline = Formula<'formula_inline'>;
 
 export interface YouTube extends SlateElement<VoidChildren> {
   type: 'youtube';

--- a/assets/src/data/content/model/schema.ts
+++ b/assets/src/data/content/model/schema.ts
@@ -25,7 +25,7 @@ const tableCell = {
   isVoid: false,
   isBlock: true,
   isTopLevel: false,
-  validChildren: toObj(['p', 'img', 'youtube', 'audio', 'math']),
+  validChildren: toObj(['p', 'img', 'youtube', 'audio', 'math', 'formula_inline', 'formula']),
 };
 
 const list = {
@@ -49,7 +49,7 @@ export const schema: Schema = {
     isVoid: false,
     isBlock: true,
     isTopLevel: true,
-    validChildren: toObj(['input_ref', 'img']),
+    validChildren: toObj(['input_ref', 'img', 'formula_inline', 'callout_inline']),
   },
   h1: header,
   h2: header,
@@ -63,6 +63,34 @@ export const schema: Schema = {
     isBlock: false,
     isTopLevel: false,
     validChildren: {},
+  },
+  callout: {
+    isVoid: false,
+    isBlock: true,
+    isTopLevel: true,
+    validChildren: toObj([
+      'p',
+      'img',
+      'youtube',
+      'audio',
+      'code',
+      'blockquote',
+      'iframe',
+      'ol',
+      'ul',
+      'h1',
+      'h2',
+      'h3',
+      'h4',
+      'h5',
+      'h6',
+    ]),
+  },
+  callout_inline: {
+    isVoid: false,
+    isBlock: false,
+    isTopLevel: true,
+    validChildren: toObj([]),
   },
   formula: {
     isVoid: true,

--- a/assets/src/data/content/writers/html.tsx
+++ b/assets/src/data/content/writers/html.tsx
@@ -129,8 +129,6 @@ export class HtmlParser implements WriterImpl {
         return (
           <MathJaxMathMLFormula src={element.src} inline={element.type === 'formula_inline'} />
         );
-      case 'richtext':
-        return <span className={element.type}>{next()}</span>;
       default:
         return <span className="formula">Unknown formula type</span>;
     }
@@ -209,6 +207,14 @@ export class HtmlParser implements WriterImpl {
       </table>
     );
   }
+  callout(context: WriterContext, next: Next) {
+    return <div className="callout-block">{next()}</div>;
+  }
+
+  calloutInline(context: WriterContext, next: Next) {
+    return <span className="callout-inline">{next()}</span>;
+  }
+
   tr(context: WriterContext, next: Next, _x: TableRow) {
     return <tr>{next()}</tr>;
   }

--- a/assets/src/data/content/writers/writer.tsx
+++ b/assets/src/data/content/writers/writer.tsx
@@ -17,6 +17,8 @@ export interface WriterImpl {
   h6: ElementWriter;
   formula: ElementWriter;
   formulaInline: ElementWriter;
+  callout: ElementWriter;
+  calloutInline: ElementWriter;
   img: ElementWriter;
   img_inline: ElementWriter;
   youtube: ElementWriter;
@@ -107,6 +109,10 @@ export class ContentWriter {
         return impl.formula(context, next, content);
       case 'formula_inline':
         return impl.formulaInline(context, next, content);
+      case 'callout':
+        return impl.callout(context, next, content);
+      case 'callout_inline':
+        return impl.calloutInline(context, next, content);
       case 'img':
         return impl.img(context, next, content);
       case 'img_inline':

--- a/assets/styles/authoring/formula.scss
+++ b/assets/styles/authoring/formula.scss
@@ -10,6 +10,9 @@
     .preview {
       margin-top: 20px;
       border: 1px solid $gray-100;
+      .formula {
+        color: #ccc;
+      }
     }
 
     .editor {

--- a/assets/styles/authoring/formula.scss
+++ b/assets/styles/authoring/formula.scss
@@ -1,0 +1,41 @@
+@import 'authoring/variables';
+
+.formula-editor {
+  min-width: 600px;
+  .split-editor {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+
+    .preview {
+      margin-top: 20px;
+      border: 1px solid $gray-100;
+    }
+
+    .editor {
+      .toolbar {
+        .buttons {
+          display: flex;
+          flex-direction: row;
+          gap: 15px;
+        }
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        text-align: left;
+        gap: 3px;
+        padding: 5px 15px 5px 5px;
+        background-color: $gray-100;
+
+        .language {
+          padding: 2px 10px;
+        }
+        .language-active {
+          border: 1px solid $blue;
+        }
+      }
+      text-align: left;
+      min-height: 30vh;
+    }
+  }
+}

--- a/assets/styles/authoring/index.scss
+++ b/assets/styles/authoring/index.scss
@@ -31,3 +31,4 @@
 @import 'shared/phx.scss';
 
 @import 'static_page/index.scss';
+@import 'formula.scss';

--- a/assets/styles/common/elements.scss
+++ b/assets/styles/common/elements.scss
@@ -1,6 +1,7 @@
 @import 'bootstrap';
 
 .structured-content,
+.activity-editor,
 .content {
   blockquote {
     margin-top: 12px;
@@ -119,6 +120,7 @@
     @extend .embed-responsive-item;
   }
 
+  .callout-inline,
   .formula-inline {
     display: inline-block;
     background-color: darken($body-bg, 5%);
@@ -126,16 +128,28 @@
     padding: 2px 0.5em;
     vertical-align: middle;
     mjx-container[display='true'] {
+      pointer-events: none;
       margin: 0px !important;
     }
   }
 
+  .callout-block,
   .formula {
     display: block;
     background-color: darken($body-bg, 5%);
     text-align: center;
     margin: 8px;
     padding: 12px;
+
+    blockquote,
+    ol,
+    ul,
+    .monaco-editor {
+      text-align: left;
+    }
+    mjx-container[display='true'] {
+      pointer-events: none;
+    }
   }
 
   .figure-wrapper {

--- a/lib/oli/rendering/content.ex
+++ b/lib/oli/rendering/content.ex
@@ -38,6 +38,9 @@ defmodule Oli.Rendering.Content do
   @callback formula(%Context{}, next, %{}) :: [any()]
   @callback formula_inline(%Context{}, next, %{}) :: [any()]
 
+  @callback callout(%Context{}, next, %{}) :: [any()]
+  @callback callout_inline(%Context{}, next, %{}) :: [any()]
+
   @callback math(%Context{}, next, %{}) :: [any()]
   @callback math_line(%Context{}, next, %{}) :: [any()]
   @callback code(%Context{}, next, %{}) :: [any()]
@@ -221,6 +224,12 @@ defmodule Oli.Rendering.Content do
 
       "popup" ->
         writer.popup(context, next, element)
+
+      "callout" ->
+        writer.callout(context, next, element)
+
+      "callout_inline" ->
+        writer.callout_inline(context, next, element)
 
       _ ->
         {error_id, error_msg} = log_error("Content element type is not supported", element)

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -38,6 +38,14 @@ defmodule Oli.Rendering.Content.Html do
     ]
   end
 
+  def callout(%Oli.Rendering.Context{} = _context, next, _) do
+    ["<span class=\"callout-block\">", next.(), "</span>\n"]
+  end
+
+  def callout_inline(%Oli.Rendering.Context{} = _context, next, _) do
+    ["<span class=\"callout-inline\">", next.(), "</span>\n"]
+  end
+
   def p(%Context{} = _context, next, _) do
     ["<p>", next.(), "</p>\n"]
   end
@@ -164,7 +172,7 @@ defmodule Oli.Rendering.Content.Html do
 
   def formula(
         %Oli.Rendering.Context{} = _context,
-        nil,
+        _next,
         %{"subtype" => "latex", "src" => src},
         true
       ) do
@@ -173,7 +181,7 @@ defmodule Oli.Rendering.Content.Html do
 
   def formula(
         %Oli.Rendering.Context{} = _context,
-        nil,
+        _next,
         %{"subtype" => "latex", "src" => src},
         false
       ) do
@@ -182,7 +190,7 @@ defmodule Oli.Rendering.Content.Html do
 
   def formula(
         %Oli.Rendering.Context{} = _context,
-        nil,
+        _next,
         %{"subtype" => "mathml", "src" => src},
         inline
       ) do
@@ -191,11 +199,6 @@ defmodule Oli.Rendering.Content.Html do
       Scrubber.scrub(src, MathMLSanitizer),
       "</span>\n"
     ]
-  end
-
-  def formula(%Oli.Rendering.Context{} = _context, next, _, inline) do
-    # The catch-all formula will handle anything with a children property, which should always be richtext
-    ["<span class=\"#{formula_class(inline)}\">", next.(), "</span>\n"]
   end
 
   def formula_inline(context, next, map) do
@@ -332,6 +335,7 @@ defmodule Oli.Rendering.Content.Html do
   def cite(%Context{} = context, next, a) do
     bib_references = Map.get(context, :bib_app_params, [])
     bib_entry = Enum.find(bib_references, fn x -> x.id == Map.get(a, "bibref") end)
+
     if bib_entry != nil do
       [~s|<cite><sup>
       [<a onclick="var d=document.getElementById('#{bib_entry.slug}'); if (d &amp;&amp; d.scrollIntoView) d.scrollIntoView();return false;" href="##{bib_entry.slug}" class="ref">#{bib_entry.ordinal}</a>]

--- a/lib/oli/rendering/content/plaintext.ex
+++ b/lib/oli/rendering/content/plaintext.ex
@@ -19,6 +19,14 @@ defmodule Oli.Rendering.Content.Plaintext do
     ["[Many students wonder]: ", next.(), " "]
   end
 
+  def callout(%Oli.Rendering.Context{} = _context, next, _) do
+    [next.(), " "]
+  end
+
+  def callout_inline(%Oli.Rendering.Context{} = _context, next, _) do
+    [next.(), " "]
+  end
+
   def p(%Context{} = _context, next, _) do
     [next.(), " "]
   end

--- a/lib/oli_web/templates/layout/authoring.html.leex
+++ b/lib/oli_web/templates/layout/authoring.html.leex
@@ -67,10 +67,6 @@
         ignoreHtmlClass: 'tex2jax_ignore',
         processHtmlClass: 'tex2jax_process'
       },
-      // Disable MathJax by default. Startup must be called explicitly to run MathJax transformations.
-      startup: {
-        ready: () => {}
-      },
       loader: {
         load: ['[tex]/noerrors']
       }

--- a/priv/schemas/v0-1-0/content-element.schema.json
+++ b/priv/schemas/v0-1-0/content-element.schema.json
@@ -62,6 +62,9 @@
         },
         {
           "$ref": "#/$defs/formula"
+        },
+        {
+          "$ref": "#/$defs/callout"
         }
       ]
     },
@@ -90,6 +93,9 @@
         },
         {
           "$ref": "#/$defs/formula-inline"
+        },
+        {
+          "$ref": "#/$defs/callout-inline"
         }
       ]
     },
@@ -539,70 +545,98 @@
       "required": ["type", "children"]
     },
 
-    "formula-src": {
+    "callout": {
       "type": "object",
       "properties": {
-        "subtype": {
-          "enum": ["mathml", "latex"]
-        },
-        "src": {
-          "type": "string"
-        }
-      },
-      "required": ["type", "subtype", "src"]
-    },
-
-    "formula-children": {
-      "type": "object",
-      "properties": {
-        "subtype": {
-          "const": "richtext"
+        "type": {
+          "const": "callout"
         },
         "children": {
           "type": "array",
           "items": {
             "anyOf": [
               {
-                "$ref": "#/$defs/text"
+                "$ref": "#/$defs/paragraph"
               },
               {
-                "$ref": "#/$defs/hyperlink"
+                "$ref": "#/$defs/heading"
               },
               {
-                "$ref": "#/$defs/input-ref"
+                "$ref": "#/$defs/code-v1"
               },
               {
-                "$ref": "#/$defs/image-inline"
+                "$ref": "#/$defs/code-v2"
+              },
+              {
+                "$ref": "#/$defs/blockquote"
+              },
+              {
+                "$ref": "#/$defs/media"
+              },
+              {
+                "$ref": "#/$defs/list"
               }
             ]
           }
         }
       },
-      "required": ["type", "subtype", "children"]
+      "required": ["type", "children"]
+    },
+
+    "callout-inline": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "callout_inline"
+        },
+        "children": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/inline"
+          }
+        }
+      },
+      "required": ["type", "children"]
     },
 
     "formula": {
-      "oneOf": [
-        { "$ref": "#/$defs/formula-src" },
-        { "$ref": "#/$defs/formula-children" }
-      ],
+      "type": "object",
       "properties": {
-        "type": {
-          "const": "formula"
+        "const": "formula",
+        "subtype": {
+          "enum": ["mathml", "latex"]
+        },
+        "src": {
+          "type": "string"
+        },
+        "children": {
+          "type": "array",
+          "items": {
+            "$ref": "#"
+          }
         }
-      }
+      },
+      "required": ["type", "subtype", "src"]
     },
 
     "formula-inline": {
-      "oneOf": [
-        { "$ref": "#/$defs/formula-src" },
-        { "$ref": "#/$defs/formula-children" }
-      ],
+      "type": "object",
       "properties": {
-        "type": {
-          "const": "formula_inline"
+        "const": "formula_inline",
+        "subtype": {
+          "enum": ["mathml", "latex"]
+        },
+        "src": {
+          "type": "string"
+        },
+        "children": {
+          "type": "array",
+          "items": {
+            "$ref": "#"
+          }
         }
-      }
+      },
+      "required": ["type", "subtype", "src"]
     },
 
     "math": {
@@ -765,11 +799,7 @@
           }
         }
       },
-      "required": [
-        "type",
-        "bibref",
-        "children"
-      ]
+      "required": ["type", "bibref", "children"]
     },
     "popup": {
       "type": "object",

--- a/test/oli/rendering/content/example_content.json
+++ b/test/oli/rendering/content/example_content.json
@@ -425,9 +425,8 @@
       "id": 169365459
     },
     {
-      "type": "formula",
-      "subtype": "richtext",
-      "children": [{ "text": "a richtext formula" }]
+      "type": "callout",
+      "children": [{ "text": "a richtext callout" }]
     },
     {
       "type": "formula",
@@ -443,9 +442,8 @@
       "type": "p",
       "children": [
         {
-          "type": "formula_inline",
-          "subtype": "richtext",
-          "children": [{ "text": "a richtext formula" }]
+          "type": "callout_inline",
+          "children": [{ "text": "a richtext inline callout" }]
         },
         {
           "type": "formula_inline",

--- a/test/oli/rendering/content/html_test.exs
+++ b/test/oli/rendering/content/html_test.exs
@@ -53,14 +53,15 @@ defmodule Oli.Content.Content.HtmlTest do
       assert rendered_html_string =~
                ~r/<iframe class=".*" allowfullscreen src="https:\/\/www.wikipedia.org"><\/iframe>/
 
-      assert rendered_html_string =~ "<span class=\"formula\">a richtext formula</span>"
+      assert rendered_html_string =~ "<span class=\"callout-block\">a richtext callout</span>"
 
       assert rendered_html_string =~
                "<span class=\"formula\"><mrow><mi>a</mi><mo>+</mo><mi>b</mi></mrow></span>"
 
       assert rendered_html_string =~ "<span class=\"formula\">\\[x^2 + y^2 = z^2\\]</span>"
 
-      assert rendered_html_string =~ "<span class=\"formula-inline\">a richtext formula</span>"
+      assert rendered_html_string =~
+               "<span class=\"callout-inline\">a richtext inline callout</span>"
 
       assert rendered_html_string =~
                "<span class=\"formula-inline\"><mrow><mi>a</mi><mo>+</mo><mi>b</mi></mrow></span>"

--- a/test/oli/rendering/content/plaintext_test.exs
+++ b/test/oli/rendering/content/plaintext_test.exs
@@ -22,7 +22,8 @@ defmodule Oli.Content.Content.PlaintextTest do
 
       assert rendered_text =~ "Introduction"
 
-      assert rendered_text =~ "[Formula]: a richtext formula"
+      assert rendered_text =~ "a richtext callout"
+      assert rendered_text =~ "a richtext inline callout"
 
       assert rendered_text =~
                "[Formula]: <mrow><mi>a</mi><mo>+</mo><mi>b</mi></mrow>"


### PR DESCRIPTION
Adds the ability to author formulas in the slate editor.

![formula-edit](https://user-images.githubusercontent.com/333265/175296406-e59b41f0-ed6f-47b0-80e1-6a4296b27ec2.gif)

This PR removes the "richtext" formula type and adds a new "callout" element that can be used for the same purpose. This was to make the code less complex and allowed a nicer authoring experience since we can now edit callouts inline in the main editor instead of in a popup window.

To edit formulas:

- Open a core-authoring lesson, place your cursor in the editor
- Choose the insert formula option under either the inline or the block menu
- Click the placeholder formula that appears
- Edit the formula in the popup window in either latex or mathml

To edit callouts

- Open a core-authoring lesson, place your cursor in the editor
- Choose the insert callout option under either the inline or the block menu
- Type and optionally use formatting options within the callout box that appears.


Here is a project export with various examples of formulas and callouts in it:
[export_formulas_and_links (2).zip](https://github.com/marc-hughes/oli-torus-1/files/8967303/export_formulas_and_links.2.zip)



