### PR TITLE
[FEATURE] [MER-1157] Improve lms grade sync failures handling

### DIFF
--- a/lib/oli/delivery/attempts/page_lifecycle/grade_update_worker.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/grade_update_worker.ex
@@ -34,9 +34,9 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.GradeUpdateWorker do
       # Consider completed jobs to be duplicates the entire time they are retained
       period: :infinity,
 
-      # Only detect conflicts on jobs that are available or scheduled.  Once a job is executing
-      # or finished we no longer want to consider it for duplicate checks
-      states: [:available, :scheduled]
+      # Only detect conflicts on jobs that are available, scheduled, or retryable.
+      # Once a job is completed or discarded we no longer want to consider it for duplicate checks
+      states: [:available, :scheduled, :retryable]
     ]
 
   import Ecto.Query, warn: false

--- a/lib/oli/delivery/attempts/page_lifecycle/grade_update_worker.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/grade_update_worker.ex
@@ -278,4 +278,8 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.GradeUpdateWorker do
     end
     |> track(:not_synced, nil, resource_access, type, job, section)
   end
+
+  def get_jobs() do
+    Repo.all(from(j in Oban.Job, where: j.queue == "grades"))
+  end
 end

--- a/lib/oli_web/live/grades/failed_grade_sync.ex
+++ b/lib/oli_web/live/grades/failed_grade_sync.ex
@@ -1,0 +1,162 @@
+defmodule OliWeb.Grades.FailedGradeSyncLive do
+  use OliWeb.Common.SortableTable.TableHandlers
+  use Surface.LiveView, layout: {OliWeb.LayoutView, "live.html"}
+
+  import Oli.Utils, only: [trap_nil: 2]
+
+  alias Oli.Delivery.Attempts.{Core, PageLifecycle.GradeUpdateWorker}
+  alias OliWeb.Common.{Breadcrumb, Filter, Listing}
+  alias OliWeb.Grades.FailedGradeSyncTableModel
+  alias OliWeb.Router.Helpers, as: Routes
+  alias OliWeb.Sections.Mount
+
+  require Logger
+
+  @title "View Failed LMS Grade Sync"
+  data title, :string, default: @title
+  data breadcrumbs, :any
+
+  data section, :any, default: nil
+  data table_model, :any, default: []
+  data failed_resource_accesses, :any, default: []
+
+  data filter, :any, default: %{}
+  data query, :string, default: ""
+  data total_count, :integer, default: 0
+  data offset, :integer, default: 0
+  data limit, :integer, default: 20
+  data sort, :string, default: "sort"
+  data page_change, :string, default: "page_change"
+  data show_bottom_paging, :boolean, default: false
+  data additional_table_class, :string, default: ""
+
+  @table_filter_fn &__MODULE__.filter_rows/3
+  @table_push_patch_path &__MODULE__.live_path/2
+
+  def filter_rows(socket, query, _filter) do
+    query_str = String.downcase(query)
+
+    Enum.filter(socket.assigns.failed_resource_accesses, fn ra ->
+      String.contains?(String.downcase(ra.user_name), query_str) or
+        String.contains?(String.downcase(ra.page_title), query_str)
+    end)
+  end
+
+  def live_path(socket, params),
+    do: Routes.live_path(socket, __MODULE__, socket.assigns.section.slug, params)
+
+  def set_breadcrumbs(type, section) do
+    type
+    |> OliWeb.Sections.OverviewView.set_breadcrumbs(section)
+    |> breadcrumb(section)
+  end
+
+  defp breadcrumb(previous, section) do
+    previous ++
+      [
+        Breadcrumb.new(%{
+          full_title: @title,
+          link: Routes.live_path(OliWeb.Endpoint, __MODULE__, section.slug)
+        })
+      ]
+  end
+
+  def mount(%{"section_slug" => section_slug}, session, socket) do
+    case Mount.for(section_slug, session) do
+      {:error, e} ->
+        Mount.handle_error(socket, {:error, e})
+
+      {type, user, section} ->
+        failed_resource_accesses = Core.get_failed_grade_sync_resource_accesses_for_section(section.slug)
+
+        {:ok, table_model} = FailedGradeSyncTableModel.new(failed_resource_accesses)
+
+        {:ok,
+          assign(socket,
+            breadcrumbs: set_breadcrumbs(type, section),
+            is_lms_or_system_admin: Mount.is_lms_or_system_admin?(user, section),
+            failed_resource_accesses: failed_resource_accesses,
+            table_model: table_model,
+            total_count: length(failed_resource_accesses),
+            section: section
+          )}
+    end
+  end
+
+  def render(assigns) do
+    ~F"""
+      <div class="d-flex p-3 justify-content-between">
+        <Filter
+          change="change_search"
+          reset="reset_search"
+          apply="apply_search"
+          query={@query} />
+
+          <button class="btn btn-primary mr-5" phx-click="bulk-retry">Retry all</button>
+      </div>
+
+      <div id="failed-sync-grades-table" class="p-4">
+        <Listing
+          filter={@query}
+          table_model={@table_model}
+          total_count={@total_count}
+          offset={@offset}
+          limit={@limit}
+          sort={@sort}
+          page_change={@page_change}
+          show_bottom_paging={@show_bottom_paging}
+          additional_table_class={@additional_table_class} />
+      </div>
+    """
+  end
+
+  def handle_event("retry", %{"resource-id" => resource_id, "user-id" => user_id}, socket) do
+    socket = clear_flash(socket)
+    section = socket.assigns.section
+
+    with {:ok, resource_access} <-
+          resource_id
+          |> Core.get_resource_access(section.slug, user_id)
+          |> trap_nil("The resource access was not found."),
+        {:ok, %Oban.Job{}} <- GradeUpdateWorker.create(section.id, resource_access.id, :manual) do
+      handle_success(socket, section.slug)
+    else
+      error ->
+        log_error(resource_id, user_id, error)
+        {:noreply, put_flash(socket, :error, "Couldn't retry grade sync.")}
+    end
+  end
+
+  def handle_event("bulk-retry", _, socket) do
+    socket = clear_flash(socket)
+    %{section: section, failed_resource_accesses: failed_resource_accesses}  = socket.assigns
+
+    Enum.reduce_while(failed_resource_accesses, true, fn resource_access, acc ->
+      case GradeUpdateWorker.create(section.id, resource_access.id, :manual_batch) do
+        {:ok, %Oban.Job{}} -> {:cont, acc}
+        error ->
+          log_error(resource_access.resource_id, resource_access.user_id, error)
+          {:halt, acc}
+      end
+    end)
+
+    handle_success(socket, section.slug)
+  end
+
+  defp log_error(resource_id, user_id, error),
+    do: Logger.error("Couldn't retry grade sync for resource_id: #{resource_id}, user_id: #{user_id}. Reason: #{inspect(error)}")
+
+  defp handle_success(socket, section_slug) do
+    if socket.assigns.is_lms_or_system_admin do
+      {:noreply,
+        socket
+        |> put_flash(:info, "Retrying grade sync. See processing in real time below.")
+        |> push_redirect(to: Routes.live_path(OliWeb.Endpoint, OliWeb.Grades.ObserveGradeUpdatesView, section_slug))}
+    else
+      {:noreply,
+        socket
+        |> put_flash(:info, "Retrying grade sync. Please check the status again in a few minutes.")
+        |> push_redirect(to: Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.OverviewView, section_slug))}
+    end
+  end
+end

