### PR TITLE
[BUG FIX] Fix preview when an activity fails to eval

### DIFF
--- a/lib/oli/authoring/editing/page_editor.ex
+++ b/lib/oli/authoring/editing/page_editor.ex
@@ -344,9 +344,8 @@ defmodule Oli.Authoring.Editing.PageEditor do
              [{:ok, t}] ->
                t
 
-             e ->
-               IO.inspect(e)
-               nil
+             _ ->
+               revision.content
            end
 
          # the activity type this revision pertains to


### PR DESCRIPTION
Simple fix, just use the raw, untransformed content (for now). 