### PR TITLE
[BUG FIX] Learner progress not showing

### DIFF
--- a/assets/css/bootstrap-shims.css
+++ b/assets/css/bootstrap-shims.css
@@ -330,6 +330,10 @@ input.form-control-sm,
   @apply flex list-style-none gap-1;
 }
 
+li.page-item {
+  list-style: none;
+}
+
 .page-item .page-link {
   @apply relative block py-1.5 px-3 rounded border-0 bg-transparent outline-none transition-all duration-300 text-body-color dark:text-body-color-dark no-underline cursor-pointer;
 }

--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -12,7 +12,7 @@ defmodule Oli.Delivery.Metrics do
   Calculate the progress for a specific student (or a list of students),
   in all pages of a specific container.
 
-  Ommitting the container_id (or specifying nil) calculates progress
+  Omitting the container_id (or specifying nil) calculates progress
   across the entire course section.
 
   This query leverages the `contained_pages` relation, which is always an

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -88,18 +88,18 @@ defmodule OliWeb.PageDeliveryController do
   end
 
   defp learner_progress(section_id, user_id) do
-    case Metrics.progress_for(section_id, user_id) do
-      progress when is_float(progress) ->
+    case Map.get(Metrics.progress_for(section_id, user_id), user_id) do
+      nil ->
+        # if there is no progress (nil) then return 0%
+        0
+
+      progress ->
         (progress * 100)
         |> round()
         # if there is any progress at all, we want to represent that by at least showing 1% min
         |> max(1)
         # ensure we never show progress above 100%
         |> min(100)
-
-      _ ->
-        # if there is no progress (nil) then return 0%
-        0
     end
   end
 

--- a/lib/oli_web/live/ingest/ingestv2.ex
+++ b/lib/oli_web/live/ingest/ingestv2.ex
@@ -225,7 +225,10 @@ defmodule OliWeb.Admin.IngestV2 do
       end
     end)
 
-    {:noreply, socket}
+    {:noreply,
+     assign(socket,
+       ingestion_step: :processing
+     )}
   end
 
   def handle_event(event, params, socket) do


### PR DESCRIPTION
- fixes an issue where learner progress was never showing up
- improves the v2 ingest processing messages
- removes disc from page-item <li element
<img width="708" alt="Screenshot 2023-04-06 at 11 49 45 AM" src="https://user-images.githubusercontent.com/6248894/230469037-99a3336e-4c8f-4332-a289-685060f1fd9b.png">
