### PR TITLE
[BUG FIX] fix an issue with backslashes in content prior to parser escaping

### DIFF
--- a/lib/oli/delivery/evaluation/parser.ex
+++ b/lib/oli/delivery/evaluation/parser.ex
@@ -41,7 +41,7 @@ defmodule Oli.Delivery.Evaluation.Parser do
     ignore(ascii_char([?\\]))
     |> ascii_char([?\\, ?{, ?}])
 
-  non_escaped = utf8_char([{:not, ?\\}])
+  non_escaped = utf8_char([])
 
   character =
     choice([

--- a/test/oli/delivery/evaluation/parser_test.exs
+++ b/test/oli/delivery/evaluation/parser_test.exs
@@ -37,4 +37,18 @@ defmodule Oli.Delivery.Evaluation.ParserTest do
                "input equals {some string with escaped curly brackets here \\} and here \\{ }"
              )
   end
+
+  test "parses math equation with escaped characters" do
+    assert {:ok,
+            {:equals, :input,
+             "\\frac{1}{\\lambda}\\left(\\left\\lbrace x\\right\\rbrace\\right)^2"}} ==
+             parse(
+               "input equals {\\\\frac\\{1\\}\\{\\\\lambda\\}\\\\left(\\\\left\\\\lbrace x\\\\right\\\\rbrace\\\\right)^2}"
+             )
+  end
+
+  test "parses existing content backslashes that are followed by a non-escape char" do
+    assert {:ok, {:like, :input, "(Plus\\s*\\[\\s*2\\s*,\\s*3\\s*,\\s*4\\s*\\])"}} ==
+             parse("input like {(Plus\\s*\\[\\s*2\\s*,\\s*3\\s*,\\s*4\\s*\\])}")
+  end
 end


### PR DESCRIPTION
Fixes an issue where existing activity content that contains backslashes breaks evaluation for that activity. The issue here is that the rules parser was specifying that a non-escaped character cannot be a backslash which is incorrect. The fix is to allow backslashes to be processed as normal as long as they do not precede a valid escape character `\`, `{` or `}`.
