### PR TITLE
[BUG FIX] Fix button toggling in video player [MER-1825]

### DIFF
--- a/assets/src/components/video_player/VideoPlayButton.tsx
+++ b/assets/src/components/video_player/VideoPlayButton.tsx
@@ -2,17 +2,20 @@ import React, { useCallback } from 'react';
 import { ControlButtonProps } from './ControlBar';
 
 export const PlayButton: React.FC<ControlButtonProps> = ({ actions, player }) => {
-
   const toggle = useCallback(() => {
     player?.paused ? actions?.play() : actions?.pause();
   }, [actions, player]);
 
-  const playOrPausedStyle = player?.paused ? "fa-solid fa-play" : "fa-solid fa-pause";
+  const playOrPausedStyle = player?.paused ? 'fa-solid fa-play' : 'fa-solid fa-pause';
 
   return (
     // The 'key' attribute is necessary here to force react to replace the entire buton on
     // a "play/pause" state change, so that we can replace the font-awesome icon correctly.
-    <button key={player?.paused + ""} className="video-react-control video-react-button" onClick={toggle}>
+    <button
+      key={player?.paused + ''}
+      className="video-react-control video-react-button"
+      onClick={toggle}
+    >
       <i className={playOrPausedStyle}></i>
     </button>
   );

--- a/assets/src/components/video_player/VideoPlayButton.tsx
+++ b/assets/src/components/video_player/VideoPlayButton.tsx
@@ -2,17 +2,18 @@ import React, { useCallback } from 'react';
 import { ControlButtonProps } from './ControlBar';
 
 export const PlayButton: React.FC<ControlButtonProps> = ({ actions, player }) => {
+
   const toggle = useCallback(() => {
     player?.paused ? actions?.play() : actions?.pause();
   }, [actions, player]);
 
+  const playOrPausedStyle = player?.paused ? "fa-solid fa-play" : "fa-solid fa-pause";
+
   return (
-    <button className="video-react-control video-react-button" onClick={toggle}>
-      {player?.paused ? (
-        <i className="fa-solid fa-pause"></i>
-      ) : (
-        <i className="fa-solid fa-play"></i>
-      )}
+    // The 'key' attribute is necessary here to force react to replace the entire buton on
+    // a "play/pause" state change, so that we can replace the font-awesome icon correctly.
+    <button key={player?.paused + ""} className="video-react-control video-react-button" onClick={toggle}>
+      <i className={playOrPausedStyle}></i>
     </button>
   );
 };


### PR DESCRIPTION
For embedded Videos, the "play / pause" button was designed to change its icon when you click play or pause - to show the other icon. As in, when I'm playing a video I should see the button to "pause" the video, and vice-versa. 

This was only ever showing the pause icon.

Root cause is related to how font awesome replaces the `<i>` element with svg.  React could not update that when the `paused` state changed.  Instead, by assigning a unique `key` to the parent `<button>` we trick React into replacing that entire node, which fixes the problem. 

