### PR TITLE
working hotspot delivery w/temp authoring

### DIFF
--- a/assets/src/components/activities/image_hotspot/ImageHotspotAuthoring.tsx
+++ b/assets/src/components/activities/image_hotspot/ImageHotspotAuthoring.tsx
@@ -1,0 +1,207 @@
+import {
+  Hints as HintsAuthoring,
+  Hints,
+} from 'components/activities/common/hints/authoring/HintsAuthoringConnected';
+import { Stem } from 'components/activities/common/stem/authoring/StemAuthoringConnected';
+import { Choices as ChoicesAuthoring } from 'components/activities/common/choices/authoring/ChoicesAuthoring';
+import { Choices } from 'data/activities/model/choices';
+import React, { useEffect, useRef } from 'react';
+import ReactDOM from 'react-dom';
+import { Provider } from 'react-redux';
+import { configureStore } from 'state/store';
+import { AuthoringElement, AuthoringElementProps } from '../AuthoringElement';
+import * as ActivityTypes from '../types';
+import { ImageHotspotActions } from './actions';
+import { getShape, Hotspot, ImageHotspotModelSchema, makeHotspot } from './schema';
+import { Radio } from 'components/misc/icons/radio/Radio';
+import { MCActions } from '../common/authoring/actions/multipleChoiceActions';
+import { TabbedNavigation } from 'components/tabbed_navigation/Tabs';
+import { defaultWriterContext } from 'data/content/writers/context';
+import { SimpleFeedback } from '../common/responses/SimpleFeedback';
+import { TargetedFeedback } from '../common/responses/TargetedFeedback';
+import { ChoicesDelivery } from '../common/choices/delivery/ChoicesDelivery';
+import { getCorrectChoice } from 'components/activities/multiple_choice/utils';
+import { useAuthoringElementContext, AuthoringElementProvider } from '../AuthoringElementProvider';
+import { Explanation } from '../common/explanation/ExplanationAuthoring';
+import { MIMETYPE_FILTERS } from 'components/media/manager/MediaManager';
+import { MediaItemRequest } from '../types';
+import { Checkbox } from 'components/misc/icons/checkbox/Checkbox';
+import { CATAActions } from '../check_all_that_apply/actions';
+import { getCorrectChoiceIds } from 'data/activities/model/responses';
+import { drawHotspotShape, HS_COLOR } from './utils';
+
+const ImageHotspot = (props: AuthoringElementProps<ImageHotspotModelSchema>) => {
+  const { dispatch, model, editMode, projectSlug, onRequestMedia } =
+    useAuthoringElementContext<ImageHotspotModelSchema>();
+
+  const selectedPartId = model.authoring.parts[0].id;
+  const writerContext = defaultWriterContext({
+    projectSlug: projectSlug,
+  });
+
+  function selectImage(): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const request = {
+        type: 'MediaItemRequest',
+        mimeTypes: MIMETYPE_FILTERS.IMAGE,
+      } as MediaItemRequest;
+      if (props.onRequestMedia) {
+        props.onRequestMedia(request).then((r) => {
+          if (r === false) {
+            reject('error');
+          } else {
+            resolve(r as string);
+          }
+        });
+      }
+    });
+  }
+
+  const setImageURL = (_e: any) => {
+    selectImage().then((url: string) => {
+      dispatch(ImageHotspotActions.setImageURL(url));
+    });
+  };
+
+  const imgRef = useRef<HTMLImageElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  const onImageLoad = () => {
+    if (imgRef.current) {
+      dispatch(ImageHotspotActions.setSize(imgRef.current.height, imgRef.current.width));
+    }
+  };
+
+  const showHotSpots = () => {
+    const canvas = canvasRef.current;
+    const ctx = canvas?.getContext('2d');
+    if (canvas && ctx) {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      model.choices.map((hs) => drawHotspotShape(ctx, hs, HS_COLOR));
+    }
+  };
+
+  useEffect(showHotSpots, [model.choices]);
+
+  return (
+    <React.Fragment>
+      <TabbedNavigation.Tabs>
+        <TabbedNavigation.Tab label="Question">
+          <Stem />
+
+          <div>
+            {model.imageURL && (
+              <div style={{ position: 'relative', width: model.width, height: model.height }}>
+                <img
+                  src={model.imageURL}
+                  ref={imgRef}
+                  onLoad={() => onImageLoad()}
+                  style={{ position: 'absolute' }}
+                />
+                {/* semi-transparent canvas for overlaying area highlighting shapes */}
+                <canvas
+                  ref={canvasRef}
+                  height={model.height}
+                  width={model.width}
+                  style={{ position: 'absolute', opacity: 0.6 }}
+                />
+              </div>
+            )}
+            <button className="btn btn-primary mt-2" onClick={setImageURL}>
+              Choose Image
+            </button>
+          </div>
+
+          <div className="form-check mb-2">
+            <input
+              className="form-check-input"
+              type="checkbox"
+              id="multiple-toggle"
+              aria-label="Checkbox for multiple selection"
+              checked={model.multiple}
+              onChange={(e: any) =>
+                dispatch(ImageHotspotActions.setMultipleSelection(e.target.checked))
+              }
+            />
+            <label className="form-check-label" htmlFor="descending-toggle">
+              Multiple Selection
+            </label>
+          </div>
+          <ChoicesAuthoring
+            icon={model.multiple ? <Checkbox.Unchecked /> : <Radio.Unchecked />}
+            choices={model.choices}
+            simpleText={true}
+            setAll={(choices: Hotspot[]) => dispatch(Choices.setAll(choices))}
+            onEdit={(id, content) => dispatch(ImageHotspotActions.setContent(id, content))}
+            addOne={() =>
+              model.multiple
+                ? dispatch(CATAActions.addChoice(makeHotspot()))
+                : dispatch(Choices.addOne(makeHotspot()))
+            }
+            onRemove={(id) =>
+              model.multiple
+                ? dispatch(CATAActions.removeChoiceAndUpdateRules(id))
+                : dispatch(MCActions.removeChoice(id, model.authoring.parts[0].id))
+            }
+          />
+        </TabbedNavigation.Tab>
+        <TabbedNavigation.Tab label="Answer Key">
+          <ChoicesDelivery
+            unselectedIcon={model.multiple ? <Checkbox.Unchecked /> : <Radio.Unchecked />}
+            selectedIcon={model.multiple ? <Checkbox.Checked /> : <Radio.Checked />}
+            choices={model.choices}
+            selected={
+              model.multiple
+                ? getCorrectChoiceIds(model)
+                : getCorrectChoice(model, selectedPartId).caseOf({
+                    just: (c) => [c.id],
+                    nothing: () => [],
+                  })
+            }
+            onSelect={(id) =>
+              model.multiple
+                ? dispatch(CATAActions.toggleChoiceCorrectness(id))
+                : dispatch(MCActions.toggleChoiceCorrectness(id, selectedPartId))
+            }
+            isEvaluated={false}
+            context={writerContext}
+          />
+          <SimpleFeedback partId={selectedPartId} />
+          <TargetedFeedback
+            toggleChoice={(choiceId, mapping) => {
+              dispatch(MCActions.editTargetedFeedbackChoice(mapping.response.id, choiceId));
+            }}
+            addTargetedResponse={() => dispatch(MCActions.addTargetedFeedback(selectedPartId))}
+            unselectedIcon={<Radio.Unchecked />}
+            selectedIcon={<Radio.Checked />}
+          />
+        </TabbedNavigation.Tab>
+
+        <TabbedNavigation.Tab label="Hints">
+          <Hints partId={selectedPartId} />
+        </TabbedNavigation.Tab>
+        <TabbedNavigation.Tab label="Explanation">
+          <Explanation partId={selectedPartId} />
+        </TabbedNavigation.Tab>
+      </TabbedNavigation.Tabs>
+    </React.Fragment>
+  );
+};
+
+const store = configureStore();
+
+export class ImageHotspotAuthoring extends AuthoringElement<ImageHotspotModelSchema> {
+  render(mountPoint: HTMLDivElement, props: AuthoringElementProps<ImageHotspotModelSchema>) {
+    ReactDOM.render(
+      <Provider store={store}>
+        <AuthoringElementProvider {...props}>
+          <ImageHotspot {...props} />
+        </AuthoringElementProvider>
+      </Provider>,
+      mountPoint,
+    );
+  }
+}
+// eslint-disable-next-line
+const manifest = require('./manifest.json') as ActivityTypes.Manifest;
+window.customElements.define(manifest.authoring.element, ImageHotspotAuthoring);

