### PR TITLE
[MER-1340] Accept string based widths on images

### DIFF
--- a/assets/src/components/editing/elements/image/block/ImageElement.tsx
+++ b/assets/src/components/editing/elements/image/block/ImageElement.tsx
@@ -11,11 +11,18 @@ import { ImageSettings } from 'components/editing/elements/image/ImageSettings';
 
 interface Props extends EditorProps<ContentModel.ImageBlock> {}
 
+const percentageWidth = /^[0-9]+%$/;
+
 const cssWidth = (width: number | string | undefined) => {
   if (!width) return undefined;
-  if (typeof width === 'number') return width; // Numbers are fine, they imply pixels
+  if (typeof width === 'number') return width;
+  if (typeof width !== 'string') return undefined;
 
-  const pixels = parseInt(width, 10);
+  if (percentageWidth.test(width)) {
+    return width;
+  }
+
+  const pixels = parseFloat(width);
   if (isNaN(pixels)) return undefined;
   return pixels;
 };

--- a/assets/src/components/editing/elements/image/block/ImageElement.tsx
+++ b/assets/src/components/editing/elements/image/block/ImageElement.tsx
@@ -10,6 +10,16 @@ import { ImagePlaceholder } from 'components/editing/elements/image/block/ImageP
 import { ImageSettings } from 'components/editing/elements/image/ImageSettings';
 
 interface Props extends EditorProps<ContentModel.ImageBlock> {}
+
+const cssWidth = (width: number | string | undefined) => {
+  if (!width) return undefined;
+  if (typeof width === 'number') return width; // Numbers are fine, they imply pixels
+
+  const pixels = parseInt(width, 10);
+  if (isNaN(pixels)) return undefined;
+  return pixels;
+};
+
 export const ImageEditor = (props: Props) => {
   const selected = useElementSelected();
   const onEdit = useEditModelCallback(props.model);
@@ -34,7 +44,10 @@ export const ImageEditor = (props: Props) => {
       >
         <div>
           <Resizable show={selected} onResize={({ width, height }) => onEdit({ width, height })}>
-            <img src={props.model.src} style={{ maxWidth: props.model.width ?? '100%' }} />
+            <img
+              src={props.model.src}
+              style={{ maxWidth: cssWidth(props.model.width) ?? '100%' }}
+            />
           </Resizable>
         </div>
       </HoverContainer>

--- a/assets/src/data/content/model/elements/types.ts
+++ b/assets/src/data/content/model/elements/types.ts
@@ -100,8 +100,8 @@ type VoidChildren = Text[];
 
 interface BaseImage extends SlateElement<VoidChildren> {
   src?: string;
-  height?: number;
-  width?: number;
+  height?: number | string;
+  width?: number | string;
   alt?: string;
 }
 export interface ImageBlock extends BaseImage {


### PR DESCRIPTION
img elements have a schema that accepts strings or numbers for width.

✔️ Both strings and numbers worked fine when rendered via elixir.
❌ The client side rendering only accepted numbers, and effectively ignored strings.

After this change, string or number widths work in both cases.