### PR TITLE
[BUGFIX][MER-2261] Verify section start and end dates before saving

### DIFF
--- a/lib/oli/utils.ex
+++ b/lib/oli/utils.ex
@@ -214,10 +214,20 @@ defmodule Oli.Utils do
   end
 
   def validate_dates_consistency(changeset, start_date_field, end_date_field) do
-    validate_change(changeset, start_date_field, fn _, field ->
-      # check if the start date is after the end date
-      if Timex.compare(field, get_field(changeset, end_date_field)) == 1 do
-        [{start_date_field, "must be before the end date"}]
+    changeset =
+      validate_change(changeset, start_date_field, fn _, field ->
+        # check if the start date is after the end date
+        if Timex.compare(field, get_field(changeset, end_date_field)) == 1 do
+          [{start_date_field, "must be before the end date"}]
+        else
+          []
+        end
+      end)
+
+    validate_change(changeset, end_date_field, fn _, field ->
+      # check if the end date is before the start date
+      if Timex.compare(field, get_field(changeset, start_date_field)) == -1 do
+        [{end_date_field, "must be after the start date"}]
       else
         []
       end

--- a/lib/oli_web/live/common/properties/group.ex
+++ b/lib/oli_web/live/common/properties/group.ex
@@ -8,7 +8,7 @@ defmodule OliWeb.Common.Properties.Group do
 
   def render(assigns) do
     ~F"""
-    <div class={"grid grid-cols-12 py-5 #{if !assigns[:is_last], do: "border-b"}"}>
+    <div class={"flex flex-col px-4 gap-4 md:px-0 md:grid md:gap-0 grid-cols-12 py-5 #{if !assigns[:is_last], do: "border-b"}"}>
       <div class="md:col-span-4">
         <h4>{@label}</h4>
         {#if assigns[:description]}

--- a/lib/oli_web/live/common/show_section.ex
+++ b/lib/oli_web/live/common/show_section.ex
@@ -7,7 +7,7 @@ defmodule OliWeb.Common.ShowSection do
 
   def render(assigns) do
     ~F"""
-    <div class="grid grid-cols-12 py-5 border-b">
+    <div class="flex md:grid grid-cols-12 py-5 border-b">
       <div class="md:col-span-4">
         <h4>{@section_title}</h4>
         {#unless is_nil(@section_description)}

--- a/lib/oli_web/live/sections/start_end.ex
+++ b/lib/oli_web/live/sections/start_end.ex
@@ -22,8 +22,8 @@ defmodule OliWeb.Sections.StartEnd do
       |> FormatDateTime.convert_datetime(assigns.ctx)
 
     ~F"""
-      <div class="form-row mt-4">
-        <Field name={:start_date} class="mr-3 form-label-group">
+      <div class="flex flex-col gap-2 mt-4">
+        <Field name={:start_date} class="form-label-group">
           <div class="d-flex justify-content-between"><Label/><ErrorTag class="help-block"/></div>
           <DateTimeLocalInput class="form-control" value={start_date} opts={disabled: @disabled}/>
         </Field>
@@ -31,7 +31,9 @@ defmodule OliWeb.Sections.StartEnd do
           <div class="d-flex justify-content-between"><Label/><ErrorTag class="help-block"/></div>
           <DateTimeLocalInput class="form-control" value={end_date} opts={disabled: @disabled}/>
         </Field>
-        <button class="btn btn-primary mt-3" type="submit">Save</button>
+        <div class="mt-3">
+          <button class="btn btn-primary" type="submit">Save</button>
+        </div>
       </div>
     """
   end

--- a/test/oli_web/live/sections/edit_live_test.exs
+++ b/test/oli_web/live/sections/edit_live_test.exs
@@ -278,5 +278,21 @@ defmodule OliWeb.Sections.EditLiveTest do
       updated_section = Sections.get_section!(section.id)
       assert updated_section.title == valid_title
     end
+
+    test "update section with an invalid start/end date shows an error", %{conn: conn, section: section} do
+      {:ok, view, _html} = live(conn, live_view_edit_route(section.slug))
+
+      today = DateTime.utc_now()
+      yesterday = DateTime.add(today, -1, :day)
+
+      view
+      |> element("form[phx-submit=\"save\"")
+      |> render_submit(%{section: %{start_date: today, end_date: yesterday}})
+
+      open_browser(view)
+
+      assert has_element?(view, "span.help-block", "must be before the end date")
+      assert has_element?(view, "span.help-block", "must be after the start date")
+    end
   end
 end


### PR DESCRIPTION
[Link to the story](https://eliterate.atlassian.net/browse/MER-1953)

This should fix similar issues with gating condition data and system messages because they also make use of `validate_dates_consistency/2`