### PR TITLE
[Bugfix] Dark mode component menu [MER-2335]

### DIFF
--- a/assets/src/components/editing/toolbar/Toolbar.modules.scss
+++ b/assets/src/components/editing/toolbar/Toolbar.modules.scss
@@ -120,7 +120,6 @@
   flex-wrap: wrap;
   padding: 8px;
   overflow-y: auto;
-  background: #f8f9fb;
   border: 2px solid var(--color-toolbar-border);
 
   .toolbarButton {
@@ -144,7 +143,6 @@
   flex-direction: column;
   padding: 8px;
   overflow-y: auto;
-  background: #f8f9fb;
   border: 2px solid var(--color-toolbar-border);
 
   .toolbarButton {
@@ -183,6 +181,7 @@
     color: #dee2f2;
   }
 
+  .multiDropdownGroup,
   .toolbarGroup {
     border-color: var(--color-toolbar-border-dark);
   }
@@ -199,7 +198,7 @@
   }
 
   .dropdownGroup {
-    background: #3e3f44;
+    background: #2a2b2e;
     border-color: var(--color-toolbar-border-dark);
   }
 }

--- a/assets/src/components/editing/toolbar/buttons/DropdownButton.tsx
+++ b/assets/src/components/editing/toolbar/buttons/DropdownButton.tsx
@@ -48,7 +48,11 @@ export const DropdownButton = (props: PropsWithChildren<Props>) => {
       reposition={true}
       align={'start'}
       containerStyle={{ zIndex: '100000' }}
-      content={<div className={classname}>{props.children}</div>}
+      content={
+        <div className={`${classname} bg-body dark:bg-body-dark text-body dark:text-body-dark `}>
+          {props.children}
+        </div>
+      }
     >
       <button
         className={classNames(


### PR DESCRIPTION
Dark mode wasn't working for the component dropdown menus. Now they look like this:

![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/44c24b4d-6176-4321-9d37-aa5dd8c23fa8)
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/93f1df8b-33ca-4c91-88e2-f170e1cd6625)
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/39b39420-8c3e-47a1-9427-b1ce757ed5df)

And lightmode still looks like:
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/2bd9890f-5762-4785-aec8-29c0a7b2e175)
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/47479645-5839-42bd-ac25-baafd37ac193)
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/7171a9db-3d97-4c5e-a031-5f905d133809)

