### PR TITLE
MER-1630 - Alt Text on Video & Audio elements

### DIFF
--- a/assets/src/components/editing/elements/audio/AudioElement.tsx
+++ b/assets/src/components/editing/elements/audio/AudioElement.tsx
@@ -4,7 +4,10 @@ import { EditorProps } from 'components/editing/elements/interfaces';
 import { updateModel } from 'components/editing/elements/utils';
 import { CaptionEditor } from 'components/editing/elements/common/settings/CaptionEditor';
 import { useSlate } from 'slate-react';
+import { HoverContainer } from '../../toolbar/HoverContainer';
+import { AudioToolbar } from './AudioSettings';
 export interface AudioProps extends EditorProps<ContentModel.Audio> {}
+
 export const AudioEditor = (props: AudioProps) => {
   const editor = useSlate();
 
@@ -14,12 +17,27 @@ export const AudioEditor = (props: AudioProps) => {
   return (
     <div {...props.attributes} contentEditable={false} className="m-4 pl-4 pr-4 text-center">
       {props.children}
-      <audio src={props.model.src} controls />
-      <CaptionEditor
-        onEdit={(caption) => onEdit({ caption })}
-        model={props.model}
-        commandContext={props.commandContext}
-      />
+      <HoverContainer
+        style={{ margin: '0 auto', display: 'block' }}
+        isOpen={true}
+        align="start"
+        position="top"
+        content={
+          <AudioToolbar
+            commandContext={props.commandContext}
+            model={props.model}
+            onEdit={onEdit}
+            projectSlug={props.commandContext.projectSlug}
+          />
+        }
+      >
+        <audio src={props.model.src} controls />
+        <CaptionEditor
+          onEdit={(caption) => onEdit({ caption })}
+          model={props.model}
+          commandContext={props.commandContext}
+        />
+      </HoverContainer>
     </div>
   );
 };

--- a/assets/src/components/editing/elements/audio/AudioSettings.tsx
+++ b/assets/src/components/editing/elements/audio/AudioSettings.tsx
@@ -3,101 +3,150 @@ import * as ContentModel from 'data/content/model/elements/types';
 import * as Settings from 'components/editing/elements/common/settings/Settings';
 import { selectAudio } from 'components/editing/elements/audio/audioActions';
 import { CommandContext } from 'components/editing/elements/commands/interfaces';
+import { useDispatch } from 'react-redux';
+import { DescriptiveButton } from '../../toolbar/buttons/DescriptiveButton';
+import { createButtonCommandDesc } from '../commands/commandFactories';
+import { modalActions } from '../../../../actions/modal';
+import { Toolbar } from '../../toolbar/Toolbar';
+import { Modal, ModalSize } from 'components/modal/Modal';
+import { MediaInfo, MediaPickerPanel } from '../common/MediaPickerPanel';
+import { MIMETYPE_FILTERS } from '../../../media/manager/MediaManager';
+import { useToggle } from '../../../hooks/useToggle';
+import { useAudio } from '../../../hooks/useAudio';
+
+interface SettingsButtonProps {
+  model: ContentModel.Audio;
+  projectSlug: string;
+  commandContext: CommandContext;
+  onEdit: (attrs: Partial<ContentModel.Audio>) => void;
+}
+export const SettingsButton = (props: SettingsButtonProps) => {
+  const dispatch = useDispatch();
+  return (
+    <DescriptiveButton
+      description={createButtonCommandDesc({
+        icon: 'play_circle_filled',
+        description: 'Settings',
+        execute: (_context, _editor, _params) =>
+          dispatch(
+            modalActions.display(
+              <AudioSettingsModal
+                commandContext={props.commandContext}
+                model={props.model}
+                onEdit={(audio: Partial<ContentModel.Audio>) => {
+                  dispatch(modalActions.dismiss());
+                  props.onEdit(audio);
+                }}
+                onCancel={() => window.oliDispatch(modalActions.dismiss())}
+              />,
+            ),
+          ),
+      })}
+    />
+  );
+};
+
+interface SettingsProps {
+  model: ContentModel.Audio;
+  projectSlug: string;
+  commandContext: CommandContext;
+  onEdit: (attrs: Partial<ContentModel.Audio>) => void;
+}
+export const AudioToolbar = (props: SettingsProps) => {
+  return (
+    <div className="video-settings">
+      <Toolbar context={props.commandContext}>
+        <Toolbar.Group>
+          <SettingsButton
+            commandContext={props.commandContext}
+            projectSlug={props.commandContext.projectSlug}
+            model={props.model}
+            onEdit={props.onEdit}
+          />
+        </Toolbar.Group>
+      </Toolbar>
+    </div>
+  );
+};
 
 type AudioSettingsProps = {
   model: ContentModel.Audio;
   onEdit: (model: ContentModel.Audio) => void;
-  onRemove: () => void;
   commandContext: CommandContext;
-  editMode: boolean;
+  onCancel: () => void;
 };
 
-// const onRemove = () => {
-//   ($('#remove-button') as any).tooltip('hide');
-
-//   const path = ReactEditor.findPath(editor, model);
-//   Transforms.removeNodes(editor, { at: path });
-
-//   setIsPopoverOpen(false);
-// };
-
-export const AudioSettings = (props: AudioSettingsProps) => {
+const AudioSettingsModal = (props: AudioSettingsProps) => {
   // Which selection is active, URL or in course page
   const [model, setModel] = useState(props.model);
+  const [audioPickerOpen, , openAudioPicker, closeAudioPicker] = useToggle();
 
-  const ref = useRef();
-
-  useEffect(() => {
-    // Inits the tooltips, since this popover rendres in a react portal
-    // this was necessary
-    if (ref !== null && ref.current !== null) {
-      (window as any).$('[data-toggle="tooltip"]').tooltip();
-    }
-  });
-
-  const setAlt = (alt: string) => setModel(Object.assign({}, model, { alt }));
-
-  const applyButton = (disabled: boolean) => (
-    <button
-      onClick={(e) => {
-        e.stopPropagation();
-        e.preventDefault();
-        props.onEdit(model);
-      }}
-      disabled={disabled}
-      className="btn btn-primary ml-1"
-    >
-      Apply
-    </button>
-  );
+  const { audioPlayer, playAudio, isPlaying } = useAudio(model.src);
+  const setAlt = (alt: string) => setModel((model) => ({ ...model, alt }));
+  const setSrc = (src: string) => setModel((model) => ({ ...model, src }));
+  const onOk = () => {
+    props.onEdit(model);
+  };
+  const onAudioSelected = (video: MediaInfo[]) => {
+    if (!video || video.length != 1) return;
+    closeAudioPicker();
+    setSrc(video[0].url);
+  };
 
   const fileName = model.src ? model.src.substr(model.src.lastIndexOf('/') + 1) : '';
 
   return (
-    <div className="settings-editor-wrapper">
-      <div className="settings-editor" ref={ref as any}>
-        <div className="d-flex justify-content-between mb-2">
-          <div>Audio</div>
-
-          <div>
-            <Settings.Action
-              icon="fas fa-trash"
-              tooltip="Remove YouTube Video"
-              id="remove-button"
-              onClick={() => props.onRemove()}
-            />
-          </div>
-        </div>
-
+    <Modal
+      title="Audio Settings"
+      size={ModalSize.X_LARGE}
+      okLabel="Save"
+      cancelLabel="Cancel"
+      onCancel={props.onCancel}
+      onOk={onOk}
+    >
+      <div>
+        {audioPlayer}
         <form className="form">
           <label>File</label>
           <div className="input-group mb-3 mr-sm-2">
             <input type="text" readOnly value={fileName} className="form-control" />
             <div className="input-group-append">
-              <button
-                onClick={() =>
-                  selectAudio(props.commandContext.projectSlug, model).then((_img) => null)
-                }
-                className="btn btn-outline-primary"
-                type="button"
-              >
+              <button onClick={openAudioPicker} className="btn btn-outline-primary" type="button">
                 Select
               </button>
+              {model.src && (
+                <button
+                  type="button"
+                  onClick={playAudio}
+                  className="btn btn-sm btn-outline-success btn-pronunciation-audio tool-button"
+                  data-toggle="tooltip"
+                  data-placement="top"
+                  title="Preview audio file"
+                >
+                  <span className="material-icons">
+                    {isPlaying ? 'stop_circle' : 'play_circle'}
+                  </span>
+                </button>
+              )}
             </div>
           </div>
 
           <label>Alt Text</label>
           <input
             type="text"
-            value={model.alt}
+            value={model.alt || ''}
             onChange={(e) => setAlt(e.target.value)}
-            onKeyPress={(e) => Settings.onEnterApply(e, () => props.onEdit(model))}
             className="form-control mr-sm-2"
           />
         </form>
-
-        {applyButton(!props.editMode)}
       </div>
-    </div>
+      <MediaPickerPanel
+        projectSlug={props.commandContext.projectSlug}
+        onMediaChange={onAudioSelected}
+        open={audioPickerOpen}
+        mimeFilter={MIMETYPE_FILTERS.AUDIO}
+        onCancel={() => closeAudioPicker()}
+      />
+    </Modal>
   );
 };

--- a/assets/src/components/editing/elements/video/VideoModal.tsx
+++ b/assets/src/components/editing/elements/video/VideoModal.tsx
@@ -188,8 +188,8 @@ export const VideoModal = ({ projectSlug, onDone, onCancel, model }: ModalProps)
               <table className="table table-striped">
                 <thead>
                   <tr>
-                    <th>Content Type</th>
                     <th>URL</th>
+                    <th>Content Type</th>
                     <th>Remove</th>
                   </tr>
                 </thead>

--- a/assets/src/components/editing/elements/video/VideoModal.tsx
+++ b/assets/src/components/editing/elements/video/VideoModal.tsx
@@ -4,6 +4,7 @@ import { Modal, ModalSize } from 'components/modal/Modal';
 import { MediaInfo, MediaPickerPanel } from '../common/MediaPickerPanel';
 import { MIMETYPE_FILTERS } from '../../../media/manager/MediaManager';
 import { iso639_language_codes } from '../../../../utils/language-codes-iso639';
+import { Tab, Tabs } from 'react-bootstrap';
 
 const MAX_DISPLAY_LENGTH = 40;
 
@@ -54,6 +55,12 @@ export const VideoModal = ({ projectSlug, onDone, onCancel, model }: ModalProps)
   const setSrc = useCallback(
     (src) => {
       setWorkingCopy({ ...workingCopy, src });
+    },
+    [workingCopy],
+  );
+  const setAlt = useCallback(
+    (alt) => {
+      setWorkingCopy({ ...workingCopy, alt });
     },
     [workingCopy],
   );
@@ -109,6 +116,12 @@ export const VideoModal = ({ projectSlug, onDone, onCancel, model }: ModalProps)
   const pickPoster = useCallback(() => setPosterPickerOpen(true), []);
   const removePoster = useCallback(() => setPoster(undefined), [setPoster]);
 
+  const onAltChange = useCallback(
+    (event) => {
+      setAlt(event.target.value);
+    },
+    [setAlt],
+  );
   const removeCaption = useCallback(
     (caption: ContentModel.VideoCaptionTrack) => () =>
       setCaptions(workingCopy.captions?.filter((c) => c !== caption)),
@@ -162,130 +175,168 @@ export const VideoModal = ({ projectSlug, onDone, onCancel, model }: ModalProps)
       onCancel={onCancel}
       onOk={onModalDone}
     >
-      <h4 className="mb-2">Video Source(s)</h4>
-      <p className="mb-2">
-        Specify at least one source for the video to play. You may specify additional sources to
-        provide multiple formats for the video. Each viewer will only see one of them depending on
-        their web browser capabilities.
-      </p>
-      <div className="mb-4">
-        <table className="table table-striped">
-          <thead>
-            <tr>
-              <th>Content Type</th>
-              <th>URL</th>
-              <th>Remove</th>
-            </tr>
-          </thead>
-          <tbody>
-            {workingCopy.src.map((src, i) => (
-              <VideoSRC key={i} src={src} onDelete={removeSrc(src)} />
-            ))}
-            <tr>
-              <td colSpan={2}></td>
-              <td>
-                <button className="btn btn-success" type="button" onClick={addVideo}>
-                  Add New
-                </button>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-
-      <h4 className="mb-2">Captions</h4>
-      <p className="mb-2">
-        Optionally provide captions for the video. These will be displayed to viewers who choose to
-        turn them on and can be supplied in multiple languages. You must provide a file formatted as
-        a{' '}
-        <a
-          href="https://developer.mozilla.org/en-US/docs/Web/API/WebVTT_API"
-          target="_blank"
-          rel="noreferrer"
-        >
-          Web Video Text Tracks
-        </a>{' '}
-        (WebVTT) file.
-      </p>
-      <div className="mb-4">
-        <table className="table table-striped">
-          <thead>
-            <tr>
-              <th>Label</th>
-              <th>Language</th>
-              <th>URL</th>
-              <th>Remove</th>
-            </tr>
-          </thead>
-          <tbody>
-            {workingCopy.captions?.map((caption, i) => (
-              <VideoCaption
-                key={i}
-                caption={caption}
-                onDelete={removeCaption(caption)}
-                onChange={modifyCaption}
-              />
-            ))}
-            <tr>
-              <td colSpan={3}></td>
-              <td>
-                <button className="btn btn-success" type="button" onClick={addCaption}>
-                  Add New
-                </button>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-
-      <h4 className="mb-2">Poster Image</h4>
-      <p className="mb-4">Provide an optional image to display before the video is playing.</p>
-      <div className="mb-4">
-        {workingCopy.poster && (
-          <img src={workingCopy.poster} className="img-fluid" style={{ maxWidth: '100%' }} />
-        )}
-        <button className="btn btn-success" type="button" onClick={pickPoster}>
-          Choose Poster Image
-        </button>
-        {workingCopy.poster && (
-          <button className="btn btn-danger" type="button" onClick={removePoster}>
-            Remove Poster Image
-          </button>
-        )}
-      </div>
-
-      <h4 className="mb-2">Size</h4>
-      <p className="mb-2">
-        You can optionally set the video width and height. If you do not, the video will be
-        automatically resized for the user&apos;s browser (recommended).
-      </p>
-      <div className="container">
-        <div className="row">
-          <div className="col-sm">
-            Width:{' '}
-            <input
-              type="number"
-              className="form-control"
-              value={workingCopy.width}
-              onChange={(e) => {
-                setWidth(e.target.value);
-              }}
-            />
+      <Tabs>
+        <Tab eventKey="source" title="Video Source">
+          <div className="video-modal-content">
+            <h4 className="mb-2">Video Source(s)</h4>
+            <p className="mb-2">
+              Specify at least one source for the video to play. You may specify additional sources
+              to provide multiple formats for the video. Each viewer will only see one of them
+              depending on their web browser capabilities.
+            </p>
+            <div className="mb-4">
+              <table className="table table-striped">
+                <thead>
+                  <tr>
+                    <th>Content Type</th>
+                    <th>URL</th>
+                    <th>Remove</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {workingCopy.src.map((src, i) => (
+                    <VideoSRC key={i} src={src} onDelete={removeSrc(src)} />
+                  ))}
+                  <tr>
+                    <td colSpan={2}></td>
+                    <td>
+                      <button className="btn btn-success" type="button" onClick={addVideo}>
+                        Add New
+                      </button>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
           </div>
+        </Tab>
 
-          <div className="col-sm">
-            Height:{' '}
+        <Tab eventKey="captions" title="Accessibility">
+          <div className="video-modal-content">
+            <h4 className="mb-2">Alt-Text</h4>
+            <p className="mb-2">
+              Text that will be presented to learners using assistive devices before the video
+              plays.
+            </p>
             <input
-              type="number"
+              type="text"
+              value={workingCopy.alt || ''}
+              onChange={onAltChange}
               className="form-control"
-              value={workingCopy.height}
-              onChange={(e) => {
-                setHeight(e.target.value);
-              }}
             />
+
+            <hr />
+            <h4 className="mb-2">Captions</h4>
+            <p className="mb-2">
+              Optionally provide captions for the video. These will be displayed to viewers who
+              choose to turn them on and can be supplied in multiple languages. You must provide a
+              file formatted as a{' '}
+              <a
+                href="https://developer.mozilla.org/en-US/docs/Web/API/WebVTT_API"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Web Video Text Tracks
+              </a>{' '}
+              (WebVTT) file.
+            </p>
+            <div className="mb-4">
+              <table className="table table-striped">
+                <thead>
+                  <tr>
+                    <th>Label</th>
+                    <th>Language</th>
+                    <th>URL</th>
+                    <th>Remove</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {workingCopy.captions?.map((caption, i) => (
+                    <VideoCaption
+                      key={i}
+                      caption={caption}
+                      onDelete={removeCaption(caption)}
+                      onChange={modifyCaption}
+                    />
+                  ))}
+                  <tr>
+                    <td colSpan={3}></td>
+                    <td>
+                      <button className="btn btn-success" type="button" onClick={addCaption}>
+                        Add New
+                      </button>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
           </div>
-        </div>
-      </div>
+        </Tab>
+        <Tab eventKey="poster" title="Poster Image">
+          <div className="video-modal-content">
+            <h4 className="mb-2">Poster Image</h4>
+            <p className="mb-4">
+              Provide an optional image to display before the video is playing.
+            </p>
+            <div className="mb-4">
+              {workingCopy.poster && (
+                <img
+                  src={workingCopy.poster}
+                  className="img-fluid"
+                  style={{ maxWidth: '100%', maxHeight: 250 }}
+                />
+              )}
+              <button className="btn btn-success" type="button" onClick={pickPoster}>
+                Choose Poster Image
+              </button>
+              {workingCopy.poster && (
+                <button className="btn btn-danger" type="button" onClick={removePoster}>
+                  Remove Poster Image
+                </button>
+              )}
+            </div>
+          </div>
+        </Tab>
+
+        <Tab eventKey="size" title="Size">
+          <div className="video-modal-content">
+            <h4 className="mb-2">Size</h4>
+            <p className="mb-2">Optionally set the video width and height.</p>
+            <p className="alert alert-info">
+              In most cases, it is best to leave this blank so the video automatically sizes to the
+              learner&apos;s screen.
+            </p>
+            <hr />
+            <div className="container">
+              <div className="row">
+                <div className="col-sm">
+                  Width:{' '}
+                  <input
+                    type="number"
+                    className="form-control"
+                    value={workingCopy.width}
+                    onChange={(e) => {
+                      setWidth(e.target.value);
+                    }}
+                  />
+                </div>
+
+                <div className="col-sm">
+                  Height:{' '}
+                  <input
+                    type="number"
+                    className="form-control"
+                    value={workingCopy.height}
+                    onChange={(e) => {
+                      setHeight(e.target.value);
+                    }}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </Tab>
+      </Tabs>
 
       <MediaPickerPanel
         projectSlug={projectSlug}

--- a/assets/src/components/video_player/VideoPlayer.tsx
+++ b/assets/src/components/video_player/VideoPlayer.tsx
@@ -101,7 +101,13 @@ export const VideoPlayer: React.FC<{ video: ContentModel.Video; children?: React
     useCommandTarget(video.id, onCommandReceived);
 
     return (
-      <div className="video-player" onClick={preventDefault}>
+      <div
+        className="video-player"
+        aria-role="img"
+        aria-roledescription="Video Player"
+        aria-aria-label={video.alt}
+        onClick={preventDefault}
+      >
         <Player poster={video.poster} {...sizeAttributes} ref={onPlayer} crossOrigin="anonymous">
           {/* Hide the video-react big play button so we can render our own that fits with our icon styles */}
           <BigPlayButton className="big-play-button-hide" />

--- a/assets/src/data/content/model/elements/types.ts
+++ b/assets/src/data/content/model/elements/types.ts
@@ -265,6 +265,7 @@ export interface Video extends SlateElement<VoidChildren> {
   captions?: VideoCaptionTrack[];
   height?: number;
   width?: number;
+  alt?: string;
 }
 
 export interface YouTube extends SlateElement<VoidChildren> {

--- a/assets/src/data/content/writers/html.tsx
+++ b/assets/src/data/content/writers/html.tsx
@@ -312,7 +312,7 @@ export class HtmlParser implements WriterImpl {
     return this.captioned_content(
       context,
       attrs,
-      <audio controls src={this.escapeXml(attrs.src)}>
+      <audio aria-label={attrs.alt || ''} controls src={this.escapeXml(attrs.src)}>
         Your browser does not support the <code>audio</code> element.
       </audio>,
     );

--- a/assets/styles/authoring/controls.scss
+++ b/assets/styles/authoring/controls.scss
@@ -176,6 +176,11 @@
   display: inline-block;
 }
 
+.video-modal-content {
+  height: 400px;
+  padding: 15px;
+}
+
 .truncate-left {
   /* Gives us ellipses at the beginning of a string so we can see the end of it.
      ex: a long string like http://www.google.com/this/is/a/long/string/that/should/be/truncated

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -107,9 +107,11 @@ defmodule Oli.Rendering.Content.Html do
   end
 
   def audio(%Context{} = context, _, %{"src" => src} = attrs) do
-    captioned_content(context, attrs, [~s|<audio controls src="#{escape_xml!(src)}">
+    captioned_content(context, attrs, [
+      ~s|<audio aria-label="#{attrs["alt"]}" controls src="#{escape_xml!(src)}">
       Your browser does not support the <code>audio</code> element.
-    </audio>\n|])
+    </audio>\n|
+    ])
   end
 
   def audio(%Context{} = context, _, e) do

--- a/priv/schemas/v0-1-0/content-element.schema.json
+++ b/priv/schemas/v0-1-0/content-element.schema.json
@@ -1261,6 +1261,9 @@
         "poster": {
           "type": "string"
         },
+        "alt": {
+          "type": "string"
+        },
         "src": {
           "type": "array",
           "items": {
@@ -1272,6 +1275,7 @@
             }
           }
         },
+
         "captions": {
           "type": "array",
           "items": {


### PR DESCRIPTION
This exposes alt-text as aria-label attributes on audio and video elements to support people using assistive devices.

I did a mini-redesign of the video settings to break the options up into tabs since that dialog was getting rather long. The new alt-text for that can be found on the accessibility tab.

This also fixes a bug where it was impossible to edit the audio clip after you inserted it because the settings dialog couldn't be opened.

![image](https://user-images.githubusercontent.com/333265/209206598-0ee9a45b-ad25-42ce-a5ff-71773aed7ea2.png)


Audio settings:
![image](https://user-images.githubusercontent.com/333265/209206339-c3ff76a4-6c88-4b6e-8649-1a2f1d603046.png)


