### PR TITLE
[NG23-14] Add real metrics for student

### DIFF
--- a/lib/oli/delivery/hierarchy/hierarchy_node.ex
+++ b/lib/oli/delivery/hierarchy/hierarchy_node.ex
@@ -22,7 +22,8 @@ defmodule Oli.Delivery.Hierarchy.HierarchyNode do
             revision: nil,
             section_resource: nil,
             ancestors: [],
-            finalized: true
+            finalized: true,
+            visited: false
 
   def simplify(%Oli.Delivery.Hierarchy.HierarchyNode{} = node) do
     %{

--- a/lib/oli_web/live/delivery/student/content_live.ex
+++ b/lib/oli_web/live/delivery/student/content_live.ex
@@ -119,7 +119,7 @@ defmodule OliWeb.Delivery.Student.ContentLive do
               ) %>
             </div>
             <div class="text-[14px] leading-[32px] tracking-[0.02px] font-semibold">
-              <span class="text-gray-400 opacity-80">Due:</span> <%= parse_datetime(
+              <span class="text-gray-400 opacity-80">Complete by:</span> <%= parse_datetime(
                 @unit.section_resource.end_date,
                 @ctx
               ) %>
@@ -384,7 +384,7 @@ defmodule OliWeb.Delivery.Student.ContentLive do
     |> Timex.format!("{WDshort} {Mshort} {D}, {YYYY}")
   end
 
-  defp week_number(_section_start_date, nil), do: 1
+  defp week_number(_section_start_date, nil), do: "not yet scheduled"
 
   defp week_number(section_start_datetime, unit_start_datetime) do
     case Date.diff(
@@ -453,7 +453,7 @@ defmodule OliWeb.Delivery.Student.ContentLive do
   end
 
   defp parse_student_progress_for_resource(student_progress_per_resource_id, resource_id) do
-    Map.get(student_progress_per_resource_id, resource_id)
+    Map.get(student_progress_per_resource_id, resource_id, 0.0)
     |> Kernel.*(100)
     |> round()
     |> trunc()


### PR DESCRIPTION
This PR continues the development of the Course Content page started on the [previous PR](https://github.com/Simon-Initiative/oli-torus/pull/4359), by adding real metrics for the student (visited pages and progress for container and pages) in an async way.

Ingested project:
[chemisty_general1_trunk-out.zip](https://github.com/Simon-Initiative/oli-torus/files/13180635/chemisty_general1_trunk-out.zip)

CSV to ingest to project (slugs must be replaced with the ones of the project csv export):
[chem_csv_custom_ok.csv](https://github.com/Simon-Initiative/oli-torus/files/13180642/chem_csv_custom_ok.csv)

In future PRs we have to:

- [ ]  Render a video (from youtube or by the provided URL in the revision)
- [ ] Cache the section hierarchy in a new field of that table
- [X] ~Show real student progress and already visited pages~
- [ ] Implement Dark Mode
- [ ] Add tests
- [ ] Add support for rendering pages (with their corresponding top right icon) at module levels (level 2 of the hierarchy)