### PR TITLE
[BUG FIX] fix alternatives previewing [MER-1814]

### DIFF
--- a/lib/oli/authoring/editing/page_editor.ex
+++ b/lib/oli/authoring/editing/page_editor.ex
@@ -276,10 +276,11 @@ defmodule Oli.Authoring.Editing.PageEditor do
            mode: mode,
            activity_map: activities,
            resource_summary_fn: &Resources.resource_summary(&1, project_slug, AuthoringResolver),
-           alternatives_groups_fn: &Resources.alternatives_groups(&1, AuthoringResolver),
+           alternatives_groups_fn: fn -> Resources.alternatives_groups(project_slug, AuthoringResolver) end,
            alternatives_selector_fn: &Resources.Alternatives.select/2,
            extrinsic_read_section_fn: &Oli.Delivery.ExtrinsicState.read_section/3,
            project_slug: project_slug,
+           section_slug: project_slug,
            bib_app_params: Keyword.get(options, :bib_app_params, []),
            learning_language: attributes.learning_language
          } do

--- a/lib/oli/rendering/alternatives.ex
+++ b/lib/oli/rendering/alternatives.ex
@@ -33,7 +33,7 @@ defmodule Oli.Rendering.Alternatives do
         writer
       ) do
 
-    {:ok, groups} = groups_fn.(section_slug)
+    {:ok, groups} = groups_fn.()
     by_id = Enum.reduce(groups, %{}, fn r, m -> Map.put(m, r.id, r) end)
 
     enrollment_id = case enrollment do

--- a/lib/oli/rendering/alternatives/html.ex
+++ b/lib/oli/rendering/alternatives/html.ex
@@ -37,7 +37,6 @@ defmodule Oli.Rendering.Alternatives.Html do
         %Context{
           user: user,
           section_slug: section_slug,
-          project_slug: project_slug,
           alternatives_groups_fn: alternatives_groups_fn,
           extrinsic_read_section_fn: extrinsic_read_section_fn,
           mode: mode
@@ -46,14 +45,7 @@ defmodule Oli.Rendering.Alternatives.Html do
           "alternatives_id" => alternatives_id
         }
       ) do
-    {:ok, groups} =
-      case section_slug do
-        nil ->
-          alternatives_groups_fn.(project_slug)
-
-        section_slug ->
-          alternatives_groups_fn.(section_slug)
-      end
+    {:ok, groups} = alternatives_groups_fn.()
 
     options =
       case Enum.find(groups, &(&1.id == alternatives_id)) do

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -524,7 +524,7 @@ defmodule OliWeb.PageDeliveryController do
         end,
       activity_map: context.activities,
       resource_summary_fn: &Resources.resource_summary(&1, section_slug, Resolver),
-      alternatives_groups_fn: &Resources.alternatives_groups(&1, Resolver),
+      alternatives_groups_fn: fn -> Resources.alternatives_groups(section_slug, Resolver) end,
       alternatives_selector_fn: &Resources.Alternatives.select/2,
       extrinsic_read_section_fn: &Oli.Delivery.ExtrinsicState.read_section/3,
       bib_app_params: context.bib_revisions,

--- a/test/oli/rendering/alternatives/html_test.exs
+++ b/test/oli/rendering/alternatives/html_test.exs
@@ -109,7 +109,7 @@ defmodule Oli.Rendering.Alternatives.HtmlTest do
         "type" => "alternatives"
       }
 
-      mock_alternatives_groups_fn = fn _slug ->
+      mock_alternatives_groups_fn = fn ->
         {:ok,
          [
            %{


### PR DESCRIPTION
The root cause here was that the rendering code was hardcoded to use the section slug as an argument to the function that retrieves the current alternative groups.   Solution was to eliminate that argument, instead "binding" it upfront.  In a preview context we of course bind the project slug, and in delivery the section slug. 