### PR TITLE
[ENHANCEMENT] Options to allow credit card, code, or both [MER-2049]

### DIFF
--- a/lib/oli/delivery/sections/blueprint.ex
+++ b/lib/oli/delivery/sections/blueprint.ex
@@ -145,6 +145,7 @@ defmodule Oli.Delivery.Sections.Blueprint do
             "end_date" => nil,
             "title" => title,
             "requires_payment" => false,
+            "payment_options" => "direct_and_deferred",
             "pay_by_institution" => false,
             "registration_open" => false,
             "grace_period_days" => 1,

--- a/lib/oli/delivery/sections/section.ex
+++ b/lib/oli/delivery/sections/section.ex
@@ -39,6 +39,7 @@ defmodule Oli.Delivery.Sections.Section do
 
     field(:visibility, Ecto.Enum, values: [:selected, :global], default: :global)
     field(:requires_payment, :boolean, default: false)
+    field(:payment_options, Ecto.Enum, values: [:direct, :deferred, :direct_and_deferred], default: :direct_and_deferred)
     field(:pay_by_institution, :boolean, default: false)
     field(:amount, Money.Ecto.Map.Type)
     field(:has_grace_period, :boolean, default: true)
@@ -139,6 +140,7 @@ defmodule Oli.Delivery.Sections.Section do
       :cover_image,
       :visibility,
       :requires_payment,
+      :payment_options,
       :pay_by_institution,
       :amount,
       :has_grace_period,

--- a/lib/oli_web/controllers/payment_controller.ex
+++ b/lib/oli_web/controllers/payment_controller.ex
@@ -10,13 +10,15 @@ defmodule OliWeb.PaymentController do
   """
   def guard(conn, %{"section_slug" => section_slug}) do
     user = conn.assigns.current_user
+    section = conn.assigns.section
 
     if user.guest do
       render(conn, "require_account.html", section_slug: section_slug)
     else
       render(conn, "guard.html",
-        section_slug: section_slug,
-        direct_payments_enabled: direct_payments_enabled?()
+        pay_by_card?: direct_payments_enabled?() and (section.payment_options == :direct or section.payment_options == :direct_and_deferred),
+        pay_by_code?: section.payment_options == :deferred or section.payment_options == :direct_and_deferred,
+        section_slug: section_slug
       )
     end
   end

--- a/lib/oli_web/live/sections/edit_view.ex
+++ b/lib/oli_web/live/sections/edit_view.ex
@@ -98,7 +98,6 @@ defmodule OliWeb.Sections.EditView do
 
   def handle_event("validate", %{"section" => params}, socket) do
     params = convert_dates(params, socket.assigns.context)
-
     {:noreply, assign(socket, changeset: Sections.change_section(socket.assigns.section, params))}
   end
 

--- a/lib/oli_web/live/sections/paywall_settings.ex
+++ b/lib/oli_web/live/sections/paywall_settings.ex
@@ -26,6 +26,14 @@ defmodule OliWeb.Sections.PaywallSettings do
     ]
   end
 
+  defp payment_options_choices do
+    [
+      {"Pay by credit card only", "direct"},
+      {"Pay by payment code only", "deferred"},
+      {"Pay by credit card or payment code", "direct_and_deferred"}
+    ]
+  end
+
   def render(assigns) do
     ~F"""
     <Group label="Payment Settings" description="Settings related to requried student fee and optional grace periody">
@@ -36,6 +44,13 @@ defmodule OliWeb.Sections.PaywallSettings do
       <Field name={:amount} class="mt-2 form-label-group">
         <div class="d-flex justify-content-between"><Label/><ErrorTag class="help-block"/></div>
         <TextInput class="form-control" opts={disabled: @disabled or !get_field(@changeset, :requires_payment)}/>
+      </Field>
+      <Field name={:payment_options}>
+        <Label/>
+        <Select
+          class="form-control" form="section" field="payment_options"
+          opts={disabled: @disabled or !get_field(@changeset, :payment_options) or !get_field(@changeset, :payment_options)}
+          options={payment_options_choices()} selected={get_field(@changeset, :payment_options)}/>
       </Field>
       {#unless get_field(@changeset, :open_and_free)}
         <Field name={:pay_by_institution} class="form-check">
@@ -56,7 +71,7 @@ defmodule OliWeb.Sections.PaywallSettings do
         <Select
           class="form-control" form="section" field="grace_period_strategy"
           opts={disabled: @disabled or !get_field(@changeset, :requires_payment) or !get_field(@changeset, :has_grace_period)}
-          options={strategies()} selected={@changeset.data.grace_period_strategy}/>
+          options={strategies()} selected={get_field(@changeset, :grace_period_strategy)}/>
       </Field>
 
       <button class="btn btn-primary mt-3" type="submit">Save</button>

--- a/lib/oli_web/templates/payment/guard.html.eex
+++ b/lib/oli_web/templates/payment/guard.html.eex
@@ -6,7 +6,7 @@
   </p>
 
   <div class="card-deck mt-5">
-    <%= if @direct_payments_enabled do %>
+    <%= if @pay_by_card? do %>
     <a href="<%= Routes.payment_path(@conn, :make_payment, @section_slug) %>" class="card btn-card">
       <div class="card-body">
         <h5 class="card-title">Pay now</h5>
@@ -14,11 +14,13 @@
       </div>
     </a>
     <% end %>
+    <%= if @pay_by_code? do %>
     <a href="<%= Routes.payment_path(@conn, :use_code, @section_slug) %>" class="card btn-card">
       <div class="card-body">
         <h5 class="card-title">Use a payment code</h5>
         <p class="card-text">Enter a payment code that you purchased from a bookstore or other provider.</p>
       </div>
     </a>
+    <% end %>
   </div>
 </div>

--- a/priv/repo/migrations/20230519125406_payment_options.exs
+++ b/priv/repo/migrations/20230519125406_payment_options.exs
@@ -1,0 +1,9 @@
+defmodule Oli.Repo.Migrations.PaymentOptions do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sections) do
+      add :payment_options, :string, default: "direct_and_deferred"
+    end
+  end
+end


### PR DESCRIPTION
This changes gives the ability to allow payment by card, code, or both. 

I also caught and fixed a UI bug in the editor for payment settings.  The dropdowns were being reset when one changed another setting due their "selected" attribute not being set using `get_field` from `Changeset`.  