### PR TITLE
[BUG] [MER-1403] [#2918] MathJax config fix.

### DIFF
--- a/lib/oli_web/common/mathjax_script.ex
+++ b/lib/oli_web/common/mathjax_script.ex
@@ -1,0 +1,26 @@
+defmodule OliWeb.Common.MathJaxScript do
+  use Phoenix.Component
+
+  def render(assigns) do
+    ~H"""
+    <script>
+    window.MathJax = {
+      tex: {
+        inlineMath: [ ["\\(","\\)"] ],
+        displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
+        processEscapes: true,
+        packages: ['base', 'ams', 'noerrors', 'noundefined', 'require']
+      },
+      options: {
+        ignoreHtmlClass: 'tex2jax_ignore',
+        processHtmlClass: 'tex2jax_process'
+      },
+      loader: {
+        load: ['[tex]/noerrors']
+      }
+    };
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" id="MathJax-script"></script>
+    """
+  end
+end

--- a/lib/oli_web/common/mathjax_script.ex
+++ b/lib/oli_web/common/mathjax_script.ex
@@ -9,7 +9,40 @@ defmodule OliWeb.Common.MathJaxScript do
         inlineMath: [ ["\\(","\\)"] ],
         displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
         processEscapes: true,
-        packages: ['base', 'ams', 'noerrors', 'noundefined', 'require']
+        packages: ['base', 'ams', 'noerrors', 'noundefined', 'require'],
+        require: {
+          defaultAllow: false,
+          allow: {
+            "action": true,
+            "amscd": true,
+            "bbox": true,
+            "boldsymbol": true,
+            "braket": true,
+            "bussproofs": true,
+            "cancel": true,
+            "cases": true,
+            "centernot": true,
+            "color": true,
+            "colortbl": true,
+            "colorv2": true,
+            "configmacros": true,
+            "empheq": true,
+            "enclose": true,
+            "extpfeil": true,
+            "gensymb": true,
+            "html": true,
+            "mathtools": true,
+            "mhchem": true,
+            "physics": true,
+            "setoptions": true,
+            "tagformat": true,
+            "textcomp": true,
+            "textmacros": true,
+            "unicode": true,
+            "upgreek": true,
+            "verb": true
+          }
+        }
       },
       options: {
         ignoreHtmlClass: 'tex2jax_ignore',

--- a/lib/oli_web/templates/layout/authoring.html.leex
+++ b/lib/oli_web/templates/layout/authoring.html.leex
@@ -55,24 +55,7 @@
       window.cite = require('citation-js')
     </script>
 
-    <script>
-    window.MathJax = {
-      tex: {
-        inlineMath: [ ["\\(","\\)"] ],
-        displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
-        processEscapes: true,
-        packages: ['base', 'ams', 'noerrors', 'noundefined']
-      },
-      options: {
-        ignoreHtmlClass: 'tex2jax_ignore',
-        processHtmlClass: 'tex2jax_process'
-      },
-      loader: {
-        load: ['[tex]/noerrors']
-      }
-    };
-    </script>
-    <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" id="MathJax-script"></script>
+    <%= OliWeb.Common.MathJaxScript.render(@conn) %>
 
     <%= csrf_meta_tag() %>
     <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/app.js") %>"></script>

--- a/lib/oli_web/templates/layout/chromeless.html.eex
+++ b/lib/oli_web/templates/layout/chromeless.html.eex
@@ -44,24 +44,7 @@
       window.cite = require('citation-js')
     </script>
 
-    <script>
-    window.MathJax = window.MathJax || {
-      tex: {
-        inlineMath: [ ["\\(","\\)"] ],
-        displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
-        processEscapes: true,
-        packages: ['base', 'ams', 'noerrors', 'noundefined']
-      },
-      options: {
-        ignoreHtmlClass: 'tex2jax_ignore',
-        processHtmlClass: 'tex2jax_process'
-      },
-      loader: {
-        load: ['[tex]/noerrors']
-      }
-    };
-    </script>
-    <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" id="MathJax-script"></script>
+    <%= OliWeb.Common.MathJaxScript.render(@conn) %>
 
     <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/app.js") %>"></script>
 

--- a/lib/oli_web/templates/layout/delivery.html.eex
+++ b/lib/oli_web/templates/layout/delivery.html.eex
@@ -51,24 +51,7 @@
       window.cite = require('citation-js')
     </script>
 
-    <script>
-    window.MathJax = window.MathJax || {
-      tex: {
-        inlineMath: [ ["\\(","\\)"] ],
-        displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
-        processEscapes: true,
-        packages: ['base', 'ams', 'noerrors', 'noundefined']
-      },
-      options: {
-        ignoreHtmlClass: 'tex2jax_ignore',
-        processHtmlClass: 'tex2jax_process'
-      },
-      loader: {
-        load: ['[tex]/noerrors']
-      }
-    };
-    </script>
-    <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" id="MathJax-script"></script>
+    <%= OliWeb.Common.MathJaxScript.render(@conn) %>
 
     <%= csrf_meta_tag() %>
     <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/app.js") %>"></script>


### PR DESCRIPTION
Fixes #2918

A tweak to our mathjax configuration to support the \require command which lets the \cancel command work in this sample formula.

```
\require{cancel}\mathrm{mol}\;\mathrm{HCl}\;\mathrm{produced}\;=\;3\;\cancel{\mathrm{mol}\;{\mathrm H}_2}\;\times\;\frac{2\;\mathrm{mol}\;\mathrm{HCl}}{1\;\cancel{\mathrm{mol}\;{\mathrm H}_2}}\;\;=\;6\;\mathrm{mol}\;\mathrm{HCl}
```

After fix applied:

![image](https://user-images.githubusercontent.com/333265/184154474-de5d518b-daf3-43f0-aee2-4f79c1cf40aa.png)

While at it, I put this config in a phoenix component since it was copy/pasted in 3 different html files.
