### PR TITLE
[MER-1321] Fix stripe charging incorrect amount on section payment

### DIFF
--- a/lib/oli/delivery.ex
+++ b/lib/oli/delivery.ex
@@ -57,7 +57,7 @@ defmodule Oli.Delivery do
       # TODO: we may need to move this to AFTER a remix if the cost calculation factors
       # in the percentage project usage
       amount =
-        case Oli.Delivery.Paywall.calculate_product_cost(blueprint, institution) do
+        case Oli.Delivery.Paywall.section_cost_from_product(blueprint, institution) do
           {:ok, amount} -> amount
           _ -> blueprint.amount
         end

--- a/lib/oli/delivery/paywall.ex
+++ b/lib/oli/delivery/paywall.ex
@@ -200,7 +200,7 @@ defmodule Oli.Delivery.Paywall do
   @doc """
     Given a section (blueprint) calculate the cost to use it for
     a specific institution, taking into account any product-wide and product-specific discounts
-    this instituttion has.
+    this institution has.
 
       Returns {:ok, %Money{}} or {:error, reason}
   """
@@ -211,21 +211,15 @@ defmodule Oli.Delivery.Paywall do
   ) do
     discounts =
       from(d in Discount,
-        where:
-          (is_nil(d.section_id) and d.institution_id == ^institution_id) or
-            (d.section_id == ^id and d.institution_id == ^institution_id),
+        where: d.institution_id == ^institution_id and (is_nil(d.section_id)) or (d.section_id == ^id),
         select: d
       )
       |> Repo.all()
 
     # Remove any institution-wide discounts if an institution and section specific discount exists
-    discounts =
-      case Enum.any?(discounts, fn d -> !is_nil(d.section_id) end) do
-        true ->
-          Enum.filter(discounts, fn d -> !is_nil(d.section_id) end)
-
-        false ->
-          discounts
+    discounts = case Enum.filter(discounts, fn d -> !is_nil(d.section_id) end) do
+        [] -> discounts
+        filtered_discounts -> filtered_discounts
       end
 
     # Now calculate the product cost, taking into account a discount

--- a/lib/oli/delivery/paywall.ex
+++ b/lib/oli/delivery/paywall.ex
@@ -198,28 +198,17 @@ defmodule Oli.Delivery.Paywall do
   end
 
   @doc """
-  Given a section (blueprint or enrollable), calculate the cost to use it for
-  a specific institution, taking into account any product-wide and product-specific discounts
-  this instituttion has.
+    Given a section (blueprint) calculate the cost to use it for
+    a specific institution, taking into account any product-wide and product-specific discounts
+    this instituttion has.
 
-  Returns {:ok, %Money{}} or {:error, reason}
+      Returns {:ok, %Money{}} or {:error, reason}
   """
