### PR TITLE
[FEATURE] [MER-1696] Student oriented summary view

### DIFF
--- a/lib/oli/resources/collaboration.ex
+++ b/lib/oli/resources/collaboration.ex
@@ -415,9 +415,8 @@ defmodule Oli.Resources.Collaboration do
         join: user in User,
         on: post.user_id == user.id,
         where:
-          post.section_id == ^section_id and
-            (post.status in [:approved, :archived] or
-               (post.status == :submitted and post.user_id == ^user_id)) and is_nil(rev2) and
+          post.section_id == ^section_id and post.user_id != ^user_id and
+            post.status in [:approved, :archived] and is_nil(rev2) and
             rev.deleted == false,
         select: %{
           id: post.id,

--- a/lib/oli/resources/collaboration.ex
+++ b/lib/oli/resources/collaboration.ex
@@ -357,22 +357,21 @@ defmodule Oli.Resources.Collaboration do
       from(
         post in Post,
         join: sr in SectionResource,
-        on: sr.resource_id == post.resource_id and sr.section_id == post.section_id,
+        on:
+          sr.resource_id == post.resource_id and sr.section_id == post.section_id and
+            sr.numbering_level > 0,
         join: spp in SectionsProjectsPublications,
         on: spp.section_id == post.section_id and spp.project_id == sr.project_id,
         join: pr in PublishedResource,
         on: pr.publication_id == spp.publication_id and pr.resource_id == post.resource_id,
         join: rev in Revision,
         on: rev.id == pr.revision_id,
-        left_join: rev2 in Revision,
-        on: rev.resource_id == rev2.resource_id and rev.id < rev2.id,
         join: user in User,
         on: post.user_id == user.id,
         where:
           post.section_id == ^section_id and post.user_id == ^user_id and
             (post.status in [:approved, :archived] or
-               (post.status == :submitted and post.user_id == ^user_id)) and is_nil(rev2) and
-            rev.deleted == false,
+               (post.status == :submitted and post.user_id == ^user_id)),
         select: %{
           id: post.id,
           content: post.content,
@@ -380,7 +379,7 @@ defmodule Oli.Resources.Collaboration do
           title: rev.title,
           updated_at: post.updated_at
         },
-        order_by: [desc: :inserted_at],
+        order_by: [desc: :updated_at],
         limit: ^limit
       )
     )
@@ -403,21 +402,20 @@ defmodule Oli.Resources.Collaboration do
       from(
         post in Post,
         join: sr in SectionResource,
-        on: sr.resource_id == post.resource_id and sr.section_id == post.section_id,
+        on:
+          sr.resource_id == post.resource_id and sr.section_id == post.section_id and
+            sr.numbering_level > 0,
         join: spp in SectionsProjectsPublications,
         on: spp.section_id == post.section_id and spp.project_id == sr.project_id,
         join: pr in PublishedResource,
         on: pr.publication_id == spp.publication_id and pr.resource_id == post.resource_id,
         join: rev in Revision,
         on: rev.id == pr.revision_id,
-        left_join: rev2 in Revision,
-        on: rev.resource_id == rev2.resource_id and rev.id < rev2.id,
         join: user in User,
         on: post.user_id == user.id,
         where:
           post.section_id == ^section_id and post.user_id != ^user_id and
-            post.status in [:approved, :archived] and is_nil(rev2) and
-            rev.deleted == false,
+            post.status in [:approved, :archived],
         select: %{
           id: post.id,
           content: post.content,
@@ -425,7 +423,7 @@ defmodule Oli.Resources.Collaboration do
           title: rev.title,
           updated_at: post.updated_at
         },
-        order_by: [desc: :inserted_at],
+        order_by: [desc: :updated_at],
         limit: ^limit
       )
     )

--- a/lib/oli/resources/collaboration.ex
+++ b/lib/oli/resources/collaboration.ex
@@ -10,6 +10,7 @@ defmodule Oli.Resources.Collaboration do
   alias Oli.Resources.{ResourceType, Revision}
   alias Oli.Resources.Collaboration.{CollabSpaceConfig, Post}
   alias Oli.Repo
+  alias Oli.Accounts.User
 
   import Ecto.Query, warn: false
   import Oli.Utils
