### PR TITLE
[FEATURE] [MER-1908] Transfer student data to another section

### DIFF
--- a/lib/oli/activities/model/part.ex
+++ b/lib/oli/activities/model/part.ex
@@ -10,6 +10,8 @@ defmodule Oli.Activities.Model.Part do
     :explanation
   ]
 
+  @grading_approaches MapSet.new(["automatic", "manual"])
+
   def parse(%{"id" => id} = part) do
     scoring_strategy =
       Map.get(part, "scoringStrategy", Oli.Resources.ScoringStrategy.get_id_by_type("average"))
@@ -19,9 +21,13 @@ defmodule Oli.Activities.Model.Part do
     responses = Map.get(part, "responses", [])
     explanation = Map.get(part, "explanation")
 
-    grading_approach =
+    grading_approach_str =
       Map.get(part, "gradingApproach", "automatic")
-      |> String.to_existing_atom()
+
+    grading_approach = case MapSet.member?(@grading_approaches, grading_approach_str) do
+      true -> String.to_atom(grading_approach_str)
+      false -> :automatic
+    end
 
     out_of = Map.get(part, "outOf")
 

--- a/lib/oli/delivery/paywall.ex
+++ b/lib/oli/delivery/paywall.ex
@@ -103,9 +103,9 @@ defmodule Oli.Delivery.Paywall do
     end
   end
 
-  defp has_paid?(nil), do: false
+  def has_paid?(nil), do: false
 
