### PR TITLE
[MER-1974] custom dnd race condition

### DIFF
--- a/assets/src/apps/SchedulerApp.tsx
+++ b/assets/src/apps/SchedulerApp.tsx
@@ -16,7 +16,7 @@ export interface SchedulerAppProps {
   edit_section_details_url: string;
 }
 
-const store = configureStore(initState(), schedulerAppReducer);
+const store = configureStore(initState(), schedulerAppReducer, { name: 'SchedulerApp' });
 
 const ScheduleEditorApp: React.FC<SchedulerAppProps> = React.memo(
   ({

--- a/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyDelivery.tsx
+++ b/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyDelivery.tsx
@@ -105,7 +105,7 @@ export const CheckAllThatApplyComponent: React.FC = () => {
 // Defines the web component, a simple wrapper over our React component above
 export class CheckAllThatApplyDelivery extends DeliveryElement<CATASchema> {
   render(mountPoint: HTMLDivElement, props: DeliveryElementProps<CATASchema>) {
-    const store = configureStore({}, activityDeliverySlice.reducer);
+    const store = configureStore({}, activityDeliverySlice.reducer, { name: 'CATADelivery' });
     ReactDOM.render(
       <Provider store={store}>
         <DeliveryElementProvider {...props}>

--- a/assets/src/components/activities/custom_dnd/CustomDnDDelivery.tsx
+++ b/assets/src/components/activities/custom_dnd/CustomDnDDelivery.tsx
@@ -107,19 +107,18 @@ export const CustomDnDComponent: React.FC = () => {
     setFocusedPart(partIdBearers === 'targets' ? targetId : draggableId);
   };
 
-  const onDetach = (targetId: string, draggableId: string) => {
+  const onDetach = async (targetId: string, draggableId: string) => {
     // update on detaching draggable from target
     const partId = partIdBearers === 'targets' ? targetId : draggableId;
 
     const part = findPart(partId);
     if (part === null) console.log('part not found! id=' + partId);
     else {
-      dispatch(resetPart(uiState.attemptState.attemptGuid, part.attemptGuid, onResetPart));
+      await dispatch(resetPart(uiState.attemptState.attemptGuid, part.attemptGuid, onResetPart));
     }
   };
 
   const onSubmit = (targetId: string, draggableId: string) => {
-    console.info('🤡🤡 onSubmit.');
     const [partId, choiceId] =
       partIdBearers === 'targets' ? [targetId, draggableId] : [draggableId, targetId];
     const response = partId + '_' + choiceId;

--- a/assets/src/components/activities/custom_dnd/CustomDnDDelivery.tsx
+++ b/assets/src/components/activities/custom_dnd/CustomDnDDelivery.tsx
@@ -119,6 +119,7 @@ export const CustomDnDComponent: React.FC = () => {
   };
 
   const onSubmit = (targetId: string, draggableId: string) => {
+    console.info('🤡🤡 onSubmit.');
     const [partId, choiceId] =
       partIdBearers === 'targets' ? [targetId, draggableId] : [draggableId, targetId];
     const response = partId + '_' + choiceId;
@@ -196,7 +197,7 @@ export const CustomDnDComponent: React.FC = () => {
 // Defines the web component, a simple wrapper over our React component above
 export class CustomDnDDelivery extends DeliveryElement<CustomDnDSchema> {
   render(mountPoint: HTMLDivElement, props: DeliveryElementProps<CustomDnDSchema>) {
-    const store = configureStore({}, activityDeliverySlice.reducer);
+    const store = configureStore({}, activityDeliverySlice.reducer, { name: 'CustomDNDDelivery' });
     ReactDOM.render(
       <Provider store={store}>
         <DeliveryElementProvider {...props}>

--- a/assets/src/components/activities/custom_dnd/DragCanvas.tsx
+++ b/assets/src/components/activities/custom_dnd/DragCanvas.tsx
@@ -211,7 +211,7 @@ function renderRawContent(id: string, props: DragCanvasProps) {
   };
 
   const dragStartHandler = (ev: DragEvent) => {
-    if (ev !== null) {
+    if (ev !== null && (ev as any)?.target?.getAttribute) {
       const inputVal = (ev as any).target.getAttribute('input_val');
       (ev as any).dataTransfer.setData('text/plain', inputVal);
       (ev as any).dataTransfer.dropEffect = 'move';

--- a/assets/src/components/activities/file_upload/FileUploadDelivery.tsx
+++ b/assets/src/components/activities/file_upload/FileUploadDelivery.tsx
@@ -319,7 +319,7 @@ export const FileUploadComponent: React.FC = () => {
 // Defines the web component, a simple wrapper over our React component above
 export class FileUploadDelivery extends DeliveryElement<FileUploadSchema> {
   render(mountPoint: HTMLDivElement, props: DeliveryElementProps<FileUploadSchema>) {
-    const store = configureStore({}, activityDeliverySlice.reducer);
+    const store = configureStore({}, activityDeliverySlice.reducer, { name: 'FileUploadDelivery' });
     ReactDOM.render(
       <Provider store={store}>
         <DeliveryElementProvider {...props}>

--- a/assets/src/components/activities/image_coding/ImageCodingDelivery.tsx
+++ b/assets/src/components/activities/image_coding/ImageCodingDelivery.tsx
@@ -379,7 +379,9 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
 // Defines the web component, a simple wrapper over our React component above
 export class ImageCodingDelivery extends DeliveryElement<ImageCodingModelSchema> {
   render(mountPoint: HTMLDivElement, props: DeliveryElementProps<ImageCodingModelSchema>) {
-    const store = configureStore({}, activityDeliverySlice.reducer);
+    const store = configureStore({}, activityDeliverySlice.reducer, {
+      name: 'ImageCodingDelivery',
+    });
 
     ReactDOM.render(
       <Provider store={store}>

--- a/assets/src/components/activities/image_hotspot/ImageHotspotDelivery.tsx
+++ b/assets/src/components/activities/image_hotspot/ImageHotspotDelivery.tsx
@@ -172,7 +172,9 @@ const ImageHotspotComponent: React.FC = () => {
 // Defines the web component, a simple wrapper over our React component above
 export class ImageHotspotDelivery extends DeliveryElement<ImageHotspotModelSchema> {
   render(mountPoint: HTMLDivElement, props: DeliveryElementProps<ImageHotspotModelSchema>) {
-    const store = configureStore({}, activityDeliverySlice.reducer);
+    const store = configureStore({}, activityDeliverySlice.reducer, {
+      name: 'ImageHotspotDelivery',
+    });
     ReactDOM.render(
       <Provider store={store}>
         <DeliveryElementProvider {...props}>

--- a/assets/src/components/activities/likert/LikertDelivery.tsx
+++ b/assets/src/components/activities/likert/LikertDelivery.tsx
@@ -98,7 +98,7 @@ const LikertComponent: React.FC = () => {
 // Defines the web component, a simple wrapper over our React component above
 export class LikertDelivery extends DeliveryElement<LikertModelSchema> {
   render(mountPoint: HTMLDivElement, props: DeliveryElementProps<LikertModelSchema>) {
-    const store = configureStore({}, activityDeliverySlice.reducer);
+    const store = configureStore({}, activityDeliverySlice.reducer, { name: 'LikertDelivery' });
     ReactDOM.render(
       <Provider store={store}>
         <DeliveryElementProvider {...props}>

--- a/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
@@ -324,7 +324,7 @@ export const MultiInputComponent: React.FC = () => {
 // Defines the web component, a simple wrapper over our React component above
 export class MultiInputDelivery extends DeliveryElement<MultiInputSchema> {
   render(mountPoint: HTMLDivElement, props: DeliveryElementProps<MultiInputSchema>) {
-    const store = configureStore({}, activityDeliverySlice.reducer);
+    const store = configureStore({}, activityDeliverySlice.reducer, { name: 'MultiInputDelivery' });
     ReactDOM.render(
       <Provider store={store}>
         <DeliveryElementProvider {...props}>

--- a/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
+++ b/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
@@ -130,7 +130,9 @@ export const MultipleChoiceComponent: React.FC = () => {
 // Defines the web component, a simple wrapper over our React component above
 export class MultipleChoiceDelivery extends DeliveryElement<MCSchema> {
   render(mountPoint: HTMLDivElement, props: DeliveryElementProps<MCSchema>) {
-    const store = configureStore({}, activityDeliverySlice.reducer);
+    const store = configureStore({}, activityDeliverySlice.reducer, {
+      name: 'MultipleChoiceDelivery',
+    });
 
     ReactDOM.render(
       <Provider store={store}>

--- a/assets/src/components/activities/oli_embedded/OliEmbeddedDelivery.tsx
+++ b/assets/src/components/activities/oli_embedded/OliEmbeddedDelivery.tsx
@@ -152,7 +152,9 @@ const EmbeddedDelivery = (props: DeliveryElementProps<OliEmbeddedModelSchema>) =
 
 export class OliEmbeddedDelivery extends DeliveryElement<OliEmbeddedModelSchema> {
   render(mountPoint: HTMLDivElement, props: DeliveryElementProps<OliEmbeddedModelSchema>) {
-    const store = configureStore({}, activityDeliverySlice.reducer);
+    const store = configureStore({}, activityDeliverySlice.reducer, {
+      name: 'OLIEmbeddedDelivery',
+    });
     ReactDOM.render(
       <Provider store={store}>
         <DeliveryElementProvider {...props}>

--- a/assets/src/components/activities/ordering/OrderingDelivery.tsx
+++ b/assets/src/components/activities/ordering/OrderingDelivery.tsx
@@ -177,7 +177,7 @@ export const OrderingComponent: React.FC = () => {
 // Defines the web component, a simple wrapper over our React component above
 export class OrderingDelivery extends DeliveryElement<OrderingSchema> {
   render(mountPoint: HTMLDivElement, props: DeliveryElementProps<OrderingSchema>) {
-    const store = configureStore({}, activityDeliverySlice.reducer);
+    const store = configureStore({}, activityDeliverySlice.reducer, { name: 'OrderingDelivery' });
     ReactDOM.render(
       <Provider store={store}>
         <DeliveryElementProvider {...props}>

--- a/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
+++ b/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
@@ -165,7 +165,9 @@ export const ShortAnswerComponent: React.FC = () => {
 // Defines the web component, a simple wrapper over our React component above
 export class ShortAnswerDelivery extends DeliveryElement<ShortAnswerModelSchema> {
   render(mountPoint: HTMLDivElement, props: DeliveryElementProps<ShortAnswerModelSchema>) {
-    const store = configureStore({}, activityDeliverySlice.reducer);
+    const store = configureStore({}, activityDeliverySlice.reducer, {
+      name: 'ShortAnswerDelivery',
+    });
     ReactDOM.render(
       <Provider store={store}>
         <DeliveryElementProvider {...props}>

--- a/assets/src/components/activities/vlab/VlabDelivery.tsx
+++ b/assets/src/components/activities/vlab/VlabDelivery.tsx
@@ -266,7 +266,7 @@ export const VlabComponent: React.FC = () => {
 // Defines the web component, a simple wrapper over our React component above
 export class VlabDelivery extends DeliveryElement<VlabSchema> {
   render(mountPoint: HTMLDivElement, props: DeliveryElementProps<VlabSchema>) {
-    const store = configureStore({}, activityDeliverySlice.reducer);
+    const store = configureStore({}, activityDeliverySlice.reducer, { name: 'VLabDelivery' });
     ReactDOM.render(
       <Provider store={store}>
         <DeliveryElementProvider {...props}>

--- a/assets/src/data/activities/DeliveryState.ts
+++ b/assets/src/data/activities/DeliveryState.ts
@@ -423,14 +423,19 @@ export const resetAndSubmitPart =
     ) => Promise<EvaluationResponse>,
   ): AppThunk =>
   async (dispatch, _getState) => {
-    const partActivityResponse = await onResetPart(attemptGuid, partAttemptGuid);
-    dispatch(slice.actions.partResetRecieved(partActivityResponse));
-    const response = await onSubmitPart(
-      attemptGuid,
-      partActivityResponse.attemptState.attemptGuid,
-      studentResponse,
-    );
-    dispatch(slice.actions.partSubmissionReceived(response));
+    try {
+      const partActivityResponse = await onResetPart(attemptGuid, partAttemptGuid);
+      dispatch(slice.actions.partResetRecieved(partActivityResponse));
+      const response = await onSubmitPart(
+        attemptGuid,
+        partActivityResponse.attemptState.attemptGuid,
+        studentResponse,
+      );
+      dispatch(slice.actions.partSubmissionReceived(response));
+    } catch (e) {
+      console.error('Reset and submit part failed', e);
+      throw e;
+    }
   };
 
 export const resetPart =

--- a/assets/src/state/store.ts
+++ b/assets/src/state/store.ts
@@ -1,11 +1,15 @@
 import { Reducer, applyMiddleware, createStore } from 'redux';
-import { composeWithDevTools } from 'redux-devtools-extension';
+import { EnhancerOptions, composeWithDevTools } from 'redux-devtools-extension';
 import { createLogger } from 'redux-logger';
 import thunk from 'redux-thunk';
 import rootReducer, { initState } from 'state';
 import nextReducer from './index';
 
-export function configureStore(initialState?: any, reducer?: Reducer) {
+export function configureStore(
+  initialState?: any,
+  reducer?: Reducer,
+  devtoolsOptions: EnhancerOptions = {},
+) {
   const logger = createLogger({
     stateTransformer: (state) => {
       const newState: any = {};
@@ -24,9 +28,9 @@ export function configureStore(initialState?: any, reducer?: Reducer) {
 
   let middleware;
   if (process.env.NODE_ENV === 'development') {
-    middleware = composeWithDevTools(applyMiddleware(thunk, logger));
+    middleware = composeWithDevTools(devtoolsOptions)(applyMiddleware(thunk, logger));
   } else {
-    middleware = composeWithDevTools(applyMiddleware(thunk));
+    middleware = composeWithDevTools(devtoolsOptions)(applyMiddleware(thunk));
   }
 
   // For backwards compatibility - only use initial state without calling


### PR DESCRIPTION
This fixes an issue described in MER-1974 / #3506 where, in delivery mode, moving the dropped tile around after the initial drop would sometimes lead to feedback not being triggered.

The root problem was that the custom dnd activity was resetting the part attempt, and then calling resetAndSubmitPart without waiting for the part attempt reset to finish. Most of the time, that would work out just fine. Sometimes, the second call finished before the first. In those cases, the order of the part attempts in the DB would be backwards from what was expected, and the server call to submit the next attempt would fail since it only looks for the latest attempt record.

Preview mode continues to only work for the first drop of each tile. That was the behavior before this fix and I left that as-is until higher priority items can be finished.
