### PR TITLE
[BUG FIX] Fix cancel button, fix finish page for adaptive [MER-2248] [MER-1999]

### DIFF
--- a/assets/src/apps/delivery/layouts/deck/LessonFinishedDialog.tsx
+++ b/assets/src/apps/delivery/layouts/deck/LessonFinishedDialog.tsx
@@ -22,9 +22,9 @@ const LessonFinishedDialog: React.FC<LessonFinishedDialogProps> = ({
   hideCloseButton,
 }) => {
   const [isOpen, setIsOpen] = useState(true);
+  const [redirectURL, setRedirectURL] = useState('');
   const isPreviewMode = useSelector(selectPreviewMode);
   const graded = useSelector(selectIsGraded);
-  const overviewURL = useSelector(selectOverviewURL);
   const revisionSlug = useSelector(selectPageSlug);
   const sectionSlug = useSelector(selectSectionSlug);
   const resourceAttemptGuid = useSelector(selectResourceAttemptGuid);
@@ -42,9 +42,9 @@ const LessonFinishedDialog: React.FC<LessonFinishedDialogProps> = ({
     if (!graded || isPreviewMode) {
       window.location.reload();
     } else {
-      window.location.href = overviewURL;
+      window.location.href = redirectURL;
     }
-  }, [isFinalized, isPreviewMode, overviewURL]);
+  }, [isFinalized, isPreviewMode, redirectURL]);
 
   const handleFinalization = useCallback(async () => {
     setFinalizationCalled(true);
@@ -62,6 +62,7 @@ const LessonFinishedDialog: React.FC<LessonFinishedDialogProps> = ({
             console.error('failed to finalize attempt', finalizeResult);
             return;
           }
+          setRedirectURL(finalizeResult.redirectTo);
         } else {
           console.error('failed to finalize attempt (SERVER ERROR)', finalizeResult);
           return;

--- a/assets/src/apps/delivery/layouts/deck/LessonFinishedDialog.tsx
+++ b/assets/src/apps/delivery/layouts/deck/LessonFinishedDialog.tsx
@@ -3,7 +3,6 @@ import { useSelector } from 'react-redux';
 import { ActionResult, finalizePageAttempt } from 'data/persistence/page_lifecycle';
 import {
   selectIsGraded,
-  selectOverviewURL,
   selectPageSlug,
   selectPreviewMode,
   selectResourceAttemptGuid,

--- a/lib/oli_web/components/delivery/actions/actions.ex
+++ b/lib/oli_web/components/delivery/actions/actions.ex
@@ -63,7 +63,6 @@ defmodule OliWeb.Components.Delivery.Actions do
           module={OliWeb.Components.Modal}
           id="unenroll_user_modal"
           title="Unenroll student"
-          on_cancel={JS.push("close", target: "unenroll_user_modal")}
           on_confirm={JS.push("unenroll", target: @myself)}
         >
           <div class="px-4">

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -675,7 +675,12 @@ defmodule OliWeb.PageDeliveryController do
         previewMode: preview_mode,
         isInstructor: true,
         reviewMode: context.review_mode,
-        overviewURL: Routes.page_delivery_path(OliWeb.Endpoint, :index, section.slug),
+        overviewURL: Routes.page_delivery_path(
+          conn,
+          :page,
+          section_slug,
+          context.page.slug
+        ),
         finalizeGradedURL:
           Routes.page_lifecycle_path(
             conn,

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -675,12 +675,7 @@ defmodule OliWeb.PageDeliveryController do
         previewMode: preview_mode,
         isInstructor: true,
         reviewMode: context.review_mode,
-        overviewURL: Routes.page_delivery_path(
-          conn,
-          :page,
-          section_slug,
-          context.page.slug
-        ),
+        overviewURL: Routes.page_delivery_path(OliWeb.Endpoint, :index, section.slug),
         finalizeGradedURL:
           Routes.page_lifecycle_path(
             conn,


### PR DESCRIPTION
Fix two open issues:

1. [MER-2248] The "cancel" button did nothing in the confirmation step for "Unenroll".  Could not get this to work correctly, so I removed it.  The "X" button does work and closes the dialog
2. [MER-1999] The LessonFinishedDialog was using the wrong URL for redirect after lesson completion. It needs to be using the URL in the response from finalization (which for Adaptive is now always going to be the 'prologue' page)

[MER-2248]: https://eliterate.atlassian.net/browse/MER-2248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MER-1999]: https://eliterate.atlassian.net/browse/MER-1999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