### PR TITLE
[FEATURE] Deliberate practice purpose type and impl [MER-2720]

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -1756,6 +1756,7 @@ defmodule Oli.Delivery.Sections do
         fn _repo, _ ->
           # updates contains_explorations field in sections
           Delivery.maybe_update_section_contains_explorations(section)
+          Delivery.maybe_update_section_contains_deliberate_practice(section)
         end
       )
       |> Repo.transaction()
@@ -2473,6 +2474,7 @@ defmodule Oli.Delivery.Sections do
       pinned_project_publications = get_pinned_project_publications(section.id)
       rebuild_section_curriculum(section, new_hierarchy, pinned_project_publications)
       Delivery.maybe_update_section_contains_explorations(section)
+      Delivery.maybe_update_section_contains_deliberate_practice(section)
 
       {:ok}
     end)

--- a/lib/oli/delivery/sections/blueprint.ex
+++ b/lib/oli/delivery/sections/blueprint.ex
@@ -163,6 +163,8 @@ defmodule Oli.Delivery.Sections.Blueprint do
               case Sections.create_section_resources(blueprint, publication, hierarchy_definition) do
                 {:ok, section} ->
                   {:ok, section} = Delivery.maybe_update_section_contains_explorations(section)
+                  {:ok, section} = Delivery.maybe_update_section_contains_deliberate_practice(section)
+
                   section
 
                 {:error, e} ->
@@ -224,6 +226,7 @@ defmodule Oli.Delivery.Sections.Blueprint do
           delivery_policy_id: nil,
           customizations: custom_labels,
           contains_explorations: section.contains_explorations,
+          contains_deliberate_practice: section.contains_deliberate_practice,
           cover_image: section.cover_image,
           skip_email_verification: section.skip_email_verification,
           registration_open: section.registration_open,

--- a/lib/oli/delivery/sections/blueprint.ex
+++ b/lib/oli/delivery/sections/blueprint.ex
@@ -163,7 +163,9 @@ defmodule Oli.Delivery.Sections.Blueprint do
               case Sections.create_section_resources(blueprint, publication, hierarchy_definition) do
                 {:ok, section} ->
                   {:ok, section} = Delivery.maybe_update_section_contains_explorations(section)
-                  {:ok, section} = Delivery.maybe_update_section_contains_deliberate_practice(section)
+
+                  {:ok, section} =
+                    Delivery.maybe_update_section_contains_deliberate_practice(section)
 
                   section
 

--- a/lib/oli/delivery/sections/section.ex
+++ b/lib/oli/delivery/sections/section.ex
@@ -65,6 +65,7 @@ defmodule Oli.Delivery.Sections.Section do
     field(:previous_next_index, :map, default: nil)
     field(:display_curriculum_item_numbering, :boolean, default: true)
     field(:contains_explorations, :boolean, default: false)
+    field(:contains_deliberate_practice, :boolean, default: false)
 
     belongs_to(:required_survey, Oli.Resources.Resource,
       foreign_key: :required_survey_resource_id
@@ -185,6 +186,7 @@ defmodule Oli.Delivery.Sections.Section do
       :publisher_id,
       :display_curriculum_item_numbering,
       :contains_explorations,
+      :contains_deliberate_practice,
       :required_survey_resource_id,
       :class_modality,
       :class_days,

--- a/lib/oli/resources/revision.ex
+++ b/lib/oli/resources/revision.ex
@@ -67,7 +67,10 @@ defmodule Oli.Resources.Revision do
     field(:page_type, :string, virtual: true)
     field(:parent_slug, :string, virtual: true)
 
-    field :purpose, Ecto.Enum, values: [:foundation, :application, :deliberate_practice], default: :foundation
+    field :purpose, Ecto.Enum,
+      values: [:foundation, :application, :deliberate_practice],
+      default: :foundation
+
     field :relates_to, {:array, :id}, default: []
 
     timestamps(type: :utc_datetime)

--- a/lib/oli/resources/revision.ex
+++ b/lib/oli/resources/revision.ex
@@ -67,7 +67,7 @@ defmodule Oli.Resources.Revision do
     field(:page_type, :string, virtual: true)
     field(:parent_slug, :string, virtual: true)
 
-    field :purpose, Ecto.Enum, values: [:foundation, :application], default: :foundation
+    field :purpose, Ecto.Enum, values: [:foundation, :application, :deliberate_practice], default: :foundation
     field :relates_to, {:array, :id}, default: []
 
     timestamps(type: :utc_datetime)

--- a/lib/oli/utils/db_seeder.ex
+++ b/lib/oli/utils/db_seeder.ex
@@ -849,7 +849,8 @@ defmodule Oli.Seeder do
       context_id: UUID.uuid4(),
       base_project_id: map.project.id,
       institution_id: map.institution.id,
-      contains_explorations: map[:contains_explorations] || false
+      contains_explorations: map[:contains_explorations] || false,
+      contains_deliberate_practice: map[:contains_deliberate_practice] || false
     }
 
     {:ok, section} =

