### PR TITLE
[ENHANCEMENT] support optional background color for ordering choices [MER-1803]

### DIFF
--- a/assets/src/components/activities/common/choices/authoring/ChoicesAuthoring.tsx
+++ b/assets/src/components/activities/common/choices/authoring/ChoicesAuthoring.tsx
@@ -8,6 +8,7 @@ import { RichTextEditorConnected } from 'components/content/RichTextEditor';
 import { toSimpleText } from 'components/editing/slateUtils';
 import { classNames } from 'utils/classNames';
 import styles from './ChoicesAuthoring.modules.scss';
+import { cpuUsage } from 'process';
 
 const renderChoiceIcon = (icon: any, choice: any, index: any) =>
   icon ? (
@@ -26,6 +27,7 @@ interface Props {
   onEdit: (id: string, content: Descendant[]) => void;
   onRemove: (id: string) => void;
   simpleText?: boolean;
+  colorMap?: Map<string, string>;
 }
 export const Choices: React.FC<Props> = ({
   icon,
@@ -35,13 +37,20 @@ export const Choices: React.FC<Props> = ({
   onEdit,
   onRemove,
   simpleText,
+  colorMap,
 }) => {
   return (
     <>
       <Draggable.Column items={choices} setItems={setAll}>
         {choices.map((choice) => (
-          <Draggable.Item key={choice.id} id={choice.id} className="mb-4" item={choice}>
-            {(_choice, index) => (
+          <Draggable.Item
+            key={choice.id}
+            id={choice.id}
+            className="mb-4"
+            item={choice}
+            color={colorMap?.get(choice.id)}
+          >
+            {(choice, index) => (
               <>
                 <Draggable.DragIndicator />
                 {renderChoiceIcon(icon, choice, index)}
@@ -54,7 +63,11 @@ export const Choices: React.FC<Props> = ({
                   />
                 ) : (
                   <RichTextEditorConnected
-                    style={{ flexGrow: 1, cursor: 'text' }}
+                    style={{
+                      flexGrow: 1,
+                      cursor: 'text',
+                      backgroundColor: colorMap?.get(choice.id),
+                    }}
                     placeholder="Answer choice"
                     value={choice.content}
                     onEdit={(content) => onEdit(choice.id, content)}

--- a/assets/src/components/activities/ordering/OrderingAuthoring.tsx
+++ b/assets/src/components/activities/ordering/OrderingAuthoring.tsx
@@ -48,6 +48,7 @@ export const Ordering: React.FC = () => {
           setAll={(choices: ActivityTypes.Choice[]) => dispatch(Choices.setAll(choices))}
           onEdit={(id, content) => dispatch(Choices.setContent(id, content))}
           onRemove={(id) => dispatch(Actions.removeChoiceAndUpdateRules(id))}
+          colorMap={model.choiceColors ? new Map(model.choiceColors) : undefined}
         />
       </TabbedNavigation.Tab>
 
@@ -57,6 +58,7 @@ export const Ordering: React.FC = () => {
         <ResponseChoices
           writerContext={writerContext}
           choices={getCorrectChoiceIds(model).map((id) => choices[id])}
+          colorMap={model.choiceColors ? new Map(model.choiceColors) : undefined}
           setChoices={(choices) => dispatch(Actions.setCorrectChoices(choices))}
         />
         <SimpleFeedback partId={model.authoring.parts[0].id} />

--- a/assets/src/components/activities/ordering/OrderingDelivery.tsx
+++ b/assets/src/components/activities/ordering/OrderingDelivery.tsx
@@ -119,6 +119,7 @@ export const OrderingComponent: React.FC = () => {
         <ResponseChoices
           writerContext={writerContext}
           choices={choices}
+          colorMap={model.choiceColors ? new Map(model.choiceColors) : undefined}
           setChoices={(choices) => onSelectionChange(choices.map((c) => c.id))}
           disabled={isEvaluated(uiState) || isSubmitted(uiState)}
         />

--- a/assets/src/components/activities/ordering/sections/ResponseChoices.tsx
+++ b/assets/src/components/activities/ordering/sections/ResponseChoices.tsx
@@ -6,12 +6,14 @@ import { HtmlContentModelRenderer } from 'data/content/writers/renderer';
 
 interface Props {
   choices: Choice[];
+  colorMap?: Map<string, string>;
   disabled?: boolean;
   writerContext: WriterContext;
   setChoices: (choices: Choice[]) => void;
 }
 export const ResponseChoices: React.FC<Props> = ({
   choices,
+  colorMap,
   setChoices,
   disabled,
   writerContext: { projectSlug },
@@ -25,8 +27,9 @@ export const ResponseChoices: React.FC<Props> = ({
           key={choice.id}
           id={choice.id}
           item={choice}
+          color={colorMap?.get(choice.id)}
         >
-          {(_choice, index) => (
+          {(choice, index) => (
             <>
               <Draggable.DragIndicator isDragDisabled={disabled ?? false} />
               <div style={{ marginRight: '0.5rem' }}>{index + 1}.</div>

--- a/assets/src/components/activities/ordering/transformations/v2.ts
+++ b/assets/src/components/activities/ordering/transformations/v2.ts
@@ -22,6 +22,7 @@ import { matchInOrderRule, matchRule } from 'data/activities/model/rules';
 export interface OrderingSchemaV2 extends ActivityModelSchema {
   stem: Stem;
   choices: Choice[];
+  choiceColors?: Array<[string, string]>;
   authoring: {
     version: 2;
     // An association list of the choice ids in the correct order to the matching response id

--- a/assets/src/components/common/DraggableColumn.tsx
+++ b/assets/src/components/common/DraggableColumn.tsx
@@ -34,6 +34,7 @@ interface ItemProps {
   items?: any[];
   index?: number;
   displayOutline?: boolean;
+  color?: string;
   isDragDisabled?: boolean;
 }
 const Item: React.FC<ItemProps> = ({
@@ -46,6 +47,7 @@ const Item: React.FC<ItemProps> = ({
   setItems = () => undefined,
   children,
   displayOutline,
+  color,
   isDragDisabled,
 }) => {
   return (
@@ -60,7 +62,7 @@ const Item: React.FC<ItemProps> = ({
             styles.draggableColumnCard,
             displayOutline ? styles.draggableColumnOutlined : null,
           )}
-          style={getStyle(provided.draggableProps.style, snapshot)}
+          style={{ ...getStyle(provided.draggableProps.style, snapshot), backgroundColor: color }}
           aria-label={itemAriaLabel || 'Item ' + index}
           onKeyDown={(e: any) => reorderByKey(e, index, items, item, setItems)}
         >


### PR DESCRIPTION
This provides support for custom background colors on choices in ordering questions, allowed in legacy OLI and used by language courses. Adds an optional "choiceColors" attribute to the ordering question model containing a mapping serialized as an array of [choiceID, colorName] pairs. Required adding optional background color prop to the Draggable.Item component which wraps the choices in order to fill the relevant background. 

Authoring of colors not supported yet. This allows ingestion and presentation of ordering questions with custom colors.