### PR TITLE
[ENHANCEMENT] Format myresponse purpose types

### DIFF
--- a/assets/styles/authoring/variables.scss
+++ b/assets/styles/authoring/variables.scss
@@ -50,6 +50,7 @@ $content-purpose-learnbydoing-color: rgba(#00b894, 0.75) !default;
 $content-purpose-learnmore-color: rgba(#27ae60, 0.75) !default;
 $content-purpose-manystudentswonder-color: rgba(#42729b, 0.75) !default;
 $content-purpose-quiz-color: rgba(#3498db, 0.75) !default;
+$content-purpose-myresponse-color: rgba(#3498db, 0.75) !default;
 $content-purpose-simulation-color: rgba(#ff7675, 0.75) !default;
 $content-purpose-walkthrough-color: rgba(#536d86, 0.75) !default;
 $content-survey-color: rgba(#22a6b3, 0.75) !default;
@@ -137,6 +138,7 @@ $alternatives-group-background-color: $gray-100 !default;
   --content-purpose-learnmore-color: #{$content-purpose-learnmore-color};
   --content-purpose-manystudentswonder-color: #{$content-purpose-manystudentswonder-color};
   --content-purpose-quiz-color: #{$content-purpose-quiz-color};
+  --content-purpose-myresponse-color: #{$content-purpose-myresponse-color};
   --content-purpose-simulation-color: #{$content-purpose-simulation-color};
   --content-purpose-walkthrough-color: #{$content-purpose-walkthrough-color};
 

--- a/assets/styles/common/purpose.scss
+++ b/assets/styles/common/purpose.scss
@@ -187,6 +187,24 @@
     }
   }
 
+  &.myresponse {
+    border: 1px solid $content-purpose-myresponse-color;
+
+    & > .content-purpose-label {
+      background-color: $content-purpose-myresponse-color;
+      color: $white;
+
+      /** icon */
+      &::before {
+        font-family: 'Line Awesome Free';
+        font-weight: 900;
+        margin-left: 8px;
+        margin-right: 8px;
+        content: '\f681';
+      }
+    }
+  }
+
   &.simulation {
     border: 1px solid $content-purpose-simulation-color;
 
@@ -295,6 +313,10 @@
 
   &.quiz {
     @include page_link_style($content-purpose-quiz-color);
+  }
+
+  &.myresponse {
+    @include page_link_style($content-purpose-myresponse-color);
   }
 
   &.simulation {

--- a/assets/styles/delivery/variables.scss
+++ b/assets/styles/delivery/variables.scss
@@ -47,6 +47,7 @@ $content-purpose-learnbydoing-color: rgba(#00b894, 0.75) !default;
 $content-purpose-learnmore-color: rgba(#27ae60, 0.75) !default;
 $content-purpose-manystudentswonder-color: rgba(#42729b, 0.75) !default;
 $content-purpose-quiz-color: rgba(#3498db, 0.75) !default;
+$content-purpose-myresponse-color: rgba(#3498db, 0.75) !default;
 $content-purpose-simulation-color: rgba(#ff7675, 0.75) !default;
 $content-survey-color: rgba(#22a6b3, 0.75) !default;
 

--- a/assets/styles/themes/preview/default.scss
+++ b/assets/styles/themes/preview/default.scss
@@ -259,6 +259,7 @@ html.preview.dark {
   $content-purpose-learnmore-color: rgba(#27ae60, 0.75) !default;
   $content-purpose-manystudentswonder-color: rgba(#42729b, 0.75) !default;
   $content-purpose-quiz-color: rgba(#3498db, 0.75) !default;
+  $content-purpose-myresponse-color: rgba(#3498db, 0.75) !default;
   $content-purpose-simulation-color: rgba(#ff7675, 0.75) !default;
   $content-survey-color: rgba(#22a6b3, 0.75) !default;
 


### PR DESCRIPTION
Adds specific formatting for `myresponse` purpose types.  These render in the same blue as a few other purpose types. Along those lines, I think we should remove "color" as a differentiator for the types of groups or content on a page.  Its not accessible and it leads to some pages that have a mixture of different purpose types looking a bit clownish.  