--- a/lib/oli_web/components/delivery/deliberate_practice_card.ex
+++ b/lib/oli_web/components/delivery/deliberate_practice_card.ex
@@ -1,0 +1,37 @@
+defmodule OliWeb.Components.Delivery.DeliberatePracticeCard do
+  use Phoenix.Component
+
+  alias OliWeb.Router.Helpers, as: Routes
+
+  attr :dark, :boolean, default: false
+  attr :practice, :map
+  attr :section_slug, :string
+  attr :preview_mode, :boolean, default: false
+
+  def render(assigns) do
+    ~H"""
+    <div class={"@container/card flex-1 bg-white dark:bg-gray-800 dark:text-white shadow #{if @dark, do: "bg-delivery-header-800 text-white"}"}>
+      <div class="p-6 flex flex-col">
+        <div class="flex flex-col @2xl/card:flex-row @2xl/card:items-center @2xl/card:justify-between">
+          <h6 class="font-semibold text-lg leading-6"><%= @practice.title %></h6>
+          <div class="flex w-full gap-3 justify-end">
+            <a
+              href={
+                Routes.page_delivery_path(
+                  OliWeb.Endpoint,
+                  if(@preview_mode, do: :page_preview, else: :page),
+                  @section_slug,
+                  @practice.slug
+                )
+              }
+              class="btn text-white hover:text-white inline-flex bg-delivery-primary hover:bg-delivery-primary-600 active:bg-delivery-primary-700"
+            >
+              Open
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/oli_web/components/delivery/deliberate_practice_list.ex
+++ b/lib/oli_web/components/delivery/deliberate_practice_list.ex
@@ -1,0 +1,37 @@
+defmodule OliWeb.Components.Delivery.DeliberatePracticeList do
+  use Phoenix.LiveView
+
+  alias Oli.Publishing.DeliveryResolver, as: Resolver
+  alias OliWeb.Components.Delivery.DeliberatePracticeCard
+
+  def mount(_params, %{"section_slug" => section_slug, "preview_mode" => preview_mode}, socket) do
+    practices = Resolver.get_by_purpose(section_slug, :deliberate_practice)
+
+    {:ok,
+     assign(socket,
+       practices: practices,
+       section_slug: section_slug,
+       preview_mode: preview_mode
+     )}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <div class="flex flex-col gap-4">
+      <%= if length(@practices) > 0 do %>
+        <%= for practice <- @practices do %>
+          <DeliberatePracticeCard.render
+            practice={practice}
+            section_slug={@section_slug}
+            preview_mode={@preview_mode}
+          />
+        <% end %>
+      <% else %>
+        <div class="bg-white dark:bg-gray-800 border-l-4 border-delivery-primary p-4" role="alert">
+          <h6>There are no deliberate practice pages available</h6>
+        </div>
+      <% end %>
+    </div>
+    """
+  end
+end

--- a/lib/oli_web/components/delivery/nav_sidebar.ex
+++ b/lib/oli_web/components/delivery/nav_sidebar.ex
@@ -193,26 +193,32 @@ defmodule OliWeb.Components.Delivery.NavSidebar do
       }
     ]
 
-    all = if assigns.section.contains_explorations do
-      all ++ [%{
-        name: "Exploration",
-        href: exploration_url(assigns),
-        active: is_active(path_info, :exploration)
-      }]
-    else
-      all
-    end
+    all =
+      if assigns.section.contains_explorations do
+        all ++
+          [
+            %{
+              name: "Exploration",
+              href: exploration_url(assigns),
+              active: is_active(path_info, :exploration)
+            }
+          ]
+      else
+        all
+      end
 
     if assigns.section.contains_deliberate_practice do
-      all ++ [%{
-        name: "Practice",
-        href: deliberate_practice_url(assigns),
-        active: is_active(path_info, :deliberate_practice)
-      }]
+      all ++
+        [
+          %{
+            name: "Practice",
+            href: deliberate_practice_url(assigns),
+            active: is_active(path_info, :deliberate_practice)
+          }
+        ]
     else
       all
     end
-
   end
 
   defp logo_details(assigns) do
@@ -273,7 +279,11 @@ defmodule OliWeb.Components.Delivery.NavSidebar do
 
   defp deliberate_practice_url(assigns) do
     if assigns[:preview_mode] do
