### PR TITLE
[ENHANCEMENT] Remove MCQ submit button

### DIFF
--- a/assets/src/components/activities/common/delivery/submit_button/SubmitButtonConnected.tsx
+++ b/assets/src/components/activities/common/delivery/submit_button/SubmitButtonConnected.tsx
@@ -1,11 +1,6 @@
 import { SubmitButton } from 'components/activities/common/delivery/submit_button/SubmitButton';
 import { useDeliveryElementContext } from 'components/activities/DeliveryElementProvider';
-import {
-  ActivityDeliveryState,
-  isEvaluated,
-  isSubmitted,
-  submit,
-} from 'data/activities/DeliveryState';
+import { ActivityDeliveryState, isSubmitted, submit } from 'data/activities/DeliveryState';
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 

--- a/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
+++ b/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
@@ -13,6 +13,7 @@ import {
   activityDeliverySlice,
   isEvaluated,
   resetAction,
+  submit,
   listenForParentSurveySubmit,
   listenForParentSurveyReset,
   listenForReviewAttemptChange,
@@ -21,12 +22,19 @@ import { Radio } from 'components/misc/icons/radio/Radio';
 import { initialPartInputs, isCorrect } from 'data/activities/utils';
 import { EvaluationConnected } from 'components/activities/common/delivery/evaluation/EvaluationConnected';
 import { HintsDeliveryConnected } from 'components/activities/common/hints/delivery/HintsDeliveryConnected';
-import { SubmitButtonConnected } from 'components/activities/common/delivery/submit_button/SubmitButtonConnected';
 import { ResetButtonConnected } from 'components/activities/common/delivery/reset_button/ResetButtonConnected';
 import { GradedPointsConnected } from 'components/activities/common/delivery/graded_points/GradedPointsConnected';
 import { StemDeliveryConnected } from 'components/activities/common/stem/delivery/StemDelivery';
 import { ChoicesDeliveryConnected } from 'components/activities/common/choices/delivery/ChoicesDeliveryConnected';
 import { castPartId } from '../common/utils';
+
+// Used instead of the real 'onSaveActivity' to bypass saving state to the server when we are just
+// about to submit that state with a submission. This saves a network call that isn't necessary and avoids
+// perhaps a weird race condition (where the submit request could arrive before the save)
+const noOpSave = (
+  _guid: string,
+  _partResponses: ActivityTypes.PartResponse[],
+): Promise<ActivityTypes.Success> => Promise.resolve({ type: 'success' });
 
 export const MultipleChoiceComponent: React.FC = () => {
   const {
@@ -58,6 +66,19 @@ export const MultipleChoiceComponent: React.FC = () => {
     return null;
   }
 
+  const saveOrSubmit =
+    context.graded || context.surveyId !== null
+      ? (id: string) =>
+          dispatch(
+            setSelection(castPartId(activityState.parts[0].partId), id, onSaveActivity, 'single'),
+          )
+      : (input: string) => {
+          dispatch(
+            setSelection(castPartId(activityState.parts[0].partId), input, noOpSave, 'single'),
+          );
+          dispatch(submit(onSubmitActivity));
+        };
+
   return (
     <div className="activity mc-activity">
       <div className="activity-content">
@@ -75,18 +96,13 @@ export const MultipleChoiceComponent: React.FC = () => {
               <Radio.Incorrect />
             )
           }
-          onSelect={(id) =>
-            dispatch(
-              setSelection(castPartId(activityState.parts[0].partId), id, onSaveActivity, 'single'),
-            )
-          }
+          onSelect={(id) => saveOrSubmit(id)}
         />
         <ResetButtonConnected
           onReset={() =>
             dispatch(resetAction(onResetActivity, { [activityState.parts[0].partId]: [] }))
           }
         />
-        <SubmitButtonConnected />
         <HintsDeliveryConnected partId={castPartId(activityState.parts[0].partId)} />
         <EvaluationConnected />
       </div>

--- a/assets/test/multiple_choice/mc_delivery_test.tsx
+++ b/assets/test/multiple_choice/mc_delivery_test.tsx
@@ -57,11 +57,6 @@ describe('multiple choice delivery', () => {
     });
     expect(await screen.findAllByLabelText(/hint [0-9]/)).toHaveLength(1);
 
-    // expect submit button
-    const submitButton = screen.queryByLabelText('submit');
-    expect(submitButton).toBeTruthy();
-    expect(submitButton).toBeDisabled();
-
     // expect 2 choices
     const choices = screen.queryAllByLabelText(/choice [0-9]/);
     expect(choices).toHaveLength(2);
@@ -70,22 +65,8 @@ describe('multiple choice delivery', () => {
     act(() => {
       fireEvent.click(choices[0]);
     });
-    expect(onSaveActivity).toHaveBeenCalledTimes(1);
-    expect(onSaveActivity).toHaveBeenCalledWith(props.state.attemptGuid, [
-      {
-        attemptGuid: '1',
-        response: { input: model.choices.map((choice) => choice.id)[0] },
-      },
-    ]);
-    expect(onSubmitActivity).toHaveBeenCalledTimes(0);
-
-    expect(submitButton).toBeEnabled();
-
-    act(() => {
-      if (submitButton) {
-        fireEvent.click(submitButton);
-      }
-    });
+    expect(onSaveActivity).toHaveBeenCalledTimes(0);
+    expect(onSubmitActivity).toHaveBeenCalledTimes(1);
 
     expect(onSubmitActivity).toHaveBeenCalledTimes(1);
     expect(onSubmitActivity).toHaveBeenCalledWith(props.state.attemptGuid, [


### PR DESCRIPTION
Closes #1584 

Removes the Submit button.  In graded context or in a survey selecting a choice simply saves their state to the server.  In a practice context (and not within a survey) auto submits the response. 

