### PR TITLE
[MER-2477] Manage student enrollment view email address

### DIFF
--- a/lib/oli_web/components/delivery/students/students.ex
+++ b/lib/oli_web/components/delivery/students/students.ex
@@ -130,6 +130,9 @@ defmodule OliWeb.Components.Delivery.Students do
           sort_order
         )
 
+      :email ->
+        Enum.sort_by(students, fn student -> student.email end, sort_order)
+
       :last_interaction ->
         Enum.sort_by(students, fn student -> student.last_interaction end, sort_order)
 
@@ -315,6 +318,7 @@ defmodule OliWeb.Components.Delivery.Students do
           "sort_by",
           [
             :name,
+            :email,
             :last_interaction,
             :progress,
             :overall_proficiency,

--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -446,6 +446,7 @@ defmodule OliWeb.DeliveryController do
           |> Enum.map(
             &%{
               name: &1.name,
+              email: &1.email,
               last_interaction: &1.last_interaction,
               progress: &1.progress,
               overall_proficiency: &1.overall_proficiency,
@@ -455,6 +456,7 @@ defmodule OliWeb.DeliveryController do
           |> DataTable.new()
           |> DataTable.headers([
             :name,
+            :email,
             :last_interaction,
             :progress,
             :overall_proficiency,

--- a/lib/oli_web/live/sections/enrollments_table_model.ex
+++ b/lib/oli_web/live/sections/enrollments_table_model.ex
@@ -25,6 +25,11 @@ defmodule OliWeb.Delivery.Sections.EnrollmentsTableModel do
             th_class: "pl-10"
           },
           %ColumnSpec{
+            name: :email,
+            label: "EMAIL",
+            render_fn: &__MODULE__.render_email_column/3
+          },
+          %ColumnSpec{
             name: :last_interaction,
             label: "LAST INTERACTED",
             render_fn: &__MODULE__.render_last_interaction_column/3
@@ -44,19 +49,19 @@ defmodule OliWeb.Delivery.Sections.EnrollmentsTableModel do
         [
           %ColumnSpec{
             name: :name,
-            label: "Name",
+            label: "NAME",
             render_fn: &__MODULE__.render_name_column/3,
             sort_fn: &__MODULE__.sort_name_column/2,
             th_class: "pl-10"
           },
           %ColumnSpec{
             name: :email,
-            label: "Email",
+            label: "EMAIL",
             render_fn: &__MODULE__.render_email_column/3
           },
           %ColumnSpec{
             name: :type,
-            label: "Type",
+            label: "TYPE",
             render_fn: &__MODULE__.render_type_column/3,
             sortable: false
           }

--- a/test/oli_web/live/delivery/instructor_dashboard/reports/students_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/reports/students_tab_test.exs
@@ -82,6 +82,34 @@ defmodule OliWeb.Delivery.InstructorDashboard.StudentsTabTest do
                OliWeb.Common.Utils.name(user.name, user.given_name, user.family_name)
     end
 
+    test "students email gets rendered correctly", %{
+      conn: conn,
+      section: section,
+      instructor: instructor
+    } do
+      student_1 =
+        insert(:user, %{given_name: "Kevin", family_name: "Durant", email: "kevin.durant@nba.com"})
+
+      student_2 =
+        insert(:user, %{given_name: "LeBron", family_name: "James", email: "lebron.james@nba.com"})
+
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+      Sections.enroll(student_1.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.enroll(student_2.id, section.id, [ContextRoles.get_role(:context_learner)])
+
+      {:ok, view, _html} = live(conn, live_view_students_route(section.slug))
+
+      [student_1_email, student_2_email] =
+        view
+        |> render()
+        |> Floki.parse_fragment!()
+        |> Floki.find(~s{.instructor_dashboard_table tbody tr td:nth-child(2)})
+        |> Enum.map(fn td -> Floki.text(td) end)
+
+      assert student_1_email == student_1.email
+      assert student_2_email == student_2.email
+    end
+
     test "students last interaction gets rendered (for a student with interaction and yet with no interaction)",
          %{instructor: instructor, conn: conn, ctx: ctx} do
       %{section: section, mod1_pages: mod1_pages} =
@@ -119,14 +147,14 @@ defmodule OliWeb.Delivery.InstructorDashboard.StudentsTabTest do
         view
         |> render()
         |> Floki.parse_fragment!()
-        |> Floki.find(~s{.instructor_dashboard_table tbody tr:nth-child(1) td:nth-child(2)})
+        |> Floki.find(~s{.instructor_dashboard_table tbody tr:nth-child(1) td:nth-child(3)})
         |> Enum.map(fn td -> Floki.text(td) end)
 
       [student_2_last_interaction] =
         view
         |> render()
         |> Floki.parse_fragment!()
-        |> Floki.find(~s{.instructor_dashboard_table tbody tr:nth-child(2) td:nth-child(2)})
+        |> Floki.find(~s{.instructor_dashboard_table tbody tr:nth-child(2) td:nth-child(3)})
         |> Enum.map(fn td -> Floki.text(td) end)
 
       assert student_1_last_interaction =~


### PR DESCRIPTION
[MER-2477](https://eliterate.atlassian.net/browse/MER-2477)

This PR adds a column to show the `email` of the students in the enrollments table that shows the list of students enrolled for a section, necessary for the instructor. 

It also adds the email field when downloading the information in .csv format.

![Captura de pantalla 2023-08-18 a la(s) 12 36 44](https://github.com/Simon-Initiative/oli-torus/assets/16328384/25b38987-e3d6-4f66-9130-cad84e1b3795)

[MER-2477]: https://eliterate.atlassian.net/browse/MER-2477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