### PR TITLE
[MER-2808] - Chem failing to create new course section

### DIFF
--- a/lib/oli_web/live/common/stepper/stepper.ex
+++ b/lib/oli_web/live/common/stepper/stepper.ex
@@ -21,6 +21,7 @@ defmodule OliWeb.Common.Stepper do
   attr :cancel_button_label, :string, default: "Cancel"
   attr :on_cancel, :any, default: nil
   attr :next_step_disabled, :boolean, default: false
+  attr :show_spinner, :boolean, default: false
 
   def render(assigns) do
     assigns = assign(assigns, steps: Enum.with_index(assigns.steps))
@@ -59,6 +60,26 @@ defmodule OliWeb.Common.Stepper do
                 class="torus-button primary"
               >
                 <%= @selected_step.next_button_label || "Next step" %>
+
+                <div :if={@show_spinner} class="ml-1" role="status">
+                  <svg
+                    aria-hidden="true"
+                    class="w-8 h-8 text-gray-200 animate-spin dark:text-gray-600 fill-blue-600"
+                    viewBox="0 0 100 101"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z"
+                      fill="currentColor"
+                    />
+                    <path
+                      d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z"
+                      fill="currentFill"
+                    />
+                  </svg>
+                  <span class="sr-only">Loading...</span>
+                </div>
               </button>
             </div>
           </div>

--- a/lib/oli_web/live/new_course/new_course.ex
+++ b/lib/oli_web/live/new_course/new_course.ex
@@ -7,7 +7,7 @@ defmodule OliWeb.Delivery.NewCourse do
   alias Oli.Delivery.Sections.{Section}
   alias Oli.Delivery.Sections
   alias Oli.Repo
-
+  alias Oli.Notifications.CreateSectionAsync
   alias OliWeb.Common.{Breadcrumb, Stepper}
   alias OliWeb.Common.Stepper.Step
   alias OliWeb.Delivery.NewCourse.{CourseDetails, NameCourse, SelectSource}
@@ -80,7 +80,8 @@ defmodule OliWeb.Delivery.NewCourse do
        current_user: current_user,
        lti_params: lti_params,
        changeset: changeset,
-       breadcrumbs: breadcrumbs(socket.assigns.live_action)
+       breadcrumbs: breadcrumbs(socket.assigns.live_action),
+       loading: false
      )}
   end
 
@@ -95,7 +96,8 @@ defmodule OliWeb.Delivery.NewCourse do
         on_cancel="redirect_to_courses"
         steps={@steps || []}
         current_step={@current_step}
-        next_step_disabled={next_step_disabled?(assigns)}
+        next_step_disabled={next_step_disabled?(assigns) || @loading}
+        show_spinner={@loading}
         data={get_step_data(assigns)}
       />
     </div>
@@ -257,96 +259,100 @@ defmodule OliWeb.Delivery.NewCourse do
         socket = put_flash(socket, :form_error, error_msg)
         {:noreply, socket}
     end
+
+    {:noreply, socket}
   end
 
   def create_section(_, socket) do
     %{source: source, changeset: changeset} = socket.assigns
 
-    case source_info(source) do
-      {project, _, :project_slug} ->
-        %{id: project_id, has_experiments: has_experiments} =
-          Oli.Authoring.Course.get_project_by_slug(project.slug)
+    liveview_pid = self()
 
