### PR TITLE
[BUG FIX] preserve scope attribute during export

### DIFF
--- a/lib/oli/interop/export.ex
+++ b/lib/oli/interop/export.ex
@@ -85,6 +85,7 @@ defmodule Oli.Interop.Export do
         title: r.title,
         tags: transform_tags(r),
         unresolvedReferences: [],
+        scope: r.scope,
         content: rewire_activity_content(r.content, project),
         objectives: to_string_ids(r.objectives),
         subType: Map.get(registrations, r.activity_type_id).slug


### PR DESCRIPTION
This PR fixes a bug where a project which contains activity bank questions, upon re-ingest, has those activities no longer appear in the activity bank. 

Root cause was the export code does not output and preserve the `scope` attribute, which indicates whether an activity is `embedded` or `banked`.  The ingest code treats the lack of this attribute with a default of `embedded` 