### PR TITLE
[BUGFIX] Media browser crashing in popup editor [MER-1637]

### DIFF
--- a/assets/src/apps/authoring/components/PropertyEditor/custom/TorusAudioBrowser.tsx
+++ b/assets/src/apps/authoring/components/PropertyEditor/custom/TorusAudioBrowser.tsx
@@ -6,16 +6,9 @@ import { useToggle } from '../../../../../components/hooks/useToggle';
 import { MIMETYPE_FILTERS } from '../../../../../components/media/manager/MediaManager';
 import { selectProjectSlug } from '../../../store/app/slice';
 import { MediaPickerModal } from '../../Modal/MediaPickerModal';
+import { MediaBrowserComponent, TorusMediaBrowserWrapper } from './TorusMediaBrowserWrapper';
 
-interface Props {
-  id: string;
-  label: string;
-  value: string;
-  onChange: (url: string) => void;
-  onBlur: (id: string, url: string) => void;
-}
-
-export const TorusAudioBrowser: React.FC<Props> = ({ id, label, value, onChange, onBlur }) => {
+const _TorusAudioBrowser: MediaBrowserComponent = ({ id, label, value, onChange, onBlur }) => {
   const [pickerOpen, , openPicker, closePicker] = useToggle();
   const projectSlug: string = useSelector(selectProjectSlug);
   const { audioPlayer, playAudio, isPlaying } = useAudio(value);
@@ -75,3 +68,5 @@ export const TorusAudioBrowser: React.FC<Props> = ({ id, label, value, onChange,
     </span>
   );
 };
+
+export const TorusAudioBrowser = TorusMediaBrowserWrapper(_TorusAudioBrowser);

--- a/assets/src/apps/authoring/components/PropertyEditor/custom/TorusImageBrowser.tsx
+++ b/assets/src/apps/authoring/components/PropertyEditor/custom/TorusImageBrowser.tsx
@@ -4,16 +4,9 @@ import { useSelector } from 'react-redux';
 import { useToggle } from '../../../../../components/hooks/useToggle';
 import { selectProjectSlug } from '../../../store/app/slice';
 import { MediaPickerModal } from '../../Modal/MediaPickerModal';
+import { MediaBrowserComponent, TorusMediaBrowserWrapper } from './TorusMediaBrowserWrapper';
 
-interface Props {
-  id: string;
-  label: string;
-  value: string;
-  onChange: (url: string) => void;
-  onBlur: (id: string, url: string) => void;
-}
-
-export const TorusImageBrowser: React.FC<Props> = ({ id, label, value, onChange, onBlur }) => {
+const _TorusImageBrowser: MediaBrowserComponent = ({ id, label, value, onChange, onBlur }) => {
   const [pickerOpen, , openPicker, closePicker] = useToggle();
   const projectSlug: string = useSelector(selectProjectSlug);
 
@@ -61,3 +54,5 @@ export const TorusImageBrowser: React.FC<Props> = ({ id, label, value, onChange,
     </span>
   );
 };
+
+export const TorusImageBrowser = TorusMediaBrowserWrapper(_TorusImageBrowser);

--- a/assets/src/apps/authoring/components/PropertyEditor/custom/TorusMediaBrowserWrapper.tsx
+++ b/assets/src/apps/authoring/components/PropertyEditor/custom/TorusMediaBrowserWrapper.tsx
@@ -1,0 +1,52 @@
+import React, { useContext } from 'react';
+import { ReactReduxContext } from 'react-redux';
+/**
+ * In some contexts, this is instantiated inside the main adaptive authoring app with a full redux store set up. In those cases, we can
+ * provide a nice torus media browser interface. In other contexts, we don't have a redux store set up, so we can't provide that and will
+ * default to just a plain text input.
+ *
+ * This handles trying the browser first, and then defaulting to the plain text input.
+ *
+ * Usage:
+ *   const Component = TorusMediaBrowserWrapper(SubComponent);
+ *   <Component id="" label="" value="" onChange={() => {}} onBlur={() => {}} />
+ *
+ * Where Component is the new component that wraps SubComponent in the redux check.
+ *
+ */
+
+export interface MediaBrowserProps {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (url: string) => void;
+  onBlur: (id: string, url: string) => void;
+}
+
+export type MediaBrowserComponent = React.FC<MediaBrowserProps>;
+
+export const TorusMediaBrowserWrapper = (
+  SubComponent: MediaBrowserComponent,
+): React.FC<MediaBrowserProps> => {
+  const Component: MediaBrowserComponent = (props) => {
+    const reduxContext = useContext(ReactReduxContext);
+    if (reduxContext) {
+      return <SubComponent {...props} />;
+    } else {
+      return (
+        <div className="mb-0 form-group">
+          <label className="form-label">{props.label}</label>
+          <input
+            type="text"
+            className="form-control"
+            value={props.value}
+            onChange={(event) => props.onChange(event.target.value)}
+            onBlur={(event) => props.onBlur(props.id, event.target.value)}
+          />
+        </div>
+      );
+    }
+  };
+  Component.displayName = `TorusMediaBrowser(${SubComponent.displayName})`;
+  return Component;
+};

--- a/assets/src/apps/authoring/components/PropertyEditor/custom/TorusVideoBrowser.tsx
+++ b/assets/src/apps/authoring/components/PropertyEditor/custom/TorusVideoBrowser.tsx
@@ -5,16 +5,9 @@ import { useToggle } from '../../../../../components/hooks/useToggle';
 import { MIMETYPE_FILTERS } from '../../../../../components/media/manager/MediaManager';
 import { selectProjectSlug } from '../../../store/app/slice';
 import { MediaPickerModal } from '../../Modal/MediaPickerModal';
+import { MediaBrowserComponent, TorusMediaBrowserWrapper } from './TorusMediaBrowserWrapper';
 
-interface Props {
-  id: string;
-  label: string;
-  value: string;
-  onChange: (url: string) => void;
-  onBlur: (id: string, url: string) => void;
-}
-
-export const TorusVideoBrowser: React.FC<Props> = ({ id, label, value, onChange, onBlur }) => {
+const _TorusVideoBrowser: MediaBrowserComponent = ({ id, label, value, onChange, onBlur }) => {
   const [pickerOpen, , openPicker, closePicker] = useToggle();
   const projectSlug: string = useSelector(selectProjectSlug);
 
@@ -56,3 +49,5 @@ export const TorusVideoBrowser: React.FC<Props> = ({ id, label, value, onChange,
     </span>
   );
 };
+
+export const TorusVideoBrowser = TorusMediaBrowserWrapper(_TorusVideoBrowser);


### PR DESCRIPTION
Bug:

1. Create an adaptive page
2. Add a popup to it
3. Edit the content of the popup
4. Add an image, video, or audio element

Expected: the element is added
Actual: the browser crashes.

This is caused by that popup content editor being a part of the popup web component in it's own react context instead of being part of the main authoring react app.

After this fix, you will get the old text-input box to enter the urls for those 3 components. A future update will attempt to re-introduce the media browser.

![popupmeia](https://user-images.githubusercontent.com/333265/208492793-67296b71-0f6d-4900-a182-7aba93e98afa.gif)

