### PR TITLE
[Fix] UX audit - Purpose group rendering

### DIFF
--- a/assets/styles/common/purpose.scss
+++ b/assets/styles/common/purpose.scss
@@ -12,11 +12,12 @@
     text-transform: uppercase;
     background: var(--color-delivery-purpose-label-bg);
     color: var(--color-gray-900);
+    line-height: 1em;
     .dark & {
       background: var(--color-delivery-purpose-label-bg-dark);
       color: var(--color-gray-50);
     }
-    padding: 20px 32px;
+    padding: 16px 32px;
     font-size: 20px;
     font-weight: 600;
   }
@@ -43,7 +44,7 @@
         font-size: 22px;
         font-weight: 900;
         margin-right: 12px;
-        content: '\f11e';
+        content: '\f14a';
       }
     }
   }
@@ -56,7 +57,7 @@
         font-size: 22px;
         font-weight: 900;
         margin-right: 12px;
-        content: '\f256';
+        content: '\3f';
       }
     }
   }
@@ -75,7 +76,7 @@
         font-size: 22px;
         font-weight: 900;
         margin-right: 12px;
-        content: '\f1e5';
+        content: '\f06e';
       }
     }
   }
@@ -88,7 +89,7 @@
         font-size: 22px;
         font-weight: 900;
         margin-right: 12px;
-        content: '\f610';
+        content: '\f0c3';
       }
     }
   }
@@ -101,7 +102,7 @@
         font-size: 22px;
         font-weight: 900;
         margin-right: 12px;
-        content: '\f51c';
+        content: '\f304';
       }
     }
   }
@@ -114,7 +115,7 @@
         font-size: 22px;
         font-weight: 900;
         margin-right: 12px;
-        content: '\f51b';
+        content: '\f109';
       }
     }
   }
@@ -160,15 +161,13 @@
 
   &.simulation {
     & > .content-purpose-label {
-      background-color: #3d81f6;
-      color: white;
       /** icon */
       &::before {
         font-family: 'Font Awesome 6 Free';
         font-size: 22px;
         font-weight: 900;
         margin-right: 12px;
-        content: '\f109';
+        content: '\f1b2';
       }
     }
   }
@@ -181,7 +180,7 @@
         font-size: 22px;
         font-weight: 900;
         margin-right: 12px;
-        content: '\f6ec';
+        content: '\f14e';
       }
     }
   }

--- a/assets/styles/common/purpose.scss
+++ b/assets/styles/common/purpose.scss
@@ -1,12 +1,28 @@
 .content-purpose {
-  margin-bottom: 1rem;
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+  border: 1px solid var(--color-delivery-purpose-label-bg);
+  .dark & {
+    border-color: var(--color-delivery-purpose-label-bg-dark);
+  }
+  border-radius: 8px;
+  overflow: hidden;
 
   & > .content-purpose-label {
     text-transform: uppercase;
     background: var(--color-delivery-purpose-label-bg);
-    padding: 4px 0;
-    color: var(--color-white);
-    margin-bottom: 1rem;
+    color: var(--color-gray-900);
+    .dark & {
+      background: var(--color-delivery-purpose-label-bg-dark);
+      color: var(--color-gray-50);
+    }
+    padding: 20px 32px;
+    font-size: 20px;
+    font-weight: 600;
+  }
+
+  & > .content-purpose-content {
+    padding: 32px;
   }
 
   &.none {
@@ -24,9 +40,9 @@
       /** icon */
       &::before {
         font-family: 'Font Awesome 6 Free';
+        font-size: 22px;
         font-weight: 900;
-        margin-left: 8px;
-        margin-right: 8px;
+        margin-right: 12px;
         content: '\f11e';
       }
     }
@@ -37,29 +53,28 @@
       /** icon */
       &::before {
         font-family: 'Font Awesome 6 Free';
+        font-size: 22px;
         font-weight: 900;
-        margin-left: 8px;
-        margin-right: 8px;
+        margin-right: 12px;
         content: '\f256';
       }
     }
   }
 
   &.example {
-    border-bottom: 1px dashed rgba(#74b9ff, 0.75);
-
     & > .content-purpose-label {
-      border-bottom: 1px dashed rgba(#74b9ff, 0.75);
-      font-weight: 700;
       background: transparent;
-      color: var(--body-color);
+      border-bottom: 1px solid var(--color-delivery-purpose-label-bg);
+      .dark & {
+        border-color: var(--color-delivery-purpose-label-bg-dark);
+      }
 
       /** icon */
       &::before {
         font-family: 'Font Awesome 6 Free';
+        font-size: 22px;
         font-weight: 900;
-        margin-left: 8px;
-        margin-right: 8px;
+        margin-right: 12px;
         content: '\f1e5';
       }
     }
@@ -70,9 +85,9 @@
       /** icon */
       &::before {
         font-family: 'Font Awesome 6 Free';
+        font-size: 22px;
         font-weight: 900;
-        margin-left: 8px;
-        margin-right: 8px;
+        margin-right: 12px;
         content: '\f610';
       }
     }
@@ -83,9 +98,9 @@
       /** icon */
       &::before {
         font-family: 'Font Awesome 6 Free';
+        font-size: 22px;
         font-weight: 900;
-        margin-left: 8px;
-        margin-right: 8px;
+        margin-right: 12px;
         content: '\f51c';
       }
     }
@@ -96,9 +111,9 @@
       /** icon */
       &::before {
         font-family: 'Font Awesome 6 Free';
+        font-size: 22px;
         font-weight: 900;
-        margin-left: 8px;
-        margin-right: 8px;
+        margin-right: 12px;
         content: '\f51b';
       }
     }
