### PR TITLE
[Feature] Better handling of duplicate content uploads [MER-2373]

### DIFF
--- a/test/oli/authoring/media_libary_test.exs
+++ b/test/oli/authoring/media_libary_test.exs
@@ -58,12 +58,8 @@ defmodule Oli.Authoring.MediaLibraryTest do
       assert {:error, {:not_found}} == MediaLibrary.size("thisprojectdoesnotexist")
     end
 
-    test "add/3 detects duplicate file name", %{project1: project1} do
-      assert {:error, {:file_exists}} == MediaLibrary.add(project1.slug, "3", "test")
-    end
-
     test "add/3 detects duplicate file contents", %{project1: project1} do
-      {:ok, item} = MediaLibrary.add(project1.slug, "newfile", "identical content")
+      {:duplicate, item} = MediaLibrary.add(project1.slug, "newfile", "identical content")
       assert item.file_name == "9"
     end
 


### PR DESCRIPTION
There was some confusing behavior around uploading duplicate files (either in filename or in content) that this PR addresses.

### Use case 1: 

Before:

> If you tried to upload a file with the same name but different content as one in the media library, you got an error.

Now:
> You are allowed to upload that second file. Both appear in your media list as expected

### Use case 2: 

Before:
> If you tried to upload a file with the same name and the same content, it would give you an error.

Now:
> The existing item will be selected and a small message telling you what happened.

### Use case 3: 

Before:
> If you tried to upload a file with a different name, but the same content, it would silently select the existing item.

Now:
> You get a small message telling you what happened.


Example message:

![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/09e96559-cf2e-450f-8c04-d5b81679b644)

It will dissapear after 5 seconds, or if you click on it.

