### PR TITLE
[MER-1988] add ability to reset practice page attempt

### DIFF
--- a/lib/oli/delivery/attempts/page_lifecycle.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle.ex
@@ -185,7 +185,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle do
 
   If the resource attempt is successfully finalized returns:
 
-  `{:ok, %ResourceAccess{}}`
+  `{:ok, %FinalizationSummary{}}`
 
   If the resource attempt has already been finalized:
 
@@ -217,11 +217,14 @@ defmodule Oli.Delivery.Attempts.PageLifecycle do
     case result do
       {:ok,
        %FinalizationSummary{
-         resource_access: resource_access,
+         graded: graded,
          part_attempt_guids: part_attempt_guids
-       }} ->
-        Snapshots.queue_or_create_snapshot(part_attempt_guids, section_slug)
-        {:ok, resource_access}
+       } = finalization_summary} ->
+        if graded do
+          Snapshots.queue_or_create_snapshot(part_attempt_guids, section_slug)
+        end
+
+        {:ok, finalization_summary}
 
       e ->
         e

--- a/lib/oli/delivery/attempts/page_lifecycle/finalization_summary.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/finalization_summary.ex
@@ -11,18 +11,21 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.FinalizationSummary do
   @enforce_keys [
     :resource_access,
     :part_attempt_guids,
-    :lifecycle_state
+    :lifecycle_state,
+    :graded
   ]
 
   defstruct [
     :resource_access,
     :part_attempt_guids,
-    :lifecycle_state
+    :lifecycle_state,
+    :graded
   ]
 
   @type t() :: %__MODULE__{
           resource_access: any(),
           part_attempt_guids: list(),
-          lifecycle_state: atom()
+          lifecycle_state: atom(),
+          graded: boolean()
         }
 end

