### PR TITLE
[MER-2055] Fix student sorting

### DIFF
--- a/assets/css/table.css
+++ b/assets/css/table.css
@@ -57,12 +57,24 @@
   @apply border-r-0 border-l-0;
 }
 
-.instructor_dashboard_table tr:has(div[data-score-check='false']) {
-  @apply bg-red-200 bg-opacity-20 dark:bg-opacity-100 dark:text-gray-800;
+.instructor_dashboard_table tr:has(div[data-score-check='false']) td {
+  @apply bg-red-100 dark:bg-opacity-100 dark:text-gray-800;
 }
 
-.instructor_dashboard_table tr:has(a[data-score-check='false']) {
-  @apply bg-red-200 bg-opacity-20 dark:bg-opacity-100 dark:text-gray-800;
+.instructor_dashboard_table tr:has(div[data-score-check='true']) td {
+  @apply bg-white dark:bg-neutral-800 dark:text-white;
+}
+
+.instructor_dashboard_table tr:has(div[data-score-check='true']) td a {
+  @apply bg-white dark:bg-neutral-800 dark:text-white;
+}
+
+.instructor_dashboard_table tr:has(a[data-score-check='false']) td {
+  @apply bg-red-100 dark:bg-opacity-100 dark:text-gray-800;
+}
+
+.instructor_dashboard_table tr:has(a[data-score-check='true']) td {
+  @apply bg-white dark:bg-neutral-800 dark:text-white;
 }
 
 .instructor_dashboard_table td:has(div.highlight-exception) {

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -149,10 +149,20 @@ defmodule Oli.Delivery.Sections do
       })
 
     case field do
-      :enrollment_date -> order_by(query, [_, e, _], {^direction, e.inserted_at})
-      :payment_date -> order_by(query, [_, _, p], {^direction, p.application_date})
-      :payment_id -> order_by(query, [_, _, p], {^direction, p.id})
-      _ -> order_by(query, [u, _, _], {^direction, field(u, ^field)})
+      :enrollment_date ->
+        order_by(query, [_, e, _], {^direction, e.inserted_at})
+
+      :payment_date ->
+        order_by(query, [_, _, p], {^direction, p.application_date})
+
+      :payment_id ->
+        order_by(query, [_, _, p], {^direction, p.id})
+
+      :name ->
+        order_by(query, [u, _, _], [{^direction, u.family_name}, {^direction, u.given_name}])
+
+      _ ->
+        order_by(query, [u, _, _], {^direction, field(u, ^field)})
     end
   end
 
@@ -2674,7 +2684,6 @@ defmodule Oli.Delivery.Sections do
         # If the current objective has one or more parents, render their parents
         parent_objectives ++ acc
       end
-
     end)
     |> Enum.uniq_by(&{&1.objective_resource_id, &1.subobjective_resource_id})
     |> Enum.map(fn obj ->
@@ -2783,14 +2792,14 @@ defmodule Oli.Delivery.Sections do
         )
       )
 
-
     # This is map used to get the name of a module's parent unit title
     # so that we can display a module as "Unit Title / Module Title"
     # instead of just "Module Title"
 
