### PR TITLE
[Bugfix] editor lockup [MER-2682]

### DIFF
--- a/assets/src/components/activities/AuthoringElementProvider.tsx
+++ b/assets/src/components/activities/AuthoringElementProvider.tsx
@@ -42,7 +42,7 @@ export const AuthoringElementProvider: React.FC<AuthoringElementProps<ActivityMo
     causing previous updates to be undone.
 
     ie: these were not the same value when called:
-      model.authoring.parts[0].responses[0].feedback
+                  model.authoring.parts[0].responses[0].feedback
       modelRef.current?.authoring.parts[0].responses[0].feedback
     */
     const newModel = produce(modelRef.current, (draftState) => action(draftState, onPostUndoable));

--- a/assets/src/data/activities/model/responses.ts
+++ b/assets/src/data/activities/model/responses.ts
@@ -37,7 +37,6 @@ export const RESPONSES_PATH = '$..responses';
 export const getResponses = (model: HasParts): Response[] =>
   model.authoring.parts.map((p) => p.responses).flat();
 
-
 export const getResponsesByPartId = (model: HasParts, partId: string): Response[] =>
   getPartById(model, partId).responses;
 

--- a/assets/src/data/activities/model/responses.ts
+++ b/assets/src/data/activities/model/responses.ts
@@ -35,8 +35,9 @@ export const Responses = {
 };
 
 export const RESPONSES_PATH = '$..responses';
-export const getResponses = (model: HasParts, path = RESPONSES_PATH): Response[] =>
-  Operations.apply(model, Operations.find(path));
+export const getResponses = (model: HasParts): Response[] =>
+  model.authoring.parts.map((p) => p.responses).flat();
+
 
 export const getResponsesByPartId = (model: HasParts, partId: string): Response[] =>
   getPartById(model, partId).responses;

--- a/assets/src/data/activities/model/responses.ts
+++ b/assets/src/data/activities/model/responses.ts
@@ -8,7 +8,6 @@ import {
 } from 'components/activities/types';
 import { containsRule, eqRule, equalsRule, matchRule } from 'data/activities/model/rules';
 import { getByUnsafe, getPartById } from 'data/activities/model/utils';
-import { Operations } from 'utils/pathOperations';
 
 export const Responses = {
   catchAll: (text = 'Incorrect') => makeResponse(matchRule('.*'), 0, text),


### PR DESCRIPTION
This bug was intermittent and presented in different ways. The most reliable way I was able to get it to occur:

1. Add an MCQ to a basic page
2. Go to the answer key
3. Start a metronome @ 62BPM
4. Every beat, type 4 or 5 characters by quickly rolling across the keyboard.

Usually, around beat 15, you will get a console error message

```
{
    "name": "AssertionError",
    "actual": false,
    "expected": true,
    "operator": "==",
    "message": "obj needs to be an object",
    "generatedMessage": false
}
```

At this point, the application would still be functioning correctly.

After another 10 or so beats of typing, you would start getting that error every single keypress. It's at this point that the editor became unresponsive.

The error occurs in the internals of jsonpath called from responses.ts around line 39.  A very odd thing with this bug, is if you caught the error, and then retried the operation, the retry would work just fine.

```
try {
            return jp.query(json, op.path).reduce((acc, result) => acc.concat(result), []);
    } catch (e) {
      // Same operation that just failed, but it succeeds.
      console.info(jp.query(json, op.path).reduce((acc, result) => acc.concat(result), []));
    }
```

This cause of the bug is still a mystery to me, after two days of investigating, I was not able to come up with a satisfactory answer. My hunch is it has to do with the immer temporary objects, and how jsonpath recursively traverses them. Since it seems timing-dependent and OS-dependent, it may have something to do with the garbage collector.

The fix applied here replaces the jsonpath call with a simpler pure JS expression. The original implementation would handle more cases, but upon examining our actual activities, none of them required the additional functionality. After applying this change, I can no longer reproduce the error state.

