### PR TITLE
[BUGFIX][MER-2219] Display correctly user roles in account menu

### DIFF
--- a/lib/oli_web/components/delivery/utils.ex
+++ b/lib/oli_web/components/delivery/utils.ex
@@ -3,7 +3,6 @@ defmodule OliWeb.Components.Delivery.Utils do
 
   alias Oli.Interop.CustomActivities.User
   alias OliWeb.Router.Helpers, as: Routes
-  alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.Section
   alias Oli.Accounts
   alias Oli.Accounts.{User, Author, SystemRole}
@@ -95,9 +94,6 @@ defmodule OliWeb.Components.Delivery.Utils do
 
   def user_role_text(section, user) do
     case user_role(section, user) do
-      :open_and_free ->
-        "Independent"
-
       :administrator ->
         "Administrator"
 
@@ -117,9 +113,6 @@ defmodule OliWeb.Components.Delivery.Utils do
 
   def user_role_is_student(assigns, user) do
     case user_role(assigns[:section], user) do
-      :open_and_free ->
-        !Sections.is_independent_instructor?(user)
-
       :student ->
         true
 
@@ -133,9 +126,6 @@ defmodule OliWeb.Components.Delivery.Utils do
 
   def user_role_color(section, user) do
     case user_role(section, user) do
-      :open_and_free ->
-        "#2C67C4"
-
       :administrator ->
         "#f39c12"
 
@@ -200,11 +190,8 @@ defmodule OliWeb.Components.Delivery.Utils do
 
   def user_role(section, user) do
     case section do
-      %Section{open_and_free: open_and_free, slug: section_slug} ->
+      %Section{open_and_free: true, slug: section_slug} ->
         cond do
-          open_and_free ->
-            :open_and_free
-
           PlatformRoles.has_roles?(user, @admin_roles, :any) ||
               ContextRoles.has_roles?(user, section_slug, @admin_roles, :any) ->
             :administrator
@@ -229,11 +216,8 @@ defmodule OliWeb.Components.Delivery.Utils do
 
       _ ->
         case user do
-          %User{guest: is_guest?} = user ->
+          %User{guest: _is_guest?} = user ->
             cond do
-              is_guest? ->
-                :open_and_free
-
               PlatformRoles.has_roles?(user, @admin_roles, :any) ->
                 :administrator
 


### PR DESCRIPTION
[MER-2219](https://eliterate.atlassian.net/browse/MER-2219)

This PR makes changes to avoid show "Independent" in the logged in user role. 

Instead, the actual role of the user will be rendered as either Student, Instructor or Administrator, regardless of whether the user is LMS or Independent.

- Logged in as Student

https://github.com/Simon-Initiative/oli-torus/assets/16328384/ee5098ab-cd58-464f-980c-656e0bf10415

- Logged in as Instructor

https://github.com/Simon-Initiative/oli-torus/assets/16328384/0b0779af-374e-49dc-885b-1f764fb29aa7


[MER-2219]: https://eliterate.atlassian.net/browse/MER-2219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