### PR TITLE
[MER-2072] Migrate xref links correctly

### DIFF
--- a/assets/src/data/content/model/elements/types.ts
+++ b/assets/src/data/content/model/elements/types.ts
@@ -387,7 +387,8 @@ export type HyperlinkType = 'page' | 'url' | 'media_library';
 export interface Hyperlink extends SlateElement<Text[]> {
   type: 'a';
   href: string;
-  target: string;
+  target?: string;
+  anchor?: string;
   linkType?: HyperlinkType;
 }
 

--- a/lib/oli/interop/rewire_links.ex
+++ b/lib/oli/interop/rewire_links.ex
@@ -45,11 +45,25 @@ defmodule Oli.Ingest.RewireLinks do
   end
 
   def rewire(
-        %{"type" => "a", "idref" => idref, "children" => children},
+        %{"type" => "a", "idref" => idref, "children" => children} = link,
         link_builder,
         _page_map
       ) do
-    {true, %{"type" => "a", "children" => children, "href" => link_builder.(idref)}}
+    target = Map.get(link, "target")
+    anchor = Map.get(link, "anchor")
+
+    putIfNotNil = fn map, key, value ->
+      if is_nil(value) do
+        map
+      else
+        Map.put(map, key, value)
+      end
+    end
+
+    {true,
+     %{"type" => "a", "children" => children, "href" => link_builder.(idref)}
+     |> putIfNotNil.("target", target)
+     |> putIfNotNil.("anchor", anchor)}
   end
 
   def rewire(%{"type" => "page_link", "idref" => idref} = other, _link_builder, page_map) do

--- a/lib/oli/interop/rewire_links.ex
+++ b/lib/oli/interop/rewire_links.ex
@@ -33,7 +33,7 @@ defmodule Oli.Ingest.RewireLinks do
     end
   end
 
-  defp rewire(items, link_builder, page_map) when is_list(items) do
+  def rewire(items, link_builder, page_map) when is_list(items) do
     results = Enum.map(items, fn i -> rewire(i, link_builder, page_map) end)
 
     children = Enum.map(results, fn {_, c} -> c end)
@@ -44,15 +44,19 @@ defmodule Oli.Ingest.RewireLinks do
     {changed, children}
   end
 
-  defp rewire(%{"type" => "a", "idref" => idref, "children" => children}, link_builder, _page_map) do
+  def rewire(
+        %{"type" => "a", "idref" => idref, "children" => children},
+        link_builder,
+        _page_map
+      ) do
     {true, %{"type" => "a", "children" => children, "href" => link_builder.(idref)}}
   end
 
-  defp rewire(%{"type" => "page_link", "idref" => idref} = other, _link_builder, page_map) do
+  def rewire(%{"type" => "page_link", "idref" => idref} = other, _link_builder, page_map) do
     {true, Map.put(other, "idref", Map.get(page_map, idref).resource_id)}
   end
 
-  defp rewire(%{"model" => model} = item, link_builder, page_map) do
+  def rewire(%{"model" => model} = item, link_builder, page_map) do
     case rewire(model, link_builder, page_map) do
       {true, model} -> {true, Map.put(item, "model", model)}
       {false, _} -> {false, item}
@@ -64,90 +68,116 @@ defmodule Oli.Ingest.RewireLinks do
   # this processing, we track whether or not we are changing anything. We return that result
   # as the first element of the tuple, with the potentially updated content as the second.
   # This allows then the caller to know whether or not to save a new revision.
-  defp rewire(%{"stem" => stem} = item, link_builder, page_map) do
-    {stem_result, item} = case rewire(stem, link_builder, page_map) do
-      {true, stem} -> {true, Map.put(item, "stem", stem)}
-      {false, _} -> {false, item}
-    end
+  def rewire(%{"stem" => stem} = item, link_builder, page_map) do
+    {stem_result, item} =
+      case rewire(stem, link_builder, page_map) do
+        {true, stem} -> {true, Map.put(item, "stem", stem)}
+        {false, _} -> {false, item}
+      end
 
