### PR TITLE
[BUG FIX] Fix top level objectives display in dashboard reports [MER-2267]

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -2631,57 +2631,123 @@ defmodule Oli.Delivery.Sections do
       get_flatten_hierarchy(rest, resources)
   end
 
+  @doc """
+  Returns all objectives and subobjectives for a given section, with associated proficiency
+  results generally available in the form:
+  %{
+    objective: "Parent Objective Title"
+    objective_resource_id: 231,
+    student_proficiency_obj: "High"
+    subobjective: "Subobjective Title",
+    subobjective_resource_id: 388,
+    student_proficiency_subobj: "Low"
+  }
+
+  For objectives that are subobjectives, the objective is shown as the `subobjective` like the
+  above example, with the aggregated proficiency for its parent shown.  For objectives that are
+  top level objectives, they appear with their proficiency for only those activities that
+  directly attached to them.
+  """
   def get_objectives_and_subobjectives(section_slug, student_id \\ nil) do
-    objective_id = Oli.Resources.ResourceType.get_id_by_type("objective")
+
+    calc = fn count, total ->
+      case total do
+        0 -> nil
+        _ -> count / total
+      end
+    end
 
     proficiency_per_learning_objective =
       case student_id do
         nil ->
-          Metrics.proficiency_per_learning_objective(section_slug)
+          Metrics.raw_proficiency_per_learning_objective(section_slug)
 
         student_id ->
-          Metrics.proficiency_for_student_per_learning_objective(section_slug, student_id)
+          Metrics.raw_proficiency_for_student_per_learning_objective(section_slug, student_id)
       end
+      |> Enum.reduce(%{}, fn {lo_id, correct, total}, acc ->
+        Map.put(acc, lo_id, {correct, total})
+      end)
 
-    ### get all objectives from the database
+    # get the minimal fields for all objectives from the database
+    objective_id = Oli.Resources.ResourceType.get_id_by_type("objective")
     objectives =
