### PR TITLE
[BUGFIX] Minor styling fix to adaptive restart dialog [MER-2321]

### DIFF
--- a/assets/src/apps/delivery/layouts/deck/RestartLessonDialog.tsx
+++ b/assets/src/apps/delivery/layouts/deck/RestartLessonDialog.tsx
@@ -105,6 +105,7 @@ const RestartLessonDialog: React.FC<RestartLessonDialogProps> = ({ onRestart }) 
         data-keyboard="false"
         aria-hidden={!isOpen}
         style={{
+          maxWidth: '600px',
           display: isOpen ? 'block' : 'none',
           top: '20%',
           left: '50%',


### PR DESCRIPTION
This is a minor change to the restart dialog to constrain it's max width and look a little nicer in default CSS.

The bug referenced in MER-2321 looks like it was fixed in lesson specific css.

Before:
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/29fa026a-fae1-465c-8405-aa2cad6426dc)

After:
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/bf19d5f1-67fe-42a2-a5c8-cb4c8f7fd195)
