### PR TITLE
[BUG FIX] optimize query knowing that project_id is now part of the snapshot [MER-2090]

### DIFF
--- a/lib/oli/delivery/attempts/core.ex
+++ b/lib/oli/delivery/attempts/core.ex
@@ -11,10 +11,8 @@ defmodule Oli.Delivery.Attempts.Core do
   alias Oli.Publishing.PublishedResource
   alias Oli.Resources.Revision
   alias Oli.Delivery.Sections.SectionsProjectsPublications
-  alias Oli.Authoring.Course.Project
   alias Oli.Delivery.Snapshots.Snapshot
   alias Oli.Accounts.User
-  alias Oli.Authoring.Course.ProjectResource
 
   alias Oli.Delivery.Attempts.Core.{
     PartAttempt,
@@ -421,23 +419,13 @@ defmodule Oli.Delivery.Attempts.Core do
   def get_part_attempts_and_users(project_id) do
     # This is our base, reusable query designed to get the part attempts
     core =
-      from project in Project,
-        join: spp in SectionsProjectsPublications,
-        on: spp.project_id == project.id,
-        join: section in Section,
-        on: spp.section_id == section.id,
-        join: project_resource in ProjectResource,
-        on: project_resource.project_id == ^project_id,
-        join: snapshot in Snapshot,
+      from snapshot in Snapshot,
         as: :snapshot,
-        on:
-          snapshot.section_id == section.id and
-            snapshot.resource_id == project_resource.resource_id,
         join: part_attempt in PartAttempt,
         as: :part_attempt,
         on: snapshot.part_attempt_id == part_attempt.id,
         where:
-          project.id == ^project_id and
+          snapshot.project_id == ^project_id and
             part_attempt.lifecycle_state == :evaluated
 
     # Now get the resource attempt revision for those part attempts, distinctly, and
@@ -453,6 +441,7 @@ defmodule Oli.Delivery.Attempts.Core do
         distinct: true,
         select: r
       )
+      |> Oli.Utils.Database.explain()
       |> Repo.all()
       |> Enum.reduce(%{}, fn r, m -> Map.put(m, r.id, r) end)
 

--- a/lib/oli/delivery/attempts/core.ex
+++ b/lib/oli/delivery/attempts/core.ex
@@ -441,7 +441,6 @@ defmodule Oli.Delivery.Attempts.Core do
         distinct: true,
         select: r
       )
-      |> Oli.Utils.Database.explain()
       |> Repo.all()
       |> Enum.reduce(%{}, fn r, m -> Map.put(m, r.id, r) end)
 


### PR DESCRIPTION
This original query went thru several joins so that it could only return part attempts from `snapshots` that pertain to a certain project. The field `project_id` was later added directly to the `snapshots` schema, but this query was never updated to take advantage of that. 

`EXPLAIN` shows a halving of the complexity of this query.  From `68` down to around `31` total cost.  There are many intermediate steps that it also removed, including a potentially expensive sort on revisions. 