### PR TITLE
[BUGFIX][MER-2572] Fix section overview crashing

### DIFF
--- a/lib/oli_web/common/session_context.ex
+++ b/lib/oli_web/common/session_context.ex
@@ -57,13 +57,22 @@ defmodule OliWeb.Common.SessionContext do
 
   @doc """
   Initialize a SessionContext struct from a Plug.Conn struct. User or Author structs are loaded
-  from the current assigns (previously loaded by set_user plug)
+  from the account lookup cache.
   """
   def init(%Plug.Conn{assigns: assigns} = conn) do
     browser_timezone = Plug.Conn.get_session(conn, "browser_timezone")
 
-    author = Map.get(assigns, :current_author)
-    user = Map.get(assigns, :current_user)
+    {_, author} =
+      case Map.get(assigns, :current_author) do
+        nil -> {:ok, nil}
+        %Author{id: author_id} -> Oli.AccountLookupCache.get_author(author_id)
+      end
+
+    {_, user} =
+      case Map.get(assigns, :current_user) do
+        nil -> {:ok, nil}
+        %User{id: user_id} -> Oli.AccountLookupCache.get_user(user_id)
+      end
 
     %__MODULE__{
       browser_timezone: browser_timezone,

--- a/test/oli_web/controllers/page_delivery_controller_test.exs
+++ b/test/oli_web/controllers/page_delivery_controller_test.exs
@@ -1339,6 +1339,14 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert html_response(conn, 200) =~ page.revision.title
       assert html_response(conn, 200) =~ "<div id=\"countdown_timer_display\""
     end
+
+    test "shows an error when the section doesn't exist", %{conn: conn} do
+      conn =
+        conn
+        |> get(Routes.page_delivery_path(conn, :index, "non_existant_section"))
+
+      assert html_response(conn, 404) =~ "The section you are trying to view does not exist"
+    end
   end
 
   describe "independent learner page_delivery_controller" do


### PR DESCRIPTION
The `SessionContext` plug is being called before the `SetCurrentUser` plug, so `OliWeb.Common.SessionContext.init/1` was fetching the user's data from the `current_author`/`current_user` fields in the assigns that were set by Pow (which doesn't make a preload of the user's platform roles). Now they're being fetched from the `Oli.AccountLookupCache`.