### PR TITLE
Refactor part property editor

### DIFF
--- a/assets/src/apps/authoring/components/RightMenu/PartPropertyEditor.tsx
+++ b/assets/src/apps/authoring/components/RightMenu/PartPropertyEditor.tsx
@@ -1,0 +1,278 @@
+import React, { useCallback, useMemo } from 'react';
+import { JSONSchema7 } from 'json-schema';
+import { updatePart } from 'apps/authoring/store/parts/actions/updatePart';
+import partSchema, {
+  partUiSchema,
+  transformModelToSchema as transformPartModelToSchema,
+  transformSchemaToModel as transformPartSchemaToModel,
+} from '../PropertyEditor/schemas/part';
+import { Button, ButtonGroup, ButtonToolbar } from 'react-bootstrap';
+import { useDispatch } from 'react-redux';
+import { isEqual } from 'lodash';
+import { clone } from '../../../../utils/common';
+import { saveActivity } from '../../store/activities/actions/saveActivity';
+import { setCopiedPart, setRightPanelActiveTab } from '../../store/app/slice';
+import { setCurrentSelection } from '../../store/parts/slice';
+import ConfirmDelete from '../Modal/DeleteConfirmationModal';
+import CompJsonEditor from '../PropertyEditor/custom/CompJsonEditor';
+import PropertyEditor from '../PropertyEditor/PropertyEditor';
+import { RightPanelTabs } from './RightMenu';
+import { useToggle } from '../../../../components/hooks/useToggle';
+import AccordionTemplate from '../PropertyEditor/custom/AccordionTemplate';
+import { IActivity } from '../../../delivery/store/features/activities/slice';
+
+interface Props {
+  currentActivity: IActivity;
+  currentActivityTree: IActivity[];
+  currentPartSelection: string;
+  existingIds: string[];
+}
+
+const findPartByIdInActivity = (currentActivity: any, targetPartId: string) => {
+  if (!currentActivity || !targetPartId) return null;
+  return currentActivity.content?.partsLayout.find((part: any) => part.id === targetPartId);
+};
+
+const getCurrentPartInstance = (type: string) => {
+  const PartClass = customElements.get(type);
+  if (PartClass) {
+    return new PartClass() as any;
+  }
+  return null;
+};
+
+const getPartDef = (currentActivityTree: any, currentPartSelection: any) => {
+  let partDef;
+  for (let i = 0; i < currentActivityTree.length; i++) {
+    const activity = currentActivityTree[i];
+    partDef = activity.content?.partsLayout.find((part: any) => part.id === currentPartSelection);
+    if (partDef) {
+      break;
+    }
+  }
+  return partDef;
+};
+
+const getComponentData = (instance: any, partDef: any) => {
+  if (!instance || !partDef) return null;
+  const data = clone(partDef);
+  if (instance.transformModelToSchema) {
+    // because the part schema below only knows about the "custom" block
+    data.custom = { ...data.custom, ...instance.transformModelToSchema(partDef.custom) };
+  }
+  return transformPartModelToSchema(data);
+};
+
+const getComponentSchema = (instance: any): JSONSchema7 => {
+  // schema
+  if (instance && instance.getSchema) {
+    const customPartSchema = instance.getSchema();
+    const newSchema: any = {
+      ...partSchema,
+      properties: {
+        ...partSchema.properties,
+        custom: { type: 'object', properties: { ...customPartSchema } },
+      },
+    };
+    if (customPartSchema.definitions) {
+      newSchema.definitions = customPartSchema.definitions;
+      delete newSchema.properties.custom.properties.definitions;
+    }
+    return newSchema;
+  }
+
+  return partSchema; // default schema for components that don't specify.
+};
+
+const getComponentUISchema = (instance: any) => {
+  // ui schema
+  if (instance && instance.getUiSchema) {
+    const customPartUiSchema = instance.getUiSchema();
+    const newUiSchema = {
+      ...partUiSchema,
+      custom: {
+        'ui:ObjectFieldTemplate': AccordionTemplate,
+        'ui:title': 'Custom',
+        ...customPartUiSchema,
+      },
+    };
+    return newUiSchema;
+  }
+  return partUiSchema; // default ui schema for components that don't specify.
+};
+
+export const PartPropertyEditor: React.FC<Props> = ({
+  currentActivity,
+  currentActivityTree,
+  currentPartSelection,
+  existingIds,
+}) => {
+  const dispatch = useDispatch();
+  const [shouldShowConfirmDelete, , showConfirmDelete, hideConfirmDelete] = useToggle(false);
+
+  const partDef = useMemo(
+    () => getPartDef(currentActivityTree, currentPartSelection),
+    [currentActivityTree, currentPartSelection],
+  );
+
+  const currentPartInstance = useMemo(() => getCurrentPartInstance(partDef?.type), [partDef?.type]);
+
+  const selectedPartDef = useMemo(
+    () => findPartByIdInActivity(currentActivity, currentPartSelection),
+    [currentActivity, currentPartSelection],
+  );
+
+  const currentComponentData = useMemo(
+    () => getComponentData(currentPartInstance, partDef),
+    [currentPartInstance, partDef],
+  );
+
+  const componentSchema = useMemo(
+    () => getComponentSchema(currentPartInstance),
+    [currentPartInstance],
+  );
+
+  const componentUiSchema = useMemo(
+    () => getComponentUISchema(currentPartInstance),
+    [currentPartInstance],
+  );
+
+  const handleDeleteComponent = useCallback(() => {
+    // only allow delete of "owned" parts
+    // TODO: disable/hide button if that is not owned
+    if (!currentActivity || !currentPartSelection) {
+      return;
+    }
+    const partDef = currentActivity.content?.partsLayout.find(
+      (part: any) => part.id === currentPartSelection,
+    );
+    if (!partDef) {
+      console.warn(`Part with id ${currentPartSelection} not found on this screen`);
+      return;
+    }
+    const cloneActivity = clone(currentActivity);
+    cloneActivity.authoring.parts = cloneActivity.authoring.parts.filter(
+      (part: any) => part.id !== currentPartSelection,
+    );
+    cloneActivity.content.partsLayout = cloneActivity.content.partsLayout.filter(
+      (part: any) => part.id !== currentPartSelection,
+    );
+    dispatch(saveActivity({ activity: cloneActivity, undoable: true }));
+    dispatch(setCurrentSelection({ selection: '' }));
+    dispatch(setRightPanelActiveTab({ rightPanelActiveTab: RightPanelTabs.SCREEN }));
+  }, [currentActivity, currentPartSelection, dispatch]);
+
+  const DeleteComponentHandler = () => {
+    handleDeleteComponent();
+    showConfirmDelete();
+  };
+
+  const handleCopyComponent = useCallback(() => {
+    if (currentActivity && currentPartSelection) {
+      const partDef = findPartByIdInActivity(currentActivity, currentPartSelection);
+
+      if (!partDef) {
+        console.warn(`Part with id ${currentPartSelection} not found on this screen`);
+        return;
+      }
+      dispatch(setCopiedPart({ copiedPart: partDef }));
+    }
+  }, [currentActivity, currentPartSelection, dispatch]);
+
+  const handleEditComponentJson = (newJson: any) => {
+    const cloneActivity = clone(currentActivity);
+    const ogPart = cloneActivity.content?.partsLayout.find(
+      (part: any) => part.id === currentPartSelection,
+    );
+    if (!ogPart) {
+      console.warn(
+        'couldnt find part in current activity, most like lives on a layer; you need to update they layer copy directly',
+      );
+      return;
+    }
+    if (newJson.id !== '' && newJson.id !== ogPart.id) {
+      ogPart.id = newJson.id;
+      // in case the id changes, update the selection
+      dispatch(setCurrentSelection({ selection: newJson.id }));
+    }
+    ogPart.custom = newJson.custom;
+    if (!isEqual(cloneActivity, currentActivity)) {
+      dispatch(saveActivity({ activity: cloneActivity, undoable: true }));
+    }
+  };
+
+  const componentPropertyChangeHandler = useCallback(
+    (properties: any) => {
+      let modelChanges = properties;
+
+      // do not allow saving of bad ID
+      if (!modelChanges.id || !modelChanges.id.trim()) {
+        modelChanges.id = currentPartSelection;
+      }
+
+      modelChanges = transformPartSchemaToModel(modelChanges);
+      if (currentPartInstance && currentPartInstance.transformSchemaToModel) {
+        modelChanges.custom = {
+          ...modelChanges.custom,
+          ...currentPartInstance.transformSchemaToModel(modelChanges.custom),
+        };
+      }
+
+      /* console.log('COMPONENT PROP CHANGED', { properties, modelChanges }); */
+      dispatch(
+        updatePart({
+          activityId: String(currentActivity.id),
+          partId: currentPartSelection,
+          changes: modelChanges,
+        }),
+      );
+
+      // in case the id changes, update the selection
+      dispatch(setCurrentSelection({ selection: modelChanges.id }));
+    },
+    [currentActivity.id, currentPartInstance, currentPartSelection, dispatch],
+  );
+
+  if (!partDef) return null;
+
+  return (
+    <div className="component-tab p-3 overflow-hidden">
+      <ButtonToolbar aria-label="Component Tools">
+        <ButtonGroup className="me-2" aria-label="First group">
+          <div className="input-group-prepend">
+            <div className="input-group-text" id="btnGroupAddon">
+              <i className="fas fa-wrench mr-2" />
+            </div>
+          </div>
+          <Button>
+            <i className="fas fa-copy mr-2" onClick={() => handleCopyComponent()} />
+          </Button>
+          {selectedPartDef && (
+            <CompJsonEditor
+              onChange={handleEditComponentJson}
+              jsonValue={selectedPartDef}
+              existingPartIds={existingIds}
+            />
+          )}
+          <Button variant="danger" onClick={showConfirmDelete}>
+            <i className="fas fa-trash mr-2" />
+          </Button>
+          <ConfirmDelete
+            show={shouldShowConfirmDelete}
+            elementType="Component"
+            elementName={currentComponentData?.id}
+            deleteHandler={DeleteComponentHandler}
+            cancelHandler={hideConfirmDelete}
+          />
+        </ButtonGroup>
+      </ButtonToolbar>
+      <PropertyEditor
+        key={currentComponentData.id}
+        schema={componentSchema}
+        uiSchema={componentUiSchema}
+        value={currentComponentData}
+        onChangeHandler={componentPropertyChangeHandler}
+      />
+    </div>
+  );
+};

