### PR TITLE
[ENHANCEMENT] [MER 1468] provide an option to create a new page from the all pages view

### DIFF
--- a/assets/src/components/editing/elements/page_link/PageLinkEditor.tsx
+++ b/assets/src/components/editing/elements/page_link/PageLinkEditor.tsx
@@ -58,9 +58,11 @@ export const PageLinkEditor = ({ model, commandContext, attributes, children }: 
       nothing: () => <div></div>,
     });
 
-    const { title } = maybe<Persistence.Page>(
+    const { title, slug } = maybe<Persistence.Page>(
       pages.find((p) => p.id === model?.idref) as Persistence.Page,
     ).valueOrThrow();
+
+    const authoringHref = `/authoring/project/${commandContext.projectSlug}/resource/${slug}`;
 
     return (
       <div
@@ -92,6 +94,9 @@ export const PageLinkEditor = ({ model, commandContext, attributes, children }: 
             <button className="btn btn-primary" onClick={showModal}>
               Select Page
             </button>
+            <a href={authoringHref} className="ml-3 my-1">
+              <i className="las la-external-link-square-alt la-2x"></i>
+            </a>
           </div>
         </div>
       </div>

--- a/lib/oli/authoring/editing/container_editor.ex
+++ b/lib/oli/authoring/editing/container_editor.ex
@@ -7,6 +7,7 @@ defmodule Oli.Authoring.Editing.ContainerEditor do
   """
 
   import Oli.Authoring.Editing.Utils
+
   alias Oli.Resources.Revision
   alias Oli.Resources
   alias Oli.Accounts.Author
@@ -18,6 +19,7 @@ defmodule Oli.Authoring.Editing.ContainerEditor do
   alias Oli.Authoring.Broadcaster
   alias Oli.Authoring.Editing.ActivityEditor
   alias Oli.Activities
+  alias Oli.Resources.ScoringStrategy
 
   @spec edit_page(Oli.Authoring.Course.Project.t(), any, map) :: any
   def edit_page(%Project{} = project, revision_slug, change) do
@@ -107,6 +109,80 @@ defmodule Oli.Authoring.Editing.ContainerEditor do
     end
 
     result
+  end
+
+  def add_new(container, type, %Author{} = author, %Project{} = project, numberings \\ nil)
+      when is_binary(type) do
+    attrs = %{
+      tags: [],
+      objectives: %{"attached" => []},
+      children: [],
+      content:
+        case type do
+          "Adaptive" ->
+            %{
+              "model" => [],
+              "advancedAuthoring" => true,
+              "advancedDelivery" => true,
+              "displayApplicationChrome" => false
+            }
+
+          _ ->
+            %{
+              "version" => "0.1.0",
+              "model" => []
+            }
+        end,
+      title:
+        case type do
+          "Adaptive" -> "New Adaptive Page"
+          "Scored" -> "New Assessment"
+          "Unscored" -> "New Page"
+          "Container" -> new_container_name(numberings, container)
+        end,
+      graded:
+        case type do
+          "Adaptive" -> false
+          "Scored" -> true
+          "Unscored" -> false
+          "Container" -> false
+        end,
+      max_attempts:
+        case type do
+          "Adaptive" -> 0
+          "Scored" -> 5
+          "Unscored" -> 0
+          "Container" -> nil
+        end,
+      recommended_attempts:
+        case type do
+          "Adaptive" -> 0
+          "Scored" -> 5
+          "Unscored" -> 0
+          "Container" -> nil
+        end,
+      scoring_strategy_id:
+        case type do
+          "Adaptive" -> ScoringStrategy.get_id_by_type("best")
+          "Scored" -> ScoringStrategy.get_id_by_type("best")
+          "Unscored" -> ScoringStrategy.get_id_by_type("best")
+          "Container" -> nil
+        end,
+      resource_type_id:
+        case type do
+          "Adaptive" -> Oli.Resources.ResourceType.get_id_by_type("page")
+          "Scored" -> Oli.Resources.ResourceType.get_id_by_type("page")
+          "Unscored" -> Oli.Resources.ResourceType.get_id_by_type("page")
+          "Container" -> Oli.Resources.ResourceType.get_id_by_type("container")
+        end
+    }
+
+    add_new(
+      container,
+      attrs,
+      author,
+      project
+    )
   end
 
   @doc """

--- a/lib/oli/authoring/editing/util.ex
+++ b/lib/oli/authoring/editing/util.ex
@@ -1,5 +1,6 @@
 defmodule Oli.Authoring.Editing.Utils do
   alias Oli.Accounts
+  alias Oli.Resources.Numbering
 
   def authorize_user(author, project) do
     case Accounts.can_access?(author, project) do
@@ -65,4 +66,13 @@ defmodule Oli.Authoring.Editing.Utils do
     end
   end
 
+  def new_container_name(numberings, parent_container) do
+    numbering = Map.get(numberings, parent_container.id)
+
+    if numbering do
+      Numbering.container_type(numbering.level + 1)
+    else
+      "Unit"
+    end
+  end
 end

--- a/lib/oli/delivery/hierarchy.ex
+++ b/lib/oli/delivery/hierarchy.ex
@@ -181,6 +181,48 @@ defmodule Oli.Delivery.Hierarchy do
     end
   end
 
+  @doc """
+  Finds the parent node of the matching node in the hierarchy with the given uuid
+  or function `fn node -> true`.
+
+  Returns the first parent that contains the matching node.
+  """
+  def find_parent_in_hierarchy(
+        node,
+        uuid_or_find_by_fn,
+        parent \\ nil
+      )
+
+  def find_parent_in_hierarchy(
+        %HierarchyNode{uuid: uuid, children: children} = node,
+        uuid_to_find,
+        parent
+      )
+      when is_binary(uuid_to_find) do
+    if uuid == uuid_to_find do
+      parent
+    else
+      Enum.reduce(children, nil, fn child, acc ->
+        if acc == nil, do: find_parent_in_hierarchy(child, uuid_to_find, node), else: acc
+      end)
+    end
+  end
+
+  def find_parent_in_hierarchy(
+        %HierarchyNode{children: children} = node,
+        find_by,
+        parent
+      )
+      when is_function(find_by) do
+    if find_by.(node) do
+      parent
+    else
+      Enum.reduce(children, nil, fn child, acc ->
+        if acc == nil, do: find_parent_in_hierarchy(child, find_by, node), else: acc
+      end)
+    end
+  end
+
   def reorder_children(
         container_node,
         source_node,

--- a/lib/oli_web/live/common/hierarchy/move_modal.ex
+++ b/lib/oli_web/live/common/hierarchy/move_modal.ex
@@ -48,7 +48,7 @@ defmodule OliWeb.Common.Hierarchy.MoveModal do
                 <button type="button"
                   id="remove_btn"
                   class="btn btn-danger"
-                  title="Remove this page from the curriculum. Pages that are removed are still be accessible from All Pages view."
+                  title="Remove this page from the curriculum. Pages that are removed are still accessible from the All Pages view."
                   phx-click="MoveModal.remove"
                   phx-value-uuid="<%= node.uuid %>"
                   phx-value-from_uuid="<%= from_container_uuid(from_container) %>"

--- a/lib/oli_web/live/common/hierarchy/move_modal.ex
+++ b/lib/oli_web/live/common/hierarchy/move_modal.ex
@@ -12,7 +12,7 @@ defmodule OliWeb.Common.Hierarchy.MoveModal do
           id: id,
           node: %HierarchyNode{uuid: uuid, revision: revision} = node,
           hierarchy: %HierarchyNode{} = hierarchy,
-          from_container: %HierarchyNode{} = from_container,
+          from_container: from_container,
           active: %HierarchyNode{} = active
         } = assigns
       ) do
@@ -35,17 +35,34 @@ defmodule OliWeb.Common.Hierarchy.MoveModal do
                 filter_items_fn: fn items -> Enum.filter(items, &(&1.uuid != uuid)) end %>
 
               <div class="text-center text-secondary mt-2">
+                <%= if already_exists_in_container?(from_container, active) do %>
+                <b><%= revision.title %></b> already exists here
+                <% else %>
                 <b><%= revision.title %></b> will be placed here
+                <% end %>
               </div>
 
             </div>
             <div class="modal-footer">
-              <button type="button" class="btn btn-secondary" data-dismiss="modal" phx-click="MoveModal.cancel">Cancel</button>
+              <%= if can_remove_page?(revision, from_container) do %>
+                <button type="button"
+                  id="remove_btn"
+                  class="btn btn-danger"
+                  title="Remove this page from the curriculum. Pages that are removed are still be accessible from All Pages view."
+                  phx-click="MoveModal.remove"
+                  phx-value-uuid="<%= node.uuid %>"
+                  phx-value-from_uuid="<%= from_container_uuid(from_container) %>"
+                  phx-hook="TooltipInit">
+                  Remove
+                </button>
+                <div class="flex-grow-1"></div>
+              <% end %>
+              <button type="button" class="btn btn-secondary" phx-click="MoveModal.cancel">Cancel</button>
               <button type="submit"
                 class="btn btn-primary"
                 phx-click="MoveModal.move_item"
                 phx-value-uuid="<%= node.uuid %>"
-                phx-value-from_uuid="<%= from_container.uuid %>"
+                phx-value-from_uuid="<%= from_container_uuid(from_container) %>"
                 phx-value-to_uuid="<%= active.uuid %>"
                 <%= if can_move?(from_container, active) , do: "", else: "disabled" %>>
                 Move
@@ -57,7 +74,25 @@ defmodule OliWeb.Common.Hierarchy.MoveModal do
     """
   end
 
+  defp from_container_uuid(from_container) do
+    case from_container do
+      nil -> nil
+      from_container -> from_container.uuid
+    end
+  end
+
+  defp can_remove_page?(revision, from_container),
+    do:
+      revision.resource_type_id == Oli.Resources.ResourceType.get_id_by_type("page") &&
+        from_container != nil
+
+  defp can_move?(nil, _active), do: true
+
   defp can_move?(from_container, active) do
-    active.uuid != nil && active.uuid != from_container.uuid
+    active.uuid != nil && !already_exists_in_container?(from_container, active)
+  end
+
+  defp already_exists_in_container?(from_container, active) do
+    from_container != nil && active.uuid == from_container.uuid
   end
 end

--- a/lib/oli_web/live/curriculum/container/container_live.ex
+++ b/lib/oli_web/live/curriculum/container/container_live.ex
@@ -313,12 +313,28 @@ defmodule OliWeb.Curriculum.ContainerLive do
     {:noreply, hide_modal(socket)}
   end
 
+  def handle_event("MoveModal.remove", %{"uuid" => uuid, "from_uuid" => from_uuid}, socket) do
+    %{
+      author: author,
+      project: project,
+      modal: %{assigns: %{hierarchy: hierarchy}}
+    } = socket.assigns
+
+    %{revision: revision} = Hierarchy.find_in_hierarchy(hierarchy, uuid)
+    %{revision: from_container} = Hierarchy.find_in_hierarchy(hierarchy, from_uuid)
+    to_container = nil
+
+    {:ok, _} = ContainerEditor.move_to(revision, from_container, to_container, author, project)
+
+    {:noreply, hide_modal(socket)}
+  end
+
   def handle_event("MoveModal.cancel", _, socket) do
-    {:noreply, socket}
+    {:noreply, hide_modal(socket)}
   end
 
   def handle_event("dismiss", _, socket) do
-    {:noreply, socket}
+    {:noreply, hide_modal(socket)}
   end
 
   # handle change of selection

--- a/lib/oli_web/live/curriculum/container/container_live.ex
+++ b/lib/oli_web/live/curriculum/container/container_live.ex
@@ -7,6 +7,7 @@ defmodule OliWeb.Curriculum.ContainerLive do
   use OliWeb.Common.Modal
 
   import Oli.Utils, only: [value_or: 2]
+  import Oli.Authoring.Editing.Utils
 
   alias Oli.Authoring.Editing.ContainerEditor
   alias Oli.Authoring.Course
@@ -23,7 +24,6 @@ defmodule OliWeb.Curriculum.ContainerLive do
 
   alias OliWeb.Common.Hierarchy.MoveModal
   alias Oli.Publishing.ChangeTracker
-  alias Oli.Resources.ScoringStrategy
   alias Oli.Publishing.AuthoringResolver
   alias Oli.Accounts
   alias Oli.Repo
@@ -430,90 +430,26 @@ defmodule OliWeb.Curriculum.ContainerLive do
 
   # handle clicking of the "Add Graded Assessment" or "Add Practice Page" buttons
   def handle_event("add", %{"type" => type}, socket) do
-    attrs = %{
-      tags: [],
-      objectives: %{"attached" => []},
-      children: [],
-      content:
-        case type do
-          "Adaptive" ->
-            %{
-              "model" => [],
-              "advancedAuthoring" => true,
-              "advancedDelivery" => true,
-              "displayApplicationChrome" => false
-            }
+    case ContainerEditor.add_new(
+           socket.assigns.container,
+           type,
+           socket.assigns.author,
+           socket.assigns.project,
+           socket.assigns.numberings
+         ) do
+      {:ok, _} ->
+        {:noreply,
+         assign(socket,
+           numberings:
+             Numbering.number_full_tree(
+               Oli.Publishing.AuthoringResolver,
+               socket.assigns.project.slug
+             )
+         )}
 
-          _ ->
-            %{
-              "version" => "0.1.0",
-              "model" => []
-            }
-        end,
-      title:
-        case type do
-          "Adaptive" -> "New Adaptive Page"
-          "Scored" -> "New Assessment"
-          "Unscored" -> "New Page"
-          "Container" -> new_container_name(socket.assigns.numberings, socket.assigns.container)
-        end,
-      graded:
-        case type do
-          "Adaptive" -> false
-          "Scored" -> true
-          "Unscored" -> false
-          "Container" -> false
-        end,
-      max_attempts:
-        case type do
-          "Adaptive" -> 0
-          "Scored" -> 5
-          "Unscored" -> 0
-          "Container" -> nil
-        end,
-      recommended_attempts:
-        case type do
-          "Adaptive" -> 0
-          "Scored" -> 5
-          "Unscored" -> 0
-          "Container" -> nil
-        end,
-      scoring_strategy_id:
-        case type do
-          "Adaptive" -> ScoringStrategy.get_id_by_type("best")
-          "Scored" -> ScoringStrategy.get_id_by_type("best")
-          "Unscored" -> ScoringStrategy.get_id_by_type("best")
-          "Container" -> nil
-        end,
-      resource_type_id:
-        case type do
-          "Adaptive" -> Oli.Resources.ResourceType.get_id_by_type("page")
-          "Scored" -> Oli.Resources.ResourceType.get_id_by_type("page")
-          "Unscored" -> Oli.Resources.ResourceType.get_id_by_type("page")
-          "Container" -> Oli.Resources.ResourceType.get_id_by_type("container")
-        end
-    }
-
-    socket =
-      case ContainerEditor.add_new(
-             socket.assigns.container,
-             attrs,
-             socket.assigns.author,
-             socket.assigns.project
-           ) do
-        {:ok, _} ->
-          socket
-
-        {:error, %Ecto.Changeset{} = _changeset} ->
-          socket
-          |> put_flash(:error, "Could not create new item")
-      end
-
-    {:noreply,
-     assign(socket,
-       numberings:
-         Numbering.number_full_tree(Oli.Publishing.AuthoringResolver, socket.assigns.project.slug)
-     )}
+      {:error, %Ecto.Changeset{} = _changeset} ->
+        {:noreply, put_flash(socket, :error, "Could not create new item")}
+    end
   end
 
   def handle_event("change-view", %{"view" => view}, socket) do
@@ -752,15 +688,5 @@ defmodule OliWeb.Curriculum.ContainerLive do
       {published_resource.resource_id, published_resource.author}
     end)
     |> Enum.into(%{})
-  end
-
-  def new_container_name(numberings, parent_container) do
-    numbering = Map.get(numberings, parent_container.id)
-
-    if numbering do
-      Numbering.container_type(numbering.level + 1)
-    else
-      "Unit"
-    end
   end
 end

--- a/lib/oli_web/live/curriculum/container/container_live.html.leex
+++ b/lib/oli_web/live/curriculum/container/container_live.html.leex
@@ -71,7 +71,7 @@
         <%= live_component DropTarget, id: "last", index: length(@children) %>
       </div>
       <div class="mt-5">
-        <span class="text-secondary mr-2">Add</span>
+        <span class="text-secondary mr-2">Create</span>
         <button phx-click="add" phx-value-type="Unscored" class="btn btn-xs btn-outline-primary p-2 mr-1" type="button">
           Practice Page
         </button>

--- a/lib/oli_web/live/curriculum/entries/actions.ex
+++ b/lib/oli_web/live/curriculum/entries/actions.ex
@@ -14,7 +14,7 @@ defmodule OliWeb.Curriculum.Actions do
         <button class="btn dropdown-toggle" type="button" data-toggle="dropdown" data-target="dropdownMenu_<%= @child.slug %>" aria-haspopup="true" aria-expanded="false"></button>
         <div class="dropdown-menu dropdown-menu-right" id="dropdownMenu_<%= @child.slug %>" aria-labelledby="dropdownMenuButton_<%= @child.slug %>">
           <button type="button" class="dropdown-item" phx-click="show_options_modal" phx-value-slug="<%= @child.slug %>"><i class="las la-sliders-h mr-1"></i> Options</button>
-          <button type="button" <%= if @disable_move do "disabled" end %> class="dropdown-item" phx-click="show_move_modal" phx-value-slug="<%= @child.slug %>"><i class="las la-arrow-circle-right mr-1"></i> Move to...</button>
+          <button type="button" class="dropdown-item" phx-click="show_move_modal" phx-value-slug="<%= @child.slug %>"><i class="las la-arrow-circle-right mr-1"></i> Move to...</button>
           <%= if ResourceType.is_non_adaptive_page(@child) do %>
             <button type="button" class="dropdown-item" phx-click="duplicate_page" phx-value-id="<%= @child.id %>"><i class="las la-copy mr-1"></i> Duplicate</button>
           <% end %>

--- a/lib/oli_web/live/curriculum/entries/entry.ex
+++ b/lib/oli_web/live/curriculum/entries/entry.ex
@@ -67,7 +67,7 @@ defmodule OliWeb.Curriculum.EntryLive do
 
       <%# prevent dragging of actions menu and modals using this draggable wrapper %>
       <div draggable="true" ondragstart="event.preventDefault(); event.stopPropagation();">
-        <%= live_component Actions, Map.merge(assigns, %{disable_move: false}) %>
+        <%= live_component Actions, assigns %>
       </div>
     </div>
     """

--- a/lib/oli_web/live/curriculum/entries/not_empty_modal.ex
+++ b/lib/oli_web/live/curriculum/entries/not_empty_modal.ex
@@ -24,7 +24,6 @@ defmodule OliWeb.Curriculum.NotEmptyModal do
                 phx-click="dismiss"
                 phx-key="enter"
                 phx-value-slug="<%= revision.slug %>"
-                onclick="$('#not_empty_<%= revision.slug %>').modal('hide')"
                 class="btn btn-primary">
                 Ok
               </button>

--- a/lib/oli_web/live/resources/pages_table_model.ex
+++ b/lib/oli_web/live/resources/pages_table_model.ex
@@ -66,6 +66,6 @@ defmodule OliWeb.Resources.PagesTableModel do
   def render_graded_column(_, %Revision{graded: false}, _), do: "Practice"
 
   def render_actions_column(_, %Revision{} = revision, _) do
-    live_component(Actions, child: revision, disable_move: true)
+    live_component(Actions, child: revision)
   end
 end

--- a/lib/oli_web/live/resources/pages_view.ex
+++ b/lib/oli_web/live/resources/pages_view.ex
@@ -176,7 +176,18 @@ defmodule OliWeb.Resources.PagesView do
 
       <div class="my-3 d-flex flex-row">
         <div class="flex-grow-1" />
-        <button class="btn btn-primary" :on-click="create_page">Create Page</button>
+          <div class="btn-group">
+            <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              Create
+            </button>
+            <div class="dropdown-menu dropdown-menu-right">
+              <button type="button" class="dropdown-item btn btn-primary" :on-click="create_page" phx-value-type="Unscored">Practice Page</button>
+              <button type="button" class="dropdown-item btn btn-primary" :on-click="create_page" phx-value-type="Scored">Graded Assessment</button>
+              {#if Oli.Features.enabled?("adaptivity")}
+                <button type="button" class="dropdown-item btn btn-primary" :on-click="create_page" phx-value-type="Adaptive">Adaptive Page</button>
+              {/if}
+            </div>
+          </div>
       </div>
 
       <PagedTable
@@ -385,31 +396,15 @@ defmodule OliWeb.Resources.PagesView do
   end
 
   # handle clicking of the "Add Graded Assessment" or "Add Practice Page" buttons
-  def handle_event("create_page", _, socket) do
+  def handle_event("create_page", %{"type" => type}, socket) do
     %{
       project: project,
       author: author
     } = socket.assigns
 
-    attrs = %{
-      tags: [],
-      objectives: %{"attached" => []},
-      children: [],
-      content: %{
-        "version" => "0.1.0",
-        "model" => []
-      },
-      title: "New Page",
-      graded: false,
-      max_attempts: 0,
-      recommended_attempts: 0,
-      scoring_strategy_id: Oli.Resources.ScoringStrategy.get_id_by_type("best"),
-      resource_type_id: Oli.Resources.ResourceType.get_id_by_type("page")
-    }
-
     case ContainerEditor.add_new(
            nil,
-           attrs,
+           type,
            author,
            project
          ) do

--- a/test/oli/delivery/hierarchy_test.exs
+++ b/test/oli/delivery/hierarchy_test.exs
@@ -116,13 +116,38 @@ defmodule Oli.Delivery.HierarchyTest do
       assert nested_node.resource_id == nested_revision1.resource_id
     end
 
+    test "find_parent_in_hierarchy/2", %{
+      hierarchy: hierarchy,
+      unit_node: unit_node,
+      nested_page_one_node: nested_page_one_node
+    } do
+      # using uuid
+      nested_node_parent =
+        Hierarchy.find_parent_in_hierarchy(
+          hierarchy,
+          nested_page_one_node.uuid
+        )
+
+      assert nested_node_parent.resource_id == unit_node.resource_id
+
+      # using find_by fn
+      nested_node_parent =
+        Hierarchy.find_parent_in_hierarchy(
+          hierarchy,
+          fn n -> n.uuid === nested_page_one_node.uuid end
+        )
+
+      assert nested_node_parent.resource_id == unit_node.resource_id
+    end
+
     test "find_and_remove_node/2", %{
       hierarchy: hierarchy,
       nested_page_one_node: nested_page_one_node
     } do
       assert Hierarchy.find_in_hierarchy(hierarchy, nested_page_one_node.uuid) != nil
 
-      hierarchy = Hierarchy.find_and_remove_node(hierarchy, nested_page_one_node.uuid)
+      hierarchy =
+        Hierarchy.find_and_remove_node(hierarchy, nested_page_one_node.uuid)
         |> Hierarchy.finalize()
 
       assert Hierarchy.find_in_hierarchy(hierarchy, nested_page_one_node.uuid) == nil
@@ -131,7 +156,8 @@ defmodule Oli.Delivery.HierarchyTest do
     test "move_node/3", %{hierarchy: hierarchy, nested_page_one_node: nested_page_one_node} do
       node = Hierarchy.find_in_hierarchy(hierarchy, nested_page_one_node.uuid)
 
-      hierarchy = Hierarchy.move_node(hierarchy, node, hierarchy.uuid)
+      hierarchy =
+        Hierarchy.move_node(hierarchy, node, hierarchy.uuid)
         |> Hierarchy.finalize()
 
       assert Hierarchy.find_in_hierarchy(hierarchy, nested_page_one_node.uuid) != nil
@@ -195,7 +221,8 @@ defmodule Oli.Delivery.HierarchyTest do
         | children: [page_one_node | unit_node.children]
       }
 
-      hierarchy = Hierarchy.find_and_update_node(hierarchy, unit_node_with_duplicate_page_one)
+      hierarchy =
+        Hierarchy.find_and_update_node(hierarchy, unit_node_with_duplicate_page_one)
         |> Hierarchy.finalize()
 
       assert hierarchy.children
@@ -215,7 +242,8 @@ defmodule Oli.Delivery.HierarchyTest do
              |> Enum.at(1)
              |> Map.get(:resource_id) == nested_page1.id
 
-      hierarchy = Hierarchy.purge_duplicate_resources(hierarchy)
+      hierarchy =
+        Hierarchy.purge_duplicate_resources(hierarchy)
         |> Hierarchy.finalize()
 
       assert hierarchy.children


### PR DESCRIPTION
Adds the ability to create a new page directly in the new "All Pages" view
<img width="1358" alt="Screen Shot 2022-10-03 at 3 58 41 PM" src="https://user-images.githubusercontent.com/6248894/193667713-09b79528-ead1-4e02-b2cf-9f1cf47b602a.png">

As well as several other related enhancements:
- Ability to move a page from the All Pages view into the curriculum
- Ability to remove a page from the curriculum (without necessarily deleting the page)
<img width="921" alt="Screen Shot 2022-10-03 at 4 10 52 PM" src="https://user-images.githubusercontent.com/6248894/193669826-a8f78ff9-bce7-4172-bde5-66926cf9c0d1.png">


- Updates the breadcrumb to show the "All Pages" link (instead of curriculum) if the page being edited does not exist in the curriculum
<img width="493" alt="Screen Shot 2022-10-03 at 4 01 55 PM" src="https://user-images.githubusercontent.com/6248894/193668348-97602c7d-dd48-4428-9bc1-f00c6c76caf1.png">


- Ability to navigate directly from a Page link to the linked page in authoring, so that authors can seamlessly jump into an unconnected page to edit it
<img width="851" alt="Screen Shot 2022-10-03 at 4 01 01 PM" src="https://user-images.githubusercontent.com/6248894/193668182-e7bcb164-82d1-477f-ad45-09cac714ea46.png">
