### PR TITLE
Fix popup audio

### DIFF
--- a/assets/src/components/common/Popup.tsx
+++ b/assets/src/components/common/Popup.tsx
@@ -3,6 +3,7 @@ import { OverlayTriggerType } from 'react-bootstrap/esm/OverlayTrigger';
 import { Popup as PopupModel } from 'data/content/model/elements/types';
 import { OverlayTrigger, Popover } from 'react-bootstrap';
 import { useAudio } from '../hooks/useAudio';
+import { isEmptyContent } from '../../data/content/utils';
 
 interface Props {
   children: React.ReactNode;
@@ -26,7 +27,9 @@ export const Popup: React.FC<Props> = ({ children, popupContent, popup }) => {
 
   const overlayContent = (
     <Popover id={popup.id}>
-      <Popover.Content className="popup__content">{popupContent}</Popover.Content>
+      <Popover.Content className="popup__content">
+        {isEmptyContent(popup.content) ? <i className="material-icons">volume_up</i> : popupContent}
+      </Popover.Content>
     </Popover>
   );
 

--- a/assets/src/components/content/RichTextEditor.tsx
+++ b/assets/src/components/content/RichTextEditor.tsx
@@ -19,30 +19,47 @@ type Props = {
   style?: React.CSSProperties;
   commandContext?: CommandContext;
   normalizerContext?: NormalizerContext;
+  fixedToolbar?: boolean;
+  allowBlockElements?: boolean;
   onEdit: (value: Descendant[], editor: SlateEditor, operations: Operation[]) => void;
   onRequestMedia?: (request: MediaItemRequest) => Promise<string | boolean>;
 };
-export const RichTextEditor: React.FC<Props> = (props) => {
+export const RichTextEditor: React.FC<Props> = ({
+  projectSlug,
+  editMode,
+  value,
+  className,
+  placeholder,
+  style,
+  commandContext,
+  normalizerContext,
+  fixedToolbar = false,
+  allowBlockElements = true,
+  onEdit,
+  onRequestMedia,
+  children,
+}) => {
   // Support content persisted when RichText had a `model` property.
-  const value = (props.value as any).model ? (props.value as any).model : props.value;
+  value = (value as any).model ? (value as any).model : value;
 
   return (
-    <div className={classNames('rich-text-editor', props.className)}>
+    <div className={classNames('rich-text-editor', className)}>
       <ErrorBoundary>
         <Editor
-          normalizerContext={props.normalizerContext}
-          placeholder={props.placeholder}
-          style={props.style}
-          editMode={props.editMode}
-          commandContext={props.commandContext ?? { projectSlug: props.projectSlug }}
-          onEdit={props.onEdit}
+          normalizerContext={normalizerContext}
+          placeholder={placeholder}
+          style={style}
+          editMode={editMode}
+          fixedToolbar={fixedToolbar}
+          commandContext={commandContext ?? { projectSlug: projectSlug }}
+          onEdit={onEdit}
           value={value}
           toolbarInsertDescs={blockInsertOptions({
-            type: 'extended',
-            onRequestMedia: props.onRequestMedia,
+            type: allowBlockElements ? 'extended' : 'inline',
+            onRequestMedia: onRequestMedia,
           })}
         >
-          {props.children}
+          {children}
         </Editor>
       </ErrorBoundary>
     </div>

--- a/assets/src/components/editing/editor/Editor.tsx
+++ b/assets/src/components/editing/editor/Editor.tsx
@@ -28,6 +28,7 @@ export type EditorProps = {
   toolbarInsertDescs: CommandDescription[];
   // Whether or not editing is allowed
   editMode: boolean;
+  fixedToolbar?: boolean;
   commandContext: CommandContext;
   normalizerContext?: NormalizerContext;
   className?: string;
@@ -109,7 +110,11 @@ export const Editor: React.FC<EditorProps> = React.memo((props: EditorProps) => 
       >
         {props.children}
 
-        <EditorToolbar context={props.commandContext} insertOptions={props.toolbarInsertDescs} />
+        <EditorToolbar
+          context={props.commandContext}
+          insertOptions={props.toolbarInsertDescs}
+          fixedToolbar={props.fixedToolbar}
+        />
 
         <Editable
           style={props.style}

--- a/assets/src/components/editing/elements/common/settings/InlineEditor.tsx
+++ b/assets/src/components/editing/elements/common/settings/InlineEditor.tsx
@@ -19,6 +19,7 @@ interface Props {
   id?: string;
   allowBlockElements?: boolean;
   editorOverride?: SlateEditor;
+  fixedToolbar?: boolean;
 }
 
 export const InlineEditor: React.FC<Props> = ({
@@ -31,6 +32,7 @@ export const InlineEditor: React.FC<Props> = ({
   allowBlockElements = false,
   onRequestMedia,
   editorOverride = undefined,
+  fixedToolbar = false,
 }) => {
   const editor = useSlate();
   const editMode = getEditMode(editor);
@@ -45,6 +47,7 @@ export const InlineEditor: React.FC<Props> = ({
         value={content}
         onEdit={onEdit}
         editorOverride={editorOverride}
+        fixedToolbar={fixedToolbar}
         toolbarInsertDescs={blockInsertOptions({
           type: allowBlockElements ? 'limited' : 'inline',
           onRequestMedia: onRequestMedia,

--- a/assets/src/components/editing/elements/popup/PopupContentModal.tsx
+++ b/assets/src/components/editing/elements/popup/PopupContentModal.tsx
@@ -82,6 +82,8 @@ export const PopupContentModal = (props: Props) => {
               projectSlug={props.commandContext.projectSlug}
               value={content}
               onEdit={(content) => setContent(content as RichText)}
+              fixedToolbar={true}
+              allowBlockElements={false}
             />
 
             <InlineAudioClipPicker

--- a/assets/src/components/editing/toolbar/Toolbar.modules.scss
+++ b/assets/src/components/editing/toolbar/Toolbar.modules.scss
@@ -11,6 +11,11 @@
     z-index: authoring.$z-content-3;
     box-shadow: 6px 6px 24px -12px rgba(0, 0, 0, 0.45);
     -webkit-box-shadow: 6px 6px 24px -12px rgba(0, 0, 0, 0.45);
+
+    &.fixedToolbar {
+      border-radius: 0px;
+      margin-bottom: 2rem;
+    }
   }
 
   .toolbarGroup {

--- a/assets/src/components/editing/toolbar/Toolbar.tsx
+++ b/assets/src/components/editing/toolbar/Toolbar.tsx
@@ -5,6 +5,7 @@ import styles from './Toolbar.modules.scss';
 
 interface Props {
   context: CommandContext;
+  fixed?: boolean;
 }
 export const Toolbar = (props: PropsWithChildren<Props>) => {
   const [submenu, setSubmenu] = React.useState<React.MutableRefObject<HTMLButtonElement> | null>(
@@ -21,9 +22,11 @@ export const Toolbar = (props: PropsWithChildren<Props>) => {
     [props.context, submenu, setSubmenu],
   );
 
+  const cssClasses = props.fixed ? `${styles.toolbar} ${styles.fixedToolbar}` : styles.toolbar;
+
   return (
     <ToolbarContext.Provider value={context}>
-      <div className={styles.toolbar}>{props.children}</div>
+      <div className={cssClasses}>{props.children}</div>
     </ToolbarContext.Provider>
   );
 };

--- a/assets/src/components/editing/toolbar/buttons/DropdownButton.tsx
+++ b/assets/src/components/editing/toolbar/buttons/DropdownButton.tsx
@@ -39,6 +39,7 @@ export const DropdownButton = (props: PropsWithChildren<Props>) => {
       positions={['bottom']}
       reposition={true}
       align={'start'}
+      containerStyle={{ zIndex: '100000' }}
       content={<div className={styles.dropdownGroup}>{props.children}</div>}
     >
       <button

--- a/assets/src/components/editing/toolbar/editorToolbar/EditorToolbar.tsx
+++ b/assets/src/components/editing/toolbar/editorToolbar/EditorToolbar.tsx
@@ -16,10 +16,23 @@ import { BlockSettings } from 'components/editing/toolbar/editorToolbar/blocks/B
 interface Props {
   context: CommandContext;
   insertOptions: CommandDescription[];
+  fixedToolbar?: boolean;
 }
 
 export const EditorToolbar = (props: Props) => {
   const editor = useSlate();
+  const toolbar = (
+    <Toolbar fixed={props.fixedToolbar} context={props.context}>
+      <Inlines />
+      <BlockToggle blockInsertOptions={props.insertOptions} />
+      <BlockSettings />
+      <BlockInsertMenu blockInsertOptions={props.insertOptions} />
+    </Toolbar>
+  );
+
+  if (props.fixedToolbar) {
+    return toolbar;
+  }
 
   return (
     <HoverContainer
@@ -32,14 +45,7 @@ export const EditorToolbar = (props: Props) => {
           .bind((node) => safeToDOMNode(editor, node))
           .valueOr<any>(undefined)
       }
-      content={
-        <Toolbar context={props.context}>
-          <Inlines />
-          <BlockToggle blockInsertOptions={props.insertOptions} />
-          <BlockSettings />
-          <BlockInsertMenu blockInsertOptions={props.insertOptions} />
-        </Toolbar>
-      }
+      content={toolbar}
     />
   );
 };

--- a/assets/src/data/content/utils.tsx
+++ b/assets/src/data/content/utils.tsx
@@ -167,3 +167,20 @@ export const elementsOfType = (content: ContentTypes, type: string): AllModelEle
   );
   return elements;
 };
+
+/**
+ * isEmptyContent([nodes]) Returns true if the content is "empty" where "empty" is defined as:
+ *   - Does not contain any text node with non-whitespace characters
+ *   - Does not contain any p/header nodes with children that have non-whitespace characters recursively
+ *   - Does not contain any other type of node
+ */
+const blocksToIgnore = ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'];
+const shouldIgnore = (type: string) => blocksToIgnore.includes(type);
+export const isEmptyContent = (content: (AllModelElements | Text)[]): boolean => {
+  return !content.find(
+    (c) =>
+      ('text' in c && c.text.trim() !== '') || // Not empty if we have a text node with content in it
+      ('type' in c && shouldIgnore(c.type) && !isEmptyContent(c.children)) || // a paragraph/heading is not empty if its children are not empty
+      ('type' in c && !shouldIgnore(c.type)), // Any other non-paragraph/header element is considered not empty
+  );
+};

--- a/assets/src/phoenix/app.ts
+++ b/assets/src/phoenix/app.ts
@@ -70,7 +70,7 @@ $(() => {
 
   $('[data-toggle="popover"]').on('show.bs.popover', function () {
     const audioAttribute = this.attributes.getNamedItem('data-audio');
-    if (audioAttribute) {
+    if (audioAttribute && audioAttribute.value !== '') {
       const audio = ($('#' + audioAttribute.value) as JQuery<HTMLAudioElement>)[0];
       audio.currentTime = 0;
       audio.play();
@@ -79,7 +79,7 @@ $(() => {
 
   $('[data-toggle="popover"]').on('hide.bs.popover', function () {
     const audioAttribute = this.attributes.getNamedItem('data-audio');
-    if (audioAttribute) {
+    if (audioAttribute && audioAttribute.value !== '') {
       ($('#' + audioAttribute.value) as JQuery<HTMLAudioElement>)[0].pause();
     }
   });

--- a/assets/test/data/content/utils_test.ts
+++ b/assets/test/data/content/utils_test.ts
@@ -1,0 +1,64 @@
+import {
+  Heading,
+  ImageBlock,
+  InputRef,
+  Paragraph,
+} from '../../../src/data/content/model/elements/types';
+import { FormattedText } from '../../../src/data/content/model/text';
+import { isEmptyContent } from '../../../src/data/content/utils';
+
+const createPara = (children: (InputRef | FormattedText | ImageBlock)[]): Paragraph => ({
+  type: 'p',
+  id: 'a',
+  children,
+});
+
+const createHeading = (children: FormattedText[]): Heading => ({
+  type: 'h1',
+  id: 'a',
+  children,
+});
+
+describe('isEmptyContent', () => {
+  it('should detect empty content on a whitespace text only node', () => {
+    expect(isEmptyContent([{ text: '' }])).toBe(true);
+    expect(isEmptyContent([{ text: '  ' }])).toBe(true);
+    expect(isEmptyContent([{ text: '\n' }])).toBe(true);
+    expect(isEmptyContent([{ text: '\t' }])).toBe(true);
+    expect(isEmptyContent([{ text: '\t' }, { text: ' ' }])).toBe(true);
+  });
+
+  it('should not detect empty content on strings', () => {
+    expect(isEmptyContent([{ text: 'Test' }])).toBe(false);
+    expect(isEmptyContent([{ text: '  Test' }])).toBe(false);
+    expect(isEmptyContent([{ text: '\nTest' }])).toBe(false);
+  });
+
+  it('should detect empty content on empty headings', () => {
+    expect(isEmptyContent([createHeading([{ text: '' }])])).toBe(true);
+    expect(isEmptyContent([createHeading([{ text: ' ' }])])).toBe(true);
+    expect(isEmptyContent([createHeading([{ text: '\n' }])])).toBe(true);
+  });
+
+  it('should not detect empty content on non-empty headings', () => {
+    expect(isEmptyContent([createHeading([{ text: 'Test' }])])).toBe(false);
+    expect(isEmptyContent([createHeading([{ text: ' Test' }])])).toBe(false);
+    expect(isEmptyContent([createHeading([{ text: '\nTest' }])])).toBe(false);
+  });
+
+  it('should detect empty content on empty paragraphs', () => {
+    expect(isEmptyContent([createPara([{ text: '' }])])).toBe(true);
+    expect(isEmptyContent([createPara([{ text: ' ' }])])).toBe(true);
+    expect(isEmptyContent([createPara([{ text: '\n' }])])).toBe(true);
+  });
+
+  it('should not detect empty content on non-empty paragraphs', () => {
+    expect(isEmptyContent([createPara([{ text: 'Test' }])])).toBe(false);
+    expect(isEmptyContent([createPara([{ text: ' Test' }])])).toBe(false);
+    expect(isEmptyContent([createPara([{ text: '\nTest' }])])).toBe(false);
+  });
+
+  it('should not detect empty content on block elements', () => {
+    expect(isEmptyContent([{ type: 'table', id: 'a', children: [] }])).toBe(false);
+  });
+});

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -616,12 +616,18 @@ defmodule Oli.Rendering.Content.Html do
     end
   end
 
-  def popup(%Context{} = context, next, %{"trigger" => trigger, "content" => content} = element) do
+  def popup(%Context{} , next, %{"trigger" => trigger, "content" => content} = element) do
     trigger =
       if escape_xml!(trigger) == "hover" do
         "hover focus"
       else
         "manual"
+      end
+
+    popup_content =
+      case parse_html_content(content) do
+        "" -> "<i class='material-icons'>volume_up</i>"
+        content -> content
       end
 
     [audio_element, _play_code, audio_id] = audio_player(element["audioSrc"])
@@ -647,7 +653,7 @@ defmodule Oli.Rendering.Content.Html do
             <h3 class="popover-header"></h3>
             <div class="popover-body"></div>
           </div>'
-        data-content="#{escape_xml!(parse_html_content(content, context))}">
+        data-content="#{escape_xml!(popup_content)}">
         #{next.()}
         #{audio_element}
       </span>\n


### PR DESCRIPTION
Couple issues fixed related to popups here.

Darren fixed an issue with an audio attribute being set, but an empty string on popup elements would cause a JS error in the console.

Added a speaker icon if you have a popup with audio and no text in it.
![image](https://user-images.githubusercontent.com/333265/193891373-f40f831c-7d8a-417a-a180-70e40087bfe2.png)

The editor wasn't displaying formatting options due to some modal-window z-index ordering issues, and when it did, it allowed you to author all kinds of content that didn't actually work inside a popup. Now, we have a fixed-editing toolbar and you're limited to inline formatting options.

![image](https://user-images.githubusercontent.com/333265/193893093-954e79e2-21ba-4cc1-8c40-fe677d78a563.png)


