### PR TITLE
[MER-2644] Allow changing of table page sizes for instructor dashboard tables

### DIFF
--- a/lib/oli_web/components/delivery/content/content.ex
+++ b/lib/oli_web/components/delivery/content/content.ex
@@ -10,7 +10,7 @@ defmodule OliWeb.Components.Delivery.Content do
 
   @default_params %{
     offset: 0,
-    limit: 25,
+    limit: 20,
     container_id: nil,
     sort_order: :asc,
     sort_by: :numbering_index,
@@ -120,6 +120,8 @@ defmodule OliWeb.Components.Delivery.Content do
           additional_table_class="instructor_dashboard_table"
           sort={JS.push("paged_table_sort", target: @myself)}
           page_change={JS.push("paged_table_page_change", target: @myself)}
+          limit_change={JS.push("paged_table_limit_change", target: @myself)}
+          show_limit_change={true}
         />
       </div>
     </div>
@@ -164,6 +166,31 @@ defmodule OliWeb.Components.Delivery.Content do
          route_for(
            socket,
            %{limit: limit, offset: offset},
+           socket.assigns.patch_url_type
+         )
+     )}
+  end
+
+  def handle_event(
+        "paged_table_limit_change",
+        params,
+        %{assigns: %{params: current_params}} = socket
+      ) do
+    new_limit = Params.get_int_param(params, "limit", 20)
+
+    new_offset =
+      OliWeb.Common.PagingParams.calculate_new_offset(
+        current_params.offset,
+        new_limit,
+        socket.assigns.total_count
+      )
+
+    {:noreply,
+     push_patch(socket,
+       to:
+         route_for(
+           socket,
+           %{limit: new_limit, offset: new_offset},
            socket.assigns.patch_url_type
          )
      )}

--- a/lib/oli_web/components/delivery/discussion_activity/discussion_activity.ex
+++ b/lib/oli_web/components/delivery/discussion_activity/discussion_activity.ex
@@ -13,7 +13,7 @@ defmodule OliWeb.Components.Delivery.DiscussionActivity do
 
   @default_params %{
     offset: 0,
-    limit: 10,
+    limit: 20,
     filter: :all
   }
 
@@ -103,6 +103,8 @@ defmodule OliWeb.Components.Delivery.DiscussionActivity do
               offset={@offset}
               limit={@limit}
               additional_table_class="border-0"
+              limit_change={JS.push("paged_table_limit_change", target: @myself)}
+              show_limit_change={true}
             />
           <% else %>
             <PagedTable.render
@@ -112,6 +114,8 @@ defmodule OliWeb.Components.Delivery.DiscussionActivity do
               offset={@offset}
               limit={@limit}
               additional_table_class="border-0"
+              limit_change={JS.push("paged_table_limit_change", target: @myself)}
+              show_limit_change={true}
             />
           <% end %>
         </div>
@@ -128,6 +132,24 @@ defmodule OliWeb.Components.Delivery.DiscussionActivity do
   @impl true
   def handle_event("paged_table_page_change", %{"offset" => offset}, socket) do
     push_with(socket, %{offset: offset})
+  end
+
+  @impl true
+  def handle_event(
+        "paged_table_limit_change",
+        params,
+        socket
+      ) do
+    new_limit = OliWeb.Common.Params.get_int_param(params, "limit", 20)
+
+    new_offset =
+      OliWeb.Common.PagingParams.calculate_new_offset(
+        socket.assigns.offset,
+        new_limit,
+        socket.assigns.count
+      )
+
+    push_with(socket, %{limit: new_limit, offset: new_offset})
   end
 
   @impl true

--- a/lib/oli_web/components/delivery/learning_objectives/learning_objectives.ex
+++ b/lib/oli_web/components/delivery/learning_objectives/learning_objectives.ex
@@ -9,7 +9,7 @@ defmodule OliWeb.Components.Delivery.LearningObjectives do
 
   @default_params %{
     offset: 0,
-    limit: 10,
+    limit: 20,
     container_id: nil,
     sort_order: :asc,
     sort_by: :objective,
@@ -122,6 +122,8 @@ defmodule OliWeb.Components.Delivery.LearningObjectives do
               additional_table_class="instructor_dashboard_table"
               show_bottom_paging={false}
               render_top_info={false}
+              limit_change={JS.push("paged_table_limit_change", target: @myself)}
+              show_limit_change={true}
             />
           </div>
         <% else %>
@@ -187,6 +189,31 @@ defmodule OliWeb.Components.Delivery.LearningObjectives do
          route_for(
            socket,
            %{limit: limit, offset: offset},
+           socket.assigns.patch_url_type
+         )
+     )}
+  end
+
+  def handle_event(
+        "paged_table_limit_change",
+        params,
+        %{assigns: %{params: current_params}} = socket
+      ) do
+    new_limit = Params.get_int_param(params, "limit", 20)
+
+    new_offset =
+      OliWeb.Common.PagingParams.calculate_new_offset(
+        current_params.offset,
+        new_limit,
+        socket.assigns.total_count
+      )
+
+    {:noreply,
+     push_patch(socket,
+       to:
+         route_for(
+           socket,
+           %{limit: new_limit, offset: new_offset},
            socket.assigns.patch_url_type
          )
      )}

