### PR TITLE
[FEATURE] [MER-1807] Instructor portal quizzes tab

### DIFF
--- a/assets/css/table.css
+++ b/assets/css/table.css
@@ -47,3 +47,7 @@
 .instructor_dashboard_table td {
   @apply border-r-0 border-l-0;
 }
+
+.instructor_dashboard_table tr:has(div[data-score-check='false']) {
+  @apply bg-red-200 bg-opacity-20;
+}

--- a/lib/oli_web/components/delivery/instructor_dashboard.ex
+++ b/lib/oli_web/components/delivery/instructor_dashboard.ex
@@ -101,6 +101,7 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard do
             {"Content", path_for(:content, @section_slug, @preview_mode), nil, is_active_tab?(:content, @active_tab)},
             {"Students", path_for(:students, @section_slug, @preview_mode), nil, is_active_tab?(:students, @active_tab)},
             {"Learning Objectives", path_for(:learning_objectives, @section_slug, @preview_mode), nil, is_active_tab?(:learning_objectives, @active_tab)},
+            {"Quiz Scores", path_for(:quiz_scores, @section_slug, @preview_mode), nil, is_active_tab?(:quiz_scores, @active_tab)},
             {"Discussion Activity", path_for(:discussions, @section_slug, @preview_mode), nil, is_active_tab?(:discussions, @active_tab)},
             {"Course Discussion", path_for(:course_discussion, @section_slug, @preview_mode), nil, is_active_tab?(:course_discussion, @active_tab)},
             {"Assignments", path_for(:assignments, @section_slug, @preview_mode), nil, is_active_tab?(:assignments, @active_tab)},

--- a/lib/oli_web/components/delivery/quiz_scores/quiz_scores.ex
+++ b/lib/oli_web/components/delivery/quiz_scores/quiz_scores.ex
@@ -85,7 +85,7 @@ defmodule OliWeb.Components.Delivery.QuizScores do
           <h4 class="!py-2 torus-h4 text-center">Quiz Scores</h4>
           <div class="flex flex-col gap-y-4 md:flex-row items-center">
             <div class="form-check">
-              <input type="checkbox" id="toggle_show_all_links" class="form-check-input -mt-1" checked={@params.show_all_links} phx-click="show_all_links" phx-target={@myself} />
+              <input type="checkbox" id="toggle_show_all_links" class="form-check-input -mt-1" checked={@params.show_all_links} phx-click="show_all_links" phx-target={@myself} phx-debounce="500"/>
               <label for="toggle_show_all_links" class="form-check-label">Shows links for all entries</label>
             </div>
             <form for="search" phx-target={@myself} phx-change="search_student" class="pb-3 md:pl-9 sm:pb-0">

