### PR TITLE
[BUGFIX] [MER-972] Add duplicate email to community

### DIFF
--- a/lib/oli/groups.ex
+++ b/lib/oli/groups.ex
@@ -213,8 +213,27 @@ defmodule Oli.Groups do
 
   """
 
-  def create_community_account_from_user_email(email, attrs \\ %{}) do
-    case Accounts.get_user_by(%{email: email}) do
+  def create_community_account_from_user_email(email, attrs \\ %{}),
+    do: create_community_account_user(:email, email, attrs)
+
+  @doc """
+  Creates a community account from a user id (gets the user first).
+
+  ## Examples
+
+      iex> create_community_account_from_user_id(123 %{field: new_value})
+      {:ok, %CommunityAccount{}}
+
+      iex> create_community_account_from_user_id(123, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+
+  def create_community_account_from_user_id(id, attrs \\ %{}),
+    do: create_community_account_user(:id, id, attrs)
+
+  defp create_community_account_user(field, value, attrs) do
+    case Accounts.get_user_by(Map.put(%{}, field, value)) do
       %User{id: id} ->
         attrs |> Map.put(:user_id, id) |> create_community_account()
 

--- a/lib/oli_web/live/community_live/select_member_modal.ex
+++ b/lib/oli_web/live/community_live/select_member_modal.ex
@@ -1,0 +1,40 @@
+defmodule OliWeb.CommunityLive.SelectMemberModal do
+  use Surface.Component
+
+  prop id, :string, required: true
+  prop members, :list, required: true
+  prop select, :event, required: true
+
+  def render(assigns) do
+    ~F"""
+    <div class="modal fade show" id={@id} style="display: block" tabindex="-1" role="dialog" aria-labelledby="delete-modal" aria-hidden="true" phx-hook="ModalLaunch">
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">Select user</h5>
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+          <div class="modal-body">
+            <div class="mb-3">There is more than one user associated to that email, please select the one you want to add:</div>
+
+            <div class="p-3">
+              {#for member <- @members}
+                <div class="d-flex justify-content-between align-items-center mb-3">
+                  <div class="d-flex flex-column">
+                    <div>{member.email} - {member.name}</div>
+                    <div class="small text-muted">Sub: {member.sub}</div>
+                  </div>
+
+                  <button class="btn btn-link" :on-click={@select} phx-value-collaborator-id={member.id}>Select</button>
+                </div>
+              {/for}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/oli_web/live/community_live/show_view.ex
+++ b/lib/oli_web/live/community_live/show_view.ex
@@ -87,6 +87,7 @@ defmodule OliWeb.CommunityLive.ShowView do
           section_description="Add other authors by email to administrate the community."
         >
           <Invitation
+            to_invite={:admin}
             list_id="admin_matches"
             invite="add_admin"
             remove="remove_admin"
@@ -100,7 +101,7 @@ defmodule OliWeb.CommunityLive.ShowView do
 
         <ShowSection
           section_title="Community Members"
-          section_description="Add users by email as members of the community. Only showing the last 3 additions here."
+          section_description="Add users by email as members of the community (one at a time). Only showing the last 3 additions here."
         >
           <Invitation
             list_id="member_matches"
@@ -231,28 +232,15 @@ defmodule OliWeb.CommunityLive.ShowView do
       """
     end
 
-    # modal = fn assigns ->
-    #   ~F"""
-    #     <DeleteModal
-    #       id={@modal_assigns.id}
-    #       description={@modal_assigns.description}
-    #       entity_name={@modal_assigns.entity_name}
-    #       entity_type={@modal_assigns.entity_type}
-    #       delete_enabled={@modal_assigns.delete_enabled}
-    #       validate={@modal_assigns.validate}
-    #       delete={@modal_assigns.delete} />
-    #   """
-    # end
-
     {:noreply, show_modal(socket, modal, modal_assigns: modal_assigns)}
   end
 
-  def handle_event("add_" <> user_type, %{"collaborator" => %{"email" => email}}, socket) do
+  def handle_event("add_admin", %{"admin" => %{"email" => email}}, socket) do
     socket = clear_flash(socket)
 
     attrs = %{
       community_id: socket.assigns.community.id,
-      is_admin: user_type == "admin"
+      is_admin: true
     }
 
     emails =
@@ -261,20 +249,51 @@ defmodule OliWeb.CommunityLive.ShowView do
       |> Enum.map(&String.trim(&1))
 
     socket =
-      case Groups.create_community_accounts_from_emails(user_type, emails, attrs) do
+      case Groups.create_community_accounts_from_emails("admin", emails, attrs) do
         {:ok, _community_accounts} ->
-          put_flash(socket, :info, "Community #{user_type}(s) successfully added.")
+          updated_assigns = community_accounts_assigns("admin", attrs.community_id)
+
+          socket
+          |> put_flash(:info, "Community admin(s) successfully added.")
+          |> assign(updated_assigns)
 
         {:error, _error} ->
           message =
-            "Some of the community #{user_type}s couldn't be added because the users don't exist in the system or are already associated."
+            "Some of the community admin(s) couldn't be added because the author(s) don't exist in the system or are already associated."
 
           put_flash(socket, :error, message)
       end
 
-    updated_assigns = community_accounts_assigns(user_type, attrs.community_id)
+    {:noreply, socket}
+  end
 
-    {:noreply, assign(socket, updated_assigns)}
+  def handle_event("add_member", %{"collaborator" => %{"email" => email}}, socket) do
+    socket = clear_flash(socket)
+
+    attrs = %{community_id: socket.assigns.community.id}
+    matches = Map.get(socket.assigns.matches, "member")
+
+    socket =
+      if length(matches) > 1 do
+        socket
+      else
+        case Groups.create_community_account_from_email("member", String.trim(email), attrs) do
+          {:ok, _community_accounts} ->
+            updated_assigns = community_accounts_assigns("member", attrs.community_id)
+
+            socket
+            |> put_flash(:info, "Community member successfully added.")
+            |> assign(updated_assigns)
+
+          {:error, _error} ->
+            message =
+              "Member couldn't be added because the user don't exist in the system or is already associated."
+
+            put_flash(socket, :error, message)
+        end
+      end
+
+    {:noreply, socket}
   end
 
   def handle_event("add_institution", %{"institution" => %{"name" => name}}, socket) do
@@ -351,9 +370,12 @@ defmodule OliWeb.CommunityLive.ShowView do
     end
   end
 
-  def handle_event("suggest_" <> user_type, %{"collaborator" => %{"email" => query}}, socket) do
-    matches = Map.put(socket.assigns.matches, user_type, browse_accounts(user_type, query))
-    {:noreply, assign(socket, matches: matches)}
+  def handle_event("suggest_admin", %{"admin" => %{"email" => query}}, socket) do
+    do_suggest("admin", query, socket)
+  end
+
+  def handle_event("suggest_member", %{"collaborator" => %{"email" => query}}, socket) do
+    do_suggest("member", query, socket)
   end
 
   def handle_event("suggest_institution", %{"institution" => %{"name" => query}}, socket) do
@@ -364,6 +386,11 @@ defmodule OliWeb.CommunityLive.ShowView do
         Institutions.search_institutions_matching(query)
       )
 
