### PR TITLE
[BUG FIX] use the slug from the session [MER-2317]

### DIFF
--- a/lib/oli_web/live/delivery/manage_source_materials.ex
+++ b/lib/oli_web/live/delivery/manage_source_materials.ex
@@ -36,10 +36,16 @@ defmodule OliWeb.Delivery.ManageSourceMaterials do
   end
 
   def mount(
-        %{"section_slug" => section_slug},
+        params,
         session,
         socket
       ) do
+
+    section_slug = case params do
+      :not_mounted_at_router -> Map.get(session, "section_slug")
+      _ -> Map.get(params, "section_slug")
+    end
+
     case Mount.for(section_slug, session) do
       {:error, e} ->
         Mount.handle_error(socket, {:error, e})

--- a/lib/oli_web/live/delivery/manage_source_materials.ex
+++ b/lib/oli_web/live/delivery/manage_source_materials.ex
@@ -36,8 +36,8 @@ defmodule OliWeb.Delivery.ManageSourceMaterials do
   end
 
   def mount(
-        _params,
-        %{"section_slug" => section_slug} = session,
+        %{"section_slug" => section_slug},
+        session,
         socket
       ) do
     case Mount.for(section_slug, session) do

--- a/lib/oli_web/live/delivery/remix/entry.ex
+++ b/lib/oli_web/live/delivery/remix/entry.ex
@@ -38,7 +38,7 @@ defmodule OliWeb.Delivery.Remix.Entry do
             <button class="btn btn-link ml-1 mr-1 entry-title" phx-click="set_active" phx-value-uuid={@node.uuid}><%= @node.revision.title %></button>
           <% else %>
             <span class="ml-1 mr-1 entry-title"><%= @node.revision.title %></span>
-            <%= if @is_product do %>
+            <%= if @is_product and !is_nil(@node.project_slug) do %>
               <a
                 id={"product-page-#{@node.revision.slug}"}
                 class="entry-title mx-3"

--- a/lib/oli_web/live/sections/gating_and_scheduling.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling.ex
@@ -85,8 +85,8 @@ defmodule OliWeb.Sections.GatingAndScheduling do
   end
 
   def mount(
-        params,
-        %{"section_slug" => section_slug} = session,
+        %{"section_slug" => section_slug} = params,
+        session,
         socket
       ) do
     {parent_gate, title} =

--- a/lib/oli_web/live/sections/gating_and_scheduling/edit.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling/edit.ex
@@ -9,8 +9,8 @@ defmodule OliWeb.Sections.GatingAndScheduling.Edit do
   alias Oli.Delivery.Gating
 
   def mount(
-        %{"id" => gating_condition_id},
-        %{"section_slug" => section_slug} = session,
+        %{"id" => gating_condition_id, "section_slug" => section_slug},
+        session,
         socket
       ) do
     case Mount.for(section_slug, session) do

--- a/lib/oli_web/live/sections/gating_and_scheduling/new.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling/new.ex
@@ -8,8 +8,8 @@ defmodule OliWeb.Sections.GatingAndScheduling.New do
   alias OliWeb.Common.SessionContext
 
   def mount(
-        params,
-        %{"section_slug" => section_slug} = session,
+        %{"section_slug" => section_slug} =params,
+        session,
         socket
       ) do
     case Mount.for(section_slug, session) do

--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -49,7 +49,7 @@ defmodule OliWeb.Sections.OverviewView do
       ]
   end
 
-  def mount(_params, %{"section_slug" => section_slug} = session, socket) do
+  def mount(%{"section_slug" => section_slug}, session, socket) do
     case Mount.for(section_slug, session) do
       {:error, e} ->
         Mount.handle_error(socket, {:error, e})

--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -49,7 +49,13 @@ defmodule OliWeb.Sections.OverviewView do
       ]
   end
 
-  def mount(%{"section_slug" => section_slug}, session, socket) do
+  def mount(params, session, socket) do
+
+    section_slug = case params do
+      :not_mounted_at_router -> Map.get(session, "section_slug")
+      _ -> Map.get(params, "section_slug")
+    end
+
     case Mount.for(section_slug, session) do
       {:error, e} ->
         Mount.handle_error(socket, {:error, e})


### PR DESCRIPTION
This fixes an issue where users would click on "Manage Source Materials" for a specific product and would be taken to a completely different product. 

Root cause was that the LiveView (and a few others) were pulling the section slug from the session, and not from the path parameters.  This is problematic when the user is logged in as both an author and instructor - in that case the section slug in the session can point to the section that they are enrolled in as a student/instructor. 

The fix in `entry.ex` is to allow pages from another project to be added during remix.  I caught this bug while troubleshooting this. 