### PR TITLE
[BUGFIX] throwing an error too harsh (crashes author sometimes)

### DIFF
--- a/assets/src/adaptivity/scripting.ts
+++ b/assets/src/adaptivity/scripting.ts
@@ -518,7 +518,8 @@ export const extractUniqueVariablesFromText = (text: string): string[] => {
   }
 
   if (openIndexes.length > 0) {
-    throw new Error(`Unmatched curly braces in text: ${text}`);
+    console.warn('Unmatched curly braces in text: ', text);
+    /* throw new Error(`Unmatched curly braces in text: ${text}`); */
   }
 
   if (variables.some((v) => v.indexOf('{') !== -1 || v.indexOf('}') !== -1)) {


### PR DESCRIPTION
currently the author is triggering this call on change of a text input for rules, so the moment you type a opening '{' it crashes;
will look into a better solution later;