### PR TITLE
[BUGFIX] [MER-2593] Hide author sign in box when coming from invitation link as student/instructor

### DIFF
--- a/lib/oli_web/controllers/pow/session_html/new.html.heex
+++ b/lib/oli_web/controllers/pow/session_html/new.html.heex
@@ -37,20 +37,21 @@
     <% end %>
   <% end %>
 <% else %>
-  <div class="container mx-auto">
-    <div class="callout callout-primary max-w-lg">
-      <h4><i class="fas fa-info-circle mr-2"></i>Looking for Authoring or your LMS?</h4>
-      <p>This sign in page is for <b>Independent Learner and Educator</b> accounts.</p>
-      <p>If your institution uses an LMS such as Canvas or Blackboard to access your course, please sign in through your LMS.</p>
-      <p>If you are trying to sign in as an author, please use the Authoring Sign In page.</p>
-      <p class="my-2 text-right">
-        <%= link to: Routes.authoring_pow_session_path(@conn, :new), class: "btn btn-sm btn-outline-primary" do %>
-          Go to Authoring Sign In <i class="fa fa-arrow-right"></i>
-        <% end %>
-      </p>
+  <%= unless Oli.Utils.string_to_boolean(@conn.params["from_invitation_link?"]) do %>
+    <div class="container mx-auto">
+      <div class="callout callout-primary max-w-lg">
+        <h4><i class="fas fa-info-circle mr-2"></i>Looking for Authoring or your LMS?</h4>
+        <p>This sign in page is for <b>Independent Learner and Educator</b> accounts.</p>
+        <p>If your institution uses an LMS such as Canvas or Blackboard to access your course, please sign in through your LMS.</p>
+        <p>If you are trying to sign in as an author, please use the Authoring Sign In page.</p>
+        <p class="my-2 text-right">
+          <%= link to: Routes.authoring_pow_session_path(@conn, :new), class: "btn btn-sm btn-outline-primary" do %>
+            Go to Authoring Sign In <i class="fa fa-arrow-right"></i>
+          <% end %>
+        </p>
+      </div>
     </div>
-  </div>
-
+  <% end %>
   <%= render OliWeb.SharedView, "_box_form_container.html", Map.merge(assigns, %{title: value_or(assigns[:title], "Learner/Educator Sign In"), bs_col_class: "sm:col-span-10 md:col-span-8 lg:col-span-6 col-xl-5 mx-auto mt-4"}) do %>
     <%# social media sign in links %>
     <%= for link <- OliWeb.Pow.PowHelpers.provider_links(@conn), do: raw link %>

--- a/lib/oli_web/templates/delivery/enroll.html.heex
+++ b/lib/oli_web/templates/delivery/enroll.html.heex
@@ -33,7 +33,7 @@
 
         <%= if user_is_guest?(assigns) or assigns.current_user == nil do %>
           <%= submit "Enroll as Guest", class: "btn btn-md btn-primary btn-block" %>
-          <a href={Routes.pow_session_path(@conn, :new, section: @section.slug)} class="btn btn-md btn-outline-primary btn-block mt-2">Sign In</a>
+          <a href={Routes.pow_session_path(@conn, :new, section: @section.slug, from_invitation_link?: assigns[:from_invitation_link?])} class="btn btn-md btn-outline-primary btn-block mt-2">Sign In</a>
         <% else %>
           <%= submit "Enroll", class: "btn btn-md btn-primary btn-block" %>
         <% end %>

--- a/test/oli_web/controllers/delivery_controller_test.exs
+++ b/test/oli_web/controllers/delivery_controller_test.exs
@@ -441,14 +441,26 @@ defmodule OliWeb.DeliveryControllerTest do
                "You are being <a href=\"/sections/join/invalid\">redirected"
     end
 
-    test "redirects to login form with section slug as query param", %{conn: conn} do
+    test "redirects to login form with section slug and from_invitation_link? as true as query params",
+         %{conn: conn} do
       section = insert(:section)
       section_invite = insert(:section_invite, %{section: section})
 
       conn = get(conn, Routes.delivery_path(conn, :enroll_independent, section_invite.slug))
 
       assert html_response(conn, 302) =~
-               "You are being <a href=\"/session/new?request_path=%2Fsections%2Fjoin%2F#{section_invite.slug}&amp;section=#{section.slug}\">redirected"
+               "You are being <a href=\"/session/new?request_path=%2Fsections%2Fjoin%2F#{section_invite.slug}&amp;section=#{section.slug}&amp;from_invitation_link%3F=true\">redirected"
+    end
+
+    test "redirects to enroll page when section is open and free and does not require enrollment",
+         %{conn: conn} do
+      section = insert(:section, requires_enrollment: false, open_and_free: true)
+      section_invite = insert(:section_invite, %{section: section})
+
+      conn = get(conn, Routes.delivery_path(conn, :enroll_independent, section_invite.slug))
+
+      assert html_response(conn, 302) =~
+               "You are being <a href=\"/sections/#{section.slug}/enroll?from_invitation_link%3F=true\">redirected</a>"
     end
   end
 
@@ -509,6 +521,88 @@ defmodule OliWeb.DeliveryControllerTest do
     end
   end
 
