### PR TITLE
[FEATURE] Allow review of practice pages

### DIFF
--- a/assets/src/apps/Components.tsx
+++ b/assets/src/apps/Components.tsx
@@ -1,12 +1,14 @@
 import { registerApplication } from './app';
 import { DarkModeSelector } from 'components/misc/DarkModeSelector';
 import { PaginationControls } from 'components/misc/PaginationControls';
+import { AttemptSelector } from 'components/misc/AttemptSelector';
 import { SurveyControls } from 'components/misc/SurveyControls';
 import { References } from './bibliography/References';
 import { VideoPlayer } from '../components/video_player/VideoPlayer';
 
 registerApplication('DarkModeSelector', DarkModeSelector, false);
 registerApplication('PaginationControls', PaginationControls);
+registerApplication('AttemptSelector', AttemptSelector);
 registerApplication('SurveyControls', SurveyControls);
 registerApplication('References', References);
 registerApplication('VideoPlayer', VideoPlayer, false);

--- a/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyDelivery.tsx
+++ b/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyDelivery.tsx
@@ -10,6 +10,7 @@ import {
   resetAction,
   listenForParentSurveySubmit,
   listenForParentSurveyReset,
+  listenForReviewAttemptChange,
 } from 'data/activities/DeliveryState';
 import React, { useEffect } from 'react';
 import ReactDOM from 'react-dom';
