### PR TITLE
[ENHANCEMENT] Align MCQ behavior with legacy [MER-1523]

### DIFF
--- a/assets/src/components/activities/check_all_that_apply/utils.ts
+++ b/assets/src/components/activities/check_all_that_apply/utils.ts
@@ -35,7 +35,7 @@ export const defaultCATAModel = (): CATA => {
       ],
       correct: [[correctChoice.id], correctResponse.id],
       targeted: [],
-      transformations: [makeTransformation('choices', Transform.shuffle)],
+      transformations: [makeTransformation('choices', Transform.shuffle, true)],
       previewText: '',
     },
   };

--- a/assets/src/components/activities/common/utils.tsx
+++ b/assets/src/components/activities/common/utils.tsx
@@ -18,7 +18,9 @@ export const toggleAnswerChoiceShuffling = () => {
       ? (model.authoring.transformations = transformations.filter(
           (xform) => xform.operation !== Transform.shuffle,
         ))
-      : model.authoring.transformations.push(makeTransformation('choices', Transform.shuffle));
+      : model.authoring.transformations.push(
+          makeTransformation('choices', Transform.shuffle, true),
+        );
   };
 };
 

--- a/assets/src/components/activities/common/variables/VariableEditorOrNot.tsx
+++ b/assets/src/components/activities/common/variables/VariableEditorOrNot.tsx
@@ -87,6 +87,7 @@ export class VariableEditorOrNot extends React.Component<
         {
           id: guid(),
           operation: 'variable_substitution',
+          firstAttemptOnly: false,
           data: [
             {
               type: 'variable',

--- a/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
@@ -5,11 +5,7 @@ import { ResetButtonConnected } from 'components/activities/common/delivery/rese
 import { SubmitButtonConnected } from 'components/activities/common/delivery/submit_button/SubmitButtonConnected';
 import { HintsDeliveryConnected } from 'components/activities/common/hints/delivery/HintsDeliveryConnected';
 import { StemDelivery } from 'components/activities/common/stem/delivery/StemDelivery';
-import {
-  DeliveryElement,
-  DeliveryElementProps,
-  PartActivityResponse,
-} from 'components/activities/DeliveryElement';
+import { DeliveryElement, DeliveryElementProps } from 'components/activities/DeliveryElement';
 import { DeliveryElementProvider, useDeliveryElementContext } from '../DeliveryElementProvider';
 import { MultiInputSchema, MultiInput } from 'components/activities/multi_input/schema';
 import { Manifest, PartId } from 'components/activities/types';

--- a/assets/src/components/activities/multi_input/utils.tsx
+++ b/assets/src/components/activities/multi_input/utils.tsx
@@ -49,7 +49,7 @@ export const defaultModel = (): MultiInputSchema => {
     authoring: {
       parts: [makePart(Responses.forTextInput(), [makeHint('')], '1')],
       targeted: [],
-      transformations: [makeTransformation('choices', Transform.shuffle)],
+      transformations: [makeTransformation('choices', Transform.shuffle, true)],
       previewText: 'Example question with a fill in the blank',
     },
   };

--- a/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
+++ b/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
@@ -98,11 +98,6 @@ export const MultipleChoiceComponent: React.FC = () => {
           }
           onSelect={(id) => saveOrSubmit(id)}
         />
-        <ResetButtonConnected
-          onReset={() =>
-            dispatch(resetAction(onResetActivity, { [activityState.parts[0].partId]: [] }))
-          }
-        />
         <HintsDeliveryConnected partId={castPartId(activityState.parts[0].partId)} />
         <EvaluationConnected />
       </div>

--- a/assets/src/components/activities/multiple_choice/utils.ts
+++ b/assets/src/components/activities/multiple_choice/utils.ts
@@ -30,7 +30,7 @@ export const defaultMCModel: () => MCSchema = () => {
         ),
       ],
       targeted: [],
-      transformations: [makeTransformation('choices', Transform.shuffle)],
+      transformations: [makeTransformation('choices', Transform.shuffle, true)],
       previewText: '',
     },
   };

