### PR TITLE
[BUG FIX] Fix Quiz Tab

### DIFF
--- a/test/oli_web/live/delivery/instructor_dashboard/quiz_scores_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/quiz_scores_tab_test.exs
@@ -144,6 +144,28 @@ defmodule OliWeb.Delivery.InstructorDashboard.QuizScoreTabTest do
       assert has_element?(view, "h6", "There are no quiz scores to show")
     end
 
+    test "loads correctly when a student has not yet finished a quiz", %{
+      conn: conn,
+      section: section,
+      instructor: instructor,
+      student_with_gating_condition: student,
+      graded_page_1: graded_page_1
+    } do
+      insert(:resource_access,
+        user: student,
+        section: section,
+        resource: graded_page_1.resource,
+        score: nil,
+        out_of: nil
+      )
+
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+
+      {:ok, view, _html} = live(conn, live_view_quiz_scores_route(section.slug))
+
+      assert has_element?(view, "h4", "Quiz Scores")
+    end
+
     test "applies searching", %{
       conn: conn,
       section: section,

--- a/test/oli_web/live/delivery/student_dashboard/components/quizz_scores_tab_test.exs
+++ b/test/oli_web/live/delivery/student_dashboard/components/quizz_scores_tab_test.exs
@@ -151,6 +151,29 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.QuizzScoresTabTest do
       assert has_element?(view, "h6", "There are no quiz scores to show")
     end
 
+    test "gets rendered correctly for a student that has not yet finished a quizz", %{
+      conn: conn,
+      section: section,
+      instructor: instructor,
+      student_with_gating_condition: student,
+      graded_page_1: graded_page_1
+    } do
+      insert(:resource_access,
+        user: student,
+        section: section,
+        resource: graded_page_1.resource,
+        score: nil,
+        out_of: nil
+      )
+
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+
+      {:ok, view, _html} =
+        live(conn, live_view_students_dashboard_route(section.slug, student.id, :quizz_scores))
+
+      assert has_element?(view, "a", "Not Finished")
+    end
+
     test "applies searching", %{
       conn: conn,
       section: section,


### PR DESCRIPTION
The students and the instructor dashboard "Quiz Scores" tab crash when a student hasn't yet finished the quiz.
This PR fixes that bug.