### PR TITLE
[MER-1210] Fix section cost changes not updating for students

### DIFF
--- a/lib/oli_web/controllers/payment_controller.ex
+++ b/lib/oli_web/controllers/payment_controller.ex
@@ -71,14 +71,14 @@ defmodule OliWeb.PaymentController do
       end
 
       if allow_payment do
-        case determine_enrollable_cost(section) do
-          {:ok, amount} ->
-            get_provider_module()
-            |> apply(:show, [conn, section, user, amount])
-
-          _ ->
+        case section.amount do
+          nil ->
             conn
             |> redirect(to: Routes.page_delivery_path(conn, :index, section.slug))
+
+          amount ->
+            get_provider_module()
+            |> apply(:show, [conn, section, user, amount])
         end
       else
         conn
@@ -88,11 +88,6 @@ defmodule OliWeb.PaymentController do
 
     # perform this check in the case that a user refreshes the payment page
     # after already paying.  This will simply redirect them to their course.
-  end
-
-  defp determine_enrollable_cost(section) do
-    section = Oli.Repo.preload(section, [:institution])
-    Oli.Delivery.Paywall.calculate_product_cost(section, section.institution)
   end
 
   @doc """

--- a/lib/oli_web/controllers/payment_controller.ex
+++ b/lib/oli_web/controllers/payment_controller.ex
@@ -71,7 +71,7 @@ defmodule OliWeb.PaymentController do
       end
 
       if allow_payment do
-        case determine_cost(section) do
+        case determine_enrollable_cost(section) do
           {:ok, amount} ->
             get_provider_module()
             |> apply(:show, [conn, section, user, amount])
@@ -90,18 +90,9 @@ defmodule OliWeb.PaymentController do
     # after already paying.  This will simply redirect them to their course.
   end
 
-  defp determine_product(section) do
-    if is_nil(section.blueprint_id) do
-      section
-    else
-      section.blueprint
-    end
-  end
-
-  defp determine_cost(section) do
-    section = Oli.Repo.preload(section, [:institution, :blueprint])
-    product = determine_product(section)
-    Oli.Delivery.Paywall.calculate_product_cost(product, section.institution)
+  defp determine_enrollable_cost(section) do
+    section = Oli.Repo.preload(section, [:institution])
+    Oli.Delivery.Paywall.calculate_product_cost(section, section.institution)
   end
 
   @doc """

--- a/test/oli_web/controllers/api/payment_controller_test.exs
+++ b/test/oli_web/controllers/api/payment_controller_test.exs
@@ -1,7 +1,10 @@
 defmodule OliWeb.PaymentControllerTest do
   use OliWeb.ConnCase
 
+  import Oli.Factory
+
   alias Oli.Seeder
+  alias OliWeb.Router.Helpers, as: Routes
 
   describe "payment controller tests" do
     setup [:setup_session]
@@ -112,6 +115,35 @@ defmodule OliWeb.PaymentControllerTest do
         )
 
       assert response(conn, 401)
+    end
+
+    test "direct payment shows section's cost", %{
+      conn: conn
+    } do
+      product = insert(:section, %{amount: Money.new(:USD, "50.00")})
+
+      user = insert(:user)
+
+      enrollable =
+        insert(:section, %{
+          type: :enrollable,
+          requires_payment: true,
+          blueprint: product,
+          amount: Money.new(:USD, "100.00"),
+          has_grace_period: true,
+          grace_period_days: 2,
+          grace_period_strategy: :relative_to_student
+        })
+
+      enroll_user_to_section(user, enrollable, :context_learner)
+
+      conn = Pow.Plug.assign_current_user(conn, user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
+
+      conn =
+        conn
+        |> get(Routes.payment_path(conn, :make_payment, enrollable.slug))
+
+      assert html_response(conn, 200) =~ "<input type=\"text\" disabled value=\"$100.00\"/>"
     end
   end
 


### PR DESCRIPTION
[MER-1210](https://eliterate.atlassian.net/browse/MER-1210)

#### What does it change?

- Fixes section cost updates not being reflected for students. 

Currently the section cost has been ignored, and when paying as a student, the blueprint's cost it's used instead. This changes that to always use the section's cost. (which will be the same as the product's unless updated by an admin).

As discussed with @darrensiegel, this does remove the ability to update all sections' cost at the product level.
However discussing with @jrissler we decided to prioritize this fix, and separately work on a feature to batch-update section costs.

New ticket for implementing a product-wide update of costs: https://eliterate.atlassian.net/browse/MER-1292