### PR TITLE
[BUGFIX][MER-2298] Disable sort by published date in add materials modal

### DIFF
--- a/lib/oli_web/live/common/hierarchy/hierarchy_picker_table_model.ex
+++ b/lib/oli_web/live/common/hierarchy/hierarchy_picker_table_model.ex
@@ -33,7 +33,8 @@ defmodule OliWeb.Common.Hierarchy.HierarchyPicker.TableModel do
         label: "Published on",
         render_fn: &__MODULE__.custom_render/3,
         th_class: "pl-2 text-right",
-        td_class: "text-right"
+        td_class: "text-right",
+        sortable: false
       }
     ]
 

--- a/test/oli_web/live/remix_section_test.exs
+++ b/test/oli_web/live/remix_section_test.exs
@@ -579,12 +579,16 @@ defmodule OliWeb.RemixSectionLiveTest do
       assert view
              |> has_element?(
                ".remix_materials_table tbody tr:first-of-type td:nth-of-type(2)",
-               "Elixir Page"
+               "Another orph. Page"
              )
 
       view
       |> element("th[phx-value-sort_by=\"title\"]")
       |> render_click()
+
+      # Can't sort by published date
+      assert view
+             |> has_element?("th[data-sortable=\"false\"]", "Published on")
 
       assert view
              |> has_element?(".remix_materials_table tr:first-of-type td", "Another orph. Page")

--- a/test/oli_web/live/remix_section_test.exs
+++ b/test/oli_web/live/remix_section_test.exs
@@ -579,7 +579,7 @@ defmodule OliWeb.RemixSectionLiveTest do
       assert view
              |> has_element?(
                ".remix_materials_table tbody tr:first-of-type td:nth-of-type(2)",
-               "Another orph. Page"
+               "Elixir Page"
              )
 
       view

--- a/test/oli_web/live/sections/edit_live_test.exs
+++ b/test/oli_web/live/sections/edit_live_test.exs
@@ -289,8 +289,6 @@ defmodule OliWeb.Sections.EditLiveTest do
       |> element("form[phx-submit=\"save\"")
       |> render_submit(%{section: %{start_date: today, end_date: yesterday}})
 
-      open_browser(view)
-
       assert has_element?(view, "span.help-block", "must be before the end date")
       assert has_element?(view, "span.help-block", "must be after the start date")
     end


### PR DESCRIPTION
[Link to the ticket](https://eliterate.atlassian.net/browse/MER-2298)

### NOTES
The issue is not because of the double click. It's because the sorting by published date wasn't being handled. I removed the ability to sort by this attribute because all revisions for a given publication are going to have the same publication date so it doesn't make sense to sort them by it.