### PR TITLE
[BUG FIX] Remove z-index from typeahead

### DIFF
--- a/assets/styles/authoring/react-typeahead.scss
+++ b/assets/styles/authoring/react-typeahead.scss
@@ -198,11 +198,6 @@
   flex: 1;
 }
 
-.input-group > .rbt .rbt-input-hint,
-.input-group > .rbt .rbt-aux {
-  z-index: $z-content-2;
-}
-
 .input-group > .rbt:not(:first-child) .form-control {
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;


### PR DESCRIPTION
Closes #2951 

I tried adding `z-index` to places in the toolbar that didn't specify it, tried increasing the `z-index` value for those that already did have it specified, but nothing would fix this issue.  The issue only seems to be a problem with the React Typeahead input text.  Since we had forked the CSS for that, I went in and removed the `z-index` specified there. It fixes the problem and in my testing I do not see any negative impacts of removing it. 