### PR TITLE
Not ready - [ENHANCEMENT] Changed logic for when hints are displayed [MER-1581]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Upgrade to Phoenix LiveView 0.18
 - Optimize webpack to improve development compile times
 - Add client side reporting to appsignal for core and adaptive authoring.
+- Updated hint logic to be consistent across core-lesson question types and allow requesting hints for auto-submit questions.
 
 ## 0.21.5 (2022-09-01)
 

--- a/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyDelivery.tsx
+++ b/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyDelivery.tsx
@@ -12,7 +12,7 @@ import {
   listenForParentSurveyReset,
   listenForReviewAttemptChange,
 } from 'data/activities/DeliveryState';
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import ReactDOM from 'react-dom';
 import { Provider, useDispatch, useSelector } from 'react-redux';
 import { configureStore } from 'state/store';
@@ -52,6 +52,11 @@ export const CheckAllThatApplyComponent: React.FC = () => {
     );
   }, []);
 
+  const resetInputs = useMemo(
+    () => ({ [castPartId(activityState.parts[0].partId)]: [] }),
+    [activityState.parts],
+  );
+
   // First render initializes state
   if (!uiState.partState) {
     return null;
@@ -85,15 +90,12 @@ export const CheckAllThatApplyComponent: React.FC = () => {
             )
           }
         />
-        <ResetButtonConnected
-          onReset={() =>
-            dispatch(
-              resetAction(onResetActivity, { [castPartId(activityState.parts[0].partId)]: [] }),
-            )
-          }
-        />
+        <ResetButtonConnected onReset={() => dispatch(resetAction(onResetActivity, resetInputs))} />
         <SubmitButtonConnected />
-        <HintsDeliveryConnected partId={castPartId(activityState.parts[0].partId)} />
+        <HintsDeliveryConnected
+          partId={castPartId(activityState.parts[0].partId)}
+          resetPartInputs={resetInputs}
+        />
         <EvaluationConnected />
       </div>
     </div>

