### PR TITLE
[MER-1978] Block list items

### DIFF
--- a/assets/src/components/editing/editor/handlers/lists.ts
+++ b/assets/src/components/editing/editor/handlers/lists.ts
@@ -1,18 +1,48 @@
 import { KeyboardEvent } from 'react';
-import { Element, Node, Path, Point, Range, Editor as SlateEditor, Text, Transforms } from 'slate';
+import {
+  Editor,
+  Element,
+  Node,
+  Path,
+  Point,
+  Range,
+  Editor as SlateEditor,
+  Text,
+  Transforms,
+} from 'slate';
+import { Location } from 'slate';
 import { Model } from 'data/content/model/elements/factories';
 import { OrderedList, UnorderedList } from 'data/content/model/elements/types';
 import { ListItem } from '../../../../data/content/model/elements/types';
+import { findNearestBlock } from '../../slateUtils';
 
 // The key down handler required to allow special list processing.
 export const onKeyDown = (editor: SlateEditor, e: KeyboardEvent) => {
-  if (e.key === 'Tab' && e.shiftKey) {
-    handleOutdent(editor, e);
-  } else if (e.key === 'Tab' && !e.shiftKey) {
-    handleIndent(editor, e);
-  } else if (e.key === 'Enter') {
-    handleTermination(editor, e);
+  try {
+    if (e.key === 'Tab' && e.shiftKey && isInsideList(editor)) {
+      handleOutdent(editor, e);
+    } else if (e.key === 'Tab' && !e.shiftKey && isInsideList(editor)) {
+      handleIndent(editor, e);
+    } else if (e.key === 'Enter' && isInsideList(editor)) {
+      if (e.shiftKey) {
+        // Inside a list, shift+enter should behave as a default enter press.
+        e.shiftKey = false;
+        return;
+      }
+      handleEnter(editor, e);
+    }
+  } catch (e) {
+    console.error('editor.handlers.lists::onKeyDown failed with:', e);
   }
+};
+
+// Returns true if any parent is a list.
+const isInsideList = (editor: SlateEditor) => {
+  const [match] = SlateEditor.nodes(editor, {
+    match: (n) => Element.isElement(n) && (n.type === 'ul' || n.type === 'ol'),
+  });
+
+  return !!match;
 };
 
 const isList = (n: Node): n is UnorderedList | OrderedList =>
@@ -93,43 +123,150 @@ export function handleOutdent(editor: SlateEditor, e?: KeyboardEvent) {
   }
 }
 
