### PR TITLE
[Enhancement] Better max-width on learning content

### DIFF
--- a/assets/styles/common/elements.scss
+++ b/assets/styles/common/elements.scss
@@ -331,6 +331,7 @@ $element-margin-bottom: 1.5em;
     padding: 12px;
     text-align: center;
     margin-bottom: $element-margin-bottom;
+    font-size: 0.8em;
 
     blockquote,
     ol,

--- a/lib/oli_web/components/delivery/page_delivery.ex
+++ b/lib/oli_web/components/delivery/page_delivery.ex
@@ -9,7 +9,7 @@ defmodule OliWeb.Components.Delivery.PageDelivery do
 
   def header(assigns) do
     ~H"""
-      <h1 class="title flex flex-row justify-between">
+      <h1 class="title flex flex-row justify-between mb-2">
         <%= @title %><%= if @review_mode == true do %>
           (Review)
         <% end %>
@@ -20,9 +20,9 @@ defmodule OliWeb.Components.Delivery.PageDelivery do
     """
   end
 
-  attr :scheduling_type, :atom, values: [:read_by, :inclass_activity]
-  attr :end_date, Date, default: nil
-  attr :est_reading_time, Timex.Duration, default: nil
+  attr(:scheduling_type, :atom, values: [:read_by, :inclass_activity])
+  attr(:end_date, Date, default: nil)
+  attr(:est_reading_time, Timex.Duration, default: nil)
 
   def details(assigns) do
     ~H"""
@@ -50,7 +50,7 @@ defmodule OliWeb.Components.Delivery.PageDelivery do
   def learning_objectives(assigns) do
     ~H"""
       <%= if length(@objectives) > 0 do %>
-        <div class="objectives py-4">
+        <div class="objectives p-4 rounded-lg bg-gray-100 dark:bg-gray-700">
           <div class="uppercase font-bold mb-2">Learning Objectives</div>
           <ul class="list-none">
             <%= for title <- @objectives do %>

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -8,7 +8,7 @@ defmodule OliWeb.PageDeliveryController do
   alias Oli.Accounts
   alias Oli.Activities
   alias Oli.Delivery.Attempts.{Core, PageLifecycle}
-  alias Oli.Delivery.Page.PageContext
+  alias Oli.Delivery.Page.{PageContext, ObjectivesRollup}
   alias Oli.Delivery.{Paywall, PreviousNextIndex, Sections}
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.Section
@@ -910,9 +910,10 @@ defmodule OliWeb.PageDeliveryController do
       end)
       |> Enum.map(fn %{"activity_id" => id} -> id end)
 
+    activity_revisions = Resolver.from_resource_id(section_slug, activity_ids)
+
     activity_map =
