### PR TITLE
Mer 2621 fix recommended actions

### DIFF
--- a/lib/oli/delivery/recommended_actions.ex
+++ b/lib/oli/delivery/recommended_actions.ex
@@ -19,17 +19,14 @@ defmodule Oli.Delivery.RecommendedActions do
   end
 
   def section_has_scheduled_resources?(section_id) do
-    items =
-      section_resource_query()
-      |> where(
-        [sr],
-        sr.section_id == ^section_id and (not is_nil(sr.start_date) or not is_nil(sr.end_date))
-      )
-      |> select([sr], sr.id)
-      |> limit(1)
-      |> Repo.all()
-
-    Enum.count(items) > 0
+    section_resource_query()
+    |> where(
+      [sr],
+      sr.section_id == ^section_id and (not is_nil(sr.start_date) or not is_nil(sr.end_date))
+    )
+    |> select([sr], sr.id)
+    |> limit(1)
+    |> Repo.exists?()
   end
 
   def section_scoring_pending_activities_count(section_id) do

--- a/lib/oli/delivery/recommended_actions.ex
+++ b/lib/oli/delivery/recommended_actions.ex
@@ -1,6 +1,8 @@
 defmodule Oli.Delivery.RecommendedActions do
   import Ecto.Query, warn: false
 
+  alias Oli.Delivery.Attempts.Core.ResourceAttempt
+  alias Oli.Delivery.Attempts.Core.ResourceAccess
   alias Oli.Delivery.Sections.{Section, SectionResource, SectionsProjectsPublications}
   alias Oli.Delivery.Attempts.Core.ActivityAttempt
   alias Oli.Repo
@@ -30,10 +32,14 @@ defmodule Oli.Delivery.RecommendedActions do
   end
 
   def section_scoring_pending_activities_count(section_id) do
-    SectionResource
-    |> join(:inner, [sr], aa in ActivityAttempt, on: aa.resource_id == sr.resource_id)
-    |> where([sr, aa], sr.section_id == ^section_id and aa.lifecycle_state == :submitted)
-    |> select([_, aa], count(aa.id))
+    from(aa in ActivityAttempt,
+      join: ra in ResourceAttempt,
+      on: aa.resource_attempt_id == ra.id,
+      join: r_acc in ResourceAccess,
+      on: ra.resource_access_id == r_acc.id,
+      where: aa.lifecycle_state == :submitted and r_acc.section_id == ^section_id,
+      select: count(aa.id)
+    )
     |> Repo.one()
   end
 

--- a/lib/oli_web/components/delivery/recommended_actions.ex
+++ b/lib/oli_web/components/delivery/recommended_actions.ex
@@ -10,69 +10,95 @@ defmodule OliWeb.Components.Delivery.RecommendedActions do
   attr :has_pending_updates, :boolean, required: true
   attr :has_due_soon_activities, :boolean, required: true
 
