### PR TITLE
[BUG FIX] Fix query to fetch required survey

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -2593,8 +2593,8 @@ defmodule Oli.Delivery.Sections do
       (s.slug == ^section_slug and
          spp.project_id == s.base_project_id and
          spp.section_id == s.id and
-         pr.resource_id == s.required_survey_resource_id) or
-        pr.resource_id == proj.required_survey_resource_id
+         (pr.resource_id == s.required_survey_resource_id or
+         pr.resource_id == proj.required_survey_resource_id))
     )
     |> select([_, _, _, rev], rev)
   end


### PR DESCRIPTION
There is an issue with how the logic clauses were structured in the query to fetch the required student survey.  The final clause needed to be part of an OR.  This issue is causing errors when course projects are duplicated. Their resources are shared across them, which ends up returning more than 1 record.