### PR TITLE
[BUGFIX] Revert formula font size [MER-2304]

### DIFF
--- a/assets/styles/common/elements.scss
+++ b/assets/styles/common/elements.scss
@@ -325,7 +325,7 @@ $element-margin-bottom: 1.5em;
   .formula {
     /* The mathjax formulas were rendering out much larger than the surrounding text, so we're scaling them down to better match the
        legacy content, but the callouts should not be scaled down since that made them look too small. */
-    font-size: 0.7em;
+    font-size: 0.9em;
   }
 
   .callout-block,


### PR DESCRIPTION
This reverts the formula sizing to 0.9REM

Here is a comparison between formula & paragraph sizing:
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/c01e99e8-4cb5-4727-bd6c-106ccdacbb04)


Some consequences:

Chemistry "Mole Conversions: Multi-step"
At a wide screen width:
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/75b21c54-7e55-43f3-a994-8234fa490641)
At a narrow screen width:
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/c9ebc5c4-37a9-438f-a479-7f9b6bd1c30c)




