### PR TITLE
[Bugfix] crash on preview of core page with adaptive activity [MER-2234]

### DIFF
--- a/lib/oli/rendering/activity/html.ex
+++ b/lib/oli/rendering/activity/html.ex
@@ -12,6 +12,10 @@ defmodule Oli.Rendering.Activity.Html do
 
   @behaviour Oli.Rendering.Activity
 
+  defp get_activity_model("oli-adaptive-delivery", nil, _, _, model) do
+    model
+  end
+
   defp get_activity_model(tag, resource_attempt, activity_id, activity_map, model) do
     case tag do
       "oli-adaptive-delivery" ->


### PR DESCRIPTION
1. Add an adaptive activity to a core page
2. Preview it

Expected: View the page without that activity (is this true?)
Actual: 500 error / server crash

The original bug report talked about a rollover inside the stem of a question, but that seems to work fine. I spent some time selectively removing elements from the problematic page to find this as the root cause.

Fixes #3810