### PR TITLE
[BUGFIX] [MER-2591] Update Canvas JSON for new integrations

### DIFF
--- a/lib/oli_web/controllers/lti_controller.ex
+++ b/lib/oli_web/controllers/lti_controller.ex
@@ -175,20 +175,12 @@ defmodule OliWeb.LtiController do
                 "placement" => "assignment_selection",
                 "message_type" => "LtiResourceLinkRequest"
               },
-              case Map.get(params, "course_navigation_default") do
-                "disabled" ->
-                  %{
-                    "default" => "disabled",
-                    "placement" => "course_navigation",
-                    "message_type" => "LtiResourceLinkRequest"
-                  }
-
-                _ ->
-                  %{
-                    "placement" => "course_navigation",
-                    "message_type" => "LtiResourceLinkRequest"
-                  }
-              end
+              %{
+                "placement" => "course_navigation",
+                "message_type" => "LtiResourceLinkRequest",
+                "default" => get_course_navigation_default(params),
+                "windowTarget" => "_blank"
+              }
               ## TODO: add support for more placement types in the future, possibly configurable by LMS admin
               # assignment_selection when we support deep linking
               # %{
@@ -231,6 +223,9 @@ defmodule OliWeb.LtiController do
     conn
     |> json(developer_key_config)
   end
+
+  defp get_course_navigation_default(%{"course_navigation_default" => "enabled"}), do: "enabled"
+  defp get_course_navigation_default(_params), do: "disabled"
 
   def jwks(conn, _params) do
     conn

--- a/test/oli_web/controllers/lti_controller_test.exs
+++ b/test/oli_web/controllers/lti_controller_test.exs
@@ -474,7 +474,12 @@ defmodule OliWeb.LtiControllerTest do
                  "message_type" => "LtiResourceLinkRequest",
                  "placement" => "assignment_selection"
                },
-               %{"message_type" => "LtiResourceLinkRequest", "placement" => "course_navigation"}
+               %{
+                 "message_type" => "LtiResourceLinkRequest",
+                 "placement" => "course_navigation",
+                 "default" => "disabled",
+                 "windowTarget" => "_blank"
+               }
              ]
 
       assert json_response(conn, 200) |> Map.get("public_jwk") |> Map.get("kid") ==
@@ -483,11 +488,11 @@ defmodule OliWeb.LtiControllerTest do
       assert json_response(conn, 200) |> Map.get("public_jwk") |> Map.get("n") == public_jwk["n"]
     end
 
-    test "returns developer key json with course navigation disabled", %{conn: conn} do
+    test "returns developer key json with course navigation enabled", %{conn: conn} do
       conn =
         get(
           conn,
-          Routes.lti_path(conn, :developer_key_json, course_navigation_default: "disabled")
+          Routes.lti_path(conn, :developer_key_json, course_navigation_default: "enabled")
         )
 
       %{"extensions" => [%{"settings" => %{"placements" => placements}} | _]} =
@@ -506,7 +511,8 @@ defmodule OliWeb.LtiControllerTest do
                %{
                  "message_type" => "LtiResourceLinkRequest",
                  "placement" => "course_navigation",
-                 "default" => "disabled"
+                 "default" => "enabled",
+                 "windowTarget" => "_blank"
                }
              ]
     end


### PR DESCRIPTION
[MER-2591](https://eliterate.atlassian.net/browse/MER-2591)

Addresses https://github.com/Simon-Initiative/oli-torus/issues/4169

Update JSON configuration on the `developer_key_json` LTI endpoint for Canvas:
1. Modify the Canvas JSON integration so OLI Torus does not appear in the navigation menu by default.
2. Ensure OLI Torus links always open in a new browser tab.


https://github.com/Simon-Initiative/oli-torus/assets/26532202/2c14ea0d-8cca-42ae-96d6-64facc8edd27



[MER-2591]: https://eliterate.atlassian.net/browse/MER-2591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