### PR TITLE
[CHORE] bump version to 24

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Oli.MixProject do
   def project do
     [
       app: :oli,
-      version: "0.23.1",
+      version: "0.24.0",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: elixirc_options(Mix.env()),


### PR DESCRIPTION
Marks the master branch as v0.24.0, which is a more accurate representation of the version being developed that will be displayed on QA servers