### PR TITLE
Improve mix test performance

### DIFF
--- a/test/oli_web/live/admin_live_test.exs
+++ b/test/oli_web/live/admin_live_test.exs
@@ -1,5 +1,5 @@
 defmodule OliWeb.AdminLiveTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   use OliWeb.ConnCase
 
   import Phoenix.LiveViewTest

--- a/test/oli_web/live/browse_updates_live_test.exs
+++ b/test/oli_web/live/browse_updates_live_test.exs
@@ -1,5 +1,5 @@
 defmodule OliWeb.BrowseUpdatesLiveTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   use OliWeb.ConnCase
 
   import Phoenix.LiveViewTest

--- a/test/oli_web/live/collaboration_live_test.exs
+++ b/test/oli_web/live/collaboration_live_test.exs
@@ -1,5 +1,5 @@
 defmodule OliWeb.CollaborationLiveTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   use OliWeb.ConnCase
 
   import Oli.Factory

--- a/test/oli_web/live/community_live_test.exs
+++ b/test/oli_web/live/community_live_test.exs
@@ -1,5 +1,5 @@
 defmodule OliWeb.CommunityLiveTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   use OliWeb.ConnCase
 
   import Phoenix.LiveViewTest
@@ -750,9 +750,9 @@ defmodule OliWeb.CommunityLiveTest do
       |> render_click(%{"collaborator-id": user_1.id})
 
       assert view
-        |> element("div.alert.alert-info")
-        |> render() =~
-          "Community member successfully added."
+             |> element("div.alert.alert-info")
+             |> render() =~
+               "Community member successfully added."
 
       assert 1 == length(Groups.list_community_members(community.id))
     end

--- a/test/oli_web/live/failed_grade_sync_live_test.exs
+++ b/test/oli_web/live/failed_grade_sync_live_test.exs
@@ -1,5 +1,5 @@
 defmodule OliWeb.FailedGradeSyncLiveTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   use OliWeb.ConnCase
 
   import ExUnit.CaptureLog
@@ -8,17 +8,17 @@ defmodule OliWeb.FailedGradeSyncLiveTest do
 
   defp live_view_overview_view_route(section_slug) do
     Routes.live_path(
-        OliWeb.Endpoint,
-        OliWeb.Sections.OverviewView,
-        section_slug
+      OliWeb.Endpoint,
+      OliWeb.Sections.OverviewView,
+      section_slug
     )
   end
 
   defp live_view_observe_grade_updates_view_route(section_slug) do
     Routes.live_path(
-        OliWeb.Endpoint,
-        OliWeb.Grades.ObserveGradeUpdatesView,
-        section_slug
+      OliWeb.Endpoint,
+      OliWeb.Grades.ObserveGradeUpdatesView,
+      section_slug
     )
   end
 
@@ -66,7 +66,7 @@ defmodule OliWeb.FailedGradeSyncLiveTest do
       instructor: instructor,
       section: section,
       resource_access_1: resource_access_1,
-      resource_access_2: resource_access_2,
+      resource_access_2: resource_access_2
     } do
       enroll_user_to_section(instructor, section, :context_instructor)
 
@@ -93,7 +93,9 @@ defmodule OliWeb.FailedGradeSyncLiveTest do
       |> render_click(%{"resource-id" => resource_id, "user-id" => user_id})
 
       flash = assert_redirected(view, live_view_overview_view_route(section.slug))
-      assert flash["info"] == "Retrying grade sync. Please check the status again in a few minutes."
+
+      assert flash["info"] ==
+               "Retrying grade sync. Please check the status again in a few minutes."
     end
   end
 
@@ -121,18 +123,18 @@ defmodule OliWeb.FailedGradeSyncLiveTest do
       {:ok, view, _html} = live(conn, live_view_failed_grade_sync_view_route(section.slug))
 
       assert view
-      |> element("tr:first-child > td:first-child")
-      |> render() =~
-        "AAAA Name"
+             |> element("tr:first-child > td:first-child")
+             |> render() =~
+               "AAAA Name"
 
       view
       |> element("th[phx-click=\"sort\"]:first-of-type")
       |> render_click(%{sort_by: "user_name"})
 
       assert view
