### PR TITLE
RTL text bug fixes [MER-2703]

### DIFF
--- a/assets/src/components/common/DeliveryElementRenderer.tsx
+++ b/assets/src/components/common/DeliveryElementRenderer.tsx
@@ -28,11 +28,18 @@ interface DeliveryElementRendererProps {
 export const DeliveryElementRenderer: React.FC<DeliveryElementRendererProps> = ({
   element,
   context,
-  inline
+  inline,
 }) => {
   const writerContext = defaultWriterContext(context);
 
-  return <HtmlContentModelRenderer inline={inline} content={element} context={writerContext} direction="auto" />;
+  return (
+    <HtmlContentModelRenderer
+      inline={inline}
+      content={element}
+      context={writerContext}
+      direction="auto"
+    />
+  );
 };
 
 DeliveryElementRenderer.defaultProps = {

--- a/assets/src/components/common/DeliveryElementRenderer.tsx
+++ b/assets/src/components/common/DeliveryElementRenderer.tsx
@@ -6,6 +6,7 @@ import { HtmlContentModelRenderer } from 'data/content/writers/renderer';
 interface DeliveryElementRendererProps {
   element: RichText;
   context?: WriterContext;
+  inline?: boolean;
 }
 
 /**
@@ -27,8 +28,13 @@ interface DeliveryElementRendererProps {
 export const DeliveryElementRenderer: React.FC<DeliveryElementRendererProps> = ({
   element,
   context,
+  inline
 }) => {
   const writerContext = defaultWriterContext(context);
 
-  return <HtmlContentModelRenderer content={element} context={writerContext} direction="auto" />;
+  return <HtmlContentModelRenderer inline={inline} content={element} context={writerContext} direction="auto" />;
+};
+
+DeliveryElementRenderer.defaultProps = {
+  inline: false,
 };

--- a/assets/src/data/content/writers/renderer.tsx
+++ b/assets/src/data/content/writers/renderer.tsx
@@ -9,11 +9,17 @@ interface Props {
   content: RichText | CaptionV2 | string | TextBlock | Pronunciation;
   direction?: TextDirection | 'auto';
   context: WriterContext;
+  inline?: boolean;
 }
 export const HtmlContentModelRenderer: React.FC<Props> = (props) => {
   // Support content persisted when RichText had a `model` property.
   const content = (props.content as any).model ? (props.content as any).model : props.content;
+  const className = props.inline ? 'inline' : '';
 
   const rendered = new ContentWriter().render(props.context, content, new HtmlParser());
-  return <div dir={props.direction}>{rendered}</div>;
+  return <div dir={props.direction} className={className} >{rendered}</div>;
+};
+
+HtmlContentModelRenderer.defaultProps = {
+  inline: false,
 };

--- a/assets/src/data/content/writers/renderer.tsx
+++ b/assets/src/data/content/writers/renderer.tsx
@@ -17,7 +17,11 @@ export const HtmlContentModelRenderer: React.FC<Props> = (props) => {
   const className = props.inline ? 'inline' : '';
 
   const rendered = new ContentWriter().render(props.context, content, new HtmlParser());
-  return <div dir={props.direction} className={className} >{rendered}</div>;
+  return (
+    <div dir={props.direction} className={className}>
+      {rendered}
+    </div>
+  );
 };
 
 HtmlContentModelRenderer.defaultProps = {

--- a/lib/oli/rendering/content.ex
+++ b/lib/oli/rendering/content.ex
@@ -121,11 +121,8 @@ defmodule Oli.Rendering.Content do
         %{"type" => "content", "children" => children} = element,
         writer
       ) do
-    [
-      "<div dir=\"#{Map.get(element, "textDirection", "ltr")}\">",
-      Enum.map(children, fn child -> render(context, child, writer) end),
-      "</div>"
-    ]
+      next = fn -> Enum.map(children, fn child -> render(context, child, writer) end) end
+      writer.content(context, next, element)
   end
 
   # Renders text content

--- a/lib/oli/rendering/content.ex
+++ b/lib/oli/rendering/content.ex
@@ -121,8 +121,8 @@ defmodule Oli.Rendering.Content do
         %{"type" => "content", "children" => children} = element,
         writer
       ) do
-      next = fn -> Enum.map(children, fn child -> render(context, child, writer) end) end
-      writer.content(context, next, element)
+    next = fn -> Enum.map(children, fn child -> render(context, child, writer) end) end
+    writer.content(context, next, element)
   end
 
   # Renders text content

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -743,7 +743,8 @@ defmodule Oli.Rendering.Content.Html do
         context,
         "Components.DeliveryElementRenderer",
         %{
-          "element" => element
+          "element" => element,
+          "inline" => true,
         },
         html_element: "span"
       )
@@ -806,6 +807,12 @@ defmodule Oli.Rendering.Content.Html do
       "</div></div>\n"
     ]
   end
+
+
+
+
+
+
 
   defp directionAttr(element) do
     case Map.get(element, "textDirection", "ltr") do

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -744,7 +744,7 @@ defmodule Oli.Rendering.Content.Html do
         "Components.DeliveryElementRenderer",
         %{
           "element" => element,
-          "inline" => true,
+          "inline" => true
         },
         html_element: "span"
       )
@@ -808,11 +808,13 @@ defmodule Oli.Rendering.Content.Html do
     ]
   end
 
-
-
-
-
-
+  def content(%Context{} = _context, next, element) do
+    [
+      ~s|<div class="content" #{directionAttr(element)}>|,
+      next.(),
+      "</div>"
+    ]
+  end
 
   defp directionAttr(element) do
     case Map.get(element, "textDirection", "ltr") do

--- a/lib/oli/rendering/content/plaintext.ex
+++ b/lib/oli/rendering/content/plaintext.ex
@@ -15,6 +15,10 @@ defmodule Oli.Rendering.Content.Plaintext do
     ["[Learn more]: ", next.(), " "]
   end
 
+  def content(%Context{} = _context, next, _) do
+    next.()
+  end
+
   def manystudentswonder(%Context{} = _context, next, _) do
     ["[Many students wonder]: ", next.(), " "]
   end

--- a/test/oli/editing/page_editor_test.exs
+++ b/test/oli/editing/page_editor_test.exs
@@ -490,7 +490,7 @@ defmodule Oli.EditingTest do
       html = PageEditor.render_page_html(project.slug, revision.content, author)
 
       assert html == [
-               "<div dir=\"ltr\">",
+               "<div class=\"content\" >",
                [["<p>", [[[[], "Here" | "&#39;"] | "s some test content"]], "</p>\n"]],
                "</div>"
              ]

--- a/test/oli/rendering/alternatives/html_test.exs
+++ b/test/oli/rendering/alternatives/html_test.exs
@@ -154,7 +154,7 @@ defmodule Oli.Rendering.Alternatives.HtmlTest do
 
       # renders R alternative
       assert rendered_html_string =~
-               ~s|<div class="alternative alternative-DhY8ERStw7vXActR5U5BqR"><div dir="ltr"><p>R</p>|
+               ~s|<div class="alternative alternative-DhY8ERStw7vXActR5U5BqR"><div class="content" ><p>R</p>|
 
       # renders activity embedded in R alternative
       assert rendered_html_string =~
@@ -162,11 +162,11 @@ defmodule Oli.Rendering.Alternatives.HtmlTest do
 
       # renders Excel alternative
       assert rendered_html_string =~
-               ~s|<div class="alternative alternative-kQqFWsHyXeMenEDzT9rymP"><div dir=\"ltr\"><p>Excel</p>\n</div>|
+               ~s|<div class="alternative alternative-kQqFWsHyXeMenEDzT9rymP"><div class=\"content\" ><p>Excel</p>\n</div>|
 
       # renders Python alternative
       assert rendered_html_string =~
-               ~s|<div class="alternative alternative-bdaqYkKs8RFE4LWLmPCLnf"><div dir=\"ltr\"><p>Python</p>\n</div>|
+               ~s|<div class="alternative alternative-bdaqYkKs8RFE4LWLmPCLnf"><div class=\"content\" ><p>Python</p>\n</div>|
     end
   end
 end

--- a/test/oli/rendering/page/html_test.exs
+++ b/test/oli/rendering/page/html_test.exs
@@ -155,7 +155,7 @@ defmodule Oli.Content.Page.HtmlTest do
                  Phoenix.HTML.raw(rendered_html) |> Phoenix.HTML.safe_to_string()
 
                assert rendered_html_string ==
-                        "<div dir=\"ltr\"><p>some specific content</p>\n</div>"
+                        "<div class=\"content\" ><p>some specific content</p>\n</div>"
              end)
     end
 
@@ -170,7 +170,7 @@ defmodule Oli.Content.Page.HtmlTest do
                  Phoenix.HTML.raw(rendered_html) |> Phoenix.HTML.safe_to_string()
 
                assert rendered_html_string ==
-                        "<div dir=\"ltr\"><p>some specific content</p>\n</div>"
+                        "<div class=\"content\" ><p>some specific content</p>\n</div>"
              end)
     end
 


### PR DESCRIPTION
There were three issues:

1. The `<div dir="rtl">` tag was being logically inserted at the wrong level of abstraction.
2. The popup element was being rendered as a block element instead of inline
3. The new div with the direction, was causing content within paragraph elements to be styled incorrectly