### PR TITLE
[BUGFIX] MER-1537 fix an issue with multi-input editing

### DIFF
--- a/assets/src/components/activities/common/responses/SimpleFeedback.tsx
+++ b/assets/src/components/activities/common/responses/SimpleFeedback.tsx
@@ -9,48 +9,22 @@ import React from 'react';
 
 interface Props {
   partId: string;
-  children?: (xs: ReturnType<typeof useSimpleFeedback>) => React.ReactElement;
 }
 
-export const useSimpleFeedback = (partId: string) => {
+export const SimpleFeedback: React.FC<Props> = ({ partId }) => {
   const { model, dispatch, editMode, authoringContext } = useAuthoringElementContext<HasParts>();
 
-  return {
-    editMode,
-    authoringContext,
-    correctResponse: getCorrectResponse(model, partId),
-    incorrectResponse: getIncorrectResponse(model, partId),
-    updateFeedback: (responseId: string, content: RichText) =>
-      dispatch(ResponseActions.editResponseFeedback(responseId, content)),
-    updateShowPage: (responseId: string, showPage: number | undefined) =>
-      dispatch(ResponseActions.editShowPage(responseId, showPage)),
-  };
-};
-
-export const SimpleFeedback: React.FC<Props> = ({ children, partId }) => {
-  const {
-    correctResponse,
-    incorrectResponse,
-    updateFeedback,
-    updateShowPage,
-    editMode,
-    authoringContext,
-  } = useSimpleFeedback(partId);
-
-  if (typeof children === 'function') {
-    return children({
-      correctResponse,
-      incorrectResponse,
-      updateFeedback,
-      updateShowPage,
-      editMode,
-      authoringContext,
-    });
-  }
+  const correctResponse = getCorrectResponse(model, partId);
+  const incorrectResponse = getIncorrectResponse(model, partId);
+  const updateFeedback = (responseId: string, content: RichText) =>
+    dispatch(ResponseActions.editResponseFeedback(responseId, content));
+  const updateShowPage = (responseId: string, showPage: number | undefined) =>
+    dispatch(ResponseActions.editShowPage(responseId, showPage));
 
   return (
     <>
       <FeedbackCard
+        key={`correct-${partId}`}
         title="Feedback for correct answer"
         feedback={correctResponse.feedback}
         update={(_id, content) => updateFeedback(correctResponse.id, content as RichText)}
@@ -65,6 +39,7 @@ export const SimpleFeedback: React.FC<Props> = ({ children, partId }) => {
         ) : null}
       </FeedbackCard>
       <FeedbackCard
+        key={`incorrect-${partId}`}
         title="Feedback for incorrect answers"
         feedback={incorrectResponse.feedback}
         update={(_id, content) => updateFeedback(incorrectResponse.id, content as RichText)}


### PR DESCRIPTION
Fixes an issue with the SimpleFeedback editor (identified in the multi input question) where the editor value changes but react doesnt know to swap the old editor for the new one. The fix here is to add a unique key to the correct/incorrect feedback elements that changes when the selected partId changes.