@@ -335,6 +336,98 @@ defmodule Oli.Resources.Collaboration do
         select_merge: %{
           replies_count: fragment("select count(*) from posts where thread_root_id = ?", post.id)
         }
+      )
+    )
+  end
+
+  @doc """
+  Returns the list of posts created by an user in a section.
+
+  ## Examples
+
+      iex> list_last_posts_for_user(1, 1, 5)
+      [%Post{status: :archived}, ...]
+
+      iex> list_last_posts_for_user(2, 2, 10)
+      []
+  """
+
+  def list_lasts_posts_for_user(user_id, section_id, limit) do
+    Repo.all(
+      from(
+        post in Post,
+        join: sr in SectionResource,
+        on: sr.resource_id == post.resource_id and sr.section_id == post.section_id,
+        join: spp in SectionsProjectsPublications,
+        on: spp.section_id == post.section_id and spp.project_id == sr.project_id,
+        join: pr in PublishedResource,
+        on: pr.publication_id == spp.publication_id and pr.resource_id == post.resource_id,
+        join: rev in Revision,
+        on: rev.id == pr.revision_id,
+        left_join: rev2 in Revision,
+        on: rev.resource_id == rev2.resource_id and rev.id < rev2.id,
+        join: user in User,
+        on: post.user_id == user.id,
+        where:
+          post.section_id == ^section_id and post.user_id == ^user_id and
+            (post.status in [:approved, :archived] or
+               (post.status == :submitted and post.user_id == ^user_id)) and is_nil(rev2) and
+            rev.deleted == false,
+        select: %{
+          id: post.id,
+          content: post.content,
+          user_name: user.name,
+          title: rev.title,
+          updated_at: post.updated_at
+        },
+        order_by: [desc: :inserted_at],
+        limit: ^limit
+      )
+    )
+  end
+
+  @doc """
+  Returns the list of posts created in all resources of section.
+
+  ## Examples
+
+      iex> list_last_posts_for_section(1, 1, 5)
+      [%Post{status: :archived}, ...]
+
+      iex> list_last_posts_for_section(2, 2, 10)
+      []
+  """
+
+  def list_lasts_posts_for_section(user_id, section_id, limit) do
+    Repo.all(
+      from(
+        post in Post,
+        join: sr in SectionResource,
+        on: sr.resource_id == post.resource_id and sr.section_id == post.section_id,
+        join: spp in SectionsProjectsPublications,
+        on: spp.section_id == post.section_id and spp.project_id == sr.project_id,
+        join: pr in PublishedResource,
+        on: pr.publication_id == spp.publication_id and pr.resource_id == post.resource_id,
+        join: rev in Revision,
+        on: rev.id == pr.revision_id,
+        left_join: rev2 in Revision,
+        on: rev.resource_id == rev2.resource_id and rev.id < rev2.id,
+        join: user in User,
+        on: post.user_id == user.id,
+        where:
+          post.section_id == ^section_id and
+            (post.status in [:approved, :archived] or
+               (post.status == :submitted and post.user_id == ^user_id)) and is_nil(rev2) and
+            rev.deleted == false,
+        select: %{
+          id: post.id,
+          content: post.content,
+          user_name: user.name,
+          title: rev.title,
+          updated_at: post.updated_at
+        },
+        order_by: [desc: :inserted_at],
+        limit: ^limit
       )
     )
   end

--- a/lib/oli_web/components/delivery/discussion_board.ex
+++ b/lib/oli_web/components/delivery/discussion_board.ex
@@ -26,12 +26,8 @@ defmodule OliWeb.Components.Delivery.DiscussionBoard do
 
   def render(assigns) do
     ~H"""
-      <div class="flex flex-col justify-start mt-4 gap-3 px-10 sm:flex-row sm:justify-between sm:items-center sm:mt-16 sm:px-0">
+      <div class="flex flex-col justify-start mt-4 px-7 sm:px-0">
         <h6 class="text-xl font-normal leading-8 tracking-wide">Discussion Board</h6>
-        <div class="inline-flex justify-between gap-3">
-          <button class="btn text-sm font-normal leading-5 py-2 px-6 text-white hover:text-white inline-flex bg-delivery-primary hover:bg-delivery-primary-600 active:bg-delivery-primary-700">+ Create Study Group</button>
-          <button class="btn text-sm font-normal leading-5 py-2 px-6 text-white hover:text-white inline-flex bg-delivery-primary hover:bg-delivery-primary-600 active:bg-delivery-primary-700">+ New Discussion</button>
-        </div>
       </div>
 
       <DiscussionPost.render last_posts={@last_posts_user} title="Your Latest Discussion Activity"/>

--- a/lib/oli_web/components/delivery/discussion_board.ex
+++ b/lib/oli_web/components/delivery/discussion_board.ex
@@ -26,11 +26,11 @@ defmodule OliWeb.Components.Delivery.DiscussionBoard do
 
   def render(assigns) do
     ~H"""
