### PR TITLE
[Bugfix] Reduce formula font size. [MER-2131]

### DIFF
--- a/assets/styles/common/elements.scss
+++ b/assets/styles/common/elements.scss
@@ -327,7 +327,7 @@ $element-margin-bottom: 1.5em;
   .formula {
     /* The mathjax formulas were rendering out much larger than the surrounding text, so we're scaling them down to better match the
        legacy content, but the callouts should not be scaled down since that made them look too small. */
-    font-size: 0.8em;
+    font-size: 0.7em;
   }
 
   .callout-block,


### PR DESCRIPTION
Originally, the formulas were set to a 1 REM font size.
On June 27, I had lowered it to 0.8, which fixed most of these issues.
This particular formula is quite long, so I'm going to further reduce the font size to 0.7REM

![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/8de6c7f6-a389-4362-8431-2761b0e60032)


Fixes #3641