### PR TITLE
[FEATURE] [MER-1914] Enrolled students filter instructor dashboard

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -46,8 +46,6 @@ defmodule Oli.Delivery.Sections do
   require Logger
 
   def enrolled_students(section_slug) do
-    student_role_id = ContextRoles.get_role(:context_learner).id
-
     query =
       from(e in Enrollment,
         join: s in Section,
@@ -56,7 +54,7 @@ defmodule Oli.Delivery.Sections do
         on: e.id == ecr.enrollment_id,
         join: u in User,
         on: e.user_id == u.id,
-        where: s.slug == ^section_slug and ecr.context_role_id == ^student_role_id,
+        where: s.slug == ^section_slug,
         select: u
       )
 

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -42,23 +42,39 @@ defmodule Oli.Delivery.Sections do
   alias Oli.Delivery.Gating.GatingCondition
   alias Oli.Delivery.Attempts.Core.ResourceAccess
   alias Oli.Delivery.Metrics
+  alias Oli.Delivery.Paywall
 
   require Logger
 
   def enrolled_students(section_slug) do
-    query =
-      from(e in Enrollment,
-        join: s in Section,
-        on: e.section_id == s.id,
-        join: ecr in EnrollmentContextRole,
-        on: e.id == ecr.enrollment_id,
-        join: u in User,
-        on: e.user_id == u.id,
-        where: s.slug == ^section_slug,
-        select: u
-      )
+    section = get_section_by_slug(section_slug)
 
