### PR TITLE
[Bugfix] Fixed the advanced author idle timeout dialog [MER-2179]

### DIFF
--- a/assets/src/apps/delivery/Delivery.tsx
+++ b/assets/src/apps/delivery/Delivery.tsx
@@ -40,6 +40,7 @@ export interface DeliveryProps {
   finalizeGradedURL: string;
   screenIdleTimeOutInSeconds?: number;
   reviewMode?: boolean;
+  signoutUrl?: string;
 }
 
 const Delivery: React.FC<DeliveryProps> = ({
@@ -53,6 +54,7 @@ const Delivery: React.FC<DeliveryProps> = ({
   resourceAttemptGuid,
   resourceAttemptState,
   activityGuidMapping,
+  signoutUrl,
   activityTypes = [],
   previewMode = false,
   isInstructor = false,
@@ -153,7 +155,9 @@ const Delivery: React.FC<DeliveryProps> = ({
           hideCloseButton={!fullscreen}
         />
       ) : null}
-      {screenIdleTimeOutTriggered ? <ScreenIdleTimeOutDialog remainingTime={2} /> : null}
+      {screenIdleTimeOutTriggered ? (
+        <ScreenIdleTimeOutDialog remainingTime={5} signoutUrl={signoutUrl} />
+      ) : null}
     </div>
   );
 };

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -669,6 +669,7 @@ defmodule OliWeb.PageDeliveryController do
         resourceAttemptState: resource_attempt.state,
         resourceAttemptGuid: resource_attempt.attempt_guid,
         activityGuidMapping: context.activities,
+        signoutUrl: Routes.session_path(OliWeb.Endpoint, :signout, type: :user),
         previousPageURL: previous_url,
         nextPageURL: next_url,
         previewMode: preview_mode,

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -1104,6 +1104,7 @@ defmodule OliWeb.Router do
     pipe_through([:browser, :delivery_protected, :pow_email_layout])
 
     delete("/signout", SessionController, :signout)
+    get("/signout", SessionController, :signout)
   end
 
   scope "/course", OliWeb do


### PR DESCRIPTION
_New pr to target prerelease branch_

The adaptive player's idle timeout dialog was sending the user to the overview page at the end of the timeout period instead of logging them out as desired. This now works correctly.

In addition, I fixed the visual display of the dialog.