### PR TITLE
[ENHANCEMENT] Remove engagement and fix objectives display bug [MER-1706]

### DIFF
--- a/assets/css/table.css
+++ b/assets/css/table.css
@@ -44,7 +44,7 @@
   @apply bg-red-200 bg-opacity-20;
 }
 
-.instructor_dashboard_table tr:has(div[data-engagement-check='false']) {
+.instructor_dashboard_table tr:has(div[data-mastery-check='false']) {
   @apply bg-red-200 bg-opacity-20;
 }
 

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -2538,23 +2538,17 @@ defmodule Oli.Delivery.Sections do
       |> Enum.into([], fn elem -> elem.objectives["attached"] end)
       |> List.flatten()
 
-    # TODO we should be able to calculate student_engagement 's metric
-    # for all students or for a specific student depending on where we are rendering the learning objectives table
-    # (from instructor dashboard or student dashboard perspective)
     objectives =
       from([sr: sr, rev: rev] in DeliveryResolver.section_resource_revisions(section_slug),
         left_join: rev2 in Revision,
         on: rev2.resource_id in rev.children,
         where: rev.deleted == false and rev.resource_type_id == ^page_id,
-        where: rev.resource_id in ^objectives_id_list,
         group_by: [rev2.title, rev.resource_id, rev.title, rev2.resource_id],
         select: %{
           objective: rev.title,
           objective_resource_id: rev.resource_id,
           subobjective: rev2.title,
-          subobjective_resource_id: rev2.resource_id,
-          student_engagement:
-            fragment("('{High,Medium,Low,Not enough data}'::text[])[ceil(random()*4)]")
+          subobjective_resource_id: rev2.resource_id
         }
       )
       |> Repo.all()

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -2533,11 +2533,6 @@ defmodule Oli.Delivery.Sections do
         student_id -> Metrics.mastery_for_student_per_learning_objective(section_slug, student_id)
       end
 
-    objectives_id_list =
-      pages_with_objectives
-      |> Enum.into([], fn elem -> elem.objectives["attached"] end)
-      |> List.flatten()
-
     objectives =
       from([sr: sr, rev: rev] in DeliveryResolver.section_resource_revisions(section_slug),
         left_join: rev2 in Revision,

--- a/lib/oli_web/components/delivery/content/content.ex
+++ b/lib/oli_web/components/delivery/content/content.ex
@@ -158,8 +158,7 @@ defmodule OliWeb.Components.Delivery.Content do
             :numbering_index,
             :container_name,
             :student_completion,
-            :student_mastery,
-            :student_engagement
+            :student_mastery
           ],
           @default_params.sort_by
         ),
@@ -238,9 +237,6 @@ defmodule OliWeb.Components.Delivery.Content do
 
       :student_mastery ->
         Enum.sort_by(containers, fn container -> container.student_mastery end, sort_order)
-
-      :student_engagement ->
-        Enum.sort_by(containers, fn container -> container.student_engagement end, sort_order)
 
       _ ->
         Enum.sort_by(containers, fn container -> container.title end, sort_order)

--- a/lib/oli_web/components/delivery/content/content_table_model.ex
+++ b/lib/oli_web/components/delivery/content/content_table_model.ex
@@ -28,12 +28,6 @@ defmodule OliWeb.Components.Delivery.ContentTableModel do
         label: "STUDENT MASTERY",
         render_fn: &__MODULE__.stub_student_mastery/3,
         th_class: "instructor_dashboard_th"
-      },
-      %ColumnSpec{
-        name: :student_engagement,
-        label: "STUDENT ENGAGEMENT",
-        render_fn: &__MODULE__.stub_student_engagement/3,
-        th_class: "instructor_dashboard_th"
       }
     ]
 
@@ -99,14 +93,6 @@ defmodule OliWeb.Components.Delivery.ContentTableModel do
 
     ~H"""
       <div class={if @container.student_mastery == "Low", do: "text-red-600 font-bold"}><%= @container.student_mastery %></div>
-    """
-  end
-
-  def stub_student_engagement(assigns, container, _) do
-    assigns = Map.merge(assigns, %{container: container})
-
-    ~H"""
-      <div class={if @container.student_engagement == "Low", do: "text-red-600 font-bold"}><%= @container.student_engagement %></div>
     """
   end
 

--- a/lib/oli_web/components/delivery/learning_objectives/objectives_table_model.ex
+++ b/lib/oli_web/components/delivery/learning_objectives/objectives_table_model.ex
@@ -32,11 +32,6 @@ defmodule OliWeb.Delivery.LearningObjectives.ObjectivesTableModel do
         name: :student_mastery_subobj,
         label: "STUDENT MASTERY(SUB OBJ.)",
         th_class: "instructor_dashboard_th",
