### PR TITLE
[ENHANCEMENT] Allow DND partIDs to be on EITHER targets or draggables MER-1749

### DIFF
--- a/assets/src/components/activities/custom_dnd/DragCanvas.tsx
+++ b/assets/src/components/activities/custom_dnd/DragCanvas.tsx
@@ -6,8 +6,8 @@ export type ResetListener = () => void;
 
 export type DragCanvasProps = {
   model: CustomDnDSchema;
-  onSubmitPart: (partId: string, value: string) => void;
-  onFocusChange: (partId: string) => void;
+  onSubmitPart: (targetId: string, draggableId: string) => void;
+  onFocusChange: (targetId: string, draggableId: string | null) => void;
   initialState: Record<string, string>;
   editMode: boolean;
   activityAttemptGuid: string;
@@ -41,13 +41,14 @@ export const DragCanvas: React.FC<DragCanvasProps> = (props: DragCanvasProps) =>
   );
 };
 
-function resetAnyChildren(container: any, element: any) {
-  while (element.childNodes.length > 0) {
-    container.appendChild(element.childNodes[0]);
-  }
+function resetChildDraggables(shadowRoot: any, target: any) {
+  const inputRoot = shadowRoot.querySelector('.input_source');
+  target
+    .querySelectorAll('.initiator')
+    .forEach((draggable: HTMLElement) => inputRoot.appendChild(draggable));
 }
 
-function getTarget(shadowRoot: any, inputVal: string) {
+function getTarget(shadowRoot: any, inputVal: string): Element | null {
   let item = null;
   shadowRoot.querySelectorAll('.target').forEach((element: any) => {
     if (element.getAttribute('input_ref') === inputVal) {
@@ -58,7 +59,7 @@ function getTarget(shadowRoot: any, inputVal: string) {
   return item;
 }
 
-function getDroppable(shadowRoot: any, inputVal: string) {
+function getDroppable(shadowRoot: any, inputVal: string): Element | null {
   let item = null;
   shadowRoot.querySelectorAll('.initiator').forEach((element: any) => {
     if (element.getAttribute('input_val') === inputVal) {
@@ -69,15 +70,17 @@ function getDroppable(shadowRoot: any, inputVal: string) {
   return item;
 }
 
-function changeFocus(shadowRoot: any, partId: string, props: DragCanvasProps) {
+function changeFocus(shadowRoot: any, targetId: string, props: DragCanvasProps) {
   shadowRoot.querySelectorAll('.target').forEach((element: any) => {
     element.style['border-width'] = '1px';
   });
-  const target = getTarget(shadowRoot, partId);
+  const target = getTarget(shadowRoot, targetId);
   if (target !== null) {
     (target as any).style['border-width'] = '3px';
   }
-  props.onFocusChange(partId);
+  // notification should also include contained draggable, null if none
+  const draggableId = target?.querySelector('.initiator')?.getAttribute('input_val');
+  props.onFocusChange(targetId, draggableId || null);
 }
 
 function createTargetDropHandler(shadowRoot: any, props: DragCanvasProps) {
@@ -89,7 +92,7 @@ function createTargetDropHandler(shadowRoot: any, props: DragCanvasProps) {
       (ev as any).dataTransfer.dropEffect = 'move';
 
       const inputVal = (ev as any).dataTransfer.getData('text/plain');
-      resetAnyChildren(shadowRoot.querySelector('.input_source'), ev.currentTarget);
+      resetChildDraggables(shadowRoot, ev.currentTarget);
 
       const droppable = getDroppable(shadowRoot, inputVal);
       (ev.currentTarget as any).appendChild(droppable);
@@ -98,9 +101,9 @@ function createTargetDropHandler(shadowRoot: any, props: DragCanvasProps) {
       newlyDropped.style.top = '0px';
       newlyDropped.style.position = 'relative';
 
-      const partId = (ev.currentTarget as any).getAttribute('input_ref');
-      changeFocus(shadowRoot, partId, props);
-      props.onSubmitPart(partId, inputVal);
+      const targetId = (ev.currentTarget as any).getAttribute('input_ref');
+      changeFocus(shadowRoot, targetId, props);
+      props.onSubmitPart(targetId, inputVal);
     }
   };
 }
@@ -186,27 +189,25 @@ function renderRawContent(id: string, props: DragCanvasProps) {
   };
 
   // Set the initial state, thus restoring the state of a partially (or entirely) completed attempt
-  let firstRestoredPart: string | null = null;
+  let firstRestoredTarget: string | null = null;
   shadowRoot.querySelectorAll('.target').forEach((element: any) => {
-    const partId = element.getAttribute('input_ref');
-    if (props.initialState[partId] !== undefined) {
-      const state = props.initialState[partId];
-      const adjustedState = state.startsWith(partId + '_')
-        ? state.substring(partId.length + 1)
-        : state;
-      const droppable = getDroppable(shadowRoot, adjustedState);
+    const targetId = element.getAttribute('input_ref');
+    if (props.initialState[targetId] !== undefined) {
+      const droppableId = props.initialState[targetId];
+      const droppable = getDroppable(shadowRoot, droppableId);
+      console.log('restoring droppable ' + droppableId + ' to target ' + targetId);
 
       element.appendChild(droppable);
-      if (firstRestoredPart === null) {
-        firstRestoredPart = partId;
+      if (firstRestoredTarget === null) {
+        firstRestoredTarget = targetId;
       }
     }
   });
 
   // If we restored state to at least one part, set the focus to the first part that
   // we restored state to.  This allows that parts feedback to be initially displayed as well
-  if (firstRestoredPart !== null) {
-    changeFocus(shadowRoot, firstRestoredPart, props);
+  if (firstRestoredTarget !== null) {
+    changeFocus(shadowRoot, firstRestoredTarget, props);
   }
 
   shadowRoot.querySelectorAll('.initiator').forEach((element: any) => {
@@ -230,7 +231,7 @@ function renderRawContent(id: string, props: DragCanvasProps) {
 
   props.onRegisterResetCallback(() => {
     shadowRoot.querySelectorAll('.target').forEach((element: any) => {
-      resetAnyChildren(shadowRoot, element);
+      resetChildDraggables(shadowRoot, element);
     });
   });
 

--- a/assets/src/components/activities/custom_dnd/utils.ts
+++ b/assets/src/components/activities/custom_dnd/utils.ts
@@ -25,9 +25,9 @@ export const defaultModel: () => CustomDnDSchema = () => {
     initiators: DEFAULT_INITIATORS,
     authoring: {
       parts: [
-        createNewPart('option1_area', 'input1'),
-        createNewPart('option2_area', 'input2'),
-        createNewPart('option3_area', 'input3'),
+        createNewPart('input1', 'input1_area1'),
+        createNewPart('input2', 'input2_area2'),
+        createNewPart('input3', 'input3_area3'),
       ],
       transformations: [],
       previewText: '',
@@ -82,9 +82,9 @@ const DEFAULT_TARGET_AREA = `
   <div id="middletitle" style="position:absolute;top:95px; left:5px" >Label 2</div>
   <div id="bottomtitle" style="position:absolute;top:160px; left:5px" >Label 3</div>
 
-  <div input_ref="option1_area" class="target" style="left:245px; top:25px; width:240px; height:40px;"> </div>
-  <div input_ref="option2_area" class="target" style="left:245px;top:85px; width:240px; height:40px;"> </div>
-  <div input_ref="option3_area" class="target" style="left:245px; top:145px; width:240px; height:40px;"> </div>
+  <div input_ref="area1" class="target" style="left:245px; top:25px; width:240px; height:40px;"> </div>
+  <div input_ref="area2" class="target" style="left:245px;top:85px; width:240px; height:40px;"> </div>
+  <div input_ref="area3" class="target" style="left:245px; top:145px; width:240px; height:40px;"> </div>
 
 </div>
 `;

--- a/assets/src/components/activities/short_answer/sections/TextInput.tsx
+++ b/assets/src/components/activities/short_answer/sections/TextInput.tsx
@@ -43,7 +43,7 @@ export const TextInput: React.FC<InputProps> = ({ input, onEditInput }) => {
 
 const textOptions: { value: string; displayValue: string }[] = [
   { value: 'equals', displayValue: 'Equals exactly' },
-  { value: 'equalsnocase', displayValue: 'Equals ignoring case' },
+  { value: 'iequals', displayValue: 'Equals ignoring case' },
   { value: 'contains', displayValue: 'Contains' },
   { value: 'notcontains', displayValue: "Doesn't Contain" },
   { value: 'regex', displayValue: 'Regex' },

--- a/assets/src/data/activities/model/rules.ts
+++ b/assets/src/data/activities/model/rules.ts
@@ -263,7 +263,6 @@ type ParsedTextRule = {
 // To implement case-insensitive literal string matches, we translate rule
 // 'input like {(?i)escapedText}' => { operator: iequals, value: unescapedText}
 export const translateRule = (r: ParsedTextRule): ParsedTextRule => {
-  console.log('translating ' + r.operator + ' ' + r.value);
   if (r.operator === 'regex' && r.value.startsWith('(?i)')) {
     // Author might have explicitly included (?i) prefix in a regex rule, in which case
     // this ought not to be translated. Detect this by checking for unescaped regex

--- a/assets/src/data/activities/model/rules.ts
+++ b/assets/src/data/activities/model/rules.ts
@@ -266,7 +266,7 @@ export const translateRule = (r: ParsedTextRule): ParsedTextRule => {
   if (r.operator === 'regex' && r.value.startsWith('(?i)')) {
     // Author might have explicitly included (?i) prefix in a regex rule, in which case
     // this ought not to be translated. Detect this by checking for unescaped regex
-    // metachars, and keeping as regex. If author wrote (?i)^pat$ regexp for literal string,
+    // metachars, and keeping as regex. If author wrote (?i)pat regexp for literal string,
     // it gets translated to iequals match, but that is equivalent.
     if (!hasUnescapedRegExpChars(r.value.slice(4))) {
       return {

--- a/lib/oli/delivery/evaluation/parser.ex
+++ b/lib/oli/delivery/evaluation/parser.ex
@@ -33,6 +33,7 @@ defmodule Oli.Delivery.Evaluation.Parser do
   op_eq = ascii_char([?=]) |> optional(string(" ")) |> replace(:eq) |> label("=")
   op_like = string("like") |> optional(string(" ")) |> replace(:like) |> label("like")
   op_equals = string("equals") |> optional(string(" ")) |> replace(:equals) |> label("equals")
+  op_iequals = string("iequals") |> optional(string(" ")) |> replace(:iequals) |> label("iequals")
 
   op_contains =
     string("contains") |> optional(string(" ")) |> replace(:contains) |> label("contains")
@@ -78,7 +79,10 @@ defmodule Oli.Delivery.Evaluation.Parser do
   defcombinatorp(:component, choice([attempt_number_, input_, input_length_]))
 
   # <operator> :== "<" | ">" | "=" | "like" | "contains"
-  defcombinatorp(:operator, choice([op_lt, op_gt, op_eq, op_like, op_contains, op_equals]))
+  defcombinatorp(
+    :operator,
+    choice([op_lt, op_gt, op_eq, op_like, op_contains, op_equals, op_iequals])
+  )
 
   # <criterion> :== <component> <operator> <check>
   defcombinatorp(

--- a/lib/oli/delivery/evaluation/rule.ex
+++ b/lib/oli/delivery/evaluation/rule.ex
@@ -62,6 +62,13 @@ defmodule Oli.Delivery.Evaluation.Rule do
     )
   end
 
+  defp eval({:iequals, lhs, rhs}, context) do
+    String.equivalent?(
+      String.downcase(eval(lhs, context)),
+      String.downcase(rhs)
+    )
+  end
+
   defp eval(:attempt_number, context), do: context.activity_attempt_number |> Integer.to_string()
   defp eval(:input, context), do: context.input
   defp eval(:input_length, context), do: String.length(context.input) |> Integer.to_string()

--- a/test/oli/delivery/evaluation/rule_eval_test.exs
+++ b/test/oli/delivery/evaluation/rule_eval_test.exs
@@ -80,8 +80,6 @@ defmodule Oli.Delivery.Evaluation.RuleEvalTest do
 
     assert eval("attemptNumber = {1} && input = {(-4.66e-19,-4.5e-19)}", "-4.6e-19") == true
 
-
-
     # gracefully handles space in between range
     assert eval("attemptNumber = {1} && input = {[3, 5]}", "4") == true
 
@@ -152,6 +150,39 @@ defmodule Oli.Delivery.Evaluation.RuleEvalTest do
 
     assert eval("!(input contains {cat})", "the bat in the hat")
     refute eval("!(input contains {cat})", "the cat in the hat")
+  end
+
+  test "evaluating string equals" do
+    assert eval("input equals {cat}", "cat")
+    refute eval("input equals {Cat}", "cat")
+    refute eval("input equals {cat}", "Cat")
+
+    assert eval("input equals {the cat in the hat}", "the cat in the hat")
+    assert eval("input equals {the CaT in the HAT}", "the CaT in the HAT")
+    refute eval("input equals {the cat in the HAT}", "the CaT in the HAT")
+    refute eval("input equals { the cat in the hat}", "the cat in the hat")
+    refute eval("input equals {the cat in the hat}", "the cat in the hat ")
+
+    assert eval("!(input equals {cat})", "the cat in the hat")
+    refute eval("!(input equals {the cat in the hat})", "the cat in the hat")
+  end
+
+  test "evaluating string iequals (case-insensitive)" do
+    assert eval("input iequals {cat}", "cat")
+    assert eval("input iequals {Cat}", "cat")
+    assert eval("input iequals {cat}", "Cat")
+
+    assert eval("input iequals {the cat in the hat}", "the CaT in the HAT")
+    refute eval("input iequals {cat}", "the CaT in the HAT")
+    refute eval("input iequals {CaT}", "the CaT in the HAT")
+
+    refute eval("input equals {the cat in the HAT}", "the CaT in the HAT")
+    refute eval("input equals { the cat in the hat}", "the cat in the hat")
+    refute eval("input equals {the cat in the hat}", "the cat in the hat ")
+
+    assert eval("!(input equals {cat})", "the cat in the hat")
+    refute eval("!(input equals {the cat in the hat})", "the cat in the hat")
+    assert eval("!(input equals {the CAT in the hat})", "the cat in the HAT")
   end
 
   test "evaluating strings with a numeric operator results in error" do

--- a/test/oli/delivery/evaluation/rule_eval_test.exs
+++ b/test/oli/delivery/evaluation/rule_eval_test.exs
@@ -176,13 +176,13 @@ defmodule Oli.Delivery.Evaluation.RuleEvalTest do
     refute eval("input iequals {cat}", "the CaT in the HAT")
     refute eval("input iequals {CaT}", "the CaT in the HAT")
 
-    refute eval("input equals {the cat in the HAT}", "the CaT in the HAT")
-    refute eval("input equals { the cat in the hat}", "the cat in the hat")
-    refute eval("input equals {the cat in the hat}", "the cat in the hat ")
+    assert eval("input iequals {the cat in the HAT}", "the CaT in the HAT")
+    refute eval("input iequals { the cat in the hat}", "the cat in the hat")
+    refute eval("input iequals {the cat in the hat}", "the cat in the hat ")
 
-    assert eval("!(input equals {cat})", "the cat in the hat")
-    refute eval("!(input equals {the cat in the hat})", "the cat in the hat")
-    assert eval("!(input equals {the CAT in the hat})", "the cat in the HAT")
+    assert eval("!(input iequals {cat})", "the cat in the hat")
+    refute eval("!(input iequals {the cat in the hat})", "the cat in the hat")
+    refute eval("!(input iequals {the CAT in the hat})", "the cat in the HAT")
   end
 
   test "evaluating strings with a numeric operator results in error" do


### PR DESCRIPTION
This addresses the following problem for converting legacy drag-and-drops to torus. Legacy DND questions are modelled as multi-input questions with a set of inputIDs = partIDs and base choiceIDs. Responses converted for torus come in as choice values of the form partID_choiceID, to represent some draggable being dropped on some target. 

Legacy layout attaches the partIDs to the draggables, and choiceIDs to the target areas, in effect treating each draggable as a question part you have to answer, with your choices for that part being the possible areas on which you can drop it.

The Torus implementation assumed partIDs would be associated with targets and choiceIDs with draggables, and the course-digest goes to some trouble to swap IDs to bring legacy layouts into this form. However, several legacy drag-and-drops may have fewer draggables than targets, and multiple possible targets for a given draggable. These are questions of the form "drag each item into the appropriate column" with, say, 2 columns of four rows, but only seven draggable items (so four possible correct choices for each draggable, but one target left blank when finished). These can't be handled in the torus model, which seems to be premised on the idea of one-to-one matching of draggables and targets.

This PR handles this by allowing Torus to handle either representation. It does this by testing a sample partID to see whether the part ids match the targetIDs or on the draggableIDs, and behaving appropriately in the small number of places where it matters. Renamed variables in the DragArea component to make no reference to partIDs at all, just to targetIDs and draggableIDs, so it is only the containing delivery component needs to deal with this.

With this feature the course converter need no longer swap IDs in the layout. However, older conversions using the swapped ID convention will still work.