### PR TITLE
[FEATURE] Dynamic question infrastructure

### DIFF
--- a/.github/actions/torus-builder/entrypoint.sh
+++ b/.github/actions/torus-builder/entrypoint.sh
@@ -12,6 +12,7 @@ MIX_ENV=prod SHA=$RELEASE_SHA mix compile
 yarn --cwd ./assets
 npm run deploy --prefix ./assets
 npm run deploy-node --prefix ./assets
+npm run deploy --prefix ./assets/src/infra/dynamic-eval
 
 MIX_ENV=prod mix phx.digest
 MIX_ENV=prod SHA=$RELEASE_SHA mix release

--- a/.github/actions/torus-builder/entrypoint.sh
+++ b/.github/actions/torus-builder/entrypoint.sh
@@ -12,7 +12,6 @@ MIX_ENV=prod SHA=$RELEASE_SHA mix compile
 yarn --cwd ./assets
 npm run deploy --prefix ./assets
 npm run deploy-node --prefix ./assets
-npm run deploy --prefix ./assets/src/infra/dynamic-eval
 
 MIX_ENV=prod mix phx.digest
 MIX_ENV=prod SHA=$RELEASE_SHA mix release

--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ postgres.env
 /assets/sdk/oli-torus-sdk-*.tgz
 /assets/sdk/dist/
 /assets/sdk/node_modules
+/assets/src/infra/dynamic-eval/node_modules/
 /assets/sdk/yarn.lock
 .devmode
 .elixir_ls

--- a/.gitignore
+++ b/.gitignore
@@ -70,7 +70,6 @@ postgres.env
 /assets/sdk/oli-torus-sdk-*.tgz
 /assets/sdk/dist/
 /assets/sdk/node_modules
-/assets/src/infra/dynamic-eval/node_modules/
 /assets/sdk/yarn.lock
 .devmode
 .elixir_ls

--- a/assets/src/data/activities/model/responses.ts
+++ b/assets/src/data/activities/model/responses.ts
@@ -42,7 +42,7 @@ export const getResponseBy = (model: HasParts, predicate: (x: Response) => boole
 
 // Does not take into account partial credit
 export const getCorrectResponse = (model: HasParts, partId: string) => {
-  return Maybe.maybe(getResponsesByPartId(model, partId).find((r) => r.score === 1)).valueOrThrow(
+  return Maybe.maybe(getResponsesByPartId(model, partId).find((r) => r.score >= 1)).valueOrThrow(
     new Error('Could not find correct response'),
   );
 };

--- a/assets/tsconfig.node.json
+++ b/assets/tsconfig.node.json
@@ -17,22 +17,12 @@
     "outDir": "../_node",
     "baseUrl": ".",
     "paths": {
-      "*": [
-        "src/*"
-      ]
+      "*": ["src/*"]
     },
-    "types": [
-      "node",
-      "jest",
-      "jquery"
-    ],
+    "types": ["node", "jest", "jquery"],
     "esModuleInterop": true
   },
-  "include": [
-    "src/adaptivity/rules.ts"
-  ],
+  "include": ["src/adaptivity/rules.ts"],
 
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }

--- a/assets/webpack.config.node.js
+++ b/assets/webpack.config.node.js
@@ -4,11 +4,11 @@ const path = require('path');
 module.exports = (env, options) => ({
   target: 'node',
   entry: {
-    rules: ['./src/adaptivity/rules.ts']
+    rules: ['./src/adaptivity/rules.ts'],
   },
   output: {
     path: path.resolve(__dirname, '../priv/node'),
-    libraryTarget: 'commonjs2'
+    libraryTarget: 'commonjs2',
   },
   resolve: {
     extensions: ['.ts', '.js'],
@@ -19,22 +19,20 @@ module.exports = (env, options) => ({
       actions: path.resolve(__dirname, 'src/actions'),
       data: path.resolve(__dirname, 'src/data'),
       state: path.resolve(__dirname, 'src/state'),
-      utils: path.resolve(__dirname, 'src/utils')
-    }
+      utils: path.resolve(__dirname, 'src/utils'),
+    },
   },
   module: {
     rules: [
       {
         test: /\.ts(x?)$/,
         include: path.resolve(__dirname, 'src'),
-        use: [
-          { loader: 'ts-loader', options: { configFile: 'tsconfig.node.json' } },
-        ],
-      }
+        use: [{ loader: 'ts-loader', options: { configFile: 'tsconfig.node.json' } }],
+      },
     ],
   },
   plugins: [],
   watchOptions: {
     ignored: ['**/*.tsx', '**/node_modules', '**/*.scss'],
-  }
+  },
 });

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -3072,7 +3072,7 @@ ajv@^6.10.0, ajv@^6.12.4, ajv@^6.12.5, ajv@^6.7.0:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.0, ajv@^8.8.0:
+ajv@^8.0.0, ajv@^8.11.0, ajv@^8.8.0:
   version "8.11.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
   integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
