### PR TITLE
[BUGFIX] Persistent session cookie handling

### DIFF
--- a/lib/oli_web/controllers/lti_controller.ex
+++ b/lib/oli_web/controllers/lti_controller.ex
@@ -427,7 +427,6 @@ defmodule OliWeb.LtiController do
 
                 # sign current user in and redirect to home page
                 conn
-                |> OliWeb.SessionController.perform_signout()
                 |> create_pow_user(:user, user)
                 |> redirect(to: Routes.delivery_path(conn, :index))
             end

--- a/lib/oli_web/controllers/session_controller.ex
+++ b/lib/oli_web/controllers/session_controller.ex
@@ -7,20 +7,11 @@ defmodule OliWeb.SessionController do
 
   @shared_session_data_to_delete [:dismissed_messages]
 
-  def signout(conn, _) do
+  def signout(conn, %{"type" => type}) do
     conn
-    |> perform_signout()
+    |> delete_pow_user(String.to_atom(type))
+    |> delete_session_data(type)
     |> redirect(to: Routes.static_page_path(conn, :index))
-  end
-
-  def perform_signout(conn) do
-    conn
-    |> delete_pow_user(:user)
-    |> delete_session_data("user")
-    |> delete_pow_user(:author)
-    |> delete_session_data("author")
-    |> PowPersistentSession.Plug.Cookie.delete(OliWeb.Pow.PowHelpers.get_pow_config(:user))
-    |> PowPersistentSession.Plug.Cookie.delete(OliWeb.Pow.PowHelpers.get_pow_config(:author))
   end
 
   defp delete_session_data(conn, type) do

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -43,7 +43,6 @@ defmodule OliWeb.Router do
   pipeline :lti do
     plug(:fetch_session)
     plug(:fetch_flash)
-    plug(Oli.Plugs.SetCurrentUser)
     plug(:put_root_layout, {OliWeb.LayoutView, "lti.html"})
   end
 
@@ -655,7 +654,7 @@ defmodule OliWeb.Router do
 
   # LTI routes
   scope "/lti", OliWeb do
-    pipe_through([:lti, :www_url_form])
+    pipe_through([:lti, :www_url_form, :delivery])
 
     post("/login", LtiController, :login)
     get("/login", LtiController, :login)

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -47,6 +47,13 @@ defmodule OliWeb.Router do
     plug(:put_root_layout, {OliWeb.LayoutView, "lti.html"})
   end
 
+  # pipeline for SSO endpoints
+  pipeline :sso do
+    plug(:fetch_session)
+    plug(:fetch_flash)
+    plug(Oli.Plugs.ValidateIdToken)
+  end
+
   pipeline :skip_csrf_protection do
     plug(:accepts, ["html"])
     plug(:fetch_session)
@@ -197,10 +204,6 @@ defmodule OliWeb.Router do
     plug Plug.Static,
       at: "/superactivity",
       from: System.get_env("SUPER_ACTIVITY_FOLDER", "priv/superactivity")
-  end
-
-  pipeline :sso do
-    plug(Oli.Plugs.ValidateIdToken)
   end
 
   scope "/superactivity", OliWeb do
@@ -1012,11 +1015,15 @@ defmodule OliWeb.Router do
 
   # Support for cognito JWT auth currently used by Infiniscope
   scope "/cognito", OliWeb do
-    pipe_through([:sso])
+    pipe_through([:sso, :delivery])
 
     get("/launch", CognitoController, :index)
     get("/launch/products/:product_slug", CognitoController, :launch)
     get("/launch/projects/:project_slug", CognitoController, :launch)
+  end
+
+  scope "/cognito", OliWeb do
+    pipe_through([:sso, :authoring])
 
     get("/launch_clone/products/:product_slug", CognitoController, :launch_clone,
       as: :product_clone


### PR DESCRIPTION
[MER-1312](https://eliterate.atlassian.net/browse/MER-1312)

Fixes an issue where some endpoints are not creating the session with the correct user or author cookie and instead using a generic one, causing issues as the same cookie is used with the wrong pow config.

Added the missing `authoring` and `delivery` plugs that set the correct cookies and made sure all endpoints now have at least one of those two (or the `_protected` ones) when they are necessary.

Also changed the signout logic to log out only the correct account and not all of them (as they are independent).