### PR TITLE
[BUG FIX] [MER-2396] cover image set in product does not propagate to section

### DIFF
--- a/lib/oli/delivery/sections/blueprint.ex
+++ b/lib/oli/delivery/sections/blueprint.ex
@@ -222,7 +222,8 @@ defmodule Oli.Delivery.Sections.Blueprint do
           brand_id: nil,
           delivery_policy_id: nil,
           customizations: custom_labels,
-          contains_explorations: section.contains_explorations
+          contains_explorations: section.contains_explorations,
+          cover_image: section.cover_image
         },
         attrs
       )

--- a/lib/oli_web/live/new_course/new_course.ex
+++ b/lib/oli_web/live/new_course/new_course.ex
@@ -23,8 +23,7 @@ defmodule OliWeb.Delivery.NewCourse do
     steps = [
       %Step{
         title: "Select your source materials",
-        description:
-          "Select the source of materials to base your course curriculum on.",
+        description: "Select the source of materials to base your course curriculum on.",
         render_fn: fn assigns -> render_step(:select_source, assigns) end,
         on_next_step: JS.push("change_step", value: %{current_step: 1})
       },
@@ -319,7 +318,8 @@ defmodule OliWeb.Delivery.NewCourse do
             open_and_free: true,
             has_experiments: project.has_experiments,
             base_project_id: blueprint.base_project_id,
-            context_id: UUID.uuid4()
+            context_id: UUID.uuid4(),
+            cover_image: blueprint.cover_image
           })
 
         case create_from_product(socket, blueprint, section_params) do

--- a/lib/oli_web/templates/delivery/open_and_free_index.html.heex
+++ b/lib/oli_web/templates/delivery/open_and_free_index.html.heex
@@ -20,7 +20,7 @@
           <div class="flex flex-wrap">
             <%= for section <- @sections do %>
               <a href={Routes.page_delivery_path(@conn, :index, section.slug)} class="rounded-lg shadow-lg bg-white dark:bg-gray-600 max-w-xs mr-3 mb-3 border-2 border-transparent hover:border-blue-500 hover:no-underline">
-                <img class="rounded-t-lg" src={cover_image(section)} alt="course image"/>
+                <img class="rounded-t-lg object-cover h-64 w-96" src={cover_image(section)} alt="course image"/>
                 <div class="p-6">
                   <h5 class="text-gray-900 dark:text-white text-xl font-medium mb-2"><%= section.title %></h5>
                   <p class="text-gray-700 dark:text-white text-base mb-4">


### PR DESCRIPTION
Fixes an issue where a product cover image doesn't propagate to course sections created from it.

Closes #4014