### PR TITLE
[FEATURE] [MER-1808] Quiz scores tab for student dashboard

### DIFF
--- a/assets/css/table.css
+++ b/assets/css/table.css
@@ -51,3 +51,7 @@
 .instructor_dashboard_table tr:has(div[data-score-check='false']) {
   @apply bg-red-200 bg-opacity-20;
 }
+
+.instructor_dashboard_table tr:has(a[data-score-check='false']) {
+  @apply bg-red-200 bg-opacity-20;
+}

--- a/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
@@ -84,7 +84,9 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive do
         module={OliWeb.Components.Delivery.QuizScores}
         params={@params}
         section={@section}
-        patch_url_type={:quiz_scores}
+        patch_url_type={:quiz_scores_instructor}
+        student_id={nil}
+        scores={nil}
       />
     """
   end

--- a/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
@@ -85,8 +85,6 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive do
         params={@params}
         section={@section}
         patch_url_type={:quiz_scores_instructor}
-        student_id={nil}
-        scores={nil}
       />
     """
   end

--- a/lib/oli_web/live/delivery/student_dashboard/components/helpers.ex
+++ b/lib/oli_web/live/delivery/student_dashboard/components/helpers.ex
@@ -74,7 +74,7 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.Helpers do
           <%= for {label, href, badge, active} <- [
             {"Content", path_for(:content, @section_slug, @student_id, @preview_mode), nil, is_active_tab?(:content, @active_tab)},
             {"Learning Objectives", path_for(:learning_objectives, @section_slug, @student_id, @preview_mode), nil, is_active_tab?(:learning_objectives, @active_tab)},
-            {"Quizz Scores", path_for(:quizz_scores, @section_slug, @student_id, @preview_mode), nil, is_active_tab?(:quizz_scores, @active_tab)},
+            {"Quiz Scores", path_for(:quizz_scores, @section_slug, @student_id, @preview_mode), nil, is_active_tab?(:quizz_scores, @active_tab)},
             {"Progress", path_for(:progress, @section_slug, @student_id, @preview_mode), nil, is_active_tab?(:progress, @active_tab)},
           ] do %>
             <li class="nav-item" role="presentation">

--- a/lib/oli_web/live/delivery/student_dashboard/components/quizz_scores_tab.ex
+++ b/lib/oli_web/live/delivery/student_dashboard/components/quizz_scores_tab.ex
@@ -3,7 +3,17 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.QuizzScoresTab do
 
   def render(assigns) do
     ~H"""
-    <p class="container mx-auto">Not available yet</p>
+      <div>
+        <.live_component
+          id="quiz_scores_table"
+          module={OliWeb.Components.Delivery.QuizScores}
+          params={@params}
+          section={@section}
+          patch_url_type={:quiz_scores_student}
+          student_id={@student_id}
+          scores={@scores}
+        />
+      </div>
     """
   end
 end

--- a/lib/oli_web/live/grades/gradebook_table_model.ex
+++ b/lib/oli_web/live/grades/gradebook_table_model.ex
@@ -53,6 +53,54 @@ defmodule OliWeb.Grades.GradebookTableModel do
     )
   end
 
+  def new(graded_pages, section_slug, student_id) do
+    column_specs = [
+      %ColumnSpec{
+        name: :name,
+        label: "Quiz",
+        render_fn: &__MODULE__.render_grade/3,
+        th_class: "pl-10 instructor_dashboard_th"
+      },
+      %ColumnSpec{
+        name: :score,
+        label: "Score",
+        render_fn: &__MODULE__.render_grade_score/3,
+        th_class: "pl-10 instructor_dashboard_th",
+        sortable: false
+      }
+    ]
+
+    SortableTableModel.new(
+      rows: graded_pages,
+      column_specs: column_specs,
+      event_suffix: "",
+      id_field: [:id],
+      data: %{section_slug: section_slug, student_id: student_id}
+    )
+  end
+
+  def render_grade(assigns, row, _) do
+    ~F"""
+      <div class="ml-8">
+        {row.label}
+      </div>
+    """
+  end
+
+  def render_grade_score(assigns, row, _) do
+    perc = row.score / row.out_of * 100
+
+    ~F"""
+      <a
+        class={"ml-8 #{if perc < 40, do: "text-red-500", else: "text-black"}"}
+        data-score-check={if perc < 40, do: "false", else: "true"}
+        href={Routes.live_path(OliWeb.Endpoint, OliWeb.Progress.StudentResourceView, assigns.section_slug, assigns.student_id, row.resource_id)}
+      >
+          {row.score}/{row.out_of}
+      </a>
+    """
+  end
+
   def render_student(assigns, row, _) do
     resource_accesses_approved =
       Map.values(row)

