### PR TITLE
[BUG FIX] Fix UpNext date display, fix sorting on identifical end_dates

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -2502,13 +2502,17 @@ defmodule Oli.Delivery.Sections do
       section_id: s.id,
       relates_to: rev.relates_to
     })
-    |> order_by([{:asc_nulls_last, fragment("end_date")}])
+    |> order_by([
+      {:asc_nulls_last, fragment("end_date")},
+      {:asc_nulls_last, fragment("numbering_level")},
+      {:asc_nulls_last, fragment("numbering_index")}
+    ])
   end
 
   @doc """
     Returns the activities that a student need to complete next.
   """
-  def get_next_activities_for_student(section_slug, user_id) do
+  def get_next_activities_for_student(section_slug, user_id, session_context) do
     student_pages_query = get_student_pages(section_slug, user_id)
 
     query =
@@ -2532,7 +2536,7 @@ defmodule Oli.Delivery.Sections do
         if is_nil(sr.end_date) do
           nil
         else
-          to_datetime(sr.end_date)
+          OliWeb.Common.FormatDateTime.date(sr.end_date,)
         end
       )
     end)

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -2536,7 +2536,7 @@ defmodule Oli.Delivery.Sections do
         if is_nil(sr.end_date) do
           nil
         else
-          OliWeb.Common.FormatDateTime.date(sr.end_date,)
+          OliWeb.Common.FormatDateTime.date(sr.end_date, session_context)
         end
       )
     end)

--- a/lib/oli/delivery/sections/scheduling.ex
+++ b/lib/oli/delivery/sections/scheduling.ex
@@ -55,6 +55,7 @@ defmodule Oli.Delivery.Sections.Scheduling do
   updated - or a {:error, error} tuple.
   """
   def update(%Section{id: section_id}, updates, timezone) do
+
     if is_valid_update?(updates) do
       case build_values_params(updates, timezone) do
         {[], []} ->

--- a/lib/oli_web/components/delivery/up_next.ex
+++ b/lib/oli_web/components/delivery/up_next.ex
@@ -24,7 +24,7 @@ defmodule OliWeb.Components.Delivery.UpNext do
                 badge_bg_color={if activity.graded, do: "bg-fuchsia-800", else: "bg-green-700"}
                 title={activity.title}
                 percent_complete={activity.progress}
-                complete_by_date={format_date(activity.end_date)}
+                complete_by_date={activity.end_date}
                 scheduling_type={activity.scheduling_type}
                 open_href={Routes.page_delivery_path(OliWeb.Endpoint, :page, @section_slug, activity.slug)}
                 percent_students_completed={Float.floor(activity.completion_percentage) |> trunc()}

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -32,6 +32,8 @@ defmodule OliWeb.PageDeliveryController do
     user = conn.assigns.current_user
     section = conn.assigns.section
 
+    context = conn.assigns[:ctx]
+
     if Sections.is_enrolled?(user.id, section_slug) do
       case section
            |> Oli.Repo.preload([:base_project, :root_section_resource]) do
@@ -59,7 +61,7 @@ defmodule OliWeb.PageDeliveryController do
               Oli.Delivery.Settings.get_combined_settings(revision, section.id, user.id)
 
             next_activities =
-              Sections.get_next_activities_for_student(section_slug, user.id)
+              Sections.get_next_activities_for_student(section_slug, user.id, context)
               |> Enum.map(fn sr ->
                 case sr.scheduling_type do
                   :read_by -> Map.put(sr, :scheduling_type, "Read by")


### PR DESCRIPTION
Fixes two problems:

1. Identically scheduled resources can seemingly be "randomly" picked for the UpNext display. This is due to lack of secondary sorting to sort by course positioning. 
2. UpNext was not rendering date in user's local timezone