### PR TITLE
[BUG FIX] Preserve assessment settings during course update application

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -1520,7 +1520,26 @@ defmodule Oli.Delivery.Sections do
       |> then(
         &Repo.insert_all(SectionResource, &1,
           placeholders: placeholders,
-          on_conflict: {:replace_all_except, [:inserted_at, :scoring_strategy_id]},
+          on_conflict: {:replace_all_except, [
+            :inserted_at,
+            :scoring_strategy_id,
+            :scheduling_type,
+            :manually_scheduled,
+            :start_date,
+            :end_date,
+            :collab_space_config,
+            :explanation_strategy,
+            :max_attempts,
+            :retake_mode,
+            :password,
+            :late_submit,
+            :late_start,
+            :time_limit,
+            :grace_period,
+            :review_submission,
+            :feedback_mode,
+            :feedback_scheduled_date
+            ]},
           conflict_target: [:section_id, :resource_id]
         )
       )
@@ -1864,7 +1883,26 @@ defmodule Oli.Delivery.Sections do
       |> then(
         &Repo.insert_all(SectionResource, &1,
           placeholders: placeholders,
-          on_conflict: {:replace_all_except, [:inserted_at, :scoring_strategy_id]},
+          on_conflict: {:replace_all_except, [
+            :inserted_at,
+            :scoring_strategy_id,
+            :scheduling_type,
+            :manually_scheduled,
+            :start_date,
+            :end_date,
+            :collab_space_config,
+            :explanation_strategy,
+            :max_attempts,
+            :retake_mode,
+            :password,
+            :late_submit,
+            :late_start,
+            :time_limit,
+            :grace_period,
+            :review_submission,
+            :feedback_mode,
+            :feedback_scheduled_date
+          ]},
           conflict_target: [:section_id, :resource_id]
         )
       )
@@ -1962,7 +2000,26 @@ defmodule Oli.Delivery.Sections do
       |> then(
         &Repo.insert_all(SectionResource, &1,
           placeholders: placeholders,
-          on_conflict: {:replace_all_except, [:inserted_at, :scoring_strategy_id]},
+          on_conflict: {:replace_all_except, [
+            :inserted_at,
+            :scoring_strategy_id,
+            :scheduling_type,
+            :manually_scheduled,
+            :start_date,
+            :end_date,
+            :collab_space_config,
+            :explanation_strategy,
+            :max_attempts,
+            :retake_mode,
+            :password,
+            :late_submit,
+            :late_start,
+            :time_limit,
+            :grace_period,
+            :review_submission,
+            :feedback_mode,
+            :feedback_scheduled_date
+          ]},
           conflict_target: [:section_id, :resource_id]
         )
       )
@@ -2076,7 +2133,26 @@ defmodule Oli.Delivery.Sections do
             # if there is a conflict on the unique section_id resource_id constraint,
             # we assume it is because a resource has been moved or removed/readded in
             # a remix operation, so we simply replace the existing section_resource record
-            on_conflict: :replace_all,
+            on_conflict: {:replace_all_except, [
+              :inserted_at,
+              :scoring_strategy_id,
+              :scheduling_type,
+              :manually_scheduled,
+              :start_date,
+              :end_date,
+              :collab_space_config,
+              :explanation_strategy,
+              :max_attempts,
+              :retake_mode,
+              :password,
+              :late_submit,
+              :late_start,
+              :time_limit,
+              :grace_period,
+              :review_submission,
+              :feedback_mode,
+              :feedback_scheduled_date
+            ]},
             conflict_target: [:section_id, :resource_id]
           )
 


### PR DESCRIPTION
The various `insert_all` invocations meant to upsert SectionResource records during application of new course project publications had a conflict strategy that resulted in many attributes getting reset to default values.  This was trivial to reproduce manually, just change some assessment settings, apply an update, and check to see that they reverted. 

The fix here was to exclude the necessary settings.  The unit test proves they remain unchanged. 