### PR TITLE
[BUGFIX] [MER-1324] Replace get_user to get_author

### DIFF
--- a/lib/oli/utils/db_seeder.ex
+++ b/lib/oli/utils/db_seeder.ex
@@ -207,7 +207,7 @@ defmodule Oli.Seeder do
 
     create_published_resource(publication, container_resource, container_revision)
 
-    %{resource: page1, revision: revision1} =
+    %{resource: page1, revision: revision1, published_resource: published_resource1} =
       create_page("Page one", publication, project, author)
 
     %{resource: page2, revision: revision2} =
@@ -227,6 +227,7 @@ defmodule Oli.Seeder do
     |> Map.put(:page2, page2)
     |> Map.put(:revision1, revision1)
     |> Map.put(:revision2, revision2)
+    |> Map.put(:published_resource1, published_resource1)
   end
 
   def add_adaptive_page(
@@ -758,9 +759,9 @@ defmodule Oli.Seeder do
       })
       |> Repo.insert()
 
-    create_published_resource(publication, resource, revision)
+    {:ok, published_resource} = create_published_resource(publication, resource, revision)
 
-    %{resource: resource, revision: revision}
+    %{resource: resource, revision: revision, published_resource: published_resource}
   end
 
   def create_container(title, publication, project, author, children \\ []) do

--- a/lib/oli_web/live/curriculum/container/container_live.ex
+++ b/lib/oli_web/live/curriculum/container/container_live.ex
@@ -683,9 +683,7 @@ defmodule OliWeb.Curriculum.ContainerLive do
     # latest active publication_id would need to be tracked in the assigns and updated if a project is published.
     # Same thing applies to the :lock_released handler below.
     if Publishing.get_unpublished_publication_id!(project_id) == publication_id do
-      author =
-        Accounts.get_user!(author_id)
-        |> Repo.preload(:author)
+      author = Accounts.get_author(author_id)
 
       new_resources_being_edited = Map.put(resources_being_edited, resource_id, author)
       {:noreply, assign(socket, resources_being_edited: new_resources_being_edited)}

--- a/test/oli_web/live/curriculum/container_test.exs
+++ b/test/oli_web/live/curriculum/container_test.exs
@@ -1,11 +1,39 @@
 defmodule OliWeb.Curriculum.ContainerLiveTest do
   use OliWeb.ConnCase
+
   alias Oli.Seeder
+  alias Oli.Publishing
   alias Oli.Publishing.AuthoringResolver
 
+  import Oli.Factory
   import Phoenix.ConnTest
   import Phoenix.LiveViewTest
+
   @endpoint OliWeb.Endpoint
+
+  describe "cannot access when is not logged in" do
+    test "redirect to new session when accessing the container view", %{conn: conn} do
+      project = insert(:project)
+
+      redirect_path = "/authoring/session/new?request_path=%2Fauthoring%2Fproject%2F#{project.slug}%2Fcurriculum"
+
+      {:error, {:redirect, %{to: ^redirect_path}}} =
+        live(conn, Routes.container_path(@endpoint, :index, project.slug))
+    end
+  end
+
+  describe "cannot access when is not an author" do
+    setup [:user_conn]
+
+    test "redirect to new session when accessing the container view", %{conn: conn} do
+      project = insert(:project)
+
+      redirect_path = "/authoring/session/new?request_path=%2Fauthoring%2Fproject%2F#{project.slug}%2Fcurriculum"
+
+      {:error, {:redirect, %{to: ^redirect_path}}} =
+        live(conn, Routes.container_path(@endpoint, :index, project.slug))
+    end
+  end
 
   describe "container live test" do
     setup [:setup_session]
@@ -41,6 +69,25 @@ defmodule OliWeb.Curriculum.ContainerLiveTest do
 
       assert view |> element("##{Integer.to_string(page1.id)}") |> has_element?()
       assert view |> element("##{Integer.to_string(page2.id)}") |> has_element?()
+    end
+
+    test "shows the author name editing the page correctly", %{
+      conn: conn,
+      project: project,
+      map: %{
+        published_resource1: published_resource1
+      }
+    } do
+      editing_author = insert(:author)
+
+      Publishing.update_published_resource(published_resource1, %{
+        locked_by_id: editing_author.id,
+        lock_updated_at: now()
+      })
+
+      {:ok, view, _} = live(conn, Routes.container_path(@endpoint, :index, project.slug))
+
+      assert has_element?(view, "span", "#{editing_author.name} is editing")
     end
   end
 


### PR DESCRIPTION
[MER-1324](https://eliterate.atlassian.net/browse/MER-1324)

After locking the page and broadcasting the `lock_acquired` message, the `handle_info` in `ContainerLive` was going to the users table with the author id, so if you were other author looking at the same project, you were seeing the user's name that corresponds to the author id. Doesn't even make sense to have that there since it's an author view.