### PR TITLE
[BUG FIX] Allow management of guest student gating exceptions [MER-1829]

### DIFF
--- a/lib/oli_web/live/common/utils.ex
+++ b/lib/oli_web/live/common/utils.ex
@@ -4,6 +4,10 @@ defmodule OliWeb.Common.Utils do
   alias Oli.Accounts.{User, Author}
   alias OliWeb.Common.SessionContext
 
+  def name(%User{guest: true}) do
+    "Guest Student"
+  end
+
   def name(%User{} = user) do
     name(user.name, user.given_name, user.family_name)
   end

--- a/lib/oli_web/live/sections/enrollments_table_model.ex
+++ b/lib/oli_web/live/sections/enrollments_table_model.ex
@@ -59,16 +59,13 @@ defmodule OliWeb.Delivery.Sections.EnrollmentsTableModel do
   def render_name_column(
         assigns,
         %{
-          id: id,
-          name: name,
-          given_name: given_name,
-          family_name: family_name
-        },
+          id: id
+        } = user,
         _
       ) do
     ~F"""
     <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Progress.StudentView, assigns.section_slug, id)}>
-      {name(name, given_name, family_name)}
+      {name(user)}
     </a>
     """
   end

--- a/lib/oli_web/live/sections/gating_and_scheduling/table_model.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling/table_model.ex
@@ -174,9 +174,16 @@ defmodule OliWeb.Delivery.Sections.GatingAndScheduling.TableModel do
       ) do
     ~F"""
       <div :if={user_id}>
-        <Link to={Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.GatingAndScheduling.Edit, section_slug, id)}>{user.name}</Link>
-
+        <Link to={Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.GatingAndScheduling.Edit, section_slug, id)}>{safe_name(user)}</Link>
       </div>
     """
+  end
+
+  defp safe_name(user) do
+    case user.name do
+      nil -> "Unknown User"
+      "" -> "Unknown User"
+      _ -> user.name
+    end
   end
 end

--- a/lib/oli_web/live/sections/gating_and_scheduling/table_model.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling/table_model.ex
@@ -174,16 +174,9 @@ defmodule OliWeb.Delivery.Sections.GatingAndScheduling.TableModel do
       ) do
     ~F"""
       <div :if={user_id}>
-        <Link to={Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.GatingAndScheduling.Edit, section_slug, id)}>{safe_name(user)}</Link>
+        <Link to={Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.GatingAndScheduling.Edit, section_slug, id)}>{OliWeb.Common.Utils.name(user)}</Link>
       </div>
     """
   end
 
-  defp safe_name(user) do
-    case user.name do
-      nil -> "Unknown User"
-      "" -> "Unknown User"
-      _ -> user.name
-    end
-  end
 end


### PR DESCRIPTION
Instructors probably shouldn't be creating student exceptions for guest users, but if they do, there was no way to manage that exception (even just to delete it) since the table of exceptions was not rendering a name which allowed the link to be clickable. 

I took this opportunity to adjust how we render names for guest users.  Previously we rendered "Unknown Unknown", now it will read "Guest Student".