### PR TITLE
[ENHANCEMENT] work around MathJax 3 bug handling LaTeX newlines [MER-2791]

### DIFF
--- a/assets/src/components/common/MathJaxFormula.tsx
+++ b/assets/src/components/common/MathJaxFormula.tsx
@@ -84,6 +84,13 @@ export const MathJaxMathMLFormula: React.FC<MathJaxFormulaProps> = ({
 
 MathJaxMathMLFormula.defaultProps = { style: {} };
 
+// MathJax 3.0 only handles \\ as newlines if wrapped in \displaylines{..}
+const fixNL = (s: string) =>
+  // look for double slash followed by any other character to avoid matching at end
+  s.match(/\\\\./) && !s.startsWith('\\begin{array}') && !s.startsWith('\\displaylines')
+    ? `\\displaylines{${s}}`
+    : s;
+
 export const MathJaxLatexFormula: React.FC<MathJaxFormulaProps> = ({
   src,
   inline,
@@ -91,7 +98,8 @@ export const MathJaxLatexFormula: React.FC<MathJaxFormulaProps> = ({
   onClick,
 }) => {
   const ref = useMathJax(src);
-  const wrapped = inline ? `\\(${src}\\)` : `\\[${src}\\]`;
+  const fixed = fixNL(src);
+  const wrapped = inline ? `\\(${fixed}\\)` : `\\[${fixed}\\]`;
 
   return (
     <span onClick={onClick} style={style} className={cssClass(inline)} ref={ref}>

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -484,9 +484,18 @@ defmodule Oli.Rendering.Content.Html do
         %Oli.Rendering.Context{} = _context,
         _next,
         %{"subtype" => "latex", "src" => src},
-        inline
+        true
       ) do
-    ["<span class=\"#{formula_class(inline)}\">\\(", escape_xml!(fix_nl(src)), "\\)</span>\n"]
+    ["<span class=\"#{formula_class(true)}\">\\(", escape_xml!(fix_nl(src)), "\\)</span>\n"]
+  end
+
+  def formula(
+        %Oli.Rendering.Context{} = _context,
+        _next,
+        %{"subtype" => "latex", "src" => src},
+        false
+      ) do
+    ["<span class=\"#{formula_class(false)}\">\\[", escape_xml!(fix_nl(src)), "\\]</span>\n"]
   end
 
   def formula(

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -484,18 +484,9 @@ defmodule Oli.Rendering.Content.Html do
         %Oli.Rendering.Context{} = _context,
         _next,
         %{"subtype" => "latex", "src" => src},
-        true
+        inline
       ) do
-    ["<span class=\"#{formula_class(true)}\">\\(", escape_xml!(src), "\\)</span>\n"]
-  end
-
-  def formula(
-        %Oli.Rendering.Context{} = _context,
-        _next,
-        %{"subtype" => "latex", "src" => src},
-        false
-      ) do
-    ["<span class=\"#{formula_class(false)}\">\\[", escape_xml!(src), "\\]</span>\n"]
+    ["<span class=\"#{formula_class(inline)}\">\\(", escape_xml!(fix_nl(src)), "\\)</span>\n"]
   end
 
   def formula(
@@ -509,6 +500,15 @@ defmodule Oli.Rendering.Content.Html do
       Scrubber.scrub(src, MathMLSanitizer),
       "</span>\n"
     ]
+  end
+
+  # workaround lack of support in MathJax 3.0 for LaTeX newline \\
+  def fix_nl(src) do
+    if String.match?(src, ~r/\\\\./) and
+         not (String.starts_with?(src, "\\displaylines") or
+                String.starts_with?(src, "\\begin{array}")),
+       do: "\displaylines{#{src}}",
+       else: src
   end
 
   def figure(%Context{} = _context, render_children, render_title, _) do


### PR DESCRIPTION
MathJax 3 doesn't handle embedded LaTeX newline `\\` unless wrapped in `\displaylines{...}` or certain other wrapping constructs. This is expected to be fixed in MathJax 4. Because embedded newlines are used extensively in migrated Chem courses to show multiline derivations in feedback (instances in the hundreds, too numerous to easily fix manually), this PR works around the MathJax 3 defect by rewriting newline-containing LaTeX formulas to wrap in `\displaylines` just before rendering. 

To avoid rewriting when not necessary, applies only when double-backslash followed by some other character (to ignore newlines at end of formula, which occur frequently in Chem instances, perhaps as a result of some auto-generating procedure). Also ignores if formula wrapped in `\begin{array}...\end{array}` which works and occurs frequently Chem instances. This will still rewrite on formulas like `\require{cancel}\begin{array}...` where it is not necessary, but this appears harmless. 