### PR TITLE
[BUG FIX] Live update after post approvals [MER-1838]

### DIFF
--- a/lib/oli_web/live/delivery/remix_section.ex
+++ b/lib/oli_web/live/delivery/remix_section.ex
@@ -623,10 +623,11 @@ defmodule OliWeb.Delivery.RemixSection do
 
   defp render_breadcrumb(%{hierarchy: hierarchy, active: active} = assigns) do
     assigns = assign(assigns, :breadcrumbs, Breadcrumb.breadcrumb_trail_to(hierarchy, active))
+    assigns = assign(assigns, :arrow_disabled, Enum.count(assigns.breadcrumbs) == 1)
 
     ~H"""
       <div class="breadcrumb custom-breadcrumb p-1 px-2">
-        <button id="curriculum-back" class="btn btn-sm btn-link" phx-click="set_active" phx-value-uuid={previous_uuid(@breadcrumbs)}><i class="fas fa-arrow-left"></i></button>
+        <button disabled={@arrow_disabled} id="curriculum-back" class="btn btn-sm btn-link" phx-click="set_active" phx-value-uuid={previous_uuid(@breadcrumbs)}><i class="fas fa-arrow-left"></i></button>
 
         <%= for {breadcrumb, index} <- Enum.with_index(@breadcrumbs) do %>
           <%= render_breadcrumb_item Enum.into(%{


### PR DESCRIPTION
The "Approve" and "Reject" buttons were not launching their respective modal confirmation dialogs due to a missing rendering of that modal. 

I also noticed that approving and rejecting did not live update the view of a discussion board.  I added the necessary broadcast message so that after an instructor approves a pending message all students that happen to be on the page see that post appear, without a hard refresh. 

There is a minor tweak here to course remix, to disable the navigation button when the user is at the top-level of the hierarchy. 