### PR TITLE
[FEATURE] [MER-1913] Change Unenroll feature to preserve all data

### DIFF
--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -123,7 +123,7 @@ defmodule Oli.Delivery.Metrics do
   def completion_for(section_id, container_id) do
     completions =
       User
-      |> join(:inner, [u], e in Enrollment, on: u.id == e.user_id and e.section_id == ^section_id)
+      |> join(:inner, [u], e in Enrollment, on: u.id == e.user_id and e.section_id == ^section_id and e.status == :enrolled)
       |> join(:inner, [u, e], ecr in EnrollmentContextRole,
         on:
           ecr.enrollment_id == e.id and
@@ -361,7 +361,7 @@ defmodule Oli.Delivery.Metrics do
         on: e.section_id == s.id,
         left_join: ra in ResourceAccess,
         on: ^on,
-        where: s.slug == ^section.slug,
+        where: s.slug == ^section.slug and e.status == :enrolled,
         group_by: [e.user_id, e.updated_at],
         select: {
           e.user_id,
@@ -398,7 +398,7 @@ defmodule Oli.Delivery.Metrics do
         on: e.section_id == s.id,
         left_join: ra in ResourceAccess,
         on: e.user_id == ra.user_id,
-        where: s.slug == ^section_slug and (ra.resource_id == ^page_id or is_nil(ra.resource_id)),
+        where: s.slug == ^section_slug and (ra.resource_id == ^page_id or is_nil(ra.resource_id)) and e.status == :enrolled,
         group_by: [e.user_id, e.updated_at],
         select: {
           e.user_id,
@@ -707,7 +707,7 @@ defmodule Oli.Delivery.Metrics do
         on: enr.user_id == u.id,
         join: ra in ResourceAccess,
         on: ra.user_id == enr.user_id,
-        where: u.id == ^user_id and ra.section_id == ^section_id,
+        where: u.id == ^user_id and ra.section_id == ^section_id and enr.status == :enrolled,
         group_by: u.name,
         select: fragment("MAX(?)", ra.updated_at)
       )

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -165,7 +165,9 @@ defmodule Oli.Delivery.Sections do
       e in Enrollment,
       join: s in Section,
       on: e.section_id == s.id,
-      where: e.user_id == ^user_id and s.slug == ^section_slug and s.status == :active,
+      where:
+        e.user_id == ^user_id and s.slug == ^section_slug and s.status == :active and
+          e.status == :enrolled,
       preload: :context_roles
     )
     |> Repo.one()
@@ -318,7 +320,9 @@ defmodule Oli.Delivery.Sections do
           Enum.filter(enrollment.context_roles, &(!Enum.member?(context_roles, &1)))
 
         if Enum.count(other_context_roles) == 0 do
-          Repo.delete(enrollment)
+          enrollment
+          |> Enrollment.changeset(%{status: :suspended})
+          |> Repo.update()
         else
           enrollment
           |> Enrollment.changeset(%{section_id: section_id})
@@ -345,7 +349,9 @@ defmodule Oli.Delivery.Sections do
         e in Enrollment,
         join: s in Section,
         on: e.section_id == s.id,
-        where: e.user_id == ^user_id and s.slug == ^section_slug and s.status == :active
+        where:
+          e.user_id == ^user_id and s.slug == ^section_slug and s.status == :active and
+            e.status == :enrolled
       )
 
     case Repo.one(query) do
@@ -364,7 +370,7 @@ defmodule Oli.Delivery.Sections do
         e in Enrollment,
         join: s in Section,
         on: e.section_id == s.id,
-        where: s.slug == ^section_slug and s.status == :active,
+        where: s.slug == ^section_slug and s.status == :active and e.status == :enrolled,
         preload: [:user, :context_roles],
         select: e
       )
@@ -387,7 +393,9 @@ defmodule Oli.Delivery.Sections do
         on: e.id == e_cr.enrollment_id,
         join: cr in Lti_1p3.DataProviders.EctoProvider.ContextRole,
         on: e_cr.context_role_id == cr.id,
-        where: s.slug == ^section_slug and s.status == :active and cr.id in ^role_ids,
+        where:
+          s.slug == ^section_slug and s.status == :active and cr.id in ^role_ids and
+            e.status == :enrolled,
         select: count(e)
       )
 
