### PR TITLE
[MER-2620] z-index issue between the page title and the create menu modal

### DIFF
--- a/assets/styles/authoring/layout/workspace.scss
+++ b/assets/styles/authoring/layout/workspace.scss
@@ -83,7 +83,7 @@ $workspace-sidebar-width: 65px;
     position: sticky;
     top: $workspace-header-height;
     height: calc(100vh - #{$workspace-header-height});
-    z-index: var(--z-20);
+    z-index: 45;
   }
 
   .workspace-right {


### PR DESCRIPTION
Fixes an issue where Titlebar zindex was greater than the sidebar menu.

<img width="422" alt="Screenshot 2023-10-02 at 4 42 27 PM" src="https://github.com/Simon-Initiative/oli-torus/assets/6248894/da6dd7cc-eb23-4f5e-b690-3035f0ca3475">
