### PR TITLE
[MER-1389] Fix discounts being applied to all institutions

### DIFF
--- a/lib/oli/delivery/paywall.ex
+++ b/lib/oli/delivery/paywall.ex
@@ -211,8 +211,9 @@ defmodule Oli.Delivery.Paywall do
   ) do
     discounts =
       from(d in Discount,
-        where: (d.institution_id == ^institution_id and is_nil(d.section_id))  # Institution-wide discounts
-          or (d.section_id == ^id and d.institution_id == ^institution_id), # Section-specific discounts for the given institution
+        where: d.institution_id == ^institution_id and
+          (is_nil(d.section_id) or # Institution-wide discounts
+          d.section_id == ^id),  # Section-specific discounts for the given institution
         select: d
       )
       |> Repo.all()

--- a/lib/oli/delivery/paywall.ex
+++ b/lib/oli/delivery/paywall.ex
@@ -211,7 +211,8 @@ defmodule Oli.Delivery.Paywall do
   ) do
     discounts =
       from(d in Discount,
-        where: d.institution_id == ^institution_id and (is_nil(d.section_id)) or (d.section_id == ^id),
+        where: (d.institution_id == ^institution_id and is_nil(d.section_id))  # Institution-wide discounts
+          or (d.section_id == ^id and d.institution_id == ^institution_id), # Section-specific discounts for the given institution
         select: d
       )
       |> Repo.all()

--- a/test/oli/delivery/paywall_test.exs
+++ b/test/oli/delivery/paywall_test.exs
@@ -463,6 +463,24 @@ defmodule Oli.Delivery.PaywallTest do
       end
     end
 
+    test "section_cost_from_product/2 doesn't apply institution-specific discount to other institutions", %{
+      institution: institution_a,
+      paid: paid
+    } do
+      Paywall.create_discount(%{
+        institution_id: institution_a.id,
+        section_id: nil,
+        type: :fixed_amount,
+        percentage: 0,
+        amount: Money.new(:USD, 90)
+      })
+
+      assert {:ok, Money.new(:USD, 90)} == Paywall.section_cost_from_product(paid, institution_a)
+
+      institution_b = insert(:institution)
+      assert {:ok, Money.new(:USD, 100)} == Paywall.section_cost_from_product(paid, institution_b)
+    end
+
     test "section_cost_from_product/2 correctly works when no institution present", %{
       free: free,
       paid: paid


### PR DESCRIPTION
[MER-1389](https://eliterate.atlassian.net/browse/MER-1389)

### What does it change?

Fixes the Paywall.section_cost_from_product/2 query retrieving all discounts for a product instead of limiting to a specific institution. 
