### PR TITLE
[BUG FIX] Handle scientific notation in ranges

### DIFF
--- a/assets/src/data/activities/model/rules.ts
+++ b/assets/src/data/activities/model/rules.ts
@@ -328,7 +328,7 @@ const matchBetweenRule = (rule: string): Maybe<InputRange> =>
 // e.g. `input = {[123.4,123.5]}` or`input = {(123.4,123.5)#3}`
 
 const matchRangeRule = (rule: string): Maybe<InputRange> =>
-  parseRegex(rule, /{([[(])\s*(-?[\d.]+(?:e-?\d+)?)\s*,\s*(-?[\d.]+(?:e-?\d+)?)\s*[\])]#?(\d+)?}/)
+  parseRegex(rule, /{([[(])\s*(-?[01234567890e.]+)\s*,\s*(-?[01234567890e.]+)\s*[\])]#?(\d+)?}/)
     .lift((matches) => ({
       bracketOrBrace: matches[1],
       matches: matches.slice(2, 5).map(maybeAsNumber),

--- a/assets/src/data/activities/model/rules.ts
+++ b/assets/src/data/activities/model/rules.ts
@@ -326,8 +326,9 @@ const matchBetweenRule = (rule: string): Maybe<InputRange> =>
 
 // Look for a range match, possibly with a precision
 // e.g. `input = {[123.4,123.5]}` or`input = {(123.4,123.5)#3}`
+
 const matchRangeRule = (rule: string): Maybe<InputRange> =>
-  parseRegex(rule, /{([[(])\s*(-?[.\d]+)\s*,\s*(-?[.\d]+)\s*[\])]#?(\d+)?}/)
+  parseRegex(rule, /{([[(])\s*(-?[\d.]+(?:e-?\d+)?)\s*,\s*(-?[\d.]+(?:e-?\d+)?)\s*[\])]#?(\d+)?}/)
     .lift((matches) => ({
       bracketOrBrace: matches[1],
       matches: matches.slice(2, 5).map(maybeAsNumber),

--- a/lib/oli/delivery/evaluation/rule.ex
+++ b/lib/oli/delivery/evaluation/rule.ex
@@ -140,10 +140,15 @@ defmodule Oli.Delivery.Evaluation.Rule do
   end
 
   defp is_range?(str), do: String.starts_with?(str, ["[", "("])
-  defp is_float?(str), do: String.contains?(str, ".")
+
+  defp is_float?(str),
+    do: String.contains?(str, ".") or (String.contains?(str, "e") and String.contains?(str, "."))
 
   defp parse_range(range_str) do
-    case Regex.run(~r/([[(])\s*(-?[.\d]+)\s*,\s*(-?[.\d]+)\s*[\])]#?(\d+)?/, range_str) do
+    case Regex.run(
+           ~r/([[(])\s*(-?[01234567890e.]+)\s*,\s*(-?[01234567890e.]+)\s*[\])]#?(\d+)?/,
+           range_str
+         ) do
       [_, "[", lower, upper | maybe_precision] ->
         {:inclusive, parse_number(lower), parse_number(upper), parse_precision(maybe_precision)}
 

--- a/test/oli/delivery/evaluation/rule_eval_test.exs
+++ b/test/oli/delivery/evaluation/rule_eval_test.exs
@@ -44,6 +44,9 @@ defmodule Oli.Delivery.Evaluation.RuleEvalTest do
   end
 
   test "evaluating ranges" do
+    # scientific notation inside the range, evaluates to true
+    assert eval("attemptNumber = {1} && input = {[3.0e5,4.0e5]}", "3.5e5") == true
+
     # float inside the range, evaluates to true
     assert eval("attemptNumber = {1} && input = {(3,4)}", "3.1") == true
     assert eval("attemptNumber = {1} && input = {(3.0,4)}", "3.1") == true


### PR DESCRIPTION
This PR expands rule parsing support in both author and server code to allow legacy range rules that contain scientific notation of the form `3.0e6`