### PR TITLE
[BUG FIX] Preserve part state ordering during per part reset

### DIFF
--- a/assets/src/data/activities/DeliveryState.ts
+++ b/assets/src/data/activities/DeliveryState.ts
@@ -170,13 +170,15 @@ export const activityDeliverySlice = createSlice({
       }
     },
     partResetRecieved(state, action: PayloadAction<PartActivityResponse>) {
-      const parts = state.attemptState.parts.filter(
-        (p) => p.partId !== action.payload.attemptState.partId,
-      );
-
+      const parts = state.attemptState.parts.map((p: WritableDraft<PartState>) => {
+        if (action.payload.attemptState.partId === p.partId) {
+          return action.payload.attemptState;
+        }
+        return p;
+      });
       state.attemptState = {
         ...state.attemptState,
-        parts: [...parts, action.payload.attemptState],
+        parts,
       };
     },
     initializePartState(state, action: PayloadAction<ActivityState>) {


### PR DESCRIPTION
Fixes MER-1539.

The issue here was that per part reset did not update the part state in a way that preserved the original ordering of the array of part states.  That order is used to render the part evaluation (the feedbacks whether correct or not). 