### PR TITLE
[ENHANCEMENT] author multiple correct answers [MER-2294]

### DIFF
--- a/assets/src/components/activities/common/authoring/AuthoringCheckbox.tsx
+++ b/assets/src/components/activities/common/authoring/AuthoringCheckbox.tsx
@@ -17,20 +17,21 @@ interface Props {
 export const AuthoringCheckbox: React.FC<Props> = (props: Props) => {
   return (
     <div>
-      <label className="form-check-label" htmlFor={props.id}>
-        {props.label}
-      </label>
-      &nbsp;
       <input
         id={props.id}
         aria-label={props.ariaLabel || ''}
         style={props.style}
-        className={classNames('form-check-input', props.className)}
+        className={classNames('my-auto', props.className)}
         disabled={props.disabled || !props.editMode}
         type="checkbox"
         checked={props.value}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => props.onChange(e.target.checked)}
       ></input>
+      &nbsp;
+      <label className="form-check-label" htmlFor={props.id}>
+        {props.label}
+      </label>
+      &nbsp;
     </div>
   );
 };

--- a/assets/src/components/activities/common/authoring/AuthoringCheckbox.tsx
+++ b/assets/src/components/activities/common/authoring/AuthoringCheckbox.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { useAuthoringElementContext } from 'components/activities/AuthoringElementProvider';
+import { classNames } from 'utils/classNames';
+
+interface Props {
+  label: string;
+  id: string;
+  value: boolean;
+  onChange: (value: boolean) => void;
+  editMode: boolean;
+  ariaLabel?: string;
+  style?: React.CSSProperties;
+  className?: string;
+  disabled?: boolean;
+}
+
+export const AuthoringCheckbox: React.FC<Props> = (props: Props) => {
+  return (
+    <div>
+      <label className="form-check-label" htmlFor={props.id}>
+        {props.label}
+      </label>
+      &nbsp;
+      <input
+        id={props.id}
+        aria-label={props.ariaLabel || ''}
+        style={props.style}
+        className={classNames('form-check-input', props.className)}
+        disabled={props.disabled || !props.editMode}
+        type="checkbox"
+        checked={props.value}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) => props.onChange(e.target.checked)}
+      ></input>
+    </div>
+  );
+};
+
+export const AuthoringCheckboxConnected: React.FC<Omit<Props, 'editMode'>> = (props) => {
+  const { editMode } = useAuthoringElementContext();
+  return <AuthoringCheckbox {...props} editMode={editMode} />;
+};

--- a/assets/src/components/activities/common/responses/ResponseCard.tsx
+++ b/assets/src/components/activities/common/responses/ResponseCard.tsx
@@ -4,23 +4,30 @@ import { RemoveButtonConnected } from 'components/activities/common/authoring/Re
 import { Response } from 'components/activities/types';
 import { RichTextEditorConnected } from 'components/content/RichTextEditor';
 import { Card } from 'components/misc/Card';
