### PR TITLE
[MER-2577] missing content in page editor

### DIFF
--- a/assets/src/apps/page-editor/PageEditor.tsx
+++ b/assets/src/apps/page-editor/PageEditor.tsx
@@ -125,6 +125,7 @@ export class PageEditor extends React.Component<PageEditorProps, PageEditorState
   mousedownListener: any;
   mouseupListener: any;
   windowBlurListener: any;
+  editorsRef: React.RefObject<HTMLDivElement> = React.createRef();
 
   constructor(props: PageEditorProps) {
     super(props);
@@ -549,6 +550,12 @@ export class PageEditor extends React.Component<PageEditorProps, PageEditorState
       </button>
     );
 
+    const dismissMessage = (msg: any) =>
+      this.setState({
+        messages: this.state.messages.filter((m) => msg.guid !== m.guid),
+      });
+    const executeAction = (message: any, action: any) => action.execute(message);
+
     return (
       <React.StrictMode>
         <AppsignalContext.Provider value={this.state.appsignal}>
@@ -560,18 +567,18 @@ export class PageEditor extends React.Component<PageEditorProps, PageEditorState
                 <UndoToasts undoables={this.state.undoables} onInvokeUndo={this.onInvokeUndo} />
 
                 <Banner
-                  dismissMessage={(msg: any) =>
-                    this.setState({
-                      messages: this.state.messages.filter((m) => msg.guid !== m.guid),
-                    })
-                  }
-                  executeAction={(message: any, action: any) => action.execute(message)}
+                  dismissMessage={dismissMessage}
+                  executeAction={executeAction}
                   messages={this.state.messages}
                 />
                 <TitleBar
                   title={state.title}
                   onTitleEdit={onTitleEdit}
                   editMode={this.state.editMode}
+                  parent={this.editorsRef.current}
+                  dismissMessage={dismissMessage}
+                  executeAction={executeAction}
+                  messages={this.state.messages}
                 >
                   <PersistenceStatus persistence={this.state.persistence} />
 
@@ -601,6 +608,7 @@ export class PageEditor extends React.Component<PageEditorProps, PageEditorState
                     />
                     <Editors
                       {...props}
+                      editorsRef={this.editorsRef}
                       editMode={this.state.editMode}
                       objectives={this.state.allObjectives}
                       allTags={this.state.allTags}

--- a/assets/src/components/content/TitleBar.tsx
+++ b/assets/src/components/content/TitleBar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useBoundingRect } from 'components/hooks/useBoundingRect';
+import { useBoundingClientRect } from 'components/hooks/useBoundingRect';
 import { useScrollPosition } from 'components/hooks/useScrollPosition';
 import { Banner } from 'components/messages/Banner';
 import { MessageAction, Message as Msg } from 'data/messages/messages';
@@ -36,7 +36,7 @@ export const TitleBar = (props: TitleBarProps) => {
     executeAction,
   } = props;
   const scrollPos = useScrollPosition();
-  const bounding = useBoundingRect(parent);
+  const bounding = useBoundingClientRect(parent, { triggerOnWindowResize: true });
 
   const showFloating = scrollPos > 300;
 

--- a/assets/src/components/content/TitleBar.tsx
+++ b/assets/src/components/content/TitleBar.tsx
@@ -1,4 +1,8 @@
 import React from 'react';
+import { useBoundingRect } from 'components/hooks/useBoundingRect';
+import { useScrollPosition } from 'components/hooks/useScrollPosition';
+import { Banner } from 'components/messages/Banner';
+import { MessageAction, Message as Msg } from 'data/messages/messages';
 import { classNames } from 'utils/classNames';
 import { TextEditor } from '../TextEditor';
 
@@ -8,32 +12,84 @@ export type TitleBarProps = {
   onTitleEdit: (title: string) => void;
   children: any;
   className?: string;
+  parent: HTMLElement | null;
+  dismissMessage: (message: Msg) => void;
+  executeAction: (message: Msg, action: MessageAction) => void;
+  messages: Msg[];
 };
 
 // Title bar component that allows title bar editing and displays
 // any collection of child components