-      |> element("tr:first-child > td:first-child")
-      |> render() =~
-        "BBBB Name"
+             |> element("tr:first-child > td:first-child")
+             |> render() =~
+               "BBBB Name"
     end
 
     test "applies searching", %{
@@ -181,18 +183,18 @@ defmodule OliWeb.FailedGradeSyncLiveTest do
       {:ok, view, _html} = live(conn, live_view_failed_grade_sync_view_route(section.slug))
 
       assert view
-      |> element("tr:first-child > td:first-child")
-      |> render() =~
-        "AAAA Name"
+             |> element("tr:first-child > td:first-child")
+             |> render() =~
+               "AAAA Name"
 
       view
       |> element("a[phx-click=\"page_change\"]", "2")
       |> render_click()
 
       refute view
-      |> element("tr:first-child > td:first-child")
-      |> render() =~
-        "AAAA Name"
+             |> element("tr:first-child > td:first-child")
+             |> render() =~
+               "AAAA Name"
     end
 
     test "renders error message correctly", %{
@@ -201,17 +203,19 @@ defmodule OliWeb.FailedGradeSyncLiveTest do
       resource_access_1: %{user_id: user_id}
     } do
       assert capture_log(fn ->
-        {:ok, view, _html} = live(conn, live_view_failed_grade_sync_view_route(section.slug))
+               {:ok, view, _html} =
+                 live(conn, live_view_failed_grade_sync_view_route(section.slug))
 
-        view
-        |> element("button[phx-click=\"retry\"][phx-value-user-id=\"#{user_id}\"")
-        |> render_click(%{"resource-id" => -1, "user-id" => user_id})
+               view
+               |> element("button[phx-click=\"retry\"][phx-value-user-id=\"#{user_id}\"")
+               |> render_click(%{"resource-id" => -1, "user-id" => user_id})
 
-        assert view
-        |> element("div.alert.alert-danger")
-        |> render() =~
-          "Couldn&#39;t retry grade sync."
-      end) =~ "Couldn't retry grade sync for resource_id: -1, user_id: #{user_id}. Reason: {:error, {\"The resource access was not found.\"}}"
+               assert view
+                      |> element("div.alert.alert-danger")
+                      |> render() =~
+                        "Couldn&#39;t retry grade sync."
+             end) =~
+               "Couldn't retry grade sync for resource_id: -1, user_id: #{user_id}. Reason: {:error, {\"The resource access was not found.\"}}"
     end
 
     test "retries individual failed grade sync correctly", %{
@@ -228,13 +232,14 @@ defmodule OliWeb.FailedGradeSyncLiveTest do
       flash = assert_redirected(view, live_view_observe_grade_updates_view_route(section.slug))
       assert flash["info"] == "Retrying grade sync. See processing in real time below."
 
-      [%Oban.Job{args: args, queue: "grades"}] = Oli.Delivery.Attempts.PageLifecycle.GradeUpdateWorker.get_jobs()
+      [%Oban.Job{args: args, queue: "grades"}] =
+        Oli.Delivery.Attempts.PageLifecycle.GradeUpdateWorker.get_jobs()
 
       assert %{
-        "resource_access_id" => id,
-        "section_id" => section.id,
-        "type" => "manual"
-      } == args
+               "resource_access_id" => id,
+               "section_id" => section.id,
+               "type" => "manual"
+             } == args
     end
 
     test "retries bulk failed grade sync correctly", %{
@@ -251,46 +256,48 @@ defmodule OliWeb.FailedGradeSyncLiveTest do
       assert flash["info"] == "Retrying grade sync. See processing in real time below."
 
       assert [
-        %Oban.Job{args: %{"type" => "manual_batch"}, queue: "grades"},
-        %Oban.Job{args: %{"type" => "manual_batch"}, queue: "grades"}
-      ] = Oli.Delivery.Attempts.PageLifecycle.GradeUpdateWorker.get_jobs()
+               %Oban.Job{args: %{"type" => "manual_batch"}, queue: "grades"},
+               %Oban.Job{args: %{"type" => "manual_batch"}, queue: "grades"}
+             ] = Oli.Delivery.Attempts.PageLifecycle.GradeUpdateWorker.get_jobs()
     end
   end
 
   defp create_failed_resource_accesses(%{
-    conn: conn,
-    section: section,
-    page_revision: page_revision
-  }) do
+         conn: conn,
+         section: section,
+         page_revision: page_revision
+       }) do
     first_user = insert(:user, name: "AAAA Name")
     second_user = insert(:user, name: "BBBB Name")
 
     last_successful_grade_update = insert(:lms_grade_update)
     last_grade_update = insert(:lms_grade_update)
 
-    resource_access_1 = insert(:resource_access,
-      user: first_user,
-      section: section,
-      resource: page_revision.resource,
-      last_successful_grade_update_id: last_successful_grade_update.id,
-      last_grade_update_id: last_grade_update.id
-    )
+    resource_access_1 =
+      insert(:resource_access,
+        user: first_user,
+        section: section,
+        resource: page_revision.resource,
+        last_successful_grade_update_id: last_successful_grade_update.id,
+        last_grade_update_id: last_grade_update.id
+      )
 
