### PR TITLE
[MER-2556] Convert products and payments views to use DB powered tables

### DIFF
--- a/lib/oli/delivery/paywall.ex
+++ b/lib/oli/delivery/paywall.ex
@@ -658,6 +658,27 @@ defmodule Oli.Delivery.Paywall do
     Repo.get_by(Payment, clauses)
   end
 
+  @doc """
+  Fetches and filters payment records based on various parameters.
+
+  This function retrieves payment records, optionally filtering them based on product, paging, sorting, and text search criteria.
+
+  ## Parameters
+
+  - `product_slug` (String): The slug of the product to filter payments for.
+  - `%Paging{limit: limit, offset: offset}` (Paging struct): Specifies the limit and offset for paging the results.
+  - `%Sorting{direction: direction, field: field}` (Sorting struct): Specifies the sorting direction and field for ordering the results.
+  - `opts` (Keyword list, optional): Additional options, including `:text_search` for text-based filtering.
+
+  ## Returns
+
+  A list of payment records matching the specified criteria.
+
+  ## Examples
+
+  iex> browse_payments("example-product", %Paging{limit: 10, offset: 0}, %Sorting{direction: :asc, field: :type})
+    [%Payment{}, %Payment{}, ...]
+  """
   def browse_payments(
         product_slug,
         %Paging{limit: limit, offset: offset},
@@ -691,7 +712,7 @@ defmodule Oli.Delivery.Paywall do
       Payment
       |> join(:left, [p], e in Enrollment, on: e.id == p.enrollment_id)
       |> join(:left, [_p, e], u in User, on: e.user_id == u.id)
-      |> join(:left, [p, _e, _u], s in Section,
+      |> join(:inner, [p, _e, _u], s in Section,
         on: p.section_id == s.id and s.slug == ^product_slug
       )
       |> where(^filter_by_text)

--- a/lib/oli/delivery/paywall.ex
+++ b/lib/oli/delivery/paywall.ex
@@ -677,9 +677,7 @@ defmodule Oli.Delivery.Paywall do
         dynamic(
           [p, _, _, s],
           fragment(
-            """
-            ((crockford_base32_encode(?) ILIKE ?) OR (NOT (? IS NULL) AND (? ILIKE ?)))
-            """,
+            "((crockford_base32_encode(?) ILIKE ?) OR (NOT (? IS NULL) AND (? ILIKE ?)))",
             p.code,
             ^"%#{text_search}%",
             s,
@@ -738,9 +736,7 @@ defmodule Oli.Delivery.Paywall do
             [_, _, u, _],
             {^direction,
              fragment(
-               """
-               CONCAT(COALESCE(?, ''), ' ', COALESCE(?, ''))
-               """,
+               "CONCAT(COALESCE(?, ''), ' ', COALESCE(?, ''))",
                u.family_name,
                u.given_name
              )}

--- a/lib/oli/delivery/sections/blueprint.ex
+++ b/lib/oli/delivery/sections/blueprint.ex
@@ -359,6 +359,26 @@ defmodule Oli.Delivery.Sections.Blueprint do
     |> Repo.all()
   end
 
+  @doc """
+  Fetches and filters section records based on various parameters.
+
+  This function retrieves section records, optionally filtering them based on paging, sorting, and text search criteria.
+
+  ## Parameters
+
+  - `%Paging{offset: offset, limit: limit}` (Paging struct): Specifies the limit and offset for paging the results.
+  - `%Sorting{direction: direction, field: field}` (Sorting struct): Specifies the sorting direction and field for ordering the results.
+  - `opts` (Keyword list, optional): Additional options, including `:project_id`, `:include_archived`, and `:text_search` for filtering.
+
+  ## Returns
+
+  A list of section records matching the specified criteria.
+
+  ## Examples
+
+  iex> browse(%Paging{offset: 0, limit: 10}, %Sorting{direction: :asc, field: :title}, [project_id: 1234, include_archived: false, text_search: "example"])
+  [%Section{}, %Section{}, ...]
+  """
   def browse(
         %Paging{offset: offset, limit: limit},
         %Sorting{direction: direction, field: field},
@@ -428,7 +448,7 @@ defmodule Oli.Delivery.Sections.Blueprint do
              fragment(
                """
                  CASE
-                   WHEN ? THEN COALESCE(? ->> 'id', 'Yes')
+                   WHEN ? THEN COALESCE(? ->> 'amount', 'Yes')
                    ELSE 'None'
                  END
                """,

--- a/lib/oli/delivery/sections/blueprint.ex
+++ b/lib/oli/delivery/sections/blueprint.ex
@@ -409,6 +409,7 @@ defmodule Oli.Delivery.Sections.Blueprint do
       |> limit(^limit)
       |> offset(^offset)
       |> order_by([p, _, _, _], {^direction, field(p, ^field)})
+      |> select([s, _bp], %{s | total_count: fragment("count(*) OVER()")})
 
     query =
       case field do

--- a/lib/oli_web/live/common/text_search.ex
+++ b/lib/oli_web/live/common/text_search.ex
@@ -2,7 +2,6 @@ defmodule OliWeb.Common.TextSearch do
   use OliWeb, :live_component
 
   attr(:id, :string)
-  attr(:apply, :string, default: "text_search_apply")
   attr(:reset, :string, default: "text_search_reset")
   attr(:change, :string, default: "text_search_change")
   attr(:placeholder, :string, default: "Search...")

--- a/lib/oli_web/live/common/text_search.ex
+++ b/lib/oli_web/live/common/text_search.ex
@@ -36,7 +36,12 @@ defmodule OliWeb.Common.TextSearch do
         </div>
       <% end %>
       <div :if={@tooltip} class="m-2 opacity-50 hover:cursor-help">
-        <span id={@id <> "_tooltip"} title={@tooltip} class="fas fa-info-circle" phx-hook="TooltipInit"/>
+        <span
+          id={@id <> "_tooltip"}
+          title={@tooltip}
+          class="fas fa-info-circle"
+          phx-hook="TooltipInit"
+        />
       </div>
     </div>
     """

--- a/lib/oli_web/live/common/text_search.ex
+++ b/lib/oli_web/live/common/text_search.ex
@@ -8,6 +8,7 @@ defmodule OliWeb.Common.TextSearch do
   attr(:placeholder, :string, default: "Search...")
   attr(:text, :string, default: "")
   attr(:event_target, :any, required: false, default: :live_view)
+  attr(:tooltip, :string, required: false, default: nil)
 
   def render(assigns) do
     ~H"""
@@ -35,6 +36,9 @@ defmodule OliWeb.Common.TextSearch do
           </button>
         </div>
       <% end %>
+      <div :if={@tooltip} class="m-2 opacity-50 hover:cursor-help">
+        <span id={@id <> "_tooltip"} title={@tooltip} class="fas fa-info-circle" phx-hook="TooltipInit"/>
+      </div>
     </div>
     """
   end

--- a/lib/oli_web/live/products/payments/table_model.ex
+++ b/lib/oli_web/live/products/payments/table_model.ex
@@ -8,8 +8,7 @@ defmodule OliWeb.Products.Payments.TableModel do
     inserted_at_spec = %ColumnSpec{
       name: :generation_date,
       label: "Created Date",
-      render_fn: &Common.render_date/3,
-      sort_fn: &__MODULE__.sort_date/2
+      render_fn: &__MODULE__.render_date/3
     }
 
     SortableTableModel.new(
@@ -19,15 +18,13 @@ defmodule OliWeb.Products.Payments.TableModel do
           name: :type,
           label: "Type",
           render_fn: &__MODULE__.render_type_column/3,
-          sort_fn: &__MODULE__.sort/2,
           td_class: "text-center text-nowrap"
         },
         inserted_at_spec,
         %ColumnSpec{
           name: :application_date,
           label: "Application Date",
-          render_fn: &Common.render_date/3,
-          sort_fn: &__MODULE__.sort_date/2
+          render_fn: &__MODULE__.render_date/3
         },
         %ColumnSpec{
           name: :details,
@@ -149,25 +146,8 @@ defmodule OliWeb.Products.Payments.TableModel do
     end
   end
 
-  def sort(direction, _) do
-    {fn v ->
-       case v.payment.type do
-         :direct -> "zzzDirect: #{v.payment.provider_type}"
-         :deferred -> "Code: [#{v.code}]"
-       end
-     end, direction}
-  end
-
-  def sort_date(direction, spec) do
-    {fn r ->
-       case Map.get(r.payment, spec.name) do
-         nil ->
-           0
-
-         d ->
-           DateTime.to_unix(d)
-       end
-     end, direction}
+  def render_date(assigns, item, column_spec) do
+    Common.render_date(assigns, item.payment, column_spec)
   end
 
   def render(assigns) do

--- a/lib/oli_web/live/products/payments_view.ex
+++ b/lib/oli_web/live/products/payments_view.ex
@@ -1,37 +1,16 @@
 defmodule OliWeb.Products.PaymentsView do
   use OliWeb, :live_view
-  use OliWeb.Common.SortableTable.TableHandlers
 
-  alias OliWeb.Common.Filter
-  alias OliWeb.Common.Listing
-  alias OliWeb.Common.Breadcrumb
-  alias OliWeb.Products.Payments.CreateCodes
+  import OliWeb.DelegatedEvents
+
+  alias Oli.Delivery.Paywall
+  alias Oli.Repo.{Paging, Sorting}
+  alias OliWeb.Common.{Breadcrumb, Params, PagedTable, SessionContext, TextSearch}
   alias OliWeb.Common.Table.SortableTableModel
+  alias OliWeb.Products.Payments.CreateCodes
   alias OliWeb.Router.Helpers, as: Routes
-  alias OliWeb.Common.SessionContext
 
-  @table_filter_fn &OliWeb.Products.PaymentsView.filter_rows/3
-  @table_push_patch_path &OliWeb.Products.PaymentsView.live_path/2
-
-  def filter_rows(socket, query, _filter) do
-    case String.downcase(query) do
-      "" ->
-        socket.assigns.payments
-
-      str ->
-        Enum.filter(socket.assigns.payments, fn p ->
-          title =
-            case is_nil(p.section) do
-              true -> ""
-              false -> p.section.title
-            end
-
-          String.contains?(String.downcase(p.code), str) or
-            String.contains?(String.downcase(title), str)
-        end)
-    end
-  end
-
+  @limit 25
   def live_path(socket, params) do
     Routes.live_path(socket, OliWeb.Products.PaymentsView, socket.assigns.product_slug, params)
   end
@@ -39,9 +18,13 @@ defmodule OliWeb.Products.PaymentsView do
   def mount(%{"product_id" => product_slug}, session, socket) do
     ctx = SessionContext.init(socket, session)
 
-    payments = list_payments(product_slug)
+    payments =
+      browse_payments(product_slug, %Paging{offset: 0, limit: @limit}, %Sorting{
+        direction: :asc,
+        field: :type
+      })
 
-    total_count = length(payments)
+    total_count = determine_total(payments)
 
     {:ok, table_model} = OliWeb.Products.Payments.TableModel.new(payments, ctx)
 
@@ -50,7 +33,6 @@ defmodule OliWeb.Products.PaymentsView do
        ctx: ctx,
        product: Oli.Delivery.Sections.get_section_by(slug: product_slug),
        product_slug: product_slug,
-       payments: payments,
        total_count: total_count,
        table_model: table_model,
        breadcrumbs: [Breadcrumb.new(%{full_title: "Payments"})],
@@ -58,7 +40,7 @@ defmodule OliWeb.Products.PaymentsView do
        code_count: 50,
        offset: 0,
        limit: 20,
-       applied_query: "",
+       text_search: "",
        download_enabled: false
      )}
   end
@@ -77,63 +59,114 @@ defmodule OliWeb.Products.PaymentsView do
 
       <hr class="mt-5 mb-5" />
 
-      <Filter.render apply="apply_search" change="change_search" reset="reset_search" />
+      <TextSearch.render
+        id="text-search"
+        apply="text_search_apply"
+        reset="text_search_reset"
+        change="text_search_change"
+        text={@text_search}
+        event_target={nil}
+      />
 
       <div class="mb-3" />
 
-      <Listing.render
-        filter={@applied_query}
-        table_model={@table_model}
+      <PagedTable.render
+        page_change="paged_table_page_change"
+        sort="paged_table_sort"
         total_count={@total_count}
-        offset={@offset}
+        filter={@text_search}
+        allow_selection={false}
         limit={@limit}
-        sort="sort"
-        page_change="page_change"
+        offset={@offset}
+        table_model={@table_model}
+        show_bottom_paging={true}
       />
     </div>
     """
   end
 
-  defp list_payments(product_slug) do
-    Oli.Delivery.Paywall.list_payments(product_slug)
+  def handle_params(params, _, socket) do
+    table_model =
+      SortableTableModel.update_from_params(
+        socket.assigns.table_model,
+        params
+      )
+
+    offset = Params.get_int_param(params, "offset", 0)
+    text_search = Params.get_param(params, "text_search", "")
+
+    payments =
+      browse_payments(
+        socket.assigns.product_slug,
+        %Paging{offset: offset, limit: @limit},
+        %Sorting{direction: table_model.sort_order, field: table_model.sort_by_spec.name},
+        text_search
+      )
+
+    table_model = Map.put(table_model, :rows, payments)
+
+    total_count = determine_total(payments)
+
+    {:noreply,
+     assign(socket,
+       offset: offset,
+       table_model: table_model,
+       total_count: total_count,
+       text_search: text_search
+     )}
+  end
+
+  defp browse_payments(product_slug, paging, sorting, text_search \\ "") do
+    Paywall.browse_payments(
+      product_slug,
+      paging,
+      sorting,
+      text_search: text_search
+    )
     |> Enum.map(fn element ->
       Map.put(
         element,
         :code,
-        if is_nil(element.payment.code) do
-          ""
-        else
-          Oli.Delivery.Paywall.Payment.to_human_readable(element.payment.code)
+        case element.payment.code do
+          nil ->
+            ""
+
+          code ->
+            Paywall.Payment.to_human_readable(code)
         end
       )
       |> Map.put(:unique_id, element.payment.id)
     end)
   end
 
-  def handle_event("create", _, socket) do
+  def handle_event("create", _, %{assigns: assigns} = socket) do
     create_payment_codes =
-      Oli.Delivery.Paywall.create_payment_codes(
-        socket.assigns.product_slug,
-        socket.assigns.code_count
+      Paywall.create_payment_codes(
+        assigns.product_slug,
+        assigns.code_count
       )
 
     case create_payment_codes do
       {:ok, _} ->
-        payments = list_payments(socket.assigns.product_slug)
-
-        {:ok, table_model} =
-          OliWeb.Products.Payments.TableModel.new(
-            payments,
-            socket.assigns.ctx
+        payments =
+          browse_payments(
+            assigns.product_slug,
+            %Paging{offset: assigns.offset, limit: @limit},
+            %Sorting{
+              direction: assigns.table_model.sort_order,
+              field: assigns.table_model.sort_by_spec.name
+            },
+            assigns.text_search
           )
 
-        total_count = length(payments)
+        table_model = Map.put(assigns.table_model, :rows, payments)
+
+        total_count = determine_total(payments)
 
         {:noreply,
          socket
          |> put_flash(:info, "Payment codes successfully added.")
          |> assign(
-           payments: payments,
            total_count: total_count,
            table_model: table_model,
            download_enabled: true
@@ -154,5 +187,40 @@ defmodule OliWeb.Products.PaymentsView do
       end
 
     {:noreply, assign(socket, code_count: count, download_enabled: false)}
+  end
+
+  def handle_event(event, params, socket) do
+    {event, params, socket, &__MODULE__.patch_with/2}
+    |> delegate_to([
+      &TextSearch.handle_delegated/4,
+      &PagedTable.handle_delegated/4
+    ])
+  end
+
+  def patch_with(socket, changes) do
+    {:noreply,
+     push_patch(socket,
+       to:
+         live_path(
+           socket,
+           Map.merge(
+             %{
+               sort_by: socket.assigns.table_model.sort_by_spec.name,
+               sort_order: socket.assigns.table_model.sort_order,
+               offset: socket.assigns.offset,
+               text_search: socket.assigns.text_search
+             },
+             changes
+           )
+         ),
+       replace: true
+     )}
+  end
+
+  defp determine_total(payments) do
+    case payments do
+      [] -> 0
+      [hd | _] -> hd.total_count
+    end
   end
 end

--- a/lib/oli_web/live/products/payments_view.ex
+++ b/lib/oli_web/live/products/payments_view.ex
@@ -11,6 +11,9 @@ defmodule OliWeb.Products.PaymentsView do
   alias OliWeb.Router.Helpers, as: Routes
 
   @limit 20
+  @text_search_tooltip """
+  Search by payment code and section title.
+  """
 
   def live_path(socket, params) do
     Routes.live_path(socket, OliWeb.Products.PaymentsView, socket.assigns.product_slug, params)
@@ -42,6 +45,7 @@ defmodule OliWeb.Products.PaymentsView do
        offset: 0,
        limit: @limit,
        text_search: "",
+       text_search_tooltip: @text_search_tooltip,
        download_enabled: false
      )}
   end
@@ -67,6 +71,7 @@ defmodule OliWeb.Products.PaymentsView do
         change="text_search_change"
         text={@text_search}
         event_target={nil}
+        tooltip={@text_search_tooltip}
       />
 
       <div class="mb-3" />

--- a/lib/oli_web/live/products/payments_view.ex
+++ b/lib/oli_web/live/products/payments_view.ex
@@ -10,7 +10,8 @@ defmodule OliWeb.Products.PaymentsView do
   alias OliWeb.Products.Payments.CreateCodes
   alias OliWeb.Router.Helpers, as: Routes
 
-  @limit 25
+  @limit 20
+
   def live_path(socket, params) do
     Routes.live_path(socket, OliWeb.Products.PaymentsView, socket.assigns.product_slug, params)
   end
@@ -39,7 +40,7 @@ defmodule OliWeb.Products.PaymentsView do
        title: "Payments",
        code_count: 50,
        offset: 0,
-       limit: 20,
+       limit: @limit,
        text_search: "",
        download_enabled: false
      )}
@@ -75,11 +76,9 @@ defmodule OliWeb.Products.PaymentsView do
         sort="paged_table_sort"
         total_count={@total_count}
         filter={@text_search}
-        allow_selection={false}
         limit={@limit}
         offset={@offset}
         table_model={@table_model}
-        show_bottom_paging={true}
       />
     </div>
     """

--- a/lib/oli_web/live/products/payments_view.ex
+++ b/lib/oli_web/live/products/payments_view.ex
@@ -66,7 +66,6 @@ defmodule OliWeb.Products.PaymentsView do
 
       <TextSearch.render
         id="text-search"
-        apply="text_search_apply"
         reset="text_search_reset"
         change="text_search_change"
         text={@text_search}

--- a/lib/oli_web/live/products/products_tabel_model.ex
+++ b/lib/oli_web/live/products/products_tabel_model.ex
@@ -25,8 +25,7 @@ defmodule OliWeb.Products.ProductsTableModel do
         %ColumnSpec{
           name: :inserted_at,
           label: "Created",
-          render_fn: &Common.render_date/3,
-          sort_fn: &Common.sort_date/2
+          render_fn: &Common.render_date/3
         }
       ],
       event_suffix: "",

--- a/lib/oli_web/live/products/products_view.ex
+++ b/lib/oli_web/live/products/products_view.ex
@@ -15,6 +15,9 @@ defmodule OliWeb.Products.ProductsView do
   alias Oli.Publishing
 
   @limit 20
+  @text_search_tooltip """
+    Search by section title, amount or base project title.
+  """
 
   def live_path(socket, params) do
     if socket.assigns.is_admin_view do
@@ -105,6 +108,7 @@ defmodule OliWeb.Products.ProductsView do
        limit: @limit,
        query: "",
        text_search: "",
+       text_search_tooltip: @text_search_tooltip,
        creation_title: "",
        ctx: ctx
      )}
@@ -122,6 +126,7 @@ defmodule OliWeb.Products.ProductsView do
             change="text_search_change"
             text={@text_search}
             event_target={nil}
+            tooltip={@text_search_tooltip}
           />
         <% else %>
           <Create.render title={@creation_title} change="title" click="create" />

--- a/lib/oli_web/live/products/products_view.ex
+++ b/lib/oli_web/live/products/products_view.ex
@@ -81,7 +81,7 @@ defmodule OliWeb.Products.ProductsView do
         project_id: project_id
       )
 
-    total_count = length(products)
+    total_count = determine_total(products)
 
     ctx = SessionContext.init(socket, session)
     {:ok, table_model} = OliWeb.Products.ProductsTableModel.new(products, ctx)
@@ -121,7 +121,6 @@ defmodule OliWeb.Products.ProductsView do
         <%= if @is_admin_view do %>
           <TextSearch.render
             id="text-search"
-            apply="text_search_apply"
             reset="text_search_reset"
             change="text_search_change"
             text={@text_search}
@@ -176,7 +175,7 @@ defmodule OliWeb.Products.ProductsView do
 
     table_model = Map.put(table_model, :rows, products)
 
-    total_count = length(products)
+    total_count = determine_total(products)
 
     {:noreply,
      assign(socket,
@@ -275,5 +274,12 @@ defmodule OliWeb.Products.ProductsView do
          ),
        replace: true
      )}
+  end
+
+  defp determine_total(products) do
+    case products do
+      [] -> 0
+      [hd | _] -> hd.total_count
+    end
   end
 end

--- a/lib/oli_web/live/products/products_view.ex
+++ b/lib/oli_web/live/products/products_view.ex
@@ -191,7 +191,8 @@ defmodule OliWeb.Products.ProductsView do
 
     include_archived = !socket.assigns.include_archived
 
-    %{offset: offset, limit: limit, table_model: table_model, text_search: text_search} = socket.assigns
+    %{offset: offset, limit: limit, table_model: table_model, text_search: text_search} =
+      socket.assigns
 
     products =
       Blueprint.browse(

--- a/lib/oli_web/live/projects/projects_live.ex
+++ b/lib/oli_web/live/projects/projects_live.ex
@@ -197,7 +197,6 @@ defmodule OliWeb.Projects.ProjectsLive do
             <TextSearch.render
               event_target={:live_view}
               id="text-search"
-              apply="text_search_apply"
               reset="text_search_reset"
               change="text_search_change"
               text={@text_search}

--- a/priv/repo/migrations/20231107183704_add_crockford_base32_encode_function.exs
+++ b/priv/repo/migrations/20231107183704_add_crockford_base32_encode_function.exs
@@ -1,0 +1,30 @@
+defmodule Oli.Repo.Migrations.AddCrockfordBase32EncodeFunction do
+  use Ecto.Migration
+
+  def up do
+
+    execute """
+    CREATE OR REPLACE FUNCTION crockford_base32_encode(number BIGINT) RETURNS TEXT AS $$
+    DECLARE
+      alphabet TEXT := '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+      encoded TEXT := '';
+      remainder INT;
+    BEGIN
+      IF number = 0 THEN
+        RETURN '0';
+      END IF;
+      WHILE number > 0 LOOP
+        remainder := number % 32;
+        encoded := SUBSTRING(alphabet FROM remainder+1 FOR 1) || encoded;
+        number := number / 32;
+      END LOOP;
+      RETURN encoded;
+    END;
+    $$ LANGUAGE plpgsql IMMUTABLE STRICT;
+    """
+  end
+
+  def down do
+    execute "DROP FUNCTION IF EXISTS crockford_base32_encode(BIGINT);"
+  end
+end

--- a/priv/repo/migrations/20231107183704_add_crockford_base32_encode_function.exs
+++ b/priv/repo/migrations/20231107183704_add_crockford_base32_encode_function.exs
@@ -2,7 +2,6 @@ defmodule Oli.Repo.Migrations.AddCrockfordBase32EncodeFunction do
   use Ecto.Migration
 
   def up do
-
     execute """
     CREATE OR REPLACE FUNCTION crockford_base32_encode(number BIGINT) RETURNS TEXT AS $$
     DECLARE

--- a/test/oli/delivery/paywall_test.exs
+++ b/test/oli/delivery/paywall_test.exs
@@ -810,6 +810,7 @@ defmodule Oli.Delivery.PaywallTest do
         insert(:section, %{
           type: :blueprint
         })
+
       [product: product]
     end
 
@@ -817,14 +818,22 @@ defmodule Oli.Delivery.PaywallTest do
       payment_1_id = insert(:payment, section: product, code: 123_456_789).id
       _payment_2_id = insert(:payment, section: product, code: 987_654_321).id
 
-      [%{payment: %Payment{id: ^payment_1_id}}] = Paywall.browse_payments(product.slug, %Paging{limit: 1, offset: 0}, %Sorting{direction: :asc, field: :type})
+      [%{payment: %Payment{id: ^payment_1_id}}] =
+        Paywall.browse_payments(product.slug, %Paging{limit: 1, offset: 0}, %Sorting{
+          direction: :asc,
+          field: :type
+        })
     end
 
     test "browse_payments/4 applies sorting by type", %{product: product} do
       payment_1_id = insert(:payment, section: product, type: :deferred).id
       _payment_2_id = insert(:payment, section: product, type: :direct).id
 
-      [%{payment: %Payment{id: ^payment_1_id}}] = Paywall.browse_payments(product.slug, %Paging{limit: 1, offset: 0}, %Sorting{direction: :asc, field: :type})
+      [%{payment: %Payment{id: ^payment_1_id}}] =
+        Paywall.browse_payments(product.slug, %Paging{limit: 1, offset: 0}, %Sorting{
+          direction: :asc,
+          field: :type
+        })
     end
 
     test "browse_payments/4 applies sorting by user name", %{product: product} do
@@ -837,14 +846,29 @@ defmodule Oli.Delivery.PaywallTest do
       payment_1_id = insert(:payment, section: product, enrollment: enrollment_1).id
       _payment_2_id = insert(:payment, section: product, enrollment: enrollment_2).id
 
-      [%{payment: %Payment{id: ^payment_1_id}}] = Paywall.browse_payments(product.slug, %Paging{limit: 1, offset: 0}, %Sorting{direction: :asc, field: :user})
+      [%{payment: %Payment{id: ^payment_1_id}}] =
+        Paywall.browse_payments(product.slug, %Paging{limit: 1, offset: 0}, %Sorting{
+          direction: :asc,
+          field: :user
+        })
     end
 
     test "browse_payments/4 applies sorting by details", %{product: product} do
-      payment_1_id = insert(:payment, section: product, type: :direct, provider_type: :stripe, provider_payload: %{id: 1}).id
+      payment_1_id =
+        insert(:payment,
+          section: product,
+          type: :direct,
+          provider_type: :stripe,
+          provider_payload: %{id: 1}
+        ).id
+
       _payment_2_id = insert(:payment, section: product, type: :deferred).id
 
-      [%{payment: %Payment{id: ^payment_1_id}}] = Paywall.browse_payments(product.slug, %Paging{limit: 1, offset: 0}, %Sorting{direction: :desc, field: :details})
+      [%{payment: %Payment{id: ^payment_1_id}}] =
+        Paywall.browse_payments(product.slug, %Paging{limit: 1, offset: 0}, %Sorting{
+          direction: :desc,
+          field: :details
+        })
     end
 
     test "browse_payments/4 applies searching by code", %{product: product} do
@@ -855,7 +879,13 @@ defmodule Oli.Delivery.PaywallTest do
 
       human_code_1 = Paywall.Payment.to_human_readable(code_1)
 
-      [%{payment: %Payment{id: ^payment_1_id}}] = Paywall.browse_payments(product.slug, %Paging{limit: 1, offset: 0}, %Sorting{direction: :asc, field: :type}, text_search: human_code_1)
+      [%{payment: %Payment{id: ^payment_1_id}}] =
+        Paywall.browse_payments(
+          product.slug,
+          %Paging{limit: 1, offset: 0},
+          %Sorting{direction: :asc, field: :type},
+          text_search: human_code_1
+        )
     end
   end
 end

--- a/test/oli/delivery/sections/blueprint_test.exs
+++ b/test/oli/delivery/sections/blueprint_test.exs
@@ -169,14 +169,14 @@ defmodule Oli.Delivery.Sections.BlueprintTest do
     end
 
     test "browse/3 lists products and applies searching by amount" do
-      product_id_1 = insert(:section, requires_payment: true, amount: Money.new(:USD, 10)).id
-      _product_id_2 = insert(:section, requires_payment: true, amount: Money.new(:USD, 20)).id
+      product_id_1 = insert(:section, requires_payment: true, amount: Money.new(:USD, 500)).id
+      _product_id_2 = insert(:section, requires_payment: true, amount: Money.new(:USD, 100)).id
 
       assert [%Sections.Section{id: ^product_id_1}] =
                Blueprint.browse(
                  %Paging{offset: 0, limit: 2},
                  %Sorting{direction: :asc, field: :title},
-                 text_search: "10"
+                 text_search: "500"
                )
     end
 

--- a/test/oli/delivery/sections/blueprint_test.exs
+++ b/test/oli/delivery/sections/blueprint_test.exs
@@ -8,6 +8,7 @@ defmodule Oli.Delivery.Sections.BlueprintTest do
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.Blueprint
   alias Oli.Publishing
+  alias Oli.Repo.{Paging, Sorting}
 
   describe "basic blueprint operations" do
     setup do
@@ -104,6 +105,67 @@ defmodule Oli.Delivery.Sections.BlueprintTest do
       insert(:section, status: :deleted)
 
       assert [%Sections.Section{id: ^active_product_id}] = Blueprint.list()
+    end
+
+    test "browse/3 lists products and applies paging" do
+      product_id = insert(:section).id
+      _product_id_2 = insert(:section).id
+      assert [%Sections.Section{id: ^product_id}] = Blueprint.browse(%Paging{offset: 0, limit: 1}, %Sorting{direction: :asc, field: :title})
+    end
+
+    test "browse/3 lists products and applies sorting by base project title" do
+      project_1 = insert(:project, title: "A")
+      project_2 = insert(:project, title: "B")
+      product_id_1 = insert(:section, base_project: project_1).id
+      product_id_2 = insert(:section, base_project: project_2).id
+
+      assert [%Sections.Section{id: ^product_id_1}, %Sections.Section{id: ^product_id_2}] = Blueprint.browse(%Paging{offset: 0, limit: 2}, %Sorting{direction: :asc, field: :base_project_id})
+    end
+
+    test "browse/3 lists products and applies sorting by amount" do
+      product_id_1 = insert(:section, requires_payment: true, amount: Money.new(:USD, 10)).id
+      product_id_2 = insert(:section, requires_payment: true, amount: Money.new(:USD, 20)).id
+
+      assert [%Sections.Section{id: ^product_id_1}, %Sections.Section{id: ^product_id_2}] = Blueprint.browse(%Paging{offset: 0, limit: 2}, %Sorting{direction: :asc, field: :requires_payment})
+    end
+
+    test "browse/3 lists products and applies searching by product title" do
+      product_id_1 = insert(:section, title: "A1").id
+      _product_id_2 = insert(:section, title: "B1").id
+
+      assert [%Sections.Section{id: ^product_id_1}] = Blueprint.browse(%Paging{offset: 0, limit: 2}, %Sorting{direction: :asc, field: :title}, [text_search: "A1"])
+    end
+
+    test "browse/3 lists products and applies searching by base project title" do
+      project_1 = insert(:project, title: "A1")
+      project_2 = insert(:project, title: "B1")
+      product_id_1 = insert(:section, base_project: project_1).id
+      _product_id_2 = insert(:section, base_project: project_2).id
+
+      assert [%Sections.Section{id: ^product_id_1}] = Blueprint.browse(%Paging{offset: 0, limit: 2}, %Sorting{direction: :asc, field: :title}, [text_search: "A1"])
+    end
+
+    test "browse/3 lists products and applies searching by amount" do
+      product_id_1 = insert(:section, requires_payment: true, amount: Money.new(:USD, 10)).id
+      _product_id_2 = insert(:section, requires_payment: true, amount: Money.new(:USD, 20)).id
+
+      assert [%Sections.Section{id: ^product_id_1}] = Blueprint.browse(%Paging{offset: 0, limit: 2}, %Sorting{direction: :asc, field: :title}, [text_search: "10"])
+    end
+
+    test "browse/3 lists products and applies filtering by base project" do
+      project_1 = insert(:project)
+      project_2 = insert(:project)
+      product_id_1 = insert(:section, base_project: project_1).id
+      _product_id_2 = insert(:section, base_project: project_2).id
+
+      assert [%Sections.Section{id: ^product_id_1}] = Blueprint.browse(%Paging{offset: 0, limit: 2}, %Sorting{direction: :asc, field: :title}, [project_id: project_1.id])
+    end
+
+    test "browse/3 lists products and applies filtering by status" do
+      archived_product_id = insert(:section, title: "B", status: :archived).id
+      product_id = insert(:section, title: "A").id
+
+      assert [%Sections.Section{id: ^product_id}, %Sections.Section{id: ^archived_product_id}] = Blueprint.browse(%Paging{offset: 0, limit: 2}, %Sorting{direction: :asc, field: :title}, [include_archived: true])
     end
 
     def get_resources(id) do

--- a/test/oli/delivery/sections/blueprint_test.exs
+++ b/test/oli/delivery/sections/blueprint_test.exs
@@ -110,7 +110,12 @@ defmodule Oli.Delivery.Sections.BlueprintTest do
     test "browse/3 lists products and applies paging" do
       product_id = insert(:section).id
       _product_id_2 = insert(:section).id
-      assert [%Sections.Section{id: ^product_id}] = Blueprint.browse(%Paging{offset: 0, limit: 1}, %Sorting{direction: :asc, field: :title})
+
+      assert [%Sections.Section{id: ^product_id}] =
+               Blueprint.browse(%Paging{offset: 0, limit: 1}, %Sorting{
+                 direction: :asc,
+                 field: :title
+               })
     end
 
     test "browse/3 lists products and applies sorting by base project title" do
@@ -119,21 +124,34 @@ defmodule Oli.Delivery.Sections.BlueprintTest do
       product_id_1 = insert(:section, base_project: project_1).id
       product_id_2 = insert(:section, base_project: project_2).id
 
-      assert [%Sections.Section{id: ^product_id_1}, %Sections.Section{id: ^product_id_2}] = Blueprint.browse(%Paging{offset: 0, limit: 2}, %Sorting{direction: :asc, field: :base_project_id})
+      assert [%Sections.Section{id: ^product_id_1}, %Sections.Section{id: ^product_id_2}] =
+               Blueprint.browse(%Paging{offset: 0, limit: 2}, %Sorting{
+                 direction: :asc,
+                 field: :base_project_id
+               })
     end
 
     test "browse/3 lists products and applies sorting by amount" do
       product_id_1 = insert(:section, requires_payment: true, amount: Money.new(:USD, 10)).id
       product_id_2 = insert(:section, requires_payment: true, amount: Money.new(:USD, 20)).id
 
-      assert [%Sections.Section{id: ^product_id_1}, %Sections.Section{id: ^product_id_2}] = Blueprint.browse(%Paging{offset: 0, limit: 2}, %Sorting{direction: :asc, field: :requires_payment})
+      assert [%Sections.Section{id: ^product_id_1}, %Sections.Section{id: ^product_id_2}] =
+               Blueprint.browse(%Paging{offset: 0, limit: 2}, %Sorting{
+                 direction: :asc,
+                 field: :requires_payment
+               })
     end
 
     test "browse/3 lists products and applies searching by product title" do
       product_id_1 = insert(:section, title: "A1").id
       _product_id_2 = insert(:section, title: "B1").id
 
-      assert [%Sections.Section{id: ^product_id_1}] = Blueprint.browse(%Paging{offset: 0, limit: 2}, %Sorting{direction: :asc, field: :title}, [text_search: "A1"])
+      assert [%Sections.Section{id: ^product_id_1}] =
+               Blueprint.browse(
+                 %Paging{offset: 0, limit: 2},
+                 %Sorting{direction: :asc, field: :title},
+                 text_search: "A1"
+               )
     end
 
     test "browse/3 lists products and applies searching by base project title" do
@@ -142,14 +160,24 @@ defmodule Oli.Delivery.Sections.BlueprintTest do
       product_id_1 = insert(:section, base_project: project_1).id
       _product_id_2 = insert(:section, base_project: project_2).id
 
-      assert [%Sections.Section{id: ^product_id_1}] = Blueprint.browse(%Paging{offset: 0, limit: 2}, %Sorting{direction: :asc, field: :title}, [text_search: "A1"])
+      assert [%Sections.Section{id: ^product_id_1}] =
+               Blueprint.browse(
+                 %Paging{offset: 0, limit: 2},
+                 %Sorting{direction: :asc, field: :title},
+                 text_search: "A1"
+               )
     end
 
     test "browse/3 lists products and applies searching by amount" do
       product_id_1 = insert(:section, requires_payment: true, amount: Money.new(:USD, 10)).id
       _product_id_2 = insert(:section, requires_payment: true, amount: Money.new(:USD, 20)).id
 
-      assert [%Sections.Section{id: ^product_id_1}] = Blueprint.browse(%Paging{offset: 0, limit: 2}, %Sorting{direction: :asc, field: :title}, [text_search: "10"])
+      assert [%Sections.Section{id: ^product_id_1}] =
+               Blueprint.browse(
+                 %Paging{offset: 0, limit: 2},
+                 %Sorting{direction: :asc, field: :title},
+                 text_search: "10"
+               )
     end
 
     test "browse/3 lists products and applies filtering by base project" do
@@ -158,14 +186,24 @@ defmodule Oli.Delivery.Sections.BlueprintTest do
       product_id_1 = insert(:section, base_project: project_1).id
       _product_id_2 = insert(:section, base_project: project_2).id
 
-      assert [%Sections.Section{id: ^product_id_1}] = Blueprint.browse(%Paging{offset: 0, limit: 2}, %Sorting{direction: :asc, field: :title}, [project_id: project_1.id])
+      assert [%Sections.Section{id: ^product_id_1}] =
+               Blueprint.browse(
+                 %Paging{offset: 0, limit: 2},
+                 %Sorting{direction: :asc, field: :title},
+                 project_id: project_1.id
+               )
     end
 
     test "browse/3 lists products and applies filtering by status" do
       archived_product_id = insert(:section, title: "B", status: :archived).id
       product_id = insert(:section, title: "A").id
 
-      assert [%Sections.Section{id: ^product_id}, %Sections.Section{id: ^archived_product_id}] = Blueprint.browse(%Paging{offset: 0, limit: 2}, %Sorting{direction: :asc, field: :title}, [include_archived: true])
+      assert [%Sections.Section{id: ^product_id}, %Sections.Section{id: ^archived_product_id}] =
+               Blueprint.browse(
+                 %Paging{offset: 0, limit: 2},
+                 %Sorting{direction: :asc, field: :title},
+                 include_archived: true
+               )
     end
 
     def get_resources(id) do

--- a/test/oli_web/live/payments_live_test.exs
+++ b/test/oli_web/live/payments_live_test.exs
@@ -227,7 +227,7 @@ defmodule OliWeb.PaymentsLiveTest do
       assert view
              |> element("tr:first-child > td:first-child")
              |> render() =~
-             code1
+               code1
 
       view
       |> element("th[phx-click=\"paged_table_sort\"]:first-of-type")
@@ -236,7 +236,7 @@ defmodule OliWeb.PaymentsLiveTest do
       assert view
              |> element("tr:first-child > td:first-child")
              |> render() =~
-             code2
+               code2
     end
   end
 end

--- a/test/oli_web/live/payments_live_test.exs
+++ b/test/oli_web/live/payments_live_test.exs
@@ -24,7 +24,7 @@ defmodule OliWeb.PaymentsLiveTest do
     code_to_test = Payment.to_human_readable(payment.code)
 
     Paywall.redeem_code(code_to_test, user, product.slug)
-    {user, product}
+    {user, product, payment}
   end
 
   defp live_view_payments_route(product_slug) do
@@ -139,7 +139,7 @@ defmodule OliWeb.PaymentsLiveTest do
     end
 
     test "section title is a link to the instructor dashboard", %{conn: conn, product: product} do
-      {user, product} = create_payment_code(product)
+      {user, product, _} = create_payment_code(product)
 
       {:ok, view, _html} = live(conn, live_view_payments_route(product.slug))
 
@@ -158,7 +158,7 @@ defmodule OliWeb.PaymentsLiveTest do
 
     test "The username is a link to the student details view for that student in that section",
          %{conn: conn, product: product} do
-      {user, product} = create_payment_code(product)
+      {user, product, _} = create_payment_code(product)
 
       {:ok, view, _html} = live(conn, live_view_payments_route(product.slug))
 
@@ -173,6 +173,70 @@ defmodule OliWeb.PaymentsLiveTest do
                "a[href=\"/sections/#{product.slug}/student_dashboard/#{user.id}/content\"]",
                "#{user.family_name}, #{user.given_name}"
              )
+    end
+
+    test "search payment by code", %{conn: conn, product: product} do
+      {_, product, payment1} = create_payment_code(product)
+      {_, product, payment2} = create_payment_code(product)
+
+      {:ok, view, _html} = live(conn, live_view_payments_route(product.slug))
+
+      code1 = Paywall.Payment.to_human_readable(payment1.code)
+      code2 = Paywall.Payment.to_human_readable(payment2.code)
+
+      assert has_element?(view, "div", code1)
+      assert has_element?(view, "div", code2)
+
+      render_hook(view, "text_search_change", %{value: code1})
+
+      assert has_element?(view, "div", code1)
+      refute has_element?(view, "div", code2)
+
+      view
+      |> element("button[phx-click=\"text_search_reset\"]")
+      |> render_click()
+
+      assert has_element?(view, "div", code1)
+      assert has_element?(view, "div", code2)
+    end
+
+    test "search payment by section title", %{conn: conn, product: product} do
+      {_, _product, _payment1} = create_payment_code(product)
+      {_, _product, _payment2} = create_payment_code(product)
+
+      {:ok, view, _html} = live(conn, live_view_payments_route(product.slug))
+
+      assert has_element?(view, "div", product.title)
+      assert has_element?(view, "div", product.title)
+
+      render_hook(view, "text_search_change", %{value: product.title})
+
+      assert has_element?(view, "div", product.title)
+      assert has_element?(view, "div", product.title)
+    end
+
+    test "applies sorting", %{conn: conn, product: product} do
+      {_, _product, payment1} = create_payment_code(product)
+      {_, _product, payment2} = create_payment_code(product)
+
+      {:ok, view, _html} = live(conn, live_view_payments_route(product.slug))
+
+      code1 = Paywall.Payment.to_human_readable(payment1.code)
+      code2 = Paywall.Payment.to_human_readable(payment2.code)
+
+      assert view
+             |> element("tr:first-child > td:first-child")
+             |> render() =~
+             code1
+
+      view
+      |> element("th[phx-click=\"paged_table_sort\"]:first-of-type")
+      |> render_click(%{sort_by: "user"})
+
+      assert view
+             |> element("tr:first-child > td:first-child")
+             |> render() =~
+             code2
     end
   end
 end

--- a/test/oli_web/live/products_test.exs
+++ b/test/oli_web/live/products_test.exs
@@ -130,9 +130,10 @@ defmodule OliWeb.ProductsLiveTest do
     test "search product by amount", %{conn: conn, product: product} do
       [{_, product_2} | _] = create_product(conn)
 
-      {:ok, product_2} = Sections.update_section(product_2, %{
-        amount: Money.new(:USD, 25)
-      })
+      {:ok, product_2} =
+        Sections.update_section(product_2, %{
+          amount: Money.new(:USD, 25)
+        })
 
       {:ok, view, _html} = live(conn, @live_view_all_products)
 
@@ -166,7 +167,6 @@ defmodule OliWeb.ProductsLiveTest do
       assert view
              |> element("tr:first-child > td:first-child")
              |> render() =~ product.title
-
 
       view
       |> element("th[phx-click=\"paged_table_sort\"]:first-of-type")


### PR DESCRIPTION
[MER-2556](https://eliterate.atlassian.net/browse/MER-2556)

Refactor payment and product views to use a browsing approach, so that all the records are not loaded in memory.
With these changes every time a user performs any operation on these tables, it executes a DB query only to retrieve the desired rows.

**Payments view:**

https://github.com/Simon-Initiative/oli-torus/assets/26532202/e4783229-a899-4cc9-9379-f8a807194bef

**Products view:**

https://github.com/Simon-Initiative/oli-torus/assets/26532202/69cf1dfc-ec91-4dec-ac1a-af1c07f64bb5




[MER-2556]: https://eliterate.atlassian.net/browse/MER-2556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