### PR TITLE
[BUG FIX] Add necessary assign for authoring preview templates

### DIFF
--- a/lib/oli_web/controllers/resource_controller.ex
+++ b/lib/oli_web/controllers/resource_controller.ex
@@ -104,6 +104,7 @@ defmodule OliWeb.ResourceController do
           project_slug: project_slug,
           title: revision.title,
           preview_mode: true,
+          display_curriculum_item_numbering: true,
           app_params: %{
             activityTypes: activity_types,
             resourceId: revision.resource_id,
@@ -152,7 +153,8 @@ defmodule OliWeb.ResourceController do
                 ),
               content_html:
                 PageEditor.render_page_html(project_slug, transformed_content, author,
-                  preview: true, bib_app_params: bib_references
+                  preview: true,
+                  bib_app_params: bib_references
                 ),
               context: context,
               bib_app_params: %{
@@ -167,6 +169,7 @@ defmodule OliWeb.ResourceController do
                 else
                   nil
                 end,
+              display_curriculum_item_numbering: true,
               page_link_url: &Routes.resource_path(conn, :preview, project_slug, &1),
               container_link_url: &Routes.resource_path(conn, :preview, project_slug, &1)
             )


### PR DESCRIPTION
Closes #2732 

Root cause was the feature that added section-level ability to disable numbering did not provide the assign that controls this to the authoring preview template.  Both authoring and delivery leverage a bit of shared infrastructure for rendering (in this case the links for containers).

This was easily reproducible: simply preview as an author a course that contains a container in the curriculum.  Using the 'prev' and 'next' links at the bottom of the previewed page, as soon as you navigate to a container page this error occurs.  Fixed by adding the assign: hardcoding it to `true`, since this is really an instructor feature.  This leaves numbering on for the author, but of course is still toggleable for the instructor in the section. 
