### PR TITLE
[Fix] UX audit - Tooltip styles

### DIFF
--- a/assets/src/components/common/Navbar.tsx
+++ b/assets/src/components/common/Navbar.tsx
@@ -65,10 +65,10 @@ export const Navbar = ({
   timezones,
 }: NavbarProps) => {
   const [showNavbar, setShowNavbar] = useState(false);
-  const [popoutContainer, setPopoutContianer] = useState<Popout>();
+  const [popoutContainer, setPopoutContainer] = useState<Popout>();
   const isLargeScreen = useMediaQuery(MediaSize.lg);
   const ref = useOnClickOutside<HTMLDivElement>(
-    useCallback(() => setPopoutContianer(undefined), []),
+    useCallback(() => setPopoutContainer(undefined), []),
   );
 
   return (
@@ -125,7 +125,7 @@ export const Navbar = ({
                   active={active}
                   popout={popout}
                   popoutContainer={popoutContainer}
-                  setPopoutContianer={setPopoutContianer}
+                  setPopoutContainer={setPopoutContainer}
                 />
               ) : (
                 <NavLink key={name} name={name} active={active} href={href} />
@@ -166,7 +166,7 @@ export const Navbar = ({
       </nav>
 
       {isLargeScreen && (
-        <LargePopoutContainer show={!!popoutContainer} setPopoutContianer={setPopoutContianer}>
+        <LargePopoutContainer show={!!popoutContainer} setPopoutContainer={setPopoutContainer}>
           {popoutContainer && renderComponent(popoutContainer?.component, popoutContainer?.props)}
         </LargePopoutContainer>
       )}
@@ -183,7 +183,7 @@ interface NavLinkProps {
 const NavLink = ({ href, active, name }: NavLinkProps) => (
   <a
     href={href}
-    className="block no-underline px-6 py-2 hover:no-underline text-current hover:text-delivery-primary-active hover:dark:text-delivery-primary-dark-active"
+    className="block no-underline px-6 py-2 hover:no-underline text-current hover:text-delivery-primary-hover hover:dark:text-delivery-primary-dark-hover"
   >
     <div
       className={classNames(
@@ -203,7 +203,7 @@ interface NavExpandProps {
   active: boolean;
   popout: Popout;
   popoutContainer?: Popout;
-  setPopoutContianer: (p: Popout | undefined) => void;
+  setPopoutContainer: (p: Popout | undefined) => void;
 }
 
 const NavExpand = ({
@@ -211,7 +211,7 @@ const NavExpand = ({
   popout,
   active,
   popoutContainer,
-  setPopoutContianer,
+  setPopoutContainer,
 }: PropsWithChildren<NavExpandProps>) => {
   const [show, setShow] = useState(false);
   const isLargeScreen = useMediaQuery(MediaSize.lg);
@@ -221,9 +221,9 @@ const NavExpand = ({
   return (
     <div ref={ref}>
       <div
-        className="block no-underline px-6 py-2 cursor-pointer hover:no-underline text-current hover:text-delivery-primary-active dark:hover:text-delivery-primary-dark-active"
+        className="block no-underline px-6 py-2 cursor-pointer hover:no-underline text-current hover:text-delivery-primary-hover dark:hover:text-delivery-primary-dark-hover"
         onClick={() => {
-          popoutContainer ? setPopoutContianer(undefined) : setPopoutContianer(popout);
+          popoutContainer ? setPopoutContainer(undefined) : setPopoutContainer(popout);
           setShow(!show);
         }}
       >
@@ -249,7 +249,7 @@ const NavExpand = ({
 
 interface LargePopoutContainerProps {
   show: boolean;
-  setPopoutContianer: (p: Popout | undefined) => void;
+  setPopoutContainer: (p: Popout | undefined) => void;
 }
 
 const LargePopoutContainer = ({ show, children }: PropsWithChildren<LargePopoutContainerProps>) => (

--- a/assets/src/components/common/Navbar.tsx
+++ b/assets/src/components/common/Navbar.tsx
@@ -183,12 +183,14 @@ interface NavLinkProps {
 const NavLink = ({ href, active, name }: NavLinkProps) => (
   <a
     href={href}
-    className="block no-underline px-6 py-2 hover:no-underline text-current hover:text-delivery-primary-400"
+    className="block no-underline px-6 py-2 hover:no-underline text-current hover:text-delivery-primary-active hover:dark:text-delivery-primary-dark-active"
   >
     <div
       className={classNames(
         'border-b-2',
-        active ? 'font-bold border-delivery-primary !text-delivery-primary' : 'border-transparent',
+        active
+          ? 'font-bold border-delivery-primary dark:border-delivery-primary-dark text-delivery-primary dark:text-delivery-primary-dark'
+          : 'border-transparent',
       )}
     >
       {name}
@@ -219,7 +221,7 @@ const NavExpand = ({
   return (
     <div ref={ref}>
       <div
-        className="block no-underline px-6 py-2 cursor-pointer hover:no-underline text-current hover:text-delivery-primary-400"
+        className="block no-underline px-6 py-2 cursor-pointer hover:no-underline text-current hover:text-delivery-primary-active dark:hover:text-delivery-primary-dark-active"
         onClick={() => {
           popoutContainer ? setPopoutContianer(undefined) : setPopoutContianer(popout);
           setShow(!show);
@@ -229,7 +231,7 @@ const NavExpand = ({
           className={classNames(
             'border-b-2',
             active
-              ? 'font-bold border-delivery-primary !text-delivery-primary'
+              ? 'font-bold border-delivery-primary dark:border-delivery-primary-dark text-delivery-primary dark:text-delivery-primary-dark'
               : 'border-transparent',
           )}
         >

--- a/assets/src/components/content/Popup.tsx
+++ b/assets/src/components/content/Popup.tsx
@@ -79,7 +79,7 @@ export const Popup: React.FC<Props> = ({ children, popupContent, popup }) => {
       containerClassName="z-50 react-tiny-popover structured-content pointer-events-none max-w-[300px]"
     >
       <span
-        className="italic font-bold cursor-pointer text-delivery-primary dark:text-delivery-primary-dark hover:text-delivery-primary-active dark:hover:text-delivery-primary-dark-active"
+        className="italic font-bold cursor-pointer text-delivery-primary dark:text-delivery-primary-dark hover:text-delivery-primary-hover dark:hover:text-delivery-primary-dark-hover"
         onMouseEnter={onHover}
         onMouseLeave={onBlur}
         onClick={onClick}

--- a/assets/src/components/content/Popup.tsx
+++ b/assets/src/components/content/Popup.tsx
@@ -64,22 +64,22 @@ export const Popup: React.FC<Props> = ({ children, popupContent, popup }) => {
           childRect={childRect}
           popoverRect={popoverRect}
           arrowSize={10}
-          className="popup-arrow"
-          arrowColor="white"
+          arrowColor="currentColor"
+          arrowClassName="text-delivery-tooltip-bg dark:text-delivery-tooltip-bg-dark z-10 translate-y-[-1px]"
         >
-          <div className="popup-content dark:text-white dark:bg-neutral-600 bg-body p-4 drop-shadow rounded">
+          <div className="popup-content text-sm text-delivery-tooltip-content dark:text-delivery-tooltip-content-dark bg-delivery-tooltip-bg dark:bg-delivery-tooltip-bg-dark p-4 drop-shadow rounded">
             {isEmptyContent(popup.content) ? (
-              <i className="fa-solid fa-volume-high"></i>
+              <i className="fa-solid fa-volume-high" />
             ) : (
-              popupContent
+              <span className="pointer-events-auto">{popupContent}</span>
             )}
           </div>
         </ArrowContainer>
       )}
-      containerClassName="z-50 react-tiny-popover structured-content"
+      containerClassName="z-50 react-tiny-popover structured-content pointer-events-none max-w-[300px]"
     >
       <span
-        className={`popup-anchor${popup.trigger === 'hover' ? '' : ' popup-click'}`}
+        className="italic font-bold cursor-pointer text-delivery-primary dark:text-delivery-primary-dark hover:text-delivery-primary-active dark:hover:text-delivery-primary-dark-active"
         onMouseEnter={onHover}
         onMouseLeave={onBlur}
         onClick={onClick}

--- a/assets/styles/common/elements.scss
+++ b/assets/styles/common/elements.scss
@@ -56,7 +56,15 @@ $element-margin-bottom: 1.5em;
     color: var(--color-delivery-primary);
 
     &:hover {
-      color: var(--color-delivery-primary-600);
+      color: var(--color-delivery-primary-hover);
+    }
+
+    .dark & {
+      color: var(--color-delivery-primary-dark);
+
+      &:hover {
+        color: var(--color-delivery-primary-dark-hover);
+      }
     }
   }
 

--- a/assets/styles/common/elements.scss
+++ b/assets/styles/common/elements.scss
@@ -447,17 +447,6 @@ $element-margin-bottom: 1.5em;
     }
   }
 
-  .popup-anchor {
-    color: var(--color-emerald-600);
-    font-style: italic;
-    cursor: pointer;
-    font-weight: bold;
-
-    &.popup-click {
-      text-decoration: underline;
-    }
-  }
-
   .popup-arrow div:first-of-type {
     @media (prefers-color-scheme: light) {
       border-top-color: var(white) !important;
@@ -472,13 +461,6 @@ $element-margin-bottom: 1.5em;
     p:last-of-type {
       margin: 0;
     }
-  }
-
-  .popup-anchor,
-  span.term {
-    font-weight: bold;
-    color: var(--color-emerald-600);
-    font-style: italic;
   }
 
   .popover-body {

--- a/assets/styles/common/previous_next_nav.scss
+++ b/assets/styles/common/previous_next_nav.scss
@@ -8,25 +8,46 @@
     max-width: 400px;
     height: fit-content;
     color: var(--color-delivery-primary);
+    .dark & {
+      color: var(--color-delivery-primary-dark);
+    }
     background-color: var(--color-white);
 
     &:hover {
       border-color: var(--color-delivery-primary);
+      .dark & {
+        border-color: var(--color-delivery-primary-dark);
+      }
       background-color: rgba(var(--color-delivery-primary), 10%);
+      .dark & {
+        background-color: rgba(var(--color-delivery-primary-dark), 10%);
+      }
       box-shadow: 1px 1px 6px -2px rgba(var(--color-delivery-primary), 0.15);
+      .dark & {
+        box-shadow: 1px 1px 6px -2px rgba(var(--color-delivery-primary-dark), 0.15);
+      }
 
       .nav-title,
       .nav-icon {
         color: var(--color-delivery-primary);
+        & .dark {
+          color: var(--color-delivery-primary-dark);
+        }
       }
     }
 
     &:active {
       background-color: rgba(var(--color-delivery-primary), 25%);
+      .dark & {
+        background-color: rgba(var(--color-delivery-primary-dark), 25%);
+      }
 
       .nav-title,
       .nav-icon {
         color: var(--color-delivery-primary);
+        .dark & {
+          color: var(--color-delivery-primary-dark);
+        }
       }
     }
   }
@@ -40,6 +61,9 @@
   .nav-label {
     display: none;
     color: var(--color-gray-600);
+    .dark & {
+      color: var(--color-gray-400);
+    }
   }
 
   .nav-title {

--- a/assets/tailwind.theme.js
+++ b/assets/tailwind.theme.js
@@ -197,9 +197,11 @@ module.exports = {
       primary: {
         DEFAULT: colors.azure['600'],
         active: colors.azure['700'],
+        hover: colors.azure['700'],
         dark: {
           DEFAULT: colors.azure['500'],
           active: colors.azure['400'],
+          hover: colors.azure['400'],
         },
         ...colors.azure,
       },

--- a/assets/tailwind.theme.js
+++ b/assets/tailwind.theme.js
@@ -36,6 +36,21 @@ const colors = {
     800: '#7C5005',
     900: '#462D03',
   },
+  // new colors from UX audit 11.2023
+  offWhite: '#E8E8E8',
+  offBlack: '#373A44',
+  azure: {
+    50: '#D1DFF5',
+    100: '#E9F4FF',
+    200: '#CEE7FF',
+    300: '#A1D2FF',
+    400: '#69B0FB',
+    500: '#2B8BFE',
+    600: '#0165D9',
+    700: '#004A9F',
+    800: '#002E72',
+    900: '#071538',
+  },
 };
 
 module.exports = {
@@ -180,8 +195,13 @@ module.exports = {
         },
       },
       primary: {
-        DEFAULT: colors.blue['500'],
-        ...colors.blue,
+        DEFAULT: colors.azure['600'],
+        active: colors.azure['700'],
+        dark: {
+          DEFAULT: colors.azure['500'],
+          active: colors.azure['400'],
+        },
+        ...colors.azure,
       },
       hints: {
         bg: {
@@ -205,6 +225,16 @@ module.exports = {
               DEFAULT: colors.gray['600'],
             },
           },
+        },
+      },
+      tooltip: {
+        bg: {
+          DEFAULT: colors.offBlack,
+          dark: colors.offWhite,
+        },
+        content: {
+          DEFAULT: colors.white,
+          dark: colors.black,
         },
       },
     },


### PR DESCRIPTION
This PR makes a few tweaks to tooltip (popover) styles and primary color:
- tooltips should have max width
- tooltips (stems included) should have proper light/dark colors
- tooltip frame should no longer have pointer interactions - this fixes a hilarious edge case where mousing over an anchor from above would appear to not trigger the popup (this was caused by the frame getting between the cursor and the anchor, causing `mouseLeave` event)
- tooltip stems should now be rendered above frame box shadows (z-index-wise)
- `--color-delivery-primary` should have light and dark variants to help with contrast in some situations (I've added a new-ish shade of blue to the theme - called it "azure" to avoid name conflicts)

**Before (dark - note the box shadow on the tooltip stem):**
![original - dark](https://github.com/Simon-Initiative/oli-torus/assets/2022097/f42f5188-93db-421e-8b35-99b2aa166863)

**Before (light - note the miscolored stem):**
![original - light](https://github.com/Simon-Initiative/oli-torus/assets/2022097/ec69a53c-a5d8-4925-9ba1-95ea1632e3d0)

**After (dark):**
![improved - dark](https://github.com/Simon-Initiative/oli-torus/assets/2022097/bde3141f-962a-4aa3-a5f9-234e351385e0)

**After (light):**
![improved - light](https://github.com/Simon-Initiative/oli-torus/assets/2022097/d106a61c-0ec4-4d95-8685-40fcbd1cd515)