--- a/assets/src/components/activities/image_hotspot/ImageHotspotDelivery.tsx
+++ b/assets/src/components/activities/image_hotspot/ImageHotspotDelivery.tsx
@@ -1,0 +1,195 @@
+import React, { useEffect, useReducer, useRef } from 'react';
+import ReactDOM from 'react-dom';
+import { DeliveryElement, DeliveryElementProps } from '../DeliveryElement';
+import { getShape, Hotspot, ImageHotspotModelSchema } from './schema';
+import * as ActivityTypes from '../types';
+import { StemDelivery } from '../common/stem/delivery/StemDelivery';
+import { configureStore } from 'state/store';
+import {
+  activityDeliverySlice,
+  ActivityDeliveryState,
+  initializeState,
+  setSelection,
+  resetAction,
+  PartInputs,
+  isEvaluated,
+  listenForParentSurveySubmit,
+  listenForParentSurveyReset,
+  listenForReviewAttemptChange,
+} from 'data/activities/DeliveryState';
+import { Provider, useSelector, useDispatch } from 'react-redux';
+import { initialPartInputs, isCorrect } from 'data/activities/utils';
+import { SubmitButtonConnected } from '../common/delivery/submit_button/SubmitButtonConnected';
+import { HintsDeliveryConnected } from '../common/hints/delivery/HintsDeliveryConnected';
+import { EvaluationConnected } from '../common/delivery/evaluation/EvaluationConnected';
+import { GradedPointsConnected } from '../common/delivery/graded_points/GradedPointsConnected';
+import { ResetButtonConnected } from '../common/delivery/reset_button/ResetButtonConnected';
+import { useDeliveryElementContext, DeliveryElementProvider } from '../DeliveryElementProvider';
+import { castPartId } from '../common/utils';
+import { toSimpleText } from 'components/editing/slateUtils';
+import guid from 'utils/guid';
+import { Choices } from '../common/choices/authoring/ChoicesAuthoring';
+import { ConsoleLogger } from 'typedoc/dist/lib/utils';
+import { drawHotspotShape, HS_COLOR } from './utils';
+
+const ImageHotspotComponent: React.FC = () => {
+  const {
+    state: activityState,
+    context,
+    model,
+    writerContext,
+    onSubmitActivity,
+    onSaveActivity,
+    onResetActivity,
+  } = useDeliveryElementContext<ImageHotspotModelSchema>();
+  const uiState = useSelector((state: ActivityDeliveryState) => state);
+  const dispatch = useDispatch();
+
+  const emptySelectionMap = {};
+
+  useEffect(() => {
+    listenForParentSurveySubmit(context.surveyId, dispatch, onSubmitActivity);
+    listenForParentSurveyReset(context.surveyId, dispatch, onResetActivity, emptySelectionMap);
+    listenForReviewAttemptChange(model, activityState.activityId as number, dispatch, context);
+
+    dispatch(
+      initializeState(activityState, initialPartInputs(model, activityState), model, context),
+    );
+  }, []);
+
+  const partId = castPartId(activityState.parts[0].partId);
+  const partState = uiState.partState?.[partId];
+  const selected = partState?.studentInput;
+
+  const [hovered, setHovered] = React.useState<Hotspot | null>(null);
+
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const canvasRef2 = useRef<HTMLCanvasElement>(null);
+  const canvas = canvasRef.current;
+  const ctx = canvas?.getContext('2d');
+
+  const showSelected = () => {
+    if (canvas && ctx) {
+      ctx?.clearRect(0, 0, canvas?.width, canvas.height);
+    }
+    if (selected) {
+      selected.map((id) => {
+        const hotspot = model.choices.find((hs) => hs.id === id);
+        if (ctx && hotspot) {
+          drawHotspotShape(
+            ctx,
+            hotspot,
+            isEvaluated(uiState) && isCorrect(uiState.attemptState) ? '#00FF00' : HS_COLOR,
+          );
+        }
+      });
+    }
+  };
+
+  const showHovered = () => {
+    const canvas2 = canvasRef2.current;
+    const ctx2 = canvas2?.getContext('2d');
+    if (canvas2) ctx2?.clearRect(0, 0, canvas2.width, canvas2.height);
+    if (ctx2 && hovered) {
+      drawHotspotShape(ctx2, hovered, HS_COLOR, false);
+    }
+  };
+
+  useEffect(showSelected);
+  useEffect(showHovered, [hovered]);
+
+  // First render initializes state
+  if (!uiState.partState) {
+    return null;
+  }
+
+  const onSelect = (partId: string, choiceId: string) => {
+    dispatch(
+      setSelection(partId, choiceId, onSaveActivity, model.multiple ? 'multiple' : 'single'),
+    );
+  };
+
+  const onClickHotspot = (hs: Hotspot) => {
+    console.log('Clicked hotspot ' + hs.id);
+    if (!isEvaluated(uiState)) {
+      onSelect(partId, hs.id);
+    }
+  };
+
+  const mapName = 'map' + model.choices[0].id;
+
+  return (
+    <div className="activity multiple-choice-activity">
+      <div className="activity-content">
+        <StemDelivery
+          stem={(uiState.model as ImageHotspotModelSchema).stem}
+          context={writerContext}
+        />
+        <div
+          style={{ position: 'relative', width: model.width, height: model.height }}
+          tabIndex={0}
+        >
+          {/* bottom layer: image with associated map */}
+          <img src={model.imageURL} style={{ position: 'absolute' }} useMap={'#' + mapName} />
+          {/* overlay 1: semi-transparent canvas for drawing selected area shapes */}
+          <canvas
+            ref={canvasRef}
+            height={model.height}
+            width={model.width}
+            style={{ position: 'absolute', opacity: 0.5, pointerEvents: 'none' }}
+          />
+          {/* overlay 2: semi-transparent canvas for drawing hovered area shapes */}
+          <canvas
+            ref={canvasRef2}
+            height={model.height}
+            width={model.width}
+            style={{ position: 'absolute', opacity: 0.5, pointerEvents: 'none' }}
+          />
+          <map name={mapName}>
+            {model.choices.filter(getShape).map((hs) => (
+              <area
+                id={hs.id}
+                key={hs.id}
+                shape={getShape(hs)}
+                coords={hs.coords.join(',')}
+                onClick={() => onClickHotspot(hs)}
+                onMouseEnter={() => setHovered(hs)}
+                onMouseLeave={() => setHovered(null)}
+                title={hs.title}
+                tabIndex={0}
+              />
+            ))}
+          </map>
+        </div>
+
+        <GradedPointsConnected />
+        <ResetButtonConnected
+          onReset={() => dispatch(resetAction(onResetActivity, { [partId]: [] }))}
+        />
+        <SubmitButtonConnected />
+        <HintsDeliveryConnected partId={partId} />
+        <EvaluationConnected />
+      </div>
+    </div>
+  );
+};
+
+// Defines the web component, a simple wrapper over our React component above
+export class ImageHotspotDelivery extends DeliveryElement<ImageHotspotModelSchema> {
+  render(mountPoint: HTMLDivElement, props: DeliveryElementProps<ImageHotspotModelSchema>) {
+    const store = configureStore({}, activityDeliverySlice.reducer);
+    ReactDOM.render(
+      <Provider store={store}>
+        <DeliveryElementProvider {...props}>
+          <ImageHotspotComponent />
+        </DeliveryElementProvider>
+      </Provider>,
+      mountPoint,
+    );
+  }
+}
+
+// Register the web component:
+// eslint-disable-next-line
+const manifest = require('./manifest.json') as ActivityTypes.Manifest;
+window.customElements.define(manifest.delivery.element, ImageHotspotDelivery);