-        publication =
-          Oli.Publishing.get_latest_published_publication_by_slug(project.slug)
-          |> Repo.preload(:project)
+    Task.Supervisor.start_child(Oli.TaskSupervisor, fn ->
+      case source_info(source) do
+        {project, _, :project_slug} ->
+          %{id: project_id, has_experiments: has_experiments} =
+            Oli.Authoring.Course.get_project_by_slug(project.slug)
 
-        customizations =
-          case publication.project.customizations do
-            nil -> nil
-            labels -> Map.from_struct(labels)
+          publication =
+            Oli.Publishing.get_latest_published_publication_by_slug(project.slug)
+            |> Repo.preload(:project)
+
+          customizations =
+            case publication.project.customizations do
+              nil -> nil
+              labels -> Map.from_struct(labels)
+            end
+
+          section_params =
+            changeset
+            |> Ecto.Changeset.apply_changes()
+            |> Map.from_struct()
+            |> Map.merge(%{
+              type: :enrollable,
+              base_project_id: project_id,
+              open_and_free: true,
+              context_id: UUID.uuid4(),
+              customizations: customizations,
+              has_experiments: has_experiments,
+              analytics_version: :v2
+            })
+
+          case create_from_publication(socket, publication, section_params) do
+            {:ok, section} ->
+              send(liveview_pid, {:section_created, section.slug})
+
+            {:error, error} ->
+              {_error_id, error_msg} = log_error("Failed to create new section", error)
+              send(liveview_pid, {:section_created_error, error_msg})
           end
 
-        section_params =
-          changeset
-          |> Ecto.Changeset.apply_changes()
-          |> Map.from_struct()
-          |> Map.merge(%{
-            type: :enrollable,
-            base_project_id: project_id,
-            open_and_free: true,
-            context_id: UUID.uuid4(),
-            customizations: customizations,
-            has_experiments: has_experiments,
-            analytics_version: :v2
-          })
+        {blueprint, _, :product_slug} ->
+          project = Oli.Repo.get(Oli.Authoring.Course.Project, blueprint.base_project_id)
 
-        case create_from_publication(socket, publication, section_params) do
-          {:ok, section} ->
-            socket = put_flash(socket, :info, "Section successfully created.")
+          section_params =
+            changeset
+            |> Ecto.Changeset.apply_changes()
+            |> Map.from_struct()
+            |> Map.take([
+              :title,
+              :course_section_number,
+              :class_modality,
+              :class_days,
+              :start_date,
+              :end_date,
+              :preferred_scheduling_time
+            ])
+            |> Map.merge(%{
+              blueprint_id: blueprint.id,
+              required_survey_resource_id: project.required_survey_resource_id,
+              type: :enrollable,
+              open_and_free: true,
+              has_experiments: project.has_experiments,
+              context_id: UUID.uuid4(),
+              analytics_version: :v2
+            })
 
-            {:noreply,
-             redirect(socket,
-               to: Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.OverviewView, section.slug)
-             )}
+          case create_from_product(socket, blueprint, section_params) do
+            {:ok, section} ->
+              # socket = put_flash(socket, :info, "Section successfully created.")
 
-          {:error, error} ->
-            {_error_id, error_msg} = log_error("Failed to create new section", error)
-            socket = put_flash(socket, :form_error, error_msg)
-            {:noreply, socket}
-        end
+              # {:noreply,
+              #  redirect(socket,
+              #    to: Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.OverviewView, section.slug)
+              #  )}
+              send(liveview_pid, {:section_created, section.slug})
 
-      {blueprint, _, :product_slug} ->
-        project = Oli.Repo.get(Oli.Authoring.Course.Project, blueprint.base_project_id)
+            {:error, error} ->
+              {_error_id, error_msg} = log_error("Failed to create new section", error)
+              # socket = put_flash(socket, :form_error, error_msg)
+              # {:noreply, socket}
+              send(liveview_pid, {:section_created_error, error_msg})
+          end
+      end
+    end)
 
-        section_params =
-          changeset
-          |> Ecto.Changeset.apply_changes()
-          |> Map.from_struct()
-          |> Map.take([
-            :title,
-            :course_section_number,
-            :class_modality,
-            :class_days,
-            :start_date,
-            :end_date,
-            :preferred_scheduling_time
-          ])
-          |> Map.merge(%{
-            blueprint_id: blueprint.id,
-            required_survey_resource_id: project.required_survey_resource_id,
-            type: :enrollable,
-            open_and_free: true,
-            has_experiments: project.has_experiments,
-            context_id: UUID.uuid4(),
-            analytics_version: :v2
-          })
-
-        case create_from_product(socket, blueprint, section_params) do
-          {:ok, section} ->
-            socket = put_flash(socket, :info, "Section successfully created.")
-
-            {:noreply,
-             redirect(socket,
-               to: Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.OverviewView, section.slug)
-             )}
-
-          {:error, error} ->
-            {_error_id, error_msg} = log_error("Failed to create new section", error)
-            socket = put_flash(socket, :form_error, error_msg)
-            {:noreply, socket}
-        end
-    end
+    {:noreply, assign(socket, loading: true)}
   end
 
   defp source_info(source_id) do
