### PR TITLE
[MER-2595] Enable discussion activity for all pages

### DIFF
--- a/lib/oli/resources/collaboration.ex
+++ b/lib/oli/resources/collaboration.ex
@@ -254,6 +254,15 @@ defmodule Oli.Resources.Collaboration do
     end
   end
 
+  defp project_working_publication(project_slug) do
+    from(p in Publication,
+      join: c in Project,
+      on: p.project_id == c.id,
+      where: is_nil(p.published) and c.slug == ^project_slug,
+      select: p.id
+    )
+  end
+
   @doc """
   Counts the number of pages with collab space enabled and the number of total pages for a given project,
   for the current working publication.
@@ -267,19 +276,11 @@ defmodule Oli.Resources.Collaboration do
   def count_collab_spaces_enabled_in_pages_for_project(project_slug) do
     page_id = Oli.Resources.ResourceType.get_id_by_type("page")
 
-    project_working_publication =
-      from(p in Publication,
-        join: c in Project,
-        on: p.project_id == c.id,
-        where: is_nil(p.published) and c.slug == ^project_slug,
-        select: p.id
-      )
-
     from(m in PublishedResource,
       join: rev in Revision,
       on: rev.id == m.revision_id,
       where:
-        m.publication_id in subquery(project_working_publication) and
+        m.publication_id in subquery(project_working_publication(project_slug)) and
           rev.resource_type_id == ^page_id and rev.deleted == false,
       select: {
         count(
@@ -297,7 +298,7 @@ defmodule Oli.Resources.Collaboration do
   end
 
   @doc """
-  Counts the number of pages with collab space enabled and the number of total pages for a given project,
+  Counts the number of pages with collab space enabled and the number of total pages for a given section,
   for the current working publication.
   Returns a tuple like {pages_with_collab_space_enabled_count, total_pages_count}
 
@@ -334,19 +335,11 @@ defmodule Oli.Resources.Collaboration do
   def disable_all_page_collab_spaces_for_project(project_slug) do
     page_id = Oli.Resources.ResourceType.get_id_by_type("page")
 
-    project_working_publication =
-      from(p in Publication,
-        join: c in Project,
-        on: p.project_id == c.id,
-        where: is_nil(p.published) and c.slug == ^project_slug,
-        select: p.id
-      )
-
     from(rev in Revision,
       join: m in PublishedResource,
       on: m.revision_id == rev.id,
       where:
-        m.publication_id in subquery(project_working_publication) and
+        m.publication_id in subquery(project_working_publication(project_slug)) and
           rev.resource_type_id == ^page_id and rev.deleted == false,
       select: rev
     )
@@ -361,19 +354,11 @@ defmodule Oli.Resources.Collaboration do
   def enable_all_page_collab_spaces_for_project(project_slug, collab_space_config) do
     page_id = Oli.Resources.ResourceType.get_id_by_type("page")
 
-    project_working_publication =
-      from(p in Publication,
-        join: c in Project,
-        on: p.project_id == c.id,
-        where: is_nil(p.published) and c.slug == ^project_slug,
-        select: p.id
-      )
-
     from(rev in Revision,
       join: m in PublishedResource,
       on: m.revision_id == rev.id,
       where:
-        m.publication_id in subquery(project_working_publication) and
+        m.publication_id in subquery(project_working_publication(project_slug)) and
           rev.resource_type_id == ^page_id and rev.deleted == false,
       select: rev
     )

--- a/lib/oli/resources/collaboration.ex
+++ b/lib/oli/resources/collaboration.ex
@@ -297,6 +297,34 @@ defmodule Oli.Resources.Collaboration do
     |> Repo.one()
   end
 
+  @doc """
+  Disables all page collaborative spaces for a given section.
+  """
+
+  def disable_all_page_collab_spaces_for_section(section_slug) do
+    page_id = Oli.Resources.ResourceType.get_id_by_type("page")
+
+    from([sr: sr, rev: rev] in DeliveryResolver.section_resource_revisions(section_slug),
+      where: rev.resource_type_id == ^page_id and rev.deleted == false,
+      select: sr
+    )
+    |> Repo.update_all(set: [collab_space_config: %CollabSpaceConfig{}])
+  end
+
+  @doc """
+  Enables all page collaborative spaces for a given section, bulk applying the collab space config provided.
+  """
+
+  def enable_all_page_collab_spaces_for_section(section_slug, collab_space_config) do
+    page_id = Oli.Resources.ResourceType.get_id_by_type("page")
+
+    from([sr: sr, rev: rev] in DeliveryResolver.section_resource_revisions(section_slug),
+      where: rev.resource_type_id == ^page_id and rev.deleted == false,
+      select: sr
+    )
+    |> Repo.update_all(set: [collab_space_config: collab_space_config])
+  end
+
   # ------------------------------------------------------------
   # Posts
 

