### PR TITLE
AOPS-1021 | Unable to submit/edit blue planet report

### DIFF
--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -337,8 +337,7 @@ defmodule OliWeb.PageDeliveryController do
       |> Enum.reduce(%{}, fn {survey_id, activity_ids}, acc ->
         survey_state =
           Enum.all?(activity_ids, fn id ->
-            context.activities[id].lifecycle_state === :submitted ||
-              context.activities[id].lifecycle_state === :evaluated
+            context.activities[id].lifecycle_state === :evaluated
           end)
 
         Map.put(acc, survey_id, survey_state)


### PR DESCRIPTION
Currently, the system does not allow students to submit additional attempts if their current attempt 'lifecycle_state' is in 'Active' or 'Submitted' state. 

As per the conversation with the team, if the 'lifecycle_state' is 'Submitted', we would like the student to be able to submit additional attempts even if the first attempt isn't evaluated or graded by the author yet.
