### PR TITLE
[NG23-23] Student onboarding wizard

### DIFF
--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -43,7 +43,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
 
   def header(assigns) do
     ~H"""
-    <div class="fixed z-50 w-full h-14 flex flex-row bg-delivery-header dark:bg-delivery-header-dark">
+    <div class="fixed z-50 w-full h-14 flex flex-row bg-delivery-header dark:bg-delivery-header-dark shadow-sm">
       <div class="w-48 p-2">
         <a
           className="block lg:p-2 lg:mb-14 mx-auto"
@@ -105,7 +105,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
         flex-col
         w-full
         md:w-48
-        shadow-xl
+        shadow-sm
         bg-delivery-navbar
         dark:bg-delivery-navbar-dark
       "

--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -53,7 +53,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
         </a>
       </div>
       <div class="flex items-center flex-grow-1 p-2">
-        <div class="hidden md:block">
+        <div :if={@section} class="hidden md:block">
           <span class="text-2xl text-bold"><%= @section.title %></span>
         </div>
       </div>

--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -52,12 +52,12 @@ defmodule OliWeb.Components.Delivery.Layouts do
           <.logo_img />
         </a>
       </div>
-      <div class="flex-grow-1 p-2">
+      <div class="flex items-center flex-grow-1 p-2">
         <div class="hidden md:block">
           <span class="text-2xl text-bold"><%= @section.title %></span>
         </div>
       </div>
-      <div class="p-2">
+      <div class="flex items-center p-2">
         <div class="hidden md:block">
           <UserAccountMenu.menu id="user-account-menu" ctx={@ctx} section={@section} />
         </div>

--- a/lib/oli_web/components/header.ex
+++ b/lib/oli_web/components/header.ex
@@ -16,7 +16,7 @@ defmodule OliWeb.Components.Header do
 
   def header(assigns) do
     ~H"""
-    <nav class="navbar py-1">
+    <nav class="navbar py-1 bg-delivery-header dark:bg-delivery-header-dark">
       <div class="container mx-auto flex flex-row">
         <a
           class="navbar-brand torus-logo my-1 mr-auto"

--- a/lib/oli_web/components/header.ex
+++ b/lib/oli_web/components/header.ex
@@ -73,7 +73,7 @@ defmodule OliWeb.Components.Header do
               </button>
             </div>
           <% user_signed_in?(assigns) -> %>
-            <div class="max-w-[400px]">
+            <div class="max-w-[400px] my-auto">
               <UserAccountMenu.menu id="user-account-menu" ctx={@ctx} />
             </div>
           <% true -> %>

--- a/lib/oli_web/components/header.ex
+++ b/lib/oli_web/components/header.ex
@@ -16,7 +16,7 @@ defmodule OliWeb.Components.Header do
 
   def header(assigns) do
     ~H"""
-    <nav class="navbar py-1 bg-delivery-header dark:bg-delivery-header-dark">
+    <nav class="navbar py-1 bg-delivery-header dark:bg-delivery-header-dark shadow-sm">
       <div class="container mx-auto flex flex-row">
         <a
           class="navbar-brand torus-logo my-1 mr-auto"

--- a/lib/oli_web/live/common/card_listing.ex
+++ b/lib/oli_web/live/common/card_listing.ex
@@ -12,8 +12,8 @@ defmodule OliWeb.Common.CardListing do
 
   def render(assigns) do
     ~H"""
-    <div class="select-sources">
-      <div class="card-deck mr-0 ml-0 inline-flex flex-wrap">
+    <div class="select-sources flex justify-center">
+      <div class="card-deck mr-0 ml-0 inline-flex flex-wrap justify-center">
         <%= for item <- @model.rows do %>
           <a
             phx-click={@selected}

--- a/lib/oli_web/live/common/stepper/stepper.ex
+++ b/lib/oli_web/live/common/stepper/stepper.ex
@@ -46,7 +46,10 @@ defmodule OliWeb.Common.Stepper do
             <% end %>
           </div>
         </div>
-        <div class="bg-white dark:bg-[#0B0C11] w-full md:w-2/3 flex flex-col my-auto overflow-hidden shadow-xl">
+        <div class={[
+          "bg-white dark:bg-[#0B0C11] w-full md:w-2/3 flex flex-col overflow-y-scroll shadow-xl",
+          if(@id == "course_creation_stepper", do: "my-10", else: "my-32")
+        ]}>
           <%= @selected_step.render_fn.(@data) %>
           <div class={"p-3 flex items-center bg-gray-100/50 dark:bg-black #{if is_nil(@on_cancel), do: "justify-end", else: "justify-between"}"}>
             <%= if !is_nil(@on_cancel) do %>

