### PR TITLE
[Bugfix] Moving components in advanced authoring was not saving

### DIFF
--- a/assets/src/apps/authoring/components/EditingCanvas/AuthoringActivityRenderer.tsx
+++ b/assets/src/apps/authoring/components/EditingCanvas/AuthoringActivityRenderer.tsx
@@ -123,10 +123,9 @@ const AuthoringActivityRenderer: React.FC<AuthoringActivityRendererProps> = ({
     document.addEventListener('customEvent', customEventHandler);
 
     const handleActivityEdit = async (e: any) => {
-      const target = e.target as HTMLElement;
-      if (target?.id === elementProps.id) {
+      if (e.detail?.model?.id === activityModel.id) {
         const { model } = e.detail;
-        /* console.log('AAR handleActivityEdit', { model }); */
+        // console.log('AAR handleActivityEdit', { model });
         dispatch(saveActivity({ activity: model, undoable: true, immediate: true }));
         // why were we clearing the selection on edit?...
         // dispatch(setCurrentSelection({ selection: '' }));
@@ -141,7 +140,7 @@ const AuthoringActivityRenderer: React.FC<AuthoringActivityRendererProps> = ({
       document.removeEventListener('customEvent', customEventHandler);
       document.removeEventListener('modelUpdated', handleActivityEdit);
     };
-  }, [elementProps.id]);
+  }, [elementProps.id, activityModel]);
 
   if (!activityModel.authoring || !activityModel.activityType) {
     console.warn('Bad Activity Data', activityModel);

--- a/assets/src/components/activities/AuthoringElement.ts
+++ b/assets/src/components/activities/AuthoringElement.ts
@@ -69,7 +69,9 @@ export abstract class AuthoringElement<T extends ActivityModelSchema> extends HT
     }
 
     const onEdit = (model: T) => {
-      this.dispatchEvent(new CustomEvent('modelUpdated', { bubbles: true, detail: { model } }));
+      this.dispatchEvent(
+        new CustomEvent('modelUpdated', { composed: true, bubbles: true, detail: { model } }),
+      );
     };
     const onPostUndoable = (undoable: Undoable) => {
       this.dispatchEvent(new CustomEvent('postUndoable', { bubbles: true, detail: { undoable } }));


### PR DESCRIPTION
1. Go into advanced authoring editor
2. Click a component
3. Move or resize the component
4. Click off the component

Expected: Component stays where you left it and is saved.
Actual: Component snaps back to original location / size

With the advanced authoring app being put into a shadow-dom container, a new class of potential bugs has surfaced having to do with how events bubble up. To fix these:

1. Events meant to bubble to the document must be marked as composable (see AuthoringElement.ts below)
2. Event handlers should not expect event.target to point to the element inside the shadow-dom as they get rewritten to the shadow root. (see AuthoringActivityRenderer.tsx below)

Note: the reason for this flow of data outside of normal react conventions is because AuthoringElement lives inside a web component, and that web component lives inside our main react editor. 