-    resource_access_2 = insert(:resource_access,
-      user: second_user,
-      section: section,
-      resource: page_revision.resource,
-      last_successful_grade_update_id: last_successful_grade_update.id,
-      last_grade_update_id: last_grade_update.id
-    )
+    resource_access_2 =
+      insert(:resource_access,
+        user: second_user,
+        section: section,
+        resource: page_revision.resource,
+        last_successful_grade_update_id: last_successful_grade_update.id,
+        last_grade_update_id: last_grade_update.id
+      )
 
     {:ok,
-      conn: conn,
-      section: section,
-      page_revision: page_revision,
-      last_successful_grade_update: last_successful_grade_update,
-      last_grade_update: last_grade_update,
-      resource_access_1: resource_access_1,
-      resource_access_2: resource_access_2}
+     conn: conn,
+     section: section,
+     page_revision: page_revision,
+     last_successful_grade_update: last_successful_grade_update,
+     last_grade_update: last_grade_update,
+     resource_access_1: resource_access_1,
+     resource_access_2: resource_access_2}
   end
 end

--- a/test/oli_web/live/gradebook_view_live_test.exs
+++ b/test/oli_web/live/gradebook_view_live_test.exs
@@ -1,5 +1,5 @@
 defmodule OliWeb.GradebookViewLiveTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   use OliWeb.ConnCase
 
   import Phoenix.LiveViewTest
@@ -56,7 +56,7 @@ defmodule OliWeb.GradebookViewLiveTest do
       90.10 => 90.10,
       120 => 120.0,
       0.0 => 0.0,
-      0 => 0.0,
+      0 => 0.0
     }
 
     for {score, expected_score} <- scores_expected_format do
@@ -86,8 +86,10 @@ defmodule OliWeb.GradebookViewLiveTest do
         {:ok, view, _html} = live(conn, live_view_gradebook_view_route(section.slug))
 
         assert view
-          |> element("tr[phx-value-id=\"#{user.id}\"] a[href=\"/sections/#{section.slug}/progress/#{user.id}/#{page_revision.resource.id}\"]")
-          |> render =~ "#{@expected_score}/#{@out_of}"
+               |> element(
+                 "tr[phx-value-id=\"#{user.id}\"] a[href=\"/sections/#{section.slug}/progress/#{user.id}/#{page_revision.resource.id}\"]"
+               )
+               |> render =~ "#{@expected_score}/#{@out_of}"
       end
     end
   end

--- a/test/oli_web/live/ingest_live_test.exs
+++ b/test/oli_web/live/ingest_live_test.exs
@@ -1,5 +1,5 @@
 defmodule OliWeb.IngestLiveTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   use OliWeb.ConnCase
 
   import Phoenix.LiveViewTest

--- a/test/oli_web/live/institutions_live_test.exs
+++ b/test/oli_web/live/institutions_live_test.exs
@@ -1,5 +1,5 @@
 defmodule OliWeb.InstitutionsLiveTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   use OliWeb.ConnCase
 
   import Phoenix.LiveViewTest
@@ -9,7 +9,12 @@ defmodule OliWeb.InstitutionsLiveTest do
   alias Oli.Institutions.Institution
 
   defp live_view_route(institution_id),
-    do: Routes.institution_path(OliWeb.Endpoint, OliWeb.Admin.Institutions.ResearchConsentView, institution_id)
+    do:
+      Routes.institution_path(
+        OliWeb.Endpoint,
+        OliWeb.Admin.Institutions.ResearchConsentView,
+        institution_id
+      )
 
   defp create_institution(_conn) do
     institution = insert(:institution)
@@ -20,7 +25,10 @@ defmodule OliWeb.InstitutionsLiveTest do
   describe "user cannot access when is not logged in" do
     setup [:create_institution]
 
-    test "redirects to new session when accessing the research content view", %{conn: conn, institution: institution} do
+    test "redirects to new session when accessing the research content view", %{
+      conn: conn,
+      institution: institution
+    } do
       redirect_path =
         "/authoring/session/new?request_path=%2Fadmin%2Finstitutions%2F#{institution.id}%2Fresearch_consent"
 
@@ -31,7 +39,10 @@ defmodule OliWeb.InstitutionsLiveTest do
   describe "user cannot access when is logged in as an author but is not a system admin" do
     setup [:author_conn, :create_institution]
 
-    test "returns forbidden when accessing the research consent view", %{conn: conn, institution: institution} do
+    test "returns forbidden when accessing the research consent view", %{
+      conn: conn,
+      institution: institution
+    } do
       conn = get(conn, live_view_route(institution.id))
 
       assert response(conn, 403)
