### PR TITLE
[BUG FIX] Adjust float comparison [MER-1747]

### DIFF
--- a/lib/oli/delivery/evaluation/rule.ex
+++ b/lib/oli/delivery/evaluation/rule.ex
@@ -111,7 +111,7 @@ defmodule Oli.Delivery.Evaluation.Rule do
         l_value = parse_number(left)
         {r_value, r_precision} = parse_number_with_precision(right)
 
-        abs(abs(l_value) - abs(r_value)) < 0.00001 &&
+        abs(l_value - r_value) < 0.00001 &&
           check_precision(left, r_precision)
 
       true ->

--- a/test/oli/delivery/evaluation/rule_eval_test.exs
+++ b/test/oli/delivery/evaluation/rule_eval_test.exs
@@ -21,6 +21,10 @@ defmodule Oli.Delivery.Evaluation.RuleEvalTest do
     end
   end
 
+  test "evaluating negative decimal submissions against decimal value" do
+    refute eval("input = {0.0200}", "-0.02")
+  end
+
   test "evaluating integers" do
     assert eval("attemptNumber = {1} && input = {3}", "3")
     refute eval("attemptNumber = {1} && input = {3}", "4")


### PR DESCRIPTION
This impl should not have been taking the absolute value of each operand, just the absolute value of their difference. 

To reproduce this problem, create a numeric input question with correct answer "Equal to"  0.02.

Then in preview or delivery, submit an answer of -0.02

