### PR TITLE
[CHORE] add try rescue around extension

### DIFF
--- a/lib/oli_web/components/delivery/instructor_dashboard.ex
+++ b/lib/oli_web/components/delivery/instructor_dashboard.ex
@@ -203,7 +203,7 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard do
           <%= if @preview_mode do %>
             <UserAccountMenu.preview_user />
           <% else %>
-            <UserAccountMenu.menu ctx={@ctx} section={@section} />
+            <UserAccountMenu.menu id="user-account-menu" ctx={@ctx} section={@section} />
           <% end %>
         </div>
 

--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -59,7 +59,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
       </div>
       <div class="p-2">
         <div class="hidden md:block">
-          <UserAccountMenu.menu ctx={@ctx} section={@section} />
+          <UserAccountMenu.menu id="user-account-menu" ctx={@ctx} section={@section} />
         </div>
         <button
           class="block md:hidden py-1.5 px-3 rounded border border-transparent hover:border-gray-300 active:bg-gray-100"
@@ -146,7 +146,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
         </div>
 
         <div class="px-6 py-4">
-          <UserAccountMenu.menu ctx={@ctx} section={@section} />
+          <UserAccountMenu.menu id="user-account-menu-sidebar" ctx={@ctx} section={@section} />
         </div>
       </div>
     </nav>

--- a/lib/oli_web/components/delivery/user_account_menu.ex
+++ b/lib/oli_web/components/delivery/user_account_menu.ex
@@ -10,6 +10,7 @@ defmodule OliWeb.Components.Delivery.UserAccountMenu do
   alias OliWeb.Common.SessionContext
   alias OliWeb.Common.React
 
+  attr(:id, :string, required: true)
   attr(:ctx, SessionContext)
   attr(:section, Section, default: nil)
 
@@ -28,7 +29,7 @@ defmodule OliWeb.Components.Delivery.UserAccountMenu do
         selectedTimezone: @selected_timezone,
         timezones: @timezones
       },
-      id: "menu"
+      id: @id
     ) %>
     """
   end

--- a/lib/oli_web/components/header.ex
+++ b/lib/oli_web/components/header.ex
@@ -74,7 +74,7 @@ defmodule OliWeb.Components.Header do
             </div>
           <% user_signed_in?(assigns) -> %>
             <div class="max-w-[400px]">
-              <UserAccountMenu.menu ctx={@ctx} />
+              <UserAccountMenu.menu id="user-account-menu" ctx={@ctx} />
             </div>
           <% true -> %>
             <%= link("Learner/Educator Sign In",

--- a/lib/oli_web/live/delivery/student_dashboard/components/helpers.ex
+++ b/lib/oli_web/live/delivery/student_dashboard/components/helpers.ex
@@ -152,7 +152,7 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.Helpers do
         <%= if @preview_mode do %>
           <UserAccountMenu.preview_user />
         <% else %>
-          <UserAccountMenu.menu ctx={@ctx} />
+          <UserAccountMenu.menu id="user-account-menu" ctx={@ctx} />
         <% end %>
         <div class="flex items-center border-l border-slate-300">
           <button

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -926,7 +926,6 @@ defmodule OliWeb.Router do
 
   ### NextGen23 Student Course Delivery
   scope "/ng23/sections/:section_slug", OliWeb do
-    # TODO: Do we need all these pipeline steps?
     pipe_through([
       :browser,
       :delivery,

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -929,19 +929,12 @@ defmodule OliWeb.Router do
     # TODO: Do we need all these pipeline steps?
     pipe_through([
       :browser,
-      :require_section,
       :delivery,
-      :require_exploration_pages,
-      :delivery_preview,
-      :delivery_protected,
-      :maybe_gated_resource,
-      :enforce_enroll_and_paywall,
-      :ensure_user_section_visit,
-      :force_required_survey,
-      :pow_email_layout
+      :delivery_and_admin
     ])
 
     live_session :delivery,
+      root_layout: {OliWeb.LayoutView, :delivery},
       on_mount: [
         OliWeb.LiveSessionPlugs.SetSection,
         OliWeb.LiveSessionPlugs.SetCurrentUser,

--- a/priv/repo/migrations/20231010144119_add_prompt_templates.exs
+++ b/priv/repo/migrations/20231010144119_add_prompt_templates.exs
@@ -25,14 +25,10 @@ defmodule Oli.Repo.Migrations.AddPromptTemplates do
   """
 
   def up do
