### PR TITLE
[BUGFIX] set width when present in model for client rendered block images [MER-2125]

### DIFF
--- a/assets/src/data/content/writers/html.tsx
+++ b/assets/src/data/content/writers/html.tsx
@@ -276,6 +276,7 @@ export class HtmlParser implements WriterImpl {
       <img
         className="figure-img img-fluid"
         alt={attrs.alt ? this.escapeXml(attrs.alt) : ''}
+        width={attrs.width ? this.escapeXml(String(attrs.width)) : undefined}
         src={this.escapeXml(attrs.src)}
       />,
     );


### PR DESCRIPTION
This fixes a problem where block images in activities that had a specific width sets in the XML were not being rendered correctly. 

The fix was to simply set the image `width` attr when present.  Tested locally and it fixes the issue. 