### PR TITLE
[MER-1613] Build hierarchy from previous_next_index on course index

### DIFF
--- a/lib/oli_web/templates/page_delivery/_link_assessment.html.eex
+++ b/lib/oli_web/templates/page_delivery/_link_assessment.html.eex
@@ -1,13 +1,13 @@
 <div class="d-flex border-bottom mb-2" style="border-color: #dee2e6;">
   <div class="flex-grow-1">
-    <%= link to: @page_link_url.(@node.revision.slug),
-      class: resource_link_class(@active_page == @node.revision.slug) do %>
+    <%= link to: @page_link_url.(from_node(@node, :slug)),
+      class: resource_link_class(@active_page == from_node(@node, :slug)) do %>
       <span class="page-title">
-        <i class="far fa-check-circle mr-2"></i> <%= @node.revision.title %>
+        <i class="far fa-check-circle mr-2"></i> <%= from_node(@node, :title) %>
       </span>
     <% end %>
   </div>
   <div class="mr-2">
-    <%= @node.numbering.index %>
+    <%= node_index(@node) %>
   </div>
 </div>

--- a/lib/oli_web/templates/page_delivery/_link_container.html.eex
+++ b/lib/oli_web/templates/page_delivery/_link_container.html.eex
@@ -1,8 +1,8 @@
 
 <div class="border-bottom mb-2" style="border-color: #dee2e6;">
   <h5 class="text-primary border-primary mb-2">
-    <%= link to: @container_link_url.(@node.revision.slug),
-      class: resource_link_class(@active_page == @node.revision.slug) do %>
+    <%= link to: @container_link_url.(from_node(@node, :slug)),
+      class: resource_link_class(@active_page == from_node(@node, :slug)) do %>
       <span class="container-title my-2">
         <%= container_title(@node, @display_curriculum_item_numbering) %>
       </span>
@@ -10,12 +10,12 @@
   </h5>
 </div>
 
-<%= if Enum.empty?(@node.children) do %>
+<%= if Enum.empty?(node_children(@node)) do %>
   <div class="text-secondary">There are no items</div>
 <% else %>
   <ol style="list-style: none; padding-left: 24px;">
     <%= render"_outline.html", Map.merge(assigns, %{
-      nodes: @node.children,
+      nodes: node_children(@node),
       active_page: nil,
     }) %>
   </ol>

--- a/lib/oli_web/templates/page_delivery/_link_page.html.eex
+++ b/lib/oli_web/templates/page_delivery/_link_page.html.eex
@@ -1,13 +1,13 @@
 <div class="d-flex border-bottom mb-2" style="border-color: #dee2e6;">
   <div class="flex-grow-1">
-    <%= link to: @page_link_url.(@node.revision.slug),
-      class: resource_link_class(@active_page == @node.revision.slug) do %>
+    <%= link to: @page_link_url.(from_node(@node, :slug)),
+      class: resource_link_class(@active_page == from_node(@node, :slug)) do %>
       <span class="page-title">
-        <i class="far fa-file mr-2"></i> <%= @node.revision.title %>
+        <i class="far fa-file mr-2"></i> <%= from_node(@node, :title) %>
       </span>
     <% end %>
   </div>
   <div class="mr-2">
-    <%= @node.numbering.index %>
+    <%= node_index(@node) %>
   </div>
 </div>

--- a/lib/oli_web/templates/page_delivery/_link_shallow_container.html.eex
+++ b/lib/oli_web/templates/page_delivery/_link_shallow_container.html.eex
@@ -1,6 +1,6 @@
 <div class="border-bottom mb-2" style="border-color: #dee2e6;">
-  <%= link to: @container_link_url.(@node.revision.slug),
-    class: resource_link_class(@active_page == @node.revision.slug) do %>
+  <%= link to: @container_link_url.(from_node(@node, :slug)),
+    class: resource_link_class(@active_page == from_node(@node, :slug)) do %>
     <span class="container-title my-2">
       <%= container_title(@node, @display_curriculum_item_numbering) %>
     </span>

--- a/lib/oli_web/templates/page_delivery/_outline.html.eex
+++ b/lib/oli_web/templates/page_delivery/_outline.html.eex
@@ -2,12 +2,12 @@
   <li>
   <% props = Map.merge(assigns, %{
     node: node,
-    nodes: node.children,
+    nodes: node_children(node),
   }) %>
   <%= cond do %>
-    <% container?(node.revision) -> %>
+    <% container?(node) -> %>
       <%= render "_link_container.html", props %>
-    <% node.revision.graded -> %>
+    <% from_node(node, :graded) -> %>
       <%= render "_link_assessment.html", props %>
     <% true -> %>
       <%= render "_link_page.html", props %>

--- a/lib/oli_web/views/page_delivery_view.ex
+++ b/lib/oli_web/views/page_delivery_view.ex
@@ -108,9 +108,22 @@ defmodule OliWeb.PageDeliveryView do
     end
   end
 
-  def container?(rev) do
-    ResourceType.get_type_by_id(rev.resource_type_id) == "container"
-  end
+  def from_node(%HierarchyNode{revision: revision}, field), do: Map.get(revision, field)
+  def from_node(map, field), do: Map.get(map, Atom.to_string(field))
+
+  def node_index(%HierarchyNode{numbering: %Numbering{index: index}}), do: index
+  def node_index(%{"index" => index}), do: index
+
+  def node_children(%HierarchyNode{children: children}), do: children
+  def node_children(%{"children" => children}), do: children
+
+  def container?(%HierarchyNode{revision: %{resource_type_id: resource_type_id}}),
+    do: ResourceType.get_type_by_id(resource_type_id) == "container"
+  def container?(%{resource_type_id: resource_type_id}),
+    do: ResourceType.get_type_by_id(resource_type_id) == "container"
+  def container?(%{"type" => type}), do: type == "container"
+
+  def container_title(_node, display_curriculum_item_numbering \\ true)
 
   def container_title(
         %HierarchyNode{
@@ -119,11 +132,30 @@ defmodule OliWeb.PageDeliveryView do
           },
           revision: revision
         } = h,
-        display_curriculum_item_numbering \\ true
+        display_curriculum_item_numbering
       ) do
     if display_curriculum_item_numbering,
       do: "#{Numbering.container_type_label(h.numbering)} #{index}: #{revision.title}",
       else: "#{Numbering.container_type_label(h.numbering)}: #{revision.title}"
+  end
+
+  def container_title(
+        %{
+          "index" => index,
+          "title" => title,
+          "level" => level
+        },
+        display_curriculum_item_numbering
+      ) do
+    numbering = %Numbering{
+      level: String.to_integer(level),
+      index: String.to_integer(index),
+      labels: Oli.Branding.CustomLabels.default()
+    }
+
+    if display_curriculum_item_numbering,
+      do: "#{Numbering.container_type_label(numbering)} #{index}: #{title}",
+      else: "#{Numbering.container_type_label(numbering)}: #{title}"
   end
 
   def has_submitted_attempt?(resource_access) do


### PR DESCRIPTION
[MER-1613](https://eliterate.atlassian.net/browse/MER-1613)

Analyzed the query to build the hierarchy itself and from a SQL perspective there isn't much else to improve as it goes through indices (basically primary keys). One minor improvement we can make is to not retrieve as much data that is being fetched now, since not all of it is needed but would require further investigation.

Instead we look for another approach using the `previous_next_index` field in the section. Calling `retrieve` from `PreviousNextIndex` should be safe enough to always retrieve the correct hierarchy at the moment.

The hierarchy query will only be called when that field is null, but any other time a student enters the index it will just use that data.