### PR TITLE
[MER-1288] Add project ids to snapshots

### DIFF
--- a/priv/repo/migrations/20220629134948_update_snapshots_add_project_ids.exs
+++ b/priv/repo/migrations/20220629134948_update_snapshots_add_project_ids.exs
@@ -1,0 +1,28 @@
+defmodule Oli.Repo.Migrations.UpdateSnapshotsAddProjectIds do
+  use Ecto.Migration
+
+  def up do
+    drop index(:snapshots, [:objective_id])
+    drop index(:snapshots, [:activity_id])
+    drop index(:snapshots, [:section_id])
+    drop index(:snapshots, [:part_attempt_id, :objective_id], name: :snapshot_unique_part)
+
+    execute """
+      UPDATE snapshots
+      SET project_id = sect.base_project_id
+      FROM sections sect WHERE sect.id = snapshots.section_id;
+      """
+
+    create index(:snapshots, [:objective_id])
+    create index(:snapshots, [:activity_id])
+    create index(:snapshots, [:section_id])
+    create unique_index(:snapshots, [:part_attempt_id, :objective_id], name: :snapshot_unique_part)
+  end
+
+  def down do
+    execute """
+      UPDATE snapshots
+      SET project_id = NULL
+      """
+  end
+end


### PR DESCRIPTION
[MER-1288](https://eliterate.atlassian.net/browse/MER-1288)

### What does it change?

- Updates snapshots table to add `project_id`s

For reference, we're dropping indices and re-creating them after the update, which is faster than having them update on each row update.
However the biggest improvement comes from removing an unnecessary self join on the update query when we first introduced it.

**Previous query**

```
UPDATE snapshots 
SET project_id = sect.base_project_id 
FROM snapshots snap 
LEFT JOIN sections sect ON snap.section_id = sect.id;
```
![Screen Shot 2022-06-29 at 15 26 39](https://user-images.githubusercontent.com/22042418/176518427-deda16a4-1dc2-4c2a-a5d9-1eca8f8f3f56.png)



**New query**
```
UPDATE snapshots
SET project_id = sect.base_project_id
FROM sections sect WHERE sect.id = snapshots.section_id;
```

![Screen Shot 2022-06-29 at 15 27 06](https://user-images.githubusercontent.com/22042418/176518451-dbbec1d3-8b1b-41c3-aa1b-25f7f0d7f380.png)


For a production dump with 14.235.739 records it took ~8 min locally.

![Screen Shot 2022-06-29 at 16 08 26](https://user-images.githubusercontent.com/22042418/176518496-d2295bd0-f120-4994-a0f7-ebfcabd1e4b5.png)

