### PR TITLE
[MER-2573] Task to create contained objectives for existing sections

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -154,7 +154,8 @@ config :oli, Oban,
     grades: 30,
     auto_submit: 3,
     analytics_export: 3,
-    datashop_export: 3
+    datashop_export: 3,
+    objectives: 3
   ]
 
 config :ex_money,

--- a/lib/mix/tasks/create_contained_objectives.ex
+++ b/lib/mix/tasks/create_contained_objectives.ex
@@ -1,5 +1,4 @@
 defmodule Mix.Tasks.CreateContainedObjectives do
-  @moduledoc "Printed when the user requests `mix help create_contained_objectives`"
   @shortdoc "Create contained objectives for all sections that were not migrated"
 
   use Mix.Task

--- a/lib/mix/tasks/create_contained_objectives.ex
+++ b/lib/mix/tasks/create_contained_objectives.ex
@@ -16,6 +16,10 @@ defmodule Mix.Tasks.CreateContainedObjectives do
   def run(_args) do
     Mix.Task.run("app.start")
 
+    run_now()
+  end
+
+  def run_now() do
     Logger.info("Start enqueueing contained objectives creation")
 
     Multi.new()

--- a/lib/mix/tasks/create_contained_objectives.ex
+++ b/lib/mix/tasks/create_contained_objectives.ex
@@ -1,0 +1,51 @@
+defmodule Mix.Tasks.CreateContainedObjectives do
+  @moduledoc "Printed when the user requests `mix help create_contained_objectives`"
+  @shortdoc "Create contained objectives for all sections that were not migrated"
+
+  use Mix.Task
+
+  alias Oli.Delivery.Sections
+  alias Oli.Repo
+  alias Oli.Delivery.Sections.Section
+  alias Ecto.Multi
+
+  require Logger
+
+  import Ecto.Query, only: [from: 2]
+
+  @impl Mix.Task
+  def run(_args) do
+    Mix.Task.run("app.start")
+
+    Logger.info("Start enqueueing contained objectives creation")
+
+    res =
+      Multi.new()
+      |> Multi.run(:sections, &get_not_started_sections(&1, &2))
+      |> Oban.insert_all(:jobs, &build_contained_objectives_jobs(&1))
+      |> Ecto.Multi.update_all(
+        :update_all_sections,
+        fn _ -> from(Section, where: [v25_migration: :not_started]) end,
+        set: [v25_migration: :pending]
+      )
+      |> Repo.transaction()
+
+    case res do
+      {:ok, %{jobs: jobs}} ->
+        Logger.info("#{Enum.count(jobs)} jobs enqueued for contained objectives creation")
+
+      {:error, _, changeset, _} ->
+        Logger.error("Error enqueuing jobs: #{inspect(changeset)}")
+    end
+  end
+
+  defp get_not_started_sections(_repo, _changes),
+    do: {:ok, Sections.get_sections_by([v25_migration: :not_started], [:slug])}
+
+  defp build_contained_objectives_jobs(%{sections: sections}) do
+    Enum.map(
+      sections,
+      &Oli.Delivery.Sections.ContainedObjectivesBuilder.new(%{section_slug: &1.slug})
+    )
+  end
+end

--- a/lib/mix/tasks/create_contained_objectives.ex
+++ b/lib/mix/tasks/create_contained_objectives.ex
@@ -6,7 +6,7 @@ defmodule Mix.Tasks.CreateContainedObjectives do
 
   alias Oli.Delivery.Sections
   alias Oli.Repo
-  alias Oli.Delivery.Sections.Section
+  alias Oli.Delivery.Sections.{ContainedObjectivesBuilder, Section}
   alias Ecto.Multi
 
   require Logger
@@ -19,33 +19,31 @@ defmodule Mix.Tasks.CreateContainedObjectives do
 
     Logger.info("Start enqueueing contained objectives creation")
 
