### PR TITLE
[Bugfix] activity editor crash [MER-2689]

### DIFF
--- a/assets/src/components/editing/editor/Editor.tsx
+++ b/assets/src/components/editing/editor/Editor.tsx
@@ -143,7 +143,11 @@ export const Editor: React.FC<EditorProps> = React.memo((props: EditorProps) => 
 
   return (
     <React.Fragment>
-      <Slate editor={editor} initialValue={validateEditorContentValue(props.value)} onChange={onChange}>
+      <Slate
+        editor={editor}
+        initialValue={validateEditorContentValue(props.value)}
+        onChange={onChange}
+      >
         {props.children}
 
         <EditorToolbar

--- a/assets/src/components/editing/editor/Editor.tsx
+++ b/assets/src/components/editing/editor/Editor.tsx
@@ -61,6 +61,21 @@ function areEqual(prevProps: EditorProps, nextProps: EditorProps) {
   );
 }
 
+const defaultValue = () => [Model.p()];
+export const validateEditorContentValue = (value: any): Descendant[] => {
+  if (!value) {
+    return defaultValue();
+  }
+  if (!Array.isArray(value) && Array.isArray(value.model)) {
+    // MER-2689 - Some content had an extra model property that was the array of elements.
+    return value.model;
+  }
+  if (!Array.isArray(value) || value.length === 0) {
+    return defaultValue();
+  }
+  return value;
+};
+
 export const Editor: React.FC<EditorProps> = React.memo((props: EditorProps) => {
   const editor = useMemo(() => {
     if (props.editorOverride) {
@@ -128,11 +143,7 @@ export const Editor: React.FC<EditorProps> = React.memo((props: EditorProps) => 
 
   return (
     <React.Fragment>
-      <Slate
-        editor={editor}
-        initialValue={props.value.length === 0 ? [Model.p()] : props.value}
-        onChange={onChange}
-      >
+      <Slate editor={editor} initialValue={validateEditorContentValue(props.value)} onChange={onChange}>
         {props.children}
 
         <EditorToolbar

--- a/assets/test/editor/validate_editor_content_test.ts
+++ b/assets/test/editor/validate_editor_content_test.ts
@@ -1,0 +1,36 @@
+import { validateEditorContentValue } from 'components/editing/editor/Editor';
+import { Model } from 'data/content/model/elements/factories';
+import { expectAnyId } from './normalize-test-utils';
+import { Descendant } from 'slate';
+
+describe('validateEditorContentValue', () => {
+  it('should return default value for undefined value', () => {
+    const value = undefined;
+    const expectedOutput = [Model.p()];
+    expect(validateEditorContentValue(value)).toEqual(expectAnyId(expectedOutput));
+  });
+
+  it('should return default value for empty array value', () => {
+    const value: any[] = [];
+    const expectedOutput = [Model.p()];
+    expect(validateEditorContentValue(value)).toEqual(expectAnyId(expectedOutput));
+  });
+
+  it('should return default value for non-array value', () => {
+    const value = 'not an array';
+    const expectedOutput = [Model.p()];
+    expect(validateEditorContentValue(value)).toEqual(expectAnyId(expectedOutput));
+  });
+
+  it('should return model property value for object with model property', () => {
+    const value = { model: [{ type: 'p', id: '1', children: [{ text: 'Hello, world!' }] }] };
+    const expectedOutput = value.model as Descendant[];
+    expect(validateEditorContentValue(value)).toEqual(expectAnyId(expectedOutput));
+  });
+
+  it('should return input array value for valid array value', () => {
+    const value = [{ type: 'p', id: '1', children: [{ text: 'Hello, world!' }] }];
+    const expectedOutput = value as Descendant[];;
+    expect(validateEditorContentValue(value)).toEqual(expectAnyId(expectedOutput));
+  });
+});

--- a/assets/test/editor/validate_editor_content_test.ts
+++ b/assets/test/editor/validate_editor_content_test.ts
@@ -1,7 +1,7 @@
+import { Descendant } from 'slate';
 import { validateEditorContentValue } from 'components/editing/editor/Editor';
 import { Model } from 'data/content/model/elements/factories';
 import { expectAnyId } from './normalize-test-utils';
-import { Descendant } from 'slate';
 
 describe('validateEditorContentValue', () => {
   it('should return default value for undefined value', () => {
@@ -30,7 +30,7 @@ describe('validateEditorContentValue', () => {
 
   it('should return input array value for valid array value', () => {
     const value = [{ type: 'p', id: '1', children: [{ text: 'Hello, world!' }] }];
-    const expectedOutput = value as Descendant[];;
+    const expectedOutput = value as Descendant[];
     expect(validateEditorContentValue(value)).toEqual(expectAnyId(expectedOutput));
   });
 });


### PR DESCRIPTION
There was some content that had an extra model object in the content hierarchy. Upon examining torus, I couldn't figure out where it was coming from. The current theory is that this content actually came from a bad import ~11 months ago. To fix this, we will now detect & fix this type of content.

A hint from current software:
```
{
            "content": [
              {
                "children": [
                  {
                    "text": ""
                  }
                ],
                "id": "2852515758",
                "type": "p"
              }
            ],
            "editor": "slate",
            "id": "2322934457"
          }

A hint from that lesson:

{
            "content": {
              "model": [
                {
                  "children": [
                    {
                      "text": ""
                    }
                  ],
                  "type": "p"
                }
              ]
            },
            "id": "1862042623"
          }
```