### PR TITLE
Quiz submission failure handling [MER-2600]

### DIFF
--- a/assets/src/apps/Components.tsx
+++ b/assets/src/apps/Components.tsx
@@ -14,6 +14,7 @@ import { YoutubePlayer } from 'components/youtube_player/YoutubePlayer';
 import { registerApplication } from 'apps/app';
 import { globalStore } from 'state/store';
 import { VideoPlayer } from '../components/video_player/VideoPlayer';
+import { OfflineDetector } from './OfflineDetector';
 import { References } from './bibliography/References';
 
 registerApplication('ModalDisplay', ModalDisplay, globalStore);
@@ -31,3 +32,4 @@ registerApplication('DeliveryElementRenderer', DeliveryElementRenderer, globalSt
 registerApplication('ECLRepl', ECLRepl, globalStore);
 registerApplication('SelectTimezone', SelectTimezone, globalStore);
 registerApplication('YoutubePlayer', YoutubePlayer, globalStore);
+registerApplication('OfflineDetector', OfflineDetector, globalStore);

--- a/assets/src/apps/OfflineDetector.tsx
+++ b/assets/src/apps/OfflineDetector.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { useOffline } from 'components/hooks/useOffline';
+import { Alert } from 'components/misc/Alert';
+
+export const OfflineDetector: React.FC = () => {
+  const offline = useOffline();
+  if (!offline) return null;
+
+  return (
+    <div className="fixed left-2 top-2 z-50">
+      <Alert variant="warning">You have gone offline, your work will not be saved.</Alert>
+    </div>
+  );
+};

--- a/assets/src/components/activities/ActivityErrorDisplay.tsx
+++ b/assets/src/components/activities/ActivityErrorDisplay.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React from 'react';
 import { Alert } from 'components/misc/Alert';
 
 interface Props {

--- a/assets/src/components/activities/ActivityErrorDisplay.tsx
+++ b/assets/src/components/activities/ActivityErrorDisplay.tsx
@@ -7,7 +7,7 @@ interface Props {
 }
 
 const ErrorContainer: React.FC<Props> = ({ children, error }) => {
-  const className = error ? 'border-l-4 py-4 pl-4 border-red-200' : '';
+  const className = error ? 'border-l-4 mb-4 py-4 pl-4 border-red-200' : '';
   return <div className={className}>{children}</div>;
 };
 

--- a/assets/src/components/activities/ActivityErrorDisplay.tsx
+++ b/assets/src/components/activities/ActivityErrorDisplay.tsx
@@ -1,0 +1,27 @@
+import React, { ReactNode } from 'react';
+import { Alert } from 'components/misc/Alert';
+
+interface Props {
+  error: string | null;
+  children: React.ReactNode;
+}
+
+const ErrorContainer: React.FC<Props> = ({ children, error }) => {
+  const className = error ? 'border-l-4 py-4 pl-4 border-red-200' : '';
+  return <div className={className}>{children}</div>;
+};
+
+export const ActivityErrorDisplay: React.FC<Props> = ({ error, children }) => {
+  return (
+    <ErrorContainer error={error}>
+      {children}
+
+      {error && (
+        <>
+          <br />
+          <Alert variant="error">{error}</Alert>
+        </>
+      )}
+    </ErrorContainer>
+  );
+};

--- a/assets/src/components/activities/DeliveryElementProvider.tsx
+++ b/assets/src/components/activities/DeliveryElementProvider.tsx
@@ -1,8 +1,10 @@
 import React, { useContext } from 'react';
 import { Maybe } from 'tsmonad';
 import { WriterContext, defaultWriterContext } from 'data/content/writers/context';
+import { ActivityErrorDisplay } from './ActivityErrorDisplay';
 import { DeliveryElementProps } from './DeliveryElement';
 import { ActivityModelSchema } from './types';
+import { useDeliveryErrorHandlers } from './useDeliveryErrorHandlers';
 
 export interface DeliveryElementState<T extends ActivityModelSchema>
   extends DeliveryElementProps<T> {
@@ -19,6 +21,7 @@ export function useDeliveryElementContext<T extends ActivityModelSchema>() {
   );
 }
 export const DeliveryElementProvider: React.FC<DeliveryElementProps<any>> = (props) => {
+  const { onSaveActivity, onSavePart, error } = useDeliveryErrorHandlers(props);
   const writerContext = defaultWriterContext({
     graded: props.context.graded,
     sectionSlug: props.context.sectionSlug,
@@ -29,8 +32,10 @@ export const DeliveryElementProvider: React.FC<DeliveryElementProps<any>> = (pro
   });
 
   return (
-    <DeliveryElementContext.Provider value={{ ...props, writerContext }}>
-      {props.children}
+    <DeliveryElementContext.Provider
+      value={{ ...props, writerContext, onSaveActivity, onSavePart }}
+    >
+      <ActivityErrorDisplay error={error}>{props.children}</ActivityErrorDisplay>
     </DeliveryElementContext.Provider>
   );
 };

--- a/assets/src/components/activities/DeliveryElementProvider.tsx
+++ b/assets/src/components/activities/DeliveryElementProvider.tsx
@@ -10,9 +10,11 @@ export interface DeliveryElementState<T extends ActivityModelSchema>
   extends DeliveryElementProps<T> {
   writerContext: WriterContext;
 }
+
 const DeliveryElementContext = React.createContext<DeliveryElementState<any> | undefined>(
   undefined,
 );
+
 export function useDeliveryElementContext<T extends ActivityModelSchema>() {
   return Maybe.maybe(
     useContext<DeliveryElementState<T> | undefined>(DeliveryElementContext),
@@ -20,8 +22,11 @@ export function useDeliveryElementContext<T extends ActivityModelSchema>() {
     new Error('useDeliveryElementContext must be used within an DeliveryElementProvider'),
   );
 }
+
 export const DeliveryElementProvider: React.FC<DeliveryElementProps<any>> = (props) => {
-  const { onSaveActivity, onSavePart, error } = useDeliveryErrorHandlers(props);
+  const { onSaveActivity, onSavePart, onSubmitActivity, onResetActivity, onSubmitPart, error } =
+    useDeliveryErrorHandlers(props);
+
   const writerContext = defaultWriterContext({
     graded: props.context.graded,
     sectionSlug: props.context.sectionSlug,
@@ -33,7 +38,15 @@ export const DeliveryElementProvider: React.FC<DeliveryElementProps<any>> = (pro
 
   return (
     <DeliveryElementContext.Provider
-      value={{ ...props, writerContext, onSaveActivity, onSavePart }}
+      value={{
+        ...props,
+        writerContext,
+        onSaveActivity,
+        onSavePart,
+        onSubmitActivity,
+        onResetActivity,
+        onSubmitPart,
+      }}
     >
       <ActivityErrorDisplay error={error}>{props.children}</ActivityErrorDisplay>
     </DeliveryElementContext.Provider>

--- a/assets/src/components/activities/useDeliveryErrorHandlers.ts
+++ b/assets/src/components/activities/useDeliveryErrorHandlers.ts
@@ -1,0 +1,51 @@
+import { useCallback, useState } from 'react';
+import { PartResponse, StudentResponse, Success } from './types';
+
+interface UseDeliveryErrorHandlersParams {
+  onSaveActivity: (attemptGuid: string, partResponses: PartResponse[]) => Promise<Success>;
+  onSavePart: (
+    attemptGuid: string,
+    partAttemptGuid: string,
+    response: StudentResponse,
+  ) => Promise<Success>;
+}
+
+export const useDeliveryErrorHandlers = (params: UseDeliveryErrorHandlersParams) => {
+  const [error, setError] = useState<string | null>(null);
+
+  const onSaveActivity = useCallback(
+    async (attemptGuid: string, partResponses: PartResponse[]): Promise<Success> => {
+      try {
+        const result = await params.onSaveActivity(attemptGuid, partResponses);
+        setError(null);
+        return result;
+      } catch (e) {
+        setError(`Could not save activity (${e.message})`);
+        throw e;
+      }
+    },
+    [params.onSaveActivity],
+  );
+
+  const onSavePart = useCallback(
+    async (
+      attemptGuid: string,
+      partAttemptGuid: string,
+      response: StudentResponse,
+    ): Promise<Success> => {
+      try {
+        return await params.onSavePart(attemptGuid, partAttemptGuid, response);
+      } catch (e) {
+        setError(`Could not save part (${e.message})`);
+        throw e;
+      }
+    },
+    [params.onSavePart],
+  );
+
+  return {
+    error,
+    onSaveActivity,
+    onSavePart,
+  };
+};

--- a/assets/src/components/activities/useDeliveryErrorHandlers.ts
+++ b/assets/src/components/activities/useDeliveryErrorHandlers.ts
@@ -1,26 +1,99 @@
 import { useCallback, useState } from 'react';
+import { set } from 'nprogress';
+import { EvaluationResponse, ResetActivityResponse } from './DeliveryElement';
 import { PartResponse, StudentResponse, Success } from './types';
 
+type SaveActivityCallback = (
+  attemptGuid: string,
+  partResponses: PartResponse[],
+) => Promise<Success>;
+
 interface UseDeliveryErrorHandlersParams {
-  onSaveActivity: (attemptGuid: string, partResponses: PartResponse[]) => Promise<Success>;
+  onSaveActivity: SaveActivityCallback;
   onSavePart: (
     attemptGuid: string,
     partAttemptGuid: string,
     response: StudentResponse,
   ) => Promise<Success>;
+  onSubmitActivity: (
+    attemptGuid: string,
+    partResponses: PartResponse[],
+  ) => Promise<EvaluationResponse>;
+  onResetActivity: (attemptGuid: string) => Promise<ResetActivityResponse>;
+  onSubmitPart: (
+    attemptGuid: string,
+    partAttemptGuid: string,
+    response: StudentResponse,
+  ) => Promise<EvaluationResponse>;
 }
 
 export const useDeliveryErrorHandlers = (params: UseDeliveryErrorHandlersParams) => {
   const [error, setError] = useState<string | null>(null);
 
+  const onSubmitPart = useCallback(
+    async (
+      attemptGuid: string,
+      partAttemptGuid: string,
+      response: StudentResponse,
+    ): Promise<EvaluationResponse> => {
+      try {
+        return await params.onSubmitPart(attemptGuid, partAttemptGuid, response);
+      } catch (e) {
+        setError(`Could not submit part (${e.message})`);
+        throw e;
+      }
+    },
+    [params.onSubmitPart],
+  );
+
+  const onResetActivity = useCallback(
+    async (attemptGuid: string): Promise<ResetActivityResponse> => {
+      try {
+        const result = await params.onResetActivity(attemptGuid);
+        setError(null);
+        return result;
+      } catch (e) {
+        setError(`Could not reset activity (${e.message})`);
+        throw e;
+      }
+    },
+    [params.onResetActivity],
+  );
+
+  const onSubmitActivity = useCallback(
+    async (attemptGuid: string, partResponses: PartResponse[]): Promise<EvaluationResponse> => {
+      try {
+        const result = await params.onSubmitActivity(attemptGuid, partResponses);
+        setError(null);
+        return result;
+      } catch (e) {
+        setError(`Could not submit activity (${e.message})`);
+        throw e;
+      }
+    },
+    [params.onSubmitActivity],
+  );
+
   const onSaveActivity = useCallback(
     async (attemptGuid: string, partResponses: PartResponse[]): Promise<Success> => {
+      const _saveActivity = () =>
+        params
+          .onSaveActivity(attemptGuid, partResponses)
+          .then((result) => {
+            removeActivitySaveRetry(attemptGuid); // Whenever we successfully save, remove any pending retries
+            return result;
+          })
+          .catch((e) => {
+            throw e;
+          });
+
       try {
-        const result = await params.onSaveActivity(attemptGuid, partResponses);
+        const result = await _saveActivity();
         setError(null);
         return result;
       } catch (e) {
         setError(`Could not save activity (${e.message})`);
+        queueActivitySaveRetry(partResponses, attemptGuid, params.onSaveActivity);
         throw e;
       }
     },
@@ -47,5 +120,70 @@ export const useDeliveryErrorHandlers = (params: UseDeliveryErrorHandlersParams)
     error,
     onSaveActivity,
     onSavePart,
+    onSubmitActivity,
+    onSubmitPart,
+    onResetActivity,
   };
 };
+
+interface RequestRetry {
+  id: string;
+  responses: PartResponse[];
+  fn: () => Promise<Success>;
+}
+
+export function getActivitySaveRetry(id: string) {
+  if (!window.retryQueue) return null;
+  return window.retryQueue.find((r) => r.id === id);
+}
+
+export function removeActivitySaveRetry(id: string) {
+  if (!window.retryQueue) return;
+  const index = window.retryQueue.findIndex((r) => r.id === id);
+  if (index !== -1) {
+    window.retryQueue.splice(index, 1);
+  }
+}
+
+/**
+ * If you have a failed activity save, you can queue it for retry right before the finalization.
+ */
+export function queueActivitySaveRetry(
+  responses: PartResponse[],
+  id: string,
+  onSaveActivity: SaveActivityCallback,
+) {
+  const existingEntry = getActivitySaveRetry(id);
+
+  if (existingEntry) {
+    mergeResponses(existingEntry.responses, responses);
+    existingEntry.fn = () => onSaveActivity(id, existingEntry.responses);
+  } else {
+    // Add it to the queue
+    window.retryQueue = window.retryQueue || [];
+    window.retryQueue.push({
+      id,
+      responses,
+      fn: () => onSaveActivity(id, responses),
+    });
+  }
+}
+
+function mergeResponses(existingResponses: PartResponse[], newResponses: PartResponse[]) {
+  newResponses.forEach((newResponse) => {
+    const existingResponse = existingResponses.find(
+      (r) => r.attemptGuid === newResponse.attemptGuid,
+    );
+    if (existingResponse) {
+      existingResponse.response = newResponse.response;
+    } else {
+      existingResponses.push(newResponse);
+    }
+  });
+}
+
+declare global {
+  interface Window {
+    retryQueue?: RequestRetry[];
+  }
+}

--- a/assets/src/components/hooks/useOffline.tsx
+++ b/assets/src/components/hooks/useOffline.tsx
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+
+export const useOffline = () => {
+  const [offline, setOffline] = useState(!navigator.onLine);
+
+  useEffect(() => {
+    const handleOffline = () => setOffline(true);
+    const handleOnline = () => setOffline(false);
+    window.addEventListener('offline', handleOffline);
+    window.addEventListener('online', handleOnline);
+    return () => {
+      window.removeEventListener('offline', handleOffline);
+      window.removeEventListener('online', handleOnline);
+    };
+  }, []);
+
+  return offline;
+};

--- a/assets/src/phoenix/app.ts
+++ b/assets/src/phoenix/app.ts
@@ -27,7 +27,7 @@ import { CreateAccountPopup } from 'components/messages/CreateAccountPopup';
 import { commandButtonClicked } from '../components/editing/elements/command_button/commandButtonClicked';
 import { initActivityBridge, initPreviewActivityBridge } from './activity_bridge';
 import { initCountdownTimer, initEndDateTimer } from './countdownTimer';
-import { finalize } from './finalize';
+import { finalize, queueActivitySaveRetry, removeActivitySaveRetry } from './finalize';
 import { showModal } from './modal';
 import { enableSubmitWhenTitleMatches } from './package_delete';
 import { onReady } from './ready';
@@ -94,6 +94,8 @@ window.OLI = {
   finalize,
   initCountdownTimer,
   initEndDateTimer,
+  queueActivitySaveRetry,
+  removeActivitySaveRetry,
   CreateAccountPopup: (node: any, props: any) => mount(CreateAccountPopup, node, props),
 };
 
@@ -184,6 +186,8 @@ declare global {
       initCountdownTimer: typeof initCountdownTimer;
       initEndDateTimer: typeof initEndDateTimer;
       CreateAccountPopup: (node: any, props: any) => void;
+      queueActivitySaveRetry: typeof queueActivitySaveRetry;
+      removeActivitySaveRetry: typeof removeActivitySaveRetry;
     };
     keepAlive: () => void;
   }

--- a/lib/oli_web/templates/page_delivery/page.html.heex
+++ b/lib/oli_web/templates/page_delivery/page.html.heex
@@ -1,5 +1,6 @@
 <div class="pt-5 mx-auto max-w-[900px]">
   <%= if not (Map.has_key?(@resource_attempt.content, "advancedDelivery") and @resource_attempt.content["advancedDelivery"]) do %>
+    <%= react_component("Components.OfflineDetector") %>
     <Components.Delivery.PageDelivery.header
       title={@title}
       page_number={@page_number}


### PR DESCRIPTION
Demo:
https://github.com/Simon-Initiative/oli-torus/assets/333265/f280ad1f-17da-4cc5-a5fc-1a1024b16b88


Previously, errors when saving activities were silently dropped. This PR adds:

- Learners get a visual indicator that an activity did not save
- If the network goes offline, there is a warning banner
- Upon submitting an assessment, we retry failed saves.