### PR TITLE
[FEATURE] track session identifier in part attempt for datashop

### DIFF
--- a/lib/oli/accounts.ex
+++ b/lib/oli/accounts.ex
@@ -167,6 +167,26 @@ defmodule Oli.Accounts do
   def get_user_by(clauses), do: Repo.get_by(User, clauses)
 
   @doc """
+  Gets a single user with platform roles and author preloaded
+  Returns `nil` if the User does not exist.
+  ## Examples
+      iex> get_user_with_roles(123)
+      %User{}
+      iex> get_user_with_roles(456)
+      nil
+
+  """
+  def get_user_with_roles(id) do
+    from(user in User,
+      where: user.id == ^id,
+      left_join: platform_roles in assoc(user, :platform_roles),
+      left_join: author in assoc(user, :author),
+      preload: [platform_roles: platform_roles, author: author]
+    )
+    |> Repo.one()
+  end
+
+  @doc """
   Creates a user.
   ## Examples
       iex> create_user(%{field: value})

--- a/lib/oli/delivery/attempts/activity_lifecycle.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle.ex
@@ -86,7 +86,12 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle do
 
   `{:error, {:not_found}}`
   """
-  def reset_activity(section_slug, activity_attempt_guid, seed_state_from_previous \\ false) do
+  def reset_activity(
+        section_slug,
+        activity_attempt_guid,
+        datashop_session_id,
+        seed_state_from_previous \\ false
+      ) do
     Repo.transaction(fn ->
       activity_attempt = get_activity_attempt_by(attempt_guid: activity_attempt_guid)
 
@@ -152,7 +157,8 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle do
                             part_id: p.part_id,
                             grading_approach: p.grading_approach,
                             response: response,
-                            activity_attempt_id: new_activity_attempt.id
+                            activity_attempt_id: new_activity_attempt.id,
+                            datashop_session_id: datashop_session_id
                           }) do
                        {:ok, part_attempt} -> {:cont, {:ok, acc ++ [part_attempt]}}
                        {:error, changeset} -> {:halt, {:error, changeset}}

--- a/lib/oli/delivery/attempts/core/part_attempt.ex
+++ b/lib/oli/delivery/attempts/core/part_attempt.ex
@@ -17,6 +17,7 @@ defmodule Oli.Delivery.Attempts.Core.PartAttempt do
     field(:feedback, :map)
     field(:hints, {:array, :string}, default: [])
     field(:part_id, :string)
+    field(:datashop_session_id, :string)
 
     belongs_to(:activity_attempt, Oli.Delivery.Attempts.Core.ActivityAttempt)
 
@@ -39,8 +40,15 @@ defmodule Oli.Delivery.Attempts.Core.PartAttempt do
       :feedback,
       :hints,
       :part_id,
+      :datashop_session_id,
       :activity_attempt_id
     ])
-    |> validate_required([:attempt_guid, :attempt_number, :part_id, :activity_attempt_id])
+    |> validate_required([
+      :attempt_guid,
+      :attempt_number,
+      :part_id,
+      :activity_attempt_id,
+      :datashop_session_id
+    ])
   end
 end

--- a/lib/oli/delivery/attempts/page_lifecycle.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle.ex
@@ -44,7 +44,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle do
   `{:error, {:no_more_attempts}}` if no more attempts are present
 
   """
-  def start(revision_slug, section_slug, user_id, activity_provider) do
+  def start(revision_slug, section_slug, datashop_session_id, user_id, activity_provider) do
     Repo.transaction(fn ->
       case DeliveryResolver.from_revision_slug(section_slug, revision_slug) do
         nil ->
@@ -64,6 +64,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle do
             page_revision: page_revision,
             section_slug: section_slug,
             user_id: user_id,
+            datashop_session_id: datashop_session_id,
             activity_provider: activity_provider
           }
 
@@ -96,13 +97,14 @@ defmodule Oli.Delivery.Attempts.PageLifecycle do
 
   `{:ok, {:not_started, %HistorySummary{}}}`
   """
-  @spec visit(%Revision{}, String.t(), number(), any) ::
+  @spec visit(%Revision{}, String.t(), String.t(), number(), any) ::
           {:ok, {:in_progress | :revised, %AttemptState{}}}
           | {:ok, {:not_started, %HistorySummary{}}}
           | {:error, any}
   def visit(
         page_revision,
         section_slug,
+        datashop_session_id,
         user_id,
         activity_provider
       ) do
@@ -121,6 +123,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle do
         page_revision: page_revision,
         section_slug: section_slug,
         user_id: user_id,
+        datashop_session_id: datashop_session_id,
         activity_provider: activity_provider
       }
 

--- a/lib/oli/delivery/attempts/page_lifecycle/visit_context.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/visit_context.ex
@@ -18,6 +18,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.VisitContext do
     :page_revision,
     :section_slug,
     :user_id,
+    :datashop_session_id,
     :activity_provider
   ]
 
