### PR TITLE
[FEATURE] Analytics infrastructure for progress [MER-1707]

### DIFF
--- a/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
@@ -323,7 +323,7 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
         _ -> Repo.rollback("unknown error")
       end
 
-      Oli.Delivery.Metrics.calculate_page_progress(activity_attempt_guid)
+      Oli.Delivery.Metrics.update_page_progress(activity_attempt_guid)
       result
     end)
     |> Snapshots.maybe_create_snapshot(part_inputs, section_slug)
@@ -514,7 +514,7 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
             false,
             datashop_session_id
           )
-          Oli.Delivery.Metrics.calculate_page_progress(activity_attempt_guid)
+          Oli.Delivery.Metrics.update_page_progress(activity_attempt_guid)
 
           result
         end)

--- a/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
@@ -316,12 +316,15 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
 
       roll_up_fn = determine_activity_rollup_fn(activity_attempt_guid, part_inputs, part_attempts)
 
-      case evaluate_submissions(activity_attempt_guid, part_inputs, part_attempts)
+      result = case evaluate_submissions(activity_attempt_guid, part_inputs, part_attempts)
            |> persist_evaluations(part_inputs, roll_up_fn, datashop_session_id) do
         {:ok, results} -> results
         {:error, error} -> Repo.rollback(error)
         _ -> Repo.rollback("unknown error")
       end
+
+      Oli.Delivery.Metrics.calculate_page_progress(activity_attempt_guid)
+      result
     end)
     |> Snapshots.maybe_create_snapshot(part_inputs, section_slug)
   end
@@ -504,15 +507,20 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
               normalize_mode
             )
 
-          persist_client_evaluations(
+          result = persist_client_evaluations(
             part_inputs,
             client_evaluations,
             roll_up_fn,
             false,
             datashop_session_id
           )
+          Oli.Delivery.Metrics.calculate_page_progress(activity_attempt_guid)
+
+          result
         end)
         |> Snapshots.maybe_create_snapshot(part_inputs, section_slug)
+
+
 
       _ ->
         {:error, "Activity type does not allow client evaluation"}

--- a/lib/oli/delivery/attempts/core.ex
+++ b/lib/oli/delivery/attempts/core.ex
@@ -672,6 +672,19 @@ defmodule Oli.Delivery.Attempts.Core do
     )
   end
 
