### PR TITLE
[FEATURE] Pagination policies, automation of page display

### DIFF
--- a/assets/src/apps/delivery/components/ActivityRenderer.tsx
+++ b/assets/src/apps/delivery/components/ActivityRenderer.tsx
@@ -115,6 +115,7 @@ const ActivityRenderer: React.FC<ActivityRendererProps> = ({
     parts: [],
     hasMoreAttempts: true,
     hasMoreHints: true,
+    groupId: null,
   };
 
   const partState: PartState = {

--- a/assets/src/apps/delivery/layouts/deck/EverApps.ts
+++ b/assets/src/apps/delivery/layouts/deck/EverApps.ts
@@ -2,6 +2,7 @@ import { clone } from 'utils/common';
 import { ActivityState } from 'components/activities/types';
 
 export const everAppActivityState: ActivityState = {
+  groupId: null,
   attemptGuid: 'preview_2946819616',
   attemptNumber: 1,
   dateEvaluated: null,

--- a/assets/src/apps/delivery/store/features/groups/actions/deck.ts
+++ b/assets/src/apps/delivery/store/features/groups/actions/deck.ts
@@ -518,6 +518,7 @@ export const loadActivities = createAsyncThunk(
         parts: partAttempts,
         hasMoreAttempts: result.hasMoreAttempts || true,
         hasMoreHints: result.hasMoreHints || true,
+        groupId: null,
       };
       return { model: activityModel, state: attemptState };
     });

--- a/assets/src/components/activities/AuthoringElementProvider.tsx
+++ b/assets/src/components/activities/AuthoringElementProvider.tsx
@@ -8,6 +8,7 @@ import { AuthoringElementProps } from './AuthoringElement';
 export interface AuthoringElementState<T> {
   projectSlug: string;
   editMode: boolean;
+  authoringContext: any;
   onRequestMedia: (request: MediaItemRequest) => Promise<string | boolean>;
   dispatch: (action: (model: T, post: PostUndoable) => any) => T;
   model: T;
@@ -27,6 +28,7 @@ export const AuthoringElementProvider: React.FC<AuthoringElementProps<ActivityMo
   editMode,
   children,
   model,
+  authoringContext,
   onPostUndoable,
   onRequestMedia,
   onEdit,
@@ -38,7 +40,7 @@ export const AuthoringElementProvider: React.FC<AuthoringElementProps<ActivityMo
   };
   return (
     <AuthoringElementContext.Provider
-      value={{ projectSlug, editMode, dispatch, model, onRequestMedia }}
+      value={{ projectSlug, editMode, dispatch, model, onRequestMedia, authoringContext }}
     >
       {children}
       <ModalDisplay />

--- a/assets/src/components/activities/DeliveryElement.ts
+++ b/assets/src/components/activities/DeliveryElement.ts
@@ -53,8 +53,8 @@ export interface ActivityContext {
   graded: boolean;
   sectionSlug: string;
   userId: number;
-  groupId: string;
-  surveyId: string;
+  groupId: string | null;
+  surveyId: string | null;
   bibParams: any;
   pageAttemptGuid: string;
 }

--- a/assets/src/components/activities/DeliveryElement.ts
+++ b/assets/src/components/activities/DeliveryElement.ts
@@ -1,4 +1,3 @@
-import { ActivityEditContext } from 'data/content/activity';
 import { EventEmitter } from 'events';
 import { valueOr } from 'utils/common';
 import {

--- a/assets/src/components/activities/DeliveryElementProvider.tsx
+++ b/assets/src/components/activities/DeliveryElementProvider.tsx
@@ -18,8 +18,8 @@ export function useDeliveryElementContext<T>() {
 }
 export const DeliveryElementProvider: React.FC<DeliveryElementProps<any>> = (props) => {
   const writerContext = defaultWriterContext({
-    sectionSlug: props.sectionSlug,
-    bibParams: props.bibParams,
+    sectionSlug: props.context.sectionSlug,
+    bibParams: props.context.bibParams,
   });
 
   return (

--- a/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyDelivery.tsx
+++ b/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyDelivery.tsx
@@ -38,12 +38,12 @@ export const CheckAllThatApplyComponent: React.FC = () => {
   } = useDeliveryElementContext<CATASchema>();
   const uiState = useSelector((state: ActivityDeliveryState) => state);
   const dispatch = useDispatch();
-  const { surveyId, sectionSlug } = context;
+  const { surveyId } = context;
   useEffect(() => {
     listenForParentSurveySubmit(surveyId, dispatch, onSubmitActivity);
     listenForParentSurveyReset(surveyId, dispatch, onResetActivity, { [DEFAULT_PART_ID]: [] });
 
-    dispatch(initializeState(activityState, initialPartInputs(activityState), model, sectionSlug));
+    dispatch(initializeState(activityState, initialPartInputs(activityState), model, context));
   }, []);
 
   // First render initializes state

--- a/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyDelivery.tsx
+++ b/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyDelivery.tsx
@@ -30,7 +30,7 @@ import { DEFAULT_PART_ID } from 'components/activities/common/utils';
 export const CheckAllThatApplyComponent: React.FC = () => {
   const {
     state: activityState,
-    surveyId,
+    context,
     onSubmitActivity,
     onResetActivity,
     onSaveActivity,
@@ -38,12 +38,12 @@ export const CheckAllThatApplyComponent: React.FC = () => {
   } = useDeliveryElementContext<CATASchema>();
   const uiState = useSelector((state: ActivityDeliveryState) => state);
   const dispatch = useDispatch();
-
+  const { surveyId, sectionSlug } = context;
   useEffect(() => {
     listenForParentSurveySubmit(surveyId, dispatch, onSubmitActivity);
     listenForParentSurveyReset(surveyId, dispatch, onResetActivity, { [DEFAULT_PART_ID]: [] });
 
-    dispatch(initializeState(activityState, initialPartInputs(activityState), model));
+    dispatch(initializeState(activityState, initialPartInputs(activityState), model, sectionSlug));
   }, []);
 
   // First render initializes state

--- a/assets/src/components/activities/common/delivery/evaluation/EvaluationConnected.tsx
+++ b/assets/src/components/activities/common/delivery/evaluation/EvaluationConnected.tsx
@@ -6,13 +6,14 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 
 export const EvaluationConnected: React.FC = () => {
-  const { surveyId, writerContext } = useDeliveryElementContext();
+  const { context, writerContext } = useDeliveryElementContext();
+  const { surveyId } = context;
   const uiState = useSelector((state: ActivityDeliveryState) => state);
 
   return (
     <>
       <Evaluation
-        shouldShow={isEvaluated(uiState) && surveyId === undefined}
+        shouldShow={isEvaluated(uiState) && surveyId === null}
         attemptState={uiState.attemptState}
         context={writerContext}
       />

--- a/assets/src/components/activities/common/delivery/evaluation/Submission.tsx
+++ b/assets/src/components/activities/common/delivery/evaluation/Submission.tsx
@@ -3,13 +3,13 @@ import React from 'react';
 
 interface Props {
   attemptState: ActivityState;
-  surveyId: string | undefined;
+  surveyId: string | null;
 }
 export const Submission: React.FC<Props> = ({ attemptState, surveyId }) => {
   if (
     attemptState.dateEvaluated === null &&
     attemptState.dateSubmitted !== null &&
-    surveyId === undefined
+    surveyId === null
   ) {
     return <p>Your attempt has been submitted for instructor grading</p>;
   } else {

--- a/assets/src/components/activities/common/delivery/graded_points/GradedPointsConnected.tsx
+++ b/assets/src/components/activities/common/delivery/graded_points/GradedPointsConnected.tsx
@@ -8,11 +8,11 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 
 export const GradedPointsConnected: React.FC = () => {
-  const { graded, surveyId } = useDeliveryElementContext();
+  const { graded, surveyId } = useDeliveryElementContext().context;
   const uiState = useSelector((state: ActivityDeliveryState) => state);
   return (
     <GradedPoints
-      shouldShow={uiState.attemptState.score !== null && graded && surveyId === undefined}
+      shouldShow={uiState.attemptState.score !== null && graded && surveyId === null}
       icon={isCorrect(uiState.attemptState) ? <Checkmark /> : <Cross />}
       attemptState={uiState.attemptState}
     />

--- a/assets/src/components/activities/common/delivery/reset_button/ResetButtonConnected.tsx
+++ b/assets/src/components/activities/common/delivery/reset_button/ResetButtonConnected.tsx
@@ -13,9 +13,7 @@ export const ResetButtonConnected: React.FC<Props> = ({ onReset }) => {
 
   return (
     <ResetButton
-      shouldShow={
-        (isEvaluated(uiState) || isSubmitted(uiState)) && !graded && surveyId === undefined
-      }
+      shouldShow={(isEvaluated(uiState) || isSubmitted(uiState)) && !graded && surveyId === null}
       disabled={!uiState.attemptState.hasMoreAttempts}
       action={onReset}
     />

--- a/assets/src/components/activities/common/delivery/reset_button/ResetButtonConnected.tsx
+++ b/assets/src/components/activities/common/delivery/reset_button/ResetButtonConnected.tsx
@@ -8,7 +8,7 @@ interface Props {
   onReset: () => void;
 }
 export const ResetButtonConnected: React.FC<Props> = ({ onReset }) => {
-  const { graded, surveyId } = useDeliveryElementContext();
+  const { graded, surveyId } = useDeliveryElementContext().context;
   const uiState = useSelector((state: ActivityDeliveryState) => state);
 
   return (

--- a/assets/src/components/activities/common/delivery/submit_button/SubmitButtonConnected.tsx
+++ b/assets/src/components/activities/common/delivery/submit_button/SubmitButtonConnected.tsx
@@ -13,12 +13,13 @@ interface Props {
   disabled?: boolean;
 }
 export const SubmitButtonConnected: React.FC<Props> = ({ disabled }) => {
-  const { graded, surveyId, onSubmitActivity } = useDeliveryElementContext();
+  const { context, onSubmitActivity } = useDeliveryElementContext();
+  const { graded, surveyId } = context;
   const uiState = useSelector((state: ActivityDeliveryState) => state);
   const dispatch = useDispatch();
   return (
     <SubmitButton
-      shouldShow={!isSubmitted(uiState) && !graded && surveyId === undefined}
+      shouldShow={!isSubmitted(uiState) && !graded && surveyId === null}
       disabled={
         disabled === undefined
           ? Object.values(uiState.partState)

--- a/assets/src/components/activities/common/hints/delivery/HintsDeliveryConnected.tsx
+++ b/assets/src/components/activities/common/hints/delivery/HintsDeliveryConnected.tsx
@@ -15,7 +15,8 @@ interface Props {
   shouldShow?: boolean;
 }
 export const HintsDeliveryConnected: React.FC<Props> = (props) => {
-  const { graded, surveyId, writerContext, onRequestHint } = useDeliveryElementContext<HasHints>();
+  const { context, writerContext, onRequestHint } = useDeliveryElementContext<HasHints>();
+  const { graded, surveyId } = context;
   const uiState = useSelector((state: ActivityDeliveryState) => state);
   const dispatch = useDispatch();
 
@@ -26,7 +27,7 @@ export const HintsDeliveryConnected: React.FC<Props> = (props) => {
         !isEvaluated(uiState) &&
         !isSubmitted(uiState) &&
         !graded &&
-        surveyId === undefined
+        surveyId === null
       }
       onClick={() => dispatch(requestHint(props.partId, onRequestHint))}
       hints={uiState.partState[props.partId]?.hintsShown || []}

--- a/assets/src/components/activities/common/responses/FeedbackCard.tsx
+++ b/assets/src/components/activities/common/responses/FeedbackCard.tsx
@@ -10,7 +10,8 @@ export const FeedbackCard: React.FC<{
   title: React.ReactNode;
   update: (id: ID, content: Descendant[]) => void;
   placeholder?: string;
-}> = ({ title, feedback, update, placeholder }) => {
+  children: any;
+}> = ({ title, feedback, update, placeholder, children }) => {
   return (
     <Card.Card>
       <Card.Title>{title}</Card.Title>
@@ -20,6 +21,7 @@ export const FeedbackCard: React.FC<{
           value={feedback.content}
           onEdit={(content) => update(feedback.id, content)}
         />
+        {children}
       </Card.Content>
     </Card.Card>
   );

--- a/assets/src/components/activities/common/responses/ResponseCard.tsx
+++ b/assets/src/components/activities/common/responses/ResponseCard.tsx
@@ -23,12 +23,12 @@ export const ResponseCard: React.FC<Props> = (props) => {
         </div>
       </Card.Title>
       <Card.Content>
-        {props.children}
         <RichTextEditorConnected
           placeholder="Explain why the student might have arrived at this answer"
           value={props.response.feedback.content}
           onEdit={(content) => props.updateFeedback(props.response.id, content)}
         />
+        {props.children}
       </Card.Content>
     </Card.Card>
   );

--- a/assets/src/components/activities/common/responses/ShowPage.tsx
+++ b/assets/src/components/activities/common/responses/ShowPage.tsx
@@ -8,27 +8,23 @@ export const ShowPage: React.FC<{
 }> = ({ index, onChange, editMode }) => {
   if (index === undefined) {
     return (
-      <div className="alert alert-info">
-        <div className="d-flex justify-content-between">
-          <div>Branch to another group of content after showing this feedback</div>
-          <button className="btn btn-sm btn-primary" onClick={() => onChange(0)}>
-            Enable branching
-          </button>
-        </div>
+      <div className="float-right">
+        <button className="btn btn-sm btn-link" onClick={(_e) => onChange(0)}>
+          Trigger pagination change <i className={`tiny-icon las la-code-branch`}></i>
+        </button>
       </div>
     );
   }
   return (
     <div className="alert alert-info">
       <div className="d-flex">
-        <div className="col-sm-4">Display group number:</div>
+        <div className="col-sm-5">Display pagination group number:</div>
         <div className="col-sm-2">
           <TextInput
             editMode={editMode}
             label=""
             value={(index as any) + 1 + ''}
-            type="numeric"
-            style={{ display: 'inline-block' }}
+            type="number"
             onEdit={(v) => {
               onChange(parseInt(v) - 1);
             }}
@@ -37,9 +33,9 @@ export const ShowPage: React.FC<{
 
         <div className="col-sm-4"></div>
 
-        <div className="col-sm-2">
-          <button className="btn btn-sm btn-secondary" onClick={() => onChange(undefined)}>
-            Remove
+        <div className="col-sm-1">
+          <button className="float-right btn btn-sm btn-info" onClick={() => onChange(undefined)}>
+            <i className={`tiny-icon las la-trash`}></i>
           </button>
         </div>
       </div>

--- a/assets/src/components/activities/common/responses/ShowPage.tsx
+++ b/assets/src/components/activities/common/responses/ShowPage.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { TextInput } from 'components/common/TextInput';
+
+export const ShowPage: React.FC<{
+  editMode: boolean;
+  index: number | undefined;
+  onChange: (index: undefined | number) => void;
+}> = ({ index, onChange, editMode }) => {
+  if (index === undefined) {
+    return (
+      <div className="alert alert-info">
+        <div className="d-flex justify-content-between">
+          <div>Branch to another group of content after showing this feedback</div>
+          <button className="btn btn-sm btn-primary" onClick={() => onChange(0)}>
+            Enable branching
+          </button>
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className="alert alert-info">
+      <div className="d-flex">
+        <div className="col-sm-4">Display group number:</div>
+        <div className="col-sm-2">
+          <TextInput
+            editMode={editMode}
+            label=""
+            value={(index as any) + 1 + ''}
+            type="numeric"
+            style={{ display: 'inline-block' }}
+            onEdit={(v) => {
+              onChange(parseInt(v) - 1);
+            }}
+          />
+        </div>
+
+        <div className="col-sm-4"></div>
+
+        <div className="col-sm-2">
+          <button className="btn btn-sm btn-secondary" onClick={() => onChange(undefined)}>
+            Remove
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/assets/src/components/activities/common/responses/ShowPage.tsx
+++ b/assets/src/components/activities/common/responses/ShowPage.tsx
@@ -10,7 +10,7 @@ export const ShowPage: React.FC<{
     return (
       <div className="float-right">
         <button className="btn btn-sm btn-link" onClick={(_e) => onChange(0)}>
-          Trigger pagination change <i className={`tiny-icon las la-code-branch`}></i>
+          Automate the reveal of a content page <i className={`tiny-icon las la-code-branch`}></i>
         </button>
       </div>
     );
@@ -18,7 +18,7 @@ export const ShowPage: React.FC<{
   return (
     <div className="alert alert-info">
       <div className="d-flex">
-        <div className="col-sm-5">Display pagination group number:</div>
+        <div className="col-sm-5">Display content group number:</div>
         <div className="col-sm-2">
           <TextInput
             editMode={editMode}

--- a/assets/src/components/activities/common/responses/SimpleFeedback.tsx
+++ b/assets/src/components/activities/common/responses/SimpleFeedback.tsx
@@ -3,7 +3,10 @@ import { FeedbackCard } from 'components/activities/common/responses/FeedbackCar
 import { ResponseActions } from 'components/activities/common/responses/responseActions';
 import { HasParts, RichText } from 'components/activities/types';
 import { getCorrectResponse, getIncorrectResponse } from 'data/activities/model/responses';
+import { ShowPage } from './ShowPage';
+
 import React from 'react';
+import { valHooks } from 'jquery';
 
 interface Props {
   partId: string;
@@ -11,21 +14,39 @@ interface Props {
 }
 
 export const useSimpleFeedback = (partId: string) => {
-  const { model, dispatch } = useAuthoringElementContext<HasParts>();
+  const { model, dispatch, editMode, authoringContext } = useAuthoringElementContext<HasParts>();
 
   return {
+    editMode,
+    authoringContext,
     correctResponse: getCorrectResponse(model, partId),
     incorrectResponse: getIncorrectResponse(model, partId),
     updateFeedback: (responseId: string, content: RichText) =>
       dispatch(ResponseActions.editResponseFeedback(responseId, content)),
+    updateShowPage: (responseId: string, showPage: number | undefined) =>
+      dispatch(ResponseActions.editShowPage(responseId, showPage)),
   };
 };
 
 export const SimpleFeedback: React.FC<Props> = ({ children, partId }) => {
-  const { correctResponse, incorrectResponse, updateFeedback } = useSimpleFeedback(partId);
+  const {
+    correctResponse,
+    incorrectResponse,
+    updateFeedback,
+    updateShowPage,
+    editMode,
+    authoringContext,
+  } = useSimpleFeedback(partId);
 
   if (typeof children === 'function') {
-    return children({ correctResponse, incorrectResponse, updateFeedback });
+    return children({
+      correctResponse,
+      incorrectResponse,
+      updateFeedback,
+      updateShowPage,
+      editMode,
+      authoringContext,
+    });
   }
 
   return (
@@ -36,12 +57,26 @@ export const SimpleFeedback: React.FC<Props> = ({ children, partId }) => {
         update={(_id, content) => updateFeedback(correctResponse.id, content as RichText)}
         placeholder="Encourage students or explain why the answer is correct"
       />
+      {authoringContext.contentBreaksExist ? (
+        <ShowPage
+          editMode={editMode}
+          index={correctResponse.showPage}
+          onChange={(v) => updateShowPage(correctResponse.id, v)}
+        />
+      ) : null}
       <FeedbackCard
         title="Feedback for incorrect answers"
         feedback={incorrectResponse.feedback}
         update={(_id, content) => updateFeedback(incorrectResponse.id, content as RichText)}
         placeholder="Enter catch-all feedback for incorrect answers"
       />
+      {authoringContext.contentBreaksExist ? (
+        <ShowPage
+          editMode={editMode}
+          index={incorrectResponse.showPage}
+          onChange={(v) => updateShowPage(incorrectResponse.id, v)}
+        />
+      ) : null}
     </>
   );
 };

--- a/assets/src/components/activities/common/responses/SimpleFeedback.tsx
+++ b/assets/src/components/activities/common/responses/SimpleFeedback.tsx
@@ -6,7 +6,6 @@ import { getCorrectResponse, getIncorrectResponse } from 'data/activities/model/
 import { ShowPage } from './ShowPage';
 
 import React from 'react';
-import { valHooks } from 'jquery';
 
 interface Props {
   partId: string;
@@ -56,27 +55,29 @@ export const SimpleFeedback: React.FC<Props> = ({ children, partId }) => {
         feedback={correctResponse.feedback}
         update={(_id, content) => updateFeedback(correctResponse.id, content as RichText)}
         placeholder="Encourage students or explain why the answer is correct"
-      />
-      {authoringContext.contentBreaksExist ? (
-        <ShowPage
-          editMode={editMode}
-          index={correctResponse.showPage}
-          onChange={(v) => updateShowPage(correctResponse.id, v)}
-        />
-      ) : null}
+      >
+        {authoringContext.contentBreaksExist ? (
+          <ShowPage
+            editMode={editMode}
+            index={correctResponse.showPage}
+            onChange={(v) => updateShowPage(correctResponse.id, v)}
+          />
+        ) : null}
+      </FeedbackCard>
       <FeedbackCard
         title="Feedback for incorrect answers"
         feedback={incorrectResponse.feedback}
         update={(_id, content) => updateFeedback(incorrectResponse.id, content as RichText)}
         placeholder="Enter catch-all feedback for incorrect answers"
-      />
-      {authoringContext.contentBreaksExist ? (
-        <ShowPage
-          editMode={editMode}
-          index={incorrectResponse.showPage}
-          onChange={(v) => updateShowPage(incorrectResponse.id, v)}
-        />
-      ) : null}
+      >
+        {authoringContext.contentBreaksExist ? (
+          <ShowPage
+            editMode={editMode}
+            index={incorrectResponse.showPage}
+            onChange={(v) => updateShowPage(incorrectResponse.id, v)}
+          />
+        ) : null}
+      </FeedbackCard>
     </>
   );
 };

--- a/assets/src/components/activities/common/responses/TargetedFeedback.tsx
+++ b/assets/src/components/activities/common/responses/TargetedFeedback.tsx
@@ -3,6 +3,7 @@ import { AuthoringButtonConnected } from 'components/activities/common/authoring
 import { ChoicesDelivery } from 'components/activities/common/choices/delivery/ChoicesDelivery';
 import { ResponseActions } from 'components/activities/common/responses/responseActions';
 import { ResponseCard } from 'components/activities/common/responses/ResponseCard';
+import { ShowPage } from './ShowPage';
 import {
   Choice,
   ChoiceId,
@@ -35,12 +36,14 @@ export const useTargetedFeedback = () => {
       dispatch(ResponseActions.editResponseFeedback(responseId, content)),
     removeFeedback: (responseId: string) =>
       dispatch(ResponseActions.removeTargetedFeedback(responseId)),
+    updateShowPage: (responseId: string, showPage: number | undefined) =>
+      dispatch(ResponseActions.editShowPage(responseId, showPage)),
   };
 };
 
 export const TargetedFeedback: React.FC<Props> = (props) => {
   const hook = useTargetedFeedback();
-  const { model } = useAuthoringElementContext<
+  const { model, authoringContext, editMode } = useAuthoringElementContext<
     HasParts & HasChoices & { authoring: { targeted: ChoiceIdsToResponseId[] } }
   >();
 
@@ -67,6 +70,13 @@ export const TargetedFeedback: React.FC<Props> = (props) => {
             isEvaluated={false}
             context={defaultWriterContext()}
           />
+          {authoringContext.contentBreaksExist ? (
+            <ShowPage
+              editMode={editMode}
+              index={mapping.response.showPage}
+              onChange={(v) => hook.updateShowPage(mapping.response.id, v)}
+            />
+          ) : null}
         </ResponseCard>
       ))}
       <AuthoringButtonConnected className="btn btn-link pl-0" action={props.addTargetedResponse}>

--- a/assets/src/components/activities/common/responses/responseActions.ts
+++ b/assets/src/components/activities/common/responses/responseActions.ts
@@ -33,6 +33,12 @@ export const ResponseActions = {
     };
   },
 
+  editShowPage(responseId: ResponseId, showPage: number | undefined) {
+    return (model: HasParts) => {
+      getResponseBy(model, (r) => r.id === responseId).showPage = showPage;
+    };
+  },
+
   removeResponse(responseId: ResponseId, _path = RESPONSES_PATH) {
     return (model: HasParts) => {
       getParts(model).forEach((part) => {

--- a/assets/src/components/activities/custom_dnd/CustomDnDDelivery.tsx
+++ b/assets/src/components/activities/custom_dnd/CustomDnDDelivery.tsx
@@ -32,13 +32,13 @@ export const CustomDnDComponent: React.FC = () => {
     model,
     state,
     mode,
-    surveyId,
+    context,
     onResetActivity,
     onSubmitActivity,
     onResetPart,
     onSubmitPart,
   } = useDeliveryElementContext<CustomDnDSchema>();
-
+  const { surveyId, sectionSlug } = context;
   const initialState = state.parts.reduce((m: any, p) => {
     if (p.response !== null) {
       m[p.partId] = p.response.input;
@@ -65,6 +65,7 @@ export const CustomDnDComponent: React.FC = () => {
           }),
         }),
         model,
+        sectionSlug,
       ),
     );
   }, []);

--- a/assets/src/components/activities/custom_dnd/CustomDnDDelivery.tsx
+++ b/assets/src/components/activities/custom_dnd/CustomDnDDelivery.tsx
@@ -38,7 +38,7 @@ export const CustomDnDComponent: React.FC = () => {
     onResetPart,
     onSubmitPart,
   } = useDeliveryElementContext<CustomDnDSchema>();
-  const { surveyId, sectionSlug } = context;
+  const { surveyId } = context;
   const initialState = state.parts.reduce((m: any, p) => {
     if (p.response !== null) {
       m[p.partId] = p.response.input;
@@ -65,7 +65,7 @@ export const CustomDnDComponent: React.FC = () => {
           }),
         }),
         model,
-        sectionSlug,
+        context,
       ),
     );
   }, []);

--- a/assets/src/components/activities/file_upload/FileUploadDelivery.tsx
+++ b/assets/src/components/activities/file_upload/FileUploadDelivery.tsx
@@ -54,7 +54,7 @@ const getFilesFromState = (state: ActivityDeliveryState) => {
 };
 
 const listenForParentSurveySubmit = (
-  surveyId: string | undefined,
+  surveyId: string | null,
   dispatch: Dispatch<any>,
   onSubmitActivity: (
     attemptGuid: string,
@@ -264,7 +264,7 @@ export const FileUploadComponent: React.FC = () => {
           }),
         }),
         model,
-        sectionSlug,
+        context,
       ),
     );
   }, []);

--- a/assets/src/components/activities/image_coding/ImageCodingDelivery.tsx
+++ b/assets/src/components/activities/image_coding/ImageCodingDelivery.tsx
@@ -31,7 +31,7 @@ type Evaluation = {
 };
 
 const listenForParentSurveySubmit = (
-  surveyId: string | undefined,
+  surveyId: string | null,
   onRun: () => void,
   onSubmit: () => void,
 ) =>
@@ -49,7 +49,7 @@ const listenForParentSurveySubmit = (
     ),
   );
 
-const listenForParentSurveyReset = (surveyId: string | undefined, onReset: () => void) =>
+const listenForParentSurveyReset = (surveyId: string | null, onReset: () => void) =>
   maybe(surveyId).lift((surveyId) =>
     // listen for survey submit events if the delivery element is in a survey
     document.addEventListener(

--- a/assets/src/components/activities/image_coding/ImageCodingDelivery.tsx
+++ b/assets/src/components/activities/image_coding/ImageCodingDelivery.tsx
@@ -21,8 +21,8 @@ import { activityDeliverySlice } from 'data/activities/DeliveryState';
 import { Provider } from 'react-redux';
 import { configureStore } from 'state/store';
 import { DeliveryElementProvider } from '../DeliveryElementProvider';
-import { SurveyEventDetails } from 'components/misc/SurveyControls';
 import { maybe } from 'tsmonad';
+import * as Events from 'data/events';
 
 type Evaluation = {
   score: number;
@@ -37,24 +37,30 @@ const listenForParentSurveySubmit = (
 ) =>
   maybe(surveyId).lift((surveyId) =>
     // listen for survey submit events if the delivery element is in a survey
-    document.addEventListener('oli-survey-submit', (e: CustomEvent<SurveyEventDetails>) => {
-      // check if this activity belongs to the survey being submitted
-      if (e.detail.id === surveyId) {
-        onRun();
-        onSubmit();
-      }
-    }),
+    document.addEventListener(
+      Events.Registry.SurveySubmit,
+      (e: CustomEvent<Events.SurveyDetails>) => {
+        // check if this activity belongs to the survey being submitted
+        if (e.detail.id === surveyId) {
+          onRun();
+          onSubmit();
+        }
+      },
+    ),
   );
 
 const listenForParentSurveyReset = (surveyId: string | undefined, onReset: () => void) =>
   maybe(surveyId).lift((surveyId) =>
     // listen for survey submit events if the delivery element is in a survey
-    document.addEventListener('oli-survey-reset', (e: CustomEvent<SurveyEventDetails>) => {
-      // check if this activity belongs to the survey being reset
-      if (e.detail.id === surveyId) {
-        onReset();
-      }
-    }),
+    document.addEventListener(
+      Events.Registry.SurveyReset,
+      (e: CustomEvent<Events.SurveyDetails>) => {
+        // check if this activity belongs to the survey being reset
+        if (e.detail.id === surveyId) {
+          onReset();
+        }
+      },
+    ),
   );
 
 // eslint-disable-next-line
@@ -80,8 +86,8 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
   const isEvaluated = attemptState.score !== null;
 
   const writerContext = defaultWriterContext({
-    sectionSlug: props.sectionSlug,
-    bibParams: props.bibParams,
+    sectionSlug: props.context.sectionSlug,
+    bibParams: props.context.bibParams,
   });
 
   // tslint:disable-next-line:prefer-array-literal
@@ -119,8 +125,8 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
 
   // effect hook to initiate fetching of resources, executes once on first render
   useEffect(() => {
-    listenForParentSurveySubmit(props.surveyId, onRun, onSubmit);
-    listenForParentSurveyReset(props.surveyId, onReset);
+    listenForParentSurveySubmit(props.context.surveyId, onRun, onSubmit);
+    listenForParentSurveyReset(props.context.surveyId, onReset);
 
     resourceURLs.map((url, i) => {
       url.endsWith('csv') ? loadCSV(url, i) : loadImage(url, i);
@@ -261,14 +267,14 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
     <Evaluation key="evaluation" attemptState={attemptState} context={writerContext} />
   ) : null;
 
-  const reset = isEvaluated && !props.graded && props.surveyId === undefined && (
+  const reset = isEvaluated && !props.context.graded && props.context.surveyId === undefined && (
     <div className="d-flex">
       <div className="flex-fill"></div>
       <Reset hasMoreAttempts={attemptState.hasMoreAttempts} onClick={onReset} />
     </div>
   );
 
-  const ungradedDetails = props.graded
+  const ungradedDetails = props.context.graded
     ? null
     : [
         evaluationSummary,
@@ -321,7 +327,7 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
     return solution ? solnRef.current : resultRef.current;
   };
 
-  const maybeSubmitButton = !model.isExample && props.surveyId === undefined && (
+  const maybeSubmitButton = !model.isExample && props.context.surveyId === undefined && (
     <button
       className="btn btn-primary mt-2 float-right"
       disabled={isEvaluated || !ranCode}
@@ -360,7 +366,7 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
           <canvas ref={solnRef} style={{ display: 'none' }} height="0" width="0" />
         </div>
 
-        {!model.isExample && props.surveyId === undefined && ungradedDetails}
+        {!model.isExample && props.context.surveyId === undefined && ungradedDetails}
       </div>
       {reset}
     </div>

--- a/assets/src/components/activities/likert/LikertDelivery.tsx
+++ b/assets/src/components/activities/likert/LikertDelivery.tsx
@@ -30,7 +30,7 @@ import { LikertTable } from './Sections/LikertTable';
 const LikertComponent: React.FC = () => {
   const {
     state: activityState,
-    surveyId,
+    context,
     model,
     writerContext,
     onSubmitActivity,
@@ -46,9 +46,9 @@ const LikertComponent: React.FC = () => {
   }, {} as PartInputs);
 
   useEffect(() => {
-    listenForParentSurveySubmit(surveyId, dispatch, onSubmitActivity);
-    listenForParentSurveyReset(surveyId, dispatch, onResetActivity, emptySelectionMap);
-    dispatch(initializeState(activityState, initialPartInputs(activityState), model));
+    listenForParentSurveySubmit(context.surveyId, dispatch, onSubmitActivity);
+    listenForParentSurveyReset(context.surveyId, dispatch, onResetActivity, emptySelectionMap);
+    dispatch(initializeState(activityState, initialPartInputs(activityState), model, context));
   }, []);
 
   // First render initializes state

--- a/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
@@ -30,15 +30,14 @@ import { configureStore } from 'state/store';
 export const MultiInputComponent: React.FC = () => {
   const {
     state: activityState,
-    surveyId,
-    sectionSlug,
-    bibParams,
+    context,
     onSubmitActivity,
     onSaveActivity,
     onResetActivity,
     model,
   } = useDeliveryElementContext<MultiInputSchema>();
 
+  const { surveyId, sectionSlug, bibParams } = context;
   const uiState = useSelector((state: ActivityDeliveryState) => state);
   const [hintsShown, setHintsShown] = React.useState<PartId[]>([]);
   const dispatch = useDispatch();
@@ -64,6 +63,7 @@ export const MultiInputComponent: React.FC = () => {
             }, {} as PartInputs),
         }),
         model,
+        sectionSlug,
       ),
     );
   }, []);

--- a/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
@@ -63,7 +63,7 @@ export const MultiInputComponent: React.FC = () => {
             }, {} as PartInputs),
         }),
         model,
-        sectionSlug,
+        context,
       ),
     );
   }, []);

--- a/assets/src/components/activities/multi_input/sections/AnswerKeyTab.tsx
+++ b/assets/src/components/activities/multi_input/sections/AnswerKeyTab.tsx
@@ -7,6 +7,7 @@ import { ResponseCard } from 'components/activities/common/responses/ResponseCar
 import { SimpleFeedback } from 'components/activities/common/responses/SimpleFeedback';
 import { TargetedFeedback } from 'components/activities/common/responses/TargetedFeedback';
 import { getCorrectChoice } from 'components/activities/multiple_choice/utils';
+import { ShowPage } from 'components/activities/common/responses/ShowPage';
 import {
   Dropdown,
   FillInTheBlank,
@@ -44,7 +45,8 @@ interface Props {
   input: MultiInput;
 }
 export const AnswerKeyTab: React.FC<Props> = (props) => {
-  const { model, dispatch } = useAuthoringElementContext<MultiInputSchema>();
+  const { model, dispatch, authoringContext, editMode } =
+    useAuthoringElementContext<MultiInputSchema>();
 
   if (props.input.inputType === 'dropdown') {
     const choices = model.choices.filter((choice) =>
@@ -103,6 +105,15 @@ export const AnswerKeyTab: React.FC<Props> = (props) => {
             response={response}
             onEditResponseRule={(id, rule) => dispatch(ResponseActions.editRule(id, rule))}
           />
+          {authoringContext.contentBreaksExist ? (
+            <ShowPage
+              editMode={editMode}
+              index={response.showPage}
+              onChange={(showPage: any) =>
+                dispatch(ResponseActions.editShowPage(response.id, showPage))
+              }
+            />
+          ) : null}
         </ResponseCard>
       ))}
       <AuthoringButtonConnected

--- a/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
+++ b/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
@@ -30,7 +30,7 @@ import { DEFAULT_PART_ID } from 'components/activities/common/utils';
 export const MultipleChoiceComponent: React.FC = () => {
   const {
     state: activityState,
-    surveyId,
+    context,
     onSubmitActivity,
     onSaveActivity,
     onResetActivity,
@@ -38,12 +38,13 @@ export const MultipleChoiceComponent: React.FC = () => {
   } = useDeliveryElementContext<MCSchema>();
   const uiState = useSelector((state: ActivityDeliveryState) => state);
   const dispatch = useDispatch();
+  const { surveyId, sectionSlug } = context;
 
   useEffect(() => {
     listenForParentSurveySubmit(surveyId, dispatch, onSubmitActivity);
     listenForParentSurveyReset(surveyId, dispatch, onResetActivity, { [DEFAULT_PART_ID]: [] });
 
-    dispatch(initializeState(activityState, initialPartInputs(activityState), model));
+    dispatch(initializeState(activityState, initialPartInputs(activityState), model, sectionSlug));
   }, []);
 
   // First render initializes state

--- a/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
+++ b/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
@@ -38,13 +38,13 @@ export const MultipleChoiceComponent: React.FC = () => {
   } = useDeliveryElementContext<MCSchema>();
   const uiState = useSelector((state: ActivityDeliveryState) => state);
   const dispatch = useDispatch();
-  const { surveyId, sectionSlug } = context;
+  const { surveyId } = context;
 
   useEffect(() => {
     listenForParentSurveySubmit(surveyId, dispatch, onSubmitActivity);
     listenForParentSurveyReset(surveyId, dispatch, onResetActivity, { [DEFAULT_PART_ID]: [] });
 
-    dispatch(initializeState(activityState, initialPartInputs(activityState), model, sectionSlug));
+    dispatch(initializeState(activityState, initialPartInputs(activityState), model, context));
   }, []);
 
   // First render initializes state

--- a/assets/src/components/activities/ordering/OrderingDelivery.tsx
+++ b/assets/src/components/activities/ordering/OrderingDelivery.tsx
@@ -32,15 +32,15 @@ import { OrderingSchema } from './schema';
 export const OrderingComponent: React.FC = () => {
   const {
     model,
+    context,
     state: activityState,
-    surveyId,
     onSubmitActivity,
     onResetActivity,
     onSaveActivity,
   } = useDeliveryElementContext<OrderingSchema>();
   const uiState = useSelector((state: ActivityDeliveryState) => state);
   const dispatch = useDispatch();
-
+  const { surveyId, sectionSlug } = context;
   const onSelectionChange = (studentInput: ActivityTypes.ChoiceId[]) => {
     dispatch(
       activityDeliverySlice.actions.setStudentInputForPart({
@@ -72,6 +72,7 @@ export const OrderingComponent: React.FC = () => {
           [DEFAULT_PART_ID]: model.choices.map((c) => c.id),
         }),
         model,
+        sectionSlug,
       ),
     );
 

--- a/assets/src/components/activities/ordering/OrderingDelivery.tsx
+++ b/assets/src/components/activities/ordering/OrderingDelivery.tsx
@@ -40,7 +40,7 @@ export const OrderingComponent: React.FC = () => {
   } = useDeliveryElementContext<OrderingSchema>();
   const uiState = useSelector((state: ActivityDeliveryState) => state);
   const dispatch = useDispatch();
-  const { surveyId, sectionSlug } = context;
+  const { surveyId } = context;
   const onSelectionChange = (studentInput: ActivityTypes.ChoiceId[]) => {
     dispatch(
       activityDeliverySlice.actions.setStudentInputForPart({
@@ -72,7 +72,7 @@ export const OrderingComponent: React.FC = () => {
           [DEFAULT_PART_ID]: model.choices.map((c) => c.id),
         }),
         model,
-        sectionSlug,
+        context,
       ),
     );
 

--- a/assets/src/components/activities/ordering/sections/TargetedFeedback.tsx
+++ b/assets/src/components/activities/ordering/sections/TargetedFeedback.tsx
@@ -8,10 +8,12 @@ import { ResponseChoices } from 'components/activities/ordering/sections/Respons
 import { RichText } from 'components/activities/types';
 import { Choices } from 'data/activities/model/choices';
 import { getTargetedResponseMappings } from 'data/activities/model/responses';
+import { ShowPage } from 'components/activities/common/responses/ShowPage';
 import React from 'react';
 
 export const TargetedFeedback: React.FC = () => {
-  const { model, dispatch } = useAuthoringElementContext<OrderingSchema>();
+  const { model, dispatch, authoringContext, editMode } =
+    useAuthoringElementContext<OrderingSchema>();
   return (
     <>
       {getTargetedResponseMappings(model).map((mapping) => (
@@ -35,6 +37,15 @@ export const TargetedFeedback: React.FC = () => {
               )
             }
           />
+          {authoringContext.contentBreaksExist ? (
+            <ShowPage
+              editMode={editMode}
+              index={mapping.response.showPage}
+              onChange={(showPage: any) =>
+                dispatch(ResponseActions.editShowPage(mapping.response.id, showPage))
+              }
+            />
+          ) : null}
         </ResponseCard>
       ))}
       <AuthoringButtonConnected

--- a/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
+++ b/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
@@ -71,7 +71,7 @@ export const ShortAnswerComponent: React.FC = () => {
     onResetActivity,
   } = useDeliveryElementContext<ShortAnswerModelSchema>();
   const uiState = useSelector((state: ActivityDeliveryState) => state);
-  const { surveyId, sectionSlug } = context;
+  const { surveyId } = context;
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -90,7 +90,7 @@ export const ShortAnswerComponent: React.FC = () => {
           }),
         }),
         model,
-        sectionSlug,
+        context,
       ),
     );
   }, []);

--- a/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
+++ b/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
@@ -65,13 +65,13 @@ export const ShortAnswerComponent: React.FC = () => {
   const {
     model,
     state: activityState,
-    surveyId,
+    context,
     onSubmitActivity,
     onSaveActivity,
     onResetActivity,
   } = useDeliveryElementContext<ShortAnswerModelSchema>();
   const uiState = useSelector((state: ActivityDeliveryState) => state);
-
+  const { surveyId, sectionSlug } = context;
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -90,6 +90,7 @@ export const ShortAnswerComponent: React.FC = () => {
           }),
         }),
         model,
+        sectionSlug,
       ),
     );
   }, []);

--- a/assets/src/components/activities/types.ts
+++ b/assets/src/components/activities/types.ts
@@ -425,6 +425,11 @@ export interface Response extends Identifiable {
    * Feedback to assign if this response matches.
    */
   feedback: Feedback;
+
+  /**
+   * Optional, show a page by index when this response is evaluated.
+   */
+  showPage?: number;
 }
 
 /**

--- a/assets/src/components/activities/types.ts
+++ b/assets/src/components/activities/types.ts
@@ -275,6 +275,8 @@ export interface PartState {
  * and a specific activity instance.
  */
 export interface ActivityState {
+  pageAttemptGuid: string;
+
   /**
    * Resource id of the activity that this attempt pertains to.
    */

--- a/assets/src/components/activities/types.ts
+++ b/assets/src/components/activities/types.ts
@@ -275,8 +275,6 @@ export interface PartState {
  * and a specific activity instance.
  */
 export interface ActivityState {
-  pageAttemptGuid: string;
-
   /**
    * Resource id of the activity that this attempt pertains to.
    */

--- a/assets/src/components/activities/types.ts
+++ b/assets/src/components/activities/types.ts
@@ -322,6 +322,8 @@ export interface ActivityState {
    */
   hasMoreHints: boolean;
   snapshot?: any;
+
+  groupId: null | string;
 }
 
 /**
@@ -477,6 +479,7 @@ export interface FeedbackAction extends IsAction {
   out_of: number;
   score: number;
   feedback: Feedback;
+  show_page: number | null;
 }
 
 /**

--- a/assets/src/components/activity/InlineActivityEditor.tsx
+++ b/assets/src/components/activity/InlineActivityEditor.tsx
@@ -149,8 +149,6 @@ export class InlineActivityEditor extends React.Component<
       authoringcontext: JSON.stringify({ contentBreaksExist }),
     };
 
-    console.log(webComponentProps.authoringcontext);
-
     const parts = valueOr(this.props.model.authoring.parts, []);
     const partIds = parts.map((p: any) => p.id);
 

--- a/assets/src/components/activity/InlineActivityEditor.tsx
+++ b/assets/src/components/activity/InlineActivityEditor.tsx
@@ -20,6 +20,7 @@ export interface ActivityEditorProps extends ActivityEditContext {
   allTags: Tag[];
   banked: boolean;
   canRemove: boolean;
+  contentBreaksExist: boolean;
   customToolbarItems?: React.ComponentType;
   onEdit: (state: EditorUpdate) => void;
   onPostUndoable: (undoable: Undoable) => void;
@@ -134,7 +135,7 @@ export class InlineActivityEditor extends React.Component<
   }
 
   render() {
-    const { authoringElement } = this.props;
+    const { authoringElement, contentBreaksExist } = this.props;
 
     const onTitleEdit = (title: string) => {
       this.update({ title });
@@ -145,7 +146,11 @@ export class InlineActivityEditor extends React.Component<
       model: JSON.stringify(this.props.model),
       editmode: new Boolean(this.props.editMode).toString(),
       projectslug: this.props.projectSlug,
+      authoringcontext: JSON.stringify({ contentBreaksExist }),
     };
+
+    console.log(webComponentProps.authoringcontext);
+
     const parts = valueOr(this.props.model.authoring.parts, []);
     const partIds = parts.map((p: any) => p.id);
 

--- a/assets/src/components/misc/PaginationControls.tsx
+++ b/assets/src/components/misc/PaginationControls.tsx
@@ -94,12 +94,9 @@ export const PaginationControls = (props: PaginationControlsProps) => {
             className="btn btn-primary"
             onClick={() => {
               onSelectPage(active + 1);
-              updatePaginationState(
-                props.sectionSlug,
-                props.pageAttemptGuid,
-                props.forId,
+              updatePaginationState(props.sectionSlug, props.pageAttemptGuid, props.forId, [
                 active + 1,
-              );
+              ]);
             }}
           >
             Next

--- a/assets/src/components/misc/PaginationControls.tsx
+++ b/assets/src/components/misc/PaginationControls.tsx
@@ -3,10 +3,11 @@ import { List } from 'immutable';
 import styles from './PaginationControls.modules.scss';
 import { classNames } from 'utils/classNames';
 import * as Events from 'data/events';
+import { PaginationMode } from 'data/content/resource';
 
 export interface PaginationControlsProps {
   forId: string;
-  hideControls?: boolean;
+  paginationMode: PaginationMode;
 }
 
 type Page = List<Element>;
@@ -50,55 +51,68 @@ export const PaginationControls = (props: PaginationControlsProps) => {
             );
           }
         }
-
         setPages(pages);
       }
     }
   }, [controls]);
 
   useEffect(() => {
-    hideAll();
+    if (props.paginationMode === 'normal') {
+      hideAll();
+    }
     show(active);
   }, [pages, active]);
 
   const onSelectPage = (pageIndex: number) => {
-    setActive(Math.min(pages.count() - 1, Math.max(0, pageIndex)));
+    setActive(Math.max(0, pageIndex));
   };
 
   const previousDisabled = active === 0;
   const nextDisabled = active === pages.count() - 1;
 
   return (
-    <div className={styles.paginationControls} ref={controls}>
-      <div className="flex-grow-1"></div>
-      <ul className="pagination" style={{ display: props.hideControls ? 'none' : 'inline-block' }}>
-        <li className={classNames('page-item', previousDisabled ? 'disabled' : '')}>
-          <button
-            className="page-link"
-            onClick={() => onSelectPage(active - 1)}
-            disabled={previousDisabled}
-          >
-            Previous
-          </button>
-        </li>
-        {pages.map((p, i) => (
-          <li key={i} className={classNames('page-item', i == active ? 'active' : '')}>
-            <button className="page-link" onClick={() => onSelectPage(i)}>
-              {i + 1}
-            </button>
-          </li>
-        ))}
-        <li className={classNames('page-item', nextDisabled ? 'disabled' : '')}>
-          <button
-            className="page-link"
-            onClick={() => onSelectPage(active + 1)}
-            disabled={nextDisabled}
-          >
+    <>
+      <div className="d-flex justify-content-center">
+        {props.paginationMode === 'manualReveal' && active !== pages.toArray().length - 1 ? (
+          <button className="btn btn-primary" onClick={() => onSelectPage(active + 1)}>
             Next
           </button>
-        </li>
-      </ul>
-      <div className="flex-grow-1"></div>
-    </div>
+        ) : null}
+      </div>
+      <div className={styles.paginationControls} ref={controls}>
+        <div className="flex-grow-1"></div>
+        <ul
+          className="pagination"
+          style={{ visibility: props.paginationMode !== 'normal' ? 'hidden' : 'visible' }}
+        >
+          <li className={classNames('page-item', previousDisabled ? 'disabled' : '')}>
+            <button
+              className="page-link"
+              onClick={() => onSelectPage(active - 1)}
+              disabled={previousDisabled}
+            >
+              Previous
+            </button>
+          </li>
+          {pages.map((p, i) => (
+            <li key={i} className={classNames('page-item', i == active ? 'active' : '')}>
+              <button className="page-link" onClick={() => onSelectPage(i)}>
+                {i + 1}
+              </button>
+            </li>
+          ))}
+          <li className={classNames('page-item', nextDisabled ? 'disabled' : '')}>
+            <button
+              className="page-link"
+              onClick={() => onSelectPage(active + 1)}
+              disabled={nextDisabled}
+            >
+              Next
+            </button>
+          </li>
+        </ul>
+        <div className="flex-grow-1"></div>
+      </div>
+    </>
   );
 };

--- a/assets/src/components/misc/PaginationControls.tsx
+++ b/assets/src/components/misc/PaginationControls.tsx
@@ -2,12 +2,15 @@ import React, { useEffect, useState, useRef } from 'react';
 import { List } from 'immutable';
 import styles from './PaginationControls.modules.scss';
 import { classNames } from 'utils/classNames';
+import * as Events from 'data/events';
 
-export interface PaginationControlsProps {}
+export interface PaginationControlsProps {
+  forId: string;
+}
 
 type Page = List<Element>;
 
-export const PaginationControls = (_props: PaginationControlsProps) => {
+export const PaginationControls = (props: PaginationControlsProps) => {
   const controls = useRef<HTMLDivElement>(null);
   const [pages, setPages] = useState(List<Page>());
   const [active, setActive] = useState(0);
@@ -19,6 +22,15 @@ export const PaginationControls = (_props: PaginationControlsProps) => {
   const show = (pageIndex: number) => {
     pages.get(pageIndex)?.forEach((el) => el.classList.add(styles.show));
   };
+
+  useEffect(() => {
+    document.addEventListener(Events.Registry.ShowContentPage, (e) => {
+      // check if this activity belongs to the survey being reset
+      if (e.detail.forId === props.forId) {
+        onSelectPage(e.detail.index);
+      }
+    });
+  }, []);
 
   useEffect(() => {
     const parentElement = controls?.current?.parentElement?.parentElement;

--- a/assets/src/components/misc/PaginationControls.tsx
+++ b/assets/src/components/misc/PaginationControls.tsx
@@ -4,10 +4,14 @@ import styles from './PaginationControls.modules.scss';
 import { classNames } from 'utils/classNames';
 import * as Events from 'data/events';
 import { PaginationMode } from 'data/content/resource';
+import { updatePaginationState } from 'data/persistence/pagination';
 
 export interface PaginationControlsProps {
   forId: string;
   paginationMode: PaginationMode;
+  sectionSlug: string;
+  pageAttemptGuid: string;
+  initiallyVisible: number[];
 }
 
 type Page = List<Element>;
@@ -51,6 +55,18 @@ export const PaginationControls = (props: PaginationControlsProps) => {
             );
           }
         }
+
+        // Set the visibility of our initial state
+        props.initiallyVisible.forEach((index) => {
+          pages.get(index)?.forEach((el) => el.classList.add(styles.show));
+        });
+        const maxItem = props.initiallyVisible.reduce((p, c) => {
+          if (p > c) {
+            return p;
+          }
+          return c;
+        }, 0);
+        setActive(maxItem);
         setPages(pages);
       }
     }
@@ -74,7 +90,18 @@ export const PaginationControls = (props: PaginationControlsProps) => {
     <>
       <div className="d-flex justify-content-center">
         {props.paginationMode === 'manualReveal' && active !== pages.toArray().length - 1 ? (
-          <button className="btn btn-primary" onClick={() => onSelectPage(active + 1)}>
+          <button
+            className="btn btn-primary"
+            onClick={() => {
+              onSelectPage(active + 1);
+              updatePaginationState(
+                props.sectionSlug,
+                props.pageAttemptGuid,
+                props.forId,
+                active + 1,
+              );
+            }}
+          >
             Next
           </button>
         ) : null}
@@ -104,7 +131,9 @@ export const PaginationControls = (props: PaginationControlsProps) => {
           <li className={classNames('page-item', nextDisabled ? 'disabled' : '')}>
             <button
               className="page-link"
-              onClick={() => onSelectPage(active + 1)}
+              onClick={() => {
+                onSelectPage(active + 1);
+              }}
               disabled={nextDisabled}
             >
               Next

--- a/assets/src/components/misc/PaginationControls.tsx
+++ b/assets/src/components/misc/PaginationControls.tsx
@@ -6,6 +6,7 @@ import * as Events from 'data/events';
 
 export interface PaginationControlsProps {
   forId: string;
+  hideControls?: boolean;
 }
 
 type Page = List<Element>;
@@ -70,7 +71,7 @@ export const PaginationControls = (props: PaginationControlsProps) => {
   return (
     <div className={styles.paginationControls} ref={controls}>
       <div className="flex-grow-1"></div>
-      <ul className="pagination">
+      <ul className="pagination" style={{ display: props.hideControls ? 'none' : 'inline-block' }}>
         <li className={classNames('page-item', previousDisabled ? 'disabled' : '')}>
           <button
             className="page-link"

--- a/assets/src/components/misc/SurveyControls.tsx
+++ b/assets/src/components/misc/SurveyControls.tsx
@@ -1,26 +1,19 @@
 import React, { useState } from 'react';
+import * as Events from 'data/events';
 
 export interface SurveyControlsProps {
   id: string;
   isSubmitted: boolean;
 }
 
-export interface SurveyEventDetails {
-  id: string;
-}
-
 export const SurveyControls = ({ id, isSubmitted }: SurveyControlsProps) => {
   const [submitted, setSubmitted] = useState(isSubmitted);
   const onSubmit = () => {
-    document.dispatchEvent(
-      new CustomEvent<SurveyEventDetails>('oli-survey-submit', { detail: { id } }),
-    );
+    Events.dispatch(Events.Registry.SurveySubmit, Events.makeSurveySubmitEvent({ id }));
     setSubmitted(true);
   };
   const onReset = () => {
-    document.dispatchEvent(
-      new CustomEvent<SurveyEventDetails>('oli-survey-reset', { detail: { id } }),
-    );
+    Events.dispatch(Events.Registry.SurveyReset, Events.makeSurveyResetEvent({ id }));
     setSubmitted(false);
   };
 

--- a/assets/src/components/resource/editors/ActivityEditor.tsx
+++ b/assets/src/components/resource/editors/ActivityEditor.tsx
@@ -17,6 +17,7 @@ export const ActivityEditor = ({
   allObjectives,
   allTags,
   canRemove,
+  contentBreaksExist,
   onEditActivity,
   onRemove,
   onPostUndoable,
@@ -49,6 +50,7 @@ export const ActivityEditor = ({
           activityId={activity.activityId}
           title={activity.title}
           banked={false}
+          contentBreaksExist={contentBreaksExist}
           canRemove={canRemove}
           onRemove={onRemove}
           onEdit={(update: EditorUpdate) => onEditActivity(activity.activitySlug, update)}

--- a/assets/src/components/resource/editors/Editors.tsx
+++ b/assets/src/components/resource/editors/Editors.tsx
@@ -74,6 +74,11 @@ export const Editors = (props: EditorsProps) => {
       props.onEdit(content.updateContentItem(contentItem.id, contentItem));
     const onRemove = () => props.onRemove(contentItem.id);
 
+    const contentBreaksExist =
+      (contentItem as any).children !== undefined
+        ? (contentItem as any).children.some((v: ResourceContent) => v.type === 'break')
+        : false;
+
     const editor = createEditor({
       resourceContext: resourceContext,
       contentItem,
@@ -90,6 +95,7 @@ export const Editors = (props: EditorsProps) => {
       editorMap,
       canRemove,
       featureFlags,
+      contentBreaksExist,
       onEdit,
       onEditActivity,
       onPostUndoable,

--- a/assets/src/components/resource/editors/GroupBlock.tsx
+++ b/assets/src/components/resource/editors/GroupBlock.tsx
@@ -10,6 +10,7 @@ import {
 import { Purpose } from 'components/content/Purpose';
 import { classNames } from 'utils/classNames';
 import styles from './ContentBlock.modules.scss';
+import { PaginationModes } from './PaginationModes';
 
 interface GroupBlockProps {
   editMode: boolean;
@@ -33,13 +34,6 @@ export const GroupBlock = ({
   const onEditPurpose = (purpose: string) => {
     onEdit(Object.assign(contentItem, { purpose }));
   };
-  const onEditPaginationDisplay = (_e: any) => {
-    const hidePaginationControls =
-      contentItem.hidePaginationControls === undefined || !contentItem.hidePaginationControls
-        ? true
-        : false;
-    onEdit(Object.assign(contentItem, { hidePaginationControls }));
-  };
 
   // a purpose can only be set if no parents have a purpose or no children have purpose
   const canEditPurpose =
@@ -54,17 +48,11 @@ export const GroupBlock = ({
       <div className={styles.groupBlockHeader}>
         <div className="flex-grow-1"></div>
         {contentBreaksExist ? (
-          <div>
-            <input
-              type="checkbox"
-              defaultChecked={
-                contentItem.hidePaginationControls !== undefined &&
-                contentItem.hidePaginationControls
-              }
-              onChange={(v: any) => onEditPaginationDisplay(v)}
-            />
-            <label className="ml-2 mr-4">Hide pagination controls</label>
-          </div>
+          <PaginationModes
+            onEdit={(paginationMode) => onEdit(Object.assign(contentItem, { paginationMode }))}
+            editMode={editMode}
+            mode={contentItem.paginationMode === undefined ? 'normal' : contentItem.paginationMode}
+          />
         ) : null}
         <Purpose
           purpose={contentItem.purpose}

--- a/assets/src/components/resource/editors/GroupBlock.tsx
+++ b/assets/src/components/resource/editors/GroupBlock.tsx
@@ -16,6 +16,7 @@ interface GroupBlockProps {
   contentItem: GroupContent;
   parents: ResourceContent[];
   canRemove: boolean;
+  contentBreaksExist: boolean;
   onEdit: (contentItem: GroupContent) => void;
   onRemove: () => void;
 }
@@ -24,12 +25,20 @@ export const GroupBlock = ({
   contentItem,
   parents,
   canRemove,
+  contentBreaksExist,
   children,
   onEdit,
   onRemove,
 }: PropsWithChildren<GroupBlockProps>) => {
   const onEditPurpose = (purpose: string) => {
     onEdit(Object.assign(contentItem, { purpose }));
+  };
+  const onEditPaginationDisplay = (_e: any) => {
+    const hidePaginationControls =
+      contentItem.hidePaginationControls === undefined || !contentItem.hidePaginationControls
+        ? true
+        : false;
+    onEdit(Object.assign(contentItem, { hidePaginationControls }));
   };
 
   // a purpose can only be set if no parents have a purpose or no children have purpose
@@ -44,6 +53,19 @@ export const GroupBlock = ({
     >
       <div className={styles.groupBlockHeader}>
         <div className="flex-grow-1"></div>
+        {contentBreaksExist ? (
+          <div>
+            <input
+              type="checkbox"
+              defaultChecked={
+                contentItem.hidePaginationControls !== undefined &&
+                contentItem.hidePaginationControls
+              }
+              onChange={(v: any) => onEditPaginationDisplay(v)}
+            />
+            <label className="ml-2 mr-4">Hide pagination controls</label>
+          </div>
+        ) : null}
         <Purpose
           purpose={contentItem.purpose}
           editMode={editMode}

--- a/assets/src/components/resource/editors/GroupEditor.tsx
+++ b/assets/src/components/resource/editors/GroupEditor.tsx
@@ -44,8 +44,6 @@ export const GroupEditor = ({
     .toArray()
     .some((v: ResourceContent) => v.type === 'break');
 
-  console.log(contentBreaksExist);
-
   return (
     <GroupBlock
       editMode={editMode}
@@ -54,6 +52,7 @@ export const GroupEditor = ({
       canRemove={canRemove}
       onRemove={onRemove}
       onEdit={onEdit}
+      contentBreaksExist={contentBreaksExist}
     >
       {contentItem.children.map((c, childIndex) => {
         const onRemoveChild = () =>

--- a/assets/src/components/resource/editors/GroupEditor.tsx
+++ b/assets/src/components/resource/editors/GroupEditor.tsx
@@ -40,6 +40,12 @@ export const GroupEditor = ({
     onEdit(updatedContent);
   };
 
+  const contentBreaksExist = contentItem.children
+    .toArray()
+    .some((v: ResourceContent) => v.type === 'break');
+
+  console.log(contentBreaksExist);
+
   return (
     <GroupBlock
       editMode={editMode}
@@ -84,6 +90,7 @@ export const GroupEditor = ({
               editorMap,
               canRemove,
               featureFlags,
+              contentBreaksExist,
               onEdit: onEditChild,
               onEditActivity,
               onRemove: onRemoveChild,

--- a/assets/src/components/resource/editors/PaginationModes.tsx
+++ b/assets/src/components/resource/editors/PaginationModes.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { PaginationMode } from 'data/content/resource';
+
+export type PaginationModesProps = {
+  editMode: boolean; // Whether or not we can edit
+  mode: PaginationMode;
+  onEdit: (mode: PaginationMode) => void;
+};
+
+const descriptions: any = {
+  normal: 'Allow user to paginate through items',
+  manualReveal: 'Allow user to reveal items one at a time',
+  automatedReveal: 'Reveal items with automation',
+};
+
+export const PaginationModes = (props: PaginationModesProps) => {
+  const { editMode, mode, onEdit } = props;
+
+  const current = descriptions[mode];
+  const options = Object.keys(descriptions).map((m) => {
+    return (
+      <button className="dropdown-item" key={m} onClick={() => onEdit(m as PaginationMode)}>
+        {descriptions[m]}
+      </button>
+    );
+  });
+
+  return (
+    <div className="form-inline">
+      <div className="dropdown">
+        <button
+          type="button"
+          disabled={!editMode}
+          className={'btn btn-sm dropdown-toggle btn-purpose'}
+          data-toggle="dropdown"
+          aria-haspopup="true"
+          aria-expanded="false"
+        >
+          {current}
+        </button>
+        <div className="dropdown-menu dropdown-menu-right">{options}</div>
+      </div>
+    </div>
+  );
+};

--- a/assets/src/components/resource/editors/SurveyBlock.tsx
+++ b/assets/src/components/resource/editors/SurveyBlock.tsx
@@ -10,6 +10,7 @@ interface SurveyBlockProps {
   editMode: boolean;
   contentItem: SurveyContent;
   canRemove: boolean;
+  contentBreaksExist: boolean;
   onEdit: (item: SurveyContent) => void;
   onRemove: () => void;
 }
@@ -18,11 +19,19 @@ export const SurveyBlock = ({
   contentItem,
   canRemove,
   children,
+  contentBreaksExist,
   onEdit,
   onRemove,
 }: PropsWithChildren<SurveyBlockProps>) => {
   const onEditTitle = (title: string) => {
     onEdit(Object.assign(contentItem, { title }));
+  };
+  const onEditPaginationDisplay = (_e: any) => {
+    const hidePaginationControls =
+      contentItem.hidePaginationControls === undefined || !contentItem.hidePaginationControls
+        ? true
+        : false;
+    onEdit(Object.assign(contentItem, { hidePaginationControls }));
   };
 
   return (
@@ -41,6 +50,19 @@ export const SurveyBlock = ({
             editMode={editMode}
           />
           <div className="flex-grow-1"></div>
+          {contentBreaksExist ? (
+            <div>
+              <input
+                type="checkbox"
+                defaultChecked={
+                  contentItem.hidePaginationControls !== undefined &&
+                  contentItem.hidePaginationControls
+                }
+                onChange={(v: any) => onEditPaginationDisplay(v)}
+              />
+              <label className="ml-2 mr-4">Hide pagination controls</label>
+            </div>
+          ) : null}
           <DeleteButton className="ml-2" editMode={editMode && canRemove} onClick={onRemove} />
         </div>
         <div>{children}</div>

--- a/assets/src/components/resource/editors/SurveyBlock.tsx
+++ b/assets/src/components/resource/editors/SurveyBlock.tsx
@@ -10,7 +10,6 @@ interface SurveyBlockProps {
   editMode: boolean;
   contentItem: SurveyContent;
   canRemove: boolean;
-  contentBreaksExist: boolean;
   onEdit: (item: SurveyContent) => void;
   onRemove: () => void;
 }
@@ -19,19 +18,11 @@ export const SurveyBlock = ({
   contentItem,
   canRemove,
   children,
-  contentBreaksExist,
   onEdit,
   onRemove,
 }: PropsWithChildren<SurveyBlockProps>) => {
   const onEditTitle = (title: string) => {
     onEdit(Object.assign(contentItem, { title }));
-  };
-  const onEditPaginationDisplay = (_e: any) => {
-    const hidePaginationControls =
-      contentItem.hidePaginationControls === undefined || !contentItem.hidePaginationControls
-        ? true
-        : false;
-    onEdit(Object.assign(contentItem, { hidePaginationControls }));
   };
 
   return (
@@ -50,19 +41,6 @@ export const SurveyBlock = ({
             editMode={editMode}
           />
           <div className="flex-grow-1"></div>
-          {contentBreaksExist ? (
-            <div>
-              <input
-                type="checkbox"
-                defaultChecked={
-                  contentItem.hidePaginationControls !== undefined &&
-                  contentItem.hidePaginationControls
-                }
-                onChange={(v: any) => onEditPaginationDisplay(v)}
-              />
-              <label className="ml-2 mr-4">Hide pagination controls</label>
-            </div>
-          ) : null}
           <DeleteButton className="ml-2" editMode={editMode && canRemove} onClick={onRemove} />
         </div>
         <div>{children}</div>

--- a/assets/src/components/resource/editors/SurveyEditor.tsx
+++ b/assets/src/components/resource/editors/SurveyEditor.tsx
@@ -40,10 +40,6 @@ export const SurveyEditor = ({
     onEdit(updatedContent);
   };
 
-  const contentBreaksExist = contentItem.children
-    .toArray()
-    .some((v: ResourceContent) => v.type === 'break');
-
   return (
     <SurveyBlock
       editMode={editMode}
@@ -51,7 +47,6 @@ export const SurveyEditor = ({
       canRemove={canRemove}
       onRemove={onRemove}
       onEdit={onEdit}
-      contentBreaksExist={contentBreaksExist}
     >
       {contentItem.children.map((c, childIndex) => {
         const onRemoveChild = () =>
@@ -88,7 +83,7 @@ export const SurveyEditor = ({
               editorMap,
               canRemove,
               featureFlags,
-              contentBreaksExist,
+              contentBreaksExist: false,
               onEdit: onEditChild,
               onEditActivity,
               onRemove: onRemoveChild,

--- a/assets/src/components/resource/editors/SurveyEditor.tsx
+++ b/assets/src/components/resource/editors/SurveyEditor.tsx
@@ -51,6 +51,7 @@ export const SurveyEditor = ({
       canRemove={canRemove}
       onRemove={onRemove}
       onEdit={onEdit}
+      contentBreaksExist={contentBreaksExist}
     >
       {contentItem.children.map((c, childIndex) => {
         const onRemoveChild = () =>

--- a/assets/src/components/resource/editors/SurveyEditor.tsx
+++ b/assets/src/components/resource/editors/SurveyEditor.tsx
@@ -40,6 +40,10 @@ export const SurveyEditor = ({
     onEdit(updatedContent);
   };
 
+  const contentBreaksExist = contentItem.children
+    .toArray()
+    .some((v: ResourceContent) => v.type === 'break');
+
   return (
     <SurveyBlock
       editMode={editMode}
@@ -83,6 +87,7 @@ export const SurveyEditor = ({
               editorMap,
               canRemove,
               featureFlags,
+              contentBreaksExist,
               onEdit: onEditChild,
               onEditActivity,
               onRemove: onRemoveChild,

--- a/assets/src/components/resource/editors/createEditor.tsx
+++ b/assets/src/components/resource/editors/createEditor.tsx
@@ -32,6 +32,7 @@ export type EditorProps = {
   allTags: Tag[];
   editorMap: ActivityEditorMap;
   featureFlags: FeatureFlags;
+  contentBreaksExist: boolean;
   onEdit: (content: ResourceContent) => void;
   onRemove: () => void;
   onEditActivity: (key: string, update: EditorUpdate) => void;

--- a/assets/src/data/activities/DeliveryState.ts
+++ b/assets/src/data/activities/DeliveryState.ts
@@ -120,6 +120,17 @@ export const activityDeliverySlice = createSlice({
       if (action.payload.actions.length > 0) {
         const { score, out_of } = calculateNewScore(action);
 
+        if (action.payload.actions[0].type === 'FeedbackAction') {
+          if (action.payload.actions[0].show_page !== null) {
+            const forId = state.attemptState.groupId as string;
+            const index = action.payload.actions[0].show_page;
+            Events.dispatch(
+              Events.Registry.ShowContentPage,
+              Events.makeShowContentPage({ forId, index }),
+            );
+          }
+        }
+
         state.attemptState = {
           ...state.attemptState,
           score,

--- a/assets/src/data/activities/DeliveryState.ts
+++ b/assets/src/data/activities/DeliveryState.ts
@@ -17,12 +17,11 @@ import {
   Success,
   FileMetaData,
 } from 'components/activities/types';
-import { SurveyEventDetails } from 'components/misc/SurveyControls';
+import * as Events from 'data/events';
 import { studentInputToString } from 'data/activities/utils';
 import { WritableDraft } from 'immer/dist/internal';
 import { ActivityModelSchema } from 'components/activities/types';
 import { Maybe } from 'tsmonad';
-import { isObjectBindingPattern } from 'typescript';
 
 export type AppThunk<ReturnType = void> = ThunkAction<
   ReturnType,
@@ -447,7 +446,8 @@ export const listenForParentSurveySubmit = (
 ) =>
   Maybe.maybe(surveyId).lift((surveyId) =>
     // listen for survey submit events if the delivery element is in a survey
-    document.addEventListener('oli-survey-submit', (e: CustomEvent<SurveyEventDetails>) => {
+
+    document.addEventListener(Events.Registry.SurveySubmit, (e) => {
       // check if this activity belongs to the survey being submitted
       if (e.detail.id === surveyId) {
         dispatch(submit(onSubmitActivity));
@@ -463,7 +463,7 @@ export const listenForParentSurveyReset = (
 ) =>
   Maybe.maybe(surveyId).lift((surveyId) =>
     // listen for survey submit events if the delivery element is in a survey
-    document.addEventListener('oli-survey-reset', (e: CustomEvent<SurveyEventDetails>) => {
+    document.addEventListener(Events.Registry.SurveySubmit, (e) => {
       // check if this activity belongs to the survey being reset
       if (e.detail.id === surveyId) {
         dispatch(resetAction(onResetActivity, partInputs));

--- a/assets/src/data/activities/DeliveryState.ts
+++ b/assets/src/data/activities/DeliveryState.ts
@@ -124,19 +124,25 @@ export const activityDeliverySlice = createSlice({
         const { score, out_of } = calculateNewScore(action);
 
         if (action.payload.actions[0].type === 'FeedbackAction') {
-          if (action.payload.actions[0].show_page !== null) {
+          const toShow: number[] = action.payload.actions
+            .filter((a: FeedbackAction) => a.show_page !== null)
+            .map((a: FeedbackAction) => a.show_page) as number[];
+
+          if (toShow.length > 0) {
             const forId = state.attemptState.groupId as string;
-            const index = action.payload.actions[0].show_page;
-            Events.dispatch(
-              Events.Registry.ShowContentPage,
-              Events.makeShowContentPage({ forId, index }),
+
+            toShow.forEach((index: number) =>
+              Events.dispatch(
+                Events.Registry.ShowContentPage,
+                Events.makeShowContentPage({ forId, index }),
+              ),
             );
 
             updatePaginationState(
               state.activityContext.sectionSlug,
               state.activityContext.pageAttemptGuid,
               forId,
-              index,
+              toShow,
             );
           }
         }

--- a/assets/src/data/activities/DeliveryState.ts
+++ b/assets/src/data/activities/DeliveryState.ts
@@ -4,6 +4,7 @@ import {
   RequestHintResponse,
   ResetActivityResponse,
   PartActivityResponse,
+  ActivityContext,
 } from 'components/activities/DeliveryElement';
 import {
   ActivityState,
@@ -35,8 +36,7 @@ export type PartInputs = Record<PartId, StudentInput>;
 
 export interface ActivityDeliveryState {
   model: ActivityModelSchema;
-  sectionSlug: string;
-  pageAttemptGuid: string;
+  activityContext: ActivityContext;
   attemptState: ActivityState;
   partState: Record<
     PartId,
@@ -132,7 +132,12 @@ export const activityDeliverySlice = createSlice({
               Events.makeShowContentPage({ forId, index }),
             );
 
-            updatePaginationState(state.sectionSlug, state.pageAttemptGuid, forId, index);
+            updatePaginationState(
+              state.activityContext.sectionSlug,
+              state.activityContext.pageAttemptGuid,
+              forId,
+              index,
+            );
           }
         }
 
@@ -233,8 +238,8 @@ export const activityDeliverySlice = createSlice({
     updateModel(state, action: PayloadAction<ActivityModelSchema>) {
       state.model = action.payload;
     },
-    updateSectionSlug(state, action: PayloadAction<string>) {
-      state.sectionSlug = action.payload;
+    updateActivityContext(state, action: PayloadAction<ActivityContext>) {
+      state.activityContext = action.payload;
     },
     hideHintsForPart(state, action: PayloadAction<PartId>) {
       Maybe.maybe(state.partState[action.payload]).lift((partState) => (partState.hintsShown = []));
@@ -402,12 +407,12 @@ export const initializeState =
     state: ActivityState,
     initialPartInputs: PartInputs,
     model: ActivityModelSchema,
-    sectionSlug: string | undefined,
+    activityContext: ActivityContext,
   ): AppThunk =>
   async (dispatch, _getState) => {
     dispatch(slice.actions.initializePartState(state));
     dispatch(slice.actions.updateModel(model));
-    dispatch(slice.actions.updateSectionSlug(sectionSlug as string));
+    dispatch(slice.actions.updateActivityContext(activityContext));
     state.parts.forEach((partState) => {
       dispatch(
         slice.actions.setHintsShownForPart({
@@ -462,7 +467,7 @@ export const setSelection =
   };
 
 export const listenForParentSurveySubmit = (
-  surveyId: string | undefined,
+  surveyId: string | null,
   dispatch: Dispatch<any>,
   onSubmitActivity: (
     attemptGuid: string,
@@ -481,7 +486,7 @@ export const listenForParentSurveySubmit = (
   );
 
 export const listenForParentSurveyReset = (
-  surveyId: string | undefined,
+  surveyId: string | null,
   dispatch: Dispatch<any>,
   onResetActivity: (attemptGuid: string) => Promise<ResetActivityResponse>,
   partInputs?: PartInputs,

--- a/assets/src/data/activities/utils.ts
+++ b/assets/src/data/activities/utils.ts
@@ -115,5 +115,6 @@ export const defaultActivityState = (model: ActivityModelSchema): ActivityState 
     hasMoreAttempts: true,
     parts,
     hasMoreHints: false,
+    groupId: null,
   };
 };

--- a/assets/src/data/content/resource.ts
+++ b/assets/src/data/content/resource.ts
@@ -204,12 +204,14 @@ export interface ActivityReference {
 
 export type GroupLayout = 'vertical' | 'deck';
 
+export type PaginationMode = 'normal' | 'manualReveal' | 'automatedReveal';
+
 export interface GroupContent {
   type: 'group';
   id: string;
   layout: GroupLayout; // TODO define layout types
   purpose: string;
-  hidePaginationControls?: boolean;
+  paginationMode?: PaginationMode;
   children: Immutable.List<ResourceContent>;
 }
 
@@ -217,7 +219,6 @@ export interface SurveyContent {
   type: 'survey';
   id: string;
   title: string | undefined;
-  hidePaginationControls?: boolean;
   children: Immutable.List<ResourceContent>;
 }
 

--- a/assets/src/data/content/resource.ts
+++ b/assets/src/data/content/resource.ts
@@ -155,7 +155,7 @@ export const createGroup = (
   id: guid(),
   children,
   layout: 'vertical',
-  purpose: 'none',
+  purpose: 'didigetthis',
 });
 
 export const createSurvey = (

--- a/assets/src/data/content/resource.ts
+++ b/assets/src/data/content/resource.ts
@@ -209,6 +209,7 @@ export interface GroupContent {
   id: string;
   layout: GroupLayout; // TODO define layout types
   purpose: string;
+  hidePaginationControls?: boolean;
   children: Immutable.List<ResourceContent>;
 }
 
@@ -216,6 +217,7 @@ export interface SurveyContent {
   type: 'survey';
   id: string;
   title: string | undefined;
+  hidePaginationControls?: boolean;
   children: Immutable.List<ResourceContent>;
 }
 

--- a/assets/src/data/events.ts
+++ b/assets/src/data/events.ts
@@ -1,0 +1,35 @@
+export interface SurveyDetails {
+  id: string;
+}
+
+export interface TorusEventMap {
+  'oli-survey-submit': CustomEvent<SurveyDetails>;
+  'oli-survey-reset': CustomEvent<SurveyDetails>;
+}
+
+export enum Registry {
+  SurveySubmit = 'oli-survey-submit',
+  SurveyReset = 'oli-survey-reset',
+}
+
+export function makeSurveySubmitEvent(detail: SurveyDetails) {
+  return new CustomEvent(Registry.SurveySubmit, { detail });
+}
+
+export function makeSurveyResetEvent(detail: SurveyDetails) {
+  return new CustomEvent(Registry.SurveyReset, { detail });
+}
+
+declare global {
+  interface Document {
+    //adds definition to Document, but you can do the same with HTMLElement
+    addEventListener<K extends keyof TorusEventMap>(
+      type: K,
+      listener: (this: Document, ev: TorusEventMap[K]) => void,
+    ): void;
+  }
+}
+
+export function dispatch<K extends keyof TorusEventMap>(kind: Registry, event: TorusEventMap[K]) {
+  return document.dispatchEvent(event);
+}

--- a/assets/src/data/events.ts
+++ b/assets/src/data/events.ts
@@ -2,14 +2,21 @@ export interface SurveyDetails {
   id: string;
 }
 
+export interface ShowContentPage {
+  forId: string;
+  index: number;
+}
+
 export interface TorusEventMap {
   'oli-survey-submit': CustomEvent<SurveyDetails>;
   'oli-survey-reset': CustomEvent<SurveyDetails>;
+  'oli-show-content-page': CustomEvent<ShowContentPage>;
 }
 
 export enum Registry {
   SurveySubmit = 'oli-survey-submit',
   SurveyReset = 'oli-survey-reset',
+  ShowContentPage = 'oli-show-content-page',
 }
 
 export function makeSurveySubmitEvent(detail: SurveyDetails) {
@@ -18,6 +25,10 @@ export function makeSurveySubmitEvent(detail: SurveyDetails) {
 
 export function makeSurveyResetEvent(detail: SurveyDetails) {
   return new CustomEvent(Registry.SurveyReset, { detail });
+}
+
+export function makeShowContentPage(detail: ShowContentPage) {
+  return new CustomEvent(Registry.ShowContentPage, { detail });
 }
 
 declare global {

--- a/assets/src/data/persistence/extrinsic.ts
+++ b/assets/src/data/persistence/extrinsic.ts
@@ -157,6 +157,34 @@ export function upsertSection(slug: SectionSlug, keyValues: KeyValues) {
   return makeRequest<ExtrinsicDelete>(params);
 }
 
+export function readAttempt(slug: SectionSlug, attemptGuid: string, keys: string[] | null = null) {
+  const params = {
+    method: 'GET',
+    url: `/state/course/${slug}/resource_attempt/${attemptGuid}` + toKeyParams(keys),
+  };
+
+  return makeRequest<ExtrinsicRead>(params);
+}
+
+export function deleteAttempt(slug: SectionSlug, attemptGuid: string, keys: string[]) {
+  const params = {
+    method: 'DELETE',
+    url: `/state/course/${slug}/resource_attempt/${attemptGuid}` + toKeyParams(keys),
+  };
+
+  return makeRequest<ExtrinsicRead>(params);
+}
+
+export function upsertAttempt(slug: SectionSlug, attemptGuid: string, keyValues: KeyValues) {
+  const params = {
+    method: 'PUT',
+    body: JSON.stringify(keyValues),
+    url: `/state/course/${slug}/resource_attempt/${attemptGuid}`,
+  };
+
+  return makeRequest<ExtrinsicDelete>(params);
+}
+
 // Take a list of string key names and turn it into the form expected by
 // Phoenix: foo[]=bar&foo[]=baz&foo[]=qux.
 function toKeyParams(keys: string[] | null = null) {

--- a/assets/src/data/persistence/pagination.ts
+++ b/assets/src/data/persistence/pagination.ts
@@ -1,0 +1,47 @@
+import * as Extrinsic from './extrinsic';
+import { SectionSlug } from 'data/types';
+
+export function updatePaginationState(
+  slug: SectionSlug,
+  attemptGuid: string,
+  forId: string,
+  index: number,
+) {
+  // At the moment adding an entry to a list that is a value of a key is a multi step operation,
+  // that involves two server requests:
+  //
+  // 1. Fetch the key-value (server request 1)
+  // 2. Client-side append the value to the list (if the key even exists)
+  // 3. Upsert the new key-value (server request 2)
+  return new Promise((resolve, reject) => {
+    return Extrinsic.readAttempt(slug, attemptGuid, ['paginationState']).then((result: any) => {
+      console.log('here');
+      console.log(result);
+      if ((result as any).type !== undefined && (result as any).type === 'ServerError') {
+        reject(result);
+      } else {
+        let update: any = { paginationState: {} };
+        update.paginationState[forId + ''] = [0, index];
+
+        if (result['paginationState'] !== undefined) {
+          const existingValue = (result['paginationState'] as any)[forId + ''];
+          if (existingValue !== undefined) {
+            result.paginationState[forId + ''] = [...existingValue, index];
+            update = result;
+          } else {
+            result.paginationState[forId + ''] = [0, index];
+            update = result;
+          }
+        }
+
+        Extrinsic.upsertAttempt(slug, attemptGuid, update).then((result) => {
+          if ((result as any).type !== undefined && (result as any).type === 'ServerError') {
+            reject(result);
+          } else {
+            resolve(result);
+          }
+        });
+      }
+    });
+  });
+}

--- a/assets/src/data/persistence/pagination.ts
+++ b/assets/src/data/persistence/pagination.ts
@@ -5,7 +5,7 @@ export function updatePaginationState(
   slug: SectionSlug,
   attemptGuid: string,
   forId: string,
-  index: number,
+  index: number[],
 ) {
   // At the moment adding an entry to a list that is a value of a key is a multi step operation,
   // that involves two server requests:
@@ -15,21 +15,19 @@ export function updatePaginationState(
   // 3. Upsert the new key-value (server request 2)
   return new Promise((resolve, reject) => {
     return Extrinsic.readAttempt(slug, attemptGuid, ['paginationState']).then((result: any) => {
-      console.log('here');
-      console.log(result);
       if ((result as any).type !== undefined && (result as any).type === 'ServerError') {
         reject(result);
       } else {
         let update: any = { paginationState: {} };
-        update.paginationState[forId + ''] = [0, index];
+        update.paginationState[forId + ''] = [0, ...index];
 
         if (result['paginationState'] !== undefined) {
           const existingValue = (result['paginationState'] as any)[forId + ''];
           if (existingValue !== undefined) {
-            result.paginationState[forId + ''] = [...existingValue, index];
+            result.paginationState[forId + ''] = [...existingValue, ...index];
             update = result;
           } else {
-            result.paginationState[forId + ''] = [0, index];
+            result.paginationState[forId + ''] = [0, ...index];
             update = result;
           }
         }

--- a/assets/styles/authoring/controls.scss
+++ b/assets/styles/authoring/controls.scss
@@ -101,3 +101,7 @@
 .indented-list {
   padding-left: 2rem;
 }
+
+.tiny-icon {
+  font-size: 16px;
+}

--- a/assets/test/activities/redux_delivery_test.ts
+++ b/assets/test/activities/redux_delivery_test.ts
@@ -13,23 +13,33 @@ import {
   studentInputToString,
 } from 'data/activities/utils';
 import { DEFAULT_PART_ID } from 'components/activities/common/utils';
+import { ActivityContext } from 'components/activities';
 
 describe('activity delivery state management', () => {
   const model = defaultCATAModel();
   model.authoring.parts[0].hints.push(makeHint('Hint 1'));
+  const context = {
+    graded: false,
+    surveyId: null,
+    groupId: null,
+    bibParams: [],
+    pageAttemptGuid: '',
+    sectionSlug: '',
+    userId: 0,
+  } as ActivityContext;
   const props = {
     model,
     activitySlug: 'activity-slug',
     state: Object.assign(defaultActivityState(model), { hasMoreHints: false }),
-    graded: false,
-    preview: false,
+    context,
   };
+
   const { onSaveActivity } = defaultDeliveryElementProps;
   const store: Store<ActivityDeliveryState> = configureStore({}, activityDeliverySlice.reducer);
   const dispatch: Dispatch<any> = store.dispatch;
 
   it('can initialize state', () => {
-    dispatch(initializeState(props.state, initialPartInputs(props.state), model));
+    dispatch(initializeState(props.state, initialPartInputs(props.state), model, context));
     expect(store.getState().attemptState).toEqual(props.state);
     const partState = store.getState().partState[DEFAULT_PART_ID];
     expect(partState).toBeTruthy();
@@ -39,7 +49,7 @@ describe('activity delivery state management', () => {
   });
 
   it('can select single choices', () => {
-    dispatch(initializeState(props.state, initialPartInputs(props.state), model));
+    dispatch(initializeState(props.state, initialPartInputs(props.state), model, context));
     dispatch(setSelection(DEFAULT_PART_ID, model.choices[0].id, onSaveActivity, 'single'));
     expect(store.getState().partState[DEFAULT_PART_ID]?.studentInput).toEqual([
       model.choices[0].id,
@@ -47,7 +57,7 @@ describe('activity delivery state management', () => {
   });
 
   it('can select multiple choices', () => {
-    dispatch(initializeState(props.state, initialPartInputs(props.state), model));
+    dispatch(initializeState(props.state, initialPartInputs(props.state), model, context));
     dispatch(setSelection(DEFAULT_PART_ID, model.choices[0].id, onSaveActivity, 'multiple'));
     dispatch(setSelection(DEFAULT_PART_ID, model.choices[1].id, onSaveActivity, 'multiple'));
     expect(store.getState().partState[DEFAULT_PART_ID]?.studentInput).toEqual([

--- a/assets/test/check_all_that_apply/cata_delivery_test.tsx
+++ b/assets/test/check_all_that_apply/cata_delivery_test.tsx
@@ -20,7 +20,15 @@ describe('check all that apply delivery', () => {
       model,
       activitySlug: 'activity-slug',
       state: Object.assign(defaultActivityState(model), { hasMoreHints: false }),
-      graded: false,
+      context: {
+        graded: false,
+        surveyId: null,
+        groupId: null,
+        userId: 0,
+        pageAttemptGuid: '',
+        sectionSlug: '',
+        bibParams: [],
+      },
       preview: false,
     };
     const { onSaveActivity, onSubmitActivity } = defaultDeliveryElementProps;

--- a/assets/test/data/editor/PageEditorContent_test.ts
+++ b/assets/test/data/editor/PageEditorContent_test.ts
@@ -258,7 +258,7 @@ describe('PageEditorContent', () => {
           ],
           id: expect.any(String),
           layout: 'vertical',
-          purpose: 'none',
+          purpose: 'didigetthis',
           type: 'group',
         },
       ],

--- a/assets/test/data/editor/PageEditorContent_test.ts
+++ b/assets/test/data/editor/PageEditorContent_test.ts
@@ -336,7 +336,7 @@ describe('PageEditorContent', () => {
           ],
           id: guid(),
           layout: 'vertical',
-          purpose: 'none',
+          purpose: 'didigetthis',
           type: 'group',
         },
       ],

--- a/assets/test/multiple_choice/mc_delivery_test.tsx
+++ b/assets/test/multiple_choice/mc_delivery_test.tsx
@@ -21,6 +21,15 @@ describe('multiple choice delivery', () => {
       model,
       activitySlug: 'activity-slug',
       state: Object.assign(defaultActivityState(model), { hasMoreHints: false }),
+      context: {
+        graded: false,
+        surveyId: null,
+        groupId: null,
+        userId: 0,
+        pageAttemptGuid: '',
+        sectionSlug: '',
+        bibParams: [],
+      },
       graded: false,
       preview: false,
     };

--- a/assets/test/ordering/ordering_delivery_test.tsx
+++ b/assets/test/ordering/ordering_delivery_test.tsx
@@ -20,7 +20,15 @@ describe('ordering delivery', () => {
       model,
       activitySlug: 'activity-slug',
       state: Object.assign(defaultActivityState(model), { hasMoreHints: false }),
-      graded: false,
+      context: {
+        graded: false,
+        surveyId: null,
+        groupId: null,
+        userId: 0,
+        pageAttemptGuid: '',
+        sectionSlug: '',
+        bibParams: [],
+      },
       preview: false,
     };
     const { onSubmitActivity } = defaultDeliveryElementProps;

--- a/assets/test/short_answer/short_answer_delivery_test.tsx
+++ b/assets/test/short_answer/short_answer_delivery_test.tsx
@@ -20,7 +20,15 @@ describe('multiple choice delivery', () => {
       model,
       activitySlug: 'activity-slug',
       state: Object.assign(defaultActivityState(model), { hasMoreHints: false }),
-      graded: false,
+      context: {
+        graded: false,
+        surveyId: null,
+        groupId: null,
+        userId: 0,
+        pageAttemptGuid: '',
+        sectionSlug: '',
+        bibParams: [],
+      },
       preview: false,
     };
     const { onSaveActivity, onSubmitActivity } = defaultDeliveryElementProps;

--- a/assets/test/utils/activity_mocks.ts
+++ b/assets/test/utils/activity_mocks.ts
@@ -35,6 +35,7 @@ export const attemptState: ActivityState = {
   hasMoreAttempts: true,
   hasMoreHints: true,
   groupId: null,
+  pageAttemptGuid: 'guid',
 };
 
 const feedbackAction: Action = {

--- a/assets/test/utils/activity_mocks.ts
+++ b/assets/test/utils/activity_mocks.ts
@@ -35,7 +35,6 @@ export const attemptState: ActivityState = {
   hasMoreAttempts: true,
   hasMoreHints: true,
   groupId: null,
-  pageAttemptGuid: 'guid',
 };
 
 const feedbackAction: Action = {
@@ -86,6 +85,7 @@ export const defaultAuthoringElementProps = <T>(initialModel: T): AuthoringEleme
   const model = initialModel;
   return {
     projectSlug: '',
+    authoringContext: { contentBreaksExist: false },
     editMode: true,
     model,
     onPostUndoable: jest.fn(),

--- a/assets/test/utils/activity_mocks.ts
+++ b/assets/test/utils/activity_mocks.ts
@@ -34,6 +34,7 @@ export const attemptState: ActivityState = {
   parts: [partState],
   hasMoreAttempts: true,
   hasMoreHints: true,
+  groupId: null,
 };
 
 const feedbackAction: Action = {
@@ -42,6 +43,7 @@ const feedbackAction: Action = {
   part_id: '1',
   out_of: 1,
   score: 1,
+  show_page: null,
   feedback: makeFeedback('correct feedback'),
 };
 

--- a/lib/oli/activities/model/response.ex
+++ b/lib/oli/activities/model/response.ex
@@ -1,7 +1,7 @@
 defmodule Oli.Activities.Model.Response do
-  defstruct [:id, :rule, :score, :feedback]
+  defstruct [:id, :rule, :score, :feedback, :show_page]
 
-  def parse(%{"id" => id, "rule" => rule, "score" => score, "feedback" => feedback}) do
+  def parse(%{"id" => id, "rule" => rule, "score" => score, "feedback" => feedback} = response) do
     case Oli.Activities.Model.Feedback.parse(feedback) do
       {:ok, feedback} ->
         {:ok,
@@ -9,7 +9,8 @@ defmodule Oli.Activities.Model.Response do
            id: id,
            rule: rule,
            score: score,
-           feedback: feedback
+           feedback: feedback,
+           show_page: Map.get(response, "showPage", nil)
          }}
 
       error ->

--- a/lib/oli/activities/state/activity_state.ex
+++ b/lib/oli/activities/state/activity_state.ex
@@ -36,7 +36,11 @@ defmodule Oli.Activities.State.ActivityState do
           Oli.Activities.Model.t()
         ) ::
           %Oli.Activities.State.ActivityState{}
-  def from_attempt(%ActivityAttempt{} = attempt, part_attempts, %Model{} = model) do
+  def from_attempt(
+        %ActivityAttempt{} = attempt,
+        part_attempts,
+        %Model{} = model
+      ) do
     # Create the part states, and where we encounter parts from the model
     # that do not have an attempt we create the default state
     attempt_map = Enum.reduce(part_attempts, %{}, fn p, m -> Map.put(m, p.part_id, p) end)

--- a/lib/oli/activities/state/activity_state.ex
+++ b/lib/oli/activities/state/activity_state.ex
@@ -70,7 +70,7 @@ defmodule Oli.Activities.State.ActivityState do
     }
   end
 
-  def create_preview_state(transformed_model) do
+  def create_preview_state(transformed_model, group_id \\ nil) do
     %Oli.Activities.State.ActivityState{
       attemptGuid: UUID.uuid4(),
       attemptNumber: 1,
@@ -80,7 +80,7 @@ defmodule Oli.Activities.State.ActivityState do
       score: nil,
       outOf: nil,
       hasMoreAttempts: true,
-      groupId: nil,
+      groupId: group_id,
       parts:
         Enum.map(transformed_model["authoring"]["parts"], fn p ->
           %Oli.Activities.State.PartState{

--- a/lib/oli/activities/state/activity_state.ex
+++ b/lib/oli/activities/state/activity_state.ex
@@ -12,7 +12,8 @@ defmodule Oli.Activities.State.ActivityState do
     :score,
     :outOf,
     :hasMoreAttempts,
-    :parts
+    :parts,
+    :groupId
   ]
 
   @derive Jason.Encoder
@@ -25,7 +26,8 @@ defmodule Oli.Activities.State.ActivityState do
     :score,
     :outOf,
     :hasMoreAttempts,
-    :parts
+    :parts,
+    :groupId
   ]
 
   @spec from_attempt(
@@ -59,7 +61,8 @@ defmodule Oli.Activities.State.ActivityState do
       score: attempt.score,
       outOf: attempt.out_of,
       hasMoreAttempts: has_more_attempts,
-      parts: parts
+      parts: parts,
+      groupId: attempt.group_id
     }
   end
 
@@ -73,6 +76,7 @@ defmodule Oli.Activities.State.ActivityState do
       score: nil,
       outOf: nil,
       hasMoreAttempts: true,
+      groupId: nil,
       parts:
         Enum.map(transformed_model["authoring"]["parts"], fn p ->
           %Oli.Activities.State.PartState{

--- a/lib/oli/authoring/editing/page_editor.ex
+++ b/lib/oli/authoring/editing/page_editor.ex
@@ -316,6 +316,10 @@ defmodule Oli.Authoring.Editing.PageEditor do
       end)
       |> Enum.map(fn %{"activity_id" => id} -> id end)
 
+    # Get a mapping of the activities to their parent groups. We need to set this
+    # correctly so that client-side pagination automation works
+    group_mapping = Oli.Resources.PageContent.activity_parent_groups(content)
+
     if length(found_activities) != 0 do
       # get a view of all current registered activity types
       registrations = Activities.list_activity_registrations()
@@ -351,7 +355,11 @@ defmodule Oli.Authoring.Editing.PageEditor do
          # the activity type this revision pertains to
          type = Map.get(reg_map, activity_type_id)
 
-         state = ActivityState.create_preview_state(transformed)
+         state =
+           ActivityState.create_preview_state(
+             transformed,
+             Map.get(group_mapping, resource_id).group
+           )
 
          %ActivitySummary{
            id: resource_id,

--- a/lib/oli/delivery/attempts/activity_lifecycle.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle.ex
@@ -137,6 +137,7 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle do
                    attempt_number: attempt_count + 1,
                    transformed_model: model_to_store,
                    resource_id: activity_attempt.resource_id,
+                   group_id: activity_attempt.group_id,
                    revision_id: revision.id,
                    resource_attempt_id: activity_attempt.resource_attempt_id
                  }) do

--- a/lib/oli/delivery/evaluation/actions/feedback_action.ex
+++ b/lib/oli/delivery/evaluation/actions/feedback_action.ex
@@ -1,4 +1,4 @@
 defmodule Oli.Delivery.Evaluation.Actions.FeedbackAction do
   @derive Jason.Encoder
-  defstruct [:type, :score, :out_of, :feedback, :error, :attempt_guid, :part_id]
+  defstruct [:type, :score, :out_of, :feedback, :error, :attempt_guid, :part_id, :show_page]
 end

--- a/lib/oli/delivery/evaluation/evaluator.ex
+++ b/lib/oli/delivery/evaluation/evaluator.ex
@@ -22,7 +22,7 @@ defmodule Oli.Delivery.Evaluation.Evaluator do
 
   def evaluate(%Part{} = part, %EvaluationContext{} = context) do
     case Enum.reduce(part.responses, {context, nil, 0, 0}, &consider_response/2) do
-      {_, %Response{feedback: feedback, score: score}, _, out_of} ->
+      {_, %Response{feedback: feedback, score: score, show_page: show_page}, _, out_of} ->
         {:ok,
          %FeedbackAction{
            type: "FeedbackAction",
@@ -31,6 +31,7 @@ defmodule Oli.Delivery.Evaluation.Evaluator do
            feedback: feedback,
            attempt_guid: context.part_attempt_guid,
            error: nil,
+           show_page: show_page,
            part_id: part.id
          }}
 
@@ -54,6 +55,7 @@ defmodule Oli.Delivery.Evaluation.Evaluator do
            feedback: ParseUtils.default_content_item("Incorrect"),
            attempt_guid: context.part_attempt_guid,
            error: nil,
+           show_page: nil,
            part_id: part.id
          }}
 

--- a/lib/oli/rendering/activity/html.ex
+++ b/lib/oli/rendering/activity/html.ex
@@ -3,7 +3,6 @@ defmodule Oli.Rendering.Activity.Html do
   Implements the Html writer for activity rendering
   """
   import Oli.Utils
-  import Oli.Rendering.Activity.Common
 
   alias Oli.Rendering.Context
   alias Oli.Rendering.Error

--- a/lib/oli/rendering/activity/html.ex
+++ b/lib/oli/rendering/activity/html.ex
@@ -83,7 +83,12 @@ defmodule Oli.Rendering.Activity.Html do
             surveyId: survey_id,
             groupId: group_id,
             bibParams: bib_params,
-            pageAttemptGuid: resource_attempt.attempt_guid
+            pageAttemptGuid:
+              if is_nil(resource_attempt) do
+                ""
+              else
+                resource_attempt.attempt_guid
+              end
           }
           |> Poison.encode!()
           |> HtmlEntities.encode()

--- a/lib/oli/rendering/activity/html.ex
+++ b/lib/oli/rendering/activity/html.ex
@@ -26,15 +26,12 @@ defmodule Oli.Rendering.Activity.Html do
         } = context,
         %{"activity_id" => activity_id} = activity
       ) do
-
     activity_summary = activity_map[activity_id]
 
     bib_params =
       Enum.reduce(bib_app_params, [], fn x, acc ->
         acc ++ [%{"id" => x.id, "ordinal" => x.ordinal, "slug" => x.slug, "title" => x.title}]
       end)
-
-    {:ok, bib_params_json} = Jason.encode(bib_params)
 
     case activity_summary do
       nil ->
@@ -63,28 +60,46 @@ defmodule Oli.Rendering.Activity.Html do
             _ -> delivery_element
           end
 
-        model_json = case tag do
-          "oli-adaptive-delivery" ->
-            page_model = Map.get(resource_attempt.content, "model")
-            get_flattened_activity_model(page_model, activity_id, activity_map)
+        model_json =
+          case tag do
+            "oli-adaptive-delivery" ->
+              page_model = Map.get(resource_attempt.content, "model")
+              get_flattened_activity_model(page_model, activity_id, activity_map)
 
-          _ -> model
-        end
+            _ ->
+              model
+          end
 
         section_slug = context.section_slug
 
         activity_html_id = get_activity_html_id(activity_id, model_json)
 
+        # See DeliveryElement.ts for a definition of the corresponding client-side type ActivityContext
+        activity_context =
+          %{
+            graded: graded,
+            userId: user.id,
+            sectionSlug: section_slug,
+            surveyId: survey_id,
+            groupId: group_id,
+            bibParams: bib_params,
+            pageAttemptGuid: resource_attempt.attempt_guid
+          }
+          |> Poison.encode!()
+          |> HtmlEntities.encode()
+
         activity_html =
           case mode do
             :instructor_preview ->
+              {:ok, bib_params_json} = Jason.encode(bib_params)
+
               [
-                ~s|<#{tag} activity_id=\"#{activity_html_id}\" model="#{model_json}" editmode="false" projectSlug="#{section_slug}" bib_params="#{Base.encode64(bib_params_json)}" #{maybe_group_id(group_id)}#{maybe_survey_id(survey_id)}></#{tag}>\n|
+                ~s|<#{tag} activity_id=\"#{activity_html_id}\" model="#{model_json}" editmode="false" projectSlug="#{section_slug}" bib_params="#{Base.encode64(bib_params_json)}"></#{tag}>\n|
               ]
 
             _ ->
               [
-                ~s|<#{tag} activity_id=\"#{activity_html_id}\" class="activity-container" graded="#{graded}" state="#{state}" model="#{model_json}" mode="#{mode}" user_id="#{user.id}" section_slug="#{section_slug}" bib_params="#{Base.encode64(bib_params_json)}" #{maybe_group_id(group_id)}#{maybe_survey_id(survey_id)}></#{tag}>\n|
+                ~s|<#{tag} class="activity-container" state="#{state}" model="#{model_json}" mode="#{mode}"  context="#{activity_context}"></#{tag}>\n|
               ]
           end
 
@@ -118,8 +133,8 @@ defmodule Oli.Rendering.Activity.Html do
 
   defp get_activity_html_id(activity_id, model_json) do
     model_json
-    |> HtmlEntities.decode
-    |> Poison.decode!
+    |> HtmlEntities.decode()
+    |> Poison.decode!()
     |> Map.get("id", "activity_#{activity_id}")
   end
 
@@ -127,30 +142,39 @@ defmodule Oli.Rendering.Activity.Html do
     Logger.debug("get_flattened_activity_model: #{activity_id}")
 
     sequence_entries = page_content |> List.first(%{}) |> Map.get("children", [])
-    Logger.debug("sequence_entries: #{sequence_entries |> Jason.encode!}")
+    Logger.debug("sequence_entries: #{sequence_entries |> Jason.encode!()}")
 
     activity_lineage = get_activity_lineage(activity_id, sequence_entries)
-    Logger.debug("activity_lineage (#{Enum.count(activity_lineage)}): #{activity_lineage |> Jason.encode!}")
+
+    Logger.debug(
+      "activity_lineage (#{Enum.count(activity_lineage)}): #{activity_lineage |> Jason.encode!()}"
+    )
 
     # need to take each item from the lineage, get the model for it, and then
     # merge all partsLayout into the final model
-    activity_model = Enum.reduce(activity_lineage, %{}, fn lineage_entry, acc ->
-      lineage_entry_activity_id = Map.get(lineage_entry, "activity_id")
-      Logger.debug("lineage_entry_activity_id: #{lineage_entry_activity_id}")
+    activity_model =
+      Enum.reduce(activity_lineage, %{}, fn lineage_entry, acc ->
+        lineage_entry_activity_id = Map.get(lineage_entry, "activity_id")
+        Logger.debug("lineage_entry_activity_id: #{lineage_entry_activity_id}")
 
-      case activity_map[lineage_entry_activity_id] do
-        nil ->
-          Logger.error("Could not find activity summary for lineage_entry_activity_id: #{lineage_entry_activity_id}")
-          acc
-        lineage_summary ->
-          model = lineage_summary.model |> HtmlEntities.decode() |> Poison.decode!()
-          parts_layout = Map.get(model, "partsLayout", [])
-          current_parts_layout = Map.get(acc, "partsLayout", [])
+        case activity_map[lineage_entry_activity_id] do
+          nil ->
+            Logger.error(
+              "Could not find activity summary for lineage_entry_activity_id: #{lineage_entry_activity_id}"
+            )
 
-          Map.put(model, "partsLayout", Enum.concat(parts_layout, current_parts_layout))
-      end
-    end)
-    Logger.debug("activity_model AFTER REDUCE: #{activity_model |> Jason.encode!}")
+            acc
+
+          lineage_summary ->
+            model = lineage_summary.model |> HtmlEntities.decode() |> Poison.decode!()
+            parts_layout = Map.get(model, "partsLayout", [])
+            current_parts_layout = Map.get(acc, "partsLayout", [])
+
+            Map.put(model, "partsLayout", Enum.concat(parts_layout, current_parts_layout))
+        end
+      end)
+
+    Logger.debug("activity_model AFTER REDUCE: #{activity_model |> Jason.encode!()}")
 
     # the activity_model needs the "id" to be the "sequenceId" from the sequence_entry
     sequence_entry = List.last(activity_lineage)
@@ -160,7 +184,7 @@ defmodule Oli.Rendering.Activity.Html do
     activity_model = Map.put(activity_model, "id", activity_sequence_id)
 
     # finally it needs to be stringified again
-    activity_model |> Poison.encode! |> HtmlEntities.encode
+    activity_model |> Poison.encode!() |> HtmlEntities.encode()
   end
 
   defp get_activity_lineage(activity_id, entries) do
@@ -168,9 +192,13 @@ defmodule Oli.Rendering.Activity.Html do
     parent_sequence_id = entry |> Map.get("custom", %{}) |> Map.get("layerRef", nil)
 
     case parent_sequence_id do
-      nil -> [entry]
+      nil ->
+        [entry]
+
       _ ->
-        %{"activity_id" => parent_activity_id} = find_sequence_entry_by_sequence_id(parent_sequence_id, entries)
+        %{"activity_id" => parent_activity_id} =
+          find_sequence_entry_by_sequence_id(parent_sequence_id, entries)
+
         parent_lineage = get_activity_lineage(parent_activity_id, entries)
 
         List.insert_at(parent_lineage, -1, entry)
@@ -178,7 +206,10 @@ defmodule Oli.Rendering.Activity.Html do
   end
 
   defp find_sequence_entry_by_activity_id(activity_id, entries) do
-    entry = Enum.find(entries, fn %{"activity_id" => ref_activity_id} -> ref_activity_id == activity_id end)
+    entry =
+      Enum.find(entries, fn %{"activity_id" => ref_activity_id} ->
+        ref_activity_id == activity_id
+      end)
 
     case entry do
       nil -> Logger.error("Could not find sequence entry for activity_id: #{activity_id}")
@@ -187,7 +218,10 @@ defmodule Oli.Rendering.Activity.Html do
   end
 
   defp find_sequence_entry_by_sequence_id(sequence_id, entries) do
-    entry = Enum.find(entries, fn e -> e |> Map.get("custom", %{}) |> Map.get("sequenceId") == sequence_id end)
+    entry =
+      Enum.find(entries, fn e ->
+        e |> Map.get("custom", %{}) |> Map.get("sequenceId") == sequence_id
+      end)
 
     case entry do
       nil -> Logger.error("Could not find sequence entry for sequence_id: #{sequence_id}")

--- a/lib/oli/rendering/context.ex
+++ b/lib/oli/rendering/context.ex
@@ -18,7 +18,7 @@ defmodule Oli.Rendering.Context do
             resource_attempt: nil,
             group_id: nil,
             survey_id: nil,
-            hide_pagination_controls: false,
+            pagination_mode: "normal",
             bib_app_params: [],
             submitted_surveys: %{}
 end

--- a/lib/oli/rendering/context.ex
+++ b/lib/oli/rendering/context.ex
@@ -18,6 +18,7 @@ defmodule Oli.Rendering.Context do
             resource_attempt: nil,
             group_id: nil,
             survey_id: nil,
+            hide_pagination_controls: false,
             bib_app_params: [],
             submitted_surveys: %{}
 end

--- a/lib/oli/rendering/elements.ex
+++ b/lib/oli/rendering/elements.ex
@@ -14,7 +14,7 @@ defmodule Oli.Rendering.Elements do
   @callback survey(%Context{}, %{}) :: [any()]
   @callback break(%Context{}, %{}) :: [any()]
   @callback error(%Context{}, %{}, {Atom.t(), String.t(), String.t()}) :: [any()]
-  @callback paginate({[], Integer.t()}) :: [any()]
+  @callback paginate(%Context{}, {[], Integer.t()}) :: [any()]
 
   @doc """
   Renders an Oli page given a valid page model (list of page items).
@@ -56,7 +56,7 @@ defmodule Oli.Rendering.Elements do
              writer.error(context, element, {:unsupported, error_id, error_msg}), br_count}
       end
     end)
-    |> writer.paginate()
+    |> then(fn rendered -> writer.paginate(context, rendered) end)
   end
 
   # Renders an error message if the signature above does not match. Logging and rendering of errors

--- a/lib/oli/rendering/elements/html.ex
+++ b/lib/oli/rendering/elements/html.ex
@@ -40,7 +40,8 @@ defmodule Oli.Rendering.Elements.Html do
     if br_count > 0 do
       {:safe, pagination_controls} =
         ReactPhoenix.ClientSide.react_component("Components.PaginationControls", %{
-          forId: for_id(context)
+          forId: for_id(context),
+          hideControls: context.hide_pagination_controls
         })
 
       [

--- a/lib/oli/rendering/elements/html.ex
+++ b/lib/oli/rendering/elements/html.ex
@@ -36,10 +36,12 @@ defmodule Oli.Rendering.Elements.Html do
     Error.render(context, element, error, Error.Html)
   end
 
-  def paginate({rendered, br_count}) do
+  def paginate(%Context{} = context, {rendered, br_count}) do
     if br_count > 0 do
       {:safe, pagination_controls} =
-        ReactPhoenix.ClientSide.react_component("Components.PaginationControls")
+        ReactPhoenix.ClientSide.react_component("Components.PaginationControls", %{
+          forId: for_id(context)
+        })
 
       [
         ~s|<div class="paginated">|,
@@ -53,4 +55,8 @@ defmodule Oli.Rendering.Elements.Html do
       rendered
     end
   end
+
+  defp for_id(%Context{survey_id: nil, group_id: nil, page_id: id}), do: id
+  defp for_id(%Context{survey_id: nil, group_id: id}), do: id
+  defp for_id(%Context{survey_id: id}), do: id
 end

--- a/lib/oli/rendering/elements/html.ex
+++ b/lib/oli/rendering/elements/html.ex
@@ -38,15 +38,13 @@ defmodule Oli.Rendering.Elements.Html do
 
   def paginate(%Context{} = context, {rendered, br_count}) do
     if br_count > 0 do
-      IO.inspect(context.resource_attempt.state)
-
       {:safe, pagination_controls} =
         ReactPhoenix.ClientSide.react_component("Components.PaginationControls", %{
           forId: for_id(context),
           paginationMode: context.pagination_mode,
           sectionSlug: context.section_slug,
-          pageAttemptGuid: context.resource_attempt.attempt_guid,
-          initiallyVisible: extract_for(context.resource_attempt.state, for_id(context))
+          pageAttemptGuid: page_attempt_guid(context.resource_attempt),
+          initiallyVisible: extract_for(context.resource_attempt, for_id(context))
         })
 
       [
@@ -66,8 +64,19 @@ defmodule Oli.Rendering.Elements.Html do
   defp for_id(%Context{survey_id: nil, group_id: id}), do: id
   defp for_id(%Context{survey_id: id}), do: id
 
-  defp extract_for(state, id) do
-    Map.get(state, "paginationState", %{})
-    |> Map.get(id, [])
+  defp extract_for(nil, _), do: []
+
+  defp extract_for(resource_attempt, id) do
+    case resource_attempt.state do
+      nil ->
+        []
+
+      state ->
+        Map.get(state, "paginationState", %{})
+        |> Map.get(id, [])
+    end
   end
+
+  defp page_attempt_guid(nil), do: ""
+  defp page_attempt_guid(resource_attempt), do: resource_attempt.attempt_guid
 end

--- a/lib/oli/rendering/elements/html.ex
+++ b/lib/oli/rendering/elements/html.ex
@@ -38,10 +38,15 @@ defmodule Oli.Rendering.Elements.Html do
 
   def paginate(%Context{} = context, {rendered, br_count}) do
     if br_count > 0 do
+      IO.inspect(context.resource_attempt.state)
+
       {:safe, pagination_controls} =
         ReactPhoenix.ClientSide.react_component("Components.PaginationControls", %{
           forId: for_id(context),
-          paginationMode: context.pagination_mode
+          paginationMode: context.pagination_mode,
+          sectionSlug: context.section_slug,
+          pageAttemptGuid: context.resource_attempt.attempt_guid,
+          initiallyVisible: extract_for(context.resource_attempt.state, for_id(context))
         })
 
       [
@@ -60,4 +65,9 @@ defmodule Oli.Rendering.Elements.Html do
   defp for_id(%Context{survey_id: nil, group_id: nil, page_id: id}), do: id
   defp for_id(%Context{survey_id: nil, group_id: id}), do: id
   defp for_id(%Context{survey_id: id}), do: id
+
+  defp extract_for(state, id) do
+    Map.get(state, "paginationState", %{})
+    |> Map.get(id, [])
+  end
 end

--- a/lib/oli/rendering/elements/html.ex
+++ b/lib/oli/rendering/elements/html.ex
@@ -41,7 +41,7 @@ defmodule Oli.Rendering.Elements.Html do
       {:safe, pagination_controls} =
         ReactPhoenix.ClientSide.react_component("Components.PaginationControls", %{
           forId: for_id(context),
-          hideControls: context.hide_pagination_controls
+          paginationMode: context.pagination_mode
         })
 
       [

--- a/lib/oli/rendering/elements/plaintext.ex
+++ b/lib/oli/rendering/elements/plaintext.ex
@@ -36,5 +36,5 @@ defmodule Oli.Rendering.Elements.Plaintext do
     Error.render(context, element, error, Error.Plaintext)
   end
 
-  def paginate({rendered, _br_count}), do: rendered
+  def paginate(_id, {rendered, _br_count}), do: rendered
 end

--- a/lib/oli/rendering/group.ex
+++ b/lib/oli/rendering/group.ex
@@ -20,11 +20,11 @@ defmodule Oli.Rendering.Group do
         %{"type" => "group", "id" => id, "children" => children} = element,
         writer
       ) do
-    hide_pagination_controls = Map.get(element, "hidePaginationControls", false)
+    pagination_mode = Map.get(element, "paginationMode", "normal")
 
     next = fn ->
       writer.elements(
-        %Context{context | group_id: id, hide_pagination_controls: hide_pagination_controls},
+        %Context{context | group_id: id, pagination_mode: pagination_mode},
         children
       )
     end

--- a/lib/oli/rendering/group.ex
+++ b/lib/oli/rendering/group.ex
@@ -20,7 +20,14 @@ defmodule Oli.Rendering.Group do
         %{"type" => "group", "id" => id, "children" => children} = element,
         writer
       ) do
-    next = fn -> writer.elements(%Context{context | group_id: id}, children) end
+    hide_pagination_controls = Map.get(element, "hidePaginationControls", false)
+
+    next = fn ->
+      writer.elements(
+        %Context{context | group_id: id, hide_pagination_controls: hide_pagination_controls},
+        children
+      )
+    end
 
     writer.group(context, next, element)
   end

--- a/lib/oli/rendering/survey.ex
+++ b/lib/oli/rendering/survey.ex
@@ -20,11 +20,9 @@ defmodule Oli.Rendering.Survey do
         %{"type" => "survey", "id" => id, "children" => children} = element,
         writer
       ) do
-    hide_pagination_controls = Map.get(element, "hidePaginationControls", false)
-
     next = fn ->
       writer.elements(
-        %Context{context | survey_id: id, hide_pagination_controls: hide_pagination_controls},
+        %Context{context | survey_id: id, pagination_mode: "normal"},
         children
       )
     end

--- a/lib/oli/rendering/survey.ex
+++ b/lib/oli/rendering/survey.ex
@@ -20,7 +20,14 @@ defmodule Oli.Rendering.Survey do
         %{"type" => "survey", "id" => id, "children" => children} = element,
         writer
       ) do
-    next = fn -> writer.elements(%Context{context | survey_id: id}, children) end
+    hide_pagination_controls = Map.get(element, "hidePaginationControls", false)
+
+    next = fn ->
+      writer.elements(
+        %Context{context | survey_id: id, hide_pagination_controls: hide_pagination_controls},
+        children
+      )
+    end
 
     writer.survey(context, next, element)
   end

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -535,6 +535,7 @@ defmodule OliWeb.PageDeliveryController do
           user
         end,
       section_slug: section_slug,
+      resource_attempt: hd(context.resource_attempts),
       mode:
         if context.review_mode do
           :review

--- a/priv/schemas/v0-1-0/content-group.schema.json
+++ b/priv/schemas/v0-1-0/content-group.schema.json
@@ -14,8 +14,8 @@
     "layout": {
       "enum": ["vertical", "deck"]
     },
-    "hidePaginationControls": {
-      "type": "boolean"
+    "paginationMode": {
+      "enum": ["normal", "manualReveal", "automatedReveal"]
     },
     "purpose": {
       "$ref": "http://torus.oli.cmu.edu/schemas/v0-1-0/purpose-type.schema.json"

--- a/priv/schemas/v0-1-0/content-group.schema.json
+++ b/priv/schemas/v0-1-0/content-group.schema.json
@@ -9,16 +9,13 @@
       "const": "group"
     },
     "id": {
-      "type": [
-        "integer",
-        "string"
-      ]
+      "type": ["integer", "string"]
     },
     "layout": {
-      "enum": [
-        "vertical",
-        "deck"
-      ]
+      "enum": ["vertical", "deck"]
+    },
+    "hidePaginationControls": {
+      "type": "boolean"
     },
     "purpose": {
       "$ref": "http://torus.oli.cmu.edu/schemas/v0-1-0/purpose-type.schema.json"
@@ -27,10 +24,5 @@
       "$ref": "http://torus.oli.cmu.edu/schemas/v0-1-0/elements.schema.json"
     }
   },
-  "required": [
-    "type",
-    "layout",
-    "purpose",
-    "children"
-  ]
+  "required": ["type", "layout", "purpose", "children"]
 }

--- a/priv/schemas/v0-1-0/content-survey.schema.json
+++ b/priv/schemas/v0-1-0/content-survey.schema.json
@@ -9,21 +9,17 @@
       "const": "survey"
     },
     "id": {
-      "type": [
-        "integer",
-        "string"
-      ]
+      "type": ["integer", "string"]
     },
     "title": {
       "type": "string"
+    },
+    "hidePaginationControls": {
+      "type": "boolean"
     },
     "children": {
       "$ref": "http://torus.oli.cmu.edu/schemas/v0-1-0/elements.schema.json"
     }
   },
-  "required": [
-    "type",
-    "id",
-    "children"
-  ]
+  "required": ["type", "id", "children"]
 }

--- a/priv/schemas/v0-1-0/content-survey.schema.json
+++ b/priv/schemas/v0-1-0/content-survey.schema.json
@@ -14,9 +14,6 @@
     "title": {
       "type": "string"
     },
-    "hidePaginationControls": {
-      "type": "boolean"
-    },
     "children": {
       "$ref": "http://torus.oli.cmu.edu/schemas/v0-1-0/elements.schema.json"
     }

--- a/test/oli/rendering/activity/html_test.exs
+++ b/test/oli/rendering/activity/html_test.exs
@@ -48,7 +48,7 @@ defmodule Oli.Content.Activity.HtmlTest do
       rendered_html_string = Phoenix.HTML.raw(rendered_html) |> Phoenix.HTML.safe_to_string()
 
       assert rendered_html_string =~
-               ~s|<oli-multiple-choice-delivery activity_id=\"activity_1\" class="activity-container" graded="false" state="{ "active": true }" model="{ "choices": [ "A", "B", "C", "D" ], "feedback": [ "A", "B", "C", "D" ], "stem": ""}"|
+               ~s|<oli-multiple-choice-delivery class="activity-container" state="{ "active": true }" model="{ "choices": [ "A", "B", "C", "D" ], "feedback": [ "A", "B", "C", "D" ], "stem": ""}"|
     end
 
     test "renders malformed activity gracefully", %{author: author} do

--- a/test/oli/rendering/survey/html_test.exs
+++ b/test/oli/rendering/survey/html_test.exs
@@ -69,10 +69,10 @@ defmodule Oli.Content.Survey.HtmlTest do
                ~s|<div id="1855946510" class="survey"><div class="survey-label">Survey</div><div class="survey-content">|
 
       assert rendered_html_string =~
-               ~s|<p>Please complete the following survey:</p>\n<oli-multiple-choice-delivery activity_id=\"activity_1\" class="activity-container" graded="false" state="{ "active": true }" model="{ "choices": [ "A", "B", "C", "D" ], "feedback": [ "A", "B", "C", "D" ], "stem": ""}" mode="delivery"|
+               ~s|<p>Please complete the following survey:</p>\n<oli-multiple-choice-delivery class="activity-container" state="{ "active": true }" model="{ "choices": [ "A", "B", "C", "D" ], "feedback": [ "A", "B", "C", "D" ], "stem": ""}" mode="delivery"|
 
       assert rendered_html_string =~
-               ~s|survey_id="1855946510"></oli-multiple-choice-delivery>|
+               ~s|</oli-multiple-choice-delivery>|
 
       assert rendered_html_string =~
                ~s|<div data-react-class="Components.SurveyControls" data-react-props="{&quot;id&quot;:&quot;1855946510&quot;,&quot;isSubmitted&quot;:null}"></div>|


### PR DESCRIPTION
This PR adds the ability for an author to control how content breaks are paginated.  It also allows feedbacks within paginated activities to automate the "reveal" of other groups of content.  This combination of features realizes the legacy "Branching assessment" feature. 

Some of the key aspects of the changes here include:
1. Creation of a more strongly typed client-side "Eventing" subsystem.  This is used for the new `ShowPage` event and the previous events related to surveys. 
2. Three modes for paginated content: User controlled pagination (what existed before), user controlled 'reveal', and programmatic (aka 'automated') reveal where something else on the page sends a message to the pagination controls to trigger the reveal. 
3. Cleaned up the DeliveryElement webcomponent interface, adding a `context` required parameter that now contains the previous `graded`, `survey_id`, `group_id`, `user_id`, etc.  All attributes are now required as opposed to allowing `undefined`, replaced with the value of `null` for special meaning for group and survey.
4. UI changes to allow paginated groups to configure their pagination mode.
5. UI changes to allow activities within paginated groups to specify the automated reveal of another page. 
6. Server side changes to pass this `show_page` parameter back to the client upon evaluation, and client-side handling to dispatch this event.
7. Leverage the "page attempt" extrinsic state to preserve the state of reveal style paginated groups.  This allows a student to reveal items in a page, navigate away and return to the page with that state preserved. 

## To Test this out

1. Create a practice page.
2. In the page, create three groups.  Add content breaks and content to all three groups.
3. Verify that only after content breaks appear that the pagination mode UI appears.
4. Verify that only after content breaks appear that the Feedback option for automating page display appears.
5. Verify that if all content breaks are deleted the pagination mode and the automating page display options disappear.
6. Restore all breaks, set the pagination mode for each of the three groups to each of the three pagination modes.
7. In the one with "automated reveal" as the option, set feedbacks some some of the activities present in that group to reveal other page groups in that group. 
8. Publish and enter the course section as a student.  Verify that regular pagination works, manual reveal, and the automated reveal via feedbacks received works.
9. Change the page type to be "graded" then re-publish.  Access the page as a student as a graded page and verify that everything works *EXCEPT* there is no way to trigger the feedback received page display commands, since graded page activities are not evaluated until the entire page is submitted. 
10. Submit the entire page and verify in the "Review Attempt" mode that all questions are displayed and were scored. 


