### PR TITLE
[FEATURE] [MER-1725] Student progress details tab

### DIFF
--- a/lib/oli_web/components/delivery/progress/progress.ex
+++ b/lib/oli_web/components/delivery/progress/progress.ex
@@ -1,0 +1,211 @@
+defmodule OliWeb.Components.Delivery.Progress do
+  use Surface.LiveComponent
+
+  alias OliWeb.Common.{PagedTable, SearchInput, Params}
+  alias OliWeb.Components.Delivery.StudentProgressTabelModel
+  alias OliWeb.Router.Helpers, as: Routes
+  alias Phoenix.LiveView.JS
+
+  data title, :string, default: "Progress"
+  prop params, :map, required: true
+  prop total_count, :integer, required: true
+  prop table_model, :map, required: true
+
+  @default_params %{
+    offset: 0,
+    limit: 10,
+    sort_order: :asc,
+    sort_by: :title,
+    text_search: nil
+  }
+
+  def update(
+        %{
+          student_id: student_id,
+          section_slug: section_slug,
+          params: params,
+          context: context,
+          pages: pages
+        } = _assigns,
+        socket
+      ) do
+    params = decode_params(params)
+
+    {total_count, rows} = apply_filters(pages, params)
+
+    {:ok, table_model} =
+      StudentProgressTabelModel.new(
+        rows,
+        section_slug,
+        student_id,
+        context
+      )
+
+    table_model =
+      Map.merge(table_model, %{
+        rows: rows,
+        sort_order: params.sort_order,
+        sort_by_spec:
+          Enum.find(table_model.column_specs, fn col_spec ->
+            col_spec.name == params.sort_by
+          end)
+      })
+
+    {:ok,
+     assign(socket,
+       table_model: table_model,
+       total_count: total_count,
+       params: params,
+       section_slug: section_slug,
+       student_id: student_id
+     )}
+  end
+
+  def render(assigns) do
+    ~F"""
+      <div class="mx-10 mb-10 bg-white">
+        <div class="flex flex-col sm:flex-row sm:items-end px-6 py-4 border instructor_dashboard_table">
+          <h4 class="pl-9 !py-2 torus-h4 mr-auto">{@title}</h4>
+          <form for="search" phx-target={@myself} phx-change="search_progress" class="pb-6 ml-9 sm:pb-0">
+            <SearchInput.render id="progress_search_input" name="resource_title" text={@params.text_search} />
+          </form>
+        </div>
+
+        {#if @total_count > 0}
+          <div id="progress-table">
+            <PagedTable
+              table_model={@table_model}
+              page_change={JS.push("paged_table_page_change", target: @myself)}
+              sort={JS.push("paged_table_sort", target: @myself)}
+              total_count={@total_count}
+              offset={@params.offset}
+              limit={@params.limit}
+              additional_table_class="instructor_dashboard_table"
+              show_bottom_paging={false}
+              render_top_info={false}
+            />
+          </div>
+        {#else}
+          <h6 class="text-center py-4">There are no progress to show</h6>
+        {/if}
+      </div>
+    """
+  end
+
+  def handle_event("search_progress", %{"resource_title" => resource_title}, socket) do
+    {:noreply,
+     push_patch(socket,
+       to:
+         Routes.live_path(
+           socket,
+           OliWeb.Delivery.StudentDashboard.StudentDashboardLive,
+           socket.assigns.section_slug,
+           socket.assigns.student_id,
+           :progress,
+           update_params(socket.assigns.params, %{text_search: resource_title})
+         )
+     )}
+  end
+
+  def handle_event("paged_table_sort", %{"sort_by" => sort_by}, socket) do
+    {:noreply,
+     push_patch(socket,
+       to:
+         Routes.live_path(
+           socket,
+           OliWeb.Delivery.StudentDashboard.StudentDashboardLive,
+           socket.assigns.section_slug,
+           socket.assigns.student_id,
+           :progress,
+           update_params(socket.assigns.params, %{sort_by: String.to_existing_atom(sort_by)})
+         )
+     )}
+  end
+
+  def handle_event("paged_table_page_change", %{"limit" => limit, "offset" => offset}, socket) do
+    {:noreply,
+     push_patch(socket,
+       to:
+         Routes.live_path(
+           socket,
+           OliWeb.Delivery.StudentDashboard.StudentDashboardLive,
+           socket.assigns.section_slug,
+           socket.assigns.student_id,
+           :progress,
+           update_params(socket.assigns.params, %{limit: limit, offset: offset})
+         )
+     )}
+  end
+
+  defp decode_params(params) do
+    %{
+      offset: Params.get_int_param(params, "offset", @default_params.offset),
+      limit: Params.get_int_param(params, "limit", @default_params.limit),
+      sort_order:
+        Params.get_atom_param(params, "sort_order", [:asc, :desc], @default_params.sort_order),
+      sort_by:
+        Params.get_atom_param(
+          params,
+          "sort_by",
+          [:title, :type, :index],
+          @default_params.sort_by
+        ),
+      text_search: Params.get_param(params, "text_search", @default_params.text_search)
+    }
+  end
+
+  defp update_params(%{sort_by: current_sort_by, sort_order: current_sort_order} = params, %{
+         sort_by: new_sort_by
+       })
+       when current_sort_by == new_sort_by do
+    toggled_sort_order = if current_sort_order == :asc, do: :desc, else: :asc
+    update_params(params, %{sort_order: toggled_sort_order})
+  end
+
+  defp update_params(params, new_param) do
+    Map.merge(params, new_param)
+    |> purge_default_params()
+  end
+
+  defp purge_default_params(params) do
+    # there is no need to add a param to the url if its value is equal to the default one
+    Map.filter(params, fn {key, value} ->
+      @default_params[key] != value
+    end)
+  end
+
+  defp apply_filters(page_nodes, params) do
+    page_nodes =
+      page_nodes
+      |> maybe_filter_by_text(params.text_search)
+      |> sort_by(params.sort_by, params.sort_order)
+
+    {length(page_nodes), page_nodes |> Enum.drop(params.offset) |> Enum.take(params.limit)}
+  end
+
+  defp sort_by(page_nodes, sort_by, sort_order) do
+    case sort_by do
+      :title ->
+        Enum.sort_by(page_nodes, fn node -> node.title end, sort_order)
+
+      :type ->
+        Enum.sort_by(page_nodes, fn node -> node.type end, sort_order)
+
+      :index ->
+        Enum.sort_by(page_nodes, fn node -> node.index end, sort_order)
+
+      _ ->
+        Enum.sort_by(page_nodes, fn node -> node.title end, sort_order)
+    end
+  end
+
+  defp maybe_filter_by_text(page_nodes, nil), do: page_nodes
+  defp maybe_filter_by_text(page_nodes, ""), do: page_nodes
+
+  defp maybe_filter_by_text(page_nodes, text_search) do
+    page_nodes
+    |> Enum.filter(fn node ->
+      String.contains?(String.downcase(node.title), String.downcase(text_search))
+    end)
+  end
+end