--- a/lib/oli_web/components/delivery/progress/progress.ex
+++ b/lib/oli_web/components/delivery/progress/progress.ex
@@ -8,7 +8,7 @@ defmodule OliWeb.Components.Delivery.Progress do
 
   @default_params %{
     offset: 0,
-    limit: 10,
+    limit: 20,
     sort_order: :asc,
     sort_by: :title,
     text_search: nil
@@ -93,6 +93,8 @@ defmodule OliWeb.Components.Delivery.Progress do
             additional_table_class="instructor_dashboard_table"
             show_bottom_paging={false}
             render_top_info={false}
+            limit_change={JS.push("paged_table_limit_change", target: @myself)}
+            show_limit_change={true}
           />
         </div>
       <% else %>
@@ -143,6 +145,34 @@ defmodule OliWeb.Components.Delivery.Progress do
            socket.assigns.student_id,
            :progress,
            update_params(socket.assigns.params, %{limit: limit, offset: offset})
+         )
+     )}
+  end
+
+  def handle_event(
+        "paged_table_limit_change",
+        params,
+        %{assigns: %{params: current_params}} = socket
+      ) do
+    new_limit = Params.get_int_param(params, "limit", 20)
+
+    new_offset =
+      OliWeb.Common.PagingParams.calculate_new_offset(
+        current_params.offset,
+        new_limit,
+        socket.assigns.total_count
+      )
+
+    {:noreply,
+     push_patch(socket,
+       to:
+         Routes.live_path(
+           socket,
+           OliWeb.Delivery.StudentDashboard.StudentDashboardLive,
+           socket.assigns.section_slug,
+           socket.assigns.student_id,
+           :progress,
+           update_params(socket.assigns.params, %{limit: new_limit, offset: new_offset})
          )
      )}
   end

--- a/lib/oli_web/components/delivery/quiz_scores/quiz_scores.ex
+++ b/lib/oli_web/components/delivery/quiz_scores/quiz_scores.ex
@@ -11,7 +11,7 @@ defmodule OliWeb.Components.Delivery.QuizScores do
 
   @default_params %{
     offset: 0,
-    limit: 10,
+    limit: 20,
     sort_order: :asc,
     sort_by: :name,
     text_search: nil,
@@ -106,6 +106,8 @@ defmodule OliWeb.Components.Delivery.QuizScores do
             show_bottom_paging={false}
             sort={JS.push("paged_table_sort", target: @myself)}
             page_change={JS.push("paged_table_page_change", target: @myself)}
+            limit_change={JS.push("paged_table_limit_change", target: @myself)}
+            show_limit_change={true}
           />
         <% else %>
           <h6 class="text-center py-4">There are no quiz scores to show</h6>
@@ -214,6 +216,31 @@ defmodule OliWeb.Components.Delivery.QuizScores do
          route_for(
            socket,
            %{limit: limit, offset: offset},
+           socket.assigns.patch_url_type
+         )
+     )}
+  end
+
+  def handle_event(
+        "paged_table_limit_change",
+        params,
+        %{assigns: %{params: current_params}} = socket
+      ) do
+    new_limit = Params.get_int_param(params, "limit", 20)
+
+    new_offset =
+      OliWeb.Common.PagingParams.calculate_new_offset(
+        current_params.offset,
+        new_limit,
+        socket.assigns.total_count
+      )
+
+    {:noreply,
+     push_patch(socket,
+       to:
+         route_for(
+           socket,
+           %{limit: new_limit, offset: new_offset},
            socket.assigns.patch_url_type
          )
      )}

--- a/lib/oli_web/components/delivery/scored_activities/scored_activities.ex
+++ b/lib/oli_web/components/delivery/scored_activities/scored_activities.ex
@@ -43,7 +43,7 @@ defmodule OliWeb.Components.Delivery.ScoredActivities do
 
   @default_params %{
     offset: 0,
-    limit: 10,
+    limit: 20,
     sort_order: :asc,
     sort_by: :title,
     text_search: nil
@@ -243,6 +243,8 @@ defmodule OliWeb.Components.Delivery.ScoredActivities do
           additional_table_class="instructor_dashboard_table"
           allow_selection={!is_nil(@current_assessment)}
           show_bottom_paging={false}
+          limit_change={JS.push("paged_table_limit_change", target: @myself)}
+          show_limit_change={true}
         />
       </div>
       <div :if={@current_assessment != nil and @activities != []} class="mt-9">
@@ -348,6 +350,30 @@ defmodule OliWeb.Components.Delivery.ScoredActivities do
          route_to(
            socket,
            update_params(socket.assigns.params, %{limit: limit, offset: offset})
+         )
+     )}
+  end
+
+  def handle_event(
+        "paged_table_limit_change",
+        params,
+        %{assigns: %{params: current_params}} = socket
+      ) do
+    new_limit = Params.get_int_param(params, "limit", 20)
+
+    new_offset =
+      OliWeb.Common.PagingParams.calculate_new_offset(
+        current_params.offset,
+        new_limit,
+        socket.assigns.total_count
+      )
+
+    {:noreply,
+     push_patch(socket,
+       to:
+         route_to(
+           socket,
+           update_params(socket.assigns.params, %{limit: new_limit, offset: new_offset})
          )
      )}
   end

--- a/lib/oli_web/components/delivery/students/students.ex
+++ b/lib/oli_web/components/delivery/students/students.ex
@@ -9,7 +9,7 @@ defmodule OliWeb.Components.Delivery.Students do
 
   @default_params %{
     offset: 0,
-    limit: 25,
+    limit: 20,
     container_id: nil,
     section_slug: nil,
     page_id: nil,
@@ -237,6 +237,8 @@ defmodule OliWeb.Components.Delivery.Students do
           additional_table_class="instructor_dashboard_table"
           sort={JS.push("paged_table_sort", target: @myself)}
           page_change={JS.push("paged_table_page_change", target: @myself)}
+          limit_change={JS.push("paged_table_limit_change", target: @myself)}
+          show_limit_change={true}
         />
       </div>
     </div>
@@ -269,6 +271,34 @@ defmodule OliWeb.Components.Delivery.Students do
            socket.assigns.view,
            socket.assigns.tab_name,
            update_params(socket.assigns.params, %{limit: limit, offset: offset})
+         )
+     )}
+  end
+
+  def handle_event(
+        "paged_table_limit_change",
+        params,
+        %{assigns: %{params: current_params}} = socket
+      ) do
+    new_limit = Params.get_int_param(params, "limit", 20)
+
+    new_offset =
+      OliWeb.Common.PagingParams.calculate_new_offset(
+        current_params.offset,
+        new_limit,
+        socket.assigns.total_count
+      )
+
+    {:noreply,
+     push_patch(socket,
+       to:
+         Routes.live_path(
+           socket,
+           OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive,
+           socket.assigns.section_slug,
+           socket.assigns.view,
+           socket.assigns.tab_name,
+           update_params(socket.assigns.params, %{limit: new_limit, offset: new_offset})
          )
      )}
   end