-      },
-      %ColumnSpec{
-        name: :student_engagement,
-        label: "STUDENT ENGAGEMENT",
-        th_class: "instructor_dashboard_th",
       }
     ]
 
@@ -48,15 +43,26 @@ defmodule OliWeb.Delivery.LearningObjectives.ObjectivesTableModel do
     )
   end
 
-  def custom_render(assigns, %{objective: objective, student_engagement: student_engagement} = _objectives, %ColumnSpec{
+  def custom_render(assigns, %{objective: objective, student_mastery: student_mastery} = _objectives, %ColumnSpec{
         name: :objective
       }) do
     ~F"""
-      <div class="flex items-center ml-8 gap-x-4" data-engagement-check={if student_engagement == "Low", do: "false", else: "true"}>
-        <span class={"flex flex-shrink-0 rounded-full w-2 h-2 #{if student_engagement == "Low", do: "bg-red-600", else: "bg-gray-500"}"}></span>
+      <div class="flex items-center ml-8 gap-x-4" data-mastery-check={if student_mastery == "Low", do: "false", else: "true"}>
+        <span class={"flex flex-shrink-0 rounded-full w-2 h-2 #{if student_mastery == "Low", do: "bg-red-600", else: "bg-gray-500"}"}></span>
         <span>{objective}</span>
       </div>
     """
+  end
+
+  def custom_render(assigns, %{objective: objective} = _objectives, %ColumnSpec{
+      name: :objective
+    }) do
+  ~F"""
+    <div class="flex items-center ml-8 gap-x-4">
+      <span></span>
+      <span>{objective}</span>
+    </div>
+  """
   end
 
   def custom_render(assigns, %{subobjective: subobjective} = _objectives, %ColumnSpec{

--- a/lib/oli_web/components/delivery/students/students.ex
+++ b/lib/oli_web/components/delivery/students/students.ex
@@ -138,9 +138,6 @@ defmodule OliWeb.Components.Delivery.Students do
       :overall_mastery ->
         Enum.sort_by(students, fn student -> student.overall_mastery end, sort_order)
 
-      :engagement ->
-        Enum.sort_by(students, fn student -> student.engagement end, sort_order)
-
       _ ->
         Enum.sort_by(
           students,
@@ -254,7 +251,7 @@ defmodule OliWeb.Components.Delivery.Students do
         Params.get_atom_param(
           params,
           "sort_by",
-          [:name, :last_interaction, :progress, :overall_mastery, :engagement],
+          [:name, :last_interaction, :progress, :overall_mastery],
           @default_params.sort_by
         ),
       text_search: Params.get_param(params, "text_search", @default_params.text_search),

--- a/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
@@ -181,7 +181,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive do
   end
 
   defp get_students(section, params) do
-    # TODO get real student engagement
+
     # when that metric is ready (see Oli.Delivery.Metrics)
     case params.page_id do
       nil ->
@@ -189,14 +189,12 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive do
         |> add_students_progress(section.id, params.container_id)
         |> add_students_last_interaction(section, params.container_id)
         |> add_students_overall_mastery(section, params.container_id)
-        |> add_students_engagement(section.slug)
 
       page_id ->
         Sections.enrolled_students(section.slug)
         |> add_students_progress_for_page(section.id, page_id)
         |> add_students_last_interaction_for_page(section.slug, page_id)
         |> add_students_overall_mastery_for_page(section.slug, page_id)
-        |> add_students_engagement_for_page(section.slug, page_id)
     end
   end
 
@@ -213,14 +211,12 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive do
 
     mastery_per_container = Metrics.mastery_per_container(section.slug)
 
-    # TODO get real student engagement values
     # when those metrics are ready (see Oli.Delivery.Metrics)
 
     containers_with_metrics =
       Enum.map(containers, fn container ->
         Map.merge(container, %{
           progress: student_progress[container.id] || 0.0,
-          student_engagement: Enum.random(["Low", "Medium", "High", "Not enough data"]),
           student_mastery: Map.get(mastery_per_container, container.id, "Not enough data")
         })
       end)
@@ -300,22 +296,6 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive do
     Enum.map(students, fn student ->
       Map.merge(student, %{
         overall_mastery: Map.get(mastery_per_student_for_page, student.id, "Not enough data")
-      })
-    end)
-  end
-
-  defp add_students_engagement(students, _section_slug) do
-    Enum.map(students, fn student ->
-      Map.merge(student, %{
-        engagement: Enum.random(["Low", "Medium", "High", "Not enough data"])
-      })
-    end)
-  end
-
-  defp add_students_engagement_for_page(students, _section_slug, _page_id) do
-    Enum.map(students, fn student ->
-      Map.merge(student, %{
-        engagement: Enum.random(["Low", "Medium", "High", "Not enough data"])
       })
     end)
   end

--- a/lib/oli_web/live/delivery/student_dashboard/components/helpers.ex
+++ b/lib/oli_web/live/delivery/student_dashboard/components/helpers.ex
@@ -193,10 +193,6 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.Helpers do
               <h4 class="text-xs uppercase text-gray-800 font-normal flex items-center">course completion</h4>
               <span class={"text-base font-semibold tracking-wide flex items-center mt-2 #{text_color(:progress, @student.progress)}"}><%= format_percentage(@student.progress) %></span>
             </div>
-            <div class="flex flex-col justify-between">
-              <h4 class="text-xs uppercase text-gray-800 font-normal flex items-center">platform engagement <i class="fa fa-info-circle text-primary h-3 w-3 ml-2"></i></h4>
-              <span class={"text-base font-semibold tracking-wide flex items-center mt-2 #{text_color(:engagement, @student.engagement)}"}><%= @student.engagement %></span>
-            </div>
           </div>
           <%= if length(@survey_responses) > 0 do%>
             <div class="grid grid-cols-5 gap-4 w-full p-8">
@@ -232,15 +228,6 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.Helpers do
       nil -> "text-gray-800"
       value when value < 0.5 -> "text-red-600"
       value when value < 0.8 -> "text-yellow-600"
-      _ -> "text-green-700"
-    end
-  end
-
-  defp text_color(:engagement, metric_value) do
-    case metric_value do
-      nil -> "text-gray-800"
-      "Low" -> "text-red-600"
-      "Medium" -> "text-yellow-600"
       _ -> "text-green-700"
     end
   end

--- a/lib/oli_web/live/delivery/student_dashboard/initial_assigns.ex
+++ b/lib/oli_web/live/delivery/student_dashboard/initial_assigns.ex
@@ -45,7 +45,7 @@ defmodule OliWeb.Delivery.StudentDashboard.InitialAssigns do
   end
 
   defp add_students_metrics(student, section_id) do
-    # TODO get real engagement metric when developed in Oli.Delivery.Metrics
+
     progress = Metrics.progress_for(section_id, student.id) |> Map.get(student.id, 0.0)
 
     avg_score =
@@ -54,8 +54,7 @@ defmodule OliWeb.Delivery.StudentDashboard.InitialAssigns do
 
     Map.merge(student, %{
       avg_score: avg_score,
-      progress: progress,
-      engagement: Enum.random(["Low", "Medium", "High"])
+      progress: progress
     })
   end
 

--- a/lib/oli_web/live/delivery/student_dashboard/student_dashboard_live.ex
+++ b/lib/oli_web/live/delivery/student_dashboard/student_dashboard_live.ex
@@ -246,14 +246,12 @@ defmodule OliWeb.Delivery.StudentDashboard.StudentDashboardLive do
 
     mastery_per_container = Metrics.mastery_for_student_per_container(section.slug, student_id)
 
-    # TODO get real student engagement values
     # when those metrics are ready (see Oli.Delivery.Metrics)
 
     containers_with_metrics =
       Enum.map(containers, fn container ->
         Map.merge(container, %{
           progress: student_progress[container.id] || 0.0,
-          student_engagement: Enum.random(["Low", "Medium", "High", "Not enough data"]),
           student_mastery: Map.get(mastery_per_container, container.id, "Not enough data")
         })
       end)

--- a/lib/oli_web/live/sections/enrollments_table_model.ex
+++ b/lib/oli_web/live/sections/enrollments_table_model.ex
@@ -35,12 +35,6 @@ defmodule OliWeb.Delivery.Sections.EnrollmentsTableModel do
         label: "OVERALL COURSE MASTERY",
         render_fn: &__MODULE__.render_overall_mastery_column/3,
         th_class: "instructor_dashboard_th"
-      },
-      %ColumnSpec{
-        name: :engagement,
-        label: "COURSE ENGAGEMENT",
-        render_fn: &__MODULE__.render_engagement_column/3,
-        th_class: "instructor_dashboard_th"
       }
     ]
 
@@ -121,14 +115,6 @@ defmodule OliWeb.Delivery.Sections.EnrollmentsTableModel do
 
     ~H"""
       <div class={if @overall_mastery == "Low", do: "text-red-600 font-bold"}><%= @overall_mastery %></div>
-    """
-  end
-
-  def render_engagement_column(assigns, user, _) do
-    assigns = Map.merge(assigns, %{engagement: Map.get(user, :engagement)})
-
-    ~H"""
-      <div class={if @engagement == "Low", do: "text-red-600 font-bold"}><%= @engagement %></div>
     """
   end
 


### PR DESCRIPTION
Removes all "Student Engagement" references from UI and code, since we are not moving forward with that analytic

In testing my changes, I caught a bug in how the Learning Objectives tab was populated.  It only showed LO's that were actually attached to pages.  I removed that constraint so that it shows all LOs. 