### PR TITLE
[BUG FIX] Enrolled users table model over constrains payment status pattern

### DIFF
--- a/lib/oli_web/live/users/user_enrolled_table_model.ex
+++ b/lib/oli_web/live/users/user_enrolled_table_model.ex
@@ -122,6 +122,16 @@ defmodule OliWeb.Users.UserEnrolledTableModel do
         ~F"""
           <span>Within Grace Period</span>
         """
+
+      :instructor ->
+        ~F"""
+          <span>Instructor</span>
+        """
+
+      _ ->
+        ~F"""
+          <span>Unknown</span>
+        """
     end
   end
 end


### PR DESCRIPTION
** (CaseClauseError) no case clause matching: :instructor
Backtrace: lib/oli_web/live/users/user_enrolled_table_model.ex:105 in OliWeb.Users.UserEnrolledTableModel.render_payment_status/3

See the above in AppSignal.  Root case is that payment status is being reported as `:instructor` for users that are instructors in a paid section.  Added a catch all clause to make this future proof. 