### PR TITLE
[BUGFIX] Change 'Submit Assessment' to 'Submit Answers' 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fix an issue where underlined and strikethrough text were not being rendered
 - Fix an issue where guest user_id is blank in datashop export
 - Allow insertion of tables, iframes and all other elements in stem, choices and feedback
+- Change 'Submit Assessment' button to 'Submit'
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Fix an issue where underlined and strikethrough text were not being rendered
 - Fix an issue where guest user_id is blank in datashop export
 - Allow insertion of tables, iframes and all other elements in stem, choices and feedback
-- Change 'Submit Assessment' button to 'Submit'
+- Change 'Submit Assessment' button to 'Submit Answers'
 
 ### Enhancements
 

--- a/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
@@ -370,7 +370,7 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
   @doc """
   Evaluates an activity attempt using only the already stored state present in
   the child part attempts.  This exists primarly to allow graded pages to
-  submit all of the contained activites when the student clicks "Submit".
+  submit all of the contained activites when the student clicks "Submit Answers".
   """
   def evaluate_from_stored_input(activity_attempt_guid, datashop_session_id) do
     part_attempts = get_latest_part_attempts(activity_attempt_guid)

--- a/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
@@ -370,7 +370,7 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
   @doc """
   Evaluates an activity attempt using only the already stored state present in
   the child part attempts.  This exists primarly to allow graded pages to
-  submit all of the contained activites when the student clicks "Submit Assessment".
+  submit all of the contained activites when the student clicks "Submit".
   """
   def evaluate_from_stored_input(activity_attempt_guid, datashop_session_id) do
     part_attempts = get_latest_part_attempts(activity_attempt_guid)

--- a/lib/oli_web/templates/page_delivery/page.html.eex
+++ b/lib/oli_web/templates/page_delivery/page.html.eex
@@ -57,7 +57,7 @@ window.userToken = "<%= assigns[:user_token] %>";
 
 <%= if @graded && @activity_count > 0 && @review_mode == false do %>
   <div class="d-flex align-items-center justify-content-center">
-    <%= link "Submit Assessment", to: Routes.page_delivery_path(@conn, :finalize_attempt, @section_slug, @slug, @attempt_guid), class: "btn btn-primary btn-lg text-center" %>
+    <%= link "Submit", to: Routes.page_delivery_path(@conn, :finalize_attempt, @section_slug, @slug, @attempt_guid), class: "btn btn-primary btn-lg text-center" %>
   </div>
 <% end %>
 

--- a/lib/oli_web/templates/page_delivery/page.html.eex
+++ b/lib/oli_web/templates/page_delivery/page.html.eex
@@ -57,7 +57,7 @@ window.userToken = "<%= assigns[:user_token] %>";
 
 <%= if @graded && @activity_count > 0 && @review_mode == false do %>
   <div class="d-flex align-items-center justify-content-center">
-    <%= link "Submit", to: Routes.page_delivery_path(@conn, :finalize_attempt, @section_slug, @slug, @attempt_guid), class: "btn btn-primary btn-lg text-center" %>
+    <%= link "Submit Answers", to: Routes.page_delivery_path(@conn, :finalize_attempt, @section_slug, @slug, @attempt_guid), class: "btn btn-primary btn-lg text-center" %>
   </div>
 <% end %>
 

--- a/test/oli_web/controllers/page_delivery_controller_test.exs
+++ b/test/oli_web/controllers/page_delivery_controller_test.exs
@@ -164,13 +164,13 @@ defmodule OliWeb.PageDeliveryControllerTest do
       redir_path = redirected_to(conn, 302)
 
       # and then the rendering of the page, which should contain a button