@@ -415,7 +423,9 @@ defmodule Oli.Delivery.Sections do
         e in Enrollment,
         join: s in Section,
         on: e.section_id == s.id,
-        where: e.user_id == ^user_id and s.slug == ^section_slug and s.status == :active,
+        where:
+          e.user_id == ^user_id and s.slug == ^section_slug and s.status == :active and
+            e.status == :enrolled,
         select: e
       )
 
@@ -437,7 +447,9 @@ defmodule Oli.Delivery.Sections do
         s in Section,
         join: e in Enrollment,
         on: e.section_id == s.id,
-        where: e.user_id == ^user_id and s.open_and_free == true and s.status == :active,
+        where:
+          e.user_id == ^user_id and s.open_and_free == true and s.status == :active and
+            e.status == :enrolled,
         preload: [:base_project],
         select: s
       )
@@ -454,7 +466,7 @@ defmodule Oli.Delivery.Sections do
         s in Section,
         join: e in Enrollment,
         on: e.section_id == s.id,
-        where: e.user_id == ^user_id and s.status == :active,
+        where: e.user_id == ^user_id and s.status == :active and e.status == :enrolled,
         select: s
       )
 

--- a/lib/oli/delivery/sections/browse.ex
+++ b/lib/oli/delivery/sections/browse.ex
@@ -84,7 +84,7 @@ defmodule Oli.Delivery.Sections.Browse do
         join: e in Enrollment,
         on: e.user_id == u.id,
         join: ecr in "enrollments_context_roles",
-        on: ecr.enrollment_id == e.id and ecr.context_role_id == ^instructor_role_id,
+        on: ecr.enrollment_id == e.id and ecr.context_role_id == ^instructor_role_id and e.status == :enrolled,
         select: %{
           name: fragment("array_to_string((array_agg(?)), ', ')", u.name),
           section_id: e.section_id

--- a/test/oli/sections_test.exs
+++ b/test/oli/sections_test.exs
@@ -121,7 +121,7 @@ defmodule Oli.SectionsTest do
       assert length(Sections.list_enrollments(section.slug)) > 0
     end
 
-    test "unenroll/3 deletes an enrollment if all context roles are removed", %{
+    test "unenroll/3 soft delete an enrollment if all context roles are removed", %{
       section: section,
       user1: user1
     } do
@@ -132,7 +132,7 @@ defmodule Oli.SectionsTest do
       assert Sections.list_enrollments(section.slug) == []
     end
 
-    test "unenroll_learner/2 deletes an enrollment if the user is only a student", %{
+    test "unenroll_learner/2 soft delete an enrollment if the user is only a student", %{
       section: section,
       user1: user1
     } do
@@ -141,6 +141,32 @@ defmodule Oli.SectionsTest do
       Sections.unenroll_learner(user1.id, section.id)
 
       assert Sections.list_enrollments(section.slug) == []
+    end
+
+    test "unenroll/3 changes enrollment status if all context roles are removed", %{
+      section: section,
+      user1: user1
+    } do
+      Sections.enroll(user1.id, section.id, [ContextRoles.get_role(:context_instructor)])
+
+      Sections.unenroll(user1.id, section.id, [ContextRoles.get_role(:context_instructor)])
+
+      [head | _] = Sections.enrolled_students(section.slug)
+
+      assert head.enrollment_status == :suspended
+    end
+
+    test "unenroll_learner/2 changes enrollment status if the user is only a student", %{
+      section: section,
+      user1: user1
+    } do
+      Sections.enroll(user1.id, section.id, [ContextRoles.get_role(:context_learner)])
+
+      Sections.unenroll_learner(user1.id, section.id)
+
+      [head | _] = Sections.enrolled_students(section.slug)
+
+      assert head.enrollment_status == :suspended
     end
   end
 


### PR DESCRIPTION
[MER-1913](https://eliterate.atlassian.net/browse/MER-1913)

This PR modifies the `unenroll` function to avoid deleting the record of a specific user in the enrollment table and instead modifying the enrollment status for that user.
The goal is to perform a soft delete and not lose the information of that enrollment.

Also the enrollment status check is added in several queries in which it is necessary to know if the user is enrolled or not in a section.

_*** Please let me know if there is any query that should not have this enrollment status check or if there is any query that does not have it and should have it._

[MER-1913]: https://eliterate.atlassian.net/browse/MER-1913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