### PR TITLE
[ENHANCEMENT] Adjust content browser for when only pages are present [MER-2319]

### DIFF
--- a/assets/css/button.css
+++ b/assets/css/button.css
@@ -1,6 +1,6 @@
 a.torus-button,
 button.torus-button {
-  @apply btn inline-flex items-center gap-2 text-sm;
+  @apply btn inline-flex items-center gap-2 text-sm hover:no-underline;
 }
 
 a.torus-button.primary,

--- a/lib/oli_web/components/delivery/buttons.ex
+++ b/lib/oli_web/components/delivery/buttons.ex
@@ -3,9 +3,9 @@ defmodule OliWeb.Components.Delivery.Buttons do
 
   alias Phoenix.LiveView.JS
 
-  attr :type, :string, default: "button"
-  attr :disabled, :boolean, default: false
-  attr :class, :string, default: nil
+  attr(:type, :string, default: "button")
+  attr(:disabled, :boolean, default: false)
+  attr(:class, :string, default: nil)
 
   def button(assigns) do
     ~H"""
@@ -15,21 +15,29 @@ defmodule OliWeb.Components.Delivery.Buttons do
     """
   end
 
-  attr :type, :string, default: "button"
-  attr :disabled, :boolean, default: false
-  attr :class, :string, default: nil
-  attr :id, :string, required: true
-  attr :options, :list, required: true
-  attr :onclick, :string, default: nil
-  slot :inner_block
+  attr(:type, :string, default: "button")
+  attr(:disabled, :boolean, default: false)
+  attr(:class, :string, default: nil)
+  attr(:id, :string, required: true)
+  attr(:options, :list, required: true)
+  attr(:onclick, :string, default: nil)
+  attr(:href, :string, default: nil)
+  attr(:target, :string, default: nil)
+  slot(:inner_block)
 
   def button_with_options(assigns) do
     ~H"""
     <div class="relative inline-block text-left">
       <div class="flex">
-        <button phx-target={assigns[:onclick_target]} phx-click={assigns[:onclick]} id={"#{@id}_button"} type={@type} class={["torus-button primary !rounded-r-none", @class]} disabled={@disabled}>
-          <%= render_slot(@inner_block) %>
-        </button>
+        <%= if assigns[:href] do %>
+          <a href={@href} {(if @target do [target: @target] else [] end)} class={["torus-button primary !rounded-r-none", @class]} disabled={@disabled}>
+            <%= render_slot(@inner_block) %>
+          </a>
+        <% else %>
+          <button phx-target={assigns[:onclick_target]} phx-click={assigns[:onclick]} id={"#{@id}_button"} type={@type} class={["torus-button primary !rounded-r-none", @class]} disabled={@disabled}>
+            <%= render_slot(@inner_block) %>
+          </button>
+        <% end %>
         <button type="button" phx-click={toggle_options(@id)} class="flex justify-center rounded-r-sm items-center px-2 text-white bg-delivery-primary-600 hover:bg-delivery-primary-700">
           <svg  class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
             <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
@@ -39,7 +47,16 @@ defmodule OliWeb.Components.Delivery.Buttons do
       <div phx-click-away={toggle_options(@id)} id={"#{@id}_options"} class="hidden absolute w-40 right-0 z-10 mt-2 origin-top-right divide-y divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none" role="menu" aria-orientation="vertical" aria-labelledby="menu-button" tabindex="-1">
         <div class="py-1" role="none">
           <%= for {option, index} <- Enum.with_index(@options) do %>
-            <button type="button" phx-click={toggle_options(option.on_click, @id)} class="text-gray-600 block px-4 py-2 text-sm w-full text-left hover:bg-gray-100" role="menuitem" tabindex="-1" id={"menu-item-#{@id}-#{index}"}><%= option.text %></button>
+            <%= if option[:href] do %>
+              <a href={option.href} {(if option[:target] do [target: option.target] else [] end)} class="text-gray-600 block whitespace-nowrap px-4 py-2 text-sm w-full text-left hover:bg-gray-100" role="menuitem" tabindex="-1" id={"menu-item-#{@id}-#{index}"}>
+                <%= option.text %>
+                <%= if option[:target] == "_blank" do %>
+                  <i class="fa-solid fa-arrow-up-right-from-square ml-2"></i>
+                <% end %>
+              </a>
+            <% else %>
+              <button type="button" phx-click={toggle_options(option.on_click, @id)} class="text-gray-600 block px-4 py-2 text-sm w-full text-left hover:bg-gray-100" role="menuitem" tabindex="-1" id={"menu-item-#{@id}-#{index}"}><%= option.text %></button>
+            <% end %>
           <% end %>
         </div>
       </div>

--- a/lib/oli_web/components/delivery/course_content.ex
+++ b/lib/oli_web/components/delivery/course_content.ex
@@ -17,6 +17,30 @@ defmodule OliWeb.Components.Delivery.CourseContent do
   attr(:is_instructor, :boolean, default: false)
   attr(:preview_mode, :boolean, default: false)
 
+  def adjust_hierarchy_for_only_pages(hierarchy) do
+    case Enum.all?(hierarchy["children"], fn child -> child["type"] == "page" end) do
+      true ->
+        %{
+          "children" => [
+            %{
+              "graded" => "false",
+              "id" => "0",
+              "index" => "0",
+              "level" => "-1", # The course content browser handles case of the special level of -1
+              "next" => nil,
+              "prev" => nil,
+              "slug" => nil,
+              "title" => "Curriculum",
+              "type" => "container",
+              "children" => hierarchy["children"]
+            }
+          ]
+        }
+
+      _ -> hierarchy
+    end
+  end
+
   def render(assigns) do
     ~H"""
     <div class="bg-white dark:bg-gray-800 shadow-sm">
