### PR TITLE
[Feature] Allow iframe sizes to be specified by author [MER-2306]

### DIFF
--- a/assets/src/components/editing/elements/webpage/WebpageElement.tsx
+++ b/assets/src/components/editing/elements/webpage/WebpageElement.tsx
@@ -5,12 +5,27 @@ import { elementBorderStyle, useEditModelCallback } from 'components/editing/ele
 import { WebpageSettings } from 'components/editing/elements/webpage/WebpageSettings';
 import * as ContentModel from 'data/content/model/elements/types';
 import { useElementSelected } from 'data/content/utils';
-import { classNames } from 'utils/classNames';
 
 export interface Props extends EditorProps<ContentModel.Webpage> {}
 export const WebpageEditor = (props: Props) => {
   const selected = useElementSelected();
   const onEdit = useEditModelCallback(props.model);
+
+  const dimensions: { width?: number | string; height?: number | string } = {};
+  if (props.model.width) {
+    dimensions['width'] = props.model.width;
+  }
+  if (props.model.height) {
+    dimensions['height'] = props.model.height;
+  } else if (props.model.width) {
+    // If we have a width, but no height, set the height to the same as width.
+    dimensions['height'] = props.model.width;
+  }
+
+  const iframeClass = props.model.width ? '' : 'embed-responsive-item';
+  const containerClass = props.model.width
+    ? 'img-thumbnail'
+    : 'embed-responsive embed-responsive-16by9 img-thumbnail';
 
   return (
     <div {...props.attributes} className="webpage-editor">
@@ -23,7 +38,7 @@ export const WebpageEditor = (props: Props) => {
           overflow: 'visible',
           ...elementBorderStyle(selected),
         }}
-        className={classNames('embed-responsive', 'embed-responsive-16by9', 'img-thumbnail')}
+        className={containerClass}
       >
         <div
           style={{
@@ -41,7 +56,8 @@ export const WebpageEditor = (props: Props) => {
         </div>
 
         <iframe
-          className="embed-responsive-item"
+          className={iframeClass}
+          {...dimensions}
           src={props.model.src}
           allowFullScreen
           frameBorder={0}

--- a/assets/src/components/editing/elements/webpage/WebpageModal.tsx
+++ b/assets/src/components/editing/elements/webpage/WebpageModal.tsx
@@ -11,11 +11,15 @@ interface ModalProps {
   model: ContentModel.Webpage;
   projectSlug: string;
 }
+
+const stringToNumOrUndefined = (v: string): string | undefined => (v === '' ? undefined : v);
+
 export const WebpageModal = ({ onDone, onCancel, model, projectSlug }: ModalProps) => {
   const [srcType, setSrcType] = useState<ContentModel.WebpageSrcType>(model.srcType || 'url');
   const [src, setSrc] = useState(model.src);
   const [alt, setAlt] = useState(model.alt ?? '');
-  const [width, _setWidth] = useState(model.width);
+  const [width, setWidth] = useState(model.width ? String(model.width) : '');
+  const [height, setHeight] = useState(model.height ? String(model.height) : '');
 
   const onSrcTypeChange = useCallback(
     (v: ContentModel.WebpageSrcType) => {
@@ -35,7 +39,15 @@ export const WebpageModal = ({ onDone, onCancel, model, projectSlug }: ModalProp
       okLabel="Save"
       cancelLabel="Cancel"
       onCancel={onCancel}
-      onOk={() => onDone({ alt, width, src, srcType })}
+      onOk={() =>
+        onDone({
+          alt,
+          width: stringToNumOrUndefined(width),
+          height: stringToNumOrUndefined(height),
+          src,
+          srcType,
+        })
+      }
     >
       <div>
         <h3 className="mb-2">Settings</h3>
@@ -46,6 +58,29 @@ export const WebpageModal = ({ onDone, onCancel, model, projectSlug }: ModalProp
         {srcType === 'media_library' && (
           <MediaEntry href={src || ''} setHref={setSrc} projectSlug={projectSlug} />
         )}
+        <h4 className="mb-2">Size (Leave blank for default)</h4>
+        <div className="d-flex flex-row">
+          <div className="mr-2">
+            <span>Width:</span>
+            <input
+              type="text"
+              className="form-control"
+              value={width}
+              onChange={(e) => setWidth(e.target.value)}
+              placeholder="Width"
+            />
+          </div>
+          <div>
+            <span>Height:</span>
+            <input
+              type="text"
+              className="form-control"
+              value={height}
+              onChange={(e) => setHeight(e.target.value)}
+              placeholder="Height"
+            />
+          </div>
+        </div>
 
         <h4 className="mb-2">Alternative Text</h4>
         <p className="mb-4">

--- a/assets/src/components/editing/elements/webpage/WebpageSettings.tsx
+++ b/assets/src/components/editing/elements/webpage/WebpageSettings.tsx
@@ -59,10 +59,10 @@ const SettingsButton = (props: SettingsButtonProps) => (
             <WebpageModal
               projectSlug={props.projectSlug}
               model={props.model}
-              onDone={({ alt, width, src, srcType }: Partial<ContentModel.Webpage>) => {
+              onDone={({ alt, width, height, src, srcType }: Partial<ContentModel.Webpage>) => {
                 console.log('width', width, alt, src);
                 window.oliDispatch(modalActions.dismiss());
-                props.onEdit({ alt, width, src, srcType });
+                props.onEdit({ alt, width, src, srcType, height });
               }}
               onCancel={() => window.oliDispatch(modalActions.dismiss())}
             />,

--- a/assets/src/data/content/model/elements/types.ts
+++ b/assets/src/data/content/model/elements/types.ts
@@ -296,8 +296,8 @@ export interface Webpage extends SlateElement<VoidChildren> {
   type: 'iframe';
   src?: string;
   srcType?: WebpageSrcType;
-  height?: number;
-  width?: number;
+  height?: string | number;
+  width?: string | number;
   alt?: string;
   caption?: Caption;
   // Legacy, unused

--- a/assets/src/data/content/writers/html.tsx
+++ b/assets/src/data/content/writers/html.tsx
@@ -315,12 +315,30 @@ export class HtmlParser implements WriterImpl {
   }
   iframe(context: WriterContext, next: Next, attrs: Webpage | YouTube) {
     if (!attrs.src) return <></>;
+    const dimensions: { width?: number; height?: number } = {};
+    if (attrs.width) {
+      dimensions['width'] = attrs.width;
+    }
+    if (attrs.height) {
+      dimensions['height'] = attrs.height;
+    } else if (attrs.width) {
+      // If we have a width, but no height, set the height to the same as width.
+      dimensions['height'] = attrs.width;
+    }
+
+    const iframeClass = attrs.width ? '' : 'embed-responsive-item';
+    const containerClass = attrs.width ? '' : 'embed-responsive embed-responsive-16by9';
 
     return this.captioned_content(
       context,
       attrs,
-      <div className="embed-responsive embed-responsive-16by9">
-        <iframe className="embed-responsive-item" allowFullScreen src={this.escapeXml(attrs.src)} />
+      <div className={containerClass}>
+        <iframe
+          className={iframeClass}
+          {...dimensions}
+          allowFullScreen
+          src={this.escapeXml(attrs.src)}
+        />
       </div>,
     );
   }

--- a/assets/src/data/content/writers/html.tsx
+++ b/assets/src/data/content/writers/html.tsx
@@ -315,7 +315,7 @@ export class HtmlParser implements WriterImpl {
   }
   iframe(context: WriterContext, next: Next, attrs: Webpage | YouTube) {
     if (!attrs.src) return <></>;
-    const dimensions: { width?: number; height?: number } = {};
+    const dimensions: { width?: string | number; height?: string | number } = {};
     if (attrs.width) {
       dimensions['width'] = attrs.width;
     }

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -107,18 +107,43 @@ defmodule Oli.Rendering.Content.Html do
   def youtube(%Context{} = _context, _, _e), do: ""
 
   def iframe(%Context{} = context, _, %{"src" => src} = attrs) do
-    iframe_width =
-      if attrs["width"] do
-        " style=\"width: #{escape_xml!(attrs["width"])}px\""
+    has_width = not is_nil(attrs["width"])
+    has_height = not is_nil(attrs["height"])
+
+    dimensions =
+      cond do
+        has_width and has_height ->
+          # Both dimensions specified
+          " width=\"#{attrs["width"]}\" height=\"#{attrs["height"]}\" "
+
+        has_width ->
+          # Width with no height, default to a square size
+          " width=\"#{attrs["width"]}\" height=\"#{attrs["width"]}\" "
+
+        true ->
+          ""
+      end
+
+    # With no dimensions set, we rely on the responsive CSS classes to set dimensions
+    iframe_class =
+      if has_width do
+        "mx-auto"
       else
+        "embed-responsive-item"
+      end
+
+    container_class =
+      if has_width do
         ""
+      else
+        "embed-responsive embed-responsive-16by9"
       end
 
     captioned_content(context, attrs, [
       """
-      <div class="embed-responsive embed-responsive-16by9"#{iframe_width}>
+      <div class="#{container_class}">
         <div class="embed-wrapper">
-          <iframe#{maybeAlt(attrs)} class="embed-responsive-item" allowfullscreen src="#{escape_xml!(src)}"></iframe>
+          <iframe#{maybeAlt(attrs)} class="#{iframe_class}" #{dimensions} allowfullscreen src="#{escape_xml!(src)}"></iframe>
         </div>
       </div>
       """

--- a/test/oli/rendering/content/html_test.exs
+++ b/test/oli/rendering/content/html_test.exs
@@ -52,7 +52,7 @@ defmodule Oli.Content.Content.HtmlTest do
                "<pre><code class=\"language-python\">import fresh-pots</code></pre>"
 
       assert rendered_html_string =~
-               ~r/<iframe class=".*" allowfullscreen src="https:\/\/www.wikipedia.org"><\/iframe>/
+               ~r/<iframe class=".*"  allowfullscreen src="https:\/\/www.wikipedia.org"><\/iframe>/
 
       assert rendered_html_string =~ "<span class=\"callout-block\">a richtext callout</span>"
 


### PR DESCRIPTION
Authors can now specify the size of an iframe, this is initially intended to support importing legacy content with those dimensions set, but can actively be used moving forward in new content.

If no size is specified, the previous behavior of a responsive iframe will continue.

New settings dialog:
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/6e6687bc-9e37-4f2b-84dd-b7ccc6ac5ec0)