--- a/lib/oli/resources/collaboration.ex
+++ b/lib/oli/resources/collaboration.ex
@@ -255,7 +255,7 @@ defmodule Oli.Resources.Collaboration do
   end
 
   @doc """
-  Counts the number pages with collab space enabled and the number of total pages for a given project,
+  Counts the number of pages with collab space enabled and the number of total pages for a given project,
   for the current working publication.
   Returns a tuple like {pages_with_collab_space_enabled_count, total_pages_count}
 
@@ -297,7 +297,7 @@ defmodule Oli.Resources.Collaboration do
   end
 
   @doc """
-  Counts the number pages with collab space enabled and the number of total pages for a given project,
+  Counts the number of pages with collab space enabled and the number of total pages for a given project,
   for the current working publication.
   Returns a tuple like {pages_with_collab_space_enabled_count, total_pages_count}
 

--- a/lib/oli_web/live/collaboration_live/collab_space_config_view.ex
+++ b/lib/oli_web/live/collaboration_live/collab_space_config_view.ex
@@ -147,7 +147,7 @@ defmodule OliWeb.CollaborationLive.CollabSpaceConfigView do
         :if={@is_overview_render}
         class="flex flex-col space-y-4 mt-8 pt-6 border-t border-gray-200"
       >
-        <h5>
+        <h5 role="collab_space_page_summary">
           <%= ~s{#{if @pages_count == @collab_space_pages_count, do: "All"} #{@collab_space_pages_count} #{Gettext.ngettext(OliWeb.Gettext, "page currently has", "pages currently have", @collab_space_pages_count)}} %> Collaborative Spaces enabled
         </h5>
         <button
@@ -155,19 +155,15 @@ defmodule OliWeb.CollaborationLive.CollabSpaceConfigView do
             @pages_count > @collab_space_pages_count &&
               Modal.show_modal("enable_collab_space_modal")
           }
-          class={[
-            "btn btn-primary w-[450px]",
-            "#{if @pages_count == @collab_space_pages_count, do: "disabled"}"
-          ]}
+          class="btn btn-primary w-[450px]"
+          disabled={@pages_count == @collab_space_pages_count}
         >
           Enable Collaboration Spaces for all pages in the course
         </button>
         <button
           phx-click={@collab_space_pages_count > 0 && Modal.show_modal("disable_collab_space_modal")}
-          class={[
-            "btn btn-primary w-[450px]",
-            "#{if @collab_space_pages_count == 0, do: "disabled"}"
-          ]}
+          class="btn btn-primary w-[450px]"
+          disabled={@collab_space_pages_count == 0}
         >
           Disable Collaboration Spaces for all pages in the course
         </button>

--- a/lib/oli_web/live/collaboration_live/collab_space_config_view.ex
+++ b/lib/oli_web/live/collaboration_live/collab_space_config_view.ex
@@ -450,8 +450,6 @@ defmodule OliWeb.CollaborationLive.CollabSpaceConfigView do
     Collaboration.count_collab_spaces_enabled_in_pages_for_section(section_slug)
   end
 
-  defp get_collab_space_pages_count(nil, _), do: %{with_collab_spaces_enabled: 0, total: 0}
-
   defp from_struct(nil), do: %{}
   defp from_struct(collab_space), do: Map.from_struct(collab_space)
 

--- a/lib/oli_web/live/collaboration_live/collab_space_config_view.ex
+++ b/lib/oli_web/live/collaboration_live/collab_space_config_view.ex
@@ -10,6 +10,8 @@ defmodule OliWeb.CollaborationLive.CollabSpaceConfigView do
   alias Oli.Delivery.Sections.SectionResource
   alias OliWeb.CollaborationLive.CollabSpaceView
   alias Phoenix.PubSub
