### PR TITLE
[ENHANCEMENT] Ignore retake mode when enabled for adaptive pages

### DIFF
--- a/lib/oli/delivery/attempts/page_lifecycle/hierarchy.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/hierarchy.ex
@@ -82,6 +82,11 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Hierarchy do
   defp construct_attempt_prototypes(%VisitContext{latest_resource_attempt: nil}), do: []
 
   defp construct_attempt_prototypes(%VisitContext{
+         page_revision: %Revision{content: %{"advancedDelivery" => true}}
+       }),
+       do: []
+
+  defp construct_attempt_prototypes(%VisitContext{
          latest_resource_attempt: latest_resource_attempt,
          page_revision: %Revision{retake_mode: :targeted} = page_revision
        }) do


### PR DESCRIPTION
Retake mode would likely break an adaptive page if enabled. This PR ignores retake mode when the page in question is an adaptive page. 