-      Routes.page_delivery_path(OliWeb.Endpoint, :deliberate_practice_preview, assigns[:section_slug])
+      Routes.page_delivery_path(
+        OliWeb.Endpoint,
+        :deliberate_practice_preview,
+        assigns[:section_slug]
+      )
     else
       Routes.page_delivery_path(OliWeb.Endpoint, :deliberate_practice, assigns[:section_slug])
     end

--- a/lib/oli_web/components/delivery/nav_sidebar.ex
+++ b/lib/oli_web/components/delivery/nav_sidebar.ex
@@ -114,6 +114,22 @@ defmodule OliWeb.Components.Delivery.NavSidebar do
           links
       end
     end)
+    |> then(fn links ->
+      case section do
+        %Section{contains_deliberate_practice: true} ->
+          links ++
+            [
+              %{
+                name: "Practice",
+                href: deliberate_practice_url(assigns),
+                active: is_active(assigns.path_info, :deliberate_practice)
+              }
+            ]
+
+        _ ->
+          links
+      end
+    end)
   end
 
   defp get_preview_links(%{project: %Project{} = project}) do
@@ -145,51 +161,13 @@ defmodule OliWeb.Components.Delivery.NavSidebar do
     ]
   end
 
-  defp get_links(%{section: %{contains_explorations: true}} = assigns, path_info) do
-    hierarchy =
-      assigns[:section]
-      |> Oli.Repo.preload([:root_section_resource])
-      |> Sections.build_hierarchy()
-
-    [
-      %{
-        name: "Home",
-        href: home_url(assigns),
-        active: is_active(path_info, :overview)
-      },
-      %{
-        name: "Course Content",
-        popout: %{
-          component: "Components.CourseContentOutline",
-          props: %{hierarchy: hierarchy, sectionSlug: assigns[:section].slug}
-        },
-        active: is_active(path_info, :content)
-      },
-      %{
-        name: "Discussion",
-        href: discussion_url(assigns),
-        active: is_active(path_info, :discussion)
-      },
-      %{
-        name: "Assignments",
-        href: assignments_url(assigns),
-        active: is_active(path_info, :assignments)
-      },
-      %{
-        name: "Exploration",
-        href: exploration_url(assigns),
-        active: is_active(path_info, :exploration)
-      }
-    ]
-  end
-
   defp get_links(assigns, path_info) do
     hierarchy =
       assigns[:section]
       |> Oli.Repo.preload([:root_section_resource])
       |> Sections.build_hierarchy()
 