+  alias OliWeb.Components.Modal
+  alias Phoenix.LiveView.JS
 
   def mount(
         _params,
@@ -72,93 +74,141 @@ defmodule OliWeb.CollaborationLive.CollabSpaceConfigView do
 
   def render(assigns) do
     ~H"""
-    <div class={"card max-w-full #{if @is_overview_render, do: "shadow-none"}"}>
-      <div class="flex flex-col md:flex-row md:items-center card-body justify-between">
-        <div class="flex flex-col justify-start md:flex-row md:items-center gap-2">
-          <%= unless @is_overview_render do %>
-            <h3 class="card-title">Collaborative Space Config</h3>
-          <% end %>
-          <div>
-            <span class="bg-delivery-primary-200 badge badge-info">
-              <%= humanize(@collab_space_status) %>
-            </span>
+    <Modal.modal
+      id="enable_collab_space_modal"
+      class="!w-auto"
+      on_confirm={
+        JS.push("enable_all_pages_collab_spaces") |> Modal.hide_modal("enable_collab_space_modal")
+      }
+    >
+      Are you sure you want to <strong>enable</strong>
+      collaboration spaces for all pages in the course?
+      <:confirm>OK</:confirm>
+      <:cancel>Cancel</:cancel>
+    </Modal.modal>
+
+    <Modal.modal
+      id="disable_collab_space_modal"
+      class="!w-auto"
+      on_confirm={
+        JS.push("disable_all_pages_collab_spaces") |> Modal.hide_modal("disable_collab_space_modal")
+      }
+    >
+      Are you sure you want to <strong>disable</strong>
+      collaboration spaces for all pages in the course?
+      <:confirm>OK</:confirm>
+      <:cancel>Cancel</:cancel>
+    </Modal.modal>
+
+    <div class={"card max-w-full #{if @is_overview_render, do: "shadow-none p-0"}"}>
+      <section>
+        <h5>Student Course Portal Collaborative Space</h5>
+        <div class="flex flex-col md:flex-row md:items-center card-body justify-between">
+          <div class="flex flex-col justify-start md:flex-row md:items-center gap-2">
+            <%= unless @is_overview_render do %>
+              <h3 class="card-title">Collaborative Space Config</h3>
+            <% end %>
+            <div>
+              <span class="bg-delivery-primary-200 badge badge-info">
+                <%= humanize(@collab_space_status) %>
+              </span>
+            </div>
+          </div>
+
+          <div class="mt-4 md:mt-0">
+            <.action_buttons status={@collab_space_status} />
           </div>
         </div>
+        <%= if  @collab_space_status == :enabled do %>
+          <div class="card-footer bg-transparent flex mt-8">
+            <.form class="w-full" for={@form} phx-submit="save">
+              <.inputs_for :let={cs} field={@form[:collab_space_config]}>
+                <.input type="hidden" field={cs[:status]} />
 
-        <div class="mt-4 md:mt-0">
-          <.action_buttons status={@collab_space_status} />
-        </div>
-      </div>
-      <%= if  @collab_space_status == :enabled do %>
-        <div class="card-footer bg-transparent flex mt-8">
-          <.form class="w-full" for={@form} phx-submit="save">
-            <.inputs_for :let={cs} field={@form[:collab_space_config]}>
-              <.input type="hidden" field={cs[:status]} />
-
-              <div class="form-check mt-1">
-                <.input
-                  type="checkbox"
-                  field={cs[:threaded]}
-                  class="form-check-input"
-                  label="Allow threading of posts with replies"
-                />
-              </div>
-
-              <div class="form-check mt-1">
-                <.input
-                  type="checkbox"
-                  field={cs[:auto_accept]}
-                  class="form-check-input"
-                  label="Allow posts to be visible without approval"
-                />
-              </div>
-
-              <div class="form-check mt-1">
-                <.input
-                  type="checkbox"
-                  field={cs[:show_full_history]}
-                  class="form-check-input"
-                  label="Show full history"
-                />
-              </div>
-
-              <div class="form-check mt-1">
-                <.input
-                  type="checkbox"
-                  field={cs[:anonymous_posting]}
-                  class="form-check-input"
-                  label="Allow anonymous posts"
-                />
-              </div>
-
-              <br /> Participation requirements
-              <div class="flex flex-col gap-4">
-                <div class="form-group">
+                <div class="form-check mt-1">
                   <.input
-                    type="number"
-                    min={0}
-                    field={cs[:participation_min_replies]}
-                    class="form-control"
-                    label="Minimum replies"
+                    type="checkbox"
+                    field={cs[:threaded]}
+                    class="form-check-input"
+                    label="Allow threading of posts with replies"
                   />
                 </div>
 
-                <div class="form-group">
+                <div class="form-check mt-1">
                   <.input
-                    type="number"
-                    min={0}
-                    field={cs[:participation_min_posts]}
-                    class="form-control"
-                    label="Minimum posts"
+                    type="checkbox"
+                    field={cs[:auto_accept]}
+                    class="form-check-input"
+                    label="Allow posts to be visible without approval"
                   />
                 </div>
-              </div>
-            </.inputs_for>
 
-            <button class="torus-button primary !flex ml-auto mt-8" type="submit">Save</button>
-          </.form>
-        </div>
-      <% end %>
+                <div class="form-check mt-1">
+                  <.input
+                    type="checkbox"
+                    field={cs[:show_full_history]}
+                    class="form-check-input"
+                    label="Show full history"
+                  />
+                </div>
+
+                <div class="form-check mt-1">
+                  <.input
+                    type="checkbox"
+                    field={cs[:anonymous_posting]}
+                    class="form-check-input"
+                    label="Allow anonymous posts"
+                  />
+                </div>
+
+                <br /> Participation requirements
+                <div class="flex flex-col gap-4">
+                  <div class="form-group">
+                    <.input
+                      type="number"
+                      min={0}
+                      field={cs[:participation_min_replies]}
+                      class="form-control"
+                      label="Minimum replies"
+                    />
+                  </div>
+
+                  <div class="form-group">
+                    <.input
+                      type="number"
+                      min={0}
+                      field={cs[:participation_min_posts]}
+                      class="form-control"
+                      label="Minimum posts"
+                    />
+                  </div>
+                </div>
+              </.inputs_for>
+
+              <button class="torus-button primary !flex ml-auto mt-4" type="submit">Save</button>
+            </.form>
+          </div>
+        <% end %>
+      </section>
+
+      <section
+        :if={@collab_space_status == :enabled}
+        class="flex flex-col space-y-4 mt-8 pt-6 border-t border-gray-200"
+      >
+        <h5>X pages currently have Collaborative Spaces enabled</h5>
+        <button
+          phx-click={Modal.show_modal("enable_collab_space_modal")}
+          class="btn btn-primary w-[450px]"
+        >
+          Enable Collaboration Spaces for all pages in the course
+        </button>
+        <button
+          phx-click={Modal.show_modal("disable_collab_space_modal")}
+          class="btn btn-primary w-[450px]"
+        >
+          Disable Collaboration Spaces for all pages in the course
+        </button>
+      </section>
     </div>
     """
   end
@@ -218,6 +268,16 @@ defmodule OliWeb.CollaborationLive.CollabSpaceConfigView do
       Map.merge(from_struct(socket.assigns.collab_space_config), %{status: :archived}),
       socket
     )