+//
+// When scrolling the editor, the title bar will float to the top
+// of the screen and remain there until the user scrolls back to the top
 export const TitleBar = (props: TitleBarProps) => {
-  const { editMode, className, title, onTitleEdit, children } = props;
+  const {
+    editMode,
+    className,
+    title,
+    children,
+    parent,
+    messages,
+    onTitleEdit,
+    dismissMessage,
+    executeAction,
+  } = props;
+  const scrollPos = useScrollPosition();
+  const bounding = useBoundingRect(parent);
+
+  const showFloating = scrollPos > 300;
 
   return (
-    <div
-      className={classNames(
-        'TitleBar',
-        'd-flex flex-row flex-md-row align-items-baseline my-2',
-        className,
-      )}
-    >
-      <div className="d-flex align-items-baseline flex-grow-1 mr-2">
-        <TextEditor
-          onEdit={onTitleEdit}
-          model={title}
-          showAffordances={true}
-          size="large"
-          allowEmptyContents={false}
-          editMode={editMode}
-        />
+    <>
+      <div
+        className={classNames(
+          'TitleBar',
+          'block w-100 align-items-baseline',
+          className,
+          showFloating ? 'fixed z-10 top-[65px] px-[1px]' : 'h-[40px]',
+        )}
+        style={showFloating ? { width: bounding?.width, left: bounding?.left } : {}}
+      >
+        <div
+          className={classNames(
+            'flex-1 d-flex align-items-baseline',
+            showFloating && 'px-4 py-2 backdrop-blur-md bg-white/75 shadow-lg',
+          )}
+        >
+          <div
+            className={classNames(
+              'd-flex align-items-baseline flex-grow-1 mr-2',
+              showFloating && 'px-4 py-2',
+            )}
+          >
+            <TextEditor
+              onEdit={onTitleEdit}
+              model={title}
+              showAffordances={true}
+              size="large"
+              allowEmptyContents={false}
+              editMode={editMode}
+            />
+          </div>
+          {children}
+        </div>
+        <div className="p-3">
+          {showFloating && (
+            <Banner
+              dismissMessage={dismissMessage}
+              executeAction={executeAction}
+              messages={messages}
+            />
+          )}
+        </div>
       </div>
-      {children}
-    </div>
+
+      {showFloating && (
+        <>
+          <div className="h-[40px]"></div>
+        </>
+      )}
+    </>
   );
 };

