### PR TITLE
[MER-1941] Delivery style bugs

### DIFF
--- a/assets/src/components/ContentTable.tsx
+++ b/assets/src/components/ContentTable.tsx
@@ -6,20 +6,11 @@ export const ContentTable: React.FC<{
   model: ContentTypes.Table;
   children: React.ReactNode;
 }> = ({ model, children }) => {
-  const cssClasses = [];
-  if (model.border === 'hidden') {
-    cssClasses.push('table-borderless');
-  }
-
-  if (model.rowstyle === 'alternating') {
-    cssClasses.push('table-striped');
-  }
-
   return (
     <table
       className={classNames(
         'min-w-full',
-        model.border === 'hidden' && 'table-borderless',
+        model.border === 'hidden' ? 'table-borderless' : 'table-bordered',
         model.rowstyle === 'alternating' && 'table-striped',
       )}
     >

--- a/assets/src/components/activities/common/delivery/inputs/DropdownInput.tsx
+++ b/assets/src/components/activities/common/delivery/inputs/DropdownInput.tsx
@@ -15,13 +15,11 @@ export const DropdownInput: React.FC<Props> = (props) => {
     },
     ...props.options,
   ];
-
   return (
     <select
       onChange={(e) => props.onChange(e.target.value)}
       disabled={typeof props.disabled === 'boolean' ? props.disabled : false}
-      className="custom-select"
-      style={{ flexBasis: '160px', width: '160px' }}
+      className="custom-select dropdown-input" // see: multi-input.scss
     >
       {options.map((option, i) => (
         <option selected={option.value === props.selected} key={i} value={option.value}>

--- a/assets/src/components/editing/elements/list/listActions.tsx
+++ b/assets/src/components/editing/elements/list/listActions.tsx
@@ -97,14 +97,14 @@ export const unorderedListStyleCommands = UnorderdListStyles.map((styleType: str
   createButtonCommandDesc({
     icon: <i className="fa-regular fa-rectangle-list"></i>,
     description: listStyleLabels[styleType],
-    active: (editor) => isPropActive(editor, 'ul', { style: styleType }),
+    active: (editor) => false,
     execute: (_ctx, editor) => {
-      const [, at] = [...Editor.nodes(editor)][1];
-      Transforms.setNodes(
-        editor,
-        { style: styleType },
-        { at, match: (e) => Element.isElement(e) && isList(e), mode: 'all' },
-      );
+      const r = Editor.above(editor, {
+        match: (e) => Element.isElement(e) && isList(e),
+      });
+      if (!r) return;
+      const [, at] = r;
+      Transforms.setNodes(editor, { style: styleType }, { at, mode: 'all' });
     },
   }),
 );
@@ -117,14 +117,14 @@ export const orderedListStyleCommands = OrderedListStyles.filter(notLatinOption)
     createButtonCommandDesc({
       icon: <i className="fa-regular fa-rectangle-list"></i>,
       description: listStyleLabels[styleType],
-      active: (editor) => isPropActive(editor, 'ol', { style: styleType }),
+      active: (editor) => false,
       execute: (_ctx, editor) => {
-        const [, at] = [...Editor.nodes(editor)][1];
-        Transforms.setNodes(
-          editor,
-          { style: styleType },
-          { at, match: (e) => Element.isElement(e) && isList(e), mode: 'all' },
-        );
+        const r = Editor.above(editor, {
+          match: (e) => Element.isElement(e) && isList(e),
+        });
+        if (!r) return;
+        const [, at] = r;
+        Transforms.setNodes(editor, { style: styleType }, { at, mode: 'all' });
       },
     }),
 );

--- a/assets/src/components/editing/elements/list/listActions.tsx
+++ b/assets/src/components/editing/elements/list/listActions.tsx
@@ -4,7 +4,7 @@ import { handleIndent, handleOutdent } from 'components/editing/editor/handlers/
 import { createButtonCommandDesc } from 'components/editing/elements/commands/commandFactories';
 import { Command, CommandDescription } from 'components/editing/elements/commands/interfaces';
 import { switchType } from 'components/editing/elements/commands/toggleTextTypes';
-import { isActive, isPropActive, isTopLevel } from 'components/editing/slateUtils';
+import { isActive, isTopLevel } from 'components/editing/slateUtils';
 import guid from 'utils/guid';
 import {
   OrderedListStyle,

--- a/assets/src/data/content/model/elements/factories.ts
+++ b/assets/src/data/content/model/elements/factories.ts
@@ -73,9 +73,9 @@ export const Model = {
 
   li: () => create<ListItem>({ type: 'li' }),
 
-  ol: () => create<OrderedList>({ type: 'ol', style: 'decimal', children: [Model.li()] }),
+  ol: () => create<OrderedList>({ type: 'ol', children: [Model.li()] }),
 
-  ul: () => create<UnorderedList>({ type: 'ul', style: 'disc', children: [Model.li()] }),
+  ul: () => create<UnorderedList>({ type: 'ul', children: [Model.li()] }),
 
   dt: () => create<DescriptionListTerm>({ type: 'dt', children: [Model.p([{ text: 'A term' }])] }),
   dd: () =>

--- a/assets/styles/common/elements.scss
+++ b/assets/styles/common/elements.scss
@@ -168,6 +168,12 @@ $element-margin-bottom: 1.5em;
     }
   }
 
+  .table-bordered {
+    th {
+      border-right: 1px solid #e5e5e5;
+    }
+  }
+
   img {
     margin-bottom: $element-margin-bottom;
   }

--- a/assets/styles/common/elements.scss
+++ b/assets/styles/common/elements.scss
@@ -99,11 +99,26 @@ $element-margin-bottom: 1.5em;
     }
   }
 
-  ul,
-  ol {
+  ul {
     padding-left: 1.5em;
     margin-bottom: $element-margin-bottom;
     list-style: disc;
+    // Nested lists without a style specified go disc->circle->square then back to disc for the rest as they indent
+    ul {
+      list-style: circle;
+      ul {
+        list-style: square;
+        ul {
+          list-style: disc;
+        }
+      }
+    }
+  }
+
+  ol {
+    padding-left: 1.5em;
+    margin-bottom: $element-margin-bottom;
+    list-style: decimal;
   }
 
   ul li,

--- a/assets/styles/common/list.scss
+++ b/assets/styles/common/list.scss
@@ -1,40 +1,40 @@
 ul.list-square {
-  list-style: square;
+  list-style: square !important;
 }
 ul.list-circle {
-  list-style: circle;
+  list-style: circle !important;
 }
 ul.list-disc {
-  list-style: disc;
+  list-style: disc !important;
 }
 ul.list-none {
-  list-style: none;
+  list-style: none !important;
 }
 
 ol.list-none {
-  list-style: none;
+  list-style: none !important;
 }
 ol.list-decimal {
-  list-style: decimal;
+  list-style: decimal !important;
 }
 ol.list-decimal-leading-zero {
-  list-style: decimal-leading-zero;
+  list-style: decimal-leading-zero !important;
 }
 ol.list-lower-roman {
-  list-style: lower-roman;
+  list-style: lower-roman !important;
 }
 ol.list-upper-roman {
-  list-style: upper-roman;
+  list-style: upper-roman !important;
 }
 ol.list-lower-alpha {
-  list-style: lower-alpha;
+  list-style: lower-alpha !important;
 }
 ol.list-upper-alpha {
-  list-style: upper-alpha;
+  list-style: upper-alpha !important;
 }
 ol.list-lower-latin {
-  list-style: lower-latin;
+  list-style: lower-latin !important;
 }
 ol.list-upper-latin {
-  list-style: upper-latin;
+  list-style: upper-latin !important;
 }

--- a/assets/styles/delivery/index.scss
+++ b/assets/styles/delivery/index.scss
@@ -9,3 +9,5 @@
 @import 'page_delivery/after_finalized.scss';
 @import 'page_delivery/collab_space.scss';
 @import 'page_delivery/page.scss';
+
+@import 'multi-input.scss';

--- a/assets/styles/delivery/multi-input.scss
+++ b/assets/styles/delivery/multi-input.scss
@@ -1,0 +1,8 @@
+.multi-input-activity {
+  .dropdown-input {
+    width: unset;
+    padding-right: 35px;
+    margin: 0px 0.1rem;
+    min-width: 2rem;
+  }
+}

--- a/lib/oli/interop/rewire_links.ex
+++ b/lib/oli/interop/rewire_links.ex
@@ -20,12 +20,16 @@ defmodule Oli.Ingest.RewireLinks do
       end
     end
 
-    case rewire(revision.content, link_builder, page_map) do
-      {true, content} ->
-        Oli.Resources.update_revision(revision, %{content: content})
+    try do
+      case rewire(revision.content, link_builder, page_map) do
+        {true, content} ->
+          Oli.Resources.update_revision(revision, %{content: content})
 
-      {false, _} ->
-        {:ok, revision}
+        {false, _} ->
+          {:ok, revision}
+      end
+    rescue
+      _ in KeyError -> {:ok, revision}
     end
   end
 

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -121,7 +121,7 @@ defmodule Oli.Rendering.Content.Html do
   end
 
   defp tableBorderClass(%{"border" => "hidden"}), do: "table-borderless"
-  defp tableBorderClass(_), do: ""
+  defp tableBorderClass(_), do: "table-bordered"
 
   defp tableRowClass(%{"rowstyle" => "alternating"}), do: "table-striped"
   defp tableRowClass(_), do: ""

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -207,7 +207,7 @@ defmodule Oli.Rendering.Content.Html do
   end
 
   def ol(%Context{} = _context, next, _) do
-    ["<ol class=\"list-decimal list-inside pl-2\">", next.(), "</ol>\n"]
+    ["<ol class=\"list-inside pl-2\">", next.(), "</ol>\n"]
   end
 
   def dl(%Context{}, next, title, %{}) do
@@ -234,7 +234,7 @@ defmodule Oli.Rendering.Content.Html do
   end
 
   def ul(%Context{} = _context, next, _) do
-    ["<ul class=\"list-disc list-inside pl-2\">", next.(), "</ul>\n"]
+    ["<ul class=\"list-inside pl-2\">", next.(), "</ul>\n"]
   end
 
   def li(%Context{} = _context, next, _) do

--- a/test/oli/rendering/content/html_test.exs
+++ b/test/oli/rendering/content/html_test.exs
@@ -40,10 +40,10 @@ defmodule Oli.Content.Content.HtmlTest do
       assert rendered_html_string =~ "<h3>1651–1748: Early seeds</h3>"
 
       assert rendered_html_string =~
-               "<ol class=\"list-decimal list-inside pl-2\"><li>one</li>\n<li><em>two</em></li>\n<li><em><strong>three</strong></em></li>\n</ol>"
+               "<ol class=\"list-inside pl-2\"><li>one</li>\n<li><em>two</em></li>\n<li><em><strong>three</strong></em></li>\n</ol>"
 
       assert rendered_html_string =~
-               "<ul class=\"list-disc list-inside pl-2\"><li>alpha</li>\n<li>beta</li>\n<li>gamma</li>\n</ul>"
+               "<ul class=\"list-inside pl-2\"><li>alpha</li>\n<li>beta</li>\n<li>gamma</li>\n</ul>"
 
       assert rendered_html_string =~
                ~r/<div class=".*">\s*<iframe.* src="https:\/\/www.youtube.com\/embed\/fhdCslFcKFU"><\/iframe>\s*<\/div>/
@@ -82,7 +82,7 @@ defmodule Oli.Content.Content.HtmlTest do
                "<div class='figure'><figure><figcaption><p>Figure Title</p>\n</figcaption><div class='figure-content'><p>Figure Content</p>\n</div></figure></div>"
 
       assert rendered_html_string =~
-               "<div class=\"conjugation\"><div class=\"title\">My Term</div><div class=\"term\">El Verbo<span class='pronunciation'><p>my pronunciation</p>\n</span>\n</div><table class=' '><tr><th>form</th>\n<th>meaning</th>\n</tr>\n<tr><td>my form</td>\n<td>my meaning</td>\n</tr>\n</table>\n</div>"
+               "<div class=\"conjugation\"><div class=\"title\">My Term</div><div class=\"term\">El Verbo<span class='pronunciation'><p>my pronunciation</p>\n</span>\n</div><table class='table-bordered '><tr><th>form</th>\n<th>meaning</th>\n</tr>\n<tr><td>my form</td>\n<td>my meaning</td>\n</tr>\n</table>\n</div>"
 
       assert rendered_html_string =~
                "<span class=\"btn btn-primary command-button\" data-action=\"command-button\" data-target=\"3603298117\" data-message=\"startcuepoint=5.0;endcuepoint=10.0\">Play Intro</span>"


### PR DESCRIPTION
This fixes 4 of the bugs identified in MER-1941

# Un-styled lists

Unordered lists without a style attribute now follow a pattern of disc, circle, square, for each level of indentation. Furthermore, inserting a new list, now creates a list without the style set so it takes that default behavior for all new lists.

![image](https://user-images.githubusercontent.com/333265/236309868-7270ff0f-aeec-4204-8368-88cb23d040b9.png)

# Formatting sub lists

Previously, changing the style of list would change it for all parent & child lists. Now it only affects the single closest ancestor list to the cursor. This allows each level to be customized by the author and provides a much more natural user experience.

# Table header borders

In tables with borders turned on, borders between the cells of headers are again present.

![image](https://user-images.githubusercontent.com/333265/236310433-1fef171c-c764-4e77-a2bc-26daa1243e9a.png)

# Multi input dropdown sizing

In multi-input questions with dropdowns, those dropdowns are now auto-sized based upon their content. Previously they were a fixed 160px wide.  This makes the chem-equation style questions usable again and fixes #3455 

![image](https://user-images.githubusercontent.com/333265/236311145-74ef1f68-ec3d-45b8-81e9-55eed5708f3d.png)
![image](https://user-images.githubusercontent.com/333265/236310957-ae865d69-c3d5-4c68-99e5-4e27df8234b5.png)

![image](https://user-images.githubusercontent.com/333265/236311203-cd755830-907f-4ded-a22a-50c047de00a8.png)



