### PR TITLE
Bugfix: Numeric lists didn't have correct menu [MER-2523]

### DIFF
--- a/assets/src/components/editing/elements/list/listActions.tsx
+++ b/assets/src/components/editing/elements/list/listActions.tsx
@@ -86,7 +86,7 @@ export const toggleOrderedList: CommandDescription = {
 const listStyleLabels: Record<OrderedListStyle | UnorderedListStyle, string> = {
   none: 'No Bullet',
   decimal: 'Decimal - 1',
-  'decimal-leading-zero': 'Decimal w/ Zero - 01',
+  'decimal-leading-zero': 'Zero Decimal - 01',
   'lower-roman': 'Lower Roman - i',
   'upper-roman': 'Upper Roman - I',
   'lower-alpha': 'Lower Alpha - a',

--- a/assets/src/components/editing/toolbar/editorToolbar/blocks/BlockToggle.tsx
+++ b/assets/src/components/editing/toolbar/editorToolbar/blocks/BlockToggle.tsx
@@ -10,7 +10,8 @@ import { DescriptiveButton } from 'components/editing/toolbar/buttons/Descriptiv
 import { DropdownButton } from 'components/editing/toolbar/buttons/DropdownButton';
 import { activeBlockType } from 'components/editing/toolbar/toolbarUtils';
 
-export const toggleTextTypes = [toggleParagraph, toggleHeading, toggleList, toggleBlockquote];
+// Note: The order here matters since a paragraph can be inside a list item.
+export const toggleTextTypes = [toggleList, toggleParagraph, toggleHeading, toggleBlockquote];
 
 interface BlockToggleProps {
   blockInsertOptions: CommandDescription[];


### PR DESCRIPTION
The list menu wasn't always appearing correctly.

Steps to reproduce:

1. Type some text on a single line
2. Convert it into a list.
3. Change it to a numeric ordered list

Expected: List menu is visible.
Actual: List menu is not visible.

![timer](https://github.com/Simon-Initiative/oli-torus/assets/333265/51e31a88-2d2f-44be-b955-a1b8d434ff93)

Fixes: #4123 