@@ -73,23 +84,30 @@ defmodule OliWeb.InstitutionsLiveTest do
       |> render_submit(%{"institution" => %{"research_consent" => "invalid"}})
 
       assert view
-            |> element("div.alert.alert-danger")
-            |> render() =~
-              "Institution couldn&#39;t be created/updated. Please check the errors below."
+             |> element("div.alert.alert-danger")
+             |> render() =~
+               "Institution couldn&#39;t be created/updated. Please check the errors below."
+
       assert has_element?(view, "span", "is invalid")
     end
 
-    test "saves institution with no form when data is valid", %{conn: conn, institution: institution} do
+    test "saves institution with no form when data is valid", %{
+      conn: conn,
+      institution: institution
+    } do
       {:ok, view, _html} = live(conn, live_view_route(institution.id))
 
       view
       |> element("form[phx-submit=\"save\"")
       |> render_submit(%{"institution" => %{"research_consent" => "no_form"}})
 
-      flash = assert_redirected(view, Routes.institution_path(OliWeb.Endpoint, :show, institution.id))
+      flash =
+        assert_redirected(view, Routes.institution_path(OliWeb.Endpoint, :show, institution.id))
+
       assert flash["info"] == "Institution successfully updated."
 
-      %Institution{research_consent: research_consent} = Institutions.get_institution_by!(%{id: institution.id})
+      %Institution{research_consent: research_consent} =
+        Institutions.get_institution_by!(%{id: institution.id})
 
       assert research_consent == :no_form
     end
@@ -102,10 +120,13 @@ defmodule OliWeb.InstitutionsLiveTest do
       |> element("form[phx-submit=\"save\"")
       |> render_submit(%{"institution" => %{"research_consent" => "oli_form"}})
 
-      flash = assert_redirected(view, Routes.institution_path(OliWeb.Endpoint, :show, institution.id))
+      flash =
+        assert_redirected(view, Routes.institution_path(OliWeb.Endpoint, :show, institution.id))
+
       assert flash["info"] == "Institution successfully updated."
 
-      %Institution{research_consent: research_consent} = Institutions.get_institution_by!(%{id: institution.id})
+      %Institution{research_consent: research_consent} =
+        Institutions.get_institution_by!(%{id: institution.id})
 
       assert research_consent == :oli_form
     end

--- a/test/oli_web/live/manage_source_materials_live_test.exs
+++ b/test/oli_web/live/manage_source_materials_live_test.exs
@@ -1,5 +1,5 @@
 defmodule OliWeb.ManageSourceMaterialsLiveTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   use OliWeb.ConnCase
 
   import Oli.Factory

--- a/test/oli_web/live/payments_live_test.exs
+++ b/test/oli_web/live/payments_live_test.exs
@@ -1,5 +1,5 @@
 defmodule OliWeb.PaymentsLiveTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   use OliWeb.ConnCase
 
   import Phoenix.LiveViewTest

--- a/test/oli_web/live/products_test.exs
+++ b/test/oli_web/live/products_test.exs
@@ -1,5 +1,5 @@
 defmodule OliWeb.ProductsLiveTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   use OliWeb.ConnCase
 
   import Phoenix.LiveViewTest

--- a/test/oli_web/live/progress/student_resource_view_live_test.exs
+++ b/test/oli_web/live/progress/student_resource_view_live_test.exs
@@ -1,5 +1,5 @@
 defmodule OliWeb.Progress.StudentResourceViewLiveTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   use OliWeb.ConnCase
 
   import Phoenix.LiveViewTest

--- a/test/oli_web/live/progress_live_test.exs
+++ b/test/oli_web/live/progress_live_test.exs
@@ -1,5 +1,5 @@
 defmodule OliWeb.ProgressLiveTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   use OliWeb.ConnCase
 
   import Phoenix.LiveViewTest
@@ -80,7 +80,7 @@ defmodule OliWeb.ProgressLiveTest do
       6.10 => 6.10,
       4 => 4.0,
       0.0 => 0.0,
-      0 => 0.0,
+      0 => 0.0
     }
 
     for {score, expected_score} <- scores_expected_format do
@@ -93,15 +93,20 @@ defmodule OliWeb.ProgressLiveTest do
         resource: resource,
         student: student
       } do
-
-        insert(:resource_access, user: student, resource: resource, section: section, score: @score, out_of: 10.0)
+        insert(:resource_access,
+          user: student,
+          resource: resource,
+          section: section,
+          score: @score,
+          out_of: 10.0
+        )
 
         {:ok, view, _html} =
           live(conn, live_view_student_resource_route(section.slug, student.id, resource.id))
 
         assert view
-          |> element("input[name=\"resource_access[score]\"]")
-          |> render =~ "value=\"#{@expected_score}\""
+               |> element("input[name=\"resource_access[score]\"]")
+               |> render =~ "value=\"#{@expected_score}\""
       end
     end
 