--- a/lib/oli_web/live/grades/gradebook_view.ex
+++ b/lib/oli_web/live/grades/gradebook_view.ex
@@ -55,7 +55,9 @@ defmodule OliWeb.Grades.GradebookView do
         id: "quiz_scores_table",
         section: assigns.section,
         params: assigns.params,
-        patch_url_type: :gradebook_view
+        patch_url_type: :gradebook_view,
+        student_id: nil,
+        scores: nil
       }
     """
   end

--- a/lib/oli_web/live/grades/gradebook_view.ex
+++ b/lib/oli_web/live/grades/gradebook_view.ex
@@ -55,9 +55,7 @@ defmodule OliWeb.Grades.GradebookView do
         id: "quiz_scores_table",
         section: assigns.section,
         params: assigns.params,
-        patch_url_type: :gradebook_view,
-        student_id: nil,
-        scores: nil
+        patch_url_type: :gradebook_view
       }
     """
   end

--- a/test/oli_web/live/delivery/student_dashboard/components/quizz_scores_tab_test.exs
+++ b/test/oli_web/live/delivery/student_dashboard/components/quizz_scores_tab_test.exs
@@ -11,7 +11,7 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.QuizzScoresTabTest do
   defp live_view_students_dashboard_route(
          section_slug,
          student_id,
-         tab,
+         :quizz_scores,
          params \\ %{}
        ) do
     Routes.live_path(
@@ -19,26 +19,125 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.QuizzScoresTabTest do
       OliWeb.Delivery.StudentDashboard.StudentDashboardLive,
       section_slug,
       student_id,
-      tab,
+      :quizz_scores,
       params
     )
   end
 
-  defp enrolled_student_and_instructor(%{section: section, instructor: instructor}) do
-    student = insert(:user)
-    Sections.enroll(student.id, section.id, [ContextRoles.get_role(:context_learner)])
-    Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
-    %{student: student}
+  defp insert_resource_access(page1, page3, page5, section, user1) do
+    # Page 1
+    insert(:resource_access,
+      user: user1,
+      section: section,
+      resource: page1.resource,
+      score: 5,
+      out_of: 10
+    )
+
+    # Page 3
+    insert(:resource_access,
+      user: user1,
+      section: section,
+      resource: page3.resource,
+      score: 7,
+      out_of: 10
+    )
+
+    # Page 5
+    insert(:resource_access,
+      user: user1,
+      section: section,
+      resource: page5.resource,
+      score: 2,
+      out_of: 10
+    )
+  end
+
+  describe "user" do
+    test "cannot access page when it is not logged in", %{conn: conn} do
+      section = insert(:section)
+      student = insert(:user)
+
+      redirect_path =
+        "/session/new?request_path=%2Fsections%2F#{section.slug}%2Fstudent_dashboard%2F#{student.id}%2Fquizz_scores"
+
+      assert {:error, {:redirect, %{to: ^redirect_path}}} =
+               live(
+                 conn,
+                 live_view_students_dashboard_route(section.slug, student.id, :quizz_scores)
+               )
+    end
+  end
+
+  describe "student" do
+    setup [:user_conn]
+
+    test "cannot access page", %{user: user, conn: conn} do
+      section = insert(:section)
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+
+      redirect_path = "/unauthorized"
+
+      assert {:error, {:redirect, %{to: ^redirect_path}}} =
+               live(
+                 conn,
+                 live_view_students_dashboard_route(section.slug, user.id, :quizz_scores)
+               )
+    end
+  end
+
+  describe "instructor" do
+    setup [:instructor_conn, :section_with_assessment]
+
+    test "cannot access page if not enrolled to section", %{conn: conn, section: section} do
+      student = insert(:user)
+      redirect_path = "/unauthorized"
+
+      assert {:error, {:redirect, %{to: ^redirect_path}}} =
+               live(
+                 conn,
+                 live_view_students_dashboard_route(section.slug, student.id, :quizz_scores)
+               )
+    end
+
+    test "can access page if enrolled to section", %{
+      instructor: instructor,
+      section: section,
+      conn: conn
+    } do
+      student = insert(:user)
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+
+      {:ok, view, _html} =
+        live(conn, live_view_students_dashboard_route(section.slug, student.id, :quizz_scores))
+
+      # QuizScores tab is the selected one
+      assert has_element?(
+               view,
+               ~s{a[href="#{live_view_students_dashboard_route(section.slug, student.id, :quizz_scores)}"].border-b-2},
+               "Quiz Scores"
+             )
+
+      # QuizScores tab content gets rendered
+      assert has_element?(view, "h6", "There are no quiz scores to show")
+    end
   end
 
   describe "Quizz Scores tab" do
