### PR TITLE
[FEATURE] Remove redundant points display [MER-1986]

### DIFF
--- a/assets/src/components/activities/common/delivery/evaluation/Evaluation.tsx
+++ b/assets/src/components/activities/common/delivery/evaluation/Evaluation.tsx
@@ -74,25 +74,11 @@ interface ComponentProps {
 }
 
 const Component: React.FC<ComponentProps> = (props) => {
-  const scoreOrGraphic = props.graded ? (
-    (props.score || props.outOf) && (
-      <div className="result">
-        <span aria-label="score" className="score">
-          {props.score}
-        </span>
-        <span className="result-divider">/</span>
-        <span aria-label="out of" className="out-of">
-          {props.outOf}
-        </span>
-      </div>
-    )
-  ) : (
-    <div className="mr-2 mt-1">{graphicForResultClass(props.resultClass)}</div>
-  );
+  const graphic = <div className="mr-2">{graphicForResultClass(props.resultClass)}</div>
 
   return (
     <div aria-label="result" className={`evaluation feedback ${props.resultClass} my-1`}>
-      {scoreOrGraphic}
+      {graphic}
       {props.children}
       <div></div>
     </div>

--- a/assets/src/components/activities/common/delivery/evaluation/Evaluation.tsx
+++ b/assets/src/components/activities/common/delivery/evaluation/Evaluation.tsx
@@ -74,7 +74,7 @@ interface ComponentProps {
 }
 
 const Component: React.FC<ComponentProps> = (props) => {
-  const graphic = <div className="mr-2">{graphicForResultClass(props.resultClass)}</div>
+  const graphic = <div className="mr-2">{graphicForResultClass(props.resultClass)}</div>;
 
   return (
     <div aria-label="result" className={`evaluation feedback ${props.resultClass} my-1`}>


### PR DESCRIPTION
Removes the "per part" point display, in favor of only the graphic.  This allows the "Points: 0 out of 1" to be less confusing and not redundant.  