### PR TITLE
[BUG FIX] disable scroll wheel on numeric input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bug Fixes
 
+- Fix an issue where scroll wheel changes the value of numeric input
+
 ### Enhancements
 
 ## 0.21.2 (2022-07-20)

--- a/assets/src/components/activities/common/delivery/inputs/NumericInput.tsx
+++ b/assets/src/components/activities/common/delivery/inputs/NumericInput.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { createRef } from 'react';
 
 interface Props {
   onChange: React.ChangeEventHandler<HTMLInputElement>;
@@ -7,8 +7,14 @@ interface Props {
   placeholder?: string;
 }
 export const NumericInput: React.FC<Props> = (props) => {
+  const input = createRef<HTMLInputElement>();
+
+  // disable changing of the value via scroll wheel in certain browsers
+  const handleScrollWheelChange = () => input.current?.blur();
+
   return (
     <input
+      ref={input}
       placeholder={props.placeholder}
       type="number"
       aria-label="answer submission textbox"
@@ -16,6 +22,7 @@ export const NumericInput: React.FC<Props> = (props) => {
       onChange={props.onChange}
       value={props.value}
       disabled={typeof props.disabled === 'boolean' ? props.disabled : false}
+      onWheel={handleScrollWheelChange}
     />
   );
 };


### PR DESCRIPTION
Disables the changing of numeric input value using the scroll wheel in certain browsers.

Closes #2852