### PR TITLE
[BUGFIX] Fix bib entry editing redisplay [MER-1815]

### DIFF
--- a/lib/oli_web/controllers/api/bib_entry_controller.ex
+++ b/lib/oli_web/controllers/api/bib_entry_controller.ex
@@ -6,7 +6,6 @@ defmodule OliWeb.Api.BibEntryController do
   alias Oli.Authoring.Editing.BibEntryEditor
   import OliWeb.Api.Helpers
   alias Oli.Repo.{Paging}
-  alias Oli.Repo
 
   use OliWeb, :controller
 
@@ -50,8 +49,8 @@ defmodule OliWeb.Api.BibEntryController do
     author = conn.assigns[:current_author]
 
     case BibEntryEditor.edit(project_slug, entry_id, author, %{"title" => title, "author_id" => author.id, "content" => %{data: Poison.decode!(content)}}) do
-      {:ok, resource} ->
-        json(conn, %{"result" => "success", "bibentry" => serialize_revision(Repo.preload(resource, :revision).revision)})
+      {:ok, revision} ->
+        json(conn, %{"result" => "success", "bibentry" => serialize_revision(revision)})
 
       {:error, {:not_found}} ->
         error(conn, 404, "not found")

--- a/test/oli/editing/bib_entry_editor_test.exs
+++ b/test/oli/editing/bib_entry_editor_test.exs
@@ -1,6 +1,7 @@
 defmodule Oli.BibEntryEditorTest do
   use Oli.DataCase
 
+  alias Oli.Resources.Revision
   alias Oli.Authoring.Editing.BibEntryEditor
   alias Oli.Accounts.{SystemRole, Author}
   alias Oli.Repo.{Paging}
@@ -127,7 +128,7 @@ defmodule Oli.BibEntryEditorTest do
     end
 
     test "edit/4 allows title editing", %{author: author, project: project, first: first} do
-      {:ok, _} =
+      {:ok, %Revision{} = _revision} =
         BibEntryEditor.edit(project.slug, first.revision.resource_id, author, %{
           "title" => "updated title"
         })
@@ -149,7 +150,7 @@ defmodule Oli.BibEntryEditorTest do
       first: first,
       second: second
     } do
-      {:ok, _} =
+      {:ok, %Revision{} = _revision} =
         BibEntryEditor.edit(project.slug, first.revision.resource_id, author, %{
           "deleted" => true
         })


### PR DESCRIPTION
Fix a problem that after one edits a bib entry, the UI does not update to show that edit. 

The root cause was a server side error, where code in the controller expected `PublishedResource` to be returned after editing, and tried to preload the revision from that. In fact, the `BibEntryEditor.edit/4` returns `{:ok, %Revision{}}`.  I've fixed this and strengthened the unit tests in a way that would have caught this. 