### PR TITLE
[BUGFIX] MER-1412 Fix feature flags reset on deploy

### DIFF
--- a/lib/oli/features/feature.ex
+++ b/lib/oli/features/feature.ex
@@ -1,7 +1,6 @@
 defmodule Oli.Features.Feature do
   @derive Jason.Encoder
   defstruct [
-    :id,
     :label,
     :description
   ]

--- a/lib/oli/features/feature_state.ex
+++ b/lib/oli/features/feature_state.ex
@@ -2,21 +2,20 @@ defmodule Oli.Features.FeatureState do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @primary_key {:label, :string, autogenerate: false}
   schema "feature_states" do
     field :state, Ecto.Enum, values: [:enabled, :disabled], default: :disabled
-
-    timestamps(type: :utc_datetime)
   end
 
   @doc false
   def changeset(feature, attrs \\ %{}) do
     feature
     |> cast(attrs, [
-      :id,
+      :label,
       :state
     ])
     |> validate_required([
-      :id,
+      :label,
       :state
     ])
   end

--- a/priv/repo/migrations/20221103202020_feature_flags.exs
+++ b/priv/repo/migrations/20221103202020_feature_flags.exs
@@ -1,0 +1,36 @@
+defmodule Oli.Repo.Migrations.FeatureFlags do
+  use Ecto.Migration
+  import Ecto.Query, warn: false
+
+  alias Oli.Repo
+
+  @previous_id_labels %{
+    1 => "adaptivity",
+    2 => "equity"
+  }
+
+  def change do
+    existing_label_states =
+      from(
+        fs in "feature_states",
+        select: %{id: fs.id, state: fs.state}
+      )
+      |> Repo.all()
+      |> Enum.map(fn %{id: id, state: state} ->
+        %{label: @previous_id_labels[id], state: state}
+      end)
+
+    drop table(:feature_states)
+
+    flush()
+
+    create table("feature_states", primary_key: false) do
+      add :label, :string, primary_key: true
+      add :state, :string
+    end
+
+    flush()
+
+    Repo.insert_all("feature_states", existing_label_states)
+  end
+end

--- a/test/oli/features_test.exs
+++ b/test/oli/features_test.exs
@@ -10,13 +10,14 @@ defmodule Oli.FeaturesTest do
     end
 
     test "basic operations of feature flags", _ do
-      [{%Feature{id: 1, label: "adaptivity"}, state} | _] = Features.list_features_and_states()
+      [{%Feature{label: "adaptivity"}, state} | _] = Features.list_features_and_states()
       assert state == :disabled
 
       refute Features.enabled?("adaptivity")
 
       Features.change_state("adaptivity", :enabled)
-      [{%Feature{id: 1, label: "adaptivity"}, state} | _] = Features.list_features_and_states()
+
+      [{%Feature{label: "adaptivity"}, state} | _] = Features.list_features_and_states()
       assert state == :enabled
 
       assert Features.enabled?("adaptivity")


### PR DESCRIPTION
Fixes an issue where feature flags were being reset on every deployment. The underlying issue here was that the flag records were always being recreated as disabled. After digging in, I relized there is no good way to identify and retain a flag's state given the current id field is hardcoded and could be changed/reused upon a code update. I opted to make the label a string primary key instead so that a flag's state can always be identified by this unique label