### PR TITLE
[FEATURE] Maintain legacy latex block rendering [MER-1500]

### DIFF
--- a/assets/src/data/content/model/elements/types.ts
+++ b/assets/src/data/content/model/elements/types.ts
@@ -208,6 +208,7 @@ export type FormulaSubTypes = 'mathml' | 'latex';
 interface Formula<typeIdentifier> extends SlateElement<VoidChildren> {
   type: typeIdentifier;
   subtype: FormulaSubTypes;
+  legacyBlockRendered: boolean;
   src: string;
 }
 

--- a/assets/src/data/content/writers/html.tsx
+++ b/assets/src/data/content/writers/html.tsx
@@ -214,9 +214,16 @@ export class HtmlParser implements WriterImpl {
   }
 
   formula(ctx: WriterContext, next: Next, element: FormulaBlock | FormulaInline) {
+    const forceBlockRendering =
+      element.legacyBlockRendered !== undefined && element.legacyBlockRendered;
     switch (element.subtype) {
       case 'latex':
-        return <MathJaxLatexFormula src={element.src} inline={element.type === 'formula_inline'} />;
+        return (
+          <MathJaxLatexFormula
+            src={element.src}
+            inline={element.type === 'formula_inline' && !forceBlockRendering}
+          />
+        );
       case 'mathml':
         return (
           <MathJaxMathMLFormula src={element.src} inline={element.type === 'formula_inline'} />

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -395,6 +395,15 @@ defmodule Oli.Rendering.Content.Html do
   def formula(
         %Oli.Rendering.Context{} = _context,
         _next,
+        %{"subtype" => "latex", "src" => src, "legacyBlockRendered" => true},
+        true
+      ) do
+    ["<span class=\"#{formula_class(false)}\">\\(", escape_xml!(src), "\\)</span>\n"]
+  end
+
+  def formula(
+        %Oli.Rendering.Context{} = _context,
+        _next,
         %{"subtype" => "latex", "src" => src},
         true
       ) do

--- a/priv/schemas/v0-1-0/content-element.schema.json
+++ b/priv/schemas/v0-1-0/content-element.schema.json
@@ -787,6 +787,9 @@
         "subtype": {
           "enum": ["mathml", "latex"]
         },
+        "legacyBlockRendered": {
+          "type": "boolean"
+        },
         "src": {
           "type": "string"
         },


### PR DESCRIPTION
This PR adjusts inline latex formula rendering to respect a new attribute: `legacyBlockRendered`.  If this attr is present and set to `true` the inline formula that contains Latex will render with block level Latex escapes, and not inlines.  This is to account for pages authored by hand in XML where the author did not realize `<formula>` was a mixed element, and thus used it as an inline, but with block level Latex escapes. 


https://eliterate.atlassian.net/browse/MER-1500