### PR TITLE
[FEATURE] Targeted retake mode, infrastructure only

### DIFF
--- a/lib/oli/delivery/activity_provider.ex
+++ b/lib/oli/delivery/activity_provider.ex
@@ -281,7 +281,8 @@ defmodule Oli.Delivery.ActivityProvider do
       activity_id: activity_reference["activity_id"],
       survey_id: survey_id,
       group_id: group_id,
-      selection_id: nil
+      selection_id: nil,
+      inherit_state_from_previous: false
     }
   end
 
@@ -290,7 +291,8 @@ defmodule Oli.Delivery.ActivityProvider do
       revision: revision,
       survey_id: survey_id,
       group_id: group_id,
-      selection_id: selection_id
+      selection_id: selection_id,
+      inherit_state_from_previous: false
     }
   end
 

--- a/lib/oli/delivery/activity_provider.ex
+++ b/lib/oli/delivery/activity_provider.ex
@@ -5,6 +5,7 @@ defmodule Oli.Delivery.ActivityProvider do
   alias Oli.Resources.Revision
   alias Oli.Resources.PageContent
   alias Oli.Delivery.ActivityProvider.Result, as: ProviderResult
+  alias Oli.Delivery.ActivityProvider.AttemptPrototype
   alias Oli.Utils.BibUtils
 
   @doc """
@@ -31,6 +32,7 @@ defmodule Oli.Delivery.ActivityProvider do
   def provide(
         %Revision{content: %{"advancedDelivery" => true} = content},
         %Source{} = source,
+        _,
         resolver
       ) do
     refs =
@@ -73,28 +75,35 @@ defmodule Oli.Delivery.ActivityProvider do
 
     %ProviderResult{
       errors: [],
-      revisions: revisions,
+      prototypes:
+        Enum.map(revisions, fn r ->
+          %AttemptPrototype{
+            revision: r
+          }
+        end),
       bib_revisions: bib_revisions,
       transformed_content: content,
-      unscored: unscored,
-      activity_to_source_selection_mapping: %{}
+      unscored: unscored
     }
   end
 
   def provide(
         %Revision{content: %{"model" => model} = content},
         %Source{} = source,
+        existing_attempt_prototypes,
         resolver
       ) do
-    {errors, activities, model, _, activity_to_source_selection_mapping} = fulfill(model, source)
+    %{
+      prototypes: prototypes,
+      errors: errors
+    } = fulfill(model, source, existing_attempt_prototypes)
 
-    only_revisions =
-      resolve_activity_ids(source.section_slug, activities, resolver) |> Enum.reverse()
+    prototypes_with_revisions = resolve_activity_ids(source.section_slug, prototypes, resolver)
 
     bib_revisions =
       BibUtils.assemble_bib_entries(
         content,
-        only_revisions,
+        Enum.map(prototypes_with_revisions, fn p -> p.revision end),
         fn r -> Map.get(r.content, "bibrefs", []) end,
         source.section_slug,
         resolver
@@ -102,13 +111,19 @@ defmodule Oli.Delivery.ActivityProvider do
       |> Enum.with_index(1)
       |> Enum.map(fn {revision, ordinal} -> BibUtils.serialize_revision(revision, ordinal) end)
 
+    has_selection = Enum.any?(prototypes_with_revisions, fn p -> !is_nil(p.selection_id) end)
+
     %ProviderResult{
       errors: errors,
-      revisions: only_revisions,
+      prototypes: prototypes_with_revisions,
       bib_revisions: bib_revisions,
-      transformed_content: Map.put(content, "model", Enum.reverse(model)),
       unscored: MapSet.new(),
-      activity_to_source_selection_mapping: activity_to_source_selection_mapping
+      transformed_content:
+        if has_selection do
+          transform_content(content, prototypes_with_revisions)
+        else
+          content
+        end
     }
   end
 
@@ -122,112 +137,249 @@ defmodule Oli.Delivery.ActivityProvider do
   # Note: To optimize performance we prepend all activity ids and revisions as we pass through, and
   # then do a final Enum.reverse to restore the correct order.  We do the same thing for the elements
   # within the transformed page model.
-  defp fulfill(model, %Source{} = source) do
-    Enum.reduce(model, {[], [], [], source, %{}}, fn e,
-                                                     {errors, activities, model, source,
-                                                      selection_mapping} ->
-      case e["type"] do
-        "activity-reference" ->
-          {errors, [e["activity_id"] | activities], [e | model], source, selection_mapping}
+  defp fulfill(model, %Source{} = source, existing_attempt_prototypes) do
+    # Create a map of selection ids to a list of their existing prototypes
+    prototypes_by_selection = build_prototypes_by_selection_map(existing_attempt_prototypes)
 
-        "selection" ->
-          {:ok, %Selection{id: id} = selection} = Selection.parse(e)
+    # Create a map of activity id (aka resource id) to its existing prototype
+    prototypes_by_activity_id =
+      Enum.reduce(existing_attempt_prototypes, %{}, fn p, m ->
+        Map.put(m, p.revision.resource_id, p)
+      end)
 
-          case Selection.fulfill(selection, source) do
-            {:ok, %Result{} = result} ->
-              reversed = Enum.reverse(result.rows)
+    fulfillment_state = %{
+      # These are the three items that we update throughout do_fulfill
+      errors: [],
+      prototypes: [],
+      source: source,
 
-              selection_mapping =
-                Enum.reduce(reversed, selection_mapping, fn r, m ->
-                  Map.put(m, r.resource_id, id)
-                end)
+      # These are here merely for optimizing access to existing prototypes
+      prototypes_by_selection: prototypes_by_selection,
+      prototypes_by_activity_id: prototypes_by_activity_id
+    }
 
-              {errors, reversed ++ activities, replace_selection(e, reversed) ++ model,
-               merge_blacklist(source, result.rows), selection_mapping}
+    Enum.reduce(model, fulfillment_state, fn e, state -> do_fulfill(state, e, nil, nil) end)
+  end
 
-            {:partial, %Result{} = result} ->
-              missing = selection.count - result.rowCount
+  defp do_fulfill(
+         fulfillment_state,
+         %{"type" => "activity-reference"} = model_component,
+         group_id,
+         survey_id
+       ) do
+    # Create a new attempt prototype, or use an existing one if present for this activity id
+    prototype =
+      case Map.get(fulfillment_state.prototypes_by_activity_id, model_component["activity_id"]) do
+        nil ->
+          reference_to_prototype(model_component, group_id, survey_id)
 
-              error = "Selection failed to fulfill completely with #{missing} missing activities"
-
-              reversed = Enum.reverse(result.rows)
-
-              selection_mapping =
-                Enum.reduce(reversed, selection_mapping, fn r, m ->
-                  Map.put(m, r.resource_id, id)
-                end)
-
-              {[error | errors], reversed ++ activities, replace_selection(e, reversed) ++ model,
-               merge_blacklist(source, result.rows), selection_mapping}
-
-            e ->
-              error = "Selection failed to fulfill with error: #{e}"
-              {[error | errors], activities, model, source, selection_mapping}
-          end
-
-        "group" ->
-          {c_errors, c_activities, c_model, source, group_selection_mapping} =
-            fulfill(e["children"], source)
-
-          e = %{e | "children" => Enum.reverse(c_model)}
-
-          {c_errors ++ errors, c_activities ++ activities, [e | model], source,
-           Map.merge(selection_mapping, group_selection_mapping)}
-
-        "survey" ->
-          {c_errors, c_activities, c_model, source, survey_selection_mapping} =
-            fulfill(e["children"], source)
-
-          e = %{e | "children" => Enum.reverse(c_model)}
-
-          {c_errors ++ errors, c_activities ++ activities, [e | model], source,
-           Map.merge(selection_mapping, survey_selection_mapping)}
-
-        _ ->
-          {errors, activities, [e | model], source, selection_mapping}
+        existing_prototype ->
+          # update an existing one to make sure it tracks the latest survey and group context
+          existing_prototype
+          |> Map.put(:survey_id, survey_id)
+          |> Map.put(:group_id, group_id)
       end
+
+    fulfillment_state
+    |> Map.put(:prototypes, [prototype | Map.get(fulfillment_state, :prototypes)])
+  end
+
+  defp do_fulfill(
+         fulfillment_state,
+         %{"type" => "selection"} = model_component,
+         group_id,
+         survey_id
+       ) do
+    {:ok, %Selection{id: id} = selection} =
+      Selection.parse(model_component)
+      |> decrement_for_prototypes(fulfillment_state.prototypes_by_selection)
+
+    # handle the case that existing prototypes for this selection completely decrement
+    # the count down to zero
+    if selection.count == 0 do
+      add_existing_for_selection(fulfillment_state, id)
+    else
+      # We need to draw some number of activities from the bank
+      case Selection.fulfill(selection, fulfillment_state.source) do
+        {:ok, %Result{} = result} ->
+          new_prototypes =
+            Enum.reverse(result.rows)
+            |> Enum.map(fn r -> revision_to_prototype(r, group_id, survey_id, id) end)
+
+          fulfillment_state
+          |> Map.put(:prototypes, new_prototypes ++ fulfillment_state.prototypes)
+          |> Map.put(:source, merge_blacklist(fulfillment_state.source, result.rows))
+          |> add_existing_for_selection(id)
+
+        {:partial, %Result{} = result} ->
+          missing = selection.count - result.rowCount
+
+          error = "Selection failed to fulfill completely with #{missing} missing activities"
+
+          new_prototypes =
+            Enum.map(result.rows, fn r ->
+              revision_to_prototype(r, group_id, survey_id, id)
+            end)
+
+          fulfillment_state
+          |> Map.put(:prototypes, new_prototypes ++ fulfillment_state.prototypes)
+          |> Map.put(:source, merge_blacklist(fulfillment_state.source, result.rows))
+          |> Map.put(:errors, [error | fulfillment_state.errors])
+          |> add_existing_for_selection(id)
+
+        e ->
+          error = "Selection failed to fulfill with error: #{e}"
+
+          fulfillment_state
+          |> Map.put(:errors, [error | fulfillment_state.errors])
+      end
+    end
+  end
+
+  defp do_fulfill(fulfillment_state, %{"type" => "group"} = model_component, _, survey_id) do
+    Enum.reduce(model_component["children"], fulfillment_state, fn c, s ->
+      do_fulfill(s, c, model_component["id"], survey_id)
     end)
   end
 
-  # At this point "activities" is a list whose entries are either activity_ids or revisions, now
-  # we must resolve the revisions of all the entires that are simply activity ids,
-  # replacing them in the list with the resolved revision.
+  defp do_fulfill(fulfillment_state, %{"type" => "survey"} = model_component, group_id, _) do
+    Enum.reduce(model_component["children"], fulfillment_state, fn c, s ->
+      do_fulfill(s, c, group_id, model_component["id"])
+    end)
+  end
 
-  # Returns a list of revisions.
-  defp resolve_activity_ids(section_slug, activities, resolver) do
+  defp do_fulfill(fulfillment_state, _, _, _) do
+    fulfillment_state
+  end
+
+  defp add_existing_for_selection(fulfillment_state, selection_id) do
+    prototypes =
+      fulfillment_state.prototypes_by_selection
+      |> Map.get(selection_id, [])
+
+    fulfillment_state
+    |> Map.put(:prototypes, prototypes ++ fulfillment_state.prototypes)
+    |> Map.put(
+      :source,
+      merge_blacklist(fulfillment_state.source, Enum.map(prototypes, fn p -> p.revision end))
+    )
+  end
+
+  defp reference_to_prototype(activity_reference, group_id, survey_id) do
+    %AttemptPrototype{
+      activity_id: activity_reference["activity_id"],
+      survey_id: survey_id,
+      group_id: group_id,
+      selection_id: nil
+    }
+  end
+
+  defp revision_to_prototype(revision, group_id, survey_id, selection_id) do
+    %AttemptPrototype{
+      revision: revision,
+      survey_id: survey_id,
+      group_id: group_id,
+      selection_id: selection_id
+    }
+  end
+
+  # decrement the selection count by the size of any activity attempts prototypes
+  # supplied for this selection. As a safeguard, be careful to never let a count go negative.
+  defp decrement_for_prototypes(
+         {:ok, %Selection{id: id, count: count} = selection},
+         prototypes_by_selection
+       ) do
+    decrement = Map.get(prototypes_by_selection, id, []) |> Enum.count()
+
+    new_count =
+      if decrement > count do
+        0
+      else
+        count - decrement
+      end
+
+    {:ok, %{selection | count: new_count}}
+  end
+
+  # At this point "prototypes" is a list of prototypes, some of which might need
+  # to have a revision fetched.
+  # Returns a list of prototypes.
+  defp resolve_activity_ids(section_slug, prototypes, resolver) do
     activity_ids =
-      Enum.filter(activities, fn a ->
-        case a do
-          %Revision{id: _} -> false
-          _ -> true
-        end
-      end)
+      Enum.filter(prototypes, fn p -> !is_nil(p.activity_id) end)
+      |> Enum.map(fn p -> p.activity_id end)
 
     map =
       resolver.from_resource_id(section_slug, activity_ids)
       |> Enum.reduce(%{}, fn rev, m -> Map.put(m, rev.resource_id, rev) end)
 
-    Enum.map(activities, fn a ->
-      case a do
-        %Revision{id: _} -> a
-        id -> Map.get(map, id)
+    Enum.map(prototypes, fn p ->
+      case p.revision do
+        nil -> %{p | revision: Map.get(map, p.activity_id)}
+        _ -> p
       end
     end)
   end
 
+  defp build_prototypes_by_selection_map(prototypes) do
+    Enum.reduce(prototypes, %{}, fn p, m ->
+      case p.selection_id do
+        nil -> m
+        id -> Map.put(m, id, Map.get(m, id, []) ++ [p])
+      end
+    end)
+  end
+
+  # Replace all bank selections with activity-references that represent the fulfilled
+  # activities for those selections
+  defp transform_content(content, prototypes) do
+    prototypes_by_selection = build_prototypes_by_selection_map(prototypes)
+
+    mapped_model =
+      transform_content_helper(content["model"], prototypes_by_selection) |> List.flatten()
+
+    Map.put(content, "model", mapped_model)
+  end
+
+  defp transform_content_helper(model_component, prototypes_by_selection)
+       when is_list(model_component) do
+    Enum.map(model_component, fn component ->
+      transform_content_helper(component, prototypes_by_selection)
+    end)
+  end
+
+  defp transform_content_helper(
+         %{"type" => "selection", "id" => id} = selection,
+         prototypes_by_selection
+       ) do
+    Map.get(prototypes_by_selection, id)
+    |> Enum.map(fn prototype -> replace_with_reference(selection, prototype.revision) end)
+  end
+
+  defp transform_content_helper(
+         %{"type" => kind, "children" => children} = component,
+         prototypes_by_selection
+       )
+       when kind in ["group", "survey"] do
+    children = transform_content_helper(children, prototypes_by_selection) |> List.flatten()
+    Map.put(component, "children", children)
+  end
+
+  defp transform_content_helper(other, _) do
+    other
+  end
+
   # Takes a JSON selection element as a map and returns a list of activity-reference
   # JSON elements that represent which activities fulfilled the selection.
-  defp replace_selection(selection_element, revisions) do
-    Enum.map(revisions, fn r ->
-      %{
-        "type" => "activity-reference",
-        "id" => Oli.Utils.uuid(),
-        "activity_id" => r.resource_id,
-        "purpose" => Map.get(selection_element, "purpose", ""),
-        "children" => [],
-        "source-selection" => selection_element["id"]
-      }
-    end)
+  defp replace_with_reference(selection_element, revision) do
+    %{
+      "type" => "activity-reference",
+      "id" => Oli.Utils.uuid(),
+      "activity_id" => revision.resource_id,
+      "purpose" => Map.get(selection_element, "purpose", ""),
+      "children" => [],
+      "source-selection" => selection_element["id"]
+    }
   end
 
   # Merge the blacklisted activity ids of the given source with the resource ids of the

--- a/lib/oli/delivery/activity_provider.ex
+++ b/lib/oli/delivery/activity_provider.ex
@@ -194,6 +194,17 @@ defmodule Oli.Delivery.ActivityProvider do
       Selection.parse(model_component)
       |> decrement_for_prototypes(fulfillment_state.prototypes_by_selection)
 
+    existing_for_this_selection =
+      Map.get(fulfillment_state.prototypes_by_selection, id, [])
+      |> Enum.map(fn p -> p.revision end)
+
+    fulfillment_state =
+      Map.put(
+        fulfillment_state,
+        :source,
+        merge_blacklist(fulfillment_state.source, existing_for_this_selection)
+      )
+
     # handle the case that existing prototypes for this selection completely decrement
     # the count down to zero
     if selection.count == 0 do

--- a/lib/oli/delivery/activity_provider/attempt_prototype.ex
+++ b/lib/oli/delivery/activity_provider/attempt_prototype.ex
@@ -1,0 +1,12 @@
+defmodule Oli.Delivery.ActivityProvider.AttemptPrototype do
+  defstruct [
+    :revision,
+    :activity_id,
+    :transformed_model,
+    :scoreable,
+    :survey_id,
+    :group_id,
+    :selection_id,
+    :inherit_state_from_previous
+  ]
+end

--- a/lib/oli/delivery/activity_provider/attempt_prototype.ex
+++ b/lib/oli/delivery/activity_provider/attempt_prototype.ex
@@ -1,4 +1,12 @@
 defmodule Oli.Delivery.ActivityProvider.AttemptPrototype do
+  @moduledoc """
+  An attempt prototype represents a template, or a blueprint, that the system
+  uses to create actual activity attempts.
+
+  AttemptPrototype is a fundamental unit of currency between the ActivityProvider
+  and client code that uses it.
+  """
+
   alias Oli.Delivery.Attempts.Core.{
     ActivityAttempt
   }

--- a/lib/oli/delivery/activity_provider/attempt_prototype.ex
+++ b/lib/oli/delivery/activity_provider/attempt_prototype.ex
@@ -1,4 +1,8 @@
 defmodule Oli.Delivery.ActivityProvider.AttemptPrototype do
+  alias Oli.Delivery.Attempts.Core.{
+    ActivityAttempt
+  }
+
   defstruct [
     :revision,
     :activity_id,
@@ -9,4 +13,17 @@ defmodule Oli.Delivery.ActivityProvider.AttemptPrototype do
     :selection_id,
     :inherit_state_from_previous
   ]
+
+  def from_attempt(%ActivityAttempt{} = attempt) do
+    %Oli.Delivery.ActivityProvider.AttemptPrototype{
+      revision: attempt.revision,
+      activity_id: attempt.revision.resource_id,
+      transformed_model: attempt.transformed_model,
+      scoreable: attempt.scoreable,
+      survey_id: attempt.survey_id,
+      group_id: attempt.group_id,
+      selection_id: attempt.selection_id,
+      inherit_state_from_previous: true
+    }
+  end
 end

--- a/lib/oli/delivery/activity_provider/result.ex
+++ b/lib/oli/delivery/activity_provider/result.ex
@@ -1,10 +1,9 @@
 defmodule Oli.Delivery.ActivityProvider.Result do
   defstruct [
     :errors,
-    :revisions,
+    :prototypes,
     :bib_revisions,
     :unscored,
-    :transformed_content,
-    :activity_to_source_selection_mapping
+    :transformed_content
   ]
 end

--- a/lib/oli/delivery/attempts/core/activity_attempt.ex
+++ b/lib/oli/delivery/attempts/core/activity_attempt.ex
@@ -17,6 +17,7 @@ defmodule Oli.Delivery.Attempts.Core.ActivityAttempt do
     field(:transformed_model, :map, default: nil)
     field(:group_id, :string, default: nil)
     field(:survey_id, :string, default: nil)
+    field(:selection_id, :string, default: nil)
 
     belongs_to(:resource, Oli.Resources.Resource)
     belongs_to(:revision, Oli.Resources.Revision)
@@ -53,7 +54,10 @@ defmodule Oli.Delivery.Attempts.Core.ActivityAttempt do
       :transformed_model,
       :resource_attempt_id,
       :resource_id,
-      :revision_id
+      :revision_id,
+      :group_id,
+      :survey_id,
+      :selection_id
     ])
     |> validate_required([
       :attempt_guid,

--- a/lib/oli/delivery/page/page_context.ex
+++ b/lib/oli/delivery/page/page_context.ex
@@ -110,7 +110,7 @@ defmodule Oli.Delivery.Page.PageContext do
 
     Attempts.track_access(page_revision.resource_id, section_id, user.id)
 
-    activity_provider = &Oli.Delivery.ActivityProvider.provide/3
+    activity_provider = &Oli.Delivery.ActivityProvider.provide/4
 
     {progress_state, resource_attempts, latest_attempts, activities} =
       case PageLifecycle.visit(

--- a/lib/oli/resources.ex
+++ b/lib/oli/resources.ex
@@ -309,6 +309,7 @@ defmodule Oli.Resources do
           recommended_attempts: previous_revision.recommended_attempts,
           time_limit: previous_revision.time_limit,
           scope: previous_revision.scope,
+          retake_mode: previous_revision.retake_mode,
           tags: previous_revision.tags
         },
         convert_strings_to_atoms(attrs)

--- a/lib/oli/resources/revision.ex
+++ b/lib/oli/resources/revision.ex
@@ -45,6 +45,7 @@ defmodule Oli.Resources.Revision do
     field :recommended_attempts, :integer, default: 0
     field :time_limit, :integer, default: 0
     field :scope, Ecto.Enum, values: [:embedded, :banked], default: :embedded
+    field :retake_mode, Ecto.Enum, values: [:normal, :targeted], default: :normal
     belongs_to :scoring_strategy, Oli.Resources.ScoringStrategy
     belongs_to :activity_type, Oli.Activities.ActivityRegistration
     belongs_to :primary_resource, Oli.Resources.Resource
@@ -75,6 +76,7 @@ defmodule Oli.Resources.Revision do
       :recommended_attempts,
       :time_limit,
       :scope,
+      :retake_mode,
       :scoring_strategy_id,
       :activity_type_id
     ])

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -599,7 +599,7 @@ defmodule OliWeb.PageDeliveryController do
     section = conn.assigns.section
     datashop_session_id = Plug.Conn.get_session(conn, :datashop_session_id)
 
-    activity_provider = &Oli.Delivery.ActivityProvider.provide/3
+    activity_provider = &Oli.Delivery.ActivityProvider.provide/4
 
     if Sections.is_enrolled?(user.id, section_slug) do
       # We must check gating conditions here to account for gates that activated after

--- a/lib/oli_web/controllers/resource_controller.ex
+++ b/lib/oli_web/controllers/resource_controller.ex
@@ -125,7 +125,7 @@ defmodule OliWeb.ResourceController do
 
       revision ->
         %Oli.Delivery.ActivityProvider.Result{
-          revisions: activity_revisions,
+          prototypes: prototypes,
           bib_revisions: bib_references,
           transformed_content: transformed_content
         } =
@@ -136,6 +136,7 @@ defmodule OliWeb.ResourceController do
               section_slug: project_slug,
               publication_id: Oli.Publishing.project_working_publication(project_slug).id
             },
+            [],
             Oli.Publishing.AuthoringResolver
           )
 
@@ -147,7 +148,7 @@ defmodule OliWeb.ResourceController do
               objectives:
                 Oli.Delivery.Page.ObjectivesRollup.rollup_objectives(
                   revision,
-                  activity_revisions,
+                  Enum.map(prototypes, fn p -> p.revision end),
                   AuthoringResolver,
                   project_slug
                 ),

--- a/priv/repo/migrations/20220802161855_retake_mode.exs
+++ b/priv/repo/migrations/20220802161855_retake_mode.exs
@@ -1,0 +1,13 @@
+defmodule Oli.Repo.Migrations.RetakeMode do
+  use Ecto.Migration
+
+  def change do
+    alter table(:revisions) do
+      add :retake_mode, :string, default: "normal", null: false
+    end
+
+    alter table(:activity_attempts) do
+      add :selection_id, :string
+    end
+  end
+end

--- a/test/oli/delivery/activity_provider_test.exs
+++ b/test/oli/delivery/activity_provider_test.exs
@@ -5,6 +5,11 @@ defmodule Oli.Delivery.ActivityProviderTest do
   alias Oli.Activities.Realizer.Query.Source
   alias Oli.Delivery.ActivityProvider.Result
 
+  defp index_of(prototypes, list) do
+    collection = MapSet.new(list)
+    Enum.find_index(prototypes, fn p -> MapSet.member?(collection, p.revision.resource_id) end)
+  end
+
   describe "fulfilling static activity references with adaptive page" do
     setup do
       content = %{
@@ -97,18 +102,19 @@ defmodule Oli.Delivery.ActivityProviderTest do
         section_slug: section.slug
       }
 
-      %Result{errors: errors, revisions: activity_revisions} =
+      %Result{errors: errors, prototypes: prototypes} =
         ActivityProvider.provide(
           page.revision,
           source,
+          [],
           Oli.Publishing.DeliveryResolver
         )
 
       assert length(errors) == 0
 
-      assert length(activity_revisions) == 2
-      assert Enum.at(activity_revisions, 0).resource_id == activity1.revision.resource_id
-      assert Enum.at(activity_revisions, 1).resource_id == activity2.revision.resource_id
+      assert length(prototypes) == 2
+      assert Enum.at(prototypes, 0).revision.resource_id == activity1.revision.resource_id
+      assert Enum.at(prototypes, 1).revision.resource_id == activity2.revision.resource_id
     end
   end
 
@@ -240,26 +246,38 @@ defmodule Oli.Delivery.ActivityProviderTest do
 
       %Result{
         errors: errors,
-        revisions: activity_revisions,
+        prototypes: prototypes,
         transformed_content: transformed_content
       } =
         ActivityProvider.provide(
           %{page.revision | content: content},
           source,
+          [],
           Oli.Publishing.DeliveryResolver
         )
 
       assert length(errors) == 0
 
-      assert length(activity_revisions) == 2
-      assert Enum.at(activity_revisions, 0).resource_id == activity6.revision.resource_id
-      assert_one_of(Enum.at(activity_revisions, 1).resource_id, [activity1, activity2, activity3])
+      assert length(prototypes) == 2
+
+      index6 = index_of(prototypes, [activity6.revision.resource_id])
+
+      other =
+        index_of(prototypes, [
+          activity1.revision.resource_id,
+          activity2.revision.resource_id,
+          activity3.revision.resource_id
+        ])
+
+      refute index6 == other
+      refute is_nil(other)
+      refute is_nil(index6)
 
       model = Map.get(transformed_content, "model")
       assert length(model) == 2
 
       static_id = activity6.revision.resource_id
-      banked_id = Enum.at(activity_revisions, 1).resource_id
+      banked_id = Enum.at(prototypes, other).revision.resource_id
 
       assert [
                %{"type" => "activity-reference", "activity_id" => ^static_id},
@@ -331,34 +349,38 @@ defmodule Oli.Delivery.ActivityProviderTest do
 
       %Result{
         errors: errors,
-        revisions: activity_revisions,
+        prototypes: prototypes,
         transformed_content: transformed_content
       } =
         ActivityProvider.provide(
           %{page.revision | content: content},
           source,
+          [],
           Oli.Publishing.DeliveryResolver
         )
 
       assert length(errors) == 0
 
-      assert length(activity_revisions) == 4
-      assert Enum.at(activity_revisions, 0).resource_id == activity6.revision.resource_id
-      assert_one_of(Enum.at(activity_revisions, 1).resource_id, [activity1, activity2, activity3])
-      assert Enum.at(activity_revisions, 2).resource_id == activity7.revision.resource_id
-      assert_one_of(Enum.at(activity_revisions, 3).resource_id, [activity1, activity2, activity3])
+      assert length(prototypes) == 4
+      assert Enum.at(prototypes, 0).revision.resource_id == activity6.revision.resource_id
+
+      assert_one_of(Enum.at(prototypes, 1).revision.resource_id, [activity1, activity2, activity3])
+
+      assert Enum.at(prototypes, 2).revision.resource_id == activity7.revision.resource_id
+
+      assert_one_of(Enum.at(prototypes, 3).revision.resource_id, [activity1, activity2, activity3])
 
       # This verifies that the second selection cannot pick an activity that the first selection did
-      refute Enum.at(activity_revisions, 1).resource_id ==
-               Enum.at(activity_revisions, 3).resource_id
+      refute Enum.at(prototypes, 1).revision.resource_id ==
+               Enum.at(prototypes, 3).revision.resource_id
 
       model = Map.get(transformed_content, "model")
       assert length(model) == 4
 
       static_id1 = activity6.revision.resource_id
-      banked_id1 = Enum.at(activity_revisions, 1).resource_id
+      banked_id1 = Enum.at(prototypes, 1).revision.resource_id
       static_id2 = activity7.revision.resource_id
-      banked_id2 = Enum.at(activity_revisions, 3).resource_id
+      banked_id2 = Enum.at(prototypes, 3).revision.resource_id
 
       assert [
                %{"type" => "activity-reference", "activity_id" => ^static_id1},
@@ -424,35 +446,39 @@ defmodule Oli.Delivery.ActivityProviderTest do
 
       %Result{
         errors: errors,
-        revisions: activity_revisions,
+        prototypes: prototypes,
         transformed_content: transformed_content
       } =
         ActivityProvider.provide(
           %{page.revision | content: content},
           source,
+          [],
           Oli.Publishing.DeliveryResolver
         )
 
       assert length(errors) == 0
 
-      assert length(activity_revisions) == 3
-      assert_one_of(Enum.at(activity_revisions, 0).resource_id, [activity1, activity2, activity3])
-      assert_one_of(Enum.at(activity_revisions, 1).resource_id, [activity1, activity2, activity3])
-      assert_one_of(Enum.at(activity_revisions, 2).resource_id, [activity1, activity2, activity3])
+      assert length(prototypes) == 3
+
+      assert_one_of(Enum.at(prototypes, 0).revision.resource_id, [activity1, activity2, activity3])
+
+      assert_one_of(Enum.at(prototypes, 1).revision.resource_id, [activity1, activity2, activity3])
+
+      assert_one_of(Enum.at(prototypes, 2).revision.resource_id, [activity1, activity2, activity3])
 
       # This verifies that the second selection cannot pick an activity that the first selection did.
       # The activity provider internal logic prevents this.
-      refute Enum.at(activity_revisions, 2).resource_id ==
-               Enum.at(activity_revisions, 0).resource_id or
-               Enum.at(activity_revisions, 2).resource_id ==
-                 Enum.at(activity_revisions, 1).resource_id
+      refute Enum.at(prototypes, 2).revision.resource_id ==
+               Enum.at(prototypes, 0).revision.resource_id or
+               Enum.at(prototypes, 2).revision.resource_id ==
+                 Enum.at(prototypes, 1).revision.resource_id
 
       model = Map.get(transformed_content, "model")
       assert length(model) == 3
 
-      banked_id1 = Enum.at(activity_revisions, 0).resource_id
-      banked_id2 = Enum.at(activity_revisions, 1).resource_id
-      banked_id3 = Enum.at(activity_revisions, 2).resource_id
+      banked_id1 = Enum.at(prototypes, 0).revision.resource_id
+      banked_id2 = Enum.at(prototypes, 1).revision.resource_id
+      banked_id3 = Enum.at(prototypes, 2).revision.resource_id
 
       assert [
                %{
@@ -522,12 +548,13 @@ defmodule Oli.Delivery.ActivityProviderTest do
 
       %Result{
         errors: errors,
-        revisions: activity_revisions,
+        prototypes: prototypes,
         transformed_content: transformed_content
       } =
         ActivityProvider.provide(
           %{page.revision | content: content},
           source,
+          [],
           Oli.Publishing.DeliveryResolver
         )
 
@@ -538,24 +565,27 @@ defmodule Oli.Delivery.ActivityProviderTest do
                "Selection failed to fulfill completely with 1 missing activities"
              )
 
-      assert length(activity_revisions) == 3
-      assert_one_of(Enum.at(activity_revisions, 0).resource_id, [activity1, activity2, activity3])
-      assert_one_of(Enum.at(activity_revisions, 1).resource_id, [activity1, activity2, activity3])
-      assert_one_of(Enum.at(activity_revisions, 2).resource_id, [activity1, activity2, activity3])
+      assert length(prototypes) == 3
+
+      assert_one_of(Enum.at(prototypes, 0).revision.resource_id, [activity1, activity2, activity3])
+
+      assert_one_of(Enum.at(prototypes, 1).revision.resource_id, [activity1, activity2, activity3])
+
+      assert_one_of(Enum.at(prototypes, 2).revision.resource_id, [activity1, activity2, activity3])
 
       # This verifies that the second selection cannot pick an activity that the first selection did.
       # The activity provider internal logic prevents this.
-      refute Enum.at(activity_revisions, 2).resource_id ==
-               Enum.at(activity_revisions, 0).resource_id or
-               Enum.at(activity_revisions, 2).resource_id ==
-                 Enum.at(activity_revisions, 1).resource_id
+      refute Enum.at(prototypes, 2).revision.resource_id ==
+               Enum.at(prototypes, 0).revision.resource_id or
+               Enum.at(prototypes, 2).revision.resource_id ==
+                 Enum.at(prototypes, 1).revision.resource_id
 
       model = Map.get(transformed_content, "model")
       assert length(model) == 3
 
-      banked_id1 = Enum.at(activity_revisions, 0).resource_id
-      banked_id2 = Enum.at(activity_revisions, 1).resource_id
-      banked_id3 = Enum.at(activity_revisions, 2).resource_id
+      banked_id1 = Enum.at(prototypes, 0).revision.resource_id
+      banked_id2 = Enum.at(prototypes, 1).revision.resource_id
+      banked_id3 = Enum.at(prototypes, 2).revision.resource_id
 
       assert [
                %{

--- a/test/oli/delivery/attempts/hiearchy_test.exs
+++ b/test/oli/delivery/attempts/hiearchy_test.exs
@@ -77,7 +77,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.HierarchyTest do
     } do
       Attempts.track_access(p1.resource.id, section.id, user.id)
 
-      activity_provider = &Oli.Delivery.ActivityProvider.provide/3
+      activity_provider = &Oli.Delivery.ActivityProvider.provide/4
       datashop_session_id = UUID.uuid4()
 
       {:ok, resource_attempt} =

--- a/test/oli/delivery/attempts/hiearchy_test.exs
+++ b/test/oli/delivery/attempts/hiearchy_test.exs
@@ -46,6 +46,8 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.HierarchyTest do
         |> Seeder.add_objective("objective one", :o1)
         |> Seeder.add_activity(%{title: "one", content: content1}, :a1)
         |> Seeder.add_activity(%{title: "two", content: content2}, :a2)
+        |> Seeder.add_activity(%{title: "three", content: content1, scope: :banked}, :a3)
+        |> Seeder.add_activity(%{title: "three", content: content1, scope: :banked}, :a3)
         |> Seeder.add_user(%{}, :user1)
         |> Seeder.add_user(%{}, :user2)
 

--- a/test/oli/delivery/attempts/optimized_hiearchy_test.exs
+++ b/test/oli/delivery/attempts/optimized_hiearchy_test.exs
@@ -124,7 +124,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.OptimizedHierarchyTest do
     } do
       Attempts.track_access(p1.resource.id, section.id, user.id)
 
-      activity_provider = &Oli.Delivery.ActivityProvider.provide/3
+      activity_provider = &Oli.Delivery.ActivityProvider.provide/4
       datashop_session_id = UUID.uuid4()
 
       {:ok, resource_attempt} =

--- a/test/oli/delivery/attempts/retake_mode_test.exs
+++ b/test/oli/delivery/attempts/retake_mode_test.exs
@@ -1,0 +1,180 @@
+defmodule Oli.Delivery.Attempts.PageLifecycle.RetakeModeTest do
+  use Oli.DataCase
+
+  alias Oli.Delivery.Attempts.Core, as: Attempts
+  alias Oli.Delivery.Attempts.PageLifecycle.{Hierarchy, VisitContext}
+
+  describe "targeted retake mode" do
+    setup do
+      content1 = %{
+        "stem" => "1",
+        "authoring" => %{
+          "parts" => [
+            %{
+              "id" => "1",
+              "responses" => [],
+              "scoringStrategy" => "best",
+              "evaluationStrategy" => "regex"
+            }
+          ]
+        }
+      }
+
+      map =
+        Seeder.base_project_with_resource2()
+        |> Seeder.create_section()
+        |> Seeder.add_objective("objective one", :o1)
+        |> Seeder.add_activity(%{title: "one", content: content1}, :a1)
+        |> Seeder.add_activity(%{title: "two", content: content1}, :a2)
+        |> Seeder.add_user(%{}, :user1)
+        |> Seeder.add_user(%{}, :user2)
+
+      attrs = %{
+        title: "page1",
+        retake_mode: :targeted,
+        content: %{
+          "model" => [
+            %{"type" => "activity-reference", "activity_id" => Map.get(map, :a1).resource.id},
+            %{"type" => "activity-reference", "activity_id" => Map.get(map, :a2).resource.id}
+          ]
+        },
+        objectives: %{"attached" => [Map.get(map, :o1).resource.id]},
+        graded: true
+      }
+
+      Seeder.ensure_published(map.publication.id)
+
+      Seeder.add_page(map, attrs, :p1)
+      |> Seeder.add_page(attrs, :p2)
+      |> Seeder.create_section_resources()
+    end
+
+    test "targeted retake mode for one activity out of two", %{
+      p1: p1,
+      user1: user,
+      section: section,
+      a1: a1,
+      a2: a2,
+      publication: pub
+    } do
+      Attempts.track_access(p1.resource.id, section.id, user.id)
+
+      activity_provider = &Oli.Delivery.ActivityProvider.provide/4
+      datashop_session_id = UUID.uuid4()
+
+      {:ok, resource_attempt} =
+        Hierarchy.create(%VisitContext{
+          latest_resource_attempt: nil,
+          page_revision: p1.revision,
+          section_slug: section.slug,
+          datashop_session_id: datashop_session_id,
+          user_id: user.id,
+          activity_provider: activity_provider,
+          blacklisted_activity_ids: [],
+          publication_id: pub.id
+        })
+
+      attempts = Hierarchy.get_latest_attempts(resource_attempt.id)
+      {attempt, part_map} = Map.get(attempts, a1.resource.id)
+
+      Attempts.update_activity_attempt(attempt, %{score: 1, out_of: 1})
+
+      Map.get(part_map, "1")
+      |> Attempts.update_part_attempt(%{score: 1, out_of: 1, response: %{input: "this was right"}})
+
+      {attempt, part_map} = Map.get(attempts, a2.resource.id)
+      Attempts.update_activity_attempt(attempt, %{score: 1, out_of: 3})
+
+      Map.get(part_map, "1")
+      |> Attempts.update_part_attempt(%{score: 1, out_of: 3, response: %{input: "this was wrong"}})
+
+      {:ok, resource_attempt2} =
+        Hierarchy.create(%VisitContext{
+          latest_resource_attempt: resource_attempt,
+          page_revision: p1.revision,
+          section_slug: section.slug,
+          datashop_session_id: datashop_session_id,
+          user_id: user.id,
+          activity_provider: activity_provider,
+          blacklisted_activity_ids: [],
+          publication_id: pub.id
+        })
+
+      attempts = Hierarchy.get_latest_attempts(resource_attempt2.id)
+
+      # Ensure that the new part attempt records carried forward the state of only the correct
+      # activity attempt from the previous resource attempt
+      {_, part_map} = Map.get(attempts, a1.resource.id)
+      assert Map.get(part_map, "1").response == %{"input" => "this was right"}
+      {_, part_map} = Map.get(attempts, a2.resource.id)
+      assert Map.get(part_map, "1").response == nil
+    end
+
+    test "targeted retake mode disabled when page revision changes", %{
+      p1: p1,
+      p2: p2,
+      user1: user,
+      section: section,
+      a1: a1,
+      a2: a2,
+      publication: pub
+    } do
+      Attempts.track_access(p1.resource.id, section.id, user.id)
+
+      activity_provider = &Oli.Delivery.ActivityProvider.provide/4
+      datashop_session_id = UUID.uuid4()
+
+      {:ok, resource_attempt} =
+        Hierarchy.create(%VisitContext{
+          latest_resource_attempt: nil,
+          page_revision: p1.revision,
+          section_slug: section.slug,
+          datashop_session_id: datashop_session_id,
+          user_id: user.id,
+          activity_provider: activity_provider,
+          blacklisted_activity_ids: [],
+          publication_id: pub.id
+        })
+
+      attempts = Hierarchy.get_latest_attempts(resource_attempt.id)
+      {attempt, part_map} = Map.get(attempts, a1.resource.id)
+
+      Attempts.update_activity_attempt(attempt, %{score: 1, out_of: 1})
+
+      Map.get(part_map, "1")
+      |> Attempts.update_part_attempt(%{score: 1, out_of: 1, response: %{input: "this was right"}})
+
+      {attempt, part_map} = Map.get(attempts, a2.resource.id)
+      Attempts.update_activity_attempt(attempt, %{score: 1, out_of: 3})
+
+      Map.get(part_map, "1")
+      |> Attempts.update_part_attempt(%{score: 1, out_of: 3, response: %{input: "this was wrong"}})
+
+      # We can safely simulate moving ahead to a new publication for the page by
+      # changing the revision id on the resource_attempt
+      {:ok, resource_attempt} =
+        Attempts.update_resource_attempt(resource_attempt, %{revision_id: p2.revision.id})
+
+      {:ok, resource_attempt2} =
+        Hierarchy.create(%VisitContext{
+          latest_resource_attempt: resource_attempt,
+          page_revision: p1.revision,
+          section_slug: section.slug,
+          datashop_session_id: datashop_session_id,
+          user_id: user.id,
+          activity_provider: activity_provider,
+          blacklisted_activity_ids: [],
+          publication_id: pub.id
+        })
+
+      attempts = Hierarchy.get_latest_attempts(resource_attempt2.id)
+
+      # Ensure that the new part attempt records carried forward the state of only the correct
+      # activity attempt from the previous resource attempt
+      {_, part_map} = Map.get(attempts, a1.resource.id)
+      assert Map.get(part_map, "1").response == nil
+      {_, part_map} = Map.get(attempts, a2.resource.id)
+      assert Map.get(part_map, "1").response == nil
+    end
+  end
+end

--- a/test/oli/delivery/attempts/retake_mode_test.exs
+++ b/test/oli/delivery/attempts/retake_mode_test.exs
@@ -110,6 +110,71 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.RetakeModeTest do
       assert Map.get(part_map, "1").response == nil
     end
 
+    test "targeted retake mode for all activities", %{
+      p1: p1,
+      user1: user,
+      section: section,
+      a1: a1,
+      a2: a2,
+      publication: pub
+    } do
+      Attempts.track_access(p1.resource.id, section.id, user.id)
+
+      activity_provider = &Oli.Delivery.ActivityProvider.provide/4
+      datashop_session_id = UUID.uuid4()
+
+      {:ok, resource_attempt} =
+        Hierarchy.create(%VisitContext{
+          latest_resource_attempt: nil,
+          page_revision: p1.revision,
+          section_slug: section.slug,
+          datashop_session_id: datashop_session_id,
+          user_id: user.id,
+          activity_provider: activity_provider,
+          blacklisted_activity_ids: [],
+          publication_id: pub.id
+        })
+
+      attempts = Hierarchy.get_latest_attempts(resource_attempt.id)
+      {attempt, part_map} = Map.get(attempts, a1.resource.id)
+
+      Attempts.update_activity_attempt(attempt, %{score: 1, out_of: 1})
+
+      Map.get(part_map, "1")
+      |> Attempts.update_part_attempt(%{score: 1, out_of: 1, response: %{input: "this was right"}})
+
+      {attempt, part_map} = Map.get(attempts, a2.resource.id)
+      Attempts.update_activity_attempt(attempt, %{score: 1, out_of: 1})
+
+      Map.get(part_map, "1")
+      |> Attempts.update_part_attempt(%{
+        score: 1,
+        out_of: 1,
+        response: %{input: "this was right, also"}
+      })
+
+      {:ok, resource_attempt2} =
+        Hierarchy.create(%VisitContext{
+          latest_resource_attempt: resource_attempt,
+          page_revision: p1.revision,
+          section_slug: section.slug,
+          datashop_session_id: datashop_session_id,
+          user_id: user.id,
+          activity_provider: activity_provider,
+          blacklisted_activity_ids: [],
+          publication_id: pub.id
+        })
+
+      attempts = Hierarchy.get_latest_attempts(resource_attempt2.id)
+
+      # Ensure that the new part attempt records carried forward the state of only the correct
+      # activity attempt from the previous resource attempt
+      {_, part_map} = Map.get(attempts, a1.resource.id)
+      assert Map.get(part_map, "1").response == %{"input" => "this was right"}
+      {_, part_map} = Map.get(attempts, a2.resource.id)
+      assert Map.get(part_map, "1").response == %{"input" => "this was right, also"}
+    end
+
     test "targeted retake mode disabled when page revision changes", %{
       p1: p1,
       p2: p2,

--- a/test/oli/delivery/attempts_test.exs
+++ b/test/oli/delivery/attempts_test.exs
@@ -78,7 +78,7 @@ defmodule Oli.Delivery.AttemptsTest do
     } do
       Attempts.track_access(p1.resource.id, section.id, user.id)
 
-      activity_provider = &Oli.Delivery.ActivityProvider.provide/3
+      activity_provider = &Oli.Delivery.ActivityProvider.provide/4
       datashop_session_id = UUID.uuid4()
 
       refute Attempts.has_any_attempts?(user, section, p1.revision.resource_id)
@@ -146,7 +146,7 @@ defmodule Oli.Delivery.AttemptsTest do
       section: section,
       user1: user1
     } do
-      activity_provider = &Oli.Delivery.ActivityProvider.provide/3
+      activity_provider = &Oli.Delivery.ActivityProvider.provide/4
       datashop_session_id = UUID.uuid4()
 
       PageContext.create_for_visit(section, revision.slug, user1, datashop_session_id)
@@ -201,7 +201,7 @@ defmodule Oli.Delivery.AttemptsTest do
       user1: user1,
       user2: user2
     } do
-      activity_provider = &Oli.Delivery.ActivityProvider.provide/3
+      activity_provider = &Oli.Delivery.ActivityProvider.provide/4
       datashop_session_id_user1 = UUID.uuid4()
       datashop_session_id_user2 = UUID.uuid4()
 
@@ -378,7 +378,7 @@ defmodule Oli.Delivery.AttemptsTest do
       graded_page: %{revision: revision},
       user1: user1
     } do
-      activity_provider = &Oli.Delivery.ActivityProvider.provide/3
+      activity_provider = &Oli.Delivery.ActivityProvider.provide/4
       datashop_session_id_user1 = UUID.uuid4()
 
       PageContext.create_for_visit(section, revision.slug, user1, datashop_session_id_user1)
@@ -407,7 +407,7 @@ defmodule Oli.Delivery.AttemptsTest do
       user1: user1,
       user2: user2
     } do
-      activity_provider = &Oli.Delivery.ActivityProvider.provide/3
+      activity_provider = &Oli.Delivery.ActivityProvider.provide/4
       datashop_session_id_user1 = UUID.uuid4()
       datashop_session_id_user2 = UUID.uuid4()
 
@@ -486,7 +486,8 @@ defmodule Oli.Delivery.AttemptsTest do
         last_grade_update_id: last_grade_update.id
       )
 
-      assert length(Attempts.get_failed_grade_sync_resource_accesses_for_section(section.slug)) == 2
+      assert length(Attempts.get_failed_grade_sync_resource_accesses_for_section(section.slug)) ==
+               2
     end
 
     test "get latest attempt - activity attempts", %{
@@ -538,7 +539,7 @@ defmodule Oli.Delivery.AttemptsTest do
       section: section,
       user1: user1
     } do
-      activity_provider = &Oli.Delivery.ActivityProvider.provide/3
+      activity_provider = &Oli.Delivery.ActivityProvider.provide/4
       datashop_session_id_user1 = UUID.uuid4()
 
       PageContext.create_for_visit(section, revision.slug, user1, datashop_session_id_user1)

--- a/test/oli/delivery/submission_test.exs
+++ b/test/oli/delivery/submission_test.exs
@@ -105,7 +105,7 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
       assert Enum.empty?(user1_page_context.resource_attempts)
 
       # Start the attempt and go into the assessment
-      activity_provider = &Oli.Delivery.ActivityProvider.provide/3
+      activity_provider = &Oli.Delivery.ActivityProvider.provide/4
 
       {:ok,
        %Oli.Delivery.Attempts.PageLifecycle.AttemptState{
@@ -405,7 +405,7 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
       user1_activity_attempt1: activity_attempt,
       graded_page_user1_attempt1: resource_attempt1
     } do
-      activity_provider = &Oli.Delivery.ActivityProvider.provide/3
+      activity_provider = &Oli.Delivery.ActivityProvider.provide/4
       datashop_session_id_user1 = UUID.uuid4()
 
       # User1 has a started resource attempt, so it should be "in progress"
@@ -454,7 +454,7 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
       user1_part1_attempt1: part_attempt,
       user1_activity_attempt1: activity_attempt
     } do
-      activity_provider = &Oli.Delivery.ActivityProvider.provide/3
+      activity_provider = &Oli.Delivery.ActivityProvider.provide/4
       datashop_session_id_user1 = UUID.uuid4()
 
       {:ok, {:in_progress, _resource_attempt}} =
@@ -498,7 +498,7 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
            graded_page_user2_attempt1: user2_resource_attempt1,
            user2: user2
          } do
-      activity_provider = &Oli.Delivery.ActivityProvider.provide/3
+      activity_provider = &Oli.Delivery.ActivityProvider.provide/4
       datashop_session_id_user1 = UUID.uuid4()
       datashop_session_id_user2 = UUID.uuid4()
 


### PR DESCRIPTION
This PR introduces the infrastructure to power "Targeted Retake Mode" - the ability for a graded page that allows multiple attempts to "pull forward" the state of activities that were answered correctly from previous attempts into new attempts. Essentially this allows a student that keep taking attempts, but only having to answer the questions that they got wrong in previous attempts. 

 A key change here is the introduction of the `AttemptPrototype` module, and a corresponding refactoring of the `ActivityProvider` module, to having it yield its results as attempt prototypes.  The AP can now also take as input a list of existing attempt prototypes that constrain how the AP will realize activities.  Basically this is the mechanism that allows a selection bank to pick the same (partial or complete) set of activities between attempts. 

Also, the PageLifecycle.Hiearchy.create implementation has changed to look for the presence of `retake_mode: :targeted` in the page revision to drive the creation and supply of existing attempt prototypes to the AP.  Also, a specialized method of creating part attempts that reuse state had to be authored. 