### PR TITLE
[PERFORMANCE] Optimize resource_access fetch with gradebook LV

### DIFF
--- a/lib/oli/delivery/attempts/core.ex
+++ b/lib/oli/delivery/attempts/core.ex
@@ -224,37 +224,31 @@ defmodule Oli.Delivery.Attempts.Core do
 
   `[%ResourceAccess{}, ...]`
   """
-  def get_graded_resource_access_for_context(section_slug) do
+  def get_graded_resource_access_for_context(section_id) do
     Repo.all(
-      from(a in ResourceAccess,
-        join: s in Section,
-        on: a.section_id == s.id,
-        join: spp in SectionsProjectsPublications,
-        on: s.id == spp.section_id,
+      from(spp in SectionsProjectsPublications,
         join: pr in PublishedResource,
         on: pr.publication_id == spp.publication_id,
         join: r in Revision,
-        on: pr.revision_id == r.id,
-        where: s.slug == ^section_slug and s.status == :active and r.graded == true,
+        on: r.id == pr.revision_id,
+        join: a in ResourceAccess,
+        on: r.resource_id == a.resource_id,
+        where: spp.section_id == ^section_id and r.graded == true,
         select: a
       )
     )
   end
 
-  def get_graded_resource_access_for_context(section_slug, student_ids) do
+  def get_graded_resource_access_for_context(section_id, user_ids) do
     Repo.all(
-      from(a in ResourceAccess,
-        join: s in Section,
-        on: a.section_id == s.id,
-        join: spp in SectionsProjectsPublications,
-        on: s.id == spp.section_id,
+      from(spp in SectionsProjectsPublications,
         join: pr in PublishedResource,
         on: pr.publication_id == spp.publication_id,
         join: r in Revision,
-        on: pr.revision_id == r.id,
-        where:
-          a.user_id in ^student_ids and s.slug == ^section_slug and s.status == :active and
-            r.graded == true,
+        on: r.id == pr.revision_id,
+        join: a in ResourceAccess,
+        on: r.resource_id == a.resource_id,
+        where: spp.section_id == ^section_id and r.graded == true and a.user_id in ^user_ids,
         select: a
       )
     )

--- a/lib/oli/delivery/attempts/core.ex
+++ b/lib/oli/delivery/attempts/core.ex
@@ -232,7 +232,7 @@ defmodule Oli.Delivery.Attempts.Core do
         join: r in Revision,
         on: r.id == pr.revision_id,
         join: a in ResourceAccess,
-        on: r.resource_id == a.resource_id,
+        on: r.resource_id == a.resource_id and a.section_id == spp.section_id,
         where: spp.section_id == ^section_id and r.graded == true,
         select: a
       )
@@ -247,7 +247,7 @@ defmodule Oli.Delivery.Attempts.Core do
         join: r in Revision,
         on: r.id == pr.revision_id,
         join: a in ResourceAccess,
-        on: r.resource_id == a.resource_id,
+        on: r.resource_id == a.resource_id and a.section_id == spp.section_id,
         where: spp.section_id == ^section_id and r.graded == true and a.user_id in ^user_ids,
         select: a
       )

--- a/lib/oli/grading.ex
+++ b/lib/oli/grading.ex
@@ -171,7 +171,7 @@ defmodule Oli.Grading do
     students = fetch_students(section.slug)
 
     # create a map of all resource accesses, keyed off resource id
-    resource_accesses = fetch_resource_accesses(section.slug)
+    resource_accesses = fetch_resource_accesses(section.id)
 
     # build gradebook map - for each user in the section, create a gradebook row. Using
     # resource_accesses, create a list of gradebook scores leaving scores null if they do not exist
@@ -284,9 +284,8 @@ defmodule Oli.Grading do
     |> Enum.map(fn e -> e.user end)
   end
 
-
-  def fetch_resource_accesses(section_slug) do
-    Attempts.get_graded_resource_access_for_context(section_slug)
+  def fetch_resource_accesses(section_id) do
+    Attempts.get_graded_resource_access_for_context(section_id)
     |> Enum.reduce(%{}, fn resource_access, acc ->
       case acc[resource_access.resource_id] do
         nil ->

--- a/lib/oli_web/live/grades/gradebook_view.ex
+++ b/lib/oli_web/live/grades/gradebook_view.ex
@@ -53,11 +53,6 @@ defmodule OliWeb.Grades.GradebookView do
       {type, _, section} ->
         hierarchy = Oli.Publishing.DeliveryResolver.full_hierarchy(section.slug)
 
-        Oli.Utils.FlameGraph.create(
-          fn -> Oli.Publishing.DeliveryResolver.full_hierarchy(section.slug) end,
-          :hierarchy
-        )
-
         graded_pages =
           hierarchy
           |> Oli.Delivery.Hierarchy.flatten()

--- a/test/oli/delivery/attempts_test.exs
+++ b/test/oli/delivery/attempts_test.exs
@@ -393,7 +393,7 @@ defmodule Oli.Delivery.AttemptsTest do
         )
 
       access =
-        Attempts.get_graded_resource_access_for_context(section.slug)
+        Attempts.get_graded_resource_access_for_context(section.id)
         |> Enum.filter(fn a -> a.resource_id == revision.resource_id && a.user_id == user1.id end)
         |> hd
 
@@ -433,14 +433,14 @@ defmodule Oli.Delivery.AttemptsTest do
           activity_provider
         )
 
-      accesses1 = Attempts.get_graded_resource_access_for_context(section.slug, [user1.id])
+      accesses1 = Attempts.get_graded_resource_access_for_context(section.id, [user1.id])
       assert Enum.all?(accesses1, fn a -> a.user_id == user1.id end)
 
-      accesses2 = Attempts.get_graded_resource_access_for_context(section.slug, [user2.id])
+      accesses2 = Attempts.get_graded_resource_access_for_context(section.id, [user2.id])
       assert Enum.all?(accesses2, fn a -> a.user_id == user2.id end)
 
       accesses_both =
-        Attempts.get_graded_resource_access_for_context(section.slug, [user1.id, user2.id])
+        Attempts.get_graded_resource_access_for_context(section.id, [user1.id, user2.id])
 
       assert length(accesses_both) == length(accesses1) + length(accesses2)
     end


### PR DESCRIPTION
The query to retrieve the resource access records for all graded pages, for a window of 25 users was taking long enough time to trip the 10 second Phoenix socket timeout during the Gradebook LV init. 

Analyzing the query showed that it had:

```
"Startup Cost": 153.25,
"Total Cost": 270.65
```

This was primarily due to how the query accounted for the specific set of users, given the join through section slug to SPP to PR to revision. 

I simplified and reworked the join approach to lower that to:

```
"Startup Cost": 8.53,
"Total Cost": 41.99
```