-      section_slug
-      |> Resolver.from_resource_id(activity_ids)
+      activity_revisions
       |> Enum.map(fn rev ->
         type = Map.get(type_by_id, rev.activity_type_id)
 
@@ -973,6 +974,9 @@ defmodule OliWeb.PageDeliveryController do
 
     section_resource = Sections.get_section_resource(section.id, revision.resource_id)
 
+    objectives =
+      ObjectivesRollup.rollup_objectives(revision, activity_revisions, Resolver, section_slug)
+
     conn
     |> put_root_layout({OliWeb.LayoutView, "page.html"})
     |> render(
@@ -985,10 +989,12 @@ defmodule OliWeb.PageDeliveryController do
         previous_page: previous,
         next_page: next,
         current_page: current,
-        page_number: section_resource.numbering_level,
+        page_number: section_resource.numbering_index,
         title: revision.title,
+        graded: revision.graded,
+        review_mode: false,
         html: html,
-        objectives: [],
+        objectives: objectives,
         section: section,
         revision: revision,
         page_link_url: &Routes.page_delivery_path(conn, :page_preview, section_slug, &1),

--- a/lib/oli_web/templates/layout/page.html.heex
+++ b/lib/oli_web/templates/layout/page.html.heex
@@ -14,36 +14,36 @@
         <Components.Delivery.SectionTitle.section_title title={assigns.section.title}/>
       <% end %>
 
-      <div class="max-w-[900px] mx-auto w-full">
-        <div class="w-full flex flex-col xl:flex-row gap-4 p-10">
+      <div class="w-full md:container md:mx-auto md:my-10 lg:px-10">
+        <div class="w-full flex flex-col xl:flex-row gap-4">
           <div class={if Map.get(assigns, :collab_space_config) && show_collab_space?(@collab_space_config), do: "xl:w-2/3 w-full", else: "w-full"}>
             <div class="bg-white dark:bg-gray-800 dark:text-delivery-body-color-dark p-8 shadow">
               <div id="wrapper d-block mb-4">
 
-                    <!-- Page Content -->
-                    <div id="page-content">
+                  <!-- Page Content -->
+                  <div id="page-content">
 
-                      <%= @inner_content %>
+                    <%= @inner_content %>
 
-                      <%= render OliWeb.BibliographyView, "_references.html", conn: @conn, bib_app_params: @bib_app_params %>
+                    <%= render OliWeb.BibliographyView, "_references.html", conn: @conn, bib_app_params: @bib_app_params %>
 
-                    </div>
+                  </div>
 
-                    <%= render OliWeb.PageDeliveryView, "_previous_next_nav.html",
-                      conn: @conn,
-                      section_slug: @section_slug,
-                      previous_page: @previous_page,
-                      next_page: @next_page,
-                      current_page: @current_page,
-                      page_number: @page_number,
-                      section: @section,
-                      preview_mode: @preview_mode,
-                      revision: @revision,
-                      resource_slug: @resource_slug %>
+                  <%= render OliWeb.PageDeliveryView, "_previous_next_nav.html",
+                    conn: @conn,
+                    section_slug: @section_slug,
+                    previous_page: @previous_page,
+                    next_page: @next_page,
+                    current_page: @current_page,
+                    page_number: @page_number,
+                    section: @section,
+                    preview_mode: @preview_mode,
+                    revision: @revision,
+                    resource_slug: @resource_slug %>
 
-                </div>
               </div>
             </div>
+          </div>
 
           <%= if Map.get(assigns, :collab_space_config) && show_collab_space?(@collab_space_config) do %>
             <div class="xl:w-1/3 w-full">

--- a/lib/oli_web/templates/layout/page.html.heex
+++ b/lib/oli_web/templates/layout/page.html.heex
@@ -14,7 +14,7 @@
         <Components.Delivery.SectionTitle.section_title title={assigns.section.title}/>
       <% end %>
 
-      <div class="md:container md:mx-auto md:px-10 md:mt-3 md:mb-5">
+      <div class="max-w-[900px] mx-auto w-full">
         <div class="w-full flex flex-col xl:flex-row gap-4 p-10">
           <div class={if Map.get(assigns, :collab_space_config) && show_collab_space?(@collab_space_config), do: "xl:w-2/3 w-full", else: "w-full"}>
             <div class="bg-white dark:bg-gray-800 dark:text-delivery-body-color-dark p-8 shadow">

--- a/lib/oli_web/templates/layout/preview.html.heex
+++ b/lib/oli_web/templates/layout/preview.html.heex
@@ -5,7 +5,7 @@
   <% end %>
 
   <Components.Delivery.NavSidebar.main_with_nav {assigns}>
-    <div class="md:container md:mx-auto md:px-10 md:mt-3 md:mb-5">
+    <div class="max-w-[900px] mx-auto w-full">
       <div class="message flex justify-content-between alert alert-info enter-done my-5">
         <div>
           <div>

--- a/lib/oli_web/templates/layout/preview.html.heex
+++ b/lib/oli_web/templates/layout/preview.html.heex
@@ -5,38 +5,40 @@
   <% end %>
 
   <Components.Delivery.NavSidebar.main_with_nav {assigns}>
-    <div class="max-w-[900px] mx-auto w-full">
-      <div class="message flex justify-content-between alert alert-info enter-done my-5">
-        <div>
+    <div class="relative flex-1 flex flex-col pb-[60px]">
+      <div class="w-full md:container md:mx-auto lg:px-10">
+        <div class="message flex justify-content-between alert alert-info rounded-none md:rounded-md mb-0 enter-done md:my-5">
           <div>
-            <strong>Preview Mode</strong>
-            <br>
-            <%= if @context.graded do %>
-              <p>This is a preview of your graded assessment but it is displayed as an ungraded page to show feedback and hints.</p>
-            <% else %>
-              <p>This is a preview of your ungraded page.</p>
-            <% end %>
+            <div>
+              <strong>Preview Mode</strong>
+              <br>
+              <%= if @context.graded do %>
+                <p>This is a preview of your graded assessment but it is displayed as an ungraded page to show feedback and hints.</p>
+              <% else %>
+                <p>This is a preview of your ungraded page.</p>
+              <% end %>
+            </div>
+          </div>
+          <div class="form-inline m-2 my-lg-0">
+            <button class="btn btn-action btn-warning" type="button" style="white-space: nowrap;" onclick="window.close()">
+              Exit Preview
+            </button>
           </div>
         </div>
-        <div class="form-inline m-2 my-lg-0">
-          <button class="btn btn-action btn-warning" type="button" style="white-space: nowrap;" onclick="window.close()">
-            Exit Preview
-          </button>
-        </div>
-      </div>
 
-      <div class="bg-white dark:bg-gray-800 p-8 shadow">
-        <div id="wrapper d-block mb-4">
+        <div class="bg-white dark:bg-gray-800 p-8 shadow">
+          <div id="wrapper d-block mb-4">
 
-          <!-- Page Content -->
-          <div id="page-content">
+            <!-- Page Content -->
+            <div id="page-content">
 
-            <%= @inner_content %>
+              <%= @inner_content %>
+
+            </div>
+
+            <%= render OliWeb.ResourceView, "_preview_previous_next_nav.html", conn: @conn, context: @context, action: :preview %>
 
           </div>
-
-          <%= render OliWeb.ResourceView, "_preview_previous_next_nav.html", conn: @conn, context: @context, action: :preview %>
-
         </div>
       </div>
     </div>

--- a/lib/oli_web/templates/page_delivery/instructor_page_preview.html.heex
+++ b/lib/oli_web/templates/page_delivery/instructor_page_preview.html.heex
@@ -1,30 +1,37 @@
-<h1 class="title"><%= @title %> (Preview)</h1>
+<div class="pt-5 mx-auto max-w-[900px]">
+  <Components.Delivery.PageDelivery.header title={"#{@title} (Preview)"} page_number={@page_number} review_mode={@review_mode} />
 
-<script>
-  window.userToken = "<%= assigns[:user_token] %>";
-</script>
+  <script>
+    window.userToken = "<%= assigns[:user_token] %>";
+  </script>
 
-<%= if Oli.Resources.ResourceType.is_container(@revision) do %>
-  <%= render OliWeb.PageDeliveryView, "container.html", Map.merge(assigns, %{
-    children: @hierarchy_node.children,
-    active_page: nil
-  }) %>
-<% else %>
-  <Components.Delivery.PageDelivery.learning_objectives objectives={@objectives} />
+  <%= if Oli.Resources.ResourceType.is_container(@revision) do %>
+    <%= render OliWeb.PageDeliveryView, "container.html", Map.merge(assigns, %{
+      children: @hierarchy_node.children,
+      active_page: nil
+    }) %>
+  <% else %>
+    <%= unless @graded && not @review_mode do %>
+      <div class="mb-8">
+        <Components.Delivery.PageDelivery.learning_objectives objectives={@objectives} />
+      </div>
+    <% end %>
 
-  <div class="content">
-    <%= raw(@html) %>
-  </div>
+    <div class="content">
+        <%= raw(@html) %>
+    </div>
 
-  <div class="container mt-5">
-    <%=
-      live_render(@conn, OliWeb.CollaborationLive.CollabSpaceConfigView,
-        session: %{
-          "collab_space_config" => @collab_space_config,
-          "section_slug" => @section_slug,
-          "resource_slug" => @revision.slug,
-          "is_delivery" => true
-        })
-    %>
-  </div>
-<% end %>
+    <div class="container mt-5">
+      <%=
+        live_render(@conn, OliWeb.CollaborationLive.CollabSpaceConfigView,
+          session: %{
+            "collab_space_config" => @collab_space_config,
+            "section_slug" => @section_slug,
+            "resource_slug" => @revision.slug,
+            "is_delivery" => true
+          })
+      %>
+    </div>
+  <% end %>
+
+</div>

--- a/lib/oli_web/templates/page_delivery/page.html.heex
+++ b/lib/oli_web/templates/page_delivery/page.html.heex
@@ -1,3 +1,4 @@
+<div class="pt-5 mx-auto max-w-[900px]">
 
 <%= if not (Map.has_key?(@resource_attempt.content, "advancedDelivery") and @resource_attempt.content["advancedDelivery"]) do %>
   <Components.Delivery.PageDelivery.header title={@title} page_number={@page_number} review_mode={@review_mode} />
@@ -11,10 +12,10 @@ window.userToken = "<%= assigns[:user_token] %>";
 </script>
 
 <%= unless @graded && not @review_mode do %>
-  <Components.Delivery.PageDelivery.learning_objectives objectives={@objectives} />
+  <div class="mb-8">
+    <Components.Delivery.PageDelivery.learning_objectives objectives={@objectives} />
+  </div>
 <% end %>
-
-<hr class="text-gray-400 my-4" />
 
 <%= if @review_mode == true do %>
   <%= if @resource_attempt.lifecycle_state == :evaluated do  %>
@@ -106,3 +107,5 @@ __FINALIZATION_URL__<%= encode_url(Routes.page_delivery_path(@conn, :finalize_at
 __ACTIVITY_ATTEMPTS__<%= encode_activity_attempts(@activity_type_slug_mapping, @latest_attempts) %>__ACTIVITY_ATTEMPTS__
 -->
 <% end %>
+
+</div>

--- a/lib/oli_web/templates/resource/page_preview.html.heex
+++ b/lib/oli_web/templates/resource/page_preview.html.heex
@@ -1,23 +1,25 @@
-<%= if not is_nil(@container) and
-  Oli.Resources.ResourceType.is_container(@container.revision) do %>
-  <%= render OliWeb.PageDeliveryView, "container.html", Map.merge(assigns, %{
-    children: @container.children,
-    active_page: nil
-  }) %>
-<% else %>
+<div class="pt-5 mx-auto max-w-[900px]">
+  <%= if not is_nil(@container) and
+    Oli.Resources.ResourceType.is_container(@container.revision) do %>
+    <%= render OliWeb.PageDeliveryView, "container.html", Map.merge(assigns, %{
+      children: @container.children,
+      active_page: nil
+    }) %>
+  <% else %>
 
-  <%= if not (Map.has_key?(@context.content, "advancedDelivery") and @context.content["advancedDelivery"]) do %>
-    <Components.Delivery.PageDelivery.header title={@context.title} page_number={0} review_mode={false} />
+    <%= if not (Map.has_key?(@context.content, "advancedDelivery") and @context.content["advancedDelivery"]) do %>
+      <Components.Delivery.PageDelivery.header title={@context.title} page_number={0} review_mode={false} />
+    <% end %>
+
+    <Components.Delivery.PageDelivery.details />
+
+    <div id="eventIntercept" class="content">
+      <%= raw(@content_html) %>
+    </div>
+    <script>
+      OLI.initPreviewActivityBridge('eventIntercept');
+    </script>
   <% end %>
 
-  <Components.Delivery.PageDelivery.details />
-
-  <div id="eventIntercept" class="content">
-    <%= raw(@content_html) %>
-  </div>
-  <script>
-    OLI.initPreviewActivityBridge('eventIntercept');
-  </script>
-<% end %>
-
-<%= render OliWeb.BibliographyView, "_references.html", conn: @conn, context: @context, bib_app_params: @bib_app_params, action: :preview %>
+  <%= render OliWeb.BibliographyView, "_references.html", conn: @conn, context: @context, bib_app_params: @bib_app_params, action: :preview %>
+</div>


### PR DESCRIPTION
This adds a 900px max width to our content canvas and cleans up some of the resizing that happens at different media sizes. An example of how the page should resize now:

![page-resize](https://github.com/Simon-Initiative/oli-torus/assets/333265/768861c7-a573-4ba3-adef-a0caf695595f)

I went with 900 instead of 800 suggested in the ticket to keep it closer to the legacy of 850, but we have a slightly larger font size.

Also, I modified the font size of formulas. With this new page-width, many of the equations in chemistry overflowed the page. The new size doesn't perfectly match the legacy sizing, but comes really close as shown in this image with both overlaid on top of each other. The light-grey is torus and the darker is legacy.

![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/2b0c1ff7-f467-458a-ab0f-63e3c3c9531c)

Fixes #3523
