### PR TITLE
[FEATURE] allow runtime log level changing [MER-2742]

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -210,6 +210,14 @@ config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   metadata: [:request_id]
 
+case System.get_env("LOG_LEVEL", nil) do
+  nil ->
+    nil
+
+  log_level ->
+    config :logger, level: String.to_existing_atom(log_level)
+end
+
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
 

--- a/lib/oli_web/live/admin/admin_view.ex
+++ b/lib/oli_web/live/admin/admin_view.ex
@@ -113,7 +113,7 @@ defmodule OliWeb.Admin.AdminView do
           </li>
           <li>
             <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Features.FeaturesLive)}>
-              Enable and Disable Feature Flags
+              Feature Flags and Logging
             </a>
           </li>
           <li>

--- a/lib/oli_web/live/features/features_live.ex
+++ b/lib/oli_web/live/features/features_live.ex
@@ -53,22 +53,52 @@ defmodule OliWeb.Features.FeaturesLive do
             <button type="button" class="btn btn-secondary" phx-click="logging" phx-value-level="info">
               Info
             </button>
-            <button type="button" class="btn btn-secondary" phx-click="logging" phx-value-level="notice">
+            <button
+              type="button"
+              class="btn btn-secondary"
+              phx-click="logging"
+              phx-value-level="notice"
+            >
               Notice
             </button>
-            <button type="button" class="btn btn-secondary" phx-click="logging" phx-value-level="warning">
+            <button
+              type="button"
+              class="btn btn-secondary"
+              phx-click="logging"
+              phx-value-level="warning"
+            >
               Warning
             </button>
-            <button type="button" class="btn btn-secondary" phx-click="logging" phx-value-level="error">
+            <button
+              type="button"
+              class="btn btn-secondary"
+              phx-click="logging"
+              phx-value-level="error"
+            >
               Error
             </button>
-            <button type="button" class="btn btn-secondary" phx-click="logging" phx-value-level="critical">
+            <button
+              type="button"
+              class="btn btn-secondary"
+              phx-click="logging"
+              phx-value-level="critical"
+            >
               Critical
             </button>
-            <button type="button" class="btn btn-secondary" phx-click="logging" phx-value-level="alert">
+            <button
+              type="button"
+              class="btn btn-secondary"
+              phx-click="logging"
+              phx-value-level="alert"
+            >
               Alert
             </button>
-            <button type="button" class="btn btn-secondary" phx-click="logging" phx-value-level="emergency">
+            <button
+              type="button"
+              class="btn btn-secondary"
+              phx-click="logging"
+              phx-value-level="emergency"
+            >
               Emergency (least verbose)
             </button>
           </p>
@@ -125,17 +155,17 @@ defmodule OliWeb.Features.FeaturesLive do
   end
 
   def handle_event("logging", %{"level" => level}, socket) do
+    socket =
+      case Logger.configure(level: String.to_atom(level)) do
+        :ok ->
+          socket
+          |> put_flash(:info, "Logging level changed to #{level}")
+          |> assign(log_level: Logger.level())
 
-    socket = case Logger.configure(level: String.to_atom(level)) do
-      :ok ->
-        socket
-        |> put_flash(:info, "Logging level changed to #{level}")
-        |> assign(log_level: Logger.level())
-
-      _ ->
-        socket
-        |> put_flash(:error, "Logging level could not be changed to #{level}")
-    end
+        _ ->
+          socket
+          |> put_flash(:error, "Logging level could not be changed to #{level}")
+      end
 
     {:noreply, socket}
   end

--- a/lib/oli_web/live/features/features_live.ex
+++ b/lib/oli_web/live/features/features_live.ex
@@ -19,6 +19,7 @@ defmodule OliWeb.Features.FeaturesLive do
     {:ok,
      assign(socket,
        title: "Feature Flags",
+       log_level: Logger.level(),
        active: :features,
        features: Features.list_features_and_states(),
        breadcrumbs: set_breadcrumbs()
@@ -37,11 +38,47 @@ defmodule OliWeb.Features.FeaturesLive do
   def render(assigns) do
     ~H"""
     <div class="container">
-      <div class="grid grid-cols-12">
+      <div class="grid grid-cols-12 mb-5">
         <div class="col-span-12">
-          <p class="mb-3">
-            Change the status of system-wide feature flags
+          <h2 class="mb-5">
+            Change the logging level of the system.
+          </h2>
+          <p class="mb-5">
+            Current log level is: <strong><mark><%= @log_level %></mark></strong>.
           </p>
+          <p>
+            <button type="button" class="btn btn-danger" phx-click="logging" phx-value-level="debug">
+              Debug (most verbose)
+            </button>
+            <button type="button" class="btn btn-secondary" phx-click="logging" phx-value-level="info">
+              Info
+            </button>
+            <button type="button" class="btn btn-secondary" phx-click="logging" phx-value-level="notice">
+              Notice
+            </button>
+            <button type="button" class="btn btn-secondary" phx-click="logging" phx-value-level="warning">
+              Warning
+            </button>
+            <button type="button" class="btn btn-secondary" phx-click="logging" phx-value-level="error">
+              Error
+            </button>
+            <button type="button" class="btn btn-secondary" phx-click="logging" phx-value-level="critical">
+              Critical
+            </button>
+            <button type="button" class="btn btn-secondary" phx-click="logging" phx-value-level="alert">
+              Alert
+            </button>
+            <button type="button" class="btn btn-secondary" phx-click="logging" phx-value-level="emergency">
+              Emergency (least verbose)
+            </button>
+          </p>
+        </div>
+      </div>
+      <div class="grid grid-cols-12 mt-5">
+        <div class="col-span-12">
+          <h2 class="mb-5">
+            Change the status of system-wide feature flags
+          </h2>
         </div>
       </div>
       <div class="grid grid-cols-12">
@@ -85,5 +122,21 @@ defmodule OliWeb.Features.FeaturesLive do
   def handle_event("toggle", %{"label" => label, "action" => action}, socket) do
     Features.change_state(label, to_state(action))
     {:noreply, assign(socket, features: Features.list_features_and_states())}
+  end
+
+  def handle_event("logging", %{"level" => level}, socket) do
+
+    socket = case Logger.configure(level: String.to_atom(level)) do
+      :ok ->
+        socket
+        |> put_flash(:info, "Logging level changed to #{level}")
+        |> assign(log_level: Logger.level())
+
+      _ ->
+        socket
+        |> put_flash(:error, "Logging level could not be changed to #{level}")
+    end
+
+    {:noreply, socket}
   end
 end


### PR DESCRIPTION
This PR adds an Admin UI which allows the changing of the system logging level at runtime. 

The rationale here is that we likely should be running production with a higher logging level (i.e. logging less information) and only when we are trying to trouble shoot a problem will we increase the verbosity, temporarily.  This is to counter cases where the Logging process within the system becomes overwhelmed and begins queuing log messages in memory. 