--- a/lib/oli_web/live/common/stepper/stepper.ex
+++ b/lib/oli_web/live/common/stepper/stepper.ex
@@ -36,9 +36,16 @@ defmodule OliWeb.Common.Stepper do
 
     ~H"""
     <div id={@id} class="flex md:flex-row flex-col-reverse h-screen w-full">
-      <div class="bg-delivery-body-color-dark dark:bg-gray-900 h-3/5 w-full md:h-full md:w-3/5" />
       <div class="bg-blue-700 h-2/5 w-full md:h-full md:w-2/5" />
+      <div class="bg-delivery-body-color-dark dark:bg-gray-900 h-3/5 w-full md:h-full md:w-3/5" />
       <div class="flex md:flex-row flex-col-reverse absolute p-16 top-0 bottom-0 left-0 right-0 m-auto">
+        <div class="w-full md:w-1/3 my-auto z-20">
+          <div class="flex md:flex-col flex-row gap-4 md:-mr-[29px] scrollbar-hide overflow-x-auto md:overflow-x-hidden">
+            <%= for {step, index} <- @steps do %>
+              <.step index={index + 1} step={step} active={index == @current_step} />
+            <% end %>
+          </div>
+        </div>
         <div class="bg-white dark:bg-gray-800 w-full md:w-2/3 border border-gray-200 dark:border-gray-600 flex flex-col overflow-hidden">
           <%= @selected_step.render_fn.(@data) %>
           <div class={"px-9 py-4 flex items-center border-gray-200 dark:border-gray-600 border-t #{if is_nil(@on_cancel), do: "justify-end", else: "justify-between"}"}>
@@ -63,13 +70,6 @@ defmodule OliWeb.Common.Stepper do
             </div>
           </div>
         </div>
-        <div class="w-full md:w-1/3 my-auto z-10">
-          <div class="flex md:flex-col flex-row gap-4 md:-ml-7 scrollbar-hide overflow-x-auto md:overflow-x-hidden">
-            <%= for {step, index} <- @steps do %>
-              <.step index={index + 1} step={step} active={index == @current_step} />
-            <% end %>
-          </div>
-        </div>
       </div>
     </div>
     """
@@ -82,12 +82,12 @@ defmodule OliWeb.Common.Stepper do
   def step(%{index: _index, step: %Step{}, active: _active} = assigns) do
     ~H"""
     <div class="flex gap-8 items-center shrink-0 w-80 md:w-auto">
-      <div class={"flex shrink-0 items-center justify-center text-xl font-extrabold h-14 w-14 rounded-full shadow-sm #{if @active, do: "bg-primary text-white", else: "bg-white dark:bg-gray-800 border text-gray-400 border-gray-300 dark:border-gray-600"}"}>
-        <%= @index %>
-      </div>
       <div class={"flex flex-col text-white #{if !@active, do: "opacity-50"}"}>
         <h4 class="font-bold"><%= @step.title %></h4>
         <p class="font-normal"><%= @step.description %></p>
+      </div>
+      <div class={"flex shrink-0 items-center justify-center text-xl font-extrabold h-14 w-14 rounded-full shadow-sm #{if @active, do: "bg-primary text-white", else: "bg-white dark:bg-gray-800 border text-gray-400 border-gray-300 dark:border-gray-600"}"}>
+        <%= @index %>
       </div>
     </div>
     """

