### PR TITLE
[Feature] Insert menu redesign [MER-1418]

### DIFF
--- a/assets/src/components/editing/elements/audio/audioActions.tsx
+++ b/assets/src/components/editing/elements/audio/audioActions.tsx
@@ -58,6 +58,7 @@ export const insertAudio = (onRequestMedia: any) =>
   createButtonCommandDesc({
     icon: <i className="fa-solid fa-music"></i>,
     description: 'Audio Clip',
+    category: 'Media',
 
     execute: (context, editor: Editor) => {
       const at = editor.selection as any;

--- a/assets/src/components/editing/elements/blockcode/codeblockActions.tsx
+++ b/assets/src/components/editing/elements/blockcode/codeblockActions.tsx
@@ -12,6 +12,7 @@ const ui = {
 
 export const insertCodeblock = createButtonCommandDesc({
   ...ui,
+  category: 'STEM',
   execute: (_context, editor) => {
     if (!editor.selection) return;
     Transforms.insertNodes(editor, Model.code(), { at: editor.selection });
@@ -21,6 +22,7 @@ export const insertCodeblock = createButtonCommandDesc({
 
 export const toggleCodeblock = createButtonCommandDesc({
   ...ui,
+  category: 'STEM',
   active: (editor) => isActive(editor, 'code'),
   execute: (_ctx, editor) => switchType(editor, 'code'),
 });

--- a/assets/src/components/editing/elements/callout/calloutActions.tsx
+++ b/assets/src/components/editing/elements/callout/calloutActions.tsx
@@ -7,6 +7,7 @@ import { insideSemanticElement } from '../utils';
 export const insertCallout = createButtonCommandDesc({
   icon: <i className="fa-solid fa-bullhorn"></i>,
   description: 'Callout',
+  category: 'General',
   execute: (_context, editor) => {
     const at = editor.selection;
     if (!at) return;
@@ -19,6 +20,7 @@ export const insertCallout = createButtonCommandDesc({
 export const insertInlineCallout = createButtonCommandDesc({
   icon: <i className="fa-solid fa-bullhorn"></i>,
   description: 'Callout',
+  category: 'General',
   execute: (_context, editor) => {
     const at = editor.selection;
     if (!at) return;

--- a/assets/src/components/editing/elements/cite/CiteCmd.tsx
+++ b/assets/src/components/editing/elements/cite/CiteCmd.tsx
@@ -63,7 +63,7 @@ const command: Command = {
 
 export const citationCmdDesc: CommandDescription = {
   type: 'CommandDesc',
-  category: 'Language',
+  category: 'General',
   icon: () => <i className="fa-solid fa-book"></i>,
   description: () => 'Cite',
   command,

--- a/assets/src/components/editing/elements/cite/CiteCmd.tsx
+++ b/assets/src/components/editing/elements/cite/CiteCmd.tsx
@@ -63,6 +63,7 @@ const command: Command = {
 
 export const citationCmdDesc: CommandDescription = {
   type: 'CommandDesc',
+  category: 'Language',
   icon: () => <i className="fa-solid fa-book"></i>,
   description: () => 'Cite',
   command,

--- a/assets/src/components/editing/elements/command_button/commandButtonActions.tsx
+++ b/assets/src/components/editing/elements/command_button/commandButtonActions.tsx
@@ -7,6 +7,7 @@ import { createButtonCommandDesc } from '../commands/commandFactories';
 export const insertCommandButton = createButtonCommandDesc({
   icon: <i className="fa-solid fa-wand-magic-sparkles"></i>,
   description: 'Command Button',
+  category: 'General',
   execute: (_context, editor, _params) => {
     const selection = editor.selection;
     if (!selection) return;

--- a/assets/src/components/editing/elements/commands/commandFactories.ts
+++ b/assets/src/components/editing/elements/commands/commandFactories.ts
@@ -1,10 +1,11 @@
 import { Editor } from 'slate';
 import { Mark } from 'data/content/model/text';
-import { Command, CommandDescription } from './interfaces';
+import { Command, CommandCategories, CommandDescription } from './interfaces';
 
 interface CommandWrapperProps {
   icon?: JSX.Element;
   description: string;
+  category?: CommandCategories;
   execute: Command['execute'];
   mark?: Mark;
   active?: CommandDescription['active'];
@@ -20,10 +21,12 @@ function createCommandDesc({
   description,
   execute,
   active,
+  category,
   precondition,
 }: CommandWrapperProps): CommandDescription {
   return {
     type: 'CommandDesc',
+    category,
     icon: () => icon,
     description: () => description,
     ...(active ? { active } : {}),

--- a/assets/src/components/editing/elements/commands/interfaces.ts
+++ b/assets/src/components/editing/elements/commands/interfaces.ts
@@ -3,11 +3,72 @@ import { MultiInput, MultiInputType } from 'components/activities/multi_input/sc
 import { InputRef } from 'data/content/model/elements/types';
 import { ID } from 'data/content/model/other';
 
+export type CommandCategories =
+  | 'Media'
+  | 'Language'
+  | 'STEM'
+  | 'General'
+  | 'Formatting'
+  | 'Structure'
+  | 'Other';
+
+// Media:
+// insertImage
+// insertYoutube
+// insertVideo
+// insertAudio
+// insertWebpage
+
+// Language:
+// insertDefinition
+// insertDialog
+// insertConjugation
+
+// STEM:
+// insertFormula
+// insertCodeblock
+// insertFigure
+
+// General:
+// insertTable
+// insertCallout
+// insertPageLink
+// insertDescriptionListCommand
+
+// ---- inline:
+
+// Formatting:
+// underLineDesc,
+// strikethroughDesc,
+// deemphasisDesc,
+// subscriptDesc,
+// doublesubscriptDesc,
+// superscriptDesc,
+
+// Language:
+// termDesc,
+// citationCmdDesc,
+// insertForeign,
+
+// Media:
+//insertImageInline,
+//insertPopup,
+
+// STEM:
+//insertInlineFormula,
+// insertInlineCodeblock,
+
+// General:
+// Link
+//insertInlineCallout,
+//insertCommandButton,
+
 // For toolbar buttons
 export type CommandDescription = {
   type: 'CommandDesc';
   icon: (editor: Editor) => JSX.Element | undefined;
   command: Command;
+  category?: CommandCategories;
   description: (editor: Editor) => string;
   // active: is the item in the cursor's selection
   active?: (editor: Editor) => boolean;

--- a/assets/src/components/editing/elements/commands/interfaces.ts
+++ b/assets/src/components/editing/elements/commands/interfaces.ts
@@ -3,65 +3,17 @@ import { MultiInput, MultiInputType } from 'components/activities/multi_input/sc
 import { InputRef } from 'data/content/model/elements/types';
 import { ID } from 'data/content/model/other';
 
-export type CommandCategories =
-  | 'Media'
-  | 'Language'
-  | 'STEM'
-  | 'General'
-  | 'Formatting'
-  | 'Structure'
-  | 'Other';
+export const CommandCategoryList = [
+  'Formatting',
+  'Media',
+  'STEM',
+  'General',
+  'Language',
+  'Structure',
+  'Other',
+];
 
-// Media:
-// insertImage
-// insertYoutube
-// insertVideo
-// insertAudio
-// insertWebpage
-
-// Language:
-// insertDefinition
-// insertDialog
-// insertConjugation
-
-// STEM:
-// insertFormula
-// insertCodeblock
-// insertFigure
-
-// General:
-// insertTable
-// insertCallout
-// insertPageLink
-// insertDescriptionListCommand
-
-// ---- inline:
-
-// Formatting:
-// underLineDesc,
-// strikethroughDesc,
-// deemphasisDesc,
-// subscriptDesc,
-// doublesubscriptDesc,
-// superscriptDesc,
-
-// Language:
-// termDesc,
-// citationCmdDesc,
-// insertForeign,
-
-// Media:
-//insertImageInline,
-//insertPopup,
-
-// STEM:
-//insertInlineFormula,
-// insertInlineCodeblock,
-
-// General:
-// Link
-//insertInlineCallout,
-//insertCommandButton,
+export type CommandCategories = typeof CommandCategoryList[number];
 
 // For toolbar buttons
 export type CommandDescription = {

--- a/assets/src/components/editing/elements/conjugation/conjugationActions.tsx
+++ b/assets/src/components/editing/elements/conjugation/conjugationActions.tsx
@@ -6,6 +6,7 @@ import { createButtonCommandDesc } from '../commands/commandFactories';
 export const insertConjugation = createButtonCommandDesc({
   icon: <i className="fa-solid fa-language"></i>,
   description: 'Conjugation',
+  category: 'Language',
   execute: (_context, editor) => {
     const at = editor.selection;
     if (!at) return;

--- a/assets/src/components/editing/elements/definition/definitionActions.tsx
+++ b/assets/src/components/editing/elements/definition/definitionActions.tsx
@@ -7,6 +7,7 @@ import { insideSemanticElement } from '../utils';
 export const insertDefinition = createButtonCommandDesc({
   icon: <i className="fa-solid fa-book-open"></i>,
   description: 'Definition',
+  category: 'Language',
   execute: (_context, editor) => {
     const at = editor.selection;
     if (!at) return;

--- a/assets/src/components/editing/elements/description/description-list-actions.tsx
+++ b/assets/src/components/editing/elements/description/description-list-actions.tsx
@@ -8,6 +8,7 @@ import { createButtonCommandDesc } from '../commands/commandFactories';
 export const insertDescriptionListCommand = createButtonCommandDesc({
   icon: <i className="fa-solid fa-list"></i>,
   description: 'Description List',
+  category: 'Structure',
 
   execute: (context, editor: Editor) => {
     insertDescriptionList(editor);

--- a/assets/src/components/editing/elements/description/description-list-actions.tsx
+++ b/assets/src/components/editing/elements/description/description-list-actions.tsx
@@ -8,7 +8,7 @@ import { createButtonCommandDesc } from '../commands/commandFactories';
 export const insertDescriptionListCommand = createButtonCommandDesc({
   icon: <i className="fa-solid fa-list"></i>,
   description: 'Description List',
-  category: 'Structure',
+  category: 'General',
 
   execute: (context, editor: Editor) => {
     insertDescriptionList(editor);

--- a/assets/src/components/editing/elements/dialog/dialogActions.tsx
+++ b/assets/src/components/editing/elements/dialog/dialogActions.tsx
@@ -17,6 +17,7 @@ const store = configureStore();
 
 export const insertDialog = createButtonCommandDesc({
   icon: <i className="fa-regular fa-comment-dots"></i>,
+  category: 'Language',
   description: 'Dialog',
   execute: (_context, editor) => {
     const at = editor.selection;

--- a/assets/src/components/editing/elements/ecl/actions.tsx
+++ b/assets/src/components/editing/elements/ecl/actions.tsx
@@ -11,6 +11,7 @@ const ui = {
 
 export const insertEcl = createButtonCommandDesc({
   ...ui,
+  category: 'STEM',
   execute: (_context, editor) => {
     if (!editor.selection) return;
     Transforms.insertNodes(editor, Model.ecl(), { at: editor.selection });

--- a/assets/src/components/editing/elements/figure/figureActions.tsx
+++ b/assets/src/components/editing/elements/figure/figureActions.tsx
@@ -7,6 +7,7 @@ import { insideSemanticElement } from '../utils';
 export const insertFigure = createButtonCommandDesc({
   icon: <i className="fa-solid fa-note-sticky"></i>,
   description: 'Figure',
+  category: 'STEM',
   execute: (_context, editor) => {
     const at = editor.selection;
     if (!at) return;

--- a/assets/src/components/editing/elements/foreign/foreignActions.tsx
+++ b/assets/src/components/editing/elements/foreign/foreignActions.tsx
@@ -7,6 +7,7 @@ import { isActive } from '../../slateUtils';
 export const insertForeign = createButtonCommandDesc({
   icon: <i className="fa-solid fa-language"></i>,
   description: 'Foreign',
+  category: 'General',
   execute: (_context, editor) => {
     const at = editor.selection;
     if (!at) return;

--- a/assets/src/components/editing/elements/formula/formulaActions.tsx
+++ b/assets/src/components/editing/elements/formula/formulaActions.tsx
@@ -6,6 +6,7 @@ import { Model } from 'data/content/model/elements/factories';
 export const insertFormula = createButtonCommandDesc({
   icon: <i className="fa-solid fa-square-root-variable"></i>,
   description: 'Formula',
+  category: 'STEM',
   execute: (_context, editor) => {
     const at = editor.selection;
     if (!at) return;
@@ -15,6 +16,7 @@ export const insertFormula = createButtonCommandDesc({
 });
 
 export const insertInlineFormula = createButtonCommandDesc({
+  category: 'STEM',
   icon: <i className="fa-solid fa-square-root-variable"></i>,
   description: 'Formula (Inline)',
   execute: (_context, editor) => {

--- a/assets/src/components/editing/elements/formula/formulaActions.tsx
+++ b/assets/src/components/editing/elements/formula/formulaActions.tsx
@@ -16,7 +16,7 @@ export const insertFormula = createButtonCommandDesc({
 });
 
 export const insertInlineFormula = createButtonCommandDesc({
-  category: 'STEM',
+  category: 'General',
   icon: <i className="fa-solid fa-square-root-variable"></i>,
   description: 'Formula (Inline)',
   execute: (_context, editor) => {

--- a/assets/src/components/editing/elements/heading/headingActions.tsx
+++ b/assets/src/components/editing/elements/heading/headingActions.tsx
@@ -7,6 +7,7 @@ import { getNearestBlock, isActive, isTopLevel } from 'components/editing/slateU
 
 export const toggleHeading = createButtonCommandDesc({
   icon: <i className="fa-solid fa-heading"></i>,
+  category: 'Formatting',
   description: 'Heading',
   active: (editor) => isActive(editor, ['h1', 'h2']),
   execute: (_ctx, editor) => switchType(editor, 'h2'),
@@ -31,11 +32,13 @@ const selectedType = (editor: Editor) =>
 
 export const headingTypeDescs = [
   createButtonCommandDesc({
+    category: 'Formatting',
     description: 'H1',
     active: (editor) => isActive(editor, ['h1']),
     execute: (_ctx, editor) => switchType(editor, 'h1'),
   }),
   createButtonCommandDesc({
+    category: 'Formatting',
     description: 'H2',
     active: (editor) => isActive(editor, ['h2']),
     execute: (_ctx, editor) => switchType(editor, 'h2'),
@@ -44,6 +47,7 @@ export const headingTypeDescs = [
 
 export const headingLevelDesc = (editor: Editor) =>
   createButtonCommandDesc({
+    category: 'Formatting',
     description: isActive(editor, 'h1') ? 'H1' : 'H2',
     active: (editor) => isActive(editor, ['h1', 'h2']),
     execute: () => {},
@@ -52,6 +56,7 @@ export const headingLevelDesc = (editor: Editor) =>
 export const commandDesc: CommandDescription = {
   type: 'CommandDesc',
   icon: () => <i className="fa-solid fa-heading"></i>,
+  category: 'Formatting',
   description: () => 'Title (# or ##)',
   command: {
     execute: (_context, editor) => {

--- a/assets/src/components/editing/elements/image/imageActions.tsx
+++ b/assets/src/components/editing/elements/image/imageActions.tsx
@@ -109,7 +109,7 @@ export const insertImage = (onReqMedia: any) =>
 export const insertImageInline = createButtonCommandDesc({
   icon: <i className="fa-solid fa-images"></i>,
   description: 'Image (Inline)',
-  category: 'Media',
+  category: 'General',
   execute: (context, editor) =>
     selectImage(context.projectSlug).then((selection) =>
       Maybe.maybe(selection).map((src) =>

--- a/assets/src/components/editing/elements/image/imageActions.tsx
+++ b/assets/src/components/editing/elements/image/imageActions.tsx
@@ -100,6 +100,7 @@ const execute =
 export const insertImage = (onReqMedia: any) =>
   createButtonCommandDesc({
     icon: <i className="fa-solid fa-image"></i>,
+    category: 'Media',
     description: 'Image',
     execute: execute(onReqMedia),
   });
@@ -108,6 +109,7 @@ export const insertImage = (onReqMedia: any) =>
 export const insertImageInline = createButtonCommandDesc({
   icon: <i className="fa-solid fa-images"></i>,
   description: 'Image (Inline)',
+  category: 'Media',
   execute: (context, editor) =>
     selectImage(context.projectSlug).then((selection) =>
       Maybe.maybe(selection).map((src) =>

--- a/assets/src/components/editing/elements/inputref/actions.tsx
+++ b/assets/src/components/editing/elements/inputref/actions.tsx
@@ -10,6 +10,7 @@ export const initCommands = (
 ): CommandDescription[] => {
   const makeCommand = (description: string, type: VlabInputType): CommandDescription => ({
     type: 'CommandDesc',
+    category: 'General',
     icon: () => undefined,
     description: () => description,
     active: () => model.inputType === type,

--- a/assets/src/components/editing/elements/link/LinkCmd.tsx
+++ b/assets/src/components/editing/elements/link/LinkCmd.tsx
@@ -7,6 +7,7 @@ import { createButtonCommandDesc } from '../commands/commandFactories';
 export const commandDesc = createButtonCommandDesc({
   icon: <i className="fa-solid fa-link"></i>,
   description: 'Link (⌘L)',
+  category: 'General',
   execute: (_context, editor, _params) => {
     const selection = editor.selection;
     if (!selection) return;

--- a/assets/src/components/editing/elements/list/listActions.tsx
+++ b/assets/src/components/editing/elements/list/listActions.tsx
@@ -61,6 +61,7 @@ const listCommandMaker = (listType: 'ul' | 'ol'): Command => {
 };
 
 export const toggleList = createButtonCommandDesc({
+  category: 'Structure',
   icon: <i className="fa-solid fa-list-ul"></i>,
   description: 'List',
   active: (editor) => isActive(editor, ['ul', 'ol']),
@@ -68,6 +69,7 @@ export const toggleList = createButtonCommandDesc({
 });
 
 export const toggleUnorderedList: CommandDescription = {
+  category: 'Structure',
   type: 'CommandDesc',
   icon: () => <i className="fa-solid fa-list-ul"></i>,
   description: () => 'Unordered List',
@@ -76,6 +78,7 @@ export const toggleUnorderedList: CommandDescription = {
 };
 
 export const toggleOrderedList: CommandDescription = {
+  category: 'Structure',
   type: 'CommandDesc',
   icon: () => <i className="fa-solid fa-list-ol"></i>,
   description: () => 'Ordered List',
@@ -151,6 +154,7 @@ export const listSettingButtonGroups = [
     createButtonCommandDesc({
       icon: <i className="fa-solid fa-list-ul"></i>,
       description: 'Unordered List',
+      category: 'Structure',
       active: (editor) => listTypeActive(editor, 'ul'),
       execute: (_ctx, editor) => {
         if (listTypeActive(editor, 'ul')) {
@@ -171,6 +175,7 @@ export const listSettingButtonGroups = [
     createButtonCommandDesc({
       icon: <i className="fa-solid fa-list-ol"></i>,
       description: 'Ordered List',
+      category: 'Structure',
       active: (editor) => listTypeActive(editor, 'ol'),
       execute: (_ctx, editor) => {
         if (listTypeActive(editor, 'ol')) {

--- a/assets/src/components/editing/elements/marks/toggleMarkActions.tsx
+++ b/assets/src/components/editing/elements/marks/toggleMarkActions.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Editor } from 'slate';
 import { citationCmdDesc } from 'components/editing/elements/cite/CiteCmd';
 import { createButtonCommandDesc } from 'components/editing/elements/commands/commandFactories';
-import { Command } from 'components/editing/elements/commands/interfaces';
+import { Command, CommandCategories } from 'components/editing/elements/commands/interfaces';
 import { isActive, isMarkActive } from 'components/editing/slateUtils';
 import { Mark } from 'data/content/model/text';
 
@@ -15,6 +15,7 @@ export const toggleFormat = (attrs: {
   icon: JSX.Element;
   description: string;
   mark: Mark;
+  category: CommandCategories;
   precondition?: Command['precondition'];
   execute?: Command['execute'];
 }) => {
@@ -29,24 +30,28 @@ export const toggleFormat = (attrs: {
 
 export const boldDesc = toggleFormat({
   icon: <i className="fa-solid fa-bold"></i>,
+  category: 'Formatting',
   mark: 'strong',
   description: 'Bold',
 });
 
 export const italicDesc = toggleFormat({
   icon: <i className="fa-solid fa-italic"></i>,
+  category: 'Formatting',
   mark: 'em',
   description: 'Italic',
 });
 
 export const underLineDesc = toggleFormat({
   icon: <i className="fa-solid fa-underline"></i>,
+  category: 'Formatting',
   mark: 'underline',
   description: 'Underline',
 });
 
 export const strikethroughDesc = toggleFormat({
   icon: <i className="fa-solid fa-strikethrough"></i>,
+  category: 'Formatting',
   mark: 'strikethrough',
   description: 'Strikethrough',
 });
@@ -54,6 +59,7 @@ export const strikethroughDesc = toggleFormat({
 export const subscriptDesc = toggleFormat({
   icon: <i className="fa-solid fa-subscript"></i>,
   mark: 'sub',
+  category: 'Formatting',
   description: 'Subscript',
   precondition: (editor) => !isActive(editor, ['code']),
   execute: (context, editor) => {
@@ -64,6 +70,7 @@ export const subscriptDesc = toggleFormat({
 
 export const superscriptDesc = toggleFormat({
   icon: <i className="fa-solid fa-superscript"></i>,
+  category: 'Formatting',
   mark: 'sup',
   description: 'Superscript',
   precondition: (editor) => !isActive(editor, ['code']),
@@ -71,6 +78,7 @@ export const superscriptDesc = toggleFormat({
 
 export const doublesubscriptDesc = toggleFormat({
   icon: <i className="fa-solid fa-subscript"></i>,
+  category: 'Formatting',
   mark: 'doublesub',
   description: 'Double Subscript',
   precondition: (editor) => !isActive(editor, ['code']),
@@ -82,6 +90,7 @@ export const doublesubscriptDesc = toggleFormat({
 
 export const inlineCodeDesc = toggleFormat({
   icon: <i className="fa-solid fa-code"></i>,
+  category: 'Formatting',
   mark: 'code',
   description: 'Code',
   precondition: (editor) => !isActive(editor, ['code']),
@@ -89,6 +98,7 @@ export const inlineCodeDesc = toggleFormat({
 
 export const termDesc = toggleFormat({
   icon: <i className="fa-solid fa-book-open"></i>,
+  category: 'Formatting',
   mark: 'term',
   description: 'Term',
   precondition: (editor) => !isActive(editor, ['term']),
@@ -96,6 +106,7 @@ export const termDesc = toggleFormat({
 
 export const deemphasisDesc = toggleFormat({
   icon: <i className="fa-solid fa-bold line-through"></i>,
+  category: 'Formatting',
   mark: 'deemphasis',
   description: 'Deemphasis',
   precondition: (editor) => !isActive(editor, ['term']),

--- a/assets/src/components/editing/elements/page_link/pageLinkActions.tsx
+++ b/assets/src/components/editing/elements/page_link/pageLinkActions.tsx
@@ -42,6 +42,7 @@ export function selectPage(commandContext: CommandContext): Promise<{ idref: num
 export const insertPageLink = createButtonCommandDesc({
   icon: <i className="fa-solid fa-square-up-right"></i>,
   description: 'Page Link',
+  category: 'General',
   execute: (context, editor) =>
     selectPage(context).then(({ idref }) => {
       if (idref) {

--- a/assets/src/components/editing/elements/paragraph/paragraphActions.tsx
+++ b/assets/src/components/editing/elements/paragraph/paragraphActions.tsx
@@ -9,6 +9,7 @@ import { isActive } from 'components/editing/slateUtils';
 
 export const toggleParagraph = createButtonCommandDesc({
   icon: <i className="fa-solid fa-paragraph"></i>,
+  category: 'Formatting',
   description: 'Paragraph',
   active: (editor) =>
     isActive(editor, 'p') &&

--- a/assets/src/components/editing/elements/popup/PopupCmd.tsx
+++ b/assets/src/components/editing/elements/popup/PopupCmd.tsx
@@ -7,6 +7,7 @@ import { createButtonCommandDesc } from '../commands/commandFactories';
 export const popupCmdDesc = createButtonCommandDesc({
   icon: <i className="fa-solid fa-window-restore"></i>,
   description: 'Popup Content',
+  category: 'General',
   execute: (_context, editor, _params) => {
     const selection = editor.selection;
     if (!selection) return;

--- a/assets/src/components/editing/elements/table/commands/insertTable.tsx
+++ b/assets/src/components/editing/elements/table/commands/insertTable.tsx
@@ -6,6 +6,7 @@ import { Model } from 'data/content/model/elements/factories';
 
 export const insertTable = createButtonCommandDesc({
   icon: <i className="fa-solid fa-table-cells"></i>,
+  category: 'Structure',
   description: 'Table',
   execute: (
     _context: any,

--- a/assets/src/components/editing/elements/video/videoActions.tsx
+++ b/assets/src/components/editing/elements/video/videoActions.tsx
@@ -14,6 +14,7 @@ import { VideoSource } from '../../../../data/content/model/elements/types';
 
 export const insertVideo = createButtonCommandDesc({
   icon: <i className="fa-solid fa-circle-play"></i>,
+  category: 'Media',
   description: 'Video',
   execute: (_context, editor) => {
     const at = editor.selection;

--- a/assets/src/components/editing/elements/webpage/WebpageSettings.tsx
+++ b/assets/src/components/editing/elements/webpage/WebpageSettings.tsx
@@ -52,6 +52,7 @@ const SettingsButton = (props: SettingsButtonProps) => (
   <DescriptiveButton
     description={createButtonCommandDesc({
       icon: <i className="fa-solid fa-globe"></i>,
+      category: 'Media',
       description: 'Settings',
       execute: (_context, _editor, _params) =>
         window.oliDispatch(

--- a/assets/src/components/editing/elements/webpage/webpageActions.tsx
+++ b/assets/src/components/editing/elements/webpage/webpageActions.tsx
@@ -44,6 +44,7 @@ export function selectWebpage(projectSlug: string): Promise<Webpage | null> {
 
 export const insertWebpage = createButtonCommandDesc({
   icon: <i className="fa-solid fa-globe"></i>,
+  category: 'Media',
   description: 'Webpage',
   execute: (context, editor) => {
     const at = editor.selection;

--- a/assets/src/components/editing/elements/youtube/youtubeActions.tsx
+++ b/assets/src/components/editing/elements/youtube/youtubeActions.tsx
@@ -30,6 +30,7 @@ export const youtubeUrlToId = (src?: string | null) => {
 
 export const insertYoutube = createButtonCommandDesc({
   icon: <i className="fa-brands fa-youtube"></i>,
+  category: 'Media',
   description: 'YouTube',
   execute: (_context, editor, _params) => {
     const at = editor.selection;

--- a/assets/src/components/editing/toolbar/CategorizedCommandList.tsx
+++ b/assets/src/components/editing/toolbar/CategorizedCommandList.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import {
+  CommandCategories,
+  CommandCategoryList,
+  CommandDescription,
+} from '../elements/commands/interfaces';
+import styles from './Toolbar.modules.scss';
+import { DescriptiveButton } from './buttons/DescriptiveButton';
+
+interface CategorizedCommandListProps {
+  commands: CommandDescription[];
+}
+
+// Optional label translations for the short-category names
+const labels: Record<CommandCategories, string> = {
+  Language: 'Language Learning',
+  Formatting: 'Text Formatting',
+};
+
+const categorizeCommands = (commands: CommandDescription[]) => {
+  return commands.reduce((acc: { [category: string]: CommandDescription[] }, curr) => {
+    const category = curr.category || 'Other';
+    acc[category] = [...(acc[category] || []), curr];
+    return acc;
+  }, {});
+};
+
+export const CategorizedCommandList: React.FC<CategorizedCommandListProps> = ({ commands }) => {
+  const categorizedCommands = categorizeCommands(commands);
+  return (
+    <div>
+      {CommandCategoryList.filter((category) => !!categorizedCommands[category]).map(
+        (category, i) => (
+          <CommandCategory key={i} category={category} commands={categorizedCommands[category]} />
+        ),
+      )}
+    </div>
+  );
+};
+
+interface CommandCategoryProps {
+  category: string;
+  commands: CommandDescription[];
+}
+
+const CommandCategory: React.FC<CommandCategoryProps> = ({ category, commands }) => {
+  return (
+    <div>
+      <div className={styles.toolbarLabel}>{labels[category] || category}:</div>
+      {commands.map((command, i) => (
+        <DescriptiveButton key={i} description={command} />
+      ))}
+    </div>
+  );
+};

--- a/assets/src/components/editing/toolbar/Toolbar.modules.scss
+++ b/assets/src/components/editing/toolbar/Toolbar.modules.scss
@@ -63,6 +63,9 @@
   }
 }
 
+.toolbarLabel {
+  color: #6b7281;
+}
 .toolbarButton {
   display: flex;
   flex-direction: row;
@@ -113,6 +116,7 @@
   text-align: center;
 }
 
+.categorizedDropdownGroup,
 .multiDropdownGroup {
   width: 580px;
   display: flex;
@@ -135,6 +139,13 @@
       margin-right: 0px;
       border-radius: 6px;
     }
+  }
+}
+
+.categorizedDropdownGroup {
+  width: 760px;
+  .toolbarButton {
+    padding: 4px;
   }
 }
 
@@ -177,6 +188,7 @@
     }
   }
 
+  .toolbarLabel,
   .toolbarButton {
     color: #dee2f2;
   }

--- a/assets/src/components/editing/toolbar/buttons/DropdownButton.tsx
+++ b/assets/src/components/editing/toolbar/buttons/DropdownButton.tsx
@@ -30,13 +30,20 @@ export const DropdownButton = (props: PropsWithChildren<Props>) => {
     [toolbar, thisDropdown],
   );
 
+  const isCategorizedList =
+    props.children && (props.children as any).type?.name === 'CategorizedCommandList';
+
   const multiColumn =
     props.children &&
     // eslint-disable-next-line no-prototype-builtins
     (props.children as any).hasOwnProperty('length') &&
     (props.children as { length: number }).length > 6;
 
-  const classname = multiColumn ? styles.multiDropdownGroup : styles.dropdownGroup;
+  const classname = isCategorizedList
+    ? styles.categorizedDropdownGroup
+    : multiColumn
+    ? styles.multiDropdownGroup
+    : styles.dropdownGroup;
 
   return (
     <Popover
@@ -49,7 +56,9 @@ export const DropdownButton = (props: PropsWithChildren<Props>) => {
       align={'start'}
       containerStyle={{ zIndex: '100000' }}
       content={
-        <div className={`${classname} bg-body dark:bg-body-dark text-body dark:text-body-dark `}>
+        <div
+          className={`${classname} bg-body dark:bg-body-dark text-body-800 dark:text-body-dark-100 `}
+        >
           {props.children}
         </div>
       }

--- a/assets/src/components/editing/toolbar/editorToolbar/EditorSettingsMenu.tsx
+++ b/assets/src/components/editing/toolbar/editorToolbar/EditorSettingsMenu.tsx
@@ -6,7 +6,7 @@ import { Icon } from 'components/misc/Icon';
 import { classNames } from 'utils/classNames';
 import styles from '../Toolbar.modules.scss';
 
-export const insertItemDropdown = createButtonCommandDesc({
+export const editorSettingsDropdown = createButtonCommandDesc({
   icon: <Icon icon="gear" />,
   description: 'Editor Settings',
   execute: () => {},
@@ -19,7 +19,7 @@ interface Props {
 export const EditorSettingsMenu = ({ onSwitchToMarkdown }: Props) => {
   return (
     <Toolbar.Group>
-      <DropdownButton description={insertItemDropdown} showDropdownArrow={false}>
+      <DropdownButton description={editorSettingsDropdown} showDropdownArrow={false}>
         <button
           onClick={onSwitchToMarkdown}
           className={classNames(styles.toolbarButton, styles.descriptive)}

--- a/assets/src/components/editing/toolbar/editorToolbar/Inlines.tsx
+++ b/assets/src/components/editing/toolbar/editorToolbar/Inlines.tsx
@@ -11,12 +11,12 @@ import {
 import { popupCmdDesc as insertPopup } from 'components/editing/elements/popup/PopupCmd';
 import { Toolbar } from 'components/editing/toolbar/Toolbar';
 import { CommandButton } from 'components/editing/toolbar/buttons/CommandButton';
-import { DescriptiveButton } from 'components/editing/toolbar/buttons/DescriptiveButton';
 import { DropdownButton } from 'components/editing/toolbar/buttons/DropdownButton';
 import { insertInlineCallout } from '../../elements/callout/calloutActions';
 import { insertCommandButton } from '../../elements/command_button/commandButtonActions';
 import { insertForeign } from '../../elements/foreign/foreignActions';
 import { insertInlineFormula } from '../../elements/formula/formulaActions';
+import { CategorizedCommandList } from '../CategorizedCommandList';
 
 interface Props {}
 export const Inlines = (_props: Props) => {
@@ -45,9 +45,7 @@ export const Inlines = (_props: Props) => {
     <Toolbar.Group>
       {basicFormattingOptions}
       <DropdownButton description={seeMoreInlineOptions} showDropdownArrow={false}>
-        {moreInlineOptions.map((desc, i) => (
-          <DescriptiveButton key={i} description={desc} />
-        ))}
+        <CategorizedCommandList commands={moreInlineOptions} />
       </DropdownButton>
     </Toolbar.Group>
   );

--- a/assets/src/components/editing/toolbar/editorToolbar/blocks/BlockInsertMenu.tsx
+++ b/assets/src/components/editing/toolbar/editorToolbar/blocks/BlockInsertMenu.tsx
@@ -3,8 +3,8 @@ import { useSlate } from 'slate-react';
 import { createButtonCommandDesc } from 'components/editing/elements/commands/commandFactories';
 import { CommandDescription } from 'components/editing/elements/commands/interfaces';
 import { Toolbar } from 'components/editing/toolbar/Toolbar';
-import { DescriptiveButton } from 'components/editing/toolbar/buttons/DescriptiveButton';
 import { DropdownButton } from 'components/editing/toolbar/buttons/DropdownButton';
+import { CategorizedCommandList } from '../../CategorizedCommandList';
 import { CommandButton } from '../../buttons/CommandButton';
 
 export const insertItemDropdown = createButtonCommandDesc({
@@ -32,9 +32,7 @@ export const BlockInsertMenu = ({ blockInsertOptions }: Props) => {
       ))}
       {remainingInsertOptions.length > 0 && (
         <DropdownButton description={insertItemDropdown} showDropdownArrow={false}>
-          {remainingInsertOptions.map((desc, i) => (
-            <DescriptiveButton key={i} description={desc} />
-          ))}
+          <CategorizedCommandList commands={remainingInsertOptions} />
         </DropdownButton>
       )}
     </Toolbar.Group>

--- a/assets/src/components/editing/toolbar/editorToolbar/blocks/BlockSettings.tsx
+++ b/assets/src/components/editing/toolbar/editorToolbar/blocks/BlockSettings.tsx
@@ -86,6 +86,7 @@ function CodeBlock() {
   const switchLanguage = (prettyName: string) =>
     createButtonCommandDesc({
       icon: <i className="fa-solid fa-laptop-code"></i>,
+      category: 'STEM',
       description: prettyName,
       active: (editor) => {
         const topLevel = getHighestTopLevel(editor).valueOr<any>(undefined);

--- a/assets/src/components/editing/toolbar/items.tsx
+++ b/assets/src/components/editing/toolbar/items.tsx
@@ -48,7 +48,17 @@ export const addItemActions = (onRequestMedia: any) => [
 ];
 
 export const formatMenuCommands = [
-  toggleFormat({ icon: <i className="fa-solid fa-bold"></i>, mark: 'strong', description: 'Bold' }),
-  toggleFormat({ icon: <i className="fa-solid fa-italic"></i>, mark: 'em', description: 'Italic' }),
+  toggleFormat({
+    category: 'Formatting',
+    icon: <i className="fa-solid fa-bold"></i>,
+    mark: 'strong',
+    description: 'Bold',
+  }),
+  toggleFormat({
+    category: 'Formatting',
+    icon: <i className="fa-solid fa-italic"></i>,
+    mark: 'em',
+    description: 'Italic',
+  }),
   linkCmd,
 ];

--- a/assets/src/components/resource/editors/useBlueprints.tsx
+++ b/assets/src/components/resource/editors/useBlueprints.tsx
@@ -5,6 +5,7 @@ import guid from 'utils/guid';
 import { ModelTypes } from '../../../data/content/model/elements/types';
 import {
   Command,
+  CommandCategories,
   CommandContext,
   CommandDescription,
 } from '../../editing/elements/commands/interfaces';
@@ -12,6 +13,7 @@ import {
 interface Blueprint {
   name: string;
   description: string;
+  category: CommandCategories;
   content: {
     blueprint: any[];
   };
@@ -72,6 +74,7 @@ const createBlueprintCommand = (blueprint: Blueprint): Command => {
 
 const blueprintToCommand = (blueprint: Blueprint): CommandDescription => ({
   type: 'CommandDesc',
+  category: blueprint.category,
   icon: () => <i className={blueprint.icon}></i>,
   command: createBlueprintCommand(blueprint),
   description: () => blueprint.name,

--- a/lib/oli/authoring/editing/blueprint.ex
+++ b/lib/oli/authoring/editing/blueprint.ex
@@ -8,6 +8,7 @@ defmodule Oli.Authoring.Editing.Blueprint do
     field :description, :string
     field :icon, :string
     field :content, :map, default: %{}
+    field :category, :string, default: "STEM"
   end
 
   def changeset(blueprint, attrs \\ %{}) do

--- a/lib/oli_web/controllers/api/blueprint_controller.ex
+++ b/lib/oli_web/controllers/api/blueprint_controller.ex
@@ -64,7 +64,8 @@ defmodule OliWeb.Api.BlueprintController do
       name: blueprint.name,
       description: blueprint.description,
       content: blueprint.content,
-      icon: blueprint.icon
+      icon: blueprint.icon,
+      category: blueprint.category
     }
   end
 end

--- a/priv/repo/migrations/20221020142919_add_blueprint_table.exs
+++ b/priv/repo/migrations/20221020142919_add_blueprint_table.exs
@@ -6,10 +6,10 @@ defmodule Oli.Repo.Migrations.AddBlueprintTable do
 
   def change do
     create table(:blueprints) do
-      add :name, :string, size: 64, null: false
-      add :description, :string, null: false
-      add :content, :map, null: false
-      add :icon, :string, null: false
+      add(:name, :string, size: 64, null: false)
+      add(:description, :string, null: false)
+      add(:content, :map, null: false)
+      add(:icon, :string, null: false)
       timestamps(type: :timestamptz)
     end
 
@@ -26,14 +26,10 @@ defmodule Oli.Repo.Migrations.AddBlueprintTable do
         "{\"blueprint\":[{\"id\":\"\",\"children\":[{\"text\":\"Theorem Title\"}],\"type\":\"h4\"},{\"id\":\"\",\"children\":[{\"text\":\"Statement\"}],\"type\":\"h5\"},{\"id\":\"\",\"children\":[{\"text\":\"Enter a statement here\"}],\"type\":\"p\"},{\"id\":\"\",\"children\":[{\"text\":\"Proof\"}],\"type\":\"h5\"},{\"id\":\"\",\"children\":[{\"text\":\"Enter the proof here\"}],\"type\":\"p\"}]}"
       )
 
-    changeset =
-      Blueprint.changeset(%Blueprint{}, %{
-        name: "Theorem",
-        description: "A theorem is a statement that can be proven true.",
-        content: theorem_blueprint,
-        icon: "rate_review"
-      })
+    insert_statement =
+      "insert into blueprints (name, description, content, icon, inserted_at, updated_at)
+       values ('Theorem', 'A theorem is a statement that can be proven true.', $1, 'rate_review', now(), now());"
 
-    {:ok, _} = Repo.insert(changeset)
+    {:ok, _} = Ecto.Adapters.SQL.query(Repo, insert_statement, [theorem_blueprint])
   end
 end

--- a/priv/repo/migrations/20230915131050_add_blueprint_category.exs
+++ b/priv/repo/migrations/20230915131050_add_blueprint_category.exs
@@ -1,0 +1,9 @@
+defmodule Oli.Repo.Migrations.AddBlueprintCategory do
+  use Ecto.Migration
+
+  def change do
+    alter table(:blueprints) do
+      add :category, :string, default: "STEM"
+    end
+  end
+end


### PR DESCRIPTION
This is a minor design change to the insert menus in the editor to help categorize the contents of those menus and make them easier to find what you're looking for.

The inline-formatting menu was tough to categorize. I had a few tries that ended up with some categories only having a single entry, which was clearly not helpful. I settled on the single Text-Formatting and everything else going under General, but would be happy to consider other options if there are better ideas.

Block insert before:

![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/aadbef37-58c3-432c-8e48-66204c698836)

Block insert after:

![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/fd4b2227-82c0-46c8-9b48-016069472843)


Inline before:

![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/c6069d94-de5d-4532-a97b-23195120c90d)

Inline After:

![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/fb0d6bc6-9c79-47ca-927d-055c73d9d383)
