### PR TITLE
[BUG FIX] Fix snapshot creation when objectives are duplicated

### DIFF
--- a/lib/oli/delivery/snapshots/worker.ex
+++ b/lib/oli/delivery/snapshots/worker.ex
@@ -88,9 +88,12 @@ defmodule Oli.Delivery.Snapshots.Worker do
           # If there are no attached objectives, create one record recoring nils for the objectives
           [] -> [to_attrs(result, nil, nil, project_id)]
 
-          # Otherwise create one record for each objective
+          # Otherwise create one record for each objective, careful to dedupe in the event that
+          # somehow a part has objectives duplicated
           objective_ids ->
-            Enum.map(objective_ids, fn id ->
+            MapSet.new(objective_ids)
+            |> MapSet.to_list()
+            |> Enum.map(fn id ->
               to_attrs(result, id, Map.get(objective_revisions_by_id, id), project_id)
             end)
         end

--- a/lib/oli/interop/ingest/processor/activities.ex
+++ b/lib/oli/interop/ingest/processor/activities.ex
@@ -54,6 +54,8 @@ defmodule Oli.Interop.Ingest.Processor.Activities do
         |> Enum.reduce(%{}, fn k, m ->
           mapped =
             Map.get(activity, "objectives")[k]
+            |> MapSet.new()
+            |> MapSet.to_list()
             |> Enum.map(fn id ->
               case Map.get(objective_map, id) do
                 nil ->
@@ -74,7 +76,9 @@ defmodule Oli.Interop.Ingest.Processor.Activities do
         |> Enum.map(fn %{"id" => id} -> id end)
         |> Enum.reduce(%{}, fn e, m ->
           objectives =
-            Enum.map(list, fn id ->
+            MapSet.new(list)
+            |> MapSet.to_list()
+            |> Enum.map(fn id ->
               case Map.get(objective_map, id) do
                 nil ->
                   IO.inspect("Missing objective #{id}")

--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -178,6 +178,11 @@ defmodule OliWeb.Sections.OverviewView do
           </li>
           <li><a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Grades.GradebookView, @section.slug)} class={"btn btn-link"}>View all Grades</a></li>
           <li><a href={Routes.page_delivery_path(OliWeb.Endpoint, :export_gradebook, @section.slug)} class={"btn btn-link"}>Download Gradebook as <code>.csv</code> file</a></li>
+
+          {#if @is_system_admin}
+            <li><a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Snapshots.SnapshotsView, @section.slug)} class={"btn btn-link"}>Manage Snapshot Records</a></li>
+          {/if}
+
           {#if !@section.open_and_free}
             <li><a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Grades.GradesLive, @section.slug)} class={"btn btn-link"}>Manage LMS Gradebook</a></li>
             <li><a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Grades.FailedGradeSyncLive, @section.slug)} class={"btn btn-link"}>View Grades that failed to sync</a></li>

