### PR TITLE
[BUG FIX] Handle groups and survey fulfillment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,17 @@
 
 ### Enhancements
 
+## 0.21.2 (2022-07-20)
+
+### Bug Fixes
+
+- Fix a problem with handling groups and surveys
+
 ## 0.21.1 (2022-07-19)
 
 ### Bug Fixes
 
-- Fix an with activity bank selections
+- Fix a problem with activity bank selections
 
 ## 0.21.0 (2022-07-15)
 

--- a/lib/oli/delivery/activity_provider.ex
+++ b/lib/oli/delivery/activity_provider.ex
@@ -166,16 +166,22 @@ defmodule Oli.Delivery.ActivityProvider do
           end
 
         "group" ->
-          {c_errors, c_activities, c_model, source} = fulfill(e["children"], source)
+          {c_errors, c_activities, c_model, source, group_selection_mapping} =
+            fulfill(e["children"], source)
+
           e = %{e | "children" => Enum.reverse(c_model)}
 
-          {c_errors ++ errors, c_activities ++ activities, [e | model], source, selection_mapping}
+          {c_errors ++ errors, c_activities ++ activities, [e | model], source,
+           Map.merge(selection_mapping, group_selection_mapping)}
 
         "survey" ->
-          {c_errors, c_activities, c_model, source} = fulfill(e["children"], source)
+          {c_errors, c_activities, c_model, source, survey_selection_mapping} =
+            fulfill(e["children"], source)
+
           e = %{e | "children" => Enum.reverse(c_model)}
 
-          {c_errors ++ errors, c_activities ++ activities, [e | model], source, selection_mapping}
+          {c_errors ++ errors, c_activities ++ activities, [e | model], source,
+           Map.merge(selection_mapping, survey_selection_mapping)}
 
         _ ->
           {errors, activities, [e | model], source, selection_mapping}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Oli.MixProject do
   def project do
     [
       app: :oli,
-      version: "0.21.1",
+      version: "0.21.2",
       elixir: "~> 1.13.2",
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: elixirc_options(Mix.env()),


### PR DESCRIPTION
Follow on PR to handle two other cases, the recursive calls into `fulfill` to handle groups and survey. We have to merge the resulting map from these calls into the parent `selection_mapping` map.  