### PR TITLE
[BUG FIX] Allow upload and dnd activities to be reviewable in all cases [MER-1827]

### DIFF
--- a/assets/src/components/activities/custom_dnd/CustomDnDDelivery.tsx
+++ b/assets/src/components/activities/custom_dnd/CustomDnDDelivery.tsx
@@ -56,7 +56,7 @@ export const CustomDnDComponent: React.FC = () => {
 
   // state we pass is always a mapping from targetId to draggableId
   const initialState = state.parts.reduce((m: any, p) => {
-    if (p.response !== null) {
+    if (p.response !== null && (p.response.input !== null)) {
       const choiceId = p.response.input.substr((p.partId as string).length + 1);
       if (partIdBearers === 'targets') {
         m[p.partId] = choiceId;

--- a/assets/src/components/activities/custom_dnd/CustomDnDDelivery.tsx
+++ b/assets/src/components/activities/custom_dnd/CustomDnDDelivery.tsx
@@ -56,7 +56,7 @@ export const CustomDnDComponent: React.FC = () => {
 
   // state we pass is always a mapping from targetId to draggableId
   const initialState = state.parts.reduce((m: any, p) => {
-    if (p.response !== null && (p.response.input !== null)) {
+    if (p.response !== null && p.response.input !== null) {
       const choiceId = p.response.input.substr((p.partId as string).length + 1);
       if (partIdBearers === 'targets') {
         m[p.partId] = choiceId;

--- a/assets/src/components/activities/file_upload/FileUploadDelivery.tsx
+++ b/assets/src/components/activities/file_upload/FileUploadDelivery.tsx
@@ -51,7 +51,7 @@ function onUploadClick(id: string) {
 const getFilesFromState = (state: ActivityDeliveryState) => {
   const key = Object.keys(state.partState)[0];
 
-  return state.partState[key].studentInput === undefined
+  return state.partState[key].studentInput === undefined || state.partState[key].studentInput === null
     ? []
     : (state.partState[key].studentInput as any as FileMetaData[]);
 };

--- a/assets/src/components/activities/file_upload/FileUploadDelivery.tsx
+++ b/assets/src/components/activities/file_upload/FileUploadDelivery.tsx
@@ -51,7 +51,8 @@ function onUploadClick(id: string) {
 const getFilesFromState = (state: ActivityDeliveryState) => {
   const key = Object.keys(state.partState)[0];
 
-  return state.partState[key].studentInput === undefined || state.partState[key].studentInput === null
+  return state.partState[key].studentInput === undefined ||
+    state.partState[key].studentInput === null
     ? []
     : (state.partState[key].studentInput as any as FileMetaData[]);
 };

--- a/lib/oli_web/live/progress/page_attempt_summary.ex
+++ b/lib/oli_web/live/progress/page_attempt_summary.ex
@@ -49,12 +49,14 @@ defmodule OliWeb.Progress.PageAttemptSummary do
   def do_render(%{attempt: %{lifecycle_state: :submitted}} = assigns) do
     ~F"""
     <li class="list-group-item list-group-action flex-column align-items-start">
-      <div class="d-flex w-100 justify-content-between">
-        <h5 class="mb-1">Attempt {@attempt.attempt_number}</h5>
-        <span>Submitted</span>
-      </div>
-      <p class="mb-1 text-muted">Submitted: {Utils.render_date(@attempt, :date_submitted, @context)} ({Utils.render_relative_date(@attempt, :date_submitted, @context)})</p>
-      <small class="text-muted">Time elapsed: {duration(@attempt.inserted_at, @attempt.date_submitted)}.</small>
+      <a href={Routes.instructor_review_path(OliWeb.Endpoint, :review_attempt, @section.slug, @attempt.attempt_guid)}>
+        <div class="d-flex w-100 justify-content-between">
+          <h5 class="mb-1">Attempt {@attempt.attempt_number}</h5>
+          <span>Submitted</span>
+        </div>
+        <p class="mb-1 text-muted">Submitted: {Utils.render_date(@attempt, :date_submitted, @context)} ({Utils.render_relative_date(@attempt, :date_submitted, @context)})</p>
+        <small class="text-muted">Time elapsed: {duration(@attempt.inserted_at, @attempt.date_submitted)}.</small>
+      </a>
     </li>
     """
   end


### PR DESCRIPTION
Both FileUpload and CustomDND activities had code that was not robust against restoring submissions that were incomplete.   This would throw a client side error and effectively render nothing for these activities while in review mode. 

I also fixed the inability to review an attempt that is in a `submitted` state.  It simply needed to have its contents wrapped in a `<a>` element. 
