### PR TITLE
[BUG FIX] Include negative sign in regex parsing pattern

### DIFF
--- a/assets/src/data/activities/model/rules.ts
+++ b/assets/src/data/activities/model/rules.ts
@@ -328,7 +328,7 @@ const matchBetweenRule = (rule: string): Maybe<InputRange> =>
 // e.g. `input = {[123.4,123.5]}` or`input = {(123.4,123.5)#3}`
 
 const matchRangeRule = (rule: string): Maybe<InputRange> =>
-  parseRegex(rule, /{([[(])\s*(-?[01234567890e.]+)\s*,\s*(-?[01234567890e.]+)\s*[\])]#?(\d+)?}/)
+  parseRegex(rule, /{([[(])\s*(-?[-01234567890e.]+)\s*,\s*(-?[-01234567890e.]+)\s*[\])]#?(\d+)?}/)
     .lift((matches) => ({
       bracketOrBrace: matches[1],
       matches: matches.slice(2, 5).map(maybeAsNumber),

--- a/assets/test/activities/rules_test.ts
+++ b/assets/test/activities/rules_test.ts
@@ -198,6 +198,17 @@ describe('rules', () => {
     );
   });
 
+  it('properly parses range with negative exponent from rule', () => {
+    expect(parseInputFromRule('input like {(-4.66e-19,-4.5e-19)}').valueOrThrow()).toEqual(
+      expect.objectContaining({
+        kind: InputKind.Range,
+        lowerBound: -4.66e-19,
+        upperBound: -4.5e-19,
+        inclusive: false,
+      }),
+    );
+  });
+
   it('properly parses range input from rule with precision', () => {
     expect(parseInputFromRule('input like {[-151.0,151.3]#3}').valueOrThrow()).toEqual(
       expect.objectContaining({

--- a/lib/oli/delivery/evaluation/rule.ex
+++ b/lib/oli/delivery/evaluation/rule.ex
@@ -146,7 +146,7 @@ defmodule Oli.Delivery.Evaluation.Rule do
 
   defp parse_range(range_str) do
     case Regex.run(
-           ~r/([[(])\s*(-?[01234567890e.]+)\s*,\s*(-?[01234567890e.]+)\s*[\])]#?(\d+)?/,
+           ~r/([[(])\s*(-?[-01234567890e.]+)\s*,\s*(-?[-01234567890e.]+)\s*[\])]#?(\d+)?/,
            range_str
          ) do
       [_, "[", lower, upper | maybe_precision] ->

--- a/test/oli/delivery/evaluation/rule_eval_test.exs
+++ b/test/oli/delivery/evaluation/rule_eval_test.exs
@@ -74,6 +74,10 @@ defmodule Oli.Delivery.Evaluation.RuleEvalTest do
     assert eval("attemptNumber = {1} && input = {[3,4]}", "4.0") == true
     assert eval("attemptNumber = {1} && input = {[3.0,4.0]}", "4") == true
 
+    assert eval("attemptNumber = {1} && input = {(-4.66e-19,-4.5e-19)}", "-4.6e-19") == true
+
+
+
     # gracefully handles space in between range
     assert eval("attemptNumber = {1} && input = {[3, 5]}", "4") == true
 


### PR DESCRIPTION
A few chemistry activities are failing to render in authoring.  They show this error message:

"failed to parse input value from rule input = {[-4.66e-19,-4.5e-19]}"

Root cause was the Regex pattern used for parsing the rule did not include the negative sign, which allows numbers with negative exponent to exist.  