--- a/assets/src/components/activities/common/hints/delivery/HintsDelivery.tsx
+++ b/assets/src/components/activities/common/hints/delivery/HintsDelivery.tsx
@@ -5,8 +5,7 @@ import { Card } from 'components/misc/Card';
 import { Hint } from 'components/activities/types';
 
 interface Props {
-  isEvaluated: boolean;
-  isSubmitted: boolean;
+  requestHintDisabled: boolean;
   hints: Hint[];
   hasMoreHints: boolean;
   context: WriterContext;
@@ -15,8 +14,7 @@ interface Props {
 }
 
 export const HintsDelivery: React.FC<Props> = ({
-  isEvaluated,
-  isSubmitted,
+  requestHintDisabled,
   hints,
   hasMoreHints,
   context,
@@ -50,7 +48,7 @@ export const HintsDelivery: React.FC<Props> = ({
           <button
             aria-label="request hint"
             onClick={onClick}
-            disabled={isEvaluated || isSubmitted || !hasMoreHints}
+            disabled={requestHintDisabled}
             className="btn btn-sm btn-link"
             style={{ padding: 0 }}
           >

--- a/assets/src/components/activities/file_upload/FileUploadDelivery.tsx
+++ b/assets/src/components/activities/file_upload/FileUploadDelivery.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { maybe } from 'tsmonad';
 import { StemDeliveryConnected } from 'components/activities/common/stem/delivery/StemDelivery';
@@ -275,6 +275,8 @@ export const FileUploadComponent: React.FC = () => {
     );
   }, []);
 
+  const resetParts = useMemo(() => ({ [castPartId(state.parts[0].partId)]: [] }), [state.parts]);
+
   // First render initializes state
   if (!uiState.partState) {
     return null;
@@ -295,17 +297,16 @@ export const FileUploadComponent: React.FC = () => {
           }
         />
 
-        <ResetButtonConnected
-          onReset={() =>
-            dispatch(resetAction(onResetActivity, { [castPartId(state.parts[0].partId)]: [] }))
-          }
-        />
+        <ResetButtonConnected onReset={() => dispatch(resetAction(onResetActivity, resetParts))} />
         <SubmitButton
           shouldShow={!isSubmitted(uiState) && !graded && surveyId === undefined}
           disabled={getFilesFromState(uiState).length === 0}
           onClick={() => dispatch(submitFiles(onSubmitActivity, getFilesFromState))}
         />
-        <HintsDeliveryConnected partId={castPartId(state.parts[0].partId)} />
+        <HintsDeliveryConnected
+          partId={castPartId(state.parts[0].partId)}
+          resetPartInputs={resetParts}
+        />
         <EvaluationConnected />
       </div>
     </div>

--- a/assets/src/components/activities/likert/LikertDelivery.tsx
+++ b/assets/src/components/activities/likert/LikertDelivery.tsx
@@ -85,7 +85,10 @@ const LikertComponent: React.FC = () => {
           onReset={() => dispatch(resetAction(onResetActivity, emptySelectionMap))}
         />
         <SubmitButtonConnected />
-        <HintsDeliveryConnected partId={castPartId(activityState.parts[0].partId)} />
+        <HintsDeliveryConnected
+          partId={castPartId(activityState.parts[0].partId)}
+          resetPartInputs={emptySelectionMap}
+        />
         <EvaluationConnected />
       </div>
     </div>

--- a/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
@@ -291,6 +291,7 @@ export const MultiInputComponent: React.FC = () => {
             key={partId}
             partId={partId}
             shouldShow={hintsShown.includes(partId)}
+            resetPartInputs={emptyPartInputs}
           />
         ))}
         <Evaluation

--- a/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
+++ b/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
@@ -117,7 +117,10 @@ export const MultipleChoiceComponent: React.FC = () => {
           isEvaluated={isEvaluated(uiState) && context.graded}
           context={writerContext}
         />
-        <HintsDeliveryConnected partId={castPartId(activityState.parts[0].partId)} />
+        <HintsDeliveryConnected
+          partId={castPartId(activityState.parts[0].partId)}
+          resetPartInputs={{ [activityState.parts[0].partId]: [] }}
+        />
         <EvaluationConnected />
       </div>
     </div>

--- a/assets/src/components/activities/ordering/OrderingDelivery.tsx
+++ b/assets/src/components/activities/ordering/OrderingDelivery.tsx
@@ -126,7 +126,10 @@ export const OrderingComponent: React.FC = () => {
           onReset={() => dispatch(resetAction(onResetActivity, defaultPartInputs))}
         />
         <SubmitButtonConnected />
-        <HintsDeliveryConnected partId={castPartId(activityState.parts[0].partId)} />
+        <HintsDeliveryConnected
+          partId={castPartId(activityState.parts[0].partId)}
+          resetPartInputs={defaultPartInputs}
+        />
         <EvaluationConnected />
       </div>
     </div>

--- a/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
+++ b/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import ReactDOM from 'react-dom';
 import { assertNever, valueOr } from 'utils/common';
 import { StemDeliveryConnected } from 'components/activities/common/stem/delivery/StemDelivery';
@@ -104,6 +104,11 @@ export const ShortAnswerComponent: React.FC = () => {
     );
   }, []);
 
+  const resetParts = useMemo(
+    () => ({ [castPartId(activityState.parts[0].partId)]: [''] }),
+    [activityState.parts],
+  );
+
   // First render initializes state
   if (!uiState.partState) {
     return null;
@@ -145,15 +150,12 @@ export const ShortAnswerComponent: React.FC = () => {
           onBlur={() => deferredSave.current.flushPendingChanges(false)}
         />
 
-        <ResetButtonConnected
-          onReset={() =>
-            dispatch(
-              resetAction(onResetActivity, { [castPartId(activityState.parts[0].partId)]: [''] }),
-            )
-          }
-        />
+        <ResetButtonConnected onReset={() => dispatch(resetAction(onResetActivity, resetParts))} />
         <SubmitButtonConnected />
-        <HintsDeliveryConnected partId={castPartId(activityState.parts[0].partId)} />
+        <HintsDeliveryConnected
+          partId={castPartId(activityState.parts[0].partId)}
+          resetPartInputs={resetParts}
+        />
         <EvaluationConnected />
       </div>
     </div>

--- a/assets/src/components/activities/vlab/VlabDelivery.tsx
+++ b/assets/src/components/activities/vlab/VlabDelivery.tsx
@@ -254,6 +254,7 @@ export const VlabComponent: React.FC = () => {
             key={partId}
             partId={partId}
             shouldShow={hintsShown.includes(partId)}
+            resetPartInputs={emptyPartInputs}
           />
         ))}
         <EvaluationConnected />

--- a/assets/src/data/activities/DeliveryState.ts
+++ b/assets/src/data/activities/DeliveryState.ts
@@ -312,6 +312,18 @@ export const isEvaluated = (state: ActivityDeliveryState) =>
 export const isSubmitted = (state: ActivityDeliveryState) =>
   selectAttemptState(state).dateSubmitted !== null;
 
+export const resetAndRequestHintAction =
+  (
+    partId: PartId,
+    onRequestHint: (attemptGuid: string, partAttemptGuid: string) => Promise<RequestHintResponse>,
+    onResetActivity: (attemptGuid: string) => Promise<ResetActivityResponse>,
+    partInputs?: PartInputs,
+  ): AppThunk =>
+  async (dispatch, getState) => {
+    await dispatch(resetAction(onResetActivity, partInputs));
+    await dispatch(requestHint(partId, onRequestHint));
+  };
+
 export const resetAction =
   (
     onResetActivity: (attemptGuid: string) => Promise<ResetActivityResponse>,
@@ -320,7 +332,6 @@ export const resetAction =
   async (dispatch, getState) => {
     const response = await onResetActivity(getState().attemptState.attemptGuid);
     partInputs && dispatch(slice.actions.setPartInputs(partInputs));
-    dispatch(slice.actions.hideAllHints());
     dispatch(slice.actions.updateModel(response.model));
     dispatch(slice.actions.setAttemptState(response.attemptState));
     getState().attemptState.parts.forEach((partState) =>
@@ -434,7 +445,6 @@ export const resetAndSubmitActivity =
   ): AppThunk =>
   async (dispatch, getState) => {
     const response = await onResetActivity(attemptGuid);
-    dispatch(slice.actions.hideAllHints());
     dispatch(slice.actions.updateModel(response.model));
     dispatch(slice.actions.setAttemptState(response.attemptState));
     getState().attemptState.parts.forEach((partState) =>

--- a/lib/oli/delivery/attempts/activity_lifecycle.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle.ex
@@ -201,7 +201,7 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle do
       lifecycle_state: :active,
       date_evaluated: nil,
       date_submitted: nil,
-      hints: [],
+      hints: previous_part_attempt.hints,
       grading_approach: previous_part_attempt.grading_approach
     }
   end
@@ -289,7 +289,8 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle do
                grading_approach: part_attempt.grading_approach,
                response: nil,
                activity_attempt_id: activity_attempt.id,
-               datashop_session_id: datashop_session_id
+               datashop_session_id: datashop_session_id,
+               hints: part_attempt.hints
              }) do
           {:ok, part_attempt} ->
             PartState.from_attempt(part_attempt, part, explanation_provider_fn)


### PR DESCRIPTION
This updates the hint logic on practice pages:

1. You can request hints before answering
2. You can see hints on incorrect
3. You can request additional hints on incorrect, but that implicitly resets 
4. Hints are hidden on correct
5. Once you see a hint, it remains revealed until you get it correct.

![MCQHints](https://user-images.githubusercontent.com/333265/205658446-1f726a21-e37c-4656-a0aa-8ffb4b57b748.gif)
