### PR TITLE
[MER-2568][BUGFIX] invalid utf8 encoding

### DIFF
--- a/test/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live_test.exs
@@ -149,5 +149,30 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLiveTest do
 
       assert has_element?(view, "h4", "Discussion Activity")
     end
+
+    test "user is sent to report/default_content_tab if an invalid tab is provided in the url param",
+         %{
+           conn: conn,
+           instructor: instructor,
+           section: section
+         } do
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          Routes.live_path(
+            OliWeb.Endpoint,
+            OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive,
+            section.slug,
+            :reports,
+            "invalid_tab",
+            %{}
+          )
+        )
+
+      # content is the active tab
+      assert has_element?(view, "a.active", "Content")
+    end
   end
 end


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-2568) to the ticket

In all appsignal reports, the user was trying to access an invalid tab (~normalize.css)
`/sections/ux_design_for_effective_instru_t4ifr/instructor_dashboard/reports/~normalize.css/normalize.css`

And since we handled the tab name by converting its value into an existing atom, the app was crashing.
If the user enters an invalid tab in the URL, we will rescue the `String.to_existing_atom` error and assign a default valid tab instead.