### PR TITLE
[BUG FIX] use date submitted for datashop attempt result pairs

### DIFF
--- a/lib/oli/analytics/datashop.ex
+++ b/lib/oli/analytics/datashop.ex
@@ -203,6 +203,8 @@ defmodule Oli.Analytics.Datashop do
     |> Enum.flat_map(fn {hint_content, hint_index} ->
       context =
         Map.merge(context, %{
+          # TODO: add better hint request timestamp tracking. For now, just use the part attempt inserted_at
+          date: part_attempt.inserted_at,
           current_hint_number: hint_index + 1,
           hint_text: Utils.hint_text(hint_content)
         })

--- a/lib/oli/analytics/datashop.ex
+++ b/lib/oli/analytics/datashop.ex
@@ -104,6 +104,7 @@ defmodule Oli.Analytics.Datashop do
               Map.merge(
                 context,
                 %{
+                  date: part_attempt.date_submitted,
                   transaction_id: Utils.make_unique_id(activity_slug, part_id),
                   part_attempt: part_attempt,
                   skill_ids:

--- a/lib/oli/utils/db_seeder.ex
+++ b/lib/oli/utils/db_seeder.ex
@@ -727,7 +727,11 @@ defmodule Oli.Seeder do
     attempt_tag = Map.get(selector_tags, :attempt, :attempt)
 
     {:ok, %ResourceAccess{} = resource_access} =
-      PageLifecycle.finalize(map[section_tag], map[attempt_tag].attempt_guid, datashop_session_id)
+      PageLifecycle.finalize(
+        map[section_tag].slug,
+        map[attempt_tag].attempt_guid,
+        datashop_session_id
+      )
 
     case tag do
       nil -> map

--- a/test/oli/analytics/datashop_test.exs
+++ b/test/oli/analytics/datashop_test.exs
@@ -182,6 +182,8 @@ defmodule Oli.Analytics.DatashopTest do
         )
         |> Seeder.ensure_published()
         |> Seeder.create_section_resources()
+        # ensure the timestamps are actually different by introducing some delay
+        |> simulate_student_delay(1000)
         |> Seeder.simulate_student_attempt(%StudentAttemptSeed{
           user: :user1,
           datashop_session_id: datashop_session_id_user1,
@@ -284,7 +286,7 @@ defmodule Oli.Analytics.DatashopTest do
       xml = Datashop.export(project.id)
 
       attempts = Hierarchy.get_latest_attempts(user1_graded_page_attempt.id)
-      {_, part_map} = Map.get(attempts, graded_page_activity.resource.id)
+      {_activity_attempt, part_map} = Map.get(attempts, graded_page_activity.resource.id)
 
       date_accessed = user1_graded_page_attempt.inserted_at |> format_date()
       date_submitted = Map.get(part_map, "1").date_submitted |> format_date()
@@ -306,5 +308,11 @@ defmodule Oli.Analytics.DatashopTest do
   defp format_date(date) do
     {:ok, time} = Timex.format(date, "{YYYY}-{0M}-{0D} {0h24}:{0m}:{0s}")
     time
+  end
+
+  defp simulate_student_delay(map, timeout) do
+    Process.sleep(timeout)
+
+    map
   end
 end

--- a/test/oli/analytics/datashop_test.exs
+++ b/test/oli/analytics/datashop_test.exs
@@ -278,12 +278,8 @@ defmodule Oli.Analytics.DatashopTest do
     test "uses correct timestamp for context tool and tutor messages", %{
       project: project,
       user1: user1,
-      user2_guest: user2_guest,
-      datashop_session_id_user1: datashop_session_id_user1,
-      graded_page: graded_page,
       activity_2: graded_page_activity,
-      user1_graded_page_attempt: user1_graded_page_attempt,
-      user1_graded_page_activity_2_part_1_attempt: user1_graded_page_activity_2_part_1_attempt
+      user1_graded_page_attempt: user1_graded_page_attempt
     } do
       xml = Datashop.export(project.id)
 

--- a/test/oli/analytics/datashop_test.exs
+++ b/test/oli/analytics/datashop_test.exs
@@ -7,6 +7,7 @@ defmodule Oli.Analytics.DatashopTest do
   alias Oli.Utils.Seeder.StudentAttemptSeed
   alias Oli.Analytics.Datashop
   alias Oli.Delivery.Attempts.Core.StudentInput
+  alias Oli.Delivery.Attempts.PageLifecycle.Hierarchy
 
   describe "datashop export" do
     setup do
@@ -148,13 +149,6 @@ defmodule Oli.Analytics.DatashopTest do
           :author,
           :activity_2
         )
-        |> Seeder.add_activity(
-          %{title: "activity 3", content: content},
-          :publication,
-          :project,
-          :author,
-          :activity_3
-        )
 
       map =
         map
@@ -195,8 +189,8 @@ defmodule Oli.Analytics.DatashopTest do
           activity: :activity_1,
           get_part_inputs: &[%{attempt_guid: &1, input: %StudentInput{input: "3222237681"}}],
           transformed_model: content,
-          resource_attempt_tag: :user1_graded_page_attempt,
-          activity_attempt_tag: :user1_graded_page_activity_1_attempt,
+          resource_attempt_tag: :user1_ungraded_page_attempt,
+          activity_attempt_tag: :user1_ungraded_page_activity_1_attempt,
           part_attempt_tag: :user1_graded_page_activity_1_part_1_attempt
         })
         |> Seeder.simulate_student_attempt(%StudentAttemptSeed{
@@ -206,9 +200,24 @@ defmodule Oli.Analytics.DatashopTest do
           activity: :activity_1,
           get_part_inputs: &[%{attempt_guid: &1, input: %StudentInput{input: "3222237681"}}],
           transformed_model: content,
-          resource_attempt_tag: :user1_graded_page_attempt,
-          activity_attempt_tag: :user1_graded_page_activity_1_attempt,
+          resource_attempt_tag: :user1_ungraded_page_attempt,
+          activity_attempt_tag: :user1_ungraded_page_activity_1_attempt,
           part_attempt_tag: :user1_graded_page_activity_1_part_1_attempt
+        })
+        |> Seeder.simulate_student_attempt(%StudentAttemptSeed{
+          user: :user1,
+          datashop_session_id: datashop_session_id_user1,
+          resource: :graded_page,
+          activity: :activity_2,
+          get_part_inputs: &[%{attempt_guid: &1, input: %StudentInput{input: "3222237681"}}],
+          transformed_model: content,
+          resource_attempt_tag: :user1_graded_page_attempt,
+          activity_attempt_tag: :user1_graded_page_activity_2_attempt,
+          part_attempt_tag: :user1_graded_page_activity_2_part_1_attempt
+        })
+        |> Seeder.finalize_graded_attempt(datashop_session_id_user1, nil, %{
+          section: :section,
+          attempt: :user1_graded_page_attempt
         })
 
       map =
@@ -265,5 +274,41 @@ defmodule Oli.Analytics.DatashopTest do
              )
              |> to_string() == datashop_session_id_user2
     end
