### PR TITLE
[MER-1818] Prevent products from being created before a course is initially published

### DIFF
--- a/lib/oli/publishing.ex
+++ b/lib/oli/publishing.ex
@@ -499,6 +499,24 @@ defmodule Oli.Publishing do
     )
   end
 
+  @doc """
+  Returns true if the project is published (has at least one publication)
+
+   ## Examples
+
+      iex> is_published?("published-project-slug")
+      true
+
+      iex> is_published?("unpublished-project-slug")
+      false
+  """
+  def project_published?(project_slug) do
+    case get_latest_published_publication_by_slug(project_slug) do
+      nil -> false
+      _ -> true
+    end
+  end
+
   def last_publication_query(),
     do:
       from(p in Publication,

--- a/lib/oli_web/live/products/products_view.ex
+++ b/lib/oli_web/live/products/products_view.ex
@@ -8,6 +8,7 @@ defmodule OliWeb.Products.ProductsView do
   alias Oli.Delivery.Sections.Blueprint
   alias OliWeb.Common.Table.SortableTableModel
   alias OliWeb.Router.Helpers, as: Routes
+  alias Oli.Publishing
 
   prop is_admin_view, :boolean
   prop project, :any
@@ -72,7 +73,11 @@ defmodule OliWeb.Products.ProductsView do
       ]
   end
 
-  def mount(%{"project_id" => project_slug}, %{"current_author_id" => author_id} = session, socket) do
+  def mount(
+        %{"project_id" => project_slug},
+        %{"current_author_id" => author_id} = session,
+        socket
+      ) do
     author = Repo.get(Author, author_id)
     project = Course.get_project_by_slug(project_slug)
     products = Blueprint.list_for_project(project)
@@ -102,12 +107,15 @@ defmodule OliWeb.Products.ProductsView do
     context = SessionContext.init(session)
     {:ok, table_model} = OliWeb.Products.ProductsTableModel.new(products, context)
 
+    published? = Publishing.project_published?(project.slug)
+
     {:ok,
      assign(socket,
        breadcrumbs: breadcrumbs,
        is_admin_view: is_admin_view,
        author: author,
        project: project,
+       published?: published?,
        products: products,
        total_count: total_count,
        table_model: table_model,
@@ -118,24 +126,26 @@ defmodule OliWeb.Products.ProductsView do
   def render(assigns) do
     ~F"""
     <div>
+      {#if @published?}
+        {#if @is_admin_view == false}
+          <Create id="creation" title={@creation_title} change="title" click="create"/>
+        {#else}
+          <Filter change={"change_search"} reset="reset_search" apply="apply_search"/>
+        {/if}
 
-      {#if @is_admin_view == false}
-        <Create id="creation" title={@creation_title} change="title" click="create"/>
+        <div class="mb-3"/>
+
+        <Listing
+          filter={@query}
+          table_model={@table_model}
+          total_count={@total_count}
+          offset={@offset}
+          limit={@limit}
+          sort="sort"
+          page_change="page_change"/>
       {#else}
-        <Filter change={"change_search"} reset="reset_search" apply="apply_search"/>
+        <div>Products cannot be created until project is published.</div>
       {/if}
-
-      <div class="mb-3"/>
-
-      <Listing
-        filter={@query}
-        table_model={@table_model}
-        total_count={@total_count}
-        offset={@offset}
-        limit={@limit}
-        sort="sort"
-        page_change="page_change"/>
-
     </div>
 
     """
@@ -146,11 +156,17 @@ defmodule OliWeb.Products.ProductsView do
   end
 
   def handle_event("create", _, socket) do
-    customizations = case socket.assigns.project.customizations do
-      nil -> nil
-      labels -> Map.from_struct(labels)
-    end
-    case Blueprint.create_blueprint(socket.assigns.project.slug, socket.assigns.creation_title, customizations) do
+    customizations =
+      case socket.assigns.project.customizations do
+        nil -> nil
+        labels -> Map.from_struct(labels)
+      end
+
+    case Blueprint.create_blueprint(
+           socket.assigns.project.slug,
+           socket.assigns.creation_title,
+           customizations
+         ) do
       {:ok, blueprint} ->
         {:noreply,
          socket

--- a/lib/oli_web/templates/layout/_project_sidebar.html.eex
+++ b/lib/oli_web/templates/layout/_project_sidebar.html.eex
@@ -33,8 +33,8 @@
     </button>
     <div class="dropdown-menu">
       <a class="dropdown-item btn btn-lg" href="<%= Routes.live_path(OliWeb.Endpoint, OliWeb.Qa.QaLive, @project.slug) %>">Review</a>
-      <a class="dropdown-item btn btn-lg" href="<%= Routes.live_path(OliWeb.Endpoint, OliWeb.Products.ProductsView, @project.slug) %>">Products</a>
       <a class="dropdown-item btn btn-lg" href="<%= Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.PublishView, @project.slug) %>">Publish</a>
+      <a class="dropdown-item btn btn-lg" href="<%= Routes.live_path(OliWeb.Endpoint, OliWeb.Products.ProductsView, @project.slug) %>">Products</a>
     </div>
   </div>
 

--- a/test/oli_web/live/products_test.exs
+++ b/test/oli_web/live/products_test.exs
@@ -8,6 +8,11 @@ defmodule OliWeb.ProductsLiveTest do
 
   alias Oli.Delivery.Sections
   alias OliWeb.Router.Helpers, as: Routes
+  alias Oli.Utils.Seeder
+
+  defp live_view_products_route(project_slug) do
+    Routes.live_path(OliWeb.Endpoint, OliWeb.Products.ProductsView, project_slug)
+  end
 
   defp live_view_details_route(product_slug) do
     Routes.live_path(OliWeb.Endpoint, OliWeb.Products.DetailsView, product_slug)
@@ -188,6 +193,33 @@ defmodule OliWeb.ProductsLiveTest do
 
       assert view
              |> render() =~ "<img id=\"current-product-img\" src=\"#{current_image}\""
+    end
+  end
+
+  describe "user cannot create product until after project is published" do
+    setup [:author_conn]
+
+    test "redirects to new session when accessing the section overview view", %{
+      conn: conn,
+      author: author
+    } do
+      seeds =
+        Seeder.Project.create_sample_project(%{}, author,
+          project_tag: :project,
+          publication_tag: :publication
+        )
+
+      %{project: project, publication: publication} = seeds
+
+      {:ok, view, _html} = live(conn, live_view_products_route(project.slug))
+
+      assert render(view) =~ "Products cannot be created until project is published"
+
+      Seeder.Project.ensure_published(seeds, publication)
+
+      {:ok, view, _html} = live(conn, live_view_products_route(project.slug))
+
+      assert render(view) =~ "Create a new product with title"
     end
   end
 end


### PR DESCRIPTION
Shows a message that products cannot be created until the project is published

<img width="879" alt="Screenshot 2023-03-17 at 1 56 28 PM" src="https://user-images.githubusercontent.com/6248894/225987404-2e43a340-bc6e-43e3-abd7-4f40f918f4f6.png">
