### PR TITLE
[BUGFIX][MER-2687] Fix scored activities page advanced

### DIFF
--- a/lib/oli_web/components/delivery/scored_activities/scored_activities.ex
+++ b/lib/oli_web/components/delivery/scored_activities/scored_activities.ex
@@ -131,6 +131,11 @@ defmodule OliWeb.Components.Delivery.ScoredActivities do
               })
               |> SortableTableModel.update_sort_params(params.sort_by)
 
+            selected_activity =
+              if params[:selected_activity] in ["", nil],
+                do: nil,
+                else: String.to_integer(params[:selected_activity])
+
             {:ok,
              assign(socket,
                current_assessment: current_assessment,
@@ -143,9 +148,7 @@ defmodule OliWeb.Components.Delivery.ScoredActivities do
                  count_attempts(current_assessment, assigns.section, student_ids),
                rendered_activity_id: UUID.uuid4()
              )
-             |> assign_selected_activity(
-               params[:selected_activity] && String.to_integer(params[:selected_activity])
-             )}
+             |> assign_selected_activity(selected_activity)}
         end
     end
   end

--- a/test/oli_web/live/delivery/instructor_dashboard/scored_activities/scored_activities_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/scored_activities/scored_activities_tab_test.exs
@@ -1891,6 +1891,41 @@ defmodule OliWeb.Delivery.InstructorDashboard.ScoredActivitiesTabTest do
       assert a1.title == "Module 1: IntroductionPage 1"
     end
 
+    test "change page size works as expected", %{
+      conn: conn,
+      section: section
+    } do
+      {:ok, view, _html} = live(conn, live_view_scored_activities_route(section.slug))
+
+      # Refute that the pagination options are displayed
+      refute has_element?(view, "nav[aria-label=\"Paging\"]")
+
+      # Change page size from default (20) to 2
+      view
+      |> element("#header_paging_page_size_form")
+      |> render_change(%{limit: "2"})
+
+      [a0, a1] = table_as_list_of_maps(view, :assessments)
+
+      # Page 1
+      assert a0.title == "Orphaned Page"
+      assert a1.title == "Module 1: IntroductionPage 1"
+
+      # Assert that the pagination options are displayed
+      assert has_element?(view, "nav[aria-label=\"Paging\"]")
+
+      # Change to page 2
+      view
+      |> element("button[phx-value-offset=\"2\"]", "2")
+      |> render_click()
+
+      [a2, a3] = table_as_list_of_maps(view, :assessments)
+
+      # Page 2
+      assert a2.title == "Module 1: IntroductionPage 2"
+      assert a3.title == "Module 2: BasicsPage 3"
+    end
+
     test "keeps showing the same elements when changing the page size", %{
       conn: conn,
       section: section


### PR DESCRIPTION
[MER-2687](https://eliterate.atlassian.net/browse/MER-2687)

This PR fixes the error that happened when changing the page size in the view that shows the activities of a page in the `Scored Activities` tab in the Instructor Dashboard. 

By default the page size is 20, but having more than 10 activities listed in the table and changing the page size to 10, the corresponding pagination was not shown and the application generated an error.

https://github.com/Simon-Initiative/oli-torus/assets/16328384/cf577d29-aab0-4f7e-b5b2-92babaaadd9c
