### PR TITLE
[Bugfix] Advanced author crash on startup.

### DIFF
--- a/assets/src/apps/authoring/store/app/slice.ts
+++ b/assets/src/apps/authoring/store/app/slice.ts
@@ -9,7 +9,6 @@ import {
 } from 'apps/delivery/store/features/attempt/actions/savePart';
 import { Objective } from '../../../../data/content/objective';
 import { RightPanelTabs } from '../../components/RightMenu/RightMenu';
-import { saveActivity } from '../activities/actions/saveActivity';
 import { savePage } from '../page/actions/savePage';
 import { AuthoringRootState } from '../rootReducer';
 import { acquireEditingLock } from './actions/locking';
@@ -191,11 +190,12 @@ const slice: Slice<AppState> = createSlice({
     builder.addCase(savePage.rejected, (state) => {
       state.hasEditingLock = false;
     });
-    if (saveActivity?.rejected) {
-      builder.addCase(saveActivity.rejected, (state) => {
-        state.hasEditingLock = false;
-      });
-    }
+
+    // TODO: This is a hack to get the saveActivity.rejected action to work around a circular dependency
+    builder.addCase(/*saveActivity.rejected*/ 'activities/saveActivity/rejected', (state) => {
+      state.hasEditingLock = false;
+    });
+
     builder.addCase(savePartState.rejected, (state) => {
       state.hasEditingLock = false;
     });


### PR DESCRIPTION
Bug: Launch advanced authoring.
Expected: It launches
Actual: It crashes with this in the console:

```
Uncaught ReferenceError: Cannot access 'saveActivity' before initialization
    at Module.saveActivity (rules.ts:100:12)
    at extraReducers (slice.ts:196:21)
    at executeReducerBuilderCallback (redux-toolkit.esm.js:554:1)
    at createSlice (redux-toolkit.esm.js:618:1)
    at ./src/apps/authoring/store/app/slice.ts (slice.ts:115:43)
    at __webpack_require__ (bootstrap:19:1)
    at ./src/apps/authoring/store/activities/actions/saveActivity.ts (rules.ts:100:12)
    at __webpack_require__ (bootstrap:19:1)
    at ./src/apps/authoring/BottomPanel.tsx (AuthoringFlowchartPageEditor.tsx:77:21)
    at __webpack_require__ (bootstrap:19:1)
```

I'm unsure of the exact cause here, it looks like an odd circular-import causing saveActivity to not be initialized in time. This is a quick fix to get around the problem.
