### PR TITLE
[Bugfix] Fixes duplicate page on ingested projects

### DIFF
--- a/lib/oli/authoring/editing/container_editor.ex
+++ b/lib/oli/authoring/editing/container_editor.ex
@@ -365,8 +365,15 @@ defmodule Oli.Authoring.Editing.ContainerEditor do
     new_page_attrs =
       original_page
       |> Map.drop([:slug, :inserted_at, :updated_at, :resource_id, :resource])
-      |> Map.put(:title, "Copy of #{original_page.title}")
+      |> Map.put(:title, "#{original_page.title} (copy)")
       |> Map.put(:content, nil)
+      |> then(fn map ->
+        if is_nil(map.legacy) do
+          map
+        else
+          Map.put(map, :legacy, Map.from_struct(original_page.legacy))
+        end
+      end)
 
     Repo.transaction(fn ->
       with {:ok, created_revision} <- add_new(container, new_page_attrs, author, project),

--- a/lib/oli_web/live/resources/pages_view.ex
+++ b/lib/oli_web/live/resources/pages_view.ex
@@ -574,16 +574,16 @@ defmodule OliWeb.Resources.PagesView do
     new_page_attrs =
       original_page
       |> Map.drop([:slug, :inserted_at, :updated_at, :resource_id, :resource])
-      |> Map.put(:title, "Copy of #{original_page.title}")
+      |> Map.put(:title, "#{original_page.title} (copy)")
       |> Map.put(:content, nil)
       |> Map.put(:author_id, author.id)
-      |> (fn map ->
-            if is_nil(map.legacy) do
-              map
-            else
-              Map.put(map, :legacy, Map.from_struct(original_page.legacy))
-            end
-          end).()
+      |> then(fn map ->
+        if is_nil(map.legacy) do
+          map
+        else
+          Map.put(map, :legacy, Map.from_struct(original_page.legacy))
+        end
+      end)
 
     Oli.Repo.transaction(fn ->
       with {:ok, %{revision: revision}} <-

--- a/lib/oli_web/live/resources/pages_view.ex
+++ b/lib/oli_web/live/resources/pages_view.ex
@@ -577,6 +577,13 @@ defmodule OliWeb.Resources.PagesView do
       |> Map.put(:title, "Copy of #{original_page.title}")
       |> Map.put(:content, nil)
       |> Map.put(:author_id, author.id)
+      |> (fn map ->
+            if is_nil(map.legacy) do
+              map
+            else
+              Map.put(map, :legacy, Map.from_struct(original_page.legacy))
+            end
+          end).()
 
     Oli.Repo.transaction(fn ->
       with {:ok, %{revision: revision}} <-

--- a/test/oli/editing/container_editor_test.exs
+++ b/test/oli/editing/container_editor_test.exs
@@ -151,14 +151,11 @@ defmodule Oli.Authoring.Editing.ContainerEditorTest do
     } do
       assert length(root_container.children) == 3
 
-      {:ok, _} =
-        ContainerEditor.move_to(page1_revision, root_container, unit1_container, author, project)
+      {:ok, _} = ContainerEditor.move_to(page1_revision, root_container, unit1_container, author, project)
 
-      root_container =
-        AuthoringResolver.from_resource_id(project.slug, root_container.resource_id)
+      root_container = AuthoringResolver.from_resource_id(project.slug, root_container.resource_id)
 
-      unit1_container =
-        AuthoringResolver.from_resource_id(project.slug, unit1_container.resource_id)
+      unit1_container = AuthoringResolver.from_resource_id(project.slug, unit1_container.resource_id)
 
       # Ensure that the edit has inserted the moved page into unit1 container
       assert length(root_container.children) == 2
@@ -172,7 +169,7 @@ defmodule Oli.Authoring.Editing.ContainerEditorTest do
   describe "page duplication" do
     setup do
       Seeder.base_project_with_resource2()
-        |> Seeder.add_objective("objective 1", :obj1)
+      |> Seeder.add_objective("objective 1", :obj1)
     end
 
     test "duplicate_page/1 duplicates a page correctly", %{
@@ -193,7 +190,7 @@ defmodule Oli.Authoring.Editing.ContainerEditorTest do
                   "score" => 10,
                   "id" => "r1",
                   "feedback" => %{"id" => "1", "content" => "yes"}
-                },
+                }
               ],
               "scoringStrategy" => "best",
               "evaluationStrategy" => "regex"
@@ -202,15 +199,16 @@ defmodule Oli.Authoring.Editing.ContainerEditorTest do
         }
       }
 
-      {:ok, {activity_revision, _}} = ActivityEditor.create(
-        project.slug,
-        "oli_short_answer",
-        author,
-        embeded_activity_content,
-        [obj1.resource.id],
-        "embedded",
-        "An embedded activity"
-      )
+      {:ok, {activity_revision, _}} =
+        ActivityEditor.create(
+          project.slug,
+          "oli_short_answer",
+          author,
+          embeded_activity_content,
+          [obj1.resource.id],
+          "embedded",
+          "An embedded activity"
+        )
 
       page = %{
         objectives: %{"attached" => [obj1.resource.id]},
@@ -235,7 +233,7 @@ defmodule Oli.Authoring.Editing.ContainerEditorTest do
               "type" => "activity-reference",
               "children" => [],
               "activity_id" => activity_revision.resource_id
-            },
+            }
           ]
         },
         title: "New Page",
@@ -251,8 +249,11 @@ defmodule Oli.Authoring.Editing.ContainerEditorTest do
       {:ok, duplicated_page_revision} =
         ContainerEditor.duplicate_page(root_container, page_revision.id, author, project)
 
-      assert duplicated_page_revision.title == "Copy of New Page"
-      assert length(duplicated_page_revision.content["model"]) == length(page_revision.content["model"])
+      assert duplicated_page_revision.title == "New Page (copy)"
+
+      assert length(duplicated_page_revision.content["model"]) ==
+               length(page_revision.content["model"])
+
       assert duplicated_page_revision.objectives == page.objectives
 
       # Verify that it deep copied the activities, id should't be the same as the previous one
@@ -260,6 +261,7 @@ defmodule Oli.Authoring.Editing.ContainerEditorTest do
       refute activity_reference["activity_id"] == activity_revision.resource_id
 
       created_activity = Repo.get_by(Oli.Resources.Revision, %{resource_id: activity_reference["activity_id"]})
+
       assert created_activity.objectives["1"] == activity_revision.objectives["1"]
     end
   end


### PR DESCRIPTION
Steps to reproduce:

1. Ingest any project
2. Go to the all-pages of that project
3. Click the (...) menu on a page and select duplicate

Expected: The page duplicates
Actual: No visual change, error in elixir console


Cause of the bug:

Oli.Authoring.Course.create_and_attach_resource eventually calls Resources.create_revision which passes the attributes passed in through a changeset function. If any of the children of those attributes are a struct and not a map, you fail with an ecto error.

This change makes sure the legacy property passed in is a map.


Fixes #3592 