### PR TITLE
[FEATURE] add parameters for objective ingest

### DIFF
--- a/assets/src/components/editing/elements/definition/DefinitionToolbar.tsx
+++ b/assets/src/components/editing/elements/definition/DefinitionToolbar.tsx
@@ -16,7 +16,7 @@ interface SettingsProps {
 
 export const DefinitionSettings = (props: SettingsProps) => {
   return (
-    <Toolbar context={props.commandContext} orientation="horizontal">
+    <Toolbar context={props.commandContext}>
       <Toolbar.Group>
         <SettingsButton
           editing={props.editing}

--- a/lib/oli/interop/ingest.ex
+++ b/lib/oli/interop/ingest.ex
@@ -726,12 +726,15 @@ defmodule Oli.Interop.Ingest do
         title -> title
       end
 
+    parameters = Map.get(objective, "parameters", nil)
+
     %{
       tags: transform_tags(objective, tag_map),
       title: title,
       content: %{},
       author_id: as_author.id,
       objectives: %{},
+      parameters: parameters,
       children:
         Map.get(objective, "objectives", [])
         |> Enum.map(fn id -> Map.get(objective_map, id).resource_id end),

--- a/lib/oli/resources.ex
+++ b/lib/oli/resources.ex
@@ -310,6 +310,7 @@ defmodule Oli.Resources do
           time_limit: previous_revision.time_limit,
           scope: previous_revision.scope,
           retake_mode: previous_revision.retake_mode,
+          parameters: previous_revision.parameters,
           tags: previous_revision.tags
         },
         convert_strings_to_atoms(attrs)

--- a/lib/oli/resources/revision.ex
+++ b/lib/oli/resources/revision.ex
@@ -46,6 +46,7 @@ defmodule Oli.Resources.Revision do
     field :time_limit, :integer, default: 0
     field :scope, Ecto.Enum, values: [:embedded, :banked], default: :embedded
     field :retake_mode, Ecto.Enum, values: [:normal, :targeted], default: :normal
+    field :parameters, :map
     belongs_to :scoring_strategy, Oli.Resources.ScoringStrategy
     belongs_to :activity_type, Oli.Activities.ActivityRegistration
     belongs_to :primary_resource, Oli.Resources.Resource
@@ -80,6 +81,7 @@ defmodule Oli.Resources.Revision do
       :time_limit,
       :scope,
       :retake_mode,
+      :parameters,
       :scoring_strategy_id,
       :activity_type_id
     ])

--- a/lib/oli_web/live/history/details.ex
+++ b/lib/oli_web/live/history/details.ex
@@ -7,7 +7,7 @@ defmodule OliWeb.RevisionHistory.Details do
 
   def render(assigns) do
     attrs =
-      ~w"slug deleted author_id previous_revision_id resource_type_id graded max_attempts time_limit scoring_strategy_id activity_type_id"
+      ~w"slug deleted author_id previous_revision_id resource_type_id graded max_attempts time_limit scoring_strategy_id activity_type_id parameters"
 
     ~F"""
     <div class="revision-details">

--- a/priv/repo/migrations/20220825105222_add_parameters.exs
+++ b/priv/repo/migrations/20220825105222_add_parameters.exs
@@ -1,0 +1,9 @@
+defmodule Oli.Repo.Migrations.AddParameters do
+  use Ecto.Migration
+
+  def change do
+    alter table(:revisions) do
+      add :parameters, :map
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a new `parameters` field to `Revision` - to allow storage of learning objective parameters (for both skill and objective quasi-subtypes).  This PR pairs nicely with https://github.com/Simon-Initiative/course-digest/pull/84