### PR TITLE
[FEATURE] [MER-2089] Display course section title student views

### DIFF
--- a/lib/oli_web/components/delivery/exploration_shade.ex
+++ b/lib/oli_web/components/delivery/exploration_shade.ex
@@ -5,6 +5,7 @@ defmodule OliWeb.Components.Delivery.ExplorationShade do
 
   attr :exploration_pages, :map, default: nil
   attr :section_slug, :string
+  attr :title, :string
 
   def exploration_shade(assigns) do
     ~H"""
@@ -12,7 +13,7 @@ defmodule OliWeb.Components.Delivery.ExplorationShade do
         <div class="container mx-auto md:px-10 py-2 flex flex-row justify-between text-sm md:text-lg">
           <div class="flex items-center gap-2">
             <h4 class="p-2 md:p-0 md:leading-loose">
-              Your Exploration Activities
+              <%= "#{@title} | " %>Your Exploration Activities
             </h4>
             <%= if @exploration_pages && length(@exploration_pages) > 0 do %>
               <span class="badge badge-info rounded-full"><%= length(@exploration_pages) %></span>

--- a/lib/oli_web/components/delivery/section_title.ex
+++ b/lib/oli_web/components/delivery/section_title.ex
@@ -1,7 +1,7 @@
 defmodule OliWeb.Components.Delivery.SectionTitle do
   use Phoenix.Component
 
-  attr :title, :string
+  attr :title, :string, required: true
 
   def section_title(assigns) do
     ~H"""

