### PR TITLE
[MER-2058] double subscript and deemphasis

### DIFF
--- a/assets/src/components/content/Popup.tsx
+++ b/assets/src/components/content/Popup.tsx
@@ -83,17 +83,17 @@ export const Popup: React.FC<Props> = ({ children, popupContent, popup }) => {
         onMouseLeave={onBlur}
         onClick={onClick}
       >
-        {children}
         {hasAudio && (
           <>
             {isPlaying ? (
-              <i className="fa-solid fa-circle-pause ml-2"></i>
+              <i className="fa-solid fa-circle-pause mx-1"></i>
             ) : (
-              <i className="fa-solid fa-volume-high ml-2"></i>
+              <i className="fa-solid fa-volume-high mx-1"></i>
             )}
             {audioPlayer}
           </>
         )}
+        {children}
       </span>
     </Popover>
   );

--- a/assets/src/components/editing/editor/modelEditorDispatch.tsx
+++ b/assets/src/components/editing/editor/modelEditorDispatch.tsx
@@ -176,6 +176,14 @@ export function markFor(mark: Mark, children: any): JSX.Element {
       return <sub>{children}</sub>;
     case 'sup':
       return <sup>{children}</sup>;
+    case 'doublesub':
+      return (
+        <sub>
+          <sub>{children}</sub>
+        </sub>
+      );
+    case 'deemphasis':
+      return <em className="deemphasis">{children}</em>;
     case 'term':
       return <span className="term">{children}</span>;
     case 'strikethrough':

--- a/assets/src/components/editing/elements/marks/toggleMarkActions.tsx
+++ b/assets/src/components/editing/elements/marks/toggleMarkActions.tsx
@@ -16,12 +16,16 @@ export const toggleFormat = (attrs: {
   description: string;
   mark: Mark;
   precondition?: Command['precondition'];
-}) =>
-  createButtonCommandDesc({
+  execute?: Command['execute'];
+}) => {
+  const defaultExecute: Command['execute'] = (context, editor) => toggleMark(editor, attrs.mark);
+
+  return createButtonCommandDesc({
     ...attrs,
-    execute: (context, editor) => toggleMark(editor, attrs.mark),
+    execute: attrs.execute || defaultExecute,
     active: (editor) => isMarkActive(editor, attrs.mark),
   });
+};
 
 export const boldDesc = toggleFormat({
   icon: <i className="fa-solid fa-bold"></i>,
@@ -52,6 +56,10 @@ export const subscriptDesc = toggleFormat({
   mark: 'sub',
   description: 'Subscript',
   precondition: (editor) => !isActive(editor, ['code']),
+  execute: (context, editor) => {
+    Editor.removeMark(editor, 'doublesub'); // We really don't want both double & single subscript at the same time.
+    toggleMark(editor, 'sub');
+  },
 });
 
 export const superscriptDesc = toggleFormat({
@@ -59,6 +67,17 @@ export const superscriptDesc = toggleFormat({
   mark: 'sup',
   description: 'Superscript',
   precondition: (editor) => !isActive(editor, ['code']),
+});
+
+export const doublesubscriptDesc = toggleFormat({
+  icon: <i className="fa-solid fa-subscript"></i>,
+  mark: 'doublesub',
+  description: 'Double Subscript',
+  precondition: (editor) => !isActive(editor, ['code']),
+  execute: (context, editor) => {
+    Editor.removeMark(editor, 'sub');
+    toggleMark(editor, 'doublesub');
+  },
 });
 
 export const inlineCodeDesc = toggleFormat({
@@ -75,11 +94,20 @@ export const termDesc = toggleFormat({
   precondition: (editor) => !isActive(editor, ['term']),
 });
 
+export const deemphasisDesc = toggleFormat({
+  icon: <i className="fa-solid fa-square-dashed"></i>,
+  mark: 'deemphasis',
+  description: 'Deemphasis',
+  precondition: (editor) => !isActive(editor, ['term']),
+});
+
 export const additionalFormattingOptions = [
   underLineDesc,
   strikethroughDesc,
   subscriptDesc,
+  doublesubscriptDesc,
   superscriptDesc,
   termDesc,
   citationCmdDesc,
+  deemphasisDesc,
 ];

--- a/assets/src/components/editing/elements/marks/toggleMarkActions.tsx
+++ b/assets/src/components/editing/elements/marks/toggleMarkActions.tsx
@@ -95,7 +95,7 @@ export const termDesc = toggleFormat({
 });
 
 export const deemphasisDesc = toggleFormat({
-  icon: <i className="fa-solid fa-square-dashed"></i>,
+  icon: <i className="fa-solid fa-bold line-through"></i>,
   mark: 'deemphasis',
   description: 'Deemphasis',
   precondition: (editor) => !isActive(editor, ['term']),

--- a/assets/src/data/content/model/text.ts
+++ b/assets/src/data/content/model/text.ts
@@ -10,7 +10,9 @@ export type Mark =
   | 'sup'
   | 'underline'
   | 'strikethrough'
-  | 'foreign';
+  | 'foreign'
+  | 'doublesub'
+  | 'deemphasis';
 
 export enum Marks {
   'em',
@@ -25,6 +27,8 @@ export enum Marks {
   'underline',
   'strikethrough',
   'foreign',
+  'doublesub',
+  'deemphasis',
 }
 
 export type FormattedText = Record<'text', string> & Partial<Record<Mark, true>>;

--- a/assets/src/data/content/writers/html.tsx
+++ b/assets/src/data/content/writers/html.tsx
@@ -96,6 +96,12 @@ export class HtmlParser implements WriterImpl {
       term: (e) => <span className="term">{e}</span>,
       underline: (e) => <span style={{ textDecoration: 'underline' }}>{e}</span>,
       strikethrough: (e) => <span style={{ textDecoration: 'line-through' }}>{e}</span>,
+      doublesub: (e) => (
+        <sub>
+          <sub>{e}</sub>
+        </sub>
+      ),
+      deemphasis: (e) => <em className="deemphasis">{e}</em>,
     };
     return Object.keys(textEntity)
       .filter((attr: Mark | 'text') => textEntity[attr] === true)

--- a/assets/styles/common/elements.scss
+++ b/assets/styles/common/elements.scss
@@ -502,6 +502,11 @@ $element-margin-bottom: 1.5em;
     margin: auto;
     margin-bottom: $element-margin-bottom;
   }
+
+  em.deemphasis {
+    font-style: normal;
+    color: var(--color-gray-400);
+  }
 }
 
 .conjugation {

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -787,6 +787,8 @@ defmodule Oli.Rendering.Content.Html do
       "term" => "term",
       "code" => "code",
       "sub" => "sub",
+      "doublesub" => "doublesub",
+      "deemphasis" => "deemphasis",
       "sup" => "sup",
       "underline" => "underline",
       "strikethrough" => "strikethrough"
@@ -809,6 +811,8 @@ defmodule Oli.Rendering.Content.Html do
           "term" -> ~s|<span class="term">#{acc}</span>|
           "underline" -> ~s|<span style="text-decoration: underline;">#{acc}</span>|
           "strikethrough" -> ~s|<span style="text-decoration: line-through;">#{acc}</span>|
+          "doublesub" -> ~s|<sub><sub>#{acc}</sub></sub>|
+          "deemphasis" -> ~s|<em class="deemphasis">#{acc}</em>|
           _ -> "<#{mark}>#{acc}</#{mark}>"
         end
       end


### PR DESCRIPTION
This implements both the double-subscript and the de-emphasis marks in the core authoring & delivery environments.

It also fixes an issue with popup content where the play icon was on the right side instead of the left.

Dark and light mode examples attached.

![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/7119da21-a82b-440a-bd55-3d133aa26c0f)
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/08f8593a-4be5-45d6-bdca-92af9fb29025)
