### PR TITLE
[ENHANCEMENT] Allow tables within figures

### DIFF
--- a/priv/schemas/v0-1-0/content-element.schema.json
+++ b/priv/schemas/v0-1-0/content-element.schema.json
@@ -908,7 +908,8 @@
         { "$ref": "#/$defs/block" },
         { "$ref": "#/$defs/text-block" },
         { "$ref": "#/$defs/code-v2" },
-        { "$ref": "#/$defs/code-v1" }
+        { "$ref": "#/$defs/code-v1" },
+        { "$ref": "#/$defs/table" }
       ]
     },
 


### PR DESCRIPTION
This PR expands the schema for `semantic-element-content` to include tables.  This is primarily so that tables can exist inside of figures. 