### PR TITLE
[MER-2135] Choices migrated with only a single image are not editable in torus

### DIFF
--- a/assets/src/components/editing/editor/Editor.tsx
+++ b/assets/src/components/editing/editor/Editor.tsx
@@ -68,6 +68,8 @@ export const Editor: React.FC<EditorProps> = React.memo((props: EditorProps) => 
     );
 
     installNormalizer(editor, props.normalizerContext);
+    editor.normalizeNode;
+    SlateEditor.normalize(editor, { force: true });
     return editor;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/assets/src/components/editing/editor/Editor.tsx
+++ b/assets/src/components/editing/editor/Editor.tsx
@@ -68,8 +68,14 @@ export const Editor: React.FC<EditorProps> = React.memo((props: EditorProps) => 
     );
 
     installNormalizer(editor, props.normalizerContext);
-    editor.normalizeNode;
-    SlateEditor.normalize(editor, { force: true });
+
+    // Force normalization on initial render, this will help a few use-cases:
+    //   1. Our normalization code has changed since the last time this doc was opened
+    //   2. The doc was created from another source (like the digest tool) and has never been opened.
+    setTimeout(() => {
+      SlateEditor.normalize(editor, { force: true });
+    });
+
     return editor;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/assets/test/multi_input/multi_input_authoring_test.tsx
+++ b/assets/test/multi_input/multi_input_authoring_test.tsx
@@ -113,9 +113,10 @@ describe('multi input question - default (with text input)', () => {
       </Provider>,
     );
 
-    fireEvent.click(screen.getByText('Answer Key'));
-    await screen.findByText('Add targeted feedback');
-    fireEvent.click(screen.getByText('Add targeted feedback'));
+    const answerKeyLink = await screen.findByText('Answer Key');
+    fireEvent.click(answerKeyLink);
+    const feedbackLink = await screen.findByText('Add targeted feedback');
+    fireEvent.click(feedbackLink);
     const responses = model.authoring.parts[0].responses;
     expect(responses).toHaveLength(3);
     expect(responses[1]).toHaveProperty('rule', 'input contains {}');


### PR DESCRIPTION
Choices in a multiple choice activity which only contain a single image in their content are not editable without completely removing the image first. This is likely because these content blocks need to be wrapped in a higher level content item, such as a paragraph.

Fixed this by forcing a normalization of the doc on opening it in the editor.