@@ -3086,16 +3086,6 @@ ajv@^8.0.1:
   version "8.9.0"
   resolved "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz"
   integrity sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==
-  dependencies:
-    fast-deep-equal "^3.1.1"
-    json-schema-traverse "^1.0.0"
-    require-from-string "^2.0.2"
-    uri-js "^4.2.2"
-
-ajv@^8.11.0:
-  version "8.11.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
-  integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"

--- a/config/config.exs
+++ b/config/config.exs
@@ -68,7 +68,7 @@ config :oli, :rule_evaluator,
 
 variable_substitution_provider =
   case System.get_env("VARIABLE_SUBSTITUTION_PROVIDER") do
-    nil -> Oli.Activities.Transformers.VariableSubstitution.RestImpl
+    nil -> Oli.Activities.Transformers.VariableSubstitution.NoOpImpl
     provider -> Module.concat([Oli, Activities, Transformers, VariableSubstitution, provider])
   end
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -52,7 +52,8 @@ config :oli,
       ),
     favicons: System.get_env("BRANDING_FAVICONS_DIR", "/favicons")
   ],
-  payment_provider: System.get_env("PAYMENT_PROVIDER", "none")
+  payment_provider: System.get_env("PAYMENT_PROVIDER", "none"),
+  node_js_pool_size: String.to_integer(System.get_env("NODE_JS_POOL_SIZE", "2"))
 
 rule_evaluator_provider =
   case System.get_env("RULE_EVALUATOR_PROVIDER") do
@@ -62,9 +63,21 @@ rule_evaluator_provider =
 
 config :oli, :rule_evaluator,
   dispatcher: rule_evaluator_provider,
-  node_js_pool_size: String.to_integer(System.get_env("NODE_JS_POOL_SIZE", "2")),
   aws_fn_name: System.get_env("EVAL_LAMBDA_FN_NAME", "rules"),
   aws_region: System.get_env("EVAL_LAMBDA_REGION", "us-east-1")
+
+variable_substitution_provider =
+  case System.get_env("VARIABLE_SUBSTITUTION_PROVIDER") do
+    nil -> Oli.Activities.Transformers.VariableSubstitution.RestImpl
+    provider -> Module.concat([Oli, Activities, Transformers, VariableSubstitution, provider])
+  end
+
+config :oli, :variable_substitution,
+  dispatcher: variable_substitution_provider,
+  aws_fn_name: System.get_env("VARIABLE_SUBSTITUTION_LAMBDA_FN_NAME", "eval"),
+  aws_region: System.get_env("VARIABLE_SUBSTITUTION_LAMBDA_REGION", "us-east-1"),
+  rest_endpoint_url:
+    System.get_env("VARIABLE_SUBSTITUTION_REST_ENDPOINT_URL", "http://localhost:8000/sandbox")
 
 default_description = """
 The Open Learning Initiative enables research and experimentation with all aspects of the learning experience.

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -139,7 +139,7 @@ config :oli, :rule_evaluator,
 
 variable_substitution_provider =
   case System.get_env("VARIABLE_SUBSTITUTION_PROVIDER") do
-    nil -> Oli.Activities.Transformers.VariableSubstitution.RestImpl
+    nil -> Oli.Activities.Transformers.VariableSubstitution.NoOpImpl
     provider -> Module.concat([Oli, Activities, Transformers, VariableSubstitution, provider])
   end
 

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -88,7 +88,8 @@ config :oli,
         System.get_env("BRANDING_LOGO", "/images/oli_torus_logo_dark.png")
       ),
     favicons: System.get_env("BRANDING_FAVICONS_DIR", "/favicons")
-  ]
+  ],
+  node_js_pool_size: String.to_integer(System.get_env("NODE_JS_POOL_SIZE", "2"))
 
 default_description = """
 The Open Learning Initiative enables research and experimentation with all aspects of the learning experience.
