### PR TITLE
[BUGFIX][MER-2214] Fix decimals quiz question points

### DIFF
--- a/assets/src/components/activities/common/delivery/graded_points/GradedPoints.tsx
+++ b/assets/src/components/activities/common/delivery/graded_points/GradedPoints.tsx
@@ -14,7 +14,7 @@ export const GradedPoints: React.FC<Props> = ({ icon, attemptState, shouldShow }
     <div className="text-info font-italic">
       {icon}
       <span>Points: </span>
-      <span>{attemptState.score + ' out of ' + attemptState.outOf}</span>
+      <span>{attemptState.score?.toFixed(2) + ' out of ' + attemptState.outOf}</span>
     </div>
   );
 };


### PR DESCRIPTION
[MER-2214](https://eliterate.atlassian.net/browse/MER-2214)

This PR rounds the quiz questions points to 2 decimal places. 
Previously the results were showing 16 decimal places and this did not look good. 

I leave a video showing how it will be displayed from now on.

https://github.com/Simon-Initiative/oli-torus/assets/16328384/14d90252-16dd-4dec-9694-b5e1a15a0797



[MER-2214]: https://eliterate.atlassian.net/browse/MER-2214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