### PR TITLE
[MER-2004] [Bugfix] Allow learner to complete flowchart based lessons

### DIFF
--- a/assets/src/apps/authoring/components/Flowchart/rules/rule-compilation.ts
+++ b/assets/src/apps/authoring/components/Flowchart/rules/rule-compilation.ts
@@ -168,6 +168,13 @@ const createBlankScreenRules = (
   sequence: SequenceEntry<SequenceEntryChild>[],
   defaultDestination: number,
 ): RulesAndVariables => {
+  if (screen.authoring?.flowchart?.screenType === 'end_screen') {
+    return {
+      rules: [defaultNextScreenRule()],
+      variables: [],
+    };
+  }
+
   //const notBlank = screen.authoring?.flowchart?.screenType !== 'blank';
   //notBlank && console.warn('Using generic blank screen rules for screen', screen);
   const paths = screen.authoring?.flowchart?.paths || [];


### PR DESCRIPTION
1. Create a flowchart based lesson 
2. Author the start & end screens
3. Preview the lesson
4. Progress past the last screen

Expected: End of lesson message is displayed, lesson ends
Actual: Lesson freezes up, next button goes blank

Cause: The end-screen needs a janus rule to navigate to the next screen, which the delivery engine will intercept since there is no next-screen and display the exit message & handle the completion. 