### PR TITLE
[MER-2589] Re-enroll students from Student Dashboard

### DIFF
--- a/lib/oli/delivery/paywall.ex
+++ b/lib/oli/delivery/paywall.ex
@@ -325,7 +325,7 @@ defmodule Oli.Delivery.Paywall do
             {:error, {:unknown_section}}
 
           %Section{blueprint_id: blueprint_id, id: id} = section ->
-            case Repo.get_by(Payment, code: code) do
+            case get_payment_by(code: code) do
               nil ->
                 {:error, {:unknown_code}}
 
@@ -361,7 +361,7 @@ defmodule Oli.Delivery.Paywall do
         {:error, {:not_enrolled}}
 
       %{id: id} ->
-        case Repo.get_by(Payment, enrollment_id: id) do
+        case get_payment_by(enrollment_id: id) do
           nil ->
             update_payment(payment, %{
               enrollment_id: id,
@@ -643,5 +643,17 @@ defmodule Oli.Delivery.Paywall do
     end
     |> Discount.changeset(attrs)
     |> Repo.insert_or_update()
+  end
+
+  @doc """
+  Gets a single payment by a list of clauses
+  ## Examples
+      iex> get_payment_by(code: "123")
+      %Payment{}
+      iex> get_section_by(code: "111")
+      nil
+  """
+  def get_payment_by(clauses) do
+    Repo.get_by(Payment, clauses)
   end
 end

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -435,7 +435,7 @@ defmodule Oli.Delivery.Sections do
     case Repo.get_by(Enrollment, user_id: user_id, section_id: section_id, status: :suspended) do
       nil ->
         # Enrollment not found
-        {:error, nil}
+        {:error, :not_found}
 
       enrollment ->
         enrollment

--- a/lib/oli_web/components/delivery/actions/actions.ex
+++ b/lib/oli_web/components/delivery/actions/actions.ex
@@ -23,14 +23,16 @@ defmodule OliWeb.Components.Delivery.Actions do
         } = _assigns,
         socket
       ) do
-    %{enrollment: enrollment, user_role_id: user_role_id, current_user: current_user} =
+    %{
+      enrollment: enrollment,
+      user_role_id: user_role_id,
+      current_user: current_user,
+      is_suspended?: is_suspended?
+    } =
       enrollment_info
 
     has_payment =
-      case Repo.get_by(Payment, enrollment_id: enrollment.id) do
-        nil -> false
-        _ -> true
-      end
+      !is_suspended? and !is_nil(Paywall.get_payment_by(enrollment_id: enrollment.id))
 
     {:ok,
      assign(socket,
@@ -41,7 +43,8 @@ defmodule OliWeb.Components.Delivery.Actions do
        user_role_data: @user_role_data,
        has_payment: has_payment,
        current_user: current_user,
-       is_admin: Accounts.is_admin?(current_user)
+       is_admin: Accounts.is_admin?(current_user),
+       is_suspended?: is_suspended?
      )}
   end
 
@@ -55,70 +58,91 @@ defmodule OliWeb.Components.Delivery.Actions do
       id="student_actions"
       class="mx-10 mb-10 bg-white dark:bg-gray-800 shadow-sm px-14 py-7 flex flex-col gap-6"
     >
-      <.live_component
-        module={OliWeb.Components.LiveModal}
-        id="unenroll_user_modal"
-        title="Unenroll student"
-        on_confirm={JS.push("unenroll", target: @myself)}
-      >
-        <div class="px-4">
-          <p>
-            Are you sure you want to unenroll "<%= @user.name %>" from the course "<%= @section.title %>"?
-          </p>
-        </div>
-      </.live_component>
-
-      <div class="flex flex-col sm:flex-row sm:items-end instructor_dashboard_table">
-        <h4 class="torus-h4 !py-0 mr-auto dark:text-white">Actions</h4>
-      </div>
-
-      <div class="flex justify-between items-center">
-        <div class="flex flex-col">
-          <span class="dark:text-white">Change enrolled user role</span>
-          <span class="text-xs text-gray-400 dark:text-gray-950">
-            Select the role to change for the user in this section.
-          </span>
-        </div>
-        <form phx-change="display_confirm_modal" phx-target={@myself}>
-          <select class="torus-select pr-32" name="filter_by_role_id">
-            <%= for elem <- @user_role_data do %>
-              <option selected={elem.id == @user_role_id} value={elem.id}>
-                <%= elem.title %>
-              </option>
-            <% end %>
-          </select>
-        </form>
-      </div>
-      <%= if @section.requires_payment and @is_admin do %>
-        <div class="flex justify-between items-center px-14 py-8">
-          <div class="flex flex-col">
-            <span class="dark:text-black">Bypass payment</span>
-            <span class="text-xs text-gray-400 dark:text-gray-950">Apply bypass payment</span>
+      <div :if={@is_suspended?} id="unenrolled_student_actions">
+        <.live_component
+          module={OliWeb.Components.LiveModal}
+          id="re_enroll_user_modal"
+          title="Re-enroll student"
+          on_confirm={JS.push("re_enroll", target: @myself)}
+        >
+          <div class="px-4">
+            <p>
+              Are you sure you want to re-enroll "<%= @user.name %>" in the course "<%= @section.title %>"?
+            </p>
           </div>
