### PR TITLE
[BUG FIX] Prevent duplicate part ids in ingest, fix part mapping refresh

### DIFF
--- a/lib/oli/interop/ingest.ex
+++ b/lib/oli/interop/ingest.ex
@@ -613,6 +613,20 @@ defmodule Oli.Interop.Ingest do
     end
   end
 
+  # The part ids are valid when a unique string id is present for all parts.
+  defp has_valid_part_ids?(content) do
+    part_ids =
+      Map.get(content, "authoring", %{"parts" => []})
+      |> Map.get("parts", [])
+      |> Enum.map(fn p -> Map.get(p, "id") end)
+
+    ids = MapSet.new(part_ids)
+
+    # Presence of `nil` or a difference in size indicates either a part was missing an id
+    # or a part id was duplicated
+    !MapSet.member?(ids, nil) and MapSet.size(ids) == Enum.count(part_ids)
+  end
+
   defp create_activity(
          project,
          activity,
@@ -624,31 +638,35 @@ defmodule Oli.Interop.Ingest do
     with {:ok, %{"content" => content} = activity} <-
            maybe_migrate_resource_content(activity, :activity),
          :ok <- validate_json(activity, SchemaResolver.schema("activity.schema.json")) do
-      title =
-        case Map.get(activity, "title") do
-          nil -> Map.get(activity, "subType")
-          "" -> Map.get(activity, "subType")
-          title -> title
-        end
+      if has_valid_part_ids?(content) do
+        title =
+          case Map.get(activity, "title") do
+            nil -> Map.get(activity, "subType")
+            "" -> Map.get(activity, "subType")
+            title -> title
+          end
 
-      scope =
-        case Map.get(activity, "scope", "embedded") do
-          str when str in ~w(embedded banked) -> String.to_existing_atom(str)
-          _ -> :embedded
-        end
+        scope =
+          case Map.get(activity, "scope", "embedded") do
+            str when str in ~w(embedded banked) -> String.to_existing_atom(str)
+            _ -> :embedded
+          end
 
-      %{
-        scope: scope,
-        tags: transform_tags(activity, tag_map),
-        title: title,
-        content: content,
-        author_id: as_author.id,
-        objectives: process_activity_objectives(activity, objective_map),
-        resource_type_id: Oli.Resources.ResourceType.get_id_by_type("activity"),
-        activity_type_id: Map.get(registration_by_subtype, Map.get(activity, "subType")),
-        scoring_strategy_id: Oli.Resources.ScoringStrategy.get_id_by_type("average")
-      }
-      |> create_resource(project)
+        %{
+          scope: scope,
+          tags: transform_tags(activity, tag_map),
+          title: title,
+          content: content,
+          author_id: as_author.id,
+          objectives: process_activity_objectives(activity, objective_map),
+          resource_type_id: Oli.Resources.ResourceType.get_id_by_type("activity"),
+          activity_type_id: Map.get(registration_by_subtype, Map.get(activity, "subType")),
+          scoring_strategy_id: Oli.Resources.ScoringStrategy.get_id_by_type("average")
+        }
+        |> create_resource(project)
+      else
+        {:error, "Invalid part id in activity #{Map.get(activity, "id")}"}
+      end
     end
   end
 

--- a/priv/repo/migrations/20220829172419_fix_part_mapping_refresh.exs
+++ b/priv/repo/migrations/20220829172419_fix_part_mapping_refresh.exs
@@ -1,0 +1,132 @@
+defmodule Oli.Repo.Migrations.FixPartMappingRefresh do
+  use Ecto.Migration
+
+  def change do
+    flush()
+
+    drop_trigger()
+    drop_materialized_view()
+
+    user = get_current_db_user()
+    create_materialized_view(user)
+    create_trigger(user)
+    refresh_materialized_view()
+
+    flush()
+  end
+
+  def drop_materialized_view() do
+    execute """
+    DROP INDEX IF EXISTS part_id_revision_id;
+    """
+
+    execute """
+    DROP INDEX IF EXISTS revision_id_index;
+    """
+
+    execute """
+    DROP MATERIALIZED VIEW IF EXISTS public.part_mapping;
+    """
+  end
+
+  def create_materialized_view(user) do
+    execute """
+    CREATE MATERIALIZED VIEW IF NOT EXISTS public.part_mapping
+    TABLESPACE pg_default
+    AS
+    SELECT DISTINCT t.parts->>'id' as part_id, t.parts->>'gradingApproach' as grading_approach, t.revision_id as revision_id FROM (
+      SELECT jsonb_path_query(r.content, '$."authoring"."parts"[*]') as parts,
+        r.id as revision_id
+      FROM published_resources pr
+        LEFT JOIN publications p ON p.id = pr.publication_id
+        LEFT JOIN revisions r ON r.id = pr.revision_id
+      WHERE r.resource_type_id = 3 AND p.published IS NOT NULL) t
+    WITH DATA;
+    """
+
+    execute """
+    ALTER TABLE IF EXISTS public.part_mapping
+    OWNER TO #{user};
+    """
+
+    execute """
+    CREATE UNIQUE INDEX part_id_revision_id
+    ON public.part_mapping USING btree
+    (part_id COLLATE pg_catalog."default", revision_id)
+    TABLESPACE pg_default;
+    """
+
+    execute """
+    CREATE INDEX revision_id_index
+    ON public.part_mapping USING btree
+    (revision_id)
+    TABLESPACE pg_default;
+    """
+  end
+
+  def get_current_db_user() do
+    case System.get_env("DATABASE_URL", nil) do
+      nil -> "postgres"
+      url -> parse_user_from_db_url(url, "postgres")
+    end
+  end
+
+  def parse_user_from_db_url(url, default) do
+    case url do
+      "ecto://" <> rest ->
+        split = String.split(rest, ":")
+
+        case Enum.count(split) do
+          0 -> default
+          1 -> default
+          _ -> Enum.at(split, 0)
+        end
+
+      _ ->
+        default
+    end
+  end
+
+  def drop_trigger() do
+    execute """
+    DROP TRIGGER IF EXISTS published_resources_tr ON public.published_resources;
+    """
+
+    execute "DROP FUNCTION IF EXISTS public.refresh_part_mapping() CASCADE;"
+  end
+
+  def create_trigger(user) do
+    execute """
+    CREATE OR REPLACE FUNCTION public.refresh_part_mapping()
+        RETURNS trigger
+        LANGUAGE 'plpgsql'
+        COST 100
+        VOLATILE NOT LEAKPROOF
+    AS $BODY$
+    BEGIN
+        REFRESH MATERIALIZED VIEW CONCURRENTLY part_mapping;
+        RETURN NULL;
+    END;
+    $BODY$;
+    """
+
+    execute """
+    ALTER FUNCTION public.refresh_part_mapping()
+    OWNER TO #{user};
+    """
+
+    execute """
+    CREATE TRIGGER publications_tr
+        AFTER UPDATE OR DELETE
+        ON public.publications
+        FOR EACH STATEMENT
+        EXECUTE FUNCTION public.refresh_part_mapping();
+    """
+  end
+
+  def refresh_materialized_view() do
+    execute """
+    REFRESH MATERIALIZED VIEW part_mapping;
+    """
+  end
+end

--- a/priv/repo/migrations/20220829172419_fix_part_mapping_refresh.exs
+++ b/priv/repo/migrations/20220829172419_fix_part_mapping_refresh.exs
@@ -50,7 +50,14 @@ defmodule Oli.Repo.Migrations.FixPartMappingRefresh do
     """
 
     execute """
-    CREATE UNIQUE INDEX part_id_revision_id
+    CREATE UNIQUE INDEX part_id_revision_id_grading
+    ON public.part_mapping USING btree
+    (part_id COLLATE pg_catalog."default", revision_id, grading_approach)
+    TABLESPACE pg_default;
+    """
+
+    execute """
+    CREATE INDEX part_id_revision_id
     ON public.part_mapping USING btree
     (part_id COLLATE pg_catalog."default", revision_id)
     TABLESPACE pg_default;

--- a/test/oli/publishing/part_mapping_refresh_test.exs
+++ b/test/oli/publishing/part_mapping_refresh_test.exs
@@ -1,0 +1,151 @@
+defmodule Oli.Publishing.PartMappingRefreshTest do
+  use Oli.DataCase
+
+  alias Oli.Publishing.PartMappingRefreshWorker
+
+  describe "part mapping refresh" do
+    setup do
+      Seeder.base_project_with_resource2()
+    end
+
+    test "part mapping refresh works with well formed parts", %{
+      project: project,
+      publication: publication,
+      author: author
+    } do
+      good_parts = %{
+        "authoring" => %{
+          "parts" => [
+            %{"id" => "1", "gradingApproach" => "automatic"},
+            %{"id" => "2", "gradingApproach" => "manual"},
+            %{"id" => "3"}
+          ]
+        }
+      }
+
+      %{revision: revision} =
+        Seeder.create_activity(%{content: good_parts}, publication, project, author)
+
+      Oli.Publishing.update_publication(publication, %{published: DateTime.utc_now()})
+
+      PartMappingRefreshWorker.perform_now()
+
+      %{rows: rows, num_rows: 3} =
+        Ecto.Adapters.SQL.query!(
+          Oli.Repo,
+          "SELECT * FROM part_mapping",
+          []
+        )
+
+      entries =
+        Enum.reduce(rows, %{}, fn [_, approach, _] = row, m -> Map.put(m, approach, row) end)
+
+      assert Map.get(entries, "automatic") == ["1", "automatic", revision.id]
+      assert Map.get(entries, "manual") == ["2", "manual", revision.id]
+      assert Map.get(entries, nil) == ["3", nil, revision.id]
+    end
+
+    test "part mapping refresh works with duplicated part ids and distinct grading approaches", %{
+      project: project,
+      publication: publication,
+      author: author
+    } do
+      good_parts = %{
+        "authoring" => %{
+          "parts" => [
+            %{"id" => "1", "gradingApproach" => "automatic"},
+            %{"id" => "1", "gradingApproach" => "manual"},
+            %{"id" => "1"}
+          ]
+        }
+      }
+
+      %{revision: revision} =
+        Seeder.create_activity(%{content: good_parts}, publication, project, author)
+
+      Oli.Publishing.update_publication(publication, %{published: DateTime.utc_now()})
+
+      PartMappingRefreshWorker.perform_now()
+
+      %{rows: rows, num_rows: 3} =
+        Ecto.Adapters.SQL.query!(
+          Oli.Repo,
+          "SELECT * FROM part_mapping",
+          []
+        )
+
+      entries =
+        Enum.reduce(rows, %{}, fn [_, approach, _] = row, m -> Map.put(m, approach, row) end)
+
+      assert Map.get(entries, "manual") == ["1", "manual", revision.id]
+      assert Map.get(entries, "automatic") == ["1", "automatic", revision.id]
+      assert Map.get(entries, nil) == ["1", nil, revision.id]
+    end
+
+    test "part mapping refresh works with duplicated part ids and duplicated grading approaches",
+         %{
+           project: project,
+           publication: publication,
+           author: author
+         } do
+      good_parts = %{
+        "authoring" => %{
+          "parts" => [
+            %{"id" => "1", "gradingApproach" => "automatic"},
+            %{"id" => "1", "gradingApproach" => "automatic"},
+            %{"id" => "1", "gradingApproach" => "automatic"}
+          ]
+        }
+      }
+
+      %{revision: %{id: revision_id}} =
+        Seeder.create_activity(%{content: good_parts}, publication, project, author)
+
+      Oli.Publishing.update_publication(publication, %{published: DateTime.utc_now()})
+
+      PartMappingRefreshWorker.perform_now()
+
+      %{rows: rows, num_rows: 1} =
+        Ecto.Adapters.SQL.query!(
+          Oli.Repo,
+          "SELECT * FROM part_mapping",
+          []
+        )
+
+      assert [["1", "automatic", ^revision_id]] = rows
+    end
+
+    test "part mapping refresh works with missing part ids",
+         %{
+           project: project,
+           publication: publication,
+           author: author
+         } do
+      good_parts = %{
+        "authoring" => %{
+          "parts" => [
+            %{"gradingApproach" => "automatic"},
+            %{"gradingApproach" => "automatic"},
+            %{"gradingApproach" => "automatic"}
+          ]
+        }
+      }
+
+      %{revision: %{id: revision_id}} =
+        Seeder.create_activity(%{content: good_parts}, publication, project, author)
+
+      Oli.Publishing.update_publication(publication, %{published: DateTime.utc_now()})
+
+      PartMappingRefreshWorker.perform_now()
+
+      %{rows: rows, num_rows: 1} =
+        Ecto.Adapters.SQL.query!(
+          Oli.Repo,
+          "SELECT * FROM part_mapping",
+          []
+        )
+
+      assert [[nil, "automatic", ^revision_id]] = rows
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes the part_mapping materialized view refresh to properly select the part `id` and `gradingApproach` attributes in a way that keeps them aligned.  The previous attempt at this was very very broken in that it allowed the resulting resultset to "shuffle" the part ids and grading approaches.  This was only detected because a duplicate part id for an activity crept into a Torus instance.  The part refresh query "mismatched" these two part ids with different grading approaches (one manual, one automatic) and attempted to insert this triple (part id, grading approach, revision id) into the part map.  That violated the unique index constraint on the combination of part_id and revision id being a unique combination.  The root cause of the problem was that multiple `jsonb_path_query` instances in a SELECT are not guaranteed to order their results in the same consistent way.  I addressed this by rewriting the query to do a single `jsonb_path_query` in a subquery, then selecting the two attributes out of that list of objects.  PgAdmin analysis shows this new approach is about 30% more efficent. 

This PR widens the unique index on the `part_mapping` view to include the grading approach. This guarantees that even if duplicate ids for parts creep in, that the part mapping view will continue to get refreshed correctly.  The new unit test added here demonstrates this increased robustness. 
