### PR TITLE
[FEATURE] UX support for targeted retake

### DIFF
--- a/assets/src/components/activities/common/delivery/evaluation/EvaluationConnected.tsx
+++ b/assets/src/components/activities/common/delivery/evaluation/EvaluationConnected.tsx
@@ -6,15 +6,13 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 
 export const EvaluationConnected: React.FC = () => {
-  const { graded, mode, surveyId, writerContext } = useDeliveryElementContext();
+  const { surveyId, writerContext } = useDeliveryElementContext();
   const uiState = useSelector((state: ActivityDeliveryState) => state);
 
   return (
     <>
       <Evaluation
-        shouldShow={
-          isEvaluated(uiState) && (!graded || mode === 'review') && surveyId === undefined
-        }
+        shouldShow={isEvaluated(uiState) && surveyId === undefined}
         attemptState={uiState.attemptState}
         context={writerContext}
       />

--- a/assets/src/components/activities/common/delivery/graded_points/GradedPointsConnected.tsx
+++ b/assets/src/components/activities/common/delivery/graded_points/GradedPointsConnected.tsx
@@ -8,13 +8,11 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 
 export const GradedPointsConnected: React.FC = () => {
-  const { graded, mode, surveyId } = useDeliveryElementContext();
+  const { graded, surveyId } = useDeliveryElementContext();
   const uiState = useSelector((state: ActivityDeliveryState) => state);
   return (
     <GradedPoints
-      shouldShow={
-        uiState.attemptState.score !== null && graded && mode === 'review' && surveyId === undefined
-      }
+      shouldShow={uiState.attemptState.score !== null && graded && surveyId === undefined}
       icon={isCorrect(uiState.attemptState) ? <Checkmark /> : <Cross />}
       attemptState={uiState.attemptState}
     />

--- a/lib/oli/delivery/activity_provider/attempt_prototype.ex
+++ b/lib/oli/delivery/activity_provider/attempt_prototype.ex
@@ -19,6 +19,11 @@ defmodule Oli.Delivery.ActivityProvider.AttemptPrototype do
     :survey_id,
     :group_id,
     :selection_id,
+    :score,
+    :out_of,
+    :lifecycle_state,
+    :date_submitted,
+    :date_evaluated,
     :inherit_state_from_previous
   ]
 
@@ -31,6 +36,11 @@ defmodule Oli.Delivery.ActivityProvider.AttemptPrototype do
       survey_id: attempt.survey_id,
       group_id: attempt.group_id,
       selection_id: attempt.selection_id,
+      score: attempt.score,
+      out_of: attempt.out_of,
+      lifecycle_state: attempt.lifecycle_state,
+      date_submitted: attempt.date_submitted,
+      date_evaluated: attempt.date_evaluated,
       inherit_state_from_previous: true
     }
   end

--- a/lib/oli_web/live/curriculum/entries/options_modal.ex
+++ b/lib/oli_web/live/curriculum/entries/options_modal.ex
@@ -85,6 +85,17 @@ defmodule OliWeb.Curriculum.OptionsModal do
                         placeholder: "Scoring Strategy" %>
                     <small id="scoringStrategy" class="form-text text-muted">The scoring strategy determines how to calculate the final grade book score across all attempts.</small>
                   </div>
+
+                  <div class="form-group">
+                    <%= label f, "Retake Mode" %>
+                    <%= select f, :retake_mode, [{"Normal: Students answer all questions in each attempt", :normal}, {"Targeted: Students answer only incorrect questions from previous attempts", :targeted}],
+                        class: "custom-select",
+                        disabled: is_disabled(changeset, revision) or !@revision.graded,
+                        class: "form-control",
+                        aria_describedby: "retakeMode",
+                        placeholder: "Retake Mode" %>
+                    <small id="retakeMode" class="form-text text-muted">The retake mode determines how subsequent attempts are presented to students.</small>
+                  </div>
                 <% end %>
               </div>
               <div class="modal-footer">


### PR DESCRIPTION
This PR adds the UX support for targeted retake mode. 

It does three things:
1. Adds support for editing the "Retake Mode" attribute for a graded page
2. Augments the logic for creating attempts from constraining prototypes to set the score, out_of, lifecycle_state and evaluated and submitted dates, also sets the feedback, score, outof and lifecycle attrs for part attempts. This then allows:
3. Changes client side activities to render score and feedback when an item is evaluated, regardless of "review_mode" or not. 