### PR TITLE
[BUGFIX] [MER-2612] Scoring in assessment settings defaulting to average

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -1506,7 +1506,6 @@ defmodule Oli.Delivery.Sections do
     section_resources = [
       # The below is necessary because Repo.insert_all/3 receives a map, not a struct
       # The below is necessary because Repo.insert_all/3 doesn't autogenerate values
-      # TODO: CAMBIAR ESTO
       %SectionResource{
         numbering_index: numbering_index,
         numbering_level: level,

--- a/lib/oli/delivery/sections/section_resource.ex
+++ b/lib/oli/delivery/sections/section_resource.ex
@@ -117,6 +117,7 @@ defmodule Oli.Delivery.Sections.SectionResource do
       :project_id,
       :section_id,
       :delivery_policy_id,
+      :scoring_strategy_id,
       :inserted_at,
       :updated_at
     ])

--- a/lib/oli_web/live/sections/assessment_settings/settings_table_model.ex
+++ b/lib/oli_web/live/sections/assessment_settings/settings_table_model.ex
@@ -274,6 +274,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTableModel do
       name={"scoring_strategy_id-#{@id}"}
       id={"scoring_strategy_id-#{@id}"}
     >
+      <option disabled selected={@scoring_strategy_id == nil} hidden value="">-</option>
       <option selected={@scoring_strategy_id == 1} value={1}>Average</option>
       <option selected={@scoring_strategy_id == 2} value={2}>Best</option>
       <option selected={@scoring_strategy_id == 3} value={3}>Last</option>


### PR DESCRIPTION
[MER-2612](https://eliterate.atlassian.net/browse/MER-2612)

This PR fixes the default scoring strategy shown on the Assessment Settings page when an assessment has no scoring strategy set.

Since there was not an option in the select for when the scoring strategy is not set (is `nil`), the select was taking the first option (`Average`) as the default one.

[MER-2612]: https://eliterate.atlassian.net/browse/MER-2612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