### PR TITLE
[BUGFIX][MER-2545] superactivity iframe size

### DIFF
--- a/assets/src/components/activities/oli_embedded/OliEmbeddedDelivery.tsx
+++ b/assets/src/components/activities/oli_embedded/OliEmbeddedDelivery.tsx
@@ -144,22 +144,6 @@ const EmbeddedDelivery = (props: DeliveryElementProps<OliEmbeddedModelSchema>) =
           data-userguid={context.user_guid}
           data-partids={context.part_ids}
           data-mode="oli"
-          onLoad={(event: any) => {
-            if (iframeHeight > 0) return;
-            const { contentWindow, contentDocument } = event.target;
-            const embed = contentWindow.document.body.querySelector('body > :first-of-type');
-
-            // Observe any size changes in the content and update the iframe height
-            const resizeObserver = new ResizeObserver((entries) => {
-              // This limit to 700px prevents uncontrolled iframe height growth.
-              // A bug where for some content layouts settings the iframe height results in a run away height growth loop
-              if (contentDocument.body.scrollHeight < 700) {
-                setIframeHeight(contentDocument.body.scrollHeight);
-              }
-            });
-
-            resizeObserver.observe(embed);
-          }}
         ></iframe>
       )}
       {preview && <h4>OLI Embedded activity does not yet support preview</h4>}

--- a/assets/src/components/activities/oli_embedded/OliEmbeddedDelivery.tsx
+++ b/assets/src/components/activities/oli_embedded/OliEmbeddedDelivery.tsx
@@ -34,7 +34,7 @@ const EmbeddedDelivery = (props: DeliveryElementProps<OliEmbeddedModelSchema>) =
 
   const [context, setContext] = useState<Context>();
   const [preview, setPreview] = useState<boolean>(false);
-  const [iframeHeight, setIframeHeight] = useState(0);
+  const [iframeHeight, setIframeHeight] = useState(500);
 
   const dispatch = useDispatch();
   useEffect(() => {
@@ -46,6 +46,22 @@ const EmbeddedDelivery = (props: DeliveryElementProps<OliEmbeddedModelSchema>) =
       dispatch,
       activityContext,
     );
+
+    const parser = new DOMParser();
+    const modelDoc = parser.parseFromString(model.modelXml, 'text/xml');
+    const modelRootNode = modelDoc.querySelector(':root');
+    if (modelRootNode != null) {
+      let height = modelRootNode.getAttribute('height');
+      if (height) {
+        try {
+          // Extract number
+          height = height.replace(/[^0-9]/g,"");
+          setIframeHeight(parseInt(height));
+        } catch(error) {
+          console.error(error);
+        }
+      }
+    }
 
     fetchContext();
   }, []);
@@ -129,8 +145,9 @@ const EmbeddedDelivery = (props: DeliveryElementProps<OliEmbeddedModelSchema>) =
           data-partids={context.part_ids}
           data-mode="oli"
           onLoad={(event: any) => {
+            if (iframeHeight > 0) return;
             const { contentWindow, contentDocument } = event.target;
-            const embed = contentWindow.document.body.querySelector('#oli-embed');
+            const embed = contentWindow.document.body.querySelector('body > :first-of-type');
 
             // Observe any size changes in the content and update the iframe height
             const resizeObserver = new ResizeObserver((entries) => {

--- a/assets/src/components/activities/oli_embedded/OliEmbeddedDelivery.tsx
+++ b/assets/src/components/activities/oli_embedded/OliEmbeddedDelivery.tsx
@@ -55,9 +55,9 @@ const EmbeddedDelivery = (props: DeliveryElementProps<OliEmbeddedModelSchema>) =
       if (height) {
         try {
           // Extract number
-          height = height.replace(/[^0-9]/g,"");
+          height = height.replace(/[^0-9]/g, '');
           setIframeHeight(parseInt(height));
-        } catch(error) {
+        } catch (error) {
           console.error(error);
         }
       }


### PR DESCRIPTION
This PR sets the height of a superactivity iframe by reading the activity XML and using the “height” attribute configured in those XML files, and if that is not set, use a default of 500px.