### PR TITLE
[BUGFIX] Component menu offscreen [MER-2315]

### DIFF
--- a/assets/src/components/editing/toolbar/Toolbar.modules.scss
+++ b/assets/src/components/editing/toolbar/Toolbar.modules.scss
@@ -113,6 +113,32 @@
   text-align: center;
 }
 
+.multiDropdownGroup {
+  width: 580px;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  padding: 8px;
+  overflow-y: auto;
+  background: #f8f9fb;
+  border: 2px solid var(--color-toolbar-border);
+
+  .toolbarButton {
+    width: 185px;
+    display: inline-flex;
+    align-items: center;
+    text-align: left;
+    border-radius: 6px;
+
+    &:first-of-type,
+    &:last-of-type {
+      margin-left: 0px;
+      margin-right: 0px;
+      border-radius: 6px;
+    }
+  }
+}
+
 .dropdownGroup {
   display: flex;
   flex-direction: column;

--- a/assets/src/components/editing/toolbar/buttons/DropdownButton.tsx
+++ b/assets/src/components/editing/toolbar/buttons/DropdownButton.tsx
@@ -30,6 +30,14 @@ export const DropdownButton = (props: PropsWithChildren<Props>) => {
     [toolbar, thisDropdown],
   );
 
+  const multiColumn =
+    props.children &&
+    // eslint-disable-next-line no-prototype-builtins
+    (props.children as any).hasOwnProperty('length') &&
+    (props.children as { length: number }).length > 6;
+
+  const classname = multiColumn ? styles.multiDropdownGroup : styles.dropdownGroup;
+
   return (
     <Popover
       ref={thisDropdown}
@@ -40,7 +48,7 @@ export const DropdownButton = (props: PropsWithChildren<Props>) => {
       reposition={true}
       align={'start'}
       containerStyle={{ zIndex: '100000' }}
-      content={<div className={styles.dropdownGroup}>{props.children}</div>}
+      content={<div className={classname}>{props.children}</div>}
     >
       <button
         className={classNames(


### PR DESCRIPTION
The dropdowns from the slate editor toolbar had gotten too large and were often offscreen. I've modified them so whenever there is more than 6 items in the dropdown, it uses a multi-column format to fit more on screen.

Examples:
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/efb36c73-1498-449d-967b-4a0540e1a20f)
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/d6031308-e77a-4a49-b385-e4413f18f421)

Fewer than 6 items behave as before:
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/b52b92c1-b758-436e-8be3-aa1b5474e41e)
