### PR TITLE
Fix GH actions build PR for forked repos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   elixir-build-test:
+    name: Elixir build and test
     runs-on: ubuntu-latest
 
     env:
@@ -88,7 +89,7 @@ jobs:
           if-no-files-found: ignore
 
   check-simon-token:
-    name: check simon-bot access token
+    name: Check simon-bot access token
     runs-on: ubuntu-latest
     outputs:
       available: ${{ steps.check_token.outputs.available }}
@@ -98,6 +99,7 @@ jobs:
         run: echo "::set-output name=available::$(if [ "${{ secrets.SIMON_BOT_PERSONAL_ACCESS_TOKEN }}" != "" ] ; then echo true ; else echo false ; fi)"
 
   auto-format:
+    name: Auto format and lint
     runs-on: ubuntu-latest
     needs: check-simon-token
     if: ${{ needs.check-simon-token.outputs.available }}
@@ -138,6 +140,7 @@ jobs:
           committer_email: simondevbot@gmail.com
 
   ts-build-test:
+    name: TypeScript build and test
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,7 +111,7 @@ jobs:
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.SIMON_BOT_PERSONAL_ACCESS_TOKEN }}
+          token: ${{ secrets.SIMON_BOT_PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: 🔧 Configure
         uses: actions/setup-node@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,60 +87,40 @@ jobs:
           path: test-results
           if-no-files-found: ignore
 
-  check-simon-token:
-    name: check simon-bot access token
-    runs-on: ubuntu-latest
-    outputs:
-      available: ${{ steps.check_token.outputs.available }}
-    steps:
-      - name: Check whether SIMON_BOT_PERSONAL_ACCESS_TOKEN is set
-        id: check_token
-        run: echo "::set-output name=available::$(if [ "${{ secrets.SIMON_BOT_PERSONAL_ACCESS_TOKEN }}" != "" ] ; then echo true ; else echo false ; fi)"
-
   auto-format:
     runs-on: ubuntu-latest
-    needs: check-simon-token
+    if: if "${{ secrets.SIMON_BOT_PERSONAL_ACCESS_TOKEN }}" != ""
 
     steps:
-      - name: Info
-        run: if ${{ needs.check-simon-token.outputs.available }} ; then echo "Running auto format job..." ; else echo "No simon token. Skipping auto format." ; fi
-
       - name: 🛎️ Checkout
         uses: actions/checkout@v3
-        if: ${{ needs.check-simon-token.outputs.available }}
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.SIMON_BOT_PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.SIMON_BOT_PERSONAL_ACCESS_TOKEN }}
 
       - name: 🔧 Configure
         uses: actions/setup-node@v1
-        if: ${{ needs.check-simon-token.outputs.available }}
         with:
           node-version: "16.13.2"
 
       - name: 🧪 Setup elixir
         uses: erlef/setup-elixir@v1
-        if: ${{ needs.check-simon-token.outputs.available }}
         with:
           elixir-version: 1.13.2 # Define the elixir version [required]
           otp-version: 24.0 # Define the OTP version [required]
 
       - name: ⬇️ Install elixir dependencies
         run: mix deps.get
-        if: ${{ needs.check-simon-token.outputs.available }}
 
       - name: 📦 Install node_module dependencies
         run: yarn --cwd assets --frozen-lockfile
-        if: ${{ needs.check-simon-token.outputs.available }}
 
       - name: 🤖 Auto format
         run: yarn --cwd assets run format
-        if: ${{ needs.check-simon-token.outputs.available }}
 
       - name: ✅ Commit
         uses: EndBug/add-and-commit@v9
-        if: ${{ needs.check-simon-token.outputs.available }}
         with:
           message: Auto format
           committer_name: Simon Bot (GitHub Actions)
@@ -148,7 +128,6 @@ jobs:
 
   ts-build-test:
     runs-on: ubuntu-latest
-    needs: auto-format
 
     steps:
       - name: 🛎️ Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,9 +87,20 @@ jobs:
           path: test-results
           if-no-files-found: ignore
 
+  check-simon-token:
+    name: check simon-bot access token
+    runs-on: ubuntu-latest
+    outputs:
+      available: ${{ steps.check_token.outputs.available }}
+    steps:
+      - name: Check whether SIMON_BOT_PERSONAL_ACCESS_TOKEN is set
+        id: check_token
+        run: echo "::set-output name=available::$(if [ "${{ secrets.SIMON_BOT_PERSONAL_ACCESS_TOKEN }}" != "" ] ; then echo true ; else echo false ; fi)"
+
   auto-format:
     runs-on: ubuntu-latest
-    if: if "${{ secrets.SIMON_BOT_PERSONAL_ACCESS_TOKEN }}" != ""
+    needs: check-simon-token
+    if: ${{ needs.check-simon-token.outputs.available }}
 
     steps:
       - name: 🛎️ Checkout

--- a/assets/src/components/activities/likert/Sections/LikertTable.tsx
+++ b/assets/src/components/activities/likert/Sections/LikertTable.tsx
@@ -16,8 +16,7 @@ interface Props {
 }
 
 // only include item column if more than one item or single item is non-blank
-const needItemColumn = (items: LikertItem[]) => {
-  return items.length > 1 || toSimpleText(items[0].content).trim() != '';
+const needItemColumn = (items: LikertItem[]) => {  return items.length > 1 || toSimpleText(items[0].content).trim() != '';
 };
 
 export const LikertTable: React.FC<Props> = ({

--- a/assets/src/components/activities/likert/Sections/LikertTable.tsx
+++ b/assets/src/components/activities/likert/Sections/LikertTable.tsx
@@ -16,7 +16,8 @@ interface Props {
 }
 
 // only include item column if more than one item or single item is non-blank
-const needItemColumn = (items: LikertItem[]) => {  return items.length > 1 || toSimpleText(items[0].content).trim() != '';
+const needItemColumn = (items: LikertItem[]) => {
+  return items.length > 1 || toSimpleText(items[0].content).trim() != '';
 };
 
 export const LikertTable: React.FC<Props> = ({


### PR DESCRIPTION
GH actions does not allow PRs from forked repositories to access secrets needed to auto format. Therefore this PR changes the way the CI works so that auto-format job will only run if the necessary secret token is available. This auto-format job is no longer a prerequisite to the ts-build-test because if automatic formatting is performed, then a new job will be kicked off in the CI from the newly created auto-format commit.