### PR TITLE
[BUG FIX] remove numbering_level >= 0 constraint

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -1969,7 +1969,7 @@ defmodule Oli.Delivery.Sections do
       )
       |> where(
         [sr, s, _, _, _, gc, gc2],
-        s.slug == ^section_slug and sr.numbering_level >= 0 and (is_nil(gc) or gc.type == :schedule) and (is_nil(gc2) or gc2.type == :schedule)
+        s.slug == ^section_slug and (is_nil(gc) or gc.type == :schedule) and (is_nil(gc2) or gc2.type == :schedule)
       )
       |> select([sr, s, _, _, rev, gc, gc2], %{
         id: sr.id,

--- a/lib/oli/resources/collaboration.ex
+++ b/lib/oli/resources/collaboration.ex
@@ -368,8 +368,7 @@ defmodule Oli.Resources.Collaboration do
         post in Post,
         join: sr in SectionResource,
         on:
-          sr.resource_id == post.resource_id and sr.section_id == post.section_id and
-            sr.numbering_level > 0,
+          sr.resource_id == post.resource_id and sr.section_id == post.section_id,
         join: spp in SectionsProjectsPublications,
         on: spp.section_id == post.section_id and spp.project_id == sr.project_id,
         join: pr in PublishedResource,
@@ -414,8 +413,7 @@ defmodule Oli.Resources.Collaboration do
         post in Post,
         join: sr in SectionResource,
         on:
-          sr.resource_id == post.resource_id and sr.section_id == post.section_id and
-            sr.numbering_level > 0,
+          sr.resource_id == post.resource_id and sr.section_id == post.section_id,
         join: spp in SectionsProjectsPublications,
         on: spp.section_id == post.section_id and spp.project_id == sr.project_id,
         join: pr in PublishedResource,
@@ -504,8 +502,7 @@ defmodule Oli.Resources.Collaboration do
     |> join(:inner, [p], s in Section, on: s.slug == ^section_slug)
     |> join(:inner, [p], sr in SectionResource,
       on:
-        sr.resource_id == p.resource_id and sr.section_id == p.section_id and
-          sr.numbering_level > 0
+        sr.resource_id == p.resource_id and sr.section_id == p.section_id
     )
     |> join(:inner, [p, s, sr], spp in SectionsProjectsPublications,
       on: spp.section_id == p.section_id and spp.project_id == sr.project_id


### PR DESCRIPTION
Several queries include the constraint that the `numbering_level` for a section resource must be greater than or equal to `0`.  This ends up having the effect of excluding pages that do not exist in the course hierarchy (but that are simply linked from pages that do exist in the hierarchy).  Many courses, especially legacy OLI courses, will feature graded pages that do no exist in the hierarchy.  Removing this constraint allows those pages to show up in the "Assignments" view and their posts to show up in the various "Collaboration Spaces" views. 