### PR TITLE
[BUGFIX][MER-2496] Changes customize curriculum link text

### DIFF
--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -181,7 +181,7 @@ defmodule OliWeb.Sections.OverviewView do
               href={Routes.live_path(OliWeb.Endpoint, OliWeb.Delivery.RemixSection, @section.slug)}
               class="btn btn-link"
             >
-              Customize Curriculum
+              Customize Content
             </a>
           </li>
           <li>

--- a/test/oli_web/live/sections/overview_live_test.exs
+++ b/test/oli_web/live/sections/overview_live_test.exs
@@ -187,7 +187,7 @@ defmodule OliWeb.Sections.OverviewLiveTest do
       assert has_element?(
                view,
                "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Delivery.RemixSection, section.slug)}\"]",
-               "Customize Curriculum"
+               "Customize Content"
              )
 
       assert has_element?(


### PR DESCRIPTION
[MER-2496](https://eliterate.atlassian.net/browse/MER-2496)

This PR changes the text of the link from `customize curriculum` to `customize content` in the manage section view to match the text in the breadcrumb view for customize content.

![Captura de pantalla 2023-09-07 a la(s) 16 57 06](https://github.com/Simon-Initiative/oli-torus/assets/16328384/555f1c6d-2cdc-4542-81cb-9aa6bb1034e4)

![Captura de pantalla 2023-09-07 a la(s) 16 56 42](https://github.com/Simon-Initiative/oli-torus/assets/16328384/fe70282d-57b3-4fed-999c-678c75d65c23)


[MER-2496]: https://eliterate.atlassian.net/browse/MER-2496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