### PR TITLE
[BUGFIX][MER-2410] New Institution not being created after approving registration

### DIFF
--- a/lib/oli_web/live/admin/institutions/index_live.ex
+++ b/lib/oli_web/live/admin/institutions/index_live.ex
@@ -201,7 +201,7 @@ defmodule OliWeb.Admin.Institutions.IndexLive do
           Are you sure you want to decline this request from "<%= @registration_changeset.name %>"?
         </p>
         <div :if={@registration_changeset} class="flex justify-end border-0">
-          <button type="button" class="btn btn-secondary mr-2">
+          <button phx-click={Modal.hide("#decline-registration-modal")} type="button" class="btn btn-secondary mr-2">
             Cancel
           </button>
           <button
@@ -341,7 +341,7 @@ defmodule OliWeb.Admin.Institutions.IndexLive do
             </div>
 
             <div class="flex justify-end border-0">
-              <button type="button" class="btn btn-secondary mr-2">
+              <button phx-click={Modal.hide("#review-registration-modal")} type="button" class="btn btn-secondary mr-2">
                 Cancel
               </button>
               <button type="submit" class="submit btn btn-success">

--- a/lib/oli_web/live/admin/institutions/index_live.ex
+++ b/lib/oli_web/live/admin/institutions/index_live.ex
@@ -493,7 +493,10 @@ defmodule OliWeb.Admin.Institutions.IndexLive do
                    registration
                  ),
                {:ok, {institution, registration, _deployment}} <-
-                 Institutions.approve_pending_registration(pending_registration) do
+                 approve_pending_registration(
+                   registration["institution_id"],
+                   pending_registration
+                 ) do
             registration_approved_email =
               Oli.Email.create_email(
                 institution.institution_email,
@@ -600,6 +603,13 @@ defmodule OliWeb.Admin.Institutions.IndexLive do
        attr: "data-hide_modal"
      })}
   end
+
+  # handle the case where the creation of a new institution was required (when institution_id == "")
+  defp approve_pending_registration("", pending_registration),
+    do: Institutions.approve_pending_registration_as_new_institution(pending_registration)
+
+  defp approve_pending_registration(_, pending_registration),
+    do: Institutions.approve_pending_registration(pending_registration)
 
   defp root_breadcrumbs() do
     OliWeb.Admin.AdminView.breadcrumb() ++

--- a/lib/oli_web/live/admin/institutions/index_live.ex
+++ b/lib/oli_web/live/admin/institutions/index_live.ex
@@ -531,7 +531,8 @@ defmodule OliWeb.Admin.Institutions.IndexLive do
                 Enum.filter(
                   socket.assigns.pending_registrations,
                   &(&1.id != pending_registration.id)
-                )
+                ),
+              institutions: Institutions.list_institutions()
             )
             |> put_flash(:info, [
               "Registration for ",


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-2410?focusedCommentId=21238) to the ticket's comment

# Pending Registration Approval
## Before
https://github.com/Simon-Initiative/oli-torus/assets/74839302/9e565066-19b9-474f-b525-b3f4a2e68efc

## After
https://github.com/Simon-Initiative/oli-torus/assets/74839302/d7723246-602d-4824-84bc-0343285f8a21

I also checked that, after the registration is approved, the user is being redirected to the section creation wizard when launching Argos from the Canvas course, as expected:

https://github.com/Simon-Initiative/oli-torus/assets/74839302/c9b31fe8-1b3e-493c-9ca9-3546797fc891

# Modal's Cancel button not working
I found that the modal's cancel button was not working, so this PR also fixes that bug.

## Before
https://github.com/Simon-Initiative/oli-torus/assets/74839302/147d8bbc-6a54-419e-9d33-19f392afc762

## After
https://github.com/Simon-Initiative/oli-torus/assets/74839302/9a489b65-3001-47d7-98fc-54a36600edd6