@@ -109,9 +124,9 @@
       /** icon */
       &::before {
         font-family: 'Font Awesome 6 Free';
+        font-size: 22px;
         font-weight: 900;
-        margin-left: 8px;
-        margin-right: 8px;
+        margin-right: 12px;
         content: '\f5da';
       }
     }
@@ -122,9 +137,9 @@
       /** icon */
       &::before {
         font-family: 'Font Awesome 6 Free';
+        font-size: 22px;
         font-weight: 900;
-        margin-left: 8px;
-        margin-right: 8px;
+        margin-right: 12px;
         content: '\f46c';
       }
     }
@@ -135,9 +150,9 @@
       /** icon */
       &::before {
         font-family: 'Font Awesome 6 Free';
+        font-size: 22px;
         font-weight: 900;
-        margin-left: 8px;
-        margin-right: 8px;
+        margin-right: 12px;
         content: '\f681';
       }
     }
@@ -145,12 +160,14 @@
 
   &.simulation {
     & > .content-purpose-label {
+      background-color: #3d81f6;
+      color: white;
       /** icon */
       &::before {
         font-family: 'Font Awesome 6 Free';
+        font-size: 22px;
         font-weight: 900;
-        margin-left: 8px;
-        margin-right: 8px;
+        margin-right: 12px;
         content: '\f109';
       }
     }
@@ -161,9 +178,9 @@
       /** icon */
       &::before {
         font-family: 'Font Awesome 6 Free';
+        font-size: 22px;
         font-weight: 900;
-        margin-left: 8px;
-        margin-right: 8px;
+        margin-right: 12px;
         content: '\f6ec';
       }
     }

--- a/assets/tailwind.theme.js
+++ b/assets/tailwind.theme.js
@@ -200,7 +200,7 @@ module.exports = {
       purpose: {
         label: {
           bg: {
-            DEFAULT: '#222439',
+            DEFAULT: colors.gray['300'],
             dark: {
               DEFAULT: colors.gray['600'],
             },

--- a/assets/tailwind.theme.js
+++ b/assets/tailwind.theme.js
@@ -200,9 +200,9 @@ module.exports = {
       purpose: {
         label: {
           bg: {
-            DEFAULT: colors.gray['300'],
+            DEFAULT: '#ddd',
             dark: {
-              DEFAULT: colors.gray['600'],
+              DEFAULT: '#404040',
             },
           },
         },


### PR DESCRIPTION
This PR adjusts styles of purpose groups ("Example", "Did I get this?" etc). New icons come from Font Awesome Free, so I've just replaced the char codes.

**Before:**
![Screenshot 2023-11-27 at 22 58 18](https://github.com/Simon-Initiative/oli-torus/assets/2022097/7ccc9126-3c3b-45a3-ab37-4c4c9a6b1a4c)

**After (dark):**
![Screenshot 2023-11-27 at 22 56 40](https://github.com/Simon-Initiative/oli-torus/assets/2022097/36ca7b93-1268-4f0a-9e60-f02ef5d18809)

**After (light):**
![Screenshot 2023-11-27 at 22 56 33](https://github.com/Simon-Initiative/oli-torus/assets/2022097/8c206c24-d8a7-42f8-9ec7-c5c5b2a761e7)
