### PR TITLE
[BUG FIX] handle missing attrs in group rendering [MER-1644]

### DIFF
--- a/lib/oli/rendering/group/html.ex
+++ b/lib/oli/rendering/group/html.ex
@@ -18,6 +18,16 @@ defmodule Oli.Rendering.Group.Html do
     ]
   end
 
+  def group(%Context{} = context, next, params) do
+
+    id = Map.get(params, "id", UUID.uuid4())
+
+    params = Map.put(params, "id", id)
+    |> Map.put("purpose", "none")
+
+    group(context, next, params)
+  end
+
   def elements(%Context{} = context, elements) do
     Elements.render(context, elements, Elements.Html)
   end

--- a/lib/oli/rendering/group/html.ex
+++ b/lib/oli/rendering/group/html.ex
@@ -21,9 +21,10 @@ defmodule Oli.Rendering.Group.Html do
   def group(%Context{} = context, next, params) do
 
     id = Map.get(params, "id", UUID.uuid4())
+    purpose = Map.get(params, "purpose", "none")
 
     params = Map.put(params, "id", id)
-    |> Map.put("purpose", "none")
+    |> Map.put("purpose", purpose)
 
     group(context, next, params)
   end


### PR DESCRIPTION
The issue here is that `group/3` specifies a pattern match that fails rendering if either the `id` or the `purpose` attributes are missing.  Handle this by generating and id and setting purpose to `"none"` when they are missing. 