### PR TITLE
[FEATURE] [MER-1774] Section does not show access to Explorations

### DIFF
--- a/lib/oli/delivery.ex
+++ b/lib/oli/delivery.ex
@@ -7,6 +7,7 @@ defmodule Oli.Delivery do
   alias Oli.Lti.LtiParams
   alias Oli.Publishing
   alias Oli.Repo
+  alias Oli.Publishing.DeliveryResolver
 
   import Ecto.Query, warn: false
   import Oli.Utils
@@ -234,6 +235,53 @@ defmodule Oli.Delivery do
     }) do
       nil -> create_delivery_setting(attrs)
       ds -> update_delivery_setting(ds, attrs)
+    end
+  end
+
+  defp contains_explorations(section_slug) do
+    page_id = Oli.Resources.ResourceType.get_id_by_type("page")
+
+    Repo.one(
+      from([sr: sr, rev: rev] in DeliveryResolver.section_resource_revisions(section_slug),
+        where:
+          rev.purpose == :application and rev.deleted == false and
+            rev.resource_type_id == ^page_id and
+            sr.numbering_level > 0,
+        select: rev.id,
+        limit: 1
+      )
+    )
+    |> case do
+      nil -> false
+      _ -> true
+    end
+  end
+
+  defp update_contains_explorations(section_slug, value) do
+    result =
+      from(
+        s in Section,
+        update: [set: [contains_explorations: ^value]],
+        where: s.slug == ^section_slug
+      )
+      |> Repo.update_all([])
+
+    {:ok, result}
+  end
+
+  def maybe_update_section_contains_explorations(%Section{
+        slug: section_slug,
+        contains_explorations: contains_explorations
+      }) do
+    case {contains_explorations(section_slug), contains_explorations} do
+      {true, false} ->
+        update_contains_explorations(section_slug, true)
+
+      {false, true} ->
+        update_contains_explorations(section_slug, false)
+
+      _ ->
+        {:ok, "No need to update records"}
     end
   end
 end

--- a/lib/oli/delivery/sections/blueprint.ex
+++ b/lib/oli/delivery/sections/blueprint.ex
@@ -5,6 +5,7 @@ defmodule Oli.Delivery.Sections.Blueprint do
   alias Oli.Authoring.Course.Project
   alias Oli.Authoring.Course.ProjectVisibility
   alias Oli.Publishing.Publications.Publication
+  alias Oli.Delivery
   alias Oli.Delivery.Sections.Section
   alias Oli.Delivery.Sections
   alias Oli.Groups.CommunityVisibility
@@ -158,8 +159,12 @@ defmodule Oli.Delivery.Sections.Blueprint do
                 Oli.Publishing.get_latest_published_publication_by_slug(base_project_slug)
 
               case Sections.create_section_resources(blueprint, publication, hierarchy_definition) do
-                {:ok, section} -> section
-                {:error, e} -> Repo.rollback(e)
+                {:ok, section} ->
+                  {:ok, section} = Delivery.maybe_update_section_contains_explorations(section)
+                  section
+
+                {:error, e} ->
+                  Repo.rollback(e)
               end
 
             {:error, e} ->
@@ -215,7 +220,8 @@ defmodule Oli.Delivery.Sections.Blueprint do
           institution_id: nil,
           brand_id: nil,
           delivery_policy_id: nil,
-          customizations: custom_labels
+          customizations: custom_labels,
+          contains_explorations: section.contains_explorations
         },
         attrs
       )

--- a/lib/oli/delivery/sections/section.ex
+++ b/lib/oli/delivery/sections/section.ex
@@ -57,6 +57,7 @@ defmodule Oli.Delivery.Sections.Section do
     field(:resource_gating_index, :map, default: %{}, null: false)
     field(:previous_next_index, :map, default: nil, null: true)
     field(:display_curriculum_item_numbering, :boolean, default: true)
+    field(:contains_explorations, :boolean, default: false)
 
     embeds_one(:customizations, CustomLabels, on_replace: :delete)
 
@@ -146,7 +147,8 @@ defmodule Oli.Delivery.Sections.Section do
       :requires_enrollment,
       :skip_email_verification,
       :publisher_id,