@@ -114,34 +119,64 @@ defmodule OliWeb.ProgressLiveTest do
     } do
       first_attempt = %{score: 5.2222, formatted: 5.22}
       second_attempt = %{score: 4.876, formatted: 4.88}
-      third_attempt =  %{score: 7.239, formatted: 7.24}
+      third_attempt = %{score: 7.239, formatted: 7.24}
       out_of = 10.0
 
-      resource_access = insert(:resource_access, user: student, resource: resource, section: section, score: third_attempt.score, out_of: out_of)
+      resource_access =
+        insert(:resource_access,
+          user: student,
+          resource: resource,
+          section: section,
+          score: third_attempt.score,
+          out_of: out_of
+        )
 
       date_now = DateTime.utc_now()
 
-      insert(:resource_attempt, revision: revision, resource_access: resource_access, score: first_attempt.score, out_of: out_of, lifecycle_state: "evaluated",
-        date_submitted: date_now, date_evaluated: date_now)
-      insert(:resource_attempt, revision: revision, resource_access: resource_access, score: second_attempt.score, out_of: out_of, lifecycle_state: "evaluated",
-        date_submitted: date_now, date_evaluated: date_now)
-      insert(:resource_attempt, revision: revision, resource_access: resource_access, score: third_attempt.score, out_of: out_of, lifecycle_state: "evaluated",
-        date_submitted: date_now, date_evaluated: date_now)
+      insert(:resource_attempt,
+        revision: revision,
+        resource_access: resource_access,
+        score: first_attempt.score,
+        out_of: out_of,
+        lifecycle_state: "evaluated",
+        date_submitted: date_now,
+        date_evaluated: date_now
+      )
+
+      insert(:resource_attempt,
+        revision: revision,
+        resource_access: resource_access,
+        score: second_attempt.score,
+        out_of: out_of,
+        lifecycle_state: "evaluated",
+        date_submitted: date_now,
+        date_evaluated: date_now
+      )
+
+      insert(:resource_attempt,
+        revision: revision,
+        resource_access: resource_access,
+        score: third_attempt.score,
+        out_of: out_of,
+        lifecycle_state: "evaluated",
+        date_submitted: date_now,
+        date_evaluated: date_now
+      )
 
       {:ok, view, _html} =
         live(conn, live_view_student_resource_route(section.slug, student.id, resource.id))
 
       assert view
-        |> element("li[data-phx-component=\"1\"]")
-        |> render =~ "#{first_attempt.formatted} / #{out_of}"
+             |> element("li[data-phx-component=\"1\"]")
+             |> render =~ "#{first_attempt.formatted} / #{out_of}"
 
       assert view
-        |> element("li[data-phx-component=\"2\"]")
-        |> render =~ "#{second_attempt.formatted} / #{out_of}"
+             |> element("li[data-phx-component=\"2\"]")
+             |> render =~ "#{second_attempt.formatted} / #{out_of}"
 
       assert view
-        |> element("li[data-phx-component=\"3\"]")
-        |> render =~ "#{third_attempt.formatted} / #{out_of}"
+             |> element("li[data-phx-component=\"3\"]")
+             |> render =~ "#{third_attempt.formatted} / #{out_of}"
 
       assert true
     end
@@ -155,7 +190,10 @@ defmodule OliWeb.ProgressLiveTest do
       section: section
     } do
       conn =
-        get(conn, Routes.live_path(OliWeb.Endpoint, OliWeb.ManualGrading.ManualGradingView, section.slug))
+        get(
+          conn,
+          Routes.live_path(OliWeb.Endpoint, OliWeb.ManualGrading.ManualGradingView, section.slug)
+        )
 
       {:ok, _view, html} = live(conn)
 
@@ -170,7 +208,10 @@ defmodule OliWeb.ProgressLiveTest do
       student: student
     } do
       {:ok, _view, html} =
-        live(conn, Routes.live_path(OliWeb.Endpoint, OliWeb.Progress.StudentView, section.slug, student.id))
+        live(
+          conn,
+          Routes.live_path(OliWeb.Endpoint, OliWeb.Progress.StudentView, section.slug, student.id)
+        )
 
       assert html =~ "<nav class=\"breadcrumb-bar"
       assert html =~ "<a href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.AdminView)}\""
@@ -188,7 +229,10 @@ defmodule OliWeb.ProgressLiveTest do
 
       assert html =~ "<nav class=\"breadcrumb-bar"
       assert html =~ "<a href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.AdminView)}\""