-      <div class="flex flex-col md:flex-row justify-between items-center mt-4 sm:mt-16">
+      <div class="flex flex-col justify-start mt-4 gap-3 px-10 sm:flex-row sm:justify-between sm:items-center sm:mt-16 sm:px-0">
         <h6 class="text-xl font-normal leading-8 tracking-wide">Discussion Board</h6>
-        <div class="inline-flex">
-          <button class="btn text-sm font-normal leading-5 py-2 px-6 text-white hover:text-white inline-flex ml-2 bg-delivery-primary hover:bg-delivery-primary-600 active:bg-delivery-primary-700">+ Create Study Group</button>
-          <button class="btn text-sm font-normal leading-5 py-2 px-6 text-white hover:text-white inline-flex ml-2 bg-delivery-primary hover:bg-delivery-primary-600 active:bg-delivery-primary-700">+ New Discussion</button>
+        <div class="inline-flex justify-between gap-3">
+          <button class="btn text-sm font-normal leading-5 py-2 px-6 text-white hover:text-white inline-flex bg-delivery-primary hover:bg-delivery-primary-600 active:bg-delivery-primary-700">+ Create Study Group</button>
+          <button class="btn text-sm font-normal leading-5 py-2 px-6 text-white hover:text-white inline-flex bg-delivery-primary hover:bg-delivery-primary-600 active:bg-delivery-primary-700">+ New Discussion</button>
         </div>
       </div>
 

--- a/lib/oli_web/components/delivery/discussion_board.ex
+++ b/lib/oli_web/components/delivery/discussion_board.ex
@@ -1,0 +1,41 @@
+defmodule OliWeb.Components.Delivery.DiscussionBoard do
+  use Phoenix.LiveView
+
+  alias OliWeb.Components.Delivery.DiscussionPost
+  alias Oli.Resources.Collaboration
+
+  @posts_limit 5
+
+  def mount(
+        _params,
+        %{
+          "section_id" => section_id,
+          "current_user_id" => current_user_id
+        },
+        socket
+      ) do
+    last_posts_user = Collaboration.list_lasts_posts_for_user(current_user_id, section_id, @posts_limit)
+    last_posts_section = Collaboration.list_lasts_posts_for_section(current_user_id, section_id, @posts_limit)
+
+    {:ok,
+     assign(socket,
+       last_posts_user: last_posts_user,
+       last_posts_section: last_posts_section
+     )}
+  end
+
+  def render(assigns) do
+    ~H"""
+      <div class="flex flex-col md:flex-row justify-between items-center mt-4 sm:mt-16">
+        <h6 class="text-xl font-normal leading-8 tracking-wide">Discussion Board</h6>
+        <div class="inline-flex">
+          <button class="btn text-sm font-normal leading-5 py-2 px-6 text-white hover:text-white inline-flex ml-2 bg-delivery-primary hover:bg-delivery-primary-600 active:bg-delivery-primary-700">+ Create Study Group</button>
+          <button class="btn text-sm font-normal leading-5 py-2 px-6 text-white hover:text-white inline-flex ml-2 bg-delivery-primary hover:bg-delivery-primary-600 active:bg-delivery-primary-700">+ New Discussion</button>
+        </div>
+      </div>
+
+      <DiscussionPost.render last_posts={@last_posts_user} title="Your Latest Discussion Activity"/>
+      <DiscussionPost.render last_posts={@last_posts_section} title="All Discussion Activity"/>
+    """
+  end
+end

