### PR TITLE
Revert "MER-1510 (#3137)"

### DIFF
--- a/assets/src/data/persistence/extrinsic.ts
+++ b/assets/src/data/persistence/extrinsic.ts
@@ -13,7 +13,6 @@ export type ExtrinsicUpsert = {
 export type ExtrinsicDelete = {
   result: 'success';
 };
-const userStateCache: Record<any, any> = {};
 const setQ = new Set();
 const lastSet = () => {
   const arr = Array.from(setQ);
@@ -52,27 +51,7 @@ export const readGlobalUserState = async (
     if (lastSet()) {
       await lastSet();
     }
-    let refreshFromServer = false;
     if (keys) {
-      const cacheTimeThreshold = 300000;
-      const { timestamp: lastCacheTimeStamp } = userStateCache;
-      //If cache is not older than 5 min then lets fetch the data from cache
-      if (Date.now() - lastCacheTimeStamp < cacheTimeThreshold) {
-        keys.forEach((key) => {
-          const keyExists = userStateCache[key];
-          if (keyExists === undefined || keyExists === null) {
-            //if cache does not have any of the requested keys, we should make the server call
-            refreshFromServer = true;
-          }
-          result[key] = userStateCache[key];
-        });
-      } else {
-        refreshFromServer = true;
-      }
-    } else {
-      result = userStateCache;
-    }
-    if (refreshFromServer) {
       //if cache does not have any of the requested keys, we should make the server call
       const serverUserState = await readGlobal(keys);
       // merge server state with result
@@ -84,19 +63,6 @@ export const readGlobalUserState = async (
   return result;
 };
 
-const formatUserState = (updates: any, userSate: any) => {
-  const topLevelKeys = Object.keys(updates);
-  topLevelKeys.forEach((topKey: any) => {
-    const actualKeys = Object.keys(updates[topKey]);
-    actualKeys.forEach((actualKey) => {
-      userSate[`${topKey}`] = {
-        ...userSate[topKey],
-        [actualKey]: updates[topKey][actualKey],
-      };
-    });
-  });
-};
-
 export const internalUpdateGlobalUserState = async (
   updates: { [topKey: string]: { [key: string]: any } },
   useLocalStorage = false,
@@ -106,7 +72,12 @@ export const internalUpdateGlobalUserState = async (
   const currentState = await readGlobalUserState(topLevelKeys, useLocalStorage);
 
   const newState = { ...currentState };
-  formatUserState(updates, newState);
+  topLevelKeys.forEach((topKey) => {
+    const actualKeys = Object.keys(updates[topKey]);
+    actualKeys.forEach((actualKey) => {
+      newState[topKey] = { ...newState[topKey], [actualKey]: updates[topKey][actualKey] };
+    });
+  });
 
   if (useLocalStorage) {
     const existingState = localStorage.getItem('torus.userState') || '{}';
@@ -132,11 +103,6 @@ export const updateGlobalUserState = async (
   useLocalStorage = false,
 ) => {
   /*console.log('updateGlobalUserState called', { updates, useLocalStorage });*/
-
-  //Lets update the cache with latest changes.
-  userStateCache.timestamp = Date.now();
-  formatUserState(updates, userStateCache);
-
   const result = await batchedUpdate(updates, useLocalStorage);
   /* console.log('updateGlobalUserState result', { result, updates }); */
   return result;


### PR DESCRIPTION
This reverts commit 9fb1ca6e97d7dcb52a97466130b1ab491a65afba which was the fix for https://eliterate.atlassian.net/browse/MER-1510

I believe it to be the cause of https://eliterate.atlassian.net/browse/MER-1653

Before reverting, this is the behavior we were seeing:

On a page refresh...

1. We load that global state on startup.
2. For some reason we also save that global state on startup.
3. Then... after loading the global state from 1, we save it again.

In 2... we actually save a blank report because that starts before we've finished 1.  

Luckily, most of the time, 3 happens so we overwrite the blank report with a good one again. But every single load, we corrupt the learner's data and then get lucky that we fix it later.

This is caused because our cache is separated out by top-level key, but userStateCache.timestamp was global. So if you cached "Key A" and then tried to read "Key B" but "Key B" was stale in the cache, readGlobalUserState would see that we had a recent cache. That scenario interacted badly with some sims that initialized some keys and saved the state on startup.



[MER-1510]: https://eliterate.atlassian.net/browse/MER-1510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MER-1653]: https://eliterate.atlassian.net/browse/MER-1653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