### PR TITLE
[ENHANCEMENT] [NG23-34] Fix explorations and practice page performance issue

### DIFF
--- a/lib/oli/application.ex
+++ b/lib/oli/application.ex
@@ -62,6 +62,9 @@ defmodule Oli.Application do
         # Starts Cachex to store datashop export info
         Oli.DatashopCache,
 
+        # Starts Cachex to store section info
+        Oli.Delivery.Sections.SectionCache,
+
         # a supervisor which can be used to dynamically supervise tasks
         {Task.Supervisor, name: Oli.TaskSupervisor}
       ] ++ maybe_node_js_config()

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -1595,7 +1595,7 @@ defmodule Oli.Delivery.Sections do
   ## Examples
       iex> get_ordered_container_labels(section_slug)
       [
-        {4 => "Section 1: Curriculum"},
+        {4, "Section 1: Curriculum"},
         {39, "Module 1: Setup"},
         {40, "Module 2: Phoenix project"},
         {41, "Unit 1: Getting Started"},

--- a/lib/oli/delivery/sections/section_cache.ex
+++ b/lib/oli/delivery/sections/section_cache.ex
@@ -1,0 +1,94 @@
+defmodule Oli.Delivery.Sections.SectionCache do
+  @moduledoc """
+    Provides a cache that can be used for section delivery related information retrieval. This cache is backed by
+    Cachex for local storage.
+
+    Keys are set to expire after 1 year as that is the longest a section is expected to be active.
+    This is to prevent data from building up in the cache over a long time period. It is more than
+    likely that the cache will be restarted/cleared before the 1 year expiration.
+  """
+
+  use GenServer
+
+  require Logger
+
+  @cache_name :cache_section
+
+  @cache_keys [
+    :ordered_container_labels
+  ]
+
+  # ----------------
+  # Client
+
+  def start_link(init_args),
+    do: GenServer.start_link(__MODULE__, init_args, name: __MODULE__)
+
+  def get(key),
+    do: GenServer.call(__MODULE__, {:get, key})
+
+  def delete(key),
+    do: GenServer.call(__MODULE__, {:delete, key})
+
+  def put(key, value),
+    do: GenServer.call(__MODULE__, {:put, key, value})
+
+  def get_or_compute(section_slug, key, fun) do
+    case get("#{section_slug}_#{key}") do
+      {:ok, nil} ->
+        Logger.info(
+          "Section #{section_slug} has no cached entry for #{section_slug}_#{key}. One will be computed now and cached."
+        )
+
+        value = fun.()
+
+        put(key, value)
+
+        value
+
+      {:ok, value} ->
+        value
+    end
+  end
+
+  def clear(section_slug) do
+    for key <- @cache_keys do
+      delete("#{section_slug}_#{key}")
+    end
+  end
+
+  # ----------------
+  # Server callbacks
+
+  def init(_) do
+    {:ok, _pid} = Cachex.start_link(@cache_name, stats: true)
+
+    {:ok, []}
+  end
+
+  def handle_call({:get, key}, _from, state) do
+    {:reply, Cachex.get(@cache_name, key), state}
+  end
+
+  def handle_call({:delete, key}, _from, state) do
+    case Cachex.del(@cache_name, key) do
+      {:ok, true} ->
+        {:reply, :ok, state}
+
+      _ ->
+        {:reply, :error, state}
+    end
+  end
+
+  def handle_call({:put, key, value}, _from, state) do
+    ttl = :timer.hours(24 * 365)
+
+    case Cachex.put(@cache_name, key, value, ttl: ttl) do
+      {:ok, true} ->
+        {:reply, :ok, state}
+
+      _ ->
+        {:reply, :error, state}
+    end
+  end
+end

--- a/lib/oli_web/live/delivery/student/discussions_live.ex
+++ b/lib/oli_web/live/delivery/student/discussions_live.ex
@@ -25,7 +25,7 @@ defmodule OliWeb.Delivery.Student.DiscussionsLive do
         )
 
     ordered_containers_map =
-      Sections.fetch_ordered_containers(socket.assigns.section.slug)
+      Sections.get_ordered_container_labels(socket.assigns.section.slug)
       |> Enum.into(%{})
 
     resource_to_container_map = Sections.get_resource_to_container_map(socket.assigns.section)


### PR DESCRIPTION
One of the queries on the explorations, practice and discussions pages `Sections.get_ordered_container_labels` was taking a while to run on load and slowing down responsiveness. This PR adds a JIT caching mechanism for section related data, specifically in this case ordered container labels.