@@ -409,6 +415,20 @@ defmodule OliWeb.Delivery.NewCourse do
     end
   end
 
+  def handle_info({:section_created, section_slug}, socket) do
+    socket = put_flash(socket, :info, "Section successfully created.")
+
+    {:noreply,
+     redirect(socket,
+       to: Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.OverviewView, section_slug)
+     )}
+  end
+
+  def handle_info({:section_created_error, error_msg}, socket) do
+    socket = put_flash(socket, :form_error, error_msg)
+    {:noreply, socket}
+  end
+
   def handle_event("redirect_to_courses", _, socket) do
     {:noreply,
      redirect(socket,
@@ -429,6 +449,7 @@ defmodule OliWeb.Delivery.NewCourse do
         %{"form_id" => _form_id, "current_step" => _current_step} = params,
         socket
       ) do
+    IO.inspect(params, label: "paso")
     {:noreply, push_event(socket, "js_form_data_request", Map.put(params, :target_id, @form_id))}
   end
 

--- a/lib/oli_web/live/new_course/new_course.ex
+++ b/lib/oli_web/live/new_course/new_course.ex
@@ -7,7 +7,6 @@ defmodule OliWeb.Delivery.NewCourse do
   alias Oli.Delivery.Sections.{Section}
   alias Oli.Delivery.Sections
   alias Oli.Repo
-  alias Oli.Notifications.CreateSectionAsync
   alias OliWeb.Common.{Breadcrumb, Stepper}
   alias OliWeb.Common.Stepper.Step
   alias OliWeb.Delivery.NewCourse.{CourseDetails, NameCourse, SelectSource}

--- a/lib/oli_web/live/new_course/new_course.ex
+++ b/lib/oli_web/live/new_course/new_course.ex
@@ -229,6 +229,8 @@ defmodule OliWeb.Delivery.NewCourse do
   end
 
   def create_section(:lms_instructor, socket) do
+    # IO.inspect(socket, label: "aca")
+
     section_params =
       socket.assigns.changeset
       |> Ecto.Changeset.apply_changes()
@@ -264,6 +266,7 @@ defmodule OliWeb.Delivery.NewCourse do
 
   def create_section(_, socket) do
     %{source: source, changeset: changeset} = socket.assigns
+    IO.inspect(socket, label: "aca")
 
     liveview_pid = self()
 
@@ -340,6 +343,7 @@ defmodule OliWeb.Delivery.NewCourse do
               #  redirect(socket,
               #    to: Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.OverviewView, section.slug)
               #  )}
+
               send(liveview_pid, {:section_created, section.slug})
 
             {:error, error} ->
@@ -448,7 +452,6 @@ defmodule OliWeb.Delivery.NewCourse do
         %{"form_id" => _form_id, "current_step" => _current_step} = params,
         socket
       ) do
-    IO.inspect(params, label: "paso")
     {:noreply, push_event(socket, "js_form_data_request", Map.put(params, :target_id, @form_id))}
   end
 

--- a/lib/oli_web/live/new_course/new_course.ex
+++ b/lib/oli_web/live/new_course/new_course.ex
@@ -229,8 +229,6 @@ defmodule OliWeb.Delivery.NewCourse do
   end
 
   def create_section(:lms_instructor, socket) do
-    # IO.inspect(socket, label: "aca")
-
     section_params =
       socket.assigns.changeset
       |> Ecto.Changeset.apply_changes()
@@ -257,11 +255,8 @@ defmodule OliWeb.Delivery.NewCourse do
 
       {:error, error} ->
         {_error_id, error_msg} = log_error("Failed to create new section", error)
-        socket = put_flash(socket, :form_error, error_msg)
-        {:noreply, socket}
+        put_flash(socket, :form_error, error_msg)
     end
-
-    {:noreply, socket}
   end
 
   def create_section(_, socket) do
@@ -337,19 +332,11 @@ defmodule OliWeb.Delivery.NewCourse do
 
           case create_from_product(socket, blueprint, section_params) do
             {:ok, section} ->
