### PR TITLE
[MER-1295] Add missing setup for stripe in payments_controller test

### DIFF
--- a/test/oli_web/controllers/api/payment_controller_test.exs
+++ b/test/oli_web/controllers/api/payment_controller_test.exs
@@ -121,7 +121,7 @@ defmodule OliWeb.PaymentControllerTest do
       conn: conn
     } do
       load_stripe_config()
-      
+
       product = insert(:section, %{amount: Money.new(:USD, "50.00")})
       user = insert(:user)
 
@@ -145,6 +145,8 @@ defmodule OliWeb.PaymentControllerTest do
         |> get(Routes.payment_path(conn, :make_payment, enrollable.slug))
 
       assert html_response(conn, 200) =~ "<input type=\"text\" disabled value=\"$100.00\"/>"
+
+      reset_test_payment_config()
     end
   end
 

--- a/test/oli_web/controllers/payment_providers/stripe_controller_test.exs
+++ b/test/oli_web/controllers/payment_providers/stripe_controller_test.exs
@@ -10,6 +10,8 @@ defmodule OliWeb.PaymentProviders.StripeControllerTest do
 
   @stripe_payments_intents_url "https://api.stripe.com/v1/payment_intents"
 
+  defp create_section(), do: create_section(nil)
+
   defp create_section(_) do
     section =
       insert(:section, %{
@@ -32,7 +34,6 @@ defmodule OliWeb.PaymentProviders.StripeControllerTest do
 
       insert(:enrollment, %{user: user, section: section})
 
-
       conn = get(conn, Routes.payment_path(conn, :make_payment, section.slug))
 
       assert html_response(conn, 200) =~ "Direct payments are not enabled"
@@ -40,7 +41,11 @@ defmodule OliWeb.PaymentProviders.StripeControllerTest do
   end
 
   describe "user cannot access when is not logged in" do
-    setup [:load_stripe_config, :create_section]
+    setup do
+      load_stripe_config()
+      on_exit(fn -> reset_test_payment_config() end)
+      create_section()
+    end
 
     test "redirects to new session when accessing the show view", %{conn: conn, section: section} do
       conn = get(conn, Routes.payment_path(conn, :make_payment, section.slug))
@@ -72,7 +77,15 @@ defmodule OliWeb.PaymentProviders.StripeControllerTest do
   end
 
   describe "show (through payment controller)" do
-    setup [:user_conn, :load_stripe_config, :create_section]
+    setup attrs do
+      [section: section] = create_section()
+      {:ok, conn: conn, user: user} = user_conn(attrs)
+      load_stripe_config()
+
+      on_exit(fn -> reset_test_payment_config() end)
+
+      [conn: conn, user: user, section: section]
+    end
 
     test "can access if user already paid", %{conn: conn, user: user, section: section} do
       enrollment = insert(:enrollment, %{user: user, section: section})
@@ -85,7 +98,6 @@ defmodule OliWeb.PaymentProviders.StripeControllerTest do
     end
 
     test "displays stripe form", %{conn: conn, section: section, user: user} do
-
       insert(:enrollment, %{user: user, section: section})
 
       {:ok, amount} = Money.to_string(section.amount)

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -602,7 +602,16 @@ defmodule Oli.TestHelpers do
   def load_stripe_config(), do: load_stripe_config(nil)
 
   def load_stripe_config(_conn) do
-    Config.Reader.read!("test/config/stripe_config.exs")
-      |> Application.put_all_env()
+    load_env_file("test/config/stripe_config.exs")
+  end
+
+  def reset_test_payment_config() do
+    load_env_file("test/config/config.exs")
+  end
+
+  defp load_env_file(path) do
+    path
+    |> Config.Reader.read!()
+    |> Application.put_all_env()
   end
 end


### PR DESCRIPTION
[MER-1295](https://eliterate.atlassian.net/browse/MER-1295)

#### What does it change?

- Adds a missing direct payment setup for broken `payment_controller` test