### PR TITLE
[CHORE] Change onEditModel to useEditModelCallback

### DIFF
--- a/assets/src/components/editing/elements/blockcode/BlockcodeElement.tsx
+++ b/assets/src/components/editing/elements/blockcode/BlockcodeElement.tsx
@@ -1,6 +1,6 @@
 import React, { PropsWithChildren, useEffect, useRef, Suspense, useState } from 'react';
 import { throttle } from 'lodash';
-import { useEditModel } from 'components/editing/elements/utils';
+import { useEditModelCallback } from 'components/editing/elements/utils';
 import * as ContentModel from 'data/content/model/elements/types';
 import { EditorProps } from 'components/editing/elements/interfaces';
 import { CaptionEditor } from 'components/editing/elements/common/settings/CaptionEditor';
@@ -42,7 +42,7 @@ export const CodeEditor = (props: PropsWithChildren<CodeEditorProps>) => {
   const editorRef = useRef<RefEditorInstance>(null);
   const [model] = useState(getInitialModel(props.model));
 
-  const onEdit = useEditModel(model);
+  const onEdit = useEditModelCallback(model);
 
   const updateSize = (editor?: monaco.editor.IStandaloneCodeEditor) => {
     if (editor && editorContainer.current) {

--- a/assets/src/components/editing/elements/blockcode/BlockcodeElement.tsx
+++ b/assets/src/components/editing/elements/blockcode/BlockcodeElement.tsx
@@ -1,6 +1,6 @@
 import React, { PropsWithChildren, useEffect, useRef, Suspense, useState } from 'react';
 import { throttle } from 'lodash';
-import { onEditModel } from 'components/editing/elements/utils';
+import { useEditModel } from 'components/editing/elements/utils';
 import * as ContentModel from 'data/content/model/elements/types';
 import { EditorProps } from 'components/editing/elements/interfaces';
 import { CaptionEditor } from 'components/editing/elements/common/settings/CaptionEditor';
@@ -42,7 +42,7 @@ export const CodeEditor = (props: PropsWithChildren<CodeEditorProps>) => {
   const editorRef = useRef<RefEditorInstance>(null);
   const [model] = useState(getInitialModel(props.model));
 
-  const onEdit = onEditModel(model);
+  const onEdit = useEditModel(model);
 
   const updateSize = (editor?: monaco.editor.IStandaloneCodeEditor) => {
     if (editor && editorContainer.current) {

--- a/assets/src/components/editing/elements/cite/CiteElement.tsx
+++ b/assets/src/components/editing/elements/cite/CiteElement.tsx
@@ -1,10 +1,10 @@
 import { EditorProps } from 'components/editing/elements/interfaces';
 import { CitationEditor } from 'components/editing/elements/cite/CitationEditor';
-import { InlineChromiumBugfix, onEditModel, updateModel } from 'components/editing/elements/utils';
+import { InlineChromiumBugfix, updateModel } from 'components/editing/elements/utils';
 import { HoverContainer } from 'components/editing/toolbar/HoverContainer';
 import { Toolbar } from 'components/editing/toolbar/Toolbar';
 import * as ContentModel from 'data/content/model/elements/types';
-import React, { useState } from 'react';
+import React from 'react';
 import { useSelected, useSlate } from 'slate-react';
 import { CommandButton } from 'components/editing/toolbar/buttons/CommandButton';
 import { createButtonCommandDesc } from '../commands/commandFactories';

--- a/assets/src/components/editing/elements/formula/FormulaEditor.tsx
+++ b/assets/src/components/editing/elements/formula/FormulaEditor.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useEditModel } from 'components/editing/elements/utils';
+import { useEditModelCallback } from 'components/editing/elements/utils';
 import * as ContentModel from 'data/content/model/elements/types';
 import { EditorProps } from 'components/editing/elements/interfaces';
 import { Formula } from '../../../common/Formula';
@@ -9,7 +9,7 @@ import { modalActions } from '../../../../actions/modal';
 
 interface Props extends EditorProps<ContentModel.FormulaBlock | ContentModel.FormulaInline> {}
 export const FormulaEditor = (props: Props) => {
-  const onEdit = useEditModel(props.model);
+  const onEdit = useEditModelCallback(props.model);
 
   if (props.model.src === undefined)
     return (

--- a/assets/src/components/editing/elements/formula/FormulaEditor.tsx
+++ b/assets/src/components/editing/elements/formula/FormulaEditor.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { onEditModel } from 'components/editing/elements/utils';
+import { useEditModel } from 'components/editing/elements/utils';
 import * as ContentModel from 'data/content/model/elements/types';
 import { EditorProps } from 'components/editing/elements/interfaces';
 import { Formula } from '../../../common/Formula';
@@ -9,7 +9,7 @@ import { modalActions } from '../../../../actions/modal';
 
 interface Props extends EditorProps<ContentModel.FormulaBlock | ContentModel.FormulaInline> {}
 export const FormulaEditor = (props: Props) => {
-  const onEdit = onEditModel(props.model);
+  const onEdit = useEditModel(props.model);
 
   if (props.model.src === undefined)
     return (

--- a/assets/src/components/editing/elements/image/block/ImageElement.tsx
+++ b/assets/src/components/editing/elements/image/block/ImageElement.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { onEditModel } from 'components/editing/elements/utils';
+import { useEditModel } from 'components/editing/elements/utils';
 import * as ContentModel from 'data/content/model/elements/types';
 import { EditorProps } from 'components/editing/elements/interfaces';
 import { HoverContainer } from 'components/editing/toolbar/HoverContainer';
@@ -12,7 +12,7 @@ import { ImageSettings } from 'components/editing/elements/image/ImageSettings';
 interface Props extends EditorProps<ContentModel.ImageBlock> {}
 export const ImageEditor = (props: Props) => {
   const selected = useElementSelected();
-  const onEdit = onEditModel(props.model);
+  const onEdit = useEditModel(props.model);
 
   if (props.model.src === undefined) return <ImagePlaceholder {...props} />;
 

--- a/assets/src/components/editing/elements/image/block/ImageElement.tsx
+++ b/assets/src/components/editing/elements/image/block/ImageElement.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useEditModel } from 'components/editing/elements/utils';
+import { useEditModelCallback } from 'components/editing/elements/utils';
 import * as ContentModel from 'data/content/model/elements/types';
 import { EditorProps } from 'components/editing/elements/interfaces';
 import { HoverContainer } from 'components/editing/toolbar/HoverContainer';
@@ -12,7 +12,7 @@ import { ImageSettings } from 'components/editing/elements/image/ImageSettings';
 interface Props extends EditorProps<ContentModel.ImageBlock> {}
 export const ImageEditor = (props: Props) => {
   const selected = useElementSelected();
-  const onEdit = useEditModel(props.model);
+  const onEdit = useEditModelCallback(props.model);
 
   if (props.model.src === undefined) return <ImagePlaceholder {...props} />;
 

--- a/assets/src/components/editing/elements/image/block/ImagePlaceholder.tsx
+++ b/assets/src/components/editing/elements/image/block/ImagePlaceholder.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { onEditModel } from 'components/editing/elements/utils';
+import { useEditModel } from 'components/editing/elements/utils';
 import * as ContentModel from 'data/content/model/elements/types';
 import { EditorProps } from 'components/editing/elements/interfaces';
 import { Placeholder } from 'components/editing/elements/common/Placeholder';
@@ -8,7 +8,7 @@ import { Maybe } from 'tsmonad';
 
 interface Props extends EditorProps<ContentModel.ImageBlock> {}
 export function ImagePlaceholder(props: Props) {
-  const onEdit = onEditModel(props.model);
+  const onEdit = useEditModel(props.model);
 
   return (
     <Placeholder

--- a/assets/src/components/editing/elements/image/block/ImagePlaceholder.tsx
+++ b/assets/src/components/editing/elements/image/block/ImagePlaceholder.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useEditModel } from 'components/editing/elements/utils';
+import { useEditModelCallback } from 'components/editing/elements/utils';
 import * as ContentModel from 'data/content/model/elements/types';
 import { EditorProps } from 'components/editing/elements/interfaces';
 import { Placeholder } from 'components/editing/elements/common/Placeholder';
@@ -8,7 +8,7 @@ import { Maybe } from 'tsmonad';
 
 interface Props extends EditorProps<ContentModel.ImageBlock> {}
 export function ImagePlaceholder(props: Props) {
-  const onEdit = useEditModel(props.model);
+  const onEdit = useEditModelCallback(props.model);
 
   return (
     <Placeholder

--- a/assets/src/components/editing/elements/image/inline/ImageInlineElement.tsx
+++ b/assets/src/components/editing/elements/image/inline/ImageInlineElement.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { elementBorderStyle, onEditModel } from 'components/editing/elements/utils';
+import { elementBorderStyle, useEditModel } from 'components/editing/elements/utils';
 import * as ContentModel from 'data/content/model/elements/types';
 import { EditorProps } from 'components/editing/elements/interfaces';
 import { useElementSelected } from 'data/content/utils';
@@ -8,7 +8,7 @@ import { ImageSettings } from 'components/editing/elements/image/ImageSettings';
 interface Props extends EditorProps<ContentModel.ImageInline> {}
 export const ImageInlineEditor = (props: Props) => {
   const selected = useElementSelected();
-  const onEdit = onEditModel(props.model);
+  const onEdit = useEditModel(props.model);
 
   return (
     <span {...props.attributes} onMouseDown={(e) => e.stopPropagation()}>

--- a/assets/src/components/editing/elements/image/inline/ImageInlineElement.tsx
+++ b/assets/src/components/editing/elements/image/inline/ImageInlineElement.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { elementBorderStyle, useEditModel } from 'components/editing/elements/utils';
+import { elementBorderStyle, useEditModelCallback } from 'components/editing/elements/utils';
 import * as ContentModel from 'data/content/model/elements/types';
 import { EditorProps } from 'components/editing/elements/interfaces';
 import { useElementSelected } from 'data/content/utils';
@@ -8,7 +8,7 @@ import { ImageSettings } from 'components/editing/elements/image/ImageSettings';
 interface Props extends EditorProps<ContentModel.ImageInline> {}
 export const ImageInlineEditor = (props: Props) => {
   const selected = useElementSelected();
-  const onEdit = useEditModel(props.model);
+  const onEdit = useEditModelCallback(props.model);
 
   return (
     <span {...props.attributes} onMouseDown={(e) => e.stopPropagation()}>

--- a/assets/src/components/editing/elements/link/LinkElement.tsx
+++ b/assets/src/components/editing/elements/link/LinkElement.tsx
@@ -1,5 +1,5 @@
 import { EditorProps } from 'components/editing/elements/interfaces';
-import { InlineChromiumBugfix, onEditModel } from 'components/editing/elements/utils';
+import { InlineChromiumBugfix, useEditModel } from 'components/editing/elements/utils';
 import { HoverContainer } from 'components/editing/toolbar/HoverContainer';
 import { Toolbar } from 'components/editing/toolbar/Toolbar';
 import * as ContentModel from 'data/content/model/elements/types';
@@ -18,7 +18,7 @@ export interface Props extends EditorProps<ContentModel.Hyperlink> {}
 export const LinkEditor = (props: Props) => {
   const selected = useSelected();
   const isOpen = React.useCallback(() => selected, [selected]);
-  const onEdit = onEditModel(props.model);
+  const onEdit = useEditModel(props.model);
 
   return (
     <a

--- a/assets/src/components/editing/elements/link/LinkElement.tsx
+++ b/assets/src/components/editing/elements/link/LinkElement.tsx
@@ -1,5 +1,5 @@
 import { EditorProps } from 'components/editing/elements/interfaces';
-import { InlineChromiumBugfix, useEditModel } from 'components/editing/elements/utils';
+import { InlineChromiumBugfix, useEditModelCallback } from 'components/editing/elements/utils';
 import { HoverContainer } from 'components/editing/toolbar/HoverContainer';
 import { Toolbar } from 'components/editing/toolbar/Toolbar';
 import * as ContentModel from 'data/content/model/elements/types';
@@ -18,7 +18,7 @@ export interface Props extends EditorProps<ContentModel.Hyperlink> {}
 export const LinkEditor = (props: Props) => {
   const selected = useSelected();
   const isOpen = React.useCallback(() => selected, [selected]);
-  const onEdit = useEditModel(props.model);
+  const onEdit = useEditModelCallback(props.model);
 
   return (
     <a

--- a/assets/src/components/editing/elements/utils.tsx
+++ b/assets/src/components/editing/elements/utils.tsx
@@ -18,7 +18,7 @@ export function updateModel<T extends ContentModel.ModelElement>(
   Transforms.setNodes(editor, changes, { at: path });
 }
 
-export const useEditModel = <T extends ContentModel.ModelElement>(model: T) => {
+export const useEditModelCallback = <T extends ContentModel.ModelElement>(model: T) => {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const editor = useSlate();
 

--- a/assets/src/components/editing/elements/utils.tsx
+++ b/assets/src/components/editing/elements/utils.tsx
@@ -18,7 +18,7 @@ export function updateModel<T extends ContentModel.ModelElement>(
   Transforms.setNodes(editor, changes, { at: path });
 }
 
-export const onEditModel = <T extends ContentModel.ModelElement>(model: T) => {
+export const useEditModel = <T extends ContentModel.ModelElement>(model: T) => {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const editor = useSlate();
 

--- a/assets/src/components/editing/elements/utils.tsx
+++ b/assets/src/components/editing/elements/utils.tsx
@@ -19,10 +19,8 @@ export function updateModel<T extends ContentModel.ModelElement>(
 }
 
 export const useEditModelCallback = <T extends ContentModel.ModelElement>(model: T) => {
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const editor = useSlate();
 
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   return React.useCallback((attrs: Partial<T>) => updateModel<T>(editor, model, attrs), [editor]);
 };
 

--- a/assets/src/components/editing/elements/video/VideoEditor.tsx
+++ b/assets/src/components/editing/elements/video/VideoEditor.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { onEditModel } from 'components/editing/elements/utils';
+import { useEditModelCallback } from 'components/editing/elements/utils';
 import { Video } from 'data/content/model/elements/types';
 import { EditorProps } from 'components/editing/elements/interfaces';
 
@@ -13,7 +13,7 @@ interface Props extends EditorProps<Video> {}
 
 export const VideoEditor = (props: Props) => {
   const { model } = props;
-  const onEdit = onEditModel(model);
+  const onEdit = useEditModelCallback(model);
   const selected = useElementSelected();
 
   if (!model.src || model.src.length === 0) {

--- a/assets/src/components/editing/elements/video/VideoPlaceholder.tsx
+++ b/assets/src/components/editing/elements/video/VideoPlaceholder.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { onEditModel } from 'components/editing/elements/utils';
+import { useEditModelCallback } from 'components/editing/elements/utils';
 import * as ContentModel from 'data/content/model/elements/types';
 import { EditorProps } from 'components/editing/elements/interfaces';
 import { Placeholder } from 'components/editing/elements/common/Placeholder';
@@ -9,7 +9,7 @@ import { selectVideo } from './videoActions';
 
 interface Props extends EditorProps<ContentModel.Video> {}
 export function VideoPlaceholder(props: Props) {
-  const onEdit = onEditModel(props.model);
+  const onEdit = useEditModelCallback(props.model);
 
   const onSelectVideo = () =>
     selectVideo(props.commandContext.projectSlug, props.model.src[0]?.url).then((selection) =>

--- a/assets/src/components/editing/elements/webpage/WebpageElement.tsx
+++ b/assets/src/components/editing/elements/webpage/WebpageElement.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { elementBorderStyle, onEditModel } from 'components/editing/elements/utils';
+import { elementBorderStyle, useEditModel } from 'components/editing/elements/utils';
 import * as ContentModel from 'data/content/model/elements/types';
 import { EditorProps } from 'components/editing/elements/interfaces';
 import { CaptionEditor } from 'components/editing/elements/common/settings/CaptionEditor';
@@ -10,7 +10,7 @@ import { WebpageSettings } from 'components/editing/elements/webpage/WebpageSett
 export interface Props extends EditorProps<ContentModel.Webpage> {}
 export const WebpageEditor = (props: Props) => {
   const selected = useElementSelected();
-  const onEdit = onEditModel(props.model);
+  const onEdit = useEditModel(props.model);
 
   return (
     <div {...props.attributes} className="webpage-editor">

--- a/assets/src/components/editing/elements/webpage/WebpageElement.tsx
+++ b/assets/src/components/editing/elements/webpage/WebpageElement.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { elementBorderStyle, useEditModel } from 'components/editing/elements/utils';
+import { elementBorderStyle, useEditModelCallback } from 'components/editing/elements/utils';
 import * as ContentModel from 'data/content/model/elements/types';
 import { EditorProps } from 'components/editing/elements/interfaces';
 import { CaptionEditor } from 'components/editing/elements/common/settings/CaptionEditor';
@@ -10,7 +10,7 @@ import { WebpageSettings } from 'components/editing/elements/webpage/WebpageSett
 export interface Props extends EditorProps<ContentModel.Webpage> {}
 export const WebpageEditor = (props: Props) => {
   const selected = useElementSelected();
-  const onEdit = useEditModel(props.model);
+  const onEdit = useEditModelCallback(props.model);
 
   return (
     <div {...props.attributes} className="webpage-editor">

--- a/assets/src/components/editing/elements/youtube/YoutubeElement.tsx
+++ b/assets/src/components/editing/elements/youtube/YoutubeElement.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useSelected, useFocused } from 'slate-react';
-import { onEditModel } from 'components/editing/elements/utils';
+import { useEditModel } from 'components/editing/elements/utils';
 import * as ContentModel from 'data/content/model/elements/types';
 import { EditorProps } from 'components/editing/elements/interfaces';
 import { CaptionEditor } from 'components/editing/elements/common/settings/CaptionEditor';
@@ -50,7 +50,7 @@ export const YouTubeEditor = (props: YouTubeProps) => {
   const fullSrc =
     'https://www.youtube.com/embed/' + (props.model.src || CUTE_OTTERS) + '?' + parameters;
 
-  const onEdit = onEditModel(props.model);
+  const onEdit = useEditModel(props.model);
 
   const borderStyle =
     focused && selected

--- a/assets/src/components/editing/elements/youtube/YoutubeElement.tsx
+++ b/assets/src/components/editing/elements/youtube/YoutubeElement.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useSelected, useFocused } from 'slate-react';
-import { useEditModel } from 'components/editing/elements/utils';
+import { useEditModelCallback } from 'components/editing/elements/utils';
 import * as ContentModel from 'data/content/model/elements/types';
 import { EditorProps } from 'components/editing/elements/interfaces';
 import { CaptionEditor } from 'components/editing/elements/common/settings/CaptionEditor';
@@ -50,7 +50,7 @@ export const YouTubeEditor = (props: YouTubeProps) => {
   const fullSrc =
     'https://www.youtube.com/embed/' + (props.model.src || CUTE_OTTERS) + '?' + parameters;
 
-  const onEdit = useEditModel(props.model);
+  const onEdit = useEditModelCallback(props.model);
 
   const borderStyle =
     focused && selected


### PR DESCRIPTION
Changes onEditModel to useEditModelCallback to be more consistent with hooks naming convention.