### PR TITLE
[BUG FIX] [MER-2204] [MER-2207] [MER-2243] Adaptive player styling fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## 0.24 (unreleased)
+## 0.25.0 (unreleased)
+
+### Bug Fixes
+
+### Enhancements
+
+### Configs
+
+## 0.24.0 (prerelease)
 
 ### Bug Fixes
 

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -8,6 +8,8 @@
 @import 'button';
 @import 'table';
 
+@import 'adaptive-reset.scss';
+
 /**
  * Automatically style all links with blue text and underline on hover.
  * External links will automatically get an arrow icon appended.

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -8,8 +8,6 @@
 @import 'button';
 @import 'table';
 
-@import 'adaptive-reset.scss';
-
 /**
  * Automatically style all links with blue text and underline on hover.
  * External links will automatically get an arrow icon appended.

--- a/assets/styles/adaptive/adaptive-reset.scss
+++ b/assets/styles/adaptive/adaptive-reset.scss
@@ -4,21 +4,20 @@
   theme can still benefit from it.
 */
 
+/*
+   This is the only actual global style, it's because Tailwind uses `box-sizing: border-box` by default on *, if we do that inside our
+   .mainView scoping, it gets a higher specificity and then breaks some of the custom style sheets in the adaptive player. Putting it
+   here is the only way to get it to apply at the right level without having control of all those custom style sheets out there.
+*/
+* {
+  box-sizing: content-box;
+}
+
 /* Looks like `.mainView` will be specific enough to just the adaptive player. */
 .mainView {
   .content {
     border-color: #000;
   }
-
-  * {
-    /*
-      This one is a little dangerous. Tailwind uses `box-sizing: border-box` by default on *, but this one
-      is in the .mainView .content scope, this could end up overriding some other box-sizing styles set in
-      custom sheets that have lower specificity.
-    */
-    box-sizing: content-box;
-  }
-
   ol,
   ul {
     display: block;

--- a/assets/styles/adaptive/adaptive-reset.scss
+++ b/assets/styles/adaptive/adaptive-reset.scss
@@ -62,3 +62,13 @@ select {
   border-radius: 2px;
   min-height: 44px;
 }
+
+img,
+video {
+  max-width: unset;
+  height: unset;
+}
+
+janus-video video {
+  max-height: 100%;
+}

--- a/assets/styles/adaptive/adaptive-reset.scss
+++ b/assets/styles/adaptive/adaptive-reset.scss
@@ -8,7 +8,9 @@
   at the right level without having control of all those custom style sheets out there.
 */
 
-* {
+*,
+::before,
+::after {
   box-sizing: content-box;
 }
 

--- a/assets/styles/adaptive/adaptive-reset.scss
+++ b/assets/styles/adaptive/adaptive-reset.scss
@@ -1,66 +1,62 @@
 /*
-  Applies some "global" styles to adaptive player to bring us back to a pre-tailwind preflight state.
+  Applies some global styles to adaptive player to bring us back to a pre-tailwind preflight state.
   This needs to be a top-level css outside of the adaptive theming css so lessons that define a custom
   theme can still benefit from it.
+
+  These can not be scoped under a parent selector because then they gets a higher specificity and it breaks
+  some of the custom style sheets in the adaptive player. Putting it here is the only way to get it to apply
+  at the right level without having control of all those custom style sheets out there.
 */
 
-/*
-   This is the only actual global style, it's because Tailwind uses `box-sizing: border-box` by default on *, if we do that inside our
-   .mainView scoping, it gets a higher specificity and then breaks some of the custom style sheets in the adaptive player. Putting it
-   here is the only way to get it to apply at the right level without having control of all those custom style sheets out there.
-*/
 * {
   box-sizing: content-box;
 }
 
-/* Looks like `.mainView` will be specific enough to just the adaptive player. */
-.mainView {
-  .content {
-    border-color: #000;
-  }
-  ol,
-  ul {
-    display: block;
-    margin-block-start: 1em;
-    margin-block-end: 1em;
-    margin-inline-start: 0px;
-    margin-inline-end: 0px;
-    padding-inline-start: 40px;
-  }
+.content {
+  border-color: #000;
+}
+ol,
+ul {
+  display: block;
+  margin-block-start: 1em;
+  margin-block-end: 1em;
+  margin-inline-start: 0px;
+  margin-inline-end: 0px;
+  padding-inline-start: 40px;
+}
 
-  ol {
-    li {
-      list-style-type: decimal;
-    }
+ol {
+  li {
     list-style-type: decimal;
   }
+  list-style-type: decimal;
+}
 
-  ul {
-    li {
-      list-style-type: disc;
-    }
+ul {
+  li {
     list-style-type: disc;
   }
+  list-style-type: disc;
+}
 
-  [type='text'],
-  [type='email'],
-  [type='url'],
-  [type='password'],
-  [type='number'],
-  [type='date'],
-  [type='datetime-local'],
-  [type='month'],
-  [type='search'],
-  [type='tel'],
-  [type='time'],
-  [type='week'],
-  [multiple],
-  textarea,
-  select {
-    padding: 5px;
-    border: 1px solid var(--grayDark20);
-    box-sizing: border-box;
-    border-radius: 2px;
-    min-height: 44px;
-  }
+[type='text'],
+[type='email'],
+[type='url'],
+[type='password'],
+[type='number'],
+[type='date'],
+[type='datetime-local'],
+[type='month'],
+[type='search'],
+[type='tel'],
+[type='time'],
+[type='week'],
+[multiple],
+textarea,
+select {
+  padding: 5px;
+  border: 1px solid var(--grayDark20);
+  box-sizing: border-box;
+  border-radius: 2px;
+  min-height: 44px;
 }

--- a/assets/styles/adaptive/adaptive-reset.scss
+++ b/assets/styles/adaptive/adaptive-reset.scss
@@ -1,0 +1,67 @@
+/*
+  Applies some "global" styles to adaptive player to bring us back to a pre-tailwind preflight state.
+  This needs to be a top-level css outside of the adaptive theming css so lessons that define a custom
+  theme can still benefit from it.
+*/
+
+/* Looks like `.mainView` will be specific enough to just the adaptive player. */
+.mainView {
+  .content {
+    border-color: #000;
+  }
+
+  * {
+    /*
+      This one is a little dangerous. Tailwind uses `box-sizing: border-box` by default on *, but this one
+      is in the .mainView .content scope, this could end up overriding some other box-sizing styles set in
+      custom sheets that have lower specificity.
+    */
+    box-sizing: content-box;
+  }
+
+  ol,
+  ul {
+    display: block;
+    margin-block-start: 1em;
+    margin-block-end: 1em;
+    margin-inline-start: 0px;
+    margin-inline-end: 0px;
+    padding-inline-start: 40px;
+  }
+
+  ol {
+    li {
+      list-style-type: decimal;
+    }
+    list-style-type: decimal;
+  }
+
+  ul {
+    li {
+      list-style-type: disc;
+    }
+    list-style-type: disc;
+  }
+
+  [type='text'],
+  [type='email'],
+  [type='url'],
+  [type='password'],
+  [type='number'],
+  [type='date'],
+  [type='datetime-local'],
+  [type='month'],
+  [type='search'],
+  [type='tel'],
+  [type='time'],
+  [type='week'],
+  [multiple],
+  textarea,
+  select {
+    padding: 5px;
+    border: 1px solid var(--grayDark20);
+    box-sizing: border-box;
+    border-radius: 2px;
+    min-height: 44px;
+  }
+}

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -60,7 +60,10 @@ const populateEntries = () => {
     };
   });
 
-  const styleSheets = [{ styles: './styles/index.scss' }, { preview: './styles/preview.scss' }];
+  const styleSheets = [
+    { adaptive: './styles/adaptive/adaptive-reset.scss' },
+    { styles: './styles/index.scss' },
+    { preview: './styles/preview.scss' }];
 
   // Merge the attributes of all found activities and the initialEntries
   // into one single object.
@@ -74,9 +77,9 @@ const populateEntries = () => {
   if (
     Object.keys(merged).length !=
     Object.keys(initialEntries).length +
-      2 * foundActivities.length +
-      2 * foundParts.length +
-      styleSheets.length
+    2 * foundActivities.length +
+    2 * foundParts.length +
+    styleSheets.length
   ) {
     throw new Error(
       'Encountered a possible naming collision in activity or part manifests. Aborting.',

--- a/lib/oli/delivery/evaluation/rule.ex
+++ b/lib/oli/delivery/evaluation/rule.ex
@@ -70,9 +70,11 @@ defmodule Oli.Delivery.Evaluation.Rule do
   end
 
   defp eval(:attempt_number, context), do: context.activity_attempt_number |> Integer.to_string()
+
   defp eval(:input, context) do
     Oli.Utils.normalize_whitespace(context.input)
   end
+
   defp eval(:input_length, context), do: String.length(context.input) |> Integer.to_string()
 
   defp eval({:lt, lhs, rhs}, context) do
@@ -188,6 +190,13 @@ defmodule Oli.Delivery.Evaluation.Rule do
   end
 
   defp parse_number(str) when is_binary(str) do
+    str =
+      if Regex.match?(~r/^\.\d+$/, str) do
+        "0#{str}"
+      else
+        str
+      end
+
     if is_float?(str) do
       str
       |> Float.parse()
@@ -209,5 +218,4 @@ defmodule Oli.Delivery.Evaluation.Rule do
   end
 
   defp drop_remainder({val, _rem}), do: val
-
 end

--- a/lib/oli_web/templates/layout/chromeless.html.eex
+++ b/lib/oli_web/templates/layout/chromeless.html.eex
@@ -11,8 +11,6 @@
     <link rel="icon" type="image/png" sizes="16x16" href="<%= favicons("favicon-16x16.png", assigns[:section]) %>">
     <link rel="icon" type="image/png" sizes="32x32" href="<%= favicons("favicon-32x32.png", assigns[:section]) %>">
 
-    <!-- CSS -->
-    <link id="styles" rel="stylesheet" href="/css/styles.css" />
 
     <!-- Tailwind CSS -->
     <link id="app" rel="stylesheet" href="/css/app.css" />
@@ -56,7 +54,8 @@
 
     <%= OliWeb.Common.MathJaxScript.render(@conn) %>
 
-    <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/vendor.js") %>"></script>
+    <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/
+    vendor.js") %>"></script>
     <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/app.js") %>"></script>
 
     <%= additional_stylesheets(assigns) %>

--- a/lib/oli_web/templates/layout/chromeless.html.eex
+++ b/lib/oli_web/templates/layout/chromeless.html.eex
@@ -14,6 +14,7 @@
 
     <!-- Tailwind CSS -->
     <link id="app" rel="stylesheet" href="/css/app.css" />
+    <link id="app" rel="stylesheet" href="/css/adaptive.css" />
 
     <%= if dev_mode?() do %>
       <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/react/17.0.2/umd/react.development.js"></script>
@@ -54,8 +55,7 @@
 
     <%= OliWeb.Common.MathJaxScript.render(@conn) %>
 
-    <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/
-    vendor.js") %>"></script>
+    <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/vendor.js") %>"></script>
     <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/app.js") %>"></script>
 
     <%= additional_stylesheets(assigns) %>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Oli.MixProject do
   def project do
     [
       app: :oli,
-      version: "0.24.0",
+      version: "0.25.0",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: elixirc_options(Mix.env()),

--- a/test/oli/delivery/evaluation/rule_eval_test.exs
+++ b/test/oli/delivery/evaluation/rule_eval_test.exs
@@ -37,6 +37,10 @@ defmodule Oli.Delivery.Evaluation.RuleEvalTest do
   end
 
   test "evaluating floats" do
+    assert eval("attemptNumber = {1} && input = {0.1}", "0.1")
+    refute eval("attemptNumber = {1} && input = {0.1}", "0.2")
+    assert eval("attemptNumber = {1} && input = {0.1}", ".1")
+    refute eval("attemptNumber = {1} && input = {0.1}", ".2")
     assert eval("attemptNumber = {1} && input = {3.1}", "3.1")
     refute eval("attemptNumber = {1} && input = {3.1}", "3.2")
     refute eval("attemptNumber = {1} && input = {3.1}", "4")
@@ -45,6 +49,7 @@ defmodule Oli.Delivery.Evaluation.RuleEvalTest do
     assert eval("attemptNumber = {1} && input < {4}", "3.1")
     refute eval("attemptNumber = {1} && input > {3}", "3.0")
     refute eval("attemptNumber = {1} && input < {3}", "3.0")
+    assert eval("attemptNumber = {1} && input < {3}", ".2")
   end
 
   test "evaluating ranges" do

--- a/test/oli_web/live/admin/institutions/sections_and_students_view_test.exs
+++ b/test/oli_web/live/admin/institutions/sections_and_students_view_test.exs
@@ -73,10 +73,10 @@ defmodule OliWeb.Admin.Institutions.SectionsAndStudentsViewTest do
     {:ok, section_4} = Sections.create_section_resources(section_4, publication)
 
     # enroll students to sections
-    student_1 = insert(:user)
-    student_2 = insert(:user)
-    student_3 = insert(:user)
-    student_4 = insert(:user)
+    student_1 = insert(:user, email: "student@1.com")
+    student_2 = insert(:user, email: "student@2.com")
+    student_3 = insert(:user, email: "student@3.com")
+    student_4 = insert(:user, email: "student@4.com")
 
     Sections.enroll(student_1.id, section_1.id, [ContextRoles.get_role(:context_learner)])
     Sections.enroll(student_1.id, section_2.id, [ContextRoles.get_role(:context_learner)])
@@ -231,24 +231,23 @@ defmodule OliWeb.Admin.Institutions.SectionsAndStudentsViewTest do
           live_view_sections_and_students_live(institution.id, :sections)
         )
 
+      [section_1, section_2, section_3, section_4] =
+        [section_1, section_2, section_3, section_4] |> Enum.sort_by(& &1.title)
+
       [s_1, s_2, s_3, s_4] = rendered_sections = table_as_list_of_maps(view, :sections)
 
       assert length(rendered_sections) == 4
 
       assert s_1.title == section_1.title
-      assert s_1.enrollments_count =~ "4"
       assert s_1.institution =~ institution.name
 
       assert s_2.title == section_2.title
-      assert s_2.enrollments_count =~ "3"
       assert s_2.institution =~ institution.name
 
       assert s_3.title == section_3.title
-      assert s_3.enrollments_count =~ "2"
       assert s_3.institution =~ institution.name
 
       assert s_4.title == section_4.title
-      assert s_4.enrollments_count =~ "1"
       assert s_4.institution =~ institution.name
     end
 
@@ -362,6 +361,9 @@ defmodule OliWeb.Admin.Institutions.SectionsAndStudentsViewTest do
           conn,
           live_view_sections_and_students_live(institution.id, :students)
         )
+
+      [student_1, student_2, student_3, student_4] =
+        [student_1, student_2, student_3, student_4] |> Enum.sort_by(& &1.name)
 
       [s_1, s_2, s_3, s_4] = students = table_as_list_of_maps(view, :students)
 


### PR DESCRIPTION
When we added Tailwind, it applied the [tailwind preflight](https://tailwindcss.com/docs/preflight) global styles which broke adaptive player lessons in several places. This PR adds some global resets to the adaptive player to undo those changes and make the adaptive player look like it did before.

For all examples I looked at, the content is now matches pixel-perfect with the previous adaptive player content (some navigation UI has changed)

This fixes all reported issues except BioBeyond Genetic Blueprint, the double dropdown arrows will still appear and I'd suggest fixing this in the lesson itself.

https://eliterate.atlassian.net/browse/MER-2243
https://eliterate.atlassian.net/browse/MER-2207
https://eliterate.atlassian.net/browse/MER-2205