### PR TITLE
[ENHANCEMENT] various formatting fixes from chemistry qa feedback [MER-1505]

### DIFF
--- a/assets/src/components/activities/DeliveryElementProvider.tsx
+++ b/assets/src/components/activities/DeliveryElementProvider.tsx
@@ -20,6 +20,7 @@ export function useDeliveryElementContext<T extends ActivityModelSchema>() {
 }
 export const DeliveryElementProvider: React.FC<DeliveryElementProps<any>> = (props) => {
   const writerContext = defaultWriterContext({
+    graded: props.context.graded,
     sectionSlug: props.context.sectionSlug,
     projectSlug: props.context.projectSlug,
     bibParams: props.context.bibParams,

--- a/assets/src/components/activities/common/delivery/evaluation/Evaluation.tsx
+++ b/assets/src/components/activities/common/delivery/evaluation/Evaluation.tsx
@@ -32,6 +32,7 @@ export function renderPartFeedback(partState: PartState, context: WriterContext)
         resultClass={resultClass(partState.score, partState.outOf, partState.error)}
         score={partState.score}
         outOf={partState.outOf}
+        graded={context.graded}
       >
         <HtmlContentModelRenderer
           content={error ? errorText.content : feedback ? feedback : makeFeedback('').content}
@@ -39,7 +40,11 @@ export function renderPartFeedback(partState: PartState, context: WriterContext)
         />
       </Component>
       {explanation && (
-        <Component key={`${partState.partId}-explanation`} resultClass="explanation">
+        <Component
+          key={`${partState.partId}-explanation`}
+          resultClass="explanation"
+          graded={context.graded}
+        >
           <div>
             <div className="mb-1">
               <b>Explanation:</b>
@@ -74,7 +79,12 @@ export const Evaluation: React.FC<Props> = ({ shouldShow = true, attemptState, c
 
   return (
     <>
-      <Component resultClass={resultClass(score, outOf, undefined)} score={score} outOf={outOf}>
+      <Component
+        resultClass={resultClass(score, outOf, undefined)}
+        score={score}
+        outOf={outOf}
+        graded={context.graded}
+      >
         <HtmlContentModelRenderer content={totalScoreText} context={context} />
       </Component>
       {parts.map((partState) => renderPartFeedback(partState, context))}
@@ -86,11 +96,11 @@ interface ComponentProps {
   resultClass: string;
   score?: number | null;
   outOf?: number | null;
+  graded?: boolean;
 }
 const Component: React.FC<ComponentProps> = (props) => {
-  return (
-    <div aria-label="result" className={`evaluation feedback ${props.resultClass} my-1`}>
-      {(props.score || props.outOf) && (
+  const scoreOrGraphic = props.graded
+    ? (props.score || props.outOf) && (
         <div className="result">
           <span aria-label="score" className="score">
             {props.score}
@@ -100,11 +110,30 @@ const Component: React.FC<ComponentProps> = (props) => {
             {props.outOf}
           </span>
         </div>
-      )}
+      )
+    : graphicForResultClass(props.resultClass);
+
+  return (
+    <div aria-label="result" className={`evaluation feedback ${props.resultClass} my-1`}>
+      {scoreOrGraphic}
       {props.children}
       <div></div>
     </div>
   );
+};
+
+const graphicForResultClass = (resultClass: string) => {
+  if (resultClass === 'correct') {
+    return <span className="icon_30H-hYww material-icons mr-2">check_circle</span>;
+  }
+  if (resultClass === 'incorrect') {
+    return <span className="icon_30H-hYww material-icons mr-2">cancel</span>;
+  }
+  if (resultClass === 'partially-correct') {
+    return <span className="icon_30H-hYww material-icons mr-2">check</span>;
+  }
+
+  return <span className="icon_30H-hYww material-icons mr-2">error</span>;
 };
 
 const resultClass = (score: number | null, outOf: number | null, error: string | undefined) => {

--- a/assets/src/components/activities/image_coding/ImageCodingDelivery.tsx
+++ b/assets/src/components/activities/image_coding/ImageCodingDelivery.tsx
@@ -86,6 +86,7 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
   const isEvaluated = attemptState.score !== null;
 
   const writerContext = defaultWriterContext({
+    graded: props.context.graded,
     sectionSlug: props.context.sectionSlug,
     bibParams: props.context.bibParams,
   });

--- a/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
@@ -188,6 +188,7 @@ export const MultiInputComponent: React.FC = () => {
     state.attemptState.parts.some((p) => p.dateEvaluated !== null);
 
   const writerContext = defaultWriterContext({
+    graded: context.graded,
     sectionSlug,
     bibParams,
     inputRefContext: {

--- a/assets/src/components/activities/vlab/VlabDelivery.tsx
+++ b/assets/src/components/activities/vlab/VlabDelivery.tsx
@@ -217,9 +217,11 @@ export const VlabComponent: React.FC = () => {
   const writerContext = defaultWriterContext({
     sectionSlug: context.sectionSlug,
     bibParams: context.bibParams,
+    graded: context.graded,
     inputRefContext: {
       toggleHints,
       onChange,
+      onBlur: (_id: string) => true,
       // TODO: This 'as any' cast was necessary as the types do not align
       // Is the right fix for this to add 'input: MultiInputDelivery | VlabDelivery' to context.ts?
       inputs: inputs as any,

--- a/assets/src/data/content/writers/context.ts
+++ b/assets/src/data/content/writers/context.ts
@@ -3,6 +3,7 @@ import { VlabInputDelivery } from 'components/activities/vlab/schema';
 import { ID } from 'data/content/model/other';
 
 export interface WriterContext {
+  graded?: boolean;
   sectionSlug?: string;
   projectSlug?: string;
   bibParams?: any;

--- a/assets/styles/common/elements.scss
+++ b/assets/styles/common/elements.scss
@@ -45,13 +45,25 @@ span.term {
   table {
     @extend .table-bordered;
     @extend .table;
+    width: auto;
+    -webkit-box-sizing: content-box;
+    -moz-box-sizing: content-box;
+    box-sizing: content-box;
+    margin: auto;
     border-collapse: collapse;
-    table-layout: fixed;
+    table-layout: auto;
     word-wrap: break-word;
     overflow: hidden;
 
     th {
       background-color: rgba($blue, 15%);
+    }
+
+    th,
+    td {
+      p:last-of-type {
+        margin-bottom: 0;
+      }
     }
 
     caption {
@@ -137,7 +149,7 @@ span.term {
   .definition {
     .term {
       color: $green;
-      font-size: 2em;
+      font-size: 1.3em;
       font-weight: bold;
     }
 
@@ -207,7 +219,6 @@ span.term {
   .callout-inline,
   .formula-inline {
     display: inline-block;
-    background-color: darken($body-bg, 5%);
     margin: 0px 0.5em;
     padding: 2px 0.5em;
     vertical-align: middle;
@@ -217,13 +228,17 @@ span.term {
     }
   }
 
+  .callout-inline,
+  .callout {
+    background-color: darken($body-bg, 5%);
+  }
+
   .callout-block,
   .formula {
     display: block;
-    background-color: darken($body-bg, 5%);
-    text-align: center;
     margin: 8px;
     padding: 12px;
+    text-align: center;
 
     blockquote,
     ol,
@@ -234,10 +249,6 @@ span.term {
     mjx-container[display='true'] {
       pointer-events: none;
     }
-  }
-
-  table {
-    table-layout: auto;
   }
 
   .dialog {

--- a/assets/styles/delivery/page_delivery/page.scss
+++ b/assets/styles/delivery/page_delivery/page.scss
@@ -1,7 +1,7 @@
 @import 'delivery/variables';
 
 h1.title {
-  font-weight: 300;
+  font-weight: 600;
   color: $title-color;
   padding-bottom: 0.5em;
   border-bottom: 1px solid $gray-400;

--- a/assets/test/check_all_that_apply/cata_delivery_test.tsx
+++ b/assets/test/check_all_that_apply/cata_delivery_test.tsx
@@ -90,7 +90,5 @@ describe('check all that apply delivery', () => {
 
     // expect results to be displayed after submission
     expect(await screen.findAllByLabelText('result')).toHaveLength(1);
-    expect(screen.getByLabelText('score')).toHaveTextContent('1');
-    expect(screen.getByLabelText('out of')).toHaveTextContent('1');
   });
 });

--- a/assets/test/multiple_choice/mc_delivery_test.tsx
+++ b/assets/test/multiple_choice/mc_delivery_test.tsx
@@ -79,7 +79,5 @@ describe('multiple choice delivery', () => {
 
     // expect results to be displayed after submission
     expect(await screen.findAllByLabelText('result')).toHaveLength(1);
-    expect(screen.getByLabelText('score')).toHaveTextContent('1');
-    expect(screen.getByLabelText('out of')).toHaveTextContent('1');
   });
 });

--- a/assets/test/ordering/ordering_delivery_test.tsx
+++ b/assets/test/ordering/ordering_delivery_test.tsx
@@ -78,7 +78,5 @@ describe('ordering delivery', () => {
 
     // expect results to be displayed after submission
     expect(await screen.findAllByLabelText('result')).toHaveLength(1);
-    expect(screen.getByLabelText('score')).toHaveTextContent('1');
-    expect(screen.getByLabelText('out of')).toHaveTextContent('1');
   });
 });

--- a/assets/test/short_answer/short_answer_delivery_test.tsx
+++ b/assets/test/short_answer/short_answer_delivery_test.tsx
@@ -82,7 +82,5 @@ describe('multiple choice delivery', () => {
 
     // expect results to be displayed after submission
     expect(await screen.findAllByLabelText('result')).toHaveLength(1);
-    expect(screen.getByLabelText('score')).toHaveTextContent('1');
-    expect(screen.getByLabelText('out of')).toHaveTextContent('1');
   });
 });

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -337,7 +337,7 @@ defmodule Oli.Rendering.Content.Html do
   end
 
   defp maybePronunciationHeader(%{"pronunciation" => pronunciation}) do
-    if pronunciation do
+    if Oli.Activities.ParseUtils.has_content?(pronunciation) do
       "Pronunciation: "
     else
       ""

--- a/lib/oli_web/common/mathjax_script.ex
+++ b/lib/oli_web/common/mathjax_script.ex
@@ -50,6 +50,11 @@ defmodule OliWeb.Common.MathJaxScript do
       },
       loader: {
         load: ['[tex]/noerrors']
+      },
+      renderMathML(math, doc) {
+        math.typesetRoot = document.createElement('mjx-container');
+        math.typesetRoot.innerHTML = MathJax.startup.toMML(math.root);
+        math.display && math.typesetRoot.setAttribute('display', 'block');
       }
     };
     </script>


### PR DESCRIPTION
This PR contains several (mainly) formatting fixes that came from the Chemistry course migration QA effort. 

1. Do not show score and out of in formative evaluation. In a formative the score can be confusing to a student. 
2. Makes definition title font smaller
3. Font for Page Title is now more bold than an h1
4. Changes tables to render in a way similar to Legacy, (not full width). Removes the margin following the last paragraph in a `<td>`
5. Do not display “Pronunciation” label if there isn’t one for Definitions
6. Includes the proper MathML MathJAX configuration to actually render MathML.  
7. Do not render block formula elements with a gray background. 

<img width="1184" alt="Screen Shot 2022-10-20 at 9 20 09 PM" src="https://user-images.githubusercontent.com/7431756/197089585-95a71832-3e7a-456d-8902-6a3c293a7642.png">

