### PR TITLE
[MER-1992] Improve product search capability

### DIFF
--- a/lib/oli_web/live/products/products_tabel_model.ex
+++ b/lib/oli_web/live/products/products_tabel_model.ex
@@ -25,7 +25,8 @@ defmodule OliWeb.Products.ProductsTableModel do
         %ColumnSpec{
           name: :inserted_at,
           label: "Created",
-          render_fn: &Common.render_date/3
+          render_fn: &Common.render_date/3,
+          sort_fn: &Common.sort_date/2
         }
       ],
       event_suffix: "",

--- a/lib/oli_web/live/products/products_view.ex
+++ b/lib/oli_web/live/products/products_view.ex
@@ -45,7 +45,9 @@ defmodule OliWeb.Products.ProductsView do
               "none"
             end
 
-          String.contains?(String.downcase(p.title), str) or String.contains?(amount_str, str)
+          String.contains?(String.downcase(p.title), str) or
+            String.contains?(String.downcase(p.base_project.title), str) or
+            String.contains?(amount_str, str)
         end)
     end
   end


### PR DESCRIPTION
[MER-1992](https://eliterate.atlassian.net/browse/MER-1992)

This PR adds the possibility to search also by the title of the base project of the product. 

So, in the search bar it will be possible to search both by product title and by title of the product base project. 

It's also verified that the sorting by date of creation is using the `inserted_at` field of the database.


https://github.com/Simon-Initiative/oli-torus/assets/16328384/63ee6e0e-48ea-4718-941c-8302a556660e



[MER-1992]: https://eliterate.atlassian.net/browse/MER-1992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