+  def is_first_activity_attempt?(activity_attempt_guid) do
+    attempt_number = Repo.one(
+      from(a in ActivityAttempt,
+        where: a.attempt_guid == ^activity_attempt_guid,
+        select: a.attempt_number
+      )
+    )
+    case attempt_number do
+      1 -> true
+      _ -> false
+    end
+  end
+
   @doc """
   Gets a collection of activity attempt records that pertain to a collection of activity
   attempt guids. There is no guarantee that the ordering of the results of the activity attempts

--- a/lib/oli/delivery/attempts/core/resource_access.ex
+++ b/lib/oli/delivery/attempts/core/resource_access.ex
@@ -6,6 +6,7 @@ defmodule Oli.Delivery.Attempts.Core.ResourceAccess do
     field(:access_count, :integer)
     field(:score, :float)
     field(:out_of, :float)
+    field(:progress, :float)
 
     # Completed LMS grade updates
     field(:last_successful_grade_update_id, :integer)
@@ -28,6 +29,7 @@ defmodule Oli.Delivery.Attempts.Core.ResourceAccess do
       :access_count,
       :score,
       :out_of,
+      :progress,
       :last_successful_grade_update_id,
       :last_grade_update_id,
       :user_id,

--- a/lib/oli/delivery/attempts/page_lifecycle/graded.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/graded.ex
@@ -123,6 +123,9 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Graded do
                  resource_attempt.resource_access_id
                ) do
             {:ok, resource_access} ->
+
+              {:ok, _} = Oli.Delivery.Metrics.mark_completed(resource_access)
+
               {:ok,
                %FinalizationSummary{
                  lifecycle_state: :evaluated,

--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -1,0 +1,5 @@
+defmodule Oli.Delivery.Metrics do
+
+
+
+end

--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -5,11 +5,21 @@ defmodule Oli.Delivery.Metrics do
   alias Oli.Repo
 
   alias Oli.Delivery.Sections.ContainedPage
-  alias Oli.Delivery.Sections.SectionResource
-  alias Oli.Delivery.Sections.Section
-  alias Oli.Delivery.Attempts.Core.{ResourceAccess, ResourceAttempt, ActivityAttempt}
+  alias Oli.Delivery.Attempts.Core.{ResourceAccess}
 
-  def progress_for(section_id, container_id, user_id) do
+  @doc """
+  Calculate the progress for a specific student, in all pages of a
+  specific container.
+
+  Ommitting the container_id (or specifying nil) calculates progress
+  across the entire course section.
+
+  This query leverages the `contained_pages` relation, which is always an
+  up to date view of the structure of a course section. This allows this
+  query to take into account structural chagnes as the result of course
+  remix. The `contained_pages` relation is rebuilt after every remix.
+  """
+  def progress_for(section_id, user_id, container_id \\ nil) do
 
     filter_by_container =
       case container_id do
@@ -33,14 +43,9 @@ defmodule Oli.Delivery.Metrics do
           )
       })
 
-   Repo.one(query).progress
+    Repo.one(query).progress
   end
 
-  def set_progress(section_id, resource_id, user_id, progress) do
-    from(ra in ResourceAccess,
-      where: ra.section_id == ^section_id and ra.resource_,
-      update: [set: [progress: ^progress]])
-    |> Repo.update_all([])
-  end
+
 
 end

--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -1,5 +1,72 @@
 defmodule Oli.Delivery.Metrics do
 
+  import Ecto.Query, warn: false
+
+  alias Oli.Repo
+
+  alias Oli.Delivery.Sections.ContainedPage
+  alias Oli.Delivery.Sections.SectionResource
+  alias Oli.Delivery.Sections.Section
+  alias Oli.Delivery.Attempts.Core.{ResourceAccess, ResourceAttempt, ActivityAttempt}
+
+  def progress_for(section_id, container_id, user_id) do
+
+    # For all contained pages for this container
+    # join through the SR record to get to the activity_count
+    # join through the resource access and count the
+
+    Repo.all(
+      from(a in ResourceAccess,
+        left_join: ra in ResourceAttempt,
+        on: a.id == ra.resource_access_id,
+        join: s in Section,
+        on: a.section_id == s.id,
+        where: a.user_id == ^user_id and s.slug == ^section_slug,
+        group_by: a.id,
+        select: a,
+        select_merge: %{
+          resource_attempts_count: count(ra.id)
+        }
+      )
+    )
+
+    # divide all by total contained page count
+
+    query =
+      ContainedPage
+      |> join(:left, [cp], sr in SectionResource, on: cp.page_id == sr.id)
+      |> join(:left, [cp, sr], ra in ResourceAccess,
+        on: ra.resource_id == sr.resource_id and ra.user_id == ^user_id)
+      |> join(:left, [cp, sr, ra], attempt in ResourceAttempt,
+        on: ra.id == attempt.resource_id and ra.user_id == ^user_id)
+      |> where(^filter_by_text)
+      |> where(^filter_by_role)
+      |> where([e, _], e.section_id == ^section_id)
+      |> limit(^limit)
+      |> offset(^offset)
+      |> group_by([e, u, p], [e.id, u.id, p.id])
+      |> select([_, u], u)
+      |> select_merge([e, _, p], %{
+        total_count: fragment("count(*) OVER()"),
+        enrollment_date: e.inserted_at,
+        payment_date: p.application_date,
+        payment_id: p.id
+      })
+
+    query =
+      case field do
+        :enrollment_date -> order_by(query, [e, _, _], {^direction, e.inserted_at})
+        :payment_date -> order_by(query, [_, _, p], {^direction, p.application_date})
+        :payment_id -> order_by(query, [_, _, p], {^direction, p.id})
+        _ -> order_by(query, [_, u, _], {^direction, field(u, ^field)})
+      end
+
+    Repo.all(query)
+
+
+  end
+
+
 
 
 end

--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -5,7 +5,8 @@ defmodule Oli.Delivery.Metrics do
   alias Oli.Repo
 
   alias Oli.Delivery.Sections.ContainedPage
-  alias Oli.Delivery.Attempts.Core.{ResourceAccess}
+  alias Oli.Delivery.Attempts.Core.{ResourceAccess, ActivityAttempt}
+  alias Oli.Delivery.Attempts.Core
 
   @doc """
   Calculate the progress for a specific student, in all pages of a
