### PR TITLE
[BUG FIX] [MER-1488] Properly restore dnd state

### DIFF
--- a/assets/src/components/activities/custom_dnd/DragCanvas.tsx
+++ b/assets/src/components/activities/custom_dnd/DragCanvas.tsx
@@ -190,7 +190,11 @@ function renderRawContent(id: string, props: DragCanvasProps) {
   shadowRoot.querySelectorAll('.target').forEach((element: any) => {
     const partId = element.getAttribute('input_ref');
     if (props.initialState[partId] !== undefined) {
-      const droppable = getDroppable(shadowRoot, props.initialState[partId]);
+      const state = props.initialState[partId];
+      const adjustedState = state.startsWith(partId + '_')
+        ? state.substring(partId.length + 1)
+        : state;
+      const droppable = getDroppable(shadowRoot, adjustedState);
 
       element.appendChild(droppable);
       if (firstRestoredPart === null) {


### PR DESCRIPTION
This PR fixes logic intended to restore a students previous state with the DnD activity.

Root cause of failure was that since now the part id is included as part of the response, that part id has to be parsed out to properly identify the droppable whose `input_val` matches.   

Fixes [input_val](https://eliterate.atlassian.net/browse/MER-1488)