-      from([sr: sr, rev: rev] in DeliveryResolver.section_resource_revisions(section_slug),
-        left_join: rev2 in Revision,
-        on: rev2.resource_id in rev.children,
+      from([rev: rev] in DeliveryResolver.section_resource_revisions(section_slug),
         where: rev.deleted == false and rev.resource_type_id == ^objective_id,
-        group_by: [rev2.title, rev.resource_id, rev.title, rev2.resource_id, rev.children],
         select: %{
-          objective: rev.title,
-          objective_resource_id: rev.resource_id,
-          subobjective: rev2.title,
-          subobjective_resource_id: rev2.resource_id,
+          title: rev.title,
+          resource_id: rev.resource_id,
           children: rev.children
         }
       )
       |> Repo.all()
 
-    Enum.reduce(objectives, [], fn objective, acc ->
-      # Get all the parent objectives of the current objective
-      parent_objectives =
-        Enum.filter(objectives, fn obj ->
-          obj.subobjective_resource_id == objective.objective_resource_id
-        end)
-
-      if Enum.empty?(parent_objectives) do
-        # If the current objective doesn't have a parent, just render it
-        [objective | acc]
-      else
-        # If the current objective has one or more parents, render their parents
-        parent_objectives ++ acc
-      end
-
+    lookup_map = Enum.reduce(objectives, %{}, fn obj, acc ->
+      Map.put(acc, obj.resource_id, obj)
     end)
-    |> Enum.uniq_by(&{&1.objective_resource_id, &1.subobjective_resource_id})
-    |> Enum.map(fn obj ->
-      add_necessary_fields_to_objectives(
-        obj,
-        proficiency_per_learning_objective
-      )
+
+    # identify top level objectives (those that don't have a parent)
+    parent_map = Enum.reduce(objectives, %{}, fn obj, acc ->
+      Enum.reduce(obj.children, acc, fn child, acc ->
+        Map.put(acc, child, obj.resource_id)
+      end)
+    end)
+
+    top_level_objectives = Enum.filter(objectives, fn obj ->
+      !Map.has_key?(parent_map, obj.resource_id)
+    end)
+
+    # Now calculate the aggregate proficiency for each top level objective
+    top_level_aggregation = Enum.reduce(top_level_objectives, %{}, fn obj, map ->
+
+      aggregation = Enum.reduce(obj.children, {0, 0}, fn child, {correct, total} ->
+        {child_correct, child_total} = Map.get(proficiency_per_learning_objective, child, {0, 0})
+        {correct + child_correct, total + child_total}
+      end)
+
+      Map.put(map, obj.resource_id, aggregation)
+    end)
+
+    # Now make a pass over top level objectives, and for each one, pull in its subobjectives.
+    # We have to take this approach to account for the fact that a sub objective can have
+    # multiple parents.
+    Enum.reduce(objectives, [], fn objective, all ->
+
+      case Map.has_key?(parent_map, objective.resource_id) do
+        false -> # this is a top-level objective
+
+          {correct, total} = Map.get(proficiency_per_learning_objective, objective.resource_id, {0, 0})
+
+          objective = Map.merge(objective, %{
+            objective: objective.title,
+            objective_resource_id: objective.resource_id,
+            student_proficiency_obj: calc.(correct, total) |> Metrics.proficiency_range(),
+            subobjective: "",
+            subobjective_resource_id: nil,
+            student_proficiency_subobj: ""
+          })
+
+          {parent_correct, parent_total} = Map.get(top_level_aggregation, objective.resource_id, {0, 0})
+
+          sub_objectives = Enum.map(objective.children, fn child ->
+            sub_objective = Map.get(lookup_map, child)
+            {correct, total} = Map.get(proficiency_per_learning_objective, sub_objective.resource_id, {0, 0})
+
+            Map.merge(sub_objective, %{
+              objective: objective.title,
+              objective_resource_id: objective.resource_id,
+              student_proficiency_obj: calc.(parent_correct, parent_total) |> Metrics.proficiency_range(),
+              subobjective: sub_objective.title,
+              subobjective_resource_id: sub_objective.resource_id,
+              student_proficiency_subobj: calc.(correct, total) |> Metrics.proficiency_range()
+            })
+          end)
+
+          [objective | sub_objectives] ++ all
+
+        _ -> # this is a subobjective, we do nothing as it will be handled in the context of its parent(s)
+            all
+        end
     end)
   end
 
@@ -2739,29 +2805,6 @@ defmodule Oli.Delivery.Sections do
       2 -> Map.get(customizations, :module)
       _ -> Map.get(customizations, :section)
     end
-  end
-
-  defp add_necessary_fields_to_objectives(
-         obj,
-         proficiency_per_learning_objective
-       ) do
-    obj
-    |> Map.put(
-      :student_proficiency_obj,
-      Map.get(
-        proficiency_per_learning_objective,
-        obj.objective_resource_id,
-        "Not enough data"
-      )
-    )
-    |> Map.put(
-      :student_proficiency_subobj,
-      Map.get(
-        proficiency_per_learning_objective,
-        obj.subobjective_resource_id,
-        "Not enough data"
-      )
-    )
   end
 
   def get_units_and_modules_from_a_section(section_slug) do

--- a/test/oli/delivery/metrics/learning_proficiency_test.exs
+++ b/test/oli/delivery/metrics/learning_proficiency_test.exs
@@ -354,7 +354,7 @@ defmodule Oli.Delivery.Metrics.LearningProficiencyTest do
   describe "learning proficiency calculations" do
     setup [:create_project]
 
-    test "proficiency_per_learning_objective/1 calculates correctly", %{
+    test "raw_proficiency_per_learning_objective/1 calculates correctly", %{
       section: section,
       student_1: student_1,
       student_2: student_2,
@@ -384,22 +384,25 @@ defmodule Oli.Delivery.Metrics.LearningProficiencyTest do
       set_snapshot(section, page_3.resource, page_3_obj.resource, student_4, false)
 
       proficiency_per_learning_objective =
-        Metrics.proficiency_per_learning_objective(section.slug)
+        Metrics.raw_proficiency_per_learning_objective(section.slug)
 
+      # "High"
       assert proficiency_per_learning_objective[page_1_obj.resource.id] ==
-               "High"
+               {4.0, 4.0}
 
+      # "Medium"
       assert proficiency_per_learning_objective[page_2_obj.resource.id] ==
-               "Medium"
+               {3.0, 4.0}
 
+      # "Low"
       assert proficiency_per_learning_objective[page_3_obj.resource.id] ==
-               "Low"
+               {1.0, 4.0}
 
       assert proficiency_per_learning_objective[page_4_obj.resource.id] ==
                nil
     end
 
-    test "proficiency_for_student_per_learning_objective/2 calculates correctly", %{
+    test "raw_proficiency_for_student_per_learning_objective/2 calculates correctly", %{
       section: section,
       student_1: student_1,
       student_2: student_2,
@@ -421,20 +424,26 @@ defmodule Oli.Delivery.Metrics.LearningProficiencyTest do
       set_snapshot(section, page_4.resource, page_4_obj.resource, student_2, true)
 
       student_1_proficiency_per_learning_objective =
-        Metrics.proficiency_for_student_per_learning_objective(section.slug, student_1.id)
+        Metrics.raw_proficiency_for_student_per_learning_objective(section.slug, student_1.id)
 
       student_2_proficiency_per_learning_objective =
-        Metrics.proficiency_for_student_per_learning_objective(section.slug, student_2.id)
+        Metrics.raw_proficiency_for_student_per_learning_objective(section.slug, student_2.id)
 
-      assert student_1_proficiency_per_learning_objective[page_1_obj.resource.id] == "High"
-      assert student_1_proficiency_per_learning_objective[page_2_obj.resource.id] == "Low"
-      assert student_1_proficiency_per_learning_objective[page_3_obj.resource.id] == "High"
+      # "High"
+      assert student_1_proficiency_per_learning_objective[page_1_obj.resource.id] == {1.0, 1.0}
+      # "Low"
+      assert student_1_proficiency_per_learning_objective[page_2_obj.resource.id] == {0.0, 1.0}
+      # "High"
+      assert student_1_proficiency_per_learning_objective[page_3_obj.resource.id] == {1.0, 1.0}
       assert student_1_proficiency_per_learning_objective[page_4_obj.resource.id] == nil
 
-      assert student_2_proficiency_per_learning_objective[page_1_obj.resource.id] == "Low"
+      # "Low"
+      assert student_2_proficiency_per_learning_objective[page_1_obj.resource.id] == {0.0, 1.0}
       assert student_2_proficiency_per_learning_objective[page_2_obj.resource.id] == nil
-      assert student_2_proficiency_per_learning_objective[page_3_obj.resource.id] == "Low"
-      assert student_2_proficiency_per_learning_objective[page_4_obj.resource.id] == "High"
+      # "Low"
+      assert student_2_proficiency_per_learning_objective[page_3_obj.resource.id] == {0.0, 1.0}
+      # "High"
+      assert student_2_proficiency_per_learning_objective[page_4_obj.resource.id] == {1.0, 1.0}
     end
 
     test "proficiency_per_container/1 calculates correctly", %{


### PR DESCRIPTION
This PR reworks the arrangement of objectives within the rows of the "Learning Objectives" reports in the instructor dashboard.  

Consider an authored project with the following objectives, noting how `Sub2` is a sub objective that appears under both of the top-level objectives:
```
TOP
 --Sub1
 --Sub2
TOP2
 --Sub2
 --Sub3
```

This PR now correctly renders this structure:
![Screenshot 2023-07-11 at 9 17 08 AM](https://github.com/Simon-Initiative/oli-torus/assets/7431756/fae3aaba-f9de-40f6-ba77-8255aed3a7ea)

Moreover, for the rows where only a top-level objective is shown, the proficiency results are for only when that top-level objective is directly attached to activities.  For the other rows where a sub objective is displayed, the values shown for the "top level" objective are the aggregated results across all sub objectives that appear under that top-level objective. 
