### PR TITLE
 [BUGFIX] Stop DND hint from obscuring feedback [MER-2515]

### DIFF
--- a/assets/src/components/activities/custom_dnd/CustomDnDDelivery.tsx
+++ b/assets/src/components/activities/custom_dnd/CustomDnDDelivery.tsx
@@ -194,12 +194,11 @@ export const CustomDnDComponent: React.FC = () => {
             }}
           />
         )}
-
+        <FocusedHints focusedPart={focusedPart} />
         <div className="h-7 text-left">
           {working || <FocusedFeedback focusedPart={focusedPart} />}
           {working && <WorkingMessage />}
         </div>
-        <FocusedHints focusedPart={focusedPart} />
       </div>
     </div>
   );

--- a/assets/src/components/activities/custom_dnd/CustomDnDDelivery.tsx
+++ b/assets/src/components/activities/custom_dnd/CustomDnDDelivery.tsx
@@ -195,10 +195,7 @@ export const CustomDnDComponent: React.FC = () => {
           />
         )}
         <FocusedHints focusedPart={focusedPart} />
-        <div className="h-7 text-left">
-          {working || <FocusedFeedback focusedPart={focusedPart} />}
-          {working && <WorkingMessage />}
-        </div>
+        {working ? <WorkingMessage /> : <FocusedFeedback focusedPart={focusedPart} />}
       </div>
     </div>
   );


### PR DESCRIPTION
After recent  change to add a "working..." message, DND hints can obscure feedback as shown in screenshot. This PR
moves feedback after hints, as is standard for other actvities, to avoid this problem.

Also simplifies by eliminating the div introduced around the WorkingMessage-or-Feedback area of the display. That div was apparently intended to prevent activity size from changing frequently as "Working" message comes and goes, but it did not actually reserve a fixed height large enough to accommodate either of Message or Feedback, so did not accomplish that, and generally does not seem necessary. 

<img width="743" alt="Screenshot 2023-08-25 at 11 38 55 AM" src="https://github.com/Simon-Initiative/oli-torus/assets/7094628/44a7e908-61e8-47bf-ac67-c8bae61a9cfe">
