### PR TITLE
[BUG FIX] fix cardinality assumption in Accounts.is_lms_user?/1 [MER-2576]

### DIFF
--- a/lib/oli/accounts.ex
+++ b/lib/oli/accounts.ex
@@ -412,18 +412,13 @@ defmodule Oli.Accounts do
   Returns true if a user belongs to an LMS.
   """
   def is_lms_user?(email) do
-    case get_user_by(%{email: email}) do
-      nil ->
-        false
 
-      %User{id: user_id} ->
-        Repo.exists?(
-          from(
-            lti in LtiParams,
-            where: lti.user_id == ^user_id
-          )
-        )
-    end
+    query = from lti in LtiParams,
+      join: user in User,
+      on: lti.user_id == user.id,
+      where: ilike(user.email, ^email)
+
+    Repo.exists?(query)
   end
 
   @doc """

--- a/lib/oli/accounts.ex
+++ b/lib/oli/accounts.ex
@@ -16,7 +16,6 @@ defmodule Oli.Accounts do
 
   alias Oli.Groups
   alias Oli.Groups.CommunityAccount
-  alias Oli.Lti.LtiParams
   alias Oli.Repo
   alias Oli.Repo.{Paging, Sorting}
   alias Oli.AccountLookupCache
@@ -413,10 +412,8 @@ defmodule Oli.Accounts do
   """
   def is_lms_user?(email) do
 
-    query = from lti in LtiParams,
-      join: user in User,
-      on: lti.user_id == user.id,
-      where: ilike(user.email, ^email)
+    query = from user in User,
+      where: user.email == ^email and user.independent_learner == false
 
     Repo.exists?(query)
   end

--- a/test/oli/accounts_test.exs
+++ b/test/oli/accounts_test.exs
@@ -312,6 +312,32 @@ defmodule Oli.AccountsTest do
       assert Accounts.is_lms_user?(user.email)
     end
 
+    test "is_lms_user?/1 returns true when more than one user email exists and one is lms" do
+      user1 = insert(:user, %{email: "test@test.com", independent_learner: false})
+      insert(:lti_params, user_id: user1.id)
+
+      _user2 = insert(:user, %{email: "test@test.com", independent_learner: false})
+
+      assert Accounts.is_lms_user?(user1.email)
+    end
+
+    test "is_lms_user?/1 returns true when more than one user email exists and all are lms" do
+      user1 = insert(:user, %{email: "test@test.com", independent_learner: false})
+      insert(:lti_params, user_id: user1.id)
+
+      user2 = insert(:user, %{email: "test@test.com", independent_learner: false})
+      insert(:lti_params, user_id: user2.id)
+
+      assert Accounts.is_lms_user?(user1.email)
+    end
+
+    test "is_lms_user?/1 returns false only user is independent" do
+      user1 = insert(:user, %{email: "test@test.com", independent_learner: true})
+
+      refute Accounts.is_lms_user?(user1.email)
+    end
+
+
     test "is_lms_user?/1 returns false when the user does not exist" do
       refute Accounts.is_lms_user?("invalid_email")
     end

--- a/test/oli/accounts_test.exs
+++ b/test/oli/accounts_test.exs
@@ -306,7 +306,7 @@ defmodule Oli.AccountsTest do
     end
 
     test "is_lms_user?/1 returns true when the user exists and belongs to an lms" do
-      user = insert(:user)
+      user = insert(:user, %{email: "test@test.com", independent_learner: false})
       insert(:lti_params, user_id: user.id)
 
       assert Accounts.is_lms_user?(user.email)
@@ -343,7 +343,7 @@ defmodule Oli.AccountsTest do
     end
 
     test "is_lms_user?/1 returns false when the user exists but is not from an lms" do
-      user = insert(:user)
+      user = insert(:user, %{email: "test@test.com", independent_learner: true})
 
       refute Accounts.is_lms_user?(user.email)
     end

--- a/test/oli_web/pow/pow_test.exs
+++ b/test/oli_web/pow/pow_test.exs
@@ -112,7 +112,7 @@ defmodule OliWeb.Common.PowTest do
       conn: conn
     } do
       # sign user in
-      user = insert(:user)
+      user = insert(:user, %{independent_learner: false})
       insert(:lti_params, user_id: user.id)
 
       conn =


### PR DESCRIPTION
Function `Oli.Accounts.is_lms_user?/1` incorrectly assumed that email addresses are unique across all users.  They are only unique for **non LMS users**.  This PR reworks that implementation. 