### PR TITLE
[ENHANCEMENT] play all function for ordering audio choices [MER-1804]

### DIFF
--- a/assets/src/components/activities/ordering/OrderingDelivery.tsx
+++ b/assets/src/components/activities/ordering/OrderingDelivery.tsx
@@ -21,13 +21,13 @@ import {
 } from 'data/activities/DeliveryState';
 import { Choices } from 'data/activities/model/choices';
 import { initialPartInputs, studentInputToString } from 'data/activities/utils';
+import { elementsOfType } from 'data/content/utils';
 import { configureStore } from 'state/store';
 import { DeliveryElement, DeliveryElementProps } from '../DeliveryElement';
 import { DeliveryElementProvider, useDeliveryElementContext } from '../DeliveryElementProvider';
 import { castPartId } from '../common/utils';
 import * as ActivityTypes from '../types';
 import { OrderingSchema } from './schema';
-import { elementsOfType } from 'data/content/utils';
 
 export const OrderingComponent: React.FC = () => {
   const {


### PR DESCRIPTION
This supports the Play All function for ordering questions whose choices contain audio elements. This is used in legacy OLI language courses for questions asking to listen to conversation audio and then put audio clips in from it in correct order. When any choices contain audio, the activity will show a Play All button which when clicked, plays each choice's audio in the current order of choices. While playing it changes to "Stop Playing All" and can be used to interrupt the playback. 