### PR TITLE
[BUG FIX] Fix ordering reset problem.

### DIFF
--- a/assets/src/components/activities/common/choices/delivery/ChoicesDeliveryConnected.tsx
+++ b/assets/src/components/activities/common/choices/delivery/ChoicesDeliveryConnected.tsx
@@ -17,13 +17,13 @@ export const ChoicesDeliveryConnected: React.FC<Props> = ({
   selectedIcon,
   partId,
 }) => {
-  const { model, writerContext } = useDeliveryElementContext<HasChoices & ActivityModelSchema>();
+  const { writerContext } = useDeliveryElementContext<HasChoices & ActivityModelSchema>();
   const uiState = useSelector((state: ActivityDeliveryState) => state);
   return (
     <ChoicesDelivery
       unselectedIcon={unselectedIcon}
       selectedIcon={selectedIcon}
-      choices={model.choices}
+      choices={(uiState.model as HasChoices).choices}
       selected={uiState.partState[partId]?.studentInput || []}
       onSelect={onSelect}
       isEvaluated={isEvaluated(uiState)}

--- a/assets/src/components/activities/ordering/OrderingDelivery.tsx
+++ b/assets/src/components/activities/ordering/OrderingDelivery.tsx
@@ -15,16 +15,13 @@ import {
   listenForParentSurveyReset,
   listenForReviewAttemptChange,
   resetAction,
-  StudentInput,
 } from 'data/activities/DeliveryState';
 import { Choices } from 'data/activities/model/choices';
 import { initialPartInputs, studentInputToString } from 'data/activities/utils';
-import { HasChoices } from 'oli-torus-sdk';
 import React, { useEffect } from 'react';
 import ReactDOM from 'react-dom';
 import { Provider, useDispatch, useSelector } from 'react-redux';
 import { configureStore } from 'state/store';
-import { Maybe } from 'tsmonad';
 import { castPartId } from '../common/utils';
 import { DeliveryElement, DeliveryElementProps } from '../DeliveryElement';
 import { DeliveryElementProvider, useDeliveryElementContext } from '../DeliveryElementProvider';
@@ -104,9 +101,12 @@ export const OrderingComponent: React.FC = () => {
   const studentInput =
     uiState.partState[castPartId(uiState.attemptState.parts[0].partId)]?.studentInput;
 
+  // If there is user state, let that drive the order of choices.  If there is no user state,
+  // just use the ordering inherent in the choices from the model.  This allows student and
+  // instructor review use cases to both work.
   const choices =
     studentInput === null || studentInput.length === 0
-      ? (uiState.model as HasChoices).choices
+      ? (uiState.model as ActivityTypes.HasChoices).choices
       : studentInput.map((id) => Choices.getOne(uiState.model as OrderingSchema, id));
 
   return (

--- a/assets/src/components/activities/ordering/OrderingDelivery.tsx
+++ b/assets/src/components/activities/ordering/OrderingDelivery.tsx
@@ -109,9 +109,6 @@ export const OrderingComponent: React.FC = () => {
       ? (uiState.model as HasChoices).choices
       : studentInput.map((id) => Choices.getOne(uiState.model as OrderingSchema, id));
 
-  console.log(studentInput);
-  console.log(choices);
-
   return (
     <div className="activity ordering-activity">
       <div className="activity-content">

--- a/assets/src/components/activities/ordering/OrderingDelivery.tsx
+++ b/assets/src/components/activities/ordering/OrderingDelivery.tsx
@@ -19,6 +19,7 @@ import {
 } from 'data/activities/DeliveryState';
 import { Choices } from 'data/activities/model/choices';
 import { initialPartInputs, studentInputToString } from 'data/activities/utils';
+import { HasChoices } from 'oli-torus-sdk';
 import React, { useEffect } from 'react';
 import ReactDOM from 'react-dom';
 import { Provider, useDispatch, useSelector } from 'react-redux';
@@ -93,12 +94,23 @@ export const OrderingComponent: React.FC = () => {
         ]);
       }
     }, 0);
-  }, [uiState.model]);
+  }, []);
 
   // First render initializes state
   if (!uiState.partState) {
     return null;
   }
+
+  const studentInput =
+    uiState.partState[castPartId(uiState.attemptState.parts[0].partId)]?.studentInput;
+
+  const choices =
+    studentInput === null || studentInput.length === 0
+      ? (uiState.model as HasChoices).choices
+      : studentInput.map((id) => Choices.getOne(uiState.model as OrderingSchema, id));
+
+  console.log(studentInput);
+  console.log(choices);
 
   return (
     <div className="activity ordering-activity">
@@ -106,11 +118,7 @@ export const OrderingComponent: React.FC = () => {
         <StemDeliveryConnected />
         <GradedPointsConnected />
         <ResponseChoices
-          choices={Maybe.maybe(
-            uiState.partState[castPartId(activityState.parts[0].partId)]?.studentInput,
-          )
-            .valueOr<StudentInput>([])
-            .map((id) => Choices.getOne(uiState.model as OrderingSchema, id))}
+          choices={choices}
           setChoices={(choices) => onSelectionChange(choices.map((c) => c.id))}
           disabled={isEvaluated(uiState) || isSubmitted(uiState)}
         />


### PR DESCRIPTION
Closes #3021 

Root cause of the failure was the inclusion of `uiState.model` in the `useEffect` dependency.  After removing that, the problem was fixed.  I noticed two other issues, though:

1. Multiple choice and CATA activities were not shuffling their choices upon reset. 
2. Review mode view of the latest Ordering activity - when that latest activity is unsubmitted and has no interact - did not render choices (due to the database student input being empty).  

This PR fixes those two issues as well. 