### PR TITLE
[BUG FIX] [MER-2312] Enter course as student doesn't work

### DIFF
--- a/lib/oli_web/components/delivery/user_account_menu.ex
+++ b/lib/oli_web/components/delivery/user_account_menu.ex
@@ -3,6 +3,7 @@ defmodule OliWeb.Components.Delivery.UserAccountMenu do
 
   import OliWeb.Components.Delivery.Utils
 
+  alias Oli.Accounts.{Author, SystemRole}
   alias OliWeb.Router.Helpers, as: Routes
   alias Oli.Delivery.Sections
   alias OliWeb.Common.SessionContext
@@ -57,7 +58,7 @@ defmodule OliWeb.Components.Delivery.UserAccountMenu do
       %{
         signin:
           Routes.delivery_path(OliWeb.Endpoint, :signin, section: maybe_section_slug(assigns)),
-        signout: Routes.session_path(OliWeb.Endpoint, :signout, type: :user),
+        signout: signout_path(assigns.ctx),
         projects: Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.ProjectsLive),
         linkAccount: Routes.delivery_path(OliWeb.Endpoint, :link_account),
         editAccount: Routes.pow_registration_path(OliWeb.Endpoint, :edit),
@@ -105,5 +106,17 @@ defmodule OliWeb.Components.Delivery.UserAccountMenu do
         </button>
       </div>
     """
+  end
+
+  defp signout_path(%SessionContext{user: user_or_admin}) do
+    admin_role_id = SystemRole.role_id().admin
+
+    case user_or_admin do
+      %Author{system_role_id: ^admin_role_id} ->
+        Routes.authoring_session_path(OliWeb.Endpoint, :signout, type: :author)
+
+      _ ->
+        Routes.session_path(OliWeb.Endpoint, :signout, type: :user)
+    end
   end
 end

--- a/lib/oli_web/live/common/properties/read_only.ex
+++ b/lib/oli_web/live/common/properties/read_only.ex
@@ -3,10 +3,11 @@ defmodule OliWeb.Common.Properties.ReadOnly do
 
   alias Surface.Components.Link
 
-  prop label, :string, required: true
-  prop value, :string, required: true
-  prop type, :string, default: "text"
-  prop link_label, :string
+  prop(label, :string, required: true)
+  prop(value, :string, required: true)
+  prop(type, :string, default: "text")
+  prop(show_copy_btn, :boolean, default: false)
+  prop(link_label, :string)
 
   def render(assigns) do
     ~F"""
@@ -20,6 +21,21 @@ defmodule OliWeb.Common.Properties.ReadOnly do
   defp render_property(%{type: "link"} = assigns) do
     ~F"""
     <Link label={@link_label} to={@value} class="form-control"/>
+    """
+  end
+
+  defp render_property(%{show_copy_btn: true} = assigns) do
+    copy_id = "copy-#{UUID.uuid4(:hex)}"
+
+    ~F"""
+    <div class="relative">
+      <input id={copy_id} class="form-control" type={@type} disabled value={@value}/>
+      <div class="absolute inset-y-0 right-0 flex items-center">
+        <button id={"#{copy_id}-button"} class="h-full rounded-md border-0 bg-transparent py-0 px-2 text-gray-500 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm" data-clipboard-target={"##{copy_id}"} phx-hook="CopyListener">
+          <i class="fa-regular fa-clipboard"></i> Copy
+        </button>
+      </div>
+    </div>
     """
   end
 

--- a/lib/oli_web/live/new_course/select_source.ex
+++ b/lib/oli_web/live/new_course/select_source.ex
@@ -151,7 +151,7 @@ defmodule OliWeb.Delivery.NewCourse.SelectSource do
             <a
               href={Routes.delivery_path(OliWeb.Endpoint, :link_account)}
               target="_blank"
-              class="btn btn-primary link-account"
+              class="btn btn-primary link-account inline-block my-2"
             >Link Authoring Account</a>
           </div>
         </div>

--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -119,7 +119,7 @@ defmodule OliWeb.Sections.OverviewView do
         <ReadOnly label="Course Section ID" value={@section.slug} />
         <ReadOnly label="Title" value={@section.title} />
         <ReadOnly label="Course Section Type" value={type_to_string(@section)} />
