### PR TITLE
[MER-1656] Escape JSON special chars in variable evaluations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- Fix an issue with dynamic questions and variables that contain " or \
+
 ## 0.22.0 (2022-12-20)
 
 ### Bug Fixes

--- a/lib/oli/activities/transformers/variable_substitution/common.ex
+++ b/lib/oli/activities/transformers/variable_substitution/common.ex
@@ -13,20 +13,25 @@ defmodule Oli.Activities.Transformers.VariableSubstitution.Common do
           number -> Kernel.to_string(number)
         end
 
-      String.replace(s, "@@#{v}@@", json_encode(r))
+      String.replace(s, "@@#{v}@@", json_escape(r))
     end)
     |> Jason.decode()
   end
 
-  # according to RFC 4627, only \ and " must be escaped in JSON
+  # according to RFC 4627, escape special chars in JSON
   # https://www.ietf.org/rfc/rfc4627.txt
-  defp json_encode(str) do
+  defp json_escape(str) do
     str
     |> String.split("")
     |> Enum.map(fn c ->
       case c do
         "\\" -> "\\\\"
         "\"" -> "\\\""
+        "\b" -> "\\b"
+        "\f" -> "\\f"
+        "\n" -> "\\n"
+        "\r" -> "\\r"
+        "\t" -> "\\t"
         _ -> c
       end
     end)

--- a/lib/oli/activities/transformers/variable_substitution/common.ex
+++ b/lib/oli/activities/transformers/variable_substitution/common.ex
@@ -13,8 +13,23 @@ defmodule Oli.Activities.Transformers.VariableSubstitution.Common do
           number -> Kernel.to_string(number)
         end
 
-      String.replace(s, "@@#{v}@@", r)
+      String.replace(s, "@@#{v}@@", json_encode(r))
     end)
     |> Jason.decode()
+  end
+
+  # according to RFC 4627, only \ and " must be escaped in JSON
+  # https://www.ietf.org/rfc/rfc4627.txt
+  defp json_encode(str) do
+    str
+    |> String.split("")
+    |> Enum.map(fn c ->
+      case c do
+        "\\" -> "\\\\"
+        "\"" -> "\\\""
+        _ -> c
+      end
+    end)
+    |> Enum.join()
   end
 end

--- a/test/oli/activities/transformers/variable_substitution_test.exs
+++ b/test/oli/activities/transformers/variable_substitution_test.exs
@@ -50,5 +50,12 @@ defmodule Oli.Activities.TransformersTest do
       ])
 
     assert transformed["stem"] == ~s|var1 = "|
+
+    {:ok, transformed} =
+      VariableSubstitution.transform(model, nil, [
+        %{"variable" => "var1", "result" => ~s|1\n2|}
+      ])
+
+    assert transformed["stem"] == ~s|var1 = 1\n2|
   end
 end

--- a/test/oli/activities/transformers/variable_substitution_test.exs
+++ b/test/oli/activities/transformers/variable_substitution_test.exs
@@ -1,0 +1,54 @@
+defmodule Oli.Activities.TransformersTest do
+  use ExUnit.Case, async: true
+
+  alias Oli.Activities.Transformers
+
+  alias Oli.Activities.Transformers.VariableSubstitution
+
+  defp as_revision(id, model) do
+    %Oli.Resources.Revision{
+      id: id,
+      resource_id: id,
+      content: model
+    }
+  end
+
+  test "correctly escapes and replaces variables that possibly contain JSON special chars" do
+    model = %{
+      "stem" => "var1 = @@var1@@",
+      "choices" => [
+        %{id: "1", content: []},
+        %{id: "2", content: []},
+        %{id: "3", content: []},
+        %{id: "4", content: []}
+      ],
+      "authoring" => %{
+        "parts" => [
+          %{
+            "id" => "1",
+            "responses" => [],
+            "scoringStrategy" => "best",
+            "evaluationStrategy" => "regex"
+          }
+        ],
+        "transformations" => [
+          %{"id" => "1", "path" => "choices", "operation" => "shuffle"}
+        ]
+      }
+    }
+
+    {:ok, transformed} =
+      VariableSubstitution.transform(model, nil, [
+        %{"variable" => "var1", "result" => "evaluated"}
+      ])
+
+    assert transformed["stem"] == "var1 = evaluated"
+
+    {:ok, transformed} =
+      VariableSubstitution.transform(model, nil, [
+        %{"variable" => "var1", "result" => ~s|"|}
+      ])
+
+    assert transformed["stem"] == ~s|var1 = "|
+  end
+end

--- a/test/oli/activities/transformers/variable_substitution_test.exs
+++ b/test/oli/activities/transformers/variable_substitution_test.exs
@@ -1,17 +1,7 @@
-defmodule Oli.Activities.TransformersTest do
+defmodule Oli.Activities.Transformers.VariableSubstitutionTest do
   use ExUnit.Case, async: true
 
-  alias Oli.Activities.Transformers
-
   alias Oli.Activities.Transformers.VariableSubstitution
-
-  defp as_revision(id, model) do
-    %Oli.Resources.Revision{
-      id: id,
-      resource_id: id,
-      content: model
-    }
-  end
 
   test "correctly escapes and replaces variables that possibly contain JSON special chars" do
     model = %{


### PR DESCRIPTION
Fixes an issue where JSON special characters in variables breaks the evaluation leaving the unevaluated variable name.

https://eliterate.atlassian.net/browse/MER-1656

[MER-1656]: https://eliterate.atlassian.net/browse/MER-1656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