### PR TITLE
[MER-2525] Add available date to assessment settings

### DIFF
--- a/lib/oli/delivery/settings.ex
+++ b/lib/oli/delivery/settings.ex
@@ -133,11 +133,9 @@ defmodule Oli.Delivery.Settings do
   def check_start_date(%Combined{start_date: nil}), do: {:allowed}
 
   def check_start_date(%Combined{start_date: start_date}) do
-    if DateTime.compare(start_date, DateTime.utc_now()) == :gt do
-      {:before_start_date}
-    else
-      {:allowed}
-    end
+    if DateTime.compare(start_date, DateTime.utc_now()) == :gt,
+      do: {:before_start_date},
+      else: {:allowed}
   end
 
   def check_end_date(%Combined{end_date: nil}), do: {:allowed}
@@ -176,11 +174,9 @@ defmodule Oli.Delivery.Settings do
 
         # both an end date and a time limit, use the earlier of the two
         {end_date, time_limit} ->
-          if end_date < DateTime.add(resource_attempt.inserted_at, time_limit, :minute) do
-            end_date
-          else
-            DateTime.add(resource_attempt.inserted_at, time_limit, :minute)
-          end
+          if end_date < DateTime.add(resource_attempt.inserted_at, time_limit, :minute),
+            do: end_date,
+            else: DateTime.add(resource_attempt.inserted_at, time_limit, :minute)
       end
 
     case deadline do

--- a/lib/oli/delivery/settings.ex
+++ b/lib/oli/delivery/settings.ex
@@ -54,6 +54,7 @@ defmodule Oli.Delivery.Settings do
 
     %Combined{
       resource_id: resolved_revision.resource_id,
+      start_date: combine_field(:start_date, section_resource, student_exception),
       end_date: combine_field(:end_date, section_resource, student_exception),
       max_attempts: max_attempts,
       retake_mode: combine_field(:retake_mode, section_resource, student_exception),

--- a/lib/oli/delivery/settings.ex
+++ b/lib/oli/delivery/settings.ex
@@ -201,11 +201,9 @@ defmodule Oli.Delivery.Settings do
   def check_password(_effective_settings, ""), do: {:allowed}
   def check_password(_effective_settings, nil), do: {:allowed}
 
-  def check_password?(%Combined{password: password}, received_password) do
-    if password == received_password do
-      {:allowed}
-    else
-      {:invalid_password}
-    end
-  end
+  def check_password(%Combined{password: password}, received_password)
+      when password == received_password,
+      do: {:allowed}
+
+  def check_password(_, _), do: {:invalid_password}
 end

--- a/lib/oli/delivery/settings/combined.ex
+++ b/lib/oli/delivery/settings/combined.ex
@@ -1,5 +1,6 @@
 defmodule Oli.Delivery.Settings.Combined do
   defstruct resource_id: nil,
+            start_date: nil,
             end_date: nil,
             max_attempts: 0,
             retake_mode: :normal,
@@ -17,6 +18,7 @@ defmodule Oli.Delivery.Settings.Combined do
 
   @type t() :: %__MODULE__{
           resource_id: integer(),
+          start_date: DateTime.t(),
           end_date: DateTime.t(),
           max_attempts: integer(),
           retake_mode: :normal | :targeted,

--- a/lib/oli/delivery/settings/student_exception.ex
+++ b/lib/oli/delivery/settings/student_exception.ex
@@ -8,9 +8,12 @@ defmodule Oli.Delivery.Settings.StudentException do
     belongs_to :section, Oli.Delivery.Sections.Section
     belongs_to :resource, Oli.Resources.Resource
 
-    embeds_one :collab_space_config, Oli.Resources.Collaboration.CollabSpaceConfig, on_replace: :delete
+    embeds_one :collab_space_config, Oli.Resources.Collaboration.CollabSpaceConfig,
+      on_replace: :delete
+
     embeds_one :explanation_strategy, Oli.Resources.ExplanationStrategy, on_replace: :delete
 
+    field :start_date, :utc_datetime, null: true
     field :end_date, :utc_datetime, null: true
     field :password, :string, null: true
     field :max_attempts, :integer, null: true
@@ -33,6 +36,7 @@ defmodule Oli.Delivery.Settings.StudentException do
       :user_id,
       :section_id,
       :resource_id,
+      :start_date,
       :end_date,
       :password,
       :max_attempts,
@@ -44,7 +48,7 @@ defmodule Oli.Delivery.Settings.StudentException do
       :scoring_strategy_id,
       :review_submission,
       :feedback_mode,
-      :feedback_scheduled_date,
+      :feedback_scheduled_date
     ])
     |> cast_embed(:explanation_strategy)
     |> cast_embed(:collab_space_config)

--- a/lib/oli/utils.ex
+++ b/lib/oli/utils.ex
@@ -370,4 +370,9 @@ defmodule Oli.Utils do
       dynamic([entity], field(entity, ^field) == ^value or ^conditions)
     end)
   end
+
+  @doc """
+  Converts an atom into a readable string by replacing underscores with empty spaces.
+  """
+  def stringify_atom(atom), do: atom |> Atom.to_string() |> String.replace("_", " ")
 end

--- a/lib/oli_web/common/format_date_time.ex
+++ b/lib/oli_web/common/format_date_time.ex
@@ -198,6 +198,9 @@ defmodule OliWeb.Common.FormatDateTime do
 
       :relative ->
         Timex.format!(datetime, "{relative}", :relative)
+
+      :simple_iso8601 ->
+        Timex.format!(datetime, "{ISOdate}T{h24}:{m}")
     end
   end
 

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -9,7 +9,7 @@ defmodule OliWeb.PageDeliveryController do
   alias Oli.Activities
   alias Oli.Delivery.Attempts.{Core, PageLifecycle}
   alias Oli.Delivery.Page.{PageContext, ObjectivesRollup}
-  alias Oli.Delivery.{Paywall, PreviousNextIndex, Sections}
+  alias Oli.Delivery.{Paywall, PreviousNextIndex, Sections, Settings}
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.Section
   alias Oli.Delivery.Paywall.Discount
@@ -57,8 +57,7 @@ defmodule OliWeb.PageDeliveryController do
           else
             revision = DeliveryResolver.root_container(section_slug)
 
-            effective_settings =
-              Oli.Delivery.Settings.get_combined_settings(revision, section.id, user.id)
+            effective_settings = Settings.get_combined_settings(revision, section.id, user.id)
 
             next_activities =
               Sections.get_next_activities_for_student(section_slug, user.id, context)
@@ -359,7 +358,7 @@ defmodule OliWeb.PageDeliveryController do
     blocking_gates = Map.get(conn.assigns, :blocking_gates, [])
 
     new_attempt_allowed =
