### PR TITLE
fix a typo in the download_codes route

### DIFF
--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -350,7 +350,7 @@ defmodule OliWeb.Router do
     )
 
     get(
-      "/products/:product_id/payments/donwload_codes",
+      "/products/:product_id/payments/download_codes",
       PaymentController,
       :download_payment_codes
     )


### PR DESCRIPTION
Fixes a typo in the download_codes route. This functionally works because routes in phoenix are typically based off the function atom which is spelled correctly. This just fixes the spelling for the actual route itself.