### PR TITLE
[BUGFIX] Sort attempts by date submitted

### DIFF
--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -400,7 +400,7 @@ defmodule OliWeb.PageDeliveryController do
     resource_attempts =
       Enum.filter(resource_attempts, fn r -> r.date_submitted != nil end)
       |> Enum.sort(fn r1, r2 ->
-        r1.date_submitted <= r2.date_submitted
+        DateTime.before?(r1.date_submitted, r2.date_submitted)
       end)
 
     {:ok, {previous, next, current}, _} = PreviousNextIndex.retrieve(section, page.resource_id)


### PR DESCRIPTION
This PR fixes the sorting of the submitted attempts by using `DateTime.before?/2` instead of directly comparing the two datetimes.

## Before
![Screenshot 2023-10-18 at 11 20 11](https://github.com/Simon-Initiative/oli-torus/assets/74839302/435248fb-ea56-4056-9442-81affb558977)

## After
![Screenshot 2023-10-18 at 11 25 01](https://github.com/Simon-Initiative/oli-torus/assets/74839302/2f4e4381-12c9-4c43-849c-9ba1a1b07821)