@@ -133,9 +134,20 @@ rule_evaluator_provider =
 
 config :oli, :rule_evaluator,
   dispatcher: rule_evaluator_provider,
-  node_js_pool_size: String.to_integer(System.get_env("NODE_JS_POOL_SIZE", "2")),
   aws_fn_name: System.get_env("EVAL_LAMBDA_FN_NAME", "rules"),
   aws_region: System.get_env("EVAL_LAMBDA_REGION", "us-east-1")
+
+variable_substitution_provider =
+  case System.get_env("VARIABLE_SUBSTITUTION_PROVIDER") do
+    nil -> Oli.Activities.Transformers.VariableSubstitution.RestImpl
+    provider -> Module.concat([Oli, Activities, Transformers, VariableSubstitution, provider])
+  end
+
+config :oli, :variable_substitution,
+  dispatcher: variable_substitution_provider,
+  aws_fn_name: System.get_env("VARIABLE_SUBSTITUTION_LAMBDA_FN_NAME", "eval"),
+  aws_region: System.get_env("VARIABLE_SUBSTITUTION_LAMBDA_REGION", "us-east-1"),
+  rest_endpoint_url: System.get_env("VARIABLE_SUBSTITUTION_REST_ENDPOINT_URL", "us-east-1")
 
 # Configure help
 # HELP_PROVIDER env var must be a string representing an existing provider module, such as "FreshdeskHelp"

--- a/lib/oli/activities/model/transformations.ex
+++ b/lib/oli/activities/model/transformations.ex
@@ -1,14 +1,24 @@
 defmodule Oli.Activities.Model.Transformation do
-  defstruct [:id, :path, :operation]
+  defstruct [:id, :path, :operation, :data]
 
-  def parse(%{"id" => id, "path" => path, "operation" => operation_str}) do
+  def parse(%{"id" => id, "operation" => operation_str} = json) do
     case operation_str do
       "shuffle" ->
         {:ok,
          %Oli.Activities.Model.Transformation{
+           data: nil,
            id: id,
-           path: path,
+           path: Map.get(json, "path"),
            operation: :shuffle
+         }}
+
+      "variable_substitution" ->
+        {:ok,
+         %Oli.Activities.Model.Transformation{
+           data: Map.get(json, "data"),
+           id: id,
+           path: nil,
+           operation: :variable_substitution
          }}
 
       _ ->

--- a/lib/oli/activities/transformers.ex
+++ b/lib/oli/activities/transformers.ex
@@ -1,46 +1,161 @@
 defmodule Oli.Activities.Transformers do
   alias Oli.Activities.Model
-  alias Oli.Activities.Model.Transformation
-  alias Oli.Activities.Transformers.Shuffle
+
+  require Logger
+
+  @supported_transformations_by_operation [
+    {:variable_substitution, Oli.Activities.Transformers.VariableSubstitution},
+    {:shuffle, Oli.Activities.Transformers.Shuffle}
+  ]
 
   @doc """
-  Transforms an unparsed activity model.
+  Transforms a collection of activity revisions, batching the execution of the "context gathering"
+  step of each transformation operation type.
 
-  When no transformations exist, or the resulting transformations had no effect this
-  returns {:no_effect, original_model} where `original_model` is the original unparsed model
-  of the activity.
+  Returns a list of transformation results, where each entry is one of:
 
-  Otherwise, this applies all transformations and returns {:ok, transformed_model} where
-  `transformed_model` is the raw model after mutation from transformations.
-
-  If errors occur during parsing or transformation, returns {:error, e}
+  {:ok, nil} -> No transformations were present in the revision content
+  {:ok, transformed_model} -> transformed_model is the newly transformed activity model
+  {:error, e} -> an error was encountered in either parsing of the model or execution of transformation.
   """
-  def apply_transforms(model) do
-    case Model.parse(model) do
-      {:ok, parsed_model} ->
-        case Enum.count(parsed_model.transformations) do
-          0 ->
-            {:no_effect, model}
+  def apply_transforms(revisions) when is_list(revisions) do
+    # We transform raw, unparsed models, so create a repository of those, keyed by revision id
+    model_repository = Enum.reduce(revisions, %{}, fn r, m -> Map.put(m, r.id, r.content) end)
 
