### PR TITLE
[BUGFIX] Fix server crash when admin/author tries to preview adaptive [MER-2273]

### DIFF
--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -839,8 +839,7 @@ defmodule OliWeb.PageDeliveryController do
             effective_settings =
               Oli.Delivery.Settings.get_combined_settings(
                 revision,
-                section.id,
-                conn.assigns.current_user.id
+                section.id
               )
 
             numbered_revisions = Sections.get_revision_indexes(section.slug)
@@ -856,6 +855,9 @@ defmodule OliWeb.PageDeliveryController do
                 preview_mode: true,
                 previous_page: previous,
                 next_page: next,
+                page_number: 1,
+                graded: false,
+                review_mode: false,
                 numbered_revisions: numbered_revisions,
                 current_page: current,
                 title: revision.title,


### PR DESCRIPTION
When an admin viewed the manage section page and selected "Preview Course as Instructor" then tried to preview an adaptive page, a 500 error would be returned from the server.

They should have received a message saying it's not supported instead. (This intention may need confirmation)

After this change:

1. When logged in as an instructor, preview as instructor of an adaptive page works as expected, with the screen controls.
2. When logged in as an admin and not an instructor in the section, preview as instructor displays a “not supported” message instead of throwing a 500 error.
3. When logged in as an admin AND as an instructor in the section, preview as instructor works as expected, with the screen controls. 