--- a/lib/oli_web/components/delivery/discussion_post.ex
+++ b/lib/oli_web/components/delivery/discussion_post.ex
@@ -1,0 +1,31 @@
+defmodule OliWeb.Components.Delivery.DiscussionPost do
+  use Phoenix.Component
+
+  import OliWeb.Common.FormatDateTime
+
+  def render(assigns) do
+    ~H"""
+      <div class="bg-white dark:bg-gray-800 shadow mt-7 py-6 px-7">
+        <span class="font-normal text-base leading-5 tracking-wide"><%= @title %></span>
+      </div>
+      <div class="flex flex-col gap-y-0.5 mt-0.5">
+        <%= if length(@last_posts) > 0 do %>
+          <%= for post <- @last_posts do %>
+            <div class="flex flex-col bg-white dark:bg-gray-800 shadow py-4 px-7 gap-y-3">
+              <div class="flex flex-row justify-between items-center">
+                <h6 class="font-normal text-sm leading-5 text-gray-500"><%= post.title %></h6>
+                <h6 class="font-medium text-sm leading-5"><%= date(post.updated_at, precision: :relative) %></h6>
+              </div>
+              <h6 class="font-bold text-sm leading-5 tracking-wide"><%= post.user_name %></h6>
+              <p class="mb-0 font-normal text-sm leading-5 tracking-wide"><%= post.content.message %></p>
+            </div>
+          <% end %>
+        <% else %>
+          <div class="bg-white dark:bg-gray-800 px-7 py-4">
+            <h6>There are no posts to show</h6>
+          </div>
+        <% end %>
+      </div>
+    """
+  end
+end

--- a/lib/oli_web/components/delivery/nav_sidebar.ex
+++ b/lib/oli_web/components/delivery/nav_sidebar.ex
@@ -63,7 +63,7 @@ defmodule OliWeb.Components.Delivery.NavSidebar do
 
           <div class="flex-1 items-center lg:items-start">
             <%= if assigns[:section] do %>
-              <%= for {name, href, active} <- [{"Home", home_url(assigns), is_active(@conn.path_info, :overview)}, {"Course Content", "#", is_active(@conn.path_info, "")}, {"Discussion", "#", is_active(@conn.path_info, "")}, {"Assignments", "#", is_active(@conn.path_info, "")}, {"Exploration", exploration_url(assigns), is_active(@conn.path_info, :exploration)}] do %>
+              <%= for {name, href, active} <- [{"Home", home_url(assigns), is_active(@conn.path_info, :overview)}, {"Course Content", "#", is_active(@conn.path_info, "")}, {"Discussion", discussion_url(assigns), is_active(@conn.path_info, :discussion)}, {"Assignments", "#", is_active(@conn.path_info, "")}, {"Exploration", exploration_url(assigns), is_active(@conn.path_info, :exploration)}] do %>
                 <.nav_link name={name} href={href} active={active} />
               <% end %>
             <% end %>
@@ -131,8 +131,10 @@ defmodule OliWeb.Components.Delivery.NavSidebar do
 
   defp is_active(["sections", _, "overview"], :overview), do: true
   defp is_active(["sections", _, "exploration"], :exploration), do: true
+  defp is_active(["sections", _, "discussion"], :discussion), do: true
   defp is_active(["sections", _, "preview", "overview"], :overview), do: true
   defp is_active(["sections", _, "preview", "exploration"], :exploration), do: true
+  defp is_active(["sections", _, "preview", "discussion"], :discussion), do: true
   defp is_active(_, _), do: false
 
   defp home_url(assigns) do
@@ -152,6 +154,14 @@ defmodule OliWeb.Components.Delivery.NavSidebar do
       Routes.page_delivery_path(OliWeb.Endpoint, :exploration_preview, assigns[:section_slug])
     else
       Routes.page_delivery_path(OliWeb.Endpoint, :exploration, assigns[:section_slug])
+    end
+  end
+
+  defp discussion_url(assigns) do
+    if assigns[:preview_mode] do
+      Routes.page_delivery_path(OliWeb.Endpoint, :discussion_preview, assigns[:section_slug])
+    else
+      Routes.page_delivery_path(OliWeb.Endpoint, :discussion, assigns[:section_slug])
     end
   end
 end

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -103,6 +103,41 @@ defmodule OliWeb.PageDeliveryController do
     end
   end
 
