### PR TITLE
[BUG FIX] Soft delete institution

### DIFF
--- a/lib/oli/institutions/institution.ex
+++ b/lib/oli/institutions/institution.ex
@@ -8,6 +8,7 @@ defmodule Oli.Institutions.Institution do
     field :institution_email, :string
     field :institution_url, :string
     field :research_consent, Ecto.Enum, values: [:oli_form, :no_form], default: :oli_form
+    field :status, Ecto.Enum, values: [:active, :deleted], default: :active
 
     # an institution can specify a default brand
     belongs_to :default_brand, Oli.Branding.Brand
@@ -35,7 +36,8 @@ defmodule Oli.Institutions.Institution do
       :institution_email,
       :institution_url,
       :default_brand_id,
-      :research_consent
+      :research_consent,
+      :status
     ])
     |> validate_required([
       :name,

--- a/priv/repo/migrations/20220722020459_enable_remove_institution.exs
+++ b/priv/repo/migrations/20220722020459_enable_remove_institution.exs
@@ -1,0 +1,9 @@
+defmodule Oli.Repo.Migrations.EnableRemoveInstitution do
+  use Ecto.Migration
+
+  def change do
+    alter table(:institutions) do
+      add :status, :string, default: "active"
+    end
+  end
+end

--- a/test/oli/institutions_test.exs
+++ b/test/oli/institutions_test.exs
@@ -68,7 +68,8 @@ defmodule Oli.InstitutionsTest do
     test "update_institution/2 updates the institution successfully" do
       institution = insert(:institution)
 
-      {:ok, updated_institution} = Institutions.update_institution(institution, %{name: "new_name"})
+      {:ok, updated_institution} =
+        Institutions.update_institution(institution, %{name: "new_name"})
 
       assert institution.id == updated_institution.id
       assert updated_institution.name == "new_name"
@@ -77,18 +78,13 @@ defmodule Oli.InstitutionsTest do
     test "update_institution/2 does not update the institution when there is an invalid field" do
       institution = insert(:institution)
 
-      {:error, changeset} = Institutions.update_institution(institution, %{research_consent: "invalid"})
+      {:error, changeset} =
+        Institutions.update_institution(institution, %{research_consent: "invalid"})
+
       {error, _} = changeset.errors[:research_consent]
 
       refute changeset.valid?
       assert error =~ "is invalid"
-    end
-
-    test "delete_institution/1 deletes the institution" do
-      institution = insert(:institution)
-      assert {:ok, _deleted_institution} = Institutions.delete_institution(institution)
-
-      assert_raise Ecto.NoResultsError, fn -> Institutions.get_institution!(institution.id) end
     end
 
     test "change_institution/1 returns a institution changeset" do

--- a/test/oli_web/controllers/institution_controller_test.exs
+++ b/test/oli_web/controllers/institution_controller_test.exs
@@ -7,6 +7,7 @@ defmodule OliWeb.InstitutionControllerTest do
   alias Oli.Accounts
   alias Oli.Accounts.Author
   alias Oli.Institutions
+  alias Oli.Institutions.Institution
   alias Oli.Lti.Tool.Registration
   alias Oli.Lti.Tool.Deployment
   alias Oli.Institutions.PendingRegistration
@@ -50,7 +51,7 @@ defmodule OliWeb.InstitutionControllerTest do
     test "redirects to page index when data is valid", %{conn: conn} do
       conn = post(conn, Routes.institution_path(conn, :create), institution: @create_attrs)
 
-      assert redirected_to(conn) == Routes.static_page_path(conn, :index)
+      assert redirected_to(conn) == Routes.institution_path(conn, :index)
     end
 
     test "renders errors when data is invalid", %{conn: conn} do
@@ -112,17 +113,14 @@ defmodule OliWeb.InstitutionControllerTest do
   end
 
   describe "delete institution" do
-    test "deletes chosen institution", %{conn: conn, author: author, institution: institution} do
+    test "deletes chosen institution", %{conn: conn, institution: institution} do
       conn = delete(conn, Routes.institution_path(conn, :delete, institution))
       assert redirected_to(conn) == Routes.institution_path(conn, :index)
 
-      assert_error_sent(404, fn ->
-        conn =
-          recycle(conn)
-          |> Pow.Plug.assign_current_user(author, OliWeb.Pow.PowHelpers.get_pow_config(:author))
+      institution_id = institution.id
 
-        get(conn, Routes.institution_path(conn, :show, institution))
-      end)
+      assert %Institution{id: ^institution_id} =
+               Institutions.get_institution_by!(%{status: :deleted})
     end
   end
 


### PR DESCRIPTION
Fixes an issue where institution deletion may fail due to all the fk constraints. This PR fixes that by allowing a "soft" deletion, simply setting a status flag and hiding the deleted institutions from the manage list.

Closes #2824