### PR TITLE
[BUGFIX] MER-1765 Equals ignoring case should match whole string

### DIFF
--- a/assets/src/components/activities/short_answer/sections/TextInput.tsx
+++ b/assets/src/components/activities/short_answer/sections/TextInput.tsx
@@ -43,7 +43,7 @@ export const TextInput: React.FC<InputProps> = ({ input, onEditInput }) => {
 
 const textOptions: { value: string; displayValue: string }[] = [
   { value: 'equals', displayValue: 'Equals exactly' },
-  { value: 'equalsnocase', displayValue: 'Equals ignoring case' },
+  { value: 'iequals', displayValue: 'Equals ignoring case' },
   { value: 'contains', displayValue: 'Contains' },
   { value: 'notcontains', displayValue: "Doesn't Contain" },
   { value: 'regex', displayValue: 'Regex' },

--- a/assets/src/data/activities/model/rules.ts
+++ b/assets/src/data/activities/model/rules.ts
@@ -263,7 +263,6 @@ type ParsedTextRule = {
 // To implement case-insensitive literal string matches, we translate rule
 // 'input like {(?i)escapedText}' => { operator: iequals, value: unescapedText}
 export const translateRule = (r: ParsedTextRule): ParsedTextRule => {
-  console.log('translating ' + r.operator + ' ' + r.value);
   if (r.operator === 'regex' && r.value.startsWith('(?i)')) {
     // Author might have explicitly included (?i) prefix in a regex rule, in which case
     // this ought not to be translated. Detect this by checking for unescaped regex

--- a/assets/src/data/activities/model/rules.ts
+++ b/assets/src/data/activities/model/rules.ts
@@ -266,7 +266,7 @@ export const translateRule = (r: ParsedTextRule): ParsedTextRule => {
   if (r.operator === 'regex' && r.value.startsWith('(?i)')) {
     // Author might have explicitly included (?i) prefix in a regex rule, in which case
     // this ought not to be translated. Detect this by checking for unescaped regex
-    // metachars, and keeping as regex. If author wrote (?i)^pat$ regexp for literal string,
+    // metachars, and keeping as regex. If author wrote (?i)pat regexp for literal string,
     // it gets translated to iequals match, but that is equivalent.
     if (!hasUnescapedRegExpChars(r.value.slice(4))) {
       return {

--- a/lib/oli/delivery/evaluation/parser.ex
+++ b/lib/oli/delivery/evaluation/parser.ex
@@ -33,6 +33,7 @@ defmodule Oli.Delivery.Evaluation.Parser do
   op_eq = ascii_char([?=]) |> optional(string(" ")) |> replace(:eq) |> label("=")
   op_like = string("like") |> optional(string(" ")) |> replace(:like) |> label("like")
   op_equals = string("equals") |> optional(string(" ")) |> replace(:equals) |> label("equals")
+  op_iequals = string("iequals") |> optional(string(" ")) |> replace(:iequals) |> label("iequals")
 
   op_contains =
     string("contains") |> optional(string(" ")) |> replace(:contains) |> label("contains")
@@ -78,7 +79,10 @@ defmodule Oli.Delivery.Evaluation.Parser do
   defcombinatorp(:component, choice([attempt_number_, input_, input_length_]))
 
   # <operator> :== "<" | ">" | "=" | "like" | "contains"
-  defcombinatorp(:operator, choice([op_lt, op_gt, op_eq, op_like, op_contains, op_equals]))
+  defcombinatorp(
+    :operator,
+    choice([op_lt, op_gt, op_eq, op_like, op_contains, op_equals, op_iequals])
+  )
 
   # <criterion> :== <component> <operator> <check>
   defcombinatorp(

--- a/lib/oli/delivery/evaluation/rule.ex
+++ b/lib/oli/delivery/evaluation/rule.ex
@@ -62,6 +62,13 @@ defmodule Oli.Delivery.Evaluation.Rule do
     )
   end
 
+  defp eval({:iequals, lhs, rhs}, context) do
+    String.equivalent?(
+      String.downcase(eval(lhs, context)),
+      String.downcase(rhs)
+    )
+  end
+
   defp eval(:attempt_number, context), do: context.activity_attempt_number |> Integer.to_string()
   defp eval(:input, context), do: context.input
   defp eval(:input_length, context), do: String.length(context.input) |> Integer.to_string()

--- a/test/oli/delivery/evaluation/rule_eval_test.exs
+++ b/test/oli/delivery/evaluation/rule_eval_test.exs
@@ -80,8 +80,6 @@ defmodule Oli.Delivery.Evaluation.RuleEvalTest do
 
     assert eval("attemptNumber = {1} && input = {(-4.66e-19,-4.5e-19)}", "-4.6e-19") == true
 
-
-
     # gracefully handles space in between range
     assert eval("attemptNumber = {1} && input = {[3, 5]}", "4") == true
 
@@ -152,6 +150,39 @@ defmodule Oli.Delivery.Evaluation.RuleEvalTest do
 
     assert eval("!(input contains {cat})", "the bat in the hat")
     refute eval("!(input contains {cat})", "the cat in the hat")
+  end
+
+  test "evaluating string equals" do
+    assert eval("input equals {cat}", "cat")
+    refute eval("input equals {Cat}", "cat")
+    refute eval("input equals {cat}", "Cat")
+
+    assert eval("input equals {the cat in the hat}", "the cat in the hat")
+    assert eval("input equals {the CaT in the HAT}", "the CaT in the HAT")
+    refute eval("input equals {the cat in the HAT}", "the CaT in the HAT")
+    refute eval("input equals { the cat in the hat}", "the cat in the hat")
+    refute eval("input equals {the cat in the hat}", "the cat in the hat ")
+
+    assert eval("!(input equals {cat})", "the cat in the hat")
+    refute eval("!(input equals {the cat in the hat})", "the cat in the hat")
+  end
+
+  test "evaluating string iequals (case-insensitive)" do
+    assert eval("input iequals {cat}", "cat")
+    assert eval("input iequals {Cat}", "cat")
+    assert eval("input iequals {cat}", "Cat")
+
+    assert eval("input iequals {the cat in the hat}", "the CaT in the HAT")
+    refute eval("input iequals {cat}", "the CaT in the HAT")
+    refute eval("input iequals {CaT}", "the CaT in the HAT")
+
+    refute eval("input equals {the cat in the HAT}", "the CaT in the HAT")
+    refute eval("input equals { the cat in the hat}", "the cat in the hat")
+    refute eval("input equals {the cat in the hat}", "the cat in the hat ")
+
+    assert eval("!(input equals {cat})", "the cat in the hat")
+    refute eval("!(input equals {the cat in the hat})", "the cat in the hat")
+    assert eval("!(input equals {the CAT in the hat})", "the cat in the HAT")
   end
 
   test "evaluating strings with a numeric operator results in error" do

--- a/test/oli/delivery/evaluation/rule_eval_test.exs
+++ b/test/oli/delivery/evaluation/rule_eval_test.exs
@@ -176,13 +176,13 @@ defmodule Oli.Delivery.Evaluation.RuleEvalTest do
     refute eval("input iequals {cat}", "the CaT in the HAT")
     refute eval("input iequals {CaT}", "the CaT in the HAT")
 
-    refute eval("input equals {the cat in the HAT}", "the CaT in the HAT")
-    refute eval("input equals { the cat in the hat}", "the cat in the hat")
-    refute eval("input equals {the cat in the hat}", "the cat in the hat ")
+    assert eval("input iequals {the cat in the HAT}", "the CaT in the HAT")
+    refute eval("input iequals { the cat in the hat}", "the cat in the hat")
+    refute eval("input iequals {the cat in the hat}", "the cat in the hat ")
 
-    assert eval("!(input equals {cat})", "the cat in the hat")
-    refute eval("!(input equals {the cat in the hat})", "the cat in the hat")
-    assert eval("!(input equals {the CAT in the hat})", "the cat in the HAT")
+    assert eval("!(input iequals {cat})", "the cat in the hat")
+    refute eval("!(input iequals {the cat in the hat})", "the cat in the hat")
+    refute eval("!(input iequals {the CAT in the hat})", "the cat in the HAT")
   end
 
   test "evaluating strings with a numeric operator results in error" do


### PR DESCRIPTION
For MER-1765: This corrects behavior of the Equals ignoring case match operator to match against the whole input. Did this by recoding to use the newly added iequals rule, making the rule-handling code more uniform with other rules. 