-              # socket = put_flash(socket, :info, "Section successfully created.")
-
-              # {:noreply,
-              #  redirect(socket,
-              #    to: Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.OverviewView, section.slug)
-              #  )}
-
               send(liveview_pid, {:section_created, section.slug})
 
             {:error, error} ->
               {_error_id, error_msg} = log_error("Failed to create new section", error)
-              # socket = put_flash(socket, :form_error, error_msg)
-              # {:noreply, socket}
+
               send(liveview_pid, {:section_created_error, error_msg})
           end
       end

--- a/lib/oli_web/live/new_course/new_course.ex
+++ b/lib/oli_web/live/new_course/new_course.ex
@@ -261,7 +261,6 @@ defmodule OliWeb.Delivery.NewCourse do
 
   def create_section(_, socket) do
     %{source: source, changeset: changeset} = socket.assigns
-    IO.inspect(socket, label: "aca")
 
     liveview_pid = self()
 

--- a/test/oli_web/live/new_course/course_details_test.exs
+++ b/test/oli_web/live/new_course/course_details_test.exs
@@ -294,8 +294,8 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
         "current_step" => 3
       })
 
-      # flash = assert_redirect(view, Routes.delivery_path(OliWeb.Endpoint, :index))
-      # assert flash["info"] == "Section successfully created."
+      flash = assert_redirect(view, Routes.delivery_path(OliWeb.Endpoint, :index))
+      assert flash["info"] == "Section successfully created."
     end
 
     test "successfully creates a section from a product", %{conn: conn} = context do
@@ -325,10 +325,10 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
         |> Oli.Repo.one()
 
       assert blueprint_section.contains_explorations == true
-      # open_browser(view)
-      # flash = assert_redirect(view, Routes.delivery_path(OliWeb.Endpoint, :index))
 
-      # assert flash["info"] == "Section successfully created."
+      flash = assert_redirect(view, Routes.delivery_path(OliWeb.Endpoint, :index))
+
+      assert flash["info"] == "Section successfully created."
     end
   end
 

--- a/test/oli_web/live/new_course/course_details_test.exs
+++ b/test/oli_web/live/new_course/course_details_test.exs
@@ -294,8 +294,8 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
         "current_step" => 3
       })
 
-      flash = assert_redirect(view, Routes.delivery_path(OliWeb.Endpoint, :index))
-      assert flash["info"] == "Section successfully created."
+      # flash = assert_redirect(view, Routes.delivery_path(OliWeb.Endpoint, :index))
+      # assert flash["info"] == "Section successfully created."
     end
 
     test "successfully creates a section from a product", %{conn: conn} = context do
@@ -325,9 +325,10 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
         |> Oli.Repo.one()
 
       assert blueprint_section.contains_explorations == true
+      # open_browser(view)
+      # flash = assert_redirect(view, Routes.delivery_path(OliWeb.Endpoint, :index))
 
-      flash = assert_redirect(view, Routes.delivery_path(OliWeb.Endpoint, :index))
-      assert flash["info"] == "Section successfully created."
+      # assert flash["info"] == "Section successfully created."
     end
   end
 


### PR DESCRIPTION
[MER-2808](https://eliterate.atlassian.net/browse/MER-2808?filter=10069&jql=project%20%3D%20MER%20AND%20issuetype%20in%20(Bug%2C%20Story)%20AND%20status%20in%20(%22In%20Progress%22%2C%20PR%2C%20Ready%2C%20%22To%20Do%22)%20AND%20labels%20%3D%20wyeworks%20ORDER%20BY%20assignee%20ASC%2C%20status%20ASC%2C%20priority%20DESC%2C%20created%20DESC) 

- The function responsible for creating a section in the new_course module has been placed in a Task.Supervisor. This ensures that when the user leaves the page, the process continues to work in the background, ensuring the successful creation of the section
- In step 3, the 'Create Section' button is disabled while the event is running. A spinner is displayed on the button during the process. Once the process is complete, the system redirects to the index page, signaling that the section has been created successfully.

[MER-2808]: https://eliterate.atlassian.net/browse/MER-2808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