### PR TITLE
Fixed list styling issue in definition meanings [MER-2705]

### DIFF
--- a/assets/styles/common/elements.scss
+++ b/assets/styles/common/elements.scss
@@ -249,7 +249,7 @@ $element-margin-bottom: 1.5em;
     .meanings-single {
       display: inline;
       padding-left: 3px;
-      li {
+      & > li {
         list-style: none;
         display: inline;
         p {


### PR DESCRIPTION
Steps to reproduce:

1. On a basic authoring page, add a definition element
2. Edit that definition
3. In the first meaning, author a list - do not author a second meaning
4. Preview the definition

Expected: A definition where the first meaning visually has a list inside it.
Actual: A definition where the first meaning has no visual list.

 

Sample Input:

![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/7fbb9d6b-3f63-463b-897a-63d646aad057)

Before fix:

![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/4732c7b8-453f-4bab-a645-a1ca8efd7d1d)

After fix:

![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/528a3066-f193-41e6-bb9a-c3585911b7f6)

 