@@ -25,6 +49,7 @@ defmodule OliWeb.Components.Delivery.CourseContent do
           <h4 class="text-base font-semibold mr-auto tracking-wide text-gray-800 dark:text-white h-8">Course Content</h4>
           <span class="text-sm font-normal tracking-wide text-gray-800 dark:text-white mt-2">Find all your course content, material, assignments and class activities here.</span>
         </section>
+        <%= if get_current_node(@current_level_nodes, @current_position)["level"] != "-1" do %>
         <section class="flex flex-row justify-between p-8">
           <div class="text-xs absolute -mt-5"><%= render_breadcrumbs(%{breadcrumbs_tree: @breadcrumbs_tree, myself: @myself}) %></div>
           <button phx-click="previous_node" phx-target={@myself} class={if @current_position == 0, do: "grayscale pointer-events-none"}>
@@ -45,6 +70,7 @@ defmodule OliWeb.Components.Delivery.CourseContent do
             <i class="fa-regular fa-circle-right text-primary text-xl"></i>
           </button>
         </section>
+        <% end %>
         <%= for {resource, index} <- get_current_node(@current_level_nodes, @current_position)["children"] |> Enum.with_index() do %>
           <section class="flex flex-row justify-between items-center w-full p-8">
             <h4

--- a/lib/oli_web/components/delivery/course_content.ex
+++ b/lib/oli_web/components/delivery/course_content.ex
@@ -26,7 +26,8 @@ defmodule OliWeb.Components.Delivery.CourseContent do
               "graded" => "false",
               "id" => "0",
               "index" => "0",
-              "level" => "-1", # The course content browser handles case of the special level of -1
+              # The course content browser handles case of the special level of -1
+              "level" => "-1",
               "next" => nil,
               "prev" => nil,
               "slug" => nil,
@@ -37,7 +38,8 @@ defmodule OliWeb.Components.Delivery.CourseContent do
           ]
         }
 
-      _ -> hierarchy
+      _ ->
+        hierarchy
     end
   end
 
@@ -89,12 +91,23 @@ defmodule OliWeb.Components.Delivery.CourseContent do
             <% else %>
               <Buttons.button_with_options
                 id={"open-resource-button-#{index}"}
-                type="submit"
-                onclick={JS.push("open_resource", target: @myself, value: %{resource_slug: resource["slug"], resource_type: resource["type"], preview: "true"})}
+                href={Routes.page_delivery_path(
+                  OliWeb.Endpoint,
+                  preview_resource_type(resource["type"]),
+                  @section.slug,
+                  resource["slug"]
+                )}
+                target={"_blank"}
                 options={[
                   %{
                     text: "Open as student",
-                    on_click: JS.push("open_resource", target: @myself, value: %{resource_slug: resource["slug"], resource_type: resource["type"]})
+                    href: Routes.page_delivery_path(
+                      OliWeb.Endpoint,
+                      String.to_existing_atom(resource["type"]),
+                      @section.slug,
+                      resource["slug"]
+                    ),
+                    target: "_blank"
                   }
                 ]}
               >
@@ -280,18 +293,19 @@ defmodule OliWeb.Components.Delivery.CourseContent do
   end
 
   defp get_page_preview_delivery_path(socket, section_slug, resource_slug, resource_type) do
-    resource_type =
-      case resource_type do
-        "page" -> :page_preview
-        "container" -> :container_preview
-      end
-
     Routes.page_delivery_path(
       socket,
-      resource_type,
+      preview_resource_type(resource_type),
       section_slug,
       resource_slug
     )
