### PR TITLE
[ENHANCEMENT] Ensure that there is state prior to submit [MER-1558]

### DIFF
--- a/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
@@ -222,13 +222,20 @@ export const MultiInputComponent: React.FC = () => {
     }
   };
 
+  const hasActualInput = (id: string) => {
+    const input = getByUnsafe((uiState.model as MultiInputSchema).inputs, (x) => x.id === id);
+    const partState = uiState.partState[input.partId];
+
+    return partState.studentInput[0].trim() !== '';
+  };
+
   // When inputs of type other than dropdown lose their focus:
   // 1. We flush pending changes, so we save their state if the student's next interaction is to navigate
   //    away to another page
   // 2. If submitPerPart is active, we then submit the part
   const onBlur = (id: string) => {
     const input = getByUnsafe((uiState.model as MultiInputSchema).inputs, (x) => x.id === id);
-    if (input.inputType !== 'dropdown') {
+    if (input.inputType !== 'dropdown' && hasActualInput(id)) {
       deferredSaves.current[id].flushPendingChanges(false);
       if ((uiState.model as MultiInputSchema).submitPerPart) {
         handlePerPartSubmission(input.partId);
@@ -238,9 +245,11 @@ export const MultiInputComponent: React.FC = () => {
 
   const onPressEnter = (id: string) => {
     const input = getByUnsafe((uiState.model as MultiInputSchema).inputs, (x) => x.id === id);
-    deferredSaves.current[id].flushPendingChanges(false);
-    if ((uiState.model as MultiInputSchema).submitPerPart) {
-      handlePerPartSubmission(input.partId);
+    if (hasActualInput(id)) {
+      deferredSaves.current[id].flushPendingChanges(false);
+      if ((uiState.model as MultiInputSchema).submitPerPart) {
+        handlePerPartSubmission(input.partId);
+      }
     }
   };
 


### PR DESCRIPTION
This PR adjusts the behavior of the multi input activity to only submit a part if there is actual student input present.  Prior to this PR, if a student (in a submit per part multiinput) clicked into an input to gain its focues then clicked away, that input would submit that part.  Same thing for pressing Enter.  Now, the parts only submit if there is actual student input present. 