### PR TITLE
[MER 1763] activity bank crashes when a single part selection part id is missing

### DIFF
--- a/assets/src/components/resource/objectives/ActivityLOs.tsx
+++ b/assets/src/components/resource/objectives/ActivityLOs.tsx
@@ -62,10 +62,11 @@ const MultiPartSelections = (props: Props) => (
 
 const SinglePartSelection = (props: Props) => {
   const partId = props.partIds[0];
+
   return (
     <ObjectivesSelection
       {...props}
-      selected={props.objectives[partId]}
+      selected={props.objectives[partId] || []}
       objectives={props.allObjectives}
       onEdit={(objectives) => props.onEdit({ ...props.objectives, ...{ [partId]: objectives } })}
     />


### PR DESCRIPTION
Fixes a bug found in the activity bank editor (but actually applies to all InlineActivityEditors) for Multi Input questions with a single input where removing/changing an input could cause the partId to be missing from the objectives map, crashing the page.

This fix simply takes the same approach as the above `MultiPartSelection` component and initializes the `ObjectivesSelection` selection prop to empty array `[]` if no partId is found in the objectives map.