### PR TITLE
[BUGFIX][MER-744] Display payment codes when generated

### DIFF
--- a/assets/styles/common/utils.scss
+++ b/assets/styles/common/utils.scss
@@ -13,3 +13,7 @@
     cursor: pointer;
   }
 }
+
+.fs-button-download {
+  font-size: 0.6em !important;
+}

--- a/lib/oli/delivery/paywall.ex
+++ b/lib/oli/delivery/paywall.ex
@@ -363,6 +363,24 @@ defmodule Oli.Delivery.Paywall do
   end
 
   @doc """
+  Get the last X(quantity) payment codes for the given product.
+  """
+  def get_payment_codes(count, product_slug) do
+    query =
+      from(
+        p in Payment,
+        left_join: s in Section,
+        on: p.section_id == s.id,
+        where: s.slug == ^product_slug,
+        limit: ^count,
+        select: p,
+        order_by: [desc: :inserted_at]
+      )
+
+    Repo.all(query)
+  end
+
+  @doc """
   Retrieve a payment for a specific provider and id.
   """
   def get_provider_payment(provider_type, provider_id) do
@@ -572,17 +590,5 @@ defmodule Oli.Delivery.Paywall do
     end
     |> Discount.changeset(attrs)
     |> Repo.insert_or_update()
-  end
-
-  def list_last_payment_codes_generated(count) do
-    query =
-      from(
-        p in Payment,
-        limit: ^count,
-        select: p,
-        order_by: [desc: :inserted_at]
-      )
-
-    Repo.all(query)
   end
 end

--- a/lib/oli/delivery/paywall.ex
+++ b/lib/oli/delivery/paywall.ex
@@ -365,7 +365,7 @@ defmodule Oli.Delivery.Paywall do
   @doc """
   Get the last X(quantity) payment codes for the given product.
   """
