### PR TITLE
[BUGFIX] Removed vendor.css references in html templates. [MER-1660]

### DIFF
--- a/lib/oli_web/templates/layout/authoring.html.leex
+++ b/lib/oli_web/templates/layout/authoring.html.leex
@@ -14,7 +14,6 @@
     <!-- Theme CSS (contains all bootstrap styles as well as custom styles for a specific theme) -->
     <link id="authoring-theme" rel="stylesheet" href="/css/authoring_default.css" />
     <link id="delivery-theme" rel="stylesheet" href="/css/delivery_default.css" />
-    <link id="vendor-css" rel="stylesheet" href="/css/vendor.css" />
 
     <%= if dev_mode?() do %>
       <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/react/17.0.2/umd/react.development.js"></script>

--- a/lib/oli_web/templates/layout/chromeless.html.eex
+++ b/lib/oli_web/templates/layout/chromeless.html.eex
@@ -41,7 +41,6 @@
 
     <!-- Janus Part Component external CSS Files -->
     <link rel="stylesheet" href="/css/janus_image_carousel_delivery.css"/>
-    <link id="vendor-css" rel="stylesheet" href="/css/vendor.css" />
 
     <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 

--- a/lib/oli_web/templates/layout/delivery.html.eex
+++ b/lib/oli_web/templates/layout/delivery.html.eex
@@ -13,7 +13,6 @@
 
     <!-- Theme CSS (contains all bootstrap styles as well as custom styles for a specific theme) -->
     <link id="delivery-theme" rel="stylesheet" href="/css/delivery_default.css" />
-    <link id="vendor-css" rel="stylesheet" href="/css/vendor.css" />
 
     <%= if dev_mode?() do %>
       <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/react/17.0.2/umd/react.development.js"></script>

--- a/lib/oli_web/templates/layout/lti.html.eex
+++ b/lib/oli_web/templates/layout/lti.html.eex
@@ -13,7 +13,6 @@
 
     <!-- Theme CSS (contains all bootstrap styles as well as custom styles for a specific theme) -->
     <link id="delivery-theme" rel="stylesheet" href="/css/delivery_default.css" />
-    <link id="vendor-css" rel="stylesheet" href="/css/vendor.css" />
 
     <script crossorigin src="https://unpkg.com/react@17.0.2/umd/react.production.min.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@17.0.2/umd/react-dom.production.min.js"></script>


### PR DESCRIPTION
Previously, we had changed the bundling of the client files to create a vendor.js and a vendor.css.

However, we later found the vendor.css didn’t play well with components utilizing the shadow-dom and reverted the generation of that file.

Unfortunately, we did not remove the reference to the css file in the html, so torus attempts to load the file which no longer exists and throws a console warning.