### PR TITLE
[BUG FIX] [MER-2382] discussions card unreadable in dark mode

### DIFF
--- a/assets/styles/delivery/page_delivery/collab_space.scss
+++ b/assets/styles/delivery/page_delivery/collab_space.scss
@@ -49,7 +49,7 @@ ul.collab-space__active-users {
     content: '\2022';
     color: var(--color-green-400);
     position: absolute;
-    top: -15px;
+    top: -12px;
     left: -20px;
     font-size: 2em;
   }

--- a/lib/oli_web/components/delivery/buttons.ex
+++ b/lib/oli_web/components/delivery/buttons.ex
@@ -26,36 +26,48 @@ defmodule OliWeb.Components.Delivery.Buttons do
   slot(:inner_block)
 
   def button_with_options(assigns) do
+    assigns =
+      assigns
+      |> assign(:button_class, "torus-button primary !rounded-r-none")
+      |> assign(
+        :dropdown_button_class,
+        "flex justify-center rounded-r-sm items-center px-2 text-white bg-delivery-primary hover:bg-delivery-primary-600 active:bg-delivery-primary-600 border-l border-delivery-primary-600 hover:bg-delivery-primary-700"
+      )
+      |> assign(
+        :option_class,
+        "text-gray-600 dark:text-white block whitespace-nowrap px-4 py-2 text-sm w-full text-left hover:bg-gray-100 dark:hover:bg-gray-800"
+      )
+
     ~H"""
     <div class="relative inline-block text-left">
       <div class="flex">
         <%= if assigns[:href] do %>
-          <a href={@href} {(if @target do [target: @target] else [] end)} class={["torus-button primary !rounded-r-none", @class]} disabled={@disabled}>
+          <a href={@href} {(if @target do [target: @target] else [] end)} class={[@button_class, @class]} disabled={@disabled}>
             <%= render_slot(@inner_block) %>
           </a>
         <% else %>
-          <button phx-target={assigns[:onclick_target]} phx-click={assigns[:onclick]} id={"#{@id}_button"} type={@type} class={["torus-button primary !rounded-r-none", @class]} disabled={@disabled}>
+          <button phx-target={assigns[:onclick_target]} phx-click={assigns[:onclick]} id={"#{@id}_button"} type={@type} class={[@button_class, @class]} disabled={@disabled}>
             <%= render_slot(@inner_block) %>
           </button>
         <% end %>
-        <button type="button" phx-click={toggle_options(@id)} class="flex justify-center rounded-r-sm items-center px-2 text-white bg-delivery-primary-600 hover:bg-delivery-primary-700">
+        <button type="button" phx-click={toggle_options(@id)} class={@dropdown_button_class}>
           <svg  class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
             <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
           </svg>
         </button>
       </div>
-      <div phx-click-away={toggle_options(@id)} id={"#{@id}_options"} class="hidden absolute w-40 right-0 z-10 mt-2 origin-top-right divide-y divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none" role="menu" aria-orientation="vertical" aria-labelledby="menu-button" tabindex="-1">
+      <div phx-click-away={toggle_options(@id)} id={"#{@id}_options"} class="hidden absolute w-40 right-0 z-10 mt-2 origin-top-right divide-y divide-gray-100 rounded-md bg-white dark:bg-black dark:text shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none" role="menu" aria-orientation="vertical" aria-labelledby="menu-button" tabindex="-1">
         <div class="py-1" role="none">
           <%= for {option, index} <- Enum.with_index(@options) do %>
             <%= if option[:href] do %>
-              <a href={option.href} {(if option[:target] do [target: option.target] else [] end)} class="text-gray-600 block whitespace-nowrap px-4 py-2 text-sm w-full text-left hover:bg-gray-100" role="menuitem" tabindex="-1" id={"menu-item-#{@id}-#{index}"}>
+              <a href={option.href} {(if option[:target] do [target: option.target] else [] end)} class={@option_class} role="menuitem" tabindex="-1" id={"menu-item-#{@id}-#{index}"}>
                 <%= option.text %>
                 <%= if option[:target] == "_blank" do %>
                   <i class="fa-solid fa-arrow-up-right-from-square ml-2"></i>
                 <% end %>
               </a>
             <% else %>
-              <button type="button" phx-click={toggle_options(option.on_click, @id)} class="text-gray-600 block px-4 py-2 text-sm w-full text-left hover:bg-gray-100" role="menuitem" tabindex="-1" id={"menu-item-#{@id}-#{index}"}><%= option.text %></button>
+              <button type="button" phx-click={toggle_options(option.on_click, @id)} class={@option_class} role="menuitem" tabindex="-1" id={"menu-item-#{@id}-#{index}"}><%= option.text %></button>
             <% end %>
           <% end %>
         </div>

--- a/lib/oli_web/live/collaboration_live/active_users.ex
+++ b/lib/oli_web/live/collaboration_live/active_users.ex
@@ -1,7 +1,7 @@
 defmodule OliWeb.CollaborationLive.ActiveUsers do
   use Surface.Component
 
-  prop users, :list, required: true
+  prop(users, :list, required: true)
 
   def render(assigns) do
     ~F"""
