### PR TITLE
[BUGFIX] [MER-1622] products are receiving major course project updates they should not

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -1165,8 +1165,9 @@ defmodule Oli.Delivery.Sections do
 
         %PublicationDiff{classification: :major} ->
           cond do
-            # Case 1: The course section is based on this project, but not seeded from a product
-            section.base_project_id == project_id and is_nil(section.blueprint_id) ->
+            # Case 1: The course section is based on this project, but is not a product and is not seeded from a product
+            section.base_project_id == project_id and section.type == :enrollable and
+                is_nil(section.blueprint_id) ->
               perform_update(
                 :major,
                 section,
@@ -1179,7 +1180,11 @@ defmodule Oli.Delivery.Sections do
             section.base_project_id == project_id and !is_nil(section.blueprint_id) ->
               perform_update(:minor, section, project_id, new_publication, current_hierarchy)
 
-            # Case 3: The course section is not based on this project (but it remixes some materials from project)
+            # Case 3: The course section is a product based on this project
+            section.base_project_id == project_id and section.type == :blueprint ->
+              perform_update(:minor, section, project_id, new_publication, current_hierarchy)
+
+            # Case 4: The course section is not based on this project (but it remixes some materials from project)
             true ->
               perform_update(:minor, section, project_id, new_publication, current_hierarchy)
           end

--- a/test/oli/sections_test.exs
+++ b/test/oli/sections_test.exs
@@ -870,10 +870,9 @@ defmodule Oli.SectionsTest do
       page1: page1,
       revision1: revision1,
       page2: page2,
-      revision2: revision2,
-      institution: institution
+      revision2: revision2
     } do
-      {:ok, initial_pub} = Publishing.publish_project(project, "some changes")
+      {:ok, _initial_pub} = Publishing.publish_project(project, "some changes")
 
       %{product: product, section: section} =
         %{}

--- a/test/oli/sections_test.exs
+++ b/test/oli/sections_test.exs
@@ -2,6 +2,7 @@ defmodule Oli.SectionsTest do
   use Oli.DataCase
 
   import Oli.Factory
+  import Oli.Utils.Seeder.Utils
 
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.Section
@@ -860,6 +861,176 @@ defmodule Oli.SectionsTest do
 
       assert section_resources
              |> Enum.find(fn sr -> sr.resource_id == Map.get(map, :o1).resource.id end)
