### PR TITLE
[BUGFIX][MER-2535] Unnecessary grade update jobs being created

### DIFF
--- a/lib/oli_web/controllers/api/page_lifecycle_controller.ex
+++ b/lib/oli_web/controllers/api/page_lifecycle_controller.ex
@@ -22,7 +22,9 @@ defmodule OliWeb.Api.PageLifecycleController do
        }} ->
         # graded resource finalization success
         section = Sections.get_section_by(slug: section_slug)
-        PageLifecycle.GradeUpdateWorker.create(section.id, id, :inline)
+
+        if section.grade_passback_enabled,
+          do: PageLifecycle.GradeUpdateWorker.create(section.id, id, :inline)
 
         is_adaptive_page? = case Oli.Publishing.DeliveryResolver.from_revision_slug(section_slug, revision_slug) do
           %Oli.Resources.Revision{content: %{"advancedDelivery" => true}} -> true


### PR DESCRIPTION
[MER-2535](https://eliterate.atlassian.net/browse/MER-2535)

This PR aims to avoid completed graded pages from having update workers if the course section containing them has its `grade_passback_enabled` attribute set to `false`.

[MER-2535]: https://eliterate.atlassian.net/browse/MER-2535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