### PR TITLE
[ENHANCEMENT] [MER-1467] Provide option for Multi-Input to submit parts Legacy style

### DIFF
--- a/assets/src/components/activities/common/authoring/settings/activitySettingsActions.ts
+++ b/assets/src/components/activities/common/authoring/settings/activitySettingsActions.ts
@@ -1,5 +1,9 @@
-import { isShuffled, toggleAnswerChoiceShuffling } from 'components/activities/common/utils';
-import { HasTransformations } from 'components/activities/types';
+import {
+  isShuffled,
+  toggleAnswerChoiceShuffling,
+  togglePerPartSubmissionOption,
+} from 'components/activities/common/utils';
+import { HasTransformations, HasPerPartSubmissionOption } from 'components/activities/types';
 
 export const shuffleAnswerChoiceSetting = (
   model: HasTransformations,
@@ -8,4 +12,13 @@ export const shuffleAnswerChoiceSetting = (
   isEnabled: isShuffled(model.authoring.transformations),
   label: 'Shuffle answer choice order',
   onToggle: () => dispatch(toggleAnswerChoiceShuffling()),
+});
+
+export const changePerPartSubmission = (
+  model: HasPerPartSubmissionOption,
+  dispatch: (action: any) => void,
+) => ({
+  isEnabled: model.submitPerPart === true,
+  label: 'Submit answers per input',
+  onToggle: () => dispatch(togglePerPartSubmissionOption()),
 });

--- a/assets/src/components/activities/common/delivery/evaluation/Evaluation.tsx
+++ b/assets/src/components/activities/common/delivery/evaluation/Evaluation.tsx
@@ -56,7 +56,7 @@ export function renderPartFeedback(partState: PartState, context: WriterContext)
 
 export const Evaluation: React.FC<Props> = ({ shouldShow = true, attemptState, context }) => {
   const { score, outOf, parts } = attemptState;
-  if (!shouldShow || outOf === null || score === null) {
+  if (!shouldShow) {
     return null;
   }
 

--- a/assets/src/components/activities/common/utils.tsx
+++ b/assets/src/components/activities/common/utils.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { maybe } from 'tsmonad';
 import {
-  ActivityModelSchema,
+  HasPerPartSubmissionOption,
   makeTransformation,
   PartId,
   Transform,
@@ -20,6 +19,13 @@ export const toggleAnswerChoiceShuffling = () => {
           (xform) => xform.operation !== Transform.shuffle,
         ))
       : model.authoring.transformations.push(makeTransformation('choices', Transform.shuffle));
+  };
+};
+
+export const togglePerPartSubmissionOption = () => {
+  return (model: HasPerPartSubmissionOption): void => {
+    model.submitPerPart =
+      model.submitPerPart === undefined || model.submitPerPart === false ? true : false;
   };
 };
 

--- a/assets/src/components/activities/multi_input/MultiInputAuthoring.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputAuthoring.tsx
@@ -1,5 +1,8 @@
 import { ActivitySettings } from 'components/activities/common/authoring/settings/ActivitySettings';
-import { shuffleAnswerChoiceSetting } from 'components/activities/common/authoring/settings/activitySettingsActions';
+import {
+  shuffleAnswerChoiceSetting,
+  changePerPartSubmission,
+} from 'components/activities/common/authoring/settings/activitySettingsActions';
 import { MultiInputSchema } from 'components/activities/multi_input/schema';
 import { AnswerKeyTab } from 'components/activities/multi_input/sections/AnswerKeyTab';
 import { HintsTab } from 'components/activities/multi_input/sections/HintsTab';
@@ -73,7 +76,12 @@ export const MultiInputComponent = () => {
               onEdit={(t) => dispatch(VariableActions.onUpdateTransformations(t))}
             />
           </TabbedNavigation.Tab>
-          <ActivitySettings settings={[shuffleAnswerChoiceSetting(model, dispatch)]} />
+          <ActivitySettings
+            settings={[
+              shuffleAnswerChoiceSetting(model, dispatch),
+              changePerPartSubmission(model, dispatch),
+            ]}
+          />
         </TabbedNavigation.Tabs>
       ) : (
         'Select an input to edit it'

--- a/assets/src/components/activities/multi_input/schema.ts
+++ b/assets/src/components/activities/multi_input/schema.ts
@@ -49,6 +49,7 @@ export interface MultiInputSchema extends ActivityModelSchema {
   choices: Choice[];
   // The actual student-answerable inputs, designated by their type
   inputs: MultiInput[];
+  submitPerPart: boolean;
   authoring: {
     targeted: ChoiceIdsToResponseId[];
     parts: Part[];

--- a/assets/src/components/activities/multi_input/utils.tsx
+++ b/assets/src/components/activities/multi_input/utils.tsx
@@ -45,6 +45,7 @@ export const defaultModel = (): MultiInputSchema => {
     stem: multiInputStem(input),
     choices: [],
     inputs: [{ inputType: 'text', id: input.id, partId: '1' }],
+    partSubmission: false,
     authoring: {
       parts: [makePart(Responses.forTextInput(), [makeHint('')], '1')],
       targeted: [],

--- a/assets/src/components/activities/multi_input/utils.tsx
+++ b/assets/src/components/activities/multi_input/utils.tsx
@@ -45,7 +45,7 @@ export const defaultModel = (): MultiInputSchema => {
     stem: multiInputStem(input),
     choices: [],
     inputs: [{ inputType: 'text', id: input.id, partId: '1' }],
-    partSubmission: false,
+    submitPerPart: false,
     authoring: {
       parts: [makePart(Responses.forTextInput(), [makeHint('')], '1')],
       targeted: [],

--- a/assets/src/components/activities/types.ts
+++ b/assets/src/components/activities/types.ts
@@ -407,6 +407,11 @@ export interface HasTransformations {
     transformations: Transformation[];
   };
 }
+
+export interface HasPerPartSubmissionOption {
+  submitPerPart: boolean;
+}
+
 /**
  * Helper function to create a transformation.
  * @param path  JSON path of the node within the model to transform

--- a/assets/test/multi_input/multi_input_authoring_test.tsx
+++ b/assets/test/multi_input/multi_input_authoring_test.tsx
@@ -33,6 +33,7 @@ const choices = [makeChoice('Choice A'), makeChoice('Choice B')];
 const _dropdownModel: MultiInputSchema = {
   stem: multiInputStem(input),
   choices,
+  submitPerPart: false,
   inputs: [
     {
       inputType: 'dropdown',
@@ -52,6 +53,7 @@ const _dropdownModel: MultiInputSchema = {
 const _numericModel: MultiInputSchema = {
   stem: multiInputStem(input),
   choices: [],
+  submitPerPart: false,
   inputs: [{ inputType: 'numeric', id: input.id, partId: DEFAULT_PART_ID }],
   authoring: {
     parts: [makePart(Responses.forNumericInput(), [makeHint('')], DEFAULT_PART_ID)],


### PR DESCRIPTION
This PR adds an author facing option on the MultiInput activity to allow "per part" submission, the same way that Legacy multi-input questions work. 

Tested this in practice, summative, survey and review contexts.  

There will be a corresponding PR in `course-digest` to set the `perPartSubmission` flag to `true` for all multi-input questions in migrated courses. 