-  def get_payment_codes(count, product_slug) do
+  def list_payments_by_count(product_slug, count) do
     query =
       from(
         p in Payment,

--- a/lib/oli_web/controllers/payment_controller.ex
+++ b/lib/oli_web/controllers/payment_controller.ex
@@ -103,7 +103,7 @@ defmodule OliWeb.PaymentController do
     end
   end
 
-  defp create_payment_codes_file(conn, data, product_slug) do
+  def create_payment_codes_file(conn, data, product_slug) do
     contents =
       Enum.map(data, fn p ->
         Oli.Delivery.Paywall.Payment.to_human_readable(p.code)

--- a/lib/oli_web/controllers/payment_controller.ex
+++ b/lib/oli_web/controllers/payment_controller.ex
@@ -103,7 +103,7 @@ defmodule OliWeb.PaymentController do
     end
   end
 
-  defp get_contents(conn, data, product_slug) do
+  defp create_payment_codes_file(conn, data, product_slug) do
     contents =
       Enum.map(data, fn p ->
         Oli.Delivery.Paywall.Payment.to_human_readable(p.code)
@@ -119,9 +119,9 @@ defmodule OliWeb.PaymentController do
   @doc """
   Endpoint that triggers download of a batch of payemnt codes.
   """
-  def download_codes_generated(conn, %{"product_id" => product_slug}) do
-    codes = Oli.Delivery.Paywall.list_last_payment_codes_generated(conn.params["count"] || 50)
-    get_contents(conn, codes, product_slug)
+  def download_payment_codes(conn, %{"product_id" => product_slug}) do
+    codes = Oli.Delivery.Paywall.get_payment_codes(conn.params["count"] || 50, product_slug)
+    create_payment_codes_file(conn, codes, product_slug)
   end
 
   @doc """
@@ -130,7 +130,7 @@ defmodule OliWeb.PaymentController do
   def download_codes(conn, %{"count" => count, "product_id" => product_slug}) do
     case Oli.Delivery.Paywall.create_payment_codes(product_slug, String.to_integer(count)) do
       {:ok, payments} ->
-        get_contents(conn, payments, product_slug)
+        create_payment_codes_file(conn, payments, product_slug)
 
       _ ->
         conn

--- a/lib/oli_web/controllers/payment_controller.ex
+++ b/lib/oli_web/controllers/payment_controller.ex
@@ -103,7 +103,7 @@ defmodule OliWeb.PaymentController do
     end
   end
 
-  def create_payment_codes_file(conn, data, product_slug) do
+  defp create_payment_codes_file(conn, data, product_slug) do
     contents =
       Enum.map(data, fn p ->
         Oli.Delivery.Paywall.Payment.to_human_readable(p.code)
@@ -120,7 +120,7 @@ defmodule OliWeb.PaymentController do
   Endpoint that triggers download of a batch of payemnt codes.
   """
   def download_payment_codes(conn, %{"product_id" => product_slug}) do
-    codes = Oli.Delivery.Paywall.get_payment_codes(conn.params["count"] || 50, product_slug)
+    codes = Oli.Delivery.Paywall.list_payments_by_count(product_slug, conn.params["count"] || 50)
     create_payment_codes_file(conn, codes, product_slug)
   end
 

--- a/lib/oli_web/live/products/payments/create_codes.ex
+++ b/lib/oli_web/live/products/payments/create_codes.ex
@@ -7,32 +7,37 @@ defmodule OliWeb.Products.Payments.CreateCodes do
   prop change, :event, required: true
   prop disabled, :boolean, required: true
   data something, :any, default: true
+  prop enabled_download, :boolean, required: true
 
   def render(assigns) do
     ~F"""
-    <div>
+    <div class="d-flex justify-content-between align-items-center">
       <div class="form-inline">
 
         <p>Download a new batch of payment codes:</p>
-        <input class="ml-2 form-control form-control-sm" disabled={@disabled} type="number" value={@count} style="width: 90px;" :on-blur={@change} :on-keyup={@change}/>
+        <input class="ml-2 form-control form-control-sm" disabled={@disabled} type="number" value={@count} style="width: 90px;" :on-blur={@change} :on-keyup={@change} :on-click={@change}/>
 
-        <a class="btn btn-primary btn-sm ml-1" href={route_or_disabled(assigns)}>Create</a>
+        <button class="btn btn-primary btn-sm ml-1" :on-click={@click}>Create</button>
 
       </div>
       <div>
-        <small class="text-muted">You will need to refresh this page to see these newly created codes</small>
+        <a class={"btn btn-outline-primary btn-sm ml-1" <> if @enabled_download, do: "", else: " disabled"} href={route_or_disabled(assigns)} style="font-size: 0.6rem;">Download last created</a>
       </div>
+
     </div>
     """
   end
 
   defp route_or_disabled(assigns) do
-    case assigns.disabled do
-      true ->
-        "#"
-
-      _ ->
-        Routes.payment_path(OliWeb.Endpoint, :download_codes, assigns.product_slug, assigns.count)
+    if assigns.enabled_download do
+      Routes.payment_path(
+        OliWeb.Endpoint,
+        :download_codes_generated,
+        assigns.product_slug,
+        count: assigns.count
+      )
+    else
+      "#"
     end
   end
 end

--- a/lib/oli_web/live/products/payments/create_codes.ex
+++ b/lib/oli_web/live/products/payments/create_codes.ex
@@ -3,11 +3,11 @@ defmodule OliWeb.Products.Payments.CreateCodes do
   alias OliWeb.Router.Helpers, as: Routes
   prop product_slug, :string, required: true
   prop count, :integer, required: true
-  prop click, :event, required: true
+  prop create_codes, :event, required: true
   prop change, :event, required: true
   prop disabled, :boolean, required: true
+  prop download_enabled, :boolean, default: false
   data something, :any, default: true
-  prop enabled_download, :boolean, required: true
 
   def render(assigns) do
     ~F"""
@@ -15,13 +15,13 @@ defmodule OliWeb.Products.Payments.CreateCodes do
       <div class="form-inline">
 
         <p>Download a new batch of payment codes:</p>
-        <input class="ml-2 form-control form-control-sm" disabled={@disabled} type="number" value={@count} style="width: 90px;" :on-blur={@change} :on-keyup={@change} :on-click={@change}/>
+        <input class="ml-2 form-control form-control-sm" disabled={@disabled} type="number" value={@count} style="width: 90px;" :on-blur={@change} :on-focus={@change}/>
 
-        <button class="btn btn-primary btn-sm ml-1" :on-click={@click}>Create</button>
+        <button class="btn btn-primary btn-sm ml-1" :on-click={@create_codes}>Create</button>
 
       </div>
       <div>
-        <a class={"btn btn-outline-primary btn-sm ml-1" <> if @enabled_download, do: "", else: " disabled"} href={route_or_disabled(assigns)} style="font-size: 0.6rem;">Download last created</a>
+        <a class={"btn btn-outline-primary btn-sm ml-1 fs-button-download" <> if @download_enabled, do: "", else: " disabled"} href={route_or_disabled(assigns)}>Download last created</a>
       </div>
 
     </div>
@@ -29,10 +29,10 @@ defmodule OliWeb.Products.Payments.CreateCodes do
   end
 
   defp route_or_disabled(assigns) do
-    if assigns.enabled_download do
+    if assigns.download_enabled do
       Routes.payment_path(
         OliWeb.Endpoint,
-        :download_codes_generated,
+        :download_payment_codes,
         assigns.product_slug,
         count: assigns.count
       )

--- a/lib/oli_web/live/products/payments/tabel_model.ex
+++ b/lib/oli_web/live/products/payments/tabel_model.ex
@@ -5,6 +5,13 @@ defmodule OliWeb.Products.Payments.TableModel do
   alias OliWeb.Common.Utils
 
   def new(payments, context) do
+    inserted_at_spec = %ColumnSpec{
+      name: :generation_date,
+      label: "Created Date",
+      render_fn: &__MODULE__.render_date_column/3,
+      sort_fn: &__MODULE__.sort_date/2
+    }
+
     SortableTableModel.new(
       rows: payments,
       column_specs: [
@@ -14,12 +21,7 @@ defmodule OliWeb.Products.Payments.TableModel do
           render_fn: &__MODULE__.render_type_column/3,
           sort_fn: &__MODULE__.sort/2
         },
-        %ColumnSpec{
-          name: :generation_date,
-          label: "Created Date",
-          render_fn: &__MODULE__.render_date_column/3,
-          sort_fn: &__MODULE__.sort_date/2
-        },
+        inserted_at_spec,
         %ColumnSpec{
           name: :application_date,
           label: "Application Date",
@@ -44,6 +46,8 @@ defmodule OliWeb.Products.Payments.TableModel do
       ],
       event_suffix: "",
       id_field: [:unique_id],
+      sort_by_spec: inserted_at_spec,
+      sort_order: :desc,
       data: %{
         context: context
       }

--- a/lib/oli_web/live/products/payments_view.ex
+++ b/lib/oli_web/live/products/payments_view.ex
@@ -22,7 +22,7 @@ defmodule OliWeb.Products.PaymentsView do
   data limit, :integer, default: 20
   data query, :string, default: ""
   data applied_query, :string, default: ""
-  data enabled_download, :boolean, default: false
+  data download_enabled, :boolean, default: false
 
   @table_filter_fn &OliWeb.Products.PaymentsView.filter_rows/3
   @table_push_patch_path &OliWeb.Products.PaymentsView.live_path/2
@@ -74,7 +74,7 @@ defmodule OliWeb.Products.PaymentsView do
     ~F"""
     <div>
 
-      <CreateCodes id="create_codes" disabled={!@product.requires_payment} count={@code_count} product_slug={@product_slug} enabled_download={@enabled_download} click="create" change="change_count"/>
+      <CreateCodes id="create_codes" disabled={!@product.requires_payment} count={@code_count} product_slug={@product_slug} download_enabled={@download_enabled} create_codes="create" change="change_count"/>
 
       <hr class="mt-5 mb-5"/>
 
@@ -113,10 +113,13 @@ defmodule OliWeb.Products.PaymentsView do
   end
 
   def handle_event("create", _, socket) do
-    case Oli.Delivery.Paywall.create_payment_codes(
-           socket.assigns.product_slug,
-           socket.assigns.code_count
-         ) do
+    create_payment_codes =
+      Oli.Delivery.Paywall.create_payment_codes(
+        socket.assigns.product_slug,
+        socket.assigns.code_count
+      )
+
+    case create_payment_codes do
       {:ok, _} ->
         payments = list_payments(socket.assigns.product_slug)
 
@@ -135,7 +138,7 @@ defmodule OliWeb.Products.PaymentsView do
            payments: payments,
            total_count: total_count,
            table_model: table_model,
-           enabled_download: true
+           download_enabled: true
          )}
 
       _ ->
@@ -152,6 +155,6 @@ defmodule OliWeb.Products.PaymentsView do
         _ -> 1
       end
 
-    {:noreply, assign(socket, code_count: count, enabled_download: false)}
+    {:noreply, assign(socket, code_count: count, download_enabled: false)}
   end
 end

--- a/lib/oli_web/live/products/payments_view.ex
+++ b/lib/oli_web/live/products/payments_view.ex
@@ -1,5 +1,6 @@
 defmodule OliWeb.Products.PaymentsView do
   use Surface.LiveView
+  use OliWeb.Common.SortableTable.TableHandlers
 
   alias(OliWeb.Common.Filter)
 
@@ -21,6 +22,7 @@ defmodule OliWeb.Products.PaymentsView do
   data limit, :integer, default: 20
   data query, :string, default: ""
   data applied_query, :string, default: ""
+  data enabled_download, :boolean, default: false
 
   @table_filter_fn &OliWeb.Products.PaymentsView.filter_rows/3
   @table_push_patch_path &OliWeb.Products.PaymentsView.live_path/2
@@ -51,20 +53,7 @@ defmodule OliWeb.Products.PaymentsView do
   def mount(%{"product_id" => product_slug}, session, socket) do
     context = SessionContext.init(session)
 
-    payments =
-      Oli.Delivery.Paywall.list_payments(product_slug)
-      |> Enum.map(fn element ->
-        Map.put(
-          element,
-          :code,
-          if is_nil(element.payment.code) do
-            ""
-          else
-            Oli.Delivery.Paywall.Payment.to_human_readable(element.payment.code)
-          end
-        )
-        |> Map.put(:unique_id, element.payment.id)
-      end)
+    payments = list_payments(product_slug)
 
     total_count = length(payments)
 
@@ -85,7 +74,7 @@ defmodule OliWeb.Products.PaymentsView do
     ~F"""
     <div>
 
-      <CreateCodes id="create_codes" disabled={!@product.requires_payment} count={@code_count} product_slug={@product_slug} click="create_codes" change="change_count"/>
+      <CreateCodes id="create_codes" disabled={!@product.requires_payment} count={@code_count} product_slug={@product_slug} enabled_download={@enabled_download} click="create" change="change_count"/>
 
       <hr class="mt-5 mb-5"/>
 
@@ -107,6 +96,55 @@ defmodule OliWeb.Products.PaymentsView do
     """
   end
 
+  defp list_payments(product_slug) do
+    Oli.Delivery.Paywall.list_payments(product_slug)
+    |> Enum.map(fn element ->
+      Map.put(
+        element,
+        :code,
+        if is_nil(element.payment.code) do
+          ""
+        else
+          Oli.Delivery.Paywall.Payment.to_human_readable(element.payment.code)
+        end
+      )
+      |> Map.put(:unique_id, element.payment.id)
+    end)
+  end
+
+  def handle_event("create", _, socket) do
+    case Oli.Delivery.Paywall.create_payment_codes(
+           socket.assigns.product_slug,
+           socket.assigns.code_count
+         ) do
+      {:ok, _} ->
+        payments = list_payments(socket.assigns.product_slug)
+
+        {:ok, table_model} =
+          OliWeb.Products.Payments.TableModel.new(
+            payments,
+            socket.assigns.context
+          )
+
+        total_count = length(payments)
+
+        {:noreply,
+         socket
+         |> put_flash(:info, "Payment codes successfully added.")
+         |> assign(
+           payments: payments,
+           total_count: total_count,
+           table_model: table_model,
+           enabled_download: true
+         )}
+
+      _ ->
+        {:noreply,
+         socket
+         |> put_flash(:error, "Code payments couldn't be added.")}
+    end
+  end
+
   def handle_event("change_count", %{"value" => count}, socket) do
     count =
       case String.to_integer(count) do
@@ -114,8 +152,6 @@ defmodule OliWeb.Products.PaymentsView do
         _ -> 1
       end
 
-    {:noreply, assign(socket, code_count: count)}
+    {:noreply, assign(socket, code_count: count, enabled_download: false)}
   end
-
-  use OliWeb.Common.SortableTable.TableHandlers
 end

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -320,7 +320,7 @@ defmodule OliWeb.Router do
     get(
       "/products/:product_id/payments/donwload_codes",
       PaymentController,
-      :download_codes_generated
+      :download_payment_codes
     )
 
     get("/products/:product_id/payments/:count", PaymentController, :download_codes)

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -317,6 +317,12 @@ defmodule OliWeb.Router do
     live("/products/:section_slug/updates", Delivery.ManageUpdates)
     live("/products/:section_slug/remix", Delivery.RemixSection, as: :product_remix)
 
+    get(
+      "/products/:product_id/payments/donwload_codes",
+      PaymentController,
+      :download_codes_generated
+    )
+
     get("/products/:product_id/payments/:count", PaymentController, :download_codes)
 
     live("/account", Workspace.AccountDetailsLive)

--- a/test/oli/delivery/paywall_test.exs
+++ b/test/oli/delivery/paywall_test.exs
@@ -703,4 +703,47 @@ defmodule Oli.Delivery.PaywallTest do
       assert error =~ "can't be blank"
     end
   end
+
+  describe "payments codes" do
+    setup do
+      product =
+        insert(:section, %{
+          type: :blueprint
+        })
+
+      %{
+        product: product
+      }
+    end
+
+    test "get an amount of payment codes for a specific product", %{product: product} do
+      insert(:payment, section: product, code: 123_456_789)
+      insert(:payment, section: product, code: 987_654_321)
+
+      codes = Paywall.list_payments_by_count(product.slug, 2)
+      assert length(codes) == 2
+    end
+
+    test "request more payment codes than the total number of existing payment codes, returns the amount of total existing payment codes",
+         %{
+           product: product
+         } do
+      insert(:payment, section: product, code: 123_456_789)
+      insert(:payment, section: product, code: 987_654_321)
+
+      codes = Paywall.list_payments_by_count(product.slug, 3)
+      assert length(codes) == 2
+    end
+
+    test "request less payment codes than the total number of existing payment codes, returns the amount of total existing payment codes",
+         %{
+           product: product
+         } do
+      insert(:payment, section: product, code: 123_456_789)
+      insert(:payment, section: product, code: 987_654_321)
+
+      codes = Paywall.list_payments_by_count(product.slug, 1)
+      assert length(codes) == 1
+    end
+  end
 end

--- a/test/oli_web/controllers/api/payment_controller_test.exs
+++ b/test/oli_web/controllers/api/payment_controller_test.exs
@@ -163,11 +163,7 @@ defmodule OliWeb.PaymentControllerTest do
           type: :blueprint
         })
 
