### PR TITLE
[FEATURE][MER-1981] Permit admins to update name and email fields

### DIFF
--- a/lib/oli_web/live/users/author_detail_view.ex
+++ b/lib/oli_web/live/users/author_detail_view.ex
@@ -21,6 +21,8 @@ defmodule OliWeb.Users.AuthorsDetailView do
   alias OliWeb.Pow.AuthorContext
   alias OliWeb.Router.Helpers, as: Routes
   alias OliWeb.Users.Actions
+  alias Surface.Components.Form
+  alias Surface.Components.Form.{Label, Field, Submit, TextInput}
 
   prop author, :any
   data breadcrumbs, :any
@@ -28,6 +30,8 @@ defmodule OliWeb.Users.AuthorsDetailView do
   data user, :struct, default: nil
   data modal, :any, default: nil
   data csrf_token, :any
+  data changeset, :changeset
+  data disabled_edit, :boolean, default: true
 
   defp set_breadcrumbs(author) do
     OliWeb.Admin.AdminView.breadcrumb()
@@ -64,7 +68,9 @@ defmodule OliWeb.Users.AuthorsDetailView do
            breadcrumbs: set_breadcrumbs(user),
            author: author,
            user: user,
-           csrf_token: csrf_token
+           csrf_token: csrf_token,
+           changeset: author_changeset(user),
+           disabled_edit: true
          )}
     end
   end
@@ -75,11 +81,28 @@ defmodule OliWeb.Users.AuthorsDetailView do
       {render_modal(assigns)}
       <Groups>
         <Group label="Details" description="User details">
-          <ReadOnly label="Name" value={@user.name}/>
-          <ReadOnly label="First Name" value={@user.given_name}/>
-          <ReadOnly label="Last Name" value={@user.family_name}/>
-          <ReadOnly label="Email" value={@user.email}/>
-          <ReadOnly label="Role" value={role(@user.system_role_id)}/>
+          <Form for={@changeset} change="change" submit="submit" opts={autocomplete: "off"}>
+            <ReadOnly label="Name" value={@user.name}/>
+            <Field name={:given_name} class="form-group">
+              <Label text="First Name"/>
+              <TextInput class="form-control" opts={disabled: @disabled_edit}/>
+            </Field>
+            <Field name={:family_name} class="form-group">
+              <Label text="Last Name"/>
+              <TextInput class="form-control" opts={disabled: @disabled_edit}/>
+            </Field>
+            <Field name={:email} class="form-group">
+              <Label text="Email"/>
+              <TextInput class="form-control" opts={disabled: @disabled_edit}/>
+            </Field>
+            <ReadOnly label="Role" value={role(@user.system_role_id)}/>
+            {#unless @disabled_edit}
+              <Submit class={"float-right btn btn-md btn-primary mt-2"}>Save</Submit>
+            {/unless}
+          </Form>
+          {#if @disabled_edit}
+            <button class={"float-right btn btn-md btn-primary mt-2"} phx-click="start_edit">Edit</button>
+          {/if}
         </Group>
         <Group label="Actions" description="Actions that can be taken for this user">
           {#if @user.id != @author.id and @user.email != System.get_env("ADMIN_EMAIL", "admin@example.edu")}
@@ -266,6 +289,31 @@ defmodule OliWeb.Users.AuthorsDetailView do
      socket
      |> change_system_role(author, author_role_id)
      |> hide_modal(modal_assigns: nil)}
+  end
+
+  def handle_event("change", %{"author" => params}, socket) do
+    {:noreply, assign(socket, changeset: author_changeset(socket.assigns.user, params))}
+  end
+
+  def handle_event("submit", %{"author" => params}, socket) do
+    case Accounts.update_author(socket.assigns.user, params) do
+      {:ok, user} ->
+        {:noreply,
+         socket
+         |> assign(user: user, changeset: author_changeset(user, params), disabled_edit: true)}
+
+      {:error, _error} ->
+        {:noreply, put_flash(socket, :error, "Author couldn't be updated.")}
+    end
+  end
+
+  def handle_event("start_edit", _, socket) do
+    {:noreply, socket |> assign(disabled_edit: false)}
+  end
+
+  defp author_changeset(author, attrs \\ %{}) do
+    Author.noauth_changeset(author, attrs)
+    |> Map.put(:action, :update)
   end
 
   defp change_system_role(socket, author, role_id) do

--- a/lib/oli_web/live/users/author_detail_view.ex
+++ b/lib/oli_web/live/users/author_detail_view.ex
@@ -300,6 +300,7 @@ defmodule OliWeb.Users.AuthorsDetailView do
       {:ok, user} ->
         {:noreply,
          socket
+         |> put_flash(:info, "Author successfully updated.")
          |> assign(user: user, changeset: author_changeset(user, params), disabled_edit: true)}
 
       {:error, _error} ->

--- a/lib/oli_web/live/users/user_detail_view.ex
+++ b/lib/oli_web/live/users/user_detail_view.ex
@@ -322,6 +322,7 @@ defmodule OliWeb.Users.UsersDetailView do
       {:ok, user} ->
         {:noreply,
          socket
+         |> put_flash(:info, "User successfully updated.")
          |> assign(user: user, changeset: user_changeset(user, params), disabled_edit: true)}
 
       {:error, _error} ->

--- a/lib/oli_web/live/users/user_detail_view.ex
+++ b/lib/oli_web/live/users/user_detail_view.ex
@@ -4,6 +4,7 @@ defmodule OliWeb.Users.UsersDetailView do
 
   import OliWeb.Common.Properties.Utils
   import OliWeb.Common.Utils
+  import Ecto.Changeset
 
   alias Oli.Accounts
   alias Oli.Accounts.User
@@ -23,7 +24,7 @@ defmodule OliWeb.Users.UsersDetailView do
   alias OliWeb.Router.Helpers, as: Routes
   alias OliWeb.Users.Actions
   alias Surface.Components.Form
-  alias Surface.Components.Form.{Checkbox, Label, Field, Submit}
+  alias Surface.Components.Form.{Checkbox, Label, Field, Submit, TextInput}
 
   data(breadcrumbs, :any)
   data(changeset, :changeset)
@@ -31,6 +32,7 @@ defmodule OliWeb.Users.UsersDetailView do
   data(modal, :any, default: nil)
   data(title, :string, default: "User Details")
   data(user, :struct, default: nil)
+  data(disabled_edit, :boolean, default: true)
 
   defp set_breadcrumbs(user) do
     OliWeb.Admin.AdminView.breadcrumb()
@@ -73,7 +75,8 @@ defmodule OliWeb.Users.UsersDetailView do
            csrf_token: csrf_token,
            changeset: user_changeset(user),
            user_lti_params: LtiParams.all_user_lti_params(user.id),
-           enrolled_sections: enrolled_sections
+           enrolled_sections: enrolled_sections,
+           disabled_edit: true
          )}
     end
   end
