### PR TITLE
Fix avatar size

### DIFF
--- a/lib/oli_web/live/delivery/student_dashboard/components/helpers.ex
+++ b/lib/oli_web/live/delivery/student_dashboard/components/helpers.ex
@@ -180,7 +180,7 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.Helpers do
           <%= if @student.picture do %>
             <img src={@student.picture} class="rounded-full h-52 w-52" referrerPolicy="no-referrer" />
           <% else %>
-              <i class="h-52 w-52 fa-solid fa-circle-user fa-2xl mt-[-1px] ml-[-1px] text-gray-200"></i>
+            <i class="fa-solid fa-circle-user text-[208px] text-gray-200"></i>
           <% end %>
         </div>
         <div class="flex flex-col divide-y divide-gray-100 w-full bg-white">


### PR DESCRIPTION
This PR fixes the avatar size for students without picture.

### Student with picture ✅ 
![image](https://github.com/Simon-Initiative/oli-torus/assets/74839302/a9ffe856-3778-461d-b72a-c006e5295bac)

### Student without picture (before) ❌ 
![image](https://github.com/Simon-Initiative/oli-torus/assets/74839302/1aee0e1a-42db-430d-b2bd-cc32bbd73921)

### Student without picture (after) ✅ 
![image](https://github.com/Simon-Initiative/oli-torus/assets/74839302/ae2d1560-6660-47bf-a9fb-d53624a40959)
