### PR TITLE
[BUGFIX][MER-2152] Fix enter course as a student

### DIFF
--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -81,7 +81,8 @@ defmodule OliWeb.PageDeliveryController do
               is_instructor: is_instructor,
               progress: learner_progress(section.id, user.id),
               next_activities: next_activities,
-              independent_learner: user.independent_learner
+              independent_learner: user.independent_learner,
+              current_user_id: user.id
             )
           end
       end
@@ -720,6 +721,8 @@ defmodule OliWeb.PageDeliveryController do
   # PREVIEW
 
   def index_preview(conn, %{"section_slug" => section_slug}) do
+    current_user = conn.assigns.current_author || conn.assigns.current_user
+
     section =
       conn.assigns.section
       |> Oli.Repo.preload([:base_project, :root_section_resource])
@@ -727,7 +730,11 @@ defmodule OliWeb.PageDeliveryController do
     revision = DeliveryResolver.root_container(section_slug)
 
     effective_settings =
-      Oli.Delivery.Settings.get_combined_settings(revision, section.id, conn.assigns.current_user.id)
+      Oli.Delivery.Settings.get_combined_settings(
+        revision,
+        section.id,
+        current_user.id
+      )
 
     render(conn, "index.html",
       title: section.title,
@@ -741,7 +748,8 @@ defmodule OliWeb.PageDeliveryController do
       independent_learner: true,
       collab_space_config: effective_settings.collab_space_config,
       revision_slug: revision.slug,
-      is_instructor: false
+      is_instructor: false,
+      current_user_id: current_user.id
     )
   end
 

--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -160,7 +160,7 @@ defmodule OliWeb.Sections.OverviewView do
             ><span>Preview Course as Instructor</span> <i class="fas fa-external-link-alt self-center ml-1" /></a>
           </li>
           <li><a
-              href={Routes.page_delivery_path(OliWeb.Endpoint, :index_preview, @section.slug)}
+              href={Routes.page_delivery_url(OliWeb.Endpoint, :index, @section.slug)}
               class="btn btn-link"
               target="_blank"
             ><span>Enter Course as a Student</span> <i class="fas fa-external-link-alt self-center ml-1" /></a></li>

--- a/lib/oli_web/templates/page_delivery/index.html.heex
+++ b/lib/oli_web/templates/page_delivery/index.html.heex
@@ -39,6 +39,7 @@
             live_render(@conn, OliWeb.Delivery.StudentDashboard.CourseContentLive,
               session: %{
                 "section_slug" => @section_slug,
+                "current_user_id" => @current_user_id
               })
             %>
           </div>

--- a/test/oli_web/controllers/page_delivery_controller_test.exs
+++ b/test/oli_web/controllers/page_delivery_controller_test.exs
@@ -1529,6 +1529,39 @@ defmodule OliWeb.PageDeliveryControllerTest do
       # page title
       assert html_response(conn, 200) =~ "page1 (Preview)"
     end
+
+    test "index preview - can access if the user is logged in as instructor", %{
+      conn: conn,
+      section: section
+    } do
+      user = insert(:user)
+      enroll_as_instructor(%{section: section, user: user})
+
+      conn =
+        get(
+          conn,
+          Routes.page_delivery_path(conn, :index_preview, section.slug)
+        )
+
+      assert html_response(conn, 200) =~ section.title
+      assert html_response(conn, 200) =~ "Preview"
+    end
+
+    test "index preview - can access if the user is logged in as admin", %{
+      conn: conn,
+      section: section
+    } do
+      {:ok, conn: conn, admin: _admin} = admin_conn(%{conn: conn})
+
+      conn =
+        get(
+          conn,
+          Routes.page_delivery_path(conn, :index_preview, section.slug)
+        )
+
+      assert html_response(conn, 200) =~ section.title
+      assert html_response(conn, 200) =~ "Preview"
+    end
   end
 
   describe "exploration" do

--- a/test/oli_web/live/sections/overview_live_test.exs
+++ b/test/oli_web/live/sections/overview_live_test.exs
@@ -186,7 +186,7 @@ defmodule OliWeb.Sections.OverviewLiveTest do
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.page_delivery_path(OliWeb.Endpoint, :index_preview, section.slug)}\"]",
+               "a[href=\"#{Routes.page_delivery_url(OliWeb.Endpoint, :index, section.slug)}\"]",
                "Enter Course as a Student"
              )
 


### PR DESCRIPTION
[MER-2152](https://eliterate.atlassian.net/browse/MER-2152)

This PR fixes the error that happened when trying to enter a section as a student while being an Admin or an Instructor.

Enter Course as a Student being Admin

https://github.com/Simon-Initiative/oli-torus/assets/16328384/f6d4eca1-d8ad-4886-b27e-c6b85736a8a2

Enter Course as a Student being an Instructor

https://github.com/Simon-Initiative/oli-torus/assets/16328384/71a47be8-35fe-46b6-bf7a-5418e1e02f1b

[MER-2152]: https://eliterate.atlassian.net/browse/MER-2152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