### PR TITLE
[BUGFIX] Fixes many-paragraph insert normalization bug [MER-1566]

### DIFF
--- a/assets/src/components/editing/editor/normalizers/root.ts
+++ b/assets/src/components/editing/editor/normalizers/root.ts
@@ -11,9 +11,13 @@ export const normalize = (editor: Editor, node: Editor, _path: Path) => {
   const first = node.children[0];
   const last = node.children[node.children.length - 1];
   if (!isBlockText(first)) {
+    // Using a hard-coded path here instead of Editor.start(editor, []) to fix
+    // https://github.com/Simon-Initiative/oli-torus/issues/3082
+    // Editor.start(editor, []) was returning [0,0] which corresponded to the first
+    // text node in the first element, even if it was a void node.
     Transforms.insertNodes(editor, Model.p(), {
       mode: 'highest',
-      at: Editor.start(editor, []),
+      at: [0],
     });
     console.warn('Normalizing content: Inserted paragraph at start of document');
     return;


### PR DESCRIPTION
Fixes bug:

1. Create a core authoring page
2. Insert an image
3. Edit the page in the admin view and make the image the very first element with no paragraph before it.
4. Go back to normal page editor
5. Make any change

You’ll see this warning in the console many times (should only happen once)

react_devtools_backend.js:4026 Normalizing content: Inserted paragraph at start of document

And there will be many empty lines after your image.

Fixes #3082