### PR TITLE
[MER-1743] [Bugfix] Multi input displays hints on first click

### DIFF
--- a/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
@@ -21,6 +21,7 @@ import {
   listenForParentSurveyReset,
   listenForParentSurveySubmit,
   listenForReviewAttemptChange,
+  requestHint,
   resetAction,
   resetAndSavePart,
   resetAndSubmitPart,
@@ -42,6 +43,7 @@ export const MultiInputComponent: React.FC = () => {
     onSubmitPart,
     onResetPart,
     onResetActivity,
+    onRequestHint,
     mode,
     model,
   } = useDeliveryElementContext<MultiInputSchema>();
@@ -92,10 +94,11 @@ export const MultiInputComponent: React.FC = () => {
 
   const toggleHints = (id: string) => {
     const input = getByUnsafe((uiState.model as MultiInputSchema).inputs, (x) => x.id === id);
+
+    dispatch(requestHint(input.partId, onRequestHint));
+
     setHintsShown((hintsShown) =>
-      hintsShown.includes(input.partId)
-        ? hintsShown.filter((id) => id !== input.partId)
-        : hintsShown.concat(input.partId),
+      hintsShown.includes(input.partId) ? hintsShown : hintsShown.concat(input.partId),
     );
   };
 


### PR DESCRIPTION
In multi-input questions, clicking the hint icon next to an input will now show the hint box *and* display the first (or next) hint. Previously, it only showed the box, and you had to click the "request hint" link in that box.

![singleclickhints](https://user-images.githubusercontent.com/333265/236463548-4ec6769a-8327-46bd-b304-9cde695b30c3.gif)

Fixes #3450 