### PR TITLE
[BUG FIX] handle top level discussion links

### DIFF
--- a/lib/oli/resources/collaboration.ex
+++ b/lib/oli/resources/collaboration.ex
@@ -377,6 +377,7 @@ defmodule Oli.Resources.Collaboration do
           user_name: user.name,
           title: rev.title,
           slug: rev.slug,
+          resource_type_id: rev.resource_type_id,
           updated_at: post.updated_at
         },
         order_by: [desc: :updated_at],
@@ -421,6 +422,7 @@ defmodule Oli.Resources.Collaboration do
           user_name: user.name,
           title: rev.title,
           slug: rev.slug,
+          resource_type_id: rev.resource_type_id,
           updated_at: post.updated_at
         },
         order_by: [desc: :updated_at],
@@ -529,6 +531,7 @@ defmodule Oli.Resources.Collaboration do
       user_name: u.name,
       slug: r.slug,
       title: r.title,
+      resource_type_id: r.resource_type_id,
       inserted_at: p.inserted_at,
       status: p.status,
       count: over(count(p.id))

--- a/lib/oli_web/components/delivery/discussion_activity/discussion_table_model.ex
+++ b/lib/oli_web/components/delivery/discussion_activity/discussion_table_model.ex
@@ -32,11 +32,24 @@ defmodule OliWeb.Discussion.TableModel do
     """
   end
 
+  defp href(section_slug, post) do
+
+    container_type_id = Oli.Resources.ResourceType.get_id_by_type("container")
+
+    case post.resource_type_id do
+      ^container_type_id ->
+        Routes.live_path(OliWeb.Endpoint, OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive, section_slug, "reports", "course_discussion")
+      _ ->
+        Routes.page_delivery_path(OliWeb.Endpoint, :page_preview, section_slug, post.slug)
+    end
+
+  end
+
   def render_post(assigns, post, _) do
     ~F"""
       <div class="flex flex-col px-10 py-5">
           <div class="flex justify-between mb-6">
-            <a class="text-delivery-primary hover:text-delivery-primary" href={Routes.page_delivery_path(OliWeb.Endpoint, :page_preview, assigns.section_slug, post.slug)}>
+            <a class="text-delivery-primary hover:text-delivery-primary" href={href(assigns.section_slug, post)}>
               {post.title}
             </a>
             <span class="torus-span">{FormatDateTime.format_datetime(post.inserted_at, show_timezone: false)}</span>


### PR DESCRIPTION
The link that was being rendered for the "top level" course section discussion was for a page preview.  That link, when clicked, triggered a 500 error as the code attempted to "page preview" that root resource.

Instead, for we simply want to show a link to the existing "Course Discussion" view. The "top level" course section discussion is the only discussion that *is* a container, so (at least for now) it is safe simply to check the `resource_type_id` of the revision that the post is related to. 