### PR TITLE
[MER-2550] Preview with activity bank shows error

### DIFF
--- a/lib/oli/activities/realizer/logic/expression.ex
+++ b/lib/oli/activities/realizer/logic/expression.ex
@@ -47,35 +47,38 @@ defmodule Oli.Activities.Realizer.Logic.Expression do
   alias Oli.Activities.Realizer.Logic.Expression
 
   def parse(%{"fact" => fact, "operator" => operator, "value" => value}) when is_list(value) do
-    case {fact, operator} do
-      {"objectives", "contains"} ->
+    case {fact, operator, value} do
+      {_fact, _operator, []} ->
+        {:error, "no values provided for expression"}
+
+      {"objectives", "contains", value} ->
         {:ok, %Expression{fact: :objectives, operator: :contains, value: value}}
 
-      {"objectives", "equals"} ->
+      {"objectives", "equals", value} ->
         {:ok, %Expression{fact: :objectives, operator: :equals, value: value}}
 
-      {"objectives", "does_not_equal"} ->
+      {"objectives", "does_not_equal", value} ->
         {:ok, %Expression{fact: :objectives, operator: :does_not_equal, value: value}}
 
-      {"objectives", "does_not_contain"} ->
+      {"objectives", "does_not_contain", value} ->
         {:ok, %Expression{fact: :objectives, operator: :does_not_contain, value: value}}
 
-      {"tags", "contains"} ->
+      {"tags", "contains", value} ->
         {:ok, %Expression{fact: :tags, operator: :contains, value: value}}
 
-      {"tags", "equals"} ->
+      {"tags", "equals", value} ->
         {:ok, %Expression{fact: :tags, operator: :equals, value: value}}
 
-      {"tags", "does_not_contain"} ->
+      {"tags", "does_not_contain", value} ->
         {:ok, %Expression{fact: :tags, operator: :does_not_contain, value: value}}
 
-      {"tags", "does_not_equal"} ->
+      {"tags", "does_not_equal", value} ->
         {:ok, %Expression{fact: :tags, operator: :does_not_equal, value: value}}
 
-      {"type", "contains"} ->
+      {"type", "contains", value} ->
         {:ok, %Expression{fact: :type, operator: :contains, value: value}}
 
-      {"type", "does_not_contain"} ->
+      {"type", "does_not_contain", value} ->
         {:ok, %Expression{fact: :type, operator: :does_not_contain, value: value}}
 
       _ ->

--- a/lib/oli/qa/reviewers/selection_worker.ex
+++ b/lib/oli/qa/reviewers/selection_worker.ex
@@ -50,6 +50,15 @@ defmodule Oli.Qa.Reviewers.Content.SelectionWorker do
             )
         end
 
+      {:error, "no values provided for expression"} ->
+        create_warning(
+          review.id,
+          revision_id,
+          project_slug,
+          selection,
+          "No value provided for criteria in bank selection logic"
+        )
+
       _ ->
         create_warning(
           review.id,

--- a/lib/oli_web/controllers/activity_bank_controller.ex
+++ b/lib/oli_web/controllers/activity_bank_controller.ex
@@ -150,6 +150,9 @@ defmodule OliWeb.ActivityBankController do
           e ->
             e
         end
+
+      {:error, "no values provided for expression"} ->
+        {:ok, {revision, selection, [], 0}}
     end
   end
 end

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -560,7 +560,17 @@ defmodule OliWeb.PageDeliveryController do
     }
 
     this_attempt = context.resource_attempts |> hd
-    html = render_content_html(render_context, this_attempt.content, context.page.slug)
+
+    attempt_content =
+      if Enum.any?(this_attempt.errors, fn e ->
+           e == "Selection failed to fulfill: no values provided for expression"
+         end) and context.is_student do
+        %{"model" => []}
+      else
+        this_attempt.content
+      end
+
+    html = render_content_html(render_context, attempt_content, context.page.slug)
     conn = put_root_layout(conn, {OliWeb.LayoutView, "page.html"})
 
     all_activities = Activities.list_activity_registrations()

--- a/lib/oli_web/live/qa/qa_live.ex
+++ b/lib/oli_web/live/qa/qa_live.ex
@@ -143,11 +143,18 @@ defmodule OliWeb.Qa.QaLive do
     <div class="container review">
       <div class="grid grid-cols-12">
         <div class="col-span-12">
-          <p>Run an automated review before publishing to check for broken links and other common issues that may be present in your course.</p>
+          <p>
+            Run an automated review before publishing to check for broken links and other common issues that may be present in your course.
+          </p>
 
