### PR TITLE
[BUGFIX] Vlab: don't split text input on restoring saved state [MER-2509]

### DIFF
--- a/assets/src/components/activities/vlab/VlabDelivery.tsx
+++ b/assets/src/components/activities/vlab/VlabDelivery.tsx
@@ -23,7 +23,7 @@ import {
   resetAction,
 } from 'data/activities/DeliveryState';
 import { getByUnsafe } from 'data/activities/model/utils';
-import { safelySelectInputs } from 'data/activities/utils';
+import { safelySelectStringInputs } from 'data/activities/utils';
 import { defaultWriterContext } from 'data/content/writers/context';
 import { configureStore } from 'state/store';
 import { DeliveryElementProvider, useDeliveryElementContext } from '../DeliveryElementProvider';
@@ -119,7 +119,7 @@ export const VlabComponent: React.FC = () => {
     dispatch(
       initializeState(
         activityState,
-        safelySelectInputs(activityState).caseOf({
+        safelySelectStringInputs(activityState).caseOf({
           just: (inputs) => inputs,
           nothing: () =>
             model.inputs.reduce((acc, input) => {


### PR DESCRIPTION
Vlab activity code has the same bug as MER-2450: when initializing inputs from saved state, it was using a utility function, safelySelectInputs, that splits the persisted string representation of the input into an array at spaces. This splitting is useful for activities representing student input as singleton or multiple selection id lists, and harmless where input is a single number, but is inappropriate for free text input that may contain multiple words, such as "Carbon Dioxide", in which case the visible effect will be to restore the first word of the saved input only. This replaces with the variant utility function safelySelectStringInputs which does not apply the split transformation.