--- a/lib/oli_web/components/delivery/quiz_scores/quiz_scores.ex
+++ b/lib/oli_web/components/delivery/quiz_scores/quiz_scores.ex
@@ -1,0 +1,237 @@
+defmodule OliWeb.Components.Delivery.QuizScores do
+  use Surface.LiveComponent
+
+  alias Oli.Delivery.Sections
+  alias Oli.Delivery.Sections.EnrollmentBrowseOptions
+  alias Oli.Repo.{Paging, Sorting}
+  alias OliWeb.Common.Params
+  alias OliWeb.Common.{PagedTable, SearchInput}
+  alias OliWeb.Grades.GradebookTableModel
+  alias OliWeb.Router.Helpers, as: Routes
+  alias Phoenix.LiveView.JS
+
+  prop(params, :map, required: true)
+  prop(total_count, :number, required: true)
+  prop(grades_table_model, :struct, required: true)
+
+  @default_params %{
+    offset: 0,
+    limit: 10,
+    sort_order: :asc,
+    sort_by: :name,
+    text_search: nil,
+    show_all_links: false
+  }
+
+  def update(
+        %{params: params, section: section, patch_url_type: patch_url_type} = _assigns,
+        socket
+      ) do
+    params = decode_params(params)
+
+    enrollments =
+      Sections.browse_enrollments(
+        section,
+        %Paging{offset: params.offset, limit: params.limit},
+        %Sorting{direction: params.sort_order, field: params.sort_by},
+        %EnrollmentBrowseOptions{
+          text_search: params.text_search,
+          is_student: true,
+          is_instructor: false
+        }
+      )
+
+    hierarchy = Oli.Publishing.DeliveryResolver.full_hierarchy(section.slug)
+
+    graded_pages =
+      hierarchy
+      |> Oli.Delivery.Hierarchy.flatten()
+      |> Enum.filter(fn node -> node.revision.graded end)
+      |> Enum.map(fn node -> node.revision end)
+
+    resource_accesses = fetch_resource_accesses(enrollments, section)
+
+    {:ok, table_model} =
+      GradebookTableModel.new(
+        enrollments,
+        graded_pages,
+        resource_accesses,
+        section,
+        params.show_all_links
+      )
+
+    table_model =
+      Map.merge(table_model, %{
+        sort_order: params.sort_order,
+        sort_by_spec:
+          Enum.find(table_model.column_specs, fn col_spec -> col_spec.name == params.sort_by end)
+      })
+
+    {:ok,
+     assign(
+       socket,
+       total_count: determine_total(enrollments),
+       grades_table_model: table_model,
+       params: params,
+       section_slug: section.slug,
+       patch_url_type: patch_url_type
+     )}
+  end
+
+  def render(assigns) do
+    ~F"""
+      <div class="mx-10 mb-10 bg-white shadow-sm">
+        <div class="flex flex-col justify-between sm:flex-row items-center px-6 py-4">
+          <h4 class="pl-9 !py-2 torus-h4 mr-auto">Quiz Scores</h4>
+          <div class="flex flex-row items-center">
+            <div class="form-check">
+              <input type="checkbox" id="toggle_show_all_links" class="form-check-input -mt-1" checked={@params.show_all_links} phx-click="show_all_links" phx-target={@myself} />
+              <label for="toggle_show_all_links" class="form-check-label">Shows links for all entries</label>
+            </div>
+            <form for="search" phx-target={@myself} phx-change="search_student" class="pb-6 ml-9 sm:pb-0">
+              <SearchInput.render id="student_search_input" name="student_name" text={@params.text_search} />
+            </form>
+          </div>
+        </div>
+
+
+        {#if @total_count > 0}
+          <PagedTable
+            table_model={@grades_table_model}
+            total_count={@total_count}
+            offset={@params.offset}
+            limit={@params.limit}
+            render_top_info={false}
+            additional_table_class="instructor_dashboard_table"
+            show_bottom_paging={false}
+            sort={JS.push("paged_table_sort", target: @myself)}
+            page_change={JS.push("paged_table_page_change", target: @myself)}
+          />
+        {#else}
+          <h6 class="text-center py-4">There are no quiz scores to show</h6>
+        {/if}
+      </div>
+    """
+  end
+
+  def handle_event("search_student", %{"student_name" => student_name}, socket) do
+    {:noreply,
+     push_patch(socket,
+       to:
+         route_for(
+           socket,
+           %{text_search: student_name},
+           socket.assigns.patch_url_type
+         )
+     )}
+  end
+
+  def handle_event("paged_table_page_change", %{"limit" => limit, "offset" => offset}, socket) do
+    {:noreply,
+     push_patch(socket,
+       to:
+         route_for(
+           socket,
+           %{limit: limit, offset: offset},
+           socket.assigns.patch_url_type
+         )
+     )}
+  end
+
+  def handle_event("paged_table_sort", %{"sort_by" => sort_by} = _params, socket) do
+    {:noreply,
+     push_patch(socket,
+       to:
+         route_for(
+           socket,
+           %{sort_by: String.to_existing_atom(sort_by)},
+           socket.assigns.patch_url_type
+         )
+     )}
+  end
+
+  def handle_event("show_all_links", _params, socket) do
+    {:noreply,
+     push_patch(socket,
+       to:
+         route_for(
+           socket,
+           %{show_all_links: !socket.assigns.params.show_all_links},
+           socket.assigns.patch_url_type
+         )
+     )}
+  end
+
+  defp decode_params(params) do
+    %{
+      offset: Params.get_int_param(params, "offset", @default_params.offset),
+      limit: Params.get_int_param(params, "limit", @default_params.limit),
+      sort_order:
+        Params.get_atom_param(params, "sort_order", [:asc, :desc], @default_params.sort_order),
+      sort_by:
+        Params.get_atom_param(
+          params,
+          "sort_by",
+          [:name],
+          @default_params.sort_by
+        ),
+      text_search: Params.get_param(params, "text_search", @default_params.text_search),
+      show_all_links:
+        Params.get_boolean_param(params, "show_all_links", @default_params.show_all_links)
+    }
+  end
+
+  defp fetch_resource_accesses(enrollments, section) do
+    student_ids = Enum.map(enrollments, fn user -> user.id end)
+
+    Oli.Delivery.Attempts.Core.get_graded_resource_access_for_context(
+      section.id,
+      student_ids
+    )
+  end
+
+  defp determine_total(enrollments) do
+    case(enrollments) do
+      [] -> 0
+      [hd | _] -> hd.total_count
+    end
+  end
+
+  defp update_params(%{sort_by: current_sort_by, sort_order: current_sort_order} = params, %{
+         sort_by: new_sort_by
+       })
+       when current_sort_by == new_sort_by do
+    toggled_sort_order = if current_sort_order == :asc, do: :desc, else: :asc
+    update_params(params, %{sort_order: toggled_sort_order})
+  end
+
+  defp update_params(params, new_param) do
+    Map.merge(params, new_param)
+    |> purge_default_params()
+  end
+
+  defp purge_default_params(params) do
+    Map.filter(params, fn {key, value} ->
+      @default_params[key] != value
+    end)
+  end
+
+  defp route_for(socket, new_params, :gradebook_view) do
+    Routes.live_path(
+      socket,
+      OliWeb.Grades.GradebookView,
+      socket.assigns.section_slug,
+      update_params(socket.assigns.params, new_params)
+    )
+  end
+
+  defp route_for(socket, new_params, :quiz_scores) do
+    Routes.live_path(
+      socket,
+      OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive,
+      socket.assigns.section_slug,
+      :quiz_scores,
+      update_params(socket.assigns.params, new_params)
+    )
+  end
+end

