### PR TITLE
[MER-2622] Use custom labels for sections on instructor and student views

### DIFF
--- a/lib/oli/branding/custom_labels.ex
+++ b/lib/oli/branding/custom_labels.ex
@@ -22,4 +22,8 @@ defmodule Oli.Branding.CustomLabels do
       section: "Section"
     }
   end
+
+  def default_map() do
+    Map.from_struct(default())
+  end
 end

--- a/lib/oli/delivery/hierarchy.ex
+++ b/lib/oli/delivery/hierarchy.ex
@@ -110,7 +110,7 @@ defmodule Oli.Delivery.Hierarchy do
 
     labels =
       case pub.project.customizations do
-        nil -> Map.from_struct(CustomLabels.default())
+        nil -> CustomLabels.default_map()
         l -> Map.from_struct(l)
       end
 

--- a/lib/oli/publishing/authoring_resolver.ex
+++ b/lib/oli/publishing/authoring_resolver.ex
@@ -264,7 +264,7 @@ defmodule Oli.Publishing.AuthoringResolver do
 
     labels =
       case project.customizations do
-        nil -> Map.from_struct(CustomLabels.default())
+        nil -> CustomLabels.default_map()
         l -> Map.from_struct(l)
       end
 

--- a/lib/oli/publishing/delivery_resolver.ex
+++ b/lib/oli/publishing/delivery_resolver.ex
@@ -325,7 +325,7 @@ defmodule Oli.Publishing.DeliveryResolver do
       |> Enum.reduce({%{}, nil}, fn {s, sr, rev, is_root?, proj_slug}, {nodes, root} ->
         labels =
           case s.customizations do
-            nil -> Map.from_struct(CustomLabels.default())
+            nil -> CustomLabels.default_map()
             l -> Map.from_struct(l)
           end
 

--- a/lib/oli/resources/numbering.ex
+++ b/lib/oli/resources/numbering.ex
@@ -50,13 +50,15 @@ defmodule Oli.Resources.Numbering do
 
   defstruct level: 0,
             index: 0,
-            labels: Map.from_struct(CustomLabels.default())
+            labels: CustomLabels.default_map()
 
   def container_type_label(numbering) do
+    labels = numbering.labels || CustomLabels.default_map()
+
     case numbering.level do
-      1 -> Map.get(numbering.labels, :unit)
-      2 -> Map.get(numbering.labels, :module)
-      _ -> Map.get(numbering.labels, :section)
+      1 -> Map.get(labels, :unit)
+      2 -> Map.get(labels, :module)
+      _ -> Map.get(labels, :section)
     end
   end
 

--- a/lib/oli_web/components/delivery/course_content.ex
+++ b/lib/oli_web/components/delivery/course_content.ex
@@ -5,6 +5,7 @@ defmodule OliWeb.Components.Delivery.CourseContent do
   alias OliWeb.Router.Helpers, as: Routes
   alias OliWeb.Components.Delivery.Buttons
   alias OliWeb.Components.Delivery.Utils, as: DeliveryUtils
+  alias Oli.Resources.Numbering
 
   attr(:breadcrumbs_tree, :map, required: true)
   attr(:current_position, :integer, required: true)
@@ -75,13 +76,14 @@ defmodule OliWeb.Components.Delivery.CourseContent do
                 <%= get_resource_name(
                   @current_level_nodes,
                   @current_position,
-                  @section.display_curriculum_item_numbering
+                  @section.display_curriculum_item_numbering,
+                  @section.customizations
                 ) %>
               </h4>
               <%= if !assigns[:is_instructor] do %>
                 <div class="flex items-center justify-center space-x-3 mt-1">
                   <span class="uppercase text-[10px] tracking-wide text-gray-800 dark:text-white">
-                    <%= "#{get_resource_prefix(get_current_node(@current_level_nodes, @current_position), @section.display_curriculum_item_numbering)} overall progress" %>
+                    <%= "#{get_resource_prefix(get_current_node(@current_level_nodes, @current_position), @section.display_curriculum_item_numbering, @section.customizations)} overall progress" %>
                   </span>
                   <div id="browser_overall_progress_bar" class="w-52 rounded-full bg-gray-200 h-2">
                     <div
@@ -270,7 +272,8 @@ defmodule OliWeb.Components.Delivery.CourseContent do
           {socket.assigns.current_level + 1, selected_resource_index,
            get_resource_prefix(
              current_node,
-             socket.assigns.section.display_curriculum_item_numbering
+             socket.assigns.section.display_curriculum_item_numbering,
+             socket.assigns.section.customizations
            )}
         ]
 
@@ -425,31 +428,71 @@ defmodule OliWeb.Components.Delivery.CourseContent do
     end
   end
 
-  defp get_resource_name(current_level_nodes, current_position, display_curriculum_item_numbering) do
+  defp get_resource_name(
+         current_level_nodes,
+         current_position,
+         display_curriculum_item_numbering,
+         customizations
+       ) do
     current_node = get_current_node(current_level_nodes, current_position)
 