-          <button
-            class="torus-button flex justify-center primary h-9 w-48"
-            disabled={@has_payment}
-            phx-click="display_bypass_modal"
-            phx-target={@myself}
-          >
-            Apply Bypass Payment
+        </.live_component>
+        <div class="ml-auto">
+          <button phx-click={JS.push("open", target: "#re_enroll_user_modal")} class="btn btn-primary">
+            Re-enroll
           </button>
         </div>
-      <% end %>
-
-      <%= if @is_admin do %>
+      </div>
+      <div :if={!@is_suspended?} id="enrolled_student_actions">
         <.live_component
-          id="transfer_enrollment"
-          module={OliWeb.Delivery.Actions.TransferEnrollment}
-          section={@section}
-          user={@user}
-        />
-      <% end %>
+          module={OliWeb.Components.LiveModal}
+          id="unenroll_user_modal"
+          title="Unenroll student"
+          on_confirm={JS.push("unenroll", target: @myself)}
+        >
+          <div class="px-4">
+            <p>
+              Are you sure you want to unenroll "<%= @user.name %>" from the course "<%= @section.title %>"?
+            </p>
+          </div>
+        </.live_component>
 
-      <div class="ml-auto">
-        <button phx-click={JS.push("open", target: "#unenroll_user_modal")} class="btn btn-danger">
-          Unenroll
-        </button>
+        <div class="flex flex-col sm:flex-row sm:items-end instructor_dashboard_table">
+          <h4 class="torus-h4 !py-0 mr-auto dark:text-white">Actions</h4>
+        </div>
+
+        <div class="flex justify-between items-center">
+          <div class="flex flex-col">
+            <span class="dark:text-white">Change enrolled user role</span>
+            <span class="text-xs text-gray-400 dark:text-gray-950">
+              Select the role to change for the user in this section.
+            </span>
+          </div>
+          <form phx-change="display_confirm_modal" phx-target={@myself}>
+            <select class="torus-select pr-32" name="filter_by_role_id">
+              <%= for elem <- @user_role_data do %>
+                <option selected={elem.id == @user_role_id} value={elem.id}>
+                  <%= elem.title %>
+                </option>
+              <% end %>
+            </select>
+          </form>
+        </div>
+        <%= if @section.requires_payment and @is_admin do %>
+          <div class="flex justify-between items-center px-14 py-8">
+            <div class="flex flex-col">
+              <span class="dark:text-black">Bypass payment</span>
+              <span class="text-xs text-gray-400 dark:text-gray-950">Apply bypass payment</span>
+            </div>
+            <button
+              class="torus-button flex justify-center primary h-9 w-48"
+              disabled={@has_payment}
+              phx-click="display_bypass_modal"
+              phx-target={@myself}
+            >
+              Apply Bypass Payment
+            </button>
+          </div>
+        <% end %>
+
+        <%= if @is_admin do %>
+          <.live_component
+            id="transfer_enrollment"
+            module={OliWeb.Delivery.Actions.TransferEnrollment}
+            section={@section}
+            user={@user}
+          />
+        <% end %>
+
+        <div class="ml-auto">
+          <button phx-click={JS.push("open", target: "#unenroll_user_modal")} class="btn btn-danger">
+            Unenroll
+          </button>
+        </div>
       </div>
     </div>
     """
@@ -128,6 +152,27 @@ defmodule OliWeb.Components.Delivery.Actions do
     %{section: section, user: user} = socket.assigns
 
     case Oli.Delivery.Sections.unenroll_learner(user.id, section.id) do
+      {:ok, _} ->
+        {:noreply,
+         redirect(socket,
+           to:
+             Routes.live_path(
+               OliWeb.Endpoint,
+               OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive,
+               socket.assigns.section.slug,
+               :manage
+             )
+         )}
+
+      _ ->
+        {:noreply, socket}
+    end
+  end
+
+  def handle_event("re_enroll", _params, socket) do
+    %{section: section, user: user} = socket.assigns
+
+    case Oli.Delivery.Sections.re_enroll_learner(user.id, section.id) do
       {:ok, _} ->
         {:noreply,
          redirect(socket,

--- a/lib/oli_web/components/delivery/actions/actions.ex
+++ b/lib/oli_web/components/delivery/actions/actions.ex
@@ -8,6 +8,7 @@ defmodule OliWeb.Components.Delivery.Actions do
   alias Phoenix.LiveView.JS
   alias Oli.Delivery.Paywall
   alias OliWeb.Router.Helpers, as: Routes
+  alias OliWeb.Components.Modal
 
   @user_role_data [
     %{id: 3, name: :instructor, title: "Instructor"},
@@ -59,21 +60,18 @@ defmodule OliWeb.Components.Delivery.Actions do
     >
       <%= if @is_suspended? do %>
         <div id="unenrolled_student_actions">
-          <.live_component
-            module={OliWeb.Components.LiveModal}
+          <Modal.modal
             id="re_enroll_user_modal"
-            title="Re-enroll student"
-            on_confirm={JS.push("re_enroll", target: @myself)}
+            class="w-5/6"
+            on_confirm={JS.push("re_enroll", target: @myself) |> Modal.hide_modal("re_enroll_user_modal")}
           >
-            <div class="px-4">
-              <p>
-                Are you sure you want to re-enroll "<%= @user.name %>" in the course "<%= @section.title %>"?
-              </p>
-            </div>
-          </.live_component>
+            <:title>Re-enroll student</:title>
+            <%= "Are you sure you want to re-enroll #{@user.name} in the course #{@section.title}" %>
+            <:confirm>Confirm</:confirm>
+          </Modal.modal>
           <div class="ml-auto">
             <button
-              phx-click={JS.push("open", target: "#re_enroll_user_modal")}
+              phx-click={Modal.show_modal("re_enroll_user_modal")}
               class="btn btn-primary"
             >
               Re-enroll
@@ -82,19 +80,15 @@ defmodule OliWeb.Components.Delivery.Actions do
         </div>
       <% else %>
         <div id="enrolled_student_actions">
-          <.live_component
-            module={OliWeb.Components.LiveModal}
+          <Modal.modal
             id="unenroll_user_modal"
-            title="Unenroll student"
-            on_confirm={JS.push("unenroll", target: @myself)}
+            class="w-5/6"
+            on_confirm={JS.push("unenroll", target: @myself) |> Modal.hide_modal("unenroll_user_modal")}
           >
-            <div class="px-4">
-              <p>
-                Are you sure you want to unenroll "<%= @user.name %>" from the course "<%= @section.title %>"?
-              </p>
-            </div>
-          </.live_component>
-
+            <:title>Unenroll student</:title>
+            <%= "Are you sure you want to unenroll #{@user.name} from the course #{@section.title}" %>
+            <:confirm>Confirm</:confirm>
+          </Modal.modal>
           <div class="flex flex-col sm:flex-row sm:items-end instructor_dashboard_table">
             <h4 class="torus-h4 !py-0 mr-auto dark:text-white">Actions</h4>
           </div>
@@ -143,7 +137,7 @@ defmodule OliWeb.Components.Delivery.Actions do
           <% end %>
 
           <div class="ml-auto">
-            <button phx-click={JS.push("open", target: "#unenroll_user_modal")} class="btn btn-danger">
+            <button phx-click={Modal.show_modal("unenroll_user_modal")} class="btn btn-danger">
               Unenroll
             </button>
           </div>

--- a/lib/oli_web/components/delivery/actions/actions.ex
+++ b/lib/oli_web/components/delivery/actions/actions.ex
@@ -190,7 +190,8 @@ defmodule OliWeb.Components.Delivery.Actions do
              )
          )}
 
-      _ ->
+      {:error, :not_found} ->
+        send(self(), {:put_flash, :info, "Could not re-enroll the student. Previous enrollment was not found."})
         {:noreply, socket}
     end
   end

--- a/lib/oli_web/components/modal.ex
+++ b/lib/oli_web/components/modal.ex
@@ -64,7 +64,7 @@ defmodule OliWeb.Components.Modal do
               phx-window-keydown={hide_modal(@on_cancel, @id)}
               phx-key="escape"
               phx-click-away={hide_modal(@on_cancel, @id)}
-              class="hidden relative rounded-lg bg-white shadow-lg shadow-zinc-700/10 ring-1 ring-zinc-700/10 transition"
+              class="hidden relative rounded-lg bg-white dark:bg-body-dark shadow-lg shadow-zinc-700/10 ring-1 ring-zinc-700/10 transition"
             >
               <!-- Modal header -->
               <div class="flex items-start justify-between p-4">

--- a/lib/oli_web/live/delivery/student_dashboard/student_dashboard_live.ex
+++ b/lib/oli_web/live/delivery/student_dashboard/student_dashboard_live.ex
@@ -96,14 +96,18 @@ defmodule OliWeb.Delivery.StudentDashboard.StudentDashboardLive do
   def handle_params(%{"active_tab" => "actions"} = params, _, socket) do
     enrollment = Sections.get_enrollment(socket.assigns.section.slug, socket.assigns.student.id)
 
+    user_role_id =
+      if is_nil(enrollment), do: nil, else: Sections.get_user_role_from_enrollment(enrollment)
+
     socket =
       socket
       |> assign(params: params, active_tab: String.to_existing_atom(params["active_tab"]))
       |> assign_new(:enrollment_info, fn ->
         %{
           enrollment: enrollment,
-          user_role_id: Sections.get_user_role_from_enrollment(enrollment),
-          current_user: socket.assigns.current_user
+          user_role_id: user_role_id,
+          current_user: socket.assigns.current_user,
+          is_suspended?: is_nil(enrollment)
         }
       end)
 
@@ -122,82 +126,81 @@ defmodule OliWeb.Delivery.StudentDashboard.StudentDashboardLive do
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
-      <%= render_modal(assigns) %>
-      <Helpers.student_details survey_responses={@survey_responses || []} student={@student} />
-      <Helpers.tabs
-        hidden_tabs={if !@enrollment, do: [:actions], else: []}
-        active_tab={@active_tab}
-        section_slug={@section.slug}
-        student_id={@student.id}
-        preview_mode={@preview_mode}
-      />
-      <%= render_tab(assigns) %>
+    <%= render_modal(assigns) %>
+    <Helpers.student_details survey_responses={@survey_responses || []} student={@student} />
+    <Helpers.tabs
+      active_tab={@active_tab}
+      section_slug={@section.slug}
+      student_id={@student.id}
+      preview_mode={@preview_mode}
+    />
+    <%= render_tab(assigns) %>
     """
   end
 
   defp render_tab(%{active_tab: :content} = assigns) do
     ~H"""
-      <.live_component
+    <.live_component
       id="content_tab"
       module={OliWeb.Delivery.StudentDashboard.Components.ContentTab}
       params={@params}
       section_slug={@section.slug}
       containers={@containers}
       student_id={@student.id}
-      />
+    />
     """
   end
 
   defp render_tab(%{active_tab: :learning_objectives} = assigns) do
     ~H"""
-      <.live_component
+    <.live_component
       id="learning_objectives_tab"
       module={OliWeb.Delivery.StudentDashboard.Components.LearningObjectivesTab}
       params={@params}
       section={@section}
       objectives_tab={@objectives_tab}
       student_id={@student.id}
-      />
+    />
     """
   end
 
   defp render_tab(%{active_tab: :quizz_scores} = assigns) do
     ~H"""
-      <.live_component
-        id="quiz_scores_table"
-        module={OliWeb.Delivery.StudentDashboard.Components.QuizzScoresTab}
-        params={@params}
-        section={@section}
-        patch_url_type={:quiz_scores_student}
-        student_id={@student.id}
-        scores={@scores}
-      />
+    <.live_component
+      id="quiz_scores_table"
+      module={OliWeb.Delivery.StudentDashboard.Components.QuizzScoresTab}
+      params={@params}
+      section={@section}
+      patch_url_type={:quiz_scores_student}
+      student_id={@student.id}
+      scores={@scores}
+    />
     """
   end
 
   defp render_tab(%{active_tab: :progress} = assigns) do
     ~H"""
-      <.live_component
-        id="progress_tab"
-        module={OliWeb.Delivery.StudentDashboard.Components.ProgressTab}
-        params={@params}
-        section_slug={@section.slug}
-        student_id={@student.id}
-        ctx={@ctx}
-        pages={@pages}
-      />
+    <.live_component
+      id="progress_tab"
+      module={OliWeb.Delivery.StudentDashboard.Components.ProgressTab}
+      params={@params}
+      section_slug={@section.slug}
+      student_id={@student.id}
+      ctx={@ctx}
+      pages={@pages}
+    />
     """
   end
 
   defp render_tab(%{active_tab: :actions} = assigns) do
     ~H"""
-      <.live_component
-        id="actions_table"
-        module={OliWeb.Components.Delivery.Actions}
-        user={@student}
-        section={@section}
-        enrollment_info={@enrollment_info}
-      />
+    <.live_component
+      id="actions_table"
+      module={OliWeb.Components.Delivery.Actions}
+      user={@student}
+      section={@section}
+      enrollment_info={@enrollment_info}
+    />
     """
   end
 

