### PR TITLE
[BUG FIX] [MER-2643] Creating new institution with same issuer and client_id fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug Fixes
 
+- Fix an issue where admin attempting to create a new institution when an existing registration with the same issuer and client_id fails
+
 ## 0.25.0 (2023-10-5)
 
 ### Enhancements

--- a/lib/oli/institutions.ex
+++ b/lib/oli/institutions.ex
@@ -650,7 +650,7 @@ defmodule Oli.Institutions do
                institution_id: institution.id,
                tool_jwk_id: active_jwk.id
              }),
-           {:ok, registration} <- create_registration(registration_attrs),
+           {:ok, registration} <- find_or_create_registration(registration_attrs),
            deployment_attrs =
              Map.merge(PendingRegistration.deployment_attrs(pending_registration), %{
                institution_id: institution.id,

--- a/lib/oli_web/templates/institution/show.html.eex
+++ b/lib/oli_web/templates/institution/show.html.eex
@@ -50,17 +50,17 @@
       <tr>
         <td><strong>Deployments:</strong></td>
         <td>
-          <%= for deployment <- @institution.deployments do %>
             <ul>
-              <li id="<%= "deployment-#{deployment.id}" %>">
-                <%= deployment.deployment_id %>
-                <%= link to: Routes.registration_path(@conn, :show, deployment.registration_id) <> "#deployment-#{deployment.id}",
-                  class: "btn btn-xs btn-link ml-2 float-right" do %>
-                    LTI 1.3 Registration Details
-                <% end %>
-              </li>
+            <%= for deployment <- @institution.deployments do %>
+                <li id="<%= "deployment-#{deployment.id}" %>" class="flex flex-row">
+                  <div><%= deployment.deployment_id %></div>
+                  <%= link to: Routes.registration_path(@conn, :show, deployment.registration_id) <> "#deployment-#{deployment.id}",
+                    class: "btn btn-xs btn-link ml-2" do %>
+                      LTI 1.3 Registration Details
+                  <% end %>
+                </li>
+            <% end %>
             </ul>
-          <% end %>
         </td>
       </tr>
 

--- a/lib/oli_web/templates/layout/live.html.leex
+++ b/lib/oli_web/templates/layout/live.html.leex
@@ -1,9 +1,10 @@
 
 <div id="live_flash_container" class="flash container mx-auto px-0 sticky top-[80px]">
   <%= if live_flash(@flash, :info) do %>
-    <div class="alert alert-info flex flex-row justify-between" role="alert">
-
-      <%= live_flash(@flash, :info) %>
+    <div class="alert alert-info flex flex-row" role="alert">
+      <div class="flex-1">
+        <%= live_flash(@flash, :info) %>
+      </div>
 
       <button type="button" class="close" data-bs-dismiss="alert" aria-label="Close" phx-click="lv:clear-flash" phx-value-key="info">
         <i class="fa-solid fa-xmark fa-lg"></i>
@@ -13,9 +14,11 @@
   <% end %>
 
   <%= if live_flash(@flash, :error) do %>
-    <div class="alert alert-danger flex flex-row justify-between" role="alert">
+    <div class="alert alert-danger flex flex-row" role="alert">
 
-      <%= live_flash(@flash, :error) %>
+      <div class="flex-1">
+        <%= live_flash(@flash, :error) %>
+      </div>
 
       <button type="button" class="close" data-bs-dismiss="alert" aria-label="Close" phx-click="lv:clear-flash" phx-value-key="error">
         <i class="fa-solid fa-xmark fa-lg"></i>

--- a/lib/oli_web/templates/registration/show.html.eex
+++ b/lib/oli_web/templates/registration/show.html.eex
@@ -52,24 +52,24 @@
         <tr>
         <td><strong>Deployments:</strong></td>
         <td>
-            <%= for deployment <- @registration.deployments do %>
             <ul>
-                <li id="<%= "deployment-#{deployment.id}" %>">
+              <%= for deployment <- @registration.deployments do %>
+                <li id="<%= "deployment-#{deployment.id}" %>" class="my-1">
                 <%= deployment.deployment_id %>
                 <%= link to: Routes.registration_deployment_path(@conn, :edit, @registration.id, deployment.id),
-                    class: "btn btn-xs btn-primary ml-2 float-right" do %>
+                    class: "btn btn-xs btn-primary ml-2" do %>
                     <i class="far fa-trash-alt"></i> Edit
                 <% end %>
 
                 <%= link to: Routes.registration_deployment_path(@conn, :delete, @registration.id, deployment.id),
                     method: :delete,
-                    class: "btn btn-xs btn-danger ml-2 float-right",
+                    class: "btn btn-xs btn-danger ml-2",
                     data: [confirm: "Are you sure you want to delete this deployment? \"#{deployment.deployment_id}\""] do %>
                     <i class="far fa-trash-alt"></i> Delete
                 <% end %>
                 </li>
+              <% end %>
             </ul>
-            <% end %>
 
             <%= link "Add a Deployment", to: Routes.registration_deployment_path(@conn, :new, @registration.id), class: "btn btn-sm btn-outline-primary" %>
         </td>


### PR DESCRIPTION
Fixes an issue where admin attempting to create a new institution when an existing registration with the same issuer and client_id crashes.

I tested simply dropping the index constraint but unfortunately it does not resolve the issue. While it does allow the new institution and registration to be created, it creates a new issue on LTI launch where the system expects only a single registration with issuer and client_id to exist. A code change is required to fix this.

The new approach taken here is for the system to check on institution creation if a registration already exists for a given issuer client_id and if so, continue to create the new institution but reuse the existing registration. The system was already doing this in a previous code path but the enhancements made to allow institution customization were not using the `find_or_create_registration` function.

I also made a couple of easy QOL style enhancements/bug fixes while I was here.