### PR TITLE
[BUG FIX] center a figure-img in delivery

### DIFF
--- a/assets/styles/common/elements.scss
+++ b/assets/styles/common/elements.scss
@@ -305,4 +305,10 @@ span.term {
       }
     }
   }
+
+  .figure-img {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+  }
 }


### PR DESCRIPTION
This PR fixes a delivery style issue where a images which are represented as centered in authoring were being rendered aligned to the left. The fix here centers the image so that it matches what is displayed in authoring.

Authoring:
<img width="1224" alt="Screen Shot 2022-09-20 at 1 42 00 PM" src="https://user-images.githubusercontent.com/6248894/191328728-0f32b629-b789-44b0-8ce7-fa495c62b505.png">

Before:
<img width="840" alt="Screen Shot 2022-09-20 at 1 41 52 PM" src="https://user-images.githubusercontent.com/6248894/191328739-9d67b02a-5a8d-4b9d-a4be-0628963cfbe7.png">

After:
<img width="862" alt="Screen Shot 2022-09-20 at 1 42 13 PM" src="https://user-images.githubusercontent.com/6248894/191328753-f9d07681-d8a6-49bd-b5ee-600618c8f70a.png">

