### PR TITLE
[Bugfix] Don't allow type change in read only file upload [MER-2355]

### DIFF
--- a/assets/src/components/activities/file_upload/FileSpecConfiguration.tsx
+++ b/assets/src/components/activities/file_upload/FileSpecConfiguration.tsx
@@ -85,21 +85,27 @@ export const FileSpecConfiguration = (props: FileSpecConfigurationProps) => {
         }}
       />
 
-      <div className="btn-group btn-group-sm mt-3" role="group">
-        {commonAccepts.map((ca) => {
-          return (
-            <button
-              key={ca.value}
-              type="button"
-              className="btn btn-outline-secondary"
-              onClick={() => props.onEdit(Object.assign({}, props.fileSpec, { accept: ca.value }))}
-            >
-              {ca.label}
-            </button>
-          );
-        })}
-      </div>
-      <small className="mt-3 text-muted">Common file extension choices</small>
+      {props.editMode && (
+        <>
+          <div className="btn-group btn-group-sm mt-3" role="group">
+            {commonAccepts.map((ca) => {
+              return (
+                <button
+                  key={ca.value}
+                  type="button"
+                  className="btn btn-outline-secondary"
+                  onClick={() =>
+                    props.onEdit(Object.assign({}, props.fileSpec, { accept: ca.value }))
+                  }
+                >
+                  {ca.label}
+                </button>
+              );
+            })}
+          </div>
+          <small className="mt-3 text-muted">Common file extension choices</small>
+        </>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
*Describe the bug*
File upload in activity bank allows changing filetype while it is read-only, but it doesnt get persisted (as expected). This could be confusing as a use could forget to click "Edit" and try to change this without realizing their changes arent being saved.

*To Reproduce*
Steps to reproduce the behavior:
1. Go to Activity Bank editor
2. Add file upload activity
3. Click the Allowed files tab and select a type while the editor is read-only