### PR TITLE
[MER-2075] Links and Iframes from media library

### DIFF
--- a/assets/src/components/editing/elements/link/LinkElement.tsx
+++ b/assets/src/components/editing/elements/link/LinkElement.tsx
@@ -74,11 +74,12 @@ const SettingsButton = (props: SettingsButtonProps) => (
         window.oliDispatch(
           modalActions.display(
             <LinkModal
+              projectSlug={props.commandContext.projectSlug}
               model={props.model}
               commandContext={props.commandContext}
-              onDone={({ href }: Partial<ContentModel.Hyperlink>) => {
+              onDone={({ href, linkType }: Partial<ContentModel.Hyperlink>) => {
                 window.oliDispatch(modalActions.dismiss());
-                props.onEdit({ href });
+                props.onEdit({ href, linkType });
               }}
               onCancel={() => window.oliDispatch(modalActions.dismiss())}
             />,

--- a/assets/src/components/editing/elements/link/LinkModal.tsx
+++ b/assets/src/components/editing/elements/link/LinkModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { Maybe } from 'tsmonad';
 import { CommandContext } from 'components/editing/elements/commands/interfaces';
 import { onEnterApply } from 'components/editing/elements/common/settings/Settings';

--- a/assets/src/components/editing/elements/webpage/WebpageModal.tsx
+++ b/assets/src/components/editing/elements/webpage/WebpageModal.tsx
@@ -1,40 +1,51 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
+import { UrlOrUpload } from 'components/media/UrlOrUpload';
+import { SELECTION_TYPES } from 'components/media/manager/MediaManager';
 import { Modal, ModalSize } from 'components/modal/Modal';
 import * as ContentModel from 'data/content/model/elements/types';
+import { MediaItem } from 'types/media';
 
 interface ModalProps {
-  onDone: (x: any) => void;
+  onDone: (x: Partial<ContentModel.Webpage>) => void;
   onCancel: () => void;
   model: ContentModel.Webpage;
+  projectSlug: string;
 }
-export const WebpageModal = ({ onDone, onCancel, model }: ModalProps) => {
+export const WebpageModal = ({ onDone, onCancel, model, projectSlug }: ModalProps) => {
+  const [srcType, setSrcType] = useState<ContentModel.WebpageSrcType>(model.srcType || 'url');
   const [src, setSrc] = useState(model.src);
   const [alt, setAlt] = useState(model.alt ?? '');
   const [width, _setWidth] = useState(model.width);
 
+  const onSrcTypeChange = useCallback(
+    (v: ContentModel.WebpageSrcType) => {
+      if (srcType !== v) {
+        // Don't re-use generic url's as media library urls and vice versa
+        setSrc('');
+      }
+      setSrcType(v);
+    },
+    [srcType],
+  );
+
   return (
     <Modal
       title=""
-      size={ModalSize.MEDIUM}
+      size={ModalSize.LARGE}
       okLabel="Save"
       cancelLabel="Cancel"
       onCancel={onCancel}
-      onOk={() => onDone({ alt, width, src })}
+      onOk={() => onDone({ alt, width, src, srcType })}
     >
       <div>
         <h3 className="mb-2">Settings</h3>
         <h4 className="mb-2">Change Webpage Embed URL</h4>
-        <div className="mb-4">
-          <span>
-            Webpage Embed URL:
-            <input
-              className="form-control"
-              value={src}
-              onChange={(e) => setSrc(e.target.value)}
-              placeholder="Webpage Embed URL"
-            />
-          </span>
-        </div>
+
+        <LinkType linkType={srcType} setLinkType={onSrcTypeChange} />
+        {srcType === 'url' && <URLEntry src={src || ''} setSrc={setSrc} />}
+        {srcType === 'media_library' && (
+          <MediaEntry href={src || ''} setHref={setSrc} projectSlug={projectSlug} />
+        )}
 
         <h4 className="mb-2">Alternative Text</h4>
         <p className="mb-4">
@@ -51,3 +62,84 @@ export const WebpageModal = ({ onDone, onCancel, model }: ModalProps) => {
     </Modal>
   );
 };
+
+const MediaEntry: React.FC<{
+  href: string;
+  setHref: (v: string) => void;
+  projectSlug: string;
+}> = ({ href, setHref, projectSlug }) => {
+  const onMediaChange = useCallback(
+    (items: MediaItem[]) => {
+      if (items.length > 0) {
+        setHref(items[0].url);
+      } else {
+        setHref('');
+      }
+    },
+    [setHref],
+  );
+  return (
+    <UrlOrUpload
+      onUrlChange={setHref}
+      onMediaSelectionChange={onMediaChange}
+      projectSlug={projectSlug}
+      mimeFilter={undefined}
+      selectionType={SELECTION_TYPES.SINGLE}
+      initialSelectionPaths={href ? [href] : []}
+      externalUrlAllowed={false}
+    ></UrlOrUpload>
+  );
+};
+
+const URLEntry: React.FC<{
+  src: string;
+  setSrc: (v: string) => void;
+}> = ({ src, setSrc }) => (
+  <div className="mb-4">
+    <span>
+      Webpage Embed URL:
+      <input
+        className="form-control"
+        value={src}
+        onChange={(e) => setSrc(e.target.value)}
+        placeholder="Webpage Embed URL"
+      />
+    </span>
+  </div>
+);
+
+const LinkType: React.FC<{
+  linkType: ContentModel.WebpageSrcType;
+  setLinkType: (v: ContentModel.WebpageSrcType) => void;
+}> = ({ linkType, setLinkType }) => (
+  <div className="d-flex flex-column">
+    <div className="form-check">
+      <input
+        className="form-check-input mr-2"
+        defaultChecked={linkType === 'url'}
+        onChange={() => setLinkType('url')}
+        type="radio"
+        name="inlineRadioOptions"
+        id="inlineRadio1"
+        value="url"
+      />
+      <label className="form-check-label" htmlFor="inlineRadio1">
+        Link to URL
+      </label>
+    </div>
+    <div className="form-check">
+      <input
+        className="form-check-input mr-2"
+        defaultChecked={linkType === 'media_library'}
+        onChange={() => setLinkType('media_library')}
+        type="radio"
+        name="inlineRadioOptions"
+        id="inlineRadio2"
+        value="media_library"
+      />
+      <label className="form-check-label" htmlFor="inlineRadio2">
+        Link to Media Library
+      </label>
+    </div>
+  </div>
+);

--- a/assets/src/components/editing/elements/webpage/WebpageSettings.tsx
+++ b/assets/src/components/editing/elements/webpage/WebpageSettings.tsx
@@ -33,7 +33,11 @@ export const WebpageSettings = (props: SettingsProps) => {
         />
       </Toolbar.Group>
       <Toolbar.Group>
-        <SettingsButton model={props.model} onEdit={props.onEdit} />
+        <SettingsButton
+          model={props.model}
+          onEdit={props.onEdit}
+          projectSlug={props.commandContext.projectSlug}
+        />
       </Toolbar.Group>
     </Toolbar>
   );
@@ -41,7 +45,9 @@ export const WebpageSettings = (props: SettingsProps) => {
 interface SettingsButtonProps {
   model: ContentModel.Webpage;
   onEdit: (attrs: Partial<ContentModel.Webpage>) => void;
+  projectSlug: string;
 }
+
 const SettingsButton = (props: SettingsButtonProps) => (
   <DescriptiveButton
     description={createButtonCommandDesc({
@@ -51,11 +57,12 @@ const SettingsButton = (props: SettingsButtonProps) => (
         window.oliDispatch(
           modalActions.display(
             <WebpageModal
+              projectSlug={props.projectSlug}
               model={props.model}
-              onDone={({ alt, width, src }: Partial<ContentModel.Webpage>) => {
+              onDone={({ alt, width, src, srcType }: Partial<ContentModel.Webpage>) => {
                 console.log('width', width, alt, src);
                 window.oliDispatch(modalActions.dismiss());
-                props.onEdit({ alt, width, src });
+                props.onEdit({ alt, width, src, srcType });
               }}
               onCancel={() => window.oliDispatch(modalActions.dismiss())}
             />,

--- a/assets/src/components/media/UrlOrUpload.tsx
+++ b/assets/src/components/media/UrlOrUpload.tsx
@@ -14,6 +14,7 @@ interface Props {
   onMediaSelectionChange: (items: MediaItem[]) => void;
   onUrlChange: (url: string) => void;
   children?: React.ReactNode;
+  externalUrlAllowed?: boolean;
 }
 
 export const UrlOrUpload = (props: Props) => {
@@ -42,12 +43,14 @@ export const UrlOrUpload = (props: Props) => {
         >
           Media Library
         </button>
-        <button
-          className={classNames('nav-link', whenActive('url', 'active'))}
-          onClick={() => setSource('url')}
-        >
-          External URL
-        </button>
+        {props.externalUrlAllowed && (
+          <button
+            className={classNames('nav-link', whenActive('url', 'active'))}
+            onClick={() => setSource('url')}
+          >
+            External URL
+          </button>
+        )}
       </div>
       <div className="tab-content py-3">
         <div
@@ -100,3 +103,7 @@ const MediaManagerError = () => (
     <p>If the problem persists, contact support with the following details:</p>
   </>
 );
+
+UrlOrUpload.defaultProps = {
+  externalUrlAllowed: true,
+};

--- a/assets/src/data/content/model/elements/types.ts
+++ b/assets/src/data/content/model/elements/types.ts
@@ -381,10 +381,12 @@ export interface Citation extends SlateElement<Text[]> {
   bibref: number;
 }
 
+export type HyperlinkType = 'page' | 'url' | 'media_library';
 export interface Hyperlink extends SlateElement<Text[]> {
   type: 'a';
   href: string;
   target: string;
+  linkType?: HyperlinkType;
 }
 
 export interface CommandButton extends SlateElement<Text[]> {

--- a/assets/src/data/content/model/elements/types.ts
+++ b/assets/src/data/content/model/elements/types.ts
@@ -287,11 +287,13 @@ export interface Audio extends SlateElement<VoidChildren> {
   caption?: Caption;
 }
 
+export type WebpageSrcType = 'url' | 'media_library';
 // Webpage and Iframe are synonymous. Webpage is used in most UI-related
 // code, and Iframe is used for the underlying slate data model.
 export interface Webpage extends SlateElement<VoidChildren> {
   type: 'iframe';
   src?: string;
+  srcType?: WebpageSrcType;
   height?: number;
   width?: number;
   alt?: string;

--- a/lib/oli/authoring/media_library.ex
+++ b/lib/oli/authoring/media_library.ex
@@ -212,7 +212,9 @@ defmodule Oli.Authoring.MediaLibrary do
   end
 
   defp upload_file(bucket, file_name, contents) do
-    S3.put_object(bucket, file_name, contents, [{:acl, :public_read}]) |> ExAws.request()
+    mime_type = MIME.from_path(file_name)
+    options = [{:acl, :public_read}, {:content_type, mime_type}]
+    S3.put_object(bucket, file_name, contents, options) |> ExAws.request()
   end
 
   defp upload(file_name, file_contents) do

--- a/priv/schemas/v0-1-0/content-element.schema.json
+++ b/priv/schemas/v0-1-0/content-element.schema.json
@@ -595,6 +595,9 @@
         },
         "display": {
           "type": "string"
+        },
+        "srcType": {
+          "oneOf": [{ "const": "url" }, { "const": "media_library" }]
         }
       },
       "required": ["type"]

--- a/priv/schemas/v0-1-0/content-element.schema.json
+++ b/priv/schemas/v0-1-0/content-element.schema.json
@@ -987,6 +987,13 @@
         "target": {
           "type": "string"
         },
+        "linkType": {
+          "oneOf": [
+            { "const": "page" },
+            { "const": "url" },
+            { "const": "media_library" }
+          ]
+        },
         "children": {
           "type": "array",
           "items": {


### PR DESCRIPTION
Now, both links and webpages (iframes) in core authoring allow you to select a destination from the media library (including uploading files to use)

I modified the media library S3 upload to add a content-type to make viewing uploaded files in iframes work correctly, otherwise it just wants to download them. 

There is a bit of tension between the desire to have a link that downloads a file, vs. a link that opens in a new tab. Here's where I landed:

1. Links to media library uploads from the past will download (undesirable, but reasonable)
2. IFrames to media library uploads from the past will download (undesirable and useless)
3. Links to new media library items will do the browser-default behavior. Generally:
   - Images, Videos, Audio, PDF will open in a new browser tab 
   - HTML files will open in a new tab
   - Most other file types will download
4. IFrames to new media library items will do the browser-default behavior. Generally:
   - Images, Videos, Audio, PDF will display inside the iframe
   - HTML files will display in the iframe
   - Most other file types will initiate a download with nothing visible in the iframe


https://github.com/Simon-Initiative/oli-torus/assets/333265/1604e2ec-e299-4dab-bbb8-6eeb682a647a

