### PR TITLE
[Bugfix] Media manager UI fixes [MER-2195]

### DIFF
--- a/assets/src/components/media/manager/MediaManager.scss
+++ b/assets/src/components/media/manager/MediaManager.scss
@@ -238,6 +238,7 @@
             text-align: center;
             vertical-align: top;
             line-height: 20px;
+            font-size: 14px;
           }
 
           &.not-selectable {
@@ -290,6 +291,7 @@
         .list-body {
           flex: 1;
           overflow: auto;
+          max-height: 374px;
         }
 
         .sel-col {
@@ -358,7 +360,7 @@
           .selection-check {
             display: none;
             visibility: hidden;
-            margin: 15px 10px;
+            margin: 3px;
             vertical-align: middle;
             text-align: center;
             cursor: pointer;

--- a/assets/src/components/media/manager/MediaManager.tsx
+++ b/assets/src/components/media/manager/MediaManager.tsx
@@ -15,7 +15,7 @@ import { VideoUploadWarning } from './VideoUploadWarning';
 import { uploadFiles } from './upload';
 
 const PAGELOAD_TRIGGER_MARGIN_PX = 100;
-const MAX_NAME_LENGTH = 26;
+const MAX_NAME_LENGTH = 30;
 const PAGE_LOADING_MESSAGE = 'Hang on while we load your items...';
 
 export const MIMETYPE_FILTERS = {
@@ -127,6 +127,26 @@ export interface MediaManagerState {
   duplicateWarning: string[];
 }
 
+const setMediaManagerLayoutSetting = (layout: LAYOUTS) => {
+  window.localStorage.setItem('media-manager-layout', layout === LAYOUTS.LIST ? 'list' : 'grid');
+};
+
+const getMediaManagerLayoutSetting = (): LAYOUTS => {
+  const layout = window.localStorage.getItem('media-manager-layout');
+  switch (layout) {
+    case 'list':
+      return LAYOUTS.LIST;
+    case 'grid':
+    default:
+      return LAYOUTS.GRID;
+  }
+};
+
+const formatDate = (date: string) => {
+  const d = new Date(date);
+  return `${d.toLocaleDateString()} ${d.toLocaleTimeString()}`;
+};
+
 /**
  * MediaManager React Component
  */
@@ -142,7 +162,7 @@ export class MediaManager extends React.PureComponent<MediaManagerProps, MediaMa
       searchText: undefined,
       orderBy: SORT_MAPPINGS.Newest.orderBy,
       order: SORT_MAPPINGS.Newest.order,
-      layout: LAYOUTS.GRID,
+      layout: getMediaManagerLayoutSetting(),
       showDetails: true,
       error: Maybe.nothing<string>(),
       filteredMimeTypes: props.mimeFilter,
@@ -291,6 +311,7 @@ export class MediaManager extends React.PureComponent<MediaManagerProps, MediaMa
               }
             });
           })
+
           .then(() => this.setState({ error: Maybe.nothing<string>() }));
       })
       .catch((e: Error | string) => {
@@ -304,6 +325,7 @@ export class MediaManager extends React.PureComponent<MediaManagerProps, MediaMa
   }
 
   onChangeLayout(newLayout: LAYOUTS) {
+    setMediaManagerLayoutSetting(newLayout);
     this.setState({
       layout: newLayout,
     });
@@ -443,7 +465,7 @@ export class MediaManager extends React.PureComponent<MediaManagerProps, MediaMa
                 <div className="refs-col">
                   {mediaItemRefs.get(item.guid) && (mediaItemRefs.get(item.guid) as any).size}
                 </div>
-                <div className="date-col">{item.dateUpdated}</div>
+                <div className="date-col">{formatDate(item.dateUpdated)}</div>
                 <div className="size-col">{convert.toByteNotation(item.fileSize)}</div>
               </div>
             ))}
@@ -496,7 +518,7 @@ export class MediaManager extends React.PureComponent<MediaManagerProps, MediaMa
               />
               <MediaIcon filename={item.fileName} mimeType={item.mimeType} url={item.url} />
               <div className="name">
-                {stringFormat.ellipsize(item.fileName, MAX_NAME_LENGTH, 5)}
+                {stringFormat.ellipsize(item.fileName, MAX_NAME_LENGTH, 12)}
               </div>
             </div>
           ))}


### PR DESCRIPTION
1. New Feature: The media manager will remember if you were in list or grid view, store that in local storage, and give you the same view next time you use it.

2. Made some tweaks to the grid view so you can see more of the filename, and moved where the ellipses are so you can see the end of the filename. It should also be noted that you can view the full filename after selecting an item and before confirming your selection below the grid.
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/149701f7-cb66-4b58-bae2-4bb0a34b8e04)

4. Fixed: The list view can scroll again
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/7db60ffa-bcdb-4af1-988f-e183423583cf)

5. In the list view, the time is now in your local time zone instead of UTC

Fixes #3710 