### PR TITLE
[BUG] fix citation ingest rewire bug

### DIFF
--- a/lib/oli/interop/ingest.ex
+++ b/lib/oli/interop/ingest.ex
@@ -533,7 +533,7 @@ defmodule Oli.Interop.Ingest do
   end
 
   defp rewire_bib_refs(%{"type" => "content", "children" => _children} = content, bib_map) do
-    PageContent.map_reduce(content, {:ok, []}, fn i, {status, bibrefs}, _tr_context ->
+    PageContent.bibliography_rewire(content, {:ok, []}, fn i, {status, bibrefs}, _tr_context ->
       case i do
         %{"type" => "cite", "bibref" => bibref} = ref ->
           bib_id = Map.get(Map.get(bib_map, bibref, %{resource_id: bibref}), :resource_id)

--- a/lib/oli/resources/page_content.ex
+++ b/lib/oli/resources/page_content.ex
@@ -162,4 +162,8 @@ defmodule Oli.Resources.PageContent do
     )
     |> then(fn {_, result} -> result end)
   end
+
+  def bibliography_rewire(%{"children" => _children} = item, acc, map_fn) do
+    item_with_children(item, acc, map_fn, %TraversalContext{})
+  end
 end

--- a/test/oli/interop/digest/31.json
+++ b/test/oli/interop/digest/31.json
@@ -16,19 +16,6 @@
             "children": [
               {
                 "text": "This course will introduce the dishes and drink that are typical of the Spanish regions of Galicia and Asturias.  Since this course intends to serve as merely an introduction to this topic, links will be provided throughout to provide access to additional materials."
-              },
-              {
-                "type": "cite",
-                "children": [
-                  {
-                    "text": "[citation]"
-                  }
-                ],
-                "id": "Kluver_1939",
-                "bibref": "241064652"
-              },
-              {
-                "text": " example"
               }
             ],
             "id": "3219906296",

--- a/test/oli/interop/digest/43.json
+++ b/test/oli/interop/digest/43.json
@@ -7,6 +7,19 @@
             "children": [
               {
                 "text": "Here is an edit"
+              },
+              {
+                "type": "cite",
+                "children": [
+                  {
+                    "text": "[citation]"
+                  }
+                ],
+                "id": "Kluver_1939",
+                "bibref": "241064652"
+              },
+              {
+                "text": " example"
               }
             ],
             "id": "2483274500",

--- a/test/oli/interop/ingest_test.exs
+++ b/test/oli/interop/ingest_test.exs
@@ -114,6 +114,18 @@ defmodule Oli.Interop.IngestTest do
       # verify that every practice page has a content attribute with a model
       assert Enum.all?(practice_pages, fn p -> Map.has_key?(p.content, "model") end)
 
+      # verify that citations are rewired correctly
+      page_with_citation = Enum.filter(practice_pages, fn p -> p.title == "Feedback" end) |> hd
+      citation = Enum.at(page_with_citation.content["model"], 0)
+        |> Map.get("children")
+        |> Enum.at(0)
+        |> Map.get("children")
+        |> Enum.at(1)
+
+      bib_entries = Oli.Publishing.get_unpublished_revisions(project, [Map.get(citation, "bibref")])
+
+      assert length(bib_entries) == 1
+
       # verify that the page that had a link to another page had that link rewired correctly
       src = Enum.filter(practice_pages, fn p -> p.title == "Introduction" end) |> hd
 


### PR DESCRIPTION
This PR fixes a bibliography and citation rewiring bug whereby citation references in course page ingest are not being correctly rewired to point to bibliography entries ingested into the db.