### PR TITLE
[BUG FIX] Only finalize latest attempt for each activity

### DIFF
--- a/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
@@ -90,7 +90,10 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
 
     Enum.filter(part_attempts, fn pa -> pa.lifecycle_state == :active end)
     |> Enum.reduce_while({:ok, []}, fn pa, {:ok, updated} ->
-      case update_part_attempt(pa, %{lifecycle_state: :submitted, date_submitted: DateTime.utc_now()}) do
+      case update_part_attempt(pa, %{
+             lifecycle_state: :submitted,
+             date_submitted: DateTime.utc_now()
+           }) do
         {:ok, updated_part_attempt} -> {:cont, {:ok, [updated_part_attempt | updated]}}
         e -> {:halt, e}
       end

--- a/lib/oli/delivery/attempts/core.ex
+++ b/lib/oli/delivery/attempts/core.ex
@@ -573,6 +573,19 @@ defmodule Oli.Delivery.Attempts.Core do
     |> Repo.preload(revision: [:activity_type])
   end
 
+  def get_latest_activity_attempts(resource_attempt_id) do
+    Repo.all(
+      from(aa in ActivityAttempt,
+        left_join: aa2 in ActivityAttempt,
+        on:
+          aa.resource_attempt_id == aa2.resource_attempt_id and aa.resource_id == aa2.resource_id and
+            aa.id < aa2.id,
+        where: aa.resource_attempt_id == ^resource_attempt_id and is_nil(aa2),
+        select: aa
+      )
+    )
+  end
+
   @doc """
   Retrieves the latest resource attempt for a given resource id,
   context id and user id.  If no attempts exist, returns nil.

--- a/test/oli/delivery/attempts/page_lifecycle_test.exs
+++ b/test/oli/delivery/attempts/page_lifecycle_test.exs
@@ -90,7 +90,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycleTest do
         lifecycle_state: :active,
         part_id: "1"
       },
-      %Part{id: "1", responses: [], hints: [], grading_approach: :manual},
+      %Part{id: "1", responses: [], hints: [], grading_approach: :automatic},
       activity_attempt_tag
     )
   end


### PR DESCRIPTION
Closes #2933 

This changes graded page finalization logic to only finalize and only roll-up the *latest* attempt for each activity present.  

This was never an issue for basic pages, given that there is no way to ever create a second attempt for an activity within the same page attempt.  Adaptive pages can do this, however. 