### PR TITLE
[MER-2617] Codeblock text appears too small

### DIFF
--- a/assets/styles/common/elements.scss
+++ b/assets/styles/common/elements.scss
@@ -83,7 +83,7 @@ $element-margin-bottom: 1.5em;
     color: var(--color-body-color);
     background: var(--color-gray-100);
     font-family: 'Source Code Pro', 'Courier New', Courier, monospace;
-    font-size: 0.75em;
+    font-size: 0.9em;
     letter-spacing: -0.003em;
     border-radius: 6px;
     padding: 1em;


### PR DESCRIPTION
Adjusts the code block font size to be more readable.

Before:
<img width="1036" alt="Screenshot 2023-10-02 at 9 56 17 AM" src="https://github.com/Simon-Initiative/oli-torus/assets/6248894/2b1d35c9-d8a6-47db-820f-01ea1a0138ed">


After:
<img width="1495" alt="Screenshot 2023-10-02 at 3 19 35 PM" src="https://github.com/Simon-Initiative/oli-torus/assets/6248894/b2c346b9-05a7-4135-b3c3-37167767a853">
