### PR TITLE
[Bugfix] adaptive data bounce [MER-1561]

### DIFF
--- a/assets/src/apps/authoring/BottomPanel.tsx
+++ b/assets/src/apps/authoring/BottomPanel.tsx
@@ -64,7 +64,8 @@ export const BottomPanel: React.FC<BottomPanelProps> = (props: BottomPanelProps)
   const debounceSaveChanges = useCallback(
     debounce(
       (activity) => {
-        dispatch(saveActivity({ activity, undoable: true }));
+        // TODO - we could probably refactor this component to debounce inside saveActivity instead of here.
+        dispatch(saveActivity({ activity, undoable: true, immediate: true }));
       },
       500,
       { maxWait: 10000, leading: false },

--- a/assets/src/apps/authoring/components/AdaptiveRulesList/AdaptiveRulesList.tsx
+++ b/assets/src/apps/authoring/components/AdaptiveRulesList/AdaptiveRulesList.tsx
@@ -78,7 +78,8 @@ const AdaptiveRulesList: React.FC = () => {
   const debounceSaveChanges = useCallback(
     debounce(
       (activity) => {
-        dispatch(saveActivity({ activity, undoable: true }));
+        // TODO - we could probably refactor this component to debounce inside saveActivity instead of here.
+        dispatch(saveActivity({ activity, undoable: true, immediate: true }));
       },
       500,
       { maxWait: 10000, leading: false },

--- a/assets/src/apps/authoring/components/AdaptivityEditor/AdaptivityEditor.tsx
+++ b/assets/src/apps/authoring/components/AdaptivityEditor/AdaptivityEditor.tsx
@@ -179,7 +179,7 @@ export const AdaptivityEditor: React.FC<AdaptivityEditorProps> = () => {
         rule,
       });*/
 
-      dispatch(saveActivity({ activity: activityClone, undoable: true }));
+      dispatch(saveActivity({ activity: activityClone, undoable: true, immediate: true }));
       // setTimeout(() => dispatch(setCurrentRule({ currentRule: rule })));
     }
   };

--- a/assets/src/apps/authoring/components/AdaptivityEditor/InitStateEditor.tsx
+++ b/assets/src/apps/authoring/components/AdaptivityEditor/InitStateEditor.tsx
@@ -215,7 +215,7 @@ export const InitStateEditor: React.FC<InitStateEditorProps> = () => {
     const activityClone = clone(currentActivity);
     const initStateClone = clone(initState);
     activityClone.content.custom.facts = initStateClone;
-    dispatch(saveActivity({ activity: activityClone, undoable: true }));
+    dispatch(saveActivity({ activity: activityClone, undoable: true, immediate: true }));
     setIsDirty(false);
   }, [isDirty]);
 

--- a/assets/src/apps/authoring/components/ComponentToolbar/AddComponentToolbar.tsx
+++ b/assets/src/apps/authoring/components/ComponentToolbar/AddComponentToolbar.tsx
@@ -1,9 +1,7 @@
-import { saveActivity } from 'apps/authoring/store/activities/actions/saveActivity';
 import {
   selectCopiedPart,
   selectPartComponentTypes,
   selectPaths,
-  setCopiedPart,
   setRightPanelActiveTab,
 } from 'apps/authoring/store/app/slice';
 

--- a/assets/src/apps/authoring/components/ComponentToolbar/ComponentSearchContextMenu.tsx
+++ b/assets/src/apps/authoring/components/ComponentToolbar/ComponentSearchContextMenu.tsx
@@ -59,7 +59,7 @@ const ComponentSearchContextMenu: React.FC = () => {
   const updateActivityTreeParts = (list: any) => {
     const activity = cloneDeep((currentActivityTree || []).slice(-1)[0]);
     activity.content.partsLayout = list;
-    dispatch(saveActivity({ activity, undoable: true }));
+    dispatch(saveActivity({ activity, undoable: true, immediate: true }));
   };
 
   const moveComponentUp = (event: any, part: any, index: number) => {

--- a/assets/src/apps/authoring/components/EditingCanvas/AuthoringActivityRenderer.tsx
+++ b/assets/src/apps/authoring/components/EditingCanvas/AuthoringActivityRenderer.tsx
@@ -128,7 +128,7 @@ const AuthoringActivityRenderer: React.FC<AuthoringActivityRendererProps> = ({
       if (target?.id === elementProps.id) {
         const { model } = e.detail;
         /* console.log('AAR handleActivityEdit', { model }); */
-        dispatch(saveActivity({ activity: model, undoable: true }));
+        dispatch(saveActivity({ activity: model, undoable: true, immediate: true }));
         // why were we clearing the selection on edit?...
         // dispatch(setCurrentSelection({ selection: '' }));
         // dispatch(setRightPanelActiveTab({ rightPanelActiveTab: RightPanelTabs.SCREEN }));

--- a/assets/src/apps/authoring/components/Modal/diagnostics/actions.ts
+++ b/assets/src/apps/authoring/components/Modal/diagnostics/actions.ts
@@ -51,7 +51,7 @@ export const updateRule = (rule: any, problem: any, activities: any) => {
     const rulesClone = activity ? [...activity.authoring.rules] : [];
     rulesClone[activity?.authoring.rules.indexOf(existing)] = rule;
     activityClone.authoring.rules = rulesClone;
-    return saveActivity({ activity: activityClone, undoable: true });
+    return saveActivity({ activity: activityClone, undoable: true, immediate: true });
   }
 };
 
@@ -129,7 +129,7 @@ export const updateInitComponentPath =
       const factsClone = activity ? [...activity.content.custom.facts] : [];
       factsClone[activity?.content.custom.facts.indexOf(existing)] = factClone;
       activityClone.content.custom.facts = factsClone;
-      return saveActivity({ activity: activityClone, undoable: true });
+      return saveActivity({ activity: activityClone, undoable: true, immediate: true });
     }
   };
 

--- a/assets/src/apps/authoring/components/PropertyEditor/PropertyEditor.tsx
+++ b/assets/src/apps/authoring/components/PropertyEditor/PropertyEditor.tsx
@@ -66,13 +66,13 @@ const PropertyEditor: React.FC<PropertyEditorProps> = ({
         if (shouldTriggerChange || changedPropType === 'boolean') {
           // because 'id' is used to maintain selection, it MUST be onBlur or else bad things happen
           if (updatedData.id === formData.id) {
-            /* console.log('ONCHANGE P EDITOR TRIGGERED', {
-              e,
-              updatedData,
-              changedProp,
-              changedPropType,
-              triggerOnChange,
-            }); */
+            // console.log('ONCHANGE P EDITOR TRIGGERED', {
+            //   e,
+            //   updatedData,
+            //   changedProp,
+            //   changedPropType,
+            //   triggerOnChange,
+            // });
             onChangeHandler(updatedData);
           }
         }

--- a/assets/src/apps/authoring/components/PropertyEditor/schemas/lesson.ts
+++ b/assets/src/apps/authoring/components/PropertyEditor/schemas/lesson.ts
@@ -216,7 +216,7 @@ export const transformSchemaToModel = (schema: any) => {
     additionalStylesheets,
     title: schema.Properties.title,
     customCss: schema.Properties.customCSS || '',
-    customScript: schema.CustomLogic.customScript,
+    customScript: schema.CustomLogic.customScript || '',
   };
 };
 

--- a/assets/src/apps/authoring/components/SequenceEditor/SequenceEditor.tsx
+++ b/assets/src/apps/authoring/components/SequenceEditor/SequenceEditor.tsx
@@ -130,7 +130,7 @@ const SequenceEditor: React.FC<any> = () => {
       title: newTitle,
       tags: [],
     };
-    dispatch(saveActivity({ activity: reduxActivity, undoable: false }));
+    dispatch(saveActivity({ activity: reduxActivity, undoable: false, immediate: true }));
     await dispatch(upsertActivity({ activity: reduxActivity }));
     addNewSequence(newSequenceEntry, currentActivity?.activitySlug);
   };
@@ -329,7 +329,7 @@ const SequenceEditor: React.FC<any> = () => {
     copiedActivity.resourceId = newActivity.resourceId;
     copiedActivity.activitySlug = newActivity.activitySlug;
     copiedActivity.title = newTitle;
-    dispatch(saveActivity({ activity: copiedActivity, undoable: false }));
+    dispatch(saveActivity({ activity: copiedActivity, undoable: false, immediate: true }));
     await dispatch(upsertActivity({ activity: copiedActivity }));
     addNewSequence(newSequenceEntry, item.activitySlug);
   };

--- a/assets/src/apps/authoring/store/activities/actions/saveActivity.ts
+++ b/assets/src/apps/authoring/store/activities/actions/saveActivity.ts
@@ -27,7 +27,10 @@ import { SAVE_DEBOUNCE_TIMEOUT, SAVE_DEBOUNCE_OPTIONS } from '../../persistance-
 
 export const saveActivity = createAsyncThunk(
   `${ActivitiesSlice}/saveActivity`,
-  async (payload: { activity: IActivity; undoable?: boolean }, { dispatch, getState }) => {
+  async (
+    payload: { activity: IActivity; undoable?: boolean; immediate?: boolean },
+    { dispatch, getState },
+  ) => {
     try {
       const { activity, undoable = true } = payload;
       const rootState = getState() as any;
@@ -68,6 +71,9 @@ export const saveActivity = createAsyncThunk(
         const debouncedEdit = getDebouncedEdit(String(activity.id));
 
         debouncedEdit(projectSlug, resourceId, activity.resourceId as number, changeData, false);
+        if (payload.immediate) {
+          await debouncedEdit.flush();
+        }
 
         // grab the activity before it's updated for the score check
         const oldActivityData = selectActivityById(rootState, activity.resourceId as number);

--- a/assets/src/apps/authoring/store/page/actions/initializeFromContext.ts
+++ b/assets/src/apps/authoring/store/page/actions/initializeFromContext.ts
@@ -71,7 +71,7 @@ export const initializeFromContext = createAsyncThunk(
       const { payload: newGroup } = await dispatch(createNewGroup({ children: newSequence }));
 
       // write model to server now or else the above created activity will be orphaned
-      await dispatch(savePage({ undoable: true }));
+      await dispatch(savePage({ undoable: true, immiediate: true }));
 
       pageModel = [newGroup];
     }

--- a/assets/src/apps/authoring/store/page/actions/savePage.ts
+++ b/assets/src/apps/authoring/store/page/actions/savePage.ts
@@ -16,6 +16,7 @@ import { SAVE_DEBOUNCE_OPTIONS, SAVE_DEBOUNCE_TIMEOUT } from '../../persistance-
 
 export interface PagePayload extends Partial<PageState> {
   undoable?: boolean;
+  immiediate?: boolean; // Do not debounce the save.
 }
 
 export const savePage = createAsyncThunk(
@@ -72,7 +73,7 @@ export const savePage = createAsyncThunk(
         if (sequenceItem.custom.isLayer || sequenceItem.custom.isBank) {
           return acc;
         }
-        const currActivity = allActivities.find((a) => a.id === sequenceItem.resourceId);
+        const currActivity: any = allActivities.find((a) => a.id === sequenceItem.resourceId);
         if (!currActivity) {
           return acc;
         }
@@ -109,6 +110,9 @@ export const savePage = createAsyncThunk(
     }
 
     _edit(projectSlug, revisionSlug, update, dispatch);
+    if (payload.immiediate) {
+      await _edit.flush();
+    }
   },
 );
 

--- a/assets/src/apps/authoring/store/parts/actions/updatePart.ts
+++ b/assets/src/apps/authoring/store/parts/actions/updatePart.ts
@@ -80,6 +80,7 @@ export const updatePart = createAsyncThunk(
           }
         });
         if (activitiesToUpdate.length) {
+          console.info('Bulk saving', activitiesToUpdate.map((a) => a.id).join(', '));
           await dispatch(bulkSaveActivity({ activities: activitiesToUpdate, undoable: false }));
           undo.unshift(bulkSaveActivity({ activities: orig, undoable: false }));
           redo.unshift(bulkSaveActivity({ activities: activitiesToUpdate, undoable: false }));

--- a/assets/src/apps/authoring/store/persistance-options.ts
+++ b/assets/src/apps/authoring/store/persistance-options.ts
@@ -1,0 +1,3 @@
+/** Some common options for debouncing server-put operations for updating resources. */
+export const SAVE_DEBOUNCE_TIMEOUT = 500;
+export const SAVE_DEBOUNCE_OPTIONS = { maxWait: 10000, leading: false };


### PR DESCRIPTION
### Description of bug:

This bug is for the right-hand panel, but in a lot of places in the adaptive lesson editor, if you:

1.  Edit something
2.  Then edit something else before 1 finishes saving
3.  Your edit to 2 will be reset to data before 1.


**Easiest way I can reproduce this:**

Let’s say I want to change my dimensions from 700x500 to 800x600

![image](https://user-images.githubusercontent.com/333265/203076092-dd9cea34-d0e7-4997-9a85-d73842434b36.png)

I might type in 800, hit tab, type in 600 and expect those values to be there.

In reality what usually happens is I type in 800, hit tab, start typing 600, maybe get one or two characters in, and then it resets to 500 and I finish typing. So on each keypress I might get:

- 500 <- starting
- 6     <- typed 6
- 60   <- typed 0
- 500 <- it resets to the original on it’s own
- 5000 <- I type my last 0

 
**A similar symptom of the same type of issue:**

- You edit a value.
- You briefly see the old value.
- You then see your new value.


### Cause of bug

The main cause of this sort of bug is trying to debounce the saving of data to torus too soon.

We have a few redux-thunk actions (such as saveActivity) that actually do two things:

- Save the data to torus
- Update our internal data model

Previously, the entire saveActivity was getting wrapped in a debounce, which means our internal data update was also getting debounced, effectively delaying a change by a minimum of half a second. It's that half-second that was causing this bug since you might make other changes during it, and then that time elapses and reverts your change.

This fix moves the debounce from around saveActivity to around just the torus api call. That way our internal state immediately updates.

This PR only fixes the bug from happening in the right-hand panel, where it was most obvious. We may want similar changes in the future if other areas of the app are experiencing similar issues.
