### PR TITLE
[FEATURE] Add blueprints with Theorem as the first one [MER-1415]

### DIFF
--- a/assets/src/components/resource/editors/ContentEditor.tsx
+++ b/assets/src/components/resource/editors/ContentEditor.tsx
@@ -4,6 +4,7 @@ import { StructuredContentEditor } from 'components/content/StructuredContentEdi
 import { ContentBlock } from './ContentBlock';
 import { blockInsertOptions } from 'components/editing/toolbar/editorToolbar/blocks/blockInsertOptions';
 import { EditorProps } from './createEditor';
+import { useBlueprintCommandDescriptions, useBlueprints } from './useBlueprints';
 
 interface ContentEditorProps extends EditorProps {
   contentItem: StructuredContent;
@@ -22,6 +23,8 @@ export const ContentEditor = (editorProps: ContentEditorProps) => {
     onAddItem,
   } = editorProps;
 
+  const blueprints = useBlueprintCommandDescriptions();
+
   return (
     <ContentBlock {...editorProps}>
       <StructuredContentEditor
@@ -31,13 +34,16 @@ export const ContentEditor = (editorProps: ContentEditorProps) => {
         onEdit={onEdit}
         projectSlug={projectSlug}
         resourceSlug={resourceSlug}
-        toolbarInsertDescs={blockInsertOptions({
-          type: 'all',
-          resourceContext,
-          onAddItem,
-          editorMap,
-          index,
-        })}
+        toolbarInsertDescs={[
+          ...blockInsertOptions({
+            type: 'all',
+            resourceContext,
+            onAddItem,
+            editorMap,
+            index,
+          }),
+          ...blueprints,
+        ]}
       />
     </ContentBlock>
   );

--- a/assets/src/components/resource/editors/useBlueprints.ts
+++ b/assets/src/components/resource/editors/useBlueprints.ts
@@ -1,0 +1,78 @@
+import { useEffect, useMemo, useState } from 'react';
+import guid from 'utils/guid';
+import { Editor, Node, Transforms } from 'slate';
+import {
+  CommandDescription,
+  Command,
+  CommandContext,
+} from '../../editing/elements/commands/interfaces';
+import { AllModelTypes, ModelTypes } from '../../../data/content/model/elements/types';
+
+interface Blueprint {
+  name: string;
+  description: string;
+  content: {
+    blueprint: any[];
+  };
+  icon: string;
+}
+
+// Any element with an id attribute gets a new value set for that attribute, recursive through children.
+export const generateIds = (
+  elements: { type: ModelTypes; id: string; children: any[] }[],
+): Node[] => {
+  const withIds = elements.map((element) => {
+    if ('id' in element) {
+      const id = guid();
+      const children: any = element.children && generateIds(element.children);
+      return { ...element, id, children };
+    } else {
+      const children: any = element.children && generateIds(element.children);
+      return { ...element, children };
+    }
+  });
+  return withIds as unknown as Node[];
+};
+
+export const useBlueprints = () => {
+  const [blueprints, setBlueprints] = useState<Blueprint[]>([]);
+
+  useEffect(() => {
+    const fetchBlueprints = async () => {
+      const response = await fetch('/api/v1/blueprint');
+      const data = await response.json();
+      if (data.result === 'success' && data.rows) {
+        setBlueprints(data.rows);
+      }
+    };
+
+    fetchBlueprints();
+  }, []);
+
+  return blueprints;
+};
+
+export const useBlueprintCommandDescriptions = (): CommandDescription[] => {
+  const blueprints = useBlueprints();
+  const commands = useMemo(() => (blueprints || []).map(blueprintToCommand), [blueprints]);
+  return commands;
+};
+
+const createBlueprintCommand = (blueprint: Blueprint): Command => {
+  return {
+    precondition: (_editor: Editor) => true,
+    execute: (context: CommandContext, editor: Editor) => {
+      const at = editor.selection as any;
+      const content = generateIds(blueprint.content.blueprint);
+      Transforms.insertNodes(editor, content, { at });
+    },
+  };
+};
+
+const blueprintToCommand = (blueprint: Blueprint): CommandDescription => ({
+  type: 'CommandDesc',
+  icon: () => blueprint.icon,
+  command: createBlueprintCommand(blueprint),
+  description: () => blueprint.name,
+  active: () => false,
+});

--- a/assets/src/data/content/model/elements/types.ts
+++ b/assets/src/data/content/model/elements/types.ts
@@ -13,6 +13,9 @@ export type ModelElement = TopLevel | Block | Inline;
 // A list of all our element types, including those that can't be "bare" inside a children array.
 export type AllModelElements = ModelElement | SubElements;
 
+export type AllModelTypes = AllModelElements['type'];
+export type ModelTypes = ModelElement['type'];
+
 // specifies the type of items that can be inserted using the toolbar
 export type ContentModelMode =
   | 'all' // all SlateElement types

--- a/lib/oli/authoring/editing/blueprint.ex
+++ b/lib/oli/authoring/editing/blueprint.ex
@@ -1,0 +1,27 @@
+defmodule Oli.Authoring.Editing.Blueprint do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "blueprints" do
+    timestamps(type: :utc_datetime)
+    field :name, :string
+    field :description, :string
+    field :icon, :string
+    field :content, :map, default: %{}
+  end
+
+  def changeset(blueprint, attrs \\ %{}) do
+    blueprint
+    |> cast(attrs, [
+      :name,
+      :description,
+      :content,
+      :icon
+    ])
+    |> validate_required([:name, :description, :content, :icon])
+  end
+
+  def list_blueprints do
+    Oli.Repo.all(Oli.Authoring.Editing.Blueprint)
+  end
+end

--- a/lib/oli_web/controllers/api/blueprint_controller.ex
+++ b/lib/oli_web/controllers/api/blueprint_controller.ex
@@ -1,0 +1,70 @@
+defmodule OliWeb.Api.BlueprintController do
+  @moduledoc tags: ["Blueprints Service"]
+  @moduledoc """
+  Endpoints to provide access to authoring blueprints
+  """
+
+  alias OpenApiSpex.Schema
+  alias Oli.Authoring.Editing.Blueprint
+
+  require Logger
+
+  use OliWeb, :controller
+  use OpenApiSpex.Controller
+
+  defmodule BlueprintResponse do
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "Blueprint",
+      description: "A blueprint that can be inserted into content",
+      type: :object,
+      properties: %{
+        name: %Schema{type: :string, description: "Name of the blueprint"},
+        description: %Schema{type: :string, description: "Short description of what it is"},
+        icon: %Schema{type: :string, description: "A Material UI icon name to display in the UI"},
+        content: %Schema{
+          type: :string,
+          description: "Array of content nodes to insert into the document"
+        }
+      },
+      required: [:name, :description, :icon, :content],
+      example: [
+        %{
+          "name" => "Theorem",
+          "description" => "A theorem is a statement that is true under certain conditions",
+          "icon" => "rate_review",
+          "content" => %{
+            "blueprint" => [
+              %{"type" => "h1", "children" => [%{"text" => "Enter a statement here"}]}
+            ]
+          }
+        }
+      ]
+    })
+  end
+
+  @doc parameters: [],
+       responses: %{
+         200 =>
+           {"All Blueprints", "application/json",
+            OliWeb.Api.BlueprintController.BlueprintResponse}
+       }
+  def index(conn, _attrs) do
+    blueprints = Blueprint.list_blueprints()
+
+    json(conn, %{
+      "result" => "success",
+      "rows" => Enum.map(blueprints, &serialize_blueprint/1)
+    })
+  end
+
+  defp serialize_blueprint(%Blueprint{} = blueprint) do
+    %{
+      name: blueprint.name,
+      description: blueprint.description,
+      content: blueprint.content,
+      icon: blueprint.icon
+    }
+  end
+end

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -503,6 +503,13 @@ defmodule OliWeb.Router do
     post("/", Api.ActivityBankController, :retrieve)
   end
 
