### PR TITLE
[NG23-11] Course content

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -8,6 +8,7 @@
 @import 'button';
 @import 'table';
 @import 'markdown-editor';
+@import 'ng23';
 
 /**
  * Automatically style all links with blue text and underline on hover.

--- a/assets/css/ng23.css
+++ b/assets/css/ng23.css
@@ -1,0 +1,15 @@
+/*
+The following classes are used to style the html rendered with Oli.Rendering.Content.render/3
+We should try to avoid defining classes in this way.
+The prefered way is to do it directly in the HTML with TailwindCSS, as explained:
+
+https://tailwindcss.com/docs/utility-first
+*/
+
+.intro-content p {
+  @apply pb-2 text-[14px] leading-[30px] font-normal;
+}
+
+.intro-content h1 {
+  @apply mb-[20px] text-2xl tracking-[0.02px] font-light;
+}

--- a/assets/src/hooks/index.ts
+++ b/assets/src/hooks/index.ts
@@ -15,6 +15,7 @@ import { ModalLaunch } from './modal';
 import { MonacoEditor } from './monaco_editor';
 import { ProjectsTypeahead } from './projects_typeahead';
 import { ReviewActivity } from './review_activity';
+import { ScrollToTarget } from './scroll_to_target';
 import { SelectListener } from './select_listener';
 import { SubmitForm } from './submit_form';
 import { SystemMessage } from './system_message';
@@ -49,4 +50,5 @@ export const Hooks = {
   LoadSurveyScripts,
   LiveModal,
   EmailList,
+  ScrollToTarget,
 };

--- a/assets/src/hooks/scroll_to_target.ts
+++ b/assets/src/hooks/scroll_to_target.ts
@@ -1,0 +1,10 @@
+export const ScrollToTarget = {
+  mounted() {
+    window.addEventListener('phx:scroll_to_target', (e: Event) => {
+      const el = document.getElementById((e as CustomEvent).detail.id);
+      if (el) {
+        el.scrollIntoView({ block: 'start' });
+      }
+    });
+  },
+};

