### PR TITLE
[CHORE] require AUTO_DEPLOY_ENABLED to be TRUE for automatic deployment to test

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -99,8 +99,9 @@ jobs:
 
   deployment:
     runs-on: ubuntu-latest
+    environment: tokamak.oli.cmu.edu
     needs: package
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master' && secrets.AUTO_DEPLOY_ENABLED == 'TRUE'
 
     environment:
       name: ${{ needs.package.outputs.deploy_host }}


### PR DESCRIPTION
Allows automatic deployment to tokamak to be controlled using environment secret.

To enable auto deploy, the AUTO_DEPLOY_ENABLED secret must be set to TRUE (all uppercase)