### PR TITLE
[BUG FIX] Treat submitted graded pages the same as evaluated [AOPS-1021]

### DIFF
--- a/lib/oli/delivery/attempts/page_lifecycle/graded.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/graded.ex
@@ -34,8 +34,10 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Graded do
         user_id: user_id
       }) do
     # There is no "active" attempt if there has never been an attempt or if the latest
-    # attempt has been finalized.
-    if is_nil(latest_resource_attempt) or !is_nil(latest_resource_attempt.date_evaluated) do
+    # attempt has been finalized or submitted
+    if is_nil(latest_resource_attempt) or
+         latest_resource_attempt.lifecycle_state == :submitted or
+         latest_resource_attempt.lifecycle_state == :evaluated do
       # Graded pages must be started explicitly by the student, giving them to chance to
       # see how many attempts, etc.
 

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -197,9 +197,9 @@ defmodule OliWeb.PageDeliveryController do
     conn = put_root_layout(conn, {OliWeb.LayoutView, "page.html"})
 
     resource_attempts =
-      Enum.filter(resource_attempts, fn r -> r.date_evaluated != nil end)
+      Enum.filter(resource_attempts, fn r -> r.date_submitted != nil end)
       |> Enum.sort(fn r1, r2 ->
-        r1.date_evaluated <= r2.date_evaluated
+        r1.date_submitted <= r2.date_submitted
       end)
 
     {:ok, {previous, next, current}, _} =

--- a/lib/oli_web/templates/page_delivery/prologue.html.eex
+++ b/lib/oli_web/templates/page_delivery/prologue.html.eex
@@ -23,21 +23,27 @@
       <% end %>
     </h5>
     <div class="row justify-content-start">
+      <div class="col-sm-3">Status:</div>
+      <div><%= if resource_attempt.lifecycle_state == :evaluated do "Scored" else "Awaiting Instructor Scoring" end %></div>
+    </div>
+    <div class="row justify-content-start">
       <div class="col-sm-3">Started:</div>
       <div><%= OliWeb.Common.Utils.render_date(resource_attempt, :inserted_at, @conn) %></div>
     </div>
     <div class="row">
       <div class="col-sm-3">Submitted:</div>
-      <div><%= OliWeb.Common.Utils.render_date(resource_attempt, :date_evaluated, @conn) %></div>
+      <div><%= OliWeb.Common.Utils.render_date(resource_attempt, :date_submitted, @conn) %></div>
     </div>
     <div class="row">
       <div class="col-sm-3">Score:</div>
       <div><%= show_score(resource_attempt.score, resource_attempt.out_of) %>%</div>
     </div>
+    <%= if !is_nil(resource_attempt.score) do %>
     <div class="row">
       <div class="col-sm-3">Points:</div>
       <div><%= :erlang.float_to_binary(resource_attempt.score, [:compact, {:decimals, 2}]) %> out of <%= :erlang.float_to_binary(resource_attempt.out_of, [:compact, {:decimals, 2}]) %> </div>
     </div>
+    <% end %>
   </div>
   <% end %>
   </div>

--- a/test/oli_web/plugs/maybe_gated_resource_test.exs
+++ b/test/oli_web/plugs/maybe_gated_resource_test.exs
@@ -213,6 +213,8 @@ defmodule Oli.Plugs.MaybeGatedResourceTest do
 
       insert_resource_attempt(ra, revision.id, %{
         date_evaluated: DateTime.utc_now(),
+        date_submitted: DateTime.utc_now(),
+        lifecycle_state: :evaluated,
         score: 5,
         out_of: 10
       })


### PR DESCRIPTION
This PR adjusts the implementation to allow a student to submit additional attempts in graded pages when their previous attempt enters a "submitted" state and is awaiting instructor manual scoring.  The rationale here is that a student should not have to wait for the instructor to manually score previous work in order to start another attempt.

To test this out, do the following:

1. Create a graded page that contains at least one manually scored activity and that allows multiple attempts.
2. Deploy to a course section, access and submit a first attempt as a student.
3. Verify that the attempt shows up in the instructor manual scoring UI.
4. As the student, visit the page again and verify that you see the 'Prologue' page that shows the first attempts is awaiting instructor scoring.
5. Verify that clicking "start attempt" allows you to start and then submit a second attempt
6. Verify that both attempts show up in the instructors manual scoring UI