### PR TITLE
[Bugfix] Prevent data loss in list items [MER-2448]

### DIFF
--- a/assets/src/data/content/model/elements/factories.ts
+++ b/assets/src/data/content/model/elements/factories.ts
@@ -29,6 +29,7 @@ import {
   ImageBlock,
   ImageInline,
   InputRef,
+  ListChildren,
   ListItem,
   ModelElement,
   OrderedList,
@@ -83,7 +84,8 @@ export const Model = {
 
   ol: () => create<OrderedList>({ type: 'ol', children: [Model.li()] }),
 
-  ul: () => create<UnorderedList>({ type: 'ul', children: [Model.li()] }),
+  ul: (children?: ListChildren | undefined) =>
+    create<UnorderedList>({ type: 'ul', children: children || [Model.li()] }),
 
   dt: () => create<DescriptionListTerm>({ type: 'dt', children: [Model.p([{ text: 'A term' }])] }),
   dd: () =>

--- a/assets/src/data/content/model/elements/types.ts
+++ b/assets/src/data/content/model/elements/types.ts
@@ -144,7 +144,7 @@ export type OrderedListStyle = typeof OrderedListStyles[number];
 export const UnorderdListStyles = ['none', 'disc', 'circle', 'square'];
 export type UnorderedListStyle = typeof UnorderdListStyles[number];
 
-type ListChildren = (ListItem | OrderedList | UnorderedList | Text)[];
+export type ListChildren = (ListItem | OrderedList | UnorderedList | Text)[];
 
 export interface OrderedList extends SlateElement<ListChildren> {
   type: 'ol';

--- a/assets/test/editor/normalize_list_test.ts
+++ b/assets/test/editor/normalize_list_test.ts
@@ -1,0 +1,249 @@
+import { Editor, createEditor } from 'slate';
+import { withHistory } from 'slate-history';
+import { withReact } from 'slate-react';
+import { installNormalizer } from 'components/editing/editor/normalizers/normalizer';
+import { withInlines } from 'components/editing/editor/overrides/inlines';
+import { withTables } from 'components/editing/editor/overrides/tables';
+import { withVoids } from 'components/editing/editor/overrides/voids';
+import { Model } from 'data/content/model/elements/factories';
+
+const expectAnyEmptyParagraph = { type: 'p', id: expect.any(String), children: [{ text: '' }] };
+
+describe('List normalization', () => {
+  it('should not touch non-lists', () => {
+    const editor = withReact(withHistory(withTables(withInlines(withVoids(createEditor())))));
+    const original = Model.p('Hello World');
+    editor.children = [original];
+    installNormalizer(editor);
+    Editor.normalize(editor, { force: true });
+    expect(editor.children).toEqual([original]);
+  });
+
+  it('should not touch well formed lists', () => {
+    const editor = withReact(withHistory(withTables(withInlines(withVoids(createEditor())))));
+    const original = [
+      Model.p('Hello World'),
+      Model.ul([Model.li('Hello List World 1'), Model.li('Hello list World 2')]),
+      Model.p('Goodbye World'),
+    ];
+    editor.children = [...original];
+    installNormalizer(editor);
+    Editor.normalize(editor, { force: true });
+    expect(editor.children).toEqual(original);
+  });
+
+  it('should wrap text nodes inside list items with a p', () => {
+    const editor = withReact(withHistory(withTables(withInlines(withVoids(createEditor())))));
+    const original = [
+      Model.p(''),
+      Model.ul([
+        {
+          ...Model.li(),
+          children: [{ text: 'Hello World' } as any],
+        },
+      ]),
+      Model.p(''),
+    ];
+    editor.children = [...original];
+    installNormalizer(editor);
+    Editor.normalize(editor, { force: true });
+    jest.clearAllMocks();
+
+    expect(editor.children[1]).toEqual({
+      type: 'ul',
+      id: expect.any(String),
+      children: [
+        {
+          type: 'li',
+          id: expect.any(String),
+          children: [
+            {
+              type: 'p',
+              id: expect.any(String),
+              children: [{ text: 'Hello World' }],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('should wrap multiple text nodes inside list items with a single p', () => {
+    const editor = withReact(withHistory(withTables(withInlines(withVoids(createEditor())))));
+    const original = [
+      Model.p(''),
+      Model.ul([
+        {
+          ...Model.li(),
+          children: [{ text: 'Hello World 1' } as any, { text: ' Hello World 2' } as any],
+        },
+      ]),
+      Model.p(''),
+    ];
+    editor.children = [...original];
+    installNormalizer(editor);
+    Editor.normalize(editor, { force: true });
+
+    expect(editor.children[1]).toEqual({
+      type: 'ul',
+      id: expect.any(String),
+      children: [
+        {
+          type: 'li',
+          id: expect.any(String),
+          children: [
+            {
+              type: 'p',
+              id: expect.any(String),
+              children: [{ text: 'Hello World 1 Hello World 2' }],
+              // Note: Slate also combines adjacent text nodes with the same marks
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('should wrap multiple text nodes with different marks inside list items with a single p', () => {
+    const editor = withReact(withHistory(withTables(withInlines(withVoids(createEditor())))));
+    const original = [
+      Model.p(''),
+      Model.ul([
+        {
+          ...Model.li(),
+          children: [
+            { text: 'Hello World 1', bold: true } as any,
+            { text: 'Hello World 2', italic: true } as any,
+          ],
+        },
+      ]),
+      Model.p(''),
+    ];
+    editor.children = [...original];
+    installNormalizer(editor);
+    Editor.normalize(editor, { force: true });
+
+    expect(editor.children[1]).toEqual({
+      type: 'ul',
+      id: expect.any(String),
+      children: [
+        {
+          type: 'li',
+          id: expect.any(String),
+          children: [
+            {
+              type: 'p',
+              id: expect.any(String),
+              children: [
+                { text: 'Hello World 1', bold: true },
+                { text: 'Hello World 2', italic: true },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('removes mixed block and inline children in list items', () => {
+    const editor = withReact(withHistory(withTables(withInlines(withVoids(createEditor())))));
+    const original = [
+      Model.p(''),
+      Model.ul([
+        {
+          ...Model.li(),
+          children: [
+            Model.p('Hello World 1'),
+            { text: 'Hello World 2', bold: true } as any,
+            { text: 'Hello World 3', italic: true } as any,
+          ],
+        },
+      ]),
+      Model.p(''),
+    ];
+    editor.children = [...original];
+    installNormalizer(editor);
+    Editor.normalize(editor, { force: true });
+
+    expect(editor.children).toEqual([
+      expectAnyEmptyParagraph,
+      {
+        type: 'ul',
+        id: expect.any(String),
+        children: [
+          {
+            type: 'li',
+            id: expect.any(String),
+            children: [
+              {
+                type: 'p',
+                id: expect.any(String),
+                children: [{ text: 'Hello World 1' }],
+              },
+            ],
+          },
+        ],
+      },
+      expectAnyEmptyParagraph,
+    ]);
+  });
+
+  it('preserves a popup in a list item', () => {
+    // Simulates MER-2448
+    const editor = withReact(withHistory(withTables(withInlines(withVoids(createEditor())))));
+
+    const originalPopup = {
+      children: [
+        {
+          text: 'por ejemplo',
+        },
+      ],
+      content: [
+        {
+          children: [
+            {
+              text: 'for example',
+            },
+          ],
+          id: '998512574',
+          type: 'p',
+        },
+      ],
+      id: '1636902826',
+      trigger: 'hover',
+      type: 'popup',
+    };
+
+    const original = [
+      Model.p(''),
+      Model.ul([
+        {
+          ...Model.li(),
+          children: [{ text: '' } as any, originalPopup, { text: '' } as any],
+        },
+      ]),
+      Model.p(''),
+    ];
+    editor.children = [...original];
+    installNormalizer(editor);
+    Editor.normalize(editor, { force: true });
+
+    expect(editor.children[1]).toEqual({
+      type: 'ul',
+      id: expect.any(String),
+      children: [
+        {
+          type: 'li',
+          id: expect.any(String),
+          children: [
+            {
+              type: 'p',
+              id: expect.any(String),
+              children: [{ text: '' }, originalPopup, { text: '' }],
+            },
+          ],
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
If a list item has multiple inline elements as direct children, then content within that list item may be lost the next time the document is edited.

Example of problematic content:

```
{
  type: 'li',
  children: [
    {text ""},
    {type: "popup", ...more content here... },
    {text ""},
  ]
}
 ```

Previously, the normalizers run, see that first text node, wrap it in a paragraph, and then run another round of normalization.

However, that left us with block elements next to inline elements, which is invalid content. So those two extra inline elements would be deleted by slate and data gets lost.
 

Sample page the problem occurs on:

[OLI Torus](https://proton.oli.cmu.edu/authoring/project/spanish_for_beginners_level_a1/resource/por_vs_para)