--- a/assets/src/components/activities/image_hotspot/actions.ts
+++ b/assets/src/components/activities/image_hotspot/actions.ts
@@ -1,0 +1,63 @@
+import { ImageHotspotModelSchema } from './schema';
+import { HasParts, Part } from '../types';
+import * as ActivityTypes from '../types';
+import { PostUndoable, makeUndoable } from 'components/activities/types';
+import { Operations } from 'utils/pathOperations';
+
+import { toSimpleText } from 'components/editing/slateUtils';
+import { Descendant } from 'slate';
+import { matchListRule } from 'data/activities/model/rules';
+import PartsLayoutRenderer from '../adaptive/components/delivery/PartsLayoutRenderer';
+import { Responses } from 'data/activities/model/responses';
+
+export const ImageHotspotActions = {
+  setContent(id: string, content: Descendant[]) {
+    return (model: any, _post: PostUndoable) => {
+      // sync coords w/content text as comma-separated list. Result filtered to all numbers,
+      // but may still have bad size for an area definition.
+      const coords: Number[] = toSimpleText(content)
+        .split(',')
+        .map(Number)
+        .filter((x) => !isNaN(x));
+      Operations.applyAll(model, [
+        Operations.replace(`$..choices[?(@.id=='${id}')].content`, content),
+        Operations.replace(`$..choices[?(@.id=='${id}')].coords`, coords),
+      ]);
+    };
+  },
+
+  setImageURL(url: string) {
+    return (model: any & HasParts, post: PostUndoable) => {
+      model.imageURL = url;
+    };
+  },
+
+  setSize(height: number, width: number) {
+    console.log('setSize ' + height + ', ' + width);
+    return (model: any & HasParts, post: PostUndoable) => {
+      model.height = height;
+      model.width = width;
+    };
+  },
+
+  setMultipleSelection(multiple: boolean) {
+    return (model: any & HasParts, post: PostUndoable) => {
+      model.multiple = multiple;
+
+      // Changing type between CATA and MCQuestion requires changing response rules
+      // For simplicity, just reset correct choice to default of choice 1
+      const correctChoice = model.choices[0];
+      if (multiple) {
+        const correctResponse = ActivityTypes.makeResponse(
+          matchListRule([correctChoice.id], [correctChoice.id]),
+          1,
+          '',
+        );
+        model.authoring.parts[0].responses = [correctResponse, Responses.catchAll()];
+        model.authoring.correct = [[correctChoice.id], correctResponse.id];
+      } else {
+        model.authoring.parts[0].responses = Responses.forMultipleChoice(correctChoice.id);
+      }
+    };
+  },
+};