-    parent_title_map = Enum.reduce(all, %{}, fn %{children: children} = elem, map ->
-      Enum.reduce(children, map, fn child, map -> Map.put(map, child, elem.title) end)
-    end)
+    parent_title_map =
+      Enum.reduce(all, %{}, fn %{children: children} = elem, map ->
+        Enum.reduce(children, map, fn child, map -> Map.put(map, child, elem.title) end)
+      end)
 
     Enum.map(all, fn %{children: children} = elem ->
       children_from_children =
@@ -2803,7 +2812,6 @@ defmodule Oli.Delivery.Sections do
       elem = %{elem | children: children ++ children_from_children}
 
       if elem.level == 2 do
-
         # Determine the parent unit title, in a robust way that works even if the
         # somehow the module is not contained in a unit
         parent_title = Map.get(parent_title_map, elem.container_id, "Unknown")

--- a/lib/oli_web/components/delivery/content/content_table_model.ex
+++ b/lib/oli_web/components/delivery/content/content_table_model.ex
@@ -8,26 +8,23 @@ defmodule OliWeb.Components.Delivery.ContentTableModel do
       %ColumnSpec{
         name: :numbering_index,
         label: "ORDER",
-        th_class: "pl-10 instructor_dashboard_th",
+        th_class: "pl-10",
         td_class: "pl-10"
       },
       %ColumnSpec{
         name: :container_name,
         label: container_column_name,
-        render_fn: &__MODULE__.render_name_column/3,
-        th_class: "instructor_dashboard_th"
+        render_fn: &__MODULE__.render_name_column/3
       },
       %ColumnSpec{
         name: :student_completion,
         label: "STUDENT COMPLETION",
-        render_fn: &__MODULE__.render_student_completion/3,
-        th_class: "instructor_dashboard_th"
+        render_fn: &__MODULE__.render_student_completion/3
       },
       %ColumnSpec{
         name: :student_proficiency,
         label: "STUDENT PROFICIENCY",
-        render_fn: &__MODULE__.render_student_proficiency/3,
-        th_class: "instructor_dashboard_th"
+        render_fn: &__MODULE__.render_student_proficiency/3
       }
     ]
 

--- a/lib/oli_web/components/delivery/learning_objectives/objectives_table_model.ex
+++ b/lib/oli_web/components/delivery/learning_objectives/objectives_table_model.ex
@@ -15,23 +15,20 @@ defmodule OliWeb.Delivery.LearningObjectives.ObjectivesTableModel do
         name: :objective,
         label: "LEARNING OBJECTIVE",
         render_fn: &__MODULE__.custom_render/3,
-        th_class: "pl-10 instructor_dashboard_th"
+        th_class: "pl-10"
       },
       %ColumnSpec{
         name: :subobjective,
         label: "SUB LEARNING OBJ.",
-        render_fn: &__MODULE__.custom_render/3,
-        th_class: "instructor_dashboard_th"
+        render_fn: &__MODULE__.custom_render/3
       },
       %ColumnSpec{
         name: :student_proficiency_obj,
-        label: "STUDENT PROFICIENCY OBJ.",
-        th_class: "instructor_dashboard_th"
+        label: "STUDENT PROFICIENCY OBJ."
       },
       %ColumnSpec{
         name: :student_proficiency_subobj,
-        label: "STUDENT PROFICIENCY (SUB OBJ.)",
-        th_class: "instructor_dashboard_th"
+        label: "STUDENT PROFICIENCY (SUB OBJ.)"
       }
     ]
 

--- a/lib/oli_web/live/grades/gradebook_table_model.ex
+++ b/lib/oli_web/live/grades/gradebook_table_model.ex
@@ -32,7 +32,7 @@ defmodule OliWeb.Grades.GradebookTableModel do
           name: :name,
           label: "STUDENT NAME",
           render_fn: &__MODULE__.render_student/3,
-          th_class: "pl-10 whitespace-nowrap !sticky left-0 z-10 instructor_dashboard_th",
+          th_class: "pl-10 whitespace-nowrap !sticky left-0 z-10",
           td_class: "sticky left-0 z-10"
         }
       ] ++
@@ -41,7 +41,7 @@ defmodule OliWeb.Grades.GradebookTableModel do
             name: revision.resource_id,
             label: String.upcase(revision.title),
             render_fn: &__MODULE__.render_score/3,
-            th_class: "instructor_dashboard_th whitespace-nowrap",
+            th_class: "whitespace-nowrap",
             sortable: false
           }
         end)
@@ -61,13 +61,13 @@ defmodule OliWeb.Grades.GradebookTableModel do
         name: :name,
         label: "Quiz",
         render_fn: &__MODULE__.render_grade/3,
-        th_class: "pl-10 instructor_dashboard_th"
+        th_class: "pl-10"
       },
       %ColumnSpec{
         name: :score,
         label: "Score",
         render_fn: &__MODULE__.render_grade_score/3,
-        th_class: "pl-10 instructor_dashboard_th",
+        th_class: "pl-10",
         sortable: false
       }
     ]

