### PR TITLE
[MER-1206] Display only two decimal points in grading scores

### DIFF
--- a/lib/oli_web/live/common/utils.ex
+++ b/lib/oli_web/live/common/utils.ex
@@ -66,8 +66,7 @@ defmodule OliWeb.Common.Utils do
   """
   @spec format_score(float) :: float
   def format_score(score) when is_float(score) do
-    formatted_score = Float.round(score, 2)
-    if score - formatted_score != 0.0, do: formatted_score, else: score
+    Float.round(score, 2)
   end
 
   defp has_value(v) do

--- a/lib/oli_web/live/common/utils.ex
+++ b/lib/oli_web/live/common/utils.ex
@@ -36,12 +36,39 @@ defmodule OliWeb.Common.Utils do
     render_date_with_opts(item, attr_name, opts)
   end
 
+  @spec render_precise_date(map, any, any) :: binary
   def render_precise_date(item, attr_name, context) do
     opts = [context: context, precision: :minutes]
     render_date_with_opts(item, attr_name, opts)
   end
 
   def render_date_with_opts(item, attr_name, opts), do: date(Map.get(item, attr_name), opts)
+
+  @doc """
+    Rounds up a grading score to two significant figures.
+    For numbers with no decimals, or non-significant zeros after the comma, it keeps only one zero
+
+    ## Examples
+    iex> format_score(200.0)
+    200.0
+
+    iex> format_score(120.2333)
+    120.23
+
+    iex> format_score(88.00)
+    88.0
+
+    iex> format_score(78.479)
+    78.48
+
+    iex> format_score(0.0)
+    0.0
+  """
+  @spec format_score(float) :: float
+  def format_score(score) when is_float(score) do
+    formatted_score = Float.round(score, 2)
+    if score - formatted_score != 0.0, do: formatted_score, else: score
+  end
 
   defp has_value(v) do
     !is_nil(v) and v != ""

--- a/lib/oli_web/live/grades/gradebook_table_model.ex
+++ b/lib/oli_web/live/grades/gradebook_table_model.ex
@@ -1,6 +1,9 @@
 defmodule OliWeb.Grades.GradebookTableModel do
-  alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
+
   use Surface.LiveComponent
+
+  alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
+  alias OliWeb.Common.Utils
   alias Oli.Delivery.Attempts.Core.ResourceAccess
   alias OliWeb.Router.Helpers, as: Routes
 
@@ -105,7 +108,7 @@ defmodule OliWeb.Grades.GradebookTableModel do
         if is_nil(score) do
           "?"
         else
-          score
+          Utils.format_score(score)
         end
 
       safe_out_of =

--- a/lib/oli_web/live/progress/page_attempt_summary.ex
+++ b/lib/oli_web/live/progress/page_attempt_summary.ex
@@ -35,7 +35,7 @@ defmodule OliWeb.Progress.PageAttemptSummary do
       <a href={Routes.instructor_review_path(OliWeb.Endpoint, :review_attempt, @section.slug, @attempt.attempt_guid)}>
         <div class="d-flex w-100 justify-content-between">
           <h5 class="mb-1">Attempt {@attempt.attempt_number}</h5>
-          <span>{@attempt.score} / {@attempt.out_of}</span>
+          <span>{Utils.format_score(@attempt.score)} / {@attempt.out_of}</span>
         </div>
         <p class="mb-1 text-muted">Submitted: {Utils.render_date(@attempt, :date_evaluated, @context)} ({Utils.render_relative_date(@attempt, :date_evaluated, @context)})</p>
         <small class="text-muted">Time elapsed: {duration(@attempt.inserted_at, @attempt.date_evaluated)}.</small>

--- a/lib/oli_web/live/progress/student_resource_view.ex
+++ b/lib/oli_web/live/progress/student_resource_view.ex
@@ -1,6 +1,6 @@
 defmodule OliWeb.Progress.StudentResourceView do
   use Surface.LiveView, layout: {OliWeb.LayoutView, "live.html"}
-  alias OliWeb.Common.{Breadcrumb, SessionContext}
+  alias OliWeb.Common.{Breadcrumb, SessionContext, Utils}
   alias OliWeb.Common.Properties.{Groups, Group, ReadOnly}
   alias Oli.Delivery.Attempts.Core.ResourceAccess
   alias Surface.Components.Form
@@ -63,7 +63,7 @@ defmodule OliWeb.Progress.StudentResourceView do
                 _ ->
                   ResourceAccess.changeset(resource_access, %{
                     # limit score decimals to two significant figures, rounding up
-                    score: Float.round(resource_access.score, 2)
+                    score: Utils.format_score(resource_access.score)
                   })
               end
 
@@ -237,6 +237,7 @@ defmodule OliWeb.Progress.StudentResourceView do
       |> ensure_no_nil("out_of")
 
     case Core.update_resource_access(socket.assigns.resource_access, params) do
+      # Score is updated as provided, and it's formatted and rounded for display only
       {:ok, resource_access} ->
         socket = put_flash(socket, :info, "Grade changed")
 
@@ -244,7 +245,7 @@ defmodule OliWeb.Progress.StudentResourceView do
          assign(socket,
            is_editing: false,
            resource_access: resource_access,
-           changeset: ResourceAccess.changeset(resource_access, %{score: Float.round(resource_access.score, 2)})
+           changeset: ResourceAccess.changeset(resource_access, %{score: Utils.format_score(resource_access.score)})
          )}
 
       {:error, %Ecto.Changeset{} = changeset} ->

--- a/lib/oli_web/live/progress/student_resource_view.ex
+++ b/lib/oli_web/live/progress/student_resource_view.ex
@@ -57,8 +57,14 @@ defmodule OliWeb.Progress.StudentResourceView do
 
             changeset =
               case resource_access do
-                nil -> nil
-                _ -> ResourceAccess.changeset(resource_access, %{})
+                nil ->
+                  nil
+
+                _ ->
+                  ResourceAccess.changeset(resource_access, %{
+                    # limit score decimals to two significant figures, rounding up
+                    score: Float.round(resource_access.score, 2)
+                  })
               end
 
             {:ok,
@@ -136,6 +142,7 @@ defmodule OliWeb.Progress.StudentResourceView do
             <Field name={:score} class="form-label-group">
               <div class="d-flex justify-content-between"><Label/><ErrorTag class="help-block"/></div>
               <NumberInput class="form-control" opts={disabled: !@is_editing}/>
+              <div class="text-muted">Scores are rounded up, limiting to two decimal points.</div>
             </Field>
             <Field name={:out_of} class="form-label-group mb-4">
               <div class="d-flex justify-content-between"><Label/><ErrorTag class="help-block"/></div>
@@ -237,7 +244,7 @@ defmodule OliWeb.Progress.StudentResourceView do
          assign(socket,
            is_editing: false,
            resource_access: resource_access,
-           changeset: ResourceAccess.changeset(resource_access, %{})
+           changeset: ResourceAccess.changeset(resource_access, %{score: Float.round(resource_access.score, 2)})
          )}
 
       {:error, %Ecto.Changeset{} = changeset} ->

--- a/lib/oli_web/live/progress/student_view.ex
+++ b/lib/oli_web/live/progress/student_view.ex
@@ -60,7 +60,11 @@ defmodule OliWeb.Progress.StudentView do
                 section_slug,
                 user_id
               )
-              |> Enum.reduce(%{}, fn r, m -> Map.put(m, r.resource_id, r) end)
+              |> Enum.reduce(%{}, fn r, m ->
+                 # limit score decimals to two significant figures, rounding up
+                r = Map.put(r, :score, Float.round(r.score, 2))
+                Map.put(m, r.resource_id, r)
+              end)
 
             hierarchy = Oli.Publishing.DeliveryResolver.full_hierarchy(section.slug)
 

--- a/lib/oli_web/live/progress/student_view.ex
+++ b/lib/oli_web/live/progress/student_view.ex
@@ -62,7 +62,7 @@ defmodule OliWeb.Progress.StudentView do
               )
               |> Enum.reduce(%{}, fn r, m ->
                  # limit score decimals to two significant figures, rounding up
-                r = Map.put(r, :score, Float.round(r.score, 2))
+                r = Map.put(r, :score, format_score(r.score))
                 Map.put(m, r.resource_id, r)
               end)
 

--- a/lib/oli_web/templates/page_delivery/page.html.eex
+++ b/lib/oli_web/templates/page_delivery/page.html.eex
@@ -14,11 +14,11 @@ window.userToken = "<%= assigns[:user_token] %>";
     <div class="mb-2">
     <div class="row justify-content-start">
       <div class="col-sm-3">Started:</div>
-      <div><%= Utils.render_date(@resource_attempt, :inserted_at, @session_context) %></div>
+      <div><%= Utils.render_date(@resource_attempt, :inserted_at, @conn) %></div>
     </div>
     <div class="row">
       <div class="col-sm-3">Submitted:</div>
-      <div><%= Utils.render_date(@resource_attempt, :date_evaluated, @session_context) %></div>
+      <div><%= Utils.render_date(@resource_attempt, :date_evaluated, @conn) %></div>
     </div>
     <div class="row">
       <div class="col-sm-3">Score:</div>
@@ -35,11 +35,11 @@ window.userToken = "<%= assigns[:user_token] %>";
     <h3>Awaiting Instructor Grading</h3>
     <div class="row justify-content-start">
       <div class="col-sm-3">Started:</div>
-      <div><%= Utils.render_date(@resource_attempt, :inserted_at, @session_context) %></div>
+      <div><%= Utils.render_date(@resource_attempt, :inserted_at, @conn) %></div>
     </div>
     <div class="row">
       <div class="col-sm-3">Submitted:</div>
-      <div><%= Utils.render_date(@resource_attempt, :date_submitted, @session_context) %></div>
+      <div><%= Utils.render_date(@resource_attempt, :date_submitted, @conn) %></div>
     </div>
     </div>
   <% end %>

--- a/lib/oli_web/templates/page_delivery/page.html.eex
+++ b/lib/oli_web/templates/page_delivery/page.html.eex
@@ -14,11 +14,11 @@ window.userToken = "<%= assigns[:user_token] %>";
     <div class="mb-2">
     <div class="row justify-content-start">
       <div class="col-sm-3">Started:</div>
-      <div><%= OliWeb.Common.Utils.render_date(@resource_attempt, :inserted_at, @conn) %></div>
+      <div><%= Utils.render_date(@resource_attempt, :inserted_at, @session_context) %></div>
     </div>
     <div class="row">
       <div class="col-sm-3">Submitted:</div>
-      <div><%= OliWeb.Common.Utils.render_date(@resource_attempt, :date_evaluated, @conn) %></div>
+      <div><%= Utils.render_date(@resource_attempt, :date_evaluated, @session_context) %></div>
     </div>
     <div class="row">
       <div class="col-sm-3">Score:</div>
@@ -26,7 +26,7 @@ window.userToken = "<%= assigns[:user_token] %>";
     </div>
     <div class="row">
       <div class="col-sm-3">Points:</div>
-      <div><%= @resource_attempt.score %> out of <%= @resource_attempt.out_of %> </div>
+      <div><%= Utils.format_score(@resource_attempt.score) %> out of <%= @resource_attempt.out_of %> </div>
     </div>
     </div>
   <% end %>
@@ -35,11 +35,11 @@ window.userToken = "<%= assigns[:user_token] %>";
     <h3>Awaiting Instructor Grading</h3>
     <div class="row justify-content-start">
       <div class="col-sm-3">Started:</div>
-      <div><%= OliWeb.Common.Utils.render_date(@resource_attempt, :inserted_at, @conn) %></div>
+      <div><%= Utils.render_date(@resource_attempt, :inserted_at, @session_context) %></div>
     </div>
     <div class="row">
       <div class="col-sm-3">Submitted:</div>
-      <div><%= OliWeb.Common.Utils.render_date(@resource_attempt, :date_submitted, @conn) %></div>
+      <div><%= Utils.render_date(@resource_attempt, :date_submitted, @session_context) %></div>
     </div>
     </div>
   <% end %>

--- a/lib/oli_web/views/page_delivery_view.ex
+++ b/lib/oli_web/views/page_delivery_view.ex
@@ -8,6 +8,7 @@ defmodule OliWeb.PageDeliveryView do
   alias OliWeb.Router.Helpers, as: Routes
   alias Oli.Delivery.Attempts.Core
   alias Oli.Resources.Revision
+  alias OliWeb.Common.Utils
 
   import Oli.Utils, only: [value_or: 2]
 

--- a/test/oli_web/common/utils_test.exs
+++ b/test/oli_web/common/utils_test.exs
@@ -1,0 +1,4 @@
+defmodule OliWeb.Common.UtilsTest do
+  use ExUnit.Case, async: true
+  doctest OliWeb.Common.Utils, import: true
+end

--- a/test/oli_web/live/gradebook_view_live_test.exs
+++ b/test/oli_web/live/gradebook_view_live_test.exs
@@ -1,0 +1,159 @@
+defmodule OliWeb.GradebookViewLiveTest do
+  use ExUnit.Case
+  use OliWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+  import Oli.Factory
+
+  alias Oli.Delivery.Sections
+
+  defp live_view_gradebook_view_route(section_slug) do
+    Routes.live_path(
+      OliWeb.Endpoint,
+      OliWeb.Grades.GradebookView,
+      section_slug
+    )
+  end
+
+  describe "user cannot access when is not logged in" do
+    setup [:setup_section]
+
+    test "redirects to enroll page when accessing the gradebook view", %{
+      conn: conn,
+      section: section
+    } do
+      redirect_path = "/sections/#{section.slug}/enroll"
+
+      {:error, {:redirect, %{to: ^redirect_path}}} =
+        live(conn, live_view_gradebook_view_route(section.slug))
+    end
+  end
+
+  describe "user cannot access when is logged in as an author but is not a system admin" do
+    setup [:author_conn, :setup_section]
+
+    test "redirects to section enroll page when accessing the student view", %{
+      conn: conn,
+      section: section
+    } do
+      conn = get(conn, live_view_gradebook_view_route(section.slug))
+
+      redirect_path = "/sections/#{section.slug}/enroll"
+
+      assert conn
+             |> get(live_view_gradebook_view_route(section.slug))
+             |> html_response(302) =~
+               "<html><body>You are being <a href=\"#{redirect_path}\">redirected</a>.</body></html>"
+    end
+  end
+
+  describe "gradebook view" do
+    setup [:admin_conn, :setup_section]
+
+    scores_expected_format = %{
+      100.334 => 100.33,
+      119.336 => 119.34,
+      62.889 => 62.89,
+      60.33333 => 60.33,
+      90.10 => 90.10,
+      120 => 120.0,
+      0.0 => 0.0,
+      0 => 0.0,
+    }
+
+    for {score, expected_score} <- scores_expected_format do
+      @score score
+      @expected_score expected_score
+      @out_of 120.0
+
+      test "loads gradebook view table data correctly with score: #{score}", %{
+        conn: conn,
+        section: section,
+        page_revision: page_revision
+      } do
+        user = insert(:user)
+        enroll_user_to_section(user, section, :context_learner)
+
+        resource_access =
+          insert(:resource_access,
+            user: user,
+            resource: page_revision.resource,
+            section: section,
+            score: @score,
+            out_of: @out_of
+          )
+
+        insert(:resource_attempt, resource_access: resource_access)
+
+        {:ok, view, _html} = live(conn, live_view_gradebook_view_route(section.slug))
+
+        assert view
+          |> element("tr[phx-value-id=\"#{user.id}\"] a[href=\"/sections/#{section.slug}/progress/#{user.id}/#{page_revision.resource.id}\"]")
+          |> render =~ "#{@expected_score}/#{@out_of}"
+      end
+    end
+  end
+
+  def setup_section(_context) do
+    project = insert(:project)
+
+    # Graded page revision
+    page_revision =
+      insert(:revision,
+        resource_type_id: Oli.Resources.ResourceType.get_id_by_type("page"),
+        title: "Progress test revision",
+        graded: true
+      )
+
+    # Associate nested graded page to the project
+    insert(:project_resource, %{project_id: project.id, resource_id: page_revision.resource.id})
+
+    # root container
+    container_resource = insert(:resource)
+
+    # Associate root container to the project
+    insert(:project_resource, %{project_id: project.id, resource_id: container_resource.id})
+
+    container_revision =
+      insert(:revision, %{
+        resource: container_resource,
+        objectives: %{},
+        resource_type_id: Oli.Resources.ResourceType.get_id_by_type("container"),
+        children: [page_revision.resource.id],
+        content: %{},
+        deleted: false,
+        slug: "root_container",
+        title: "Root Container"
+      })
+
+    # Publication of project with root container
+    publication =
+      insert(:publication, %{project: project, root_resource_id: container_resource.id})
+
+    # Publish root container resource
+    insert(:published_resource, %{
+      publication: publication,
+      resource: container_resource,
+      revision: container_revision
+    })
+
+    # Publish nested page resource
+    insert(:published_resource, %{
+      publication: publication,
+      resource: page_revision.resource,
+      revision: page_revision
+    })
+
+    section =
+      insert(:section,
+        base_project: project,
+        context_id: UUID.uuid4(),
+        open_and_free: true,
+        registration_open: true
+      )
+
+    {:ok, section} = Sections.create_section_resources(section, publication)
+
+    {:ok, section: section, page_revision: page_revision}
+  end
+end

--- a/test/oli_web/live/progress_live_test.exs
+++ b/test/oli_web/live/progress_live_test.exs
@@ -26,32 +26,32 @@ defmodule OliWeb.ProgressLiveTest do
       conn: conn,
       section: section,
       resource: resource,
-      user: user
+      student: student
     } do
       redirect_path =
-        "/session/new?request_path=%2Fsections%2F#{section.slug}%2Fprogress%2F#{user.id}%2F#{resource.id}&section=#{section.slug}"
+        "/session/new?request_path=%2Fsections%2F#{section.slug}%2Fprogress%2F#{student.id}%2F#{resource.id}&section=#{section.slug}"
 
       {:error, {:redirect, %{to: ^redirect_path}}} =
-        live(conn, live_view_student_resource_route(section.slug, user.id, resource.id))
+        live(conn, live_view_student_resource_route(section.slug, student.id, resource.id))
     end
   end
 
   describe "user cannot access when is logged in as an author but is not a system admin" do
     setup [:author_conn, :create_resource]
 
-    test "redirects to section enroll page when accessing the student resource view", %{
+    test "redirects to new session when accessing the student resource view", %{
       conn: conn,
       section: section,
       resource: resource,
-      user: user
+      student: student
     } do
-      conn = get(conn, live_view_student_resource_route(section.slug, user.id, resource.id))
+      conn = get(conn, live_view_student_resource_route(section.slug, student.id, resource.id))
 
       redirect_path =
-        "/session/new?request_path=%2Fsections%2F#{section.slug}%2Fprogress%2F#{user.id}%2F#{resource.id}&amp;section=#{section.slug}"
+        "/session/new?request_path=%2Fsections%2F#{section.slug}%2Fprogress%2F#{student.id}%2F#{resource.id}&amp;section=#{section.slug}"
 
       assert conn
-             |> get(live_view_student_resource_route(section.slug, user.id, resource.id))
+             |> get(live_view_student_resource_route(section.slug, student.id, resource.id))
              |> html_response(302) =~
                "<html><body>You are being <a href=\"#{redirect_path}\">redirected</a>.</body></html>"
     end
@@ -60,18 +60,90 @@ defmodule OliWeb.ProgressLiveTest do
   describe "student resource" do
     setup [:admin_conn, :create_resource]
 
-    test "loads student resource progress data correctly", %{
+    test "renders resource progress page correctly", %{
       conn: conn,
       section: section,
       resource: resource,
-      user: user
+      student: student
     } do
-      {:ok, view, _html} =
-        live(conn, live_view_student_resource_route(section.slug, user.id, resource.id))
+      {:ok, _view, html} =
+        live(conn, live_view_student_resource_route(section.slug, student.id, resource.id))
 
-      html = render(view)
       assert html =~ "Details"
       assert html =~ "Attempt History"
+    end
+
+    scores_expected_format = %{
+      7.239 => 7.24,
+      4.876 => 4.88,
+      5.22222 => 5.22,
+      6.10 => 6.10,
+      4 => 4.0,
+      0.0 => 0.0,
+      0 => 0.0,
+    }
+
+    for {score, expected_score} <- scores_expected_format do
+      @score score
+      @expected_score expected_score
+
+      test "loads student progress score correctly for #{score}", %{
+        conn: conn,
+        section: section,
+        resource: resource,
+        student: student
+      } do
+
+        insert(:resource_access, user: student, resource: resource, section: section, score: @score, out_of: 10.0)
+
+        {:ok, view, _html} =
+          live(conn, live_view_student_resource_route(section.slug, student.id, resource.id))
+
+        assert view
+          |> element("input[name=\"resource_access[score]\"]")
+          |> render =~ "value=\"#{@expected_score}\""
+      end
+    end
+
+    test "loads attempt history score correctly", %{
+      conn: conn,
+      section: section,
+      resource: resource,
+      revision: revision,
+      student: student
+    } do
+      first_attempt = %{score: 5.2222, formatted: 5.22}
+      second_attempt = %{score: 4.876, formatted: 4.88}
+      third_attempt =  %{score: 7.239, formatted: 7.24}
+      out_of = 10.0
+
+      resource_access = insert(:resource_access, user: student, resource: resource, section: section, score: third_attempt.score, out_of: out_of)
+
+      date_now = DateTime.utc_now()
+
+      insert(:resource_attempt, revision: revision, resource_access: resource_access, score: first_attempt.score, out_of: out_of, lifecycle_state: "evaluated",
+        date_submitted: date_now, date_evaluated: date_now)
+      insert(:resource_attempt, revision: revision, resource_access: resource_access, score: second_attempt.score, out_of: out_of, lifecycle_state: "evaluated",
+        date_submitted: date_now, date_evaluated: date_now)
+      insert(:resource_attempt, revision: revision, resource_access: resource_access, score: third_attempt.score, out_of: out_of, lifecycle_state: "evaluated",
+        date_submitted: date_now, date_evaluated: date_now)
+
+      {:ok, view, _html} =
+        live(conn, live_view_student_resource_route(section.slug, student.id, resource.id))
+
+      assert view
+        |> element("li[data-phx-component=\"1\"]")
+        |> render =~ "#{first_attempt.formatted} / #{out_of}"
+
+      assert view
+        |> element("li[data-phx-component=\"2\"]")
+        |> render =~ "#{second_attempt.formatted} / #{out_of}"
+
+      assert view
+        |> element("li[data-phx-component=\"3\"]")
+        |> render =~ "#{third_attempt.formatted} / #{out_of}"
+
+      assert true
     end
   end
 
@@ -95,10 +167,10 @@ defmodule OliWeb.ProgressLiveTest do
     test "student view", %{
       conn: conn,
       section: section,
-      user: user
+      student: student
     } do
       {:ok, _view, html} =
-        live(conn, Routes.live_path(OliWeb.Endpoint, OliWeb.Progress.StudentView, section.slug, user.id))
+        live(conn, Routes.live_path(OliWeb.Endpoint, OliWeb.Progress.StudentView, section.slug, student.id))
 
       assert html =~ "<nav class=\"breadcrumb-bar"
       assert html =~ "<a href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.AdminView)}\""
@@ -108,15 +180,15 @@ defmodule OliWeb.ProgressLiveTest do
     test "student resource view", %{
       conn: conn,
       section: section,
-      user: user,
+      student: student,
       resource: resource
     } do
       {:ok, _view, html} =
-        live(conn, live_view_student_resource_route(section.slug, user.id, resource.id))
+        live(conn, live_view_student_resource_route(section.slug, student.id, resource.id))
 
       assert html =~ "<nav class=\"breadcrumb-bar"
       assert html =~ "<a href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.AdminView)}\""
-      assert html =~ "<a href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Progress.StudentView, section.slug, user.id)}\""
+      assert html =~ "<a href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Progress.StudentView, section.slug, student.id)}\""
       assert html =~ "View Resource Progress"
     end
   end
@@ -142,10 +214,10 @@ defmodule OliWeb.ProgressLiveTest do
     test "student view", %{
       conn: conn,
       section: section,
-      user: user
+      student: student
     } do
       {:ok, _view, html} =
-        live(conn, Routes.live_path(OliWeb.Endpoint, OliWeb.Progress.StudentView, section.slug, user.id))
+        live(conn, Routes.live_path(OliWeb.Endpoint, OliWeb.Progress.StudentView, section.slug, student.id))
 
       assert html =~ "<nav class=\"breadcrumb-bar"
       refute html =~ "<a href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.AdminView)}\""
@@ -156,29 +228,29 @@ defmodule OliWeb.ProgressLiveTest do
     test "student resource view", %{
       conn: conn,
       section: section,
-      user: user,
+      student: student,
       resource: resource
     } do
       {:ok, _view, html} =
-        live(conn, live_view_student_resource_route(section.slug, user.id, resource.id))
+        live(conn, live_view_student_resource_route(section.slug, student.id, resource.id))
 
       assert html =~ "<nav class=\"breadcrumb-bar"
       refute html =~ "<a href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.AdminView)}\""
       assert html =~ "<a href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.OverviewView, section.slug)}\""
-      assert html =~ "<a href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Progress.StudentView, section.slug, user.id)}\""
+      assert html =~ "<a href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Progress.StudentView, section.slug, student.id)}\""
       assert html =~ "View Resource Progress"
     end
   end
 
   def create_resource(_context) do
-    user = insert(:user)
-    project = insert(:project, authors: [user.author])
+    instructor = insert(:user)
+    project = insert(:project, authors: [instructor.author])
     section = insert(:section, type: :enrollable)
 
     section_project_publication =
       insert(:section_project_publication, %{section: section, project: project})
 
-    revision = insert(:revision, resource_type_id: Oli.Resources.ResourceType.get_id_by_type("page"))
+    revision = insert(:revision, resource_type_id: Oli.Resources.ResourceType.get_id_by_type("page"), graded: true)
 
     section_resource = insert(:section_resource, %{
       section: section,
@@ -192,13 +264,14 @@ defmodule OliWeb.ProgressLiveTest do
       resource: revision.resource,
       revision: revision,
       publication: section_project_publication.publication,
-      author: user.author
+      author: instructor.author
     })
 
-    {:ok, section: section, resource: revision.resource, user: user}
+    student = insert(:user)
+    {:ok, section: section, resource: revision.resource, revision: revision, instructor: instructor, student: student}
   end
 
-  defp setup_instructor_session(%{conn: conn, user: user, section: section}) do
+  defp setup_instructor_session(%{conn: conn, instructor: user, section: section}) do
     {:ok, user} =
       Accounts.update_user(user, %{can_create_sections: true, independent_learner: true})
     {:ok, instructor} =

--- a/test/oli_web/live/student_view_live_test.exs
+++ b/test/oli_web/live/student_view_live_test.exs
@@ -5,8 +5,6 @@ defmodule OliWeb.StudentViewLiveTest do
   import Phoenix.LiveViewTest
   import Oli.Factory
 
-  alias Oli.Delivery.Sections
-
   defp live_view_student_view_route(section_slug, user_id) do
     Routes.live_path(
       OliWeb.Endpoint,
@@ -17,41 +15,41 @@ defmodule OliWeb.StudentViewLiveTest do
   end
 
   describe "user cannot access when is not logged in" do
-    setup [:setup_section]
+    setup [:section_with_assessment]
 
     test "redirects to section enroll page when accessing the student view", %{
       conn: conn,
-      section: section,
-      student: student
+      section: section
     } do
+      user = insert(:user)
       redirect_path = "/sections/#{section.slug}/enroll"
 
       {:error, {:redirect, %{to: ^redirect_path}}} =
-        live(conn, live_view_student_view_route(section.slug, student.id))
+        live(conn, live_view_student_view_route(section.slug, user.id))
     end
   end
 
   describe "student cannot access when is logged in as an author but is not a system admin" do
-    setup [:author_conn, :setup_section]
+    setup [:author_conn, :section_with_assessment]
 
     test "redirects to enroll page when accessing the student view", %{
       conn: conn,
       section: section,
-      student: student
     } do
-      conn = get(conn, live_view_student_view_route(section.slug, student.id))
+      user = insert(:user)
+      conn = get(conn, live_view_student_view_route(section.slug, user.id))
 
       redirect_path = "/sections/#{section.slug}/enroll"
 
       assert conn
-             |> get(live_view_student_view_route(section.slug, student.id))
+             |> get(live_view_student_view_route(section.slug, user.id))
              |> html_response(302) =~
                "<html><body>You are being <a href=\"#{redirect_path}\">redirected</a>.</body></html>"
     end
   end
 
   describe "student view" do
-    setup [:admin_conn, :setup_section]
+    setup [:admin_conn, :section_with_assessment]
 
     scores_expected_format = %{
       1.334 => 1.33,
@@ -72,12 +70,13 @@ defmodule OliWeb.StudentViewLiveTest do
       test "loads student view data correctly with score #{score}", %{
         conn: conn,
         section: section,
-        page_revision: page_revision,
-        student: student
+        page_revision: page_revision
       } do
+        user = insert(:user)
+
         resource_access =
           insert(:resource_access,
-            user: student,
+            user: user,
             resource: page_revision.resource,
             section: section,
             score: @score,
@@ -86,9 +85,9 @@ defmodule OliWeb.StudentViewLiveTest do
 
         insert(:resource_attempt, resource_access: resource_access)
 
-        {:ok, view, html} = live(conn, live_view_student_view_route(section.slug, student.id))
+        {:ok, view, html} = live(conn, live_view_student_view_route(section.slug, user.id))
 
-        assert html =~ "Progress Details for #{student.family_name}, #{student.given_name}"
+        assert html =~ "Progress Details for #{user.family_name}, #{user.given_name}"
 
         assert view
           |> element("tr[id=\"0\" phx-value-id=\"0\"]")
@@ -96,67 +95,8 @@ defmodule OliWeb.StudentViewLiveTest do
 
         assert view
         |> element("tr[id=\"0\" phx-value-id=\"0\"]")
-        |> render =~ "<a href=\"/sections/#{section.slug}/progress/#{student.id}/#{page_revision.resource.id}\">#{page_revision.title}</a>"
+        |> render =~ "<a href=\"/sections/#{section.slug}/progress/#{user.id}/#{page_revision.resource.id}\">#{page_revision.title}</a>"
       end
     end
-  end
-
-  def setup_section(_context) do
-    project = insert(:project)
-
-    # Graded page revision
-    page_revision =
-      insert(:revision,
-        resource_type_id: Oli.Resources.ResourceType.get_id_by_type("page"),
-        title: "Progress test revision",
-        graded: true
-      )
-
-    # Associate nested graded page to the project
-    insert(:project_resource, %{project_id: project.id, resource_id: page_revision.resource.id})
-
-    # root container
-    container_resource = insert(:resource)
-
-    # Associate root container to the project
-    insert(:project_resource, %{project_id: project.id, resource_id: container_resource.id})
-
-    container_revision =
-      insert(:revision, %{
-        resource: container_resource,
-        objectives: %{},
-        resource_type_id: Oli.Resources.ResourceType.get_id_by_type("container"),
-        children: [page_revision.resource.id],
-        content: %{},
-        deleted: false,
-        slug: "root_container",
-        title: "Root Container"
-      })
-
-    # Publication of project with root container
-    publication =
-      insert(:publication, %{project: project, root_resource_id: container_resource.id})
-
-    # Publish root container resource
-    insert(:published_resource, %{
-      publication: publication,
-      resource: container_resource,
-      revision: container_revision
-    })
-
-    # Publish nested page resource
-    insert(:published_resource, %{
-      publication: publication,
-      resource: page_revision.resource,
-      revision: page_revision
-    })
-
-    section = insert(:section, base_project: project, context_id: UUID.uuid4(), open_and_free: true, registration_open: true)
-
-    student = insert(:user)
-
-    {:ok, section} = Sections.create_section_resources(section, publication)
-
-    {:ok, section: section, page_revision: page_revision, student: student}
   end
 end

--- a/test/oli_web/live/student_view_live_test.exs
+++ b/test/oli_web/live/student_view_live_test.exs
@@ -1,0 +1,162 @@
+defmodule OliWeb.StudentViewLiveTest do
+  use ExUnit.Case
+  use OliWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+  import Oli.Factory
+
+  alias Oli.Delivery.Sections
+
+  defp live_view_student_view_route(section_slug, user_id) do
+    Routes.live_path(
+      OliWeb.Endpoint,
+      OliWeb.Progress.StudentView,
+      section_slug,
+      user_id
+    )
+  end
+
+  describe "user cannot access when is not logged in" do
+    setup [:setup_section]
+
+    test "redirects to section enroll page when accessing the student view", %{
+      conn: conn,
+      section: section,
+      student: student
+    } do
+      redirect_path = "/sections/#{section.slug}/enroll"
+
+      {:error, {:redirect, %{to: ^redirect_path}}} =
+        live(conn, live_view_student_view_route(section.slug, student.id))
+    end
+  end
+
+  describe "student cannot access when is logged in as an author but is not a system admin" do
+    setup [:author_conn, :setup_section]
+
+    test "redirects to enroll page when accessing the student view", %{
+      conn: conn,
+      section: section,
+      student: student
+    } do
+      conn = get(conn, live_view_student_view_route(section.slug, student.id))
+
+      redirect_path = "/sections/#{section.slug}/enroll"
+
+      assert conn
+             |> get(live_view_student_view_route(section.slug, student.id))
+             |> html_response(302) =~
+               "<html><body>You are being <a href=\"#{redirect_path}\">redirected</a>.</body></html>"
+    end
+  end
+
+  describe "student view" do
+    setup [:admin_conn, :setup_section]
+
+    scores_expected_format = %{
+      1.334 => 1.33,
+      1.336 => 1.34,
+      4.889 => 4.89,
+      7.33333 => 7.33,
+      9.10 => 9.10,
+      5 => 5.0,
+      0.0 => 0.0,
+      0 => 0.0,
+    }
+
+    for {score, expected_score} <- scores_expected_format do
+      @score score
+      @expected_score expected_score
+      @out_of 10.0
+
+      test "loads student view data correctly with score #{score}", %{
+        conn: conn,
+        section: section,
+        page_revision: page_revision,
+        student: student
+      } do
+        resource_access =
+          insert(:resource_access,
+            user: student,
+            resource: page_revision.resource,
+            section: section,
+            score: @score,
+            out_of: @out_of
+          )
+
+        insert(:resource_attempt, resource_access: resource_access)
+
+        {:ok, view, html} = live(conn, live_view_student_view_route(section.slug, student.id))
+
+        assert html =~ "Progress Details for #{student.family_name}, #{student.given_name}"
+
+        assert view
+          |> element("tr[id=\"0\" phx-value-id=\"0\"]")
+          |> render =~ "#{@expected_score} / #{@out_of}"
+
+        assert view
+        |> element("tr[id=\"0\" phx-value-id=\"0\"]")
+        |> render =~ "<a href=\"/sections/#{section.slug}/progress/#{student.id}/#{page_revision.resource.id}\">#{page_revision.title}</a>"
+      end
+    end
+  end
+
+  def setup_section(_context) do
+    project = insert(:project)
+
+    # Graded page revision
+    page_revision =
+      insert(:revision,
+        resource_type_id: Oli.Resources.ResourceType.get_id_by_type("page"),
+        title: "Progress test revision",
+        graded: true
+      )
+
+    # Associate nested graded page to the project
+    insert(:project_resource, %{project_id: project.id, resource_id: page_revision.resource.id})
+
+    # root container
+    container_resource = insert(:resource)
+
+    # Associate root container to the project
+    insert(:project_resource, %{project_id: project.id, resource_id: container_resource.id})
+
+    container_revision =
+      insert(:revision, %{
+        resource: container_resource,
+        objectives: %{},
+        resource_type_id: Oli.Resources.ResourceType.get_id_by_type("container"),
+        children: [page_revision.resource.id],
+        content: %{},
+        deleted: false,
+        slug: "root_container",
+        title: "Root Container"
+      })
+
+    # Publication of project with root container
+    publication =
+      insert(:publication, %{project: project, root_resource_id: container_resource.id})
+
+    # Publish root container resource
+    insert(:published_resource, %{
+      publication: publication,
+      resource: container_resource,
+      revision: container_revision
+    })
+
+    # Publish nested page resource
+    insert(:published_resource, %{
+      publication: publication,
+      resource: page_revision.resource,
+      revision: page_revision
+    })
+
+    section = insert(:section, base_project: project, context_id: UUID.uuid4(), open_and_free: true, registration_open: true)
+
+    student = insert(:user)
+
+    {:ok, section} = Sections.create_section_resources(section, publication)
+
+    {:ok, section: section, page_revision: page_revision, student: student}
+  end
+end


### PR DESCRIPTION
[MER-1206](https://eliterate.atlassian.net/browse/MER-1206)

### What does it change?

- Formats score for limiting to two decimal points in the displaying of scores in the following pages:
    - Student progress view
    - Student resource progress view
    - Section's Gradebook view
    - Attempt review (student and instructor)

When editing a resoure's score manually, a number with N decimals numbers is accepted, but following the same logic as everywhere else, the number get's rounded up and limited to two significant decimals for display.