### PR TITLE
[BUGFIX] Uniq by slug for page attachments in objectives view

### DIFF
--- a/lib/oli_web/live/objectives/objectives.ex
+++ b/lib/oli_web/live/objectives/objectives.ex
@@ -422,19 +422,18 @@ defmodule OliWeb.ObjectivesLive.Objectives do
         resource_id = rev.resource_id
         children = Enum.map(rev.children, & &1.resource_id)
 
-        sub_objectives_page_attachments =
+        all_page_attachments =
           Enum.filter(objectives_attachments, fn
             %{resource_type_id: ^page_id, attached_objective: resource_id} ->
               Enum.member?(children, resource_id)
             _ -> false
-          end)
-
-        page_attachments =
-          sub_objectives_page_attachments ++
+          end) ++
             for pa = %{
               attached_objective: ^resource_id,
               resource_type_id: ^page_id
             } <- objectives_attachments, do: pa
+
+        page_attachments = Enum.uniq_by(all_page_attachments, & &1.slug)
 
         activity_attachments =
           for aa = %{


### PR DESCRIPTION
We are displaying the pages attached to the objective + pages attached to the sub-objectives (and could be the same), so it's needed to do a `uniq_by` slug in order to take each page into account just once.