### PR TITLE
[BUG FIX] never show hints in graded context [MER-2624]

### DIFF
--- a/assets/src/components/activities/common/hints/delivery/HintsDeliveryConnected.tsx
+++ b/assets/src/components/activities/common/hints/delivery/HintsDeliveryConnected.tsx
@@ -25,9 +25,9 @@ const shouldShow = (
   surveyId: string | null,
   shouldShow?: boolean,
 ) => {
-  if (shouldShow) return true;
   if (graded) return false;
   if (surveyId !== null) return false;
+  if (shouldShow) return true;
 
   return !isEvaluated(uiState) && !isSubmitted(uiState);
 };


### PR DESCRIPTION
Changed the ordering of the checks within the `HintsDeliveryConnected` component to ensure that if we are in a graded page that we do not show hints. 