### PR TITLE
[BUGFIX] fix adaptive graded restart [MER-2274]

### DIFF
--- a/assets/src/data/persistence/page_lifecycle.ts
+++ b/assets/src/data/persistence/page_lifecycle.ts
@@ -5,6 +5,7 @@ export type ActionSuccess = {
   result: 'success';
   commandResult: 'success';
   redirectTo: string;
+  restartUrl?: string;
 };
 
 export type ActionFailure = {
@@ -12,6 +13,7 @@ export type ActionFailure = {
   commandResult: 'failure';
   reason: string;
   redirectTo: string;
+  restartUrl?: string;
 };
 
 export type ActionResult = ActionSuccess | ActionFailure;


### PR DESCRIPTION
When choosing the restart option on graded adaptive lesson pages, the learner was brought to the review page instead of giving the option to start a new attempt as intended. They will now be sent to the "start attempt" page. (Note: If they have exceeded the maximum number of retries, they can not start a new attempt)

On an ungraded page, the learner is brought to the start of the adaptive lesson with no "start attempt" page as expected.

Also made some minor UI tweaks to the restart dialog:

1. Made it 80% width so it looks like a dialog again
2. Made the entire "ok" button clickable instead of just the text
3. Added "restarting..." feedback since it can take a few seconds and the learner might click "OK" multiple times.