--- a/lib/oli_web/live/grades/failed_grade_sync_table_model.ex
+++ b/lib/oli_web/live/grades/failed_grade_sync_table_model.ex
@@ -1,0 +1,40 @@
+defmodule OliWeb.Grades.FailedGradeSyncTableModel do
+  use Surface.LiveComponent
+
+  alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
+
+  def new(failed_resource_accesses) do
+    SortableTableModel.new(
+      rows: failed_resource_accesses,
+      column_specs: [
+        %ColumnSpec{
+          name: :user_name,
+          label: "Student Name"
+        },
+        %ColumnSpec{
+          name: :page_title,
+          label: "Page title"
+        },
+        %ColumnSpec{
+          name: :action,
+          label: "Action",
+          render_fn: &__MODULE__.render_retry_column/3
+        }
+      ],
+      event_suffix: "",
+      id_field: [:id]
+    )
+  end
+
+  def render_retry_column(assigns, item, _) do
+    ~F"""
+      <button class="btn btn-primary" phx-click="retry" phx-value-resource-id={item.resource_id} phx-value-user-id={item.user_id}>Retry</button>
+    """
+  end
+
+  def render(assigns) do
+    ~F"""
+      <div>nothing</div>
+    """
+  end
+end

--- a/lib/oli_web/live/grades/observe_grade_updates.ex
+++ b/lib/oli_web/live/grades/observe_grade_updates.ex
@@ -98,9 +98,10 @@ defmodule OliWeb.Grades.ObserveGradeUpdatesView do
     {:ok, table_model} = ObserveTableModel.new(updates)
 
     {:noreply,
-     assign(socket,
-       table_model: table_model,
-       total_count: Enum.count(updates)
-     )}
+      assign(socket,
+        updates: updates,
+        table_model: table_model,
+        total_count: Enum.count(updates)
+      )}
   end
 end