+  end
+
+  def handle_event("disable_all_pages_collab_spaces", _params, socket) do
+    # TODO handle this
+    {:noreply, socket}
+  end
+
+  def handle_event("enable_all_pages_collab_spaces", _params, socket) do
+    # TODO handle this
+    {:noreply, socket}
   end
 
   # first argument is a flag that specifies whether it is delivery or not, to accordingly

--- a/lib/oli_web/live/collaboration_live/collab_space_config_view.ex
+++ b/lib/oli_web/live/collaboration_live/collab_space_config_view.ex
@@ -135,7 +135,7 @@ defmodule OliWeb.CollaborationLive.CollabSpaceConfigView do
         </div>
         <%= if  @collab_space_status == :enabled do %>
           <div class="card-footer bg-transparent flex mt-8">
-            <.form class="w-full" for={@form} phx-submit="save">
+            <.form id="collab_space_config_form" class="w-full" for={@form} phx-submit="save">
               <.collab_space_form_content form={@form} />
               <button class="torus-button primary !flex ml-auto mt-4" type="submit">Save</button>
             </.form>

--- a/lib/oli_web/live/projects/overview_live.ex
+++ b/lib/oli_web/live/projects/overview_live.ex
@@ -276,8 +276,8 @@ defmodule OliWeb.Projects.OverviewLive do
       ) %>
 
       <Overview.section