-  def calculate_product_cost(
-        %Section{requires_payment: false},
-        _
-      ),
-      do: {:ok, Money.new(:USD, 0)}
-
-  def calculate_product_cost(
-        %Section{requires_payment: true, amount: amount},
-        nil
-      ),
-      do: {:ok, amount}
-
-  def calculate_product_cost(
-        %Section{requires_payment: true, id: id, amount: amount},
-        %Institution{id: institution_id}
-      ) do
+  @spec section_cost_from_product(%Section{}, %Institution{}) :: {:ok, %Money{}} | {:error, any}
+   def section_cost_from_product(
+    %Section{requires_payment: true, id: id, amount: amount},
+    %Institution{id: institution_id}
+  ) do
     discounts =
       from(d in Discount,
         where:
@@ -256,6 +245,9 @@ defmodule Oli.Delivery.Paywall do
         {:ok, amount}
     end
   end
+
+  def section_cost_from_product(%Section{requires_payment: true, amount: amount}, nil), do: {:ok, amount}
+  def section_cost_from_product(%Section{requires_payment: false}, _), do: {:ok, Money.new(:USD, 0)}
 
   @doc """
   Redeems a payment code for a given course section.

--- a/lib/oli/delivery/paywall/providers/stripe.ex
+++ b/lib/oli/delivery/paywall/providers/stripe.ex
@@ -8,6 +8,7 @@ defmodule Oli.Delivery.Paywall.Providers.Stripe do
 
   @zero_decimal_currencies ~w"bif clp djf gnf jpy kmf krw mga pyg rwf ugx vnd vuv xaf xof xpf"
   @zero_decimal_currencies_set MapSet.new(@zero_decimal_currencies)
+  @payment_intents_url "https://api.stripe.com/v1/payment_intents"
 
   @doc """
   Converts an ex_money amount to a valid Stripe value and
@@ -94,7 +95,7 @@ defmodule Oli.Delivery.Paywall.Providers.Stripe do
            Application.fetch_env(:oli, :stripe_provider),
          {:ok, %{status_code: 200, body: body}} <-
            http().post(
-             "https://api.stripe.com/v1/payment_intents",
+             @payment_intents_url,
              body,
              headers.(private_secret)
            ),

--- a/lib/oli_web/controllers/payment_providers/stripe_controller.ex
+++ b/lib/oli_web/controllers/payment_providers/stripe_controller.ex
@@ -4,7 +4,7 @@ defmodule OliWeb.PaymentProviders.StripeController do
   import Oli.Utils
   import OliWeb.Api.Helpers
 
-  alias Oli.Delivery.{Paywall, Sections}
+  alias Oli.Delivery.Sections
   alias Oli.Delivery.Paywall.Providers.Stripe
   alias OliWeb.Router.Helpers, as: Routes
 
@@ -112,29 +112,27 @@ defmodule OliWeb.PaymentProviders.StripeController do
       # Lookup the section, determine the product, and determine the cost. For security
       # reasons, we *always* calculate cost on the server instead of allowing the client
       # to pass the cost along to the server.
-      with {:ok, section} <- Sections.get_section_by_slug(section_slug) |> trap_nil(),
-           {:ok, section} <- Oli.Repo.preload(section, [:institution, :blueprint]) |> trap_nil(),
-           {:ok, product} <- determine_product(section),
-           {:ok, amount} <- Paywall.calculate_product_cost(product, section.institution) do
-        # Now ask Stripe to create a payment intent, which also results in a %Payment record
-        # created in the system but in a "pending" state
-        case Stripe.create_intent(amount, user, section, product) do
-          {:ok, %{"client_secret" => client_secret, "id" => id}} ->
-            Logger.debug("StripeController:init_intent ended", %{
-              intent_id: id,
-              section_slug: section_slug,
-              user_id: user.id
-            })
+      case Sections.get_section_by_slug(section_slug) |> trap_nil() do
+        {:ok, section} ->
+          # Now ask Stripe to create a payment intent, which also results in a %Payment record
+          # created in the system but in a "pending" state
+          case Stripe.create_intent(section, user) do
+            {:ok, %{"client_secret" => client_secret, "id" => id}} ->
+              Logger.debug("StripeController:init_intent ended", %{
+                intent_id: id,
+                section_slug: section_slug,
+                user_id: user.id
+              })
 
-            json(conn, %{clientSecret: client_secret})
+              json(conn, %{clientSecret: client_secret})
 
-          e ->
-            {_, msg} = Oli.Utils.log_error("StripeController:init_intent failed.", e)
-            error(conn, 500, msg)
-        end
-      else
-        e ->
-          Logger.error("StripeController could not init intent", e)
+            e ->
+              {_, msg} = Oli.Utils.log_error("StripeController:init_intent failed.", e)
+              error(conn, 500, msg)
+          end
+
+        _ ->
+          Logger.error("StripeController could not init intent")
           error(conn, 400, "client error")
       end
     else
@@ -143,16 +141,6 @@ defmodule OliWeb.PaymentProviders.StripeController do
       )
 
       error(conn, 401, "unauthorized, this user is not enrolled in this section")
-    end
-  end
-
-  # Determines the product to apply a payment to.  If a section was not created
-  # from a product, the product is the section itself.
-  defp determine_product(section) do
-    if is_nil(section.blueprint_id) do
-      {:ok, section}
-    else
-      {:ok, section.blueprint}
     end
   end
 end

--- a/test/oli/delivery/paywall/providers/stripe_test.exs
+++ b/test/oli/delivery/paywall/providers/stripe_test.exs
@@ -41,6 +41,7 @@ defmodule Oli.Delivery.Paywall.Providers.StripeTest do
     end
   end
 
+  @moduletag :capture_log
   describe "create_intent/4" do
     setup [:setup_conn]
 

--- a/test/oli/delivery/paywall/providers/stripe_test.exs
+++ b/test/oli/delivery/paywall/providers/stripe_test.exs
@@ -45,7 +45,7 @@ defmodule Oli.Delivery.Paywall.Providers.StripeTest do
     setup [:setup_conn]
 
     test "intent creation succeeds",