--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -144,10 +144,11 @@ defmodule OliWeb.Sections.OverviewView do
               {/if}
             </a>
           </li>
-          <li><a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Grades.GradebookView, @section.slug)}>View Grades</a></li>
+          <li><a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Grades.GradebookView, @section.slug)}>View all Grades</a></li>
           <li><a href={Routes.page_delivery_path(OliWeb.Endpoint, :export_gradebook, @section.slug)}>Download Gradebook as <code>.csv</code> file</a></li>
           {#if !@section.open_and_free}
             <li><a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Grades.GradesLive, @section.slug)}>Manage LMS Gradebook</a></li>
+            <li><a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Grades.FailedGradeSyncLive, @section.slug)}>View Grades that failed to sync</a></li>
             {#if @is_lms_or_system_admin}
               <li><a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Grades.ObserveGradeUpdatesView, @section.slug)}>Observe grade updates in real-time</a></li>
             {/if}

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -782,6 +782,7 @@ defmodule OliWeb.Router do
 
     live("/:section_slug/grades/lms", Grades.GradesLive)
     live("/:section_slug/grades/lms_grade_updates", Grades.BrowseUpdatesView)
+    live("/:section_slug/grades/failed", Grades.FailedGradeSyncLive)
     live("/:section_slug/grades/observe", Grades.ObserveGradeUpdatesView)
     live("/:section_slug/grades/gradebook", Grades.GradebookView)
     live("/:section_slug/scoring", ManualGrading.ManualGradingView)

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Oli.MixProject do
       elixir: "~> 1.13.2",
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: elixirc_options(Mix.env()),
-      compilers: [:phoenix, :gettext] ++ Mix.compilers(),
+      compilers: [:phoenix] ++ Mix.compilers(),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
       deps: deps(),

--- a/test/oli/delivery/attempts_test.exs
+++ b/test/oli/delivery/attempts_test.exs
@@ -11,6 +11,8 @@ defmodule Oli.Delivery.AttemptsTest do
   alias Oli.Delivery.Page.PageContext
   alias Oli.Delivery.Attempts.Core.{ClientEvaluation, StudentInput, ActivityAttempt}
 
