### PR TITLE
[BUGFIX] Ability to add definition list items anywhere in list [MER-1633]

### DIFF
--- a/assets/src/components/editing/editor/Editor.tsx
+++ b/assets/src/components/editing/editor/Editor.tsx
@@ -1,6 +1,6 @@
 import { Model } from 'data/content/model/elements/factories';
 import { Mark, Marks } from 'data/content/model/text';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { FocusEventHandler, useCallback, useMemo } from 'react';
 import { createEditor, Descendant, Editor as SlateEditor, Operation, Transforms } from 'slate';
 import { withHistory } from 'slate-history';
 import { Editable, RenderElementProps, RenderLeafProps, Slate, withReact } from 'slate-react';
@@ -37,6 +37,8 @@ export type EditorProps = {
   children?: React.ReactNode;
   onPaste?: React.ClipboardEventHandler<HTMLDivElement>;
   editorOverride?: SlateEditor;
+  onFocus?: FocusEventHandler | undefined;
+  onBlur?: FocusEventHandler | undefined;
 };
 
 // Necessary to work around FireFox focus and selection issues with Slate
@@ -81,6 +83,7 @@ export const Editor: React.FC<EditorProps> = React.memo((props: EditorProps) => 
     quoteOnKeyDown(editor, e);
     titleOnKeyDown(editor, e);
     hotkeyHandler(editor, e.nativeEvent, props.commandContext);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const renderLeaf = useCallback(({ attributes, children, leaf }: RenderLeafProps) => {
@@ -129,7 +132,8 @@ export const Editor: React.FC<EditorProps> = React.memo((props: EditorProps) => 
           renderLeaf={renderLeaf}
           placeholder={props.placeholder ?? 'Type here or use + to begin...'}
           onKeyDown={onKeyDown}
-          onFocus={emptyOnFocus}
+          onFocus={props.onFocus || emptyOnFocus}
+          onBlur={props.onBlur}
           onPaste={(e: React.ClipboardEvent<HTMLDivElement>) => {
             if (props.onPaste) return props.onPaste(e);
 

--- a/assets/src/components/editing/elements/common/settings/InlineEditor.tsx
+++ b/assets/src/components/editing/elements/common/settings/InlineEditor.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { CaptionV2 } from 'data/content/model/elements/types';
+import React, { FocusEventHandler } from 'react';
+
 import { getEditMode } from 'components/editing/elements/utils';
 import { useSlate } from 'slate-react';
 import { Descendant, Editor as SlateEditor } from 'slate';
@@ -20,6 +20,8 @@ interface Props {
   allowBlockElements?: boolean;
   editorOverride?: SlateEditor;
   fixedToolbar?: boolean;
+  onFocus?: FocusEventHandler | undefined;
+  onBlur?: FocusEventHandler | undefined;
 }
 
 export const InlineEditor: React.FC<Props> = ({
@@ -33,6 +35,8 @@ export const InlineEditor: React.FC<Props> = ({
   onRequestMedia,
   editorOverride = undefined,
   fixedToolbar = false,
+  onFocus = undefined,
+  onBlur = undefined,
 }) => {
   const editor = useSlate();
   const editMode = getEditMode(editor);
@@ -45,6 +49,8 @@ export const InlineEditor: React.FC<Props> = ({
         commandContext={commandContext}
         editMode={editMode}
         value={content}
+        onFocus={onFocus}
+        onBlur={onBlur}
         onEdit={onEdit}
         editorOverride={editorOverride}
         fixedToolbar={fixedToolbar}

--- a/assets/src/components/editing/elements/description/DescriptionListEditor.tsx
+++ b/assets/src/components/editing/elements/description/DescriptionListEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { FocusEventHandler, useCallback, useState } from 'react';
 import { EditorProps } from 'components/editing/elements/interfaces';
 import * as ContentModel from '../../../../data/content/model/elements/types';
 import { useEditModelCallback } from '../utils';
@@ -13,7 +13,8 @@ const TitleEditor: React.FC<{
   title: TitleType[];
   onEdit: (val: TitleType[]) => void;
   commandContext: CommandContext;
-}> = ({ title, onEdit, commandContext }) => {
+  onFocus?: FocusEventHandler | undefined;
+}> = ({ title, onEdit, commandContext, onFocus }) => {
   return (
     <div className="figure-title-editor">
       <InlineEditor
@@ -22,6 +23,7 @@ const TitleEditor: React.FC<{
         commandContext={commandContext}
         content={Array.isArray(title) ? title : []}
         onEdit={onEdit}
+        onFocus={onFocus}
       />
     </div>
   );
@@ -32,16 +34,21 @@ const ItemEditor: React.FC<{
   commandContext: CommandContext;
   onEdit: (content: any[]) => void;
   onDelete: () => void;
-}> = ({ item, commandContext, onEdit, onDelete }) => {
+  insertAt: boolean;
+  onFocus?: FocusEventHandler | undefined;
+  onBlur?: FocusEventHandler | undefined;
+}> = ({ item, commandContext, insertAt, onEdit, onDelete, onFocus, onBlur }) => {
   const Root = item.type as keyof JSX.IntrinsicElements; // works out to <dt> or <dd>
   return (
-    <Root>
+    <Root className={insertAt ? 'insert-point' : ''}>
       <InlineEditor
         placeholder={item.type === 'dt' ? 'Description List Term' : 'Description List Definition'}
         allowBlockElements={true}
         commandContext={commandContext}
         content={item.children}
         onEdit={onEdit}
+        onFocus={onFocus}
+        onBlur={onBlur}
       />
       <button
         className="btn btn-outline-danger btn-small delete-btn"
@@ -64,19 +71,44 @@ export const DescriptionListEditor: React.FC<Props> = ({
   const onEdit = useEditModelCallback(model);
   const selected = useSelected();
 
+  const [focusedItem, setFocusedItem] = useState(-1);
+  const onItemFocused = useCallback(
+    (index: number) => () => {
+      setFocusedItem(index);
+    },
+    [],
+  );
+
   const onAddTerm = useCallback(() => {
+    const items =
+      focusedItem === -1
+        ? [...model.items, Model.dt()]
+        : [
+            ...model.items.slice(0, focusedItem + 1),
+            Model.dt(),
+            ...model.items.slice(focusedItem + 1),
+          ];
+
     onEdit({
       ...model,
-      items: [...model.items, Model.dt()],
+      items,
     });
-  }, [model, onEdit]);
+  }, [model, onEdit, focusedItem]);
 
   const onAddDefinition = useCallback(() => {
+    const items =
+      focusedItem === -1
+        ? [...model.items, Model.dd()]
+        : [
+            ...model.items.slice(0, focusedItem + 1),
+            Model.dd(),
+            ...model.items.slice(focusedItem + 1),
+          ];
     onEdit({
       ...model,
-      items: [...model.items, Model.dd()],
+      items,
     });
-  }, [model, onEdit]);
+  }, [model, onEdit, focusedItem]);
 
   const onEditTitle = useCallback(
     (val: TitleType[]) => {
@@ -114,6 +146,17 @@ export const DescriptionListEditor: React.FC<Props> = ({
 
   const editorClass = selected ? 'selected description-list-editor' : 'description-list-editor';
 
+  const addControls = (
+    <div className="description-list-editor-controls">
+      <button className="btn btn-secondary btn-sm" onClick={onAddTerm}>
+        Add Term
+      </button>
+      <button className="btn btn-secondary btn-sm" onClick={onAddDefinition}>
+        Add Definition
+      </button>
+    </div>
+  );
+
   return (
     <div {...attributes} className={editorClass} contentEditable={false}>
       <h4>
@@ -121,25 +164,25 @@ export const DescriptionListEditor: React.FC<Props> = ({
       </h4>
 
       <dl>
-        {model.items.map((item, index) => (
-          <ItemEditor
-            key={index}
-            commandContext={commandContext}
-            item={item}
-            onEdit={editItem(index)}
-            onDelete={deleteItem(index)}
-          />
-        ))}
+        {model.items.map((item, index) => {
+          return (
+            <>
+              <ItemEditor
+                key={`${index}-${model.items.length}`} // The editor won't reset if it's value changes, so we want to make sure to have new keys when items are added/removed
+                commandContext={commandContext}
+                item={item}
+                onEdit={editItem(index)}
+                onDelete={deleteItem(index)}
+                onFocus={onItemFocused(index)}
+                insertAt={index === focusedItem}
+              />
+              {index === focusedItem && <dt>{addControls}</dt>}
+            </>
+          );
+        })}
       </dl>
 
-      <div className="description-list-editor-controls">
-        <button className="btn btn-secondary btn-small" onClick={onAddTerm}>
-          Add Term
-        </button>
-        <button className="btn btn-secondary btn-small" onClick={onAddDefinition}>
-          Add Definition
-        </button>
-      </div>
+      {focusedItem === -1 && addControls}
 
       {children}
     </div>

--- a/assets/styles/authoring/description-list.scss
+++ b/assets/styles/authoring/description-list.scss
@@ -27,6 +27,7 @@
       top: 0px;
     }
   }
+
   dd:hover,
   dt:hover {
     border: 1px dashed #ccc;


### PR DESCRIPTION
Previously, there was no ability to add definition terms/definitions anywhere except the end of the list. Now you can insert them anywhere in the list.

![definitionlist](https://user-images.githubusercontent.com/333265/208980993-aec7bba9-f450-4f9e-b748-b0b96956e378.gif)
