### PR TITLE
[BUGFIX] Fix setting objectives on multi-part activities. [MER-2270]

### DIFF
--- a/assets/src/apps/authoring/store/activities/actions/objectives.ts
+++ b/assets/src/apps/authoring/store/activities/actions/objectives.ts
@@ -1,4 +1,4 @@
-import { ObjectiveMap } from '../content/activity';
+import { ActivityUpdate } from '../../../../../data/persistence/activity';
 
 /**
  * In the backend data model, objectives are attached to parts.
@@ -17,11 +17,8 @@ import { ObjectiveMap } from '../content/activity';
  * the __default part is added/removed. This function does just that.
  *
  */
-interface UpdateParam {
-  objectives?: ObjectiveMap;
-  authoring?: any;
-}
-export const fixObjectiveParts = (activity: UpdateParam): UpdateParam => {
+
+export const fixObjectiveParts = (activity: ActivityUpdate): ActivityUpdate => {
   if (!activity.objectives) {
     console.info('fixObjectiveParts - No activity.objectives');
     return activity;
@@ -34,19 +31,20 @@ export const fixObjectiveParts = (activity: UpdateParam): UpdateParam => {
     return activity;
   }
 
-  if (!Array.isArray(activity?.authoring?.parts)) {
+  const parts = activity.content?.authoring?.parts;
+  if (!Array.isArray(parts)) {
     console.info('fixObjectiveParts - Parts not an array');
     return activity;
   }
 
-  if (activity.authoring.parts.length === 0) {
+  if (parts.length === 0) {
     // This really should never happen since the __default part would be generated beforehand
     console.error('fixObjectiveParts - No parts were present in the activity');
     return activity;
   }
 
   const targetKey =
-    Object.values(activity.authoring.parts)
+    Object.values(parts)
       .map((p: { id: string }) => p.id)
       .filter((k) => k !== '__default')[0] || '__default';
 

--- a/assets/src/apps/authoring/store/activities/actions/saveActivity.ts
+++ b/assets/src/apps/authoring/store/activities/actions/saveActivity.ts
@@ -25,6 +25,7 @@ import { createUndoAction } from '../../history/slice';
 import { savePage } from '../../page/actions/savePage';
 import { selectState as selectCurrentPage, selectResourceId } from '../../page/slice';
 import { SAVE_DEBOUNCE_OPTIONS, SAVE_DEBOUNCE_TIMEOUT } from '../../persistance-options';
+import { fixObjectiveParts } from './objectives';
 
 export const saveActivity = createAsyncThunk(
   `${ActivitiesSlice}/saveActivity`,
@@ -163,6 +164,9 @@ const wrapEdit = (activityId: string) =>
         pendingUpdate,
         releaseLock,
       });
+
+      pendingUpdate = fixObjectiveParts(pendingUpdate);
+
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const editResults = await edit(project, resource, activity, pendingUpdate, releaseLock);
       console.log('EDIT SAVE RESULTS', { editResults });

--- a/assets/src/components/resource/objectives/ActivityLOs.tsx
+++ b/assets/src/components/resource/objectives/ActivityLOs.tsx
@@ -45,9 +45,9 @@ const MultiPartSelection = (props: Props & { id: string; index: number }) => {
         {...props}
         selected={props.objectives[props.id] || []}
         objectives={props.allObjectives}
-        onEdit={(objectives) =>
-          props.onEdit({ ...props.objectives, ...{ [props.id]: objectives } })
-        }
+        onEdit={(objectives) => {
+          return props.onEdit({ ...props.objectives, [props.id]: objectives });
+        }}
       />
     </div>
   );

--- a/assets/src/data/persistence/activity.ts
+++ b/assets/src/data/persistence/activity.ts
@@ -8,7 +8,6 @@ import { ObjectiveMap } from 'data/content/activity';
 import { ActivityTypeSlug, ProjectSlug, ResourceId } from 'data/types';
 import { clone } from 'utils/common';
 import { makeRequest } from './common';
-import { fixObjectiveParts } from './objectives';
 
 export type ActivityUpdate = {
   title: string;
@@ -195,12 +194,12 @@ export function bulkEdit(
     if (u.authoring) {
       indexBibrefs(u.authoring, citationRefs);
     }
-    const { objectives } = fixObjectiveParts(u);
+
     // make content mutable
     const contentClone = clone(u.content);
     contentClone.bibrefs = citationRefs;
     u.content = contentClone;
-    u.objectives = objectives || {};
+    u.objectives = u.objectives || {};
   });
 
   const params = {
@@ -228,7 +227,7 @@ export function edit(
   pendingUpdate: ActivityUpdate,
   releaseLock: boolean,
 ) {
-  let update = Object.assign({}, pendingUpdate, { releaseLock });
+  const update = Object.assign({}, pendingUpdate, { releaseLock });
   try {
     update.content = Object.assign({}, update.content);
 
@@ -246,7 +245,6 @@ export function edit(
       indexBibrefs(update.authoring, citationRefs);
     }
     update.content.bibrefs = citationRefs;
-    update = fixObjectiveParts(update) as ActivityUpdate & { releaseLock: boolean };
   } catch (e) {
     console.error('activity::edit failed', e);
     throw e;


### PR DESCRIPTION
Retargeting this previous PR to the prerelease branch.

Setting objectives on any multi-part activity was broken

To reproduce:

From course project overview, enable the “Likert” activity
Go into the basic page page editor and create a Likert activity
Add a second “item” (by clicking the second “Add choice” button link, this really should read “Add item”)
From the Learning Objectives attachment dialog for that activity, attempt to attach LOs to each of the different parts
Refresh and reload the page
You will see that after reloading, both objectives are attached to the first part.

This was caused by logic meant for only saving adaptive lesson activities being applied to saving all activities.

Originally: https://github.com/Simon-Initiative/oli-torus/pull/3885