### PR TITLE
[MER-2149] Fix feedback alignment when there are multiple blocks

### DIFF
--- a/assets/src/components/activities/common/delivery/evaluation/Evaluation.tsx
+++ b/assets/src/components/activities/common/delivery/evaluation/Evaluation.tsx
@@ -79,8 +79,7 @@ const Component: React.FC<ComponentProps> = (props) => {
   return (
     <div aria-label="result" className={`evaluation feedback ${props.resultClass} my-1`}>
       {graphic}
-      {props.children}
-      <div></div>
+      <div>{props.children}</div>
     </div>
   );
 };


### PR DESCRIPTION
The feedback was laying out paragraphs next to each other instead of stacked. Was caused by an inline-flex applied at the wrong level.

Before:

![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/0c5faa29-f924-4cb5-945b-b0719998fe82)

After:

![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/3c0b5ac9-a853-49df-956d-4c634616adcd)

Fixes #3597