### PR TITLE
[JAN-1827] Fixes one cause a race condition

### DIFF
--- a/assets/src/adaptivity/scripting.ts
+++ b/assets/src/adaptivity/scripting.ts
@@ -222,6 +222,9 @@ export const getExpressionStringForValue = (
     // val = convertExponentialToDecimal(val);
     val = parseFloat(val);
     if (val === '') {
+      // TODO: Figure out the intent here.
+      // If val == '' then parseFloat will return NaN before it
+      // hits this block, so we'll never get here.
       val = 'null';
     }
   }


### PR DESCRIPTION
Additional debugging in this issue has come up with the following observations:

When I'm seeing the bug occur, in defaultGlobalEnv from scripting.ts, the value of the input is set to NaN, and it continues to be NaN long after the initial render, so it doesn't seem to be a case of the component not getting an updated value.

I put some debugging statements into evalScript and we're running this script:
`let {q:1461614198663:472|stage.VolcanicCChange.value} = NaN;`

When the bug occurs, it runs after this script which sets it to the correct value.
`let {q:1461614198663:472|stage.VolcanicCChange.value} = 4.7;`

So something is explicitly setting the value to NaN

Sometimes that script runs before, and sometimes it runs after the debug message:
DECK HANDLE READY (ALL ACTIVITIES DONE INIT) 

I've traced up where the `let {q:1461614198663:472|stage.VolcanicCChange.value} = NaN;` script gets run from, and it appears to be generated from the getAssignStatements in savePart.ts around line 48

This leads me to believe this might not be a systemic problem in adaptive lessons, but more a bug in individual components within them. We've seen similar problems on number inputs and in sliders, but it may be more widespread if the same patterns were followed in other components.

Sometimes, the `let {q:1461614198663:472|stage.VolcanicCChange.value} = NaN;` script runs with 2 other assignments, and sometimes it's alone. This corresponds to two different symptoms of the bug:

1. the input will be empty & enabled - I think this is caused by an init coming from that component after we've set the value
2. the input will be empty but disabled - This is caused by a debounced onSave coming through with an empty value after the initial value was set

This PR should fix the second source of the bug. There's a very slim chance it fixes the first, since I also cleaned up the dependencies around initialize.

This does not fix the bug in any component except the NumberInput, if this works, we'll have to do a similar refactor to each affected component

I've been unable to positively identify the first cause of the bug, so it probably is still possible.