### PR TITLE
Increase live socket timeout to 60 sec

### DIFF
--- a/assets/src/phoenix/app.ts
+++ b/assets/src/phoenix/app.ts
@@ -21,6 +21,7 @@ const csrfToken = (document as any)
 const liveSocket = new LiveSocket('/live', Socket, {
   hooks: Hooks,
   params: { _csrf_token: csrfToken },
+  timeout: 60000,
   metadata: {
     keydown: (e: any, _el: any) => {
       return {


### PR DESCRIPTION
Increase timeout of live socket to 60 sec so we can render a live view that's running a long query. After working on that query specific and improve it, we can low down again the socket timeout number.