### PR TITLE
[BUG FIX] Correct progress tracking in surveys [MER-2236]

### DIFF
--- a/lib/oli/delivery/attempts/page_lifecycle/ungraded.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/ungraded.ex
@@ -98,7 +98,16 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Ungraded do
          resource_access_id: resource_access_id
        }) do
     number_of_scorable_activities = Map.values(state.attempt_hierarchy)
-    |> Enum.map(fn {attempt, _} -> attempt end)
+    |> Enum.map(fn args ->
+      # The adaptive page and basic page have different shapes of their attempt hierarchy
+      # state.  We handle only the basic page here, and the adaptive page state gets mapped
+      # to mimic attempts that are scoreable.  We can do this because we know that it is
+      # impossible for an adaptive page to only have non-scoreable activities.
+      case args do
+        {attempt, _} -> attempt
+        _ -> %{scoreable: true}
+      end
+    end)
     |> Enum.filter(fn attempt -> attempt.scoreable end)
     |> Enum.count()
 

--- a/lib/oli/delivery/attempts/page_lifecycle/ungraded.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/ungraded.ex
@@ -97,10 +97,13 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Ungraded do
   defp update_progress({:ok, state}, %ResourceAttempt{
          resource_access_id: resource_access_id
        }) do
-    number_of_activities = Map.keys(state.attempt_hierarchy) |> Enum.count()
+    number_of_scorable_activities = Map.values(state.attempt_hierarchy)
+    |> Enum.map(fn {attempt, _} -> attempt end)
+    |> Enum.filter(fn attempt -> attempt.scoreable end)
+    |> Enum.count()
 
     Oli.Delivery.Attempts.Core.get_resource_access(resource_access_id)
-    |> do_update_progress(number_of_activities)
+    |> do_update_progress(number_of_scorable_activities)
 
     {:ok, state}
   end

--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -160,7 +160,7 @@ defmodule OliWeb.Sections.OverviewView do
             ><span>Preview Course as Instructor</span> <i class="fas fa-external-link-alt self-center ml-1" /></a>
           </li>
           <li><a
-              href={Routes.page_delivery_path(OliWeb.Endpoint, :index_preview, @section.slug)}
+              href={Routes.page_delivery_path(OliWeb.Endpoint, :index, @section.slug)}
               class="btn btn-link"
               target="_blank"
             ><span>Enter Course as a Student</span> <i class="fas fa-external-link-alt self-center ml-1" /></a></li>

--- a/test/oli_web/live/sections/overview_live_test.exs
+++ b/test/oli_web/live/sections/overview_live_test.exs
@@ -186,7 +186,7 @@ defmodule OliWeb.Sections.OverviewLiveTest do
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.page_delivery_path(OliWeb.Endpoint, :index_preview, section.slug)}\"]",
+               "a[href=\"#{Routes.page_delivery_path(OliWeb.Endpoint, :index, section.slug)}\"]",
                "Enter Course as a Student"
              )
 


### PR DESCRIPTION
Pages that only contain survey activities were not updating their progress.  Since activities within surveys are considered "unscoreable", the system needs to detect when a page *only* has unscoreable activities and mark the page progress as 100% upon visit.

In fixing this, I caught a regression where the "Enter course as a student" link had changed.  I corrected that. 