### PR TITLE
[BUG FIX] Filter out nil ResourceAccess records

### DIFF
--- a/lib/oli/delivery/attempts/core.ex
+++ b/lib/oli/delivery/attempts/core.ex
@@ -243,7 +243,7 @@ defmodule Oli.Delivery.Attempts.Core do
     |> join(:left, [spp, _, r], a in ResourceAccess,
       on: r.resource_id == a.resource_id and a.section_id == spp.section_id
     )
-    |> where([spp, _, r, _], spp.section_id == ^section_id and r.graded == true)
+    |> where([spp, _, r, a], not is_nil(a) and spp.section_id == ^section_id and r.graded == true)
     |> select([_, _, _, a], a)
   end
 

--- a/test/oli/delivery/attempts_test.exs
+++ b/test/oli/delivery/attempts_test.exs
@@ -401,6 +401,14 @@ defmodule Oli.Delivery.AttemptsTest do
       assert is_nil(access.score)
     end
 
+    test "get graded resource access when no attempts exist", %{
+      section: section
+    } do
+      accesses = Attempts.get_graded_resource_access_for_context(section.id)
+
+      assert Enum.count(accesses) == 0
+    end
+
     test "get graded resource access for specific students", %{
       section: section,
       graded_page: %{revision: revision},
@@ -448,7 +456,9 @@ defmodule Oli.Delivery.AttemptsTest do
     test "get graded resource accesses where the last lms sync failed - returns empty when no failed sync exists" do
       user = insert(:user)
 
-      {:ok, section: section, unit_one_revision: _unit_one_revision, page_revision: page_revision} = section_with_assessment(%{})
+      {:ok, section: section, unit_one_revision: _unit_one_revision, page_revision: page_revision} =
+        section_with_assessment(%{})
+
       last_grade_update = insert(:lms_grade_update)
 
       insert(:resource_access,
@@ -466,7 +476,9 @@ defmodule Oli.Delivery.AttemptsTest do
       user1 = insert(:user)
       user2 = insert(:user)
 
-      {:ok, section: section, unit_one_revision: _unit_one_revision, page_revision: page_revision} = section_with_assessment(%{})
+      {:ok, section: section, unit_one_revision: _unit_one_revision, page_revision: page_revision} =
+        section_with_assessment(%{})
+
       last_successful_grade_update = insert(:lms_grade_update)
       last_grade_update = insert(:lms_grade_update)
 


### PR DESCRIPTION
`Core.get_graded_resource_access_for_context/` can return `nil` records due to the structure of the query.  Take the case where no student has visited a graded page.  This query still returns a record for that singular graded page but the ResourceAccess is `nil`.   Lowest risk fix here is to filer out `nil` RAs in the where clause. 

Unit test that was added demonstrates this perfectly.  Without the change to the query, this new unit test fails. 