### PR TITLE
[Feature] Audio support on popups. [MER-1470]

### DIFF
--- a/assets/src/components/common/Popup.tsx
+++ b/assets/src/components/common/Popup.tsx
@@ -1,0 +1,45 @@
+import React, { useCallback } from 'react';
+import { OverlayTriggerType } from 'react-bootstrap/esm/OverlayTrigger';
+import { Popup as PopupModel } from 'data/content/model/elements/types';
+import { OverlayTrigger, Popover } from 'react-bootstrap';
+import { useAudio } from '../hooks/useAudio';
+
+interface Props {
+  children: React.ReactNode;
+  popupContent: React.ReactNode;
+  popup: PopupModel;
+}
+export const Popup: React.FC<Props> = ({ children, popupContent, popup }) => {
+  const trigger: OverlayTriggerType[] = popup.trigger === 'hover' ? ['hover', 'focus'] : ['focus'];
+  const { audioPlayer, playAudio, isPlaying } = useAudio(popup.audioSrc);
+
+  const onToggle = useCallback(
+    (isOpen: boolean) => {
+      if (isOpen) {
+        playAudio();
+      } else {
+        if (isPlaying) playAudio();
+      }
+    },
+    [isPlaying, playAudio],
+  );
+
+  const overlayContent = (
+    <Popover id={popup.id}>
+      <Popover.Content className="popup__content">{popupContent}</Popover.Content>
+    </Popover>
+  );
+
+  return (
+    <OverlayTrigger trigger={trigger} placement="top" overlay={overlayContent} onToggle={onToggle}>
+      <span
+        tabIndex={0}
+        role="button"
+        className={`popup__anchorText${trigger.includes('hover') ? '' : ' popup__click'}`}
+      >
+        {children}
+        {audioPlayer}
+      </span>
+    </OverlayTrigger>
+  );
+};

--- a/assets/src/components/editing/elements/common/AudioClipPicker.tsx
+++ b/assets/src/components/editing/elements/common/AudioClipPicker.tsx
@@ -12,6 +12,9 @@ interface Props {
 }
 
 // Sub-component used in other editors to select & preview an audio clip.