--- a/assets/src/components/activities/image_hotspot/authoring-entry.ts
+++ b/assets/src/components/activities/image_hotspot/authoring-entry.ts
@@ -1,0 +1,33 @@
+// This is the entry point for the Likert authoring
+// component, as specified in the manifest.json
+
+// An authoring component entry point must expose the following
+// three things:
+//
+// 1. The web component specified to use for authoring.
+// 2. The web component specified to use for delivery. Delivery
+//    component must be exposed to allow the resource editor to
+//    operate activites of this type in 'test mode'
+// 3. A 'creation function'.  A function that when invoked will
+//    asynchronously delivery a new model instance for this
+//    activity type. This is to allow the activity author to have
+//    full control over populating a new activity.
+
+// Fulfills 1. and 2. from above by exporting these components:
+export { ImageHotspotDelivery } from './ImageHotspotDelivery';
+export { ImageHotspotAuthoring } from './ImageHotspotAuthoring';
+
+// Registers the creation function:
+import { Manifest, CreationContext } from '../types';
+import { registerCreationFunc } from '../creation';
+import { ImageHotspotModelSchema } from './schema';
+import { defaultImageHotspotModel } from './utils';
+
+// eslint-disable-next-line
+const manifest: Manifest = require('./manifest.json');
+
+function createFn(content: CreationContext): Promise<ImageHotspotModelSchema> {
+  return Promise.resolve(Object.assign({}, defaultImageHotspotModel()));
+}
+
+registerCreationFunc(manifest, createFn);

