### PR TITLE
[BUGFIX][MER-2113] Fix complete course button for pages outside of the hierarchy

### DIFF
--- a/lib/oli_web/templates/page_delivery/_previous_next_nav.html.eex
+++ b/lib/oli_web/templates/page_delivery/_previous_next_nav.html.eex
@@ -1,4 +1,4 @@
-<nav class="previous-next-nav d-flex flex-row" aria-label="Page navigation">
+<nav class="<%= if is_nil(@current_page), do: "hidden", else: "previous-next-nav d-flex flex-row" %>" aria-label="Page navigation">
 
   <%= cond do %>
     <% @previous_page != nil -> %>
@@ -24,18 +24,6 @@
       <%= OliWeb.PageDeliveryView.next_link(%{
         to: next_url(@conn, @next_page, @preview_mode, @section_slug),
         title: next_title(@next_page) }) %>
-
-    <% @current_page == nil -> %>
-      <%= link to: "#", class: "page-nav-link btn", onclick: "window.close();" do %>
-        <div class="flex items-center justify-between">
-          <div class="flex flex-col text-left">
-            <div class="nav-title">Complete</div>
-          </div>
-          <div>
-            <i class="fas fa-check nav-icon"></i>
-          </div>
-        </div>
-      <% end %>
 
     <% true -> %>
       <%= link to: Routes.page_delivery_path(@conn, :index, @section_slug), class: "page-nav-link btn" do %>

--- a/lib/oli_web/templates/page_delivery/_previous_next_nav.html.eex
+++ b/lib/oli_web/templates/page_delivery/_previous_next_nav.html.eex
@@ -25,10 +25,22 @@
         to: next_url(@conn, @next_page, @preview_mode, @section_slug),
         title: next_title(@next_page) }) %>
 
+    <% @current_page == nil -> %>
+      <%= link to: "#", class: "page-nav-link btn", onclick: "window.close();" do %>
+        <div class="flex items-center justify-between">
+          <div class="flex flex-col text-left">
+            <div class="nav-title">Complete</div>
+          </div>
+          <div>
+            <i class="fas fa-check nav-icon"></i>
+          </div>
+        </div>
+      <% end %>
+
     <% true -> %>
       <%= link to: Routes.page_delivery_path(@conn, :index, @section_slug), class: "page-nav-link btn" do %>
-        <div class="d-flex flex-row">
-          <div class="d-flex flex-column flex-1 flex-ellipsis-fix text-left">
+        <div class="flex items-center justify-between">
+          <div class="flex flex-col text-left">
             <div class="nav-label">Complete</div>
             <div class="nav-title"><%= @section.title %></div>
           </div>

--- a/lib/oli_web/views/page_delivery_view.ex
+++ b/lib/oli_web/views/page_delivery_view.ex
@@ -59,11 +59,11 @@ defmodule OliWeb.PageDeliveryView do
   def prev_link(assigns) do
     ~H"""
       <%= link to: @to, class: "page-nav-link btn", onclick: assigns[:onclick] do %>
-        <div class="d-flex flex-row">
+        <div class="flex items-center justify-between">
           <div>
             <i class="fas fa-arrow-left nav-icon"></i>
           </div>
-          <div class="d-flex flex-column flex-1 flex-ellipsis-fix text-right">
+          <div class="flex flex-col text-right">
             <div class="nav-label"><%= value_or(assigns[:label], "Previous") %></div>
             <div class="nav-title"><%= @title %></div>
           </div>
@@ -75,8 +75,8 @@ defmodule OliWeb.PageDeliveryView do
   def next_link(assigns) do
     ~H"""
       <%= link to: @to, class: "page-nav-link btn", onclick: assigns[:onclick] do %>
-        <div class="d-flex flex-row">
-          <div class="d-flex flex-column flex-1 flex-ellipsis-fix text-left">
+        <div class="flex items-center justify-between">
+          <div class="flex flex-col text-left">
             <div class="nav-label"><%= value_or(assigns[:label], "Next") %></div>
             <div class="nav-title"><%= @title %></div>
           </div>


### PR DESCRIPTION
Link to the story [MER-2113](https://eliterate.atlassian.net/browse/MER-2113)

### Notes
With these changes, if the user is on a page that is outside of the hierarchy, when they click the "Complete" button, the tab will close

[MER-2113]: https://eliterate.atlassian.net/browse/MER-2113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