### PR TITLE
Fix insert resource part responses

### DIFF
--- a/lib/oli/analytics/summary.ex
+++ b/lib/oli/analytics/summary.ex
@@ -145,7 +145,7 @@ defmodule Oli.Analytics.Summary do
           | values
         ]
 
-        params = [response, label | params]
+        params = params ++ [response, label]
 
         {values, params}
       end)


### PR DESCRIPTION
When doing an upsert to the resource_part_responses table after submitting a page with more than one activity, the responses and labels did not match the activity resource_id they belong to (they were being inserted the other way round)

## Submit by student: 

activity 1 -> response 1
activity 2 -> response 2

## Upsert Before

activity 1 -> response 2
activity 2 -> response 1

## Upsert After

activity 1 -> response 1
activity 2 -> response 2