### PR TITLE
[FEATURE] [MER-1673] Infrastructure for exploration and relates_to resource access

### DIFF
--- a/lib/oli/publishing/delivery_resolver.ex
+++ b/lib/oli/publishing/delivery_resolver.ex
@@ -291,20 +291,14 @@ defmodule Oli.Publishing.DeliveryResolver do
   """
 
   def get_by_purpose(section_slug, purpose) do
+    page_id = Oli.Resources.ResourceType.get_id_by_type("page")
+
     Repo.all(
-      from(
-        revision in Revision,
-        join: sect_res in SectionResource,
-        on: sect_res.resource_id == revision.resource_id,
-        join: sec in Section,
-        on: sec.id == sect_res.section_id,
+      from([sr: sr, rev: rev] in section_resource_revisions(section_slug),
         where:
-          revision.purpose ==
-            ^purpose and
-            revision.resource_type_id ==
-              1 and sec.slug == ^section_slug and revision.deleted == false and
-            sect_res.numbering_level > 0,
-        select: revision,
+          rev.purpose == ^purpose and rev.deleted == false and rev.resource_type_id == ^page_id and
+            sr.numbering_level > 0,
+        select: rev,
         order_by: [asc: :resource_id]
       )
     )
@@ -321,19 +315,15 @@ defmodule Oli.Publishing.DeliveryResolver do
   """
 
   def targeted_via_related_to(section_slug, resource_id) do
+    page_id = Oli.Resources.ResourceType.get_id_by_type("page")
+
     Repo.all(
-      from(
-        revision in Revision,
-        join: sect_res in SectionResource,
-        on: sect_res.resource_id == revision.resource_id,
-        join: sec in Section,
-        on: sec.id == sect_res.section_id,
+      from([sr: sr, rev: rev] in section_resource_revisions(section_slug),
         where:
-          ^resource_id in revision.relates_to and
-            revision.resource_type_id ==
-              1 and sec.slug == ^section_slug and revision.deleted == false and
-            sect_res.numbering_level > 0,
-        select: revision,
+          ^resource_id in rev.relates_to and rev.deleted == false and
+            rev.resource_type_id == ^page_id and
+            sr.numbering_level > 0,
+        select: rev,
         order_by: [asc: :resource_id]
       )
     )

--- a/lib/oli/publishing/delivery_resolver.ex
+++ b/lib/oli/publishing/delivery_resolver.ex
@@ -279,4 +279,63 @@ defmodule Oli.Publishing.DeliveryResolver do
       select: spp.publication_id
     )
   end
+
+  @doc """
+  Returns the current revisions of all page resources whose purpose type matches the one it receives as parameter
+  ## Examples
+      iex> get_by_purpose(valid_section_slug, valid_purpose)
+      [%Revision{}, ...]
+
+      iex> get_by_purpose(invalid_section_slug, invalid_purpose)
+      []
+  """
+
+  def get_by_purpose(section_slug, purpose) do
+    Repo.all(
+      from(
+        revision in Revision,
+        join: sect_res in SectionResource,
+        on: sect_res.resource_id == revision.resource_id,
+        join: sec in Section,
+        on: sec.id == sect_res.section_id,
+        where:
+          revision.purpose ==
+            ^purpose and
+            revision.resource_type_id ==
+              1 and sec.slug == ^section_slug and revision.deleted == false and
+            sect_res.numbering_level > 0,
+        select: revision,
+        order_by: [asc: :resource_id]
+      )
+    )
+  end
+
+  @doc """
+  Returns the current revisions of all page resources whose have the given resource_id in their "relates_to" attribute
+  ## Examples
+      iex> targeted_via_related_to(valid_section_slug, valid_resource_id)
+      [%Revision{}, ...]
+
+      iex> targeted_via_related_to(invalid_section_slug, invalid_resource_id)
+      []
+  """
+
+  def targeted_via_related_to(section_slug, resource_id) do
+    Repo.all(
+      from(
+        revision in Revision,
+        join: sect_res in SectionResource,
+        on: sect_res.resource_id == revision.resource_id,
+        join: sec in Section,
+        on: sec.id == sect_res.section_id,
+        where:
+          ^resource_id in revision.relates_to and
+            revision.resource_type_id ==
+              1 and sec.slug == ^section_slug and revision.deleted == false and
+            sect_res.numbering_level > 0,
+        select: revision,
+        order_by: [asc: :resource_id]
+      )
+    )
+  end
 end

--- a/test/oli/publishing/authoring_resolver_test.exs
+++ b/test/oli/publishing/authoring_resolver_test.exs
@@ -1,6 +1,8 @@
 defmodule Oli.Publishing.AuthoringResolverTest do
   use Oli.DataCase
 
+  import Oli.Factory
+
   alias Oli.Publishing.AuthoringResolver
   alias Oli.Authoring.Editing.ResourceEditor
   alias Oli.Resources.ResourceType
@@ -221,6 +223,60 @@ defmodule Oli.Publishing.AuthoringResolverTest do
 
       assert Enum.count(revisions) == 2
       assert revisions |> Enum.map(& &1.title) |> Enum.sort() == ["Alt 1", "Alt 3"]