-    try do
-      execute "CREATE EXTENSION IF NOT EXISTS vector"
-    catch
-      _ ->
-        IO.puts("Could not create extension vector. You may need to install it manually.")
-    end
+    # NOTE: This extension requires su privs on RDS and therefore must be run manually
+    # execute "CREATE EXTENSION IF NOT EXISTS vector"
 
-    flush()
+    # flush()
 
     alter table(:sections) do
       add(:page_prompt_template, :text, default: @page_prompt)
@@ -60,11 +56,6 @@ defmodule Oli.Repo.Migrations.AddPromptTemplates do
       remove(:page_prompt_template)
     end
 
-    try do
-      execute "DROP EXTENSION vector"
-    catch
-      _ ->
-        IO.puts("Could not drop extension vector. You may need to uninstall it manually.")
-    end
+    # execute "DROP EXTENSION vector"
   end
 end

--- a/priv/repo/migrations/20231010144119_add_prompt_templates.exs
+++ b/priv/repo/migrations/20231010144119_add_prompt_templates.exs
@@ -25,7 +25,6 @@ defmodule Oli.Repo.Migrations.AddPromptTemplates do
   """
 
   def up do
-    # NOTE: vector extension needs to be enabled in database
     try do
       execute "CREATE EXTENSION IF NOT EXISTS vector"
     catch

--- a/priv/repo/migrations/20231010144119_add_prompt_templates.exs
+++ b/priv/repo/migrations/20231010144119_add_prompt_templates.exs
@@ -25,7 +25,12 @@ defmodule Oli.Repo.Migrations.AddPromptTemplates do
   """
 
   def up do
-    execute "CREATE EXTENSION IF NOT EXISTS vector"
+    try do
+      execute "CREATE EXTENSION IF NOT EXISTS vector"
+    rescue
+      _ ->
+        IO.puts("Could not create extension vector. You may need to install it manually.")
+    end
 
     flush()
 
@@ -55,6 +60,11 @@ defmodule Oli.Repo.Migrations.AddPromptTemplates do
       remove(:page_prompt_template)
     end
 
-    execute "DROP EXTENSION vector"
+    try do
+      execute "DROP EXTENSION vector"
+    rescue
+      _ ->
+        IO.puts("Could not drop extension vector. You may need to uninstall it manually.")
+    end
   end
 end

--- a/priv/repo/migrations/20231010144119_add_prompt_templates.exs
+++ b/priv/repo/migrations/20231010144119_add_prompt_templates.exs
@@ -25,9 +25,10 @@ defmodule Oli.Repo.Migrations.AddPromptTemplates do
   """
 
   def up do
+    # NOTE: vector extension needs to be enabled in database
     try do
       execute "CREATE EXTENSION IF NOT EXISTS vector"
-    rescue
+    catch
       _ ->
         IO.puts("Could not create extension vector. You may need to install it manually.")
     end
@@ -62,7 +63,7 @@ defmodule Oli.Repo.Migrations.AddPromptTemplates do
 
     try do
       execute "DROP EXTENSION vector"
-    rescue
+    catch
       _ ->
         IO.puts("Could not drop extension vector. You may need to uninstall it manually.")
     end


### PR DESCRIPTION
Deploying to stellarator indicated that the DB application user does not have sufficient privileges in RDS to enable certain extensions so this must be enabled manually by a super user. This PR removes the `CREATE EXTENSION vector` SQL statement from the migration so that when RDS blocks this call the entire migration does not fail. We will have to add this to the list of manual steps required for `nextgen-ux` when deploying.

This statement must be run manually by a database superuser:
```
execute "CREATE EXTENSION IF NOT EXISTS vector"
```

I also uncovered an issue trying to access the new `/ng23/...` route related to sessions. There were a bunch of unnecessary plugs being invoked and so I pared this down to only the minimum required ones, using the LiveSessionPlugs to dictate all required assigns etc...

Finally there was an issue with the UserAccountMenu phoenix-react component being rendered twice with the same id. I fix that issue here as well.