### PR TITLE
[BUG FIX] Restore ability for admins to review attempts [MER-1830]

### DIFF
--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -924,9 +924,11 @@ defmodule OliWeb.PageDeliveryController do
 
     section = conn.assigns.section
 
+    is_admin? = Oli.Accounts.is_admin?(author)
+
     if Oli.Accounts.is_admin?(author) or
          PageLifecycle.can_access_attempt?(attempt_guid, user, section) do
-      PageContext.create_for_review(section_slug, attempt_guid, user)
+      PageContext.create_for_review(section_slug, attempt_guid, user, is_admin?)
       |> render_page(conn, section_slug, false)
     else
       render(conn, "not_authorized.html")

--- a/test/oli/resources/collaboration_test.exs
+++ b/test/oli/resources/collaboration_test.exs
@@ -3,11 +3,9 @@ defmodule Oli.Resources.CollaborationTest do
 
   import Oli.Factory
 
-  alias Oli.Delivery.Sections
   alias Oli.Resources
   alias Oli.Resources.Collaboration
   alias Oli.Resources.Collaboration.{CollabSpaceConfig, Post}
-  alias Oli.Resources.ResourceType
 
   describe "collaborative spaces" do
     test "upsert_collaborative_space/4 with valid data creates a collaborative space" do


### PR DESCRIPTION
Admins were no longer able to view arbitrary student attempts in course sections due to changes in how we are determining the type of user.  Reworked this to expand the `create_for_review` interface to take a fourth argument, `is_admin?`, thus allowing the case for when a user is an admin to be handled correctly (and efficiently, as it avoids the DB call to `get_user_roles`).

Also found a test that had a couple of unused aliases. 