### PR TITLE
[BUGFIX] Fix root_section_resource nil

### DIFF
--- a/lib/oli/delivery.ex
+++ b/lib/oli/delivery.ex
@@ -21,7 +21,8 @@ defmodule Oli.Delivery do
       Institutions.get_institution_registration_deployment(
         lti_params["iss"],
         LtiParams.peek_client_id(lti_params),
-        lti_params[@deployment_claims])
+        lti_params[@deployment_claims]
+      )
 
     Publishing.retrieve_visible_sources(user, institution)
   end
@@ -46,6 +47,7 @@ defmodule Oli.Delivery do
             "product:" <> product_id ->
               {&create_from_product/6, String.to_integer(product_id)}
           end
+
         create_fn.(id, user, institution, lti_params, deployment, registration)
 
       section ->
@@ -94,14 +96,22 @@ defmodule Oli.Delivery do
     end)
   end
 
-  defp create_from_publication(publication_id, user, institution, lti_params, deployment, registration) do
+  defp create_from_publication(
+         publication_id,
+         user,
+         institution,
+         lti_params,
+         deployment,
+         registration
+       ) do
     Repo.transaction(fn ->
       publication = Publishing.get_publication!(publication_id) |> Repo.preload(:project)
 
-      customizations = case publication.project.customizations do
-        nil -> nil
-        labels -> Map.from_struct(labels)
-      end
+      customizations =
+        case publication.project.customizations do
+          nil -> nil
+          labels -> Map.from_struct(labels)
+        end
 
       {:ok, section} =
         Sections.create_section(%{
@@ -118,7 +128,8 @@ defmodule Oli.Delivery do
           nrps_context_memberships_url: NRPS.get_context_memberships_url(lti_params),
           customizations: customizations
         })
-      {:ok, %Section{}} = Sections.create_section_resources(section, publication)
+
+      {:ok, %Section{} = section} = Sections.create_section_resources(section, publication)
       {:ok, _} = Sections.rebuild_contained_pages(section)
 
       enroll(user.id, section.id, lti_params)
@@ -231,9 +242,9 @@ defmodule Oli.Delivery do
     resource_id = attrs["resource_id"] || attrs.resource_id
 
     case get_delivery_setting_by(%{
-      section_id: section_id,
-      resource_id: resource_id
-    }) do
+           section_id: section_id,
+           resource_id: resource_id
+         }) do
       nil -> create_delivery_setting(attrs)
       ds -> update_delivery_setting(ds, attrs)
     end

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -890,10 +890,6 @@ defmodule Oli.Delivery.Sections do
         skip_resource_ids: processed_ids
       )
 
-      IO.inspect(%{root_section_resource_id: root_section_resource_id},
-        label: "%{root_section_resource_id: root_section_resource_id}"
-      )
-
       update_section(section, %{root_section_resource_id: root_section_resource_id})
       |> case do
         {:ok, section} ->
@@ -1320,17 +1316,10 @@ defmodule Oli.Delivery.Sections do
       |> Enum.map(fn rev -> rev.resource_id end)
       |> MapSet.new()
 
-    IO.inspect(section, label: "section")
-
     # From the section resources, locate the root section resource, and also create a lookup map
     # from section_resource id to each section resource.
-    root =
-      Enum.find(section_resources, fn sr -> sr.id == section.root_section_resource_id end)
-      |> IO.inspect(label: "root")
-
-    map =
-      Enum.reduce(section_resources, %{}, fn sr, map -> Map.put(map, sr.id, sr) end)
-      |> IO.inspect(label: "map")
+    root = Enum.find(section_resources, fn sr -> sr.id == section.root_section_resource_id end)
+    map = Enum.reduce(section_resources, %{}, fn sr, map -> Map.put(map, sr.id, sr) end)
 
     # Now recursively traverse the containers within the course section hierarchy, starting with the root
     # to build a map of page resource_ids to lists of the ancestor container resource_ids.  The resultant

