### PR TITLE
[BUG FIX] Datashop missing user id for guest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,6 @@
 
 ### Bug Fixes
 
-### Enhancements
-
-## 0.21.3 (2022-07-21)
-
-### Bug Fixes
-
 - Fix an issue where guest user_id is blank in datashop export
 
 ## 0.21.2 (2022-07-20)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 ### Enhancements
 
+## 0.21.3 (2022-07-21)
+
+### Bug Fixes
+
+- Fix an issue where guest user_id is blank in datashop export
+
 ## 0.21.2 (2022-07-20)
 
 ### Bug Fixes

--- a/lib/oli/analytics/datashop/elements/meta.ex
+++ b/lib/oli/analytics/datashop/elements/meta.ex
@@ -9,7 +9,7 @@ defmodule Oli.Analytics.Datashop.Elements.Meta do
   """
   import XmlBuilder
 
-  def setup(%{date: date, sub: sub, datashop_session_id: datashop_session_id, email: nil}),
+  def setup(%{date: date, sub: sub, datashop_session_id: datashop_session_id, email: ""}),
     do: setup(%{date: date, user_id: sub, datashop_session_id: datashop_session_id})
 
   def setup(%{date: date, datashop_session_id: datashop_session_id, email: email}),

--- a/lib/oli/utils/seeder/student_attempt_seed.ex
+++ b/lib/oli/utils/seeder/student_attempt_seed.ex
@@ -1,0 +1,14 @@
+defmodule Oli.Utils.Seeder.StudentAttemptSeed do
+  @moduledoc false
+  defstruct [
+    :user,
+    :resource,
+    :activity,
+    :get_part_inputs,
+    :transformed_model,
+    :datashop_session_id,
+    :resource_attempt_tag,
+    :activity_attempt_tag,
+    :part_attempt_tag
+  ]
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Oli.MixProject do
   def project do
     [
       app: :oli,
-      version: "0.21.2",
+      version: "0.21.3",
       elixir: "~> 1.13.2",
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: elixirc_options(Mix.env()),

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Oli.MixProject do
   def project do
     [
       app: :oli,
-      version: "0.21.3",
+      version: "0.21.2",
       elixir: "~> 1.13.2",
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: elixirc_options(Mix.env()),

--- a/test/oli/analytics/datashop_test.exs
+++ b/test/oli/analytics/datashop_test.exs
@@ -1,0 +1,269 @@
+defmodule Oli.Analytics.DatashopTest do
+  use Oli.DataCase
+
+  import SweetXml
+
+  alias Oli.Seeder
+  alias Oli.Utils.Seeder.StudentAttemptSeed
+  alias Oli.Analytics.Datashop
+  alias Oli.Delivery.Attempts.Core.StudentInput
+
+  describe "datashop export" do
+    setup do
+      content = %{
+        "stem" => "Example MCQ activity. Correct answer is 'Choice A'",
+        "authoring" => %{
+          "parts" => [
+            %{
+              "id" => "1",
+              "gradingApproach" => "automatic",
+              "scoringStrategy" => "average",
+              "responses" => [
+                %{
+                  "rule" => "input like {3222237681}",
+                  "score" => 10,
+                  "id" => "r1",
+                  "feedback" => %{
+                    "id" => "1",
+                    "content" => [
+                      %{
+                        "children" => [
+                          %{
+                            "text" => "Correct"
+                          }
+                        ],
+                        "id" => "2624267862",
+                        "type" => "p"
+                      }
+                    ]
+                  }
+                },
+                %{
+                  "rule" => "input like {1945694347}",
+                  "score" => 1,
+                  "id" => "r2",
+                  "feedback" => %{
+                    "id" => "2",
+                    "content" => [
+                      %{
+                        "children" => [
+                          %{
+                            "text" => "Almost"
+                          }
+                        ],
+                        "id" => "2624267863",
+                        "type" => "p"
+                      }
+                    ]
+                  }
+                },
+                %{
+                  "rule" => "input like {1945694348}",
+                  "score" => 0,
+                  "id" => "r3",
+                  "feedback" => %{
+                    "id" => "3",
+                    "content" => [
+                      %{
+                        "children" => [
+                          %{
+                            "text" => "No"
+                          }
+                        ],
+                        "id" => "2624267864",
+                        "type" => "p"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "choices" => [
+          %{
+            "content" => [
+              %{
+                "children" => [
+                  %{
+                    "text" => "Choice A"
+                  }
+                ],
+                "id" => "644441764",
+                "type" => "p"
+              }
+            ],
+            "id" => "3222237681"
+          },
+          %{
+            "content" => [
+              %{
+                "children" => [
+                  %{
+                    "text" => "Choice B"
+                  }
+                ],
+                "id" => "2252168149",
+                "type" => "p"
+              }
+            ],
+            "id" => "1945694347"
+          },
+          %{
+            "content" => [
+              %{
+                "children" => [
+                  %{
+                    "text" => "Choice C"
+                  }
+                ],
+                "id" => "2252168150",
+                "type" => "p"
+              }
+            ],
+            "id" => "1945694348"
+          }
+        ]
+      }
+
+      datashop_session_id_user1 = UUID.uuid4()
+      datashop_session_id_user2 = UUID.uuid4()
+
+      map =
+        Seeder.base_project_with_resource2()
+        |> Seeder.create_section()
+        |> Seeder.add_user(%{}, :user1)
+        |> Seeder.add_guest_user(%{}, :user2_guest)
+        |> Seeder.add_activity(
+          %{title: "activity 1", content: content},
+          :publication,
+          :project,
+          :author,
+          :activity_1
+        )
+        |> Seeder.add_activity(
+          %{title: "activity 2", content: content},
+          :publication,
+          :project,
+          :author,
+          :activity_2
+        )
+        |> Seeder.add_activity(
+          %{title: "activity 3", content: content},
+          :publication,
+          :project,
+          :author,
+          :activity_3
+        )
+
+      map =
+        map
+        |> Seeder.add_page(
+          %{
+            graded: false,
+            content: %{
+              "model" => [
+                %{
+                  "type" => "activity-reference",
+                  "activity_id" => Map.get(map, :activity_1).revision.resource_id
+                }
+              ]
+            }
+          },
+          :ungraded_page
+        )
+        |> Seeder.add_page(
+          %{
+            graded: true,
+            content: %{
+              "model" => [
+                %{
+                  "type" => "activity-reference",
+                  "activity_id" => Map.get(map, :activity_2).revision.resource_id
+                }
+              ]
+            }
+          },
+          :graded_page
+        )
+        |> Seeder.ensure_published()
+        |> Seeder.create_section_resources()
+        |> Seeder.simulate_student_attempt(%StudentAttemptSeed{
+          user: :user1,
+          datashop_session_id: datashop_session_id_user1,
+          resource: :ungraded_page,
+          activity: :activity_1,
+          get_part_inputs: &[%{attempt_guid: &1, input: %StudentInput{input: "3222237681"}}],
+          transformed_model: content,
+          resource_attempt_tag: :user1_graded_page_attempt,
+          activity_attempt_tag: :user1_graded_page_activity_1_attempt,
+          part_attempt_tag: :user1_graded_page_activity_1_part_1_attempt
+        })
+        |> Seeder.simulate_student_attempt(%StudentAttemptSeed{
+          user: :user2_guest,
+          datashop_session_id: datashop_session_id_user2,
+          resource: :ungraded_page,
+          activity: :activity_1,
+          get_part_inputs: &[%{attempt_guid: &1, input: %StudentInput{input: "3222237681"}}],
+          transformed_model: content,
+          resource_attempt_tag: :user1_graded_page_attempt,
+          activity_attempt_tag: :user1_graded_page_activity_1_attempt,
+          part_attempt_tag: :user1_graded_page_activity_1_part_1_attempt
+        })
+
+      map =
+        map
+        |> Map.put(:datashop_session_id_user1, datashop_session_id_user1)
+        |> Map.put(:datashop_session_id_user2, datashop_session_id_user2)
+
+      {:ok, map}
+    end
+
+    test "generates a valid export", %{
+      project: project,
+      user1: user1,
+      user2_guest: user2_guest
+    } do
+      xml = Datashop.export(project.id)
+
+      xml =~ ~s|<?xml version="1.0" encoding="UTF-8"?>|
+
+      xml =~
+        ~s|<tutor_related_message_sequence version_number="4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://pslcdatashop.org/dtd/tutor_message_v4.xsd">|
+
+      xml =~ ~s|<context_message|
+      xml =~ ~s|<tool_message|
+      xml =~ ~s|<tutor_message|
+      xml =~ ~s|<user_id>#{user1.email}</user_id>|
+      xml =~ ~s|<user_id>#{user2_guest.email}</user_id>|
+      xml =~ ~s|<event_descriptor>|
+      xml =~ ~s|<selection>Activity activity_1, part 1</selection>|
+      xml =~ ~s|<action>Multiple choice submission</action>|
+      xml =~ ~s|<input><![CDATA[<p>Correct</p>]]></input>|
+      xml =~ ~s|</event_descriptor>|
+      xml =~ ~s|<action_evaluation>CORRECT</action_evaluation>|
+    end
+
+    test "uses correct datashop session id for user and uses guest user sub for user_id", %{
+      project: project,
+      user1: user1,
+      user2_guest: user2_guest,
+      datashop_session_id_user1: datashop_session_id_user1,
+      datashop_session_id_user2: datashop_session_id_user2
+    } do
+      xml = Datashop.export(project.id)
+
+      assert xml
+             |> xpath(
+               ~x"//context_message/meta[user_id/text() = '#{user1.email}']/session_id/text()"
+             )
+             |> to_string() == datashop_session_id_user1
+
+      assert xml
+             |> xpath(
+               ~x"//context_message/meta[user_id/text() = '#{user2_guest.sub}']/session_id/text()"
+             )
+             |> to_string() == datashop_session_id_user2
+    end
+  end
+end

--- a/test/oli/delivery/attempts/browse_updates_test.exs
+++ b/test/oli/delivery/attempts/browse_updates_test.exs
@@ -1,4 +1,4 @@
-defmodule Oli.Delivery.Attempts.BrwoseUpdatesTest do
+defmodule Oli.Delivery.Attempts.BrowseUpdatesTest do
   use Oli.DataCase
 
   alias Oli.Delivery.Attempts.Core, as: Attempts

--- a/test/oli/delivery/submission_test.exs
+++ b/test/oli/delivery/submission_test.exs
@@ -166,7 +166,7 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
         PageContext.create_for_visit(section, revision.slug, user2, datashop_session_id_user2)
 
       assert user2_page_context.progress_state == :not_started
-      assert Enum.count(user2_page_context.resource_attempts) == 0
+      assert Enum.empty?(user2_page_context.resource_attempts)
 
       {:ok,
        %Oli.Delivery.Attempts.PageLifecycle.AttemptState{


### PR DESCRIPTION
Fixes an issue where the user_id for guest users is empty datashop export. This should be set to the unique sub of the user in order to identify the separate events for a single anonymous user.

The bulk of the work here is getting a unit test to prove the fix. The unit test simulates users working through an activity and generating data events.

Closes: #2819