### PR TITLE
[FEATURE] Add media-browser support to adaptive video & audio elements [MER-1528, MER-1527]

### DIFF
--- a/assets/src/apps/authoring/components/Modal/MediaPickerModal.tsx
+++ b/assets/src/apps/authoring/components/Modal/MediaPickerModal.tsx
@@ -13,36 +13,43 @@ interface Props {
   onOK: () => void;
   projectSlug: string;
   onUrlChanged: (url: string) => void;
+  mimeFilter?: string[] | undefined;
+  title?: string;
 }
 
 /**
  * Media manager component wrapped in a react-bootstrap modal, initially for advanced authoring environment usage.
  **/
 
-export const ImagePickerModal: React.FC<Props> = ({
+export const MediaPickerModal: React.FC<Props> = ({
   projectSlug,
   initialSelection,
   onCancel,
   onOK,
   onUrlChanged,
+  mimeFilter,
+  title,
 }) => {
-  const onMediaSelected = useCallback((items: MediaItem[]) => {
-    if (items.length > 0) {
-      onUrlChanged(items[0].url);
-    }
-  }, []);
+  const onMediaSelected = useCallback(
+    (items: MediaItem[]) => {
+      if (items.length > 0) {
+        onUrlChanged(items[0].url);
+      }
+    },
+    [onUrlChanged],
+  );
 
   return (
     <Modal show={true} size={'xl'} onHide={onCancel}>
       <Modal.Header closeButton={true}>
-        <h3 className="modal-title">Select Image</h3>
+        <h3 className="modal-title">{title}</h3>
       </Modal.Header>
       <Modal.Body>
         <UrlOrUpload
           onUrlChange={onUrlChanged}
           onMediaSelectionChange={onMediaSelected}
           projectSlug={projectSlug}
-          mimeFilter={MIMETYPE_FILTERS.IMAGE}
+          mimeFilter={mimeFilter}
           selectionType={SELECTION_TYPES.SINGLE}
           initialSelectionPaths={initialSelection ? [initialSelection] : []}
         />
@@ -57,4 +64,9 @@ export const ImagePickerModal: React.FC<Props> = ({
       </Modal.Footer>
     </Modal>
   );
+};
+
+MediaPickerModal.defaultProps = {
+  mimeFilter: MIMETYPE_FILTERS.IMAGE,
+  title: 'Select Image',
 };

--- a/assets/src/apps/authoring/components/PropertyEditor/PropertyEditor.tsx
+++ b/assets/src/apps/authoring/components/PropertyEditor/PropertyEditor.tsx
@@ -8,6 +8,7 @@ import ColorPickerWidget from './custom/ColorPickerWidget';
 import CustomCheckbox from './custom/CustomCheckbox';
 import { TorusImageBrowser } from './custom/TorusImageBrowser';
 import ScreenDropdownTemplate from './custom/ScreenDropdownTemplate';
+import { TorusAudioBrowser } from './custom/TorusAudioBrowser';
 
 interface PropertyEditorProps {
   schema: JSONSchema7;
@@ -22,6 +23,7 @@ const widgets: any = {
   CheckboxWidget: CustomCheckbox,
   ScreenDropdownTemplate: ScreenDropdownTemplate,
   TorusImageBrowser: TorusImageBrowser,
+  TorusAudioBrowser: TorusAudioBrowser,
 };
 
 const PropertyEditor: React.FC<PropertyEditorProps> = ({

--- a/assets/src/apps/authoring/components/PropertyEditor/PropertyEditor.tsx
+++ b/assets/src/apps/authoring/components/PropertyEditor/PropertyEditor.tsx
@@ -9,6 +9,7 @@ import CustomCheckbox from './custom/CustomCheckbox';
 import { TorusImageBrowser } from './custom/TorusImageBrowser';
 import ScreenDropdownTemplate from './custom/ScreenDropdownTemplate';
 import { TorusAudioBrowser } from './custom/TorusAudioBrowser';
+import { TorusVideoBrowser } from './custom/TorusVideoBrowser';
 
 interface PropertyEditorProps {
   schema: JSONSchema7;
@@ -24,6 +25,7 @@ const widgets: any = {
   ScreenDropdownTemplate: ScreenDropdownTemplate,
   TorusImageBrowser: TorusImageBrowser,
   TorusAudioBrowser: TorusAudioBrowser,
+  TorusVideoBrowser: TorusVideoBrowser,
 };
 
 const PropertyEditor: React.FC<PropertyEditorProps> = ({

--- a/assets/src/apps/authoring/components/PropertyEditor/custom/TorusAudioBrowser.tsx
+++ b/assets/src/apps/authoring/components/PropertyEditor/custom/TorusAudioBrowser.tsx
@@ -69,6 +69,7 @@ export const TorusAudioBrowser: React.FC<Props> = ({ id, label, value, onChange,
           onOK={commitSelection}
           onCancel={closePicker}
           mimeFilter={MIMETYPE_FILTERS.AUDIO}
+          title="Select Audio File"
         />
       )}
     </span>

--- a/assets/src/apps/authoring/components/PropertyEditor/custom/TorusAudioBrowser.tsx
+++ b/assets/src/apps/authoring/components/PropertyEditor/custom/TorusAudioBrowser.tsx
@@ -1,0 +1,76 @@
+import React, { useCallback } from 'react';
+import { Button, ButtonGroup } from 'react-bootstrap';
+import { useSelector } from 'react-redux';
+import { useAudio } from '../../../../../components/hooks/useAudio';
+import { useToggle } from '../../../../../components/hooks/useToggle';
+import { MIMETYPE_FILTERS } from '../../../../../components/media/manager/MediaManager';
+import { selectProjectSlug } from '../../../store/app/slice';
+import { MediaPickerModal } from '../../Modal/MediaPickerModal';
+
+interface Props {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (url: string) => void;
+  onBlur: (id: string, url: string) => void;
+}
+
+export const TorusAudioBrowser: React.FC<Props> = ({ id, label, value, onChange, onBlur }) => {
+  const [pickerOpen, , openPicker, closePicker] = useToggle();
+  const projectSlug: string = useSelector(selectProjectSlug);
+  const { audioPlayer, playAudio, isPlaying } = useAudio(value);
+
+  const commitSelection = useCallback(() => {
+    onBlur(id, value);
+    closePicker();
+  }, [closePicker, id, onBlur, value]);
+
+  const hasAudio = !!value;
+
+  return (
+    <span>
+      <label className="form-label">{label}</label>
+      {hasAudio && (
+        <>
+          <div className="truncate-left">{value}</div>
+          {audioPlayer}
+        </>
+      )}
+
+      {hasAudio || <div className="truncate-left">No Audio</div>}
+
+      <ButtonGroup>
+        <Button
+          onClick={openPicker}
+          type="button"
+          variant="secondary"
+          size="sm"
+          aria-label="Select Audio File"
+        >
+          <span className="material-icons-outlined">mic</span>
+        </Button>
+
+        {hasAudio && (
+          <Button size="sm" variant="secondary" onClick={playAudio}>
+            {isPlaying ? (
+              <span className="material-icons-outlined">stop_circle</span>
+            ) : (
+              <span className="material-icons-outlined">play_circle</span>
+            )}
+          </Button>
+        )}
+      </ButtonGroup>
+
+      {pickerOpen && (
+        <MediaPickerModal
+          onUrlChanged={onChange}
+          initialSelection={value}
+          projectSlug={projectSlug}
+          onOK={commitSelection}
+          onCancel={closePicker}
+          mimeFilter={MIMETYPE_FILTERS.AUDIO}
+        />
+      )}
+    </span>
+  );
+};

--- a/assets/src/apps/authoring/components/PropertyEditor/custom/TorusImageBrowser.tsx
+++ b/assets/src/apps/authoring/components/PropertyEditor/custom/TorusImageBrowser.tsx
@@ -3,7 +3,7 @@ import { Button } from 'react-bootstrap';
 import { useSelector } from 'react-redux';
 import { useToggle } from '../../../../../components/hooks/useToggle';
 import { selectProjectSlug } from '../../../store/app/slice';
-import { ImagePickerModal } from '../../Modal/ImagePickerModal';
+import { MediaPickerModal } from '../../Modal/MediaPickerModal';
 
 interface Props {
   id: string;
@@ -50,7 +50,7 @@ export const TorusImageBrowser: React.FC<Props> = ({ id, label, value, onChange,
       </Button>
 
       {pickerOpen && (
-        <ImagePickerModal
+        <MediaPickerModal
           onUrlChanged={onChange}
           initialSelection={value}
           projectSlug={projectSlug}

--- a/assets/src/apps/authoring/components/PropertyEditor/custom/TorusVideoBrowser.tsx
+++ b/assets/src/apps/authoring/components/PropertyEditor/custom/TorusVideoBrowser.tsx
@@ -1,0 +1,58 @@
+import React, { useCallback } from 'react';
+import { Button } from 'react-bootstrap';
+import { useSelector } from 'react-redux';
+import { useToggle } from '../../../../../components/hooks/useToggle';
+import { MIMETYPE_FILTERS } from '../../../../../components/media/manager/MediaManager';
+import { selectProjectSlug } from '../../../store/app/slice';
+import { MediaPickerModal } from '../../Modal/MediaPickerModal';
+
+interface Props {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (url: string) => void;
+  onBlur: (id: string, url: string) => void;
+}
+
+export const TorusVideoBrowser: React.FC<Props> = ({ id, label, value, onChange, onBlur }) => {
+  const [pickerOpen, , openPicker, closePicker] = useToggle();
+  const projectSlug: string = useSelector(selectProjectSlug);
+
+  const commitSelection = useCallback(() => {
+    onBlur(id, value);
+    closePicker();
+  }, [closePicker, id, onBlur, value]);
+
+  const hasVideo = !!value;
+
+  return (
+    <span>
+      <label className="form-label">{label}</label>
+
+      {hasVideo && <div className="truncate-left">{value}</div>}
+      {hasVideo || <div className="truncate-left">No Video</div>}
+
+      <Button
+        onClick={openPicker}
+        type="button"
+        variant="secondary"
+        size="sm"
+        aria-label="Select Video File"
+      >
+        <span className="material-icons-outlined">video_library</span>
+      </Button>
+
+      {pickerOpen && (
+        <MediaPickerModal
+          onUrlChanged={onChange}
+          initialSelection={value}
+          projectSlug={projectSlug}
+          onOK={commitSelection}
+          onCancel={closePicker}
+          mimeFilter={MIMETYPE_FILTERS.VIDEO}
+          title="Select Video File"
+        />
+      )}
+    </span>
+  );
+};

--- a/assets/src/components/hooks/useAudio.tsx
+++ b/assets/src/components/hooks/useAudio.tsx
@@ -15,6 +15,7 @@ import { useCallback, useRef } from 'react';
 export const useAudio = (src?: string) => {
   const audioRef = useRef<HTMLAudioElement>(null);
   const [isPlaying, setIsPlaying] = useState(false);
+
   const playAudio = useCallback((event?: any) => {
     event?.preventDefault && event?.preventDefault(); // Fixes https://eliterate.atlassian.net/browse/MER-1503
 
@@ -22,9 +23,9 @@ export const useAudio = (src?: string) => {
     if (audio) {
       if (audio.paused) {
         audio.currentTime = 0;
-        setIsPlaying(true);
-        audio.currentTime = 0;
-        audio.play();
+        audio.play().then(() => setIsPlaying(true));
+        audio.onabort = () => setIsPlaying(false);
+        audio.onerror = () => setIsPlaying(false);
         audio.onended = () => setIsPlaying(false);
       } else {
         setIsPlaying(false);

--- a/assets/src/components/parts/janus-audio/schema.ts
+++ b/assets/src/components/parts/janus-audio/schema.ts
@@ -67,7 +67,11 @@ export const schema: JSONSchema7Object = {
   },
 };
 
-export const uiSchema = {};
+export const uiSchema = {
+  src: {
+    'ui:widget': 'TorusAudioBrowser',
+  },
+};
 
 export const adaptivitySchema = {
   exposureInSeconds: CapiVariableTypes.NUMBER,

--- a/assets/src/components/parts/janus-video/schema.ts
+++ b/assets/src/components/parts/janus-video/schema.ts
@@ -74,6 +74,9 @@ export const uiSchema = {
     'ui:title': 'Subtitles',
     'ui:ObjectFieldTemplate': CustomFieldTemplate,
   },
+  src: {
+    'ui:widget': 'TorusVideoBrowser',
+  },
 };
 
 export const adaptivitySchema = {


### PR DESCRIPTION
Use the torus media-manager to select audio and video URL's for the audio and video components in adaptive lessons. 

Audio editor allows you to preview audio from the editor.

Example Audio Editor:

![image](https://user-images.githubusercontent.com/333265/200590320-139cb5e8-5c8c-4f8b-b6d4-cd20c3595496.png)


Example Video Editor:

![image](https://user-images.githubusercontent.com/333265/200605184-40b07bf6-7b01-4941-8eb6-bf767930503a.png)
