### PR TITLE
[BUG] Image selection bugs [MER-1533]

### DIFF
--- a/assets/src/actions/media.ts
+++ b/assets/src/actions/media.ts
@@ -179,7 +179,9 @@ export const fetchMediaItemByPath =
     return persistence.fetchMedia(courseId, offset, limit, undefined, url).then((response) => {
       if (response.type === 'success') {
         const data = Map<string, MediaItem>(response.results.map((item) => [item.guid, item]));
-        return Maybe.just<MediaItem>(data.first() as any);
+        if (data.size > 0) {
+          return Maybe.just<MediaItem>(data.first() as any);
+        }
       }
       return Maybe.nothing<MediaItem>();
     });

--- a/assets/src/components/media/UrlOrUpload.tsx
+++ b/assets/src/components/media/UrlOrUpload.tsx
@@ -18,7 +18,7 @@ interface Props {
 export const UrlOrUpload = (props: Props) => {
   const { onUrlChange } = props;
   const [source, setSource] = useState<Source>('library');
-  const [url, setUrl] = useState('');
+  const [url, setUrl] = useState(props.initialSelectionPaths?.[0] ?? '');
 
   const whenActive = (s: Source, c: string) => s === source && c;
 

--- a/assets/src/components/media/manager/MediaManager.tsx
+++ b/assets/src/components/media/manager/MediaManager.tsx
@@ -500,9 +500,9 @@ export class MediaManager extends React.PureComponent<MediaManagerProps, MediaMa
     const { media } = this.props;
     const { selection, showDetails } = this.state;
 
-    const selectedMediaItems = selection.map((guid) =>
-      media.data.get(guid),
-    ) as Immutable.List<MediaItem>;
+    const selectedMediaItems = selection
+      .map((guid) => media.data.get(guid))
+      .filter((item) => !!item) as Immutable.List<MediaItem>;
 
     if (selectedMediaItems.size > 1) {
       return (


### PR DESCRIPTION
This fixes two bugs in media-selection for images.

First bug is #3089 - Inability to modify the source of an image previously set.

Second bug:

1. Add an image to a page
2. Choose image button
3. Select “external url” and type in an image url.
4. Close the selection dialog.
5. Edit the source of the image and go to the external url tab.

Expected: the input box has the URL in it  
Actual: the input box is empty




Fixes #3089