### PR TITLE
[BUG FIX] [MER-2822] Revert bg change for inputs

### DIFF
--- a/assets/css/bootstrap-shims.css
+++ b/assets/css/bootstrap-shims.css
@@ -264,7 +264,7 @@ textarea.form-control,
 .input-group select,
 select.custom-select,
 select.form-control {
-  @apply border py-1 px-1.5 border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-850 rounded w-full disabled:bg-neutral-100 disabled:text-neutral-600 dark:text-white;
+  @apply border py-1 px-1.5 border-gray-300 dark:border-gray-600 dark:bg-gray-850 rounded w-full disabled:bg-neutral-100 disabled:text-neutral-600 dark:text-white;
 }
 
 input.form-control-sm,


### PR DESCRIPTION
A recent style change makes inputs with the legacy boostrap `form-control` class look disabled. This PR reverts that system-wide style change.

If we want this style to be applied to delivery content, we can create another PR that is more targeted.

Before:
![screenshot_2023-12-08_at_4 11 31___pm](https://github.com/Simon-Initiative/oli-torus/assets/6248894/cdc217ac-6451-4273-a0d0-61dc36ceab96)

After:
<img width="809" alt="Screenshot 2023-12-11 at 1 38 04 PM" src="https://github.com/Simon-Initiative/oli-torus/assets/6248894/1faebb2c-5436-44ab-b1df-3c9ee215bd61">
