### PR TITLE
[BUG FIX] [MER-2200] Can't restart adaptive page when torus navigation is present

### DIFF
--- a/assets/src/apps/delivery/layouts/deck/RestartLessonDialog.tsx
+++ b/assets/src/apps/delivery/layouts/deck/RestartLessonDialog.tsx
@@ -64,8 +64,10 @@ const RestartLessonDialog: React.FC<RestartLessonDialogProps> = ({ onRestart }) 
     }
     if (isPreviewMode) {
       window.location.reload();
-    } else {
+    } else if (window.top) {
       window.top.location.href = redirectTo;
+    } else {
+      window.location.href = redirectTo;
     }
   };
 

--- a/assets/src/apps/delivery/layouts/deck/RestartLessonDialog.tsx
+++ b/assets/src/apps/delivery/layouts/deck/RestartLessonDialog.tsx
@@ -65,7 +65,7 @@ const RestartLessonDialog: React.FC<RestartLessonDialogProps> = ({ onRestart }) 
     if (isPreviewMode) {
       window.location.reload();
     } else {
-      window.location.href = redirectTo;
+      window.top.location.href = redirectTo;
     }
   };
 

--- a/assets/src/apps/delivery/layouts/deck/RestartLessonDialog.tsx
+++ b/assets/src/apps/delivery/layouts/deck/RestartLessonDialog.tsx
@@ -62,7 +62,7 @@ const RestartLessonDialog: React.FC<RestartLessonDialogProps> = ({ onRestart }) 
       const newAttemptUrl = `/sections/${sectionSlug}/page/${revisionSlug}/attempt`;
       redirectTo = newAttemptUrl;
     }
-    if (!graded || isPreviewMode) {
+    if (isPreviewMode) {
       window.location.reload();
     } else {
       window.location.href = redirectTo;

--- a/assets/src/apps/delivery/layouts/deck/RestartLessonDialog.tsx
+++ b/assets/src/apps/delivery/layouts/deck/RestartLessonDialog.tsx
@@ -65,7 +65,7 @@ const RestartLessonDialog: React.FC<RestartLessonDialogProps> = ({ onRestart }) 
     if (isPreviewMode) {
       window.location.reload();
     } else {
-      window.top.location.href = redirectTo;
+      window.location.href = redirectTo;
     }
   };
 


### PR DESCRIPTION
Fixes an issue with adaptive pages, when the Display Torus Navigation check box is checked, the user cannot restart the lesson.

https://eliterate.atlassian.net/browse/MER-2200