### PR TITLE
[FEATURE] [MER-1955} Bypass payment for a student

### DIFF
--- a/lib/oli/delivery/paywall/payment.ex
+++ b/lib/oli/delivery/paywall/payment.ex
@@ -20,7 +20,7 @@ defmodule Oli.Delivery.Paywall.Payment do
   """
 
   schema "payments" do
-    field :type, Ecto.Enum, values: [:direct, :deferred], default: :direct
+    field :type, Ecto.Enum, values: [:direct, :deferred, :bypass], default: :direct
     field :code, :integer
     field :generation_date, :utc_datetime
     field :application_date, :utc_datetime
@@ -30,6 +30,7 @@ defmodule Oli.Delivery.Paywall.Payment do
     field :provider_payload, :map
     field :pending_user_id, :integer
     field :pending_section_id, :integer
+    field :bypassed_by_user_id, :integer
 
     belongs_to :section, Oli.Delivery.Sections.Section
     belongs_to :enrollment, Oli.Delivery.Sections.Enrollment
@@ -52,7 +53,8 @@ defmodule Oli.Delivery.Paywall.Payment do
       :pending_user_id,
       :pending_section_id,
       :section_id,
-      :enrollment_id
+      :enrollment_id,
+      :bypassed_by_user_id
     ])
     |> validate_required([:type, :generation_date, :amount, :section_id])
   end

--- a/lib/oli_web/live/delivery/student_dashboard/student_dashboard_live.ex
+++ b/lib/oli_web/live/delivery/student_dashboard/student_dashboard_live.ex
@@ -98,7 +98,8 @@ defmodule OliWeb.Delivery.StudentDashboard.StudentDashboardLive do
       |> assign_new(:enrollment_info, fn ->
         %{
           enrollment: enrollment,
-          user_role_id: Sections.get_user_role_from_enrollment(enrollment)
+          user_role_id: Sections.get_user_role_from_enrollment(enrollment),
+          current_user: socket.assigns.current_user
         }
       end)
 
@@ -185,7 +186,7 @@ defmodule OliWeb.Delivery.StudentDashboard.StudentDashboardLive do
         id="actions_table"
         module={OliWeb.Components.Delivery.Actions}
         user={@student}
-        section_slug={@section.slug}
+        section={@section}
         enrollment_info={@enrollment_info}
       />
     """

--- a/priv/repo/migrations/20230530172546_add_bypassed_by_field.exs
+++ b/priv/repo/migrations/20230530172546_add_bypassed_by_field.exs
@@ -1,0 +1,9 @@
+defmodule Oli.Repo.Migrations.AddBypassedByField do
+  use Ecto.Migration
+
+  def change do
+    alter table(:payments) do
+      add :bypassed_by_user_id, :integer, null: true
+    end
+  end
+end


### PR DESCRIPTION
[MER-1955](https://eliterate.atlassian.net/browse/MER-1955)

This PR adds the possibility for an admin user to bypass a student's payment. This new functionality is added in the actions tab for the student's dashboard.
If the student has already made a payment the button to bypass payment will be disabled.

<img width="1436" alt="Captura de pantalla 2023-06-01 a la(s) 17 02 48" src="https://github.com/Simon-Initiative/oli-torus/assets/16328384/2cccf8ea-2c73-4cc4-9f4b-c4687160de0c">

<img width="1436" alt="Captura de pantalla 2023-06-01 a la(s) 17 03 09" src="https://github.com/Simon-Initiative/oli-torus/assets/16328384/edd7d44d-70cb-4fd7-a62c-ce21f8423769">

[MER-1955]: https://eliterate.atlassian.net/browse/MER-1955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