-          _ ->
-            Enum.reduce_while(parsed_model.transformations, {:ok, model}, fn t, {:ok, model} ->
-              case apply_transform(model, t) do
-                {:ok, transformed_model} -> {:cont, {:ok, transformed_model}}
-                {:error, error} -> {:halt, {:error, error}}
-              end
-            end)
+    # Parse the models, and create a list of tuples of the revision and the parse result
+    parsed_models = Enum.map(revisions, fn r -> {r, Model.parse(r.content)} end)
+
+    parsing_errors_by_id = index_parsing_errors(parsed_models)
+
+    # Create a MapSet of all revision ids that parsed successfully and that have at least one transformation
+    has_transformation =
+      Enum.filter(parsed_models, fn {_, parsed_model_result} ->
+        case parsed_model_result do
+          {:ok, parsed_model} -> Enum.count(parsed_model.transformations) > 0
+          _ -> false
         end
+      end)
+      |> Enum.map(fn {rev, _} -> rev.id end)
+      |> MapSet.new()
 
-      {:error, error} ->
-        {:error, error}
+    # Group the transformers by type and batch execute their context creation and individually
+    # apply their transforms
+    {model_repository, transform_errors} =
+      group_by_operation(parsed_models)
+      |> batch_execute(model_repository)
+
+    # Now map our original list of revisions to the result of the transformation.
+    Enum.map(revisions, fn r ->
+      if MapSet.member?(has_transformation, r.id) do
+        if Map.has_key?(transform_errors, r.id) do
+          {:error, Map.get(transform_errors, r.id)}
+        else
+          {:ok, Map.get(model_repository, r.id)}
+        end
+      else
+        if Map.has_key?(parsing_errors_by_id, r.id) do
+          {:error, Map.get(parsing_errors_by_id, r.id)}
+        else
+          {:ok, nil}
+        end
+      end
+    end)
+  end
+
+  # Executes all transformations, grouped by operation (aka, their "type"), in a manner
+  # that gathers any required context in a batch manner.
+  #
+  # Takes a map of operations as keys, with values being a list of tuples of revision id
+  # and transformation.  Second argument is a map of revision models, keyed by their revision
+  # id.
+  #
+  # Returns a tuple with the first element being the updated map of revision models and the
+  # second element being a map of revision ids to errors encountered.
+  defp batch_execute(by_operation, model_repository) do
+    @supported_transformations_by_operation
+    |> Enum.reduce({model_repository, %{}}, fn {operation, module},
+                                               {model_repository, errors_by_id} ->
+      case Map.get(by_operation, operation) do
+        nil ->
+          {model_repository, errors_by_id}
+
+        revision_id_transform_pairs ->
+          run_one_operation(model_repository, module, revision_id_transform_pairs, errors_by_id)
+      end
+    end)
+  end
+
+  # Run one batch of transformers, for a specific operation.
+  #
+  # Takes the model repository, the module of the transformer impl, and a list of
+  # tuples of revision ids and transformer.  The larevision_id_transform_pairsst argument is really our
+  # "batch" of work.
+  #
+  # Returns a tuple with first element being the new model_repository, and second being a map of
+  # revision ids to errors, for those that errored
+  defp run_one_operation(model_repository, module, revision_id_transform_pairs, errors_by_id) do
+    transformers = Enum.map(revision_id_transform_pairs, fn {_, t} -> t end)
+
+    # Generate the batch context
+    case apply(module, :provide_batch_context, [transformers]) do
+      {:ok, batch_context} ->
+        # Now that we have the context for each transformer, go ahead and run
+        # that single transformer and update the model repository with its results
+        Enum.zip(batch_context, revision_id_transform_pairs)
+        |> Enum.reduce({model_repository, errors_by_id}, fn {context, {id, t}},
+                                                            {model_repository, errors_by_id} ->
+          case apply(module, :transform, [Map.get(model_repository, id), t, context]) do
+            {:ok, model} ->
+              {Map.put(model_repository, id, model), errors_by_id}
+
+            {:error, e} ->
+              {model_repository, Map.put(errors_by_id, id, e)}
+          end
+        end)
+
+      {:error, e} ->
+        # add an entry for all revisions that used this operation, since their batch context
+        # gathering step failed
+        errors_by_id =
+          Enum.map(revision_id_transform_pairs, fn {id, _} -> id end)
+          |> Enum.reduce(errors_by_id, fn id, by_id -> Map.put(by_id, id, e) end)
+
+        {model_repository, errors_by_id}
     end
   end
 