-    Repo.all(query)
+    from(e in Enrollment,
+      join: s in assoc(e, :section),
+      join: ecr in assoc(e, :context_roles),
+      join: u in assoc(e, :user),
+      left_join: p in Payment,
+      on: p.enrollment_id == e.id,
+      where: s.slug == ^section_slug,
+      select: {u, ecr.id, e, p},
+      preload: [user: :platform_roles],
+      distinct: u.id
+    )
+    |> Repo.all()
+    |> Enum.map(fn {user, context_role_id, enrollment, payment} ->
+      Map.merge(user, %{
+        enrollment_status: enrollment.status,
+        user_role_id: context_role_id,
+        payment_status:
+          Paywall.summarize_access(
+            enrollment.user,
+            section,
+            context_role_id,
+            enrollment,
+            payment
+          ).reason
+      })
+    end)
   end
 
   def browse_enrollments(
@@ -2618,11 +2634,11 @@ defmodule Oli.Delivery.Sections do
     |> join(:inner, [s], proj in Project, on: proj.id == s.base_project_id)
     |> where(
       [s, spp, _, pr, proj],
-      (s.slug == ^section_slug and
-         spp.project_id == s.base_project_id and
-         spp.section_id == s.id and
-         (pr.resource_id == s.required_survey_resource_id or
-         pr.resource_id == proj.required_survey_resource_id))
+      s.slug == ^section_slug and
+        spp.project_id == s.base_project_id and
+        spp.section_id == s.id and
+        (pr.resource_id == s.required_survey_resource_id or
+           pr.resource_id == proj.required_survey_resource_id)
     )
     |> select([_, _, _, rev], rev)
   end

--- a/lib/oli/delivery/sections/enrollment.ex
+++ b/lib/oli/delivery/sections/enrollment.ex
@@ -7,6 +7,7 @@ defmodule Oli.Delivery.Sections.Enrollment do
     belongs_to :section, Oli.Delivery.Sections.Section
 
     field :state, :map, default: %{}
+    field :status, Ecto.Enum, values: [:enrolled, :suspended], default: :enrolled
 
     many_to_many :context_roles, Lti_1p3.DataProviders.EctoProvider.ContextRole,
       join_through: "enrollments_context_roles",
@@ -18,7 +19,7 @@ defmodule Oli.Delivery.Sections.Enrollment do
   @doc false
   def changeset(enrollment, attrs) do
     enrollment
-    |> cast(attrs, [:user_id, :section_id, :state])
+    |> cast(attrs, [:user_id, :section_id, :state, :status])
     |> validate_required([:user_id, :section_id])
   end
 end

--- a/lib/oli_web/components/delivery/students/students.ex
+++ b/lib/oli_web/components/delivery/students/students.ex
@@ -81,37 +81,37 @@ defmodule OliWeb.Components.Delivery.Students do
     case dropdown_value do
       :enrolled ->
         Enum.filter(students, fn student ->
-          String.to_atom(String.downcase(student.enrollment_status)) == :enrolled and
+          student.enrollment_status == :enrolled and
             student.user_role_id == 4
         end)
 
       :suspended ->
         Enum.filter(students, fn student ->
-          String.to_atom(String.downcase(student.enrollment_status)) == :suspended and
+          student.enrollment_status == :suspended and
             student.user_role_id == 4
         end)
 
       :paid ->
         Enum.filter(students, fn student ->
-          String.to_atom(String.downcase(student.enrollment_status)) == :enrolled and
+          student.enrollment_status == :enrolled and
             student.user_role_id == 4 and student.payment_status == :paid
         end)
 
       :not_paid ->
         Enum.filter(students, fn student ->
-          String.to_atom(String.downcase(student.enrollment_status)) == :enrolled and
+          student.enrollment_status == :enrolled and
             student.user_role_id == 4 and student.payment_status == :not_paid
         end)
 
       :grace_period ->
         Enum.filter(students, fn student ->
-          String.to_atom(String.downcase(student.enrollment_status)) == :enrolled and
+          student.enrollment_status == :enrolled and
             student.user_role_id == 4 and student.payment_status == :within_grace_period
         end)
 
       :non_students ->
         Enum.filter(students, fn student ->
-          String.to_atom(String.downcase(student.enrollment_status)) == :enrolled and
+          student.enrollment_status == :enrolled and
             student.user_role_id != 4
         end)
 

--- a/lib/oli_web/components/delivery/students/students.ex
+++ b/lib/oli_web/components/delivery/students/students.ex
@@ -3,15 +3,14 @@ defmodule OliWeb.Components.Delivery.Students do
 
   alias Phoenix.LiveView.JS
 
-  alias OliWeb.Common.{PagedTable, SearchInput}
+  alias OliWeb.Common.{PagedTable, SearchInput, Params, Utils}
   alias OliWeb.Delivery.Sections.EnrollmentsTableModel
-  alias OliWeb.Common.Params
-  alias OliWeb.Common.Utils
   alias OliWeb.Router.Helpers, as: Routes
 
-  prop(params, :map, required: true)
-  prop(total_count, :number, required: true)
-  prop(table_model, :struct, required: true)
+  prop params, :map, required: true
+  prop total_count, :number, required: true
+  prop table_model, :struct, required: true
+  prop dropdown_options, :list, required: true
 
   @default_params %{
     offset: 0,
@@ -20,11 +19,18 @@ defmodule OliWeb.Components.Delivery.Students do
     page_id: nil,
     sort_order: :asc,
     sort_by: :name,
-    text_search: nil
+    text_search: nil,
+    filter_by: :enrolled
   }
 
   def update(
-        %{params: params, section: section, context: context, students: students} = _assigns,
+        %{
+          params: params,
+          section: section,
+          context: context,
+          students: students,
+          dropdown_options: dropdown_options
+        } = _assigns,
         socket
       ) do
     {total_count, rows} = apply_filters(students, params)
@@ -44,7 +50,8 @@ defmodule OliWeb.Components.Delivery.Students do
        total_count: total_count,
        table_model: table_model,
        params: params,
-       section_slug: section.slug
+       section_slug: section.slug,
+       dropdown_options: dropdown_options
      )}
   end
 
@@ -52,6 +59,7 @@ defmodule OliWeb.Components.Delivery.Students do
     students =
       students
       |> maybe_filter_by_text(params.text_search)
+      |> maybe_filter_by_option(params.filter_by)
       |> sort_by(params.sort_by, params.sort_order)
 
     {length(students), students |> Enum.drop(params.offset) |> Enum.take(params.limit)}
