### PR TITLE
[FEATURE] implementation of feedback mode setting [MER-1950]

### DIFF
--- a/assets/src/components/activities/DeliveryElement.ts
+++ b/assets/src/components/activities/DeliveryElement.ts
@@ -59,6 +59,7 @@ export interface ActivityContext {
   bibParams: any;
   pageAttemptGuid: string;
   pageState?: any;
+  showFeedback: boolean | null;
 }
 
 /**

--- a/assets/src/components/activities/common/delivery/evaluation/EvaluationConnected.tsx
+++ b/assets/src/components/activities/common/delivery/evaluation/EvaluationConnected.tsx
@@ -13,7 +13,7 @@ export const EvaluationConnected: React.FC = () => {
   return (
     <>
       <Evaluation
-        shouldShow={isEvaluated(uiState) && surveyId === null}
+        shouldShow={(context.showFeedback == true) && isEvaluated(uiState) && surveyId === null}
         attemptState={uiState.attemptState}
         context={writerContext}
       />

--- a/assets/src/components/activities/common/delivery/graded_points/GradedPointsConnected.tsx
+++ b/assets/src/components/activities/common/delivery/graded_points/GradedPointsConnected.tsx
@@ -8,11 +8,11 @@ import { ActivityDeliveryState } from 'data/activities/DeliveryState';
 import { isCorrect } from 'data/activities/utils';
 
 export const GradedPointsConnected: React.FC = () => {
-  const { graded, surveyId } = useDeliveryElementContext().context;
+  const { graded, surveyId, showFeedback } = useDeliveryElementContext().context;
   const uiState = useSelector((state: ActivityDeliveryState) => state);
   return (
     <GradedPoints
-      shouldShow={uiState.attemptState.score !== null && graded && surveyId === null}
+      shouldShow={(showFeedback == true) && uiState.attemptState.score !== null && graded && surveyId === null}
       icon={isCorrect(uiState.attemptState) ? <Checkmark /> : <Cross />}
       attemptState={uiState.attemptState}
     />

--- a/assets/src/components/activities/custom_dnd/FocusedFeedback.tsx
+++ b/assets/src/components/activities/custom_dnd/FocusedFeedback.tsx
@@ -12,13 +12,13 @@ export const FocusedFeedback: React.FC<FocusedFeedbackProps> = (props: FocusedFe
   const { focusedPart } = props;
   const {
     mode,
-    context: { graded, surveyId },
+    context: { graded, surveyId, showFeedback },
     writerContext,
   } = useDeliveryElementContext();
   const uiState = useSelector((state: ActivityDeliveryState) => state);
 
   // if this is within a survey or if it is graded but not in review mode, do not show feedback
-  if (surveyId || (graded && mode !== 'review')) {
+  if (surveyId || (graded && mode !== 'review') || showFeedback == false) {
     return null;
   }
 

--- a/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
@@ -299,7 +299,7 @@ export const MultiInputComponent: React.FC = () => {
         ))}
         <Evaluation
           shouldShow={
-            anyEvaluated(uiState) && surveyId === null && (!context.graded || mode === 'review')
+            context.showFeedback == true && anyEvaluated(uiState) && surveyId === null && (!context.graded || mode === 'review')
           }
           attemptState={uiState.attemptState}
           context={writerContext}

--- a/lib/oli/delivery/page/activity_context.ex
+++ b/lib/oli/delivery/page/activity_context.ex
@@ -38,7 +38,9 @@ defmodule Oli.Delivery.Page.ActivityContext do
 
       # the activity type this revision pertains to
       type = Map.get(reg_map, revision.activity_type_id)
+
       state = Map.get(activity_states, id)
+      |> prune_feedback_from_state(Keyword.get(opts, :show_feedback, true))
 
       {id,
        %ActivitySummary{
@@ -56,6 +58,18 @@ defmodule Oli.Delivery.Page.ActivityContext do
        }}
     end)
     |> Map.new()
+  end
+
+  defp prune_feedback_from_state(state, true), do: state
+  defp prune_feedback_from_state(state, false) do
+    %Oli.Activities.State.ActivityState{state |
+      parts: prune_feedback_from_parts(state.parts), score: nil, outOf: nil}
+  end
+
+  defp prune_feedback_from_parts(parts) do
+    Enum.map(parts, fn part ->
+      %Oli.Activities.State.PartState{part | feedback: nil}
+    end)
   end
 
   defp create_ordinal_assignment_fn(false, _), do: fn _ -> nil end

--- a/lib/oli/delivery/settings.ex
+++ b/lib/oli/delivery/settings.ex
@@ -149,4 +149,10 @@ defmodule Oli.Delivery.Settings do
     |> DateTime.add(effective_settings.grace_period, :minute)
   end
 
+  def show_feedback?(%Combined{feedback_mode: :allow}), do: true
+  def show_feedback?(%Combined{feedback_mode: :disallow}), do: false
+  def show_feedback?(%Combined{feedback_scheduled_date: date}) do
+    DateTime.compare(date, DateTime.utc_now()) == :lt
+  end
+
 end

--- a/lib/oli/delivery/settings/combined.ex
+++ b/lib/oli/delivery/settings/combined.ex
@@ -24,7 +24,7 @@ defstruct end_date: nil,
           grace_period: integer(),
           scoring_strategy_id: integer(),
           review_submission: :allow | :disallow,
-          feedback_mode: :allow | :disallow,
+          feedback_mode: :allow | :disallow | :scheduled,
           feedback_scheduled_date: DateTime.t(),
           collab_space_config: Oli.Resources.Collaboration.CollabSpaceConfig.t(),
           explanation_strategy: Oli.Resources.ExplanationStrategy.t()

--- a/lib/oli/rendering/activity/html.ex
+++ b/lib/oli/rendering/activity/html.ex
@@ -140,7 +140,8 @@ defmodule Oli.Rendering.Activity.Html do
            resource_attempt: resource_attempt,
            group_id: group_id,
            survey_id: survey_id,
-           learning_language: learning_language
+           learning_language: learning_language,
+           effective_settings: effective_settings
          } = context,
          %ActivitySummary{
            state: state,
@@ -159,6 +160,7 @@ defmodule Oli.Rendering.Activity.Html do
         groupId: group_id,
         bibParams: bib_params,
         learningLanguage: learning_language,
+        showFeedback: Oli.Delivery.Settings.show_feedback?(effective_settings),
         pageAttemptGuid:
           if is_nil(resource_attempt) do
             ""

--- a/lib/oli/rendering/context.ex
+++ b/lib/oli/rendering/context.ex
@@ -27,5 +27,6 @@ defmodule Oli.Rendering.Context do
             alternatives_groups_fn: nil,
             alternatives_selector_fn: nil,
             extrinsic_read_section_fn: nil,
-            learning_language: nil
+            learning_language: nil,
+            effective_settings: nil
 end

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -538,7 +538,8 @@ defmodule OliWeb.PageDeliveryController do
       bib_app_params: context.bib_revisions,
       submitted_surveys: submitted_surveys,
       historical_attempts: context.historical_attempts,
-      learning_language: base_project_attributes.learning_language
+      learning_language: base_project_attributes.learning_language,
+      effective_settings: effective_settings
     }
 
     this_attempt = context.resource_attempts |> hd
@@ -584,6 +585,7 @@ defmodule OliWeb.PageDeliveryController do
         latest_attempts: context.latest_attempts,
         section: section,
         children: context.page.children,
+        show_feedback: Oli.Delivery.Settings.show_feedback?(effective_settings),
         page_link_url: &Routes.page_delivery_path(conn, :page, section_slug, &1),
         container_link_url: &Routes.page_delivery_path(conn, :container, section_slug, &1),
         revision: context.page,
@@ -681,8 +683,6 @@ defmodule OliWeb.PageDeliveryController do
           "revision_slug" => revision_slug
         }
       ) do
-
-
 
     case Resolver.from_revision_slug(section_slug, revision_slug) do
       %{content: %{"advancedDelivery" => true}} = revision ->

--- a/lib/oli_web/templates/page_delivery/page.html.heex
+++ b/lib/oli_web/templates/page_delivery/page.html.heex
@@ -17,22 +17,24 @@ window.userToken = "<%= assigns[:user_token] %>";
 <%= if @review_mode == true do %>
   <%= if @resource_attempt.lifecycle_state == :evaluated do  %>
     <div class="mb-2">
-    <div class="grid grid-cols-12 justify-content-start">
-      <div class="col-span-3">Started:</div>
-      <div class="col-span-9"><%= Utils.render_date(@resource_attempt, :inserted_at, @conn) %></div>
-    </div>
-    <div class="grid grid-cols-12">
-      <div class="col-span-3">Submitted:</div>
-      <div class="col-span-9"><%= Utils.render_date(@resource_attempt, :date_evaluated, @conn) %></div>
-    </div>
-    <div class="grid grid-cols-12">
-      <div class="col-span-3">Score:</div>
-      <div class="col-span-9"><%= show_score(@resource_attempt.score, @resource_attempt.out_of) %>%</div>
-    </div>
-    <div class="grid grid-cols-12">
-      <div class="col-span-3">Points:</div>
-      <div class="col-span-9"><%= Utils.format_score(@resource_attempt.score) %> out of <%= @resource_attempt.out_of %> </div>
-    </div>
+      <div class="grid grid-cols-12 justify-content-start">
+        <div class="col-span-3">Started:</div>
+        <div class="col-span-9"><%= Utils.render_date(@resource_attempt, :inserted_at, @conn) %></div>
+      </div>
+      <div class="grid grid-cols-12">
+        <div class="col-span-3">Submitted:</div>
+        <div class="col-span-9"><%= Utils.render_date(@resource_attempt, :date_evaluated, @conn) %></div>
+      </div>
+      <%= if @show_feedback do %>
+        <div class="grid grid-cols-12">
+          <div class="col-span-3">Score:</div>
+          <div class="col-span-9"><%= show_score(@resource_attempt.score, @resource_attempt.out_of) %>%</div>
+        </div>
+        <div class="grid grid-cols-12">
+          <div class="col-span-3">Points:</div>
+          <div class="col-span-9"><%= Utils.format_score(@resource_attempt.score) %> out of <%= @resource_attempt.out_of %> </div>
+        </div>
+      <% end %>
     </div>
   <% end %>
   <%= if @resource_attempt.lifecycle_state == :submitted do  %>


### PR DESCRIPTION
Implements the `:allow`, `:disallow`, and `:scheduled` options of the `:feedback_mode` delivery assessment setting.

This required both client side and server side parts:
1. client-side: From within the delivery components, we do not show the points and out_of as well as the textual feedback when feedback is not allowed (or not yet released)
2. server-side: When feedback is not to be shown, we set to `nil` the relevant pieces of the attempt state, so that someone cannot still get at this feedback as it sits encoded within the webcomponent attributes. 
 