### PR TITLE
[MER-2574] Calculate contained objectives on section actions

### DIFF
--- a/lib/oli/delivery.ex
+++ b/lib/oli/delivery.ex
@@ -105,6 +105,7 @@ defmodule Oli.Delivery do
         )
 
       {:ok, _} = Sections.rebuild_contained_pages(section)
+      {:ok, _} = Sections.rebuild_contained_objectives(section)
 
       enroll(user.id, section.id, lti_params)
 
@@ -153,6 +154,7 @@ defmodule Oli.Delivery do
 
       {:ok, %Section{} = section} = Sections.create_section_resources(section, publication)
       {:ok, _} = Sections.rebuild_contained_pages(section)
+      {:ok, _} = Sections.rebuild_contained_objectives(section)
 
       enroll(user.id, section.id, lti_params)
       {:ok, updated_section} = maybe_update_section_contains_explorations(section)

--- a/lib/oli/delivery/sections/contained_objectives_builder.ex
+++ b/lib/oli/delivery/sections/contained_objectives_builder.ex
@@ -8,6 +8,7 @@ defmodule Oli.Delivery.Sections.ContainedObjectivesBuilder do
 
   alias Oli.Publishing.DeliveryResolver
   alias Oli.Delivery.Sections.{ContainedObjective, ContainedPage, Section}
+  alias Oli.Delivery.Sections
   alias Oli.Resources.{Revision, ResourceType}
   alias Oli.Repo
   alias Ecto.Multi
@@ -24,7 +25,10 @@ defmodule Oli.Delivery.Sections.ContainedObjectivesBuilder do
     }
 
     Multi.new()
