### PR TITLE
[FEATURE] [MER-1907] All course sections user enrolled

### DIFF
--- a/assets/css/table.css
+++ b/assets/css/table.css
@@ -32,6 +32,10 @@
   background-repeat: no-repeat;
 }
 
+.instructor_dashboard_table_link {
+  @apply h-14 text-gray-500 font-semibold text-xs sm:text-sm;
+}
+
 .instructor_dashboard_table tr {
   @apply h-14 text-gray-500 font-semibold text-xs sm:text-sm;
 }

--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -454,4 +454,23 @@ defmodule Oli.Delivery.Metrics do
       end
     end)
   end
+
+  @doc """
+    Returns the last time a user accessed a section
+  """
+
+  def get_last_access_for_user_in_a_section(user_id, section_id) do
+    query =
+      from(u in User,
+        join: enr in Enrollment,
+        on: enr.user_id == u.id,
+        join: ra in ResourceAccess,
+        on: ra.user_id == enr.user_id,
+        where: u.id == ^user_id and ra.section_id == ^section_id,
+        group_by: u.name,
+        select: fragment("MAX(?)", ra.updated_at)
+      )
+
+    Repo.one(query)
+  end
 end

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -419,6 +419,22 @@ defmodule Oli.Delivery.Sections do
   end
 
   @doc """
+  Returns a listing of all enrolled sections for a given user.
+  """
+  def list_user_enrolled_sections(%{id: user_id} = _user) do
+    query =
+      from(
+        s in Section,
+        join: e in Enrollment,
+        on: e.section_id == s.id,
+        where: e.user_id == ^user_id and s.status == :active,
+        select: s
+      )
+
+    Repo.all(query)
+  end
+
+  @doc """
   Returns the list of sections.
   ## Examples
       iex> list_sections()

--- a/lib/oli_web/live/users/user_enrolled_sections.ex
+++ b/lib/oli_web/live/users/user_enrolled_sections.ex
@@ -1,0 +1,215 @@
+defmodule OliWeb.Users.UserEnrolledSections do
+  use Surface.LiveComponent
+
+  alias OliWeb.Common.{PagedTable, SearchInput, Params}
+  alias OliWeb.Router.Helpers, as: Routes
+  alias OliWeb.Users.UserEnrolledTableModel
+  alias Phoenix.LiveView.JS
+
+  prop enrolled_sections, :list, required: true
+  prop params, :map, required: true
+  prop table_model, :struct, required: true
+  prop total_count, :number, required: true
+
+  @default_params %{
+    offset: 0,
+    limit: 10,
+    sort_order: :asc,
+    sort_by: :title,
+    text_search: nil
+  }
+
+  def update(
+        %{user: user, params: params, context: context, enrolled_sections: enrolled_sections} =
+          _assigns,
+        socket
+      ) do
+    params = decode_params(params)
+
+    {total_count, rows} = apply_filters(enrolled_sections, params)
+
+    {:ok, table_model} = UserEnrolledTableModel.new(rows, user, context)
+
+    table_model =
+      Map.merge(table_model, %{
+        rows: rows,
+        sort_order: params.sort_order,
+        sort_by_spec:
+          Enum.find(table_model.column_specs, fn col_spec -> col_spec.name == params.sort_by end)
+      })
+
+    {:ok,
+     assign(socket,
+       enrolled_sections: enrolled_sections,
+       params: params,
+       table_model: table_model,
+       total_count: total_count,
+       user: user
+     )}
+  end
+
+  def render(assigns) do
+    ~F"""
+      <div class="flex flex-col gap-y-4">
+        {#if length(@enrolled_sections) > 0}
+          <div class="d-flex justify-end">
+            <form for="search" phx-target={@myself} phx-change="search_section" class="pb-6 ml-9 sm:pb-0">
+              <SearchInput.render id="section_search_input" name="section_title" text={@params.text_search} />
+            </form>
+          </div>
+
+
+          {#if @total_count > 0}
+            <div id="sections-enrolled-table">
+              <PagedTable
+                table_model={@table_model}
+                total_count={@total_count}
+                offset={@params.offset}
+                limit={@params.limit}
+                additional_table_class="instructor_dashboard_table"
+                sort={JS.push("paged_table_sort", target: @myself)}
+                page_change={JS.push("paged_table_page_change", target: @myself)}
+                show_bottom_paging={false}
+                render_top_info={false}
+              />
+            </div>
+          {#else}
+            <h6 class="text-center py-4">There are no sections to show</h6>
+          {/if}
+        {#else}
+          <h6 class="text-center py-4">User is not enrolled in any course section</h6>
+        {/if}
+      </div>
+    """
+  end
+
+  def handle_event("search_section", %{"section_title" => section_title}, socket) do
+    {:noreply,
+     push_patch(socket,
+       to:
+         Routes.live_path(
+           socket,
+           OliWeb.Users.UsersDetailView,
+           socket.assigns.user.id,
+           update_params(socket.assigns.params, %{text_search: section_title})
+         )
+     )}
+  end
+
+  def handle_event("paged_table_page_change", %{"limit" => limit, "offset" => offset}, socket) do
+    {:noreply,
+     push_patch(socket,
+       to:
+         Routes.live_path(
+           socket,
+           OliWeb.Users.UsersDetailView,
+           socket.assigns.user.id,
+           update_params(socket.assigns.params, %{limit: limit, offset: offset})
+         )
+     )}
+  end
+
+  def handle_event("paged_table_sort", %{"sort_by" => sort_by} = _params, socket) do
+    {:noreply,
+     push_patch(socket,
+       to:
+         Routes.live_path(
+           socket,
+           OliWeb.Users.UsersDetailView,
+           socket.assigns.user.id,
+           update_params(socket.assigns.params, %{sort_by: String.to_existing_atom(sort_by)})
+         )
+     )}
+  end
+
+  defp decode_params(params) do
+    %{
+      offset: Params.get_int_param(params, "offset", @default_params.offset),
+      limit: Params.get_int_param(params, "limit", @default_params.limit),
+      sort_order:
+        Params.get_atom_param(params, "sort_order", [:asc, :desc], @default_params.sort_order),
+      sort_by:
+        Params.get_atom_param(
+          params,
+          "sort_by",
+          [
+            :title,
+            :enrollment_status,
+            :enrollment_role,
+            :start_date,
+            :end_date,
+            :payment_status,
+            :last_accessed
+          ],
+          @default_params.sort_by
+        ),
+      text_search: Params.get_param(params, "text_search", @default_params.text_search)
+    }
+  end
+
+  defp update_params(%{sort_by: current_sort_by, sort_order: current_sort_order} = params, %{
+         sort_by: new_sort_by
+       })
+       when current_sort_by == new_sort_by do
+    toggled_sort_order = if current_sort_order == :asc, do: :desc, else: :asc
+    update_params(params, %{sort_order: toggled_sort_order})
+  end
+
+  defp update_params(params, new_param) do
+    Map.merge(params, new_param)
+    |> purge_default_params()
+  end
+
+  defp purge_default_params(params) do
+    Map.filter(params, fn {key, value} ->
+      @default_params[key] != value
+    end)
+  end
+
+  defp apply_filters(sections, params) do
+    sections =
+      sections
+      |> maybe_filter_by_text(params.text_search)
+      |> sort_by(params.sort_by, params.sort_order)
+
+    {length(sections), sections |> Enum.drop(params.offset) |> Enum.take(params.limit)}
+  end
+
+  defp sort_by(sections, sort_by, sort_order) do
+    case sort_by do
+      :title ->
+        Enum.sort_by(sections, fn section -> section.title end, sort_order)
+
+      :enrollment_status ->
+        Enum.sort_by(sections, fn section -> section.enrollment_status end, sort_order)
+
+      :enrollment_role ->
+        Enum.sort_by(sections, fn section -> section.enrollment_role end, sort_order)
+
+      :start_date ->
+        Enum.sort_by(sections, fn section -> section.start_date end, sort_order)
+
+      :end_date ->
+        Enum.sort_by(sections, fn section -> section.end_date end, sort_order)
+
+      :payment_status ->
+        Enum.sort_by(sections, fn section -> section.payment_status end, sort_order)
+
+      :last_accessed ->
+        Enum.sort_by(sections, fn section -> section.last_accessed end, sort_order)
+
+      _ ->
+        Enum.sort_by(sections, fn section -> section.title end, sort_order)
+    end
+  end
+
+  defp maybe_filter_by_text(sections, nil), do: sections
+  defp maybe_filter_by_text(sections, ""), do: sections
+
+  defp maybe_filter_by_text(sections, text_search) do
+    sections
+    |> Enum.filter(fn section ->
+      String.contains?(String.downcase(section.title), String.downcase(text_search))
+    end)
+  end
+end

--- a/lib/oli_web/live/users/user_enrolled_table_model.ex
+++ b/lib/oli_web/live/users/user_enrolled_table_model.ex
@@ -1,0 +1,127 @@
+defmodule OliWeb.Users.UserEnrolledTableModel do
+  use Surface.LiveComponent
+
+  alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
+  alias OliWeb.Common.Utils
+  alias OliWeb.Router.Helpers, as: Routes
+
+  def render(assigns) do
+    ~F"""
+      <div>nothing</div>
+    """
+  end
+
+  def new(sections, user, context) do
+    SortableTableModel.new(
+      rows: sections,
+      column_specs: [
+        %ColumnSpec{
+          name: :title,
+          label: "Title",
+          render_fn: &__MODULE__.render_title_column/3,
+          th_class: "whitespace-nowrap"
+        },
+        %ColumnSpec{
+          name: :enrollment_status,
+          label: "Enrollment Status",
+          th_class: "whitespace-nowrap"
+        },
+        %ColumnSpec{
+          name: :enrollment_role,
+          label: "Enrollment Role",
+          th_class: "whitespace-nowrap"
+        },
+        %ColumnSpec{
+          name: :start_date,
+          label: "Start Date",
+          render_fn: &__MODULE__.custom_render_date/3,
+          th_class: "whitespace-nowrap"
+        },
+        %ColumnSpec{
+          name: :end_date,
+          label: "End Date",
+          render_fn: &__MODULE__.custom_render_date/3,
+          th_class: "whitespace-nowrap"
+        },
+        %ColumnSpec{
+          name: :payment_status,
+          label: "Payment Status",
+          render_fn: &__MODULE__.render_payment_status/3,
+          th_class: "whitespace-nowrap"
+        },
+        %ColumnSpec{
+          name: :last_accessed,
+          label: "Last Accessed",
+          render_fn: &__MODULE__.render_last_accessed/3,
+          th_class: "whitespace-nowrap"
+        }
+      ],
+      event_suffix: "",
+      id_field: [:id],
+      data: %{
+        context: context,
+        user: user
+      }
+    )
+  end
+
+  def render_last_accessed(assigns, row, col_spec) do
+    case row.last_accessed do
+      nil ->
+        ~F"""
+          <span>Not accessed yet</span>
+        """
+
+      _ ->
+        ~F"""
+          <span>{Utils.render_relative_date(row, col_spec.name, Map.get(assigns, :context))}</span>
+        """
+    end
+  end
+
+  def custom_render_date(assigns, row, col_spec) do
+    Utils.render_relative_date(row, col_spec.name, Map.get(assigns, :context))
+  end
+
+  def render_title_column(assigns, row, _col_spec) do
+    route_path =
+      Routes.live_path(
+        OliWeb.Endpoint,
+        OliWeb.Delivery.StudentDashboard.StudentDashboardLive,
+        row.slug,
+        assigns.user.id,
+        :content
+      )
+
+    SortableTableModel.render_link_column(
+      assigns,
+      row.title,
+      route_path,
+      "instructor_dashboard_table_link"
+    )
+  end
+
+  def render_payment_status(assigns, row, _col_spec) do
+    case row.payment_status do
+      :not_paywalled ->
+        ~F"""
+          <span>N/A</span>
+        """
+
+      :paid ->
+        ~F"""
+          <span>Paid</span>
+        """
+
+      :not_paid ->
+        ~F"""
+          <span>Not Paid</span>
+        """
+
+      :within_grace_period ->
+        ~F"""
+          <span>Within Grace Period</span>
+        """
+    end
+  end
+end

--- a/test/oli/sections_test.exs
+++ b/test/oli/sections_test.exs
@@ -1264,19 +1264,25 @@ defmodule Oli.SectionsTest do
 
       Sections.enroll(student.id, section_1.id, [ContextRoles.get_role(:context_learner)])
       Sections.enroll(student.id, section_2.id, [ContextRoles.get_role(:context_learner)])
-      {:ok, %{student: student}}
+      {:ok, %{student: student, section_1: section_1, section_2: section_2}}
     end
 
-    test "returns sections for user", %{student: student} do
-      sections = Sections.list_user_enrolled_sections(student)
+    test "returns sections for user", %{
+      student: student,
+      section_1: section_1,
+      section_2: section_2
+    } do
+      [s1 | [s2 | _rest]] = sections = Sections.list_user_enrolled_sections(student)
       assert length(sections) == 2
+
+      assert s1.id == section_1.id
+      assert s2.id == section_2.id
     end
 
     test "returns empty list when user is not enrolled in any sections", %{} do
       student = insert(:user)
       sections = Sections.list_user_enrolled_sections(student)
       assert sections == []
-      assert length(sections) == 0
     end
   end
 end

--- a/test/oli/sections_test.exs
+++ b/test/oli/sections_test.exs
@@ -1255,4 +1255,28 @@ defmodule Oli.SectionsTest do
       assert Enum.at(Enum.at(hierarchy.children, 2).children, 1).numbering.index == 4
     end
   end
+
+  describe "list_user_enrolled_sections/1" do
+    setup do
+      student = insert(:user)
+      section_1 = insert(:section)
+      section_2 = insert(:section)
+
+      Sections.enroll(student.id, section_1.id, [ContextRoles.get_role(:context_learner)])
+      Sections.enroll(student.id, section_2.id, [ContextRoles.get_role(:context_learner)])
+      {:ok, %{student: student}}
+    end
+
+    test "returns sections for user", %{student: student} do
+      sections = Sections.list_user_enrolled_sections(student)
+      assert length(sections) == 2
+    end
+
+    test "returns empty list when user is not enrolled in any sections", %{} do
+      student = insert(:user)
+      sections = Sections.list_user_enrolled_sections(student)
+      assert sections == []
+      assert length(sections) == 0
+    end
+  end
 end


### PR DESCRIPTION
[MER-1907](https://eliterate.atlassian.net/browse/MER-1907)

This PR adds a new section within the user details view, to show the course sections in which a given user is enrolled.

In this section a table is rendered showing the required data. This table is sortable, pageable and has a search field to search by the title of a course section.

The title of each course section listed is a link to the user details view for that specific section.

![Captura de pantalla 2023-05-04 a la(s) 10 43 15](https://user-images.githubusercontent.com/16328384/236224699-97d0f255-91a2-4d7b-afd4-2eb746e7cdc0.png)

![Captura de pantalla 2023-05-04 a la(s) 10 44 17](https://user-images.githubusercontent.com/16328384/236224692-f0906dc1-894c-4109-9cea-ca58515f25be.png)

[MER-1907]: https://eliterate.atlassian.net/browse/MER-1907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