### PR TITLE
[BUG FIX] Fix assignments view rendering when assignment has a non schedule GatingCondition [MER-1839]

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -1982,6 +1982,12 @@ defmodule Oli.Delivery.Sections do
             gc.data["end_datetime"],
             sr.end_date
           ),
+        scheduled_type: sr.scheduling_type,
+        gate_type: fragment(
+          "coalesce(coalesce(cast(? as text), cast(? as text)), NULL) as hard_gate_type",
+          gc2.type,
+          gc.type
+        ),
         graded: rev.graded,
         resource_type_id: rev.resource_type_id,
         numbering_level: sr.numbering_level,

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -1968,12 +1968,13 @@ defmodule Oli.Delivery.Sections do
             gc2.user_id == ^user_id
       )
       |> where(
-        [sr, s],
-        s.slug == ^section_slug and sr.numbering_level >= 0
+        [sr, s, _, _, _, gc, gc2],
+        s.slug == ^section_slug and sr.numbering_level >= 0 and (is_nil(gc) or gc.type == :schedule) and (is_nil(gc2) or gc2.type == :schedule)
       )
       |> select([sr, s, _, _, rev, gc, gc2], %{
         id: sr.id,
         title: rev.title,
+        slug: rev.slug,
         end_date:
           fragment(
             "cast(coalesce(coalesce(cast(? as text), cast(? as text)), cast(? as text)) as date) as end_date",

--- a/lib/oli_web/components/delivery/assignments/assignment_card.ex
+++ b/lib/oli_web/components/delivery/assignments/assignment_card.ex
@@ -3,6 +3,16 @@ defmodule OliWeb.Components.Delivery.AssignmentCard do
 
   alias OliWeb.Router.Helpers, as: Routes
 
+  defp due_date_label(assignment) do
+    case assignment.gate_type do
+      nil -> case assignment.scheduled_type do
+        :read_by -> "Suggested by"
+        _ -> "In class activity"
+      end
+      _ -> "Due by"
+    end
+  end
+
   def render(assigns) do
     ~H"""
       <div class="flex justify-between items-center bg-delivery-header p-8">
@@ -10,7 +20,7 @@ defmodule OliWeb.Components.Delivery.AssignmentCard do
         <div class="flex gap-2">
           <span class="bg-white bg-opacity-10 rounded-sm text-white text-center w-56 py-2">
             <%= if @assignment.end_date do %>
-              Due by <%= @assignment.end_date %>
+              <%= due_date_label(@assignment) %> <%= @assignment.end_date %>
             <% else %>
               No due date
             <% end %>

--- a/lib/oli_web/components/delivery/assignments/assignment_card.ex
+++ b/lib/oli_web/components/delivery/assignments/assignment_card.ex
@@ -1,6 +1,8 @@
 defmodule OliWeb.Components.Delivery.AssignmentCard do
   use Phoenix.Component
 
+  alias OliWeb.Router.Helpers, as: Routes
+
   def render(assigns) do
     ~H"""
       <div class="flex justify-between items-center bg-delivery-header p-8">
@@ -13,7 +15,7 @@ defmodule OliWeb.Components.Delivery.AssignmentCard do
               No due date
             <% end %>
           </span>
-          <button class="torus-button primary px-2">Quiz</button>
+          <a class="torus-button primary px-2" href={Routes.page_delivery_path(OliWeb.Endpoint, :page, @section_slug, @assignment.slug)}>Open</a>
         </div>
       </div>
     """

--- a/lib/oli_web/components/delivery/assignments/assignments_list.ex
+++ b/lib/oli_web/components/delivery/assignments/assignments_list.ex
@@ -10,7 +10,7 @@ defmodule OliWeb.Components.Delivery.AssignmentsList do
       <p>Find all your assignments, quizzes and activities associated with graded material.</p>
       <div class="flex flex-col gap-2 mt-6">
       <%= for assignment <- @assignments do %>
-        <AssignmentCard.render assignment={assignment}/>
+        <AssignmentCard.render assignment={assignment} section_slug={@section_slug}/>
       <% end %>
       </div>
     </div>

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -694,12 +694,14 @@ defmodule Oli.TestHelpers do
     graded_page_3_resource = insert(:resource)
     graded_page_4_resource = insert(:resource)
     graded_page_5_resource = insert(:resource)
+    graded_page_6_resource = insert(:resource)
 
     insert(:project_resource, %{project_id: project.id, resource_id: graded_page_1_resource.id})
     insert(:project_resource, %{project_id: project.id, resource_id: graded_page_2_resource.id})
     insert(:project_resource, %{project_id: project.id, resource_id: graded_page_3_resource.id})
     insert(:project_resource, %{project_id: project.id, resource_id: graded_page_4_resource.id})
     insert(:project_resource, %{project_id: project.id, resource_id: graded_page_5_resource.id})
+    insert(:project_resource, %{project_id: project.id, resource_id: graded_page_6_resource.id})
 
     graded_page_1_revision =
       insert(
@@ -746,6 +748,15 @@ defmodule Oli.TestHelpers do
         resource: graded_page_5_resource
       )
 
+    graded_page_6_revision =
+      insert(
+        :revision,
+        resource_type_id: Oli.Resources.ResourceType.get_id_by_type("page"),
+        title: "Graded page 6 - Level 0 (w/o student gating condition)",
+        graded: true,
+        resource: graded_page_6_resource
+      )
+
     # Create a unit inside the project
     unit_one_resource = insert(:resource)
 
@@ -779,7 +790,8 @@ defmodule Oli.TestHelpers do
           unit_one_resource.id,
           graded_page_3_resource.id,
           graded_page_4_resource.id,
-          graded_page_5_resource.id
+          graded_page_5_resource.id,
+          graded_page_6_resource.id,
         ],
         content: %{},
         deleted: false,
@@ -829,6 +841,12 @@ defmodule Oli.TestHelpers do
 
     insert(:published_resource, %{
       publication: publication,
+      resource: graded_page_6_resource,
+      revision: graded_page_6_revision
+    })
+
+    insert(:published_resource, %{
+      publication: publication,
       resource: unit_one_resource,
       revision: unit_one_revision
     })
@@ -849,6 +867,7 @@ defmodule Oli.TestHelpers do
     insert(:gating_condition, %{
       section: section,
       resource: graded_page_4_resource,
+      type: :schedule,
       user: nil,
       data: %GatingConditionData{end_datetime: ~U[2023-01-12 13:30:00Z]}
     })
@@ -856,6 +875,7 @@ defmodule Oli.TestHelpers do
     insert(:gating_condition, %{
       section: section,
       resource: graded_page_5_resource,
+      type: :schedule,
       user: nil,
       data: %GatingConditionData{end_datetime: ~U[2023-06-05 14:00:00Z]}
     })
@@ -863,9 +883,19 @@ defmodule Oli.TestHelpers do
     insert(:gating_condition, %{
       section: section,
       resource: graded_page_5_resource,
+      type: :schedule,
       user: student,
       data: %GatingConditionData{end_datetime: ~U[2023-07-08 14:00:00Z]}
     })
+
+    insert(:gating_condition, %{
+      section: section,
+      resource: graded_page_6_resource,
+      type: :always_open,
+      user: student,
+      data: %GatingConditionData{end_datetime: nil}
+    })
+
 
     %{
       section: section,
@@ -874,6 +904,7 @@ defmodule Oli.TestHelpers do
       graded_page_3: graded_page_3_revision,
       graded_page_4: graded_page_4_revision,
       graded_page_5: graded_page_5_revision,
+      graded_page_6: graded_page_6_revision,
       student_with_gating_condition: student
     }
   end


### PR DESCRIPTION
A postgrex error `** (Postgrex.Error) ERROR 22007 (invalid_datetime_format) invalid input syntax for type date: "null"` was being thrown when the assignments view attempted to load an assignment that had a gating condition other than type `:scheduled`.  

The solution was restrict the query to only returning gating conditions of type `:scheduled`.  I added unit test support to cover this case. 

Also, I noticed that there was no way to access an assignment from this view.  I changed "Quiz" button (which did nothing) to "Open" which now launches that assignment. 