-      :display_curriculum_item_numbering
+      :display_curriculum_item_numbering,
+      :contains_explorations
     ])
     |> cast_embed(:customizations, required: false)
     |> validate_required([

--- a/lib/oli/utils/db_seeder.ex
+++ b/lib/oli/utils/db_seeder.ex
@@ -580,7 +580,8 @@ defmodule Oli.Seeder do
       title: "some title",
       context_id: UUID.uuid4(),
       base_project_id: map.project.id,
-      institution_id: map.institution.id
+      institution_id: map.institution.id,
+      contains_explorations: map[:contains_explorations] || false
     }
 
     {:ok, section} =

--- a/lib/oli_web/components/delivery/nav_sidebar.ex
+++ b/lib/oli_web/components/delivery/nav_sidebar.ex
@@ -9,6 +9,7 @@ defmodule OliWeb.Components.Delivery.NavSidebar do
   alias Oli.Branding.Brand
   alias OliWeb.Components.Delivery.UserAccountMenu
   alias Oli.Delivery.Sections
+  alias Oli.Delivery.Sections.Section
 
   slot :inner_block, required: true
 
@@ -38,53 +39,9 @@ defmodule OliWeb.Components.Delivery.NavSidebar do
       |> assign(
         :links,
         if is_preview_mode?(assigns) do
-          [
-            %{
-              name: "Home",
-              href: "#",
-              active: is_active(path_info, :overview)
-            },
-            %{name: "Course Content", href: "#", active: is_active(path_info, :content)},
-            %{name: "Discussion", href: "#", active: is_active(path_info, :discussion)},
-            %{name: "Assignments", href: "#", active: is_active(path_info, "")},
-            %{
-              name: "Exploration",
-              href: "#",
-              active: is_active(path_info, :exploration)
-            }
-          ]
+          get_preview_links(assigns.section, path_info)
         else
-          hierarchy =
-            assigns[:section]
-            |> Oli.Repo.preload([:root_section_resource])
-            |> Sections.build_hierarchy()
-
-          [
-            %{
-              name: "Home",
-              href: home_url(assigns),
-              active: is_active(path_info, :overview)
-            },
-            %{
-              name: "Course Content",
-              popout: %{
-                component: "Components.CourseContentOutline",
-                props: %{hierarchy: hierarchy, sectionSlug: assigns[:section].slug}
-              },
-              active: is_active(path_info, :content)
-            },
-            %{
-              name: "Discussion",
-              href: discussion_url(assigns),
-              active: is_active(path_info, :discussion)
-            },
-            %{name: "Assignments", href: "#", active: is_active(path_info, "")},
-            %{
-              name: "Exploration",
-              href: exploration_url(assigns),
-              active: is_active(path_info, :exploration)
-            }
-          ]
+          get_links(assigns, path_info)
         end
       )
       |> UserAccountMenu.user_account_menu_assigns()
@@ -104,6 +61,100 @@ defmodule OliWeb.Components.Delivery.NavSidebar do
         }) %>
       </div>
     """
+  end
+
+  defp get_preview_links(%Section{contains_explorations: true}, path_info) do
+    [
+      %{
+        name: "Home",
+        href: "#",
+        active: is_active(path_info, :overview)
+      },
+      %{name: "Course Content", href: "#", active: is_active(path_info, :content)},
+      %{name: "Discussion", href: "#", active: is_active(path_info, :discussion)},
+      %{name: "Assignments", href: "#", active: is_active(path_info, "")},
+      %{
+        name: "Exploration",
+        href: "#",
+        active: is_active(path_info, :exploration)
+      }
+    ]
+  end
+
+  defp get_preview_links(%Section{contains_explorations: false}, path_info) do
+    [
+      %{
+        name: "Home",
+        href: "#",
+        active: is_active(path_info, :overview)
+      },
+      %{name: "Course Content", href: "#", active: is_active(path_info, :content)},
+      %{name: "Discussion", href: "#", active: is_active(path_info, :discussion)},
+      %{name: "Assignments", href: "#", active: is_active(path_info, "")}
+    ]
+  end
+
+  defp get_links(%{section: %{contains_explorations: true}} = assigns, path_info) do
+    hierarchy =
+      assigns[:section]
+      |> Oli.Repo.preload([:root_section_resource])
+      |> Sections.build_hierarchy()
+
+    [
+      %{
+        name: "Home",
+        href: home_url(assigns),
+        active: is_active(path_info, :overview)
+      },
+      %{
+        name: "Course Content",
+        popout: %{
+          component: "Components.CourseContentOutline",
+          props: %{hierarchy: hierarchy, sectionSlug: assigns[:section].slug}
+        },
+        active: is_active(path_info, :content)
+      },
+      %{
+        name: "Discussion",
+        href: discussion_url(assigns),
+        active: is_active(path_info, :discussion)
+      },
+      %{name: "Assignments", href: "#", active: is_active(path_info, "")},
+      %{
+        name: "Exploration",
+        href: exploration_url(assigns),
+        active: is_active(path_info, :exploration)
+      }
+    ]
+  end
+
+  defp get_links(%{section: %{contains_explorations: false}} = assigns, path_info) do
+    hierarchy =
+      assigns[:section]
+      |> Oli.Repo.preload([:root_section_resource])
+      |> Sections.build_hierarchy()
+
+    [
+      %{
+        name: "Home",
+        href: home_url(assigns),
+        active: is_active(path_info, :overview)
+      },
+      %{
+        name: "Course Content",
+        popout: %{
+          component: "Components.CourseContentOutline",
+          props: %{hierarchy: hierarchy, sectionSlug: assigns[:section].slug}
+        },
+        active: is_active(path_info, :content)
+      },
+      %{
+        name: "Discussion",
+        href: discussion_url(assigns),
+        active: is_active(path_info, :discussion)
+      },
+      %{name: "Assignments", href: "#", active: is_active(path_info, "")}
+    ]
   end
 
   defp logo_details(assigns) do

--- a/lib/oli_web/components/delivery/nav_sidebar.ex
+++ b/lib/oli_web/components/delivery/nav_sidebar.ex
@@ -39,7 +39,7 @@ defmodule OliWeb.Components.Delivery.NavSidebar do
       |> assign(
         :links,
         if is_preview_mode?(assigns) do
-          get_preview_links(assigns.section, path_info)
+          get_preview_links(assigns[:section], path_info)
         else
           get_links(assigns, path_info)
         end
@@ -81,7 +81,7 @@ defmodule OliWeb.Components.Delivery.NavSidebar do
     ]
   end
 
-  defp get_preview_links(%Section{contains_explorations: false}, path_info) do
+  defp get_preview_links(_, path_info) do
     [
       %{
         name: "Home",
@@ -128,7 +128,7 @@ defmodule OliWeb.Components.Delivery.NavSidebar do
     ]
   end
 
-  defp get_links(%{section: %{contains_explorations: false}} = assigns, path_info) do
+  defp get_links(assigns, path_info) do
     hierarchy =
       assigns[:section]
       |> Oli.Repo.preload([:root_section_resource])

--- a/lib/oli_web/controllers/open_and_free_controller.ex
+++ b/lib/oli_web/controllers/open_and_free_controller.ex
@@ -2,6 +2,7 @@ defmodule OliWeb.OpenAndFreeController do
   use OliWeb, :controller
 
   alias Oli.{Repo, Publishing, Branding}
+  alias Oli.Delivery
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.Section
   alias Oli.Authoring.Course
@@ -361,8 +362,9 @@ defmodule OliWeb.OpenAndFreeController do
       with {:ok, section} <- Sections.create_section(section_params),
            {:ok, section} <- Sections.create_section_resources(section, publication),
            {:ok, _} <- Sections.rebuild_contained_pages(section),
-           {:ok, _enrollment} <- enroll(conn, section) do
-        section
+           {:ok, _enrollment} <- enroll(conn, section),
+           {:ok, updated_section} <- Delivery.maybe_update_section_contains_explorations(section) do
+        updated_section
       else
         {:error, changeset} -> Repo.rollback(changeset)
       end

--- a/lib/oli_web/plugs/require_exploration_activities.ex
+++ b/lib/oli_web/plugs/require_exploration_activities.ex
@@ -9,16 +9,20 @@ defmodule Oli.Plugs.RequireExplorationPages do
   def call(conn, _opts) do
     case conn.path_params do
       %{"revision_slug" => revision_slug, "section_slug" => section_slug} ->
-        case Resources.get_resource_from_slug(revision_slug) do
-          nil ->
-            conn
+        if conn.assigns.section.contains_explorations do
+          case Resources.get_resource_from_slug(revision_slug) do
+            nil ->
+              conn
 
-          %{id: id} ->
-            conn
-            |> assign(
-              :exploration_pages,
-              DeliveryResolver.targeted_via_related_to(section_slug, id)
-            )
+            %{id: id} ->
+              conn
+              |> assign(
+                :exploration_pages,
+                DeliveryResolver.targeted_via_related_to(section_slug, id)
+              )
+          end
+        else
+          conn
         end
 
       _ ->

--- a/lib/oli_web/templates/layout/page.html.heex
+++ b/lib/oli_web/templates/layout/page.html.heex
@@ -8,7 +8,9 @@
         <script type="text/javascript" src={Routes.static_path(@conn, "/js/" <> script)}></script>
       <% end %>
 
-      <Components.Delivery.ExplorationShade.exploration_shade exploration_pages={Map.get(@conn.assigns, :exploration_pages, nil)} />
+      <%= if assigns.section.contains_explorations do%>
+        <Components.Delivery.ExplorationShade.exploration_shade exploration_pages={Map.get(@conn.assigns, :exploration_pages, nil)} />
+      <% end %>
 
       <div class="md:container md:mx-auto md:px-10 md:mt-3 md:mb-5">
         <div class="flex flex-col lg:flex-row gap-4">

--- a/lib/oli_web/templates/page_delivery/discussion.html.heex
+++ b/lib/oli_web/templates/page_delivery/discussion.html.heex
@@ -3,7 +3,9 @@
   <div class="relative flex-1 flex flex-col pb-[60px]">
     <%= render OliWeb.LayoutView, "_pay_early.html", assigns %>
 
-    <Components.Delivery.ExplorationShade.exploration_shade />
+    <%= if assigns.section.contains_explorations do%>
+      <Components.Delivery.ExplorationShade.exploration_shade />
+    <% end %>
 
     <div class="container px-0 sm:px-10 mx-auto mt-3 mb-5 flex flex-col">
       <%= live_render @conn, Components.Delivery.DiscussionBoard, session: %{ "section_id" => @section_id } %>

--- a/lib/oli_web/templates/page_delivery/exploration.html.heex
+++ b/lib/oli_web/templates/page_delivery/exploration.html.heex
@@ -3,7 +3,9 @@
   <div class="relative flex-1 flex flex-col pb-[60px]">
     <%= render OliWeb.LayoutView, "_pay_early.html", assigns %>
 
-    <Components.Delivery.ExplorationShade.exploration_shade />
+    <%= if assigns.section.contains_explorations do%>
+      <Components.Delivery.ExplorationShade.exploration_shade />
+    <% end %>
 
     <div class="container mx-auto px-10 mt-3 mb-5 flex flex-col">
       <%= live_render @conn, Components.Delivery.ExplorationList, session: %{ "section_slug" => @section_slug } %>

--- a/priv/repo/migrations/20230302190535_contains_explorations.exs
+++ b/priv/repo/migrations/20230302190535_contains_explorations.exs
@@ -1,0 +1,22 @@
+defmodule Oli.Repo.Migrations.ContainsExplorations do
+  use Ecto.Migration
+
+  def up do
+    alter table(:sections) do
+      add :contains_explorations, :boolean, default: false
+    end
+
+    flush()
+
+    execute "UPDATE sections SET contains_explorations = true WHERE id in (SELECT sec.id FROM sections as sec
+    JOIN section_resources as sr on sr.section_id = sec.id
+    JOIN revisions as rev on rev.resource_id = sr.resource_id
+    WHERE rev.purpose = 'application' and rev.deleted = false and rev.resource_type_id = 1 group by sec.id)"
+  end
+
+  def down do
+    alter table(:sections) do
+      remove :contains_explorations, :boolean, default: false
+    end
+  end
+end

--- a/test/oli/delivery_test.exs
+++ b/test/oli/delivery_test.exs
@@ -89,5 +89,24 @@ defmodule Oli.DeliveryTest do
       assert delivery_setting.id == updated_delivery_setting.id
       assert updated_delivery_setting.collab_space_config.status == :archived
     end
+
+    test "maybe_update_section_contains_explorations/1 update contains_explorations field" do
+      {:ok,
+       project: _project,
+       section: section,
+       page_revision: _page_revision,
+       other_revision: other_revision} = project_section_revisions(%{})
+
+      author = insert(:author)
+
+      assert section.contains_explorations
+
+      Oli.Resources.update_revision(other_revision, %{purpose: :foundation, author_id: author.id})
+
+      Delivery.maybe_update_section_contains_explorations(section)
+      section_without_explorations = Oli.Delivery.Sections.get_section_by_slug(section.slug)
+
+      refute section_without_explorations.contains_explorations
+    end
   end
 end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -764,7 +764,8 @@ defmodule Oli.TestHelpers do
         context_id: UUID.uuid4(),
         open_and_free: true,
         registration_open: true,
-        type: :enrollable
+        type: :enrollable,
+        contains_explorations: true
       )
 
     {:ok, section} = Sections.create_section_resources(section, publication)


### PR DESCRIPTION
[MER-1774](https://eliterate.atlassian.net/browse/MER-1774)

This PR adds functionality to not show access to "Explorations" when the section does not have any resource of this type. 
When this happens, both the access from the left sidebar and the Windowshade are hidden. 

Also, thanks to the contribution of @nicocirio, this PR includes the fix for the error that happens when the last resource is removed from the content of a section.



[MER-1774]: https://eliterate.atlassian.net/browse/MER-1774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