-        title="Collaboration Space"
-        description="Allows to activate and configure a collaborative space for the root resource of a project."
+        title="Collaboration Spaces"
+        description="Manage the Collaborative Spaces within the project."
       >
         <div class="container mx-auto">
           <%= live_render(@socket, OliWeb.CollaborationLive.CollabSpaceConfigView,
@@ -449,7 +449,9 @@ defmodule OliWeb.Projects.OverviewLive do
     case Course.update_project(project, %{status: :deleted}) do
       {:ok, _project} ->
         {:noreply,
-         push_redirect(socket, to: Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.ProjectsLive))}
+         push_redirect(socket,
+           to: Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.ProjectsLive)
+         )}
 
       {:error, %Ecto.Changeset{} = changeset} ->
         socket =

--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -311,22 +311,16 @@ defmodule OliWeb.Sections.OverviewView do
         description="Activate and configure a collaborative space for this section"
       >
         <div class="container mx-auto">
-          <%= if @collab_space_config && @collab_space_config.status != :disabled do %>
-            <%= live_render(@socket, OliWeb.CollaborationLive.CollabSpaceConfigView,
-              id: "collab_space_config",
-              session: %{
-                "collab_space_config" => @collab_space_config,
-                "section_slug" => @section.slug,
-                "resource_slug" => @resource_slug,
-                "is_overview_render" => true,
-                "is_delivery" => true
-              }
-            ) %>
-          <% else %>
-            <p class="ml-8 mt-2">
-              Collaborative spaces are not enabled by the course project.<br />Please contact a system administrator to enable.
-            </p>
-          <% end %>
+          <%= live_render(@socket, OliWeb.CollaborationLive.CollabSpaceConfigView,
+            id: "collab_space_config",
+            session: %{
+              "collab_space_config" => @collab_space_config,
+              "section_slug" => @section.slug,
+              "resource_slug" => @resource_slug,
+              "is_overview_render" => true,
+              "is_delivery" => true
+            }
+          ) %>
         </div>
       </Group.render>
       <Group.render

--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -307,8 +307,8 @@ defmodule OliWeb.Sections.OverviewView do
         <% end %>
       </Group.render>
       <Group.render
-        label="Collaborative Space"
-        description="Activate and configure a collaborative space for this section"
+        label="Collaboration Spaces"
+        description="Manage the Collaborative Spaces within the course"
       >
         <div class="container mx-auto">
           <%= live_render(@socket, OliWeb.CollaborationLive.CollabSpaceConfigView,

--- a/test/oli_web/live/collaboration_live_test.exs
+++ b/test/oli_web/live/collaboration_live_test.exs
@@ -458,27 +458,39 @@ defmodule OliWeb.CollaborationLiveTest do
       assert has_element?(view, "span", "Enabled")
 
       assert view
-             |> element("#section_resource_collab_space_config_0_threaded")
+             |> element(
+               "#collab_space_config_form #section_resource_collab_space_config_0_threaded"
+             )
              |> render() =~ "checked"
 
       assert view
-             |> element("#section_resource_collab_space_config_0_auto_accept")
+             |> element(
+               "#collab_space_config_form #section_resource_collab_space_config_0_auto_accept"
+             )
              |> render() =~ "checked"
 
       assert view
-             |> element("#section_resource_collab_space_config_0_show_full_history")
+             |> element(
+               "#collab_space_config_form #section_resource_collab_space_config_0_show_full_history"
+             )
              |> render() =~ "checked"
 
       assert view
-             |> element("#section_resource_collab_space_config_0_anonymous_posting")
+             |> element(
+               "#collab_space_config_form #section_resource_collab_space_config_0_anonymous_posting"
+             )
              |> render() =~ "checked"
 
       assert view
-             |> element("#section_resource_collab_space_config_0_participation_min_replies")
+             |> element(
+               "#collab_space_config_form #section_resource_collab_space_config_0_participation_min_replies"
+             )
              |> render() =~ "0"
 
       assert view
-             |> element("#section_resource_collab_space_config_0_participation_min_posts")
+             |> element(
+               "#collab_space_config_form #section_resource_collab_space_config_0_participation_min_posts"
+             )
              |> render() =~ "0"
     end
 
@@ -515,19 +527,27 @@ defmodule OliWeb.CollaborationLiveTest do
       })
 
       refute view
-             |> element("#section_resource_collab_space_config_0_threaded")
+             |> element(
+               "#collab_space_config_form #section_resource_collab_space_config_0_threaded"
+             )
              |> render() =~ "checked"
 
       refute view
