### PR TITLE
[Fix] UX audit - Image and caption rendering

### DIFF
--- a/assets/styles/common/elements.scss
+++ b/assets/styles/common/elements.scss
@@ -419,7 +419,6 @@ $element-margin-bottom: 1.5em;
     display: block;
     margin-left: auto;
     margin-right: auto;
-    // margin-bottom: $element-margin-bottom;
   }
 
   .embed-responsive {

--- a/assets/styles/common/elements.scss
+++ b/assets/styles/common/elements.scss
@@ -389,13 +389,6 @@ $element-margin-bottom: 1.5em;
     align-items: center;
     justify-content: center;
     margin-bottom: $element-margin-bottom;
-
-    figure {
-      figcaption {
-        color: var(--color-primary);
-      }
-      padding: 1rem;
-    }
   }
 
   .caption-wrapper {
@@ -409,6 +402,7 @@ $element-margin-bottom: 1.5em;
 
       figcaption {
         text-align: center;
+        font-size: 0.85rem;
       }
 
       .embed-responsive {
@@ -417,11 +411,15 @@ $element-margin-bottom: 1.5em;
     }
   }
 
+  .caption-wrapper-image .img-fluid {
+    margin-bottom: 0.5em;
+  }
+
   .figure-img {
     display: block;
     margin-left: auto;
     margin-right: auto;
-    margin-bottom: $element-margin-bottom;
+    // margin-bottom: $element-margin-bottom;
   }
 
   .embed-responsive {

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -55,7 +55,7 @@ defmodule Oli.Rendering.Content.Html do
   def img(%Context{} = context, _, %{"src" => src} = attrs) do
     captioned_content(context, attrs, [
       ~s|<img class="figure-img img-fluid"#{maybeAlt(attrs)}#{maybeWidth(attrs)} src="#{escape_xml!(src)}"/>\n|
-    ])
+    ], "image")
   end
 
   def img(%Context{} = _context, _, _e), do: ""
@@ -866,12 +866,22 @@ defmodule Oli.Rendering.Content.Html do
       end
     )
   end
+  
+  defp maybe_content_type(content_type) do
+    if content_type != "" do
+      " caption-wrapper-#{content_type}"
+    else
+      ""
+    end
+  end
+
+  defp captioned_content(context, attrs, content, content_type \\ "")
 
   # Accessible captions are created using a combination of the <figure /> and <figcaption /> elements.
-  defp captioned_content(_context, %{"caption" => ""} = _attrs, content), do: content
+  defp captioned_content(_context, %{"caption" => ""} = _attrs, content, _content_type), do: content
 
-  defp captioned_content(%Context{} = context, %{"caption" => caption_content} = _attrs, content) do
-    [~s|<div class="caption-wrapper">|] ++
+  defp captioned_content(%Context{} = context, %{"caption" => caption_content} = _attrs, content, content_type) do
+    [~s|<div class="caption-wrapper#{maybe_content_type(content_type)}">|] ++
       [~s|<figure class="figure embed-responsive">|] ++
       content ++
       [~s|<figcaption class="figure-caption text-center">|] ++
@@ -881,7 +891,7 @@ defmodule Oli.Rendering.Content.Html do
       ["</div>"]
   end
 
-  defp captioned_content(_context, _attrs, content), do: content
+  defp captioned_content(_context, _attrs, content, _content_type), do: content
 
   defp caption(_context, content) when is_binary(content) do
     escape_xml!(content)


### PR DESCRIPTION
This PR makes minor adjustments to figcaption styles. Additionally, it modifies `captioned_content()` to (optionally) add a class name to its resulting `<figure />` wrapper, to indicate what is being wrapped. In this case - `caption-wrapper-image`. This makes it easier to target styles. Here, it is used to override the bottom margin of an image if that image happens to have a caption.

**Before:**
![original style](https://github.com/Simon-Initiative/oli-torus/assets/2022097/55aa50ea-2a4a-44ee-bc63-24dea73f3d0c)

**After:**
![improved style](https://github.com/Simon-Initiative/oli-torus/assets/2022097/f8b4906d-30ad-49db-a12f-a95bed126c75)