-      admin = author_fixture(%{system_role_id: Oli.Accounts.SystemRole.role_id().admin})
-
-      conn =
-        conn
-        |> Pow.Plug.assign_current_user(admin, OliWeb.Pow.PowHelpers.get_pow_config(:author))
+      {:ok, conn: conn, admin: _admin} = admin_conn(%{conn: conn})
 
       code1 = generate_payment_code(product, 123_456_789)
 
@@ -201,6 +197,23 @@ defmodule OliWeb.PaymentControllerTest do
         )
 
       assert response(conn_without_count, 200) =~ "#{code1}\n#{code2}\n#{code3}"
+    end
+
+    test "download .txt file of a product that has no payment codes generated", %{conn: conn} do
+      product =
+        insert(:section, %{
+          type: :blueprint
+        })
+
+      {:ok, conn: conn, admin: _admin} = admin_conn(%{conn: conn})
+
+      conn =
+        get(
+          conn,
+          Routes.payment_path(OliWeb.Endpoint, :download_payment_codes, product.slug, count: 2)
+        )
+
+      assert response(conn, 200) =~ ""
     end
   end
 

--- a/test/oli_web/controllers/api/payment_controller_test.exs
+++ b/test/oli_web/controllers/api/payment_controller_test.exs
@@ -5,6 +5,8 @@ defmodule OliWeb.PaymentControllerTest do
 
   alias Oli.Seeder
   alias OliWeb.Router.Helpers, as: Routes