--- a/lib/oli_web/components/delivery/progress/student_progress_table_model.ex
+++ b/lib/oli_web/components/delivery/progress/student_progress_table_model.ex
@@ -1,0 +1,113 @@
+defmodule OliWeb.Components.Delivery.StudentProgressTabelModel do
+  use Surface.LiveComponent
+  alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
+  alias OliWeb.Router.Helpers, as: Routes
+  alias OliWeb.Progress.ResourceTitle
+
+  @moduledoc """
+  This table model displays various pieces of "progress" information for all course resources in a
+  course section, for a specific student.
+
+  To construct this rows of this model, this implementation takes a flattened list of hierarchy nodes
+  and maps those to the specific row structure that is needed, pulling in information from a %ResourceAccess{}
+  struct.  A resource access record only exists though if that student has visited the resource at least
+  once.
+  """
+
+  @doc """
+  Takes a list of %HierarchyNode{}, a map of resource_ids to %ResourceAccess{} structs, and the
+  section and user to construct the table model.
+  """
+  def new(rows, section_slug, student_id, context) do
+    SortableTableModel.new(
+      rows: rows,
+      column_specs: [
+        %ColumnSpec{
+          name: :index,
+          label: "Order",
+          td_class: "text-center pl-0",
+          th_class: "!text-center"
+        },
+        %ColumnSpec{
+          name: :title,
+          label: "Resource Title",
+          render_fn: &__MODULE__.custom_render/3
+        },
+        %ColumnSpec{
+          name: :type,
+          label: "Type"
+        },
+        %ColumnSpec{
+          name: :score,
+          label: "Score",
+          render_fn: &__MODULE__.custom_render/3,
+          sortable: false,
+          td_class: "text-center",
+          th_class: "!text-center"
+        },
+        %ColumnSpec{
+          name: :number_attempts,
+          label: "# Attempts",
+          render_fn: &__MODULE__.custom_render/3,
+          sortable: false,
+          td_class: "text-center",
+          th_class: "!text-center"
+        },
+        %ColumnSpec{
+          name: :number_accesses,
+          label: "# Accesses",
+          render_fn: &__MODULE__.custom_render/3,
+          sortable: false,
+          td_class: "text-center",
+          th_class: "!text-center"
+        },
+        %ColumnSpec{
+          name: :inserted_at,
+          label: "First Visited",
+          render_fn: &OliWeb.Common.Table.Common.render_date/3,
+          sortable: false
+        },
+        %ColumnSpec{
+          name: :updated_at,
+          label: "Last Visited",
+          render_fn: &OliWeb.Common.Table.Common.render_date/3,
+          sortable: false
+        }
+      ],
+      event_suffix: "",
+      id_field: [:index],
+      data: %{
+        section_slug: section_slug,
+        user_id: student_id,
+        context: context
+      }
+    )
+  end
+
+  def custom_render(assigns, row, %ColumnSpec{name: :title}) do
+    ~F"""
+      <ResourceTitle
+        node={row.node}
+        url={Routes.live_path(OliWeb.Endpoint, OliWeb.Progress.StudentResourceView, assigns.section_slug, assigns.user_id, row.resource_id)}
+      />
+    """
+  end
+
+  def custom_render(_assigns, row, %ColumnSpec{name: :score}) do
+    if row.type == "Graded" and !is_nil(row.score), do: "#{row.score} / #{row.out_of}", else: ""
+  end
+
+  def custom_render(_assigns, row, %ColumnSpec{name: :number_accesses}) do
+    if row.number_accesses == 0, do: "", else: row.number_accesses
+  end
+
+  def custom_render(_assigns, row, %ColumnSpec{name: :number_attempts}) do
+    if row.number_attempts == 0, do: "", else: row.number_attempts
+  end
+
+  def render(assigns) do
+    ~F"""
+      <div>nothing</div>
+    """
+  end
+end