+    end
+
+    test "get_by_purpose/2 returns all revisions when receive a valid project_slug and purpose",
+         %{} do
+      {:ok,
+       project: project,
+       section: _section,
+       page_revision: page_revision,
+       other_revision: other_revision} = project_section_revisions(%{})
+
+      assert project.slug
+             |> AuthoringResolver.get_by_purpose(page_revision.purpose)
+             |> length() == 1
+
+      assert project.slug
+             |> AuthoringResolver.get_by_purpose(other_revision.purpose)
+             |> length() == 1
+    end
+
+    test "get_by_purpose/2 returns empty list when receive a invalid project_slug",
+         %{} do
+      project = insert(:project)
+
+      assert AuthoringResolver.get_by_purpose(project.slug, :foundation) == []
+      assert AuthoringResolver.get_by_purpose(project.slug, :application) == []
+    end
+
+    test "targeted_via_related_to/2 returns all revisions when receive a valid project_slug and resource_id",
+         %{} do
+      {:ok,
+       project: project,
+       section: _section,
+       page_revision: page_revision,
+       other_revision: _other_revision} = project_section_revisions(%{})
+
+      assert project.slug
+             |> AuthoringResolver.targeted_via_related_to(page_revision.resource_id)
+             |> length() == 1
+    end
+
+    test "targeted_via_related_to/2 returns empty list when don't receive a valid project_slug and resource_id",
+         %{} do
+      project = insert(:project)
+
+      page_revision =
+        insert(:revision,
+          resource_type_id: Oli.Resources.ResourceType.get_id_by_type("page"),
+          title: "Example test revision",
+          graded: true,
+          content: %{"advancedDelivery" => true}
+        )
+
+      assert AuthoringResolver.targeted_via_related_to(project.slug, page_revision.resource_id) ==
+               []
     end
   end
 end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -729,7 +729,7 @@ defmodule Oli.TestHelpers do
 
     # Publication of project with root container
     publication =
-      insert(:publication, %{project: project, root_resource_id: container_resource.id})
+      insert(:publication, %{project: project, root_resource_id: container_resource.id, published: nil})
 
     # Publish root container resource
     insert(:published_resource, %{

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -682,6 +682,92 @@ defmodule Oli.TestHelpers do
     {:ok, section: section, unit_one_revision: unit_one_revision, page_revision: page_revision}
   end
 
+  def project_section_revisions(_) do
+    author = insert(:author)
+    project = insert(:project, authors: [author])
+
+    # Graded page revision
+    page_revision =
+      insert(:revision,
+        resource_type_id: Oli.Resources.ResourceType.get_id_by_type("page"),
+        title: "Progress test revision",
+        graded: true,
+        content: %{"advancedDelivery" => true}
+      )
+
+    other_revision =
+      insert(:revision,
+        resource_type_id: Oli.Resources.ResourceType.get_id_by_type("page"),
+        title: "Other test revision",
+        graded: true,
+        content: %{"advancedDelivery" => true},
+        relates_to: [page_revision.resource_id],
+        purpose: :application
+      )
+
+    # Associate nested graded page to the project
+    insert(:project_resource, %{project_id: project.id, resource_id: page_revision.resource.id})
+    insert(:project_resource, %{project_id: project.id, resource_id: other_revision.resource.id})
+
+    # root container
+    container_resource = insert(:resource)
+
+    # Associate root container to the project
+    insert(:project_resource, %{project_id: project.id, resource_id: container_resource.id})
+
+    container_revision =
+      insert(:revision, %{
+        resource: container_resource,
+        objectives: %{},
+        resource_type_id: Oli.Resources.ResourceType.get_id_by_type("container"),
+        children: [page_revision.resource.id, other_revision.resource.id],
+        content: %{},
+        deleted: false,
+        slug: "root_container",
+        title: "Root Container"
+      })
+
+    # Publication of project with root container
+    publication =
+      insert(:publication, %{project: project, root_resource_id: container_resource.id})
+
+    # Publish root container resource
+    insert(:published_resource, %{
+      publication: publication,
+      resource: container_resource,
+      revision: container_revision,
+      author: author
+    })
+
+    # Publish nested page resource
+    insert(:published_resource, %{
+      publication: publication,
+      resource: page_revision.resource,
+      revision: page_revision,
+      author: author
+    })
+
+    insert(:published_resource, %{
+      publication: publication,
+      resource: other_revision.resource,
+      revision: other_revision,
+      author: author
+    })
+
+    section =
+      insert(:section,
+        base_project: project,
+        context_id: UUID.uuid4(),
+        open_and_free: true,
+        registration_open: true,
+        type: :enrollable
+      )
+
+    {:ok, section} = Sections.create_section_resources(section, publication)
+
+    {:ok, project: project, section: section, page_revision: page_revision, other_revision: other_revision}
+  end
+
   def enroll_user_to_section(user, section, role) do
     Sections.enroll(user.id, section.id, [
       ContextRoles.get_role(role)


### PR DESCRIPTION
[MER-1673 ](https://eliterate.atlassian.net/browse/MER-1673)

This PR adds two new functions to the delivery and authoring resolvers. 

- `get_by_purpose/2` - Returns the current versions of all page resources whose purpose type matches.

- `targeted_via_related_to/2` - Returns a list of Revisions of all pages that target the given resource id in their "relates_to" attribute.