+
+    test "uses correct timestamp for context tool and tutor messages", %{
+      project: project,
+      user1: user1,
+      user2_guest: user2_guest,
+      datashop_session_id_user1: datashop_session_id_user1,
+      graded_page: graded_page,
+      activity_2: graded_page_activity,
+      user1_graded_page_attempt: user1_graded_page_attempt,
+      user1_graded_page_activity_2_part_1_attempt: user1_graded_page_activity_2_part_1_attempt
+    } do
+      xml = Datashop.export(project.id)
+
+      attempts = Hierarchy.get_latest_attempts(user1_graded_page_attempt.id)
+      {_, part_map} = Map.get(attempts, graded_page_activity.resource.id)
+
+      date_accessed = user1_graded_page_attempt.inserted_at |> format_date()
+      date_submitted = Map.get(part_map, "1").date_submitted |> format_date()
+
+      assert xml
+             |> xpath(~x"//context_message/meta[user_id/text() = '#{user1.email}']/time/text()")
+             |> to_string() == date_accessed
+
+      assert xml
+             |> xpath(~x"//tool_message/meta[user_id/text() = '#{user1.email}']/time/text()")
+             |> to_string() == date_submitted
+
+      assert xml
+             |> xpath(~x"//tutor_message/meta[user_id/text() = '#{user1.email}']/time/text()")
+             |> to_string() == date_submitted
+    end
+  end
+
+  defp format_date(date) do
+    {:ok, time} = Timex.format(date, "{YYYY}-{0M}-{0D} {0h24}:{0m}:{0s}")
+    time
   end
 end

--- a/test/oli/datashop_test.exs
+++ b/test/oli/datashop_test.exs
@@ -512,6 +512,7 @@ defmodule Oli.DatashopTest do
           %{
             lifecycle_state: :evaluated,
             date_evaluated: DateTime.utc_now(),
+            date_submitted: DateTime.utc_now(),
             attempt_number: 1,
             score: 0,
             out_of: 1,
@@ -548,6 +549,7 @@ defmodule Oli.DatashopTest do
           %{
             lifecycle_state: :evaluated,
             date_evaluated: DateTime.utc_now(),
+            date_submitted: DateTime.utc_now(),
             attempt_number: 2,
             score: 1,
             out_of: 1,
@@ -574,6 +576,7 @@ defmodule Oli.DatashopTest do
           %{
             lifecycle_state: :active,
             date_evaluated: nil,
+            date_submitted: nil,
             attempt_number: 3,
             score: nil,
             out_of: nil,
@@ -618,6 +621,7 @@ defmodule Oli.DatashopTest do
           %{
             lifecycle_state: :evaluated,
             date_evaluated: DateTime.utc_now(),
+            date_submitted: DateTime.utc_now(),
             attempt_number: 1,
             score: 1,
             out_of: 1,
@@ -664,6 +668,7 @@ defmodule Oli.DatashopTest do
           %{
             lifecycle_state: :evaluated,
             date_evaluated: DateTime.utc_now(),
+            date_submitted: DateTime.utc_now(),
             attempt_number: 1,
             score: 0,
             out_of: 1,
@@ -700,6 +705,7 @@ defmodule Oli.DatashopTest do
           %{
             lifecycle_state: :evaluated,
             date_evaluated: DateTime.utc_now(),
+            date_submitted: DateTime.utc_now(),
             attempt_number: 2,
             score: 1,
             out_of: 1,
@@ -744,6 +750,7 @@ defmodule Oli.DatashopTest do
           %{
             lifecycle_state: :evaluated,
             date_evaluated: DateTime.utc_now(),
+            date_submitted: DateTime.utc_now(),
             attempt_number: 1,
             score: 1,
             out_of: 1,


### PR DESCRIPTION
This PR changes the datashop export to use "date submitted" instead of the part attempt "date inserted" timestamp for ATTEMPT and RESULT pairs.

This does not fix/account for the issue that hints requested do not contain a date timestamp, and therefore hints will continue to use the "date inserted" timestamp (when a student accesses the page/resets the activity) instead of when they actually requested a hint.