### PR TITLE
[BUG FIX] Allow users logged in strictly as an admin to review adaptive page attempts [MER-1459]

### DIFF
--- a/lib/oli/delivery/attempts/core.ex
+++ b/lib/oli/delivery/attempts/core.ex
@@ -25,6 +25,17 @@ defmodule Oli.Delivery.Attempts.Core do
     GradeUpdateBrowseOptions
   }
 
+  def get_user_from_attempt(%ResourceAttempt{resource_access_id: resource_access_id}) do
+    query =
+      from access in ResourceAccess,
+        join: user in User,
+        on: access.user_id == user.id,
+        select: user,
+        where: access.id == ^resource_access_id
+
+    Repo.one(query)
+  end
+
   @doc """
   For a given user, section, and resource id, determine whether any resource attempts are
   present.

--- a/lib/oli/delivery/page/page_context.ex
+++ b/lib/oli/delivery/page/page_context.ex
@@ -4,6 +4,7 @@ defmodule Oli.Delivery.Page.PageContext do
   """
 
   @enforce_keys [
+    :user,
     :review_mode,
     :page,
     :progress_state,
@@ -15,6 +16,7 @@ defmodule Oli.Delivery.Page.PageContext do
     :historical_attempts
   ]
   defstruct [
+    :user,
     :review_mode,
     :page,
     :progress_state,
@@ -64,7 +66,8 @@ defmodule Oli.Delivery.Page.PageContext do
           {:error, [], %{}}
       end
 
-    page_revision = hd(resource_attempts).revision
+    resource_attempt = hd(resource_attempts)
+    page_revision = resource_attempt.revision
 
     summaries = if activities != nil, do: Map.values(activities), else: []
 
@@ -80,6 +83,7 @@ defmodule Oli.Delivery.Page.PageContext do
       |> Enum.map(fn {summary, ordinal} -> BibUtils.serialize_revision(summary, ordinal) end)
 
     %PageContext{
+      user: Attempts.get_user_from_attempt(resource_attempt),
       review_mode: true,
       page: page_revision,
       progress_state: progress_state,
@@ -171,6 +175,7 @@ defmodule Oli.Delivery.Page.PageContext do
       |> Enum.map(fn {summary, ordinal} -> BibUtils.serialize_revision(summary, ordinal) end)
 
     %PageContext{
+      user: user,
       review_mode: false,
       page: page_revision,
       progress_state: progress_state,

--- a/test/oli/delivery/attempts_test.exs
+++ b/test/oli/delivery/attempts_test.exs
@@ -344,6 +344,14 @@ defmodule Oli.Delivery.AttemptsTest do
       )
     end
 
+    test "ensure we can get the user from just the resource attempt", %{
+      attempt1: attempt1,
+      user1: user1
+    } do
+      %Oli.Accounts.User{id: id} = Attempts.get_user_from_attempt(attempt1)
+      assert id == user1.id
+    end
+
     test "model selection", %{
       activity_a: activity,
       activity_attempt1: activity_attempt1,


### PR DESCRIPTION
This PR fixes an issue in the server-side rendering code of the adaptive page that used the `assigns.current_user` to get the  id and name of the student that is the current user.  This is the same code that is run for both "visitation" and "reviewing".  In a review mode, the `assigns.current_user` is the logged in instructor (if its an instructor reviewing an attempt) and not the actual student.  Worse, if the logged in user is just an admin, the `assigns.current_user` will be `nil`, which was triggering the "Internal Server Error". 

The fix here is to not rely on the `assigns.current_user` for student information relative to the attempt.  Instead, this PR introduces a new `user` attribute to the `PageContext` which, during review mode, is populated by looking up the student pinned to the `ResoruceAccess` record from the resource attempt that is being reviewed.  In visitation, we can safely use the user that came from the `current_user` assign, since this can only be the student. 