### PR TITLE
[PERFORMANCE] Streamline submit activity

### DIFF
--- a/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
@@ -32,7 +32,7 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
         evaluate_from_input(section_slug, activity_attempt_guid, part_inputs, datashop_session_id)
 
       {:ok, %Model{rules: rules, delivery: delivery, authoring: authoring}} ->
-        submit_active_part_attempts(activity_attempt)
+        submit_active_part_attempts(part_attempts)
 
         custom = Map.get(delivery, "custom", %{})
 
@@ -85,19 +85,19 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
     end
   end
 
-  defp submit_active_part_attempts(activity_attempt) do
-    part_attempts = get_latest_part_attempts(activity_attempt.attempt_guid)
+  defp submit_active_part_attempts(part_attempts) do
+    right_now = DateTime.utc_now()
 
-    Enum.filter(part_attempts, fn pa -> pa.lifecycle_state == :active end)
-    |> Enum.reduce_while({:ok, []}, fn pa, {:ok, updated} ->
-      case update_part_attempt(pa, %{
-             lifecycle_state: :submitted,
-             date_submitted: DateTime.utc_now()
-           }) do
-        {:ok, updated_part_attempt} -> {:cont, {:ok, [updated_part_attempt | updated]}}
-        e -> {:halt, e}
-      end
+    update_attrs = Enum.filter(part_attempts, fn pa -> pa.lifecycle_state == :active end)
+    |> Enum.map(fn pa ->
+      %{
+        lifecycle_state: :submitted,
+        date_submitted: right_now,
+        updated_at: right_now
+      }
     end)
+
+    Oli.Repo.update_all()
   end
 
   def evaluate_from_rules(

--- a/lib/oli/delivery/attempts/activity_lifecycle/persistence.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle/persistence.ex
@@ -4,12 +4,8 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Persistence do
 
   alias Oli.Delivery.Evaluation.Actions.{
     FeedbackAction,
-    NavigationAction,
-    StateUpdateAction,
     SubmissionAction
   }
-
-  alias Oli.Delivery.Attempts.Core.PartAttempt
 
   @moduledoc """
   Routines for persisting evaluations for part attempts.
@@ -30,151 +26,90 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Persistence do
   def persist_evaluations({:ok, evaluations}, part_inputs, roll_up_fn, datashop_session_id) do
     evaluated_inputs = Enum.zip(part_inputs, evaluations)
 
-    case Enum.reduce_while(
-           evaluated_inputs,
-           {:ok, false, []},
-           persist_single_evaluation_with_datashop_session_fn(datashop_session_id)
-         ) do
-      {:ok, _, results} -> roll_up_fn.({:ok, results})
-      error -> error
-    end
-  end
-
-  def persist_evaluations(
-        {:ok, evaluations},
-        part_inputs,
-        roll_up_fn,
-        replace,
-        datashop_session_id
-      ) do
-    case replace do
-      false ->
-        persist_evaluations({:ok, evaluations}, part_inputs, roll_up_fn, datashop_session_id)
-
-      true ->
-        evaluated_inputs = Enum.zip(part_inputs, evaluations)
-
-        case Enum.reduce_while(
-               evaluated_inputs,
-               {:ok, replace, []},
-               persist_single_evaluation_with_datashop_session_fn(datashop_session_id)
-             ) do
-          {:ok, _, results} -> roll_up_fn.({:ok, results})
-          error -> error
-        end
-    end
-  end
-
-  defp persist_single_evaluation_with_datashop_session_fn(datashop_session_id) do
-    &persist_single_evaluation(&1, &2, datashop_session_id)
-  end
-
-  # Persist the result of a single evaluation for a single part_input submission.
-  defp persist_single_evaluation({_, {:error, error}}, _, _), do: {:halt, {:error, error}}
-
-  defp persist_single_evaluation(
-         {_, {:ok, %NavigationAction{} = action_result}},
-         {:ok, replace, results},
-         _datashop_session_id
-       ) do
-    {:cont, {:ok, replace, results ++ [action_result]}}
-  end
-
-  defp persist_single_evaluation(
-         {_, {:ok, %StateUpdateAction{} = action_result}},
-         {:ok, replace, results},
-         _datashop_session_id
-       ) do
-    {:cont, {:ok, replace, results ++ [action_result]}}
-  end
-
-  defp persist_single_evaluation(
-         {%{attempt_guid: attempt_guid, input: input},
-          {:ok,
-           %FeedbackAction{
-             feedback: feedback,
-             score: score,
-             out_of: out_of
-           } = feedback_action}},
-         {:ok, replace, results},
-         datashop_session_id
-       ) do
-    now = DateTime.utc_now()
-
-    query =
-      from(p in PartAttempt,
-        where: p.attempt_guid == ^attempt_guid
+    update_values = Enum.map(evaluated_inputs, fn pair -> attrs_for(pair, datashop_session_id) end)
+    |> Enum.filter(fn attrs -> !is_nil(attrs) end)
+    |> Enum.map(fn pa ->
+      """
+      (
+        '#{pa.attempt_guid}',
+        #{handle_json(pa.response)},
+        '#{Atom.to_string(pa.lifecycle_state)}',
+        #{null_or_now(pa.date_evaluated)},
+        #{null_or_now(pa.date_submitted)},
+        #{handle_num(pa.score)},
+        #{handle_num(pa.out_of)},
+        #{handle_json(pa.feedback)},
+        '#{pa.datashop_session_id}'
       )
+      """
+    end)
+    |> Enum.join(",")
 
-    query =
-      if replace === false do
-        where(query, [p], is_nil(p.date_evaluated))
-      else
-        query
-      end
+    sql = """
+      UPDATE part_attempts
+      SET
+        response = batch_values.response,
+        lifecycle_state = batch_values.lifecycle_state,
+        date_evaluated = batch_values.date_evaluated,
+        date_submitted = batch_values.date_submitted,
+        score = batch_values.score,
+        out_of = batch_values.out_of,
+        feedback = batch_values.feedback,
+        datashop_session_id = batch_values.datashop_session_id,
+        updated_at = NOW()
+      FROM (
+          VALUES
+          #{update_values}
+      ) AS batch_values (attempt_guid, response, lifecycle_state, date_evaluated, date_submitted, score, out_of, feedback, datashop_session_id)
+      WHERE part_attempts.attempt_guid = batch_values.attempt_guid
+    """
 
-    case Repo.update_all(
-           query,
-           set: [
-             response: input,
-             lifecycle_state: :evaluated,
-             date_evaluated: now,
-             date_submitted: now,
-             score: score,
-             out_of: out_of,
-             feedback: feedback,
-             datashop_session_id: datashop_session_id
-           ]
-         ) do
-      nil ->
-        {:halt, {:error, :error}}
-
-      {1, _} ->
-        {:cont, {:ok, replace, results ++ [feedback_action]}}
-
-      _ ->
-        {:halt, {:error, :error}}
+    case Ecto.Adapters.SQL.query(Repo, sql, []) do
+      {:ok, _} -> roll_up_fn.({:ok, Enum.map(evaluations, fn {:ok, action} -> action end)})
+      e -> e
     end
   end
 
-  defp persist_single_evaluation(
-         {%{attempt_guid: attempt_guid, input: input},
-          {:ok, %SubmissionAction{} = submission_action}},
-         {:ok, replace, results},
-         datashop_session_id
-       ) do
-    now = DateTime.utc_now()
-
-    query =
-      from(p in PartAttempt,
-        where: p.attempt_guid == ^attempt_guid
-      )
-
-    query =
-      if replace === false do
-        where(query, [p], is_nil(p.date_evaluated))
-      else
-        query
-      end
-
-    case Repo.update_all(
-           query,
-           set: [
-             response: input,
-             lifecycle_state: :submitted,
-             date_evaluated: nil,
-             date_submitted: now,
-             datashop_session_id: datashop_session_id
-           ]
-         ) do
-      nil ->
-        {:halt, {:error, :error}}
-
-      {1, _} ->
-        {:cont, {:ok, replace, results ++ [submission_action]}}
-
-      _ ->
-        {:halt, {:error, :error}}
-    end
+  defp attrs_for({%{attempt_guid: attempt_guid, input: input}, {:ok, %FeedbackAction{
+    feedback: feedback,
+    score: score,
+    out_of: out_of}}}, datashop_session_id) do
+    %{
+      attempt_guid: attempt_guid,
+      response: input,
+      lifecycle_state: :evaluated,
+      date_evaluated: true,
+      date_submitted: true,
+      score: score,
+      out_of: out_of,
+      feedback: feedback,
+      datashop_session_id: datashop_session_id
+    }
   end
+
+  defp attrs_for({%{attempt_guid: attempt_guid, input: input}, {:ok, %SubmissionAction{}}}, datashop_session_id) do
+    %{
+      attempt_guid: attempt_guid,
+      response: input,
+      lifecycle_state: :submitted,
+      date_evaluated: nil,
+      date_submitted: true,
+      score: nil,
+      out_of: nil,
+      feedback: nil,
+      datashop_session_id: datashop_session_id
+    }
+  end
+
+  defp attrs_for(_, _), do: nil
+
+  defp handle_num(nil), do: "NULL::double precision"
+  defp handle_num(v), do: "#{v}"
+
+  defp handle_json(nil), do: "NULL::JSONB"
+  defp handle_json(map), do: "'#{Jason.encode!(map)}'::JSONB"
+
+  defp null_or_now(nil), do: "NULL::timestamp"
+  defp null_or_now(_), do: "NOW()"
+
 end


### PR DESCRIPTION
This PR streamlines the execution of the `submit_activity` endpoint by:

1. Eliminating the unnecessary call to `get_latest_part_attempts(activity_attempt.attempt_guid)` from within `submit_active_part_attempts ` when the calling code already had the part attempts and can just supply them as an argument.
2. Reworks `submit_active_part_attempts` to do a bulk edit, instead of a serial edit for each part attempt
3. Reworks `persist_evaluations` to do a bulk edit instead of serial edits for each part attempt