-    "#{get_resource_prefix(current_node, display_curriculum_item_numbering)}: #{current_node["title"]}"
+    "#{get_resource_prefix(current_node, display_curriculum_item_numbering, customizations)}: #{current_node["title"]}"
   end
 
-  defp get_resource_prefix(%{"type" => "page"} = page, display_curriculum_item_numbering),
+  defp get_resource_prefix(%{"type" => "page"} = page, display_curriculum_item_numbering, _),
     do: if(display_curriculum_item_numbering, do: "Page #{page["index"]}", else: "Page")
 
   defp get_resource_prefix(
          %{"type" => "container", "level" => "1"} = unit,
-         display_curriculum_item_numbering
-       ),
-       do: if(display_curriculum_item_numbering, do: "Unit #{unit["index"]}", else: "Unit")
+         display_curriculum_item_numbering,
+         customizations
+       ) do
+    container_label =
+      Numbering.container_type_label(%Numbering{
+        level: 1,
+        labels: customizations
+      })
+
+    if display_curriculum_item_numbering do
+      "#{container_label} #{unit["index"]}"
+    else
+      container_label
+    end
+  end
 
   defp get_resource_prefix(
          %{"type" => "container", "level" => "2"} = module,
-         display_curriculum_item_numbering
-       ),
-       do: if(display_curriculum_item_numbering, do: "Module #{module["index"]}", else: "Module")
+         display_curriculum_item_numbering,
+         customizations
+       ) do
+    container_label =
+      Numbering.container_type_label(%Numbering{
+        level: 2,
+        labels: customizations
+      })
+
+    if display_curriculum_item_numbering do
+      "#{container_label} #{module["index"]}"
+    else
+      container_label
+    end
+  end
 
   defp get_resource_prefix(
          %{"type" => "container", "level" => _} = section,
-         display_curriculum_item_numbering
-       ),
-       do:
-         if(display_curriculum_item_numbering, do: "Section #{section["index"]}", else: "Section")
+         display_curriculum_item_numbering,
+         customizations
+       ) do
+    container_label =
+      Numbering.container_type_label(%Numbering{
+        level: nil,
+        labels: customizations
+      })
+
+    if display_curriculum_item_numbering do
+      "#{container_label} #{section["index"]}"
+    else
+      container_label
+    end
+  end
 end

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -292,8 +292,9 @@ defmodule OliWeb.PageDeliveryController do
             scripts: [],
             section: section,
             title: title,
-            children: simulate_children_nodes(current, previous_next_index),
-            container: simulate_node(current),
+            children:
+              simulate_children_nodes(current, previous_next_index, section.customizations),
+            container: simulate_node(current, section.customizations),
             section_slug: section_slug,
             previous_page: previous,
             next_page: next,
@@ -1401,20 +1402,24 @@ defmodule OliWeb.PageDeliveryController do
     end
   end
 
