### PR TITLE
[FEATURE] Dynamic questions editing

### DIFF
--- a/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyAuthoring.tsx
+++ b/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyAuthoring.tsx
@@ -22,13 +22,15 @@ import { configureStore } from 'state/store';
 import { Maybe } from 'tsmonad';
 import { AuthoringElement, AuthoringElementProps } from '../AuthoringElement';
 import { AuthoringElementProvider, useAuthoringElementContext } from '../AuthoringElementProvider';
+import { VariableEditorOrNot } from '../common/variables/VariableEditorOrNot';
+import { VariableActions } from '../common/variables/variableActions';
 import * as ActivityTypes from '../types';
 import { CATAActions } from './actions';
 
 const store = configureStore();
 
 const CheckAllThatApply = () => {
-  const { dispatch, model } = useAuthoringElementContext<CATASchema>();
+  const { dispatch, model, editMode } = useAuthoringElementContext<CATASchema>();
   return (
     <TabbedNavigation.Tabs>
       <TabbedNavigation.Tab label="Question">
@@ -76,7 +78,13 @@ const CheckAllThatApply = () => {
       <TabbedNavigation.Tab label="Hints">
         <HintsAuthoring partId={DEFAULT_PART_ID} />
       </TabbedNavigation.Tab>
-
+      <TabbedNavigation.Tab label="Dynamic Variables">
+        <VariableEditorOrNot
+          editMode={editMode}
+          model={model}
+          onEdit={(t) => dispatch(VariableActions.onUpdateTransformations(t))}
+        />
+      </TabbedNavigation.Tab>
       <ActivitySettings settings={[shuffleAnswerChoiceSetting(model, dispatch)]} />
     </TabbedNavigation.Tabs>
   );

--- a/assets/src/components/activities/common/variables/VariableEditorFacade.tsx
+++ b/assets/src/components/activities/common/variables/VariableEditorFacade.tsx
@@ -8,6 +8,7 @@ export interface VariablesEditorFacadeProps {
   editMode: boolean;
   variables: Variable[];
   onEdit: (vars: Variable[]) => void;
+  activetab: boolean;
 }
 
 /**

--- a/assets/src/components/activities/common/variables/VariableEditorFacade.tsx
+++ b/assets/src/components/activities/common/variables/VariableEditorFacade.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { Variable } from 'data/persistence/variables';
+
+import { ModuleEditor } from './secondgen/ModuleEditor';
+import { VariablesEditor } from './firstgen/VariablesEditor';
+
+export interface VariablesEditorFacadeProps {
+  editMode: boolean;
+  variables: Variable[];
+  onEdit: (vars: Variable[]) => void;
+}
+
+/**
+ * VariablesEditor React Component
+ */
+export class VariablesEditorFacade extends React.Component<
+  VariablesEditorFacadeProps,
+  Record<string, never>
+> {
+  constructor(props: VariablesEditorFacadeProps) {
+    super(props);
+  }
+
+  render() {
+    if (this.props.variables.length === 1 && this.props.variables[0].variable === 'module') {
+      const onSwitch = () => {
+        this.props.onEdit([
+          Object.assign({}, this.props.variables[0], { variable: 'V1', expression: '' }),
+        ]);
+      };
+      return <ModuleEditor {...this.props} onSwitchToOldVariableEditor={onSwitch} />;
+    }
+    return <VariablesEditor {...this.props} />;
+  }
+}

--- a/assets/src/components/activities/common/variables/VariableEditorOrNot.tsx
+++ b/assets/src/components/activities/common/variables/VariableEditorOrNot.tsx
@@ -10,7 +10,22 @@ export interface VariableEditorOrNotProps {
   editMode: boolean;
   model: ActivityModelSchema;
   onEdit: (transformations: any) => void;
+  activetab?: boolean;
 }
+
+const featureDesc = (
+  <>
+    <h5 className="card-title">Dynamic variable support</h5>
+    <p className="card-text">
+      Dynamic variable support is an advanced authoring feature that allows users with experience
+      writing JavaScript to create a question that changes on each student attempt.
+    </p>
+    <p className="card-text">
+      For more information regarding this feature consult the{' '}
+      <a href="https://docs.oli.cmu.edu">Dynamic Questions Guide</a>
+    </p>
+  </>
+);
 
 export class VariableEditorOrNot extends React.Component<
   VariableEditorOrNotProps,
@@ -27,19 +42,38 @@ export class VariableEditorOrNot extends React.Component<
       (t: any) => t.operation === 'variable_substitution',
     );
 
+    const onDisable = () => {
+      const transformations = model.authoring.transformations.filter(
+        (t: any) => t.operation !== 'variable_substitution',
+      );
+      onEdit(transformations);
+    };
+
     if (variableTransformer.length > 0) {
       const onVariablesEdit = (data: any) => {
-        const transformations = model.authoring.transformations
-          .filter((t: any) => t.operation !== 'variable_substitution')
-          .push(Object.assign({}, variableTransformer[0], { data }));
-        onEdit(transformations);
+        const transformations = model.authoring.transformations.filter(
+          (t: any) => t.operation !== 'variable_substitution',
+        );
+
+        onEdit([...transformations, Object.assign({}, variableTransformer[0], { data })]);
       };
       return (
-        <VariablesEditorFacade
-          editMode={editMode}
-          onEdit={onVariablesEdit}
-          variables={variableTransformer[0].data}
-        />
+        <>
+          <VariablesEditorFacade
+            editMode={editMode}
+            onEdit={onVariablesEdit}
+            variables={variableTransformer[0].data}
+            activetab={this.props.activetab || false}
+          />
+          <div className="card text-center mt-5">
+            <div className="card-body">
+              {featureDesc}
+              <button className="btn btn-outline-danger mt-4" onClick={onDisable}>
+                Disable Dynamic Variables
+              </button>
+            </div>
+          </div>
+        </>
       );
     }
 
@@ -68,10 +102,13 @@ export class VariableEditorOrNot extends React.Component<
     };
 
     return (
-      <div>
-        <button className="btn btn-primary" onClick={onEnable}>
-          Enable Dynamic Variables
-        </button>
+      <div className="card text-center">
+        <div className="card-body">
+          {featureDesc}
+          <button className="btn btn-warning mt-4" onClick={onEnable}>
+            Enable Dynamic Variables
+          </button>
+        </div>
       </div>
     );
   }

--- a/assets/src/components/activities/common/variables/VariableEditorOrNot.tsx
+++ b/assets/src/components/activities/common/variables/VariableEditorOrNot.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react';
+
+import { ActivityModelSchema } from 'components/activities/types';
+import { VariablesEditorFacade } from './VariableEditorFacade';
+import guid from 'utils/guid';
+
+const defaultExpresssion = '\n\n\nmodule.exports = {};\n';
+
+export interface VariableEditorOrNotProps {
+  editMode: boolean;
+  model: ActivityModelSchema;
+  onEdit: (transformations: any) => void;
+}
+
+export class VariableEditorOrNot extends React.Component<
+  VariableEditorOrNotProps,
+  Record<string, never>
+> {
+  constructor(props: VariableEditorOrNotProps) {
+    super(props);
+  }
+
+  render() {
+    const { editMode, model, onEdit } = this.props;
+
+    const variableTransformer = model.authoring.transformations.filter(
+      (t: any) => t.operation === 'variable_substitution',
+    );
+
+    if (variableTransformer.length > 0) {
+      const onVariablesEdit = (data: any) => {
+        const transformations = model.authoring.transformations
+          .filter((t: any) => t.operation !== 'variable_substitution')
+          .push(Object.assign({}, variableTransformer[0], { data }));
+        onEdit(transformations);
+      };
+      return (
+        <VariablesEditorFacade
+          editMode={editMode}
+          onEdit={onVariablesEdit}
+          variables={variableTransformer[0].data}
+        />
+      );
+    }
+
+    const onEnable = () => {
+      const transformations = model.authoring.transformations.filter(
+        (t: any) => t.operation !== 'variable_substitution',
+      );
+
+      const withVariableSub = [
+        ...transformations,
+        {
+          id: guid(),
+          operation: 'variable_substitution',
+          data: [
+            {
+              type: 'variable',
+              id: guid(),
+              name: 'module',
+              variable: 'module',
+              expression: defaultExpresssion,
+            },
+          ],
+        },
+      ];
+      onEdit(withVariableSub);
+    };
+
+    return (
+      <div>
+        <button className="btn btn-primary" onClick={onEnable}>
+          Enable Dynamic Variables
+        </button>
+      </div>
+    );
+  }
+}

