### PR TITLE
[BUGFIX] Fixes components when in MCQ choices that were causing submissions [MER-1503]

### DIFF
--- a/assets/src/components/common/Popup.tsx
+++ b/assets/src/components/common/Popup.tsx
@@ -25,6 +25,9 @@ export const Popup: React.FC<Props> = ({ children, popupContent, popup }) => {
     [isPlaying, playAudio],
   );
 
+  // This fixes https://eliterate.atlassian.net/browse/MER-1503
+  const preventDefault = useCallback((e: React.MouseEvent) => e.preventDefault(), []);
+
   const overlayContent = (
     <Popover id={popup.id}>
       <Popover.Content className="popup__content">
@@ -37,6 +40,7 @@ export const Popup: React.FC<Props> = ({ children, popupContent, popup }) => {
     <OverlayTrigger trigger={trigger} placement="top" overlay={overlayContent} onToggle={onToggle}>
       <span
         tabIndex={0}
+        onClick={preventDefault}
         role="button"
         className={`popup__anchorText${trigger.includes('hover') ? '' : ' popup__click'}`}
       >

--- a/assets/src/components/hooks/useAudio.tsx
+++ b/assets/src/components/hooks/useAudio.tsx
@@ -15,7 +15,9 @@ import { useCallback, useRef } from 'react';
 export const useAudio = (src?: string) => {
   const audioRef = useRef<HTMLAudioElement>(null);
   const [isPlaying, setIsPlaying] = useState(false);
-  const playAudio = useCallback(() => {
+  const playAudio = useCallback((event?: any) => {
+    event?.preventDefault && event?.preventDefault(); // Fixes https://eliterate.atlassian.net/browse/MER-1503
+
     const audio = audioRef.current;
     if (audio) {
       if (audio.paused) {

--- a/assets/src/components/video_player/VideoPlayer.tsx
+++ b/assets/src/components/video_player/VideoPlayer.tsx
@@ -83,6 +83,10 @@ export const VideoPlayer: React.FC<{ video: ContentModel.Video; children?: React
       });
     }, []);
 
+    const preventDefault = useCallback((e) => {
+      e.preventDefault(); // fixes https://eliterate.atlassian.net/browse/MER-1503
+    }, []);
+
     const onCommandReceived = useCallback((message: string) => {
       if (!playerRef.current) return;
       const player = playerRef.current as VideoInterface;
@@ -97,7 +101,7 @@ export const VideoPlayer: React.FC<{ video: ContentModel.Video; children?: React
     useCommandTarget(video.id, onCommandReceived);
 
     return (
-      <div className="video-player">
+      <div className="video-player" onClick={preventDefault}>
         <Player poster={video.poster} {...sizeAttributes} ref={onPlayer} crossOrigin="anonymous">
           {/* Hide the video-react big play button so we can render our own that fits with our icon styles */}
           <BigPlayButton className="big-play-button-hide" />


### PR DESCRIPTION
This fixes 4 more components that had the same bug as https://github.com/Simon-Initiative/oli-torus/pull/3066

These all had interactable controls that wanted a learner to click on them, but if they were part of an MCQ choice, that MCQ would receive the input and select the answer prematurely.

- Definition with Pronunciation Audio
- A conjugation table, where one of the cells has an audio file to play on click
- Video Player
- Popups set to activate on “click”


I also tested web pages, youtube, and audio elements since they also have click handlers, but those components were all set as-is. 

