### PR TITLE
[ENHANCEMENT] replace init_live with init and LiveSocket pattern match

### DIFF
--- a/lib/oli_web/common/session_context.ex
+++ b/lib/oli_web/common/session_context.ex
@@ -79,7 +79,7 @@ defmodule OliWeb.Common.SessionContext do
   given as options (previously loaded by set_user plug), they will be used instead of looking up
   the user/author from the session map and making a cache lookup/database call.
   """
-  def init_live(%{} = session, opts \\ []) do
+  def init(%Phoenix.LiveView.Socket{} = _socket, %{} = session, opts \\ []) do
     browser_timezone = Map.get(session, "browser_timezone")
 
     author =

--- a/lib/oli_web/live/admin/registrations/registrations_view.ex
+++ b/lib/oli_web/live/admin/registrations/registrations_view.ex
@@ -49,7 +49,7 @@ defmodule OliWeb.Admin.RegistrationsView do
   end
 
   def mount(_, %{"current_author_id" => author_id} = session, socket) do
-    ctx = SessionContext.init_live(session)
+    ctx = SessionContext.init(socket, session)
     author = Repo.get(Author, author_id)
 
     registrations =

--- a/lib/oli_web/live/collaboration_live/index_view.ex
+++ b/lib/oli_web/live/collaboration_live/index_view.ex
@@ -67,7 +67,7 @@ defmodule OliWeb.CollaborationLive.IndexView do
 
   def mount(params, session, socket) do
     live_action = socket.assigns.live_action
-    ctx = SessionContext.init_live(session)
+    ctx = SessionContext.init(socket, session)
     section_slug = params["section_slug"]
 
     do_mount = fn ->

--- a/lib/oli_web/live/community_live/associated/index_view.ex
+++ b/lib/oli_web/live/community_live/associated/index_view.ex
@@ -43,7 +43,7 @@ defmodule OliWeb.CommunityLive.Associated.IndexView do
   end
 
   def mount(%{"community_id" => community_id}, session, socket) do
-    ctx = SessionContext.init_live(session)
+    ctx = SessionContext.init(socket, session)
 
     associations = Groups.list_community_visibilities(community_id)
     {:ok, table_model} = TableModel.new(associations, ctx, :id, "remove")

--- a/lib/oli_web/live/community_live/associated/new_view.ex
+++ b/lib/oli_web/live/community_live/associated/new_view.ex
@@ -60,7 +60,7 @@ defmodule OliWeb.CommunityLive.Associated.NewView do
   end
 
   def mount(%{"community_id" => community_id}, session, socket) do
-    ctx = SessionContext.init_live(session)
+    ctx = SessionContext.init(socket, session)
     sources = retrieve_all_sources(community_id)
     {:ok, table_model} = TableModel.new(sources, ctx)
 

--- a/lib/oli_web/live/community_live/index_view.ex
+++ b/lib/oli_web/live/community_live/index_view.ex
@@ -62,7 +62,7 @@ defmodule OliWeb.CommunityLive.IndexView do
         Accounts.list_admin_communities(author_id)
       end
 
-    ctx = SessionContext.init_live(session)
+    ctx = SessionContext.init(socket, session)
 
     {:ok, table_model} = TableModel.new(communities, ctx)
 

--- a/lib/oli_web/live/curriculum/container/container_live.ex
+++ b/lib/oli_web/live/curriculum/container/container_live.ex
@@ -46,7 +46,7 @@ defmodule OliWeb.Curriculum.ContainerLive do
         %{"current_author_id" => _} = session,
         socket
       ) do
-    %SessionContext{author: author} = ctx = SessionContext.init_live(session)
+    %SessionContext{author: author} = ctx = SessionContext.init(socket, session)
 
     root_container = AuthoringResolver.root_container(project_slug)
     container_slug = Map.get(params, "container_slug")

--- a/lib/oli_web/live/delivery/instructor_dashboard/initial_assigns.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/initial_assigns.ex
@@ -25,7 +25,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.InitialAssigns do
 
         {:cont,
          assign(socket,
-           ctx: SessionContext.init_live(session, user: current_user),
+           ctx: SessionContext.init(socket, session, user: current_user),
            browser_timezone: Map.get(session, "browser_timezone"),
            current_user: current_user,
            title: section.title,

--- a/lib/oli_web/live/delivery/student_dashboard/initial_assigns.ex
+++ b/lib/oli_web/live/delivery/student_dashboard/initial_assigns.ex
@@ -32,7 +32,7 @@ defmodule OliWeb.Delivery.StudentDashboard.InitialAssigns do
 
         {:cont,
          assign(socket,
-           ctx: SessionContext.init_live(session, user: current_user),
+           ctx: SessionContext.init(socket, session, user: current_user),
            browser_timezone: Map.get(session, "browser_timezone"),
            current_user: current_user,
            student:

--- a/lib/oli_web/live/grades/browse_updates_view.ex
+++ b/lib/oli_web/live/grades/browse_updates_view.ex
@@ -15,14 +15,14 @@ defmodule OliWeb.Grades.BrowseUpdatesView do
 
   @limit 25
 
-  data breadcrumbs, :any
-  data title, :string, default: "LMS Grade Updates"
-  data section, :any, default: nil
-  data tabel_model, :struct
-  data total_count, :integer, default: 0
-  data offset, :integer, default: 0
-  data limit, :integer, default: @limit
-  data options, :any
+  data(breadcrumbs, :any)
+  data(title, :string, default: "LMS Grade Updates")
+  data(section, :any, default: nil)
+  data(tabel_model, :struct)
+  data(total_count, :integer, default: 0)
+  data(offset, :integer, default: 0)
+  data(limit, :integer, default: @limit)
+  data(options, :any)
 
   def set_breadcrumbs(type, section) do
     type
@@ -54,7 +54,7 @@ defmodule OliWeb.Grades.BrowseUpdatesView do
         Mount.handle_error(socket, {:error, e})
 
       {type, _, section} ->
-        ctx = SessionContext.init_live(session)
+        ctx = SessionContext.init(socket, session)
 
         options = default_options(section)
 

--- a/lib/oli_web/live/history/revision_history.ex
+++ b/lib/oli_web/live/history/revision_history.ex
@@ -27,7 +27,7 @@ defmodule OliWeb.RevisionHistory do
 
   @impl Phoenix.LiveView
   def mount(%{"slug" => slug, "project_id" => project_slug}, session, socket) do
-    ctx = SessionContext.init_live(session)
+    ctx = SessionContext.init(socket, session)
 
     case AuthoringResolver.from_revision_slug(project_slug, slug) do
       nil ->
@@ -39,7 +39,7 @@ defmodule OliWeb.RevisionHistory do
   end
 
   def mount(%{"resource_id" => resource_id_str, "project_id" => project_slug}, session, socket) do
-    ctx = SessionContext.init_live(session)
+    ctx = SessionContext.init(socket, session)
 
     case AuthoringResolver.from_resource_id(project_slug, String.to_integer(resource_id_str)) do
       nil ->

--- a/lib/oli_web/live/manual_grading/manual_grading_view.ex
+++ b/lib/oli_web/live/manual_grading/manual_grading_view.ex
@@ -102,7 +102,7 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
 
         activity_types_map = Enum.reduce(activities, %{}, fn e, m -> Map.put(m, e.id, e) end)
 
-        ctx = SessionContext.init_live(session)
+        ctx = SessionContext.init(socket, session)
         {:ok, table_model} = TableModel.new(attempts, activity_types_map, ctx)
 
         table_model =

--- a/lib/oli_web/live/new_course/select_source.ex
+++ b/lib/oli_web/live/new_course/select_source.ex
@@ -46,7 +46,7 @@ defmodule OliWeb.Delivery.NewCourse.SelectSource do
         socket
       ) do
     if !socket.assigns[:loaded] do
-      ctx = SessionContext.init_live(session)
+      ctx = SessionContext.init(socket, session)
 
       # live_action is :independent_learner, :admin or :lms_instructor
       live_action = session["live_action"]

--- a/lib/oli_web/live/products/payments/discounts/products_index_view.ex
+++ b/lib/oli_web/live/products/payments/discounts/products_index_view.ex
@@ -42,7 +42,7 @@ defmodule OliWeb.Products.Payments.Discounts.ProductsIndexView do
     case Sections.get_section_by_slug(product_slug) do
       %Section{type: :blueprint} = product ->
         discounts = Paywall.get_product_discounts(product.id)
-        ctx = SessionContext.init_live(session)
+        ctx = SessionContext.init(socket, session)
 
         {:ok, table_model} = TableModel.new(discounts, ctx)
 

--- a/lib/oli_web/live/products/payments_view.ex
+++ b/lib/oli_web/live/products/payments_view.ex
@@ -51,7 +51,7 @@ defmodule OliWeb.Products.PaymentsView do
   end
 
   def mount(%{"product_id" => product_slug}, session, socket) do
-    ctx = SessionContext.init_live(session)
+    ctx = SessionContext.init(socket, session)
 
     payments = list_payments(product_slug)
 

--- a/lib/oli_web/live/products/products_view.ex
+++ b/lib/oli_web/live/products/products_view.ex
@@ -10,20 +10,20 @@ defmodule OliWeb.Products.ProductsView do
   alias OliWeb.Router.Helpers, as: Routes
   alias Oli.Publishing
 
-  prop is_admin_view, :boolean
-  prop project, :any
-  prop author, :any
-  data breadcrumbs, :any
-  data title, :string, default: "Products"
+  prop(is_admin_view, :boolean)
+  prop(project, :any)
+  prop(author, :any)
+  data(breadcrumbs, :any)
+  data(title, :string, default: "Products")
 
-  data creation_title, :string, default: ""
-  data products, :list, default: []
-  data tabel_model, :struct
-  data total_count, :integer, default: 0
-  data offset, :integer, default: 0
-  data limit, :integer, default: 20
-  data query, :string, default: ""
-  data applied_query, :string, default: ""
+  data(creation_title, :string, default: "")
+  data(products, :list, default: [])
+  data(tabel_model, :struct)
+  data(total_count, :integer, default: 0)
+  data(offset, :integer, default: 0)
+  data(limit, :integer, default: 20)
+  data(query, :string, default: "")
+  data(applied_query, :string, default: "")
 
   @table_filter_fn &OliWeb.Products.ProductsView.filter_rows/3
   @table_push_patch_path &OliWeb.Products.ProductsView.live_path/2
@@ -104,7 +104,7 @@ defmodule OliWeb.Products.ProductsView do
   defp mount_as(author, is_admin_view, products, project, breadcrumbs, title, socket, session) do
     total_count = length(products)
 
-    ctx = SessionContext.init_live(session)
+    ctx = SessionContext.init(socket, session)
     {:ok, table_model} = OliWeb.Products.ProductsTableModel.new(products, ctx)
 
     published? =

--- a/lib/oli_web/live/progress/student_resource_view.ex
+++ b/lib/oli_web/live/progress/student_resource_view.ex
@@ -60,7 +60,7 @@ defmodule OliWeb.Progress.StudentResourceView do
             Mount.handle_error(socket, {:error, e})
 
           {type, _, section} ->
-            ctx = SessionContext.init_live(session)
+            ctx = SessionContext.init(socket, session)
             resource_access = get_resource_access(resource_id, section_slug, user_id)
 
             changeset =

--- a/lib/oli_web/live/progress/student_view.ex
+++ b/lib/oli_web/live/progress/student_view.ex
@@ -48,7 +48,7 @@ defmodule OliWeb.Progress.StudentView do
         Mount.handle_error(socket, {:error, e})
 
       {:ok, user} ->
-        ctx = SessionContext.init_live(session)
+        ctx = SessionContext.init(socket, session)
 
         case Mount.for(section_slug, session) do
           {:error, e} ->

--- a/lib/oli_web/live/projects/projects_live.ex
+++ b/lib/oli_web/live/projects/projects_live.ex
@@ -39,7 +39,7 @@ defmodule OliWeb.Projects.ProjectsLive do
   data(is_admin, :boolean, default: false)
 
   def mount(_, %{"current_author_id" => _} = session, socket) do
-    %SessionContext{author: author} = ctx = SessionContext.init_live(session)
+    %SessionContext{author: author} = ctx = SessionContext.init(socket, session)
     is_admin = Accounts.is_admin?(author)
 
     show_all =

--- a/lib/oli_web/live/projects/publish_view.ex
+++ b/lib/oli_web/live/projects/publish_view.ex
@@ -20,14 +20,14 @@ defmodule OliWeb.Projects.PublishView do
 
   alias OliWeb.Router.Helpers, as: Routes
 
-  data is_force_push, :boolean, default: false
-  data limit, :integer, default: 10
-  data modal, :any, default: nil
-  data offset, :integer, default: 0
-  data page_change, :string, default: "page_change"
-  data query, :string, default: ""
-  data show_bottom_paging, :boolean, default: false
-  data sort, :string, default: "sort"
+  data(is_force_push, :boolean, default: false)
+  data(limit, :integer, default: 10)
+  data(modal, :any, default: nil)
+  data(offset, :integer, default: 0)
+  data(page_change, :string, default: "page_change")
+  data(query, :string, default: "")
+  data(show_bottom_paging, :boolean, default: false)
+  data(sort, :string, default: "sort")
 
   @table_filter_fn &__MODULE__.filter_rows/3
   @table_push_patch_path &__MODULE__.live_path/2
@@ -42,7 +42,7 @@ defmodule OliWeb.Projects.PublishView do
         session,
         socket
       ) do
-    ctx = SessionContext.init_live(session)
+    ctx = SessionContext.init(socket, session)
     project = Course.get_project_by_slug(project_slug)
     active_sections = Sections.get_active_sections_by_project(project.id)
 

--- a/lib/oli_web/live/publisher_live/index_view.ex
+++ b/lib/oli_web/live/publisher_live/index_view.ex
@@ -46,7 +46,7 @@ defmodule OliWeb.PublisherLive.IndexView do
   end
 
   def mount(_, session, socket) do
-    ctx = SessionContext.init_live(session)
+    ctx = SessionContext.init(socket, session)
     publishers = Inventories.list_publishers()
 
     {:ok, table_model} = TableModel.new(publishers, ctx)

--- a/lib/oli_web/live/qa/qa_live.ex
+++ b/lib/oli_web/live/qa/qa_live.ex
@@ -22,7 +22,7 @@ defmodule OliWeb.Qa.QaLive do
         %{"current_author_id" => _} = session,
         socket
       ) do
-    ctx = SessionContext.init_live(session)
+    ctx = SessionContext.init(socket, session)
     project = Course.get_project_by_slug(project_slug)
 
     subscribe(project.slug)

--- a/lib/oli_web/live/resources/activities_view.ex
+++ b/lib/oli_web/live/resources/activities_view.ex
@@ -49,7 +49,7 @@ defmodule OliWeb.Resources.ActivitiesView do
       with {:ok, author} <- Accounts.get_author(author_id) |> trap_nil(),
            {:ok, project} <- Oli.Authoring.Course.get_project_by_slug(project_slug) |> trap_nil(),
            {:ok} <- authorize_user(author, project) do
-        ctx = SessionContext.init_live(session)
+        ctx = SessionContext.init(socket, session)
 
         activities =
           ActivityBrowse.browse_activities(

--- a/lib/oli_web/live/resources/alternatives_editor.ex
+++ b/lib/oli_web/live/resources/alternatives_editor.ex
@@ -20,7 +20,7 @@ defmodule OliWeb.Resources.AlternativesEditor do
 
   @impl Phoenix.LiveView
   def mount(%{"project_id" => project_slug}, session, socket) do
-    ctx = SessionContext.init_live(session)
+    ctx = SessionContext.init(socket, session)
     project = Course.get_project_by_slug(project_slug)
 
     {:ok, alternatives} =

--- a/lib/oli_web/live/resources/pages_view.ex
+++ b/lib/oli_web/live/resources/pages_view.ex
@@ -28,11 +28,11 @@ defmodule OliWeb.Resources.PagesView do
   alias Oli.Authoring.Course.Project
   alias OliWeb.Curriculum.OptionsModal
 
-  data title, :string, default: "All Pages"
-  data project, :any
-  data breadcrumbs, :list
-  data author, :any
-  data pages, :list
+  data(title, :string, default: "All Pages")
+  data(project, :any)
+  data(breadcrumbs, :list)
+  data(author, :any)
+  data(pages, :list)
 
   @limit 25
 
@@ -66,7 +66,7 @@ defmodule OliWeb.Resources.PagesView do
       with {:ok, author} <- Accounts.get_author(author_id) |> trap_nil(),
            {:ok, project} <- Oli.Authoring.Course.get_project_by_slug(project_slug) |> trap_nil(),
            {:ok} <- authorize_user(author, project) do
-        ctx = SessionContext.init_live(session)
+        ctx = SessionContext.init(socket, session)
 
         pages =
           PageBrowse.browse_pages(

--- a/lib/oli_web/live/sections/assessment_settings/settings_live.ex
+++ b/lib/oli_web/live/sections/assessment_settings/settings_live.ex
@@ -27,7 +27,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLive do
 
         {:ok,
          assign(socket,
-           context: SessionContext.init_live(session, user: current_user),
+           context: SessionContext.init(socket, session, user: current_user),
            current_user: current_user,
            preview_mode: socket.assigns[:live_action] == :preview,
            title: "Assessment Settings",

--- a/lib/oli_web/live/sections/edit_view.ex
+++ b/lib/oli_web/live/sections/edit_view.ex
@@ -61,7 +61,7 @@ defmodule OliWeb.Sections.EditView do
 
         {:ok,
          assign(socket,
-           ctx: SessionContext.init_live(session),
+           ctx: SessionContext.init(socket, session),
            brands: available_brands,
            changeset: Sections.change_section(section),
            is_admin: type == :admin,

--- a/lib/oli_web/live/sections/enrollments/enrollments_view.ex
+++ b/lib/oli_web/live/sections/enrollments/enrollments_view.ex
@@ -56,7 +56,7 @@ defmodule OliWeb.Sections.EnrollmentsView do
         Mount.handle_error(socket, {:error, e})
 
       {type, _, section} ->
-        ctx = SessionContext.init_live(session)
+        ctx = SessionContext.init(socket, session)
 
         %{total_count: total_count, table_model: table_model} = enrollment_assigns(section, ctx)
 

--- a/lib/oli_web/live/sections/gating_and_scheduling.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling.ex
@@ -109,7 +109,7 @@ defmodule OliWeb.Sections.GatingAndScheduling do
   end
 
   def assign_defaults(socket, section, session, parent_gate, title, user_type) do
-    ctx = SessionContext.init_live(session)
+    ctx = SessionContext.init(socket, session)
 
     rows =
       Gating.browse_gating_conditions(

--- a/lib/oli_web/live/sections/gating_and_scheduling/edit.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling/edit.ex
@@ -26,7 +26,7 @@ defmodule OliWeb.Sections.GatingAndScheduling.Edit do
             %{parent_id: parent_id} -> {parent_id, "Edit Student Exception"}
           end
 
-        ctx = SessionContext.init_live(session)
+        ctx = SessionContext.init(socket, session)
 
         {:ok,
          GatingConditionStore.init(

--- a/lib/oli_web/live/sections/gating_and_scheduling/new.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling/new.ex
@@ -23,7 +23,7 @@ defmodule OliWeb.Sections.GatingAndScheduling.New do
             id -> {id, "Create Student Exception"}
           end
 
-        ctx = SessionContext.init_live(session)
+        ctx = SessionContext.init(socket, session)
 
         {:ok,
          GatingConditionStore.init(

--- a/lib/oli_web/live/sections/invite_view.ex
+++ b/lib/oli_web/live/sections/invite_view.ex
@@ -39,7 +39,7 @@ defmodule OliWeb.Sections.InviteView do
       {type, _, section} ->
         {:ok,
          assign(socket,
-           ctx: SessionContext.init_live(session),
+           ctx: SessionContext.init(socket, session),
            breadcrumbs: set_breadcrumbs(type, section),
            section: section,
            invitations: SectionInvites.list_section_invites(section.id)

--- a/lib/oli_web/live/sections/schedule_view.ex
+++ b/lib/oli_web/live/sections/schedule_view.ex
@@ -33,7 +33,7 @@ defmodule OliWeb.Sections.ScheduleView do
       {type, current_user, section} ->
         {:ok,
          assign(socket,
-           ctx: SessionContext.init_live(session, user: current_user),
+           ctx: SessionContext.init(socket, session, user: current_user),
            breadcrumbs: set_breadcrumbs(type, section),
            section: section,
            js_path: Routes.static_path(OliWeb.Endpoint, "/js/scheduler.js"),

--- a/lib/oli_web/live/sections/sections_view.ex
+++ b/lib/oli_web/live/sections/sections_view.ex
@@ -48,7 +48,7 @@ defmodule OliWeb.Sections.SectionsView do
   end
 
   def mount(_, %{"current_author_id" => _} = session, socket) do
-    %SessionContext{author: author} = ctx = SessionContext.init_live(session)
+    %SessionContext{author: author} = ctx = SessionContext.init(socket, session)
 
     sections =
       Browse.browse_sections(

--- a/lib/oli_web/live/system_message_live/index_view.ex
+++ b/lib/oli_web/live/system_message_live/index_view.ex
@@ -33,7 +33,7 @@ defmodule OliWeb.SystemMessageLive.IndexView do
 
     {:ok,
      assign(socket,
-       ctx: SessionContext.init_live(session),
+       ctx: SessionContext.init(socket, session),
        messages: messages,
        breadcrumbs: breadcrumb()
      )}

--- a/lib/oli_web/live/users/authors_view.ex
+++ b/lib/oli_web/live/users/authors_view.ex
@@ -52,7 +52,7 @@ defmodule OliWeb.Users.AuthorsView do
         @default_options
       )
 
-    ctx = SessionContext.init_live(session)
+    ctx = SessionContext.init(socket, session)
     total_count = SortableTableModel.determine_total(authors)
     {:ok, table_model} = AuthorsTableModel.new(authors, ctx)
 

--- a/lib/oli_web/live/users/user_detail_view.ex
+++ b/lib/oli_web/live/users/user_detail_view.ex
@@ -25,12 +25,12 @@ defmodule OliWeb.Users.UsersDetailView do
   alias Surface.Components.Form
   alias Surface.Components.Form.{Checkbox, Label, Field, Submit}
 
-  data breadcrumbs, :any
-  data changeset, :changeset
-  data csrf_token, :any
-  data modal, :any, default: nil
-  data title, :string, default: "User Details"
-  data user, :struct, default: nil
+  data(breadcrumbs, :any)
+  data(changeset, :changeset)
+  data(csrf_token, :any)
+  data(modal, :any, default: nil)
+  data(title, :string, default: "User Details")
+  data(user, :struct, default: nil)
 
   defp set_breadcrumbs(user) do
     OliWeb.Admin.AdminView.breadcrumb()
@@ -53,7 +53,7 @@ defmodule OliWeb.Users.UsersDetailView do
         %{"csrf_token" => csrf_token} = session,
         socket
       ) do
-    ctx = SessionContext.init_live(session)
+    ctx = SessionContext.init(socket, session)
     user = user_with_platform_roles(user_id)
 
     case user do

--- a/lib/oli_web/live/users/users_view.ex
+++ b/lib/oli_web/live/users/users_view.ex
@@ -18,13 +18,13 @@ defmodule OliWeb.Users.UsersView do
     text_search: ""
   }
 
-  data breadcrumbs, :any
-  data users, :list, default: []
-  data tabel_model, :struct
-  data total_count, :integer, default: 0
-  data offset, :integer, default: 0
-  data limit, :integer, default: @limit
-  data options, :any
+  data(breadcrumbs, :any)
+  data(users, :list, default: [])
+  data(tabel_model, :struct)
+  data(total_count, :integer, default: 0)
+  data(offset, :integer, default: 0)
+  data(limit, :integer, default: @limit)
+  data(options, :any)
 
   defp set_breadcrumbs() do
     OliWeb.Admin.AdminView.breadcrumb()
@@ -51,7 +51,7 @@ defmodule OliWeb.Users.UsersView do
 
     total_count = SortableTableModel.determine_total(users)
 
-    ctx = SessionContext.init_live(session)
+    ctx = SessionContext.init(socket, session)
     {:ok, table_model} = UsersTableModel.new(users, ctx)
 
     {:ok,


### PR DESCRIPTION
This PR improves the SessionContext interface by replacing the separate `init_live` function with the `init` function that pattern matches on a LiveView socket