### PR TITLE
[MER-2541] [ENHANCEMENT] Allow configurable max header value length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@
 
 ### Enhancements
 
-- Allow configuration of HTTP/HTTPS max header length
+- Allow configuration of HTTP/HTTPS cowboy protocol options
 
 ### Environment Configs
 
 ```
-HTTP_MAX_VALUE_HEADER_LENGTH       (Optional) HTTP/HTTPS max header length accepted by Cowboy
+HTTP_MAX_HEADER_NAME_LENGTH       (Optional) HTTP/HTTPS Maximum length of header names for Cowboy (Default 64)
+HTTP_MAX_HEADER_VALUE_LENGTH      (Optional) HTTP/HTTPS Maximum length of header values for Cowboy (Default 4096)
+HTTP_MAX_HEADERS                  (Optional) HTTP/HTTPS Maximum number of headers allowed per request for Cowboy (Default 100)
 ```
 
 ## 0.24.4 (2023-8-11)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 HTTP_MAX_HEADER_NAME_LENGTH       (Optional) HTTP/HTTPS Maximum length of header names for Cowboy (Default 64)
 HTTP_MAX_HEADER_VALUE_LENGTH      (Optional) HTTP/HTTPS Maximum length of header values for Cowboy (Default 4096)
 HTTP_MAX_HEADERS                  (Optional) HTTP/HTTPS Maximum number of headers allowed per request for Cowboy (Default 100)
