### PR TITLE
[BUG FIX] fix dnd questions, rendering of popup term

### DIFF
--- a/assets/src/components/activities/custom_dnd/CustomDnDDelivery.tsx
+++ b/assets/src/components/activities/custom_dnd/CustomDnDDelivery.tsx
@@ -92,7 +92,7 @@ export const CustomDnDComponent: React.FC = () => {
         resetAndSubmitPart(
           uiState.attemptState.attemptGuid,
           findPart(partId).attemptGuid,
-          toStudentResponse(value),
+          toStudentResponse(partId + '_' + value),
           onResetPart,
           onSubmitPart,
         ),
@@ -102,7 +102,7 @@ export const CustomDnDComponent: React.FC = () => {
         submitPart(
           uiState.attemptState.attemptGuid,
           findPart(partId).attemptGuid,
-          toStudentResponse(value),
+          toStudentResponse(partId + '_' + value),
           onSubmitPart,
         ),
       );

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -518,7 +518,7 @@ defmodule Oli.Rendering.Content.Html do
       <span
         tabindex="0"
         role="button"
-        class="popup__anchorText#{if !String.contains?(trigger, "hover") do
+        class="term popup__anchorText#{if !String.contains?(trigger, "hover") do
         " popup__click"
       else
         ""


### PR DESCRIPTION
This PR fixes two issues noticed during QA of the chemistry course:

1. Popup definitions were not rendering the term inline with any special markup. I added the `term` class which renders them now the same as regular terms (bold italic and green).
2. The CustomDnD activity was not working due to some underlying changes in how the multipart activity now correctly partitions choices between multiple dropdown components.  The migration tool now preprends the partId and a "_" in front of the choice values to make the overall id unique within the question.  The DnD question has to do this manually, every time on submission because those choice values are separately embedded with the HTML of the layout file. 

