### PR TITLE
[ENHANCEMENT] track dirty state of input for onBlur submission [MER-2344]

### DIFF
--- a/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
@@ -53,12 +53,11 @@ export const MultiInputComponent: React.FC = () => {
   const [hintsShown, setHintsShown] = React.useState<PartId[]>([]);
 
   const [isInputDirty, setInputDirty] = React.useState(
-    activityState.parts
-    .reduce((acc: any, part) => {
+    activityState.parts.reduce((acc: any, part) => {
       acc[part.partId] = false;
       return acc;
-    },
-    {}));
+    }, {}),
+  );
 
   const deferredSaves = useRef(
     model.inputs.reduce((m: any, input: MultiInput) => {
@@ -262,7 +261,11 @@ export const MultiInputComponent: React.FC = () => {
     const input = getByUnsafe((uiState.model as MultiInputSchema).inputs, (x) => x.id === id);
     if (input.inputType !== 'dropdown' && hasActualInput(id)) {
       deferredSaves.current[id].flushPendingChanges(false);
-      if ((uiState.model as MultiInputSchema).submitPerPart && !context.graded && isInputDirty[id as any]) {
+      if (
+        (uiState.model as MultiInputSchema).submitPerPart &&
+        !context.graded &&
+        isInputDirty[id as any]
+      ) {
         handlePerPartSubmission(input.partId);
         setInputDirty(Object.assign({}, isInputDirty, { [id]: false }));
       }


### PR DESCRIPTION
This PR adds "isDirty" tracking to the "submitPerPart" mode of the MultiInput activity.  This changes the behavior so that losing focus only submits the part when there had been a content change made to the input. 