--- a/lib/oli_web/live/common/stepper/stepper.ex
+++ b/lib/oli_web/live/common/stepper/stepper.ex
@@ -35,28 +35,34 @@ defmodule OliWeb.Common.Stepper do
       )
 
     ~H"""
-    <div id={@id} class="flex md:flex-row flex-col-reverse h-screen w-full">
+    <div id={@id} class="flex md:flex-row flex-col-reverse h-full w-full">
       <div class="bg-blue-700 h-2/5 w-full md:h-full md:w-2/5" />
-      <div class="bg-delivery-body-color-dark dark:bg-gray-900 h-3/5 w-full md:h-full md:w-3/5" />
-      <div class="flex md:flex-row flex-col-reverse absolute p-16 top-0 bottom-0 left-0 right-0 m-auto">
+      <div class="dark:bg-gray-900 h-3/5 w-full md:h-full md:w-3/5" />
+      <div class="flex md:flex-row flex-col-reverse absolute px-8 sm:px-16 lg:px-24 xl:px-32 top-14 bottom-0 left-0 right-0 m-auto">
         <div class="w-full md:w-1/3 my-auto z-20">
-          <div class="flex md:flex-col flex-row gap-4 md:-mr-[29px] scrollbar-hide overflow-x-auto md:overflow-x-hidden">
+          <div class="flex md:flex-col flex-row gap-[42px] md:-mr-[30px] scrollbar-hide overflow-x-auto md:overflow-x-hidden">
             <%= for {step, index} <- @steps do %>
               <.step index={index + 1} step={step} active={index == @current_step} />
             <% end %>
           </div>
         </div>
-        <div class="bg-white dark:bg-gray-800 w-full md:w-2/3 border border-gray-200 dark:border-gray-600 flex flex-col overflow-hidden">
+        <div class="bg-white dark:bg-gray-800 w-full md:w-2/3 flex flex-col my-auto overflow-hidden shadow-xl">
           <%= @selected_step.render_fn.(@data) %>
-          <div class={"px-9 py-4 flex items-center border-gray-200 dark:border-gray-600 border-t #{if is_nil(@on_cancel), do: "justify-end", else: "justify-between"}"}>
+          <div class={"p-3 flex items-center #{if is_nil(@on_cancel), do: "justify-end", else: "justify-between"}"}>
             <%= if !is_nil(@on_cancel) do %>
-              <button phx-click={@on_cancel} class="torus-button secondary">
+              <button
+                phx-click={@on_cancel}
+                class="torus-button secondary py-[10px] px-5 rounded-[3px] text-sm flex items-center justify-center"
+              >
                 <%= @cancel_button_label %>
               </button>
             <% end %>
             <div class="flex gap-2">
               <%= if @current_step != 0 do %>
-                <button phx-click={@selected_step.on_previous_step} class="torus-button secondary">
+                <button
+                  phx-click={@selected_step.on_previous_step}
+                  class="torus-button secondary py-[10px] px-5 rounded-[3px] text-sm flex items-center justify-center"
+                >
                   <%= @selected_step.previous_button_label || "Previous step" %>
                 </button>
               <% end %>
@@ -81,12 +87,14 @@ defmodule OliWeb.Common.Stepper do
 
   def step(%{index: _index, step: %Step{}, active: _active} = assigns) do
     ~H"""
-    <div class="flex gap-8 items-center shrink-0 w-80 md:w-auto">
+    <div class="flex gap-6 items-center justify-between shrink-0 md:w-auto">
       <div class={"flex flex-col text-white #{if !@active, do: "opacity-50"}"}>
-        <h4 class="font-bold"><%= @step.title %></h4>
-        <p class="font-normal"><%= @step.description %></p>
+        <h4 class="font-bold text-[20px] tracking-[0.02px] leading-5 mb-[9px]"><%= @step.title %></h4>
+        <p class="font-normal text-[16px] tracking-[0.02px] leading-[24px]">
+          <%= @step.description %>
+        </p>
       </div>
-      <div class={"flex shrink-0 items-center justify-center text-xl font-extrabold h-14 w-14 rounded-full shadow-sm #{if @active, do: "bg-primary text-white", else: "bg-white dark:bg-gray-800 border text-gray-400 border-gray-300 dark:border-gray-600"}"}>
+      <div class={"flex self-start shrink-0 items-center justify-center text-xl font-extrabold h-[60px] w-[60px] rounded-full shadow-sm #{if @active, do: "bg-primary text-white", else: "bg-white dark:bg-gray-800 border text-gray-400 border-gray-300 dark:border-gray-600"}"}>
         <%= @index %>
       </div>
     </div>

