### PR TITLE
[MER-2639] Post created flash appears in all active user windows

### DIFF
--- a/lib/oli/resources/collaboration.ex
+++ b/lib/oli/resources/collaboration.ex
@@ -110,7 +110,7 @@ defmodule Oli.Resources.Collaboration do
           ),
         number_of_posts:
           fragment(
-            "select count(*) from posts where section_id = ? and resource_id = ?",
+            "select count(*) from posts where section_id = ? and resource_id = ? and status != 'deleted'",
             section.id,
             page_revision.resource_id
           ),
@@ -122,7 +122,7 @@ defmodule Oli.Resources.Collaboration do
           ),
         most_recent_post:
           fragment(
-            "select max(inserted_at) from posts where section_id = ? and resource_id = ?",
+            "select max(inserted_at) from posts where section_id = ? and resource_id = ? and status != 'deleted'",
             section.id,
             page_revision.resource_id
           ),

--- a/lib/oli_web/live/collaboration_live/instructor_table_model.ex
+++ b/lib/oli_web/live/collaboration_live/instructor_table_model.ex
@@ -105,7 +105,7 @@ defmodule OliWeb.CollaborationLive.InstructorTableModel do
             <%= @status %>
           </span>
         </div>
-        <span class="torus-span">
+        <span :if={@most_recent_post} class="torus-span">
           <%= "Most recent post: #{FormatDateTime.date(@most_recent_post, @ctx)}" %>
         </span>
       </div>

--- a/test/oli_web/live/collaboration_live_test.exs
+++ b/test/oli_web/live/collaboration_live_test.exs
@@ -1120,7 +1120,8 @@ defmodule OliWeb.CollaborationLiveTest do
              |> render() =~
                "Post successfully created"
 
