### PR TITLE
[FIX] Footer positioning within nav_sidebar layout

### DIFF
--- a/lib/oli_web/components/delivery/nav_sidebar.ex
+++ b/lib/oli_web/components/delivery/nav_sidebar.ex
@@ -21,7 +21,7 @@ defmodule OliWeb.Components.Delivery.NavSidebar do
 
   def main_with_nav(assigns) do
     ~H"""
-    <main role="main" class="flex-1 flex flex-col relative lg:flex-row">
+    <main role="main" class="flex-1 flex flex-col lg:flex-row">
       <.navbar {assigns} path_info={@conn.path_info} />
 
       <div class="flex-1 flex flex-col lg:pl-[200px]">

--- a/lib/oli_web/components/delivery/nav_sidebar.ex
+++ b/lib/oli_web/components/delivery/nav_sidebar.ex
@@ -21,7 +21,7 @@ defmodule OliWeb.Components.Delivery.NavSidebar do
 
   def main_with_nav(assigns) do
     ~H"""
-    <main role="main" class="flex-1 flex flex-col lg:flex-row">
+    <main role="main" class="flex-1 flex flex-col relative lg:flex-row">
       <.navbar {assigns} path_info={@conn.path_info} />
 
       <div class="flex-1 flex flex-col lg:pl-[200px]">

--- a/lib/oli_web/templates/layout/page.html.heex
+++ b/lib/oli_web/templates/layout/page.html.heex
@@ -1,6 +1,6 @@
 <%= render_layout "delivery.html", assigns do %>
   <Components.Delivery.NavSidebar.main_with_nav {assigns}>
-    <div class="flex-1 flex flex-col pb-[60px]">
+    <div class="flex-1 flex flex-col relative pb-[60px]">
       <%= render(OliWeb.LayoutView, "_pay_early.html", assigns) %>
 
       <%= for script <- @scripts do %>


### PR DESCRIPTION
This PR fixes footer positioning when rendered within nav sidebar layout above "lg" breakpoint.

**The issue**
The layout's content slot has 200px of left-padding to accommodate the sidebar. The footer has absolute position to make it sit over its container's (seemingly unnecessary) bottom padding. That same container was missing `position: relative`, so the footer's `left: 0` was at the layout's left border - underneath the sidebar.

Before:
<img width="635" alt="Screenshot 2023-11-17 at 13 20 11" src="https://github.com/Simon-Initiative/oli-torus/assets/2022097/8102cca5-51db-4b41-a9ee-a01c91f06c06">

After:
<img width="481" alt="Screenshot 2023-11-17 at 13 21 32" src="https://github.com/Simon-Initiative/oli-torus/assets/2022097/bb8a85b9-102b-4f5a-8df5-b6ed7aec17ff">


[EDIT]: This does not seem related to [issue 3635](https://github.com/Simon-Initiative/oli-torus/issues/3635) after all. That issue concerns Project Overview page, which uses a different layout (also, I wasn't able to replicate it, so maybe it got fixed).

**Note**
In the long term, my recommendation would be to make the layout responsible for its children's positioning. Currently, the footer template contains specific positioning rules which limit its reusability. Perhaps a dedicated footer slot in the layout?