+  end
+
+  defp preview_resource_type(resource_type) do
+    case resource_type do
+      "page" -> :page_preview
+      "container" -> :container_preview
+    end
   end
 
   defp update_breadcrumbs_tree(breadcrumbs_tree, 0, _target_position),

--- a/lib/oli_web/components/delivery/course_content.ex
+++ b/lib/oli_web/components/delivery/course_content.ex
@@ -4,7 +4,6 @@ defmodule OliWeb.Components.Delivery.CourseContent do
   alias Oli.Delivery.Metrics
   alias OliWeb.Router.Helpers, as: Routes
   alias OliWeb.Components.Delivery.Buttons
-  alias Phoenix.LiveView.JS
 
   attr(:breadcrumbs_tree, :map, required: true)
   attr(:current_position, :integer, required: true)

--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -27,6 +27,11 @@ defmodule OliWeb.DeliveryController do
 
   plug(Oli.Plugs.RegistrationCaptcha when action in [:process_create_and_link_account_user])
 
+  def instructor_dashboard(conn, %{"section_slug" => section_slug}) do
+    # redirect to live view
+    redirect(conn, to: Routes.live_path(conn, OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive, section_slug, "overview"))
+  end
+
   def index(conn, _params) do
     user = conn.assigns.current_user
     lti_params = conn.assigns.lti_params

--- a/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
@@ -173,7 +173,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive do
 
   @impl Phoenix.LiveView
   def handle_params(%{"view" => "overview", "section_slug" => _section_slug} = params, _, socket) do
-    IO.inspect params["active_tab"]
+
     socket =
       case params["active_tab"] do
         value when value in [nil, "course_content"] ->

--- a/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
@@ -173,6 +173,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive do
 
   @impl Phoenix.LiveView
   def handle_params(%{"view" => "overview", "section_slug" => _section_slug} = params, _, socket) do
+    IO.inspect params["active_tab"]
     socket =
       case params["active_tab"] do
         value when value in [nil, "course_content"] ->
@@ -182,7 +183,8 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive do
                 socket.assigns.section
                 |> Oli.Repo.preload([:base_project, :root_section_resource])
 
-              %{"children" => Sections.build_hierarchy(section).children}
+              hierarchy = %{"children" => Sections.build_hierarchy(section).children}
+              OliWeb.Components.Delivery.CourseContent.adjust_hierarchy_for_only_pages(hierarchy)
             end)
 
           socket

--- a/lib/oli_web/live/delivery/student_dashboard/course_content_live.ex
+++ b/lib/oli_web/live/delivery/student_dashboard/course_content_live.ex
@@ -21,6 +21,9 @@ defmodule OliWeb.Delivery.StudentDashboard.CourseContentLive do
     current_position = 0
     current_level = 0
 
+    # Adjust the hierarchy in the case that there are only pages in the course, no containers
+    hierarchy = OliWeb.Components.Delivery.CourseContent.adjust_hierarchy_for_only_pages(hierarchy)
+
     {:ok,
      assign(socket,
        hierarchy: hierarchy,

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -887,10 +887,16 @@ defmodule OliWeb.Router do
       :download_quiz_scores
     )
 
+    get(
+      "/",
+      DeliveryController,
+      :instructor_dashboard
+    )
+
     live_session :instructor_dashboard,
       on_mount: OliWeb.Delivery.InstructorDashboard.InitialAssigns,
       root_layout: {OliWeb.LayoutView, "delivery_dashboard.html"} do
-      live("/", Delivery.InstructorDashboard.InstructorDashboardLive)
+
       live("/:view", Delivery.InstructorDashboard.InstructorDashboardLive)
       live("/:view/:active_tab", Delivery.InstructorDashboard.InstructorDashboardLive)
 

--- a/test/oli_web/live/delivery/instructor_dashboard/overview/content_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/overview/content_tab_test.exs
@@ -47,7 +47,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.Overview.Content do
                "Find all your course content, material, assignments and class activities here."
              )
 
-      assert has_element?(view, "button", "Open as instructor")
+      assert has_element?(view, "a", "Open as instructor")
     end
   end
 end


### PR DESCRIPTION
The content browser (both student and instructor facing) does not handle well courses that *only* contain pages.  These pages appear almost as "units" that the user can navigate between via the left and right arrow, but the user cannot click to access, nor see any page pertinent information such as due dates.  

The PR corrects that by detecting this case and just listing the pages, as pages.

For example:
![Screenshot 2023-07-13 at 2 24 57 PM](https://github.com/Simon-Initiative/oli-torus/assets/7431756/e64618be-53e2-4bf6-be4d-bad4baeda982)

There is also a change here to handle the root path for the dashboard explicitly and redirect to the "overview" route.  This fixes a bug where an Internal Server Error was being thrown when trying to hit this route directly.

