### PR TITLE
[ENHANCEMENT] Allow preview of gated resources [MER-1921]

### DIFF
--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -792,7 +792,6 @@ defmodule OliWeb.Router do
     pipe_through([
       :browser,
       :delivery_and_admin,
-      :maybe_gated_resource,
       :pow_email_layout
     ])
 
@@ -819,7 +818,6 @@ defmodule OliWeb.Router do
     pipe_through([
       :browser,
       :delivery_and_admin,
-      :maybe_gated_resource,
       :pow_email_layout
     ])
 
@@ -836,7 +834,6 @@ defmodule OliWeb.Router do
     pipe_through([
       :browser,
       :delivery_and_admin,
-      :maybe_gated_resource,
       :pow_email_layout
     ])
 


### PR DESCRIPTION
There were three places in the router where the `maybe_gated_resource` plug was being used that didn't need to exist.  I've removed those.

But in the end, left the plug in place to guard page access as a student, even for instructors. There's a bit too much work to adjust at this point of the release to allow for instructors to bypass hard gates.  Given that they can bypass hard gates to "Access as an instructor" (which is now the default and more prominent option in the course content browser), this is a decent workaround for now. 