### PR TITLE
[MER-1308] List styling

### DIFF
--- a/assets/src/components/editing/editor/modelEditorDispatch.tsx
+++ b/assets/src/components/editing/editor/modelEditorDispatch.tsx
@@ -56,9 +56,17 @@ export function editorFor(
     case 'img_inline':
       return <ImageInlineEditor {...(editorProps as EditorProps<ContentModel.ImageInline>)} />;
     case 'ol':
-      return <ol {...attributes}>{children}</ol>;
+      return (
+        <ol className={listClassName(model.style)} {...attributes}>
+          {children}
+        </ol>
+      );
     case 'ul':
-      return <ul {...attributes}>{children}</ul>;
+      return (
+        <ul className={listClassName(model.style)} {...attributes}>
+          {children}
+        </ul>
+      );
     case 'li':
       return <li {...attributes}>{children}</li>;
     case 'callout':
@@ -108,6 +116,8 @@ export function editorFor(
       return <span>{children}</span>;
   }
 }
+
+const listClassName = (style?: string): string | undefined => (style ? `list-${style}` : undefined);
 
 export function markFor(mark: Mark, children: any): JSX.Element {
   switch (mark) {

--- a/assets/src/components/editing/elements/callout/calloutActions.ts
+++ b/assets/src/components/editing/elements/callout/calloutActions.ts
@@ -1,10 +1,4 @@
-import { toggleCodeblock } from 'components/editing/elements/blockcode/codeblockActions';
-import { toggleBlockquote } from 'components/editing/elements/blockquote/blockquoteActions';
 import { createButtonCommandDesc } from 'components/editing/elements/commands/commandFactories';
-import { switchType } from 'components/editing/elements/commands/toggleTextTypes';
-import { toggleHeading } from 'components/editing/elements/heading/headingActions';
-import { toggleUnorderedList } from 'components/editing/elements/list/listActions';
-import { isActive } from 'components/editing/slateUtils';
 import { Transforms } from 'slate';
 import { Model } from '../../../../data/content/model/elements/factories';
 

--- a/assets/src/components/editing/elements/list/listActions.ts
+++ b/assets/src/components/editing/elements/list/listActions.ts
@@ -2,9 +2,16 @@ import { handleOutdent, handleIndent } from 'components/editing/editor/handlers/
 import { createButtonCommandDesc } from 'components/editing/elements/commands/commandFactories';
 import { Command, CommandDescription } from 'components/editing/elements/commands/interfaces';
 import { switchType } from 'components/editing/elements/commands/toggleTextTypes';
-import { isActive, isTopLevel } from 'components/editing/slateUtils';
+import { isActive, isPropActive, isTopLevel } from 'components/editing/slateUtils';
+
 import { Transforms, Editor, Element } from 'slate';
 import guid from 'utils/guid';
+import {
+  OrderedListStyle,
+  OrderedListStyles,
+  UnorderdListStyles,
+  UnorderedListStyle,
+} from '../../../../data/content/model/elements/types';
 
 const listCommandMaker = (listType: 'ul' | 'ol'): Command => {
   return {
@@ -71,6 +78,57 @@ export const toggleOrderedList: CommandDescription = {
   active: (editor) => isActive(editor, ['ol']),
 };
 
+const listStyleLabels: Record<OrderedListStyle | UnorderedListStyle, string> = {
+  none: 'No Bullet',
+  decimal: 'Decimal - 1',
+  'decimal-leading-zero': 'Decimal w/ Zero - 01',
+  'lower-roman': 'Lower Roman - i',
+  'upper-roman': 'Upper Roman - I',
+  'lower-alpha': 'Lower Alpha - a',
+  'upper-alpha': 'Upper Alpha - A',
+  // 'lower-latin': 'Lower Latin - a', // These are the same as -alpha, no need to have both in the menu
+  // 'upper-latin': 'Upper Latin - A', // but we do support rendering both for legacy content.
+  disc: 'Disc - •',
+  circle: 'Circle - ○',
+  square: 'Square - ■',
+};
+
+export const unorderedListStyleCommands = UnorderdListStyles.map((styleType: string) =>
+  createButtonCommandDesc({
+    icon: 'list_alt',
+    description: listStyleLabels[styleType],
+    active: (editor) => isPropActive(editor, 'ul', { style: styleType }),
+    execute: (_ctx, editor) => {
+      const [, at] = [...Editor.nodes(editor)][1];
+      Transforms.setNodes(
+        editor,
+        { style: styleType },
+        { at, match: (e) => Element.isElement(e) && isList(e), mode: 'all' },
+      );
+    },
+  }),
+);
+
+// The two -latin options don't need menu options since they are the same as -alpha
+const notLatinOption = (styleType: string) => styleType.indexOf('latin') === -1;
+
+export const orderedListStyleCommands = OrderedListStyles.filter(notLatinOption).map(
+  (styleType: string) =>
+    createButtonCommandDesc({
+      icon: 'list_alt',
+      description: listStyleLabels[styleType],
+      active: (editor) => isPropActive(editor, 'ol', { style: styleType }),
+      execute: (_ctx, editor) => {
+        const [, at] = [...Editor.nodes(editor)][1];
+        Transforms.setNodes(
+          editor,
+          { style: styleType },
+          { at, match: (e) => Element.isElement(e) && isList(e), mode: 'all' },
+        );
+      },
+    }),
+);
+
 export const listSettings = [
   createButtonCommandDesc({
     icon: 'format_list_bulleted',
@@ -80,7 +138,7 @@ export const listSettings = [
       const [, at] = [...Editor.nodes(editor)][1];
       Transforms.setNodes(
         editor,
-        { type: 'ul' },
+        { type: 'ul', style: undefined },
         { at, match: (e) => Element.isElement(e) && e.type === 'ol', mode: 'all' },
       );
     },
@@ -93,7 +151,7 @@ export const listSettings = [
       const [, at] = [...Editor.nodes(editor)][1];
       Transforms.setNodes(
         editor,
-        { type: 'ol' },
+        { type: 'ol', style: undefined },
         { at, match: (e) => Element.isElement(e) && e.type === 'ul', mode: 'all' },
       );
     },
@@ -111,6 +169,8 @@ export const listSettings = [
     execute: (_ctx, editor) => handleIndent(editor),
   }),
 ];
+
+const isList = (e: Element): boolean => ['ul', 'ol'].indexOf(e.type) !== -1;
 
 function isActiveList(editor: Editor) {
   return isActive(editor, ['ul', 'ol']);

--- a/assets/src/components/editing/slateUtils.tsx
+++ b/assets/src/components/editing/slateUtils.tsx
@@ -117,3 +117,43 @@ export const isActive = (editor: Editor, type: string | string[]) => {
   });
   return !!match;
 };
+
+/**
+ * Returns true if all the properties in propMap match properties in node.
+ *
+ * Examples:
+ *   containsProps({a: 5}, {a: 5}) => true
+ *   containsProps({a: 5, b: 5}, {a: 5}) => true, extra params in node don't matter
+ *   containsProps({a: 5}, {a: 6}) => false, a doesn't equal
+ *   containsProps({a: 5}, {a: 5, b: 6}) => false, b is not in node
+ */
+const containsProps = (node: any, propMap: Record<string, string>): boolean => {
+  return Object.keys(propMap).reduce((result, currentKey) => {
+    return result && node[currentKey] === propMap[currentKey];
+  }, true);
+};
+
+/**
+ * Returns true if a specific property (or set of properties) are currently active.
+ *
+ * Example:
+ *   Do we currently have an image selected with the given src:
+ *     isPropActive(editor, "img", { src: 'http://example.com/image.jpg' })
+ *
+ *   Do we currently have a list selected with the given style?
+ *     isPropActive(editor, ["ul", "ol"], { style: 'disc' })
+ *
+ */
+export const isPropActive = (
+  editor: Editor,
+  type: string | string[],
+  propMap: Record<string, string>,
+) => {
+  const [match] = Editor.nodes(editor, {
+    match: (n) =>
+      Element.isElement(n) &&
+      (typeof type === 'string' ? n.type === type : type.indexOf(n.type as string) > -1) &&
+      containsProps(n, propMap),
+  });
+  return !!match;
+};

--- a/assets/src/components/editing/toolbar/editorToolbar/ListStyleToggle.tsx
+++ b/assets/src/components/editing/toolbar/editorToolbar/ListStyleToggle.tsx
@@ -1,0 +1,34 @@
+import { DescriptiveButton } from 'components/editing/toolbar/buttons/DescriptiveButton';
+import { DropdownButton } from 'components/editing/toolbar/buttons/DropdownButton';
+
+import React from 'react';
+
+import { CommandDescription } from 'components/editing/elements/commands/interfaces';
+import { createButtonCommandDesc } from '../../elements/commands/commandFactories';
+
+interface ListStyleProps {
+  listStyleOptions: CommandDescription[];
+}
+
+/**
+ * The drop-down menu that lets you pick a list style in the editor. There are different
+ * styles for ordered and unordered lists, so pass in an appropriate listStyleOptions for
+ * the current list type.
+ */
+export const ListStyleToggle = ({ listStyleOptions }: ListStyleProps) => {
+  if (listStyleOptions.length === 0) return null;
+  return (
+    <DropdownButton
+      description={createButtonCommandDesc({
+        icon: 'list_alt',
+        description: 'List Style',
+        active: (_editor) => false,
+        execute: (_ctx, _editor) => null,
+      })}
+    >
+      {listStyleOptions.map((desc, i) => (
+        <DescriptiveButton key={i} description={desc} />
+      ))}
+    </DropdownButton>
+  );
+};

--- a/assets/src/components/editing/toolbar/editorToolbar/blocks/BlockSettings.tsx
+++ b/assets/src/components/editing/toolbar/editorToolbar/blocks/BlockSettings.tsx
@@ -5,16 +5,21 @@ import {
   headingLevelDesc,
   headingTypeDescs,
 } from 'components/editing/elements/heading/headingActions';
-import { listSettings } from 'components/editing/elements/list/listActions';
+import {
+  listSettings,
+  orderedListStyleCommands,
+  unorderedListStyleCommands,
+} from 'components/editing/elements/list/listActions';
 import { CommandButton } from 'components/editing/toolbar/buttons/CommandButton';
 import { DescriptiveButton } from 'components/editing/toolbar/buttons/DescriptiveButton';
 import { DropdownButton } from 'components/editing/toolbar/buttons/DropdownButton';
 import { Toolbar } from 'components/editing/toolbar/Toolbar';
-import { getHighestTopLevel } from 'components/editing/slateUtils';
+import { getHighestTopLevel, isActive } from 'components/editing/slateUtils';
 import React from 'react';
 import { Editor, Element, Transforms } from 'slate';
 import { useSlate } from 'slate-react';
 import { activeBlockType } from 'components/editing/toolbar/toolbarUtils';
+import { ListStyleToggle } from '../ListStyleToggle';
 
 interface BlockSettingProps {}
 export const BlockSettings = (_props: BlockSettingProps) => {
@@ -34,11 +39,17 @@ export const BlockSettings = (_props: BlockSettingProps) => {
 };
 
 function List() {
+  const editor = useSlate();
+  const formatOptions = isActive(editor, ['ol'])
+    ? orderedListStyleCommands
+    : unorderedListStyleCommands;
+
   return (
     <>
       {listSettings.map((desc, i) => (
         <CommandButton key={i} description={desc} />
       ))}
+      <ListStyleToggle listStyleOptions={formatOptions} />
     </>
   );
 }

--- a/assets/src/data/content/model/elements/types.ts
+++ b/assets/src/data/content/model/elements/types.ts
@@ -68,13 +68,31 @@ export interface HeadingSix extends SlateElement<HeadingChildren> {
   type: 'h6';
 }
 
+export const OrderedListStyles = [
+  'none',
+  'decimal',
+  'decimal-leading-zero',
+  'lower-roman',
+  'upper-roman',
+  'lower-alpha',
+  'upper-alpha',
+  'lower-latin',
+  'upper-latin',
+] as const;
+export type OrderedListStyle = typeof OrderedListStyles[number];
+
+export const UnorderdListStyles = ['none', 'disc', 'circle', 'square'];
+export type UnorderedListStyle = typeof UnorderdListStyles[number];
+
 type ListChildren = (ListItem | OrderedList | UnorderedList | Text)[];
 export interface OrderedList extends SlateElement<ListChildren> {
   type: 'ol';
+  style?: OrderedListStyle;
 }
 
 export interface UnorderedList extends SlateElement<ListChildren> {
   type: 'ul';
+  style?: UnorderedListStyle;
 }
 
 type VoidChildren = Text[];

--- a/assets/src/data/content/writers/html.tsx
+++ b/assets/src/data/content/writers/html.tsx
@@ -224,11 +224,11 @@ export class HtmlParser implements WriterImpl {
   td(context: WriterContext, next: Next, _x: TableData) {
     return <td>{next()}</td>;
   }
-  ol(context: WriterContext, next: Next, _x: OrderedList) {
-    return <ol>{next()}</ol>;
+  ol(context: WriterContext, next: Next, item: OrderedList) {
+    return item.style ? <ol className={`list-${item.style}`}>{next()}</ol> : <ol>{next()}</ol>;
   }
-  ul(context: WriterContext, next: Next, _x: UnorderedList) {
-    return <ul>{next()}</ul>;
+  ul(context: WriterContext, next: Next, item: UnorderedList) {
+    return item.style ? <ul className={`list-${item.style}`}>{next()}</ul> : <ul>{next()}</ul>;
   }
   li(context: WriterContext, next: Next, _x: ListItem) {
     return <li>{next()}</li>;

--- a/assets/styles/common/index.scss
+++ b/assets/styles/common/index.scss
@@ -16,3 +16,4 @@
 @import 'survey.scss';
 @import 'user.scss';
 @import 'utils.scss';
+@import 'list.scss';

--- a/assets/styles/common/list.scss
+++ b/assets/styles/common/list.scss
@@ -1,0 +1,40 @@
+ul.list-square {
+  list-style: square;
+}
+ul.list-circle {
+  list-style: circle;
+}
+ul.list-disc {
+  list-style: disc;
+}
+ul.list-none {
+  list-style: none;
+}
+
+ol.list-none {
+  list-style: none;
+}
+ol.list-decimal {
+  list-style: decimal;
+}
+ol.list-decimal-leading-zero {
+  list-style: decimal-leading-zero;
+}
+ol.list-lower-roman {
+  list-style: lower-roman;
+}
+ol.list-upper-roman {
+  list-style: upper-roman;
+}
+ol.list-lower-alpha {
+  list-style: lower-alpha;
+}
+ol.list-upper-alpha {
+  list-style: upper-alpha;
+}
+ol.list-lower-latin {
+  list-style: lower-latin;
+}
+ol.list-upper-latin {
+  list-style: upper-latin;
+}

--- a/assets/styles/themes/authoring/default.scss
+++ b/assets/styles/themes/authoring/default.scss
@@ -496,10 +496,10 @@ html.authoring.dark {
   .editorToolbar {
     border-top: 1px solid $body-color;
     border-bottom: 1px solid $body-color;
-    background: $body-bg;
+    background: $gray-400;
 
     &__group {
-      background: $body-bg;
+      background: $gray-400;
       border-left: 1px solid $body-color;
     }
     &__group:last-of-type {
@@ -508,11 +508,11 @@ html.authoring.dark {
 
     &__dropdownGroup {
       border: 1px solid $body-color;
-      background: $body-bg;
+      background: $gray-400;
     }
 
     &__button {
-      background: $body-bg;
+      background: $gray-400;
 
       &--descriptive {
         &:hover {

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -153,8 +153,16 @@ defmodule Oli.Rendering.Content.Html do
     ["<td>", next.(), "</td>\n"]
   end
 
+  def ol(%Context{} = _context, next, %{"style" => style}) do
+    ["<ol class=\"list-#{style}\">", next.(), "</ol>\n"]
+  end
+
   def ol(%Context{} = _context, next, _) do
     ["<ol>", next.(), "</ol>\n"]
+  end
+
+  def ul(%Context{} = _context, next, %{"style" => style}) do
+    ["<ul class=\"list-#{style}\">", next.(), "</ul>\n"]
   end
 
   def ul(%Context{} = _context, next, _) do

--- a/priv/schemas/v0-1-0/content-element.schema.json
+++ b/priv/schemas/v0-1-0/content-element.schema.json
@@ -276,6 +276,19 @@
         "type": {
           "const": "ol"
         },
+        "style": {
+          "oneOf": [
+            { "const": "none" },
+            { "const": "decimal" },
+            { "const": "decimal-leading-zero" },
+            { "const": "lower-roman" },
+            { "const": "upper-roman" },
+            { "const": "lower-alpha" },
+            { "const": "upper-alpha" },
+            { "const": "lower-latin" },
+            { "const": "upper-latin" }
+          ]
+        },
         "children": {
           "type": "array",
           "items": {
@@ -297,6 +310,14 @@
       "properties": {
         "type": {
           "const": "ul"
+        },
+        "style": {
+          "oneOf": [
+            { "const": "none" },
+            { "const": "disc" },
+            { "const": "circle" },
+            { "const": "square" }
+          ]
         },
         "children": {
           "type": "array",


### PR DESCRIPTION
Adds ability to set your bullet-style on ordered and unordered lists. While in core-authoring editor, there is a new menu option for lists that opens a sub-menu with the different styles.

The content-model was changed to add a style prop to the list element

```
{
type: 'ul',
style: 'square'
...
}
```

Fixes #2743

Example styles:
![image](https://user-images.githubusercontent.com/333265/179020458-747f88a0-abf3-45cb-9e6c-9039af989e86.png)
![image](https://user-images.githubusercontent.com/333265/179020474-193f193c-3661-4455-9e83-771d0fd0e52c.png)
![image](https://user-images.githubusercontent.com/333265/179020497-f23b8d2f-b47d-4ea3-9b31-d14cf5c06368.png)

Example editor controls:
![image](https://user-images.githubusercontent.com/333265/179020622-ed692e43-2099-413a-a00b-b009da74a10d.png)
![image](https://user-images.githubusercontent.com/333265/179020674-d7ebd720-da6e-43b0-a43c-8a55f2ca4dbb.png)