+import CustomCheckbox from 'apps/authoring/components/PropertyEditor/custom/CustomCheckbox';
 import { ID } from 'data/content/model/other';
 
 interface Props {
   title: React.ReactNode;
   response: Response;
   updateFeedback: (responseId: ID, content: Descendant[]) => void;
+  updateCorrectness: (responseId: ID, correct: boolean) => void;
   removeResponse: (responseId: ID) => void;
 }
 export const ResponseCard: React.FC<Props> = (props) => {
   return (
     <Card.Card>
       <Card.Title>
-        <div className="d-flex justify-content-between w-100">
-          {props.title}
-          <div className="flex-grow-1"></div>
-          <RemoveButtonConnected onClick={() => props.removeResponse(props.response.id)} />
-        </div>
+        <div className="d-flex justify-content-between w-100">{props.title}</div>
+        <div className="flex-grow-1"></div>
+        <CustomCheckbox
+          label="Correct&nbsp;"
+          id={props.response.id + '-correct'}
+          value={!!props.response.score}
+          onChange={(value) => props.updateCorrectness(props.response.id, value)}
+        />
+
+        <RemoveButtonConnected onClick={() => props.removeResponse(props.response.id)} />
       </Card.Title>
       <Card.Content>
         <RichTextEditorConnected

--- a/assets/src/components/activities/common/responses/ResponseCard.tsx
+++ b/assets/src/components/activities/common/responses/ResponseCard.tsx
@@ -4,8 +4,8 @@ import { RemoveButtonConnected } from 'components/activities/common/authoring/Re
 import { Response } from 'components/activities/types';
 import { RichTextEditorConnected } from 'components/content/RichTextEditor';
 import { Card } from 'components/misc/Card';
-import CustomCheckbox from 'apps/authoring/components/PropertyEditor/custom/CustomCheckbox';
 import { ID } from 'data/content/model/other';
+import { AuthoringCheckboxConnected } from '../authoring/AuthoringCheckbox';
 
 interface Props {
   title: React.ReactNode;
@@ -20,8 +20,8 @@ export const ResponseCard: React.FC<Props> = (props) => {
       <Card.Title>
         <div className="d-flex justify-content-between w-100">{props.title}</div>
         <div className="flex-grow-1"></div>
-        <CustomCheckbox
-          label="Correct&nbsp;"
+        <AuthoringCheckboxConnected
+          label="Correct"
           id={props.response.id + '-correct'}
           value={!!props.response.score}
           onChange={(value) => props.updateCorrectness(props.response.id, value)}

--- a/assets/src/components/activities/common/responses/ResponseCard.tsx
+++ b/assets/src/components/activities/common/responses/ResponseCard.tsx
@@ -26,7 +26,6 @@ export const ResponseCard: React.FC<Props> = (props) => {
           value={!!props.response.score}
           onChange={(value) => props.updateCorrectness(props.response.id, value)}
         />
-
         <RemoveButtonConnected onClick={() => props.removeResponse(props.response.id)} />
       </Card.Title>
       <Card.Content>

--- a/assets/src/components/activities/common/responses/TargetedFeedback.tsx
+++ b/assets/src/components/activities/common/responses/TargetedFeedback.tsx
@@ -34,6 +34,8 @@ export const useTargetedFeedback = () => {
     targetedMappings: getTargetedResponseMappings(model),
     updateFeedback: (responseId: string, content: RichText) =>
       dispatch(ResponseActions.editResponseFeedback(responseId, content)),
+    updateCorrectness: (responseId: string, correct: boolean) =>
+      dispatch(ResponseActions.editResponseCorrectness(responseId, correct)),
     removeFeedback: (responseId: string) =>
       dispatch(ResponseActions.removeTargetedFeedback(responseId)),
     updateShowPage: (responseId: string, showPage: number | undefined) =>
@@ -75,6 +77,7 @@ export const TargetedFeedback: React.FC<Props> = (props) => {
           title="Targeted feedback"
           response={mapping.response}
           updateFeedback={hook.updateFeedback}
+          updateCorrectness={hook.updateCorrectness}
           removeResponse={hook.removeFeedback}
         >
           <ChoicesDelivery

--- a/assets/src/components/activities/common/responses/responseActions.ts
+++ b/assets/src/components/activities/common/responses/responseActions.ts
@@ -33,6 +33,12 @@ export const ResponseActions = {
     };
   },
 
+  editResponseCorrectness(responseId: ResponseId, correct: boolean) {
+    return (model: HasParts) => {
+      getResponseBy(model, (r) => r.id === responseId).score = correct ? 1 : 0;
+    };
+  },
+
   editShowPage(responseId: ResponseId, showPage: number | undefined) {
     return (model: HasParts) => {
       getResponseBy(model, (r) => r.id === responseId).showPage = showPage;

--- a/assets/src/components/activities/custom_dnd/AnswerKey.tsx
+++ b/assets/src/components/activities/custom_dnd/AnswerKey.tsx
@@ -56,6 +56,9 @@ export const AnswerKey: React.FC<Props> = (props) => {
           updateFeedback={(_id, content) =>
             dispatch(ResponseActions.editResponseFeedback(response.id, content as RichText))
           }
+          updateCorrectness={(_id, correct) =>
+            dispatch(ResponseActions.editResponseCorrectness(response.id, correct))
+          }
           removeResponse={(id) => dispatch(ResponseActions.removeResponse(id))}
           key={response.id}
         >

--- a/assets/src/components/activities/multi_input/sections/AnswerKeyTab.tsx
+++ b/assets/src/components/activities/multi_input/sections/AnswerKeyTab.tsx
@@ -102,6 +102,9 @@ export const AnswerKeyTab: React.FC<Props> = (props) => {
           updateFeedback={(_id, content) =>
             dispatch(ResponseActions.editResponseFeedback(response.id, content as RichText))
           }
+          updateCorrectness={(_id, correct) =>
+            dispatch(ResponseActions.editResponseCorrectness(response.id, correct))
+          }
           removeResponse={(id) => dispatch(ResponseActions.removeResponse(id))}
           key={response.id}
         >

--- a/assets/src/components/activities/ordering/sections/TargetedFeedback.tsx
+++ b/assets/src/components/activities/ordering/sections/TargetedFeedback.tsx
@@ -26,6 +26,9 @@ export const TargetedFeedback: React.FC = () => {
           updateFeedback={(id, content) =>
             dispatch(ResponseActions.editResponseFeedback(mapping.response.id, content as RichText))
           }
+          updateCorrectness={(_id, correct) =>
+            dispatch(ResponseActions.editResponseCorrectness(mapping.response.id, correct))
+          }
           removeResponse={(id) => dispatch(ResponseActions.removeTargetedFeedback(id))}
           key={mapping.response.id}
         >

--- a/assets/src/components/activities/short_answer/ShortAnswerAuthoring.tsx
+++ b/assets/src/components/activities/short_answer/ShortAnswerAuthoring.tsx
@@ -89,6 +89,9 @@ const ShortAnswer = () => {
                 updateFeedback={(id, content) =>
                   dispatch(ResponseActions.editResponseFeedback(response.id, content as RichText))
                 }
+                updateCorrectness={(_id, correct) =>
+                  dispatch(ResponseActions.editResponseCorrectness(response.id, correct))
+                }
                 removeResponse={(id) => dispatch(ResponseActions.removeResponse(id))}
                 key={response.id}
               >


### PR DESCRIPTION
This adds the ability for an author to specify multiple correct answers. It works by adding a checkbox labeled "Correct" to the ResponseCard component used to display a response when adding targeted feedback. Value is bound by code to the "score" attribute of the response, with non-zero score being correct, anything else incorrect. Checking the box on a previously incorrect response sets a score of 1.

Note score was preserved through migration tool, so migrated courses may have multiple correct responses, though this fact was invisible on the interface. 

Adds a simple AuthoringCheckbox[Connected] component wrapping a checkbox; "connected" version picks up the editMode from the authoring context. Modeled on AuthoringButton. 