--- a/test/oli_web/live/delivery/student_dashboard/components/actions_tab_test.exs
+++ b/test/oli_web/live/delivery/student_dashboard/components/actions_tab_test.exs
@@ -136,16 +136,6 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.ActionsTabTest do
       refute has_element?(view, "button", "Re-enroll")
 
       view
-      |> with_target("#unenroll_user_modal")
-      |> render_click("open", %{})
-
-      assert has_element?(
-               view,
-               "p",
-               "Are you sure you want to unenroll \"#{student.name}\" from the course \"#{section.title}\"?"
-             )
-
-      view
       |> with_target("#student_actions")
       |> render_click("unenroll", %{})
 
@@ -188,16 +178,6 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.ActionsTabTest do
 
       assert has_element?(view, "button", "Re-enroll")
       refute has_element?(view, "button", "Unenroll")
-
-      view
-      |> with_target("#re_enroll_user_modal")
-      |> render_click("open", %{})
-
-      assert has_element?(
-               view,
-               "p",
-               "Are you sure you want to re-enroll \"#{student.name}\" in the course \"#{section.title}\"?"
-             )
 
       view
       |> with_target("#student_actions")

--- a/test/oli_web/live/delivery/student_dashboard/student_dashboard_live_test.exs
+++ b/test/oli_web/live/delivery/student_dashboard/student_dashboard_live_test.exs
@@ -114,25 +114,6 @@ defmodule OliWeb.Delivery.StudentDashboard.StudentDashboardLiveTest do
       assert render(student_details_card) =~ "A lot"
     end
 
