### PR TITLE
[FEATURE] [MER-1948] Add payment status to enrolled students table

### DIFF
--- a/lib/oli/accounts/schemas/user.ex
+++ b/lib/oli/accounts/schemas/user.ex
@@ -71,6 +71,9 @@ defmodule Oli.Accounts.User do
     field :enrollment_date, :utc_datetime, virtual: true
     field :payment_date, :utc_datetime, virtual: true
     field :payment_id, :integer, virtual: true
+    field :payment, :map, virtual: true
+    field :context_role_id, :integer, virtual: true
+    field :enrollment, :map, virtual: true
 
     field :enroll_after_email_confirmation, :string, virtual: true
 

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -54,7 +54,7 @@ defmodule Oli.Delivery.Sections do
       join: ecr in assoc(e, :context_roles),
       join: u in assoc(e, :user),
       left_join: p in Payment,
-      on: p.enrollment_id == e.id,
+      on: p.enrollment_id == e.id and not is_nil(p.application_date),
       where: s.slug == ^section_slug,
       select: {u, ecr.id, e, p},
       preload: [user: :platform_roles],
@@ -72,7 +72,8 @@ defmodule Oli.Delivery.Sections do
             context_role_id,
             enrollment,
             payment
-          ).reason
+          ).reason,
+        payment_date: if(!is_nil(payment), do: payment.application_date, else: nil)
       })
     end)
   end

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -90,7 +90,7 @@ defmodule Oli.Delivery.Sections do
       case options do
         %EnrollmentBrowseOptions{is_student: true} ->
           dynamic(
-            [e, u],
+            [u, e],
             fragment(
               "(NOT EXISTS (SELECT 1 FROM enrollments_context_roles r WHERE r.enrollment_id = ? AND r.context_role_id = ?))",
               e.id,
@@ -100,7 +100,7 @@ defmodule Oli.Delivery.Sections do
 
         %EnrollmentBrowseOptions{is_instructor: true} ->
           dynamic(
-            [e, u],
+            [u, e],
             fragment(
               "(EXISTS (SELECT 1 FROM enrollments_context_roles r WHERE r.enrollment_id = ? AND r.context_role_id = ?))",
               e.id,
@@ -117,7 +117,7 @@ defmodule Oli.Delivery.Sections do
         true
       else
         dynamic(
-          [_, s],
+          [s, _],
           ilike(s.name, ^"%#{options.text_search}%") or
             ilike(s.email, ^"%#{options.text_search}%") or
             ilike(s.given_name, ^"%#{options.text_search}%") or
@@ -130,17 +130,17 @@ defmodule Oli.Delivery.Sections do
       end
 
     query =
-      Enrollment
-      |> join(:left, [e], u in User, on: u.id == e.user_id)
-      |> join(:left, [e, _], p in Payment, on: p.enrollment_id == e.id)
+      User
+      |> join(:left, [u], e in Enrollment, on: u.id == e.user_id)
+      |> join(:left, [_, e], p in Payment, on: p.enrollment_id == e.id)
       |> where(^filter_by_text)
       |> where(^filter_by_role)
-      |> where([e, _], e.section_id == ^section_id)
+      |> where([u, e], e.section_id == ^section_id)
       |> limit(^limit)
       |> offset(^offset)
-      |> group_by([e, u, p], [e.id, u.id, p.id])
-      |> select([_, u], u)
-      |> select_merge([e, _, p], %{
+      |> group_by([u, e, p], [e.id, u.id, p.id])
+      |> select([u, _], u)
+      |> select_merge([_, e, p], %{
         total_count: fragment("count(*) OVER()"),
         enrollment_date: e.inserted_at,
         payment_date: p.application_date,
@@ -149,10 +149,10 @@ defmodule Oli.Delivery.Sections do
 
     query =
       case field do
-        :enrollment_date -> order_by(query, [e, _, _], {^direction, e.inserted_at})
+        :enrollment_date -> order_by(query, [_, e, _], {^direction, e.inserted_at})
         :payment_date -> order_by(query, [_, _, p], {^direction, p.application_date})
         :payment_id -> order_by(query, [_, _, p], {^direction, p.id})
-        _ -> order_by(query, [_, u, _], {^direction, field(u, ^field)})
+        _ -> order_by(query, [u, _, _], {^direction, field(u, ^field)})
       end
   end
 
@@ -170,19 +170,18 @@ defmodule Oli.Delivery.Sections do
   end
 
   def browse_enrollments_with_context_roles(
-        %Section{id: section_id} = section,
-        %Paging{limit: limit, offset: offset} = paging,
-        %Sorting{field: field, direction: direction} = sorting,
+        %Section{id: _section_id} = section,
+        %Paging{limit: _limit, offset: _offset} = paging,
+        %Sorting{field: _field, direction: _direction} = sorting,
         %EnrollmentBrowseOptions{} = options
       ) do
         browse_enrollments_query(
           section, paging, sorting, options
         )
-        |> join(:left, [e, _, p], ecr in EnrollmentContextRole, on: ecr.enrollment_id == e.id)
-        |> join(:left, [_, u], pr in "users_platform_roles", on: pr.user_id == u.id)
+        |> join(:left, [_, e, p], ecr in EnrollmentContextRole, on: ecr.enrollment_id == e.id)
         |> group_by([_, _, _, ecr], [ecr.context_role_id])
-        |> preload([_, u, _, _, pr], user: {u, platform_roles: pr})
-        |> select_merge([e, u, p, ecr], %{context_role_id: ecr.context_role_id, payment: p, enrollment: e}) |> Repo.all()
+        |> preload([u], :platform_roles)
+        |> select_merge([u, e, p, ecr], %{context_role_id: ecr.context_role_id, payment: p, enrollment: e}) |> Repo.all()
   end
 
   @doc """

--- a/lib/oli/delivery/sections/enrollment.ex
+++ b/lib/oli/delivery/sections/enrollment.ex
@@ -13,6 +13,8 @@ defmodule Oli.Delivery.Sections.Enrollment do
       join_through: "enrollments_context_roles",
       on_replace: :delete
 
+    field :user_platform_roles, {:array, :map}, virtual: true
+
     timestamps(type: :utc_datetime)
   end
 

--- a/lib/oli/delivery/sections/enrollment.ex
+++ b/lib/oli/delivery/sections/enrollment.ex
@@ -13,8 +13,6 @@ defmodule Oli.Delivery.Sections.Enrollment do
       join_through: "enrollments_context_roles",
       on_replace: :delete
 
-    field :user_platform_roles, {:array, :map}, virtual: true
-
     timestamps(type: :utc_datetime)
   end
 

--- a/lib/oli_web/components/delivery/students/students.ex
+++ b/lib/oli_web/components/delivery/students/students.ex
@@ -21,7 +21,8 @@ defmodule OliWeb.Components.Delivery.Students do
     sort_order: :asc,
     sort_by: :name,
     text_search: nil,
-    filter_by: :enrolled
+    filter_by: :enrolled,
+    payment_status: nil
   }
 
   def update(
@@ -140,6 +141,12 @@ defmodule OliWeb.Components.Delivery.Students do
       :overall_mastery ->
         Enum.sort_by(students, fn student -> student.overall_mastery end, sort_order)
 
+      :engagement ->
+        Enum.sort_by(students, fn student -> student.engagement end, sort_order)
+
+      :payment_status ->
+        Enum.sort_by(students, fn student -> student.payment_status end, sort_order)
+
       _ ->
         Enum.sort_by(
           students,
@@ -257,7 +264,7 @@ defmodule OliWeb.Components.Delivery.Students do
         Params.get_atom_param(
           params,
           "sort_by",
-          [:name, :last_interaction, :progress, :overall_mastery],
+          [:name, :last_interaction, :progress, :overall_mastery, :engagement, :payment_status],
           @default_params.sort_by
         ),
       text_search: Params.get_param(params, "text_search", @default_params.text_search),

--- a/lib/oli_web/live/sections/enrollments/enrollments_view.ex
+++ b/lib/oli_web/live/sections/enrollments/enrollments_view.ex
@@ -203,8 +203,6 @@ defmodule OliWeb.Sections.EnrollmentsView do
       |> add_students_progress(section.id, nil)
       |> add_payment_status(section)
 
-      IO.inspect enrollments
-
     total_count = determine_total(enrollments)
 
     {:ok, table_model} = EnrollmentsTableModel.new(enrollments, section, context)
@@ -219,12 +217,6 @@ defmodule OliWeb.Sections.EnrollmentsView do
       Map.merge(user, %{progress: Map.get(users_progress, user.id)})
     end)
   end
-
-  # defp add_payment_status(users, section) do
-  #   Enum.map(users, fn user ->
-  #     Map.merge(user, %{payment_status: :paid, payment_date: DateTime.utc_now()})
-  #   end)
-  # end
 
   defp add_payment_status(users, section) do
     Enum.map(users, fn user ->

--- a/lib/oli_web/live/sections/enrollments_table_model.ex
+++ b/lib/oli_web/live/sections/enrollments_table_model.ex
@@ -37,12 +37,6 @@ defmodule OliWeb.Delivery.Sections.EnrollmentsTableModel do
         th_class: "instructor_dashboard_th"
       },
       %ColumnSpec{
-        name: :engagement,
-        label: "COURSE ENGAGEMENT",
-        render_fn: &__MODULE__.render_engagement_column/3,
-        th_class: "instructor_dashboard_th"
-      },
-      %ColumnSpec{
         name: :payment_status,
         label: "PAYMENT STATUS",
         render_fn: &__MODULE__.render_payment_status/3,

--- a/lib/oli_web/live/sections/enrollments_table_model.ex
+++ b/lib/oli_web/live/sections/enrollments_table_model.ex
@@ -11,38 +11,45 @@ defmodule OliWeb.Delivery.Sections.EnrollmentsTableModel do
   end
 
   def new(users, section, context) do
-    column_specs = [
-      %ColumnSpec{
-        name: :name,
-        label: "STUDENT NAME",
-        render_fn: &__MODULE__.render_name_column/3,
-        th_class: "pl-10 instructor_dashboard_th"
-      },
-      %ColumnSpec{
-        name: :last_interaction,
-        label: "LAST INTERACTED",
-        render_fn: &__MODULE__.render_last_interaction_column/3,
-        th_class: "instructor_dashboard_th"
-      },
-      %ColumnSpec{
-        name: :progress,
-        label: "COURSE PROGRESS",
-        render_fn: &__MODULE__.render_progress_column/3,
-        th_class: "instructor_dashboard_th"
-      },
-      %ColumnSpec{
-        name: :overall_mastery,
-        label: "OVERALL COURSE MASTERY",
-        render_fn: &__MODULE__.render_overall_mastery_column/3,
-        th_class: "instructor_dashboard_th"
-      },
-      %ColumnSpec{
-        name: :payment_status,
-        label: "PAYMENT STATUS",
-        render_fn: &__MODULE__.render_payment_status/3,
-        th_class: "instructor_dashboard_th"
-      }
-    ]
+    column_specs =
+      [
+        %ColumnSpec{
+          name: :name,
+          label: "STUDENT NAME",
+          render_fn: &__MODULE__.render_name_column/3,
+          th_class: "pl-10 instructor_dashboard_th"
+        },
+        %ColumnSpec{
+          name: :last_interaction,
+          label: "LAST INTERACTED",
+          render_fn: &__MODULE__.render_last_interaction_column/3,
+          th_class: "instructor_dashboard_th"
+        },
+        %ColumnSpec{
+          name: :progress,
+          label: "COURSE PROGRESS",
+          render_fn: &__MODULE__.render_progress_column/3,
+          th_class: "instructor_dashboard_th"
+        },
+        %ColumnSpec{
+          name: :overall_mastery,
+          label: "OVERALL COURSE MASTERY",
+          render_fn: &__MODULE__.render_overall_mastery_column/3,
+          th_class: "instructor_dashboard_th"
+        }
+      ] ++
+        if section.requires_payment do
+          [
+            %ColumnSpec{
+              name: :payment_status,
+              label: "PAYMENT STATUS",
+              render_fn: &__MODULE__.render_payment_status/3,
+              th_class: "instructor_dashboard_th"
+            }
+          ]
+        else
+          []
+        end
 
     SortableTableModel.new(
       rows: users,


### PR DESCRIPTION
[MER-1948](https://eliterate.atlassian.net/browse/MER-1948)

This PR adds a column to show the `payment status` for users in the table that is rendered within the `students` tab on the `instructor dashboard`.

In addition, this new column is also shown in the enrollments view for an author/admin.

![Captura de pantalla 2023-05-24 a la(s) 13 36 12](https://github.com/Simon-Initiative/oli-torus/assets/16328384/b1cc3f9a-d32b-46b7-ae94-adf41efbfe4f)

[MER-1948]: https://eliterate.atlassian.net/browse/MER-1948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