### PR TITLE
[BuGFIX] JAN-1857 core activities were failing with nil historical_attempts

### DIFF
--- a/lib/oli/rendering/activity/html.ex
+++ b/lib/oli/rendering/activity/html.ex
@@ -95,31 +95,35 @@ defmodule Oli.Rendering.Activity.Html do
   end
 
   defp render_historical_attempts(activity_id, historical_attempts, section_slug) do
-    case Map.get(historical_attempts, activity_id) do
-      nil ->
-        []
+    case historical_attempts do
+      nil -> []
+      _ ->
+        case Map.get(historical_attempts, activity_id) do
+          nil ->
+            []
 
-      [] ->
-        []
+          [] ->
+            []
 
-      attempts ->
-        {:safe, attempt_selector} =
-          ReactPhoenix.ClientSide.react_component("Components.AttemptSelector", %{
-            activityId: activity_id,
-            attempts:
-              Enum.map(attempts, fn a ->
-                %{
-                  state: a.lifecycle_state,
-                  attemptNumber: a.attempt_number,
-                  attemptGuid: a.attempt_guid,
-                  date:
-                    Timex.format!(a.updated_at, "{Mfull} {D}, {YYYY} at {h12}:{m} {AM} {Zabbr}")
-                }
-              end),
-            sectionSlug: section_slug
-          })
+          attempts ->
+            {:safe, attempt_selector} =
+              ReactPhoenix.ClientSide.react_component("Components.AttemptSelector", %{
+                activityId: activity_id,
+                attempts:
+                  Enum.map(attempts, fn a ->
+                    %{
+                      state: a.lifecycle_state,
+                      attemptNumber: a.attempt_number,
+                      attemptGuid: a.attempt_guid,
+                      date:
+                        Timex.format!(a.updated_at, "{Mfull} {D}, {YYYY} at {h12}:{m} {AM} {Zabbr}")
+                    }
+                  end),
+                sectionSlug: section_slug
+              })
 
-        [attempt_selector]
+            [attempt_selector]
+        end
     end
   end
 


### PR DESCRIPTION
this is for "core" pages. I added a couple Single Response activities set to manual scoring and they would fail to render
