### PR TITLE
[BUG-FIX] Attempt summary and student completion [MER-2227]

### DIFF
--- a/lib/oli/publishing/delivery_resolver.ex
+++ b/lib/oli/publishing/delivery_resolver.ex
@@ -51,13 +51,13 @@ defmodule Oli.Publishing.DeliveryResolver do
     |> Repo.all()
   end
 
-  def students_with_attempts_for_page(page_revision_id, section_id) do
+  def students_with_attempts_for_page(page, section_id, student_ids) do
     from(ra in ResourceAttempt,
       join: rac in ResourceAccess,
       on: ra.resource_access_id == rac.id,
       where:
-        ra.revision_id == ^page_revision_id and not is_nil(ra.date_evaluated) and
-          rac.section_id == ^section_id,
+        ra.revision_id == ^page.id and not is_nil(ra.date_evaluated) and
+          rac.section_id == ^section_id and rac.user_id in ^student_ids,
       select: rac.user_id
     )
     |> Repo.all()

--- a/lib/oli/publishing/delivery_resolver.ex
+++ b/lib/oli/publishing/delivery_resolver.ex
@@ -56,12 +56,13 @@ defmodule Oli.Publishing.DeliveryResolver do
       join: rac in ResourceAccess,
       on: ra.resource_access_id == rac.id,
       where:
-        ra.revision_id == ^page.id and not is_nil(ra.date_evaluated) and
-          rac.section_id == ^section_id and rac.user_id in ^student_ids,
+        ra.lifecycle_state == :evaluated and
+          rac.section_id == ^section_id and rac.user_id in ^student_ids and
+          rac.resource_id == ^page.resource_id,
+      group_by: rac.user_id,
       select: rac.user_id
     )
     |> Repo.all()
-    |> Enum.uniq()
   end
 
   def objectives_by_resource_ids(resource_ids, section_slug) do

--- a/lib/oli_web/components/delivery/scored_activities/scored_activities.ex
+++ b/lib/oli_web/components/delivery/scored_activities/scored_activities.ex
@@ -71,9 +71,9 @@ defmodule OliWeb.Components.Delivery.ScoredActivities do
               a.id == assessment_id
             end)
 
-          activities = get_activities(current_assessment, assigns.section)
-
           student_ids = Enum.map(assigns.students, & &1.id)
