### PR TITLE
[BUG FIX] Correct logic for showing submit button in File Upload [MER-1614]

### DIFF
--- a/assets/src/components/activities/file_upload/FileUploadDelivery.tsx
+++ b/assets/src/components/activities/file_upload/FileUploadDelivery.tsx
@@ -299,7 +299,7 @@ export const FileUploadComponent: React.FC = () => {
 
         <ResetButtonConnected onReset={() => dispatch(resetAction(onResetActivity, resetParts))} />
         <SubmitButton
-          shouldShow={!isSubmitted(uiState) && !graded && surveyId === undefined}
+          shouldShow={!isSubmitted(uiState) && !graded && (surveyId === undefined || surveyId === null)}
           disabled={getFilesFromState(uiState).length === 0}
           onClick={() => dispatch(submitFiles(onSubmitActivity, getFilesFromState))}
         />


### PR DESCRIPTION
The "Submit" button was not appearing in practice pages due to `surveyId` only being compared to `undefined`.  It actually is `null`.  Left the `undefined` there just to be more safe. 

With this fix in place, I can now see the "Submit" button and can submit the attempt for the uploaded files. 