-      assert_receive {:post_created, %PostSchema{}}
+      post_created_by = user.id
+      assert_receive {:post_created, %PostSchema{}, ^post_created_by}
 
       posts =
         Collaboration.list_posts_for_user_in_page_section(
@@ -1170,7 +1171,8 @@ defmodule OliWeb.CollaborationLiveTest do
              |> render() =~
                "Post successfully created"
 
-      assert_receive {:post_created, %PostSchema{}}
+      post_created_by = user.id
+      assert_receive {:post_created, %PostSchema{}, ^post_created_by}
 
       posts =
         Collaboration.list_posts_for_user_in_page_section(
@@ -1266,7 +1268,8 @@ defmodule OliWeb.CollaborationLiveTest do
              |> render() =~
                "Post successfully edited"
 
-      assert_receive {:post_edited, %PostSchema{}}
+      edited_by = user.id
+      assert_receive {:post_edited, %PostSchema{}, ^edited_by}
 
       updated_post =
         Collaboration.list_posts_for_user_in_page_section(
@@ -1343,7 +1346,8 @@ defmodule OliWeb.CollaborationLiveTest do
              |> render() =~
                "Post/s successfully deleted"
 
-      assert_receive {:post_deleted, ^post_id}
+      user_id = user.id
+      assert_receive {:post_deleted, ^post_id, ^user_id}
 
       posts =
         Collaboration.list_posts_for_user_in_page_section(
@@ -1387,7 +1391,8 @@ defmodule OliWeb.CollaborationLiveTest do
              |> render() =~
                "Post successfully created"
 
-      assert_receive {:post_created, %PostSchema{}}
+      post_created_by = user.id
+      assert_receive {:post_created, %PostSchema{}, ^post_created_by}
 
       posts =
         Collaboration.list_posts_for_user_in_page_section(
@@ -1453,7 +1458,8 @@ defmodule OliWeb.CollaborationLiveTest do
              |> render() =~
                "Post successfully edited"
 
-      assert_receive {:post_edited, %PostSchema{}}
+      post_edited_by = user.id
+      assert_receive {:post_edited, %PostSchema{}, ^post_edited_by}
 
       updated_reply =
         Collaboration.list_posts_for_user_in_page_section(
@@ -1524,7 +1530,8 @@ defmodule OliWeb.CollaborationLiveTest do
              |> render() =~
                "Post/s successfully deleted"
 
-      assert_receive {:post_deleted, ^reply_id}
+      deleted_by_id = user.id
+      assert_receive {:post_deleted, ^reply_id, ^deleted_by_id}
 
       posts =
         Collaboration.list_posts_for_user_in_page_section(
@@ -1585,7 +1592,8 @@ defmodule OliWeb.CollaborationLiveTest do
              |> render() =~
                "Post successfully created"
 
-      assert_receive {:post_created, %PostSchema{}}
+      post_created_by = user.id
+      assert_receive {:post_created, %PostSchema{}, ^post_created_by}
 
       posts =
         Collaboration.list_posts_for_user_in_page_section(
@@ -1714,7 +1722,8 @@ defmodule OliWeb.CollaborationLiveTest do
              |> render() =~
                "Post successfully created"
 
-      assert_receive {:post_created, %PostSchema{}}
+      post_created_by = user.id
+      assert_receive {:post_created, %PostSchema{}, ^post_created_by}
 
       created_post =
         Collaboration.list_posts_for_user_in_page_section(
@@ -1739,7 +1748,7 @@ defmodule OliWeb.CollaborationLiveTest do
              |> render() =~
                "Post successfully created"
 
-      assert_receive {:post_created, %PostSchema{}}
+      assert_receive {:post_created, %PostSchema{}, ^post_created_by}
 
       reply =
         Collaboration.list_posts_for_user_in_page_section(
@@ -1854,7 +1863,8 @@ defmodule OliWeb.CollaborationLiveTest do
              |> render() =~
                "Post successfully created"
 
-      assert_receive {:post_created, %PostSchema{}}
+      post_created_by = user.id
+      assert_receive {:post_created, %PostSchema{}, ^post_created_by}
 
       created_post =
         Collaboration.list_posts_for_user_in_page_section(
@@ -1955,7 +1965,8 @@ defmodule OliWeb.CollaborationLiveTest do
              |> render() =~
                "Post successfully created"
 
-      assert_receive {:post_created, %PostSchema{}}
+      post_created_by = instructor.id
+      assert_receive {:post_created, %PostSchema{}, ^post_created_by}
 
       posts =
         Collaboration.list_posts_for_instructor_in_page_section(
@@ -2030,7 +2041,8 @@ defmodule OliWeb.CollaborationLiveTest do
              |> render() =~
                "Post/s successfully deleted"
 
-      assert_receive {:post_deleted, ^parent_post_id}
+      instructor_id = instructor.id
+      assert_receive {:post_deleted, ^parent_post_id, ^instructor_id}
 
       posts =
         Collaboration.list_posts_for_instructor_in_page_section(
@@ -2085,11 +2097,6 @@ defmodule OliWeb.CollaborationLiveTest do
 
       display_accept_modal(view, second_post.id)
       confirm_accept(view)
-
-      assert view
-             |> element("div.alert.alert-info")
-             |> render() =~
-               "Post successfully edited"
 
       refute has_element?(
                view,
@@ -2267,11 +2274,6 @@ defmodule OliWeb.CollaborationLiveTest do
 
       display_unarchive_modal(view, post.id)
       confirm_unarchive(view)
-
-      assert view
-             |> element("div.alert.alert-info")
-             |> render() =~
-               "Post successfully edited"
 
       # parent post is not archived, but its reply is still archived
       refute has_element?(view, "#post_#{post.id}.bg-gray-100")

--- a/test/oli_web/live/delivery/instructor_dashboard/discussions/discussions_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/discussions/discussions_tab_test.exs
@@ -50,8 +50,22 @@ defmodule OliWeb.Delivery.InstructorDashboard.DiscussionsTabTest do
         title: "Page #2"
       )
 
+    page_resource_3 = insert(:resource)
+    collab_space_config_3 = build(:collab_space_config, status: :enabled)
+
+    page_revision_3 =
+      insert(:revision,
+        resource: page_resource_3,
+        resource_type_id: ResourceType.get_id_by_type("page"),
+        content: %{"model" => []},
+        slug: "page_3",
+        collab_space_config: collab_space_config_3,
+        title: "Page #3"
+      )
+
     insert(:project_resource, %{project_id: project.id, resource_id: page_resource_1.id})
     insert(:project_resource, %{project_id: project.id, resource_id: page_resource_2.id})
+    insert(:project_resource, %{project_id: project.id, resource_id: page_resource_3.id})
 
     container_resource = insert(:resource)
 
@@ -59,7 +73,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.DiscussionsTabTest do
       insert(:revision, %{
         resource: container_resource,
         resource_type_id: ResourceType.get_id_by_type("container"),
-        children: [page_resource_1.id, page_resource_2.id],
+        children: [page_resource_1.id, page_resource_2.id, page_resource_3.id],
         content: %{},
         deleted: false,
         slug: "root_container",
@@ -93,6 +107,13 @@ defmodule OliWeb.Delivery.InstructorDashboard.DiscussionsTabTest do
       publication: publication,
       resource: page_resource_2,
       revision: page_revision_2,
+      author: author
+    })
+
+    insert(:published_resource, %{
+      publication: publication,
+      resource: page_resource_3,
+      revision: page_revision_3,
       author: author
     })
 
@@ -156,7 +177,8 @@ defmodule OliWeb.Delivery.InstructorDashboard.DiscussionsTabTest do
       page_1_post_2: page_1_post_2,
       page_1_post_3: page_1_post_3,
       page_1_post_4: page_1_post_4,
-      page_2_post_1: page_2_post_1
+      page_2_post_1: page_2_post_1,
+      page_revision_1: page_revision_1
     ]
   end
 
@@ -260,20 +282,77 @@ defmodule OliWeb.Delivery.InstructorDashboard.DiscussionsTabTest do
 
       view |> element("form[phx-change='filter']") |> render_change(%{filter: "by_discussion"})
 
-      assert get_elements_in_table_count(view) == 2
+      assert get_elements_in_table_count(view) == 3
       assert view |> has_element?("span", "Page #1")
 
       assert view
-             |> element("table tbody tr:first-of-type p")
+             |> element("table tbody tr:nth-of-type(1) p")
              |> render =~
                ~s{<p class=\"torus-p\">\n      \n        Number of posts: <b>4</b>\n        \n          (1 pending approval)\n        \n      \n    </p>}
 
       assert view |> has_element?("span", "Page #2")
 
       assert view
-             |> element("table tbody tr:last-of-type p")
+             |> element("table tbody tr:nth-of-type(2) p")
              |> render =~
                ~s{<p class=\"torus-p\">\n      \n        Number of posts: <b>1</b>\n        \n          (1 pending approval)\n        \n      \n    </p>}
+
+      assert view
+             |> element("table tbody tr:nth-of-type(3) p")
+             |> render =~ "No posts yet"
+    end
+
+    test "deleted posts are not included in posts count when filtering by collab space", %{
+      conn: conn,
+      instructor: instructor,
+      section: section,
+      page_revision_1: page_revision_1
+    } do
+      enroll_user_to_section(instructor, section, :context_instructor)
+
+      _deleted_post =
+        insert(:post,
+          status: :deleted,
+          content: %{message: "Page 1 - approved post"},
+          section: section,
+          resource: page_revision_1.resource,
+          user: instructor
+        )
+
+      {:ok, view, _html} = live(conn, live_view_discussions_route(section.slug))
+      view |> element("form[phx-change='filter']") |> render_change(%{filter: "by_discussion"})
+
+      # we check that the count is 4 and not 5
+      assert view
+             |> element("table tbody tr:first-of-type p")
+             |> render =~
+               ~s{<p class=\"torus-p\">\n      \n        Number of posts: <b>4</b>\n        \n          (1 pending approval)\n        \n      \n    </p>}
+    end
+
+    test "the 'Most recent post' detail is only shown for pages with posts when filtering by collab space",
+         %{
+           conn: conn,
+           instructor: instructor,
+           section: section
+         } do
+      enroll_user_to_section(instructor, section, :context_instructor)
+
+      {:ok, view, _html} = live(conn, live_view_discussions_route(section.slug))
+      view |> element("form[phx-change='filter']") |> render_change(%{filter: "by_discussion"})
+
+      # most recent post detail is rendered for a page with posts
+      assert view
+             |> element("table tbody tr:nth-of-type(2)")
+             |> render =~ "Most recent post"
+
+      # but it is not rendered for a page without posts
+      assert view
+             |> element("table tbody tr:nth-of-type(3)")
+             |> render =~ "No posts yet"
+
+      refute view
+             |> element("table tbody tr:nth-of-type(3)")
+             |> render =~ "Most recent post"
     end
 
     defp get_elements_in_table_count(view) do


### PR DESCRIPTION
This PR addresses [MER-2639](https://eliterate.atlassian.net/browse/MER-2639) and [MER-2640](https://eliterate.atlassian.net/browse/MER-2640)

# MER-2639
## Flash messages work as expected
A flash message is only shown to the user that triggers the action (the post creation for example). 

https://github.com/Simon-Initiative/oli-torus/assets/74839302/deffa160-32d7-43aa-a820-cb208f574a40

While working on the ticket I realized a similar bug occurred when another user left the collab-space, or when an instructor approved a post, etc.
All bugs had the same root cause; while handling the broadcast message in the `handle_info` callbacks, we were not indicating the user that triggered the action in order to prevent showing the flash message to other users connected to the same collab-space.

# MER-2640
## Deleted posts are not considered in the post count

https://github.com/Simon-Initiative/oli-torus/assets/74839302/5d92fd94-fcd7-4ccd-8a70-ba241bc0aec9




## "Most recent post" detail is not shown for pages without posts
![image](https://github.com/Simon-Initiative/oli-torus/assets/74839302/2712cdbe-ddd6-4edc-bf03-26e40b74d2dc)


[MER-2639]: https://eliterate.atlassian.net/browse/MER-2639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MER-2640]: https://eliterate.atlassian.net/browse/MER-2640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