### PR TITLE
[MER-2680] Allow product setting for receipt of major updates

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -2215,7 +2215,11 @@ defmodule Oli.Delivery.Sections do
 
             # Case 2: The course section is based on this project and was seeded from a product
             section.base_project_id == project_id and !is_nil(section.blueprint_id) ->
-              perform_update(:minor, section, project_id, new_publication, current_hierarchy)
+              if section.blueprint.apply_major_updates do
+                perform_update(:major, section, project_id, current_publication, new_publication)
+              else
+                perform_update(:minor, section, project_id, new_publication, current_hierarchy)
+              end
 
             # Case 3: The course section is a product based on this project
             section.base_project_id == project_id and section.type == :blueprint ->

--- a/lib/oli/delivery/sections/section.ex
+++ b/lib/oli/delivery/sections/section.ex
@@ -134,6 +134,9 @@ defmodule Oli.Delivery.Sections.Section do
       default: :done
     )
 
+    # Allow major project publications to be applied to course sections created from this product
+    field(:apply_major_updates, :boolean, default: false)
+
     timestamps(type: :utc_datetime)
   end
 
@@ -187,7 +190,8 @@ defmodule Oli.Delivery.Sections.Section do
       :class_days,
       :course_section_number,
       :preferred_scheduling_time,
-      :v25_migration
+      :v25_migration,
+      :apply_major_updates
     ])
     |> cast_embed(:customizations, required: false)
     |> validate_required([
@@ -198,7 +202,7 @@ defmodule Oli.Delivery.Sections.Section do
     ])
     |> validate_required_if([:amount], &requires_payment?/1)
     |> validate_required_if([:grace_period_days], &has_grace_period?/1)
-    |> validate_required_if([:publisher_id], &is_product?/1)
+    |> validate_required_if([:publisher_id, :apply_major_updates], &is_product?/1)
     |> foreign_key_constraint_if(:publisher_id, &is_product?/1)
     |> validate_positive_grace_period()
     |> Oli.Delivery.Utils.validate_positive_money(:amount)

--- a/lib/oli_web/live/products/details/content.ex
+++ b/lib/oli_web/live/products/details/content.ex
@@ -47,7 +47,7 @@ defmodule OliWeb.Products.Details.Content do
         <div class="col-span-12">
           <.form for={@changeset} phx-change={@save} class="d-flex">
             <div class="form-group">
-              <div class="form-row">
+              <div class="form-row my-3">
                 <div class="custom-control custom-switch pl-4">
                   <div class="form-check">
                     <.input
@@ -58,6 +58,21 @@ defmodule OliWeb.Products.Details.Content do
                     />
                     <p class="text-muted">
                       Enable students to see the curriculum's module and unit numbers
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div class="form-row my-3">
+                <div class="custom-control custom-switch pl-4">
+                  <div class="form-check">
+                    <.input
+                      type="checkbox"
+                      class="custom-control-input"
+                      field={@changeset[:apply_major_updates]}
+                      label="Apply major updates to course sections"
+                    />
+                    <p class="text-muted">
+                      Allow major project publications to be applied to course sections created from this product
                     </p>
                   </div>
                 </div>

--- a/priv/repo/migrations/20231023142303_add_apply_major_updates_to_sections.exs
+++ b/priv/repo/migrations/20231023142303_add_apply_major_updates_to_sections.exs
@@ -1,0 +1,9 @@
+defmodule Oli.Repo.Migrations.AddApplyMajorUpdatesToSections do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sections) do
+      add(:apply_major_updates, :boolean, default: false)
+    end
+  end
+end

--- a/test/oli/sections_test.exs
+++ b/test/oli/sections_test.exs
@@ -1056,7 +1056,7 @@ defmodule Oli.SectionsTest do
           section_tag: :section
         )
 
-      # one week agao
+      # one week ago
       one_week_ago = DateTime.utc_now() |> DateTime.add(-7, :day) |> DateTime.truncate(:second)
       a_day_later = DateTime.utc_now() |> DateTime.add(-6, :day) |> DateTime.truncate(:second)
 
