### PR TITLE
[MER-1463] Add tests GradesLive

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -112,6 +112,7 @@ config :oli, Oli.Repo, migration_timestamps: [type: :timestamptz]
 
 # Config adapter for refreshing part_mapping
 config :oli, Oli.Publishing, refresh_adapter: Oli.Publishing.PartMappingRefreshAsync
+config :oli, :lti_access_token_provider, provider: Oli.Lti.AccessTokenLibrary
 
 # Configures the endpoint
 config :oli, OliWeb.Endpoint,

--- a/config/test.exs
+++ b/config/test.exs
@@ -48,7 +48,17 @@ config :oli, OliWeb.Pow.Mailer, adapter: Bamboo.TestAdapter
 config :bcrypt_elixir, log_rounds: 4
 
 config :lti_1p3,
-  http_client: Oli.Test.MockHTTP
+  http_client: Oli.Test.MockHTTP,
+  provider: Lti_1p3.DataProviders.EctoProvider,
+  ecto_provider: [
+    repo: Oli.Repo,
+    schemas: [
+      user: Oli.Accounts.User,
+      registration: Oli.Lti.Tool.Registration,
+      deployment: Oli.Lti.Tool.Deployment
+    ]
+  ],
+  ags_line_item_prefix: "oli-torus-"
 
 # We don't run a server during test. If one is required,
 # you can enable the server option below.
@@ -58,6 +68,7 @@ config :oli, OliWeb.Endpoint,
 
 # Config adapter for refreshing part_mapping
 config :oli, Oli.Publishing, refresh_adapter: Oli.Publishing.PartMappingRefreshSync
+config :oli, :lti_access_token_provider, provider: Oli.Lti.AccessTokenTest
 
 # Print only warnings and errors during test
 config :logger, level: :warn

--- a/lib/oli/lti/access_token_adapter.ex
+++ b/lib/oli/lti/access_token_adapter.ex
@@ -3,13 +3,13 @@ defmodule Oli.Lti.AccessTokenAdapter do
   alias Lti_1p3.Tool.Services.AccessToken
 
   @moduledoc """
-    Behaviour for spawning a function that freshes the part_mapping materialized view:
+    Behaviour to generate a function that returns an access token:
   """
 
   @type access_token :: {:ok, %AccessToken{}} | {:error, String.t()}
 
   @doc """
-  Defines a callback to be used by refresh adapters
+  Defines a callback to be used by access token adapters
   """
   @callback fetch_access_token(%Registration{}, list(), String.t()) :: access_token
 end

--- a/lib/oli/lti/access_token_adapter.ex
+++ b/lib/oli/lti/access_token_adapter.ex
@@ -1,0 +1,15 @@
+defmodule Oli.Lti.AccessTokenAdapter do
+  alias Oli.Lti.Tool.Registration
+  alias Lti_1p3.Tool.Services.AccessToken
+
+  @moduledoc """
+    Behaviour for spawning a function that freshes the part_mapping materialized view:
+  """
+
+  @type access_token :: {:ok, %AccessToken{}} | {:error, String.t()}
+
+  @doc """
+  Defines a callback to be used by refresh adapters
+  """
+  @callback fetch_access_token(%Registration{}, list(), String.t()) :: access_token
+end

--- a/lib/oli/lti/access_token_library.ex
+++ b/lib/oli/lti/access_token_library.ex
@@ -8,8 +8,8 @@ defmodule Oli.Lti.AccessTokenLibrary do
   @behaviour AccessTokenAdapter
 
   @doc """
-    Mock implementation of the refresh adapter,
-    the refresh operation is ran synchronously to simplify testing
+    Mock implementation of the access token adapter,
+    the fetch_access_token function of the lti_1p3 library is called to obtain an access token.
   """
   @impl AccessTokenAdapter
   @spec fetch_access_token(%Registration{}, list(), String.t()) :: access_token

--- a/lib/oli/lti/access_token_library.ex
+++ b/lib/oli/lti/access_token_library.ex
@@ -1,0 +1,19 @@
+defmodule Oli.Lti.AccessTokenLibrary do
+  alias Oli.Lti.AccessTokenAdapter
+  alias Lti_1p3.Tool.Services.AccessToken
+  alias Oli.Lti.Tool.Registration
+
+  @type access_token :: AccessTokenAdapter.access_token()
+
+  @behaviour AccessTokenAdapter
+
+  @doc """
+    Mock implementation of the refresh adapter,
+    the refresh operation is ran synchronously to simplify testing
+  """
+  @impl AccessTokenAdapter
+  @spec fetch_access_token(%Registration{}, list(), String.t()) :: access_token
+  def fetch_access_token(registration, scopes, host) do
+    AccessToken.fetch_access_token(registration, scopes, host)
+  end
+end

