### PR TITLE
[ENCHANCEMENT] some style tweaks

### DIFF
--- a/assets/styles/common/purpose.scss
+++ b/assets/styles/common/purpose.scss
@@ -21,6 +21,28 @@
     }
   }
 
+  &.objectives {
+    border: 1px solid $content-purpose-objectives-color;
+
+    .content-purpose-label {
+      background-color: $content-purpose-objectives-color;
+      color: $white;
+
+      /** icon */
+      &::before {
+        font-family: 'Line Awesome Free';
+        font-weight: 900;
+        margin-left: 8px;
+        margin-right: 8px;
+        content: '\f11e';
+      }
+    }
+
+    .content-purpose-content {
+      font-size: 1.3em;
+    }
+  }
+
   &.checkpoint {
     border: 1px solid $content-purpose-checkpoint-color;
 
@@ -58,11 +80,11 @@
   }
 
   &.example {
-    border: 1px solid $content-purpose-example-color;
+    border-bottom: 1px dashed $content-purpose-example-color;
 
     .content-purpose-label {
-      background-color: $content-purpose-example-color;
-      color: $white;
+      border-bottom: 1px dashed $content-purpose-example-color;
+      font-weight: 700;
 
       /** icon */
       &::before {

--- a/assets/styles/delivery/page_delivery/page.scss
+++ b/assets/styles/delivery/page_delivery/page.scss
@@ -46,9 +46,8 @@ h1.title {
 }
 
 .content {
-  max-width: 770px;
   margin: 0 auto;
-
+  font-size: 1.1em;
   & > * {
     margin-bottom: 1.5rem;
   }

--- a/assets/styles/delivery/variables.scss
+++ b/assets/styles/delivery/variables.scss
@@ -33,6 +33,7 @@ $hints-border: none !default;
 
 $content-figure-caption-color: #0984e3;
 
+$content-purpose-objectives-color: rgba(#0984e3, 0.75) !default;
 $content-purpose-checkpoint-color: rgba(#0984e3, 0.75) !default;
 $content-purpose-didigetthis-color: rgba(#8e44ad, 0.75) !default;
 $content-purpose-example-color: rgba(#74b9ff, 0.75) !default;

--- a/assets/styles/themes/preview/default.scss
+++ b/assets/styles/themes/preview/default.scss
@@ -250,6 +250,7 @@ html.preview.dark {
   $feedback-error-bg: lighten($orange, 42%);
   $feedback-error-color: $orange;
 
+  $content-purpose-objectives-color: rgba(#0984e3, 0.75) !default;
   $content-purpose-checkpoint-color: rgba(#0984e3, 0.75) !default;
   $content-purpose-didigetthis-color: rgba(#8e44ad, 0.75) !default;
   $content-purpose-example-color: rgba(#74b9ff, 0.75) !default;

--- a/lib/oli_web/templates/page_delivery/_objectives.html.eex
+++ b/lib/oli_web/templates/page_delivery/_objectives.html.eex
@@ -1,14 +1,18 @@
 
 <%= if length(@objectives) > 0 do %>
 
-  <div class="rolled-up-objectives">
+  <div class="group content-purpose objectives">
 
-    <div class="label">Learning Objectives</div>
-    <ul>
-    <%= for title <- @objectives do %>
-      <li class="title"><%= title %></li>
-    <% end %>
-    </ul>
+    <div class="content-purpose-label">Learning Objectives</div>
+    <div class="content-purpose-content">
+      <ul>
+      <%= for title <- @objectives do %>
+        <li class="title"><%= title %></li>
+      <% end %>
+      </ul>
+    </div>
+
+
   </div>
 
 <% end %>


### PR DESCRIPTION
This PR adjusts some page delivery styles to accomplish:

1. Allow content to use a wider portion of the page. (by removing the hardcoded `770px` max width)
2. Remove block styling of examples to match Legacy Chaperone style
3. Use same block styling for attached objectives. 
4. Bump the font size of the content overall slightly bigger. 