### PR TITLE
[MER-2055] Sort student by last name

### DIFF
--- a/test/oli/grading_test.exs
+++ b/test/oli/grading_test.exs
@@ -196,9 +196,9 @@ defmodule Oli.GradingTest do
       expected_csv = """
       Student,Page one,Page two\r
           Points Possible,20.0,5.0\r
-      Ms Jane Marie Doe (jane0@platform.example.edu),12.0,0.0\r
-      Ms Jane Marie Doe (jane1@platform.example.edu),20.0,3.0\r
-      Ms Jane Marie Doe (jane2@platform.example.edu),19.0,5.0\r
+      "Doe, Jane (jane0@platform.example.edu)",12.0,0.0\r
+      "Doe, Jane (jane1@platform.example.edu)",20.0,3.0\r
+      "Doe, Jane (jane2@platform.example.edu)",19.0,5.0\r
       """
 
       csv = Grading.export_csv(section) |> Enum.join("")

--- a/test/oli_web/live/grades_live_test.exs
+++ b/test/oli_web/live/grades_live_test.exs
@@ -8,7 +8,7 @@ defmodule OliWeb.GradesLiveTest do
 
   alias Oli.Test.MockHTTP
   alias OliWeb.Router.Helpers, as: Routes
-  # alias Oli.Delivery.Sections
+  alias OliWeb.Common.Utils
   alias Oli.Delivery.Sections.Section
 
   defp live_view_grades_route(section_slug) do
@@ -28,11 +28,8 @@ defmodule OliWeb.GradesLiveTest do
 
     deployment = insert(:lti_deployment, %{registration: registration})
 
-    {:ok,
-      section: section,
-      unit_one_revision: _unit_one_revision,
-      page_revision: page_revision
-    } = section_with_assessment(%{}, deployment)
+    {:ok, section: section, unit_one_revision: _unit_one_revision, page_revision: page_revision} =
+      section_with_assessment(%{}, deployment)
 
     [section: section, page_revision: page_revision]
   end
@@ -45,11 +42,8 @@ defmodule OliWeb.GradesLiveTest do
 
     deployment = insert(:lti_deployment, %{registration: registration})
 
-    {:ok,
-      section: section,
-      unit_one_revision: _unit_one_revision,
-      page_revision: _page_revision
-    } = section_with_assessment(%{}, deployment)
+    {:ok, section: section, unit_one_revision: _unit_one_revision, page_revision: _page_revision} =
+      section_with_assessment(%{}, deployment)
 
     [section: section]
   end
@@ -143,11 +137,11 @@ defmodule OliWeb.GradesLiveTest do
 
       expect(MockHTTP, :get, fn ^url_line_items, _headers ->
         {:ok,
-          %HTTPoison.Response{
-            status_code: 200,
-            body:
-              "[{ \"id\": \"id\", \"scoreMaximum\": \"scoreMaximum\", \"resourceId\": \"resourceId\", \"label\": \"label\" }]"
-          }}
+         %HTTPoison.Response{
+           status_code: 200,
+           body:
+             "[{ \"id\": \"id\", \"scoreMaximum\": \"scoreMaximum\", \"resourceId\": \"resourceId\", \"label\": \"label\" }]"
+         }}
       end)
 
       {:ok, view, _html} = live(conn, live_view_grades_route(section.slug))
@@ -201,10 +195,11 @@ defmodule OliWeb.GradesLiveTest do
 
       expect(MockHTTP, :get, fn ^url_line_items, _headers ->
         {:ok,
-          %HTTPoison.Response{
-            status_code: 200,
-            body: "[{\"id\": \"1\", \"label\":\"#{page_revision.title}\", \"resourceId\":\"oli-torus-#{page_revision.resource_id}\", \"scoreMaximum\":1.0}]"
-          }}
+         %HTTPoison.Response{
+           status_code: 200,
+           body:
+             "[{\"id\": \"1\", \"label\":\"#{page_revision.title}\", \"resourceId\":\"oli-torus-#{page_revision.resource_id}\", \"scoreMaximum\":1.0}]"
+         }}
       end)
 
       {:ok, view, _html} = live(conn, live_view_grades_route(section.slug))