--- a/lib/oli_web/components/delivery/section_title.ex
+++ b/lib/oli_web/components/delivery/section_title.ex
@@ -1,0 +1,19 @@
+defmodule OliWeb.Components.Delivery.SectionTitle do
+  use Phoenix.Component
+
+  attr :title, :string
+
+  def section_title(assigns) do
+    ~H"""
+      <div class="text-white bg-delivery-header border-b border-slate-300">
+        <div class="container mx-auto md:px-10 py-2 flex flex-row justify-between text-sm md:text-lg">
+          <div class="flex items-center gap-2">
+            <h4 class="p-2 md:p-0 md:leading-loose">
+              <%= @title %>
+            </h4>
+          </div>
+        </div>
+      </div>
+    """
+  end
+end

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -157,6 +157,7 @@ defmodule OliWeb.PageDeliveryController do
       render(
         conn,
         "assignments.html",
+        title: section.title,
         assignments: assignments,
         section_slug: section_slug,
         preview_mode: false,

--- a/lib/oli_web/templates/layout/page.html.heex
+++ b/lib/oli_web/templates/layout/page.html.heex
@@ -9,7 +9,9 @@
       <% end %>
 
       <%= if assigns.section.contains_explorations do%>
-        <Components.Delivery.ExplorationShade.exploration_shade section_slug={assigns.section.slug} exploration_pages={Map.get(@conn.assigns, :exploration_pages, nil)} />
+        <Components.Delivery.ExplorationShade.exploration_shade section_slug={assigns.section.slug} title={assigns.section.title} exploration_pages={Map.get(@conn.assigns, :exploration_pages, nil)} />
+      <% else %>
+        <Components.Delivery.SectionTitle.section_title title={assigns.section.title}/>
       <% end %>
 
       <div class="md:container md:mx-auto md:px-10 md:mt-3 md:mb-5">

--- a/lib/oli_web/templates/page_delivery/assignments.html.heex
+++ b/lib/oli_web/templates/page_delivery/assignments.html.heex
@@ -3,6 +3,8 @@
   <div class="relative flex-1 flex flex-col pb-[60px]">
     <%= render OliWeb.LayoutView, "_pay_early.html", assigns %>
 
+    <Components.Delivery.SectionTitle.section_title {assigns}/>
+
     <Components.Delivery.AssignmentsList.render {assigns} />
 
     <%= render OliWeb.LayoutView, "_delivery_footer.html", assigns %>

--- a/lib/oli_web/templates/page_delivery/discussion.html.heex
+++ b/lib/oli_web/templates/page_delivery/discussion.html.heex
@@ -4,7 +4,9 @@
     <%= render OliWeb.LayoutView, "_pay_early.html", assigns %>
 
     <%= if assigns.section.contains_explorations do%>
-      <Components.Delivery.ExplorationShade.exploration_shade />
+      <Components.Delivery.ExplorationShade.exploration_shade title={assigns.title}/>
+    <% else %>
+      <Components.Delivery.SectionTitle.section_title title={assigns.title}/>
     <% end %>
 
     <div class="container px-0 sm:px-10 mx-auto mt-3 mb-5 flex flex-col">

--- a/lib/oli_web/templates/page_delivery/exploration.html.heex
+++ b/lib/oli_web/templates/page_delivery/exploration.html.heex
@@ -4,7 +4,9 @@
     <%= render OliWeb.LayoutView, "_pay_early.html", assigns %>
 
     <%= if assigns.section.contains_explorations do%>
-      <Components.Delivery.ExplorationShade.exploration_shade />
+      <Components.Delivery.ExplorationShade.exploration_shade title={assigns.title}/>
+    <% else %>
+      <Components.Delivery.SectionTitle.section_title title={assigns.title}/>
     <% end %>
 
     <div class="container mx-auto px-10 mt-3 mb-5 flex flex-col">

--- a/lib/oli_web/templates/page_delivery/index.html.heex
+++ b/lib/oli_web/templates/page_delivery/index.html.heex
@@ -3,6 +3,8 @@
   <div class="relative flex-1 flex flex-col pb-[60px]">
     <%= render OliWeb.LayoutView, "_pay_early.html", assigns %>
 
+    <Components.Delivery.SectionTitle.section_title title={assigns.section.title}/>
+
     <%= if length(@next_activities) > 0 do %>
       <Components.Delivery.UpNext.up_next
         section_slug={@section_slug}

--- a/test/oli_web/controllers/page_delivery_controller_test.exs
+++ b/test/oli_web/controllers/page_delivery_controller_test.exs
@@ -181,6 +181,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
         |> get(Routes.page_delivery_path(conn, :index, section.slug))
 
       assert html_response(conn, 200) =~ "Course Content"
+      assert html_response(conn, 200) =~ section.title
     end
 
     test "handles student page access by an enrolled student", %{
@@ -196,6 +197,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
         |> get(Routes.page_delivery_path(conn, :page, section.slug, revision.slug))
 
       assert html_response(conn, 200) =~ "Page one"
+      assert html_response(conn, 200) =~ section.title
     end
 
     test "shows the related exploration pages for a given page", %{
@@ -212,6 +214,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
 
       assert html_response(conn, 200) =~ "exploration page 1"
       assert html_response(conn, 200) =~ "exploration page 2"
+      assert html_response(conn, 200) =~ section.title
     end
 
     test "shows a 'no exploration pages' message when the page doesn't have any related exploration pages",
@@ -228,6 +231,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
         |> get(Routes.page_delivery_path(conn, :page, section.slug, ungraded_page_revision.slug))
 
       assert html_response(conn, 200) =~ "There are no explorations related to this page"
+      assert html_response(conn, 200) =~ section.title
     end
 
     test "handles student adaptive page access by an enrolled student", %{
@@ -1469,6 +1473,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
 
       # Unit title
       assert html_response(conn, 200) =~ "The first unit"
+      assert html_response(conn, 200) =~ section.title
     end
 
     test "page preview - renders ok", %{
@@ -1484,6 +1489,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
 
       # page title
       assert html_response(conn, 200) =~ "Page one (Preview)"
+      assert html_response(conn, 200) =~ section.title
     end
 
     test "page preview - adaptive renders ok", %{
@@ -1529,6 +1535,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
         |> get(Routes.page_delivery_path(conn, :exploration, section.slug))
 
       assert html_response(conn, 200)
+      assert html_response(conn, 200) =~ "#{section.title} | Your Exploration Activities"
     end
 
     test "instructor can access if is enrolled in the section", %{conn: conn, section: section} do
@@ -1584,6 +1591,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
         |> get(Routes.page_delivery_path(conn, :exploration, section.slug))
 
       assert html_response(conn, 200) =~ other_revision.title
+      assert html_response(conn, 200) =~ "#{section.title} | Your Exploration Activities"
     end
 
     test "page renders a message when there are no exploration pages available", %{
@@ -1619,6 +1627,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
         |> get(Routes.page_delivery_path(conn, :index, section.slug))
 
       refute html_response(conn, 200) =~ "<a>Exploration</a>"
+      assert html_response(conn, 200) =~ section.title
     end
 
     test "do not show the 'exploration' access in the Windowshade when the section does not have explorations to show",
@@ -1636,6 +1645,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
         |> get(Routes.page_delivery_path(conn, :index, section.slug))
 
       refute html_response(conn, 200) =~ "<h4>Your Exploration Activities</h4>"
+      assert html_response(conn, 200) =~ section.title
     end
   end
 
@@ -1651,7 +1661,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
         |> Pow.Plug.assign_current_user(user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
         |> get(Routes.page_delivery_path(conn, :discussion, section.slug))
 
-      assert html_response(conn, 200)
+      assert html_response(conn, 200) =~ section.title
     end
 
     test "instructor can access if is enrolled in the section", %{conn: conn, section: section} do
@@ -1747,6 +1757,8 @@ defmodule OliWeb.PageDeliveryControllerTest do
           )
         )
 
+      assert html_response(conn, 200) =~ section.title
+
       assert html_response(conn, 200) =~ "Assignments"
 
       assert html_response(conn, 200) =~
@@ -1768,6 +1780,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
           )
         )
 
+      assert html_response(conn, 200) =~ section.title
       assert html_response(conn, 200) =~ "Course content"
       assert html_response(conn, 200) =~ "Explorations"
 


### PR DESCRIPTION
[MER-2089](https://eliterate.atlassian.net/browse/MER-2089)

This PR adds the course section title for all student views. 
When the view displays the "Your Exploration Activities" top bar the title is added to that bar.
If the view does not contain this component, the course section title is added in the same place with an identical component.

![Captura de pantalla 2023-06-06 a la(s) 12 36 09](https://github.com/Simon-Initiative/oli-torus/assets/16328384/e9b69c07-3e7e-46fd-a2f4-2843e9433f15)

![Captura de pantalla 2023-06-06 a la(s) 12 36 17](https://github.com/Simon-Initiative/oli-torus/assets/16328384/9ae5a97a-5ab3-4eba-a04a-e8a98eee34f0)

[MER-2089]: https://eliterate.atlassian.net/browse/MER-2089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