### PR TITLE
[MER-611] Fix wrong admin redirection on remix edit save

### DIFF
--- a/lib/oli_web/live/delivery/remix_section.ex
+++ b/lib/oli_web/live/delivery/remix_section.ex
@@ -31,7 +31,7 @@ defmodule OliWeb.Delivery.RemixSection do
     do: Routes.page_delivery_path(OliWeb.Endpoint, :index, slug)
 
   defp redirect_after_save(:open_and_free, section),
-    do: OliWeb.OpenAndFreeView.get_path([:admin, :show, section])
+    do: Routes.admin_open_and_free_path(OliWeb.Endpoint, :show, section)
 
   defp redirect_after_save(:admin, %Section{slug: slug}, socket),
     do: Routes.live_path(socket, OliWeb.Sections.OverviewView, slug)


### PR DESCRIPTION
[MER-611](https://eliterate.atlassian.net/browse/MER-611)

### What does it change?

Fixes admin being redirect to a new student/instructor session after saving changes on the section remix page.