-      Oli.Delivery.Settings.new_attempt_allowed(
+      Settings.new_attempt_allowed(
         effective_settings,
         attempts_taken,
         blocking_gates
@@ -374,6 +373,9 @@ defmodule OliWeb.PageDeliveryController do
 
         {:no_attempts_remaining} ->
           "You have no attempts remaining out of #{effective_settings.max_attempts} total attempt#{plural(effective_settings.max_attempts)}."
+
+        {:before_start_date} ->
+          before_start_date_message(conn, effective_settings)
 
         {:end_date_passed} ->
           "The deadline for this assignment has passed."
@@ -604,7 +606,7 @@ defmodule OliWeb.PageDeliveryController do
         latest_attempts: context.latest_attempts,
         section: section,
         children: context.page.children,
-        show_feedback: Oli.Delivery.Settings.show_feedback?(effective_settings),
+        show_feedback: Settings.show_feedback?(effective_settings),
         page_link_url: &Routes.page_delivery_path(conn, :page, section_slug, &1),
         container_link_url: &Routes.page_delivery_path(conn, :container, section_slug, &1),
         revision: context.page,
@@ -619,7 +621,7 @@ defmodule OliWeb.PageDeliveryController do
         time_limit: effective_settings.time_limit,
         attempt_start_time: resource_attempt.inserted_at |> to_epoch,
         effective_end_time:
-          Oli.Delivery.Settings.determine_effective_deadline(resource_attempt, effective_settings)
+          Settings.determine_effective_deadline(resource_attempt, effective_settings)
           |> to_epoch,
         end_date: effective_settings.end_date,
         auto_submit: effective_settings.late_submit == :disallow,
@@ -673,7 +675,10 @@ defmodule OliWeb.PageDeliveryController do
         resourceAttemptGuid: resource_attempt.attempt_guid,
         currentServerTime: DateTime.utc_now() |> to_epoch,
         effectiveEndTime:
-          Oli.Delivery.Settings.determine_effective_deadline(resource_attempt, context.effective_settings)
+          Settings.determine_effective_deadline(
+            resource_attempt,
+            context.effective_settings
+          )
           |> to_epoch,
         lateSubmit: context.effective_settings.late_submit,
         activityGuidMapping: context.activities,
@@ -745,7 +750,7 @@ defmodule OliWeb.PageDeliveryController do
     revision = DeliveryResolver.root_container(section_slug)
 
     effective_settings =
-      Oli.Delivery.Settings.get_combined_settings(
+      Settings.get_combined_settings(
         revision,
         section.id,
         current_user.id
@@ -846,7 +851,7 @@ defmodule OliWeb.PageDeliveryController do
               ~s|<div class="text-center"><em>Instructor preview of adaptive activities is not supported</em></div>|
 
             effective_settings =
-              Oli.Delivery.Settings.get_combined_settings(
+              Settings.get_combined_settings(
                 revision,
                 section.id
               )
@@ -1004,8 +1009,8 @@ defmodule OliWeb.PageDeliveryController do
 
     effective_settings =
       case conn.assigns.current_user do
-        nil -> Oli.Delivery.Settings.get_combined_settings(revision, section.id)
-        user -> Oli.Delivery.Settings.get_combined_settings(revision, section.id, user.id)
+        nil -> Settings.get_combined_settings(revision, section.id)
+        user -> Settings.get_combined_settings(revision, section.id, user.id)
       end
 
     section_resource = Sections.get_section_resource(section.id, revision.resource_id)
@@ -1066,26 +1071,32 @@ defmodule OliWeb.PageDeliveryController do
     if Sections.is_enrolled?(user.id, section_slug) do
       revision = Resolver.from_revision_slug(section_slug, revision_slug)
 
-      effective_settings =
-        Oli.Delivery.Settings.get_combined_settings(revision, section.id, user.id)
+      effective_settings = Settings.get_combined_settings(revision, section.id, user.id)
 
-      case effective_settings.password do
-        nil ->
+      case check_settings_before_attempt(conn, effective_settings, password) do
+        :ok ->
           do_start_attempt(conn, section, user, revision, effective_settings)
 
-        "" ->
-          do_start_attempt(conn, section, user, revision, effective_settings)
-
-        ^password ->
-          do_start_attempt(conn, section, user, revision, effective_settings)
-
-        _ ->
+        {:error, error_message} ->
           conn
-          |> put_flash(:error, "Incorrect password")
+          |> put_flash(:error, error_message)
           |> redirect(to: Routes.page_delivery_path(conn, :page, section.slug, revision.slug))
       end
     else
       render(conn, "not_authorized.html")
+    end
+  end
+
+  defp check_settings_before_attempt(conn, effective_settings, received_password) do
+    with {:allowed} <- Settings.check_password(effective_settings, received_password),
+         {:allowed} <- Settings.check_start_date(effective_settings) do
+      :ok
+    else
+      {:invalid_password} ->
+        {:error, "Incorrect password"}
+
+      {:before_start_date} ->
+        {:error, before_start_date_message(conn, effective_settings)}
     end
   end
 
@@ -1373,4 +1384,8 @@ defmodule OliWeb.PageDeliveryController do
 
   defp url_from_desc(conn, section_slug, %{"type" => "page", "slug" => slug}),
     do: Routes.page_delivery_path(conn, :page_preview, section_slug, slug)
+
+  defp before_start_date_message(conn, effective_settings) do
+    "This assessment is not yet available. It will be available on #{date(effective_settings.start_date, conn: conn, precision: :minutes)}."
+  end
 end

--- a/lib/oli_web/live/common/utils.ex
+++ b/lib/oli_web/live/common/utils.ex
@@ -92,16 +92,16 @@ defmodule OliWeb.Common.Utils do
     If the date was not nil, we don't need to set a limit since we can calculate the time distance accordingly.
 
     ## Examples
-    iex> datetime_input_limit(:start_date, %{start_date: nil, end_date: ~U[2023-09-06 13:28:34]}, %SessionContext{browser_timezone: "America/Montevideo"})
+    iex> datetime_input_limit(:start_date, %{start_date: nil, end_date: ~U[2023-09-06 13:28:00Z]}, %{SessionContext.init() | local_tz: "America/Montevideo"})
     "2023-09-05T10:28"
 
-    iex> datetime_input_limit(:start_date, %{start_date: ~U[2023-09-01 13:28:34], end_date: ~U[2023-09-06 13:28:34]}, %SessionContext{browser_timezone: "America/Montevideo"})
+    iex> datetime_input_limit(:start_date, %{start_date: ~U[2023-09-01 13:28:00Z], end_date: ~U[2023-09-06 13:28:00Z]}, %{SessionContext.init() | local_tz: "America/Montevideo"})
     ""
 
-    iex> datetime_input_limit(:end_date, %{start_date: ~U[2023-09-02 13:28:34], end_date: nil}, %SessionContext{browser_timezone: "America/Montevideo"})
+    iex> datetime_input_limit(:end_date, %{start_date: ~U[2023-09-02 13:28:00Z], end_date: nil}, %{SessionContext.init() | local_tz: "America/Montevideo"})
     "2023-09-03T10:28"
 
-    iex> datetime_input_limit(:end_date, %{start_date: ~U[2023-09-02 13:28:34], end_date: ~U[2023-09-03 13:28:34]}, %SessionContext{browser_timezone: "America/Montevideo"})
+    iex> datetime_input_limit(:end_date, %{start_date: ~U[2023-09-02 13:28:00Z], end_date: ~U[2023-09-03 13:28:00Z]}, %{SessionContext.init() | local_tz: "America/Montevideo"})
     ""
   """
 
@@ -129,11 +129,11 @@ defmodule OliWeb.Common.Utils do
   If the new start date (end date) or the existing end date (start date) are nil, we don't need to preserve the distance.
   If the new start date (end date) is before (after) the existing end date (start date), we don't need to preserve the distance.
 
-  iex> maybe_preserve_dates_distance(:start_date, ~U[2023-09-04 13:28:34], %{start_date: ~U[2023-09-01 13:28:34], end_date: ~U[2023-09-02 13:28:34]})
-    {~U[2023-09-04 13:28:34], ~U[2023-09-05 13:28:34], true}
+  iex> maybe_preserve_dates_distance(:start_date, ~U[2023-09-04 13:28:00Z], %{start_date: ~U[2023-09-01 13:28:00Z], end_date: ~U[2023-09-02 13:28:00Z]})
+  {~U[2023-09-04 13:28:00Z], ~U[2023-09-05 13:28:00Z], :end_date}
 
-  iex> maybe_preserve_dates_distance(:end_date, nil, %{start_date: ~U[2023-09-01 13:28:34], end_date: ~U[2023-09-02 13:28:34]})
-      {~U[2023-09-01 13:28:34], ~U[2023-09-02 13:28:34], false}
+  iex> maybe_preserve_dates_distance(:end_date, nil, %{start_date: ~U[2023-09-01 13:28:00Z], end_date: ~U[2023-09-02 13:28:00Z]})
+  {~U[2023-09-01 13:28:00Z], nil, nil}
   """
   def maybe_preserve_dates_distance(:start_date, new_start_date, %{end_date: end_date}) when is_nil(new_start_date) or is_nil(end_date) do
     {new_start_date, end_date, nil}

--- a/lib/oli_web/live/sections/assessment_settings/settings_table.ex
+++ b/lib/oli_web/live/sections/assessment_settings/settings_table.ex
@@ -25,8 +25,6 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTable do
     text_search: nil
   }
 
-  @date_fields ["start_date", "end_date"]
-
   def mount(socket) do
     {:ok, assign(socket, modal_assigns: %{show: false})}
   end
@@ -703,10 +701,10 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTable do
     })
   end
 
-  defp maybe_add_scheduling_type("end_date", section_resource),
+  defp maybe_add_scheduling_type(:end_date, section_resource),
     do: [{:scheduling_type, section_resource.scheduling_type}]
 
-  defp maybe_add_scheduling_type("start_date", _section_resource), do: []
+  defp maybe_add_scheduling_type(:start_date, _section_resource), do: []
 
   defp do_update(key, assessment_setting_id, new_value, socket) do
     Sections.get_section_resource(
@@ -783,7 +781,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTable do
                value != "" ->
           abs(String.to_integer(value))
 
-        {key, value} when key in @date_fields ->
+        {key, value} when key in ["start_date", "end_date"] ->
           FormatDateTime.datestring_to_utc_datetime(value, ctx)
 
         {_, value} ->

--- a/lib/oli_web/live/sections/assessment_settings/settings_table_model.ex
+++ b/lib/oli_web/live/sections/assessment_settings/settings_table_model.ex
@@ -165,7 +165,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTableModel do
       phx-value-assessment_id={@id}
     >
       <%= if is_nil(@available_date) do %>
-        No available date
+        Always available
       <% else %>
         <%= value_from_datetime(@available_date, @ctx) %>
       <% end %>

--- a/lib/oli_web/live/sections/assessment_settings/settings_table_model.ex
+++ b/lib/oli_web/live/sections/assessment_settings/settings_table_model.ex
@@ -3,6 +3,8 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTableModel do
   alias OliWeb.Router.Helpers, as: Routes
   alias OliWeb.Common.FormatDateTime
   alias OliWeb.Sections.AssessmentSettings.Tooltips
+  alias Phoenix.LiveView.JS
+
   use Phoenix.Component
 
   def new(
@@ -29,6 +31,13 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTableModel do
         th_class: "!sticky left-20 bg-white z-10",
         td_class: "sticky left-20 bg-white dark:bg-neutral-800 z-10 whitespace-nowrap",
         tooltip: Tooltips.for(:name)
+      },
+      %ColumnSpec{
+        name: :available_date,
+        label: "AVAILABLE DATE",
+        render_fn: &__MODULE__.render_available_date_column/3,
+        th_class: "whitespace-nowrap",
+        tooltip: Tooltips.for(:available_date)
       },
       %ColumnSpec{
         name: :due_date,
@@ -141,6 +150,29 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTableModel do
     """
   end
 
+  def render_available_date_column(assigns, assessment, _) do
+    assigns =
+      Map.merge(assigns, %{
+        available_date: assessment.start_date,
+        id: assessment.resource_id
+      })
+
+    ~H"""
+    <button
+      class="hover:underline whitespace-nowrap"
+      type="button"
+      phx-click={edit_date_and_show_modal(@on_edit_date, "available_date")}
+      phx-value-assessment_id={@id}
+    >
+      <%= if is_nil(@available_date) do %>
+        No available date
+      <% else %>
+        <%= value_from_datetime(@available_date, @ctx) %>
+      <% end %>
+    </button>
+    """
+  end
+
   def render_due_date_column(assigns, assessment, _) do
     assigns =
       Map.merge(assigns, %{
@@ -153,7 +185,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTableModel do
     <button
       class="hover:underline whitespace-nowrap"
       type="button"
-      phx-click={@on_edit_date}
+      phx-click={edit_date_and_show_modal(@on_edit_date, "due_date")}
       phx-value-assessment_id={@id}
     >
       <%= if @due_date != nil and @scheduling_type == :due_by do %>
@@ -379,4 +411,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTableModel do
     datetime
     |> FormatDateTime.date(ctx: ctx, show_timezone: false)
   end
+
+  defp edit_date_and_show_modal(on_edit_date, date_input_type),
+    do: JS.push(on_edit_date, "open", target: "#assessment_#{date_input_type}_modal")
 end

--- a/lib/oli_web/live/sections/assessment_settings/student_exceptions_table.ex
+++ b/lib/oli_web/live/sections/assessment_settings/student_exceptions_table.ex
@@ -43,8 +43,7 @@ defmodule OliWeb.Sections.AssessmentSettings.StudentExceptionsTable do
         socket.assigns.myself,
         socket.assigns.selected_student_exceptions,
         assigns.ctx,
-        JS.push("edit_date", target: socket.assigns.myself)
-        |> JS.push("open", target: "#student_due_date_modal"),
+        JS.push("edit_date", target: socket.assigns.myself),
         JS.push("edit_password", target: socket.assigns.myself),
         JS.push("no_edit_password", target: socket.assigns.myself)
       )
@@ -98,11 +97,17 @@ defmodule OliWeb.Sections.AssessmentSettings.StudentExceptionsTable do
     ~H"""
     <div id="student_exceptions_table" class="mx-10 mb-10 bg-white dark:bg-gray-800 shadow-sm">
       <%= due_date_modal(assigns) %>
+      <%= available_date_modal(assigns) %>
       <%= modal(@modal_assigns) %>
       <div class="flex flex-col sm:flex-row sm:items-center pr-6 mb-4">
         <div class="flex flex-col pl-9 mr-auto">
           <h4 class="torus-h4">Student Exceptions</h4>
-          <.form for={@assessment_changeset} id="assessment_select" phx-change="change_assessment" phx-target={@myself}>
+          <.form
+            for={@assessment_changeset}
+            id="assessment_select"
+            phx-change="change_assessment"
+            phx-target={@myself}
+          >
             <div class="form-group">
               <.input
                 type="select"
@@ -161,6 +166,48 @@ defmodule OliWeb.Sections.AssessmentSettings.StudentExceptionsTable do
         />
       </form>
     </div>
+    """
+  end
+
+  def available_date_modal(assigns) do
+    ~H"""
+    <.live_component
+      id="student_available_date_modal"
+      title={if @selected_setting, do: "Available date for #{@selected_setting.user.name}"}
+      module={OliWeb.Components.LiveModal}
+      on_confirm={
+        JS.dispatch("submit", to: "#student-available-date-form")
+        |> JS.push("close", target: "#student_available_date_modal")
+      }
+      on_confirm_label="Save"
+    >
+      <div class="p-4">
+        <form
+          id="student-available-date-form"
+          for="settings_table"
+          phx-target={@myself}
+          phx-submit="edit_date"
+        >
+          <label for="start_date_input">Please pick an available date for the selected student</label>
+          <div class="flex gap-2 items-center mt-2">
+            <input
+              id="start_date_input"
+              name="start_date"
+              type="datetime-local"
+              phx-debounce={500}
+              value={value_from_datetime(@selected_setting.start_date, @ctx)}
+            />
+            <button
+              class="torus-button primary"
+              type="button"
+              phx-click={JS.set_attribute({"value", ""}, to: "#start_date_input")}
+            >
+              Clear
+            </button>
+          </div>
+        </form>
+      </div>
+    </.live_component>
     """
   end
 
@@ -396,8 +443,7 @@ defmodule OliWeb.Sections.AssessmentSettings.StudentExceptionsTable do
         socket.assigns.myself,
         socket.assigns.selected_student_exceptions,
         socket.assigns.ctx,
-        JS.push("edit_date", target: socket.assigns.myself)
-        |> JS.push("open", target: "#student_due_date_modal"),
+        JS.push("edit_date", target: socket.assigns.myself),
         JS.push("edit_password", target: socket.assigns.myself),
         JS.push("no_edit_password", target: socket.assigns.myself),
         edit_password_id
@@ -418,45 +464,11 @@ defmodule OliWeb.Sections.AssessmentSettings.StudentExceptionsTable do
     {:noreply, assign(socket, selected_setting: selected_setting)}
   end
 
-  def handle_event("edit_date", %{"end_date" => end_date}, socket) do
-    selected_setting = socket.assigns.selected_setting
+  def handle_event("edit_date", %{"start_date" => start_date}, socket),
+    do: on_edit_date(:start_date, start_date, socket)
 
-    end_date =
-      if String.length(end_date) > 0 do
-        FormatDateTime.datestring_to_utc_datetime(
-          end_date,
-          socket.assigns.ctx
-        )
-      else
-        nil
-      end
-
-    scheduling_type = if !is_nil(end_date), do: :due_by, else: :read_by
-
-    Delivery.get_delivery_setting_by(%{
-      resource_id: selected_setting.resource_id,
-      user_id: selected_setting.user_id
-    })
-    |> StudentException.changeset(%{end_date: end_date, scheduling_type: scheduling_type})
-    |> Repo.update()
-    |> case do
-      {:error, _changeset} ->
-        {:noreply,
-         socket
-         |> flash_to_liveview(:error, "ERROR: Student Exception could not be updated")}
-
-      {:ok, updated_student_exception} ->
-        update_liveview_student_exceptions(
-          :updated,
-          [Repo.preload(updated_student_exception, :user)],
-          false
-        )
-
-        {:noreply,
-         socket
-         |> flash_to_liveview(:info, "Student Exception updated!")}
-    end
-  end
+  def handle_event("edit_date", %{"end_date" => end_date}, socket),
+    do: on_edit_date(:end_date, end_date, socket)
 
   def handle_event("show_modal", %{"modal_name" => name}, socket) do
     common_modal_assings = %{show: name, myself: socket.assigns.myself}
@@ -717,6 +729,57 @@ defmodule OliWeb.Sections.AssessmentSettings.StudentExceptionsTable do
      )}
   end
 
+  defp on_edit_date(date_field, new_date, socket) do
+    selected_setting = socket.assigns.selected_setting
+
+    new_date =
+      if String.length(new_date) > 0 do
+        FormatDateTime.datestring_to_utc_datetime(
+          new_date,
+          socket.assigns.ctx
+        )
+      else
+        nil
+      end
+
+    Delivery.get_delivery_setting_by(%{
+      resource_id: selected_setting.resource_id,
+      user_id: selected_setting.user_id
+    })
+    |> change_student_exception(date_field, new_date)
+    |> Repo.update()
+    |> case do
+      {:error, _changeset} ->
+        {:noreply,
+         socket
+         |> flash_to_liveview(:error, "ERROR: Student Exception could not be updated")}
+
+      {:ok, updated_student_exception} ->
+        update_liveview_student_exceptions(
+          :updated,
+          [Repo.preload(updated_student_exception, :user)],
+          false
+        )
+
+        {:noreply,
+         socket
+         |> flash_to_liveview(:info, "Student Exception updated!")}
+    end
+  end
+
+  defp change_student_exception(student_exception, :start_date, start_date) do
+    StudentException.changeset(student_exception, %{
+      start_date: start_date
+    })
+  end
+
+  defp change_student_exception(student_exception, :end_date, end_date) do
+    StudentException.changeset(student_exception, %{
+      end_date: end_date,
+      scheduling_type: unless(is_nil(end_date), do: :due_by, else: :read_by)
+    })
+  end
+
   def decode_params(params) do
     %{
       offset: Params.get_int_param(params, "offset", @default_params.offset),
@@ -882,7 +945,7 @@ defmodule OliWeb.Sections.AssessmentSettings.StudentExceptionsTable do
         when key in ["scoring_strategy_id", "time_limit", "max_attempts"] and value != "" ->
           abs(String.to_integer(value))
 
-        {"end_date", value} ->
+        {key, value} when key in ["start_date", "end_date"] ->
           FormatDateTime.datestring_to_utc_datetime(value, ctx)
 
         {_, value} ->

--- a/lib/oli_web/live/sections/assessment_settings/student_exceptions_table_model.ex
+++ b/lib/oli_web/live/sections/assessment_settings/student_exceptions_table_model.ex
@@ -2,6 +2,8 @@ defmodule OliWeb.Sections.AssessmentSettings.StudentExceptionsTableModel do
   alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
   alias OliWeb.Common.FormatDateTime
   alias OliWeb.Sections.AssessmentSettings.Tooltips
+  alias Phoenix.LiveView.JS
+
   use Phoenix.Component
 
   def new(
@@ -23,6 +25,13 @@ defmodule OliWeb.Sections.AssessmentSettings.StudentExceptionsTableModel do
         render_fn: &__MODULE__.render_student_column/3,
         th_class: "pl-10 !sticky left-0 bg-white dark:bg-neutral-800 z-10",
         td_class: "sticky left-0 bg-white dark:bg-neutral-800 z-10 whitespace-nowrap"
+      },
+      %ColumnSpec{
+        name: :available_date,
+        label: "AVAILABLE DATE",
+        render_fn: &__MODULE__.render_available_date_column/3,
+        th_class: "whitespace-nowrap",
+        tooltip: Tooltips.for(:available_date)
       },
       %ColumnSpec{
         name: :due_date,
@@ -140,6 +149,29 @@ defmodule OliWeb.Sections.AssessmentSettings.StudentExceptionsTableModel do
     """
   end
 
+  def render_available_date_column(assigns, student_exception, _) do
+    assigns =
+      Map.merge(assigns, %{
+        available_date: student_exception.start_date,
+        id: student_exception.user_id
+      })
+
+    ~H"""
+    <button
+      class="hover:underline whitespace-nowrap"
+      type="button"
+      phx-click={edit_date_and_show_modal(@on_edit_date, "available_date")}
+      phx-value-user_id={@id}
+    >
+      <%= if is_nil(@available_date) do %>
+        No available date
+      <% else %>
+        <%= value_from_datetime(@available_date, @ctx) %>
+      <% end %>
+    </button>
+    """
+  end
+
   def render_due_date_column(assigns, student_exception, _) do
     assigns =
       Map.merge(assigns, %{
@@ -151,7 +183,7 @@ defmodule OliWeb.Sections.AssessmentSettings.StudentExceptionsTableModel do
     <button
       class="hover:underline whitespace-nowrap"
       type="button"
-      phx-click={@on_edit_date}
+      phx-click={edit_date_and_show_modal(@on_edit_date, "due_date")}
       phx-value-user_id={@id}
     >
       <%= if @due_date do %>
@@ -404,4 +436,7 @@ defmodule OliWeb.Sections.AssessmentSettings.StudentExceptionsTableModel do
     datetime
     |> FormatDateTime.date(ctx: ctx, show_timezone: false)
   end
+
+  defp edit_date_and_show_modal(on_edit_date, date_input_type),
+    do: JS.push(on_edit_date, "open", target: "#student_#{date_input_type}_modal")
 end

--- a/lib/oli_web/live/sections/assessment_settings/student_exceptions_table_model.ex
+++ b/lib/oli_web/live/sections/assessment_settings/student_exceptions_table_model.ex
@@ -164,7 +164,7 @@ defmodule OliWeb.Sections.AssessmentSettings.StudentExceptionsTableModel do
       phx-value-user_id={@id}
     >
       <%= if is_nil(@available_date) do %>
-        No available date
+        Always available
       <% else %>
         <%= value_from_datetime(@available_date, @ctx) %>
       <% end %>

--- a/lib/oli_web/live/sections/assessment_settings/tooltips.ex
+++ b/lib/oli_web/live/sections/assessment_settings/tooltips.ex
@@ -1,18 +1,36 @@
 defmodule OliWeb.Sections.AssessmentSettings.Tooltips do
-
   def for(:index), do: "Position that this assessment appears within the course materials"
   def for(:name), do: "The name of the assessment, as it appears to the student"
+  def for(:available_date), do: "The available date and time for the assessment"
   def for(:due_date), do: "The due date and time for the assessment"
   def for(:max_attempts), do: "The maximum number of times a student can attempt the assessment"
   def for(:time_limit), do: "A time limit, in minutes, that the student has for each attempt"
-  def for(:late_submit), do: "Whether or not to allow submissions past the due date or time limit. If set to disallow the system will automatically submit an attempt at the deadline"
-  def for(:late_start), do: "Whether or not to allow a student to start a new attempt after the due date"
-  def for(:scoring_strategy_id), do: "How the system will score multiple attempts for an assessment"
-  def for(:grace_period), do: "The number of minutes after the deadline that the student can submit without penalty"
-  def for(:retake_mode), do: "Targeted retakes allows the student to retake only the questions they missed on a previous attempt"
-  def for(:feedback_mode), do: "Whether or not to allow the student to see question feedback and scores after an attempt"
-  def for(:review_submission), do: "Whether or not a student can review their submission after submitting an attempt"
-  def for(:password), do: "A password that the student must enter to access the assessment"
-  def for(:exceptions_count), do: "The number of student specific exceptions defined for this assessment"
 
+  def for(:late_submit),
+    do:
+      "Whether or not to allow submissions past the due date or time limit. If set to disallow the system will automatically submit an attempt at the deadline"
+
+  def for(:late_start),
+    do: "Whether or not to allow a student to start a new attempt after the due date"
+
+  def for(:scoring_strategy_id),
+    do: "How the system will score multiple attempts for an assessment"
+
+  def for(:grace_period),
+    do: "The number of minutes after the deadline that the student can submit without penalty"
+
+  def for(:retake_mode),
+    do:
+      "Targeted retakes allows the student to retake only the questions they missed on a previous attempt"
+
+  def for(:feedback_mode),
+    do: "Whether or not to allow the student to see question feedback and scores after an attempt"
+
+  def for(:review_submission),
+    do: "Whether or not a student can review their submission after submitting an attempt"
+
+  def for(:password), do: "A password that the student must enter to access the assessment"
+
+  def for(:exceptions_count),
+    do: "The number of student specific exceptions defined for this assessment"
 end

--- a/priv/repo/migrations/20230904155403_add_start_date_to_delivery_settings.exs
+++ b/priv/repo/migrations/20230904155403_add_start_date_to_delivery_settings.exs
@@ -1,0 +1,9 @@
+defmodule Oli.Repo.Migrations.AddStartDateToDeliverySettings do
+  use Ecto.Migration
+
+  def change do
+    alter table(:delivery_settings) do
+      add :start_date, :utc_datetime, null: true
+    end
+  end
+end

--- a/test/oli/delivery/settings_test.exs
+++ b/test/oli/delivery/settings_test.exs
@@ -9,31 +9,59 @@ defmodule Oli.Delivery.SettingsTest do
   alias Oli.Delivery.Settings.StudentException
 
   test "new_attempt_allowed/3 determines if a new attempt is allowed" do
-    assert {:no_attempts_remaining} == Settings.new_attempt_allowed(%Combined{max_attempts: 5}, 5, [])
+    assert {:no_attempts_remaining} ==
+             Settings.new_attempt_allowed(%Combined{max_attempts: 5}, 5, [])
+
     assert {:blocking_gates} == Settings.new_attempt_allowed(%Combined{max_attempts: 5}, 1, [1])
-    assert {:end_date_passed} == Settings.new_attempt_allowed(%Combined{max_attempts: 5, late_start: :disallow, end_date: ~U[2020-01-01 00:00:00Z]}, 1, [])
-    assert {:allowed} == Settings.new_attempt_allowed(%Combined{max_attempts: 5, late_start: :allow, end_date: ~U[2020-01-01 00:00:00Z]}, 1, [])
+
+    assert {:end_date_passed} ==
+             Settings.new_attempt_allowed(
+               %Combined{
+                 max_attempts: 5,
+                 late_start: :disallow,
+                 end_date: ~U[2020-01-01 00:00:00Z]
+               },
+               1,
+               []
+             )
+
+    assert {:before_start_date} ==
+             Settings.new_attempt_allowed(
+               %Combined{
+                 max_attempts: 5,
+                 late_start: :disallow,
+                 start_date: DateTime.utc_now() |> DateTime.add(1, :day)
+               },
+               1,
+               []
+             )
+
+    assert {:allowed} ==
+             Settings.new_attempt_allowed(
+               %Combined{max_attempts: 5, late_start: :allow, end_date: ~U[2020-01-01 00:00:00Z]},
+               1,
+               []
+             )
   end
 
   test "was_late/2 never returns true when late submissions disallowed" do
-
     ra = %ResourceAttempt{
-      inserted_at: ~U[2020-01-01 00:00:00Z],
+      inserted_at: ~U[2020-01-01 00:00:00Z]
     }
+
     settings = %Combined{
       late_submit: :disallow,
       time_limit: 1
     }
 
     refute Settings.was_late?(ra, settings, DateTime.add(ra.inserted_at, 20, :minute))
-
   end
 
   test "was_late/2 determines lateness correctly when only a time limit" do
-
     ra = %ResourceAttempt{
-      inserted_at: ~U[2020-01-01 00:00:00Z],
+      inserted_at: ~U[2020-01-01 00:00:00Z]
     }
+
     settings_with_grace_period = %Combined{
       end_date: nil,
       time_limit: 30,
@@ -46,33 +74,58 @@ defmodule Oli.Delivery.SettingsTest do
       grace_period: 0
     }
 
-    refute Settings.was_late?(ra, settings_with_grace_period, DateTime.add(ra.inserted_at, 20, :minute))
-    refute Settings.was_late?(ra, settings_with_grace_period, DateTime.add(ra.inserted_at, 31, :minute))
-    assert Settings.was_late?(ra, settings_with_grace_period, DateTime.add(ra.inserted_at, 36, :minute))
+    refute Settings.was_late?(
+             ra,
+             settings_with_grace_period,
+             DateTime.add(ra.inserted_at, 20, :minute)
+           )
 
-    refute Settings.was_late?(ra, settings_with_no_grace_period, DateTime.add(ra.inserted_at, 20, :minute))
-    assert Settings.was_late?(ra, settings_with_no_grace_period, DateTime.add(ra.inserted_at, 31, :minute))
+    refute Settings.was_late?(
+             ra,
+             settings_with_grace_period,
+             DateTime.add(ra.inserted_at, 31, :minute)
+           )
 
+    assert Settings.was_late?(
+             ra,
+             settings_with_grace_period,
+             DateTime.add(ra.inserted_at, 36, :minute)
+           )
+
+    refute Settings.was_late?(
+             ra,
+             settings_with_no_grace_period,
+             DateTime.add(ra.inserted_at, 20, :minute)
+           )
+
+    assert Settings.was_late?(
+             ra,
+             settings_with_no_grace_period,
+             DateTime.add(ra.inserted_at, 31, :minute)
+           )
   end
 
   test "was_late/2 determines lateness correctly when no effective due date" do
-
     ra = %ResourceAttempt{
-      inserted_at: ~U[2020-01-01 01:00:00Z],
+      inserted_at: ~U[2020-01-01 01:00:00Z]
     }
+
     settings_with_no_end_date = %Combined{
       end_date: nil
     }
 
-    refute Settings.was_late?(ra, settings_with_no_end_date, DateTime.add(ra.inserted_at, 1, :minute))
-
+    refute Settings.was_late?(
+             ra,
+             settings_with_no_end_date,
+             DateTime.add(ra.inserted_at, 1, :minute)
+           )
   end
 
   test "was_late/2 determines lateness correctly when only a due date" do
-
     ra = %ResourceAttempt{
-      inserted_at: ~U[2020-01-01 01:00:00Z],
+      inserted_at: ~U[2020-01-01 01:00:00Z]
     }
+
     settings_with_grace_period = %Combined{
       end_date: ~U[2020-01-01 02:00:00Z],
       grace_period: 5
@@ -83,20 +136,42 @@ defmodule Oli.Delivery.SettingsTest do
       grace_period: 0
     }
 
-    refute Settings.was_late?(ra, settings_with_grace_period, DateTime.add(ra.inserted_at, 59, :minute))
-    refute Settings.was_late?(ra, settings_with_grace_period, DateTime.add(ra.inserted_at, 64, :minute))
-    assert Settings.was_late?(ra, settings_with_grace_period, DateTime.add(ra.inserted_at, 66, :minute))
+    refute Settings.was_late?(
+             ra,
+             settings_with_grace_period,
+             DateTime.add(ra.inserted_at, 59, :minute)
+           )
 
-    refute Settings.was_late?(ra, settings_with_no_grace_period, DateTime.add(ra.inserted_at, 59, :minute))
-    assert Settings.was_late?(ra, settings_with_no_grace_period, DateTime.add(ra.inserted_at, 61, :minute))
+    refute Settings.was_late?(
+             ra,
+             settings_with_grace_period,
+             DateTime.add(ra.inserted_at, 64, :minute)
+           )
 
+    assert Settings.was_late?(
+             ra,
+             settings_with_grace_period,
+             DateTime.add(ra.inserted_at, 66, :minute)
+           )
+
+    refute Settings.was_late?(
+             ra,
+             settings_with_no_grace_period,
+             DateTime.add(ra.inserted_at, 59, :minute)
+           )
+
+    assert Settings.was_late?(
+             ra,
+             settings_with_no_grace_period,
+             DateTime.add(ra.inserted_at, 61, :minute)
+           )
   end
 
   test "was_late/2 determines lateness correctly with both due date and time limit" do
-
     ra1 = %ResourceAttempt{
-      inserted_at: ~U[2020-01-01 01:00:00Z],
+      inserted_at: ~U[2020-01-01 01:00:00Z]
     }
+
     settings = %Combined{
       end_date: ~U[2020-01-01 02:00:00Z],
       time_limit: 30
@@ -106,34 +181,34 @@ defmodule Oli.Delivery.SettingsTest do
     assert Settings.was_late?(ra1, settings, DateTime.add(ra1.inserted_at, 31, :minute))
 
     ra2 = %ResourceAttempt{
-      inserted_at: ~U[2020-01-01 01:45:00Z],
+      inserted_at: ~U[2020-01-01 01:45:00Z]
     }
+
     refute Settings.was_late?(ra2, settings, DateTime.add(ra2.inserted_at, 14, :minute))
     assert Settings.was_late?(ra2, settings, DateTime.add(ra2.inserted_at, 16, :minute))
-
   end
 
   test "combine/3 honors the inline -1 for max_attempts" do
-
     revision = %Revision{
       max_attempts: 5
     }
+
     sr = %SectionResource{
       max_attempts: -1
     }
+
     se = %StudentException{
       max_attempts: nil
     }
 
     assert Settings.combine(revision, sr, se).max_attempts == 5
-
   end
 
   test "combine/3 honors student exceptions" do
-
     revision = %Revision{
       max_attempts: 5
     }
+
     sr = %SectionResource{
       end_date: nil,
       max_attempts: 10,
@@ -149,6 +224,7 @@ defmodule Oli.Delivery.SettingsTest do
       collab_space_config: 11,
       explanation_strategy: 12
     }
+
     se = %StudentException{
       end_date: ~U[2019-01-01 00:00:00Z],
       max_attempts: 1,
@@ -179,14 +255,13 @@ defmodule Oli.Delivery.SettingsTest do
     assert combined.feedback_scheduled_date == ~U[2021-01-01 00:00:00Z]
     assert combined.collab_space_config == 2
     assert combined.explanation_strategy == 3
-
   end
 
   test "combine/3 honors nils in student exceptions" do
-
     revision = %Revision{
       max_attempts: 5
     }
+
     sr = %SectionResource{
       end_date: nil,
       max_attempts: 10,
@@ -234,7 +309,36 @@ defmodule Oli.Delivery.SettingsTest do
     assert combined.feedback_scheduled_date == ~U[2021-01-01 00:00:00Z]
     assert combined.collab_space_config == 2
     assert combined.explanation_strategy == 3
-
   end
 
+  test "check_start_date/1 returns allowed when start date is nil" do
+    assert Settings.check_start_date(%Combined{start_date: nil}) == {:allowed}
+  end
+
+  test "check_start_date/1 returns allowed when start date has passed" do
+    yesterday = DateTime.utc_now() |> DateTime.add(-1, :day)
+    assert Settings.check_start_date(%Combined{start_date: yesterday}) == {:allowed}
+  end
+
+  test "check_start_date/1 returns before_start_date when start date has not passed" do
+    tomorrow = DateTime.utc_now() |> DateTime.add(1, :day)
+    assert Settings.check_start_date(%Combined{start_date: tomorrow}) == {:before_start_date}
+  end
+
+  test "check_password/2 returns allowed when the received password is nil" do
+    assert Settings.check_password(%{}, nil) == {:allowed}
+  end
+
+  test "check_password/2 returns allowed when the received password is empty" do
+    assert Settings.check_password(%{}, "") == {:allowed}
+  end
+
+  test "check_password/2 returns allowed when the received password is equal to the actual password" do
+    assert Settings.check_password(%Combined{password: "password"}, "password") == {:allowed}
+  end
+
+  test "check_password/2 returns invalid password when the received password is different from the actual password" do
+    assert Settings.check_password(%Combined{password: "password"}, "bad_password") ==
+             {:invalid_password}
+  end
 end

--- a/test/oli/utils_test.exs
+++ b/test/oli/utils_test.exs
@@ -24,7 +24,6 @@ defmodule Oli.UtilsTest do
     end
   end
 
-
   describe "ensure_absolute_url" do
     test "returns an absolute url" do
       assert Utils.ensure_absolute_url("test") == "https://localhost/test"
@@ -68,6 +67,12 @@ defmodule Oli.UtilsTest do
       test_string = "test string"
 
       assert Utils.find_and_linkify_urls_in_string(test_string) == test_string
+    end
+  end
+
+  describe "stringify_atom/1" do
+    test "returns the string representation of an atom without underscores" do
+      assert Utils.stringify_atom(:this_is_a_test) == "this is a test"
     end
   end
 end

--- a/test/oli_web/common/utils_test.exs
+++ b/test/oli_web/common/utils_test.exs
@@ -1,4 +1,6 @@
 defmodule OliWeb.Common.UtilsTest do
   use ExUnit.Case, async: true
+
+  alias OliWeb.Common.SessionContext
   doctest OliWeb.Common.Utils, import: true
 end

--- a/test/oli_web/controllers/page_delivery_controller_test.exs
+++ b/test/oli_web/controllers/page_delivery_controller_test.exs
@@ -520,6 +520,115 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert html_response(conn, 200) =~ "Submit Answers"
     end
 
+    # This tests the edge case for when a student goes to a page that is available to start and the instructor changes the start date
+    # to a future date simultaneously and before the student refreshes the page.
+    # The student should be redirected back to the page and see a message that the page is not yet available when trying to start an attempt.
+    test "requires a past start date to start an attempt", %{
+      user: user,
+      conn: conn,
+      section: section,
+      page_revision: page_revision
+    } do
+      enroll_as_student(%{section: section, user: user})
+
+      sr = Sections.get_section_resource(section.id, page_revision.resource_id)
+
+      conn = get(conn, Routes.page_delivery_path(conn, :page, section.slug, page_revision.slug))
+
+      assert html_response(conn, 200) =~ "Start Attempt"
+
+      # change the start date to tomorrow
+      tomorrow = DateTime.utc_now() |> DateTime.add(1, :day)
+      Sections.update_section_resource(sr, %{start_date: tomorrow})
+
+      # now start the attempt
+      conn =
+        recycle(conn)
+        |> Pow.Plug.assign_current_user(user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
+
+      conn =
+        get(
+          conn,
+          Routes.page_delivery_path(conn, :start_attempt, section.slug, page_revision.slug)
+        )
+
+      assert html_response(conn, 302) =~ "redirected"
+      redir_path = redirected_to(conn, 302)
+
+      conn =
+        recycle(conn)
+        |> Pow.Plug.assign_current_user(user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
+
+      conn = get(conn, redir_path)
+
+      assert html_response(conn, 200) =~
+               "This assessment is not yet available. It will be available on #{FormatDateTime.date(tomorrow, conn: conn, precision: :minutes)}."
+    end
+
+    test "shows 'Start Attempt' button when start date has passed", %{
+      user: user,
+      conn: conn,
+      section: section,
+      page_revision: page_revision
+    } do
+      enroll_as_student(%{section: section, user: user})
+
+      sr = Sections.get_section_resource(section.id, page_revision.resource_id)
+
+      tomorrow = DateTime.utc_now() |> DateTime.add(-1, :day)
+      Sections.update_section_resource(sr, %{start_date: tomorrow})
+
+      conn = get(conn, Routes.page_delivery_path(conn, :page, section.slug, page_revision.slug))
+
+      assert html_response(conn, 200) =~ "When you are ready to begin, you may"
+
+      # now start the attempt
+      conn =
+        recycle(conn)
+        |> Pow.Plug.assign_current_user(user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
+
+      conn =
+        get(
+          conn,
+          Routes.page_delivery_path(conn, :start_attempt, section.slug, page_revision.slug)
+        )
+
+      # verify the redirection
+      assert html_response(conn, 302) =~ "redirected"
+      redir_path = redirected_to(conn, 302)
+
+      # and then the rendering of the page, which should contain a button
+      # that says 'Submit Answers'
+      conn =
+        recycle(conn)
+        |> Pow.Plug.assign_current_user(user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
+
+      conn = get(conn, redir_path)
+      assert html_response(conn, 200) =~ "Submit Answers"
+    end
+
+    test "does not show 'Start Attempt' button when start date has not passed yet", %{
+      user: user,
+      conn: conn,
+      section: section,
+      page_revision: page_revision
+    } do
+      enroll_as_student(%{section: section, user: user})
+
+      sr = Sections.get_section_resource(section.id, page_revision.resource_id)
+
+      tomorrow = DateTime.utc_now() |> DateTime.add(1, :day)
+      Sections.update_section_resource(sr, %{start_date: tomorrow})
+
+      conn = get(conn, Routes.page_delivery_path(conn, :page, section.slug, page_revision.slug))
+      html_response = html_response(conn, 200)
+
+      assert html_response =~
+               "This assessment is not yet available. It will be available on #{FormatDateTime.date(tomorrow, conn: conn, precision: :minutes)}."
+
+      refute html_response =~ "Start Attempt"
+    end
+
     test "changing a page from graded to ungraded allows the graded attempt to continue", %{
       map: map,
       project: project,

--- a/test/oli_web/live/sections/assessment_settings/settings_live_test.exs
+++ b/test/oli_web/live/sections/assessment_settings/settings_live_test.exs
@@ -1270,7 +1270,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
       |> render() =~ "max=\"2023-10-10T17:00\""
     end
 
-    test "available date renders 'No available date' if it is not set",
+    test "available date renders 'Always available' if it is not set",
          %{
            conn: conn,
            section: section,
@@ -1287,7 +1287,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
         table_as_list_of_maps(view, :settings)
 
       assert assessment_1.available_date =~ "October 10, 2023"
-      assert assessment_2.available_date =~ "No available date"
+      assert assessment_2.available_date =~ "Always available"
     end
 
     test "due date date can be changed by clicking the due date in the table",
@@ -1940,7 +1940,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
       |> render() =~ "max=\"2023-10-10T17:00\""
     end
 
-    test "available date renders 'No available date' if it is not set",
+    test "available date renders 'Always available' if it is not set",
          %{
            conn: conn,
            section: section,
@@ -1972,7 +1972,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
       [exception_1, exception_2] = table_as_list_of_maps(view, :student_exceptions)
 
       assert exception_1.available_date =~ "October 10, 2023"
-      assert exception_2.available_date =~ "No available date"
+      assert exception_2.available_date =~ "Always available"
     end
 
     test "due date can be changed by clicking the due date in the table",

--- a/test/oli_web/live/sections/assessment_settings/settings_live_test.exs
+++ b/test/oli_web/live/sections/assessment_settings/settings_live_test.exs
@@ -6,6 +6,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
   import Oli.Factory
 
   alias Oli.Delivery.{Settings, Sections}
+  alias Oli.Delivery
   alias Lti_1p3.Tool.ContextRoles
   alias Oli.Resources.ResourceType
   alias Oli.Publishing.DeliveryResolver
@@ -407,6 +408,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
           [
             :index,
             :name,
+            :available_date,
             :due_date,
             :max_attempts,
             :time_limit,
@@ -424,6 +426,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
         :student_exceptions ->
           [
             :student,
+            :available_date,
             :due_date,
             :max_attempts,
             :time_limit,
@@ -452,7 +455,9 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
               Floki.text(data) |> String.trim()
 
             select ->
-              Floki.find(select, "option[selected]") |> Floki.text() |> String.trim()
+              Floki.find(select, "option[selected]")
+              |> Floki.text()
+              |> String.trim()
           end
         end)
       end)
@@ -1149,7 +1154,143 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
       assert page_1_assessment_settings.feedback_scheduled_date == nil
     end
 
-    test "schedule date can be changed by clicking the due date in the table",
+    test "available date can be changed by clicking the available date in the table",
+         %{
+           conn: conn,
+           section: section,
+           page_1: page_1
+         } do
+      {:ok, view, _html} = live(conn, live_view_overview_route(section.slug, "settings", "all"))
+
+      # LiveViewTest doesn't support testing two or more JS.push chained so I need to trigger two events separatedly
+      view
+      |> with_target("#settings_table")
+      |> render_click("edit_date", %{assessment_id: "#{page_1.resource_id}"})
+
+      view
+      |> with_target("#assessment_available_date_modal")
+      |> render_click("open", %{})
+
+      assert has_element?(view, "h5", "Page 1 available date")
+
+      assert has_element?(
+               view,
+               "label",
+               "Please pick an available date for the selected assessment"
+             )
+
+      new_date = ~U[2023-10-10 16:00:00Z]
+
+      view
+      |> element("#assessment-available-date-form")
+      |> render_submit(%{start_date: new_date})
+
+      assert has_element?(view, "button", "October 10, 2023")
+    end
+
+    test "preserves distance when setting available date after due date",
+         %{
+           conn: conn,
+           section: section,
+           page_1: page_1
+         } do
+      Sections.get_section_resource(section.id, page_1.resource.id)
+      |> Sections.update_section_resource(%{
+        start_date: ~U[2023-10-10 16:00:00Z],
+        end_date: ~U[2023-10-11 17:00:00Z],
+        scheduling_type: :due_by
+      })
+
+      {:ok, view, _html} = live(conn, live_view_overview_route(section.slug, "settings", "all"))
+
+      # LiveViewTest doesn't support testing two or more JS.push chained so I need to trigger two events separatedly
+      view
+      |> with_target("#settings_table")
+      |> render_click("edit_date", %{assessment_id: "#{page_1.resource_id}"})
+
+      view
+      |> with_target("#assessment_available_date_modal")
+      |> render_click("open", %{})
+
+      assert has_element?(view, "h5", "Page 1 available date")
+
+      assert has_element?(
+               view,
+               "label",
+               "Please pick an available date for the selected assessment"
+             )
+
+      new_date = ~U[2023-10-14 17:00:00Z]
+
+      view
+      |> element("#assessment-available-date-form")
+      |> render_submit(%{start_date: new_date})
+
+      # due date should be moved to 1 day after the new available date
+      assert has_element?(view, "button", "October 15, 2023 6:00 PM")
+    end
+
+    test "limits datetime selection when setting available date for the first time and the due date is already set",
+         %{
+           conn: conn,
+           section: section,
+           page_1: page_1
+         } do
+      end_date = ~U[2023-10-11 17:00:00Z]
+
+      Sections.get_section_resource(section.id, page_1.resource.id)
+      |> Sections.update_section_resource(%{
+        start_date: nil,
+        end_date: end_date,
+        scheduling_type: :due_by
+      })
+
+      {:ok, view, _html} = live(conn, live_view_overview_route(section.slug, "settings", "all"))
+
+      # LiveViewTest doesn't support testing two or more JS.push chained so I need to trigger two events separatedly
+      view
+      |> with_target("#settings_table")
+      |> render_click("edit_date", %{assessment_id: "#{page_1.resource_id}"})
+
+      view
+      |> with_target("#assessment_available_date_modal")
+      |> render_click("open", %{})
+
+      assert has_element?(view, "h5", "Page 1 available date")
+
+      assert has_element?(
+               view,
+               "label",
+               "Please pick an available date for the selected assessment"
+             )
+
+      # it only allows start dates up to one day before the end date for this scenario
+      view
+      |> element("#start_date_input[max]")
+      |> render() =~ "max=\"2023-10-10T17:00\""
+    end
+
+    test "available date renders 'No available date' if it is not set",
+         %{
+           conn: conn,
+           section: section,
+           page_1: page_1
+         } do
+      Sections.get_section_resource(section.id, page_1.resource.id)
+      |> Sections.update_section_resource(%{
+        start_date: ~U[2023-10-10 16:00:00Z]
+      })
+
+      {:ok, view, _html} = live(conn, live_view_overview_route(section.slug, "settings", "all"))
+
+      [assessment_1, assessment_2, _assessment_3, _assessment_4] =
+        table_as_list_of_maps(view, :settings)
+
+      assert assessment_1.available_date =~ "October 10, 2023"
+      assert assessment_2.available_date =~ "No available date"
+    end
+
+    test "due date date can be changed by clicking the due date in the table",
          %{
            conn: conn,
            section: section,
@@ -1167,7 +1308,12 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
       |> render_click("open", %{})
 
       assert has_element?(view, "h5", "Page 1 due date")
-      assert has_element?(view, "label", "Please pick a due date for the selected assessment")
+
+      assert has_element?(
+               view,
+               "label",
+               "Please pick a due date for the selected assessment"
+             )
 
       new_date = ~U[2023-10-10 16:00:00Z]
 
@@ -1176,6 +1322,88 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
       |> render_submit(%{end_date: new_date})
 
       assert has_element?(view, "button", "October 10, 2023")
+    end
+
+    test "preserves distance when setting due date before available date",
+         %{
+           conn: conn,
+           section: section,
+           page_1: page_1
+         } do
+      Sections.get_section_resource(section.id, page_1.resource.id)
+      |> Sections.update_section_resource(%{
+        start_date: ~U[2023-10-10 16:00:00Z],
+        end_date: ~U[2023-10-11 17:00:00Z],
+        scheduling_type: :due_by
+      })
+
+      {:ok, view, _html} = live(conn, live_view_overview_route(section.slug, "settings", "all"))
+
+      # LiveViewTest doesn't support testing two or more JS.push chained so I need to trigger two events separatedly
+      view
+      |> with_target("#settings_table")
+      |> render_click("edit_date", %{assessment_id: "#{page_1.resource_id}"})
+
+      view
+      |> with_target("#assessment_due_date_modal")
+      |> render_click("open", %{})
+
+      assert has_element?(view, "h5", "Page 1 due date")
+
+      assert has_element?(
+               view,
+               "label",
+               "Please pick a due date for the selected assessment"
+             )
+
+      new_date = ~U[2023-10-08 12:00:00Z]
+
+      view
+      |> element("#assessment-due-date-form")
+      |> render_submit(%{end_date: new_date})
+
+      # available date should be moved to 1 day before the new due date
+      assert has_element?(view, "button", "October 7, 2023 11:00 AM")
+    end
+
+    test "limits datetime selection when setting due date for the first time and the available date is already set",
+         %{
+           conn: conn,
+           section: section,
+           page_1: page_1
+         } do
+      start_date = ~U[2023-10-11 17:00:00Z]
+
+      Sections.get_section_resource(section.id, page_1.resource.id)
+      |> Sections.update_section_resource(%{
+        start_date: start_date,
+        end_date: nil,
+        scheduling_type: :due_by
+      })
+
+      {:ok, view, _html} = live(conn, live_view_overview_route(section.slug, "settings", "all"))
+
+      # LiveViewTest doesn't support testing two or more JS.push chained so I need to trigger two events separatedly
+      view
+      |> with_target("#settings_table")
+      |> render_click("edit_date", %{assessment_id: "#{page_1.resource_id}"})
+
+      view
+      |> with_target("#assessment_due_date_modal")
+      |> render_click("open", %{})
+
+      assert has_element?(view, "h5", "Page 1 due date")
+
+      assert has_element?(
+               view,
+               "label",
+               "Please pick a due date for the selected assessment"
+             )
+
+      # it only allows end dates one day after from the start date for this scenario
+      view
+      |> element("#end_date_input[min]")
+      |> render() =~ "min=\"2023-10-12T17:00\""
     end
 
     test "due date renders 'No due date' if scheduling type != due_by, and renders the date if scheduling type = due_by",
@@ -1233,7 +1461,9 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
       # select assessment 1
       view
       |> form(~s{form[id=assessment_select]})
-      |> render_change(%{"assessments" => %{"assessment_id" => page_1.resource.id}})
+      |> render_change(%{
+        "assessments" => %{"assessment_id" => page_1.resource.id}
+      })
 
       assert [se_1, se_2] = table_as_list_of_maps(view, :student_exceptions)
       assert se_1.student =~ student_1.name
@@ -1243,7 +1473,9 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
       # select assessment 2
       view
       |> form(~s{form[id=assessment_select]})
-      |> render_change(%{"assessments" => %{"assessment_id" => page_2.resource.id}})
+      |> render_change(%{
+        "assessments" => %{"assessment_id" => page_2.resource.id}
+      })
 
       assert [se_1] = table_as_list_of_maps(view, :student_exceptions)
       assert se_1.student =~ student_1.name
@@ -1252,7 +1484,9 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
       # select assessment 3
       view
       |> form(~s{form[id=assessment_select]})
-      |> render_change(%{"assessments" => %{"assessment_id" => page_3.resource.id}})
+      |> render_change(%{
+        "assessments" => %{"assessment_id" => page_3.resource.id}
+      })
 
       assert [] = table_as_list_of_maps(view, :student_exceptions)
       assert render(view) =~ "None exist"
@@ -1413,7 +1647,10 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
       assert render(view) =~ "None exist"
 
       view
-      |> element(~s{button[phx-value-modal_name=add_student_exception]}, "Add New")
+      |> element(
+        ~s{button[phx-value-modal_name=add_student_exception]},
+        "Add New"
+      )
       |> render_click()
 
       # the modal is shown
@@ -1492,6 +1729,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
       })
 
       [updated_student_exception_1] = table_as_list_of_maps(view, :student_exceptions)
+
       assert updated_student_exception_1.late_submit == "Disallow"
       assert student_exception_1.student == updated_student_exception_1.student
     end
@@ -1552,7 +1790,192 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
              )
     end
 
-    test "schedule date can be changed by clicking the due date in the table",
+    test "available date can be changed by clicking the available date in the table",
+         %{
+           conn: conn,
+           section: section,
+           page_1: page_1,
+           student_1: student_1
+         } do
+      exception = set_student_exception(section, page_1.resource, student_1)
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_overview_route(
+            section.slug,
+            "student_exceptions",
+            page_1.resource.id
+          )
+        )
+
+      # LiveViewTest doesn't support testing two or more JS.push chained so I need to trigger two events separatedly
+      view
+      |> with_target("#student_exceptions_table")
+      |> render_click("edit_date", %{user_id: "#{exception.user_id}"})
+
+      view
+      |> with_target("#student_available_date_modal")
+      |> render_click("open", %{})
+
+      assert has_element?(view, "h5", "Available date for #{student_1.name}")
+
+      assert has_element?(
+               view,
+               "label",
+               "Please pick an available date for the selected student"
+             )
+
+      new_date = ~U[2023-10-10 16:00:00Z]
+
+      view
+      |> element("#student-available-date-form")
+      |> render_submit(%{start_date: new_date})
+
+      assert has_element?(view, "button", "October 10, 2023")
+    end
+
+    test "preserves distance when setting available date after due date",
+         %{
+           conn: conn,
+           section: section,
+           page_1: page_1,
+           student_1: student_1
+         } do
+      exception = set_student_exception(section, page_1.resource, student_1)
+
+      Delivery.get_delivery_setting_by(%{
+        resource_id: page_1.resource.id,
+        user_id: student_1.id
+      })
+      |> Delivery.update_delivery_setting(%{
+        start_date: ~U[2023-10-10 16:00:00Z],
+        end_date: ~U[2023-10-11 17:00:00Z],
+        scheduling_type: :due_by
+      })
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_overview_route(
+            section.slug,
+            "student_exceptions",
+            page_1.resource.id
+          )
+        )
+
+      # LiveViewTest doesn't support testing two or more JS.push chained so I need to trigger two events separatedly
+      view
+      |> with_target("#student_exceptions_table")
+      |> render_click("edit_date", %{user_id: "#{exception.user_id}"})
+
+      view
+      |> with_target("#student_available_date_modal")
+      |> render_click("open", %{})
+
+      assert has_element?(view, "h5", "Available date for #{student_1.name}")
+
+      assert has_element?(
+               view,
+               "label",
+               "Please pick an available date for the selected student"
+             )
+
+      new_date = ~U[2023-10-14 17:00:00Z]
+
+      view
+      |> element("#student-available-date-form")
+      |> render_submit(%{start_date: new_date})
+
+      # due date should be moved to 1 day after the new available date
+      assert has_element?(view, "button", "October 15, 2023 6:00 PM")
+    end
+
+    test "limits datetime selection when setting available date for the first time and the due date is already set",
+         %{
+           conn: conn,
+           section: section,
+           page_1: page_1,
+           student_1: student_1
+         } do
+      end_date = ~U[2023-10-11 17:00:00Z]
+      exception = set_student_exception(section, page_1.resource, student_1)
+
+      Delivery.get_delivery_setting_by(%{
+        resource_id: page_1.resource.id,
+        user_id: student_1.id
+      })
+      |> Delivery.update_delivery_setting(%{
+        start_date: nil,
+        end_date: end_date,
+        scheduling_type: :due_by
+      })
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_overview_route(section.slug, "student_exceptions", page_1.resource.id)
+        )
+
+      # LiveViewTest doesn't support testing two or more JS.push chained so I need to trigger two events separatedly
+      view
+      |> with_target("#student_exceptions_table")
+      |> render_click("edit_date", %{user_id: "#{exception.user_id}"})
+
+      view
+      |> with_target("#student_available_date_modal")
+      |> render_click("open", %{})
+
+      assert has_element?(view, "h5", "Available date for #{student_1.name}")
+
+      assert has_element?(
+               view,
+               "label",
+               "Please pick an available date for the selected student"
+             )
+
+      # it only allows start dates from one day before the end date for this scenario
+      view
+      |> element("#start_date_input[max]")
+      |> render() =~ "max=\"2023-10-10T17:00\""
+    end
+
+    test "available date renders 'No available date' if it is not set",
+         %{
+           conn: conn,
+           section: section,
+           page_1: page_1,
+           student_1: student_1,
+           student_2: student_2
+         } do
+      _exception_1 = set_student_exception(section, page_1.resource, student_1)
+      _exception_2 = set_student_exception(section, page_1.resource, student_2)
+
+      Delivery.get_delivery_setting_by(%{
+        resource_id: page_1.resource.id,
+        user_id: student_1.id
+      })
+      |> Delivery.update_delivery_setting(%{
+        start_date: ~U[2023-10-10 16:00:00Z]
+      })
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_overview_route(
+            section.slug,
+            "student_exceptions",
+            page_1.resource.id
+          )
+        )
+
+      [exception_1, exception_2] = table_as_list_of_maps(view, :student_exceptions)
+
+      assert exception_1.available_date =~ "October 10, 2023"
+      assert exception_2.available_date =~ "No available date"
+    end
+
+    test "due date can be changed by clicking the due date in the table",
          %{
            conn: conn,
            section: section,
@@ -1581,7 +2004,12 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
       |> render_click("open", %{})
 
       assert has_element?(view, "h5", "Due date for #{student_1.name}")
-      assert has_element?(view, "label", "Please pick a due date for the selected student")
+
+      assert has_element?(
+               view,
+               "label",
+               "Please pick a due date for the selected student"
+             )
 
       new_date = ~U[2023-10-10 16:00:00Z]
 
@@ -1590,6 +2018,111 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
       |> render_submit(%{end_date: new_date})
 
       assert has_element?(view, "button", "October 10, 2023")
+    end
+
+    test "preserves distance when setting due date before available date",
+         %{
+           conn: conn,
+           section: section,
+           page_1: page_1,
+           student_1: student_1
+         } do
+      exception = set_student_exception(section, page_1.resource, student_1)
+
+      Delivery.get_delivery_setting_by(%{
+        resource_id: page_1.resource.id,
+        user_id: student_1.id
+      })
+      |> Delivery.update_delivery_setting(%{
+        start_date: ~U[2023-10-10 16:00:00Z],
+        end_date: ~U[2023-10-11 17:00:00Z],
+        scheduling_type: :due_by
+      })
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_overview_route(
+            section.slug,
+            "student_exceptions",
+            page_1.resource.id
+          )
+        )
+
+      # LiveViewTest doesn't support testing two or more JS.push chained so I need to trigger two events separatedly
+      view
+      |> with_target("#student_exceptions_table")
+      |> render_click("edit_date", %{user_id: "#{exception.user_id}"})
+
+      view
+      |> with_target("#student_due_date_modal")
+      |> render_click("open", %{})
+
+      assert has_element?(view, "h5", "Due date for #{student_1.name}")
+
+      assert has_element?(
+               view,
+               "label",
+               "Please pick a due date for the selected student"
+             )
+
+      new_date = ~U[2023-10-03 12:00:00Z]
+
+      view
+      |> element("#student-due-date-form")
+      |> render_submit(%{end_date: new_date})
+
+      # available date should be moved to 1 day before the new due date
+      assert has_element?(view, "button", "October 2, 2023 11:00 AM")
+    end
+
+    test "limits datetime selection when setting due date for the first time and the available date is already set",
+         %{
+           conn: conn,
+           section: section,
+           page_1: page_1,
+           student_1: student_1
+         } do
+      start_date = ~U[2023-10-11 17:00:00Z]
+      exception = set_student_exception(section, page_1.resource, student_1)
+
+      Delivery.get_delivery_setting_by(%{
+        resource_id: page_1.resource.id,
+        user_id: student_1.id
+      })
+      |> Delivery.update_delivery_setting(%{
+        start_date: start_date,
+        end_date: nil,
+        scheduling_type: :due_by
+      })
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_overview_route(section.slug, "student_exceptions", page_1.resource.id)
+        )
+
+      # LiveViewTest doesn't support testing two or more JS.push chained so I need to trigger two events separatedly
+      view
+      |> with_target("#student_exceptions_table")
+      |> render_click("edit_date", %{user_id: "#{exception.user_id}"})
+
+      view
+      |> with_target("#student_due_date_modal")
+      |> render_click("open", %{})
+
+      assert has_element?(view, "h5", "Due date for #{student_1.name}")
+
+      assert has_element?(
+               view,
+               "label",
+               "Please pick a due date for the selected student"
+             )
+
+      # it only allows end dates from one day after the start date for this scenario
+      view
+      |> element("#end_date_input[min]")
+      |> render() =~ "min=\"2023-10-12T17:00\""
     end
   end
 end


### PR DESCRIPTION
[MER-2525](https://eliterate.atlassian.net/browse/MER-2525)

This PR adds the following changes:
- Add available date to both **Assessment Settings** and **Student Exceptions** pages.
    - If both Available and Due dates are already defined and one of them is inconsistently updated (i.e. `due_date < available_date`), both dates are updated to keep the time distance. (See Video 1)
    - If the Available Date is set but the Due Date **is not** and the instructor attempts to set it, the datetime select does not allow dates before or equal to the Available Date. The reason is that we cannot calculate a time distance in this scenario. (See Video 2)
    - If the Due Date is set but the Available Date **is not** and the instructor attempts to set it, the datetime select does not allow dates after or equal to the Due Date. Same reason as above.
- Do not allow students to start new attempts if the assessment is not available yet.
- Do not allow students to start new attempts if the assessment was available when visiting the prologue page and the instructor sets a new available date before the student refreshes the page.

In order to keep PRs small, the Graphical Scheduler changes will be addressed in a separate PR.


https://github.com/Simon-Initiative/oli-torus/assets/26532202/94d69412-d145-46ba-b479-e1f009c45384


https://github.com/Simon-Initiative/oli-torus/assets/26532202/90f69498-0fda-4e2e-ad6e-f4d08b3d26cb



[MER-2525]: https://eliterate.atlassian.net/browse/MER-2525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