### PR TITLE
[FEATURE][MER-1957] Add clickable links payment management

### DIFF
--- a/lib/oli_web/live/products/payments/tabel_model.ex
+++ b/lib/oli_web/live/products/payments/tabel_model.ex
@@ -18,7 +18,8 @@ defmodule OliWeb.Products.Payments.TableModel do
           name: :type,
           label: "Type",
           render_fn: &__MODULE__.render_type_column/3,
-          sort_fn: &__MODULE__.sort/2
+          sort_fn: &__MODULE__.sort/2,
+          td_class: "text-center text-nowrap"
         },
         inserted_at_spec,
         %ColumnSpec{
@@ -35,12 +36,14 @@ defmodule OliWeb.Products.Payments.TableModel do
         %ColumnSpec{
           name: :user,
           label: "User",
-          render_fn: &__MODULE__.render_user_column/3
+          render_fn: &__MODULE__.render_user_column/3,
+          td_class: "text-center text-nowrap"
         },
         %ColumnSpec{
           name: :section,
           label: "Section",
-          render_fn: &__MODULE__.render_section_column/3
+          render_fn: &__MODULE__.render_section_column/3,
+          td_class: "text-center text-nowrap"
         }
       ],
       event_suffix: "",
@@ -53,20 +56,42 @@ defmodule OliWeb.Products.Payments.TableModel do
     )
   end
 
-  def render_section_column(_, %{section: section}, _) do
+  def render_section_column(assigns, %{section: section}, _) do
     case section do
-      nil -> ""
-      s -> s.title
+      nil ->
+        ""
+
+      s ->
+        ~F"""
+          <a href={Routes.live_path(
+            OliWeb.Endpoint,
+            OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive,
+            section.slug,
+            :overview
+          )}>
+            <span>{s.title}</span>
+          </a>
+        """
     end
   end
 
-  def render_user_column(_, %{user: user}, _) do
+  def render_user_column(assigns, %{user: user, section: section}, _) do
     case user do
       nil ->
         ""
 
       user ->
-        safe_get(user.family_name, "Unknown") <> ", " <> safe_get(user.given_name, "Unknown")
+        ~F"""
+          <a href={Routes.live_path(
+            OliWeb.Endpoint,
+            OliWeb.Delivery.StudentDashboard.StudentDashboardLive,
+            section.slug,
+            user.id,
+            :content
+          )}>
+            <span>{safe_get(user.family_name, "Unknown")}, {safe_get(user.given_name, "Unknown")}</span>
+          </a>
+        """
     end
   end
 

--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -12,6 +12,7 @@ defmodule OliWeb.Sections.OverviewView do
   alias Oli.Publishing.DeliveryResolver
   alias Oli.Resources.Collaboration
   alias OliWeb.Projects.RequiredSurvey
+  alias Oli.Repo
 
   prop(user, :any)
   data(modal, :any, default: nil)
@@ -74,6 +75,8 @@ defmodule OliWeb.Sections.OverviewView do
             section.slug
           )
 
+        %{base_project: base_project} = section |> Repo.preload(:base_project)
+
         {:ok,
          assign(socket,
            is_system_admin: type == :admin,
@@ -87,7 +90,8 @@ defmodule OliWeb.Sections.OverviewView do
              Oli.Delivery.Attempts.ManualGrading.count_submitted_attempts(section),
            collab_space_config: collab_space_config,
            resource_slug: revision_slug,
-           show_required_section_config: show_required_section_config
+           show_required_section_config: show_required_section_config,
+           base_project: base_project
          )}
     end
   end
@@ -125,6 +129,22 @@ defmodule OliWeb.Sections.OverviewView do
               do: Routes.institution_path(OliWeb.Endpoint, :show, deployment.institution_id),
               else: deployment.institution.name}
           />
+        {/unless}
+        <div class="flex flex-col form-group">
+          <label>Base Project</label>
+          <a
+            href={Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.OverviewLive, @base_project.slug)}
+            class="">{@base_project.title}
+          </a>
+        </div>
+        {#unless is_nil(@section.blueprint_id)}
+          <div class="flex flex-col form-group">
+            <label>Product</label>
+            <a
+              href={Routes.live_path(OliWeb.Endpoint, OliWeb.Products.DetailsView, @section.blueprint.slug)}
+              class="">{@section.blueprint.title}
+            </a>
+          </div>
         {/unless}
       </Group>
       <Group label="Instructors" description="Manage users with instructor level access">


### PR DESCRIPTION
[MER-1957](https://eliterate.atlassian.net/browse/MER-1957)

This PR adds clickable links to the information in the User and Section columns of the payments table. 

User: Adds the link to the student details view for that student in that section.
Section: Adds the link to access the instructor dashboard for that section.

![Captura de pantalla 2023-06-13 a la(s) 09 30 05](https://github.com/Simon-Initiative/oli-torus/assets/16328384/908217ba-3494-48e7-8bea-e0172a860e59)

Also, the base project and product information (if there is one) is shown in the manage section view, in the section details.
Both also have clickable links to access the base project and product details.

![Captura de pantalla 2023-06-13 a la(s) 09 30 19](https://github.com/Simon-Initiative/oli-torus/assets/16328384/d78d4428-590c-4316-86dc-2439bcb31cc7)
![Captura de pantalla 2023-06-13 a la(s) 09 30 30](https://github.com/Simon-Initiative/oli-torus/assets/16328384/8f37016c-c92f-4e44-8a38-1a52fa92a836)


[MER-1957]: https://eliterate.atlassian.net/browse/MER-1957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