### PR TITLE
[CHORE] Fix v24 version number

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Oli.MixProject do
   def project do
     [
       app: :oli,
-      version: "0.25.0",
+      version: "0.24.0",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: elixirc_options(Mix.env()),


### PR DESCRIPTION
Somehow it appears the version number 0.25.0 crept into the v0.24.0 branch. This fixes that in the mix file.