-    [
+    all = [
       %{
         name: "Home",
         href: home_url(assigns),
@@ -214,6 +192,27 @@ defmodule OliWeb.Components.Delivery.NavSidebar do
         active: is_active(path_info, :assignments)
       }
     ]
+
+    all = if assigns.section.contains_explorations do
+      all ++ [%{
+        name: "Exploration",
+        href: exploration_url(assigns),
+        active: is_active(path_info, :exploration)
+      }]
+    else
+      all
+    end
+
+    if assigns.section.contains_deliberate_practice do
+      all ++ [%{
+        name: "Practice",
+        href: deliberate_practice_url(assigns),
+        active: is_active(path_info, :deliberate_practice)
+      }]
+    else
+      all
+    end
+
   end
 
   defp logo_details(assigns) do
@@ -250,6 +249,7 @@ defmodule OliWeb.Components.Delivery.NavSidebar do
       {"overview", :overview} -> true
       {"exploration", :exploration} -> true
       {"discussion", :discussion} -> true
+      {"practice", :deliberate_practice} -> true
       {"my_assignments", :assignments} -> true
       _ -> false
     end
@@ -268,6 +268,14 @@ defmodule OliWeb.Components.Delivery.NavSidebar do
       Routes.page_delivery_path(OliWeb.Endpoint, :exploration_preview, assigns[:section_slug])
     else
       Routes.page_delivery_path(OliWeb.Endpoint, :exploration, assigns[:section_slug])
+    end
+  end
+
+  defp deliberate_practice_url(assigns) do
+    if assigns[:preview_mode] do
+      Routes.page_delivery_path(OliWeb.Endpoint, :deliberate_practice_preview, assigns[:section_slug])
+    else
+      Routes.page_delivery_path(OliWeb.Endpoint, :deliberate_practice, assigns[:section_slug])
     end
   end
 

--- a/lib/oli_web/controllers/open_and_free_controller.ex
+++ b/lib/oli_web/controllers/open_and_free_controller.ex
@@ -354,7 +354,8 @@ defmodule OliWeb.OpenAndFreeController do
            {:ok, _} <- Sections.rebuild_contained_pages(section),
            {:ok, _} <- Sections.rebuild_contained_objectives(section),
            {:ok, _enrollment} <- enroll(conn, section),
-           {:ok, updated_section} <- Delivery.maybe_update_section_contains_explorations(section) do
+           {:ok, section} <- Delivery.maybe_update_section_contains_explorations(section),
+           {:ok, updated_section} <- Delivery.maybe_update_section_contains_deliberate_practice(section) do
         updated_section
       else
         {:error, changeset} -> Repo.rollback(changeset)

--- a/lib/oli_web/controllers/open_and_free_controller.ex
+++ b/lib/oli_web/controllers/open_and_free_controller.ex
@@ -355,7 +355,8 @@ defmodule OliWeb.OpenAndFreeController do
            {:ok, _} <- Sections.rebuild_contained_objectives(section),
            {:ok, _enrollment} <- enroll(conn, section),
            {:ok, section} <- Delivery.maybe_update_section_contains_explorations(section),
-           {:ok, updated_section} <- Delivery.maybe_update_section_contains_deliberate_practice(section) do
+           {:ok, updated_section} <-
+             Delivery.maybe_update_section_contains_deliberate_practice(section) do
         updated_section
       else
         {:error, changeset} -> Repo.rollback(changeset)

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -148,6 +148,40 @@ defmodule OliWeb.PageDeliveryController do
     end
   end
 
+  def deliberate_practice(conn, %{"section_slug" => section_slug}) do
+    user = conn.assigns.current_user
+    section = conn.assigns.section
+
+    if Sections.is_enrolled?(user.id, section_slug) do
+      case section
+           |> Oli.Repo.preload([:base_project, :root_section_resource]) do
+        nil ->
+          render(conn, "error.html")
+
+        section ->
+          render(conn, "deliberate_practice.html",
+            title: section.title,
+            description: section.description,
+            section_slug: section_slug,
+            hierarchy: Sections.build_hierarchy(section),
+            display_curriculum_item_numbering: section.display_curriculum_item_numbering,
+            preview_mode: false,
+            page_link_url: &Routes.page_delivery_path(conn, :page, section_slug, &1),
+            container_link_url: &Routes.page_delivery_path(conn, :container, section_slug, &1)
+          )
+      end
+    else
+      case section do
+        %Section{open_and_free: true, requires_enrollment: false} ->
+          conn
+          |> redirect(to: Routes.delivery_path(conn, :show_enroll, section_slug))
+
+        _ ->
+          render(conn, "not_authorized.html")
+      end
+    end
+  end
+
   def assignments(conn, %{"section_slug" => section_slug}) do
     user = conn.assigns.current_user
     section = conn.assigns.section
@@ -799,6 +833,23 @@ defmodule OliWeb.PageDeliveryController do
       |> Oli.Repo.preload([:base_project, :root_section_resource])
 
     render(conn, "exploration.html",
+      title: section.title,
+      description: section.description,
+      section_slug: section_slug,
+      hierarchy: Sections.build_hierarchy(section),
+      display_curriculum_item_numbering: section.display_curriculum_item_numbering,
+      preview_mode: true,
+      page_link_url: &Routes.page_delivery_path(conn, :page, section_slug, &1),
+      container_link_url: &Routes.page_delivery_path(conn, :container, section_slug, &1)
+    )
+  end
+
+  def deliberate_practice_preview(conn, %{"section_slug" => section_slug}) do
+    section =
+      conn.assigns.section
+      |> Oli.Repo.preload([:base_project, :root_section_resource])
+
+    render(conn, "deliberate_practice.html",
       title: section.title,
       description: section.description,
       section_slug: section_slug,

--- a/lib/oli_web/live/curriculum/entries/options_modal.ex
+++ b/lib/oli_web/live/curriculum/entries/options_modal.ex
@@ -208,7 +208,7 @@ defmodule OliWeb.Curriculum.OptionsModal do
                     placeholder="Purpose"
                     class="form-control custom-select"
                     value={fetch_field(@changeset, :purpose)}
-                    options={[{"Foundation", :foundation}, {"Exploration", :application}]}
+                    options={[{"Foundation", :foundation}, {"Deliberate Practice", :deliberate_practice}, {"Exploration", :application}]}
                   />
                 </div>
 

--- a/lib/oli_web/live/curriculum/entries/options_modal.ex
+++ b/lib/oli_web/live/curriculum/entries/options_modal.ex
@@ -208,7 +208,11 @@ defmodule OliWeb.Curriculum.OptionsModal do
                     placeholder="Purpose"
                     class="form-control custom-select"
                     value={fetch_field(@changeset, :purpose)}
-                    options={[{"Foundation", :foundation}, {"Deliberate Practice", :deliberate_practice}, {"Exploration", :application}]}
+                    options={[
+                      {"Foundation", :foundation},
+                      {"Deliberate Practice", :deliberate_practice},
+                      {"Exploration", :application}
+                    ]}
                   />
                 </div>
 

--- a/lib/oli_web/live/new_course/new_course.ex
+++ b/lib/oli_web/live/new_course/new_course.ex
@@ -374,8 +374,11 @@ defmodule OliWeb.Delivery.NewCourse do
            {:ok, _} <- Sections.rebuild_contained_pages(section),
            {:ok, _} <- Sections.rebuild_contained_objectives(section),
            {:ok, _enrollment} <- enroll(socket, section),
-           {:ok, updated_section} <-
-             Oli.Delivery.maybe_update_section_contains_explorations(section) do
+           {:ok, section} <-
+             Oli.Delivery.maybe_update_section_contains_explorations(section),
+            {:ok, updated_section} <-
+              Oli.Delivery.maybe_update_section_contains_deliberate_practice(section)
+             do
         updated_section
       else
         {:error, changeset} ->

--- a/lib/oli_web/live/new_course/new_course.ex
+++ b/lib/oli_web/live/new_course/new_course.ex
@@ -376,9 +376,8 @@ defmodule OliWeb.Delivery.NewCourse do
            {:ok, _enrollment} <- enroll(socket, section),
            {:ok, section} <-
              Oli.Delivery.maybe_update_section_contains_explorations(section),
-            {:ok, updated_section} <-
-              Oli.Delivery.maybe_update_section_contains_deliberate_practice(section)
-             do
+           {:ok, updated_section} <-
+             Oli.Delivery.maybe_update_section_contains_deliberate_practice(section) do
         updated_section
       else
         {:error, changeset} ->

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -939,6 +939,7 @@ defmodule OliWeb.Router do
     get("/overview", PageDeliveryController, :index)
 
     get("/exploration", PageDeliveryController, :exploration)
+    get("/practice", PageDeliveryController, :deliberate_practice)
     get("/discussion", PageDeliveryController, :discussion)
     get("/my_assignments", PageDeliveryController, :assignments)
     get("/container/:revision_slug", PageDeliveryController, :container)
@@ -981,6 +982,7 @@ defmodule OliWeb.Router do
     # Redirect deprecated routes
     get("/overview", PageDeliveryController, :index_preview)
     get("/exploration", PageDeliveryController, :exploration_preview)
+    get("/practice", PageDeliveryController, :deliberate_practice_preview)
     get("/discussion", PageDeliveryController, :discussion_preview)
     get("/my_assignments", PageDeliveryController, :assignments_preview)
     get("/container/:revision_slug", PageDeliveryController, :container_preview)

--- a/lib/oli_web/templates/page_delivery/deliberate_practice.html.heex
+++ b/lib/oli_web/templates/page_delivery/deliberate_practice.html.heex
@@ -1,0 +1,19 @@
+<Components.Delivery.NavSidebar.main_with_nav {assigns}>
+  <div class="relative flex-1 flex flex-col pb-[60px]">
+    <%= render(OliWeb.LayoutView, "_pay_early.html", assigns) %>
+
+    <%= if assigns.section.contains_explorations do %>
+      <Components.Delivery.ExplorationShade.exploration_shade title={assigns.title} />
+    <% else %>
+      <Components.Delivery.SectionTitle.section_title title={assigns.title} />
+    <% end %>
+
+    <div class="container mx-auto px-10 mt-3 mb-5 flex flex-col">
+      <%= live_render(@conn, Components.Delivery.DeliberatePracticeList,
+        session: %{"section_slug" => @section_slug, "preview_mode" => @preview_mode}
+      ) %>
+    </div>
+
+    <%= render(OliWeb.LayoutView, "_delivery_footer.html", assigns) %>
+  </div>
+</Components.Delivery.NavSidebar.main_with_nav>

--- a/priv/repo/migrations/20231112194542_add_has_practice.exs
+++ b/priv/repo/migrations/20231112194542_add_has_practice.exs
@@ -1,0 +1,9 @@
+defmodule Oli.Repo.Migrations.AddHasPractice do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sections) do
+      add(:contains_deliberate_practice, :boolean, default: false)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a new page purpose type "Deliberate Practice".  This new purpose type works almost the same as "Explorations": any page designated as "Deliberate Practice" will show up in a list when the student accesses the navbar "Practice" menu. 