### PR TITLE
[BUG FIX] Handle namespaced mathml [MER-1550]

### DIFF
--- a/assets/src/utils/mathmlSanitizer.ts
+++ b/assets/src/utils/mathmlSanitizer.ts
@@ -181,6 +181,89 @@ const allowedAttributes = {
   munderover: ['accent', 'accentunder', 'align', ...commonAttributes],
 
   semantics: ['src', 'definitionurl', 'encoding', 'cd', 'name', ...commonAttributes],
+
+  'm:maction': ['actiontype', 'selection', ...commonAttributes],
+
+  'm:math': ['dir', 'display', 'mode', ...mstyleAttributes, ...commonAttributes],
+
+  'm:menclose': ['notation', ...commonAttributes],
+
+  'm:merror': commonAttributes,
+
+  'm:mfenced': ['close', 'open', 'separators', ...commonAttributes],
+
+  'm:mfrac': ['bevelled', 'denomalign', 'linethickness', 'numalign', ...commonAttributes],
+
+  'm:mi': ['dir', 'mathvariant', ...commonAttributes],
+
+  'm:mmultiscripts': ['subscriptshift', 'superscriptshift', ...commonAttributes],
+
+  'm:mn': ['dir', 'mathvariant', ...commonAttributes],
+
+  'm:mo': [
+    'accent',
+    'fence',
+    'lspace',
+    'mathvariant',
+    'maxsize',
+    'minsize',
+    'movablelimits',
+    'rspace',
+    'separator',
+    'stretchy',
+    'symmetric',
+    ...commonAttributes,
+  ],
+
+  'm:mover': ['accent', 'align', ...commonAttributes],
+
+  'm:mpadded': ['depth', 'height', 'lspace', 'voffset', 'width', ...commonAttributes],
+
+  'm:mphantom': commonAttributes,
+
+  'm:mroot': commonAttributes,
+
+  'm:mrow': ['dir', ...commonAttributes],
+
+  'm:ms': ['dir', 'lquote', 'mathvariant', 'rquote', ...commonAttributes],
+
+  'm:mspace': ['depth', 'height', 'width', ...commonAttributes],
+
+  'm:msqrt': commonAttributes,
+
+  'm:mstyle': [...mstyleAttributes, ...commonAttributes],
+
+  'm:msub': ['subscriptshift', ...commonAttributes],
+
+  'm:msubsup': ['subscriptshift', 'superscriptshift', ...commonAttributes],
+
+  'm:msup': ['superscriptshift', ...commonAttributes],
+
+  'm:mtable': [
+    'align',
+    'columnalign',
+    'columnlines',
+    'columnspacing',
+    'frame',
+    'framespacing',
+    'rowalign',
+    'rowlines',
+    'width',
+
+    ...commonAttributes,
+  ],
+
+  'm:mtd': ['columnalign', 'columnspan', 'rowalign', 'rowspan', ...commonAttributes],
+
+  'm:mtext': ['dir', 'mathvariant', ...commonAttributes],
+
+  'm:mtr': ['columnalign', 'rowalign', ...commonAttributes],
+
+  'm:munder': ['accentunder', 'align', ...commonAttributes],
+
+  'm:munderover': ['accent', 'accentunder', 'align', ...commonAttributes],
+
+  'm:semantics': ['src', 'definitionurl', 'encoding', 'cd', 'name', ...commonAttributes],
 };
 
 const config: IOptions = {

--- a/lib/oli/rendering/content/mathml_sanitizer.ex
+++ b/lib/oli/rendering/content/mathml_sanitizer.ex
@@ -521,5 +521,506 @@ defmodule Oli.Rendering.Content.MathMLSanitizer do
 
   Meta.allow_tag_with_uri_attributes("semantics", ["src", "definitionURL"], @valid_schemes)
 
+  Meta.allow_tag_with_these_attributes("m:maction", [
+    "actiontype",
+    "selection",
+    "class",
+    "id",
+    "style",
+    "mathbackground",
+    "mathcolor",
+    "displaystyle",
+    "mathsize"
+  ])
+
+  Meta.allow_tag_with_these_attributes("m:math", [
+    "dir",
+    "display",
+    "mode",
+    "class",
+    "id",
+    "style",
+    "mathbackground",
+    "mathcolor",
+    "displaystyle",
+    "mathsize",
+    "accent",
+    "accentunder",
+    "actiontype",
+    "align ",
+    "altimg",
+    "altimg-width",
+    "altimg-height",
+    "altimg-valign",
+    "alttext",
+    "bevelled ",
+    "charalign",
+    "close",
+    "columnalign",
+    "columnlines",
+    "columnspacing",
+    "columnspan",
+    "crossout",
+    "denomalign ",
+    "depth",
+    "edge",
+    "fence",
+    "frame",
+    "framespacing",
+    "groupalign",
+    "height",
+    "indentalign",
+    "indentalignfirst",
+    "indentalignlast",
+    "indentshift",
+    "indentshiftfirst",
+    "indentshiftlast",
+    "indenttarget",
+    "infixlinebreakstyle",
+    "length",
+    "linebreak",
+    "linebreakmultchar",
+    "linebreakstyle",
+    "lineleading",
+    "linethickness",
+    "location",
+    "longdivstyle",
+    "lspace",
+    "lquote",
+    "mathvariant",
+    "maxsize",
+    "minsize",
+    "movablelimits",
+    "notation",
+    "numalign ",
+    "open",
+    "position",
+    "rowalign",
+    "rowlines",
+    "rowspacing",
+    "rowspan",
+    "rspace",
+    "rquote",
+    "scriptlevel",
+    "scriptminsize",
+    "scriptsizemultiplier",
+    "selection",
+    "separator",
+    "separators",
+    "shift",
+    "stackalign",
+    "stretchy",
+    "subscriptshift ",
+    "supscriptshift ",
+    "symmetric",
+    "voffset",
+    "width"
+  ])
+
+  Meta.allow_tag_with_these_attributes("m:menclose", [
+    "notation",
+    "class",
+    "id",
+    "style",
+    "mathbackground",
+    "mathcolor",
+    "displaystyle",
+    "mathsize"
+  ])
+
+  Meta.allow_tag_with_these_attributes("m:merror", [
+    "class",
+    "id",
+    "style",
+    "mathbackground",
+    "mathcolor",
+    "displaystyle",
+    "mathsize"
+  ])
+
+  Meta.allow_tag_with_these_attributes("m:mfenced", [
+    "close",
+    "open",
+    "separators",
+    "class",
+    "id",
+    "style",
+    "mathbackground",
+    "mathcolor",
+    "displaystyle",
+    "mathsize"
+  ])
+
+  Meta.allow_tag_with_these_attributes("m:mfrac", [
+    "bevelled",
+    "denomalign",
+    "linethickness",
+    "numalign",
+    "class",
+    "id",
+    "style",
+    "mathbackground",
+    "mathcolor",
+    "displaystyle",
+    "mathsize"
+  ])
+
+  Meta.allow_tag_with_these_attributes("m:mi", [
+    "dir",
+    "mathvariant",
+    "class",
+    "id",
+    "style",
+    "mathbackground",
+    "mathcolor",
+    "displaystyle",
+    "mathsize"
+  ])
+
+  Meta.allow_tag_with_these_attributes("m:mmultiscripts", [
+    "subscriptshift",
+    "superscriptshift",
+    "class",
+    "id",
+    "style",
+    "mathbackground",
+    "mathcolor",
+    "displaystyle",
+    "mathsize"
+  ])
+
+  Meta.allow_tag_with_these_attributes("m:mn", [
+    "dir",
+    "mathvariant",
+    "class",
+    "id",
+    "style",
+    "mathbackground",
+    "mathcolor",
+    "displaystyle",
+    "mathsize"
+  ])
+
+  Meta.allow_tag_with_these_attributes(
+    "m:mo",
+    [
+      "accent",
+      "fence",
+      "lspace",
+      "mathvariant",
+      "maxsize",
+      "minsize",
+      "movablelimits",
+      "rspace",
+      "separator",
+      "stretchy",
+      "symmetric",
+      "class",
+      "id",
+      "style",
+      "mathbackground",
+      "mathcolor",
+      "displaystyle",
+      "mathsize"
+    ]
+  )
+
+  Meta.allow_tag_with_these_attributes("m:mover", [
+    "accent",
+    "align",
+    "class",
+    "id",
+    "style",
+    "mathbackground",
+    "mathcolor",
+    "displaystyle",
+    "mathsize"
+  ])
+
+  Meta.allow_tag_with_these_attributes("m:mpadded", [
+    "depth",
+    "height",
+    "lspace",
+    "voffset",
+    "width",
+    "class",
+    "id",
+    "style",
+    "mathbackground",
+    "mathcolor",
+    "displaystyle",
+    "mathsize"
+  ])
+
+  Meta.allow_tag_with_these_attributes("m:mphantom", [
+    "class",
+    "id",
+    "style",
+    "mathbackground",
+    "mathcolor",
+    "displaystyle",
+    "mathsize"
+  ])
+
+  Meta.allow_tag_with_these_attributes("m:mroot", [
+    "class",
+    "id",
+    "style",
+    "mathbackground",
+    "mathcolor",
+    "displaystyle",
+    "mathsize"
+  ])
+
+  Meta.allow_tag_with_these_attributes("m:mrow", [
+    "dir",
+    "class",
+    "id",
+    "style",
+    "mathbackground",
+    "mathcolor",
+    "displaystyle",
+    "mathsize"
+  ])
+
+  Meta.allow_tag_with_these_attributes("m:ms", [
+    "dir",
+    "lquote",
+    "mathvariant",
+    "rquote",
+    "class",
+    "id",
+    "style",
+    "mathbackground",
+    "mathcolor",
+    "displaystyle",
+    "mathsize"
+  ])
+
+  Meta.allow_tag_with_these_attributes("m:mspace", [
+    "depth",
+    "height",
+    "width",
+    "class",
+    "id",
+    "style",
+    "mathbackground",
+    "mathcolor",
+    "displaystyle",
+    "mathsize"
+  ])
+
+  Meta.allow_tag_with_these_attributes("m:msqrt", [""])
+
+  Meta.allow_tag_with_these_attributes("m:mstyle", [
+    "accent",
+    "accentunder",
+    "actiontype",
+    "align ",
+    "altimg",
+    "altimg-width",
+    "altimg-height",
+    "altimg-valign",
+    "alttext",
+    "bevelled ",
+    "charalign",
+    "close",
+    "columnalign",
+    "columnlines",
+    "columnspacing",
+    "columnspan",
+    "crossout",
+    "denomalign ",
+    "depth",
+    "dir",
+    "display",
+    "edge",
+    "fence",
+    "frame",
+    "framespacing",
+    "groupalign",
+    "height",
+    "indentalign",
+    "indentalignfirst",
+    "indentalignlast",
+    "indentshift",
+    "indentshiftfirst",
+    "indentshiftlast",
+    "indenttarget",
+    "infixlinebreakstyle",
+    "length",
+    "linebreak",
+    "linebreakmultchar",
+    "linebreakstyle",
+    "lineleading",
+    "linethickness",
+    "location",
+    "longdivstyle",
+    "lspace",
+    "lquote",
+    "mathvariant",
+    "maxsize",
+    "minsize",
+    "movablelimits",
+    "notation",
+    "numalign ",
+    "open",
+    "position",
+    "rowalign",
+    "rowlines",
+    "rowspacing",
+    "rowspan",
+    "rspace",
+    "rquote",
+    "scriptlevel",
+    "scriptminsize",
+    "scriptsizemultiplier",
+    "selection",
+    "separator",
+    "separators",
+    "shift",
+    "stackalign",
+    "stretchy",
+    "subscriptshift ",
+    "supscriptshift ",
+    "symmetric",
+    "voffset",
+    "width"
+  ])
+
+  Meta.allow_tag_with_these_attributes("m:msub", [
+    "subscriptshift",
+    "class",
+    "id",
+    "style",
+    "mathbackground",
+    "mathcolor",
+    "displaystyle",
+    "mathsize"
+  ])
+
+  Meta.allow_tag_with_these_attributes("m:msubsup", [
+    "subscriptshift",
+    "superscriptshift",
+    "class",
+    "id",
+    "style",
+    "mathbackground",
+    "mathcolor",
+    "displaystyle",
+    "mathsize"
+  ])
+
+  Meta.allow_tag_with_these_attributes("m:msup", [
+    "superscriptshift",
+    "class",
+    "id",
+    "style",
+    "mathbackground",
+    "mathcolor",
+    "displaystyle",
+    "mathsize"
+  ])
+
+  Meta.allow_tag_with_these_attributes(
+    "m:mtable",
+    [
+      "align",
+      "columnalign",
+      "columnlines",
+      "columnspacing",
+      "frame",
+      "framespacing",
+      "rowalign",
+      "rowlines",
+      "width",
+      "class",
+      "id",
+      "style",
+      "mathbackground",
+      "mathcolor",
+      "displaystyle",
+      "mathsize"
+    ]
+  )
+
+  Meta.allow_tag_with_these_attributes("m:mtd", [
+    "columnalign",
+    "columnspan",
+    "rowalign",
+    "rowspan",
+    "class",
+    "id",
+    "style",
+    "mathbackground",
+    "mathcolor",
+    "displaystyle",
+    "mathsize"
+  ])
+
+  Meta.allow_tag_with_these_attributes("m:mtext", [
+    "dir",
+    "mathvariant",
+    "class",
+    "id",
+    "style",
+    "mathbackground",
+    "mathcolor",
+    "displaystyle",
+    "mathsize"
+  ])
+
+  Meta.allow_tag_with_these_attributes("m:mtr", [
+    "columnalign",
+    "rowalign",
+    "class",
+    "id",
+    "style",
+    "mathbackground",
+    "mathcolor",
+    "displaystyle",
+    "mathsize"
+  ])
+
+  Meta.allow_tag_with_these_attributes("m:munder", [
+    "accentunder",
+    "align",
+    "class",
+    "id",
+    "style",
+    "mathbackground",
+    "mathcolor",
+    "displaystyle",
+    "mathsize"
+  ])
+
+  Meta.allow_tag_with_these_attributes("m:munderover", [
+    "accent",
+    "accentunder",
+    "align",
+    "class",
+    "id",
+    "style",
+    "mathbackground",
+    "mathcolor",
+    "displaystyle",
+    "mathsize"
+  ])
+
+  Meta.allow_tag_with_these_attributes("m:semantics", [
+    "encoding",
+    "cd",
+    "name",
+    "class",
+    "id",
+    "style",
+    "mathbackground",
+    "mathcolor",
+    "displaystyle",
+    "mathsize"
+  ])
+
+  Meta.allow_tag_with_uri_attributes("m:semantics", ["src", "definitionURL"], @valid_schemes)
+
   Meta.strip_everything_not_covered()
 end

--- a/lib/oli_web/templates/layout/authoring.html.leex
+++ b/lib/oli_web/templates/layout/authoring.html.leex
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="authoring">
+<html lang="en" class="authoring" xmlns:m="http://www.w3.org/1998/Math/MathML">
   <head>
     <meta charset="utf-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>

--- a/lib/oli_web/templates/layout/chromeless.html.eex
+++ b/lib/oli_web/templates/layout/chromeless.html.eex
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="<%= if @preview_mode == true do %>preview<% else %>delivery<% end %>">
+<html lang="en" xmlns:m="http://www.w3.org/1998/Math/MathML" class="<%= if @preview_mode == true do %>preview<% else %>delivery<% end %>">
   <head>
     <meta charset="utf-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>

--- a/lib/oli_web/templates/layout/delivery.html.eex
+++ b/lib/oli_web/templates/layout/delivery.html.eex
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="delivery">
+<html lang="en" class="delivery" xmlns:m="http://www.w3.org/1998/Math/MathML">
   <head>
     <meta charset="utf-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>


### PR DESCRIPTION
This PR allows Torus to render MathML that contains the `m` namespace.  Two things were required:

1. Expand the mathml scrubbing configuration to whitelist all elements with that namespace
2. Add the namespace declaration to the root `<html>` element. 