### PR TITLE
[MER-1297] Attempt fix for part mapping refresh not being executed

### DIFF
--- a/lib/oli/publishing/part_mapping_refresh_async.ex
+++ b/lib/oli/publishing/part_mapping_refresh_async.ex
@@ -8,7 +8,10 @@ defmodule Oli.Publishing.PartMappingRefreshAsync do
   @impl PartMappingRefreshAdapter
   @spec maybe_refresh_part_mapping(ecto_publication_operation) :: ecto_publication_operation
   def maybe_refresh_part_mapping({:ok, _publication} = operation_result) do
-    Task.async(fn -> Oli.Publishing.refresh_part_mapping() end)
+    Task.start(fn ->
+      Process.sleep(5_000)
+      Oli.Publishing.refresh_part_mapping()
+    end)
     operation_result
   end
 


### PR DESCRIPTION
[MER-1297](https://eliterate.atlassian.net/browse/MER-1297)

### What does it change?

- Attempts to fix the part_mapping view not being refreshed on project publication updates

This replaces `Task.async` for `Task.start`
From the [elixir docs](https://hexdocs.pm/elixir/1.13/Task.html#module-dynamically-supervised-tasks): 

> ..async tasks link the caller and the spawned process. This means that, if the caller crashes, the task will crash too and vice-versa. This is on purpose: if the process meant to receive the result no longer exists, there is no purpose in completing the computation.
>

One reason for the refresh not being executed could be that process running the publication update is finishing before the spawned process that runs the refresh. 

From the[ Task.start docs](https://hexdocs.pm/elixir/1.13/Task.html#start/1) 

>This should only used when the task is used for side-effects (like I/O) and you have no interest on its results nor if it completes successfully.
>
> If the current node is shutdown, the node will terminate even if the task was not completed. For this reason, we recommend to use [Task.Supervisor.start_child/2](https://hexdocs.pm/elixir/1.13/Task.Supervisor.html#start_child/2) instead, which allows you to control the shutdown time via the :shutdown option
>

This fits our use case, since we don't want to depend (or limit) the child process lifetime from the current process. We also don't need to supervise it or shut it down manually, so no need to use `Task.Supervisor.start_child`

Another option would be to use `Task.asnyc_nolink` but it requires a supervisor and we have no intention on supervising the process.

The `Process.sleep/1` call is added as an extra safety measure for cases when the `Publishing.update_publication` is executed inside another transaction. Before refreshing the view, we want all the changes to be persisted.

I didn't manage to replicate the original issue locally, so we agreed on running this in QA to test if this fixes the part_mapping view not being refreshed.