--- a/lib/oli_web/components/delivery/quiz_scores/quiz_scores.ex
+++ b/lib/oli_web/components/delivery/quiz_scores/quiz_scores.ex
@@ -81,14 +81,14 @@ defmodule OliWeb.Components.Delivery.QuizScores do
   def render(assigns) do
     ~F"""
       <div class="mx-10 mb-10 bg-white shadow-sm">
-        <div class="flex flex-col justify-between sm:flex-row items-center px-6 py-4">
-          <h4 class="pl-9 !py-2 torus-h4 mr-auto">Quiz Scores</h4>
-          <div class="flex flex-row items-center">
+        <div class="flex flex-col justify-between sm:flex-row items-center px-6 py-4 pl-9">
+          <h4 class="!py-2 torus-h4 text-center">Quiz Scores</h4>
+          <div class="flex flex-col gap-y-4 md:flex-row items-center">
             <div class="form-check">
               <input type="checkbox" id="toggle_show_all_links" class="form-check-input -mt-1" checked={@params.show_all_links} phx-click="show_all_links" phx-target={@myself} />
               <label for="toggle_show_all_links" class="form-check-label">Shows links for all entries</label>
             </div>
-            <form for="search" phx-target={@myself} phx-change="search_student" class="pb-6 ml-9 sm:pb-0">
+            <form for="search" phx-target={@myself} phx-change="search_student" class="pb-3 md:pl-9 sm:pb-0">
               <SearchInput.render id="student_search_input" name="student_name" text={@params.text_search} />
             </form>
           </div>

--- a/lib/oli_web/live/common/sortable_table/table.ex
+++ b/lib/oli_web/live/common/sortable_table/table.ex
@@ -45,11 +45,13 @@ defmodule OliWeb.Common.SortableTable.Table do
       phx-value-sort_by={column_spec.name}
     >
       {column_spec.label}
-      {#if @model.sort_by_spec == column_spec}
-        <i class={"fas fa-sort-" <> sort_direction_cls} />
-        <span class={"data-sort-" <> sort_direction_cls} data-sort-column="true"></span>
-      {#else}
-        <span class="data-sort-up" data-sort-column="false"></span>
+      {#if column_spec.sortable}
+        {#if @model.sort_by_spec == column_spec}
+          <i class={"fas fa-sort-" <> sort_direction_cls} />
+          <span class={"data-sort-" <> sort_direction_cls} data-sort-column="true"></span>
+        {#else}
+          <span class="data-sort-up" data-sort-column="false"></span>
+        {/if}
       {/if}
     </th>
     """

