### PR TITLE
[MER-1712] Instructor portal students view

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -6,6 +6,7 @@
 @import 'input';
 @import 'text';
 @import 'button';
+@import 'table';
 
 /**
  * Automatically style all links with blue text and underline on hover.

--- a/assets/css/table.css
+++ b/assets/css/table.css
@@ -1,0 +1,45 @@
+.instructor_dashboard_table {
+  @apply border-r-0 border-l-0 font-sans not-italic text-sm bg-white;
+}
+
+.instructor_dashboard_table th {
+  @apply h-16 border-r-0 border-l-0 bg-white text-left font-normal text-xs sm:text-sm;
+}
+
+.instructor_dashboard_table th:has(span[data-sort-column='true']) {
+  @apply font-bold text-gray-800;
+}
+
+.instructor_dashboard_table th svg {
+  @apply hidden;
+}
+
+.instructor_dashboard_table th span.data-sort-up[data-sort-column='true'] {
+  @apply pl-4 ml-1 sm:pl-9 sm:ml-3;
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%235B1EEA' stroke-linecap='round' stroke-linejoin='round' stroke-width='2.0' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
+  background-repeat: no-repeat;
+}
+
+.instructor_dashboard_table th span.data-sort-down[data-sort-column='true'] {
+  @apply pl-4 ml-1 sm:pl-9 sm:ml-3;
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%235B1EEA' stroke-linecap='round' stroke-linejoin='round' stroke-width='2.0' d='M6 12 L10 8 L14 12'/%3e%3c/svg%3e");
+  background-repeat: no-repeat;
+}
+
+.instructor_dashboard_table th span.data-sort-up[data-sort-column='false'] {
+  @apply pl-4 ml-1 sm:pl-9 sm:ml-3 grayscale;
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%235B1EEA' stroke-linecap='round' stroke-linejoin='round' stroke-width='2.0' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
+  background-repeat: no-repeat;
+}
+
+.instructor_dashboard_table tr {
+  @apply h-14 text-gray-500 font-semibold text-xs sm:text-sm;
+}
+
+.instructor_dashboard_table tr:has(div[data-progress-check='false']) {
+  @apply bg-red-200 bg-opacity-20;
+}
+
+.instructor_dashboard_table td {
+  @apply border-r-0 border-l-0;
+}

--- a/assets/css/text.css
+++ b/assets/css/text.css
@@ -1,5 +1,5 @@
 h4.torus-h4 {
-  @apply text-delivery-body-color text-xl font-bold;
+  @apply text-delivery-body-color text-xl font-bold tracking-wide pt-7 pb-4;
 }
 
 h6.torus-h6 {

--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -1,5 +1,4 @@
 defmodule Oli.Delivery.Metrics do
-
   import Ecto.Query, warn: false
 
   alias Oli.Repo
@@ -10,8 +9,8 @@ defmodule Oli.Delivery.Metrics do
   alias Oli.Delivery.Attempts.Core
 
   @doc """
-  Calculate the progress for a specific student, in all pages of a
-  specific container.
+  Calculate the progress for a specific student (or a list of students),
+  in all pages of a specific container.
 
   Ommitting the container_id (or specifying nil) calculates progress
   across the entire course section.
@@ -20,8 +19,21 @@ defmodule Oli.Delivery.Metrics do
   up to date view of the structure of a course section. This allows this
   query to take into account structural chagnes as the result of course
   remix. The `contained_pages` relation is rebuilt after every remix.
+
+  It returns a map:
+
+    %{user_id_1 => user_1_progress,
+      ...
+      user_id_n => user_n_progress
+    }
   """
+  @spec progress_for(
+          section_id :: integer,
+          user_id :: integer | list(integer),
+          container_id :: integer | nil
+        ) :: map
   def progress_for(section_id, user_id, container_id \\ nil) do
+    user_id_list = if is_list(user_id), do: user_id, else: [user_id]
 
     filter_by_container =
       case container_id do
@@ -32,20 +44,28 @@ defmodule Oli.Delivery.Metrics do
           dynamic([cp, _], cp.container_id == ^container_id)
       end
 
+    pages_count =
+      from(cp in ContainedPage)
+      |> where([cp], cp.section_id == ^section_id)
+      |> where(^filter_by_container)
+      |> select([cp], count(cp.id))
+      |> Repo.one()
+      |> max(1)
+
     query =
       ContainedPage
-      |> join(:left, [cp], ra in ResourceAccess, on: cp.page_id == ra.resource_id and cp.section_id == ra.section_id and ra.user_id == ^user_id)
+      |> join(:left, [cp], ra in ResourceAccess,
+        on:
+          cp.page_id == ra.resource_id and cp.section_id == ra.section_id and
+            ra.user_id in ^user_id_list
+      )
       |> where([cp, ra], cp.section_id == ^section_id)
       |> where(^filter_by_container)
-      |> select([cp, ra], %{
-        progress:
-          fragment(
-            "SUM(?) / COUNT(*)",
-            ra.progress
-          )
-      })
+      |> group_by([_cp, ra], ra.user_id)
+      |> select([cp, ra], {ra.user_id, fragment("SUM(?)", ra.progress) / ^pages_count})
 
-    Repo.one(query).progress
+    Repo.all(query)
+    |> Enum.into(%{})
   end
 
   @doc """
@@ -55,7 +75,11 @@ defmodule Oli.Delivery.Metrics do
   def progress_across(section_id, container_ids, user_id) do
     query =
       ContainedPage
-      |> join(:left, [cp], ra in ResourceAccess, on: cp.page_id == ra.resource_id and cp.section_id == ra.section_id and ra.user_id == ^user_id)
+      |> join(:left, [cp], ra in ResourceAccess,
+        on:
+          cp.page_id == ra.resource_id and cp.section_id == ra.section_id and
+            ra.user_id == ^user_id
+      )
       |> where([cp, ra], cp.section_id == ^section_id and cp.container_id in ^container_ids)
       |> group_by([cp, ra], cp.container_id)
       |> select([cp, ra], %{
@@ -80,16 +104,23 @@ defmodule Oli.Delivery.Metrics do
   number of enrolled students (excluding the count of those in the exlusion parameter).
   """
   def progress_across(section_id, container_ids, user_ids_to_ignore, user_count) do
-
     # If zero was passed in, we can allow the query to execute correctly and avoid a divide by zero by
     # simply changing it to 1
     user_count = max(user_count, 1)
 
     query =
       ContainedPage
-      |> join(:left, [cp], ra in ResourceAccess, on: cp.page_id == ra.resource_id and cp.section_id == ra.section_id)
-      |> join(:left, [cp, _], sr in SectionResource, on: cp.container_id == sr.resource_id and cp.section_id == sr.section_id)
-      |> where([cp, ra, _], cp.section_id == ^section_id and cp.container_id in ^container_ids and ra.user_id not in ^user_ids_to_ignore)
+      |> join(:left, [cp], ra in ResourceAccess,
+        on: cp.page_id == ra.resource_id and cp.section_id == ra.section_id
+      )
+      |> join(:left, [cp, _], sr in SectionResource,
+        on: cp.container_id == sr.resource_id and cp.section_id == sr.section_id
+      )
+      |> where(
+        [cp, ra, _],
+        cp.section_id == ^section_id and cp.container_id in ^container_ids and
+          ra.user_id not in ^user_ids_to_ignore
+      )
       |> group_by([cp, ra, sr], [cp.container_id, sr.contained_page_count])
       |> select([cp, ra, sr], %{
         container_id: cp.container_id,
@@ -148,7 +179,6 @@ defmodule Oli.Delivery.Metrics do
   end
 
   defp do_update(activity_attempt_guid) do
-
     Oli.Repo.transaction(fn ->
       sql = """
         UPDATE
@@ -176,8 +206,6 @@ defmodule Oli.Delivery.Metrics do
         {:ok, %{num_rows: _}} -> Oli.Repo.rollback(:unexpected_update_count)
         {:error, e} -> Oli.Repo.rollback(e)
       end
-
     end)
   end
-
 end

--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -54,7 +54,7 @@ defmodule Oli.Delivery.Metrics do
 
     query =
       ContainedPage
-      |> join(:left, [cp], ra in ResourceAccess,
+      |> join(:inner, [cp], ra in ResourceAccess,
         on:
           cp.page_id == ra.resource_id and cp.section_id == ra.section_id and
             ra.user_id in ^user_id_list

--- a/lib/oli_web/components/delivery/instructor_dashboard.ex
+++ b/lib/oli_web/components/delivery/instructor_dashboard.ex
@@ -364,12 +364,6 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard do
     """
   end
 
-  def students(assigns) do
-    ~H"""
-
-    """
-  end
-
   def content(assigns) do
     ~H"""
       <.tabs active_tab={:content} section_slug={@section_slug} preview_mode={@preview_mode} />

--- a/lib/oli_web/components/delivery/instructor_dashboard.ex
+++ b/lib/oli_web/components/delivery/instructor_dashboard.ex
@@ -159,7 +159,15 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard do
 
   attr :active_tab, :atom,
     required: true,
-    values: [:learning_objectives, :students, :content, :discussions, :course_discussion, :assignments, :manage]
+    values: [
+      :learning_objectives,
+      :students,
+      :content,
+      :discussions,
+      :course_discussion,
+      :assignments,
+      :manage
+    ]
 
   attr :section_slug, :string, required: true
   attr :preview_mode, :boolean, required: true
@@ -358,9 +366,7 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard do
 
   def students(assigns) do
     ~H"""
-      <.tabs active_tab={:students} section_slug={@section_slug} preview_mode={@preview_mode} />
 
-      <p class="mx-auto">Not available yet</p>
     """
   end
 

--- a/lib/oli_web/components/delivery/students/students.ex
+++ b/lib/oli_web/components/delivery/students/students.ex
@@ -63,25 +63,23 @@ defmodule OliWeb.Components.Delivery.Students do
 
   def render(assigns) do
     ~F"""
-    <div class="p-10">
-      <div class="bg-white w-full">
-        <div class="flex items-center border-b border-b-gray-200 pr-6">
-          <h4 class="px-10 py-6 torus-h4 mr-auto">Students</h4>
-          <form for="search" phx-target={@myself} phx-change="search_student" phx-debounce="5000">
-            <SearchInput.render id="students_search_input" name="student_name" text={@params.text_search}/>
-          </form>
-        </div>
-
-        <PagedTable
-          table_model={@students_table_model}
-          total_count={@total_count}
-          offset={@params.offset}
-          limit={@params.limit}
-          filter={@params.text_search}
-          additional_table_class="border-0"
-          sort={JS.push("paged_table_sort", target: @myself)}
-        />
+    <div class="px-10 pb-10">
+      <div class="flex flex-col sm:flex-row sm:items-center pr-6 bg-white">
+        <h4 class="pl-9 torus-h4 mr-auto">Students</h4>
+        <form for="search" phx-target={@myself} phx-change="search_student" class="pb-6 ml-9 sm:pb-0">
+          <SearchInput.render id="students_search_input" name="student_name" text={@params.text_search} />
+        </form>
       </div>
+
+      <PagedTable
+        table_model={@students_table_model}
+        total_count={@total_count}
+        offset={@params.offset}
+        limit={@params.limit}
+        render_top_info={false}
+        additional_table_class="instructor_dashboard_table"
+        sort={JS.push("paged_table_sort", target: @myself)}
+      />
     </div>
     """
   end

--- a/lib/oli_web/components/delivery/students/students.ex
+++ b/lib/oli_web/components/delivery/students/students.ex
@@ -68,7 +68,7 @@ defmodule OliWeb.Components.Delivery.Students do
         <div class="flex items-center border-b border-b-gray-200 pr-6">
           <h4 class="px-10 py-6 torus-h4 mr-auto">Students</h4>
           <form for="search" phx-target={@myself} phx-change="search_student" phx-debounce="5000">
-            <SearchInput.render id="students_search_input" name="student_name" />
+            <SearchInput.render id="students_search_input" name="student_name" text={@params.text_search}/>
           </form>
         </div>
 

--- a/lib/oli_web/components/delivery/students/students.ex
+++ b/lib/oli_web/components/delivery/students/students.ex
@@ -1,0 +1,46 @@
+defmodule OliWeb.Components.Delivery.Students do
+  use Surface.LiveComponent
+
+  alias OliWeb.Common.{PagedTable, SearchInput}
+
+  prop limit, :number, default: 10
+  prop filter, :string, required: true
+  prop offset, :number, required: true
+  prop count, :number, required: true
+  prop students_table_model, :struct, required: true
+
+  def mount(socket) do
+    {:ok, socket}
+  end
+
+  def render(assigns) do
+    ~F"""
+        <div class="p-10">
+      <div class="bg-white w-full">
+        <div class="flex items-center border-b border-b-gray-200 pr-6">
+          <h4 class="px-10 py-6 torus-h4 mr-auto">Students</h4>
+          <form for="search" phx-target={@myself} phx-change="search_student" phx-debounce="5000">
+            <SearchInput.render
+                    id="students_search_input"
+                    name="student_name"
+                  />
+          </form>
+        </div>
+
+          <PagedTable
+            table_model={@students_table_model}
+            total_count={@count}
+            offset={@offset}
+            limit={@limit}
+            additional_table_class="border-0"
+            />
+            </div>
+            </div>
+    """
+  end
+
+  def handle_event("search_student", %{"student_name" => student_name}, socket) do
+    IO.inspect(student_name)
+    {:noreply, socket}
+  end
+end

--- a/lib/oli_web/components/delivery/students/students.ex
+++ b/lib/oli_web/components/delivery/students/students.ex
@@ -43,6 +43,14 @@ defmodule OliWeb.Components.Delivery.Students do
 
     {:ok, table_model} = EnrollmentsTableModel.new(enrollments, section, context)
 
+    table_model =
+      Map.merge(table_model, %{
+        rows: enrollments,
+        sort_order: params.sort_order,
+        sort_by_spec:
+          Enum.find(table_model.column_specs, fn col_spec -> col_spec.name == params.sort_by end)
+      })
+
     {:ok,
      assign(socket,
        total_count: determine_total(enrollments),

--- a/lib/oli_web/components/delivery/students/students.ex
+++ b/lib/oli_web/components/delivery/students/students.ex
@@ -63,7 +63,7 @@ defmodule OliWeb.Components.Delivery.Students do
 
   def render(assigns) do
     ~F"""
-    <div class="px-10 pb-10">
+    <div class="mx-10 mb-10 bg-white shadow-sm">
       <div class="flex flex-col sm:flex-row sm:items-center pr-6 bg-white">
         <h4 class="pl-9 torus-h4 mr-auto">Students</h4>
         <form for="search" phx-target={@myself} phx-change="search_student" class="pb-6 ml-9 sm:pb-0">

--- a/lib/oli_web/components/delivery/students/students.ex
+++ b/lib/oli_web/components/delivery/students/students.ex
@@ -79,6 +79,7 @@ defmodule OliWeb.Components.Delivery.Students do
         render_top_info={false}
         additional_table_class="instructor_dashboard_table"
         sort={JS.push("paged_table_sort", target: @myself)}
+        page_change={JS.push("paged_table_page_change", target: @myself)}
       />
     </div>
     """
@@ -93,6 +94,19 @@ defmodule OliWeb.Components.Delivery.Students do
            OliWeb.Delivery.InstructorDashboard.StudentsLive,
            socket.assigns.section_slug,
            update_params(socket.assigns.params, %{text_search: student_name})
+         )
+     )}
+  end
+
+  def handle_event("paged_table_page_change", %{"limit" => limit, "offset" => offset}, socket) do
+    {:noreply,
+     push_patch(socket,
+       to:
+         Routes.live_path(
+           socket,
+           OliWeb.Delivery.InstructorDashboard.StudentsLive,
+           socket.assigns.section_slug,
+           update_params(socket.assigns.params, %{limit: limit, offset: offset})
          )
      )}
   end

--- a/lib/oli_web/components/delivery/students/students.ex
+++ b/lib/oli_web/components/delivery/students/students.ex
@@ -124,8 +124,10 @@ defmodule OliWeb.Components.Delivery.Students do
   end
 
   defp add_students_progress(users, section_id, container_id) do
+    users_progress = Metrics.progress_for(section_id, Enum.map(users, & &1.id), container_id)
+
     Enum.map(users, fn user ->
-      Map.merge(user, %{progress: Metrics.progress_for(section_id, user.id, container_id)})
+      Map.merge(user, %{progress: Map.get(users_progress, user.id)})
     end)
   end
 

--- a/lib/oli_web/live/common/paged_table.ex
+++ b/lib/oli_web/live/common/paged_table.ex
@@ -14,11 +14,12 @@ defmodule OliWeb.Common.PagedTable do
   prop selection_change, :event, default: "paged_table_selection_change"
   prop show_bottom_paging, :boolean, default: true
   prop additional_table_class, :string, default: ""
+  prop render_top_info, :boolean, default: true
 
   def render(assigns) do
     ~F"""
-      <div>
-        {#if @filter != ""}
+      <div class="overflow-x-scroll">
+        {#if @filter != "" and @render_top_info}
           <strong>Results filtered on &quot;{@filter}&quot;</strong>
         {/if}
 
@@ -29,7 +30,9 @@ defmodule OliWeb.Common.PagedTable do
             <Paging id="footer_paging" total_count={@total_count} offset={@offset} limit={@limit} click={@page_change}/>
           {/if}
         {#elseif @total_count > 0}
-          <div class="px-5 py-2">Showing all results ({@total_count} total)</div>
+          {#if @render_top_info}
+            <div class="px-5 py-2">Showing all results ({@total_count} total)</div>
+          {/if}
           {render_table(assigns)}
         {#else}
           <p class="px-5 py-2">None exist</p>

--- a/lib/oli_web/live/common/search_input.ex
+++ b/lib/oli_web/live/common/search_input.ex
@@ -3,20 +3,11 @@ defmodule OliWeb.Common.SearchInput do
 
   alias Phoenix.LiveView.JS
 
-  # prop apply, :event, default: "text_search_apply"
-  # prop reset, :event, default: "text_search_reset"
-  # prop change, :event, default: "text_search_change"
-  # prop placeholder, :string, default: "Search..."
-  # prop text, :string, default: ""
-  # prop event_target, :any, required: false, default: :live_view
   attr :class, :string, default: nil
   attr :placeholder, :string, default: ""
   attr :text, :string, default: ""
   attr :id, :string, required: true
   attr :name, :string, required: true
-
-  # attr :on_change, :string, required: true
-  # attr :phx_target, :any, required: true
 
   def render(assigns) do
     ~H"""
@@ -26,20 +17,4 @@ defmodule OliWeb.Common.SearchInput do
       </div>
     """
   end
-
-  # def handle_delegated(event, params, socket, patch_fn) do
-  #   delegate_handle_event(event, params, socket, patch_fn)
-  # end
-
-  # def delegate_handle_event("text_search_reset", %{"id" => _id}, socket, patch_fn) do
-  #   patch_fn.(socket, %{text_search: "", offset: 0})
-  # end
-
-  # def delegate_handle_event("text_search_change", %{"value" => value}, socket, patch_fn) do
-  #   patch_fn.(socket, %{text_search: value, offset: 0})
-  # end
-
-  # def delegate_handle_event(_, _, _, _) do
-  #   :not_handled
-  # end
 end

--- a/lib/oli_web/live/common/search_input.ex
+++ b/lib/oli_web/live/common/search_input.ex
@@ -1,0 +1,45 @@
+defmodule OliWeb.Common.SearchInput do
+  use Phoenix.Component
+
+  alias Phoenix.LiveView.JS
+
+  # prop apply, :event, default: "text_search_apply"
+  # prop reset, :event, default: "text_search_reset"
+  # prop change, :event, default: "text_search_change"
+  # prop placeholder, :string, default: "Search..."
+  # prop text, :string, default: ""
+  # prop event_target, :any, required: false, default: :live_view
+  attr :class, :string, default: nil
+  attr :placeholder, :string, default: ""
+  attr :text, :string, default: ""
+  attr :id, :string, required: true
+  attr :name, :string, required: true
+
+  # attr :on_change, :string, required: true
+  # attr :phx_target, :any, required: true
+
+  def render(assigns) do
+    ~H"""
+      <div>
+        <i id={"#{@id}-icon"} class="absolute fa-solid fa-magnifying-glass pl-3 pt-3 h-4 w-4 "></i>
+        <input id={"#{@id}-input"} phx-debounce="300" phx-focus={JS.add_class("text-delivery-primary", to: "##{@id}-icon")} phx-blur={JS.remove_class("text-delivery-primary", to: "##{@id}-icon")} type="text" class="h-9 w-44 rounded border pl-9 focus:ring-1 focus:ring-delivery-primary focus:outline-2" placeholder={@placeholder} value={@text} name={@name}>
+      </div>
+    """
+  end
+
+  # def handle_delegated(event, params, socket, patch_fn) do
+  #   delegate_handle_event(event, params, socket, patch_fn)
+  # end
+
+  # def delegate_handle_event("text_search_reset", %{"id" => _id}, socket, patch_fn) do
+  #   patch_fn.(socket, %{text_search: "", offset: 0})
+  # end
+
+  # def delegate_handle_event("text_search_change", %{"value" => value}, socket, patch_fn) do
+  #   patch_fn.(socket, %{text_search: value, offset: 0})
+  # end
+
+  # def delegate_handle_event(_, _, _, _) do
+  #   :not_handled
+  # end
+end

--- a/lib/oli_web/live/common/sortable_table/table.ex
+++ b/lib/oli_web/live/common/sortable_table/table.ex
@@ -47,6 +47,9 @@ defmodule OliWeb.Common.SortableTable.Table do
       {column_spec.label}
       {#if @model.sort_by_spec == column_spec}
         <i class={"fas fa-sort-" <> sort_direction_cls} />
+        <span class={"data-sort-" <> sort_direction_cls} data-sort-column="true"></span>
+      {#else}
+        <span class="data-sort-up" data-sort-column="false"></span>
       {/if}
     </th>
     """

--- a/lib/oli_web/live/common/text_search.ex
+++ b/lib/oli_web/live/common/text_search.ex
@@ -4,13 +4,14 @@ defmodule OliWeb.Common.TextSearch do
   prop apply, :event, default: "text_search_apply"
   prop reset, :event, default: "text_search_reset"
   prop change, :event, default: "text_search_change"
+  prop placeholder, :string, default: "Search..."
   prop text, :string, default: ""
   prop event_target, :any, required: false, default: :live_view
 
   def render(%{id: id} = assigns) do
     ~F"""
       <div class="input-group" style="max-width: 350px;">
-        <input id={"#{id}-input"} type="text" class="form-control" placeholder="Search..." value={@text} phx-hook="TextInputListener" phx-hook-target={@event_target} phx-target={@event_target} phx-value-change={@change}>
+        <input id={"#{id}-input"} type="text" class="form-control" placeholder={@placeholder} value={@text} phx-hook="TextInputListener" phx-hook-target={@event_target} phx-target={@event_target} phx-value-change={@change}>
         {#if @text != ""}
           <div class="input-group-append">
             <button class="btn btn-outline-secondary" :on-click={@reset} phx-value-id={@id}><i class="fas fa-times"></i></button>

--- a/lib/oli_web/live/delivery/instructor_dashboard/students_live.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/students_live.ex
@@ -1,19 +1,121 @@
 defmodule OliWeb.Delivery.InstructorDashboard.StudentsLive do
-  use OliWeb, :live_view
+  # use OliWeb, :live_view
+  use Surface.LiveView
 
   alias OliWeb.Components.Delivery.InstructorDashboard
+  alias Oli.Repo.{Paging, Sorting}
+  alias Oli.Delivery.Sections.EnrollmentBrowseOptions
+  alias OliWeb.Delivery.Sections.EnrollmentsTableModel
+  alias Oli.Delivery.Sections
+  alias OliWeb.Common.Params
+  alias OliWeb.Common.Table.SortableTableModel
+  alias Oli.Delivery.Metrics
 
+  @limit 25
+  @default_options %EnrollmentBrowseOptions{
+    is_student: true,
+    is_instructor: false,
+    text_search: nil
+  }
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    {:ok, socket}
+    %{total_count: total_count, table_model: table_model} =
+      student_assigns(socket.assigns.section, socket.assigns.context)
+
+    {:ok,
+     assign(socket,
+       total_count: total_count,
+       table_model: table_model,
+       options: @default_options
+     )}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_params(params, _, socket) do
+    table_model =
+      SortableTableModel.update_from_params(
+        socket.assigns.table_model,
+        params
+      )
+
+    offset = Params.get_int_param(params, "offset", 0)
+    limit = Params.get_int_param(params, "limit", @limit)
+    container_id = Params.get_param(params, "container_id", nil)
+
+    options = %EnrollmentBrowseOptions{
+      text_search: Params.get_param(params, "text_search", ""),
+      is_student: true,
+      is_instructor: false
+    }
+
+    enrollments =
+      Sections.browse_enrollments(
+        socket.assigns.section,
+        %Paging{offset: offset, limit: limit},
+        %Sorting{direction: table_model.sort_order, field: table_model.sort_by_spec.name},
+        options
+      )
+      |> add_students_progress(socket.assigns.section.id, container_id)
+
+    table_model = Map.put(table_model, :rows, enrollments)
+    total_count = determine_total(enrollments)
+
+    {:noreply,
+     assign(socket,
+       offset: offset,
+       limit: limit,
+       table_model: table_model,
+       total_count: total_count,
+       options: options,
+       active_tab: :students
+     )}
   end
 
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
       <InstructorDashboard.main_layout {assigns}>
-        <InstructorDashboard.students {assigns} />
+         <InstructorDashboard.tabs active_tab={@active_tab} section_slug={@section_slug} preview_mode={@preview_mode} />
+
+    <.live_component
+        id="students_table"
+        module={OliWeb.Components.Delivery.Students}
+        limit={@limit}
+        filter={""}
+        offset={@offset}
+        count={@total_count}
+        students_table_model={@table_model}
+         />
       </InstructorDashboard.main_layout>
     """
+  end
+
+  defp student_assigns(section, context, container_id \\ nil) do
+    enrollments =
+      Sections.browse_enrollments(
+        section,
+        %Paging{offset: 0, limit: @limit},
+        %Sorting{direction: :asc, field: :name},
+        @default_options
+      )
+      |> add_students_progress(section.id, container_id)
+
+    {:ok, table_model} = EnrollmentsTableModel.new(enrollments, section, context)
+
+    %{total_count: determine_total(enrollments), table_model: table_model}
+  end
+
+  defp add_students_progress(users, section_id, container_id) do
+    users
+    |> Enum.map(fn user ->
+      Map.merge(user, %{progress: Metrics.progress_for(section_id, user.id, container_id)})
+    end)
+  end
+
+  defp determine_total(projects) do
+    case(projects) do
+      [] -> 0
+      [hd | _] -> hd.total_count
+    end
   end
 end

--- a/lib/oli_web/live/delivery/instructor_dashboard/students_live.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/students_live.ex
@@ -1,121 +1,32 @@
 defmodule OliWeb.Delivery.InstructorDashboard.StudentsLive do
-  # use OliWeb, :live_view
-  use Surface.LiveView
+  use OliWeb, :live_view
 
   alias OliWeb.Components.Delivery.InstructorDashboard
-  alias Oli.Repo.{Paging, Sorting}
-  alias Oli.Delivery.Sections.EnrollmentBrowseOptions
-  alias OliWeb.Delivery.Sections.EnrollmentsTableModel
-  alias Oli.Delivery.Sections
-  alias OliWeb.Common.Params
-  alias OliWeb.Common.Table.SortableTableModel
-  alias Oli.Delivery.Metrics
 
-  @limit 25
-  @default_options %EnrollmentBrowseOptions{
-    is_student: true,
-    is_instructor: false,
-    text_search: nil
-  }
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    %{total_count: total_count, table_model: table_model} =
-      student_assigns(socket.assigns.section, socket.assigns.context)
-
-    {:ok,
-     assign(socket,
-       total_count: total_count,
-       table_model: table_model,
-       options: @default_options
-     )}
+    {:ok, assign(socket, active_tab: :students)}
   end
 
   @impl Phoenix.LiveView
   def handle_params(params, _, socket) do
-    table_model =
-      SortableTableModel.update_from_params(
-        socket.assigns.table_model,
-        params
-      )
-
-    offset = Params.get_int_param(params, "offset", 0)
-    limit = Params.get_int_param(params, "limit", @limit)
-    container_id = Params.get_param(params, "container_id", nil)
-
-    options = %EnrollmentBrowseOptions{
-      text_search: Params.get_param(params, "text_search", ""),
-      is_student: true,
-      is_instructor: false
-    }
-
-    enrollments =
-      Sections.browse_enrollments(
-        socket.assigns.section,
-        %Paging{offset: offset, limit: limit},
-        %Sorting{direction: table_model.sort_order, field: table_model.sort_by_spec.name},
-        options
-      )
-      |> add_students_progress(socket.assigns.section.id, container_id)
-
-    table_model = Map.put(table_model, :rows, enrollments)
-    total_count = determine_total(enrollments)
-
-    {:noreply,
-     assign(socket,
-       offset: offset,
-       limit: limit,
-       table_model: table_model,
-       total_count: total_count,
-       options: options,
-       active_tab: :students
-     )}
+    {:noreply, assign(socket, params: params)}
   end
 
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
       <InstructorDashboard.main_layout {assigns}>
-         <InstructorDashboard.tabs active_tab={@active_tab} section_slug={@section_slug} preview_mode={@preview_mode} />
+        <InstructorDashboard.tabs active_tab={@active_tab} section_slug={@section_slug} preview_mode={@preview_mode} />
 
-    <.live_component
-        id="students_table"
-        module={OliWeb.Components.Delivery.Students}
-        limit={@limit}
-        filter={""}
-        offset={@offset}
-        count={@total_count}
-        students_table_model={@table_model}
-         />
+        <.live_component
+            id="students_table"
+            module={OliWeb.Components.Delivery.Students}
+            params={@params}
+            context={@context}
+            section={@section}
+            />
       </InstructorDashboard.main_layout>
     """
-  end
-
-  defp student_assigns(section, context, container_id \\ nil) do
-    enrollments =
-      Sections.browse_enrollments(
-        section,
-        %Paging{offset: 0, limit: @limit},
-        %Sorting{direction: :asc, field: :name},
-        @default_options
-      )
-      |> add_students_progress(section.id, container_id)
-
-    {:ok, table_model} = EnrollmentsTableModel.new(enrollments, section, context)
-
-    %{total_count: determine_total(enrollments), table_model: table_model}
-  end
-
-  defp add_students_progress(users, section_id, container_id) do
-    users
-    |> Enum.map(fn user ->
-      Map.merge(user, %{progress: Metrics.progress_for(section_id, user.id, container_id)})
-    end)
-  end
-
-  defp determine_total(projects) do
-    case(projects) do
-      [] -> 0
-      [hd | _] -> hd.total_count
-    end
   end
 end

--- a/lib/oli_web/live/sections/enrollments/enrollments_view.ex
+++ b/lib/oli_web/live/sections/enrollments/enrollments_view.ex
@@ -209,8 +209,10 @@ defmodule OliWeb.Sections.EnrollmentsView do
   end
 
   defp add_students_progress(users, section_id, container_id) do
+    users_progress = Metrics.progress_for(section_id, Enum.map(users, & &1.id), container_id)
+
     Enum.map(users, fn user ->
-      Map.merge(user, %{progress: Metrics.progress_for(section_id, user.id, container_id)})
+      Map.merge(user, %{progress: Map.get(users_progress, user.id)})
     end)
   end
 end

--- a/lib/oli_web/live/sections/enrollments/enrollments_view.ex
+++ b/lib/oli_web/live/sections/enrollments/enrollments_view.ex
@@ -14,6 +14,7 @@ defmodule OliWeb.Sections.EnrollmentsView do
   alias OliWeb.Sections.Mount
   alias OliWeb.Common.SessionContext
   alias Surface.Components.Link
+  alias Oli.Delivery.Metrics
 
   @limit 25
   @default_options %EnrollmentBrowseOptions{
@@ -103,6 +104,7 @@ defmodule OliWeb.Sections.EnrollmentsView do
         %Sorting{direction: table_model.sort_order, field: table_model.sort_by_spec.name},
         options
       )
+      |> add_students_progress(socket.assigns.section.id, nil)
 
     table_model = Map.put(table_model, :rows, enrollments)
     total_count = determine_total(enrollments)
@@ -197,10 +199,18 @@ defmodule OliWeb.Sections.EnrollmentsView do
         %Sorting{direction: :asc, field: :name},
         @default_options
       )
+      |> add_students_progress(section.id, nil)
 
     total_count = determine_total(enrollments)
+
     {:ok, table_model} = EnrollmentsTableModel.new(enrollments, section, context)
 
     %{total_count: total_count, table_model: table_model}
+  end
+
+  defp add_students_progress(users, section_id, container_id) do
+    Enum.map(users, fn user ->
+      Map.merge(user, %{progress: Metrics.progress_for(section_id, user.id, container_id)})
+    end)
   end
 end

--- a/lib/oli_web/live/sections/enrollments_table_model.ex
+++ b/lib/oli_web/live/sections/enrollments_table_model.ex
@@ -1,7 +1,7 @@
 defmodule OliWeb.Delivery.Sections.EnrollmentsTableModel do
   alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
   alias OliWeb.Router.Helpers, as: Routes
-  import OliWeb.Common.Utils
+  alias OliWeb.Common.Utils
   use Surface.LiveComponent
 
   def render(assigns) do
@@ -11,38 +11,46 @@ defmodule OliWeb.Delivery.Sections.EnrollmentsTableModel do
   end
 
   def new(users, section, context) do
-    base_columns = [
-      %ColumnSpec{name: :name, label: "Name", render_fn: &__MODULE__.render_name_column/3},
+    column_specs = [
       %ColumnSpec{
-        name: :email,
-        label: "Email",
-        render_fn: &OliWeb.Users.Common.render_email_column/3
+        name: :name,
+        label: "STUDENT NAME",
+        render_fn: &__MODULE__.render_name_column/3
       },
       %ColumnSpec{
-        name: :enrollment_date,
-        label: "Enrolled On",
-        render_fn: &OliWeb.Common.Table.Common.render_date/3
+        name: :last_interaction,
+        label: "LAST INTERACTED",
+        render_fn: &__MODULE__.stub_last_interacted/3
       },
       %ColumnSpec{
-        name: :unenroll,
-        label: "Unenroll",
-        render_fn: &__MODULE__.render_unenroll_column/3
+        name: :progress,
+        label: "COURSE PROGRESS"
+      },
+      %ColumnSpec{
+        name: :overall_mastery,
+        label: "OVERALL COURSE MASTERY",
+        render_fn: &__MODULE__.stub_overall_mastery/3
+      },
+      %ColumnSpec{
+        name: :engagement,
+        label: "COURSE ENGAGEMENT",
+        render_fn: &__MODULE__.stub_engagement/3
       }
     ]
 
-    column_specs =
-      if section.requires_payment do
-        base_columns ++
-          [
-            %ColumnSpec{
-              name: :payment_date,
-              label: "Paid On",
-              render_fn: &OliWeb.Common.Table.Common.render_date/3
-            }
-          ]
-      else
-        base_columns
-      end
+    # column_specs =
+    #   if section.requires_payment do
+    #     base_columns ++
+    #       [
+    #         %ColumnSpec{
+    #           name: :payment_date,
+    #           label: "Paid On",
+    #           render_fn: &OliWeb.Common.Table.Common.render_date/3
+    #         }
+    #       ]
+    #   else
+    #     base_columns
+    #   end
 
     SortableTableModel.new(
       rows: users,
@@ -67,9 +75,12 @@ defmodule OliWeb.Delivery.Sections.EnrollmentsTableModel do
         _
       ) do
     ~F"""
-    <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Progress.StudentView, assigns.section_slug, id)}>
-      {name(name, given_name, family_name)}
-    </a>
+    <div class="flex items-center ml-10">
+      <div class="rounded-full w-2 h-2 bg-red-500"></div>
+      <a class="ml-6" href={Routes.live_path(OliWeb.Endpoint, OliWeb.Progress.StudentView, assigns.section_slug, id)}>
+        {Utils.name(name, given_name, family_name)}
+      </a>
+    </div>
     """
   end
 
@@ -80,4 +91,27 @@ defmodule OliWeb.Delivery.Sections.EnrollmentsTableModel do
     </button>
     """
   end
+
+  def stub_last_interacted(assigns, _user, _) do
+    random_datetime = DateTime.utc_now() |> DateTime.add(-Enum.random(1..365), :day)
+    assigns = Map.merge(assigns, %{last_interacted_stub: random_datetime})
+
+    ~F"""
+      {Timex.format!(@last_interacted_stub, "{Mshort}. {0D}, {YYYY} - {h12}:{m} {AM}")}
+    """
+  end
+
+  def stub_overall_mastery(assigns, _user, _) do
+    ~F"""
+       {random_stub()}
+    """
+  end
+
+  def stub_engagement(assigns, _user, _) do
+    ~F"""
+      {random_stub()}
+    """
+  end
+
+  defp random_stub(), do: Enum.random(["Low", "Medium", "High", "Not enough data"])
 end

--- a/lib/oli_web/live/sections/enrollments_table_model.ex
+++ b/lib/oli_web/live/sections/enrollments_table_model.ex
@@ -68,7 +68,7 @@ defmodule OliWeb.Delivery.Sections.EnrollmentsTableModel do
         _
       ) do
     assigns = Map.merge(assigns, %{progress: parse_progress(progress)})
-
+    # TODO link to "Student Details View" (not yet developed) instead of "Student Progress View"
     ~F"""
     <div class="flex items-center ml-8">
       <div class={"flex flex-shrink-0 rounded-full w-2 h-2 #{if @progress < 50, do: "bg-red-600", else: "bg-gray-500"}"}></div>

--- a/lib/oli_web/live/sections/enrollments_table_model.ex
+++ b/lib/oli_web/live/sections/enrollments_table_model.ex
@@ -38,20 +38,6 @@ defmodule OliWeb.Delivery.Sections.EnrollmentsTableModel do
       }
     ]
 
-    # column_specs =
-    #   if section.requires_payment do
-    #     base_columns ++
-    #       [
-    #         %ColumnSpec{
-    #           name: :payment_date,
-    #           label: "Paid On",
-    #           render_fn: &OliWeb.Common.Table.Common.render_date/3
-    #         }
-    #       ]
-    #   else
-    #     base_columns
-    #   end
-
     SortableTableModel.new(
       rows: users,
       column_specs: column_specs,
@@ -76,8 +62,11 @@ defmodule OliWeb.Delivery.Sections.EnrollmentsTableModel do
       ) do
     ~F"""
     <div class="flex items-center ml-10">
-      <div class="rounded-full w-2 h-2 bg-red-500"></div>
-      <a class="ml-6" href={Routes.live_path(OliWeb.Endpoint, OliWeb.Progress.StudentView, assigns.section_slug, id)}>
+      <div class="rounded-full w-2 h-2 bg-red-500" />
+      <a
+        class="ml-6"
+        href={Routes.live_path(OliWeb.Endpoint, OliWeb.Progress.StudentView, assigns.section_slug, id)}
+      >
         {Utils.name(name, given_name, family_name)}
       </a>
     </div>
@@ -97,19 +86,19 @@ defmodule OliWeb.Delivery.Sections.EnrollmentsTableModel do
     assigns = Map.merge(assigns, %{last_interacted_stub: random_datetime})
 
     ~F"""
-      {Timex.format!(@last_interacted_stub, "{Mshort}. {0D}, {YYYY} - {h12}:{m} {AM}")}
+    {Timex.format!(@last_interacted_stub, "{Mshort}. {0D}, {YYYY} - {h12}:{m} {AM}")}
     """
   end
 
   def stub_overall_mastery(assigns, _user, _) do
     ~F"""
-       {random_stub()}
+    {random_stub()}
     """
   end
 
   def stub_engagement(assigns, _user, _) do
     ~F"""
-      {random_stub()}
+    {random_stub()}
     """
   end
 

--- a/test/oli/delivery/metrics/progress_test.exs
+++ b/test/oli/delivery/metrics/progress_test.exs
@@ -52,59 +52,102 @@ defmodule Oli.Delivery.Metrics.ProgressTest do
       unit1_resource: unit1_resource,
       unit2_resource: unit2_resource
     } do
-
       # Verify the modules
-      assert_in_delta 0.5, Metrics.progress_for(section.id, this_user.id, mod1_resource.id), 0.0001
-      assert_in_delta 0.2, Metrics.progress_for(section.id, this_user.id, mod2_resource.id), 0.0001
-      assert_in_delta 0.25, Metrics.progress_for(section.id, this_user.id, mod3_resource.id), 0.0001
+      assert_in_delta 0.5,
+                      Map.get(
+                        Metrics.progress_for(section.id, this_user.id, mod1_resource.id),
+                        this_user.id
+                      ),
+                      0.0001
+
+      assert_in_delta 0.2,
+                      Map.get(
+                        Metrics.progress_for(section.id, this_user.id, mod2_resource.id),
+                        this_user.id
+                      ),
+                      0.0001
+
+      assert_in_delta 0.25,
+                      Map.get(
+                        Metrics.progress_for(section.id, this_user.id, mod3_resource.id),
+                        this_user.id
+                      ),
+                      0.0001
 
       # Then the units
-      assert_in_delta 0.35, Metrics.progress_for(section.id, this_user.id, unit1_resource.id), 0.0001
-      assert_in_delta 0.25, Metrics.progress_for(section.id, this_user.id, unit2_resource.id), 0.0001
+      assert_in_delta 0.35,
+                      Map.get(
+                        Metrics.progress_for(section.id, this_user.id, unit1_resource.id),
+                        this_user.id
+                      ),
+                      0.0001
+
+      assert_in_delta 0.25,
+                      Map.get(
+                        Metrics.progress_for(section.id, this_user.id, unit2_resource.id),
+                        this_user.id
+                      ),
+                      0.0001
 
       # Then the entire course (there are two other pages, outside of the units)
-      assert_in_delta 0.2583, Metrics.progress_for(section.id, this_user.id), 0.0001
-      assert_in_delta 0.2583, Metrics.progress_for(section.id, this_user.id, nil), 0.0001
+      assert_in_delta 0.2583,
+                      Map.get(Metrics.progress_for(section.id, this_user.id), this_user.id),
+                      0.0001
 
+      assert_in_delta 0.2583,
+                      Map.get(Metrics.progress_for(section.id, this_user.id, nil), this_user.id),
+                      0.0001
     end
 
-    test "container based progress across collection of containers works correctly", %{
-      section: section,
-      this_user: this_user,
-      mod1_resource: mod1_resource,
-      mod2_resource: mod2_resource,
-      mod3_resource: mod3_resource,
-      unit1_resource: unit1_resource,
-      unit2_resource: unit2_resource
-    } = map do
-
-      [r1, r2, r3] = Metrics.progress_across(section.id, [mod1_resource.id, mod2_resource.id, mod3_resource.id], this_user.id)
-      |> Enum.map(fn r -> r.progress end)
-      |> Enum.sort()
-
-      assert_in_delta 0.2, r1, 0.0001
-      assert_in_delta 0.25, r2, 0.0001
-      assert_in_delta 0.5, r3, 0.0001
-
-      [r1, r2, r3] = Metrics.progress_across(section.id, [mod1_resource.id, mod2_resource.id, mod3_resource.id], [], 1)
-      |> Enum.map(fn r -> r.progress end)
-      |> Enum.sort()
+    test "container based progress across collection of containers works correctly",
+         %{
+           section: section,
+           this_user: this_user,
+           mod1_resource: mod1_resource,
+           mod2_resource: mod2_resource,
+           mod3_resource: mod3_resource,
+           unit1_resource: unit1_resource,
+           unit2_resource: unit2_resource
+         } = map do
+      [r1, r2, r3] =
+        Metrics.progress_across(
+          section.id,
+          [mod1_resource.id, mod2_resource.id, mod3_resource.id],
+          this_user.id
+        )
+        |> Enum.map(fn r -> r.progress end)
+        |> Enum.sort()
 
       assert_in_delta 0.2, r1, 0.0001
       assert_in_delta 0.25, r2, 0.0001
       assert_in_delta 0.5, r3, 0.0001
 
+      [r1, r2, r3] =
+        Metrics.progress_across(
+          section.id,
+          [mod1_resource.id, mod2_resource.id, mod3_resource.id],
+          [],
+          1
+        )
+        |> Enum.map(fn r -> r.progress end)
+        |> Enum.sort()
 
-      [r1, r2] = Metrics.progress_across(section.id, [unit1_resource.id, unit2_resource.id], this_user.id)
-      |> Enum.map(fn r -> r.progress end)
-      |> Enum.sort()
+      assert_in_delta 0.2, r1, 0.0001
+      assert_in_delta 0.25, r2, 0.0001
+      assert_in_delta 0.5, r3, 0.0001
+
+      [r1, r2] =
+        Metrics.progress_across(section.id, [unit1_resource.id, unit2_resource.id], this_user.id)
+        |> Enum.map(fn r -> r.progress end)
+        |> Enum.sort()
 
       assert_in_delta 0.25, r1, 0.0001
       assert_in_delta 0.35, r2, 0.0001
 
-      [r1, r2] = Metrics.progress_across(section.id, [unit1_resource.id, unit2_resource.id], [], 1)
-      |> Enum.map(fn r -> r.progress end)
-      |> Enum.sort()
+      [r1, r2] =
+        Metrics.progress_across(section.id, [unit1_resource.id, unit2_resource.id], [], 1)
+        |> Enum.map(fn r -> r.progress end)
+        |> Enum.sort()
 
       assert_in_delta 0.25, r1, 0.0001
       assert_in_delta 0.35, r2, 0.0001
@@ -118,77 +161,90 @@ defmodule Oli.Delivery.Metrics.ProgressTest do
       set_progress(section.id, p1.published_resource.resource_id, user_id, 1)
       set_progress(section.id, p2.published_resource.resource_id, user_id, 1)
 
-      [r1, r2, r3] = Metrics.progress_across(section.id, [mod1_resource.id, mod2_resource.id, mod3_resource.id], [], 2)
-      |> Enum.map(fn r -> r.progress end)
-      |> Enum.sort()
+      [r1, r2, r3] =
+        Metrics.progress_across(
+          section.id,
+          [mod1_resource.id, mod2_resource.id, mod3_resource.id],
+          [],
+          2
+        )
+        |> Enum.map(fn r -> r.progress end)
+        |> Enum.sort()
 
       assert_in_delta 0.1, r1, 0.0001
       assert_in_delta 0.125, r2, 0.0001
       assert_in_delta 0.5833, r3, 0.0001
 
       # Finally, exclude that student and verify the previous result
-      [r1, r2, r3] = Metrics.progress_across(section.id, [mod1_resource.id, mod2_resource.id, mod3_resource.id], [user_id], 1)
-      |> Enum.map(fn r -> r.progress end)
-      |> Enum.sort()
+      [r1, r2, r3] =
+        Metrics.progress_across(
+          section.id,
+          [mod1_resource.id, mod2_resource.id, mod3_resource.id],
+          [user_id],
+          1
+        )
+        |> Enum.map(fn r -> r.progress end)
+        |> Enum.sort()
 
       assert_in_delta 0.2, r1, 0.0001
       assert_in_delta 0.25, r2, 0.0001
       assert_in_delta 0.5, r3, 0.0001
-
-
     end
 
     test "page level progress calculation and setting", map do
-
       [p1, _, _] = map.mod1_pages
 
-      map = map
-      |> Map.put(:our_page, %{revision: p1.revision, resource: p1.resource})
-      |> Seeder.create_resource_attempt(
-        %{attempt_number: 1, lifecycle_state: :active},
-        :this_user,
-        :our_page,
-        :attempt1)
-      |> Seeder.create_activity_attempt(
-        %{attempt_number: 1, lifecycle_state: :evaluated, scoreable: true},
-        :activity_a,
-        :attempt1,
-        :a1)
-      |> Seeder.create_activity_attempt(
-        %{attempt_number: 1, lifecycle_state: :evaluated, scoreable: true},
-        :activity_b,
-        :attempt1,
-        :a2)
-      |> Seeder.create_activity_attempt(
-        %{attempt_number: 2, lifecycle_state: :evaluated, scoreable: true},
-        :activity_b,
-        :attempt1,
-        :a21)
-      |> Seeder.create_activity_attempt(
-        %{attempt_number: 1, lifecycle_state: :active, scoreable: true},
-        :activity_c,
-        :attempt1,
-        :a3)
-      |> Seeder.create_activity_attempt(
-        %{attempt_number: 1, lifecycle_state: :submitted, scoreable: true},
-        :activity_d,
-        :attempt1,
-        :a4)
-      |> Seeder.create_activity_attempt(
-        %{attempt_number: 1, lifecycle_state: :active, scoreable: false},
-        :activity_e,
-        :attempt1,
-        :a5)
+      map =
+        map
+        |> Map.put(:our_page, %{revision: p1.revision, resource: p1.resource})
+        |> Seeder.create_resource_attempt(
+          %{attempt_number: 1, lifecycle_state: :active},
+          :this_user,
+          :our_page,
+          :attempt1
+        )
+        |> Seeder.create_activity_attempt(
+          %{attempt_number: 1, lifecycle_state: :evaluated, scoreable: true},
+          :activity_a,
+          :attempt1,
+          :a1
+        )
+        |> Seeder.create_activity_attempt(
+          %{attempt_number: 1, lifecycle_state: :evaluated, scoreable: true},
+          :activity_b,
+          :attempt1,
+          :a2
+        )
+        |> Seeder.create_activity_attempt(
+          %{attempt_number: 2, lifecycle_state: :evaluated, scoreable: true},
+          :activity_b,
+          :attempt1,
+          :a21
+        )
+        |> Seeder.create_activity_attempt(
+          %{attempt_number: 1, lifecycle_state: :active, scoreable: true},
+          :activity_c,
+          :attempt1,
+          :a3
+        )
+        |> Seeder.create_activity_attempt(
+          %{attempt_number: 1, lifecycle_state: :submitted, scoreable: true},
+          :activity_d,
+          :attempt1,
+          :a4
+        )
+        |> Seeder.create_activity_attempt(
+          %{attempt_number: 1, lifecycle_state: :active, scoreable: false},
+          :activity_e,
+          :attempt1,
+          :a5
+        )
 
       guid = map.a5.attempt_guid
       assert {:ok, :updated} = Metrics.update_page_progress(guid)
 
       ra = Oli.Repo.get(ResourceAccess, map.attempt1.resource_access_id)
       assert_in_delta 0.75, ra.progress, 0.0001
-
-
     end
-
   end
-
 end

--- a/test/oli_web/live/delivery/instructor_dashboard/students_live_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/students_live_test.exs
@@ -7,12 +7,14 @@ defmodule OliWeb.Delivery.InstructorDashboard.StudentsLiveTest do
 
   alias Lti_1p3.Tool.ContextRoles
   alias Oli.Delivery.Sections
+  alias Oli.Delivery.Attempts.Core
 
-  defp live_view_students_route(section_slug) do
+  defp live_view_students_route(section_slug, params \\ %{}) do
     Routes.live_path(
       OliWeb.Endpoint,
       OliWeb.Delivery.InstructorDashboard.StudentsLive,
-      section_slug
+      section_slug,
+      params
     )
   end
 
@@ -76,5 +78,143 @@ defmodule OliWeb.Delivery.InstructorDashboard.StudentsLiveTest do
       assert render(view) =~
                OliWeb.Common.Utils.name(user.name, user.given_name, user.family_name)
     end
+
+    test "students table gets rendered considering the given url params", %{
+      instructor: instructor,
+      conn: conn
+    } do
+      %{section: section, mod1_pages: mod1_pages, mod1_resource: mod1_resource} =
+        Oli.Seeder.base_project_with_larger_hierarchy()
+
+      [page_1, _page_2, _page_3] = mod1_pages
+
+      user_1 = insert(:user, %{given_name: "Lionel", family_name: "Messi"})
+      user_2 = insert(:user, %{given_name: "Luis", family_name: "Suarez"})
+      user_3 = insert(:user, %{given_name: "Neymar", family_name: "Jr"})
+      user_4 = insert(:user, %{given_name: "Angelito", family_name: "Di Maria"})
+
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+      Sections.enroll(user_1.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.enroll(user_2.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.enroll(user_3.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.enroll(user_4.id, section.id, [ContextRoles.get_role(:context_learner)])
+
+      {:ok, _} = Sections.rebuild_contained_pages(section)
+
+      set_progress(section.id, page_1.published_resource.resource_id, user_1.id, 0.9)
+      set_progress(section.id, page_1.published_resource.resource_id, user_2.id, 0.6)
+      set_progress(section.id, page_1.published_resource.resource_id, user_3.id, 0)
+      set_progress(section.id, page_1.published_resource.resource_id, user_4.id, 0.3)
+
+      ### sorting by student
+      params = %{
+        sort_order: :desc,
+        sort_by: :name
+      }
+
+      {:ok, view, _html} = live(conn, live_view_students_route(section.slug, params))
+
+      [student_for_tr_1, student_for_tr_2, student_for_tr_3, student_for_tr_4] =
+        view
+        |> render()
+        |> Floki.parse_fragment!()
+        |> Floki.find(~s{.instructor_dashboard_table tr a})
+        |> Enum.map(fn a_tag -> Floki.text(a_tag) end)
+
+      assert student_for_tr_1 =~ "Di Maria, Angelito"
+      assert student_for_tr_2 =~ "Jr, Neymar"
+      assert student_for_tr_3 =~ "Suarez, Luis"
+      assert student_for_tr_4 =~ "Messi, Lionel"
+
+      ### text filtering
+      params = %{
+        text_search: "Messi"
+      }
+
+      {:ok, view, _html} = live(conn, live_view_students_route(section.slug, params))
+
+      [student_for_tr_1] =
+        view
+        |> render()
+        |> Floki.parse_fragment!()
+        |> Floki.find(~s{.instructor_dashboard_table tr a})
+        |> Enum.map(fn a_tag -> Floki.text(a_tag) end)
+
+      assert student_for_tr_1 =~ "Messi, Lionel"
+      assert element(view, "#students_search_input-input", "Messi")
+      refute render(view) =~ "Jr, Neymar"
+      refute render(view) =~ "Suarez, Luis"
+      refute render(view) =~ "Di Maria, Angelito"
+
+      ### pagination
+      params = %{
+        offset: 2,
+        limit: 2
+      }
+
+      {:ok, view, _html} = live(conn, live_view_students_route(section.slug, params))
+
+      [student_for_tr_1, student_for_tr_2] =
+        view
+        |> render()
+        |> Floki.parse_fragment!()
+        |> Floki.find(~s{.instructor_dashboard_table tr a})
+        |> Enum.map(fn a_tag -> Floki.text(a_tag) end)
+
+      assert student_for_tr_1 =~ "Jr, Neymar"
+      assert student_for_tr_2 =~ "Di Maria, Angelito"
+      assert element(view, "#header_paging div", "Showing result 2 - 2 of 2 total")
+      assert element(view, "li.page-item.active a", "2")
+      refute render(view) =~ "Suarez, Luis"
+      refute render(view) =~ "Messi, Lionel"
+
+      ### filtering by container
+      params = %{container_id: mod1_resource.id}
+
+      {:ok, view, _html} = live(conn, live_view_students_route(section.slug, params))
+
+      progress =
+        view
+        |> render()
+        |> Floki.parse_fragment!()
+        |> Floki.find(~s{.instructor_dashboard_table tr [data-progress-check]})
+        |> Enum.map(fn div_tag -> Floki.text(div_tag) end)
+
+      assert progress == ["30%", "20%", "0%", "10%"]
+
+      ### filtering by no container
+      ### (we want to get the progress across all course section)
+      params = %{container_id: nil}
+
+      {:ok, view, _html} = live(conn, live_view_students_route(section.slug, params))
+
+      progress =
+        view
+        |> render()
+        |> Floki.parse_fragment!()
+        |> Floki.find(~s{.instructor_dashboard_table tr [data-progress-check]})
+        |> Enum.map(fn div_tag -> Floki.text(div_tag) end)
+
+      assert progress == ["8%", "5%", "0%", "3%"]
+
+      ### filtering by non existing container
+      params = %{container_id: 99999}
+
+      {:ok, view, _html} = live(conn, live_view_students_route(section.slug, params))
+
+      progress =
+        view
+        |> render()
+        |> Floki.parse_fragment!()
+        |> Floki.find(~s{.instructor_dashboard_table tr [data-progress-check]})
+        |> Enum.map(fn div_tag -> Floki.text(div_tag) end)
+
+      assert progress == ["0%", "0%", "0%", "0%"]
+    end
+  end
+
+  defp set_progress(section_id, resource_id, user_id, progress) do
+    Core.track_access(resource_id, section_id, user_id)
+    |> Core.update_resource_access(%{progress: progress})
   end
 end

--- a/test/oli_web/live/delivery/instructor_dashboard/students_live_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/students_live_test.exs
@@ -56,7 +56,10 @@ defmodule OliWeb.Delivery.InstructorDashboard.StudentsLiveTest do
       section: section,
       conn: conn
     } do
+      user = insert(:user)
+
       Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
 
       {:ok, view, _html} = live(conn, live_view_students_route(section.slug))
 
@@ -67,8 +70,11 @@ defmodule OliWeb.Delivery.InstructorDashboard.StudentsLiveTest do
                "Students"
              )
 
-      # Students tab content gets rendered
-      assert has_element?(view, ~s{p}, "Not available yet")
+      # Students table gets rendered
+      assert has_element?(view, "h4", "Students")
+
+      assert render(view) =~
+               OliWeb.Common.Utils.name(user.name, user.given_name, user.family_name)
     end
   end
 end

--- a/test/oli_web/live/publisher_live_test.exs
+++ b/test/oli_web/live/publisher_live_test.exs
@@ -82,7 +82,7 @@ defmodule OliWeb.PublisherLiveTest do
              |> render() =~ "Torus Publisher"
 
       assert view
-             |> element("#publishers-table span")
+             |> element("#publishers-table span.badge")
              |> render() =~ "default"
     end
 

--- a/test/oli_web/live/sections/enrollments_view_test.exs
+++ b/test/oli_web/live/sections/enrollments_view_test.exs
@@ -71,9 +71,7 @@ defmodule OliWeb.Sections.EnrollmentsViewTest do
   describe "gating and scheduling live test admin" do
     setup [:setup_enrollments_view]
 
-    test "mount enrollments for admin", %{section: section} = context do
-      {:ok, conn: conn, context: session_context} = set_timezone(context)
-
+    test "mount enrollments for admin", %{section: section, conn: conn} do
       {:ok, _view, html} =
         live(conn, Routes.live_path(@endpoint, OliWeb.Sections.EnrollmentsView, section.slug))
 
@@ -82,7 +80,7 @@ defmodule OliWeb.Sections.EnrollmentsViewTest do
       assert html =~ "Admin"
       assert html =~ "Enrollments"
       assert html =~ "Download as .CSV"
-      assert html =~ OliWeb.Common.Utils.render_date(e, :inserted_at, session_context)
+      assert html =~ OliWeb.Common.Utils.name(e.user.name, e.user.given_name, e.user.family_name)
     end
   end
 


### PR DESCRIPTION
[Link to ticket](https://eliterate.atlassian.net/browse/MER-1712)

## Notes
The ticket says:

> Another key change that we need to the existing “Manage enrolled students” view is what view the user is routed to when they click on a student’s name.  Currently, instructors are routed to the “Student progress view”, which is a listing of all course pages and the progress for that student. Instead, we need to route the user to the “Student details view” for that student. 

The Students Details view has not yet been developed, so I left the link unchanged. 
When that view gets developed we will be able to update the link