### PR TITLE
[BUG FIX] [MER-2179] Fix an issue where adaptive player is timing out due to session_ttl_renewal

### DIFF
--- a/lib/oli_web/pow/pow_helpers.ex
+++ b/lib/oli_web/pow/pow_helpers.ex
@@ -11,7 +11,7 @@ defmodule OliWeb.Pow.PowHelpers do
       current_user_assigns_key: :current_user,
       session_key: "user_auth",
       # session_ttl_renewal: :timer.minutes(15),    # default is 15 minutes
-      credentials_cache_store: {Pow.Store.CredentialsCache, ttl: :timer.hours(12)},
+      credentials_cache_store: {Pow.Store.CredentialsCache, ttl: :timer.hours(24)},
       plug: Pow.Plug.Session,
       web_module: OliWeb,
       routes_backend: OliWeb.Pow.UserRoutes,
@@ -36,7 +36,7 @@ defmodule OliWeb.Pow.PowHelpers do
       current_user_assigns_key: :current_author,
       session_key: "author_auth",
       # session_ttl_renewal: :timer.minutes(15),    # default is 15 minutes
-      credentials_cache_store: {Pow.Store.CredentialsCache, ttl: :timer.hours(12)},
+      credentials_cache_store: {Pow.Store.CredentialsCache, ttl: :timer.hours(24)},
       plug: Pow.Plug.Session,
       web_module: OliWeb,
       routes_backend: OliWeb.Pow.AuthorRoutes,

--- a/lib/oli_web/pow/pow_helpers.ex
+++ b/lib/oli_web/pow/pow_helpers.ex
@@ -10,7 +10,8 @@ defmodule OliWeb.Pow.PowHelpers do
       user: Oli.Accounts.User,
       current_user_assigns_key: :current_user,
       session_key: "user_auth",
-      session_ttl_renewal: :timer.hours(24),
+      # session_ttl_renewal: :timer.minutes(15),    # default is 15 minutes
+      credentials_cache_store: {Pow.Store.CredentialsCache, ttl: :timer.hours(12)},
       plug: Pow.Plug.Session,
       web_module: OliWeb,
       routes_backend: OliWeb.Pow.UserRoutes,
@@ -34,7 +35,8 @@ defmodule OliWeb.Pow.PowHelpers do
       user: Oli.Accounts.Author,
       current_user_assigns_key: :current_author,
       session_key: "author_auth",
-      session_ttl_renewal: :timer.hours(24),
+      # session_ttl_renewal: :timer.minutes(15),    # default is 15 minutes
+      credentials_cache_store: {Pow.Store.CredentialsCache, ttl: :timer.hours(12)},
       plug: Pow.Plug.Session,
       web_module: OliWeb,
       routes_backend: OliWeb.Pow.AuthorRoutes,


### PR DESCRIPTION
This PR reverts [a previous change](https://github.com/Simon-Initiative/oli-torus/pull/3563) that attempted to increase the inactivity timeout, however it set the wrong configuration value to achieve this. After investigating further, it appears the intended change should have adjusted `credentials_cache_store` which specifies how long session credentials remain in the cache store, which actually dictates how much time of inactivity a user is afforded before they will have to re-authenticate. The previously configured value `session_ttl_renewal` configures when a session token becomes stale and a new session ID has to be generated for the user, which is not of much value to the original issue and actually causes problems for long running client apps like the adaptive player.

https://hexdocs.pm/pow/Pow.Plug.Session.html#module-session-expiration

I inspected the routes the advanced author and adaptive player are using and they both appear to properly refresh the session when they are called, ensuring that actually page navigation is not necessary but API call will refresh the session as well.

I tested over LTI with *both* of these configuration values removed (simply using pow defaults), and the system worked as expected. This is because LTI routes are *always* automatically defaulting to persistent sessions (a.k.a "Remember me") which, by default, will last for 30 days before requiring re-authentication and that window will be refresh/reset every time a protected resource is accessed. However, I believe this was initially put in place to fix a UX issue with independent users to just allow a more lenient time gap of inactivity, instead of the stricter 30 mins default, for users who elect (or forget) to not check the persistent session "Remember me" checkbox . So I configured `credentials_cache_store` to allow a 24hr window of inactivity before requiring re-authentication so that a typical user will have a reasonable time period within the day where they will not need to re-authenticate but will not have a long running persistent session without checking the "Remember me" checkbox

Keep in mind, this change is all just for non-persistent sessions, users who want to enable long running session on their personal devices can (and should be encouraged to) still enable this using the "Remember me" checkbox, which will allow for up to 30 days of inactivity before requiring re-authentication.

If we need to, in the future we can investigate removing the "Remember me" checkbox altogether and just defaulting all logins to persistent sessions. But I think this is a reasonable first step given the trade-off of user experience and account security.