### PR TITLE
[FEATURE] Add ability to browse all pages in a course project

### DIFF
--- a/lib/oli/resources/page_browse.ex
+++ b/lib/oli/resources/page_browse.ex
@@ -100,7 +100,7 @@ defmodule Oli.Resources.PageBrowse do
         total_count: fragment("count(*) OVER()"),
         page_type:
           fragment(
-            "case when ?->>'advancedDelivery' = 'true' then 'Advanced' else 'Regular' end",
+            "case when ?->>'advancedDelivery' = 'true' then 'Adaptive' else 'Regular' end",
             rev.content
           )
       })
@@ -114,7 +114,7 @@ defmodule Oli.Resources.PageBrowse do
             [rev, _, _, _],
             {^direction,
              fragment(
-               "case when ?->>'advancedDelivery' = 'true' then 'Advanced' else 'Regular' end",
+               "case when ?->>'advancedDelivery' = 'true' then 'Adaptive' else 'Regular' end",
                rev.content
              )}
           )

--- a/lib/oli/resources/page_browse.ex
+++ b/lib/oli/resources/page_browse.ex
@@ -1,0 +1,150 @@
+defmodule Oli.Resources.PageBrowse do
+  import Ecto.Query, warn: false
+
+  alias Oli.Resources.PageBrowseOptions
+  alias Oli.Repo
+  alias Oli.Authoring.Course.Project
+  alias Oli.Resources.Revision
+  alias Oli.Repo.{Paging, Sorting}
+
+  @chars_to_replace_on_search [" ", "&", ":", ";", "(", ")", "|", "!", "'", "<", ">"]
+
+  @doc """
+    Paged, sorted, filterable queries for course sections. Joins the institution,
+    the base product or project and counts the number of enrollments.
+  """
+  def browse_pages(
+        %Project{id: project_id},
+        %Paging{limit: limit, offset: offset},
+        %Sorting{direction: direction, field: field},
+        %PageBrowseOptions{} = options
+      ) do
+    # text search
+    filter_by_text =
+      if options.text_search == "" or is_nil(options.text_search) do
+        true
+      else
+        # allow to search by prefix
+        search_term =
+          options.text_search
+          |> String.split(@chars_to_replace_on_search, trim: true)
+          |> Enum.map(fn x -> x <> ":*" end)
+          |> Enum.join(" & ")
+
+        dynamic(
+          [rev, _, _, _],
+          fragment(
+            "to_tsvector('simple', ?) @@ to_tsquery('simple', ?)",
+            rev.title,
+            ^search_term
+          )
+        )
+      end
+
+    filter_by_graded =
+      if !is_nil(options.graded),
+        do: dynamic([rev, _, _, _], rev.graded == ^options.graded),
+        else: true
+
+    filter_by_deleted =
+      if !is_nil(options.deleted) do
+        dynamic([rev, _, _, _], rev.deleted == ^options.deleted)
+      else
+        true
+      end
+
+    filter_by_page_type =
+      if is_nil(options.basic) do
+        true
+      else
+        if options.basic do
+          dynamic(
+            [rev, _, _, _],
+            fragment(
+              "NOT (?->>'advancedDelivery' = true)",
+              rev.content
+            )
+          )
+        else
+          dynamic(
+            [rev, _, _, _],
+            fragment(
+              "?->>'advancedDelivery' = true",
+              rev.content
+            )
+          )
+        end
+      end
+
+    page_type_id = Oli.Resources.ResourceType.get_id_by_type("page")
+
+    query =
+      Revision
+      |> join(:left, [rev], pr in Oli.Publishing.PublishedResource, on: pr.revision_id == rev.id)
+      |> join(:left, [_, pr], pub in Oli.Publishing.Publication, on: pr.publication_id == pub.id)
+      |> join(:left, [_, _, pub], proj in Oli.Authoring.Course.Project,
+        on: pub.project_id == proj.id
+      )
+      |> where(
+        [rev, _, pub, proj],
+        proj.id == ^project_id and is_nil(pub.published) and rev.resource_type_id == ^page_type_id
+      )
+      |> where(^filter_by_text)
+      |> where(^filter_by_graded)
+      |> where(^filter_by_deleted)
+      |> where(^filter_by_page_type)
+      |> limit(^limit)
+      |> offset(^offset)
+      |> select_merge([rev, _, _, _], %{
+        total_count: fragment("count(*) OVER()"),
+        page_type:
+          fragment(
+            "case when ?->>'advancedDelivery' = 'true' then 'Advanced' else 'Regular' end",
+            rev.content
+          )
+      })
+
+    # sorting
+    query =
+      case field do
+        :page_type ->
+          order_by(
+            query,
+            [rev, _, _, _],
+            {^direction,
+             fragment(
+               "case when ?->>'advancedDelivery' = 'true' then 'Advanced' else 'Regular' end",
+               rev.content
+             )}
+          )
+
+        _ ->
+          order_by(query, [rev, _, _, _], {^direction, field(rev, ^field)})
+      end
+
+    Repo.all(query)
+  end
+
+  def find_parent_container(project, page_revision) do
+    container_type_id = Oli.Resources.ResourceType.get_id_by_type("container")
+
+    query =
+      Revision
+      |> join(:left, [rev], pr in Oli.Publishing.PublishedResource, on: pr.revision_id == rev.id)
+      |> join(:left, [_, pr], pub in Oli.Publishing.Publication, on: pr.publication_id == pub.id)
+      |> join(:left, [_, _, pub], proj in Oli.Authoring.Course.Project,
+        on: pub.project_id == proj.id
+      )
+      |> where(
+        [rev, _, pub, proj],
+        proj.id == ^project.id and is_nil(pub.published) and
+          rev.resource_type_id == ^container_type_id
+      )
+      |> where(
+        [rev, _, _, _],
+        fragment("? = ANY (?)", ^page_revision.resource_id, rev.children)
+      )
+
+    Repo.all(query)
+  end
+end