@@ -46,6 +47,69 @@ defmodule Oli.Delivery.Metrics do
     Repo.one(query).progress
   end
 
+  def mark_completed(%ResourceAccess{} = ra) do
+    Core.update_resource_access(ra, %{progress: 1.0})
+  end
 
+  @doc """
+  For an activity attempt specified by an attempt guid, calculate and set in the corresponding resource access
+  record, the percentage complete for the related page. This calculation only needs to be performed after the
+  evaluation of the first attempt for given activity.  This method should update exactly one record, the resource
+  access for the page that this activity attempt ultimately pertains to (through its parent resource attempt).
+
+  Can return one of:
+  {:ok, :updated} -> Progress calculated and set
+  {:ok, :noop} -> Noting needed to be done, since the attempt number was greater than 1
+  {:error, :unexpected_update_count} -> 0 or more than 1 record would have been updated, rolled back
+  {:error, e} -> An other error occurred, rolled back
+  """
+  def calculate_page_progress(activity_attempt_guid) when is_binary(activity_attempt_guid) do
+    if Core.is_first_activity_attempt?(activity_attempt_guid) do
+      do_calculate(activity_attempt_guid)
+    else
+      {:ok, :noop}
+    end
+  end
+
+  def calculate_page_progress(%ActivityAttempt{attempt_number: 1, attempt_guid: attempt_guid}) do
+    do_calculate(attempt_guid)
+  end
+
+  def calculate_page_progress(_) do
+    {:ok, :noop}
+  end
+
+  defp do_calculate(activity_attempt_guid) do
+
+    Oli.Repo.transaction(fn ->
+      sql = """
+        UPDATE
+          resource_accesses
+        SET
+          progress = (SELECT
+              COUNT(aa2.id) filter (WHERE aa2.lifecycle_state = 'evaluated' OR aa2.lifecycle_state = 'submitted')::float / COUNT(aa2.id)::float
+            FROM activity_attempts as aa
+            JOIN resource_attempts as ra ON ra.id = aa.resource_attempt_id
+            JOIN activity_attempts as aa2 ON ra.id = aa2.resource_attempt_id
+            WHERE aa.attempt_guid = $1 AND aa2.scoreable = true AND aa2.attempt_number = 1),
+          updated_at = NOW()
+        WHERE
+          id =
+            (SELECT
+              resource_attempts.resource_access_id
+            FROM resource_attempts
+            JOIN activity_attempts ON resource_attempts.id = activity_attempts.resource_attempt_id
+            WHERE activity_attempts.attempt_guid = $2
+            LIMIT 1);
+      """
+
+      case Ecto.Adapters.SQL.query(Oli.Repo, sql, [activity_attempt_guid, activity_attempt_guid]) do
+        {:ok, %{num_rows: 1}} -> :updated
+        {:ok, %{num_rows: _}} -> Oli.Repo.rollback(:unexpected_update_count)
+        {:error, e} -> Oli.Repo.rollback(e)
+      end
+
+    end)
+  end
 
 end

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -1243,6 +1243,14 @@ defmodule Oli.Delivery.Sections do
     end)
   end
 
+  @doc """
+  Rebuilds the "contained pages" relations for a course section.  A "contained page" for a
+  container is the full set of pages found immeidately within that container or in any of
+  its sub-containers.  For every container in a course section, one row will exist in this
+  "contained pages" table for each contained page.  This allows a straightforward join through
+  this relation from a container to then all of its contained pages - to power calculations like
+  aggregating progress complete across all pages within a container.
+  """
   def rebuild_contained_pages(%Section{id: section_id} = section) do
     section_resources = from(sr in SectionResource, where: sr.section_id == ^section_id)
     |> Repo.all()
@@ -1252,19 +1260,39 @@ defmodule Oli.Delivery.Sections do
 
   def rebuild_contained_pages(%Section{slug: slug, id: section_id} = section, section_resources) do
 
+    # First start be deleting all existing contained pages for this section.
     from(cp in ContainedPage, where: cp.section_id == ^section_id)
     |> Repo.delete_all
 
