### PR TITLE
[FEATURE] [MER 1469] [MER 1487] provide backwards compatible precision support for numeric

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+--cwd assets

--- a/assets/src/components/activities/AuthoringElementProvider.tsx
+++ b/assets/src/components/activities/AuthoringElementProvider.tsx
@@ -4,6 +4,7 @@ import { Maybe } from 'tsmonad';
 import { ActivityModelSchema, MediaItemRequest, PostUndoable } from './types';
 import { ModalDisplay } from 'components/modal/ModalDisplay';
 import { AuthoringElementProps } from './AuthoringElement';
+import { ErrorBoundary } from 'components/common/ErrorBoundary';
 
 export interface AuthoringElementState<T> {
   projectSlug: string;
@@ -42,7 +43,7 @@ export const AuthoringElementProvider: React.FC<AuthoringElementProps<ActivityMo
     <AuthoringElementContext.Provider
       value={{ projectSlug, editMode, dispatch, model, onRequestMedia, authoringContext }}
     >
-      {children}
+      <ErrorBoundary>{children}</ErrorBoundary>
       <ModalDisplay />
     </AuthoringElementContext.Provider>
   );

--- a/assets/src/components/activities/common/authoring/GradingApproachDropdown.tsx
+++ b/assets/src/components/activities/common/authoring/GradingApproachDropdown.tsx
@@ -25,8 +25,8 @@ export const GradingApproachDropdown = <K extends string>({
   };
 
   return (
-    <div className="mb-4 d-flex">
-      <span>Grading Approach:</span>
+    <div className="mb-4 d-flex align-items-center">
+      <span className="mr-2">Grading Approach</span>
       <select
         style={{ width: 250 }}
         disabled={!editMode}

--- a/assets/src/components/activities/common/delivery/inputs/NumericInput.tsx
+++ b/assets/src/components/activities/common/delivery/inputs/NumericInput.tsx
@@ -1,3 +1,4 @@
+import { disableScrollWheelChange } from 'components/activities/short_answer/utils';
 import React, { createRef } from 'react';
 
 interface Props {
@@ -8,14 +9,11 @@ interface Props {
   onBlur?: () => void;
 }
 export const NumericInput: React.FC<Props> = (props) => {
-  const input = createRef<HTMLInputElement>();
-
-  // disable changing of the value via scroll wheel in certain browsers
-  const handleScrollWheelChange = () => input.current?.blur();
+  const numericInputRef = createRef<HTMLInputElement>();
 
   return (
     <input
-      ref={input}
+      ref={numericInputRef}
       placeholder={props.placeholder}
       type="number"
       aria-label="answer submission textbox"
@@ -24,7 +22,7 @@ export const NumericInput: React.FC<Props> = (props) => {
       onBlur={props.onBlur}
       value={props.value}
       disabled={typeof props.disabled === 'boolean' ? props.disabled : false}
-      onWheel={handleScrollWheelChange}
+      onWheel={disableScrollWheelChange(numericInputRef)}
     />
   );
 };

--- a/assets/src/components/activities/custom_dnd/AnswerKey.tsx
+++ b/assets/src/components/activities/custom_dnd/AnswerKey.tsx
@@ -8,7 +8,7 @@ import { InputEntry } from 'components/activities/short_answer/sections/InputEnt
 import { getTargetedResponses } from 'components/activities/short_answer/utils';
 import { makeResponse, Response, RichText } from 'components/activities/types';
 import { getCorrectResponse } from 'data/activities/model/responses';
-import { containsRule } from 'data/activities/model/rules';
+import { containsRule, InputKind } from 'data/activities/model/rules';
 import { TextInput } from 'components/common/TextInput';
 
 import { makeRule } from 'data/activities/model/rules';
@@ -44,7 +44,7 @@ export const AnswerKey: React.FC<Props> = (props) => {
           dispatch(
             ResponseActions.editRule(
               getCorrectResponse(model, props.partId).id,
-              makeRule('regex', value),
+              makeRule({ kind: InputKind.Text, operator: 'regex', value }),
             ),
           )
         }

--- a/assets/src/components/activities/multi_input/sections/AnswerKeyTab.tsx
+++ b/assets/src/components/activities/multi_input/sections/AnswerKeyTab.tsx
@@ -26,7 +26,7 @@ import React from 'react';
 const defaultRuleForInputType = (inputType: string | undefined) => {
   switch (inputType) {
     case 'numeric':
-      return eqRule('');
+      return eqRule(0);
     case 'math':
       return equalsRule('');
     case 'text':

--- a/assets/src/components/activities/multi_input/sections/InputRefToolbar.tsx
+++ b/assets/src/components/activities/multi_input/sections/InputRefToolbar.tsx
@@ -14,9 +14,10 @@ export const InputRefToolbar: React.FC<InputRefToolbar> = (props) => {
   }, [editor]);
 
   return (
-    <div>
+    <div className="d-flex flex-row my-2">
+      <div className="flex-grow-1"></div>
       <AuthoringButtonConnected
-        className="btn-light"
+        className="btn-primary btn-sm"
         style={{ borderBottomLeftRadius: 0, borderBottomRightRadius: 0 }}
         action={(e) => {
           e.preventDefault();

--- a/assets/src/components/activities/short_answer/ShortAnswerAuthoring.tsx
+++ b/assets/src/components/activities/short_answer/ShortAnswerAuthoring.tsx
@@ -107,7 +107,7 @@ const ShortAnswer = () => {
                 dispatch(
                   ResponseActions.addResponse(
                     makeResponse(
-                      model.inputType === 'numeric' ? eqRule('1') : containsRule('another answer'),
+                      model.inputType === 'numeric' ? eqRule(1) : containsRule('another answer'),
                       0,
                       '',
                     ),

--- a/assets/src/components/activities/short_answer/sections/InputEntry.tsx
+++ b/assets/src/components/activities/short_answer/sections/InputEntry.tsx
@@ -1,8 +1,10 @@
 import {
   makeRule,
   parseInputFromRule,
-  parseOperatorFromRule,
-  RuleOperator,
+  Input,
+  InputText,
+  InputNumeric,
+  InputRange,
 } from 'data/activities/model/rules';
 import { InputType } from 'components/activities/short_answer/schema';
 import { Response } from 'components/activities/types';
@@ -11,7 +13,6 @@ import React from 'react';
 import { NumericInput } from 'components/activities/short_answer/sections/NumericInput';
 import { TextInput } from 'components/activities/short_answer/sections/TextInput';
 import { MathInput } from 'components/activities/short_answer/sections/MathInput';
-import { valueOr } from 'utils/common';
 
 interface InputProps {
   inputType: InputType;
@@ -19,29 +20,23 @@ interface InputProps {
   onEditResponseRule: (id: string, rule: string) => void;
 }
 
-interface SingleState {
-  operator: RuleOperator;
-  input: string;
-}
-
 export const InputEntry: React.FC<InputProps> = ({ inputType, response, onEditResponseRule }) => {
-  const [{ operator, input }, setState] = useState({
-    input: parseInputFromRule(response.rule),
-    operator: parseOperatorFromRule(response.rule),
-  });
+  const [input, setInput] = useState(
+    parseInputFromRule(response.rule).valueOrThrow(
+      Error(`failed to parse input value from rule ${response.rule}`),
+    ),
+  );
 
-  const onEditRule = (inputState: { input: string | [string, string]; operator: RuleOperator }) => {
-    setState(inputState);
-    onEditResponseRule(response.id, makeRule(inputState.operator, inputState.input));
+  const onEditInput = (update: Input) => {
+    setInput(update);
+    onEditResponseRule(response.id, makeRule(update));
   };
 
-  const state = { operator, input: valueOr(input, '') };
-
   if (inputType === 'math') {
-    return <MathInput state={state as SingleState} setState={onEditRule} />;
+    return <MathInput input={input as InputText} onEditInput={onEditInput} />;
   }
   if (inputType === 'numeric' || inputType === 'vlabvalue') {
-    return <NumericInput state={state as SingleState} setState={onEditRule} />;
+    return <NumericInput input={input as InputNumeric | InputRange} onEditInput={onEditInput} />;
   }
-  return <TextInput state={state as SingleState} setState={onEditRule} />;
+  return <TextInput input={input as InputText} onEditInput={onEditInput} />;
 };

--- a/assets/src/components/activities/short_answer/sections/InputEntry.tsx
+++ b/assets/src/components/activities/short_answer/sections/InputEntry.tsx
@@ -24,11 +24,6 @@ interface SingleState {
   input: string;
 }
 
-interface RangeState {
-  operator: RuleOperator;
-  input: [string, string];
-}
-
 export const InputEntry: React.FC<InputProps> = ({ inputType, response, onEditResponseRule }) => {
   const [{ operator, input }, setState] = useState({
     input: parseInputFromRule(response.rule),

--- a/assets/src/components/activities/short_answer/sections/MathInput.tsx
+++ b/assets/src/components/activities/short_answer/sections/MathInput.tsx
@@ -1,31 +1,23 @@
 import React from 'react';
 import { useAuthoringElementContext } from 'components/activities/AuthoringElementProvider';
-import { RuleOperator } from 'data/activities/model/rules';
+import { InputText } from 'data/activities/model/rules';
 import { MathLive } from 'components/common/MathLive';
 
-interface State {
-  operator: RuleOperator;
-  input: string;
+interface MathInputProps {
+  input: InputText;
+  onEditInput: (input: InputText) => void;
 }
-interface InputProps {
-  setState: (s: State) => void;
-  state: State;
-}
-export const MathInput: React.FC<InputProps> = ({ state, setState }) => {
+export const MathInput: React.FC<MathInputProps> = ({ input, onEditInput }) => {
   const { editMode } = useAuthoringElementContext();
-
-  if (typeof state.input != 'string') {
-    return null;
-  }
 
   return (
     <div className="mb-2">
       <MathLive
-        value={state.input}
+        value={input.value}
         options={{
           readOnly: !editMode,
         }}
-        onChange={(latex: string) => setState({ input: latex, operator: 'equals' })}
+        onChange={(latex: string) => onEditInput({ ...input, value: latex, operator: 'equals' })}
       />
     </div>
   );

--- a/assets/src/components/activities/short_answer/sections/MathInput.tsx
+++ b/assets/src/components/activities/short_answer/sections/MathInput.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useAuthoringElementContext } from 'components/activities/AuthoringElementProvider';
-import { escapeInput, RuleOperator, unescapeInput } from 'data/activities/model/rules';
+import { RuleOperator } from 'data/activities/model/rules';
 import { MathLive } from 'components/common/MathLive';
 
 interface State {
@@ -21,11 +21,11 @@ export const MathInput: React.FC<InputProps> = ({ state, setState }) => {
   return (
     <div className="mb-2">
       <MathLive
-        value={unescapeInput(state.input)}
+        value={state.input}
         options={{
           readOnly: !editMode,
         }}
-        onChange={(latex: string) => setState({ input: escapeInput(latex), operator: 'equals' })}
+        onChange={(latex: string) => setState({ input: latex, operator: 'equals' })}
       />
     </div>
   );

--- a/assets/src/components/activities/short_answer/sections/NumericInput.tsx
+++ b/assets/src/components/activities/short_answer/sections/NumericInput.tsx
@@ -1,23 +1,24 @@
 import { useAuthoringElementContext } from 'components/activities/AuthoringElementProvider';
-import React, { createRef, useRef, useState } from 'react';
-import { isOperator, RuleOperator } from 'data/activities/model/rules';
+import React, { createRef, useState } from 'react';
+import {
+  InputKind,
+  InputNumeric,
+  InputRange,
+  numericOperator,
+  rangeOperator,
+  RuleOperator,
+} from 'data/activities/model/rules';
 import guid from 'utils/guid';
 import { classNames } from 'utils/classNames';
 import { disableScrollWheelChange } from '../utils';
 
-interface SimpleNumericInputState {
-  operator: RuleOperator;
-  input: string;
-}
-
 interface SimpleNumericInputProps extends InputProps {
-  state: SimpleNumericInputState;
+  input: InputNumeric;
+  onEditInput: (input: InputNumeric) => void;
 }
 
-const SimpleNumericInput: React.FC<SimpleNumericInputProps> = ({ state, setState }) => {
+const SimpleNumericInput: React.FC<SimpleNumericInputProps> = ({ input, onEditInput }) => {
   const { editMode } = useAuthoringElementContext();
-
-  const [value, _] = parseValueAndPrecision(state.input);
 
   return (
     <input
@@ -25,23 +26,19 @@ const SimpleNumericInput: React.FC<SimpleNumericInputProps> = ({ state, setState
       type="number"
       className="form-control"
       onChange={(e) => {
-        setState({ input: e.target.value, operator: state.operator });
+        onEditInput({ ...input, value: parseInt(e.target.value) });
       }}
-      value={value}
+      value={input.value}
     />
   );
 };
 
-interface RangeNumericInputState {
-  operator: RuleOperator;
-  input: [string, string];
-}
-
 interface RangeNumericInputProps extends InputProps {
-  state: RangeNumericInputState;
+  input: InputRange;
+  onEditInput: (input: InputRange) => void;
 }
 
-const RangeNumericInput: React.FC<RangeNumericInputProps> = ({ state, setState }) => {
+const RangeNumericInput: React.FC<RangeNumericInputProps> = ({ input, onEditInput }) => {
   const { editMode } = useAuthoringElementContext();
   const numericInputRef = createRef<HTMLInputElement>();
 
@@ -51,11 +48,10 @@ const RangeNumericInput: React.FC<RangeNumericInputProps> = ({ state, setState }
         disabled={!editMode}
         type="number"
         className="form-control"
-        onChange={(e) => {
-          const newValue = [e.target.value, state.input[1]] as [string, string];
-          setState({ input: newValue, operator: state.operator });
+        onChange={({ target: { value } }) => {
+          onEditInput({ ...input, upperBound: parseFloat(value) });
         }}
-        value={state.input[0]}
+        value={input.lowerBound}
       />
       <div className="mx-1">and</div>
       <input
@@ -64,26 +60,15 @@ const RangeNumericInput: React.FC<RangeNumericInputProps> = ({ state, setState }
         disabled={!editMode}
         type="number"
         className="form-control"
-        onChange={(e) => {
-          const newValue = [state.input[0], e.target.value] as [string, string];
-          setState({ input: newValue, operator: state.operator });
+        onChange={({ target: { value } }) => {
+          onEditInput({ ...input, lowerBound: parseFloat(value) });
         }}
-        value={state.input[1]}
+        value={input.upperBound}
         onWheel={disableScrollWheelChange(numericInputRef)}
       />
     </div>
   );
 };
-
-interface State {
-  operator: RuleOperator;
-  input: string | [string, string];
-}
-
-interface InputProps {
-  setState: (s: State) => void;
-  state: State;
-}
 
 export enum PrecisionKind {
   None,
@@ -97,182 +82,119 @@ export interface NoPrecision {
 
 export interface InvalidPrecision {
   kind: PrecisionKind.Invalid;
-  value: string;
+  value: number | '';
 }
 
 export interface WithPrecision {
   kind: PrecisionKind.WithPrecision;
-  value: string;
+  value: number;
 }
 
 export type Precision = NoPrecision | InvalidPrecision | WithPrecision;
 
-const isRangeOperator = (op: RuleOperator) => op === 'btw' || op === 'nbtw';
+export const validatePrecision = (value: string) =>
+  value.length > 0 && !isNaN(parseInt(value)) && parseInt(value) > 0
+    ? { kind: PrecisionKind.WithPrecision, value: parseInt(value) }
+    : { kind: PrecisionKind.Invalid, value: numberOrEmptyString(parseInt(value)) };
 
-export const validatePrecision = (value: string): Precision =>
-  value.length > 0 && Number.isInteger(parseInt(value)) && parseInt(value) > 0
-    ? { kind: PrecisionKind.WithPrecision, value }
-    : { kind: PrecisionKind.Invalid, value };
-
-const parseValueAndPrecision = (
-  input: string | [string, string],
-): [string | [string, string], Precision] => {
-  if (Array.isArray(input)) return [input, { kind: PrecisionKind.None }];
-
-  const [v, p] = input.split('#');
-
-  switch (true) {
-    case p && p.length > 0:
-      return [v, { kind: PrecisionKind.WithPrecision, value: p }];
-    default:
-      return [v, { kind: PrecisionKind.None }];
-  }
-};
-
-const numberOrEmptyString = (num: number) => (isNaN(num) ? '' : num);
+const numberOrEmptyString = (num: number | '') => (num === '' || isNaN(num) ? '' : num);
 
 const precisionInputValue = (precision: Precision) => {
   switch (precision.kind) {
     case PrecisionKind.WithPrecision:
     case PrecisionKind.Invalid:
-      return numberOrEmptyString(parseInt(precision.value));
+      return numberOrEmptyString(precision.value);
     default:
       return '';
   }
 };
 
-const composeInput = (
-  value: string | [string, string],
-  precision: Precision,
-): string | [string, string] => {
-  if (Array.isArray(value)) return value;
+const initialPrecision = (p: number | undefined): Precision =>
+  p === undefined ? { kind: PrecisionKind.None } : { kind: PrecisionKind.WithPrecision, value: p };
 
-  switch (precision.kind) {
-    case PrecisionKind.WithPrecision:
-      return `${value}#${precision.value}`;
-    default:
-      return value;
-  }
-};
+interface PrecisionInputProps {
+  input: InputNumeric | InputRange;
+  onEditInput: (input: InputNumeric | InputRange) => void;
+}
 
-export const NumericInput: React.FC<InputProps> = ({ setState, state }) => {
+const PrecisionInput: React.FC<PrecisionInputProps> = ({ input, onEditInput }) => {
   const { editMode } = useAuthoringElementContext();
   const numericInputRef = createRef<HTMLInputElement>();
-  const [inputValue, p]: [string | [string, string], Precision] = parseValueAndPrecision(
-    state.input,
-  );
-  const [precision, setPrecision] = useState(p);
+  const [precision, setPrecision] = useState(initialPrecision(input.precision));
   const precisionEdit = precision.kind !== PrecisionKind.None;
+  const precisionCheckboxId = `checkbox-${guid()}`;
+  const precisionInvalid = precision.kind === PrecisionKind.Invalid;
 
   const onTogglePrecision = () => {
     if (precisionEdit) {
       setPrecision({ kind: PrecisionKind.None });
     } else {
-      const DEFAULT_PRECISION = '3';
+      const DEFAULT_PRECISION = 3;
       const p = { kind: PrecisionKind.WithPrecision, value: DEFAULT_PRECISION };
       setPrecision(p);
-      setState({ ...state, input: composeInput(inputValue, p) });
+      onEditInput({ ...input, precision: p.value });
     }
   };
 
   const onEditPrecision: React.ChangeEventHandler<HTMLInputElement> = ({ target: { value } }) => {
     const p = validatePrecision(value);
-    setPrecision(p);
+    setPrecision(p as Precision);
 
-    if (p.kind !== PrecisionKind.Invalid) {
-      setState({ ...state, input: composeInput(inputValue, p) });
+    if (p.kind === PrecisionKind.WithPrecision) {
+      onEditInput({ ...input, precision: (p as WithPrecision).value });
     }
   };
 
-  const precisionCheckboxId = `checkbox-${guid()}`;
-  const precisionInvalid = precision.kind === PrecisionKind.Invalid;
-
   return (
-    <div className="mb-2">
+    <div className="d-flex flex-column">
+      <div className="d-flex flex-row my-3">
+        <div className="flex-grow-1"></div>
+        <div className="d-flex flex-row align-items-center">
+          <div className="custom-control custom-switch mr-2">
+            <input
+              type="checkbox"
+              className="custom-control-input"
+              disabled={!editMode}
+              id={precisionCheckboxId}
+              checked={precisionEdit}
+              onChange={onTogglePrecision}
+            />
+            <label className="custom-control-label" htmlFor={precisionCheckboxId}>
+              Precision
+            </label>
+          </div>
+          <input
+            ref={numericInputRef}
+            type="number"
+            className={classNames('form-control', precisionInvalid && 'is-invalid')}
+            style={{ width: 200 }}
+            disabled={!editMode || !precisionEdit}
+            value={precisionInputValue(precision)}
+            onChange={onEditPrecision}
+            aria-label="Precision"
+            onWheel={disableScrollWheelChange(numericInputRef)}
+          />
+        </div>
+      </div>
       <div className="d-flex flex-row">
-        <select
-          disabled={!editMode}
-          className="form-control mr-1"
-          value={state.operator}
-          onChange={(e) => {
-            const nextOp = e.target.value;
-            if (!isOperator(nextOp)) {
-              return;
-            }
-
-            let nextValue;
-            if (isRangeOperator(nextOp) && !isRangeOperator(state.operator)) {
-              nextValue = [state.input, state.input] as [string, string];
-            } else if (isRangeOperator(state.operator) && !isRangeOperator(nextOp)) {
-              nextValue = state.input[0];
-            } else {
-              nextValue = state.input;
-            }
-
-            setState({ operator: nextOp, input: composeInput(nextValue, precision) });
-          }}
-          name="question-type"
-        >
-          {numericOptions.map((option) => (
-            <option key={option.value} value={option.value}>
-              {option.displayValue}
-            </option>
-          ))}
-        </select>
-        {isRangeOperator(state.operator) ? (
-          <RangeNumericInput state={state as RangeNumericInputState} setState={setState} />
-        ) : (
+        <div className="flex-grow-1"></div>
+        {precisionInvalid && (
           <div>
-            <SimpleNumericInput state={state as SimpleNumericInputState} setState={setState} />
-
-            <div className="d-flex flex-column">
-              <div className="d-flex flex-row my-3">
-                <div className="flex-grow-1"></div>
-                <div className="d-flex flex-row align-items-center">
-                  <div className="custom-control custom-switch mr-2">
-                    <input
-                      type="checkbox"
-                      className="custom-control-input"
-                      id={precisionCheckboxId}
-                      checked={precisionEdit}
-                      onChange={onTogglePrecision}
-                    />
-                    <label className="custom-control-label" htmlFor={precisionCheckboxId}>
-                      Precision
-                    </label>
-                  </div>
-                  <input
-                    ref={numericInputRef}
-                    type="number"
-                    className={classNames('form-control', precisionInvalid && 'is-invalid')}
-                    style={{ width: 200 }}
-                    disabled={!precisionEdit}
-                    value={precisionInputValue(precision)}
-                    onChange={onEditPrecision}
-                    aria-label="Precision"
-                    onWheel={disableScrollWheelChange(numericInputRef)}
-                  />
-                </div>
-              </div>
-              <div className="d-flex flex-row">
-                <div className="flex-grow-1"></div>
-                {precisionInvalid && (
-                  <div>
-                    <small className="text-danger">
-                      Precision must be a number greater than zero
-                    </small>
-                  </div>
-                )}
-              </div>
-            </div>
+            <small className="text-danger">Precision must be a number greater than zero</small>
           </div>
         )}
       </div>
     </div>
   );
 };
+interface InputProps {
+  onEditInput: (input: InputNumeric | InputRange) => void;
+  input: InputNumeric | InputRange;
+}
 
-export const numericOptions: { value: RuleOperator; displayValue: string }[] = [
+const isRangeOperator = (op: string) => op === 'btw' || op === 'nbtw';
+
+export const operatorOptions: { value: RuleOperator; displayValue: string }[] = [
   { value: 'gt', displayValue: 'Greater than' },
   { value: 'gte', displayValue: 'Greater than or equal to' },
   { value: 'lt', displayValue: 'Less than' },
@@ -282,3 +204,61 @@ export const numericOptions: { value: RuleOperator; displayValue: string }[] = [
   { value: 'btw', displayValue: 'Between' },
   { value: 'nbtw', displayValue: 'Not between' },
 ];
+
+export const NumericInput: React.FC<InputProps> = ({ input, onEditInput }) => {
+  const { editMode } = useAuthoringElementContext();
+
+  const onSelectOperator: React.ChangeEventHandler<HTMLSelectElement> = (e) => {
+    if (isRangeOperator(e.target.value)) {
+      const nextOp = rangeOperator(e.target.value);
+      // if we are switching from numeric operator to range, change the input
+      // type and use the numeric value as the initial lower bound
+      const nextInput = isRangeOperator(input.operator)
+        ? {
+            kind: InputKind.Range,
+            lowerBound: (input as InputNumeric).value,
+          }
+        : input;
+      onEditInput({ ...nextInput, operator: nextOp } as InputRange);
+    } else {
+      const nextOp = numericOperator(e.target.value);
+      // if we are switching from range operator to numeric, change the input
+      // type and use lower bound as initial value
+      const nextInput = isRangeOperator(input.operator)
+        ? {
+            kind: InputKind.Numeric,
+            value: (input as InputRange).lowerBound,
+          }
+        : input;
+      onEditInput({ ...nextInput, operator: nextOp } as InputNumeric);
+    }
+  };
+
+  return (
+    <div className="mb-2">
+      <div className="d-flex flex-row">
+        <select
+          disabled={!editMode}
+          className="form-control mr-1"
+          value={input.operator}
+          onChange={onSelectOperator}
+          name="question-type"
+        >
+          {operatorOptions.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.displayValue}
+            </option>
+          ))}
+        </select>
+        {isRangeOperator(input.operator) ? (
+          <RangeNumericInput input={input as InputRange} onEditInput={onEditInput} />
+        ) : (
+          <div>
+            <SimpleNumericInput input={input as InputNumeric} onEditInput={onEditInput} />
+          </div>
+        )}
+      </div>
+      <PrecisionInput input={input} onEditInput={onEditInput} />
+    </div>
+  );
+};

--- a/assets/src/components/activities/short_answer/sections/NumericInput.tsx
+++ b/assets/src/components/activities/short_answer/sections/NumericInput.tsx
@@ -232,6 +232,30 @@ const precisionInputValue = (precision: Precision) => {
   }
 };
 
+const DIGITS: Record<string, boolean> = {
+  '0': true,
+  '1': true,
+  '2': true,
+  '3': true,
+  '4': true,
+  '5': true,
+  '6': true,
+  '7': true,
+  '8': true,
+  '9': true,
+};
+const isDigit = (c: string): boolean => DIGITS[c];
+const numberOfDigits = (value: number) => value.toString().split('').filter(isDigit).length;
+
+const inferPrecision = (input: InputNumeric | InputRange) => {
+  switch (input.kind) {
+    case InputKind.Numeric:
+      return numberOfDigits(input.value);
+    case InputKind.Range:
+      return Math.min(numberOfDigits(input.lowerBound), numberOfDigits(input.upperBound));
+  }
+};
+
 interface PrecisionInputProps {
   input: InputNumeric | InputRange;
   onEditInput: (input: InputNumeric | InputRange) => void;
@@ -251,8 +275,7 @@ const PrecisionInput: React.FC<PrecisionInputProps> = ({ input, onEditInput }) =
       setPrecision({ kind: PrecisionKind.None });
       onEditInput({ ...input, precision: undefined });
     } else {
-      const DEFAULT_PRECISION = 3;
-      const p = { kind: PrecisionKind.WithPrecision, value: DEFAULT_PRECISION };
+      const p = { kind: PrecisionKind.WithPrecision, value: inferPrecision(input) };
       setPrecision(p);
       onEditInput({ ...input, precision: p.value });
     }

--- a/assets/src/components/activities/short_answer/sections/NumericInput.tsx
+++ b/assets/src/components/activities/short_answer/sections/NumericInput.tsx
@@ -1,8 +1,9 @@
 import { useAuthoringElementContext } from 'components/activities/AuthoringElementProvider';
-import React, { useState } from 'react';
+import React, { createRef, useRef, useState } from 'react';
 import { isOperator, RuleOperator } from 'data/activities/model/rules';
 import guid from 'utils/guid';
 import { classNames } from 'utils/classNames';
+import { disableScrollWheelChange } from '../utils';
 
 interface SimpleNumericInputState {
   operator: RuleOperator;
@@ -42,6 +43,7 @@ interface RangeNumericInputProps extends InputProps {
 
 const RangeNumericInput: React.FC<RangeNumericInputProps> = ({ state, setState }) => {
   const { editMode } = useAuthoringElementContext();
+  const numericInputRef = createRef<HTMLInputElement>();
 
   return (
     <div className="d-flex flex-column d-md-flex flex-md-row align-items-center">
@@ -57,6 +59,7 @@ const RangeNumericInput: React.FC<RangeNumericInputProps> = ({ state, setState }
       />
       <div className="mx-1">and</div>
       <input
+        ref={numericInputRef}
         placeholder="Correct answer"
         disabled={!editMode}
         type="number"
@@ -66,6 +69,7 @@ const RangeNumericInput: React.FC<RangeNumericInputProps> = ({ state, setState }
           setState({ input: newValue, operator: state.operator });
         }}
         value={state.input[1]}
+        onWheel={disableScrollWheelChange(numericInputRef)}
       />
     </div>
   );
@@ -153,6 +157,7 @@ const composeInput = (
 
 export const NumericInput: React.FC<InputProps> = ({ setState, state }) => {
   const { editMode } = useAuthoringElementContext();
+  const numericInputRef = createRef<HTMLInputElement>();
   const [inputValue, p]: [string | [string, string], Precision] = parseValueAndPrecision(
     state.input,
   );
@@ -237,6 +242,7 @@ export const NumericInput: React.FC<InputProps> = ({ setState, state }) => {
                     </label>
                   </div>
                   <input
+                    ref={numericInputRef}
                     type="number"
                     className={classNames('form-control', precisionInvalid && 'is-invalid')}
                     style={{ width: 200 }}
@@ -244,6 +250,7 @@ export const NumericInput: React.FC<InputProps> = ({ setState, state }) => {
                     value={precisionInputValue(precision)}
                     onChange={onEditPrecision}
                     aria-label="Precision"
+                    onWheel={disableScrollWheelChange(numericInputRef)}
                   />
                 </div>
               </div>

--- a/assets/src/components/activities/short_answer/sections/NumericInput.tsx
+++ b/assets/src/components/activities/short_answer/sections/NumericInput.tsx
@@ -19,9 +19,11 @@ interface SimpleNumericInputProps extends InputProps {
 
 const SimpleNumericInput: React.FC<SimpleNumericInputProps> = ({ input, onEditInput }) => {
   const { editMode } = useAuthoringElementContext();
+  const numericInputRef = createRef<HTMLInputElement>();
 
   return (
     <input
+      ref={numericInputRef}
       disabled={!editMode}
       type="number"
       className="form-control"
@@ -29,6 +31,7 @@ const SimpleNumericInput: React.FC<SimpleNumericInputProps> = ({ input, onEditIn
         onEditInput({ ...input, value: parseInt(e.target.value) });
       }}
       value={input.value}
+      onWheel={disableScrollWheelChange(numericInputRef)}
     />
   );
 };
@@ -40,31 +43,34 @@ interface RangeNumericInputProps extends InputProps {
 
 const RangeNumericInput: React.FC<RangeNumericInputProps> = ({ input, onEditInput }) => {
   const { editMode } = useAuthoringElementContext();
-  const numericInputRef = createRef<HTMLInputElement>();
+  const lowerBoundInputRef = createRef<HTMLInputElement>();
+  const upperBoundInputRef = createRef<HTMLInputElement>();
 
   return (
     <div className="d-flex flex-column d-md-flex flex-md-row align-items-center">
       <input
-        disabled={!editMode}
-        type="number"
-        className="form-control"
-        onChange={({ target: { value } }) => {
-          onEditInput({ ...input, upperBound: parseFloat(value) });
-        }}
-        value={input.lowerBound}
-      />
-      <div className="mx-1">and</div>
-      <input
-        ref={numericInputRef}
-        placeholder="Correct answer"
+        ref={lowerBoundInputRef}
         disabled={!editMode}
         type="number"
         className="form-control"
         onChange={({ target: { value } }) => {
           onEditInput({ ...input, lowerBound: parseFloat(value) });
         }}
+        value={input.lowerBound}
+        onWheel={disableScrollWheelChange(lowerBoundInputRef)}
+      />
+      <div className="mx-1">and</div>
+      <input
+        ref={lowerBoundInputRef}
+        placeholder="Correct answer"
+        disabled={!editMode}
+        type="number"
+        className="form-control"
+        onChange={({ target: { value } }) => {
+          onEditInput({ ...input, upperBound: parseFloat(value) });
+        }}
         value={input.upperBound}
-        onWheel={disableScrollWheelChange(numericInputRef)}
+        onWheel={disableScrollWheelChange(upperBoundInputRef)}
       />
     </div>
   );
@@ -212,13 +218,14 @@ export const NumericInput: React.FC<InputProps> = ({ input, onEditInput }) => {
     if (isRangeOperator(e.target.value)) {
       const nextOp = rangeOperator(e.target.value);
       // if we are switching from numeric operator to range, change the input
-      // type and use the numeric value as the initial lower bound
-      const nextInput = isRangeOperator(input.operator)
+      // type and use the numeric value as the initial lower and upper bounds
+      const nextInput = !isRangeOperator(input.operator)
         ? {
             kind: InputKind.Range,
             lowerBound: (input as InputNumeric).value,
+            upperBound: (input as InputNumeric).value,
           }
-        : input;
+        : (input as InputNumeric);
       onEditInput({ ...nextInput, operator: nextOp } as InputRange);
     } else {
       const nextOp = numericOperator(e.target.value);
@@ -229,7 +236,7 @@ export const NumericInput: React.FC<InputProps> = ({ input, onEditInput }) => {
             kind: InputKind.Numeric,
             value: (input as InputRange).lowerBound,
           }
-        : input;
+        : (input as InputRange);
       onEditInput({ ...nextInput, operator: nextOp } as InputNumeric);
     }
   };

--- a/assets/src/components/activities/short_answer/sections/NumericInput.tsx
+++ b/assets/src/components/activities/short_answer/sections/NumericInput.tsx
@@ -2,6 +2,7 @@ import { useAuthoringElementContext } from 'components/activities/AuthoringEleme
 import React, { useState } from 'react';
 import { isOperator, RuleOperator } from 'data/activities/model/rules';
 import guid from 'utils/guid';
+import { classNames } from 'utils/classNames';
 
 interface SimpleNumericInputState {
   operator: RuleOperator;
@@ -124,13 +125,15 @@ const parseValueAndPrecision = (
   }
 };
 
-const precisionInt = (precision: Precision) => {
+const numberOrEmptyString = (num: number) => (isNaN(num) ? '' : num);
+
+const precisionInputValue = (precision: Precision) => {
   switch (precision.kind) {
     case PrecisionKind.WithPrecision:
     case PrecisionKind.Invalid:
-      return parseInt(precision.value);
+      return numberOrEmptyString(parseInt(precision.value));
     default:
-      return undefined;
+      return '';
   }
 };
 
@@ -177,6 +180,7 @@ export const NumericInput: React.FC<InputProps> = ({ setState, state }) => {
   };
 
   const precisionCheckboxId = `checkbox-${guid()}`;
+  const precisionInvalid = precision.kind === PrecisionKind.Invalid;
 
   return (
     <div className="mb-2">
@@ -234,10 +238,10 @@ export const NumericInput: React.FC<InputProps> = ({ setState, state }) => {
                   </div>
                   <input
                     type="number"
-                    className="form-control"
+                    className={classNames('form-control', precisionInvalid && 'is-invalid')}
                     style={{ width: 200 }}
                     disabled={!precisionEdit}
-                    value={precisionInt(precision)}
+                    value={precisionInputValue(precision)}
                     onChange={onEditPrecision}
                     aria-label="Precision"
                   />
@@ -245,9 +249,9 @@ export const NumericInput: React.FC<InputProps> = ({ setState, state }) => {
               </div>
               <div className="d-flex flex-row">
                 <div className="flex-grow-1"></div>
-                {precision.kind === PrecisionKind.Invalid && (
+                {precisionInvalid && (
                   <div>
-                    <small className="text-warning">
+                    <small className="text-danger">
                       Precision must be a number greater than zero
                     </small>
                   </div>

--- a/assets/src/components/activities/short_answer/sections/TextInput.tsx
+++ b/assets/src/components/activities/short_answer/sections/TextInput.tsx
@@ -1,5 +1,5 @@
 import { useAuthoringElementContext } from 'components/activities/AuthoringElementProvider';
-import { escapeInput, isOperator, RuleOperator, unescapeInput } from 'data/activities/model/rules';
+import { isOperator, RuleOperator } from 'data/activities/model/rules';
 import React from 'react';
 
 interface State {
@@ -42,8 +42,8 @@ export const TextInput: React.FC<InputProps> = ({ state, setState }) => {
         disabled={!editMode}
         type="text"
         className="form-control"
-        onChange={(e) => setState({ operator: state.operator, input: escapeInput(e.target.value) })}
-        value={unescapeInput(state.input)}
+        onChange={(e) => setState({ operator: state.operator, input: e.target.value })}
+        value={state.input}
       />
     </div>
   );

--- a/assets/src/components/activities/short_answer/sections/TextInput.tsx
+++ b/assets/src/components/activities/short_answer/sections/TextInput.tsx
@@ -1,16 +1,12 @@
 import { useAuthoringElementContext } from 'components/activities/AuthoringElementProvider';
-import { isOperator, RuleOperator } from 'data/activities/model/rules';
+import { InputText, textOperator } from 'data/activities/model/rules';
 import React from 'react';
 
-interface State {
-  operator: RuleOperator;
-  input: string;
-}
 interface InputProps {
-  setState: (s: State) => void;
-  state: State;
+  onEditInput: (input: InputText) => void;
+  input: InputText;
 }
-export const TextInput: React.FC<InputProps> = ({ state, setState }) => {
+export const TextInput: React.FC<InputProps> = ({ input, onEditInput }) => {
   const { editMode } = useAuthoringElementContext();
   return (
     <div className="d-flex flex-md-row mb-2">
@@ -18,15 +14,11 @@ export const TextInput: React.FC<InputProps> = ({ state, setState }) => {
         disabled={!editMode}
         className="form-control mr-2"
         style={{ width: 250 }}
-        value={state.operator}
-        onChange={(e) => {
-          if (!isOperator(e.target.value)) {
-            return;
-          }
-
-          setState({
-            operator: e.target.value,
-            input: state.input,
+        value={input.operator}
+        onChange={({ target: { value } }) => {
+          onEditInput({
+            ...input,
+            operator: textOperator(value),
           });
         }}
         name="question-type"
@@ -42,8 +34,8 @@ export const TextInput: React.FC<InputProps> = ({ state, setState }) => {
         disabled={!editMode}
         type="text"
         className="form-control"
-        onChange={(e) => setState({ operator: state.operator, input: e.target.value })}
-        value={state.input}
+        onChange={(e) => onEditInput({ ...input, value: e.target.value })}
+        value={input.value}
       />
     </div>
   );

--- a/assets/src/components/activities/short_answer/utils.ts
+++ b/assets/src/components/activities/short_answer/utils.ts
@@ -40,3 +40,7 @@ export const shortAnswerOptions: SelectOption<InputType>[] = [
   { value: 'textarea', displayValue: 'Paragraph' },
   { value: 'math', displayValue: 'Math' },
 ];
+
+// disable changing of the value via scroll wheel in certain browsers
+export const disableScrollWheelChange = (numericInput: React.RefObject<HTMLInputElement>) => () =>
+  numericInput.current?.blur();

--- a/assets/src/components/common/ErrorBoundary.tsx
+++ b/assets/src/components/common/ErrorBoundary.tsx
@@ -23,12 +23,11 @@ export class ErrorBoundary extends React.Component<
       if (this.state.hasError) {
         return (
           <div className="alert alert-warning" role="alert">
-            <h4 className="alert-heading">Oh no!</h4>
-            <p className="mb-4">Something went wrong. Refresh the page and try again.</p>
+            <p className="mb-4">Something went wrong. Please refresh the page and try again.</p>
 
             <hr />
 
-            <p>If the problem persists, contact OLI support with the following error message:</p>
+            <p>If the problem persists, contact support with the following details:</p>
 
             <Collapse caption="Show error message">
               <div

--- a/assets/src/components/misc/Tooltip.tsx
+++ b/assets/src/components/misc/Tooltip.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { createRef, useEffect } from 'react';
 import { classNames } from 'utils/classNames';
 
 interface Props {
@@ -6,10 +6,14 @@ interface Props {
   title: string;
 }
 export const Tooltip = ({ className, title }: Props) => {
+  const ref = createRef<HTMLElement>();
+
+  useEffect(() => ref.current !== null && ($(ref.current) as any).tooltip(), [ref]);
+
   return (
     <i
+      ref={ref}
       className={classNames('ml-2 material-icons-outlined', className)}
-      data-toggle="tooltip"
       data-placement="top"
       title={title}
     >

--- a/assets/src/components/misc/Tooltip.tsx
+++ b/assets/src/components/misc/Tooltip.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
+import { classNames } from 'utils/classNames';
 
 interface Props {
+  className?: string;
   title: string;
 }
-export const Tooltip = ({ title }: Props) => {
+export const Tooltip = ({ className, title }: Props) => {
   return (
     <i
-      className="ml-2 material-icons-outlined"
+      className={classNames('ml-2 material-icons-outlined', className)}
       data-toggle="tooltip"
       data-placement="top"
       title={title}

--- a/assets/src/data/activities/model/responses.ts
+++ b/assets/src/data/activities/model/responses.ts
@@ -17,7 +17,7 @@ export const Responses = {
     Responses.catchAll(incorrectText),
   ],
   forNumericInput: (correctText = 'Correct', incorrectText = 'Incorrect') => [
-    makeResponse(eqRule('1'), 1, correctText),
+    makeResponse(eqRule(1), 1, correctText),
     Responses.catchAll(incorrectText),
   ],
   forMathInput: (correctText = 'Correct', incorrectText = 'Incorrect') => [

--- a/assets/src/data/activities/model/rules.ts
+++ b/assets/src/data/activities/model/rules.ts
@@ -45,8 +45,8 @@ export function isOperator(s: string): s is RuleOperator {
   ].includes(s);
 }
 
-export const escapeInput = (s: string) => s.replace(/[\\{}]/g, (i) => `\\${i}`);
-export const unescapeInput = (s: string) => s.replace(/\\[\\{}]/g, (i) => i.substring(1));
+const escapeInput = (s: string) => s.replace(/[\\{}]/g, (i) => `\\${i}`);
+const unescapeInput = (s: string) => s.replace(/\\[\\{}]/g, (i) => i.substring(1));
 
 export const unescapeSingleOrMultipleInputs = (
   s: string | [string, string],
@@ -54,17 +54,17 @@ export const unescapeSingleOrMultipleInputs = (
   typeof s === 'string' ? unescapeInput(s) : [unescapeInput(s[0]), unescapeInput(s[1])];
 
 // text
-export const equalsRule = (input: string) => `input equals {${input}}`;
-export const matchRule = (input: string) => `input like {${input}}`;
-export const containsRule = (input: string) => `input contains {${input}}`;
+export const equalsRule = (input: string) => `input equals {${escapeInput(input)}}`;
+export const matchRule = (input: string) => `input like {${escapeInput(input)}}`;
+export const containsRule = (input: string) => `input contains {${escapeInput(input)}}`;
 export const notContainsRule = (input: string) => invertRule(containsRule(input));
 
 // numeric
-export const eqRule = (input: string) => `input = {${input}}`;
+export const eqRule = (input: string) => `input = {${escapeInput(input)}}`;
 export const neqRule = (input: string) => invertRule(eqRule(input));
-export const ltRule = (input: string) => `input < {${input}}`;
+export const ltRule = (input: string) => `input < {${escapeInput(input)}}`;
 export const lteRule = (input: string) => orRules(ltRule(input), eqRule(input));
-export const gtRule = (input: string) => `input > {${input}}`;
+export const gtRule = (input: string) => `input > {${escapeInput(input)}}`;
 export const gteRule = (input: string) => orRules(gtRule(input), eqRule(input));
 
 const makeBtwRule = (lesser: string, greater: string) =>
@@ -122,7 +122,7 @@ export const makeRule = (operator: RuleOperator, input: string | [string, string
 const matchBetweenRule = (rule: string) => rule.match(/= {(\d+)}.* = {(\d+)}/);
 export const parseInputFromRule = (rule: string) =>
   Maybe.maybe(matchBetweenRule(rule)).caseOf<string | [string, string]>({
-    just: (betweenMatch) => [betweenMatch[1], betweenMatch[2]],
+    just: (betweenMatch) => [unescapeInput(betweenMatch[1]), unescapeInput(betweenMatch[2])],
     nothing: () => parseSingleInput(rule),
   });
 

--- a/assets/src/data/activities/model/rules.ts
+++ b/assets/src/data/activities/model/rules.ts
@@ -302,7 +302,7 @@ type ParsedRangeRule = {
 
 // ** Deprecated ** this format will still be parsed, but will be converted to range rule on save
 // Look for two equality matches, something like `input = {-123} || input = {234.5}`
-const matchDeprecatedBetweenRule = (rule: string): Maybe<InputRange> =>
+const matchBetweenRule = (rule: string): Maybe<InputRange> =>
   parseRegex(rule, /= {(-?[.\d]+)}.* = {(-?[.\d]+)}/)
     .lift((matches) => matches.slice(1, 3).map(maybeAsNumber))
     .bind(([lowerBound, upperBound]) =>
@@ -352,7 +352,7 @@ const matchRangeRule = (rule: string): Maybe<InputRange> =>
     }));
 
 export const parseInputFromRule = firstMatch<string, Input>([
-  matchDeprecatedBetweenRule,
+  matchBetweenRule,
   matchRangeRule,
   matchSingleNumberRule,
   matchSingleTextRule,

--- a/assets/test/activities/rules_test.ts
+++ b/assets/test/activities/rules_test.ts
@@ -137,4 +137,8 @@ describe('rules', () => {
       ),
     ).toEqual('\\frac{1}{\\lambda}\\left(\\left\\lbrace x\\right\\rbrace\\right)^2');
   });
+
+  it('properly parses legacy range input from rule', () => {
+    expect(parseInputFromRule('input like {[-151.0,151.3]}')).toEqual(['-151.0', '151.3']);
+  });
 });

--- a/assets/test/activities/rules_test.ts
+++ b/assets/test/activities/rules_test.ts
@@ -72,6 +72,15 @@ describe('rules', () => {
     expect(notRangeRule(42, 43, true)).toBe('(!(input = {[42,43]}))');
   });
 
+  it('exclusive range', () => {
+    expect(rangeRule(42, 43, false)).toBe('input = {(42,43)}');
+  });
+
+  it('range with precision', () => {
+    expect(rangeRule(-42.5, 43, true, 3)).toBe('input = {[-42.5,43]#3}');
+    expect(rangeRule(-142.001, 43, false, 4)).toBe('input = {(-142.001,43)#4}');
+  });
+
   it('invert rule', () => {
     expect(invertRule(matchRule('id'))).toBe('(!(input like {id}))');
   });
@@ -125,7 +134,7 @@ describe('rules', () => {
     );
   });
 
-  it('properly parses range input from rule', () => {
+  it('properly parses old range input from rule', () => {
     expect(parseInputFromRule('input = {123} || input = {234}').valueOrThrow()).toEqual(
       expect.objectContaining({
         kind: InputKind.Range,
@@ -157,12 +166,45 @@ describe('rules', () => {
     });
   });
 
-  it('properly parses legacy range input from rule', () => {
+  it('properly parses inclusive range input from rule', () => {
+    expect(parseInputFromRule('input like {[0,26]}').valueOrThrow()).toEqual(
+      expect.objectContaining({
+        kind: InputKind.Range,
+        lowerBound: 0,
+        upperBound: 26,
+      }),
+    );
+  });
+
+  it('properly parses inclusive range input from rule', () => {
     expect(parseInputFromRule('input like {[-151.0,151.3]}').valueOrThrow()).toEqual(
       expect.objectContaining({
         kind: InputKind.Range,
         lowerBound: -151.0,
         upperBound: 151.3,
+        inclusive: true,
+      }),
+    );
+  });
+
+  it('properly parses exclusive range input from rule', () => {
+    expect(parseInputFromRule('input like {(-151.0,151.3)}').valueOrThrow()).toEqual(
+      expect.objectContaining({
+        kind: InputKind.Range,
+        lowerBound: -151.0,
+        upperBound: 151.3,
+        inclusive: false,
+      }),
+    );
+  });
+
+  it('properly parses range input from rule with precision', () => {
+    expect(parseInputFromRule('input like {[-151.0,151.3]#3}').valueOrThrow()).toEqual(
+      expect.objectContaining({
+        kind: InputKind.Range,
+        lowerBound: -151.0,
+        upperBound: 151.3,
+        precision: 3,
       }),
     );
   });

--- a/assets/test/activities/rules_test.ts
+++ b/assets/test/activities/rules_test.ts
@@ -65,15 +65,11 @@ describe('rules', () => {
   });
 
   it('between two numbers rule', () => {
-    expect(rangeRule(42, 43, true)).toBe(
-      'input = {43} || (input < {43}) && (input = {42} || (input > {42}))',
-    );
+    expect(rangeRule(42, 43, true)).toBe('input = {[42,43]}');
   });
 
   it('not between two numbers', () => {
-    expect(notRangeRule(42, 43, true)).toBe(
-      '(!(input = {43} || (input < {43}) && (input = {42} || (input > {42}))))',
-    );
+    expect(notRangeRule(42, 43, true)).toBe('(!(input = {[42,43]}))');
   });
 
   it('invert rule', () => {
@@ -120,27 +116,33 @@ describe('rules', () => {
   });
 
   it('properly parses escaped input from rule', () => {
-    expect(parseInputFromRule('input like {\\{id2\\}}').valueOrThrow()).toEqual({
-      kind: InputKind.Text,
-      operator: 'regex',
-      value: '{id2}',
-    });
+    expect(parseInputFromRule('input like {\\{id2\\}}').valueOrThrow()).toEqual(
+      expect.objectContaining({
+        kind: InputKind.Text,
+        operator: 'regex',
+        value: '{id2}',
+      }),
+    );
   });
 
   it('properly parses range input from rule', () => {
-    expect(parseInputFromRule('input = {123} || input = {234}').valueOrThrow()).toEqual({
-      kind: InputKind.Range,
-      operator: 'btw',
-      lowerBound: 123,
-      upperBound: 234,
-    });
+    expect(parseInputFromRule('input = {123} || input = {234}').valueOrThrow()).toEqual(
+      expect.objectContaining({
+        kind: InputKind.Range,
+        operator: 'btw',
+        lowerBound: 123,
+        upperBound: 234,
+      }),
+    );
 
-    expect(parseInputFromRule('input = {-123.5} || input = {234.2}').valueOrThrow()).toEqual({
-      kind: InputKind.Range,
-      operator: 'btw',
-      lowerBound: -123.5,
-      upperBound: 234.2,
-    });
+    expect(parseInputFromRule('input = {-123.5} || input = {234.2}').valueOrThrow()).toEqual(
+      expect.objectContaining({
+        kind: InputKind.Range,
+        operator: 'btw',
+        lowerBound: -123.5,
+        upperBound: 234.2,
+      }),
+    );
   });
 
   it('properly escapes math equation', () => {

--- a/assets/test/activities/rules_test.ts
+++ b/assets/test/activities/rules_test.ts
@@ -1,6 +1,6 @@
 import {
   andRules,
-  btwRule,
+  rangeRule,
   containsRule,
   matchListRule,
   eqRule,
@@ -10,7 +10,7 @@ import {
   lteRule,
   ltRule,
   matchRule,
-  nbtwRule,
+  notRangeRule,
   neqRule,
   notContainsRule,
   orRules,
@@ -65,13 +65,13 @@ describe('rules', () => {
   });
 
   it('between two numbers rule', () => {
-    expect(btwRule(42, 43)).toBe(
+    expect(rangeRule(42, 43, true)).toBe(
       'input = {43} || (input < {43}) && (input = {42} || (input > {42}))',
     );
   });
 
   it('not between two numbers', () => {
-    expect(nbtwRule(42, 43)).toBe(
+    expect(notRangeRule(42, 43, true)).toBe(
       '(!(input = {43} || (input < {43}) && (input = {42} || (input > {42}))))',
     );
   });

--- a/assets/test/components/activities/short_answer/sections/NumericInput_test.tsx
+++ b/assets/test/components/activities/short_answer/sections/NumericInput_test.tsx
@@ -4,13 +4,13 @@ import {
 } from 'components/activities/short_answer/sections/NumericInput';
 
 it('validatePrecision returns a validated Precision object', () => {
-  expect(validatePrecision('3')).toEqual({ kind: PrecisionKind.WithPrecision, value: '3' });
+  expect(validatePrecision('3')).toEqual({ kind: PrecisionKind.WithPrecision, value: 3 });
   expect(validatePrecision('1203000')).toEqual({
     kind: PrecisionKind.WithPrecision,
-    value: '1203000',
+    value: 1203000,
   });
   expect(validatePrecision('')).toEqual({ kind: PrecisionKind.Invalid, value: '' });
-  expect(validatePrecision('0')).toEqual({ kind: PrecisionKind.Invalid, value: '0' });
-  expect(validatePrecision('-1')).toEqual({ kind: PrecisionKind.Invalid, value: '-1' });
-  expect(validatePrecision('-23')).toEqual({ kind: PrecisionKind.Invalid, value: '-23' });
+  expect(validatePrecision('0')).toEqual({ kind: PrecisionKind.Invalid, value: 0 });
+  expect(validatePrecision('-1')).toEqual({ kind: PrecisionKind.Invalid, value: -1 });
+  expect(validatePrecision('-23')).toEqual({ kind: PrecisionKind.Invalid, value: -23 });
 });

--- a/assets/test/components/activities/short_answer/sections/NumericInput_test.tsx
+++ b/assets/test/components/activities/short_answer/sections/NumericInput_test.tsx
@@ -1,16 +1,16 @@
 import {
   PrecisionKind,
-  validatePrecision,
+  precisionFromString,
 } from 'components/activities/short_answer/sections/NumericInput';
 
 it('validatePrecision returns a validated Precision object', () => {
-  expect(validatePrecision('3')).toEqual({ kind: PrecisionKind.WithPrecision, value: 3 });
-  expect(validatePrecision('1203000')).toEqual({
+  expect(precisionFromString('3')).toEqual({ kind: PrecisionKind.WithPrecision, value: 3 });
+  expect(precisionFromString('1203000')).toEqual({
     kind: PrecisionKind.WithPrecision,
     value: 1203000,
   });
-  expect(validatePrecision('')).toEqual({ kind: PrecisionKind.Invalid, value: '' });
-  expect(validatePrecision('0')).toEqual({ kind: PrecisionKind.Invalid, value: 0 });
-  expect(validatePrecision('-1')).toEqual({ kind: PrecisionKind.Invalid, value: -1 });
-  expect(validatePrecision('-23')).toEqual({ kind: PrecisionKind.Invalid, value: -23 });
+  expect(precisionFromString('')).toEqual({ kind: PrecisionKind.Invalid, value: '' });
+  expect(precisionFromString('0')).toEqual({ kind: PrecisionKind.Invalid, value: 0 });
+  expect(precisionFromString('-1')).toEqual({ kind: PrecisionKind.Invalid, value: -1 });
+  expect(precisionFromString('-23')).toEqual({ kind: PrecisionKind.Invalid, value: -23 });
 });

--- a/assets/test/components/activities/short_answer/sections/NumericInput_test.tsx
+++ b/assets/test/components/activities/short_answer/sections/NumericInput_test.tsx
@@ -1,0 +1,16 @@
+import {
+  PrecisionKind,
+  validatePrecision,
+} from 'components/activities/short_answer/sections/NumericInput';
+
+it('validatePrecision returns a validated Precision object', () => {
+  expect(validatePrecision('3')).toEqual({ kind: PrecisionKind.WithPrecision, value: '3' });
+  expect(validatePrecision('1203000')).toEqual({
+    kind: PrecisionKind.WithPrecision,
+    value: '1203000',
+  });
+  expect(validatePrecision('')).toEqual({ kind: PrecisionKind.Invalid, value: '' });
+  expect(validatePrecision('0')).toEqual({ kind: PrecisionKind.Invalid, value: '0' });
+  expect(validatePrecision('-1')).toEqual({ kind: PrecisionKind.Invalid, value: '-1' });
+  expect(validatePrecision('-23')).toEqual({ kind: PrecisionKind.Invalid, value: '-23' });
+});

--- a/assets/test/short_answer/short_answer_authoring_test.ts
+++ b/assets/test/short_answer/short_answer_authoring_test.ts
@@ -48,7 +48,7 @@ describe('short answer question', () => {
 
     updated = dispatch(
       updated,
-      ResponseActions.addResponse(makeResponse(eqRule('1'), 0, ''), DEFAULT_PART_ID),
+      ResponseActions.addResponse(makeResponse(eqRule(1), 0, ''), DEFAULT_PART_ID),
     );
     expect(updated.authoring.parts[0].responses[0].score).toBe(1);
     expect(updated.authoring.parts[0].responses[1].score).toBe(0);

--- a/lib/oli/delivery/evaluation/rule.ex
+++ b/lib/oli/delivery/evaluation/rule.ex
@@ -67,35 +67,100 @@ defmodule Oli.Delivery.Evaluation.Rule do
   defp eval(:input_length, context), do: String.length(context.input) |> Integer.to_string()
 
   defp eval({:lt, lhs, rhs}, context) do
-    {left, _} = eval(lhs, context) |> Float.parse()
-    {right, _} = eval(rhs, context) |> Float.parse()
+    left = eval(lhs, context)
+    right = eval(rhs, context)
+    {l_value, _} = parse_with_precision(left)
+    {r_value, r_precision} = parse_with_precision(right)
 
-    left < right
+    l_value < r_value &&
+      check_precision(left, r_precision)
   end
 
   defp eval({:gt, lhs, rhs}, context) do
-    {left, _} = eval(lhs, context) |> Float.parse()
-    {right, _} = eval(rhs, context) |> Float.parse()
+    left = eval(lhs, context)
+    right = eval(rhs, context)
+    {l_value, _} = parse_with_precision(left)
+    {r_value, r_precision} = parse_with_precision(right)
 
-    left > right
+    l_value > r_value &&
+      check_precision(left, r_precision)
   end
 
   defp eval({:eq, lhs, rhs}, context) do
     left = eval(lhs, context)
     right = eval(rhs, context)
 
-    if is_float?(left) or is_float?(right) do
-      {left, _} = Float.parse(left)
-      {right, _} = Float.parse(right)
+    # this code assumes that the left value is the input and right value
+    # is the rule. we only care that the precision specified in the rule
+    # matches the precision of the input and not the other way around.
+    {l_value, _} = parse_with_precision(left)
+    {r_value, r_precision} = parse_with_precision(right)
 
-      abs(abs(left) - abs(right)) < 0.00001
+    if is_float(left) or is_float(right) do
+      abs(abs(l_value) - abs(r_value)) < 0.00001 &&
+        check_precision(left, r_precision)
     else
-      eval(lhs, context) |> String.to_integer() ==
-        eval(rhs, context) |> String.to_integer()
+      l_value == r_value &&
+        check_precision(left, r_precision)
     end
   end
 
   defp eval(value, _) when is_binary(value), do: value
 
+  # if a precision is not specified (nil) then always evaluate to true
+  defp check_precision(_value, nil), do: true
+
+  # checks the precision
+  defp check_precision(value, precision) do
+    digit_count =
+      value
+      |> String.split("")
+      |> Enum.filter(&is_digit?/1)
+      |> Enum.count()
+
+    digit_count == precision
+  end
+
   defp is_float?(str), do: String.contains?(str, ".")
+
+  @digits %{
+    "0" => true,
+    "1" => true,
+    "2" => true,
+    "3" => true,
+    "4" => true,
+    "5" => true,
+    "6" => true,
+    "7" => true,
+    "8" => true,
+    "9" => true
+  }
+  defp is_digit?(c), do: Map.has_key?(@digits, c)
+
+  defp parse_with_precision(str) when is_binary(str) do
+    case String.split(str, "#") do
+      [value] -> {parse_value(value), nil}
+      [v, p] -> {parse_value(v), parse_precision(p)}
+    end
+  end
+
+  defp parse_value(str) when is_binary(str) do
+    if is_float?(str) do
+      str
+      |> Float.parse()
+      |> drop_remainder()
+    else
+      str
+      |> Integer.parse()
+      |> drop_remainder()
+    end
+  end
+
+  defp parse_precision(str) when is_binary(str) do
+    str
+    |> Integer.parse()
+    |> drop_remainder()
+  end
+
+  defp drop_remainder({val, _rem}), do: val
 end

--- a/test/oli/delivery/evaluation/rule_eval_test.exs
+++ b/test/oli/delivery/evaluation/rule_eval_test.exs
@@ -101,4 +101,49 @@ defmodule Oli.Delivery.Evaluation.RuleEvalTest do
     {:error, _} = eval("input < {3}", "cat")
     {:error, _} = eval("input = {apple}", "apple")
   end
+
+  test "evaluating float and integer precision" do
+    # precision specified, should evaluate matching precision to true
+    assert eval("attemptNumber = {1} && input = {3.1#2}", "3.1")
+
+    # no precision specified, should evaluate extra precision to true
+    assert eval("attemptNumber = {1} && input = {3.1}", "3.10")
+
+    # precision specified, should evaluate extra precision to false
+    refute eval("attemptNumber = {1} && input = {3.1#2}", "3.10")
+
+    assert eval("attemptNumber = {1} && input = {0.001#4}", "0.001")
+    assert eval("attemptNumber = {1} && input = {3.100#4}", "3.100")
+
+    # eval returns false, although the precision is correct the value is wrong
+    refute eval("attemptNumber = {1} && input = {3.268#2}", "3.2")
+    refute eval("attemptNumber = {1} && input = {3.268#2}", "3.26")
+
+    # eval returns false, although the value is correct, precision is wrong
+    refute eval("attemptNumber = {1} && input = {3.268#2}", "3.268")
+
+    # rule eval doesn't do any rounding, so these will return false
+    refute eval("attemptNumber = {1} && input = {3.5#1}", "4")
+    refute eval("attemptNumber = {1} && input = {3.25#2}", "3.3")
+
+    # even though the value specified is more precise, the value and expected precision match
+    assert eval("attemptNumber = {1} && input = {3.100#2}", "3.1")
+
+    # even though the value specified is less precise, the value and expected precision match
+    assert eval("attemptNumber = {1} && input = {2#2}", "2.0")
+
+    # input is greater than, but precision is wrong
+    refute eval("attemptNumber = {1} && input > {2#3}", "3.2")
+
+    # input is less than, but precision is wrong
+    refute eval("attemptNumber = {1} && input < {4#1}", "3.8")
+
+    # precision is correct, but input is equal to
+    refute eval("attemptNumber = {1} && input < {3#4}", "3.000")
+
+    assert eval("attemptNumber = {1} && input < {4#2}", "3.1")
+    assert eval("attemptNumber = {1} && input < {4#1}", "3")
+    assert eval("attemptNumber = {1} && input > {3#2}", "3.1")
+    assert eval("attemptNumber = {1} && input > {3#1}", "4")
+  end
 end


### PR DESCRIPTION
Adds support for numeric precision for legacy courses. Configuring a precision will tell the evaluator to check to a specific number of digits in the input response.
<img width="790" alt="Screen Shot 2022-10-05 at 5 16 26 PM" src="https://user-images.githubusercontent.com/6248894/194165357-a1529416-e516-4b17-8ed8-1d10c63496a8.png">

This PR also includes a fix to add support for legacy numeric range format: `input like {[151.0,151.3]}`. Though, this addition will result in support for two different range formats in the system. Any creation/edit of numeric input activities will result in the new (or legacy) format as it is more concise and a bit easier to parse.

Finally, there is a bit of refactor around the way torus escapes/unescapes input. These functions were starting to leak into the codebase beyond the parsing layer into activities, it makes much more sense to keep them scope to the parsing step so that activities do not have to worry about this implementation detail. The addition of precision and ranges with inclusive/exclusive support required much of the client side parsing to be refactored. I also took the opportunity to fix a few bugs I stumbled across as well as ensure there are no valid states persisted (such as an empty `input {}`). I added some more tests around this to ensure the change isn't breaking anything.

Still to do:
- [x] Update course-digest to produce range rules as `input = {[151.0,151.3]}` (instead of `input like {[151.0,151.3]}`). The `=` operator is considered numeric in the system while `like` is used for string regular expressions. https://github.com/Simon-Initiative/course-digest/pull/101