### PR TITLE
[BUG FIX] Fixes for assignments view rendering problems

### DIFF
--- a/lib/oli_web/components/delivery/assignments/assignment_card.ex
+++ b/lib/oli_web/components/delivery/assignments/assignment_card.ex
@@ -4,16 +4,13 @@ defmodule OliWeb.Components.Delivery.AssignmentCard do
   alias OliWeb.Router.Helpers, as: Routes
 
   defp due_date_label(assignment) do
-    case assignment.gate_type do
-      nil ->
-        case assignment.scheduled_type do
-          :read_by -> "Suggested by"
-          _ -> "In class activity"
-        end
 
-      _ ->
-        "Due by"
+    case assignment.scheduled_type do
+      :due_by -> "Due by"
+      :read_by -> "Read by"
+      _ -> "In class activity"
     end
+
   end
 
   def render(assigns) do
@@ -28,9 +25,9 @@ defmodule OliWeb.Components.Delivery.AssignmentCard do
             <h3 class="text-white text-xl"><%= @assignment.title %></h3>
           </div>
           <div class="flex gap-2">
-            <span class="bg-white bg-opacity-10 rounded-sm text-white text-center w-56 py-2">
+            <span class="bg-white bg-opacity-10 rounded-sm text-white text-center w-110 p-2">
               <%= if @assignment.end_date do %>
-                <%= due_date_label(@assignment) %> <%= @assignment.end_date %>
+                <%= due_date_label(@assignment) %> <%= @format_datetime_fn.(@assignment.end_date) %>
               <% else %>
                 No due date
               <% end %>
@@ -82,7 +79,7 @@ defmodule OliWeb.Components.Delivery.AssignmentCard do
         <td class="w-1/3 border-none"><%= @page.title %></td>
         <td class={"w-1/3 border-none text-center #{if !@page.progress, do: "text-red-600"}"}>
           <%= if @page.progress do %>
-            <%= @page.progress %>% Completed
+            <%= (@page.progress * 100.0) %>% Completed
           <% else %>
             Not attempted
           <% end %>

--- a/lib/oli_web/components/delivery/assignments/assignments_list.ex
+++ b/lib/oli_web/components/delivery/assignments/assignments_list.ex
@@ -10,7 +10,7 @@ defmodule OliWeb.Components.Delivery.AssignmentsList do
       <p>Find all your assignments, quizzes and activities associated with graded material.</p>
       <div class="flex flex-col gap-4 mt-6">
       <%= for assignment <- @assignments do %>
-        <AssignmentCard.render assignment={assignment} section_slug={@section_slug}/>
+        <AssignmentCard.render assignment={assignment} section_slug={@section_slug} format_datetime_fn={@format_datetime_fn}/>
       <% end %>
       </div>
     </div>

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -157,7 +157,8 @@ defmodule OliWeb.PageDeliveryController do
         "assignments.html",
         assignments: assignments,
         section_slug: section_slug,
-        preview_mode: false
+        preview_mode: false,
+        format_datetime_fn: format_datetime_fn(conn)
       )
     else
       case section do


### PR DESCRIPTION
In prepping to demo this, discovered and fixed a few issues:

1. `gate_type` was still being used to determine gate type.  Now only `:scheduling_type` from the SR is needed
2. Percentages were shown as `0.0 %` to `1.0 %`.  Multiplied by `100` to fix
3. DateTimes were not formatted correctly