+    {:noreply, assign(socket, matches: matches)}
+  end
+
+  defp do_suggest(user_type, query, socket) do
+    matches = Map.put(socket.assigns.matches, user_type, browse_accounts(user_type, query))
     {:noreply, assign(socket, matches: matches)}
   end
 

--- a/test/oli/groups_test.exs
+++ b/test/oli/groups_test.exs
@@ -206,6 +206,37 @@ defmodule Oli.GroupsTest do
                })
     end
 
+    test "create_community_account_from_user_id/2 with valid data creates a community account" do
+      user = insert(:user)
+      params = params_with_assocs(:community_member_account)
+
+      assert {:ok, %CommunityAccount{} = community_account} =
+               Groups.create_community_account_from_user_id(user.id, params)
+
+      assert community_account.user_id == user.id
+      assert community_account.community_id == params.community_id
+      assert community_account.is_admin == params.is_admin
+    end
+
+    test "create_community_account_from_user_id/2 for non existing user id returns author not found" do
+      params = params_with_assocs(:community_account)
+
+      assert {:error, :user_not_found} =
+               Groups.create_community_account_from_user_id(-12345, params)
+    end
+
+    test "create_community_account_from_user_id/2 for existing user and community returns error changeset" do
+      user = insert(:user)
+      community = build(:community)
+      insert(:community_member_account, %{user: user, community: community})
+
+      assert {:error, %Ecto.Changeset{}} =
+               Groups.create_community_account_from_user_id(user.id, %{
+                 user: user,
+                 community: community
+               })
+    end
+
     test "create_community_account_from_email/3 with valid data creates a community admin account" do
       author = insert(:author)
       params = params_with_assocs(:community_admin_account)

