### PR TITLE
 [BUGFIX] Config MathJax to autoload standard extensions[MER-1863][MER-1869]

### DIFF
--- a/lib/oli_web/common/mathjax_script.ex
+++ b/lib/oli_web/common/mathjax_script.ex
@@ -49,7 +49,7 @@ defmodule OliWeb.Common.MathJaxScript do
         processHtmlClass: 'tex2jax_process'
       },
       loader: {
-        load: ['[tex]/noerrors', '[tex]/autoload']
+        load: ['[tex]/noerrors']
       },
       renderMathML(math, doc) {
         math.typesetRoot = document.createElement('mjx-container');

--- a/lib/oli_web/common/mathjax_script.ex
+++ b/lib/oli_web/common/mathjax_script.ex
@@ -9,7 +9,7 @@ defmodule OliWeb.Common.MathJaxScript do
         inlineMath: [ ["\\(","\\)"] ],
         displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
         processEscapes: true,
-        packages: ['base', 'ams', 'noerrors', 'noundefined', 'require'],
+        packages: ['base', 'ams', 'noerrors', 'noundefined', 'require', 'autoload'],
         require: {
           defaultAllow: false,
           allow: {
@@ -49,7 +49,7 @@ defmodule OliWeb.Common.MathJaxScript do
         processHtmlClass: 'tex2jax_process'
       },
       loader: {
-        load: ['[tex]/noerrors']
+        load: ['[tex]/noerrors', '[tex]/autoload']
       },
       renderMathML(math, doc) {
         math.typesetRoot = document.createElement('mjx-container');


### PR DESCRIPTION
Adjusts MathJax configuration to allow the autoload extension to be used to automatically load other tex extensions as needed. This fixes issue seen on the \boldsymbol macro, enabling the macro to trigger autoload the boldsymbol tex extension without use of \require{boldsymbol}. Also the \style macro which should trigger autoload the html extension. 

MathJax documentation suggests the tex-mml-chtml combined component we are using includes the autoload package with it so that \requires are not needed for the macros above. But it seems autoload must still be listed in the configured tex packages list before MathJax will use it.