-          <button class="btn btn-primary mt-3" id="button-publish"
+          <button
+            class="btn btn-primary mt-3"
+            id="button-publish"
             phx-click="review"
-            phx-disable-with="Reviewing...">Run Review</button>
+            phx-disable-with="Reviewing..."
+          >
+            Run Review
+          </button>
 
           <%= link to: Routes.resource_path(OliWeb.Endpoint, :preview, @project.slug), class: "btn btn-outline-primary mt-3 ml-2", target: "preview-#{@project.slug}" do %>
             Preview Course <i class="fas fa-external-link-alt ml-1"></i>
@@ -160,30 +167,41 @@ defmodule OliWeb.Qa.QaLive do
           <div class="col-span-12">
             <p class="mb-3">
               Last reviewed <strong><%= Utils.render_date(hd(@qa_reviews), :inserted_at, @ctx) %></strong>,
-              with <strong><%= length @warnings %></strong> potential improvement <%= if (length @warnings) == 1 do "opportunity" else "opportunities" end %> found.
+              with <strong><%= length(@warnings) %></strong>
+              potential improvement <%= if length(@warnings) == 1 do
+                "opportunity"
+              else
+                "opportunities"
+              end %> found.
             </p>
             <%= if !Enum.empty?(@warnings_by_type) do %>
               <div class="d-flex">
                 <%= for type <- @warning_types do %>
-                  <%= live_component WarningFilter, active: MapSet.member?(@filters, type), type: type, warnings: Map.get(@warnings_by_type, type) %>
+                  <%= live_component(WarningFilter,
+                    active: MapSet.member?(@filters, type),
+                    type: type,
+                    warnings: Map.get(@warnings_by_type, type)
+                  ) %>
                 <% end %>
               </div>
 
               <div class="reviews">
                 <ul class="review-links">
-                  <%= for warning <- @filtered_warnings do %>
-                    <%= live_component WarningSummary, warning: warning, selected: @selected %>
-                  <% end %>
+                  <WarningSummary.render
+                    :for={warning <- @filtered_warnings}
+                    warning={warning}
+                    selected={@selected}
+                  />
                 </ul>
                 <div class="review-cards">
-                  <%= if @selected != nil do %>
-                    <%= live_component WarningDetails,
-                      parent_pages: @parent_pages,
-                      selected: @selected,
-                      author: @author,
-                      project: @project,
-                      warning: @selected %>
-                  <% end %>
+                  <WarningDetails.render
+                    :if={@selected != nil}
+                    parent_pages={@parent_pages}
+                    selected={@selected}
+                    author={@author}
+                    project={@project}
+                    warning={@selected}
+                  />
                 </div>
               </div>
             <% end %>

--- a/lib/oli_web/live/qa/warning_summary.ex
+++ b/lib/oli_web/live/qa/warning_summary.ex
@@ -1,6 +1,9 @@
 defmodule OliWeb.Qa.WarningSummary do
-  use Phoenix.LiveComponent
+  use OliWeb, :html
   import OliWeb.Qa.Utils
+
+  attr(:warning, :map, required: true)
+  attr(:selected, :map, required: true)
 
   def render(assigns) do
     ~H"""


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-2550?filter=10069&jql=project%20%3D%20MER%20AND%20issuetype%20in%20(Bug,%20Story)%20AND%20status%20in%20(%22In%20Progress%22,%20PR,%20Ready,%20%22To%20Do%22)%20AND%20labels%20%3D%20wyeworks%20ORDER%20BY%20priority%20DESC,%20status%20ASC,%20created%20DESC) to the ticket, that complements the work done at [MER-2570](https://github.com/Simon-Initiative/oli-torus/pull/4244)

This ticket was asked for V0.26 (that's why it targets to `master` branch). Maybe we should implement it for V0.25 (and target it to `prerealase-v0.25.0` branch) as it complements the work done by Santi for v0.25.

## Before (delivery crashing)
https://github.com/Simon-Initiative/oli-torus/assets/74839302/f3712bf8-4f4f-4962-90ab-40ba51f5238c

## After
https://github.com/Simon-Initiative/oli-torus/assets/74839302/9c924d98-b658-4f3f-9ed7-42466293fe2a

## QA Review added for activity bank that contains no logic
https://github.com/Simon-Initiative/oli-torus/assets/74839302/4165fe39-b8db-401c-a285-c3e61428f875



[MER-2570]: https://eliterate.atlassian.net/browse/MER-2570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