--- a/lib/oli_web/components/delivery/course_content_panel.ex
+++ b/lib/oli_web/components/delivery/course_content_panel.ex
@@ -1,26 +1,12 @@
 defmodule OliWeb.Components.Delivery.CourseContentPanel do
   use Phoenix.Component
 
-  import OliWeb.ViewHelpers
-
-  alias OliWeb.Router.Helpers, as: Routes
   alias OliWeb.Components.Delivery.CourseOutline
 
   def course_content_panel(assigns) do
     ~H"""
       <div class="container mx-auto mt-3 mb-5">
         <div class="bg-white dark:bg-gray-800 p-8 shadow">
-          <p class="text-secondary"><%= @description %></p>
-          <%= if is_section_instructor_or_admin?(@section_slug, @current_user) and not @preview_mode do %>
-            <div class="d-flex flex-row my-2">
-              <div class="flex-1"></div>
-              <div>
-                <.link navigate={Routes.live_path(OliWeb.Endpoint, OliWeb.Delivery.InstructorDashboard.OtherLive, @section_slug)} class="btn btn-warning btn-sm ml-1">
-                  Manage Section
-                </.link>
-              </div>
-            </div>
-          <% end %>
           <div class="d-flex text-secondary border-b border-secondary mb-2">
             <div class="flex-grow-1">
               <h5>

--- a/lib/oli_web/components/delivery/instructor_dashboard.ex
+++ b/lib/oli_web/components/delivery/instructor_dashboard.ex
@@ -88,8 +88,8 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard do
           section_slug
         )
 
-      :other ->
-        Routes.other_path(
+      :manage ->
+        Routes.manage_path(
           OliWeb.Endpoint,
           :preview,
           section_slug
@@ -134,10 +134,10 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard do
           section_slug
         )
 
-      :other ->
+      :manage ->
         Routes.live_path(
           OliWeb.Endpoint,
-          OliWeb.Delivery.InstructorDashboard.OtherLive,
+          OliWeb.Delivery.InstructorDashboard.ManageLive,
           section_slug
         )
     end
@@ -145,7 +145,7 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard do
 
   attr :active_tab, :atom,
     required: true,
-    values: [:learning_objectives, :students, :content, :discussions, :assignments, :other]
+    values: [:learning_objectives, :students, :content, :discussions, :assignments, :manage]
 
   attr :section_slug, :string, required: true
   attr :preview_mode, :boolean, required: true
@@ -162,7 +162,7 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard do
             {"Modules", path_for(:content, @section_slug, @preview_mode), nil, is_active_tab?(:content, @active_tab)},
             {"Discussion Activity", path_for(:discussions, @section_slug, @preview_mode), nil, is_active_tab?(:discussions, @active_tab)},
             {"Assignments", path_for(:assignments, @section_slug, @preview_mode), nil, is_active_tab?(:assignments, @active_tab)},
-            {"Other", path_for(:other, @section_slug, @preview_mode), nil, is_active_tab?(:other, @active_tab)},
+            {"Manage", path_for(:manage, @section_slug, @preview_mode), nil, is_active_tab?(:manage, @active_tab)},
           ] do %>
             <li class="nav-item" role="presentation">
               <.link navigate={href}
@@ -373,9 +373,9 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard do
     """
   end
 
