### PR TITLE
[BUG FIX] Fix activity editor rendering

### DIFF
--- a/assets/src/components/resource/editors/ActivityEditor.tsx
+++ b/assets/src/components/resource/editors/ActivityEditor.tsx
@@ -27,7 +27,7 @@ export const ActivityEditor = ({
 }: ActivityEditorProps) => {
   const activity = activities.get(contentItem.activitySlug);
 
-  const contentBreaksExist = (contentItem as any).children.some(
+  const contentBreaksExist = (contentItem as any).children?.some(
     (v: ResourceContent) => v.type === 'break',
   );
 


### PR DESCRIPTION
In some cases children can be undefined so this adds a check to ensure the editor doesn't crash in that case.