### PR TITLE
[MER-2731] Remove max limits on Datashop download and add caching

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -292,6 +292,9 @@ config :ex_cldr,
   default_locale: "en",
   default_backend: Oli.Cldr
 
+config :oli, :datashop,
+  cache_limit: String.to_integer(System.get_env("DATASHOP_CACHE_LIMIT", "200"))
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -335,4 +335,6 @@ if config_env() == :prod do
             ]
         end
     ]
+
+  config :oli, :datashop, cache_limit: System.get_env("DATASHOP_CACHE_LIMIT", "200")
 end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -336,5 +336,6 @@ if config_env() == :prod do
         end
     ]
 
-  config :oli, :datashop, cache_limit: System.get_env("DATASHOP_CACHE_LIMIT", "200")
+  config :oli, :datashop,
+    cache_limit: String.to_integer(System.get_env("DATASHOP_CACHE_LIMIT", "200"))
 end

--- a/lib/oli/analytics/datashop.ex
+++ b/lib/oli/analytics/datashop.ex
@@ -9,8 +9,10 @@ defmodule Oli.Analytics.Datashop do
 
   import XmlBuilder
   import Oli.Utils, only: [value_or: 2]
-  alias Oli.Repo
   import Ecto.Query
+  alias Oli.Repo
+
+  alias Oli.DatashopCache
   alias Oli.Publishing
   alias Oli.Delivery.Snapshots.Snapshot
   alias Oli.Authoring.Course
@@ -251,20 +253,13 @@ defmodule Oli.Analytics.Datashop do
                        slug: activity_slug,
                        part_attempt: part_attempt
                      } ->
-      # TODO, it may make a lot of sense to front these next four fetches with an
-      # in memory cache
-      activity_attempt =
-        Oli.Repo.get(Oli.Delivery.Attempts.Core.ActivityAttempt, part_attempt.activity_attempt_id)
+      activity_attempt = DatashopCache.get_activity_attempt!(part_attempt.activity_attempt_id)
 
-      activity_revision = Oli.Repo.get(Oli.Resources.Revision, activity_attempt.revision_id)
+      activity_revision = DatashopCache.get_revision!(activity_attempt.revision_id)
 
-      resource_attempt =
-        Oli.Repo.get(
-          Oli.Delivery.Attempts.Core.ResourceAttempt,
-          activity_attempt.resource_attempt_id
-        )
+      resource_attempt = DatashopCache.get_resource_attempt!(activity_attempt.resource_attempt_id)
 
-      page_revision = Oli.Repo.get(Oli.Resources.Revision, resource_attempt.revision_id)
+      page_revision = DatashopCache.get_revision!(resource_attempt.revision_id)
 
       resource_attempt = %{resource_attempt | revision: page_revision}
       activity_attempt = %{activity_attempt | revision: activity_revision}

--- a/lib/oli/analytics/datashop.ex
+++ b/lib/oli/analytics/datashop.ex
@@ -28,7 +28,7 @@ defmodule Oli.Analytics.Datashop do
   end
 
   def max_record_size() do
-    20000
+    20_000
   end
 
   # Creates a map of resource ids to lists, where the lists are the
@@ -168,9 +168,7 @@ defmodule Oli.Analytics.Datashop do
     |> Enum.map(fn {k, v} -> {k, v} end)
   end
 
-  defp part_attempts_stream(section_ids) do
-    max = max_record_size()
-
+  defp part_attempts_stream(section_ids, offset, limit) do
     from(snapshot in Snapshot,
       join: user in Oli.Accounts.User,
       on: snapshot.user_id == user.id,
@@ -189,7 +187,8 @@ defmodule Oli.Analytics.Datashop do
         activity_type_id: snapshot.activity_type_id
       },
       order_by: [desc: snapshot.inserted_at],
-      limit: ^max
+      offset: ^offset,
+      limit: ^limit
     )
     |> Repo.stream()
   end
@@ -233,7 +232,7 @@ defmodule Oli.Analytics.Datashop do
     |> Repo.one()
   end
 
-  def content_stream(context) do
+  def content_stream(context, offset, limit) do
     %{
       hierarchy_map: hierarchy_map,
       activity_types: activity_types,
@@ -245,7 +244,7 @@ defmodule Oli.Analytics.Datashop do
     } = context
 
     section_ids