-  defp apply_transform(model, %Transformation{operation: :shuffle} = transformation) do
-    Shuffle.transform(model, transformation)
+  defp index_parsing_errors(parsed_model_pairs) do
+    Enum.reduce(parsed_model_pairs, %{}, fn {r, parsed_model_result}, by_id ->
+      case parsed_model_result do
+        {:ok, _} -> by_id
+        {:error, e} -> Map.put(by_id, r.id, e)
+      end
+    end)
   end
 
-  defp apply_transform(_, _) do
-    {:error, :transformation_not_implemented}
+  # Given a list of tuples of revision and parsed model results, create a
+  # map of transformation operation keys to a list of tuples containing revision ids and a transformer.
+  #
+  # An example of the return value:
+  #
+  # %{
+  #   shuffle: [{23, %Transformer{...}}, {36, %Transformer{...}}],
+  #   variable_substitution: [{23, %Transformer{...}}]
+  # }
+  #
+  defp group_by_operation(revision_operation_pairs) do
+    Enum.reduce(revision_operation_pairs, %{}, fn {r, parsed_model_result}, all ->
+      case parsed_model_result do
+        {:ok, parsed_model} ->
+          Enum.reduce(parsed_model.transformations, all, fn t, by_operation ->
+            Map.put(by_operation, t.operation, [
+              {r.id, t} | Map.get(by_operation, t.operation, [])
+            ])
+          end)
+
+        _ ->
+          all
+      end
+    end)
   end
 end

--- a/lib/oli/activities/transformers/shuffle.ex
+++ b/lib/oli/activities/transformers/shuffle.ex
@@ -5,10 +5,18 @@ defmodule Oli.Activities.Transformers.Shuffle do
   @behaviour Transformer
 
   @impl Transformer
-  def transform(model, %Transformation{path: path}) do
+  def transform(model, %Transformation{path: path}, _context) do
     case Map.get(model, path) do
-      nil -> {:error, :path_not_found}
-      collection -> {:ok, Map.put(model, path, Enum.shuffle(collection))}
+      nil ->
+        {:error, :path_not_found}
+
+      collection ->
+        {:ok, Map.put(model, path, Enum.shuffle(collection))}
     end
+  end
+
+  @impl Transformer
+  def provide_batch_context(_transformers) do
+    {:ok, %{}}
   end
 end

--- a/lib/oli/activities/transformers/transformer.ex
+++ b/lib/oli/activities/transformers/transformer.ex
@@ -1,5 +1,7 @@
 defmodule Oli.Activities.Transformers.Transformer do
   alias Oli.Activities.Model.Transformation
 
-  @callback transform(map(), %Transformation{}) :: {:ok, map()} | {:error, any}
+  @callback transform(map(), %Transformation{}, map()) :: {:ok, map()} | {:error, any}
+
+  @callback provide_batch_context([%Transformation{}]) :: {:ok, map()} | {:error, any}
 end

--- a/lib/oli/activities/transformers/variable_substitution.ex
+++ b/lib/oli/activities/transformers/variable_substitution.ex
@@ -1,0 +1,16 @@
+defmodule Oli.Activities.Transformers.VariableSubstitution do
+  alias Oli.Activities.Transformers.Transformer
+  alias Oli.Activities.Transformers.VariableSubstitution.Strategy
+
+  @behaviour Transformer
+
+  @impl Transformer
+  def transform(model, _, evaluated_variables) do
+    Strategy.substitute(model, evaluated_variables)
+  end
+
+  @impl Transformer
+  def provide_batch_context(transformers) do
+    Strategy.provide_batch_context(transformers)
+  end
+end

--- a/lib/oli/activities/transformers/variable_substitution/common.ex
+++ b/lib/oli/activities/transformers/variable_substitution/common.ex
@@ -1,0 +1,20 @@
+defmodule Oli.Activities.Transformers.VariableSubstitution.Common do
+  @doc """
+  Replace the variables found in the model with their evaluations from the evaluation
+  digest.
+  """
+  def replace_variables(model, evaluation_digest) do
+    encoded = Jason.encode!(model)
+
+    Enum.reduce(evaluation_digest, encoded, fn %{"variable" => v, "result" => r}, s ->
+      r =
+        case r do
+          s when is_binary(s) -> s
+          number -> Kernel.to_string(number)
+        end
+
+      String.replace(s, "@@#{v}@@", r)
+    end)
+    |> Jason.decode()
+  end
+end