--- a/lib/oli/resources/page_browse.ex
+++ b/lib/oli/resources/page_browse.ex
@@ -61,7 +61,8 @@ defmodule Oli.Resources.PageBrowse do
           dynamic(
             [rev, _, _, _],
             fragment(
-              "NOT (?->>'advancedDelivery' = true)",
+              "?->>'advancedDelivery' = 'false' OR NOT (? \\? 'advancedDelivery')",
+              rev.content,
               rev.content
             )
           )
@@ -69,7 +70,7 @@ defmodule Oli.Resources.PageBrowse do
           dynamic(
             [rev, _, _, _],
             fragment(
-              "?->>'advancedDelivery' = true",
+              "?->>'advancedDelivery' = 'true'",
               rev.content
             )
           )

--- a/lib/oli/resources/page_browse_options.ex
+++ b/lib/oli/resources/page_browse_options.ex
@@ -1,0 +1,26 @@
+defmodule Oli.Resources.PageBrowseOptions do
+  @moduledoc """
+  Params for browse all pages queries.
+  """
+
+  @enforce_keys [
+    :text_search,
+    :graded,
+    :deleted,
+    :basic
+  ]
+
+  defstruct [
+    :text_search,
+    :graded,
+    :deleted,
+    :basic
+  ]
+
+  @type t() :: %__MODULE__{
+          text_search: String.t(),
+          graded: boolean(),
+          deleted: boolean(),
+          basic: boolean()
+        }
+end

--- a/lib/oli/resources/revision.ex
+++ b/lib/oli/resources/revision.ex
@@ -52,6 +52,9 @@ defmodule Oli.Resources.Revision do
 
     has_many :warnings, Oli.Qa.Warning
 
+    field(:total_count, :integer, virtual: true)
+    field(:page_type, :string, virtual: true)
+
     timestamps(type: :utc_datetime)
   end
 

--- a/lib/oli_web/live/curriculum/container/container_live.ex
+++ b/lib/oli_web/live/curriculum/container/container_live.ex
@@ -213,7 +213,7 @@ defmodule OliWeb.Curriculum.ContainerLive do
 
     assigns = %{
       id: "options_#{slug}",
-      container: container,
+      redirect_url: Routes.container_path(socket, :index, project.slug, container.slug),
       revision: Enum.find(socket.assigns.children, fn r -> r.slug == slug end),
       project: project
     }
@@ -267,14 +267,14 @@ defmodule OliWeb.Curriculum.ContainerLive do
 
         {:error, %Ecto.Changeset{} = _changeset} ->
           socket
-            |> put_flash(:error, "Could not duplicate page")
+          |> put_flash(:error, "Could not duplicate page")
       end
 
     {:noreply,
-      assign(socket,
-        numberings:
-          Numbering.number_full_tree(Oli.Publishing.AuthoringResolver, socket.assigns.project.slug)
-    )}
+     assign(socket,
+       numberings:
+         Numbering.number_full_tree(Oli.Publishing.AuthoringResolver, socket.assigns.project.slug)
+     )}
   end
 
   def handle_event("HierarchyPicker.update_active", %{"uuid" => uuid}, socket) do