+  # Blueprint Service
+  scope "/api/v1/blueprint", OliWeb do
+    pipe_through([:api, :authoring_protected])
+
+    get("/", Api.BlueprintController, :index)
+  end
+
   # Objectives Service
   scope "/api/v1/objectives/project/:project", OliWeb do
     pipe_through([:api, :authoring_protected])

--- a/priv/repo/migrations/20221020142919_add_blueprint_table.exs
+++ b/priv/repo/migrations/20221020142919_add_blueprint_table.exs
@@ -1,0 +1,39 @@
+defmodule Oli.Repo.Migrations.AddBlueprintTable do
+  alias Oli.Repo
+  alias Oli.Authoring.Editing.Blueprint
+  use Ecto.Migration
+  require Logger
+
+  def change do
+    create table(:blueprints) do
+      add :name, :string, size: 64, null: false
+      add :description, :string, null: false
+      add :content, :map, null: false
+      add :icon, :string, null: false
+      timestamps(type: :timestamptz)
+    end
+
+    execute(&insert_theorem/0, &noop/0)
+  end
+
+  def noop(), do: :ok
+
+  def insert_theorem() do
+    flush()
+
+    theorem_blueprint =
+      Jason.decode!(
+        "{\"blueprint\":[{\"id\":\"\",\"children\":[{\"text\":\"Theorem Title\"}],\"type\":\"h4\"},{\"id\":\"\",\"children\":[{\"text\":\"Statement\"}],\"type\":\"h5\"},{\"id\":\"\",\"children\":[{\"text\":\"Enter a statement here\"}],\"type\":\"p\"},{\"id\":\"\",\"children\":[{\"text\":\"Proof\"}],\"type\":\"h5\"},{\"id\":\"\",\"children\":[{\"text\":\"Enter the proof here\"}],\"type\":\"p\"}]}"
+      )
+
+    changeset =
+      Blueprint.changeset(%Blueprint{}, %{
+        name: "Theorem",
+        description: "A theorem is a statement that can be proven true.",
+        content: theorem_blueprint,
+        icon: "rate_review"
+      })
+
+    {:ok, _} = Repo.insert(changeset)
+  end
+end


### PR DESCRIPTION
Added a new blueprint feature with a single blueprint available that inserts elements that resemble a theorem. In the future, we can use the blueprint feature to adding other template-style items.

![theorems](https://user-images.githubusercontent.com/333265/197246338-a828e456-c5c1-498a-a02b-b6220cd7c2d5.gif)

Also added to swagger UI if you want a quick way to test the API:
![image](https://user-images.githubusercontent.com/333265/197246426-4fd796ce-f7e8-47be-b791-d6cd7869f0f7.png)

Future improvements to blueprints to consider include user-defined blueprints and discoverability of those between users.