### PR TITLE
[BUG FIX] Use returned model after client initiated "Reset Activity"

### DIFF
--- a/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyDelivery.tsx
+++ b/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyDelivery.tsx
@@ -34,6 +34,7 @@ export const CheckAllThatApplyComponent: React.FC = () => {
     onSubmitActivity,
     onResetActivity,
     onSaveActivity,
+    model,
   } = useDeliveryElementContext<CATASchema>();
   const uiState = useSelector((state: ActivityDeliveryState) => state);
   const dispatch = useDispatch();
@@ -42,7 +43,7 @@ export const CheckAllThatApplyComponent: React.FC = () => {
     listenForParentSurveySubmit(surveyId, dispatch, onSubmitActivity);
     listenForParentSurveyReset(surveyId, dispatch, onResetActivity, { [DEFAULT_PART_ID]: [] });
 
-    dispatch(initializeState(activityState, initialPartInputs(activityState)));
+    dispatch(initializeState(activityState, initialPartInputs(activityState), model));
   }, []);
 
   // First render initializes state

--- a/assets/src/components/activities/common/stem/delivery/StemDelivery.tsx
+++ b/assets/src/components/activities/common/stem/delivery/StemDelivery.tsx
@@ -1,9 +1,10 @@
 import { useDeliveryElementContext } from 'components/activities/DeliveryElementProvider';
-import { HasStem, Stem, HasContent } from 'components/activities/types';
+import { HasStem, Stem } from 'components/activities/types';
 import { WriterContext } from 'data/content/writers/context';
 import { HtmlContentModelRenderer } from 'data/content/writers/renderer';
 import React from 'react';
-
+import { ActivityDeliveryState } from 'data/activities/DeliveryState';
+import { useSelector } from 'react-redux';
 import './StemDelivery.scss';
 
 interface StemProps {
@@ -24,6 +25,7 @@ interface Props {
   className?: string;
 }
 export const StemDeliveryConnected: React.FC<Props> = (props) => {
-  const { model, writerContext } = useDeliveryElementContext<HasStem>();
-  return <StemDelivery stem={model.stem} context={writerContext} {...props} />;
+  const { writerContext } = useDeliveryElementContext<HasStem>();
+  const uiState = useSelector((state: ActivityDeliveryState) => state);
+  return <StemDelivery stem={(uiState.model as any).stem} context={writerContext} {...props} />;
 };

--- a/assets/src/components/activities/file_upload/FileUploadDelivery.tsx
+++ b/assets/src/components/activities/file_upload/FileUploadDelivery.tsx
@@ -286,7 +286,7 @@ export const FileUploadComponent: React.FC = () => {
 
         <FileSubmission
           sectionSlug={sectionSlug as any}
-          model={model}
+          model={uiState.model}
           state={state}
           onSavePart={(a, p, s) => dispatch(savePart(DEFAULT_PART_ID, s, onSavePart))}
         />

--- a/assets/src/components/activities/file_upload/FileUploadDelivery.tsx
+++ b/assets/src/components/activities/file_upload/FileUploadDelivery.tsx
@@ -268,6 +268,7 @@ export const FileUploadComponent: React.FC = () => {
             [DEFAULT_PART_ID]: [],
           }),
         }),
+        model,
       ),
     );
   }, []);

