### PR TITLE
[BUGFIX] Command button was submitting MCQ question [MER-1496]

### DIFF
--- a/assets/src/components/activities/common/choices/delivery/ChoicesDelivery.tsx
+++ b/assets/src/components/activities/common/choices/delivery/ChoicesDelivery.tsx
@@ -1,7 +1,7 @@
 import { Choice, ChoiceId } from 'components/activities/types';
 import { WriterContext } from 'data/content/writers/context';
 import { HtmlContentModelRenderer } from 'data/content/writers/renderer';
-import React from 'react';
+import React, { useCallback } from 'react';
 import { classNames } from 'utils/classNames';
 import styles from './ChoicesDelivery.modules.scss';
 
@@ -24,13 +24,27 @@ export const ChoicesDelivery: React.FC<Props> = ({
   selectedIcon,
 }) => {
   const isSelected = (choiceId: ChoiceId) => !!selected.find((s) => s === choiceId);
+
+  const onClicked = useCallback(
+    (choiceId: ChoiceId) => (event: React.MouseEvent) => {
+      if (event.isDefaultPrevented()) {
+        // Allow sub-elements to have clickable items that do things (like command buttons)
+        return;
+      }
+      if (!isEvaluated) {
+        onSelect(choiceId);
+      }
+    },
+    [isEvaluated, onSelect],
+  );
+
   return (
     <div className={styles.choicesContainer} aria-label="answer choices">
       {choices.map((choice, index) => (
         <div
           key={choice.id}
           aria-label={`choice ${index + 1}`}
-          onClick={() => (isEvaluated ? undefined : onSelect(choice.id))}
+          onClick={onClicked(choice.id)}
           className={classNames(styles.choicesChoiceRow, isSelected(choice.id) ? 'selected' : '')}
         >
           <div className={styles.choicesChoiceWrapper}>

--- a/assets/src/components/common/CommandButton.tsx
+++ b/assets/src/components/common/CommandButton.tsx
@@ -15,13 +15,18 @@ export const CommandButton: React.FC<Props> = ({
   disableCommand = false,
   editorAttributes = null,
 }) => {
-  const onClick = useCallback(() => {
-    const event = makeCommandButtonEvent({
-      forId: commandButton.target,
-      message: commandButton.message,
-    });
-    disableCommand || dispatch(Registry.CommandButtonClick, event);
-  }, [commandButton.message, commandButton.target, disableCommand]);
+  const onClick = useCallback(
+    (clickEvent: React.MouseEvent) => {
+      clickEvent.preventDefault(); // Fixes MER-1496 - command buttons would submit an MCQ question.
+
+      const event = makeCommandButtonEvent({
+        forId: commandButton.target,
+        message: commandButton.message,
+      });
+      disableCommand || dispatch(Registry.CommandButtonClick, event);
+    },
+    [commandButton.message, commandButton.target, disableCommand],
+  );
 
   const cssClass =
     commandButton.style === 'button'


### PR DESCRIPTION
Before, if you had a command button within an MCQ choice, and you clicked it, it would submit the MCQ question. Now, only the command is exectuted.

From bug:

```
Steps to reproduce:

1. Create a multiple choice question
2. Embed a video within the question stem.
3. In one of the choices, embed a command button that sends a message to the video.
4. Preview the question (or deploy it within a course section)
5. Click the button to start/stop the video.

Expected: the video starts and stops.
Actually: the video starts and stops, but the click event bubbles up to the choice and triggers a submission of the activity with that choice selected
```