### PR TITLE
Annotaiton proof of concept

### DIFF
--- a/assets/src/apps/AnnotatorApp.tsx
+++ b/assets/src/apps/AnnotatorApp.tsx
@@ -1,0 +1,4 @@
+import { Annotator } from './annotator/Annotator';
+import { registerApplication } from './app';
+
+registerApplication('Annotator', Annotator);

--- a/assets/src/apps/annotator/Annotator.tsx
+++ b/assets/src/apps/annotator/Annotator.tsx
@@ -1,0 +1,212 @@
+import React, { useCallback, useMemo } from 'react';
+import { useToggle } from '../../components/hooks/useToggle';
+import useWindowSize from '../../components/hooks/useWindowSize';
+import { useDocumentMouseEvents } from './useDocumentMouseEvents';
+
+interface TextAnnotation {
+  id: string;
+  startOffset: number;
+  endOffset: number;
+}
+
+const getHeadingBlockHighlight = () => {
+  const heading = document.querySelector('#E236710925');
+  const rects = heading?.getClientRects();
+  // console.info(rects);
+  if (rects?.length) {
+    return rects![0];
+  }
+  return null;
+};
+
+const getHeadingParagraphTextHighlight = () => {
+  return getAnnotation('E236710926', 10, 19);
+};
+
+const getAnnotation = (id: string, startOffset: number, endOffset: number) => {
+  const element = document.querySelector('#' + id);
+  if (!element) return [];
+  if (!element.firstChild) return [];
+
+  try {
+    const range = document.createRange();
+    range.setStart(element.firstChild, startOffset);
+    range.setEnd(element.firstChild, endOffset);
+
+    const rects = range?.getClientRects();
+    if (rects?.length) {
+      return Array.from(rects);
+    }
+  } catch (e) {
+    console.info(e);
+  }
+
+  return [];
+};
+
+const getHeadingParagraphTextHighlight2 = () => {
+  return getAnnotation('E236710926', 99, 150);
+};
+
+const getIdFromTextNode = (node: Node | null): string | null => {
+  if (!node) return null;
+  if (node.nodeType === Node.TEXT_NODE) {
+    return getIdFromTextNode(node.parentElement);
+  }
+  if (node.nodeType === Node.ELEMENT_NODE) {
+    const id = (node as Element).attributes.getNamedItem('id')?.value;
+    if (id) return id;
+    return getIdFromTextNode(node.parentElement);
+  }
+  return null;
+};
+
+const getActiveTextHighlight = (activeHighlight: TextAnnotation | null) => {
+  if (!activeHighlight) return [];
+
+  return getAnnotation(activeHighlight.id, activeHighlight.startOffset, activeHighlight.endOffset);
+};
+
+const hasBlockAnnotationAttribute = (element: Element) => {
+  return element.attributes.getNamedItem('data-annotate')?.value === 'block';
+};
+
+const hasID = (element: Element) => {
+  return !!element.attributes.getNamedItem('id');
+};
+
+const blockAnnotatable = (element: Element) => {
+  return (
+    element.nodeType === Node.ELEMENT_NODE && hasBlockAnnotationAttribute(element) && hasID(element)
+  );
+};
+
+const getHighlightCoords = (highlights: TextAnnotation[]) =>
+  highlights.map(getActiveTextHighlight).flat(1);
+
+// -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+export const Annotator = () => {
+  const windowSize = useWindowSize();
+  const [editMode, toggleMode] = useToggle(true);
+  const [mouseDown, toggleMouse] = useToggle();
+  const [activeHighlight, setActiveHighlight] = React.useState<TextAnnotation | null>(null);
+  const [highlights, setHighlights] = React.useState<TextAnnotation[]>([]);
+
+  const appendHighlight = useCallback((highlight: TextAnnotation) => {
+    setHighlights((highlights) => [...highlights, highlight]);
+  }, []);
+
+  const highlightCoords = useMemo(() => {
+    return [...getHighlightCoords(highlights), ...getActiveTextHighlight(activeHighlight)];
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [windowSize, activeHighlight]);
+
+  const onMouseDown = useCallback((event: MouseEvent) => {
+    toggleMouse();
+  }, []);
+
+  const onMouseUp = useCallback(
+    (event: MouseEvent) => {
+      toggleMouse();
+      activeHighlight && appendHighlight(activeHighlight);
+      setActiveHighlight(null);
+    },
+    [activeHighlight, appendHighlight, toggleMouse],
+  );
+
+  const onMouseMove = useCallback(
+    (event: MouseEvent) => {
+      event.stopPropagation();
+      event.preventDefault();
+
+      const { pageX, pageY, clientX, clientY } = event;
+
+      if (mouseDown) {
+        const blockHighlightable = document
+          .elementsFromPoint(clientX, clientY)
+          .filter(blockAnnotatable);
+        // .forEach((element) => {
+        //   console.info('Bock highlight:', element);
+        // });
+
+        if (blockHighlightable.length === 0) {
+          let range;
+          let textNode;
+          let offset;
+          if (document.caretPositionFromPoint) {
+            range = document.caretPositionFromPoint(clientX, clientY);
+            textNode = range.offsetNode;
+            offset = range.offset;
+          } else if (document.caretRangeFromPoint) {
+            // Use WebKit-proprietary fallback method
+            range = document.caretRangeFromPoint(clientX, clientY);
+            if (range) {
+              textNode = range.startContainer;
+              offset = range.startOffset;
+            }
+          } else {
+            // Neither method is supported, do nothing
+            return;
+          }
+          const id = getIdFromTextNode(textNode);
+          if (activeHighlight && activeHighlight.id === id) {
+            setActiveHighlight({
+              ...activeHighlight,
+              endOffset: offset,
+            });
+          } else {
+            if (id) {
+              setActiveHighlight({
+                id,
+                startOffset: offset,
+                endOffset: offset,
+              });
+            }
+          }
+          console.info(editMode, mouseDown, {
+            clientX,
+            clientY,
+            activeHighlight,
+            textNode,
+            offset,
+          });
+        }
+      }
+    },
+    [activeHighlight, editMode, mouseDown],
+  );
+
+  useDocumentMouseEvents(editMode, onMouseDown, onMouseUp, onMouseMove);
+
+  return (
+    <>
+      <div className="annotation-controls">
+        <button onClick={toggleMode}>Highlighter ({editMode ? 'On' : 'Off'})</button>
+      </div>
+      <svg width="100%" height="100%">
+        {highlightCoords.map(
+          (highlight, index) =>
+            highlight && (
+              <rect
+                key={index}
+                x={highlight.x}
+                y={highlight.y}
+                width={highlight.width}
+                height={highlight.height}
+                rx="5"
+                fill="yellow"
+                fillOpacity="0.4"
+              />
+            ),
+        )}
+      </svg>
+    </>
+  );
+};
+
+declare global {
+  interface Document {
+    caretPositionFromPoint: any;
+  }
+}

