### PR TITLE
[BUGFIX] [MER-2695] Fix 'Move to' functionality on All Pages view

### DIFF
--- a/lib/oli_web/live/common/paged_table.ex
+++ b/lib/oli_web/live/common/paged_table.ex
@@ -16,10 +16,11 @@ defmodule OliWeb.Common.PagedTable do
   attr :show_top_paging, :boolean, default: true
   attr :additional_table_class, :string, default: ""
   attr :render_top_info, :boolean, default: true
+  attr :scrollable, :boolean, default: true
 
   def render(assigns) do
     ~H"""
-    <div class="overflow-x-scroll">
+    <div class={if @scrollable, do: "overflow-x-scroll"}>
       <%= if @filter != "" and @render_top_info do %>
         <strong>Results filtered on &quot;<%= @filter %>&quot;</strong>
       <% end %>

--- a/lib/oli_web/live/resources/pages_table_model.ex
+++ b/lib/oli_web/live/resources/pages_table_model.ex
@@ -30,7 +30,7 @@ defmodule OliWeb.Resources.PagesTableModel do
       },
       %ColumnSpec{
         name: :actions,
-        label: "",
+        label: "Actions",
         render_fn: &__MODULE__.render_actions_column/3,
         sortable: false,
         th_class: "w-4",

--- a/lib/oli_web/live/resources/pages_view.ex
+++ b/lib/oli_web/live/resources/pages_view.ex
@@ -156,11 +156,20 @@ defmodule OliWeb.Resources.PagesView do
         show_sort={false}
         show_more_opts={true}
       >
-        <TextSearch.render id="text-search" text={@options.text_search} event_target={"#text-search-input"}/>
+        <TextSearch.render
+          id="text-search"
+          text={@options.text_search}
+          event_target="#text-search-input"
+        />
 
         <:extra_opts>
           <form phx-change="change_graded" class="d-flex">
-            <select name="graded" id="select_graded" class="custom-select custom-select mr-2" style="width: 170px;">
+            <select
+              name="graded"
+              id="select_graded"
+              class="custom-select custom-select mr-2"
+              style="width: 170px;"
+            >
               <option value="" selected>Grading Type</option>
               <option
                 :for={
@@ -176,7 +185,12 @@ defmodule OliWeb.Resources.PagesView do
           </form>
 
           <form phx-change="change_type" class="d-flex">
-            <select name="type" id="select_type" class="custom-select custom-select mr-2" style="width: 170px;">
+            <select
+              name="type"
+              id="select_type"
+              class="custom-select custom-select mr-2"
+              style="width: 170px;"
+            >
               <option value="" selected>Page Type</option>
               <option
                 :for={
@@ -242,6 +256,7 @@ defmodule OliWeb.Resources.PagesView do
         total_count={@total_count}
         offset={@offset}
         limit={limit()}
+        scrollable={false}
       />
     </div>
     """
@@ -517,29 +532,17 @@ defmodule OliWeb.Resources.PagesView do
 
   def handle_event(
         "MoveModal.move_item",
-        %{"to_uuid" => to_uuid} = params,
+        %{"uuid" => uuid, "to_uuid" => to_uuid, "from_uuid" => from_uuid},
         socket
       ) do
     %{
       author: author,
       project: project,
-      modal_assigns: %{node: node, hierarchy: hierarchy}
+      modal_assigns: %{hierarchy: hierarchy}
     } = socket.assigns
 
-    %{revision: revision} = node
-
-    from_container =
-      case params["from_uuid"] do
-        nil ->
-          nil
-
-        from_uuid ->
-          case Hierarchy.find_parent_in_hierarchy(hierarchy, from_uuid) do
-            %{revision: from_container} -> from_container
-            _ -> nil
-          end
-      end
-
+    %{revision: revision} = Hierarchy.find_in_hierarchy(hierarchy, uuid)
+    %{revision: from_container} = Hierarchy.find_in_hierarchy(hierarchy, from_uuid)
     %{revision: to_container} = Hierarchy.find_in_hierarchy(hierarchy, to_uuid)
 
     {:ok, _} = ContainerEditor.move_to(revision, from_container, to_container, author, project)


### PR DESCRIPTION
[MER-2695](https://eliterate.atlassian.net/browse/MER-2695)

Fix the `Move to` functionality in the All Pages view, causing duplicate pages when trying to move a page from one container to another.
This PR also fixes a styling issue that was causing the 'Actions' dropdown to be hidden.

**Before changes:**

https://github.com/Simon-Initiative/oli-torus/assets/26532202/6a85406e-1d5e-4510-bcbb-e668e0f5af54


**After changes:**

https://github.com/Simon-Initiative/oli-torus/assets/26532202/5f234616-d441-48de-b84a-14856ed9701b



[MER-2695]: https://eliterate.atlassian.net/browse/MER-2695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