### PR TITLE
[Feature] Added availability date in scheduler [MER-2536]

### DIFF
--- a/assets/src/apps/scheduler/PageDragBar.tsx
+++ b/assets/src/apps/scheduler/PageDragBar.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from 'react';
 import { DateWithoutTime } from 'epoq';
 import { useDocumentMouseEvents } from '../../components/hooks/useDocumentMouseEvents';
 import { useToggle } from '../../components/hooks/useToggle';
-import { DayGeometry, barGeometry, leftToDate } from './date-utils';
+import { DayGeometry, barGeometry, leftToDate, validateStartEndDates } from './date-utils';
 import { SchedulingType } from './scheduler-slice';
 
 interface DragBarProps {
@@ -89,16 +89,6 @@ export const DraggableIcon: React.FC<{
   );
 };
 
-const validateDates = (start: DateWithoutTime | null, end: DateWithoutTime | null) => {
-  if (!start || !end) {
-    return [start, end];
-  }
-  if (start.getDaysSinceEpoch() > end.getDaysSinceEpoch()) {
-    return [end, start];
-  }
-  return [start, end];
-};
-
 export const PageDragBar: React.FC<DragBarProps> = ({
   endDate,
   startDate,
@@ -110,7 +100,7 @@ export const PageDragBar: React.FC<DragBarProps> = ({
 }) => {
   const onEndDateChange = useCallback(
     (date: DateWithoutTime) => {
-      const [start, end] = validateDates(startDate, date);
+      const [start, end] = validateStartEndDates(startDate, date);
       onChange && onChange(start, end);
     },
     [onChange, startDate],
@@ -118,7 +108,7 @@ export const PageDragBar: React.FC<DragBarProps> = ({
 
   const onStartDateChange = useCallback(
     (date: DateWithoutTime) => {
-      const [start, end] = validateDates(date, endDate);
+      const [start, end] = validateStartEndDates(date, endDate);
       onChange && onChange(start, end);
     },
     [onChange, endDate],
@@ -126,7 +116,7 @@ export const PageDragBar: React.FC<DragBarProps> = ({
 
   const hasStartEnd = isGraded && startDate && endDate;
   const geometry = barGeometry(dayGeometry, startDate, endDate);
-  const offsetIcons = Math.abs(geometry.width) < 20;
+  const offsetIcons = hasStartEnd && Math.abs(geometry.width) < 20;
 
   const showConnector = hasStartEnd && !offsetIcons;
 

--- a/assets/src/apps/scheduler/PageScheduleLine.tsx
+++ b/assets/src/apps/scheduler/PageScheduleLine.tsx
@@ -33,6 +33,19 @@ export const PageScheduleLine: React.FC<ScheduleLineProps> = ({ item, indent, da
   const onChange = useCallback(
     (startDate: DateWithoutTime | null, endDate: DateWithoutTime) => {
       let targetEndDate: Date | DateWithoutTime = endDate;
+      let targetStartDate: Date | DateWithoutTime | null = startDate;
+
+      if (item.startDateTime && startDate) {
+        targetStartDate = new Date();
+        targetStartDate.setDate(startDate.getDate());
+        targetStartDate.setMonth(startDate.getMonth());
+        targetStartDate.setFullYear(startDate.getFullYear());
+        targetStartDate.setHours(
+          item.startDateTime.getHours(),
+          item.startDateTime.getMinutes(),
+          item.startDateTime.getSeconds(),
+        );
+      }
 
       // On a drag, need to change the date, but preserve the end time if one exists.
       if (item.endDateTime) {
@@ -47,9 +60,11 @@ export const PageScheduleLine: React.FC<ScheduleLineProps> = ({ item, indent, da
         );
       }
 
-      dispatch(moveScheduleItem({ itemId: item.id, startDate, endDate: targetEndDate }));
+      dispatch(
+        moveScheduleItem({ itemId: item.id, startDate: targetStartDate, endDate: targetEndDate }),
+      );
     },
-    [dispatch, item.id, item.endDateTime],
+    [item.startDateTime, item.endDateTime, item.id, dispatch],
   );
 
   const rowClass = isSelected ? 'bg-green-50' : '';

--- a/assets/src/apps/scheduler/PageScheduleLine.tsx
+++ b/assets/src/apps/scheduler/PageScheduleLine.tsx
@@ -76,18 +76,19 @@ export const PageScheduleLine: React.FC<ScheduleLineProps> = ({ item, indent, da
 
         <td className="relative p-0">
           <ScheduleHeader labels={false} dayGeometry={dayGeometry} />
-          {item.endDate && (
-            <PageDragBar
-              onChange={onChange}
-              onStartDrag={onSelect}
-              endDate={item.endDate}
-              manual={item.manually_scheduled}
-              dayGeometry={dayGeometry}
-              isContainer={false}
-              isSingleDay={true}
-              hardSchedule={item.scheduling_type === 'due_by'}
-            />
-          )}
+
+          <PageDragBar
+            onChange={onChange}
+            onStartDrag={onSelect}
+            startDate={item.startDate}
+            endDate={item.endDate}
+            manual={item.manually_scheduled}
+            dayGeometry={dayGeometry}
+            isContainer={false}
+            isSingleDay={true}
+            isGraded={item.graded}
+            schedulingType={item.scheduling_type}
+          />
         </td>
       </tr>
     </>

--- a/assets/src/apps/scheduler/ScheduleGrid.tsx
+++ b/assets/src/apps/scheduler/ScheduleGrid.tsx
@@ -51,7 +51,38 @@ export const ScheduleGrid: React.FC<GridProps> = ({ startDate, endDate, onReset 
             ))}
           </tbody>
         </table>
+        <Legend />
       </div>
     </div>
   );
 };
+
+const LegendIconItem: React.FC<{ icon: string; text: string; color: string }> = ({
+  icon,
+  text,
+  color,
+}) => (
+  <span className="inline-flex items-center mr-4 rounded-md bg-gray-100 py-1 px-3">
+    <i className={`fa fa-${icon} mr-3 ${color}`} />
+    {text}
+  </span>
+);
+
+const LegendBarItem: React.FC = () => (
+  <span className="inline-flex items-center mr-4 rounded-md bg-gray-100 py-1 px-3">
+    <span className="inline-block rounded bg-delivery-primary-300 dark:bg-delivery-primary-600 h-5 justify-between p-0.5 cursor-move w-10 mr-3" />
+    Suggested Range
+  </span>
+);
+
+const Legend = () => (
+  <div className="flex flex-row align-middle mt-3 ">
+    <span className="mr-3 my-auto">Legend:</span>
+    <LegendBarItem />
+
+    <LegendIconItem icon="flag" text="Available Date" color="text-green-500" />
+    <LegendIconItem icon="file" text="Suggested Date" color="text-blue-500" />
+    <LegendIconItem icon="users-line" text="In Class Activity" color="text-blue-500" />
+    <LegendIconItem icon="calendar" text="Due Date" color="text-red-700" />
+  </div>
+);

--- a/assets/src/apps/scheduler/SchedulerSaveBar.tsx
+++ b/assets/src/apps/scheduler/SchedulerSaveBar.tsx
@@ -1,12 +1,5 @@
-import React, {
-  ChangeEvent,
-  ChangeEventHandler,
-  MouseEventHandler,
-  ReactNode,
-  useCallback,
-} from 'react';
+import React, { ChangeEvent, ChangeEventHandler, ReactNode, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { select } from 'slate';
 import {
   dateWithTimeLabel,
   dateWithoutTimeLabel,
@@ -115,18 +108,6 @@ const PageDetailEditor: React.FC<PageDetailEditorProps> = ({
     </FormRow>
   );
 };
-
-const SmallLinkButton: React.FC<{
-  children: ReactNode;
-  onClick: MouseEventHandler<HTMLButtonElement>;
-}> = ({ children, onClick }) => (
-  <button
-    onClick={onClick}
-    className="text-xs text-delivery-primary-700 hover:text-delivery-primary-500"
-  >
-    {children}
-  </button>
-);
 
 const FormRow: React.FC<{ children: ReactNode }> = ({ children }) => (
   <div className="flex flex-row gap-1 flex-grow-0 text-sm justify-center">{children}</div>

--- a/assets/src/apps/scheduler/SchedulerSaveBar.tsx
+++ b/assets/src/apps/scheduler/SchedulerSaveBar.tsx
@@ -1,5 +1,12 @@
-import React, { ChangeEventHandler, useCallback } from 'react';
+import React, {
+  ChangeEvent,
+  ChangeEventHandler,
+  MouseEventHandler,
+  ReactNode,
+  useCallback,
+} from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { select } from 'slate';
 import {
   dateWithTimeLabel,
   dateWithoutTimeLabel,
@@ -24,6 +31,7 @@ interface PageDetailEditorProps {
   onChangeTypeHandler: ChangeEventHandler<HTMLSelectElement>;
   onChangeEndHandler: ChangeEventHandler<HTMLInputElement>;
   onChangeDueEndHandler: ChangeEventHandler<HTMLInputElement>;
+  onChangeAvailableFromHandler: (event: ChangeEvent<HTMLInputElement> | null) => void;
 }
 
 const DateRangeView: React.FC<{ selectedItem: HierarchyItem | undefined | null }> = ({
@@ -49,46 +57,102 @@ const PageDetailEditor: React.FC<PageDetailEditorProps> = ({
   onChangeTypeHandler,
   onChangeEndHandler,
   onChangeDueEndHandler,
+  onChangeAvailableFromHandler,
 }) => {
   if (!selectedItem) return null;
-  return (
-    <div className="flex flex-row gap-1 flex-grow-0  ">
-      <div className="text-ellipsis text-sm overflow-hidden whitespace-nowrap text-right pt-3 mr-2">
-        {selectedItem.title}:
-      </div>
-      <div className="w-52 pt-0.5">
-        <select
-          className="form-control text-sm"
-          value={selectedItem.scheduling_type}
-          onChange={onChangeTypeHandler}
-        >
-          <option value="read_by">Suggested by:</option>
-          <option value="inclass_activity">In-Class Activity On:</option>
-          <option value="due_by">Due By:</option>
-        </select>
-      </div>
-      <div className="w-52 pt-0.5">
-        {selectedItem.scheduling_type === 'due_by' || (
-          <input
-            className="form-control text-sm"
-            type="date"
-            onChange={onChangeEndHandler}
-            value={dateWithoutTimeLabel(selectedItem.endDate) || ''}
-          />
-        )}
 
-        {selectedItem.scheduling_type === 'due_by' && (
-          <input
-            className="form-control text-sm"
-            type="datetime-local"
-            onChange={onChangeDueEndHandler}
-            value={dateWithTimeLabel(selectedItem.endDateTime) || ''}
-          />
+  return (
+    <FormRow>
+      <ItemTitle>{selectedItem.title}:</ItemTitle>
+
+      <InputColumn>
+        {selectedItem.graded && (
+          <InputRow>
+            <InputLabel>Available From:</InputLabel>
+            <InputField>
+              <input
+                className="form-control text-sm"
+                type="datetime-local"
+                onChange={onChangeAvailableFromHandler}
+                value={dateWithTimeLabel(selectedItem.startDateTime) || ''}
+              />
+            </InputField>
+          </InputRow>
         )}
-      </div>
-    </div>
+        <InputRow>
+          <InputLabel>
+            <select
+              className="form-control text-sm"
+              value={selectedItem.scheduling_type}
+              onChange={onChangeTypeHandler}
+            >
+              <option value="read_by">Suggested by:</option>
+              <option value="inclass_activity">In-Class Activity On:</option>
+              <option value="due_by">Due By:</option>
+            </select>
+          </InputLabel>
+          <InputField>
+            {selectedItem.scheduling_type === 'due_by' || (
+              <input
+                className="form-control text-sm"
+                type="date"
+                onChange={onChangeEndHandler}
+                value={dateWithoutTimeLabel(selectedItem.endDate) || ''}
+              />
+            )}
+
+            {selectedItem.scheduling_type === 'due_by' && (
+              <input
+                className="form-control text-sm"
+                type="datetime-local"
+                onChange={onChangeDueEndHandler}
+                value={dateWithTimeLabel(selectedItem.endDateTime) || ''}
+              />
+            )}
+          </InputField>
+        </InputRow>
+      </InputColumn>
+    </FormRow>
   );
 };
+
+const SmallLinkButton: React.FC<{
+  children: ReactNode;
+  onClick: MouseEventHandler<HTMLButtonElement>;
+}> = ({ children, onClick }) => (
+  <button
+    onClick={onClick}
+    className="text-xs text-delivery-primary-700 hover:text-delivery-primary-500"
+  >
+    {children}
+  </button>
+);
+
+const FormRow: React.FC<{ children: ReactNode }> = ({ children }) => (
+  <div className="flex flex-row gap-1 flex-grow-0 text-sm justify-center">{children}</div>
+);
+
+const InputColumn: React.FC<{ children: ReactNode }> = ({ children }) => (
+  <div className="flex flex-col gap-1 flex-grow-0 my-auto">{children}</div>
+);
+
+const ItemTitle: React.FC<{ children: ReactNode }> = ({ children }) => (
+  <div className="text-ellipsis text-sm overflow-hidden whitespace-nowrap text-right mr-5 w-40 my-auto font-bold">
+    {children}
+  </div>
+);
+
+const InputRow: React.FC<{ children: ReactNode }> = ({ children }) => (
+  <div className="flex flex-row gap-1 flex-grow-0  ">{children}</div>
+);
+
+const InputLabel: React.FC<{ children: ReactNode }> = ({ children }) => (
+  <div className="w-40 pt-0.5">{children}</div>
+);
+
+const InputField: React.FC<{ children: ReactNode }> = ({ children }) => (
+  <div className="pt-0.5">{children}</div>
+);
 
 export const ScheduleSaveBar: React.FC<SaveIndicatorProps> = ({ onSave }) => {
   const unsavedChanges = useSelector(hasUnsavedChanges);
@@ -117,8 +181,24 @@ export const ScheduleSaveBar: React.FC<SaveIndicatorProps> = ({ onSave }) => {
       dispatch(
         moveScheduleItem({
           itemId: selectedItem.id,
-          startDate: selectedItem.startDate,
+          startDate: selectedItem.startDateTime || selectedItem.startDate,
           endDate: target,
+        }),
+      );
+    },
+    [dispatch, selectedItem],
+  );
+
+  const onChangeAvailableFromHandler = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const newDate = e.target.value;
+      const target = newDate ? stringToDateWithTime(newDate) : null;
+      if (!selectedItem) return;
+      dispatch(
+        moveScheduleItem({
+          itemId: selectedItem.id,
+          startDate: target,
+          endDate: selectedItem.endDateTime || selectedItem.endDate,
         }),
       );
     },
@@ -134,7 +214,7 @@ export const ScheduleSaveBar: React.FC<SaveIndicatorProps> = ({ onSave }) => {
       dispatch(
         moveScheduleItem({
           itemId: selectedItem.id,
-          startDate: selectedItem.startDate,
+          startDate: selectedItem.startDateTime || selectedItem.startDate,
           endDate: target,
         }),
       );
@@ -144,13 +224,14 @@ export const ScheduleSaveBar: React.FC<SaveIndicatorProps> = ({ onSave }) => {
   const pageIsSelected = selectedItem && selectedItem.resource_type_id === ScheduleItemType.Page;
   if (!unsavedChanges && !saving && !pageIsSelected) return null;
   return (
-    <div className="fixed p-4 bottom-0 left-0 z-50 bg-body w-full flex border-t-gray-300 border-t h-20 dark:bg-slate-800">
+    <div className="fixed p-4 pt-3 bottom-0 left-0 z-50 bg-body w-full flex border-t-gray-300 border-t h-24 dark:bg-slate-800">
       {pageIsSelected || <DateRangeView selectedItem={selectedItem} />}
       {pageIsSelected && (
         <PageDetailEditor
           onChangeDueEndHandler={onChangeDueEndHandler}
           onChangeEndHandler={onChangeEndHandler}
           onChangeTypeHandler={onChangeTypeHandler}
+          onChangeAvailableFromHandler={onChangeAvailableFromHandler}
           selectedItem={selectedItem}
         />
       )}
@@ -175,7 +256,7 @@ export const ScheduleSaveBar: React.FC<SaveIndicatorProps> = ({ onSave }) => {
               You have unsaved changes
             </div>
             <button
-              className="bg-delivery-primary px-5 py-3 text-delivery-body rounded-md text-ellipsis overflow-hidden whitespace-nowrap"
+              className="bg-delivery-primary px-5 py-3 text-delivery-body rounded-md text-ellipsis overflow-hidden whitespace-nowrap h-12"
               onClick={onSave}
             >
               Save Changes

--- a/assets/src/apps/scheduler/SchedulerSaveBar.tsx
+++ b/assets/src/apps/scheduler/SchedulerSaveBar.tsx
@@ -178,6 +178,7 @@ export const ScheduleSaveBar: React.FC<SaveIndicatorProps> = ({ onSave }) => {
       const newDate = e.target.value;
       const target = newDate ? stringToDateWithoutTime(newDate) : null;
       if (!selectedItem) return;
+
       dispatch(
         moveScheduleItem({
           itemId: selectedItem.id,

--- a/assets/src/apps/scheduler/SchedulerSaveBar.tsx
+++ b/assets/src/apps/scheduler/SchedulerSaveBar.tsx
@@ -159,6 +159,7 @@ export const ScheduleSaveBar: React.FC<SaveIndicatorProps> = ({ onSave }) => {
   const selectedItem = useSelector(getSelectedItem);
   const saving = useSelector(isSaving);
   const dispatch = useDispatch();
+
   const onChangeTypeHandler = useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => {
       if (!selectedItem) return;

--- a/assets/src/apps/scheduler/date-utils.tsx
+++ b/assets/src/apps/scheduler/date-utils.tsx
@@ -203,6 +203,20 @@ export const dateWithoutTimeShortLabel = (d: DateWithoutTime | null) => {
   return `${d.getMonth() + 1}/${d.getDate()}`;
 };
 
+/* Makes sure the start is before the end date. */
+export const validateStartEndDates = (
+  start: DateWithoutTime | null,
+  end: DateWithoutTime | null,
+) => {
+  if (!start || !end) {
+    return [start, end];
+  }
+  if (start.getDaysSinceEpoch() > end.getDaysSinceEpoch()) {
+    return [end, start];
+  }
+  return [start, end];
+};
+
 export const DateWithoutTimeLabel: React.FC<{ date: DateWithoutTime }> = ({ date }) => {
   return <span>{dateWithoutTimeLabel(date)}</span>;
 };

--- a/assets/src/apps/scheduler/date-utils.tsx
+++ b/assets/src/apps/scheduler/date-utils.tsx
@@ -207,6 +207,12 @@ export const DateWithoutTimeLabel: React.FC<{ date: DateWithoutTime }> = ({ date
   return <span>{dateWithoutTimeLabel(date)}</span>;
 };
 
+export const toDateWithoutTime = (date: Date | DateWithoutTime | null): DateWithoutTime | null => {
+  if (!date) return null;
+  if (date instanceof DateWithoutTime) return date;
+  return new DateWithoutTime(date.getFullYear(), date.getMonth(), date.getDate());
+};
+
 export const stringToDateWithTime = (s: string): Date => {
   const parts = s.split('T');
   if (parts.length !== 2) throw new Error(`Invalid date string: ${s}`);

--- a/assets/src/apps/scheduler/schedule-reset.ts
+++ b/assets/src/apps/scheduler/schedule-reset.ts
@@ -147,6 +147,20 @@ export const resetScheduleItem = (
         child.startDate = new DateWithoutTime(end.getDaysSinceEpoch());
       }
 
+      if (child.startDate) {
+        child.startDateTime = new Date(
+          child.startDate.getFullYear(),
+          child.startDate.getMonth(),
+          child.startDate.getDate(),
+          23,
+          59,
+          59,
+          999,
+        );
+      } else {
+        child.startDateTime = null;
+      }
+
       child.endDateTime = new Date(
         child.endDate.getFullYear(),
         child.endDate.getMonth(),

--- a/assets/src/apps/scheduler/scheduling-thunk.ts
+++ b/assets/src/apps/scheduler/scheduling-thunk.ts
@@ -27,7 +27,9 @@ export const scheduleAppFlushChanges = createAsyncThunk(
         const item = getScheduleItem(id, schedule);
         if (!item) return null;
         return {
-          start_date: dateWithoutTimeLabel(item.startDate),
+          start_date: item.graded
+            ? dateTimeInTorusFormat(item.startDateTime)
+            : dateWithoutTimeLabel(item.startDate),
           end_date:
             item.scheduling_type === 'due_by'
               ? dateTimeInTorusFormat(item.endDateTime) // For due-by we need the time as well as the date.

--- a/assets/test/scheduler/schedule-reset_test.ts
+++ b/assets/test/scheduler/schedule-reset_test.ts
@@ -16,6 +16,7 @@ const hierarchItemTemplate: HierarchyItem = {
   startDate: null,
   endDate: null,
   endDateTime: null,
+  startDateTime: null,
   children: [],
   end_date: '',
   start_date: '',

--- a/lib/oli_web/controllers/api/scheduling_controller.ex
+++ b/lib/oli_web/controllers/api/scheduling_controller.ex
@@ -203,7 +203,13 @@ defmodule OliWeb.Api.SchedulingController do
       "children" => sr.children,
       "resource_type_id" => sr.resource_type_id,
       "graded" => sr.graded,
-      "start_date" => sr.start_date |> just_date.(),
+      "start_date" =>
+          if sr.graded do
+            # Using start_date as the availablility date for graded items
+            sr.start_date
+          else
+            sr.start_date |> just_date.()
+          end,
       "end_date" =>
         if sr.scheduling_type == :due_by do
           sr.end_date


### PR DESCRIPTION
This PR adds the ability to set the availability date for assessments in the graphical scheduler interface. If an assessment has both an availability date, and a Due or Suggested by date, a graphical representation of the span will also appear.

Also changed some icons & colors and added a legend to help make the visual display more understandable.

![schedbar](https://github.com/Simon-Initiative/oli-torus/assets/333265/6c77dedc-edaa-4e70-bf76-7f461cbf9763)
