### PR TITLE
[BUGFIX][MER-2339] Fix error quiz score tab in suspended student

### DIFF
--- a/lib/oli_web/live/delivery/student_dashboard/student_dashboard_live.ex
+++ b/lib/oli_web/live/delivery/student_dashboard/student_dashboard_live.ex
@@ -8,7 +8,6 @@ defmodule OliWeb.Delivery.StudentDashboard.StudentDashboardLive do
   alias OliWeb.Delivery.StudentDashboard.Components.Helpers
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Metrics
-  alias Oli.Grading.GradebookRow
 
   @impl Phoenix.LiveView
   def mount(_params, session, socket) do
@@ -269,13 +268,16 @@ defmodule OliWeb.Delivery.StudentDashboard.StudentDashboardLive do
   end
 
   defp get_scores(section, student_id) do
-    {gradebook, _column_labels} = Oli.Grading.generate_gradebook_for_section(section)
+    grades_for_user =
+      Oli.Grading.generate_gradebook_for_section(section)
+      |> elem(0)
+      |> Enum.filter(fn row -> row.user.id == student_id end)
 
-    if length(gradebook) > 0 do
-      [%GradebookRow{user: _user, scores: scores} | _] =
-        Enum.filter(gradebook, fn grade -> grade.user.id == student_id end)
-
-      Enum.filter(scores, fn score -> !is_nil(score) end)
+    if length(grades_for_user) > 0 do
+      grades_for_user
+      |> List.first()
+      |> Map.get(:scores)
+      |> Enum.filter(fn score -> !is_nil(score) end)
     else
       []
     end

--- a/lib/oli_web/live/delivery/student_dashboard/student_dashboard_live.ex
+++ b/lib/oli_web/live/delivery/student_dashboard/student_dashboard_live.ex
@@ -74,7 +74,7 @@ defmodule OliWeb.Delivery.StudentDashboard.StudentDashboardLive do
         active_tab: String.to_existing_atom(params["active_tab"])
       )
       |> assign_new(:scores, fn ->
-        %{scores: Oli.Grading.get_scores_for_section_and_user(socket.assigns.section, socket.assigns.student.id)}
+        %{scores: Oli.Grading.get_scores_for_section_and_user(socket.assigns.section.id, socket.assigns.student.id)}
       end)
 
     {:noreply, socket}

--- a/lib/oli_web/live/delivery/student_dashboard/student_dashboard_live.ex
+++ b/lib/oli_web/live/delivery/student_dashboard/student_dashboard_live.ex
@@ -268,19 +268,9 @@ defmodule OliWeb.Delivery.StudentDashboard.StudentDashboardLive do
   end
 
   defp get_scores(section, student_id) do
-    grades_for_user =
-      Oli.Grading.generate_gradebook_for_section(section)
-      |> elem(0)
-      |> Enum.filter(fn row -> row.user.id == student_id end)
-
-    if length(grades_for_user) > 0 do
-      grades_for_user
-      |> List.first()
-      |> Map.get(:scores)
-      |> Enum.filter(fn score -> !is_nil(score) end)
-    else
-      []
-    end
+    if Sections.is_enrolled?(student_id, section.slug),
+      do: Oli.Grading.get_scores_for_section_and_user(section, student_id),
+      else: []
   end
 
   defp get_page_nodes(section_slug, student_id) do

--- a/lib/oli_web/live/delivery/student_dashboard/student_dashboard_live.ex
+++ b/lib/oli_web/live/delivery/student_dashboard/student_dashboard_live.ex
@@ -74,7 +74,7 @@ defmodule OliWeb.Delivery.StudentDashboard.StudentDashboardLive do
         active_tab: String.to_existing_atom(params["active_tab"])
       )
       |> assign_new(:scores, fn ->
-        %{scores: get_scores(socket.assigns.section, socket.assigns.student.id)}
+        %{scores: Oli.Grading.get_scores_for_section_and_user(socket.assigns.section, socket.assigns.student.id)}
       end)
 
     {:noreply, socket}
@@ -265,12 +265,6 @@ defmodule OliWeb.Delivery.StudentDashboard.StudentDashboardLive do
 
         {total_count, containers_with_metrics}
     end
-  end
-
-  defp get_scores(section, student_id) do
-    if Sections.is_enrolled?(student_id, section.slug),
-      do: Oli.Grading.get_scores_for_section_and_user(section, student_id),
-      else: []
   end
 
   defp get_page_nodes(section_slug, student_id) do

--- a/test/oli_web/live/delivery/student_dashboard/components/quizz_scores_tab_test.exs
+++ b/test/oli_web/live/delivery/student_dashboard/components/quizz_scores_tab_test.exs
@@ -216,15 +216,28 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.QuizzScoresTabTest do
 
       Sections.unenroll_learner(student.id, section.id)
 
-      assert Oli.Grading.generate_gradebook_for_section(section)
-             |> elem(0)
-             |> Enum.filter(fn row -> row.user.id == student.id end)
-             |> length() == 0
+      assert Oli.Grading.get_scores_for_section_and_user(section, student.id) |> length() == 3
 
       {:ok, view, _html} =
         live(conn, live_view_students_dashboard_route(section.slug, student.id, :quizz_scores))
 
-      assert has_element?(view, "h6", "There are no quiz scores to show")
+      assert has_element?(
+               view,
+               "div",
+               "#{graded_page_1.title}"
+             )
+
+      assert has_element?(
+               view,
+               "div",
+               "#{graded_page_3.title}"
+             )
+
+      assert has_element?(
+               view,
+               "div",
+               "#{graded_page_5.title}"
+             )
     end
 
     test "applies searching", %{


### PR DESCRIPTION
[MER-2339](https://eliterate.atlassian.net/browse/MER-2339)

This PR fixes a bug that happened when accessing the quiz scores tab within a student's dashboard and the student was in suspended status in that section. 

Now, when accessing the quiz scores tab for a specific student who is suspended in that section, a text is rendered indicating that there are no quiz scores to show.

[MER-2339]: https://eliterate.atlassian.net/browse/MER-2339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