### PR TITLE
[Chore] UX audit - Drag-and-drop styles

### DIFF
--- a/assets/src/components/activities/custom_dnd/utils.ts
+++ b/assets/src/components/activities/custom_dnd/utils.ts
@@ -71,6 +71,11 @@ const DEFAULT_LAYOUT_STYLES = `
   border-color: black;
 }
 
+:host-context(.dark) .initiator {
+  background-color: white;
+  color: black;
+}
+
 .dragdropspacer {
   height: 30px;
 }


### PR DESCRIPTION
This PR aims to solve the problem of light/dark mode in the context of drag-and-drop activities. Right now, the draggable bits are utterly unreadable in dark mode. As I understand it, the styles for them are part of each lesson's configuration, so the actual fix would be to use the authoring environment to edit said styles. An additional complication is that DnD has its own shadow DOM - one has to take it into account when writing styles. My proposition is to provide better defaults that will also serve as a hint (because `:host-context()` is not a pseudoselector one uses every day - I know I don't).

An alternative approach would be to inject a prop (`mode: Mode`) into all custom elements like DnD and let them handle it as they see fit.