### PR TITLE
[BUGFIX] PMP-3013 JAN-1857 manual grading issues

### DIFF
--- a/assets/styles/common/utils.scss
+++ b/assets/styles/common/utils.scss
@@ -1,4 +1,4 @@
-.cursor-pointer {
+.cursor-pointer, .selectable {
   cursor: pointer;
 }
 

--- a/lib/oli/rendering/activity/html.ex
+++ b/lib/oli/rendering/activity/html.ex
@@ -164,7 +164,7 @@ defmodule Oli.Rendering.Activity.Html do
       |> HtmlEntities.encode()
 
     [
-      ~s|<#{tag} class="activity-container" state="#{state}" model="#{model_json}" mode="#{mode}" context="#{activity_context}"></#{tag}>\n|
+      ~s|<#{tag} phx-update="ignore" class="activity-container" state="#{state}" model="#{model_json}" mode="#{mode}" context="#{activity_context}"></#{tag}>\n|
     ]
   end
 

--- a/lib/oli_web/live/common/sortable_table/table.ex
+++ b/lib/oli_web/live/common/sortable_table/table.ex
@@ -52,7 +52,11 @@ defmodule OliWeb.Common.SortableTable.Table do
       if id_field(row, assigns.model) == assigns.model.selected do
         "table-active"
       else
-        ""
+        if assigns.select != nil do
+          "selectable"
+        else
+          ""
+        end
       end
 
     ~F"""

--- a/lib/oli_web/live/manual_grading/rendered_activity.ex
+++ b/lib/oli_web/live/manual_grading/rendered_activity.ex
@@ -11,7 +11,7 @@ defmodule OliWeb.ManualGrading.RenderedActivity do
 
   def render(assigns) do
     ~F"""
-    <div class="mt-5 rendered-activity" id={@id} phx-update="ignore">{raw(@rendered_activity)}</div>
+    <div class="mt-5 rendered-activity" id={@id} >{raw(@rendered_activity)}</div>
     """
   end
 

--- a/test/oli/rendering/activity/html_test.exs
+++ b/test/oli/rendering/activity/html_test.exs
@@ -48,7 +48,7 @@ defmodule Oli.Content.Activity.HtmlTest do
       rendered_html_string = Phoenix.HTML.raw(rendered_html) |> Phoenix.HTML.safe_to_string()
 
       assert rendered_html_string =~
-               ~s|<oli-multiple-choice-delivery class="activity-container" state="{ "active": true }" model="{ "choices": [ "A", "B", "C", "D" ], "feedback": [ "A", "B", "C", "D" ], "stem": ""}"|
+               ~s|<oli-multiple-choice-delivery phx-update="ignore" class="activity-container" state="{ "active": true }" model="{ "choices": [ "A", "B", "C", "D" ], "feedback": [ "A", "B", "C", "D" ], "stem": ""}"|
     end
 
     test "renders malformed activity gracefully", %{author: author} do

--- a/test/oli/rendering/survey/html_test.exs
+++ b/test/oli/rendering/survey/html_test.exs
@@ -69,7 +69,7 @@ defmodule Oli.Content.Survey.HtmlTest do
                ~s|<div id="1855946510" class="survey"><div class="survey-label">Survey</div><div class="survey-content">|
 
       assert rendered_html_string =~
-               ~s|<p>Please complete the following survey:</p>\n<oli-multiple-choice-delivery class="activity-container" state="{ "active": true }" model="{ "choices": [ "A", "B", "C", "D" ], "feedback": [ "A", "B", "C", "D" ], "stem": ""}" mode="delivery"|
+               ~s|<p>Please complete the following survey:</p>\n<oli-multiple-choice-delivery phx-update="ignore" class="activity-container" state="{ "active": true }" model="{ "choices": [ "A", "B", "C", "D" ], "feedback": [ "A", "B", "C", "D" ], "stem": ""}" mode="delivery"|
 
       assert rendered_html_string =~
                ~s|</oli-multiple-choice-delivery>|


### PR DESCRIPTION
this makes the manual grading table show a pointer on selectable items.
also the updates set to ignore actually broke the tabs, moved the ignore to the activity itself which seems to work still
