### PR TITLE
Bugfix - due by end time bug [MER-2521]

### DIFF
--- a/assets/src/apps/scheduler/PageScheduleLine.tsx
+++ b/assets/src/apps/scheduler/PageScheduleLine.tsx
@@ -32,9 +32,24 @@ export const PageScheduleLine: React.FC<ScheduleLineProps> = ({ item, indent, da
 
   const onChange = useCallback(
     (startDate: DateWithoutTime | null, endDate: DateWithoutTime) => {
-      dispatch(moveScheduleItem({ itemId: item.id, startDate, endDate }));
+      let targetEndDate: Date | DateWithoutTime = endDate;
+
+      // On a drag, need to change the date, but preserve the end time if one exists.
+      if (item.endDateTime) {
+        targetEndDate = new Date();
+        targetEndDate.setDate(endDate.getDate());
+        targetEndDate.setMonth(endDate.getMonth());
+        targetEndDate.setFullYear(endDate.getFullYear());
+        targetEndDate.setHours(
+          item.endDateTime.getHours(),
+          item.endDateTime.getMinutes(),
+          item.endDateTime.getSeconds(),
+        );
+      }
+
+      dispatch(moveScheduleItem({ itemId: item.id, startDate, endDate: targetEndDate }));
     },
-    [dispatch, item.id],
+    [dispatch, item.id, item.endDateTime],
   );
 
   const rowClass = isSelected ? 'bg-green-50' : '';

--- a/assets/src/apps/scheduler/schedule-reset.ts
+++ b/assets/src/apps/scheduler/schedule-reset.ts
@@ -17,6 +17,8 @@ export const countWorkingDays = (
 };
 
 export const findNthDay = (startDay: number, n: number, weekdaysToSchedule: boolean[]) => {
+  if (n === 0) return new DateWithoutTime(startDay);
+
   const start = new DateWithoutTime(Math.floor(startDay) - 1);
   let workdays = 0;
   while (workdays < n) {
@@ -25,6 +27,7 @@ export const findNthDay = (startDay: number, n: number, weekdaysToSchedule: bool
       workdays++;
     }
   }
+
   return start;
 };
 

--- a/assets/src/components/editing/editor/paste/onHtmlPaste.ts
+++ b/assets/src/components/editing/editor/paste/onHtmlPaste.ts
@@ -437,7 +437,6 @@ export const onHTMLPaste = (event: React.ClipboardEvent<HTMLDivElement>, editor:
   const pastedHtml = event.clipboardData?.getData('text/html')?.trim();
 
   if (!pastedHtml) return;
-  //debugger;
   try {
     const parsed = new DOMParser().parseFromString(pastedHtml, 'text/html');
     const [body] = Array.from(parsed.getElementsByTagName('body'));


### PR DESCRIPTION
The end-time of a due-by schedule item was sometimes lost.

1. Go into the scheduler interface
2. Change an entry to have a due-date with a time other than 11:59
3. Save the schedule.
4. Click the icon (not the name in the left column) of the item

Expected: see the date/time set, and no pending modifications to save.
Actual: See the date & 11:59 set, and a pending modification to save.

Alternatively, for (4), you could have dragged that item in the timeline instead of just clicking it, the same bug occurred.


Now, if you set a time on a due-by item, that time will stick as you click or drag the item in the timeline view.


![schedulerbug](https://github.com/Simon-Initiative/oli-torus/assets/333265/14c9d1d6-1701-4962-a3ef-4372db53a0ee)



While fixing this, I noticed a small bug with the reset-schedule functionality when an item represented a very small portion of the overall timeline. That's been fixed as well.