@@ -28,6 +29,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.VisitContext do
     :page_revision,
     :section_slug,
     :user_id,
+    :datashop_session_id,
     :activity_provider
   ]
 
@@ -38,6 +40,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.VisitContext do
           page_revision: %Oli.Resources.Revision{},
           section_slug: String.t(),
           user_id: integer,
+          datashop_session_id: String.t() | nil,
           activity_provider: any()
         }
 end

--- a/lib/oli/delivery/page/page_context.ex
+++ b/lib/oli/delivery/page/page_context.ex
@@ -102,7 +102,8 @@ defmodule Oli.Delivery.Page.PageContext do
   def create_for_visit(
         %Section{slug: section_slug, id: section_id},
         page_slug,
-        user
+        user,
+        datashop_session_id
       ) do
     # resolve the page revision per section
     page_revision = DeliveryResolver.from_revision_slug(section_slug, page_slug)
@@ -115,6 +116,7 @@ defmodule Oli.Delivery.Page.PageContext do
       case PageLifecycle.visit(
              page_revision,
              section_slug,
+             datashop_session_id,
              user.id,
              activity_provider
            ) do

--- a/lib/oli_web/controllers/api/attempt_controller.ex
+++ b/lib/oli_web/controllers/api/attempt_controller.ex
@@ -584,8 +584,14 @@ defmodule OliWeb.Api.AttemptController do
         } = params
       ) do
     seed_state_from_previous = Map.get(params, "seedResponsesWithPrevious", false)
+    datashop_session_id = Plug.Conn.get_session(conn, :datashop_session_id)
 
-    case Activity.reset_activity(section_slug, activity_attempt_guid, seed_state_from_previous) do
+    case Activity.reset_activity(
+           section_slug,
+           activity_attempt_guid,
+           datashop_session_id,
+           seed_state_from_previous
+         ) do
       {:ok, {attempt_state, model}} ->
         json(conn, %{"type" => "success", "attemptState" => attempt_state, "model" => model})
 

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -217,9 +217,10 @@ defmodule OliWeb.PageDeliveryController do
   def page(conn, %{"section_slug" => section_slug, "revision_slug" => revision_slug}) do
     user = conn.assigns.current_user
     section = conn.assigns.section
+    datashop_session_id = Plug.Conn.get_session(conn, :datashop_session_id)
 
     if Sections.is_enrolled?(user.id, section_slug) do
-      PageContext.create_for_visit(section, revision_slug, user)
+      PageContext.create_for_visit(section, revision_slug, user, datashop_session_id)
       |> render_page(conn, section_slug, user, false)
     else
       render(conn, "not_authorized.html")
@@ -235,7 +236,7 @@ defmodule OliWeb.PageDeliveryController do
     section = conn.assigns.section
 
     if Sections.is_instructor?(user, section_slug) do
-      PageContext.create_for_visit(section, revision.slug, user)
+      PageContext.create_for_visit(section, revision.slug, user, nil)
       |> render_page(conn, section_slug, user, true)
     else
       render(conn, "not_authorized.html")
@@ -605,6 +606,7 @@ defmodule OliWeb.PageDeliveryController do
   def start_attempt(conn, %{"section_slug" => section_slug, "revision_slug" => revision_slug}) do
     user = conn.assigns.current_user
     section = conn.assigns.section
+    datashop_session_id = Plug.Conn.get_session(conn, :datashop_session_id)
 
     activity_provider = &Oli.Delivery.ActivityProvider.provide/3
 
@@ -619,6 +621,7 @@ defmodule OliWeb.PageDeliveryController do
           case PageLifecycle.start(
                  revision_slug,
                  section_slug,
+                 datashop_session_id,
                  user.id,
                  activity_provider
                ) do
@@ -709,7 +712,8 @@ defmodule OliWeb.PageDeliveryController do
 
   def after_finalized(conn, section_slug, revision_slug, attempt_guid, user) do
     section = conn.assigns.section
-    context = PageContext.create_for_visit(section, revision_slug, user)
+    datashop_session_id = Plug.Conn.get_session(conn, :datashop_session_id)
+    context = PageContext.create_for_visit(section, revision_slug, user, datashop_session_id)
 
     preview_mode = Map.get(conn.assigns, :preview_mode, false)
 

--- a/priv/repo/migrations/20220712214321_datashop_session_id.exs
+++ b/priv/repo/migrations/20220712214321_datashop_session_id.exs
@@ -1,0 +1,9 @@
+defmodule Oli.Repo.Migrations.DatashopSessionId do
+  use Ecto.Migration
+
+  def change do
+    alter table(:part_attempts) do
+      add :datashop_session_id, :string
+    end
+  end
+end


### PR DESCRIPTION
Adds the concept of a datashop session identifier to part attempts.

- [ ] Generate a unique datashop session id on every new session and track in the part attempt record
- [ ] Export datashop session identifier as part of the part attempts in the datashop export
- [ ] Unit tests