-// Handles pressing enter on an empty list item to turn it
-// This handler should fail fast - given that every enter press
-// in the editor passes through it
-function handleTermination(editor: SlateEditor, e: KeyboardEvent) {
+const isLastListItem = (editor: SlateEditor, listItemPath: Path) => {
+  const [listItem] = SlateEditor.node(editor, listItemPath);
+  const [list] = SlateEditor.parent(editor, listItemPath);
+  return list.children[list.children.length - 1] === listItem;
+};
+
+// Empty = A node with a single paragraph child that contains no text.
+const isEmpty = (node: any) =>
+  node.children?.length === 1 &&
+  node.children[0].type === 'p' &&
+  node.children[0].children?.length === 1 &&
+  Text.isText(node.children[0].children[0]) &&
+  ((node.children[0].children[0].text || '') as string).trim() === '';
+
+// Handles pressing enter on an list item.
+//   - On empty - terminate the list
+//   - On Content - create a new list item
+function handleEnter(editor: SlateEditor, e: KeyboardEvent) {
   if (editor.selection && Range.isCollapsed(editor.selection)) {
-    const [match] = SlateEditor.nodes<ListItem>(editor, {
+    const [listItemMatch] = SlateEditor.nodes<ListItem>(editor, {
       match: (n) => Element.isElement(n) && n.type === 'li',
     });
 
-    if (match) {
-      const [node, path] = match;
-
-      if (
-        node.children.length === 1 &&
-        Text.isText(node.children[0]) &&
-        node.children[0].text === ''
-      ) {
-        const parentMatch = SlateEditor.parent(editor, path);
-        const [parent, parentPath] = parentMatch;
-        const grandParentMatch = SlateEditor.parent(editor, parentPath);
-        const [grandParent] = grandParentMatch;
-
-        // If we are in a nested list we want to simply outdent
-        if (isList(grandParent) && isList(parent)) {
-          handleOutdent(editor, e);
-        } else {
-          // otherwise, remove the list item and add a paragraph
-          // outside of the parent list
-          Transforms.removeNodes(editor, { at: path });
-
-          // Insert it ahead of the next node
-          Transforms.insertNodes(editor, Model.p(), { at: Path.next(parentPath) });
-          Transforms.select(editor, Path.next(parentPath));
-
-          e.preventDefault();
-        }
+    if (listItemMatch) {
+      const [listItemNode, listItemPath] = listItemMatch;
+      if (isEmpty(listItemNode) && isLastListItem(editor, listItemPath)) {
+        // TODO: We should only terminate if it's the last list item, right now, this does weird things when hitting enter on an empty LI in the middle of the list.
+        console.info('Terminate list');
+        terminateList(editor, listItemPath, e);
+      } else {
+        console.info('append list item');
+        createListItem(editor, listItemPath, e);
       }
     }
   }
 }
+
+const isAtStartOfListItem = (editor: SlateEditor, listItemPath: Path) => {
+  if (!editor.selection) return false;
+  try {
+    const end = SlateEditor.start(editor, listItemPath);
+    return Point.equals(editor.selection.anchor, end);
+  } catch (e) {
+    return false;
+  }
+};
+
+const isAtEndOfListItem = (editor: SlateEditor, listItemPath: Path) => {
+  if (!editor.selection) return false;
+  try {
+    const end = SlateEditor.end(editor, listItemPath);
+    return Point.equals(editor.selection.anchor, end);
+  } catch (e) {
+    return false;
+  }
+};
+
+const createListItem = (editor: SlateEditor, listItemPath: Path, e: KeyboardEvent) => {
+  const [listItem] = SlateEditor.node(editor, listItemPath);
+
+  // If we have a list item, split it into two list items
+  if (listItem && editor.selection) {
+    //const [current, path] = listItemPath;
+    e.preventDefault();
+
+    // If the cursor is at the beginning of a list item
+    if (isAtStartOfListItem(editor, listItemPath)) {
+      console.info('Inserting LI before current LI', listItemPath);
+      Transforms.insertNodes(editor, Model.li(), { at: listItemPath });
+    } else if (isAtEndOfListItem(editor, listItemPath)) {
+      console.info('Inserting LI after current LI', listItemPath);
+      Editor.withoutNormalizing(editor, () => {
+        const newListItemPath = Path.next(listItemPath);
+        Transforms.insertNodes(editor, Model.li(), { at: newListItemPath, select: true });
+      });
+    } else {
+      console.info('MID?');
+      const nearestBlock = findNearestBlock(editor);
+      if (!nearestBlock) return;
+      console.info({ nearestBlock });
+      Editor.withoutNormalizing(editor, () => {
+        const [, /*bottomElement*/ bottomElementPath] = nearestBlock;
+        const newListItemPath = Path.next(listItemPath);
+        console.info('Children start', editor.children[1]);
+
+        // Split the current block into two blocks, the second one gets moved into the new LI below.
+        Transforms.splitNodes(editor);
+        console.info('Children after split', editor.children[1]);
+
+        // A new list item that we'll move content into.
+        Transforms.insertNodes(editor, Model.li(), {
+          at: newListItemPath,
+        });
+        console.info('Children after insert li', editor.children[1]);
+
+        const newlySplitNodePath = Path.next(bottomElementPath);
+        let count = 0;
+        while (Node.has(editor, newlySplitNodePath)) {
+          /* Need the while loop because there might be multiple block elements that need to be moved. Imaging a paragraph followed by an image, and
+             the cursor is in the middle of the paragraph.
+
+             Starts as:  <li><p>Some text</p><img /></li>
+             Then we add an empty li: <li><p>Some text</p><img /></li><li></li>
+             Then the p gets split: <li><p>Some</p><p>text</p><img /></li>
+                 That new p is now at path newlySplitNodePath
+             Then we move the second p into the new li: <li><p>Some</p></li><li><p>text</p><img /></li>
+                 Now, the image is at newlySplitNodePath because the node before it was moved.
+             Then we move the img into the new li: <li><p>Some</p></li><li><p>text</p><img /></li>
+          */
+          Transforms.moveNodes(editor, {
+            at: newlySplitNodePath,
+            to: [...newListItemPath, count++],
+          });
+          console.info('Children after move', editor.children[1]);
+        }
+
+        Transforms.removeNodes(editor, { at: [...newListItemPath, count] }); // Get rid of the empty paragraph, can't do this before moving in nodes or slate errors.
+        Transforms.select(editor, {
+          path: [...newListItemPath, 0, 0],
+          offset: 0,
+        }); // Put cursor in right spot
+        console.info('Children after trim', editor.children[1]);
+      });
+    }
+  }
+};
+
+const terminateList = (editor: SlateEditor, listItemPath: Location, e: KeyboardEvent) => {
+  const parentMatch = SlateEditor.parent(editor, listItemPath);
+  const [parent, parentPath] = parentMatch;
+  const grandParentMatch = SlateEditor.parent(editor, parentPath);
+  const [grandParent] = grandParentMatch;
+
+  // If we are in a nested list we want to simply outdent
+  if (isList(grandParent) && isList(parent)) {
+    handleOutdent(editor, e);
+  } else {
+    // otherwise, remove the list item and add a paragraph
+    // outside of the parent list
+    Transforms.removeNodes(editor, { at: listItemPath });
+
+    // Insert it ahead of the next node
+    Transforms.insertNodes(editor, Model.p(), { at: Path.next(parentPath) });
+    Transforms.select(editor, Path.next(parentPath));
+    e.preventDefault();
+  }
+};

--- a/assets/src/components/editing/editor/handlers/lists.ts
+++ b/assets/src/components/editing/editor/handlers/lists.ts
@@ -105,13 +105,13 @@ export function handleOutdent(editor: SlateEditor, e?: KeyboardEvent) {
     });
 
     if (match) {
-      const [, path] = match;
-      const start = SlateEditor.start(editor, path);
+      const [, listItemPath] = match;
+      const start = SlateEditor.start(editor, listItemPath);
 
       // If the cursor is at the beginning of a list item
       if (Point.equals(editor.selection.anchor, start)) {
         // Check to see if the list item is in a nested list
-        const parentMatch = SlateEditor.parent(editor, path);
+        const parentMatch = SlateEditor.parent(editor, listItemPath);
         const [parent, parentPath] = parentMatch;
         const grandParentMatch = SlateEditor.parent(editor, parentPath);
         const [grandParent] = grandParentMatch;
@@ -119,7 +119,7 @@ export function handleOutdent(editor: SlateEditor, e?: KeyboardEvent) {
         if (isList(grandParent) && isList(parent)) {
           // Lift the current node up one level, effectively promoting
           // it up as a list item into the parent list
-          Transforms.liftNodes(editor, { at: editor.selection });
+          Transforms.liftNodes(editor, { at: listItemPath });
           e?.preventDefault();
         }
       }

--- a/assets/src/components/editing/editor/normalizers/lists.ts
+++ b/assets/src/components/editing/editor/normalizers/lists.ts
@@ -12,6 +12,15 @@ export const normalize = (
   const [parent] = Editor.parent(editor, path);
   if (Element.isElement(parent)) {
     const config = schema[parent.type];
+
+    if (parent.type === 'li') {
+      if (Text.isText(node)) {
+        Transforms.wrapNodes(editor, Model.p(), { at: path });
+        console.warn('🔥 Normalizing content: Wrapping text in list item with paragraph');
+        return true;
+      }
+    }
+
     if (['ol', 'ul'].includes(parent.type)) {
       if (Text.isText(node)) {
         Transforms.wrapNodes(editor, Model.li(), { at: path });

--- a/assets/src/components/editing/editor/normalizers/lists.ts
+++ b/assets/src/components/editing/editor/normalizers/lists.ts
@@ -16,7 +16,7 @@ export const normalize = (
     if (parent.type === 'li') {
       if (Text.isText(node)) {
         Transforms.wrapNodes(editor, Model.p(), { at: path });
-        console.warn('🔥 Normalizing content: Wrapping text in list item with paragraph');
+        console.warn('Normalizing content: Wrapping text in list item with paragraph');
         return true;
       }
     }

--- a/assets/src/components/editing/editor/normalizers/lists.ts
+++ b/assets/src/components/editing/editor/normalizers/lists.ts
@@ -19,8 +19,9 @@ export const normalize = (
         return true;
       }
       if (Element.isElement(node) && !config.validChildren[node.type]) {
-        Transforms.setNodes(editor, { type: 'li' }, { at: path });
-        console.warn('Normalizing content: Changing node in list to list item type');
+        //Transforms.setNodes(editor, { type: 'li' }, { at: path });
+        Transforms.wrapNodes(editor, Model.li(), { at: path });
+        console.warn('Normalizing content: Wrapping node in list to list item type');
         return true;
       }
     }

--- a/assets/src/components/editing/elements/commands/toggleTextTypes.ts
+++ b/assets/src/components/editing/elements/commands/toggleTextTypes.ts
@@ -49,11 +49,13 @@ const convert = (type: any, editor: Editor) => {
       { match: (e) => Element.isElement(e) && e.type === 'p', at: editor.selection },
     );
   } else if (isList(type)) {
-    Transforms.setNodes(
-      editor,
-      { type: 'li' },
-      { match: (e) => Element.isElement(e) && e.type === 'p', mode: 'all' },
-    );
+    const newListItem = Model.li();
+    newListItem.children = [];
+
+    Transforms.wrapNodes(editor, newListItem, {
+      match: (e) => Element.isElement(e) && e.type === 'p',
+      mode: 'all',
+    });
     Transforms.wrapNodes(editor, Model.ul(), {
       match: (e) => Element.isElement(e) && e.type === 'li',
       mode: 'all',

--- a/assets/src/components/editing/elements/image/imageActions.tsx
+++ b/assets/src/components/editing/elements/image/imageActions.tsx
@@ -75,12 +75,13 @@ const insertAction = (
   at: BaseSelection,
   type: 'img' | 'img_inline',
   src: undefined | string = undefined,
-) =>
-  Transforms.insertNodes(
+) => {
+  return Transforms.insertNodes(
     editor,
     type === 'img' ? Model.image(src) : Model.imageInline(src),
     at ? { at } : undefined,
   );
+};
 
 // Block images insert the placeholder block by default
 const execute =

--- a/assets/src/components/editing/elements/list/listActions.tsx
+++ b/assets/src/components/editing/elements/list/listActions.tsx
@@ -6,6 +6,7 @@ import { Command, CommandDescription } from 'components/editing/elements/command
 import { switchType } from 'components/editing/elements/commands/toggleTextTypes';
 import { isActive, isTopLevel } from 'components/editing/slateUtils';
 import guid from 'utils/guid';
+import { Model } from '../../../../data/content/model/elements/factories';
 import {
   OrderedListStyle,
   OrderedListStyles,
@@ -21,7 +22,10 @@ const listCommandMaker = (listType: 'ul' | 'ol'): Command => {
 
         // Not a list, create one
         if (!active) {
-          Transforms.setNodes(editor, { type: 'li' });
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const newListItem = Model.li();
+          newListItem.children = [];
+          Transforms.wrapNodes(editor, newListItem);
           Transforms.wrapNodes(editor, { type: listType, id: guid(), children: [] });
           return;
         }
@@ -48,6 +52,7 @@ const listCommandMaker = (listType: 'ul' | 'ol'): Command => {
 
         // Transforms.setNodes(editor, { type: 'p' });
       });
+      Editor.normalize(editor, { force: true });
     },
     precondition: (editor) => {
       return (isTopLevel(editor) && isActive(editor, ['p'])) || isActiveList(editor);

--- a/assets/src/components/editing/slateUtils.tsx
+++ b/assets/src/components/editing/slateUtils.tsx
@@ -102,11 +102,16 @@ export const safeToDOMNode = (editor: Editor, node: Node): Maybe<HTMLElement> =>
 // For the current selection, walk up through the data model to find the
 // immediate block parent.
 export const getNearestBlock = (editor: Editor): Maybe<ModelElement> => {
+  const block: NodeEntry<ModelElement> | undefined = findNearestBlock(editor);
+  if (block) return Maybe.just(block[0]);
+  return Maybe.nothing();
+};
+
+export const findNearestBlock = (editor: Editor): NodeEntry<ModelElement> | undefined => {
   const block: NodeEntry<ModelElement> | undefined = Editor.above(editor, {
     match: (n) => Editor.isBlock(editor, n),
   });
-  if (block) return Maybe.just(block[0]);
-  return Maybe.nothing();
+  return block;
 };
 
 export const isActive = (editor: Editor, type: string | string[]) => {

--- a/assets/src/components/editing/toolbar/editorToolbar/blocks/BlockSettings.tsx
+++ b/assets/src/components/editing/toolbar/editorToolbar/blocks/BlockSettings.tsx
@@ -32,8 +32,14 @@ export const BlockSettings = (_props: BlockSettingProps) => {
     'Code Block': CodeBlock,
   };
 
-  if (component[type] !== undefined) {
-    return <Toolbar.Group>{(component[type] as any)()}</Toolbar.Group>;
+  const Component = component[type];
+
+  if (Component) {
+    return (
+      <Toolbar.Group>
+        <Component />
+      </Toolbar.Group>
+    );
   }
   return null;
 };

--- a/assets/src/data/content/model/elements/factories.ts
+++ b/assets/src/data/content/model/elements/factories.ts
@@ -30,6 +30,7 @@ import {
   ImageInline,
   InputRef,
   ListItem,
+  ModelElement,
   OrderedList,
   PageLink,
   Paragraph,
@@ -56,6 +57,12 @@ function create<E extends AllModelElements>(params: Partial<E>): E {
     ...params,
   } as E;
 }
+
+export const emptyChildren = (element: AllModelElements) =>
+  ({
+    ...element,
+    children: [],
+  } as ModelElement);
 
 export const Model = {
   h1: (text = '') => create<HeadingOne>({ type: 'h1', children: [{ text }] }),

--- a/assets/src/data/content/model/elements/factories.ts
+++ b/assets/src/data/content/model/elements/factories.ts
@@ -72,7 +72,7 @@ export const Model = {
 
   table: (children: TableRow[]) => create<Table>({ type: 'table', children }),
 
-  li: () => create<ListItem>({ type: 'li' }),
+  li: (text = '') => create<ListItem>({ type: 'li', children: [Model.p(text)] }),
 
   ol: () => create<OrderedList>({ type: 'ol', children: [Model.li()] }),
 

--- a/assets/src/data/content/model/elements/types.ts
+++ b/assets/src/data/content/model/elements/types.ts
@@ -364,7 +364,7 @@ export interface TableConjugation extends TableCellType {
   pronouns?: string;
 }
 
-export interface ListItem extends SlateElement<(List | Text)[]> {
+export interface ListItem extends SlateElement<(Block | Inline | MediaBlock | TextBlock)[]> {
   type: 'li';
 }
 

--- a/assets/src/data/content/model/schema.ts
+++ b/assets/src/data/content/model/schema.ts
@@ -232,7 +232,12 @@ export const schema: Schema = {
     isVoid: false,
     isBlock: true,
     isTopLevel: false,
-    validChildren: toObj(['ol', 'ul']),
+    validChildren: toObj([
+      ...BlockElements,
+      ...MediaElements,
+      ...TextBlockElements,
+      ...SemanticElements,
+    ]), //toObj(['ol', 'ul']),
   },
   math: {
     isVoid: false,

--- a/assets/styles/common/elements.scss
+++ b/assets/styles/common/elements.scss
@@ -105,7 +105,6 @@ $element-margin-bottom: 1.5em;
     list-style: disc;
     // Nested lists without a style specified go disc->circle->square then back to disc for the rest as they indent
     ul {
-      margin-bottom: 0px; // Nested lists should not have margin
       list-style: circle;
       ul {
         list-style: square;
@@ -117,9 +116,6 @@ $element-margin-bottom: 1.5em;
   }
 
   ol {
-    ol {
-      margin-bottom: 0px; // Nested lists should not have margin
-    }
     padding-left: 1.5em;
     margin-bottom: $element-margin-bottom;
     list-style: decimal;
@@ -128,6 +124,14 @@ $element-margin-bottom: 1.5em;
   ul li,
   ol li {
     margin-bottom: 0.25rem;
+  }
+
+  ul,
+  ol {
+    ul,
+    ol {
+      margin-bottom: 0px; // Nested lists should not have bottom margin
+    }
   }
 
   .dl-title {

--- a/assets/styles/common/elements.scss
+++ b/assets/styles/common/elements.scss
@@ -105,6 +105,7 @@ $element-margin-bottom: 1.5em;
     list-style: disc;
     // Nested lists without a style specified go disc->circle->square then back to disc for the rest as they indent
     ul {
+      margin-bottom: 0px; // Nested lists should not have margin
       list-style: circle;
       ul {
         list-style: square;
@@ -116,6 +117,9 @@ $element-margin-bottom: 1.5em;
   }
 
   ol {
+    ol {
+      margin-bottom: 0px; // Nested lists should not have margin
+    }
     padding-left: 1.5em;
     margin-bottom: $element-margin-bottom;
     list-style: decimal;

--- a/priv/schemas/v0-1-0/content-element.schema.json
+++ b/priv/schemas/v0-1-0/content-element.schema.json
@@ -450,7 +450,7 @@
                 "$ref": "#/$defs/inline"
               },
               {
-                "$ref": "#/$defs/list"
+                "$ref": "#/$defs/block"
               }
             ]
           }


### PR DESCRIPTION
This PR allows block elements inside list items.

One important change to note here, is I had to start wrapping text nodes inside list items in a paragraph. That will happen in a normalization pass for any existing content the first time it's edited. I haven't seen any visual differences, but it's a possibility.

Since pressing enter in a LI crates a new list item, an author can now create multiple paragraphs inside an LI by pressing shift-enter. 

I am not currently inserting leading and trailing paragraphs around block items. So if you have some text, then insert a block image, it will be difficult to type in the same list item after that image.  I think this best preserves the visual appearance we want in most scenarios. An author can work around this by typing in the content they want then inserting an image in the middle of that text to break it into two.

These interactions should all work:

- Pressing enter at the start of a list item creates a new empty list item "before" the current one.
- Pressing enter on an empty list item that is the last one of the list, gets rid of the empty LI and closes the list.
- Pressing enter at the end of a list item creates a new after it
- Pressing enter in the middle of a list item, splits the content into 2 different list items. Before, this was always 2 text nodes. Now it may be multiple block elements.
- Pressing shift-enter to create a new paragraph within a LI
- Pressing tab / shift-tab at the start of a LI indents or outdents the item
- The list item toolbar items all work
   - I changed the behavior of indent/outdent so the toolbar items do this no matter where they are in the list item, before they operated like the keyboard events and only worked at the start of the item.