--- a/lib/oli_web/components/delivery/progress/student_progress_table_model.ex
+++ b/lib/oli_web/components/delivery/progress/student_progress_table_model.ex
@@ -3,21 +3,8 @@ defmodule OliWeb.Components.Delivery.StudentProgressTabelModel do
   alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
   alias OliWeb.Router.Helpers, as: Routes
   alias OliWeb.Progress.ResourceTitle
+  alias OliWeb.Common.Utils
 
-  @moduledoc """
-  This table model displays various pieces of "progress" information for all course resources in a
-  course section, for a specific student.
-
-  To construct this rows of this model, this implementation takes a flattened list of hierarchy nodes
-  and maps those to the specific row structure that is needed, pulling in information from a %ResourceAccess{}
-  struct.  A resource access record only exists though if that student has visited the resource at least
-  once.
-  """
-
-  @doc """
-  Takes a list of %HierarchyNode{}, a map of resource_ids to %ResourceAccess{} structs, and the
-  section and user to construct the table model.
-  """
   def new(rows, section_slug, student_id, context) do
     SortableTableModel.new(
       rows: rows,
@@ -64,13 +51,13 @@ defmodule OliWeb.Components.Delivery.StudentProgressTabelModel do
         %ColumnSpec{
           name: :inserted_at,
           label: "First Visited",
-          render_fn: &OliWeb.Common.Table.Common.render_date/3,
+          render_fn: &__MODULE__.custom_render_date/3,
           sortable: false
         },
         %ColumnSpec{
           name: :updated_at,
           label: "Last Visited",
-          render_fn: &OliWeb.Common.Table.Common.render_date/3,
+          render_fn: &__MODULE__.custom_render_date/3,
           sortable: false
         }
       ],
@@ -82,6 +69,10 @@ defmodule OliWeb.Components.Delivery.StudentProgressTabelModel do
         context: context
       }
     )
