### PR TITLE
[BUG FIX] [MER-2323] image captions render with a gray background

### DIFF
--- a/assets/src/phoenix/dark.ts
+++ b/assets/src/phoenix/dark.ts
@@ -4,7 +4,7 @@ import theme from '../../tailwind.theme';
 function findOrCreateElement(selector: string): Element {
   const metaThemeColor = document.querySelector(selector);
   if (!metaThemeColor) {
-    document.appendChild(document.createElement('meta')).setAttribute('name', 'theme-color');
+    document.head.appendChild(document.createElement('meta')).setAttribute('name', 'theme-color');
   }
 
   return document.querySelector(selector) as Element;
@@ -32,19 +32,19 @@ if ((!('theme' in localStorage) && isDarkMode()) || localStorage.theme === 'dark
   setMetaThemeColor(false);
 }
 
-addDarkModeListener((mode) => {
-  if (!('theme' in localStorage)) {
-    if (mode === 'dark') {
-      document.documentElement.classList.add('dark');
-      setMetaThemeColor(true);
-    } else {
-      document.documentElement.classList.remove('dark');
-      setMetaThemeColor(false);
-    }
-  }
-});
-
 document.addEventListener('DOMContentLoaded', () => {
+  addDarkModeListener((mode) => {
+    if (!('theme' in localStorage)) {
+      if (mode === 'dark') {
+        document.documentElement.classList.add('dark');
+        setMetaThemeColor(true);
+      } else {
+        document.documentElement.classList.remove('dark');
+        setMetaThemeColor(false);
+      }
+    }
+  });
+
   if (isDarkMode()) {
     [].slice
       .call(document.querySelectorAll('.g-recaptcha'))

--- a/assets/styles/common/elements.scss
+++ b/assets/styles/common/elements.scss
@@ -405,9 +405,6 @@ $element-margin-bottom: 1.5em;
     margin-bottom: $element-margin-bottom;
 
     figure {
-      figcaption {
-        color: var(--color-primary);
-      }
       padding: 1rem;
     }
   }
@@ -419,16 +416,10 @@ $element-margin-bottom: 1.5em;
 
     figure {
       display: block;
-      background-color: var(--color-gray-100);
-      padding: 20px;
-      border-radius: 6px;
       margin: auto;
 
       figcaption {
-        margin-bottom: 8px;
         text-align: center;
-        margin-top: 8px;
-        color: black;
       }
 
       .embed-responsive {
@@ -605,19 +596,6 @@ html.dark {
     pre {
       color: var(--color-body-color-dark);
       background: var(--color-gray-900);
-    }
-
-    .caption-wrapper {
-      display: flex;
-      justify-content: center;
-
-      figure {
-        background-color: var(--color-gray-700);
-
-        figcaption {
-          color: white;
-        }
-      }
     }
   }
 }

--- a/assets/styles/common/elements.scss
+++ b/assets/styles/common/elements.scss
@@ -405,6 +405,9 @@ $element-margin-bottom: 1.5em;
     margin-bottom: $element-margin-bottom;
 
     figure {
+      figcaption {
+        color: var(--color-primary);
+      }
       padding: 1rem;
     }
   }


### PR DESCRIPTION
This was an issue raised in the weekly migration meeting.

Gray caption backgrounds are causing style issues with striped tables and we've received much feedback in the review process that there shouldn't be any sort of background around captions. A lot of migrated images have white backgrounds and when combined with the gray background make courses look noisy. The decision to set this caption background was made early on in torus development and removing is an easy, low risk style fix.

This PR also fixes an issue where dark mode was breaking on page load. The script was attempting to append a meta tag to the document which is not allowed, crashing the listener. This fix now properly adds the meta tag to the head of the document.

https://eliterate.atlassian.net/browse/MER-2323

Some content before/after examples:

Before:
<img width="1155" alt="Screenshot 2023-07-13 at 2 02 32 PM" src="https://github.com/Simon-Initiative/oli-torus/assets/6248894/510952c9-c8a2-4740-ad03-318bc7fd4241">

After:
<img width="1187" alt="Screenshot 2023-07-13 at 2 29 09 PM" src="https://github.com/Simon-Initiative/oli-torus/assets/6248894/32c3af62-fc2b-401b-906b-7365c6a2b2ce">

Before:
<img width="1391" alt="Screenshot 2023-07-13 at 2 07 39 PM" src="https://github.com/Simon-Initiative/oli-torus/assets/6248894/11166032-fb73-4840-b12f-bbdae7c34565">

After:
<img width="1383" alt="Screenshot 2023-07-13 at 2 14 05 PM" src="https://github.com/Simon-Initiative/oli-torus/assets/6248894/8c708e68-8c4b-47d7-944f-4af660bd8c9b">

Before:
<img width="1202" alt="Screenshot 2023-07-13 at 2 12 59 PM" src="https://github.com/Simon-Initiative/oli-torus/assets/6248894/8f345a54-7303-4f9a-b1de-74d081c77a66">

After:
<img width="1237" alt="Screenshot 2023-07-13 at 2 09 38 PM" src="https://github.com/Simon-Initiative/oli-torus/assets/6248894/4488da3f-cdf6-41d1-a96f-70c9f0b8cfc9">
