### PR TITLE
[BUG FIX] Properly set legacy field

### DIFF
--- a/lib/oli/resources.ex
+++ b/lib/oli/resources.ex
@@ -311,7 +311,7 @@ defmodule Oli.Resources do
           scope: previous_revision.scope,
           retake_mode: previous_revision.retake_mode,
           parameters: previous_revision.parameters,
-          legacy: Map.from_struct(previous_revision.legacy),
+          legacy: previous_revision.legacy |> convert_legacy,
           tags: previous_revision.tags,
           explanation_strategy: previous_revision.explanation_strategy
         },
@@ -320,6 +320,11 @@ defmodule Oli.Resources do
 
     create_revision(attrs)
   end
+
+  defp convert_legacy(nil), do: nil
+  defp convert_legacy(legacy) when is_struct(legacy), do: Map.from_struct(legacy)
+  defp convert_legacy(legacy) when is_map(legacy), do: legacy
+  defp convert_legacy(item), do: item
 
   @doc """
   Returns an `%Ecto.Changeset{}` for tracking revision changes.

--- a/lib/oli/resources.ex
+++ b/lib/oli/resources.ex
@@ -311,7 +311,7 @@ defmodule Oli.Resources do
           scope: previous_revision.scope,
           retake_mode: previous_revision.retake_mode,
           parameters: previous_revision.parameters,
-          legacy: previous_revision.legacy,
+          legacy: Map.from_struct(previous_revision.legacy),
           tags: previous_revision.tags,
           explanation_strategy: previous_revision.explanation_strategy
         },


### PR DESCRIPTION
Certain usages of the `Oli.Resources.create_revision_from_previous` trigger a failure as the legacy field is being set as a struct, rather than as a map.  

To trigger this failure (without this PR in place) just try editing the JSON of a revision in the Revision History tool.  

This PR ensures that the previous legacy attr is converted to a map, when necessary. 