--- a/lib/oli/delivery/attempts/page_lifecycle/graded.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/graded.ex
@@ -127,6 +127,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Graded do
 
               {:ok,
                %FinalizationSummary{
+                 graded: true,
                  lifecycle_state: :evaluated,
                  resource_access: resource_access,
                  part_attempt_guids: part_attempt_guids
@@ -139,6 +140,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Graded do
         %ResourceAttempt{lifecycle_state: :submitted, resource_access_id: resource_access_id} ->
           {:ok,
            %FinalizationSummary{
+             graded: true,
              lifecycle_state: :submitted,
              resource_access: Oli.Repo.get(ResourceAccess, resource_access_id),
              part_attempt_guids: part_attempt_guids

--- a/lib/oli/utils/db_seeder.ex
+++ b/lib/oli/utils/db_seeder.ex
@@ -23,6 +23,7 @@ defmodule Oli.Seeder do
   alias Oli.Activities
   alias Oli.Delivery.Gating
   alias Oli.Delivery.Attempts.PageLifecycle
+  alias Oli.Delivery.Attempts.PageLifecycle.FinalizationSummary
   alias Oli.Utils.Seeder.StudentAttemptSeed
   alias Oli.Delivery.Attempts.ActivityLifecycle.Evaluate
 
@@ -580,7 +581,8 @@ defmodule Oli.Seeder do
         create_sample_adaptive_page_content(activity_revision.resource_id)
       )
 
-    container_revision = attach_pages_to([page_resource], container.resource, container.revision, publication)
+    container_revision =
+      attach_pages_to([page_resource], container.resource, container.revision, publication)
 
     seed
     |> Map.put(:container, %{resource: container.resource, revision: container_revision})
@@ -1087,7 +1089,7 @@ defmodule Oli.Seeder do
     section_tag = Map.get(selector_tags, :section, :section)
     attempt_tag = Map.get(selector_tags, :attempt, :attempt)
 
-    {:ok, %ResourceAccess{} = resource_access} =
+    {:ok, %FinalizationSummary{resource_access: resource_access}} =
       PageLifecycle.finalize(
         map[section_tag].slug,
         map[attempt_tag].attempt_guid,

--- a/lib/oli/utils/seeder/attempt.ex
+++ b/lib/oli/utils/seeder/attempt.ex
@@ -123,7 +123,7 @@ defmodule Oli.Utils.Seeder.Attempt do
     [section, resource_attempt, datashop_session_id] =
       unpack(seeds, [section, resource_attempt, datashop_session_id])
 
-    submission_result =
+    {:ok, submission_result} =
       PageLifecycle.finalize(
         section.slug,
         resource_attempt.attempt_guid,

--- a/lib/oli_web/controllers/api/page_lifecycle_controller.ex
+++ b/lib/oli_web/controllers/api/page_lifecycle_controller.ex
@@ -33,13 +33,9 @@ defmodule OliWeb.Api.PageLifecycleController do
       when reason in [:already_submitted, :active_attempt_present, :no_more_attempts] ->
         command_failure(conn, reason, section_slug, revision_slug)
 
-      {:error, e} ->
-        error(e)
-        command_failure(conn, e, section_slug, revision_slug)
-
       e ->
         error(e)
-        command_failure(conn, e, section_slug, revision_slug)
+        command_failure(conn, "Unable to finalize page", section_slug, revision_slug)
     end
   end
 
@@ -53,7 +49,8 @@ defmodule OliWeb.Api.PageLifecycleController do
   end
 
   defp error(reason) do
-    Logger.error("Page finalization error encountered: #{reason}")
-    Oli.Utils.Appsignal.capture_error(reason)
+    error_msg = Kernel.inspect(reason)
+    Logger.error("Page finalization error encountered: #{error_msg}")
+    Oli.Utils.Appsignal.capture_error(error_msg)
   end
 end

--- a/lib/oli_web/controllers/api/page_lifecycle_controller.ex
+++ b/lib/oli_web/controllers/api/page_lifecycle_controller.ex
@@ -1,5 +1,6 @@
 defmodule OliWeb.Api.PageLifecycleController do
   use OliWeb, :controller
+  alias Oli.Delivery.Attempts.PageLifecycle.FinalizationSummary
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Attempts.PageLifecycle
   require Logger
@@ -13,10 +14,29 @@ defmodule OliWeb.Api.PageLifecycleController do
     datashop_session_id = Plug.Conn.get_session(conn, :datashop_session_id)
 
     case PageLifecycle.finalize(section_slug, attempt_guid, datashop_session_id) do
-      {:ok, %Oli.Delivery.Attempts.Core.ResourceAccess{id: id}} ->
+      {:ok,
+       %FinalizationSummary{
+         graded: true,
+         resource_access: %Oli.Delivery.Attempts.Core.ResourceAccess{id: id}
+       }} ->
+        # graded resource finalization success
         section = Sections.get_section_by(slug: section_slug)
         PageLifecycle.GradeUpdateWorker.create(section.id, id, :inline)
 
+        json(conn, %{
+          result: "success",
+          commandResult: "success",
+          redirectTo:
+            Routes.page_delivery_path(
+              conn,
+              :page,
+              section_slug,
+              revision_slug
+            )
+        })
+
+      {:ok, %FinalizationSummary{graded: false}} ->
+        # ungraded resource finalization success
         json(conn, %{
           result: "success",
           commandResult: "success",

--- a/lib/oli_web/live/ingest/ingestv2.ex
+++ b/lib/oli_web/live/ingest/ingestv2.ex
@@ -132,7 +132,7 @@ defmodule OliWeb.Admin.IngestV2 do
     ~F"""
       {#if @progress_step != ""}
       <div class="alert alert-secondary" role="alert">
-        <h4 class="alert-heading">{@progress_step}</h4>
+        <h4 class="alert-heading"><i class="fas fa-circle-notch fa-spin fa-1x fa-fw mr-2" /> {@progress_step}</h4>
 
       {#if @progress_total_tasks > 0}
         <div class="progress">

--- a/lib/oli_web/templates/page_delivery/page.html.heex
+++ b/lib/oli_web/templates/page_delivery/page.html.heex
@@ -60,8 +60,16 @@ window.userToken = "<%= assigns[:user_token] %>";
 
 <%= if @graded && @activity_count > 0 && @review_mode == false do %>
   <div class="d-flex align-items-center justify-content-center">
-    <button id="submit_answers" class="btn btn-primary btn-lg text-center" onClick={"window.OLI.finalize('#{@section_slug}', '#{@slug}', '#{@attempt_guid}', 'submit_answers')"}>
+    <button id="submit_answers" class="btn btn-primary btn-lg text-center" onClick={"window.OLI.finalize('#{@section_slug}', '#{@slug}', '#{@attempt_guid}', #{@graded}, 'submit_answers')"}>
       Submit Answers
+    </button>
+  </div>
+<% end %>
+
+<%= if @graded == false && @activity_count > 0 && @review_mode == false do %>
+  <div class="d-flex align-items-center justify-content-center">
+    <button id="reset_answers" class="btn btn-link btn-sm text-center" onClick={"window.OLI.finalize('#{@section_slug}', '#{@slug}', '#{@attempt_guid}', #{@graded}, 'reset_answers')"}>
+      <i class="fa-solid fa-rotate-right mr-2"></i> Reset Answers
     </button>
   </div>
 <% end %>

--- a/test/oli/delivery/attempts/page_lifecycle_test.exs
+++ b/test/oli/delivery/attempts/page_lifecycle_test.exs
@@ -3,7 +3,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycleTest do
 
   alias Oli.Delivery.Attempts.PageLifecycle
   alias Oli.Delivery.Attempts.Core
-  alias Oli.Delivery.Attempts.Core.ResourceAccess
+  alias Oli.Delivery.Attempts.PageLifecycle.FinalizationSummary
   alias Oli.Activities.Model.{Part}
 
   @content_automatic_by_default %{
@@ -137,10 +137,10 @@ defmodule Oli.Delivery.Attempts.PageLifecycleTest do
     } do
       datashop_session_id_user1 = UUID.uuid4()
 
-      {:ok, %ResourceAccess{} = resource_access1} =
+      {:ok, %FinalizationSummary{resource_access: resource_access1}} =
         PageLifecycle.finalize(section.slug, attempt1.attempt_guid, datashop_session_id_user1)
 
-      {:ok, %ResourceAccess{} = resource_access2} =
+      {:ok, %FinalizationSummary{resource_access: resource_access2}} =
         PageLifecycle.finalize(section.slug, attempt2.attempt_guid, datashop_session_id_user1)
 
       ra1 = Core.get_resource_attempt_by(attempt_guid: attempt1.attempt_guid)
@@ -200,13 +200,12 @@ defmodule Oli.Delivery.Attempts.PageLifecycleTest do
       assert is_nil(ra1.date_evaluated)
       assert is_nil(ra1.date_submitted)
 
-      {:ok, %ResourceAccess{} = resource_access1} =
+      {:ok, %FinalizationSummary{graded: false}} =
         PageLifecycle.finalize(section.slug, attempt1.attempt_guid, datashop_session_id_user1)
 
       ra1 = Core.get_resource_attempt_by(attempt_guid: attempt1.attempt_guid)
 
       # Attempt 1 should be in an "evaluated" state, with a nil score since it was ungraded
-      assert is_nil(resource_access1.score)
       assert ra1.lifecycle_state == :evaluated
       refute is_nil(ra1.date_evaluated)
       refute is_nil(ra1.date_submitted)

--- a/test/oli/delivery/submission_test.exs
+++ b/test/oli/delivery/submission_test.exs
@@ -11,6 +11,7 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
   alias Oli.Delivery.Attempts.Core.{ResourceAccess, ActivityAttempt, PartAttempt, StudentInput}
   alias Oli.Delivery.Snapshots.Snapshot
   alias Oli.Delivery.Page.PageContext
+  alias Oli.Delivery.Attempts.PageLifecycle.FinalizationSummary
 
   describe "concurrent activity accesses with two students" do
     setup do
@@ -206,7 +207,7 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
       ])
 
       # Make sure user 2 can submit the page
-      {:ok, access} =
+      {:ok, %FinalizationSummary{resource_access: access}} =
         PageLifecycle.finalize(
           section.slug,
           user2_resource_attempt.attempt_guid,


### PR DESCRIPTION
Adds the ability to reset all activities on an ungraded page by finalizing the resource attempt and creating a new one on subsequent access, similar to how graded pages work except no scores are recorded.

<img width="1144" alt="Screenshot 2023-05-16 at 3 00 39 PM" src="https://github.com/Simon-Initiative/oli-torus/assets/6248894/4a3e96b2-6aa2-428d-82a4-8f0418dd3303">