+  alias OliWeb.PaymentController
+  alias Oli.Delivery.Paywall
 
   describe "payment controller tests" do
     setup [:setup_session]
@@ -147,6 +149,25 @@ defmodule OliWeb.PaymentControllerTest do
       assert html_response(conn, 200) =~ "<input type=\"text\" disabled value=\"$100.00\"/>"
 
       reset_test_payment_config()
+    end
+
+    test "download a file with the last payment codes created", %{conn: conn} do
+      product = insert(:section, %{amount: Money.new(:USD, "50.00")})
+      Paywall.create_payment_codes(product.slug, 2)
+      codes = Paywall.get_payment_codes(2, product.slug)
+
+      assert response(
+               PaymentController.create_payment_codes_file(conn, codes, product.slug),
+               200
+             )
+    end
+
+    test "call 'get_payment_codes/2' return codes for a specific section" do
+      product = insert(:section, %{amount: Money.new(:USD, "50.00")})
+      Paywall.create_payment_codes(product.slug, 3)
+      codes = Paywall.get_payment_codes(3, product.slug)
+
+      assert length(codes) == 3
     end
   end
 

--- a/test/oli_web/live/payments_live_test.exs
+++ b/test/oli_web/live/payments_live_test.exs
@@ -1,0 +1,106 @@
+defmodule OliWeb.PaymentsLiveTest do
+  use ExUnit.Case
+  use OliWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+  import Oli.Factory
+
+  alias OliWeb.Router.Helpers, as: Routes
+  alias Oli.Delivery.Paywall.Payment
+
+  defp create_product(_conn) do
+    product =
+      insert(:section, type: :blueprint, requires_payment: true, amount: Money.new(:USD, 10))
+
+    [product: product]
+  end
+
+  defp live_view_payments_route(product_slug) do
+    Routes.live_path(OliWeb.Endpoint, OliWeb.Products.PaymentsView, product_slug)
+  end
+
+  @live_view_payment_route Routes.live_path(
+                             OliWeb.Endpoint,
+                             OliWeb.Products.PaymentsView,
+                             "test_product"
+                           )
+
+  @live_view_product_route Routes.live_path(
+                             OliWeb.Endpoint,
+                             OliWeb.Products.ProductsView,
+                             "test_product"
+                           )
+
+  describe "user cannot access when is not logged in" do
+    test "redirects to new session when accessing the index view", %{conn: conn} do
+      {:error,
+       {:redirect,
+        %{
+          to:
+            "/authoring/session/new?request_path=%2Fauthoring%2Fproducts%2Ftest_product%2Fpayments"
+        }}} = live(conn, @live_view_payment_route)
+    end
+  end
+
+  describe "user cannot access when is logged in as an author but is not a system admin" do
+    setup [:author_conn]
+
+    test "redirects to projects overview when accessing the payments view", %{conn: conn} do
+      {:error, {:redirect, %{to: "/authoring/projects"}}} = live(conn, @live_view_product_route)
+    end
+  end
+
+  describe "payments" do
+    setup [:admin_conn, :create_product]
+
+    test "loads correctly when there are no payments", %{conn: conn, product: product} do
+      {:ok, view, _html} = live(conn, live_view_payments_route(product.slug))
+
+      assert has_element?(view, "button", "Create")
+      assert has_element?(view, "a", "Download last created")
+      assert has_element?(view, "input[phx-change=\"change_search\"]")
+      assert has_element?(view, "p", "None exist")
+      refute has_element?(view, ".table .table-striped .table-bordered .table-sm")
+    end
+
+    test "download button is disabled if no code has been created", %{
+      conn: conn,
+      product: product
+    } do
+      {:ok, view, _html} = live(conn, live_view_payments_route(product.slug))
+
+      assert view
+             |> element("a")
+             |> render() =~ "disabled"
+    end
+
+    test "download button is enabled if any code has been created", %{
+      conn: conn,
+      product: product
+    } do
+      {:ok, view, _html} = live(conn, live_view_payments_route(product.slug))
+
+      view
+      |> element("button[phx-click=\"create\"]")
+      |> render_click()
+
+      refute view
+             |> element("a", "Download last created")
+             |> render() =~ "disabled"
+    end
+
+    test "When create codes button is clicked, codes are created and listing in a table", %{
+      conn: conn,
+      product: product
+    } do
+      {:ok, view, _html} = live(conn, live_view_payments_route(product.slug))
+
+      view
+      |> element("button[phx-click=\"create\"]")
+      |> render_click()
+
+      assert has_element?(view, ".table")
+      assert has_element?(view, "td")
+    end
+  end
+end

