### PR TITLE
[FEATURE] Allow Collab spaces to ingest [MER-1657]

### DIFF
--- a/lib/oli/interop/ingest/processor/pages.ex
+++ b/lib/oli/interop/ingest/processor/pages.ex
@@ -1,6 +1,7 @@
 defmodule Oli.Interop.Ingest.Processor.Pages do
   alias Oli.Interop.Ingest.State
   alias Oli.Interop.Ingest.Processing.Rewiring
+  alias Oli.Resources.Collaboration.CollabSpaceConfig
   import Oli.Interop.Ingest.Processor.Common
 
   def process(%State{} = state) do
@@ -22,9 +23,24 @@ defmodule Oli.Interop.Ingest.Processor.Pages do
     %Oli.Resources.ExplanationStrategy{type: :after_set_num_attempts, set_num_attempts: 2}
   end
 
+  # Read the collab space config in a robust manner, falling back to defaults if
+  # the entire collabSpace key is missing or if any sub keys are missing
   defp read_collab_space(%{"collabSpace" => config}) do
-    %{
-      status: Map.get(config, "status", "disabled") |> String.to_existing_atom(),
+
+    # Read the status in a way that falls back to the proper default
+    # status if no status is specified or if an unsupported status is specified
+    default_status_str = CollabSpaceConfig.default_status() |> Atom.to_string()
+    candidate_status = Map.get(config, "status", default_status_str)
+
+    status = case CollabSpaceConfig.status_values()
+      |> Enum.map(fn a -> Atom.to_string(a) end)
+      |> Enum.any?(fn status_str -> status_str == candidate_status end) do
+      true -> String.to_existing_atom(candidate_status)
+      _ -> CollabSpaceConfig.default_status()
+    end
+
+    %CollabSpaceConfig{
+      status: status,
       threaded:  Map.get(config, "threaded", true),
       auto_accept: Map.get(config, "auto_accept", true),
       show_full_history: Map.get(config, "show_full_history", true),
@@ -33,7 +49,7 @@ defmodule Oli.Interop.Ingest.Processor.Pages do
     }
   end
 
-  defp read_collab_space(json), do: read_collab_space(%{"collabSpace" => %{}})
+  defp read_collab_space(_), do: read_collab_space(%{"collabSpace" => %{}})
 
   defp mapper(state, resource_id, resource) do
     legacy_id = Map.get(resource, "legacyId", nil)

--- a/lib/oli/interop/ingest/processor/pages.ex
+++ b/lib/oli/interop/ingest/processor/pages.ex
@@ -23,19 +23,17 @@ defmodule Oli.Interop.Ingest.Processor.Pages do
   end
 
   defp read_collab_space(%{"collabSpace" => config}) do
-
-  end
-
-  defp read_collab_space(_) do
     %{
-      status: :disabled,
-      threaded: true,
-      auto_accept: true,
-      show_full_history: true,
-      participation_min_replies: 0,
-      participation_min_posts: 0
+      status: Map.get(config, "status", "disabled") |> String.to_existing_atom(),
+      threaded:  Map.get(config, "threaded", true),
+      auto_accept: Map.get(config, "auto_accept", true),
+      show_full_history: Map.get(config, "show_full_history", true),
+      participation_min_replies: Map.get(config, "participation_min_replies", 0),
+      participation_min_posts: Map.get(config, "participation_min_posts", 0),
     }
   end
+
+  defp read_collab_space(json), do: read_collab_space(%{"collabSpace" => %{}})
 
   defp mapper(state, resource_id, resource) do
     legacy_id = Map.get(resource, "legacyId", nil)

--- a/lib/oli/interop/ingest/processor/pages.ex
+++ b/lib/oli/interop/ingest/processor/pages.ex
@@ -22,6 +22,21 @@ defmodule Oli.Interop.Ingest.Processor.Pages do
     %Oli.Resources.ExplanationStrategy{type: :after_set_num_attempts, set_num_attempts: 2}
   end
 
+  defp read_collab_space(%{"collabSpace" => config}) do
+
+  end
+
+  defp read_collab_space(_) do
+    %{
+      status: :disabled,
+      threaded: true,
+      auto_accept: true,
+      show_full_history: true,
+      participation_min_replies: 0,
+      participation_min_posts: 0
+    }
+  end
+
   defp mapper(state, resource_id, resource) do
     legacy_id = Map.get(resource, "legacyId", nil)
     legacy_path = Map.get(resource, "legacyPath", nil)
@@ -66,6 +81,7 @@ defmodule Oli.Interop.Ingest.Processor.Pages do
       activity_type_id: Map.get(state.registration_by_subtype, Map.get(resource, "subType")),
       scoring_strategy_id: Oli.Resources.ScoringStrategy.get_id_by_type("average"),
       explanation_strategy: get_explanation_strategy(graded),
+      collab_space_config: read_collab_space(resource),
       graded: graded,
       max_attempts:
         if graded do

--- a/lib/oli/resources/collaboration/collab_space_config.ex
+++ b/lib/oli/resources/collaboration/collab_space_config.ex
@@ -3,10 +3,16 @@ defmodule Oli.Resources.Collaboration.CollabSpaceConfig do
 
   import Ecto.Changeset
 
+  @status_values [:disabled, :enabled, :archived]
+  @default_status :disabled
+
+  def status_values(), do: @status_values
+  def default_status(), do: @default_status
+
   @derive Jason.Encoder
   @primary_key false
   embedded_schema do
-    field :status, Ecto.Enum, values: [:disabled, :enabled, :archived], default: :disabled
+    field :status, Ecto.Enum, values: @status_values, default: @default_status
 
     field :threaded, :boolean, default: true
     field :auto_accept, :boolean, default: true
@@ -15,6 +21,7 @@ defmodule Oli.Resources.Collaboration.CollabSpaceConfig do
     field :participation_min_replies, :integer, default: 0
     field :participation_min_posts, :integer, default: 0
   end
+
 
   def changeset(collab_space_config, attrs \\ %{})
 


### PR DESCRIPTION
This extends the ingest V2 to allow it to read the `collabSpace` key that can optionally exist as a top-level key in a digest "Page" JSON blob.  

Testing this, convert a course that contains discussions (for example, French 1), then ingest and verify that that end-to-end that a Discussion activity is converted to a practice page with an enabled Collab Space.  You will need this PR to land to `course-digest` first, though: https://github.com/Simon-Initiative/course-digest/pull/120