+  import Oli.Factory
+
   describe "creating the attempt tree records" do
     setup do
       content1 = %{
@@ -441,6 +443,47 @@ defmodule Oli.Delivery.AttemptsTest do
         Attempts.get_graded_resource_access_for_context(section.slug, [user1.id, user2.id])
 
       assert length(accesses_both) == length(accesses1) + length(accesses2)
+    end
+
+    test "get graded resource accesses where the last lms sync failed - returns empty when no failed sync exists" do
+      user = insert(:user)
+
+      {:ok, section: section, page_revision: page_revision} = section_with_assessment(%{})
+      last_grade_update = insert(:lms_grade_update)
+
+      insert(:resource_access,
+        user: user,
+        section: section,
+        resource: page_revision.resource,
+        last_successful_grade_update_id: last_grade_update.id,
+        last_grade_update_id: last_grade_update.id
+      )
+
+      assert [] == Attempts.get_failed_grade_sync_resource_accesses_for_section(section.slug)
+    end
+
+    test "get graded resource accesses where the last lms sync failed" do
+      user = insert(:user)
+
+      {:ok, section: section, page_revision: page_revision} = section_with_assessment(%{})
+      last_successful_grade_update = insert(:lms_grade_update)
+      last_grade_update = insert(:lms_grade_update)
+
+      resource_access = insert(:resource_access,
+        user: user,
+        section: section,
+        resource: page_revision.resource,
+        last_successful_grade_update_id: last_successful_grade_update.id,
+        last_grade_update_id: last_grade_update.id
+      )
+
+      assert [%{
+        id: resource_access.id,
+        page_title: page_revision.title,
+        resource_id: page_revision.resource.id,
+        user_id: user.id,
+        user_name: user.name
+      }] == Attempts.get_failed_grade_sync_resource_accesses_for_section(section.slug)
     end
 
     test "get latest attempt - activity attempts", %{

--- a/test/oli_web/live/failed_grade_sync_live_test.exs
+++ b/test/oli_web/live/failed_grade_sync_live_test.exs
@@ -1,0 +1,296 @@
+defmodule OliWeb.FailedGradeSyncLiveTest do
+  use ExUnit.Case
+  use OliWeb.ConnCase
+
+  import ExUnit.CaptureLog
+  import Oli.Factory
+  import Phoenix.LiveViewTest
+
+  defp live_view_overview_view_route(section_slug) do
+    Routes.live_path(
+        OliWeb.Endpoint,
+        OliWeb.Sections.OverviewView,
+        section_slug
+    )
+  end
+
+  defp live_view_observe_grade_updates_view_route(section_slug) do
+    Routes.live_path(
+        OliWeb.Endpoint,
+        OliWeb.Grades.ObserveGradeUpdatesView,
+        section_slug
+    )
+  end
+
+  defp live_view_failed_grade_sync_view_route(section_slug) do
+    Routes.live_path(
+      OliWeb.Endpoint,
+      OliWeb.Grades.FailedGradeSyncLive,
+      section_slug
+    )
+  end
+
+  describe "user cannot access when is not logged in" do
+    setup [:section_with_assessment]
+
+    test "redirects to enroll page when accessing the failed grade sync view", %{
+      conn: conn,
+      section: section
+    } do
+      redirect_path = "/sections/#{section.slug}/enroll"
+
+      {:error, {:redirect, %{to: ^redirect_path}}} =
+        live(conn, live_view_failed_grade_sync_view_route(section.slug))
+    end
+  end
+
+  describe "user cannot access when is logged in as an author but is not a system admin" do
+    setup [:author_conn, :section_with_assessment]
+
+    test "redirects to section enroll page when accessing the failed grade sync view", %{
+      conn: conn,
+      section: section
+    } do
+      redirect_path = "/sections/#{section.slug}/enroll"
+
+      {:error, {:redirect, %{to: ^redirect_path}}} =
+        live(conn, live_view_failed_grade_sync_view_route(section.slug))
+    end
+  end
+
+  describe "user can access when is logged in as an instructor" do
+    setup [:lms_instructor_conn, :section_with_assessment, :create_failed_resource_accesses]
+
+    test "loads correctly", %{
+      conn: conn,
+      instructor: instructor,
+      section: section,
+      resource_access_1: resource_access_1,
+      resource_access_2: resource_access_2,
+    } do
+      enroll_user_to_section(instructor, section, :context_instructor)
+
+      {:ok, view, _html} = live(conn, live_view_failed_grade_sync_view_route(section.slug))
+
+      assert has_element?(view, "#failed-sync-grades-table")
+      assert has_element?(view, "button[phx-click=\"bulk-retry\"", "Retry all")
+      assert has_element?(view, "##{resource_access_1.id}")
+      assert has_element?(view, "##{resource_access_2.id}")
+    end
+
+    test "redirects correctly when retrying", %{
+      conn: conn,
+      instructor: instructor,
+      section: section,
+      resource_access_1: %{resource_id: resource_id, user_id: user_id}
+    } do
+      enroll_user_to_section(instructor, section, :context_instructor)
+
+      {:ok, view, _html} = live(conn, live_view_failed_grade_sync_view_route(section.slug))
+
+      view
+      |> element("button[phx-click=\"retry\"][phx-value-user-id=\"#{user_id}\"")
+      |> render_click(%{"resource-id" => resource_id, "user-id" => user_id})
+
+      flash = assert_redirected(view, live_view_overview_view_route(section.slug))
+      assert flash["info"] == "Retrying grade sync. Please check the status again in a few minutes."
+    end
+  end
+
+  describe "failed grade sync view" do
+    setup [:admin_conn, :section_with_assessment, :create_failed_resource_accesses]
+
+    test "loads correctly", %{
+      conn: conn,
+      section: section,
+      resource_access_1: resource_access_1,
+      resource_access_2: resource_access_2
+    } do
+      {:ok, view, _html} = live(conn, live_view_failed_grade_sync_view_route(section.slug))
+
+      assert has_element?(view, "#failed-sync-grades-table")
+      assert has_element?(view, "button[phx-click=\"bulk-retry\"", "Retry all")
+      assert has_element?(view, "##{resource_access_1.id}")
+      assert has_element?(view, "##{resource_access_2.id}")
+    end
+
+    test "applies sorting", %{
+      conn: conn,
+      section: section
+    } do
+      {:ok, view, _html} = live(conn, live_view_failed_grade_sync_view_route(section.slug))
+
+      assert view
+      |> element("tr:first-child > td:first-child")
+      |> render() =~
+        "AAAA Name"
+
+      view
+      |> element("th[phx-click=\"sort\"]:first-of-type")
+      |> render_click(%{sort_by: "user_name"})
+
+      assert view
+      |> element("tr:first-child > td:first-child")
+      |> render() =~
+        "BBBB Name"
+    end
+
+    test "applies searching", %{
+      conn: conn,
+      section: section,
+      resource_access_1: resource_access_1,
+      resource_access_2: resource_access_2
+    } do
+      {:ok, view, _html} = live(conn, live_view_failed_grade_sync_view_route(section.slug))
+
+      view
+      |> element("input[phx-blur=\"change_search\"]")
+      |> render_blur(%{value: "aaaa"})
+
+      view
+      |> element("button[phx-click=\"apply_search\"]")
+      |> render_click()
+
+      assert has_element?(view, "##{resource_access_1.id}")
+      refute has_element?(view, "##{resource_access_2.id}")
+
+      view
+      |> element("button[phx-click=\"reset_search\"]")
+      |> render_click()
+
+      assert has_element?(view, "##{resource_access_1.id}")
+      assert has_element?(view, "##{resource_access_2.id}")
+    end
+
+    test "applies paging", %{
+      conn: conn,
+      section: section,
+      page_revision: page_revision,
+      last_successful_grade_update: last_successful_grade_update,
+      last_grade_update: last_grade_update
+    } do
+      insert_list(
+        19,
+        :resource_access,
+        section: section,
+        resource: page_revision.resource,
+        last_successful_grade_update_id: last_successful_grade_update.id,
+        last_grade_update_id: last_grade_update.id
+      )
+
+      {:ok, view, _html} = live(conn, live_view_failed_grade_sync_view_route(section.slug))
+
+      assert view
+      |> element("tr:first-child > td:first-child")
+      |> render() =~
+        "AAAA Name"
+
+      view
+      |> element("a[phx-click=\"page_change\"]", "2")
+      |> render_click()
+
+      refute view
+      |> element("tr:first-child > td:first-child")
+      |> render() =~
+        "AAAA Name"
+    end
+
+    test "renders error message correctly", %{
+      conn: conn,
+      section: section,
+      resource_access_1: %{user_id: user_id}
+    } do
+      assert capture_log(fn ->
+        {:ok, view, _html} = live(conn, live_view_failed_grade_sync_view_route(section.slug))
+
+        view
+        |> element("button[phx-click=\"retry\"][phx-value-user-id=\"#{user_id}\"")
+        |> render_click(%{"resource-id" => -1, "user-id" => user_id})
+
+        assert view
+        |> element("div.alert.alert-danger")
+        |> render() =~
+          "Couldn&#39;t retry grade sync."
+      end) =~ "Couldn't retry grade sync for resource_id: -1, user_id: #{user_id}. Reason: {:error, {\"The resource access was not found.\"}}"
+    end
+
+    test "retries individual failed grade sync correctly", %{
+      conn: conn,
+      section: section,
+      resource_access_1: %{id: id, resource_id: resource_id, user_id: user_id}
+    } do
+      {:ok, view, _html} = live(conn, live_view_failed_grade_sync_view_route(section.slug))
+
+      view
+      |> element("button[phx-click=\"retry\"][phx-value-user-id=\"#{user_id}\"")
+      |> render_click(%{"resource-id" => resource_id, "user-id" => user_id})
+
+      flash = assert_redirected(view, live_view_observe_grade_updates_view_route(section.slug))
+      assert flash["info"] == "Retrying grade sync. See processing in real time below."
+
+      [%Oban.Job{args: args, queue: "grades"}] = Oli.Delivery.Attempts.PageLifecycle.GradeUpdateWorker.get_jobs()
+
+      assert %{
+        "resource_access_id" => id,
+        "section_id" => section.id,
+        "type" => "manual"
+      } == args
+    end
+
+    test "retries bulk failed grade sync correctly", %{
+      conn: conn,
+      section: section
+    } do
+      {:ok, view, _html} = live(conn, live_view_failed_grade_sync_view_route(section.slug))
+
+      view
+      |> element("button[phx-click=\"bulk-retry\"")
+      |> render_click()
+
+      flash = assert_redirected(view, live_view_observe_grade_updates_view_route(section.slug))
+      assert flash["info"] == "Retrying grade sync. See processing in real time below."
+
+      assert [
+        %Oban.Job{args: %{"type" => "manual_batch"}, queue: "grades"},
+        %Oban.Job{args: %{"type" => "manual_batch"}, queue: "grades"}
+      ] = Oli.Delivery.Attempts.PageLifecycle.GradeUpdateWorker.get_jobs()
+    end
+  end
+
+  defp create_failed_resource_accesses(%{
+    conn: conn,
+    section: section,
+    page_revision: page_revision
+  }) do
+    first_user = insert(:user, name: "AAAA Name")
+    second_user = insert(:user, name: "BBBB Name")
+
+    last_successful_grade_update = insert(:lms_grade_update)
+    last_grade_update = insert(:lms_grade_update)
+
+    resource_access_1 = insert(:resource_access,
+      user: first_user,
+      section: section,
+      resource: page_revision.resource,
+      last_successful_grade_update_id: last_successful_grade_update.id,
+      last_grade_update_id: last_grade_update.id
+    )
+
+    resource_access_2 = insert(:resource_access,
+      user: second_user,
+      section: section,
+      resource: page_revision.resource,
+      last_successful_grade_update_id: last_successful_grade_update.id,
+      last_grade_update_id: last_grade_update.id
+    )
+
+    {:ok,
+      conn: conn,
+      section: section,
+      page_revision: page_revision,
+      last_successful_grade_update: last_successful_grade_update,
+      last_grade_update: last_grade_update,
+      resource_access_1: resource_access_1,
+      resource_access_2: resource_access_2}
+  end
+end

--- a/test/oli_web/live/sections/overview_live_test.exs
+++ b/test/oli_web/live/sections/overview_live_test.exs
@@ -205,9 +205,10 @@ defmodule OliWeb.Sections.OverviewLiveTest do
       assert render(view) =~ "View and manage student grades and progress"
 
       assert has_element?(
-               view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Grades.GradebookView, section.slug)}\"]"
-             )
+        view,
+        "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Grades.GradebookView, section.slug)}\"]",
+        "View all Grades"
+      )
 
       assert has_element?(
                view,
@@ -218,6 +219,12 @@ defmodule OliWeb.Sections.OverviewLiveTest do
                view,
                "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Grades.GradesLive, section.slug)}\"]"
              )
