### PR TITLE
[MER-2118] [Bugfix] Center block formulas

### DIFF
--- a/assets/styles/common/elements.scss
+++ b/assets/styles/common/elements.scss
@@ -344,6 +344,13 @@ $element-margin-bottom: 1.5em;
     }
   }
 
+  .formula {
+    /* MER-2118 - Center block level formulas */
+    width: 100%;
+    margin-left: 0px;
+    margin-right: 0px;
+  }
+
   .dialog {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
Block level formulas were not centered, adjusted styles so they were again. The other piece mentioned in the bug about top/bottom margins had previously been fixed somewhere else.

![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/b0f37c8d-b582-4df8-a8ed-0a27ef0280eb)
