### PR TITLE
[BUGFIX] Ability to stop certain audio when it is playing. [MER-1632]

### DIFF
--- a/assets/src/phoenix/app.ts
+++ b/assets/src/phoenix/app.ts
@@ -77,8 +77,7 @@ $(() => {
     const audioAttribute = this.attributes.getNamedItem('data-audio');
     if (audioAttribute && audioAttribute.value !== '') {
       const audio = ($('#' + audioAttribute.value) as JQuery<HTMLAudioElement>)[0];
-      audio.currentTime = 0;
-      audio.play();
+      window.toggleAudio(audio);
     }
   });
 
@@ -121,9 +120,28 @@ $(() => {
   (window as any).hljs.highlightAll();
 });
 
+let currentlyPlaying: HTMLAudioElement | null = null;
+
+window.toggleAudio = (element: HTMLAudioElement) => {
+  if (!element) return;
+
+  if (currentlyPlaying && currentlyPlaying !== element) {
+    currentlyPlaying.pause();
+  }
+
+  if (element.paused) {
+    currentlyPlaying = element;
+    element.currentTime = 0;
+    element.play();
+  } else {
+    element.pause();
+  }
+};
+
 declare global {
   interface Window {
     liveSocket: typeof liveSocket;
+    toggleAudio: (element: HTMLAudioElement) => void;
     OLI: {
       initActivityBridge: typeof initActivityBridge;
       initPreviewActivityBridge: typeof initPreviewActivityBridge;

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -331,7 +331,8 @@ defmodule Oli.Rendering.Content.Html do
 
   defp audio_player(src) do
     audio_id = UUID.uuid4()
-    play_code = "document.getElementById(\"#{audio_id}\").play();"
+    # See app.ts for toggleAudio()
+    play_code = "window.toggleAudio(document.getElementById(\"#{audio_id}\"));"
     audio_element = "<audio id='#{audio_id}' src='#{escape_xml!(src)}' preload='auto'></audio>"
     [audio_element, play_code, audio_id]
   end


### PR DESCRIPTION
There were three places that played audio not inside a react component. Those are:

1. Pronunciation in a definition
2. Pronunciation in a conjugation
3. A table entry in conjugation

All can be seen here:

![image](https://user-images.githubusercontent.com/333265/208752021-19db758e-2040-4035-b36d-05b4eaa30689.png)

If you had a long audio file set, there was no way to interrupt the playing of that file. Now you can by clicking the link a second time.
