### PR TITLE
[MER-1216] Add duplicate page action in project curriculum

### DIFF
--- a/lib/oli/authoring/editing/activity_editor.ex
+++ b/lib/oli/authoring/editing/activity_editor.ex
@@ -588,7 +588,7 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
 
   Returns:
 
-  .`{:ok, {%Activity{}, transformed_content}}` when the creation processes succeeds
+  .`{:ok, {%Revision{}, transformed_content}}` when the creation processes succeeds
   .`{:error, {:not_found}}` if the project, resource, or user cannot be found
   .`{:error, {:not_authorized}}` if the user is not authorized to create this activity
   .`{:error, {:error}}` unknown error
@@ -598,7 +598,7 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
           | {:error, {:not_found}}
           | {:error, {:error}}
           | {:error, {:not_authorized}}
-  def create(project_slug, activity_type_slug, author, model, objectives, scope \\ "embedded") do
+  def create(project_slug, activity_type_slug, author, model, objectives, scope \\ "embedded", title \\ nil) do
     Repo.transaction(fn ->
       with {:ok, project} <- Course.get_project_by_slug(project_slug) |> trap_nil(),
            {:ok} <- authorize_user(author, project),
@@ -610,7 +610,7 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
            {:ok, %{content: content} = activity} <-
              Resources.create_new(
                %{
-                 title: activity_type.title,
+                 title: title || activity_type.title,
                  scoring_strategy_id: Oli.Resources.ScoringStrategy.get_id_by_type("total"),
                  objectives: attached_objectives,
                  author_id: author.id,

--- a/lib/oli/authoring/editing/container_editor.ex
+++ b/lib/oli/authoring/editing/container_editor.ex
@@ -317,17 +317,15 @@ defmodule Oli.Authoring.Editing.ContainerEditor do
 
     activity_type = Activities.get_registration(activity_revision.activity_type_id)
 
-    objectives =
-      Enum.reduce(activity_revision.objectives, [], fn {_key, ids}, acc -> acc ++ ids end)
-
     case ActivityEditor.create(
            project_slug,
            activity_type.slug,
            author,
            activity_revision.content,
-           objectives,
+           [],
            "embedded",
-           activity_revision.title
+           activity_revision.title,
+           activity_revision.objectives
          ) do
       {:ok, {revision, _}} ->
         {:ok,

--- a/lib/oli/resources/resource_type.ex
+++ b/lib/oli/resources/resource_type.ex
@@ -44,6 +44,9 @@ defmodule Oli.Resources.ResourceType do
   def is_secondary(revision), do: is_type(revision, "secondary")
   def is_tag(revision), do: is_type(revision, "tag")
   def is_bibentry(revision), do: is_type(revision, "bibentry")
+  def is_non_adaptive_page(revision), do: is_type(revision, "page") and !is_adaptive_page(revision)
+  def is_adaptive_page(%{content: %{"advancedAuthoring" => true}}), do: true
+  def is_adaptive_page(_), do: false
 
   schema "resource_types" do
     field :type, :string

--- a/lib/oli/utils/db_seeder.ex
+++ b/lib/oli/utils/db_seeder.ex
@@ -231,7 +231,7 @@ defmodule Oli.Seeder do
   end
 
   def add_adaptive_page(
-        %{project: project, publication: publication, author: author} = seed,
+        %{project: project, publication: publication, author: author, container: container} = seed,
         activity_resource_tag \\ :adaptive_resource,
         activity_revision_tag \\ :adaptive_revision,
         page_resource_tag \\ :adaptive_page_resource,
@@ -316,6 +316,8 @@ defmodule Oli.Seeder do
         author,
         create_sample_adaptive_page_content(activity_revision.resource_id)
       )
+
+    attach_pages_to([page_resource], container.resource, container.revision, publication)
 
     seed
     |> Map.put(page_resource_tag, page_resource)

--- a/lib/oli_web/live/curriculum/container/container_live.ex
+++ b/lib/oli_web/live/curriculum/container/container_live.ex
@@ -257,6 +257,26 @@ defmodule OliWeb.Curriculum.ContainerLive do
     end
   end
 
+  def handle_event("duplicate_page", %{"id" => page_id}, socket) do
+    %{container: container, project: project, author: author} = socket.assigns
+
+    socket =
+      case ContainerEditor.duplicate_page(container, page_id, author, project) do
+        {:ok, _result} ->
+          socket
+
+        {:error, %Ecto.Changeset{} = _changeset} ->
+          socket
+            |> put_flash(:error, "Could not duplicate page")
+      end
+
+    {:noreply,
+      assign(socket,
+        numberings:
+          Numbering.number_full_tree(Oli.Publishing.AuthoringResolver, socket.assigns.project.slug)
+    )}
+  end
+
   def handle_event("HierarchyPicker.update_active", %{"uuid" => uuid}, socket) do
     %{modal: %{assigns: %{hierarchy: hierarchy}} = modal} = socket.assigns
 

--- a/lib/oli_web/live/curriculum/entries/actions.ex
+++ b/lib/oli_web/live/curriculum/entries/actions.ex
@@ -5,6 +5,8 @@ defmodule OliWeb.Curriculum.Actions do
 
   use OliWeb, :live_component
 
+  alias Oli.Resources.ResourceType
+
   def render(assigns) do
     ~L"""
     <div class="entry-actions">
@@ -13,6 +15,9 @@ defmodule OliWeb.Curriculum.Actions do
         <div class="dropdown-menu dropdown-menu-right" id="dropdownMenu_<%= @child.slug %>" aria-labelledby="dropdownMenuButton_<%= @child.slug %>">
           <button type="button" class="dropdown-item" phx-click="show_options_modal" phx-value-slug="<%= @child.slug %>"><i class="las la-sliders-h mr-1"></i> Options</button>
           <button type="button" class="dropdown-item" phx-click="show_move_modal" phx-value-slug="<%= @child.slug %>"><i class="las la-arrow-circle-right mr-1"></i> Move to...</button>
+          <%= if ResourceType.is_non_adaptive_page(@child) do %>
+            <button type="button" class="dropdown-item" phx-click="duplicate_page" phx-value-id="<%= @child.id %>"><i class="las la-copy mr-1"></i> Duplicate</button>
+          <% end %>
           <div class="dropdown-divider"></div>
           <button type="button" class="dropdown-item text-danger" phx-click="show_delete_modal" phx-value-slug="<%= @child.slug %>"><i class="lar la-trash-alt mr-1"></i> Delete</button>
         </div>

--- a/test/oli_web/controllers/resource_controller_test.exs
+++ b/test/oli_web/controllers/resource_controller_test.exs
@@ -88,7 +88,7 @@ defmodule OliWeb.ResourceControllerTest do
   end
 
   describe "preview" do
-    test "renders an adanced lesson preview", %{
+    test "renders an advanced lesson preview", %{
       conn: conn,
       project: project,
       adaptive_page_revision: adaptive_page_revision

--- a/test/oli_web/live/curriculum/container_test.exs
+++ b/test/oli_web/live/curriculum/container_test.exs
@@ -94,7 +94,8 @@ defmodule OliWeb.Curriculum.ContainerLiveTest do
       conn: conn,
       author: author,
       project: project,
-      map: map
+      revision1: revision_page_one,
+      revision2: revision_page_two
     } do
       conn =
         recycle(conn)
@@ -103,25 +104,26 @@ defmodule OliWeb.Curriculum.ContainerLiveTest do
 
       {:ok, view, _html} = live(conn)
 
-      revision_page_one = Map.get(map, :revision1)
-      revision_page_two = Map.get(map, :revision2)
-
       # Duplicate action is present with the right revision id
       assert view
-        |> element("div[phx-value-slug=\"#{revision_page_one.slug}\"] button[phx-click=\"duplicate_page\"]")
-        |> render =~ "phx-value-id=\"#{revision_page_one.id}\""
+             |> element(
+               "div[phx-value-slug=\"#{revision_page_one.slug}\"] button[phx-click=\"duplicate_page\"]"
+             )
+             |> render =~ "phx-value-id=\"#{revision_page_one.id}\""
 
       # Clicking on duplicate action creates a new entry with the right title name
       view
-        |> element("div[phx-value-slug=\"#{revision_page_two.slug}\"] button[phx-click=\"duplicate_page\"]")
-        |> render_click =~ "entry-title\">Copy of #{revision_page_two.title}</span>"
+      |> element(
+        "div[phx-value-slug=\"#{revision_page_two.slug}\"] button[phx-click=\"duplicate_page\"]"
+      )
+      |> render_click =~ "entry-title\">Copy of #{revision_page_two.title}</span>"
     end
 
     test "does not show duplicate action for adaptive pages", %{
       conn: conn,
       author: author,
       project: project,
-      map: map
+      adaptive_page_revision: adaptive_page_revision
     } do
       conn =
         recycle(conn)
@@ -130,24 +132,32 @@ defmodule OliWeb.Curriculum.ContainerLiveTest do
 
       {:ok, view, _html} = live(conn)
 
-      adaptive_page_revision = Map.get(map, :adaptive_page_revision)
-
       assert view
-       |> element("div[phx-value-slug=\"#{adaptive_page_revision.slug}\"]") |> has_element?()
+             |> has_element?("div[phx-value-slug=\"#{adaptive_page_revision.slug}\"]")
 
       refute view
-        |> element("div[phx-value-slug=\"#{adaptive_page_revision.slug}\"] button[phx-click=\"duplicate_page\"]") |> has_element?()
+             |> has_element?(
+               "div[phx-value-slug=\"#{adaptive_page_revision.slug}\"] button[phx-click=\"duplicate_page\"]"
+             )
     end
   end
 
   defp setup_session(%{conn: conn}) do
-    map = Seeder.base_project_with_resource2()
+    map =
+      Seeder.base_project_with_resource2()
       |> Seeder.add_adaptive_page()
 
     conn =
       Plug.Test.init_test_session(conn, lti_session: nil)
       |> Pow.Plug.assign_current_user(map.author, OliWeb.Pow.PowHelpers.get_pow_config(:author))
 
-    {:ok, conn: conn, map: map, author: map.author, project: map.project}
+    {:ok,
+     conn: conn,
+     map: map,
+     author: map.author,
+     project: map.project,
+     adaptive_page_revision: map.adaptive_page_revision,
+     revision1: map.revision1,
+     revision2: map.revision2}
   end
 end

--- a/test/oli_web/live/curriculum/container_test.exs
+++ b/test/oli_web/live/curriculum/container_test.exs
@@ -89,10 +89,60 @@ defmodule OliWeb.Curriculum.ContainerLiveTest do
 
       assert has_element?(view, "span", "#{editing_author.name} is editing")
     end
+
+    test "shows duplicate action for pages", %{
+      conn: conn,
+      author: author,
+      project: project,
+      map: map
+    } do
+      conn =
+        recycle(conn)
+        |> Pow.Plug.assign_current_user(author, OliWeb.Pow.PowHelpers.get_pow_config(:author))
+        |> get("/authoring/project/#{project.slug}/curriculum/")
+
+      {:ok, view, _html} = live(conn)
+
+      revision_page_one = Map.get(map, :revision1)
+      revision_page_two = Map.get(map, :revision2)
+
+      # Duplicate action is present with the right revision id
+      assert view
+        |> element("div[phx-value-slug=\"#{revision_page_one.slug}\"] button[phx-click=\"duplicate_page\"]")
+        |> render =~ "phx-value-id=\"#{revision_page_one.id}\""
+
+      # Clicking on duplicate action creates a new entry with the right title name
+      view
+        |> element("div[phx-value-slug=\"#{revision_page_two.slug}\"] button[phx-click=\"duplicate_page\"]")
+        |> render_click =~ "entry-title\">Copy of #{revision_page_two.title}</span>"
+    end
+
+    test "does not show duplicate action for adaptive pages", %{
+      conn: conn,
+      author: author,
+      project: project,
+      map: map
+    } do
+      conn =
+        recycle(conn)
+        |> Pow.Plug.assign_current_user(author, OliWeb.Pow.PowHelpers.get_pow_config(:author))
+        |> get("/authoring/project/#{project.slug}/curriculum/")
+
+      {:ok, view, _html} = live(conn)
+
+      adaptive_page_revision = Map.get(map, :adaptive_page_revision)
+
+      assert view
+       |> element("div[phx-value-slug=\"#{adaptive_page_revision.slug}\"]") |> has_element?()
+
+      refute view
+        |> element("div[phx-value-slug=\"#{adaptive_page_revision.slug}\"] button[phx-click=\"duplicate_page\"]") |> has_element?()
+    end
   end
 
   defp setup_session(%{conn: conn}) do
     map = Seeder.base_project_with_resource2()
+      |> Seeder.add_adaptive_page()
 
     conn =
       Plug.Test.init_test_session(conn, lti_session: nil)


### PR DESCRIPTION
[MER-1216](https://eliterate.atlassian.net/browse/MER-1216)

### What does it change?

- Adds ability to duplicate a page within a project, in the curriuculum overview page.

We're running a deepy copy of resources revisoins of the page (and of its embedded activities). 
The option is only enababled for pages, not including adaptive ones, which are going to be worked on separately. 

#### Screenshots

<img width="1170" alt="image" src="https://user-images.githubusercontent.com/22042418/178325611-2a2b5b55-4a72-4c3b-ad90-4706a5f438b3.png">