@@ -42,6 +43,7 @@ export const CheckAllThatApplyComponent: React.FC = () => {
   useEffect(() => {
     listenForParentSurveySubmit(surveyId, dispatch, onSubmitActivity);
     listenForParentSurveyReset(surveyId, dispatch, onResetActivity, { [DEFAULT_PART_ID]: [] });
+    listenForReviewAttemptChange(activityState.activityId as number, dispatch, context);
 
     dispatch(initializeState(activityState, initialPartInputs(activityState), model, context));
   }, []);

--- a/assets/src/components/activities/custom_dnd/CustomDnDDelivery.tsx
+++ b/assets/src/components/activities/custom_dnd/CustomDnDDelivery.tsx
@@ -11,6 +11,7 @@ import {
   resetAction,
   listenForParentSurveyReset,
   listenForParentSurveySubmit,
+  listenForReviewAttemptChange,
   submitPart,
   resetAndSubmitPart,
 } from 'data/activities/DeliveryState';
@@ -54,6 +55,7 @@ export const CustomDnDComponent: React.FC = () => {
   useEffect(() => {
     listenForParentSurveySubmit(surveyId, dispatch, onSubmitActivity);
     listenForParentSurveyReset(surveyId, dispatch, onResetActivity, { [DEFAULT_PART_ID]: [] });
+    listenForReviewAttemptChange(state.activityId as number, dispatch, context);
 
     dispatch(
       initializeState(

--- a/assets/src/components/activities/file_upload/FileUploadDelivery.tsx
+++ b/assets/src/components/activities/file_upload/FileUploadDelivery.tsx
@@ -16,6 +16,7 @@ import {
   resetAction,
   savePart,
   submitFiles,
+  listenForReviewAttemptChange,
   listenForParentSurveyReset,
 } from 'data/activities/DeliveryState';
 import { SubmitButton } from 'components/activities/common/delivery/submit_button/SubmitButton';
@@ -251,6 +252,7 @@ export const FileUploadComponent: React.FC = () => {
   useEffect(() => {
     listenForParentSurveySubmit(surveyId, dispatch, onSubmitActivity);
     listenForParentSurveyReset(surveyId, dispatch, onResetActivity, { [DEFAULT_PART_ID]: [] });
+    listenForReviewAttemptChange(state.activityId as number, dispatch, context);
 
     dispatch(
       initializeState(

--- a/assets/src/components/activities/likert/LikertDelivery.tsx
+++ b/assets/src/components/activities/likert/LikertDelivery.tsx
@@ -15,6 +15,7 @@ import {
   isEvaluated,
   listenForParentSurveySubmit,
   listenForParentSurveyReset,
+  listenForReviewAttemptChange,
 } from 'data/activities/DeliveryState';
 import { Provider, useSelector, useDispatch } from 'react-redux';
 import { initialPartInputs } from 'data/activities/utils';
@@ -48,6 +49,8 @@ const LikertComponent: React.FC = () => {
   useEffect(() => {
     listenForParentSurveySubmit(context.surveyId, dispatch, onSubmitActivity);
     listenForParentSurveyReset(context.surveyId, dispatch, onResetActivity, emptySelectionMap);
+    listenForReviewAttemptChange(activityState.activityId as number, dispatch, context);
+
     dispatch(initializeState(activityState, initialPartInputs(activityState), model, context));
   }, []);
 

--- a/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
@@ -16,6 +16,7 @@ import {
   isEvaluated,
   listenForParentSurveySubmit,
   listenForParentSurveyReset,
+  listenForReviewAttemptChange,
   PartInputs,
   resetAction,
 } from 'data/activities/DeliveryState';
@@ -50,6 +51,7 @@ export const MultiInputComponent: React.FC = () => {
   useEffect(() => {
     listenForParentSurveySubmit(surveyId, dispatch, onSubmitActivity);
     listenForParentSurveyReset(surveyId, dispatch, onResetActivity, emptyPartInputs);
+    listenForReviewAttemptChange(activityState.activityId as number, dispatch, context);
 
     dispatch(
       initializeState(

--- a/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
+++ b/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
@@ -15,6 +15,7 @@ import {
   resetAction,
   listenForParentSurveySubmit,
   listenForParentSurveyReset,
+  listenForReviewAttemptChange,
 } from 'data/activities/DeliveryState';
 import { Radio } from 'components/misc/icons/radio/Radio';
 import { initialPartInputs, isCorrect } from 'data/activities/utils';
@@ -43,7 +44,7 @@ export const MultipleChoiceComponent: React.FC = () => {
   useEffect(() => {
     listenForParentSurveySubmit(surveyId, dispatch, onSubmitActivity);
     listenForParentSurveyReset(surveyId, dispatch, onResetActivity, { [DEFAULT_PART_ID]: [] });
-
+    listenForReviewAttemptChange(activityState.activityId as number, dispatch, context);
     dispatch(initializeState(activityState, initialPartInputs(activityState), model, context));
   }, []);
 

--- a/assets/src/components/activities/oli_embedded/OliEmbeddedDelivery.tsx
+++ b/assets/src/components/activities/oli_embedded/OliEmbeddedDelivery.tsx
@@ -10,6 +10,7 @@ import {
   activityDeliverySlice,
   listenForParentSurveySubmit,
   listenForParentSurveyReset,
+  listenForReviewAttemptChange,
 } from 'data/activities/DeliveryState';
 
 interface Context {
@@ -25,9 +26,9 @@ interface Context {
 const EmbeddedDelivery = (_props: DeliveryElementProps<OliEmbeddedModelSchema>) => {
   const {
     state: activityState,
-    surveyId,
     onSubmitActivity,
     onResetActivity,
+    context: activityContext,
   } = useDeliveryElementContext<OliEmbeddedModelSchema>();
 
   const [context, setContext] = useState<Context>();
@@ -35,8 +36,9 @@ const EmbeddedDelivery = (_props: DeliveryElementProps<OliEmbeddedModelSchema>) 
 
   const dispatch = useDispatch();
   useEffect(() => {
-    listenForParentSurveySubmit(surveyId, dispatch, onSubmitActivity);
-    listenForParentSurveyReset(surveyId, dispatch, onResetActivity);
+    listenForParentSurveySubmit(activityContext.surveyId, dispatch, onSubmitActivity);
+    listenForParentSurveyReset(activityContext.surveyId, dispatch, onResetActivity);
+    listenForReviewAttemptChange(activityState.activityId as number, dispatch, activityContext);
 
     fetchContext();
     setInterval(() => {

--- a/assets/src/components/activities/ordering/OrderingDelivery.tsx
+++ b/assets/src/components/activities/ordering/OrderingDelivery.tsx
@@ -14,6 +14,7 @@ import {
   isSubmitted,
   listenForParentSurveySubmit,
   listenForParentSurveyReset,
+  listenForReviewAttemptChange,
   resetAction,
   StudentInput,
 } from 'data/activities/DeliveryState';
@@ -64,6 +65,7 @@ export const OrderingComponent: React.FC = () => {
   useEffect(() => {
     listenForParentSurveySubmit(surveyId, dispatch, onSubmitActivity);
     listenForParentSurveyReset(surveyId, dispatch, onResetActivity, defaultPartInputs);
+    listenForReviewAttemptChange(activityState.activityId as number, dispatch, context);
 
     dispatch(
       initializeState(

--- a/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
+++ b/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
@@ -17,6 +17,7 @@ import {
   resetAction,
   listenForParentSurveySubmit,
   listenForParentSurveyReset,
+  listenForReviewAttemptChange,
 } from 'data/activities/DeliveryState';
 import { configureStore } from 'state/store';
 import { safelySelectStringInputs } from 'data/activities/utils';
@@ -77,6 +78,7 @@ export const ShortAnswerComponent: React.FC = () => {
   useEffect(() => {
     listenForParentSurveySubmit(surveyId, dispatch, onSubmitActivity);
     listenForParentSurveyReset(surveyId, dispatch, onResetActivity, { [DEFAULT_PART_ID]: [''] });
+    listenForReviewAttemptChange(activityState.activityId as number, dispatch, context);
 
     dispatch(
       initializeState(

--- a/assets/src/components/activities/vlab/VlabDelivery.tsx
+++ b/assets/src/components/activities/vlab/VlabDelivery.tsx
@@ -16,6 +16,7 @@ import {
   isEvaluated,
   listenForParentSurveySubmit,
   listenForParentSurveyReset,
+  listenForReviewAttemptChange,
   PartInputs,
   resetAction,
 } from 'data/activities/DeliveryState';
@@ -113,6 +114,7 @@ export const VlabComponent: React.FC = () => {
   useEffect(() => {
     listenForParentSurveySubmit(context.surveyId, dispatch, onSubmitActivity);
     listenForParentSurveyReset(context.surveyId, dispatch, onResetActivity, emptyPartInputs);
+    listenForReviewAttemptChange(activityState.activityId as number, dispatch, context);
 
     dispatch(
       initializeState(

--- a/assets/src/components/misc/AttemptSelector.tsx
+++ b/assets/src/components/misc/AttemptSelector.tsx
@@ -1,0 +1,75 @@
+import React, { useState } from 'react';
+import { makeRequest } from 'data/persistence/common';
+import * as Events from 'data/events';
+
+export interface AttemptDetails {
+  attemptNumber: number;
+  attemptGuid: string;
+  date: string;
+}
+
+export interface AttemptSelectorProps {
+  sectionSlug: string;
+  attempts: AttemptDetails[];
+  activityId: number;
+}
+
+type FetchAttemptResult = {
+  result: 'success';
+  model: Record<string, unknown>;
+  state: Record<string, unknown>;
+};
+
+function fetchAttempt(activityId: number, sectionSlug: string, attemptGuid: string) {
+  const params = {
+    url: `/state/course/${sectionSlug}/activity_attempt/${attemptGuid}/`,
+    method: 'GET',
+  };
+  makeRequest<FetchAttemptResult>(params).then((result) => {
+    if (result.result === 'success') {
+      Events.dispatch(
+        Events.Registry.ReviewModeAttemptChange,
+        Events.makeReviewModeAttemptChange({
+          forId: activityId,
+          model: result.model,
+          state: result.state,
+        }),
+      );
+    }
+  });
+}
+
+export const AttemptSelector = (props: AttemptSelectorProps) => {
+  const { attempts, sectionSlug, activityId } = props;
+  const [current, setCurrent] = useState(attempts[attempts.length - 1]);
+
+  const choices = attempts.map((a: AttemptDetails) => {
+    return (
+      <a
+        key={a.attemptGuid}
+        className="dropdown-item"
+        href="#"
+        onClick={() => {
+          fetchAttempt(activityId, sectionSlug, a.attemptGuid);
+          setCurrent(a);
+        }}
+      >
+        Attempt #{a.attemptNumber}: {a.date}
+      </a>
+    );
+  });
+
+  return (
+    <div className="btn-group">
+      <button
+        type="button"
+        className="btn btn-info dropdown-toggle"
+        data-toggle="dropdown"
+        aria-expanded="false"
+      >
+        Attempt #{current.attemptNumber}: {current.date}
+      </button>
+      <div className="dropdown-menu">{choices}</div>
+    </div>
+  );
+};

--- a/assets/src/components/misc/AttemptSelector.tsx
+++ b/assets/src/components/misc/AttemptSelector.tsx
@@ -6,6 +6,7 @@ export interface AttemptDetails {
   attemptNumber: number;
   attemptGuid: string;
   date: string;
+  state: 'active' | 'evaluated' | 'submitted';
 }
 
 export interface AttemptSelectorProps {
@@ -54,10 +55,15 @@ export const AttemptSelector = (props: AttemptSelectorProps) => {
           setCurrent(a);
         }}
       >
-        Attempt #{a.attemptNumber}: {a.date}
+        Attempt #{a.attemptNumber}: [{a.state}] {a.date}
       </a>
     );
   });
+
+  if (choices.length > 1) {
+    choices.splice(0, 0, <h6 className="dropdown-header">Previous attempts</h6>);
+  }
+  choices.splice(choices.length - 1, 0, <h6 className="dropdown-header">Most recent attempt</h6>);
 
   return (
     <div className="btn-group">
@@ -67,7 +73,7 @@ export const AttemptSelector = (props: AttemptSelectorProps) => {
         data-toggle="dropdown"
         aria-expanded="false"
       >
-        Attempt #{current.attemptNumber}: {current.date}
+        Attempt #{current.attemptNumber}: [{current.state}] {current.date}
       </button>
       <div className="dropdown-menu">{choices}</div>
     </div>

--- a/assets/src/data/activities/DeliveryState.ts
+++ b/assets/src/data/activities/DeliveryState.ts
@@ -24,6 +24,7 @@ import { studentInputToString } from 'data/activities/utils';
 import { WritableDraft } from 'immer/dist/internal';
 import { ActivityModelSchema } from 'components/activities/types';
 import { Maybe } from 'tsmonad';
+import { initialPartInputs, isCorrect } from 'data/activities/utils';
 
 export type AppThunk<ReturnType = void> = ThunkAction<
   ReturnType,
@@ -506,3 +507,27 @@ export const listenForParentSurveyReset = (
       }
     }),
   );
+
+export const listenForReviewAttemptChange = (
+  activityId: number,
+  dispatch: Dispatch<any>,
+  context: ActivityContext,
+) => {
+  console.log('listener');
+  document.addEventListener(Events.Registry.ReviewModeAttemptChange, (e) => {
+    // check if this activity belongs to the survey being reset
+    console.log('here');
+    console.log(e.detail);
+    console.log(activityId);
+    if (e.detail.forId === activityId) {
+      dispatch(
+        initializeState(
+          e.detail.state as any,
+          initialPartInputs(e.detail.state as any),
+          e.detail.model as any,
+          context,
+        ),
+      );
+    }
+  });
+};

--- a/assets/src/data/activities/DeliveryState.ts
+++ b/assets/src/data/activities/DeliveryState.ts
@@ -513,12 +513,8 @@ export const listenForReviewAttemptChange = (
   dispatch: Dispatch<any>,
   context: ActivityContext,
 ) => {
-  console.log('listener');
   document.addEventListener(Events.Registry.ReviewModeAttemptChange, (e) => {
-    // check if this activity belongs to the survey being reset
-    console.log('here');
-    console.log(e.detail);
-    console.log(activityId);
+    // check if this activity is having its attempt changed
     if (e.detail.forId === activityId) {
       dispatch(
         initializeState(

--- a/assets/src/data/events.ts
+++ b/assets/src/data/events.ts
@@ -7,16 +7,24 @@ export interface ShowContentPage {
   index: number;
 }
 
+export interface ReviewModeAttemptChange {
+  forId: number;
+  state: Record<string, unknown>;
+  model: Record<string, unknown>;
+}
+
 export interface TorusEventMap {
   'oli-survey-submit': CustomEvent<SurveyDetails>;
   'oli-survey-reset': CustomEvent<SurveyDetails>;
   'oli-show-content-page': CustomEvent<ShowContentPage>;
+  'oli-review-mode-attempt-change': CustomEvent<ReviewModeAttemptChange>;
 }
 
 export enum Registry {
   SurveySubmit = 'oli-survey-submit',
   SurveyReset = 'oli-survey-reset',
   ShowContentPage = 'oli-show-content-page',
+  ReviewModeAttemptChange = 'oli-review-mode-attempt-change',
 }
 
 export function makeSurveySubmitEvent(detail: SurveyDetails) {
@@ -29,6 +37,10 @@ export function makeSurveyResetEvent(detail: SurveyDetails) {
 
 export function makeShowContentPage(detail: ShowContentPage) {
   return new CustomEvent(Registry.ShowContentPage, { detail });
+}
+
+export function makeReviewModeAttemptChange(detail: ReviewModeAttemptChange) {
+  return new CustomEvent(Registry.ReviewModeAttemptChange, { detail });
 }
 
 declare global {

--- a/lib/oli/activities/state/activity_state.ex
+++ b/lib/oli/activities/state/activity_state.ex
@@ -4,6 +4,7 @@ defmodule Oli.Activities.State.ActivityState do
   alias Oli.Activities.Model
 
   @enforce_keys [
+    :activityId,
     :attemptGuid,
     :attemptNumber,
     :dateEvaluated,
@@ -18,6 +19,7 @@ defmodule Oli.Activities.State.ActivityState do
 
   @derive Jason.Encoder
   defstruct [
+    :activityId,
     :attemptGuid,
     :attemptNumber,
     :dateEvaluated,
@@ -57,6 +59,7 @@ defmodule Oli.Activities.State.ActivityState do
       end
 
     %Oli.Activities.State.ActivityState{
+      activityId: attempt.resource_id,
       attemptGuid: attempt.attempt_guid,
       attemptNumber: attempt.attempt_number,
       dateEvaluated: attempt.date_evaluated,
@@ -72,6 +75,7 @@ defmodule Oli.Activities.State.ActivityState do
 
   def create_preview_state(transformed_model, group_id \\ nil) do
     %Oli.Activities.State.ActivityState{
+      activityId: 1,
       attemptGuid: UUID.uuid4(),
       attemptNumber: 1,
       dateEvaluated: nil,

--- a/lib/oli/delivery/attempts/core.ex
+++ b/lib/oli/delivery/attempts/core.ex
@@ -683,6 +683,14 @@ defmodule Oli.Delivery.Attempts.Core do
     {:ok, results}
   end
 
+  def get_all_activity_attempts(resource_attempt_id) do
+    Repo.all(
+      from(activity_attempt in ActivityAttempt,
+        where: activity_attempt.resource_attempt_id == ^resource_attempt_id
+      )
+    )
+  end
+
   @doc """
   Gets an activity attempt by a clause.
   ## Examples

--- a/lib/oli/rendering/activity/html.ex
+++ b/lib/oli/rendering/activity/html.ex
@@ -109,6 +109,7 @@ defmodule Oli.Rendering.Activity.Html do
             attempts:
               Enum.map(attempts, fn a ->
                 %{
+                  state: a.lifecycle_state,
                   attemptNumber: a.attempt_number,
                   attemptGuid: a.attempt_guid,
                   date:

--- a/lib/oli/rendering/activity/html.ex
+++ b/lib/oli/rendering/activity/html.ex
@@ -12,119 +12,199 @@ defmodule Oli.Rendering.Activity.Html do
 
   @behaviour Oli.Rendering.Activity
 
+  defp get_activity_model(tag, resource_attempt, activity_id, activity_map, model) do
+    case tag do
+      "oli-adaptive-delivery" ->
+        page_model = Map.get(resource_attempt.content, "model")
+        get_flattened_activity_model(page_model, activity_id, activity_map)
+
+      _ ->
+        model
+    end
+  end
+
+  defp render_missing_activity(context, activity, activity_map, activity_id, render_opts) do
+    {error_id, error_msg} =
+      log_error(
+        "ActivitySummary with id #{activity_id} missing from activity_map",
+        {activity, activity_map}
+      )
+
+    if render_opts.render_errors do
+      error(context, activity, {:activity_missing, error_id, error_msg})
+    else
+      []
+    end
+  end
+
+  defp is_adaptive?(tag) do
+    String.starts_with?(tag, "oli-adaptive-")
+  end
+
+  defp render_activity_html(
+         %Context{
+           activity_map: activity_map,
+           mode: mode,
+           section_slug: section_slug,
+           resource_attempt: resource_attempt,
+           bib_app_params: bib_app_params
+         } = context,
+         %ActivitySummary{
+           authoring_element: authoring_element,
+           delivery_element: delivery_element,
+           model: model
+         } = summary,
+         %{"activity_id" => activity_id}
+       ) do
+    tag =
+      case mode do
+        :instructor_preview -> authoring_element
+        _ -> delivery_element
+      end
+
+    model_json = get_activity_model(tag, resource_attempt, activity_id, activity_map, model)
+
+    bib_params =
+      Enum.reduce(bib_app_params, [], fn x, acc ->
+        acc ++
+          [%{"id" => x.id, "ordinal" => x.ordinal, "slug" => x.slug, "title" => x.title}]
+      end)
+
+    case mode do
+      :instructor_preview ->
+        {:ok, bib_params_json} = Jason.encode(bib_params)
+        activity_html_id = get_activity_html_id(activity_id, model_json)
+
+        [
+          ~s|<#{tag} activity_id=\"#{activity_html_id}\" model="#{model_json}" editmode="false" projectSlug="#{section_slug}" bib_params="#{Base.encode64(bib_params_json)}"></#{tag}>\n|
+        ]
+
+      :review ->
+        if is_adaptive?(tag) do
+          render_single_activity_html(tag, context, summary, bib_params, model_json)
+        else
+          [
+            render_historical_attempts(summary.id, context.historical_attempts, section_slug),
+            render_single_activity_html(tag, context, summary, bib_params, model_json)
+          ]
+        end
+
+      _ ->
+        render_single_activity_html(tag, context, summary, bib_params, model_json)
+    end
+  end
+
+  defp render_historical_attempts(activity_id, historical_attempts, section_slug) do
+    case Map.get(historical_attempts, activity_id) do
+      nil ->
+        []
+
+      [] ->
+        []
+
+      attempts ->
+        {:safe, attempt_selector} =
+          ReactPhoenix.ClientSide.react_component("Components.AttemptSelector", %{
+            activityId: activity_id,
+            attempts:
+              Enum.map(attempts, fn a ->
+                %{
+                  attemptNumber: a.attempt_number,
+                  attemptGuid: a.attempt_guid,
+                  date:
+                    Timex.format!(a.updated_at, "{Mfull} {D}, {YYYY} at {h12}:{m} {AM} {Zabbr}")
+                }
+              end),
+            sectionSlug: section_slug
+          })
+
+        [attempt_selector]
+    end
+  end
+
+  defp render_single_activity_html(
+         tag,
+         %Context{
+           mode: mode,
+           user: user,
+           resource_attempt: resource_attempt,
+           group_id: group_id,
+           survey_id: survey_id
+         } = context,
+         %ActivitySummary{
+           state: state,
+           graded: graded
+         },
+         bib_params,
+         model_json
+       ) do
+    activity_context =
+      %{
+        graded: graded,
+        userId: user.id,
+        sectionSlug: context.section_slug,
+        surveyId: survey_id,
+        groupId: group_id,
+        bibParams: bib_params,
+        pageAttemptGuid:
+          if is_nil(resource_attempt) do
+            ""
+          else
+            resource_attempt.attempt_guid
+          end
+      }
+      |> Poison.encode!()
+      |> HtmlEntities.encode()
+
+    [
+      ~s|<#{tag} class="activity-container" state="#{state}" model="#{model_json}" mode="#{mode}" context="#{activity_context}"></#{tag}>\n|
+    ]
+  end
+
+  defp possibly_wrap_in_purpose(activity_html, activity) do
+    case activity["purpose"] do
+      nil ->
+        activity_html
+
+      "none" ->
+        activity_html
+
+      purpose ->
+        [
+          ~s|<h4 class="activity-purpose |,
+          Oli.Utils.Slug.slugify(purpose),
+          ~s|">|,
+          Oli.Utils.Purposes.label_for(purpose),
+          "</h4>",
+          activity_html
+        ]
+    end
+  end
+
+  defp render_activity(
+         %Context{} = context,
+         %ActivitySummary{} = summary,
+         activity
+       ) do
+    render_activity_html(context, summary, activity)
+    |> possibly_wrap_in_purpose(activity)
+  end
+
   def activity(
         %Context{
           activity_map: activity_map,
-          render_opts: render_opts,
-          mode: mode,
-          user: user,
-          resource_attempt: resource_attempt,
-          group_id: group_id,
-          survey_id: survey_id,
-          bib_app_params: bib_app_params
+          render_opts: render_opts
         } = context,
         %{"activity_id" => activity_id} = activity
       ) do
     activity_summary = activity_map[activity_id]
 
-    bib_params =
-      Enum.reduce(bib_app_params, [], fn x, acc ->
-        acc ++ [%{"id" => x.id, "ordinal" => x.ordinal, "slug" => x.slug, "title" => x.title}]
-      end)
-
     case activity_summary do
       nil ->
-        {error_id, error_msg} =
-          log_error(
-            "ActivitySummary with id #{activity_id} missing from activity_map",
-            {activity, activity_map}
-          )
+        render_missing_activity(context, activity, activity_map, activity_id, render_opts)
 
-        if render_opts.render_errors do
-          error(context, activity, {:activity_missing, error_id, error_msg})
-        else
-          []
-        end
-
-      %ActivitySummary{
-        authoring_element: authoring_element,
-        delivery_element: delivery_element,
-        state: state,
-        graded: graded,
-        model: model
-      } ->
-        tag =
-          case mode do
-            :instructor_preview -> authoring_element
-            _ -> delivery_element
-          end
-
-        model_json =
-          case tag do
-            "oli-adaptive-delivery" ->
-              page_model = Map.get(resource_attempt.content, "model")
-              get_flattened_activity_model(page_model, activity_id, activity_map)
-
-            _ ->
-              model
-          end
-
-        section_slug = context.section_slug
-
-        activity_html_id = get_activity_html_id(activity_id, model_json)
-
-        # See DeliveryElement.ts for a definition of the corresponding client-side type ActivityContext
-        activity_context =
-          %{
-            graded: graded,
-            userId: user.id,
-            sectionSlug: section_slug,
-            surveyId: survey_id,
-            groupId: group_id,
-            bibParams: bib_params,
-            pageAttemptGuid:
-              if is_nil(resource_attempt) do
-                ""
-              else
-                resource_attempt.attempt_guid
-              end
-          }
-          |> Poison.encode!()
-          |> HtmlEntities.encode()
-
-        activity_html =
-          case mode do
-            :instructor_preview ->
-              {:ok, bib_params_json} = Jason.encode(bib_params)
-
-              [
-                ~s|<#{tag} activity_id=\"#{activity_html_id}\" model="#{model_json}" editmode="false" projectSlug="#{section_slug}" bib_params="#{Base.encode64(bib_params_json)}"></#{tag}>\n|
-              ]
-
-            _ ->
-              [
-                ~s|<#{tag} class="activity-container" state="#{state}" model="#{model_json}" mode="#{mode}"  context="#{activity_context}"></#{tag}>\n|
-              ]
-          end
-
-        # purposes types directly on activities is deprecated but rendering is left here to support legacy content
-        case activity["purpose"] do
-          nil ->
-            activity_html
-
-          "none" ->
-            activity_html
-
-          purpose ->
-            [
-              ~s|<h4 class="activity-purpose |,
-              Oli.Utils.Slug.slugify(purpose),
-              ~s|">|,
-              Oli.Utils.Purposes.label_for(purpose),
-              "</h4>",
-              activity_html
-            ]
-        end
+      %ActivitySummary{} = activity_summary ->
+        render_activity(context, activity_summary, activity)
     end
   end
 

--- a/lib/oli/rendering/context.ex
+++ b/lib/oli/rendering/context.ex
@@ -20,5 +20,6 @@ defmodule Oli.Rendering.Context do
             survey_id: nil,
             pagination_mode: "normal",
             bib_app_params: [],
-            submitted_surveys: %{}
+            submitted_surveys: %{},
+            historical_attempts: nil
 end

--- a/lib/oli_web/controllers/api/attempt_controller.ex
+++ b/lib/oli_web/controllers/api/attempt_controller.ex
@@ -340,6 +340,30 @@ defmodule OliWeb.Api.AttemptController do
     }
   end
 
+  def get_activity_attempt(conn, %{
+        "activity_attempt_guid" => attempt_guid
+      }) do
+    case Attempts.get_activity_attempts([attempt_guid]) do
+      {:ok, [attempt]} ->
+        model = Oli.Delivery.Attempts.Core.select_model(attempt)
+
+        {:ok, parsed_model} = Oli.Activities.Model.parse(model)
+
+        state =
+          Oli.Activities.State.ActivityState.from_attempt(
+            attempt,
+            attempt.part_attempts,
+            parsed_model
+          )
+
+        json(conn, %{
+          "result" => "success",
+          "state" => state,
+          "model" => Map.delete(model, "authoring")
+        })
+    end
+  end
+
   @activity_attempt_parameters [
     section_slug: [
       in: :url,

--- a/lib/oli_web/controllers/api/attempt_controller.ex
+++ b/lib/oli_web/controllers/api/attempt_controller.ex
@@ -352,7 +352,7 @@ defmodule OliWeb.Api.AttemptController do
         state =
           Oli.Activities.State.ActivityState.from_attempt(
             attempt,
-            attempt.part_attempts,
+            Attempts.get_latest_part_attempts(attempt.attempt_guid),
             parsed_model
           )
 

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -362,7 +362,8 @@ defmodule OliWeb.PageDeliveryController do
         end,
       activity_map: context.activities,
       bib_app_params: context.bib_revisions,
-      submitted_surveys: submitted_surveys
+      submitted_surveys: submitted_surveys,
+      historical_attempts: context.historical_attempts
     }
 
     this_attempt = context.resource_attempts |> hd
@@ -427,8 +428,7 @@ defmodule OliWeb.PageDeliveryController do
       display_curriculum_item_numbering: section.display_curriculum_item_numbering,
       preview_mode: true,
       page_link_url: &Routes.page_delivery_path(conn, :page_preview, section_slug, &1),
-      container_link_url:
-        &Routes.page_delivery_path(conn, :container_preview, section_slug, &1)
+      container_link_url: &Routes.page_delivery_path(conn, :container_preview, section_slug, &1)
     )
   end
 
@@ -439,12 +439,12 @@ defmodule OliWeb.PageDeliveryController do
   end
 
   def page_preview(
-    conn,
-    %{
-      "section_slug" => section_slug,
-      "revision_slug" => revision_slug
-    }
-  ) do
+        conn,
+        %{
+          "section_slug" => section_slug,
+          "revision_slug" => revision_slug
+        }
+      ) do
     user = conn.assigns.current_user
 
     case Resolver.from_revision_slug(section_slug, revision_slug) do
@@ -482,7 +482,9 @@ defmodule OliWeb.PageDeliveryController do
             isInstructor: true
           }
         )
-      revision -> render_page_preview(conn, section_slug, revision)
+
+      revision ->
+        render_page_preview(conn, section_slug, revision)
     end
   end
 

--- a/lib/oli_web/live/progress/page_attempt_summary.ex
+++ b/lib/oli_web/live/progress/page_attempt_summary.ex
@@ -19,12 +19,14 @@ defmodule OliWeb.Progress.PageAttemptSummary do
   def do_render(%{attempt: %{lifecycle_state: :active}} = assigns) do
     ~F"""
     <li class="list-group-item list-group-action flex-column align-items-start">
-      <div class="d-flex w-100 justify-content-between">
-        <h5 class="mb-1">Attempt {@attempt.attempt_number}</h5>
-        <span>Not Submitted Yet</span>
-      </div>
-      <p class="mb-1">Started: {Utils.render_date(@attempt, :inserted_at, @context)}</p>
-      <small class="text-muted">Time elapsed: {duration(@attempt.inserted_at, DateTime.utc_now())}.</small>
+      <a href={Routes.instructor_review_path(OliWeb.Endpoint, :review_attempt, @section.slug, @attempt.attempt_guid)}>
+        <div class="d-flex w-100 justify-content-between">
+          <h5 class="mb-1">Attempt {@attempt.attempt_number}</h5>
+          <span>Not Submitted Yet</span>
+        </div>
+        <p class="mb-1">Started: {Utils.render_date(@attempt, :inserted_at, @context)}</p>
+        <small class="text-muted">Time elapsed: {duration(@attempt.inserted_at, DateTime.utc_now())}.</small>
+        </a>
     </li>
     """
   end

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -815,6 +815,17 @@ defmodule OliWeb.Router do
     )
   end
 
+  scope "/api/v1/state/course/:section_slug/activity_attempt", OliWeb do
+    pipe_through([
+      :browser,
+      :require_section,
+      :delivery_and_admin,
+      :pow_email_layout
+    ])
+
+    get("/:activity_attempt_guid", Api.AttemptController, :get_activity_attempt)
+  end
+
   ### Sections - Enrollment
   scope "/sections", OliWeb do
     pipe_through([


### PR DESCRIPTION
This PR adds the ability to review practice pages, including all historical activity attempts. 

The implementation here intentionally avoids any affect or risk to the adaptive page. 

During server side rendering of a page in review mode a new "AttemptSelector" will be rendered for every activitiy (that isn't an adaptive activity).  This allows then the user to see all available historical activity attempts and choose between them.  A fetch of that attempt's state and model is made, then the `initializeState` event for client side activities is used to switch the delivery element to that other attempt.  Client side eventing was needed here as my initial attempt to simply programatically set the `model` and `state` props was triggering a rendering problem that I could not figure out. 

