### PR TITLE
[CHORE] Bump to version 25 for forward development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## 0.24 (unreleased)
+## 0.25.0 (unreleased)
+
+### Bug Fixes
+
+### Enhancements
+
+### Configs
+
+## 0.24.0 (prerelease)
 
 ### Bug Fixes
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Oli.MixProject do
   def project do
     [
       app: :oli,
-      version: "0.24.0",
+      version: "0.25.0",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: elixirc_options(Mix.env()),


### PR DESCRIPTION
This PR bumps the version number to 0.25.0 for forward development on master