### PR TITLE
[ENHANCEMENT] update page progress at every ungraded page attempt start

### DIFF
--- a/lib/oli/delivery/attempts/page_lifecycle/graded.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/graded.ex
@@ -124,7 +124,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Graded do
                ) do
             {:ok, resource_access} ->
 
-              {:ok, _} = Oli.Delivery.Metrics.mark_completed(resource_access)
+              {:ok, _} = Oli.Delivery.Metrics.mark_progress_completed(resource_access)
 
               {:ok,
                %FinalizationSummary{

--- a/lib/oli/delivery/attempts/page_lifecycle/ungraded.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/ungraded.ex
@@ -85,11 +85,11 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Ungraded do
   end
 
   defp do_update_progress(resource_access, 0) do
-    Oli.Delivery.Metrics.mark_completed(resource_access)
+    Oli.Delivery.Metrics.mark_progress_completed(resource_access)
   end
 
   defp do_update_progress(resource_access, _) do
-    Oli.Delivery.Metrics.reset(resource_access)
+    Oli.Delivery.Metrics.reset_progress(resource_access)
   end
 
 end

--- a/lib/oli/delivery/attempts/page_lifecycle/ungraded.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/ungraded.ex
@@ -9,6 +9,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Ungraded do
     Lifecycle,
     Hierarchy
   }
+  alias Oli.Delivery.Attempts.Core.ResourceAttempt
 
   alias Oli.Delivery.Attempts.PageLifecycle.Common
 
@@ -64,6 +65,31 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Ungraded do
   @impl Lifecycle
   def start(%VisitContext{} = context) do
     {:ok, resource_attempt} = Hierarchy.create(context)
+
     AttemptState.fetch_attempt_state(resource_attempt, context.page_revision)
+    |> update_progress(resource_attempt)
   end
+
+  defp update_progress({:ok, activity_map}, %ResourceAttempt{resource_access_id: resource_access_id}) do
+
+    number_of_activities = Map.keys(activity_map) |> Enum.count()
+
+    Oli.Delivery.Attempts.Core.get_resource_access(resource_access_id)
+    |> do_update_progress(number_of_activities)
+
+    {:ok, activity_map}
+  end
+
+  defp update_progress(other, _) do
+    other
+  end
+
+  defp do_update_progress(resource_access, 0) do
+    Oli.Delivery.Metrics.mark_completed(resource_access)
+  end
+
+  defp do_update_progress(resource_access, _) do
+    Oli.Delivery.Metrics.reset(resource_access)
+  end
+
 end

--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -108,14 +108,14 @@ defmodule Oli.Delivery.Metrics do
   @doc """
   Updates page progress to be 100% complete.
   """
-  def mark_completed(%ResourceAccess{} = ra) do
+  def mark_progress_completed(%ResourceAccess{} = ra) do
     Core.update_resource_access(ra, %{progress: 1.0})
   end
 
   @doc """
-  Updates page progress to be 100% complete.
+  Resets page progress to be 0% complete.
   """
-  def reset(%ResourceAccess{} = ra) do
+  def reset_progress(%ResourceAccess{} = ra) do
     Core.update_resource_access(ra, %{progress: 0.0})
   end
 

--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -113,6 +113,13 @@ defmodule Oli.Delivery.Metrics do
   end
 
   @doc """
+  Updates page progress to be 100% complete.
+  """
+  def reset(%ResourceAccess{} = ra) do
+    Core.update_resource_access(ra, %{progress: 0.0})
+  end
+
+  @doc """
   For an activity attempt specified by an attempt guid, calculate and set in the corresponding resource access
   record, the percentage complete for the related page. This calculation only needs to be performed after the
   evaluation of the first attempt for given activity.  This method should update exactly one record, the resource


### PR DESCRIPTION
One final piece of the progress infrastructure:  

Page attempts are created for ungraded pages in two instances:
1. When a student visits a page for the very first time.
2. When a student returns to a page that they had already visited, but in the interim a new page publication has updated that page.  In this instance, we create a new page attempt for that new content. 

In both cases above, we must update the progress on the page.  That progress should be set to 100% if the page contains no activities, otherwise it should be set to 0%.

We do not want to do this for graded pages.  We want them to enter 100% after submission - and stay in that state even with further attempts are taken. 



