### PR TITLE
[BUG FIX] Fix activity bank selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 ### Enhancements
 
+## 0.21.1 (2022-07-19)
+
+### Bug Fixes
+
+- Fix an with activity bank selections
+
 ## 0.21.0 (2022-07-15)
 
 ### Bug Fixes

--- a/lib/oli/delivery/activity_provider/result.ex
+++ b/lib/oli/delivery/activity_provider/result.ex
@@ -4,6 +4,7 @@ defmodule Oli.Delivery.ActivityProvider.Result do
     :revisions,
     :bib_revisions,
     :unscored,
-    :transformed_content
+    :transformed_content,
+    :activity_to_source_selection_mapping
   ]
 end

--- a/lib/oli/resources/page_content.ex
+++ b/lib/oli/resources/page_content.ex
@@ -123,6 +123,13 @@ defmodule Oli.Resources.PageContent do
                survey: ensure_number_is_string(survey_id)
              })}
 
+          %{"type" => "selection", "id" => id} ->
+            {el,
+             Map.put_new(activity_groups, "bank_selection_#{id}", %{
+               group: ensure_number_is_string(group_id),
+               survey: ensure_number_is_string(survey_id)
+             })}
+
           _ ->
             {el, activity_groups}
         end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Oli.MixProject do
   def project do
     [
       app: :oli,
-      version: "0.21.0",
+      version: "0.21.1",
       elixir: "~> 1.13.2",
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: elixirc_options(Mix.env()),


### PR DESCRIPTION
This PR restores the ability to create attempts for pages that contain activity bank selections.  The fix here is to provide to the page lifecycle hierarchy creation code a mapping of realized activity resource ids to the original bank selection id. In conjunction, the code in `PageContent.activity_parent_groups` has been updated to look for activity bank selections, and add those as distinct entries (with a special key that won't conflict with resource ids) in the returned map.  With those two changes, the attempt creation code can then properly determine if a realized activity that come from a bank selection was in a group or a survey. 
