### PR TITLE
[BUG FIX] Allow admins to access new manage section routes [MER-1819]

### DIFF
--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -772,8 +772,7 @@ defmodule OliWeb.Router do
   scope "/sections/:section_slug", OliWeb do
     pipe_through([
       :browser,
-      :delivery,
-      :delivery_protected,
+      :delivery_and_admin,
       :maybe_gated_resource,
       :pow_email_layout
     ])


### PR DESCRIPTION
Root cause was that the scope for the new instructor dashboard routes did not allow admins to access them.