### PR TITLE
[BUGFIX] needed to escape the dot to include it

### DIFF
--- a/assets/src/adaptivity/scripting.ts
+++ b/assets/src/adaptivity/scripting.ts
@@ -505,11 +505,11 @@ export const extractAllExpressionsFromText = (text: string): string[] => {
 };
 
 export const variableContainsValidPrefix = (variable: string): boolean => {
-  return variable.search(/app.|variables.|stage.|session./) !== -1;
+  return variable.search(/app\.|variables\.|stage\.|session\./) !== -1;
 };
 
 export const containsExactlyOneVariable = (text: string): boolean => {
-  const m = text.match(/app.|variables.|stage.|session./g);
+  const m = text.match(/app\.|variables\.|stage\.|session\./g);
   return !!(m && m.length === 1);
 };
 


### PR DESCRIPTION
causing some variables like `app.spr-app-whatever.foo` to register as having multiple prefixes