### PR TITLE
[BUG FIX] Contained pages robustness [MER-2348] [MER-2345]

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -1678,24 +1678,36 @@ defmodule Oli.Delivery.Sections do
   # Recursive helper to traverse the hierarchy of the section resources and create the page to ancestor
   # container map.
   defp rebuild_contained_pages_helper(sr, {ancestors, page_map, all, container_ids}) do
-    case Enum.map(sr.children, fn sr_id ->
-           sr = Map.get(all, sr_id)
+    case sr do
+      nil -> %{}
 
-           case MapSet.member?(container_ids, sr.resource_id) do
-             true ->
-               rebuild_contained_pages_helper(
-                 sr,
-                 {[sr.resource_id | ancestors], page_map, all, container_ids}
-               )
-               |> Map.merge(page_map)
+      _ ->
+        case Enum.map(sr.children, fn sr_id ->
+          sr = Map.get(all, sr_id)
 
-             false ->
-               Map.put(page_map, sr.resource_id, ancestors)
-           end
-         end) do
-      [] -> %{}
-      other -> Enum.reduce(other, fn m, a -> Map.merge(m, a) end)
+          case sr do
+            nil -> []
+            _ -> case MapSet.member?(container_ids, sr.resource_id) do
+              true ->
+                rebuild_contained_pages_helper(
+                  sr,
+                  {[sr.resource_id | ancestors], page_map, all, container_ids}
+                )
+                |> Map.merge(page_map)
+
+              false ->
+                Map.put(page_map, sr.resource_id, ancestors)
+            end
+          end
+
+        end)
+        |> Enum.filter(fn m -> !is_nil(m) end) do
+        [] -> %{}
+        other -> Enum.reduce(other, fn m, a -> Map.merge(m, a) end)
+      end
     end
+
+
   end
 
   defp set_contained_page_counts(section_id) do

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -1686,7 +1686,7 @@ defmodule Oli.Delivery.Sections do
           sr = Map.get(all, sr_id)
 
           case sr do
-            nil -> []
+            nil -> nil
             _ -> case MapSet.member?(container_ids, sr.resource_id) do
               true ->
                 rebuild_contained_pages_helper(


### PR DESCRIPTION
There must be some mangled, old course sections which trip out the `Sections.rebuild_contained_pages_helper`.  This PR improves the robustness of that function by explicitly handling (and filtering out) bad data. 