--- a/lib/oli/activities/transformers/variable_substitution/lambda_impl.ex
+++ b/lib/oli/activities/transformers/variable_substitution/lambda_impl.ex
@@ -1,0 +1,17 @@
+defmodule Oli.Activities.Transformers.VariableSubstitution.LambdaImpl do
+  alias Oli.Activities.Transformers.VariableSubstitution.Strategy
+
+  require Logger
+
+  @behaviour Strategy
+
+  @impl Strategy
+  def substitute(_model, _evaluation_digest) do
+    {:error, :not_implemented}
+  end
+
+  @impl Strategy
+  def provide_batch_context(_transformers) do
+    {:error, :not_implemented}
+  end
+end

--- a/lib/oli/activities/transformers/variable_substitution/node_impl.ex
+++ b/lib/oli/activities/transformers/variable_substitution/node_impl.ex
@@ -1,0 +1,17 @@
+defmodule Oli.Activities.Transformers.VariableSubstitution.NodeImpl do
+  alias Oli.Activities.Transformers.VariableSubstitution.Strategy
+
+  require Logger
+
+  @behaviour Strategy
+
+  @impl Strategy
+  def substitute(_model, _evaluation_digest) do
+    {:error, :not_implemented}
+  end
+
+  @impl Strategy
+  def provide_batch_context(_transformers) do
+    {:error, :not_implemented}
+  end
+end

--- a/lib/oli/activities/transformers/variable_substitution/noop_impl.ex
+++ b/lib/oli/activities/transformers/variable_substitution/noop_impl.ex
@@ -1,0 +1,16 @@
+defmodule Oli.Activities.Transformers.VariableSubstitution.NoOpImpl do
+  alias Oli.Activities.Transformers.VariableSubstitution.Strategy
+  alias Oli.Activities.Transformers.VariableSubstitution.Common
+
+  @behaviour Strategy
+
+  @impl Strategy
+  def substitute(model, evaluation_digest) do
+    Common.replace_variables(model, evaluation_digest)
+  end
+
+  @impl Strategy
+  def provide_batch_context(transformers) do
+    {:ok, Enum.map(transformers, fn _ -> %{} end)}
+  end
+end

--- a/lib/oli/activities/transformers/variable_substitution/rest_impl.ex
+++ b/lib/oli/activities/transformers/variable_substitution/rest_impl.ex
@@ -1,0 +1,39 @@
+defmodule Oli.Activities.Transformers.VariableSubstitution.RestImpl do
+  alias Oli.Activities.Transformers.VariableSubstitution.Strategy
+  alias Oli.Activities.Transformers.VariableSubstitution.Common
+
+  import Oli.HTTP
+
+  require Logger
+
+  @behaviour Strategy
+
+  @impl Strategy
+  def substitute(model, evaluation_digest) do
+    Common.replace_variables(model, evaluation_digest)
+  end
+
+  @impl Strategy
+  def provide_batch_context(transformers) do
+    url = Application.fetch_env!(:oli, :variable_substitution)[:rest_endpoint_url]
+
+    body =
+      %{
+        vars: Enum.map(transformers, fn t -> %{expression: t.data, variable: "module"} end),
+        count: 1
+      }
+      |> Poison.encode!()
+
+    headers = [
+      "Content-Type": "application/json"
+    ]
+
+    case http().post(url, body, headers, []) do
+      {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
+        {:ok, Poison.decode!(body)}
+
+      {:ok, %HTTPoison.Response{}} ->
+        {:error, "Error retrieving the payload"}
+    end
+  end
+end

--- a/lib/oli/activities/transformers/variable_substitution/rest_impl.ex
+++ b/lib/oli/activities/transformers/variable_substitution/rest_impl.ex
@@ -30,7 +30,7 @@ defmodule Oli.Activities.Transformers.VariableSubstitution.RestImpl do
 
     case http().post(url, body, headers, []) do
       {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
-        {:ok, Poison.decode!(body)}
+        Poison.decode(body)
 
       {:ok, %HTTPoison.Response{}} ->
         {:error, "Error retrieving the payload"}

--- a/lib/oli/activities/transformers/variable_substitution/strategy.ex
+++ b/lib/oli/activities/transformers/variable_substitution/strategy.ex
@@ -1,0 +1,21 @@
+defmodule Oli.Activities.Transformers.VariableSubstitution.Strategy do
+  @doc """
+  Performs variable subsitution on a model.
+  """
+  @callback substitute(map(), map()) :: {:ok, map()} | {:error, term()}
+
+  @callback provide_batch_context(list()) :: {:ok, list()} | {:error, term()}
+
+  @doc """
+  Does the dynamic dispatch based on configured provider.
+  """
+  def substitute(model, data) do
+    module = Application.fetch_env!(:oli, :variable_substitution)[:dispatcher]
+    apply(module, :substitute, [model, data])
+  end
+
+  def provide_batch_context(transformers) do
+    module = Application.fetch_env!(:oli, :variable_substitution)[:dispatcher]
+    apply(module, :provide_batch_context, [transformers])
+  end
+end

--- a/lib/oli/authoring/editing/activity_editor.ex
+++ b/lib/oli/authoring/editing/activity_editor.ex
@@ -632,9 +632,9 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
                resource_id: activity.resource_id,
                revision_id: activity.id
              }) do
