### PR TITLE
[BUG FIX] [MER-2204] [MER-2207] [MER-2243] Adaptive player styling fixes [TARGET v0.24.0]

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -8,6 +8,8 @@
 @import 'button';
 @import 'table';
 
+@import 'adaptive-reset.scss';
+
 /**
  * Automatically style all links with blue text and underline on hover.
  * External links will automatically get an arrow icon appended.

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -8,8 +8,6 @@
 @import 'button';
 @import 'table';
 
-@import 'adaptive-reset.scss';
-
 /**
  * Automatically style all links with blue text and underline on hover.
  * External links will automatically get an arrow icon appended.

--- a/assets/styles/adaptive/adaptive-reset.scss
+++ b/assets/styles/adaptive/adaptive-reset.scss
@@ -4,21 +4,20 @@
   theme can still benefit from it.
 */
 
+/*
+   This is the only actual global style, it's because Tailwind uses `box-sizing: border-box` by default on *, if we do that inside our
+   .mainView scoping, it gets a higher specificity and then breaks some of the custom style sheets in the adaptive player. Putting it
+   here is the only way to get it to apply at the right level without having control of all those custom style sheets out there.
+*/
+* {
+  box-sizing: content-box;
+}
+
 /* Looks like `.mainView` will be specific enough to just the adaptive player. */
 .mainView {
   .content {
     border-color: #000;
   }
-
-  * {
-    /*
-      This one is a little dangerous. Tailwind uses `box-sizing: border-box` by default on *, but this one
-      is in the .mainView .content scope, this could end up overriding some other box-sizing styles set in
-      custom sheets that have lower specificity.
-    */
-    box-sizing: content-box;
-  }
-
   ol,
   ul {
     display: block;

--- a/assets/styles/adaptive/adaptive-reset.scss
+++ b/assets/styles/adaptive/adaptive-reset.scss
@@ -62,3 +62,13 @@ select {
   border-radius: 2px;
   min-height: 44px;
 }
+
+img,
+video {
+  max-width: unset;
+  height: unset;
+}
+
+janus-video video {
+  max-height: 100%;
+}

--- a/assets/styles/adaptive/adaptive-reset.scss
+++ b/assets/styles/adaptive/adaptive-reset.scss
@@ -8,7 +8,9 @@
   at the right level without having control of all those custom style sheets out there.
 */
 
-* {
+*,
+::before,
+::after {
   box-sizing: content-box;
 }
 

--- a/assets/styles/adaptive/adaptive-reset.scss
+++ b/assets/styles/adaptive/adaptive-reset.scss
@@ -1,66 +1,62 @@
 /*
-  Applies some "global" styles to adaptive player to bring us back to a pre-tailwind preflight state.
+  Applies some global styles to adaptive player to bring us back to a pre-tailwind preflight state.
   This needs to be a top-level css outside of the adaptive theming css so lessons that define a custom
   theme can still benefit from it.
+
+  These can not be scoped under a parent selector because then they gets a higher specificity and it breaks
+  some of the custom style sheets in the adaptive player. Putting it here is the only way to get it to apply
+  at the right level without having control of all those custom style sheets out there.
 */
 
-/*
-   This is the only actual global style, it's because Tailwind uses `box-sizing: border-box` by default on *, if we do that inside our
-   .mainView scoping, it gets a higher specificity and then breaks some of the custom style sheets in the adaptive player. Putting it
-   here is the only way to get it to apply at the right level without having control of all those custom style sheets out there.
-*/
 * {
   box-sizing: content-box;
 }
 
-/* Looks like `.mainView` will be specific enough to just the adaptive player. */
-.mainView {
-  .content {
-    border-color: #000;
-  }
-  ol,
-  ul {
-    display: block;
-    margin-block-start: 1em;
-    margin-block-end: 1em;
-    margin-inline-start: 0px;
-    margin-inline-end: 0px;
-    padding-inline-start: 40px;
-  }
+.content {
+  border-color: #000;
+}
+ol,
+ul {
+  display: block;
+  margin-block-start: 1em;
+  margin-block-end: 1em;
+  margin-inline-start: 0px;
+  margin-inline-end: 0px;
+  padding-inline-start: 40px;
+}
 
-  ol {
-    li {
-      list-style-type: decimal;
-    }
+ol {
+  li {
     list-style-type: decimal;
   }
+  list-style-type: decimal;
+}
 
-  ul {
-    li {
-      list-style-type: disc;
-    }
+ul {
+  li {
     list-style-type: disc;
   }
+  list-style-type: disc;
+}
 
-  [type='text'],
-  [type='email'],
-  [type='url'],
-  [type='password'],
-  [type='number'],
-  [type='date'],
-  [type='datetime-local'],
-  [type='month'],
-  [type='search'],
-  [type='tel'],
-  [type='time'],
-  [type='week'],
-  [multiple],
-  textarea,
-  select {
-    padding: 5px;
-    border: 1px solid var(--grayDark20);
-    box-sizing: border-box;
-    border-radius: 2px;
-    min-height: 44px;
-  }
+[type='text'],
+[type='email'],
+[type='url'],
+[type='password'],
+[type='number'],
+[type='date'],
+[type='datetime-local'],
+[type='month'],
+[type='search'],
+[type='tel'],
+[type='time'],
+[type='week'],
+[multiple],
+textarea,
+select {
+  padding: 5px;
+  border: 1px solid var(--grayDark20);
+  box-sizing: border-box;
+  border-radius: 2px;
+  min-height: 44px;
 }

--- a/assets/styles/adaptive/adaptive-reset.scss
+++ b/assets/styles/adaptive/adaptive-reset.scss
@@ -1,0 +1,67 @@
+/*
+  Applies some "global" styles to adaptive player to bring us back to a pre-tailwind preflight state.
+  This needs to be a top-level css outside of the adaptive theming css so lessons that define a custom
+  theme can still benefit from it.
+*/
+
+/* Looks like `.mainView` will be specific enough to just the adaptive player. */
+.mainView {
+  .content {
+    border-color: #000;
+  }
+
+  * {
+    /*
+      This one is a little dangerous. Tailwind uses `box-sizing: border-box` by default on *, but this one
+      is in the .mainView .content scope, this could end up overriding some other box-sizing styles set in
+      custom sheets that have lower specificity.
+    */
+    box-sizing: content-box;
+  }
+
+  ol,
+  ul {
+    display: block;
+    margin-block-start: 1em;
+    margin-block-end: 1em;
+    margin-inline-start: 0px;
+    margin-inline-end: 0px;
+    padding-inline-start: 40px;
+  }
+
+  ol {
+    li {
+      list-style-type: decimal;
+    }
+    list-style-type: decimal;
+  }
+
+  ul {
+    li {
+      list-style-type: disc;
+    }
+    list-style-type: disc;
+  }
+
+  [type='text'],
+  [type='email'],
+  [type='url'],
+  [type='password'],
+  [type='number'],
+  [type='date'],
+  [type='datetime-local'],
+  [type='month'],
+  [type='search'],
+  [type='tel'],
+  [type='time'],
+  [type='week'],
+  [multiple],
+  textarea,
+  select {
+    padding: 5px;
+    border: 1px solid var(--grayDark20);
+    box-sizing: border-box;
+    border-radius: 2px;
+    min-height: 44px;
+  }
+}

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -60,7 +60,10 @@ const populateEntries = () => {
     };
   });
 
-  const styleSheets = [{ styles: './styles/index.scss' }, { preview: './styles/preview.scss' }];
+  const styleSheets = [
+    { adaptive: './styles/adaptive/adaptive-reset.scss' },
+    { styles: './styles/index.scss' },
+    { preview: './styles/preview.scss' }];
 
   // Merge the attributes of all found activities and the initialEntries
   // into one single object.
@@ -74,9 +77,9 @@ const populateEntries = () => {
   if (
     Object.keys(merged).length !=
     Object.keys(initialEntries).length +
-      2 * foundActivities.length +
-      2 * foundParts.length +
-      styleSheets.length
+    2 * foundActivities.length +
+    2 * foundParts.length +
+    styleSheets.length
   ) {
     throw new Error(
       'Encountered a possible naming collision in activity or part manifests. Aborting.',

--- a/lib/oli_web/templates/layout/chromeless.html.eex
+++ b/lib/oli_web/templates/layout/chromeless.html.eex
@@ -16,6 +16,7 @@
 
     <!-- Tailwind CSS -->
     <link id="app" rel="stylesheet" href="/css/app.css" />
+    <link id="app" rel="stylesheet" href="/css/adaptive.css" />
 
     <%= if dev_mode?() do %>
       <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/react/17.0.2/umd/react.development.js"></script>


### PR DESCRIPTION
When we added Tailwind, it applied the [tailwind preflight](https://tailwindcss.com/docs/preflight) global styles which broke adaptive player lessons in several places. This PR adds some global resets to the adaptive player to undo those changes and make the adaptive player look like it did before.

For all examples I looked at, the content is now matches pixel-perfect with the previous adaptive player content (some navigation UI has changed)

This fixes all reported issues except BioBeyond Genetic Blueprint, the double dropdown arrows will still appear and I'd suggest fixing this in the lesson itself.

https://eliterate.atlassian.net/browse/MER-2243
https://eliterate.atlassian.net/browse/MER-2207
https://eliterate.atlassian.net/browse/MER-2205

Cherry picks commits `17cd228.. f695b8d` from https://github.com/Simon-Initiative/oli-torus/pull/3830 to target fix to `prerelease-v.0.24.0` branch