-  def other(assigns) do
+  def manage(assigns) do
     ~H"""
-      <.tabs active_tab={:other} section_slug={@section_slug} preview_mode={@preview_mode} />
+      <.tabs active_tab={:manage} section_slug={@section_slug} preview_mode={@preview_mode} />
       <div class="container mx-auto mt-3 mb-5">
         <div class="bg-white dark:bg-gray-800 p-8 shadow">
           <%= live_render(@socket, OliWeb.Sections.OverviewView, id: "overview", session: %{"section_slug" => @section_slug}) %>

--- a/lib/oli_web/components/delivery/utils.ex
+++ b/lib/oli_web/components/delivery/utils.ex
@@ -102,7 +102,7 @@ defmodule OliWeb.Components.Delivery.Utils do
         "Independent"
 
       :administrator ->
-        "LMS Administrator"
+        "Administrator"
 
       :instructor ->
         "Instructor"

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -41,7 +41,7 @@ defmodule OliWeb.PageDeliveryController do
               to:
                 Routes.live_path(
                   OliWeb.Endpoint,
-                  OliWeb.Delivery.InstructorDashboard.OtherLive,
+                  OliWeb.Delivery.InstructorDashboard.ManageLive,
                   section_slug
                 )
             )

--- a/lib/oli_web/live/common/card_listing.ex
+++ b/lib/oli_web/live/common/card_listing.ex
@@ -14,7 +14,7 @@ defmodule OliWeb.Common.CardListing do
     <div class="select-sources">
       <div class="card-deck mr-0 ml-0 inline-flex flex-wrap">
         {#for item <- @model.rows}
-          <a :on-click={@selected} class="course-card-link mb-2 no-underline" phx-value-id={action_id(item)}>
+          <a :on-click={@selected} class="course-card-link mb-2 no-underline hover:no-underline" phx-value-id={action_id(item)}>
             <div class="card mb-2 mr-1 ml-1 h-100">
               <img src={cover_image(item)} class="card-img-top" alt="course image">
               <div class="card-body">

--- a/lib/oli_web/live/delivery/instructor_dashboard/manage_live.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/manage_live.ex
@@ -1,4 +1,4 @@
-defmodule OliWeb.Delivery.InstructorDashboard.OtherLive do
+defmodule OliWeb.Delivery.InstructorDashboard.ManageLive do
   use OliWeb, :live_view
 
   alias OliWeb.Components.Delivery.InstructorDashboard
@@ -12,7 +12,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.OtherLive do
   def render(assigns) do
     ~H"""
       <InstructorDashboard.main_layout {assigns}>
-        <InstructorDashboard.other {assigns} />
+        <InstructorDashboard.manage {assigns} />
       </InstructorDashboard.main_layout>
     """
   end

--- a/lib/oli_web/live/delivery/select_source.ex
+++ b/lib/oli_web/live/delivery/select_source.ex
@@ -134,7 +134,7 @@ defmodule OliWeb.Delivery.SelectSource do
 
   def render(assigns) do
     ~F"""
-      <div class="d-flex flex-column mt-4">
+      <div class="d-flex flex-column mt-4 mx-4">
         <FilterBox table_model={@table_model} show_sort={is_cards_view?(@live_action, @view_type)} show_more_opts={is_instructor?(@live_action)}>
           <Filter query={@applied_query} apply={"apply_search"} change={"change_search"} reset="reset_search"/>
 

--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -37,7 +37,7 @@ defmodule OliWeb.Sections.OverviewView do
           link:
             Routes.live_path(
               OliWeb.Endpoint,
-              OliWeb.Delivery.InstructorDashboard.OtherLive,
+              OliWeb.Delivery.InstructorDashboard.ManageLive,
               section.slug
             )
         })

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -785,7 +785,7 @@ defmodule OliWeb.Router do
       live("/content", Delivery.InstructorDashboard.ContentLive)
       live("/discussions", Delivery.InstructorDashboard.DiscussionsLive)
       live("/assignments", Delivery.InstructorDashboard.AssignmentsLive)
-      live("/other", Delivery.InstructorDashboard.OtherLive)
+      live("/manage", Delivery.InstructorDashboard.ManageLive)
     end
 
     live_session :instructor_dashboard_preview,
@@ -800,7 +800,7 @@ defmodule OliWeb.Router do
       live("/preview/content", Delivery.InstructorDashboard.ContentLive, :preview)
       live("/preview/discussions", Delivery.InstructorDashboard.DiscussionsLive, :preview)
       live("/preview/assignments", Delivery.InstructorDashboard.AssignmentsLive, :preview)
-      live("/preview/other", Delivery.InstructorDashboard.OtherLive, :preview)
+      live("/preview/manage", Delivery.InstructorDashboard.ManageLive, :preview)
     end
   end
 