-  defp has_paid?(%Enrollment{id: id}) do
+  def has_paid?(%Enrollment{id: id}) do
     query =
       from(
         p in Payment,
@@ -489,6 +489,18 @@ defmodule Oli.Delivery.Paywall do
     p
     |> Payment.changeset(attrs)
     |> Repo.update()
+  end
+
+  def update_payments_for_enrollment(
+        %Enrollment{id: current_enrollment_id},
+        %Enrollment{id: target_enrollment_id},
+        target_section_id
+      ) do
+    from(
+      p in Payment,
+      where: p.enrollment_id == ^current_enrollment_id
+    )
+    |> Repo.update_all(set: [enrollment_id: target_enrollment_id, section_id: target_section_id])
   end
 
   # ------------------------------------------

--- a/lib/oli/delivery/snapshots.ex
+++ b/lib/oli/delivery/snapshots.ex
@@ -12,6 +12,12 @@ defmodule Oli.Delivery.Snapshots do
   |> Snapshots.maybe_create_snapshot(part_inputs, section_slug)
   ```
   """
+
+  import Ecto.Query, warn: false
+
+  alias Oli.Repo
+  alias Oli.Delivery.Snapshots.Snapshot
+
   def maybe_create_snapshot(result, part_inputs, section_slug) do
     case result do
       {:ok, _} ->
@@ -40,5 +46,33 @@ defmodule Oli.Delivery.Snapshots do
         |> Oli.Delivery.Snapshots.Worker.new()
         |> Oban.insert()
     end
+  end
+
+  @doc """
+  Updates all snapshot records for a given section and user.
+  """
+
+  def update_snapshots_by_section_and_user(
+        current_section_id,
+        current_user_id,
+        target_section_id,
+        target_user_id
+      ) do
+    from(
+      sn in Snapshot,
+      where: sn.section_id == ^current_section_id and sn.user_id == ^current_user_id
+    )
+    |> Repo.update_all(set: [section_id: target_section_id, user_id: target_user_id])
+  end
+
+  @doc """
+  Deletes all snapshot records for a given section and user.
+  """
+  def delete_snapshots_by_section_and_user(target_section_id, target_user_id) do
+    from(
+      sn in Snapshot,
+      where: sn.section_id == ^target_section_id and sn.user_id == ^target_user_id
+    )
+    |> Repo.delete_all()
   end
 end

--- a/lib/oli/delivery/transfer.ex
+++ b/lib/oli/delivery/transfer.ex
@@ -1,0 +1,142 @@
+defmodule Oli.Delivery.Transfer do
+  @moduledoc """
+  The Transfer context.
+  """
+
+  import Ecto.Query, warn: false
+
+  alias Oli.Delivery.Attempts.Core
+  alias Oli.Delivery.Paywall
+  alias Oli.Delivery.Sections
+  alias Oli.Delivery.Sections.{Enrollment, Section, SectionsProjectsPublications}
+  alias Oli.Delivery.Snapshots
+  alias Oli.Repo
+
+  @doc """
+  Get the course sections to which a student's data can be transferred.
+  """
+
+  def get_sections_to_transfer_data(source_section) do
+    data =
+      Repo.all(
+        from(
+          section in Section,
+          join: spp in SectionsProjectsPublications,
+          on: spp.section_id == section.id,
+          ## condition 1: sections must have the same base_project_id (taken from the sections table)
+          where: section.base_project_id == ^source_section.base_project_id,
+          select: {spp, spp.section_id, section},
+          order_by: [asc: section.title]
+        )
+      )
+
+    {spps, section_mapper} =
+      data
+      |> Enum.reduce({[], %{}}, fn {spp, section_id, section}, {spps, section_mapper} = _acc ->
+        {[spp | spps], Map.put(section_mapper, section_id, section)}
+      end)
+
+    {sources_spp, targets_spp} =
+      Enum.split_with(spps, fn spp -> spp.section_id == source_section.id end)
+
+    source = Enum.into(sources_spp, %{}, fn spp -> {spp.project_id, spp.publication_id} end)
+
+    targets_spp
+    |> Enum.group_by(& &1.section_id)
+    |> Enum.into(%{}, fn {section_id, sppublications} ->
+      {section_id,
+       Enum.into(sppublications, %{}, fn spp -> {spp.project_id, spp.publication_id} end)}
+    end)
+    |> Enum.filter(fn {_section_id, section_candidate_data} ->
+      with true <-
+             project_match?(source, section_candidate_data),
+           true <-
+             valid_publication_ids?(source, section_candidate_data) do
+        true
+      end
+    end)
+    |> Enum.map(fn {target_section_id, _target_section_data} ->
+      section_mapper[target_section_id]
+      |> Map.put(:instructors, Sections.get_instructors_for_section(target_section_id))
+    end)
+    |> Enum.sort_by(fn section -> section.id end)
+  end
+
+  defp project_match?(source, target) do
+    ## condition 2: The source and target sections must have the same list of project_ids from the sections_projects_publications table
+
+    Map.keys(source) |> Enum.sort() == Map.keys(target) |> Enum.sort()
+  end
+
+  defp valid_publication_ids?(source, target) do
+    ## condition 3: For each project_id in the source SPP table, the publications must be contained in the target (but the target cannot have any before that)
+
+    Enum.reduce_while(source, 0, fn {project_id, publication_id}, acc ->
+      case publication_id <= target[project_id] do
+        true -> {:cont, acc}
+        false -> {:halt, 1}
+      end
+    end) == 0
+  end
+
+  ## Updates payments for current enrollment with target enrollment data if current enrollment has payments and target enrollment does not
+  defp maybe_transfer_payment(current_enrollment, target_enrollment, target_section_id) do
+    if Paywall.has_paid?(current_enrollment) and not Paywall.has_paid?(target_enrollment) do
+      case Paywall.update_payments_for_enrollment(
+             current_enrollment,
+             target_enrollment,
+             target_section_id
+           ) do
+        {changes_count, nil} when is_integer(changes_count) ->
+          {:ok, "Payments successfully transfered"}
+
+        error ->
+          {:error, error}
+      end
+    else
+      {:ok, nil}
+    end
+  end
+
+  @doc """
+  Transfers a student's enrollment data from one section to another.
+  """
+
+  def transfer_enrollment(current_section, current_student_id, target_section, target_student_id) do
+    ## gets both enrollments (current and target)
+    current_enrollment = Sections.get_enrollment(current_section.slug, current_student_id)
+    target_enrollment = Sections.get_enrollment(target_section.slug, target_student_id)
+
+    Repo.transaction(fn ->
+      with {:ok, %Enrollment{}} <-
+             Sections.update_enrollment(target_enrollment, %{state: current_enrollment.state}),
+           {:ok, _} <-
+             maybe_transfer_payment(current_enrollment, target_enrollment, target_section.id),
+           {changes_count, nil} when is_integer(changes_count) <-
+             Snapshots.delete_snapshots_by_section_and_user(target_section.id, target_student_id),
+           {changes_count, nil} when is_integer(changes_count) <-
+             Core.delete_resource_accesses_by_section_and_user(
+               target_section.id,
+               target_student_id
+             ),
+           {changes_count, nil} when is_integer(changes_count) <-
+             Snapshots.update_snapshots_by_section_and_user(
+               current_section.id,
+               current_student_id,
+               target_section.id,
+               target_student_id
+             ),
+           {changes_count, nil} when is_integer(changes_count) <-
+             Core.update_resource_accesses_by_section_and_user(
+               current_section.id,
+               current_student_id,
+               target_section.id,
+               target_student_id
+             ) do
+        {:ok, "User successfully transfered"}
+      else
+        error -> Repo.rollback(error)
+      end
+    end)
+  end
+end

--- a/lib/oli_web/components/delivery/actions/actions.ex
+++ b/lib/oli_web/components/delivery/actions/actions.ex
@@ -105,6 +105,15 @@ defmodule OliWeb.Components.Delivery.Actions do
           </div>
         {/if}
 
+        {#if @is_admin}
+          <.live_component
+            id="transfer_enrollment"
+            module={OliWeb.Delivery.Actions.TransferEnrollment}
+            section={@section}
+            user={@user}
+          />
+        {/if}
+
         <div class="ml-auto">
           <button phx-click={JS.push("open", target: "#unenroll_user_modal")} class="btn btn-danger">Unenroll</button>
         </div>

--- a/lib/oli_web/components/delivery/actions/sections_to_transfer_table_model.ex
+++ b/lib/oli_web/components/delivery/actions/sections_to_transfer_table_model.ex
@@ -1,0 +1,101 @@
+defmodule OliWeb.Delivery.Actions.SectionsToTransferTableModel do
+  use Phoenix.Component
+
+  alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
+  alias OliWeb.Common.FormatDateTime
+
+  def new(sections, target) do
+    column_specs = [
+      %ColumnSpec{
+        name: :title,
+        label: "TITLE",
+        render_fn: &__MODULE__.render_section_column/3,
+        th_class: "pl-10"
+      },
+      %ColumnSpec{
+        name: :start_date,
+        label: "START DATE",
+        render_fn: &__MODULE__.render_date/3
+      },
+      %ColumnSpec{
+        name: :end_date,
+        label: "END DATE",
+        render_fn: &__MODULE__.render_date/3
+      },
+      %ColumnSpec{
+        name: :instructor,
+        label: "INSTRUCTOR NAME",
+        render_fn: &__MODULE__.render_instructors_column/3,
+        sortable: false
+      }
+    ]
+
+    SortableTableModel.new(
+      rows: sections,
+      column_specs: column_specs,
+      event_suffix: "",
+      id_field: [:id],
+      data: %{target: target}
+    )
+  end
+
+  def render_section_column(assigns, section, _) do
+    assigns = assign(assigns, title: section.title, section_id: section.id)
+
+    ~H"""
+    <div class="pl-9 pr-4 flex flex-col">
+      <%= @title %>
+    </div>
+    """
+  end
+
+  def render_date(assigns, section, %ColumnSpec{name: :start_date}) do
+    assigns = assign(assigns, :start_date, section.start_date)
+
+    ~H"""
+    <%= FormatDateTime.format_datetime(@start_date, show_timezone: false) %>
+    """
+  end
+
+  def render_date(assigns, section, %ColumnSpec{name: :end_date}) do
+    assigns = assign(assigns, :end_date, section.end_date)
+
+    ~H"""
+    <%= FormatDateTime.format_datetime(@end_date, show_timezone: false) %>
+    """
+  end
+
+  def render_instructors_column(assigns, section, %ColumnSpec{name: :instructor}) do
+    names = Enum.map(section.instructors, & &1.name)
+    names_count = length(names)
+
+    instructors =
+      case names_count do
+        0 ->
+          "-"
+
+        1 ->
+          hd(names)
+
+        2 ->
+          Enum.join(names, " , ")
+
+        _ ->
+          first_three_names = Enum.take(names, 3)
+          rest_count = names_count - 3
+
+          first_three_names_str = Enum.join(first_three_names, ", ")
+
+          others_str =
+            "and #{rest_count} more #{if rest_count == 1, do: "instructor", else: "instructors"}"
+
+          "#{first_three_names_str}, #{others_str}"
+      end
+
+    assigns = assign(assigns, :instructors, instructors)
+
+    ~H"""
+    <%= @instructors %>
+    """
+  end
+end

--- a/lib/oli_web/components/delivery/actions/students_to_transfer_table_model.ex
+++ b/lib/oli_web/components/delivery/actions/students_to_transfer_table_model.ex
@@ -1,0 +1,48 @@
+defmodule OliWeb.Delivery.Actions.StudentsToTransferTableModel do
+  use Phoenix.Component
+
+  alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
+  alias OliWeb.Common.FormatDateTime
+
+  def new(students, target) do
+    column_specs = [
+      %ColumnSpec{
+        name: :name,
+        label: "NAME",
+        render_fn: &__MODULE__.render_name_column/3,
+        th_class: "pl-10"
+      },
+      %ColumnSpec{
+        name: :enrollment_date,
+        label: "ENROLLMENT DATE",
+        render_fn: &__MODULE__.render_date/3
+      }
+    ]
+
+    SortableTableModel.new(
+      rows: students,
+      column_specs: column_specs,
+      event_suffix: "",
+      id_field: [:id],
+      data: %{target: target}
+    )
+  end
+
+  def render_name_column(assigns, student, _) do
+    assigns = assign(assigns, name: student.name, student_id: student.id)
+
+    ~H"""
+    <div class="pl-9 pr-4 flex flex-col">
+      <%= @name %>
+    </div>
+    """
+  end
+
+  def render_date(assigns, student, %ColumnSpec{name: :enrollment_date}) do
+    assigns = assign(assigns, :enrollment_date, student.enrollment_date)
+
+    ~H"""
+    <%= FormatDateTime.format_datetime(@enrollment_date, show_timezone: false) %>
+    """
+  end
+end

--- a/lib/oli_web/components/delivery/actions/transfer_enrollment.ex
+++ b/lib/oli_web/components/delivery/actions/transfer_enrollment.ex
@@ -1,0 +1,507 @@
+defmodule OliWeb.Delivery.Actions.TransferEnrollment do
+  use Phoenix.LiveComponent
+
+  alias Oli.Accounts
+  alias Oli.Delivery.{Sections, Transfer}
+  alias OliWeb.Common.{PagedTable, Params, SearchInput}
+  alias OliWeb.Common.Table.SortableTableModel
+  alias OliWeb.Delivery.Actions.{SectionsToTransferTableModel, StudentsToTransferTableModel}
+  alias Phoenix.LiveView.JS
+
+  @default_params %{
+    offset: 0,
+    limit: 10,
+    sort_order: :asc,
+    sort_by: :title,
+    text_search: nil
+  }
+
+  def update(assigns, socket) do
+    params = decode_params(@default_params)
+
+    list_sections = Transfer.get_sections_to_transfer_data(assigns.section)
+
+    {total_count, rows} = apply_filters(list_sections, params, :step_1)
+
+    {:ok, sections_table_model} = SectionsToTransferTableModel.new(rows, socket.assigns.myself)
+
+    sections_table_model =
+      sections_table_model
+      |> Map.merge(%{
+        rows: rows,
+        sort_order: params.sort_order
+      })
+      |> SortableTableModel.update_sort_params(params.sort_by)
+
+    {:ok,
+     assign(socket,
+       current_section: assigns.section,
+       current_student: assigns.user,
+       list_sections: list_sections,
+       list_students: nil,
+       params: params,
+       sections_table_model: sections_table_model,
+       sections_total_count: total_count,
+       selected_section_to_transfer: nil,
+       selected_student_to_transfer: nil,
+       students_table_model: nil,
+       students_total_count: 0,
+       transfer_data_step: :step_1
+     )}
+  end
+
+  def update_table_model(socket) do
+    case socket.assigns.transfer_data_step do
+      :step_1 ->
+        {total_count, rows} =
+          apply_filters(
+            socket.assigns.list_sections,
+            socket.assigns.params,
+            :step_1
+          )
+
+        sections_table_model =
+          socket.assigns.sections_table_model
+          |> Map.merge(%{
+            rows: rows,
+            sort_order: socket.assigns.params.sort_order,
+          })
+          |> SortableTableModel.update_sort_params(socket.assigns.params.sort_by)
+
+        {:noreply,
+         assign(socket,
+           sections_table_model: sections_table_model,
+           sections_total_count: total_count,
+           transfer_data_step: :step_1
+         )}
+
+      :step_2 ->
+        set_students_table_model(socket)
+
+      :step_3 ->
+        {:noreply, socket}
+    end
+  end
+
+  def set_students_table_model(socket) do
+    {total_count, rows} =
+      apply_filters(
+        socket.assigns.list_students,
+        socket.assigns.params,
+        :step_2
+      )
+
+    {:ok, students_table_model} = StudentsToTransferTableModel.new(rows, socket.assigns.myself)
+
+    students_table_model =
+      students_table_model
+      |> Map.merge(%{
+        rows: rows,
+        sort_order: socket.assigns.params.sort_order,
+      })
+      |> SortableTableModel.update_sort_params(socket.assigns.params.sort_by)
+
+    {:noreply,
+     assign(socket,
+       students_table_model: students_table_model,
+       students_total_count: total_count,
+       transfer_data_step: :step_2
+     )}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <div id="transfer_enrollment">
+      <.live_component
+        module={OliWeb.Components.LiveModal}
+        id="transfer_enrollment_modal"
+        title="Transfer Enrollment"
+        on_confirm={
+          if @transfer_data_step == :step_3 and @selected_student_to_transfer != nil and
+               @selected_section_to_transfer != nil do
+            JS.push("finish_transfer_enrollment", target: @myself)
+            |> JS.push("close", target: "#transfer_enrollment_modal")
+          end
+        }
+        on_confirm_label={if @transfer_data_step == :step_3, do: "Confirm"}
+        on_cancel={
+          case @transfer_data_step do
+            :step_1 ->
+              JS.push("close", target: "#transfer_enrollment_modal")
+
+            :step_2 ->
+              JS.push("transfer_data_go_to_step_1", target: @myself)
+
+            :step_3 ->
+              JS.push("transfer_data_go_to_step_2", target: @myself)
+          end
+        }
+        on_cancel_label={if @transfer_data_step == :step_1, do: "Cancel", else: "Back"}
+        class="w-2/3 max-w-full"
+      >
+        <.transfer_enrollment
+          current_section={@current_section}
+          current_student={@current_student}
+          list_sections={@list_sections}
+          list_students={@list_students}
+          myself={@myself}
+          params={@params}
+          sections_table_model={@sections_table_model}
+          sections_total_count={@sections_total_count}
+          students_table_model={@students_table_model}
+          students_total_count={@students_total_count}
+          target_section={@selected_section_to_transfer}
+          target_student={@selected_student_to_transfer}
+          transfer_data_step={@transfer_data_step}
+        />
+      </.live_component>
+      <div class="flex justify-between items-center py-6">
+        <div class="flex flex-col">
+          <span class="dark:text-black">Transfer Enrollment</span>
+          <span class="text-xs text-gray-400 dark:text-gray-950">
+            Transfer data from this section to another section
+          </span>
+        </div>
+        <button phx-click="open" phx-target="#transfer_enrollment_modal" class="torus-button primary">
+          Transfer Enrollment
+        </button>
+      </div>
+    </div>
+    """
+  end
+
+  #### Transfer enrollment modal related stuff ####
+  def transfer_enrollment(%{transfer_data_step: :step_1} = assigns) do
+    ~H"""
+    <div class="px-4">
+      <p class="mb-2">
+        This will transfer this student's enrollment, and all their current progress, to the selected course section. If this student is already enrolled in the selected course section, that progress will be lost.
+      </p>
+      <hr class="my-5" />
+      <%= if length(assigns.list_sections) > 0 do %>
+        <div class="flex flex-col gap-2">
+          <div class="flex justify-between items-center">
+            <small class="torus-small uppercase">Select section to transfer enrolllment</small>
+            <form for="search" phx-target={@myself} phx-change="search_item" class="w-44">
+              <SearchInput.render
+                id="section_search_input"
+                name="item_name"
+                text={@params.text_search}
+              />
+            </form>
+          </div>
+          <PagedTable.render
+            __context__={assigns[:__context_]}
+            table_model={@sections_table_model}
+            total_count={@sections_total_count}
+            offset={@params.offset}
+            limit={@params.limit}
+            page_change={%{name: "paged_table_page_change", target: "#transfer_enrollment"}}
+            selection_change={
+              %{name: "paged_table_selection_section_change", target: "#transfer_enrollment"}
+            }
+            sort={%{name: "paged_table_sort", target: "#transfer_enrollment"}}
+            additional_table_class="instructor_dashboard_table"
+            filter=""
+            show_top_paging={true}
+            show_bottom_paging={false}
+            render_top_info={false}
+            allow_selection={true}
+          />
+        </div>
+      <% else %>
+        <p class="mt-4">There are no other sections to transfer this student to.</p>
+      <% end %>
+    </div>
+    """
+  end
+
+  def transfer_enrollment(%{transfer_data_step: :step_2} = assigns) do
+    ~H"""
+    <div class="px-4">
+      <p class="mb-2">
+        This will transfer this student's enrollment, and all their current progress, to the selected course section. If this student is already enrolled in the selected course section, that progress will be lost.
+      </p>
+      <hr class="my-5"/>
+      <%= if length(assigns.list_students) > 0 do %>
+        <div class="flex flex-col gap-2">
+          <div class="flex justify-between items-center">
+            <small class="torus-small uppercase">Select student to transfer enrolllment</small>
+            <form for="search" phx-target={@myself} phx-change="search_item" class="w-44">
+              <SearchInput.render
+                id="student_search_input"
+                name="item_name"
+                text={@params.text_search}
+              />
+            </form>
+          </div>
+          <PagedTable.render
+            __context__={assigns[:__context_]}
+            table_model={@students_table_model}
+            total_count={@students_total_count}
+            offset={@params.offset}
+            limit={@params.limit}
+            page_change={%{name: "paged_table_page_change", target: "#transfer_enrollment"}}
+            selection_change={
+              %{name: "paged_table_selection_student_change", target: "#transfer_enrollment"}
+            }
+            sort={%{name: "paged_table_sort", target: "#transfer_enrollment"}}
+            additional_table_class="instructor_dashboard_table"
+            filter=""
+            show_top_paging={true}
+            show_bottom_paging={false}
+            render_top_info={false}
+            allow_selection={true}
+          />
+        </div>
+      <% else %>
+        <p class="mt-4">There are no other students to transfer this student to.</p>
+      <% end %>
+    </div>
+    """
+  end
+
+  def transfer_enrollment(%{transfer_data_step: :step_3} = assigns) do
+    ~H"""
+    <div class="px-4">
+      <p class="mb-2">
+        This will transfer this student's enrollment, and all their current progress, to the selected course section. If this student is already enrolled in the selected course section, that progress will be lost.
+      </p>
+      <hr class="my-5"/>
+      <p class="my-4">
+        Are you sure you want to transfer the <strong><%= @current_student.name %></strong>
+        enrollment's in <strong><%= @current_section.title %></strong>
+        to <strong><%= @target_student.name %></strong>
+        in <strong><%= @target_section.title %></strong>?
+      </p>
+    </div>
+    """
+  end
+
+  def handle_event("transfer_data_go_to_step_1", _, socket) do
+    update_table_model(
+      assign(
+        socket,
+        params: @default_params,
+        transfer_data_step: :step_1,
+        selected_section_to_transfer: nil,
+        selected_student_to_transfer: nil
+      )
+    )
+  end
+
+  def handle_event("transfer_data_go_to_step_2", _, socket) do
+    update_table_model(
+      assign(
+        socket,
+        transfer_data_step: :step_2
+      )
+    )
+  end
+
+  def handle_event("finish_transfer_enrollment", _params, socket) do
+    %{
+      current_section: current_section,
+      current_student: current_student,
+      selected_section_to_transfer: target_section,
+      selected_student_to_transfer: target_student
+    } = socket.assigns
+
+    case Transfer.transfer_enrollment(
+           current_section,
+           current_student.id,
+           target_section,
+           target_student.id
+         ) do
+      {:ok, _} ->
+        send(self(), {:put_flash, :info, "Enrollment successfully transfered"})
+        {:noreply, socket}
+
+      {:error, _} ->
+        send(self(), {:put_flash, :error, "Couldn't transfer enrollment data. Please try again"})
+        {:noreply, socket}
+    end
+  end
+
+  def handle_event(
+        "paged_table_selection_section_change",
+        %{"id" => selected_section_id},
+        socket
+      ) do
+    selected_target_section = Sections.get_section!(String.to_integer(selected_section_id))
+
+    set_students_table_model(
+      assign(
+        socket,
+        list_students:
+          Sections.get_students_for_section_with_enrollment_date(selected_target_section.id),
+        params: update_params(socket.assigns.params, %{sort_by: :name}),
+        selected_section_to_transfer: selected_target_section,
+        selected_student_to_transfer: nil
+      )
+    )
+  end
+
+  def handle_event(
+        "paged_table_selection_student_change",
+        %{"id" => selected_student_id},
+        socket
+      ) do
+    target_student = Accounts.get_user!(String.to_integer(selected_student_id))
+
+    update_table_model(
+      assign(
+        socket,
+        selected_student_to_transfer: target_student,
+        transfer_data_step: :step_3
+      )
+    )
+  end
+
+  def handle_event(
+        "search_item",
+        %{"item_name" => item_name},
+        socket
+      ) do
+    update_table_model(
+      assign(
+        socket,
+        :params,
+        update_params(socket.assigns.params, %{text_search: item_name})
+      )
+    )
+  end
+
+  def handle_event(
+        "paged_table_page_change",
+        %{"limit" => limit, "offset" => offset},
+        socket
+      ) do
+    update_table_model(
+      assign(
+        socket,
+        :params,
+        update_params(socket.assigns.params, %{
+          limit: String.to_integer(limit),
+          offset: String.to_integer(offset)
+        })
+      )
+    )
+  end
+
+  def handle_event(
+        "paged_table_sort",
+        %{"sort_by" => sort_by} = _params,
+        socket
+      ) do
+    update_table_model(
+      assign(
+        socket,
+        :params,
+        update_params(socket.assigns.params, %{sort_by: String.to_existing_atom(sort_by)})
+      )
+    )
+  end
+
+  defp decode_params(params) do
+    %{
+      offset: Params.get_int_param(params, "offset", @default_params.offset),
+      limit: Params.get_int_param(params, "limit", @default_params.limit),
+      sort_order:
+        Params.get_atom_param(
+          params,
+          "sort_order",
+          [:asc, :desc],
+          @default_params.sort_order
+        ),
+      sort_by:
+        Params.get_atom_param(
+          params,
+          "sort_by",
+          [
+            :title,
+            :start_date,
+            :end_date,
+            :name,
+            :enrollment_date
+          ],
+          @default_params.sort_by
+        ),
+      text_search: Params.get_param(params, "text_search", @default_params.text_search)
+    }
+  end
+
+  defp apply_filters(list_to_work, params, step) do
+    list_to_work =
+      list_to_work
+      |> maybe_filter_by_text(params.text_search, step)
+      |> sort_by(params.sort_by, params.sort_order)
+
+    {length(list_to_work), list_to_work |> Enum.drop(params.offset) |> Enum.take(params.limit)}
+  end
+
+  defp maybe_filter_by_text(list_to_work, nil, _), do: list_to_work
+  defp maybe_filter_by_text(list_to_work, "", _), do: list_to_work
+
+  defp maybe_filter_by_text(list_to_work, text_search, step) do
+    case step do
+      :step_1 ->
+        Enum.filter(list_to_work, fn data ->
+          String.contains?(
+            String.downcase(data.title),
+            String.downcase(text_search)
+          )
+        end)
+
+      :step_2 ->
+        Enum.filter(list_to_work, fn data ->
+          String.contains?(
+            String.downcase(data.name),
+            String.downcase(text_search)
+          )
+        end)
+    end
+  end
+
+  defp sort_by(list_to_work, sort_by, sort_order) do
+    case sort_by do
+      :title ->
+        Enum.sort_by(
+          list_to_work,
+          fn data -> Map.get(data, :title) |> String.downcase() end,
+          sort_order
+        )
+
+      :start_date ->
+        Enum.sort_by(list_to_work, fn data -> data.start_date end, sort_order)
+
+      :end_date ->
+        Enum.sort_by(list_to_work, fn data -> data.end_date end, sort_order)
+
+      :enrollment_date ->
+        Enum.sort_by(list_to_work, fn data -> data.enrollment_date end, sort_order)
+
+      :name ->
+        Enum.sort_by(
+          list_to_work,
+          fn data -> Map.get(data, :name) |> String.downcase() end,
+          sort_order
+        )
+    end
+  end
+
+  defp update_params(
+         %{sort_by: current_sort_by, sort_order: current_sort_order} = params,
+         %{
+           sort_by: new_sort_by
+         }
+       )
+       when current_sort_by == new_sort_by do
+    toggled_sort_order = if current_sort_order == :asc, do: :desc, else: :asc
+    update_params(params, %{sort_order: toggled_sort_order})
+  end
+
+  defp update_params(params, new_param) do
+    Map.merge(params, new_param)
+  end
+end

--- a/lib/oli_web/components/delivery/actions/transfer_enrollment.ex
+++ b/lib/oli_web/components/delivery/actions/transfer_enrollment.ex
@@ -448,16 +448,16 @@ defmodule OliWeb.Delivery.Actions.TransferEnrollment do
       :step_1 ->
         Enum.filter(list_to_work, fn data ->
           String.contains?(
-            String.downcase(data.title),
-            String.downcase(text_search)
+            safe_downcase(data.title),
+            String.safe_downcase(text_search)
           )
         end)
 
       :step_2 ->
         Enum.filter(list_to_work, fn data ->
           String.contains?(
-            String.downcase(data.name),
-            String.downcase(text_search)
+            safe_downcase(data.name),
+            safe_downcase(text_search)
           )
         end)
     end
@@ -468,7 +468,7 @@ defmodule OliWeb.Delivery.Actions.TransferEnrollment do
       :title ->
         Enum.sort_by(
           list_to_work,
-          fn data -> Map.get(data, :title) |> String.downcase() end,
+          fn data -> data.title |> safe_downcase end,
           sort_order
         )
 
@@ -484,11 +484,14 @@ defmodule OliWeb.Delivery.Actions.TransferEnrollment do
       :name ->
         Enum.sort_by(
           list_to_work,
-          fn data -> Map.get(data, :name) |> String.downcase() end,
+          fn data -> data.name |> safe_downcase end,
           sort_order
         )
     end
   end
+
+  defp safe_downcase(nil), do: ""
+  defp safe_downcase(string), do: String.downcase(string)
 
   defp update_params(
          %{sort_by: current_sort_by, sort_order: current_sort_order} = params,

--- a/lib/oli_web/live/delivery/student_dashboard/student_dashboard_live.ex
+++ b/lib/oli_web/live/delivery/student_dashboard/student_dashboard_live.ex
@@ -217,6 +217,11 @@ defmodule OliWeb.Delivery.StudentDashboard.StudentDashboardLive do
      )}
   end
 
+  @impl Phoenix.LiveView
+  def handle_info({:put_flash, type, message}, socket) do
+    {:noreply, put_flash(socket, type, message)}
+  end
+
   defp get_containers(section, student_id) do
     case Sections.get_units_and_modules_containers(section.slug) do
       {0, pages} ->


### PR DESCRIPTION
[MER-1908](https://eliterate.atlassian.net/browse/MER-1908)

This PR adds the possibility for an admin user to transfer the enrollment of a student from one course section to another course section.

This functionality can be found in the `actions` tab within the `student dashboard`.

https://github.com/Simon-Initiative/oli-torus/assets/16328384/aeed67db-71e4-4bc1-8fdb-2575e8a631fa


[MER-1908]: https://eliterate.atlassian.net/browse/MER-1908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