-         %{section: section, product: product, user1: user} do
+         %{section: section, user1: user} do
       expected_body =
         %{
           amount: 10000,
@@ -64,20 +64,20 @@ defmodule Oli.Delivery.Paywall.Providers.StripeTest do
          }}
       end)
 
-      {:ok, _intent1} = Stripe.create_intent(Money.new(:USD, 100), user, section, product)
+      {:ok, _intent1} = Stripe.create_intent(section, user)
 
       pending_payment = Paywall.get_provider_payment(:stripe, "test_id")
       assert pending_payment
       refute pending_payment.application_date
       assert pending_payment.pending_section_id == section.id
       assert pending_payment.pending_user_id == user.id
-      assert pending_payment.section_id == product.id
+      assert pending_payment.section_id == section.id
       assert pending_payment.provider_type == :stripe
       assert pending_payment.provider_id == "test_id"
     end
 
     test "intent creation fails when stripe fails",
-         %{section: section, product: product, user1: user} do
+         %{section: section, user1: user} do
       MockHTTP
       |> expect(:post, fn @stripe_payments_intents_url, _body, @expected_headers ->
         {:ok,
@@ -87,11 +87,11 @@ defmodule Oli.Delivery.Paywall.Providers.StripeTest do
       end)
 
       assert {:error, "Could not create stripe intent"} ==
-               Stripe.create_intent(Money.new(:USD, 100), user, section, product)
+               Stripe.create_intent(section, user)
     end
 
     test "multiple intent creation succeeds when first is not finalized",
-         %{section: section, product: product, user1: user} do
+         %{section: section, user1: user} do
       MockHTTP
       |> expect(:post, fn @stripe_payments_intents_url, _body, @expected_headers ->
         {:ok,
@@ -101,7 +101,7 @@ defmodule Oli.Delivery.Paywall.Providers.StripeTest do
          }}
       end)
 
-      {:ok, _intent1} = Stripe.create_intent(Money.new(:USD, 100), user, section, product)
+      {:ok, _intent1} = Stripe.create_intent(section, user)
 
       MockHTTP
       |> expect(:post, fn @stripe_payments_intents_url, _body, @expected_headers ->
@@ -112,7 +112,7 @@ defmodule Oli.Delivery.Paywall.Providers.StripeTest do
          }}
       end)
 
-      {:ok, _intent2} = Stripe.create_intent(Money.new(:USD, 100), user, section, product)
+      {:ok, _intent2} = Stripe.create_intent(section, user)
 
       assert is_nil(Paywall.get_provider_payment(:stripe, "test_id"))
 
@@ -121,13 +121,13 @@ defmodule Oli.Delivery.Paywall.Providers.StripeTest do
       refute pending_payment.application_date
       assert pending_payment.pending_section_id == section.id
       assert pending_payment.pending_user_id == user.id
-      assert pending_payment.section_id == product.id
+      assert pending_payment.section_id == section.id
       assert pending_payment.provider_type == :stripe
       assert pending_payment.provider_id == "second_id"
     end
 
     test "multiple intent creation fails when first is finalized",
-         %{section: section, product: product, user1: user} do
+         %{section: section, user1: user} do
       MockHTTP
       |> expect(:post, fn @stripe_payments_intents_url, _body, @expected_headers ->
         {:ok,
@@ -137,7 +137,7 @@ defmodule Oli.Delivery.Paywall.Providers.StripeTest do
          }}
       end)
 
-      {:ok, intent1} = Stripe.create_intent(Money.new(:USD, 100), user, section, product)
+      {:ok, intent1} = Stripe.create_intent(section, user)
       pending_payment = Paywall.get_provider_payment(:stripe, "test_id")
       assert {:ok, _} = Stripe.finalize_payment(intent1)
 
@@ -150,8 +150,7 @@ defmodule Oli.Delivery.Paywall.Providers.StripeTest do
          }}
       end)
 
-      assert {:error, {:payment_already_exists}} =
-               Stripe.create_intent(Money.new(:USD, 100), user, section, product)
+      assert {:error, {:payment_already_exists}} = Stripe.create_intent(section, user)
 
       finalized = Paywall.get_provider_payment(:stripe, "test_id")
       assert finalized
@@ -165,7 +164,6 @@ defmodule Oli.Delivery.Paywall.Providers.StripeTest do
 
     test "finalization succeeds", %{
       section: section,
-      product: product,
       user1: user,
       enrollment: enrollment
     } do
@@ -178,7 +176,7 @@ defmodule Oli.Delivery.Paywall.Providers.StripeTest do
          }}
       end)
 