--- a/assets/src/components/editing/toolbar/HoverContainer.tsx
+++ b/assets/src/components/editing/toolbar/HoverContainer.tsx
@@ -55,7 +55,7 @@ export const HoverContainer = (props: PropsWithChildren<Props>) => {
 
         if (mousedown) return position;
 
-        const HEADER_OFFSET = 150;
+        const HEADER_OFFSET = 200;
         const newPosition = positionRect(
           {
             ...state,

--- a/assets/src/components/hooks/useBoundingRect.tsx
+++ b/assets/src/components/hooks/useBoundingRect.tsx
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+
+function observeSize(element: HTMLElement, callback: () => void): () => void {
+  const resizeObserver = new ResizeObserver(() => {
+    callback();
+  });
+  resizeObserver.observe(element);
+  return () => {
+    resizeObserver.disconnect();
+  };
+}
+
+export function useBoundingRect(node: HTMLElement | null) {
+  const [rect, setRect] = useState<DOMRect | null>(null);
+
+  useEffect(() => {
+    if (node) {
+      return observeSize(node, () => {
+        setRect(node.getBoundingClientRect());
+      });
+    }
+  }, [node]);
+
+  return rect;
+}

--- a/assets/src/components/hooks/useBoundingRect.tsx
+++ b/assets/src/components/hooks/useBoundingRect.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
+import useWindowSize from './useWindowSize';
 
-function observeSize(element: HTMLElement, callback: () => void): () => void {
+export function observeSize(element: HTMLElement, callback: () => void): () => void {
   const resizeObserver = new ResizeObserver(() => {
     callback();
   });
@@ -10,8 +11,15 @@ function observeSize(element: HTMLElement, callback: () => void): () => void {
   };
 }
 
-export function useBoundingRect(node: HTMLElement | null) {
+type Opts = {
+  triggerOnWindowResize?: boolean;
+};
+
+export function useBoundingClientRect(node: HTMLElement | null, opts?: Opts) {
   const [rect, setRect] = useState<DOMRect | null>(null);
+  const windowSize = useWindowSize();
+
+  const windowSizeTrigger = opts?.triggerOnWindowResize && windowSize;
 
   useEffect(() => {
     if (node) {
@@ -19,7 +27,7 @@ export function useBoundingRect(node: HTMLElement | null) {
         setRect(node.getBoundingClientRect());
       });
     }
-  }, [node]);
+  }, [node, windowSizeTrigger]);
 
   return rect;
 }

--- a/assets/src/components/hooks/useScrollPosition.ts
+++ b/assets/src/components/hooks/useScrollPosition.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+import { throttle } from 'lodash';
+
+export function useScrollPosition(el?: HTMLElement, throttleMs = 200) {
+  const [scrollPos, setScrollPos] = useState(0);
+
+  const scrollElement: HTMLElement = el || (document.documentElement as HTMLElement);
+
+  useEffect(() => {
+    const scrollListener = throttle(() => setScrollPos(scrollElement.scrollTop), throttleMs);
+    document.addEventListener('scroll', scrollListener);
+
+    return () => {
+      window.removeEventListener('scroll', scrollListener);
+    };
+  }, [scrollPos]);
+
+  return scrollPos;
+}

--- a/assets/src/components/messages/Banner.tsx
+++ b/assets/src/components/messages/Banner.tsx
@@ -34,7 +34,7 @@ export class Banner extends React.PureComponent<BannerProps, {}> {
     const messages = [...errors, ...warnings, ...infos, ...tasks];
 
     return (
-      <div className={classNames(styles.banner, 'sticky-top')}>
+      <div className={classNames(styles.banner, 'sticky top-[80px]')}>
         <TransitionGroup>
           {messages.map((m) => (
             <CSSTransition key={m.guid} timeout={{ enter: 200, exit: 200 }}>

--- a/assets/src/components/resource/editors/Editors.tsx
+++ b/assets/src/components/resource/editors/Editors.tsx
@@ -30,6 +30,7 @@ export type EditorsProps = {
   objectives: Immutable.List<Objective>;
   childrenObjectives: Immutable.Map<ResourceId, Immutable.List<Objective>>;
   featureFlags: FeatureFlags;
+  editorsRef: React.RefObject<HTMLDivElement>;
   onEdit: (content: PageEditorContent) => void;
   onRemove: (id: string) => void;
   onAddItem: (c: ResourceContent, index: number[], a?: ActivityEditContext) => void;
@@ -57,6 +58,7 @@ export const Editors = (props: EditorsProps) => {
     editorMap,
     resourceContext,
     featureFlags,
+    editorsRef,
     onAddItem,
     onEditActivity,
     onPostUndoable,
@@ -131,7 +133,10 @@ export const Editors = (props: EditorsProps) => {
   });
 
   return (
-    <div className={classNames(className, 'editors d-flex flex-column flex-grow-1 shadow-lg')}>
+    <div
+      ref={editorsRef}
+      className={classNames(className, 'editors d-flex flex-column flex-grow-1 shadow-lg')}
+    >
       {editors}
 
       <AddResource


### PR DESCRIPTION
It is believed this issue was the result of a UX gap where error messages and save notification are not visible when scrolled on a page so the user has no good indication that a save was not successful.

This PR adds a floating page titlebar so that these messages along with preview button and save indicator are visible when scrolled. The floating toolbar appears once the top level titlebar is scrolled out of view.

<img width="1286" alt="Screenshot 2023-09-20 at 5 48 06 PM" src="https://github.com/Simon-Initiative/oli-torus/assets/6248894/d2f4ebce-d063-43f3-8e60-fd3eabe0f140">

Closes #3358