### PR TITLE
[BUG FIX] [MER-2368] fix typo in activity bank selection title

### DIFF
--- a/lib/oli_web/controllers/activity_bank_controller.ex
+++ b/lib/oli_web/controllers/activity_bank_controller.ex
@@ -77,7 +77,7 @@ defmodule OliWeb.ActivityBankController do
           conn = put_root_layout(conn, {OliWeb.LayoutView, "delivery.html"})
 
           render(conn, "preview.html",
-            title: "Actiivty Bank Selection Preview",
+            title: "Activity Bank Selection Preview",
             rendered_selection: rendered_selection,
             paging: paging_params,
             limit: 5,


### PR DESCRIPTION
Fixes a typo

<img width="211" alt="Screenshot 2023-07-19 at 11 50 25 AM" src="https://github.com/Simon-Initiative/oli-torus/assets/6248894/5adb5abd-40f0-4881-9f97-ae2c100e895d">
