### PR TITLE
[Bugfix] PMP-2988 JAN-1836 user state queue

### DIFF
--- a/assets/src/data/persistence/extrinsic.ts
+++ b/assets/src/data/persistence/extrinsic.ts
@@ -14,13 +14,23 @@ export type ExtrinsicDelete = {
   result: 'success';
 };
 
+const setQ = new Set();
+const lastSet = () => {
+  const arr = Array.from(setQ);
+  return arr[arr.length - 1];
+};
+
 export function readGlobal(keys: string[] | null = null) {
   const params = {
     method: 'GET',
     url: '/state' + toKeyParams(keys),
   };
 
-  return makeRequest<ExtrinsicRead>(params);
+  const result = makeRequest<ExtrinsicRead>(params);
+
+  console.log('GET DATA FROM STATE', { keys, params, result });
+
+  return result;
 }
 
 export const readGlobalUserState = async (
@@ -39,6 +49,9 @@ export const readGlobalUserState = async (
       result = storedUserState;
     }
   } else {
+    if (lastSet()) {
+      await lastSet();
+    }
     const serverUserState = await readGlobal(keys);
     // merge server state with result
     if ((serverUserState as any).type !== 'ServerError') {
@@ -72,7 +85,10 @@ export const internalUpdateGlobalUserState = async (
 
     localStorage.setItem('torus.userState', JSON.stringify(mergedState));
   } else {
-    await upsertGlobal(newState);
+    const op = upsertGlobal(newState);
+    setQ.add(op);
+    await op;
+    setQ.delete(op);
   }
   return newState;
 };
@@ -106,7 +122,11 @@ export function upsertGlobal(keyValues: KeyValues) {
     url: '/state',
   };
 
-  return makeRequest<ExtrinsicDelete>(params);
+  const result = makeRequest<ExtrinsicDelete>(params);
+
+  console.log('UPSERT DATA TO STATE', { params, result });
+
+  return result;
 }
 
 export function readSection(slug: SectionSlug, keys: string[] | null = null) {

--- a/assets/src/data/persistence/extrinsic.ts
+++ b/assets/src/data/persistence/extrinsic.ts
@@ -28,7 +28,7 @@ export function readGlobal(keys: string[] | null = null) {
 
   const result = makeRequest<ExtrinsicRead>(params);
 
-  console.log('GET DATA FROM STATE', { keys, params, result });
+  /* console.log('GET DATA FROM STATE', { keys, params, result }); */
 
   return result;
 }
@@ -124,7 +124,7 @@ export function upsertGlobal(keyValues: KeyValues) {
 
   const result = makeRequest<ExtrinsicDelete>(params);
 
-  console.log('UPSERT DATA TO STATE', { params, result });
+  /* console.log('UPSERT DATA TO STATE', { params, result }); */
 
   return result;
 }


### PR DESCRIPTION
this helps with an everapp race condition. everapps (observer) that are constantly polling the data previously might have executed a get request while a set request was still processing.