### PR TITLE
[Bugfix]  schedule timezone bug [MER-2378]

### DIFF
--- a/lib/oli/delivery/sections/scheduling.ex
+++ b/lib/oli/delivery/sections/scheduling.ex
@@ -99,8 +99,8 @@ defmodule Oli.Delivery.Sections.Scheduling do
   end
 
   defp parse_date(nil, _), do: nil
-  defp parse_date(date_time_str, timezone) do
 
+  defp parse_date(date_time_str, timezone) do
     # From the front end we can receive two forms of date time strings:
     # 1. "2019-01-01 00:00:00"
     # 2. "2019-01-01"
@@ -110,11 +110,13 @@ defmodule Oli.Delivery.Sections.Scheduling do
       true ->
         [date_str, time_str] = String.split(date_time_str, " ")
 
-        [y, m, d] = String.split(date_str, "-")
-        |> Enum.map(fn s -> String.to_integer(s) end)
+        [y, m, d] =
+          String.split(date_str, "-")
+          |> Enum.map(fn s -> String.to_integer(s) end)
 
-        [h, n, s] = String.split(time_str, ":")
-        |> Enum.map(fn s -> String.to_integer(s) end)
+        [h, n, s] =
+          String.split(time_str, ":")
+          |> Enum.map(fn s -> String.to_integer(s) end)
 
         {:ok, date} = Date.new(y, m, d)
         {:ok, time} = Time.new(h, n, s)
@@ -124,19 +126,16 @@ defmodule Oli.Delivery.Sections.Scheduling do
         DateTime.truncate(date_time, :second)
 
       false ->
-
-        [y, m, d] = String.split(date_time_str, "-")
-        |> Enum.map(fn s -> String.to_integer(s) end)
+        [y, m, d] =
+          String.split(date_time_str, "-")
+          |> Enum.map(fn s -> String.to_integer(s) end)
 
         {:ok, date} = Date.new(y, m, d)
         {:ok, time} = Time.new(23, 59, 59)
-
         {:ok, date_time} = DateTime.new(date, time, timezone)
         {:ok, date_time} = DateTime.shift_zone(date_time, "Etc/UTC")
         DateTime.truncate(date_time, :second)
-
     end
-
   end
 
   defp build_values_params(updates, timezone) do

--- a/test/oli_web/controllers/api/scheduling_controller_test.exs
+++ b/test/oli_web/controllers/api/scheduling_controller_test.exs
@@ -21,7 +21,6 @@ defmodule OliWeb.SchedulingControllerTest do
       conn: conn,
       map: map
     } do
-
       user = map.teacher
 
       conn =
@@ -36,46 +35,52 @@ defmodule OliWeb.SchedulingControllerTest do
       # Change the end date for all 3
       updates = Enum.map(resources, fn sr -> Map.put(sr, "end_date", "2024-01-02") end)
 
-      conn = again(conn, user)
-      |> put(Routes.scheduling_path(conn, :update, map.section.slug),
-          %{"updates" => updates})
+      conn =
+        again(conn, user)
+        |> put(
+          Routes.scheduling_path(conn, :update, map.section.slug),
+          %{"updates" => updates}
+        )
 
       assert %{"result" => "success", "count" => 3} = json_response(conn, 200)
 
-      conn = again(conn, user)
+      conn =
+        again(conn, user)
         |> get(Routes.scheduling_path(conn, :index, map.section.slug))
 
       assert %{"result" => "success", "resources" => resources} = json_response(conn, 200)
       assert length(resources) == 3
 
       Enum.each(resources, fn sr -> assert sr["end_date"] == "2024-01-02" end)
-
     end
 
     test "can catch unauthorized user access", %{
       conn: conn,
       map: map
     } do
-
       user = map.someone_else
 
-      conn = again(conn, user)
-      |> get(
-          Routes.scheduling_path(conn, :index, map.section.slug)
-        )
+      conn =
+        again(conn, user)
+        |> get(Routes.scheduling_path(conn, :index, map.section.slug))
 
       assert response(conn, 401)
-
     end
   end
 
   defp setup_session(%{conn: conn}) do
-
-    map = Seeder.base_project_with_resource2()
-    |> Seeder.add_user(%{}, :teacher)
-    |> Seeder.add_user(%{}, :someone_else)
+    map =
+      Seeder.base_project_with_resource2()
+      |> Seeder.add_user(
+        %{
+          preferences: %{timezone: "America/New_York"}
+        },
+        :teacher
+      )
+      |> Seeder.add_user(%{}, :someone_else)
 
     {:ok, initial_pub} = Publishing.publish_project(map.project, "some changes")
+
     {:ok, section} =
       Sections.create_section(%{
         title: "1",


### PR DESCRIPTION
1. Open scheduler for a course section that has some practice pages
2. Manually schedule a page for "Suggested By" for today, 7/20/23
3. Save the changes
4. Refresh the page
5. View that same practice page

Expected: the practice page says 7/20/23
Actual: the practice page says 7/21/23

The api sends a date with no time component back and forth, such as  `end_date: "2023-07-20"`.  The save call would convert that to "2023-07-20 11:59:59" in the user's timezone (America/New_York for this example), then convert to UTC (2023-07-21 3:59:59) and save it. 

The retrieval API call would later grab that (2023-07-21 3:59:59) strip the time (2023-07-21) and send it to the front end, effectively giving the date in UTC instead of the user's local time.


