### PR TITLE
[MER-879] Add non empty lti score comment

### DIFF
--- a/lib/oli/grading.ex
+++ b/lib/oli/grading.ex
@@ -94,7 +94,7 @@ defmodule Oli.Grading do
       timestamp: timestamp,
       scoreGiven: resource_access.score,
       scoreMaximum: resource_access.out_of,
-      comment: "",
+      comment: "Score default comment",
       activityProgress: "Completed",
       gradingProgress: "FullyGraded",
       userId: sub

--- a/test/oli/grading_test.exs
+++ b/test/oli/grading_test.exs
@@ -1,7 +1,10 @@
 defmodule Oli.GradingTest do
   use Oli.DataCase
 
+  import Oli.Factory
+
   alias Oli.Grading
+  alias Lti_1p3.Tool.Services.AGS.Score
 
   describe "grading" do
     defp set_resources_as_graded(%{revision1: revision1, revision2: revision2} = map) do
@@ -204,6 +207,17 @@ defmodule Oli.GradingTest do
       csv = Grading.export_csv(section) |> Enum.join("")
 
       assert expected_csv == csv
+    end
+
+    test "to score parses correctly" do
+      resource_access = insert(:resource_access)
+
+      %Score{
+        activityProgress: "Completed",
+        comment: "Score default comment",
+        gradingProgress: "FullyGraded",
+        userId: "some_sub"
+      } = Grading.to_score("some_sub", resource_access)
     end
   end
 end


### PR DESCRIPTION
[MER-879](https://eliterate.atlassian.net/browse/MER-879)

Fixing some issues Schoology was having for syncing grades:

- Do not send an empty comment when posting score
  - Fixed error: `[error] Error encountered posting score for user 118752747::f9e5b6fb327dad106e4cd6445cc2cc1f for line item 'New Assessment 1' {:ok, %HTTPoison.Response{body: "{\"error\":\"Invalid parameter \\\"body.comment\\\": \\\"comment\\\" is not allowed to be empty\"}", headers: [{`

Tested that Moodle and Canvas continue working as expected.

[Related PR](https://github.com/Simon-Initiative/lti_1p3/pull/27)

Leaving it as draft for now, since it's not fully working yet due to an error from the Schoology side. See ticket in Jira for further information. Although I agree if we want to proceed with these changes anyway.