### PR TITLE
[BUGFIX][MER-2213] Timer sometimes appears on non quiz pages

### DIFF
--- a/lib/oli_web/templates/page_delivery/page.html.heex
+++ b/lib/oli_web/templates/page_delivery/page.html.heex
@@ -62,13 +62,13 @@ window.userToken = "<%= assigns[:user_token] %>";
   <% end %>
 <% end %>
 
-<%= if @review_mode == false and @time_limit > 0 do %>
+<%= if @review_mode == false and @time_limit > 0 and @graded do %>
   <div id="countdown_timer_display" class="text-xl font-bold text-center sticky top-0"></div>
   <script>
     OLI.initCountdownTimer('countdown_timer_display', 'submit_answers', <%= @time_limit %>, <%= @attempt_start_time %>, <%= @effective_end_time %>, <%= @auto_submit %>);
   </script>
 <% else %>
-  <%= if @review_mode == false and !is_nil(@effective_end_time) do %>
+  <%= if @review_mode == false and !is_nil(@effective_end_time) and @graded do %>
     <div id="countdown_timer_display" class="text-xl font-bold text-center sticky top-0"></div>
     <script>
       OLI.initEndDateTimer('countdown_timer_display', 'submit_answers', <%= @effective_end_time %>, <%= @auto_submit %>);


### PR DESCRIPTION
[MER-2213](https://eliterate.atlassian.net/browse/MER-2213)

This PR adds an extra condition in the `if` statement that checks whether or not the timer should be rendered on a page. 

The timer will be rendered if the page is graded, in addition to the other conditions that already exist.

[MER-2213]: https://eliterate.atlassian.net/browse/MER-2213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