### PR TITLE
[ENHANCEMENT] Media manager errors are no longer fatal

### DIFF
--- a/assets/src/apps/page-editor/PageEditor.tsx
+++ b/assets/src/apps/page-editor/PageEditor.tsx
@@ -42,6 +42,7 @@ import { empty, PageUndoable, Undoables, FeatureFlags } from './types';
 import { ContentOutline } from 'components/resource/editors/ContentOutline';
 import { PageEditorContent } from '../../data/editor/PageEditorContent';
 import '../ResourceEditor.scss';
+import { ErrorBoundary } from '../../components/common/ErrorBoundary';
 
 export interface PageEditorProps extends ResourceContext {
   editorMap: ActivityEditorMap; // Map of activity types to activity elements
@@ -523,63 +524,71 @@ export class PageEditor extends React.Component<PageEditorProps, PageEditorState
 
     return (
       <React.StrictMode>
-        <div className="resource-editor row">
-          <div className="col-12">
-            <UndoToasts undoables={this.state.undoables} onInvokeUndo={this.onInvokeUndo} />
+        <ErrorBoundary>
+          <div className="resource-editor row">
+            <div className="col-12">
+              <UndoToasts undoables={this.state.undoables} onInvokeUndo={this.onInvokeUndo} />
 
-            <Banner
-              dismissMessage={(msg: any) =>
-                this.setState({ messages: this.state.messages.filter((m) => msg.guid !== m.guid) })
-              }
-              executeAction={(message: any, action: any) => action.execute(message)}
-              messages={this.state.messages}
-            />
-            <TitleBar title={state.title} onTitleEdit={onTitleEdit} editMode={this.state.editMode}>
-              <PersistenceStatus persistence={this.state.persistence} />
+              <Banner
+                dismissMessage={(msg: any) =>
+                  this.setState({
+                    messages: this.state.messages.filter((m) => msg.guid !== m.guid),
+                  })
+                }
+                executeAction={(message: any, action: any) => action.execute(message)}
+                messages={this.state.messages}
+              />
+              <TitleBar
+                title={state.title}
+                onTitleEdit={onTitleEdit}
+                editMode={this.state.editMode}
+              >
+                <PersistenceStatus persistence={this.state.persistence} />
 
-              <PreviewButton />
-            </TitleBar>
-            <Objectives>
-              <ObjectivesSelection
-                editMode={this.state.editMode}
-                projectSlug={this.props.projectSlug}
-                objectives={this.state.allObjectives.toArray()}
-                selected={this.state.objectives.toArray()}
-                onEdit={(objectives) => this.update({ objectives: Immutable.List(objectives) })}
-                onRegisterNewObjective={onRegisterNewObjective}
-              />
-            </Objectives>
+                <PreviewButton />
+              </TitleBar>
+              <Objectives>
+                <ObjectivesSelection
+                  editMode={this.state.editMode}
+                  projectSlug={this.props.projectSlug}
+                  objectives={this.state.allObjectives.toArray()}
+                  selected={this.state.objectives.toArray()}
+                  onEdit={(objectives) => this.update({ objectives: Immutable.List(objectives) })}
+                  onRegisterNewObjective={onRegisterNewObjective}
+                />
+              </Objectives>
 
-            <div className="d-flex flex-row">
-              <ContentOutline
-                editMode={this.state.editMode}
-                content={this.state.content}
-                activityContexts={this.state.activityContexts}
-                editorMap={props.editorMap}
-                projectSlug={projectSlug}
-                resourceSlug={resourceSlug}
-                onEditContent={onEdit}
-              />
-              <Editors
-                {...props}
-                editMode={this.state.editMode}
-                objectives={this.state.allObjectives}
-                allTags={this.state.allTags}
-                childrenObjectives={this.state.childrenObjectives}
-                onRegisterNewObjective={onRegisterNewObjective}
-                onRegisterNewTag={onRegisterNewTag}
-                activityContexts={this.state.activityContexts}
-                onRemove={(key: string) => this.onRemove(key)}
-                onEdit={onEdit}
-                onEditActivity={this.onEditActivity}
-                onPostUndoable={this.onPostUndoable}
-                content={this.state.content}
-                onAddItem={onAddItem}
-                resourceContext={props}
-              />
+              <div className="d-flex flex-row">
+                <ContentOutline
+                  editMode={this.state.editMode}
+                  content={this.state.content}
+                  activityContexts={this.state.activityContexts}
+                  editorMap={props.editorMap}
+                  projectSlug={projectSlug}
+                  resourceSlug={resourceSlug}
+                  onEditContent={onEdit}
+                />
+                <Editors
+                  {...props}
+                  editMode={this.state.editMode}
+                  objectives={this.state.allObjectives}
+                  allTags={this.state.allTags}
+                  childrenObjectives={this.state.childrenObjectives}
+                  onRegisterNewObjective={onRegisterNewObjective}
+                  onRegisterNewTag={onRegisterNewTag}
+                  activityContexts={this.state.activityContexts}
+                  onRemove={(key: string) => this.onRemove(key)}
+                  onEdit={onEdit}
+                  onEditActivity={this.onEditActivity}
+                  onPostUndoable={this.onPostUndoable}
+                  content={this.state.content}
+                  onAddItem={onAddItem}
+                  resourceContext={props}
+                />
+              </div>
             </div>
           </div>
-        </div>
+        </ErrorBoundary>
       </React.StrictMode>
     );
   }