-      assert html =~ "<a href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Progress.StudentView, section.slug, student.id)}\""
+
+      assert html =~
+               "<a href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Progress.StudentView, section.slug, student.id)}\""
+
       assert html =~ "View Resource Progress"
     end
   end
@@ -201,13 +245,19 @@ defmodule OliWeb.ProgressLiveTest do
       section: section
     } do
       conn =
-        get(conn, Routes.live_path(OliWeb.Endpoint, OliWeb.ManualGrading.ManualGradingView, section.slug))
+        get(
+          conn,
+          Routes.live_path(OliWeb.Endpoint, OliWeb.ManualGrading.ManualGradingView, section.slug)
+        )
 
       {:ok, _view, html} = live(conn)
 
       assert html =~ "<nav class=\"breadcrumb-bar"
       refute html =~ "<a href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.AdminView)}\""
-      assert html =~ "<a href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.OverviewView, section.slug)}\""
+
+      assert html =~
+               "<a href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.OverviewView, section.slug)}\""
+
       assert html =~ "Manual Scoring"
     end
 
@@ -217,11 +267,17 @@ defmodule OliWeb.ProgressLiveTest do
       student: student
     } do
       {:ok, _view, html} =
-        live(conn, Routes.live_path(OliWeb.Endpoint, OliWeb.Progress.StudentView, section.slug, student.id))
+        live(
+          conn,
+          Routes.live_path(OliWeb.Endpoint, OliWeb.Progress.StudentView, section.slug, student.id)
+        )
 
       assert html =~ "<nav class=\"breadcrumb-bar"
       refute html =~ "<a href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.AdminView)}\""
-      assert html =~ "<a href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.OverviewView, section.slug)}\""
+
+      assert html =~
+               "<a href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.OverviewView, section.slug)}\""
+
       assert html =~ "Student Progress"
     end
 
@@ -236,8 +292,13 @@ defmodule OliWeb.ProgressLiveTest do
 
       assert html =~ "<nav class=\"breadcrumb-bar"
       refute html =~ "<a href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.AdminView)}\""
-      assert html =~ "<a href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.OverviewView, section.slug)}\""
-      assert html =~ "<a href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Progress.StudentView, section.slug, student.id)}\""
+
+      assert html =~
+               "<a href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.OverviewView, section.slug)}\""
+
+      assert html =~
+               "<a href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Progress.StudentView, section.slug, student.id)}\""
+
       assert html =~ "View Resource Progress"
     end
   end
@@ -250,13 +311,18 @@ defmodule OliWeb.ProgressLiveTest do
     section_project_publication =
       insert(:section_project_publication, %{section: section, project: project})
 
-    revision = insert(:revision, resource_type_id: Oli.Resources.ResourceType.get_id_by_type("page"), graded: true)
+    revision =
+      insert(:revision,
+        resource_type_id: Oli.Resources.ResourceType.get_id_by_type("page"),
+        graded: true
+      )
 
-    section_resource = insert(:section_resource, %{
-      section: section,
-      project: project,
-      resource_id: revision.resource.id
-    })
+    section_resource =
+      insert(:section_resource, %{
+        section: section,
+        project: project,
+        resource_id: revision.resource.id
+      })
 
     Sections.update_section(section, %{root_section_resource_id: section_resource.id})
 
@@ -268,12 +334,19 @@ defmodule OliWeb.ProgressLiveTest do
     })
 
     student = insert(:user)
-    {:ok, section: section, resource: revision.resource, revision: revision, instructor: instructor, student: student}
+
+    {:ok,
+     section: section,
+     resource: revision.resource,
+     revision: revision,
+     instructor: instructor,
+     student: student}
   end
 
   defp setup_instructor_session(%{conn: conn, instructor: user, section: section}) do
     {:ok, user} =
       Accounts.update_user(user, %{can_create_sections: true, independent_learner: true})
+
     {:ok, instructor} =
       Accounts.update_user_platform_roles(user, [PlatformRoles.get_role(:institution_instructor)])
 

--- a/test/oli_web/live/publish_live_test.exs
+++ b/test/oli_web/live/publish_live_test.exs
@@ -1,5 +1,5 @@
 defmodule OliWeb.PublishLiveTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   use OliWeb.ConnCase
 
   import Oli.Factory
@@ -351,8 +351,8 @@ defmodule OliWeb.PublishLiveTest do
       {:ok, view, _html} = live(conn, live_view_publish_route(project.slug))
 
       view
-        |> element("button[phx-click=\"display_lti_connect_modal\"]")
-        |> render_click()
+      |> element("button[phx-click=\"display_lti_connect_modal\"]")
+      |> render_click()
 
       assert has_element?(view, "h4", "Deliver this course through your institution's LMS")
     end