+// This will open a modal to choose an audio clip, bootstrap does not support
+// multiple modals open at once, so if you're already in a modal please use
+// InlineAudioClipPicker instead.
 export const AudioClipPicker: React.FC<Props> = ({
   clipSrc,
   onChange,
@@ -39,7 +42,7 @@ export const AudioClipPicker: React.FC<Props> = ({
       <button
         onClick={onChangeAudio}
         type="button"
-        className="btn btn-sm btn-outline-secondary btn-pronunciation-audio"
+        className="btn btn-sm btn-outline-secondary btn-pronunciation-audio tool-button"
         data-toggle="tooltip"
         data-placement="top"
         title="Browse for audio"
@@ -52,7 +55,7 @@ export const AudioClipPicker: React.FC<Props> = ({
           <button
             type="button"
             onClick={playAudio}
-            className="btn btn-sm btn-outline-success btn-pronunciation-audio "
+            className="btn btn-sm btn-outline-success btn-pronunciation-audio tool-button"
             data-toggle="tooltip"
             data-placement="top"
             title="Preview audio file"
@@ -62,7 +65,7 @@ export const AudioClipPicker: React.FC<Props> = ({
           <button
             type="button"
             onClick={onRemoveAudio}
-            className="btn btn-sm btn-outline-danger btn-pronunciation-audio "
+            className="btn btn-sm btn-outline-danger btn-pronunciation-audio tool-button"
             data-toggle="tooltip"
             data-placement="top"
             title="Remove audio file"

--- a/assets/src/components/editing/elements/common/InlineAudioClipPicker.tsx
+++ b/assets/src/components/editing/elements/common/InlineAudioClipPicker.tsx
@@ -1,0 +1,121 @@
+import React, { useCallback, useRef, useState } from 'react';
+import { AudioSource } from '../../../../data/content/model/elements/types';
+import { MediaItem } from '../../../../types/media';
+import { useAudio } from '../../../hooks/useAudio';
+import { MIMETYPE_FILTERS, SELECTION_TYPES } from '../../../media/manager/MediaManager';
+import { UrlOrUpload } from '../../../media/UrlOrUpload';
+import { CommandContext } from '../commands/interfaces';
+import { AudioClipProvider } from './settings/AudioClipPickerSettings';
+
+interface Props {
+  clipSrc?: string;
+  commandContext: CommandContext;
+  onChange: (src?: AudioSource) => void;
+  children?: React.ReactNode;
+}
+
+// Sub-component used in other editors to select & preview an audio clip.
+// This version is suitable to use inside a modal dialog, it will open an absolute positioned
+// div within the existing dialog, whereas <AudioClipPicker> opens it's own modal.
+export const InlineAudioClipPicker: React.FC<Props> = ({
+  clipSrc,
+  onChange,
+  commandContext,
+  children,
+}) => {
+  const { audioPlayer, playAudio, isPlaying } = useAudio(clipSrc);
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  const onUrlSelection = (url: string) => {
+    if (url.length > 0) {
+      onChange({ url, contenttype: 'audio/mpeg' });
+    } else {
+      onChange(undefined);
+    }
+  };
+
+  const closePicker = useCallback(() => setPickerOpen(false), []);
+  const onMediaSelection = (sel: MediaItem[]) => {
+    if (sel.length > 0) {
+      const url = sel[0].url;
+      const contenttype = sel[0].mimeType;
+      onChange({ url, contenttype });
+    } else {
+      onChange(undefined);
+    }
+    setPickerOpen(false);
+  };
+
+  const onChangeAudio = useCallback(() => {
+    setPickerOpen((current) => !current);
+  }, []);
+
+  const onRemoveAudio = useCallback(() => {
+    if (isPlaying) {
+      playAudio();
+    }
+    onChange(undefined);
+  }, [isPlaying, onChange, playAudio]);
+
+  return (
+    <AudioClipProvider>
+      <div className="audio-picker audio-picker-inline">
+        {children}
+        <button
+          onClick={onChangeAudio}
+          type="button"
+          className="btn btn-sm btn-outline-secondary btn-pronunciation-audio tool-button"
+          data-toggle="tooltip"
+          data-placement="top"
+          title="Browse for audio"
+        >
+          <span className="material-icons ">audio_file</span>
+        </button>
+        {clipSrc && (
+          <>
+            {audioPlayer}
+            <button
+              type="button"
+              onClick={playAudio}
+              className="btn btn-sm btn-outline-success btn-pronunciation-audio tool-button"
+              data-toggle="tooltip"
+              data-placement="top"
+              title="Preview audio file"
+            >
+              <span className="material-icons">{isPlaying ? 'stop_circle' : 'play_circle'}</span>
+            </button>
+            <button
+              type="button"
+              onClick={onRemoveAudio}
+              className="btn btn-sm btn-outline-danger btn-pronunciation-audio tool-button"
+              data-toggle="tooltip"
+              data-placement="top"
+              title="Remove audio file"
+            >
+              <span className="material-icons">delete</span>
+            </button>
+          </>
+        )}
+      </div>
+      {pickerOpen && (
+        <div className="audio-clip-browser-modal">
+          <UrlOrUpload
+            onUrlChange={onUrlSelection}
+            onMediaSelectionChange={onMediaSelection}
+            projectSlug={commandContext.projectSlug}
+            mimeFilter={MIMETYPE_FILTERS.AUDIO}
+            selectionType={SELECTION_TYPES.SINGLE}
+          />
+          <div className="audio-clip-footer">
+            <button className="btn btn-link" type="button" onClick={closePicker}>
+              Cancel
+            </button>
+            <button className="btn btn-primary" type="button" onClick={closePicker}>
+              Select Audio
+            </button>
+          </div>
+        </div>
+      )}
+    </AudioClipProvider>
+  );
+};

--- a/assets/src/components/editing/elements/common/settings/AudioClipPickerSettings.tsx
+++ b/assets/src/components/editing/elements/common/settings/AudioClipPickerSettings.tsx
@@ -13,64 +13,75 @@ const dismiss = () => window.oliDispatch(modalActions.dismiss());
 const display = (c: any) => window.oliDispatch(modalActions.display(c));
 const store = configureStore();
 
+interface Props {
+  resolve: (src: AudioSource) => void;
+  projectSlug: string;
+}
+
+export const AudioClipProvider: React.FC = ({ children }) => {
+  return <Provider store={store}>{children}</Provider>;
+};
+
+const MediaLibrary: React.FC<Props> = ({ projectSlug, resolve }) => {
+  const [selected, setSelected] = useState(Maybe.nothing<AudioSource>());
+
+  const onUrlSelection = (url: string) => {
+    if (url.length > 0) {
+      setSelected(
+        Maybe.just({
+          url,
+          contenttype: 'audio/mp3',
+        }),
+      );
+    } else {
+      setSelected(Maybe.nothing());
+    }
+  };
+
+  const onMediaSelection = (mediaOrUrl: MediaItem[]) => {
+    if (mediaOrUrl && mediaOrUrl.length > 0) {
+      // The user picked a MediaItem from the media library which has mime info with it.
+      setSelected(
+        Maybe.just({
+          url: mediaOrUrl[0].url,
+          contenttype: mediaOrUrl[0].mimeType,
+        }),
+      );
+    } else {
+      setSelected(Maybe.nothing());
+    }
+  };
+  return (
+    <AudioClipProvider>
+      <Modal
+        backdrop="static"
+        title="Select Audio"
+        size={ModalSize.X_LARGE}
+        onOk={() => {
+          dismiss();
+          resolve(selected.valueOrThrow());
+        }}
+        onCancel={dismiss}
+        disableOk={selected.caseOf({ just: () => false, nothing: () => true })}
+        okLabel="Select"
+      >
+        <UrlOrUpload
+          onUrlChange={onUrlSelection}
+          onMediaSelectionChange={onMediaSelection}
+          projectSlug={projectSlug}
+          mimeFilter={MIMETYPE_FILTERS.AUDIO}
+          selectionType={SELECTION_TYPES.SINGLE}
+        />
+      </Modal>
+    </AudioClipProvider>
+  );
+};
+
 export function selectAudio(
   projectSlug: string,
   _selectedUrl?: string,
 ): Promise<AudioSource | undefined> {
   return new Promise((resolve, _reject) => {
-    const [selected, setSelected] = useState(Maybe.nothing<AudioSource>());
-
-    const onUrlSelection = (url: string) => {
-      if (url.length > 0) {
-        setSelected(
-          Maybe.just({
-            url,
-            contenttype: 'audio/mp3',
-          }),
-        );
-      } else {
-        setSelected(Maybe.nothing());
-      }
-    };
-
-    const onMediaSelection = (mediaOrUrl: MediaItem[]) => {
-      if (mediaOrUrl && mediaOrUrl.length > 0) {
-        // The user picked a MediaItem from the media library which has mime info with it.
-        setSelected(
-          Maybe.just({
-            url: mediaOrUrl[0].url,
-            contenttype: mediaOrUrl[0].mimeType,
-          }),
-        );
-      } else {
-        setSelected(Maybe.nothing());
-      }
-    };
-
-    const mediaLibrary = (
-      <Provider store={store}>
-        <Modal
-          title="Select Audio"
-          size={ModalSize.X_LARGE}
-          onOk={() => {
-            dismiss();
-            resolve(selected.valueOrThrow());
-          }}
-          onCancel={dismiss}
-          disableOk={selected.caseOf({ just: () => false, nothing: () => true })}
-          okLabel="Select"
-        >
-          <UrlOrUpload
-            onUrlChange={onUrlSelection}
-            onMediaSelectionChange={onMediaSelection}
-            projectSlug={projectSlug}
-            mimeFilter={MIMETYPE_FILTERS.AUDIO}
-            selectionType={SELECTION_TYPES.SINGLE}
-          />
-        </Modal>
-      </Provider>
-    );
-
-    display(mediaLibrary);
+    display(<MediaLibrary projectSlug={projectSlug} resolve={resolve} />);
   });
 }

--- a/assets/src/components/editing/elements/popup/PopupContentModal.tsx
+++ b/assets/src/components/editing/elements/popup/PopupContentModal.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { RichText } from 'components/activities/types';
 import { RichTextEditor } from 'components/content/RichTextEditor';
 import { CommandContext } from 'components/editing/elements/commands/interfaces';
 import * as ContentModel from 'data/content/model/elements/types';
 import { OverlayTriggerType } from 'react-bootstrap/esm/OverlayTrigger';
 import { Modal, ModalSize } from 'components/modal/Modal';
+import { InlineAudioClipPicker } from '../common/InlineAudioClipPicker';
 
 interface Props {
   onDone: (changes: Partial<ContentModel.Popup>) => void;
@@ -15,8 +16,18 @@ interface Props {
 export const PopupContentModal = (props: Props) => {
   const [content, setContent] = React.useState<RichText>(props.model.content);
   const [trigger, setTrigger] = React.useState(props.model.trigger);
+  const [audioParams, setAudioParams] = React.useState({
+    audioSrc: props.model.audioSrc,
+    audioType: props.model.audioType,
+  });
 
   const isTriggerMode = (mode: OverlayTriggerType) => mode === trigger;
+  const onAudioChange = useCallback((src?: ContentModel.AudioSource) => {
+    setAudioParams({
+      audioSrc: src?.url,
+      audioType: src?.contenttype,
+    });
+  }, []);
 
   const triggerSettings = (
     <form onSubmit={() => {}} id="popup__trigger_mode">
@@ -53,25 +64,33 @@ export const PopupContentModal = (props: Props) => {
 
   return (
     <Modal
-      title=""
-      size={ModalSize.MEDIUM}
+      title="Popup Content"
+      size={ModalSize.LARGE}
       okLabel="Save"
       cancelLabel="Cancel"
       onCancel={props.onCancel}
-      onOk={() => props.onDone({ content, trigger })}
+      onOk={() => props.onDone({ content, trigger, ...audioParams })}
     >
-      <div className="row">
+      <div className="row popup-modal-content">
         <div className="col-12">
-          <h3 className="mb-2">Popup Content</h3>
           <p className="mb-4">Shown to students when triggered</p>
           <div className="popup__modalContent">
             {triggerSettings}
+
             <RichTextEditor
               editMode={true}
               projectSlug={props.commandContext.projectSlug}
               value={content}
               onEdit={(content) => setContent(content as RichText)}
             />
+
+            <InlineAudioClipPicker
+              commandContext={props.commandContext}
+              clipSrc={audioParams.audioSrc}
+              onChange={onAudioChange}
+            >
+              Audio to play
+            </InlineAudioClipPicker>
           </div>
         </div>
       </div>

--- a/assets/src/components/editing/elements/popup/PopupElement.scss
+++ b/assets/src/components/editing/elements/popup/PopupElement.scss
@@ -27,4 +27,5 @@
 .popup__modalContent {
   text-align: initial;
   min-width: 600px;
+  min-height: 485px;
 }

--- a/assets/src/components/modal/Modal.tsx
+++ b/assets/src/components/modal/Modal.tsx
@@ -17,6 +17,7 @@ export interface ModalProps {
   okClassName?: string;
   cancelLabel?: string;
   disableOk?: boolean;
+  backdrop?: string;
   hideDialogCloseButton?: boolean;
   title: string;
   hideOkButton?: boolean;
@@ -64,7 +65,7 @@ export const Modal = (props: PropsWithChildren<ModalProps>) => {
   };
 
   return (
-    <div ref={modal} data-backdrop="true" className="modal">
+    <div ref={modal} data-backdrop={props.backdrop} className="modal">
       <div className={`modal-dialog modal-dialog-centered modal-${size}`} role="document">
         <div className="modal-content">
           <div className="modal-header">
@@ -108,4 +109,8 @@ export const Modal = (props: PropsWithChildren<ModalProps>) => {
       </div>
     </div>
   );
+};
+
+Modal.defaultProps = {
+  backdrop: 'true',
 };

--- a/assets/src/components/modal/ModalDisplay.tsx
+++ b/assets/src/components/modal/ModalDisplay.tsx
@@ -32,6 +32,9 @@ const mapStateToProps = (state: State, _ownProps: OwnProps): StateProps => {
   };
 };
 
+const w = window as any;
+w.init_count = w.init_count || 0;
+
 const mapDispatchToProps = (dispatch: Dispatch, _ownProps: OwnProps): DispatchProps => {
   window.oliDispatch = dispatch;
 

--- a/assets/src/data/content/model/elements/types.ts
+++ b/assets/src/data/content/model/elements/types.ts
@@ -349,6 +349,8 @@ export interface InputRef extends SlateElement<Text[]> {
 export interface Popup extends SlateElement<Text[]> {
   type: 'popup';
   trigger: any;
+  audioSrc?: string;
+  audioType?: string;
   content: RichText;
 }
 

--- a/assets/src/data/content/writers/html.tsx
+++ b/assets/src/data/content/writers/html.tsx
@@ -35,7 +35,7 @@ import {
   ModelElement,
   OrderedList,
   Paragraph,
-  Popup,
+  Popup as PopupModel,
   Table,
   TableData,
   TableHeader,
@@ -50,8 +50,6 @@ import {
 } from 'data/content/model/elements/types';
 import { Mark } from 'data/content/model/text';
 import React from 'react';
-import { OverlayTrigger, Popover } from 'react-bootstrap';
-import { OverlayTriggerType } from 'react-bootstrap/esm/OverlayTrigger';
 import { Text } from 'slate';
 import { assertNever, valueOr } from 'utils/common';
 import {
@@ -69,6 +67,7 @@ import { Figure as FigureElement } from '../../../components/common/Figure';
 import { Dialog } from '../../../components/Dialog';
 import { Conjugation } from '../../../components/common/Conjugation';
 import { TableConjugation } from '../../../components/common/TableConjugation';
+import { Popup } from '../../../components/common/Popup';
 
 // Important: any changes to this file must be replicated
 // in content/html.ex for non-activity rendering.
@@ -444,26 +443,11 @@ export class HtmlParser implements WriterImpl {
     }
   }
 
-  popup(context: WriterContext, anchorNext: Next, contentNext: Next, popup: Popup) {
-    const trigger: OverlayTriggerType[] =
-      this.escapeXml(popup.trigger) === 'hover' ? ['hover', 'focus'] : ['focus'];
-
-    const popupContent = (
-      <Popover id={popup.id}>
-        <Popover.Content className="popup__content">{contentNext()}</Popover.Content>
-      </Popover>
-    );
-
+  popup(context: WriterContext, anchorNext: Next, contentNext: Next, popup: PopupModel) {
     return (
-      <OverlayTrigger trigger={trigger} placement="top" overlay={popupContent}>
-        <span
-          tabIndex={0}
-          role="button"
-          className={`popup__anchorText${trigger.includes('hover') ? '' : ' popup__click'}`}
-        >
-          {anchorNext()}
-        </span>
-      </OverlayTrigger>
+      <Popup popup={popup} popupContent={contentNext()}>
+        {anchorNext()}
+      </Popup>
     );
   }
 

--- a/assets/src/phoenix/app.ts
+++ b/assets/src/phoenix/app.ts
@@ -68,10 +68,27 @@ $(() => {
   ($('.ui.dropdown') as any).dropdown();
   ($('.ui.dropdown.item') as any).dropdown();
 
+  $('[data-toggle="popover"]').on('show.bs.popover', function () {
+    const audioAttribute = this.attributes.getNamedItem('data-audio');
+    if (audioAttribute) {
+      const audio = ($('#' + audioAttribute.value) as JQuery<HTMLAudioElement>)[0];
+      audio.currentTime = 0;
+      audio.play();
+    }
+  });
+
+  $('[data-toggle="popover"]').on('hide.bs.popover', function () {
+    const audioAttribute = this.attributes.getNamedItem('data-audio');
+    if (audioAttribute) {
+      ($('#' + audioAttribute.value) as JQuery<HTMLAudioElement>)[0].pause();
+    }
+  });
+
   $('[data-toggle="popover"]').on('focus', (e) => {
     ($('[data-toggle="popover"]:not(.popup__click)') as any).popover('hide');
     ($(e.target) as any).popover('show');
   });
+
   $('[data-toggle="popover"]').on('blur', (e) => {
     if (!$(e.target).hasClass('popup__click')) {
       ($(e.target) as any).popover('hide');

--- a/assets/styles/authoring/controls.scss
+++ b/assets/styles/authoring/controls.scss
@@ -116,7 +116,29 @@
   flex-direction: row;
   gap: 8px;
   align-items: center;
-  button {
+
+  button.tool-button {
     padding: 2px 0px 0px 0px;
+  }
+
+  .audio-clip-browser {
+    flex-grow: 1;
+  }
+}
+
+.audio-clip-browser-modal {
+  position: absolute;
+  min-height: 618px;
+  background-color: $body-bg;
+  left: 0px;
+  top: 0px;
+  right: 0px;
+  .audio-clip-footer {
+    display: flex;
+    flex-direction: row;
+    gap: 1em;
+    position: absolute;
+    right: 5px;
+    bottom: 5px;
   }
 }

--- a/priv/schemas/v0-1-0/content-element.schema.json
+++ b/priv/schemas/v0-1-0/content-element.schema.json
@@ -970,6 +970,12 @@
         "trigger": {
           "enum": ["hover", "click", "focus"]
         },
+        "audioSrc": {
+          "type": "string"
+        },
+        "audioType": {
+          "type": "string"
+        },
         "content": {
           "$ref": "#/$defs/rich-text"
         },


### PR DESCRIPTION
This adds the ability to add an audio clip to popup elements. That audio clip will play when the popup is displayed, and stop if the popup is dismissed.

Due to some recent changes in the modal infrastructure, I had to modify the audio-picker control to browse the audio files within the already-open popup config modal instead of opening a new one.

![popup](https://user-images.githubusercontent.com/333265/193601718-3959209d-b55e-4291-a03e-c07946256b65.gif)
