### PR TITLE
[BUGFIX][MER-2489] Fixs user account menu logged in as author/admin

### DIFF
--- a/lib/oli_web/components/delivery/user_account_menu.ex
+++ b/lib/oli_web/components/delivery/user_account_menu.ex
@@ -50,6 +50,20 @@ defmodule OliWeb.Components.Delivery.UserAccountMenu do
             selectedTimezone: timezone_preference(user_or_admin)
           }
 
+        %SessionContext{author: author} when not is_nil(author) ->
+          %{
+            picture: author.picture,
+            name: user_name(author),
+            role: user_role(assigns[:section], author),
+            roleLabel: user_role_text(assigns[:section], author),
+            roleColor: user_role_color(assigns[:section], author),
+            isGuest: user_is_guest?(assigns),
+            isIndependentInstructor: Sections.is_independent_instructor?(author),
+            isIndependentLearner: user_is_independent_learner?(author),
+            linkedAuthorAccount: linked_author_account(author),
+            selectedTimezone: timezone_preference(author)
+          }
+
         _ ->
           nil
       end


### PR DESCRIPTION
[MER-2489](https://eliterate.atlassian.net/browse/MER-2489)

This PR fixes the bug when logged in as an Author/Admin and accessing the instructor dashboard. The author name, role and photo were not being displayed correctly in the top bar.

![Captura de pantalla 2023-08-21 a la(s) 10 57 32](https://github.com/Simon-Initiative/oli-torus/assets/16328384/865ab247-f516-4867-be34-113dd17057d8)



[MER-2489]: https://eliterate.atlassian.net/browse/MER-2489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