### PR TITLE
[BUGFIX] Fixes adaptive author crash on unknown operator. [MER-1544]

### DIFF
--- a/assets/src/apps/authoring/components/AdaptivityEditor/AdaptiveItemOptions.ts
+++ b/assets/src/apps/authoring/components/AdaptivityEditor/AdaptiveItemOptions.ts
@@ -220,6 +220,10 @@ export const inferTypeFromOperatorAndValue = (operator: string, value: any): Cap
     const supportedTypes = typeCombos.map((combo) => combo.type);
     if (!supportedTypes.includes(valueType)) {
       // in this case then ignore the value type and use the first type combo
+      if (!typeCombos[0]) {
+        console.warn(`Could not infer type for operator ${operator}`);
+        return CapiVariableTypes.STRING;
+      }
       return typeCombos[0].type;
     }
     // TODO: figure out how to tell that a STRING is an ENUM or a MATH_EXPR

--- a/assets/src/apps/authoring/components/AdaptivityEditor/ConditionItemEditor.tsx
+++ b/assets/src/apps/authoring/components/AdaptivityEditor/ConditionItemEditor.tsx
@@ -70,7 +70,7 @@ const ConditionItemEditor: React.FC<ConditionItemEditorProps> = (props) => {
     const filteredCombo: ConditionTypeOperatorCombo[] = conditionTypeOperatorCombos.filter(
       (combo) => combo.type === targetType,
     );
-    filteredCombo[0].operators.forEach((comboOperator) => {
+    filteredCombo[0]?.operators.forEach((comboOperator) => {
       conditionOperatorOptions.forEach((conditionOperator) => {
         if (conditionOperator.key === comboOperator) {
           filteredConditionOperatorOptions.push(conditionOperator);


### PR DESCRIPTION
Bug:
1. on argos prod, open [Columbia Lesson-6: Calculations, Fall 2022](https://localhost:8043/authoring/project/columbia_lesson6_calculations_)
2. Edit the only page in it
3. Select the `Q5. Breaking Problems into Steps (Again)` screen under "Report a problem -> Back of the envelope calculations" layers
4. Click the Incorrect state on the left
5. Observe the app crashes

Somehow, the incorrect state for that screen had an operator of isNotEquivalentOf set where the correct name would have been notIsEquivalentOf

I don’t know how that would have gotten in there, maybe some sort of import or manual edit?

But now, the software will use reasonable defaults and not crash if it hits an unknown operator there.