### PR TITLE
[BUG FIX] Allow for no decimal point, only e in floats

### DIFF
--- a/lib/oli/delivery/evaluation/rule.ex
+++ b/lib/oli/delivery/evaluation/rule.ex
@@ -153,7 +153,7 @@ defmodule Oli.Delivery.Evaluation.Rule do
   defp is_range?(str), do: String.starts_with?(str, ["[", "("])
 
   defp is_float?(str),
-    do: String.contains?(str, ".") or String.contains?(str, "e")
+    do: String.contains?(str, ".") or String.contains?(str, "e-")
 
   defp parse_range(range_str) do
     case Regex.run(

--- a/lib/oli/delivery/evaluation/rule.ex
+++ b/lib/oli/delivery/evaluation/rule.ex
@@ -153,7 +153,7 @@ defmodule Oli.Delivery.Evaluation.Rule do
   defp is_range?(str), do: String.starts_with?(str, ["[", "("])
 
   defp is_float?(str),
-    do: String.contains?(str, ".") or (String.contains?(str, "e") and String.contains?(str, "."))
+    do: String.contains?(str, ".") or String.contains?(str, "e")
 
   defp parse_range(range_str) do
     case Regex.run(

--- a/test/oli/delivery/evaluation/rule_eval_test.exs
+++ b/test/oli/delivery/evaluation/rule_eval_test.exs
@@ -54,6 +54,8 @@ defmodule Oli.Delivery.Evaluation.RuleEvalTest do
 
   test "evaluating ranges" do
     # scientific notation inside the range, evaluates to true
+    assert eval("attemptNumber = {1} && input = {[4e-5,3e-3]}", "3e-4") == true
+
     assert eval("attemptNumber = {1} && input = {[3.0e+5,4.0e+5]}", "3.5e5") == true
     assert eval("attemptNumber = {1} && input = {[3.0e5,4.0e5]}", "3.5e5") == true
 


### PR DESCRIPTION
Fixes a problem where a range matches fail when the range is specified with scientific notation which omits the decimal point (e.g. `4e-8`)

The problem was in the exact location suggested by @andersweinstein 

The fix here is to check for either `.` or `e-`.  This correctly identifies `4e-9` as being a floating point number, but leaves `4e9` as an integer. The unit test shows that it works.  Without the code change, that updated unit test fails. 