### PR TITLE
[BUG FIX] Videos, youtube unusable when placed in hints or feedback [MER-1602]

### DIFF
--- a/assets/src/components/activities/common/hints/delivery/HintsDelivery.tsx
+++ b/assets/src/components/activities/common/hints/delivery/HintsDelivery.tsx
@@ -41,7 +41,11 @@ export const HintsDelivery: React.FC<Props> = ({
             className="d-flex align-items-center mb-2"
           >
             <span className="mr-2">{index + 1}.</span>
-            <HtmlContentModelRenderer content={hint.content} context={context} />
+            <HtmlContentModelRenderer
+              content={hint.content}
+              context={context}
+              style={{ width: '100%' }}
+            />
           </div>
         ))}
         {hasMoreHints && (

--- a/assets/src/data/content/model/schema.ts
+++ b/assets/src/data/content/model/schema.ts
@@ -82,7 +82,8 @@ export interface SchemaConfig {
   isSimpleText?: boolean;
 }
 
-interface Schema extends Record<AllModelElements['type'], SchemaConfig> {}
+export type ModelTypes = AllModelElements['type'];
+interface Schema extends Record<ModelTypes, SchemaConfig> {}
 export const schema: Schema = {
   p: {
     isVoid: false,

--- a/assets/src/utils/common.ts
+++ b/assets/src/utils/common.ts
@@ -1,3 +1,5 @@
+import { ModelTypes, schema } from '../data/content/model/schema';
+
 /**
  * Returns the given value if it is not null or undefined. Otherwise, it returns
  * the default value. The return value will always be a defined value of the type given
@@ -31,6 +33,14 @@ function hasContent(item: any): boolean {
     if (!item) return false;
     if (typeof item?.type === 'string' && item.type !== 'p') return true;
     if (Array.isArray(item)) return item.some(hasContent);
+
+    if (item?.type) {
+      const s = schema[item.type as ModelTypes];
+      const sc = schema;
+      // We'll assume void elements are content.
+      if (s?.isVoid) return true;
+    }
+
     if (item.text) return item.text?.trim();
 
     return ([item?.children, item?.content, item?.content?.model] as any)

--- a/lib/oli/activities/parse_utils.ex
+++ b/lib/oli/activities/parse_utils.ex
@@ -43,6 +43,23 @@ defmodule Oli.Activities.ParseUtils do
       xs when is_list(xs) ->
         Enum.any?(for x <- xs, do: has_content?(x))
 
+      # These elements ARE content, even if they don't have children or text in them.
+      %{"type" => t}
+      when t in [
+             "img",
+             "img_inline",
+             "conjugation",
+             "dialog",
+             "definition",
+             "formula",
+             "formula_inline",
+             "youtube",
+             "audio",
+             "iframe",
+             "video"
+           ] ->
+        true
+
       %{content: content} ->
         case content do
           # :model -> former impl when selection was persisted


### PR DESCRIPTION
This fixes two bugs

1. If you inserted a video into a hint, the video would be sized based on other content in that hint. If there was no other content, it would be very tiny and unusable.
2. If you inserted ONLY a video into a single hint, the "request a hint" link would not show up.

The second one was caused by us filtering out "empty" hints with an improper definition of "empty"