### PR TITLE
[BUG FIX] [MER-2450] multi input text inputs on graded pages restoring only first word

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,26 @@
 
 ### Configs
 
-## 0.24.1 (unreleased)
+## 0.24.3 (unreleased)
 
 ### Bug Fixes
 
-- Fix an issue where a nil end_datetime in scheduled gate crashes overview page
+- Fix an issue in assessment review of multi inputs where text was being truncated
+
+## 0.24.2 (2023-7-27)
+
+### Bug Fixes
+
+- Improved handling of adaptive pages that have hard deadlines
+- Added explanatory tooltips to the Assessment Settings UX
+- Fixed a bug where Scheduler date/time labels disappeared
+- Fixed a bug with handling gates without end dates
+- Removed the background colors of the Dialog content element rendering
+- Handle scientific notation with an explicit "+" sign in response evaluation
+- Fix styling inconsistencies in Example content groups
+- Ensure that course section creation inherits the cover image from a product
+- Fix styling issues for dark mode rendering of the Likert activity
+- Correct the link to the top-level discussion forum
 
 ## 0.24.1 (2023-7-21)
 

--- a/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
@@ -121,7 +121,7 @@ export const MultiInputComponent: React.FC = () => {
   );
 
   const inputValue = (input: MultiInput) => {
-    const studentInput = uiState.partState[input.partId].studentInput;
+    const studentInput = uiState.partState[input.partId]?.studentInput;
 
     // safeguard against null/undefined studentInput
     if (!studentInput) return '';

--- a/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
@@ -83,10 +83,12 @@ export const MultiInputComponent: React.FC = () => {
       initializeState(
         activityState,
         safelySelectStringInputs(activityState).caseOf({
-          just: (input) => input,
-          nothing: () => ({
-            [castPartId(activityState.parts[0].partId)]: [''],
-          }),
+          just: (inputs) => inputs,
+          nothing: () =>
+            model.inputs.reduce((acc, input) => {
+              acc[input.partId] = [''];
+              return acc;
+            }, {} as PartInputs),
         }),
         model,
         context,

--- a/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
@@ -120,6 +120,19 @@ export const MultiInputComponent: React.FC = () => {
     {},
   );
 
+  const inputValue = (input: MultiInput) => {
+    const studentInput = uiState.partState[input.partId].studentInput
+
+    // safeguard against null/undefined studentInput
+    if (!studentInput) return '';
+
+    if (input.inputType === 'text') {
+      return uiState.partState[input.partId].studentInput.join(' ');
+    }
+
+    return uiState.partState[input.partId].studentInput[0];
+  };
+
   const inputs = new Map(
     (uiState.model as MultiInputSchema).inputs.map((input) => [
       input.id,
@@ -136,7 +149,7 @@ export const MultiInputComponent: React.FC = () => {
                 size: input.size,
               }
             : { id: input.id, inputType: input.inputType, size: input.size },
-        value: (uiState.partState[input.partId]?.studentInput || [''])[0],
+        value: inputValue(input),
         hasHints: uiState.partState[input.partId].hasMoreHints,
       },
     ]),

--- a/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
@@ -126,6 +126,9 @@ export const MultiInputComponent: React.FC = () => {
     // safeguard against null/undefined studentInput
     if (!studentInput) return '';
 
+    // safeguard against studentInput of type string
+    if (typeof studentInput === 'string') return studentInput;
+
     if (input.inputType === 'text') {
       return uiState.partState[input.partId].studentInput.join(' ');
     }

--- a/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
@@ -121,7 +121,7 @@ export const MultiInputComponent: React.FC = () => {
   );
 
   const inputValue = (input: MultiInput) => {
-    const studentInput = uiState.partState[input.partId].studentInput
+    const studentInput = uiState.partState[input.partId].studentInput;
 
     // safeguard against null/undefined studentInput
     if (!studentInput) return '';

--- a/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
@@ -29,11 +29,11 @@ import {
 } from 'data/activities/DeliveryState';
 import { getByUnsafe } from 'data/activities/model/utils';
 import { safelySelectStringInputs } from 'data/activities/utils';
-import { castPartId } from '../common/utils';
 import { defaultWriterContext } from 'data/content/writers/context';
 import { configureStore } from 'state/store';
 import { DeliveryElementProvider, useDeliveryElementContext } from '../DeliveryElementProvider';
 import { initializePersistence } from '../common/delivery/persistence';
+import { castPartId } from '../common/utils';
 
 export const MultiInputComponent: React.FC = () => {
   const {

--- a/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
@@ -119,22 +119,6 @@ export const MultiInputComponent: React.FC = () => {
     {},
   );
 
-  const inputValue = (input: MultiInput) => {
-    const studentInput = uiState.partState[input.partId]?.studentInput;
-
-    // safeguard against null/undefined studentInput
-    if (!studentInput) return '';
-
-    // safeguard against studentInput of type string
-    if (typeof studentInput === 'string') return studentInput;
-
-    if (input.inputType === 'text') {
-      return uiState.partState[input.partId].studentInput.join(' ');
-    }
-
-    return uiState.partState[input.partId].studentInput[0];
-  };
-
   const inputs = new Map(
     (uiState.model as MultiInputSchema).inputs.map((input) => [
       input.id,
@@ -151,7 +135,7 @@ export const MultiInputComponent: React.FC = () => {
                 size: input.size,
               }
             : { id: input.id, inputType: input.inputType, size: input.size },
-        value: inputValue(input),
+        value: (uiState.partState[input.partId]?.studentInput || [''])[0],
         hasHints: uiState.partState[input.partId].hasMoreHints,
       },
     ]),

--- a/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
@@ -28,7 +28,8 @@ import {
   submitPart,
 } from 'data/activities/DeliveryState';
 import { getByUnsafe } from 'data/activities/model/utils';
-import { safelySelectInputs } from 'data/activities/utils';
+import { safelySelectStringInputs } from 'data/activities/utils';
+import { castPartId } from '../common/utils';
 import { defaultWriterContext } from 'data/content/writers/context';
 import { configureStore } from 'state/store';
 import { DeliveryElementProvider, useDeliveryElementContext } from '../DeliveryElementProvider';
@@ -81,13 +82,11 @@ export const MultiInputComponent: React.FC = () => {
     dispatch(
       initializeState(
         activityState,
-        safelySelectInputs(activityState).caseOf({
-          just: (inputs) => inputs,
-          nothing: () =>
-            model.inputs.reduce((acc, input) => {
-              acc[input.partId] = [''];
-              return acc;
-            }, {} as PartInputs),
+        safelySelectStringInputs(activityState).caseOf({
+          just: (input) => input,
+          nothing: () => ({
+            [castPartId(activityState.parts[0].partId)]: [''],
+          }),
         }),
         model,
         context,

--- a/assets/src/data/activities/utils.ts
+++ b/assets/src/data/activities/utils.ts
@@ -20,6 +20,8 @@ export const stringToStudentInput = (input: string): StudentInput =>
 
 // An `ActivityState` only has an input if it has been saved or submitted.
 // Each activity part may have an input.
+// NB: this version splits input strings into array of words, useful if input string codes a set of
+// selected ids. Not appropriate for text input activities which should use safelySelectStringInputs
 export const safelySelectInputs = (activityState: ActivityState | undefined): Maybe<PartInputs> => {
   const partInputs = activityState?.parts.filter((part) => !!part?.response?.input);
   if (!partInputs) return Maybe.nothing();

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Oli.MixProject do
   def project do
     [
       app: :oli,
-      version: "0.24.2",
+      version: "0.24.3",
       elixir: "~> 1.14.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: elixirc_options(Mix.env()),


### PR DESCRIPTION
Fixes an issue with multi input questions in review mode of an assessment where only the first word in a text input was being rendered.