-    res =
-      Multi.new()
-      |> Multi.run(:sections, &get_not_started_sections(&1, &2))
-      |> Oban.insert_all(:jobs, &build_contained_objectives_jobs(&1))
-      |> Ecto.Multi.update_all(
-        :update_all_sections,
-        fn _ -> from(Section, where: [v25_migration: :not_started]) end,
-        set: [v25_migration: :pending]
-      )
-      |> Repo.transaction()
-
-    case res do
+    Multi.new()
+    |> Multi.run(:sections, &get_not_started_sections(&1, &2))
+    |> Oban.insert_all(:jobs, &build_contained_objectives_jobs(&1))
+    |> Ecto.Multi.update_all(
+      :update_all_sections,
+      fn _ -> from(Section, where: [v25_migration: :not_started]) end,
+      set: [v25_migration: :pending]
+    )
+    |> Repo.transaction()
+    |> case do
       {:ok, %{jobs: jobs}} ->
         Logger.info("#{Enum.count(jobs)} jobs enqueued for contained objectives creation")
 
+        :ok
+
       {:error, _, changeset, _} ->
         Logger.error("Error enqueuing jobs: #{inspect(changeset)}")
+
+        :error
     end
   end
 
   defp get_not_started_sections(_repo, _changes),
     do: {:ok, Sections.get_sections_by([v25_migration: :not_started], [:slug])}
 
-  defp build_contained_objectives_jobs(%{sections: sections}) do
-    Enum.map(
-      sections,
-      &Oli.Delivery.Sections.ContainedObjectivesBuilder.new(%{section_slug: &1.slug})
-    )
-  end
+  defp build_contained_objectives_jobs(%{sections: sections}),
+    do: Enum.map(sections, &ContainedObjectivesBuilder.new(%{section_slug: &1.slug}))
 end

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -3364,4 +3364,21 @@ defmodule Oli.Delivery.Sections do
       )
     )
   end
+
+  @doc """
+    Get all sections filtered by the clauses passed as the first argument.
+    The second argument is a list of fields to be selected from the Section table.
+    If the second argument is not passed, all fields will be selected.
+  """
+  def get_sections_by(clauses, select_fields \\ nil) do
+    Section
+    |> from(where: ^clauses)
+    |> maybe_select_section_fields(select_fields)
+    |> Repo.all()
+  end
+
+  defp maybe_select_section_fields(query, nil), do: query
+
+  defp maybe_select_section_fields(query, select_fields),
+    do: select(query, [s], struct(s, ^select_fields))
 end

--- a/lib/oli/delivery/sections/contained_objective.ex
+++ b/lib/oli/delivery/sections/contained_objective.ex
@@ -31,8 +31,9 @@ defmodule Oli.Delivery.Sections.ContainedObjective do
     ])
     |> validate_required([
       :section_id,
-      :container_id,
       :objective_id
     ])
+    |> foreign_key_constraint(:section_id)
+    |> foreign_key_constraint(:objective_id)
   end
 end

