### PR TITLE
[ENHANCEMENT] do not show page read by or time estimate when not provided

### DIFF
--- a/assets/styles/common/previous_next_nav.scss
+++ b/assets/styles/common/previous_next_nav.scss
@@ -1,7 +1,7 @@
 .previous-next-nav {
   margin-top: 3rem;
   margin-bottom: 2rem;
-  border-top: 1px solid var(--color-gray-400);
+  border-top: 1px solid var(--color-gray-200);
 
   .page-nav-link {
     margin-top: 20px;

--- a/lib/oli_web/components/delivery/learning_opportunities.ex
+++ b/lib/oli_web/components/delivery/learning_opportunities.ex
@@ -40,21 +40,21 @@ defmodule OliWeb.Components.Delivery.LearningOpportunities do
             type: :course_content,
             title: "1.0 Intro to Chemistry 101: Foundational Content",
             progress: {:percent_complete, 20},
-            complete_by_date: Oli.Cldr.Date.to_string(~D[2020-10-03]) |> elem(1),
+            complete_by_date: format_date(~D[2020-10-03]),
             open_href: "#"
           },
           %LearningOpportunity{
             type: :graded_assignment,
             title: "1.0 Intro to Chemistry 101: Chemistry Assignment",
             progress: {:score, 3, 10},
-            complete_by_date: Oli.Cldr.Date.to_string(~D[2020-10-03]) |> elem(1),
+            complete_by_date: format_date(~D[2020-10-03]),
             open_href: "#"
           },
           %LearningOpportunity{
             type: :mission_activities,
             title: "Mission Activity: Water Pollution on Planet Earth",
             progress: {:activities_completed, 5, 10},
-            complete_by_date: Oli.Cldr.Date.to_string(~D[2020-10-03]) |> elem(1),
+            complete_by_date: format_date(~D[2020-10-03]),
             open_href: "#"
           }
         ] do %>

--- a/lib/oli_web/components/delivery/page_delivery.ex
+++ b/lib/oli_web/components/delivery/page_delivery.ex
@@ -20,15 +20,16 @@ defmodule OliWeb.Components.Delivery.PageDelivery do
     """
   end
 
-  attr :read_by, Date, default: nil
+  attr :scheduling_type, :atom, values: [:read_by, :inclass_activity]
+  attr :end_date, Date, default: nil
   attr :est_reading_time, Timex.Duration, default: nil
 
   def details(assigns) do
     ~H"""
       <div class="flex flex-row my-2">
-        <%= if @read_by do %>
+        <%= if @end_date do %>
           <div class="py-1.5 px-4 bg-gray-100 text-gray-700 rounded">
-            Read by <%= format_date(@read_by) %>
+            <%= scheduling_type_label(@scheduling_type) %> <%= format_date(@end_date) %>
           </div>
         <% end %>
         <%= if @est_reading_time do %>
@@ -39,6 +40,9 @@ defmodule OliWeb.Components.Delivery.PageDelivery do
       </div>
     """
   end
+
+  defp scheduling_type_label(:read_by), do: "Read by"
+  defp scheduling_type_label(:inclass_activity), do: "In-class activity"
 
   attr(:objectives, :list, required: true)
 

--- a/lib/oli_web/components/delivery/page_delivery.ex
+++ b/lib/oli_web/components/delivery/page_delivery.ex
@@ -1,6 +1,8 @@
 defmodule OliWeb.Components.Delivery.PageDelivery do
   use Phoenix.Component
 
+  import OliWeb.Components.Delivery.Utils
+
   attr(:title, :string, required: true)
   attr(:page_number, :integer, required: true)
   attr(:review_mode, :boolean, required: true)
@@ -18,15 +20,22 @@ defmodule OliWeb.Components.Delivery.PageDelivery do
     """
   end
 
