### PR TITLE
[FEATURE] Add description list element [MER-1507]

### DIFF
--- a/assets/src/components/common/DescriptionList.tsx
+++ b/assets/src/components/common/DescriptionList.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEventHandler, ReactNode } from 'react';
+import React from 'react';
 import * as ContentModel from 'data/content/model/elements/types';
 import { HtmlContentModelRenderer } from '../../data/content/writers/renderer';
 import { WriterContext } from '../../data/content/writers/context';
@@ -9,7 +9,7 @@ export const DescriptionList: React.FC<{
 }> = ({ description, context }) => {
   return (
     <>
-      <h4>
+      <h4 className="dl-title">
         <HtmlContentModelRenderer context={context} content={description.title} />
       </h4>
       <dl>

--- a/assets/src/components/common/DescriptionList.tsx
+++ b/assets/src/components/common/DescriptionList.tsx
@@ -1,0 +1,20 @@
+import React, { MouseEventHandler, ReactNode } from 'react';
+import * as ContentModel from 'data/content/model/elements/types';
+import { HtmlContentModelRenderer } from '../../data/content/writers/renderer';
+import { WriterContext } from '../../data/content/writers/context';
+
+export const DescriptionList: React.FC<{
+  description: ContentModel.DescriptionList;
+  context: WriterContext;
+}> = ({ description, context }) => {
+  return (
+    <>
+      <h4>
+        <HtmlContentModelRenderer context={context} content={description.title} />
+      </h4>
+      <dl>
+        <HtmlContentModelRenderer context={context} content={description.items} />
+      </dl>
+    </>
+  );
+};

--- a/assets/src/components/editing/editor/modelEditorDispatch.tsx
+++ b/assets/src/components/editing/editor/modelEditorDispatch.tsx
@@ -30,6 +30,7 @@ import { ConjugationEditor } from '../elements/conjugation/ConjugationEditor';
 import { TcEditor } from '../elements/table/TcElement';
 import { ForeignEditor } from '../elements/foreign/ForeignEditor';
 import { CommandButtonEditor } from '../elements/command_button/CommandButtonEditor';
+import { DescriptionListEditor } from '../elements/description/DescriptionListEditor';
 
 export function editorFor(
   model: ContentModel.ModelElement,
@@ -78,6 +79,15 @@ export function editorFor(
       );
     case 'li':
       return <li {...attributes}>{children}</li>;
+
+    case 'dl':
+      return (
+        <DescriptionListEditor {...(editorProps as EditorProps<ContentModel.DescriptionList>)} />
+      );
+    case 'dt':
+      return <dt {...attributes}>{children}</dt>;
+    case 'dd':
+      return <dd {...attributes}>{children}</dd>;
     case 'callout':
       return <CalloutEditor {...(editorProps as EditorProps<ContentModel.Callout>)} />;
     case 'callout_inline':

--- a/assets/src/components/editing/elements/description/DescriptionListEditor.tsx
+++ b/assets/src/components/editing/elements/description/DescriptionListEditor.tsx
@@ -1,0 +1,147 @@
+import React, { useCallback } from 'react';
+import { EditorProps } from 'components/editing/elements/interfaces';
+import * as ContentModel from '../../../../data/content/model/elements/types';
+import { useEditModelCallback } from '../utils';
+import { InlineEditor } from '../common/settings/InlineEditor';
+import { CommandContext } from '../commands/interfaces';
+import { useSelected } from 'slate-react';
+import { Model } from '../../../../data/content/model/elements/factories';
+
+type TitleType = ContentModel.Inline | ContentModel.TextBlock;
+
+const TitleEditor: React.FC<{
+  title: TitleType[];
+  onEdit: (val: TitleType[]) => void;
+  commandContext: CommandContext;
+}> = ({ title, onEdit, commandContext }) => {
+  return (
+    <div className="figure-title-editor">
+      <InlineEditor
+        placeholder="Description List Title"
+        allowBlockElements={false}
+        commandContext={commandContext}
+        content={Array.isArray(title) ? title : []}
+        onEdit={onEdit}
+      />
+    </div>
+  );
+};
+
+const ItemEditor: React.FC<{
+  item: ContentModel.DescriptionListDefinition | ContentModel.DescriptionListTerm;
+  commandContext: CommandContext;
+  onEdit: (content: any[]) => void;
+  onDelete: () => void;
+}> = ({ item, commandContext, onEdit, onDelete }) => {
+  const Root = item.type as keyof JSX.IntrinsicElements; // works out to <dt> or <dd>
+  return (
+    <Root>
+      <InlineEditor
+        placeholder={item.type === 'dt' ? 'Description List Term' : 'Description List Definition'}
+        allowBlockElements={true}
+        commandContext={commandContext}
+        content={item.children}
+        onEdit={onEdit}
+      />
+      <button
+        className="btn btn-outline-danger btn-small delete-btn"
+        type="button"
+        onClick={onDelete}
+      >
+        <span className="material-icons">delete</span>
+      </button>
+    </Root>
+  );
+};
+
+interface Props extends EditorProps<ContentModel.DescriptionList> {}
+export const DescriptionListEditor: React.FC<Props> = ({
+  model,
+  attributes,
+  children,
+  commandContext,
+}) => {
+  const onEdit = useEditModelCallback(model);
+  const selected = useSelected();
+
+  const onAddTerm = useCallback(() => {
+    onEdit({
+      ...model,
+      items: [...model.items, Model.dt()],
+    });
+  }, [model, onEdit]);
+
+  const onAddDefinition = useCallback(() => {
+    onEdit({
+      ...model,
+      items: [...model.items, Model.dd()],
+    });
+  }, [model, onEdit]);
+
+  const onEditTitle = useCallback(
+    (val: TitleType[]) => {
+      onEdit({
+        title: val,
+      });
+    },
+    [onEdit],
+  );
+
+  const deleteItem = useCallback(
+    (indexToDelete: number) => () => {
+      onEdit({
+        ...model,
+        items: model.items.filter((_item, index) => index !== indexToDelete),
+      });
+    },
+    [model, onEdit],
+  );
+
+  const editItem = useCallback(
+    (itemIndex: number) => (val: any[]) => {
+      onEdit({
+        ...model,
+        items: model.items.map((item, index) => {
+          if (index === itemIndex) {
+            return { ...item, children: val };
+          }
+          return item;
+        }),
+      });
+    },
+    [model, onEdit],
+  );
+
+  const editorClass = selected ? 'selected description-list-editor' : 'description-list-editor';
+
+  return (
+    <div {...attributes} className={editorClass} contentEditable={false}>
+      <h4>
+        <TitleEditor title={model.title} commandContext={commandContext} onEdit={onEditTitle} />
+      </h4>
+
+      <dl>
+        {model.items.map((item, index) => (
+          <ItemEditor
+            key={index}
+            commandContext={commandContext}
+            item={item}
+            onEdit={editItem(index)}
+            onDelete={deleteItem(index)}
+          />
+        ))}
+      </dl>
+
+      <div className="description-list-editor-controls">
+        <button className="btn btn-secondary btn-small" onClick={onAddTerm}>
+          Add Term
+        </button>
+        <button className="btn btn-secondary btn-small" onClick={onAddDefinition}>
+          Add Definition
+        </button>
+      </div>
+
+      {children}
+    </div>
+  );
+};

--- a/assets/src/components/editing/elements/description/description-list-actions.ts
+++ b/assets/src/components/editing/elements/description/description-list-actions.ts
@@ -1,0 +1,24 @@
+import { Editor, Transforms } from 'slate';
+import { Model } from '../../../../data/content/model/elements/factories';
+import {
+  DescriptionListDefinition,
+  DescriptionListTerm,
+} from '../../../../data/content/model/elements/types';
+import { SlateEditor } from '../../../../data/content/model/slate';
+import { createButtonCommandDesc } from '../commands/commandFactories';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const insertDescriptionListCommand = createButtonCommandDesc({
+  icon: 'view_list',
+  description: 'Description List',
+
+  execute: (context, editor: Editor) => {
+    insertDescriptionList(editor);
+  },
+});
+
+export const insertDescriptionList = (editor: SlateEditor) => {
+  const at = editor.selection as any;
+  const list = Model.dl();
+  Transforms.insertNodes(editor, list, { at });
+};

--- a/assets/src/components/editing/toolbar/editorToolbar/blocks/blockInsertOptions.ts
+++ b/assets/src/components/editing/toolbar/editorToolbar/blocks/blockInsertOptions.ts
@@ -18,6 +18,7 @@ import { insertFigure } from '../../../elements/figure/figureActions';
 import { insertDialog } from '../../../elements/dialog/dialogActions';
 import { insertPageLink } from '../../../elements/page_link/pageLinkActions';
 import { insertConjugation } from '../../../elements/conjugation/conjugationActions';
+import { insertDescriptionListCommand } from '../../../elements/description/description-list-actions';
 
 export const extendedBlockInsertActions = (onRequestMedia: any) => [
   insertTable,
@@ -33,6 +34,7 @@ export const extendedBlockInsertActions = (onRequestMedia: any) => [
   insertFigure,
   insertDialog,
   insertConjugation,
+  insertDescriptionListCommand,
 ];
 
 export const allBlockInsertActions = (onRequestMedia: any) => [
@@ -50,6 +52,7 @@ export const allBlockInsertActions = (onRequestMedia: any) => [
   insertDialog,
   insertPageLink,
   insertConjugation,
+  insertDescriptionListCommand,
 ];
 
 interface Opts {

--- a/assets/src/data/content/model/elements/factories.ts
+++ b/assets/src/data/content/model/elements/factories.ts
@@ -42,6 +42,10 @@ import {
   TableCell,
   Foreign,
   CommandButton,
+  DescriptionListTerm,
+  DescriptionListDefinition,
+  DescriptionList,
+  ModelElement,
 } from 'data/content/model/elements/types';
 import { Text } from 'slate';
 import guid from 'utils/guid';
@@ -74,6 +78,19 @@ export const Model = {
   ol: () => create<OrderedList>({ type: 'ol', children: [Model.li()] }),
 
   ul: () => create<UnorderedList>({ type: 'ul', children: [Model.li()] }),
+
+  dt: () => create<DescriptionListTerm>({ type: 'dt', children: [Model.p([{ text: 'A term' }])] }),
+  dd: () =>
+    create<DescriptionListDefinition>({
+      type: 'dd',
+      children: [Model.p([{ text: 'A definition' }])],
+    }),
+  dl: (children: (DescriptionListDefinition | DescriptionListTerm)[] | null = null) =>
+    create<DescriptionList>({
+      type: 'dl',
+      title: [Model.p([{ text: 'Description Title' }])],
+      items: children || [Model.dt(), Model.dd()],
+    }),
 
   video: () => create<Video>({ type: 'video', src: [] }),
 

--- a/assets/src/data/content/model/elements/types.ts
+++ b/assets/src/data/content/model/elements/types.ts
@@ -26,6 +26,7 @@ export type ContentModelMode =
 export type TopLevel =
   | TextBlock
   | List
+  | DescriptionList
   | MediaBlock
   | Table
   | Math
@@ -36,7 +37,15 @@ export type TopLevel =
   | Semantic
   | PageLink;
 
-export type Block = TableRow | TableCell | ListItem | MathLine | CodeLine | FormulaBlock;
+export type Block =
+  | TableRow
+  | TableCell
+  | ListItem
+  | MathLine
+  | CodeLine
+  | FormulaBlock
+  | DescriptionListTerm
+  | DescriptionListDefinition;
 
 export type Semantic = Definition | Callout | Figure | Dialog | Conjugation;
 
@@ -59,7 +68,7 @@ export type Heading =
   | HeadingFour
   | HeadingFive
   | HeadingSix;
-export type List = OrderedList | UnorderedList;
+export type List = OrderedList | UnorderedList | DescriptionList;
 export type MediaBlock = ImageBlock | YouTube | Audio | Webpage | Video;
 export type SemanticChildren = TextBlock | Block;
 // These types are only used inside other structured types and not directly as .children5
@@ -135,6 +144,7 @@ export const UnorderdListStyles = ['none', 'disc', 'circle', 'square'];
 export type UnorderedListStyle = typeof UnorderdListStyles[number];
 
 type ListChildren = (ListItem | OrderedList | UnorderedList | Text)[];
+
 export interface OrderedList extends SlateElement<ListChildren> {
   type: 'ol';
   style?: OrderedListStyle;
@@ -143,6 +153,22 @@ export interface OrderedList extends SlateElement<ListChildren> {
 export interface UnorderedList extends SlateElement<ListChildren> {
   type: 'ul';
   style?: UnorderedListStyle;
+}
+
+export interface DescriptionListTerm extends SlateElement<SemanticChildren[]> {
+  type: 'dt';
+}
+
+export interface DescriptionListDefinition extends SlateElement<SemanticChildren[]> {
+  type: 'dd';
+}
+
+type DescriptionListChildren = (DescriptionListTerm | DescriptionListDefinition)[];
+
+export interface DescriptionList extends SlateElement<VoidChildren> {
+  type: 'dl';
+  title: (Inline | TextBlock)[];
+  items: DescriptionListChildren;
 }
 
 interface BaseImage extends SlateElement<VoidChildren> {

--- a/assets/src/data/content/model/schema.ts
+++ b/assets/src/data/content/model/schema.ts
@@ -15,6 +15,7 @@ const BlockElements: SchemaKey[] = [
   'tc',
   'ol',
   'ul',
+  'dl',
   'math',
   'math_line',
   'code_line',
@@ -121,6 +122,24 @@ export const schema: Schema = {
     validChildren: toObj([]),
   },
   dialog_line: {
+    isVoid: false,
+    isBlock: true,
+    isTopLevel: false,
+    validChildren: toObj(SemanticChildrenElements),
+  },
+  dl: {
+    isVoid: true,
+    isBlock: true,
+    isTopLevel: true,
+    validChildren: toObj([]),
+  },
+  dt: {
+    isVoid: false,
+    isBlock: true,
+    isTopLevel: false,
+    validChildren: toObj(SemanticChildrenElements),
+  },
+  dd: {
     isVoid: false,
     isBlock: true,
     isTopLevel: false,

--- a/assets/src/data/content/writers/html.tsx
+++ b/assets/src/data/content/writers/html.tsx
@@ -48,6 +48,9 @@ import {
   TableConjugation as TableConjugationModel,
   Foreign,
   CommandButton as CommandButtonModel,
+  DescriptionList as DescriptionListModel,
+  DescriptionListDefinition,
+  DescriptionListTerm,
 } from 'data/content/model/elements/types';
 import { Mark } from 'data/content/model/text';
 import React from 'react';
@@ -70,6 +73,7 @@ import { Conjugation } from '../../../components/common/Conjugation';
 import { TableConjugation } from '../../../components/common/TableConjugation';
 import { Popup } from '../../../components/common/Popup';
 import { CommandButton } from '../../../components/common/CommandButton';
+import { DescriptionList } from '../../../components/common/DescriptionList';
 
 // Important: any changes to this file must be replicated
 // in content/html.ex for non-activity rendering.
@@ -148,6 +152,22 @@ export class HtmlParser implements WriterImpl {
         {next()}
       </FigureElement>
     );
+  }
+
+  dl(context: WriterContext, next: Next, element: DescriptionListModel) {
+    return (
+      <DescriptionList context={context} description={element}>
+        {next()}
+      </DescriptionList>
+    );
+  }
+
+  dd(context: WriterContext, next: Next, _element: DescriptionListDefinition) {
+    return <dd>{next()}</dd>;
+  }
+
+  dt(context: WriterContext, next: Next, _element: DescriptionListTerm) {
+    return <dt>{next()}</dt>;
   }
 
   conjugation(context: WriterContext, next: Next, element: ConjugationModel) {

--- a/assets/src/data/content/writers/writer.tsx
+++ b/assets/src/data/content/writers/writer.tsx
@@ -41,6 +41,9 @@ export interface WriterImpl {
   ol: ElementWriter;
   ul: ElementWriter;
   li: ElementWriter;
+  dd: ElementWriter;
+  dl: ElementWriter;
+  dt: ElementWriter;
   math: ElementWriter;
   mathLine: ElementWriter;
   code: ElementWriter;
@@ -165,6 +168,12 @@ export class ContentWriter {
         return impl.ul(context, next, content);
       case 'li':
         return impl.li(context, next, content);
+      case 'dt':
+        return impl.dt(context, next, content);
+      case 'dd':
+        return impl.dd(context, next, content);
+      case 'dl':
+        return impl.dl(context, next, content);
       case 'math':
         return impl.math(context, next, content);
       case 'math_line':

--- a/assets/styles/authoring/description-list.scss
+++ b/assets/styles/authoring/description-list.scss
@@ -1,0 +1,37 @@
+.description-list-editor {
+  .description-list-editor-controls {
+    display: flex;
+    gap: 1em;
+  }
+
+  h4 {
+    border: 1px dashed $body-bg;
+  }
+  h4:hover {
+    border: 1px dashed #ccc;
+  }
+
+  dd,
+  dt {
+    border: 1px dashed $body-bg;
+    padding: 0.1em;
+    padding-left: 0.1em;
+    margin: 2px;
+    position: relative;
+    .delete-btn {
+      display: none;
+      position: absolute;
+      right: 0px;
+      padding: 0px;
+      height: 25px;
+      top: 0px;
+    }
+  }
+  dd:hover,
+  dt:hover {
+    border: 1px dashed #ccc;
+    .delete-btn {
+      display: block;
+    }
+  }
+}

--- a/assets/styles/authoring/index.scss
+++ b/assets/styles/authoring/index.scss
@@ -36,3 +36,4 @@
 @import 'figure.scss';
 @import 'foreign.scss';
 @import 'conjugation.scss';
+@import 'description-list.scss';

--- a/assets/styles/common/elements.scss
+++ b/assets/styles/common/elements.scss
@@ -42,6 +42,29 @@ span.term {
     margin-bottom: 14px;
   }
 
+  .dl-title {
+    color: $green;
+    font-size: 1.3em;
+    font-weight: bold;
+  }
+
+  dl dt {
+    margin-left: 10px;
+    margin-bottom: 0px;
+    margin-top: 8px;
+    p {
+      margin-bottom: 0;
+    }
+  }
+
+  dl dd {
+    margin-left: 18px;
+    margin-bottom: 0;
+    p {
+      margin-bottom: 0;
+    }
+  }
+
   table {
     @extend .table-bordered;
     @extend .table;

--- a/lib/oli/rendering/content.ex
+++ b/lib/oli/rendering/content.ex
@@ -33,6 +33,9 @@ defmodule Oli.Rendering.Content do
   @callback ol(%Context{}, next, %{}) :: [any()]
   @callback ul(%Context{}, next, %{}) :: [any()]
   @callback li(%Context{}, next, %{}) :: [any()]
+  @callback dl(%Context{}, next, next, %{}) :: [any()]
+  @callback dt(%Context{}, next, %{}) :: [any()]
+  @callback dd(%Context{}, next, %{}) :: [any()]
 
   @callback command_button(%Context{}, next, %{}) :: [any()]
   @callback conjugation(%Context{}, next, next, %{}) :: [any()]
@@ -221,6 +224,26 @@ defmodule Oli.Rendering.Content do
 
   def render(
         %Context{} = context,
+        %{"type" => "dl", "items" => items, "title" => title} = element,
+        writer
+      ) do
+    render_items = fn -> render(context, items, writer) end
+    render_title = fn -> render(context, title, writer) end
+    writer.dl(context, render_items, render_title, element)
+  end
+
+  def render(
+        %Context{} = context,
+        %{"type" => "dl", "items" => items} = element,
+        writer
+      ) do
+    render_items = fn -> render(context, items, writer) end
+    render_title = fn -> [] end
+    writer.dl(context, render_items, render_title, element)
+  end
+
+  def render(
+        %Context{} = context,
         %{"type" => "dialog"} = element,
         writer
       ) do
@@ -312,6 +335,12 @@ defmodule Oli.Rendering.Content do
 
       "li" ->
         writer.li(context, next, element)
+
+      "dt" ->
+        writer.dt(context, next, element)
+
+      "dd" ->
+        writer.dd(context, next, element)
 
       "math" ->
         writer.math(context, next, element)

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -206,6 +206,25 @@ defmodule Oli.Rendering.Content.Html do
     ["<ol>", next.(), "</ol>\n"]
   end
 
+  def dl(%Context{}, next, title, %{}) do
+    [
+      "<h4>",
+      title.(),
+      "</h4>\n",
+      "<dl>",
+      next.(),
+      "</dl>\n"
+    ]
+  end
+
+  def dt(%Context{}, next, %{}) do
+    ["<dt>", next.(), "</dt>\n"]
+  end
+
+  def dd(%Context{}, next, %{}) do
+    ["<dd>", next.(), "</dd>\n"]
+  end
+
   def ul(%Context{} = _context, next, %{"style" => style}) do
     ["<ul class=\"list-#{style}\">", next.(), "</ul>\n"]
   end

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -208,7 +208,7 @@ defmodule Oli.Rendering.Content.Html do
 
   def dl(%Context{}, next, title, %{}) do
     [
-      "<h4>",
+      "<h4 class=\"dl-title\">",
       title.(),
       "</h4>\n",
       "<dl>",

--- a/lib/oli/rendering/content/plaintext.ex
+++ b/lib/oli/rendering/content/plaintext.ex
@@ -55,6 +55,22 @@ defmodule Oli.Rendering.Content.Plaintext do
     [next.(), " "]
   end
 
+  def dl(%Context{}, next, title, %{}) do
+    [
+      title.(),
+      "\n",
+      next.()
+    ]
+  end
+
+  def dt(%Context{}, next, %{}) do
+    [next.(), "\n"]
+  end
+
+  def dd(%Context{}, next, %{}) do
+    [next.(), "\n"]
+  end
+
   def img(%Context{} = _context, _, %{"src" => src}) do
     ["[image with src #{src}] "]
   end

--- a/priv/schemas/v0-1-0/content-element.schema.json
+++ b/priv/schemas/v0-1-0/content-element.schema.json
@@ -24,6 +24,9 @@
           "$ref": "#/$defs/list"
         },
         {
+          "$ref": "#/$defs/description-list"
+        },
+        {
           "$ref": "#/$defs/media"
         },
         {
@@ -284,6 +287,53 @@
         }
       },
       "required": ["type", "children"]
+    },
+    "description-list": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "dl"
+        },
+        "title": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/inline"
+          }
+        },
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/desription-list-item"
+          }
+        },
+        "children": {
+          "type": "array",
+          "items": {
+            "$ref": "#"
+          }
+        }
+      }
+    },
+    "desription-list-item": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "oneOf": [
+            {
+              "const": "dd"
+            },
+            {
+              "const": "dt"
+            }
+          ]
+        },
+        "children": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/semantic-element-content"
+          }
+        }
+      }
     },
     "list": {
       "oneOf": [


### PR DESCRIPTION
Adds a definition list element to core authoring. They consist of a title followed by a series of terms and definitions which get rendered out in html dl,dd,dt tags.

Example:
![image](https://user-images.githubusercontent.com/333265/198057991-531a3102-8ab7-42a3-ba02-982c96676903.png)


A note on implementation: Originally, in the json format, I had the dd/dt tags in the children property of the dl element. I liked that since you had just one editor and it flowed a little nicer. However, I ran into a couple slate JS specific issues with that method that I was unable to resolve with the core problem being that many times, invalid children of the DL would get added and eventually invalid HTML would be rendered.

We have that same issue with our normal lists. For example, if you try to insert an image into a list item, then go preview, you end up with a structure like this which isn't properly formatted html.  This may be a bug we need to address someday in the future.
![image](https://user-images.githubusercontent.com/333265/198058862-b5d27282-3ee1-4dc3-a3b5-2da197e92672.png)