-  def render(%{
-    has_scheduled_resources: false,
-    scoring_pending_activities_count: 0,
-    approval_pending_posts_count: 0,
-    has_pending_updates: false,
-    has_due_soon_activities: false
-  } = assigns) do
+  def render(
+        %{
+          has_scheduled_resources: true,
+          scoring_pending_activities_count: 0,
+          approval_pending_posts_count: 0,
+          has_pending_updates: false,
+          has_due_soon_activities: false
+        } = assigns
+      ) do
     ~H"""
-      <div class="flex justify-center p-4">
-        <span class="torus-span">No action needed</span>
-      </div>
+    <div class="flex justify-center p-4">
+      <span class="torus-span">No action needed</span>
+    </div>
     """
   end
 
   def render(assigns) do
     ~H"""
-      <div class="grid grid-cols-2 gap-2">
-        <%= if !@has_scheduled_resources do %>
-          <.action_card to={Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.ScheduleView, @section_slug)}>
-            <:icon><i class="fa-regular fa-calendar" /></:icon>
-            <:title>Scheduling</:title>
-            <:description>
-              You have not defined a schedule for your course content
-            </:description>
-          </.action_card>
-        <% end %>
-        <%= if @scoring_pending_activities_count > 0 do %>
-          <.action_card to={Routes.live_path(OliWeb.Endpoint, OliWeb.ManualGrading.ManualGradingView, @section_slug)}>
-            <:icon><i class="fa-solid fa-circle-question" /></:icon>
-            <:title>Score questions</:title>
-            <:description>
-              You have <%= @scoring_pending_activities_count %> <%= if @scoring_pending_activities_count > 1, do: "questions that are", else: "question that is" %> awaiting your manual scoring
-            </:description>
-          </.action_card>
-        <% end %>
-        <%= if @approval_pending_posts_count > 0 do %>
-          <.action_card to={Routes.page_delivery_path(OliWeb.Endpoint, :discussion, @section_slug)}>
-            <:icon><i class="fa-solid fa-circle-check" /></:icon>
-            <:title>Approve Pending Posts</:title>
-            <:description>
-              You have <%= @approval_pending_posts_count %> discussion <%= if @approval_pending_posts_count > 1, do: "posts that are", else: "post that is" %> pending your approval
-            </:description>
-          </.action_card>
-        <% end %>
-        <%= if @has_pending_updates do %>
-          <.action_card to={Routes.source_materials_path(OliWeb.Endpoint, OliWeb.Delivery.ManageSourceMaterials, @section_slug)}>
-            <:icon><i class="fa-solid fa-rotate" /></:icon>
-            <:title>Pending course update</:title>
-            <:description>
-              There are available course content updates that you have not accepted
-            </:description>
-          </.action_card>
-        <% end %>
-        <%= if @has_due_soon_activities do %>
-          <.action_card to={Routes.live_path(OliWeb.Endpoint, OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive, @section_slug, :overview, :scored_activities)}>
-            <:icon><i class="fa-solid fa-hourglass-half" /></:icon>
-            <:title>Remind Students of Deadlines</:title>
-            <:description>
-              There are assessments due soon, review and remind students
-            </:description>
-          </.action_card>
-        <% end %>
-      </div>
+    <div class="grid grid-cols-2 gap-2">
+      <%= if !@has_scheduled_resources do %>
+        <.action_card to={
+          Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.ScheduleView, @section_slug)
+        }>
+          <:icon><i class="fa-regular fa-calendar" /></:icon>
+          <:title>Scheduling</:title>
+          <:description>
+            You have not defined a schedule for your course content
+          </:description>
+        </.action_card>
+      <% end %>
+      <%= if @scoring_pending_activities_count > 0 do %>
+        <.action_card to={
+          Routes.live_path(OliWeb.Endpoint, OliWeb.ManualGrading.ManualGradingView, @section_slug)
+        }>
+          <:icon><i class="fa-solid fa-circle-question" /></:icon>
+          <:title>Score questions</:title>
+          <:description>
+            You have <%= @scoring_pending_activities_count %> <%= if @scoring_pending_activities_count >
+                                                                       1,
+                                                                     do: "questions that are",
+                                                                     else: "question that is" %> awaiting your manual scoring
+          </:description>
+        </.action_card>
+      <% end %>
+      <%= if @approval_pending_posts_count > 0 do %>
+        <.action_card to={Routes.page_delivery_path(OliWeb.Endpoint, :discussion, @section_slug)}>
+          <:icon><i class="fa-solid fa-circle-check" /></:icon>
+          <:title>Approve Pending Posts</:title>
+          <:description>
+            You have <%= @approval_pending_posts_count %> discussion <%= if @approval_pending_posts_count >
+                                                                              1,
+                                                                            do: "posts that are",
+                                                                            else: "post that is" %> pending your approval
+          </:description>
+        </.action_card>
+      <% end %>
+      <%= if @has_pending_updates do %>
+        <.action_card to={
+          Routes.source_materials_path(
+            OliWeb.Endpoint,
+            OliWeb.Delivery.ManageSourceMaterials,
+            @section_slug
+          )
+        }>
+          <:icon><i class="fa-solid fa-rotate" /></:icon>
+          <:title>Pending course update</:title>
+          <:description>
+            There are available course content updates that you have not accepted
+          </:description>
+        </.action_card>
+      <% end %>
+      <%= if @has_due_soon_activities do %>
+        <.action_card to={
+          Routes.live_path(
+            OliWeb.Endpoint,
+            OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive,
+            @section_slug,
+            :overview,
+            :scored_activities
+          )
+        }>
+          <:icon><i class="fa-solid fa-hourglass-half" /></:icon>
+          <:title>Remind Students of Deadlines</:title>
+          <:description>
+            There are assessments due soon, review and remind students
+          </:description>
+        </.action_card>
+      <% end %>
+    </div>
     """
   end
 
@@ -83,13 +109,18 @@ defmodule OliWeb.Components.Delivery.RecommendedActions do
 
   defp action_card(assigns) do
     ~H"""
-      <a href={@to} class="group border border-gray-200 dark:border-gray-600 rounded p-3 pl-8 flex flex-col justify-center cursor-pointer hover:bg-delivery-primary-50 active:bg-delivery-primary active:text-white hover:no-underline">
-        <div class="flex items-center gap-2">
-          <%= render_slot(@icon) %>
-          <h4><%= render_slot(@title) %></h4>
-        </div>
-        <span class="torus-span group-hover:text-gray-500 group-active:text-white"><%= render_slot(@description) %></span>
-      </a>
+    <a
+      href={@to}
+      class="group border border-gray-200 dark:border-gray-600 rounded p-3 pl-8 flex flex-col justify-center cursor-pointer hover:bg-delivery-primary-50 active:bg-delivery-primary active:text-white hover:no-underline"
+    >
+      <div class="flex items-center gap-2">
+        <%= render_slot(@icon) %>
+        <h4><%= render_slot(@title) %></h4>
+      </div>
+      <span class="torus-span group-hover:text-gray-500 group-active:text-white">
+        <%= render_slot(@description) %>
+      </span>
+    </a>
     """
   end
 end

