### PR TITLE
[MER-2334] V2 ingest report invalid zip

### DIFF
--- a/lib/oli_web/live/ingest/ingestv2.ex
+++ b/lib/oli_web/live/ingest/ingestv2.ex
@@ -298,7 +298,11 @@ defmodule OliWeb.Admin.IngestV2 do
          activities: Enum.count(state.activities),
          pages: Enum.count(state.pages),
          products: Enum.count(state.products),
-         media_items: Enum.count(state.media_manifest["mediaItems"])
+         media_items:
+           if(not is_nil(state.media_manifest),
+             do: Enum.count(state.media_manifest["mediaItems"]),
+             else: 0
+           )
        },
        total_count: Enum.count(state.errors),
        table_model: table_model,

--- a/test/support/digests/digest_4/_hierarchy.json
+++ b/test/support/digests/digest_4/_hierarchy.json
@@ -1,0 +1,11 @@
+{
+  "type": "Hierarchy",
+  "id": "",
+  "legacyPath": "",
+  "legacyId": "",
+  "title": "",
+  "tags": [],
+  "unresolvedReferences": [],
+  "children": [],
+  "warnings": []
+}

--- a/test/support/digests/digest_4/_project.json
+++ b/test/support/digests/digest_4/_project.json
@@ -1,0 +1,5 @@
+{
+  "description": "Empty project template for authoring OLI content packages.",
+  "svnRoot": "",
+  "type": "Manifest"
+}

--- a/test/support/digests/digest_5/_media-manifest.json
+++ b/test/support/digests/digest_5/_media-manifest.json
@@ -1,0 +1,3 @@
+{
+  "mediaItems": []
+}

--- a/test/support/digests/digest_5/_project.json
+++ b/test/support/digests/digest_5/_project.json
@@ -1,0 +1,6 @@
+{
+  "title": "",
+  "description": "Empty project template for authoring OLI content packages.",
+  "svnRoot": "",
+  "type": "Manifest"
+}

--- a/test/support/digests/digest_6/_hierarchy.json
+++ b/test/support/digests/digest_6/_hierarchy.json
@@ -1,0 +1,11 @@
+{
+  "type": "Hierarchy",
+  "id": "",
+  "legacyPath": "",
+  "legacyId": "",
+  "title": "",
+  "tags": [],
+  "unresolvedReferences": [],
+  "children": [],
+  "warnings": []
+}

--- a/test/support/digests/digest_6/_media-manifest.json
+++ b/test/support/digests/digest_6/_media-manifest.json
@@ -1,0 +1,3 @@
+{
+  "mediaItems": []
+}

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -2365,4 +2365,19 @@ defmodule Oli.TestHelpers do
       IO.write("\nhtml file rendered to #{filepath}\n")
     end
   end
+
+  @doc """
+    Provides set of helpers to test async events
+  """
+  def wait_until(fun), do: wait_until(fun, 500)
+
+  def wait_until(fun, 0), do: fun.()
+
+  def wait_until(fun, timeout) do
+    fun.()
+  rescue
+    ExUnit.AssertionError ->
+      :timer.sleep(100)
+      wait_until(fun, max(0, timeout - 100))
+  end
 end


### PR DESCRIPTION
[MER-2334](https://eliterate.atlassian.net/browse/MER-2334)

This PR fixes the issue that happened when ingesting a project that does not contain the `media-manifest` file in V2 Ingest Project. 

It also adds some tests for different cases where you try to digest a project with missing files.


https://github.com/Simon-Initiative/oli-torus/assets/16328384/c52b3ca0-6f13-4fc5-8030-ffdc0c280ff6

[MER-2334]: https://eliterate.atlassian.net/browse/MER-2334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