### PR TITLE
add explanation field to part

### DIFF
--- a/assets/src/components/activities/types.ts
+++ b/assets/src/components/activities/types.ts
@@ -497,6 +497,7 @@ export interface SubmissionAction extends IsAction {
 export interface Part extends Identifiable {
   responses: Response[];
   hints: Hint[];
+  explanation?: Feedback;
   scoringStrategy: ScoringStrategy;
   gradingApproach?: GradingApproach;
   outOf?: null | number;


### PR DESCRIPTION
Adds optional field to part to hold the "explanation", the answer-revealing final feedback that will serve the function of multiple feedback in legacy OLI.