### PR TITLE
[BUGFIX][MER-2619] Fix registration changeset function to trim editable fields

### DIFF
--- a/lib/oli/lti/registration.ex
+++ b/lib/oli/lti/registration.ex
@@ -1,6 +1,7 @@
 defmodule Oli.Lti.Tool.Registration do
   use Ecto.Schema
   import Ecto.Changeset
+  import Oli.Utils, only: [update_changes: 3]
 
   schema "lti_1p3_registrations" do
     field(:issuer, :string)
@@ -43,5 +44,20 @@ defmodule Oli.Lti.Tool.Registration do
       :auth_server,
       :tool_jwk_id
     ])
+    |> update_changes(
+      [
+        :issuer,
+        :client_id,
+        :key_set_url,
+        :auth_token_url,
+        :auth_login_url,
+        :auth_server,
+        :line_items_service_domain
+      ],
+      &maybe_trim/1
+    )
   end
+
+  defp maybe_trim(value) when is_binary(value) and not is_nil(value), do: String.trim(value)
+  defp maybe_trim(value), do: value
 end

--- a/lib/oli/utils.ex
+++ b/lib/oli/utils.ex
@@ -254,6 +254,35 @@ defmodule Oli.Utils do
     end)
   end
 
+  @doc """
+  Updates specific fields in a given Ecto changeset using a provided function.
+
+  ## Parameters:
+
+  - `changeset`: An Ecto.Changeset that contains the changes we want to apply to.
+  - `fields`: A list of fields (atoms) that we want to update within the changeset.
+  - `fun`: A function that will be applied to the current value of each specified field in the changeset. This function should accept the current value of the field and return the new value.
+
+  ## Returns:
+
+  - A new Ecto.Changeset with the specified fields updated based on the provided function.
+
+  ## Example:
+
+  Suppose you have a changeset for a User schema and you want to update the fields `:first_name` and `:last_name` to be in uppercase:
+
+      changeset = %Ecto.Changeset{data: %User{first_name: "john", last_name: "doe"}}
+      updated_changeset = update_changes(changeset, [:first_name, :last_name], &String.upcase/1)
+
+  The `updated_changeset` will now contain the values "JOHN" for `:first_name` and "DOE" for `:last_name`.
+
+  """
+  def update_changes(changeset, fields, fun) do
+    Enum.reduce(fields, changeset, fn field, changeset ->
+      Ecto.Changeset.update_change(changeset, field, fun)
+    end)
+  end
+
   @spec read_json_file(
           binary
           | maybe_improper_list(

--- a/test/oli/institutions_test.exs
+++ b/test/oli/institutions_test.exs
@@ -186,6 +186,27 @@ defmodule Oli.InstitutionsTest do
       assert registration.line_items_service_domain == "some updated line_items_service_domain"
     end
 
+    test "update_registration/2 with non-normalized data removes extra whitespaces and updates the registration",
+         %{
+           registration: registration
+         } do
+      non_normalized_attrs =
+        @update_attrs
+        |> Enum.map(fn {k, v} -> {k, "  #{v}  "} end)
+        |> Enum.into(%{})
+
+      assert {:ok, %Registration{} = registration} =
+               Institutions.update_registration(registration, non_normalized_attrs)
+
+      assert registration.auth_login_url == "some updated auth_login_url"
+      assert registration.auth_server == "some updated auth_server"
+      assert registration.auth_token_url == "some updated auth_token_url"
+      assert registration.client_id == "some updated client_id"
+      assert registration.issuer == "some updated issuer"
+      assert registration.key_set_url == "some updated key_set_url"
+      assert registration.line_items_service_domain == "some updated line_items_service_domain"
+    end
+
     test "update_registration/2 with invalid data returns error changeset", %{
       registration: registration
     } do


### PR DESCRIPTION
[MER-2619](https://eliterate.atlassian.net/browse/MER-2619)

Trim registration fields on edit.

**Before changes:**

https://github.com/Simon-Initiative/oli-torus/assets/26532202/e721f1d8-8b84-4b8a-a7eb-915395ed747a



**After changes:**

https://github.com/Simon-Initiative/oli-torus/assets/26532202/45f99f0d-4f47-4845-8294-525fce4c8414



[MER-2619]: https://eliterate.atlassian.net/browse/MER-2619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