--- a/test/oli_web/live/payments_live_test.exs
+++ b/test/oli_web/live/payments_live_test.exs
@@ -107,7 +107,7 @@ defmodule OliWeb.PaymentsLiveTest do
       # Simulate entering a number of payment codes to be created
       view
       |> element("input[phx-blur=\"change_count\"]")
-      |> render_blur(%{value: "4"})
+      |> render_blur(%{value: "1"})
 
       # Simulate clicking on the button to create payment codes
       view
@@ -115,15 +115,15 @@ defmodule OliWeb.PaymentsLiveTest do
       |> render_click()
 
       # Get the payment codes generated for a current product
-      [hd | _] = codes = Paywall.list_payments_by_count(product.slug, 4)
+      [hd | _] = codes = Paywall.list_payments_by_count(product.slug, 1)
       code_to_test = Payment.to_human_readable(hd.code)
 
       # Test that payment codes were obtained.
-      assert length(codes) == 4
+      assert length(codes) == 1
 
       # Test that the table contains at least one code
       assert view
-             |> element("tr:last-child > td:first-child > div")
+             |> element("tr:first-child > td:first-child > div")
              |> render() =~ "Code: <code>#{code_to_test}</code>"
     end
   end


### PR DESCRIPTION
[MER-744](https://eliterate.atlassian.net/browse/MER-744)

This PR mainly solves the error that was occurring when adding new payment codes for a product. Now, the payment codes table is updated when adding them.

Also, a button has been added to download newly generated payment codes to a .txt file.

<img width="1438" alt="Captura de Pantalla 2022-09-29 a la(s) 20 43 21" src="https://user-images.githubusercontent.com/16328384/193160854-b9a6f0fe-3e35-46f9-a885-ce540b378127.png">