-    |> Multi.run(:contained_objectives, &build_contained_objectives(&1, &2, section_slug))
+    |> Multi.run(
+      :contained_objectives,
+      &Sections.build_contained_objectives(&1, &2, section_slug)
+    )
     |> Multi.insert_all(
       :inserted_contained_objectives,
       ContainedObjective,
@@ -44,69 +48,6 @@ defmodule Oli.Delivery.Sections.ContainedObjectivesBuilder do
       {:error, _, changeset, _} ->
         {:error, changeset}
     end
-  end
-
-  defp build_contained_objectives(repo, _changes, section_slug) do
-    page_type_id = ResourceType.get_id_by_type("page")
-    activity_type_id = ResourceType.get_id_by_type("activity")
-
-    section_resource_pages =
-      from(
-        [sr: sr, rev: rev, s: s] in DeliveryResolver.section_resource_revisions(section_slug),
-        where: not rev.deleted and rev.resource_type_id == ^page_type_id
-      )
-
-    section_resource_activities =
-      from(
-        [sr: sr, rev: rev, s: s] in DeliveryResolver.section_resource_revisions(section_slug),
-        where: not rev.deleted and rev.resource_type_id == ^activity_type_id,
-        select: rev
-      )
-
-    activity_references =
-      from(
-        rev in Revision,
-        join: content_elem in fragment("jsonb_array_elements(?->'model')", rev.content),
-        select: %{
-          revision_id: rev.id,
-          activity_id: fragment("(?->>'activity_id')::integer", content_elem)
-        },
-        where: fragment("?->>'type'", content_elem) == "activity-reference"
-      )
-
-    activity_objectives =
-      from(
-        rev in Revision,
-        join: obj in fragment("jsonb_each_text(?)", rev.objectives),
-        select: %{
-          objective_revision_id: rev.id,
-          objective_resource_id:
-            fragment("jsonb_array_elements_text(?::jsonb)::integer", obj.value)
-        },
-        where: rev.deleted == false and rev.resource_type_id == ^activity_type_id
-      )
-
-    contained_objectives =
-      from(
-        [sr: sr, rev: rev, s: s] in section_resource_pages,
-        join: cp in ContainedPage,
-        on: cp.page_id == rev.resource_id and cp.section_id == s.id,
-        join: ar in subquery(activity_references),
-        on: ar.revision_id == rev.id,
-        join: act in subquery(section_resource_activities),
-        on: act.resource_id == ar.activity_id,
-        join: ao in subquery(activity_objectives),
-        on: ao.objective_revision_id == act.id,
-        group_by: [cp.section_id, cp.container_id, ao.objective_resource_id],
-        select: %{
-          section_id: cp.section_id,
-          container_id: cp.container_id,
-          objective_id: ao.objective_resource_id
-        }
-      )
-      |> repo.all()
-
-    {:ok, contained_objectives}
   end
 
   defp objectives_with_timestamps(%{contained_objectives: contained_objectives}, timestamps) do

--- a/lib/oli/delivery/sections/contained_objectives_builder.ex
+++ b/lib/oli/delivery/sections/contained_objectives_builder.ex
@@ -4,12 +4,8 @@ defmodule Oli.Delivery.Sections.ContainedObjectivesBuilder do
     unique: [keys: [:section_slug]],
     max_attempts: 1
 
-  import Ecto.Query, only: [from: 2]
-
-  alias Oli.Publishing.DeliveryResolver
-  alias Oli.Delivery.Sections.{ContainedObjective, ContainedPage, Section}
+  alias Oli.Delivery.Sections.{ContainedObjective, Section}
   alias Oli.Delivery.Sections
-  alias Oli.Resources.{Revision, ResourceType}
   alias Oli.Repo
   alias Ecto.Multi
 

--- a/lib/oli_web/controllers/open_and_free_controller.ex
+++ b/lib/oli_web/controllers/open_and_free_controller.ex
@@ -338,6 +338,7 @@ defmodule OliWeb.OpenAndFreeController do
     Repo.transaction(fn ->
       with {:ok, section} <- Oli.Delivery.Sections.Blueprint.duplicate(blueprint, section_params),
            {:ok, _} <- Sections.rebuild_contained_pages(section),
+           {:ok, _} <- Sections.rebuild_contained_objectives(section),
            {:ok, _maybe_enrollment} <- enroll(conn, section) do
         section
       else
@@ -351,6 +352,7 @@ defmodule OliWeb.OpenAndFreeController do
       with {:ok, section} <- Sections.create_section(section_params),
            {:ok, section} <- Sections.create_section_resources(section, publication),
            {:ok, _} <- Sections.rebuild_contained_pages(section),
+           {:ok, _} <- Sections.rebuild_contained_objectives(section),
            {:ok, _enrollment} <- enroll(conn, section),
            {:ok, updated_section} <- Delivery.maybe_update_section_contains_explorations(section) do
         updated_section

--- a/lib/oli_web/live/new_course/new_course.ex
+++ b/lib/oli_web/live/new_course/new_course.ex
@@ -372,6 +372,7 @@ defmodule OliWeb.Delivery.NewCourse do
       with {:ok, section} <- Sections.create_section(section_params),
            {:ok, section} <- Sections.create_section_resources(section, publication),
            {:ok, _} <- Sections.rebuild_contained_pages(section),
+           {:ok, _} <- Sections.rebuild_contained_objectives(section),
            {:ok, _enrollment} <- enroll(socket, section),
            {:ok, updated_section} <-
              Oli.Delivery.maybe_update_section_contains_explorations(section) do
@@ -387,6 +388,7 @@ defmodule OliWeb.Delivery.NewCourse do
     Repo.transaction(fn ->
       with {:ok, section} <- Oli.Delivery.Sections.Blueprint.duplicate(blueprint, section_params),
            {:ok, _} <- Sections.rebuild_contained_pages(section),
+           {:ok, _} <- Sections.rebuild_contained_objectives(section),
            {:ok, _maybe_enrollment} <- enroll(socket, section) do
         section
       else

--- a/test/oli/delivery/sections/contained_objectives_builder_test.exs
+++ b/test/oli/delivery/sections/contained_objectives_builder_test.exs
@@ -2,11 +2,9 @@ defmodule Oli.Delivery.Sections.ContainedObjectivesBuilderTest do
   use Oban.Testing, repo: Oli.Repo
   use Oli.DataCase
 
-  import Ecto.Query, only: [from: 2]
-
   alias Oli.Delivery.Sections
-  alias Oli.Delivery.Sections.{ContainedObjectivesBuilder, ContainedObjective}
-  alias Oli.{Factory, Repo}
+  alias Oli.Delivery.Sections.ContainedObjectivesBuilder
+  alias Oli.Factory
 
   describe "given a section with objectives" do
     setup [:create_full_project_with_objectives]
@@ -39,7 +37,7 @@ defmodule Oli.Delivery.Sections.ContainedObjectivesBuilderTest do
       assert {:ok, _} = perform_job(ContainedObjectivesBuilder, %{section_slug: section.slug})
 
       # Check Root Container objectives
-      root_container_objectives = get_section_contained_objectives(section.id, nil)
+      root_container_objectives = Sections.get_section_contained_objectives(section.id, nil)
 
       # Objectives A and B are not attached
       [resources.obj_resource_a, resources.obj_resource_b]
@@ -58,7 +56,7 @@ defmodule Oli.Delivery.Sections.ContainedObjectivesBuilderTest do
 
       # Check Module Container 1 objectives
       module_container_1_objectives =
-        get_section_contained_objectives(section.id, resources.module_resource_1.id)
+        Sections.get_section_contained_objectives(section.id, resources.module_resource_1.id)
 
       # C, C1 and D are the objectives attached to the inner activities
       assert length(module_container_1_objectives) == 3
@@ -72,7 +70,7 @@ defmodule Oli.Delivery.Sections.ContainedObjectivesBuilderTest do
 
       # Check Unit Container objectives
       unit_container_objectives =
-        get_section_contained_objectives(section.id, resources.unit_resource.id)
+        Sections.get_section_contained_objectives(section.id, resources.unit_resource.id)
 
       # C, C1 and D are the objectives attached to the inner activities
       assert length(unit_container_objectives) == 3
@@ -86,7 +84,7 @@ defmodule Oli.Delivery.Sections.ContainedObjectivesBuilderTest do
 
       # Check Module Container 2 objectives
       module_container_2_objectives =
-        get_section_contained_objectives(section.id, resources.module_resource_2.id)
+        Sections.get_section_contained_objectives(section.id, resources.module_resource_2.id)
 
       # E and F are the objectives attached to the inner activities
       assert length(module_container_2_objectives) == 2
@@ -98,7 +96,7 @@ defmodule Oli.Delivery.Sections.ContainedObjectivesBuilderTest do
                ])
 
       # Check Root Container objectives
-      root_container_objectives = get_section_contained_objectives(section.id, nil)
+      root_container_objectives = Sections.get_section_contained_objectives(section.id, nil)
 
       # C, C1, D, E and F are the objectives attached to the inner activities
       assert length(root_container_objectives) == 5
@@ -123,25 +121,7 @@ defmodule Oli.Delivery.Sections.ContainedObjectivesBuilderTest do
       assert {:ok, _} = perform_job(ContainedObjectivesBuilder, %{section_slug: section.slug})
 
       assert Sections.get_section_by(slug: section.slug).v25_migration == :done
-      assert [] == get_section_contained_objectives(section.id, nil)
+      assert [] == Sections.get_section_contained_objectives(section.id, nil)
     end
-  end
-
-  defp get_section_contained_objectives(section_id, nil) do
-    Repo.all(
-      from(co in ContainedObjective,
-        where: co.section_id == ^section_id and is_nil(co.container_id),
-        select: co.objective_id
-      )
-    )
-  end
-
-  defp get_section_contained_objectives(section_id, container_id) do
-    Repo.all(
-      from(co in ContainedObjective,
-        where: [section_id: ^section_id, container_id: ^container_id],
-        select: co.objective_id
-      )
-    )
   end
 end

--- a/test/oli/delivery/sections_test.exs
+++ b/test/oli/delivery/sections_test.exs
@@ -4,6 +4,8 @@ defmodule Oli.Delivery.SectionsTest do
   import Oli.Utils.Seeder.Utils
 
   alias Oli.Utils.Seeder
+  alias Oli.Factory
+  alias Oli.Delivery.Sections
 
   describe "sections" do
     setup(%{conn: conn}) do
@@ -54,6 +56,126 @@ defmodule Oli.Delivery.SectionsTest do
         |> get(Routes.page_delivery_path(conn, :index, section.slug))
 
       assert html_response(conn, 200) =~ "Example Section"
+    end
+  end
+
+  describe "rebuild_contained_objectives/1 for a section with objectives" do
+    setup [:create_full_project_with_objectives]
+
+    ## Course Hierarchy
+    #
+    # Root Container --> Page 1 --> Activity X
+    #                |--> Unit Container --> Module Container 1 --> Page 2 --> Activity Y
+    #                |                                                     |--> Activity Z
+    #                |--> Module Container 2 --> Page 3 --> Activity W
+    #
+    ## Objectives Hierarchy
+    #
+    # Page 1 --> Objective A
+    # Page 2 --> Objective B
+    #
+    # Note: the objectives above are not considered since they are attached to the pages
+    #
+    # Activity Y --> Objective C
+    #           |--> SubObjective C1
+    # Activity Z --> Objective D
+    # Activity W --> Objective E
+    #           |--> Objective F
+    #
+    # Note: Activity X does not have objectives
+    test "it ignores objectives attached to inner pages", %{
+      section: section,
+      resources: resources
+    } do
+      assert {:ok, _} = Sections.rebuild_contained_objectives(section)
+
+      # Check Root Container objectives
+      root_container_objectives = Sections.get_section_contained_objectives(section.id, nil)
+
+      # Objectives A and B are not attached
+      [resources.obj_resource_a, resources.obj_resource_b]
+      |> Enum.each(fn objective ->
+        refute Enum.find(root_container_objectives, &(&1 == objective.id))
+      end)
+
+      assert Sections.get_section_by(slug: section.slug).v25_migration == :done
+    end
+
+    test "it creates contained objectives for each objective in the inner activities", %{
+      section: section,
+      resources: resources
+    } do
+      assert {:ok, _} = Sections.rebuild_contained_objectives(section)
+
+      # Check Module Container 1 objectives
+      module_container_1_objectives =
+        Sections.get_section_contained_objectives(section.id, resources.module_resource_1.id)
+
+      # C, C1 and D are the objectives attached to the inner activities
+      assert length(module_container_1_objectives) == 3
+
+      assert Enum.sort(module_container_1_objectives) ==
+               Enum.sort([
+                 resources.obj_resource_c.id,
+                 resources.obj_resource_c1.id,
+                 resources.obj_resource_d.id
+               ])
+
+      # Check Unit Container objectives
+      unit_container_objectives =
+        Sections.get_section_contained_objectives(section.id, resources.unit_resource.id)
+
+      # C, C1 and D are the objectives attached to the inner activities
+      assert length(unit_container_objectives) == 3
+
+      assert Enum.sort(unit_container_objectives) ==
+               Enum.sort([
+                 resources.obj_resource_c.id,
+                 resources.obj_resource_c1.id,
+                 resources.obj_resource_d.id
+               ])
+
+      # Check Module Container 2 objectives
+      module_container_2_objectives =
+        Sections.get_section_contained_objectives(section.id, resources.module_resource_2.id)
+
+      # E and F are the objectives attached to the inner activities
+      assert length(module_container_2_objectives) == 2
+
+      assert Enum.sort(module_container_2_objectives) ==
+               Enum.sort([
+                 resources.obj_resource_e.id,
+                 resources.obj_resource_f.id
+               ])
+
+      # Check Root Container objectives
+      root_container_objectives = Sections.get_section_contained_objectives(section.id, nil)
+
+      # C, C1, D, E and F are the objectives attached to the inner activities
+      assert length(root_container_objectives) == 5
+
+      assert Enum.sort(root_container_objectives) ==
+               Enum.sort([
+                 resources.obj_resource_c.id,
+                 resources.obj_resource_c1.id,
+                 resources.obj_resource_d.id,
+                 resources.obj_resource_e.id,
+                 resources.obj_resource_f.id
+               ])
+
+      assert Sections.get_section_by(slug: section.slug).v25_migration == :done
+    end
+  end
+
+  describe "rebuild_contained_objectives/1 for a section without objectives" do
+    setup [:create_full_project_with_objectives]
+
+    test "it does not insert any contained objective" do
+      section = Factory.insert(:section)
+
+      assert {:ok, _} = Sections.rebuild_contained_objectives(section)
+
+      assert [] == Sections.get_section_contained_objectives(section.id, nil)
     end
   end
 end

--- a/test/oli/delivery_test.exs
+++ b/test/oli/delivery_test.exs
@@ -4,6 +4,7 @@ defmodule Oli.DeliveryTest do
   import Oli.Factory
 
   alias Oli.Delivery
+  alias Oli.Delivery.Sections
 
   describe "delivery settings" do
     test "maybe_update_section_contains_explorations/1 update contains_explorations field" do
@@ -23,6 +24,295 @@ defmodule Oli.DeliveryTest do
       section_without_explorations = Oli.Delivery.Sections.get_section_by_slug(section.slug)
 
       refute section_without_explorations.contains_explorations
+    end
+  end
+
+  describe "create_section/4" do
+    ## Course Hierarchy
+    #
+    # Root Container --> Page 1 --> Activity X
+    #                |--> Unit Container --> Module Container 1 --> Page 2 --> Activity Y
+    #                |                                                     |--> Activity Z
+    #                |--> Module Container 2 --> Page 3 --> Activity W
+    #
+    ## Objectives Hierarchy
+    #
+    # Page 1 --> Objective A
+    # Page 2 --> Objective B
+    #
+    # Note: the objectives above are not considered since they are attached to the pages
+    #
+    # Activity Y --> Objective C
+    #           |--> SubObjective C1
+    # Activity Z --> Objective D
+    # Activity W --> Objective E
+    #           |--> Objective F
+    #
+    # Note: Activity X does not have objectives
+    setup do
+      map = create_full_project_with_objectives()
+      institution = insert(:institution)
+      user = insert(:user)
+      jwk = jwk_fixture()
+      registration = registration_fixture(%{tool_jwk_id: jwk.id})
+
+      deployment =
+        deployment_fixture(%{institution_id: institution.id, registration_id: registration.id})
+
+      lti_params =
+        Oli.Lti.TestHelpers.all_default_claims()
+        |> put_in(["iss"], registration.issuer)
+        |> put_in(["aud"], registration.client_id)
+        |> put_in(["https://purl.imsglobal.org/spec/lti/claim/roles"], [
+          "http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor"
+        ])
+
+      product =
+        insert(:section,
+          base_project: map.project,
+          open_and_free: false,
+          registration_open: false,
+          type: :blueprint,
+          title: "Product 1",
+          slug: "product_1"
+        )
+
+      {:ok, product} = Sections.create_section_resources(product, map.publication)
+
+      {:ok,
+       Map.merge(map, %{
+         institution: institution,
+         user: user,
+         lti_params: lti_params,
+         deployment: deployment,
+         product: product
+       })}
+    end
+
+    test "returns section if it already exists", context do
+      section =
+        insert(:section, %{
+          institution: context.institution,
+          base_project: context.project,
+          lti_1p3_deployment: context.deployment
+        })
+
+      lti_params =
+        put_in(
+          context.lti_params,
+          ["https://purl.imsglobal.org/spec/lti/claim/context", "id"],
+          section.context_id
+        )
+
+      assert {:ok, returned_section} =
+               Delivery.create_section(
+                 "publication:#{context.publication.id}",
+                 context.user,
+                 lti_params
+               )
+
+      assert returned_section.id == section.id
+    end
+
+    test "creates section with contained objectives from publication if it does not exist",
+         context do
+      context_id = "123"
+      title = "Intro to Math"
+
+      lti_params =
+        context.lti_params
+        |> put_in(
+          ["https://purl.imsglobal.org/spec/lti/claim/context", "id"],
+          context_id
+        )
+        |> put_in(["https://purl.imsglobal.org/spec/lti/claim/context", "title"], title)
+
+      assert {:ok, returned_section} =
+               Delivery.create_section(
+                 "publication:#{context.publication.id}",
+                 context.user,
+                 lti_params
+               )
+
+      # Check section fields
+      assert returned_section.type == :enrollable
+      assert returned_section.title == title
+      assert returned_section.context_id == context_id
+      assert returned_section.institution_id == context.institution.id
+      assert returned_section.base_project_id == context.publication.project_id
+      assert returned_section.lti_1p3_deployment_id == context.deployment.id
+
+      # User is enrolled as instructor
+      instructors = Sections.instructors_per_section([returned_section.id])
+      assert [instructor] = instructors[returned_section.id]
+      assert context.user.name == instructor
+
+      # Check contained objectives
+      # Check Module Container 1 objectives
+      module_container_1_objectives =
+        Sections.get_section_contained_objectives(
+          returned_section.id,
+          context.resources.module_resource_1.id
+        )
+
+      # C, C1 and D are the objectives attached to the inner activities
+      assert length(module_container_1_objectives) == 3
+
+      assert Enum.sort(module_container_1_objectives) ==
+               Enum.sort([
+                 context.resources.obj_resource_c.id,
+                 context.resources.obj_resource_c1.id,
+                 context.resources.obj_resource_d.id
+               ])
+
+      # Check Unit Container objectives
+      unit_container_objectives =
+        Sections.get_section_contained_objectives(
+          returned_section.id,
+          context.resources.unit_resource.id
+        )
+
+      # C, C1 and D are the objectives attached to the inner activities
+      assert length(unit_container_objectives) == 3
+
+      assert Enum.sort(unit_container_objectives) ==
+               Enum.sort([
+                 context.resources.obj_resource_c.id,
+                 context.resources.obj_resource_c1.id,
+                 context.resources.obj_resource_d.id
+               ])
+
+      # Check Module Container 2 objectives
+      module_container_2_objectives =
+        Sections.get_section_contained_objectives(
+          returned_section.id,
+          context.resources.module_resource_2.id
+        )
+
+      # E and F are the objectives attached to the inner activities
+      assert length(module_container_2_objectives) == 2
+
+      assert Enum.sort(module_container_2_objectives) ==
+               Enum.sort([
+                 context.resources.obj_resource_e.id,
+                 context.resources.obj_resource_f.id
+               ])
+
+      # Check Root Container objectives
+      root_container_objectives =
+        Sections.get_section_contained_objectives(returned_section.id, nil)
+
+      # C, C1, D, E and F are the objectives attached to the inner activities
+      assert length(root_container_objectives) == 5
+
+      assert Enum.sort(root_container_objectives) ==
+               Enum.sort([
+                 context.resources.obj_resource_c.id,
+                 context.resources.obj_resource_c1.id,
+                 context.resources.obj_resource_d.id,
+                 context.resources.obj_resource_e.id,
+                 context.resources.obj_resource_f.id
+               ])
+    end
+
+    test "creates section with contained objectives from product if it does not exist", context do
+      lti_params =
+        context.lti_params
+        |> put_in(
+          ["https://purl.imsglobal.org/spec/lti/claim/context", "id"],
+          context.product.context_id
+        )
+        |> put_in(
+          ["https://purl.imsglobal.org/spec/lti/claim/context", "title"],
+          context.product.title
+        )
+
+      assert {:ok, returned_section} =
+               Delivery.create_section(
+                 "product:#{context.product.id}",
+                 context.user,
+                 lti_params
+               )
+
+      # Check section fields
+      assert returned_section.type == :enrollable
+      assert returned_section.title == context.product.title
+      assert returned_section.context_id == context.product.context_id
+      assert returned_section.institution_id == context.institution.id
+      assert returned_section.base_project_id == context.publication.project_id
+      assert returned_section.lti_1p3_deployment_id == context.deployment.id
+
+      # User is enrolled as instructor
+      instructors = Sections.instructors_per_section([returned_section.id])
+      assert [instructor] = instructors[returned_section.id]
+      assert context.user.name == instructor
+
+      # Check contained objectives
+      # Check Module Container 1 objectives
+      module_container_1_objectives =
+        Sections.get_section_contained_objectives(
+          returned_section.id,
+          context.resources.module_resource_1.id
+        )
+
+      # C, C1 and D are the objectives attached to the inner activities
+      assert length(module_container_1_objectives) == 3
+
+      assert Enum.sort(module_container_1_objectives) ==
+               Enum.sort([
+                 context.resources.obj_resource_c.id,
+                 context.resources.obj_resource_c1.id,
+                 context.resources.obj_resource_d.id
+               ])
+
+      # Check Unit Container objectives
+      unit_container_objectives =
+        Sections.get_section_contained_objectives(
+          returned_section.id,
+          context.resources.unit_resource.id
+        )
+
+      # C, C1 and D are the objectives attached to the inner activities
+      assert length(unit_container_objectives) == 3
+
+      assert Enum.sort(unit_container_objectives) ==
+               Enum.sort([
+                 context.resources.obj_resource_c.id,
+                 context.resources.obj_resource_c1.id,
+                 context.resources.obj_resource_d.id
+               ])
+
+      # Check Module Container 2 objectives
+      module_container_2_objectives =
+        Sections.get_section_contained_objectives(
+          returned_section.id,
+          context.resources.module_resource_2.id
+        )
+
+      # E and F are the objectives attached to the inner activities
+      assert length(module_container_2_objectives) == 2
+
+      assert Enum.sort(module_container_2_objectives) ==
+               Enum.sort([
+                 context.resources.obj_resource_e.id,
+                 context.resources.obj_resource_f.id
+               ])
+
+      # Check Root Container objectives
+      root_container_objectives =
+        Sections.get_section_contained_objectives(returned_section.id, nil)
+
+      # C, C1, D, E and F are the objectives attached to the inner activities
+      assert length(root_container_objectives) == 5
+
+      assert Enum.sort(root_container_objectives) ==
+               Enum.sort([
+                 context.resources.obj_resource_c.id,
+                 context.resources.obj_resource_c1.id,
+                 context.resources.obj_resource_d.id,
+                 context.resources.obj_resource_e.id,
+                 context.resources.obj_resource_f.id
+               ])
     end
   end
 end

--- a/test/oli_web/controllers/open_and_free_controller_test.exs
+++ b/test/oli_web/controllers/open_and_free_controller_test.exs
@@ -104,15 +104,17 @@ defmodule OliWeb.OpenAndFreeControllerTest do
   end
 
   describe "create open_and_free" do
-    setup [:create_fixtures]
+    setup [:create_full_project_with_objectives]
 
     test "redirects to show when data is valid", %{
       conn: conn,
       admin: admin,
       project: project,
-      user: user,
-      revision1: revision1
+      resources: resources,
+      revisions: %{page_revision_1: page_revision_1}
     } do
+      user = insert(:user)
+
       conn =
         post(conn, Routes.admin_open_and_free_path(conn, :create),
           section: Enum.into(@create_attrs, %{project_slug: project.slug})
@@ -125,6 +127,21 @@ defmodule OliWeb.OpenAndFreeControllerTest do
 
       # can access open and free index and pages
       section = Sections.get_section_by(slug: slug)
+
+      # Check Root Container objectives
+      root_container_objectives = Sections.get_section_contained_objectives(section.id, nil)
+
+      # C, C1, D, E and F are the objectives attached to the inner activities
+      assert length(root_container_objectives) == 5
+
+      assert Enum.sort(root_container_objectives) ==
+               Enum.sort([
+                 resources.obj_resource_c.id,
+                 resources.obj_resource_c1.id,
+                 resources.obj_resource_d.id,
+                 resources.obj_resource_e.id,
+                 resources.obj_resource_f.id
+               ])
 
       conn =
         conn
@@ -139,9 +156,9 @@ defmodule OliWeb.OpenAndFreeControllerTest do
       conn =
         conn
         |> recycle_user_session(user)
-        |> get(Routes.page_delivery_path(conn, :page, section.slug, revision1.slug))
+        |> get(Routes.page_delivery_path(conn, :page, section.slug, page_revision_1.slug))
 
-      assert html_response(conn, 200) =~ "Page one"
+      assert html_response(conn, 200) =~ "Page 1"
     end
   end
 

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -6,6 +6,7 @@ defmodule Oli.TestHelpers do
   alias Oli.Repo
   alias Oli.Accounts
   alias Oli.Accounts.{Author, AuthorPreferences, User}
+  alias Oli.Activities
   alias Oli.Authoring.Course
   alias Oli.Authoring.Course.Project
   alias Oli.Delivery.Sections
@@ -1300,6 +1301,22 @@ defmodule Oli.TestHelpers do
         module_resource_2: module_resource_2,
         unit_resource: unit_resource,
         root_resource: root_resource
+      },
+      revisions: %{
+        obj_revision_a: obj_revision_a,
+        obj_revision_b: obj_revision_b,
+        obj_revision_c: obj_revision_c,
+        obj_revision_c1: obj_revision_c1,
+        obj_revision_d: obj_revision_d,
+        obj_revision_e: obj_revision_e,
+        obj_revision_f: obj_revision_f,
+        page_revision_1: page_revision_1,
+        page_revision_2: page_revision_2,
+        page_revision_3: page_revision_3,
+        module_revision_1: module_revision_1,
+        module_revision_2: module_revision_2,
+        unit_revision: unit_revision,
+        root_revision: root_revision
       }
     }
   end
@@ -1333,6 +1350,7 @@ defmodule Oli.TestHelpers do
         objectives: %{"1" => objectives},
         scoring_strategy_id: Oli.Resources.ScoringStrategy.get_id_by_type("average"),
         resource_type_id: ResourceType.get_id_by_type("activity"),
+        activity_type_id: Activities.get_registration_by_slug("oli_multiple_choice").id,
         children: [],
         content: %{"model" => []},
         deleted: false,


### PR DESCRIPTION
[MER-2574](https://eliterate.atlassian.net/browse/MER-2574)

This is the second of a series of three PRs to setup and use contained objectives on Torus.
The new `contained_objectives` table will be used as a support for optimizing queries and finding which objectives are attached to a container in an easier way.

This PR adds the creation of contained objectives in the following three scenarios:
1. When a section is created.
2. When a project update is applied to a section.
3. When a section is remixed.

[MER-2574]: https://eliterate.atlassian.net/browse/MER-2574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