### PR TITLE
[BUG FIX] Fix logging spam from worker

### DIFF
--- a/lib/oli/delivery/experiments/log_worker.ex
+++ b/lib/oli/delivery/experiments/log_worker.ex
@@ -56,7 +56,7 @@ defmodule Oli.Delivery.Experiments.LogWorker do
         Oli.Delivery.Experiments.log(enrollment_id, correctness)
 
       _ ->
-        {:nothing_to_do}
+        {:ok, :nothing_to_do}
     end
   end
 


### PR DESCRIPTION
Return {:ok, :nothing_to_do} to prevent oban warning message