-             |> element("#section_resource_collab_space_config_0_auto_accept")
+             |> element(
+               "#collab_space_config_form #section_resource_collab_space_config_0_auto_accept"
+             )
              |> render() =~ "checked"
 
       refute view
-             |> element("#section_resource_collab_space_config_0_anonymous_posting")
+             |> element(
+               "#collab_space_config_form #section_resource_collab_space_config_0_anonymous_posting"
+             )
              |> render() =~ "checked"
 
       assert view
-             |> element("#section_resource_collab_space_config_0_participation_min_replies")
+             |> element(
+               "#collab_space_config_form #section_resource_collab_space_config_0_participation_min_replies"
+             )
              |> render() =~ "2"
 
       assert_receive {
@@ -566,11 +586,15 @@ defmodule OliWeb.CollaborationLiveTest do
       })
 
       refute view
-             |> element("#section_resource_collab_space_config_0_participation_min_replies")
+             |> element(
+               "#collab_space_config_form #section_resource_collab_space_config_0_participation_min_replies"
+             )
              |> render() =~ "-1"
 
       assert view
-             |> element("#section_resource_collab_space_config_0_participation_min_replies")
+             |> element(
+               "#collab_space_config_form #section_resource_collab_space_config_0_participation_min_replies"
+             )
              |> render() =~ "0"
 
       refute_receive {:updated_collab_space_config, _}
@@ -668,23 +692,39 @@ defmodule OliWeb.CollaborationLiveTest do
       assert has_element?(view, "h3", "Collaborative Space Config")
       assert has_element?(view, "span", "Enabled")
 
-      assert view |> element("#revision_collab_space_config_0_threaded") |> render() =~ "checked"
+      assert view
+             |> element("#collab_space_config_form #revision_collab_space_config_0_threaded")
+             |> render() =~ "checked"
 
-      assert view |> element("#revision_collab_space_config_0_auto_accept") |> render() =~
-               "checked"
-
-      assert view |> element("#revision_collab_space_config_0_show_full_history") |> render() =~
-               "checked"
-
-      assert view |> element("#revision_collab_space_config_0_anonymous_posting") |> render() =~
+      assert view
+             |> element("#collab_space_config_form #revision_collab_space_config_0_auto_accept")
+             |> render() =~
                "checked"
 
       assert view
-             |> element("#revision_collab_space_config_0_participation_min_replies")
+             |> element(
+               "#collab_space_config_form #revision_collab_space_config_0_show_full_history"
+             )
+             |> render() =~
+               "checked"
+
+      assert view
+             |> element(
+               "#collab_space_config_form #revision_collab_space_config_0_anonymous_posting"
+             )
+             |> render() =~
+               "checked"
+
+      assert view
+             |> element(
+               "#collab_space_config_form #revision_collab_space_config_0_participation_min_replies"
+             )
              |> render() =~ "0"
 
       assert view
-             |> element("#revision_collab_space_config_0_participation_min_posts")
+             |> element(
+               "#collab_space_config_form #revision_collab_space_config_0_participation_min_posts"
+             )
              |> render() =~
                "0"
     end
@@ -720,16 +760,26 @@ defmodule OliWeb.CollaborationLiveTest do
         }
       })
 
-      refute view |> element("#revision_collab_space_config_0_threaded") |> render() =~ "checked"
+      refute view
+             |> element("#collab_space_config_form #revision_collab_space_config_0_threaded")
+             |> render() =~ "checked"
 
-      refute view |> element("#revision_collab_space_config_0_auto_accept") |> render() =~
+      refute view
+             |> element("#collab_space_config_form #revision_collab_space_config_0_auto_accept")
+             |> render() =~
                "checked"
 
-      refute view |> element("#revision_collab_space_config_0_anonymous_posting") |> render() =~
+      refute view
+             |> element(
+               "#collab_space_config_form #revision_collab_space_config_0_anonymous_posting"
+             )
+             |> render() =~
                "checked"
 
       assert view
-             |> element("#revision_collab_space_config_0_participation_min_replies")
+             |> element(
+               "#collab_space_config_form #revision_collab_space_config_0_participation_min_replies"
+             )
              |> render() =~ "2"
     end
 
@@ -756,11 +806,15 @@ defmodule OliWeb.CollaborationLiveTest do
       |> render_submit(%{revision: %{collab_space_config: %{participation_min_replies: -1}}})
 
       refute view
