### PR TITLE
[ENHANCEMENT] add a cleanup task for publication diffs [MER-1596]

### DIFF
--- a/lib/oli/application.ex
+++ b/lib/oli/application.ex
@@ -36,11 +36,19 @@ defmodule Oli.Application do
           id: "cleanup_nonce_store_daily",
           start: {SchedEx, :run_every, [Lti_1p3.Nonces, :cleanup_nonce_store, [], "1 1 * * *"]}
         },
+        # Starts the login hint cleanup task
         %{
           id: "cleanup_login_hint_store_daily",
           start:
             {SchedEx, :run_every,
              [Lti_1p3.Platform.LoginHints, :cleanup_login_hint_store, [], "1 1 * * *"]}
+        },
+        # Starts the publication diff cleanup task
+        %{
+          id: "cleanup_publication_diffs_daily",
+          start:
+            {SchedEx, :run_every,
+             [Oli.Publishing.Publications.DiffAgent, :cleanup_diff_store, [], "1 1 * * *"]}
         },
 
         # Starts the publication diff agent store
@@ -67,6 +75,8 @@ defmodule Oli.Application do
 
     # Get the current oban config in all other nodes in the cluster
     nodes_config = :erpc.multicall(Node.list(), Oli.Application, :current_oban_config, [])
+
+    Oban.Telemetry.attach_default_logger()
 
     # Check if a node already has the part_mapping_refresh queue configured
     pm_refresh_already_setup? =

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -27,8 +27,7 @@ defmodule Oli.Delivery.Sections do
   alias Oli.Publishing.DeliveryResolver
   alias Oli.Resources.Revision
   alias Oli.Publishing.PublishedResource
-  alias Oli.Publishing.Publications.DiffAgent
-  alias Oli.Publishing.Publications.{PublicationDiff, PublicationDiffKey}
+  alias Oli.Publishing.Publications.{PublicationDiff}
   alias Oli.Accounts.User
   alias Lti_1p3.Tool.ContextRoles
   alias Lti_1p3.Tool.PlatformRoles
@@ -1157,19 +1156,7 @@ defmodule Oli.Delivery.Sections do
     current_hierarchy = DeliveryResolver.full_hierarchy(section.slug)
 
     # fetch diff from cache if one is available. If not, compute one on the fly
-    diff =
-      case DiffAgent.get(PublicationDiffKey.key(current_publication.id, new_publication.id)) do
-        nil ->
-          Logger.warn(
-            "No precomputed publication diff found for delta #{current_publication.id} -> #{new_publication.id}. Generating one now."
-          )
-
-          # generate a diff between the old and new publication
-          Publishing.diff_publications(current_publication, new_publication)
-
-        diff ->
-          diff
-      end
+    diff = Publishing.get_publication_diff(current_publication, new_publication)
 
     result =
       case diff do

--- a/lib/oli/publishing/publications/diff_agent.ex
+++ b/lib/oli/publishing/publications/diff_agent.ex
@@ -1,6 +1,8 @@
 defmodule Oli.Publishing.Publications.DiffAgent do
   use Agent
 
+  require Logger
+
   alias Oli.Publishing.Publications.{PublicationDiff, PublicationDiffKey}
 
   @doc """
@@ -31,5 +33,22 @@ defmodule Oli.Publishing.Publications.DiffAgent do
   """
   def delete(%PublicationDiffKey{key: key}) do
     Agent.get_and_update(__MODULE__, &Map.pop(&1, key))
+  end
+
+  @doc """
+  Removes all publication diffs older than 10 days
+  """
+  def cleanup_diff_store() do
+    Logger.info("Cleaning up publication diffs older than 10 days...")
+
+    ten_days_ago = Timex.now() |> Timex.subtract(Timex.Duration.from_days(10))
+
+    Agent.update(__MODULE__, fn cache ->
+      Enum.filter(cache, fn %PublicationDiff{created_at: created_at} ->
+        Timex.compare(created_at, ten_days_ago) > 0
+      end)
+    end)
+
+    Logger.info("Publication diff cleanup complete.")
   end
 end

--- a/lib/oli/publishing/publications/publication_diff.ex
+++ b/lib/oli/publishing/publications/publication_diff.ex
@@ -8,7 +8,8 @@ defmodule Oli.Publishing.Publications.PublicationDiff do
     :minor,
     :changes,
     :from_pub,
-    :to_pub
+    :to_pub,
+    :created_at
   ]
 
   defstruct [
@@ -18,7 +19,8 @@ defmodule Oli.Publishing.Publications.PublicationDiff do
     :minor,
     :changes,
     :from_pub,
-    :to_pub
+    :to_pub,
+    :created_at
   ]
 
   @type t() :: %__MODULE__{
@@ -28,6 +30,7 @@ defmodule Oli.Publishing.Publications.PublicationDiff do
           minor: Integer.t(),
           changes: Map.t(),
           from_pub: Publication.t(),
-          to_pub: Publication.t()
+          to_pub: Publication.t(),
+          created_at: DateTime.t()
         }
 end


### PR DESCRIPTION
Followup to #3166, this PR adds a diff to the cache when one is generated JIT and also adds a daily cleanup job to remove diffs that are 10 days or older.