### PR TITLE
[FEATURE] MER-1762 add Equals Exactly and Equals Ignoring Case text answer matching options

### DIFF
--- a/assets/src/components/activities/multi_input/sections/AnswerKeyTab.tsx
+++ b/assets/src/components/activities/multi_input/sections/AnswerKeyTab.tsx
@@ -19,7 +19,7 @@ import { getTargetedResponses } from 'components/activities/short_answer/utils';
 import { makeResponse, Response, RichText } from 'components/activities/types';
 import { Radio } from 'components/misc/icons/radio/Radio';
 import { getCorrectResponse } from 'data/activities/model/responses';
-import { containsRule, eqRule, equalsRule } from 'data/activities/model/rules';
+import { eqRule, equalsnocaseRule, equalsRule } from 'data/activities/model/rules';
 import { defaultWriterContext } from 'data/content/writers/context';
 import React from 'react';
 
@@ -31,7 +31,7 @@ const defaultRuleForInputType = (inputType: string | undefined) => {
       return equalsRule('');
     case 'text':
     default:
-      return containsRule('');
+      return equalsnocaseRule('');
   }
 };
 

--- a/assets/src/components/activities/multi_input/sections/AnswerKeyTab.tsx
+++ b/assets/src/components/activities/multi_input/sections/AnswerKeyTab.tsx
@@ -19,7 +19,7 @@ import { getTargetedResponses } from 'components/activities/short_answer/utils';
 import { makeResponse, Response, RichText } from 'components/activities/types';
 import { Radio } from 'components/misc/icons/radio/Radio';
 import { getCorrectResponse } from 'data/activities/model/responses';
-import { eqRule, equalsnocaseRule, equalsRule } from 'data/activities/model/rules';
+import { containsRule, eqRule, equalsRule } from 'data/activities/model/rules';
 import { defaultWriterContext } from 'data/content/writers/context';
 import React from 'react';
 
@@ -31,7 +31,7 @@ const defaultRuleForInputType = (inputType: string | undefined) => {
       return equalsRule('');
     case 'text':
     default:
-      return equalsnocaseRule('');
+      return containsRule('');
   }
 };
 

--- a/assets/src/components/activities/short_answer/sections/TextInput.tsx
+++ b/assets/src/components/activities/short_answer/sections/TextInput.tsx
@@ -42,6 +42,8 @@ export const TextInput: React.FC<InputProps> = ({ input, onEditInput }) => {
 };
 
 const textOptions: { value: string; displayValue: string }[] = [
+  { value: 'equals', displayValue: 'Equals exactly' },
+  { value: 'equalsnocase', displayValue: 'Equals ignoring case' },
   { value: 'contains', displayValue: 'Contains' },
   { value: 'notcontains', displayValue: "Doesn't Contain" },
   { value: 'regex', displayValue: 'Regex' },

--- a/assets/src/data/activities/model/rules.ts
+++ b/assets/src/data/activities/model/rules.ts
@@ -189,7 +189,7 @@ export const makeRule = (input: Input): string => {
       case 'equals':
         return equalsRule(input.value);
       case 'equalsnocase':
-        return equalsnocaseRule(input.value));
+        return equalsnocaseRule(input.value);
     }
   }
 

--- a/assets/src/data/activities/model/rules.ts
+++ b/assets/src/data/activities/model/rules.ts
@@ -294,8 +294,8 @@ export const matchSingleTextRule = (rule: string): Maybe<InputText> =>
     .lift(translateRule)
     .lift(({ value, operator }: ParsedTextRule) => ({
       kind: InputKind.Text,
-      value: value,
-      operator: operator,
+      value,
+      operator,
     }));
 
 type ParsedNumericRule = {


### PR DESCRIPTION
For MER-1762. Adds Equals Exactly and Equals Ignoring Case answer matching options for text input items.

The former maps to the "input equals {text}' rule which already existed. The latter is implemented by translating the pseudo-operator "equalsnocase" appropriately to and from regex-matching rule "input like {(?:i)escapedText}' at the rule level. 

Dealing with this mapping introduces a bit of complexity, but it is not too bad and seems to work as is. Still, code would be simpler and more uniform if an appropriate operator existed in the rule language. 

Note these expose a quirk of the behavior of the rule engine: It appears both equals and regex matches effectively do a "contains" match, satisfying the rule if the pattern appears anywhere in the input string. See MER-1761.

With this addition, could think about changing the default operator for new text input items to one of these, but it is unchanged for now.