### PR TITLE
[MER-2185]  Fix page name and arrow overflow from the previous page/next page box

### DIFF
--- a/assets/styles/common/previous_next_nav.scss
+++ b/assets/styles/common/previous_next_nav.scss
@@ -1,15 +1,14 @@
 .previous-next-nav {
-  margin-top: 3rem;
-  margin-bottom: 2rem;
-  border-top: 1px solid var(--color-gray-200);
+  margin: 1rem;
 
   .page-nav-link {
     margin-top: 20px;
-    border: 1px solid var(--color-gray-400);
+    border: 1px solid var(--color-gray-200);
     box-shadow: 1px 1px 6px -2px rgba(0, 0, 0, 0.25);
     max-width: 400px;
     height: fit-content;
     color: var(--color-delivery-primary);
+    background-color: var(--color-white);
 
     &:hover {
       border-color: var(--color-delivery-primary);
@@ -50,8 +49,13 @@
     max-width: 100px;
     margin: 0 5px;
   }
+}
 
-  @media (min-width: 768px) {
+@media (min-width: 768px) {
+  .previous-next-nav {
+    margin-left: 0;
+    margin-right: 0;
+
     .page-nav-link,
     .page-nav-link-placeholder {
       padding: 16px;
@@ -77,9 +81,13 @@
       font-weight: 600;
       margin: 6px 0;
     }
+  }
+}
 
-    .flex-ellipsis-fix {
-      min-width: 0;
+html.dark {
+  .previous-next-nav {
+    .page-nav-link {
+      background-color: var(--color-gray-800);
     }
   }
 }

--- a/lib/oli_web/components/delivery/page_navigator.ex
+++ b/lib/oli_web/components/delivery/page_navigator.ex
@@ -72,6 +72,7 @@ defmodule OliWeb.Components.Delivery.PageNavigator do
             bold
             bg-transparent
             group-hover:bg-white
+            dark:group-hover:bg-gray-800
             py-1
             w-12
             text-center

--- a/lib/oli_web/components/delivery/page_navigator.ex
+++ b/lib/oli_web/components/delivery/page_navigator.ex
@@ -66,7 +66,20 @@ defmodule OliWeb.Components.Delivery.PageNavigator do
         <% end %>
         <input
           id={"#{@id}_input"}
-          class={"text-2xl text-gray-500 bold py-1 w-12 text-center group-hover:mx-0 focus:mx-0 cursor-text #{if @show_navigation_arrows, do: "mx-8", else: ""}"}
+          class={"
+            text-2xl
+            text-gray-500
+            bold
+            bg-transparent
+            group-hover:bg-white
+            py-1
+            w-12
+            text-center
+            group-hover:mx-0
+            focus:mx-0
+            cursor-text
+            #{if @show_navigation_arrows, do: "mx-8", else: ""}"
+          }
           onfocus={"handleInputFocus_#{@id}()"}
           onblur={"handleInputFocus_#{@id}(false)"}
           name="page_number"

--- a/lib/oli_web/templates/layout/page.html.heex
+++ b/lib/oli_web/templates/layout/page.html.heex
@@ -28,20 +28,6 @@
                     <%= render OliWeb.BibliographyView, "_references.html", conn: @conn, bib_app_params: @bib_app_params %>
 
                   </div>
-
-                  <%= render OliWeb.PageDeliveryView, "_previous_next_nav.html",
-                    conn: @conn,
-                    section_slug: @section_slug,
-                    previous_page: @previous_page,
-                    next_page: @next_page,
-                    current_page: @current_page,
-                    page_number: @page_number,
-                    section: @section,
-                    preview_mode: @preview_mode,
-                    revision: @revision,
-                    resource_slug: @resource_slug,
-                    numbered_revisions: assigns[:numbered_revisions] %>
-
               </div>
             </div>
           </div>
@@ -62,8 +48,21 @@
             </div>
           <% end %>
         </div>
-      </div>
 
+        <%= render OliWeb.PageDeliveryView, "_previous_next_nav.html",
+          conn: @conn,
+          section_slug: @section_slug,
+          previous_page: @previous_page,
+          next_page: @next_page,
+          current_page: @current_page,
+          page_number: @page_number,
+          section: @section,
+          preview_mode: @preview_mode,
+          revision: @revision,
+          resource_slug: @resource_slug,
+          numbered_revisions: assigns[:numbered_revisions] %>
+
+      </div>
 
       <%= render OliWeb.LayoutView, "_delivery_footer.html", assigns %>
     </div>

--- a/lib/oli_web/templates/layout/preview.html.heex
+++ b/lib/oli_web/templates/layout/preview.html.heex
@@ -35,11 +35,11 @@
               <%= @inner_content %>
 
             </div>
-
-            <%= render OliWeb.ResourceView, "_preview_previous_next_nav.html", conn: @conn, context: @context, action: :preview %>
-
           </div>
         </div>
+
+        <%= render OliWeb.ResourceView, "_preview_previous_next_nav.html", conn: @conn, context: @context, action: :preview %>
+
       </div>
     </div>
   </Components.Delivery.NavSidebar.main_with_nav>

--- a/lib/oli_web/templates/resource/_preview_previous_next_nav.html.eex
+++ b/lib/oli_web/templates/resource/_preview_previous_next_nav.html.eex
@@ -21,7 +21,7 @@
     <% @action != :edit -> %>
       <%= link to: "#", class: "page-nav-link btn", onclick: "window.close();" do %>
         <div class="d-flex flex-row">
-          <div class="d-flex flex-column flex-fill flex-ellipsis-fix text-left">
+          <div class="d-flex flex-column flex-fill text-left overflow-hidden">
             <div class="nav-label">Complete</div>
             <div class="nav-title"><%= @context.project.title %></div>
           </div>

--- a/lib/oli_web/views/page_delivery_view.ex
+++ b/lib/oli_web/views/page_delivery_view.ex
@@ -59,10 +59,10 @@ defmodule OliWeb.PageDeliveryView do
     ~H"""
       <%= link to: @to, class: "page-nav-link btn", onclick: assigns[:onclick] do %>
         <div class="flex items-center justify-between">
-          <div>
+          <div class="mr-4">
             <i class="fas fa-arrow-left nav-icon"></i>
           </div>
-          <div class="flex flex-col text-right">
+          <div class="flex flex-col text-right overflow-hidden">
             <div class="nav-label"><%= value_or(assigns[:label], "Previous") %></div>
             <div class="nav-title"><%= @title %></div>
           </div>
@@ -75,11 +75,11 @@ defmodule OliWeb.PageDeliveryView do
     ~H"""
       <%= link to: @to, class: "page-nav-link btn", onclick: assigns[:onclick] do %>
         <div class="flex items-center justify-between">
-          <div class="flex flex-col text-left">
+          <div class="flex flex-col text-left overflow-hidden">
             <div class="nav-label"><%= value_or(assigns[:label], "Next") %></div>
             <div class="nav-title"><%= @title %></div>
           </div>
-          <div>
+          <div class="ml-4">
             <i class="fas fa-arrow-right nav-icon"></i>
           </div>
         </div>


### PR DESCRIPTION
Fixes an issue with the page navigation at the bottom where names were overflowing and not ellipsized