-    |> part_attempts_stream()
+    |> part_attempts_stream(offset, limit)
     |> Stream.map(fn %{
                        email: email,
                        sub: sub,

--- a/lib/oli/analytics/datashop_export_worker.ex
+++ b/lib/oli/analytics/datashop_export_worker.ex
@@ -98,6 +98,8 @@ defmodule Oli.Analytics.DatashopExportWorker do
     total = Datashop.count(section_ids)
     batch_count = ceil(total / batch_size)
 
+    context = Datashop.build_context(project.id, section_ids)
+
     if batch_count != 0 do
       Enum.reduce(1..batch_count, 0, fn batch_index, offset ->
         # notify subscribers that a new batch has started
@@ -107,7 +109,7 @@ defmodule Oli.Analytics.DatashopExportWorker do
           batch_count
         )
 
-        Datashop.build_context(project.id, section_ids)
+        context
         |> Datashop.content_stream(offset, batch_size)
         |> Stream.with_index(offset + 1)
         |> Stream.map(fn {chunk, index} ->

--- a/lib/oli/application.ex
+++ b/lib/oli/application.ex
@@ -57,6 +57,8 @@ defmodule Oli.Application do
 
         # Starts Cachex to store user/author info across requests
         Oli.AccountLookupCache,
+        # Starts Cachex to store datashop export info
+        Oli.DatashopCache,
 
         # a supervisor which can be used to dynamically supervise tasks
         {Task.Supervisor, name: Oli.TaskSupervisor}

--- a/lib/oli/authoring/broadcasting/broadcaster.ex
+++ b/lib/oli/authoring/broadcasting/broadcaster.ex
@@ -136,4 +136,15 @@ defmodule Oli.Authoring.Broadcaster do
       {:datashop_export_status, status}
     )
   end
+
+  @doc """
+  Broadcasts a datashop export batch started update
+  """
+  def broadcast_datashop_export_batch_started(project_slug, current_batch, batch_count) do
+    PubSub.broadcast(
+      Oli.PubSub,
+      message_datashop_export_batch_started(project_slug),
+      {:datashop_export_batch_started, {:batch_started, current_batch, batch_count}}
+    )
+  end
 end

--- a/lib/oli/authoring/broadcasting/messages.ex
+++ b/lib/oli/authoring/broadcasting/messages.ex
@@ -49,6 +49,10 @@ defmodule Oli.Authoring.Broadcaster.Messages do
     ["datashop_export_status", project(project_slug)] |> join
   end
 
+  def message_datashop_export_batch_started(project_slug) do
+    ["datashop_export_batch_started", project(project_slug)] |> join
+  end
+
   ## Private helpers
   defp resource_type(resource_type_id),
     do: "resource_type:" <> Integer.to_string(resource_type_id)

--- a/lib/oli/authoring/broadcasting/subscriber.ex
+++ b/lib/oli/authoring/broadcasting/subscriber.ex
@@ -51,6 +51,10 @@ defmodule Oli.Authoring.Broadcaster.Subscriber do
     PubSub.subscribe(Oli.PubSub, message_datashop_export_status(project_slug))
   end
 
+  def subscribe_to_datashop_export_batch_started(project_slug) do
+    PubSub.subscribe(Oli.PubSub, message_datashop_export_batch_started(project_slug))
+  end
+
   ### Unsubscription API
   def unsubscribe_to_new_revisions(resource_id) do
     PubSub.unsubscribe(Oli.PubSub, message_new_revision(resource_id))

--- a/lib/oli/datashop_cache.ex
+++ b/lib/oli/datashop_cache.ex
@@ -1,0 +1,163 @@
+defmodule Oli.DatashopCache do
+  @moduledoc """
+    Provides a cache that can be used for datashop export related information retrieval. This cache is backed by
+    Cachex for local storage. Keys are set to expire after 1 day in order to prevent stale data in our cache over a long time period.
+  """
+
+  use GenServer
+
+  alias Oli.Delivery.Attempts.Core.{ActivityAttempt, ResourceAttempt}
+  alias Oli.Resources.Revision
+  alias Oli.Repo
+
+  @cache_name :cache_datashop
+
+  # ----------------
+  # Client
+
+  def start_link(init_args),
+    do: GenServer.start_link(__MODULE__, init_args, name: __MODULE__)
+
+  def get(key),
+    do: GenServer.call(__MODULE__, {:get, key})
+
+  def delete(key),
+    do: GenServer.call(__MODULE__, {:delete, key})
+
+  def put(key, value),
+    do: GenServer.call(__MODULE__, {:put, key, value})
+
+  @doc """
+  Gets a revision from the cache. If the revision is not found in the cache, it will be loaded from the database
+  """
+  def get_revision(revision_id) do
+    case get("revision_#{revision_id}") do
+      {:ok, %Revision{}} = response ->
+        response
+
+      _ ->
+        case Repo.get(Revision, revision_id) do
+          nil ->
+            {:error, :not_found}
+
+          revision ->
+            put("revision_#{revision_id}", revision)
+
+            {:ok, revision}
+        end
+    end
+  end
+
+  def get_revision!(revision_id) do
+    case get_revision(revision_id) do
+      {:ok, revision} ->
+        revision
+
+      _ ->
+        raise "Revision not found"
+    end
+  end
+
+  @doc """
+  Gets an activity attempt from the cache. If the activity attempt is not found in the cache, it will be loaded from the database
+  """
+  def get_activity_attempt(activity_attempt_id) do
+    case get("activity_attempt_#{activity_attempt_id}") do
+      {:ok, %ActivityAttempt{}} = response ->
+        response
+
+      _ ->
+        case Repo.get(ActivityAttempt, activity_attempt_id) do
+          nil ->
+            {:error, :not_found}
+
+          activity_attempt ->
+            put("activity_attempt_#{activity_attempt_id}", activity_attempt)
+
+            {:ok, activity_attempt}
+        end
+    end
+  end
+
+  def get_activity_attempt!(activity_attempt_id) do
+    case get_activity_attempt(activity_attempt_id) do
+      {:ok, activity_attempt} ->
+        activity_attempt
+
+      _ ->
+        raise "Activity attempt not found"
+    end
+  end
+
+  @doc """
+  Gets a resource attempt from the cache. If the resource attempt is not found in the cache, it will be loaded from the database
+  """
+  def get_resource_attempt(resource_attempt_id) do
+    case get("resource_attempt_#{resource_attempt_id}") do
+      {:ok, %ResourceAttempt{}} = response ->
+        response
+
+      _ ->
+        case Repo.get(ResourceAttempt, resource_attempt_id) do
+          nil ->
+            {:error, :not_found}
+
+          resource_attempt ->
+            put("resource_attempt_#{resource_attempt_id}", resource_attempt)
+
+            {:ok, resource_attempt}
+        end
+    end
+  end
+
+  def get_resource_attempt!(resource_attempt_id) do
+    case get_resource_attempt(resource_attempt_id) do
+      {:ok, resource_attempt} ->
+        resource_attempt
+
+      _ ->
+        raise "Resource attempt not found"
+    end
+  end
+
+  # ----------------
+  # Server callbacks
+
+  def init(_) do
+    {:ok, _pid} = Cachex.start_link(@cache_name, stats: true, limit: cache_limit())
+
+    {:ok, []}
+  end
+
+  def handle_call({:get, key}, _from, state) do
+    {:reply, Cachex.get(@cache_name, key), state}
+  end
+
+  def handle_call({:delete, key}, _from, state) do
+    case Cachex.del(@cache_name, key) do
+      {:ok, true} ->
+        {:reply, :ok, state}
+
+      _ ->
+        {:reply, :error, state}
+    end
+  end
+
+  def handle_call({:put, key, value}, _from, state) do
+    ttl = :timer.hours(24)
+
+    case Cachex.put(@cache_name, key, value, ttl: ttl) do
+      {:ok, true} ->
+        {:reply, :ok, state}
+
+      _ ->
+        {:reply, :error, state}
+    end
+  end
+
+  # ----------------
+  # Private
+
+  defp cache_limit,
+    do: Application.fetch_env!(:oli, :datashop)[:cache_limit]
+end

--- a/lib/oli_web/components/project/async_exporter.ex
+++ b/lib/oli_web/components/project/async_exporter.ex
@@ -73,6 +73,8 @@ defmodule OliWeb.Components.Project.AsyncExporter do
   attr(:datashop_export_status, :atom, values: [:not_available, :in_progress, :available, :error])
   attr(:datashop_export_url, :string)
   attr(:datashop_export_timestamp, :string)
+  attr(:datashop_export_current_batch, :integer)
+  attr(:datashop_export_batch_count, :integer)
   attr(:on_generate_datashop_snapshot, :string)
   attr(:on_kill, :string)
 
@@ -96,6 +98,9 @@ defmodule OliWeb.Components.Project.AsyncExporter do
           <div class="text-sm text-gray-500 mt-2">
             <i class="fa-solid fa-circle-notch fa-spin text-primary"></i>
             Generating datashop snapshot... this might take a while.
+            <div :if={@datashop_export_current_batch && @datashop_export_batch_count}>
+              Processing Batch <%= @datashop_export_current_batch %> of <%= @datashop_export_batch_count %>
+            </div>
           </div>
         </div>
       <% :available -> %>

--- a/lib/oli_web/live/common/sortable_table/table.ex
+++ b/lib/oli_web/live/common/sortable_table/table.ex
@@ -81,6 +81,7 @@ defmodule OliWeb.Common.SortableTable.Table do
     <tr
       id={id_field(@row, @model)}
       class={@row_class <> if Map.get(@row, :selected) || id_field(@row, @model) == @model.selected, do: " bg-delivery-primary-100 shadow-inner dark:bg-gray-700 dark:text-black", else: ""}
+      aria-selected={if Map.get(@row, :selected), do: "true", else: "false"}
       phx-click={@select}
       phx-value-id={id_field(@row, @model)}
     >

--- a/lib/oli_web/live/datashop/analytics_live.ex
+++ b/lib/oli_web/live/datashop/analytics_live.ex
@@ -241,10 +241,16 @@ defmodule OliWeb.Datashop.AnalyticsLive do
 
     selected_sections = toggle_fn.(socket.assigns.selected_sections, section_id)
 
+    rows =
+      Enum.map(
+        socket.assigns.table_model.rows,
+        &Map.put(&1, :selected, MapSet.member?(selected_sections, &1.id))
+      )
+
     {:ok, table_model} =
       SectionsTableModel.new(
         socket.assigns.ctx,
-        socket.assigns.table_model.rows,
+        rows,
         selected_sections
       )
 

--- a/test/oli_web/live/datashop/analytics_live_test.exs
+++ b/test/oli_web/live/datashop/analytics_live_test.exs
@@ -135,12 +135,13 @@ defmodule OliWeb.Datashop.AnalyticsLiveTest do
 
       for s <- rest_s do
         render_click(view, "toggle_section", %{"section_id" => s.id, "value" => "on"})
+        assert has_element?(view, "##{s.id}[aria-selected=\"true\"]")
       end
 
       assert has_element?(view, "#select-section-#{first_s.id}[disabled]")
     end
 
-    test "generates amd kills export", %{
+    test "generates and kills export", %{
       conn: conn,
       project: project
     } do
@@ -150,6 +151,8 @@ defmodule OliWeb.Datashop.AnalyticsLiveTest do
 
       # Select section and generate export
       render_click(view, "toggle_section", %{"section_id" => section.id, "value" => "on"})
+      assert has_element?(view, "##{section.id}[aria-selected=\"true\"]")
+
       render_click(view, "generate_datashop_snapshot")
 
       assert has_element?(view, "#button-kill-datashop", "Kill Datashop Export")


### PR DESCRIPTION
[MER-2731](https://eliterate.atlassian.net/browse/MER-2731)

Second PR for improving the Datashop export feature (first PR https://github.com/Simon-Initiative/oli-torus/pull/4459)

It introduces the following changes:
- Process the Datashop export process in batches, showing the number of batches processed in real time.
- Use a Cache for storing intermediate data.
- Some UI/CSS improvements.


https://github.com/Simon-Initiative/oli-torus/assets/26532202/46d4d78c-4699-4bec-8a49-59c0d499625e



[MER-2731]: https://eliterate.atlassian.net/browse/MER-2731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