### PR TITLE
[BUG] Fixed video settings browse dialogs.

### DIFF
--- a/assets/src/components/editing/elements/common/MediaPickerPanel.tsx
+++ b/assets/src/components/editing/elements/common/MediaPickerPanel.tsx
@@ -1,0 +1,60 @@
+import React, { useCallback, useState } from 'react';
+import { MIMETYPE_FILTERS, SELECTION_TYPES } from '../../../media/manager/MediaManager';
+import { UrlOrUpload } from '../../../media/UrlOrUpload';
+import { SlideOutPanel } from './SlideOutPanel';
+
+export interface MediaInfo {
+  url: string;
+  mimeType?: string;
+}
+
+interface Props {
+  projectSlug: string;
+  mimeFilter?: string[];
+  selectionType?: SELECTION_TYPES;
+  initialSelectionPaths?: string[];
+  onMediaChange: (media: MediaInfo[]) => void;
+  open: boolean;
+}
+
+/**
+ * Component suitable for selecting an image from the media library, especially from within
+ * an already open modal when we don't want to open modals on top of other modals. (which doesn't
+ * work well with bootstrap style modals).
+ *
+ */
+export const MediaPickerPanel: React.FC<Props> = ({
+  projectSlug,
+  onMediaChange,
+  mimeFilter = MIMETYPE_FILTERS.IMAGE,
+  selectionType = SELECTION_TYPES.SINGLE,
+  initialSelectionPaths = [],
+  open,
+}) => {
+  const [url, setUrl] = useState(initialSelectionPaths.length > 0 ? initialSelectionPaths[0] : '');
+
+  const onUrlChange = useCallback((url) => {
+    setUrl(url);
+  }, []);
+
+  const onOk = useCallback(() => {
+    onMediaChange([{ url, mimeType: 'image/png' }]);
+  }, [onMediaChange, url]);
+
+  return (
+    <SlideOutPanel open={open}>
+      <UrlOrUpload
+        onUrlChange={onUrlChange}
+        onMediaSelectionChange={onMediaChange}
+        projectSlug={projectSlug}
+        mimeFilter={mimeFilter}
+        selectionType={selectionType}
+        initialSelectionPaths={initialSelectionPaths}
+      >
+        <button className="btn" onClick={onOk}>
+          OK
+        </button>
+      </UrlOrUpload>
+    </SlideOutPanel>
+  );
+};

--- a/assets/src/components/editing/elements/common/SlideOutPanel.tsx
+++ b/assets/src/components/editing/elements/common/SlideOutPanel.tsx
@@ -1,0 +1,33 @@
+import React, { ReactNode, useEffect } from 'react';
+
+/**
+ * Component to implement a slide-out panel like the file-browser in OSX that opens up over the top of a modal
+ * window, primarily used for selecting media via the MediaPickerPanel
+ *
+ * This will open an absolute-positioned div over the top of the modal, so make sure whatever holds this has
+ * a position value set (bootstrap modals do by default).
+ *
+ */
+
+interface Props {
+  open: boolean;
+  children: ReactNode;
+}
+export const SlideOutPanel: React.FC<Props> = ({ open, children }) => {
+  const [pickerClass, setPickerClass] = React.useState('picker-panel');
+  useEffect(() => {
+    // Trigger an extra css class one frame later so the css transistion occurs
+    setTimeout(() => {
+      setPickerClass(open ? 'picker-panel open' : 'picker-panel');
+    }, 50);
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <>
+      <div className="picker-panel-shade" />
+      <div className={pickerClass}>{children}</div>
+    </>
+  );
+};

--- a/assets/src/components/media/UrlOrUpload.tsx
+++ b/assets/src/components/media/UrlOrUpload.tsx
@@ -12,6 +12,7 @@ interface Props {
   initialSelectionPaths?: string[];
   onMediaSelectionChange: (items: MediaItem[]) => void;
   onUrlChange: (url: string) => void;
+  children?: React.ReactNode;
 }
 
 export const UrlOrUpload = (props: Props) => {
@@ -68,6 +69,7 @@ export const UrlOrUpload = (props: Props) => {
                 onUrlChange(value);
               }}
             />
+            {props.children}
           </div>
         </div>
       </div>

--- a/assets/styles/authoring/controls.scss
+++ b/assets/styles/authoring/controls.scss
@@ -142,3 +142,29 @@
     bottom: 5px;
   }
 }
+
+.picker-panel {
+  padding: 1rem;
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  background-color: $body-bg;
+  right: 0px;
+  height: 0px;
+  overflow: hidden;
+  transition: height 0.4s ease-out;
+
+  &.open {
+    height: 690px;
+    z-index: 1000;
+  }
+}
+.picker-panel-shade {
+  position: absolute;
+  left: 0px;
+  right: 0px;
+  bottom: 0px;
+  top: 0px;
+  z-index: 900;
+  background-color: rgba(0, 0, 0, 0.25);
+}


### PR DESCRIPTION
The browse-video and browse-image options in the video settings were broken due to some modal-dialog changes preventing multiple modals visible at the same time.

This change takes that browsing out of a new modal and does an osx-style sheet that slides down from the top of the edit-modal to pick the media.

![media-picker](https://user-images.githubusercontent.com/333265/194134643-f0d385e1-510a-42b4-a945-a8aae92bf2f4.gif)