@@ -67,6 +75,49 @@ defmodule OliWeb.Components.Delivery.Students do
         String.downcase(text_search)
       )
     end)
+  end
+
+  defp maybe_filter_by_option(students, dropdown_value) do
+    case dropdown_value do
+      :enrolled ->
+        Enum.filter(students, fn student ->
+          String.to_atom(String.downcase(student.enrollment_status)) == :enrolled and
+            student.user_role_id == 4
+        end)
+
+      :suspended ->
+        Enum.filter(students, fn student ->
+          String.to_atom(String.downcase(student.enrollment_status)) == :suspended and
+            student.user_role_id == 4
+        end)
+
+      :paid ->
+        Enum.filter(students, fn student ->
+          String.to_atom(String.downcase(student.enrollment_status)) == :enrolled and
+            student.user_role_id == 4 and student.payment_status == :paid
+        end)
+
+      :not_paid ->
+        Enum.filter(students, fn student ->
+          String.to_atom(String.downcase(student.enrollment_status)) == :enrolled and
+            student.user_role_id == 4 and student.payment_status == :not_paid
+        end)
+
+      :grace_period ->
+        Enum.filter(students, fn student ->
+          String.to_atom(String.downcase(student.enrollment_status)) == :enrolled and
+            student.user_role_id == 4 and student.payment_status == :within_grace_period
+        end)
+
+      :non_students ->
+        Enum.filter(students, fn student ->
+          String.to_atom(String.downcase(student.enrollment_status)) == :enrolled and
+            student.user_role_id != 4
+        end)
+
+      _ ->
+        students
+    end
   end
 
   defp sort_by(students, sort_by, sort_order) do
