### PR TITLE
[BUG FIX] fix explorations

### DIFF
--- a/lib/oli/delivery.ex
+++ b/lib/oli/delivery.ex
@@ -257,8 +257,7 @@ defmodule Oli.Delivery do
       from([sr: sr, rev: rev] in DeliveryResolver.section_resource_revisions(section_slug),
         where:
           rev.purpose == :application and rev.deleted == false and
-            rev.resource_type_id == ^page_id and
-            sr.numbering_level > 0,
+            rev.resource_type_id == ^page_id,
         select: rev.id,
         limit: 1
       )

--- a/lib/oli/publishing/delivery_resolver.ex
+++ b/lib/oli/publishing/delivery_resolver.ex
@@ -296,8 +296,7 @@ defmodule Oli.Publishing.DeliveryResolver do
     Repo.all(
       from([sr: sr, rev: rev] in section_resource_revisions(section_slug),
         where:
-          rev.purpose == ^purpose and rev.deleted == false and rev.resource_type_id == ^page_id and
-            sr.numbering_level > 0,
+          rev.purpose == ^purpose and rev.deleted == false and rev.resource_type_id == ^page_id,
         select: rev,
         order_by: [asc: :resource_id]
       )
@@ -321,8 +320,7 @@ defmodule Oli.Publishing.DeliveryResolver do
       from([sr: sr, rev: rev] in section_resource_revisions(section_slug),
         where:
           ^resource_id in rev.relates_to and rev.deleted == false and
-            rev.resource_type_id == ^page_id and
-            sr.numbering_level > 0,
+            rev.resource_type_id == ^page_id,
         select: rev,
         order_by: [asc: :resource_id]
       )

--- a/lib/oli_web/components/delivery/exploration_card.ex
+++ b/lib/oli_web/components/delivery/exploration_card.ex
@@ -1,28 +1,22 @@
 defmodule OliWeb.Components.Delivery.ExplorationCard do
   use Phoenix.Component
 
+  alias OliWeb.Router.Helpers, as: Routes
+
   attr :dark, :boolean, default: false
   attr :exploration, :map
+  attr :section_slug, :string
 
   def render(assigns) do
     ~H"""
       <div class={"@container/card flex-1 bg-white dark:bg-gray-800 dark:text-white shadow #{if @dark, do: "bg-delivery-header-800 text-white"}"}>
         <div class="p-6 flex flex-col">
-          <h6 class="font-semibold text-lg leading-6"><%= @exploration.title %></h6>
           <div class="flex flex-col @2xl/card:flex-row @2xl/card:items-center @2xl/card:justify-between">
-            <div class="flex w-full flex-col my-3 gap-y-3">
-              <div class="flex items-center">
-                <div class="flex items-center gap-1">
-                  <div class="text-delivery-primary"><i class="fa-solid fa-clock"></i></div>
-                  <span class="font-normal text-sm leading-5">Estimated completion time: 10 mins</span>
-                </div>
-              </div>
-            </div>
+            <h6 class="font-semibold text-lg leading-6"><%= @exploration.title %></h6>
             <div class="flex w-full gap-3 justify-end">
-              <div class={"flex flex-1 @2xl/card:flex-initial @2xl/card:w-64 bg-gray-100 items-center justify-center rounded-sm #{if @dark, do: "bg-opacity-10"}"}>
-                <span class="py-2 px-5">Completed!</span>
-              </div>
-              <button class="btn text-white hover:text-white inline-flex bg-delivery-primary hover:bg-delivery-primary-600 active:bg-delivery-primary-700">Review</button>
+              <a
+                href={Routes.page_delivery_path(OliWeb.Endpoint, :page, @section_slug, @exploration.slug)}
+                class="btn text-white hover:text-white inline-flex bg-delivery-primary hover:bg-delivery-primary-600 active:bg-delivery-primary-700">Open</a>
             </div>
           </div>
         </div>

--- a/lib/oli_web/components/delivery/exploration_list.ex
+++ b/lib/oli_web/components/delivery/exploration_list.ex
@@ -9,7 +9,8 @@ defmodule OliWeb.Components.Delivery.ExplorationList do
 
     {:ok,
      assign(socket,
-       explorations: explorations
+       explorations: explorations,
+       section_slug: section_slug
      )}
   end
 
@@ -18,7 +19,7 @@ defmodule OliWeb.Components.Delivery.ExplorationList do
       <div class="flex flex-col gap-4">
         <%= if length(@explorations) > 0 do %>
           <%= for exploration <- @explorations do %>
-            <ExplorationCard.render exploration={exploration} />
+            <ExplorationCard.render exploration={exploration} section_slug={@section_slug}/>
           <% end %>
         <% else %>
           <div class="bg-white dark:bg-gray-800 border-l-4 border-delivery-primary p-4" role="alert">

--- a/lib/oli_web/components/delivery/exploration_shade.ex
+++ b/lib/oli_web/components/delivery/exploration_shade.ex
@@ -4,6 +4,7 @@ defmodule OliWeb.Components.Delivery.ExplorationShade do
   alias OliWeb.Components.Delivery.ExplorationCard
 
   attr :exploration_pages, :map, default: nil
+  attr :section_slug, :string
 
   def exploration_shade(assigns) do
     ~H"""
@@ -26,9 +27,9 @@ defmodule OliWeb.Components.Delivery.ExplorationShade do
         </div>
         <div class="collapse container mx-auto md:px-10 pt-2 pb-4" id="collapseExploration">
           <%= if @exploration_pages && length(@exploration_pages) > 0 do %>
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-4 max-h">
+            <div class="grid grid-cols-1 md:grid-cols-1 gap-4 max-h">
               <%= for exploration <- @exploration_pages do %>
-                <ExplorationCard.render dark={true} exploration={exploration} />
+                <ExplorationCard.render dark={true} exploration={exploration} section_slug={@section_slug}/>
               <% end %>
             </div>
           <% else %>

--- a/lib/oli_web/templates/layout/page.html.heex
+++ b/lib/oli_web/templates/layout/page.html.heex
@@ -9,7 +9,7 @@
       <% end %>
 
       <%= if assigns.section.contains_explorations do%>
-        <Components.Delivery.ExplorationShade.exploration_shade exploration_pages={Map.get(@conn.assigns, :exploration_pages, nil)} />
+        <Components.Delivery.ExplorationShade.exploration_shade section_slug={assigns.section.slug} exploration_pages={Map.get(@conn.assigns, :exploration_pages, nil)} />
       <% end %>
 
       <div class="md:container md:mx-auto md:px-10 md:mt-3 md:mb-5">


### PR DESCRIPTION
There were a couple things broken with Explorations.

1. The impl did not recognize explorations that lived outside the hierarchy of the course. This is actually going to be the pattern that most courses that use explorations will follow. Fix here was to remove the `numbering_level > 0` portions of relevant queries
2. The rendering of explorations included hard-coded information and did not allow the user to "click to open"