--- a/lib/oli_web/live/common/table/column_spec.ex
+++ b/lib/oli_web/live/common/table/column_spec.ex
@@ -35,7 +35,9 @@ defmodule OliWeb.Common.Table.ColumnSpec do
             # class to be applied to the th element
             th_class: nil,
             # class to be applied to the td element
-            td_class: nil
+            td_class: nil,
+            # indicates whether a column can be sortable or not
+            sortable: true
 
   def default_sort_fn(:asc, %{name: name}),
     do: fn row1, row2 -> Map.get(row1, name) <= Map.get(row2, name) end

--- a/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
@@ -76,6 +76,18 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive do
     """
   end
 
+  defp render_tab(%{active_tab: :quiz_scores} = assigns) do
+    ~H"""
+      <.live_component
+        id="quiz_scores_table"
+        module={OliWeb.Components.Delivery.QuizScores}
+        params={@params}
+        section={@section}
+        patch_url_type={:quiz_scores}
+      />
+    """
+  end
+
   defp render_tab(%{active_tab: :content} = assigns) do
     ~H"""
       <.live_component

--- a/lib/oli_web/live/grades/gradebook_table_model.ex
+++ b/lib/oli_web/live/grades/gradebook_table_model.ex
@@ -111,7 +111,7 @@ defmodule OliWeb.Grades.GradebookTableModel do
          %ResourceAccess{
            score: score,
            out_of: out_of
-         } = _resource_access
+         }
        ) do
     link_type = "bg-white text-red-500"
 

--- a/lib/oli_web/live/grades/gradebook_view.ex
+++ b/lib/oli_web/live/grades/gradebook_view.ex
@@ -1,32 +1,13 @@
 defmodule OliWeb.Grades.GradebookView do
   use Surface.LiveView, layout: {OliWeb.LayoutView, "live.html"}
 
-  alias Oli.Repo.{Paging, Sorting}
-  alias OliWeb.Common.{TextSearch, PagedTable, Breadcrumb}
-  alias Oli.Delivery.Sections.{EnrollmentBrowseOptions}
-  alias OliWeb.Common.Table.SortableTableModel
+  alias OliWeb.Common.Breadcrumb
   alias OliWeb.Router.Helpers, as: Routes
-  alias Oli.Delivery.Sections
-  import OliWeb.DelegatedEvents
-  import OliWeb.Common.Params
   alias OliWeb.Sections.Mount
-  alias OliWeb.Grades.GradebookTableModel
-
-  @limit 25
-  @default_options %EnrollmentBrowseOptions{
-    is_student: true,
-    is_instructor: false,
-    text_search: nil
-  }
 
   data breadcrumbs, :any
   data title, :string, default: "Gradebook"
   data section, :any, default: nil
-  data tabel_model, :struct
-  data total_count, :integer, default: 0
-  data offset, :integer, default: 0
-  data limit, :integer, default: @limit
-  data options, :any
   data show_all_links, :boolean, default: false
 
   def set_breadcrumbs(type, section) do
@@ -51,167 +32,31 @@ defmodule OliWeb.Grades.GradebookView do
         Mount.handle_error(socket, {:error, e})
 
       {type, _, section} ->
