### PR TITLE
[CHORE] Fixes the CI package build step

### DIFF
--- a/.github/actions/torus-builder/Dockerfile
+++ b/.github/actions/torus-builder/Dockerfile
@@ -29,6 +29,8 @@ RUN yum install https://rpm.nodesource.com/pub_16.x/nodistro/repo/nodesource-rel
 RUN yum install nodejs -y --setopt=nodesource-nodejs.module_hotfixes=1
 RUN npm install -g yarn
 
+WORKDIR /app
+
 # fix elixir encoding warning
 # https://stackoverflow.com/questions/32407164/the-vm-is-running-with-native-name-encoding-of-latin1-which-may-cause-elixir-to
 ENV LANG="en_US.utf8"

--- a/assets/src/adaptivity/scripting.ts
+++ b/assets/src/adaptivity/scripting.ts
@@ -9,7 +9,7 @@ import { janus_std } from './janus-scripts/builtin_functions';
 let conditionsNeedEvaluation: string[] = [];
 export const setConditionsWithExpression = (facts: string[]) => {
   conditionsNeedEvaluation.push(...facts);
-  conditionsNeedEvaluation = uniq(flatten([...new Set(conditionsNeedEvaluation)]));
+  conditionsNeedEvaluation = uniq(flatten(Array.from(new Set(conditionsNeedEvaluation))));
   const script = `let session.conditionsNeedEvaluation = ${JSON.stringify(
     conditionsNeedEvaluation,
   )}`;


### PR DESCRIPTION
The issue was a typescript related compilation error.
```
ERROR in /app/assets/src/adaptivity/scripting.ts
./src/adaptivity/scripting.ts 13:46-88
[tsl] ERROR in /app/assets/src/adaptivity/scripting.ts(13,47)
      TS2569: Type 'IterableIterator<string>' is not an array type or a string type. Use compiler option '--downlevelIteration' to allow iterating of iterators.
ts-loader-default_8e11959e0762e3a1
 @ ./src/adaptivity/rules-engine.ts 72:18-40
 @ ./src/adaptivity/rules.ts 3:21-46

webpack 5.76.0 compiled with 1 error in 10896 ms
```
This issue was outlined in https://github.com/Microsoft/TypeScript/issues/8856. There are a few solutions proposed. One is compiling with the `--downlevelIteration` flag as the error message indicates, but this can cause adverse performance effects. I ultimately decided to just wrap the Set being being spread in `Array.from()`.