### PR TITLE
[BUGFIX] MER-992 MER-1332 manual graded activity preview doesn't always render

### DIFF
--- a/assets/src/components/activities/DeliveryElement.ts
+++ b/assets/src/components/activities/DeliveryElement.ts
@@ -394,9 +394,12 @@ export abstract class DeliveryElement<T extends ActivityModelSchema> extends HTM
   abstract render(mountPoint: HTMLDivElement, props: DeliveryElementProps<T>): void;
 
   connectedCallback() {
-    this.appendChild(this.mountPoint);
-    this.render(this.mountPoint, this.props());
-    this.connected = true;
+    // need to skip a cycle to let old elements handle disconnect in LiveView
+    setTimeout(() => {
+      this.appendChild(this.mountPoint);
+      this.render(this.mountPoint, this.props());
+      this.connected = true;
+    }, 0);
   }
 
   attributeChangedCallback(_name: any, _oldValue: any, _newValue: any) {

--- a/assets/src/components/activities/adaptive/AdaptiveDelivery.tsx
+++ b/assets/src/components/activities/adaptive/AdaptiveDelivery.tsx
@@ -21,7 +21,7 @@ const sharedPromiseMap = new Map();
 const sharedAttemptStateMap = new Map();
 
 const Adaptive = (props: DeliveryElementProps<AdaptiveModelSchema>) => {
-  const [activityId, setActivityId] = useState<string>(props.model?.id || `unknown_activity`);
+  const [activityId, setActivityId] = useState<string>(props.model?.activity_id || `unknown_activity`);
   const [mode, setMode] = useState<string>(props.mode);
 
   const isReviewMode = mode === 'review';

--- a/assets/src/components/activities/adaptive/AdaptiveDelivery.tsx
+++ b/assets/src/components/activities/adaptive/AdaptiveDelivery.tsx
@@ -21,7 +21,9 @@ const sharedPromiseMap = new Map();
 const sharedAttemptStateMap = new Map();
 
 const Adaptive = (props: DeliveryElementProps<AdaptiveModelSchema>) => {
-  const [activityId, setActivityId] = useState<string>(props.model?.activity_id || `unknown_activity`);
+  const [activityId, setActivityId] = useState<string>(
+    props.model?.activity_id || `unknown_activity`,
+  );
   const [mode, setMode] = useState<string>(props.mode);
 
   const isReviewMode = mode === 'review';

--- a/assets/src/components/activities/types.ts
+++ b/assets/src/components/activities/types.ts
@@ -204,6 +204,7 @@ export interface ActivityModelSchema {
   activityType?: any;
   id?: string; // maybe slug
   bibrefs?: string[];
+  activity_id?: string;
 }
 
 /**

--- a/lib/oli/rendering/activity/html.ex
+++ b/lib/oli/rendering/activity/html.ex
@@ -79,12 +79,12 @@ defmodule Oli.Rendering.Activity.Html do
           case mode do
             :instructor_preview ->
               [
-                ~s|<#{tag} id=\"#{activity_html_id}\" model="#{model_json}" editmode="false" projectSlug="#{section_slug}" bib_params="#{Base.encode64(bib_params_json)}" #{maybe_group_id(group_id)}#{maybe_survey_id(survey_id)}></#{tag}>\n|
+                ~s|<#{tag} activity_id=\"#{activity_html_id}\" model="#{model_json}" editmode="false" projectSlug="#{section_slug}" bib_params="#{Base.encode64(bib_params_json)}" #{maybe_group_id(group_id)}#{maybe_survey_id(survey_id)}></#{tag}>\n|
               ]
 
             _ ->
               [
-                ~s|<#{tag} id=\"#{activity_html_id}\" class="activity-container" graded="#{graded}" state="#{state}" model="#{model_json}" mode="#{mode}" user_id="#{user.id}" section_slug="#{section_slug}" bib_params="#{Base.encode64(bib_params_json)}" #{maybe_group_id(group_id)}#{maybe_survey_id(survey_id)}></#{tag}>\n|
+                ~s|<#{tag} activity_id=\"#{activity_html_id}\" class="activity-container" graded="#{graded}" state="#{state}" model="#{model_json}" mode="#{mode}" user_id="#{user.id}" section_slug="#{section_slug}" bib_params="#{Base.encode64(bib_params_json)}" #{maybe_group_id(group_id)}#{maybe_survey_id(survey_id)}></#{tag}>\n|
               ]
           end
 

--- a/lib/oli_web/live/manual_grading/rendered_activity.ex
+++ b/lib/oli_web/live/manual_grading/rendered_activity.ex
@@ -11,7 +11,7 @@ defmodule OliWeb.ManualGrading.RenderedActivity do
 
   def render(assigns) do
     ~F"""
-    <div class="mt-5 rendered-activity" id={@id} phx-update="none">{raw(@rendered_activity)}</div>
+    <div class="mt-5 rendered-activity" id={@id} phx-update="ignore">{raw(@rendered_activity)}</div>
     """
   end
 

--- a/test/oli/rendering/activity/html_test.exs
+++ b/test/oli/rendering/activity/html_test.exs
@@ -48,7 +48,7 @@ defmodule Oli.Content.Activity.HtmlTest do
       rendered_html_string = Phoenix.HTML.raw(rendered_html) |> Phoenix.HTML.safe_to_string()
 
       assert rendered_html_string =~
-               ~s|<oli-multiple-choice-delivery id=\"activity_1\" class="activity-container" graded="false" state="{ "active": true }" model="{ "choices": [ "A", "B", "C", "D" ], "feedback": [ "A", "B", "C", "D" ], "stem": ""}"|
+               ~s|<oli-multiple-choice-delivery activity_id=\"activity_1\" class="activity-container" graded="false" state="{ "active": true }" model="{ "choices": [ "A", "B", "C", "D" ], "feedback": [ "A", "B", "C", "D" ], "stem": ""}"|
     end
 
     test "renders malformed activity gracefully", %{author: author} do

--- a/test/oli/rendering/survey/html_test.exs
+++ b/test/oli/rendering/survey/html_test.exs
@@ -69,7 +69,7 @@ defmodule Oli.Content.Survey.HtmlTest do
                ~s|<div id="1855946510" class="survey"><div class="survey-label">Survey</div><div class="survey-content">|
 
       assert rendered_html_string =~
-               ~s|<p>Please complete the following survey:</p>\n<oli-multiple-choice-delivery id=\"activity_1\" class="activity-container" graded="false" state="{ "active": true }" model="{ "choices": [ "A", "B", "C", "D" ], "feedback": [ "A", "B", "C", "D" ], "stem": ""}" mode="delivery"|
+               ~s|<p>Please complete the following survey:</p>\n<oli-multiple-choice-delivery activity_id=\"activity_1\" class="activity-container" graded="false" state="{ "active": true }" model="{ "choices": [ "A", "B", "C", "D" ], "feedback": [ "A", "B", "C", "D" ], "stem": ""}" mode="delivery"|
 
       assert rendered_html_string =~
                ~s|survey_id="1855946510"></oli-multiple-choice-delivery>|


### PR DESCRIPTION
when LiveView re-renders the markup the new connected callback was firing before the disconnected callback. also need to make sure that phx-update is set to "ignore". previously it was set to "none" which isn't a valid value. (without ignore it will latch onto any children with an id attribute and try to control its updates)