### PR TITLE
[BUGFIX][MER-2557] Precision not working as expected

### DIFF
--- a/assets/src/components/activities/short_answer/sections/NumericInput.tsx
+++ b/assets/src/components/activities/short_answer/sections/NumericInput.tsx
@@ -320,7 +320,7 @@ const PrecisionInput: React.FC<PrecisionInputProps> = ({ input, onEditInput }) =
               onChange={onTogglePrecision}
             />
             <label className="custom-control-label" htmlFor={precisionCheckboxId}>
-              Precision
+              Significant Figures
             </label>
           </div>
           <input
@@ -331,7 +331,7 @@ const PrecisionInput: React.FC<PrecisionInputProps> = ({ input, onEditInput }) =
             disabled={!editMode || !precisionEdit}
             value={precisionInputValue(precision)}
             onChange={onEditPrecision}
-            aria-label="Precision"
+            aria-label="Significant Figures"
             onWheel={disableScrollWheelChange(numericInputRef)}
           />
         </div>

--- a/lib/oli/delivery/evaluation/rule.ex
+++ b/lib/oli/delivery/evaluation/rule.ex
@@ -146,21 +146,23 @@ defmodule Oli.Delivery.Evaluation.Rule do
         ["0", decimal] ->
           decimal
           |> String.replace_leading("0", "")
-          |> String.split("")
-          |> Enum.filter(&is_digit?/1)
-          |> Enum.count()
+          |> count_digits()
 
         [_integer, _decimal] ->
-          str
-          |> String.split("")
-          |> Enum.filter(&is_digit?/1)
-          |> Enum.count()
+          count_digits(str)
 
         [integer] ->
-          integer |> String.split("") |> Enum.filter(&is_digit?/1) |> Enum.count()
+          count_digits(integer)
       end
 
     digit_count == count
+  end
+
+  defp count_digits(string_number) do
+    string_number
+    |> String.split("")
+    |> Enum.filter(&is_digit?/1)
+    |> Enum.count()
   end
 
   defp is_range?(str), do: String.starts_with?(str, ["[", "("])

--- a/lib/oli/delivery/evaluation/rule.ex
+++ b/lib/oli/delivery/evaluation/rule.ex
@@ -139,7 +139,7 @@ defmodule Oli.Delivery.Evaluation.Rule do
   # if a precision is not specified (nil) then always evaluate to true
   defp check_precision(_value, nil), do: true
 
-  # checks the precision, now interpreted as # of significant figures
+  # checks the precision, now interpreted as number of significant figures
   defp check_precision(str, count) when is_binary(str) do
     sigfigs =
       case String.split(String.downcase(str), "e") do
@@ -155,26 +155,23 @@ defmodule Oli.Delivery.Evaluation.Rule do
     sigfigs == count
   end
 
+  #  Leading zeros before first non-zero digit are just placeholders so not significant.
+  #  Require non-zero digit so in edge case of all zeros they count: 0.0 => 2 sigfigs
+  defp count_digits_after_zeros(str_number) do
+    str_number
+    |> String.replace(".", "")
+    |> String.replace(~r"^0+(?=[1-9])", "")
+    |> String.split("")
+    |> Enum.filter(&is_digit?/1)
+    |> Enum.count()
+  end
+
+  # Trailing zeros afer non-zero digit in integers assumed placeholders so not significant
+  # In edge case of plain 0 it counts: 0 => 1 sigfig
   defp strip_integer_trailing_zeros(str_number) do
     if not String.contains?(str_number, "."),
-      do: String.replace_trailing(str_number, "0", ""),
+      do: String.replace(str_number, ~r"(?<=[1-9])0+$", ""),
       else: str_number
-  end
-
-  defp count_digits_after_zeros(string_number) do
-    string_number
-    |> String.replace(".", "")
-    |> String.replace_leading("0", "")
-    |> String.split("")
-    |> Enum.filter(&is_digit?/1)
-    |> Enum.count()
-  end
-
-  defp count_digits(string_number) do
-    string_number
-    |> String.split("")
-    |> Enum.filter(&is_digit?/1)
-    |> Enum.count()
   end
 
   defp is_range?(str), do: String.starts_with?(str, ["[", "("])

--- a/lib/oli/delivery/evaluation/rule.ex
+++ b/lib/oli/delivery/evaluation/rule.ex
@@ -142,10 +142,23 @@ defmodule Oli.Delivery.Evaluation.Rule do
   # checks the precision
   defp check_precision(str, count) when is_binary(str) do
     digit_count =
-      str
-      |> String.split("")
-      |> Enum.filter(&is_digit?/1)
-      |> Enum.count()
+      case String.split(str, ".") do
+        ["0", decimal] ->
+          decimal
+          |> String.replace_leading("0", "")
+          |> String.split("")
+          |> Enum.filter(&is_digit?/1)
+          |> Enum.count()
+
+        [_integer, _decimal] ->
+          str
+          |> String.split("")
+          |> Enum.filter(&is_digit?/1)
+          |> Enum.count()
+
+        [integer] ->
+          integer |> String.split("") |> Enum.filter(&is_digit?/1) |> Enum.count()
+      end
 
     digit_count == count
   end

--- a/test/oli/delivery/evaluation/rule_eval_test.exs
+++ b/test/oli/delivery/evaluation/rule_eval_test.exs
@@ -204,6 +204,7 @@ defmodule Oli.Delivery.Evaluation.RuleEvalTest do
   test "evaluating float and integer precision" do
     # precision specified, should evaluate matching precision to true
     assert eval("attemptNumber = {1} && input = {3.1#2}", "3.1")
+    assert eval("attemptNumber = {1} && input = {0.36#2}", "0.36")
 
     # no precision specified, should evaluate extra precision to true
     assert eval("attemptNumber = {1} && input = {3.1}", "3.10")
@@ -211,7 +212,7 @@ defmodule Oli.Delivery.Evaluation.RuleEvalTest do
     # precision specified, should evaluate extra precision to false
     refute eval("attemptNumber = {1} && input = {3.1#2}", "3.10")
 
-    assert eval("attemptNumber = {1} && input = {0.001#4}", "0.001")
+    assert eval("attemptNumber = {1} && input = {0.001#1}", "0.001")
     assert eval("attemptNumber = {1} && input = {3.100#4}", "3.100")
 
     # eval returns false, although the precision is correct the value is wrong


### PR DESCRIPTION
[MER-2557](https://eliterate.atlassian.net/browse/MER-2557)

This PR modifies the way to check the precision of an activity input result.

To check the precision, we take the definition of `precision` given in the stack overflow link in the [ticket description](https://eliterate.atlassian.net/browse/MER-2557).

- As an example, the correct result for the following activity should be 0.36, with a precision of 2.

![Captura de pantalla 2023-10-31 a la(s) 16 30 27](https://github.com/Simon-Initiative/oli-torus/assets/16328384/2445b0aa-9411-459e-81a2-c220879eb874)

- Activity resolution.

https://github.com/Simon-Initiative/oli-torus/assets/16328384/5cd56647-1de4-4baa-a8fa-ad3ed14a10fe

[MER-2557]: https://eliterate.atlassian.net/browse/MER-2557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