### PR TITLE
[BUGFIX][MER-2158] Show always hint options

### DIFF
--- a/assets/src/components/activities/common/hints/delivery/HintsDeliveryConnected.tsx
+++ b/assets/src/components/activities/common/hints/delivery/HintsDeliveryConnected.tsx
@@ -28,7 +28,7 @@ const shouldShow = (
 ) => {
   if (graded) return false;
   if (surveyId !== null) return false;
-  if (!correct) return true;
+  if (!correct || correct) return true;
 
   return (
     (typeof shouldShow === 'undefined' || shouldShow) &&
@@ -43,9 +43,8 @@ const isRequestHintDisabled = (
   correct: boolean,
   graded: boolean,
 ) => {
-  if (!hasMoreHints) return false;
+  if (!hasMoreHints || correct || !correct) return false;
   if (isEvaluated(uiState) && graded) return true;
-  if (!correct) return false;
 
   return isEvaluated(uiState) || isSubmitted(uiState);
 };

--- a/assets/src/components/activities/common/hints/delivery/HintsDeliveryConnected.tsx
+++ b/assets/src/components/activities/common/hints/delivery/HintsDeliveryConnected.tsx
@@ -28,10 +28,9 @@ const shouldShow = (
 ) => {
   if (graded) return false;
   if (surveyId !== null) return false;
-  if (!correct || correct) return true;
 
   return (
-    (typeof shouldShow === 'undefined' || shouldShow) &&
+    (typeof shouldShow === undefined || shouldShow) &&
     !isEvaluated(uiState) &&
     !isSubmitted(uiState)
   );
@@ -43,8 +42,9 @@ const isRequestHintDisabled = (
   correct: boolean,
   graded: boolean,
 ) => {
-  if (!hasMoreHints || correct || !correct) return false;
+  if (!hasMoreHints) return false;
   if (isEvaluated(uiState) && graded) return true;
+  if (!correct) return false;
 
   return isEvaluated(uiState) || isSubmitted(uiState);
 };
@@ -55,7 +55,7 @@ const isRequestHintDisabled = (
     1. You can request hints before answering
     2. You can see hints on incorrect
     3. You can request additional hints on incorrect, but that implicitly resets (I'd suggest that for both question types).
-    4. Hints are hidden on correct
+    4. Hints are always visible
     5. Once you see a hint, it remains revealed until you get it correct.
 */
 export const HintsDeliveryConnected: React.FC<Props> = (props) => {

--- a/assets/src/components/activities/common/hints/delivery/HintsDeliveryConnected.tsx
+++ b/assets/src/components/activities/common/hints/delivery/HintsDeliveryConnected.tsx
@@ -28,9 +28,10 @@ const shouldShow = (
 ) => {
   if (graded) return false;
   if (surveyId !== null) return false;
+  if (correct !== undefined) return true;
 
   return (
-    (typeof shouldShow === undefined || shouldShow) &&
+    (typeof shouldShow === 'undefined' || shouldShow) &&
     !isEvaluated(uiState) &&
     !isSubmitted(uiState)
   );

--- a/assets/src/components/activities/common/hints/delivery/HintsDeliveryConnected.tsx
+++ b/assets/src/components/activities/common/hints/delivery/HintsDeliveryConnected.tsx
@@ -23,18 +23,13 @@ const shouldShow = (
   uiState: ActivityDeliveryState,
   graded: boolean,
   surveyId: string | null,
-  correct: boolean,
   shouldShow?: boolean,
 ) => {
+  if (shouldShow) return true;
   if (graded) return false;
   if (surveyId !== null) return false;
-  if (correct !== undefined) return true;
 
-  return (
-    (typeof shouldShow === 'undefined' || shouldShow) &&
-    !isEvaluated(uiState) &&
-    !isSubmitted(uiState)
-  );
+  return !isEvaluated(uiState) && !isSubmitted(uiState);
 };
 
 const isRequestHintDisabled = (
@@ -67,7 +62,7 @@ export const HintsDeliveryConnected: React.FC<Props> = (props) => {
   const dispatch = useDispatch();
 
   const correct = isCorrect(uiState.attemptState);
-  const shouldShowHint = shouldShow(uiState, graded, surveyId, correct, props.shouldShow);
+  const shouldShowHint = shouldShow(uiState, graded, surveyId, props.shouldShow);
   const hasMoreHints = uiState.partState[props.partId]?.hasMoreHints || false;
   const requestHintDisabled = isRequestHintDisabled(uiState, hasMoreHints, correct, graded);
 

--- a/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
+++ b/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
@@ -120,6 +120,7 @@ export const MultipleChoiceComponent: React.FC = () => {
         <HintsDeliveryConnected
           partId={castPartId(activityState.parts[0].partId)}
           resetPartInputs={{ [activityState.parts[0].partId]: [] }}
+          shouldShow
         />
         <EvaluationConnected />
       </div>

--- a/assets/test/multiple_choice/mc_delivery_test.tsx
+++ b/assets/test/multiple_choice/mc_delivery_test.tsx
@@ -78,6 +78,8 @@ describe('multiple choice delivery', () => {
       },
     ]);
 
+    expect(requestHintButton).toBeTruthy();
+
     // expect results to be displayed after submission
     expect(await screen.findAllByLabelText('result')).toHaveLength(1);
   });


### PR DESCRIPTION
[MER-2158](https://eliterate.atlassian.net/browse/MER-2158)

This PR fixes the error that happened when rendering the hints when changing the chosen option in a MC. 

Now, the hints are always visible even if the MC option is changed.


https://github.com/Simon-Initiative/oli-torus/assets/16328384/d18651d7-ae52-4182-9c20-eced11c62872


[MER-2158]: https://eliterate.atlassian.net/browse/MER-2158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