--- a/assets/src/components/activities/image_hotspot/delivery-entry.ts
+++ b/assets/src/components/activities/image_hotspot/delivery-entry.ts
@@ -1,0 +1,5 @@
+// This is the entry point for the delivery component for
+// the multiple choice activitity.  All that needs to be exposed
+// is the actual delivery web component.
+
+export { ImageHotspotDelivery } from './ImageHotspotDelivery';

--- a/assets/src/components/activities/image_hotspot/manifest.json
+++ b/assets/src/components/activities/image_hotspot/manifest.json
@@ -1,0 +1,20 @@
+{
+  "id": "oli_image_hotspot",
+  "friendlyName": "Image Hotspot",
+  "petiteLabel": "Hotspot",
+  "description": "A multiple choice question answered by selecting from a set of designated hotspots in an image",
+  "icon": "image",
+  "allowClientEvaluation": false,
+  "delivery": {
+    "element": "oli-image-hotspot-delivery",
+    "entry": "./delivery-entry.ts"
+  },
+  "authoring": {
+    "element": "oli-image-hotspot-authoring",
+    "entry": "./authoring-entry.ts"
+  },
+  "schemaPruning": {
+    "type": "keys",
+    "keys": ["feedback"]
+  }
+}

--- a/assets/src/components/activities/image_hotspot/schema.ts
+++ b/assets/src/components/activities/image_hotspot/schema.ts
@@ -1,0 +1,60 @@
+import {
+  ActivityModelSchema,
+  Stem,
+  Part,
+  ChoiceIdsToResponseId,
+  Transformation,
+  Choice,
+  RichText,
+  makeChoice,
+  PostUndoable,
+} from '../types';
+import { ID } from 'data/content/model/other';
+import { CATACompatible } from '../check_all_that_apply/actions';
+
+export class Hotspot implements Choice {
+  id: ID;
+  content: RichText;
+  coords: number[];
+  title?: string;
+}
+
+export function getShape(hotspot: Hotspot): string | undefined {
+  const n = hotspot.coords.length;
+  if (n === 3) return 'circle';
+  if (n === 4) return 'rect';
+  if (n >= 6 && n % 2 === 0) return 'poly';
+  return undefined;
+}
+
+export function makeHotspot(): Hotspot {
+  const hotspot = new Hotspot();
+  const choice = makeChoice('');
+  hotspot.id = choice.id;
+  hotspot.content = choice.content;
+  hotspot.coords = [];
+  return hotspot;
+}
+
+export interface ImageHotspotModelSchema extends ActivityModelSchema, CATACompatible {
+  stem: Stem;
+  imageURL: string | undefined;
+  height?: number;
+  width?: number;
+  choices: Hotspot[];
+  multiple: boolean;
+  authoring: {
+    // If multiple is true, we must provide a CATA model, in which response rules are complex and
+    // correct holds an association list of correct choice ids to the matching response id
+    correct: ChoiceIdsToResponseId;
+    targeted: ChoiceIdsToResponseId[];
+    parts: Part[];
+    transformations: Transformation[];
+    previewText: string;
+  };
+}
+
+export interface ModelEditorProps {
+  model: ImageHotspotModelSchema;
+  editMode: boolean;
+}

