### PR TITLE
[MER-1409] [GH#2929] Increase max upload size

### DIFF
--- a/assets/src/components/media/manager/MediaManager.tsx
+++ b/assets/src/components/media/manager/MediaManager.tsx
@@ -280,7 +280,13 @@ export class MediaManager extends React.PureComponent<MediaManagerProps, MediaMa
           })
           .then(() => this.setState({ error: Maybe.nothing<string>() }));
       })
-      .catch((e: Error) => this.setState({ error: Maybe.just(e.message) }))
+      .catch((e: Error | string) => {
+        if (typeof e === 'string') {
+          this.setState({ error: Maybe.just(e) });
+        } else {
+          this.setState({ error: Maybe.just(e.message) });
+        }
+      })
       .finally(() => this.setState({ uploading: false }));
   }
 
@@ -572,7 +578,9 @@ export class MediaManager extends React.PureComponent<MediaManagerProps, MediaMa
     return error.caseOf({
       just: (error) => (
         <div className="alert alert-danger fade show" role="alert">
-          {error}
+          Error: Could not upload file.
+          <br />
+          <i>{error}</i>
         </div>
       ),
       nothing: () => null,

--- a/assets/src/components/media/manager/VideoUploadWarning.tsx
+++ b/assets/src/components/media/manager/VideoUploadWarning.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import { MaxFileUploadSizeMB } from './upload';
 
 export const VideoUploadWarning = () => (
   <div className="alert alert-info show" role="alert">
-    File uploads have a 20mb limit. We recommend uploading your video to YouTube and then embedding
-    that within your lesson for most uses.
+    File uploads have a {MaxFileUploadSizeMB}mb limit. We recommend uploading your video to YouTube
+    and then embedding that within your lesson for most uses.
   </div>
 );

--- a/assets/src/components/media/manager/upload.ts
+++ b/assets/src/components/media/manager/upload.ts
@@ -1,13 +1,20 @@
 import * as persistence from 'data/persistence/media';
 
+export const MaxFileUploadSizeMB = 350; // User-friendly number
+export const MaxFileUploadSizeBytes = MaxFileUploadSizeMB * 1048576;
+
 // the server creates a lock on upload, so we must upload files one at a
 // time. This factory function returns a new promise to upload a file
 // recursively until files is empty
 export const uploadFiles = async (projectSlug: string, files: File[]) => {
   const results: any[] = [];
 
-  const uploadFile = async (file: File): Promise<any> =>
-    persistence.createMedia(projectSlug, file).then((result) => {
+  const uploadFile = async (file: File): Promise<any> => {
+    if (file.size >= MaxFileUploadSizeBytes) {
+      throw new Error('File is too large');
+    }
+
+    return persistence.createMedia(projectSlug, file).then((result) => {
       results.push(result);
 
       if (files.length > 0) {
@@ -16,6 +23,7 @@ export const uploadFiles = async (projectSlug: string, files: File[]) => {
 
       return results;
     });
+  };
 
   return uploadFile(files.pop() as File);
 };

--- a/assets/src/data/persistence/media.ts
+++ b/assets/src/data/persistence/media.ts
@@ -26,7 +26,11 @@ export function encodeFile(file: File): Promise<string> {
       reader.addEventListener(
         'load',
         () => {
-          if (reader.result !== null) {
+          if (reader.result === '') {
+            // Max string-size in V8 is 512mb, if your base64 string is bigger than that,
+            // file-reader will return an empty string here
+            reject('failed to encode');
+          } else if (reader.result !== null) {
             resolve((reader.result as string).substr((reader.result as string).indexOf(',') + 1));
           } else {
             reject('failed to encode');

--- a/lib/oli_web/endpoint.ex
+++ b/lib/oli_web/endpoint.ex
@@ -49,7 +49,8 @@ defmodule OliWeb.Endpoint do
   plug(Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json],
     pass: ["*/*"],
-    length: 20_000_000,
+    # 512mb is the max body size our file-upload client code can generate.
+    length: 512_000_000,
     json_decoder: Phoenix.json_library(),
     body_reader: {OliWeb.CacheBodyReader, :read_body, []}
   )


### PR DESCRIPTION
This increases our max file upload size from 20mb to 350mb, which is the maximum size we can currently do in chrome with our current architecture. Going beyond this would require us to upload the file in multiple parts to get around a string size-limitation in V8.

Mostly Fixes #2929 