### PR TITLE
[BUGFIX]  Image coding on graded page not evaluated [MER-2259]

### DIFF
--- a/assets/src/components/activities/image_coding/ImageCodingAuthoring.tsx
+++ b/assets/src/components/activities/image_coding/ImageCodingAuthoring.tsx
@@ -189,9 +189,17 @@ const ImageCoding = (props: AuthoringElementProps<ImageCodingModelSchema>) => {
 
       {!model.isExample && (
         <div>
-          {solutionParameters()}
-
           <TabbedNavigation.Tabs>
+            <TabbedNavigation.Tab label="Answer Key">
+              {solutionParameters()}
+              <Feedback
+                {...sharedProps}
+                projectSlug={props.projectSlug}
+                onEditResponse={(score, content) =>
+                  dispatch(ICActions.editFeedback(score, content))
+                }
+              />
+            </TabbedNavigation.Tab>
             <TabbedNavigation.Tab label="Hints">
               <HintsAuthoring partId={model.authoring.parts[0].id} />
             </TabbedNavigation.Tab>
@@ -199,12 +207,6 @@ const ImageCoding = (props: AuthoringElementProps<ImageCodingModelSchema>) => {
               <Explanation partId={model.authoring.parts[0].id} />
             </TabbedNavigation.Tab>
           </TabbedNavigation.Tabs>
-
-          <Feedback
-            {...sharedProps}
-            projectSlug={props.projectSlug}
-            onEditResponse={(score, content) => dispatch(ICActions.editFeedback(score, content))}
-          />
         </div>
       )}
     </React.Fragment>

--- a/assets/src/components/activities/image_coding/ImageCodingDelivery.tsx
+++ b/assets/src/components/activities/image_coding/ImageCodingDelivery.tsx
@@ -2,9 +2,11 @@ import React, { useEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import { maybe } from 'tsmonad';
-import { EvaluationConnected } from 'components/activities/common/delivery/evaluation/EvaluationConnected';
 import { GradedPointsConnected } from 'components/activities/common/delivery/graded_points/GradedPointsConnected';
+import { Checkmark } from 'components/misc/icons/Checkmark';
+import { Cross } from 'components/misc/icons/Cross';
 import { activityDeliverySlice } from 'data/activities/DeliveryState';
+import { isCorrect } from 'data/activities/utils';
 import { defaultWriterContext } from 'data/content/writers/context';
 import * as Events from 'data/events';
 import { configureStore } from 'state/store';
@@ -20,6 +22,7 @@ import { Hints } from '../common/DisplayedHints';
 import { Stem } from '../common/DisplayedStem';
 import { Reset } from '../common/Reset';
 import { Evaluation } from '../common/delivery/evaluation/Evaluation';
+import { GradedPoints } from '../common/delivery/graded_points/GradedPoints';
 import * as ActivityTypes from '../types';
 import { EvalContext, Evaluator } from './Evaluator';
 import { ImageCodingModelSchema } from './schema';
@@ -86,6 +89,7 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
   let currentOutput = output;
 
   const isEvaluated = attemptState.score !== null;
+  const isSubmitted = attemptState.dateSubmitted != undefined && attemptState.dateSubmitted != null;
 
   const writerContext = defaultWriterContext({
     graded: props.context.graded,
@@ -287,6 +291,20 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
     />
   );
 
+  const maybeGradedPoints = (
+    <GradedPoints
+      shouldShow={
+        !model.isExample &&
+        isEvaluated &&
+        (!props.context.graded || isSubmitted) &&
+        props.context.showFeedback === true &&
+        props.context.surveyId === null
+      }
+      icon={isCorrect(attemptState) ? <Checkmark /> : <Cross />}
+      attemptState={attemptState}
+    />
+  );
+
   const maybeHints = !model.isExample && props.context.graded && (
     <Hints
       key="hints"
@@ -357,6 +375,7 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
     <div className="activity short-answer-activity">
       <div className="activity-content">
         <Stem stem={stem} context={writerContext} />
+        {maybeGradedPoints}
         <div>
           <ImageCodeEditor value={input} disabled={isEvaluated} onChange={onInputChange} />
           {runButton} {maybeSubmitButton}

--- a/assets/src/components/activities/image_coding/ImageCodingDelivery.tsx
+++ b/assets/src/components/activities/image_coding/ImageCodingDelivery.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import { maybe } from 'tsmonad';
+import { EvaluationConnected } from 'components/activities/common/delivery/evaluation/EvaluationConnected';
+import { GradedPointsConnected } from 'components/activities/common/delivery/graded_points/GradedPointsConnected';
 import { activityDeliverySlice } from 'data/activities/DeliveryState';
 import { defaultWriterContext } from 'data/content/writers/context';
 import * as Events from 'data/events';
@@ -264,30 +266,27 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
     return diff < model.tolerance;
   };
 
-  const evaluationSummary = isEvaluated ? (
-    <Evaluation key="evaluation" attemptState={attemptState} context={writerContext} />
-  ) : null;
-
-  const reset = isEvaluated && !props.context.graded && !props.context.surveyId && (
+  const maybeResetButton = isEvaluated && !props.context.graded && !props.context.surveyId && (
     <div className="d-flex">
       <div className="flex-fill"></div>
       <Reset hasMoreAttempts={attemptState.hasMoreAttempts} onClick={onReset} />
     </div>
   );
 
-  const ungradedDetails = props.context.graded
-    ? null
-    : [
-        evaluationSummary,
-        <Hints
-          key="hints"
-          onClick={onRequestHint}
-          hints={hints}
-          context={writerContext}
-          hasMoreHints={hasMoreHints}
-          isEvaluated={isEvaluated}
-        />,
-      ];
+  const maybeEvaluation = !model.isExample && isEvaluated && (
+    <Evaluation key="evaluation" attemptState={attemptState} context={writerContext} />
+  );
+
+  const maybeHints = !model.isExample && props.context.graded && (
+    <Hints
+      key="hints"
+      onClick={onRequestHint}
+      hints={hints}
+      context={writerContext}
+      hasMoreHints={hasMoreHints}
+      isEvaluated={isEvaluated}
+    />
+  );
 
   const renderOutput = () => {
     if (output === '') {
@@ -328,17 +327,15 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
     return solution ? solnRef.current : resultRef.current;
   };
 
-  const maybeSubmitButton = !model.isExample &&
-    !props.context.surveyId &&
-    !props.context.graded && (
-      <button
-        className="btn btn-primary mt-2 float-right"
-        disabled={isEvaluated || !ranCode}
-        onClick={onSubmit}
-      >
-        Submit
-      </button>
-    );
+  const maybeSubmitButton = !model.isExample && !props.context.surveyId && (
+    <button
+      className="btn btn-primary mt-2 float-right"
+      disabled={isEvaluated || !ranCode}
+      onClick={onSubmit}
+    >
+      Submit
+    </button>
+  );
 
   const runButton = (
     <button className="btn btn-primary mt-2 float-left" disabled={isEvaluated} onClick={onRun}>
@@ -350,16 +347,13 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
     <div className="activity short-answer-activity">
       <div className="activity-content">
         <Stem stem={stem} context={writerContext} />
-
         <div>
           <ImageCodeEditor value={input} disabled={isEvaluated} onChange={onInputChange} />
           {runButton} {maybeSubmitButton}
         </div>
-
         {/* implementation relies on 2 hidden canvases for image operations */}
         <canvas ref={canvasRef} style={{ display: 'none' }} />
         <canvas ref={canvasRef2} style={{ display: 'none' }} />
-
         <div style={{ whiteSpace: 'pre-wrap' }}>
           <h5>Output:</h5>
           {renderOutput()}
@@ -369,9 +363,10 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
           <canvas ref={solnRef} style={{ display: 'none' }} height="0" width="0" />
         </div>
 
-        {!model.isExample && !props.context.surveyId && ungradedDetails}
+        {maybeEvaluation}
+        {maybeHints}
       </div>
-      {reset}
+      {maybeResetButton}
     </div>
   );
 };

--- a/assets/src/components/activities/image_coding/ImageCodingDelivery.tsx
+++ b/assets/src/components/activities/image_coding/ImageCodingDelivery.tsx
@@ -105,7 +105,7 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
   const resultRef = useRef<HTMLCanvasElement>(null);
   const solnRef = useRef<HTMLCanvasElement>(null);
 
-  // for tracking when all resource are loaded
+  // for tracking when all resource are loaded, used for regenerating output on return to evaluated page
   const [resourcesLoaded, setResourcesLoaded] = useState(false);
   const updateResourceState = () => {
     if (
@@ -160,12 +160,24 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
 
     // For non-resource-using problems, will be ready right now
     updateResourceState();
+    /*
+    // On graded page, page-wide submit can be used w/starter code unedited, comparable to submitting
+    // assessment w/unanswered short answers. Following would auto-save the starter code as the
+    // user input on first render, so it shows up on review in this case. However, now opting to
+    // leave blank in this case to show that question was never even answered.
+    if (props.context.graded) {
+      props.onSaveActivity(attemptState.attemptGuid, [
+        { attemptGuid: attemptState.parts[0].attemptGuid, response: { input } },
+      ]);
+    }
+    */
   }, []);
 
   // On a return to evaluated activity not run by this instance, regenerate output state by
   // simulating Run button click to execute student code. Requires that all resources have loaded.
+  // input will be null in case where starter code never edited.
   useEffect(() => {
-    if (isEvaluated && !ranCode && resourcesLoaded) onRun();
+    if (isEvaluated && !ranCode && resourcesLoaded && input != null) onRun();
   }, [resourcesLoaded]);
 
   const onInputChange = (input: string) => {

--- a/assets/src/components/activities/image_coding/ImageCodingDelivery.tsx
+++ b/assets/src/components/activities/image_coding/ImageCodingDelivery.tsx
@@ -295,7 +295,8 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
       shouldShow={
         !model.isExample &&
         isEvaluated &&
-        (!props.context.graded || props.mode === 'review') &&
+        props.context.graded &&
+        props.mode === 'review' &&
         props.context.showFeedback === true &&
         props.context.surveyId === null
       }

--- a/assets/src/components/activities/image_coding/ImageCodingDelivery.tsx
+++ b/assets/src/components/activities/image_coding/ImageCodingDelivery.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
-import { Provider } from 'react-redux';
+import { Provider, useSelector } from 'react-redux';
 import { maybe } from 'tsmonad';
-import { GradedPointsConnected } from 'components/activities/common/delivery/graded_points/GradedPointsConnected';
 import { Checkmark } from 'components/misc/icons/Checkmark';
 import { Cross } from 'components/misc/icons/Cross';
 import { activityDeliverySlice } from 'data/activities/DeliveryState';
@@ -89,7 +88,6 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
   let currentOutput = output;
 
   const isEvaluated = attemptState.score !== null;
-  const isSubmitted = attemptState.dateSubmitted != undefined && attemptState.dateSubmitted != null;
 
   const writerContext = defaultWriterContext({
     graded: props.context.graded,
@@ -282,6 +280,7 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
       shouldShow={
         !model.isExample &&
         isEvaluated &&
+        (!props.context.graded || props.mode === 'review') &&
         props.context.showFeedback === true &&
         props.context.surveyId === null
       }
@@ -296,7 +295,7 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
       shouldShow={
         !model.isExample &&
         isEvaluated &&
-        (!props.context.graded || isSubmitted) &&
+        (!props.context.graded || props.mode === 'review') &&
         props.context.showFeedback === true &&
         props.context.surveyId === null
       }

--- a/assets/src/components/activities/image_coding/ImageCodingDelivery.tsx
+++ b/assets/src/components/activities/image_coding/ImageCodingDelivery.tsx
@@ -273,8 +273,18 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
     </div>
   );
 
-  const maybeEvaluation = !model.isExample && isEvaluated && (
-    <Evaluation key="evaluation" attemptState={attemptState} context={writerContext} />
+  const maybeEvaluation = (
+    <Evaluation
+      shouldShow={
+        !model.isExample &&
+        isEvaluated &&
+        props.context.showFeedback === true &&
+        props.context.surveyId === null
+      }
+      key="evaluation"
+      attemptState={attemptState}
+      context={writerContext}
+    />
   );
 
   const maybeHints = !model.isExample && props.context.graded && (

--- a/assets/src/components/activities/image_coding/ImageCodingDelivery.tsx
+++ b/assets/src/components/activities/image_coding/ImageCodingDelivery.tsx
@@ -370,6 +370,11 @@ const ImageCoding = (props: ImageCodingDeliveryProps) => {
     </button>
   );
 
+  // On return to evaluated activity, regenerate output state by auto-running student code
+  if (isEvaluated && !ranCode) {
+    onRun();
+  }
+
   return (
     <div className="activity short-answer-activity">
       <div className="activity-content">

--- a/assets/src/components/activities/image_coding/sections/ImageCodeEditor.tsx
+++ b/assets/src/components/activities/image_coding/sections/ImageCodeEditor.tsx
@@ -11,6 +11,13 @@ export type ImageCodeEditorProps = {
 
 export const ImageCodeEditor = (props: ImageCodeEditorProps) => {
   const value = props.value === null ? '' : props.value;
+  // style edit box border to match other input controls
+  const styles: React.CSSProperties = {
+    border: '1px solid rgb(212,212,212)',
+    borderRadius: '0.375rem',
+  };
+  if (props.disabled) styles.background = '#ECF0F1';
+
   return (
     <AceEditor
       className="form-control"
@@ -22,7 +29,7 @@ export const ImageCodeEditor = (props: ImageCodeEditorProps) => {
       value={value}
       onChange={props.onChange}
       readOnly={props.disabled}
-      style={props.disabled ? { background: '#ECF0F1' } : {}}
+      style={styles}
       setOptions={{
         showLineNumbers: false,
         tabSize: 4,


### PR DESCRIPTION
This provides support for image coding on a graded page. The activity's submit button is shown; it must be clicked before page submission to finalize the image coding answer (this kicks off the needed client-side evaluation). Also adjusts conditional rendering of hints, evaluation feedback, and graded points to be appropriate for graded delivery, graded review mode, and practice page contexts, respecting new showFeedback flag. Returning to an evaluated page (as in review mode) also attempts to regenerate output from student code, since this output is not part of persistent activity state. 

There are still issues in graded context: if activity-local Submit is never used before page-wide Submit Answers, question will be marked incorrect even if code is correct and there is no indication this is the reason in the review display. And if code is never edited at all (comparable to leaving text input question blank) before page-wide Submit Answers, code input box will show up as empty on review (which at least indicates what happened). Better treatment probably requires more support from the torus framework for client-evaluated activities on graded pages. But as long as code is finalized by Submit button, image coding questions should behave reasonably.

This PR also explicitly styles the code box with a border which had disappeared at some point for clearer display.