+    # We will need the set of resource ids for all containers in the hierarchy.
     container_type_id = Oli.Resources.ResourceType.get_id_by_type("container")
     container_ids = DeliveryResolver.revisions_of_type(slug, container_type_id)
     |> Enum.map(fn rev -> rev.resource_id end)
     |> MapSet.new()
 
+    # From the section resources, locate the root section resource, and also create a lookup map
+    # from section_resource id to each section resource.
     root = Enum.find(section_resources, fn sr -> sr.id == section.root_section_resource_id end)
     map = Enum.reduce(section_resources, %{}, fn sr, map -> Map.put(map, sr.id, sr) end)
 
+    # Now recursively traverse the containers within the course section hierarchy, starting with the root
+    # to build a map of page resource_ids to lists of the ancestor container resource_ids.  The resultant
+    # map will look like:
+    #
+    # %{
+    #   234 => [32, 25, nil],
+    #   135 => [33, 25, nil],
+    #   299 => [25, nil],
+    #   408 => [nil]
+    # }
+    #
+    # The `nil` entries above represent their presence in the root container, and each preceding resource id
+    # references a parent container (like Unit, module, etc).  All container references besides the root are
+    # true resource_id references, and not ids of the section resoource.
+    #
     page_map = rebuild_contained_pages_helper(root, {[nil], %{}, map, container_ids})
 
+    # Now convert the page_map to a list of maps for bulk insert
     insertions = Enum.reduce(page_map, [], fn {page_id, ancestors}, all ->
       Enum.map(ancestors, fn id -> %{section_id: section_id, container_id: id, page_id: page_id} end) ++ all
     end)
@@ -1273,6 +1301,8 @@ defmodule Oli.Delivery.Sections do
 
   end
 
+  # Recursive helper to traverse the hierarchy of the section resources and create the page to ancestor
+  # container map.
   defp rebuild_contained_pages_helper(sr, {ancestors, page_map, all, container_ids}) do
     Enum.map(sr.children, fn sr_id ->
       sr = Map.get(all, sr_id)

--- a/lib/oli/delivery/sections/contained_page.ex
+++ b/lib/oli/delivery/sections/contained_page.ex
@@ -1,0 +1,28 @@
+defmodule Oli.Delivery.Sections.ContainedPage do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Oli.Delivery.Sections.SectionResource
+
+  schema "contained_pages" do
+
+    belongs_to :container, SectionResource
+    belongs_to :page, SectionResource
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  def changeset(contained_page, attrs) do
+    contained_page
+    |> cast(attrs, [
+      :container_id,
+      :page_id
+    ])
+    |> validate_required([
+      :container_id,
+      :page_id
+    ])
+  end
+
+end

--- a/lib/oli/delivery/sections/contained_page.ex
+++ b/lib/oli/delivery/sections/contained_page.ex
@@ -2,24 +2,27 @@ defmodule Oli.Delivery.Sections.ContainedPage do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias Oli.Delivery.Sections.SectionResource
+  alias Oli.Delivery.Sections.Section
+  alias Oli.Resources.Resource
 
   schema "contained_pages" do
 
-    belongs_to :container, SectionResource
-    belongs_to :page, SectionResource
+    belongs_to :section, Section
+    belongs_to :container, Resource
+    belongs_to :page, Resource
 
-    timestamps(type: :utc_datetime)
   end
 
   @doc false
   def changeset(contained_page, attrs) do
     contained_page
     |> cast(attrs, [
+      :section_id,
       :container_id,
       :page_id
     ])
     |> validate_required([
+      :section_id,
       :container_id,
       :page_id
     ])

--- a/lib/oli/delivery/sections/section_resource.ex
+++ b/lib/oli/delivery/sections/section_resource.ex
@@ -16,6 +16,9 @@ defmodule Oli.Delivery.Sections.SectionResource do
     # an array of ids to other section resources
     field :children, {:array, :id}, default: []
 
+    # if a container, records the total number of contained pages
+    field :contained_page_count, :integer, default: 0
+
     # the resource slug, resource and project mapping
     field :slug, :string
     field :resource_id, :integer
@@ -37,6 +40,7 @@ defmodule Oli.Delivery.Sections.SectionResource do
       :numbering_index,
       :numbering_level,
       :children,
+      :contained_page_count,
       :slug,
       :resource_id,
       :project_id,
@@ -60,6 +64,7 @@ defmodule Oli.Delivery.Sections.SectionResource do
       :numbering_index,
       :numbering_level,
       :children,
+      :contained_page_count,
       :slug,
       :resource_id,
       :project_id,

--- a/lib/oli/publishing.ex
+++ b/lib/oli/publishing.ex
@@ -3,6 +3,7 @@ defmodule Oli.Publishing do
 
   require Logger
 
+  alias Oli.Publishing.DeliveryResolver
   alias Oli.Publishing.Publications.DiffAgent
   alias Oli.Repo
 

--- a/lib/oli/publishing.ex
+++ b/lib/oli/publishing.ex
@@ -3,7 +3,6 @@ defmodule Oli.Publishing do
 
   require Logger
 
-  alias Oli.Publishing.DeliveryResolver
   alias Oli.Publishing.Publications.DiffAgent
   alias Oli.Repo
 

--- a/lib/oli/utils/db_seeder.ex
+++ b/lib/oli/utils/db_seeder.ex
@@ -381,6 +381,11 @@ defmodule Oli.Seeder do
 
   def base_project_with_larger_hierarchy() do
     mappings = base_project_with_resource2()
+    |> add_activity(%{title: "title 1"}, :publication, :project, :author, :activity_a)
+    |> add_activity(%{title: "title 2"}, :publication, :project, :author, :activity_b)
+    |> add_activity(%{title: "title 3"}, :publication, :project, :author, :activity_c)
+    |> add_activity(%{title: "title 4"}, :publication, :project, :author, :activity_d)
+    |> add_activity(%{title: "title 5"}, :publication, :project, :author, :activity_e)
 
     %{
       container: %{resource: container_resource, revision: container_revision},

--- a/lib/oli/utils/db_seeder.ex
+++ b/lib/oli/utils/db_seeder.ex
@@ -364,6 +364,86 @@ defmodule Oli.Seeder do
     })
   end
 
