### PR TITLE
[BUGFIX] MER-1548 ensure email is lowercase before query

### DIFF
--- a/lib/oli/accounts.ex
+++ b/lib/oli/accounts.ex
@@ -463,6 +463,8 @@ defmodule Oli.Accounts do
   Gets a single author with the given email
   """
   def get_author_by_email(email) do
+    email = String.downcase(email)
+
     Repo.get_by(Author, email: email)
   end
 
@@ -493,6 +495,8 @@ defmodule Oli.Accounts do
   Returns true if a author exists
   """
   def author_with_email_exists?(email) do
+    email = String.downcase(email)
+
     case Repo.get_by(Author, email: email) do
       nil -> false
       _author -> true

--- a/test/oli_web/controllers/collaborator_controller_test.exs
+++ b/test/oli_web/controllers/collaborator_controller_test.exs
@@ -37,6 +37,19 @@ defmodule OliWeb.CollaboratorControllerTest do
       assert assert get_flash(conn, :info) == "Collaborator invitations sent!"
     end
 
+    test "allows capital letters in emails", %{conn: conn, project: project} do
+      expect_recaptcha_http_post()
+
+      conn =
+        post(conn, Routes.collaborator_path(conn, :create, project),
+          collaborator_emails: "Invite@Example.COM",
+          "g-recaptcha-response": "any"
+        )
+
+      assert html_response(conn, 302) =~ "/project/"
+      assert assert get_flash(conn, :info) == "Collaborator invitations sent!"
+    end
+
     test "some emails succeed, some fail", %{conn: conn, project: project} do
       expect_recaptcha_http_post()
 


### PR DESCRIPTION
Fixes an issue where inviting a collaborator with an email that contains capital letter might fail.

Closes #3097