--- a/lib/oli_web/live/snapshots/snapshots_view.ex
+++ b/lib/oli_web/live/snapshots/snapshots_view.ex
@@ -1,0 +1,125 @@
+defmodule OliWeb.Snapshots.SnapshotsView do
+
+  use Surface.LiveView, layout: {OliWeb.LayoutView, "live.html"}
+
+  import Ecto.Query, warn: false
+  alias Oli.Repo
+
+  alias Oli.Delivery.Attempts.Core.{
+    PartAttempt,
+    ResourceAccess,
+    ResourceAttempt,
+    ActivityAttempt,
+  }
+  alias Oli.Delivery.Snapshots.Snapshot
+  alias OliWeb.Sections.Mount
+  alias OliWeb.Common.Breadcrumb
+  alias OliWeb.Router.Helpers, as: Routes
+
+  data missing, :any, default: []
+  data section, :any, default: nil
+  data result, :any, default: nil
+
+  def set_breadcrumbs(type, section) do
+    OliWeb.Sections.OverviewView.set_breadcrumbs(type, section)
+    |> breadcrumb(section)
+  end
+
+  def breadcrumb(previous, section) do
+    previous ++
+      [
+        Breadcrumb.new(%{
+          full_title: "Manage Snapshot Records",
+          link: Routes.live_path(OliWeb.Endpoint, __MODULE__, section.slug)
+        })
+      ]
+  end
+
+  def mount(%{"section_slug" => section_slug}, session, socket) do
+    case Mount.for(section_slug, session) do
+      {:error, e} ->
+        Mount.handle_error(socket, {:error, e})
+
+      {type, _, section} ->
+
+        missing = get_missing(section)
+        count_missing = Enum.count(missing)
+
+        {:ok,
+         assign(socket,
+           breadcrumbs: set_breadcrumbs(type, section),
+           section: section,
+           missing: missing,
+           count_missing: count_missing
+         )}
+    end
+  end
+
+
+  def render(assigns) do
+    ~F"""
+    <div class="container mx-auto">
+    {#if @count_missing > 0}
+
+        <p>There seems to be {@count_missing} snapshot records.</p>
+
+        {#if is_nil(@result)}
+          <button class="btn btn-primary" :on-click="run">Generate Snapshots</button>
+        {#else}
+          {#if @result == :success}
+            <p><strong>Success!</strong></p>
+          {#else}
+            <p><strong>Error!</strong></p>
+            {Kernel.inspect(@result)}
+          {/if}
+        {/if}
+
+    {#else}
+      <p>There seems to be no missing snapshot records.</p>
+    {/if}
+
+    </div>
+    """
+  end
+
+  defp get_missing(section) do
+
+    section_id = section.id
+
+    all_guids =
+      from(pa in PartAttempt,
+        join: aa in ActivityAttempt,
+        on: pa.activity_attempt_id == aa.id,
+        join: ra in ResourceAttempt,
+        on: aa.resource_attempt_id == ra.id,
+        join: a in ResourceAccess,
+        on: ra.resource_access_id == a.id,
+        where: a.section_id == ^section_id and pa.lifecycle_state == :evaluated,
+        select: pa.attempt_guid
+      )
+      |> Repo.all()
+      |> MapSet.new()
+
+    all_snapshots =
+      from(s in Snapshot,
+        join: pa in PartAttempt,
+        on: pa.id == s.part_attempt_id,
+        where: s.section_id == ^section_id,
+        select: pa.attempt_guid
+      )
+      |> Repo.all()
+      |> MapSet.new()
+
+    MapSet.difference(all_guids, all_snapshots) |> MapSet.to_list()
+
+  end
+
+  def handle_event("run", _, socket) do
+    case Oli.Delivery.Snapshots.Worker.perform_now(socket.assigns.missing, socket.assigns.section.slug) |> IO.inspect do
+      {:ok, _} ->  {:noreply, assign(socket, missing: [], count_missing: 0, result: :success)}
+      {:error, e} -> {:noreply, assign(socket, result: e)}
+      e -> {:noreply, assign(socket, result: e)}
+    end
+  end
+
+end

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -884,6 +884,7 @@ defmodule OliWeb.Router do
     live("/:section_slug/grades/observe", Grades.ObserveGradeUpdatesView)
     live("/:section_slug/grades/gradebook", Grades.GradebookView)
     live("/:section_slug/scoring", ManualGrading.ManualGradingView)
+    live("/:section_slug/snapshots", Snapshots.SnapshotsView)
     live("/:section_slug/progress/:user_id/:resource_id", Progress.StudentResourceView)
     live("/:section_slug/progress/:user_id", Progress.StudentView)
     get("/:section_slug/grades/export", PageDeliveryController, :export_gradebook)


### PR DESCRIPTION
Snapshot creation fails when there is an activity that duplicates an objective for one part.  This can only happen when an objective is ingested in this state.  

This PR does the following:
1. Makes the snapshot generation code in `worker.ex` robust to duplicates, by deduping the part specific list of objectives, prior to snapshot insertion.
2. Fixes the activity ingest processor to dedupe objective ids
3. Adds a new LiveView "Manage Snapshot Records", which is Admin accessible only, that detects when there are snapshot records missing for a specific course section and then allows these snapshot records to be created. 

To test the LV out end-to-end, the easiest thing to do is to create a course section with a page that have a couple of MCQ questions.  Then, as a guest student, access that page and answer the questions.  This will generate snapshot records.  Open PgAdmin, and run `DELETE from snapshots;` to delete those records.   Then go to the LV and verify that it detects the missing snapshot records and after clicking "Generate Snaphot records" that indeed generates them (by looking in PgAdmin)