-    test "actions tab is hidden if user is suspended", %{
-      instructor: instructor,
-      student: student,
-      conn: conn
-    } do
-      %{section: section, survey: survey, survey_questions: survey_questions} =
-        section_with_survey()
-
-      complete_student_survey(student, section, survey, survey_questions)
-
-      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
-      Sections.unenroll(student.id, section.id, [ContextRoles.get_role(:context_learner)])
-
-      {:ok, view, _html} =
-        live(conn, live_view_students_dashboard_route(section.slug, student.id))
-
-      refute has_element?(view, "li.nav-item a", "Actions")
-    end
-
     test "breadcrumbs get render correctly when coming from the instructor dashboard", %{
       instructor: instructor,
       student: student,


### PR DESCRIPTION
[MER-2589](https://eliterate.atlassian.net/browse/MER-2589)

Addresses https://github.com/Simon-Initiative/oli-torus/issues/4158

Allow instructors to re-enroll previously suspended students. The Actions tab in the Student Dashboard is no longer hidden for instructors when a student is suspended. Instead, it now has a **"Re-enroll"** button.

https://github.com/Simon-Initiative/oli-torus/assets/26532202/e8ad8698-7f32-4e90-b0b6-c5a0d88d490a


This also fixes an issue on the Modal function component whose css classes were not properly set on Dark mode.

Modal before the fix:

![Screenshot 2023-10-19 at 2 24 28 PM](https://github.com/Simon-Initiative/oli-torus/assets/26532202/5a481436-2c6a-4f27-8bc9-bd42a94e47e7)


[MER-2589]: https://eliterate.atlassian.net/browse/MER-2589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