### PR TITLE
[BUG FIX] fix activity bank selection width

### DIFF
--- a/assets/src/components/resource/editors/ActivityBankSelectionEditor.scss
+++ b/assets/src/components/resource/editors/ActivityBankSelectionEditor.scss
@@ -1,4 +1,6 @@
 .activity-bank-selection {
+  padding: 0 calc(50% - 400px);
+
   .label {
     font-size: 1.5em;
   }


### PR DESCRIPTION
Fixes an issue where the activity bank selection editor was wider than other activities in the editor.