+  defp n_pages_for(n, pub, project, author, container_resource, container_revision) do
+
+    pages = 1..n
+    |> Enum.map(fn n ->
+      create_page("Page #{n}", pub, project, author)
+    end)
+
+    resources = Enum.map(pages, fn %{resource: r} -> r end)
+
+    attach_pages_to(resources, container_resource, container_revision, pub)
+
+    pages
+  end
+
+
+  def base_project_with_larger_hierarchy() do
+    mappings = base_project_with_resource2()
+
+    %{
+      container: %{resource: container_resource, revision: container_revision},
+      publication: publication,
+      project: project,
+      author: author
+    } = mappings
+
+    %{resource: unit1_resource, revision: unit1_revision} =
+      create_container("Unit 1", publication, project, author)
+
+    %{resource: unit2_resource, revision: unit2_revision} =
+      create_container("Unit 2", publication, project, author)
+
+    %{resource: mod1_resource, revision: mod1_revision} =
+      create_container("Module 1", publication, project, author)
+
+    %{resource: mod2_resource, revision: mod2_revision} =
+      create_container("Module 2", publication, project, author)
+
+    %{resource: mod3_resource, revision: mod3_revision} =
+      create_container("Module 3", publication, project, author)
+
+    mod1_pages = n_pages_for(3, publication, project, author, mod1_resource, mod1_revision)
+    mod2_pages = n_pages_for(3, publication, project, author, mod2_resource, mod2_revision)
+    mod3_pages = n_pages_for(4, publication, project, author, mod3_resource, mod3_revision)
+
+    attach_pages_to([mod1_resource, mod2_resource], unit1_resource, unit1_revision, publication)
+    attach_pages_to([mod3_resource], unit2_resource, unit2_revision, publication)
+
+    container_revision =
+      attach_pages_to([unit1_resource, unit2_resource], container_resource, container_revision, publication)
+
+    {:ok, pub1} = Publishing.publish_project(project, "some changes")
+
+
+    {:ok, section} =
+      Sections.create_section(%{
+        title: "3",
+        registration_open: true,
+        open_and_free: true,
+        context_id: UUID.uuid4(),
+        institution_id: mappings.institution.id,
+        base_project_id: project.id
+      })
+      |> then(fn {:ok, section} -> section end)
+      |> Sections.create_section_resources(pub1)
+
+    Map.merge(mappings, %{
+      container: %{resource: container_resource, revision: container_revision},
+      unit1_container: %{resource: unit1_resource, revision: unit1_revision},
+      mod1_pages: mod1_pages,
+      mod2_pages: mod2_pages,
+      mod3_pages: mod3_pages,
+      mod1_resource: mod1_resource,
+      mod2_resource: mod2_resource,
+      mod3_resource: mod3_resource,
+      unit1_resource: unit1_resource,
+      unit2_resource: unit2_resource,
+      section: section
+    })
+  end
+
   def base_project_with_resource4() do
     map =
       base_project_with_resource3()

