### PR TITLE
 [ENHANCEMENT] Style new DnDs so text remains legible in dark mode [MER-2652]

### DIFF
--- a/assets/src/components/activities/custom_dnd/CustomDnDAuthoring.tsx
+++ b/assets/src/components/activities/custom_dnd/CustomDnDAuthoring.tsx
@@ -65,9 +65,9 @@ const CustomDnd = () => {
         </TabbedNavigation.Tab>
         <TabbedNavigation.Tab label="Target Area">
           <div className="alert alert-info" role="alert">
-            Every part identifier must have a corresponding <code>&lt;div&gt;</code> element whose{' '}
-            <code>input_ref</code> attribute is set to that part identifier. Each of these{' '}
-            <code>&lt;div&gt;</code> elements must also have <code>target</code> set a CSS class
+            Every target area must have a corresponding <code>&lt;div&gt;</code> element whose{' '}
+            <code>input_ref</code> attribute is set to that target identifier. Each of these{' '}
+            <code>&lt;div&gt;</code> elements must also have <code>target</code> set as a CSS class
             name.
           </div>
           <WrappedMonaco
@@ -79,10 +79,10 @@ const CustomDnd = () => {
         </TabbedNavigation.Tab>
         <TabbedNavigation.Tab label="Initiators">
           <div className="alert alert-info" role="alert">
-            For each possible initiator identifier (the things students will drag) define a{' '}
+            For each possible initiator (the things students will drag) define a{' '}
             <code>&lt;div&gt;</code> element whose <code>input_val</code> attribute is set to that
             initiator identifier. Each of these <code>&lt;div&gt;</code> elements must also have{' '}
-            <code>initiator</code> set a CSS class name.
+            <code>initiator</code> set as a CSS class name.
           </div>
           <WrappedMonaco
             model={model.initiators}

--- a/assets/src/components/activities/custom_dnd/utils.ts
+++ b/assets/src/components/activities/custom_dnd/utils.ts
@@ -56,6 +56,7 @@ const DEFAULT_LAYOUT_STYLES = `
 }
 
 .initiator {
+  color: black;
   display: inline-block;
   min-height: 20px;
   height: 30px;


### PR DESCRIPTION
This adjusts the custom Drag-and-Drop stylesheet used for newly authored DnDs by setting text color style of black on the initiators to ensure the text remains visible against the yellow background in dark mode.

This has no effect on migrated or previously authored DnDs. It is just for newly created ones. 

Also includes slight adjustments to on-screen messages shown to author. In particular, removed the implication that part IDs are associated with targets which is now incorrect: on any newly created DnD, it is the initiators that carry part IDs.  Older  DnDs might have used the targets-as-parts model, so simply avoid saying which element carries part Id.