### PR TITLE
[BUG FIX] handle plus sign within ranges properly [MER-2400]

### DIFF
--- a/lib/oli/delivery/evaluation/rule.ex
+++ b/lib/oli/delivery/evaluation/rule.ex
@@ -157,7 +157,7 @@ defmodule Oli.Delivery.Evaluation.Rule do
 
   defp parse_range(range_str) do
     case Regex.run(
-           ~r/([[(])\s*(-?[-01234567890e.]+)\s*,\s*(-?[-01234567890e.]+)\s*[\])]#?(\d+)?/,
+           ~r/([[(])\s*(-?[-+01234567890e.]+)\s*,\s*(-?[-+01234567890e.]+)\s*[\])]#?(\d+)?/,
            range_str
          ) do
       [_, "[", lower, upper | maybe_precision] ->

--- a/test/oli/delivery/evaluation/parser_test.exs
+++ b/test/oli/delivery/evaluation/parser_test.exs
@@ -3,6 +3,11 @@ defmodule Oli.Delivery.Evaluation.ParserTest do
 
   defp parse(input), do: Oli.Delivery.Evaluation.Rule.parse(input)
 
+  test "parses scientific with +" do
+    assert {:ok, {:eq, :input, "[3.0e+5,4.0e+5]"}} ==
+             parse("input = {[3.0e+5,4.0e+5]}")
+  end
+
   test "parses conjunction" do
     assert {:ok, {:&&, {:gt, :attempt_number, "1"}, {:like, :input, "cat.*"}}} ==
              parse("attemptNumber > {1} && input like {cat.*}")

--- a/test/oli/delivery/evaluation/rule_eval_test.exs
+++ b/test/oli/delivery/evaluation/rule_eval_test.exs
@@ -54,6 +54,7 @@ defmodule Oli.Delivery.Evaluation.RuleEvalTest do
 
   test "evaluating ranges" do
     # scientific notation inside the range, evaluates to true
+    assert eval("attemptNumber = {1} && input = {[3.0e+5,4.0e+5]}", "3.5e5") == true
     assert eval("attemptNumber = {1} && input = {[3.0e5,4.0e5]}", "3.5e5") == true
 
     # float inside the range, evaluates to true


### PR DESCRIPTION
The system was allowing this form of scientific notation: `1.0e8` but not `1.0e+8`.   Root cause was the code detecting and parsing ranges did not include `+` sign in its regexp. 

Added unit tests demonstrating that this fixes the problem, and also tested end to end by creating a multi input question with a numeric range. 