+  attr :read_by, Date, default: nil
+  attr :est_reading_time, Timex.Duration, default: nil
+
   def details(assigns) do
     ~H"""
       <div class="flex flex-row my-2">
-        <div class="py-1.5 px-4 bg-gray-100 text-gray-700 rounded">
-          Read by 10-03-2022
-        </div>
-        <div class="py-1.5 px-4 bg-gray-100 text-gray-700 rounded ml-1">
-          Estimated reading time: 5 mins
-        </div>
+        <%= if @read_by do %>
+          <div class="py-1.5 px-4 bg-gray-100 text-gray-700 rounded">
+            Read by <%= format_date(@read_by) %>
+          </div>
+        <% end %>
+        <%= if @est_reading_time do %>
+          <div class="py-1.5 px-4 bg-gray-100 text-gray-700 rounded ml-1">
+            Estimated reading time: <%= format_duration(@est_reading_time) %>
+          </div>
+        <% end %>
       </div>
     """
   end

--- a/lib/oli_web/components/delivery/up_next.ex
+++ b/lib/oli_web/components/delivery/up_next.ex
@@ -20,7 +20,7 @@ defmodule OliWeb.Components.Delivery.UpNext do
               badge_bg_color="bg-green-700"
               title="3.3 Molarity"
               percent_complete={20}
-              complete_by_date={Oli.Cldr.Date.to_string(~D[2020-10-03]) |> elem(1)}
+              complete_by_date={format_date(~D[2020-10-03])}
               open_href="#"
               percent_students_completed={80}
               />
@@ -30,7 +30,7 @@ defmodule OliWeb.Components.Delivery.UpNext do
               badge_bg_color="bg-fuchsia-800"
               title="Unit 3.1: Understanding Chem 101"
               percent_complete={0}
-              complete_by_date={Oli.Cldr.Date.to_string(~D[2020-10-03]) |> elem(1)}
+              complete_by_date={format_date(~D[2020-10-03])}
               open_href="#"
               request_extension_href="#"
               percent_students_completed={80}

--- a/lib/oli_web/components/delivery/utils.ex
+++ b/lib/oli_web/components/delivery/utils.ex
@@ -306,4 +306,9 @@ defmodule OliWeb.Components.Delivery.Utils do
       </div>
     """
   end
+
+  def format_date(date), do: Oli.Cldr.Date.to_string(date) |> elem(1)
+
+  def format_duration(%Timex.Duration{} = duration),
+    do: Timex.format_duration(duration, :humanized)
 end

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -538,7 +538,11 @@ defmodule OliWeb.PageDeliveryController do
         },
         collab_space_config: context.collab_space_config,
         is_instructor: context.is_instructor,
-        is_student: context.is_student
+        is_student: context.is_student,
+        scheduling_type: section_resource.scheduling_type,
+        end_date: section_resource.end_date,
+        # TODO: implement reading time estimation
+        est_reading_time: nil
       }
     )
   end

--- a/lib/oli_web/templates/page_delivery/page.html.heex
+++ b/lib/oli_web/templates/page_delivery/page.html.heex
@@ -1,7 +1,7 @@
 
 <Components.Delivery.PageDelivery.header title={@title} page_number={@page_number} review_mode={@review_mode} />
 
-<Components.Delivery.PageDelivery.details />
+<Components.Delivery.PageDelivery.details scheduling_type={@scheduling_type} end_date={@end_date} est_reading_time={@est_reading_time} />
 
 
 <script>

--- a/test/oli_web/plugs/maybe_gated_resource_test.exs
+++ b/test/oli_web/plugs/maybe_gated_resource_test.exs
@@ -272,7 +272,6 @@ defmodule Oli.Plugs.MaybeGatedResourceTest do
         |> get(Routes.page_delivery_path(conn, :page, section.slug, revision.slug))
 
       assert html_response(conn, 200) =~ "Page one"
-      assert html_response(conn, 200) =~ "Estimated reading time"
     end
   end
 


### PR DESCRIPTION
This PR removes the page read by and time estimate by hiding those elements when they are not provided