+    end
+
+    test "apply_publication_update/2 only applies minor changes to products", %{
+      author: author,
+      project: project,
+      container: %{resource: container_resource, revision: container_revision},
+      page1: page1,
+      revision1: revision1,
+      page2: page2,
+      revision2: revision2,
+      institution: institution
+    } do
+      {:ok, initial_pub} = Publishing.publish_project(project, "some changes")
+
+      %{product: product, section: section} =
+        %{}
+        |> Oli.Utils.Seeder.Project.create_product("Product 1", project, product_tag: :product)
+        |> Oli.Utils.Seeder.Section.create_section_from_product(ref(:product), nil, nil, %{},
+          section_tag: :section
+        )
+
+      # verify the curriculum precondition
+      hierarchy = DeliveryResolver.full_hierarchy(section.slug)
+
+      assert hierarchy.children |> Enum.count() == 2
+      assert hierarchy.children |> Enum.at(0) |> Map.get(:resource_id) == page1.id
+      assert hierarchy.children |> Enum.at(1) |> Map.get(:resource_id) == page2.id
+
+      # make some changes to project and publish
+      working_pub = Publishing.project_working_publication(project.slug)
+
+      # minor resource content changes
+      page1_changes = %{
+        "content" => %{
+          "model" => [
+            %{
+              "type" => "content",
+              "children" => [%{"type" => "p", "children" => [%{"text" => "SECOND"}]}]
+            }
+          ]
+        }
+      }
+
+      Seeder.revise_page(page1_changes, page1, revision1, working_pub)
+
+      # add some pages to the root container
+      %{resource: p1_new_page1, revision: _revision} =
+        Seeder.create_page("P1 New Page one", working_pub, project, author)
+
+      %{resource: p1_new_page2, revision: _revision} =
+        Seeder.create_page("P1 New Page two", working_pub, project, author)
+
+      container_revision =
+        Seeder.attach_pages_to(
+          [p1_new_page1, p1_new_page2],
+          container_resource,
+          container_revision,
+          working_pub
+        )
+
+      # create a unit
+      %{resource: unit1_resource, revision: unit1_revision} =
+        Seeder.create_container("Unit 1", working_pub, project, author)
+
+      # create some nested children
+      %{resource: nested_page1, revision: _nested_revision1} =
+        Seeder.create_page("Nested Page One", working_pub, project, author)
+
+      %{resource: nested_page2, revision: _nested_revision2} =
+        Seeder.create_page(
+          "Nested Page Two",
+          working_pub,
+          project,
+          author,
+          Seeder.create_sample_content()
+        )
+
+      _unit1_revision =
+        Seeder.attach_pages_to(
+          [nested_page1, nested_page2],
+          unit1_resource,
+          unit1_revision,
+          working_pub
+        )
+
+      container_revision =
+        Seeder.attach_pages_to(
+          [unit1_resource],
+          container_resource,
+          container_revision,
+          working_pub
+        )
+
+      # remove page 2
+      _deleted_revision =
+        Seeder.delete_page(page2, revision2, container_resource, container_revision, working_pub)
+
+      # publish changes
+      {:ok, latest_publication} = Publishing.publish_project(project, "some changes")
+
+      # apply the new publication update to the product
+      Sections.apply_publication_update(product, latest_publication.id)
+
+      # reload latest hierarchy
+      product_hierarchy = DeliveryResolver.full_hierarchy(product.slug)
+
+      # verify non-structural changes are applied as expected
+      assert product_hierarchy.children |> Enum.at(0) |> then(& &1.revision.content) ==
+               page1_changes["content"]
+
+      # verify structural changes are not applied tp product
+      assert product_hierarchy.children |> Enum.count() == 2
+      assert product_hierarchy.children |> Enum.at(0) |> Map.get(:resource_id) == page1.id
+      assert product_hierarchy.children |> Enum.at(1) |> Map.get(:resource_id) == page2.id
+
+      # verify the final number of section resource records matches what is
+      # expected to guard against section resource record leaks
+      product_id = product.id
+
+      product_section_resources =
+        from(sr in SectionResource,
+          where: sr.section_id == ^product_id
+        )
+        |> Repo.all()
+
+      assert product_section_resources |> Enum.count() == 7
+
+      # apply the new publication update to the section
+      Sections.apply_publication_update(section, latest_publication.id)
+
+      # reload latest hierarchy
+      hierarchy = DeliveryResolver.full_hierarchy(section.slug)
+
+      # verify non-structural changes are applied as expected
+      assert hierarchy.children |> Enum.at(0) |> then(& &1.revision.content) ==
+               page1_changes["content"]
+
+      # verify the updated curriculum structure matches the expected result
+
+      assert hierarchy.children |> Enum.count() == 4
+      assert hierarchy.children |> Enum.at(0) |> Map.get(:resource_id) == page1.id
+      assert hierarchy.children |> Enum.at(1) |> Map.get(:resource_id) == p1_new_page1.id
+      assert hierarchy.children |> Enum.at(2) |> Map.get(:resource_id) == p1_new_page2.id
+      assert hierarchy.children |> Enum.at(3) |> Map.get(:resource_id) == unit1_resource.id
+
+      assert hierarchy.children |> Enum.at(3) |> Map.get(:children) |> Enum.count() == 2
+
+      assert hierarchy.children
+             |> Enum.at(3)
+             |> Map.get(:children)
+             |> Enum.at(0)
+             |> Map.get(:resource_id) == nested_page1.id
+
+      assert hierarchy.children
+             |> Enum.at(3)
+             |> Map.get(:children)
+             |> Enum.at(1)
+             |> Map.get(:resource_id) == nested_page2.id
+
+      # verify the final number of section resource records matches what is
+      # expected to guard against section resource record leaks
+      section_id = section.id
+
+      section_resources =
+        from(sr in SectionResource,
+          where: sr.section_id == ^section_id
+        )
+        |> Repo.all()
+
+      assert section_resources |> Enum.count() == 8
     end
   end
 


### PR DESCRIPTION
This PR fixes an issue where major updates were changing the hierarchical structure of products. With this fix, only minor changes will be applied to a product during an update.