-        graded_pages =
-          Oli.Grading.fetch_graded_pages(section.slug)
-
-        enrollments =
-          Sections.browse_enrollments(
-            section,
-            %Paging{offset: 0, limit: @limit},
-            %Sorting{direction: :asc, field: :name},
-            @default_options
-          )
-
-        total_count = determine_total(enrollments)
-
-        resource_accesses = fetch_resource_accesses(enrollments, section)
-
-        {:ok, table_model} =
-          GradebookTableModel.new(
-            enrollments,
-            graded_pages,
-            resource_accesses,
-            section,
-            false
-          )
-
         {:ok,
-          assign(socket,
-            breadcrumbs: set_breadcrumbs(type, section),
-            section: section,
-            total_count: total_count,
-            table_model: table_model,
-            graded_pages: graded_pages,
-            options: @default_options
-          )}
+         assign(socket,
+           breadcrumbs: set_breadcrumbs(type, section),
+           section: section,
+           params: %{}
+         )}
     end
-  end
-
-  defp determine_total(projects) do
-    case(projects) do
-      [] -> 0
-      [hd | _] -> hd.total_count
-    end
-  end
-
-  defp fetch_resource_accesses(enrollments, section) do
-    # retrieve all graded resource accesses, but only for this slice of students
-    student_ids = Enum.map(enrollments, fn user -> user.id end)
-
-    Oli.Delivery.Attempts.Core.get_graded_resource_access_for_context(
-      section.id,
-      student_ids
-    )
   end
 
   def handle_params(params, _, socket) do
-    table_model =
-      SortableTableModel.update_from_params(
-        socket.assigns.table_model,
-        params
-      )
-
-    offset = get_int_param(params, "offset", 0)
-    show_all_links = get_boolean_param(params, "show_all_links", false)
-
-    options = %EnrollmentBrowseOptions{
-      text_search: get_param(params, "text_search", ""),
-      is_student: true,
-      is_instructor: false
-    }
-
-    enrollments =
-      Sections.browse_enrollments(
-        socket.assigns.section,
-        %Paging{offset: offset, limit: @limit},
-        # We cannot support sorting by columns other than the user name, so ignore any
-        # attempt to do that
-        %Sorting{direction: table_model.sort_order, field: :name},
-        options
-      )
-
-    resource_accesses = fetch_resource_accesses(enrollments, socket.assigns.section)
-
-    {:ok, table_model} =
-      GradebookTableModel.new(
-        enrollments,
-        socket.assigns.graded_pages,
-        resource_accesses,
-        socket.assigns.section,
-        show_all_links
-      )
-
-    total_count = determine_total(enrollments)
-
     {:noreply,
      assign(
        socket,
-       offset: offset,
-       table_model: table_model,
-       total_count: total_count,
-       show_all_links: show_all_links,
-       options: options
+       params: params
      )}
   end
 
   def render(assigns) do
     ~F"""
-    <div class="container mx-auto">
-
-      <div>
-        <TextSearch id="text-search"/>
-        <div class="form-check mt-2">
-          <input type="checkbox" id="toggle_show_all_links" class="form-check-input" checked={@show_all_links} phx-hook="CheckboxListener" />
-          <label for="toggle_show_all_links" class="form-check-label">
-            <div>Shows links for all gradebook entries</div>
-            <small class="text-muted">Allows access to pages that students have not finished or started</small>
-          </label>
-        </div>
-      </div>
-
-      <div class="mb-3"/>
-
-      <PagedTable
-        filter={@options.text_search}
-        table_model={@table_model}
-        total_count={@total_count}
-        offset={@offset}
-        limit={@limit}/>
-    </div>
+      {live_component OliWeb.Components.Delivery.QuizScores,
+        id: "quiz_scores_table",
+        section: assigns.section,
+        params: assigns.params,
+        patch_url_type: :gradebook_view
+      }
     """
-  end
-
-  def patch_with(socket, changes) do
-    {:noreply,
-     push_patch(socket,
-       to:
-         Routes.live_path(
-           socket,
-           __MODULE__,
-           socket.assigns.section.slug,
-           Map.merge(
-             %{
-               sort_by: socket.assigns.table_model.sort_by_spec.name,
-               sort_order: socket.assigns.table_model.sort_order,
-               offset: socket.assigns.offset,
-               text_search: socket.assigns.options.text_search
-             },
-             changes
-           )
-         ),
-       replace: true
-     )}
-  end
-
-  def handle_event("change", %{"id" => "toggle_show_all_links", "checked" => checked}, socket) do
-    patch_with(socket, %{show_all_links: checked})
-  end
-
-  def handle_event(event, params, socket) do
-    {event, params, socket, &__MODULE__.patch_with/2}
-    |> delegate_to([
-      &TextSearch.handle_delegated/4,
-      &PagedTable.handle_delegated/4
-    ])
   end
 end

