### PR TITLE
[MER-2217] Fixed css rule causing extra width on spans.

### DIFF
--- a/assets/styles/common/elements.scss
+++ b/assets/styles/common/elements.scss
@@ -527,12 +527,9 @@ $element-margin-bottom: 1.5em;
     color: var(--color-gray-400);
   }
 
-  span,
   input[type='text'],
   input[type='numeric'],
   select.dropdown-input {
-    width: 180px;
-
     &.input-size-small {
       width: 80px;
     }


### PR DESCRIPTION
Most of MER-2217 was already fixed when I started on this bug. This PR adjusts sizing on some dropdown elements and it removed a hard coded width from spans to make the sizing on these as intended.

See before image in #3749

After:

![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/d40c0595-5d4e-4932-880d-22d711f6aac2)
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/4d536bd8-275d-4fda-a8be-57e0d3b85b0e)
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/08421a86-80fd-4d67-aa12-7d2616af29a7)
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/971f27f8-8c01-4976-88f0-ac0b07ef434b)
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/de7b3fa0-9b86-4d2d-a01b-eeddf9f7d353)
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/616e672b-d6a4-49cb-8c0c-5adb3d025daf)
