### PR TITLE
[BUGFIX][MER-2651] Fix sticky flash message

### DIFF
--- a/lib/oli_web/templates/layout/live.html.leex
+++ b/lib/oli_web/templates/layout/live.html.leex
@@ -1,5 +1,5 @@
 
-<div id="live_flash_container" class="flash container mx-auto px-0 sticky top-[80px]">
+<div id="live_flash_container" class="flash container mx-auto px-0 top-[80px]">
   <%= if live_flash(@flash, :info) do %>
     <div class="alert alert-info flex flex-row" role="alert">
       <div class="flex-1">

--- a/test/oli_web/live/collaboration_live_test.exs
+++ b/test/oli_web/live/collaboration_live_test.exs
@@ -1356,6 +1356,9 @@ defmodule OliWeb.CollaborationLiveTest do
              |> render() =~
                "Post successfully created"
 
+      # refute that the flash message has sticky class applied
+      refute has_element?(view, "div.alert.alert-info.sticky", "Post successfully created")
+
       post_created_by = user.id
       assert_receive {:post_created, %PostSchema{}, ^post_created_by}
 
@@ -1406,6 +1409,9 @@ defmodule OliWeb.CollaborationLiveTest do
              |> element("div.alert.alert-info")
              |> render() =~
                "Post successfully created"
+
+      # refute that the flash message has sticky class applied
+      refute has_element?(view, "div.alert.alert-info.sticky", "Post successfully created")
 
       post_created_by = user.id
       assert_receive {:post_created, %PostSchema{}, ^post_created_by}
@@ -1627,6 +1633,9 @@ defmodule OliWeb.CollaborationLiveTest do
              |> render() =~
                "Post successfully created"
 
+      # refute that the flash message has sticky class applied
+      refute has_element?(view, "div.alert.alert-info.sticky", "Post successfully created")
+
       post_created_by = user.id
       assert_receive {:post_created, %PostSchema{}, ^post_created_by}
 
@@ -1828,6 +1837,9 @@ defmodule OliWeb.CollaborationLiveTest do
              |> render() =~
                "Post successfully created"
 
+      # refute that the flash message has sticky class applied
+      refute has_element?(view, "div.alert.alert-info.sticky", "Post successfully created")
+
       post_created_by = user.id
       assert_receive {:post_created, %PostSchema{}, ^post_created_by}
 
@@ -1958,6 +1970,9 @@ defmodule OliWeb.CollaborationLiveTest do
              |> render() =~
                "Post successfully created"
 
+      # refute that the flash message has sticky class applied
+      refute has_element?(view, "div.alert.alert-info.sticky", "Post successfully created")
+
       post_created_by = user.id
       assert_receive {:post_created, %PostSchema{}, ^post_created_by}
 
@@ -1983,6 +1998,9 @@ defmodule OliWeb.CollaborationLiveTest do
              |> element("div.alert.alert-info")
              |> render() =~
                "Post successfully created"
+
+      # refute that the flash message has sticky class applied
+      refute has_element?(view, "div.alert.alert-info.sticky", "Post successfully created")
 
       assert_receive {:post_created, %PostSchema{}, ^post_created_by}
 
@@ -2099,6 +2117,9 @@ defmodule OliWeb.CollaborationLiveTest do
              |> render() =~
                "Post successfully created"
 
+      # refute that the flash message has sticky class applied
+      refute has_element?(view, "div.alert.alert-info.sticky", "Post successfully created")
+
       post_created_by = user.id
       assert_receive {:post_created, %PostSchema{}, ^post_created_by}
 
@@ -2200,6 +2221,9 @@ defmodule OliWeb.CollaborationLiveTest do
              |> element("div.alert.alert-info")
              |> render() =~
                "Post successfully created"
+
+      # refute that the flash message has sticky class applied
+      refute has_element?(view, "div.alert.alert-info.sticky", "Post successfully created")
 
       post_created_by = instructor.id
       assert_receive {:post_created, %PostSchema{}, ^post_created_by}


### PR DESCRIPTION
[MER-2651](https://eliterate.atlassian.net/browse/MER-2651)

This PR fixes the bug in flash messages when they appear. 

They had a sticky class applied to them and were fixed at the top level of the view causing interposition of elements.


https://github.com/Simon-Initiative/oli-torus/assets/16328384/5f7f6747-8c96-42b1-9068-fbefdd44bedc


https://github.com/Simon-Initiative/oli-torus/assets/16328384/c1aa12db-64d7-49b4-8ad6-f280555ac6fb


[MER-2651]: https://eliterate.atlassian.net/browse/MER-2651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