### PR TITLE
[BUG FIX] Handle activity to activity references on ingest [MER-2093]

### DIFF
--- a/lib/oli/interop/ingest/processor.ex
+++ b/lib/oli/interop/ingest/processor.ex
@@ -18,7 +18,8 @@ defmodule Oli.Interop.Ingest.Processor do
     BibEntries,
     Hyperlinks,
     PublishedResources,
-    MediaItems
+    MediaItems,
+    InternalActivityRefs
   }
 
   def process(%State{} = state) do
@@ -33,6 +34,7 @@ defmodule Oli.Interop.Ingest.Processor do
       |> Activities.process()
       |> Pages.process()
       |> PublishedResources.process()
+      |> InternalActivityRefs.process()
       |> Hyperlinks.process()
       |> Hierarchy.process()
       |> Products.process()

--- a/lib/oli/interop/ingest/processor/internal_activity_refs.ex
+++ b/lib/oli/interop/ingest/processor/internal_activity_refs.ex
@@ -1,0 +1,79 @@
+defmodule Oli.Interop.Ingest.Processor.InternalActivityRefs do
+  import Ecto.Query, warn: false
+  alias Oli.Repo
+  alias Oli.Interop.Ingest.State
+
+  @doc """
+  Makes a pass across all activities to rewire internal activity references. Currently
+  the only place this is used is in the flowchart paths, where the destinationScreenId
+  is a reference to a resource id of another activity.
+  """
+  def process(
+        %State{project: project, legacy_to_resource_id_map: legacy_to_resource_id_map} = state
+      ) do
+    State.notify_step_start(state, :internal_activity_refs)
+
+    resource_id_to_legacy =
+      Enum.reduce(legacy_to_resource_id_map, %{}, fn {legacy_id, resource_id}, m ->
+        Map.put(m, resource_id, legacy_id)
+      end)
+
+    activity_map =
+      Oli.Publishing.query_unpublished_revisions_by_type(project.slug, "activity")
+      |> Repo.all()
+      |> Enum.reduce(%{}, fn r, m ->
+        Map.put(m, Map.get(resource_id_to_legacy, r.resource_id), r)
+      end)
+
+    rewire_all_internal_refs(activity_map)
+
+    state
+  end
+
+  def rewire_all_internal_refs(activity_map) do
+    Map.values(activity_map)
+    |> Enum.map(fn revision ->
+      rewire_internal_refs(revision, activity_map)
+    end)
+  end
+
+  defp rewire_internal_refs(revision, activity_map) do
+
+    try do
+
+      case revision.content do
+        %{"authoring" => %{"flowchart" => %{"paths" => paths} = flowchart} = authoring} ->
+
+          if Enum.any?(paths, fn p -> Map.has_key?(p, "destinationScreenId") end) do
+
+            paths = Enum.map(paths, fn path ->
+              case path do
+                %{"destinationScreenId" => id} ->
+
+                  id_as_str = Integer.to_string(id)
+                  Map.put(path, "destinationScreenId", Map.get(activity_map, id_as_str).resource_id)
+
+                other -> other
+              end
+            end)
+
+            flowchart = Map.put(flowchart, "paths", paths)
+            authoring = Map.put(authoring, "flowchart", flowchart)
+            content = Map.put(revision.content, "authoring", authoring)
+
+            Oli.Resources.update_revision(revision, %{content: content})
+
+          else
+            {:ok, revision}
+          end
+
+        _ ->
+          {:ok, revision}
+      end
+
+    rescue
+      _ in KeyError -> {:ok, revision}
+    end
+  end
+
+end


### PR DESCRIPTION
The flowchart based adaptive page introduces activity to activity references via resource ids.  These have to be updated to their new resource ids after one exports a project with a flowchart page, then re-ingests. 

How to test this end to end:

1. Create a three screen, flowchart based adaptive page.
2. Export that project.
3. Using V2 ingest, ingest that zip file.
4. Verify that the links still exist between the three screens. 

