### PR TITLE
[Bugfix] Render bar between dates correctly

### DIFF
--- a/assets/src/apps/scheduler/PageDragBar.tsx
+++ b/assets/src/apps/scheduler/PageDragBar.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from 'react';
 import { DateWithoutTime } from 'epoq';
 import { useDocumentMouseEvents } from '../../components/hooks/useDocumentMouseEvents';
 import { useToggle } from '../../components/hooks/useToggle';
-import { DayGeometry, barGeometry, leftToDate, validateStartEndDates } from './date-utils';
+import { DayGeometry, barGeometry, betweenGeometry, leftToDate, validateStartEndDates } from './date-utils';
 import { SchedulingType } from './scheduler-slice';
 
 interface DragBarProps {
@@ -115,7 +115,7 @@ export const PageDragBar: React.FC<DragBarProps> = ({
   );
 
   const hasStartEnd = isGraded && startDate && endDate;
-  const geometry = barGeometry(dayGeometry, startDate, endDate);
+  const geometry = betweenGeometry(dayGeometry, startDate, endDate);
   const offsetIcons = hasStartEnd && Math.abs(geometry.width) < 20;
 
   const showConnector = hasStartEnd && !offsetIcons;
@@ -165,11 +165,11 @@ const ConnectorLine: React.FC<{
   startDate: DateWithoutTime;
   endDate: DateWithoutTime;
 }> = ({ dayGeometry, startDate, endDate }) => {
-  const geometry = barGeometry(dayGeometry, startDate, endDate);
+  const geometry = betweenGeometry(dayGeometry, startDate, endDate);
 
   const barStyle = {
-    left: geometry.left + 17,
-    width: geometry.width - 22,
+    left: geometry.left,
+    width: geometry.width ,
     top: 17,
   };
 

--- a/assets/src/apps/scheduler/PageDragBar.tsx
+++ b/assets/src/apps/scheduler/PageDragBar.tsx
@@ -2,7 +2,13 @@ import React, { useCallback, useState } from 'react';
 import { DateWithoutTime } from 'epoq';
 import { useDocumentMouseEvents } from '../../components/hooks/useDocumentMouseEvents';
 import { useToggle } from '../../components/hooks/useToggle';
-import { DayGeometry, barGeometry, betweenGeometry, leftToDate, validateStartEndDates } from './date-utils';
+import {
+  DayGeometry,
+  barGeometry,
+  betweenGeometry,
+  leftToDate,
+  validateStartEndDates,
+} from './date-utils';
 import { SchedulingType } from './scheduler-slice';
 
 interface DragBarProps {
@@ -169,7 +175,7 @@ const ConnectorLine: React.FC<{
 
   const barStyle = {
     left: geometry.left,
-    width: geometry.width ,
+    width: geometry.width,
     top: 17,
   };
 

--- a/assets/src/apps/scheduler/PageScheduleLine.tsx
+++ b/assets/src/apps/scheduler/PageScheduleLine.tsx
@@ -36,23 +36,31 @@ export const PageScheduleLine: React.FC<ScheduleLineProps> = ({ item, indent, da
       let targetStartDate: Date | DateWithoutTime | null = startDate;
 
       if (item.startDateTime && startDate) {
+
         targetStartDate = new Date();
-        targetStartDate.setDate(startDate.getDate());
-        targetStartDate.setMonth(startDate.getMonth());
+        // Important: Important to set these in order
         targetStartDate.setFullYear(startDate.getFullYear());
+        targetStartDate.setMonth(startDate.getMonth());
+        targetStartDate.setDate(startDate.getDate());
         targetStartDate.setHours(
           item.startDateTime.getHours(),
           item.startDateTime.getMinutes(),
           item.startDateTime.getSeconds(),
         );
+
+        console.info("PageScheduleLine::onChange", {
+          startDate,
+          item: item.startDateTime,
+          targetStartDate
+        })
       }
 
       // On a drag, need to change the date, but preserve the end time if one exists.
       if (item.endDateTime) {
         targetEndDate = new Date();
-        targetEndDate.setDate(endDate.getDate());
-        targetEndDate.setMonth(endDate.getMonth());
         targetEndDate.setFullYear(endDate.getFullYear());
+        targetEndDate.setMonth(endDate.getMonth());
+        targetEndDate.setDate(endDate.getDate());
         targetEndDate.setHours(
           item.endDateTime.getHours(),
           item.endDateTime.getMinutes(),

--- a/assets/src/apps/scheduler/PageScheduleLine.tsx
+++ b/assets/src/apps/scheduler/PageScheduleLine.tsx
@@ -36,7 +36,6 @@ export const PageScheduleLine: React.FC<ScheduleLineProps> = ({ item, indent, da
       let targetStartDate: Date | DateWithoutTime | null = startDate;
 
       if (item.startDateTime && startDate) {
-
         targetStartDate = new Date();
         // Important: Important to set these in order
         targetStartDate.setFullYear(startDate.getFullYear());
@@ -48,11 +47,11 @@ export const PageScheduleLine: React.FC<ScheduleLineProps> = ({ item, indent, da
           item.startDateTime.getSeconds(),
         );
 
-        console.info("PageScheduleLine::onChange", {
+        console.info('PageScheduleLine::onChange', {
           startDate,
           item: item.startDateTime,
-          targetStartDate
-        })
+          targetStartDate,
+        });
       }
 
       // On a drag, need to change the date, but preserve the end time if one exists.

--- a/assets/src/apps/scheduler/date-utils.tsx
+++ b/assets/src/apps/scheduler/date-utils.tsx
@@ -84,6 +84,38 @@ const findGeometry = (dayGeometry: DayGeometry, date: DateWithoutTime | null) =>
   return cloneOf(dayGeometry.geometry.find((dg) => dg.date.getDaysSinceEpoch() === epoc));
 };
 
+/** Gets geometry between two dates
+ * This differs from barGeometry, because it goes from the start of the first day to the start of the last day
+ * instead of the start of the first day to the end of the last day.
+ */
+export const betweenGeometry = (
+  dayGeometry: DayGeometry,
+  startDate: DateWithoutTime | null,
+  endDate: DateWithoutTime | null,
+) => {
+  if (!dayGeometry || !startDate) {
+    return { width: 0, left: 0 };
+  }
+
+  const firstDate = new DateWithoutTime(
+    Math.min(startDate.getDaysSinceEpoch(), (endDate || startDate).getDaysSinceEpoch()),
+  );
+  const lastDate = new DateWithoutTime(
+    Math.max(startDate.getDaysSinceEpoch(), (endDate || startDate).getDaysSinceEpoch()),
+  );
+
+  const start = findGeometry(dayGeometry, firstDate);
+  const end = findGeometry(dayGeometry, lastDate);
+  const endPostion = end ? end.left : start ? start.left : 0;
+  const left = start ? start.left : 0;
+  const width = start ? endPostion - left : 0;
+
+  return {
+    width,
+    left,
+  };
+};
+
 export const barGeometry = (
   dayGeometry: DayGeometry,
   startDate: DateWithoutTime | null,


### PR DESCRIPTION
Steps to reproduce:

1. Have a section with a short duration, just a couple weeks
2. Use the scheduler
3. Set an available & due date for an item

Expected: the blue bar goes between the icons
Actual: The blue bar extends past the end date.

This was because the bar was being drawn to the end of the due-date instead of the start of the due date. On schedules that span large amounts of time, it was not noticeable. On schedules spanning only a few weeks, it looked very wrong.

After:
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/a5fbbafc-1d07-4728-966e-987579b9cd29)


Also fixed:

1. Have your computer clock set to a month with 30 days
2. Try to drag to the 31st day in a month with 31 days

Expected: You can drag to the 31st day
Actual: It goes to the 1st day of the month you dragged to

This was caused by us setting the day of a date before the month. The internal date object would be set to the current month, which only had 30 days in it, and if you set it to 31 days, it would revert to the first. Fix was to set date parts in year, month, day order instead of day, month, year order.


