### PR TITLE
[MER-1337] Fixed formula schema bug

### DIFF
--- a/priv/schemas/v0-1-0/content-element.schema.json
+++ b/priv/schemas/v0-1-0/content-element.schema.json
@@ -602,7 +602,9 @@
     "formula": {
       "type": "object",
       "properties": {
-        "const": "formula",
+        "type": {
+          "const": "formula"
+        },
         "subtype": {
           "enum": ["mathml", "latex"]
         },
@@ -622,7 +624,9 @@
     "formula-inline": {
       "type": "object",
       "properties": {
-        "const": "formula_inline",
+        "type": {
+          "const": "formula_inline"
+        },
         "subtype": {
           "enum": ["mathml", "latex"]
         },


### PR DESCRIPTION
Had a bug in the schema when I implemented the formulas, this cleans it up.

Before any type that matched the formula shape would have been accepted. ie:

```
{
  type: 'formulazzzzzz`,
  subtype: 'latex',
  src: 'hi'
}
```

Now, type has to be formula or formula_inline as intended