### PR TITLE
[FEATURE] Upload media as content addressable storage [MER-1562]

### DIFF
--- a/test/oli/authoring/media_libary_test.exs
+++ b/test/oli/authoring/media_libary_test.exs
@@ -161,5 +161,13 @@ defmodule Oli.Authoring.MediaLibraryTest do
 
       assert hd(items).file_name == "100"
     end
+
+    test "upload_path/2 returns correct hashed path" do
+      assert MediaLibrary.upload_path("MyFile.txt", "here are the contents") ==
+               "/media/6B/6B43F3521620769F03BF4B1A1ECEA71F/MyFile.txt"
+
+      assert MediaLibrary.upload_path("MyFile2.txt", "here are some other contents") ==
+               "/media/8E/8E429C143925928F4DD1A659387DA90A/MyFile2.txt"
+    end
   end
 end


### PR DESCRIPTION
Fixes #3114 

Describe the bug
Torus should upload media to S3 as a content addressable storage and not include slug

To Reproduce
Steps to reproduce the behavior:

Upload an item, see that it contains the project slug in the media url


Example url from a local dev instance:
https://torus-media-dev.s3.amazonaws.com/media/14/14A94AA2B771544B9B66CF77A4DB0055/minus-circle.png
