### PR TITLE
[PERFORMANCE] Remove trigger, again [MER-1442]

### DIFF
--- a/priv/repo/migrations/20220920205152_delete_publications_trigger.exs
+++ b/priv/repo/migrations/20220920205152_delete_publications_trigger.exs
@@ -1,0 +1,13 @@
+defmodule Oli.Repo.Migrations.DeletePublicationsTrigger do
+  use Ecto.Migration
+
+  def change do
+    drop_trigger()
+  end
+
+  def drop_trigger() do
+    execute """
+    DROP TRIGGER IF EXISTS published_resources_tr ON public.published_resources;
+    """
+  end
+end


### PR DESCRIPTION
This PR fixes a problem introduced (by me) back when the refresh mapping query was fixed to account for duplicate part ids and grading approaches.  The migration in that PR (https://github.com/Simon-Initiative/oli-torus/pull/2958) accidentally re-introduced the `published_resources` trigger to invoke the part mapping refresh, which is what is now causing publication to take > 30 seconds. 

I verified this locally by seeing the trigger there in pgAdmin, then deleting it.  The UPDATE... SET query went from taking 2.5 seconds locally to like 11 msec.  