--- a/assets/src/components/activities/likert/LikertDelivery.tsx
+++ b/assets/src/components/activities/likert/LikertDelivery.tsx
@@ -48,7 +48,7 @@ const LikertComponent: React.FC = () => {
   useEffect(() => {
     listenForParentSurveySubmit(surveyId, dispatch, onSubmitActivity);
     listenForParentSurveyReset(surveyId, dispatch, onResetActivity, emptySelectionMap);
-    dispatch(initializeState(activityState, initialPartInputs(activityState)));
+    dispatch(initializeState(activityState, initialPartInputs(activityState), model));
   }, []);
 
   // First render initializes state

--- a/assets/src/components/activities/likert/LikertDelivery.tsx
+++ b/assets/src/components/activities/likert/LikertDelivery.tsx
@@ -69,8 +69,8 @@ const LikertComponent: React.FC = () => {
       <div className="activity-content">
         <StemDelivery stem={model.stem} context={writerContext} />
         <LikertTable
-          items={model.items}
-          choices={model.choices}
+          items={(uiState.model as any).items}
+          choices={(uiState.model as any).choices}
           isSelected={isSelected}
           onSelect={onSelect}
           disabled={isEvaluated(uiState)}

--- a/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
@@ -31,18 +31,19 @@ export const MultiInputComponent: React.FC = () => {
   const {
     state: activityState,
     surveyId,
-    model,
     sectionSlug,
     bibParams,
     onSubmitActivity,
     onSaveActivity,
     onResetActivity,
+    model,
   } = useDeliveryElementContext<MultiInputSchema>();
+
   const uiState = useSelector((state: ActivityDeliveryState) => state);
   const [hintsShown, setHintsShown] = React.useState<PartId[]>([]);
   const dispatch = useDispatch();
 
-  const emptyPartInputs = model.inputs.reduce((acc, input) => {
+  const emptyPartInputs = model.inputs.reduce((acc: any, input: any) => {
     acc[input.partId] = [''];
     return acc;
   }, {} as PartInputs);
@@ -73,7 +74,7 @@ export const MultiInputComponent: React.FC = () => {
   }
 
   const toggleHints = (id: string) => {
-    const input = getByUnsafe(model.inputs, (x) => x.id === id);
+    const input = getByUnsafe((uiState.model as MultiInputSchema).inputs, (x) => x.id === id);
     setHintsShown((hintsShown) =>
       hintsShown.includes(input.partId)
         ? hintsShown.filter((id) => id !== input.partId)
@@ -82,7 +83,7 @@ export const MultiInputComponent: React.FC = () => {
   };
 
   const inputs = new Map(
-    model.inputs.map((input) => [
+    (uiState.model as MultiInputSchema).inputs.map((input) => [
       input.id,
       {
         input:
@@ -90,7 +91,7 @@ export const MultiInputComponent: React.FC = () => {
             ? {
                 id: input.id,
                 inputType: input.inputType,
-                options: model.choices
+                options: (uiState.model as MultiInputSchema).choices
                   .filter((c) => input.choiceIds.includes(c.id))
                   .map((choice) => ({
                     value: choice.id,
@@ -105,7 +106,7 @@ export const MultiInputComponent: React.FC = () => {
   );
 
   const onChange = (id: string, e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
-    const input = getByUnsafe(model.inputs, (x) => x.id === id);
+    const input = getByUnsafe((uiState.model as MultiInputSchema).inputs, (x) => x.id === id);
     const value = e.target.value;
     dispatch(
       activityDeliverySlice.actions.setStudentInputForPart({
@@ -137,7 +138,11 @@ export const MultiInputComponent: React.FC = () => {
   return (
     <div className="activity mc-activity">
       <div className="activity-content">
-        <StemDelivery className="form-inline" stem={model.stem} context={writerContext} />
+        <StemDelivery
+          className="form-inline"
+          stem={(uiState.model as MultiInputSchema).stem}
+          context={writerContext}
+        />
         <GradedPointsConnected />
         <ResetButtonConnected
           onReset={() => dispatch(resetAction(onResetActivity, emptyPartInputs))}

--- a/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
@@ -62,6 +62,7 @@ export const MultiInputComponent: React.FC = () => {
               return acc;
             }, {} as PartInputs),
         }),
+        model,
       ),
     );
   }, []);

--- a/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
+++ b/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
@@ -34,6 +34,7 @@ export const MultipleChoiceComponent: React.FC = () => {
     onSubmitActivity,
     onSaveActivity,
     onResetActivity,
+    model,
   } = useDeliveryElementContext<MCSchema>();
   const uiState = useSelector((state: ActivityDeliveryState) => state);
   const dispatch = useDispatch();
@@ -42,7 +43,7 @@ export const MultipleChoiceComponent: React.FC = () => {
     listenForParentSurveySubmit(surveyId, dispatch, onSubmitActivity);
     listenForParentSurveyReset(surveyId, dispatch, onResetActivity, { [DEFAULT_PART_ID]: [] });
 
-    dispatch(initializeState(activityState, initialPartInputs(activityState)));
+    dispatch(initializeState(activityState, initialPartInputs(activityState), model));
   }, []);
 
   // First render initializes state

--- a/assets/src/components/activities/ordering/OrderingDelivery.tsx
+++ b/assets/src/components/activities/ordering/OrderingDelivery.tsx
@@ -68,7 +68,9 @@ export const OrderingComponent: React.FC = () => {
     dispatch(
       initializeState(
         activityState,
-        initialPartInputs(activityState, { [DEFAULT_PART_ID]: model.choices.map((c) => c.id) }),
+        initialPartInputs(activityState, {
+          [DEFAULT_PART_ID]: model.choices.map((c) => c.id),
+        }),
         model,
       ),
     );
@@ -78,7 +80,7 @@ export const OrderingComponent: React.FC = () => {
     // to be evaluated correctly.
     setTimeout(() => {
       if (activityState.parts[0].response === null) {
-        const selection = model.choices.map((choice) => choice.id);
+        const selection = (uiState.model as OrderingSchema).choices.map((choice) => choice.id);
         const input = studentInputToString(selection);
         onSaveActivity(activityState.attemptGuid, [
           {
@@ -103,7 +105,7 @@ export const OrderingComponent: React.FC = () => {
         <ResponseChoices
           choices={Maybe.maybe(uiState.partState[DEFAULT_PART_ID]?.studentInput)
             .valueOr<StudentInput>([])
-            .map((id) => Choices.getOne(model, id))}
+            .map((id) => Choices.getOne(uiState.model as OrderingSchema, id))}
           setChoices={(choices) => onSelectionChange(choices.map((c) => c.id))}
           disabled={isEvaluated(uiState) || isSubmitted(uiState)}
         />

--- a/assets/src/components/activities/ordering/OrderingDelivery.tsx
+++ b/assets/src/components/activities/ordering/OrderingDelivery.tsx
@@ -69,6 +69,7 @@ export const OrderingComponent: React.FC = () => {
       initializeState(
         activityState,
         initialPartInputs(activityState, { [DEFAULT_PART_ID]: model.choices.map((c) => c.id) }),
+        model,
       ),
     );
 

--- a/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
+++ b/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
@@ -115,7 +115,7 @@ export const ShortAnswerComponent: React.FC = () => {
         <GradedPointsConnected />
 
         <Input
-          inputType={model.inputType}
+          inputType={(uiState.model as ShortAnswerModelSchema).inputType}
           // Short answers only have one selection, but are modeled as an array.
           // Select the first element.
           input={Maybe.maybe(uiState.partState[DEFAULT_PART_ID]?.studentInput).valueOr([''])[0]}

--- a/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
+++ b/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
@@ -85,6 +85,7 @@ export const ShortAnswerComponent: React.FC = () => {
             [DEFAULT_PART_ID]: [''],
           }),
         }),
+        model,
       ),
     );
   }, []);

--- a/assets/src/data/activities/DeliveryState.ts
+++ b/assets/src/data/activities/DeliveryState.ts
@@ -19,6 +19,7 @@ import {
 import { SurveyEventDetails } from 'components/misc/SurveyControls';
 import { studentInputToString } from 'data/activities/utils';
 import { WritableDraft } from 'immer/dist/internal';
+import { ActivityModelSchema } from 'oli-torus-sdk';
 import { Maybe } from 'tsmonad';
 
 export type AppThunk<ReturnType = void> = ThunkAction<
@@ -31,6 +32,7 @@ export type StudentInput = string[];
 export type PartInputs = Record<PartId, StudentInput>;
 
 export interface ActivityDeliveryState {
+  model: ActivityModelSchema;
   attemptState: ActivityState;
   partState: Record<
     PartId,
@@ -190,6 +192,9 @@ export const activityDeliverySlice = createSlice({
     hideAllHints(state) {
       Object.values(state.partState).forEach((partState) => (partState.hintsShown = []));
     },
+    updateModel(state, action: PayloadAction<ActivityModelSchema>) {
+      state.model = action.payload;
+    },
     hideHintsForPart(state, action: PayloadAction<PartId>) {
       Maybe.maybe(state.partState[action.payload]).lift((partState) => (partState.hintsShown = []));
     },
@@ -252,6 +257,7 @@ export const resetAction =
     const response = await onResetActivity(getState().attemptState.attemptGuid);
     partInputs && dispatch(slice.actions.setPartInputs(partInputs));
     dispatch(slice.actions.hideAllHints());
+    dispatch(slice.actions.updateModel(response.model));
     dispatch(slice.actions.setAttemptState(response.attemptState));
     getState().attemptState.parts.forEach((partState) =>
       dispatch(
@@ -312,9 +318,10 @@ export const submitFiles =
   };
 
 export const initializeState =
-  (state: ActivityState, initialPartInputs: PartInputs): AppThunk =>
+  (state: ActivityState, initialPartInputs: PartInputs, model: ActivityModelSchema): AppThunk =>
   async (dispatch, _getState) => {
     dispatch(slice.actions.initializePartState(state));
+    dispatch(slice.actions.updateModel(model));
     state.parts.forEach((partState) => {
       dispatch(
         slice.actions.setHintsShownForPart({

--- a/assets/test/activities/redux_delivery_test.ts
+++ b/assets/test/activities/redux_delivery_test.ts
@@ -29,7 +29,7 @@ describe('activity delivery state management', () => {
   const dispatch: Dispatch<any> = store.dispatch;
 
   it('can initialize state', () => {
-    dispatch(initializeState(props.state, initialPartInputs(props.state)));
+    dispatch(initializeState(props.state, initialPartInputs(props.state), model));
     expect(store.getState().attemptState).toEqual(props.state);
     const partState = store.getState().partState[DEFAULT_PART_ID];
     expect(partState).toBeTruthy();
@@ -39,7 +39,7 @@ describe('activity delivery state management', () => {
   });
 
   it('can select single choices', () => {
-    dispatch(initializeState(props.state, initialPartInputs(props.state)));
+    dispatch(initializeState(props.state, initialPartInputs(props.state), model));
     dispatch(setSelection(DEFAULT_PART_ID, model.choices[0].id, onSaveActivity, 'single'));
     expect(store.getState().partState[DEFAULT_PART_ID]?.studentInput).toEqual([
       model.choices[0].id,
@@ -47,7 +47,7 @@ describe('activity delivery state management', () => {
   });
 
   it('can select multiple choices', () => {
-    dispatch(initializeState(props.state, initialPartInputs(props.state)));
+    dispatch(initializeState(props.state, initialPartInputs(props.state), model));
     dispatch(setSelection(DEFAULT_PART_ID, model.choices[0].id, onSaveActivity, 'multiple'));
     dispatch(setSelection(DEFAULT_PART_ID, model.choices[1].id, onSaveActivity, 'multiple'));
     expect(store.getState().partState[DEFAULT_PART_ID]?.studentInput).toEqual([


### PR DESCRIPTION
This PR fixes a bug where a subsequent attempt after a "Reset" does not use the new model for the activity. The result is that students keep seeing the same, original activity.  This was not caught until now because the only transformation that existed prior to the variable substitution transformer was the shuffle.  Folks just didn't realize the choices were supposed to shuffle.  

The key change here is to use the model that is returned from the "Reset Activity" action. To do that I had to add the "model" to the delivery element state.  Then I had to update every activity to use the model from that state, and not the model from props (which never changes)

