### PR TITLE
[FEATURE] Fix adaptive backgrounds and add media browser. [MER-1529]

### DIFF
--- a/assets/src/apps/authoring/components/PropertyEditor/schemas/lesson.ts
+++ b/assets/src/apps/authoring/components/PropertyEditor/schemas/lesson.ts
@@ -126,6 +126,9 @@ export const lessonUiSchema: UiSchema = {
     Appearance: {
       'ui:ObjectFieldTemplate': CustomFieldTemplate,
       'ui:title': 'Lesson Appearance',
+      backgroundImageURL: {
+        'ui:widget': 'TorusImageBrowser',
+      },
     },
     FinishPanel: {
       'ui:ObjectFieldTemplate': CustomFieldTemplate,

--- a/assets/styles/themes/delivery/adaptive_themes/default/layout/background.scss
+++ b/assets/styles/themes/delivery/adaptive_themes/default/layout/background.scss
@@ -1,0 +1,16 @@
+.background {
+  height: auto;
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: -1000;
+  background-repeat: no-repeat;
+  background-position: top center;
+  transform: translateZ(0);
+}
+
+.background-scaled {
+  background-size: 100% 100%;
+}

--- a/assets/styles/themes/delivery/adaptive_themes/default/light.scss
+++ b/assets/styles/themes/delivery/adaptive_themes/default/light.scss
@@ -8,6 +8,7 @@
 @import 'layout/header-container';
 @import 'layout/content-container';
 @import 'layout/check-container';
+@import 'layout/background';
 
 /*-- Activity Types --*/
 @import 'activities/text-flow';


### PR DESCRIPTION
Lesson background images in the default theme for adaptive lessons were broken as the were displaying as a 0-height image.

This change adds some css to the default theme to fix that, plus it adds media-library browsing to choose the background image. I verified this works in both preview & delivery modes.