--- a/lib/oli/lti/access_token_test.ex
+++ b/lib/oli/lti/access_token_test.ex
@@ -1,0 +1,29 @@
+defmodule Oli.Lti.AccessTokenTest do
+  alias Oli.Lti.AccessTokenAdapter
+  alias Lti_1p3.Tool.Services.AccessToken
+  alias Oli.Lti.Tool.Registration
+
+  @type access_token :: AccessTokenAdapter.access_token()
+
+  @behaviour AccessTokenAdapter
+
+  @doc """
+    Mock implementation of the refresh adapter,
+    the refresh operation is ran synchronously to simplify testing
+  """
+  @impl AccessTokenAdapter
+  @spec fetch_access_token(%Registration{}, list(), String.t()) :: access_token
+  def fetch_access_token(%Registration{client_id: "error"}, _, _) do
+    {:error, "error fetching access token"}
+  end
+
+  def fetch_access_token(_, _, _) do
+    {:ok,
+     %AccessToken{
+       access_token: "access_token",
+       token_type: "token_type",
+       expires_in: "expires_in",
+       scope: "scope"
+     }}
+  end
+end

--- a/lib/oli/lti/access_token_test.ex
+++ b/lib/oli/lti/access_token_test.ex
@@ -8,8 +8,8 @@ defmodule Oli.Lti.AccessTokenTest do
   @behaviour AccessTokenAdapter
 
   @doc """
-    Mock implementation of the refresh adapter,
-    the refresh operation is ran synchronously to simplify testing
+    Mock implementation of the access token adapter,
+    The operation returns a value for the access token to simplify testing.
   """
   @impl AccessTokenAdapter
   @spec fetch_access_token(%Registration{}, list(), String.t()) :: access_token

--- a/lib/oli_web/live/grades/grades.ex
+++ b/lib/oli_web/live/grades/grades.ex
@@ -5,13 +5,13 @@ defmodule OliWeb.Grades.GradesLive do
   alias Lti_1p3.Tool.Services.AGS
   alias Lti_1p3.Tool.Services.AGS.LineItem
   alias Lti_1p3.Tool.Services.NRPS
-  alias Lti_1p3.Tool.Services.AccessToken
   alias Lti_1p3.Tool.ContextRoles
   alias Oli.Delivery.Attempts.Core, as: Attempts
   alias Oli.Delivery.Sections
   alias Oli.Accounts
   alias Oli.Repo
   alias Oli.Delivery.Attempts.PageLifecycle.Broadcaster
