### PR TITLE
[BUGFIX] size table according to its content

### DIFF
--- a/assets/styles/common/elements.scss
+++ b/assets/styles/common/elements.scss
@@ -433,6 +433,10 @@ $element-margin-bottom: 1.5em;
   .popover-body {
     max-width: 276px;
   }
+
+  table {
+    min-width: fit-content;
+  }
 }
 
 .conjugation {


### PR DESCRIPTION
This PR sets table delivery styles to fit a table's width according to its content.

Closes #3323