### PR TITLE
[BUG FIX] ensure payment settings get captured correctly [MER-2263]

### DIFF
--- a/lib/oli_web/live/new_course/new_course.ex
+++ b/lib/oli_web/live/new_course/new_course.ex
@@ -310,6 +310,14 @@ defmodule OliWeb.Delivery.NewCourse do
           |> Map.from_struct()
           |> Map.merge(%{
             blueprint_id: blueprint.id,
+            requires_payment: blueprint.requires_payment,
+            payment_options: blueprint.payment_options,
+            pay_by_institution: blueprint.pay_by_institution,
+            amount: blueprint.amount,
+            has_grace_period: blueprint.has_grace_period,
+            grace_period_days: blueprint.grace_period_days,
+            grace_period_strategy: blueprint.grace_period_strategy,
+            required_survey_resource_id: project.required_survey_resource_id,
             type: :enrollable,
             open_and_free: true,
             has_experiments: project.has_experiments,


### PR DESCRIPTION
The payment settings and required survey id were not being pulled forward during creation from a product. 