### PR TITLE
[MER-985] Display status to authors on projects page

### DIFF
--- a/lib/oli_web/live/projects/table_model.ex
+++ b/lib/oli_web/live/projects/table_model.ex
@@ -5,36 +5,29 @@ defmodule OliWeb.Projects.TableModel do
   alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
   alias OliWeb.Router.Helpers, as: Routes
 
-  def new(%SessionContext{} = context, sections, include_status?) do
-    column_specs =
-      [
-        %ColumnSpec{
-          name: :title,
-          label: "Title",
-          render_fn: &__MODULE__.custom_render/3
-        },
-        %ColumnSpec{
-          name: :inserted_at,
-          label: "Created",
-          render_fn: &OliWeb.Common.Table.Common.render_date/3
-        },
-        %ColumnSpec{
-          name: :name,
-          label: "Created By",
-          render_fn: &__MODULE__.custom_render/3
-        }
-      ] ++
-        if include_status? do
-          [
-            %ColumnSpec{
-              name: :status,
-              label: "Status",
-              render_fn: &__MODULE__.custom_render/3
-            }
-          ]
-        else
-          []
-        end
+  def new(%SessionContext{} = context, sections) do
+    column_specs = [
+      %ColumnSpec{
+        name: :title,
+        label: "Title",
+        render_fn: &__MODULE__.custom_render/3
+      },
+      %ColumnSpec{
+        name: :inserted_at,
+        label: "Created",
+        render_fn: &OliWeb.Common.Table.Common.render_date/3
+      },
+      %ColumnSpec{
+        name: :name,
+        label: "Created By",
+        render_fn: &__MODULE__.custom_render/3
+      },
+      %ColumnSpec{
+        name: :status,
+        label: "Status",
+        render_fn: &__MODULE__.custom_render/3
+      }
+    ]
 
     SortableTableModel.new(
       rows: sections,

--- a/test/oli_web/live/projects_live_test.exs
+++ b/test/oli_web/live/projects_live_test.exs
@@ -2,37 +2,218 @@ defmodule OliWeb.Projects.ProjectsLiveTest do
   use OliWeb.ConnCase
 
   import Phoenix.LiveViewTest
+  import Oli.Factory
 
-  alias Oli.Accounts
-  alias Oli.Seeder
+  alias OliWeb.Endpoint
+  alias OliWeb.Projects.ProjectsLive
 
-  describe "projects live" do
-    setup [:setup_author_project]
-
-    test "loads correctly when there are no collaborators for a project", %{
-      conn: conn,
-      map: %{
-        author: author,
-        author2: author2
-      }
-    } do
-      {:ok, _author} = Accounts.delete_author(author)
-      {:ok, _author} = Accounts.delete_author(author2)
-
-      conn = get(conn, "/authoring/projects")
-
-      {:ok, _view, _} = live(conn)
+  describe "author cannot access when is not logged in" do
+    test "redirects to new session when accessing the index view", %{conn: conn} do
+      {:error, {:redirect, %{to: "/authoring/session/new?request_path=%2Fauthoring%2Fprojects"}}} =
+        live(conn, Routes.live_path(Endpoint, ProjectsLive))
     end
   end
 
-  defp setup_author_project(%{conn: conn}) do
-    map = Seeder.base_project_with_resource2()
-    admin = author_fixture(%{system_role_id: Oli.Accounts.SystemRole.role_id().admin})
+  describe "projects live as admin" do
+    setup [:admin_conn, :set_timezone]
 
-    conn =
-      Plug.Test.init_test_session(conn, lti_session: nil)
-      |> Pow.Plug.assign_current_user(admin, OliWeb.Pow.PowHelpers.get_pow_config(:author))
+    test "loads correctly when there are no projects", %{conn: conn} do
+      {:ok, view, _html} = live(conn, Routes.live_path(Endpoint, ProjectsLive))
 
-    {:ok, conn: conn, map: map}
+      assert has_element?(view, "#projects-table")
+      assert has_element?(view, "p", "None exist")
+      assert has_element?(view, "#button-new-project")
+    end
+
+    test "lists projects", %{conn: conn, admin: admin, context: context} do
+      project = create_project_with_owner(admin)
+
+      {:ok, view, _html} = live(conn, Routes.live_path(Endpoint, ProjectsLive))
+
+      project_row =
+        view
+        |> element("##{project.id}")
+        |> render()
+
+      assert project_row =~ project.title
+      assert project_row =~ OliWeb.Common.Utils.render_date(project, :inserted_at, context)
+      assert project_row =~ admin.name
+      assert project_row =~ admin.email
+      assert project_row =~ "Active"
+    end
+
+    test "applies show-all filter", %{conn: conn, admin: admin} do
+      admin_project = create_project_with_owner(admin)
+      project = insert(:author) |> create_project_with_owner()
+
+      {:ok, view, _html} = live(conn, Routes.live_path(Endpoint, ProjectsLive))
+
+      # shows all projects by default
+      assert has_element?(view, "##{admin_project.id}")
+      assert has_element?(view, "##{project.id}")
+
+      view
+      |> element("#allCheck")
+      |> render_click()
+
+      # shows only admin projects
+      assert has_element?(view, "##{admin_project.id}")
+      refute has_element?(view, "##{project.id}")
+    end
+
+    test "applies show-deleted filter", %{conn: conn, admin: admin} do
+      active_project = create_project_with_owner(admin)
+      deleted_project = insert(:project, status: :deleted)
+
+      {:ok, view, _html} = live(conn, Routes.live_path(Endpoint, ProjectsLive))
+
+      # shows only active projects by default
+      assert has_element?(view, "##{active_project.id}")
+      refute has_element?(view, "##{deleted_project.id}")
+
+      view
+      |> element("#deletedCheck")
+      |> render_click()
+
+      # shows both active and deleted projects
+      assert has_element?(view, "##{active_project.id}")
+      assert has_element?(view, "##{deleted_project.id}")
+    end
+
+    test "applies paging", %{conn: conn} do
+      [first_p | tail] = insert_list(26, :project) |> Enum.sort_by(& &1.title)
+      last_p = List.last(tail)
+
+      {:ok, view, _html} = live(conn, Routes.live_path(Endpoint, ProjectsLive))
+
+      assert has_element?(view, "##{first_p.id}")
+      refute has_element?(view, "##{last_p.id}")
+
+      view
+      |> element("#header_paging a[phx-click=\"paged_table_page_change\"]", "2")
+      |> render_click()
+
+      refute has_element?(view, "##{first_p.id}")
+      assert has_element?(view, "##{last_p.id}")
+    end
+
+    test "applies sorting", %{conn: conn} do
+      insert(:project, %{title: "Testing A"})
+      insert(:project, %{title: "Testing B"})
+
+      {:ok, view, _html} = live(conn, Routes.live_path(Endpoint, ProjectsLive))
+
+      assert view
+             |> element("tr:first-child > td:first-child")
+             |> render() =~
+               "Testing A"
+
+      view
+      |> element("th[phx-click=\"paged_table_sort\"]:first-of-type")
+      |> render_click(%{sort_by: "title"})
+
+      assert view
+             |> element("tr:first-child > td:first-child")
+             |> render() =~
+               "Testing B"
+    end
+  end
+
+  describe "projects live as author" do
+    setup [:author_conn, :set_timezone]
+
+    test "loads correctly when there are no projects", %{conn: conn} do
+      {:ok, view, _html} = live(conn, Routes.live_path(Endpoint, ProjectsLive))
+
+      assert has_element?(view, "#projects-table")
+      assert has_element?(view, "p", "None exist")
+      assert has_element?(view, "#button-new-project")
+    end
+
+    test "lists only projects the author owns", %{conn: conn, author: author} do
+      author_project = create_project_with_owner(author)
+      another_project = insert(:author) |> create_project_with_owner()
+
+      {:ok, view, _html} = live(conn, Routes.live_path(Endpoint, ProjectsLive))
+
+      author_project_row =
+        view
+        |> element("##{author_project.id}")
+        |> render()
+
+      assert author_project_row =~ author_project.title
+      assert author_project_row =~ author.name
+      assert author_project_row =~ author.email
+      assert author_project_row =~ "Active"
+
+      refute has_element?(view, "##{another_project.id}")
+    end
+
+    test "applies show-deleted filter", %{conn: conn, author: author} do
+      active_project = create_project_with_owner(author)
+      deleted_project = create_project_with_owner(author, %{status: :deleted})
+
+      {:ok, view, _html} = live(conn, Routes.live_path(Endpoint, ProjectsLive))
+
+      # shows only active projects by default
+      assert has_element?(view, "##{active_project.id}")
+      refute has_element?(view, "##{deleted_project.id}")
+
+      view
+      |> element("#deletedCheck")
+      |> render_click()
+
+      # shows both active and deleted projects
+      assert has_element?(view, "##{active_project.id}")
+      assert has_element?(view, "##{deleted_project.id}")
+    end
+
+    test "applies paging", %{conn: conn, author: author} do
+      [first_p | tail] =
+        1..26
+        |> Enum.map(fn _ -> create_project_with_owner(author) end)
+        |> Enum.sort_by(& &1.title)
+
+      last_p = List.last(tail)
+
+      {:ok, view, _html} = live(conn, Routes.live_path(Endpoint, ProjectsLive))
+
+      assert has_element?(view, "##{first_p.id}")
+      refute has_element?(view, "##{last_p.id}")
+
+      view
+      |> element("#header_paging a[phx-click=\"paged_table_page_change\"]", "2")
+      |> render_click()
+
+      refute has_element?(view, "##{first_p.id}")
+      assert has_element?(view, "##{last_p.id}")
+    end
+
+    test "applies sorting", %{conn: conn, author: author} do
+      create_project_with_owner(author, %{title: "Testing A"})
+      create_project_with_owner(author, %{title: "Testing B"})
+
+      {:ok, view, _html} = live(conn, Routes.live_path(Endpoint, ProjectsLive))
+
+      assert view
+             |> element("tr:first-child > td:first-child")
+             |> render() =~
+               "Testing A"
+
+      view
+      |> element("th[phx-click=\"paged_table_sort\"]:first-of-type")
+      |> render_click(%{sort_by: "title"})
+
+      assert view
+             |> element("tr:first-child > td:first-child")
+             |> render() =~
+               "Testing B"
+    end
+  end
+
+  defp create_project_with_owner(owner, attrs \\ %{}) do
+    project = insert(:project, attrs)
+    insert(:author_project, project_id: project.id, author_id: owner.id)
+    project
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -2,6 +2,7 @@ defmodule Oli.Factory do
   use ExMachina.Ecto, repo: Oli.Repo
 
   alias Oli.Accounts.{Author, User}
+  alias Oli.Authoring.Authors.{AuthorProject, ProjectRole}
   alias Oli.Authoring.Course.{Family, Project, ProjectVisibility, ProjectResource}
   alias Oli.Branding.Brand
 
@@ -114,6 +115,17 @@ defmodule Oli.Factory do
       visibility: :global,
       authors: anonymous_build_list(2, :author),
       publisher: anonymous_build(:publisher)
+    }
+  end
+
+  def author_project_factory() do
+    author = insert(:author)
+    project = insert(:project)
+
+    %AuthorProject{
+      author_id: author.id,
+      project_id: project.id,
+      project_role_id: ProjectRole.role_id().owner
     }
   end
 


### PR DESCRIPTION
[MER-985](https://eliterate.atlassian.net/browse/MER-985)

- Show status column on projects index page to normal authors (like it is shown to admins).
- Display "Show deleted projects" filter to authors.
- Add tests for the ProjectsLive view.