--- a/assets/src/apps/authoring/components/RightMenu/RightMenu.tsx
+++ b/assets/src/apps/authoring/components/RightMenu/RightMenu.tsx
@@ -1,17 +1,17 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import { UiSchema } from '@rjsf/core';
-import { updatePart } from 'apps/authoring/store/parts/actions/updatePart';
 import { JSONSchema7 } from 'json-schema';
-import { isEqual } from 'lodash';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Button, ButtonGroup, ButtonToolbar, Tab, Tabs } from 'react-bootstrap';
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { Tab, Tabs } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
 import { clone } from 'utils/common';
+
 import {
   selectRightPanelActiveTab,
-  setCopiedPart,
   setRightPanelActiveTab,
 } from '../../../authoring/store/app/slice';
+
 import {
   findInSequence,
   SequenceBank,
@@ -27,10 +27,8 @@ import { saveActivity } from '../../store/activities/actions/saveActivity';
 import { updateSequenceItem } from '../../store/groups/layouts/deck/actions/updateSequenceItemFromActivity';
 import { savePage } from '../../store/page/actions/savePage';
 import { selectState as selectPageState } from '../../store/page/slice';
-import { selectCurrentSelection, setCurrentSelection } from '../../store/parts/slice';
-import ConfirmDelete from '../Modal/DeleteConfirmationModal';
-import AccordionTemplate from '../PropertyEditor/custom/AccordionTemplate';
-import CompJsonEditor from '../PropertyEditor/custom/CompJsonEditor';
+import { selectCurrentSelection } from '../../store/parts/slice';
+
 import PropertyEditor from '../PropertyEditor/PropertyEditor';
 import bankSchema, {
   bankUiSchema,
@@ -47,16 +45,13 @@ import lessonSchema, {
   transformModelToSchema as transformLessonModel,
   transformSchemaToModel as transformLessonSchema,
 } from '../PropertyEditor/schemas/lesson';
-import partSchema, {
-  partUiSchema,
-  transformModelToSchema as transformPartModelToSchema,
-  transformSchemaToModel as transformPartSchemaToModel,
-} from '../PropertyEditor/schemas/part';
+
 import screenSchema, {
   screenUiSchema,
   transformScreenModeltoSchema,
   transformScreenSchematoModel,
 } from '../PropertyEditor/schemas/screen';
+import { PartPropertyEditor } from './PartPropertyEditor';
 
 export enum RightPanelTabs {
   LESSON = 'lesson',
@@ -73,9 +68,6 @@ const RightMenu: React.FC<any> = () => {
   const currentPartSelection = useSelector(selectCurrentSelection);
 
   // TODO: dynamically load schema from Part Component configuration
-  const [componentSchema, setComponentSchema] = useState<JSONSchema7>(partSchema);
-  const [componentUiSchema, setComponentUiSchema] = useState(partUiSchema);
-  const [currentComponent, setCurrentComponent] = useState(null);
   const currentSequenceId = useSelector(selectCurrentSequenceId);
   const sequence = useSelector(selectSequence);
   const currentSequence = findInSequence(sequence, currentSequenceId || '');
@@ -87,12 +79,6 @@ const RightMenu: React.FC<any> = () => {
   const [scrUiSchema, setScreenUiSchema] = useState<UiSchema>();
   const [questionBankData, setBankData] = useState<any>();
   const [questionBankSchema, setBankSchema] = useState<JSONSchema7>();
-  const [showConfirmDelete, setShowConfirmDelete] = useState<boolean>(false);
-
-  const selectedPartDef = useMemo(
-    () => findPartByIdInActivity(currentActivity, currentPartSelection),
-    [currentActivity, currentPartSelection],
-  );
 
   useEffect(() => {
     if (!currentActivity) {
@@ -109,10 +95,13 @@ const RightMenu: React.FC<any> = () => {
 
     setBankData(transformBankModeltoSchema(currentSequence as SequenceEntry<SequenceBank>));
     setBankSchema(bankSchema);
-    const currentIds = currentActivityTree?.reduce(
-      (acc, activity) => acc.concat(activity.content.partsLayout.map((p: any) => p.id)),
-      [],
-    );
+    const currentIds: string[] =
+      currentActivityTree?.reduce((acc, activity) => {
+        const ids: string[] = (activity.content?.partsLayout || []).map(
+          (p: { id: string }): string => p.id,
+        );
+        return acc.concat(ids);
+      }, [] as string[]) || [];
     setExistingIds(currentIds);
   }, [currentActivity, currentSequence]);
 
@@ -123,17 +112,7 @@ const RightMenu: React.FC<any> = () => {
     // TODO: any other saving or whatever
     dispatch(setRightPanelActiveTab({ rightPanelActiveTab: key }));
   };
-  const handleCopyComponent = useCallback(() => {
-    if (currentActivity && currentPartSelection) {
-      const partDef = findPartByIdInActivity(currentActivity, currentPartSelection);
 
-      if (!partDef) {
-        console.warn(`Part with id ${currentPartSelection} not found on this screen`);
-        return;
-      }
-      dispatch(setCopiedPart({ copiedPart: partDef }));
-    }
-  }, [currentActivity, currentPartSelection, dispatch]);
   const bankPropertyChangeHandler = useCallback(
     (properties: object) => {
       if (currentSequence) {
@@ -172,7 +151,7 @@ const RightMenu: React.FC<any> = () => {
         if (objectives.length === 0) {
           // Potentially removing all objectives, clear them out
           cloneActivity.objectives = {};
-        } else if (currentActivity.authoring.parts.length > 0) {
+        } else if (currentActivity.authoring?.parts && currentActivity.authoring.parts.length > 0) {
           // Adding objectives, and we have an existing part to attach them to.
           cloneActivity.objectives = {
             [currentActivity.authoring.parts[0].id]: objectives,
@@ -234,161 +213,7 @@ const RightMenu: React.FC<any> = () => {
     [currentLesson, dispatch],
   );
 
-  const [currentComponentData, setCurrentComponentData] = useState<any>();
-  const [currentPartInstance, setCurrentPartInstance] = useState<any>(null);
   const [existingIds, setExistingIds] = useState<string[]>([]);
-  useEffect(() => {
-    if (!currentPartSelection || !currentActivityTree) {
-      return;
-    }
-    let partDef;
-    for (let i = 0; i < currentActivityTree.length; i++) {
-      const activity = currentActivityTree[i];
-      partDef = activity.content?.partsLayout.find((part: any) => part.id === currentPartSelection);
-      if (partDef) {
-        break;
-      }
-    }
-    /* console.log('part selected', { partDef }); */
-    if (partDef) {
-      // part component should be registered by type as a custom element
-      const PartClass = customElements.get(partDef.type);
-      if (PartClass) {
-        const instance = new PartClass() as any;
-
-        setCurrentPartInstance(instance);
-
-        let data = clone(partDef);
-        if (instance.transformModelToSchema) {
-          // because the part schema below only knows about the "custom" block
-          data.custom = { ...data.custom, ...instance.transformModelToSchema(partDef.custom) };
-        }
-        data = transformPartModelToSchema(data);
-        setCurrentComponentData(data);
-
-        // schema
-        if (instance.getSchema) {
-          const customPartSchema = instance.getSchema();
-          const newSchema: any = {
-            ...partSchema,
-            properties: {
-              ...partSchema.properties,
-              custom: { type: 'object', properties: { ...customPartSchema } },
-            },
-          };
-          if (customPartSchema.definitions) {
-            newSchema.definitions = customPartSchema.definitions;
-            delete newSchema.properties.custom.properties.definitions;
-          }
-          setComponentSchema(newSchema);
-        }
-
-        // ui schema
-        if (instance.getUiSchema) {
-          const customPartUiSchema = instance.getUiSchema();
-          const newUiSchema = {
-            ...partUiSchema,
-            custom: {
-              'ui:ObjectFieldTemplate': AccordionTemplate,
-              'ui:title': 'Custom',
-              ...customPartUiSchema,
-            },
-          };
-          setComponentUiSchema(newUiSchema);
-        }
-      }
-      setCurrentComponent(partDef);
-    }
-    return () => {
-      setComponentSchema(partSchema);
-      setComponentUiSchema(partUiSchema);
-      setCurrentComponent(null);
-      setCurrentComponentData(null);
-      setCurrentPartInstance(null);
-    };
-  }, [currentPartSelection, currentActivityTree]);
-
-  const componentPropertyChangeHandler = useCallback(
-    (properties: any) => {
-      let modelChanges = properties;
-
-      // do not allow saving of bad ID
-      if (!modelChanges.id || !modelChanges.id.trim()) {
-        modelChanges.id = currentPartSelection;
-      }
-
-      modelChanges = transformPartSchemaToModel(modelChanges);
-      if (currentPartInstance && currentPartInstance.transformSchemaToModel) {
-        modelChanges.custom = {
-          ...modelChanges.custom,
-          ...currentPartInstance.transformSchemaToModel(modelChanges.custom),
-        };
-      }
-
-      /* console.log('COMPONENT PROP CHANGED', { properties, modelChanges }); */
-      dispatch(
-        updatePart({
-          activityId: currentActivity.id,
-          partId: currentPartSelection,
-          changes: modelChanges,
-        }),
-      );
-
-      // in case the id changes, update the selection
-      dispatch(setCurrentSelection({ selection: modelChanges.id }));
-    },
-    [currentActivity, currentPartInstance, currentPartSelection, dispatch],
-  );
-
-  const handleEditComponentJson = (newJson: any) => {
-    const cloneActivity = clone(currentActivity);
-    const ogPart = cloneActivity.content?.partsLayout.find(
-      (part: any) => part.id === currentPartSelection,
-    );
-    if (!ogPart) {
-      console.warn(
-        'couldnt find part in current activity, most like lives on a layer; you need to update they layer copy directly',
-      );
-      return;
-    }
-    if (newJson.id !== '' && newJson.id !== ogPart.id) {
-      ogPart.id = newJson.id;
-      // in case the id changes, update the selection
-      dispatch(setCurrentSelection({ selection: newJson.id }));
-    }
-    ogPart.custom = newJson.custom;
-    if (!isEqual(cloneActivity, currentActivity)) {
-      dispatch(saveActivity({ activity: cloneActivity, undoable: true }));
-    }
-  };
-  const DeleteComponentHandler = () => {
-    handleDeleteComponent();
-    setShowConfirmDelete(false);
-  };
-  const handleDeleteComponent = useCallback(() => {
-    // only allow delete of "owned" parts
-    // TODO: disable/hide button if that is not owned
-    if (!currentActivity || !currentPartSelection) {
-      return;
-    }
-    const partDef = currentActivity.content?.partsLayout.find(
-      (part: any) => part.id === currentPartSelection,
-    );
-    if (!partDef) {
-      console.warn(`Part with id ${currentPartSelection} not found on this screen`);
-      return;
-    }
-    const cloneActivity = clone(currentActivity);
-    cloneActivity.authoring.parts = cloneActivity.authoring.parts.filter(
-      (part: any) => part.id !== currentPartSelection,
-    );
-    cloneActivity.content.partsLayout = cloneActivity.content.partsLayout.filter(
-      (part: any) => part.id !== currentPartSelection,
-    );
-    dispatch(saveActivity({ activity: cloneActivity, undoable: true }));
-    dispatch(setCurrentSelection({ selection: '' }));
-    dispatch(setRightPanelActiveTab({ rightPanelActiveTab: RightPanelTabs.SCREEN }));
-  }, [currentPartSelection, currentActivity]);
 
   return (
     <Tabs
@@ -431,58 +256,18 @@ const RightMenu: React.FC<any> = () => {
           ) : null}
         </div>
       </Tab>
-      <Tab eventKey={RightPanelTabs.COMPONENT} title="Component" disabled={!currentComponent}>
-        {currentComponent && currentComponentData && (
-          <div className="component-tab p-3 overflow-hidden">
-            <ButtonToolbar aria-label="Component Tools">
-              <ButtonGroup className="me-2" aria-label="First group">
-                <Button>
-                  <i className="fas fa-wrench mr-2" />
-                </Button>
-                <Button>
-                  <i className="fas fa-cog mr-2" />
-                </Button>
-                <Button>
-                  <i className="fas fa-copy mr-2" onClick={() => handleCopyComponent()} />
-                </Button>
-                {selectedPartDef && (
-                  <CompJsonEditor
-                    onChange={handleEditComponentJson}
-                    jsonValue={selectedPartDef}
-                    existingPartIds={existingIds}
-                  />
-                )}
-                <Button variant="danger" onClick={() => setShowConfirmDelete(true)}>
-                  <i className="fas fa-trash mr-2" />
-                </Button>
-                <ConfirmDelete
-                  show={showConfirmDelete}
-                  elementType="Component"
-                  elementName={currentComponentData?.id}
-                  deleteHandler={DeleteComponentHandler}
-                  cancelHandler={() => {
-                    setShowConfirmDelete(false);
-                  }}
-                />
-              </ButtonGroup>
-            </ButtonToolbar>
-            <PropertyEditor
-              key={currentComponentData.id}
-              schema={componentSchema}
-              uiSchema={componentUiSchema}
-              value={currentComponentData}
-              onChangeHandler={componentPropertyChangeHandler}
-            />
-          </div>
+      <Tab eventKey={RightPanelTabs.COMPONENT} title="Component" disabled={!currentPartSelection}>
+        {currentPartSelection && currentActivityTree && (
+          <PartPropertyEditor
+            currentActivityTree={currentActivityTree}
+            currentActivity={currentActivity}
+            currentPartSelection={currentPartSelection}
+            existingIds={existingIds}
+          />
         )}
       </Tab>
     </Tabs>
   );
-};
-
-const findPartByIdInActivity = (currentActivity: any, targetPartId: string) => {
-  if (!currentActivity || !targetPartId) return null;
-  return currentActivity.content?.partsLayout.find((part: any) => part.id === targetPartId);
 };
 
 export default RightMenu;


### PR DESCRIPTION
The advanced-authoring right menu was getting rather long and abusing react's useEffect hook making it difficult to modify it for the new flowcharting feature. This PR refactors the part property editor.  The only user-visible change being the removal of a couple buttons that had no function.

![image](https://user-images.githubusercontent.com/333265/223495616-85d57212-1a9b-477d-9050-110116a54aa2.png)