--- a/lib/oli_web/live/common/stepper/stepper.ex
+++ b/lib/oli_web/live/common/stepper/stepper.ex
@@ -36,7 +36,7 @@ defmodule OliWeb.Common.Stepper do
 
     ~H"""
     <div id={@id} class="flex md:flex-row flex-col-reverse h-full w-full">
-      <div class="bg-blue-700 h-2/5 w-full md:h-full md:w-2/5" />
+      <div class="bg-blue-700 dark:bg-black h-2/5 w-full md:h-full md:w-2/5" />
       <div class="dark:bg-gray-900 h-3/5 w-full md:h-full md:w-3/5" />
       <div class="flex md:flex-row flex-col-reverse absolute px-8 sm:px-16 lg:px-24 xl:px-32 top-14 bottom-0 left-0 right-0 m-auto">
         <div class="w-full md:w-1/3 my-auto z-20">
@@ -46,13 +46,13 @@ defmodule OliWeb.Common.Stepper do
             <% end %>
           </div>
         </div>
-        <div class="bg-white dark:bg-gray-800 w-full md:w-2/3 flex flex-col my-auto overflow-hidden shadow-xl">
+        <div class="bg-white dark:bg-[#0B0C11] w-full md:w-2/3 flex flex-col my-auto overflow-hidden shadow-xl">
           <%= @selected_step.render_fn.(@data) %>
-          <div class={"p-3 flex items-center #{if is_nil(@on_cancel), do: "justify-end", else: "justify-between"}"}>
+          <div class={"p-3 flex items-center bg-gray-100/50 dark:bg-black #{if is_nil(@on_cancel), do: "justify-end", else: "justify-between"}"}>
             <%= if !is_nil(@on_cancel) do %>
               <button
                 phx-click={@on_cancel}
-                class="torus-button secondary py-[10px] px-5 rounded-[3px] text-sm flex items-center justify-center"
+                class="torus-button secondary !py-[10px] !px-5 !rounded-[3px] !text-sm flex items-center justify-center  dark:!text-white dark:!bg-black dark:hover:!bg-gray-900"
               >
                 <%= @cancel_button_label %>
               </button>
@@ -61,15 +61,16 @@ defmodule OliWeb.Common.Stepper do
               <%= if @current_step != 0 do %>
                 <button
                   phx-click={@selected_step.on_previous_step}
-                  class="torus-button secondary py-[10px] px-5 rounded-[3px] text-sm flex items-center justify-center"
+                  class="torus-button secondary !py-[10px] !px-5 !rounded-[3px] !text-sm flex items-center justify-center  dark:!text-white dark:!bg-black dark:hover:!bg-gray-900"
                 >
-                  <%= @selected_step.previous_button_label || "Previous step" %>
+                  <i class="fa-solid fa-arrow-left mr-2"></i><%= @selected_step.previous_button_label ||
+                    "Previous step" %>
                 </button>
               <% end %>
               <button
                 disabled={@next_step_disabled}
                 phx-click={@selected_step.on_next_step}
-                class="torus-button primary"
+                class="torus-button primary !py-[10px] !px-5 !rounded-[3px] !text-sm flex items-center justify-center"
               >
                 <%= @selected_step.next_button_label || "Next step" %>
               </button>
@@ -94,7 +95,7 @@ defmodule OliWeb.Common.Stepper do
           <%= @step.description %>
         </p>
       </div>
-      <div class={"flex self-start shrink-0 items-center justify-center text-xl font-extrabold h-[60px] w-[60px] rounded-full shadow-sm #{if @active, do: "bg-primary text-white", else: "bg-white dark:bg-gray-800 border text-gray-400 border-gray-300 dark:border-gray-600"}"}>
+      <div class={"flex self-start shrink-0 items-center justify-center text-xl font-extrabold h-[60px] w-[60px] rounded-full shadow-sm #{if @active, do: "bg-primary text-white", else: "bg-white dark:bg-black border text-gray-400 border-gray-300 dark:border-gray-600"}"}>
         <%= @index %>
       </div>
     </div>

--- a/lib/oli_web/live/delivery/student_onboarding/explorations.ex
+++ b/lib/oli_web/live/delivery/student_onboarding/explorations.ex
@@ -15,7 +15,7 @@ defmodule OliWeb.Delivery.StudentOnboarding.Explorations do
           </span>
         </div>
       </div>
-      <img class="aspect-video w-full my-10n h-[334px]" src="/images/exploration.gif" />
+      <img class="aspect-video w-full h-[334px]" src="/images/exploration.gif" />
       <p class="text-[14px] leading-[20px] tracking-[0.02px] dark:text-white px-[84px] py-9">
         You will have access to both simulations and digital versions of tools used in the real world to help you explore the topics brought up in the course from a real-world perspective.
       </p>

--- a/lib/oli_web/live/delivery/student_onboarding/explorations.ex
+++ b/lib/oli_web/live/delivery/student_onboarding/explorations.ex
@@ -1,6 +1,7 @@
 defmodule OliWeb.Delivery.StudentOnboarding.Explorations do
   use Phoenix.Component
 
+  # TODO add real DOT svg icon instead of the gray rounded placeholder
   def render(assigns) do
     ~H"""
     <div class="h-full">