--- a/test/oli_web/live/delivery/instructor_dashboard/quiz_scores_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/quiz_scores_tab_test.exs
@@ -1,0 +1,321 @@
+defmodule OliWeb.Delivery.InstructorDashboard.QuizScoreTabTest do
+  use ExUnit.Case, async: true
+  use OliWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+  import Oli.Factory
+
+  alias Lti_1p3.Tool.ContextRoles
+  alias Oli.Delivery.Sections
+
+  defp live_view_quiz_scores_route(section_slug, params \\ %{}) do
+    Routes.live_path(
+      OliWeb.Endpoint,
+      OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive,
+      section_slug,
+      :quiz_scores,
+      params
+    )
+  end
+
+  defp insert_resource_access(page1, page3, page5, section, user1, user2) do
+    # Page 1
+    insert(:resource_access,
+      user: user1,
+      section: section,
+      resource: page1.resource,
+      score: 5,
+      out_of: 10
+    )
+
+    insert(:resource_access,
+      user: user2,
+      section: section,
+      resource: page1.resource,
+      score: 3,
+      out_of: 10
+    )
+
+    # Page 3
+    insert(:resource_access,
+      user: user1,
+      section: section,
+      resource: page3.resource,
+      score: 7,
+      out_of: 10
+    )
+
+    insert(:resource_access,
+      user: user2,
+      section: section,
+      resource: page3.resource,
+      score: 6,
+      out_of: 10
+    )
+
+    # Page 5
+    insert(:resource_access,
+      user: user1,
+      section: section,
+      resource: page5.resource,
+      score: 9,
+      out_of: 10
+    )
+
+    insert(:resource_access,
+      user: user2,
+      section: section,
+      resource: page5.resource,
+      score: 10,
+      out_of: 10
+    )
+  end
+
+  describe "user" do
+    test "cannot access page when it is not logged in", %{conn: conn} do
+      section = insert(:section)
+
+      redirect_path =
+        "/session/new?request_path=%2Fsections%2F#{section.slug}%2Finstructor_dashboard%2Fquiz_scores"
+
+      assert {:error, {:redirect, %{to: ^redirect_path}}} =
+               live(conn, live_view_quiz_scores_route(section.slug))
+    end
+  end
+
+  describe "student" do
+    setup [:user_conn]
+
+    test "cannot access page", %{user: user, conn: conn} do
+      section = insert(:section)
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+
+      redirect_path = "/unauthorized"
+
+      assert {:error, {:redirect, %{to: ^redirect_path}}} =
+               live(conn, live_view_quiz_scores_route(section.slug))
+    end
+  end
+
+  describe "instructor" do
+    setup [:instructor_conn, :section_with_assessment]
+
+    test "cannot access page if not enrolled to section", %{conn: conn, section: section} do
+      redirect_path = "/unauthorized"
+
+      assert {:error, {:redirect, %{to: ^redirect_path}}} =
+               live(conn, live_view_quiz_scores_route(section.slug))
+    end
+
+    test "can access page if enrolled to section", %{
+      instructor: instructor,
+      section: section,
+      conn: conn
+    } do
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+      {:ok, view, _html} = live(conn, live_view_quiz_scores_route(section.slug))
+
+      # QuizScores tab is the selected one
+      assert has_element?(
+               view,
+               ~s{a[href="#{live_view_quiz_scores_route(section.slug)}"].border-b-2},
+               "Quiz Scores"
+             )
+
+      # QuizScores tab content gets rendered
+      assert has_element?(view, "h6", "There are no quiz scores to show")
+    end
+  end
+
+  describe "quiz scores" do
+    setup [:instructor_conn, :section_with_gating_conditions]
+
+    test "loads correctly when there are no quiz scores", %{
+      conn: conn,
+      instructor: instructor
+    } do
+      {:ok,
+       section: section, unit_one_revision: _unit_one_revision, page_revision: _page_revision} =
+        section_with_assessment(nil)
+
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+      {:ok, view, _html} = live(conn, live_view_quiz_scores_route(section.slug))
+
+      assert has_element?(view, "h6", "There are no quiz scores to show")
+    end
+
+    test "applies searching", %{
+      conn: conn,
+      section: section,
+      instructor: instructor,
+      student_with_gating_condition: student_with_gating_condition,
+      student_with_gating_condition_2: student_with_gating_condition_2,
+      graded_page_1: graded_page_1,
+      graded_page_3: graded_page_3,
+      graded_page_5: graded_page_5
+    } do
+      insert_resource_access(
+        graded_page_1,
+        graded_page_3,
+        graded_page_5,
+        section,
+        student_with_gating_condition,
+        student_with_gating_condition_2
+      )
+
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+      {:ok, view, _html} = live(conn, live_view_quiz_scores_route(section.slug))
+
+      assert has_element?(
+               view,
+               "div",
+               "#{student_with_gating_condition.family_name}, #{student_with_gating_condition.given_name}"
+             )
+
+      assert has_element?(
+               view,
+               "div",
+               "#{student_with_gating_condition_2.family_name}, #{student_with_gating_condition_2.given_name}"
+             )
+
+      # searching by student
+      params = %{
+        text_search: student_with_gating_condition.given_name
+      }
+
+      {:ok, view, _html} = live(conn, live_view_quiz_scores_route(section.slug, params))
+
+      assert has_element?(
+               view,
+               "div",
+               "#{student_with_gating_condition.family_name}, #{student_with_gating_condition.given_name}"
+             )
+
+      refute has_element?(
+               view,
+               "div",
+               "#{student_with_gating_condition_2.family_name}, #{student_with_gating_condition_2.given_name}"
+             )
+    end
+
+    test "applies sorting", %{
+      conn: conn,
+      instructor: instructor,
+      section: section,
+      student_with_gating_condition: student_with_gating_condition,
+      student_with_gating_condition_2: student_with_gating_condition_2,
+      graded_page_1: graded_page_1,
+      graded_page_3: graded_page_3,
+      graded_page_5: graded_page_5
+    } do
+      insert_resource_access(
+        graded_page_1,
+        graded_page_3,
+        graded_page_5,
+        section,
+        student_with_gating_condition,
+        student_with_gating_condition_2
+      )
+
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+      {:ok, view, _html} = live(conn, live_view_quiz_scores_route(section.slug))
+
+      assert view
+             |> element("table.instructor_dashboard_table > tbody > tr:first-child")
+             |> render() =~ student_with_gating_condition.family_name
+
+      assert view
+             |> element("table.instructor_dashboard_table > tbody > tr:nth-child(2)")
+             |> render() =~ student_with_gating_condition_2.family_name
+
+      ## sorting by student
+      params = %{
+        sort_order: :desc
+      }
+
+      {:ok, view, _html} = live(conn, live_view_quiz_scores_route(section.slug, params))
+
+      assert view
+             |> element("table.instructor_dashboard_table > tbody > tr:first-child")
+             |> render() =~ student_with_gating_condition_2.family_name
+
+      assert view
+             |> element("table.instructor_dashboard_table > tbody > tr:nth-child(2)")
+             |> render() =~ student_with_gating_condition.family_name
+    end
+
+    test "applies pagination", %{
+      conn: conn,
+      instructor: instructor,
+      section: section,
+      student_with_gating_condition: student_with_gating_condition,
+      student_with_gating_condition_2: student_with_gating_condition_2,
+      graded_page_1: graded_page_1,
+      graded_page_3: graded_page_3,
+      graded_page_5: graded_page_5
+    } do
+      insert_resource_access(
+        graded_page_1,
+        graded_page_3,
+        graded_page_5,
+        section,
+        student_with_gating_condition,
+        student_with_gating_condition_2
+      )
+
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+      {:ok, view, _html} = live(conn, live_view_quiz_scores_route(section.slug))
+
+      assert has_element?(
+               view,
+               "div",
+               "#{student_with_gating_condition.family_name}, #{student_with_gating_condition.given_name}"
+             )
+
+      assert has_element?(
+               view,
+               "div",
+               "#{student_with_gating_condition_2.family_name}, #{student_with_gating_condition_2.given_name}"
+             )
+
+      ## aplies limit
+      params = %{
+        limit: 1,
+        sort_order: "asc"
+      }
+
+      {:ok, view, _html} = live(conn, live_view_quiz_scores_route(section.slug, params))
+
+      assert has_element?(
+               view,
+               "div",
+               "#{student_with_gating_condition.family_name}, #{student_with_gating_condition.given_name}"
+             )
+
+      refute has_element?(
+               view,
+               "div",
+               "#{student_with_gating_condition_2.family_name}, #{student_with_gating_condition_2.given_name}"
+             )
+
+      ## aplies pagination
+      params = %{
+        offset: 1
+      }
+
+      {:ok, view, _html} = live(conn, live_view_quiz_scores_route(section.slug, params))
+
+      refute has_element?(
+               view,
+               "div",
+               "#{student_with_gating_condition.family_name}, #{student_with_gating_condition.given_name}"
+             )
+
+      assert has_element?(
+               view,
+               "div",
+               "#{student_with_gating_condition_2.family_name}, #{student_with_gating_condition_2.given_name}"
+             )
+    end
+  end
+end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -1082,7 +1082,8 @@ defmodule Oli.TestHelpers do
   def section_with_gating_conditions(_context) do
     author = insert(:author)
     project = insert(:project, authors: [author])