@@ -102,9 +153,21 @@ defmodule OliWeb.Components.Delivery.Students do
   def render(assigns) do
     ~F"""
     <div class="mx-10 mb-10 bg-white shadow-sm">
-      <div class="flex flex-col sm:flex-row sm:items-center pr-6 bg-white">
-        <h4 class="pl-9 torus-h4 mr-auto">Students</h4>
-        <form for="search" phx-target={@myself} phx-change="search_student" class="pb-6 ml-9 sm:pb-0">
+      <div class="flex flex-col gap-y-4 items-center sm:flex-row sm:items-center px-6 py-4 border instructor_dashboard_table">
+        <h4 class="sm:pl-9 torus-h4 sm:mr-auto">Students</h4>
+        <div class="flex sm:items-end gap-2">
+          <form phx-change="filter_by" phx-target={@myself}>
+            <label class="cursor-pointer inline-flex flex-col gap-1">
+              <small class="torus-small uppercase">Filter by</small>
+              <select class="torus-select pr-32" name="filter">
+                {#for elem <- @dropdown_options}
+                  <option selected={@params.filter_by == elem.value} value={elem.value}>{elem.label}</option>
+                {/for}
+              </select>
+            </label>
+          </form>
+        </div>
+        <form for="search" phx-target={@myself} phx-change="search_student" class="sm:ml-9">
           <SearchInput.render id="students_search_input" name="student_name" text={@params.text_search} />
         </form>
       </div>
@@ -165,6 +228,20 @@ defmodule OliWeb.Components.Delivery.Students do
      )}
   end
 
+  def handle_event("filter_by", %{"filter" => filter}, socket) do
+    {:noreply,
+     push_patch(socket,
+       to:
+         Routes.live_path(
+           socket,
+           OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive,
+           socket.assigns.section_slug,
+           :students,
+           update_params(socket.assigns.params, %{filter_by: String.to_existing_atom(filter)})
+         )
+     )}
+  end
+
   def decode_params(params) do
     %{
       offset: Params.get_int_param(params, "offset", @default_params.offset),
@@ -180,7 +257,14 @@ defmodule OliWeb.Components.Delivery.Students do
           [:name, :last_interaction, :progress, :overall_mastery, :engagement],
           @default_params.sort_by
         ),
-      text_search: Params.get_param(params, "text_search", @default_params.text_search)
+      text_search: Params.get_param(params, "text_search", @default_params.text_search),
+      filter_by:
+        Params.get_atom_param(
+          params,
+          "filter_by",
+          [:enrolled, :suspended, :paid, :not_paid, :grace_period, :non_students],
+          @default_params.filter_by
+        )
     }
   end
 

--- a/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
@@ -2,10 +2,9 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive do
   use OliWeb, :live_view
   use OliWeb.Common.Modal
 
-  alias Oli.Delivery.{Metrics, Paywall, Sections}
+  alias Oli.Delivery.{Metrics, Sections}
   alias Oli.Publishing.DeliveryResolver
   alias Oli.Resources.Collaboration
-  alias Oli.Repo
   alias OliWeb.Components.Delivery.InstructorDashboard
 
   @impl Phoenix.LiveView
@@ -191,7 +190,6 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive do
         |> add_students_last_interaction(section, params.container_id)
         |> add_students_overall_mastery(section, params.container_id)
         |> add_students_engagement(section.slug)
-        |> add_enrollment_and_payment_data(section)
 
       page_id ->
         Sections.enrolled_students(section.slug)
@@ -199,7 +197,6 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive do
         |> add_students_last_interaction_for_page(section.slug, page_id)
         |> add_students_overall_mastery_for_page(section.slug, page_id)
         |> add_students_engagement_for_page(section.slug, page_id)
-        |> add_enrollment_and_payment_data(section)
     end
   end
 
@@ -320,23 +317,6 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive do
       Map.merge(student, %{
         engagement: Enum.random(["Low", "Medium", "High", "Not enough data"])
       })
-    end)
-  end
-
-  defp add_enrollment_and_payment_data(students, section) do
-    Enum.map(students, fn student ->
-      Map.merge(
-        student,
-        %{
-          enrollment_status:
-            if(Sections.is_enrolled?(student.id, section.slug), do: "Enrolled", else: "Suspended"),
-          payment_status:
-            Paywall.summarize_access(student |> Repo.preload(:platform_roles), section).reason,
-          user_role_id:
-            Sections.get_enrollment(section.slug, student.id)
-            |> Sections.get_user_role_from_enrollment()
-        }
-      )
     end)
   end
 

--- a/priv/repo/migrations/20230518010722_add_status_in_enrollment.exs
+++ b/priv/repo/migrations/20230518010722_add_status_in_enrollment.exs
@@ -1,0 +1,9 @@
+defmodule Oli.Repo.Migrations.AddStatusInEnrollment do
+  use Ecto.Migration
+
+  def change do
+    alter table(:enrollments) do
+      add :status, :string, default: "enrolled"
+    end
+  end
+end


### PR DESCRIPTION
[MER-1914](https://eliterate.atlassian.net/browse/MER-1914)

This PR adds a dropdown to filter students on the `students` tab in the instructor dashboard.
This new filter allows filtering students enrolled in the section, as well as users who are not students but are also enrolled in that section.
Also, if the section requires a payment, it allows filtering by those students who have paid, those who have not paid and those who have a grace period.

**_Students enrolled in the section_**

![Captura de pantalla 2023-05-12 a la(s) 11 51 39](https://github.com/Simon-Initiative/oli-torus/assets/16328384/738da14f-85fb-4a42-9f13-671257632891)

**_Non-students enrolled in the section_**

![Captura de pantalla 2023-05-12 a la(s) 11 51 47](https://github.com/Simon-Initiative/oli-torus/assets/16328384/fdac5fd7-82b5-4510-9130-2ac882162dd7)

**_Students who have paid for the section_**

![Captura de pantalla 2023-05-12 a la(s) 11 51 57](https://github.com/Simon-Initiative/oli-torus/assets/16328384/2bd23fe2-80a2-44e1-a93b-31d90a58f86b)




[MER-1914]: https://eliterate.atlassian.net/browse/MER-1914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