### PR TITLE
[BUG FIX] Remove hardcoded chemistry references [MER-2088]

### DIFF
--- a/lib/oli_web/live/delivery/student_onboarding/wizard.ex
+++ b/lib/oli_web/live/delivery/student_onboarding/wizard.ex
@@ -26,7 +26,7 @@ defmodule OliWeb.Delivery.StudentOnboarding.Wizard do
     introduction_step = %Step{
       title: "Introduction",
       description:
-        "Welcome to Chemistry 101! Here's what you can expect during this set up process.",
+        "Welcome to #{section.title}! Here's what you can expect during this set up process.",
       render_fn: &render_step/1,
       data: %{},
       next_button_label:
@@ -65,7 +65,7 @@ defmodule OliWeb.Delivery.StudentOnboarding.Wizard do
 
     exploration_step = %Step{
       title: "Explorations",
-      description: "An introduction to Explorations -- real world chemistry applications.",
+      description: "An introduction to Explorations -- real world applications.",
       render_fn: &render_step/1,
       data: %{},
       next_button_label: @course_label,

--- a/test/oli_web/live/delivery/onboarding_wizard/student_onboarding_wizard_test.exs
+++ b/test/oli_web/live/delivery/onboarding_wizard/student_onboarding_wizard_test.exs
@@ -59,18 +59,18 @@ defmodule OliWeb.Deliver.StudentOnboarding.WizardTest do
     setup [:user_conn]
 
     test "the introduction step gets rendered", %{conn: conn, user: student} do
-      %{section: section} = basic_section(nil, %{title: "Chemistry 101"})
+      %{section: section} = basic_section(nil, %{title: "Chemistry 201"})
       enroll_student(student, section)
 
       {:ok, view, _html} = live(conn, onboarding_wizard_route(section.slug))
 
-      assert has_element?(view, "h5", "Chemistry 101 Set Up")
-      assert has_element?(view, "h2", "Welcome to Chemistry 101!")
+      assert has_element?(view, "h5", "Chemistry 201 Set Up")
+      assert has_element?(view, "h2", "Welcome to Chemistry 201!")
 
       assert has_element?(
                view,
                "li",
-               "A personalized Chemistry 101 experience based on your skillsets"
+               "A personalized Chemistry 201 experience based on your skillsets"
              )
 
       refute has_element?(


### PR DESCRIPTION
Removed two chemistry references. Added some variety to the underlying test infra to ensure it is data driven. 