### PR TITLE
[BUG FIX] Improve empty hint detection approach

### DIFF
--- a/lib/oli/activities/parse_utils.ex
+++ b/lib/oli/activities/parse_utils.ex
@@ -47,6 +47,9 @@ defmodule Oli.Activities.ParseUtils do
         case content do
           # :model -> former impl when selection was persisted
           # along with the model
+          %{"model" => model} ->
+            has_content?(model)
+
           %{model: model} ->
             has_content?(model)
 
@@ -88,7 +91,7 @@ defmodule Oli.Activities.ParseUtils do
       content: %{
         "model" => [
           %{"children" => [%{"text" => text}], "id" => uuid(), "type" => "p"}
-        ],
+        ]
       },
       id: uuid()
     }

--- a/test/oli/activities/parse_utils_test.exs
+++ b/test/oli/activities/parse_utils_test.exs
@@ -34,6 +34,18 @@ defmodule Oli.Activities.ParseUtilsTest do
              ])
   end
 
+  test "has_content?/1 correctly detects when there's no content in a string keyed model inside content" do
+    no_content = %{
+      content: %{
+        "model" => [
+          %{"children" => [%{"text" => ""}], "type" => "p"}
+        ]
+      }
+    }
+
+    refute ParseUtils.has_content?(no_content)
+  end
+
   test "has_content?/1 correctly detects when there's content" do
     has_content1 = %{
       content: %{


### PR DESCRIPTION
This PR makes the utility used to detect empty hints more robust. There was a case not detected where the item being considered had an atom-keyed `content` attribute but a string-keyed `model` attribute inside of it.  This case was being tripped by an ingested course. 

Without this fix I saw a handful of MCQs in this course that suggested a hint was available when there really weren't. 