### PR TITLE
[BUGFIX] Configure app signal key during deployments.

### DIFF
--- a/config/releases.exs
+++ b/config/releases.exs
@@ -239,19 +239,22 @@ config :libcluster,
       case System.get_env("LIBCLUSTER_STRATEGY", "Cluster.Strategy.Gossip") do
         "ClusterEC2.Strategy.Tags" = ec2_strategy ->
           [
-            strategy:  Module.concat([ec2_strategy]),
+            strategy: Module.concat([ec2_strategy]),
             config: [
               ec2_tagname: System.get_env("LIBCLUSTER_EC2_STRATEGY_TAG_NAME", ""),
               ec2_tagvalue: System.get_env("LIBCLUSTER_EC2_STRATEGY_TAG_VALUE", ""),
               app_prefix: System.get_env("LIBCLUSTER_EC2_STRATEGY_APP_PREFIX", "oli")
             ]
           ]
+
         strategy ->
           [
             strategy: Module.concat([strategy])
           ]
       end
   ]
+
+config :appsignal, :client_key, System.get_env("APPSIGNAL_PUSH_API_KEY", nil)
 
 # ## Using releases (Elixir v1.9+)
 #


### PR DESCRIPTION
The appsignal key wasn't being read in on deployed instances. This should read it in at runtime.

I don't know how to test this without doing a full build/deploy, it doesn't do anything when just running locally.