--- a/lib/oli_web/live/delivery/student_onboarding/explorations.ex
+++ b/lib/oli_web/live/delivery/student_onboarding/explorations.ex
@@ -5,7 +5,7 @@ defmodule OliWeb.Delivery.StudentOnboarding.Explorations do
     ~H"""
     <div class="h-full">
       <div class="flex pt-12 pb-6 px-[84px] gap-3">
-        <div class="h-14 w-14 bg-gray-700 rounded-full" />
+        <div class="h-14 w-14 bg-gray-700 rounded-full shrink-0" />
         <div class="flex flex-col gap-3">
           <h2 class="text-[40px] leading-[54px] tracking-[0.02px] dark:text-white">
             Exploration Activities

--- a/lib/oli_web/live/delivery/student_onboarding/explorations.ex
+++ b/lib/oli_web/live/delivery/student_onboarding/explorations.ex
@@ -3,13 +3,20 @@ defmodule OliWeb.Delivery.StudentOnboarding.Explorations do
 
   def render(assigns) do
     ~H"""
-    <div class="h-full text-center">
-      <h2>Exploration Activities</h2>
-      <span class="text-gray-500 text-sm">
-        Explorations dig into how the course subject matter affects you
-      </span>
-      <img class="aspect-video w-full" src="/images/exploration.gif" />
-      <p class="mt-14">
+    <div class="h-full">
+      <div class="flex pt-12 pb-6 px-[84px] gap-3">
+        <div class="h-14 w-14 bg-gray-700 rounded-full" />
+        <div class="flex flex-col gap-3">
+          <h2 class="text-[40px] leading-[54px] tracking-[0.02px] dark:text-white">
+            Exploration Activities
+          </h2>
+          <span class="text-[14px] leading-[20px] tracking-[0.02px] dark:text-white">
+            Explorations dig into how the course subject matter affects you
+          </span>
+        </div>
+      </div>
+      <img class="aspect-video w-full my-10n h-[334px]" src="/images/exploration.gif" />
+      <p class="text-[14px] leading-[20px] tracking-[0.02px] dark:text-white px-[84px] py-9">
         You will have access to both simulations and digital versions of tools used in the real world to help you explore the topics brought up in the course from a real-world perspective.
       </p>
     </div>

--- a/lib/oli_web/live/delivery/student_onboarding/intro.ex
+++ b/lib/oli_web/live/delivery/student_onboarding/intro.ex
@@ -10,12 +10,14 @@ defmodule OliWeb.Delivery.StudentOnboarding.Intro do
 
   def render(assigns) do
     ~H"""
-    <div class="flex flex-col gap-6">
-      <img class="object-cover h-80 w-full" src={cover_image(@section)} />
-      <h2>Welcome to <%= @section.title %>!</h2>
-      <div>
-        <p class="font-bold mb-0">Here's what to expect</p>
-        <ul class="list-disc ml-6">
+    <img class="object-cover h-[386px] w-full" src={cover_image(@section)} />
+    <div class="flex flex-col gap-3 px-[84px] py-9 dark:text-white">
+      <h2 class="font-semibold text-[40px] leading-[54px] tracking-[0.02px]">
+        Welcome to <%= @section.title %>!
+      </h2>
+      <div class="text-[14px] leading-5 tracking-[0.02px] dark:text-opacity-80">
+        <p class="font-bold mb-0">Here's what to expect:</p>
+        <ul class="font-normal list-disc ml-6">
           <%= if has_required_survey(@section) do %>
             <li>
               A 5 minute survey to help shape learning your experience and let your instructor get to know you
@@ -23,7 +25,7 @@ defmodule OliWeb.Delivery.StudentOnboarding.Intro do
           <% end %>
           <%= if has_explorations(@section) do %>
             <li>
-              Explorations will bring the course to life, showing its relevance in the real world
+              Learning about the new ‘Exploration’ activities that provide real-world examples
             </li>
           <% end %>
           <li>A personalized <%= @section.title %> experience based on your skillsets</li>

--- a/lib/oli_web/live/delivery/student_onboarding/survey.ex
+++ b/lib/oli_web/live/delivery/student_onboarding/survey.ex
@@ -99,6 +99,7 @@ defmodule OliWeb.Delivery.StudentOnboarding.Survey do
   attr :survey, :map, required: true
   attr :datashop_session_id, :string, required: true
 
+  # TODO add real DOT svg icon instead of the gray rounded placeholder
   def render(assigns) do
     ~H"""
     <div id="eventIntercept" phx-target={@myself} phx-hook="LoadSurveyScripts" class="h-full">

--- a/lib/oli_web/live/delivery/student_onboarding/survey.ex
+++ b/lib/oli_web/live/delivery/student_onboarding/survey.ex
@@ -110,14 +110,23 @@ defmodule OliWeb.Delivery.StudentOnboarding.Survey do
           Something went wrong when loading the survey
         </div>
       <% else %>
