### PR TITLE
[Fix] UX audit - Input styles

### DIFF
--- a/assets/css/bootstrap-shims.css
+++ b/assets/css/bootstrap-shims.css
@@ -264,7 +264,7 @@ textarea.form-control,
 .input-group select,
 select.custom-select,
 select.form-control {
-  @apply border py-1 px-1.5 border-neutral-300 rounded w-full disabled:bg-neutral-100 disabled:text-neutral-600 dark:bg-neutral-800 dark:border-neutral-700 dark:text-white;
+  @apply border py-1 px-1.5 border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-850 rounded w-full disabled:bg-neutral-100 disabled:text-neutral-600 dark:text-white;
 }
 
 input.form-control-sm,

--- a/assets/styles/delivery/multi-input.scss
+++ b/assets/styles/delivery/multi-input.scss
@@ -1,8 +1,13 @@
 .multi-input-activity {
+  line-height: 2em;
+
   .dropdown-input {
     width: unset;
-    padding-right: 35px;
+    padding: 6px 30px 6px 12px;
     margin: 0px 0.1rem;
     min-width: 2rem;
+    line-height: 1em;
+    white-space: nowrap;
+    text-overflow: ellipsis;
   }
 }

--- a/assets/tailwind.theme.js
+++ b/assets/tailwind.theme.js
@@ -9,7 +9,10 @@ const tailwindColors = require('tailwindcss/colors');
  */
 const colors = {
   ...tailwindColors,
-  gray: tailwindColors.neutral,
+  gray: {
+    ...tailwindColors.neutral,
+    850: '#1E1E1E',
+  },
   blue: {
     DEFAULT: '#3B76D3',
     50: '#D1DFF5',


### PR DESCRIPTION
This PR adjusts input styles - colors, spacings and text overflow. I tried to keep splash damage to a minimum, so some changes are limited to `.multi-input-activity`.

**Before:** <sub>(yes, I know - sulphur is not a compound)</sub>
![Screenshot 2023-11-27 at 16 21 56](https://github.com/Simon-Initiative/oli-torus/assets/2022097/c0a4d690-3272-46ab-b443-707f8339dc2c)

**After (light):**
![Screenshot 2023-11-27 at 16 17 13](https://github.com/Simon-Initiative/oli-torus/assets/2022097/c46908a1-d14a-4dde-811e-8b899aa23da6)

**After (dark):**
![Screenshot 2023-11-27 at 16 17 23](https://github.com/Simon-Initiative/oli-torus/assets/2022097/a5b782aa-2160-49e2-a561-d569a0833284)