-    student = insert(:user)
+    student = insert(:user, %{family_name: "Example", given_name: "Student1"})
+    student_2 = insert(:user, %{family_name: "Example", given_name: "Student2"})
 
     # Create graded pages
     graded_page_1_resource = insert(:resource)
@@ -1262,6 +1263,7 @@ defmodule Oli.TestHelpers do
     {:ok, section} = Sections.create_section_resources(section, publication)
 
     enroll_user_to_section(student, section, :context_learner)
+    enroll_user_to_section(student_2, section, :context_learner)
 
     insert(:gating_condition, %{
       section: section,
@@ -1295,6 +1297,22 @@ defmodule Oli.TestHelpers do
       data: %GatingConditionData{end_datetime: nil}
     })
 
+    insert(:gating_condition, %{
+      section: section,
+      resource: graded_page_5_resource,
+      type: :schedule,
+      user: student_2,
+      data: %GatingConditionData{end_datetime: ~U[2023-07-08 14:00:00Z]}
+    })
+
+    insert(:gating_condition, %{
+      section: section,
+      resource: graded_page_6_resource,
+      type: :always_open,
+      user: student_2,
+      data: %GatingConditionData{end_datetime: nil}
+    })
+
     %{
       section: section,
       graded_page_1: graded_page_1_revision,
@@ -1303,7 +1321,8 @@ defmodule Oli.TestHelpers do
       graded_page_4: graded_page_4_revision,
       graded_page_5: graded_page_5_revision,
       graded_page_6: graded_page_6_revision,
-      student_with_gating_condition: student
+      student_with_gating_condition: student,
+      student_with_gating_condition_2: student_2
     }
   end
 


### PR DESCRIPTION
[MER-1807](https://eliterate.atlassian.net/browse/MER-1807)

This PR adds a list of student quiz scores contained in a course section, within the "Quiz Scores" tab.

Here are listed the student scores obtained in each of the quizzes.

When a student scores less than 50% on any of their quizzes their entry is highlighted in the table.

The Gradebook view is also modified so that it uses the component developed for this tab and respects the same design.

![Captura de pantalla 2023-04-18 a la(s) 11 50 01](https://user-images.githubusercontent.com/16328384/232815148-82886b73-9eed-4923-9fa2-87637eca9683.png)

![Captura de pantalla 2023-04-18 a la(s) 11 51 38](https://user-images.githubusercontent.com/16328384/232815867-72ff3221-a157-4955-a070-ce932143b52a.png)

[MER-1807]: https://eliterate.atlassian.net/browse/MER-1807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