-        <ReadOnly label="URL" value={Routes.page_delivery_url(OliWeb.Endpoint, :index, @section.slug)} />
+        <ReadOnly label="URL" show_copy_btn={true} value={Routes.page_delivery_url(OliWeb.Endpoint, :index, @section.slug)} />
         {#unless is_nil(deployment)}
           <ReadOnly
             label="Institution"
@@ -155,15 +155,10 @@ defmodule OliWeb.Sections.OverviewView do
           <li>
             <a
               target="_blank"
-              href={Routes.instructor_dashboard_path(OliWeb.Endpoint, :preview, @section.slug, :overview)}
+              href={Routes.page_delivery_path(OliWeb.Endpoint, :index_preview, @section.slug)}
               class="btn btn-link"
             ><span>Preview Course as Instructor</span> <i class="fas fa-external-link-alt self-center ml-1" /></a>
           </li>
-          <li><a
-              href={Routes.page_delivery_path(OliWeb.Endpoint, :index, @section.slug)}
-              class="btn btn-link"
-              target="_blank"
-            ><span>Enter Course as a Student</span> <i class="fas fa-external-link-alt self-center ml-1" /></a></li>
           <li><a
               href={Routes.live_path(OliWeb.Endpoint, OliWeb.Delivery.RemixSection, @section.slug)}
               class="btn btn-link"

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -997,7 +997,7 @@ defmodule OliWeb.Router do
       :pow_email_layout
     ])
 
-    live("/:section_slug", Sections.OverviewView)
+    get("/:section_slug", PageDeliveryController, :index)
 
     live("/:section_slug/grades/lms", Grades.GradesLive)
     live("/:section_slug/grades/lms_grade_updates", Grades.BrowseUpdatesView)

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -997,7 +997,7 @@ defmodule OliWeb.Router do
       :pow_email_layout
     ])
 
-    get("/:section_slug", PageDeliveryController, :index)
+    live("/:section_slug", Sections.OverviewView)
 
     live("/:section_slug/grades/lms", Grades.GradesLive)
     live("/:section_slug/grades/lms_grade_updates", Grades.BrowseUpdatesView)

--- a/lib/oli_web/templates/delivery/getting_started.html.eex
+++ b/lib/oli_web/templates/delivery/getting_started.html.eex
@@ -5,6 +5,7 @@
   <div class="mt-5 max-w-md mx-auto p-2">
       <img class="card-img my-2 mx-auto" src="/images/icons/icon-copy.svg" alt="Standard Quick Start icon">
       <p>Click Start to select a base curriculum for your course. After you complete section setup, you can customize or add to the contents of your course.</p>
-      <a href="<%= Routes.select_source_path(OliWeb.Endpoint, :lms_instructor) %>" class="btn btn-outline-primary">Start</a>
+      <a href="<%= Routes.select_source_path(OliWeb.Endpoint, :lms_instructor) %>" class="btn
+      btn-outline-primary inline-block my-2">Start</a>
   </div>
 </div>

--- a/test/oli_web/live/sections/overview_live_test.exs
+++ b/test/oli_web/live/sections/overview_live_test.exs
@@ -180,14 +180,8 @@ defmodule OliWeb.Sections.OverviewLiveTest do
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.instructor_dashboard_path(OliWeb.Endpoint, :preview, section.slug, :overview)}\"]",
+               "a[href=\"#{Routes.page_delivery_path(OliWeb.Endpoint, :index_preview, section.slug)}\"]",
                "Preview Course as Instructor"
-             )
-
-      assert has_element?(
-               view,
-               "a[href=\"#{Routes.page_delivery_path(OliWeb.Endpoint, :index, section.slug)}\"]",
-               "Enter Course as a Student"
              )
 
       assert has_element?(
@@ -414,7 +408,7 @@ defmodule OliWeb.Sections.OverviewLiveTest do
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.instructor_dashboard_path(OliWeb.Endpoint, :preview, section.slug, :overview)}\"]",
+               "a[href=\"#{Routes.page_delivery_path(OliWeb.Endpoint, :index_preview, section.slug)}\"]",
                "Preview Course as Instructor"
              )
     end


### PR DESCRIPTION
There were a couple issues related to manage links to Preview as instructor and Enter course as student around the different roles in the system. This PR attempts to fix those issues by:

1. "Preview as Instructor" always takes Instructors and System Admins to the instructor preview overview
2. Removes "Enter course as student" link, as this was not useful to instructors or system admins
3. Fixes a couple other issues identified through testing:
  - Sign out was broken for system admins in instructor dashboard
  - Various buttons were siblings with block elements, making margins not render correctly 

<img width="1578" alt="Screenshot 2023-07-12 at 1 06 03 PM" src="https://github.com/Simon-Initiative/oli-torus/assets/6248894/3681fdc8-d46c-442b-8dcf-21395eecf456">

As a side note: the copy button does not work inside LTI iframes, as it would require a clipboard permission that, at least when tested in canvas, doesn't have.