-             |> element("#revision_collab_space_config_0_participation_min_replies")
+             |> element(
+               "#collab_space_config_form #revision_collab_space_config_0_participation_min_replies"
+             )
              |> render() =~ "-1"
 
       assert view
-             |> element("#revision_collab_space_config_0_participation_min_replies")
+             |> element(
+               "#collab_space_config_form #revision_collab_space_config_0_participation_min_replies"
+             )
              |> render() =~ "0"
     end
   end

--- a/test/oli_web/live/collaboration_live_test.exs
+++ b/test/oli_web/live/collaboration_live_test.exs
@@ -599,6 +599,97 @@ defmodule OliWeb.CollaborationLiveTest do
 
       refute_receive {:updated_collab_space_config, _}
     end
+
+    test "can enable Collab spaces for all pages in course", %{
+      conn: conn,
+      instructor: instructor,
+      section: section,
+      page_revision_cs: page_revision_cs
+    } do
+      {:ok, view, _html} =
+        live_isolated(
+          conn,
+          CollabSpaceConfigView,
+          session: %{
+            "current_user_id" => instructor.id,
+            "collab_space_config" => page_revision_cs.collab_space_config,
+            "section_slug" => section.slug,
+            "is_delivery" => true,
+            "resource_slug" => page_revision_cs.slug,
+            "is_overview_render" => true
+          }
+        )
+
+      assert element(view, "h5[role='collab_space_page_summary']")
+             |> render() =~ "1 page currently has Collaborative Spaces enabled"
+
+      # can not trigger a JS command from a test to show the confirmation modal (hidden to the user),
+      # so we directly submit the form in the modal
+      element(view, ~s{form[phx-submit="enable_all_page_collab_spaces"]})
+      |> render_submit(%{
+        section_resource: %{
+          collab_space_config: %{
+            anonymous_posting: false,
+            auto_accept: true,
+            participation_min_posts: 0,
+            participation_min_replies: 0,
+            show_full_history: true,
+            status: :enabled,
+            threaded: true
+          }
+        }
+      })
+
+      assert element(view, "h5[role='collab_space_page_summary']")
+             |> render() =~ "All 2 pages currently have Collaborative Spaces enabled"
+
+      # enable all pages button is disabled
+      assert has_element?(
+               view,
+               "button[disabled=disabled]",
+               "Enable Collaboration Spaces for all pages in the course"
+             )
+    end
+
+    test "can disable Collab spaces for all pages in course", %{
+      conn: conn,
+      instructor: instructor,
+      section: section,
+      page_revision_cs: page_revision_cs
+    } do
+      {:ok, view, _html} =
+        live_isolated(
+          conn,
+          CollabSpaceConfigView,
+          session: %{
+            "current_user_id" => instructor.id,
+            "collab_space_config" => page_revision_cs.collab_space_config,
+            "section_slug" => section.slug,
+            "is_delivery" => true,
+            "resource_slug" => page_revision_cs.slug,
+            "is_overview_render" => true
+          }
+        )
+
+      assert element(view, "h5[role='collab_space_page_summary']")
+             |> render() =~ "1 page currently has Collaborative Spaces enabled"
+
+      # can not trigger a JS command from a test to show the confirmation modal (hidden to the user),
+      # so we directly confirm the modal
+      view
+      |> element(~s{div[id="disable_collab_space_modal"] button}, "OK")
+      |> render_click()
+
+      assert element(view, "h5[role='collab_space_page_summary']")
+             |> render() =~ "0 pages currently have Collaborative Spaces enabled"
+
+      # disable all pages button is disabled
+      assert has_element?(
+               view,
+               "button[disabled=disabled]",
+               "Disable Collaboration Spaces for all pages in the course"
+             )
+    end
   end
 
   describe "admin - collab space config view" do
@@ -816,6 +907,97 @@ defmodule OliWeb.CollaborationLiveTest do
                "#collab_space_config_form #revision_collab_space_config_0_participation_min_replies"
              )
              |> render() =~ "0"
