### PR TITLE
[BUGFIX][MER-2026] Prevent guest user registration into sections requiring enrollment

### DIFF
--- a/test/oli_web/controllers/delivery_controller_test.exs
+++ b/test/oli_web/controllers/delivery_controller_test.exs
@@ -546,8 +546,8 @@ defmodule OliWeb.DeliveryControllerTest do
       section = insert(:section, requires_enrollment: true)
       conn = get(conn, Routes.delivery_path(conn, :show_enroll, section.slug))
 
-      assert html_response(conn, 200) =~
-               "Enroll as Guest"
+      assert html_response(conn, 302) =~
+               "<html><body>You are being <a href=\"/session/new?section=#{section.slug}\">redirected</a>.</body></html>"
 
       conn = mock_captcha(conn, section)
 


### PR DESCRIPTION
This PR fixes an issue where guest accounts are able to erroneously register into sections requiring non-guest accounts. 