### PR TITLE
[FEATURE] [MER-1646] Add necessary fields for exploration pages

### DIFF
--- a/lib/oli/resources.ex
+++ b/lib/oli/resources.ex
@@ -315,7 +315,9 @@ defmodule Oli.Resources do
           legacy: previous_revision.legacy |> convert_legacy,
           tags: previous_revision.tags,
           explanation_strategy: previous_revision.explanation_strategy,
-          collab_space_config: previous_revision.collab_space_config
+          collab_space_config: previous_revision.collab_space_config,
+          purpose: previous_revision.purpose,
+          relates_to: previous_revision.relates_to
         },
         convert_strings_to_atoms(attrs)
       )

--- a/lib/oli/resources/revision.ex
+++ b/lib/oli/resources/revision.ex
@@ -65,6 +65,9 @@ defmodule Oli.Resources.Revision do
     field(:page_type, :string, virtual: true)
     field(:parent_slug, :string, virtual: true)
 
+    field :purpose, Ecto.Enum, values: [:foundation, :application], default: :foundation
+    field :relates_to, {:array, :id}, default: []
+
     timestamps(type: :utc_datetime)
   end
 

--- a/priv/repo/migrations/20230125131506_update_revisions_add_purpose.exs
+++ b/priv/repo/migrations/20230125131506_update_revisions_add_purpose.exs
@@ -1,0 +1,28 @@
+defmodule Oli.Repo.Migrations.UpdateRevisionsAddPurpose do
+  use Ecto.Migration
+
+  def up do
+    alter table(:revisions) do
+      add :purpose, :string, default: "foundation"
+      add :relates_to, {:array, :id}, default: []
+    end
+
+    execute """
+    UPDATE revisions
+    SET purpose = 'foundation', relates_to=array[]::integer[];
+    """
+
+    alter table(:revisions) do
+      modify :purpose, :string, default: "foundation", null: false
+      modify :relates_to, {:array, :id}, default: [], null: false
+    end
+  end
+
+
+  def down do
+    alter table(:revisions) do
+      remove :purpose
+      remove :tags
+    end
+  end
+end

--- a/priv/repo/migrations/20230125131506_update_revisions_add_purpose.exs
+++ b/priv/repo/migrations/20230125131506_update_revisions_add_purpose.exs
@@ -1,28 +1,10 @@
 defmodule Oli.Repo.Migrations.UpdateRevisionsAddPurpose do
   use Ecto.Migration
 
-  def up do
+  def change do
     alter table(:revisions) do
-      add :purpose, :string, default: "foundation"
-      add :relates_to, {:array, :id}, default: []
-    end
-
-    execute """
-    UPDATE revisions
-    SET purpose = 'foundation', relates_to=array[]::integer[];
-    """
-
-    alter table(:revisions) do
-      modify :purpose, :string, default: "foundation", null: false
-      modify :relates_to, {:array, :id}, default: [], null: false
-    end
-  end
-
-
-  def down do
-    alter table(:revisions) do
-      remove :purpose
-      remove :tags
+      add :purpose, :string, default: "foundation", null: false
+      add :relates_to, {:array, :id}, default: [], null: false
     end
   end
 end


### PR DESCRIPTION
[Link to the story](https://eliterate.atlassian.net/browse/MER-1671)
### NOTES
I'm not sure what's the best way to handle the update of application pages once a resource gets deleted (if a resource gets deleted and it's related to an application page, the `relates_to` of that page should be updated). Maybe we can ignore it and when we get the related resources of an application page, we can filter deleted resources.