--- a/test/oli_web/live/community_live_test.exs
+++ b/test/oli_web/live/community_live_test.exs
@@ -457,7 +457,7 @@ defmodule OliWeb.CommunityLiveTest do
 
       view
       |> element("form[phx-submit=\"add_admin\"")
-      |> render_submit(%{collaborator: %{email: author.email}})
+      |> render_submit(%{admin: %{email: author.email}})
 
       assert view
              |> element("div.alert.alert-info")
@@ -481,7 +481,7 @@ defmodule OliWeb.CommunityLiveTest do
       |> render_submit(%{collaborator: %{email: author.email}})
 
       error_message =
-        "Some of the community admins couldn&#39;t be added because the users don&#39;t exist in the system or are already associated."
+        "Some of the community admin(s) couldn&#39;t be added because the author(s) don&#39;t exist in the system or are already associated."
 
       assert view
              |> element("div.alert.alert-danger")
@@ -511,7 +511,7 @@ defmodule OliWeb.CommunityLiveTest do
 
       view
       |> element("form[phx-submit=\"add_admin\"")
-      |> render_submit(%{collaborator: %{email: Enum.join(emails, ",")}})
+      |> render_submit(%{admin: %{email: Enum.join(emails, ",")}})
 
       assert view
              |> element("div.alert.alert-info")
@@ -577,7 +577,7 @@ defmodule OliWeb.CommunityLiveTest do
 
       view
       |> element("form[phx-change=\"suggest_admin\"")
-      |> render_change(%{collaborator: %{email: author.name}})
+      |> render_change(%{admin: %{email: author.name}})
 
       assert view
              |> element("#admin_matches")
@@ -586,7 +586,7 @@ defmodule OliWeb.CommunityLiveTest do
 
       view
       |> element("form[phx-change=\"suggest_admin\"")
-      |> render_change(%{collaborator: %{email: "other_name"}})
+      |> render_change(%{admin: %{email: "other_name"}})
 
       refute view
              |> element("#admin_matches")
@@ -612,7 +612,7 @@ defmodule OliWeb.CommunityLiveTest do
       assert view
              |> element("div.alert.alert-info")
              |> render() =~
-               "Community member(s) successfully added."
+               "Community member successfully added."
 
       assert 2 == length(Groups.list_community_members(community.id))
     end
@@ -631,7 +631,7 @@ defmodule OliWeb.CommunityLiveTest do
       |> render_submit(%{collaborator: %{email: user.email}})
 
       error_message =
-        "Some of the community members couldn&#39;t be added because the users don&#39;t exist in the system or are already associated."
+        "Member couldn&#39;t be added because the user don&#39;t exist in the system or is already associated."
 
       assert view
              |> element("div.alert.alert-danger")
@@ -646,29 +646,6 @@ defmodule OliWeb.CommunityLiveTest do
              |> render() =~ error_message
 
       assert 1 == length(Groups.list_community_members(community.id))
-    end
-
-    test "adds more than one community member correctly", %{
-      conn: conn,
-      community: community
-    } do
-      emails = insert_pair(:user) |> Enum.map(& &1.email)
-      insert(:community_member_account, %{community: community})
-
-      {:ok, view, _html} = live(conn, live_view_show_route(community.id))
-
-      assert 1 == length(Groups.list_community_members(community.id))
-
-      view
-      |> element("form[phx-submit=\"add_member\"")
-      |> render_submit(%{collaborator: %{email: Enum.join(emails, ",")}})
-
-      assert view
-             |> element("div.alert.alert-info")
-             |> render() =~
-               "Community member(s) successfully added."
-
-      assert 3 == length(Groups.list_community_members(community.id))
     end
 
     test "removes community member correctly", %{


### PR DESCRIPTION
[MER-972](https://eliterate.atlassian.net/browse/MER-972)

Allow duplicated user email to be added as member of the community, displaying a modal to select which one the admin wants to add.

## Note 
We don't support anymore adding more than one email at the same time for members, as that would require a little more of rework.

#

<img width="1919" alt="image" src="https://user-images.githubusercontent.com/42446726/212972569-89c8cef2-6ec2-4bb2-8060-2fb5c5605500.png">


[MER-972]: https://eliterate.atlassian.net/browse/MER-972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