### PR TITLE
[IMPROVEMENT][MER-1985] Add 'Edit Page' link to pages in customize product content page

### DIFF
--- a/assets/src/hooks/before_unload.ts
+++ b/assets/src/hooks/before_unload.ts
@@ -1,11 +1,15 @@
-const listener = (e: any) => {
-  e.preventDefault();
-  e.returnValue = '';
+const listener = (e: any, elementId?: string) => {
+  const element = elementId && document.getElementById(elementId);
+  if (!element || element.dataset.saved !== 'true') {
+    e.preventDefault();
+    e.returnValue = '';
+  }
 };
 
 export const BeforeUnloadListener = {
   mounted() {
-    window.addEventListener('beforeunload', listener);
+    const elementId = this.el && this.el.id;
+    window.addEventListener('beforeunload', (e: any) => listener(e, elementId));
   },
   destroyed() {
     window.removeEventListener('beforeunload', listener);

--- a/lib/oli/delivery/hierarchy/hierarchy_node.ex
+++ b/lib/oli/delivery/hierarchy/hierarchy_node.ex
@@ -18,6 +18,7 @@ defmodule Oli.Delivery.Hierarchy.HierarchyNode do
             children: [],
             resource_id: nil,
             project_id: nil,
+            project_slug: nil,
             revision: nil,
             section_resource: nil,
             ancestors: [],

--- a/lib/oli_web/live/delivery/remix/entry.ex
+++ b/lib/oli_web/live/delivery/remix/entry.ex
@@ -9,6 +9,12 @@ defmodule OliWeb.Delivery.Remix.Entry do
 
   alias OliWeb.Delivery.Remix.Actions
   alias Oli.Delivery.Hierarchy.HierarchyNode
+  alias OliWeb.Router.Helpers, as: Routes
+
+  attr :node, :map, required: true
+  attr :index, :integer, required: true
+  attr :selected, :boolean, required: true
+  attr :is_product, :boolean, default: false
 
   def entry(%{node: %HierarchyNode{}} = assigns) do
     ~H"""
@@ -32,6 +38,20 @@ defmodule OliWeb.Delivery.Remix.Entry do
             <button class="btn btn-link ml-1 mr-1 entry-title" phx-click="set_active" phx-value-uuid={@node.uuid}><%= @node.revision.title %></button>
           <% else %>
             <span class="ml-1 mr-1 entry-title"><%= @node.revision.title %></span>
+            <%= if @is_product do %>
+              <a
+                id={"product-page-#{@node.revision.slug}"}
+                class="entry-title mx-3"
+                href={Routes.resource_path(
+                  OliWeb.Endpoint,
+                  :edit,
+                  @node.project_slug,
+                  @node.revision.slug
+                )}
+              >
+                Edit Page
+              </a>
+            <% end %>
           <% end %>
         </div>
       </div>

--- a/lib/oli_web/live/delivery/remix_section.ex
+++ b/lib/oli_web/live/delivery/remix_section.ex
@@ -31,6 +31,8 @@ defmodule OliWeb.Delivery.RemixSection do
   alias OliWeb.Sections.Mount
   alias Oli.Delivery.Sections.Section
 
+  alias Phoenix.LiveView.JS
+
   defp redirect_after_save(:instructor, %Section{slug: slug}),
     do:
       Routes.live_path(
@@ -224,7 +226,8 @@ defmodule OliWeb.Delivery.RemixSection do
        available_publications: available_publications,
        publications_table_model: publications_table_model,
        publications_table_model_total_count: publications_table_model_total_count,
-       publications_table_model_params: publications_table_model_params
+       publications_table_model_params: publications_table_model_params,
+       is_product: is_product?(socket)
      )}
   end
 
@@ -696,7 +699,11 @@ defmodule OliWeb.Delivery.RemixSection do
     {:noreply, assign(socket, modal_assigns: modal_assigns)}
   end
 
-  def handle_event("HierarchyPicker.pages_page_change", %{"limit" => limit, "offset" => offset}, socket) do
+  def handle_event(
+        "HierarchyPicker.pages_page_change",
+        %{"limit" => limit, "offset" => offset},
+        socket
+      ) do
     %{modal_assigns: modal_assigns} = socket.assigns
     selected_publication_id = modal_assigns.selected_publication.id
 
@@ -924,4 +931,7 @@ defmodule OliWeb.Delivery.RemixSection do
       %HierarchyNode{uuid: UUID.uuid4(), revision: rev}
     end)
   end
+
+  defp is_product?(%{assigns: %{live_action: :product_remix}} = _socket), do: true
+  defp is_product?(_), do: false
 end

--- a/lib/oli_web/live/delivery/remix_section.html.heex
+++ b/lib/oli_web/live/delivery/remix_section.html.heex
@@ -1,6 +1,6 @@
 <%= render_modal(assigns) %>
 
-<div id="curriculum-container" class="container curriculum-editor">
+<div data-saved={if @has_unsaved_changes, do: "false", else: "true"} phx-hook="BeforeUnloadListener" id="curriculum-container" class="container curriculum-editor">
   <h3><%= @section.title %></h3>
 
   <div class="grid grid-cols-12 mt-3">
@@ -10,7 +10,15 @@
         <div class="flex-grow-1"></div>
         <div class="flex-shrink-0">
           <button id="cancel" class="btn btn-outline-primary ml-1" phx-click="cancel">Cancel</button>
-          <button id="save" disabled={!@has_unsaved_changes} class="btn btn-primary ml-1" phx-click="save" phx-disabled-with="Saving...">Save</button>
+          <button
+            id="save"
+            disabled={!@has_unsaved_changes}
+            class="btn btn-primary ml-1"
+            phx-click={JS.set_attribute({"data-saved", "true"}, to: "#curriculum-container") |> JS.push("save")}
+            phx-disabled-with="Saving..."
+          >
+            Save
+          </button>
         </div>
       </div>
     </div>
@@ -33,7 +41,8 @@
           <Entry.entry
               index={index}
               selected={@selected == node.uuid}
-              node={node} />
+              node={node}
+              is_product={assigns[:is_product]} />
         <% end %>
         <DropTarget.droptarget id={"last"} index={length(@active.children)} />
       </div>

--- a/lib/oli_web/live/products/details/content.ex
+++ b/lib/oli_web/live/products/details/content.ex
@@ -41,7 +41,7 @@ defmodule OliWeb.Products.Details.Content do
           <p>
             <Link
               label={"Customize content"}
-              to={Routes.product_remix_path(OliWeb.Endpoint, OliWeb.Delivery.RemixSection, @product.slug)}
+              to={Routes.product_remix_path(OliWeb.Endpoint, :product_remix, @product.slug)}
             />
           </p>
           <p>

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -333,7 +333,7 @@ defmodule OliWeb.Router do
     live("/products/:product_id", Products.DetailsView)
     live("/products/:product_id/payments", Products.PaymentsView)
     live("/products/:section_slug/source_materials", Delivery.ManageSourceMaterials)
-    live("/products/:section_slug/remix", Delivery.RemixSection, as: :product_remix)
+    live("/products/:section_slug/remix", Delivery.RemixSection, :product_remix, as: :product_remix)
 
     get(
       "/products/:product_id/payments/donwload_codes",

--- a/test/oli_web/live/remix_section_test.exs
+++ b/test/oli_web/live/remix_section_test.exs
@@ -275,18 +275,37 @@ defmodule OliWeb.RemixSectionLiveTest do
       conn: conn,
       prod: prod,
       revision1: revision1,
-      revision2: revision2
+      revision2: revision2,
+      project_slug: project_slug
     } do
       conn =
         get(
           conn,
-          Routes.product_remix_path(OliWeb.Endpoint, OliWeb.Delivery.RemixSection, prod.slug)
+          Routes.product_remix_path(OliWeb.Endpoint, :product_remix, prod.slug)
         )
 
       {:ok, view, _html} = live(conn)
 
       assert view |> element("#entry-#{revision1.resource_id}") |> has_element?()
       assert view |> element("#entry-#{revision2.resource_id}") |> has_element?()
+
+      assert view
+             |> has_element?(
+               "#entry-#{revision1.resource_id} a[href=\"#{Routes.resource_path(OliWeb.Endpoint,
+               :edit,
+               project_slug,
+               revision1.slug)}\"]",
+               "Edit Page"
+             )
+
+      assert view
+             |> has_element?(
+               "#entry-#{revision2.resource_id} a[href=\"#{Routes.resource_path(OliWeb.Endpoint,
+               :edit,
+               project_slug,
+               revision2.slug)}\"]",
+               "Edit Page"
+             )
     end
 
     test "saving redirects product manager correctly", %{
@@ -296,7 +315,7 @@ defmodule OliWeb.RemixSectionLiveTest do
       conn =
         get(
           conn,
-          Routes.product_remix_path(OliWeb.Endpoint, OliWeb.Delivery.RemixSection, prod.slug)
+          Routes.product_remix_path(OliWeb.Endpoint, :product_remix, prod.slug)
         )
 
       {:ok, view, _html} = live(conn)
@@ -428,7 +447,7 @@ defmodule OliWeb.RemixSectionLiveTest do
           Routes.live_path(OliWeb.Endpoint, OliWeb.Delivery.RemixSection, oaf_section_1.slug)
         )
 
-        # click add materials and assert is listing units first
+      # click add materials and assert is listing units first
       view
       |> element("button[phx-click=\"show_add_materials_modal\"]")
       |> render_click()
@@ -641,24 +660,23 @@ defmodule OliWeb.RemixSectionLiveTest do
 
     insert(:publication, %{
       project: proj_1,
-      published: DateTime.utc_now(),
+      published: DateTime.utc_now()
     })
 
     insert(:publication, %{
       project: proj_2,
-      published: DateTime.utc_now(),
+      published: DateTime.utc_now()
     })
 
     insert(:publication, %{
       project: proj_3,
-      published: DateTime.utc_now(),
+      published: DateTime.utc_now()
     })
 
     insert(:publication, %{
       project: proj_4,
-      published: DateTime.utc_now(),
+      published: DateTime.utc_now()
     })
-
 
     {:ok,
      conn: conn,
@@ -666,7 +684,7 @@ defmodule OliWeb.RemixSectionLiveTest do
      author: map.author,
      institution: map.institution,
      project: map.project,
-     publication: map.publication,}
+     publication: map.publication}
   end
 
   defp setup_instructor_session(%{conn: conn}) do
@@ -704,7 +722,8 @@ defmodule OliWeb.RemixSectionLiveTest do
       author: product_author,
       publication: publication,
       revision1: revision1,
-      revision2: revision2
+      revision2: revision2,
+      project: project
     } =
       Seeder.base_project_with_resource2()
       |> Seeder.create_product(%{title: "My 1st product", amount: Money.new(:USD, 100)}, :prod1)
@@ -718,6 +737,11 @@ defmodule OliWeb.RemixSectionLiveTest do
         OliWeb.Pow.PowHelpers.get_pow_config(:author)
       )
 
-    {:ok, conn: conn, prod: prod, revision1: revision1, revision2: revision2}
+    {:ok,
+     conn: conn,
+     prod: prod,
+     revision1: revision1,
+     revision2: revision2,
+     project_slug: project.slug}
   end
 end


### PR DESCRIPTION
[Link to the ticket](https://eliterate.atlassian.net/browse/MER-1985)

### NOTES
If users modify the curriculum but they don't save the changes, they will get a browser warning when they try to navigate to the "Edit Page" (or any other page)
<img width="600" alt="image" src="https://github.com/Simon-Initiative/oli-torus/assets/53446634/bc2bbfd2-961a-442a-9540-ba19d9eae57c">
