### PR TITLE
Add numbering to likert items

### DIFF
--- a/assets/src/components/activities/likert/LikertAuthoring.tsx
+++ b/assets/src/components/activities/likert/LikertAuthoring.tsx
@@ -51,7 +51,21 @@ const Likert = (props: AuthoringElementProps<LikertModelSchema>) => {
               addOne={() => dispatch(LikertActions.addChoice())}
               onRemove={(id) => dispatch(LikertActions.removeChoice(id))}
             />
+            <div className="form-check mb-2">
+              <input
+                className="form-check-input"
+                type="checkbox"
+                id="descending-toggle"
+                aria-label="Checkbox for descending order"
+                checked={model.orderDescending}
+                onChange={(e: any) => dispatch(LikertActions.setOrderDescending(e.target.checked))}
+              />
+              <label className="form-check-label" htmlFor="descending-toggle">
+                Number Descending
+              </label>
+            </div>
           </div>
+
           <p>Questions:</p>
           <ChoicesAuthoring
             choices={model.items}

--- a/assets/src/components/activities/likert/LikertDelivery.tsx
+++ b/assets/src/components/activities/likert/LikertDelivery.tsx
@@ -69,8 +69,7 @@ const LikertComponent: React.FC = () => {
       <div className="activity-content">
         <StemDelivery stem={(uiState.model as LikertModelSchema).stem} context={writerContext} />
         <LikertTable
-          items={(uiState.model as LikertModelSchema).items}
-          choices={(uiState.model as LikertModelSchema).choices}
+          model={uiState.model as LikertModelSchema}
           isSelected={isSelected}
           onSelect={onSelect}
           disabled={isEvaluated(uiState)}

--- a/assets/src/components/activities/likert/Sections/LikertTable.tsx
+++ b/assets/src/components/activities/likert/Sections/LikertTable.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
-import { Choice, ChoiceId, PartId } from 'components/activities/types';
+import { Choice, ChoiceId, makeContent, PartId } from 'components/activities/types';
 import { WriterContext } from 'data/content/writers/context';
 import { HtmlContentModelRenderer } from 'data/content/writers/renderer';
-import { LikertItem } from '../schema';
+import { LikertItem, LikertModelSchema } from '../schema';
 import './LikertTable.scss';
 import { toSimpleText } from 'components/editing/slateUtils';
+import { getChoiceValue } from '../utils';
 
 interface Props {
-  items: LikertItem[];
-  choices: Choice[];
+  model: LikertModelSchema;
   isSelected: (itemId: PartId, choiceId: ChoiceId) => boolean;
   onSelect: (itemId: PartId, choiceId: ChoiceId) => void;
   disabled: boolean;
@@ -21,13 +21,14 @@ const needItemColumn = (items: LikertItem[]) => {
 };
 
 export const LikertTable: React.FC<Props> = ({
-  items,
-  choices,
+  model,
   isSelected,
   onSelect,
   disabled = false,
   context,
 }) => {
+  const { choices, items, orderDescending } = model;
+
   return (
     <table className="likertTable">
       <thead>
@@ -54,13 +55,24 @@ export const LikertTable: React.FC<Props> = ({
                   type="radio"
                   checked={isSelected(item.id, choice.id)}
                   disabled={disabled}
-                  onClick={() => onSelect(item.id, choice.id)}
+                  onChange={() => onSelect(item.id, choice.id)}
                 />
               </td>
             ))}
           </tr>
         ))}
       </tbody>
+      {/* footer row with choice values. Use th cells to match header style */}
+      <tfoot>
+        <tr>
+          {needItemColumn(items) && <th />}
+          {choices.map((choice, i) => (
+            <th key={'foot-' + i}>
+              <p>{getChoiceValue(model, i).toString()}</p>
+            </th>
+          ))}
+        </tr>
+      </tfoot>
     </table>
   );
 };