+        <div class="flex pt-12 pb-6 px-[84px] gap-3">
+          <div class="h-14 w-14 bg-gray-700 rounded-full shrink-0" />
+          <div class="flex flex-col gap-3">
+            <h2 class="text-[40px] leading-[54px] tracking-[0.02px] dark:text-white">
+              <%= @title %>
+            </h2>
+            <span class="text-[14px] leading-[20px] tracking-[0.02px] dark:text-white">
+              We’ve pulled the information we can from your LMS, but feel free to adjust it!
+            </span>
+          </div>
+        </div>
         <%= if @loaded do %>
-          <h1 class="mb-4"><%= @title %></h1>
-          <hr class="text-gray-400 my-4" />
-          <div class="pb-1">
+          <div class="px-[84px] py-9 my-10 h-[334px]">
             <%= Phoenix.HTML.raw(@html) %>
           </div>
         <% else %>
-          <div class="h-full w-full flex items-center justify-center">
+          <div class="w-full flex items-center justify-center my-10 h-[334px]">
             <span
               class="spinner-border spinner-border-sm text-primary h-16 w-16"
               role="status"

--- a/lib/oli_web/live/delivery/student_onboarding/wizard.ex
+++ b/lib/oli_web/live/delivery/student_onboarding/wizard.ex
@@ -8,6 +8,8 @@ defmodule OliWeb.Delivery.StudentOnboarding.Wizard do
 
   alias Phoenix.LiveView.JS
 
+  import OliWeb.Components.Delivery.Layouts
+
   @intro_step :intro
   @survey_step :survey
   @explorations_step :explorations
@@ -102,7 +104,8 @@ defmodule OliWeb.Delivery.StudentOnboarding.Wizard do
 
   def render(assigns) do
     ~H"""
-    <div>
+    <.header ctx={@ctx} section={@section} brand={@brand} preview_mode={@preview_mode} />
+    <div class="mt-14 h-[calc(100vh-56px)]">
       <.live_component
         id="student-onboarding-wizard"
         module={Stepper}
@@ -118,12 +121,9 @@ defmodule OliWeb.Delivery.StudentOnboarding.Wizard do
   slot(:inner_block, required: true)
   attr(:section, :map, required: true)
 
-  defp header(assigns) do
+  defp wizard_header(assigns) do
     ~H"""
-    <h5 class="px-9 py-4 border-gray-200 dark:border-gray-600 border-b text-sm font-semibold">
-      <%= @section.title %> Set Up
-    </h5>
-    <div class="overflow-y-auto scrollbar-hide relative h-full px-10 py-4">
+    <div class="overflow-y-auto scrollbar-hide relative h-full pb-4">
       <%= render_slot(@inner_block) %>
     </div>
     """
@@ -133,15 +133,15 @@ defmodule OliWeb.Delivery.StudentOnboarding.Wizard do
 
   def render_step(%{current_step_name: @intro_step} = assigns) do
     ~H"""
-    <.header section={@section}>
+    <.wizard_header section={@section}>
       <Intro.render section={@section} />
-    </.header>
+    </.wizard_header>
     """
   end
 
   def render_step(%{current_step_name: @survey_step} = assigns) do
     ~H"""
-    <.header section={@section}>
+    <.wizard_header section={@section}>
       <.live_component
         id="onboarding_wizard_survey"
         module={Survey}
@@ -150,15 +150,15 @@ defmodule OliWeb.Delivery.StudentOnboarding.Wizard do
         survey={@survey}
         datashop_session_id={@datashop_session_id}
       />
-    </.header>
+    </.wizard_header>
     """
   end
 
   def render_step(%{current_step_name: @explorations_step} = assigns) do
     ~H"""
-    <.header section={@section}>
+    <.wizard_header section={@section}>
       <Explorations.render />