+  end
+
+  def custom_render_date(assigns, row, col_spec) do
+    Utils.render_relative_date(row, col_spec.name, Map.get(assigns, :context))
   end
 
   def custom_render(assigns, row, %ColumnSpec{name: :title}) do

--- a/lib/oli_web/live/delivery/student_dashboard/components/progress_tab.ex
+++ b/lib/oli_web/live/delivery/student_dashboard/components/progress_tab.ex
@@ -3,7 +3,17 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.ProgressTab do
 
   def render(assigns) do
     ~H"""
-    <p class="container mx-auto">Not available yet</p>
+      <div>
+        <.live_component
+          id="progress_table"
+          module={OliWeb.Components.Delivery.Progress}
+          params={@params}
+          section_slug={@section_slug}
+          student_id={@student_id}
+          context={@context}
+          pages={@pages}
+        />
+      </div>
     """
   end
 end

--- a/lib/oli_web/live/delivery/student_dashboard/student_dashboard_live.ex
+++ b/lib/oli_web/live/delivery/student_dashboard/student_dashboard_live.ex
@@ -1,6 +1,8 @@
 defmodule OliWeb.Delivery.StudentDashboard.StudentDashboardLive do
   use OliWeb, :live_view
 
+  import OliWeb.Common.Utils
+
   alias OliWeb.Delivery.StudentDashboard.Components.Helpers
   alias alias Oli.Delivery.Sections
   alias Oli.Delivery.Metrics
@@ -70,6 +72,18 @@ defmodule OliWeb.Delivery.StudentDashboard.StudentDashboardLive do
   end
 
   @impl Phoenix.LiveView
