### PR TITLE
[BUGFIX] hotspot error if questions use same choice IDs [MER-1905]

### DIFF
--- a/assets/src/components/activities/image_hotspot/ImageHotspotDelivery.tsx
+++ b/assets/src/components/activities/image_hotspot/ImageHotspotDelivery.tsx
@@ -26,6 +26,7 @@ import { castPartId } from '../common/utils';
 import * as ActivityTypes from '../types';
 import { Hotspot, ImageHotspotModelSchema, getShape } from './schema';
 import { HS_COLOR, drawHotspotShape } from './utils';
+import guid from 'utils/guid';
 
 const ImageHotspotComponent: React.FC = () => {
   const {
@@ -110,7 +111,7 @@ const ImageHotspotComponent: React.FC = () => {
     }
   };
 
-  const mapName = 'map' + model.choices[0].id;
+  const mapName = 'map' + guid();
 
   return (
     <div className="activity multiple-choice-activity">


### PR DESCRIPTION
Image hotspot generated an ID for the image’s associated map element based on the id of the first choice in the question. However choice IDs do not have to be globally unique. Ran into a case in an ingested course of multiple questions using same image/hotspots, apparently copied and pasted, leading to bad behavior on delivery (mousing over any of the images always highlighted the first one.) This changes to use a guid.