-    </.header>
+    </.wizard_header>
     """
   end
 

--- a/lib/oli_web/live/delivery/student_onboarding/wizard.ex
+++ b/lib/oli_web/live/delivery/student_onboarding/wizard.ex
@@ -13,8 +13,8 @@ defmodule OliWeb.Delivery.StudentOnboarding.Wizard do
   @explorations_step :explorations
   @course_step :course
 
-  @survey_label "Start survey"
-  @explorations_label "Go to explorations"
+  @survey_label "Start Survey"
+  @explorations_label "Let's Begin"
   @course_label "Go to course"
 
   def mount(_params, %{"datashop_session_id" => datashop_session_id}, socket) do

--- a/lib/oli_web/live/new_course/new_course.ex
+++ b/lib/oli_web/live/new_course/new_course.ex
@@ -1,6 +1,12 @@
 defmodule OliWeb.Delivery.NewCourse do
   use OliWeb, :live_view
 
+  on_mount(OliWeb.LiveSessionPlugs.SetSection)
+  on_mount(OliWeb.LiveSessionPlugs.SetCurrentUser)
+  on_mount(OliWeb.LiveSessionPlugs.SetSessionContext)
+  on_mount(OliWeb.LiveSessionPlugs.SetBrand)
+  on_mount(OliWeb.LiveSessionPlugs.SetPreviewMode)
+
   alias Oli.Accounts
   alias Oli.Delivery
   alias Oli.Lti.LtiParams
@@ -15,6 +21,8 @@ defmodule OliWeb.Delivery.NewCourse do
   alias Lti_1p3.Tool.ContextRoles
 
   alias Phoenix.LiveView.JS
+
+  import OliWeb.Components.Delivery.Layouts
 
   @form_id "open_and_free_form"
   def mount(_params, session, socket) do
@@ -88,7 +96,8 @@ defmodule OliWeb.Delivery.NewCourse do
 
   def render(assigns) do
     ~H"""
-    <div id={@form_id} phx-hook="SubmitForm">
+    <.header ctx={@ctx} section={@section} brand={@brand} preview_mode={@preview_mode} />
+    <div id={@form_id} phx-hook="SubmitForm" class="mt-14 h-[calc(100vh-56px)]">
       <.live_component
         id="course_creation_stepper"
         module={Stepper}
@@ -104,7 +113,7 @@ defmodule OliWeb.Delivery.NewCourse do
 
   slot(:inner_block, required: true)
 
-  defp header(assigns) do
+  defp new_course_header(assigns) do
     ~H"""
     <h5 class="px-9 py-4 border-gray-200 dark:border-gray-600 border-b text-sm font-semibold">
       New course set up
@@ -140,8 +149,8 @@ defmodule OliWeb.Delivery.NewCourse do
 
   def render_step(:select_source, assigns) do
     ~H"""
-    <.header>
-      <div class="flex flex-col items-center gap-3 pl-9 pr-16 py-6">
+    <.new_course_header>
+      <div class="flex flex-col items-center gap-3 pr-9 pl-16 py-6">
         <h2>Select source</h2>
         <.live_component
           id="select_source_step"
@@ -153,33 +162,33 @@ defmodule OliWeb.Delivery.NewCourse do
           lti_params={@lti_params}
         />
       </div>
-    </.header>
+    </.new_course_header>
     """
   end
 
   def render_step(:name_course, assigns) do
     ~H"""
-    <.header>
-      <div class="flex flex-col items-center gap-3 pl-9 pr-16 py-6">
+    <.new_course_header>
+      <div class="flex flex-col items-center gap-3 pr-9 pl-16 py-6">
         <img src="/images/icons/course-creation-wizard-step-1.svg" style="height: 170px;" />
         <h2>Name your course</h2>
         <.render_flash flash={@flash} />
         <NameCourse.render changeset={to_form(@changeset)} />
       </div>
-    </.header>
+    </.new_course_header>
     """
   end
 
   def render_step(:course_details, assigns) do
     ~H"""
-    <.header>
-      <div class="flex flex-col items-center gap-3 pl-9 pr-16 py-6">
+    <.new_course_header>
+      <div class="flex flex-col items-center gap-3 pr-9 pl-16 py-6">
         <img src="/images/icons/course-creation-wizard-step-2.svg" style="height: 170px;" />
         <h2>Course details</h2>
         <.render_flash flash={@flash} />
         <CourseDetails.render changeset={to_form(@changeset)} />
       </div>
