### PR TITLE
[BUG FIX] make refresh adapter config available in prod

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -97,6 +97,9 @@ config :oli, :stripe_provider,
 # Configure database
 config :oli, Oli.Repo, migration_timestamps: [type: :timestamptz]
 
+# Config adapter for refreshing part_mapping
+config :oli, Oli.Publishing, refresh_adapter: Oli.Publishing.PartMappingRefreshAsync
+
 # Configures the endpoint
 config :oli, OliWeb.Endpoint,
   live_view: [signing_salt: System.get_env("LIVE_VIEW_SALT", "LIVE_VIEW_SALT")],

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -109,9 +109,6 @@ config :oli, OliWeb.Endpoint,
 # configured to run both http and https servers on
 # different ports.
 
-# Config adapter for refreshing part_mapping
-config :oli, Oli.Publishing, refresh_adapter: Oli.Publishing.PartMappingRefreshAsync
-
 # Watch static and templates for browser reloading.
 config :oli, OliWeb.Endpoint,
   live_reload: [


### PR DESCRIPTION
Fixes an issue where refresh adapter was only being configured in dev environment by setting the configuration in `config.exs` so that it is compiled for all environments.