--- a/lib/oli_web/controllers/open_and_free_controller.ex
+++ b/lib/oli_web/controllers/open_and_free_controller.ex
@@ -155,7 +155,7 @@ defmodule OliWeb.OpenAndFreeController do
         nil -> nil
         labels -> Map.from_struct(labels)
       end
-      
+
       section_params =
         section_params
         |> Map.put("type", :enrollable)
@@ -343,6 +343,7 @@ defmodule OliWeb.OpenAndFreeController do
   defp create_from_product(conn, blueprint, section_params) do
     Repo.transaction(fn ->
       with {:ok, section} <- Oli.Delivery.Sections.Blueprint.duplicate(blueprint, section_params),
+           {:ok, _} <- Section.rebuild_contained_pages(section),
            {:ok, _maybe_enrollment} <- enroll(conn, section) do
         section
       else
@@ -355,6 +356,7 @@ defmodule OliWeb.OpenAndFreeController do
     Repo.transaction(fn ->
       with {:ok, section} <- Sections.create_section(section_params),
            {:ok, section} <- Sections.create_section_resources(section, publication),
+           {:ok, _} <- Section.rebuild_contained_pages(section),
            {:ok, _enrollment} <- enroll(conn, section) do
         section
       else

--- a/lib/oli_web/controllers/open_and_free_controller.ex
+++ b/lib/oli_web/controllers/open_and_free_controller.ex
@@ -343,7 +343,7 @@ defmodule OliWeb.OpenAndFreeController do
   defp create_from_product(conn, blueprint, section_params) do
     Repo.transaction(fn ->
       with {:ok, section} <- Oli.Delivery.Sections.Blueprint.duplicate(blueprint, section_params),
-           {:ok, _} <- Section.rebuild_contained_pages(section),
+           {:ok, _} <- Sections.rebuild_contained_pages(section),
            {:ok, _maybe_enrollment} <- enroll(conn, section) do
         section
       else
@@ -356,7 +356,7 @@ defmodule OliWeb.OpenAndFreeController do
     Repo.transaction(fn ->
       with {:ok, section} <- Sections.create_section(section_params),
            {:ok, section} <- Sections.create_section_resources(section, publication),
-           {:ok, _} <- Section.rebuild_contained_pages(section),
+           {:ok, _} <- Sections.rebuild_contained_pages(section),
            {:ok, _enrollment} <- enroll(conn, section) do
         section
       else

--- a/priv/repo/migrations/20230208185959_contained_pages.exs
+++ b/priv/repo/migrations/20230208185959_contained_pages.exs
@@ -3,13 +3,16 @@ defmodule Oli.Repo.Migrations.ContainedPages do
 
   def change do
     create table(:contained_pages) do
-      add :container_id, references(:section_resources)
-      add :page_id, references(:section_resources)
-
-      timestamps(type: :timestamptz)
+      add :section_id, references(:sections)
+      add :container_id, references(:resources)
+      add :page_id, references(:resources)
     end
 
-    create unique_index(:contained_pages, [:container_id, :page_id])
+    create unique_index(:contained_pages, [:section_id, :container_id, :page_id])
     create index(:contained_pages, [:container_id])
+
+    alter table(:resource_accesses) do
+      add :progress, :float, default: 0.0
+    end
   end
 end

--- a/priv/repo/migrations/20230208185959_contained_pages.exs
+++ b/priv/repo/migrations/20230208185959_contained_pages.exs
@@ -14,5 +14,9 @@ defmodule Oli.Repo.Migrations.ContainedPages do
     alter table(:resource_accesses) do
       add :progress, :float, default: 0.0
     end
+
+    alter table(:section_resources) do
+      add :contained_page_count, :integer, default: 0
+    end
   end
 end

--- a/priv/repo/migrations/20230208185959_contained_pages.exs
+++ b/priv/repo/migrations/20230208185959_contained_pages.exs
@@ -1,0 +1,15 @@
+defmodule Oli.Repo.Migrations.ContainedPages do
+  use Ecto.Migration
+
+  def change do
+    create table(:contained_pages) do
+      add :container_id, references(:section_resources)
+      add :page_id, references(:section_resources)
+
+      timestamps(type: :timestamptz)
+    end
+
+    create unique_index(:contained_pages, [:container_id, :page_id])
+    create index(:contained_pages, [:container_id])
+  end
+end

--- a/test/oli/delivery/metrics/progress_test.exs
+++ b/test/oli/delivery/metrics/progress_test.exs
@@ -48,16 +48,17 @@ defmodule Oli.Delivery.Metrics.ProgressTest do
     } do
 
       # Verify the modules
-      assert_in_delta 0.5, Metrics.progress_for(section.id, mod1_resource.id, this_user.id), 0.0001
-      assert_in_delta 0.2, Metrics.progress_for(section.id, mod2_resource.id, this_user.id), 0.0001
-      assert_in_delta 0.25, Metrics.progress_for(section.id, mod3_resource.id, this_user.id), 0.0001
+      assert_in_delta 0.5, Metrics.progress_for(section.id, this_user.id, mod1_resource.id), 0.0001
+      assert_in_delta 0.2, Metrics.progress_for(section.id, this_user.id, mod2_resource.id), 0.0001
+      assert_in_delta 0.25, Metrics.progress_for(section.id, this_user.id, mod3_resource.id), 0.0001
 
       # Then the units
-      assert_in_delta 0.35, Metrics.progress_for(section.id, unit1_resource.id, this_user.id), 0.0001
-      assert_in_delta 0.25, Metrics.progress_for(section.id, unit2_resource.id, this_user.id), 0.0001
+      assert_in_delta 0.35, Metrics.progress_for(section.id, this_user.id, unit1_resource.id), 0.0001
+      assert_in_delta 0.25, Metrics.progress_for(section.id, this_user.id, unit2_resource.id), 0.0001
 
       # Then the entire course (there are two other pages, outside of the units)
-      assert_in_delta 0.2583, Metrics.progress_for(section.id, nil, this_user.id), 0.0001
+      assert_in_delta 0.2583, Metrics.progress_for(section.id, this_user.id), 0.0001
+      assert_in_delta 0.2583, Metrics.progress_for(section.id, this_user.id, nil), 0.0001
 
     end
 

--- a/test/oli/delivery/metrics/progress_test.exs
+++ b/test/oli/delivery/metrics/progress_test.exs
@@ -34,6 +34,11 @@ defmodule Oli.Delivery.Metrics.ProgressTest do
       set_progress(section.id, p7.published_resource.resource_id, user_id, 0.5)
       set_progress(section.id, p8.published_resource.resource_id, user_id, 0.5)
 
+      # Notice that we aren't setting progress - even to 0 - for p9 and p10.
+      # It is an important test case to NOT have a resource_access record present for
+      # a couple of these pages.  We need to make sure the progress for pages that
+      # have never been visited is considered.
+
       map
     end
 

--- a/test/oli/delivery/metrics/progress_test.exs
+++ b/test/oli/delivery/metrics/progress_test.exs
@@ -1,0 +1,65 @@
+defmodule Oli.Delivery.Metrics.ProgressTest do
+  use Oli.DataCase
+
+  alias Oli.Delivery.Metrics
+  alias Oli.Delivery.Sections
+  alias Oli.Delivery.Attempts.Core
+
+  defp set_progress(section_id, resource_id, user_id, progress) do
+    Core.track_access(resource_id, section_id, user_id)
+    |> Core.update_resource_access(%{progress: progress})
+  end
+
+  describe "progress calculations" do
+    setup do
+      map = Seeder.base_project_with_larger_hierarchy()
+      map = Seeder.add_user(map, %{}, :this_user)
+      Seeder.add_users_to_section(map, :section, [:this_user])
+
+      {:ok, _} = Sections.rebuild_contained_pages(map.section)
+
+      user_id = map.this_user.id
+      section = map.section
+
+      [p1, p2, p3] = map.mod1_pages
+      [p4, p5, p6] = map.mod2_pages
+      [p7, p8, _, _] = map.mod3_pages
+
+      set_progress(section.id, p1.published_resource.resource_id, user_id, 0.5)
+      set_progress(section.id, p2.published_resource.resource_id, user_id, 1)
+      set_progress(section.id, p3.published_resource.resource_id, user_id, 0.0)
+      set_progress(section.id, p4.published_resource.resource_id, user_id, 0.1)
+      set_progress(section.id, p5.published_resource.resource_id, user_id, 0.2)
+      set_progress(section.id, p6.published_resource.resource_id, user_id, 0.3)
+      set_progress(section.id, p7.published_resource.resource_id, user_id, 0.5)
+      set_progress(section.id, p8.published_resource.resource_id, user_id, 0.5)
+
+      map
+    end
+
+    test "progress calculates correctly", %{
+      section: section,
+      this_user: this_user,
+      mod1_resource: mod1_resource,
+      mod2_resource: mod2_resource,
+      mod3_resource: mod3_resource,
+      unit1_resource: unit1_resource,
+      unit2_resource: unit2_resource
+    } do
+
+      # Verify the modules
+      assert_in_delta 0.5, Metrics.progress_for(section.id, mod1_resource.id, this_user.id), 0.0001
+      assert_in_delta 0.2, Metrics.progress_for(section.id, mod2_resource.id, this_user.id), 0.0001
+      assert_in_delta 0.25, Metrics.progress_for(section.id, mod3_resource.id, this_user.id), 0.0001
+
+      # Then the units
+      assert_in_delta 0.35, Metrics.progress_for(section.id, unit1_resource.id, this_user.id), 0.0001
+      assert_in_delta 0.25, Metrics.progress_for(section.id, unit2_resource.id, this_user.id), 0.0001
+
+      # Then the entire course (there are two other pages, outside of the units)
+      assert_in_delta 0.2583, Metrics.progress_for(section.id, nil, this_user.id), 0.0001
+
+    end
+
+  end
+end

--- a/test/oli/delivery/metrics/progress_test.exs
+++ b/test/oli/delivery/metrics/progress_test.exs
@@ -126,6 +126,16 @@ defmodule Oli.Delivery.Metrics.ProgressTest do
       assert_in_delta 0.125, r2, 0.0001
       assert_in_delta 0.5833, r3, 0.0001
 
+      # Finally, exclude that student and verify the previous result
+      [r1, r2, r3] = Metrics.progress_across(section.id, [mod1_resource.id, mod2_resource.id, mod3_resource.id], [user_id], 1)
+      |> Enum.map(fn r -> r.progress end)
+      |> Enum.sort()
+
+      assert_in_delta 0.2, r1, 0.0001
+      assert_in_delta 0.25, r2, 0.0001
+      assert_in_delta 0.5, r3, 0.0001
+
+
     end
 
     test "page level progress calculation and setting", map do


### PR DESCRIPTION
This PR adds the infrastructure needed to track and compute, efficiently, student progress.  

A new context `Oli.Delivery.Metrics` provides methods for calculating progress:
- For a specific container, in a section, for a specific student. 
- Across a collection of containers in a section for a specific student
- Across a collection of containers in a section for all enrolled students

The above calculations are done in one query, leveraging a new "contained_pages" schema, which always provides an up to date view of the recursively nested pages within all containers of a section.  This allows efficient joining and aggregation of progress that is now stored for a page, at the "resource_access" level. 

While these queries and this infrastructure are designed to be as efficient as possible, the UXes that will be designed to show the Units and Module details to an instructor very likely will want to cache these results.  That work, as well as "just in time" population of the "contained_pages" records for sections that do not have them is for another PR.

This new `Metrics` context also provides a single, uniform impl of a calculation of progress at a page level.  Graded page finalization now will set that progress to be 1.0 (100%). 

Additional background material on progress infrastructure and design is in this FDD:
https://docs.google.com/document/d/1CteqnTvnMpIM59EZxdWwnR6ylUu5NBZtWU2GyMxj08E/edit#