-    </.header>
+    </.new_course_header>
     """
   end
 

--- a/lib/oli_web/live_session_plugs/set_section.ex
+++ b/lib/oli_web/live_session_plugs/set_section.ex
@@ -26,6 +26,6 @@ defmodule OliWeb.LiveSessionPlugs.SetSection do
   end
 
   def on_mount(:default, _params, _session, socket) do
-    {:cont, socket}
+    {:cont, assign(socket, section: nil)}
   end
 end

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -1049,6 +1049,9 @@ defmodule OliWeb.Router do
       on_mount: [
         OliWeb.LiveSessionPlugs.SetSection,
         OliWeb.LiveSessionPlugs.SetCurrentUser,
+        OliWeb.LiveSessionPlugs.SetSessionContext,
+        OliWeb.LiveSessionPlugs.SetBrand,
+        OliWeb.LiveSessionPlugs.SetPreviewMode,
         OliWeb.LiveSessionPlugs.RequireEnrollment
       ] do
       live(

--- a/test/oli_web/live/delivery/onboarding_wizard/student_onboarding_wizard_test.exs
+++ b/test/oli_web/live/delivery/onboarding_wizard/student_onboarding_wizard_test.exs
@@ -64,7 +64,6 @@ defmodule OliWeb.Deliver.StudentOnboarding.WizardTest do
 
       {:ok, view, _html} = live(conn, onboarding_wizard_route(section.slug))
 
-      assert has_element?(view, "h5", "Chemistry 201 Set Up")
       assert has_element?(view, "h2", "Welcome to Chemistry 201!")
 
       assert has_element?(
@@ -101,10 +100,10 @@ defmodule OliWeb.Deliver.StudentOnboarding.WizardTest do
       assert has_element?(
                view,
                "li",
-               "Explorations will bring the course to life, showing its relevance in the real world"
+               "Learning about the new ‘Exploration’ activities that provide real-world examples"
              )
 
-      assert has_element?(view, "button", "Go to explorations")
+      assert has_element?(view, "button", "Let's Begin")
     end
 
     test "the survey description rendered when the section has a survey", %{
@@ -122,7 +121,7 @@ defmodule OliWeb.Deliver.StudentOnboarding.WizardTest do
                "A 5 minute survey to help shape learning your experience and let your instructor get to know you"
              )
 
-      assert has_element?(view, "button", "Start survey")
+      assert has_element?(view, "button", "Start Survey")
     end
   end
 
@@ -139,7 +138,7 @@ defmodule OliWeb.Deliver.StudentOnboarding.WizardTest do
       {:ok, view, _html} = live(conn, onboarding_wizard_route(section.slug))
 
       view
-      |> element("button", "Start survey")
+      |> element("button", "Start Survey")
       |> render_click()
 
       view
@@ -165,7 +164,7 @@ defmodule OliWeb.Deliver.StudentOnboarding.WizardTest do
       {:ok, view, _html} = live(conn, onboarding_wizard_route(section.slug))
 
       view
-      |> element("button", "Go to explorations")
+      |> element("button", "Let's Begin")
       |> render_click()
 
       assert has_element?(view, "h2", "Exploration Activities")

--- a/test/oli_web/live/delivery/onboarding_wizard/student_onboarding_wizard_test.exs
+++ b/test/oli_web/live/delivery/onboarding_wizard/student_onboarding_wizard_test.exs
@@ -145,7 +145,7 @@ defmodule OliWeb.Deliver.StudentOnboarding.WizardTest do
       |> element("#eventIntercept")
       |> render_hook("survey_scripts_loaded", %{"loaded" => true})
 
-      assert has_element?(view, "h1", "Course Survey")
+      assert has_element?(view, "h2", "Course Survey")
       assert has_element?(view, "oli-multiple-choice-delivery")
       assert has_element?(view, "button", "Go to course")
     end


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/NG23-23) to the ticket

This PR implements the onboarding wizard to match the Figma design.
**In the "exploration" and "survey" steps there is a gray rounded placeholder for the DOT SVG icon (I was not allowed to export it).**

https://github.com/Simon-Initiative/oli-torus/assets/74839302/84184802-f024-423f-a735-03ba6c9eaa59



Since the instructor's new course wizard is based on the same component, this PR also adjusts that wizard to have the same look and feel as the latest designs.

https://github.com/Simon-Initiative/oli-torus/assets/74839302/fdcba0ca-d749-49fd-9664-5394d91c3d64


Finally, some minor adjustments were made

- Align the user account menu and the course title vertically on the navbar, and added a small bottom shadow to it
### Before
![image](https://github.com/Simon-Initiative/oli-torus/assets/74839302/fdac23e2-f3e0-4584-8dd2-a57acbd1586d)
### After
![image](https://github.com/Simon-Initiative/oli-torus/assets/74839302/fa76b7be-921b-4194-8301-6d686562fe25)


- Added missing background on some header navbars and align the user account menu vertically
### Before
![image](https://github.com/Simon-Initiative/oli-torus/assets/74839302/ec69c4f9-809e-4efc-896f-ba3e7cfeaeef)

### After
![image](https://github.com/Simon-Initiative/oli-torus/assets/74839302/f5269375-135e-4cc3-be9c-15ee8c82e12a)





