### PR TITLE
[MER-2206] Admin sections view link to instructor dashboard

### DIFF
--- a/lib/oli_web/live/sections/table_model.ex
+++ b/lib/oli_web/live/sections/table_model.ex
@@ -72,7 +72,7 @@ defmodule OliWeb.Sections.SectionsTableModel do
 
   def custom_render(assigns, section, %ColumnSpec{name: :title}) do
     ~F"""
-      <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.OverviewView, section.slug)}>{section.title}</a>
+      <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive, section.slug, :manage)}>{section.title}</a>
     """
   end
 

--- a/test/oli_web/live/sections/admin_index_live_test.exs
+++ b/test/oli_web/live/sections/admin_index_live_test.exs
@@ -260,5 +260,25 @@ defmodule OliWeb.Sections.AdminIndexLiveTest do
       refute has_element?(view, "td", first_s.title)
       assert has_element?(view, "td", last_s.title)
     end
+
+    test "section title is a link to the manage tab of the instructor dashboard", %{conn: conn} do
+      project = insert(:project, authors: [])
+      institution = insert(:institution)
+
+      section =
+        insert(:section,
+          type: :enrollable,
+          base_project: project,
+          institution: institution
+        )
+
+      {:ok, view, _html} = live(conn, @live_view_index_route)
+
+      assert has_element?(
+               view,
+               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive, section.slug, :manage)}\"]",
+               section.title
+             )
+    end
   end
 end


### PR DESCRIPTION
[MER-2206](https://eliterate.atlassian.net/browse/MER-2206)

This PR changes the path that is redirected to when clicking on a section title in the course section listing for the admin view.


https://github.com/Simon-Initiative/oli-torus/assets/16328384/0cb3aa25-3705-4f0d-ba54-90ca524b5e1a

[MER-2206]: https://eliterate.atlassian.net/browse/MER-2206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