### PR TITLE
PMP-2978 | JAN-1827 init state race condition

### DIFF
--- a/assets/src/apps/delivery/store/features/adaptivity/slice.ts
+++ b/assets/src/apps/delivery/store/features/adaptivity/slice.ts
@@ -83,8 +83,12 @@ const slice: Slice<AdaptivityState> = createSlice({
     ) {
       state.historyModeNavigation = action.payload.historyModeNavigation;
     },
-    setInitPhaseComplete(state) {
-      state.initPhaseComplete = Date.now();
+    setInitPhaseComplete(state, action: PayloadAction<boolean>) {
+      if (!action.payload) {
+        state.initPhaseComplete = null;
+      } else {
+        state.initPhaseComplete = Date.now();
+      }
     },
   },
 });

--- a/assets/src/apps/delivery/store/features/groups/actions/deck.ts
+++ b/assets/src/apps/delivery/store/features/groups/actions/deck.ts
@@ -13,6 +13,7 @@ import {
   writePageAttemptState,
 } from 'data/persistence/state/intrinsic';
 import { ResourceId } from 'data/types';
+import thunk from 'redux-thunk';
 import guid from 'utils/guid';
 import {
   ApplyStateOperation,
@@ -29,7 +30,7 @@ import {
   setActivities,
   setCurrentActivityId,
 } from '../../activities/slice';
-import { selectHistoryNavigationActivity, setLessonEnd } from '../../adaptivity/slice';
+import { selectHistoryNavigationActivity, setInitPhaseComplete, setLessonEnd } from '../../adaptivity/slice';
 import { loadActivityAttemptState, updateExtrinsicState } from '../../attempt/slice';
 import {
   selectActivityTypes,
@@ -48,6 +49,7 @@ import { SequenceBank, SequenceEntry, SequenceEntryType } from './sequence';
 export const initializeActivity = createAsyncThunk(
   `${GroupsSlice}/deck/initializeActivity`,
   async (activityId: ResourceId, thunkApi) => {
+    thunkApi.dispatch(setInitPhaseComplete(false));
     const rootState = thunkApi.getState() as RootState;
     const isPreviewMode = selectPreviewMode(rootState);
     const sectionSlug = selectSectionSlug(rootState);


### PR DESCRIPTION
sometimes the check complete (context change) would happen before all the parts got initialized, so the part init was wiping out any init state that might have been applied, or it was simply not registering.