### PR TITLE
[FEATURE] Set grades manually even for when a student hasn't visited or completed a page

### DIFF
--- a/lib/oli/delivery/attempts/core.ex
+++ b/lib/oli/delivery/attempts/core.ex
@@ -285,15 +285,18 @@ defmodule Oli.Delivery.Attempts.Core do
         join: published_resource in PublishedResource,
         on: section_project_publication.publication_id == published_resource.publication_id,
         join: revision in Revision,
-        on: revision.id == published_resource.revision_id and revision.resource_id == resource_access.resource_id,
+        on:
+          revision.id == published_resource.revision_id and
+            revision.resource_id == resource_access.resource_id,
         where:
           section.slug == ^section_slug and
-          section.status == :active and
-          revision.deleted == false and
-          revision.graded == true and
-          (not is_nil(resource_access.last_grade_update_id) and
-            (is_nil(resource_access.last_successful_grade_update_id) or
-              resource_access.last_grade_update_id != resource_access.last_successful_grade_update_id)),
+            section.status == :active and
+            revision.deleted == false and
+            revision.graded == true and
+            (not is_nil(resource_access.last_grade_update_id) and
+               (is_nil(resource_access.last_successful_grade_update_id) or
+                  resource_access.last_grade_update_id !=
+                    resource_access.last_successful_grade_update_id)),
         select: %{
           id: resource_access.id,
           resource_id: resource_access.resource_id,
@@ -389,7 +392,7 @@ defmodule Oli.Delivery.Attempts.Core do
   def get_resource_accesses(section_slug, user_id) do
     Repo.all(
       from(a in ResourceAccess,
-        join: ra in ResourceAttempt,
+        left_join: ra in ResourceAttempt,
         on: a.id == ra.resource_access_id,
         join: s in Section,
         on: a.section_id == s.id,

--- a/lib/oli_web/live/grades/gradebook_table_model.ex
+++ b/lib/oli_web/live/grades/gradebook_table_model.ex
@@ -1,5 +1,4 @@
 defmodule OliWeb.Grades.GradebookTableModel do
-
   use Surface.LiveComponent
 
   alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
@@ -7,7 +6,7 @@ defmodule OliWeb.Grades.GradebookTableModel do
   alias Oli.Delivery.Attempts.Core.ResourceAccess
   alias OliWeb.Router.Helpers, as: Routes
 
-  def new(enrollments, graded_pages, resource_accesses, section) do
+  def new(enrollments, graded_pages, resource_accesses, section, show_all_links) do
     by_user =
       Enum.reduce(resource_accesses, %{}, fn ra, m ->
         case Map.has_key?(m, ra.user_id) do
@@ -46,7 +45,8 @@ defmodule OliWeb.Grades.GradebookTableModel do
       rows: rows,
       column_specs: column_specs,
       event_suffix: "",
-      id_field: [:id]
+      id_field: [:id],
+      data: %{show_all_links: show_all_links}
     )
   end
 
@@ -58,11 +58,31 @@ defmodule OliWeb.Grades.GradebookTableModel do
     case Map.get(row, resource_id) do
       # Indicates that this student has never visited this resource
       nil ->
-        ""
+        case assigns.show_all_links do
+          true ->
+            ~F"""
+            <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Progress.StudentResourceView, row.section.slug, row.id, resource_id)}>
+              <span>Never Visited</span>
+            </a>
+            """
+
+          _ ->
+            ""
+        end
 
       # Indicates that this student has visited, but not completed this assessment
       %ResourceAccess{score: nil, out_of: nil} ->
-        ""
+        case assigns.show_all_links do
+          true ->
+            ~F"""
+            <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Progress.StudentResourceView, row.section.slug, row.id, resource_id)}>
+              <span>Never Finished</span>
+            </a>
+            """
+
+          _ ->
+            ""
+        end
 
       # We have a rolled-up grade from at least one attempt
       %ResourceAccess{} = resource_access ->

--- a/lib/oli_web/live/grades/gradebook_table_model.ex
+++ b/lib/oli_web/live/grades/gradebook_table_model.ex
@@ -62,7 +62,7 @@ defmodule OliWeb.Grades.GradebookTableModel do
           true ->
             ~F"""
             <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Progress.StudentResourceView, row.section.slug, row.id, resource_id)}>
-              <span>Never Visited</span>
+              <span class="text-muted">Never Visited</span>
             </a>
             """
 
@@ -76,7 +76,7 @@ defmodule OliWeb.Grades.GradebookTableModel do
           true ->
             ~F"""
             <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Progress.StudentResourceView, row.section.slug, row.id, resource_id)}>
-              <span>Never Finished</span>
+              <span>Not Finished</span>
             </a>
             """
 

--- a/lib/oli_web/live/grades/gradebook_view.ex
+++ b/lib/oli_web/live/grades/gradebook_view.ex
@@ -27,6 +27,7 @@ defmodule OliWeb.Grades.GradebookView do
   data offset, :integer, default: 0
   data limit, :integer, default: @limit
   data options, :any
+  data show_all_links, :boolean, default: false
 
   def set_breadcrumbs(type, section) do
     type
@@ -71,7 +72,7 @@ defmodule OliWeb.Grades.GradebookView do
         resource_accesses = fetch_resource_accesses(enrollments, section)
 
         {:ok, table_model} =
-          GradebookTableModel.new(enrollments, graded_pages, resource_accesses, section)
+          GradebookTableModel.new(enrollments, graded_pages, resource_accesses, section, false)
 
         {:ok,
          assign(socket,
@@ -111,6 +112,7 @@ defmodule OliWeb.Grades.GradebookView do
       )
 
     offset = get_int_param(params, "offset", 0)
+    show_all_links = get_boolean_param(params, "show_all_links", false)
 
     options = %EnrollmentBrowseOptions{
       text_search: get_param(params, "text_search", ""),
@@ -135,7 +137,8 @@ defmodule OliWeb.Grades.GradebookView do
         enrollments,
         socket.assigns.graded_pages,
         resource_accesses,
-        socket.assigns.section
+        socket.assigns.section,
+        show_all_links
       )
 
     total_count = determine_total(enrollments)
@@ -146,6 +149,7 @@ defmodule OliWeb.Grades.GradebookView do
        offset: offset,
        table_model: table_model,
        total_count: total_count,
+       show_all_links: show_all_links,
        options: options
      )}
   end
@@ -154,7 +158,16 @@ defmodule OliWeb.Grades.GradebookView do
     ~F"""
     <div>
 
-      <TextSearch id="text-search"/>
+      <div class="d-flex justify-content-between">
+        <TextSearch id="text-search"/>
+        <div class="form-check mt-2">
+          <input type="checkbox" id="toggle_show_all_links" class="form-check-input" checked={@show_all_links} phx-hook="CheckboxListener" />
+          <label for="toggle_show_all_links" class="form-check-label">
+            <div>Shows links for all gradebook entries</div>
+            <small class="text-muted">Allows access to pages that students have not finished or started</small>
+          </label>
+        </div>
+      </div>
 
       <div class="mb-3"/>
 
@@ -188,6 +201,10 @@ defmodule OliWeb.Grades.GradebookView do
          ),
        replace: true
      )}
+  end
+
+  def handle_event("change", %{"id" => "toggle_show_all_links", "checked" => checked}, socket) do
+    patch_with(socket, %{show_all_links: checked})
   end
 
   def handle_event(event, params, socket) do

--- a/lib/oli_web/live/progress/student_resource_view.ex
+++ b/lib/oli_web/live/progress/student_resource_view.ex
@@ -188,7 +188,7 @@ defmodule OliWeb.Progress.StudentResourceView do
 
         {#if @revision.graded}
           <p>If there is a need to manually set the grade for this student without the student ever having visited this page, first create the access record:</p>
-          <button class="btn btn-primary" type="button" :on-click="create_access_record">Create Access Record</button>
+          <button class="btn btn-primary mt-4" type="button" :on-click="create_access_record">Create Access Record</button>
         {/if}
 
       </Group>

--- a/lib/oli_web/live/progress/student_resource_view.ex
+++ b/lib/oli_web/live/progress/student_resource_view.ex
@@ -63,7 +63,12 @@ defmodule OliWeb.Progress.StudentResourceView do
                 _ ->
                   ResourceAccess.changeset(resource_access, %{
                     # limit score decimals to two significant figures, rounding up
-                    score: Utils.format_score(resource_access.score)
+                    score:
+                      if is_nil(resource_access.score) do
+                        nil
+                      else
+                        Utils.format_score(resource_access.score)
+                      end
                   })
               end
 
@@ -179,7 +184,13 @@ defmodule OliWeb.Progress.StudentResourceView do
         <ReadOnly label="Resource" value={@revision.title}/>
       </Group>
       <Group label="Attempt History" description="">
-        The student has not yet accessed this course resource
+        <p>The student has not yet accessed this course resource.</p>
+
+        {#if @revision.graded}
+          <p>If there is a need to manually set the grade for this student without the student ever having visited this page, first create the access record:</p>
+          <button class="btn btn-primary" type="button" :on-click="create_access_record">Create Access Record</button>
+        {/if}
+
       </Group>
     </Groups>
     """
@@ -203,6 +214,15 @@ defmodule OliWeb.Progress.StudentResourceView do
       |> ResourceAccess.changeset(params)
 
     {:noreply, assign(socket, changeset: changeset)}
+  end
+
+  def handle_event("create_access_record", _, socket) do
+    section = socket.assigns.section
+    user = socket.assigns.user
+    revision = socket.assigns.revision
+
+    {:ok, resource_access} = Core.track_access(revision.resource_id, section.id, user.id)
+    {:noreply, assign(socket, resource_access: resource_access)}
   end
 
   def handle_event("passback", _, socket) do
@@ -245,7 +265,10 @@ defmodule OliWeb.Progress.StudentResourceView do
          assign(socket,
            is_editing: false,
            resource_access: resource_access,
-           changeset: ResourceAccess.changeset(resource_access, %{score: Utils.format_score(resource_access.score)})
+           changeset:
+             ResourceAccess.changeset(resource_access, %{
+               score: Utils.format_score(resource_access.score)
+             })
          )}
 
       {:error, %Ecto.Changeset{} = changeset} ->

--- a/lib/oli_web/live/progress/student_view.ex
+++ b/lib/oli_web/live/progress/student_view.ex
@@ -61,11 +61,12 @@ defmodule OliWeb.Progress.StudentView do
                 user_id
               )
               |> Enum.reduce(%{}, fn r, m ->
-                 # limit score decimals to two significant figures, rounding up
+                # limit score decimals to two significant figures, rounding up
                 r = Map.put(r, :score, format_score(r.score))
                 Map.put(m, r.resource_id, r)
               end)
 
+            IO.inspect(resource_accesses)
             hierarchy = Oli.Publishing.DeliveryResolver.full_hierarchy(section.slug)
 
             page_nodes =

--- a/lib/oli_web/live/progress/student_view.ex
+++ b/lib/oli_web/live/progress/student_view.ex
@@ -62,11 +62,15 @@ defmodule OliWeb.Progress.StudentView do
               )
               |> Enum.reduce(%{}, fn r, m ->
                 # limit score decimals to two significant figures, rounding up
-                r = Map.put(r, :score, format_score(r.score))
+                r =
+                  case r.score do
+                    nil -> r
+                    _ -> Map.put(r, :score, format_score(r.score))
+                  end
+
                 Map.put(m, r.resource_id, r)
               end)
 
-            IO.inspect(resource_accesses)
             hierarchy = Oli.Publishing.DeliveryResolver.full_hierarchy(section.slug)
 
             page_nodes =


### PR DESCRIPTION
This PR adds a feature to the gradebook that allows an instructor to set a student's score, manually, even in situations where the student never visited a page or completed at least one attempt.  

I had to change a join to a left_join to account for the possibility that no resource_attempt records exist. 