### PR TITLE
[PERFORMANCE] delay and coalesce edits in input questions

### DIFF
--- a/assets/src/components/activities/common/delivery/inputs/NumericInput.tsx
+++ b/assets/src/components/activities/common/delivery/inputs/NumericInput.tsx
@@ -5,6 +5,7 @@ interface Props {
   disabled?: boolean;
   placeholder?: string;
   onChange: (value: string) => void;
+  onBlur?: () => void;
 }
 export const NumericInput: React.FC<Props> = (props) => {
   const input = createRef<HTMLInputElement>();
@@ -20,6 +21,7 @@ export const NumericInput: React.FC<Props> = (props) => {
       aria-label="answer submission textbox"
       className="form-control"
       onChange={(e) => props.onChange(e.target.value)}
+      onBlur={props.onBlur}
       value={props.value}
       disabled={typeof props.disabled === 'boolean' ? props.disabled : false}
       onWheel={handleScrollWheelChange}

--- a/assets/src/components/activities/common/delivery/inputs/TextInput.tsx
+++ b/assets/src/components/activities/common/delivery/inputs/TextInput.tsx
@@ -5,8 +5,9 @@ interface Props {
   disabled?: boolean;
   placeholder?: string;
   onChange: (value: string) => void;
+  onBlur?: () => void;
 }
-export const TextInput: React.FC<Props> = ({ onChange, value, disabled, placeholder }) => {
+export const TextInput: React.FC<Props> = ({ onChange, value, disabled, placeholder, onBlur }) => {
   return (
     <input
       placeholder={placeholder}
@@ -14,6 +15,7 @@ export const TextInput: React.FC<Props> = ({ onChange, value, disabled, placehol
       aria-label="answer submission textbox"
       className="form-control"
       onChange={(e) => onChange(e.target.value)}
+      onBlur={onBlur}
       value={value}
       disabled={typeof disabled === 'boolean' ? disabled : false}
     />

--- a/assets/src/components/activities/common/delivery/inputs/TextareaInput.tsx
+++ b/assets/src/components/activities/common/delivery/inputs/TextareaInput.tsx
@@ -6,6 +6,7 @@ interface Props {
   cols?: number;
   disabled?: boolean;
   onChange: (value: string) => void;
+  onBlur?: () => void;
 }
 export const TextareaInput: React.FC<Props> = (props) => {
   return (
@@ -15,6 +16,7 @@ export const TextareaInput: React.FC<Props> = (props) => {
       cols={typeof props.rows === 'number' ? props.cols : 80}
       className="form-control"
       onChange={(e) => props.onChange(e.target.value)}
+      onBlur={props.onBlur}
       value={props.value}
       disabled={typeof props.disabled === 'boolean' ? props.disabled : false}
     ></textarea>

--- a/assets/src/components/activities/common/delivery/persistence.ts
+++ b/assets/src/components/activities/common/delivery/persistence.ts
@@ -1,0 +1,15 @@
+import { DeferredPersistenceStrategy } from 'data/persistence/DeferredPersistenceStrategy';
+import { PersistenceStrategy, PersistenceState } from 'data/persistence/PersistenceStrategy';
+import { LockResult } from 'data/persistence//lock';
+
+export function initializePersistence(): PersistenceStrategy {
+  const p = new DeferredPersistenceStrategy();
+  const noOpLockAcquire = () => Promise.resolve({ type: 'acquired' } as LockResult);
+  const noOpLockRelease = () => Promise.resolve({ type: 'released' } as LockResult);
+  const noOpSuccess = () => {};
+  const noOpFailure = (_f: string) => {};
+  const noOpStateChanged = (_s: PersistenceState) => {};
+
+  p.initialize(noOpLockAcquire, noOpLockRelease, noOpSuccess, noOpFailure, noOpStateChanged);
+  return p;
+}

--- a/assets/src/data/content/writers/context.ts
+++ b/assets/src/data/content/writers/context.ts
@@ -6,6 +6,7 @@ export interface WriterContext {
   sectionSlug?: string;
   bibParams?: any;
   inputRefContext?: {
+    onBlur: (id: string) => void;
     onChange: (id: string, value: string) => void;
     toggleHints: (id: string) => void;
     inputs: Map<

--- a/assets/src/data/content/writers/html.tsx
+++ b/assets/src/data/content/writers/html.tsx
@@ -397,6 +397,7 @@ export class HtmlParser implements WriterImpl {
 
     const shared = {
       onChange: (value: string) => inputRefContext.onChange(inputRef.id, value),
+      onBlur: () => inputRefContext.onBlur(inputRef.id),
       value: valueOr(inputData.value, ''),
       disabled: inputRefContext.disabled,
       placeholder: inputData.placeholder || '',

--- a/assets/test/short_answer/short_answer_delivery_test.tsx
+++ b/assets/test/short_answer/short_answer_delivery_test.tsx
@@ -62,8 +62,6 @@ describe('multiple choice delivery', () => {
       });
     });
 
-    expect(onSaveActivity).toHaveBeenCalledTimes(1);
-
     // expect a submit button
     const submitButton = screen.getByLabelText('submit');
     expect(submitButton).toBeTruthy();


### PR DESCRIPTION
This PR introduces the same "delay and coalesce" saving logic that we use in Authoring into the Single Response and Multi-Input delivery implementations. This should fix the second most impactful performance that we see in AppSignal (for Proton, at least)

Without this PR, every character that a student types into a text field generates a network request to save the full value of the text of that text field.  So, if the student types:

`My answer to this question contains several important points and demonstrates my complete lack of understanding`

The system would generate 112 network requests to incrementatlly save:

`M`
`My`
`My `
`My a`
`My an`
`My ans`
`My answ`
`My answe`
`My answer`
...and so on.

Depending on how quickly a student types, the number of total network requests with the new implementation can be as little as 2.  `onBlur` handling is introduced to guarantee on quick transitions to navigate away from the page or into other questions that pending saves are immediately flushed.  