### PR TITLE
fix: Update developer.md to fix a link #3611

### DIFF
--- a/guides/starting/developer.md
+++ b/guides/starting/developer.md
@@ -193,4 +193,4 @@ When making an LTI connection from an LMS such as Canvas, we need an internet ac
 
 Torus supports LTI 1.3 integration and leverages the Learning Management System for course delivery.
 
-To configure an LTI connection, refer to the [Torus LTI 1.3 Manual Configuration](https://github.com/Simon-Initiative/oli-torus/wiki/Torus-LTI-1.3-Manual-Configuration).
+To configure an LTI connection, refer to the [Torus LTI 1.3 Manual Configuration](https://github.com/Simon-Initiative/oli-torus/wiki/Torus-LTI-1.3-Configuration).


### PR DESCRIPTION
**Addressing issue #3611**
Broken link to LTI configuration page on https://simon-initiative.github.io/oli-torus/developer.html

**Proposed Change:**
Changes what looks to be a stale or incorrect link to https://github.com/Simon-Initiative/oli-torus/wiki/Torus-LTI-1.3-Manual-Configuration which does not exist to https://github.com/Simon-Initiative/oli-torus/wiki/Torus-LTI-1.3-Configuration

**Alternatives:**
No other relevant documents seem to exist within the wiki, so the assumption is that the new link was the intended one.

**Verification:**
I used the github online editor to make the change which includes a preview feature to verify that the link points to the existing document.