-  defp simulate_node(%{
-         "level" => level_str,
-         "index" => index_str,
-         "title" => title,
-         "id" => id_str,
-         "type" => type,
-         "graded" => graded,
-         "slug" => slug
-       }) do
+  defp simulate_node(
+         %{
+           "level" => level_str,
+           "index" => index_str,
+           "title" => title,
+           "id" => id_str,
+           "type" => type,
+           "graded" => graded,
+           "slug" => slug
+         },
+         customizations
+       ) do
     %Oli.Delivery.Hierarchy.HierarchyNode{
       uuid: UUID.uuid4(),
       numbering: %Oli.Resources.Numbering{
         level: String.to_integer(level_str),
-        index: String.to_integer(index_str)
+        index: String.to_integer(index_str),
+        labels: customizations
       },
       revision: %{
         slug: slug,
@@ -1432,14 +1437,14 @@ defmodule OliWeb.PageDeliveryController do
     }
   end
 
-  defp simulate_children_nodes(current, previous_next_index) do
+  defp simulate_children_nodes(current, previous_next_index, customizations) do
     Enum.map(current["children"], fn s ->
       {:ok, {_, _, child}, _} =
         PreviousNextIndex.retrieve(previous_next_index, String.to_integer(s))
 
       child
     end)
-    |> Enum.map(fn link_desc -> simulate_node(link_desc) end)
+    |> Enum.map(fn link_desc -> simulate_node(link_desc, customizations) end)
   end
 
   defp format_datetime_fn(conn) do

--- a/lib/oli_web/live/projects/customization.ex
+++ b/lib/oli_web/live/projects/customization.ex
@@ -15,7 +15,7 @@ defmodule OliWeb.Projects.CustomizationLive do
 
     labels =
       case project.customizations do
-        nil -> Map.from_struct(CustomLabels.default())
+        nil -> CustomLabels.default_map()
         val -> Map.from_struct(val)
       end
 

--- a/lib/oli_web/live/sections/edit_view.ex
+++ b/lib/oli_web/live/sections/edit_view.ex
@@ -51,7 +51,7 @@ defmodule OliWeb.Sections.EditView do
 
         labels =
           case section.customizations do
-            nil -> Map.from_struct(CustomLabels.default())
+            nil -> CustomLabels.default_map()
             val -> Map.from_struct(val)
           end
 
@@ -75,7 +75,7 @@ defmodule OliWeb.Sections.EditView do
   attr(:changeset, :any)
   attr(:is_admin, :boolean)
   attr(:brands, :list)
-  attr(:labels, :map, default: Map.from_struct(CustomLabels.default()))
+  attr(:labels, :map, default: CustomLabels.default_map())
 
   def render(assigns) do
     assigns = assign(assigns, changeset: to_form(assigns.changeset))

--- a/test/oli/resources/numbering_test.exs
+++ b/test/oli/resources/numbering_test.exs
@@ -296,5 +296,29 @@ defmodule Oli.Resources.NumberingTest do
 
       assert page_2_crumb.full_title == "Lesson 1: Page 2"
     end
+
+    test "container_type_label/1 uses custom labels" do
+      custom_labels = %{unit: "Volume", module: "Chapter", section: "Lesson"}
+
+      assert Numbering.container_type_label(%Numbering{level: 1, labels: custom_labels}) ==
+               "Volume"
+
+      assert Numbering.container_type_label(%Numbering{level: 2, labels: custom_labels}) ==
+               "Chapter"
+
+      assert Numbering.container_type_label(%Numbering{level: nil, labels: custom_labels}) ==
+               "Lesson"
+    end
+
+    test "container_type_label/1 uses default labels" do
+      assert Numbering.container_type_label(%Numbering{level: 1}) ==
+               Oli.Branding.CustomLabels.default_map().unit
+
+      assert Numbering.container_type_label(%Numbering{level: 2}) ==
+               Oli.Branding.CustomLabels.default_map().module
+
+      assert Numbering.container_type_label(%Numbering{level: nil}) ==
+               Oli.Branding.CustomLabels.default_map().section
+    end
   end
 end

--- a/test/oli_web/live/delivery/instructor_dashboard/scored_activities/scored_activities_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/scored_activities/scored_activities_tab_test.exs
@@ -989,6 +989,27 @@ defmodule OliWeb.Delivery.InstructorDashboard.ScoredActivitiesTabTest do
       assert a4.title == "Module 2: BasicsPage 4"
     end
 
+    test "displays custom labels", %{
+      conn: conn,
+      section: section
+    } do
+      {:ok, section} =
+        Sections.update_section(section, %{
+          customizations: %{unit: "Volume", module: "Chapter", section: "Lesson"}
+        })
+
+      {:ok, view, _html} = live(conn, live_view_scored_activities_route(section.slug))
+
+      [a0, a1, a2, a3, a4] = table_as_list_of_maps(view, :assessments)
+
+      assert has_element?(view, "h4", "Scored Activities")
+      assert a0.title == "Orphaned Page"
+      assert a1.title == "Chapter 1: IntroductionPage 1"
+      assert a2.title == "Chapter 1: IntroductionPage 2"
+      assert a3.title == "Chapter 2: BasicsPage 3"
+      assert a4.title == "Chapter 2: BasicsPage 4"
+    end
+
     test "patches url to see activity details when a row is clicked", %{
       conn: conn,
       section: section,

--- a/test/oli_web/live/delivery/student_dashboard/course_content_live_test.exs
+++ b/test/oli_web/live/delivery/student_dashboard/course_content_live_test.exs
@@ -91,6 +91,25 @@ defmodule OliWeb.Delivery.StudentDashboard.CourseContentLiveTest do
     end
 
     test "navigates to next level in hierarchy", %{conn: conn, user: user, section: section} do
+      {:ok, section} =
+        Sections.update_section(section, %{
+          customizations: %{unit: "Volume", module: "Chapter", section: "Lesson"}
+        })
+
+      {:ok, view, _html} = isolated_live_view_course_content(conn, section.slug, user.id)
+
+      view
+      |> navigate_to_unit_1()
+
+      assert has_element?(view, "#course_browser_node_title", "Volume 1: Unit 1")
+
+      view
+      |> drill_down_to_module_1()
+
+      assert has_element?(view, "#course_browser_node_title", "Chapter 1: Module 1")
+    end
+
+    test "displays custom labels", %{conn: conn, user: user, section: section} do
       {:ok, view, _html} = isolated_live_view_course_content(conn, section.slug, user.id)
 
       view


### PR DESCRIPTION
[MER-2622](https://eliterate.atlassian.net/browse/MER-2622)

Several Students' and Instructors' views did not respect the custom labels set for projects and sections.
The views that were fixed include:

- Course Content Browser

![Screenshot 2023-12-04 at 2 11 51 PM](https://github.com/Simon-Initiative/oli-torus/assets/26532202/4b729c28-3174-4a15-8dae-2615c0e09e24)

- Scored Activities tab

![Screenshot 2023-12-04 at 2 11 32 PM](https://github.com/Simon-Initiative/oli-torus/assets/26532202/d5fbe4e8-4517-44f0-8110-2328b209416f)

- Container Preview

![Screenshot 2023-12-04 at 2 13 48 PM](https://github.com/Simon-Initiative/oli-torus/assets/26532202/abd40980-99e6-4489-9e81-2bbbc9e545ea)


[MER-2622]: https://eliterate.atlassian.net/browse/MER-2622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