### PR TITLE
[BUG FIX] fix lesson restart, eval persistence when no parts need saving [MER-1598]

### DIFF
--- a/assets/src/apps/delivery/layouts/deck/RestartLessonDialog.tsx
+++ b/assets/src/apps/delivery/layouts/deck/RestartLessonDialog.tsx
@@ -96,7 +96,6 @@ const RestartLessonDialog: React.FC<RestartLessonDialogProps> = ({ onRestart }) 
           <button className="btn">
             <a
               onClick={handleRestart}
-              href={isPreviewMode ? '#' : graded ? finalizeGradedURL : overviewURL}
               style={{ color: 'inherit', textDecoration: 'none' }}
               title="OK, Restart Lesson"
               aria-label="OK, Restart Lesson"


### PR DESCRIPTION
This PR fixes two problems encountered during regression testing:

1. The ability to "Restart" a graded adaptive page was broke.  The root cause here was an incomplete migration to the new POST based finalization API (away from the previous GET based HTML returning endpoint).  The "Ok" button in the popup dialog to confirm and initiate Restart still contained a hyperlink that triggered a GET request, with the URL now being the `/api/v1/page_lifecycle` JSON endpoint.  This triggers the "Not Found" error.    The solution here is to simply remove the `href` from that link and allow the onClick handler `handleRestart` to do its intended job. 

2. While replicating the above error, I stumbled across another regression.  There seem to be certain adaptive screens that when the trigger a check event the "evaluations"  end up only containing "StateUpdate" and "Navigation" actions, and zero "Submission" or "Feedback" actions.  The recent perf improvement to migrate to a bulk save of part attempt records in `lib/oli/delivery/attempts/activity_lifecycle/persistence.ex` did not take this into account (the previous impl was robust to this) and attempts to then execute a query where the SQL is invalid since the `values` variable is an empty string.  I was able to trigger this using Kingdom of Peril, on the second screen where I had entered my name, selected "King" as my stature but did NOT select an image.  Clicking Next triggers this problem.  This solution here is to simply check the length of the filtered `values` list before converting to comma separated string and invoking the SQL update. 