### PR TITLE
[BUGFIX]  fix deletion of hints on multipart activities [MER-2432]

### DIFF
--- a/assets/src/components/activities/common/hints/authoring/HintsAuthoringConnected.tsx
+++ b/assets/src/components/activities/common/hints/authoring/HintsAuthoringConnected.tsx
@@ -13,7 +13,7 @@ export const Hints: React.FC<Props> = (props) => {
     <HintsAuthoring
       addOne={() => dispatch(HintUtils.addCognitiveHint(makeHint(''), props.partId))}
       updateOne={(id, content) => dispatch(HintUtils.setContent(id, content))}
-      removeOne={(id) => dispatch(HintUtils.removeOne(id))}
+      removeOne={(id) => dispatch(HintUtils.removeOne(id, props.partId))}
       deerInHeadlightsHint={HintUtils.getDeerInHeadlightsHint(model, props.partId)}
       cognitiveHints={HintUtils.getCognitiveHints(model, props.partId)}
       bottomOutHint={HintUtils.getBottomOutHint(model, props.partId)}

--- a/assets/src/components/activities/custom_dnd/HintsEditor.tsx
+++ b/assets/src/components/activities/custom_dnd/HintsEditor.tsx
@@ -17,7 +17,7 @@ export const HintsEditor: React.FC<Props> = (props) => {
       hints={Hints.byPart(model, props.partId)}
       updateOne={(id, content) => dispatch(Hints.setContent(id, content as RichText))}
       addOne={() => dispatch(Hints.addOne(makeHint(''), props.partId))}
-      removeOne={(id) => dispatch(Hints.removeOne(id))}
+      removeOne={(id) => dispatch(Hints.removeOne(id, props.partId))}
       placeholder="Hint"
       title={props.partId}
     />

--- a/assets/src/components/activities/multi_input/sections/HintsTab.tsx
+++ b/assets/src/components/activities/multi_input/sections/HintsTab.tsx
@@ -19,7 +19,7 @@ export const HintsTab: React.FC<Props> = (props) => {
       hints={Hints.byPart(model, props.input.partId)}
       updateOne={(id, content) => dispatch(Hints.setContent(id, content as RichText))}
       addOne={() => dispatch(Hints.addOne(makeHint(''), props.input.partId))}
-      removeOne={(id) => dispatch(Hints.removeOne(id))}
+      removeOne={(id) => dispatch(Hints.removeOne(id, props.input.partId))}
       placeholder="Hint"
       title={partTitle(props.input, props.index)}
     />

--- a/assets/src/data/activities/model/hints.ts
+++ b/assets/src/data/activities/model/hints.ts
@@ -62,7 +62,11 @@ export const Hints: Hints = {
       const hint = Hints.byPart(model, partId)[index];
 
       List<Hint>(HINTS_BY_PART_PATH(partId)).removeOne(id)(model);
-      post(makeUndoable('Removed a hint', [Operations.insert(HINTS_BY_PART_PATH(partId), clone(hint), index)]));
+      post(
+        makeUndoable('Removed a hint', [
+          Operations.insert(HINTS_BY_PART_PATH(partId), clone(hint), index),
+        ]),
+      );
     };
   },
 };

--- a/assets/src/data/activities/model/hints.ts
+++ b/assets/src/data/activities/model/hints.ts
@@ -14,7 +14,7 @@ interface Hints extends Omit<List<Hint>, 'addOne' | 'removeOne'> {
   getBottomOutHint: (model: HasHints, partId: string) => Hint;
   addCognitiveHint(hint: Hint, partId: string): (model: HasHints, _post: PostUndoable) => void;
   setContent(id: string, content: RichText): (model: HasHints, _post: PostUndoable) => void;
-  removeOne: (id: string) => (model: any, post: PostUndoable) => void;
+  removeOne: (id: string, partId: string) => (model: any, post: PostUndoable) => void;
 }
 
 export const HINTS_BY_PART_PATH = (partId: string) => `$..parts[?(@.id=='${partId}')].hints`;
@@ -56,13 +56,13 @@ export const Hints: Hints = {
     };
   },
 
-  removeOne(id: string) {
+  removeOne(id: string, partId: string) {
     return (model: HasHints, post: PostUndoable) => {
-      const hint = Hints.getOne(model, id);
-      const index = Hints.getAll(model).findIndex((h) => h.id === id);
+      const index = Hints.byPart(model, partId).findIndex((h) => h.id === id);
+      const hint = Hints.byPart(model, partId)[index];
 
-      List<Hint>(PATH).removeOne(id)(model);
-      post(makeUndoable('Removed a hint', [Operations.insert(PATH, clone(hint), index)]));
+      List<Hint>(HINTS_BY_PART_PATH(partId)).removeOne(id)(model);
+      post(makeUndoable('Removed a hint', [Operations.insert(HINTS_BY_PART_PATH(partId), clone(hint), index)]));
     };
   },
 };

--- a/assets/test/activities/hints_test.ts
+++ b/assets/test/activities/hints_test.ts
@@ -32,6 +32,6 @@ describe('authoring hints', () => {
 
   it('can remove a hint', () => {
     const firstHint = Hints.byPart(model, '1')[0];
-    expect(Hints.byPart(dispatch(model, Hints.removeOne(firstHint.id)), '1')).toHaveLength(2);
+    expect(Hints.byPart(dispatch(model, Hints.removeOne(firstHint.id, '1')), '1')).toHaveLength(2);
   });
 });


### PR DESCRIPTION
Utility function Hints.removeHint used by hint editing components was not coded to handle multi-part items, causing bad behavior on author deletion of a hint from any multi-part activity. This recodes it to take partId parameter and use appropriate JSON path operations to operate on the specified part's hint list only.
