### PR TITLE
Add leading zero when necessary

### DIFF
--- a/lib/oli/delivery/evaluation/rule.ex
+++ b/lib/oli/delivery/evaluation/rule.ex
@@ -70,9 +70,11 @@ defmodule Oli.Delivery.Evaluation.Rule do
   end
 
   defp eval(:attempt_number, context), do: context.activity_attempt_number |> Integer.to_string()
+
   defp eval(:input, context) do
     Oli.Utils.normalize_whitespace(context.input)
   end
+
   defp eval(:input_length, context), do: String.length(context.input) |> Integer.to_string()
 
   defp eval({:lt, lhs, rhs}, context) do
@@ -188,6 +190,13 @@ defmodule Oli.Delivery.Evaluation.Rule do
   end
 
   defp parse_number(str) when is_binary(str) do
+    str =
+      if Regex.match?(~r/^\.\d+$/, str) do
+        "0#{str}"
+      else
+        str
+      end
+
     if is_float?(str) do
       str
       |> Float.parse()
@@ -209,5 +218,4 @@ defmodule Oli.Delivery.Evaluation.Rule do
   end
 
   defp drop_remainder({val, _rem}), do: val
-
 end

--- a/test/oli/delivery/evaluation/rule_eval_test.exs
+++ b/test/oli/delivery/evaluation/rule_eval_test.exs
@@ -37,6 +37,10 @@ defmodule Oli.Delivery.Evaluation.RuleEvalTest do
   end
 
   test "evaluating floats" do
+    assert eval("attemptNumber = {1} && input = {0.1}", "0.1")
+    refute eval("attemptNumber = {1} && input = {0.1}", "0.2")
+    assert eval("attemptNumber = {1} && input = {0.1}", ".1")
+    refute eval("attemptNumber = {1} && input = {0.1}", ".2")
     assert eval("attemptNumber = {1} && input = {3.1}", "3.1")
     refute eval("attemptNumber = {1} && input = {3.1}", "3.2")
     refute eval("attemptNumber = {1} && input = {3.1}", "4")
@@ -45,6 +49,7 @@ defmodule Oli.Delivery.Evaluation.RuleEvalTest do
     assert eval("attemptNumber = {1} && input < {4}", "3.1")
     refute eval("attemptNumber = {1} && input > {3}", "3.0")
     refute eval("attemptNumber = {1} && input < {3}", "3.0")
+    assert eval("attemptNumber = {1} && input < {3}", ".2")
   end
 
   test "evaluating ranges" do


### PR DESCRIPTION
[Link to the ticket](https://eliterate.atlassian.net/browse/MER-2216)

It seems that [Float.parse/1](https://hexdocs.pm/elixir/1.12.3/Float.html#parse/1) doesn't work with values without leading zeros.

https://github.com/Simon-Initiative/oli-torus/assets/53446634/f216f106-9e34-4a78-9aab-096d531eb70f

