### PR TITLE
[BUG] [MER-1402] [#2917] Table settings menu in th

### DIFF
--- a/assets/styles/authoring/model-editors.scss
+++ b/assets/styles/authoring/model-editors.scss
@@ -16,6 +16,7 @@
       word-wrap: break-word;
       overflow: visible;
 
+      th,
       td {
         position: relative;
       }


### PR DESCRIPTION
Fixes bug #2917 

I believe the real cause of the bug was the menu was in the top right of the entire table instead of the top right of the cell. Now, the menu will be in the cell as expected.

![image](https://user-images.githubusercontent.com/333265/184141612-d0839ba7-1450-4aa8-b155-ab8e0d2e72fa.png)
