### PR TITLE
[BUGFIX] [MER-1627] ensure resolvers of type do not return deleted items

### DIFF
--- a/lib/oli/publishing/authoring_resolver.ex
+++ b/lib/oli/publishing/authoring_resolver.ex
@@ -141,7 +141,7 @@ defmodule Oli.Publishing.AuthoringResolver do
         on: rev.id == m.revision_id,
         where:
           m.publication_id in subquery(project_working_publication(project_slug)) and
-            rev.resource_type_id == ^resource_type_id,
+            rev.resource_type_id == ^resource_type_id and rev.deleted == false,
         select: rev
       )
       |> Repo.all()

--- a/lib/oli/publishing/delivery_resolver.ex
+++ b/lib/oli/publishing/delivery_resolver.ex
@@ -150,7 +150,7 @@ defmodule Oli.Publishing.DeliveryResolver do
   def revisions_of_type(section_slug, resource_type_id) do
     fn ->
       from([s: s, sr: sr, rev: rev] in section_resource_revisions(section_slug),
-        where: rev.resource_type_id == ^resource_type_id,
+        where: rev.resource_type_id == ^resource_type_id and rev.deleted == false,
         select: rev
       )
       |> Repo.all()

--- a/test/oli/publishing/delivery_resolver_test.exs
+++ b/test/oli/publishing/delivery_resolver_test.exs
@@ -2,6 +2,7 @@ defmodule Oli.Publishing.DeliveryResolverTest do
   use Oli.DataCase
 
   alias Oli.Publishing.DeliveryResolver
+  alias Oli.Resources.ResourceType
 
   describe "delivery resolution" do
     setup do
@@ -192,6 +193,25 @@ defmodule Oli.Publishing.DeliveryResolverTest do
              |> Enum.at(0)
              |> Map.get(:numbering)
              |> Map.get(:level) == 2
+    end
+
+    test "revisions_of_type/2 returns all revisions of a specified type", %{
+      section_1: section
+    } do
+      revisions =
+        DeliveryResolver.revisions_of_type(
+          section.slug,
+          ResourceType.get_id_by_type("page")
+        )
+
+      assert Enum.count(revisions) == 4
+
+      assert revisions |> Enum.map(& &1.title) |> Enum.sort() == [
+               "Nested Page One",
+               "Nested Page Two",
+               "Page one",
+               "Page two"
+             ]
     end
   end
 end


### PR DESCRIPTION
Fixes an issue where alternatives options were still showing deleted alternatives groups as an option in the editor.

The underlying issue is that the resolvers `revisions_of_type` were not filtering out deleted revisions.