### PR TITLE
[MER-2575] Implement Filter By Module in Learning Objetives tab

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -3092,11 +3092,15 @@ defmodule Oli.Delivery.Sections do
 
     objectives =
       from([rev: rev] in DeliveryResolver.section_resource_revisions(section_slug),
+        left_join: co in ContainedObjective,
+        on: co.objective_id == rev.resource_id,
         where: rev.deleted == false and rev.resource_type_id == ^objective_id,
+        group_by: [rev.title, rev.resource_id, rev.children],
         select: %{
           title: rev.title,
           resource_id: rev.resource_id,
-          children: rev.children
+          children: rev.children,
+          container_ids: fragment("array_agg(DISTINCT ?)", co.container_id)
         }
       )
       |> Repo.all()

--- a/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
@@ -74,7 +74,12 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive do
       ) do
     socket =
       socket
-      |> assign(params: params, view: :reports, active_tab: :learning_objectives)
+      |> assign(
+        params: params,
+        view: :reports,
+        active_tab: :learning_objectives,
+        section: socket.assigns.section
+      )
       |> assign_new(:objectives_tab, fn ->
         %{
           objectives: Sections.get_objectives_and_subobjectives(socket.assigns.section),
@@ -489,6 +494,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive do
       section_slug={@section.slug}
       view={@view}
       objectives_tab={@objectives_tab}
+      section={@section}
       patch_url_type={:instructor_dashboard}
     />
     """

--- a/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
@@ -491,7 +491,6 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive do
       id="objectives_table"
       module={OliWeb.Components.Delivery.LearningObjectives}
       params={@params}
-      section_slug={@section.slug}
       view={@view}
       objectives_tab={@objectives_tab}
       section={@section}

--- a/lib/oli_web/live/delivery/student_dashboard/components/learning_objectives_tab.ex
+++ b/lib/oli_web/live/delivery/student_dashboard/components/learning_objectives_tab.ex
@@ -8,7 +8,7 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.LearningObjectivesTab do
         id="objectives_table"
         module={OliWeb.Components.Delivery.LearningObjectives}
         params={@params}
-        section_slug={@section_slug}
+        section={@section}
         objectives_tab={@objectives_tab}
         student_id={@student_id}
         patch_url_type={:student_dashboard}

--- a/lib/oli_web/live/delivery/student_dashboard/student_dashboard_live.ex
+++ b/lib/oli_web/live/delivery/student_dashboard/student_dashboard_live.ex
@@ -154,7 +154,7 @@ defmodule OliWeb.Delivery.StudentDashboard.StudentDashboardLive do
       id="learning_objectives_tab"
       module={OliWeb.Delivery.StudentDashboard.Components.LearningObjectivesTab}
       params={@params}
-      section_slug={@section.slug}
+      section={@section}
       objectives_tab={@objectives_tab}
       student_id={@student.id}
       />

--- a/priv/repo/migrations/20221020142919_add_blueprint_table.exs
+++ b/priv/repo/migrations/20221020142919_add_blueprint_table.exs
@@ -1,6 +1,5 @@
 defmodule Oli.Repo.Migrations.AddBlueprintTable do
   alias Oli.Repo
-  alias Oli.Authoring.Editing.Blueprint
   use Ecto.Migration
   require Logger
 

--- a/test/oli_web/live/delivery/instructor_dashboard/reports/learning_objectives_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/reports/learning_objectives_tab_test.exs
@@ -104,6 +104,8 @@ defmodule OliWeb.Delivery.InstructorDashboard.LearningObjectivesTabTest do
       obj_revision_2: obj_revision_2
     } do
       Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+      Sections.update_section(section, %{v25_migration: :not_started})
+
       {:ok, view, _html} = live(conn, live_view_learning_objectives_route(section.slug))
 
       assert has_element?(view, "#objectives-table")
@@ -129,6 +131,8 @@ defmodule OliWeb.Delivery.InstructorDashboard.LearningObjectivesTabTest do
       obj_revision_2: obj_revision_2
     } do
       Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+      Sections.update_section(section, %{v25_migration: :not_started})
+
       {:ok, view, _html} = live(conn, live_view_learning_objectives_route(section.slug))
 
       assert view
@@ -163,6 +167,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.LearningObjectivesTabTest do
       obj_revision_2: obj_revision_2
     } do
       Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+      Sections.update_section(section, %{v25_migration: :not_started})
       {:ok, view, _html} = live(conn, live_view_learning_objectives_route(section.slug))
 
       assert has_element?(view, "span", "#{obj_revision_1.title}")
@@ -188,6 +193,143 @@ defmodule OliWeb.Delivery.InstructorDashboard.LearningObjectivesTabTest do
       refute has_element?(view, "span", "#{obj_revision_1.title}")
       assert has_element?(view, "span", "#{obj_revision_2.title}")
     end
+  end
 
+  describe "objectives filtering" do
+    setup [:instructor_conn, :create_full_project_with_objectives]
+    ## Course Hierarchy
+    #
+    # Root Container --> Page 1 --> Activity X
+    #                |--> Unit Container --> Module Container 1 --> Page 2 --> Activity Y
+    #                |                                                     |--> Activity Z
+    #                |--> Module Container 2 --> Page 3 --> Activity W
+    #
+    ## Objectives Hierarchy
+    #
+    # Page 1 --> Objective A
+    # Page 2 --> Objective B
+    #
+    # Note: the objectives above are not considered since they are attached to the pages
+    #
+    # Activity Y --> Objective C
+    #           |--> SubObjective C1
+    # Activity Z --> Objective D
+    # Activity W --> Objective E
+    #           |--> Objective F
+    #
+    # Note: Activity X does not have objectives
+    test "applies filtering by module when contained objectives were created", %{
+      conn: conn,
+      instructor: instructor,
+      section: section,
+      revisions: revisions
+    } do
+      # Setup section data
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+      Sections.rebuild_contained_objectives(section)
+
+      {:ok, view, _html} = live(conn, live_view_learning_objectives_route(section.slug))
+
+      assert has_element?(view, "#objectives-table")
+
+      refute has_element?(view, "span", "#{revisions.obj_revision_a.title}")
+      refute has_element?(view, "span", "#{revisions.obj_revision_b.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_c.title}")
+      assert has_element?(view, "div", "#{revisions.obj_revision_c1.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_d.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_e.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_f.title}")
+
+      ## searching by Unit Container
+      params = %{
+        filter_by: revisions.unit_revision.resource_id
+      }
+
+      {:ok, view, _html} = live(conn, live_view_learning_objectives_route(section.slug, params))
+
+      assert has_element?(view, "#objectives-table")
+      assert has_element?(view, "span", "#{revisions.obj_revision_c.title}")
+      assert has_element?(view, "div", "#{revisions.obj_revision_c1.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_d.title}")
+      refute has_element?(view, "span", "#{revisions.obj_revision_e.title}")
+      refute has_element?(view, "span", "#{revisions.obj_revision_f.title}")
+
+      ## searching by Module Container 2
+      params = %{
+        filter_by: revisions.module_revision_2.resource_id
+      }
+
+      {:ok, view, _html} = live(conn, live_view_learning_objectives_route(section.slug, params))
+
+      assert has_element?(view, "#objectives-table")
+      refute has_element?(view, "span", "#{revisions.obj_revision_c.title}")
+      refute has_element?(view, "div", "#{revisions.obj_revision_c1.title}")
+      refute has_element?(view, "span", "#{revisions.obj_revision_d.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_e.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_f.title}")
+
+      # Does not have info tooltip
+      refute has_element?(view, "#filter-disabled-tooltip")
+      # Select is enabled
+      refute has_element?(view, ".torus-select[disabled]")
+    end
+
+    test "does not allow filtering by module when contained objectives were not created", %{
+      conn: conn,
+      instructor: instructor,
+      section: section,
+      revisions: revisions
+    } do
+      # Setup section data
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+      Sections.update_section(section, %{v25_migration: :not_started})
+
+      {:ok, view, _html} = live(conn, live_view_learning_objectives_route(section.slug))
+
+      assert has_element?(view, "#objectives-table")
+
+      # It contains objectives attached to pages but not to activities
+      assert has_element?(view, "span", "#{revisions.obj_revision_a.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_b.title}")
+
+      assert has_element?(view, "span", "#{revisions.obj_revision_c.title}")
+      assert has_element?(view, "div", "#{revisions.obj_revision_c1.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_d.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_e.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_f.title}")
+
+      # Has info tooltip
+      assert has_element?(view, "#filter-disabled-tooltip")
+      # Select is disabled
+      assert has_element?(view, ".torus-select[disabled]")
+    end
+
+    test "does not allow filtering by module when section has the wrong migration status", %{
+      conn: conn,
+      instructor: instructor,
+      section: section,
+      revisions: revisions
+    } do
+      # Setup section data
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+      Sections.rebuild_contained_objectives(section)
+      Sections.update_section(section, %{v25_migration: :not_started})
+
+      {:ok, view, _html} = live(conn, live_view_learning_objectives_route(section.slug))
+
+      assert has_element?(view, "#objectives-table")
+      assert has_element?(view, "span", "#{revisions.obj_revision_a.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_b.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_c.title}")
+      assert has_element?(view, "div", "#{revisions.obj_revision_c1.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_d.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_e.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_f.title}")
+
+      # Has info tooltip
+      assert has_element?(view, "#filter-disabled-tooltip")
+      # Select is disabled
+      assert has_element?(view, ".torus-select[disabled]")
+    end
   end
 end

--- a/test/oli_web/live/delivery/instructor_dashboard/reports/learning_objectives_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/reports/learning_objectives_tab_test.exs
@@ -274,36 +274,6 @@ defmodule OliWeb.Delivery.InstructorDashboard.LearningObjectivesTabTest do
       refute has_element?(view, ".torus-select[disabled]")
     end
 
-    test "does not allow filtering by module when contained objectives were not created", %{
-      conn: conn,
-      instructor: instructor,
-      section: section,
-      revisions: revisions
-    } do
-      # Setup section data
-      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
-      Sections.update_section(section, %{v25_migration: :not_started})
-
-      {:ok, view, _html} = live(conn, live_view_learning_objectives_route(section.slug))
-
-      assert has_element?(view, "#objectives-table")
-
-      # It contains objectives attached to pages but not to activities
-      assert has_element?(view, "span", "#{revisions.obj_revision_a.title}")
-      assert has_element?(view, "span", "#{revisions.obj_revision_b.title}")
-
-      assert has_element?(view, "span", "#{revisions.obj_revision_c.title}")
-      assert has_element?(view, "div", "#{revisions.obj_revision_c1.title}")
-      assert has_element?(view, "span", "#{revisions.obj_revision_d.title}")
-      assert has_element?(view, "span", "#{revisions.obj_revision_e.title}")
-      assert has_element?(view, "span", "#{revisions.obj_revision_f.title}")
-
-      # Has info tooltip
-      assert has_element?(view, "#filter-disabled-tooltip")
-      # Select is disabled
-      assert has_element?(view, ".torus-select[disabled]")
-    end
-
     test "does not allow filtering by module when section has the wrong migration status", %{
       conn: conn,
       instructor: instructor,

--- a/test/oli_web/live/delivery/student_dashboard/components/learning_objectives_tab_test.exs
+++ b/test/oli_web/live/delivery/student_dashboard/components/learning_objectives_tab_test.exs
@@ -329,39 +329,6 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.LearningObjectivesTabTest 
       refute has_element?(view, ".torus-select[disabled]")
     end
 
-    test "does not allow filtering by module when contained objectives were not created", %{
-      conn: conn,
-      student: student,
-      section: section,
-      revisions: revisions
-    } do
-      # Setup section data
-      Sections.update_section(section, %{v25_migration: :not_started})
-
-      {:ok, view, _html} =
-        live(
-          conn,
-          live_view_students_dashboard_route(section.slug, student.id, :learning_objectives)
-        )
-
-      assert has_element?(view, "#objectives-table")
-
-      # It contains objectives attached to pages but not to activities
-      assert has_element?(view, "span", "#{revisions.obj_revision_a.title}")
-      assert has_element?(view, "span", "#{revisions.obj_revision_b.title}")
-
-      assert has_element?(view, "span", "#{revisions.obj_revision_c.title}")
-      assert has_element?(view, "div", "#{revisions.obj_revision_c1.title}")
-      assert has_element?(view, "span", "#{revisions.obj_revision_d.title}")
-      assert has_element?(view, "span", "#{revisions.obj_revision_e.title}")
-      assert has_element?(view, "span", "#{revisions.obj_revision_f.title}")
-
-      # Has info tooltip
-      assert has_element?(view, "#filter-disabled-tooltip")
-      # Select is disabled
-      assert has_element?(view, ".torus-select[disabled]")
-    end
-
     test "does not allow filtering by module when section has the wrong migration status", %{
       conn: conn,
       student: student,

--- a/test/oli_web/live/delivery/student_dashboard/components/learning_objectives_tab_test.exs
+++ b/test/oli_web/live/delivery/student_dashboard/components/learning_objectives_tab_test.exs
@@ -86,6 +86,8 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.LearningObjectivesTabTest 
       obj_revision_1: obj_revision_1,
       obj_revision_2: obj_revision_2
     } do
+      Sections.update_section(section, %{v25_migration: :not_started})
+
       {:ok, view, _html} =
         live(
           conn,
@@ -123,6 +125,8 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.LearningObjectivesTabTest 
       obj_revision_1: obj_revision_1,
       obj_revision_2: obj_revision_2
     } do
+      Sections.update_section(section, %{v25_migration: :not_started})
+
       {:ok, view, _html} =
         live(
           conn,
@@ -169,6 +173,8 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.LearningObjectivesTabTest 
       obj_revision_1: obj_revision_1,
       obj_revision_2: obj_revision_2
     } do
+      Sections.update_section(section, %{v25_migration: :not_started})
+
       {:ok, view, _html} =
         live(
           conn,
@@ -216,6 +222,175 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.LearningObjectivesTabTest 
       refute has_element?(view, "span", "#{obj_revision_1.title}")
       assert has_element?(view, "span", "#{obj_revision_2.title}")
     end
+  end
 
+  describe "objectives filtering" do
+    setup [
+      :instructor_conn,
+      :create_full_project_with_objectives,
+      :enrolled_student_and_instructor
+    ]
+
+    ## Course Hierarchy
+    #
+    # Root Container --> Page 1 --> Activity X
+    #                |--> Unit Container --> Module Container 1 --> Page 2 --> Activity Y
+    #                |                                                     |--> Activity Z
+    #                |--> Module Container 2 --> Page 3 --> Activity W
+    #
+    ## Objectives Hierarchy
+    #
+    # Page 1 --> Objective A
+    # Page 2 --> Objective B
+    #
+    # Note: the objectives above are not considered since they are attached to the pages
+    #
+    # Activity Y --> Objective C
+    #           |--> SubObjective C1
+    # Activity Z --> Objective D
+    # Activity W --> Objective E
+    #           |--> Objective F
+    #
+    # Note: Activity X does not have objectives
+    test "applies filtering by module when contained objectives were created", %{
+      conn: conn,
+      student: student,
+      section: section,
+      revisions: revisions
+    } do
+      # Setup section data
+      Sections.rebuild_contained_objectives(section)
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_students_dashboard_route(section.slug, student.id, :learning_objectives)
+        )
+
+      assert has_element?(view, "#objectives-table")
+
+      refute has_element?(view, "span", "#{revisions.obj_revision_a.title}")
+      refute has_element?(view, "span", "#{revisions.obj_revision_b.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_c.title}")
+      assert has_element?(view, "div", "#{revisions.obj_revision_c1.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_d.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_e.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_f.title}")
+
+      ## searching by Unit Container
+      params = %{
+        filter_by: revisions.unit_revision.resource_id
+      }
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_students_dashboard_route(
+            section.slug,
+            student.id,
+            :learning_objectives,
+            params
+          )
+        )
+
+      assert has_element?(view, "#objectives-table")
+      assert has_element?(view, "span", "#{revisions.obj_revision_c.title}")
+      assert has_element?(view, "div", "#{revisions.obj_revision_c1.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_d.title}")
+      refute has_element?(view, "span", "#{revisions.obj_revision_e.title}")
+      refute has_element?(view, "span", "#{revisions.obj_revision_f.title}")
+
+      ## searching by Module Container 2
+      params = %{
+        filter_by: revisions.module_revision_2.resource_id
+      }
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_students_dashboard_route(
+            section.slug,
+            student.id,
+            :learning_objectives,
+            params
+          )
+        )
+
+      assert has_element?(view, "#objectives-table")
+      refute has_element?(view, "span", "#{revisions.obj_revision_c.title}")
+      refute has_element?(view, "div", "#{revisions.obj_revision_c1.title}")
+      refute has_element?(view, "span", "#{revisions.obj_revision_d.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_e.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_f.title}")
+
+      # Does not have info tooltip
+      refute has_element?(view, "#filter-disabled-tooltip")
+      # Select is enabled
+      refute has_element?(view, ".torus-select[disabled]")
+    end
+
+    test "does not allow filtering by module when contained objectives were not created", %{
+      conn: conn,
+      student: student,
+      section: section,
+      revisions: revisions
+    } do
+      # Setup section data
+      Sections.update_section(section, %{v25_migration: :not_started})
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_students_dashboard_route(section.slug, student.id, :learning_objectives)
+        )
+
+      assert has_element?(view, "#objectives-table")
+
+      # It contains objectives attached to pages but not to activities
+      assert has_element?(view, "span", "#{revisions.obj_revision_a.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_b.title}")
+
+      assert has_element?(view, "span", "#{revisions.obj_revision_c.title}")
+      assert has_element?(view, "div", "#{revisions.obj_revision_c1.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_d.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_e.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_f.title}")
+
+      # Has info tooltip
+      assert has_element?(view, "#filter-disabled-tooltip")
+      # Select is disabled
+      assert has_element?(view, ".torus-select[disabled]")
+    end
+
+    test "does not allow filtering by module when section has the wrong migration status", %{
+      conn: conn,
+      student: student,
+      section: section,
+      revisions: revisions
+    } do
+      # Setup section data
+      Sections.rebuild_contained_objectives(section)
+      Sections.update_section(section, %{v25_migration: :not_started})
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_students_dashboard_route(section.slug, student.id, :learning_objectives)
+        )
+
+      assert has_element?(view, "#objectives-table")
+      assert has_element?(view, "span", "#{revisions.obj_revision_a.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_b.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_c.title}")
+      assert has_element?(view, "div", "#{revisions.obj_revision_c1.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_d.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_e.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_f.title}")
+
+      # Has info tooltip
+      assert has_element?(view, "#filter-disabled-tooltip")
+      # Select is disabled
+      assert has_element?(view, ".torus-select[disabled]")
+    end
   end
 end


### PR DESCRIPTION
[MER-2575](https://eliterate.atlassian.net/browse/MER-2575)

This is the last of the series of three PRs that create contained objectives for optimizing queries and reimplement the "Filter by Module" feature in the Learning Objectives tab, either from the Instructor Dashboard or from the Students Dashboard. There are two different scenarios. The first one considers a section that has contained objectives caused by the migration script being run or because it is a newly created section. The second is an old section that has no contained objectives yet.

**Scenario 1:** Section migrated with contained objectives.

https://github.com/Simon-Initiative/oli-torus/assets/26532202/e141f45b-dd2f-4e35-b3ea-520161e3fa53



**Scenario 2:** Legacy section without contained objectives yet.

https://github.com/Simon-Initiative/oli-torus/assets/26532202/774472e7-dd58-496c-94e6-4c5bf44dc452



[MER-2575]: https://eliterate.atlassian.net/browse/MER-2575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