-      {:ok, intent} = Stripe.create_intent(Money.new(:USD, 100), user, section, product)
+      {:ok, intent} = Stripe.create_intent(section, user)
 
       pending_payment = Paywall.get_provider_payment(:stripe, "test_id")
       assert pending_payment
@@ -186,7 +184,7 @@ defmodule Oli.Delivery.Paywall.Providers.StripeTest do
       assert is_nil(pending_payment.enrollment_id)
       assert pending_payment.pending_section_id == section.id
       assert pending_payment.pending_user_id == user.id
-      assert pending_payment.section_id == product.id
+      assert pending_payment.section_id == section.id
       assert pending_payment.provider_type == :stripe
       assert pending_payment.provider_id == "test_id"
 
@@ -199,7 +197,7 @@ defmodule Oli.Delivery.Paywall.Providers.StripeTest do
       assert finalized.application_date
       assert finalized.pending_section_id == section.id
       assert finalized.pending_user_id == user.id
-      assert finalized.section_id == product.id
+      assert finalized.section_id == section.id
       assert finalized.provider_type == :stripe
       assert finalized.provider_id == "test_id"
 
@@ -228,7 +226,7 @@ defmodule Oli.Delivery.Paywall.Providers.StripeTest do
                Stripe.finalize_payment(%{"id" => "a_made_up_intent_id"})
     end
 
-    test "double finalization fails", %{section: section, product: product, user1: user} do
+    test "double finalization fails", %{section: section, user1: user} do
       MockHTTP
       |> expect(:post, fn @stripe_payments_intents_url, _body, @expected_headers ->
         {:ok,
@@ -238,7 +236,7 @@ defmodule Oli.Delivery.Paywall.Providers.StripeTest do
          }}
       end)
 
-      {:ok, intent} = Stripe.create_intent(Money.new(:USD, 100), user, section, product)
+      {:ok, intent} = Stripe.create_intent(section, user)
       assert {:ok, _} = Stripe.finalize_payment(intent)
 
       assert {:error, "Payment already finalized"} = Stripe.finalize_payment(intent)
