### PR TITLE
[BUGFIX] JAN-1857 activity preview covers scoring area

### DIFF
--- a/assets/styles/authoring/layout/workspace.scss
+++ b/assets/styles/authoring/layout/workspace.scss
@@ -229,9 +229,3 @@ $workspace-sidebar-width: 65px;
     }
   }
 }
-
-/* manual grading instructor preview */
-.rendered-activity {
-  min-height: 500px;
-  overflow: auto;
-}

--- a/assets/styles/common/index.scss
+++ b/assets/styles/common/index.scss
@@ -19,3 +19,4 @@
 @import 'utils.scss';
 @import 'video.scss';
 @import 'list.scss';
+@import 'section-views.scss';

--- a/assets/styles/common/section-views.scss
+++ b/assets/styles/common/section-views.scss
@@ -1,0 +1,5 @@
+/* manual grading instructor preview */
+.rendered-activity {
+  min-height: 500px;
+  overflow: auto;
+}


### PR DESCRIPTION
the manual scoring interface was displaying the adaptive activity in such a way that it would escape the container. this only occurred via LTI and not in direct delivery mode because the css was previously only implemented for authoring mode. when an instructor is accessing via LTI it is in delivery mode.