### PR TITLE
[MER-2147] App crashes found on improper content

### DIFF
--- a/assets/src/components/activities/common/hints/authoring/HintCard.tsx
+++ b/assets/src/components/activities/common/hints/authoring/HintCard.tsx
@@ -17,7 +17,7 @@ export const HintCard: React.FC<{
       <Card.Content>
         <RichTextEditorConnected
           placeholder={placeholder}
-          value={hint.content}
+          value={hint?.content || []}
           onEdit={(content) => updateOne(hint.id, content)}
         />
       </Card.Content>

--- a/lib/oli/activities/model/part.ex
+++ b/lib/oli/activities/model/part.ex
@@ -50,6 +50,10 @@ defmodule Oli.Activities.Model.Part do
     |> Oli.Activities.ParseUtils.items_or_errors()
   end
 
+  def parse(_) do
+    {:error, "invalid part"}
+  end
+
   def parse() do
     {:error, "invalid part"}
   end


### PR DESCRIPTION
While working through MER-2147, I found 2 places where the application would crash on marginally-invalid content.  One was client based related to hints, one was server-based related to part ID's. Not-crashing is preferable to crashing, so some light checks to deal with those. This doesn't actually fix MER-2147