### PR TITLE
[Bugfix] Maintain cursor position in dialog editor [MER-2283]

### DIFF
--- a/assets/src/components/editing/elements/dialog/CursorInput.tsx
+++ b/assets/src/components/editing/elements/dialog/CursorInput.tsx
@@ -1,0 +1,37 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+/* Slate uses a deferred update mechanism when you call updateModel.
+   that works great for most use cases, but if you're doing a standard
+   input field with a value & onchange handler, the cursor position
+   will get reset on changes because of that. This is a workaround
+   input field that will manually remember the cursor position. */
+
+interface Props {
+  value: string;
+  onChange: (v: string) => void;
+  [key: string]: any;
+}
+
+export const CursorInput: React.FC<Props> = ({ value, onChange, ...props }) => {
+  const [cursor, setCursor] = useState<null | number>(null);
+  const ref = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (ref.current) {
+      ref.current.setSelectionRange(cursor, cursor);
+    }
+  }, [ref, cursor, value]);
+
+  return (
+    <input
+      ref={ref}
+      type="text"
+      {...props}
+      value={value}
+      onChange={(e) => {
+        setCursor(e.target.selectionStart);
+        onChange(e.target.value);
+      }}
+    />
+  );
+};

--- a/assets/src/components/editing/elements/dialog/DialogEditor.tsx
+++ b/assets/src/components/editing/elements/dialog/DialogEditor.tsx
@@ -37,11 +37,7 @@ export const DialogEditor: React.FC<Props> = ({ model, attributes, children, com
           />
         }
       >
-        {preview && (
-          <>
-            <Dialog dialog={model} context={temporaryContext} />
-          </>
-        )}
+        {preview && <Dialog dialog={model} context={temporaryContext} />}
         {preview || (
           <DialogInlineEditor commandContext={commandContext} dialog={model} onEdit={onEdit} />
         )}

--- a/assets/src/components/editing/elements/dialog/DialogInlineEditor.tsx
+++ b/assets/src/components/editing/elements/dialog/DialogInlineEditor.tsx
@@ -5,6 +5,7 @@ import { Model } from '../../../../data/content/model/elements/factories';
 import { Speaker } from '../../../Dialog';
 import { CommandContext } from '../commands/interfaces';
 import { InlineEditor } from '../common/settings/InlineEditor';
+import { CursorInput } from './CursorInput';
 import { selectPortrait } from './dialogActions';
 
 export const DialogInlineEditor: React.FC<{
@@ -31,8 +32,8 @@ export const DialogInlineEditor: React.FC<{
 
   const onEditSpeakerName = useCallback(
     // Curried update function. Usage - onEditSpeakerName(index)(changeEvent)
-    (index: number) => (e: ChangeEvent<HTMLInputElement>) => {
-      onSpeakerEdit(index, { name: e.target.value });
+    (index: number) => (name: string) => {
+      onSpeakerEdit(index, { name });
     },
     [onSpeakerEdit],
   );
@@ -153,7 +154,7 @@ export const DialogInlineEditor: React.FC<{
                   </span>
                 )
               )}
-              <input
+              <CursorInput
                 className="form-control form-control-sm"
                 type="text"
                 value={speaker.name}

--- a/assets/src/components/editing/elements/dialog/DialogInlineEditor.tsx
+++ b/assets/src/components/editing/elements/dialog/DialogInlineEditor.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useCallback } from 'react';
+import React, { useCallback } from 'react';
 import { v4 } from 'uuid';
 import * as ContentModel from 'data/content/model/elements/types';
 import { Model } from '../../../../data/content/model/elements/factories';


### PR DESCRIPTION
*Describe the bug*
When editing a speaker label in a dialog element, the cursor always jumps to the end of the textfield.

*To Reproduce*
Steps to reproduce the behavior:
1. Go to dialog on basic page
2. Edit a speaker label from the middle of the label
3. See cursor jump to end of textfield