### PR TITLE
[BUG FIX] Hide learning objectives on scored pages

### DIFF
--- a/assets/styles/delivery/page_delivery/page.scss
+++ b/assets/styles/delivery/page_delivery/page.scss
@@ -102,12 +102,12 @@ h1.title {
 }
 
 .rolled-up-objectives {
-  margin: 10px;
-  margin-top: 20px;
-  padding: 10px;
+  margin: 20px 10px;
+  padding: 16px;
   background-color: $objectives-background;
   color: $objectives-text;
-  border-radius: 3px;
+  border: 2px solid $objectives-border-color;
+  border-radius: 4px;
 
   .label {
     font-size: 1.2em;

--- a/assets/styles/delivery/variables.scss
+++ b/assets/styles/delivery/variables.scss
@@ -59,6 +59,10 @@ $z-overlay-3: 1100 !default;
 $z-overlay-4: 1150 !default;
 $z-highest: 10000 !default;
 
+$objectives-text: $black !default;
+$objectives-background: lighten($cyan, 35%) !default;
+$objectives-border-color: lighten($cyan, 30%) !default;
+
 // Export all theme SASS variables to CSS
 
 :root {

--- a/assets/styles/themes/delivery/default.scss
+++ b/assets/styles/themes/delivery/default.scss
@@ -41,8 +41,9 @@ html.authoring .content-block .delivery {
   $body-bg: $white;
   $body-color: $gray-900;
 
-  $objectives-text: black;
-  $objectives-background: hsl(178, 70%, 79%);
+  $objectives-text: $black;
+  $objectives-background: lighten($cyan, 35%);
+  $objectives-border-color: lighten($cyan, 30%);
 
   // Auth providers buttons
 
@@ -266,8 +267,9 @@ html.authoring.dark .content-block .delivery {
   $hints-color: $gray-200;
   $hints-bg: $gray-700;
 
-  $objectives-text: white;
-  $objectives-background: hsl(178, 64%, 27%);
+  $objectives-text: $white;
+  $objectives-background: darken($cyan, 35%);
+  $objectives-border-color: darken($cyan, 30%);
 
   // Auth providers buttons
 

--- a/lib/oli_web/templates/page_delivery/page.html.eex
+++ b/lib/oli_web/templates/page_delivery/page.html.eex
@@ -7,7 +7,9 @@
 window.userToken = "<%= assigns[:user_token] %>";
 </script>
 
-<%= render "_objectives.html", objectives: @objectives %>
+<%= unless @graded && not @review_mode do %>
+  <%= render "_objectives.html", objectives: @objectives %>
+<% end %>
 
 <%= if @review_mode == true do %>
   <%= if @resource_attempt.lifecycle_state == :evaluated do  %>


### PR DESCRIPTION
Changes rendering so that pages do not show learning objectives on scored (graded) pages unless in review mode.

Some users commented that the objectives box background color didn't match the rest of the theme, so I tweaked the color here too.

Closes #2853