### PR TITLE
[BUGFIX] fix an issue where content cant be removed

### DIFF
--- a/assets/src/components/resource/editors/Editors.tsx
+++ b/assets/src/components/resource/editors/Editors.tsx
@@ -67,7 +67,7 @@ export const Editors = (props: EditorsProps) => {
 
   const allObjectives = props.objectives.toArray();
   const allTags = props.allTags.toArray();
-  const canRemove = content.canDelete();
+  const canRemove = editMode;
 
   const editors = content.model.map((contentItem, index) => {
     const onEdit = (contentItem: ResourceContent) =>

--- a/assets/src/data/editor/PageEditorContent.ts
+++ b/assets/src/data/editor/PageEditorContent.ts
@@ -119,13 +119,6 @@ export class PageEditorContent extends Immutable.Record(defaultParams()) {
   }
 
   /**
-   * @returns true if an item can be deleted from the model
-   */
-  canDelete() {
-    return this.model.size > 1;
-  }
-
-  /**
    * @returns the first resource content item
    */
   first() {


### PR DESCRIPTION
Fixes an issue where content cant be removed if there is only one top level element. The editor appears to already be resilient to a model with zero items by automatically creating a single structured content element if no elements exist in the model. If all items are removed from a page, a user can still use the insertion menu to add something.

Closes #2810