### PR TITLE
[Feature] Custom scoring options [MER-2586]

### DIFF
--- a/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyAuthoring.tsx
+++ b/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyAuthoring.tsx
@@ -26,6 +26,7 @@ import { VariableEditorOrNot } from '../common/variables/VariableEditorOrNot';
 import { VariableActions } from '../common/variables/variableActions';
 import * as ActivityTypes from '../types';
 import { CATAActions } from './actions';
+import { ActivityScoring } from '../common/responses/ActivityScoring';
 
 const store = configureStore();
 
@@ -64,6 +65,8 @@ const CheckAllThatApply = () => {
           context={writerContext}
         />
         <SimpleFeedback partId={model.authoring.parts[0].id} />
+        <ActivityScoring partId={model.authoring.parts[0].id} />
+
         <TargetedFeedback
           toggleChoice={(choiceId, mapping) => {
             dispatch(

--- a/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyAuthoring.tsx
+++ b/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyAuthoring.tsx
@@ -22,11 +22,11 @@ import { configureStore } from 'state/store';
 import { AuthoringElement, AuthoringElementProps } from '../AuthoringElement';
 import { AuthoringElementProvider, useAuthoringElementContext } from '../AuthoringElementProvider';
 import { Explanation } from '../common/explanation/ExplanationAuthoring';
+import { ActivityScoring } from '../common/responses/ActivityScoring';
 import { VariableEditorOrNot } from '../common/variables/VariableEditorOrNot';
 import { VariableActions } from '../common/variables/variableActions';
 import * as ActivityTypes from '../types';
 import { CATAActions } from './actions';
-import { ActivityScoring } from '../common/responses/ActivityScoring';
 
 const store = configureStore();
 

--- a/assets/src/components/activities/check_all_that_apply/utils.ts
+++ b/assets/src/components/activities/check_all_that_apply/utils.ts
@@ -19,7 +19,7 @@ export const defaultCATAModel = (): CATA => {
     matchListRule([correctChoice.id, incorrectChoice.id], [correctChoice.id]),
     1,
     'Correct',
-    true
+    true,
   );
 
   return {

--- a/assets/src/components/activities/check_all_that_apply/utils.ts
+++ b/assets/src/components/activities/check_all_that_apply/utils.ts
@@ -19,6 +19,7 @@ export const defaultCATAModel = (): CATA => {
     matchListRule([correctChoice.id, incorrectChoice.id], [correctChoice.id]),
     1,
     'Correct',
+    true
   );
 
   return {

--- a/assets/src/components/activities/common/authoring/actions/multipleChoiceActions.ts
+++ b/assets/src/components/activities/common/authoring/actions/multipleChoiceActions.ts
@@ -11,6 +11,7 @@ import {
 import { Choices } from 'data/activities/model/choices';
 import { getCorrectResponse, getResponseBy, getResponseId } from 'data/activities/model/responses';
 import { matchRule } from 'data/activities/model/rules';
+import { getPartById } from 'data/activities/model/utils';
 import { clone } from 'utils/common';
 import { Operations } from 'utils/pathOperations';
 
@@ -39,7 +40,12 @@ export const MCActions = {
 
   toggleChoiceCorrectness(id: string, partId: string) {
     return (model: HasParts, _post: PostUndoable) => {
-      getCorrectResponse(model, partId).rule = matchRule(id);
+      const part = getPartById(model, partId);
+      const correctScore = part.outOf || 1;
+      const correctResponse = getCorrectResponse(model, partId);
+      correctResponse.rule = matchRule(id);
+      correctResponse.score = correctScore;
+      correctResponse.correct = true; // Upgrade older content that didn't have the correct flag and relied on score to determine correctness
     };
   },
 

--- a/assets/src/components/activities/common/authoring/actions/scoringActions.ts
+++ b/assets/src/components/activities/common/authoring/actions/scoringActions.ts
@@ -1,6 +1,21 @@
+import { ActivityLevelScoring, ScoringStrategy } from 'components/activities/types';
 import { getCorrectResponse, getIncorrectResponse } from 'data/activities/model/responses';
 
 export const ScoringActions = {
+  toggleActivityDefaultScoring() {
+    // This toggles an activity-level default scoring flag, currently only used for multi input questions.
+    return (model: ActivityLevelScoring) => {
+      model.customScoring = !model.customScoring;
+    };
+  },
+
+  editActivityScoringStrategy(scoringStrategy: ScoringStrategy) {
+    return (model: ActivityLevelScoring) => {
+      // This changes an activity-level scoring strategy, currently only used for multi input questions.
+      model.scoringStrategy = scoringStrategy;
+    };
+  },
+
   editPartScoringStrategy(partId: string, scoringStrategy: string) {
     return (model: any) => {
       const part = model.authoring.parts.find((p: any) => p.id === partId);

--- a/assets/src/components/activities/common/authoring/actions/scoringActions.ts
+++ b/assets/src/components/activities/common/authoring/actions/scoringActions.ts
@@ -24,16 +24,24 @@ export const ScoringActions = {
 
       // When we change the correct & incorrect scores, we also need to update the responses for the correct & incorrect answers
       if (correctScore !== null) {
-        const correctResponse = getCorrectResponse(model, partId);
-        if (correctResponse) {
-          correctResponse.score = correctScore;
+        try {
+          const correctResponse = getCorrectResponse(model, partId);
+          if (correctResponse) {
+            correctResponse.score = correctScore;
+          }
+        } catch (e) {
+          console.warn('Could not find correct response for part', partId);
         }
       }
 
       if (incorrectScore !== null) {
-        const incorrectResponse = getIncorrectResponse(model, partId);
-        if (incorrectResponse) {
-          incorrectResponse.score = incorrectScore;
+        try {
+          const incorrectResponse = getIncorrectResponse(model, partId);
+          if (incorrectResponse) {
+            incorrectResponse.score = incorrectScore;
+          }
+        } catch (e) {
+          console.warn('Could not find incorrect response for part', partId);
         }
       }
     };

--- a/assets/src/components/activities/common/authoring/actions/scoringActions.ts
+++ b/assets/src/components/activities/common/authoring/actions/scoringActions.ts
@@ -36,7 +36,6 @@ export const ScoringActions = {
           incorrectResponse.score = incorrectScore;
         }
       }
-
     };
   },
 };

--- a/assets/src/components/activities/common/authoring/actions/scoringActions.ts
+++ b/assets/src/components/activities/common/authoring/actions/scoringActions.ts
@@ -1,3 +1,5 @@
+import { getCorrectResponse, getIncorrectResponse } from 'data/activities/model/responses';
+
 export const ScoringActions = {
   editPartScoringStrategy(partId: string, scoringStrategy: string) {
     return (model: any) => {
@@ -19,6 +21,22 @@ export const ScoringActions = {
       }
       part.outOf = correctScore;
       part.incorrectScore = incorrectScore;
+
+      // When we change the correct & incorrect scores, we also need to update the responses for the correct & incorrect answers
+      if (correctScore !== null) {
+        const correctResponse = getCorrectResponse(model, partId);
+        if (correctResponse) {
+          correctResponse.score = correctScore;
+        }
+      }
+
+      if (incorrectScore !== null) {
+        const incorrectResponse = getIncorrectResponse(model, partId);
+        if (incorrectResponse) {
+          incorrectResponse.score = incorrectScore;
+        }
+      }
+
     };
   },
 };

--- a/assets/src/components/activities/common/authoring/actions/scoringActions.ts
+++ b/assets/src/components/activities/common/authoring/actions/scoringActions.ts
@@ -7,7 +7,11 @@ export const ScoringActions = {
     return (model: ActivityLevelScoring) => {
       model.customScoring = !model.customScoring;
 
-      if (!model.customScoring) {
+      if (model.customScoring) {
+        model.authoring?.parts?.forEach((part: Part) => {
+          part.outOf = 1;
+        });
+      } else {
         // When going from custom to default, we need to reset the scores for each part to 1 or 0
         model.scoringStrategy = ScoringStrategy.average;
         model.authoring?.parts?.forEach((part: Part) => {

--- a/assets/src/components/activities/common/authoring/actions/scoringActions.ts
+++ b/assets/src/components/activities/common/authoring/actions/scoringActions.ts
@@ -1,4 +1,15 @@
 export const ScoringActions = {
+  editPartScoringStrategy(partId: string, scoringStrategy: string) {
+    return (model: any) => {
+      const part = model.authoring.parts.find((p: any) => p.id === partId);
+      if (!part) {
+        console.warn('Could not set scoring strategy for part', partId);
+        return;
+      }
+      part.scoringStrategy = scoringStrategy;
+    };
+  },
+
   editPartScore(partId: string, correctScore: number | null, incorrectScore: number | null) {
     return (model: any) => {
       const part = model.authoring.parts.find((p: any) => p.id === partId);

--- a/assets/src/components/activities/common/authoring/actions/scoringActions.ts
+++ b/assets/src/components/activities/common/authoring/actions/scoringActions.ts
@@ -1,0 +1,13 @@
+export const ScoringActions = {
+  editPartScore(partId: string, correctScore: number | null, incorrectScore: number | null) {
+    return (model: any) => {
+      const part = model.authoring.parts.find((p: any) => p.id === partId);
+      if (!part) {
+        console.warn('Could not set score for part', partId);
+        return;
+      }
+      part.outOf = correctScore;
+      part.incorrectScore = incorrectScore;
+    };
+  },
+};

--- a/assets/src/components/activities/common/responses/ActivityScoring.tsx
+++ b/assets/src/components/activities/common/responses/ActivityScoring.tsx
@@ -20,7 +20,9 @@ export const ActivityScoring: React.FC<ActivityScoreProps> = ({ partId, promptFo
   const checkboxInputId = useMemo(() => guid(), []);
   const outOf = getOutOfPoints(model, partId);
   const incorrect = getIncorrectPoints(model, partId);
-  const [useDefaultScoring, setDefaultScoring] = useState(outOf === null || outOf === undefined);
+  const [useDefaultScoring, setDefaultScoring] = useState(
+    (outOf === null || outOf === undefined) && promptForDefault,
+  );
   const outOfPoints = outOf || 1;
   const incorrectPoints = incorrect || 0;
 

--- a/assets/src/components/activities/common/responses/ActivityScoring.tsx
+++ b/assets/src/components/activities/common/responses/ActivityScoring.tsx
@@ -1,0 +1,102 @@
+import React, { ReactNode, useState } from 'react';
+import { useAuthoringElementContext } from 'components/activities/AuthoringElementProvider';
+import { HasParts } from 'components/activities/types';
+import { Card } from 'components/misc/Card';
+import { getIncorrectPoints, getOutOfPoints } from 'data/activities/model/responses';
+import { ScoringActions } from '../authoring/actions/scoringActions';
+
+interface ActivityScoreProps {
+  partId: string;
+}
+
+export const ActivityScoring: React.FC<ActivityScoreProps> = ({ partId }) => {
+  const { model, dispatch, editMode } = useAuthoringElementContext<HasParts>();
+  const checkboxInputId = `scoring-${partId}`;
+  const outOf = getOutOfPoints(model, partId);
+  const incorrect = getIncorrectPoints(model, partId);
+  const [useDefaultScoring, setDefaultScoring] = useState(outOf === null);
+  const outOfPoints = outOf || 1;
+  const incorrectPoints = incorrect || 0;
+
+  console.info('ActivityScoring', model);
+
+  const onChangeDefault = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setDefaultScoring(e.target.checked);
+    if (e.target.checked) {
+      dispatch(ScoringActions.editPartScore(partId, null, null));
+    }
+  };
+
+  const onCorrectScoreChange = (score: number) => {
+    if (score >= 0) {
+      dispatch(ScoringActions.editPartScore(partId, score, incorrectPoints || null));
+    }
+  };
+
+  const onIncorrectScoreChange = (score: number) => {
+    if (score >= 0) {
+      dispatch(ScoringActions.editPartScore(partId, outOf || null, score));
+    }
+  };
+
+  console.info('EDITMODE', editMode);
+
+  return (
+    <Card.Card>
+      <Card.Title>Scoring</Card.Title>
+      <Card.Content>
+        <div className="mb-2">
+          <input
+            className="mr-2"
+            type="checkbox"
+            aria-label="Checkbox for default scoring"
+            onChange={onChangeDefault}
+            checked={useDefaultScoring}
+            id={checkboxInputId}
+            disabled={!editMode}
+          />
+          <label className="mt-2 form-check-label" htmlFor={checkboxInputId}>
+            Use default scoring
+          </label>
+        </div>
+
+        {useDefaultScoring || (
+          <div className='flex flex-row gap-2'>
+            <ScoreInput score={outOfPoints} onChange={onCorrectScoreChange} editMode={editMode}>
+              Correct Answer Score:
+            </ScoreInput>
+
+            <ScoreInput
+              score={incorrectPoints}
+              onChange={onIncorrectScoreChange}
+              editMode={editMode}
+            >
+              Incorrect Answer Score:
+            </ScoreInput>
+          </div>
+        )}
+      </Card.Content>
+    </Card.Card>
+  );
+};
+
+const ScoreInput: React.FC<{
+  score: number;
+  onChange: (score: number) => void;
+  children: ReactNode;
+  editMode: boolean;
+}> = ({ score, onChange, children, editMode }) => {
+  return (
+    <div className='w-48'>
+      <label>{children}</label>
+      <input
+        type="number"
+        className="form-control w-10"
+        disabled={!editMode}
+        onChange={(e) => onChange(parseFloat(e.target.value || '0'))}
+        value={score}
+        step={0.1}
+      />
+    </div>
+  );
+};

--- a/assets/src/components/activities/common/responses/ActivityScoring.tsx
+++ b/assets/src/components/activities/common/responses/ActivityScoring.tsx
@@ -1,9 +1,10 @@
-import React, { ReactNode, useState } from 'react';
+import React, {  useState } from 'react';
 import { useAuthoringElementContext } from 'components/activities/AuthoringElementProvider';
 import { HasParts } from 'components/activities/types';
 import { Card } from 'components/misc/Card';
 import { getIncorrectPoints, getOutOfPoints } from 'data/activities/model/responses';
 import { ScoringActions } from '../authoring/actions/scoringActions';
+import { ScoreInput } from './ScoreInput';
 
 interface ActivityScoreProps {
   partId: string;
@@ -18,12 +19,12 @@ export const ActivityScoring: React.FC<ActivityScoreProps> = ({ partId }) => {
   const outOfPoints = outOf || 1;
   const incorrectPoints = incorrect || 0;
 
-  console.info('ActivityScoring', model);
-
   const onChangeDefault = (e: React.ChangeEvent<HTMLInputElement>) => {
     setDefaultScoring(e.target.checked);
     if (e.target.checked) {
       dispatch(ScoringActions.editPartScore(partId, null, null));
+    } else {
+      dispatch(ScoringActions.editPartScore(partId, 1, 0));
     }
   };
 
@@ -38,8 +39,6 @@ export const ActivityScoring: React.FC<ActivityScoreProps> = ({ partId }) => {
       dispatch(ScoringActions.editPartScore(partId, outOf || null, score));
     }
   };
-
-  console.info('EDITMODE', editMode);
 
   return (
     <Card.Card>
@@ -61,7 +60,7 @@ export const ActivityScoring: React.FC<ActivityScoreProps> = ({ partId }) => {
         </div>
 
         {useDefaultScoring || (
-          <div className='flex flex-row gap-2'>
+          <div className='flex flex-row gap-4'>
             <ScoreInput score={outOfPoints} onChange={onCorrectScoreChange} editMode={editMode}>
               Correct Answer Score:
             </ScoreInput>
@@ -80,23 +79,3 @@ export const ActivityScoring: React.FC<ActivityScoreProps> = ({ partId }) => {
   );
 };
 
-const ScoreInput: React.FC<{
-  score: number;
-  onChange: (score: number) => void;
-  children: ReactNode;
-  editMode: boolean;
-}> = ({ score, onChange, children, editMode }) => {
-  return (
-    <div className='w-48'>
-      <label>{children}</label>
-      <input
-        type="number"
-        className="form-control w-10"
-        disabled={!editMode}
-        onChange={(e) => onChange(parseFloat(e.target.value || '0'))}
-        value={score}
-        step={0.1}
-      />
-    </div>
-  );
-};

--- a/assets/src/components/activities/common/responses/ActivityScoring.tsx
+++ b/assets/src/components/activities/common/responses/ActivityScoring.tsx
@@ -1,8 +1,9 @@
-import React, {  useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useAuthoringElementContext } from 'components/activities/AuthoringElementProvider';
 import { HasParts } from 'components/activities/types';
 import { Card } from 'components/misc/Card';
 import { getIncorrectPoints, getOutOfPoints } from 'data/activities/model/responses';
+import guid from 'utils/guid';
 import { ScoringActions } from '../authoring/actions/scoringActions';
 import { ScoreInput } from './ScoreInput';
 
@@ -10,12 +11,15 @@ interface ActivityScoreProps {
   partId: string;
 }
 
+/*
+  Sets a single part-level score for the activity. Not appropriate for activities with multiple parts.
+*/
 export const ActivityScoring: React.FC<ActivityScoreProps> = ({ partId }) => {
   const { model, dispatch, editMode } = useAuthoringElementContext<HasParts>();
-  const checkboxInputId = `scoring-${partId}`;
+  const checkboxInputId = useMemo(() => guid(), []);
   const outOf = getOutOfPoints(model, partId);
   const incorrect = getIncorrectPoints(model, partId);
-  const [useDefaultScoring, setDefaultScoring] = useState(outOf === null);
+  const [useDefaultScoring, setDefaultScoring] = useState(outOf === null || outOf === undefined);
   const outOfPoints = outOf || 1;
   const incorrectPoints = incorrect || 0;
 
@@ -60,7 +64,7 @@ export const ActivityScoring: React.FC<ActivityScoreProps> = ({ partId }) => {
         </div>
 
         {useDefaultScoring || (
-          <div className='flex flex-row gap-4'>
+          <div className="flex flex-row gap-4">
             <ScoreInput score={outOfPoints} onChange={onCorrectScoreChange} editMode={editMode}>
               Correct Answer Score:
             </ScoreInput>
@@ -78,4 +82,3 @@ export const ActivityScoring: React.FC<ActivityScoreProps> = ({ partId }) => {
     </Card.Card>
   );
 };
-

--- a/assets/src/components/activities/common/responses/ActivityScoring.tsx
+++ b/assets/src/components/activities/common/responses/ActivityScoring.tsx
@@ -1,20 +1,21 @@
 import React, { useMemo, useState } from 'react';
 import { useAuthoringElementContext } from 'components/activities/AuthoringElementProvider';
-import { HasParts } from 'components/activities/types';
+import { HasParts, ScoringStrategy } from 'components/activities/types';
 import { Card } from 'components/misc/Card';
-import { getIncorrectPoints, getOutOfPoints } from 'data/activities/model/responses';
+import { getIncorrectPoints, getOutOfPoints, getScoringStrategy } from 'data/activities/model/responses';
 import guid from 'utils/guid';
 import { ScoringActions } from '../authoring/actions/scoringActions';
 import { ScoreInput } from './ScoreInput';
 
 interface ActivityScoreProps {
   partId: string;
+  shouldSetStrategy?: boolean;
 }
 
 /*
   Sets a single part-level score for the activity. Not appropriate for activities with multiple parts.
 */
-export const ActivityScoring: React.FC<ActivityScoreProps> = ({ partId }) => {
+export const ActivityScoring: React.FC<ActivityScoreProps> = ({ partId, shouldSetStrategy }) => {
   const { model, dispatch, editMode } = useAuthoringElementContext<HasParts>();
   const checkboxInputId = useMemo(() => guid(), []);
   const outOf = getOutOfPoints(model, partId);
@@ -22,11 +23,14 @@ export const ActivityScoring: React.FC<ActivityScoreProps> = ({ partId }) => {
   const [useDefaultScoring, setDefaultScoring] = useState(outOf === null || outOf === undefined);
   const outOfPoints = outOf || 1;
   const incorrectPoints = incorrect || 0;
+  const scoringStrategy = getScoringStrategy(model, partId);
+
 
   const onChangeDefault = (e: React.ChangeEvent<HTMLInputElement>) => {
     setDefaultScoring(e.target.checked);
     if (e.target.checked) {
       dispatch(ScoringActions.editPartScore(partId, null, null));
+      dispatch(ScoringActions.editPartScoringStrategy(partId, "average"));
     } else {
       dispatch(ScoringActions.editPartScore(partId, 1, 0));
     }
@@ -44,11 +48,15 @@ export const ActivityScoring: React.FC<ActivityScoreProps> = ({ partId }) => {
     }
   };
 
+  const onScoringStrategyChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    dispatch(ScoringActions.editPartScoringStrategy(partId, e.target.value as ScoringStrategy));
+  };
+
   return (
     <Card.Card>
       <Card.Title>Scoring</Card.Title>
       <Card.Content>
-        <div className="mb-2">
+        <div className="mb-4">
           <input
             className="mr-2"
             type="checkbox"
@@ -64,21 +72,37 @@ export const ActivityScoring: React.FC<ActivityScoreProps> = ({ partId }) => {
         </div>
 
         {useDefaultScoring || (
-          <div className="flex flex-row gap-4">
-            <ScoreInput score={outOfPoints} onChange={onCorrectScoreChange} editMode={editMode}>
-              Correct Answer Score:
-            </ScoreInput>
+          <>
+            <div className="flex flex-row gap-4">
+              <ScoreInput score={outOfPoints} onChange={onCorrectScoreChange} editMode={editMode}>
+                Correct Answer Score:
+              </ScoreInput>
 
-            <ScoreInput
-              score={incorrectPoints}
-              onChange={onIncorrectScoreChange}
-              editMode={editMode}
-            >
-              Incorrect Answer Score:
-            </ScoreInput>
-          </div>
+              <ScoreInput
+                score={incorrectPoints}
+                onChange={onIncorrectScoreChange}
+                editMode={editMode}
+              >
+                Incorrect Answer Score:
+              </ScoreInput>
+            </div>
+            {shouldSetStrategy && (
+              <div className="flex flex-row gap-4 mt-4 items-center">
+                <label className='flex items-center'>Scoring Strategy</label>
+                <select style={{width:"40%"}} className="form-control" disabled={!editMode} value={scoringStrategy || 'average'} onChange={onScoringStrategyChange}>
+                  <option value="average">Average</option>
+                  <option value="total">Total</option>
+                  <option value="best">Best</option>
+                </select>
+              </div>
+            )}
+          </>
         )}
       </Card.Content>
     </Card.Card>
   );
+};
+
+ActivityScoring.defaultProps = {
+  shouldSetStrategy: false,
 };

--- a/assets/src/components/activities/common/responses/ActivityScoring.tsx
+++ b/assets/src/components/activities/common/responses/ActivityScoring.tsx
@@ -2,7 +2,11 @@ import React, { useMemo, useState } from 'react';
 import { useAuthoringElementContext } from 'components/activities/AuthoringElementProvider';
 import { HasParts, ScoringStrategy } from 'components/activities/types';
 import { Card } from 'components/misc/Card';
-import { getIncorrectPoints, getOutOfPoints, getScoringStrategy } from 'data/activities/model/responses';
+import {
+  getIncorrectPoints,
+  getOutOfPoints,
+  getScoringStrategy,
+} from 'data/activities/model/responses';
 import guid from 'utils/guid';
 import { ScoringActions } from '../authoring/actions/scoringActions';
 import { ScoreInput } from './ScoreInput';
@@ -25,12 +29,11 @@ export const ActivityScoring: React.FC<ActivityScoreProps> = ({ partId, shouldSe
   const incorrectPoints = incorrect || 0;
   const scoringStrategy = getScoringStrategy(model, partId);
 
-
   const onChangeDefault = (e: React.ChangeEvent<HTMLInputElement>) => {
     setDefaultScoring(e.target.checked);
     if (e.target.checked) {
       dispatch(ScoringActions.editPartScore(partId, null, null));
-      dispatch(ScoringActions.editPartScoringStrategy(partId, "average"));
+      dispatch(ScoringActions.editPartScoringStrategy(partId, 'average'));
     } else {
       dispatch(ScoringActions.editPartScore(partId, 1, 0));
     }
@@ -88,8 +91,14 @@ export const ActivityScoring: React.FC<ActivityScoreProps> = ({ partId, shouldSe
             </div>
             {shouldSetStrategy && (
               <div className="flex flex-row gap-4 mt-4 items-center">
-                <label className='flex items-center'>Scoring Strategy</label>
-                <select style={{width:"40%"}} className="form-control" disabled={!editMode} value={scoringStrategy || 'average'} onChange={onScoringStrategyChange}>
+                <label className="flex items-center">Scoring Strategy</label>
+                <select
+                  style={{ width: '40%' }}
+                  className="form-control"
+                  disabled={!editMode}
+                  value={scoringStrategy || 'average'}
+                  onChange={onScoringStrategyChange}
+                >
                   <option value="average">Average</option>
                   <option value="total">Total</option>
                   <option value="best">Best</option>

--- a/assets/src/components/activities/common/responses/ActivityScoring.tsx
+++ b/assets/src/components/activities/common/responses/ActivityScoring.tsx
@@ -1,33 +1,30 @@
 import React, { useMemo, useState } from 'react';
 import { useAuthoringElementContext } from 'components/activities/AuthoringElementProvider';
-import { HasParts, ScoringStrategy } from 'components/activities/types';
+import { HasParts } from 'components/activities/types';
 import { Card } from 'components/misc/Card';
-import {
-  getIncorrectPoints,
-  getOutOfPoints,
-  getScoringStrategy,
-} from 'data/activities/model/responses';
+import { getIncorrectPoints, getOutOfPoints } from 'data/activities/model/responses';
 import guid from 'utils/guid';
 import { ScoringActions } from '../authoring/actions/scoringActions';
 import { ScoreInput } from './ScoreInput';
 
 interface ActivityScoreProps {
   partId: string;
-  shouldSetStrategy?: boolean;
+  promptForDefault?: boolean; // Should we display the "use default scoring" checkbox?
 }
 
 /*
   Sets a single part-level score for the activity. Not appropriate for activities with multiple parts.
 */
-export const ActivityScoring: React.FC<ActivityScoreProps> = ({ partId, shouldSetStrategy }) => {
+export const ActivityScoring: React.FC<ActivityScoreProps> = ({ partId, promptForDefault }) => {
   const { model, dispatch, editMode } = useAuthoringElementContext<HasParts>();
   const checkboxInputId = useMemo(() => guid(), []);
   const outOf = getOutOfPoints(model, partId);
   const incorrect = getIncorrectPoints(model, partId);
-  const [useDefaultScoring, setDefaultScoring] = useState(outOf === null || outOf === undefined);
+  const [useDefaultScoring, setDefaultScoring] = useState(
+    !promptForDefault && (outOf === null || outOf === undefined),
+  );
   const outOfPoints = outOf || 1;
   const incorrectPoints = incorrect || 0;
-  const scoringStrategy = getScoringStrategy(model, partId);
 
   const onChangeDefault = (e: React.ChangeEvent<HTMLInputElement>) => {
     setDefaultScoring(e.target.checked);
@@ -51,28 +48,26 @@ export const ActivityScoring: React.FC<ActivityScoreProps> = ({ partId, shouldSe
     }
   };
 
-  const onScoringStrategyChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    dispatch(ScoringActions.editPartScoringStrategy(partId, e.target.value as ScoringStrategy));
-  };
-
   return (
     <Card.Card>
       <Card.Title>Scoring</Card.Title>
       <Card.Content>
-        <div className="mb-4">
-          <input
-            className="mr-2"
-            type="checkbox"
-            aria-label="Checkbox for default scoring"
-            onChange={onChangeDefault}
-            checked={useDefaultScoring}
-            id={checkboxInputId}
-            disabled={!editMode}
-          />
-          <label className="mt-2 form-check-label" htmlFor={checkboxInputId}>
-            Use default scoring
-          </label>
-        </div>
+        {promptForDefault && (
+          <div className="mb-4">
+            <input
+              className="mr-2"
+              type="checkbox"
+              aria-label="Checkbox for default scoring"
+              onChange={onChangeDefault}
+              checked={useDefaultScoring}
+              id={checkboxInputId}
+              disabled={!editMode}
+            />
+            <label className="mt-2 form-check-label" htmlFor={checkboxInputId}>
+              Use default scoring
+            </label>
+          </div>
+        )}
 
         {useDefaultScoring || (
           <>
@@ -89,22 +84,6 @@ export const ActivityScoring: React.FC<ActivityScoreProps> = ({ partId, shouldSe
                 Incorrect Answer Score:
               </ScoreInput>
             </div>
-            {shouldSetStrategy && (
-              <div className="flex flex-row gap-4 mt-4 items-center">
-                <label className="flex items-center">Scoring Strategy</label>
-                <select
-                  style={{ width: '40%' }}
-                  className="form-control"
-                  disabled={!editMode}
-                  value={scoringStrategy || 'average'}
-                  onChange={onScoringStrategyChange}
-                >
-                  <option value="average">Average</option>
-                  <option value="total">Total</option>
-                  <option value="best">Best</option>
-                </select>
-              </div>
-            )}
           </>
         )}
       </Card.Content>
@@ -113,5 +92,5 @@ export const ActivityScoring: React.FC<ActivityScoreProps> = ({ partId, shouldSe
 };
 
 ActivityScoring.defaultProps = {
-  shouldSetStrategy: false,
+  promptForDefault: true,
 };

--- a/assets/src/components/activities/common/responses/ActivityScoring.tsx
+++ b/assets/src/components/activities/common/responses/ActivityScoring.tsx
@@ -20,17 +20,14 @@ export const ActivityScoring: React.FC<ActivityScoreProps> = ({ partId, promptFo
   const checkboxInputId = useMemo(() => guid(), []);
   const outOf = getOutOfPoints(model, partId);
   const incorrect = getIncorrectPoints(model, partId);
-  const [useDefaultScoring, setDefaultScoring] = useState(
-    !promptForDefault && (outOf === null || outOf === undefined),
-  );
+  const [useDefaultScoring, setDefaultScoring] = useState(outOf === null || outOf === undefined);
   const outOfPoints = outOf || 1;
   const incorrectPoints = incorrect || 0;
 
   const onChangeDefault = (e: React.ChangeEvent<HTMLInputElement>) => {
     setDefaultScoring(e.target.checked);
     if (e.target.checked) {
-      dispatch(ScoringActions.editPartScore(partId, null, null));
-      dispatch(ScoringActions.editPartScoringStrategy(partId, 'average'));
+      dispatch(ScoringActions.editPartScore(partId, null, null, 'average'));
     } else {
       dispatch(ScoringActions.editPartScore(partId, 1, 0));
     }

--- a/assets/src/components/activities/common/responses/ResponseCard.tsx
+++ b/assets/src/components/activities/common/responses/ResponseCard.tsx
@@ -9,6 +9,7 @@ import { TextDirection } from 'data/content/model/elements/types';
 import { ID } from 'data/content/model/other';
 import { DEFAULT_EDITOR, EditorType } from 'data/content/resource';
 import { AuthoringCheckboxConnected } from '../authoring/AuthoringCheckbox';
+import { ScoreInput } from './ScoreInput';
 
 interface Props {
   title: React.ReactNode;
@@ -18,6 +19,8 @@ interface Props {
   updateFeedback: (responseId: ID, content: Descendant[]) => void;
   updateCorrectness: (responseId: ID, correct: boolean) => void;
   removeResponse: (responseId: ID) => void;
+  updateScore?: (responseId: ID, score: number) => void;
+  customScoring?: boolean;
 }
 
 export const ResponseCard: React.FC<Props> = (props) => {
@@ -28,6 +31,10 @@ export const ResponseCard: React.FC<Props> = (props) => {
 
   const onChangeTextDirection = (textDirection: TextDirection) =>
     props.updateFeedbackTextDirection!(props.response.id, textDirection);
+    
+  const onScoreChange = (score: number) => {
+    props.updateScore && props.updateScore(props.response.id, score);
+  };
 
   const editorType = props.response.feedback.editor || DEFAULT_EDITOR;
 
@@ -36,12 +43,26 @@ export const ResponseCard: React.FC<Props> = (props) => {
       <Card.Title>
         <div className="d-flex justify-content-between w-100">{props.title}</div>
         <div className="flex-grow-1"></div>
-        <AuthoringCheckboxConnected
-          label="Correct"
-          id={props.response.id + '-correct'}
-          value={!!props.response.score}
-          onChange={(value) => props.updateCorrectness(props.response.id, value)}
-        />
+
+        {
+          /* No custom scoring, so a correct/incorrect checkbox that sets 1/0 score */
+          props.customScoring || (
+            <AuthoringCheckboxConnected
+              label="Correct"
+              id={props.response.id + '-correct'}
+              value={!!props.response.score}
+              onChange={(value) => props.updateCorrectness(props.response.id, value)}
+            />
+          )
+        }
+
+        {props.customScoring && (
+          /* We are using custom scoring, so prompt for a score instead of correct/incorrect */
+          <ScoreInput score={props.response.score} onChange={onScoreChange} editMode={true}>
+            Score:
+          </ScoreInput>
+        )}
+
         <RemoveButtonConnected onClick={() => props.removeResponse(props.response.id)} />
       </Card.Title>
       <Card.Content>

--- a/assets/src/components/activities/common/responses/ResponseCard.tsx
+++ b/assets/src/components/activities/common/responses/ResponseCard.tsx
@@ -31,7 +31,7 @@ export const ResponseCard: React.FC<Props> = (props) => {
 
   const onChangeTextDirection = (textDirection: TextDirection) =>
     props.updateFeedbackTextDirection!(props.response.id, textDirection);
-    
+
   const onScoreChange = (score: number) => {
     props.updateScore && props.updateScore(props.response.id, score);
   };

--- a/assets/src/components/activities/common/responses/ScoreInput.tsx
+++ b/assets/src/components/activities/common/responses/ScoreInput.tsx
@@ -1,0 +1,23 @@
+import React, { ReactNode } from 'react';
+
+export const ScoreInput: React.FC<{
+  score: number;
+  onChange: (score: number) => void;
+  children: ReactNode;
+  editMode: boolean;
+}> = ({ score, onChange, children, editMode }) => {
+  return (
+    <div className='flex flex-row gap-2 items-center'>
+      <label className='flex items-center'>{children}</label>
+      <input
+        type="number"
+        style={{width: '60px'}}
+        className="form-control inline-block"
+        disabled={!editMode}
+        onChange={(e) => onChange(parseFloat(e.target.value || '0'))}
+        value={score}
+        step={0.1}
+      />
+    </div>
+  );
+};

--- a/assets/src/components/activities/common/responses/ScoreInput.tsx
+++ b/assets/src/components/activities/common/responses/ScoreInput.tsx
@@ -7,11 +7,11 @@ export const ScoreInput: React.FC<{
   editMode: boolean;
 }> = ({ score, onChange, children, editMode }) => {
   return (
-    <div className='flex flex-row gap-2 items-center'>
-      <label className='flex items-center'>{children}</label>
+    <div className="flex flex-row gap-2 items-center">
+      <label className="flex items-center">{children}</label>
       <input
         type="number"
-        style={{width: '60px'}}
+        style={{ width: '60px' }}
         className="form-control inline-block"
         disabled={!editMode}
         onChange={(e) => onChange(parseFloat(e.target.value || '0'))}

--- a/assets/src/components/activities/common/responses/TargetedFeedback.tsx
+++ b/assets/src/components/activities/common/responses/TargetedFeedback.tsx
@@ -12,7 +12,11 @@ import {
   HasParts,
   RichText,
 } from 'components/activities/types';
-import { ResponseMapping, getTargetedResponseMappings } from 'data/activities/model/responses';
+import {
+  ResponseMapping,
+  getTargetedResponseMappings,
+  hasCustomScoring,
+} from 'data/activities/model/responses';
 import { TextDirection } from 'data/content/model/elements/types';
 import { EditorType } from 'data/content/resource';
 import { defaultWriterContext } from 'data/content/writers/context';
@@ -46,6 +50,8 @@ export const useTargetedFeedback = () => {
       dispatch(ResponseActions.removeTargetedFeedback(responseId)),
     updateShowPage: (responseId: string, showPage: number | undefined) =>
       dispatch(ResponseActions.editShowPage(responseId, showPage)),
+    updateScore: (responseId: string, score: number) =>
+      dispatch(ResponseActions.editResponseScore(responseId, score)),
   };
 };
 
@@ -75,6 +81,8 @@ export const TargetedFeedback: React.FC<Props> = (props) => {
 
   // only show feedbacks for relevant choice set, presumably current part's on multipart
   const partMappings = getFeedbackForChoices(props.choices || model.choices, hook.targetedMappings);
+  const customScoring = hasCustomScoring(model);
+
   return (
     <>
       {partMappings.map((mapping) => (
@@ -85,8 +93,10 @@ export const TargetedFeedback: React.FC<Props> = (props) => {
           updateFeedback={hook.updateFeedback}
           updateFeedbackEditor={hook.updateFeedbackEditor}
           updateCorrectness={hook.updateCorrectness}
+          updateScore={hook.updateScore}
           removeResponse={hook.removeFeedback}
           updateFeedbackTextDirection={hook.updateFeedbackTextDirection}
+          customScoring={customScoring}
         >
           <ChoicesDelivery
             unselectedIcon={props.unselectedIcon}
@@ -97,6 +107,7 @@ export const TargetedFeedback: React.FC<Props> = (props) => {
             isEvaluated={false}
             context={writerContext}
           />
+
           {authoringContext.contentBreaksExist ? (
             <ShowPage
               editMode={editMode}

--- a/assets/src/components/activities/common/responses/responseActions.ts
+++ b/assets/src/components/activities/common/responses/responseActions.ts
@@ -47,6 +47,12 @@ export const ResponseActions = {
     };
   },
 
+  editResponseScore(responseId: ResponseId, score: number) {
+    return (model: HasParts) => {
+      getResponseBy(model, (r) => r.id === responseId).score = score;
+    };
+  },
+
   editResponseCorrectness(responseId: ResponseId, correct: boolean) {
     return (model: HasParts) => {
       getResponseBy(model, (r) => r.id === responseId).score = correct ? 1 : 0;

--- a/assets/src/components/activities/custom_dnd/AnswerKey.tsx
+++ b/assets/src/components/activities/custom_dnd/AnswerKey.tsx
@@ -9,9 +9,10 @@ import { InputEntry } from 'components/activities/short_answer/sections/InputEnt
 import { getTargetedResponses } from 'components/activities/short_answer/utils';
 import { Response, RichText, makeResponse } from 'components/activities/types';
 import { TextInput } from 'components/common/TextInput';
-import { getCorrectResponse } from 'data/activities/model/responses';
+import { getCorrectResponse, hasCustomScoring } from 'data/activities/model/responses';
 import { InputKind, containsRule } from 'data/activities/model/rules';
 import { makeRule } from 'data/activities/model/rules';
+import { ActivityScoring } from '../common/responses/ActivityScoring';
 
 export const addTargetedFeedbackFillInTheBlank = (partId: string) =>
   ResponseActions.addResponse(makeResponse(containsRule('another answer'), 0, ''), partId);
@@ -26,6 +27,8 @@ function parseFromRule(rule: string) {
 
 export const AnswerKey: React.FC<Props> = (props) => {
   const { model, dispatch, editMode } = useAuthoringElementContext<CustomDnDSchema>();
+
+  const customScoring = hasCustomScoring(model, props.partId);
 
   return (
     <div className="d-flex flex-column mb-2">
@@ -49,6 +52,9 @@ export const AnswerKey: React.FC<Props> = (props) => {
       />
       <div className="mt-3 mb-3" />
       <SimpleFeedback partId={props.partId} />
+
+      <ActivityScoring partId={props.partId} />
+
       {getTargetedResponses(model, props.partId).map((response: Response) => (
         <ResponseCard
           title="Targeted feedback"
@@ -65,8 +71,12 @@ export const AnswerKey: React.FC<Props> = (props) => {
           updateCorrectness={(_id, correct) =>
             dispatch(ResponseActions.editResponseCorrectness(response.id, correct))
           }
+          updateScore={(_id, score) =>
+            dispatch(ResponseActions.editResponseScore(response.id, score))
+          }
           removeResponse={(id) => dispatch(ResponseActions.removeResponse(id))}
           key={response.id}
+          customScoring={customScoring}
         >
           <InputEntry
             key={response.id}

--- a/assets/src/components/activities/custom_dnd/utils.ts
+++ b/assets/src/components/activities/custom_dnd/utils.ts
@@ -8,7 +8,7 @@ export function createNewPart(id: string, answer: string) {
     scoringStrategy: ScoringStrategy.average,
     gradingApproach: GradingApproach.automatic,
     responses: [
-      makeResponse(matchRule(answer), 1, 'Correct'),
+      makeResponse(matchRule(answer), 1, 'Correct', true),
       makeResponse(matchRule('.*'), 0, 'Incorrect'),
     ],
     hints: [makeHint(''), makeHint(''), makeHint('')],

--- a/assets/src/components/activities/image_coding/ImageCodingAuthoring.tsx
+++ b/assets/src/components/activities/image_coding/ImageCodingAuthoring.tsx
@@ -14,6 +14,7 @@ import guid from 'utils/guid';
 import { AuthoringElement, AuthoringElementProps } from '../AuthoringElement';
 import { AuthoringElementProvider, useAuthoringElementContext } from '../AuthoringElementProvider';
 import { Explanation } from '../common/explanation/ExplanationAuthoring';
+import { ActivityScoring } from '../common/responses/ActivityScoring';
 import * as ActivityTypes from '../types';
 import { MediaItemRequest } from '../types';
 import { ICActions } from './actions';
@@ -192,6 +193,7 @@ const ImageCoding = (props: AuthoringElementProps<ImageCodingModelSchema>) => {
           <TabbedNavigation.Tabs>
             <TabbedNavigation.Tab label="Answer Key">
               {solutionParameters()}
+              <ActivityScoring partId={model.authoring.parts[0].id} />
               <Feedback
                 {...sharedProps}
                 projectSlug={props.projectSlug}

--- a/assets/src/components/activities/image_hotspot/actions.ts
+++ b/assets/src/components/activities/image_hotspot/actions.ts
@@ -41,6 +41,7 @@ export const ImageHotspotActions = {
           matchListRule([correctChoice.id], [correctChoice.id]),
           1,
           '',
+          true
         );
         model.authoring.parts[0].responses = [correctResponse, Responses.catchAll()];
         model.authoring.correct = [[correctChoice.id], correctResponse.id];

--- a/assets/src/components/activities/image_hotspot/actions.ts
+++ b/assets/src/components/activities/image_hotspot/actions.ts
@@ -41,7 +41,7 @@ export const ImageHotspotActions = {
           matchListRule([correctChoice.id], [correctChoice.id]),
           1,
           '',
-          true
+          true,
         );
         model.authoring.parts[0].responses = [correctResponse, Responses.catchAll()];
         model.authoring.correct = [[correctChoice.id], correctResponse.id];

--- a/assets/src/components/activities/likert/LikertAuthoring.tsx
+++ b/assets/src/components/activities/likert/LikertAuthoring.tsx
@@ -16,6 +16,7 @@ import { AuthoringElementProvider, useAuthoringElementContext } from '../Authori
 import { MCActions } from '../common/authoring/actions/multipleChoiceActions';
 import { ChoicesDelivery } from '../common/choices/delivery/ChoicesDelivery';
 import { Explanation } from '../common/explanation/ExplanationAuthoring';
+import { ActivityScoring } from '../common/responses/ActivityScoring';
 import { SimpleFeedback } from '../common/responses/SimpleFeedback';
 import { TargetedFeedback } from '../common/responses/TargetedFeedback';
 import { StemDelivery } from '../common/stem/delivery/StemDelivery';
@@ -24,7 +25,6 @@ import { VariableActions } from '../common/variables/variableActions';
 import * as ActivityTypes from '../types';
 import { LikertActions } from './actions';
 import { LikertModelSchema } from './schema';
-import { ActivityScoring } from '../common/responses/ActivityScoring';
 
 const Likert = (props: AuthoringElementProps<LikertModelSchema>) => {
   const { dispatch, model, editMode, projectSlug } =

--- a/assets/src/components/activities/likert/LikertAuthoring.tsx
+++ b/assets/src/components/activities/likert/LikertAuthoring.tsx
@@ -24,6 +24,7 @@ import { VariableActions } from '../common/variables/variableActions';
 import * as ActivityTypes from '../types';
 import { LikertActions } from './actions';
 import { LikertModelSchema } from './schema';
+import { ActivityScoring } from '../common/responses/ActivityScoring';
 
 const Likert = (props: AuthoringElementProps<LikertModelSchema>) => {
   const { dispatch, model, editMode, projectSlug } =
@@ -195,6 +196,8 @@ const Likert = (props: AuthoringElementProps<LikertModelSchema>) => {
             context={writerContext}
           />
           <SimpleFeedback partId={selectedPartId} />
+          <ActivityScoring partId={model.authoring.parts[0].id} />
+
           <TargetedFeedback
             toggleChoice={(choiceId, mapping) => {
               dispatch(MCActions.editTargetedFeedbackChoice(mapping.response.id, choiceId));

--- a/assets/src/components/activities/multi_input/MultiInputScoringMethod.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputScoringMethod.tsx
@@ -1,0 +1,63 @@
+import React, { useMemo } from 'react';
+import { Card } from 'components/misc/Card';
+import guid from 'utils/guid';
+import { useAuthoringElementContext } from '../AuthoringElementProvider';
+import { ScoringActions } from '../common/authoring/actions/scoringActions';
+import { ScoringStrategy } from '../types';
+import { MultiInputSchema } from './schema';
+
+interface MultiInputScoringMethodProps {}
+
+export const MultiInputScoringMethod: React.FC<MultiInputScoringMethodProps> = () => {
+  const { model, dispatch, editMode } = useAuthoringElementContext<MultiInputSchema>();
+  const checkboxInputId = useMemo(guid, []);
+  const defaultScoring = !model.customScoring;
+  const scoringStrategy = model.scoringStrategy || ScoringStrategy.total;
+
+  const onChangeDefault = (e: React.ChangeEvent<HTMLInputElement>) => {
+    dispatch(ScoringActions.toggleActivityDefaultScoring());
+  };
+
+  const onScoringStrategyChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    dispatch(ScoringActions.editActivityScoringStrategy(e.target.value as ScoringStrategy));
+  };
+
+  return (
+    <Card.Card>
+      <Card.Title>Activity Scoring Method</Card.Title>
+      <Card.Content>
+        <div className="mb-4">
+          <input
+            className="mr-2"
+            type="checkbox"
+            aria-label="Checkbox for default scoring"
+            onChange={onChangeDefault}
+            checked={defaultScoring}
+            id={checkboxInputId}
+            disabled={!editMode}
+          />
+          <label className="mt-2 form-check-label" htmlFor={checkboxInputId}>
+            Use default scoring
+          </label>
+        </div>
+
+        {defaultScoring || (
+          <div className="flex flex-row gap-4 mt-4 items-center">
+            <label className="flex items-center">Scoring Strategy</label>
+            <select
+              style={{ width: '40%' }}
+              className="form-control"
+              disabled={!editMode}
+              value={scoringStrategy || 'average'}
+              onChange={onScoringStrategyChange}
+            >
+              <option value="average">Average</option>
+              <option value="total">Total</option>
+              <option value="best">Best</option>
+            </select>
+          </div>
+        )}
+      </Card.Content>
+    </Card.Card>
+  );
+};

--- a/assets/src/components/activities/multi_input/schema.ts
+++ b/assets/src/components/activities/multi_input/schema.ts
@@ -1,6 +1,7 @@
 import { Maybe } from 'tsmonad';
 import { SelectOption } from 'components/activities/common/authoring/InputTypeDropdown';
 import {
+  ActivityLevelScoring,
   ActivityModelSchema,
   Choice,
   ChoiceId,
@@ -45,7 +46,7 @@ export const multiInputTypeFriendly = (type: MultiInputType): string =>
     }[type],
   ).valueOr(assertNever(type));
 
-export interface MultiInputSchema extends ActivityModelSchema {
+export interface MultiInputSchema extends ActivityModelSchema, ActivityLevelScoring {
   stem: Stem;
   // This is a separated out rather than putting a dropdown's choices under
   // its item in the `inputs` array because the backend transformation logic

--- a/assets/src/components/activities/multi_input/sections/AnswerKeyTab.tsx
+++ b/assets/src/components/activities/multi_input/sections/AnswerKeyTab.tsx
@@ -3,6 +3,7 @@ import { useAuthoringElementContext } from 'components/activities/AuthoringEleme
 import { AuthoringButtonConnected } from 'components/activities/common/authoring/AuthoringButton';
 import { MCActions } from 'components/activities/common/authoring/actions/multipleChoiceActions';
 import { ChoicesDelivery } from 'components/activities/common/choices/delivery/ChoicesDelivery';
+import { ActivityScoring } from 'components/activities/common/responses/ActivityScoring';
 import { ResponseCard } from 'components/activities/common/responses/ResponseCard';
 import { ShowPage } from 'components/activities/common/responses/ShowPage';
 import { SimpleFeedback } from 'components/activities/common/responses/SimpleFeedback';
@@ -19,7 +20,7 @@ import { InputEntry } from 'components/activities/short_answer/sections/InputEnt
 import { getTargetedResponses } from 'components/activities/short_answer/utils';
 import { Response, RichText, makeResponse } from 'components/activities/types';
 import { Radio } from 'components/misc/icons/radio/Radio';
-import { getCorrectResponse } from 'data/activities/model/responses';
+import { getCorrectResponse, hasCustomScoring } from 'data/activities/model/responses';
 import { containsRule, eqRule, equalsRule } from 'data/activities/model/rules';
 import { defaultWriterContext } from 'data/content/writers/context';
 
@@ -70,6 +71,8 @@ export const AnswerKeyTab: React.FC<Props> = (props) => {
           context={defaultWriterContext({ projectSlug: projectSlug })}
         />
         <SimpleFeedback partId={props.input.partId} />
+        <ActivityScoring partId={props.input.partId} />
+
         <TargetedFeedback
           choices={model.choices.filter((choice) =>
             (props.input as Dropdown).choiceIds.includes(choice.id),
@@ -95,6 +98,7 @@ export const AnswerKeyTab: React.FC<Props> = (props) => {
         onEditResponseRule={(id, rule) => dispatch(ResponseActions.editRule(id, rule))}
       />
       <SimpleFeedback partId={props.input.partId} />
+      <ActivityScoring partId={props.input.partId} />
       {getTargetedResponses(model, props.input.partId).map((response: Response) => (
         <ResponseCard
           title="Targeted feedback"
@@ -111,6 +115,10 @@ export const AnswerKeyTab: React.FC<Props> = (props) => {
           updateCorrectness={(_id, correct) =>
             dispatch(ResponseActions.editResponseCorrectness(response.id, correct))
           }
+          updateScore={(_id, score) =>
+            dispatch(ResponseActions.editResponseScore(response.id, score))
+          }
+          customScoring={hasCustomScoring(model, props.input.partId)}
           removeResponse={(id) => dispatch(ResponseActions.removeResponse(id))}
           key={response.id}
         >

--- a/assets/src/components/activities/multi_input/sections/AnswerKeyTab.tsx
+++ b/assets/src/components/activities/multi_input/sections/AnswerKeyTab.tsx
@@ -98,7 +98,7 @@ export const AnswerKeyTab: React.FC<Props> = (props) => {
         onEditResponseRule={(id, rule) => dispatch(ResponseActions.editRule(id, rule))}
       />
       <SimpleFeedback partId={props.input.partId} />
-      <ActivityScoring partId={props.input.partId} />
+      <ActivityScoring partId={props.input.partId} shouldSetStrategy={true} />
       {getTargetedResponses(model, props.input.partId).map((response: Response) => (
         <ResponseCard
           title="Targeted feedback"

--- a/assets/src/components/activities/multi_input/sections/AnswerKeyTab.tsx
+++ b/assets/src/components/activities/multi_input/sections/AnswerKeyTab.tsx
@@ -23,6 +23,7 @@ import { Radio } from 'components/misc/icons/radio/Radio';
 import { getCorrectResponse, hasCustomScoring } from 'data/activities/model/responses';
 import { containsRule, eqRule, equalsRule } from 'data/activities/model/rules';
 import { defaultWriterContext } from 'data/content/writers/context';
+import { MultiInputScoringMethod } from '../MultiInputScoringMethod';
 
 const defaultRuleForInputType = (inputType: string | undefined) => {
   switch (inputType) {
@@ -70,8 +71,13 @@ export const AnswerKeyTab: React.FC<Props> = (props) => {
           isEvaluated={false}
           context={defaultWriterContext({ projectSlug: projectSlug })}
         />
+
         <SimpleFeedback partId={props.input.partId} />
-        <ActivityScoring partId={props.input.partId} />
+
+        <MultiInputScoringMethod />
+        {model.customScoring && (
+          <ActivityScoring partId={props.input.partId} promptForDefault={false} />
+        )}
 
         <TargetedFeedback
           choices={model.choices.filter((choice) =>
@@ -98,7 +104,10 @@ export const AnswerKeyTab: React.FC<Props> = (props) => {
         onEditResponseRule={(id, rule) => dispatch(ResponseActions.editRule(id, rule))}
       />
       <SimpleFeedback partId={props.input.partId} />
-      <ActivityScoring partId={props.input.partId} shouldSetStrategy={true} />
+      <MultiInputScoringMethod />
+      {model.customScoring && (
+        <ActivityScoring partId={props.input.partId} promptForDefault={false} />
+      )}
       {getTargetedResponses(model, props.input.partId).map((response: Response) => (
         <ResponseCard
           title="Targeted feedback"

--- a/assets/src/components/activities/multiple_choice/MultipleChoiceAuthoring.tsx
+++ b/assets/src/components/activities/multiple_choice/MultipleChoiceAuthoring.tsx
@@ -22,11 +22,11 @@ import { AuthoringElement, AuthoringElementProps } from '../AuthoringElement';
 import { AuthoringElementProvider, useAuthoringElementContext } from '../AuthoringElementProvider';
 import { MCActions as Actions } from '../common/authoring/actions/multipleChoiceActions';
 import { Explanation } from '../common/explanation/ExplanationAuthoring';
+import { ActivityScoring } from '../common/responses/ActivityScoring';
 import { VariableEditorOrNot } from '../common/variables/VariableEditorOrNot';
 import { VariableActions } from '../common/variables/variableActions';
 import * as ActivityTypes from '../types';
 import { MCSchema } from './schema';
-import { ActivityScoring } from '../common/responses/ActivityScoring';
 
 const store = configureStore();
 
@@ -73,7 +73,6 @@ const MultipleChoice: React.FC = () => {
           />
           <SimpleFeedback partId={model.authoring.parts[0].id} />
           <ActivityScoring partId={model.authoring.parts[0].id} />
-
 
           <TargetedFeedback
             toggleChoice={(choiceId, mapping) => {

--- a/assets/src/components/activities/multiple_choice/MultipleChoiceAuthoring.tsx
+++ b/assets/src/components/activities/multiple_choice/MultipleChoiceAuthoring.tsx
@@ -26,6 +26,7 @@ import { VariableEditorOrNot } from '../common/variables/VariableEditorOrNot';
 import { VariableActions } from '../common/variables/variableActions';
 import * as ActivityTypes from '../types';
 import { MCSchema } from './schema';
+import { ActivityScoring } from '../common/responses/ActivityScoring';
 
 const store = configureStore();
 
@@ -71,6 +72,9 @@ const MultipleChoice: React.FC = () => {
             context={writerContext}
           />
           <SimpleFeedback partId={model.authoring.parts[0].id} />
+          <ActivityScoring partId={model.authoring.parts[0].id} />
+
+
           <TargetedFeedback
             toggleChoice={(choiceId, mapping) => {
               dispatch(Actions.editTargetedFeedbackChoice(mapping.response.id, choiceId));

--- a/assets/src/components/activities/ordering/OrderingAuthoring.tsx
+++ b/assets/src/components/activities/ordering/OrderingAuthoring.tsx
@@ -25,6 +25,7 @@ import { VariableActions } from '../common/variables/variableActions';
 import * as ActivityTypes from '../types';
 import { Actions } from './actions';
 import { OrderingSchema } from './schema';
+import { ActivityScoring } from '../common/responses/ActivityScoring';
 
 const store = configureStore();
 
@@ -64,6 +65,7 @@ export const Ordering: React.FC = () => {
           setChoices={(choices) => dispatch(Actions.setCorrectChoices(choices))}
         />
         <SimpleFeedback partId={model.authoring.parts[0].id} />
+        <ActivityScoring partId={model.authoring.parts[0].id} />
         <TargetedFeedback />
       </TabbedNavigation.Tab>
 

--- a/assets/src/components/activities/ordering/OrderingAuthoring.tsx
+++ b/assets/src/components/activities/ordering/OrderingAuthoring.tsx
@@ -20,12 +20,12 @@ import { configureStore } from 'state/store';
 import { AuthoringElement, AuthoringElementProps } from '../AuthoringElement';
 import { AuthoringElementProvider, useAuthoringElementContext } from '../AuthoringElementProvider';
 import { Explanation } from '../common/explanation/ExplanationAuthoring';
+import { ActivityScoring } from '../common/responses/ActivityScoring';
 import { VariableEditorOrNot } from '../common/variables/VariableEditorOrNot';
 import { VariableActions } from '../common/variables/variableActions';
 import * as ActivityTypes from '../types';
 import { Actions } from './actions';
 import { OrderingSchema } from './schema';
-import { ActivityScoring } from '../common/responses/ActivityScoring';
 
 const store = configureStore();
 

--- a/assets/src/components/activities/ordering/sections/TargetedFeedback.tsx
+++ b/assets/src/components/activities/ordering/sections/TargetedFeedback.tsx
@@ -9,13 +9,14 @@ import { OrderingSchema } from 'components/activities/ordering/schema';
 import { ResponseChoices } from 'components/activities/ordering/sections/ResponseChoices';
 import { RichText } from 'components/activities/types';
 import { Choices } from 'data/activities/model/choices';
-import { getTargetedResponseMappings } from 'data/activities/model/responses';
+import { getTargetedResponseMappings, hasCustomScoring } from 'data/activities/model/responses';
 import { defaultWriterContext } from 'data/content/writers/context';
 
 export const TargetedFeedback: React.FC = () => {
   const { model, dispatch, authoringContext, editMode, projectSlug } =
     useAuthoringElementContext<OrderingSchema>();
   const writerContext = defaultWriterContext({ projectSlug });
+  const customScoring = hasCustomScoring(model);
 
   return (
     <>
@@ -38,6 +39,8 @@ export const TargetedFeedback: React.FC = () => {
             dispatch(ResponseActions.editResponseCorrectness(mapping.response.id, correct))
           }
           removeResponse={(id) => dispatch(ResponseActions.removeTargetedFeedback(id))}
+          updateScore={(id, score) => dispatch(ResponseActions.editResponseScore(id, score))}
+          customScoring={customScoring}
           key={mapping.response.id}
         >
           <ResponseChoices

--- a/assets/src/components/activities/ordering/utils.ts
+++ b/assets/src/components/activities/ordering/utils.ts
@@ -9,7 +9,12 @@ export const defaultOrderingModel = (): Ordering => {
   const choice1 = makeChoice('Choice 1');
   const choice2 = makeChoice('Choice 2');
 
-  const correctResponse = makeResponse(matchInOrderRule([choice1.id, choice2.id]), 1, 'Correct', true);
+  const correctResponse = makeResponse(
+    matchInOrderRule([choice1.id, choice2.id]),
+    1,
+    'Correct',
+    true,
+  );
 
   return {
     stem: makeStem(''),

--- a/assets/src/components/activities/ordering/utils.ts
+++ b/assets/src/components/activities/ordering/utils.ts
@@ -9,7 +9,7 @@ export const defaultOrderingModel = (): Ordering => {
   const choice1 = makeChoice('Choice 1');
   const choice2 = makeChoice('Choice 2');
 
-  const correctResponse = makeResponse(matchInOrderRule([choice1.id, choice2.id]), 1, 'Correct');
+  const correctResponse = makeResponse(matchInOrderRule([choice1.id, choice2.id]), 1, 'Correct', true);
 
   return {
     stem: makeStem(''),

--- a/assets/src/components/activities/short_answer/ShortAnswerAuthoring.tsx
+++ b/assets/src/components/activities/short_answer/ShortAnswerAuthoring.tsx
@@ -20,13 +20,14 @@ import {
   makeResponse,
 } from 'components/activities/types';
 import { TabbedNavigation } from 'components/tabbed_navigation/Tabs';
-import { getCorrectResponse } from 'data/activities/model/responses';
+import { getCorrectResponse, hasCustomScoring } from 'data/activities/model/responses';
 import { containsRule, eqRule } from 'data/activities/model/rules';
 import { defaultWriterContext } from 'data/content/writers/context';
 import { configureStore } from 'state/store';
 import { AuthoringElement, AuthoringElementProps } from '../AuthoringElement';
 import { AuthoringElementProvider, useAuthoringElementContext } from '../AuthoringElementProvider';
 import { Explanation } from '../common/explanation/ExplanationAuthoring';
+import { ActivityScoring } from '../common/responses/ActivityScoring';
 import { VariableEditorOrNot } from '../common/variables/VariableEditorOrNot';
 import { VariableActions } from '../common/variables/variableActions';
 import { ShortAnswerActions } from './actions';
@@ -99,10 +100,15 @@ const ShortAnswer = () => {
               onEditResponseRule={(id, rule) => dispatch(ResponseActions.editRule(id, rule))}
             />
             <SimpleFeedback partId={model.authoring.parts[0].id} />
+            <ActivityScoring partId={model.authoring.parts[0].id} />
             {getTargetedResponses(model, model.authoring.parts[0].id).map((response: Response) => (
               <ResponseCard
                 title="Targeted feedback"
                 response={response}
+                customScoring={hasCustomScoring(model, model.authoring.parts[0].id)}
+                updateScore={(_id, score) =>
+                  dispatch(ResponseActions.editResponseScore(response.id, score))
+                }
                 updateFeedbackEditor={(_id, editor) =>
                   dispatch(ResponseActions.editResponseFeedbackEditor(response.id, editor))
                 }

--- a/assets/src/components/activities/types.ts
+++ b/assets/src/components/activities/types.ts
@@ -481,6 +481,11 @@ export interface Response extends Identifiable {
   feedback: Feedback;
 
   /**
+   * Is this response, the default correct response?
+   */
+  correct?: boolean;
+
+  /**
    * Optional, show a page by index when this response is evaluated.
    */
   showPage?: number;
@@ -493,11 +498,17 @@ export interface Response extends Identifiable {
  * @param text simple text to formulate a Feedback from
  * @returns
  */
-export const makeResponse = (rule: string, score: number, text = ''): Response => ({
+export const makeResponse = (
+  rule: string,
+  score: number,
+  text = '',
+  correct?: boolean
+): Response => ({
   id: guid(),
   rule,
   score,
   feedback: makeFeedback(text),
+  correct,
 });
 
 /**

--- a/assets/src/components/activities/types.ts
+++ b/assets/src/components/activities/types.ts
@@ -562,6 +562,7 @@ export interface Part extends Identifiable {
   scoringStrategy: ScoringStrategy;
   gradingApproach?: GradingApproach;
   outOf?: null | number;
+  incorrectScore?: null | number;
 }
 
 /**

--- a/assets/src/components/activities/types.ts
+++ b/assets/src/components/activities/types.ts
@@ -610,6 +610,9 @@ export interface HasParts {
 export interface ActivityLevelScoring {
   customScoring?: boolean;
   scoringStrategy?: ScoringStrategy;
+  authoring: {
+    parts: Part[];
+  };
 }
 
 /**

--- a/assets/src/components/activities/types.ts
+++ b/assets/src/components/activities/types.ts
@@ -502,7 +502,7 @@ export const makeResponse = (
   rule: string,
   score: number,
   text = '',
-  correct?: boolean
+  correct?: boolean,
 ): Response => ({
   id: guid(),
   rule,

--- a/assets/src/components/activities/types.ts
+++ b/assets/src/components/activities/types.ts
@@ -607,6 +607,11 @@ export interface HasParts {
   };
 }
 
+export interface ActivityLevelScoring {
+  customScoring?: boolean;
+  scoringStrategy?: ScoringStrategy;
+}
+
 /**
  * The types of grading, or scoring, supported for a part.
  */
@@ -629,6 +634,7 @@ export enum ScoringStrategy {
   'average' = 'average',
   'best' = 'best',
   'most_recent' = 'most_recent',
+  'total' = 'total',
 }
 
 /**

--- a/assets/src/data/activities/model/responses.ts
+++ b/assets/src/data/activities/model/responses.ts
@@ -49,10 +49,14 @@ export const hasCustomScoring = (model: HasParts, partId?: string): boolean => {
   return outOf !== null && outOf !== undefined;
 };
 
-
 export const getOutOfPoints = (model: HasParts, partId: string) => {
   const part = getPartById(model, partId);
   return part?.outOf;
+};
+
+export const getScoringStrategy = (model: HasParts, partId: string) => {
+  const part = getPartById(model, partId);
+  return part?.scoringStrategy;
 };
 
 export const getIncorrectPoints = (model: HasParts, partId: string) => {

--- a/assets/src/data/activities/model/responses.ts
+++ b/assets/src/data/activities/model/responses.ts
@@ -43,6 +43,13 @@ export const getResponsesByPartId = (model: HasParts, partId: string): Response[
 export const getResponseBy = (model: HasParts, predicate: (x: Response) => boolean) =>
   getByUnsafe(getResponses(model), predicate);
 
+
+export const hasCustomScoring = (model: HasParts, partId?: string): boolean => {
+  const outOf = getOutOfPoints(model, partId || model.authoring.parts[0].id);
+  console.info('hasCustomScoring', outOf, model, partId)
+  return outOf !== null && outOf !== undefined;
+};
+
 export const getOutOfPoints = (model: HasParts, partId: string) => {
   const part = getPartById(model, partId);
   return part?.outOf;
@@ -51,7 +58,7 @@ export const getOutOfPoints = (model: HasParts, partId: string) => {
 export const getIncorrectPoints = (model: HasParts, partId: string) => {
   const part = getPartById(model, partId);
   return part?.incorrectScore;
-}
+};
 
 // Does not take into account partial credit
 export const getCorrectResponse = (model: HasParts, partId: string) => {

--- a/assets/src/data/activities/model/responses.ts
+++ b/assets/src/data/activities/model/responses.ts
@@ -3,7 +3,6 @@ import {
   ChoiceId,
   ChoiceIdsToResponseId,
   HasParts,
-  Part,
   Response,
   makeResponse,
 } from 'components/activities/types';

--- a/assets/src/data/activities/model/responses.ts
+++ b/assets/src/data/activities/model/responses.ts
@@ -43,6 +43,16 @@ export const getResponsesByPartId = (model: HasParts, partId: string): Response[
 export const getResponseBy = (model: HasParts, predicate: (x: Response) => boolean) =>
   getByUnsafe(getResponses(model), predicate);
 
+export const getOutOfPoints = (model: HasParts, partId: string) => {
+  const part = getPartById(model, partId);
+  return part?.outOf;
+};
+
+export const getIncorrectPoints = (model: HasParts, partId: string) => {
+  const part = getPartById(model, partId);
+  return part?.incorrectScore;
+}
+
 // Does not take into account partial credit
 export const getCorrectResponse = (model: HasParts, partId: string) => {
   return Maybe.maybe(getResponsesByPartId(model, partId).find((r) => r.score >= 1)).valueOrThrow(

--- a/assets/src/data/activities/model/responses.ts
+++ b/assets/src/data/activities/model/responses.ts
@@ -3,6 +3,7 @@ import {
   ChoiceId,
   ChoiceIdsToResponseId,
   HasParts,
+  Part,
   Response,
   makeResponse,
 } from 'components/activities/types';
@@ -43,12 +44,11 @@ export const getResponsesByPartId = (model: HasParts, partId: string): Response[
 export const getResponseBy = (model: HasParts, predicate: (x: Response) => boolean) =>
   getByUnsafe(getResponses(model), predicate);
 
-
 export const hasCustomScoring = (model: HasParts, partId?: string): boolean => {
   const outOf = getOutOfPoints(model, partId || model.authoring.parts[0].id);
-  console.info('hasCustomScoring', outOf, model, partId)
   return outOf !== null && outOf !== undefined;
 };
+
 
 export const getOutOfPoints = (model: HasParts, partId: string) => {
   const part = getPartById(model, partId);

--- a/assets/src/data/activities/model/responses.ts
+++ b/assets/src/data/activities/model/responses.ts
@@ -12,15 +12,15 @@ import { getByUnsafe, getPartById } from 'data/activities/model/utils';
 export const Responses = {
   catchAll: (text = 'Incorrect') => makeResponse(matchRule('.*'), 0, text),
   forTextInput: (correctText = 'Correct', incorrectText = 'Incorrect') => [
-    makeResponse(containsRule('answer'), 1, correctText),
+    makeResponse(containsRule('answer'), 1, correctText, true),
     Responses.catchAll(incorrectText),
   ],
   forNumericInput: (correctText = 'Correct', incorrectText = 'Incorrect') => [
-    makeResponse(eqRule(1), 1, correctText),
+    makeResponse(eqRule(1), 1, correctText, true),
     Responses.catchAll(incorrectText),
   ],
   forMathInput: (correctText = 'Correct', incorrectText = 'Incorrect') => [
-    makeResponse(equalsRule(''), 1, correctText),
+    makeResponse(equalsRule(''), 1, correctText, true),
     Responses.catchAll(incorrectText),
   ],
   forMultipleChoice: (
@@ -28,7 +28,7 @@ export const Responses = {
     correctText = 'Correct',
     incorrectText = 'Incorrect',
   ) => [
-    makeResponse(matchRule(correctChoiceId), 1, correctText),
+    makeResponse(matchRule(correctChoiceId), 1, correctText, true),
     makeResponse(matchRule('.*'), 0, incorrectText),
   ],
 };
@@ -65,9 +65,10 @@ export const getIncorrectPoints = (model: HasParts, partId: string) => {
 
 // Does not take into account partial credit
 export const getCorrectResponse = (model: HasParts, partId: string) => {
-  return Maybe.maybe(getResponsesByPartId(model, partId).find((r) => r.score >= 1)).valueOrThrow(
-    new Error('Could not find correct response'),
-  );
+  return Maybe.maybe(
+    getResponsesByPartId(model, partId).find((r) => r.correct) ||
+      getResponsesByPartId(model, partId).find((r) => r.score >= 1),
+  ).valueOrThrow(new Error('Could not find correct response'));
 };
 export const getIncorrectResponse = (model: HasParts, partId: string) => {
   return Maybe.maybe(

--- a/assets/test/activities/responses_test.ts
+++ b/assets/test/activities/responses_test.ts
@@ -16,7 +16,7 @@ const DEFAULT_PART_ID = '1';
 
 describe('responses', () => {
   const choice = makeChoice('a');
-  const response = makeResponse(matchRule(choice.id), 1, '');
+  const response = makeResponse(matchRule(choice.id), 1, '', true);
   const model: HasParts & HasChoices & { authoring: { targeted: ChoiceIdsToResponseId[] } } = {
     choices: [choice],
     authoring: {

--- a/lib/oli_web/controllers/api/attempt_controller.ex
+++ b/lib/oli_web/controllers/api/attempt_controller.ex
@@ -619,7 +619,6 @@ defmodule OliWeb.Api.AttemptController do
            section_slug,
            activity_attempt_guid,
            client_evaluations,
-           :normalize,
            datashop_session_id
          ) do
       {:ok, evaluations} ->

--- a/lib/oli_web/controllers/legacy_superactivity_controller.ex
+++ b/lib/oli_web/controllers/legacy_superactivity_controller.ex
@@ -404,8 +404,7 @@ defmodule OliWeb.LegacySuperactivityController do
 
           rest =
             ActivityEvaluation.rollup_part_attempt_evaluations(
-              context.activity_attempt.attempt_guid,
-              :normalize
+              context.activity_attempt.attempt_guid
             )
 
           rest

--- a/test/oli/delivery/attempts_test.exs
+++ b/test/oli/delivery/attempts_test.exs
@@ -744,7 +744,6 @@ defmodule Oli.Delivery.AttemptsTest do
                context_id,
                activity_attempt_guid,
                client_evaluations,
-               :normalize,
                datashop_session_id
              ) ==
                {:ok,

--- a/test/oli/delivery/submission_test.exs
+++ b/test/oli/delivery/submission_test.exs
@@ -665,8 +665,8 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
 
       # verify that the submission rolled up to the activity attempt
       updated_attempt = Oli.Repo.get!(ActivityAttempt, activity_attempt.id)
-      assert updated_attempt.score == 1.0
-      assert updated_attempt.out_of == 1.0
+      assert updated_attempt.score == 10.0
+      assert updated_attempt.out_of == 10.0
       refute updated_attempt.date_evaluated == nil
 
       # now reset the activity
@@ -738,8 +738,8 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
 
       # verify that the submission rolled up to the activity attempt
       updated_attempt = Oli.Repo.get!(ActivityAttempt, activity_attempt.id)
-      assert updated_attempt.score == 1.0
-      assert updated_attempt.out_of == 1.0
+      assert updated_attempt.score == 10.0
+      assert updated_attempt.out_of == 10.0
       refute updated_attempt.date_evaluated == nil
 
       # Now simulate something having gone wrong, perhaps a rogue activity using
@@ -954,8 +954,8 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
 
       # verify that the submission rolled up to the activity attempt
       updated_attempt = Oli.Repo.get!(ActivityAttempt, activity_attempt.id)
-      assert updated_attempt.score == 1.0
-      assert updated_attempt.out_of == 1.0
+      assert updated_attempt.score == 10.0
+      assert updated_attempt.out_of == 10.0
       refute updated_attempt.date_evaluated == nil
 
       # verify that the updated part attempt has the latest datashop session id
@@ -1240,8 +1240,8 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
       # verify that the submission did roll up to the activity attempt
       # with the fact that the scoring strategy defaults to best
       updated_attempt = Oli.Repo.get!(ActivityAttempt, activity_attempt.id)
-      assert updated_attempt.score == 1.0
-      assert updated_attempt.out_of == 1.0
+      assert updated_attempt.score == 10.0
+      assert updated_attempt.out_of == 10.0
       refute updated_attempt.date_evaluated == nil
     end
   end

--- a/test/oli_web/controllers/page_delivery_controller_test.exs
+++ b/test/oli_web/controllers/page_delivery_controller_test.exs
@@ -410,8 +410,8 @@ defmodule OliWeb.PageDeliveryControllerTest do
 
       # fetch the resource id record and verify the grade rolled up
       [access] = Oli.Repo.all(ResourceAccess)
-      assert abs(access.score - 0.909) < 0.01
-      assert access.out_of == 1
+      assert access.score == 10.0
+      assert access.out_of == 11.0
 
       # now visit the page again, verifying that we see the prologue, but this time it
       # does not allow us to start a new attempt


### PR DESCRIPTION
Opening this as a draft, we need some backend support for the evaluation portions.

This PR adds new scoring options to the authoring interface to capture the number of points a correct or incorrect answer will award.
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/653d421e-d64b-40c2-b1d0-9d26ffdd9914)

It also adds the ability to specify the points of targeted feedback.
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/bdf57595-a81e-446c-be95-f189635e3f0c)

In multi-input questions, you can specify the scoring strategy:
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/2e40ac3c-ba13-4985-814b-b5775b9822dc)

