### PR TITLE
[ENHANCEMENT] Appsignal support in client authoring apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Enhancements
 
 - Add tab for authoring 'explanation' feedback to all activities
+- Add client side reporting to appsignal for core and adaptive authoring.
 
 ## 0.21.5 (2022-09-01)
 

--- a/assets/package.json
+++ b/assets/package.json
@@ -22,6 +22,11 @@
     "sdk-docs": "npx typedoc --tsconfig tsconfig.sdk.json --plugin typedoc-plugin-markdown  --out typedocs src/components/activities/index.ts"
   },
   "dependencies": {
+    "@appsignal/javascript": "^1.3.24",
+    "@appsignal/plugin-breadcrumbs-console": "^1.1.25",
+    "@appsignal/plugin-breadcrumbs-network": "^1.1.21",
+    "@appsignal/plugin-window-events": "^1.0.18",
+    "@appsignal/react": "^1.0.21",
     "@reduxjs/toolkit": "^1.5.1",
     "@restart/hooks": "^0.3.26",
     "@rjsf/bootstrap-4": "^3.0.0",

--- a/assets/src/components/common/ErrorBoundary.tsx
+++ b/assets/src/components/common/ErrorBoundary.tsx
@@ -4,6 +4,7 @@ import { Collapse } from 'components/common/Collapse';
 import Appsignal from '@appsignal/javascript';
 
 export const AppsignalContext = React.createContext<Appsignal | null>(null);
+AppsignalContext.displayName = 'Appsignal';
 
 const DefaultErrorMessage = () => (
   <>

--- a/assets/src/components/common/ErrorBoundary.tsx
+++ b/assets/src/components/common/ErrorBoundary.tsx
@@ -1,6 +1,9 @@
 import React, { ErrorInfo } from 'react';
 import guid from 'utils/guid';
 import { Collapse } from 'components/common/Collapse';
+import Appsignal from '@appsignal/javascript';
+
+export const AppsignalContext = React.createContext<Appsignal | null>(null);
 
 const DefaultErrorMessage = () => (
   <>
@@ -11,6 +14,8 @@ const DefaultErrorMessage = () => (
     <p>If the problem persists, contact support with the following details:</p>
   </>
 );
+
+let lastReported: any = null;
 
 export class ErrorBoundary extends React.Component<
   { errorMessage?: React.ReactNode; children: React.ReactNode },
@@ -28,6 +33,14 @@ export class ErrorBoundary extends React.Component<
   componentDidCatch(error: Error, info: ErrorInfo) {
     // tslint:disable-next-line
     console.error(error);
+    if (this.context) {
+      if (lastReported !== error) {
+        // lastReported is in case you have nested ErrorBoundaries so you only report an error once.
+        const appsignal = this.context;
+        appsignal.sendError(error);
+        lastReported = error;
+      }
+    }
 
     this.setState({ hasError: true, error, info });
   }
@@ -61,3 +74,5 @@ export class ErrorBoundary extends React.Component<
     }
   }
 }
+
+ErrorBoundary.contextType = AppsignalContext;

--- a/assets/src/components/parts/janus-image/Image.tsx
+++ b/assets/src/components/parts/janus-image/Image.tsx
@@ -115,6 +115,7 @@ const Image: React.FC<PartComponentProps<ImageModel>> = (props) => {
 
     props.onResize({ id: `${id}`, settings: styleChanges });
   }, [width, height]);
+
   return ready ? (
     <img data-janus-type={tagName} draggable="false" alt={alt} src={src} style={imageStyles} />
   ) : null;

