### PR TITLE
[BUGFIX][MER-2570] Fix error accessing project preview

### DIFF
--- a/lib/oli/rendering/content/selection.ex
+++ b/lib/oli/rendering/content/selection.ex
@@ -94,7 +94,15 @@ defmodule Oli.Rendering.Content.Selection do
         %{}
 
       ids ->
-        Oli.Publishing.AuthoringResolver.from_resource_id(section_slug, ids)
+        revisions =
+          if Enum.any?(
+               Oli.Publishing.AuthoringResolver.from_resource_id(section_slug, ids),
+               fn elem -> is_nil(elem) end
+             ),
+             do: Oli.Publishing.DeliveryResolver.from_resource_id(section_slug, ids),
+             else: Oli.Publishing.AuthoringResolver.from_resource_id(section_slug, ids)
+
+        revisions
         |> Enum.reduce(%{}, fn rev, m -> Map.put(m, rev.resource_id, rev.title) end)
     end
   end
@@ -139,6 +147,8 @@ defmodule Oli.Rendering.Content.Selection do
     |> Enum.join(" ")
   end
 
-  defp titles(id, title_map, class),
-    do: "<span class=\"#{class}\">#{Map.get(title_map, id)}</span>"
+  defp titles(id, title_map, class) do
+    unless Map.equal?(title_map, %{}),
+      do: "<span class=\"#{class}\">#{Map.get(title_map, id)}</span>"
+  end
 end

--- a/lib/oli/rendering/content/selection.ex
+++ b/lib/oli/rendering/content/selection.ex
@@ -94,15 +94,9 @@ defmodule Oli.Rendering.Content.Selection do
         %{}
 
       ids ->
-        revisions =
-          if Enum.any?(
-               Oli.Publishing.AuthoringResolver.from_resource_id(section_slug, ids),
-               fn elem -> is_nil(elem) end
-             ),
-             do: Oli.Publishing.DeliveryResolver.from_resource_id(section_slug, ids),
-             else: Oli.Publishing.AuthoringResolver.from_resource_id(section_slug, ids)
-
-        revisions
+        # This section_slug really is the project slug
+        Oli.Publishing.AuthoringResolver.from_resource_id(section_slug, ids)
+        |> Enum.filter(fn r -> !is_nil(r) end)
         |> Enum.reduce(%{}, fn rev, m -> Map.put(m, rev.resource_id, rev.title) end)
     end
   end

--- a/lib/oli/rendering/content/selection.ex
+++ b/lib/oli/rendering/content/selection.ex
@@ -94,7 +94,7 @@ defmodule Oli.Rendering.Content.Selection do
         %{}
 
       ids ->
-        Oli.Publishing.DeliveryResolver.from_resource_id(section_slug, ids)
+        Oli.Publishing.AuthoringResolver.from_resource_id(section_slug, ids)
         |> Enum.reduce(%{}, fn rev, m -> Map.put(m, rev.resource_id, rev.title) end)
     end
   end
@@ -129,8 +129,10 @@ defmodule Oli.Rendering.Content.Selection do
     |> Enum.join(" ")
   end
 
-  defp activity_names(id, activity_types_map),
-    do: "<span class=\"activity-name\">#{Map.get(activity_types_map, id).title}</span>"
+  defp activity_names(id, activity_types_map) do
+    unless Map.equal?(activity_types_map, %{}),
+      do: "<span class=\"activity-name\">#{Map.get(activity_types_map, id).title}</span>"
+  end
 
   defp titles(ids, title_map, class) when is_list(ids) do
     Enum.map(ids, fn id -> titles(id, title_map, class) end)


### PR DESCRIPTION
[MER-2570](https://eliterate.atlassian.net/browse/MER-2570)

Fixed a couple of bugs when rendering the project preview. 

- Error when calling `DeliveryResolver` instead of calling `AuthoringResolver`. This was failing when you have one selection criteria for an activity bank by objective and there is no objective added in the activity banks.

- Error when applying a selection criteria by item type and there is no such activity in the activity bank.

[MER-2570]: https://eliterate.atlassian.net/browse/MER-2570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