### PR TITLE
[PERFORMANCE] Remove prometheus telemetry reporter

### DIFF
--- a/lib/oli_web/telemetry.ex
+++ b/lib/oli_web/telemetry.ex
@@ -7,13 +7,7 @@ defmodule OliWeb.Telemetry do
   end
 
   def init(_arg) do
-    children = [
-      {TelemetryMetricsPrometheus,
-       [metrics: metrics(), port: Application.get_env(:oli, :prometheus_port)]},
-      {:telemetry_poller, measurements: periodic_measurements(), period: 10_000}
-    ]
-
-    Supervisor.init(children, strategy: :one_for_one)
+    Supervisor.init([], strategy: :one_for_one)
   end
 
   def metrics do
@@ -64,9 +58,5 @@ defmodule OliWeb.Telemetry do
       summary("vm.total_run_queue_lengths.cpu"),
       summary("vm.total_run_queue_lengths.io")
     ]
-  end
-
-  defp periodic_measurements do
-    []
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -190,7 +190,6 @@ defmodule Oli.MixProject do
       {:telemetry, "~> 0.4.1"},
       {:telemetry_poller, "~> 0.4"},
       {:telemetry_metrics, "~> 0.4"},
-      {:telemetry_metrics_prometheus, "~> 1.0.0"},
       {:timex, "~> 3.5"},
       {:tzdata, "~> 1.1"},
       {:uuid, "~> 1.1"},


### PR DESCRIPTION
Remove the prometheus reporter to determine if this is indeed causing the memory leak and crashes