### PR TITLE
[BUG FIX] [MER-1918] checking automatically push update box erases info in the description field for the update

### DIFF
--- a/lib/oli_web/live/projects/publish_view.ex
+++ b/lib/oli_web/live/projects/publish_view.ex
@@ -20,7 +20,7 @@ defmodule OliWeb.Projects.PublishView do
 
   alias OliWeb.Router.Helpers, as: Routes
 
-  data(is_force_push, :boolean, default: false)
+  data(auto_update_sections, :boolean, default: false)
   data(limit, :integer, default: 10)
   data(modal, :any, default: nil)
   data(offset, :integer, default: 0)
@@ -147,12 +147,11 @@ defmodule OliWeb.Projects.PublishView do
 
             {#if @has_changes}
               <VersioningDetails
+                id="versioning-details"
                 active_publication={@active_publication}
                 active_publication_changes={@active_publication_changes}
                 changeset={@changeset}
-                force_push="force_push"
                 has_changes={@has_changes}
-                is_force_push={@is_force_push}
                 latest_published_publication={@latest_published_publication}
                 project={@project}
                 publish_active="publish_active"
@@ -220,10 +219,6 @@ defmodule OliWeb.Projects.PublishView do
            to: Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.PublishView, project.slug)
          )}
     end
-  end
-
-  def handle_event("force_push", _, socket) do
-    {:noreply, assign(socket, is_force_push: !socket.assigns.is_force_push)}
   end
 
   def handle_event("display_lti_connect_modal", %{}, socket) do

--- a/lib/oli_web/live/projects/versioning_details.ex
+++ b/lib/oli_web/live/projects/versioning_details.ex
@@ -29,7 +29,7 @@ defmodule OliWeb.Projects.VersioningDetails do
   def render(assigns) do
     ~F"""
       <div class="my-4 border-t pt-3">
-        <Form for={@changeset} submit={@publish_active} change="form_changed">
+        <Form id="versioning-details-form" for={@changeset} submit={@publish_active} change="form_changed">
 
           {#if @has_changes && @active_publication_changes}
             <h5>Versioning Details</h5>

--- a/test/oli_web/live/publish_live_test.exs
+++ b/test/oli_web/live/publish_live_test.exs
@@ -296,8 +296,10 @@ defmodule OliWeb.PublishLiveTest do
       {:ok, view, _html} = live(conn, live_view_publish_route(project.slug))
 
       view
-      |> element("input[phx-click=\"force_push\"]")
-      |> render_click()
+      |> element("form#versioning-details-form")
+      |> render_change(%{
+        "publication" => %{"auto_push_update" => "true", "description" => "some description"}
+      })
 
       assert has_element?(view, "li", "#{push_affected.product_count} product(s)")
       assert has_element?(view, "li", "#{push_affected.section_count} course section(s)")
@@ -309,11 +311,14 @@ defmodule OliWeb.PublishLiveTest do
            project: project
          } do
       insert(:publication, project: project, published: yesterday())
+
       {:ok, view, _html} = live(conn, live_view_publish_route(project.slug))
 
       view
-      |> element("input[phx-click=\"force_push\"]")
-      |> render_click()
+      |> element("form#versioning-details-form")
+      |> render_change(%{
+        "publication" => %{"auto_push_update" => "true", "description" => "some description"}
+      })
 
       assert view
              |> element("div.alert.alert-warning")


### PR DESCRIPTION
I kept stumbling into this issue while testing and it was very frustrating. This fixes an issue where clicking the "Automatically push this publication update to all products and sections" would clear the existing description textfield.

I tested this thoroughly, publishing both with and without the checkbox checked and verified the description was still being saved properly.

<img width="1244" alt="Screenshot 2023-07-14 at 3 56 48 PM" src="https://github.com/Simon-Initiative/oli-torus/assets/6248894/69d95579-a58b-465b-932a-b552399805bc">
