### PR TITLE
[BUG FIX] [MER-2394] styling inconsistencies between normal text and examples

### DIFF
--- a/assets/src/components/activities/common/choices/delivery/ChoicesDelivery.modules.scss
+++ b/assets/src/components/activities/common/choices/delivery/ChoicesDelivery.modules.scss
@@ -24,8 +24,6 @@
 
 .choicesChoiceContent {
   margin-left: 0.6rem;
-  font-size: 14px;
-  line-height: 20px;
   flex-grow: 1;
 
   /* When inside a MCQ/CATA, we want the images near the checkbox, not centered on the page */

--- a/assets/src/components/activities/common/choices/delivery/ChoicesDelivery.tsx
+++ b/assets/src/components/activities/common/choices/delivery/ChoicesDelivery.tsx
@@ -51,7 +51,7 @@ export const ChoicesDelivery: React.FC<Props> = ({
             <label className={styles.choicesChoiceLabel} htmlFor={`choice-${index}`}>
               <div className="d-flex align-items-center col">
                 {isSelected(choice.id) ? selectedIcon : unselectedIcon}
-                <div className={styles.choicesChoiceContent}>
+                <div className={classNames('content', styles.choicesChoiceContent)}>
                   <HtmlContentModelRenderer content={choice.content} context={context} />
                 </div>
               </div>

--- a/assets/src/components/activities/common/stem/delivery/StemDelivery.tsx
+++ b/assets/src/components/activities/common/stem/delivery/StemDelivery.tsx
@@ -15,7 +15,7 @@ interface StemProps {
 
 export const StemDelivery: React.FC<StemProps> = (props) => {
   return (
-    <div className={`stem__delivery${props.className ? ' ' + props.className : ''}`}>
+    <div className={`stem__delivery content${props.className ? ' ' + props.className : ''}`}>
       <HtmlContentModelRenderer content={props.stem.content} context={props.context} />
     </div>
   );

--- a/assets/src/components/content/Popup.tsx
+++ b/assets/src/components/content/Popup.tsx
@@ -76,7 +76,7 @@ export const Popup: React.FC<Props> = ({ children, popupContent, popup }) => {
           </div>
         </ArrowContainer>
       )}
-      containerClassName="react-tiny-popover structured-content"
+      containerClassName="z-50 react-tiny-popover structured-content"
     >
       <span
         className={`popup-anchor${popup.trigger === 'hover' ? '' : ' popup-click'}`}

--- a/assets/styles/common/elements.scss
+++ b/assets/styles/common/elements.scss
@@ -122,7 +122,8 @@ $element-margin-bottom: 1.5em;
 
   ul li,
   ol li {
-    margin-bottom: 0.25rem;
+    line-height: 2em;
+    margin-bottom: $element-margin-bottom;
   }
 
   ul,

--- a/assets/styles/common/purpose.scss
+++ b/assets/styles/common/purpose.scss
@@ -9,10 +9,6 @@
     margin-bottom: 1rem;
   }
 
-  & > .content-purpose-content {
-    padding: 0 2em;
-  }
-
   &.none {
     & > .content-purpose-label {
       display: none;
@@ -201,7 +197,6 @@
     text-decoration: none;
 
     .content-purpose-content {
-
       .title {
         font-size: 1.3em;
         color: var(--color-body-color);

--- a/assets/styles/delivery/page_delivery/page.scss
+++ b/assets/styles/delivery/page_delivery/page.scss
@@ -10,11 +10,6 @@
   width: 65px;
 }
 
-.content {
-  margin: 0 auto;
-  font-size: 1.1em;
-}
-
 .selection {
   border-top: 1px solid var(--color-gray-400);
   border-bottom: 1px solid var(--color-gray-400);

--- a/lib/oli/rendering/group/html.ex
+++ b/lib/oli/rendering/group/html.ex
@@ -12,23 +12,22 @@ defmodule Oli.Rendering.Group.Html do
 
   def group(%Context{} = _context, next, %{"id" => id, "purpose" => purpose}) do
     [
-      ~s|<div id="#{id}" class="group content-purpose #{purpose}"><div class="content-purpose-label">#{Purposes.label_for(purpose)}</div><div class="content-purpose-content">|,
+      ~s|<div id="#{id}" class="group content-purpose #{purpose}"><div class="content-purpose-label">#{Purposes.label_for(purpose)}</div><div class="content-purpose-content content">|,
       next.(),
       "</div></div>\n"
     ]
   end
 
   def group(%Context{} = context, next, params) do
-
     id = Map.get(params, "id", UUID.uuid4())
     purpose = Map.get(params, "purpose", "none")
 
-    params = Map.put(params, "id", id)
-    |> Map.put("purpose", purpose)
+    params =
+      Map.put(params, "id", id)
+      |> Map.put("purpose", purpose)
 
     group(context, next, params)
   end
-
 
   def elements(%Context{} = context, elements) do
     Elements.render(context, elements, Elements.Html)


### PR DESCRIPTION
Fixes some style inconsistencies across different element types.
<img width="1144" alt="Screenshot 2023-07-25 at 10 12 24 AM" src="https://github.com/Simon-Initiative/oli-torus/assets/6248894/b15ceb37-6fc2-4dfc-8a23-ea01aca64158">

1. Add proper line height and paragraph spacing to groups (example, learn by doing, etc...), lists and activity delivery stems
2. Remove x padding on groups, which can compound making content width unreasonable
3. Fix an issue where popups were hidden behind side navbar

<img width="599" alt="Screenshot 2023-07-25 at 10 58 12 AM" src="https://github.com/Simon-Initiative/oli-torus/assets/6248894/e9d162ef-9245-4a53-bea2-e259660b6fae">

I went through about 50 pages and verified the style changed looked reasonable.