--- a/assets/src/components/activities/ordering/utils.ts
+++ b/assets/src/components/activities/ordering/utils.ts
@@ -25,7 +25,9 @@ export const defaultOrderingModel = (): Ordering => {
       ],
       targeted: [],
       correct: [[choice1.id, choice2.id], correctResponse.id],
-      transformations: [{ id: guid(), path: 'choices', operation: Transform.shuffle }],
+      transformations: [
+        { id: guid(), path: 'choices', operation: Transform.shuffle, firstAttemptOnly: true },
+      ],
       previewText: '',
     },
   };

--- a/assets/src/components/activities/types.ts
+++ b/assets/src/components/activities/types.ts
@@ -398,6 +398,7 @@ export const makeFeedback: (text: string) => Feedback = makeContent;
 export interface Transformation extends Identifiable {
   path: string;
   operation: Transform;
+  firstAttemptOnly: boolean;
 }
 /**
  * Marker interface for an entity that has transformations.
@@ -418,10 +419,15 @@ export interface HasPerPartSubmissionOption {
  * @param operation The transformation operation
  * @returns
  */
-export const makeTransformation = (path: string, operation: Transform): Transformation => ({
+export const makeTransformation = (
+  path: string,
+  operation: Transform,
+  firstAttemptOnly: boolean,
+): Transformation => ({
   id: guid(),
   path,
   operation,
+  firstAttemptOnly,
 });
 
 /**

--- a/assets/src/components/activities/vlab/utils.tsx
+++ b/assets/src/components/activities/vlab/utils.tsx
@@ -51,7 +51,7 @@ export const defaultModel = (): VlabSchema => {
     authoring: {
       parts: [makePart(Responses.forNumericInput(), [makeHint('')], '1')],
       targeted: [],
-      transformations: [makeTransformation('choices', Transform.shuffle)],
+      transformations: [makeTransformation('choices', Transform.shuffle, true)],
       previewText: 'Example question with a fill in the blank',
     },
   };

--- a/assets/test/multi_input/multi_input_authoring_test.tsx
+++ b/assets/test/multi_input/multi_input_authoring_test.tsx
@@ -45,7 +45,7 @@ const _dropdownModel: MultiInputSchema = {
   authoring: {
     parts: [makePart(Responses.forMultipleChoice(choices[0].id), [makeHint('')], DEFAULT_PART_ID)],
     targeted: [],
-    transformations: [makeTransformation('choices', Transform.shuffle)],
+    transformations: [makeTransformation('choices', Transform.shuffle, true)],
     previewText: 'Example question with a fill in the blank',
   },
 };
@@ -58,7 +58,7 @@ const _numericModel: MultiInputSchema = {
   authoring: {
     parts: [makePart(Responses.forNumericInput(), [makeHint('')], DEFAULT_PART_ID)],
     targeted: [],
-    transformations: [makeTransformation('choices', Transform.shuffle)],
+    transformations: [makeTransformation('choices', Transform.shuffle, true)],
     previewText: 'Example question with a fill in the blank',
   },
 };

--- a/lib/oli/activities/model/transformations.ex
+++ b/lib/oli/activities/model/transformations.ex
@@ -1,5 +1,5 @@
 defmodule Oli.Activities.Model.Transformation do
-  defstruct [:id, :path, :operation, :data]
+  defstruct [:id, :path, :operation, :data, :first_attempt_only]
 
   def parse(%{"operation" => operation_str} = json) do
     id = Map.get(json, "id", UUID.uuid4())
@@ -11,6 +11,7 @@ defmodule Oli.Activities.Model.Transformation do
            data: nil,
            id: id,
            path: Map.get(json, "path"),
+           first_attempt_only: Map.get(json, "firstAttemptOnly", true),
            operation: :shuffle
          }}
 
@@ -20,6 +21,7 @@ defmodule Oli.Activities.Model.Transformation do
            data: Map.get(json, "data"),
            id: id,
            path: nil,
+           first_attempt_only: Map.get(json, "firstAttemptOnly", false),
            operation: :variable_substitution
          }}
 

--- a/lib/oli/activities/transformers.ex
+++ b/lib/oli/activities/transformers.ex
@@ -80,7 +80,12 @@ defmodule Oli.Activities.Transformers do
           {model_repository, errors_by_id}
 
         revision_id_transform_pairs ->
-          run_one_operation(model_repository, module, revision_id_transform_pairs, errors_by_id)
+          run_one_operation(
+            model_repository,
+            module,
+            revision_id_transform_pairs,
+            errors_by_id
+          )
       end
     end)
   end
@@ -93,7 +98,12 @@ defmodule Oli.Activities.Transformers do
   #
   # Returns a tuple with first element being the new model_repository, and second being a map of
   # revision ids to errors, for those that errored
-  defp run_one_operation(model_repository, module, revision_id_transform_pairs, errors_by_id) do
+  defp run_one_operation(
+         model_repository,
+         module,
+         revision_id_transform_pairs,
+         errors_by_id
+       ) do
     transformers = Enum.map(revision_id_transform_pairs, fn {_, t} -> t end)
 
     # Generate the batch context
@@ -104,7 +114,11 @@ defmodule Oli.Activities.Transformers do
         Enum.zip(batch_context, revision_id_transform_pairs)
         |> Enum.reduce({model_repository, errors_by_id}, fn {context, {id, t}},
                                                             {model_repository, errors_by_id} ->
-          case apply(module, :transform, [Map.get(model_repository, id), t, context]) do
+          case apply(module, :transform, [
+                 Map.get(model_repository, id),
+                 t,
+                 context
+               ]) do
             {:ok, model} ->
               {Map.put(model_repository, id, model), errors_by_id}
 

--- a/lib/oli_web/templates/layout/authoring.html.leex
+++ b/lib/oli_web/templates/layout/authoring.html.leex
@@ -16,11 +16,11 @@
     <link id="delivery-theme" rel="stylesheet" href="/css/delivery_default.css" />
 
     <%= if dev_mode?() do %>
-      <script crossorigin src="https://unpkg.com/react@17.0.2/umd/react.development.js"></script>
-      <script crossorigin src="https://unpkg.com/react-dom@17.0.2/umd/react-dom.development.js"></script>
+      <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/react/17.0.2/umd/react.development.js"></script>
+      <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/17.0.2/umd/react-dom.development.js"></script>
     <% else %>
-      <script crossorigin src="https://unpkg.com/react@17.0.2/umd/react.production.min.js"></script>
-      <script crossorigin src="https://unpkg.com/react-dom@17.0.2/umd/react-dom.production.min.js"></script>
+      <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/react/17.0.2/umd/react.production.min.js"></script>
+      <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/17.0.2/umd/react-dom.production.min.js"></script>
     <% end %>
 
     <!-- jQuery first, then Popper.js, then Bootstrap JS -->

--- a/lib/oli_web/templates/layout/chromeless.html.eex
+++ b/lib/oli_web/templates/layout/chromeless.html.eex
@@ -11,8 +11,13 @@
     <link rel="icon" type="image/png" sizes="16x16" href="<%= favicons("favicon-16x16.png", assigns[:section]) %>">
     <link rel="icon" type="image/png" sizes="32x32" href="<%= favicons("favicon-32x32.png", assigns[:section]) %>">
 
-    <script crossorigin src="https://unpkg.com/react@17.0.2/umd/react.production.min.js"></script>
-    <script crossorigin src="https://unpkg.com/react-dom@17.0.2/umd/react-dom.production.min.js"></script>
+    <%= if dev_mode?() do %>
+      <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/react/17.0.2/umd/react.development.js"></script>
+      <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/17.0.2/umd/react-dom.development.js"></script>
+    <% else %>
+      <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/react/17.0.2/umd/react.production.min.js"></script>
+      <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/17.0.2/umd/react-dom.production.min.js"></script>
+    <% end %>
 
     <!-- jQuery first, then Popper.js, then Bootstrap JS -->
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>

--- a/lib/oli_web/templates/layout/delivery.html.eex
+++ b/lib/oli_web/templates/layout/delivery.html.eex
@@ -15,11 +15,11 @@
     <link id="delivery-theme" rel="stylesheet" href="/css/delivery_default.css" />
 
     <%= if dev_mode?() do %>
-      <script crossorigin src="https://unpkg.com/react@17.0.2/umd/react.development.js"></script>
-      <script crossorigin src="https://unpkg.com/react-dom@17.0.2/umd/react-dom.development.js"></script>
+      <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/react/17.0.2/umd/react.development.js"></script>
+      <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/17.0.2/umd/react-dom.development.js"></script>
     <% else %>
-      <script crossorigin src="https://unpkg.com/react@17.0.2/umd/react.production.min.js"></script>
-      <script crossorigin src="https://unpkg.com/react-dom@17.0.2/umd/react-dom.production.min.js"></script>
+      <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/react/17.0.2/umd/react.production.min.js"></script>
+      <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/17.0.2/umd/react-dom.production.min.js"></script>
     <% end %>
 
     <!-- jQuery first, then Popper.js, then Bootstrap JS -->

--- a/test/oli/delivery/attempts/attempt_reset_test.exs
+++ b/test/oli/delivery/attempts/attempt_reset_test.exs
@@ -1,0 +1,202 @@
+defmodule Oli.Delivery.Attempts.ActivityResetTest do
+  use Oli.DataCase
+
+  alias Oli.Activities.Model.Part
+  alias Oli.Delivery.Attempts.ActivityLifecycle
+  alias Oli.Delivery.Attempts.ActivityLifecycle.Evaluate
+
+  alias Oli.Delivery.Attempts.Core
+  alias Oli.Delivery.Attempts.Core.{StudentInput}
+
+  def build_content(transformations) do
+    %{
+      "stem" => "1",
+      "choices" => [1, 2, 3],
+      "authoring" => %{
+        "transformations" => transformations,
+        "parts" => [
+          %{
+            "id" => "1",
+            "responses" => [
+              %{
+                "rule" => "input like {1}",
+                "score" => 10,
+                "id" => "r1",
+                "feedback" => %{"id" => "1", "content" => "yes"}
+              },
+              %{
+                "rule" => "input like {2}",
+                "score" => 1,
+                "id" => "r2",
+                "feedback" => %{"id" => "2", "content" => "almost"}
+              },
+              %{
+                "rule" => "input like {3}",
+                "score" => 0,
+                "id" => "r3",
+                "feedback" => %{"id" => "3", "content" => "no"}
+              }
+            ],
+            "scoringStrategy" => "best",
+            "evaluationStrategy" => "regex"
+          }
+        ]
+      }
+    }
+  end
+
+  describe "resetting an activity with transformations" do
+    setup do
+      content1 =
+        build_content([
+          %{
+            "id" => "1",
+            "path" => "choices",
+            "operation" => "shuffle",
+            "firstAttemptOnly" => true
+          },
+          %{
+            "id" => "1",
+            "path" => "responses",
+            "operation" => "shuffle",
+            "firstAttemptOnly" => false
+          }
+        ])
+
+      content2 =
+        build_content([
+          %{
+            "id" => "1",
+            "path" => "choices",
+            "operation" => "shuffle",
+            "firstAttemptOnly" => false
+          }
+        ])
+
+      map =
+        Seeder.base_project_with_resource2()
+        |> Seeder.create_section()
+        |> Seeder.add_objective("objective one", :o1)
+        |> Seeder.add_activity(%{title: "one", max_attempts: 5, content: content1}, :activity1)
+        |> Seeder.add_activity(%{title: "two", max_attempts: 5, content: content2}, :activity2)
+        |> Seeder.add_user(%{}, :user1)
+        |> Seeder.add_user(%{}, :user2)
+
+      Seeder.ensure_published(map.publication.id)
+
+      Seeder.add_page(
+        map,
+        %{
+          title: "practice page",
+          content: %{
+            "model" => [
+              %{
+                "type" => "activity-reference",
+                "activity_id" => Map.get(map, :activity1).revision.resource_id
+              },
+              %{
+                "type" => "activity-reference",
+                "activity_id" => Map.get(map, :activity2).revision.resource_id
+              }
+            ]
+          },
+          objectives: %{"attached" => [Map.get(map, :o1).resource.id]},
+          graded: false
+        },
+        :container,
+        :ungraded_page
+      )
+      |> Seeder.create_section_resources()
+      |> Seeder.create_resource_attempt(
+        %{attempt_number: 1},
+        :user1,
+        :ungraded_page,
+        :ungraded_page_user1_attempt1
+      )
+      |> Seeder.create_activity_attempt(
+        %{attempt_number: 1, transformed_model: content1},
+        :activity1,
+        :ungraded_page_user1_attempt1,
+        :ungraded_page_user1_activity1_attempt1
+      )
+      |> Seeder.create_part_attempt(
+        %{attempt_number: 1},
+        %Part{id: "1", responses: [], hints: []},
+        :ungraded_page_user1_activity1_attempt1,
+        :ungraded_page_user1_activity1_attempt1_part1_attempt1
+      )
+      |> Seeder.create_activity_attempt(
+        %{attempt_number: 1, transformed_model: content2},
+        :activity2,
+        :ungraded_page_user1_attempt1,
+        :ungraded_page_user1_activity2_attempt1
+      )
+      |> Seeder.create_part_attempt(
+        %{attempt_number: 1},
+        %Part{id: "1", responses: [], hints: []},
+        :ungraded_page_user1_activity2_attempt1,
+        :ungraded_page_user1_activity2_attempt1_part1_attempt1
+      )
+    end
+
+    test "ensure transformations run according to firstAttemptOnly constraints", %{
+      ungraded_page_user1_activity1_attempt1_part1_attempt1: part_attempt1,
+      ungraded_page_user1_activity2_attempt1_part1_attempt1: part_attempt2,
+      section: section,
+      ungraded_page_user1_activity1_attempt1: activity1_attempt,
+      ungraded_page_user1_activity2_attempt1: activity2_attempt
+    } do
+      datashop_session_id_user1 = UUID.uuid4()
+
+      part_inputs = [
+        %{attempt_guid: part_attempt1.attempt_guid, input: %StudentInput{input: "1"}}
+      ]
+
+      {:ok, _} =
+        Evaluate.evaluate_from_input(
+          section.slug,
+          activity1_attempt.attempt_guid,
+          part_inputs,
+          datashop_session_id_user1
+        )
+
+      # now reset the activity, this should not have a transform - we can softly assert
+      # that by ensuring that the transformed_models are the same
+      {:ok, {attempt_state, _}} =
+        ActivityLifecycle.reset_activity(
+          section.slug,
+          activity1_attempt.attempt_guid,
+          datashop_session_id_user1
+        )
+
+      attempt = Core.get_activity_attempt_by(attempt_guid: attempt_state.attemptGuid)
+      assert attempt.transformed_model == activity1_attempt.transformed_model
+
+      part_inputs = [
+        %{attempt_guid: part_attempt2.attempt_guid, input: %StudentInput{input: "1"}}
+      ]
+
+      {:ok, _} =
+        Evaluate.evaluate_from_input(
+          section.slug,
+          activity2_attempt.attempt_guid,
+          part_inputs,
+          datashop_session_id_user1
+        )
+
+      # now reset the second activity, this should result in a shuffle.
+
+      :rand.seed(:exsss, {1, 2, 3})
+
+      {:ok, {attempt_state, _}} =
+        ActivityLifecycle.reset_activity(
+          section.slug,
+          activity2_attempt.attempt_guid,
+          datashop_session_id_user1
+        )
+
+      attempt = Core.get_activity_attempt_by(attempt_guid: attempt_state.attemptGuid)
+      refute attempt.transformed_model == activity1_attempt.transformed_model
+    end
+  end
+end


### PR DESCRIPTION
This adjusts how MCQs work in a practice context:

1. Do not show the "Reset" button, rather, simply allow students to click other choices to reset and submit automatically.
2. Do not shuffle choices - even when shuffle is enabled - after the first attempt.

Task 1 above was straightforward.  Task 2 required extending the "transformation" framework a bit to introduce a `first_attempt_only` attribute on transformation instances.  If any of the transformations present have `:first_attempt_only` set to `true`, then none of the transformations run and the previous attempt's model is used for the new attempt.

I also ran into someweirdness with the CDN that we serve React from.  It was failing due to CORS issues in my dev env.  I switched it over to the CloudFlare CDN (which we use for all others).