### PR TITLE
[BUG FIX] [MER-2363] fix an issue where input refs don't reflect their actual size

### DIFF
--- a/assets/src/components/editing/elements/inputref/InputRefEditor.tsx
+++ b/assets/src/components/editing/elements/inputref/InputRefEditor.tsx
@@ -25,7 +25,7 @@ export const InputRefEditor = (props: InputRefEditorProps) => {
       <span
         {...props.attributes}
         contentEditable={false}
-        className="inline-block align-middle select-none rounded p-1 px-2 border border-red-500 bg-red-100 text-red-500 dark:text-red-600"
+        className="input-ref inline-block align-middle select-none rounded p-1 px-2 border border-red-500 bg-red-100 text-red-500 dark:text-red-600"
       >
         Missing Input Ref (delete){props.children}
       </span>
@@ -65,7 +65,7 @@ export const InputRefEditor = (props: InputRefEditorProps) => {
         <span
           onClick={(e) => action(e)}
           className={classNames(
-            'inline-block align-middle select-none rounded p-1 px-2 whitespace-nowrap overflow-hidden border',
+            'input-ref inline-block align-middle select-none rounded p-1 px-2 whitespace-nowrap overflow-hidden border',
             inputRefContext.selectedInputRef?.id === props.model.id
               ? 'border-primary bg-blue-100 dark:bg-blue-700 text-primary dark:text-body-color-dark'
               : 'border-gray-400 dark:border-gray-600 text-gray-400 dark:text-gray-600',

--- a/assets/styles/common/elements.scss
+++ b/assets/styles/common/elements.scss
@@ -526,9 +526,12 @@ $element-margin-bottom: 1.5em;
     font-family: Arial, Helvetica, sans-serif;
   }
 
+  .input-ref,
   input[type='text'],
   input[type='numeric'],
   select.dropdown-input {
+    width: 180px;
+
     &.input-size-small {
       width: 80px;
     }


### PR DESCRIPTION
This PR fixes an issue where input refs in multi-input author do not properly reflect the size set on them.

<img width="867" alt="Screenshot 2023-07-18 at 3 33 53 PM" src="https://github.com/Simon-Initiative/oli-torus/assets/6248894/956b89f1-4cf2-4cf3-965d-710502c5d561">

This fix seems to high risk and low priority for v24 at this point, but I already tracked down and fixed the issue so I am targeting for v25

Closes #3956