### PR TITLE
[BUG FIX] Left arrow cursor navigation does not work properly through all inline types [MER-1603]

### DIFF
--- a/assets/src/components/editing/elements/callout/calloutActions.ts
+++ b/assets/src/components/editing/elements/callout/calloutActions.ts
@@ -22,6 +22,6 @@ export const insertInlineCallout = createButtonCommandDesc({
     const at = editor.selection;
     if (!at) return;
 
-    Transforms.insertNodes(editor, Model.calloutInline(), { at, select: true });
+    Transforms.wrapNodes(editor, Model.calloutInline(), { at, split: true });
   },
 });

--- a/assets/src/components/editing/toolbar/HoverContainer.tsx
+++ b/assets/src/components/editing/toolbar/HoverContainer.tsx
@@ -1,4 +1,12 @@
-import React, { PropsWithChildren, useCallback, useEffect, useState, useRef } from 'react';
+import React, {
+  PropsWithChildren,
+  useCallback,
+  useEffect,
+  useState,
+  useRef,
+  ReactNode,
+  ReactChild,
+} from 'react';
 import { useMousedown } from 'components/misc/resizable/useMousedown';
 import { positionRect } from 'data/content/utils';
 import { Popover, PopoverAlign, PopoverPosition } from 'react-tiny-popover';
@@ -32,13 +40,17 @@ export const HoverContainer = (props: PropsWithChildren<Props>) => {
     [],
   );
 
-  const children = <span style={{ ...props.style }}>{props.children}</span>;
-
-  if (!isOpen) return children;
+  const children =
+    !props.children || props.style ? (
+      // Add a wrapping span if there are no children (so that <Popover> works) or if we have to add a style.
+      <span style={{ ...props.style }}>{props.children}</span>
+    ) : (
+      props.children
+    );
 
   return (
     <Popover
-      isOpen
+      isOpen={isOpen}
       reposition={props.reposition}
       contentLocation={(state) => {
         const childRect =

--- a/assets/src/components/editing/toolbar/HoverContainer.tsx
+++ b/assets/src/components/editing/toolbar/HoverContainer.tsx
@@ -1,12 +1,4 @@
-import React, {
-  PropsWithChildren,
-  useCallback,
-  useEffect,
-  useState,
-  useRef,
-  ReactNode,
-  ReactChild,
-} from 'react';
+import React, { PropsWithChildren, ReactNode, useCallback, useEffect, useState } from 'react';
 import { useMousedown } from 'components/misc/resizable/useMousedown';
 import { positionRect } from 'data/content/utils';
 import { Popover, PopoverAlign, PopoverPosition } from 'react-tiny-popover';
@@ -40,13 +32,14 @@ export const HoverContainer = (props: PropsWithChildren<Props>) => {
     [],
   );
 
-  const children =
+  const children = (
     !props.children || props.style ? (
       // Add a wrapping span if there are no children (so that <Popover> works) or if we have to add a style.
       <span style={{ ...props.style }}>{props.children}</span>
     ) : (
       props.children
-    );
+    )
+  ) as ReactNode & JSX.Element;
 
   return (
     <Popover


### PR DESCRIPTION
Fixes a cursor related bug and also inserting callouts now doesn't clear the selection.


https://user-images.githubusercontent.com/333265/206767114-9cac6aae-fe0f-4f35-9c20-956adcf20b17.mov