+    end
+
+    test "can enable Collab spaces for all pages in course", %{
+      conn: conn,
+      author: author,
+      project: project,
+      page_revision_cs: page_revision_cs
+    } do
+      {:ok, view, _html} =
+        live_isolated(
+          conn,
+          CollabSpaceConfigView,
+          session: %{
+            "current_user_id" => author.id,
+            "collab_space_config" => page_revision_cs.collab_space_config,
+            "project_slug" => project.slug,
+            "is_delivery" => false,
+            "resource_slug" => page_revision_cs.slug,
+            "is_overview_render" => true
+          }
+        )
+
+      assert element(view, "h5[role='collab_space_page_summary']")
+             |> render() =~ "1 page currently has Collaborative Spaces enabled"
+
+      # can not trigger a JS command from a test to show the confirmation modal (hidden to the user),
+      # so we directly submit the form in the modal
+      element(view, ~s{form[phx-submit="enable_all_page_collab_spaces"]})
+      |> render_submit(%{
+        revision: %{
+          collab_space_config: %{
+            anonymous_posting: false,
+            auto_accept: true,
+            participation_min_posts: 0,
+            participation_min_replies: 0,
+            show_full_history: true,
+            status: :enabled,
+            threaded: true
+          }
+        }
+      })
+
+      assert element(view, "h5[role='collab_space_page_summary']")
+             |> render() =~ "All 2 pages currently have Collaborative Spaces enabled"
+
+      # enable all pages button is disabled
+      assert has_element?(
+               view,
+               "button[disabled=disabled]",
+               "Enable Collaboration Spaces for all pages in the course"
+             )
+    end
+
+    test "can disable Collab spaces for all pages in course", %{
+      conn: conn,
+      author: author,
+      project: project,
+      page_revision_cs: page_revision_cs
+    } do
+      {:ok, view, _html} =
+        live_isolated(
+          conn,
+          CollabSpaceConfigView,
+          session: %{
+            "current_user_id" => author.id,
+            "collab_space_config" => page_revision_cs.collab_space_config,
+            "project_slug" => project.slug,
+            "is_delivery" => false,
+            "resource_slug" => page_revision_cs.slug,
+            "is_overview_render" => true
+          }
+        )
+
+      assert element(view, "h5[role='collab_space_page_summary']")
+             |> render() =~ "1 page currently has Collaborative Spaces enabled"
+
+      # can not trigger a JS command from a test to show the confirmation modal (hidden to the user),
+      # so we directly confirm the modal
+      view
+      |> element(~s{div[id="disable_collab_space_modal"] button}, "OK")
+      |> render_click()
+
+      assert element(view, "h5[role='collab_space_page_summary']")
+             |> render() =~ "0 pages currently have Collaborative Spaces enabled"
+
+      # disable all pages button is disabled
+      assert has_element?(
+               view,
+               "button[disabled=disabled]",
+               "Disable Collaboration Spaces for all pages in the course"
+             )
     end
   end
 

--- a/test/oli_web/live/sections/overview_live_test.exs
+++ b/test/oli_web/live/sections/overview_live_test.exs
@@ -365,15 +365,6 @@ defmodule OliWeb.Sections.OverviewLiveTest do
       assert %Section{status: :active} = Sections.get_section!(section.id)
     end
 
-    test "renders Collaboration Space config correctly (when not enabled by authoring)", %{
-      conn: conn,
-      section: section
-    } do
-      {:ok, view, _html} = live(conn, live_view_overview_route(section.slug))
-      assert render(view) =~ "Collaborative Space"
-      assert render(view) =~ "Collaborative spaces are not enabled by the course project"
-    end
-
     test "renders Collaboration Space config correctly (when enabled by authoring)", %{
       conn: conn
     } do


### PR DESCRIPTION
Link to the ticket

### Enabling Student Course Portal Collaborative Space

https://github.com/Simon-Initiative/oli-torus/assets/74839302/b23600a1-1630-4f7b-af9f-ce0664482550

### Manually enabling one page collab space (to check the collab space count)

https://github.com/Simon-Initiative/oli-torus/assets/74839302/d596c1a2-53d7-438e-a410-c9bfd8287059

### Enabling Collab Spaces for all pages in the course
Note that the confirmation modal renders a form to provide the collab space configuration that will be bulk-applied to all pages.

https://github.com/Simon-Initiative/oli-torus/assets/74839302/616b14eb-6b10-4ada-9273-339e8d332a71


### Disabling Collab Spaces for all pages in the course

https://github.com/Simon-Initiative/oli-torus/assets/74839302/7bc6209b-fe67-4518-8143-583e2f81f2fc