+
+          activities = get_activities(current_assessment, assigns.section, student_ids)
 
           students_with_attempts =
             DeliveryResolver.students_with_attempts_for_page(
@@ -541,7 +541,7 @@ defmodule OliWeb.Components.Delivery.ScoredActivities do
     |> Repo.one()
   end
 
-  defp get_activities(current_assessment, section) do
+  defp get_activities(current_assessment, section, student_ids) do
     activities =
       from(aa in ActivityAttempt,
         join: res_attempt in ResourceAttempt,
@@ -551,7 +551,8 @@ defmodule OliWeb.Components.Delivery.ScoredActivities do
         on: res_attempt.resource_access_id == res_access.id,
         where:
           res_access.section_id == ^section.id and
-            res_access.resource_id == ^current_assessment.resource_id,
+            res_access.resource_id == ^current_assessment.resource_id and
+            res_access.user_id in ^student_ids,
         join: rev in Revision,
         on: aa.revision_id == rev.id,
         join: pr in PublishedResource,

--- a/lib/oli_web/live/delivery/instructor_dashboard/helpers.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/helpers.ex
@@ -7,12 +7,15 @@ defmodule OliWeb.Delivery.InstructorDashboard.Helpers do
       {0, pages} ->
         page_ids = Enum.map(pages, & &1.id)
 
+        students =
+          Sections.enrolled_students(section.slug)
+          |> Enum.reject(fn user -> user.user_role_id != 4 end)
+
         student_progress =
           Metrics.progress_across_for_pages(
             section.id,
             page_ids,
-            [],
-            Sections.count_enrollments(section.slug)
+            Enum.map(students, & &1.id)
           )
 
         proficiency_per_page = Metrics.proficiency_per_page(section.slug, page_ids)
@@ -52,6 +55,8 @@ defmodule OliWeb.Delivery.InstructorDashboard.Helpers do
   end
 
   def get_assessments(section, students) do
+    student_ids = Enum.map(students, & &1.id)
+
     graded_pages_and_section_resources =
       DeliveryResolver.graded_pages_revisions_and_section_resources(section.slug)
 
@@ -61,21 +66,21 @@ defmodule OliWeb.Delivery.InstructorDashboard.Helpers do
       Metrics.progress_across_for_pages(
         section.id,
         page_ids,
-        [],
-        Enum.count(students)
+        student_ids
       )
 
     avg_score_across_for_pages =
       Metrics.avg_score_across_for_pages(
         section.id,
         page_ids,
-        []
+        student_ids
       )
 
     attempts_across_for_pages =
       Metrics.attempts_across_for_pages(
         section.id,
-        page_ids
+        page_ids,
+        student_ids
       )
 
     container_labels = Sections.map_resources_with_container_labels(section.slug, page_ids)

--- a/test/oli/delivery/metrics/avg_score_test.exs
+++ b/test/oli/delivery/metrics/avg_score_test.exs
@@ -209,6 +209,7 @@ defmodule Oli.Delivery.Metrics.AvgScoreTest do
     test "avg_score_across_for_pages/3 calculates correctly",
          %{
            section: section,
+           user_1: user_1,
            user_2: user_2,
            mod1_pages: mod1_pages,
            mod2_pages: mod2_pages,
@@ -219,18 +220,22 @@ defmodule Oli.Delivery.Metrics.AvgScoreTest do
       [p7, p8, p9, p10] = mod3_pages
 
       pages_avg_score =
-        Metrics.avg_score_across_for_pages(section.id, [
-          p1.published_resource.resource_id,
-          p2.published_resource.resource_id,
-          p3.published_resource.resource_id,
-          p4.published_resource.resource_id,
-          p5.published_resource.resource_id,
-          p6.published_resource.resource_id,
-          p7.published_resource.resource_id,
-          p8.published_resource.resource_id,
-          p9.published_resource.resource_id,
-          p10.published_resource.resource_id
-        ])
+        Metrics.avg_score_across_for_pages(
+          section.id,
+          [
+            p1.published_resource.resource_id,
+            p2.published_resource.resource_id,
+            p3.published_resource.resource_id,
+            p4.published_resource.resource_id,
+            p5.published_resource.resource_id,
+            p6.published_resource.resource_id,
+            p7.published_resource.resource_id,
+            p8.published_resource.resource_id,
+            p9.published_resource.resource_id,
+            p10.published_resource.resource_id
+          ],
+          [user_1.id, user_2.id]
+        )
 
       pages_avg_score_excluding_user_2 =
         Metrics.avg_score_across_for_pages(
@@ -247,7 +252,7 @@ defmodule Oli.Delivery.Metrics.AvgScoreTest do
             p9.published_resource.resource_id,
             p10.published_resource.resource_id
           ],
-          [user_2.id]
+          [user_1.id]
         )
 
       assert_in_delta 0.5,

--- a/test/oli/delivery/metrics/progress_test.exs
+++ b/test/oli/delivery/metrics/progress_test.exs
@@ -272,7 +272,7 @@ defmodule Oli.Delivery.Metrics.ProgressTest do
       assert this_user_progress == 0.5
     end
 
-    test "progress_across_for_pages/4 calculates correctly", %{
+    test "progress_across_for_pages/3 calculates correctly", %{
       mod1_pages: mod1_pages,
       this_user: this_user,
       section: section
@@ -299,18 +299,20 @@ defmodule Oli.Delivery.Metrics.ProgressTest do
       )
 
       progress =
-        Metrics.progress_across_for_pages(section.id, [p1.resource.id, p2.resource.id], [], 2)
+        Metrics.progress_across_for_pages(section.id, [p1.resource.id, p2.resource.id], [
+          this_user.id,
+          another_user.id
+        ])
 
       assert progress[p1.resource.id] == (0.5 + 0.75) / 2
       assert progress[p2.resource.id] == (1.0 + 0.5) / 2
 
-      # excluding one user...
+      # excluding 'this user'...
       progress_2 =
         Metrics.progress_across_for_pages(
           section.id,
           [p1.resource.id, p2.resource.id],
-          [this_user.id],
-          1
+          another_user.id
         )
 
       assert progress_2[p1.resource.id] == 0.75


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-2227?focusedCommentId=20740) to the comment on the ticket

```The summary statement in the upper right of this view is off. See screenshot 9. Despite what it says here, 5 students have completed 8 attempts. ``` -> We were filtering by revision and some attempts were from a previous page revision

```And back in Scored Activities, the percentage for Students Completion for the Activity Bank quiz is 120%. Is that correct? It seems like 100% should be the max value here but perhaps I’m missing something about how this gets calculated. See screenshot 10. ``` -> We were considering non-student attempts.