### PR TITLE
[BUG] | Build Errors

### DIFF
--- a/assets/src/adaptivity/scripting.ts
+++ b/assets/src/adaptivity/scripting.ts
@@ -9,7 +9,10 @@ import { janus_std } from './janus-scripts/builtin_functions';
 let conditionsNeedEvaluation: string[] = [];
 export const setConditionsWithExpression = (facts: string[]) => {
   conditionsNeedEvaluation.push(...facts);
-  conditionsNeedEvaluation = uniq(flatten([...new Set(conditionsNeedEvaluation)]));
+  if(!conditionsNeedEvaluation?.length){
+    return;
+  }
+  conditionsNeedEvaluation = uniq(flatten([...Array.from(new Set(conditionsNeedEvaluation))]));
   const script = `let session.conditionsNeedEvaluation = ${JSON.stringify(
     conditionsNeedEvaluation,
   )}`;


### PR DESCRIPTION
There was a build error that @Charles-Jones-Unicon reported in slack channel:

```
ERROR in /github/workspace/assets/src/adaptivity/scripting.ts
./src/adaptivity/scripting.ts 12:46-79
[tsl] ERROR in /github/workspace/assets/src/adaptivity/scripting.ts(12,47)
      TS2569: Type 'Set<string>' is not an array type or a string type. Use compiler option '--downlevelIteration' to allow iterating of iterators.
ts-loader-default_8e11959e0762e3a1
```

I was not getting this issue locally, but this seems to be a typescript ES6 transpilation quirk. The `...` operator should work on anything that has an iterator property, (Accessed by` obj[Symbol.iterator]`) and Sets have that property.

To work around this, I used` Array.from` to convert the set to an array first. I hope this will fix the build issue. I am not sure how to test this locally though.

Hey @bitbldr, could take a look at this PR and merge it in the Master branch. Thanks!!!