--- a/assets/src/utils/appsignal.ts
+++ b/assets/src/utils/appsignal.ts
@@ -14,6 +14,7 @@ export const initAppSignal = (
 
   const client = new Appsignal({
     key: apiKey,
+    namespace: appName,
   });
   client.use(AppsignalConsoleBreadcrumbs.plugin());
   client.use(AppsignalNetworkBreadcrumbs.plugin());

--- a/assets/src/utils/appsignal.ts
+++ b/assets/src/utils/appsignal.ts
@@ -1,0 +1,29 @@
+import Appsignal from '@appsignal/javascript';
+import * as AppsignalConsoleBreadcrumbs from '@appsignal/plugin-breadcrumbs-console';
+import * as AppsignalNetworkBreadcrumbs from '@appsignal/plugin-breadcrumbs-network';
+import * as AppsignalWindowEvents from '@appsignal/plugin-window-events';
+
+export const initAppSignal = (
+  apiKey: string | null,
+  appName: string,
+  metadata: Record<string, string>,
+) => {
+  if (!apiKey) {
+    return null;
+  }
+
+  const client = new Appsignal({
+    key: apiKey,
+  });
+  client.use(AppsignalConsoleBreadcrumbs.plugin());
+  client.use(AppsignalNetworkBreadcrumbs.plugin());
+  client.use(AppsignalWindowEvents.plugin()); // <- This handles onerror / onunhandledrejection, we'll want to watch the volume of events this generates.
+
+  client.addBreadcrumb({
+    category: 'launch',
+    action: appName + ' Launched',
+    metadata,
+  });
+
+  return client;
+};

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -2,6 +2,59 @@
 # yarn lockfile v1
 
 
+"@appsignal/core@=1.1.18":
+  version "1.1.18"
+  resolved "https://registry.yarnpkg.com/@appsignal/core/-/core-1.1.18.tgz#853e1197d2fbc8a5a10cadd90666c85d9569e6cf"
+  integrity sha512-PfFxEn6CNiX6PR6P582N5cV+5/j3tCmn1v6G+0nHrj8GY4Dir+vqJtGbgUxda0kbtCa6B4OHMH7Pe/SGL92rKw==
+  dependencies:
+    "@appsignal/types" "=3.0.0"
+    isomorphic-unfetch "^3.1.0"
+    tslib "^2.3.0"
+
+"@appsignal/javascript@=1.3.24", "@appsignal/javascript@^1.3.24":
+  version "1.3.24"
+  resolved "https://registry.yarnpkg.com/@appsignal/javascript/-/javascript-1.3.24.tgz#215be46ac926e2a7b1dfd29c880733c675d61523"
+  integrity sha512-YgXEGJNmXcdGI6122mcJ3e/hYAN0jQ4Z0VoOkh90sewZ0EYe6Z6kMZ5A7kDAM71h6dzW6eeXU9JGcJL2524ASg==
+  dependencies:
+    "@appsignal/core" "=1.1.18"
+    "@appsignal/types" "=3.0.0"
+    tslib "^2.3.0"
+
+"@appsignal/plugin-breadcrumbs-console@^1.1.25":
+  version "1.1.25"
+  resolved "https://registry.yarnpkg.com/@appsignal/plugin-breadcrumbs-console/-/plugin-breadcrumbs-console-1.1.25.tgz#19a2556cc8920342c2945e1900a32bc4de3f7cd2"
+  integrity sha512-4eamlB+ecHGTvjzhyhNFbmRpNu4J9Gf0qyqmCFxeXzmFt3lSUpM1o+pOaJhxfsNnMAq3NXmuSnIGtf01bk4KhA==
+  dependencies:
+    "@appsignal/javascript" "=1.3.24"
+
+"@appsignal/plugin-breadcrumbs-network@^1.1.21":
+  version "1.1.21"
+  resolved "https://registry.yarnpkg.com/@appsignal/plugin-breadcrumbs-network/-/plugin-breadcrumbs-network-1.1.21.tgz#fda093a529157c497da00f81e2d673f910f57a62"
+  integrity sha512-axs/EUgtAMBH9Y5OFoEugf+cFBmQkNTxYjVnqRjyZ1NOww5LUW4bmU22llh4O38UeqphFEG0YtEh3bKdR+UIVA==
+  dependencies:
+    "@appsignal/types" "=3.0.0"
+
+"@appsignal/plugin-window-events@^1.0.18":
+  version "1.0.18"
+  resolved "https://registry.yarnpkg.com/@appsignal/plugin-window-events/-/plugin-window-events-1.0.18.tgz#a8555bd03ddfa535af99dc7bc8b045d39c70255f"
+  integrity sha512-mJfaiTBJ9ACX03aAFhHs9FGwsCjXkE9T86UWq2oZWLL0zADMoQTYlFbPjDvBgE+paU40ZYk2gt1M/uR7tUCUvg==
+  dependencies:
+    "@appsignal/core" "=1.1.18"
+    "@appsignal/types" "=3.0.0"
+
+"@appsignal/react@^1.0.21":
+  version "1.0.21"
+  resolved "https://registry.yarnpkg.com/@appsignal/react/-/react-1.0.21.tgz#ac262e572cb68fc6fac8d90f8114f274c9397b73"
+  integrity sha512-l2XeJNUzVATGTr4TRBlgfCQbwF+o1/2Vw89g4azzJAs8Imoj+04uLMr6EUki34PgPRfxHRUOrNGPmT89g1+fCQ==
+  dependencies:
+    "@appsignal/core" "=1.1.18"
+    "@appsignal/types" "=3.0.0"
+
+"@appsignal/types@=3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@appsignal/types/-/types-3.0.0.tgz#7cbfe9220224d6631954610688fa9a8f6c531f75"
+  integrity sha512-L0OAKaro7209Du39UF2ZWU8CzUJxeeKaW6Zyu2FA2SGdW3HK0PoJxY7A8R52KdZiXzMlCAlrOjvoDvT/ct0RIg==
+
 "@babel/code-frame@7.12.11":
   version "7.12.11"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz"
@@ -5997,6 +6050,14 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
+isomorphic-unfetch@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz#87341d5f4f7b63843d468438128cb087b7c3e98f"
+  integrity sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==
+  dependencies:
+    node-fetch "^2.6.1"
+    unfetch "^4.2.0"
+
 istanbul-lib-coverage@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz"
@@ -7167,6 +7228,13 @@ nise@^4.0.4:
     "@sinonjs/text-encoding" "^0.7.1"
     just-extend "^4.0.2"
     path-to-regexp "^1.7.0"
+
+node-fetch@^2.6.1:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -9425,6 +9493,11 @@ tr46@^2.1.0:
   dependencies:
     punycode "^2.1.1"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
 trim-newlines@^3.0.0:
   version "3.0.1"
   resolved "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz"
@@ -9470,6 +9543,11 @@ tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.3.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
+  integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
 
 tsmonad@^0.8.0:
   version "0.8.0"
@@ -9615,6 +9693,11 @@ underscore@1.12.1:
   version "1.12.1"
   resolved "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz"
   integrity sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==
+
+unfetch@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.2.0.tgz#7e21b0ef7d363d8d9af0fb929a5555f6ef97a3be"
+  integrity sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
@@ -9823,6 +9906,11 @@ watchpack@^2.3.1:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
 webidl-conversions@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz"
@@ -9933,6 +10021,14 @@ whatwg-mimetype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 whatwg-url@^8.0.0, whatwg-url@^8.5.0:
   version "8.7.0"

--- a/config/config.exs
+++ b/config/config.exs
@@ -195,6 +195,8 @@ config :mnesia,
 
 config :appsignal, :config, revision: System.get_env("SHA", default_sha)
 
+config :appsignal, :client_key, System.get_env("APPSIGNAL_PUSH_API_KEY", nil)
+
 config :surface, :components, [
   {
     Surface.Components.Form.ErrorTag,

--- a/lib/oli/authoring/editing/page_context.ex
+++ b/lib/oli/authoring/editing/page_context.ex
@@ -15,6 +15,7 @@ defmodule Oli.Authoring.Editing.ResourceContext do
     :activityContexts,
     :resourceId,
     :featureFlags,
+    :appsignalKey,
     # these fields are not JSON encoded
     :project,
     :previous_page,

--- a/lib/oli/authoring/editing/page_editor.ex
+++ b/lib/oli/authoring/editing/page_editor.ex
@@ -245,7 +245,8 @@ defmodule Oli.Authoring.Editing.PageEditor do
          project: publication.project,
          previous_page: previous,
          next_page: next,
-         collab_space_config: collab_space_config
+         collab_space_config: collab_space_config,
+         appsignalKey: Application.get_env(:appsignal, :client_key)
        }}
     else
       _ -> {:error, :not_found}

--- a/lib/oli_web/controllers/resource_controller.ex
+++ b/lib/oli_web/controllers/resource_controller.ex
@@ -50,7 +50,8 @@ defmodule OliWeb.ResourceController do
           images: Routes.static_path(conn, "/images")
         },
         activityTypes: activity_types,
