### PR TITLE
[BUGFIX] Fix route path for LTI institution registration

### DIFF
--- a/lib/oli_web/controllers/lti_controller.ex
+++ b/lib/oli_web/controllers/lti_controller.ex
@@ -299,7 +299,7 @@ defmodule OliWeb.LtiController do
                     "type" => "plain_text",
                     "text" => "Review Request"
                   },
-                  "url" => "#{Routes.institution_url(conn, :index)}#pending-registrations"
+                  "url" => ~p"/admin/institutions"
                 }
               ]
             }


### PR DESCRIPTION
The route that users were being redirected to after an institution registration request no longer exists