### PR TITLE
[BUGFIX] Fix targeted feedback authoring when multiple dropdowns [MER-1876]

### DIFF
--- a/assets/src/components/activities/common/responses/TargetedFeedback.tsx
+++ b/assets/src/components/activities/common/responses/TargetedFeedback.tsx
@@ -41,6 +41,17 @@ export const useTargetedFeedback = () => {
   };
 };
 
+// get subset of response mappings for given choice set only, for use w/multipart items
+export const getFeedbackForChoices = (
+  partChoices: Choice[],
+  allTargetedMappings: ResponseMapping[],
+): ResponseMapping[] => {
+  const partChoiceIds = partChoices.map((choice) => choice.id);
+  return allTargetedMappings.filter((assoc) =>
+    assoc.choiceIds.every((id) => partChoiceIds.includes(id)),
+  );
+};
+
 export const TargetedFeedback: React.FC<Props> = (props) => {
   const hook = useTargetedFeedback();
   const { model, authoringContext, editMode, projectSlug } = useAuthoringElementContext<
@@ -54,9 +65,11 @@ export const TargetedFeedback: React.FC<Props> = (props) => {
     return props.children(hook);
   }
 
+  // only show feedbacks for relevant choice set, presumably current part's on multipart
+  const partMappings = getFeedbackForChoices(props.choices || model.choices, hook.targetedMappings);
   return (
     <>
-      {hook.targetedMappings.map((mapping) => (
+      {partMappings.map((mapping) => (
         <ResponseCard
           key={mapping.response.id}
           title="Targeted feedback"


### PR DESCRIPTION
Answer tab on Multi-input authoring showed bad targeted feedback n the case of a multi-input question with multiple dropdown parts. It was rendering the list of targeted feedback for ALL parts, but updating the choices shown on each to refelect those of the current part. See MER-1876 for more detail

This fixes the targeted feedback display for this case to showing only the targeted feedback for the current part by filtering the feedbacks on the currently selected part's choice set. 