@@ -11,7 +11,7 @@ defmodule OliWeb.CollaborationLive.ActiveUsers do
       <ul class="collab-space__active-users rounded-sm">
         {#for user <- @users}
           <li>
-            {user.first_name}<strong>{if user.typing do
+            {name(user)}<strong>{if user.typing do
                 " is typing..."
               end}</strong>
           </li>
@@ -20,4 +20,7 @@ defmodule OliWeb.CollaborationLive.ActiveUsers do
     </div>
     """
   end
+
+  def name(%{is_guest: true}), do: "Guest"
+  def name(user), do: "#{user.first_name}"
 end

--- a/lib/oli_web/live/collaboration_live/collab_space_view.ex
+++ b/lib/oli_web/live/collaboration_live/collab_space_view.ex
@@ -4,6 +4,7 @@ defmodule OliWeb.CollaborationLive.CollabSpaceView do
   alias Phoenix.LiveView.JS
 
   alias Oli.Accounts
+  alias Oli.Accounts.{User}
   alias Oli.Delivery.Sections
   alias Oli.Resources
   alias Oli.Resources.Collaboration
@@ -58,9 +59,12 @@ defmodule OliWeb.CollaborationLive.CollabSpaceView do
       first_name: user.name,
       email: user.email,
       user_id: user.id,
-      is_guest: user.guest
+      is_guest: is_guest(user)
     }
   end
+
+  defp is_guest(%User{guest: guest}), do: guest
+  defp is_guest(_), do: false
 
   # ----------------
 

--- a/lib/oli_web/live/collaboration_live/collab_space_view.ex
+++ b/lib/oli_web/live/collaboration_live/collab_space_view.ex
@@ -57,7 +57,8 @@ defmodule OliWeb.CollaborationLive.CollabSpaceView do
       typing: false,
       first_name: user.name,
       email: user.email,
-      user_id: user.id
+      user_id: user.id,
+      is_guest: user.guest
     }
   end
 

--- a/lib/oli_web/live/collaboration_live/posts/list.ex
+++ b/lib/oli_web/live/collaboration_live/posts/list.ex
@@ -3,13 +3,13 @@ defmodule OliWeb.CollaborationLive.Posts.List do
 
   alias OliWeb.CollaborationLive.Posts.Show
 
-  prop posts, :list, required: true
-  prop collab_space_config, :struct, required: true
-  prop user_id, :string, required: true
-  prop selected, :string, default: ""
-  prop is_instructor, :boolean, required: true
-  prop is_student, :boolean, required: true
-  prop editing_post, :string, default: ""
+  prop(posts, :list, required: true)
+  prop(collab_space_config, :struct, required: true)
+  prop(user_id, :string, required: true)
+  prop(selected, :string, default: "")
+  prop(is_instructor, :boolean, required: true)
+  prop(is_student, :boolean, required: true)
+  prop(editing_post, :string, default: "")
 
   def render(assigns) do
     ~F"""
@@ -34,12 +34,12 @@ defmodule OliWeb.CollaborationLive.Posts.List do
             />
           </div>
           {#if @collab_space_config.threaded and Integer.to_string(post.id) == @selected}
-            <div class="bg-gray-100" id={"post_#{post.id}_replies"}>
+            <div class="bg-gray-100 dark:bg-gray-900" id={"post_#{post.id}_replies"}>
               <div class="flex flex-col gap-4 ml-6">
                 {#for {reply, reply_index} <- post.replies}
                   <div
                     id={"post_reply_#{reply.id}"}
-                    class={"p-5 bg-white show #{if reply_index == 1, do: "mt-4"} #{if reply_index == length(post.replies), do: "mb-4"} #{if reply.status == :archived, do: " readonly"}"}
+                    class={"p-5 bg-white dark:bg-gray-800 show #{if reply_index == 1, do: "mt-4"} #{if reply_index == length(post.replies), do: "mb-4"} #{if reply.status == :archived, do: " readonly"}"}
                     aria-labelledby={"heading_#{post.id}"}
                   >
                     <Show


### PR DESCRIPTION
Fixes two issues related to discussions:
1. Replies were unreadable in dark mode #3995
2. Guest users show up as blank green dot in discussions #3985

<img width="656" alt="Screenshot 2023-07-21 at 1 15 45 PM" src="https://github.com/Simon-Initiative/oli-torus/assets/6248894/3368871e-b3f3-497c-b3d7-727917e5300b">

Closes #3995 #3985