@@ -288,7 +286,6 @@ defmodule Oli.Delivery.Paywall.Providers.StripeTest do
       Sections.enroll(user1.id, section.id, [ContextRoles.get_role(:context_learner)])
 
     %{
-      product: product,
       section: section,
       map: map,
       user1: user1,

--- a/test/oli/delivery/paywall_test.exs
+++ b/test/oli/delivery/paywall_test.exs
@@ -394,16 +394,16 @@ defmodule Oli.Delivery.PaywallTest do
       %{institution: map.institution, free: free, paid: paid, section: section}
     end
 
-    test "calculate_product_cost/2 correctly works when no discounts present", %{
+    test "section_cost_from_product/2 correctly works when no discounts present", %{
       free: free,
       paid: paid,
       institution: institution
     } do
-      assert {:ok, Money.new(:USD, 0)} == Paywall.calculate_product_cost(free, institution)
-      assert {:ok, Money.new(:USD, 100)} == Paywall.calculate_product_cost(paid, institution)
+      assert {:ok, Money.new(:USD, 0)} == Paywall.section_cost_from_product(free, institution)
+      assert {:ok, Money.new(:USD, 100)} == Paywall.section_cost_from_product(paid, institution)
     end
 
-    test "calculate_product_cost/2 correctly applies fixed amount discounts",
+    test "section_cost_from_product/2 correctly applies fixed amount discounts",
          %{
            paid: paid,
            institution: institution
@@ -417,7 +417,7 @@ defmodule Oli.Delivery.PaywallTest do
           amount: Money.new(:USD, 90)
         })
 
-      assert {:ok, Money.new(:USD, 90)} == Paywall.calculate_product_cost(paid, institution)
+      assert {:ok, Money.new(:USD, 90)} == Paywall.section_cost_from_product(paid, institution)
 
       Paywall.create_discount(%{
         institution_id: institution.id,
@@ -427,7 +427,7 @@ defmodule Oli.Delivery.PaywallTest do
         amount: Money.new(:USD, 80)
       })
 
-      assert {:ok, Money.new(:USD, 80)} == Paywall.calculate_product_cost(paid, institution)
+      assert {:ok, Money.new(:USD, 80)} == Paywall.section_cost_from_product(paid, institution)
     end
 
     percentage_discounts = [
@@ -445,7 +445,7 @@ defmodule Oli.Delivery.PaywallTest do
       @expected_amount expected_amount
 
       # amount from paid is #Money<:USD, 100>
-      test "calculate_product_cost/2 correctly applies percentage discount for #{discount}",
+      test "section_cost_from_product/2 correctly applies percentage discount for #{discount}",
           %{
             paid: paid,
             institution: institution
@@ -459,22 +459,22 @@ defmodule Oli.Delivery.PaywallTest do
             amount: Money.new(:USD, @expected_amount)
           })
 
-        assert {:ok, Money.new(:USD, @expected_amount)} == Paywall.calculate_product_cost(paid, institution)
+        assert {:ok, Money.new(:USD, @expected_amount)} == Paywall.section_cost_from_product(paid, institution)
       end
     end
 
-    test "calculate_product_cost/2 correctly works when no institution present", %{
+    test "section_cost_from_product/2 correctly works when no institution present", %{
       free: free,
       paid: paid
     } do
-      assert {:ok, Money.new(:USD, 0)} == Paywall.calculate_product_cost(free, nil)
-      assert {:ok, Money.new(:USD, 100)} == Paywall.calculate_product_cost(paid, nil)
+      assert {:ok, Money.new(:USD, 0)} == Paywall.section_cost_from_product(free, nil)
+      assert {:ok, Money.new(:USD, 100)} == Paywall.section_cost_from_product(paid, nil)
     end
 
-    test "calculate_product_cost/2 correctly works when given an enrollable section", %{
+    test "section_cost_from_product/2 correctly works when given an enrollable section", %{
       section: section
     } do
-      assert {:ok, Money.new(:USD, 100)} == Paywall.calculate_product_cost(section, nil)
+      assert {:ok, Money.new(:USD, 100)} == Paywall.section_cost_from_product(section, nil)
     end
   end
 

--- a/test/oli_web/controllers/payment_providers/stripe_controller_test.exs
+++ b/test/oli_web/controllers/payment_providers/stripe_controller_test.exs
@@ -234,7 +234,7 @@ defmodule OliWeb.PaymentProviders.StripeControllerTest do
       refute pending_payment.application_date
       assert pending_payment.pending_section_id == section.id
       assert pending_payment.pending_user_id == user.id
-      assert pending_payment.section_id == product.id
+      assert pending_payment.section_id == section.id
       assert pending_payment.provider_type == :stripe
       assert pending_payment.provider_id == "test_id"
     end
@@ -286,7 +286,7 @@ defmodule OliWeb.PaymentProviders.StripeControllerTest do
          }}
       end)
 
-      {:ok, intent} = Stripe.create_intent(Money.new(:USD, 100), user, section, section)
+      {:ok, intent} = Stripe.create_intent(section, user)
 
       conn =
         post(conn, Routes.stripe_path(conn, :success), %{
@@ -334,7 +334,7 @@ defmodule OliWeb.PaymentProviders.StripeControllerTest do
          }}
       end)
 
-      {:ok, intent} = Stripe.create_intent(Money.new(:USD, 100), user, section, product)
+      {:ok, intent} = Stripe.create_intent(section, user)
 
       conn =
         post(conn, Routes.stripe_path(conn, :success), %{
@@ -350,7 +350,7 @@ defmodule OliWeb.PaymentProviders.StripeControllerTest do
       assert finalized.application_date
       assert finalized.pending_section_id == section.id
       assert finalized.pending_user_id == user.id
-      assert finalized.section_id == product.id
+      assert finalized.section_id == section.id
       assert finalized.provider_type == :stripe
       assert finalized.provider_id == "test_id"
     end
@@ -371,7 +371,7 @@ defmodule OliWeb.PaymentProviders.StripeControllerTest do
          }}
       end)
 
-      {:ok, intent} = Stripe.create_intent(Money.new(:USD, 100), user, section, section)
+      {:ok, intent} = Stripe.create_intent(section, user)
       assert {:ok, _} = Stripe.finalize_payment(intent)
 
       conn =


### PR DESCRIPTION
[MER-1321](https://eliterate.atlassian.net/browse/MER-1321)

### What does it change?

When we worked on #2726 and switched from calculating costs from product to always using the section cost, we missed updating the same logic which was duplicated in the Stripe provider. 

In the reported bug, when an admin updated the cost of a section that parts from a product:
- User would see e.g. 25 USD when paying, although Stripe would charge 50 USD
- This happened because `PaymentController.make_payment` used `Section.amount`, and `Stripe.init_payment` was still doing the determine_product + cost calculation to determine the amount. 