+
+LOG_INCOMPLETE_HTTP_REQUESTS      (Optional) Log incomplete HTTP requests (Default true)
 ```
 
 ## 0.24.4 (2023-8-11)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,20 @@
 # Changelog
 
-
 ## 0.24.5 (2023-9-12)
 
 ### Bug Fixes
 
 - Scientific notation in single response range question handling
+
+### Enhancements
+
+- Allow configuration of HTTP/HTTPS max header length
+
+### Environment Configs
+
+```
+HTTP_MAX_VALUE_HEADER_LENGTH       (Optional) HTTP/HTTPS max header length accepted by Cowboy
+```
 
 ## 0.24.4 (2023-8-11)
 

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -63,7 +63,8 @@ const populateEntries = () => {
   const styleSheets = [
     { adaptive: './styles/adaptive/adaptive-reset.scss' },
     { styles: './styles/index.scss' },
-    { preview: './styles/preview.scss' }];
+    { preview: './styles/preview.scss' },
+  ];
 
   // Merge the attributes of all found activities and the initialEntries
   // into one single object.
@@ -77,9 +78,9 @@ const populateEntries = () => {
   if (
     Object.keys(merged).length !=
     Object.keys(initialEntries).length +
-    2 * foundActivities.length +
-    2 * foundParts.length +
-    styleSheets.length
+      2 * foundActivities.length +
+      2 * foundParts.length +
+      styleSheets.length
   ) {
     throw new Error(
       'Encountered a possible naming collision in activity or part manifests. Aborting.',
@@ -319,7 +320,7 @@ module.exports = (env, options) => ({
       outputFilename: '../licenses.json',
       licenseOverrides: {
         'janus-script@1.9.2': 'MIT',
-        'phoenix_html@3.2.0': 'MIT',
+        'phoenix_html@3.3.1': 'MIT',
         'typed-function@2.0.0': 'MIT',
       },
       unacceptableLicenseTest: (licenseIdentifier) => {

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -320,6 +320,7 @@ module.exports = (env, options) => ({
       outputFilename: '../licenses.json',
       licenseOverrides: {
         'janus-script@1.9.2': 'MIT',
+        'phoenix_html@3.2.0': 'MIT',
         'phoenix_html@3.3.1': 'MIT',
         'typed-function@2.0.0': 'MIT',
       },

--- a/config/config.exs
+++ b/config/config.exs
@@ -56,7 +56,8 @@ config :oli,
   node_js_pool_size: String.to_integer(System.get_env("NODE_JS_POOL_SIZE", "2")),
   screen_idle_timeout_in_seconds:
     String.to_integer(System.get_env("SCREEN_IDLE_TIMEOUT_IN_SECONDS", "1800")),
-  always_use_persistent_login_sessions: false
+  always_use_persistent_login_sessions: false,
+  log_incomplete_requests: true
 
 rule_evaluator_provider =
   case System.get_env("RULE_EVALUATOR_PROVIDER") do

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -30,7 +30,8 @@ config :oli,
     favicons: System.get_env("BRANDING_FAVICONS_DIR", "/branding/dev/favicons")
   ],
   always_use_persistent_login_sessions:
-    get_env_as_boolean.("ALWAYS_USE_PERSISTENT_LOGIN_SESSIONS", "false")
+    get_env_as_boolean.("ALWAYS_USE_PERSISTENT_LOGIN_SESSIONS", "false"),
+  log_incomplete_requests: get_env_as_boolean.("LOG_INCOMPLETE_REQUESTS", "true")
 
 config :oli, :vendor_property,
   workspace_logo:
@@ -68,6 +69,16 @@ config :oli, :cashnet_provider,
   cashnet_client: System.get_env("CASHNET_CLIENT"),
   cashnet_gl_number: System.get_env("CASHNET_GL_NUMBER")
 
+# Configurable http/https protocol options for cowboy
+# https://ninenines.eu/docs/en/cowboy/2.5/manual/cowboy_http/
+http_max_header_name_length =
+  System.get_env("HTTP_MAX_HEADER_NAME_LENGTH", "64") |> String.to_integer()
+
+http_max_header_value_length =
+  System.get_env("HTTP_MAX_HEADER_VALUE_LENGTH", "4096") |> String.to_integer()
+
+http_max_headers = System.get_env("HTTP_MAX_HEADERS", "100") |> String.to_integer()
+
 # For development, we disable any cache and enable
 # debugging and code reloading.
 #
@@ -76,7 +87,12 @@ config :oli, :cashnet_provider,
 # with webpack to recompile .js and .css sources.
 config :oli, OliWeb.Endpoint,
   http: [
-    port: String.to_integer(System.get_env("HTTP_PORT", "80"))
+    port: String.to_integer(System.get_env("HTTP_PORT", "80")),
+    protocol_options: [
+      max_header_name_length: http_max_header_name_length,
+      max_header_value_length: http_max_header_value_length,
+      max_headers: http_max_headers
+    ]
   ],
   url: [
     scheme: System.get_env("SCHEME", "https"),
@@ -87,7 +103,12 @@ config :oli, OliWeb.Endpoint,
     port: String.to_integer(System.get_env("HTTPS_PORT", "443")),
     otp_app: :oli,
     keyfile: System.get_env("SSL_KEY_PATH", "priv/ssl/localhost.key"),
-    certfile: System.get_env("SSL_CERT_PATH", "priv/ssl/localhost.crt")
+    certfile: System.get_env("SSL_CERT_PATH", "priv/ssl/localhost.crt"),
+    protocol_options: [
+      max_header_name_length: http_max_header_name_length,
+      max_header_value_length: http_max_header_value_length,
+      max_headers: http_max_headers
+    ]
   ],
   debug_errors: true,
   code_reloader: true,

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -103,7 +103,8 @@ config :oli,
   screen_idle_timeout_in_seconds:
     String.to_integer(System.get_env("SCREEN_IDLE_TIMEOUT_IN_SECONDS", "1800")),
   always_use_persistent_login_sessions:
-    get_env_as_boolean.("ALWAYS_USE_PERSISTENT_LOGIN_SESSIONS", "false")
+    get_env_as_boolean.("ALWAYS_USE_PERSISTENT_LOGIN_SESSIONS", "false"),
+  log_incomplete_requests: get_env_as_boolean.("LOG_INCOMPLETE_REQUESTS", "true")
 
 default_description = """
 The Open Learning Initiative enables research and experimentation with all aspects of the learning experience.
@@ -191,17 +192,26 @@ help_provider =
 
 config :oli, :help, dispatcher: help_provider
 
-# Configurable http/https max header length accepted for Cowboy. Default is 4096
+# Configurable http/https protocol options for cowboy
 # https://ninenines.eu/docs/en/cowboy/2.5/manual/cowboy_http/
+http_max_header_name_length =
+  System.get_env("HTTP_MAX_HEADER_NAME_LENGTH", "64") |> String.to_integer()
+
 http_max_header_value_length =
-  System.get_env("HTTP_MAX_VALUE_HEADER_LENGTH", "4096") |> String.to_integer()
+  System.get_env("HTTP_MAX_HEADER_VALUE_LENGTH", "4096") |> String.to_integer()
+
+http_max_headers = System.get_env("HTTP_MAX_HEADERS", "100") |> String.to_integer()
 
 config :oli, OliWeb.Endpoint,
   server: true,
   http: [
     :inet6,
     port: String.to_integer(System.get_env("HTTP_PORT", "80")),
-    protocol_options: [max_header_value_length: http_max_header_value_length]
+    protocol_options: [
+      max_header_name_length: http_max_header_name_length,
+      max_header_value_length: http_max_header_value_length,
+      max_headers: http_max_headers
+    ]
   ],
   url: [
     scheme: System.get_env("SCHEME", "https"),
@@ -218,7 +228,11 @@ if System.get_env("SSL_CERT_PATH") && System.get_env("SSL_KEY_PATH") do
       otp_app: :oli,
       keyfile: System.get_env("SSL_CERT_PATH", "priv/ssl/localhost.key"),
       certfile: System.get_env("SSL_KEY_PATH", "priv/ssl/localhost.crt"),
-      protocol_options: [max_header_value_length: http_max_header_value_length]
+      protocol_options: [
+        max_header_name_length: http_max_header_name_length,
+        max_header_value_length: http_max_header_value_length,
+        max_headers: http_max_headers
+      ]
     ]
 end
 

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -191,17 +191,17 @@ help_provider =
 
 config :oli, :help, dispatcher: help_provider
 
-# Configurable cowboy http/https max header length accepted. Default 4096
+# Configurable http/https max header length accepted for Cowboy. Default is 4096
 # https://ninenines.eu/docs/en/cowboy/2.5/manual/cowboy_http/
-max_header_value_length =
-  System.get_env("COWBOY_MAX_VALUE_HEADER_LENGTH", "4096") |> String.to_integer()
+http_max_header_value_length =
+  System.get_env("HTTP_MAX_VALUE_HEADER_LENGTH", "4096") |> String.to_integer()
 
 config :oli, OliWeb.Endpoint,
   server: true,
   http: [
     :inet6,
     port: String.to_integer(System.get_env("HTTP_PORT", "80")),
-    protocol_options: [max_header_value_length: max_header_value_length]
+    protocol_options: [max_header_value_length: http_max_header_value_length]
   ],
   url: [
     scheme: System.get_env("SCHEME", "https"),
@@ -218,7 +218,7 @@ if System.get_env("SSL_CERT_PATH") && System.get_env("SSL_KEY_PATH") do
       otp_app: :oli,
       keyfile: System.get_env("SSL_CERT_PATH", "priv/ssl/localhost.key"),
       certfile: System.get_env("SSL_KEY_PATH", "priv/ssl/localhost.crt"),
-      protocol_options: [max_header_value_length: max_header_value_length]
+      protocol_options: [max_header_value_length: http_max_header_value_length]
     ]
 end
 

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -191,11 +191,17 @@ help_provider =
 
 config :oli, :help, dispatcher: help_provider
 
+# Configurable cowboy http/https max header length accepted. Default 4096
+# https://ninenines.eu/docs/en/cowboy/2.5/manual/cowboy_http/
+max_header_value_length =
+  System.get_env("COWBOY_MAX_VALUE_HEADER_LENGTH", "4096") |> String.to_integer()
+
 config :oli, OliWeb.Endpoint,
   server: true,
   http: [
     :inet6,
-    port: String.to_integer(System.get_env("HTTP_PORT", "80"))
+    port: String.to_integer(System.get_env("HTTP_PORT", "80")),
+    protocol_options: [max_header_value_length: max_header_value_length]
   ],
   url: [
     scheme: System.get_env("SCHEME", "https"),
@@ -211,7 +217,8 @@ if System.get_env("SSL_CERT_PATH") && System.get_env("SSL_KEY_PATH") do
       port: 443,
       otp_app: :oli,
       keyfile: System.get_env("SSL_CERT_PATH", "priv/ssl/localhost.key"),
-      certfile: System.get_env("SSL_KEY_PATH", "priv/ssl/localhost.crt")
+      certfile: System.get_env("SSL_KEY_PATH", "priv/ssl/localhost.crt"),
+      protocol_options: [max_header_value_length: max_header_value_length]
     ]
 end
 

--- a/lib/oli/application.ex
+++ b/lib/oli/application.ex
@@ -30,7 +30,6 @@ defmodule Oli.Application do
 
         # Start the Pow MnesiaCache to persist session across multiple servers
         Oli.MnesiaClusterSupervisor,
-
         OliWeb.Presence,
 
         # Starts the nonce cleanup task, call Lti_1p3.Nonces.cleanup_nonce_store/0 at 1:01 UTC every day
@@ -58,8 +57,17 @@ defmodule Oli.Application do
 
         # Starts Cachex to store user/author info across requests
         Oli.AccountLookupCache
-
       ] ++ maybe_node_js_config()
+
+    if log_incomplete_requests?() do
+      :ok =
+        :telemetry.attach(
+          "cowboy-request-handler",
+          [:cowboy, :request, :early_error],
+          &Oli.LogIncompleteRequestHandler.handle_event/4,
+          nil
+        )
+    end
 
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
@@ -109,5 +117,9 @@ defmodule Oli.Application do
     else
       []
     end
+  end
+
+  defp log_incomplete_requests?() do
+    Application.fetch_env!(:oli, :log_incomplete_requests)
   end
 end

--- a/lib/oli/log_incomplete_request.ex
+++ b/lib/oli/log_incomplete_request.ex
@@ -1,0 +1,13 @@
+defmodule Oli.LogIncompleteRequestHandler do
+  alias Oli.Utils.Appsignal
+
+  require Logger
+
+  def handle_event([:cowboy, :request, :early_error], _response, request, nil) do
+    e = "Incomplete HTTP Request: " <> Kernel.inspect(request)
+
+    Appsignal.capture_error(e)
+
+    Logger.error(e)
+  end
+end

--- a/oli.example.env
+++ b/oli.example.env
@@ -153,3 +153,6 @@ BRANDING_FAVICONS_DIR="/favicons"
 ## Configure whether to always use persistent sessions on login or allow users to choose
 ## using the "Remember me" checkbox
 # ALWAYS_USE_PERSISTENT_LOGIN_SESSIONS=false
+
+## Configure whether incomplete http requests reported by cowboy should be logged or not
+# LOG_INCOMPLETE_HTTP_REQUESTS=true

--- a/oli.example.env
+++ b/oli.example.env
@@ -12,6 +12,12 @@ ADMIN_PASSWORD=changeme
 ## public url
 # HTTP_PORT=80
 
+## Configurable http/https protocol options for cowboy
+## https://ninenines.eu/docs/en/cowboy/2.5/manual/cowboy_http/
+# HTTP_MAX_HEADER_NAME_LENGTH=64
+# HTTP_MAX_HEADER_VALUE_LENGTH=4096
+# HTTP_MAX_HEADERS=100
+
 ## Change DB_HOST to localhost if running app natively (development only)
 DB_HOST=localhost
 


### PR DESCRIPTION
Adds a configuration env variable `HTTP_MAX_VALUE_HEADER_LENGTH` for Cowboy http server max header value length. Configuring to a larger value should resolve some of the HTTP 431 errors being returned for users.

If no value is set, then a value of 4096 will be used, which is the default value listed in the Cowboy docs https://ninenines.eu/docs/en/cowboy/2.5/manual/cowboy_http/