### PR TITLE
[Bugfix] Respect preview_mode in exploration preview [MER-2411]

### DIFF
--- a/lib/oli_web/components/delivery/exploration_card.ex
+++ b/lib/oli_web/components/delivery/exploration_card.ex
@@ -6,6 +6,7 @@ defmodule OliWeb.Components.Delivery.ExplorationCard do
   attr :dark, :boolean, default: false
   attr :exploration, :map
   attr :section_slug, :string
+  attr :preview_mode, :boolean, default: false
 
   def render(assigns) do
     ~H"""
@@ -15,7 +16,7 @@ defmodule OliWeb.Components.Delivery.ExplorationCard do
             <h6 class="font-semibold text-lg leading-6"><%= @exploration.title %></h6>
             <div class="flex w-full gap-3 justify-end">
               <a
-                href={Routes.page_delivery_path(OliWeb.Endpoint, :page, @section_slug, @exploration.slug)}
+                href={Routes.page_delivery_path(OliWeb.Endpoint, (if @preview_mode, do: :page_preview, else: :page), @section_slug, @exploration.slug)}
                 class="btn text-white hover:text-white inline-flex bg-delivery-primary hover:bg-delivery-primary-600 active:bg-delivery-primary-700">Open</a>
             </div>
           </div>

--- a/lib/oli_web/components/delivery/exploration_list.ex
+++ b/lib/oli_web/components/delivery/exploration_list.ex
@@ -4,13 +4,15 @@ defmodule OliWeb.Components.Delivery.ExplorationList do
   alias Oli.Publishing.DeliveryResolver, as: Resolver
   alias OliWeb.Components.Delivery.ExplorationCard
 
-  def mount(_params, %{"section_slug" => section_slug}, socket) do
+  def mount(_params, %{"section_slug" => section_slug, "preview_mode" => preview_mode}, socket) do
     explorations = Resolver.get_by_purpose(section_slug, :application)
+
 
     {:ok,
      assign(socket,
        explorations: explorations,
-       section_slug: section_slug
+       section_slug: section_slug,
+       preview_mode: preview_mode
      )}
   end
 
@@ -19,7 +21,7 @@ defmodule OliWeb.Components.Delivery.ExplorationList do
       <div class="flex flex-col gap-4">
         <%= if length(@explorations) > 0 do %>
           <%= for exploration <- @explorations do %>
-            <ExplorationCard.render exploration={exploration} section_slug={@section_slug}/>
+            <ExplorationCard.render exploration={exploration} section_slug={@section_slug} preview_mode={@preview_mode} />
           <% end %>
         <% else %>
           <div class="bg-white dark:bg-gray-800 border-l-4 border-delivery-primary p-4" role="alert">

--- a/lib/oli_web/templates/page_delivery/exploration.html.heex
+++ b/lib/oli_web/templates/page_delivery/exploration.html.heex
@@ -10,7 +10,7 @@
     <% end %>
 
     <div class="container mx-auto px-10 mt-3 mb-5 flex flex-col">
-      <%= live_render @conn, Components.Delivery.ExplorationList, session: %{ "section_slug" => @section_slug } %>
+      <%= live_render @conn, Components.Delivery.ExplorationList, session: %{ "section_slug" => @section_slug, "preview_mode" => @preview_mode } %>
     </div>
 
     <%= render OliWeb.LayoutView, "_delivery_footer.html", assigns %>


### PR DESCRIPTION
1. Preview course as instructor
2. click on explorations
3. click on the name of an adaptive activity exploration

Expected: Activity is opened in preview mode with the instructor tools available.
Actual: Activity is opened in student mode with no tools.