### PR TITLE
[MER-2056] Schedule top-level pages

### DIFF
--- a/assets/src/apps/scheduler/ScheduleGrid.tsx
+++ b/assets/src/apps/scheduler/ScheduleGrid.tsx
@@ -6,7 +6,6 @@ import { ScheduleHeaderRow } from './ScheduleHeader';
 import { ScheduleLine } from './ScheduleLine';
 import { generateDayGeometry } from './date-utils';
 import { getTopLevelSchedule } from './schedule-selectors';
-import { ScheduleItemType } from './scheduler-slice';
 
 interface GridProps {
   startDate: string;
@@ -47,11 +46,9 @@ export const ScheduleGrid: React.FC<GridProps> = ({ startDate, endDate, onReset 
             />
           </thead>
           <tbody>
-            {schedule
-              .filter((item) => item.resource_type_id !== ScheduleItemType.Page)
-              .map((item) => (
-                <ScheduleLine key={item.id} indent={0} item={item} dayGeometry={dayGeometry} />
-              ))}
+            {schedule.map((item) => (
+              <ScheduleLine key={item.id} indent={0} item={item} dayGeometry={dayGeometry} />
+            ))}
           </tbody>
         </table>
       </div>

--- a/assets/src/apps/scheduler/ScheduleLine.tsx
+++ b/assets/src/apps/scheduler/ScheduleLine.tsx
@@ -28,6 +28,14 @@ interface ScheduleLineProps {
 }
 
 export const ScheduleLine: React.FC<ScheduleLineProps> = ({ item, indent, dayGeometry }) => {
+  return item.resource_type_id === ScheduleItemType.Page ? (
+    <PageScheduleLine item={item} indent={indent} dayGeometry={dayGeometry} />
+  ) : (
+    <ContainerScheduleLine item={item} indent={indent} dayGeometry={dayGeometry} />
+  );
+};
+
+const ContainerScheduleLine: React.FC<ScheduleLineProps> = ({ item, indent, dayGeometry }) => {
   const [expanded, toggleExpanded] = useToggle(false);
   const dispatch = useDispatch();
   const isSelected = useSelector(getSelectedId) === item.id;

--- a/assets/test/scheduler/schedule-reset_test.ts
+++ b/assets/test/scheduler/schedule-reset_test.ts
@@ -4,16 +4,38 @@ import {
   findNthDay,
   findStartEnd,
   findStartEndByPercent,
+  getPageCount,
+  getTotalPageCount,
 } from '../../src/apps/scheduler/schedule-reset';
+import { HierarchyItem, ScheduleItemType } from '../../src/apps/scheduler/scheduler-slice';
 
 const allDays = [true, true, true, true, true, true, true];
 const weekdays = [false, true, true, true, true, true, false];
+
+const hierarchItemTemplate: HierarchyItem = {
+  startDate: null,
+  endDate: null,
+  endDateTime: null,
+  children: [],
+  end_date: '',
+  start_date: '',
+  id: 0,
+  resource_id: 0,
+  resource_type_id: ScheduleItemType.Container,
+  scheduling_type: 'read_by',
+  title: '',
+  numbering_index: 0,
+  numbering_level: 0,
+  manually_scheduled: false,
+  graded: false,
+};
 
 describe('schedule-reset', () => {
   describe('findNthDay', () => {
     it('should return the first day', () => {
       expect(findNthDay(100, 1, allDays).getDaysSinceEpoch()).toEqual(100);
     });
+
     it('should return the first working day', () => {
       // The 100th day is 1970-04-11, which is a Saturday. So the first working day is 2 days later.
       expect(findNthDay(100, 1, weekdays).getDaysSinceEpoch()).toEqual(102);
@@ -71,31 +93,220 @@ describe('schedule-reset', () => {
     const toEpoq = (d: DateWithoutTime) => d.getDaysSinceEpoch();
 
     it("should find the first day's start and end", () => {
-      expect(findStartEndByPercent(new DateWithoutTime(10), 10, 0, 5, allDays).map(toEpoq)).toEqual(
-        [10, 11],
-      );
+      expect(
+        findStartEndByPercent(
+          new DateWithoutTime(10),
+          new DateWithoutTime(15),
+          10,
+          0,
+          5,
+          allDays,
+          1,
+          3,
+        ).map(toEpoq),
+      ).toEqual([10, 12]);
 
-      expect(findStartEndByPercent(new DateWithoutTime(10), 10, 0, 4, allDays).map(toEpoq)).toEqual(
-        [10, 12],
-      );
+      expect(
+        findStartEndByPercent(
+          new DateWithoutTime(10),
+          new DateWithoutTime(15),
+          10,
+          0,
+          4,
+          allDays,
+          1,
+          3,
+        ).map(toEpoq),
+      ).toEqual([10, 12]);
 
-      expect(findStartEndByPercent(new DateWithoutTime(10), 10, 0, 3, allDays).map(toEpoq)).toEqual(
-        [10, 13],
-      );
+      expect(
+        findStartEndByPercent(
+          new DateWithoutTime(10),
+          new DateWithoutTime(15),
+          10,
+          0,
+          3,
+          allDays,
+          1,
+          3,
+        ).map(toEpoq),
+      ).toEqual([10, 12]);
     });
 
     it("should find the second day's start and end", () => {
-      expect(findStartEndByPercent(new DateWithoutTime(10), 10, 1, 5, allDays).map(toEpoq)).toEqual(
-        [12, 13],
-      );
+      expect(
+        findStartEndByPercent(
+          new DateWithoutTime(10),
+          new DateWithoutTime(15),
+          10,
+          1,
+          5,
+          allDays,
+          1,
+          3,
+        ).map(toEpoq),
+      ).toEqual([10, 12]);
 
-      expect(findStartEndByPercent(new DateWithoutTime(10), 10, 1, 4, allDays).map(toEpoq)).toEqual(
-        [13, 15],
-      );
+      expect(
+        findStartEndByPercent(
+          new DateWithoutTime(13),
+          new DateWithoutTime(15),
+          10,
+          1,
+          4,
+          allDays,
+          1,
+          3,
+        ).map(toEpoq),
+      ).toEqual([13, 15]);
 
-      expect(findStartEndByPercent(new DateWithoutTime(10), 10, 1, 3, allDays).map(toEpoq)).toEqual(
-        [14, 17],
-      );
+      expect(
+        findStartEndByPercent(
+          new DateWithoutTime(14),
+          new DateWithoutTime(15),
+          10,
+          1,
+          3,
+          allDays,
+          1,
+          3,
+        ).map(toEpoq),
+      ).toEqual([14, 16]);
+    });
+  });
+
+  describe('getPageCount', () => {
+    it('returns 0 when item is undefined', () => {
+      expect(getPageCount(undefined, [])).toBe(0);
+    });
+
+    it('returns 1 when item is a page', () => {
+      const item: HierarchyItem = {
+        ...hierarchItemTemplate,
+        resource_type_id: ScheduleItemType.Page,
+        children: [],
+      };
+      expect(getPageCount(item, [])).toBe(1);
+    });
+
+    it('returns 1 when item has no children', () => {
+      const item: HierarchyItem = {
+        ...hierarchItemTemplate,
+        resource_type_id: ScheduleItemType.Container,
+        children: [],
+      };
+      expect(getPageCount(item, [])).toBe(1);
+    });
+
+    it("returns sum of children's page count", () => {
+      const item1: HierarchyItem = {
+        ...hierarchItemTemplate,
+        resource_type_id: ScheduleItemType.Container,
+        children: [2, 3],
+        id: 1,
+      };
+      const item2: HierarchyItem = {
+        ...hierarchItemTemplate,
+        resource_type_id: ScheduleItemType.Page,
+        children: [],
+        id: 2,
+      };
+      const item3: HierarchyItem = {
+        ...hierarchItemTemplate,
+        resource_type_id: ScheduleItemType.Container,
+        children: [4],
+        id: 3,
+      };
+      const item4: HierarchyItem = {
+        ...hierarchItemTemplate,
+        resource_type_id: ScheduleItemType.Page,
+        children: [],
+        id: 4,
+      };
+      const schedule: HierarchyItem[] = [item1, item2, item3, item4];
+
+      expect(getPageCount(item1, schedule)).toBe(2);
+      expect(getPageCount(item3, schedule)).toBe(1);
+    });
+
+    it('returns 1 for empty units', () => {
+      const item: HierarchyItem = {
+        ...hierarchItemTemplate,
+        resource_type_id: ScheduleItemType.Container,
+        children: [],
+      };
+      expect(getPageCount(item, [])).toBe(1);
+    });
+  });
+
+  describe('getTotalPageCount', () => {
+    it('should return 0 when given an empty array', () => {
+      const schedule: HierarchyItem[] = [];
+      const result = getTotalPageCount(schedule);
+      expect(result).toBe(0);
+    });
+
+    it('should return the number of pages in the schedule', () => {
+      const schedule: HierarchyItem[] = [
+        {
+          ...hierarchItemTemplate,
+          id: 1,
+          resource_id: 1,
+          resource_type_id: ScheduleItemType.Page,
+        },
+        {
+          ...hierarchItemTemplate,
+          id: 2,
+          resource_id: 2,
+          resource_type_id: ScheduleItemType.Container,
+        },
+        {
+          ...hierarchItemTemplate,
+          id: 3,
+          resource_type_id: ScheduleItemType.Page,
+          scheduling_type: 'due_by',
+        },
+      ];
+      const result = getTotalPageCount(schedule);
+      expect(result).toBe(3);
+    });
+
+    it('should count containers with no children as pages', () => {
+      const schedule: HierarchyItem[] = [
+        {
+          ...hierarchItemTemplate,
+
+          id: 1,
+          resource_id: 1,
+          resource_type_id: ScheduleItemType.Container,
+        },
+        {
+          ...hierarchItemTemplate,
+          children: [2],
+
+          id: 3,
+          resource_id: 3,
+          resource_type_id: ScheduleItemType.Container,
+        },
+        {
+          ...hierarchItemTemplate,
+
+          children: [],
+          end_date: '',
+          start_date: '',
+          id: 2,
+          resource_id: 2,
+          resource_type_id: ScheduleItemType.Page,
+          scheduling_type: 'due_by',
+          title: '',
+          numbering_index: 0,
+          numbering_level: 0,
+          manually_scheduled: false,
+          graded: false,
+        },
+      ];
+      const result = getTotalPageCount(schedule);
+      expect(result).toBe(2);
     });
   });
 });


### PR DESCRIPTION
1. You can schedule top-level pages now.
2. The schedule reset functionality now takes the number of pages into account when laying out a schedule to size items more appropriately.

![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/4cfb5d2d-fd62-4fde-8b4f-ee4a2d750f2f)

![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/7851db37-bb3b-4374-a521-124290a35ad5)
