### PR TITLE
[BUG FIX] Attempt numbering can be wrong for pages that switch to graded [MER-1625]

### DIFF
--- a/lib/oli_web/templates/page_delivery/prologue.html.eex
+++ b/lib/oli_web/templates/page_delivery/prologue.html.eex
@@ -10,15 +10,15 @@
   <% end %>
   <p><%= @message %></p>
   <div>
-  <%= for resource_attempt <- @resource_attempts do %>
+  <%= for {resource_attempt, attempt_number} <- Enum.with_index(@resource_attempts, 1) do %>
   <div class="mb-2">
     <h5 class="mb-0">
       <%= link to: Routes.page_delivery_path(@conn, :review_attempt, @section_slug, @slug, resource_attempt.attempt_guid) do %>
 
       <%= if @max_attempts == 0 do %>
-        <span>Attempt <%= resource_attempt.attempt_number %></span>
+        <span>Attempt <%= attempt_number %></span>
         <% else %>
-        <span>Attempt <%= resource_attempt.attempt_number %> of <%= @max_attempts %></span>
+        <span>Attempt <%= attempt_number %> of <%= @max_attempts %></span>
         <% end %>
       <% end %>
     </h5>


### PR DESCRIPTION
Fix here is to ignore the attempt_number on the record, and calculate it JIT.  This ignores any previous practice attempts that might exist. 