-        partComponentTypes: PartComponents.part_components_for_project(project)
+        partComponentTypes: PartComponents.part_components_for_project(project),
+        appsignalKey: Application.get_env(:appsignal, :client_key)
       },
       active: :curriculum,
       activity_types: activity_types,


### PR DESCRIPTION
This adds appsignal support in the core & adaptive authoring environments to report on client side errors.

We'll get a report on:

- An error in the react error-boundary
- An uncaught exception
- An unhandled promise rejection

We'll need to watch the second two of those to see the volume of useful / not-useful reports we get, since sometimes things like browser-extensions can trip them.

On launch, I added a breadcrumb with the projectSlug, resourceSlug and resourceId to help track down issues. Then we also get breadcrumbs for console messages and fetch requests. (All of that only gets logged on an actual error)

![image](https://user-images.githubusercontent.com/333265/204815789-29abcedf-ff71-43d0-b4c0-56d071438d0f.png)

We also get a stacktrace

![image](https://user-images.githubusercontent.com/333265/204816086-6d5b65c8-c7e2-4aa4-ac57-4c8e011df4f7.png)

The errors will be in separate appsignal namespaces for the two apps.

![image](https://user-images.githubusercontent.com/333265/204828667-5b768289-3c34-4b91-90e7-094d9bd01b72.png)

The client uses the appsignal API key that the elixir backend uses from the environmental variable APPSIGNAL_PUSH_API_KEY. If you're not using appsignal, simply omit that variable.


If the stacktraces prove to not be valuable, in the future, we can upload source-maps to appsignal as part of the build/release process.