--- a/lib/oli/delivery/sections/contained_objective.ex
+++ b/lib/oli/delivery/sections/contained_objective.ex
@@ -1,0 +1,38 @@
+defmodule Oli.Delivery.Sections.ContainedObjective do
+  @moduledoc """
+  The ContainedObjective schema represents an association between section containers and objectives linked to the pages within them.
+  It is created for optimization purposes since it provides a fast way of retrieving the objectives associated to the containers of a section.
+
+  Given a section, each objective will have as many entries in the table as containers it is linked to.
+  There will be always at least one entry per objective with the container_id being nil, which represents the inclusion of the objective in the root container.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Oli.Delivery.Sections.Section
+  alias Oli.Resources.Resource
+
+  schema "contained_objectives" do
+    belongs_to(:section, Section)
+    belongs_to(:container, Resource)
+    belongs_to(:objective, Resource)
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  def changeset(contained_page, attrs) do
+    contained_page
+    |> cast(attrs, [
+      :section_id,
+      :container_id,
+      :objective_id
+    ])
+    |> validate_required([
+      :section_id,
+      :container_id,
+      :objective_id
+    ])
+  end
+end

--- a/lib/oli/delivery/sections/contained_objectives_builder.ex
+++ b/lib/oli/delivery/sections/contained_objectives_builder.ex
@@ -1,0 +1,129 @@
+defmodule Oli.Delivery.Sections.ContainedObjectivesBuilder do
+  use Oban.Worker,
+    queue: :objectives,
+    unique: [keys: [:section_slug]],
+    max_attempts: 1
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Oli.Publishing.DeliveryResolver
+  alias Oli.Delivery.Sections.{ContainedObjective, ContainedPage, Section}
+  alias Oli.Resources.{Revision, ResourceType}
+  alias Oli.Repo
+  alias Ecto.Multi
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"section_slug" => slug}}), do: perform_now(slug)
+
+  def perform_now(section_slug) do
+    timestamps = %{
+      inserted_at: {:placeholder, :now},
+      updated_at: {:placeholder, :now}
+    }
+
+    placeholders = %{
+      now: DateTime.utc_now() |> DateTime.truncate(:second)
+    }
+
+    res =
+      Multi.new()
+      |> Multi.run(:contained_objectives, &build_contained_objectives(&1, &2, section_slug))
+      |> Multi.insert_all(
+        :inserted_contained_objectives,
+        ContainedObjective,
+        &objectives_with_timestamps(&1, timestamps),
+        placeholders: placeholders
+      )
+      |> Multi.run(:section, &find_section_by_slug(&1, &2, section_slug))
+      |> Multi.update(
+        :done_section,
+        &Section.changeset(&1.section, %{v25_migration: :done})
+      )
+      |> Repo.transaction()
+
+    case res do
+      {:ok, res} ->
+        {:ok, res}
+
+      {:error, _, changeset, _} ->
+        {:error, changeset}
+    end
+  end
+
+  defp build_contained_objectives(repo, _changes, section_slug) do
+    page_type_id = ResourceType.get_id_by_type("page")
+    activity_type_id = ResourceType.get_id_by_type("activity")
+
+    section_resource_pages =
+      from(
+        [sr: sr, rev: rev, s: s] in DeliveryResolver.section_resource_revisions(section_slug),
+        where: not rev.deleted and rev.resource_type_id == ^page_type_id
+      )
+
+    section_resource_activities =
+      from(
+        [sr: sr, rev: rev, s: s] in DeliveryResolver.section_resource_revisions(section_slug),
+        where: not rev.deleted and rev.resource_type_id == ^activity_type_id,
+        select: rev
+      )
+
+    activity_references =
+      from(
+        rev in Revision,
+        join: content_elem in fragment("jsonb_array_elements(?->'model')", rev.content),
+        select: %{
+          revision_id: rev.id,
+          activity_id: fragment("(?->>'activity_id')::integer", content_elem)
+        },
+        where: fragment("?->>'type'", content_elem) == "activity-reference"
+      )
+
+    activity_objectives =
+      from(
+        rev in Revision,
+        join: obj in fragment("jsonb_each_text(?)", rev.objectives),
+        select: %{
+          objective_revision_id: rev.id,
+          objective_resource_id:
+            fragment("jsonb_array_elements_text(?::jsonb)::integer", obj.value)
+        },
+        where: rev.deleted == false and rev.resource_type_id == ^activity_type_id
+      )
+
+    contained_objectives =
+      from(
+        [sr: sr, rev: rev, s: s] in section_resource_pages,
+        join: cp in ContainedPage,
+        on: cp.page_id == rev.resource_id and cp.section_id == s.id,
+        join: ar in subquery(activity_references),
+        on: ar.revision_id == rev.id,
+        join: act in subquery(section_resource_activities),
+        on: act.resource_id == ar.activity_id,
+        join: ao in subquery(activity_objectives),
+        on: ao.objective_revision_id == act.id,
+        group_by: [cp.section_id, cp.container_id, ao.objective_resource_id],
+        select: %{
+          section_id: cp.section_id,
+          container_id: cp.container_id,
+          objective_id: ao.objective_resource_id
+        }
+      )
+      |> repo.all()
+
+    {:ok, contained_objectives}
+  end
+
+  defp objectives_with_timestamps(%{contained_objectives: contained_objectives}, timestamps) do
+    Enum.map(contained_objectives, &Map.merge(&1, timestamps))
+  end
+
+  defp find_section_by_slug(repo, _changes, section_slug) do
+    case repo.get_by(Section, slug: section_slug) do
+      nil ->
+        {:error, :section_not_found}
+
+      section ->
+        {:ok, section}
+    end
+  end
+end

--- a/lib/oli/delivery/sections/section.ex
+++ b/lib/oli/delivery/sections/section.ex
@@ -127,9 +127,10 @@ defmodule Oli.Delivery.Sections.Section do
 
     field(:preferred_scheduling_time, :time, default: ~T[23:59:59])
 
-    field :v25_migration, Ecto.Enum,
+    field(:v25_migration, Ecto.Enum,
       values: [:not_started, :done, :pending],
       default: :not_started
+    )
 
     timestamps(type: :utc_datetime)
   end
@@ -183,7 +184,8 @@ defmodule Oli.Delivery.Sections.Section do
       :class_modality,
       :class_days,
       :course_section_number,
-      :preferred_scheduling_time
+      :preferred_scheduling_time,
+      :v25_migration
     ])
     |> cast_embed(:customizations, required: false)
     |> validate_required([

--- a/lib/oli/delivery/sections/section.ex
+++ b/lib/oli/delivery/sections/section.ex
@@ -129,7 +129,7 @@ defmodule Oli.Delivery.Sections.Section do
 
     field(:v25_migration, Ecto.Enum,
       values: [:not_started, :done, :pending],
-      default: :not_started
+      default: :done
     )
 
     timestamps(type: :utc_datetime)

--- a/lib/oli/delivery/sections/section.ex
+++ b/lib/oli/delivery/sections/section.ex
@@ -127,6 +127,10 @@ defmodule Oli.Delivery.Sections.Section do
 
     field(:preferred_scheduling_time, :time, default: ~T[23:59:59])
 
+    field :v25_migration, Ecto.Enum,
+      values: [:not_started, :done, :pending],
+      default: :not_started
+
     timestamps(type: :utc_datetime)
   end
 

--- a/priv/repo/migrations/20230913183242_create_contained_objectives.exs
+++ b/priv/repo/migrations/20230913183242_create_contained_objectives.exs
@@ -3,9 +3,9 @@ defmodule Oli.Repo.Migrations.CreateContainedObjectives do
 
   def change do
     create table(:contained_objectives) do
-      add(:section_id, references(:sections, on_delete: :delete_all))
+      add(:section_id, references(:sections, on_delete: :delete_all), null: false)
       add(:container_id, references(:resources))
-      add(:objective_id, references(:resources))
+      add(:objective_id, references(:resources), null: false)
 
       timestamps(type: :timestamptz)
     end

--- a/priv/repo/migrations/20230913183242_create_contained_objectives.exs
+++ b/priv/repo/migrations/20230913183242_create_contained_objectives.exs
@@ -1,0 +1,16 @@
+defmodule Oli.Repo.Migrations.CreateContainedObjectives do
+  use Ecto.Migration
+
+  def change do
+    create table(:contained_objectives) do
+      add(:section_id, references(:sections, on_delete: :delete_all))
+      add(:container_id, references(:resources))
+      add(:objective_id, references(:resources))
+
+      timestamps(type: :timestamptz)
+    end
+
+    create(unique_index(:contained_objectives, [:section_id, :container_id, :objective_id]))
+    create(index(:contained_objectives, [:container_id]))
+  end
+end

--- a/priv/repo/migrations/20230913190657_add_v25_migration_to_sections.exs
+++ b/priv/repo/migrations/20230913190657_add_v25_migration_to_sections.exs
@@ -1,0 +1,11 @@
+defmodule Oli.Repo.Migrations.AddV25MigrationToSections do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sections) do
+      add(:v25_migration, :string, default: "not_started", null: false)
+    end
+
+    create(index(:sections, :v25_migration))
+  end
+end

--- a/test/mix/tasks/create_contained_objectives_test.exs
+++ b/test/mix/tasks/create_contained_objectives_test.exs
@@ -1,0 +1,61 @@
+defmodule Mix.Tasks.CreateContainedObjectivesTest do
+  use Oban.Testing, repo: Oli.Repo
+  use Oli.DataCase
+
+  alias Mix.Tasks.CreateContainedObjectives
+  alias Oli.Delivery.Sections.ContainedObjectivesBuilder
+  alias Oli.Delivery.Sections
+  alias Oli.Factory
+
+  describe "run/1" do
+    test "enqueues not started sections and set them as pending" do
+      [section_1, section_2] = Factory.insert_list(2, :section, v25_migration: :not_started)
+
+      assert :ok == CreateContainedObjectives.run([])
+
+      assert_enqueued(
+        worker: ContainedObjectivesBuilder,
+        args: %{
+          "section_slug" => section_1.slug
+        }
+      )
+
+      assert_enqueued(
+        worker: ContainedObjectivesBuilder,
+        args: %{
+          "section_slug" => section_2.slug
+        }
+      )
+
+      assert Sections.get_section_by(slug: section_1.slug).v25_migration == :pending
+      assert Sections.get_section_by(slug: section_2.slug).v25_migration == :pending
+    end
+
+    test "does not enqueue pending or done sections" do
+      section_1 = Factory.insert(:section, v25_migration: :pending)
+      section_2 = Factory.insert(:section, v25_migration: :done)
+
+      assert :ok == CreateContainedObjectives.run([])
+
+      refute_enqueued(
+        worker: ContainedObjectivesBuilder,
+        args: %{
+          "section_slug" => section_1.slug
+        }
+      )
+
+      refute_enqueued(
+        worker: ContainedObjectivesBuilder,
+        args: %{
+          "section_slug" => section_2.slug
+        }
+      )
+
+      assert Sections.get_section_by(slug: section_1.slug).v25_migration ==
+               section_1.v25_migration
+
+      assert Sections.get_section_by(slug: section_2.slug).v25_migration ==
+               section_2.v25_migration
+    end
+  end
+end

--- a/test/oli/delivery/sections/contained_objective_test.exs
+++ b/test/oli/delivery/sections/contained_objective_test.exs
@@ -1,0 +1,25 @@
+defmodule Oli.Delivery.Sections.ContainedObjectiveTest do
+  use Oli.DataCase
+
+  import Oli.Factory
+
+  alias Oli.Delivery.Sections.ContainedObjective
+
+  describe "changeset/2" do
+    test "changeset should be invalid if section_id is nil" do
+      changeset =
+        build(:contained_objective)
+        |> ContainedObjective.changeset(%{section_id: nil})
+
+      refute changeset.valid?
+    end
+
+    test "changeset should be invalid if container_id is nil" do
+      changeset =
+        build(:contained_objective)
+        |> ContainedObjective.changeset(%{container_id: nil})
+
+      refute changeset.valid?
+    end
+  end
+end

--- a/test/oli/delivery/sections/contained_objectives_builder_test.exs
+++ b/test/oli/delivery/sections/contained_objectives_builder_test.exs
@@ -1,0 +1,147 @@
+defmodule Oli.Delivery.Sections.ContainedObjectivesBuilderTest do
+  use Oban.Testing, repo: Oli.Repo
+  use Oli.DataCase
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Oli.Delivery.Sections
+  alias Oli.Delivery.Sections.{ContainedObjectivesBuilder, ContainedObjective}
+  alias Oli.{Factory, Repo}
+
+  describe "given a section with objectives" do
+    setup [:create_full_project_with_objectives]
+
+    ## Course Hierarchy
+    #
+    # Root Container --> Page 1 --> Activity X
+    #                |--> Unit Container --> Module Container 1 --> Page 2 --> Activity Y
+    #                |                                                     |--> Activity Z
+    #                |--> Module Container 2 --> Page 3 --> Activity W
+    #
+    ## Objectives Hierarchy
+    #
+    # Page 1 --> Objective A
+    # Page 2 --> Objective B
+    #
+    # Note: the objectives above are not considered since they are attached to the pages
+    #
+    # Activity Y --> Objective C
+    #           |--> SubObjective C1
+    # Activity Z --> Objective D
+    # Activity W --> Objective E
+    #           |--> Objective F
+    #
+    # Note: Activity X does not have objectives
+    test "it ignores objectives attached to inner pages", %{
+      section: section,
+      resources: resources
+    } do
+      assert {:ok, _} = perform_job(ContainedObjectivesBuilder, %{section_slug: section.slug})
+
+      # Check Root Container objectives
+      root_container_objectives = get_section_contained_objectives(section.id, nil)
+
+      # Objectives A and B are not attached
+      [resources.obj_resource_a, resources.obj_resource_b]
+      |> Enum.each(fn objective ->
+        refute Enum.find(root_container_objectives, &(&1 == objective.id))
+      end)
+
+      assert Sections.get_section_by(slug: section.slug).v25_migration == :done
+    end
+
+    test "it creates contained objectives for each objective in the inner activities", %{
+      section: section,
+      resources: resources
+    } do
+      assert {:ok, _} = perform_job(ContainedObjectivesBuilder, %{section_slug: section.slug})
+
+      # Check Module Container 1 objectives
+      module_container_1_objectives =
+        get_section_contained_objectives(section.id, resources.module_resource_1.id)
+
+      # C, C1 and D are the objectives attached to the inner activities
+      assert length(module_container_1_objectives) == 3
+
+      assert Enum.sort(module_container_1_objectives) ==
+               Enum.sort([
+                 resources.obj_resource_c.id,
+                 resources.obj_resource_c1.id,
+                 resources.obj_resource_d.id
+               ])
+
+      # Check Unit Container objectives
+      unit_container_objectives =
+        get_section_contained_objectives(section.id, resources.unit_resource.id)
+
+      # C, C1 and D are the objectives attached to the inner activities
+      assert length(unit_container_objectives) == 3
+
+      assert Enum.sort(unit_container_objectives) ==
+               Enum.sort([
+                 resources.obj_resource_c.id,
+                 resources.obj_resource_c1.id,
+                 resources.obj_resource_d.id
+               ])
+
+      # Check Module Container 2 objectives
+      module_container_2_objectives =
+        get_section_contained_objectives(section.id, resources.module_resource_2.id)
+
+      # E and F are the objectives attached to the inner activities
+      assert length(module_container_2_objectives) == 2
+
+      assert Enum.sort(module_container_2_objectives) ==
+               Enum.sort([
+                 resources.obj_resource_e.id,
+                 resources.obj_resource_f.id
+               ])
+
+      # Check Root Container objectives
+      root_container_objectives = get_section_contained_objectives(section.id, nil)
+
+      # C, C1, D, E and F are the objectives attached to the inner activities
+      assert length(root_container_objectives) == 5
+
+      assert Enum.sort(root_container_objectives) ==
+               Enum.sort([
+                 resources.obj_resource_c.id,
+                 resources.obj_resource_c1.id,
+                 resources.obj_resource_d.id,
+                 resources.obj_resource_e.id,
+                 resources.obj_resource_f.id
+               ])
+
+      assert Sections.get_section_by(slug: section.slug).v25_migration == :done
+    end
+  end
+
+  describe "given a section without objectives" do
+    test "it does not insert any contained objective but updates the section state" do
+      section = Factory.insert(:section, v25_migration: :not_started)
+
+      assert {:ok, _} = perform_job(ContainedObjectivesBuilder, %{section_slug: section.slug})
+
+      assert Sections.get_section_by(slug: section.slug).v25_migration == :done
+      assert [] == get_section_contained_objectives(section.id, nil)
+    end
+  end
+
+  defp get_section_contained_objectives(section_id, nil) do
+    Repo.all(
+      from(co in ContainedObjective,
+        where: co.section_id == ^section_id and is_nil(co.container_id),
+        select: co.objective_id
+      )
+    )
+  end
+
+  defp get_section_contained_objectives(section_id, container_id) do
+    Repo.all(
+      from(co in ContainedObjective,
+        where: [section_id: ^section_id, container_id: ^container_id],
+        select: co.objective_id
+      )
+    )
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -6,6 +6,8 @@ defmodule Oli.Factory do
   alias Oli.Authoring.Course.{Family, Project, ProjectVisibility, ProjectResource}
   alias Oli.Branding.Brand
 
+  alias Oli.Delivery.Sections.ContainedObjective
+
   alias Oli.Delivery.Attempts.Core.{
     ActivityAttempt,
     LMSGradeUpdate,
@@ -552,6 +554,14 @@ defmodule Oli.Factory do
       auth_login_url: "https://www.#{sequence("key_set_url_")}.com/auth/login",
       auth_server: "https://www.#{sequence("key_set_url_")}.com/auth/server",
       line_items_service_domain: ""
+    }
+  end
+
+  def contained_objective_factory() do
+    %ContainedObjective{
+      section: anonymous_build(:section),
+      container_id: insert(:resource).id,
+      objective_id: insert(:resource).id
     }
   end
 

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -1155,6 +1155,241 @@ defmodule Oli.TestHelpers do
     }
   end
 
+  def create_full_project_with_objectives(_conn), do: create_full_project_with_objectives()
+
+  def create_full_project_with_objectives() do
+    author = insert(:author)
+    project = insert(:project, authors: [author])
+
+    # Create objectives
+    {obj_resource_a, obj_revision_a} = create_objective("Objective A", "objective_A", project)
+    {obj_resource_b, obj_revision_b} = create_objective("Objective B", "objective_B", project)
+    {obj_resource_c1, obj_revision_c1} = create_objective("Objective C1", "objective_C1", project)
+
+    {obj_resource_c, obj_revision_c} =
+      create_objective("Objective C", "objective_C", project, [obj_resource_c1.id])
+
+    {obj_resource_d, obj_revision_d} = create_objective("Objective D", "objective_D", project)
+    {obj_resource_e, obj_revision_e} = create_objective("Objective E", "objective_E", project)
+    {obj_resource_f, obj_revision_f} = create_objective("Objective F", "objective_F", project)
+
+    # Create activities
+    {act_resource_x, act_revision_x} = create_activity("Activity X", "activity_x", project)
+
+    {act_resource_y, act_revision_y} =
+      create_activity("Activity Y", "activity_y", project, [obj_resource_c.id, obj_resource_c1.id])
+
+    {act_resource_z, act_revision_z} =
+      create_activity("Activity Z", "activity_z", project, [obj_resource_d.id])
+
+    {act_resource_w, act_revision_w} =
+      create_activity("Activity W", "activity_w", project, [obj_resource_e.id, obj_resource_f.id])
+
+    # Create pages
+    build_content_for_page = fn activity_ids ->
+      Enum.with_index(activity_ids, fn activity_id, id ->
+        %{
+          "activity_id" => activity_id,
+          "id" => id,
+          "type" => "activity-reference"
+        }
+      end)
+    end
+
+    {page_resource_1, page_revision_1} =
+      create_page("Page 1", "page_1", project, build_content_for_page.([act_resource_x.id]), [
+        obj_resource_a.id
+      ])
+
+    {page_resource_2, page_revision_2} =
+      create_page(
+        "Page 2",
+        "page_2",
+        project,
+        build_content_for_page.([act_resource_y.id, act_resource_z.id]),
+        [obj_resource_b.id]
+      )
+
+    {page_resource_3, page_revision_3} =
+      create_page("Page 3", "page_3", project, build_content_for_page.([act_resource_w.id]))
+
+    # Create modules
+    {module_resource_1, module_revision_1} =
+      create_container("Module Container 1", "module_container_1", project, [page_resource_2.id])
+
+    {module_resource_2, module_revision_2} =
+      create_container("Module Container 2", "module_container_2", project, [page_resource_3.id])
+
+    # Create Unit
+    {unit_resource, unit_revision} =
+      create_container("Unit Container", "unit_container", project, [module_resource_1.id])
+
+    # Create Root
+    {root_resource, root_revision} =
+      create_container("Root Container", "root_container", project, [
+        page_resource_1.id,
+        unit_resource.id,
+        module_resource_2.id
+      ])
+
+    # Publication of project with root container
+    publication =
+      insert(:publication, %{
+        project: project,
+        root_resource_id: root_resource.id
+      })
+
+    # Publish all resources
+    [
+      {obj_resource_a, obj_revision_a},
+      {obj_resource_b, obj_revision_b},
+      {obj_resource_c, obj_revision_c},
+      {obj_resource_c1, obj_revision_c1},
+      {obj_resource_d, obj_revision_d},
+      {obj_resource_e, obj_revision_e},
+      {obj_resource_f, obj_revision_f},
+      {act_resource_x, act_revision_x},
+      {act_resource_y, act_revision_y},
+      {act_resource_z, act_revision_z},
+      {act_resource_w, act_revision_w},
+      {page_resource_1, page_revision_1},
+      {page_resource_2, page_revision_2},
+      {page_resource_3, page_revision_3},
+      {module_resource_1, module_revision_1},
+      {module_resource_2, module_revision_2},
+      {unit_resource, unit_revision},
+      {root_resource, root_revision}
+    ]
+    |> Enum.each(fn {resource, revision} ->
+      insert(:published_resource, %{
+        publication: publication,
+        resource: resource,
+        revision: revision,
+        author: author
+      })
+    end)
+
+    section =
+      insert(:section,
+        base_project: project,
+        context_id: UUID.uuid4(),
+        open_and_free: true,
+        registration_open: true,
+        type: :enrollable
+      )
+
+    {:ok, section} = Sections.create_section_resources(section, publication)
+    Sections.rebuild_contained_pages(section)
+
+    %{
+      project: project,
+      section: section,
+      publication: publication,
+      resources: %{
+        obj_resource_a: obj_resource_a,
+        obj_resource_b: obj_resource_b,
+        obj_resource_c: obj_resource_c,
+        obj_resource_c1: obj_resource_c1,
+        obj_resource_d: obj_resource_d,
+        obj_resource_e: obj_resource_e,
+        obj_resource_f: obj_resource_f,
+        page_resource_1: page_resource_1,
+        page_resource_2: page_resource_2,
+        page_resource_3: page_resource_3,
+        module_resource_1: module_resource_1,
+        module_resource_2: module_resource_2,
+        unit_resource: unit_resource,
+        root_resource: root_resource
+      }
+    }
+  end
+
+  defp create_objective(title, slug, project, subobjectives \\ []) do
+    obj_resource = insert(:resource)
+
+    obj_revision =
+      insert(:revision, %{
+        resource: obj_resource,
+        objectives: %{},
+        resource_type_id: ResourceType.get_id_by_type("objective"),
+        children: subobjectives,
+        content: %{},
+        deleted: false,
+        slug: slug,
+        title: title
+      })
+
+    # Associate objective to the project
+    insert(:project_resource, %{project_id: project.id, resource_id: obj_resource.id})
+
+    {obj_resource, obj_revision}
+  end
+
+  defp create_activity(title, slug, project, objectives \\ []) do
+    activity_resource = insert(:resource)
+
+    activity_revision =
+      insert(:revision, %{
+        objectives: %{"1" => objectives},
+        scoring_strategy_id: Oli.Resources.ScoringStrategy.get_id_by_type("average"),
+        resource_type_id: ResourceType.get_id_by_type("activity"),
+        children: [],
+        content: %{"model" => []},
+        deleted: false,
+        title: title,
+        resource: activity_resource,
+        slug: slug
+      })
+
+    # Associate activity to the project
+    insert(:project_resource, %{project_id: project.id, resource_id: activity_resource.id})
+
+    {activity_resource, activity_revision}
+  end
+
+  defp create_page(title, slug, project, content_model, objectives \\ []) do
+    page_resource = insert(:resource)
+
+    page_revision =
+      insert(:revision, %{
+        objectives: %{"attached" => objectives},
+        scoring_strategy_id: Oli.Resources.ScoringStrategy.get_id_by_type("average"),
+        resource_type_id: ResourceType.get_id_by_type("page"),
+        children: [],
+        content: %{"model" => content_model},
+        deleted: false,
+        title: title,
+        resource: page_resource,
+        slug: slug
+      })
+
+    # Associate page to the project
+    insert(:project_resource, %{project_id: project.id, resource_id: page_resource.id})
+
+    {page_resource, page_revision}
+  end
+
+  defp create_container(title, slug, project, children) do
+    container_resource = insert(:resource)
+
+    container_revision =
+      insert(:revision, %{
+        resource: container_resource,
+        objectives: %{},
+        resource_type_id: ResourceType.get_id_by_type("container"),
+        children: children,
+        content: %{},
+        deleted: false,
+        slug: slug,
+        title: title
+      })
+
+    # Associate container to the project
+    insert(:project_resource, %{project_id: project.id, resource_id: container_resource.id})
+
+    {container_resource, container_revision}
+  end
+
   defp generate_attempt_content(),
     do: %{
       choices: [


### PR DESCRIPTION
[MER-2573](https://eliterate.atlassian.net/browse/MER-2573)

This PR is the first of three parts to create and use the new `ContainedObjectives` table. Similar to `ContainedPages`, this works as a quick way of knowing which objectives are attached to activities within a specific container.

As part of this pull request:
- New `contained_objectives` table and new `v25_migration` field under `sections` that states if the contained objectives were built for a section.
- A new [Mix Task](https://hexdocs.pm/mix/1.12.3/Mix.Task.html) is created for building all the contained objectives for the existing sections. You can run it with `mix create_contained_objectives` in the console.

The remaining two PRs will include the changes for automatically building the contained objectives when a section gets created, remixed, or updated, and the new Filter By implementation on the Learning Objectives tab under the Instructor Dashboard.

[MER-2573]: https://eliterate.atlassian.net/browse/MER-2573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