### PR TITLE
[BUG FIX] Use auto layout for tables

### DIFF
--- a/assets/styles/common/elements.scss
+++ b/assets/styles/common/elements.scss
@@ -236,6 +236,10 @@ span.term {
     }
   }
 
+  table {
+    table-layout: auto;
+  }
+
   .dialog {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
It was reported that latex formulas can overflow a table cell.  See this example:

https://tokamak.oli.cmu.edu/authoring/project/general_chemistry_i_fuwmp/resource/su9xt_laws_of_definite_and_multiple__qes3o

A simple fix here is to use `table-layout: auto` which sizes the columns based on content, allowing the formula to render. Example:
![Screen Shot 2022-09-28 at 2 51 53 PM](https://user-images.githubusercontent.com/7431756/192865949-b3ac1199-e678-40b0-82a6-9ccc66c7831a.png)