--- a/assets/src/components/activities/image_hotspot/utils.ts
+++ b/assets/src/components/activities/image_hotspot/utils.ts
@@ -1,0 +1,59 @@
+import { getShape, Hotspot, ImageHotspotModelSchema, makeHotspot } from './schema';
+import { makeStem, makeHint, makePart } from '../types';
+
+import { Responses } from 'data/activities/model/responses';
+
+export const defaultImageHotspotModel: () => ImageHotspotModelSchema = () => {
+  const hotspot1: Hotspot = makeHotspot();
+  // initialize for default single selection. Will need different CATA-style
+  // response structure if dynamically changed to multiple selection
+  const responses = Responses.forMultipleChoice(hotspot1.id);
+  return {
+    stem: makeStem(''),
+    imageURL: undefined,
+    choices: [hotspot1],
+    multiple: false,
+    authoring: {
+      parts: [makePart(responses, [makeHint(''), makeHint(''), makeHint('')], '1')],
+      correct: [[], ''],
+      transformations: [],
+      targeted: [],
+      previewText: '',
+    },
+  };
+};
+
+export const HS_COLOR = '#00a2ff';
+
+export const drawHotspotShape = (
+  ctx: CanvasRenderingContext2D,
+  hs: Hotspot,
+  color: string,
+  border: boolean = true,
+) => {
+  ctx.lineWidth = 2;
+  ctx.strokeStyle = '#000000';
+  ctx.fillStyle = color;
+
+  if (getShape(hs) === 'rect') {
+    const [left, top, right, bot] = hs.coords;
+    if (border) ctx.strokeRect(left, top, right - left, bot - top);
+    ctx.fillRect(left, top, right - left, bot - top);
+  } else if (getShape(hs) === 'circle') {
+    const [cx, cy, r] = hs.coords;
+    ctx.beginPath();
+    ctx.arc(cx, cy, r, 0, 2 * Math.PI);
+    ctx.closePath();
+    if (border) ctx.stroke();
+    ctx.fill();
+  } else if (getShape(hs) === 'poly') {
+    ctx.beginPath();
+    ctx.moveTo(hs.coords[0], hs.coords[1]);
+    for (var i = 2; i < hs.coords.length; i += 2) {
+      ctx.lineTo(hs.coords[i], hs.coords[i + 1]);
+    }
+    ctx.closePath();
+    if (border) ctx.stroke();
+    ctx.fill();
+  }
+};


### PR DESCRIPTION
Adds an image-hotspot activity with working delivery, suitable for use with ingested courses. Activity may be defined as single selection (behaving like a MCQ) or multiple selection (behaving like CATA).

For authoring, there is only a provisional interface to allow hand-entering and editing of hotspot coordinates in text boxes as comma-separated lists of numbers as follows:

For circle: cx, cy, radius    Example:   150,150, 50
For rect: x1, y1, x2, y2.      Example:    100,100, 150,150
For polygon: x1, y1, x2, y2, x3, y3 [...]  Example: 10,10, 100, 10, 50, 50

Desired hotspot shape is derived from the number of coordinates given. This authoring method was included solely for to allow testing during development, but should be robust enough (though user-unfriendly) to be safely deployed: Unparseable fields in the comma-separated list are ignored and invalid coordinate lists should result in an inactive hotspot that has no effect until corrected.

Note also that changing question type between single and multi-selection re-initializes the question so that the correct choice reverts to the default of first choice in list. 
