### PR TITLE
[BUG FIX] Fix auto submit [MER-2253]

### DIFF
--- a/lib/oli/delivery/attempts/page_lifecycle/grade_update_worker.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/grade_update_worker.ex
@@ -120,7 +120,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.GradeUpdateWorker do
     |> Keyword.get(:host)
   end
 
-  defp access_token_provider(section) do
+  def access_token_provider(section) do
     fn ->
       {_deployment, registration} =
         Oli.Delivery.Sections.get_deployment_registration_from_section(section)

--- a/lib/oli/delivery/attempts/page_lifecycle/graded.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/graded.ex
@@ -93,8 +93,8 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Graded do
 
     case Oli.Delivery.Settings.check_end_date(effective_settings) do
       {:allowed} ->
-        case {page_revision.max_attempts > length(resource_attempts) or
-            page_revision.max_attempts == 0, has_any_active_attempts?(resource_attempts)} do
+        case {effective_settings.max_attempts > length(resource_attempts) or
+          effective_settings.max_attempts == 0, has_any_active_attempts?(resource_attempts)} do
           {true, false} ->
 
             {:ok, resource_attempt} = Hierarchy.create(context)
@@ -148,7 +148,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Graded do
                  resource_attempt.was_late
                ) do
             {:ok, resource_access} ->
-              {:ok, _} = Oli.Delivery.Metrics.mark_progress_completed(resource_access)
+              {:ok, resource_access} = Oli.Delivery.Metrics.mark_progress_completed(resource_access)
 
               {:ok,
                %FinalizationSummary{

--- a/lib/oli/delivery/settings.ex
+++ b/lib/oli/delivery/settings.ex
@@ -93,7 +93,9 @@ defmodule Oli.Delivery.Settings do
     |> Repo.one()
   end
 
-  def was_late?(%ResourceAttempt{} = resource_attempt, %Combined{} = effective_settings, now) do
+  def was_late?(_, %Combined{late_submit: :disallow}, _now), do: false
+  def was_late?(%ResourceAttempt{} = resource_attempt, %Combined{late_submit: :allow} = effective_settings, now) do
+
     case determine_effective_deadline(resource_attempt, effective_settings) do
       nil -> false
       effective_deadline -> DateTime.compare(now, effective_deadline) == :gt

--- a/test/oli/delivery/settings_test.exs
+++ b/test/oli/delivery/settings_test.exs
@@ -15,6 +15,20 @@ defmodule Oli.Delivery.SettingsTest do
     assert {:allowed} == Settings.new_attempt_allowed(%Combined{max_attempts: 5, late_start: :allow, end_date: ~U[2020-01-01 00:00:00Z]}, 1, [])
   end
 
+  test "was_late/2 never returns true when late submissions disallowed" do
+
+    ra = %ResourceAttempt{
+      inserted_at: ~U[2020-01-01 00:00:00Z],
+    }
+    settings = %Combined{
+      late_submit: :disallow,
+      time_limit: 1
+    }
+
+    refute Settings.was_late?(ra, settings, DateTime.add(ra.inserted_at, 20, :minute))
+
+  end
+
   test "was_late/2 determines lateness correctly when only a time limit" do
 
     ra = %ResourceAttempt{


### PR DESCRIPTION
This PR appears to fix a very strange bug, where during the execution of an `Oban` auto submit job, other `Oban` jobs cannot be created.  This PR also fixes two other bugs that I discovered during this work:

1. Auto submission via the delayed Oban auto submit job will still mark the attempt as being "LATE".  Auto submit is executed because the instructor has decided for that assessment to not allow late submissions, therefore, no submissions including auto submitted ones should be marked as late.  The fix here was to take into account `late_submit: :disallow` in `Settings.was_late?`. 
2. `page_delivery_controller.ex` code was still using the max number of attempts from the page revision, instead of the effective settings to determine whether or not to allow a user to start a new attempt.  This resulted in situations where the instructor could increase the number of attempts up to 20, but the student would not be able to start an attempt beyond the value found in the page revision (typically 5)

The main issue:

The original report was that grade passback was failing during an auto submission. While testing and debugging this I triggered an auto submit (by creating an assessment with a 1 minute time limit, starting an attempt and then closing the browser).  A couple of minutes later I could see the auto submit job run and logging statements from the DB calls to finalize the attempt.  BUT, I noticed nothing appeared at all in the logs related to the last two steps of this process: snapshot creation AND grade passback.  Even logging messages that I placed after these two steps didn't show up in the logs. Wrapping code with `try catch` yielded nothing. Sometimes I would also see a message in the console that a DBConnection from a particular PID had been closed/dropped. 

After banging my head against this for several hours, I hypothesized that something might be breaking when we were trying to schedule the snapshot creation Oban job (and the grade update worker job) FROM the current auto submit Oban job.  I reworked the auto submit job to synchronously create the snapshots and perform the passback and that immediately allowed things to start working again. 