--- a/assets/src/components/activities/common/variables/WrappedMonaco.tsx
+++ b/assets/src/components/activities/common/variables/WrappedMonaco.tsx
@@ -11,6 +11,7 @@ type WrappedMonacoProps = {
   model: string;
   onEdit: (model: string) => void;
   editMode: boolean;
+  activetab: boolean;
 };
 
 export const WrappedMonaco = (props: PropsWithChildren<WrappedMonacoProps>) => {
@@ -52,6 +53,13 @@ export const WrappedMonaco = (props: PropsWithChildren<WrappedMonacoProps>) => {
       window.removeEventListener('resize', handleResize);
     };
   }, []);
+
+  useEffect(() => {
+    updateSize(editorRef.current?.editor);
+  }, [props.activetab]);
+
+  console.log('wrapped');
+  console.log(model);
 
   return (
     <div>

--- a/assets/src/components/activities/common/variables/WrappedMonaco.tsx
+++ b/assets/src/components/activities/common/variables/WrappedMonaco.tsx
@@ -1,0 +1,77 @@
+import React, { PropsWithChildren, useEffect, useRef, Suspense, useState } from 'react';
+import { throttle } from 'lodash';
+import { CodeLanguages } from 'components/editing/elements/blockcode/codeLanguages';
+import * as monaco from 'monaco-editor';
+import { RefEditorInstance } from '@uiw/react-monacoeditor';
+import { isDarkMode, addDarkModeListener, removeDarkModeListener } from 'utils/browser';
+
+const MonacoEditor = React.lazy(() => import('@uiw/react-monacoeditor'));
+
+type WrappedMonacoProps = {
+  model: string;
+  onEdit: (model: string) => void;
+  editMode: boolean;
+};
+
+export const WrappedMonaco = (props: PropsWithChildren<WrappedMonacoProps>) => {
+  const editorContainer = useRef<HTMLDivElement>(null);
+  const editorRef = useRef<RefEditorInstance>(null);
+  const [model] = useState(props.model);
+
+  const updateSize = (editor?: monaco.editor.IStandaloneCodeEditor) => {
+    if (editor && editorContainer.current) {
+      const contentHeight = Math.min(1000, editor.getContentHeight());
+      editorContainer.current.style.height = `${contentHeight}px`;
+      editor.layout({
+        width: editorContainer.current.offsetWidth,
+        height: contentHeight,
+      });
+    }
+  };
+
+  const editorDidMount = (e: monaco.editor.IStandaloneCodeEditor) => {
+    e.onDidContentSizeChange(() => updateSize(e));
+    updateSize(e);
+  };
+
+  useEffect(() => {
+    // listen for browser theme changes and update code editor accordingly
+    const listener = addDarkModeListener((theme: string) => {
+      if (theme === 'light') {
+        editorRef.current?.editor?.updateOptions({ theme: 'vs-light' });
+      } else {
+        editorRef.current?.editor?.updateOptions({ theme: 'vs-dark' });
+      }
+    });
+
+    const handleResize = throttle(() => updateSize(editorRef.current?.editor), 200);
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      removeDarkModeListener(listener);
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  return (
+    <div>
+      <div ref={editorContainer} className="border">
+        <Suspense fallback={<div>Loading...</div>}>
+          <MonacoEditor
+            ref={editorRef}
+            value={model}
+            language={CodeLanguages.byPrettyName('JavaScript').monacoMode}
+            options={{
+              tabSize: 2,
+              scrollBeyondLastLine: false,
+              minimap: { enabled: false },
+              theme: isDarkMode() ? 'vs-dark' : 'vs-light',
+            }}
+            onChange={(code) => props.onEdit(code)}
+            editorDidMount={editorDidMount}
+          />
+        </Suspense>
+      </div>
+    </div>
+  );
+};

--- a/assets/src/components/activities/common/variables/firstgen/VariablesEditor.scss
+++ b/assets/src/components/activities/common/variables/firstgen/VariablesEditor.scss
@@ -1,0 +1,30 @@
+.variablesEditor {
+  display: flex;
+  flex-direction: column;
+  min-width: 500;
+}
+.buttonPanel {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+.ace_editor {
+  font-size: 14;
+}
+.error {
+  color: red;
+}
+.evaluated {
+  color: black;
+}
+.variableLabel {
+  font-family: 'Inconsolata, monospace';
+  font-size: 14px;
+}
+.variableResult {
+  font-family: 'Inconsolata, monospace';
+  font-size: 14px;
+}
+.header {
+  flex: 1;
+}

--- a/assets/src/components/activities/common/variables/firstgen/VariablesEditor.tsx
+++ b/assets/src/components/activities/common/variables/firstgen/VariablesEditor.tsx
@@ -8,6 +8,7 @@ export interface VariablesEditorProps {
   editMode: boolean;
   variables: Variable[];
   onEdit: (vars: Variable[]) => void;
+  activetab: boolean;
 }
 
 export interface VariablesEditorState {
@@ -27,10 +28,6 @@ export class VariablesEditor extends React.Component<VariablesEditorProps, Varia
     this.state = {
       results: Immutable.Map<string, VariableEvaluation>(),
     };
-  }
-
-  shouldComponentUpdate(nextProps: VariablesEditorProps, nextState: VariablesEditorState) {
-    return this.state.results !== nextState.results;
   }
 
   onExpressionEdit(variable: Variable, expression: string) {
@@ -60,13 +57,14 @@ export class VariablesEditor extends React.Component<VariablesEditorProps, Varia
     ) : null;
 
     return (
-      <tr>
+      <tr key={variable.id}>
         <td className={'variableLabel'}>{variable.variable}</td>
         <td>
           <WrappedMonaco
             editMode={editMode}
             model={variable.expression}
             onEdit={this.onExpressionEdit.bind(this, variable)}
+            activetab={this.props.activetab}
           />
         </td>
         <td className={'variableResult'}>{evaluation}</td>

--- a/assets/src/components/activities/common/variables/firstgen/VariablesEditor.tsx
+++ b/assets/src/components/activities/common/variables/firstgen/VariablesEditor.tsx
@@ -1,0 +1,222 @@
+import * as React from 'react';
+import * as Immutable from 'immutable';
+import { VariableEvaluation, evaluateVariables, Variable } from 'data/persistence/variables';
+
+import AceEditor from 'react-ace';
+
+import 'brace/mode/java';
+import 'brace/mode/python';
+import 'brace/mode/html';
+import 'brace/mode/xml';
+import 'brace/mode/actionscript';
+import 'brace/mode/sh';
+import 'brace/mode/c_cpp';
+import 'brace/mode/text';
+
+import 'brace/theme/github';
+
+export interface VariablesEditorProps {
+  editMode: boolean;
+  variables: Variable[];
+  onEdit: (vars: Variable[]) => void;
+}
+
+export interface VariablesEditorState {
+  results: Immutable.Map<string, VariableEvaluation>;
+}
+
+type Variables = Immutable.OrderedMap<string, Variable>;
+
+/**
+ * VariablesEditor React Component
+ */
+export class VariablesEditor extends React.Component<VariablesEditorProps, VariablesEditorState> {
+  constructor(props: VariablesEditorProps) {
+    super(props);
+
+    this.onAddVariable = this.onAddVariable.bind(this);
+    this.onTestExpressions = this.onTestExpressions.bind(this);
+
+    this.state = {
+      results: Immutable.Map<string, VariableEvaluation>(),
+    };
+  }
+
+  shouldComponentUpdate(nextProps: VariablesEditorProps, nextState: VariablesEditorState) {
+    return this.state.results !== nextState.results;
+  }
+
+  onExpressionEdit(variable, expression) {
+    const { onEdit, model } = this.props;
+
+    onEdit(
+      model.set(
+        variable.guid,
+        variable.with({
+          expression,
+        }),
+      ),
+      null,
+    );
+  }
+
+  renderVariable(variable: contentTypes.Variable) {
+    const { classes, className, editMode } = this.props;
+
+    const evaluation = this.state.results.has(variable.name) ? (
+      this.state.results.get(variable.name).errored ? (
+        <span className={classNames([classes.error, className])}>Error</span>
+      ) : (
+        <span className={classNames([classes.evaluated, className])}>
+          {this.state.results.get(variable.name).result}
+        </span>
+      )
+    ) : null;
+
+    return (
+      <tr>
+        <td className={'variableLabel'}>{variable.name}</td>
+        <td>
+          <AceEditor
+            name={variable.name}
+            width="initial"
+            mode="javascript"
+            theme="github"
+            readOnly={!editMode}
+            minLines={1}
+            maxLines={40}
+            value={variable.expression}
+            onChange={this.onExpressionEdit.bind(this, variable)}
+            setOptions={{
+              enableBasicAutocompletion: false,
+              enableLiveAutocompletion: false,
+              enableSnippets: false,
+              showLineNumbers: false,
+              tabSize: 2,
+              showPrintMargin: false,
+              useWorker: false,
+              showGutter: false,
+              highlightActiveLine: false,
+            }}
+          />
+        </td>
+        <td className={'variableResult'}>{evaluation}</td>
+        <td>
+          <span className="remove-btn">
+            <button
+              disabled={!editMode}
+              tabIndex={-1}
+              onClick={this.onRemoveVariable.bind(this, variable.guid)}
+              type="button"
+              className="btn btn-sm"
+            >
+              <i className="fas fa-times"></i>
+            </button>
+          </span>
+        </td>
+      </tr>
+    );
+  }
+
+  onTestExpressions() {
+    const { model } = this.props;
+
+    // Clear the current results and re-evaluate
+    this.setState({ results: Immutable.Map<string, Evaluation>() }, () =>
+      evaluate(model).then((results) => {
+        this.setState({
+          results: Immutable.Map<string, Evaluation>(results.map((r) => [r.variable, r])),
+        });
+      }),
+    );
+  }
+
+  onRemoveVariable(guid: string) {
+    const { onEdit, model } = this.props;
+
+    let position = 0;
+    onEdit(
+      model
+        .delete(guid)
+        .map((variable) => {
+          position = position + 1;
+          return variable.with({ name: 'V' + position });
+        })
+        .toOrderedMap(),
+    );
+  }
+
+  onAddVariable() {
+    const { onEdit, model } = this.props;
+
+    const name = 'V' + (model.size + 1);
+    const expression = 'const x = 1';
+
+    const variable = new contentTypes.Variable().with({
+      name,
+      expression,
+    });
+
+    onEdit();
+
+    onEdit(model.set(variable.guid, variable), null);
+  }
+
+  renderButtonPanel() {
+    const { variables, editMode } = this.props;
+
+    // Only show the "Test" button when there is one or more
+    // variables
+    const testButton =
+      variables.length > 0 ? (
+        <button
+          className="btn btn-sm btn-link"
+          type="button"
+          disabled={!editMode}
+          onClick={() => this.onTestExpressions()}
+        >
+          Test Expressions
+        </button>
+      ) : null;
+
+    return (
+      <div className={'buttonPanel'}>
+        <button
+          className="btn btn-sm btn-link"
+          type="button"
+          disabled={!editMode}
+          onClick={() => this.onAddVariable()}
+        >
+          Add Variable
+        </button>
+        {testButton}
+      </div>
+    );
+  }
+
+  render() {
+    const { variables } = this.props;
+
+    const tableOrNot =
+      variables.length > 0 ? (
+        <table className={'table table-sm'}>
+          <thead>
+            <tr>
+              <th>Var</th>
+              <th>Expression</th>
+              <th>Evaluation</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>{variables.map((v) => this.renderVariable(v))}</tbody>
+        </table>
+      ) : null;
+
+    return (
+      <div className={'VariablesEditor'}>
+        {tableOrNot}
+        {this.renderButtonPanel()}
+      </div>
+    );
+  }
+}

--- a/assets/src/components/activities/common/variables/secondgen/ModuleEditor.scss
+++ b/assets/src/components/activities/common/variables/secondgen/ModuleEditor.scss
@@ -1,0 +1,81 @@
+.moduleEditor {
+  border-top-left-radius: 4px;
+  border-bottom-left-radius: 4px;
+}
+
+.splitPane {
+  width: 100%;
+  display: flex;
+}
+
+#source {
+  box-shadow: inset 0px 0px 10px 0px #ababab;
+  min-height: 200px;
+  max-height: 500px;
+}
+
+.panelTitle {
+  display: inline-block;
+  width: 100%;
+  padding: 5px 5px 5px 10px;
+  font-size: 16px;
+  font-family: 'Open Sans', 'Lucida Grande', 'Lucida Sans Unicode', Tahoma, Sans-Serif;
+  line-height: 1.5;
+  font-weight: 600;
+}
+
+.key-wrapper {
+  border: 1px solid #aaa;
+  border-radius: 2px;
+  padding: 0.1em 0.3em;
+  box-shadow: 0.1em 0.1em 0.2em rgba(0, 0, 0, 0.1);
+  color: black;
+  background-image: linear-gradient(to bottom, #eee, #f9f9f9, #eee);
+}
+
+.button-panel {
+  flex-direction: row;
+  justify-content: space-between;
+  background-color: #1a1a1a;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+  padding-left: 41px;
+
+  .vertical-center {
+    vertical-align: middle;
+    color: white;
+    display: inline-block;
+    line-height: 70px;
+    height: 70px;
+  }
+
+  .module-button {
+    border: 3px solid #36383f;
+    border-radius: 2px;
+    font-size: 1rem;
+    padding: 10px 15px;
+    margin: 10px 10px 10px 0px;
+
+    &:active {
+      margin-top: 12px;
+      margin-bottom: 8px;
+    }
+
+    &.btn.btn-link,
+    &.btn.btn-link:active,
+    &.btn.btn-link:hover {
+      color: white;
+      text-decoration: none;
+    }
+
+    &.run-button {
+      i {
+        color: #adafbc;
+      }
+    }
+
+    &.test-button {
+      background-color: #36383f;
+    }
+  }
+}

--- a/assets/src/components/activities/common/variables/secondgen/ModuleEditor.tsx
+++ b/assets/src/components/activities/common/variables/secondgen/ModuleEditor.tsx
@@ -11,6 +11,7 @@ export interface ModuleEditorProps {
   editMode: boolean;
   variables: Variable[];
   onEdit: (vars: Variable[]) => void;
+  activetab: boolean;
 }
 
 export interface ModuleEditorState {
@@ -135,7 +136,7 @@ export class ModuleEditor extends React.Component<ModuleEditorProps, ModuleEdito
         {variables && (
           <div className="splitPane">
             <SourcePanel
-              ref={(ref) => (this.source = ref)}
+              ref={(ref: any) => (this.source = ref)}
               {...this.props}
               script={variables[0].expression}
               onExpressionEdit={this.onExpressionEdit}

--- a/assets/src/components/activities/common/variables/secondgen/ModuleEditor.tsx
+++ b/assets/src/components/activities/common/variables/secondgen/ModuleEditor.tsx
@@ -1,0 +1,163 @@
+import * as React from 'react';
+import { VariableEvaluation, evaluateVariables } from 'data/persistence/variables';
+
+import { SourcePanel } from './SourcePanel';
+import { ResultsPanel } from './ResultsPanel';
+import { Maybe } from 'tsmonad';
+
+import './ModuleEditor.scss';
+import 'brace/ext/language_tools';
+import 'brace/snippets/javascript';
+
+const NUMBER_OF_ATTEMPTS = 10;
+
+export interface ModuleEditorProps {
+  onSwitchToOldVariableEditor: () => void;
+  script: string;
+  onEdit: (script: string) => void;
+  editMode: boolean;
+}
+
+export interface ModuleEditorState {
+  results: VariableEvaluation[];
+  testing: boolean;
+  testingCompleted: boolean;
+  failed: boolean;
+}
+
+export class ModuleEditor extends React.Component<ModuleEditorProps, ModuleEditorState> {
+  activeContent: any;
+  source: any;
+
+  constructor(props: ModuleEditorProps) {
+    super(props);
+
+    this.onEvaluate = this.onEvaluate.bind(this);
+    this.onExpressionEdit = this.onExpressionEdit.bind(this);
+    this.onRun = this.onRun.bind(this);
+
+    this.state = {
+      results: [],
+      testing: false,
+      testingCompleted: false,
+      failed: false,
+    };
+  }
+
+  componentDidMount() {
+    this.evaluateOnce();
+  }
+
+  shouldComponentUpdate() {
+    return true;
+  }
+
+  onExpressionEdit(script: string) {
+    const { onEdit } = this.props;
+    onEdit(script);
+  }
+
+  evaluateOnce() {
+    // Reset results and evaluate
+    this.setState({ results: [] }, () =>
+      evaluateVariables([{ variable: 'module', expression: this.props.script }]).then((results) => {
+        if (results.result === 'success') {
+          this.setState({ results: results.evaluations });
+        }
+      }),
+    );
+  }
+
+  onEvaluate(attempts = NUMBER_OF_ATTEMPTS): Promise<void> {
+    return evaluateVariables(
+      [{ variable: 'module', expression: this.props.script }],
+      attempts,
+    ).then((results) => {
+      if (results.result === 'success') {
+        this.setState({ results: results.evaluations });
+      }
+    });
+  }
+
+  onRun() {
+    this.setState(
+      {
+        testing: true,
+        testingCompleted: false,
+        results: [],
+      },
+      () =>
+        this.onEvaluate()
+          .then((_) =>
+            this.setState({
+              failed: false,
+              testing: false,
+              testingCompleted: true,
+            }),
+          )
+          .catch((_) =>
+            this.setState({
+              failed: true,
+              testing: false,
+              testingCompleted: true,
+            }),
+          ),
+    );
+  }
+
+  renderBottomPanel() {
+    const { editMode } = this.props;
+
+    const testResults = this.state.testing ? (
+      <span className="vertical-center">
+        <i className="fas fa-circle-notch fa-spin fa-1x fa-fw" /> Testing...
+      </span>
+    ) : this.state.testingCompleted ? (
+      this.state.failed ? (
+        <span className="vertical-center">
+          <i className="fa fa-ban fa-2x" style={{ color: '#f39c12' }}></i> Try again
+        </span>
+      ) : null
+    ) : null;
+
+    return (
+      <div className="button-panel">
+        <button
+          className="btn btn-sm btn-link module-button run-button"
+          type="button"
+          disabled={!editMode}
+          onClick={this.onRun}
+        >
+          <i className="fa fa-play"></i> Run
+        </button>
+        {testResults}
+      </div>
+    );
+  }
+
+  render(): React.ReactNode {
+    const { onSwitchToOldVariableEditor, script } = this.props;
+
+    return (
+      <div>
+        {script && (
+          <div className="splitPane">
+            <SourcePanel
+              ref={(ref) => (this.source = ref)}
+              {...this.props}
+              script={script}
+              onExpressionEdit={this.onExpressionEdit}
+              evaluate={this.onEvaluate}
+              onSwitchToOldVariableEditor={onSwitchToOldVariableEditor}
+            />
+            <ResultsPanel
+              evalResults={this.state.results}
+              onSwitchToOldVariableEditor={onSwitchToOldVariableEditor}
+            />
+          </div>
+        )}
+        {this.renderBottomPanel()}
+      </div>
+    );
+  }
+}

--- a/assets/src/components/activities/common/variables/secondgen/ResultsPanel.scss
+++ b/assets/src/components/activities/common/variables/secondgen/ResultsPanel.scss
@@ -1,16 +1,12 @@
 .resultsPanel {
   border-top-right-radius: 4px;
   border-bottom-right-radius: 4px;
-  border: 1px solid #ebebeb;
+  border-right: 1px solid #ebebeb;
   width: 40%;
   position: relative;
   display: flex;
   flex-direction: column;
-
-  // This causes an issue with the cursor positioning, but we hide the cursor anyway
-  .ace_text-layer {
-    padding-left: 12px !important;
-  }
+  margin-left: 10px;
 
   .panelTitle {
     border-bottom: 1px solid #ebebeb;

--- a/assets/src/components/activities/common/variables/secondgen/ResultsPanel.scss
+++ b/assets/src/components/activities/common/variables/secondgen/ResultsPanel.scss
@@ -1,0 +1,20 @@
+.resultsPanel {
+  border-top-right-radius: 4px;
+  border-bottom-right-radius: 4px;
+  border: 1px solid #ebebeb;
+  width: 40%;
+  position: relative;
+  background: #fafafa;
+  color: #494949;
+  display: flex;
+  flex-direction: column;
+
+  // This causes an issue with the cursor positioning, but we hide the cursor anyway
+  .ace_text-layer {
+    padding-left: 12px !important;
+  }
+
+  .panelTitle {
+      border-bottom: 1px solid #ebebeb;
+  }
+}

--- a/assets/src/components/activities/common/variables/secondgen/ResultsPanel.scss
+++ b/assets/src/components/activities/common/variables/secondgen/ResultsPanel.scss
@@ -4,8 +4,6 @@
   border: 1px solid #ebebeb;
   width: 40%;
   position: relative;
-  background: #fafafa;
-  color: #494949;
   display: flex;
   flex-direction: column;
 
@@ -15,6 +13,6 @@
   }
 
   .panelTitle {
-      border-bottom: 1px solid #ebebeb;
+    border-bottom: 1px solid #ebebeb;
   }
 }

--- a/assets/src/components/activities/common/variables/secondgen/ResultsPanel.tsx
+++ b/assets/src/components/activities/common/variables/secondgen/ResultsPanel.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { VariableEvaluation } from 'data/persistence/variables';
-import AceEditor from 'react-ace';
 import './ResultsPanel.scss';
-
-import 'brace/theme/github';
+import { WrappedMonaco } from '../WrappedMonaco';
 
 interface ResultsPanelProps {
   evalResults: VariableEvaluation[];
@@ -15,17 +13,8 @@ export class ResultsPanel extends React.Component<ResultsPanelProps, Record<stri
     super(props);
   }
 
-  reactAceComponent: any;
-
-  componentDidMount() {
-    // Hide the cursor
-    this.reactAceComponent.editor.renderer.$cursorLayer.element.style.display = 'none';
-    // Disables a console warning shown by AceEditor
-    this.reactAceComponent.editor.$blockScrolling = Infinity;
-  }
-
   render() {
-    const { evalResults, onSwitchToOldVariableEditor } = this.props;
+    const { evalResults } = this.props;
 
     const resultLines = evalResults
       .map((r) => r.variable + ': ' + JSON.stringify(r.result))
@@ -34,32 +23,7 @@ export class ResultsPanel extends React.Component<ResultsPanelProps, Record<stri
     return (
       <div className="resultsPanel">
         <span className="panelTitle">Results</span>
-        <AceEditor
-          ref={(ref) => (this.reactAceComponent = ref)}
-          className="evaluated"
-          name="source"
-          width="100%"
-          height="100%"
-          mode="javascript"
-          theme="github"
-          readOnly={true}
-          minLines={3}
-          value={resultLines}
-          commands={[
-            {
-              name: 'switchToOldVariableEditor',
-              bindKey: { win: 'Ctrl-Shift-0', mac: 'Command-Shift-0' },
-              exec: () => onSwitchToOldVariableEditor(),
-            },
-          ]}
-          setOptions={{
-            showLineNumbers: false,
-            useWorker: false,
-            showGutter: false,
-            tabSize: 2,
-            wrap: true,
-          }}
-        />
+        <WrappedMonaco editMode={false} model={resultLines} onEdit={() => true} />
       </div>
     );
   }

--- a/assets/src/components/activities/common/variables/secondgen/ResultsPanel.tsx
+++ b/assets/src/components/activities/common/variables/secondgen/ResultsPanel.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import { VariableEvaluation } from 'data/persistence/variables';
+import AceEditor from 'react-ace';
+import './ResultsPanel.scss';
+
+import 'brace/theme/github';
+
+interface ResultsPanelProps {
+  evalResults: VariableEvaluation[];
+  onSwitchToOldVariableEditor: () => void;
+}
+
+export class ResultsPanel extends React.Component<ResultsPanelProps, Record<string, never>> {
+  constructor(props: ResultsPanelProps) {
+    super(props);
+  }
+
+  reactAceComponent: any;
+
+  componentDidMount() {
+    // Hide the cursor
+    this.reactAceComponent.editor.renderer.$cursorLayer.element.style.display = 'none';
+    // Disables a console warning shown by AceEditor
+    this.reactAceComponent.editor.$blockScrolling = Infinity;
+  }
+
+  render() {
+    const { evalResults, onSwitchToOldVariableEditor } = this.props;
+
+    const resultLines = evalResults
+      .map((r) => r.variable + ': ' + JSON.stringify(r.result))
+      .join('\n');
+
+    return (
+      <div className="resultsPanel">
+        <span className="panelTitle">Results</span>
+        <AceEditor
+          ref={(ref) => (this.reactAceComponent = ref)}
+          className="evaluated"
+          name="source"
+          width="100%"
+          height="100%"
+          mode="javascript"
+          theme="github"
+          readOnly={true}
+          minLines={3}
+          value={resultLines}
+          commands={[
+            {
+              name: 'switchToOldVariableEditor',
+              bindKey: { win: 'Ctrl-Shift-0', mac: 'Command-Shift-0' },
+              exec: () => onSwitchToOldVariableEditor(),
+            },
+          ]}
+          setOptions={{
+            showLineNumbers: false,
+            useWorker: false,
+            showGutter: false,
+            tabSize: 2,
+            wrap: true,
+          }}
+        />
+      </div>
+    );
+  }
+}

--- a/assets/src/components/activities/common/variables/secondgen/ResultsPanel.tsx
+++ b/assets/src/components/activities/common/variables/secondgen/ResultsPanel.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { VariableEvaluation } from 'data/persistence/variables';
 import './ResultsPanel.scss';
-import { WrappedMonaco } from '../WrappedMonaco';
 
 interface ResultsPanelProps {
   evalResults: VariableEvaluation[];
@@ -14,16 +13,14 @@ export class ResultsPanel extends React.Component<ResultsPanelProps, Record<stri
   }
 
   render() {
-    const { evalResults } = this.props;
-
-    const resultLines = evalResults
-      .map((r) => r.variable + ': ' + JSON.stringify(r.result))
-      .join('\n');
+    const results = this.props.evalResults.map((r) => (
+      <div key={r.variable}>{r.variable + ': ' + JSON.stringify(r.result)}</div>
+    ));
 
     return (
       <div className="resultsPanel">
         <span className="panelTitle">Results</span>
-        <WrappedMonaco editMode={false} model={resultLines} onEdit={() => true} />
+        {results}
       </div>
     );
   }

--- a/assets/src/components/activities/common/variables/secondgen/SourcePanel.scss
+++ b/assets/src/components/activities/common/variables/secondgen/SourcePanel.scss
@@ -2,12 +2,10 @@
   border-top-left-radius: 4px;
   border-bottom-left-radius: 4px;
   width: 60%;
-  background: #1D1E22;
-  color: rgba(255, 255, 255, 0.9);
   display: flex;
   flex-direction: column;
 
   .panelTitle {
-      border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
   }
 }

--- a/assets/src/components/activities/common/variables/secondgen/SourcePanel.scss
+++ b/assets/src/components/activities/common/variables/secondgen/SourcePanel.scss
@@ -1,0 +1,13 @@
+.sourcePanel {
+  border-top-left-radius: 4px;
+  border-bottom-left-radius: 4px;
+  width: 60%;
+  background: #1D1E22;
+  color: rgba(255, 255, 255, 0.9);
+  display: flex;
+  flex-direction: column;
+
+  .panelTitle {
+      border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  }
+}

--- a/assets/src/components/activities/common/variables/secondgen/SourcePanel.tsx
+++ b/assets/src/components/activities/common/variables/secondgen/SourcePanel.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+import AceEditor from 'react-ace';
+import './SourcePanel.scss';
+
+import 'brace/theme/tomorrow_night_bright';
+
+interface SourcePanelProps {
+  editMode: boolean;
+  script: string;
+  onExpressionEdit: (expression: string) => void;
+  evaluate: () => void;
+  onSwitchToOldVariableEditor: () => void;
+}
+
+interface SourcePanelState {}
+
+// AceEditor is inside here!
+export class SourcePanel extends React.Component<SourcePanelProps, SourcePanelState> {
+  reactAceComponent: any;
+
+  componentDidMount() {
+    // Fixes an issue where editor was not being focused on load
+    document.activeElement && (document.activeElement as any).blur();
+    // Disables a console warning shown by AceEditor
+    this.reactAceComponent.editor.$blockScrolling = Infinity;
+  }
+
+  render() {
+    const { editMode, script, onExpressionEdit, evaluate, onSwitchToOldVariableEditor } =
+      this.props;
+
+    return (
+      <div className="sourcePanel">
+        <span className="panelTitle">JavaScript</span>
+        <AceEditor
+          ref={(ref) => (this.reactAceComponent = ref)}
+          className="source"
+          name="source"
+          width="100%"
+          height="100%"
+          mode="javascript"
+          theme="tomorrow_night_bright"
+          readOnly={!editMode}
+          minLines={3}
+          focus={true}
+          value={script}
+          onChange={onExpressionEdit}
+          commands={[
+            {
+              name: 'evaluate',
+              bindKey: { win: 'Ctrl-enter', mac: 'Command-enter' },
+              exec: () => evaluate(),
+            },
+            {
+              name: 'switchToOldVariableEditor',
+              bindKey: { win: 'Ctrl-Shift-0', mac: 'Command-Shift-0' },
+              exec: () => onSwitchToOldVariableEditor(),
+            },
+          ]}
+          annotations={[{ row: 0, column: 2, type: 'error', text: 'Some error.' }]}
+          markers={[
+            {
+              startRow: 0,
+              startCol: 2,
+              endRow: 1,
+              endCol: 20,
+              className: 'error-marker',
+              type: 'background',
+            } as any,
+          ]}
+          setOptions={{
+            enableBasicAutocompletion: true,
+            enableLiveAutocompletion: true,
+            enableSnippets: true,
+            showLineNumbers: true,
+            tabSize: 2,
+            showPrintMargin: true,
+            useWorker: false,
+            showGutter: true,
+            highlightActiveLine: true,
+            wrap: true,
+          }}
+        />
+      </div>
+    );
+  }
+}

--- a/assets/src/components/activities/common/variables/secondgen/SourcePanel.tsx
+++ b/assets/src/components/activities/common/variables/secondgen/SourcePanel.tsx
@@ -9,6 +9,7 @@ interface SourcePanelProps {
   onExpressionEdit: (expression: string) => void;
   evaluate: () => void;
   onSwitchToOldVariableEditor: () => void;
+  activetab: boolean;
 }
 
 interface SourcePanelState {}
@@ -16,12 +17,16 @@ interface SourcePanelState {}
 // AceEditor is inside here!
 export class SourcePanel extends React.Component<SourcePanelProps, SourcePanelState> {
   render() {
-    const { editMode, script, onExpressionEdit } = this.props;
-    console.log(script);
+    const { editMode, script, onExpressionEdit, activetab } = this.props;
     return (
       <div className="sourcePanel">
         <span className="panelTitle">JavaScript</span>
-        <WrappedMonaco editMode={editMode} model={script} onEdit={onExpressionEdit} />
+        <WrappedMonaco
+          editMode={editMode}
+          model={script}
+          onEdit={onExpressionEdit}
+          activetab={activetab}
+        />
       </div>
     );
   }

--- a/assets/src/components/activities/common/variables/secondgen/SourcePanel.tsx
+++ b/assets/src/components/activities/common/variables/secondgen/SourcePanel.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
-import AceEditor from 'react-ace';
 import './SourcePanel.scss';
 
-import 'brace/theme/tomorrow_night_bright';
+import { WrappedMonaco } from '../WrappedMonaco';
 
 interface SourcePanelProps {
   editMode: boolean;
@@ -16,71 +15,13 @@ interface SourcePanelState {}
 
 // AceEditor is inside here!
 export class SourcePanel extends React.Component<SourcePanelProps, SourcePanelState> {
-  reactAceComponent: any;
-
-  componentDidMount() {
-    // Fixes an issue where editor was not being focused on load
-    document.activeElement && (document.activeElement as any).blur();
-    // Disables a console warning shown by AceEditor
-    this.reactAceComponent.editor.$blockScrolling = Infinity;
-  }
-
   render() {
-    const { editMode, script, onExpressionEdit, evaluate, onSwitchToOldVariableEditor } =
-      this.props;
-
+    const { editMode, script, onExpressionEdit } = this.props;
+    console.log(script);
     return (
       <div className="sourcePanel">
         <span className="panelTitle">JavaScript</span>
-        <AceEditor
-          ref={(ref) => (this.reactAceComponent = ref)}
-          className="source"
-          name="source"
-          width="100%"
-          height="100%"
-          mode="javascript"
-          theme="tomorrow_night_bright"
-          readOnly={!editMode}
-          minLines={3}
-          focus={true}
-          value={script}
-          onChange={onExpressionEdit}
-          commands={[
-            {
-              name: 'evaluate',
-              bindKey: { win: 'Ctrl-enter', mac: 'Command-enter' },
-              exec: () => evaluate(),
-            },
-            {
-              name: 'switchToOldVariableEditor',
-              bindKey: { win: 'Ctrl-Shift-0', mac: 'Command-Shift-0' },
-              exec: () => onSwitchToOldVariableEditor(),
-            },
-          ]}
-          annotations={[{ row: 0, column: 2, type: 'error', text: 'Some error.' }]}
-          markers={[
-            {
-              startRow: 0,
-              startCol: 2,
-              endRow: 1,
-              endCol: 20,
-              className: 'error-marker',
-              type: 'background',
-            } as any,
-          ]}
-          setOptions={{
-            enableBasicAutocompletion: true,
-            enableLiveAutocompletion: true,
-            enableSnippets: true,
-            showLineNumbers: true,
-            tabSize: 2,
-            showPrintMargin: true,
-            useWorker: false,
-            showGutter: true,
-            highlightActiveLine: true,
-            wrap: true,
-          }}
-        />
+        <WrappedMonaco editMode={editMode} model={script} onEdit={onExpressionEdit} />
       </div>
     );
   }

--- a/assets/src/components/activities/common/variables/secondgen/TestResults.scss
+++ b/assets/src/components/activities/common/variables/secondgen/TestResults.scss
@@ -1,0 +1,11 @@
+.test-results {
+  display: inline-block;
+  width: 220px;
+  color: white;
+
+  svg {
+    height: 50px;
+    margin: 10px 0px;
+    transform: rotate(-90deg);
+  }
+}

--- a/assets/src/components/activities/common/variables/secondgen/TestResults.tsx
+++ b/assets/src/components/activities/common/variables/secondgen/TestResults.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+
+import './TestResults.scss';
+
+interface TestResultsProps {
+  percentTestsPassed: number;
+}
+
+export class TestResults extends React.Component<TestResultsProps, Record<string, never>> {
+  constructor(props: TestResultsProps) {
+    super(props);
+  }
+
+  render() {
+    const { percentTestsPassed } = this.props;
+    const roundedPercent = Math.round(100 * percentTestsPassed);
+
+    if (isNaN(percentTestsPassed)) {
+      return null;
+    }
+
+    const text =
+      roundedPercent === 100
+        ? `${roundedPercent}% of tests passed!`
+        : `${100 - roundedPercent}% of tests failed.`;
+
+    return <div className="test-results">{text}</div>;
+  }
+}

--- a/assets/src/components/activities/common/variables/variableActions.ts
+++ b/assets/src/components/activities/common/variables/variableActions.ts
@@ -1,7 +1,19 @@
+import { PostUndoable, makeUndoable } from 'components/activities/types';
+import { clone } from 'utils/common';
+import { Operations } from 'utils/pathOperations';
+
 export const VariableActions = {
   onUpdateTransformations(transformations: any) {
-    return (model: any) => {
+    return (model: any, post: PostUndoable) => {
+      const authoringClone = clone(model.authoring);
       model.authoring.transformations = transformations;
+
+      if (authoringClone.transformations.length > transformations.length) {
+        const undoable = makeUndoable('Disabled dynamic variables', [
+          Operations.replace('$.authoring.transformations', authoringClone.transformations),
+        ]);
+        post(undoable);
+      }
     };
   },
 };

--- a/assets/src/components/activities/common/variables/variableActions.ts
+++ b/assets/src/components/activities/common/variables/variableActions.ts
@@ -1,0 +1,7 @@
+export const VariableActions = {
+  onUpdateTransformations(transformations: any) {
+    return (model: any) => {
+      model.authoring.transformations = transformations;
+    };
+  },
+};

--- a/assets/src/components/activities/file_upload/FileUploadAuthoring.tsx
+++ b/assets/src/components/activities/file_upload/FileUploadAuthoring.tsx
@@ -12,6 +12,8 @@ import { AuthoringElementProvider, useAuthoringElementContext } from '../Authori
 import { FileSpecConfiguration } from './FileSpecConfiguration';
 import { FileUploadActions } from './actions';
 import { FileUploadSchema, FileSpec } from './schema';
+import { VariableEditorOrNot } from '../common/variables/VariableEditorOrNot';
+import { VariableActions } from '../common/variables/variableActions';
 
 const store = configureStore();
 
@@ -38,6 +40,13 @@ const FileUpload = () => {
 
         <TabbedNavigation.Tab label="Hints">
           <Hints partId={DEFAULT_PART_ID} />
+        </TabbedNavigation.Tab>
+        <TabbedNavigation.Tab label="Dynamic Variables">
+          <VariableEditorOrNot
+            editMode={editMode}
+            model={model}
+            onEdit={(t) => dispatch(VariableActions.onUpdateTransformations(t))}
+          />
         </TabbedNavigation.Tab>
       </TabbedNavigation.Tabs>
     </>

--- a/assets/src/components/activities/likert/LikertAuthoring.tsx
+++ b/assets/src/components/activities/likert/LikertAuthoring.tsx
@@ -24,10 +24,12 @@ import { SimpleFeedback } from '../common/responses/SimpleFeedback';
 import { TargetedFeedback } from '../common/responses/TargetedFeedback';
 import { ChoicesDelivery } from '../common/choices/delivery/ChoicesDelivery';
 import { getCorrectChoice } from 'components/activities/multiple_choice/utils';
+import { VariableEditorOrNot } from '../common/variables/VariableEditorOrNot';
+import { VariableActions } from '../common/variables/variableActions';
 import { useAuthoringElementContext, AuthoringElementProvider } from '../AuthoringElementProvider';
 
 const Likert = (props: AuthoringElementProps<LikertModelSchema>) => {
-  const { dispatch, model } = useAuthoringElementContext<LikertModelSchema>();
+  const { dispatch, model, editMode } = useAuthoringElementContext<LikertModelSchema>();
 
   // for now, we always select the first part for editing correct/feedback/hints.
   const selectedPartId = model.authoring.parts[0].id;
@@ -84,6 +86,13 @@ const Likert = (props: AuthoringElementProps<LikertModelSchema>) => {
 
         <TabbedNavigation.Tab label="Hints">
           <Hints partId={selectedPartId} />
+        </TabbedNavigation.Tab>
+        <TabbedNavigation.Tab label="Dynamic Variables">
+          <VariableEditorOrNot
+            editMode={editMode}
+            model={model}
+            onEdit={(t) => dispatch(VariableActions.onUpdateTransformations(t))}
+          />
         </TabbedNavigation.Tab>
       </TabbedNavigation.Tabs>
     </React.Fragment>

--- a/assets/src/components/activities/multi_input/MultiInputAuthoring.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputAuthoring.tsx
@@ -16,13 +16,14 @@ import { Editor, Transforms } from 'slate';
 import { ReactEditor } from 'slate-react';
 import { configureStore } from 'state/store';
 import { AuthoringElement, AuthoringElementProps } from '../AuthoringElement';
-
+import { VariableEditorOrNot } from '../common/variables/VariableEditorOrNot';
+import { VariableActions } from '../common/variables/variableActions';
 import { AuthoringElementProvider, useAuthoringElementContext } from '../AuthoringElementProvider';
 
 const store = configureStore();
 
 export const MultiInputComponent = () => {
-  const { dispatch, model } = useAuthoringElementContext<MultiInputSchema>();
+  const { dispatch, model, editMode } = useAuthoringElementContext<MultiInputSchema>();
   const [editor, setEditor] = React.useState<(ReactEditor & Editor) | undefined>();
   const [selectedInputRef, setSelectedInputRef] = React.useState<InputRef | undefined>(undefined);
 
@@ -59,6 +60,13 @@ export const MultiInputComponent = () => {
           </TabbedNavigation.Tab>
           <TabbedNavigation.Tab label="Hints">
             <HintsTab input={input} index={index} />
+          </TabbedNavigation.Tab>
+          <TabbedNavigation.Tab label="Dynamic Variables">
+            <VariableEditorOrNot
+              editMode={editMode}
+              model={model}
+              onEdit={(t) => dispatch(VariableActions.onUpdateTransformations(t))}
+            />
           </TabbedNavigation.Tab>
           <ActivitySettings settings={[shuffleAnswerChoiceSetting(model, dispatch)]} />
         </TabbedNavigation.Tabs>

--- a/assets/src/components/activities/multiple_choice/MultipleChoiceAuthoring.tsx
+++ b/assets/src/components/activities/multiple_choice/MultipleChoiceAuthoring.tsx
@@ -22,13 +22,15 @@ import { Maybe } from 'tsmonad';
 import { AuthoringElement, AuthoringElementProps } from '../AuthoringElement';
 import { AuthoringElementProvider, useAuthoringElementContext } from '../AuthoringElementProvider';
 import { MCActions as Actions } from '../common/authoring/actions/multipleChoiceActions';
+import { VariableEditorOrNot } from '../common/variables/VariableEditorOrNot';
+import { VariableActions } from '../common/variables/variableActions';
 import * as ActivityTypes from '../types';
 import { MCSchema } from './schema';
 
 const store = configureStore();
 
 const MultipleChoice: React.FC = () => {
-  const { dispatch, model } = useAuthoringElementContext<MCSchema>();
+  const { dispatch, model, editMode } = useAuthoringElementContext<MCSchema>();
   return (
     <>
       <TabbedNavigation.Tabs>
@@ -69,6 +71,13 @@ const MultipleChoice: React.FC = () => {
 
         <TabbedNavigation.Tab label="Hints">
           <Hints partId={DEFAULT_PART_ID} />
+        </TabbedNavigation.Tab>
+        <TabbedNavigation.Tab label="Dynamic Variables">
+          <VariableEditorOrNot
+            editMode={editMode}
+            model={model}
+            onEdit={(t) => dispatch(VariableActions.onUpdateTransformations(t))}
+          />
         </TabbedNavigation.Tab>
         <ActivitySettings settings={[shuffleAnswerChoiceSetting(model, dispatch)]} />
       </TabbedNavigation.Tabs>

--- a/assets/src/components/activities/ordering/OrderingAuthoring.tsx
+++ b/assets/src/components/activities/ordering/OrderingAuthoring.tsx
@@ -18,6 +18,8 @@ import { configureStore } from 'state/store';
 import { Maybe } from 'tsmonad';
 import { AuthoringElement, AuthoringElementProps } from '../AuthoringElement';
 import { AuthoringElementProvider, useAuthoringElementContext } from '../AuthoringElementProvider';
+import { VariableEditorOrNot } from '../common/variables/VariableEditorOrNot';
+import { VariableActions } from '../common/variables/variableActions';
 import * as ActivityTypes from '../types';
 import { Actions } from './actions';
 import { OrderingSchema } from './schema';
@@ -25,7 +27,7 @@ import { OrderingSchema } from './schema';
 const store = configureStore();
 
 export const Ordering: React.FC = () => {
-  const { dispatch, model } = useAuthoringElementContext<OrderingSchema>();
+  const { dispatch, model, editMode } = useAuthoringElementContext<OrderingSchema>();
 
   const choices = model.choices.reduce((m: any, c) => {
     m[c.id] = c;
@@ -57,6 +59,13 @@ export const Ordering: React.FC = () => {
 
       <TabbedNavigation.Tab label="Hints">
         <Hints partId={DEFAULT_PART_ID} />
+      </TabbedNavigation.Tab>
+      <TabbedNavigation.Tab label="Dynamic Variables">
+        <VariableEditorOrNot
+          editMode={editMode}
+          model={model}
+          onEdit={(t) => dispatch(VariableActions.onUpdateTransformations(t))}
+        />
       </TabbedNavigation.Tab>
 
       <ActivitySettings settings={[shuffleAnswerChoiceSetting(model, dispatch)]} />

--- a/assets/src/components/activities/short_answer/ShortAnswerAuthoring.tsx
+++ b/assets/src/components/activities/short_answer/ShortAnswerAuthoring.tsx
@@ -1,8 +1,6 @@
 import { AuthoringButtonConnected } from 'components/activities/common/authoring/AuthoringButton';
 import { InputTypeDropdown } from 'components/activities/common/authoring/InputTypeDropdown';
 import { GradingApproachDropdown } from 'components/activities/common/authoring/GradingApproachDropdown';
-import { ActivitySettings } from 'components/activities/common/authoring/settings/ActivitySettings';
-import { shuffleAnswerChoiceSetting } from 'components/activities/common/authoring/settings/activitySettingsActions';
 import { Hints } from 'components/activities/common/hints/authoring/HintsAuthoringConnected';
 import { ResponseActions } from 'components/activities/common/responses/responseActions';
 import { ResponseCard } from 'components/activities/common/responses/ResponseCard';
@@ -124,7 +122,6 @@ const ShortAnswer = () => {
             onEdit={(t) => dispatch(VariableActions.onUpdateTransformations(t))}
           />
         </TabbedNavigation.Tab>
-        <ActivitySettings settings={[shuffleAnswerChoiceSetting(model, dispatch)]} />
       </TabbedNavigation.Tabs>
     </>
   );

--- a/assets/src/components/activities/short_answer/ShortAnswerAuthoring.tsx
+++ b/assets/src/components/activities/short_answer/ShortAnswerAuthoring.tsx
@@ -32,6 +32,8 @@ import { AuthoringElementProvider, useAuthoringElementContext } from '../Authori
 
 import { ShortAnswerActions } from './actions';
 import { ShortAnswerModelSchema } from './schema';
+import { VariableEditorOrNot } from '../common/variables/VariableEditorOrNot';
+import { VariableActions } from '../common/variables/variableActions';
 
 const store = configureStore();
 
@@ -114,6 +116,13 @@ const ShortAnswer = () => {
 
         <TabbedNavigation.Tab label="Hints">
           <Hints partId={DEFAULT_PART_ID} />
+        </TabbedNavigation.Tab>
+        <TabbedNavigation.Tab label="Dynamic Variables">
+          <VariableEditorOrNot
+            editMode={editMode}
+            model={model}
+            onEdit={(t) => dispatch(VariableActions.onUpdateTransformations(t))}
+          />
         </TabbedNavigation.Tab>
         <ActivitySettings settings={[shuffleAnswerChoiceSetting(model, dispatch)]} />
       </TabbedNavigation.Tabs>

--- a/assets/src/components/tabbed_navigation/Tabs.tsx
+++ b/assets/src/components/tabbed_navigation/Tabs.tsx
@@ -12,7 +12,11 @@ const TabComponent: React.FunctionComponent<TabProps> = ({ index, children, acti
     role="tabpanel"
     aria-labelledby={'tab-' + index}
   >
-    {children}
+    {React.Children.map(
+      children,
+      (child, _index) =>
+        React.isValidElement(child) && React.cloneElement(child, { activetab: activeTab }),
+    )}
   </div>
 );
 

--- a/assets/src/data/persistence/variables.ts
+++ b/assets/src/data/persistence/variables.ts
@@ -1,0 +1,27 @@
+import { makeRequest } from './common';
+
+export type VariableScript = {
+  expression: string;
+  variable: string;
+};
+
+export type VariableEvaluation = {
+  variable: string;
+  result: string | number | null;
+  errored: boolean;
+};
+
+export interface VariableEvaluationResult {
+  result: 'success';
+  evaluations: VariableEvaluation[];
+}
+
+export function evaluateVariables(scripts: VariableScript[], count = 1) {
+  const params = {
+    method: 'POST',
+    body: JSON.stringify({ scripts, count }),
+    url: `/api/v1/variables`,
+  };
+
+  return makeRequest<VariableEvaluationResult>(params);
+}

--- a/assets/src/data/persistence/variables.ts
+++ b/assets/src/data/persistence/variables.ts
@@ -22,11 +22,11 @@ export interface VariableEvaluationResult {
   evaluations: VariableEvaluation[];
 }
 
-export function evaluateVariables(scripts: VariableScript[], count = 1) {
+export function evaluateVariables(data: VariableScript[], count = 1) {
   const params = {
     method: 'POST',
-    body: JSON.stringify({ scripts, count }),
-    url: `/api/v1/variables`,
+    body: JSON.stringify({ data, count }),
+    url: `/variables`,
   };
 
   return makeRequest<VariableEvaluationResult>(params);

--- a/assets/src/data/persistence/variables.ts
+++ b/assets/src/data/persistence/variables.ts
@@ -5,6 +5,12 @@ export type VariableScript = {
   variable: string;
 };
 
+export type Variable = {
+  variable: string;
+  expression: string;
+  id: string;
+};
+
 export type VariableEvaluation = {
   variable: string;
   result: string | number | null;

--- a/config/config.exs
+++ b/config/config.exs
@@ -68,7 +68,7 @@ config :oli, :rule_evaluator,
 
 variable_substitution_provider =
   case System.get_env("VARIABLE_SUBSTITUTION_PROVIDER") do
-    nil -> Oli.Activities.Transformers.VariableSubstitution.NoOpImpl
+    nil -> Oli.Activities.Transformers.VariableSubstitution.RestImpl
     provider -> Module.concat([Oli, Activities, Transformers, VariableSubstitution, provider])
   end
 

--- a/lib/oli/activities/model/transformations.ex
+++ b/lib/oli/activities/model/transformations.ex
@@ -1,7 +1,9 @@
 defmodule Oli.Activities.Model.Transformation do
   defstruct [:id, :path, :operation, :data]
 
-  def parse(%{"id" => id, "operation" => operation_str} = json) do
+  def parse(%{"operation" => operation_str} = json) do
+    id = Map.get(json, "id", UUID.uuid4())
+
     case operation_str do
       "shuffle" ->
         {:ok,

--- a/lib/oli/activities/transformers/variable_substitution/common.ex
+++ b/lib/oli/activities/transformers/variable_substitution/common.ex
@@ -6,9 +6,9 @@ defmodule Oli.Activities.Transformers.VariableSubstitution.Common do
   def replace_variables(model, evaluation_digest) do
     encoded = Jason.encode!(model)
 
-    Enum.reduce(evaluation_digest, encoded, fn %{"variable" => v, "result" => r}, s ->
+    Enum.reduce(evaluation_digest, encoded, fn %{"variable" => v} = e, s ->
       r =
-        case r do
+        case Map.get(e, "result", "") do
           s when is_binary(s) -> s
           number -> Kernel.to_string(number)
         end

--- a/lib/oli/activities/transformers/variable_substitution/rest_impl.ex
+++ b/lib/oli/activities/transformers/variable_substitution/rest_impl.ex
@@ -19,7 +19,7 @@ defmodule Oli.Activities.Transformers.VariableSubstitution.RestImpl do
 
     body =
       %{
-        vars: Enum.map(transformers, fn t -> %{expression: t.data, variable: "module"} end),
+        vars: Enum.map(transformers, fn t -> Enum.map(t.data, fn d -> d end) end),
         count: 1
       }
       |> Poison.encode!()

--- a/lib/oli/authoring/editing/page_editor.ex
+++ b/lib/oli/authoring/editing/page_editor.ex
@@ -335,6 +335,7 @@ defmodule Oli.Authoring.Editing.PageEditor do
          # version of the model that it can immediately use for display purposes. If it fails
          # to transform, nil will be handled by the client and the raw model will be used
          # instead
+
          transformed =
            case Transformers.apply_transforms([revision]) do
              [{:ok, nil}] ->

--- a/lib/oli_web/controllers/api/activity_controller.ex
+++ b/lib/oli_web/controllers/api/activity_controller.ex
@@ -582,8 +582,11 @@ defmodule OliWeb.Api.ActivityController do
   end
 
   @doc false
-  def transform(conn, %{"model" => model}) do
-    case ActivityLifecycle.perform_test_transformation(model) do
+  def transform(conn, content) do
+    case ActivityLifecycle.perform_test_transformation(%Oli.Resources.Revision{
+           content: content,
+           id: 1
+         }) do
       {:ok, transformed} ->
         json(conn, %{"result" => "success", "transformed" => transformed})
 

--- a/lib/oli_web/controllers/api/variable_evaluation_controller.ex
+++ b/lib/oli_web/controllers/api/variable_evaluation_controller.ex
@@ -1,0 +1,20 @@
+defmodule OliWeb.Api.VariableEvaluationController do
+  @moduledoc """
+  Endpoints to allow client-side invocation of the variable evalution service.
+  """
+
+  alias Oli.Activities.Transformers.VariableSubstitution.Strategy
+  alias Oli.Activities.Model.Transformation
+  import OliWeb.Api.Helpers
+
+  use OliWeb, :controller
+
+  def evaluate(conn, %{"data" => data, "count" => _count}) do
+    assembled_transformer = %Transformation{id: 1, data: data, operation: :variable_substitution}
+
+    case Strategy.provide_batch_context([assembled_transformer]) do
+      {:ok, [evaluations]} -> json(conn, %{"result" => "success", "evaluations" => evaluations})
+      _ -> error(conn, 500, "server error")
+    end
+  end
+end

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -520,12 +520,18 @@ defmodule OliWeb.Router do
   scope "/api/v1/bibs/project/:project", OliWeb do
     pipe_through([:api, :authoring_protected])
 
-
     post("/retrieve", Api.BibEntryController, :retrieve)
     post("/", Api.BibEntryController, :new)
     get("/", Api.BibEntryController, :index)
     delete("/entry/:entry", Api.BibEntryController, :delete)
     put("/entry/:entry", Api.BibEntryController, :update)
+  end
+
+  # Dynamic question variable evaluation service
+  scope "/api/v1/variables", OliWeb do
+    pipe_through([:api, :authoring_protected])
+
+    post("/", Api.VariableEvaluationController, :evaluate)
   end
 
   scope "/api/v1/products", OliWeb do
@@ -917,7 +923,9 @@ defmodule OliWeb.Router do
       as: :discount
     )
 
-    live("/institutions/:institution_id/research_consent", Admin.Institutions.ResearchConsentView, as: :institution)
+    live("/institutions/:institution_id/research_consent", Admin.Institutions.ResearchConsentView,
+      as: :institution
+    )
 
     live("/registrations", Admin.RegistrationsView)
 


### PR DESCRIPTION
This PR adds dynamic question editing support via the following:

1. It migrates the Echo React components for both first gen and second gen editors.
2. Embeds within all activities (except ImageCoding, Adaptive and OLIEmbedded) the ability to enable and disable and edit dynamic question scripts. 
3. Replaces the ACE editor with Monaco in the migrated Echo components
4. Adds an endpoint for the client to request variable evaluation, which then is a passthrough to the configured variable substitution strategy. 

One needs the `dynamic-questions-editing` branch of both `course-digest` and `authoring-eval` in place to test this end to end.  

1. Start `authoring-eval`
2. Create a digest from the embedded test course via `course-digest`
3. Ensure RESTImpl is the configured variable substitution strategy in Torus. 
4. Ingest the course. 
5. As author, go to the Activity Bank to see two Dynamic Questions.  Test that they run in the "test mode"
6. Publish the course, create a section, verify that graded assessment selects both questions, evaluates, and renders them correctly. 