### PR TITLE
[BUG FIX] Allow tech support window to be initialized correctly

### DIFF
--- a/assets/src/components/common/Navbar.tsx
+++ b/assets/src/components/common/Navbar.tsx
@@ -153,8 +153,7 @@ export const Navbar = ({
               active:text-delivery-primary-600
               active:hover:text-delivery-primary-600
             "
-            data-bs-toggle="modal"
-            data-bs-target="#help-modal"
+            onClick={() => (window as any).showHelpModal()}
           >
             Tech Support
           </button>

--- a/lib/oli_web/components/delivery/buttons.ex
+++ b/lib/oli_web/components/delivery/buttons.ex
@@ -53,7 +53,7 @@ defmodule OliWeb.Components.Delivery.Buttons do
   def help_button(assigns) do
     ~H"""
     <!-- Button trigger modal -->
-    <button type="button" class="btn btn-xs btn-light inline-flex items-center help-btn m-1" data-bs-toggle="modal" data-bs-target="#help-modal">
+    <button type="button" class="btn btn-xs btn-light inline-flex items-center help-btn m-1" onclick="window.showHelpModal()">
       <span>Tech Support</span>
     </button>
     """

--- a/lib/oli_web/templates/shared/_help.html.eex
+++ b/lib/oli_web/templates/shared/_help.html.eex
@@ -110,6 +110,8 @@
     }
   }
 
+  window.showHelpModal = showHelpModal;
+
   const helpForm = document.querySelector('#form-request-help')
   if (helpForm) {
     helpForm.addEventListener("submit", async function (event) {

--- a/lib/oli_web/templates/shared/_help_button.html.eex
+++ b/lib/oli_web/templates/shared/_help_button.html.eex
@@ -1,4 +1,4 @@
 <!-- Button trigger modal -->
-<button type="button" class="btn btn-xs btn-light inline-flex items-center help-btn m-1" data-bs-toggle="modal" data-bs-target="#help-modal">
+<button type="button" class="btn btn-xs btn-light inline-flex items-center help-btn m-1" onclick="window.showHelpModal();">
   <span>Tech Support</span>
 </button>


### PR DESCRIPTION
Changes the method to launch the tech support modal, so that recaptcha is properly initialized and the request can be sent.