### PR TITLE
[ENHANCEMENT] add aria-label to help buttons [MER-2726]

### DIFF
--- a/lib/oli_web/components/delivery/instructor_dashboard.ex
+++ b/lib/oli_web/components/delivery/instructor_dashboard.ex
@@ -207,6 +207,7 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard do
 
         <div class="flex items-center border-l border-slate-300 my-2">
           <button
+            aria-label="Request Help"
             class="
                 btn
                 rounded

--- a/lib/oli_web/live/delivery/student_dashboard/components/helpers.ex
+++ b/lib/oli_web/live/delivery/student_dashboard/components/helpers.ex
@@ -157,6 +157,7 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.Helpers do
         <% end %>
         <div class="flex items-center border-l border-slate-300">
           <button
+            aria-label="Request Help"
             class="
                 btn
                 rounded


### PR DESCRIPTION
This PR adds the `aria-label` attribute to allow users of screen readers to understand the purpose of the help icon button. 