### PR TITLE
[BugFix] Don't recreate the authoring element when configured. [MER-1565]

### DIFF
--- a/assets/src/components/activities/adaptive/components/authoring/LayoutEditor.tsx
+++ b/assets/src/components/activities/adaptive/components/authoring/LayoutEditor.tsx
@@ -529,8 +529,7 @@ const LayoutEditor: React.FC<LayoutEditorProps> = (props) => {
           };
 
           const disableDrag =
-            part.id === configurePartId ||
-            (selectedPartAndCapabilities && !selectedPartAndCapabilities.capabilities.move);
+            selectedPartAndCapabilities && !selectedPartAndCapabilities.capabilities.move;
 
           return (
             <ResizeContainer


### PR DESCRIPTION
This PR introduced a bug: https://github.com/Simon-Initiative/oli-torus/pull/3129

When a component in the adaptive editor went into configure mode, it would get re-created as a new component and any internal state would be lost.

This was the cause of MER-1565

- Edit an adaptive lesson
- Add an MCQ question
- Click the edit button
- Click the edit button on an option

Expected: an editor for that option

Actual: An empty window with no editor in it.


Note: There is some kind of bug inside the quill editor as well. It doesn't happen all the time, but sometimes, it doesn't dispatch change events and the individual options aren't changed. I was able to reproduce this on prod, and tracked it down to something inside the editor itself. Pressing space-bar seems to always cause a change to come through.