### PR TITLE
[BUG FIX] Fix table rendering when missing caption and inside of paged content [MER-2484]

### DIFF
--- a/test/oli/rendering/content/html_test.exs
+++ b/test/oli/rendering/content/html_test.exs
@@ -82,7 +82,7 @@ defmodule Oli.Content.Content.HtmlTest do
                "<div class='figure'><figure><figcaption><p>Figure Title</p>\n</figcaption><div class='figure-content'><p>Figure Content</p>\n</div></figure></div>"
 
       assert rendered_html_string =~
-               "<div class=\"conjugation\"><div class=\"title\">My Term</div><div class=\"term\">El Verbo<span class='pronunciation'><p>my pronunciation</p>\n</span>\n</div><table class='table-bordered '><tr><th>form</th>\n<th>meaning</th>\n</tr>\n<tr><td>my form</td>\n<td>my meaning</td>\n</tr>\n</table>\n</div>"
+               "<div class=\"conjugation\"><div class=\"title\">My Term</div><div class=\"term\">El Verbo<span class='pronunciation'><p>my pronunciation</p>\n</span>\n</div><figure class=\"figure embed-responsive\"><div class=\"figure-content\"><table class='table-bordered '><tr><th>form</th>\n<th>meaning</th>\n</tr>\n<tr><td>my form</td>\n<td>my meaning</td>\n</tr>\n</table>\n</div></figure></div>"
 
       assert rendered_html_string =~
                "<span class=\"btn btn-primary command-button\" data-action=\"command-button\" data-target=\"3603298117\" data-message=\"startcuepoint=5.0;endcuepoint=10.0\">Play Intro</span>"


### PR DESCRIPTION
Tables without a `caption` attribute, which also exist inside of a paged group of content end up rendering weirdly with an apparent extra column.  The extra column is in fact due to some weird CSS effect that the outer paged group has on causing the table to render full width and padding it with a right aligned border. 

The fix here ensures that all server rendered tables are wrapped in a `<figure class="responsive-embed">` element, which then correctly renders the table. There is some conditional logic to wrap in a figure without a caption, or a figure with a caption, depending on whether or not a non-empty caption exists.   We do not want to render "empty captions" as empty `<figcaption>` elements, as this has a less than ideal interaction with screen readers. 

This fix also removes the `text-center` class from the entire figure.  That style was overriding text display in tables, causing them to be centered.  