### PR TITLE
[Bugfix] Webcomponents now share the same global mathjax promise. [MER-1782] [MER-1779] 

### DIFF
--- a/assets/src/components/common/MathJaxFormula.tsx
+++ b/assets/src/components/common/MathJaxFormula.tsx
@@ -13,14 +13,24 @@ import { sanitizeMathML } from '../../utils/mathmlSanitizer';
 
 const cssClass = (inline: boolean) => (inline ? 'formula-inline' : 'formula');
 
-/* istanbul ignore next */
-let lastPromise = window?.MathJax?.startup?.promise;
-/* istanbul ignore next */
-if (!lastPromise) {
-  typeof jest === 'undefined' &&
-    console.warn('Load the MathJax script before this one or unpredictable rendering might occur.');
-  lastPromise = Promise.resolve();
-}
+const getGlobalLastPromise = () => {
+  /* istanbul ignore next */
+  let lastPromise = window?.MathJax?.startup?.promise;
+  /* istanbul ignore next */
+  if (!lastPromise) {
+    console.info('NO LAST PROMISE');
+    typeof jest === 'undefined' &&
+      console.warn(
+        'Load the MathJax script before this one or unpredictable rendering might occur.',
+      );
+    lastPromise = Promise.resolve();
+  }
+  return lastPromise;
+};
+
+const setGlobalLastPromise = (promise: Promise<any>) => {
+  window.MathJax.startup.promise = promise;
+};
 
 /**
  * React hook that returns a ref for you to put on your span that containst the mathjax markup.
@@ -36,7 +46,9 @@ const useMathJax = (src: string) => {
       if (node) {
         // According to the mathJax docs, you should only let 1 instance typeset at a time, so
         // that's what the promise chain here does.
+        let lastPromise = getGlobalLastPromise();
         lastPromise = lastPromise.then(() => window.MathJax.typesetPromise([node]));
+        setGlobalLastPromise(lastPromise);
       }
     },
     [src],


### PR DESCRIPTION
Bug:

1. Have a formula in a paragraph that uses the cancel extension.
2. Have a multi-input component below that. In the "explanation" section, add a formula.

Expected: Formula in 1. renders with cancels.
Actual: Formula in 1. renders, but without the cancel extension

![image](https://user-images.githubusercontent.com/333265/224369177-24406f34-4286-42f0-bb79-4878992325d3.png)

# Cause:

Mathjax only supports rendering a single window.MathJax.typesetPromise at a time.

We have a MathJaxFormula component that did some promise-handling to make sure subsequent calls to typesetPromise would wait for the first to finish. 

That code worked fine in a single JS context.

But, it relied on a global variable. If you use web-components, than a MathJaxFormula in the main app doesn't share that global variable space with the web component MathJaxFormula and the synchronization code breaks.

This PR gets rid of the global variable, and instead updates the window.MathJax.startup.promise value (which is what we were chaining off of in the first place). This effectively allows the app and webcomponents on the page to share the same value.