--- a/assets/src/components/common/ErrorBoundary.tsx
+++ b/assets/src/components/common/ErrorBoundary.tsx
@@ -2,10 +2,24 @@ import React, { ErrorInfo } from 'react';
 import guid from 'utils/guid';
 import { Collapse } from 'components/common/Collapse';
 
+const DefaultErrorMessage = () => (
+  <>
+    <p className="mb-4">Something went wrong. Please refresh the page and try again.</p>
+
+    <hr />
+
+    <p>If the problem persists, contact support with the following details:</p>
+  </>
+);
+
 export class ErrorBoundary extends React.Component<
-  any,
+  { errorMessage?: React.ReactNode; children: React.ReactNode },
   { hasError: boolean; error: Error | null; info: ErrorInfo | null; id: string }
 > {
+  static defaultProps = {
+    errorMessage: <DefaultErrorMessage />,
+  };
+
   constructor(props: any) {
     super(props);
     this.state = { hasError: false, error: null, info: null, id: guid() };
@@ -23,11 +37,7 @@ export class ErrorBoundary extends React.Component<
       if (this.state.hasError) {
         return (
           <div className="alert alert-warning" role="alert">
-            <p className="mb-4">Something went wrong. Please refresh the page and try again.</p>
-
-            <hr />
-
-            <p>If the problem persists, contact support with the following details:</p>
+            {this.props.errorMessage}
 
             <Collapse caption="Show error message">
               <div

--- a/assets/src/components/media/UrlOrUpload.tsx
+++ b/assets/src/components/media/UrlOrUpload.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { MediaItem } from 'types/media';
 import { classNames } from 'utils/classNames';
+import { ErrorBoundary } from '../common/ErrorBoundary';
 import { MediaManager, SELECTION_TYPES } from './manager/MediaManager.controller';
 
 type Source = 'library' | 'url';
@@ -45,13 +46,15 @@ export const UrlOrUpload = (props: Props) => {
           role="tabpanel"
           aria-labelledby="home-tab"
         >
-          <MediaManager
-            projectSlug={props.projectSlug}
-            mimeFilter={props.mimeFilter}
-            selectionType={SELECTION_TYPES.SINGLE}
-            initialSelectionPaths={props.initialSelectionPaths}
-            onSelectionChange={props.onMediaSelectionChange}
-          />
+          <ErrorBoundary errorMessage={<MediaManagerError />}>
+            <MediaManager
+              projectSlug={props.projectSlug}
+              mimeFilter={props.mimeFilter}
+              selectionType={SELECTION_TYPES.SINGLE}
+              initialSelectionPaths={props.initialSelectionPaths}
+              onSelectionChange={props.onMediaSelectionChange}
+            />
+          </ErrorBoundary>
         </div>
         <div
           className={classNames('tab-pane fade', whenActive('url', 'show active'))}
@@ -76,3 +79,13 @@ export const UrlOrUpload = (props: Props) => {
     </>
   );
 };
+
+const MediaManagerError = () => (
+  <>
+    <p className="mb-4">Something went wrong accessing the media manager, please try again.</p>
+
+    <hr />
+
+    <p>If the problem persists, contact support with the following details:</p>
+  </>
+);


### PR DESCRIPTION
While working on https://github.com/Simon-Initiative/oli-torus/pull/3090 I saw that an error in the media manager resulted in the app completely crashing to a blank screen.

This modifies that behavior.

1. The entire PageEditor is wrapped in an ErrorBoundary now, so we'll get a more friendly error if any of those top level components fail.
2. ErrorBoundary now takes an optional errorMessage param to customize what the user sees
3. The UrlOrUpload component now wraps the MediaManager component with a more locally-scoped error boundary, so if an error occurs there the user can just close the dialog and retry instead of being forced to reload the entire page.

Example dialog with error message:

![image](https://user-images.githubusercontent.com/333265/199521475-7b4508b3-dd0a-4147-800a-ad9ce5026650.png)
