### PR TITLE
[MER-1833] delivery renders header twice for admin and instructors

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -46,3 +46,7 @@ p {
 .slate-editor p:last-child {
   @apply mb-0;
 }
+
+.text-muted {
+  @apply text-gray-500;
+}

--- a/assets/css/text.css
+++ b/assets/css/text.css
@@ -1,19 +1,19 @@
 h4.torus-h4 {
-  @apply text-delivery-body-color text-xl font-bold;
+  @apply text-delivery-body-color dark:text-delivery-body-color-dark text-xl font-bold;
 }
 
 h6.torus-h6 {
-  @apply text-delivery-body-color text-sm font-semibold;
+  @apply text-delivery-body-color dark:text-delivery-body-color-dark text-sm font-semibold;
 }
 
 span.torus-span {
-  @apply text-gray-400 text-sm font-normal;
+  @apply text-gray-400 dark:text-gray-600 text-sm font-normal;
 }
 
 small.torus-small {
-  @apply text-gray-400 text-xs font-normal;
+  @apply text-gray-400 dark:text-gray-600 text-xs font-normal;
 }
 
 p.torus-p {
-  @apply text-delivery-body-color font-normal m-0;
+  @apply text-delivery-body-color dark:text-delivery-body-color-dark font-normal m-0;
 }

--- a/lib/oli_web/components/delivery/discussion_activity/discussion_activity.ex
+++ b/lib/oli_web/components/delivery/discussion_activity/discussion_activity.ex
@@ -15,7 +15,7 @@ defmodule OliWeb.Components.Delivery.DiscussionActivity do
   def render(assigns) do
     ~F"""
     <div class="p-10">
-      <div class="bg-white w-full">
+      <div class="bg-white dark:bg-gray-900 w-full">
         <h4 class="px-10 py-6 border-b border-b-gray-200 torus-h4">Discussion Activity</h4>
 
         <div class="flex items-end gap-2 px-10 py-6 border-b border-b-gray-200">

--- a/lib/oli_web/components/delivery/instructor_dashboard.ex
+++ b/lib/oli_web/components/delivery/instructor_dashboard.ex
@@ -5,9 +5,10 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard do
 
   alias OliWeb.Router.Helpers, as: Routes
   alias Oli.Accounts.User
+  alias Oli.Delivery.Sections.Section
   alias OliWeb.Components.Delivery.UserAccountMenu
   alias OliWeb.Components.Delivery.CourseContentPanel
-  alias OliWeb.Common.SessionContext
+  alias OliWeb.Components.Header
 
   defmodule PriorityAction do
     @enforce_keys [:type, :title, :description, :action_link]
@@ -30,11 +31,18 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard do
           }
   end
 
+  attr :current_user, User, required: true
+  attr :section, Section, required: true
+  attr :breadcrumbs, :list, required: true
+  attr :socket_or_conn, :any, required: true
+  attr :preview_mode, :boolean, default: false
+
   def main_layout(assigns) do
     ~H"""
       <div class="flex-1 flex flex-col h-screen">
-        <.header context={@context} current_user={@current_user} section_slug={@section_slug} preview_mode={@preview_mode} />
-        <.section_details_header title={@title}/>
+        <.header current_user={@current_user} section={@section} preview_mode={@preview_mode} />
+        <.section_details_header section={@section}/>
+        <Header.delivery_breadcrumb {assigns} />
 
         <div class="flex-1 flex flex-col">
 
@@ -196,6 +204,7 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard do
                   py-3
                   m-2
                   text-body-color
+                  dark:text-body-color-dark
                   bg-transparent
                   hover:no-underline
                   hover:text-body-color
@@ -218,17 +227,18 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard do
 
   defp is_active_tab?(tab, active_tab), do: tab == active_tab
 
-  defp logo_link(section_slug, preview_mode) do
+  defp logo_link(nil, _), do: Routes.delivery_path(OliWeb.Endpoint, :open_and_free_index)
+
+  defp logo_link(section, preview_mode) do
     if preview_mode do
-      Routes.content_path(OliWeb.Endpoint, :preview, section_slug)
+      Routes.content_path(OliWeb.Endpoint, :preview, section.slug)
     else
-      Routes.page_delivery_path(OliWeb.Endpoint, :index, section_slug)
+      Routes.page_delivery_path(OliWeb.Endpoint, :index, section.slug)
     end
   end
 
-  attr :section_slug, :string, required: true
-  attr :context, SessionContext
   attr :current_user, User
+  attr :section, Section
   attr :preview_mode, :boolean, default: false
 
   def header(assigns) do
@@ -236,14 +246,14 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard do
       <div class="w-full bg-delivery-header text-white border-b border-slate-600">
         <div class="container mx-auto py-2 flex flex-row justify-between">
           <div class="flex-1 flex items-center">
-            <a class="navbar-brand dark torus-logo my-1 mr-auto" href={logo_link(@section_slug, @preview_mode)}>
+            <a class="navbar-brand dark torus-logo my-1 mr-auto" href={logo_link(@section, @preview_mode)}>
               <%= brand_logo(Map.merge(assigns, %{class: "d-inline-block align-top mr-2"})) %>
             </a>
           </div>
           <%= if @preview_mode do %>
             <UserAccountMenu.preview_user />
           <% else %>
-            <UserAccountMenu.menu is_liveview={true} context={@context} current_user={@current_user} />
+            <UserAccountMenu.menu current_user={@current_user} />
           <% end %>
           <div class="flex items-center border-l border-slate-300">
             <button
@@ -267,7 +277,9 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard do
     """
   end
 
-  attr :title, :string, required: true
+  attr :section, Section
+
+  def section_details_header(%{section: nil}), do: nil
 
   def section_details_header(assigns) do
     ~H"""
@@ -275,7 +287,7 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard do
       <div class="container mx-auto flex flex-row justify-between">
         <div class="flex-1 flex items-center text-[1.5em]">
           <div class="font-bold text-slate-300">
-            <%= @title %>
+            <%= @section.title %>
           </div>
           <%!-- <div class="border-l border-white ml-4 pl-4">
             Section 2360
@@ -360,7 +372,7 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard do
     ~H"""
       <.tabs active_tab={:learning_objectives} section_slug={@section_slug} preview_mode={@preview_mode} />
 
-      <p class="mx-auto">Not available yet</p>
+      <div class="container mx-auto">Not available yet</div>
     """
   end
 
@@ -368,7 +380,7 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard do
     ~H"""
       <.tabs active_tab={:students} section_slug={@section_slug} preview_mode={@preview_mode} />
 
-      <p class="mx-auto">Not available yet</p>
+      <div class="container mx-auto">Not available yet</div>
     """
   end
 
@@ -424,7 +436,7 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard do
     ~H"""
       <.tabs active_tab={:assignments} section_slug={@section_slug} preview_mode={@preview_mode} />
 
-      <p class="mx-auto">Not available yet</p>
+      <div class="container mx-auto">Not available yet</div>
     """
   end
 

--- a/lib/oli_web/components/delivery/instructor_dashboard.ex
+++ b/lib/oli_web/components/delivery/instructor_dashboard.ex
@@ -159,7 +159,15 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard do
 
   attr :active_tab, :atom,
     required: true,
-    values: [:learning_objectives, :students, :content, :discussions, :course_discussion, :assignments, :manage]
+    values: [
+      :learning_objectives,
+      :students,
+      :content,
+      :discussions,
+      :course_discussion,
+      :assignments,
+      :manage
+    ]
 
   attr :section_slug, :string, required: true
   attr :preview_mode, :boolean, required: true

--- a/lib/oli_web/components/delivery/user_account_menu.ex
+++ b/lib/oli_web/components/delivery/user_account_menu.ex
@@ -6,11 +6,9 @@ defmodule OliWeb.Components.Delivery.UserAccountMenu do
 
   alias OliWeb.Router.Helpers, as: Routes
   alias Oli.Delivery.Sections
-  alias Oli.Accounts.User
   alias OliWeb.Common.SessionContext
 
   attr :current_user, User
-  attr :context, SessionContext
   attr :is_liveview, :boolean, default: false
 
   def menu(assigns) do

--- a/lib/oli_web/components/delivery/utils.ex
+++ b/lib/oli_web/components/delivery/utils.ex
@@ -287,9 +287,11 @@ defmodule OliWeb.Components.Delivery.Utils do
 
   def delivery_breadcrumbs?(assigns),
     do:
-      Map.has_key?(assigns, :delivery_breadcrumb) and
-        Map.get(assigns, :delivery_breadcrumb, false) and
-        (Map.has_key?(assigns, :breadcrumbs) and length(Map.get(assigns, :breadcrumbs, [])) > 0)
+      Map.has_key?(assigns, :breadcrumbs) and is_list(Map.get(assigns, :breadcrumbs)) and
+        length(Map.get(assigns, :breadcrumbs, [])) > 0
+
+  def socket_or_conn(%{socket: socket} = _assigns), do: socket
+  def socket_or_conn(%{conn: conn} = _assigns), do: conn
 
   attr :percent, :integer, required: true
   attr :width, :string, default: "100%"

--- a/lib/oli_web/components/header.ex
+++ b/lib/oli_web/components/header.ex
@@ -77,11 +77,20 @@ defmodule OliWeb.Components.Header do
         <% end %>
       </div>
     </nav>
+    <.delivery_breadcrumb breadcrumbs={assigns[:breadcrumbs]} socket_or_conn={socket_or_conn(assigns)} />
+    """
+  end
+
+  attr :breadcrumbs, :list, required: true
+  attr :socket_or_conn, :any, required: true
+
+  def delivery_breadcrumb(assigns) do
+    ~H"""
     <%= if delivery_breadcrumbs?(assigns) do %>
-      <div class="container">
+      <div class="container mx-auto my-2">
         <nav class="breadcrumb-bar d-flex align-items-center mt-3 mb-1">
           <div class="flex-1">
-            <%= live_render(@conn, BreadcrumbTrailLive, session: %{"breadcrumbs" => @breadcrumbs}) %>
+            <%= live_render(@socket_or_conn, BreadcrumbTrailLive, session: %{"breadcrumbs" => @breadcrumbs}) %>
           </div>
         </nav>
       </div>

--- a/lib/oli_web/live/collaboration_live/collab_space_view.ex
+++ b/lib/oli_web/live/collaboration_live/collab_space_view.ex
@@ -141,97 +141,99 @@ defmodule OliWeb.CollaborationLive.CollabSpaceView do
     ~F"""
     {render_modal(assigns)}
 
-    <div class="bg-white dark:bg-gray-800 dark:text-delivery-body-color-dark shadow">
-      <div>
-        <div class="flex items-center justify-between p-5">
-          <div class="flex items-center justify-between w-full">
-            <h3 class="text-xl font-bold">{@title}</h3>
-            {#if is_archived?(@collab_space_config.status)}
-              <span class="badge badge-info ml-2">Archived</span>
-            {/if}
+    <div class="container mx-auto">
+      <div class="bg-white dark:bg-gray-800 dark:text-delivery-body-color-dark shadow">
+        <div>
+          <div class="flex items-center justify-between p-5">
+            <div class="flex items-center justify-between w-full">
+              <h3 class="text-xl font-bold">{@title}</h3>
+              {#if is_archived?(@collab_space_config.status)}
+                <span class="badge badge-info ml-2">Archived</span>
+              {/if}
+            </div>
           </div>
         </div>
-      </div>
 
-      <div class="p-2 pt-0 mb-5">
-        <Form
-          id="new_post_form"
-          for={@new_post_changeset}
-          submit="create_post"
-          opts={autocomplete: "off"}
-          class="bg-gray-100 p-3 rounded-sm"
-        >
-          <HiddenInput field={:user_id} />
-          <HiddenInput field={:section_id} />
-          <HiddenInput field={:resource_id} />
+        <div class="p-2 pt-0 mb-5">
+          <Form
+            id="new_post_form"
+            for={@new_post_changeset}
+            submit="create_post"
+            opts={autocomplete: "off"}
+            class="bg-gray-100 p-3 rounded-sm"
+          >
+            <HiddenInput field={:user_id} />
+            <HiddenInput field={:section_id} />
+            <HiddenInput field={:resource_id} />
 
-          <HiddenInput field={:parent_post_id} />
-          <HiddenInput field={:thread_root_id} />
+            <HiddenInput field={:parent_post_id} />
+            <HiddenInput field={:thread_root_id} />
 
-          <Inputs for={:content}>
-            <Field name={:message}>
-              <TextArea
-                opts={
-                  placeholder: "New post",
-                  "data-grow": "true",
-                  "data-initial-height": 44,
-                  onkeyup: "resizeTextArea(this)"
-                }
-                class="torus-input border-r-0 collab-space__textarea"
-              />
-            </Field>
-          </Inputs>
-          <div class="flex justify-end">
-            {#if @is_student and @collab_space_config.anonymous_posting}
-              <Checkbox id="new_post_anonymous_checkbox" field={:anonymous} class="hidden" />
-              <Buttons.button_with_options
-                id="create_post_button"
-                type="submit"
-                disabled={is_archived?(@collab_space_config.status)}
-                options={[
-                  %{
-                    text: "Post anonymously",
-                    on_click:
-                      JS.dispatch("click", to: "#new_post_anonymous_checkbox")
-                      |> JS.dispatch("click", to: "#create_post_button_button")
+            <Inputs for={:content}>
+              <Field name={:message}>
+                <TextArea
+                  opts={
+                    placeholder: "New post",
+                    "data-grow": "true",
+                    "data-initial-height": 44,
+                    onkeyup: "resizeTextArea(this)"
                   }
-                ]}
-              >
-                Create Post
-              </Buttons.button_with_options>
-            {#else}
-              <Buttons.button disabled={is_archived?(@collab_space_config.status)} type="submit">
-                Create Post
-              </Buttons.button>
-            {/if}
+                  class="torus-input border-r-0 collab-space__textarea"
+                />
+              </Field>
+            </Inputs>
+            <div class="flex justify-end">
+              {#if @is_student and @collab_space_config.anonymous_posting}
+                <Checkbox id="new_post_anonymous_checkbox" field={:anonymous} class="hidden" />
+                <Buttons.button_with_options
+                  id="create_post_button"
+                  type="submit"
+                  disabled={is_archived?(@collab_space_config.status)}
+                  options={[
+                    %{
+                      text: "Post anonymously",
+                      on_click:
+                        JS.dispatch("click", to: "#new_post_anonymous_checkbox")
+                        |> JS.dispatch("click", to: "#create_post_button_button")
+                    }
+                  ]}
+                >
+                  Create Post
+                </Buttons.button_with_options>
+              {#else}
+                <Buttons.button disabled={is_archived?(@collab_space_config.status)} type="submit">
+                  Create Post
+                </Buttons.button>
+              {/if}
+            </div>
+          </Form>
+        </div>
+
+        {#if length(@posts) > 1}
+          <div class="flex justify-end gap-2 py-2 px-5">
+            <Sort sort={@sort} />
           </div>
-        </Form>
-      </div>
+        {#elseif length(@posts) == 0}
+          <div class="border border-gray-100 rounded-sm p-5 flex items-center justify-center m-2">
+            <span class="torus-span">No posts yet</span>
+          </div>
+        {/if}
 
-      {#if length(@posts) > 1}
-        <div class="flex justify-end gap-2 py-2 px-5">
-          <Sort sort={@sort} />
+        <div class={if is_archived?(@collab_space_config.status), do: "readonly", else: ""}>
+          <PostList
+            posts={@posts}
+            collab_space_config={@collab_space_config}
+            selected={@selected}
+            user_id={@user.id}
+            is_instructor={@is_instructor}
+            is_student={@is_student}
+            editing_post={if @is_edition_mode, do: @editing_post, else: nil}
+          />
         </div>
-      {#elseif length(@posts) == 0}
-        <div class="border border-gray-100 rounded-sm p-5 flex items-center justify-center m-2">
-          <span class="torus-span">No posts yet</span>
+
+        <div class="p-5">
+          <ActiveUsers users={@active_users} />
         </div>
-      {/if}
-
-      <div class={if is_archived?(@collab_space_config.status), do: "readonly", else: ""}>
-        <PostList
-          posts={@posts}
-          collab_space_config={@collab_space_config}
-          selected={@selected}
-          user_id={@user.id}
-          is_instructor={@is_instructor}
-          is_student={@is_student}
-          editing_post={if @is_edition_mode, do: @editing_post, else: nil}
-        />
-      </div>
-
-      <div class="p-5">
-        <ActiveUsers users={@active_users} />
       </div>
     </div>
     """

--- a/lib/oli_web/live/collaboration_live/index_view.ex
+++ b/lib/oli_web/live/collaboration_live/index_view.ex
@@ -76,7 +76,6 @@ defmodule OliWeb.CollaborationLive.IndexView do
 
       {:ok,
        assign(socket,
-         delivery_breadcrumb: true,
          breadcrumbs: breadcrumb(live_action, section_slug),
          section_slug: section_slug,
          collab_spaces: collab_spaces,

--- a/lib/oli_web/live/delivery/instructor_dashboard/assignments_live.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/assignments_live.ex
@@ -11,9 +11,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.AssignmentsLive do
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
-      <InstructorDashboard.main_layout {assigns}>
-        <InstructorDashboard.assignments {assigns} />
-      </InstructorDashboard.main_layout>
+      <InstructorDashboard.assignments {assigns} />
     """
   end
 end

--- a/lib/oli_web/live/delivery/instructor_dashboard/content_live.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/content_live.ex
@@ -44,9 +44,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.ContentLive do
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
-      <InstructorDashboard.main_layout {assigns}>
-        <InstructorDashboard.content {assigns} />
-      </InstructorDashboard.main_layout>
+      <InstructorDashboard.content {assigns} />
     """
   end
 end

--- a/lib/oli_web/live/delivery/instructor_dashboard/course_discussion_live.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/course_discussion_live.ex
@@ -22,9 +22,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.CourseDiscussionLive do
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
-      <InstructorDashboard.main_layout {assigns}>
-        <InstructorDashboard.course_discussion {assigns} />
-      </InstructorDashboard.main_layout>
+      <InstructorDashboard.course_discussion {assigns} />
     """
   end
 end

--- a/lib/oli_web/live/delivery/instructor_dashboard/discussions_live.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/discussions_live.ex
@@ -35,11 +35,9 @@ defmodule OliWeb.Delivery.InstructorDashboard.DiscussionsLive do
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
-      <InstructorDashboard.main_layout {assigns}>
-        <div id={assigns[:parent_component_id]}>
-          <InstructorDashboard.discussions {assigns} />
-        </div>
-      </InstructorDashboard.main_layout>
+      <div id={assigns[:parent_component_id]}>
+        <InstructorDashboard.discussions {assigns} />
+      </div>
     """
   end
 

--- a/lib/oli_web/live/delivery/instructor_dashboard/learning_objectives_live.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/learning_objectives_live.ex
@@ -11,9 +11,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.LearningObjectivesLive do
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
-      <InstructorDashboard.main_layout {assigns}>
-        <InstructorDashboard.learning_objectives {assigns} />
-      </InstructorDashboard.main_layout>
+      <InstructorDashboard.learning_objectives {assigns} />
     """
   end
 end

--- a/lib/oli_web/live/delivery/instructor_dashboard/manage_live.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/manage_live.ex
@@ -11,9 +11,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.ManageLive do
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
-      <InstructorDashboard.main_layout {assigns}>
-        <InstructorDashboard.manage {assigns} />
-      </InstructorDashboard.main_layout>
+      <InstructorDashboard.manage {assigns} />
     """
   end
 end

--- a/lib/oli_web/live/delivery/instructor_dashboard/students_live.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/students_live.ex
@@ -11,9 +11,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.StudentsLive do
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
-      <InstructorDashboard.main_layout {assigns}>
-        <InstructorDashboard.students {assigns} />
-      </InstructorDashboard.main_layout>
+      <InstructorDashboard.students {assigns} />
     """
   end
 end

--- a/lib/oli_web/live/delivery/manage_source_materials.ex
+++ b/lib/oli_web/live/delivery/manage_source_materials.ex
@@ -61,7 +61,6 @@ defmodule OliWeb.Delivery.ManageSourceMaterials do
            section: section,
            updates: updates,
            updates_in_progress: updates_in_progress,
-           delivery_breadcrumb: true,
            breadcrumbs: set_breadcrumbs(section, user_type),
            base_project_details: base_project_details,
            current_publication: current_publication,
@@ -73,7 +72,7 @@ defmodule OliWeb.Delivery.ManageSourceMaterials do
   def render(assigns) do
     ~F"""
       {render_modal(assigns)}
-      <div class="pb-5">
+      <div class="container mx-auto pb-5">
 
         <ProjectCard
           id={"project_info_#{@base_project_details.id}"}

--- a/lib/oli_web/live/delivery/remix_section.ex
+++ b/lib/oli_web/live/delivery/remix_section.ex
@@ -196,7 +196,6 @@ defmodule OliWeb.Delivery.RemixSection do
        dragging: nil,
        selected: nil,
        has_unsaved_changes: false,
-       delivery_breadcrumb: true,
        breadcrumbs: breadcrumbs,
        redirect_after_save: redirect_after_save,
        available_publications: available_publications

--- a/lib/oli_web/live/delivery/select_source.ex
+++ b/lib/oli_web/live/delivery/select_source.ex
@@ -122,7 +122,6 @@ defmodule OliWeb.Delivery.SelectSource do
     {:ok,
      assign(socket,
        breadcrumbs: breadcrumbs(live_action),
-       delivery_breadcrumb: true,
        total_count: length(sources),
        table_model: table_model,
        sources: sources,

--- a/lib/oli_web/live/grades/browse_updates_view.ex
+++ b/lib/oli_web/live/grades/browse_updates_view.ex
@@ -121,7 +121,7 @@ defmodule OliWeb.Grades.BrowseUpdatesView do
 
   def render(assigns) do
     ~F"""
-    <div>
+    <div class="container mx-auto">
 
       <TextSearch id="text-search"/>
 

--- a/lib/oli_web/live/grades/gradebook_view.ex
+++ b/lib/oli_web/live/grades/gradebook_view.ex
@@ -82,7 +82,6 @@ defmodule OliWeb.Grades.GradebookView do
 
         {:ok,
          assign(socket,
-           delivery_breadcrumb: true,
            breadcrumbs: set_breadcrumbs(type, section),
            section: section,
            total_count: total_count,
@@ -162,9 +161,9 @@ defmodule OliWeb.Grades.GradebookView do
 
   def render(assigns) do
     ~F"""
-    <div>
+    <div class="container mx-auto">
 
-      <div class="d-flex justify-content-between">
+      <div>
         <TextSearch id="text-search"/>
         <div class="form-check mt-2">
           <input type="checkbox" id="toggle_show_all_links" class="form-check-input" checked={@show_all_links} phx-hook="CheckboxListener" />

--- a/lib/oli_web/live/grades/grades.ex
+++ b/lib/oli_web/live/grades/grades.ex
@@ -12,81 +12,62 @@ defmodule OliWeb.Grades.GradesLive do
   alias Oli.Repo
   alias Oli.Delivery.Attempts.PageLifecycle.Broadcaster
   alias Oli.Lti.AccessTokenLibrary
+  alias OliWeb.Sections.Mount
+  alias OliWeb.Common.Breadcrumb
 
-  def mount(
-        _params,
-        %{"section_slug" => section_slug} = session,
-        socket
-      ) do
-    section = Sections.get_section_by_slug(section_slug)
-
-    if is_admin_author?(session) or is_instructor?(session, section) do
-      do_mount(section, socket)
-    else
-      {:ok, redirect(socket, to: Routes.static_page_path(OliWeb.Endpoint, :unauthorized))}
-    end
+  def set_breadcrumbs(type, section) do
+    type
+    |> OliWeb.Sections.OverviewView.set_breadcrumbs(section)
+    |> breadcrumb(section)
   end
 
-  defp do_mount(section, socket) do
-    {_d, registration} = Sections.get_deployment_registration_from_section(section)
-    line_items_url = section.line_items_service_url
-    graded_pages = Grading.fetch_graded_pages(section.slug)
-
-    selected_page =
-      if length(graded_pages) > 0 do
-        hd(graded_pages).resource_id
-      else
-        nil
-      end
-
-    {:ok,
-     assign(socket,
-       title: "LMS Grades",
-       breadcrumbs: [],
-       graded_pages: graded_pages,
-       selected_page: selected_page,
-       line_items_url: line_items_url,
-       access_token: nil,
-       task_queue: [],
-       progress_current: 0,
-       progress_max: 0,
-       section_slug: section.slug,
-       section: section,
-       registration: registration,
-       total_jobs: nil,
-       failed_jobs: nil,
-       succeeded_jobs: nil,
-       test_output: nil,
-       test_in_progress?: false
-     )}
+  def breadcrumb(previous, section) do
+    previous ++
+      [
+        Breadcrumb.new(%{
+          full_title: "Manage LMS Gradebook",
+          link: Routes.live_path(OliWeb.Endpoint, __MODULE__, section.slug)
+        })
+      ]
   end
 
-  defp is_admin_author?(session) do
-    case session["current_author_id"] do
-      nil ->
-        false
+  def mount(%{"section_slug" => section_slug}, session, socket) do
+    case Mount.for(section_slug, session) do
+      {:error, e} ->
+        Mount.handle_error(socket, {:error, e})
 
-      id ->
-        case Repo.get(Oli.Accounts.Author, id) do
-          nil -> false
-          author -> Accounts.is_admin?(author)
-        end
-    end
-  end
+      {type, _, section} ->
+        {_d, registration} = Sections.get_deployment_registration_from_section(section)
+        line_items_url = section.line_items_service_url
+        graded_pages = Grading.fetch_graded_pages(section.slug)
 
-  defp is_instructor?(session, section) do
-    case session["current_user_id"] do
-      nil ->
-        false
+        selected_page =
+          if length(graded_pages) > 0 do
+            hd(graded_pages).resource_id
+          else
+            nil
+          end
 
-      id ->
-        user = Accounts.get_user!(id) |> Repo.preload([:platform_roles, :author])
-
-        ContextRoles.has_role?(
-          user,
-          section.slug,
-          ContextRoles.get_role(:context_instructor)
-        )
+        {:ok,
+         assign(socket,
+           title: "LMS Grades",
+           breadcrumbs: set_breadcrumbs(type, section),
+           graded_pages: graded_pages,
+           selected_page: selected_page,
+           line_items_url: line_items_url,
+           access_token: nil,
+           task_queue: [],
+           progress_current: 0,
+           progress_max: 0,
+           section_slug: section.slug,
+           section: section,
+           registration: registration,
+           total_jobs: nil,
+           failed_jobs: nil,
+           succeeded_jobs: nil,
+           test_output: nil,
+           test_in_progress?: false
+         )}
     end
   end
 
@@ -112,32 +93,32 @@ defmodule OliWeb.Grades.GradesLive do
       )
 
     ~H"""
-    <div class="mb-2">
-      <%= link to: Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.OverviewView, @section.slug) do %>
-        <i class="fas fa-arrow-left"></i> Back
-      <% end %>
-    </div>
+    <div class="container mx-auto">
+      <h2><%= dgettext("grades", "Manage Grades") %></h2>
 
-    <h2><%= dgettext("grades", "Manage Grades") %></h2>
+      <p>
+        <%= dgettext("grades", "Grades for this section can be viewed by students and instructors using the LMS gradebook.") %>
+      </p>
 
-    <p>
-      <%= dgettext("grades", "Grades for this section can be viewed by students and instructors using the LMS gradebook.") %>
-    </p>
+      <div class="my-2">
+        <%= live_component OliWeb.Grades.TestConnection, assigns %>
+      </div>
+      <div class="my-2">
+        <%= live_component OliWeb.Grades.Export, assigns %>
+      </div>
 
-    <div class="card-group">
-      <%= live_component OliWeb.Grades.TestConnection, assigns %>
-      <%= live_component OliWeb.Grades.Export, assigns %>
-    </div>
+      <div class="my-2">
+        <%= live_component OliWeb.Grades.LineItems, assigns %>
+      </div>
+      <div class="my-2">
+        <%= live_component OliWeb.Grades.GradeSync, assigns %>
+      </div>
 
-    <div class="card-group">
-      <%= live_component OliWeb.Grades.LineItems, assigns %>
-      <%= live_component OliWeb.Grades.GradeSync, assigns %>
-    </div>
-
-    <div class={"mt-4 #{@progress_visible}"}>
-      <p><%= dgettext("grades", "Do not leave this page until this operation completes.") %></p>
-      <div class="progress">
-        <div class="progress-bar" role="progressbar" style={"width: #{@percent_progress}%;"} aria-valuenow={"#{@percent_progress}"} aria-valuemin="0" aria-valuemax="100"></div>
+      <div class={"my-2 #{@progress_visible}"}>
+        <p><%= dgettext("grades", "Do not leave this page until this operation completes.") %></p>
+        <div class="progress">
+          <div class="progress-bar" role="progressbar" style={"width: #{@percent_progress}%;"} aria-valuenow={"#{@percent_progress}"} aria-valuemin="0" aria-valuemax="100"></div>
+        </div>
       </div>
     </div>
     """

--- a/lib/oli_web/live/grades/observe_grade_updates.ex
+++ b/lib/oli_web/live/grades/observe_grade_updates.ex
@@ -55,7 +55,7 @@ defmodule OliWeb.Grades.ObserveGradeUpdatesView do
 
   def render(assigns) do
     ~F"""
-    <div>
+    <div class="container mx-auto">
       <PagedTable
         filter={""}
         table_model={@table_model}
@@ -98,10 +98,10 @@ defmodule OliWeb.Grades.ObserveGradeUpdatesView do
     {:ok, table_model} = ObserveTableModel.new(updates)
 
     {:noreply,
-      assign(socket,
-        updates: updates,
-        table_model: table_model,
-        total_count: Enum.count(updates)
-      )}
+     assign(socket,
+       updates: updates,
+       table_model: table_model,
+       total_count: Enum.count(updates)
+     )}
   end
 end

--- a/lib/oli_web/live/manual_grading/group.ex
+++ b/lib/oli_web/live/manual_grading/group.ex
@@ -5,10 +5,9 @@ defmodule OliWeb.ManualGrading.Group do
 
   def render(assigns) do
     ~F"""
-    <div style="padding: 20px; border: 2px inset rgba(28,110,164,0.17); border-radius: 12px;" class="mb-3">
+    <div class="mb-3">
       <#slot />
     </div>
     """
   end
-
 end

--- a/lib/oli_web/live/manual_grading/manual_grading_view.ex
+++ b/lib/oli_web/live/manual_grading/manual_grading_view.ex
@@ -1,5 +1,4 @@
 defmodule OliWeb.ManualGrading.ManualGradingView do
-
   @moduledoc """
   Implements instructor manual scoring of those activity attempts that are in a "submitted"
   state.
@@ -97,20 +96,22 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
 
         activities = Oli.Activities.list_activity_registrations()
         part_components = Oli.PartComponents.get_part_component_scripts(:delivery_script)
-        additional_scripts = Enum.map(activities, fn a -> a.authoring_script end) |> Enum.concat(part_components)
+
+        additional_scripts =
+          Enum.map(activities, fn a -> a.authoring_script end) |> Enum.concat(part_components)
 
         activity_types_map = Enum.reduce(activities, %{}, fn e, m -> Map.put(m, e.id, e) end)
 
         context = SessionContext.init(session)
         {:ok, table_model} = TableModel.new(attempts, activity_types_map, context)
 
-        table_model = Map.put(table_model, :sort_order, :desc)
-        |> Map.put(:sort_by_spec, TableModel.date_submitted_spec())
+        table_model =
+          Map.put(table_model, :sort_order, :desc)
+          |> Map.put(:sort_by_spec, TableModel.date_submitted_spec())
 
         {:ok,
          assign(socket,
            breadcrumbs: set_breadcrumbs(type, section),
-           delivery_breadcrumb: true,
            section: section,
            total_count: total_count,
            table_model: table_model,
@@ -130,6 +131,7 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
 
   defp is_apply_transition?(params) do
     selected = get_param(params, "selected", nil)
+
     cond do
       is_nil(selected) -> false
       selected == "none" -> true
@@ -163,8 +165,8 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
   # a "just select the next item that appears in this index after the query is rerun"
   # mode.
   defp handle_transition_after_apply(params, socket) do
-
     selected = get_param(params, "selected", nil)
+
     table_model =
       SortableTableModel.update_from_params(
         socket.assigns.table_model,
@@ -172,6 +174,7 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
       )
 
     offset = get_int_param(params, "offset", 0)
+
     options = %BrowseOptions{
       text_search: get_param(params, "text_search", ""),
       user_id: get_int_param(params, "user_id", nil),
@@ -179,6 +182,7 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
       page_id: get_int_param(params, "page_id", nil),
       graded: get_boolean_param(params, "graded", nil)
     }
+
     attempts =
       ManualGrading.browse_submitted_attempts(
         socket.assigns.section,
@@ -187,34 +191,40 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
         options
       )
 
-    selected = case selected do
-      "none" -> nil
-      n ->
-        index = String.to_integer(n) * -1
-        case Enum.at(attempts, index) do
-          nil -> nil
-          item -> item.id |> Integer.to_string()
-        end
-    end
+    selected =
+      case selected do
+        "none" ->
+          nil
 
-    table_model = Map.put(table_model, :rows, attempts)
-    |> Map.put(:selected, selected)
+        n ->
+          index = String.to_integer(n) * -1
+
+          case Enum.at(attempts, index) do
+            nil -> nil
+            item -> item.id |> Integer.to_string()
+          end
+      end
+
+    table_model =
+      Map.put(table_model, :rows, attempts)
+      |> Map.put(:selected, selected)
 
     total_count = determine_total(attempts)
 
     {:noreply,
-    assign(
-      socket,
-      offset: offset,
-      table_model: table_model,
-      total_count: total_count,
-      options: options)
-    |> assign(build_state_for_selection(table_model, socket.assigns))}
+     assign(
+       socket,
+       offset: offset,
+       table_model: table_model,
+       total_count: total_count,
+       options: options
+     )
+     |> assign(build_state_for_selection(table_model, socket.assigns))}
   end
 
   defp handle_regular_param_update(params, socket) do
-
     selected = get_param(params, "selected", nil)
+
     table_model =
       SortableTableModel.update_from_params(
         socket.assigns.table_model,
@@ -222,7 +232,7 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
       )
 
     offset = get_int_param(params, "offset", 0)
-    table_model =  Map.put(table_model, :selected, selected)
+    table_model = Map.put(table_model, :selected, selected)
 
     options = %BrowseOptions{
       text_search: get_param(params, "text_search", ""),
@@ -238,14 +248,12 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
       table_model = Map.put(socket.assigns.table_model, :selected, selected)
 
       {:noreply,
-      assign(
-        socket,
-        table_model: table_model
-      )
-      |> assign(build_state_for_selection(table_model, socket.assigns))
-      }
+       assign(
+         socket,
+         table_model: table_model
+       )
+       |> assign(build_state_for_selection(table_model, socket.assigns))}
     else
-
       attempts =
         ManualGrading.browse_submitted_attempts(
           socket.assigns.section,
@@ -254,31 +262,33 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
           options
         )
 
-      selected = case Enum.find(attempts, fn r -> Integer.to_string(r.id) == selected end) do
-        nil -> nil
-        attempt -> attempt.id |> Integer.to_string()
-      end
+      selected =
+        case Enum.find(attempts, fn r -> Integer.to_string(r.id) == selected end) do
+          nil -> nil
+          attempt -> attempt.id |> Integer.to_string()
+        end
 
-      table_model = Map.put(table_model, :rows, attempts)
-      |> Map.put(:selected, selected)
+      table_model =
+        Map.put(table_model, :rows, attempts)
+        |> Map.put(:selected, selected)
 
       total_count = determine_total(attempts)
 
       {:noreply,
-      assign(
-        socket,
-        offset: offset,
-        table_model: table_model,
-        total_count: total_count,
-        options: options)
-      |> assign(build_state_for_selection(table_model, socket.assigns))}
+       assign(
+         socket,
+         offset: offset,
+         table_model: table_model,
+         total_count: total_count,
+         options: options
+       )
+       |> assign(build_state_for_selection(table_model, socket.assigns))}
     end
-
   end
 
   def render(assigns) do
     ~F"""
-    <div>
+    <div class="container mx-auto">
 
       {#for script <- @additional_scripts}
         <script type="text/javascript" src={Routes.static_path(OliWeb.Endpoint, "/js/" <> script)}></script>
@@ -340,10 +350,10 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
   # Determines if any scoring or feedbacks remain to be entered for the part attempts
   # of the currently selected activity attempt
   defp scoring_remains(assigns) do
-
-    attempt_guids = Enum.filter(assigns.part_attempts, fn pa -> pa.grading_approach == :manual end)
-    |> Enum.map(fn pa -> pa.attempt_guid end)
-    |> MapSet.new()
+    attempt_guids =
+      Enum.filter(assigns.part_attempts, fn pa -> pa.grading_approach == :manual end)
+      |> Enum.map(fn pa -> pa.attempt_guid end)
+      |> MapSet.new()
 
     Map.keys(assigns.score_feedbacks)
     |> Enum.filter(fn guid -> MapSet.member?(attempt_guids, guid) end)
@@ -397,22 +407,32 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
      )}
   end
 
-  defp build_state_for_selection(%{selected: nil}, _), do: [attempt: nil, part_attempts: nil, review_rendered: nil, preview_rendered: nil]
-  defp build_state_for_selection(%{selected: ""}, _), do: [attempt: nil, part_attempts: nil, review_rendered: nil, preview_rendered: nil]
+  defp build_state_for_selection(%{selected: nil}, _),
+    do: [attempt: nil, part_attempts: nil, review_rendered: nil, preview_rendered: nil]
+
+  defp build_state_for_selection(%{selected: ""}, _),
+    do: [attempt: nil, part_attempts: nil, review_rendered: nil, preview_rendered: nil]
 
   defp build_state_for_selection(table_model, assigns) do
-
-    activity_attempt = Enum.find(table_model.rows, fn r -> r.id == String.to_integer(table_model.selected) end)
+    activity_attempt =
+      Enum.find(table_model.rows, fn r -> r.id == String.to_integer(table_model.selected) end)
 
     # Only re-render the activities when it is the first selection or on an actual selection change
-    if is_nil(assigns.attempt) or (assigns.attempt.id != activity_attempt.id) do
+    if is_nil(assigns.attempt) or assigns.attempt.id != activity_attempt.id do
       part_attempts = Core.get_latest_part_attempts(activity_attempt.attempt_guid)
 
-      rendering_context = OliWeb.ManualGrading.Rendering.create_rendering_context(
-        activity_attempt, part_attempts, assigns.activity_types_map, assigns.section)
+      rendering_context =
+        OliWeb.ManualGrading.Rendering.create_rendering_context(
+          activity_attempt,
+          part_attempts,
+          assigns.activity_types_map,
+          assigns.section
+        )
 
       review_rendered = OliWeb.ManualGrading.Rendering.render(rendering_context, :review)
-      preview_rendered = OliWeb.ManualGrading.Rendering.render(rendering_context, :instructor_preview)
+
+      preview_rendered =
+        OliWeb.ManualGrading.Rendering.render(rendering_context, :instructor_preview)
 
       {:ok, model} = Oli.Activities.Model.parse(activity_attempt.revision.content)
       parts_map = Enum.reduce(model.parts, %{}, fn p, m -> Map.put(m, p.id, p) end)
@@ -422,10 +442,10 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
         part_attempts: part_attempts,
         review_rendered: review_rendered,
         preview_rendered: preview_rendered,
-        score_feedbacks: ensure_score_feedbacks_exist(assigns.score_feedbacks, part_attempts, parts_map),
+        score_feedbacks:
+          ensure_score_feedbacks_exist(assigns.score_feedbacks, part_attempts, parts_map),
         parts_map: parts_map
       ]
-
     else
       []
     end
@@ -436,7 +456,11 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
       if Map.has_key?(m, pa.attempt_guid) do
         m
       else
-        Map.put(m, pa.attempt_guid, %ScoreFeedback{score: nil, feedback: nil, out_of: determine_out_of(pa, parts_map)})
+        Map.put(m, pa.attempt_guid, %ScoreFeedback{
+          score: nil,
+          feedback: nil,
+          out_of: determine_out_of(pa, parts_map)
+        })
       end
     end)
   end
@@ -445,34 +469,35 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
   # relative to the current assigns
   defp only_selection_changed(assigns, model_after, options_after, offset_after) do
     assigns.table_model.selected != model_after.selected and
-    assigns.table_model.sort_by_spec == model_after.sort_by_spec and
-    assigns.table_model.sort_order == model_after.sort_order and
-    assigns.options.text_search == options_after.text_search and
-    assigns.options.user_id == options_after.user_id and
-    assigns.options.activity_id == options_after.activity_id and
-    assigns.options.page_id == options_after.page_id and
-    assigns.options.graded == options_after.graded and
-    assigns.offset == offset_after
+      assigns.table_model.sort_by_spec == model_after.sort_by_spec and
+      assigns.table_model.sort_order == model_after.sort_order and
+      assigns.options.text_search == options_after.text_search and
+      assigns.options.user_id == options_after.user_id and
+      assigns.options.activity_id == options_after.activity_id and
+      assigns.options.page_id == options_after.page_id and
+      assigns.options.graded == options_after.graded and
+      assigns.offset == offset_after
   end
 
   defp ensure_valid_score(score, attempt_guid, assigns) do
-    out_of = case Enum.find(assigns.part_attempts, fn pa -> pa.attempt_guid == attempt_guid end) do
-      nil -> 1.0
-      pa -> determine_out_of(pa, assigns.parts_map)
-    end
+    out_of =
+      case Enum.find(assigns.part_attempts, fn pa -> pa.attempt_guid == attempt_guid end) do
+        nil -> 1.0
+        pa -> determine_out_of(pa, assigns.parts_map)
+      end
 
     min(score, out_of)
     |> max(0.0)
   end
 
   def handle_event("change_tab", %{"tab" => value}, socket) do
-    {:noreply, assign(socket,
-      active_tab: String.to_existing_atom(value)
-    )}
+    {:noreply,
+     assign(socket,
+       active_tab: String.to_existing_atom(value)
+     )}
   end
 
   def handle_event("apply", _, socket) do
-
     %{
       section: section,
       attempt: attempt,
@@ -481,20 +506,28 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
 
     case ManualGrading.apply_manual_scoring(section, attempt, score_feedbacks) do
       {:ok, finalized_part_attempts} ->
-
         pid = self()
-        send(pid, {:purge_score_feedbacks, Enum.map(finalized_part_attempts, fn pa -> pa.attempt_guid end)})
+
+        send(
+          pid,
+          {:purge_score_feedbacks,
+           Enum.map(finalized_part_attempts, fn pa -> pa.attempt_guid end)}
+        )
 
         put_flash(socket, :info, "Student attempt scored.")
         |> pick_next()
-      _ ->
-        {:noreply,  put_flash(socket, :error, "There was a problem encountered while scoring this attempt.")}
-    end
 
+      _ ->
+        {:noreply,
+         put_flash(socket, :error, "There was a problem encountered while scoring this attempt.")}
+    end
   end
 
-  def handle_event("feedback_changed", %{"id" => "feedback_" <> attempt_guid, "value" => feedback}, socket) do
-
+  def handle_event(
+        "feedback_changed",
+        %{"id" => "feedback_" <> attempt_guid, "value" => feedback},
+        socket
+      ) do
     sf = Map.get(socket.assigns.score_feedbacks, attempt_guid)
     sf = %{sf | feedback: feedback}
 
@@ -504,18 +537,17 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
   end
 
   def handle_event("score_changed", %{"id" => "score_" <> attempt_guid} = params, socket) do
-
-    score = case Map.get(params, "score") do
-      nil -> Map.get(params, "value")
-      score -> score
-    end
+    score =
+      case Map.get(params, "score") do
+        nil -> Map.get(params, "value")
+        score -> score
+      end
 
     case Float.parse(score) do
       :error ->
         {:noreply, socket}
 
       {score, _} ->
-
         score = ensure_valid_score(score, attempt_guid, socket.assigns)
 
         sf = Map.get(socket.assigns.score_feedbacks, attempt_guid)
@@ -524,7 +556,6 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
 
         {:noreply, assign(socket, score_feedbacks: score_feedbacks)}
     end
-
   end
 
   def handle_event(event, params, socket) do
@@ -537,10 +568,10 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
   end
 
   def handle_info({:purge_score_feedbacks, guids}, socket) do
-
-    score_feedbacks = Enum.reduce(guids, socket.assigns.score_feedbacks, fn guid, sfs ->
-      Map.delete(sfs, guid)
-    end)
+    score_feedbacks =
+      Enum.reduce(guids, socket.assigns.score_feedbacks, fn guid, sfs ->
+        Map.delete(sfs, guid)
+      end)
 
     {:noreply, assign(socket, score_feedbacks: score_feedbacks)}
   end
@@ -553,15 +584,18 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
   # case of "none" for when there should not be a selection (i.e. the user has evaluated)
   # the last attempt.
   defp pick_next(socket) do
+    index =
+      Enum.find_index(socket.assigns.table_model.rows, fn r ->
+        Integer.to_string(r.id) == socket.assigns.table_model.selected
+      end)
 
-    index = Enum.find_index(socket.assigns.table_model.rows, fn r -> Integer.to_string(r.id) == socket.assigns.table_model.selected end)
-
-    selected = cond do
-      is_nil(index) -> "none"
-      socket.assigns.total_count == 1 -> "none"
-      socket.assigns.total_count == index + 1 -> (index - 1) * -1
-      true -> index * -1
-    end
+    selected =
+      cond do
+        is_nil(index) -> "none"
+        socket.assigns.total_count == 1 -> "none"
+        socket.assigns.total_count == index + 1 -> (index - 1) * -1
+        true -> index * -1
+      end
 
     patch_with(socket, %{selected: selected})
   end

--- a/lib/oli_web/live/progress/student_resource_view.ex
+++ b/lib/oli_web/live/progress/student_resource_view.ex
@@ -77,7 +77,6 @@ defmodule OliWeb.Progress.StudentResourceView do
                context: context,
                changeset: changeset,
                breadcrumbs: set_breadcrumbs(type, section, user_id),
-               delivery_breadcrumb: true,
                section: section,
                resource_access: resource_access,
                revision: revision,

--- a/lib/oli_web/live/progress/student_view.ex
+++ b/lib/oli_web/live/progress/student_view.ex
@@ -92,7 +92,6 @@ defmodule OliWeb.Progress.StudentView do
                page_nodes: page_nodes,
                resource_accesses: resource_accesses,
                breadcrumbs: set_breadcrumbs(type, section, user_id),
-               delivery_breadcrumb: true,
                section: section,
                user: user
              )}

--- a/lib/oli_web/live/resources/activities_view.ex
+++ b/lib/oli_web/live/resources/activities_view.ex
@@ -235,7 +235,7 @@ defmodule OliWeb.Resources.ActivitiesView do
 
   def render(assigns) do
     ~F"""
-    <div id="activity_review" phx-hook="ReviewActivity">
+    <div id="activity_review" class="container mx-auto" phx-hook="ReviewActivity">
 
       <FilterBox
         card_header_text="Browse All Activities"

--- a/lib/oli_web/live/resources/pages_view.ex
+++ b/lib/oli_web/live/resources/pages_view.ex
@@ -79,7 +79,8 @@ defmodule OliWeb.Resources.PagesView do
         total_count = determine_total(pages)
         {:ok, table_model} = PagesTableModel.new(pages, project, context)
 
-        project_hierarchy = AuthoringResolver.full_hierarchy(project_slug) |> HierarchyNode.simplify()
+        project_hierarchy =
+          AuthoringResolver.full_hierarchy(project_slug) |> HierarchyNode.simplify()
 
         assign(socket,
           context: context,
@@ -147,7 +148,7 @@ defmodule OliWeb.Resources.PagesView do
   def render(assigns) do
     ~F"""
     {render_modal(assigns)}
-    <div>
+    <div class="container mx-auto">
 
       <FilterBox
         card_header_text="Browse All Pages"

--- a/lib/oli_web/live/sections/edit_view.ex
+++ b/lib/oli_web/live/sections/edit_view.ex
@@ -6,7 +6,16 @@ defmodule OliWeb.Sections.EditView do
   alias OliWeb.Common.{Breadcrumb, SessionContext, FormatDateTime, CustomLabelsForm}
   alias OliWeb.Common.Properties.{Groups, Group}
   alias OliWeb.Router.Helpers, as: Routes
-  alias OliWeb.Sections.{LtiSettings, MainDetails, Mount, OpenFreeSettings, PaywallSettings, ContentSettings}
+
+  alias OliWeb.Sections.{
+    LtiSettings,
+    MainDetails,
+    Mount,
+    OpenFreeSettings,
+    PaywallSettings,
+    ContentSettings
+  }
+
   alias Surface.Components.Form
   alias Oli.Branding.CustomLabels
 
@@ -42,14 +51,16 @@ defmodule OliWeb.Sections.EditView do
         available_brands =
           Branding.list_brands()
           |> Enum.map(fn brand -> {brand.name, brand.id} end)
-          labels = case section.customizations do
+
+        labels =
+          case section.customizations do
             nil -> Map.from_struct(CustomLabels.default())
             val -> Map.from_struct(val)
           end
+
         {:ok,
          assign(socket,
            context: SessionContext.init(session),
-           delivery_breadcrumb: true,
            brands: available_brands,
            changeset: Sections.change_section(section),
            is_admin: type == :admin,
@@ -107,9 +118,16 @@ defmodule OliWeb.Sections.EditView do
   def handle_event("save_labels", %{"view" => params}, socket) do
     socket = clear_flash(socket)
 
-    params = Map.merge(%{"unit" => "Unit", "module" => "Module", "section" => "Section"}, params, fn _k, v1, v2 ->
-      if v2 == nil || String.length(String.trim v2) == 0 do v1 else v2 end
-    end)
+    params =
+      Map.merge(%{"unit" => "Unit", "module" => "Module", "section" => "Section"}, params, fn _k,
+                                                                                              v1,
+                                                                                              v2 ->
+        if v2 == nil || String.length(String.trim(v2)) == 0 do
+          v1
+        else
+          v2
+        end
+      end)
 
     case Sections.update_section(socket.assigns.section, %{customizations: params}) do
       {:ok, section} ->

--- a/lib/oli_web/live/sections/enrollments/enrollments_view.ex
+++ b/lib/oli_web/live/sections/enrollments/enrollments_view.ex
@@ -63,7 +63,6 @@ defmodule OliWeb.Sections.EnrollmentsView do
          assign(socket,
            context: context,
            changeset: Sections.change_section(section),
-           delivery_breadcrumb: true,
            breadcrumbs: set_breadcrumbs(type, section),
            is_admin: type == :admin,
            section: section,
@@ -118,7 +117,7 @@ defmodule OliWeb.Sections.EnrollmentsView do
 
   def render(assigns) do
     ~F"""
-    <div>
+    <div class="container mx-auto">
 
       <div class="d-flex justify-content-between">
         <TextSearch id="text-search"/>

--- a/lib/oli_web/live/sections/gating_and_scheduling.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling.ex
@@ -132,7 +132,6 @@ defmodule OliWeb.Sections.GatingAndScheduling do
       title: title,
       context: context,
       section: section,
-      delivery_breadcrumb: true,
       breadcrumbs: set_breadcrumbs(section, parent_gate, user_type),
       table_model: table_model,
       total_count: total_count,

--- a/lib/oli_web/live/sections/gating_and_scheduling/gating_condition_store.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling/gating_condition_store.ex
@@ -100,7 +100,6 @@ defmodule OliWeb.Delivery.Sections.GatingAndScheduling.GatingConditionStore do
       count_exceptions: count_exceptions(parent_gate_id, gating_condition_id),
       title: title,
       section: section,
-      delivery_breadcrumb: true,
       breadcrumbs: set_breadcrumbs(section, module, title, parent_gate, user_type),
       gating_condition: gating_condition
     )

--- a/lib/oli_web/live/sections/invite_view.ex
+++ b/lib/oli_web/live/sections/invite_view.ex
@@ -39,7 +39,6 @@ defmodule OliWeb.Sections.InviteView do
         {:ok,
          assign(socket,
            context: SessionContext.init(session),
-           delivery_breadcrumb: true,
            breadcrumbs: set_breadcrumbs(type, section),
            section: section,
            invitations: SectionInvites.list_section_invites(section.id)

--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -35,7 +35,7 @@ defmodule OliWeb.Sections.OverviewView do
     previous ++
       [
         Breadcrumb.new(%{
-          full_title: "Section Overview",
+          full_title: "Manage Section",
           link:
             Routes.live_path(
               OliWeb.Endpoint,
@@ -100,7 +100,7 @@ defmodule OliWeb.Sections.OverviewView do
     ~F"""
     {render_modal(assigns)}
     <Groups>
-      <Group label="Overview" description="Overview of this course section">
+      <Group label="Details" description="Overview of course section details">
         <ReadOnly label="Course Section ID" value={@section.slug}/>
         <ReadOnly label="Title" value={@section.title}/>
         <ReadOnly label="Course Section Type" value={type_to_string(@section)}/>
@@ -118,10 +118,10 @@ defmodule OliWeb.Sections.OverviewView do
           />
         {/unless}
       </Group>
-      <Group label="Instructors" description="Manage the users with instructor level access">
+      <Group label="Instructors" description="Manage users with instructor level access">
         <Instructors users={@instructors}/>
       </Group>
-      <Group label="Curriculum" description="Manage the content delivered to students">
+      <Group label="Curriculum" description="Manage content delivered to students">
         <ul class="link-list">
         <li>
           <a target="_blank" href={Routes.content_path(OliWeb.Endpoint, :preview, @section.slug)} class={"btn btn-link"}><span>Preview Course as Instructor</span> <i class="fas fa-external-link-alt self-center ml-1"></i></a>

--- a/lib/oli_web/live/sections/schedule_view.ex
+++ b/lib/oli_web/live/sections/schedule_view.ex
@@ -34,7 +34,6 @@ defmodule OliWeb.Sections.ScheduleView do
         {:ok,
          assign(socket,
            context: SessionContext.init(session),
-           delivery_breadcrumb: true,
            breadcrumbs: set_breadcrumbs(type, section),
            section: section,
            js_path: Routes.static_path(OliWeb.Endpoint, "/js/scheduler.js"),

--- a/lib/oli_web/plugs/set_user.ex
+++ b/lib/oli_web/plugs/set_user.ex
@@ -19,8 +19,8 @@ defmodule Oli.Plugs.SetCurrentUser do
 
   def set_author(conn) do
     with pow_config <- OliWeb.Pow.PowHelpers.get_pow_config(:author),
-        %{id: author_id} <- Pow.Plug.current_user(conn, pow_config),
-        {:ok, current_author} <- get_author(author_id) do
+         %{id: author_id} <- Pow.Plug.current_user(conn, pow_config),
+         {:ok, current_author} <- get_author(author_id) do
       conn
       |> put_session(:current_author_id, current_author.id)
       |> put_session(:is_community_admin, current_author.community_admin_count > 0)
@@ -59,10 +59,14 @@ defmodule Oli.Plugs.SetCurrentUser do
 
   defp get_author(author_id) do
     case AccountLookupCache.get("author_#{author_id}") do
-      {:ok, %Author{}} = response -> response
+      {:ok, %Author{}} = response ->
+        response
+
       _ ->
         case Accounts.get_author_with_community_admin_count(author_id) do
-          nil -> {:error, :not_found}
+          nil ->
+            {:error, :not_found}
+
           author ->
             AccountLookupCache.put("author_#{author_id}", author)
 
@@ -73,10 +77,14 @@ defmodule Oli.Plugs.SetCurrentUser do
 
   defp get_user(user_id) do
     case AccountLookupCache.get("user_#{user_id}") do
-      {:ok, %User{}} = response -> response
+      {:ok, %User{}} = response ->
+        response
+
       _ ->
         case Accounts.get_user_with_roles(user_id) do
-          nil -> {:error, :not_found}
+          nil ->
+            {:error, :not_found}
+
           user ->
             AccountLookupCache.put("user_#{user_id}", user)
 

--- a/lib/oli_web/templates/layout/_footer.html.eex
+++ b/lib/oli_web/templates/layout/_footer.html.eex
@@ -1,4 +1,3 @@
-<%= render OliWeb.SharedView, "_help.html", conn: @conn %>
 <%
   privacy_policies_url = Application.fetch_env!(:oli, :privacy_policies)[:url]
   footer =  Application.fetch_env!(:oli, :footer)

--- a/lib/oli_web/templates/layout/app.html.eex
+++ b/lib/oli_web/templates/layout/app.html.eex
@@ -1,4 +1,4 @@
-<div class="flash container px-0">
+<div class="flash container mx-auto px-0">
   <%= if get_flash(@conn, :info) do %>
     <div>
       <p class="alert alert-info mb-3" role="alert"><%= get_flash(@conn, :info) %></p>

--- a/lib/oli_web/templates/layout/authoring.html.leex
+++ b/lib/oli_web/templates/layout/authoring.html.leex
@@ -74,5 +74,6 @@
 
     <%= Map.get(assigns, :inner_layout) || @inner_content %>
 
+    <%= render OliWeb.SharedView, "_help.html" %>
   </body>
 </html>

--- a/lib/oli_web/templates/layout/delivery_admin.html.heex
+++ b/lib/oli_web/templates/layout/delivery_admin.html.heex
@@ -4,14 +4,13 @@
   Skip Navigation
 </a>
 
-<div class="default pb-[60px]">
-
-  <main role="main" id="main-content">
-
-    <%= @inner_content %>
-
-  </main>
-
-</div>
+<Components.Delivery.InstructorDashboard.main_layout
+  socket_or_conn={OliWeb.Components.Delivery.Utils.socket_or_conn(assigns)}
+  current_user={@current_user}
+  section={@section}
+  preview_mode={assigns[:preview_mode]}
+  breadcrumbs={assigns[:breadcrumbs]}>
+  <%= @inner_content %>
+</Components.Delivery.InstructorDashboard.main_layout>
 
 <% end %>

--- a/lib/oli_web/templates/layout/delivery_admin.html.heex
+++ b/lib/oli_web/templates/layout/delivery_admin.html.heex
@@ -5,7 +5,6 @@
 </a>
 
 <div class="default pb-[60px]">
-  <Components.Header.header {assigns} />
 
   <main role="main" id="main-content">
 

--- a/lib/oli_web/templates/layout/live.html.leex
+++ b/lib/oli_web/templates/layout/live.html.leex
@@ -1,27 +1,28 @@
+<div class="flash container mx-auto px-0">
+  <%= if live_flash(@flash, :info) do %>
+    <div class="alert alert-info flex flex-row justify-between" role="alert">
 
-<%= if live_flash(@flash, :info) do %>
-  <div class="alert alert-info flex flex-row justify-between" role="alert">
+      <%= live_flash(@flash, :info) %>
 
-    <%= live_flash(@flash, :info) %>
+      <button type="button" class="close" data-bs-dismiss="alert" aria-label="Close" phx-click="lv:clear-flash" phx-value-key="info">
+        <i class="fa-solid fa-xmark fa-lg"></i>
+      </button>
 
-    <button type="button" class="close" data-bs-dismiss="alert" aria-label="Close" phx-click="lv:clear-flash" phx-value-key="info">
-      <i class="fa-solid fa-xmark fa-lg"></i>
-    </button>
+    </div>
+  <% end %>
 
-  </div>
-<% end %>
+  <%= if live_flash(@flash, :error) do %>
+    <div class="alert alert-danger flex flex-row justify-between" role="alert">
 
-<%= if live_flash(@flash, :error) do %>
-  <div class="alert alert-danger flex flex-row justify-between" role="alert">
+      <%= live_flash(@flash, :error) %>
 
-    <%= live_flash(@flash, :error) %>
+      <button type="button" class="close" data-bs-dismiss="alert" aria-label="Close" phx-click="lv:clear-flash" phx-value-key="error">
+        <i class="fa-solid fa-xmark fa-lg"></i>
+      </button>
 
-    <button type="button" class="close" data-bs-dismiss="alert" aria-label="Close" phx-click="lv:clear-flash" phx-value-key="error">
-      <i class="fa-solid fa-xmark fa-lg"></i>
-    </button>
-
-  </div>
-<% end %>
+    </div>
+  <% end %>
+</div>
 
 <script id="keep-alive" type="text/javascript" src="<%= Routes.static_path(OliWeb.Endpoint, "/js/keepalive.js") %>"></script>
 

--- a/lib/oli_web/templates/lti/register.html.eex
+++ b/lib/oli_web/templates/lti/register.html.eex
@@ -203,5 +203,7 @@
     </div>
   </div>
 
+  <%= render OliWeb.SharedView, "_help.html", conn: @conn %>
+
   <%= render OliWeb.LayoutView, "_delivery_footer.html", assigns %>
 </div>

--- a/lib/oli_web/templates/lti/registration_pending.html.eex
+++ b/lib/oli_web/templates/lti/registration_pending.html.eex
@@ -38,5 +38,8 @@
       <p>For help and more information regarding your request, please <a href='javascript:;' onclick="showHelpModal();">contact support</a>.</p>
     </div>
 
+
+  <%= render OliWeb.SharedView, "_help.html", conn: @conn %>
+
   <%= render OliWeb.LayoutView, "_delivery_footer.html", assigns %>
 </div>


### PR DESCRIPTION
This PR fixes an issue where two different headers were being rendered in delivery. It also addresses the issue that some manage view do not have the proper header or breadcrumb:
- refactor layout pipeline to render proper delivery header for all instructor views
- render main layout in delivery layout instead of separately in each LiveView
- remove session context and replace with explicit current_user and other assigns
- restore delivery breadcrumb
- fix some dark mode and missing container mx-auto
- remove unnecessary delivery_breadcrumb: true assign