+  def handle_params(%{"active_tab" => "progress"} = params, _, socket) do
+    socket =
+      socket
+      |> assign(params: params, active_tab: String.to_existing_atom(params["active_tab"]))
+      |> assign_new(:pages, fn ->
+        get_page_nodes(socket.assigns.section.slug, socket.assigns.student.id)
+      end)
+
+    {:noreply, socket}
+  end
+
+  @impl Phoenix.LiveView
   def handle_params(params, _, socket) do
     {:noreply,
      assign(socket,
@@ -131,8 +145,13 @@ defmodule OliWeb.Delivery.StudentDashboard.StudentDashboardLive do
   defp render_tab(%{active_tab: :progress} = assigns) do
     ~H"""
       <.live_component
-      id="progress_tab"
-      module={OliWeb.Delivery.StudentDashboard.Components.ProgressTab}
+        id="progress_tab"
+        module={OliWeb.Delivery.StudentDashboard.Components.ProgressTab}
+        params={@params}
+        section_slug={@section.slug}
+        student_id={@student.id}
+        context={@context}
+        pages={@pages}
       />
     """
   end
@@ -221,5 +240,51 @@ defmodule OliWeb.Delivery.StudentDashboard.StudentDashboardLive do
     else
       []
     end
+  end
+
+  defp get_page_nodes(section_slug, student_id) do
+    resource_accesses =
+      Oli.Delivery.Attempts.Core.get_resource_accesses(
+        section_slug,
+        student_id
+      )
+      |> Enum.reduce(%{}, fn r, m ->
+        # limit score decimals to two significant figures, rounding up
+        r =
+          case r.score do
+            nil -> r
+            _ -> Map.put(r, :score, format_score(r.score))
+          end
+
+        Map.put(m, r.resource_id, r)
+      end)
+
+    hierarchy = Oli.Publishing.DeliveryResolver.full_hierarchy(section_slug)
+
+    page_nodes =
+      hierarchy
+      |> Oli.Delivery.Hierarchy.flatten()
+      |> Enum.filter(fn node ->
+        node.revision.resource_type_id ==
+          Oli.Resources.ResourceType.get_id_by_type("page")
+      end)
+
+    Enum.with_index(page_nodes, fn node, index ->
+      ra = Map.get(resource_accesses, node.revision.resource_id)
+
+      %{
+        resource_id: node.revision.resource_id,
+        node: node,
+        index: index,
+        title: node.revision.title,
+        type: if(node.revision.graded, do: "Graded", else: "Practice"),
+        score: if(is_nil(ra), do: nil, else: ra.score),
+        out_of: if(is_nil(ra), do: nil, else: ra.out_of),
+        number_attempts: if(is_nil(ra), do: 0, else: ra.resource_attempts_count),
+        number_accesses: if(is_nil(ra), do: 0, else: ra.access_count),
+        updated_at: if(is_nil(ra), do: nil, else: ra.updated_at),
+        inserted_at: if(is_nil(ra), do: nil, else: ra.inserted_at)
+      }
+    end)
   end
 end

--- a/test/oli_web/live/delivery/student_dashboard/components/progress_tab_test.exs
+++ b/test/oli_web/live/delivery/student_dashboard/components/progress_tab_test.exs
@@ -8,7 +8,7 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.ProgressTabTest do
   alias Lti_1p3.Tool.ContextRoles
   alias Oli.Delivery.Sections
 
-  defp live_view_students_dashboard_route(
+  defp live_view_students_progress_route(
          section_slug,
          student_id,
          tab,
@@ -31,25 +31,420 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.ProgressTabTest do
     %{student: student}
   end
 
-  describe "Progress tab" do
-    setup [:instructor_conn, :section_with_assessment, :enrolled_student_and_instructor]
-
-    test "gets rendered correctly", %{
+  defp insert_resource_access(page1, page3, page5, section, user1) do
+    # Page 1
+    insert(:resource_access,
+      user: user1,
       section: section,
+      resource: page1.resource,
+      score: 5,
+      out_of: 10
+    )
+
+    # Page 3
+    insert(:resource_access,
+      user: user1,
+      section: section,
+      resource: page3.resource,
+      score: 7,
+      out_of: 10
+    )
+
+    # Page 5
+    insert(:resource_access,
+      user: user1,
+      section: section,
+      resource: page5.resource,
+      score: 2,
+      out_of: 10
+    )
+  end
+
+  describe "user" do
+    test "cannot access page when it is not logged in", %{conn: conn} do
+      section = insert(:section)
+      student = insert(:user)
+
+      redirect_path =
+        "/session/new?request_path=%2Fsections%2F#{section.slug}%2Fstudent_dashboard%2F#{student.id}%2Fprogress"
+
+      assert {:error, {:redirect, %{to: ^redirect_path}}} =
+               live(
+                 conn,
+                 live_view_students_progress_route(section.slug, student.id, :progress)
+               )
+    end
+  end
+
+  describe "student" do
+    setup [:user_conn]
+
+    test "cannot access page", %{user: user, conn: conn} do
+      section = insert(:section)
+      redirect_path = "/unauthorized"
+
+      assert {:error, {:redirect, %{to: ^redirect_path}}} =
+               live(
+                 conn,
+                 live_view_students_progress_route(section.slug, user.id, :progress)
+               )
+    end
+  end
+
+  describe "instructor" do
+    setup [:instructor_conn, :section_without_pages]
+
+    test "cannot access page if not enrolled to section", %{
       conn: conn,
-      student: student
+      section: section
     } do
+      student = insert(:user)
+      redirect_path = "/unauthorized"
+
+      assert {:error, {:redirect, %{to: ^redirect_path}}} =
+               live(
+                 conn,
+                 live_view_students_progress_route(section.slug, student.id, :progress)
+               )
+    end
+
+    test "can access page if enrolled to section", %{
+      conn: conn,
+      section: section,
+      instructor: instructor
+    } do
+      student = insert(:user)
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+
       {:ok, view, _html} =
-        live(conn, live_view_students_dashboard_route(section.slug, student.id, :progress))
+        live(
+          conn,
+          live_view_students_progress_route(section.slug, student.id, :progress)
+        )
 
       # Progress tab is the selected one
       assert has_element?(
                view,
-               ~s{a[href="#{live_view_students_dashboard_route(section.slug, student.id, :progress)}"].border-b-2},
+               ~s{a[href="#{live_view_students_progress_route(section.slug, student.id, :progress)}"].border-b-2},
                "Progress"
              )
 
-      assert has_element?(view, "p", "Not available yet")
+      # Progress tab content gets rendered
+      assert has_element?(view, "h6", "There are no progress to show")
+    end
+  end
+
+  describe "Progress tab" do
+    setup [:instructor_conn, :section_with_gating_conditions, :enrolled_student_and_instructor]
+
+    test "gets rendered correctly", %{
+      section: section,
+      conn: conn,
+      student: student,
+      graded_page_1: graded_page_1,
+      graded_page_2: graded_page_2
+    } do
+      {:ok, view, _html} =
+        live(conn, live_view_students_progress_route(section.slug, student.id, :progress))
+
+      # Progress tab is the selected one
+      assert has_element?(
+               view,
+               ~s{a[href="#{live_view_students_progress_route(section.slug, student.id, :progress)}"].border-b-2},
+               "Progress"
+             )
+
+      assert has_element?(view, "a", graded_page_1.title)
+      assert has_element?(view, "a", graded_page_2.title)
+    end
+
+    test "applies searching", %{
+      conn: conn,
+      section: section,
+      student: student,
+      graded_page_1: graded_page_1,
+      graded_page_2: graded_page_2,
+      graded_page_3: graded_page_3
+    } do
+      insert_resource_access(
+        graded_page_1,
+        graded_page_2,
+        graded_page_3,
+        section,
+        student
+      )
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_students_progress_route(
+            section.slug,
+            student.id,
+            :progress
+          )
+        )
+
+      assert has_element?(
+               view,
+               "div",
+               "#{graded_page_1.title}"
+             )
+
+      assert has_element?(
+               view,
+               "div",
+               "#{graded_page_2.title}"
+             )
+
+      assert has_element?(
+               view,
+               "div",
+               "#{graded_page_3.title}"
+             )
+
+      # searching by student
+      params = %{
+        text_search: graded_page_2.title
+      }
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_students_progress_route(
+            section.slug,
+            student.id,
+            :progress,
+            params
+          )
+        )
+
+      refute has_element?(
+               view,
+               "div",
+               "#{graded_page_1.title}"
+             )
+
+      assert has_element?(
+               view,
+               "div",
+               "#{graded_page_2.title}"
+             )
+
+      refute has_element?(
+               view,
+               "div",
+               "#{graded_page_3.title}"
+             )
+    end
+
+    test "applies sorting", %{
+      conn: conn,
+      section: section,
+      student: student,
+      graded_page_1: graded_page_1,
+      graded_page_2: graded_page_2,
+      graded_page_3: graded_page_3,
+      graded_page_4: graded_page_4,
+      graded_page_5: graded_page_5,
+      graded_page_6: graded_page_6
+    } do
+      insert_resource_access(
+        graded_page_1,
+        graded_page_2,
+        graded_page_3,
+        section,
+        student
+      )
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_students_progress_route(
+            section.slug,
+            student.id,
+            :progress
+          )
+        )
+
+      assert view
+             |> element("table.instructor_dashboard_table > tbody > tr:first-child")
+             |> render() =~ graded_page_1.title
+
+      assert view
+             |> element("table.instructor_dashboard_table > tbody > tr:nth-child(2)")
+             |> render() =~ graded_page_2.title
+
+      assert view
+             |> element("table.instructor_dashboard_table > tbody > tr:nth-child(3)")
+             |> render() =~ graded_page_3.title
+
+      assert view
+             |> element("table.instructor_dashboard_table > tbody > tr:nth-child(4)")
+             |> render() =~ graded_page_4.title
+
+      assert view
+             |> element("table.instructor_dashboard_table > tbody > tr:nth-child(5)")
+             |> render() =~ graded_page_5.title
+
+      assert view
+             |> element("table.instructor_dashboard_table > tbody > tr:last-child")
+             |> render() =~ graded_page_6.title
+
+      ## sorting by student
+      params = %{
+        sort_order: :desc
+      }
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_students_progress_route(
+            section.slug,
+            student.id,
+            :progress,
+            params
+          )
+        )
+
+      assert view
+             |> element("table.instructor_dashboard_table > tbody > tr:last-child")
+             |> render() =~ graded_page_1.title
+
+      assert view
+             |> element("table.instructor_dashboard_table > tbody > tr:nth-child(5)")
+             |> render() =~ graded_page_2.title
+
+      assert view
+             |> element("table.instructor_dashboard_table > tbody > tr:nth-child(4)")
+             |> render() =~ graded_page_3.title
+
+      assert view
+             |> element("table.instructor_dashboard_table > tbody > tr:nth-child(3)")
+             |> render() =~ graded_page_4.title
+
+      assert view
+             |> element("table.instructor_dashboard_table > tbody > tr:nth-child(2)")
+             |> render() =~ graded_page_5.title
+
+      assert view
+             |> element("table.instructor_dashboard_table > tbody > tr:first-child")
+             |> render() =~ graded_page_6.title
+    end
+
+    test "applies pagination", %{
+      conn: conn,
+      section: section,
+      student: student,
+      graded_page_1: graded_page_1,
+      graded_page_2: graded_page_2,
+      graded_page_3: graded_page_3
+    } do
+      insert_resource_access(
+        graded_page_1,
+        graded_page_2,
+        graded_page_3,
+        section,
+        student
+      )
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_students_progress_route(
+            section.slug,
+            student.id,
+            :progress
+          )
+        )
+
+      assert has_element?(
+               view,
+               "div",
+               "#{graded_page_1.title}"
+             )
+
+      assert has_element?(
+               view,
+               "div",
+               "#{graded_page_2.title}"
+             )
+
+      assert has_element?(
+               view,
+               "div",
+               "#{graded_page_3.title}"
+             )
+
+      ## aplies limit
+      params = %{
+        limit: 2,
+        sort_order: "asc"
+      }
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_students_progress_route(
+            section.slug,
+            student.id,
+            :progress,
+            params
+          )
+        )
+
+      assert has_element?(
+               view,
+               "div",
+               "#{graded_page_1.title}"
+             )
+
+      assert has_element?(
+               view,
+               "div",
+               "#{graded_page_2.title}"
+             )
+
+      refute has_element?(
+               view,
+               "div",
+               "#{graded_page_3.title}"
+             )
+
+      ## aplies pagination
+      params = %{
+        limit: 2,
+        offset: 2,
+        sort_order: "asc"
+      }
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_students_progress_route(
+            section.slug,
+            student.id,
+            :progress,
+            params
+          )
+        )
+
+      refute has_element?(
+               view,
+               "div",
+               "#{graded_page_1.title}"
+             )
+
+      refute has_element?(
+               view,
+               "div",
+               "#{graded_page_2.title}"
+             )
+
+      assert has_element?(
+               view,
+               "div",
+               "#{graded_page_3.title}"
+             )
     end
   end
 end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -1409,6 +1409,53 @@ defmodule Oli.TestHelpers do
     }
   end
 