--- a/lib/oli_web/live/grades/gradebook_table_model.ex
+++ b/lib/oli_web/live/grades/gradebook_table_model.ex
@@ -32,7 +32,8 @@ defmodule OliWeb.Grades.GradebookTableModel do
           name: :name,
           label: "STUDENT NAME",
           render_fn: &__MODULE__.render_student/3,
-          th_class: "pl-10 instructor_dashboard_th"
+          th_class: "pl-10 whitespace-nowrap !sticky left-0 z-10 instructor_dashboard_th",
+          td_class: "sticky left-0 z-10"
         }
       ] ++
         Enum.map(graded_pages, fn revision ->
@@ -40,7 +41,7 @@ defmodule OliWeb.Grades.GradebookTableModel do
             name: revision.resource_id,
             label: String.upcase(revision.title),
             render_fn: &__MODULE__.render_score/3,
-            th_class: "instructor_dashboard_th",
+            th_class: "instructor_dashboard_th whitespace-nowrap",
             sortable: false
           }
         end)
@@ -92,6 +93,7 @@ defmodule OliWeb.Grades.GradebookTableModel do
     perc = score(row.score) / out_of_score(row.out_of) * 100
     has_score? = row.score != nil
     was_late = row.was_late
+
     ~F"""
       <a
         class={"ml-8 #{if has_score? and perc < 40, do: "text-red-500", else: "text-black"}"}

--- a/lib/oli_web/live/sections/assessment_settings/settings_table_model.ex
+++ b/lib/oli_web/live/sections/assessment_settings/settings_table_model.ex
@@ -9,82 +9,81 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTableModel do
       %ColumnSpec{
         name: :index,
         label: "#",
-        th_class:
-          "pl-10 instructor_dashboard_th !sticky left-0 bg-white z-10 whitespace-nowrap w-20",
+        th_class: "pl-10 !sticky left-0 bg-white z-10 whitespace-nowrap w-20",
         td_class: "sticky pl-11 left-0 bg-white dark:bg-neutral-800 z-10 whitespace-nowrap w-20"
       },
       %ColumnSpec{
         name: :name,
         label: "ASSESSMENT",
         render_fn: &__MODULE__.render_assessment_column/3,
-        th_class: "instructor_dashboard_th !sticky left-20 bg-white z-10",
+        th_class: "!sticky left-20 bg-white z-10",
         td_class: "sticky left-20 bg-white dark:bg-neutral-800 z-10 whitespace-nowrap"
       },
       %ColumnSpec{
         name: :due_date,
         label: "DUE DATE",
         render_fn: &__MODULE__.render_due_date_column/3,
-        th_class: "instructor_dashboard_th whitespace-nowrap"
+        th_class: "whitespace-nowrap"
       },
       %ColumnSpec{
         name: :max_attempts,
         label: "# ATTEMPTS",
         render_fn: &__MODULE__.render_attempts_column/3,
-        th_class: "instructor_dashboard_th whitespace-nowrap"
+        th_class: "whitespace-nowrap"
       },
       %ColumnSpec{
         name: :time_limit,
         label: "TIME LIMIT",
         render_fn: &__MODULE__.render_time_limit_column/3,
-        th_class: "instructor_dashboard_th whitespace-nowrap"
+        th_class: "whitespace-nowrap"
       },
       %ColumnSpec{
         name: :late_submit,
         label: "LATE SUBMIT",
         render_fn: &__MODULE__.render_late_submit_column/3,
-        th_class: "instructor_dashboard_th whitespace-nowrap"
+        th_class: "whitespace-nowrap"
       },
       %ColumnSpec{
         name: :late_start,
         label: "LATE START",
         render_fn: &__MODULE__.render_late_start_column/3,
-        th_class: "instructor_dashboard_th whitespace-nowrap"
+        th_class: "whitespace-nowrap"
       },
       %ColumnSpec{
         name: :scoring_strategy_id,
         label: "SCORING",
         render_fn: &__MODULE__.render_scoring_column/3,
-        th_class: "instructor_dashboard_th whitespace-nowrap"
+        th_class: "whitespace-nowrap"
       },
       %ColumnSpec{
         name: :grace_period,
         label: "GRACE PERIOD",
         render_fn: &__MODULE__.render_grace_period_column/3,
-        th_class: "instructor_dashboard_th whitespace-nowrap"
+        th_class: "whitespace-nowrap"
       },
       %ColumnSpec{
         name: :retake_mode,
         label: "RETAKE MODE",
         render_fn: &__MODULE__.render_retake_mode_column/3,
-        th_class: "instructor_dashboard_th whitespace-nowrap"
+        th_class: "whitespace-nowrap"
       },
       %ColumnSpec{
         name: :feedback_mode,
         label: "VIEW FEEDBACK",
         render_fn: &__MODULE__.render_view_feedback_column/3,
-        th_class: "instructor_dashboard_th whitespace-nowrap"
+        th_class: "whitespace-nowrap"
       },
       %ColumnSpec{
         name: :review_submission,
         label: "VIEW ANSWERS",
         render_fn: &__MODULE__.render_view_answers_column/3,
-        th_class: "instructor_dashboard_th whitespace-nowrap"
+        th_class: "whitespace-nowrap"
       },
       %ColumnSpec{
         name: :exceptions_count,
         label: "EXCEPTIONS",
         render_fn: &__MODULE__.render_exceptions_column/3,
-        th_class: "instructor_dashboard_th whitespace-nowrap"
+        th_class: "whitespace-nowrap"
       }
     ]
 

--- a/lib/oli_web/live/sections/assessment_settings/student_exceptions_table_model.ex
+++ b/lib/oli_web/live/sections/assessment_settings/student_exceptions_table_model.ex
@@ -17,69 +17,68 @@ defmodule OliWeb.Sections.AssessmentSettings.StudentExceptionsTableModel do
         name: :student,
         label: "STUDENT",
         render_fn: &__MODULE__.render_student_column/3,
-        th_class:
-          "pl-10 instructor_dashboard_th !sticky left-0 bg-white dark:bg-neutral-800 z-10",
+        th_class: "pl-10 !sticky left-0 bg-white dark:bg-neutral-800 z-10",
         td_class: "sticky left-0 bg-white dark:bg-neutral-800 z-10 whitespace-nowrap"
       },
       %ColumnSpec{
         name: :due_date,
         label: "DUE DATE",
         render_fn: &__MODULE__.render_due_date_column/3,
-        th_class: "instructor_dashboard_th whitespace-nowrap"
+        th_class: "whitespace-nowrap"
       },
       %ColumnSpec{
         name: :max_attempts,
         label: "# ATTEMPTS",
         render_fn: &__MODULE__.render_attempts_column/3,
-        th_class: "instructor_dashboard_th whitespace-nowrap"
+        th_class: "whitespace-nowrap"
       },
       %ColumnSpec{
         name: :time_limit,
         label: "TIME LIMIT",
         render_fn: &__MODULE__.render_time_limit_column/3,
-        th_class: "instructor_dashboard_th whitespace-nowrap"
+        th_class: "whitespace-nowrap"
       },
       %ColumnSpec{
         name: :late_submit,
         label: "LATE SUBMIT",
         render_fn: &__MODULE__.render_late_submit_column/3,
-        th_class: "instructor_dashboard_th whitespace-nowrap"
+        th_class: "whitespace-nowrap"
       },
       %ColumnSpec{
         name: :late_start,
         label: "LATE START",
         render_fn: &__MODULE__.render_late_start_column/3,
-        th_class: "instructor_dashboard_th whitespace-nowrap"
+        th_class: "whitespace-nowrap"
       },
       %ColumnSpec{
         name: :scoring_strategy_id,
         label: "SCORING",
         render_fn: &__MODULE__.render_scoring_column/3,
-        th_class: "instructor_dashboard_th whitespace-nowrap"
+        th_class: "whitespace-nowrap"
       },
       %ColumnSpec{
         name: :grace_period,
         label: "GRACE PERIOD",
         render_fn: &__MODULE__.render_grace_period_column/3,
-        th_class: "instructor_dashboard_th whitespace-nowrap"
+        th_class: "whitespace-nowrap"
       },
       %ColumnSpec{
         name: :retake_mode,
         label: "RETAKE MODE",
         render_fn: &__MODULE__.render_retake_mode_column/3,
-        th_class: "instructor_dashboard_th whitespace-nowrap"
+        th_class: "whitespace-nowrap"
       },
       %ColumnSpec{
         name: :feedback_mode,
         label: "VIEW FEEDBACK",
         render_fn: &__MODULE__.render_view_feedback_column/3,
-        th_class: "instructor_dashboard_th whitespace-nowrap"
+        th_class: "whitespace-nowrap"
       },
       %ColumnSpec{
         name: :review_submission,
         label: "VIEW ANSWERS",
         render_fn: &__MODULE__.render_view_answers_column/3,
-        th_class: "instructor_dashboard_th whitespace-nowrap"
+        th_class: "whitespace-nowrap"
       }
     ]
 

--- a/lib/oli_web/live/sections/enrollments_table_model.ex
+++ b/lib/oli_web/live/sections/enrollments_table_model.ex
@@ -19,6 +19,7 @@ defmodule OliWeb.Delivery.Sections.EnrollmentsTableModel do
           name: :name,
           label: "STUDENT NAME",
           render_fn: &__MODULE__.render_name_column/3,
+          sort_fn: &__MODULE__.sort_name_column/2,
           th_class: "pl-10 instructor_dashboard_th"
         },
         %ColumnSpec{
@@ -63,6 +64,15 @@ defmodule OliWeb.Delivery.Sections.EnrollmentsTableModel do
         section: section
       }
     )
+  end
+
+  def sort_name_column(_sort_order, _sort_spec) do
+    {
+      fn item -> item end,
+      fn row1, row2 ->
+        Utils.name(row1.name, row1.given_name, row1.family_name) <= Utils.name(row2.name, row2.given_name, row2.family_name)
+      end
+    }
   end
 
   def render_name_column(

--- a/lib/oli_web/live/sections/enrollments_table_model.ex
+++ b/lib/oli_web/live/sections/enrollments_table_model.ex
@@ -20,25 +20,22 @@ defmodule OliWeb.Delivery.Sections.EnrollmentsTableModel do
           label: "STUDENT NAME",
           render_fn: &__MODULE__.render_name_column/3,
           sort_fn: &__MODULE__.sort_name_column/2,
-          th_class: "pl-10 instructor_dashboard_th"
+          th_class: "pl-10"
         },
         %ColumnSpec{
           name: :last_interaction,
           label: "LAST INTERACTED",
-          render_fn: &__MODULE__.render_last_interaction_column/3,
-          th_class: "instructor_dashboard_th"
+          render_fn: &__MODULE__.render_last_interaction_column/3
         },
         %ColumnSpec{
           name: :progress,
           label: "COURSE PROGRESS",
-          render_fn: &__MODULE__.render_progress_column/3,
-          th_class: "instructor_dashboard_th"
+          render_fn: &__MODULE__.render_progress_column/3
         },
         %ColumnSpec{
           name: :overall_proficiency,
           label: "OVERALL COURSE PROFICIENCY",
-          render_fn: &__MODULE__.render_overall_proficiency_column/3,
-          th_class: "instructor_dashboard_th"
+          render_fn: &__MODULE__.render_overall_proficiency_column/3
         }
       ] ++
         if section.requires_payment do
@@ -46,8 +43,7 @@ defmodule OliWeb.Delivery.Sections.EnrollmentsTableModel do
             %ColumnSpec{
               name: :payment_status,
               label: "PAYMENT STATUS",
-              render_fn: &__MODULE__.render_payment_status/3,
-              th_class: "instructor_dashboard_th"
+              render_fn: &__MODULE__.render_payment_status/3
             }
           ]
         else
@@ -70,7 +66,8 @@ defmodule OliWeb.Delivery.Sections.EnrollmentsTableModel do
     {
       fn item -> item end,
       fn row1, row2 ->
-        Utils.name(row1.name, row1.given_name, row1.family_name) <= Utils.name(row2.name, row2.given_name, row2.family_name)
+        Utils.name(row1.name, row1.given_name, row1.family_name) <=
+          Utils.name(row2.name, row2.given_name, row2.family_name)
       end
     }
   end

--- a/test/oli_web/live/delivery/instructor_dashboard/reports/quiz_scores_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/reports/quiz_scores_tab_test.exs
@@ -149,10 +149,12 @@ defmodule OliWeb.Delivery.InstructorDashboard.QuizScoreTabTest do
       instructor: instructor,
       section: section
     } do
-      student = insert(:user, %{family_name: "Example", given_name: "Student1"})
-      student_2 = insert(:user, %{family_name: "Example", given_name: "Student2"})
-      Sections.enroll(student.id, section.id, [ContextRoles.get_role(:context_learner)])
+      student_1 = insert(:user, %{family_name: "Smith", given_name: "Adam"})
+      student_2 = insert(:user, %{family_name: "Lee", given_name: "Bob"})
+      student_3 = insert(:user, %{family_name: "Zisk", given_name: "Tom"})
+      Sections.enroll(student_1.id, section.id, [ContextRoles.get_role(:context_learner)])
       Sections.enroll(student_2.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.enroll(student_3.id, section.id, [ContextRoles.get_role(:context_learner)])
       Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
 
       params = %{
@@ -162,12 +164,16 @@ defmodule OliWeb.Delivery.InstructorDashboard.QuizScoreTabTest do
       {:ok, view, _html} = live(conn, live_view_quiz_scores_route(section.slug, params))
 
       assert view
-             |> element("table.instructor_dashboard_table > tbody > tr:first-child")
-             |> render() =~ student_2.family_name
+             |> element("table.instructor_dashboard_table > tbody > tr:nth-child(1)")
+             |> render() =~ student_3.family_name
 
       assert view
              |> element("table.instructor_dashboard_table > tbody > tr:nth-child(2)")
-             |> render() =~ student.family_name
+             |> render() =~ student_1.family_name
+
+      assert view
+             |> element("table.instructor_dashboard_table > tbody > tr:nth-child(3)")
+             |> render() =~ student_2.family_name
     end
 
     test "applies pagination", %{

--- a/test/oli_web/live/delivery/instructor_dashboard/reports/students_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/reports/students_tab_test.exs
@@ -172,7 +172,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.StudentsTabTest do
 
       ### sorting by student
       params = %{
-        sort_order: :asc,
+        sort_order: :desc,
         sort_by: :name
       }
 
@@ -185,10 +185,10 @@ defmodule OliWeb.Delivery.InstructorDashboard.StudentsTabTest do
         |> Floki.find(~s{.instructor_dashboard_table tr a})
         |> Enum.map(fn a_tag -> Floki.text(a_tag) end)
 
-      assert student_for_tr_1 =~ "Di Maria, Angelito"
-      assert student_for_tr_2 =~ "Jr, Neymar"
-      assert student_for_tr_3 =~ "Messi, Lionel"
-      assert student_for_tr_4 =~ "Suarez, Luis"
+      assert student_for_tr_4 =~ "Di Maria, Angelito"
+      assert student_for_tr_3 =~ "Jr, Neymar"
+      assert student_for_tr_2 =~ "Messi, Lionel"
+      assert student_for_tr_1 =~ "Suarez, Luis"
 
       ### text filtering
       params = %{


### PR DESCRIPTION
[Link ](https://eliterate.atlassian.net/browse/MER-2055)to the ticket


https://github.com/Simon-Initiative/oli-torus/assets/74839302/7f8dc1f4-f2de-4254-82f4-608bd6c49fe0

This PR also improves the styling for the quiz scores tab, for the case where we have an x overflow (including dark mode).

#### Before

https://github.com/Simon-Initiative/oli-torus/assets/74839302/a8192c83-7111-4d4d-a9b4-6d71dfbb7db7

#### After

https://github.com/Simon-Initiative/oli-torus/assets/74839302/110140be-3b23-42c4-8b60-6c10d42d4455


Finally, the `instructor_dashboard_th` class was removed from many tables, since it was not defined in any `.css` file and had no effect at all. 