### PR TITLE
[BUG FIX] [MER-2633] Duplicate Quiz X results in a stuck attempt so student cannot start another attempt

### DIFF
--- a/lib/oli/delivery/attempts/core.ex
+++ b/lib/oli/delivery/attempts/core.ex
@@ -636,29 +636,6 @@ defmodule Oli.Delivery.Attempts.Core do
   end
 
   @doc """
-  Retrieves all resource attempts for a given resource id, section slug and user id.
-  """
-  def get_all_resource_attempts(resource_id, section_slug, user_id) do
-    Repo.all(
-      ResourceAttempt
-      |> join(:left, [ra1], a in ResourceAccess, on: a.id == ra1.resource_access_id)
-      |> join(:left, [_, a], s in Section, on: a.section_id == s.id)
-      |> join(:left, [ra1, a, _], ra2 in ResourceAttempt,
-        on:
-          a.id == ra2.resource_access_id and ra1.id < ra2.id and
-            ra1.resource_access_id == ra2.resource_access_id
-      )
-      |> join(:left, [ra1, _, _, _], r in Revision, on: ra1.revision_id == r.id)
-      |> where(
-        [ra1, a, s, ra2, _],
-        a.user_id == ^user_id and s.slug == ^section_slug and s.status == :active and
-          a.resource_id == ^resource_id
-      )
-      |> preload(:revision)
-    )
-  end
-
-  @doc """
   Retrieves the resource access record and all (if any) attempts related to it
   in a two element tuple of the form:
 

--- a/lib/oli/delivery/attempts/core/resource_attempt.ex
+++ b/lib/oli/delivery/attempts/core/resource_attempt.ex
@@ -6,7 +6,10 @@ defmodule Oli.Delivery.Attempts.Core.ResourceAttempt do
     field(:attempt_guid, :string)
     field(:attempt_number, :integer)
 
-    field(:lifecycle_state, Ecto.Enum, values: [:active, :submitted, :evaluated], default: :active)
+    field(:lifecycle_state, Ecto.Enum,
+      values: [:active, :submitted, :evaluated],
+      default: :active
+    )
 
     field(:date_evaluated, :utc_datetime)
     field(:date_submitted, :utc_datetime)

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -1102,12 +1102,12 @@ defmodule OliWeb.PageDeliveryController do
     end
   end
 
-  defp do_start_attempt(conn, section, user, revision, effective_settings) do
+  def do_start_attempt(conn, section, user, revision, effective_settings) do
     datashop_session_id = Plug.Conn.get_session(conn, :datashop_session_id)
     activity_provider = &Oli.Delivery.ActivityProvider.provide/6
 
     # We must check gating conditions here to account for gates that activated after
-    # the prologue page was rendered, and for malicous/deliberate attempts to start an attempt via
+    # the prologue page was rendered, and for malicious/deliberate attempts to start an attempt via
     # hitting this endpoint.
     case Oli.Delivery.Gating.blocked_by(section, user, revision.resource_id) do
       [] ->

--- a/test/oli/delivery/attempts_test.exs
+++ b/test/oli/delivery/attempts_test.exs
@@ -13,60 +13,62 @@ defmodule Oli.Delivery.AttemptsTest do
 
   import Oli.Factory
 
+  defp setup_create_attempt_records(_) do
+    content1 = %{
+      "stem" => "1",
+      "authoring" => %{
+        "parts" => [
+          %{
+            "id" => "1",
+            "responses" => [],
+            "scoringStrategy" => "best",
+            "evaluationStrategy" => "regex"
+          }
+        ]
+      }
+    }
+
+    content2 = %{
+      "stem" => "2",
+      "authoring" => %{
+        "parts" => [
+          %{
+            "id" => "1",
+            "responses" => [],
+            "scoringStrategy" => "best",
+            "evaluationStrategy" => "regex"
+          }
+        ]
+      }
+    }
+
+    map =
+      Seeder.base_project_with_resource2()
+      |> Seeder.create_section()
+      |> Seeder.add_objective("objective one", :o1)
+      |> Seeder.add_activity(%{title: "one", content: content1}, :a1)
+      |> Seeder.add_activity(%{title: "two", content: content2}, :a2)
+      |> Seeder.add_user(%{}, :user1)
+      |> Seeder.add_user(%{}, :user2)
+
+    attrs = %{
+      title: "page1",
+      content: %{
+        "model" => [
+          %{"type" => "activity-reference", "activity_id" => Map.get(map, :a1).resource.id},
+          %{"type" => "activity-reference", "activity_id" => Map.get(map, :a2).resource.id}
+        ]
+      },
+      objectives: %{"attached" => [Map.get(map, :o1).resource.id]},
+      graded: true
+    }
+
+    Seeder.add_page(map, attrs, :p1)
+    |> Seeder.create_section_resources()
+  end
+
   describe "creating the attempt tree records" do
-    setup do
-      content1 = %{
-        "stem" => "1",
-        "authoring" => %{
-          "parts" => [
-            %{
-              "id" => "1",
-              "responses" => [],
-              "scoringStrategy" => "best",
-              "evaluationStrategy" => "regex"
-            }
-          ]
-        }
-      }
-
-      content2 = %{
-        "stem" => "2",
-        "authoring" => %{
-          "parts" => [
-            %{
-              "id" => "1",
-              "responses" => [],
-              "scoringStrategy" => "best",
-              "evaluationStrategy" => "regex"
-            }
-          ]
-        }
-      }
-
-      map =
-        Seeder.base_project_with_resource2()
-        |> Seeder.create_section()
-        |> Seeder.add_objective("objective one", :o1)
-        |> Seeder.add_activity(%{title: "one", content: content1}, :a1)
-        |> Seeder.add_activity(%{title: "two", content: content2}, :a2)
-        |> Seeder.add_user(%{}, :user1)
-        |> Seeder.add_user(%{}, :user2)
-
-      attrs = %{
-        title: "page1",
-        content: %{
-          "model" => [
-            %{"type" => "activity-reference", "activity_id" => Map.get(map, :a1).resource.id},
-            %{"type" => "activity-reference", "activity_id" => Map.get(map, :a2).resource.id}
-          ]
-        },
-        objectives: %{"attached" => [Map.get(map, :o1).resource.id]},
-        graded: true
-      }
-
-      Seeder.add_page(map, attrs, :p1)
-      |> Seeder.create_section_resources()
-    end
+    setup [:setup_tags, :setup_create_attempt_records]
 
     test "create the attempt tree", %{
       p1: p1,
@@ -94,7 +96,8 @@ defmodule Oli.Delivery.AttemptsTest do
           activity_provider: activity_provider,
           blacklisted_activity_ids: [],
           publication_id: pub.id,
-          effective_settings: Oli.Delivery.Settings.get_combined_settings(p1.revision, section.id, user.id)
+          effective_settings:
+            Oli.Delivery.Settings.get_combined_settings(p1.revision, section.id, user.id)
         })
 
       assert Attempts.has_any_attempts?(user, section, p1.revision.resource_id)
@@ -143,6 +146,7 @@ defmodule Oli.Delivery.AttemptsTest do
       end
     end
 
+    @tag isolation: "serializable"
     test "starting a graded resource attempt with one user", %{
       p1: %{revision: revision, resource: resource},
       section: section,
@@ -150,7 +154,9 @@ defmodule Oli.Delivery.AttemptsTest do
     } do
       activity_provider = &Oli.Delivery.ActivityProvider.provide/6
       datashop_session_id = UUID.uuid4()
-      effective_settings = Oli.Delivery.Settings.get_combined_settings(revision, section.id, user1.id)
+
+      effective_settings =
+        Oli.Delivery.Settings.get_combined_settings(revision, section.id, user1.id)
 
       PageContext.create_for_visit(section, revision.slug, user1, datashop_session_id)
 
@@ -202,6 +208,7 @@ defmodule Oli.Delivery.AttemptsTest do
         )
     end
 
+    @tag isolation: "serializable"
     test "starting a graded resource attempt with two users", %{
       p1: %{revision: revision, resource: resource},
       section: section,
@@ -212,7 +219,8 @@ defmodule Oli.Delivery.AttemptsTest do
       datashop_session_id_user1 = UUID.uuid4()
       datashop_session_id_user2 = UUID.uuid4()
 
-      effective_settings = Oli.Delivery.Settings.get_combined_settings(revision, section.id, user1.id)
+      effective_settings =
+        Oli.Delivery.Settings.get_combined_settings(revision, section.id, user1.id)
 
       PageContext.create_for_visit(section, revision.slug, user1, datashop_session_id_user1)
       PageContext.create_for_visit(section, revision.slug, user2, datashop_session_id_user2)
@@ -279,84 +287,86 @@ defmodule Oli.Delivery.AttemptsTest do
     end
   end
 
+  defp setup_fetching_attempt_records(_) do
+    Seeder.base_project_with_resource2()
+    |> Seeder.create_section()
+    |> Seeder.add_user(%{}, :user1)
+    |> Seeder.add_user(%{}, :user2)
+    |> Seeder.add_activity(%{}, :publication, :project, :author, :activity_a)
+    |> Seeder.add_page(%{graded: true}, :graded_page)
+    |> Seeder.create_section_resources()
+    |> Seeder.create_resource_attempt(
+      %{attempt_number: 1},
+      :user1,
+      :page1,
+      :revision1,
+      :attempt1
+    )
+    |> Seeder.create_activity_attempt(
+      %{attempt_number: 1, transformed_model: %{some: :thing}},
+      :activity_a,
+      :attempt1,
+      :activity_attempt1
+    )
+    |> Seeder.create_part_attempt(
+      %{attempt_number: 1},
+      %Part{id: "1", responses: [], hints: []},
+      :activity_attempt1,
+      :part1_attempt1
+    )
+    |> Seeder.create_resource_attempt(
+      %{attempt_number: 2},
+      :user1,
+      :page1,
+      :revision1,
+      :attempt2
+    )
+    |> Seeder.create_activity_attempt(
+      %{attempt_number: 1, transformed_model: nil},
+      :activity_a,
+      :attempt2,
+      :activity_attempt2
+    )
+    |> Seeder.create_part_attempt(
+      %{attempt_number: 1},
+      %Part{id: "1", responses: [], hints: []},
+      :activity_attempt2,
+      :part1_attempt1
+    )
+    |> Seeder.create_part_attempt(
+      %{attempt_number: 2},
+      %Part{id: "1", responses: [], hints: []},
+      :activity_attempt2,
+      :part1_attempt2
+    )
+    |> Seeder.create_part_attempt(
+      %{attempt_number: 3},
+      %Part{id: "1", responses: [], hints: []},
+      :activity_attempt2,
+      :part1_attempt3
+    )
+    |> Seeder.create_part_attempt(
+      %{attempt_number: 1},
+      %Part{id: "2", responses: [], hints: []},
+      :activity_attempt2,
+      :part2_attempt1
+    )
+    |> Seeder.create_part_attempt(
+      %{attempt_number: 1},
+      %Part{id: "3", responses: [], hints: []},
+      :activity_attempt2,
+      :part3_attempt1
+    )
+    |> Seeder.create_part_attempt(
+      %{attempt_number: 2},
+      %Part{id: "3", responses: [], hints: []},
+      :activity_attempt2,
+      :part3_attempt2
+    )
+  end
+
   describe "fetching attempt records" do
-    setup do
-      Seeder.base_project_with_resource2()
-      |> Seeder.create_section()
-      |> Seeder.add_user(%{}, :user1)
-      |> Seeder.add_user(%{}, :user2)
-      |> Seeder.add_activity(%{}, :publication, :project, :author, :activity_a)
-      |> Seeder.add_page(%{graded: true}, :graded_page)
-      |> Seeder.create_section_resources()
-      |> Seeder.create_resource_attempt(
-        %{attempt_number: 1},
-        :user1,
-        :page1,
-        :revision1,
-        :attempt1
-      )
-      |> Seeder.create_activity_attempt(
-        %{attempt_number: 1, transformed_model: %{some: :thing}},
-        :activity_a,
-        :attempt1,
-        :activity_attempt1
-      )
-      |> Seeder.create_part_attempt(
-        %{attempt_number: 1},
-        %Part{id: "1", responses: [], hints: []},
-        :activity_attempt1,
-        :part1_attempt1
-      )
-      |> Seeder.create_resource_attempt(
-        %{attempt_number: 2},
-        :user1,
-        :page1,
-        :revision1,
-        :attempt2
-      )
-      |> Seeder.create_activity_attempt(
-        %{attempt_number: 1, transformed_model: nil},
-        :activity_a,
-        :attempt2,
-        :activity_attempt2
-      )
-      |> Seeder.create_part_attempt(
-        %{attempt_number: 1},
-        %Part{id: "1", responses: [], hints: []},
-        :activity_attempt2,
-        :part1_attempt1
-      )
-      |> Seeder.create_part_attempt(
-        %{attempt_number: 2},
-        %Part{id: "1", responses: [], hints: []},
-        :activity_attempt2,
-        :part1_attempt2
-      )
-      |> Seeder.create_part_attempt(
-        %{attempt_number: 3},
-        %Part{id: "1", responses: [], hints: []},
-        :activity_attempt2,
-        :part1_attempt3
-      )
-      |> Seeder.create_part_attempt(
-        %{attempt_number: 1},
-        %Part{id: "2", responses: [], hints: []},
-        :activity_attempt2,
-        :part2_attempt1
-      )
-      |> Seeder.create_part_attempt(
-        %{attempt_number: 1},
-        %Part{id: "3", responses: [], hints: []},
-        :activity_attempt2,
-        :part3_attempt1
-      )
-      |> Seeder.create_part_attempt(
-        %{attempt_number: 2},
-        %Part{id: "3", responses: [], hints: []},
-        :activity_attempt2,
-        :part3_attempt2
-      )
-    end
+    setup [:setup_tags, :setup_fetching_attempt_records]
 
     test "ensure we can get the user from just the resource attempt", %{
       attempt1: attempt1,
@@ -395,6 +405,7 @@ defmodule Oli.Delivery.AttemptsTest do
                |> Attempts.select_model()
     end
 
+    @tag isolation: "serializable"
     test "get graded resource access", %{
       section: section,
       graded_page: %{revision: revision},
@@ -403,7 +414,8 @@ defmodule Oli.Delivery.AttemptsTest do
       activity_provider = &Oli.Delivery.ActivityProvider.provide/6
       datashop_session_id_user1 = UUID.uuid4()
 
-      effective_settings = Oli.Delivery.Settings.get_combined_settings(revision, section.id, user1.id)
+      effective_settings =
+        Oli.Delivery.Settings.get_combined_settings(revision, section.id, user1.id)
 
       PageContext.create_for_visit(section, revision.slug, user1, datashop_session_id_user1)
 
@@ -434,6 +446,7 @@ defmodule Oli.Delivery.AttemptsTest do
       assert Enum.count(accesses) == 0
     end
 
+    @tag isolation: "serializable"
     test "get graded resource access for specific students", %{
       section: section,
       graded_page: %{revision: revision},
@@ -444,7 +457,8 @@ defmodule Oli.Delivery.AttemptsTest do
       datashop_session_id_user1 = UUID.uuid4()
       datashop_session_id_user2 = UUID.uuid4()
 
-      effective_settings = Oli.Delivery.Settings.get_combined_settings(revision, section.id, user1.id)
+      effective_settings =
+        Oli.Delivery.Settings.get_combined_settings(revision, section.id, user1.id)
 
       PageContext.create_for_visit(section, revision.slug, user1, datashop_session_id_user1)
 
@@ -575,6 +589,7 @@ defmodule Oli.Delivery.AttemptsTest do
                Attempts.get_section_by_activity_attempt_guid(activity_attempt1.attempt_guid).id
     end
 
+    @tag isolation: "serializable"
     test "resource attempt history", %{
       graded_page: %{resource: resource, revision: revision},
       section: section,
@@ -583,7 +598,8 @@ defmodule Oli.Delivery.AttemptsTest do
       activity_provider = &Oli.Delivery.ActivityProvider.provide/6
       datashop_session_id_user1 = UUID.uuid4()
 
-      effective_settings = Oli.Delivery.Settings.get_combined_settings(revision, section.id, user1.id)
+      effective_settings =
+        Oli.Delivery.Settings.get_combined_settings(revision, section.id, user1.id)
 
       PageContext.create_for_visit(section, revision.slug, user1, datashop_session_id_user1)
 

--- a/test/oli/delivery/evaluation/explanation_test.exs
+++ b/test/oli/delivery/evaluation/explanation_test.exs
@@ -8,34 +8,37 @@ defmodule Oli.Delivery.Evaluation.ExplanationTest do
   alias Oli.Resources.ExplanationStrategy
   alias Oli.Delivery.Attempts.Core.PartAttempt
 
-  describe "explanation" do
-    setup do
-      %{}
-      |> Seeder.Project.create_author(author_tag: :author)
-      |> Seeder.Project.create_sample_project(
-        ref(:author),
-        project_tag: :proj,
-        publication_tag: :pub,
-        unscored_page1_tag: :unscored_page1,
-        unscored_page1_activity_tag: :unscored_page1_activity,
-        scored_page2_tag: :scored_page2,
-        scored_page2_activity_tag: :scored_page2_activity
-      )
-      |> Seeder.Project.ensure_published(ref(:pub))
-      |> Seeder.Section.create_section(
-        ref(:proj),
-        ref(:pub),
-        nil,
-        %{},
-        section_tag: :section
-      )
-      |> Seeder.Section.create_and_enroll_learner(
-        ref(:section),
-        %{},
-        user_tag: :student1
-      )
-    end
+  defp setup_explanation(_) do
+    %{}
+    |> Seeder.Project.create_author(author_tag: :author)
+    |> Seeder.Project.create_sample_project(
+      ref(:author),
+      project_tag: :proj,
+      publication_tag: :pub,
+      unscored_page1_tag: :unscored_page1,
+      unscored_page1_activity_tag: :unscored_page1_activity,
+      scored_page2_tag: :scored_page2,
+      scored_page2_activity_tag: :scored_page2_activity
+    )
+    |> Seeder.Project.ensure_published(ref(:pub))
+    |> Seeder.Section.create_section(
+      ref(:proj),
+      ref(:pub),
+      nil,
+      %{},
+      section_tag: :section
+    )
+    |> Seeder.Section.create_and_enroll_learner(
+      ref(:section),
+      %{},
+      user_tag: :student1
+    )
+  end
 
+  describe "explanation" do
+    setup [:setup_tags, :setup_explanation]
+
+    @tag isolation: "serializable"
     test "after_max_resource_attempts_exhausted strategy explanation in a scored page", map do
       datashop_session_id_user1 = UUID.uuid4()
 
@@ -179,6 +182,7 @@ defmodule Oli.Delivery.Evaluation.ExplanationTest do
              } = map.scored_page2_activity_evaluation
     end
 
+    @tag isolation: "serializable"
     test "after_max_resource_attempts_exhausted strategy should not trigger when max_attempts is 0 (infinite)",
          map do
       datashop_session_id_user1 = UUID.uuid4()
@@ -283,6 +287,7 @@ defmodule Oli.Delivery.Evaluation.ExplanationTest do
               ]} = map.scored_page2_activity_evaluation
     end
 
+    @tag isolation: "serializable"
     test "after_set_num_attempts strategy explanation in a scored page", map do
       datashop_session_id_user1 = UUID.uuid4()
 

--- a/test/oli_web/controllers/page_delivery_controller_test.exs
+++ b/test/oli_web/controllers/page_delivery_controller_test.exs
@@ -5,20 +5,21 @@ defmodule OliWeb.PageDeliveryControllerTest do
   import Oli.Factory
   import Oli.Utils.Seeder.Utils
 
-  alias Oli.Delivery.Sections
+  alias Oli.Repo
   alias Oli.Seeder
+  alias Oli.Accounts
+  alias Oli.Delivery.{Sections, Settings}
+  alias Oli.Delivery.Attempts.{Core, PageLifecycle}
   alias Oli.Delivery.Attempts.Core.{ResourceAttempt, PartAttempt, ResourceAccess}
   alias Oli.Resources.Collaboration
   alias OliWeb.Common.{FormatDateTime, Utils}
   alias OliWeb.Router.Helpers, as: Routes
-  alias Oli.Repo
-  alias Oli.Accounts
 
   describe "page_delivery_controller build_hierarchy" do
-    setup [:setup_lti_session]
+    setup [:setup_tags, :setup_lti_session]
 
     test "properly converts a deeply nested  student access by an enrolled student", %{} do
-      # Defines a hierachry of:
+      # Defines a hierarchy of:
 
       # Page one
       # Page two
@@ -169,7 +170,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
   end
 
   describe "page_delivery_controller index" do
-    setup [:setup_lti_session]
+    setup [:setup_tags, :setup_lti_session]
 
     test "handles student access by an enrolled student", %{
       conn: conn,
@@ -341,6 +342,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert html_response(conn, 200) =~ "Course Content"
     end
 
+    @tag isolation: "serializable"
     test "shows the prologue page on an assessment", %{
       user: user,
       conn: conn,
@@ -449,6 +451,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert html_response(conn, 200) =~ "(Review)"
     end
 
+    @tag isolation: "serializable"
     test "grade update worker is not created if section has not grade passback enabled", %{
       user: user,
       conn: conn,
@@ -504,6 +507,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert Oli.Delivery.Attempts.PageLifecycle.GradeUpdateWorker.get_jobs() == []
     end
 
+    @tag isolation: "serializable"
     test "grade update worker is created if section has grade passback enabled", %{
       user: user,
       conn: conn,
@@ -560,6 +564,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert Oli.Delivery.Attempts.PageLifecycle.GradeUpdateWorker.get_jobs() |> length() == 1
     end
 
+    @tag isolation: "serializable"
     test "requires correct password to start an attempt", %{
       user: user,
       conn: conn,
@@ -676,6 +681,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
                "This assessment is not yet available. It will be available on #{FormatDateTime.date(tomorrow, conn: conn, precision: :minutes)}."
     end
 
+    @tag isolation: "serializable"
     test "shows 'Start Attempt' button when start date has passed", %{
       user: user,
       conn: conn,
@@ -740,6 +746,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       refute html_response =~ "Start Attempt"
     end
 
+    @tag isolation: "serializable"
     test "changing a page from graded to ungraded allows the graded attempt to continue", %{
       map: map,
       project: project,
@@ -852,6 +859,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       refute html_response(conn, 200) =~ "Submit Answers"
     end
 
+    @tag isolation: "serializable"
     test "changing a page from ungraded to graded shows the prologue even with an ungraded attempt present",
          %{
            map: map,
@@ -954,6 +962,71 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert html_response(conn, 200) =~ "Submit Answers"
     end
 
+    @tag isolation: "serializable"
+    test "multiple requests to start attempt only results in single active attempt record", %{
+      user: user,
+      conn: conn,
+      section: section,
+      page_revision: page_revision
+    } do
+      enroll_as_student(%{section: section, user: user})
+
+      # visit the page verifying that we are presented with the prologue page
+      conn = get(conn, Routes.page_delivery_path(conn, :page, section.slug, page_revision.slug))
+      assert html_response(conn, 200) =~ "When you are ready to begin, you may"
+
+      effective_settings = Settings.get_combined_settings(page_revision, section.id, user.id)
+
+      datashop_session_id = Plug.Conn.get_session(conn, :datashop_session_id)
+      activity_provider = &Oli.Delivery.ActivityProvider.provide/6
+
+      # simulate multiple requests to start an attempt, such as browser back/forward
+      [
+        Task.async(fn ->
+          PageLifecycle.start(
+            page_revision.slug,
+            section.slug,
+            datashop_session_id,
+            user,
+            effective_settings,
+            activity_provider
+          )
+        end),
+        Task.async(fn ->
+          PageLifecycle.start(
+            page_revision.slug,
+            section.slug,
+            datashop_session_id,
+            user,
+            effective_settings,
+            activity_provider
+          )
+        end)
+      ]
+      |> Task.await_many()
+
+      conn =
+        recycle(conn)
+        |> Pow.Plug.assign_current_user(user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
+
+      conn = get(conn, Routes.page_delivery_path(conn, :page, section.slug, page_revision.slug))
+
+      assert html_response(conn, 200) =~ "Submit Answers"
+
+      # verify there is only a single resource attempt record
+      assert {%ResourceAccess{
+                access_count: 2
+              },
+              [
+                %ResourceAttempt{
+                  attempt_number: 1,
+                  lifecycle_state: :active
+                }
+              ]} =
+               Core.get_resource_attempt_history(page_revision.resource_id, section.slug, user.id)
+    end
+
+    @tag isolation: "serializable"
     test "page with content breaks renders pagination controls", %{
       map: map,
       project: project,
@@ -1023,6 +1096,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert html_response(conn, 200) =~ ~s|<div data-react-class="Components.PaginationControls"|
     end
 
+    @tag isolation: "serializable"
     test "page renders learning objectives in ungraded pages but not graded, except for review mode",
          %{
            user: user,
@@ -1256,6 +1330,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
                ~s{\"role\":\"instructor\",\"roleColor\":\"#2ecc71\",\"roleLabel\":\"Instructor\"}
     end
 
+    @tag isolation: "serializable"
     test "timer will not be shown if revision is ungraded", %{
       conn: conn,
       user: user,
@@ -1298,6 +1373,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       refute html_response(conn, 200) =~ "<div id=\"countdown_timer_display\""
     end
 
+    @tag isolation: "serializable"
     test "timer will be shown it if revision is graded", %{
       conn: conn,
       user: user,
@@ -1350,7 +1426,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
   end
 
   describe "independent learner page_delivery_controller" do
-    setup [:setup_independent_learner_section]
+    setup [:setup_tags, :setup_independent_learner_section]
 
     test "handles new independent learner user access", %{conn: conn, section: section} do
       Oli.Test.MockHTTP
@@ -1561,7 +1637,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
   end
 
   describe "displaying unit numbers" do
-    setup [:base_project_with_curriculum]
+    setup [:setup_tags, :base_project_with_curriculum]
 
     test "does not display unit numbers if setting is set to false", %{
       conn: conn,
@@ -2540,7 +2616,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
   end
 
   describe "audience" do
-    setup [:setup_audience_section]
+    setup [:setup_tags, :setup_audience_section]
 
     test "student sees the appropriate content according to audience", map do
       %{
@@ -2591,6 +2667,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       refute html_response(conn, 200) =~ "group content with never audience"
     end
 
+    @tag isolation: "serializable"
     test "student sees the appropriate content according to audience during review",
          %{student1: user} = map do
       %{graded_page_with_audience_groups: graded_page_with_audience_groups, section: section} =
@@ -2640,6 +2717,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       refute html_response(conn, 200) =~ "group content with never audience"
     end
 
+    @tag isolation: "serializable"
     test "instructor sees the appropriate content according to audience during review", map do
       %{graded_page_with_audience_groups: graded_page_with_audience_groups, section: section} =
         map

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -2900,4 +2900,21 @@ defmodule Oli.TestHelpers do
       _ -> []
     end
   end
+
+  # Required in order to prevent '(Postgrex.Error) ERROR 25001 (active_sql_transaction): SET TRANSACTION ISOLATION LEVEL must be called before any query' error from occurring in tests
+  # https://stackoverflow.com/questions/54169171/phoenix-elixir-testing-when-setting-isolation-level-of-transaction/57328722#57328722
+  def setup_tags(tags) do
+    if tags[:isolation] do
+      Ecto.Adapters.SQL.Sandbox.checkin(Repo)
+      Ecto.Adapters.SQL.Sandbox.checkout(Repo, isolation: tags[:isolation])
+    else
+      Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+    end
+
+    unless tags[:async] do
+      Ecto.Adapters.SQL.Sandbox.mode(Repo, {:shared, self()})
+    end
+
+    :ok
+  end
 end


### PR DESCRIPTION
Fixes an issue where multiple attempts with same attempt_number were being created, possibly when user uses browser back/forward,  simultaneous requests to 'Start Attempt'.

The addition of a unit test and the changes required to support the new transaction SQL statement in the test infra are more invasive than the change itself. It might be worth considering if the test is even worth it in terms of changes required or not. The functionality and tests are split between 2 commits so it would be easy to remove them if we decide they are not.