@@ -88,16 +91,25 @@ defmodule OliWeb.Users.UsersDetailView do
           <Form for={@changeset} change="change" submit="submit" opts={autocomplete: "off"}>
             <ReadOnly label="Sub" value={@user.sub}/>
             <ReadOnly label="Name" value={@user.name}/>
-            <ReadOnly label="First Name" value={@user.given_name}/>
-            <ReadOnly label="Last Name" value={@user.family_name}/>
-            <ReadOnly label="Email" value={@user.email}/>
+            <Field name={:given_name} class="form-group">
+              <Label text="Given Name"/>
+              <TextInput class="form-control" opts={disabled: @disabled_edit}/>
+            </Field>
+            <Field name={:family_name} class="form-group">
+              <Label text="Last Name"/>
+              <TextInput class="form-control" opts={disabled: @disabled_edit}/>
+            </Field>
+            <Field name={:email} class="form-group">
+              <Label text="Email"/>
+              <TextInput class="form-control" opts={disabled: @disabled_edit}/>
+            </Field>
             <ReadOnly label="Guest" value={boolean(@user.guest)}/>
             {#if Application.fetch_env!(:oli, :age_verification)[:is_enabled] == "true"}
               <ReadOnly label="Confirmed is 13 or older on creation" value={boolean(@user.age_verified)}/>
             {/if}
             <div class="form-control mb-3">
               <Field name={:independent_learner}>
-                <Checkbox/>
+                <Checkbox class="form-check-input" value={get_field(@changeset, :independent_learner)} opts={disabled: @disabled_edit}/>
                 <Label class="form-check-label mr-2">Independent Learner</Label>
               </Field>
             </div>
@@ -108,7 +120,7 @@ defmodule OliWeb.Users.UsersDetailView do
               </heading>
               <div class="form-control">
                 <Field name={:can_create_sections}>
-                  <Checkbox />
+                  <Checkbox class="form-check-input" value={get_field(@changeset, :can_create_sections)} opts={disabled: @disabled_edit}/>
                   <Label class="form-check-label mr-2">Can Create Sections</Label>
                 </Field>
               </div>
@@ -117,8 +129,13 @@ defmodule OliWeb.Users.UsersDetailView do
             <ReadOnly label="Email Confirmed" value={render_date(@user, :email_confirmed_at, @ctx)}/>
             <ReadOnly label="Created" value={render_date(@user, :inserted_at, @ctx)}/>
             <ReadOnly label="Last Updated" value={render_date(@user, :updated_at, @ctx)}/>
-            <Submit class="float-right btn btn-md btn-primary mt-2">Save</Submit>
+            {#unless @disabled_edit}
+              <Submit class={"float-right btn btn-md btn-primary mt-2"}>Save</Submit>
+            {/unless}
           </Form>
+            {#if @disabled_edit}
+              <button class={"float-right btn btn-md btn-primary mt-2"} phx-click="start_edit">Edit</button>
+            {/if}
         </Group>
         {#if !Enum.empty?(@user_lti_params)}
           <Group label="LTI Details" description="LTI 1.3 details provided by an LMS">
@@ -305,11 +322,15 @@ defmodule OliWeb.Users.UsersDetailView do
       {:ok, user} ->
         {:noreply,
          socket
-         |> assign(user: user, changeset: user_changeset(user, params))}
+         |> assign(user: user, changeset: user_changeset(user, params), disabled_edit: true)}
 
       {:error, _error} ->
         {:noreply, put_flash(socket, :error, "User couldn't be updated.")}
     end
+  end
+
+  def handle_event("start_edit", _, socket) do
+    {:noreply, socket |> assign(disabled_edit: false)}
   end
 
   defp user_with_platform_roles(id) do

--- a/test/oli_web/live/admin_live_test.exs
+++ b/test/oli_web/live/admin_live_test.exs
@@ -908,5 +908,54 @@ defmodule OliWeb.AdminLiveTest do
       refute html =~ "Resend confirmation link"
       refute html =~ "Confirm email"
     end
+
+    test "edit user details", %{conn: conn, author: author} do
+      new_first_name = "New First Name"
+      new_last_name = "New Last Name"
+      new_email = "new_email@example.com"
+
+      {:ok, view, _html} = live(conn, live_view_author_detail_route(author.id))
+
+      # Assert that fields are disabled
+      assert has_element?(view, "input[value=\"#{author.given_name}\"][disabled]")
+      assert has_element?(view, "input[value=\"#{author.family_name}\"][disabled]")
+      assert has_element?(view, "input[value=\"#{author.email}\"][disabled]")
+
+      view
+      |> element("button[phx-click=\"start_edit\"]", "Edit")
+      |> render_click()
+
+      # Assert that there is a save button
+      assert has_element?(view, "button[type=\"submit\"]", "Save")
+
+      # Refute that fields are disabled
+      refute has_element?(view, "input[value=\"#{author.given_name}\"][disabled]")
+      refute has_element?(view, "input[value=\"#{author.family_name}\"][disabled]")
+      refute has_element?(view, "input[value=\"#{author.email}\"][disabled]")
+
+      view
+      |> element("form[phx-submit=\"submit\"")
+      |> render_submit(%{
+        "author" => %{
+          "given_name" => new_first_name,
+          "family_name" => new_last_name,
+          "email" => new_email
+        }
+      })
+
+      # Assert that fields are updated correctly
+      assert view |> element("input[value=\"#{new_first_name}\"][disabled]") |> render() =~
+               new_first_name
+
+      assert view |> element("input[value=\"#{new_last_name}\"][disabled]") |> render() =~
+               new_last_name
+
+      assert view |> element("input[value=\"#{new_email}\"][disabled]") |> render() =~ new_email
+
+      # Assert that the name field was updated correctly
+      assert view
+             |> element("input[value=\"#{new_first_name} #{new_last_name}\"][disabled]")
+             |> render() =~ "#{new_first_name} #{new_last_name}"
+    end
   end
 end


### PR DESCRIPTION
[MER-1981](https://eliterate.atlassian.net/browse/MER-1981)

This PR allows administrators to edit the first name, last name and email fields for a student or for an author from the individual details view.

- Edit fields for a student

https://github.com/Simon-Initiative/oli-torus/assets/16328384/925b6a96-e4ee-4ac2-a05c-d774350aa28a

- Edit fields for an author

https://github.com/Simon-Initiative/oli-torus/assets/16328384/291fed41-77ef-4569-94a1-d60d86dbf01c





[MER-1981]: https://eliterate.atlassian.net/browse/MER-1981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