@@ -227,21 +222,21 @@ defmodule OliWeb.GradesLiveTest do
       line_items_service_url = section.line_items_service_url
 
       expect(MockHTTP, :get, fn ^url_line_items, _headers ->
-          {:ok,
-          %HTTPoison.Response{
-            status_code: 200,
-            body:
-              "[{ \"id\": \"id\", \"scoreMaximum\": \"scoreMaximum\", \"resourceId\": \"resourceId\", \"label\": \"label\" }]"
-          }}
+        {:ok,
+         %HTTPoison.Response{
+           status_code: 200,
+           body:
+             "[{ \"id\": \"id\", \"scoreMaximum\": \"scoreMaximum\", \"resourceId\": \"resourceId\", \"label\": \"label\" }]"
+         }}
       end)
 
       expect(MockHTTP, :post, fn ^line_items_service_url, _body, _headers ->
-          {:ok,
-          %HTTPoison.Response{
-            status_code: 200,
-            body:
-              "{\"id\": \"1\", \"label\":\"Progress test revision\", \"resourceId\":\"oli-torus-1744\", \"scoreMaximum\":1.0}"
-          }}
+        {:ok,
+         %HTTPoison.Response{
+           status_code: 200,
+           body:
+             "{\"id\": \"1\", \"label\":\"Progress test revision\", \"resourceId\":\"oli-torus-1744\", \"scoreMaximum\":1.0}"
+         }}
       end)
 
       {:ok, view, _html} = live(conn, live_view_grades_route(section.slug))
@@ -375,7 +370,7 @@ defmodule OliWeb.GradesLiveTest do
         )
 
       assert response(conn, 200) =~
-              "Student,Progress test revision\r\n    Points Possible,#{@out_of}\r\n#{user_1.name} (#{user_1.email}),#{resource_access_1.score}\r\n#{user_2.name} (#{user_2.email}),#{resource_access_2.score}\r\n"
+               ~s{Student,Progress test revision\r\n    Points Possible,#{@out_of}\r\n"#{Utils.name(user_1.name, user_1.given_name, user_1.family_name)} (#{user_1.email})",#{resource_access_1.score}\r\n"#{Utils.name(user_2.name, user_2.given_name, user_2.family_name)} (#{user_2.email})",#{resource_access_2.score}\r\n}
     end
 
     test "download gradebook - download file without grades succesfully", %{
@@ -403,9 +398,8 @@ defmodule OliWeb.GradesLiveTest do
         )
 
       assert response(conn, 200) =~
-              "Student,Progress test revision\r\n    Points Possible,\r\n#{user_1.name} (#{user_1.email}),\r\n#{user_2.name} (#{user_2.email}),\r\n"
+               ~s{Student,Progress test revision\r\n    Points Possible,\r\n"#{Utils.name(user_1.name, user_1.given_name, user_1.family_name)} (#{user_1.email})",\r\n"#{Utils.name(user_2.name, user_2.given_name, user_2.family_name)} (#{user_2.email})",\r\n}
     end
-
   end
 
   describe "fetching invalid access token" do
@@ -427,10 +421,10 @@ defmodule OliWeb.GradesLiveTest do
     end
 
     test "update line items - shows error on failure to obtain access token",
-    %{
-      conn: conn,
-      section: section
-    } do
+         %{
+           conn: conn,
+           section: section
+         } do
       {:ok, view, _html} = live(conn, live_view_grades_route(section.slug))
 
       view
@@ -444,10 +438,10 @@ defmodule OliWeb.GradesLiveTest do
     end
 
     test "sync grades - shows error on failure to obtain access token",
-    %{
-      conn: conn,
-      section: section
-    } do
+         %{
+           conn: conn,
+           section: section
+         } do
       user = insert(:user)
       enroll_user_to_section(user, section, :context_learner)
 


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-2055) to the ticket

“Manage Student Enrollments” and “View all Grades” were already sorted by last name.
The .csv export of this data was updated to be sorted as required.

<img width="286" alt="image" src="https://github.com/Simon-Initiative/oli-torus/assets/74839302/12f3a1c7-8444-4740-8f23-669ab1cbab34">