-    setup [:instructor_conn, :section_with_assessment, :enrolled_student_and_instructor]
+    setup [:instructor_conn, :section_with_gating_conditions]
 
     test "gets rendered correctly", %{
-      section: section,
       conn: conn,
-      student: student
+      instructor: instructor
     } do
+      student = insert(:user)
+
+      {:ok,
+       section: section, unit_one_revision: _unit_one_revision, page_revision: _page_revision} =
+        section_with_assessment(nil)
+
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+
       {:ok, view, _html} =
         live(conn, live_view_students_dashboard_route(section.slug, student.id, :quizz_scores))
 
@@ -46,10 +145,280 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.QuizzScoresTabTest do
       assert has_element?(
                view,
                ~s{a[href="#{live_view_students_dashboard_route(section.slug, student.id, :quizz_scores)}"].border-b-2},
-               "Quizz Scores"
+               "Quiz Scores"
              )
 
-      assert has_element?(view, "p", "Not available yet")
+      assert has_element?(view, "h6", "There are no quiz scores to show")
+    end
+
+    test "applies searching", %{
+      conn: conn,
+      section: section,
+      instructor: instructor,
+      student_with_gating_condition: student_with_gating_condition,
+      graded_page_1: graded_page_1,
+      graded_page_3: graded_page_3,
+      graded_page_5: graded_page_5
+    } do
+      insert_resource_access(
+        graded_page_1,
+        graded_page_3,
+        graded_page_5,
+        section,
+        student_with_gating_condition
+      )
+
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_students_dashboard_route(
+            section.slug,
+            student_with_gating_condition.id,
+            :quizz_scores
+          )
+        )
+
+      assert has_element?(
+               view,
+               "div",
+               "#{graded_page_1.title}"
+             )
+
+      assert has_element?(
+               view,
+               "div",
+               "#{graded_page_3.title}"
+             )
+
+      assert has_element?(
+               view,
+               "div",
+               "#{graded_page_5.title}"
+             )
+
+      # searching by student
+      params = %{
+        text_search: graded_page_3.title
+      }
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_students_dashboard_route(
+            section.slug,
+            student_with_gating_condition.id,
+            :quizz_scores,
+            params
+          )
+        )
+
+      refute has_element?(
+               view,
+               "div",
+               "#{graded_page_1.title}"
+             )
+
+      assert has_element?(
+               view,
+               "div",
+               "#{graded_page_3.title}"
+             )
+
+      refute has_element?(
+               view,
+               "div",
+               "#{graded_page_5.title}"
+             )
+    end
+
+    test "applies sorting", %{
+      conn: conn,
+      instructor: instructor,
+      section: section,
+      student_with_gating_condition: student_with_gating_condition,
+      graded_page_1: graded_page_1,
+      graded_page_3: graded_page_3,
+      graded_page_5: graded_page_5
+    } do
+      insert_resource_access(
+        graded_page_1,
+        graded_page_3,
+        graded_page_5,
+        section,
+        student_with_gating_condition
+      )
+
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_students_dashboard_route(
+            section.slug,
+            student_with_gating_condition.id,
+            :quizz_scores
+          )
+        )
+
+      assert view
+             |> element("table.instructor_dashboard_table > tbody > tr:first-child")
+             |> render() =~ graded_page_1.title
+
+      assert view
+             |> element("table.instructor_dashboard_table > tbody > tr:nth-child(2)")
+             |> render() =~ graded_page_3.title
+
+      assert view
+             |> element("table.instructor_dashboard_table > tbody > tr:nth-child(3)")
+             |> render() =~ graded_page_5.title
+
+      ## sorting by student
+      params = %{
+        sort_order: :desc
+      }
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_students_dashboard_route(
+            section.slug,
+            student_with_gating_condition.id,
+            :quizz_scores,
+            params
+          )
+        )
+
+      assert view
+             |> element("table.instructor_dashboard_table > tbody > tr:first-child")
+             |> render() =~ graded_page_5.title
+
+      assert view
+             |> element("table.instructor_dashboard_table > tbody > tr:nth-child(2)")
+             |> render() =~ graded_page_3.title
+
+      assert view
+             |> element("table.instructor_dashboard_table > tbody > tr:nth-child(3)")
+             |> render() =~ graded_page_1.title
+    end
+
+    test "applies pagination", %{
+      conn: conn,
+      instructor: instructor,
+      section: section,
+      student_with_gating_condition: student_with_gating_condition,
+      graded_page_1: graded_page_1,
+      graded_page_3: graded_page_3,
+      graded_page_5: graded_page_5
+    } do
+      insert_resource_access(
+        graded_page_1,
+        graded_page_3,
+        graded_page_5,
+        section,
+        student_with_gating_condition
+      )
+
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_students_dashboard_route(
+            section.slug,
+            student_with_gating_condition.id,
+            :quizz_scores
+          )
+        )
+
+      assert has_element?(
+               view,
+               "div",
+               "#{graded_page_1.title}"
+             )
+
+      assert has_element?(
+               view,
+               "div",
+               "#{graded_page_3.title}"
+             )
+
+      assert has_element?(
+               view,
+               "div",
+               "#{graded_page_5.title}"
+             )
+
+      ## aplies limit
+      params = %{
+        limit: 1,
+        sort_order: "asc"
+      }
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_students_dashboard_route(
+            section.slug,
+            student_with_gating_condition.id,
+            :quizz_scores,
+            params
+          )
+        )
+
+      assert has_element?(
+               view,
+               "div",
+               "#{graded_page_1.title}"
+             )
+
+      refute has_element?(
+               view,
+               "div",
+               "#{graded_page_3.title}"
+             )
+
+      refute has_element?(
+               view,
+               "div",
+               "#{graded_page_5.title}"
+             )
+
+      ## aplies pagination
+      params = %{
+        limit: 1,
+        offset: 1
+      }
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_students_dashboard_route(
+            section.slug,
+            student_with_gating_condition.id,
+            :quizz_scores,
+            params
+          )
+        )
+
+      refute has_element?(
+               view,
+               "div",
+               "#{graded_page_1.title}"
+             )
+
+      assert has_element?(
+               view,
+               "div",
+               "#{graded_page_3.title}"
+             )
+
+      refute has_element?(
+               view,
+               "div",
+               "#{graded_page_5.title}"
+             )
     end
   end
 end


### PR DESCRIPTION
[MER-1808](https://eliterate.atlassian.net/browse/MER-1808)

This PR adds the list of quizzes with their respective scores for a given student to the quiz scores tab on the student's dashboard for the instructor.

This lists the scores obtained for the students in the quizzes they completed.

When a student scores less than 50% on any of their quizzes, their entry is highlighted in the table.

![Captura de pantalla 2023-04-24 a la(s) 13 02 32](https://user-images.githubusercontent.com/16328384/234052820-89aaa329-e926-412a-9631-dffb4c756148.png)

![Captura de pantalla 2023-04-24 a la(s) 13 01 48](https://user-images.githubusercontent.com/16328384/234052828-93a7e999-4cd7-4aa0-9524-8c7d1f749f7a.png)

[MER-1808]: https://eliterate.atlassian.net/browse/MER-1808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