### PR TITLE
[BUG FIX] Restore progress setting

### DIFF
--- a/lib/oli/delivery/attempts/page_lifecycle/graded.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/graded.ex
@@ -148,6 +148,9 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Graded do
                  resource_attempt.was_late
                ) do
             {:ok, resource_access} ->
+
+              {:ok, resource_access} = Oli.Delivery.Metrics.mark_progress_completed(resource_access)
+
               {:ok,
                %FinalizationSummary{
                  graded: true,


### PR DESCRIPTION
Adds back in the call to `mark_progress_completed` which got removed as part of hotfix v0.25.1

This was causing graded pages which roll up to be `:evaluated` to not have their progress set to 100%