-    {authoring_result, item} = case Map.get(item, "authoring") do
-      nil -> {false, item}
-      authoring ->
-        {result, parts} = case Map.get(authoring, "parts") do
-          nil -> {false, item}
-          parts ->
-            {results, parts} = Enum.map(parts, fn part ->
+    {authoring_result, item} =
+      case Map.get(item, "authoring") do
+        nil ->
+          {false, item}
 
-              {exp_result, part} = case Map.get(part, "explanation") do
-                nil -> {false, part}
-                exp ->
-                  {exp_result, exp} = rewire(exp, link_builder, page_map)
-                  {exp_result, Map.put(part, "explanation", exp)}
-              end
+        authoring ->
+          {result, parts} =
+            case Map.get(authoring, "parts") do
+              nil ->
+                {false, item}
 
-              {hint_result, part} = case Map.get(part, "hints") do
-                nil -> {false, part}
-                hints ->
-                  {hint_result, hints} = rewire(hints, link_builder, page_map)
-                  {hint_result, Map.put(part, "hints", hints)}
-              end
+              parts ->
+                {results, parts} =
+                  Enum.map(parts, fn part ->
+                    {exp_result, part} =
+                      case Map.get(part, "explanation") do
+                        nil ->
+                          {false, part}
 
-              {resp_result, part} = case Map.get(part, "responses") do
-                nil -> {false, part}
-                responses ->
-                  {results, responses} = Enum.map(responses, fn r ->
-                    case Map.get(r, "feedback") do
-                      nil -> {false, r}
-                      feedback ->
-                        {result, feedback} = rewire(feedback, link_builder, page_map)
-                        {result, Map.put(r, "feedback", feedback)}
-                    end
+                        exp ->
+                          {exp_result, exp} = rewire(exp, link_builder, page_map)
+                          {exp_result, Map.put(part, "explanation", exp)}
+                      end
+
+                    {hint_result, part} =
+                      case Map.get(part, "hints") do
+                        nil ->
+                          {false, part}
+
+                        hints ->
+                          {hint_result, hints} = rewire(hints, link_builder, page_map)
+                          {hint_result, Map.put(part, "hints", hints)}
+                      end
+
+                    {resp_result, part} =
+                      case Map.get(part, "responses") do
+                        nil ->
+                          {false, part}
+
+                        responses ->
+                          {results, responses} =
+                            Enum.map(responses, fn r ->
+                              case Map.get(r, "feedback") do
+                                nil ->
+                                  {false, r}
+
+                                feedback ->
+                                  {result, feedback} = rewire(feedback, link_builder, page_map)
+                                  {result, Map.put(r, "feedback", feedback)}
+                              end
+                            end)
+                            |> Enum.unzip()
+
+                          {Enum.any?(results), Map.put(part, "responses", responses)}
+                      end
+
+                    {exp_result || hint_result || resp_result, part}
                   end)
-                  |> Enum.unzip
+                  |> Enum.unzip()
 
-                  {Enum.any?(results), Map.put(part, "responses", responses)}
-              end
+                {Enum.any?(results), parts}
+            end
 
-              {exp_result || hint_result || resp_result, part}
+          authoring = Map.put(authoring, "parts", parts)
+          {result, Map.put(item, "authoring", authoring)}
+      end
 
-            end)
-            |> Enum.unzip
+    {choices_result, item} =
+      case Map.get(item, "choices") do
+        nil ->
+          {false, item}
 
-            {Enum.any?(results), parts}
-        end
-        authoring = Map.put(authoring, "parts", parts)
-        {result, Map.put(item, "authoring", authoring)}
-    end
-
-    {choices_result, item} = case Map.get(item, "choices") do
-      nil -> {false, item}
-      choices ->
-        {r, choices} = rewire(choices, link_builder, page_map)
-        {r, Map.put(item, "choices", choices)}
-    end
+        choices ->
+          {r, choices} = rewire(choices, link_builder, page_map)
+          {r, Map.put(item, "choices", choices)}
+      end
 
     {stem_result || authoring_result || choices_result, item}
   end
 
-  defp rewire(%{"content" => content} = item, link_builder, page_map) do
-    case rewire(content, link_builder, page_map) do
-      {true, content} -> {true, Map.put(item, "content", content)}
-      {false, _} -> {false, item}
+  def rewire(item, link_builder, page_map) do
+    # There are several properties that could exist that we need to follow recursively.
+    {children_changed, item} = rewire_property("children", item, link_builder, page_map)
+    {caption_changed, item} = rewire_property("caption", item, link_builder, page_map)
+    {pronunciation_changed, item} = rewire_property("pronunciation", item, link_builder, page_map)
+    {translations_changed, item} = rewire_property("translations", item, link_builder, page_map)
+    {content_changed, item} = rewire_property("content", item, link_builder, page_map)
+
+    {children_changed || caption_changed || pronunciation_changed || translations_changed ||
+       content_changed, item}
+  end
+
+  defp rewire_property(property, item, link_builder, page_map) do
+    children = Map.get(item, property)
+
+    if is_list(children) do
+      # IO.inspect(children, label: "rewire #{property}")
+
+      {changed, children} = rewire(children, link_builder, page_map)
+
+      {changed, Map.put(item, property, children)}
+    else
+      {false, item}
     end
-  end
-
-  defp rewire(%{"children" => children} = item, link_builder, page_map) do
-    results = Enum.map(children, fn i -> rewire(i, link_builder, page_map) end)
-
-    children = Enum.map(results, fn {_, c} -> c end)
-
-    changed =
-      Enum.map(results, fn {changed, _} -> changed end) |> Enum.any?(fn c -> c == true end)
-
-    {changed, Map.put(item, "children", children)}
-  end
-
-  defp rewire(item, _, _) do
-    {false, item}
   end
 end

--- a/priv/schemas/v0-1-0/content-element.schema.json
+++ b/priv/schemas/v0-1-0/content-element.schema.json
@@ -990,6 +990,9 @@
         "target": {
           "type": "string"
         },
+        "anchor": {
+          "type": "string"
+        },
         "linkType": {
           "oneOf": [
             { "const": "page" },

--- a/test/oli/interop/ingest_test.exs
+++ b/test/oli/interop/ingest_test.exs
@@ -27,7 +27,6 @@ defmodule Oli.Interop.IngestTest do
   end
 
   def verify_export(entries) do
-
     m = Enum.reduce(entries, %{}, fn {f, c}, m -> Map.put(m, f, c) end)
 
     assert length(entries) == 30

--- a/test/oli/interop/rewire_links_test.exs
+++ b/test/oli/interop/rewire_links_test.exs
@@ -19,6 +19,64 @@ defmodule Oli.Interop.RewireLinksTest do
       assert %{"type" => "a", "children" => [], "href" => "my-url"} == rewritten
     end
 
+    test "rewire/3 maintains anchor and target attributes for href links" do
+      link = %{
+        "type" => "a",
+        "href" => "my-url",
+        "target" => "my-target",
+        "anchor" => "my-anchor",
+        "children" => []
+      }
+
+      {false, rewritten} = RewireLinks.rewire(link, &fake_link_builder/1, %{})
+
+      assert %{
+               "type" => "a",
+               "children" => [],
+               "href" => "my-url",
+               "target" => "my-target",
+               "anchor" => "my-anchor"
+             } == rewritten
+    end
+
+    test "rewire/3 maintains anchor and target attributes for idref links" do
+      link = %{
+        "type" => "a",
+        "idref" => "id1",
+        "target" => "my-target",
+        "anchor" => "my-anchor",
+        "children" => []
+      }
+
+      {true, rewritten} = RewireLinks.rewire(link, &fake_link_builder/1, %{})
+
+      assert %{
+               "type" => "a",
+               "children" => [],
+               "href" => "rewritten:id1",
+               "target" => "my-target",
+               "anchor" => "my-anchor"
+             } == rewritten
+    end
+
+    test "rewire/3 maintains anchor and not target attributes for idref links" do
+      link = %{
+        "type" => "a",
+        "idref" => "id1",
+        "anchor" => "my-anchor",
+        "children" => []
+      }
+
+      {true, rewritten} = RewireLinks.rewire(link, &fake_link_builder/1, %{})
+
+      assert %{
+               "type" => "a",
+               "children" => [],
+               "href" => "rewritten:id1",
+               "anchor" => "my-anchor"
+             } == rewritten
+    end
+
     test "rewire/3 rewrites a link in the children with an idref" do
       link = %{"type" => "a", "idref" => "id1", "children" => []}
       para = %{"type" => "p", "children" => [link]}

--- a/test/oli/interop/rewire_links_test.exs
+++ b/test/oli/interop/rewire_links_test.exs
@@ -1,0 +1,44 @@
+defmodule Oli.Interop.RewireLinksTest do
+  use ExUnit.Case, async: true
+  alias Oli.Ingest.RewireLinks
+
+  def fake_link_builder(id) do
+    "rewritten:#{id}"
+  end
+
+  describe "rewire course internal page links" do
+    test "rewire/3 rewrites a link with an idref" do
+      link = %{"type" => "a", "idref" => "id1", "children" => []}
+      {true, rewritten} = RewireLinks.rewire(link, &fake_link_builder/1, %{})
+      assert %{"type" => "a", "children" => [], "href" => "rewritten:id1"} == rewritten
+    end
+
+    test "rewire/3 does not rewrites a link with an href" do
+      link = %{"type" => "a", "href" => "my-url", "children" => []}
+      {false, rewritten} = RewireLinks.rewire(link, &fake_link_builder/1, %{})
+      assert %{"type" => "a", "children" => [], "href" => "my-url"} == rewritten
+    end
+
+    test "rewire/3 rewrites a link in the children with an idref" do
+      link = %{"type" => "a", "idref" => "id1", "children" => []}
+      para = %{"type" => "p", "children" => [link]}
+      {true, rewritten} = RewireLinks.rewire(para, &fake_link_builder/1, %{})
+
+      assert %{
+               "type" => "p",
+               "children" => [%{"type" => "a", "children" => [], "href" => "rewritten:id1"}]
+             } == rewritten
+    end
+
+    test "rewire/3 rewrites a link in a caption with an idref" do
+      link = %{"type" => "a", "idref" => "id1", "children" => []}
+      img = %{"type" => "img", "caption" => [link]}
+      {true, rewritten} = RewireLinks.rewire(img, &fake_link_builder/1, %{})
+
+      assert %{
+               "type" => "img",
+               "caption" => [%{"type" => "a", "children" => [], "href" => "rewritten:id1"}]
+             } == rewritten
+    end
+  end
+end


### PR DESCRIPTION
Legacy xref links are converted into regular 'A' links with an idref set to a page reference by the course-digest tool. Torus had two problems with the ingest of those links. 

1. The ingest process rewrites the idref attributes to a url to an ingested page. It recursively does this through the content, but was only recursively following the 'children' attribute. There can also be links in 'caption', 'pronunciation', and 'translations' of our content model.
2. anchor (new) and target (previously existed) attributes of links with an idref were dropped on ingest.

To test this, you must use the course digest with these changes in it: https://github.com/Simon-Initiative/course-digest/pull/168/files

This has been tested:
 * kth - on learns : there is a single xref in this project which is now imported correctly
 * gsu-statistics: there are many xref's here with a few different observations:
    * They all import and can be viewed in authoring correctly
    * I couldn't find some pages that exist in delivery mode. - ex. Distribution of Sample Means (1 of 4)
    * Some pages are broken in delivery mode, both with this change, and in the master branch using a master branch course-digest tool - ex. Estimating a Population Mean (2 of 3)



Fixes https://github.com/Simon-Initiative/oli-torus/issues/3536