--- a/test/oli_web/live/publisher_live_test.exs
+++ b/test/oli_web/live/publisher_live_test.exs
@@ -1,5 +1,5 @@
 defmodule OliWeb.PublisherLiveTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   use OliWeb.ConnCase
 
   import Phoenix.LiveViewTest

--- a/test/oli_web/live/sections/admin_index_live_test.exs
+++ b/test/oli_web/live/sections/admin_index_live_test.exs
@@ -1,5 +1,5 @@
 defmodule OliWeb.Sections.AdminIndexLiveTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   use OliWeb.ConnCase
 
   alias Lti_1p3.Tool.ContextRoles
@@ -12,8 +12,7 @@ defmodule OliWeb.Sections.AdminIndexLiveTest do
 
   describe "user cannot access when is not logged in" do
     test "redirects to new session when accessing the index view", %{conn: conn} do
-      {:error,
-       {:redirect, %{to: "/authoring/session/new?request_path=%2Fadmin%2Fsections"}}} =
+      {:error, {:redirect, %{to: "/authoring/session/new?request_path=%2Fadmin%2Fsections"}}} =
         live(conn, @live_view_index_route)
     end
   end
@@ -63,12 +62,14 @@ defmodule OliWeb.Sections.AdminIndexLiveTest do
     end
 
     test "applies filtering", %{conn: conn} do
-      s1 = insert(:section,
-        type: :enrollable,
-        open_and_free: true,
-        start_date: yesterday(),
-        end_date: tomorrow()
-      )
+      s1 =
+        insert(:section,
+          type: :enrollable,
+          open_and_free: true,
+          start_date: yesterday(),
+          end_date: tomorrow()
+        )
+
       s2 = insert(:section, type: :enrollable, status: :deleted)
 
       {:ok, view, _html} = live(conn, @live_view_index_route)
@@ -139,7 +140,14 @@ defmodule OliWeb.Sections.AdminIndexLiveTest do
       institution = insert(:institution, name: "OtherInsti")
       blueprint = insert(:section, title: "TestSection")
 
-      s1 = insert(:section, type: :enrollable, base_project: other_project, title: "Testing", blueprint: blueprint)
+      s1 =
+        insert(:section,
+          type: :enrollable,
+          base_project: other_project,
+          title: "Testing",
+          blueprint: blueprint
+        )
+
       s2 = insert(:section, type: :enrollable, base_project: project, institution: institution)
 
       {:ok, view, _html} = live(conn, @live_view_index_route)
@@ -180,23 +188,23 @@ defmodule OliWeb.Sections.AdminIndexLiveTest do
 
     test "applies sorting", %{conn: conn} do
       project = insert(:project, title: "Project", authors: [])
-      s1 = insert(:section, type: :enrollable, amount: Money.new(:USD, 100000))
+      s1 = insert(:section, type: :enrollable, amount: Money.new(:USD, 100_000))
       s2 = insert(:section, type: :enrollable, base_project: project)
 
       {:ok, view, _html} = live(conn, @live_view_index_route)
 
       # by title
       assert view
-      |> element("tr:first-child > td:first-child")
-      |> render() =~ s1.title
+             |> element("tr:first-child > td:first-child")
+             |> render() =~ s1.title
 
       view
       |> element("th[phx-click=\"paged_table_sort\"]", "Title")
       |> render_click(%{sort_by: "title"})
 
       assert view
-      |> element("tr:first-child > td:first-child")
-      |> render() =~ s2.title
+             |> element("tr:first-child > td:first-child")
+             |> render() =~ s2.title
 
       # by cost
       view
@@ -204,16 +212,16 @@ defmodule OliWeb.Sections.AdminIndexLiveTest do
       |> render_click(%{sort_by: "requires_payment"})
 
       assert view
-      |> element("tr:first-child > td:first-child")
-      |> render() =~ s2.title
+             |> element("tr:first-child > td:first-child")
+             |> render() =~ s2.title
 
       view
       |> element("th[phx-click=\"paged_table_sort\"]", "Cost")
       |> render_click(%{sort_by: "requires_payment"})
 
       assert view
-      |> element("tr:first-child > td:first-child")
-      |> render() =~ s1.title
+             |> element("tr:first-child > td:first-child")
+             |> render() =~ s1.title
 
       # by instructor
       user = insert(:user, name: "Instructor")
@@ -224,16 +232,16 @@ defmodule OliWeb.Sections.AdminIndexLiveTest do
       |> render_click(%{sort_by: "instructor"})
 
       assert view
-      |> element("tr:first-child > td:first-child")
-      |> render() =~ s2.title
+             |> element("tr:first-child > td:first-child")
+             |> render() =~ s2.title
 
       view
       |> element("th[phx-click=\"paged_table_sort\"]", "Instructor")
       |> render_click(%{sort_by: "instructor"})
 
       assert view