--- a/assets/src/hooks/scroll_to_target.ts
+++ b/assets/src/hooks/scroll_to_target.ts
@@ -1,6 +1,6 @@
 export const ScrollToTarget = {
   mounted() {
-    window.addEventListener('phx:scroll_to_target', (e: Event) => {
+    window.addEventListener('phx:scroll-to-target', (e: Event) => {
       const el = document.getElementById((e as CustomEvent).detail.id);
       if (el) {
         el.scrollIntoView({ block: 'start', behavior: 'smooth' });

--- a/assets/src/hooks/scroll_to_target.ts
+++ b/assets/src/hooks/scroll_to_target.ts
@@ -3,7 +3,7 @@ export const ScrollToTarget = {
     window.addEventListener('phx:scroll_to_target', (e: Event) => {
       const el = document.getElementById((e as CustomEvent).detail.id);
       if (el) {
-        el.scrollIntoView({ block: 'start' });
+        el.scrollIntoView({ block: 'start', behavior: 'smooth' });
       }
     });
   },

--- a/lib/oli_web/components/delivery/utils.ex
+++ b/lib/oli_web/components/delivery/utils.ex
@@ -290,6 +290,26 @@ defmodule OliWeb.Components.Delivery.Utils do
     """
   end
 
+  @doc """
+  Returns the course week number of a resource based on the section start date
+  """
+  def week_number(_section_start_date, nil), do: "not yet scheduled"
+
+  def week_number(section_start_datetime, resource_datetime) do
+    case Date.diff(
+           DateTime.to_date(resource_datetime),
+           DateTime.to_date(section_start_datetime)
+         ) do
+      0 ->
+        1
+
+      day_diff ->
+        (day_diff / 7)
+        |> Float.ceil()
+        |> trunc()
+    end
+  end
+
   def get_resource_scheduled_date(resource_id, scheduled_dates, ctx) do
     case scheduled_dates[resource_id] do
       %{end_date: nil} ->

--- a/lib/oli_web/live/delivery/student/content_live.ex
+++ b/lib/oli_web/live/delivery/student/content_live.ex
@@ -190,7 +190,7 @@ defmodule OliWeb.Delivery.Student.ContentLive do
       <div
         phx-click="navigate_to_resource"
         phx-value-slug={page.revision.slug}
-        class="flex items-center gap-3 w-full border-b-2 border-gray-600 cursor-pointer"
+        class="flex items-center gap-3 w-full border-b-2 border-gray-600 cursor-pointer hover:bg-gray-200 px-2"
       >
         <span class="text-[16px] leading-[22px] font-normal truncate">
           <%= "#{@module_index}.#{page_index} #{page.revision.title}" %>
@@ -222,22 +222,24 @@ defmodule OliWeb.Delivery.Student.ContentLive do
 
   def intro_card(assigns) do
     ~H"""
-    <div class={"flex flex-col items-center rounded-lg h-[162px] w-[288px] bg-gray-300 shrink-0 px-5 pt-[15px] bg-[url('#{@bg_image_url}')]"}>
-      <h5 class="text-[13px] leading-[18px] font-bold self-start"><%= @title %></h5>
-      <div :if={@video_url} phx-click={@on_play} class="w-[70px] h-[70px] relative my-auto -top-2">
-        <div class="w-full h-full rounded-full backdrop-blur bg-gray/50"></div>
-        <button class="w-full h-full absolute top-0 left-0 flex items-center justify-center">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="white"
-            width="33"
-            height="38"
-            viewBox="0 0 16.984 24.8075"
-            class="scale-110 ml-[6px] mt-[9px]"
-          >
-            <path d="M0.759,0.158c0.39-0.219,0.932-0.21,1.313,0.021l14.303,8.687c0.368,0.225,0.609,0.625,0.609,1.057   s-0.217,0.832-0.586,1.057L2.132,19.666c-0.382,0.231-0.984,0.24-1.375,0.021C0.367,19.468,0,19.056,0,18.608V1.237   C0,0.79,0.369,0.378,0.759,0.158z" />
-          </svg>
-        </button>
+    <div class="hover:scale-[1.01]">
+      <div class={"flex flex-col items-center rounded-lg h-[162px] w-[288px] bg-gray-300 shrink-0 px-5 pt-[15px] bg-[url('#{@bg_image_url}')]"}>
+        <h5 class="text-[13px] leading-[18px] font-bold self-start"><%= @title %></h5>
+        <div :if={@video_url} phx-click={@on_play} class="w-[70px] h-[70px] relative my-auto -top-2">
+          <div class="w-full h-full rounded-full backdrop-blur bg-gray/50"></div>
+          <button class="w-full h-full absolute top-0 left-0 flex items-center justify-center">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="white"
+              width="33"
+              height="38"
+              viewBox="0 0 16.984 24.8075"
+              class="scale-110 ml-[6px] mt-[9px]"
+            >
+              <path d="M0.759,0.158c0.39-0.219,0.932-0.21,1.313,0.021l14.303,8.687c0.368,0.225,0.609,0.625,0.609,1.057   s-0.217,0.832-0.586,1.057L2.132,19.666c-0.382,0.231-0.984,0.24-1.375,0.021C0.367,19.468,0,19.056,0,18.608V1.237   C0,0.79,0.369,0.378,0.759,0.158z" />
+            </svg>
+          </button>
+        </div>
       </div>
     </div>
     """
@@ -253,50 +255,52 @@ defmodule OliWeb.Delivery.Student.ContentLive do
   def module_card(assigns) do
     # TODO: render real student progress for module
     ~H"""
-    <div flex="h-[170px] w-[288px]">
-      <div
-        id={"module_#{@module.uuid}"}
-        phx-click="select_module"
-        phx-value-unit_uuid={@unit_uuid}
-        phx-value-module_uuid={@module.uuid}
-        phx-value-module_index={@module_index}
-        class={[
-          "flex flex-col gap-[5px] cursor-pointer rounded-xl h-[162px] w-[288px] bg-gray-300 shrink-0 mb-1 px-5 pt-[15px] bg-[url('#{@bg_image_url}')]",
-          if(@selected, do: "bg-gray-400 outline outline-2 outline-gray-800")
-        ]}
-      >
-        <span class="text-[12px] leading-[16px] font-bold opacity-60 text-gray-500">
-          <%= "#{@unit_numbering_index}.#{@module_index}" %>
-        </span>
-        <h5 class="text-[18px] leading-[25px] font-bold"><%= @module.revision.title %></h5>
-        <div :if={!@selected} class="mt-auto flex h-[21px] justify-center items-center">
+    <div class="hover:scale-[1.01]">
+      <div flex="h-[170px] w-[288px]">
+        <div
+          id={"module_#{@module.uuid}"}
+          phx-click="select_module"
+          phx-value-unit_uuid={@unit_uuid}
+          phx-value-module_uuid={@module.uuid}
+          phx-value-module_index={@module_index}
+          class={[
+            "flex flex-col gap-[5px] cursor-pointer rounded-xl h-[162px] w-[288px] bg-gray-300 shrink-0 mb-1 px-5 pt-[15px] bg-[url('#{@bg_image_url}')]",
+            if(@selected, do: "bg-gray-400 outline outline-2 outline-gray-800")
+          ]}
+        >
+          <span class="text-[12px] leading-[16px] font-bold opacity-60 text-gray-500">
+            <%= "#{@unit_numbering_index}.#{@module_index}" %>
+          </span>
+          <h5 class="text-[18px] leading-[25px] font-bold"><%= @module.revision.title %></h5>
+          <div :if={!@selected} class="mt-auto flex h-[21px] justify-center items-center">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="10"
+              height="5"
+              viewBox="0 0 10 5"
+              fill="currentColor"
+            >
+              <path d="M0 0L10 0L5 5Z" />
+            </svg>
+          </div>
+        </div>
+        <.progress_bar :if={!@selected} percent={:rand.uniform(100)} width="60%" show_percent={false} />
+        <div
+          :if={@selected}
+          class={[
+            "flex justify-center items-center -mt-1"
+          ]}
+        >
           <svg
             xmlns="http://www.w3.org/2000/svg"
-            width="10"
-            height="5"
-            viewBox="0 0 10 5"
+            width="27"
+            height="12"
+            viewBox="0 0 27 12"
             fill="currentColor"
           >
-            <path d="M0 0L10 0L5 5Z" />
+            <path d="M0 0L27 0L13.5 12Z" />
           </svg>
         </div>
-      </div>
-      <.progress_bar :if={!@selected} percent={:rand.uniform(100)} width="60%" show_percent={false} />
-      <div
-        :if={@selected}
-        class={[
-          "flex justify-center items-center -mt-1"
-        ]}
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="27"
-          height="12"
-          viewBox="0 0 27 12"
-          fill="currentColor"
-        >
-          <path d="M0 0L27 0L13.5 12Z" />
-        </svg>
       </div>
     </div>
     """

--- a/lib/oli_web/live/delivery/student/content_live.ex
+++ b/lib/oli_web/live/delivery/student/content_live.ex
@@ -105,6 +105,7 @@ defmodule OliWeb.Delivery.Student.ContentLive do
           module_index={module_index}
           unit_uuid={@unit.uuid}
           unit_numbering_index={@unit.numbering.index}
+          bg_image_url={module.revision.poster_image}
           selected={module.uuid == @selected_module_uuid}
         />
       </div>
@@ -166,6 +167,7 @@ defmodule OliWeb.Delivery.Student.ContentLive do
   attr :unit_numbering_index, :integer
   attr :unit_uuid, :string
   attr :selected, :boolean, default: false
+  attr :bg_image_url, :string, doc: "the background image url for the card", default: ""
 
   def module_card(assigns) do
     ~H"""
@@ -175,7 +177,7 @@ defmodule OliWeb.Delivery.Student.ContentLive do
         phx-value-unit_uuid={@unit_uuid}
         phx-value-module_uuid={@module.uuid}
         class={[
-          "flex flex-col gap-[5px] cursor-pointer rounded-xl h-[162px] w-[288px] bg-gray-300 shrink-0 mb-1 px-5 pt-[15px]",
+          "flex flex-col gap-[5px] cursor-pointer rounded-xl h-[162px] w-[288px] bg-gray-300 shrink-0 mb-1 px-5 pt-[15px] bg-[url('#{@bg_image_url}')]",
           if(@selected, do: "bg-gray-400 border-2 border-gray-800")
         ]}
       >

--- a/lib/oli_web/live/delivery/student/content_live.ex
+++ b/lib/oli_web/live/delivery/student/content_live.ex
@@ -92,6 +92,7 @@ defmodule OliWeb.Delivery.Student.ContentLive do
   attr :section_start_date, :string, doc: "required to calculate the week number"
 
   def unit(assigns) do
+    # TODO: render real student progress for unit
     ~H"""
     <div id={"unit_#{@unit.uuid}"} class="p-[25px] pl-[50px]">
       <div class="mb-6 flex flex-col items-start gap-[6px]">
@@ -139,7 +140,7 @@ defmodule OliWeb.Delivery.Student.ContentLive do
         />
       </div>
     </div>
-    <div :if={@selected_unit} class="flex py-[24px] px-[50px] gap-x-12">
+    <div :if={@selected_unit} class="flex py-[24px] px-[50px] gap-x-4 lg:gap-x-12">
       <div class="w-1/2 flex flex-col px-6">
         <div class={[
           "intro-content",
@@ -167,6 +168,7 @@ defmodule OliWeb.Delivery.Student.ContentLive do
   attr :module_index, :integer
 
   def index(assigns) do
+    # TODO: render real check if student has visited the page
     ~H"""
     <div
       :for={{page, page_index} <- Enum.with_index(@module.children, 1)}
@@ -249,6 +251,7 @@ defmodule OliWeb.Delivery.Student.ContentLive do
   attr :bg_image_url, :string, doc: "the background image url for the card"
 
   def module_card(assigns) do
+    # TODO: render real student progress for module
     ~H"""
     <div flex="h-[170px] w-[288px]">
       <div

--- a/lib/oli_web/live/delivery/student/content_live.ex
+++ b/lib/oli_web/live/delivery/student/content_live.ex
@@ -6,6 +6,7 @@ defmodule OliWeb.Delivery.Student.ContentLive do
   alias OliWeb.Common.FormatDateTime
   alias Phoenix.LiveView.JS
   alias OliWeb.Components.Modal
+  alias OliWeb.Components.Delivery.Utils
 
   def mount(_params, _session, socket) do
     # TODO replace this with a call to the Cache data in ETS
@@ -32,7 +33,7 @@ defmodule OliWeb.Delivery.Student.ContentLive do
         socket
       ) do
     socket =
-      if module_uuid == (socket.assigns.selected_module && socket.assigns.selected_module.uuid) do
+      if module_uuid == get_in(socket.assigns, [:selected_module, Access.key!(:uuid)]) do
         assign(socket, selected_unit_uuid: nil, selected_module: nil)
       else
         selected_module = get_module(socket.assigns.hierarchy, unit_uuid, module_uuid)
@@ -43,7 +44,7 @@ defmodule OliWeb.Delivery.Student.ContentLive do
           selected_module_index: selected_module_index
         )
       end
-      |> push_event("scroll_to_target", %{id: "unit_#{unit_uuid}"})
+      |> push_event("scroll-to-target", %{id: "unit_#{unit_uuid}"})
 
     {:noreply, socket}
   end
@@ -54,7 +55,8 @@ defmodule OliWeb.Delivery.Student.ContentLive do
   end
 
   def handle_event("navigate_to_resource", %{"slug" => resource_slug}, socket) do
-    {:noreply, push_navigate(socket, to: get_url(resource_slug, socket.assigns.section.slug))}
+    {:noreply,
+     push_navigate(socket, to: resource_url(resource_slug, socket.assigns.section.slug))}
   end
 
   def render(assigns) do
@@ -75,7 +77,7 @@ defmodule OliWeb.Delivery.Student.ContentLive do
           unit={child}
           section_start_date={@section.start_date}
           ctx={@ctx}
-          selected_unit={child.uuid == @selected_unit_uuid}
+          unit_selected={child.uuid == @selected_unit_uuid}
           selected_module={@selected_module}
           selected_module_index={@selected_module_index}
         />
@@ -86,7 +88,7 @@ defmodule OliWeb.Delivery.Student.ContentLive do
 
   attr :unit, :map
   attr :ctx, :map, doc: "the context is needed to format the date considering the user's timezone"
-  attr :selected_unit, :boolean, default: false
+  attr :unit_selected, :boolean, default: false
   attr :selected_module, :map
   attr :selected_module_index, :string
   attr :section_start_date, :string, doc: "required to calculate the week number"
@@ -102,7 +104,7 @@ defmodule OliWeb.Delivery.Student.ContentLive do
         <div class="flex items-center w-full">
           <div class="flex items-center gap-3 ">
             <div class="text-[14px] leading-[32px] tracking-[0.02px] font-semibold">
-              <span class="text-gray-400 opacity-80">Week</span> <%= week_number(
+              <span class="text-gray-400 opacity-80">Week</span> <%= Utils.week_number(
                 @section_start_date,
                 @unit.section_resource.start_date
               ) %>
@@ -140,7 +142,7 @@ defmodule OliWeb.Delivery.Student.ContentLive do
         />
       </div>
     </div>
-    <div :if={@selected_unit} class="flex py-[24px] px-[50px] gap-x-4 lg:gap-x-12">
+    <div :if={@unit_selected} class="flex py-[24px] px-[50px] gap-x-4 lg:gap-x-12">
       <div class="w-1/2 flex flex-col px-6">
         <div class={[
           "intro-content",
@@ -353,27 +355,6 @@ defmodule OliWeb.Delivery.Student.ContentLive do
     |> Timex.format!("{WDshort} {Mshort} {D}, {YYYY}")
   end
 
-  defp week_number(_section_start_date, nil), do: 1
-
-  defp week_number(section_start_datetime, unit_start_datetime) do
-    case Date.diff(
-           DateTime.to_date(unit_start_datetime),
-           DateTime.to_date(section_start_datetime)
-         ) do
-      0 ->
-        1
-
-      day_diff ->
-        {week_num, _} =
-          (day_diff / 7)
-          |> Float.ceil()
-          |> Float.to_string()
-          |> Integer.parse()
-
-        week_num
-    end
-  end
-
   defp get_module(hierarchy, unit_uuid, module_uuid) do
     unit =
       Enum.find(hierarchy.children, fn unit ->
@@ -387,7 +368,7 @@ defmodule OliWeb.Delivery.Student.ContentLive do
 
   # TODO: for other courses with other hierarchy, the url might be a container url:
   # ~p"/sections/#{section_slug}/container/:revision_slug
-  defp get_url(resource_slug, section_slug) do
+  defp resource_url(resource_slug, section_slug) do
     ~p"/sections/#{section_slug}/page/#{resource_slug}"
   end
 end

--- a/lib/oli_web/live/delivery/student/content_live.ex
+++ b/lib/oli_web/live/delivery/student/content_live.ex
@@ -3,8 +3,30 @@ defmodule OliWeb.Delivery.Student.ContentLive do
 
   import OliWeb.Components.Delivery.Layouts
 
+  alias OliWeb.Common.FormatDateTime
+  alias Phoenix.LiveView.JS
+
   def mount(_params, _session, socket) do
-    {:ok, socket}
+    # TODO replace this with a call to the Cache data in ETS
+    # (finally it will be stored as a json in a new section field maybe called "cached_hierarchy")
+    hierarchy =
+      Oli.Publishing.DeliveryResolver.full_hierarchy(socket.assigns.section.slug)
+
+    {:ok,
+     assign(socket, hierarchy: hierarchy, selected_unit_uuid: nil, selected_module_uuid: nil)}
+  end
+
+  def handle_event("select_module", %{"unit_uuid" => uuid, "module_uuid" => module_uuid}, socket) do
+    if module_uuid == socket.assigns.selected_module_uuid do
+      {:noreply, assign(socket, selected_unit_uuid: nil, selected_module_uuid: nil)}
+    else
+      {:noreply, assign(socket, selected_unit_uuid: uuid, selected_module_uuid: module_uuid)}
+    end
+  end
+
+  def handle_event("play_intro_video", %{"video_url" => url}, socket) do
+    # TODO play video
+    {:noreply, socket}
   end
 
   def render(assigns) do
@@ -16,10 +38,209 @@ defmodule OliWeb.Delivery.Student.ContentLive do
       preview_mode={@preview_mode}
       active_tab={:content}
     >
-      <div class="container mx-auto px-10 py-8">
-        <h3>Content</h3>
+      <div class="container mx-auto px-10 py-8 space-y-4">
+        <.unit
+          :for={child <- @hierarchy.children}
+          unit={child}
+          section_start_date={@section.start_date}
+          ctx={@ctx}
+          selected_unit={child.uuid == @selected_unit_uuid}
+          selected_module_uuid={@selected_module_uuid}
+        />
       </div>
     </.header_with_sidebar_nav>
     """
+  end
+
+  attr :unit, :map
+  attr :ctx, :map, doc: "the context is needed to format the date considering the user's timezone"
+  attr :selected_unit, :boolean, default: false
+  attr :selected_module_uuid, :string
+  attr :section_start_date, :string, doc: "required to calculate the week number"
+
+  def unit(assigns) do
+    ~H"""
+    <div class="p-9">
+      <div class="py-6">
+        <h3 class="text-2xl tracking-[0.02px] font-semibold">
+          <%= "#{@unit.numbering.index}. #{@unit.revision.title}" %>
+        </h3>
+        <div class="mt-4 flex flex-row w-full items-center">
+          <div class="text-sm tracking-[0.02px] font-semibold">
+            <span class="text-gray-400">Week</span> <%= week_number(
+              @section_start_date,
+              @unit.section_resource.start_date
+            ) %>
+          </div>
+          <div class="ml-3 text-sm tracking-[0.02px] font-semibold">
+            <span class="text-gray-400">Due:</span> <%= parse_datetime(
+              @unit.section_resource.end_date,
+              @ctx
+            ) %>
+          </div>
+          <div class="ml-auto w-36">
+            <.progress_bar percent={:rand.uniform(100)} width="100px" />
+          </div>
+        </div>
+      </div>
+      <div class="flex space-x-4 overflow-x-scroll">
+        <.intro_card
+          :if={@unit.revision.intro_video || @unit.revision.poster_image}
+          bg_image_url={@unit.revision.poster_image}
+          video_url={@unit.revision.intro_video}
+          on_play={JS.push("play_intro_video", value: %{video_url: @unit.revision.intro_video})}
+        />
+        <.module_card
+          :for={{module, module_index} <- Enum.with_index(@unit.children, 1)}
+          module={module}
+          module_index={module_index}
+          unit_uuid={@unit.uuid}
+          unit_numbering_index={@unit.numbering.index}
+          selected={module.uuid == @selected_module_uuid}
+        />
+      </div>
+      <div :if={@selected_unit} class="flex gap-10">
+        <div class="w-1/2 flex flex-col space-y-4 p-10">
+          <h5>If you Can't Measure it...</h5>
+          <p :for={_i <- Enum.take(Enum.to_list(1..5), Enum.random(1..5))}>
+            Lorem ipsum dolor sit amet consectetur adipisicing elit. Error voluptate cupiditate, quae minus illo quo repellendus! Molestiae commodi, tenetur nam explicabo, aut repellendus dolorum ex amet delectus asperiores eligendi exercitationem?
+          </p>
+          <button class="btn btn-primary mr-auto">Let's discuss?</button>
+        </div>
+        <div class="p-10">index goes here</div>
+      </div>
+    </div>
+    """
+  end
+
+  attr :title, :string, default: "Intro"
+
+  attr :video_url,
+       :string,
+       doc: "the video url is optional and, if provided, the play button will be rendered"
+
+  attr :bg_image_url, :string, doc: "the background image url for the card"
+  attr :on_play, :any, doc: "the event to be triggered when the play button is clicked"
+
+  def intro_card(assigns) do
+    ~H"""
+    <div class={"flex flex-col items-center rounded-lg h-[170px] w-[288px] bg-gray-300 shrink-0 p-4 bg-[url('#{@bg_image_url}')]"}>
+      <h5 class="text-xs font-bold self-start"><%= @title %></h5>
+      <div :if={@video_url} phx-click={@on_play} class="w-[70px] h-[70px] relative my-auto -top-2">
+        <div class="w-full h-full rounded-full backdrop-blur bg-gray/50"></div>
+        <button class="w-full h-full absolute top-0 left-0 flex items-center justify-center">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="white"
+            width="33"
+            height="38"
+            viewBox="0 0 16.984 24.8075"
+            class="scale-110 ml-[6px] mt-[10px]"
+          >
+            <path d="M0.759,0.158c0.39-0.219,0.932-0.21,1.313,0.021l14.303,8.687c0.368,0.225,0.609,0.625,0.609,1.057   s-0.217,0.832-0.586,1.057L2.132,19.666c-0.382,0.231-0.984,0.24-1.375,0.021C0.367,19.468,0,19.056,0,18.608V1.237   C0,0.79,0.369,0.378,0.759,0.158z" />
+          </svg>
+        </button>
+      </div>
+    </div>
+    """
+  end
+
+  attr :module, :map
+  attr :module_index, :integer
+  attr :unit_numbering_index, :integer
+  attr :unit_uuid, :string
+  attr :selected, :boolean, default: false
+
+  def module_card(assigns) do
+    ~H"""
+    <div flex="flex flex-col">
+      <div
+        phx-click="select_module"
+        phx-value-unit_uuid={@unit_uuid}
+        phx-value-module_uuid={@module.uuid}
+        class={[
+          "flex flex-col cursor-pointer rounded-lg h-[170px] w-[288px] bg-gray-300 shrink-0 px-4 pt-4",
+          if(@selected, do: "bg-gray-400 border-2 border-gray-800 pt-[14px] px-[14px]")
+        ]}
+      >
+        <span class="text-xs font-bold opacity-60 text-gray-500">
+          <%= "#{@unit_numbering_index}.#{@module_index}" %>
+        </span>
+        <h5 class="text-lg font-bold"><%= @module.revision.title %></h5>
+        <div :if={!@selected} class="mt-auto flex h-5 justify-center items-center">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="10"
+            height="5"
+            viewBox="0 0 10 5"
+            fill="currentColor"
+          >
+            <path d="M0 0L10 0L5 5Z" />
+          </svg>
+        </div>
+      </div>
+      <div
+        :if={@selected}
+        class={[
+          "flex justify-center items-center"
+        ]}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="27"
+          height="12"
+          viewBox="0 0 27 12"
+          fill="currentColor"
+        >
+          <path d="M0 0L27 0L13.5 12Z" />
+        </svg>
+      </div>
+    </div>
+    """
+  end
+
+  attr(:percent, :integer, required: true)
+  attr(:width, :string, default: "100%")
+
+  def progress_bar(assigns) do
+    ~H"""
+    <div class="flex flex-row items-center">
+      <div class="flex-1 mr-1">
+        <div class={"w-[#{@width}] rounded-full bg-gray-200 h-1"}>
+          <div class="rounded-full bg-green-600 h-1" style={"width: #{@percent}%"}></div>
+        </div>
+      </div>
+      <div class="text-base tracking-[0.02px] font-bold"><%= @percent %>%</div>
+    </div>
+    """
+  end
+
+  defp parse_datetime(nil, _ctx), do: "not yet scheduled"
+
+  defp parse_datetime(datetime, ctx) do
+    datetime
+    |> FormatDateTime.convert_datetime(ctx)
+    |> Timex.format!("{WDshort} {Mshort} {D}, {YYYY}")
+  end
+
+  defp week_number(_section_start_date, nil), do: 1
+
+  defp week_number(section_start_datetime, unit_start_datetime) do
+    case Date.diff(
+           DateTime.to_date(unit_start_datetime),
+           DateTime.to_date(section_start_datetime)
+         ) do
+      0 ->
+        1
+
+      day_diff ->
+        {week_num, _} =
+          (day_diff / 7)
+          |> Float.ceil()
+          |> Float.to_string()
+          |> Integer.parse()
+
+        week_num
+    end
   end
 end

--- a/lib/oli_web/live/delivery/student/content_live.ex
+++ b/lib/oli_web/live/delivery/student/content_live.ex
@@ -5,6 +5,7 @@ defmodule OliWeb.Delivery.Student.ContentLive do
 
   alias OliWeb.Common.FormatDateTime
   alias Phoenix.LiveView.JS
+  alias OliWeb.Components.Modal
 
   def mount(_params, _session, socket) do
     # TODO replace this with a call to the Cache data in ETS
@@ -24,13 +25,16 @@ defmodule OliWeb.Delivery.Student.ContentLive do
     end
   end
 
-  def handle_event("play_intro_video", %{"video_url" => url}, socket) do
+  def handle_event("play_intro_video", %{"video_url" => _url}, socket) do
     # TODO play video
     {:noreply, socket}
   end
 
   def render(assigns) do
     ~H"""
+    <Modal.modal id="video_player">
+      <div class="h-[80vh]">"imagine a video being played :)"</div>
+    </Modal.modal>
     <.header_with_sidebar_nav
       ctx={@ctx}
       section={@section}
@@ -88,7 +92,10 @@ defmodule OliWeb.Delivery.Student.ContentLive do
           :if={@unit.revision.intro_video || @unit.revision.poster_image}
           bg_image_url={@unit.revision.poster_image}
           video_url={@unit.revision.intro_video}
-          on_play={JS.push("play_intro_video", value: %{video_url: @unit.revision.intro_video})}
+          on_play={
+            Modal.show_modal("video_player")
+            |> JS.push("play_intro_video", value: %{video_url: @unit.revision.intro_video})
+          }
         />
         <.module_card
           :for={{module, module_index} <- Enum.with_index(@unit.children, 1)}

--- a/lib/oli_web/live/delivery/student/content_live.ex
+++ b/lib/oli_web/live/delivery/student/content_live.ex
@@ -33,7 +33,7 @@ defmodule OliWeb.Delivery.Student.ContentLive do
   def render(assigns) do
     ~H"""
     <Modal.modal id="video_player">
-      <div class="h-[80vh]">"imagine a video being played :)"</div>
+      <div class="h-[80vh]">imagine a video being played :)</div>
     </Modal.modal>
     <.header_with_sidebar_nav
       ctx={@ctx}
@@ -105,7 +105,7 @@ defmodule OliWeb.Delivery.Student.ContentLive do
           module_index={module_index}
           unit_uuid={@unit.uuid}
           unit_numbering_index={@unit.numbering.index}
-          bg_image_url={module.revision.poster_image}
+          bg_image_url={module.revision.poster_image || "/images/course_default.jpg"}
           selected={module.uuid == @selected_module_uuid}
         />
       </div>
@@ -152,7 +152,7 @@ defmodule OliWeb.Delivery.Student.ContentLive do
             width="33"
             height="38"
             viewBox="0 0 16.984 24.8075"
-            class="scale-110 ml-[6px] mt-[10px]"
+            class="scale-110 ml-[6px] mt-[9px]"
           >
             <path d="M0.759,0.158c0.39-0.219,0.932-0.21,1.313,0.021l14.303,8.687c0.368,0.225,0.609,0.625,0.609,1.057   s-0.217,0.832-0.586,1.057L2.132,19.666c-0.382,0.231-0.984,0.24-1.375,0.021C0.367,19.468,0,19.056,0,18.608V1.237   C0,0.79,0.369,0.378,0.759,0.158z" />
           </svg>
@@ -167,7 +167,7 @@ defmodule OliWeb.Delivery.Student.ContentLive do
   attr :unit_numbering_index, :integer
   attr :unit_uuid, :string
   attr :selected, :boolean, default: false
-  attr :bg_image_url, :string, doc: "the background image url for the card", default: ""
+  attr :bg_image_url, :string, doc: "the background image url for the card"
 
   def module_card(assigns) do
     ~H"""

--- a/lib/oli_web/live/delivery/student/content_live.ex
+++ b/lib/oli_web/live/delivery/student/content_live.ex
@@ -190,7 +190,7 @@ defmodule OliWeb.Delivery.Student.ContentLive do
         phx-value-slug={page.revision.slug}
         class="flex items-center gap-3 w-full border-b-2 border-gray-600 cursor-pointer"
       >
-        <span class="text-[16px] leading-[22px] font-normal">
+        <span class="text-[16px] leading-[22px] font-normal truncate">
           <%= "#{@module_index}.#{page_index} #{page.revision.title}" %>
         </span>
         <div class="flex items-center gap-[6px] ml-auto">

--- a/lib/oli_web/live/delivery/student/content_live.ex
+++ b/lib/oli_web/live/delivery/student/content_live.ex
@@ -42,7 +42,7 @@ defmodule OliWeb.Delivery.Student.ContentLive do
       preview_mode={@preview_mode}
       active_tab={:content}
     >
-      <div class="container mx-auto px-10 py-8 space-y-4">
+      <div class="container mx-auto p-[25px] space-y-4">
         <.unit
           :for={child <- @hierarchy.children}
           unit={child}
@@ -64,30 +64,32 @@ defmodule OliWeb.Delivery.Student.ContentLive do
 
   def unit(assigns) do
     ~H"""
-    <div class="p-9">
-      <div class="py-6">
-        <h3 class="text-2xl tracking-[0.02px] font-semibold">
+    <div class="p-[25px] pl-[50px]">
+      <div class="mb-6 flex flex-col items-start gap-[6px]">
+        <h3 class="text-[26px] leading-[32px] tracking-[0.02px] font-semibold ml-2">
           <%= "#{@unit.numbering.index}. #{@unit.revision.title}" %>
         </h3>
-        <div class="mt-4 flex flex-row w-full items-center">
-          <div class="text-sm tracking-[0.02px] font-semibold">
-            <span class="text-gray-400">Week</span> <%= week_number(
-              @section_start_date,
-              @unit.section_resource.start_date
-            ) %>
-          </div>
-          <div class="ml-3 text-sm tracking-[0.02px] font-semibold">
-            <span class="text-gray-400">Due:</span> <%= parse_datetime(
-              @unit.section_resource.end_date,
-              @ctx
-            ) %>
+        <div class="flex items-center w-full">
+          <div class="flex items-center gap-3 ">
+            <div class="text-[14px] leading-[32px] tracking-[0.02px] font-semibold">
+              <span class="text-gray-400 opacity-80">Week</span> <%= week_number(
+                @section_start_date,
+                @unit.section_resource.start_date
+              ) %>
+            </div>
+            <div class="text-[14px] leading-[32px] tracking-[0.02px] font-semibold">
+              <span class="text-gray-400 opacity-80">Due:</span> <%= parse_datetime(
+                @unit.section_resource.end_date,
+                @ctx
+              ) %>
+            </div>
           </div>
           <div class="ml-auto w-36">
             <.progress_bar percent={:rand.uniform(100)} width="100px" />
           </div>
         </div>
       </div>
-      <div class="flex space-x-4 overflow-x-scroll">
+      <div class="flex gap-4 overflow-x-scroll">
         <.intro_card
           :if={@unit.revision.intro_video || @unit.revision.poster_image}
           bg_image_url={@unit.revision.poster_image}
@@ -106,15 +108,22 @@ defmodule OliWeb.Delivery.Student.ContentLive do
           selected={module.uuid == @selected_module_uuid}
         />
       </div>
-      <div :if={@selected_unit} class="flex gap-10">
-        <div class="w-1/2 flex flex-col space-y-4 p-10">
-          <h5>If you Can't Measure it...</h5>
-          <p :for={_i <- Enum.take(Enum.to_list(1..5), Enum.random(1..5))}>
-            Lorem ipsum dolor sit amet consectetur adipisicing elit. Error voluptate cupiditate, quae minus illo quo repellendus! Molestiae commodi, tenetur nam explicabo, aut repellendus dolorum ex amet delectus asperiores eligendi exercitationem?
-          </p>
-          <button class="btn btn-primary mr-auto">Let's discuss?</button>
-        </div>
-        <div class="p-10">index goes here</div>
+    </div>
+    <div :if={@selected_unit} class="flex py-[24px] px-[50px] gap-x-12">
+      <div class="w-1/2 flex flex-col px-6">
+        <h5 class="mb-[20px] text-2xl tracking-[0.02px] font-light">If you Can't Measure it...</h5>
+        <p
+          :for={_i <- Enum.take(Enum.to_list(1..5), Enum.random(1..5))}
+          class="py-2 text-[14px] leading-[30px] font-normal "
+        >
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Error voluptate cupiditate, quae minus illo quo repellendus! Molestiae commodi, tenetur nam explicabo, aut repellendus dolorum ex amet delectus asperiores eligendi exercitationem?
+        </p>
+        <button class="btn btn-primary mr-auto mt-[42px]">Let's discuss?</button>
+      </div>
+      <div class="mt-[52px]">
+        <p class="py-2 text-[14px] leading-[30px] font-normal ">
+          index goes here
+        </p>
       </div>
     </div>
     """
@@ -131,8 +140,8 @@ defmodule OliWeb.Delivery.Student.ContentLive do
 
   def intro_card(assigns) do
     ~H"""
-    <div class={"flex flex-col items-center rounded-lg h-[170px] w-[288px] bg-gray-300 shrink-0 p-4 bg-[url('#{@bg_image_url}')]"}>
-      <h5 class="text-xs font-bold self-start"><%= @title %></h5>
+    <div class={"flex flex-col items-center rounded-lg h-[162px] w-[288px] bg-gray-300 shrink-0 px-5 pt-[15px] bg-[url('#{@bg_image_url}')]"}>
+      <h5 class="text-[13px] leading-[18px] font-bold self-start"><%= @title %></h5>
       <div :if={@video_url} phx-click={@on_play} class="w-[70px] h-[70px] relative my-auto -top-2">
         <div class="w-full h-full rounded-full backdrop-blur bg-gray/50"></div>
         <button class="w-full h-full absolute top-0 left-0 flex items-center justify-center">
@@ -160,21 +169,21 @@ defmodule OliWeb.Delivery.Student.ContentLive do
 
   def module_card(assigns) do
     ~H"""
-    <div flex="flex flex-col">
+    <div flex="h-[170px] w-[288px]">
       <div
         phx-click="select_module"
         phx-value-unit_uuid={@unit_uuid}
         phx-value-module_uuid={@module.uuid}
         class={[
-          "flex flex-col cursor-pointer rounded-lg h-[170px] w-[288px] bg-gray-300 shrink-0 px-4 pt-4",
-          if(@selected, do: "bg-gray-400 border-2 border-gray-800 pt-[14px] px-[14px]")
+          "flex flex-col gap-[5px] cursor-pointer rounded-xl h-[162px] w-[288px] bg-gray-300 shrink-0 mb-1 px-5 pt-[15px]",
+          if(@selected, do: "bg-gray-400 border-2 border-gray-800")
         ]}
       >
-        <span class="text-xs font-bold opacity-60 text-gray-500">
+        <span class="text-[12px] leading-[16px] font-bold opacity-60 text-gray-500">
           <%= "#{@unit_numbering_index}.#{@module_index}" %>
         </span>
-        <h5 class="text-lg font-bold"><%= @module.revision.title %></h5>
-        <div :if={!@selected} class="mt-auto flex h-5 justify-center items-center">
+        <h5 class="text-[18px] leading-[25px] font-bold"><%= @module.revision.title %></h5>
+        <div :if={!@selected} class="mt-auto flex h-[21px] justify-center items-center">
           <svg
             xmlns="http://www.w3.org/2000/svg"
             width="10"
@@ -186,10 +195,11 @@ defmodule OliWeb.Delivery.Student.ContentLive do
           </svg>
         </div>
       </div>
+      <.progress_bar :if={!@selected} percent={:rand.uniform(100)} width="60%" show_percent={false} />
       <div
         :if={@selected}
         class={[
-          "flex justify-center items-center"
+          "flex justify-center items-center -mt-1"
         ]}
       >
         <svg
@@ -208,16 +218,19 @@ defmodule OliWeb.Delivery.Student.ContentLive do
 
   attr(:percent, :integer, required: true)
   attr(:width, :string, default: "100%")
+  attr(:show_percent, :boolean, default: true)
 
   def progress_bar(assigns) do
     ~H"""
-    <div class="flex flex-row items-center">
-      <div class="flex-1 mr-1">
-        <div class={"w-[#{@width}] rounded-full bg-gray-200 h-1"}>
+    <div class="flex flex-row items-center mx-auto">
+      <div class="flex justify-center w-full">
+        <div class="rounded-full bg-gray-200 h-1" style={"width: #{@width}"}>
           <div class="rounded-full bg-green-600 h-1" style={"width: #{@percent}%"}></div>
         </div>
       </div>
-      <div class="text-base tracking-[0.02px] font-bold"><%= @percent %>%</div>
+      <div :if={@show_percent} class="text-[16px] leading-[32px] tracking-[0.02px] font-bold">
+        <%= @percent %>%
+      </div>
     </div>
     """
   end

--- a/lib/oli_web/live/delivery/student/content_live.ex
+++ b/lib/oli_web/live/delivery/student/content_live.ex
@@ -135,7 +135,7 @@ defmodule OliWeb.Delivery.Student.ContentLive do
           module_index={module_index}
           unit_uuid={@unit.uuid}
           unit_numbering_index={@unit.numbering.index}
-          bg_image_url={module.revision.poster_image || "/images/course_default.jpg"}
+          bg_image_url={module.revision.poster_image}
           selected={if @selected_module, do: module.uuid == @selected_module.uuid, else: false}
         />
       </div>
@@ -190,7 +190,7 @@ defmodule OliWeb.Delivery.Student.ContentLive do
       <div
         phx-click="navigate_to_resource"
         phx-value-slug={page.revision.slug}
-        class="flex items-center gap-3 w-full border-b-2 border-gray-600 cursor-pointer hover:bg-gray-200 px-2"
+        class="flex items-center gap-3 w-full border-b-2 border-gray-600 cursor-pointer hover:bg-gray-200/70 px-2"
       >
         <span class="text-[16px] leading-[22px] font-normal truncate">
           <%= "#{@module_index}.#{page_index} #{page.revision.title}" %>
@@ -217,13 +217,19 @@ defmodule OliWeb.Delivery.Student.ContentLive do
        :string,
        doc: "the video url is optional and, if provided, the play button will be rendered"
 
-  attr :bg_image_url, :string, doc: "the background image url for the card"
   attr :on_play, :any, doc: "the event to be triggered when the play button is clicked"
+  attr :bg_image_url, :string, doc: "the background image url for the card"
 
   def intro_card(assigns) do
     ~H"""
     <div class="hover:scale-[1.01]">
-      <div class={"flex flex-col items-center rounded-lg h-[162px] w-[288px] bg-gray-300 shrink-0 px-5 pt-[15px] bg-[url('#{@bg_image_url}')]"}>
+      <div class={[
+        "flex flex-col items-center rounded-lg h-[162px] w-[288px] bg-gray-200 shrink-0 px-5 pt-[15px]",
+        if(@bg_image_url in ["", nil],
+          do: "bg-[url('/images/course_default.jpg')]",
+          else: "bg-[url('#{@bg_image_url}')]"
+        )
+      ]}>
         <h5 class="text-[13px] leading-[18px] font-bold self-start"><%= @title %></h5>
         <div :if={@video_url} phx-click={@on_play} class="w-[70px] h-[70px] relative my-auto -top-2">
           <div class="w-full h-full rounded-full backdrop-blur bg-gray/50"></div>
@@ -264,8 +270,12 @@ defmodule OliWeb.Delivery.Student.ContentLive do
           phx-value-module_uuid={@module.uuid}
           phx-value-module_index={@module_index}
           class={[
-            "flex flex-col gap-[5px] cursor-pointer rounded-xl h-[162px] w-[288px] bg-gray-300 shrink-0 mb-1 px-5 pt-[15px] bg-[url('#{@bg_image_url}')]",
-            if(@selected, do: "bg-gray-400 outline outline-2 outline-gray-800")
+            "flex flex-col gap-[5px] cursor-pointer rounded-xl h-[162px] w-[288px] shrink-0 mb-1 px-5 pt-[15px] bg-gray-200",
+            if(@selected, do: "bg-gray-400 outline outline-2 outline-gray-800"),
+            if(@bg_image_url in ["", nil],
+              do: "bg-[url('/images/course_default.jpg')]",
+              else: "bg-[url('#{@bg_image_url}')]"
+            )
           ]}
         >
           <span class="text-[12px] leading-[16px] font-bold opacity-60 text-gray-500">


### PR DESCRIPTION
This is the first PR for the student's course content page. 

https://github.com/Simon-Initiative/oli-torus/assets/74839302/c5d51361-0253-4247-a7b6-9c3354a3da19

Ingested project: 
[chemisty_general1_trunk-out.zip](https://github.com/Simon-Initiative/oli-torus/files/13180635/chemisty_general1_trunk-out.zip)

CSV to ingest to project (slugs must be replaced with the ones of the project csv export):
[chem_csv_custom_ok.csv](https://github.com/Simon-Initiative/oli-torus/files/13180642/chem_csv_custom_ok.csv)


In future PRs we have to:
* Render a video (from youtube or by the provided URL in the revision)
* Cache the section hierarchy in a new field of that table
* Show real student progress and already visited pages
* Implement Dark Mode
* Add tests
