### PR TITLE
[ENHANCEMENT] adjust color of text to pass accessibility guidelines failure [MER-1538]

### DIFF
--- a/assets/src/components/activities/common/delivery/evaluation/Evaluation.tsx
+++ b/assets/src/components/activities/common/delivery/evaluation/Evaluation.tsx
@@ -97,16 +97,16 @@ const Component: React.FC<ComponentProps> = (props) => {
 
 const graphicForResultClass = (resultClass: string) => {
   if (resultClass === 'correct') {
-    return <span className="icon_30H-hYww material-icons mr-2">check_circle</span>;
+    return <span className="icon_30H-hYww material-icons mr-2 graphic">check_circle</span>;
   }
   if (resultClass === 'incorrect') {
-    return <span className="icon_30H-hYww material-icons mr-2">cancel</span>;
+    return <span className="icon_30H-hYww material-icons mr-2 graphic">cancel</span>;
   }
   if (resultClass === 'partially-correct') {
-    return <span className="icon_30H-hYww material-icons mr-2">check</span>;
+    return <span className="icon_30H-hYww material-icons mr-2 graphic">check</span>;
   }
 
-  return <span className="icon_30H-hYww material-icons mr-2">error</span>;
+  return <span className="icon_30H-hYww material-icons mr-2 graphic">error</span>;
 };
 
 const resultClass = (score: number | null, outOf: number | null, error: string | undefined) => {

--- a/assets/styles/delivery/activity.scss
+++ b/assets/styles/delivery/activity.scss
@@ -29,6 +29,10 @@
       background-color: $feedback-correct-bg;
       color: $feedback-correct-color;
 
+      .graphic {
+        color: $feedback-correct-graphic-color;
+      }
+
       .result {
         border-color: $feedback-correct-color;
         color: $feedback-correct-color;
@@ -42,6 +46,10 @@
     &.partially-correct {
       background-color: $feedback-partially-correct-bg;
       color: $feedback-partially-correct-color;
+
+      .graphic {
+        color: $feedback-partially-correct-graphic-color;
+      }
 
       .result {
         border-color: $feedback-partially-correct-color;
@@ -57,6 +65,10 @@
       background-color: $feedback-incorrect-bg;
       color: $feedback-incorrect-color;
 
+      .graphic {
+        color: $feedback-incorrect-graphic-color;
+      }
+
       .result {
         border-color: $feedback-incorrect-color;
         color: $feedback-incorrect-color;
@@ -70,6 +82,10 @@
     &.explanation {
       background-color: $feedback-explanation-bg;
       color: $feedback-explanation-color;
+
+      .graphic {
+        color: $feedback-explanation-graphic-color;
+      }
     }
 
     &.error {

--- a/assets/styles/delivery/variables.scss
+++ b/assets/styles/delivery/variables.scss
@@ -17,15 +17,20 @@ $choice-selected-color: $primary !default;
 $choice-selected-border-color: $primary !default;
 
 $feedback-correct-bg: lighten($green, 45%) !default;
-$feedback-correct-color: $green !default;
+$feedback-correct-graphic-color: $green !default;
+$feedback-correct-color: $black !default;
 $feedback-partially-correct-bg: lighten($yellow, 45%) !default;
-$feedback-partially-correct-color: $yellow !default;
+$feedback-partially-correct-graphic-color: $yellow !default;
+$feedback-partially-correct-color: $black !default;
 $feedback-incorrect-bg: lighten($red, 40%) !default;
-$feedback-incorrect-color: $red !default;
+$feedback-incorrect-graphic-color: $red !default;
+$feedback-incorrect-color: $black !default;
 $feedback-explanation-bg: lighten($blue, 45%) !default;
-$feedback-explanation-color: $blue !default;
+$feedback-explanation-graphic-color: $blue !default;
+$feedback-explanation-color: $black !default;
 $feedback-error-bg: lighten($orange, 42%) !default;
-$feedback-error-color: $orange !default;
+$feedback-error-graphic-color: $orange !default;
+$feedback-error-color: $black !default;
 
 $hints-color: $gray-700 !default;
 $hints-bg: $gray-200 !default;

--- a/assets/styles/themes/delivery/default.scss
+++ b/assets/styles/themes/delivery/default.scss
@@ -265,13 +265,13 @@ html.authoring.dark .content-block .delivery {
   $choice-selected-border-color: $primary;
 
   $feedback-correct-bg: lighten($green, 35%);
-  $feedback-correct-color: $green;
+  $feedback-correct-color: $black;
   $feedback-incorrect-bg: lighten($red, 30%);
-  $feedback-incorrect-color: $red;
+  $feedback-incorrect-color: $black;
   $feedback-explanation-bg: lighten($blue, 45%);
-  $feedback-explanation-color: $blue;
+  $feedback-explanation-color: $black;
   $feedback-error-bg: lighten($orange, 32%);
-  $feedback-error-color: $orange;
+  $feedback-error-color: $black;
 
   // Dialog colors
   $speaker1: #051b11;


### PR DESCRIPTION
The current color schemes for "correct", "incorrect" and "explanation" are green on light green, red on light red, and blue on light blue.  This fails a WCAG compliant color contrast check that Sandy ran.  Changing to more closely mirror legacy: black text.