### PR TITLE
[FEATURE][MER-2142] Add labels to course navigation

### DIFF
--- a/assets/src/components/delivery/CourseContentOutline.tsx
+++ b/assets/src/components/delivery/CourseContentOutline.tsx
@@ -58,6 +58,8 @@ type FlattenedItem = {
   level: number;
   containerSlug: string | undefined;
   isActive: boolean;
+  label: string;
+  index: string;
 };
 
 const flatten = (
@@ -83,6 +85,8 @@ const flatten = (
           type: item.type,
           title: item.title,
           slug: item.slug,
+          label: item.label,
+          index: item.index,
           level,
           containerSlug: item.slug,
           isActive: isCurrentUrl(sectionSlug, projectSlug, item.type, item.slug, isPreview),
@@ -101,6 +105,8 @@ const flatten = (
           type: item.type,
           title: item.title,
           slug: item.slug,
+          label: item.label,
+          index: item.index,
           level,
           containerSlug,
           isActive: isCurrentUrl(sectionSlug, projectSlug, item.type, item.slug, isPreview),
@@ -118,6 +124,8 @@ interface Container {
   title: string;
   id: string;
   slug: string;
+  label: string;
+  index: string;
 }
 
 interface Page {
@@ -125,6 +133,8 @@ interface Page {
   title: string;
   id: string;
   slug: string;
+  label: string;
+  index: string;
 }
 
 type HierarchyItem = Container | Page;
@@ -162,6 +172,8 @@ interface PageItemProps extends FlattenedItem {
 const PageItem = ({
   type,
   title,
+  label,
+  index,
   slug,
   level,
   sectionSlug,
@@ -183,6 +195,10 @@ const PageItem = ({
         : 'border-transparent',
     )}
   >
-    <div style={{ marginLeft: level * 20 }}>{title}</div>
+    {type === 'container' ? (
+      <div className="font-bold" style={{ marginLeft: level * 20 }}>{label + ' ' + index + ': ' + title}</div>
+    ) : (
+      <div className="flex border-dashed border-b-2 border-gray-100" style={{ marginLeft: level * 20 }}><div className="grow">{title}</div><div className="grow-0 mr-4">{index}</div></div>
+    )}
   </a>
 );

--- a/assets/src/components/delivery/CourseContentOutline.tsx
+++ b/assets/src/components/delivery/CourseContentOutline.tsx
@@ -196,9 +196,17 @@ const PageItem = ({
     )}
   >
     {type === 'container' ? (
-      <div className="font-bold" style={{ marginLeft: level * 20 }}>{label + ' ' + index + ': ' + title}</div>
+      <div className="font-bold" style={{ marginLeft: level * 20 }}>
+        {label + ' ' + index + ': ' + title}
+      </div>
     ) : (
-      <div className="flex border-dashed border-b-2 border-gray-100" style={{ marginLeft: level * 20 }}><div className="grow">{title}</div><div className="grow-0 mr-4">{index}</div></div>
+      <div
+        className="flex border-dashed border-b-2 border-gray-100"
+        style={{ marginLeft: level * 20 }}
+      >
+        <div className="grow">{title}</div>
+        <div className="grow-0 mr-4">{index}</div>
+      </div>
     )}
   </a>
 );

--- a/assets/src/components/delivery/CourseContentOutline.tsx
+++ b/assets/src/components/delivery/CourseContentOutline.tsx
@@ -200,10 +200,7 @@ const PageItem = ({
         {label + ' ' + index + ': ' + title}
       </div>
     ) : (
-      <div
-        className="flex border-dashed border-b-2 border-gray-100"
-        style={{ marginLeft: level * 20 }}
-      >
+      <div className="flex border-dashed border-b-2 border-gray-100" style={{ marginLeft: level * 20 }}>
         <div className="grow">{title}</div>
         <div className="grow-0 mr-4">{index}</div>
       </div>

--- a/assets/src/components/delivery/CourseContentOutline.tsx
+++ b/assets/src/components/delivery/CourseContentOutline.tsx
@@ -200,7 +200,10 @@ const PageItem = ({
         {label + ' ' + index + ': ' + title}
       </div>
     ) : (
-      <div className="flex border-dashed border-b-2 border-gray-100" style={{ marginLeft: level * 20 }}>
+      <div
+        className="flex border-dashed border-b-2 border-gray-100"
+        style={{ marginLeft: level * 20 }}
+      >
         <div className="grow">{title}</div>
         <div className="grow-0 mr-4">{index}</div>
       </div>

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -2689,6 +2689,16 @@ defmodule Oli.Delivery.Sections do
     {:ok, _, previous_next_index} =
       PreviousNextIndex.retrieve(section, section.root_section_resource.resource_id)
 
+      previous_next_index = previous_next_index
+        |>Enum.map(fn {k, v} ->
+          label = if Map.get(v, "type") === "container" do
+            get_container_label(String.to_integer(Map.get(v, "level")), section.customizations || Map.from_struct(CustomLabels.default()))
+          else
+            ""
+          end
+          {k, Map.put(v, "label", label)}
+        end)
+        |> Map.new()
     # Retrieve the top level resource ids, and convert them to strings
     resource_ids =
       Oli.Delivery.Sections.map_section_resource_children_to_resource_ids(

--- a/lib/oli_web/components/delivery/nav_sidebar.ex
+++ b/lib/oli_web/components/delivery/nav_sidebar.ex
@@ -190,7 +190,7 @@ defmodule OliWeb.Components.Delivery.NavSidebar do
       assigns[:section]
       |> Oli.Repo.preload([:root_section_resource])
       |> Sections.build_hierarchy()
-
+      
     [
       %{
         name: "Home",


### PR DESCRIPTION
This PR adds default "module," "unit," "section," or custom labels to the student delivery course left navigation menu. It also renders index or page numbers in the navigation UI.