### PR TITLE
MER-1930

### DIFF
--- a/assets/src/components/parts/janus-mcq/MultipleChoiceQuestion.tsx
+++ b/assets/src/components/parts/janus-mcq/MultipleChoiceQuestion.tsx
@@ -20,6 +20,7 @@ const MCQItemContentComponent: React.FC<any> = ({ itemId, nodes, state }) => {
     //depending upon their needs
     //SS applies this on every MCQ. They override it with external CSS if in case this needs to be overridden.
     <div style={{ left: 18, position: 'relative', overflow: 'hidden' }}>
+      <style type="text/css">{`.content .mcq-input img{ margin-bottom:auto }`}</style>
       {nodes.map((subtree: any) => {
         const style: any = {};
         if (subtree.tag === 'p') {


### PR DESCRIPTION
Looks like the new CSS that got applied across the Torus impacted the delivery parts rendering as well. 

In this case, the following CSS was affecting the rendering of the img in MCQ item.

```
 .content img {
    margin-bottom: 1.5em;
}
```

I have made the change so that 'auto' gets set to margin-bottom property. Again, this can be overridden from an external CSS file so it should not cause any issues.