### PR TITLE
[NG23] Trigger rebuild full hierarchy on section re schedule

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -164,7 +164,8 @@ config :oli, Oban,
     auto_submit: 3,
     analytics_export: 3,
     datashop_export: 3,
-    objectives: 3
+    objectives: 3,
+    rebuild_full_hierarchy: 3
   ]
 
 config :ex_money,

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -42,6 +42,7 @@ defmodule Oli.Delivery.Sections do
   alias Oli.Delivery.Metrics
   alias Oli.Delivery.Paywall
   alias Oli.Branding.CustomLabels
+  alias OliWeb.Delivery.RebuildFullHierarchyWorker
 
   require Logger
 
@@ -1911,11 +1912,21 @@ defmodule Oli.Delivery.Sections do
   needed as "cache" data for student's content view (OliWeb.Delivery.Student.ContentLive).
   The full hierarchy represents the main structure in which a course curriculum is organized
   to be delivered (see Oli.Delivery.Hierarchy)
+
+  If `async` is set to true, the rebuild will be performed asynchronously relying on an Oban worker.
   """
-  def rebuild_full_hierarchy(%Section{slug: slug} = section) do
+
+  def rebuild_full_hierarchy(section, async \\ false)
+
+  def rebuild_full_hierarchy(%Section{slug: slug} = section, false) do
     update_section(section, %{
       full_hierarchy: DeliveryResolver.full_hierarchy(slug)
     })
+  end
+
+  def rebuild_full_hierarchy(%Section{slug: slug} = _section, true) do
+    RebuildFullHierarchyWorker.new(%{section_slug: slug})
+    |> Oban.insert()
   end
 
   @doc """

--- a/lib/oli_web/controllers/api/scheduling_controller.ex
+++ b/lib/oli_web/controllers/api/scheduling_controller.ex
@@ -162,9 +162,17 @@ defmodule OliWeb.Api.SchedulingController do
 
     if can_access_section?(conn, section) do
       case Scheduling.update(section, updates, ctx.local_tz) do
-        {:ok, count} -> json(conn, %{"result" => "success", "count" => count})
-        {:error, :missing_update_parameters} -> error(conn, 400, "Missing update parameters")
-        e -> error(conn, 500, e)
+        {:ok, count} ->
+          # a worker is scheduled to update section full_hierarchy
+          # since this may take some time...
+          Sections.rebuild_full_hierarchy(section, true)
+          json(conn, %{"result" => "success", "count" => count})
+
+        {:error, :missing_update_parameters} ->
+          error(conn, 400, "Missing update parameters")
+
+        e ->
+          error(conn, 500, e)
       end
     else
       error(conn, 401, "Unauthorized")

--- a/lib/oli_web/live/delivery/rebuild_full_hierarchy_worker.ex
+++ b/lib/oli_web/live/delivery/rebuild_full_hierarchy_worker.ex
@@ -11,7 +11,8 @@ defmodule OliWeb.Delivery.RebuildFullHierarchyWorker do
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"section_slug" => section_slug} = _args}) do
-    Sections.get_section_by_slug(section_slug)
+    section_slug
+    |> Sections.get_section_by_slug()
     |> Sections.rebuild_full_hierarchy()
   end
 end

--- a/lib/oli_web/live/delivery/rebuild_full_hierarchy_worker.ex
+++ b/lib/oli_web/live/delivery/rebuild_full_hierarchy_worker.ex
@@ -1,0 +1,17 @@
+defmodule OliWeb.Delivery.RebuildFullHierarchyWorker do
+  @moduledoc """
+  This worker is used to rebuild the full hierarchy of a section in an async way,
+  since the process can take a long time.
+  """
+  use Oban.Worker,
+    queue: :rebuild_full_hierarchy,
+    max_attempts: 2
+
+  alias Oli.Delivery.Sections
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"section_slug" => section_slug} = _args}) do
+    Sections.get_section_by_slug(section_slug)
+    |> Sections.rebuild_full_hierarchy()
+  end
+end

--- a/test/oli_web/controllers/api/scheduling_controller_test.exs
+++ b/test/oli_web/controllers/api/scheduling_controller_test.exs
@@ -1,5 +1,6 @@
 defmodule OliWeb.SchedulingControllerTest do
   use OliWeb.ConnCase
+  use Oban.Testing, repo: Oli.Repo
 
   alias Oli.Seeder
   alias Oli.Delivery.Sections
@@ -52,6 +53,13 @@ defmodule OliWeb.SchedulingControllerTest do
       assert length(resources) == 3
 
       Enum.each(resources, fn sr -> assert sr["end_date"] == "2024-01-02" end)
+
+      # a worker is scheduled to update section full_hierarchy
+      assert_enqueued(
+        worker: OliWeb.Delivery.RebuildFullHierarchyWorker,
+        args: %{section_slug: map.section.slug},
+        queue: :rebuild_full_hierarchy
+      )
     end
 
     test "can catch unauthorized user access", %{


### PR DESCRIPTION
This PR adds an Oban Worker to allow rebuilding full_hierarchy async.

This rebuild_full_hierarchy in async mode is used when the instructor re-schedules the course: 

<img width="999" alt="image" src="https://github.com/Simon-Initiative/oli-torus/assets/74839302/d088ef60-b0b9-4c6f-a3b5-a95b6fd416b4">