@@ -1272,6 +1272,403 @@ defmodule Oli.SectionsTest do
         |> Repo.all()
 
       assert section_resources |> Enum.count() == 7
+    end
+
+    @tag capture_log: true
+    test "apply_publication_update/2 applies major changes to section based from product when apply_major_updates is true",
+         %{
+           author: author,
+           project: project,
+           container: %{resource: container_resource, revision: container_revision},
+           page1: page1,
+           revision1: revision1,
+           page2: page2,
+           revision2: revision2
+         } do
+      {:ok, _initial_pub} = Publishing.publish_project(project, "some changes")
+
+      seeds =
+        %{product: product} =
+        Oli.Utils.Seeder.Project.create_product(%{}, "Product 1", project, product_tag: :product)
+
+      Oli.Delivery.Sections.update_section(product, %{apply_major_updates: true})
+
+      %{section: section} =
+        Oli.Utils.Seeder.Section.create_section_from_product(
+          seeds,
+          ref(:product),
+          nil,
+          nil,
+          %{blueprint_id: product.id},
+          section_tag: :section
+        )
+
+      section = Repo.preload(section, :blueprint)
+      # one week ago
+      one_week_ago = DateTime.utc_now() |> DateTime.add(-7, :day) |> DateTime.truncate(:second)
+      a_day_later = DateTime.utc_now() |> DateTime.add(-6, :day) |> DateTime.truncate(:second)
+
+      # Simulate customizing assessment settings for page1
+      page1_sr = Oli.Delivery.Sections.get_section_resource(section.id, page1.id)
+
+      {:ok, _} =
+        Oli.Delivery.Sections.update_section_resource(page1_sr, %{
+          scoring_strategy_id: 2,
+          scheduling_type: :due_by,
+          manually_scheduled: true,
+          start_date: one_week_ago,
+          end_date: a_day_later,
+          collab_space_config: %Oli.Resources.Collaboration.CollabSpaceConfig{
+            status: :enabled,
+            threaded: false,
+            auto_accept: false,
+            show_full_history: false,
+            anonymous_posting: false,
+            participation_min_posts: 100,
+            participation_min_replies: 101
+          },
+          explanation_strategy: %Oli.Resources.ExplanationStrategy{
+            type: :after_set_num_attempts,
+            set_num_attempts: 10
+          },
+          max_attempts: 200,
+          retake_mode: :targeted,
+          # "I've got the same combination on my luggage"
+          password: "12345",
+          late_submit: :disallow,
+          late_start: :disallow,
+          time_limit: 90,
+          grace_period: 100,
+          review_submission: :disallow,
+          feedback_mode: :scheduled,
+          feedback_scheduled_date: a_day_later
+        })
+
+      # verify the curriculum precondition
+      hierarchy = DeliveryResolver.full_hierarchy(section.slug)
+
+      assert hierarchy.children |> Enum.count() == 2
+      assert hierarchy.children |> Enum.at(0) |> Map.get(:resource_id) == page1.id
+      assert hierarchy.children |> Enum.at(1) |> Map.get(:resource_id) == page2.id
+
+      # make some changes to project and publish
+      working_pub = Publishing.project_working_publication(project.slug)
+
+      # minor resource content changes
+      page1_changes = %{
+        "content" => %{
+          "model" => [
+            %{
+              "type" => "content",
+              "children" => [%{"type" => "p", "children" => [%{"text" => "SECOND"}]}]
+            }
+          ]
+        }
+      }
+
+      Seeder.revise_page(page1_changes, page1, revision1, working_pub)
+
+      # add some pages to the root container
+      %{resource: p1_new_page1, revision: _revision} =
+        Seeder.create_page("P1 New Page one", working_pub, project, author)
+
+      %{resource: p1_new_page2, revision: _revision} =
+        Seeder.create_page("P1 New Page two", working_pub, project, author)
+
+      container_revision =
+        Seeder.attach_pages_to(
+          [p1_new_page1, p1_new_page2],
+          container_resource,
+          container_revision,
+          working_pub
+        )
+
+      # create a unit
+      %{resource: unit1_resource, revision: unit1_revision} =
+        Seeder.create_container("Unit 1", working_pub, project, author)
+
+      # create some nested children
+      %{resource: nested_page1, revision: _nested_revision1} =
+        Seeder.create_page("Nested Page One", working_pub, project, author)
+
+      %{resource: nested_page2, revision: _nested_revision2} =
+        Seeder.create_page(
+          "Nested Page Two",
+          working_pub,
+          project,
+          author,
+          Seeder.create_sample_content()
+        )
+
+      _unit1_revision =
+        Seeder.attach_pages_to(
+          [nested_page1, nested_page2],
+          unit1_resource,
+          unit1_revision,
+          working_pub
+        )
+
+      container_revision =
+        Seeder.attach_pages_to(
+          [unit1_resource],
+          container_resource,
+          container_revision,
+          working_pub
+        )
+
+      # remove page 2
+      _deleted_revision =
+        Seeder.delete_page(page2, revision2, container_resource, container_revision, working_pub)
+
+      # publish changes
+      {:ok, latest_publication} = Publishing.publish_project(project, "some changes")
+
+      # apply the new publication update to the section
+      Sections.apply_publication_update(section, latest_publication.id)
+
+      # reload latest hierarchy
+      hierarchy = DeliveryResolver.full_hierarchy(section.slug)
+
+      # verify non-structural changes are applied as expected
+      assert hierarchy.children |> Enum.at(0) |> then(& &1.revision.content) ==
+               page1_changes["content"]
+
+      # verify the updated curriculum structure matches the expected result
+
+      assert hierarchy.children |> Enum.count() == 4
+      assert hierarchy.children |> Enum.at(0) |> Map.get(:resource_id) == page1.id
+      assert hierarchy.children |> Enum.at(1) |> Map.get(:resource_id) == p1_new_page1.id
+      assert hierarchy.children |> Enum.at(2) |> Map.get(:resource_id) == p1_new_page2.id
+      assert hierarchy.children |> Enum.at(3) |> Map.get(:resource_id) == unit1_resource.id
+
+      assert hierarchy.children |> Enum.at(3) |> Map.get(:children) |> Enum.count() == 2
+
+      assert hierarchy.children
+             |> Enum.at(3)
+             |> Map.get(:children)
+             |> Enum.at(0)
+             |> Map.get(:resource_id) == nested_page1.id
+
+      assert hierarchy.children
+             |> Enum.at(3)
+             |> Map.get(:children)
+             |> Enum.at(1)
+             |> Map.get(:resource_id) == nested_page2.id
+
+      # verify the assessment settings remain unchanged
+      page1_sr = Oli.Delivery.Sections.get_section_resource(section.id, page1.id)
+      assert page1_sr.scoring_strategy_id == 2
+      assert page1_sr.scheduling_type == :due_by
+      assert page1_sr.manually_scheduled == true
+      assert page1_sr.start_date == one_week_ago
+      assert page1_sr.end_date == a_day_later
+      assert page1_sr.collab_space_config.status == :enabled
+      assert page1_sr.collab_space_config.threaded == false
+      assert page1_sr.collab_space_config.auto_accept == false
+      assert page1_sr.collab_space_config.show_full_history == false
+      assert page1_sr.collab_space_config.anonymous_posting == false
+      assert page1_sr.collab_space_config.participation_min_posts == 100
+      assert page1_sr.collab_space_config.participation_min_replies == 101
+      assert page1_sr.explanation_strategy.type == :after_set_num_attempts
+      assert page1_sr.explanation_strategy.set_num_attempts == 10
+      assert page1_sr.max_attempts == 200
+      assert page1_sr.retake_mode == :targeted
+      assert page1_sr.password == "12345"
+      assert page1_sr.late_submit == :disallow
+      assert page1_sr.late_start == :disallow
+      assert page1_sr.time_limit == 90
+      assert page1_sr.grace_period == 100
+      assert page1_sr.review_submission == :disallow
+      assert page1_sr.feedback_mode == :scheduled
+      assert page1_sr.feedback_scheduled_date == a_day_later
+
+      # verify the final number of section resource records matches what is
+      # expected to guard against section resource record leaks
+      section_id = section.id
+
+      section_resources =
+        from(sr in SectionResource,
+          where: sr.section_id == ^section_id
+        )
+        |> Repo.all()
+
+      assert section_resources |> Enum.count() == 7
+    end
+
+    @tag capture_log: true
+    test "apply_publication_update/2 applies minor changes to section based from product when apply_major_updates is false",
+         %{
+           author: author,
+           project: project,
+           container: %{resource: container_resource, revision: container_revision},
+           page1: page1,
+           revision1: revision1,
+           page2: page2,
+           revision2: revision2
+         } do
+      {:ok, _initial_pub} = Publishing.publish_project(project, "some changes")
+
+      seeds =
+        %{product: product} =
+        Oli.Utils.Seeder.Project.create_product(%{}, "Product 1", project, product_tag: :product)
+
+      %{section: section} =
+        Oli.Utils.Seeder.Section.create_section_from_product(
+          seeds,
+          ref(:product),
+          nil,
+          nil,
+          %{apply_major_updates: false, blueprint_id: product.id},
+          section_tag: :section
+        )
+
+      section = Repo.preload(section, :blueprint)
+
+      # one week ago
+      one_week_ago = DateTime.utc_now() |> DateTime.add(-7, :day) |> DateTime.truncate(:second)
+      a_day_later = DateTime.utc_now() |> DateTime.add(-6, :day) |> DateTime.truncate(:second)
+
+      # Simulate customizing assessment settings for page1
+      page1_sr = Oli.Delivery.Sections.get_section_resource(section.id, page1.id)
+
+      {:ok, _} =
+        Oli.Delivery.Sections.update_section_resource(page1_sr, %{
+          scoring_strategy_id: 2,
+          scheduling_type: :due_by,
+          manually_scheduled: true,
+          start_date: one_week_ago,
+          end_date: a_day_later,
+          collab_space_config: %Oli.Resources.Collaboration.CollabSpaceConfig{
+            status: :enabled,
+            threaded: false,
+            auto_accept: false,
+            show_full_history: false,
+            anonymous_posting: false,
+            participation_min_posts: 100,
+            participation_min_replies: 101
+          },
+          explanation_strategy: %Oli.Resources.ExplanationStrategy{
+            type: :after_set_num_attempts,
+            set_num_attempts: 10
+          },
+          max_attempts: 200,
+          retake_mode: :targeted,
+          # "I've got the same combination on my luggage"
+          password: "12345",
+          late_submit: :disallow,
+          late_start: :disallow,
+          time_limit: 90,
+          grace_period: 100,
+          review_submission: :disallow,
+          feedback_mode: :scheduled,
+          feedback_scheduled_date: a_day_later
+        })
+
+      # verify the curriculum precondition
+      hierarchy = DeliveryResolver.full_hierarchy(section.slug)
+
+      assert hierarchy.children |> Enum.count() == 2
+      assert hierarchy.children |> Enum.at(0) |> Map.get(:resource_id) == page1.id
+      assert hierarchy.children |> Enum.at(1) |> Map.get(:resource_id) == page2.id
+
+      # make some changes to project and publish
+      working_pub = Publishing.project_working_publication(project.slug)
+
+      # minor resource content changes
+      page1_changes = %{
+        "content" => %{
+          "model" => [
+            %{
+              "type" => "content",
+              "children" => [%{"type" => "p", "children" => [%{"text" => "SECOND"}]}]
+            }
+          ]
+        }
+      }
+
+      Seeder.revise_page(page1_changes, page1, revision1, working_pub)
+
+      # add some pages to the root container
+      %{resource: p1_new_page1, revision: _revision} =
+        Seeder.create_page("P1 New Page one", working_pub, project, author)
+
+      %{resource: p1_new_page2, revision: _revision} =
+        Seeder.create_page("P1 New Page two", working_pub, project, author)
+
+      container_revision =
+        Seeder.attach_pages_to(
+          [p1_new_page1, p1_new_page2],
+          container_resource,
+          container_revision,
+          working_pub
+        )
+
+      # create a unit
+      %{resource: unit1_resource, revision: unit1_revision} =
+        Seeder.create_container("Unit 1", working_pub, project, author)
+
+      # create some nested children
+      %{resource: nested_page1, revision: _nested_revision1} =
+        Seeder.create_page("Nested Page One", working_pub, project, author)
+
+      %{resource: nested_page2, revision: _nested_revision2} =
+        Seeder.create_page(
+          "Nested Page Two",
+          working_pub,
+          project,
+          author,
+          Seeder.create_sample_content()
+        )
+
+      _unit1_revision =
+        Seeder.attach_pages_to(
+          [nested_page1, nested_page2],
+          unit1_resource,
+          unit1_revision,
+          working_pub
+        )
+
+      container_revision =
+        Seeder.attach_pages_to(
+          [unit1_resource],
+          container_resource,
+          container_revision,
+          working_pub
+        )
+
+      # remove page 2
+      _deleted_revision =
+        Seeder.delete_page(page2, revision2, container_resource, container_revision, working_pub)
+
+      # publish changes
+      {:ok, latest_publication} = Publishing.publish_project(project, "some changes")
+
+      # apply the new publication update to the section
+      Sections.apply_publication_update(section, latest_publication.id)
+
+      # reload latest hierarchy
+      section_hierarchy = DeliveryResolver.full_hierarchy(section.slug)
+
+      # verify non-structural changes are applied as expected
+      assert section_hierarchy.children |> Enum.at(0) |> then(& &1.revision.content) ==
+               page1_changes["content"]
+
+      # verify structural changes are not applied to section
+      assert section_hierarchy.children |> Enum.count() == 2
+      assert section_hierarchy.children |> Enum.at(0) |> Map.get(:resource_id) == page1.id
+      assert section_hierarchy.children |> Enum.at(1) |> Map.get(:resource_id) == page2.id
+
+      # verify the final number of section resource records matches what is
+      # expected to guard against section resource record leaks
+      section_id = section.id
+
+      section_resources =
+        from(sr in SectionResource,
+          where: sr.section_id == ^section_id
+        )
+        |> Repo.all()
+
+      assert Enum.count(section_resources) == 3
     end
   end
 

