### PR TITLE
[BUGFIX] don't sort range bounds using variables [MER-2819]

### DIFF
--- a/assets/src/data/activities/model/rules.ts
+++ b/assets/src/data/activities/model/rules.ts
@@ -178,6 +178,10 @@ export const rangeRule = (
     return makeRangeRule(0, 0, inclusive);
   }
 
+  // don't sort if either end is a variable
+  if (typeof left === 'string' || typeof right === 'string')
+    return makeRangeRule(left, right, inclusive, precision);
+
   const lowerBound = left < right ? left : right;
   const upperBound = lowerBound === left ? right : left;
   return makeRangeRule(lowerBound, upperBound, inclusive, precision);


### PR DESCRIPTION
Code was sorting answer range rule bounds into low-to-high order on creation/updating. When dynamic variables were used, this wound up sorting them alphabetically, regardless of the order in which they were entered. That could prevent the rule from working since torus rule evaluation requires lower-to-higher numerical order. This PR protects against that case. 