### PR TITLE
[BUGFIX] Rendering issues inside MCQ/CATA choices [MER-1502]

### DIFF
--- a/assets/src/components/activities/common/choices/delivery/ChoicesDelivery.modules.scss
+++ b/assets/src/components/activities/common/choices/delivery/ChoicesDelivery.modules.scss
@@ -32,4 +32,13 @@
   margin-left: 0.6rem;
   font-size: 14px;
   line-height: 20px;
+  flex-grow: 1;
+
+  /* When inside a MCQ/CATA, we want the images near the checkbox, not centered on the page */
+  :global(.caption-wrapper) {
+    display: inline-flex !important;
+  }
+  :global(.figure-img) {
+    margin-left: 0px !important;
+  }
 }

--- a/assets/src/components/activities/common/choices/delivery/ChoicesDelivery.tsx
+++ b/assets/src/components/activities/common/choices/delivery/ChoicesDelivery.tsx
@@ -49,7 +49,7 @@ export const ChoicesDelivery: React.FC<Props> = ({
         >
           <div className={styles.choicesChoiceWrapper}>
             <label className={styles.choicesChoiceLabel} htmlFor={`choice-${index}`}>
-              <div className="d-flex align-items-center">
+              <div className="d-flex align-items-center col">
                 {isSelected(choice.id) ? selectedIcon : unselectedIcon}
                 <div className={styles.choicesChoiceContent}>
                   <HtmlContentModelRenderer content={choice.content} context={context} />


### PR DESCRIPTION
There were a series of rendering-issues with certain elements inside the choices of MCQ/CATA questions related to how they would resize vs. the width of the choice container element. Some of these, like Video, Youtube, and Webpage made the component unusable. Some, like in Dialog, introduced minor visual problems.

# Video

Before:
![image](https://user-images.githubusercontent.com/333265/196236788-9cd2b2ae-b096-4c5a-ba92-ab9708d621d4.png)


After:
![image](https://user-images.githubusercontent.com/333265/196236316-120dcb01-3a17-4e42-b536-c10c419bd96c.png)


# Youtube:

Before:
![image](https://user-images.githubusercontent.com/333265/196236718-ec3b10dd-b288-46dd-bac0-e9eaa71724a0.png)


After:
![image](https://user-images.githubusercontent.com/333265/196236401-1969b3e6-e61f-4618-bb03-a5c14c2122b3.png)

# Webpages:

Before:
![image](https://user-images.githubusercontent.com/333265/196236823-2d029d59-9bdb-4dbb-a8cd-e19fc30a67cd.png)


After:
![image](https://user-images.githubusercontent.com/333265/196236500-59d1bd39-e641-4209-9aa8-c47195e0f33e.png)


# Dialogs

Before:
![image](https://user-images.githubusercontent.com/333265/196236879-e86e0844-53d9-414b-9b48-06091beb1391.png)


After:
![image](https://user-images.githubusercontent.com/333265/196236552-54165f53-5494-4ab2-abad-f0cb1870d4f3.png)



# Callouts & Block Level Formulas:

Before:
![image](https://user-images.githubusercontent.com/333265/196237048-b6647645-c278-40fd-88d5-e8c81fc1239a.png)


After:
![image](https://user-images.githubusercontent.com/333265/196237191-3b7d22fb-497b-4b43-959f-af90eb239736.png)
![image](https://user-images.githubusercontent.com/333265/196237231-b1c25476-1639-4314-9e52-560ca874d270.png)


Tables:

Before:
![image](https://user-images.githubusercontent.com/333265/196237450-1ba68744-53fa-4418-8a19-61a8444e2e98.png)


After:
![image](https://user-images.githubusercontent.com/333265/196237315-c28f8fa0-90b4-44d5-b6fe-8bb602911de9.png)


