### PR TITLE
[MER-2730] Create new Datashop Analytics view

### DIFF
--- a/lib/oli/analytics/datashop.ex
+++ b/lib/oli/analytics/datashop.ex
@@ -244,7 +244,8 @@ defmodule Oli.Analytics.Datashop do
       section_ids: section_ids
     } = context
 
-    part_attempts_stream(section_ids)
+    section_ids
+    |> part_attempts_stream()
     |> Stream.map(fn %{
                        email: email,
                        sub: sub,

--- a/lib/oli/analytics/datashop.ex
+++ b/lib/oli/analytics/datashop.ex
@@ -168,7 +168,7 @@ defmodule Oli.Analytics.Datashop do
     |> Enum.map(fn {k, v} -> {k, v} end)
   end
 
-  defp part_attempts_stream(project_id) do
+  defp part_attempts_stream(section_ids) do
     max = max_record_size()
 
     from(snapshot in Snapshot,
@@ -178,7 +178,7 @@ defmodule Oli.Analytics.Datashop do
       on: activity_revision.id == snapshot.revision_id,
       join: part_attempt in Oli.Delivery.Attempts.Core.PartAttempt,
       on: snapshot.part_attempt_id == part_attempt.id,
-      where: snapshot.project_id == ^project_id and not is_nil(snapshot.objective_revision_id),
+      where: snapshot.section_id in ^section_ids and not is_nil(snapshot.objective_revision_id),
       select: %{
         email: user.email,
         sub: user.sub,
@@ -225,9 +225,9 @@ defmodule Oli.Analytics.Datashop do
     )
   end
 
-  def count(project_id) do
+  def count(section_ids) do
     from(snapshot in Snapshot,
-      where: snapshot.project_id == ^project_id,
+      where: snapshot.section_id in ^section_ids and not is_nil(snapshot.objective_revision_id),
       select: count(snapshot.id)
     )
     |> Repo.one()
@@ -240,10 +240,11 @@ defmodule Oli.Analytics.Datashop do
       skill_titles: skill_titles,
       dataset_name: dataset_name,
       project: project,
-      publication: publication
+      publication: publication,
+      section_ids: section_ids
     } = context
 
-    part_attempts_stream(project.id)
+    part_attempts_stream(section_ids)
     |> Stream.map(fn %{
                        email: email,
                        sub: sub,
@@ -319,7 +320,7 @@ defmodule Oli.Analytics.Datashop do
     end)
   end
 
-  def build_context(project_id) do
+  def build_context(project_id, section_ids) do
     project = Course.get_project!(project_id)
     publication = Publishing.get_latest_published_publication_by_slug(project.slug)
 
@@ -346,7 +347,8 @@ defmodule Oli.Analytics.Datashop do
       skill_titles: skill_titles,
       dataset_name: Utils.make_dataset_name(project.slug),
       project: project,
-      publication: publication
+      publication: publication,
+      section_ids: section_ids
     }
   end
 

--- a/lib/oli/authoring/course.ex
+++ b/lib/oli/authoring/course.ex
@@ -559,7 +559,7 @@ defmodule Oli.Authoring.Course do
   end
 
   @doc """
-  Generates a datashop snapshot for the given project if one is not already in progress
+  Generates a datashop snapshot for the given project and sections if one is not already in progress
   """
   def generate_datashop_snapshot(project, section_ids) do
     case datashop_export_status(project) do

--- a/lib/oli/authoring/course.ex
+++ b/lib/oli/authoring/course.ex
@@ -561,18 +561,18 @@ defmodule Oli.Authoring.Course do
   @doc """
   Generates a datashop snapshot for the given project if one is not already in progress
   """
-  def generate_datashop_snapshot(project) do
+  def generate_datashop_snapshot(project, section_ids) do
     case datashop_export_status(project) do
       {:in_progress} ->
         {:error, "Datashop snapshot is already in progress"}
 
       _ ->
-        generate_datashop_snapshot!(project)
+        generate_datashop_snapshot!(project, section_ids)
     end
   end
 
-  defp generate_datashop_snapshot!(project) do
-    %{project_slug: project.slug}
+  defp generate_datashop_snapshot!(project, section_ids) do
+    %{project_slug: project.slug, section_ids: section_ids}
     |> Oli.Analytics.DatashopExportWorker.new()
     |> Oban.insert()
   end

--- a/lib/oli/delivery/sections/blueprint.ex
+++ b/lib/oli/delivery/sections/blueprint.ex
@@ -428,7 +428,6 @@ defmodule Oli.Delivery.Sections.Blueprint do
       |> where(^filter_by_status)
       |> limit(^limit)
       |> offset(^offset)
-      |> order_by([p, _, _, _], {^direction, field(p, ^field)})
       |> select([s, _bp], %{s | total_count: fragment("count(*) OVER()")})
 
     query =

--- a/lib/oli/delivery/sections/browse.ex
+++ b/lib/oli/delivery/sections/browse.ex
@@ -77,6 +77,11 @@ defmodule Oli.Delivery.Sections.Browse do
         do: true,
         else: dynamic([s, _], s.blueprint_id == ^options.blueprint_id)
 
+    filter_by_project =
+      if is_nil(options.project_id),
+        do: true,
+        else: dynamic([s, _], s.base_project_id == ^options.project_id)
+
     instructor_role_id = ContextRoles.get_role(:context_instructor).id
 
     instructor =
@@ -109,6 +114,7 @@ defmodule Oli.Delivery.Sections.Browse do
       |> where(^filter_by_text)
       |> where(^filter_by_institution)
       |> where(^filter_by_blueprint)
+      |> where(^filter_by_project)
       |> limit(^limit)
       |> offset(^offset)
       |> preload([:institution, :base_project, :blueprint])

--- a/lib/oli/delivery/sections/browse_options.ex
+++ b/lib/oli/delivery/sections/browse_options.ex
@@ -6,6 +6,7 @@ defmodule Oli.Delivery.Sections.BrowseOptions do
   @enforce_keys [
     :institution_id,
     :blueprint_id,
+    :project_id,
     :text_search,
     :active_today,
     :filter_status,
@@ -15,6 +16,7 @@ defmodule Oli.Delivery.Sections.BrowseOptions do
   defstruct [
     :institution_id,
     :blueprint_id,
+    :project_id,
     :text_search,
     :active_today,
     :filter_status,
@@ -24,6 +26,7 @@ defmodule Oli.Delivery.Sections.BrowseOptions do
   @type t() :: %__MODULE__{
           institution_id: integer(),
           blueprint_id: integer(),
+          project_id: integer(),
           text_search: String.t(),
           active_today: boolean(),
           filter_status: atom(),

--- a/lib/oli_web/components/project/async_exporter.ex
+++ b/lib/oli_web/components/project/async_exporter.ex
@@ -69,66 +69,65 @@ defmodule OliWeb.Components.Project.AsyncExporter do
   end
 
   attr(:ctx, SessionContext, required: true)
-  attr(:latest_publication, Publication, default: nil)
+  attr(:disabled, :boolean, default: false)
   attr(:datashop_export_status, :atom, values: [:not_available, :in_progress, :available, :error])
   attr(:datashop_export_url, :string)
   attr(:datashop_export_timestamp, :string)
-  attr(:on_generate_datashop_snapshot, :string, default: "generate_datashop_snapshot")
-  attr(:on_kill, :string, default: "kill_datashop_snapshot")
+  attr(:on_generate_datashop_snapshot, :string)
+  attr(:on_kill, :string)
 
   def datashop(assigns) do
     ~H"""
-    <%= case @latest_publication do %>
-      <% nil -> %>
-        <.button_link disabled>Datashop</.button_link>
-        Project must be published to generate a datashop snapshot.
-      <% _pub -> %>
-        <%= case @datashop_export_status do %>
-          <% status when status in [:not_available, :expired] -> %>
-            <.button_link variant={:primary} phx-click={@on_generate_datashop_snapshot}>
-              Datashop
-            </.button_link>
-            <div>Create a <.datashop_link /> snapshot for download</div>
-          <% :in_progress -> %>
-            <.button_link disabled>Datashop</.button_link>
-            <.button_link variant={:primary} phx-click={@on_kill}>
-              Kill Active Datashop Export
-            </.button_link>
-            <div class="flex flex-col">
-              <div>Create a <.datashop_link /> snapshot for download</div>
-              <div class="text-sm text-gray-500">
-                <i class="fa-solid fa-circle-notch fa-spin text-primary"></i>
-                Generating datashop snapshot... this might take a while.
-              </div>
-            </div>
-          <% :available -> %>
-            <.button_link variant={:primary} href={@datashop_export_url} download>
-              <i class="fa-solid fa-download mr-1"></i> Datashop
-            </.button_link>
-            <.button_link variant={:primary} phx-click={@on_kill}>
-              Kill Active Datashop Export
-            </.button_link>
-            <div class="flex flex-col">
-              <div>Download <.datashop_link /> snapshot.</div>
-              <div class="text-sm text-gray-500">
-                Created <%= date(@datashop_export_timestamp, @ctx) %>.
-                <.button_link phx-click={@on_generate_datashop_snapshot}>
-                  <i class="fa-solid fa-rotate-right mr-1"></i>Regenerate
-                </.button_link>
-              </div>
-            </div>
-          <% :error -> %>
-            <.button_link variant={:primary} phx-click={@on_generate_datashop_snapshot}>
-              Datashop
-            </.button_link>
-            <div class="flex flex-col">
-              <div>Create a <.datashop_link /> snapshot for download</div>
-              <div class="text-sm text-gray-500">
-                <i class="fa-solid fa-exclamation-circle text-red-500"></i>
-                Error generating datashop snapshot. Please try again later or contact support.
-              </div>
-            </div>
-        <% end %>
+    <%= case @datashop_export_status do %>
+      <% status when status in [:not_available, :expired] -> %>
+        <.datashop_button
+          id="button-generate-datashop"
+          on_datashop_action={@on_generate_datashop_snapshot}
+          disabled={@disabled}
+          color="blue"
+        >
+          <i class="fa-solid fa-file-export"></i> Generate Datashop Export
+        </.datashop_button>
+      <% :in_progress -> %>
+        <.datashop_button id="button-kill-datashop" on_datashop_action={@on_kill} color="red">
+          <i class="fa-solid fa-file-export"></i> Kill Datashop Export
+        </.datashop_button>
+        <div class="text-sm text-gray-500">
+          <i class="fa-solid fa-circle-notch fa-spin text-primary"></i>
+          Generating datashop snapshot... this might take a while.
+        </div>
+      <% :available -> %>
+        <div class="flex flex-col mx-4 text-center">
+          <.button_link variant={:primary} href={@datashop_export_url} download>
+            <i class="fa-solid fa-download mr-1"></i> Datashop
+          </.button_link>
+          <div class="text-xs text-gray-500">
+            Created <%= date(@datashop_export_timestamp, @ctx) %>.
+          </div>
+        </div>
+        <.datashop_button
+          id="button-regenerate-datashop"
+          on_datashop_action={@on_generate_datashop_snapshot}
+          disabled={@disabled}
+          color="blue"
+        >
+          <i class="fa-solid fa-rotate-right mr-1"></i> Regenerate
+        </.datashop_button>
+      <% :error -> %>
+        <.datashop_button
+          id="button-generate-datashop"
+          on_datashop_action={@on_generate_datashop_snapshot}
+          disabled={@disabled}
+          color="blue"
+        >
+          <i class="fa-solid fa-file-export"></i> Generate Datashop Export
+        </.datashop_button>
+        <div class="flex flex-col">
+          <div class="text-sm text-gray-500">
+            <i class="fa-solid fa-exclamation-circle text-red-500"></i>
+            Error generating datashop snapshot. Please try again later or contact support.
+          </div>
+        </div>
     <% end %>
     """
   end
@@ -140,6 +139,25 @@ defmodule OliWeb.Components.Project.AsyncExporter do
     <a class="text-primary external" href="https://pslcdatashop.web.cmu.edu/" target="_blank">
       datashop
     </a>
+    """
+  end
+
+  attr(:id, :string, required: true)
+  attr(:disabled, :boolean, default: false)
+  attr(:color, :string, default: "blue")
+  attr(:on_datashop_action, :string, required: true)
+  slot(:inner_block, required: true)
+
+  defp datashop_button(assigns) do
+    ~H"""
+    <button
+      id={@id}
+      class={"bg-#{@color}-500 hover:bg-#{@color}-600 text-white py-2 px-4 rounded disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-#{@color}-500"}
+      phx-click={@on_datashop_action}
+      disabled={@disabled}
+    >
+      <%= render_slot(@inner_block) %>
+    </button>
     """
   end
 end

--- a/lib/oli_web/components/project/async_exporter.ex
+++ b/lib/oli_web/components/project/async_exporter.ex
@@ -152,7 +152,13 @@ defmodule OliWeb.Components.Project.AsyncExporter do
     ~H"""
     <button
       id={@id}
-      class={"bg-#{@color}-500 hover:bg-#{@color}-600 text-white py-2 px-4 rounded disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-#{@color}-500"}
+      class={[
+        "text-white py-2 px-4 rounded disabled:opacity-50 disabled:cursor-not-allowed",
+        if(@color == "blue",
+          do: "bg-blue-500 hover:bg-blue-600  disabled:hover:bg-blue-500",
+          else: "bg-red-500 hover:bg-red-600  disabled:hover:bg-red-500"
+        )
+      ]}
       phx-click={@on_datashop_action}
       disabled={@disabled}
     >

--- a/lib/oli_web/components/project/async_exporter.ex
+++ b/lib/oli_web/components/project/async_exporter.ex
@@ -89,12 +89,14 @@ defmodule OliWeb.Components.Project.AsyncExporter do
           <i class="fa-solid fa-file-export"></i> Generate Datashop Export
         </.datashop_button>
       <% :in_progress -> %>
-        <.datashop_button id="button-kill-datashop" on_datashop_action={@on_kill} color="red">
-          <i class="fa-solid fa-file-export"></i> Kill Datashop Export
-        </.datashop_button>
-        <div class="text-sm text-gray-500">
-          <i class="fa-solid fa-circle-notch fa-spin text-primary"></i>
-          Generating datashop snapshot... this might take a while.
+        <div class="flex flex-col my-4 items-end">
+          <.datashop_button id="button-kill-datashop" on_datashop_action={@on_kill} color="red">
+            <i class="fa-solid fa-file-export"></i> Kill Datashop Export
+          </.datashop_button>
+          <div class="text-sm text-gray-500 mt-2">
+            <i class="fa-solid fa-circle-notch fa-spin text-primary"></i>
+            Generating datashop snapshot... this might take a while.
+          </div>
         </div>
       <% :available -> %>
         <div class="flex flex-col mx-4 text-center">
@@ -114,16 +116,16 @@ defmodule OliWeb.Components.Project.AsyncExporter do
           <i class="fa-solid fa-rotate-right mr-1"></i> Regenerate
         </.datashop_button>
       <% :error -> %>
-        <.datashop_button
-          id="button-generate-datashop"
-          on_datashop_action={@on_generate_datashop_snapshot}
-          disabled={@disabled}
-          color="blue"
-        >
-          <i class="fa-solid fa-file-export"></i> Generate Datashop Export
-        </.datashop_button>
-        <div class="flex flex-col">
-          <div class="text-sm text-gray-500">
+        <div class="flex flex-col my-4 items-end">
+          <.datashop_button
+            id="button-generate-datashop"
+            on_datashop_action={@on_generate_datashop_snapshot}
+            disabled={@disabled}
+            color="blue"
+          >
+            <i class="fa-solid fa-file-export"></i> Generate Datashop Export
+          </.datashop_button>
+          <div class="text-sm text-gray-500 mt-2">
             <i class="fa-solid fa-exclamation-circle text-red-500"></i>
             Error generating datashop snapshot. Please try again later or contact support.
           </div>
@@ -153,7 +155,7 @@ defmodule OliWeb.Components.Project.AsyncExporter do
     <button
       id={@id}
       class={[
-        "text-white py-2 px-4 rounded disabled:opacity-50 disabled:cursor-not-allowed",
+        "text-white py-2 px-4 w-auto rounded disabled:opacity-50 disabled:cursor-not-allowed",
         if(@color == "blue",
           do: "bg-blue-500 hover:bg-blue-600  disabled:hover:bg-blue-500",
           else: "bg-red-500 hover:bg-red-600  disabled:hover:bg-red-500"

--- a/lib/oli_web/live/admin/institutions/sections_and_students_view.ex
+++ b/lib/oli_web/live/admin/institutions/sections_and_students_view.ex
@@ -54,6 +54,7 @@ defmodule OliWeb.Admin.Institutions.SectionsAndStudentsView do
         %Sorting{direction: decoded_params.sort_order, field: decoded_params.sort_by},
         %BrowseOptions{
           blueprint_id: nil,
+          project_id: nil,
           text_search: decoded_params.text_search,
           active_today: false,
           filter_status: nil,

--- a/lib/oli_web/live/datashop/analytics_live.ex
+++ b/lib/oli_web/live/datashop/analytics_live.ex
@@ -22,6 +22,8 @@ defmodule OliWeb.Datashop.AnalyticsLive do
 
   @limit 25
 
+  on_mount(OliWeb.LiveSessionPlugs.SetProject)
+
   def mount(_params, session, socket) do
     ctx = SessionContext.init(socket, session)
     project = socket.assigns.project
@@ -146,7 +148,7 @@ defmodule OliWeb.Datashop.AnalyticsLive do
     ~H"""
     <Modal.modal
       id="generate_datashop_export_modal"
-      class="w-1/3"
+      class="w-1/2"
       on_confirm={
         JS.push("generate_datashop_snapshot")
         |> Modal.hide_modal("generate_datashop_export_modal")
@@ -154,16 +156,8 @@ defmodule OliWeb.Datashop.AnalyticsLive do
     >
       <:title>Generate Datashop Export</:title>
       <div class="flex flex-col items-center justify-center text-center p-4">
-        <div class="mb-4 p-4 border border-orange-300 dark:border-orange-700 bg-orange-100 dark:bg-orange-800 rounded-lg shadow-md">
-          <i class="fas fa-exclamation-triangle text-orange-500 dark:text-orange-200 text-xl mr-2">
-          </i>
-          <span class="text-orange-600 dark:text-orange-300">
-            DataShop Download is an unstable feature at the moment as the memory demands that it places on the system can cause the server to crash.
-            Please use with extreme caution and consult Torus engineering staff before doing so.
-          </span>
-        </div>
-        <div class="text-xl font-semibold">
-          Are you sure you want to generate a DataShop export?
+        <div class="text-xl">
+          Are you sure you want to generate a Datashop export?
         </div>
       </div>
 

--- a/lib/oli_web/live/datashop/analytics_live.ex
+++ b/lib/oli_web/live/datashop/analytics_live.ex
@@ -1,0 +1,319 @@
+defmodule OliWeb.Datashop.AnalyticsLive do
+  @moduledoc """
+  LiveView implementation of datashop analytics view.
+  """
+
+  use OliWeb, :live_view
+  use OliWeb.Common.Modal
+
+  import OliWeb.Common.Params
+  import OliWeb.DelegatedEvents
+
+  alias Oli.Authoring.Broadcaster.Subscriber
+  alias Oli.Authoring.{Broadcaster, Course}
+  alias Oli.Delivery.Sections.{Browse, BrowseOptions}
+  alias Oli.Repo.{Paging, Sorting}
+  alias OliWeb.Common.{Breadcrumb, PagedTable, SessionContext, TextSearch}
+  alias OliWeb.Datashop.SectionsTableModel
+  alias OliWeb.Router.Helpers, as: Routes
+  alias OliWeb.Components.Project.AsyncExporter
+  alias OliWeb.Components.Modal
+  alias Phoenix.LiveView.JS
+
+  @limit 25
+
+  def mount(_params, session, socket) do
+    ctx = SessionContext.init(socket, session)
+    project = socket.assigns.project
+    selected_sections = MapSet.new([])
+
+    ## Setup table data
+    # Sections whose base project is the current project
+    sections =
+      Browse.browse_sections(
+        %Paging{offset: 0, limit: @limit},
+        %Sorting{direction: :asc, field: :title},
+        %BrowseOptions{
+          project_id: project.id,
+          blueprint_id: nil,
+          text_search: nil,
+          active_today: false,
+          filter_status: :active,
+          filter_type: nil,
+          institution_id: nil
+        }
+      )
+
+    {:ok, table_model} = SectionsTableModel.new(ctx, sections, selected_sections)
+
+    total_count = determine_total(sections)
+
+    ## Setup Datashop export status and Pub/Sub subscription
+    {datashop_export_status, datashop_export_url, datashop_export_timestamp} =
+      case Course.datashop_export_status(project) do
+        {:available, url, timestamp} -> {:available, url, timestamp}
+        {:expired, _, _} -> {:expired, nil, nil}
+        {status} -> {status, nil, nil}
+      end
+
+    # Subscribe to any raw analytics snapshot progress updates for this project
+    Subscriber.subscribe_to_datashop_export_status(project.slug)
+
+    socket =
+      assign(socket,
+        ctx: ctx,
+        breadcrumbs: [Breadcrumb.new(%{full_title: "Datashop Analytics"})],
+        title: "Datashop Analytics | " <> project.title,
+        table_model: table_model,
+        total_count: total_count,
+        datashop_export_status: datashop_export_status,
+        datashop_export_url: datashop_export_url,
+        datashop_export_timestamp: datashop_export_timestamp,
+        selected_sections: selected_sections
+      )
+
+    {:ok, socket}
+  end
+
+  defp determine_total(sections) do
+    case(sections) do
+      [] -> 0
+      [hd | _] -> hd.total_count
+    end
+  end
+
+  def handle_params(params, _, socket) do
+    table_model =
+      OliWeb.Common.Table.SortableTableModel.update_from_params(
+        socket.assigns.table_model,
+        params
+      )
+
+    offset = get_int_param(params, "offset", 0)
+    text_search = get_param(params, "text_search", "")
+    project = socket.assigns.project
+
+    sections =
+      Browse.browse_sections(
+        %Paging{offset: offset, limit: @limit},
+        %Sorting{direction: table_model.sort_order, field: table_model.sort_by_spec.name},
+        %BrowseOptions{
+          project_id: project.id,
+          blueprint_id: nil,
+          text_search: text_search,
+          active_today: false,
+          filter_status: :active,
+          filter_type: nil,
+          institution_id: nil
+        }
+      )
+
+    displayed_sections = Enum.map(sections, & &1.id)
+
+    selected_sections =
+      MapSet.filter(socket.assigns.selected_sections, fn s -> s in displayed_sections end)
+
+    table_model =
+      table_model
+      |> Map.put(:rows, sections)
+      |> Map.update!(:data, fn data ->
+        %{data | selected_sections: selected_sections}
+      end)
+
+    total_count = determine_total(sections)
+
+    {:noreply,
+     assign(socket,
+       offset: offset,
+       table_model: table_model,
+       total_count: total_count,
+       text_search: text_search,
+       selected_sections: selected_sections
+     )}
+  end
+
+  attr(:breadcrumbs, :any, default: [Breadcrumb.new(%{full_title: "Datashop Analytics"})])
+  attr(:title, :string, default: "Datashop Analytics")
+
+  attr(:tabel_model, :map)
+  attr(:total_count, :integer, default: 0)
+  attr(:offset, :integer, default: 0)
+  attr(:limit, :integer, default: @limit)
+  attr(:text_search, :string, default: "")
+  attr(:selected_sections, :map, default: MapSet.new([]))
+
+  def render(assigns) do
+    ~H"""
+    <Modal.modal
+      id="generate_datashop_export_modal"
+      class="w-1/3"
+      on_confirm={
+        JS.push("generate_datashop_snapshot")
+        |> Modal.hide_modal("generate_datashop_export_modal")
+      }
+    >
+      <:title>Generate Datashop Export</:title>
+      <div class="flex flex-col items-center justify-center text-center p-4">
+        <div class="mb-4 p-4 border border-orange-300 dark:border-orange-700 bg-orange-100 dark:bg-orange-800 rounded-lg shadow-md">
+          <i class="fas fa-exclamation-triangle text-orange-500 dark:text-orange-200 text-xl mr-2">
+          </i>
+          <span class="text-orange-600 dark:text-orange-300">
+            DataShop Download is an unstable feature at the moment as the memory demands that it places on the system can cause the server to crash.
+            Please use with extreme caution and consult Torus engineering staff before doing so.
+          </span>
+        </div>
+        <div class="text-xl font-semibold">
+          Are you sure you want to generate a DataShop export?
+        </div>
+      </div>
+
+      <:confirm>Confirm</:confirm>
+    </Modal.modal>
+    <div class="container mx-auto">
+      <div class="container mb-4">
+        <div class="flex justify-between items-center">
+          <div class="flex-grow">
+            <TextSearch.render
+              id="text-search"
+              reset="text_search_reset"
+              change="text_search_change"
+              text={@text_search}
+              event_target={nil}
+            />
+          </div>
+
+          <AsyncExporter.datashop
+            ctx={@ctx}
+            on_generate_datashop_snapshot={Modal.show_modal("generate_datashop_export_modal")}
+            on_kill="kill_datashop_snapshot"
+            datashop_export_status={@datashop_export_status}
+            datashop_export_url={@datashop_export_url}
+            datashop_export_timestamp={@datashop_export_timestamp}
+            disabled={Enum.empty?(@selected_sections)}
+          />
+        </div>
+      </div>
+
+      <div class="grid grid-cols-12">
+        <div id="projects-table" class="col-span-12">
+          <PagedTable.render
+            page_change="paged_table_page_change"
+            sort="paged_table_sort"
+            total_count={@total_count}
+            filter={@text_search}
+            limit={@limit}
+            offset={@offset}
+            table_model={@table_model}
+          />
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  def patch_with(socket, changes) do
+    {:noreply,
+     push_patch(socket,
+       to:
+         Routes.live_path(
+           socket,
+           OliWeb.Datashop.AnalyticsLive,
+           socket.assigns.project.slug,
+           Map.merge(
+             %{
+               sort_by: socket.assigns.table_model.sort_by_spec.name,
+               sort_order: socket.assigns.table_model.sort_order,
+               offset: socket.assigns.offset,
+               text_search: socket.assigns.text_search
+             },
+             changes
+           )
+         ),
+       replace: true
+     )}
+  end
+
+  def handle_event("toggle_section", %{"section_id" => section_id} = params, socket) do
+    toggle_fn =
+      case params["value"] do
+        "on" -> &MapSet.put/2
+        _ -> &MapSet.delete/2
+      end
+
+    selected_sections = toggle_fn.(socket.assigns.selected_sections, section_id)
+
+    {:ok, table_model} =
+      SectionsTableModel.new(
+        socket.assigns.ctx,
+        socket.assigns.table_model.rows,
+        selected_sections
+      )
+
+    {:noreply, assign(socket, table_model: table_model, selected_sections: selected_sections)}
+  end
+
+  def handle_event("generate_datashop_snapshot", _params, socket) do
+    project = socket.assigns.project
+
+    selected_sections = MapSet.to_list(socket.assigns.selected_sections)
+
+    case Course.generate_datashop_snapshot(project, selected_sections) do
+      {:ok, _job} ->
+        Broadcaster.broadcast_datashop_export_status(project.slug, {:in_progress})
+
+        {:noreply, socket}
+
+      {:error, _changeset} ->
+        socket =
+          socket
+          |> put_flash(:error, "Datashop snapshot could not be generated.")
+
+        {:noreply, socket}
+    end
+  end
+
+  def handle_event("kill_datashop_snapshot", _params, socket) do
+    Course.kill_datashop_export(socket.assigns.project.slug, "datashop_export")
+    Broadcaster.broadcast_datashop_export_status(socket.assigns.project.slug, {:not_available})
+
+    socket =
+      socket
+      |> put_flash(:info, "Snapshots killed")
+
+    {:noreply, socket}
+  end
+
+  def handle_event(event, params, socket) do
+    {event, params, socket, &__MODULE__.patch_with/2}
+    |> delegate_to([
+      &TextSearch.handle_delegated/4,
+      &PagedTable.handle_delegated/4
+    ])
+  end
+
+  def handle_info(
+        {:datashop_export_status, {:available, datashop_export_url, datashop_export_timestamp}},
+        socket
+      ) do
+    {:noreply,
+     assign(socket,
+       datashop_export_status: :available,
+       datashop_export_url: datashop_export_url,
+       datashop_export_timestamp: datashop_export_timestamp
+     )}
+  end
+
+  def handle_info(
+        {:datashop_export_status, {:error, _e}},
+        socket
+      ) do
+    {:noreply,
+     assign(socket,
+       datashop_export_status: :error
+     )}
+  end
+
+  def handle_info({:datashop_export_status, {status}}, socket) do
+    {:noreply, assign(socket, datashop_export_status: status)}
+  end
+end

--- a/lib/oli_web/live/datashop/table_model.ex
+++ b/lib/oli_web/live/datashop/table_model.ex
@@ -85,7 +85,7 @@ defmodule OliWeb.Datashop.SectionsTableModel do
     ~H"""
     <div class="form-check flex justify-center items-center">
       <input
-        id="id"
+        id={"select-section-#{@section.id}"}
         type="checkbox"
         class="form-check-input hover:cursor-pointer"
         checked={@checked}

--- a/lib/oli_web/live/datashop/table_model.ex
+++ b/lib/oli_web/live/datashop/table_model.ex
@@ -1,0 +1,153 @@
+defmodule OliWeb.Datashop.SectionsTableModel do
+  use Phoenix.Component
+
+  alias OliWeb.Common.SessionContext
+  alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
+  alias OliWeb.Router.Helpers, as: Routes
+  alias Phoenix.LiveView.JS
+
+  def new(%SessionContext{} = ctx, sections, selected_sections, max_checked \\ 5) do
+    SortableTableModel.new(
+      rows: sections,
+      column_specs: [
+        %ColumnSpec{
+          name: :title,
+          label: "Title",
+          render_fn: &__MODULE__.custom_render/3
+        },
+        %ColumnSpec{
+          name: :type,
+          label: "Type",
+          render_fn: &__MODULE__.custom_render/3
+        },
+        %ColumnSpec{
+          name: :enrollments_count,
+          label: "# Enrolled"
+        },
+        %ColumnSpec{
+          name: :requires_payment,
+          label: "Cost",
+          render_fn: &__MODULE__.custom_render/3
+        },
+        %ColumnSpec{
+          name: :start_date,
+          label: "Start",
+          render_fn: &OliWeb.Common.Table.Common.render_date/3,
+          sort_fn: &OliWeb.Common.Table.Common.sort_date/2
+        },
+        %ColumnSpec{
+          name: :end_date,
+          label: "End",
+          render_fn: &OliWeb.Common.Table.Common.render_date/3,
+          sort_fn: &OliWeb.Common.Table.Common.sort_date/2
+        },
+        %ColumnSpec{
+          name: :status,
+          label: "Status",
+          render_fn: &__MODULE__.custom_render/3
+        },
+        %ColumnSpec{
+          name: :instructor,
+          label: "Instructors",
+          render_fn: &__MODULE__.custom_render/3
+        },
+        %ColumnSpec{
+          name: :institution,
+          label: "Institution",
+          render_fn: &__MODULE__.custom_render/3
+        },
+        %ColumnSpec{
+          name: :select,
+          label: "Select",
+          td_class: "hover:cursor-auto",
+          render_fn: &__MODULE__.custom_render/3,
+          sortable: false
+        }
+      ],
+      event_suffix: "",
+      id_field: [:id],
+      data: %{
+        ctx: ctx,
+        fade_data: true,
+        selected_sections: selected_sections,
+        max_checked: max_checked
+      }
+    )
+  end
+
+  def custom_render(assigns, section, %ColumnSpec{name: :select}) do
+    assigns =
+      Map.merge(assigns, %{
+        section: section,
+        checked: MapSet.member?(assigns.selected_sections, section.id)
+      })
+
+    ~H"""
+    <div class="form-check flex justify-center items-center">
+      <input
+        id="id"
+        type="checkbox"
+        class="form-check-input hover:cursor-pointer"
+        checked={@checked}
+        phx-click={JS.push("toggle_section", value: %{section_id: @section.id})}
+        disabled={!@checked and MapSet.size(@selected_sections) >= @max_checked}
+      />
+    </div>
+    """
+  end
+
+  def custom_render(assigns, section, %ColumnSpec{name: :title}) do
+    assigns = Map.merge(assigns, %{section: section})
+
+    ~H"""
+    <a href={
+      Routes.live_path(
+        OliWeb.Endpoint,
+        OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive,
+        @section.slug,
+        :manage
+      )
+    }>
+      <%= @section.title %>
+    </a>
+    """
+  end
+
+  def custom_render(_assigns, section, %ColumnSpec{name: :type}),
+    do: if(section.open_and_free, do: "Open", else: "LMS")
+
+  def custom_render(_assigns, section, %ColumnSpec{name: :requires_payment}) do
+    if section.requires_payment do
+      case Money.to_string(section.amount) do
+        {:ok, m} -> m
+        _ -> "Yes"
+      end
+    else
+      "None"
+    end
+  end
+
+  def custom_render(assigns, section, %ColumnSpec{name: :institution}) do
+    assigns = Map.merge(assigns, %{section: section})
+
+    ~H"""
+    <div class="flex space-x-2 items-center">
+      <div>
+        <%= @section.institution && @section.institution.name %>
+      </div>
+    </div>
+    """
+  end
+
+  def custom_render(_assigns, section, %ColumnSpec{name: :status}),
+    do: Phoenix.Naming.humanize(section.status)
+
+  def custom_render(_assigns, section, %ColumnSpec{name: :instructor}),
+    do: Map.get(section, :instructor_name, "")
+
+  def render(assigns) do
+    ~H"""
+    <div>nothing</div>
+    """
+  end
+end

--- a/lib/oli_web/live/projects/overview_live.ex
+++ b/lib/oli_web/live/projects/overview_live.ex
@@ -323,7 +323,7 @@ defmodule OliWeb.Projects.OverviewLive do
             <% _pub -> %>
               <.button_link
                 class="btn btn-link action-button"
-                href={~p"/authoring/project/#{@project.slug}/datashop/analytics"}
+                href={~p"/project/#{@project.slug}/datashop"}
               >
                 Datashop Analytics
               </.button_link>

--- a/lib/oli_web/live/projects/overview_live.ex
+++ b/lib/oli_web/live/projects/overview_live.ex
@@ -476,7 +476,9 @@ defmodule OliWeb.Projects.OverviewLive do
   def handle_event("generate_datashop_snapshot", _params, socket) do
     project = socket.assigns.project
 
-    case Course.generate_datashop_snapshot(project) do
+    section_ids = []
+
+    case Course.generate_datashop_snapshot(project, section_ids) do
       {:ok, _job} ->
         Broadcaster.broadcast_datashop_export_status(project.slug, {:in_progress})
 

--- a/lib/oli_web/live/sections/sections_view.ex
+++ b/lib/oli_web/live/sections/sections_view.ex
@@ -15,6 +15,7 @@ defmodule OliWeb.Sections.SectionsView do
   @default_options %BrowseOptions{
     institution_id: nil,
     blueprint_id: nil,
+    project_id: nil,
     text_search: "",
     active_today: false,
     filter_status: nil,
@@ -74,7 +75,8 @@ defmodule OliWeb.Sections.SectionsView do
       filter_type: get_atom_param(params, "filter_type", @type_opts, nil),
       # This view is currently for all institutions and all root products
       institution_id: nil,
-      blueprint_id: nil
+      blueprint_id: nil,
+      project_id: nil
     }
 
     sections =

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -396,12 +396,6 @@ defmodule OliWeb.Router do
       on_mount: [OliWeb.LiveSessionPlugs.SetCurrentAuthor, OliWeb.LiveSessionPlugs.SetProject] do
       live("/:project_id", Projects.OverviewLive)
       live("/:project_id/overview", Projects.OverviewLive)
-
-      scope "/:project_id/datashop" do
-        pipe_through([:admin])
-
-        live("/analytics", Datashop.AnalyticsLive)
-      end
     end
   end
 
@@ -1294,6 +1288,8 @@ defmodule OliWeb.Router do
     live("/:project_id/history/resource_id/:resource_id", RevisionHistory,
       as: :history_by_resource_id
     )
+
+    live("/:project_id/datashop", Datashop.AnalyticsLive)
   end
 
   # Support for cognito JWT auth currently used by Infiniscope

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -394,8 +394,14 @@ defmodule OliWeb.Router do
 
     live_session :load_projects,
       on_mount: [OliWeb.LiveSessionPlugs.SetCurrentAuthor, OliWeb.LiveSessionPlugs.SetProject] do
-      live("/:project_id/overview", Projects.OverviewLive)
       live("/:project_id", Projects.OverviewLive)
+      live("/:project_id/overview", Projects.OverviewLive)
+
+      scope "/:project_id/datashop" do
+        pipe_through([:admin])
+
+        live("/analytics", Datashop.AnalyticsLive)
+      end
     end
   end
 

--- a/test/oli/delivery/sections/browse_test.exs
+++ b/test/oli/delivery/sections/browse_test.exs
@@ -143,7 +143,7 @@ defmodule Oli.Delivery.Sections.BrowseTest do
       assert hd(results).title == "zzz ;:-|'<$p#(!*) characters"
     end
 
-    test "filtering", %{second: second, sections: sections} do
+    test "filtering", %{second: second, sections: sections, project: project} do
       # by institution
       results = browse(0, :title, :asc, Map.merge(@default_opts, %{institution_id: second.id}))
       assert length(results) == 3
@@ -184,6 +184,11 @@ defmodule Oli.Delivery.Sections.BrowseTest do
 
       assert length(results) == 1
       assert hd(results).total_count == 1
+
+      # by project
+      results = browse(0, :title, :asc, Map.merge(@default_opts, %{project_id: project.id}))
+      assert length(results) == 3
+      assert hd(results).total_count == 30
     end
   end
 

--- a/test/oli/delivery/sections/browse_test.exs
+++ b/test/oli/delivery/sections/browse_test.exs
@@ -13,6 +13,7 @@ defmodule Oli.Delivery.Sections.BrowseTest do
   @default_opts %BrowseOptions{
     institution_id: nil,
     blueprint_id: nil,
+    project_id: nil,
     text_search: "",
     active_today: false,
     filter_status: nil,

--- a/test/oli_web/controllers/cognito_controller_test.exs
+++ b/test/oli_web/controllers/cognito_controller_test.exs
@@ -639,7 +639,7 @@ defmodule OliWeb.CognitoControllerTest do
                "Would you like to\n<a href=\"/cognito/clone/#{project.slug}\">create another copy</a>"
 
       assert html =~
-               "<a href=\"/authoring/project/#{duplicated.slug}/overview\">#{duplicated.title}</a>"
+               "<a href=\"/authoring/project/#{duplicated.slug}\">#{duplicated.title}</a>"
     end
   end
 

--- a/test/oli_web/live/datashop/analytics_live_test.exs
+++ b/test/oli_web/live/datashop/analytics_live_test.exs
@@ -10,7 +10,7 @@ defmodule OliWeb.Datashop.AnalyticsLiveTest do
       project = insert(:project)
 
       expected_path =
-        "/authoring/session/new?request_path=%2Fauthoring%2Fproject%2F#{project.slug}%2Fdatashop%2Fanalytics"
+        "/authoring/session/new?request_path=%2Fproject%2F#{project.slug}%2Fdatashop"
 
       {:error,
        {:redirect,

--- a/test/oli_web/live/datashop/analytics_live_test.exs
+++ b/test/oli_web/live/datashop/analytics_live_test.exs
@@ -188,8 +188,6 @@ defmodule OliWeb.Datashop.AnalyticsLiveTest do
         {:error, "export failed"}
       )
 
-      open_browser(view)
-
       assert has_element?(view, "#button-generate-datashop", "Generate Datashop Export")
 
       assert render(view) =~

--- a/test/oli_web/live/datashop/analytics_live_test.exs
+++ b/test/oli_web/live/datashop/analytics_live_test.exs
@@ -1,0 +1,246 @@
+defmodule OliWeb.Datashop.AnalyticsLiveTest do
+  use ExUnit.Case, async: true
+  use OliWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+  import Oli.Factory
+
+  describe "author cannot access when is not logged in" do
+    test "redirects to new session when accessing the analytics view", %{conn: conn} do
+      project = insert(:project)
+
+      expected_path =
+        "/authoring/session/new?request_path=%2Fauthoring%2Fproject%2F#{project.slug}%2Fdatashop%2Fanalytics"
+
+      {:error,
+       {:redirect,
+        %{
+          to: ^expected_path
+        }}} =
+        live(conn, live_view_analytics_route(project.slug))
+    end
+  end
+
+  describe "user cannot access when is logged in as an author but is not a system admin" do
+    setup [:author_conn, :create_project]
+
+    test "redirects to new session when accessing the datashop analytics view", %{
+      conn: conn,
+      author: author,
+      project: project
+    } do
+      make_project_author(project, author)
+
+      assert conn
+             |> get(live_view_analytics_route(project.slug))
+             |> response(403)
+    end
+  end
+
+  describe "browse section based from project" do
+    setup [:admin_conn, :create_project]
+
+    test "shows all section list", %{conn: conn, project: project} do
+      section_1 = insert(:section, type: :enrollable, base_project: project)
+      section_2 = insert(:section, type: :enrollable, base_project: project)
+      section_3 = insert(:section, type: :enrollable)
+
+      {:ok, view, _html} = live(conn, live_view_analytics_route(project.slug))
+
+      assert has_element?(view, "a", section_1.title)
+      assert has_element?(view, "a", section_2.title)
+      refute has_element?(view, "a", section_3.title)
+    end
+
+    test "applies searching", %{conn: conn, project: project} do
+      section_1 = insert(:section, type: :enrollable, base_project: project)
+      section_2 = insert(:section, type: :enrollable, base_project: project)
+
+      {:ok, view, _html} = live(conn, live_view_analytics_route(project.slug))
+
+      assert has_element?(view, "a", section_1.title)
+      assert has_element?(view, "a", section_2.title)
+
+      render_hook(view, "text_search_change", %{value: section_1.title})
+
+      assert has_element?(view, "a", section_1.title)
+      refute has_element?(view, "a", section_2.title)
+
+      view
+      |> element("button[phx-click=\"text_search_reset\"]")
+      |> render_click()
+
+      assert has_element?(view, "a", section_1.title)
+      assert has_element?(view, "a", section_2.title)
+    end
+
+    test "applies sorting", %{conn: conn, project: project} do
+      section_1 = insert(:section, type: :enrollable, base_project: project)
+      section_2 = insert(:section, type: :enrollable, base_project: project)
+
+      {:ok, view, _html} = live(conn, live_view_analytics_route(project.slug))
+
+      assert view
+             |> element("tr:first-child > td:first-child")
+             |> render() =~ section_1.title
+
+      view
+      |> element("th[phx-click=\"paged_table_sort\"]:first-of-type")
+      |> render_click(%{sort_by: "title"})
+
+      assert view
+             |> element("tr:first-child > td:first-child")
+             |> render() =~ section_2.title
+    end
+
+    test "applies paging", %{conn: conn, project: project} do
+      [first_s | tail] =
+        insert_list(26, :section, type: :enrollable, base_project: project)
+        |> Enum.sort_by(& &1.title)
+
+      last_s = List.last(tail)
+
+      {:ok, view, _html} = live(conn, live_view_analytics_route(project.slug))
+
+      assert has_element?(view, "##{first_s.id}")
+      refute has_element?(view, "##{last_s.id}")
+
+      view
+      |> element("#header_paging button[phx-click=\"paged_table_page_change\"]", "2")
+      |> render_click()
+
+      refute has_element?(view, "##{first_s.id}")
+      assert has_element?(view, "##{last_s.id}")
+    end
+
+    test "disables generate export button when no sections are selected", %{
+      conn: conn,
+      project: project
+    } do
+      insert(:section, type: :enrollable, base_project: project)
+
+      {:ok, view, _html} = live(conn, live_view_analytics_route(project.slug))
+
+      assert has_element?(view, "#button-generate-datashop[disabled]")
+    end
+
+    test "disables sections select when 5 sections are selected", %{
+      conn: conn,
+      project: project
+    } do
+      [first_s | rest_s] =
+        insert_list(6, :section, type: :enrollable, base_project: project)
+
+      {:ok, view, _html} = live(conn, live_view_analytics_route(project.slug))
+
+      for s <- rest_s do
+        render_click(view, "toggle_section", %{"section_id" => s.id, "value" => "on"})
+      end
+
+      assert has_element?(view, "#select-section-#{first_s.id}[disabled]")
+    end
+
+    test "generates amd kills export", %{
+      conn: conn,
+      project: project
+    } do
+      section = insert(:section, type: :enrollable, base_project: project)
+
+      {:ok, view, _html} = live(conn, live_view_analytics_route(project.slug))
+
+      # Select section and generate export
+      render_click(view, "toggle_section", %{"section_id" => section.id, "value" => "on"})
+      render_click(view, "generate_datashop_snapshot")
+
+      assert has_element?(view, "#button-kill-datashop", "Kill Datashop Export")
+
+      render_click(view, "kill_datashop_snapshot")
+
+      assert has_element?(view, "#button-generate-datashop", "Generate Datashop Export")
+    end
+
+    test "displays export link and regenerates export", %{conn: conn, project: project} do
+      insert(:section, type: :enrollable, base_project: project)
+
+      {:ok, view, _html} = live(conn, live_view_analytics_route(project.slug))
+
+      full_upload_url = "upload_url"
+      timestamp = DateTime.utc_now()
+
+      # Notify that the export is available
+      Oli.Authoring.Broadcaster.broadcast_datashop_export_status(
+        project.slug,
+        {:available, full_upload_url, timestamp}
+      )
+
+      assert has_element?(view, "a[href=#{full_upload_url}]", "Datashop")
+      assert has_element?(view, "#button-regenerate-datashop", "Regenerate")
+    end
+
+    test "displays error when export fails", %{conn: conn, project: project} do
+      insert(:section, type: :enrollable, base_project: project)
+
+      {:ok, view, _html} = live(conn, live_view_analytics_route(project.slug))
+
+      # Notify that the export failed
+      Oli.Authoring.Broadcaster.broadcast_datashop_export_status(
+        project.slug,
+        {:error, "export failed"}
+      )
+
+      open_browser(view)
+
+      assert has_element?(view, "#button-generate-datashop", "Generate Datashop Export")
+
+      assert render(view) =~
+               "Error generating datashop snapshot. Please try again later or contact support."
+    end
+
+    defp live_view_analytics_route(project_slug) do
+      Routes.live_path(OliWeb.Endpoint, OliWeb.Datashop.AnalyticsLive, project_slug)
+    end
+
+    defp create_project(_conn) do
+      author = insert(:author)
+      project = insert(:project, authors: [author])
+      # root container
+      container_resource = insert(:resource)
+
+      container_revision =
+        insert(:revision, %{
+          resource: container_resource,
+          objectives: %{},
+          resource_type_id: Oli.Resources.ResourceType.get_id_by_type("container"),
+          children: [],
+          content: %{},
+          deleted: false,
+          slug: "root_container",
+          title: "Root Container"
+        })
+
+      # Associate root container to the project
+
+      insert(:project_resource, %{project_id: project.id, resource_id: container_resource.id})
+      # Publication of project with root container
+      publication =
+        insert(:publication, %{
+          project: project,
+          published: nil,
+          root_resource_id: container_resource.id
+        })
+
+      # Publish root container resource
+      insert(:published_resource, %{
+        publication: publication,
+        resource: container_resource,
+        revision: container_revision,
+        author: author
+      })
+
+      [project: project, publication: publication]
+    end
+
+    defp make_project_author(project, author),
+      do: insert(:author_project, project_id: project.id, author_id: author.id)
+  end
+end

--- a/test/oli_web/live/ingest_live_test.exs
+++ b/test/oli_web/live/ingest_live_test.exs
@@ -19,22 +19,6 @@ defmodule OliWeb.IngestLiveTest do
     zip_tmp_filepath
   end
 
-  defp upload_file(file_name, conn) do
-    path = simulate_open_zip("./test/support/digests/#{file_name}")
-
-    file_upload = %{
-      "digest" => %Plug.Upload{
-        content_type: "application/zip",
-        filename: file_name,
-        path: path
-      }
-    }
-
-    post(conn, Routes.ingest_path(conn, :upload), %{
-      upload: file_upload
-    })
-  end
-
   describe "user cannot access when is not logged in" do
     test "redirects to new session when accessing the ingest project view", %{
       conn: conn

--- a/test/oli_web/live/projects/overview_live_test.exs
+++ b/test/oli_web/live/projects/overview_live_test.exs
@@ -111,7 +111,7 @@ defmodule OliWeb.Projects.OverviewLiveTest do
 
       refute has_element?(
                view,
-               "a[href=#{~p"/authoring/project/#{project.slug}/datashop/analytics"}]",
+               "a[href=#{~p"/project/#{project.slug}/datashop"}]",
                "Datashop Analytics"
              )
     end
@@ -141,7 +141,7 @@ defmodule OliWeb.Projects.OverviewLiveTest do
 
       assert has_element?(
                view,
-               "a[href=\"/authoring/project/#{project.slug}/datashop/analytics\"]",
+               "a[href=\"/project/#{project.slug}/datashop\"]",
                "Datashop Analytics"
              )
     end

--- a/test/oli_web/live/projects/overview_live_test.exs
+++ b/test/oli_web/live/projects/overview_live_test.exs
@@ -13,8 +13,7 @@ defmodule OliWeb.Projects.OverviewLiveTest do
        {:redirect,
         %{
           flash: %{},
-          to:
-            "/authoring/session/new?request_path=%2Fauthoring%2Fproject%2Ftestproject%2Foverview"
+          to: "/authoring/session/new?request_path=%2Fauthoring%2Fproject%2Ftestproject"
         }}} = live(conn, Routes.live_path(Endpoint, OverviewLive, "testproject"))
     end
   end
@@ -102,10 +101,64 @@ defmodule OliWeb.Projects.OverviewLiveTest do
       refute has_element?(view, "a", "Edit survey")
     end
 
+    test "does not display datashop analytics link when author is not admin", %{
+      conn: conn,
+      author: author
+    } do
+      project = create_project_with_author(author)
+
+      {:ok, view, _html} = live(conn, Routes.live_path(Endpoint, OverviewLive, project.slug))
+
+      refute has_element?(
+               view,
+               "a[href=#{~p"/authoring/project/#{project.slug}/datashop/analytics"}]",
+               "Datashop Analytics"
+             )
+    end
+
     defp create_project_with_author(author) do
       %{project: project} = base_project_with_curriculum(nil)
       insert(:author_project, project_id: project.id, author_id: author.id)
       project
+    end
+  end
+
+  describe "project overview as admin" do
+    setup [:admin_conn]
+
+    test "displays datashop analytics link when the project is published", %{
+      conn: conn,
+      admin: admin
+    } do
+      project = create_project_with_author(admin)
+
+      Oli.Publishing.publish_project(
+        project,
+        "Datashop test"
+      )
+
+      {:ok, view, _html} = live(conn, Routes.live_path(Endpoint, OverviewLive, project.slug))
+
+      assert has_element?(
+               view,
+               "a[href=\"/authoring/project/#{project.slug}/datashop/analytics\"]",
+               "Datashop Analytics"
+             )
+    end
+
+    test "disables datashop analytics link when the project is not published", %{
+      conn: conn,
+      admin: admin
+    } do
+      project = create_project_with_author(admin)
+
+      {:ok, view, _html} = live(conn, Routes.live_path(Endpoint, OverviewLive, project.slug))
+
+      assert has_element?(
+               view,
+               "a[disabled=\"disabled\"]",
+               "Datashop Analytics"
+             )
     end
   end
 end


### PR DESCRIPTION
[MER-2730](https://eliterate.atlassian.net/browse/MER-2730)

Part 1 of a series of 2 PRs to improve the Datashop Export experience.

Introduced changes:
- Move the Datashop Export functionality to a new LiveView
- Allow generating a project Datashop export for only a specific subset of sections based on that project.

The rest of the changes will be addressed on a separate PR ([MER-2731](https://eliterate.atlassian.net/browse/MER-2731))

https://github.com/Simon-Initiative/oli-torus/assets/26532202/64b9bec5-ad1f-4c9e-afea-72b16d55ee39



[MER-2730]: https://eliterate.atlassian.net/browse/MER-2730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MER-2731]: https://eliterate.atlassian.net/browse/MER-2731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