### PR TITLE
[BUGFIX][MER-2821] Incorrect message when section has no surveys

### DIFF
--- a/lib/oli_web/components/delivery/surveys/surveys.ex
+++ b/lib/oli_web/components/delivery/surveys/surveys.ex
@@ -111,26 +111,21 @@ defmodule OliWeb.Components.Delivery.Surveys do
             </form>
           </div>
         </div>
-        <%= if @total_count > 0 do %>
-          <PagedTable.render
-            table_model={@table_model}
-            total_count={@total_count}
-            offset={@params.offset}
-            limit={@params.limit}
-            page_change={JS.push("paged_table_page_change", target: @myself)}
-            selection_change={JS.push("paged_table_selection_change", target: @myself)}
-            sort={JS.push("paged_table_sort", target: @myself)}
-            additional_table_class="instructor_dashboard_table"
-            allow_selection={true}
-            show_bottom_paging={false}
-            limit_change={JS.push("paged_table_limit_change", target: @myself)}
-            show_limit_change={true}
-          />
-        <% else %>
-          <div class="bg-white dark:bg-gray-800 dark:text-white shadow-sm px-10 my-5">
-            <p class="py-5">There are no surveys present in this course</p>
-          </div>
-        <% end %>
+        <PagedTable.render
+          table_model={@table_model}
+          total_count={@total_count}
+          offset={@params.offset}
+          limit={@params.limit}
+          page_change={JS.push("paged_table_page_change", target: @myself)}
+          selection_change={JS.push("paged_table_selection_change", target: @myself)}
+          sort={JS.push("paged_table_sort", target: @myself)}
+          additional_table_class="instructor_dashboard_table"
+          allow_selection={true}
+          show_bottom_paging={false}
+          limit_change={JS.push("paged_table_limit_change", target: @myself)}
+          show_limit_change={true}
+          no_records_message="There are no surveys present in this course"
+        />
         <%= unless is_nil(@activities) do %>
           <%= if @activities == [] do %>
             <div class="bg-white dark:bg-gray-800 dark:text-white shadow-sm px-10 my-5 mx-10">

--- a/lib/oli_web/components/delivery/surveys/surveys.ex
+++ b/lib/oli_web/components/delivery/surveys/surveys.ex
@@ -111,21 +111,26 @@ defmodule OliWeb.Components.Delivery.Surveys do
             </form>
           </div>
         </div>
-
-        <PagedTable.render
-          table_model={@table_model}
-          total_count={@total_count}
-          offset={@params.offset}
-          limit={@params.limit}
-          page_change={JS.push("paged_table_page_change", target: @myself)}
-          selection_change={JS.push("paged_table_selection_change", target: @myself)}
-          sort={JS.push("paged_table_sort", target: @myself)}
-          additional_table_class="instructor_dashboard_table"
-          allow_selection={true}
-          show_bottom_paging={false}
-          limit_change={JS.push("paged_table_limit_change", target: @myself)}
-          show_limit_change={true}
-        />
+        <%= if @total_count > 0 do %>
+          <PagedTable.render
+            table_model={@table_model}
+            total_count={@total_count}
+            offset={@params.offset}
+            limit={@params.limit}
+            page_change={JS.push("paged_table_page_change", target: @myself)}
+            selection_change={JS.push("paged_table_selection_change", target: @myself)}
+            sort={JS.push("paged_table_sort", target: @myself)}
+            additional_table_class="instructor_dashboard_table"
+            allow_selection={true}
+            show_bottom_paging={false}
+            limit_change={JS.push("paged_table_limit_change", target: @myself)}
+            show_limit_change={true}
+          />
+        <% else %>
+          <div class="bg-white dark:bg-gray-800 dark:text-white shadow-sm px-10 my-5">
+            <p class="py-5">There are no surveys present in this course</p>
+          </div>
+        <% end %>
         <%= unless is_nil(@activities) do %>
           <%= if @activities == [] do %>
             <div class="bg-white dark:bg-gray-800 dark:text-white shadow-sm px-10 my-5 mx-10">

--- a/lib/oli_web/live/common/paged_table.ex
+++ b/lib/oli_web/live/common/paged_table.ex
@@ -19,6 +19,7 @@ defmodule OliWeb.Common.PagedTable do
   attr :render_top_info, :boolean, default: true
   attr :scrollable, :boolean, default: true
   attr :show_limit_change, :boolean, default: false
+  attr :no_records_message, :string, default: "None exist"
 
   def render(assigns) do
     ~H"""
@@ -60,7 +61,9 @@ defmodule OliWeb.Common.PagedTable do
           />
         <% end %>
       <% else %>
-        <p class="px-5 py-2">None exist</p>
+        <div class="bg-white dark:bg-gray-800 dark:text-white px-10 my-5">
+          <p><%= @no_records_message %></p>
+        </div>
       <% end %>
     </div>
     """

--- a/test/oli_web/live/delivery/instructor_dashboard/overview/surveys_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/overview/surveys_tab_test.exs
@@ -1235,7 +1235,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.SurveysTabTest do
       {:ok, view, _html} = live(conn, live_surveys_route(section.slug))
 
       assert has_element?(view, "h4", "Surveys")
-      assert has_element?(view, "p", "None exist")
+      assert has_element?(view, "p", "There are no surveys present in this course")
     end
   end
 


### PR DESCRIPTION
[MER-2821](https://eliterate.atlassian.net/browse/MER-2821)

This PR modifies the text displayed when section has no surveys to list in the `surveys` tab of the instructor dashboard. 

![Captura de pantalla 2023-12-12 a la(s) 11 50 07](https://github.com/Simon-Initiative/oli-torus/assets/16328384/18541652-f07d-42f7-93d9-8c18b5c47f72)

![Captura de pantalla 2023-12-12 a la(s) 11 50 14](https://github.com/Simon-Initiative/oli-torus/assets/16328384/bef24765-ee84-4dcc-9b1d-0c1cdd4226f9)


[MER-2821]: https://eliterate.atlassian.net/browse/MER-2821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