### PR TITLE
[BUGFIX] Allow editing youtube by url [MER-1634]

### DIFF
--- a/assets/src/components/editing/elements/youtube/YoutubeElement.tsx
+++ b/assets/src/components/editing/elements/youtube/YoutubeElement.tsx
@@ -15,6 +15,7 @@ import { YouTubeModal } from './YoutubeModal';
 import { modalActions } from 'actions/modal';
 import { createButtonCommandDesc } from 'components/editing/elements/commands/commandFactories';
 import { CommandButton } from 'components/editing/toolbar/buttons/CommandButton';
+import { youtubeUrlToId } from './youtubeActions';
 
 const toLink = (src = '') => 'https://www.youtube.com/embed/' + (src === '' ? CUTE_OTTERS : src);
 
@@ -139,7 +140,7 @@ const SettingsButton = (props: SettingsButtonProps) => (
               model={props.model}
               onDone={({ alt, width, src }: Partial<ContentModel.YouTube>) => {
                 window.oliDispatch(modalActions.dismiss());
-                props.onEdit({ alt, width, src });
+                props.onEdit({ alt, width, src: youtubeUrlToId(src) || '' });
               }}
               onCancel={() => window.oliDispatch(modalActions.dismiss())}
             />,

--- a/assets/src/components/editing/elements/youtube/YoutubeModal.tsx
+++ b/assets/src/components/editing/elements/youtube/YoutubeModal.tsx
@@ -10,7 +10,6 @@ interface ModalProps {
 export const YouTubeModal = ({ onDone, onCancel, model }: ModalProps) => {
   const [src, setSrc] = useState(model.src);
   const [alt, setAlt] = useState(model.alt);
-  const [width, _setWidth] = useState(model.width);
 
   return (
     <Modal
@@ -19,7 +18,7 @@ export const YouTubeModal = ({ onDone, onCancel, model }: ModalProps) => {
       okLabel="Save"
       cancelLabel="Cancel"
       onCancel={() => onCancel()}
-      onOk={() => onDone({ alt, width, src })}
+      onOk={() => onDone({ alt, width: model.width, src })}
     >
       <div>
         <h4 className="mb-2">Change Video</h4>

--- a/assets/src/components/editing/elements/youtube/youtubeActions.tsx
+++ b/assets/src/components/editing/elements/youtube/youtubeActions.tsx
@@ -7,6 +7,27 @@ import { modalActions } from 'actions/modal';
 import { Modal } from 'components/modal/Modal';
 import { onEnterApply } from 'components/editing/elements/common/settings/Settings';
 
+export const youtubeUrlToId = (src?: string | null) => {
+  if (!src) return null;
+
+  // https://www.youtube.com/embed/W98qXD35kXY
+  const embedRegex = /embed\/([a-zA-Z0-9_-]+)/;
+  const match = embedRegex.exec(src);
+  if (match) {
+    return match[1];
+  }
+
+  const hasParams = src.includes('?');
+  if (hasParams) {
+    const queryString = src.substr(src.indexOf('?') + 1);
+    src = getQueryVariableFromString('v', queryString);
+  } else if (src.indexOf('/youtu.be/') !== -1) {
+    src = src.substr(src.lastIndexOf('/') + 1);
+  }
+
+  return src;
+};
+
 export const insertYoutube = createButtonCommandDesc({
   icon: 'smart_display',
   description: 'YouTube',
@@ -14,22 +35,11 @@ export const insertYoutube = createButtonCommandDesc({
     const at = editor.selection;
     if (!at) return;
 
-    selectYoutube().then((selectedSrc) => {
-      if (selectedSrc !== null) {
-        let src = selectedSrc;
-
-        const hasParams = src.includes('?');
-
-        if (hasParams) {
-          const queryString = src.substr(src.indexOf('?') + 1);
-          src = getQueryVariableFromString('v', queryString);
-        } else if (src.indexOf('/youtu.be/') !== -1) {
-          src = src.substr(src.lastIndexOf('/') + 1);
-        }
-
-        Transforms.insertNodes(editor, Model.youtube(src), { at });
-      }
-    });
+    selectYoutube()
+      .then(youtubeUrlToId)
+      .then((src) => {
+        src && Transforms.insertNodes(editor, Model.youtube(src), { at });
+      });
   },
 });
 


### PR DESCRIPTION
If you tried pasting a youtube URL into the edit modal, it wasn't working. This is because the creation dialog ran some logic turning a url into a video ID that the edit modal didn't.

While in there, I also made it parse out /embed/videoid urls.

![youtubesrc](https://user-images.githubusercontent.com/333265/208940516-6c3fd9ed-f573-4456-aad2-eb5c009afd21.gif)
