### PR TITLE
[ENHANCEMENT] Improve course creation [MER-2095]

### DIFF
--- a/lib/oli_web/live/new_course/new_course.ex
+++ b/lib/oli_web/live/new_course/new_course.ex
@@ -22,9 +22,9 @@ defmodule OliWeb.Delivery.NewCourse do
 
     steps = [
       %Step{
-        title: "Select your base course project or course product",
+        title: "Select your source materials",
         description:
-          "Select a course project or product on which to base your course curriculum.",
+          "Select the source of materials to base your course curriculum on.",
         render_fn: fn assigns -> render_step(:select_source, assigns) end,
         on_next_step: JS.push("change_step", value: %{current_step: 1})
       },
@@ -138,7 +138,6 @@ defmodule OliWeb.Delivery.NewCourse do
       <.header>
         <div class="flex flex-col items-center gap-3 pl-9 pr-16 py-4">
           <h2>Select source</h2>
-          <p>We pulled the information we can from your LMS, but feel free to adjust it</p>
           <.live_component
             id="select_source_step"
             module={SelectSource}
@@ -402,7 +401,7 @@ defmodule OliWeb.Delivery.NewCourse do
   end
 
   def handle_event("source_selection", %{"id" => source}, socket) do
-    {:noreply, assign(socket, source: source)}
+    {:noreply, assign(socket, source: source, current_step: 1)}
   end
 
   def handle_event("day_selection", %{"class_days" => class_days}, socket) do

--- a/lib/oli_web/live/new_course/new_course.ex
+++ b/lib/oli_web/live/new_course/new_course.ex
@@ -216,7 +216,7 @@ defmodule OliWeb.Delivery.NewCourse do
   defp next_step_disabled?(assigns) do
     case assigns.current_step do
       0 ->
-        assigns[:source] == nil
+        true
 
       _ ->
         false

--- a/lib/oli_web/live/new_course/new_course.ex
+++ b/lib/oli_web/live/new_course/new_course.ex
@@ -455,7 +455,7 @@ defmodule OliWeb.Delivery.NewCourse do
       |> Section.changeset(section)
 
     case current_step do
-      1 ->
+      step when step == 0 or step == 1 ->
         {:noreply, assign(socket, changeset: changeset, current_step: current_step)}
 
       2 ->

--- a/lib/oli_web/live/new_course/new_course.ex
+++ b/lib/oli_web/live/new_course/new_course.ex
@@ -159,7 +159,6 @@ defmodule OliWeb.Delivery.NewCourse do
         <div class="flex flex-col items-center gap-3 pl-9 pr-16 py-4">
           <img src="/images/icons/course-creation-wizard-step-1.svg" />
           <h2>Name your course</h2>
-          <p class="mb-0">We pulled the information we can from your LMS, but feel free to adjust it</p>
           <.render_flash flash={@flash} />
           <NameCourse.render changeset={@changeset} />
         </div>
@@ -173,7 +172,6 @@ defmodule OliWeb.Delivery.NewCourse do
       <div class="flex flex-col items-center gap-3 pl-9 pr-16 py-4">
         <img src="/images/icons/course-creation-wizard-step-2.svg" />
         <h2>Course details</h2>
-        <p>We pulled the information we can from your LMS, but feel free to adjust it</p>
         <.render_flash flash={@flash} />
         <CourseDetails.render on_select={@on_select} changeset={@changeset} />
       </div>

--- a/lib/oli_web/live/new_course/table_model.ex
+++ b/lib/oli_web/live/new_course/table_model.ex
@@ -98,7 +98,7 @@ defmodule OliWeb.Delivery.NewCourse.TableModel do
     id = if is_product?(item), do: "product:#{item.id}", else: "publication:#{item.id}"
 
     ~F"""
-    <button class="btn btn-primary" phx-click="source_selection" phx-value-id={id}>Select</button>
+    <button class="btn btn-primary btn-sm" phx-click="source_selection" phx-value-id={id}>Select</button>
     """
   end
 

--- a/test/oli_web/live/new_course/select_source_test.exs
+++ b/test/oli_web/live/new_course/select_source_test.exs
@@ -140,13 +140,6 @@ defmodule OliWeb.NewCourse.SelectSourceTest do
       |> element("button[phx-click=\"source_selection\"]")
       |> render_click(%{id: "product:#{section.id}"})
 
-      refute has_element?(view, "button[disabled]", "Next step")
-      assert has_element?(view, "tbody tr:first-child.bg-delivery-primary-100")
-
-      view
-      |> element("button", "Next step")
-      |> render_click(%{current_step: 1})
-
       refute has_element?(view, "h2", "Select source")
       assert has_element?(view, "h2", "Name your course")
     end
@@ -288,13 +281,6 @@ defmodule OliWeb.NewCourse.SelectSourceTest do
       view
       |> element(".card-deck a:first-child")
       |> render_click(id: "publication:#{section.id}")
-
-      refute has_element?(view, "button[disabled]", "Next step")
-      assert has_element?(view, ".card-deck a:first-child .card.shadow-inner")
-
-      view
-      |> element("button", "Next step")
-      |> render_click(%{current_step: 1})
 
       refute has_element?(view, "h2", "Select source")
       assert has_element?(view, "h2", "Name your course")
@@ -441,12 +427,6 @@ defmodule OliWeb.NewCourse.SelectSourceTest do
       |> render_click(id: "publication:#{section.id}")
 
       refute has_element?(view, "button[disabled]", "Next step")
-      assert has_element?(view, ".card-deck a:first-child .card.shadow-inner")
-
-      view
-      |> element("button", "Next step")
-      |> render_click(%{current_step: 1})
-
       refute has_element?(view, "h2", "Select source")
       assert has_element?(view, "h2", "Name your course")
     end


### PR DESCRIPTION
This PR addresses the core issue pointed in [MER-2095], which is that the "Next" button can be scrolled off of the page, making it confusing for the user to know how to proceed to Step 2.  This PR makes a change to automatically move to Step 2 after the user 'selects' a source. 

This PR also makes a few UI adjustments to simplify some language and reduce the size of the "Select" buttons.

[MER-2095]: https://eliterate.atlassian.net/browse/MER-2095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