### PR TITLE
[BUGFIX] Initial state can now modify customCSS of components [MER-1535]

### DIFF
--- a/assets/src/components/activities/adaptive/components/common/PartComponent.tsx
+++ b/assets/src/components/activities/adaptive/components/common/PartComponent.tsx
@@ -231,7 +231,7 @@ const PartComponent: React.FC<AuthorProps | DeliveryProps> = (props) => {
     ];
     const notifications = notificationsHandled.map((notificationType: NotificationType) => {
       const handler = (e: any) => {
-        /* console.log(`${notificationType.toString()} notification handled [PC : ${props.id}]`, e); */
+        // console.log(`${notificationType.toString()} notification handled [PC : ${props.id}]`, e);
         const el = ref.current;
         if (el) {
           if (el.notify) {
@@ -269,11 +269,18 @@ const PartComponent: React.FC<AuthorProps | DeliveryProps> = (props) => {
         return;
       }
       const handler = wcEvents[e.type];
+
       if (handler) {
         // TODO: refactor all handlers to take ID and send it here
         // console.log(`${e.type} event handled [PC : ${props.id}]`, e);
         try {
           const result = await handler(payload);
+
+          if (e.type === 'init' && result.snapshot) {
+            // The init event could end up changing stage.{id}.* properties that handleStylingChanges needs
+            handleStylingChanges(result.snapshot);
+          }
+
           if (e.type === 'resize') {
             handleResize(payload);
           }


### PR DESCRIPTION
There was a bug where a rule in the initial state of a screen that tried to set the customCssClass property of a component couldn't actually set it.

This was due to the lesson state being updated after the initial styles were set up in handleStylingChanges of PartComponent and not being updated after onInit was called.

customCssClass is special because it gets set on the web-component element itself, and not inside that webcomponent.

Note: The bug would have also affected these properties:

stage.${props.id}.IFRAME_frameX
stage.${props.id}.IFRAME_frameY
stage.${props.id}.IFRAME_frameZ
stage.${props.id}.IFRAME_frameWidth
stage.${props.id}.IFRAME_frameHeight
stage.${props.id}.IFRAME_frameCssClass
stage.${props.id}.customCssClass
