### PR TITLE
[FEATURE] Redirect to display review attempt page [MER-1999]

### DIFF
--- a/lib/oli_web/controllers/api/page_lifecycle_controller.ex
+++ b/lib/oli_web/controllers/api/page_lifecycle_controller.ex
@@ -17,16 +17,15 @@ defmodule OliWeb.Api.PageLifecycleController do
         section = Sections.get_section_by(slug: section_slug)
         PageLifecycle.GradeUpdateWorker.create(section.id, id, :inline)
 
+        review_attempt_path = Routes.page_delivery_path(conn, :review_attempt, section_slug, revision_slug, attempt_guid)
+
+        # page path will be the route when users are not allowed to review their attempts
+        # page_path = Routes.page_delivery_path(conn, :page, section_slug, revision_slug)
+
         json(conn, %{
           result: "success",
           commandResult: "success",
-          redirectTo:
-            Routes.page_delivery_path(
-              conn,
-              :page,
-              section_slug,
-              revision_slug
-            )
+          redirectTo: review_attempt_path
         })
 
       {:error, {reason}}


### PR DESCRIPTION
After completing a graded page attempt, the review attempt now displays, not the page that lists all attempt history. 

I preserved in a comment the path for the attempt history, as very soon that will need to be the path used when "review answers" for a page is not allowed. 