### PR TITLE
[MER-1995] Fix explanation for multi inputs

### DIFF
--- a/lib/oli/delivery/attempts/activity_lifecycle.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle.ex
@@ -159,7 +159,7 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle do
             new_part_attempts = get_latest_part_attempts(new_activity_attempt.attempt_guid)
 
             {ActivityState.from_attempt(
-               new_activity_attempt,
+               new_activity_attempt |> Repo.preload(:part_attempts),
                new_part_attempts,
                model,
                resource_attempt,

--- a/lib/oli/delivery/attempts/core.ex
+++ b/lib/oli/delivery/attempts/core.ex
@@ -732,7 +732,9 @@ defmodule Oli.Delivery.Attempts.Core do
       nil
   """
   def get_activity_attempt_by(clauses),
-    do: Repo.get_by(ActivityAttempt, clauses) |> Repo.preload(revision: [:activity_type])
+    do:
+      Repo.get_by(ActivityAttempt, clauses)
+      |> Repo.preload([:part_attempts, revision: [:activity_type]])
 
   @doc """
   Gets a part attempt by a clause.

--- a/lib/oli/delivery/attempts/page_lifecycle/hierarchy.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/hierarchy.ex
@@ -476,7 +476,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Hierarchy do
             pa1.activity_attempt_id == pa2.activity_attempt_id,
         where:
           aa1.resource_attempt_id == ^resource_attempt_id and is_nil(aa2.id) and is_nil(pa2.id),
-        preload: [revision: r],
+        preload: [revision: r, part_attempts: pa1],
         select: {pa1, aa1}
       )
     )

--- a/lib/oli/delivery/evaluation/explanation.ex
+++ b/lib/oli/delivery/evaluation/explanation.ex
@@ -4,7 +4,6 @@ defmodule Oli.Delivery.Evaluation.Explanation do
   alias Oli.Delivery.Evaluation.ExplanationContext
   alias Oli.Delivery.Attempts.Core.{ActivityAttempt, ResourceAttempt}
   alias Oli.Delivery.Evaluation.Actions.FeedbackAction
-  alias Oli.Repo
 
   @doc """
   Determines whether an explanation should be shown using the given explanation context.
@@ -13,15 +12,9 @@ defmodule Oli.Delivery.Evaluation.Explanation do
   """
   def get_explanation(
         %ExplanationContext{
-          part: part,
-          activity_attempt: %ActivityAttempt{} = activity_attempt
+          part: part
         } = context
       ) do
-    context = %{
-      context
-      | activity_attempt: activity_attempt |> Repo.preload(:part_attempts)
-    }
-
     case check_explanation_condition(context) do
       {_strategy, true} ->
         part.explanation
@@ -40,15 +33,9 @@ defmodule Oli.Delivery.Evaluation.Explanation do
   def maybe_set_feedback_action_explanation(
         {:ok, %FeedbackAction{} = feedback_action},
         %ExplanationContext{
-          part: part,
-          activity_attempt: %ActivityAttempt{} = activity_attempt
+          part: part
         } = context
       ) do
-    context = %{
-      context
-      | activity_attempt: activity_attempt |> Repo.preload(:part_attempts)
-    }
-
     case check_explanation_condition(context) do
       {_strategy, true} ->
         {:ok, %FeedbackAction{feedback_action | explanation: part.explanation}}
@@ -117,17 +104,13 @@ defmodule Oli.Delivery.Evaluation.Explanation do
          part_attempt: part_attempt
        }) do
     if length(part_attempts) > 1 do
-      if part_attempt.attempt_number >= set_num_attempts do
-        {:after_set_num_attempts, true}
-      else
-        {:after_set_num_attempts, false}
-      end
+      if part_attempt.attempt_number >= set_num_attempts,
+        do: {:after_set_num_attempts, true},
+        else: {:after_set_num_attempts, false}
     else
-      if activity_attempt_number >= set_num_attempts do
-        {:after_set_num_attempts, true}
-      else
-        {:after_set_num_attempts, false}
-      end
+      if activity_attempt_number >= set_num_attempts,
+        do: {:after_set_num_attempts, true},
+        else: {:after_set_num_attempts, false}
     end
   end
 


### PR DESCRIPTION
[MER-1995](https://eliterate.atlassian.net/browse/MER-1995)

This PR fixes the issue that was happening with the explanation strategy in multi inputs that have more than one part and the "submit per part" option enabled. 
In this case, the explanation strategy will be tied to the part attempt number and not to the activity attempt number.
Therefore, the explanation will be displayed for each input separately, in case the answer is incorrect.


https://github.com/Simon-Initiative/oli-torus/assets/16328384/abae10b2-0e9e-487a-b6a0-7687c8e0101e




[MER-1995]: https://eliterate.atlassian.net/browse/MER-1995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