### PR TITLE
[BUGFIX] Make popup text bold/green all the time. [MER-1620]

### DIFF
--- a/assets/src/components/editing/elements/popup/PopupElement.scss
+++ b/assets/src/components/editing/elements/popup/PopupElement.scss
@@ -1,9 +1,10 @@
 @use 'authoring/theme' as authoring;
 
 .popup__anchorText {
-  color: authoring.$orange;
+  color: authoring.$green;
   font-style: italic;
   cursor: pointer;
+  font-weight: bold;
 }
 
 .slate-editor .popup__anchorText {

--- a/assets/styles/common/elements.scss
+++ b/assets/styles/common/elements.scss
@@ -1,8 +1,9 @@
 @import 'bootstrap';
 
+.popup__anchorText,
 span.term {
   font-weight: bold;
-  color: #709e30;
+  color: #63a372;
   font-style: italic;
 }
 


### PR DESCRIPTION
This makes all the popover text green & bold in both authoring, preview, and delivery.

Authoring:
![image](https://user-images.githubusercontent.com/333265/207666107-13e22533-5096-4db1-a0a5-e2b4c51a4686.png)


Preview:
![image](https://user-images.githubusercontent.com/333265/207666053-fb9a5327-b111-41e5-af68-7e66f33303c8.png)


Delivery:
![image](https://user-images.githubusercontent.com/333265/207665989-5445afd8-559a-4edc-a7a1-473863041221.png)