--- a/assets/src/apps/annotator/useDocumentMouseEvents.ts
+++ b/assets/src/apps/annotator/useDocumentMouseEvents.ts
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+
+export const useDocumentMouseEvents = (
+  active: boolean,
+  onMouseDown: (event: MouseEvent) => void,
+  onMouseUp: (event: MouseEvent) => void,
+  onMouseMove: (event: MouseEvent) => void,
+) => {
+  useEffect(() => {
+    if (!active) return;
+    const body = document.querySelector('body') as HTMLBodyElement;
+    if (!body) throw new Error('body not found');
+    body.addEventListener('mousedown', onMouseDown);
+    body.addEventListener('mouseup', onMouseUp);
+    body.addEventListener('mousemove', onMouseMove);
+    return () => {
+      body.removeEventListener('mousedown', onMouseDown);
+      body.removeEventListener('mouseup', onMouseUp);
+      body.removeEventListener('mousemove', onMouseMove);
+    };
+  }, [active, onMouseDown, onMouseMove, onMouseUp]);
+};

--- a/assets/src/components/activities/common/choices/delivery/ChoicesDelivery.tsx
+++ b/assets/src/components/activities/common/choices/delivery/ChoicesDelivery.tsx
@@ -42,6 +42,7 @@ export const ChoicesDelivery: React.FC<Props> = ({
     <div className={styles.choicesContainer} aria-label="answer choices">
       {choices.map((choice, index) => (
         <div
+          id={choice.id}
           key={choice.id}
           aria-label={`choice ${index + 1}`}
           onClick={onClicked(choice.id)}

--- a/assets/src/components/activities/common/stem/delivery/StemDelivery.tsx
+++ b/assets/src/components/activities/common/stem/delivery/StemDelivery.tsx
@@ -15,7 +15,10 @@ interface StemProps {
 
 export const StemDelivery: React.FC<StemProps> = (props) => {
   return (
-    <div className={`stem__delivery${props.className ? ' ' + props.className : ''}`}>
+    <div
+      id={'E' + props.stem.id}
+      className={`stem__delivery${props.className ? ' ' + props.className : ''}`}
+    >
       <HtmlContentModelRenderer content={props.stem.content} context={props.context} />
     </div>
   );

--- a/assets/src/data/content/writers/html.tsx
+++ b/assets/src/data/content/writers/html.tsx
@@ -124,8 +124,12 @@ export class HtmlParser implements WriterImpl {
     );
   }
 
-  p(context: WriterContext, next: Next, _x: Paragraph) {
-    return <p>{next()}</p>;
+  p(context: WriterContext, next: Next, attrs: Paragraph) {
+    return (
+      <p id={'E' + attrs.id} data-annotate="text">
+        {next()}
+      </p>
+    );
   }
   h1(context: WriterContext, next: Next, _x: HeadingOne) {
     return <h1>{next()}</h1>;

--- a/assets/styles/delivery/index.scss
+++ b/assets/styles/delivery/index.scss
@@ -14,3 +14,26 @@
 @import 'page_delivery/collab_space.scss';
 @import 'page_delivery/page.scss';
 @import 'page_delivery/prologue.scss';
+
+#annotations-root {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  pointer-events: none;
+}
+
+#annotations-root > div > svg {
+  pointer-events: none;
+}
+
+#annotations-root > div {
+  width: 100%;
+  height: 100%;
+  .annotation-controls {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+  }
+}

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -25,6 +25,7 @@ const populateEntries = () => {
     bibliography: ['./src/apps/BibliographyApp.tsx'],
     authoring: ['./src/apps/AuthoringApp.tsx'],
     delivery: ['./src/apps/DeliveryApp.tsx'],
+    annotation: ['./src/apps/AnnotatorApp.tsx'],
     stripeclient: ['./src/payment/stripe/client.ts'],
     timezone: ['./src/phoenix/timezone.ts'],
     dark: ['./src/phoenix/dark.ts'],

--- a/lib/oli/rendering/activity/html.ex
+++ b/lib/oli/rendering/activity/html.ex
@@ -176,7 +176,7 @@ defmodule Oli.Rendering.Activity.Html do
       |> HtmlEntities.encode()
 
     [
-      ~s|<#{tag} phx-update="ignore" class="activity-container" state="#{state}" model="#{model_json}" mode="#{mode}" context="#{activity_context}"></#{tag}>\n|
+      ~s|<#{tag} id="" phx-update="ignore" class="activity-container" state="#{state}" model="#{model_json}" mode="#{mode}" context="#{activity_context}"></#{tag}>\n|
     ]
   end
 

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -24,37 +24,37 @@ defmodule Oli.Rendering.Content.Html do
     ["<span class=\"callout-inline\">", next.(), "</span>\n"]
   end
 
-  def p(%Context{} = _context, next, _) do
-    ["<p>", next.(), "</p>\n"]
+  def p(%Context{} = _context, next, attrs) do
+    ["<p data-annotate='text' id='E#{attrs["id"]}'>", next.(), "</p>\n"]
   end
 
-  def h1(%Context{} = _context, next, _) do
-    ["<h1>", next.(), "</h1>\n"]
+  def h1(%Context{} = _context, next, attrs) do
+    ["<h1 data-annotate='text' id='E#{attrs["id"]}'>", next.(), "</h1>\n"]
   end
 
-  def h2(%Context{} = _context, next, _) do
-    ["<h2>", next.(), "</h2>\n"]
+  def h2(%Context{} = _context, next, attrs) do
+    ["<h2 data-annotate='text' id='E#{attrs["id"]}'>", next.(), "</h2>\n"]
   end
 
-  def h3(%Context{} = _context, next, _) do
-    ["<h3>", next.(), "</h3>\n"]
+  def h3(%Context{} = _context, next, attrs) do
+    ["<h3 data-annotate='text' id='E#{attrs["id"]}'>", next.(), "</h3>\n"]
   end
 
-  def h4(%Context{} = _context, next, _) do
-    ["<h4>", next.(), "</h4>\n"]
+  def h4(%Context{} = _context, next, attrs) do
+    ["<h4 data-annotate='text' id='E#{attrs["id"]}'>", next.(), "</h4>\n"]
   end
 
-  def h5(%Context{} = _context, next, _) do
-    ["<h5>", next.(), "</h5>\n"]
+  def h5(%Context{} = _context, next, attrs) do
+    ["<h5 data-annotate='text' id='E#{attrs["id"]}'>", next.(), "</h5>\n"]
   end
 
-  def h6(%Context{} = _context, next, _) do
-    ["<h6>", next.(), "</h6>\n"]
+  def h6(%Context{} = _context, next, attrs) do
+    ["<h6 data-annotate='text' id='E#{attrs["id"]}'>", next.(), "</h6>\n"]
   end
 
   def img(%Context{} = context, _, %{"src" => src} = attrs) do
     captioned_content(context, attrs, [
-      ~s|<img class="figure-img img-fluid"#{maybeAlt(attrs)}#{maybeWidth(attrs)} src="#{escape_xml!(src)}"/>\n|
+      ~s|<img data-annotate='block' id='E#{attrs["id"]}' class="figure-img img-fluid"#{maybeAlt(attrs)}#{maybeWidth(attrs)} src="#{escape_xml!(src)}"/>\n|
     ])
   end
 
@@ -62,7 +62,7 @@ defmodule Oli.Rendering.Content.Html do
 
   def img_inline(%Context{} = _context, _, %{"src" => src} = attrs) do
     [
-      ~s|<img class="img-fluid"#{maybeAlt(attrs)}#{maybeWidth(attrs)} src="#{escape_xml!(src)}"/>\n|
+      ~s|<img data-annotate='block' id='E#{attrs["id"]}' class="img-fluid"#{maybeAlt(attrs)}#{maybeWidth(attrs)} src="#{escape_xml!(src)}"/>\n|
     ]
   end
 

--- a/lib/oli_web/templates/layout/delivery.html.eex
+++ b/lib/oli_web/templates/layout/delivery.html.eex
@@ -57,6 +57,7 @@
     <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/vendor.js") %>"></script>
     <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/app.js") %>"></script>
     <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/components.js") %>"></script>
+    <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/annotation.js") %>"></script>
     <%= unless Plug.Conn.get_session(@conn, "browser_timezone") do %>
       <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/timezone.js") %>"></script>
     <% end %>
@@ -92,5 +93,8 @@
     <script>hljs.highlightAll();</script>
 
     <%= render OliWeb.LayoutView, "_delivery_footer.html", assigns %>
+    <div id="annotations-root">
+      <%= react_component("Components.Annotator", @context) %>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
# ⚠️ This is an example proof of concept and not meant to actually be merged at this time.

Upcoming work will be requesting an annotation / highlighting feature to be added to the torus discussion feature. This will let a student highlight a section of content on a page, and other students or educators to see that highlight and comment on it.

Some requirements to consider:

- Ability to point-annotate objects. Such as images, videos, or other content where the entire thing should be annotated.
- Ability to annotate ranges of elements. (start here, highlight through here… may include several torus elements.
- Ability to annotate ranges of text within an element.

Annotation in this context means identifying the items and showing a visual indicator around them. Additional text to actually “annotate” them will be in a separate panel with the

## There are three interesting challenges

This proof of concept shows a way of doing the first two, and comments in this PR will show some viable paths for the third.

1. Rendering the highlights on a page
2. Handling the user-input of specifying those highlights
3. Storing those highlights in a way that will be resilient to content changing.

Some things to remember:

- Elements can both be in page-content and within activities.
- Some content is server-rendered, some is react-rendered and annotation should work seamlessly across.
- Not all students get the same content. Things like question-banks exist.
- Not all students see the content in the same order. Example: MCQ options are randomized order.
- React (and probably live view???) doesn’t like an external script modifying the dom of elements it controls, so there’s render-challenges there.

## Out of scope for the first version:

- Annotating within shadow-dom based elements.
- Annotating within iframe content
- Adaptive lessons (for V1 annotation feature)
- Marking specific parts of elements (section of an image, cue point of a video, etc.)
- User input - we won’t annotate things the learner does / answers. Like _what_ option they selected in an MCQ, or what text they type in an input.

# Description of the solution

For rendering the highlights, there's two primary options.

1. Modifying the content to display highlights
2. Overlaying an element over the page to display highlights.

This POC takes the second option, primarily to solve issues with rendering the highlights across both client-rendered and server-rendered content without having to implement it twice.

For handling user-input, there are two potential API calls that come in useful for detecting what specific text ranges are at a point on the screen.

```
    document.caretPositionFromPoint(clientX, clientY);
    document.caretRangeFromPoint(clientX, clientY);
```

Most modern browsers support caretRangeFromPoint, however Firefox does not. So we'll need to use caretPositionFromPoint for Firefox.

Neither of these work when something interactable is overlaid on top of the content, so we need to make our highlight overlay `pointer-events: none;` and deal with document-level mouse events.

# Quick demo:

![annotations](https://user-images.githubusercontent.com/333265/213193218-c1ac59fd-1ba9-415e-b921-c9a50886f0bc.gif)
