### PR TITLE
[BUG FIX] Fix bad map error [MER-2311]

### DIFF
--- a/lib/oli/interop/export.ex
+++ b/lib/oli/interop/export.ex
@@ -101,6 +101,7 @@ defmodule Oli.Interop.Export do
     end)
   end
 
+  defp rewire_activity_elements(nil, _), do: nil
   defp rewire_activity_elements(content_as_list, project) when is_map(content_as_list) do
 
     case Map.get(content_as_list, "content") do

--- a/lib/oli/interop/export.ex
+++ b/lib/oli/interop/export.ex
@@ -101,7 +101,7 @@ defmodule Oli.Interop.Export do
     end)
   end
 
-  defp rewire_activity_elements(content_as_list, project) do
+  defp rewire_activity_elements(content_as_list, project) when is_map(content_as_list) do
 
     case Map.get(content_as_list, "content") do
 
@@ -119,9 +119,9 @@ defmodule Oli.Interop.Export do
         Map.put(content_as_list, "content", content)
 
     end
-
-
   end
+
+  defp rewire_activity_elements(other, _), do: other
 
   defp rewire_elements(content, project) do
     Oli.Resources.PageContent.visit_children(content, {:ok, []}, fn c, {status, []}, _tr_context ->


### PR DESCRIPTION
Fixes a problem that is breaking project export:

lib/map.ex:534 Map.get/3 |  
-- | --
lib/oli/interop/export.ex:106 Oli.Interop.Export.rewire_activity_elements/2 |  
lib/oli/interop/export.ex:176 anonymous fn/2 in Oli.Interop.Export.rewire_activity_content/2 |  
lib/enum.ex:1658 Enum."-map/2-lists^map/1-0-"/2 |  
lib/oli/interop/export.ex:173 Oli.Interop.Export.rewire_activity_content/2 |  
lib/oli/interop/export.ex:88 anony