+  def discussion(conn, %{"section_slug" => section_slug}) do
+    user = conn.assigns.current_user
+    section = conn.assigns.section
+
+    if Sections.is_enrolled?(user.id, section_slug) do
+      case section
+           |> Oli.Repo.preload([:base_project, :root_section_resource]) do
+        nil ->
+          render(conn, "error.html")
+
+        section ->
+          render(conn, "discussion.html",
+            title: section.title,
+            description: section.description,
+            section_id: section.id,
+            section_slug: section_slug,
+            hierarchy: Sections.build_hierarchy(section),
+            display_curriculum_item_numbering: section.display_curriculum_item_numbering,
+            preview_mode: false,
+            page_link_url: &Routes.page_delivery_path(conn, :page, section_slug, &1),
+            container_link_url: &Routes.page_delivery_path(conn, :container, section_slug, &1)
+          )
+      end
+    else
+      case section do
+        %Section{open_and_free: true, requires_enrollment: false} ->
+          conn
+          |> redirect(to: Routes.delivery_path(conn, :show_enroll, section_slug))
+
+        _ ->
+          render(conn, "not_authorized.html")
+      end
+    end
+  end
+
   def container(conn, %{"section_slug" => section_slug, "revision_slug" => revision_slug}) do
     user = conn.assigns.current_user
     author = conn.assigns.current_author