--- a/assets/src/components/activities/likert/actions.ts
+++ b/assets/src/components/activities/likert/actions.ts
@@ -1,4 +1,4 @@
-import { LikertModelSchema } from './schema';
+import { LikertModelSchema, makeLikertChoice } from './schema';
 import { makeHint, HasParts, Part } from '../types';
 import * as ActivityTypes from '../types';
 import { PostUndoable, makeUndoable } from 'components/activities/types';
@@ -12,7 +12,7 @@ import { getCorrectResponse, Responses } from 'data/activities/model/responses';
 export const LikertActions = {
   addChoice() {
     return (model: any & HasParts, post: PostUndoable) => {
-      Choices.addOne(ActivityTypes.makeChoice(''))(model);
+      Choices.addOne(makeLikertChoice(''))(model);
     };
   },
 
@@ -63,6 +63,12 @@ export const LikertActions = {
 
       // remove the specified item
       Items.removeOne(id)(model);
+    };
+  },
+
+  setOrderDescending(orderDescending: boolean) {
+    return (model: any & HasParts, post: PostUndoable) => {
+      model.orderDescending = orderDescending;
     };
   },
 };

--- a/assets/src/components/activities/likert/schema.ts
+++ b/assets/src/components/activities/likert/schema.ts
@@ -7,6 +7,7 @@ import {
   RichText,
   makeChoice,
   makeStem,
+  Transformation,
 } from '../types';
 import { ID } from 'data/content/model/other';
 import { Maybe } from 'tsmonad';
@@ -16,12 +17,12 @@ export class LikertChoice implements Choice {
   id: ID;
   content: RichText;
   // set only if using non-default value:
-  value: Maybe<string>;
+  value: Maybe<number>;
 }
 
 export const makeLikertChoice: (s: string) => LikertChoice = (text) => {
   const choice: any = makeChoice(text);
-  choice.value = Maybe.nothing;
+  choice.value = Maybe.nothing();
   return choice;
 };
 
@@ -44,10 +45,12 @@ export const makeLikertItem: (s: string) => LikertItem = (text) => {
 export interface LikertModelSchema extends ActivityModelSchema {
   stem: Stem;
   choices: LikertChoice[];
+  orderDescending: boolean;
   items: LikertItem[];
   authoring: {
     targeted: ChoiceIdsToResponseId[];
     parts: Part[];
+    transformations: Transformation[];
     previewText: string;
   };
 }

--- a/assets/src/components/activities/likert/utils.ts
+++ b/assets/src/components/activities/likert/utils.ts
@@ -1,7 +1,8 @@
 import { LikertModelSchema, makeLikertChoice, makeLikertItem, LikertChoice } from './schema';
-import { makeStem, makeHint, makeChoice, makePart, Choice } from '../types';
+import { makeStem, makeHint, makePart } from '../types';
 
 import { Responses } from 'data/activities/model/responses';
+import { Maybe } from 'tsmonad';
 
 export const defaultLikertModel: () => LikertModelSchema = () => {
   const choiceA: LikertChoice = makeLikertChoice('Agree');
@@ -11,6 +12,7 @@ export const defaultLikertModel: () => LikertModelSchema = () => {
   return {
     stem: makeStem('Prompt (optional)'),
     choices: [choiceA, choiceB, choiceC],
+    orderDescending: false,
     items: [item1],
     authoring: {
       parts: [
@@ -21,8 +23,14 @@ export const defaultLikertModel: () => LikertModelSchema = () => {
           item1.id,
         ),
       ],
+      transformations: [],
       targeted: [],
       previewText: '',
     },
   };
+};
+
+export const getChoiceValue = (model: LikertModelSchema, i: number): number => {
+  // TODO: use optional custom value if it is specified
+  return model.orderDescending ? model.choices.length - i : i + 1;
 };


### PR DESCRIPTION
This shows choice value numbers along the footer of the likert table on delivery. Also adds an editable option to allow authors to specify descending numbering from left to right. 