--- a/test/oli_web/live/products_test.exs
+++ b/test/oli_web/live/products_test.exs
@@ -50,6 +50,27 @@ defmodule OliWeb.ProductsLiveTest do
              |> element("#section_display_curriculum_item_numbering")
              |> render() =~ "checked"
     end
+
+    test "save event updates apply_major_updates", %{conn: conn, product: product} do
+      {:ok, view, _html} = live(conn, live_view_details_route(product.slug))
+
+      refute view
+             |> element("#section_apply_major_updates")
+             |> render() =~ "checked"
+
+      view
+      |> element("#content-form form[phx-change=\"save\"")
+      |> render_change(%{
+        "section" => %{"apply_major_updates" => "true"}
+      })
+
+      updated_section = Sections.get_section!(product.id)
+      assert updated_section.apply_major_updates
+
+      assert view
+             |> element("#section_display_curriculum_item_numbering")
+             |> render() =~ "checked"
+    end
   end
 
   describe "browse all products" do


### PR DESCRIPTION
[MER-2680](https://eliterate.atlassian.net/browse/MER-2680)

Add a new `apply_major_updates` field to sections that can be toggled from the Products Overview page, and controls how updates are applied to a course section created from a Product. 

https://github.com/Simon-Initiative/oli-torus/assets/26532202/46771284-3969-4d61-9e0c-f8e13baac3f8



[MER-2680]: https://eliterate.atlassian.net/browse/MER-2680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