### PR TITLE
[BUGFIX] Don't show hints on graded pages. [MER-1607]

### DIFF
--- a/assets/src/components/activities/common/hints/delivery/HintsDeliveryConnected.tsx
+++ b/assets/src/components/activities/common/hints/delivery/HintsDeliveryConnected.tsx
@@ -27,6 +27,7 @@ const shouldShow = (
   correct: boolean,
   shouldShow?: boolean,
 ) => {
+  if (graded) return false;
   if (surveyId !== null) return false;
   if (!correct) return true;
 


### PR DESCRIPTION
We were showing hints on graded pages, this removes that.