### PR TITLE
[BUG FIX] ensure group id number is a string

### DIFF
--- a/lib/oli/resources/page_content.ex
+++ b/lib/oli/resources/page_content.ex
@@ -1,6 +1,8 @@
 defmodule Oli.Resources.PageContent do
   alias Oli.Resources.PageContent.TraversalContext
 
+  import Oli.Utils, only: [ensure_number_is_string: 1]
+
   @doc """
   Modelled after `Enum.map_reduce`, this invokes the given function to each content element in a page content tree.
 
@@ -115,7 +117,11 @@ defmodule Oli.Resources.PageContent do
       fn el, activity_groups, %TraversalContext{group_id: group_id, survey_id: survey_id} ->
         case el do
           %{"type" => "activity-reference", "activity_id" => activity_id} ->
-            {el, Map.put_new(activity_groups, activity_id, %{group: group_id, survey: survey_id})}
+            {el,
+             Map.put_new(activity_groups, activity_id, %{
+               group: ensure_number_is_string(group_id),
+               survey: ensure_number_is_string(survey_id)
+             })}
 
           _ ->
             {el, activity_groups}

--- a/lib/oli/utils.ex
+++ b/lib/oli/utils.ex
@@ -320,7 +320,7 @@ defmodule Oli.Utils do
   """
   def ensure_number_is_string(value) when is_integer(value), do: Integer.to_string(value)
   def ensure_number_is_string(value) when is_float(value), do: Float.to_string(value)
-  def ensure_number_is_string(value), do: Integer.to_string(value)
+  def ensure_number_is_string(value), do: value
 
   @doc """
   Detects all urls in a string and replaces them with hyperlinks.

--- a/lib/oli/utils.ex
+++ b/lib/oli/utils.ex
@@ -156,7 +156,13 @@ defmodule Oli.Utils do
     end
   end
 
-  def validate_number_if(changeset, field, condition, greater_than_or_equal_to, less_than_or_equal_to) do
+  def validate_number_if(
+        changeset,
+        field,
+        condition,
+        greater_than_or_equal_to,
+        less_than_or_equal_to
+      ) do
     if condition.(changeset) do
       Ecto.Changeset.validate_number(
         changeset,
@@ -308,6 +314,13 @@ defmodule Oli.Utils do
   """
   def string_to_boolean("true"), do: true
   def string_to_boolean(_bool), do: false
+
+  @doc """
+  Ensures a number (integer/float) is a string
+  """
+  def ensure_number_is_string(value) when is_integer(value), do: Integer.to_string(value)
+  def ensure_number_is_string(value) when is_float(value), do: Float.to_string(value)
+  def ensure_number_is_string(value), do: Integer.to_string(value)
 
   @doc """
   Detects all urls in a string and replaces them with hyperlinks.


### PR DESCRIPTION
This ensures any group id given by the adaptive player is convert to a string for the server side logic/database insertion.