### PR TITLE
[FEATURE] [MER-1636] Bulk update activity attempts all at once

### DIFF
--- a/lib/oli/delivery/attempts/activity_lifecycle/persistence.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle/persistence.ex
@@ -24,12 +24,12 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Persistence do
   def persist_evaluations({:error, error}, _, _, _), do: {:error, error}
 
   def persist_evaluations({:ok, evaluations}, part_inputs, roll_up_fn, datashop_session_id) do
-    evaluated_inputs = Enum.zip(part_inputs, evaluations)
-
     right_now = DateTime.utc_now()
 
     {values, params, _} =
-      Enum.map(evaluated_inputs, fn pair -> attrs_for(pair, datashop_session_id, right_now) end)
+      part_inputs
+      |> Enum.zip(evaluations)
+      |> Enum.map(fn pair -> attrs_for(pair, datashop_session_id, right_now) end)
       |> Enum.filter(fn attrs -> !is_nil(attrs) end)
       |> Enum.reduce({[], [], 0}, fn pa, {values, params, i} ->
         {
@@ -73,8 +73,7 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Persistence do
             datashop_session_id = batch_values.datashop_session_id,
             updated_at = NOW()
           FROM (
-              VALUES
-              #{values}
+              VALUES #{values}
           ) AS batch_values (attempt_guid, response, lifecycle_state, date_evaluated, date_submitted, score, out_of, feedback, datashop_session_id)
           WHERE part_attempts.attempt_guid = batch_values.attempt_guid
         """
@@ -84,6 +83,24 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Persistence do
           e -> e
         end
     end
+  end
+
+  def bulk_update_activity_attempts(_, []), do: {:ok, []}
+
+  def bulk_update_activity_attempts(values, params) do
+    sql = """
+      UPDATE activity_attempts
+      SET
+        score = batch_values.score,
+        out_of = batch_values.out_of,
+        lifecycle_state = batch_values.lifecycle_state,
+        date_evaluated = batch_values.date_evaluated,
+        date_submitted = batch_values.date_submitted
+      FROM (VALUES #{values}) AS batch_values (activity_attempt_guid, score, out_of, lifecycle_state, date_evaluated, date_submitted)
+      WHERE activity_attempts.attempt_guid = batch_values.activity_attempt_guid
+    """
+
+    Ecto.Adapters.SQL.query(Oli.Repo, sql, params)
   end
 
   defp attrs_for(

--- a/lib/oli/delivery/attempts/core.ex
+++ b/lib/oli/delivery/attempts/core.ex
@@ -592,8 +592,10 @@ defmodule Oli.Delivery.Attempts.Core do
         on:
           aa.resource_attempt_id == aa2.resource_attempt_id and aa.resource_id == aa2.resource_id and
             aa.id < aa2.id,
+        left_join: rev in assoc(aa, :revision),
         where: aa.resource_attempt_id == ^resource_attempt_id and is_nil(aa2),
-        select: aa
+        select: aa,
+        preload: [revision: rev]
       )
     )
   end

--- a/lib/oli/delivery/attempts/page_lifecycle/graded.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/graded.ex
@@ -114,7 +114,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Graded do
       }) do
     # Collect all of the part attempt guids for all of the activities that get finalized
     with {:ok, part_attempt_guids} <-
-           finalize_activity_and_part_attempts(resource_attempt.id, datashop_session_id),
+           finalize_activity_and_part_attempts(resource_attempt, datashop_session_id),
          {:ok, resource_attempt} <- roll_up_activities_to_resource_attempt(resource_attempt) do
       case resource_attempt do
         %ResourceAttempt{lifecycle_state: :evaluated} ->
@@ -148,10 +148,10 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Graded do
 
   def finalize(_), do: {:error, {:already_submitted}}
 
-  defp finalize_activity_and_part_attempts(resource_attempt_id, datashop_session_id) do
+  defp finalize_activity_and_part_attempts(resource_attempt, datashop_session_id) do
     with {_, activity_attempt_values, activity_attempt_params, part_attempt_guids} <-
            Evaluate.update_part_attempts_and_get_activity_attempts(
-             resource_attempt_id,
+             resource_attempt,
              datashop_session_id
            ),
          {:ok, _} <-

--- a/lib/oli/delivery/attempts/page_lifecycle/graded.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/graded.ex
@@ -14,11 +14,13 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Graded do
 
   alias Oli.Delivery.Attempts.Scoring
   alias Oli.Publishing.DeliveryResolver
-  alias Oli.Delivery.Attempts.ActivityLifecycle.Evaluate
+  alias Oli.Delivery.Attempts.ActivityLifecycle.{Evaluate, Persistence}
   alias Oli.Delivery.Evaluation.Result
   alias Oli.Delivery.Attempts.PageLifecycle.Common
   alias Oli.Delivery.Attempts.Core.{ResourceAttempt, ResourceAccess}
+
   import Oli.Delivery.Attempts.Core
+  import Ecto.Query, warn: false
 
   @moduledoc """
   Implementation of a page Lifecycle behaviour for graded pages.
@@ -105,65 +107,62 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Graded do
   end
 
   @impl Lifecycle
-
   def finalize(%FinalizationContext{
         resource_attempt: %ResourceAttempt{lifecycle_state: :active} = resource_attempt,
         section_slug: section_slug,
         datashop_session_id: datashop_session_id
       }) do
-    # Collect all of the part attempt guids for all of the activities that
-    # get finalized
+    # Collect all of the part attempt guids for all of the activities that get finalized
+    with {:ok, part_attempt_guids} <-
+           finalize_activity_and_part_attempts(resource_attempt.id, datashop_session_id),
+         {:ok, resource_attempt} <- roll_up_activities_to_resource_attempt(resource_attempt) do
+      case resource_attempt do
+        %ResourceAttempt{lifecycle_state: :evaluated} ->
+          case roll_up_resource_attempts_to_access(
+                 section_slug,
+                 resource_attempt.resource_access_id
+               ) do
+            {:ok, resource_access} ->
+              {:ok,
+               %FinalizationSummary{
+                 lifecycle_state: :evaluated,
+                 resource_access: resource_access,
+                 part_attempt_guids: part_attempt_guids
+               }}
 
-    part_attempt_guids = finalize_activities(resource_attempt, datashop_session_id)
+            error -> error
+          end
 
-    case roll_up_activities_to_resource_attempt(resource_attempt) do
-      {:ok, %ResourceAttempt{lifecycle_state: :evaluated}} ->
-        case roll_up_resource_attempts_to_access(
-               section_slug,
-               resource_attempt.resource_access_id
-             ) do
-          {:ok, resource_access} ->
-            {:ok,
-             %FinalizationSummary{
-               lifecycle_state: :evaluated,
-               resource_access: resource_access,
-               part_attempt_guids: part_attempt_guids
-             }}
-
-          e ->
-            e
-        end
-
-      {:ok, %ResourceAttempt{lifecycle_state: :submitted, resource_access_id: resource_access_id}} ->
-        {:ok,
-         %FinalizationSummary{
-           lifecycle_state: :submitted,
-           resource_access: Oli.Repo.get(ResourceAccess, resource_access_id),
-           part_attempt_guids: part_attempt_guids
-         }}
-
-      e ->
-        e
+        %ResourceAttempt{lifecycle_state: :submitted, resource_access_id: resource_access_id} ->
+          {:ok,
+           %FinalizationSummary{
+             lifecycle_state: :submitted,
+             resource_access: Oli.Repo.get(ResourceAccess, resource_access_id),
+             part_attempt_guids: part_attempt_guids
+           }}
+      end
+    else
+      error -> error
     end
   end
 
   def finalize(_), do: {:error, {:already_submitted}}
 
-  defp finalize_activities(resource_attempt, datashop_session_id) do
-    activity_attempts = get_latest_activity_attempts(resource_attempt.id)
-
-    Enum.map(activity_attempts, fn a ->
-      # some activities will finalize themselves ahead of a graded page
-      # submission.  so we only submit those that are still yet to be finalized, and
-      # that are scoreable
-      if a.lifecycle_state != :evaluated and a.scoreable do
-        Evaluate.evaluate_from_stored_input(a.attempt_guid, datashop_session_id)
-      else
-        []
-      end
-    end)
-    |> List.flatten()
-    |> Enum.map(fn part_attempt -> part_attempt.attempt_guid end)
+  defp finalize_activity_and_part_attempts(resource_attempt_id, datashop_session_id) do
+    with {_, activity_attempt_values, activity_attempt_params, part_attempt_guids} <-
+           Evaluate.update_part_attempts_and_get_activity_attempts(
+             resource_attempt_id,
+             datashop_session_id
+           ),
+         {:ok, _} <-
+           Persistence.bulk_update_activity_attempts(
+             Enum.join(activity_attempt_values, ", "),
+             activity_attempt_params
+           ) do
+      {:ok, part_attempt_guids}
+    else
+      error -> error
+    end
   end
 
   def roll_up_activities_to_resource_attempt(resource_attempt_guid)


### PR DESCRIPTION
[MER-1636](https://eliterate.atlassian.net/browse/MER-1636)

Intent to improve finalization of a page attempt by making only one query to update all activity attempts at once. Still need to update the part attempts within an iteration, as is needed to have that in place to have the correct values ​​to update the activity.

We should thoroughly test these changes, as I'm a bit worried this won't break anything else.

Feel free to ask questions or make any suggestions. In fact, we don't have to take these changes if you feel they are not necessary at all.

[MER-1636]: https://eliterate.atlassian.net/browse/MER-1636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