+  def section_without_pages(_) do
+    author = insert(:author)
+    project = insert(:project, authors: [author])
+
+    # root container
+    container_resource = insert(:resource)
+
+    # Associate root container to the project
+    insert(:project_resource, %{project_id: project.id, resource_id: container_resource.id})
+
+    container_revision =
+      insert(:revision, %{
+        resource: container_resource,
+        objectives: %{},
+        resource_type_id: Oli.Resources.ResourceType.get_id_by_type("container"),
+        children: [],
+        content: %{},
+        deleted: false,
+        collab_space_config: nil,
+        title: "Root Container"
+      })
+
+    # Publication of project with root container
+    publication =
+      insert(:publication, %{project: project, root_resource_id: container_resource.id})
+
+    # Publish root container resource
+    insert(:published_resource, %{
+      publication: publication,
+      resource: container_resource,
+      revision: container_revision,
+      author: author
+    })
+
+    section = insert(:section,
+      base_project: project,
+      context_id: UUID.uuid4(),
+      open_and_free: true,
+      registration_open: true,
+      type: :enrollable
+    )
+
+    {:ok, section} = Sections.create_section_resources(section, publication)
+
+    %{section: section}
+  end
+
   def section_with_assessment_without_collab_space(_context, deployment \\ nil) do
     author = insert(:author)
     project = insert(:project, authors: [author])


### PR DESCRIPTION
[MER-1725](https://eliterate.atlassian.net/browse/MER-1725)

This PR adds a view showing the progress made by a specific student in a course section to the progress tab on the student's dashboard for the instructor.

It lists all pages and grades the student has in the course section.

![Captura de pantalla 2023-04-26 a la(s) 14 29 04](https://user-images.githubusercontent.com/16328384/234655785-9ad444ce-cabb-4bb1-bda8-c21aadc33eba.png)


![Captura de pantalla 2023-04-26 a la(s) 14 28 37](https://user-images.githubusercontent.com/16328384/234655798-57e0669a-163c-4a34-9e7b-dbb662c782d0.png)

[MER-1725]: https://eliterate.atlassian.net/browse/MER-1725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