-      |> element("tr:first-child > td:first-child")
-      |> render() =~ s1.title
+             |> element("tr:first-child > td:first-child")
+             |> render() =~ s1.title
     end
 
     test "applies paging", %{conn: conn} do

--- a/test/oli_web/live/sections/edit_live_test.exs
+++ b/test/oli_web/live/sections/edit_live_test.exs
@@ -1,5 +1,5 @@
 defmodule OliWeb.Sections.EditLiveTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   use OliWeb.ConnCase
 
   import Phoenix.LiveViewTest

--- a/test/oli_web/live/sections/invite_view_test.exs
+++ b/test/oli_web/live/sections/invite_view_test.exs
@@ -1,5 +1,5 @@
 defmodule OliWeb.Sections.InviteViewTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   use OliWeb.ConnCase
 
   import Phoenix.LiveViewTest

--- a/test/oli_web/live/sections/overview_live_test.exs
+++ b/test/oli_web/live/sections/overview_live_test.exs
@@ -1,5 +1,5 @@
 defmodule OliWeb.Sections.OverviewLiveTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   use OliWeb.ConnCase
 
   import Phoenix.LiveViewTest

--- a/test/oli_web/live/select_source_live_test.exs
+++ b/test/oli_web/live/select_source_live_test.exs
@@ -1,5 +1,5 @@
 defmodule OliWeb.SelectSourceTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   use OliWeb.ConnCase
 
   alias Oli.Delivery.Sections

--- a/test/oli_web/live/student_view_live_test.exs
+++ b/test/oli_web/live/student_view_live_test.exs
@@ -1,5 +1,5 @@
 defmodule OliWeb.StudentViewLiveTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   use OliWeb.ConnCase
 
   import Phoenix.LiveViewTest
@@ -34,7 +34,7 @@ defmodule OliWeb.StudentViewLiveTest do
 
     test "redirects to enroll page when accessing the student view", %{
       conn: conn,
-      section: section,
+      section: section
     } do
       user = insert(:user)
       conn = get(conn, live_view_student_view_route(section.slug, user.id))
@@ -59,7 +59,7 @@ defmodule OliWeb.StudentViewLiveTest do
       9.10 => 9.10,
       5 => 5.0,
       0.0 => 0.0,
-      0 => 0.0,
+      0 => 0.0
     }
 
     for {score, expected_score} <- scores_expected_format do
@@ -90,12 +90,13 @@ defmodule OliWeb.StudentViewLiveTest do
         assert html =~ "Progress Details for #{user.family_name}, #{user.given_name}"
 
         assert view
-          |> element("tr[id=\"0\" phx-value-id=\"0\"]")
-          |> render =~ "#{@expected_score} / #{@out_of}"
+               |> element("tr[id=\"0\" phx-value-id=\"0\"]")
+               |> render =~ "#{@expected_score} / #{@out_of}"
 
         assert view
-        |> element("tr[id=\"0\" phx-value-id=\"0\"]")
-        |> render =~ "<a href=\"/sections/#{section.slug}/progress/#{user.id}/#{page_revision.resource.id}\">#{page_revision.title}</a>"
+               |> element("tr[id=\"0\" phx-value-id=\"0\"]")
+               |> render =~
+                 "<a href=\"/sections/#{section.slug}/progress/#{user.id}/#{page_revision.resource.id}\">#{page_revision.title}</a>"
       end
     end
   end

--- a/test/oli_web/live/system_message_live_test.exs
+++ b/test/oli_web/live/system_message_live_test.exs
@@ -1,5 +1,5 @@
 defmodule OliWeb.SystemMessageLiveTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   use OliWeb.ConnCase
 
   import Phoenix.LiveViewTest

--- a/test/oli_web/plugs/redirect_plug_test.exs
+++ b/test/oli_web/plugs/redirect_plug_test.exs
@@ -1,6 +1,6 @@
 defmodule OliWeb.Plugs.RedirectTest do
   # use ExUnit.Case, async: true
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias OliWeb.Plugs.Redirect
 


### PR DESCRIPTION
This PR reduces `mix test` time by 15% aprox by configuring tests to run concurrently with tests of other modules (see [docs](https://hexdocs.pm/ex_unit/1.13.4/ExUnit.Case.html))

**With concurrency configured:**
![with_concurrency](https://user-images.githubusercontent.com/74839302/222565059-fe8805cd-0e0d-417f-a314-d6a022f54477.png)

**Without concurrency configured:**
![without_concurrency](https://user-images.githubusercontent.com/74839302/222565123-095949f9-b827-4d21-8901-0206888dd68b.png)