--- a/lib/oli_web/live/common/paged_table.ex
+++ b/lib/oli_web/live/common/paged_table.ex
@@ -12,10 +12,12 @@ defmodule OliWeb.Common.PagedTable do
   attr :sort, :string, default: "paged_table_sort"
   attr :page_change, :string, default: "paged_table_page_change"
   attr :selection_change, :string, default: "paged_table_selection_change"
+  attr :limit_change, :string, default: "paged_table_limit_change"
   attr :show_bottom_paging, :boolean, default: true
   attr :show_top_paging, :boolean, default: true
   attr :additional_table_class, :string, default: ""
   attr :render_top_info, :boolean, default: true
+  attr :show_limit_change, :boolean, default: false
 
   def render(assigns) do
     ~H"""
@@ -24,7 +26,8 @@ defmodule OliWeb.Common.PagedTable do
         <strong>Results filtered on &quot;<%= @filter %>&quot;</strong>
       <% end %>
 
-      <%= if(@total_count > 0 and @total_count > @limit) do %>
+      <%= if @total_count > 0 do %>
+        <div :if={@total_count <= @limit and @render_top_info} class="px-5 py-2">Showing all results (<%= @total_count %> total)</div>
         <%= if @show_top_paging do %>
           <Paging.render
             id="header_paging"
@@ -32,6 +35,8 @@ defmodule OliWeb.Common.PagedTable do
             offset={@offset}
             limit={@limit}
             click={@page_change}
+            limit_change={@limit_change}
+            show_limit_change={@show_limit_change}
           />
         <% end %>
         <%= render_table(%{
@@ -48,23 +53,11 @@ defmodule OliWeb.Common.PagedTable do
             offset={@offset}
             limit={@limit}
             click={@page_change}
+            limit_change={@limit_change}
           />
         <% end %>
       <% else %>
-        <%= if @total_count > 0 do %>
-          <%= if @render_top_info do %>
-            <div class="px-5 py-2">Showing all results (<%= @total_count %> total)</div>
-          <% end %>
-          <%= render_table(%{
-            allow_selection: @allow_selection,
-            table_model: @table_model,
-            sort: @sort,
-            selection_change: @selection_change,
-            additional_table_class: @additional_table_class
-          }) %>
-        <% else %>
-          <p class="px-5 py-2">None exist</p>
-        <% end %>
+        <p class="px-5 py-2">None exist</p>
       <% end %>
     </div>
     """
@@ -94,6 +87,29 @@ defmodule OliWeb.Common.PagedTable do
 
   def delegate_handle_event("paged_table_page_change", %{"offset" => offset}, socket, patch_fn, _) do
     patch_fn.(socket, %{offset: offset})