+
+      assert has_element?(
+        view,
+        "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Grades.FailedGradeSyncLive, section.slug)}\"]",
+        "View Grades that failed to sync"
+      )
     end
 
     test "unlink section from lms", %{conn: conn, section: section} do

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -299,7 +299,7 @@ defmodule Oli.TestHelpers do
       |> Pow.Plug.assign_current_user(instructor, OliWeb.Pow.PowHelpers.get_pow_config(:user))
       |> LtiSession.put_session_lti_params(lti_param_ids.instructor)
 
-    {:ok, conn: conn}
+    {:ok, conn: conn, instructor: instructor}
   end
 
   def author_conn(%{conn: conn}) do
@@ -623,7 +623,7 @@ defmodule Oli.TestHelpers do
       revision: page_revision
     })
 
-    section = insert(:section, base_project: project, context_id: UUID.uuid4(), open_and_free: true, registration_open: true)
+    section = insert(:section, base_project: project, context_id: UUID.uuid4(), open_and_free: true, registration_open: true, type: :enrollable)
     {:ok, section} = Sections.create_section_resources(section, publication)
     {:ok, section: section, page_revision: page_revision}
   end


### PR DESCRIPTION
[MER-1157](https://eliterate.atlassian.net/browse/MER-1157)

## What's changed?
- Add a view to list the grades that failed to sync within a section
- Add an option to retry a specific one or retry all at once
  - For the bulk retry, did a reduce + specific insert (instead of insert_all) to preserve job uniqueness. If db fail to store a job, execution is halted
- Add `retryable` state to be compared for uniqueness, so we avoid having duplicates job if one it's running 
- Fix observer updates view to list all updates happening
- Fix `gettext` warning after some version upgrades