-        case Transformers.apply_transforms(content) do
-          {:ok, transformed} -> {activity, transformed}
-          {:no_effect, original} -> {activity, original}
+        case Transformers.apply_transforms([activity]) do
+          [{:ok, nil}] -> {activity, content}
+          [{:ok, transformed}] -> {activity, transformed}
           _ -> {activity, nil}
         end
       else

--- a/lib/oli/authoring/editing/page_editor.ex
+++ b/lib/oli/authoring/editing/page_editor.ex
@@ -330,16 +330,22 @@ defmodule Oli.Authoring.Editing.PageEditor do
                         activity_type_id: activity_type_id,
                         content: content,
                         graded: graded
-                      } ->
+                      } = revision ->
          # To support 'test mode' in the editor, we give the editor an initial transformed
          # version of the model that it can immediately use for display purposes. If it fails
          # to transform, nil will be handled by the client and the raw model will be used
          # instead
          transformed =
-           case Transformers.apply_transforms(content) do
-             {:ok, t} -> t
-             {:no_effect, t} -> t
-             _ -> nil
+           case Transformers.apply_transforms([revision]) do
+             [{:ok, nil}] ->
+               revision.content
+
+             [{:ok, t}] ->
+               t
+
+             e ->
+               IO.inspect(e)
+               nil
            end
 
          # the activity type this revision pertains to

--- a/test/oli/activities/transformers_test.exs
+++ b/test/oli/activities/transformers_test.exs
@@ -3,6 +3,14 @@ defmodule Oli.Activities.TransformersTest do
 
   alias Oli.Activities.Transformers
 
+  defp as_revision(id, model) do
+    %Oli.Resources.Revision{
+      id: id,
+      resource_id: id,
+      content: model
+    }
+  end
+
   test "no transformers results in no effect" do
     model = %{
       "stem" => "this is the stem",
@@ -25,37 +33,41 @@ defmodule Oli.Activities.TransformersTest do
       }
     }
 
-    assert {:no_effect, _} = Transformers.apply_transforms(model)
+    assert [{:ok, nil}] = Transformers.apply_transforms([as_revision(1, model)])
   end
 
   test "applying shuffle" do
