### PR TITLE
[ENHANCEMENT] add code lens link to open activity revision history

### DIFF
--- a/assets/src/components/monaco_lenses/activity_links_lens.ts
+++ b/assets/src/components/monaco_lenses/activity_links_lens.ts
@@ -1,0 +1,64 @@
+import { editor } from 'monaco-editor';
+import { IMonacoEditor } from '@uiw/react-monacoeditor';
+
+export interface ActivityLinksLensArgs {
+  projectSlug: string;
+}
+
+export function activityLinksLens(
+  editor: editor.IStandaloneCodeEditor,
+  monaco: IMonacoEditor,
+  { projectSlug }: ActivityLinksLensArgs,
+) {
+  monaco.languages.registerCodeLensProvider('json', {
+    provideCodeLenses: function (model: any, token: any) {
+      const value = model.getValue() as string;
+      const lines = value.split('\n');
+
+      const lenses = lines.reduce((acc, line: string, lineNumber: number) => {
+        const activityIdRegex = /"activity_id":\s*(\d+)/;
+
+        if (activityIdRegex.test(line)) {
+          const [_match, activityId] = activityIdRegex.exec(line) as RegExpExecArray;
+
+          const commandId = editor.addCommand(
+            0,
+            function () {
+              // services available in `ctx`
+              // alert('Open Activity ' + activityId);
+              window.open(`/project/${projectSlug}/history/resource_id/${activityId}`, '_blank');
+            },
+            '',
+          ) as string;
+
+          return [
+            ...acc,
+            {
+              range: {
+                startLineNumber: lineNumber + 1,
+                startColumn: 1,
+                endLineNumber: lineNumber + 1,
+                endColumn: 1,
+              },
+              id: `Activity Ref ${lineNumber}`,
+              command: {
+                id: commandId,
+                title: 'Open Activity Revision History',
+              },
+            },
+          ];
+        }
+
+        return acc;
+      }, []);
+
+      return {
+        lenses,
+        dispose: () => {},
+      };
+    },
+    resolveCodeLens: function (model: any, codeLens: any, token: any) {
+      return codeLens;
+    },
+  });
+}

--- a/assets/src/components/monaco_lenses/activity_links_lens.ts
+++ b/assets/src/components/monaco_lenses/activity_links_lens.ts
@@ -24,8 +24,6 @@ export function activityLinksLens(
           const commandId = editor.addCommand(
             0,
             function () {
-              // services available in `ctx`
-              // alert('Open Activity ' + activityId);
               window.open(`/project/${projectSlug}/history/resource_id/${activityId}`, '_blank');
             },
             '',

--- a/assets/src/components/monaco_lenses/index.ts
+++ b/assets/src/components/monaco_lenses/index.ts
@@ -1,0 +1,10 @@
+import { activityLinksLens } from './activity_links_lens';
+
+export function registry(name: string) {
+  switch (name) {
+    case 'activity-links':
+      return activityLinksLens;
+    default:
+      throw `Unknown monaco code lens '${name}'`;
+  }
+}

--- a/assets/src/utils/surface.ts
+++ b/assets/src/utils/surface.ts
@@ -1,4 +1,3 @@
-import { Hooks } from 'hooks';
 import { Maybe } from 'tsmonad';
 
 interface SurfaceAttribute {

--- a/lib/oli_web/live/common/monaco_editor.ex
+++ b/lib/oli_web/live/common/monaco_editor.ex
@@ -15,6 +15,7 @@ defmodule OliWeb.Common.MonacoEditor do
   prop on_mount, :event
   prop on_change, :event
   prop get_value, :event
+  prop use_code_lenses, :list
 
   def render(assigns) do
     ~F"""
@@ -34,7 +35,8 @@ defmodule OliWeb.Common.MonacoEditor do
       data-set-options={encode_attr(@set_options)}
       data-set-width-height={encode_attr(@set_width_height)}
       data-set-value={encode_attr(@set_value)}
-      data-get-value={encode_attr(@get_value)}>
+      data-get-value={encode_attr(@get_value)}
+      data-use-code-lenses={if @use_code_lenses, do: encode_attr(@use_code_lenses)}>
       <div class="text-center">
         <div class="spinner-border text-secondary" role="status">
           <span class="sr-only">Loading...</span>

--- a/lib/oli_web/live/history/details.ex
+++ b/lib/oli_web/live/history/details.ex
@@ -27,8 +27,8 @@ defmodule OliWeb.RevisionHistory.Details do
         }}
         set_options="monaco_editor_set_options"
         set_value="monaco_editor_set_value"
-        get_value="monaco_editor_get_value" />
-
+        get_value="monaco_editor_get_value"
+        use_code_lenses={[%{name: "activity-links", context: %{ "projectSlug" => assigns.project.slug }}]} />
       <div>
         <table
         style="table-layout: fixed;"

--- a/lib/oli_web/live/history/revision_history.sface
+++ b/lib/oli_web/live/history/revision_history.sface
@@ -55,7 +55,7 @@
             {/for}
           {/if}
 
-          <Details revision={@selected} />
+          <Details revision={@selected} project={@project} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
Adds the ability to open an activity's revision history from an inline monaco code lens link in the page revision history json.

<img width="1164" alt="Screenshot 2022-11-30 at 1 56 49 PM" src="https://user-images.githubusercontent.com/6248894/204885678-3ad5497a-c97e-4c11-84a9-b9eb38b2e97c.png">
