### PR TITLE
[BUGFIX][MER-2302] Fix cancel button customize curriculum

### DIFF
--- a/lib/oli_web/live/common/cancel_modal.ex
+++ b/lib/oli_web/live/common/cancel_modal.ex
@@ -1,0 +1,30 @@
+defmodule OliWeb.Common.Cancel do
+  use Phoenix.LiveComponent
+
+  attr :title, :string, required: true
+  attr :ok, :any, required: true
+  attr :cancel, :any, required: true
+  attr :id, :string, required: true
+  slot :inner_block, required: true
+
+  def render(assigns) do
+    ~H"""
+    <div id={@id} class={"modal fade show"} tabindex="-1" role="dialog" aria-hidden="true" phx-hook="ModalLaunch">
+      <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title"><%= assigns.title %></h5>
+          </div>
+          <div class="modal-body">
+            <%= render_slot(@inner_block) %>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" phx-click={@cancel}>Cancel</button>
+            <button type="button" class="btn btn-primary" data-bs-dismiss="modal" phx-click={@ok}>Ok</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/oli_web/live/delivery/remix_section.ex
+++ b/lib/oli_web/live/delivery/remix_section.ex
@@ -30,6 +30,7 @@ defmodule OliWeb.Delivery.RemixSection do
   alias Oli.Publishing.PublishedResource
   alias OliWeb.Sections.Mount
   alias Oli.Delivery.Sections.Section
+  alias OliWeb.Common.Cancel
 
   alias Phoenix.LiveView.JS
 
@@ -344,6 +345,32 @@ defmodule OliWeb.Delivery.RemixSection do
   end
 
   def handle_event("cancel", _, socket) do
+    modal_assigns = %{
+      title: "Cancel changes",
+      id: "cancel_modal",
+      ok: "ok_cancel_modal",
+      cancel: "cancel_modal"
+    }
+
+    modal = fn assigns ->
+      ~H"""
+        <Cancel.render {@modal_assigns}>Are you sure you want to cancel?</Cancel.render>
+      """
+    end
+
+    {:noreply,
+     show_modal(
+       socket,
+       modal,
+       modal_assigns: modal_assigns
+     )}
+  end
+
+  def handle_event("cancel_modal", _, socket) do
+    {:noreply, hide_modal(socket, modal_assigns: nil)}
+  end
+
+  def handle_event("ok_cancel_modal", _, socket) do
     %{redirect_after_save: redirect_after_save} = socket.assigns
 
     {:noreply,

--- a/lib/oli_web/live/delivery/remix_section.html.heex
+++ b/lib/oli_web/live/delivery/remix_section.html.heex
@@ -9,7 +9,14 @@
         Customize your curriculum by adding, removing and rearranging course materials.
         <div class="flex-grow-1"></div>
         <div class="flex-shrink-0">
-          <button id="cancel" class="btn btn-outline-primary ml-1" phx-click="cancel">Cancel</button>
+          <button
+            id="cancel"
+            disabled={!@has_unsaved_changes}
+            class="btn btn-outline-primary ml-1"
+            phx-click={JS.set_attribute({"data-saved", "true"}, to: "#curriculum-container") |> JS.push("cancel")}
+          >
+            Cancel
+          </button>
           <button
             id="save"
             disabled={!@has_unsaved_changes}


### PR DESCRIPTION
[MER-2302](https://eliterate.atlassian.net/browse/MER-2302)

This PR fixes the issue that happened when clicking the cancel button in the Customize Curriculum view. 

Now, when we have added some element to the curriculum and press the cancel button we have 2 options: 

- `Cancel` option has no action. Just close the modal. 

- `Ok` option will redirect the user to the Section Overview. 


https://github.com/Simon-Initiative/oli-torus/assets/16328384/04680f80-f10d-4857-be4d-4281ae128931


[MER-2302]: https://eliterate.atlassian.net/browse/MER-2302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