+  describe "enroll independent (as guest user)" do
+    setup [:guest_conn]
+
+    test "redirects to invalid join view", %{conn: conn} do
+      section = insert(:section)
+      date_expires = DateTime.add(DateTime.utc_now(), -3600)
+      section_invite = insert(:section_invite, %{section: section, date_expires: date_expires})
+
+      conn = get(conn, Routes.delivery_path(conn, :enroll_independent, section_invite.slug))
+
+      assert html_response(conn, 302) =~
+               "You are being <a href=\"/sections/join/invalid\">redirected"
+    end
+
+    test "redirects to section unavailable when section has yet to be started", %{conn: conn} do
+      section = insert(:section)
+      later = DateTime.add(DateTime.utc_now(), 100_000)
+
+      {:ok, section} = Oli.Delivery.Sections.update_section(section, %{start_date: later})
+      assert {:unavailable, :before_start_date} == Oli.Delivery.Sections.available?(section)
+
+      section_invite = insert(:section_invite, %{section: section})
+      refute Oli.Delivery.Sections.SectionInvites.link_expired?(section_invite)
+
+      conn = get(conn, Routes.delivery_path(conn, :enroll_independent, section_invite.slug))
+
+      assert html_response(conn, 403) =~
+               "You are attempting to access a section before its scheduled start date."
+    end
+
+    test "redirects to section unavailable when section has already ended", %{conn: conn} do
+      section = insert(:section)
+      in_the_past = DateTime.add(DateTime.utc_now(), -100_000)
+
+      {:ok, section} = Oli.Delivery.Sections.update_section(section, %{end_date: in_the_past})
+      assert {:unavailable, :after_end_date} == Oli.Delivery.Sections.available?(section)
+
+      section_invite = insert(:section_invite, %{section: section})
+      refute Oli.Delivery.Sections.SectionInvites.link_expired?(section_invite)
+
+      conn = get(conn, Routes.delivery_path(conn, :enroll_independent, section_invite.slug))
+
+      assert html_response(conn, 403) =~
+               "You are attempting to access a section after its scheduled end date."
+    end
+
+    test "redirects to login form with section slug and from_invitation_link? as true as query params",
+         %{conn: conn} do
+      section = insert(:section, requires_enrollment: true)
+      section_invite = insert(:section_invite, %{section: section})
+
+      conn =
+        get(
+          conn,
+          Routes.delivery_path(conn, :enroll_independent, section_invite.slug,
+            from_invitation_link?: true
+          )
+        )
+
+      assert html_response(conn, 302) =~
+               "You are being <a href=\"/session/new?section=#{section.slug}&amp;from_invitation_link%3F=true\">redirected"
+    end
+
+    test "shows enroll view and Sign In link", %{conn: conn} do
+      section = insert(:section)
+      section_invite = insert(:section_invite, %{section: section})
+
+      conn =
+        get(
+          conn,
+          Routes.delivery_path(conn, :enroll_independent, section_invite.slug,
+            from_invitation_link?: true
+          )
+        )
+
+      assert html_response(conn, 200) =~ "Enroll in Course Section"
+
+      assert html_response(conn, 200) =~
+               "<a href=\"/session/new?section=#{section.slug}&amp;from_invitation_link%3F=true\" class=\"btn btn-md btn-outline-primary btn-block mt-2\">Sign In</a>"
+    end
+  end
+
   describe "enroll in the section while logged in" do
     setup [:user_conn]
 
@@ -547,7 +641,7 @@ defmodule OliWeb.DeliveryControllerTest do
       conn = get(conn, Routes.delivery_path(conn, :show_enroll, section.slug))
 
       assert html_response(conn, 302) =~
-               "<html><body>You are being <a href=\"/session/new?section=#{section.slug}\">redirected</a>.</body></html>"
+               "<html><body>You are being <a href=\"/session/new?section=#{section.slug}&amp;from_invitation_link%3F=false\">redirected</a>.</body></html>"
 
       conn = mock_captcha(conn, section)
 

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -258,6 +258,13 @@ defmodule Oli.TestHelpers do
     {:ok, conn: conn, user: user}
   end
 
+  def guest_conn(%{conn: conn}) do
+    guest = user_fixture(%{guest: true})
+    conn = Pow.Plug.assign_current_user(conn, guest, OliWeb.Pow.PowHelpers.get_pow_config(:user))
+
+    {:ok, conn: conn, guest: guest}
+  end
+
   def instructor_conn(%{conn: conn}) do
     {:ok, instructor} =
       Accounts.update_user_platform_roles(


### PR DESCRIPTION
[MER-2592](https://eliterate.atlassian.net/browse/MER-2592)

Addresses https://github.com/Simon-Initiative/oli-torus/issues/4174

When a student or instructor tries to enroll in a section via an invitation link and is not logged in yet, it redirects to the Sign In page without showing the Author Sign-in box.

Before:
![Screenshot 2023-10-16 at 11 45 22 AM](https://github.com/Simon-Initiative/oli-torus/assets/26532202/0be6c921-b8c1-449a-8d79-819227d0558b)

After:
![Screenshot 2023-10-16 at 11 45 09 AM](https://github.com/Simon-Initiative/oli-torus/assets/26532202/326fe0a6-4f9e-4e6c-852b-caf66e5775fa)


[MER-2592]: https://eliterate.atlassian.net/browse/MER-2592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