### PR TITLE
[BUGFIX][MER-2209] Reingest project does not retain objectives hierarchy

### DIFF
--- a/lib/oli/interop/export.ex
+++ b/lib/oli/interop/export.ex
@@ -61,8 +61,8 @@ defmodule Oli.Interop.Export do
         tags: transform_tags(r),
         unresolvedReferences: [],
         content: %{},
-        objectives: [],
-        children: Enum.map(r.children, fn id -> "#{id}" end)
+        objectives: Enum.map(r.children, fn id -> "#{id}" end),
+        children: []
       }
       |> entry("#{r.resource_id}.json")
     end)

--- a/test/oli/interop/digest/22.json
+++ b/test/oli/interop/digest/22.json
@@ -1,11 +1,8 @@
 {
-  "children": [
-    "26",
-    "25"
-  ],
+  "children": [],
   "content": {},
   "id": "22",
-  "objectives": [],
+  "objectives": ["26", "25"],
   "originalFile": "",
   "tags": [],
   "title": "Identify the primary dishes and typical drinks of Galicia",

--- a/test/oli/interop/digest/23.json
+++ b/test/oli/interop/digest/23.json
@@ -1,11 +1,8 @@
 {
-  "children": [
-    "28",
-    "27"
-  ],
+  "children": [],
   "content": {},
   "id": "23",
-  "objectives": [],
+  "objectives": ["28", "27"],
   "originalFile": "",
   "tags": [],
   "title": "Identify the primary dishes and typical drinks of Asturias",

--- a/test/oli/interop/ingest/scalable_ingest_test.exs
+++ b/test/oli/interop/ingest/scalable_ingest_test.exs
@@ -4,6 +4,7 @@ defmodule Oli.Interop.Ingest.ScalableIngestTest do
   alias Oli.Publishing.AuthoringResolver
   alias Oli.Resources.Revision
   alias Oli.Repo
+  alias Oli.Authoring.Editing.ObjectiveEditor
   use Oli.DataCase
 
   def by_title(project, title) do
@@ -93,6 +94,16 @@ defmodule Oli.Interop.Ingest.ScalableIngestTest do
       # verify that the tags were created
       tags = Oli.Publishing.get_unpublished_revisions_by_type(project.slug, "tag")
       assert length(tags) == 2
+
+      # verify that the objectives were created
+      objectives = ObjectiveEditor.fetch_objective_mappings(project)
+      assert length(objectives) == 7
+
+      # we have 2 objectives that have children so we check that it's correct
+      assert Enum.reduce(objectives, 0, fn obj, acc ->
+               if length(obj.revision.children) > 0, do: acc + 1, else: acc
+             end)
+             |> Kernel.===(2)
 
       # verify correct number of hierarchy elements were created
       containers = Oli.Publishing.get_unpublished_revisions_by_type(project.slug, "container")

--- a/test/oli/interop/ingest_test.exs
+++ b/test/oli/interop/ingest_test.exs
@@ -4,6 +4,7 @@ defmodule Oli.Interop.IngestTest do
   alias Oli.Publishing.AuthoringResolver
   alias Oli.Resources.Revision
   alias Oli.Repo
+  alias Oli.Authoring.Editing.ObjectiveEditor
   use Oli.DataCase
 
   def by_title(project, title) do
@@ -97,6 +98,16 @@ defmodule Oli.Interop.IngestTest do
       # verify that the tags were created
       tags = Oli.Publishing.get_unpublished_revisions_by_type(project.slug, "tag")
       assert length(tags) == 2
+
+      # verify that the objectives were created
+      objectives = ObjectiveEditor.fetch_objective_mappings(project)
+      assert length(objectives) == 7
+
+      # we have 2 objectives that have children so we check that it's correct
+      assert Enum.reduce(objectives, 0, fn obj, acc ->
+               if length(obj.revision.children) > 0, do: acc + 1, else: acc
+             end)
+             |> Kernel.===(2)
 
       # verify correct number of hierarchy elements were created
       containers = Oli.Publishing.get_unpublished_revisions_by_type(project.slug, "container")


### PR DESCRIPTION
[MER-2209](https://eliterate.atlassian.net/browse/MER-2209)

This PR fixes the issue that happened when ingest a project and build the objectives hierarchy. 

With this fix, the objectives and their sub-objectives added to the ingested project are rendered correctly as their hierarchy specifies.

- **Ingest Project**

https://github.com/Simon-Initiative/oli-torus/assets/16328384/ed0c0a44-f882-4574-b5c5-bffbdb5f943a

- **V2 Ingest Project**

https://github.com/Simon-Initiative/oli-torus/assets/16328384/5b9b2a0a-90a0-432a-bc79-43bfeeb75c4a



[MER-2209]: https://eliterate.atlassian.net/browse/MER-2209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