### PR TITLE
[BUG FIX] fixes to make demo work

### DIFF
--- a/lib/oli/delivery/attempts/core.ex
+++ b/lib/oli/delivery/attempts/core.ex
@@ -677,15 +677,15 @@ defmodule Oli.Delivery.Attempts.Core do
     )
   end
 
-  def is_first_activity_attempt?(activity_attempt_guid) do
-    attempt_number = Repo.one(
+  def is_scoreable_first_attempt?(activity_attempt_guid) do
+    {attempt_number, scoreable} = Repo.one(
       from(a in ActivityAttempt,
         where: a.attempt_guid == ^activity_attempt_guid,
-        select: a.attempt_number
+        select: {a.attempt_number, a.scoreable}
       )
     )
-    case attempt_number do
-      1 -> true
+    case {attempt_number, scoreable} do
+      {1, true} -> true
       _ -> false
     end
   end

--- a/lib/oli/delivery/recommended_actions.ex
+++ b/lib/oli/delivery/recommended_actions.ex
@@ -19,16 +19,16 @@ defmodule Oli.Delivery.RecommendedActions do
   end
 
   def section_has_scheduled_resources?(section_id) do
-    section_resource_query()
+    items = section_resource_query()
     |> where(
       [sr],
-      sr.section_id == ^section_id and not (is_nil(sr.start_date) and is_nil(sr.end_date))
+      sr.section_id == ^section_id and (not is_nil(sr.start_date) or not is_nil(sr.end_date))
     )
     |> select([sr], sr.id)
     |> limit(1)
-    |> Repo.one()
-    |> is_nil()
-    |> Kernel.!()
+    |> Repo.all()
+
+    Enum.count(items) > 0
   end
 
   def section_scoring_pending_activities(section_id) do

--- a/lib/oli_web/components/delivery/recommended_actions.ex
+++ b/lib/oli_web/components/delivery/recommended_actions.ex
@@ -27,12 +27,12 @@ defmodule OliWeb.Components.Delivery.RecommendedActions do
   def render(assigns) do
     ~H"""
       <div class="grid grid-cols-2 gap-2">
-        <%= if @has_scheduled_resources do %>
+        <%= if !@has_scheduled_resources do %>
           <.action_card to={Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.ScheduleView, @section_slug)}>
             <:icon><i class="fa-regular fa-calendar" /></:icon>
-            <:title>Soft Scheduling</:title>
+            <:title>Scheduling</:title>
             <:description>
-              You have not define a schedule for your course content
+              You have not defined a schedule for your course content
             </:description>
           </.action_card>
         <% end %>

--- a/test/oli/delivery/metrics/progress_test.exs
+++ b/test/oli/delivery/metrics/progress_test.exs
@@ -243,7 +243,7 @@ defmodule Oli.Delivery.Metrics.ProgressTest do
           :a5
         )
 
-      guid = map.a5.attempt_guid
+      guid = map.a4.attempt_guid
       assert {:ok, :updated} = Metrics.update_page_progress(guid)
 
       ra = Oli.Repo.get(ResourceAccess, map.attempt1.resource_access_id)

--- a/test/oli_web/live/delivery/instructor_dashboard/overview/recommended_actions_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/overview/recommended_actions_tab_test.exs
@@ -52,7 +52,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.Overview.RecommendedActionsTest do
 
       {:ok, view, _html} = live(conn, instructor_course_content_path(section.slug))
 
-      assert has_element?(view, "h4", "Soft Scheduling")
+      assert has_element?(view, "h4", "Scheduling")
       assert has_element?(view, "span", "You have not define a schedule for your course content")
     end
 

--- a/test/oli_web/live/delivery/instructor_dashboard/overview/recommended_actions_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/overview/recommended_actions_tab_test.exs
@@ -36,7 +36,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.Overview.RecommendedActionsTest do
       assert has_element?(view, "span", "No action needed")
     end
 
-    test "renders the \"soft scheduling\" action when necessary", %{
+    test "does not render the \"soft scheduling\" action when necessary", %{
       conn: conn,
       section: section
     } do
@@ -50,10 +50,22 @@ defmodule OliWeb.Delivery.InstructorDashboard.Overview.RecommendedActionsTest do
       |> Oli.Delivery.Sections.SectionResource.changeset(%{start_date: start_date})
       |> Repo.update()
 
+      assert Oli.Delivery.RecommendedActions.section_has_scheduled_resources?(section.id)
+
       {:ok, view, _html} = live(conn, instructor_course_content_path(section.slug))
 
-      assert has_element?(view, "h4", "Scheduling")
-      assert has_element?(view, "span", "You have not define a schedule for your course content")
+      refute has_element?(view, "h4", "Scheduling")
+      refute has_element?(view, "span", "You have not defined a schedule for your course content")
+    end
+
+    test "renders the \"soft scheduling\" action when necessary", %{
+      conn: conn,
+      section: section
+    } do
+
+      {:ok, _view, _html} = live(conn, instructor_course_content_path(section.slug))
+
+      refute Oli.Delivery.RecommendedActions.section_has_scheduled_resources?(section.id)
     end
 
     test "renders the \"pending approval posts\" action when necessary", %{


### PR DESCRIPTION
Encountered and fixed a few things when prepping for a demo:

1. Course progress calculation breaks on a page that ONLY contains survey activities.  
2. `section_has_scheduled_resources` logic was inverted and reported that no schedule existed when one did exist