-    model = %{
-      "stem" => "this is the stem",
-      "choices" => [
-        %{id: "1", content: []},
-        %{id: "2", content: []},
-        %{id: "3", content: []},
-        %{id: "4", content: []}
-      ],
-      "authoring" => %{
-        "parts" => [
-          %{
-            "id" => "1",
-            "responses" => [],
-            "scoringStrategy" => "best",
-            "evaluationStrategy" => "regex"
-          }
+    create_model = fn ->
+      %{
+        "stem" => "this is the stem",
+        "choices" => [
+          %{id: "1", content: []},
+          %{id: "2", content: []},
+          %{id: "3", content: []},
+          %{id: "4", content: []}
         ],
-        "transformations" => [
-          %{"id" => "1", "path" => "choices", "operation" => "shuffle"}
-        ]
+        "authoring" => %{
+          "parts" => [
+            %{
+              "id" => "1",
+              "responses" => [],
+              "scoringStrategy" => "best",
+              "evaluationStrategy" => "regex"
+            }
+          ],
+          "transformations" => [
+            %{"id" => "1", "path" => "choices", "operation" => "shuffle"}
+          ]
+        }
       }
-    }
+    end
 
     # Shuffle fifty times.  If none of the shuffles result in
     # the first element changing - we likely have a broken shuffle impl.
-    assert Enum.any?(1..50, fn _ ->
-             {:ok, transformed} = Transformers.apply_transforms(model)
+    assert Enum.any?(1..1, fn _ ->
+             [{:ok, transformed}] =
+               Transformers.apply_transforms([as_revision(1, create_model.())])
+
              transformed["choices"] |> Enum.at(0) |> Map.get("id") != "1"
            end)
   end
@@ -84,7 +96,8 @@ defmodule Oli.Activities.TransformersTest do
       }
     }
 
-    assert {:error, ["invalid operation"]} = Transformers.apply_transforms(model)
+    assert [{:error, ["invalid operation"]}] =
+             Transformers.apply_transforms([as_revision(1, model)])
   end
 
   test "catching case where path cannot be found" do
@@ -106,11 +119,11 @@ defmodule Oli.Activities.TransformersTest do
           }
         ],
         "transformations" => [
-          %{"id" => "1", "path" => "choicess", "operation" => "shuffle"}
+          %{"id" => "1", "path" => "this_path_does_not_exist", "operation" => "shuffle"}
         ]
       }
     }
 
-    assert {:error, :path_not_found} = Transformers.apply_transforms(model)
+    assert [{:error, :path_not_found}] = Transformers.apply_transforms([as_revision(1, model)])
   end
 end

--- a/test/oli/delivery/test_mode_test.exs
+++ b/test/oli/delivery/test_mode_test.exs
@@ -6,12 +6,20 @@ defmodule Oli.Delivery.TestModeTest do
   alias Oli.Delivery.Evaluation.Actions.FeedbackAction
   alias Oli.Delivery.Evaluation.Actions.SubmissionAction
 
+  defp as_revision(id, model) do
+    %Oli.Resources.Revision{
+      id: id,
+      resource_id: id,
+      content: model
+    }
+  end
+
   describe "test mode evaluation and transformation" do
     setup do
       # all we need is the definition of an activity model
       %{
         content: %{
-          "stem" => "1",
+          "stem" => "",
           "choices" => [
             %{id: "1", content: []},
             %{id: "2", content: []},
@@ -102,7 +110,8 @@ defmodule Oli.Delivery.TestModeTest do
 
     test "performing a transformation", %{content: content} do
       assert {:ok, %{"stem" => _, "authoring" => _, "choices" => _}} =
-               ActivityLifecycle.perform_test_transformation(content)
+               as_revision(1, content)
+               |> ActivityLifecycle.perform_test_transformation()
     end
 
     test "performing evaluations where one is a non-matching input", %{content: content} do


### PR DESCRIPTION
This PR adds the core infrastructure to support OLI Legacy style "Dynamic Questions".  

The key pieces of this work:

1. Introduce a new transformation operation type: `variable_substitution`.  An activity that is a "Dynamic Question" will include an instance of this transformation operation type in its `transformations` collection.  
2. Rework the transformations infrastructure to introduce a "batch context" creation step.  The idea here is that if we have a page which contains 15 dynamic questions, we do not want to serially execute the external call to evaluate their variables (whether it is to the Node bridge, Lambda, or a REST impl of the `authoring-eval`).  Rather, we want to bundle all 15 of these requests and send them to the evaluator as a batch operation.  This new batch context creation step appears in the transformer behavior as callback `provide_batch_context`
3. Implement a dynamic dispatch for the specific implementation of the variable substitution transformer.  There are four impls included: `LambdaImpl`, `NodeImpl`, `RestImpl` and `NoOpImpl`.  The NoOp impl is a stub meant for unit testing and for situations where dynamic question support is disabled (usually a dev environment).  The REST Impl allows use of the legacy `authoring-eval` REST JSON implementation.  Both Lambda and Node impls are stubbed out and unsupported at the moment.  

While there is no authoring support yet, one can test this out by creating a digest with the test migration course, ingesting that, and then visiting the "Graded Assessment with Dynamic Question" page founding within Unit 1 / Module 3. 