+  end
+
+  def delegate_handle_event(
+        "paged_table_limit_change",
+        params,
+        %{assigns: %{params: current_params}} = socket,
+        patch_fn,
+        _
+      ) do
+    new_limit = OliWeb.Common.Params.get_int_param(params, "limit", 20)
+
+    new_offset =
+      if socket.assigns.total_count < new_limit do
+        0
+      else
+        OliWeb.Common.PagingParams.calculate_new_offset(
+          current_params.offset,
+          new_limit,
+          socket.assigns.total_count
+        )
+      end
+
+    patch_fn.(socket, %{limit: new_limit, offset: new_offset})
   end
 
   def delegate_handle_event(

--- a/lib/oli_web/live/common/paging.ex
+++ b/lib/oli_web/live/common/paging.ex
@@ -45,51 +45,54 @@ defmodule OliWeb.Common.Paging do
       <nav :if={@show_pagination} aria-label="Paging">
         <ul class="pagination">
           <li class={"page-item #{if @params.current_page_index == 0, do: "disabled"}"}>
-            <a class="page-link" phx-click={@click} phx-value-offset={0} phx-value-limit={@limit}>
+            <button class="page-link" phx-click={@click} phx-value-offset={0} phx-value-limit={@limit} disabled={@params.current_page_index == 0}>
               <i class="fas fa-angle-double-left"></i>
-            </a>
+            </button>
           </li>
           <li class={"page-item #{if @params.current_page_index == 0, do: "disabled"}"}>
-            <a
+            <button
               class="page-link"
               phx-click={@click}
               phx-value-offset={@offset - @limit}
               phx-value-limit={@limit}
+              disabled={@params.current_page_index == 0}
             >
               <i class="fas fa-angle-left"></i>
-            </a>
+            </button>
           </li>
           <%= for i <- 0..(@params.rendered_pages_count- 1) do %>
             <li class={"page-item #{if @params.start_page_index + i == @params.current_page_index, do: "active"}"}>
-              <a
+              <button
                 class="page-link"
                 phx-click={@click}
                 phx-value-offset={(@params.start_page_index + i) * @limit}
                 phx-value-limit={@limit}
               >
                 <%= i + 1 + @params.start_page_index %>
-              </a>
+              </button>
             </li>
           <% end %>
           <li class={"page-item #{if @params.current_page_index == @params.last_page_index, do: "disabled"}"}>
-            <a
+            <button
               class="page-link"
               phx-click={@click}
               phx-value-offset={@offset + @limit}
               phx-value-limit={@limit}
+              disabled={@params.current_page_index == @params.last_page_index}
             >
               <i class="fas fa-angle-right"></i>
-            </a>
+            </button>
           </li>
           <li class={"page-item #{if @params.current_page_index == @params.last_page_index, do: "disabled"}"}>
-            <a
+            <button
               class="page-link"
               phx-click={@click}
               phx-value-offset={@params.last_page_index * @limit}
               phx-value-limit={@limit}
+              disabled={@params.current_page_index == @params.last_page_index}
             >
               <i class="fas fa-angle-double-right"></i>
-            </a>
+            </button>
           </li>
         </ul>
       </nav>

--- a/lib/oli_web/live/common/paging.ex
+++ b/lib/oli_web/live/common/paging.ex
@@ -2,22 +2,47 @@ defmodule OliWeb.Common.Paging do
   use Phoenix.Component
   alias OliWeb.Common.PagingParams
 
+  @page_sizes [10, 20, 50, 100]
+
   attr :total_count, :integer, required: true
   attr :click, :string, required: true
+  attr :limit_change, :string, default: "paged_table_limit_change"
   attr :offset, :integer, required: true
   attr :limit, :integer, required: true
   attr :id, :string, required: true
+  attr :page_sizes, :list, default: @page_sizes
+  attr :show_limit_change, :boolean, default: false
 
   def render(assigns) do
     params = PagingParams.calculate(assigns.total_count, assigns.offset, assigns.limit, 5)
 
-    assigns = assign(assigns, :params, params)
+    assigns =
+      assigns
+      |> assign(:params, params)
+      |> assign(:show_pagination, assigns.total_count > assigns.limit)
 
     ~H"""
     <div id={@id} class="d-flex justify-content-between items-center px-5 py-2">
-      <div><%= @params.label %></div>
+      <div :if={@show_pagination} ><%= @params.label %></div>
       <div class="flex-1"></div>
-      <nav aria-label="Paging">
+      <.form id={"#{@id}_page_size_form"} for={%{}} phx-change={@limit_change}>
+        <div :if={@show_limit_change} class="inline-flex flex-col gap-1 mr-2">
+          <small class="torus-small uppercase">
+            Page size
+          </small>
+          <select class="torus-select" name="limit">
+            <option
+              :for={page_size <- @page_sizes}
+              selected={@limit == page_size}
+              value={page_size}
+            >
+              <%= page_size %>
+            </option>
+          </select>
+        </div>
+      </.form>
+
+      <nav :if={@show_pagination} aria-label="Paging">
         <ul class="pagination">
           <li class={"page-item #{if @params.current_page_index == 0, do: "disabled"}"}>
             <a class="page-link" phx-click={@click} phx-value-offset={0} phx-value-limit={@limit}>

--- a/lib/oli_web/live/common/paging_params.ex
+++ b/lib/oli_web/live/common/paging_params.ex
@@ -57,4 +57,45 @@ defmodule OliWeb.Common.PagingParams do
       label: label
     }
   end
+
+  @doc """
+  Calculates a new offset based on a given old offset, new limit, and the total count of items.
+
+  The function is designed to ensure a consistent user experience during pagination adjustments:
+
+  1. If the total count of items is less than the new limit, it will return an offset of 0.
+  2. If changing the page size (`limit`), the function adjusts the `offset` to make sure
+     that the current view still displays at least one of the items that were visible
+     with the previous limit.
+  3. The function also ensures that the resulting offset, combined with the new limit,
+     does not exceed the total count of items.
+
+  ## Examples
+
+      iex> calculate_new_offset(4, 1, 8)
+      4
+      iex> calculate_new_offset(4, 10, 8)
+      0
+
+  ## Parameters
+
+    - `old_offset`: The original offset (usually representing the starting point of the current page).
+    - `new_limit`: The new desired limit (or page size).
+    - `total_count`: The total number of items available for pagination.
+
+  ## Returns
+
+    - The new offset that is consistent with the current view and remains within the range of total items.
+  """
+  def calculate_new_offset(_old_offset, new_limit, total_count)
+      when new_limit > total_count,
+      do: 0
+
+  def calculate_new_offset(old_offset, new_limit, total_count) do
+    # Calculate new offset
+    new_offset = old_offset - rem(old_offset, new_limit)
+
+    # Ensure the new offset is within range
+    if new_offset > total_count - new_limit, do: total_count - new_limit, else: new_offset
+  end
 end

--- a/test/oli_web/live/admin_live_test.exs
+++ b/test/oli_web/live/admin_live_test.exs
@@ -317,7 +317,7 @@ defmodule OliWeb.AdminLiveTest do
                last_user.given_name
 
       view
-      |> element("#header_paging a[phx-click=\"paged_table_page_change\"]", "2")
+      |> element("#header_paging button[phx-click=\"paged_table_page_change\"]", "2")
       |> render_click()
 
       refute view
@@ -576,7 +576,7 @@ defmodule OliWeb.AdminLiveTest do
       assert render(view) =~ first_author.given_name
 
       view
-      |> element("#header_paging a[phx-click=\"paged_table_page_change\"]", "2")
+      |> element("#header_paging button[phx-click=\"paged_table_page_change\"]", "2")
       |> render_click()
 
       refute render(view) =~ first_author.given_name

--- a/test/oli_web/live/browse_updates_live_test.exs
+++ b/test/oli_web/live/browse_updates_live_test.exs
@@ -123,7 +123,7 @@ defmodule OliWeb.BrowseUpdatesLiveTest do
       refute has_element?(view, "##{old_update.id}")
 
       view
-      |> element("#header_paging a[phx-click=\"paged_table_page_change\"]", "2")
+      |> element("#header_paging button[phx-click=\"paged_table_page_change\"]", "2")
       |> render_click()
 
       refute has_element?(view, "##{first_u.id}")

--- a/test/oli_web/live/community_live_test.exs
+++ b/test/oli_web/live/community_live_test.exs
@@ -175,7 +175,7 @@ defmodule OliWeb.CommunityLiveTest do
       refute has_element?(view, "##{last_c.id}")
 
       view
-      |> element("a[phx-click=\"page_change\"]", "2")
+      |> element("button[phx-click=\"page_change\"]", "2")
       |> render_click()
 
       refute has_element?(view, "##{first_c.id}")
@@ -1010,7 +1010,7 @@ defmodule OliWeb.CommunityLiveTest do
       refute has_element?(view, "##{last_cv.id}")
 
       view
-      |> element("a[phx-click=\"page_change\"]", "2")
+      |> element("button[phx-click=\"page_change\"]", "2")
       |> render_click()
 
       refute has_element?(view, "##{first_cv.id}")
@@ -1166,7 +1166,7 @@ defmodule OliWeb.CommunityLiveTest do
                last_p.title
 
       view
-      |> element("a[phx-click=\"page_change\"]", "2")
+      |> element("button[phx-click=\"page_change\"]", "2")
       |> render_click()
 
       assert view
@@ -1332,7 +1332,7 @@ defmodule OliWeb.CommunityLiveTest do
                last_cma.user.name
 
       view
-      |> element("a[phx-click=\"page_change\"]", "2")
+      |> element("button[phx-click=\"page_change\"]", "2")
       |> render_click()
 
       refute view

--- a/test/oli_web/live/delivery/instructor_dashboard/reports/content_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/reports/content_tab_test.exs
@@ -205,7 +205,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.ContentTabTest do
         view
         |> render()
         |> Floki.parse_fragment!()
-        |> Floki.find(~s{li.page-item.active a})
+        |> Floki.find(~s{li.page-item.active button})
         |> Enum.map(fn a_tag -> Floki.text(a_tag) end)
 
       assert top_selected_page == bottom_selected_page and bottom_selected_page =~ "2"

--- a/test/oli_web/live/delivery/instructor_dashboard/reports/content_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/reports/content_tab_test.exs
@@ -198,7 +198,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.ContentTabTest do
       refute render(view) =~ "Module 1"
       refute render(view) =~ "Module 2"
 
-      assert element(view, "#header_paging div:first-child") |> render() =~
+      assert element(view, "#header_paging > div:first-child") |> render() =~
                "Showing result 3 - 3 of 3 total"
 
       [top_selected_page, bottom_selected_page] =

--- a/test/oli_web/live/delivery/instructor_dashboard/reports/learning_objectives_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/reports/learning_objectives_tab_test.exs
@@ -302,4 +302,124 @@ defmodule OliWeb.Delivery.InstructorDashboard.LearningObjectivesTabTest do
       assert has_element?(view, ".torus-select[disabled]")
     end
   end
+
+  describe "page size change" do
+    setup [:instructor_conn, :create_full_project_with_objectives]
+
+    test "lists table elements according to the default page size", %{
+      conn: conn,
+      instructor: instructor,
+      section: section,
+      revisions: revisions
+    } do
+      # Setup section data
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+      Sections.rebuild_contained_objectives(section)
+
+      {:ok, view, _html} = live(conn, live_view_learning_objectives_route(section.slug))
+
+      assert has_element?(view, "span", "#{revisions.obj_revision_c.title}")
+      assert has_element?(view, "div", "#{revisions.obj_revision_c1.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_d.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_e.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_f.title}")
+
+      # It does not display pagination options
+      refute has_element?(view, "nav[aria-label=\"Paging\"]")
+
+      # It displays page size dropdown
+      assert has_element?(view, "form select.torus-select option[selected]", "20")
+    end
+
+    test "updates page size and list expected elements", %{
+      conn: conn,
+      section: section,
+      instructor: instructor,
+      revisions: revisions
+    } do
+      # Setup section data
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+      Sections.rebuild_contained_objectives(section)
+
+      {:ok, view, _html} = live(conn, live_view_learning_objectives_route(section.slug))
+
+      assert has_element?(view, "span", "#{revisions.obj_revision_c.title}")
+      assert has_element?(view, "div", "#{revisions.obj_revision_c1.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_d.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_e.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_f.title}")
+
+      # Change page size from default (20) to 2
+      view
+      |> element("#header_paging_page_size_form")
+      |> render_change(%{limit: "2"})
+
+      # Page 1
+      assert has_element?(view, "span", "#{revisions.obj_revision_c.title}")
+      assert has_element?(view, "div", "#{revisions.obj_revision_c1.title}")
+      # Page 2 and 3
+      refute has_element?(view, "span", "#{revisions.obj_revision_d.title}")
+      refute has_element?(view, "span", "#{revisions.obj_revision_e.title}")
+      refute has_element?(view, "span", "#{revisions.obj_revision_f.title}")
+    end
+
+    test "keeps showing the same elements when changing the page size", %{
+      conn: conn,
+      section: section,
+      instructor: instructor,
+      revisions: revisions
+    } do
+      # Setup section data
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+      Sections.rebuild_contained_objectives(section)
+
+      # Starts in page 2
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_learning_objectives_route(section.slug, %{
+            limit: 2,
+            offset: 2
+          })
+        )
+
+      # Page 1
+      refute has_element?(view, "span", "#{revisions.obj_revision_c.title}")
+      refute has_element?(view, "div", "#{revisions.obj_revision_c1.title}")
+      # Page 2
+      assert has_element?(view, "span", "#{revisions.obj_revision_d.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_e.title}")
+      # Page 3
+      refute has_element?(view, "span", "#{revisions.obj_revision_f.title}")
+
+      # Change page size from 2 to 1
+      view
+      |> element("#header_paging_page_size_form")
+      |> render_change(%{limit: "1"})
+
+      # Page 1
+      refute has_element?(view, "span", "#{revisions.obj_revision_c.title}")
+      # Page 2
+      refute has_element?(view, "div", "#{revisions.obj_revision_c1.title}")
+      # Page 3. It keeps showing the same element.
+      assert has_element?(view, "span", "#{revisions.obj_revision_d.title}")
+      # Page 4
+      refute has_element?(view, "span", "#{revisions.obj_revision_e.title}")
+      # Page 5
+      refute has_element?(view, "span", "#{revisions.obj_revision_f.title}")
+
+      # Change page size from 1 to 3
+      view
+      |> element("#header_paging_page_size_form")
+      |> render_change(%{limit: "3"})
+
+      # Page 1. Still showing the same element.
+      assert has_element?(view, "span", "#{revisions.obj_revision_c.title}")
+      assert has_element?(view, "div", "#{revisions.obj_revision_c1.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_d.title}")
+      # Page 2
+      refute has_element?(view, "span", "#{revisions.obj_revision_e.title}")
+      refute has_element?(view, "span", "#{revisions.obj_revision_f.title}")
+    end
+  end
 end

--- a/test/oli_web/live/delivery/instructor_dashboard/scored_activities/scored_activities_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/scored_activities/scored_activities_tab_test.exs
@@ -1007,7 +1007,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.ScoredActivitiesTabTest do
         {_ref, {:patch, _topic, %{kind: :push, to: url_with_params}}} ->
           assert String.starts_with?(url_with_params, url)
           assert url_with_params =~ "assessment_table_params[offset]=0"
-          assert url_with_params =~ "assessment_table_params[limit]=10"
+          assert url_with_params =~ "assessment_table_params[limit]=20"
           assert url_with_params =~ "assessment_table_params[sort_by]=title"
           assert url_with_params =~ "assessment_table_params[assessment_id]="
           assert url_with_params =~ "assessment_table_params[text_search]="
@@ -1842,6 +1842,79 @@ defmodule OliWeb.Delivery.InstructorDashboard.ScoredActivitiesTabTest do
 
       assert view
              |> has_element?("#copy_emails_button", "Copy email addresses")
+    end
+  end
+
+  describe "page size change" do
+    setup [:instructor_conn, :create_project]
+
+    test "lists table elements according to the default page size", %{
+      conn: conn,
+      section: section
+    } do
+      {:ok, view, _html} = live(conn, live_view_scored_activities_route(section.slug))
+
+      [a0, a1, a2, a3, a4] = table_as_list_of_maps(view, :assessments)
+
+      assert a0.title == "Orphaned Page"
+      assert a1.title == "Module 1: IntroductionPage 1"
+      assert a2.title == "Module 1: IntroductionPage 2"
+      assert a3.title == "Module 2: BasicsPage 3"
+      assert a4.title == "Module 2: BasicsPage 4"
+
+      # It does not display pagination options
+      refute has_element?(view, "nav[aria-label=\"Paging\"]")
+
+      # It displays page size dropdown
+      assert has_element?(view, "form select.torus-select option[selected]", "20")
+    end
+
+    test "updates page size and list expected elements", %{
+      conn: conn,
+      section: section
+    } do
+      {:ok, view, _html} = live(conn, live_view_scored_activities_route(section.slug))
+
+      # Change page size from default (20) to 2
+      view
+      |> element("#header_paging_page_size_form")
+      |> render_change(%{limit: "2"})
+
+      [a0, a1] = table_as_list_of_maps(view, :assessments)
+
+      # Page 1
+      assert a0.title == "Orphaned Page"
+      assert a1.title == "Module 1: IntroductionPage 1"
+    end
+
+    test "keeps showing the same elements when changing the page size", %{
+      conn: conn,
+      section: section
+    } do
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_scored_activities_route(section.slug, %{
+            limit: 2,
+            offset: 2
+          })
+        )
+
+      [a2, a3] = table_as_list_of_maps(view, :assessments)
+
+      # Page 2
+      assert a2.title == "Module 1: IntroductionPage 2"
+      assert a3.title == "Module 2: BasicsPage 3"
+
+      # Change page size from 2 to 1
+      view
+      |> element("#header_paging_page_size_form")
+      |> render_change(%{limit: "1"})
+
+      [a2] = table_as_list_of_maps(view, :assessments)
+
+      # Page 3. It keeps showing the same element.
+      assert a2.title == "Module 1: IntroductionPage 2"
     end
   end
 end

--- a/test/oli_web/live/delivery/student_dashboard/components/content_tab_test.exs
+++ b/test/oli_web/live/delivery/student_dashboard/components/content_tab_test.exs
@@ -157,7 +157,7 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.ContentTabTest do
         view
         |> render()
         |> Floki.parse_fragment!()
-        |> Floki.find(~s{li.page-item.active a})
+        |> Floki.find(~s{li.page-item.active button})
         |> Enum.map(fn a_tag -> Floki.text(a_tag) end)
 
       assert top_selected_page == bottom_selected_page and bottom_selected_page =~ "2"

--- a/test/oli_web/live/delivery/student_dashboard/components/content_tab_test.exs
+++ b/test/oli_web/live/delivery/student_dashboard/components/content_tab_test.exs
@@ -150,7 +150,7 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.ContentTabTest do
       refute render(view) =~ "Module 1"
       refute render(view) =~ "Module 2"
 
-      assert element(view, "#header_paging div:first-child") |> render() =~
+      assert element(view, "#header_paging > div:first-child") |> render() =~
                "Showing result 3 - 3 of 3 total"
 
       [top_selected_page, bottom_selected_page] =

--- a/test/oli_web/live/delivery/student_dashboard/components/quizz_scores_tab_test.exs
+++ b/test/oli_web/live/delivery/student_dashboard/components/quizz_scores_tab_test.exs
@@ -536,4 +536,194 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.QuizzScoresTabTest do
              )
     end
   end
+
+  describe "page size change" do
+    setup [:instructor_conn, :section_with_gating_conditions]
+
+    test "lists table elements according to the default page size", %{
+      conn: conn,
+      instructor: instructor,
+      section: section,
+      student_with_gating_condition: student_with_gating_condition,
+      graded_page_1: graded_page_1,
+      graded_page_2: graded_page_2,
+      graded_page_3: graded_page_3,
+      graded_page_4: graded_page_4,
+      graded_page_5: graded_page_5,
+      graded_page_6: graded_page_6
+    } do
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_students_dashboard_route(
+            section.slug,
+            student_with_gating_condition.id,
+            :quizz_scores
+          )
+        )
+
+      assert has_element?(
+               view,
+               "div",
+               "#{graded_page_1.title}"
+             )
+
+      assert has_element?(
+               view,
+               "div",
+               "#{graded_page_2.title}"
+             )
+
+      assert has_element?(
+               view,
+               "div",
+               "#{graded_page_3.title}"
+             )
+
+      assert has_element?(
+               view,
+               "div",
+               "#{graded_page_4.title}"
+             )
+
+      assert has_element?(
+               view,
+               "div",
+               "#{graded_page_5.title}"
+             )
+
+      assert has_element?(
+               view,
+               "div",
+               "#{graded_page_6.title}"
+             )
+
+      # It does not display pagination options
+      refute has_element?(view, "nav[aria-label=\"Paging\"]")
+
+      # It displays page size dropdown
+      assert has_element?(view, "form select.torus-select option[selected]", "20")
+    end
+
+    test "updates page size and list expected elements", %{
+      conn: conn,
+      instructor: instructor,
+      section: section,
+      student_with_gating_condition: student_with_gating_condition,
+      graded_page_1: graded_page_1,
+      graded_page_2: graded_page_2,
+      graded_page_3: graded_page_3,
+      graded_page_4: graded_page_4,
+      graded_page_5: graded_page_5,
+      graded_page_6: graded_page_6
+    } do
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_students_dashboard_route(
+            section.slug,
+            student_with_gating_condition.id,
+            :quizz_scores
+          )
+        )
+
+      # Change page size from default (20) to 2
+      view
+      |> element("#header_paging_page_size_form")
+      |> render_change(%{limit: "2"})
+
+      # Page 1
+      assert has_element?(
+               view,
+               "div",
+               "#{graded_page_1.title}"
+             )
+
+      assert has_element?(
+               view,
+               "div",
+               "#{graded_page_2.title}"
+             )
+
+      # Page 2
+      refute has_element?(
+               view,
+               "div",
+               "#{graded_page_3.title}"
+             )
+
+      refute has_element?(
+               view,
+               "div",
+               "#{graded_page_4.title}"
+             )
+
+      # Page 3
+      refute has_element?(
+               view,
+               "div",
+               "#{graded_page_5.title}"
+             )
+
+      refute has_element?(
+               view,
+               "div",
+               "#{graded_page_6.title}"
+             )
+    end
+
+    test "keeps showing the same elements when changing the page size", %{
+      conn: conn,
+      instructor: instructor,
+      section: section,
+      student_with_gating_condition: student_with_gating_condition,
+      graded_page_3: graded_page_3,
+      graded_page_4: graded_page_4
+    } do
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_students_dashboard_route(
+            section.slug,
+            student_with_gating_condition.id,
+            :quizz_scores,
+            %{
+              limit: 2,
+              offset: 2
+            }
+          )
+        )
+
+      # Page 2
+      assert has_element?(
+               view,
+               "div",
+               "#{graded_page_3.title}"
+             )
+
+      assert has_element?(
+               view,
+               "div",
+               "#{graded_page_4.title}"
+             )
+
+      # Change page size from 2 to 1
+      view
+      |> element("#header_paging_page_size_form")
+      |> render_change(%{limit: "1"})
+
+      # Page 3. It keeps showing the same element.
+      assert has_element?(
+               view,
+               "div",
+               "#{graded_page_3.title}"
+             )
+    end
+  end
 end

--- a/test/oli_web/live/discounts_live_test.exs
+++ b/test/oli_web/live/discounts_live_test.exs
@@ -182,7 +182,7 @@ defmodule OliWeb.DiscountsLiveTest do
       refute has_element?(view, "##{last_discount.id}")
 
       view
-      |> element("a[phx-click=\"page_change\"]", "2")
+      |> element("button[phx-click=\"page_change\"]", "2")
       |> render_click()
 
       refute has_element?(view, "##{first_discount.id}")

--- a/test/oli_web/live/failed_grade_sync_live_test.exs
+++ b/test/oli_web/live/failed_grade_sync_live_test.exs
@@ -188,7 +188,7 @@ defmodule OliWeb.FailedGradeSyncLiveTest do
                "AAAA Name"
 
       view
-      |> element("a[phx-click=\"page_change\"]", "2")
+      |> element("button[phx-click=\"page_change\"]", "2")
       |> render_click()
 
       refute view

--- a/test/oli_web/live/new_course/select_source_test.exs
+++ b/test/oli_web/live/new_course/select_source_test.exs
@@ -122,7 +122,7 @@ defmodule OliWeb.NewCourse.SelectSourceTest do
       refute has_element?(view, "div", last_s.title)
 
       view
-      |> element(".page-item a", "2")
+      |> element(".page-item button", "2")
       |> render_click()
 
       refute has_element?(view, "div", first_s.title)
@@ -263,7 +263,7 @@ defmodule OliWeb.NewCourse.SelectSourceTest do
       refute has_element?(view, "a[phx-value-id=\"product:#{last_s.id}\"]")
 
       view
-      |> element(".page-item a", "2")
+      |> element(".page-item button", "2")
       |> render_click()
 
       refute has_element?(view, "a[phx-value-id=\"publication:#{publication_id}\"]")
@@ -407,7 +407,7 @@ defmodule OliWeb.NewCourse.SelectSourceTest do
       refute has_element?(view, "a[phx-value-id=\"product:#{last_s.id}\"]")
 
       view
-      |> element(".page-item a", "2")
+      |> element(".page-item button", "2")
       |> render_click()
 
       refute has_element?(view, "a[phx-value-id=\"publication:#{publication_id}\"]")

--- a/test/oli_web/live/objectives_live_test.exs
+++ b/test/oli_web/live/objectives_live_test.exs
@@ -225,7 +225,7 @@ defmodule OliWeb.ObjectivesLiveTest do
 
       view
       |> element(
-        "#header_paging > nav > ul > li:nth-child(4) > a",
+        "#header_paging > nav > ul > li:nth-child(4) > button",
         "2"
       )
       |> render_click()

--- a/test/oli_web/live/projects_live_test.exs
+++ b/test/oli_web/live/projects_live_test.exs
@@ -90,7 +90,7 @@ defmodule OliWeb.Projects.ProjectsLiveTest do
       refute has_element?(view, "##{last_p.id}")
 
       view
-      |> element("#header_paging a[phx-click=\"paged_table_page_change\"]", "2")
+      |> element("#header_paging button[phx-click=\"paged_table_page_change\"]", "2")
       |> render_click()
 
       refute has_element?(view, "##{first_p.id}")
@@ -182,7 +182,7 @@ defmodule OliWeb.Projects.ProjectsLiveTest do
       refute has_element?(view, "##{last_p.id}")
 
       view
-      |> element("#header_paging a[phx-click=\"paged_table_page_change\"]", "2")
+      |> element("#header_paging button[phx-click=\"paged_table_page_change\"]", "2")
       |> render_click()
 
       refute has_element?(view, "##{first_p.id}")

--- a/test/oli_web/live/publish_live_test.exs
+++ b/test/oli_web/live/publish_live_test.exs
@@ -416,7 +416,7 @@ defmodule OliWeb.PublishLiveTest do
              |> render() =~ last_section.title
 
       view
-      |> element("a[phx-click=\"page_change\"]", "2")
+      |> element("button[phx-click=\"page_change\"]", "2")
       |> render_click()
 
       assert view

--- a/test/oli_web/live/publisher_live_test.exs
+++ b/test/oli_web/live/publisher_live_test.exs
@@ -143,7 +143,7 @@ defmodule OliWeb.PublisherLiveTest do
       refute has_element?(view, "##{last_p.id}")
 
       view
-      |> element("a[phx-click=\"page_change\"]", "2")
+      |> element("button[phx-click=\"page_change\"]", "2")
       |> render_click()
 
       refute has_element?(view, "##{first_p.id}")

--- a/test/oli_web/live/remix_section_test.exs
+++ b/test/oli_web/live/remix_section_test.exs
@@ -562,7 +562,7 @@ defmodule OliWeb.RemixSectionLiveTest do
       refute has_element?(view, "button", "Project 5")
 
       view
-      |> element("a[phx-click=\"HierarchyPicker.publications_page_change\"]", "2")
+      |> element("button[phx-click=\"HierarchyPicker.publications_page_change\"]", "2")
       |> render_click()
 
       assert has_element?(view, "button", "Project 5")

--- a/test/oli_web/live/sections/admin_index_live_test.exs
+++ b/test/oli_web/live/sections/admin_index_live_test.exs
@@ -257,7 +257,7 @@ defmodule OliWeb.Sections.AdminIndexLiveTest do
       refute has_element?(view, "td", last_s.title)
 
       view
-      |> element("#header_paging a[phx-click=\"paged_table_page_change\"]", "2")
+      |> element("#header_paging button[phx-click=\"paged_table_page_change\"]", "2")
       |> render_click()
 
       refute has_element?(view, "td", first_s.title)


### PR DESCRIPTION
[MER-2644](https://eliterate.atlassian.net/browse/MER-2644)

This PR enables changing a table page size in all the Instructor Dashboard tables. By default, the page size is 20.
When the user is on a specific page and updates the page size, the offset is recalculated so that the user still sees the same table elements.
It also fixes a bug in the pagination component that allows moving to infinite (even negative) pages.


The page size options in the videos below are not the right ones. They were updated for testing purposes, but they should be 10, 20, 50, and 100.

**Tables with new page size dropdown:**

https://github.com/Simon-Initiative/oli-torus/assets/26532202/120998e2-8d6f-4aa9-821a-87abd86292fb



**Pagination before the bugfix:**

https://github.com/Simon-Initiative/oli-torus/assets/26532202/4847e1b7-ddef-487d-8587-2f0b9e74b81d


[MER-2644]: https://eliterate.atlassian.net/browse/MER-2644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