@@ -517,6 +517,7 @@ defmodule OliWeb.Curriculum.ContainerLive do
   defp proceed_with_deletion_warning(socket, container, project, author, item) do
     assigns = %{
       id: "delete_#{item.slug}",
+      redirect_url: Routes.container_path(socket, :index, project.slug, container.slug),
       revision: item,
       container: container,
       project: project,

--- a/lib/oli_web/live/curriculum/entries/actions.ex
+++ b/lib/oli_web/live/curriculum/entries/actions.ex
@@ -14,7 +14,7 @@ defmodule OliWeb.Curriculum.Actions do
         <button class="btn dropdown-toggle" type="button" data-toggle="dropdown" data-target="dropdownMenu_<%= @child.slug %>" aria-haspopup="true" aria-expanded="false"></button>
         <div class="dropdown-menu dropdown-menu-right" id="dropdownMenu_<%= @child.slug %>" aria-labelledby="dropdownMenuButton_<%= @child.slug %>">
           <button type="button" class="dropdown-item" phx-click="show_options_modal" phx-value-slug="<%= @child.slug %>"><i class="las la-sliders-h mr-1"></i> Options</button>
-          <button type="button" class="dropdown-item" phx-click="show_move_modal" phx-value-slug="<%= @child.slug %>"><i class="las la-arrow-circle-right mr-1"></i> Move to...</button>
+          <button type="button" <%= if @disable_move do "disabled" end %> class="dropdown-item" phx-click="show_move_modal" phx-value-slug="<%= @child.slug %>"><i class="las la-arrow-circle-right mr-1"></i> Move to...</button>
           <%= if ResourceType.is_non_adaptive_page(@child) do %>
             <button type="button" class="dropdown-item" phx-click="duplicate_page" phx-value-id="<%= @child.id %>"><i class="las la-copy mr-1"></i> Duplicate</button>
           <% end %>

--- a/lib/oli_web/live/curriculum/entries/delete_modal.ex
+++ b/lib/oli_web/live/curriculum/entries/delete_modal.ex
@@ -40,22 +40,54 @@ defmodule OliWeb.Curriculum.DeleteModal do
   end
 
   def handle_event("delete", %{"slug" => slug}, socket) do
-    %{container: container, project: project, author: author, revision: revision} = socket.assigns
+    %{
+      container: container,
+      project: project,
+      author: author,
+      revision: revision,
+      redirect_url: redirect_url
+    } = socket.assigns
 
-    case ContainerEditor.remove_child(container, project, author, slug) do
-      {:ok, _} ->
-        {:noreply,
-         push_patch(socket,
-           to: Routes.container_path(socket, :index, project.slug, container.slug)
-         )}
+    case container do
+      nil ->
+        result =
+          Repo.transaction(fn ->
+            revision = AuthoringResolver.from_revision_slug(project.slug, revision.slug)
+            ChangeTracker.track_revision(project.slug, revision, %{deleted: true})
+          end)
 
-      {:error, _} ->
-        {:noreply,
-         put_flash(
-           socket,
-           :error,
-           "Could not delete #{resource_type_label(revision)} \"#{revision.title}\""
-         )}
+        case result do
+          {:ok, _} ->
+            {:noreply,
+             push_patch(socket,
+               to: redirect_url
+             )}
+
+          _ ->
+            {:noreply,
+             put_flash(
+               socket,
+               :error,
+               "Could not delete #{resource_type_label(revision)} \"#{revision.title}\""
+             )}
+        end
+
+      _ ->
+        case ContainerEditor.remove_child(container, project, author, slug) do
+          {:ok, _} ->
+            {:noreply,
+             push_patch(socket,
+               to: redirect_url
+             )}
+
+          {:error, _} ->
+            {:noreply,
+             put_flash(
+               socket,
+               :error,
+               "Could not delete #{resource_type_label(revision)} \"#{revision.title}\""
+             )}
+        end
     end
   end
 end

--- a/lib/oli_web/live/curriculum/entries/delete_modal.ex
+++ b/lib/oli_web/live/curriculum/entries/delete_modal.ex
@@ -4,7 +4,6 @@ defmodule OliWeb.Curriculum.DeleteModal do
 
   import OliWeb.Curriculum.Utils
 
-  alias OliWeb.Router.Helpers, as: Routes
   alias Oli.Authoring.Editing.ContainerEditor
 
   def render(%{revision: revision} = assigns) do
@@ -51,9 +50,11 @@ defmodule OliWeb.Curriculum.DeleteModal do
     case container do
       nil ->
         result =
-          Repo.transaction(fn ->
-            revision = AuthoringResolver.from_revision_slug(project.slug, revision.slug)
-            ChangeTracker.track_revision(project.slug, revision, %{deleted: true})
+          Oli.Repo.transaction(fn ->
+            revision =
+              Oli.Publishing.AuthoringResolver.from_revision_slug(project.slug, revision.slug)
+
+            Oli.Publishing.ChangeTracker.track_revision(project.slug, revision, %{deleted: true})
           end)
 
         case result do

--- a/lib/oli_web/live/curriculum/entries/entry.ex
+++ b/lib/oli_web/live/curriculum/entries/entry.ex
@@ -67,7 +67,7 @@ defmodule OliWeb.Curriculum.EntryLive do
 
       <%# prevent dragging of actions menu and modals using this draggable wrapper %>
       <div draggable="true" ondragstart="event.preventDefault(); event.stopPropagation();">
-        <%= live_component Actions, assigns %>
+        <%= live_component Actions, Map.merge(assigns, %{disable_move: false}) %>
       </div>
     </div>
     """

--- a/lib/oli_web/live/curriculum/entries/options_modal.ex
+++ b/lib/oli_web/live/curriculum/entries/options_modal.ex
@@ -4,7 +4,6 @@ defmodule OliWeb.Curriculum.OptionsModal do
 
   import OliWeb.Curriculum.Utils
 
-  alias OliWeb.Router.Helpers, as: Routes
   alias Oli.Authoring.Editing.ContainerEditor
   alias Oli.Resources.ScoringStrategy
   alias Oli.Resources
@@ -123,7 +122,7 @@ defmodule OliWeb.Curriculum.OptionsModal do
   end
 
   defp save_revision(socket, revision_params) do
-    %{container: container, project: project, revision: revision} = socket.assigns
+    %{redirect_url: redirect_url, project: project, revision: revision} = socket.assigns
 
     case ContainerEditor.edit_page(project, revision.slug, revision_params) do
       {:ok, _} ->
@@ -133,7 +132,7 @@ defmodule OliWeb.Curriculum.OptionsModal do
            :info,
            "#{resource_type_label(revision) |> String.capitalize()} options saved"
          )
-         |> push_redirect(to: Routes.container_path(socket, :index, project.slug, container.slug))}
+         |> push_redirect(to: redirect_url)}
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply, assign(socket, :changeset, changeset)}

--- a/lib/oli_web/live/resources/pages_table_model.ex
+++ b/lib/oli_web/live/resources/pages_table_model.ex
@@ -1,0 +1,71 @@
+defmodule OliWeb.Resources.PagesTableModel do
+  alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
+  alias OliWeb.Router.Helpers, as: Routes
+  alias Oli.Resources.Revision
+  alias OliWeb.Curriculum.Actions
+  use Surface.LiveComponent
+
+  def render(assigns) do
+    ~F"""
+    <div>nothing</div>
+    """
+  end
+
+  def new(pages, project, context) do
+    column_specs = [
+      %ColumnSpec{name: :title, label: "Title", render_fn: &__MODULE__.render_title_column/3},
+      %ColumnSpec{
+        name: :page_type,
+        label: "Type"
+      },
+      %ColumnSpec{
+        name: :graded,
+        label: "Graded",
+        render_fn: &__MODULE__.render_graded_column/3
+      },
+      %ColumnSpec{
+        name: :updated_at,
+        label: "Last Updated",
+        render_fn: &OliWeb.Common.Table.Common.render_date/3
+      },
+      %ColumnSpec{
+        name: :actions,
+        label: "",
+        render_fn: &__MODULE__.render_actions_column/3
+      }
+    ]
+
+    SortableTableModel.new(
+      rows: pages,
+      column_specs: column_specs,
+      event_suffix: "",
+      id_field: [:id],
+      data: %{
+        context: context,
+        project_slug: project.slug
+      }
+    )
+  end
+
+  def render_title_column(
+        assigns,
+        %Revision{
+          slug: slug,
+          title: title
+        },
+        _
+      ) do
+    ~F"""
+    <a href={Routes.resource_path(OliWeb.Endpoint, :edit, assigns.project_slug, slug)}>
+      {title}
+    </a>
+    """
+  end
+
+  def render_graded_column(_, %Revision{graded: true}, _), do: "Graded"
+  def render_graded_column(_, %Revision{graded: false}, _), do: "Practice"
+
+  def render_actions_column(_, %Revision{} = revision, _) do
+    live_component(Actions, child: revision, disable_move: true)
+  end
+end

--- a/lib/oli_web/live/resources/pages_view.ex
+++ b/lib/oli_web/live/resources/pages_view.ex
@@ -1,0 +1,283 @@
+defmodule OliWeb.Resources.PagesView do
+  use Surface.LiveView, layout: {OliWeb.LayoutView, "live.html"}
+  use OliWeb.Common.Modal
+
+  import OliWeb.DelegatedEvents
+  import OliWeb.Common.Params
+  import Oli.Authoring.Editing.Utils
+  alias Oli.Accounts
+  alias OliWeb.Router.Helpers, as: Routes
+  alias OliWeb.Common.{TextSearch, PagedTable, Breadcrumb}
+  alias Oli.Resources.PageBrowse
+  alias OliWeb.Common.Table.SortableTableModel
+  alias Oli.Resources.PageBrowseOptions
+  alias OliWeb.Common.SessionContext
+  alias OliWeb.Resources.PagesTableModel
+  alias Oli.Repo.{Paging, Sorting}
+
+  data title, :string, default: "All Pages"
+  data project, :any
+  data breadcrumbs, :list
+  data author, :any
+  data pages, :list
+
+  @limit 25
+
+  defp limit, do: @limit
+
+  @default_options %PageBrowseOptions{
+    basic: nil,
+    graded: nil,
+    deleted: false,
+    text_search: nil
+  }
+
+  def breadcrumb(project) do
+    [
+      Breadcrumb.new(%{
+        full_title: "Project Overview",
+        link: Routes.project_path(OliWeb.Endpoint, :overview, project.slug)
+      }),
+      Breadcrumb.new(%{full_title: "All Pages"})
+    ]
+  end
+
+  def mount(
+        %{"project_id" => project_slug},
+        %{"current_author_id" => author_id} = session,
+        socket
+      ) do
+    socket =
+      with {:ok, author} <- Accounts.get_author(author_id) |> trap_nil(),
+           {:ok, project} <- Oli.Authoring.Course.get_project_by_slug(project_slug) |> trap_nil(),
+           {:ok} <- authorize_user(author, project) do
+        context = SessionContext.init(session)
+
+        pages =
+          PageBrowse.browse_pages(
+            project,
+            %Paging{offset: 0, limit: @limit},
+            %Sorting{direction: :asc, field: :title},
+            @default_options
+          )
+
+        total_count = determine_total(pages)
+        {:ok, table_model} = PagesTableModel.new(pages, project, context)
+
+        assign(socket,
+          modal: nil,
+          context: context,
+          breadcrumbs: breadcrumb(project),
+          project: project,
+          author: author,
+          total_count: total_count,
+          table_model: table_model,
+          options: @default_options
+        )
+      else
+        _ ->
+          socket
+          |> put_flash(:info, "You do not have permission to access this course project")
+          |> push_redirect(to: Routes.live_path(OliWeb.Endpoint, IndexView))
+      end
+
+    {:ok, socket}
+  end
+
+  defp determine_total(projects) do
+    case(projects) do
+      [] -> 0
+      [hd | _] -> hd.total_count
+    end
+  end
+
+  def handle_params(params, _, socket) do
+    table_model =
+      SortableTableModel.update_from_params(
+        socket.assigns.table_model,
+        params
+      )
+
+    offset = get_int_param(params, "offset", 0)
+
+    options = %PageBrowseOptions{
+      text_search: get_param(params, "text_search", ""),
+      deleted: false,
+      graded: get_boolean_param(params, "graded", nil),
+      basic: get_boolean_param(params, "basic", nil)
+    }
+
+    pages =
+      PageBrowse.browse_pages(
+        socket.assigns.project,
+        %Paging{offset: offset, limit: @limit},
+        %Sorting{direction: table_model.sort_order, field: table_model.sort_by_spec.name},
+        options
+      )
+
+    table_model = Map.put(table_model, :rows, pages)
+    total_count = determine_total(pages)
+
+    {:noreply,
+     assign(socket,
+       offset: offset,
+       table_model: table_model,
+       total_count: total_count,
+       options: options
+     )}
+  end
+
+  def render(assigns) do
+    ~F"""
+    {render_modal(assigns)}
+    <div>
+
+      <div class="d-flex justify-content-between">
+        <TextSearch id="text-search"/>
+      </div>
+
+      <div class="mb-3"/>
+
+      <PagedTable
+        filter={@options.text_search}
+        table_model={@table_model}
+        total_count={@total_count}
+        offset={@offset}
+        limit={limit()}/>
+    </div>
+    """
+  end
+
+  def patch_with(socket, changes) do
+    {:noreply,
+     push_patch(socket,
+       to:
+         Routes.live_path(
+           socket,
+           __MODULE__,
+           socket.assigns.project.slug,
+           Map.merge(
+             %{
+               sort_by: socket.assigns.table_model.sort_by_spec.name,
+               sort_order: socket.assigns.table_model.sort_order,
+               offset: socket.assigns.offset,
+               text_search: socket.assigns.options.text_search
+             },
+             changes
+           )
+         ),
+       replace: true
+     )}
+  end
+
+  def handle_event("show_delete_modal", %{"slug" => slug}, socket) do
+    %{project: project, author: author} = socket.assigns
+
+    revision = Enum.find(socket.assigns.table_model.rows, fn r -> r.slug == slug end)
+
+    container =
+      case PageBrowse.find_parent_container(project, revision) do
+        [] -> nil
+        [container] -> container
+      end
+
+    assigns = %{
+      id: "delete_#{revision.slug}",
+      redirect_url:
+        Routes.live_path(
+          socket,
+          __MODULE__,
+          socket.assigns.project.slug,
+          %{
+            sort_by: socket.assigns.table_model.sort_by_spec.name,
+            sort_order: socket.assigns.table_model.sort_order,
+            offset: socket.assigns.offset,
+            text_search: socket.assigns.options.text_search
+          }
+        ),
+      revision: revision,
+      container: container,
+      project: project,
+      author: author
+    }
+
+    {:noreply,
+     assign(socket,
+       modal: %{component: OliWeb.Curriculum.DeleteModal, assigns: assigns}
+     )}
+  end
+
+  def handle_event("show_options_modal", %{"slug" => slug}, socket) do
+    %{project: project} = socket.assigns
+
+    assigns = %{
+      id: "options_#{slug}",
+      redirect_url:
+        Routes.live_path(
+          socket,
+          __MODULE__,
+          socket.assigns.project.slug,
+          %{
+            sort_by: socket.assigns.table_model.sort_by_spec.name,
+            sort_order: socket.assigns.table_model.sort_order,
+            offset: socket.assigns.offset,
+            text_search: socket.assigns.options.text_search
+          }
+        ),
+      revision: Enum.find(socket.assigns.table_model.rows, fn r -> r.slug == slug end),
+      project: project
+    }
+
+    {:noreply,
+     assign(socket,
+       modal: %{component: OliWeb.Curriculum.OptionsModal, assigns: assigns}
+     )}
+  end
+
+  def handle_event("duplicate_page", %{"id" => page_id}, socket) do
+    %{project: project, author: author} = socket.assigns
+    page_id = String.to_integer(page_id)
+    revision = Enum.find(socket.assigns.table_model.rows, fn r -> r.id == page_id end)
+
+    original_page = Map.from_struct(revision)
+
+    new_page_attrs =
+      original_page
+      |> Map.drop([:slug, :inserted_at, :updated_at, :resource_id, :resource])
+      |> Map.put(:title, "Copy of #{original_page.title}")
+      |> Map.put(:content, nil)
+      |> Map.put(:author_id, author.id)
+
+    Oli.Repo.transaction(fn ->
+      with {:ok, %{revision: revision}} <-
+             Oli.Authoring.Course.create_and_attach_resource(project, new_page_attrs),
+           {:ok, _} <- Oli.Publishing.ChangeTracker.track_revision(project.slug, revision),
+           {:ok, model_duplicated_activities} <-
+             Oli.Authoring.Editing.ContainerEditor.deep_copy_activities(
+               original_page.content["model"],
+               project.slug,
+               author
+             ),
+           new_content <- %{
+             original_page.content
+             | "model" => Enum.reverse(model_duplicated_activities)
+           },
+           {:ok, updated_revision} <-
+             Oli.Resources.update_revision(revision, %{content: new_content}) do
+        updated_revision
+      else
+        {:error, e} -> Oli.Repo.rollback(e)
+      end
+    end)
+
+    patch_with(socket, %{})
+  end
+
+  def handle_event(event, params, socket) do
+    {event, params, socket, &__MODULE__.patch_with/2}
+    |> delegate_to([
+      &TextSearch.handle_delegated/4,
+      &PagedTable.handle_delegated/4
+    ])
+  end
+end

--- a/lib/oli_web/live/resources/pages_view.ex
+++ b/lib/oli_web/live/resources/pages_view.ex
@@ -7,7 +7,7 @@ defmodule OliWeb.Resources.PagesView do
   import Oli.Authoring.Editing.Utils
   alias Oli.Accounts
   alias OliWeb.Router.Helpers, as: Routes
-  alias OliWeb.Common.{TextSearch, PagedTable, Breadcrumb}
+  alias OliWeb.Common.{TextSearch, PagedTable, Breadcrumb, FilterBox}
   alias Oli.Resources.PageBrowse
   alias OliWeb.Common.Table.SortableTableModel
   alias Oli.Resources.PageBrowseOptions
@@ -24,6 +24,8 @@ defmodule OliWeb.Resources.PagesView do
   @limit 25
 
   defp limit, do: @limit
+  defp graded_opts, do: [{true, "Graded"}, {false, "Practice"}]
+  defp type_opts, do: [{true, "Regular"}, {false, "Adaptive"}]
 
   @default_options %PageBrowseOptions{
     basic: nil,
@@ -132,9 +134,35 @@ defmodule OliWeb.Resources.PagesView do
     {render_modal(assigns)}
     <div>
 
-      <div class="d-flex justify-content-between">
-        <TextSearch id="text-search"/>
-      </div>
+      <FilterBox
+        card_header_text="Browse All Pages"
+        card_body_text=""
+        table_model={@table_model}
+        show_sort={false}
+        show_more_opts={true}>
+        <TextSearch id="text-search" text={@options.text_search}/>
+
+        <:extra_opts>
+
+          <form :on-change="change_graded" class="d-flex">
+            <select name="graded" id="select_graded" class="custom-select custom-select mr-2">
+              <option value="" selected>Grading Type</option>
+              {#for {value, str} <- graded_opts()}
+                <option value={Kernel.to_string(value)} selected={@options.graded == value}>{str}</option>
+              {/for}
+            </select>
+          </form>
+
+          <form :on-change="change_type" class="d-flex">
+            <select name="type" id="select_type" class="custom-select custom-select mr-2">
+              <option value="" selected>Page Type</option>
+              {#for {value, str} <- type_opts()}
+                <option value={Kernel.to_string(value)} selected={@options.basic == value}>{str}</option>
+              {/for}
+            </select>
+          </form>
+        </:extra_opts>
+      </FilterBox>
 
       <div class="mb-3"/>
 
@@ -161,13 +189,23 @@ defmodule OliWeb.Resources.PagesView do
                sort_by: socket.assigns.table_model.sort_by_spec.name,
                sort_order: socket.assigns.table_model.sort_order,
                offset: socket.assigns.offset,
-               text_search: socket.assigns.options.text_search
+               text_search: socket.assigns.options.text_search,
+               basic: socket.assigns.options.basic,
+               graded: socket.assigns.options.graded
              },
              changes
            )
          ),
        replace: true
      )}
+  end
+
+  def handle_event("change_graded", %{"graded" => graded}, socket) do
+    patch_with(socket, %{graded: graded})
+  end
+
+  def handle_event("change_type", %{"type" => basic}, socket) do
+    patch_with(socket, %{basic: basic})
   end
 
   def handle_event("show_delete_modal", %{"slug" => slug}, socket) do

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -380,6 +380,8 @@ defmodule OliWeb.Router do
 
     live("/:project_id/curriculum/", Curriculum.ContainerLive, :index)
 
+    live("/:project_id/pages/", Resources.PagesView)
+
     # Review/QA
     live("/:project_id/review", Qa.QaLive)
 

--- a/lib/oli_web/templates/layout/_project_sidebar.html.eex
+++ b/lib/oli_web/templates/layout/_project_sidebar.html.eex
@@ -15,6 +15,9 @@
       <a class="dropdown-item" href="<%= Routes.activity_bank_path(@conn, :index, @project.slug) %>">Activity Bank</a>
       <a class="dropdown-item" href="<%= Routes.bibliography_path(@conn, :index, @project.slug) %>">Bibliography</a>
       <a class="dropdown-item" href="<%= Routes.container_path(@conn, :index, @project.slug, root_container_slug(@project.slug)) %>">Curriculum</a>
+      <div class="dropdown-divider"></div>
+      <a class="dropdown-item" href="<%= Routes.live_path(OliWeb.Endpoint, OliWeb.Resources.PagesView, @project.slug) %>">All Pages</a>
+
      </div>
   </div>
 

--- a/test/oli/resources/page_browse_test.exs
+++ b/test/oli/resources/page_browse_test.exs
@@ -96,7 +96,7 @@ defmodule Oli.Resources.PageBrowseTest do
 
       # Verify sorting by the virtual page_type attr works
       pages = browse(project, offset: 0, limit: 5, direction: :asc, field: :page_type)
-      assert hd(pages).page_type == "Advanced"
+      assert hd(pages).page_type == "Adaptive"
       pages = browse(project, offset: 0, limit: 5, direction: :desc, field: :page_type)
       assert hd(pages).page_type == "Regular"
 

--- a/test/oli/resources/page_browse_test.exs
+++ b/test/oli/resources/page_browse_test.exs
@@ -1,0 +1,175 @@
+defmodule Oli.Resources.PageBrowseTest do
+  use Oli.DataCase
+
+  alias Oli.Course
+  alias Oli.Accounts.Author
+  alias Oli.Accounts.SystemRole
+  alias Oli.Authoring.Course
+  alias Oli.Resources.{PageBrowse, PageBrowseOptions}
+  alias Oli.Repo
+  alias Oli.Repo.{Paging, Sorting}
+
+  def make_pages(project, publication, author, n) do
+    65..(65 + (n - 1))
+    |> Enum.map(fn value ->
+      Course.create_and_attach_resource(project, %{
+        resource_type_id: Oli.Resources.ResourceType.get_id_by_type("page"),
+        title: List.to_string([value]),
+        author_id: author.id,
+        content:
+          if rem(value, 4) == 0 do
+            %{"advancedDelivery" => "true"}
+          else
+            %{}
+          end,
+        graded:
+          if rem(value, 3) == 0 do
+            true
+          else
+            false
+          end
+      })
+    end)
+    |> Enum.map(fn {:ok, %{revision: revision}} ->
+      Oli.Publishing.create_published_resource(%{
+        publication_id: publication.id,
+        resource_id: revision.resource_id,
+        revision_id: revision.id
+      })
+
+      revision
+    end)
+  end
+
+  def browse(project, options \\ []) do
+    PageBrowse.browse_pages(
+      project,
+      struct(Paging, options),
+      struct(Sorting, options),
+      struct(PageBrowseOptions, options)
+    )
+  end
+
+  describe "page browse functionality" do
+    setup do
+      {:ok, author} =
+        Author.noauth_changeset(%Author{}, %{
+          email: "example@test.com",
+          name: "Full name",
+          given_name: "First",
+          family_name: "Last",
+          provider: "foo",
+          system_role_id: SystemRole.role_id().admin
+        })
+        |> Repo.insert()
+
+      {:ok, %{project: project, publication: publication}} = Course.create_project("test", author)
+      pages = make_pages(project, publication, author, 20)
+
+      %{project: project, pages: pages, author: author, publication: publication}
+    end
+
+    test "browse", %{
+      project: project
+    } do
+      pages = browse(project, offset: 0, limit: 10, direction: :asc, field: :title)
+      assert length(pages) == 10
+      assert hd(pages).total_count == 20
+
+      # Verify limit and offset
+      pages = browse(project, offset: 0, limit: 5, direction: :asc, field: :title)
+      assert length(pages) == 5
+      assert hd(pages).total_count == 20
+      pages = browse(project, offset: 19, limit: 5, direction: :asc, field: :title)
+      assert length(pages) == 1
+      assert hd(pages).total_count == 20
+
+      # Verify sort by title
+      pages = browse(project, offset: 0, limit: 5, direction: :desc, field: :title)
+      assert hd(pages).title == "T"
+
+      # Verify sorting by graded words
+      pages = browse(project, offset: 0, limit: 5, direction: :asc, field: :graded)
+      assert hd(pages).graded == false
+      pages = browse(project, offset: 0, limit: 5, direction: :desc, field: :graded)
+      assert hd(pages).graded == true
+
+      # Verify sorting by the virtual page_type attr works
+      pages = browse(project, offset: 0, limit: 5, direction: :asc, field: :page_type)
+      assert hd(pages).page_type == "Advanced"
+      pages = browse(project, offset: 0, limit: 5, direction: :desc, field: :page_type)
+      assert hd(pages).page_type == "Regular"
+
+      # Verify filter by deleted
+      pages = browse(project, offset: 0, limit: 5, direction: :asc, field: :title, deleted: true)
+      assert pages == []
+      pages = browse(project, offset: 0, limit: 5, direction: :asc, field: :title, deleted: false)
+      assert length(pages) == 5
+      assert hd(pages).total_count == 20
+
+      # Verify filter by graded
+      pages = browse(project, offset: 0, limit: 5, direction: :asc, field: :title, graded: true)
+      assert length(pages) == 5
+      assert hd(pages).total_count == 7
+      pages = browse(project, offset: 0, limit: 5, direction: :asc, field: :title, graded: false)
+      assert length(pages) == 5
+      assert hd(pages).total_count == 13
+
+      # Verify filter by page_type
+      pages = browse(project, offset: 0, limit: 5, direction: :asc, field: :title, basic: true)
+      assert length(pages) == 5
+      assert hd(pages).total_count == 15
+      pages = browse(project, offset: 0, limit: 5, direction: :asc, field: :title, basic: false)
+      assert length(pages) == 5
+      assert hd(pages).total_count == 5
+
+      # Verify filter by text_search
+      pages =
+        browse(project, offset: 0, limit: 5, direction: :asc, field: :title, text_search: "A")
+
+      assert length(pages) == 1
+      assert hd(pages).total_count == 1
+
+      # Verify filter by page_type and by graded
+      pages =
+        browse(project,
+          offset: 0,
+          limit: 5,
+          direction: :asc,
+          field: :title,
+
+          # only the "value" of 72 and 84 both were advanced delivery
+          # and graded
+          basic: false,
+          graded: true
+        )
+
+      assert length(pages) == 2
+      assert hd(pages).total_count == 2
+    end
+
+    test "find parent container", %{
+      project: project,
+      publication: publication,
+      pages: [first | _rest]
+    } do
+      assert PageBrowse.find_parent_container(project, first) == []
+
+      container =
+        Oli.Publishing.AuthoringResolver.from_resource_id(
+          project.slug,
+          publication.root_resource_id
+        )
+
+      Oli.Publishing.ChangeTracker.track_revision(project.slug, container, %{
+        children: [first.resource_id]
+      })
+
+      [
+        %{resource_id: resource_id}
+      ] = PageBrowse.find_parent_container(project, first)
+
+      assert resource_id == container.resource_id
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a new view for authors which allows browsing, searching and filtering across all pages in a course, regardless of where (and if) they live inside of containers.  

This is really just an initial, base implementation.  I suspect we will want to do some/all of the following in future (small) PRs:

1. Add ability to create a new page from this view to allow authors to create pages outside of their curriculum.
2. Add ability to search "content" and not just titles of pages.
3. Add ability to filter by and see "deleted" pages, and undelete them.
4. Add ability to see which author made the most recent edit for all pages.
5. Show which objectives a page has attached to it.  
6. Indicate whether the page does not exist in the curriculum (aka "standalone pages")