### PR TITLE
[MER-1368] Persistent session keep alive improvements

### DIFF
--- a/assets/src/phoenix/keep-alive.ts
+++ b/assets/src/phoenix/keep-alive.ts
@@ -16,11 +16,15 @@
  * More Info: https://github.com/danschultzer/pow/issues/271
  * https://elixirforum.com/t/get-user-id-with-pow-from-session-for-live-view/24206/4
  */
+
+// Wait time set to 15 min which is the deafult time set by Pow to renew sessions (session_ttl_renewal)
+const waitTime = 900000 // 15 minutes in ms
+
 if (!window.keepAlive) {
   window.keepAlive = () => {
-    const scriptTag = document.getElementById('keep-alive');
-    const userType = scriptTag ? scriptTag.getAttribute('data-type') : 'user';
-    const keepAliveUrl = `${userType == 'author' ? '/authoring' : ''}/keep-alive`;
+    // Check for which template (delivery or authoring) we're in
+    const is_authoring = $("#layout-id").data("layout-id") === "authoring";
+    const keepAliveUrl = `${is_authoring ? '/authoring' : ''}/keep-alive`;
 
     const wait = (ms: number) => {
       return () =>
@@ -30,7 +34,7 @@ if (!window.keepAlive) {
     };
 
     fetch(keepAliveUrl)
-      .then(wait(60 * 1000 /*ms*/))
+      .then(wait(waitTime))
       .then(window.keepAlive);
   };
 

--- a/assets/src/phoenix/keep-alive.ts
+++ b/assets/src/phoenix/keep-alive.ts
@@ -17,14 +17,14 @@
  * https://elixirforum.com/t/get-user-id-with-pow-from-session-for-live-view/24206/4
  */
 
-// Wait time set to 15 min which is the deafult time set by Pow to renew sessions (session_ttl_renewal)
-const waitTime = 900000 // 15 minutes in ms
+// Wait time to renew session set to 10 min. Default Pow session rewnew is at 15 min (session_ttl_renewal)
+const waitTime = 600000; // 10 min in ms
 
 if (!window.keepAlive) {
   window.keepAlive = () => {
     // Check for which template (delivery or authoring) we're in
-    const is_authoring = $("#layout-id").data("layout-id") === "authoring";
-    const keepAliveUrl = `${is_authoring ? '/authoring' : ''}/keep-alive`;
+    const isAuthoring = $('#layout-id').data('layout-id') === 'authoring';
+    const keepAliveUrl = `${isAuthoring ? '/authoring' : ''}/keep-alive`;
 
     const wait = (ms: number) => {
       return () =>
@@ -33,9 +33,7 @@ if (!window.keepAlive) {
         });
     };
 
-    fetch(keepAliveUrl)
-      .then(wait(waitTime))
-      .then(window.keepAlive);
+    fetch(keepAliveUrl).then(wait(waitTime)).then(window.keepAlive);
   };
 
   window.keepAlive();

--- a/lib/oli_web/templates/layout/authoring.html.leex
+++ b/lib/oli_web/templates/layout/authoring.html.leex
@@ -81,9 +81,9 @@
       <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/timezone.js") %>"></script>
     <% end %>
     <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/dark.js") %>"></script>
-    <script id="keep-alive" type="text/javascript" src="<%= Routes.static_path(@conn, "/js/keepalive.js") %>" data-type="author"></script>
   </head>
   <body>
+    <input type="hidden" id="layout-id" data-layout-id="authoring">
 
     <%= live_render(@conn, OliWeb.SystemMessageLive.ShowView) %>
 

--- a/lib/oli_web/templates/layout/delivery.html.eex
+++ b/lib/oli_web/templates/layout/delivery.html.eex
@@ -77,9 +77,9 @@
       <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/timezone.js") %>"></script>
     <% end %>
     <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/dark.js") %>"></script>
-    <script id="keep-alive" type="text/javascript" src="<%= Routes.static_path(@conn, "/js/keepalive.js") %>" data-type="user"></script>
   </head>
   <body>
+    <input type="hidden" id="layout-id" data-layout-id="delivery">
 
     <%= live_render(@conn, OliWeb.SystemMessageLive.ShowView) %>
     <%= render OliWeb.LayoutView, "_pay_early.html", assigns %>

--- a/lib/oli_web/templates/layout/live.html.leex
+++ b/lib/oli_web/templates/layout/live.html.leex
@@ -23,4 +23,5 @@
   </div>
 <% end %>
 
+<script id="keep-alive" type="text/javascript" src="<%= Routes.static_path(OliWeb.Endpoint, "/js/keepalive.js") %>"></script>
 <%= @inner_content %>

--- a/lib/oli_web/views/layout_view.ex
+++ b/lib/oli_web/views/layout_view.ex
@@ -26,7 +26,6 @@ defmodule OliWeb.LayoutView do
   alias OliWeb.Breadcrumb.BreadcrumbTrailLive
   alias Oli.Delivery.Paywall.AccessSummary
   alias Oli.Delivery.Sections
-  alias OliWeb.Router.Helpers, as: Routes
 
   def show_pay_early(%AccessSummary{reason: :within_grace_period}), do: true
   def show_pay_early(_), do: false

--- a/lib/oli_web/views/layout_view.ex
+++ b/lib/oli_web/views/layout_view.ex
@@ -26,6 +26,7 @@ defmodule OliWeb.LayoutView do
   alias OliWeb.Breadcrumb.BreadcrumbTrailLive
   alias Oli.Delivery.Paywall.AccessSummary
   alias Oli.Delivery.Sections
+  alias OliWeb.Router.Helpers, as: Routes
 
   def show_pay_early(%AccessSummary{reason: :within_grace_period}), do: true
   def show_pay_early(_), do: false


### PR DESCRIPTION
[MER-1368](https://eliterate.atlassian.net/browse/MER-1368)

### What does it change?

Improves the calls to the keep alive endpoint by:
- Reducing frequency from 1 minute to 15 (default Pow refresh time)
- Moving keep-alive script to liveviews only, instead of loading them on every page. 