@@ -499,6 +534,24 @@ defmodule OliWeb.PageDeliveryController do
     render(conn, "exploration.html",
       title: section.title,
       description: section.description,
+      section_slug: section_slug,
+      hierarchy: Sections.build_hierarchy(section),
+      display_curriculum_item_numbering: section.display_curriculum_item_numbering,
+      preview_mode: true,
+      page_link_url: &Routes.page_delivery_path(conn, :page, section_slug, &1),
+      container_link_url: &Routes.page_delivery_path(conn, :container, section_slug, &1)
+    )
+  end
+
+  def discussion_preview(conn, %{"section_slug" => section_slug}) do
+    section =
+      conn.assigns.section
+      |> Oli.Repo.preload([:base_project, :root_section_resource])
+
+    render(conn, "discussion.html",
+      title: section.title,
+      description: section.description,
+      section_id: section.id,
       section_slug: section_slug,
       hierarchy: Sections.build_hierarchy(section),
       display_curriculum_item_numbering: section.display_curriculum_item_numbering,

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -769,6 +769,7 @@ defmodule OliWeb.Router do
     get("/overview", PageDeliveryController, :index)
 
     get("/exploration", PageDeliveryController, :exploration)
+    get("/discussion", PageDeliveryController, :discussion)
     live("/learning_objectives", Delivery.InstructorDashboard.LearningObjectivesLive)
     live("/students", Delivery.InstructorDashboard.StudentsLive)
     live("/content", Delivery.InstructorDashboard.ContentLive)
@@ -808,6 +809,7 @@ defmodule OliWeb.Router do
     live("/discussions", Delivery.InstructorDashboard.DiscussionLive, :preview)
 
     get("/exploration", PageDeliveryController, :exploration_preview)
+    get("/discussion", PageDeliveryController, :discussion_preview)
     get("/container/:revision_slug", PageDeliveryController, :container_preview)
     get("/page/:revision_slug", PageDeliveryController, :page_preview)
     get("/page/:revision_slug/page/:page", PageDeliveryController, :page_preview)

--- a/lib/oli_web/templates/page_delivery/discussion.html.heex
+++ b/lib/oli_web/templates/page_delivery/discussion.html.heex
@@ -5,7 +5,7 @@
 
     <Components.Delivery.ExplorationShade.exploration_shade />
 
-    <div class="container mx-auto px-10 mt-3 mb-5 flex flex-col">
+    <div class="container px-0 sm:px-10 mx-auto mt-3 mb-5 flex flex-col">
       <%= live_render @conn, Components.Delivery.DiscussionBoard, session: %{ "section_id" => @section_id } %>
     </div>
 

--- a/lib/oli_web/templates/page_delivery/discussion.html.heex
+++ b/lib/oli_web/templates/page_delivery/discussion.html.heex
@@ -1,0 +1,14 @@
+
+<Components.Delivery.NavSidebar.main_with_nav {assigns}>
+  <div class="relative flex-1 flex flex-col pb-[60px]">
+    <%= render OliWeb.LayoutView, "_pay_early.html", assigns %>
+
+    <Components.Delivery.ExplorationShade.exploration_shade />
+
+    <div class="container mx-auto px-10 mt-3 mb-5 flex flex-col">
+      <%= live_render @conn, Components.Delivery.DiscussionBoard, session: %{ "section_id" => @section_id } %>
+    </div>
+
+    <%= render OliWeb.LayoutView, "_delivery_footer.html", assigns %>
+  </div>
+</Components.Delivery.NavSidebar.main_with_nav>

--- a/test/oli_web/controllers/page_delivery_controller_test.exs
+++ b/test/oli_web/controllers/page_delivery_controller_test.exs
@@ -7,6 +7,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
   alias Oli.Delivery.Sections
   alias Oli.Seeder
   alias Oli.Delivery.Attempts.Core.{ResourceAttempt, PartAttempt, ResourceAccess}
+  alias Oli.Resources.Collaboration
   alias Lti_1p3.Tool.ContextRoles
   alias OliWeb.Common.{FormatDateTime, Utils}
   alias OliWeb.Router.Helpers, as: Routes
@@ -1505,6 +1506,96 @@ defmodule OliWeb.PageDeliveryControllerTest do
         |> get(Routes.page_delivery_path(conn, :exploration, section.slug))
 
       assert html_response(conn, 200) =~ "<h6>There are no exploration pages available</h6>"
+    end
+  end
+
+  describe "discussion" do
+    setup [:create_section_with_posts]
+
+    test "student can access if is enrolled in the section", %{conn: conn, section: section} do
+      user = insert(:user)
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+
+      conn =
+        recycle(conn)
+        |> Pow.Plug.assign_current_user(user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
+        |> get(Routes.page_delivery_path(conn, :discussion, section.slug))
+
+      assert html_response(conn, 200)
+    end
+
+    test "instructor can access if is enrolled in the section", %{conn: conn, section: section} do
+      user = insert(:user)
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_instructor)])
+
+      conn =
+        recycle(conn)
+        |> Pow.Plug.assign_current_user(user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
+        |> get(Routes.page_delivery_path(conn, :discussion, section.slug))
+
+      assert html_response(conn, 200)
+    end
+
+    test "page renders a list of posts of current user", %{
+      conn: conn,
+      section: section,
+      user: user
+    } do
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+
+      conn =
+        recycle(conn)
+        |> Pow.Plug.assign_current_user(user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
+        |> get(Routes.page_delivery_path(conn, :discussion, section.slug))
+
+      assert html_response(conn, 200) =~ "Your Latest Discussion Activity"
+      posts = Collaboration.list_lasts_posts_for_user(user.id, section.id, 5)
+
+      for post <- posts do
+        assert html_response(conn, 200) =~ post.title
+        assert html_response(conn, 200) =~ post.content.message
+        assert html_response(conn, 200) =~ post.user_name
+      end
+    end
+
+    test "page renders a list of posts of all users", %{
+      conn: conn,
+      section: section,
+      user: user
+    } do
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+
+      conn =
+        recycle(conn)
+        |> Pow.Plug.assign_current_user(user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
+        |> get(Routes.page_delivery_path(conn, :discussion, section.slug))
+
+      assert html_response(conn, 200) =~ "All Discussion Activity"
+      posts = Collaboration.list_lasts_posts_for_section(user.id, section.id, 5)
+
+      for post <- posts do
+        assert html_response(conn, 200) =~ post.title
+        assert html_response(conn, 200) =~ post.content.message
+        assert html_response(conn, 200) =~ post.user_name
+      end
+    end
+
+    test "page renders a message when there are no posts to show", %{
+      conn: conn
+    } do
+      {:ok,
+       section: section, unit_one_revision: _unit_one_revision, page_revision: _page_revision} =
+        section_with_assessment(%{})
+
+      user = insert(:user)
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+
+      conn =
+        recycle(conn)
+        |> Pow.Plug.assign_current_user(user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
+        |> get(Routes.page_delivery_path(conn, :discussion, section.slug))
+
+      assert html_response(conn, 200) =~ "<h6>There are no posts to show</h6>"
     end
   end
 

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -776,6 +776,111 @@ defmodule Oli.TestHelpers do
      other_revision: other_revision}
   end
 
+  def create_section_with_posts(_conn) do
+    user = insert(:user)
+    author = insert(:author)
+    project = insert(:project, authors: [author])
+
+    page_resource = insert(:resource)
+
+    page_revision =
+      insert(:revision,
+        resource: page_resource,
+        resource_type_id: Oli.Resources.ResourceType.get_id_by_type("page"),
+        content: %{"model" => []},
+        title: "Other revision A"
+      )
+
+    insert(:project_resource, %{project_id: project.id, resource_id: page_resource.id})
+
+    collab_space_config = build(:collab_space_config, status: :enabled)
+    page_resource_cs = insert(:resource)
+
+    page_revision_cs =
+      insert(:revision,
+        resource: page_resource_cs,
+        resource_type_id: Oli.Resources.ResourceType.get_id_by_type("page"),
+        content: %{"model" => []},
+        slug: "page_revision_cs",
+        collab_space_config: collab_space_config,
+        title: "Other revision B"
+      )
+
+    insert(:project_resource, %{project_id: project.id, resource_id: page_resource_cs.id})
+
+    container_resource = insert(:resource)
+
+    container_revision =
+      insert(:revision, %{
+        resource: container_resource,
+        resource_type_id: Oli.Resources.ResourceType.get_id_by_type("container"),
+        children: [page_resource.id, page_resource_cs.id],
+        content: %{},
+        deleted: false,
+        slug: "root_container",
+        title: "Root Container"
+      })
+
+    insert(:project_resource, %{project_id: project.id, resource_id: container_resource.id})
+
+    publication =
+      insert(:publication, %{
+        project: project,
+        root_resource_id: container_resource.id,
+        published: nil
+      })
+
+    insert(:published_resource, %{
+      publication: publication,
+      resource: container_resource,
+      revision: container_revision,
+      author: author
+    })
+
+    insert(:published_resource, %{
+      publication: publication,
+      resource: page_resource,
+      revision: page_revision,
+      author: author
+    })
+
+    insert(:published_resource, %{
+      publication: publication,
+      resource: page_resource_cs,
+      revision: page_revision_cs,
+      author: author
+    })
+
+    section = insert(:section, base_project: project, type: :enrollable)
+    {:ok, _sr} = Sections.create_section_resources(section, publication)
+
+    insert(:post, section: section, resource: page_resource_cs, user: user)
+
+    insert(:post,
+      content: %{message: "Other post"},
+      section: section,
+      resource: page_resource_cs,
+      user: user
+    )
+
+    other_user_1 = insert(:user)
+    other_user_2 = insert(:user)
+
+    insert(:post, section: section, resource: page_resource_cs, user: other_user_1)
+    insert(:post, section: section, resource: page_resource_cs, user: other_user_2)
+
+    [
+      project: project,
+      publication: publication,
+      page_revision: page_revision,
+      page_revision_cs: page_revision_cs,
+      section: section,
+      author: author,
+      user: user,
+      page_resource_cs: page_resource_cs
+    ]
+  end
+
   def enroll_user_to_section(user, section, role) do
     Sections.enroll(user.id, section.id, [
       ContextRoles.get_role(role)


### PR DESCRIPTION
[MER-1696](https://eliterate.atlassian.net/browse/MER-1696)

This PR aims to shows a "Discussion" link in the left navigation bar, which when clicked takes the student to a view showing two groups of publications.  

- Summary of all their publications in all collaboration spaces.

- Summary of other students most recent publications in all collaboration spaces. 

We only need to think about some kind of pagination in case we want to show more than x amount of posts. Do you think it could be possible to do it in another ticket maybe @darrensiegel?

![Captura de pantalla 2023-02-17 a la(s) 10 57 10](https://user-images.githubusercontent.com/16328384/219676185-d7f31c08-39a9-46ab-8032-83060dfb76de.png)

![Captura de pantalla 2023-02-17 a la(s) 10 58 07](https://user-images.githubusercontent.com/16328384/219676197-c8deb8ee-8e73-469b-bfc8-4b3f68003dd6.png)


[MER-1696]: https://eliterate.atlassian.net/browse/MER-1696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