--- a/test/oli_web/controllers/page_delivery_controller_test.exs
+++ b/test/oli_web/controllers/page_delivery_controller_test.exs
@@ -740,7 +740,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert html_response(conn, 302) =~
                Routes.live_path(
                  conn,
-                 OliWeb.Delivery.InstructorDashboard.OtherLive,
+                 OliWeb.Delivery.InstructorDashboard.ManageLive,
                  section.slug
                )
 

--- a/test/oli_web/controllers/page_delivery_controller_test.exs
+++ b/test/oli_web/controllers/page_delivery_controller_test.exs
@@ -726,39 +726,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert html_response(conn, 200) =~ ~s|<div data-react-class="Components.PaginationControls"|
     end
 
-    test "index show manage section button when accessing as instructor", %{
-      conn: conn,
-      user: user,
-      section: section
-    } do
-      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_instructor)])
-
-      conn =
-        conn
-        |> get(Routes.page_delivery_path(conn, :index, section.slug))
-
-      assert html_response(conn, 302) =~
-               Routes.live_path(
-                 conn,
-                 OliWeb.Delivery.InstructorDashboard.ManageLive,
-                 section.slug
-               )
-
-      conn =
-        recycle(conn)
-        |> Pow.Plug.assign_current_user(user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
-        |> get(
-          Routes.live_path(
-            conn,
-            OliWeb.Delivery.InstructorDashboard.ContentLive,
-            section.slug
-          )
-        )
-
-      assert html_response(conn, 200) =~ "Course Overview"
-      assert html_response(conn, 200) =~ "Manage Section"
-    end
-
     test "page renders learning objectives in ungraded pages but not graded, except for review mode",
          %{
            user: user,

--- a/test/oli_web/live/delivery/instructor_dashboard/content_live_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/content_live_test.exs
@@ -16,14 +16,6 @@ defmodule OliWeb.Delivery.InstructorDashboard.ContentLiveTest do
     )
   end
 
-  defp live_view_other_route(section_slug) do
-    Routes.live_path(
-      OliWeb.Endpoint,
-      OliWeb.Delivery.InstructorDashboard.ManageLive,
-      section_slug
-    )
-  end
-
   describe "user" do
     test "can not access page when it is not logged in", %{conn: conn} do
       section = insert(:section)
@@ -77,13 +69,6 @@ defmodule OliWeb.Delivery.InstructorDashboard.ContentLiveTest do
 
       # Module tab content gets rendered
       assert has_element?(view, ~s{h5}, "Course Overview")
-
-      # Module tab manage section button links to "Other" tab
-      assert has_element?(
-               view,
-               ~s{a[href="#{live_view_other_route(section.slug)}"]},
-               "Manage Section"
-             )
     end
   end
 end

--- a/test/oli_web/live/delivery/instructor_dashboard/content_live_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/content_live_test.exs
@@ -19,7 +19,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.ContentLiveTest do
   defp live_view_other_route(section_slug) do
     Routes.live_path(
       OliWeb.Endpoint,
-      OliWeb.Delivery.InstructorDashboard.OtherLive,
+      OliWeb.Delivery.InstructorDashboard.ManageLive,
       section_slug
     )
   end

--- a/test/oli_web/live/delivery/instructor_dashboard/manage_live_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/manage_live_test.exs
@@ -8,7 +8,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.ManageLiveTest do
   alias Lti_1p3.Tool.ContextRoles
   alias Oli.Delivery.Sections
 
-  defp live_view_other_route(section_slug) do
+  defp live_view_manage_route(section_slug) do
     Routes.live_path(
       OliWeb.Endpoint,
       OliWeb.Delivery.InstructorDashboard.ManageLive,
@@ -20,10 +20,10 @@ defmodule OliWeb.Delivery.InstructorDashboard.ManageLiveTest do
     test "can not access page when it is not logged in", %{conn: conn} do
       section = insert(:section)
 
-      redirect_path = "/session/new?request_path=%2Fsections%2F#{section.slug}%2Fother"
+      redirect_path = "/session/new?request_path=%2Fsections%2F#{section.slug}%2Fmanage"
 
       assert {:error, {:redirect, %{to: ^redirect_path}}} =
-               live(conn, live_view_other_route(section.slug))
+               live(conn, live_view_manage_route(section.slug))
     end
   end
 
@@ -37,7 +37,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.ManageLiveTest do
       redirect_path = "/unauthorized"
 
       assert {:error, {:redirect, %{to: ^redirect_path}}} =
-               live(conn, live_view_other_route(section.slug))
+               live(conn, live_view_manage_route(section.slug))
     end
   end
 
@@ -48,7 +48,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.ManageLiveTest do
       redirect_path = "/unauthorized"
 
       assert {:error, {:redirect, %{to: ^redirect_path}}} =
-               live(conn, live_view_other_route(section.slug))
+               live(conn, live_view_manage_route(section.slug))
     end
 
     test "can access page if enrolled to section", %{
@@ -58,16 +58,16 @@ defmodule OliWeb.Delivery.InstructorDashboard.ManageLiveTest do
     } do
       Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
 
-      {:ok, view, _html} = live(conn, live_view_other_route(section.slug))
+      {:ok, view, _html} = live(conn, live_view_manage_route(section.slug))
 
-      # Other tab is the selected one
+      # Manage tab is the selected one
       assert has_element?(
                view,
-               ~s{a[href="#{live_view_other_route(section.slug)}"].border-b-2},
-               "Other"
+               ~s{a[href="#{live_view_manage_route(section.slug)}"].border-b-2},
+               "Manage"
              )
 
-      # Other tab content gets rendered
+      # Manage tab content gets rendered
       assert has_element?(view, ~s{div[id="overview"]})
     end
   end

--- a/test/oli_web/live/delivery/instructor_dashboard/other_live_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/other_live_test.exs
@@ -1,4 +1,4 @@
-defmodule OliWeb.Delivery.InstructorDashboard.OtherLiveTest do
+defmodule OliWeb.Delivery.InstructorDashboard.ManageLiveTest do
   use ExUnit.Case, async: true
   use OliWeb.ConnCase
 
@@ -11,7 +11,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.OtherLiveTest do
   defp live_view_other_route(section_slug) do
     Routes.live_path(
       OliWeb.Endpoint,
-      OliWeb.Delivery.InstructorDashboard.OtherLive,
+      OliWeb.Delivery.InstructorDashboard.ManageLive,
       section_slug
     )
   end

--- a/test/oli_web/live/progress_live_test.exs
+++ b/test/oli_web/live/progress_live_test.exs
@@ -256,7 +256,7 @@ defmodule OliWeb.ProgressLiveTest do
       refute html =~ "<a href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.AdminView)}\""
 
       assert html =~
-               "<a href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Delivery.InstructorDashboard.OtherLive, section.slug)}\""
+               "<a href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Delivery.InstructorDashboard.ManageLive, section.slug)}\""
 
       assert html =~ "Manual Scoring"
     end
@@ -276,7 +276,7 @@ defmodule OliWeb.ProgressLiveTest do
       refute html =~ "<a href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.AdminView)}\""
 
       assert html =~
-               "<a href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Delivery.InstructorDashboard.OtherLive, section.slug)}\""
+               "<a href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Delivery.InstructorDashboard.ManageLive, section.slug)}\""
 
       assert html =~ "Student Progress"
     end
@@ -294,7 +294,7 @@ defmodule OliWeb.ProgressLiveTest do
       refute html =~ "<a href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.AdminView)}\""
 
       assert html =~
-               "<a href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Delivery.InstructorDashboard.OtherLive, section.slug)}\""
+               "<a href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Delivery.InstructorDashboard.ManageLive, section.slug)}\""
 
       assert html =~
                "<a href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Progress.StudentView, section.slug, student.id)}\""


### PR DESCRIPTION
This PR fixes the following:
 - An issue where root_section_resource is nil during section creation from a project
 - Changes the "Other" tab to "Manage"
 - Remove redundant Manage Section button from course content outline