### PR TITLE
[BUGFIX] adaptive delivery theme css and redux store.

### DIFF
--- a/assets/src/apps/DeliveryApp.tsx
+++ b/assets/src/apps/DeliveryApp.tsx
@@ -1,5 +1,5 @@
 import Delivery from './delivery/Delivery';
 import { registerApplication } from './app';
-import adaptiveStore from './authoring/store';
+import deliveryStore from '../apps/delivery/store';
 
-registerApplication('Delivery', Delivery, adaptiveStore);
+registerApplication('Delivery', Delivery, deliveryStore);

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -31,6 +31,7 @@ const populateEntries = () => {
     timezone: ['./src/phoenix/timezone.ts'],
     dark: ['./src/phoenix/dark.ts'],
     keepalive: ['./src/phoenix/keep-alive.ts'],
+    delivery_adaptive_themes_default_light: ['./styles/adaptive/light.scss'],
   };
 
   const manifests = glob.sync('./src/components/activities/*/manifest.json', {});


### PR DESCRIPTION
The adaptive delivery mode was broken in two ways.

1. It was using the wrong redux store, and would crash upon launching.
2. The default light theme css (/css/delivery_adaptive_themes_default_light.css) was not being generated, leading to visual issues after 1. was fixed.  Most (all?) real lessons have custom css, so this one was limited in impact.

To reproduce:

1. Create an adaptive page
2. Open it in the editor
3. Attempt to preview the page
