### PR TITLE
[BUG FIX] maintain proper top-level ordering in outline rendering [MER-1640]

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -561,6 +561,26 @@ defmodule Oli.Delivery.Sections do
     |> Repo.all()
   end
 
+
+  @doc """
+  For a section resource record, map its children SR records to resource ids,
+  of course preserving the order of the children list.
+
+  ## Examples
+      iex> map_section_resource_children_to_resource_ids(root_resource)
+      [1, 2, 3, 4]
+  """
+  def map_section_resource_children_to_resource_ids(root_section_resource) do
+
+    srs = from(s in SectionResource,
+      where: s.id in ^root_section_resource.children
+    )
+    |> Repo.all()
+    |> Enum.reduce(%{}, fn sr, map -> Map.put(map, sr.id, sr.resource_id) end)
+
+    Enum.map(root_section_resource.children, fn sr_id -> Map.get(srs, sr_id) end)
+  end
+
   @doc """
   Creates a section resource.
   ## Examples


### PR DESCRIPTION
This fixes a problem with outline rendering.  The previous impl did not preserve the proper top level ordering - it merely was iterating through the natural map key ordering of `hierarchy`.  This surprisingly works okay for a large majority of cases - but would break as soon as someone would course remix and would top-level reorder.

The source of truth for top-level ordering is the `children` attribute of the `root_section_resource` record.  But those ids are SR ids, not resource_ids. Our cached hierarchy is all in resource ids.  So a fetch of those resource_ids is made and then the top level is mapped thru that ordering to ensure that it is correct. 
