### PR TITLE
[BUG FIX] Correctly handle no effective end date cases [MER-2308]

### DIFF
--- a/lib/oli/delivery/settings.ex
+++ b/lib/oli/delivery/settings.ex
@@ -94,8 +94,10 @@ defmodule Oli.Delivery.Settings do
   end
 
   def was_late?(%ResourceAttempt{} = resource_attempt, %Combined{} = effective_settings, now) do
-    DateTime.compare(now, determine_effective_deadline(resource_attempt, effective_settings)) ==
-      :gt
+    case determine_effective_deadline(resource_attempt, effective_settings) do
+      nil -> false
+      effective_deadline -> DateTime.compare(now, effective_deadline) == :gt
+    end
   end
 
   @doc """
@@ -139,9 +141,13 @@ defmodule Oli.Delivery.Settings do
         %ResourceAttempt{} = resource_attempt,
         %Combined{} = effective_settings
       ) do
-    case {effective_settings.end_date, effective_settings.time_limit} do
+
+    deadline = case {effective_settings.end_date, effective_settings.time_limit} do
       # no end date or time limit, no deadline
       {nil, nil} ->
+        nil
+
+      {nil, 0} ->
         nil
 
       # only a time limit, just add the minutes to the start
@@ -160,7 +166,12 @@ defmodule Oli.Delivery.Settings do
           DateTime.add(resource_attempt.inserted_at, time_limit, :minute)
         end
     end
-    |> DateTime.add(effective_settings.grace_period, :minute)
+
+    case deadline do
+      nil -> nil
+      deadline -> DateTime.add(deadline, effective_settings.grace_period, :minute)
+    end
+
   end
 
   def show_feedback?(%Combined{feedback_mode: :allow}), do: true

--- a/lib/oli_web/components/tag.ex
+++ b/lib/oli_web/components/tag.ex
@@ -5,8 +5,9 @@ defmodule OliWeb.Components.Tag do
   slot :inner_block, required: true
 
   def render(assigns) do
+    assigns = assign(assigns, :class, "bg-#{assigns.color}-500 text-white text-xs font-medium mr-2 px-2.5 py-0.5 rounded dark:bg-#{assigns.color}-500 dark:text-white border border-#{assigns.color}-500")
     ~H"""
-      <span class={"bg-#{@color}-500 text-white text-xs font-medium mr-2 px-2.5 py-0.5 rounded dark:bg-#{@color}-500 dark:text-white border border-#{@color}-500"}>
+      <span class={@class}>
         <%= render_slot(@inner_block) %>
       </span>
     """

--- a/test/oli/delivery/settings_test.exs
+++ b/test/oli/delivery/settings_test.exs
@@ -41,6 +41,19 @@ defmodule Oli.Delivery.SettingsTest do
 
   end
 
+  test "was_late/2 determines lateness correctly when no effective due date" do
+
+    ra = %ResourceAttempt{
+      inserted_at: ~U[2020-01-01 01:00:00Z],
+    }
+    settings_with_no_end_date = %Combined{
+      end_date: nil
+    }
+
+    refute Settings.was_late?(ra, settings_with_no_end_date, DateTime.add(ra.inserted_at, 1, :minute))
+
+  end
+
   test "was_late/2 determines lateness correctly when only a due date" do
 
     ra = %ResourceAttempt{


### PR DESCRIPTION
This PR fixes the handling of graded pages that have no effective end date whatsoever.  All graded pages without end dates and without a time limit were being marked late, but we had no idea until we actually started rendering the "LATE" badge. 

I noticed something strange in my dev environment when implementing this: The "LATE" badge for me now renders (in light mode) without the red background.  It does not seem to be a problem with the Tailwind CSS.  See https://play.tailwindcss.com/mmOHSRLxN3#:~:text=.../-,mmOHSRLxN3,-v3.3.2

Perhaps it is just something strange locally in my dev environment (It is also correct on argos QA).  Please, who ever reviews this PR, verify that the "LATE" badge renders correctly for you. 