### PR TITLE
[BUGFIX] Fix media-browser bug by using local dispatch [MER-1575]

### DIFF
--- a/assets/src/components/editing/elements/video/VideoSettings.tsx
+++ b/assets/src/components/editing/elements/video/VideoSettings.tsx
@@ -8,6 +8,7 @@ import { Toolbar } from 'components/editing/toolbar/Toolbar';
 
 import * as ContentModel from 'data/content/model/elements/types';
 import { VideoModal } from './VideoModal';
+import { useDispatch } from 'react-redux';
 
 interface SettingsProps {
   commandContext: CommandContext;
@@ -36,25 +37,28 @@ interface SettingsButtonProps {
   onEdit: (attrs: Partial<ContentModel.Video>) => void;
 }
 
-const SettingsButton = (props: SettingsButtonProps) => (
-  <DescriptiveButton
-    description={createButtonCommandDesc({
-      icon: 'play_circle_filled',
-      description: 'Settings',
-      execute: (_context, _editor, _params) =>
-        window.oliDispatch(
-          modalActions.display(
-            <VideoModal
-              projectSlug={props.projectSlug}
-              model={props.model}
-              onDone={(video: Partial<ContentModel.Video>) => {
-                window.oliDispatch(modalActions.dismiss());
-                props.onEdit(video);
-              }}
-              onCancel={() => window.oliDispatch(modalActions.dismiss())}
-            />,
+const SettingsButton = (props: SettingsButtonProps) => {
+  const dispatch = useDispatch();
+  return (
+    <DescriptiveButton
+      description={createButtonCommandDesc({
+        icon: 'play_circle_filled',
+        description: 'Settings',
+        execute: (_context, _editor, _params) =>
+          dispatch(
+            modalActions.display(
+              <VideoModal
+                projectSlug={props.projectSlug}
+                model={props.model}
+                onDone={(video: Partial<ContentModel.Video>) => {
+                  dispatch(modalActions.dismiss());
+                  props.onEdit(video);
+                }}
+                onCancel={() => window.oliDispatch(modalActions.dismiss())}
+              />,
+            ),
           ),
-        ),
-    })}
-  />
-);
+      })}
+    />
+  );
+};


### PR DESCRIPTION
1. Create a core authoring page
2. Add a video to the page & set a video.
3. Add an MCQ to the page
4. Now try to edit the video and change the cover image

Expected: Media browser
Actual: Error message

 

Cause of bug:

Both the PageEditor and the MCQ editor have a `<ModalDisplay />` component.
Those components are in different redux contexts.
The ModalDisplay sets a global window.oliDispatch method.
That oliDispatch will now only work from components that originate in the same redux context as the second ModalDisplay, but the second one overwrote the window.oliDispatch from the first instance of it, so all calls will reference the second one.

This causes the bug in the video-editor because we render the media browser in a panel in the same UI instead of a popup modal which causes the store-mismatch.

Overall, having a global variable on window like this might be something we should re-think, but I made a more localized fix for just the video modal since that's the only place I could find this bug occuring.


