### PR TITLE
[BUGFIX] Change figure titles from string to richtext.

### DIFF
--- a/assets/src/components/common/Figure.tsx
+++ b/assets/src/components/common/Figure.tsx
@@ -1,12 +1,18 @@
 import React, { ReactNode } from 'react';
+import { SemanticChildren } from '../../data/content/model/elements/types';
+import { WriterContext } from '../../data/content/writers/context';
+import { HtmlContentModelRenderer } from '../../data/content/writers/renderer';
 
 export const Figure: React.FC<{
-  title: string | ReactNode;
+  title: SemanticChildren[];
   children: ReactNode;
-}> = ({ title, children }) => (
+  context: WriterContext;
+}> = ({ title, children, context }) => (
   <div className="figure">
     <figure>
-      <figcaption>{title}</figcaption>
+      <figcaption>
+        <HtmlContentModelRenderer context={context} content={title} />
+      </figcaption>
       <div className="figure-content">{children}</div>
     </figure>
   </div>

--- a/assets/src/components/editing/elements/figure/FigureEditor.tsx
+++ b/assets/src/components/editing/elements/figure/FigureEditor.tsx
@@ -4,71 +4,34 @@ import * as ContentModel from '../../../../data/content/model/elements/types';
 import { useEditModelCallback } from '../utils';
 import { ReactEditor, useSlate } from 'slate-react';
 import { Editor, Transforms } from 'slate';
+import { InlineEditor } from '../common/settings/InlineEditor';
+import { CommandContext } from '../commands/interfaces';
 
 interface Props extends EditorProps<ContentModel.Figure> {}
 
 const TitleEditor: React.FC<{
-  title: string;
-  onBlur: () => void;
-  onEdit: (val: string) => void;
-}> = ({ title, onEdit, onBlur }) => {
-  const [isEditing, setEditing] = useState(!title || title.length === 0);
-
-  const cancelEditing = useCallback(() => {
-    setEditing(false);
-    onBlur && onBlur();
-  }, [onBlur]);
-
-  const onKeypress = useCallback(
-    (e: React.KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === 'Enter') {
-        cancelEditing();
-      }
-    },
-    [cancelEditing],
-  );
-
-  const onInputCreated = useCallback((ref: HTMLInputElement) => {
-    setTimeout(() => ref?.focus()); // If you try and set focus right away, slate will not render the editor correctly
-  }, []);
-
-  const toggleEdit = useCallback(() => {
-    setEditing(true);
-  }, []);
-
-  return isEditing ? (
-    <input
-      ref={onInputCreated}
-      placeholder="Figure Title"
-      className="form-control "
-      type="text"
-      value={title}
-      onBlur={cancelEditing}
-      onKeyPress={onKeypress}
-      onChange={(e) => onEdit(e.target.value)}
-    />
-  ) : (
-    <span className="title" onClick={toggleEdit}>
-      {title || <i className="title-placeholder">Figure Title</i>}
-    </span>
+  title: ContentModel.SemanticChildren[];
+  onEdit: (val: ContentModel.SemanticChildren[]) => void;
+  commandContext: CommandContext;
+}> = ({ title, onEdit, commandContext }) => {
+  return (
+    <div className="figure-title-editor">
+      <InlineEditor
+        placeholder="Figure Title"
+        allowBlockElements={false}
+        commandContext={commandContext}
+        content={Array.isArray(title) ? title : []}
+        onEdit={onEdit}
+      />
+    </div>
   );
 };
 
-export const FigureEditor: React.FC<Props> = ({ model, attributes, children }) => {
+export const FigureEditor: React.FC<Props> = ({ model, attributes, children, commandContext }) => {
   const onEdit = useEditModelCallback(model);
-  const editor = useSlate();
-
-  const onTitleBlur = useCallback(() => {
-    // When we're done editing the title, it'd be nice to put the cursor into the figure content body
-    setTimeout(() => {
-      ReactEditor.focus(editor);
-      const path = ReactEditor.findPath(editor, model);
-      Transforms.select(editor, path);
-    });
-  }, [editor, model]);
 
   const onEditTitle = useCallback(
-    (val: string) => {
+    (val: ContentModel.SemanticChildren[]) => {
       onEdit({
         title: val,
       });
@@ -80,7 +43,7 @@ export const FigureEditor: React.FC<Props> = ({ model, attributes, children }) =
     <div className="figure-editor figure" {...attributes}>
       <figure>
         <figcaption contentEditable={false}>
-          <TitleEditor onBlur={onTitleBlur} title={model.title} onEdit={onEditTitle} />
+          <TitleEditor title={model.title} commandContext={commandContext} onEdit={onEditTitle} />
         </figcaption>
         <div className="figure-content">{children}</div>
       </figure>

--- a/assets/src/data/content/model/elements/factories.ts
+++ b/assets/src/data/content/model/elements/factories.ts
@@ -86,7 +86,7 @@ export const Model = {
       speakers: [Model.dialogSpeaker('Speaker #1'), Model.dialogSpeaker('Speaker #2')],
     }),
 
-  figure: (title = '') => create<Figure>({ type: 'figure', title, children: [Model.p()] }),
+  figure: () => create<Figure>({ type: 'figure', title: [Model.p()], children: [Model.p()] }),
 
   formula: (subtype: FormulaSubTypes = 'latex', src = '1 + 2 = 3') =>
     create<FormulaBlock>({ type: 'formula', src, subtype }),

--- a/assets/src/data/content/model/elements/types.ts
+++ b/assets/src/data/content/model/elements/types.ts
@@ -62,7 +62,7 @@ export interface Paragraph extends SlateElement<(InputRef | Text | ImageBlock)[]
 
 export interface Figure extends SlateElement<SemanticChildren[]> {
   type: 'figure';
-  title: string;
+  title: SemanticChildren[];
 }
 
 export interface Callout extends SlateElement<SemanticChildren[]> {

--- a/assets/src/data/content/writers/html.tsx
+++ b/assets/src/data/content/writers/html.tsx
@@ -136,7 +136,11 @@ export class HtmlParser implements WriterImpl {
   }
 
   figure(ctx: WriterContext, next: Next, element: Figure) {
-    return <FigureElement title={element.title}>{next()}</FigureElement>;
+    return (
+      <FigureElement context={ctx} title={element.title}>
+        {next()}
+      </FigureElement>
+    );
   }
 
   definitionMeaning(context: WriterContext, next: Next, _: any) {

--- a/assets/styles/authoring/figure.scss
+++ b/assets/styles/authoring/figure.scss
@@ -1,6 +1,12 @@
 .figure-editor {
+  margin: 1rem;
   figure {
     min-width: 10rem;
+  }
+  .figure-title-editor {
+    padding: 0.5rem;
+    min-width: 40rem;
+    border: 1px dashed $gray-400;
   }
   .title {
     cursor: pointer;

--- a/lib/oli/rendering/content.ex
+++ b/lib/oli/rendering/content.ex
@@ -45,7 +45,7 @@ defmodule Oli.Rendering.Content do
   @callback formula(%Context{}, next, %{}) :: [any()]
   @callback formula_inline(%Context{}, next, %{}) :: [any()]
 
-  @callback figure(%Context{}, next, %{}) :: [any()]
+  @callback figure(%Context{}, next, next, %{}) :: [any()]
 
   @callback callout(%Context{}, next, %{}) :: [any()]
   @callback callout_inline(%Context{}, next, %{}) :: [any()]
@@ -182,6 +182,16 @@ defmodule Oli.Rendering.Content do
 
   def render(
         %Context{} = context,
+        %{"type" => "figure", "children" => children, "title" => title} = element,
+        writer
+      ) do
+    render_children = fn -> render(context, children, writer) end
+    render_title = fn -> render(context, title, writer) end
+    writer.figure(context, render_children, render_title, element)
+  end
+
+  def render(
+        %Context{} = context,
         %{"type" => "dialog"} = element,
         writer
       ) do
@@ -237,9 +247,6 @@ defmodule Oli.Rendering.Content do
 
       "img_inline" ->
         writer.img_inline(context, next, element)
-
-      "figure" ->
-        writer.figure(context, next, element)
 
       "video" ->
         writer.video(context, next, element)

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -351,21 +351,13 @@ defmodule Oli.Rendering.Content.Html do
     ]
   end
 
-  def figure(%Context{} = _context, next, %{"title" => title}) do
+  def figure(%Context{} = _context, render_children, render_title, _) do
     [
       "<div class='figure'><figure><figcaption>",
-      title,
+      render_title.(),
       "</figcaption><div class='figure-content'>",
-      next.(),
+      render_children.(),
       "</div></figure></div>\n"
-    ]
-  end
-
-  def figure(%Context{} = _context, next, _) do
-    [
-      "<div class='figure'>",
-      next.(),
-      "</div>\n"
     ]
   end
 

--- a/lib/oli/rendering/content/plaintext.ex
+++ b/lib/oli/rendering/content/plaintext.ex
@@ -171,12 +171,8 @@ defmodule Oli.Rendering.Content.Plaintext do
     [next.(), " "]
   end
 
-  def figure(%Context{} = _context, next, %{"title" => title}) do
-    [title, next.(), " "]
-  end
-
-  def figure(%Context{} = _context, next, _) do
-    [next.(), " "]
+  def figure(%Context{} = _context, render_children, render_title, _) do
+    [render_title.(), "\n", render_children.(), "\n"]
   end
 
   def definition_meaning(%Context{} = _context, next, _) do

--- a/priv/schemas/v0-1-0/content-element.schema.json
+++ b/priv/schemas/v0-1-0/content-element.schema.json
@@ -887,7 +887,10 @@
           "const": "figure"
         },
         "title": {
-          "type": "string"
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/semantic-element-content"
+          }
         },
         "children": {
           "type": "array",
@@ -895,7 +898,8 @@
             "$ref": "#/$defs/semantic-element-content"
           }
         }
-      }
+      },
+      "required": ["type", "children", "title"]
     },
 
     "semantic-element-content": {

--- a/test/oli/rendering/content/example_content.json
+++ b/test/oli/rendering/content/example_content.json
@@ -484,6 +484,11 @@
       ]
     },
     {
+      "type": "figure",
+      "title": [{ "type": "p", "children": [{ "text": "Figure Title" }] }],
+      "children": [{ "type": "p", "children": [{ "text": "Figure Content" }] }]
+    },
+    {
       "type": "p",
       "children": [
         {

--- a/test/oli/rendering/content/html_test.exs
+++ b/test/oli/rendering/content/html_test.exs
@@ -76,6 +76,9 @@ defmodule Oli.Content.Content.HtmlTest do
 
       assert rendered_html_string =~
                "<div class=\"dialog-speaker\" ><img src=\"https://www.example.com/image.png\" class=\"img-fluid speaker-portrait\"/><div class=\"speaker-name\">Speaker 2</div></div>"
+
+      assert rendered_html_string =~
+               "<div class='figure'><figure><figcaption><p>Figure Title</p>\n</figcaption><div class='figure-content'><p>Figure Content</p>\n</div></figure></div>"
     end
 
     test "renders malformed content gracefully", %{author: author} do

--- a/test/oli/rendering/content/plaintext_test.exs
+++ b/test/oli/rendering/content/plaintext_test.exs
@@ -32,6 +32,8 @@ defmodule Oli.Content.Content.PlaintextTest do
 
       assert rendered_text =~
                "Dialog: Sample Dialog\nSpeaker 1: Hello Speaker 2 \nSpeaker 2: Hello Speaker 1"
+
+      assert rendered_text =~ "Figure Title \nFigure Content"
     end
   end
 end


### PR DESCRIPTION
This changes the type of the "title" attribute of figure elements from a string to an array of SemanticChildren so we can represent rich-text within that title.

I did restrict the editor to inserting inline elements since that seemed like the intent of figure titles and what we want to encourage authors to use, but the underlying renderers do work with block content if imported content has any.

A couple examples of rendered output:
![image](https://user-images.githubusercontent.com/333265/187710937-adeab851-7ef8-4acb-b4d1-4070b21e9df9.png)

In editor mode:
![image](https://user-images.githubusercontent.com/333265/187710992-b35f7219-8e90-4d87-beab-64b4cba6f684.png)

Fixes #2960 
