### PR TITLE
[BUG FIX] Empty slugs [MER-2625]

### DIFF
--- a/lib/oli/utils/slug.ex
+++ b/lib/oli/utils/slug.ex
@@ -172,12 +172,23 @@ defmodule Oli.Utils.Slug do
   def slugify(nil), do: ""
 
   def slugify(title) do
-    String.downcase(title, :default)
+    case String.downcase(title, :default)
     |> String.trim()
     |> String.replace(" ", "_")
     |> alpha_numeric_only()
     |> URI.encode_www_form()
-    |> String.slice(0, 30)
+    |> String.slice(0, 30) do
+
+      # A page title that only contains non-alphanumeric characters will
+      # generate a slug that is empty. This is not allowed, so we generate
+      # a random slug instead.
+      "" ->
+        random_string(10)
+
+      otherwise ->
+        otherwise
+
+    end
   end
 
   defp unique_slug(table, generate_candidate) when is_function(generate_candidate) do

--- a/test/oli/utils/slug_test.exs
+++ b/test/oli/utils/slug_test.exs
@@ -55,6 +55,23 @@ defmodule Oli.Utils.SlugTest do
       assert new_revision.slug == r.slug
     end
 
+    test "update_on_change/2 creates non-empty slug when title contains special characters", %{
+      revision1: r
+    } do
+      {:ok, new_revision} =
+        Revision.changeset(%Revision{}, %{
+          previous_revision_id: r.id,
+          title: "灵丹妙药",
+          resource_id: r.resource_id,
+          resource_type_id: r.resource_type_id,
+          author_id: r.author_id
+        })
+        |> Repo.insert()
+
+      assert new_revision.slug != r.slug
+      assert String.length(new_revision.slug) == 10
+    end
+
     test "update_on_change/2 does update the slug when the previous revision title differs", %{
       revision1: r
     } do
@@ -71,6 +88,7 @@ defmodule Oli.Utils.SlugTest do
       refute new_revision.slug == r.slug
       assert new_revision.slug == "a_different_title"
     end
+
 
     test "update_on_change/2 handles the case when there isn't a previous revision", %{
       revision1: r


### PR DESCRIPTION
If a title of a revision only contains non-alphanumeric characters, the slug generated was the empty string, which was downstream breaking assertions about uniqueness.  This edge case is handled by generating a random slug.