### PR TITLE
[BUGFIX] Allow audio element authoring in activities [MER-1501]

### DIFF
--- a/assets/src/components/editing/elements/audio/audioActions.tsx
+++ b/assets/src/components/editing/elements/audio/audioActions.tsx
@@ -6,7 +6,6 @@ import { Modal } from 'components/modal/Modal';
 import { MediaManager } from 'components/media/manager/MediaManager.controller';
 import { modalActions } from 'actions/modal';
 import { MediaItem } from 'types/media';
-import { Command } from 'components/editing/elements/commands/interfaces';
 import { Model } from 'data/content/model/elements/factories';
 import { createButtonCommandDesc } from 'components/editing/elements/commands/commandFactories';
 import { configureStore } from 'state/store';
@@ -54,42 +53,16 @@ export function selectAudio(
   });
 }
 
-function createCustomEventCommand(onRequestMedia: (r: any) => Promise<string | boolean>) {
-  const customEventCommand: Command = {
-    execute: (_context, editor: Editor) => {
-      const at = editor.selection;
-      if (!at) return;
-
-      const request = {
-        type: 'MediaItemRequest',
-        mimeTypes: MIMETYPE_FILTERS.AUDIO,
-      };
-
-      onRequestMedia(request).then((r) => {
-        if (typeof r === 'string') {
-          Transforms.insertNodes(editor, Model.audio(r), { at });
-        }
-      });
-    },
-    precondition: (_editor: Editor) => {
-      return true;
-    },
-  };
-  return customEventCommand;
-}
-
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const insertAudio = (onRequestMedia: any) =>
   createButtonCommandDesc({
     icon: 'audiotrack',
     description: 'Audio Clip',
-    ...(onRequestMedia === null || onRequestMedia === undefined
-      ? {
-          execute: (context, editor: Editor) => {
-            const at = editor.selection as any;
-            selectAudio(context.projectSlug, Model.audio()).then((audio) =>
-              Transforms.insertNodes(editor, audio, { at }),
-            );
-          },
-        }
-      : createCustomEventCommand(onRequestMedia)),
+
+    execute: (context, editor: Editor) => {
+      const at = editor.selection as any;
+      selectAudio(context.projectSlug, Model.audio()).then((audio) =>
+        Transforms.insertNodes(editor, audio, { at }),
+      );
+    },
   });


### PR DESCRIPTION
Bug:

1. Create a page
2. Add an MCQ item to the page
3. Attempt to add an audio element to an entry inside the MCQ

Expected: A browse dialog for audio files
Actual: A browse dialog for only images


🚨Before merging this, we should think a bit.  I think the original intent was to separate activity code from the "main" page code to make things more extensible via the web-component strategy. This fix ignores that concern. If that's important, there are a whole bunch of places that do media-browsing like this that we should revisit and this becomes a bigger issue.

