### PR TITLE
PMP-2910 | JAN-1759 | Ever App Observation getting disappear

### DIFF
--- a/assets/src/adaptivity/scripting.ts
+++ b/assets/src/adaptivity/scripting.ts
@@ -58,6 +58,7 @@ export const getExpressionStringForValue = (
         val[val.length - 1] === ']' &&
         v.type === CapiVariableTypes.ARRAY
       ) {
+        //Is there a possibility that EverApp variable of type array can have expression in them?
         isEverAppArrayObject = true;
       }
       /* console.log('can actually eval:', { val, canEval, test, t: typeof test.result }); */

--- a/assets/src/adaptivity/scripting.ts
+++ b/assets/src/adaptivity/scripting.ts
@@ -42,12 +42,24 @@ export const getExpressionStringForValue = (
 ): string => {
   let val: any = v.value;
   let isValueVar = false;
-
+  let isEverAppArrayObject = false;
   if (typeof val === 'string') {
     let canEval = false;
     try {
       const test = evalScript(val, env);
       canEval = test?.result !== undefined && !test.result.message;
+      if (
+        test?.result &&
+        test?.result?.length > 1 &&
+        v.key &&
+        v.key.startsWith('app.') &&
+        typeof val === 'string' &&
+        val[0] === '[' &&
+        val[val.length - 1] === ']' &&
+        v.type === CapiVariableTypes.ARRAY
+      ) {
+        isEverAppArrayObject = true;
+      }
       /* console.log('can actually eval:', { val, canEval, test, t: typeof test.result }); */
     } catch (e) {
       // failed for any reason
@@ -74,8 +86,8 @@ export const getExpressionStringForValue = (
 
     const hasBackslash = val.includes('\\');
     isValueVar =
-      (canEval && !looksLikeJSON && looksLikeAFunction && !hasBackslash) ||
-      (hasCurlies && !looksLikeJSON && !hasBackslash);
+      (canEval && !looksLikeJSON && looksLikeAFunction && !hasBackslash && !isEverAppArrayObject) ||
+      (hasCurlies && !looksLikeJSON && !hasBackslash && !isEverAppArrayObject);
   }
 
   if (isValueVar) {

--- a/assets/test/adaptivity/scripting_test.ts
+++ b/assets/test/adaptivity/scripting_test.ts
@@ -456,6 +456,18 @@ describe('Scripting Interface', () => {
       expect(script).toBe('{q:1541204522672:818|stage.FillInTheBlanks.Input 1.Value}');
     });
 
+    it('should give the array back in same format to what was sent', () => {
+      const value =
+        '[{"data":{"notes":"asd asd asdas dasdas dasdd","url":"https://static.argos.education/repo/images/6b8d8462ac05fd45cf8d73577baed921.jpg"},"type":"IMAGE","uuid":"36bfc906-88e6-4f41-938a-89ce15d3d8b1"},{"data":{"notes":"asd asd asdasdd ","url":"https://static.argos.education/repo/images/782e06cacd2729e579eba2a05d130484.jpg"},"type":"IMAGE","uuid":"cbe7fc7e-ba93-4aaf-9c5c-d5458c68de07"},{"data":{"notes":"sad asd asdas dasda sdasd","url":"https://static.argos.education/repo/images/45d4d206419c471fb035c19b852f4682.png"},"type":"IMAGE","uuid":"92197b95-2aa6-4b7c-9a55-7f48267da733"},{"uuid":"63548c9a-3fad-45e2-8c5d-e60cebb44b76","type":"IMAGE","data":{"url":"https://static.argos.education/repo/images/b9fc166eebd25a3bd65873411b8b5662.gif","notes":"as fsdf sfs s fsfd"}},{"uuid":"a13e0e2e-1039-403a-ae99-1990424da6b4","type":"IMAGE","data":{"url":"https://static.argos.education/repo/images/a3bf0a353a8344f518db51419a55c7c9.png","notes":"asd asda dasd adad"}},{"uuid":"cc0b2057-6ca2-48f7-ad34-4d86474eb6dc","type":"IMAGE","data":{"url":"https://static.argos.education/repo/images/4ab2dd2db9e1c48f2524aa29f4209b5e.png","notes":"asd asd ada sdasd"}}]';
+      const variable = {
+        type: CapiVariableTypes.ARRAY,
+        key: 'app.ispk-bio-blue-planet-report.observations',
+        value: value,
+      };
+      const script = getExpressionStringForValue(variable);
+      expect(script).toBe(value);
+    });
+
     it('should allow full janus-script expressions to be assigned', () => {
       const variable = {
         type: CapiVariableTypes.STRING,


### PR DESCRIPTION
Observation list is an array of object however it is saved as string because that's how Ever App expects the data. The getExpressionStringForValue() was trying to convert the string to array based on the ',' present in the string and after that the ""' were getting replaced with '\\\\'. Due to this the observation had invalid data causing the observation to disappear from the list.

![stringtoArrayconvert](https://user-images.githubusercontent.com/70621864/177770219-e982be3e-8169-4771-9781-5d1263e66352.png)
