### PR TITLE
[MER-1323] Oban setup for part_mapping view refresh

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -124,7 +124,7 @@ config :oli, OliWeb.Endpoint,
 config :oli, Oban,
   repo: Oli.Repo,
   plugins: [Oban.Plugins.Pruner],
-  queues: [default: 10, snapshots: 20, selections: 2, updates: 10, grades: 30]
+  queues: [default: 10, snapshots: 20, selections: 2, updates: 10, grades: 30, part_mapping_refresh: 1]
 
 config :ex_money,
   auto_start_exchange_rate_service: false,

--- a/lib/oli/publishing.ex
+++ b/lib/oli/publishing.ex
@@ -1147,14 +1147,6 @@ defmodule Oli.Publishing do
     Enum.map(results, fn [slug, title] -> %{slug: slug, title: title} end)
   end
 
-  @doc """
-    Refreshes the part_mapping materialized view.
-    Since this operation is expensive, do not use perform it synchronously unless neccesary.
-  """
-  def refresh_part_mapping() do
-    Repo.query("REFRESH MATERIALIZED VIEW CONCURRENTLY part_mapping")
-  end
-
   @spec refresh_adapter() :: PartMappingRefreshAdapter
   defp refresh_adapter() do
     :oli

--- a/lib/oli/publishing/part_mapping_refresh_async.ex
+++ b/lib/oli/publishing/part_mapping_refresh_async.ex
@@ -1,5 +1,6 @@
 defmodule Oli.Publishing.PartMappingRefreshAsync do
   alias Oli.Publishing.PartMappingRefreshAdapter
+  alias Oli.Publishing.PartMappingRefreshWorker
 
   @type ecto_publication_operation :: PartMappingRefreshAdapter.ecto_publication_operation()
 
@@ -8,11 +9,7 @@ defmodule Oli.Publishing.PartMappingRefreshAsync do
   @impl PartMappingRefreshAdapter
   @spec maybe_refresh_part_mapping(ecto_publication_operation) :: ecto_publication_operation
   def maybe_refresh_part_mapping({:ok, _publication} = operation_result) do
-    Task.start(fn ->
-      Process.sleep(5_000)
-      Oli.Publishing.refresh_part_mapping()
-    end)
-
+    PartMappingRefreshWorker.create()
     operation_result
   end
 

--- a/lib/oli/publishing/part_mapping_refresh_sync.ex
+++ b/lib/oli/publishing/part_mapping_refresh_sync.ex
@@ -1,5 +1,6 @@
 defmodule Oli.Publishing.PartMappingRefreshSync do
   alias Oli.Publishing.PartMappingRefreshAdapter
+  alias Oli.Publishing.PartMappingRefreshWorker
 
   @type ecto_publication_operation :: PartMappingRefreshAdapter.ecto_publication_operation()
 
@@ -12,7 +13,7 @@ defmodule Oli.Publishing.PartMappingRefreshSync do
   @impl PartMappingRefreshAdapter
   @spec maybe_refresh_part_mapping(ecto_publication_operation) :: ecto_publication_operation
   def maybe_refresh_part_mapping({:ok, _publication} = operation_result) do
-    Oli.Publishing.refresh_part_mapping()
+    PartMappingRefreshWorker.perform_now()
     operation_result
   end
 

--- a/lib/oli/publishing/part_mapping_refresh_worker.ex
+++ b/lib/oli/publishing/part_mapping_refresh_worker.ex
@@ -1,0 +1,46 @@
+defmodule Oli.Publishing.PartMappingRefreshWorker do
+  @moduledoc """
+    An Oban worker for refreshing the part_mapping materialized view.
+    The view must be refreshed at least once after a Publication update is made.
+    Since the complete view is refreshed, we avoid duplicate jobs in the queue, and only queue one max job if there's one being executed.
+  """
+
+  use Oban.Worker,
+    queue: :part_mapping_refresh,
+    # We're stating that all jobs scheduled or available are the same.
+    # if a there's a job in the queue (unless it's already executing), we don't want to queue another one.
+    unique: [fields: [:queue, :worker], states: [:scheduled, :available]]
+
+  import Ecto.Query, warn: false
+  alias Oli.Repo
+
+  require Logger
+
+  def create() do
+    case Oli.Publishing.PartMappingRefreshWorker.new(%{})
+         |> Oban.insert() do
+      {:ok, job} ->
+        {:ok, job}
+
+      e ->
+        e
+    end
+  end
+
+  @impl Oban.Worker
+  def perform(_job) do
+    execute_refresh()
+  end
+
+  @doc """
+    Refreshes the part_mapping materialized view.
+    Since this operation is expensive, do not use it synchronously unless neccesary.
+  """
+  def perform_now() do
+    execute_refresh()
+  end
+
+  defp execute_refresh() do
+    Repo.query("REFRESH MATERIALIZED VIEW CONCURRENTLY part_mapping")
+  end
+end

--- a/lib/oli/publishing/part_mapping_refresh_worker.ex
+++ b/lib/oli/publishing/part_mapping_refresh_worker.ex
@@ -3,6 +3,9 @@ defmodule Oli.Publishing.PartMappingRefreshWorker do
     An Oban worker for refreshing the part_mapping materialized view.
     The view must be refreshed at least once after a Publication update is made.
     Since the complete view is refreshed, we avoid duplicate jobs in the queue, and only queue one max job if there's one being executed.
+
+    In Oli.Application the part_mapping_refresh queue is setup to be only configured in one node of the cluster. This is to ensure that only one node
+    is trying to refresh the view at any time.
   """
 
   use Oban.Worker,
@@ -17,7 +20,7 @@ defmodule Oli.Publishing.PartMappingRefreshWorker do
   require Logger
 
   def create() do
-    case Oli.Publishing.PartMappingRefreshWorker.new(%{})
+    case new(%{})
          |> Oban.insert() do
       {:ok, job} ->
         {:ok, job}


### PR DESCRIPTION
[MER-1323](https://eliterate.atlassian.net/browse/MER-1323)

### What does it change?

Refactors the part_mapping materialized view refresh, by implementing an Oban worker that limits the amount of processes we trigger to refresh the view. 

In PR #2750 we introduced async tasks to refresh the publication, which could spawn N process at the same time. This implementation works, however since the materialized view is refreshed completely each time, we can improve it by avoiding locking the view with refresh operations that don't actually update the data. 

