### PR TITLE
[MER-2215] Fixed superscript characters in select inputs. [Bugfix]

### DIFF
--- a/assets/styles/common/elements.scss
+++ b/assets/styles/common/elements.scss
@@ -527,6 +527,11 @@ $element-margin-bottom: 1.5em;
     color: var(--color-gray-400);
   }
 
+  select {
+    /* MER-2215 Don't use OpenSans for the select options. When you do, the superscript characters don't align properly.   */
+    font-family: Arial, Helvetica, sans-serif;
+  }
+
   input[type='text'],
   input[type='numeric'],
   select.dropdown-input {


### PR DESCRIPTION
This turned out to be a font issue. The superscripts there were encoded using unicode superscript characters. The OpenSans font inside select inputs displayed them as reported. I swapped the select boxes to Arial, and that cleared this up. I would imagine there is a possibility that this could turn into a platform-specific issue.

Here's how a few sample font family / sizes render:
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/2e116953-300d-4513-9e8b-5910e0973b8d)

After the change in torus:
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/58ab5317-adc1-4898-be7f-5b20bd773928)


Fixes: MER-2215
Fixes: #3747 