### PR TITLE
[BUG FIX] MER-1549 fix an issue where revision history table pagination crashes

### DIFF
--- a/lib/oli_web/live/history/pagination.ex
+++ b/lib/oli_web/live/history/pagination.ex
@@ -31,7 +31,7 @@ defmodule OliWeb.RevisionHistory.Pagination do
       <nav aria-label="table results paging">
         <ul class="pagination justify-content-center">
           <%= for page <- 1..@total_pages do %>
-            <%= live_component PaginationLink, page_ordinal: page, active: @current_page == page, page_offset: @page_offset %>
+            <PaginationLink.render page_ordinal={page} active={@current_page == page} page_offset={@page_offset} />
           <% end %>
         </ul>
       </nav>

--- a/lib/oli_web/live/history/pagination_link.ex
+++ b/lib/oli_web/live/history/pagination_link.ex
@@ -5,7 +5,7 @@ defmodule OliWeb.RevisionHistory.PaginationLink do
     assigns = assign(assigns, :str, Integer.to_string(assigns.page_ordinal))
 
     ~H"""
-    <li class={"page-item #{if @active do [active: true] else [] end}"}>
+    <li class={"page-item #{if @active do "active" else "" end}"}>
       <a class="page-link" href="#" phx-click="page" phx-value-ordinal={@str}><%= @str %></a>
     </li>
     """


### PR DESCRIPTION
Fixes an issue when revision history table is large enough to show pagination controls, the view crashes.

Closes #3117