--- a/test/oli_web/live/delivery/instructor_dashboard/overview/recommended_actions_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/overview/recommended_actions_tab_test.exs
@@ -24,6 +24,18 @@ defmodule OliWeb.Delivery.InstructorDashboard.Overview.RecommendedActionsTest do
     {:ok, []}
   end
 
+  defp add_schedule(section_id) do
+    {:ok, start_date} = DateTime.from_naive(~N[2023-05-24 00:00:00], "UTC")
+
+    Oli.Delivery.Sections.SectionResource
+    |> where([sr], sr.section_id == ^section_id)
+    |> select([sr], sr)
+    |> limit(1)
+    |> Repo.one()
+    |> Oli.Delivery.Sections.SectionResource.changeset(%{start_date: start_date})
+    |> Repo.update()
+  end
+
   describe "Instructor dashboard overview - recommended_actions tab" do
     setup [:instructor_conn, :basic_section, :enroll_instructor]
 
@@ -31,6 +43,8 @@ defmodule OliWeb.Delivery.InstructorDashboard.Overview.RecommendedActionsTest do
       conn: conn,
       section: section
     } do
+      add_schedule(section.id)
+
       {:ok, view, _html} = live(conn, instructor_course_content_path(section.slug))
 
       assert has_element?(view, "span", "No action needed")
@@ -40,15 +54,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.Overview.RecommendedActionsTest do
       conn: conn,
       section: section
     } do
-      {:ok, start_date} = DateTime.from_naive(~N[2023-05-24 00:00:00], "UTC")
-
-      Oli.Delivery.Sections.SectionResource
-      |> where([sr], sr.section_id == ^section.id)
-      |> select([sr], sr)
-      |> limit(1)
-      |> Repo.one()
-      |> Oli.Delivery.Sections.SectionResource.changeset(%{start_date: start_date})
-      |> Repo.update()
+      add_schedule(section.id)
 
       assert Oli.Delivery.RecommendedActions.section_has_scheduled_resources?(section.id)
 
@@ -58,13 +64,17 @@ defmodule OliWeb.Delivery.InstructorDashboard.Overview.RecommendedActionsTest do
       refute has_element?(view, "span", "You have not defined a schedule for your course content")
     end
 
-    test "renders the \"soft scheduling\" action when necessary", %{
-      conn: conn,
-      section: section
-    } do
-      {:ok, _view, _html} = live(conn, instructor_course_content_path(section.slug))
+    test "renders the \"soft scheduling\" action when necessary (for example, after a new course section has just been created)",
+         %{
+           conn: conn,
+           section: section
+         } do
+      {:ok, view, _html} = live(conn, instructor_course_content_path(section.slug))
 
       refute Oli.Delivery.RecommendedActions.section_has_scheduled_resources?(section.id)
+
+      assert has_element?(view, "h4", "Scheduling")
+      assert has_element?(view, "span", "You have not defined a schedule for your course content")
     end
 
     test "renders the \"pending approval posts\" action when necessary", %{


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-2621) to the ticket

## Before (no schedule recommended action for a newly created course section)

https://github.com/Simon-Initiative/oli-torus/assets/74839302/f69aa1e8-966d-4b78-96ec-2a6005eebe09


## After (schedule recommended action)

https://github.com/Simon-Initiative/oli-torus/assets/74839302/07d033cd-512c-446b-945a-d2aacd2458c3

## Other validations
After implementing the fix, we validated other recommended actions worked as expected (there are unit tests for those as well), for example, a Graded Page coming due within the next 24 hours 

https://github.com/Simon-Initiative/oli-torus/assets/74839302/3ad44b53-9153-4941-8fd4-538b513869e3

## Other bug found and fixed
When a section was created the `score questions` recommended action was sometimes shown when its resources had attempts in another course (previously created from the same project, for example). This happened because attempts were not being filtered by section properly.  

### Before (score questions of other courses being shown)

https://github.com/Simon-Initiative/oli-torus/assets/74839302/3c40bac6-f183-4eed-b8a8-ee359c5031ec

### After 

![Screenshot 2023-10-03 at 09 37 47](https://github.com/Simon-Initiative/oli-torus/assets/74839302/bb7b411d-647d-4014-b21c-d581cff963de)

