### PR TITLE
[BUG FIX] [MER-2792] Fix an issue where the ingest process would crash

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -1412,8 +1412,19 @@ defmodule Oli.Delivery.Sections do
                 sr,
                 :children,
                 Enum.map(hierarchy_definition[sr.resource_id] || [], fn child_resource_id ->
-                  section_resources_by_resource_id[child_resource_id].id
+                  case section_resources_by_resource_id[child_resource_id] do
+                    nil ->
+                      Logger.error(
+                        "Resource #{child_resource_id} is referenced in the hierarchy but does not exist in the publication"
+                      )
+
+                      nil
+
+                    %SectionResource{id: id} ->
+                      id
+                  end
                 end)
+                |> Enum.filter(&(&1 != nil))
               )
               |> Map.take([:id, :children, :inserted_at, :updated_at])
 
@@ -1483,23 +1494,31 @@ defmodule Oli.Delivery.Sections do
         children,
         {[], numbering_tracker, slugs},
         fn resource_id, {processed_children, numbering_tracker, slugs} ->
-          %PublishedResource{revision: child} = published_resources_by_resource_id[resource_id]
+          case published_resources_by_resource_id[resource_id] do
+            nil ->
+              Logger.error(
+                "Resource #{resource_id} is referenced in the hierarchy but does not exist in the publication"
+              )
 
-          {section_resources, numbering_tracker, slugs} =
-            build_section_resource_insertion(%{
-              section: section,
-              publication: publication,
-              published_resources_by_resource_id: published_resources_by_resource_id,
-              processed_ids: processed_ids,
-              revision: child,
-              level: level + 1,
-              numbering_tracker: numbering_tracker,
-              hierarchy_definition: hierarchy_definition,
-              date: date,
-              slugs: slugs
-            })
+              {processed_children, numbering_tracker, slugs}
 
-          {section_resources ++ processed_children, numbering_tracker, slugs}
+            %PublishedResource{revision: child} ->
+              {section_resources, numbering_tracker, slugs} =
+                build_section_resource_insertion(%{
+                  section: section,
+                  publication: publication,
+                  published_resources_by_resource_id: published_resources_by_resource_id,
+                  processed_ids: processed_ids,
+                  revision: child,
+                  level: level + 1,
+                  numbering_tracker: numbering_tracker,
+                  hierarchy_definition: hierarchy_definition,
+                  date: date,
+                  slugs: slugs
+                })
+
+              {section_resources ++ processed_children, numbering_tracker, slugs}
+          end
         end
       )
 


### PR DESCRIPTION
Fixes an issue where the ingest process would crash during product creation if a child resource id was not found in published resources. The temporary workaround was to disable product processing in the ingest pipeline, but that is not a feasible solution in production.

I'm not really sure what the root cause here is so I just put in logic to handle this case gracefully so that the ingest doesn't crash.

Steps to recreate:
1. Export a recent chemistry digest
2. Import the digest and see the ingest process fail without an error message

https://eliterate.atlassian.net/browse/MER-2792