+  alias Oli.Lti.AccessTokenLibrary
 
   def mount(
         _params,
@@ -188,7 +188,12 @@ defmodule OliWeb.Grades.GradesLive do
   end
 
   defp access_token_provider(registration) do
-    AccessToken.fetch_access_token(registration, Grading.ags_scopes(), host())
+    provider =
+      :oli
+      |> Application.get_env(:lti_access_token_provider)
+      |> Keyword.get(:provider, AccessTokenLibrary)
+
+    provider.fetch_access_token(registration, Grading.ags_scopes(), host())
   end
 
   defp fetch_students(access_token, section) do

--- a/test/oli_web/live/grades_live_test.exs
+++ b/test/oli_web/live/grades_live_test.exs
@@ -1,0 +1,142 @@
+defmodule OliWeb.ObjectivesLiveTest do
+  use ExUnit.Case
+  use OliWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+  import Phoenix.ConnTest
+  import Oli.Factory
+  import Mox
+
+  alias Oli.Test.MockHTTP
+  alias OliWeb.Router.Helpers, as: Routes
+
+  @expected_headers %{"Content-Type" => "application/x-www-form-urlencoded"}
+
+  defp live_view_grades_route(section_slug) do
+    Routes.live_path(OliWeb.Endpoint, OliWeb.Grades.GradesLive, section_slug)
+  end
+
+  defp create_section(_conn) do
+    jwk = jwk_fixture()
+
+    registration =
+      insert(:lti_registration, %{
+        auth_token_url: "https://example.com",
+        tool_jwk_id: jwk.id,
+        client_id: "0001",
+        auth_server: "https://example.com"
+      })
+
+    deployment = insert(:lti_deployment, %{registration: registration})
+    section = insert(:section, %{lti_1p3_deployment: deployment})
+
+    [section: section]
+  end
+
+  describe "user cannot access when is not logged in" do
+    setup [:create_section]
+
+    test "redirects to new session when accessing manage LMS grades view", %{
+      conn: conn,
+      section: section
+    } do
+      section_slug = section.slug
+
+      redirect_path =
+        "/session/new?request_path=%2Fsections%2F#{section_slug}%2Fgrades%2Flms&section=#{section_slug}"
+
+      {:error, {:redirect, %{to: ^redirect_path}}} =
+        live(conn, live_view_grades_route(section_slug))
+    end
+  end
+
+  describe "user cannot access when is logged in as an author but is not a system admin" do
+    setup [:author_conn, :create_section]
+
+    test "redirects to ", %{conn: conn, section: section} do
+      section_slug = section.slug
+      conn = get(conn, live_view_grades_route(section_slug))
+
+      redirect_path =
+        "/session/new?request_path=%2Fsections%2F#{section_slug}%2Fgrades%2Flms&section=#{section_slug}"
+
+      assert redirected_to(conn, 302) =~ redirect_path
+    end
+  end
+
+  describe "test connection" do
+    setup [:admin_conn, :create_section]
+
+    test "returns success when the connection to the LMS is successful", %{
+      conn: conn,
+      section: section
+    } do
+      url = section.lti_1p3_deployment.registration.auth_token_url
+
+      MockHTTP
+      |> expect(:post, fn ^url, _body, @expected_headers ->
+        {:ok,
+         %HTTPoison.Response{
+           status_code: 200
+         }}
+      end)
+
+      {:ok, view, _html} = live(conn, live_view_grades_route(section.slug))
+
+      view
+      |> element("button[phx-click=\"test_connection\"]")
+      |> render_click()
+
+      assert has_element?(view, "samp", "Starting test")
+      assert has_element?(view, "samp", "Requesting access token...")
+      assert has_element?(view, "samp", "Received access token")
+    end
+  end
+
+  describe "export grades" do
+    setup [:admin_conn, :section_with_assessment]
+
+    test "download grades file without grades succesfully", %{conn: conn, section: section} do
+      {:ok, view, _html} = live(conn, live_view_grades_route(section.slug))
+
+      view
+      |> element(
+        "a[href=\"#{Routes.page_delivery_path(OliWeb.Endpoint, :export_gradebook, section.slug)}\"]",
+        "Download Gradebook"
+      )
+      |> render_click()
+
+      conn =
+        get(
+          conn,
+          Routes.page_delivery_path(OliWeb.Endpoint, :export_gradebook, section.slug)
+        )
+
+      assert response(conn, 200) =~ "Student,Progress test revision\r\n    Points Possible\r\n"
+    end
+  end
+
+  # describe "update line items" do
+  #   setup [:admin_conn, :create_section]
+
+  #   test "fails when cant update line items", %{conn: conn, section: section} do
+
+  #     MockHTTP
+  #     |> expect(:post, fn ^auth_token_url, _body, @expected_headers ->
+  #       {:ok,
+  #        %HTTPoison.Response{
+  #          status_code: 200
+  #        }}
+  #     end)
+
+  #     {:ok, view, _html} = live(conn, live_view_grades_route(section.slug))
+
+  #     view
+  #     |> element(
+  #       "a[phx-click=\"send_line_items\"]",
+  #       "Update LMS Line Items"
+  #     )
+  #     |> render_click()
+  #   end
+  # end
+end

--- a/test/oli_web/live/grades_live_test.exs
+++ b/test/oli_web/live/grades_live_test.exs
@@ -1,4 +1,4 @@
-defmodule OliWeb.ObjectivesLiveTest do
+defmodule OliWeb.GradesLiveTest do
   use ExUnit.Case
   use OliWeb.ConnCase
 

--- a/test/oli_web/live/grades_live_test.exs
+++ b/test/oli_web/live/grades_live_test.exs
@@ -1,5 +1,5 @@
 defmodule OliWeb.GradesLiveTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   use OliWeb.ConnCase
 
   import Phoenix.LiveViewTest
@@ -142,6 +142,7 @@ defmodule OliWeb.GradesLiveTest do
       assert has_element?(view, "samp", "Success!")
     end
 
+    @tag capture_log: true
     test "shows error message on failure to obtain line items in the connection to the LMS", %{
       conn: conn,
       section: section
@@ -192,6 +193,7 @@ defmodule OliWeb.GradesLiveTest do
       assert has_element?(view, "div.alert.alert-info", "LMS line items already up to date")
     end
 
+    @tag capture_log: true
     test "shows an error message when failure to obtain line items for update LMS line items", %{
       conn: conn,
       section: section

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -197,7 +197,8 @@ defmodule Oli.Factory do
       brand: anonymous_build(:brand),
       publisher: anonymous_build(:publisher),
       lti_1p3_deployment: deployment,
-      has_grace_period: false
+      has_grace_period: false,
+      line_items_service_url: "http://default.com"
     }
   end
 

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -575,7 +575,7 @@ defmodule Oli.TestHelpers do
     %{publication: publication, project: project, unit_one_revision: unit_one_revision}
   end
 
-  def section_with_assessment(_context) do
+  def section_with_assessment(_context, deployment \\ nil) do
     author = insert(:author)
     project = insert(:project, authors: [author])
 
@@ -637,31 +637,44 @@ defmodule Oli.TestHelpers do
     insert(:published_resource, %{
       publication: publication,
       resource: container_resource,
-      revision: container_revision
+      revision: container_revision,
+      author: author
     })
 
     # Publish nested container resource
     insert(:published_resource, %{
       publication: publication,
       resource: unit_one_resource,
-      revision: unit_one_revision
+      revision: unit_one_revision,
+      author: author
     })
 
     # Publish nested page resource
     insert(:published_resource, %{
       publication: publication,
       resource: page_revision.resource,
-      revision: page_revision
+      revision: page_revision,
+      author: author
     })
 
     section =
-      insert(:section,
-        base_project: project,
-        context_id: UUID.uuid4(),
-        open_and_free: true,
-        registration_open: true,
-        type: :enrollable
-      )
+      if deployment do
+        insert(:section,
+          base_project: project,
+          context_id: UUID.uuid4(),
+          lti_1p3_deployment: deployment,
+          registration_open: true,
+          type: :enrollable
+        )
+      else
+        insert(:section,
+          base_project: project,
+          context_id: UUID.uuid4(),
+          open_and_free: true,
+          registration_open: true,
+          type: :enrollable
+        )
+      end
 
     {:ok, section} = Sections.create_section_resources(section, publication)
 

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -576,7 +576,8 @@ defmodule Oli.TestHelpers do
   end
 
   def section_with_assessment(_context) do
-    project = insert(:project)
+    author = insert(:author)
+    project = insert(:project, authors: [author])
 
     # Graded page revision
     page_revision =
@@ -653,7 +654,15 @@ defmodule Oli.TestHelpers do
       revision: page_revision
     })
 
-    section = insert(:section, base_project: project, context_id: UUID.uuid4(), open_and_free: true, registration_open: true, type: :enrollable)
+    section =
+      insert(:section,
+        base_project: project,
+        context_id: UUID.uuid4(),
+        open_and_free: true,
+        registration_open: true,
+        type: :enrollable
+      )
+
     {:ok, section} = Sections.create_section_resources(section, publication)
 
     {:ok, section: section, unit_one_revision: unit_one_revision, page_revision: page_revision}

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -583,7 +583,8 @@ defmodule Oli.TestHelpers do
       insert(:revision,
         resource_type_id: Oli.Resources.ResourceType.get_id_by_type("page"),
         title: "Progress test revision",
-        graded: true
+        graded: true,
+        content: %{"advancedDelivery" => true}
       )
 
     # Associate nested graded page to the project


### PR DESCRIPTION
[MER-1463](https://eliterate.atlassian.net/browse/MER-1463)

This PR adds tests for the GradesLive view.

Connection to the LMS, downloading the gradebook, updating LMS line items and synchronizing grades are tested.

Files are added to be able to handle the execution of the **_fetch_access_token_** function depending on the environment in which it is running. This change has been made as it was failing in the test environment due to the time it takes to execute.