### PR TITLE
[BUGFIX] [MER-2674] Fix sort by progress on the Students Tab

### DIFF
--- a/lib/oli_web/components/delivery/students/students.ex
+++ b/lib/oli_web/components/delivery/students/students.ex
@@ -143,7 +143,11 @@ defmodule OliWeb.Components.Delivery.Students do
         Enum.sort_by(students, fn student -> student.last_interaction end, sort_order)
 
       :progress ->
-        Enum.sort_by(students, fn student -> student.progress end, sort_order)
+        Enum.sort_by(
+          students,
+          fn student -> {student.progress || 0, student.family_name} end,
+          sort_order
+        )
 
       :overall_proficiency ->
         Enum.sort_by(students, fn student -> student.overall_proficiency end, sort_order)


### PR DESCRIPTION
[MER-2674](https://eliterate.atlassian.net/browse/MER-2674)

This PR introduces two changes on the `Instructor Dashboard > Students tab` page:
1. Fix the sort by progress feature on the Students tab.
2. Sort by progress and student last name as secondary sort criteria.

**Note:**
The Manage Enrollments page as described in the ticket description does not exist anymore, since it was removed on https://github.com/Simon-Initiative/oli-torus/pull/4360

https://github.com/Simon-Initiative/oli-torus/assets/26532202/7210b915-794d-4eb6-bec4-546cf1560ad4




[MER-2674]: https://eliterate.atlassian.net/browse/MER-2674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