### PR TITLE
[BUGFIX][MER-2298] Add published_date sort in add materials modal

### DIFF
--- a/lib/oli/publishing.ex
+++ b/lib/oli/publishing.ex
@@ -733,6 +733,9 @@ defmodule Oli.Publishing do
 
           :updated_at ->
             order_by(query, [_pr, rev], [{^params.sort_order, rev.updated_at}])
+
+          :publication_date ->
+            order_by(query, [_pr, _rev, pub], [{^params.sort_order, pub.published}])
         end
       else
         query

--- a/lib/oli_web/live/common/hierarchy/hierarchy_picker_table_model.ex
+++ b/lib/oli_web/live/common/hierarchy/hierarchy_picker_table_model.ex
@@ -33,8 +33,7 @@ defmodule OliWeb.Common.Hierarchy.HierarchyPicker.TableModel do
         label: "Published on",
         render_fn: &__MODULE__.custom_render/3,
         th_class: "pl-2 text-right",
-        td_class: "text-right",
-        sortable: false
+        td_class: "text-right"
       }
     ]
 

--- a/test/oli_web/live/remix_section_test.exs
+++ b/test/oli_web/live/remix_section_test.exs
@@ -716,9 +716,9 @@ defmodule OliWeb.RemixSectionLiveTest do
                "Another orph. Page"
              )
 
-      # Can't sort by published date
+      # Can sort by published date
       assert view
-             |> has_element?("th[data-sortable=\"false\"]", "Published on")
+             |> has_element?("th[data-sortable=\"true\"]", "Published on")
     end
 
     test "remix section items - add materials - all pages view can be filtered by text", %{


### PR DESCRIPTION
[MER-2298](https://eliterate.atlassian.net/browse/MER-2298)

This PR adds the option to sort by `Published on` column in the table of all pages within the `Add Materials` modal to customize the content of a course section.

![Captura de pantalla 2023-09-26 a la(s) 14 57 50](https://github.com/Simon-Initiative/oli-torus/assets/16328384/9ef0c93b-0d21-4b59-aa47-a5df7c574ae3)




[MER-2298]: https://eliterate.atlassian.net/browse/MER-2298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