### PR TITLE
[BUG FIX] remove dialog colors [MER-2398]

### DIFF
--- a/assets/styles/common/elements.scss
+++ b/assets/styles/common/elements.scss
@@ -358,27 +358,12 @@ $element-margin-bottom: 1.5em;
     margin-bottom: $element-margin-bottom;
 
     .dialog-line {
-      &.speaker-1 {
-        background-color: #d1e7dd;
-      }
-      &.speaker-2 {
-        background-color: #f8d7da;
-      }
-      &.speaker-3 {
-        background-color: #cff4fc;
-      }
-      &.speaker-4 {
-        background-color: #fff3cd;
-      }
-      &.speaker-5 {
-        background-color: #ffe5d0;
-      }
+      border-style: solid;
+      border-width: 1px;
       display: flex;
       flex-direction: row;
       margin-bottom: 0.5rem;
       align-items: center;
-
-      color: var(--color-delivery-body);
 
       .dialog-content {
         flex-grow: 1;


### PR DESCRIPTION
This PR removes use of color altogether, leaving the standard light and dark mode.  In Dark Mode, this looks like this now:
<img width="884" alt="Screenshot 2023-07-26 at 1 26 22 PM" src="https://github.com/Simon-Initiative/oli-torus/assets/7431756/565f1c16-9a41-4fff-8854-1e328d782a90">
