### PR TITLE
[CHORE] Add a note to changelog indicating required infrastructure changes

### DIFF
--- a/.github/actions/torus-builder/action.yml
+++ b/.github/actions/torus-builder/action.yml
@@ -8,6 +8,6 @@ runs:
   using: "docker"
   # image: "Dockerfile"
   ## Use the prebuilt builder image on docker hub until github improves caching across builds
-  image: olisimon/torus-builder:latest
+  image: olisimon/torus-builder:1.3.2
   args:
     - ${{ inputs.build-sha }}

--- a/.github/workflows/torus-builder.yml
+++ b/.github/workflows/torus-builder.yml
@@ -2,6 +2,11 @@ name: Build torus-builder Docker Image
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to use for the Docker image"
+        required: true
+        default: "latest"
 
 jobs:
   build:
@@ -30,6 +35,6 @@ jobs:
         with:
           context: ./.github/actions/torus-builder
           push: true
-          tags: olisimon/torus-builder:latest
+          tags: olisimon/torus-builder:${{ github.event.inputs.tag }},
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 ### Bug Fixes
 
+### Environment
+
+#### Infrastructure Changes
+
+- [ ] Update deployment migration scripts to use `Oli.Release.migrate_and_seed` instead of `Oli.ReleaseTasks.migrate_and_seed`
+
 ## 0.25.0 (2023-10-5)
 
 ### Enhancements


### PR DESCRIPTION
This PR adds a note to the change log to indicate required infrastructure changes so that we remember to apply them. It also re-add the ability to tag the torus-builder image.

After landing this PR, torus-builder action should be run with the tag `1.3.2`