-      # that says 'Submit'
+      # that says 'Submit Answers'
       conn =
         recycle(conn)
         |> Pow.Plug.assign_current_user(user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
 
       conn = get(conn, redir_path)
-      assert html_response(conn, 200) =~ "Submit"
+      assert html_response(conn, 200) =~ "Submit Answers"
 
       # fetch the resource attempt and part attempt that will have been created
       [attempt] = Oli.Repo.all(ResourceAttempt)
@@ -271,13 +271,13 @@ defmodule OliWeb.PageDeliveryControllerTest do
       redir_path = redirected_to(conn, 302)
 
       # and then the rendering of the page, which should contain a button
-      # that says 'Submit'
+      # that says 'Submit Answers'
       conn =
         recycle(conn)
         |> Pow.Plug.assign_current_user(user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
 
       conn = get(conn, redir_path)
-      assert html_response(conn, 200) =~ "Submit"
+      assert html_response(conn, 200) =~ "Submit Answers"
 
       # fetch the resource attempt and part attempt that will have been created
       [attempt] = Oli.Repo.all(ResourceAttempt)
@@ -321,7 +321,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
         |> Pow.Plug.assign_current_user(user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
 
       conn = get(conn, Routes.page_delivery_path(conn, :page, section.slug, page_revision.slug))
-      assert html_response(conn, 200) =~ "Submit"
+      assert html_response(conn, 200) =~ "Submit Answers"
 
       # Submit the assessment
       conn =
@@ -347,7 +347,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
 
       conn = get(conn, Routes.page_delivery_path(conn, :page, section.slug, page_revision.slug))
       assert html_response(conn, 200) =~ "This is now ungraded"
-      refute html_response(conn, 200) =~ "Submit"
+      refute html_response(conn, 200) =~ "Submit Answers"
     end
 
     test "changing a page from ungraded to graded shows the prologue even with an ungraded attempt present",
@@ -390,7 +390,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       # Visit the page in its ungraded state, thus generating a resource attempt
       conn = get(conn, Routes.page_delivery_path(conn, :page, section.slug, page_revision.slug))
       assert html_response(conn, 200) =~ "This is now ungraded"
-      refute html_response(conn, 200) =~ "Submit"
+      refute html_response(conn, 200) =~ "Submit Answers"
 
       # Now change the page to graded and issue a publication
       toggle_graded = %{graded: true, title: "This is now graded"}
@@ -443,13 +443,13 @@ defmodule OliWeb.PageDeliveryControllerTest do
       redir_path = redirected_to(conn, 302)
 
       # and then the rendering of the page, which should contain a button
-      # that says 'Submit'
+      # that says 'Submit Answers'
       conn =
         recycle(conn)
         |> Pow.Plug.assign_current_user(user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
 
       conn = get(conn, redir_path)
-      assert html_response(conn, 200) =~ "Submit"
+      assert html_response(conn, 200) =~ "Submit Answers"
     end
 
     test "page with content breaks renders pagination controls", %{

--- a/test/oli_web/controllers/page_delivery_controller_test.exs
+++ b/test/oli_web/controllers/page_delivery_controller_test.exs
@@ -164,13 +164,13 @@ defmodule OliWeb.PageDeliveryControllerTest do
       redir_path = redirected_to(conn, 302)
 
       # and then the rendering of the page, which should contain a button
-      # that says 'Submit Assessment'
+      # that says 'Submit'
       conn =
         recycle(conn)
         |> Pow.Plug.assign_current_user(user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
 
       conn = get(conn, redir_path)
-      assert html_response(conn, 200) =~ "Submit Assessment"
+      assert html_response(conn, 200) =~ "Submit"
 
       # fetch the resource attempt and part attempt that will have been created
       [attempt] = Oli.Repo.all(ResourceAttempt)
@@ -271,13 +271,13 @@ defmodule OliWeb.PageDeliveryControllerTest do
       redir_path = redirected_to(conn, 302)
 
       # and then the rendering of the page, which should contain a button
-      # that says 'Submit Assessment'
+      # that says 'Submit'
       conn =
         recycle(conn)
         |> Pow.Plug.assign_current_user(user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
 
       conn = get(conn, redir_path)
-      assert html_response(conn, 200) =~ "Submit Assessment"
+      assert html_response(conn, 200) =~ "Submit"
 
       # fetch the resource attempt and part attempt that will have been created
       [attempt] = Oli.Repo.all(ResourceAttempt)
@@ -321,7 +321,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
         |> Pow.Plug.assign_current_user(user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
 
       conn = get(conn, Routes.page_delivery_path(conn, :page, section.slug, page_revision.slug))
-      assert html_response(conn, 200) =~ "Submit Assessment"
+      assert html_response(conn, 200) =~ "Submit"
 
       # Submit the assessment
       conn =
@@ -347,7 +347,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
 
       conn = get(conn, Routes.page_delivery_path(conn, :page, section.slug, page_revision.slug))
       assert html_response(conn, 200) =~ "This is now ungraded"
-      refute html_response(conn, 200) =~ "Submit Assessment"
+      refute html_response(conn, 200) =~ "Submit"
     end
 
     test "changing a page from ungraded to graded shows the prologue even with an ungraded attempt present",
@@ -390,7 +390,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       # Visit the page in its ungraded state, thus generating a resource attempt
       conn = get(conn, Routes.page_delivery_path(conn, :page, section.slug, page_revision.slug))
       assert html_response(conn, 200) =~ "This is now ungraded"
-      refute html_response(conn, 200) =~ "Submit Assessment"
+      refute html_response(conn, 200) =~ "Submit"
 
       # Now change the page to graded and issue a publication
       toggle_graded = %{graded: true, title: "This is now graded"}
@@ -443,13 +443,13 @@ defmodule OliWeb.PageDeliveryControllerTest do
       redir_path = redirected_to(conn, 302)
 
       # and then the rendering of the page, which should contain a button
-      # that says 'Submit Assessment'
+      # that says 'Submit'
       conn =
         recycle(conn)
         |> Pow.Plug.assign_current_user(user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
 
       conn = get(conn, redir_path)
-      assert html_response(conn, 200) =~ "Submit Assessment"
+      assert html_response(conn, 200) =~ "Submit"
     end
 
     test "page with content breaks renders pagination controls", %{


### PR DESCRIPTION
For #2374, change 'Submit Assessment' button label to 'Submit Answers' to avoid grade-related terminology. Use 'Submit Answers" rather than just 'Submit" so existing tests can continue to use presence/absence of unique string on page to distinguish scored assessments. 