### PR TITLE
[ENHANCEMENT] Ensure editing of start end dates available to both LTI and open and free [MER-1984] [MER-1953]

### DIFF
--- a/lib/oli_web/live/sections/edit_view.ex
+++ b/lib/oli_web/live/sections/edit_view.ex
@@ -2,6 +2,7 @@ defmodule OliWeb.Sections.EditView do
   use Surface.LiveView, layout: {OliWeb.LayoutView, "live.html"}
 
   alias Oli.Branding
+  alias OliWeb.Sections.StartEnd
   alias Oli.Delivery.Sections
   alias OliWeb.Common.{Breadcrumb, SessionContext, FormatDateTime, CustomLabelsForm}
   alias OliWeb.Common.Properties.{Groups, Group}
@@ -78,12 +79,16 @@ defmodule OliWeb.Sections.EditView do
         <Group label="Settings" description="Manage the course section settings">
           <MainDetails changeset={@changeset} disabled={false}  is_admin={@is_admin} brands={@brands} />
         </Group>
+        <Group label="Schedule" description="Edit the start and end dates for scheduling purposes">
+          <StartEnd id="start_end_editing" changeset={@changeset} disabled={false} is_admin={@is_admin} context={@context}/>
+        </Group>
 
         {#if @section.open_and_free}
           <OpenFreeSettings id="open_and_free_settings" is_admin={@is_admin} changeset={@changeset} disabled={false} {=@context}/>
         {#else}
-          <LtiSettings section={@section}/>
+          <LtiSettings section={@section} id="open_and_free_settings" is_admin={@is_admin} changeset={@changeset} disabled={false} {=@context}/>
         {/if}
+
         <PaywallSettings changeset={@changeset} disabled={!can_change_payment?(@section, @is_admin)}/>
         <ContentSettings changeset={@changeset}/>
       </Groups>

--- a/lib/oli_web/live/sections/edit_view.ex
+++ b/lib/oli_web/live/sections/edit_view.ex
@@ -86,7 +86,7 @@ defmodule OliWeb.Sections.EditView do
         {#if @section.open_and_free}
           <OpenFreeSettings id="open_and_free_settings" is_admin={@is_admin} changeset={@changeset} disabled={false} {=@context}/>
         {#else}
-          <LtiSettings section={@section} id="open_and_free_settings" is_admin={@is_admin} changeset={@changeset} disabled={false} {=@context}/>
+          <LtiSettings section={@section}/>
         {/if}
 
         <PaywallSettings changeset={@changeset} disabled={!can_change_payment?(@section, @is_admin)}/>

--- a/lib/oli_web/live/sections/open_free_settings.ex
+++ b/lib/oli_web/live/sections/open_free_settings.ex
@@ -2,8 +2,7 @@ defmodule OliWeb.Sections.OpenFreeSettings do
   use OliWeb, :surface_component
 
   alias Surface.Components.Field
-  alias Surface.Components.Form.{Field, Label, DateTimeLocalInput, Checkbox, ErrorTag}
-  alias OliWeb.Common.FormatDateTime
+  alias Surface.Components.Form.{Field, Label, Checkbox}
   alias OliWeb.Common.Properties.Group
   import Ecto.Changeset
 
@@ -13,16 +12,6 @@ defmodule OliWeb.Sections.OpenFreeSettings do
   prop context, :struct, required: true
 
   def render(assigns) do
-    start_date =
-      assigns.changeset
-      |> Ecto.Changeset.get_field(:start_date)
-      |> FormatDateTime.convert_datetime(assigns.context)
-
-    end_date =
-      assigns.changeset
-      |> Ecto.Changeset.get_field(:end_date)
-      |> FormatDateTime.convert_datetime(assigns.context)
-
     ~F"""
     <Group label="Direct Delivery" description="Direct Delivery section settings">
       <Field name={:registration_open} class="form-check">
@@ -40,16 +29,6 @@ defmodule OliWeb.Sections.OpenFreeSettings do
         <Label class="form-check-label">Omit student email verification</Label>
       </Field>
 
-      <div class="form-row mt-4">
-        <Field name={:start_date} class="mr-3 form-label-group">
-          <div class="d-flex justify-content-between"><Label/><ErrorTag class="help-block"/></div>
-          <DateTimeLocalInput class="form-control" value={start_date} opts={disabled: @disabled}/>
-        </Field>
-        <Field name={:end_date} class="form-label-group">
-          <div class="d-flex justify-content-between"><Label/><ErrorTag class="help-block"/></div>
-          <DateTimeLocalInput class="form-control" value={end_date} opts={disabled: @disabled}/>
-        </Field>
-      </div>
       <div class="form-row">
         <small class="text-nowrap form-text text-muted">
           Timezone: {@context.local_tz}

--- a/lib/oli_web/live/sections/start_end.ex
+++ b/lib/oli_web/live/sections/start_end.ex
@@ -1,0 +1,38 @@
+defmodule OliWeb.Sections.StartEnd do
+  use OliWeb, :surface_component
+
+  alias Surface.Components.Field
+  alias Surface.Components.Form.{Field, Label, DateTimeLocalInput, ErrorTag}
+  alias OliWeb.Common.FormatDateTime
+
+  prop changeset, :any, required: true
+  prop disabled, :boolean, required: true
+  prop is_admin, :boolean, required: true
+  prop context, :struct, required: true
+
+  def render(assigns) do
+    start_date =
+      assigns.changeset
+      |> Ecto.Changeset.get_field(:start_date)
+      |> FormatDateTime.convert_datetime(assigns.context)
+
+    end_date =
+      assigns.changeset
+      |> Ecto.Changeset.get_field(:end_date)
+      |> FormatDateTime.convert_datetime(assigns.context)
+
+    ~F"""
+      <div class="form-row mt-4">
+        <Field name={:start_date} class="mr-3 form-label-group">
+          <div class="d-flex justify-content-between"><Label/><ErrorTag class="help-block"/></div>
+          <DateTimeLocalInput class="form-control" value={start_date} opts={disabled: @disabled}/>
+        </Field>
+        <Field name={:end_date} class="form-label-group">
+          <div class="d-flex justify-content-between"><Label/><ErrorTag class="help-block"/></div>
+          <DateTimeLocalInput class="form-control" value={end_date} opts={disabled: @disabled}/>
+        </Field>
+        <button class="btn btn-primary mt-3" type="submit">Save</button>
+      </div>
+    """
+  end
+end


### PR DESCRIPTION
Moves the UX for editing start and end section dates to a spot in the edit dialog that always displays.  