### PR TITLE
[BUG FIX] Fix approve two posts [MER-2310]

### DIFF
--- a/lib/oli_web/components/delivery/discussion_activity/discussion_activity.ex
+++ b/lib/oli_web/components/delivery/discussion_activity/discussion_activity.ex
@@ -12,14 +12,14 @@ defmodule OliWeb.Components.Delivery.DiscussionActivity do
 
   alias Phoenix.LiveView.JS
 
-  prop limit, :number, default: 10
-  prop filter, :string, required: true
-  prop offset, :number, required: true
-  prop count, :number, required: true
-  prop collab_space_table_model, :struct, required: true
-  prop discussion_table_model, :struct, required: true
-  prop parent_component_id, :string, required: true
-  prop section_slug, :string, required: true
+  prop(limit, :number, default: 10)
+  prop(filter, :string, required: true)
+  prop(offset, :number, required: true)
+  prop(count, :number, required: true)
+  prop(collab_space_table_model, :struct, required: true)
+  prop(discussion_table_model, :struct, required: true)
+  prop(parent_component_id, :string, required: true)
+  prop(section_slug, :string, required: true)
 
   @default_params %{
     offset: 0,
@@ -108,7 +108,7 @@ defmodule OliWeb.Components.Delivery.DiscussionActivity do
   def handle_event("display_accept_modal", %{"post_id" => post_id}, socket) do
     modal_assigns = %{
       title: "Accept Post",
-      id: "accept_post_modal",
+      id: "accept_post_modal_#{UUID.uuid4()}",
       ok: JS.push("accept_post", target: socket.assigns.myself),
       cancel: JS.push("cancel_confirm_modal", target: socket.assigns.myself)
     }
@@ -140,7 +140,7 @@ defmodule OliWeb.Components.Delivery.DiscussionActivity do
   def handle_event("display_reject_modal", %{"post_id" => post_id}, socket) do
     modal_assigns = %{
       title: "Reject Post",
-      id: "reject_post_modal",
+      id: "reject_post_modal_#{UUID.uuid4()}",
       ok: JS.push("reject_post", target: socket.assigns.myself),
       cancel: JS.push("cancel_confirm_modal", target: socket.assigns.myself)
     }
@@ -207,7 +207,8 @@ defmodule OliWeb.Components.Delivery.DiscussionActivity do
         )
 
       _ ->
-        {:ok, discussion_table_model} = DiscussionTableModel.new([], section_slug, socket.assigns.myself)
+        {:ok, discussion_table_model} =
+          DiscussionTableModel.new([], section_slug, socket.assigns.myself)
 
         {count, rows} =
           Collaboration.list_posts_in_section_for_instructor(section_slug, filter,

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -39,9 +39,9 @@ defmodule OliWeb.PageDeliveryController do
           render(conn, "error.html")
 
         section ->
-          is_instructor = Sections.is_instructor?(user, section_slug)
+          user_roles = Sections.get_user_roles(user, section_slug)
 
-          if is_instructor do
+          if user_roles.is_instructor? do
             conn
             |> redirect(
               to:
@@ -79,7 +79,8 @@ defmodule OliWeb.PageDeliveryController do
               container_link_url: &Routes.page_delivery_path(conn, :container, section_slug, &1),
               collab_space_config: effective_settings.collab_space_config,
               revision_slug: revision.slug,
-              is_instructor: is_instructor,
+              is_instructor: user_roles.is_instructor?,
+              is_student: user_roles.is_student?,
               progress: learner_progress(section.id, user.id),
               next_activities: next_activities,
               independent_learner: user.independent_learner,
@@ -756,6 +757,7 @@ defmodule OliWeb.PageDeliveryController do
       collab_space_config: effective_settings.collab_space_config,
       revision_slug: revision.slug,
       is_instructor: false,
+      is_student: false,
       current_user_id: current_user.id
     )
   end

--- a/lib/oli_web/templates/page_delivery/index.html.heex
+++ b/lib/oli_web/templates/page_delivery/index.html.heex
@@ -55,6 +55,7 @@
                   "section_slug" => @section_slug,
                   "resource_slug" => @revision_slug,
                   "is_instructor" => @is_instructor,
+                  "is_student" => @is_student
                 })
             %>
           </div>


### PR DESCRIPTION
[Link to the comment](https://eliterate.atlassian.net/browse/MER-2310?focusedCommentId=20788) in the ticket

### Before
See video attached in the comment

### After

https://github.com/Simon-Initiative/oli-torus/assets/74839302/7a5420fd-fe02-4a5f-8e14-0cc6324d7c5e


While working on the ticket, another bug was found; the collab space config was not being applied correctly for students in the Discussion component of the home section, so their posts were being directly approved (as if they were instructors). In the following videos, the course has the following collab space config:

![image](https://github.com/Simon-Initiative/oli-torus/assets/74839302/9e398d2f-ad3b-41c1-a762-22cd8e017a54)

### Before

https://github.com/Simon-Initiative/oli-torus/assets/74839302/cfdb69ca-e872-407c-8ff8-f975f04208ac



### After

https://github.com/Simon-Initiative/oli-torus/assets/74839302/a3107e9f-07f1-4162-aa17-d1f64bd72af6


