### PR TITLE
[MER-2085] Make it easier to delete tables

### DIFF
--- a/assets/src/components/editing/editor/Editor.tsx
+++ b/assets/src/components/editing/editor/Editor.tsx
@@ -7,6 +7,7 @@ import { Model } from 'data/content/model/elements/factories';
 import { Mark, Marks } from 'data/content/model/text';
 import { classNames } from 'utils/classNames';
 import { CommandContext, CommandDescription } from '../elements/commands/interfaces';
+import { backspaceBlockKeyDown, deleteBlockKeyDown } from './handlers/deleteblock';
 import { hotkeyHandler } from './handlers/hotkey';
 import { onKeyDown as listOnKeyDown } from './handlers/lists';
 import { onKeyDown as quoteOnKeyDown } from './handlers/quote';
@@ -77,14 +78,18 @@ export const Editor: React.FC<EditorProps> = React.memo((props: EditorProps) => 
     [props.commandContext],
   );
 
-  const onKeyDown = useCallback((e: React.KeyboardEvent) => {
-    voidOnKeyDown(editor, e);
-    listOnKeyDown(editor, e);
-    quoteOnKeyDown(editor, e);
-    titleOnKeyDown(editor, e);
-    hotkeyHandler(editor, e.nativeEvent, props.commandContext);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      voidOnKeyDown(editor, e);
+      listOnKeyDown(editor, e);
+      quoteOnKeyDown(editor, e);
+      titleOnKeyDown(editor, e);
+      hotkeyHandler(editor, e.nativeEvent, props.commandContext);
+      backspaceBlockKeyDown(editor, e);
+      deleteBlockKeyDown(editor, e);
+    },
+    [editor, props.commandContext],
+  );
 
   const renderLeaf = useCallback(({ attributes, children, leaf }: RenderLeafProps) => {
     const markup = Object.keys(leaf).reduce(

--- a/assets/src/components/editing/editor/handlers/deleteblock.ts
+++ b/assets/src/components/editing/editor/handlers/deleteblock.ts
@@ -1,0 +1,56 @@
+import { KeyboardEvent } from 'react';
+import { Range, Editor as SlateEditor, Transforms } from 'slate';
+
+const blocksToDelete: string[] = ['table'];
+
+const matchBlockToDelete = (node: any) => blocksToDelete.includes(node.type);
+
+const deleteOrBackspaceBlock = (
+  editor: SlateEditor,
+  e: KeyboardEvent,
+  direction: 'before' | 'after',
+) => {
+  try {
+    if (
+      (e.key === 'Delete' || e.key === 'Backspace') &&
+      editor.selection &&
+      Range.isCollapsed(editor.selection)
+    ) {
+      const [currentCursorPosition] = Range.edges(editor.selection);
+
+      const nextCursorPosition =
+        direction === 'before'
+          ? SlateEditor.before(editor, currentCursorPosition)
+          : SlateEditor.after(editor, currentCursorPosition);
+
+      if (!nextCursorPosition || !currentCursorPosition) return;
+
+      // If the cursor is currently inside a deletable block, do not delete the whole block.
+      const currentDeletableItem = SlateEditor.above(editor, {
+        at: currentCursorPosition,
+        match: matchBlockToDelete,
+      });
+
+      // If the cursor would end up inside a deletable block, delete the whole block.
+      const nextDeletableItem = SlateEditor.above(editor, {
+        at: nextCursorPosition,
+        match: matchBlockToDelete,
+      });
+
+      if (!currentDeletableItem && nextDeletableItem) {
+        Transforms.removeNodes(editor, { at: nextDeletableItem[1] });
+        e.preventDefault();
+      }
+    }
+  } catch (error) {
+    console.error(`An error occurred while handling ${direction} keydown:`, error);
+  }
+};
+
+export const deleteBlockKeyDown = (editor: SlateEditor, e: KeyboardEvent) => {
+  deleteOrBackspaceBlock(editor, e, 'after');
+};
+
+export const backspaceBlockKeyDown = (editor: SlateEditor, e: KeyboardEvent) => {
+  deleteOrBackspaceBlock(editor, e, 'before');
+};


### PR DESCRIPTION
Previously, it was difficult to delete a table from core authoring. Now, all three of these interactions should work:

1. Place the cursor immediately after the table, press backspace, the table should be removed.
2. Place the cursor immediately before the table, press delete, the table should be removed
3. Internally highlight multiple cells and press delete, the table should be removed