### PR TITLE
[BUG FIX] [MER-2805] Do not allow an student to start an attempt without a password

### DIFF
--- a/lib/oli/delivery/settings.ex
+++ b/lib/oli/delivery/settings.ex
@@ -194,12 +194,11 @@ defmodule Oli.Delivery.Settings do
 
   def show_feedback?(nil), do: true
 
-  def check_password(_effective_settings, ""), do: {:allowed}
+  def check_password(_effective_settings, ""), do: {:empty_password}
   def check_password(_effective_settings, nil), do: {:allowed}
 
-  def check_password(%Combined{password: password}, received_password)
-      when password == received_password,
-      do: {:allowed}
+  def check_password(%Combined{password: password}, password),
+    do: {:allowed}
 
   def check_password(_, _), do: {:invalid_password}
 end

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -1166,6 +1166,9 @@ defmodule OliWeb.PageDeliveryController do
       {:invalid_password} ->
         {:error, "Incorrect password"}
 
+      {:empty_password} ->
+        {:error, "Empty password"}
+
       {:before_start_date} ->
         {:error, before_start_date_message(conn, effective_settings)}
     end

--- a/test/oli/delivery/settings_test.exs
+++ b/test/oli/delivery/settings_test.exs
@@ -330,7 +330,7 @@ defmodule Oli.Delivery.SettingsTest do
   end
 
   test "check_password/2 returns allowed when the received password is empty" do
-    assert Settings.check_password(%{}, "") == {:allowed}
+    assert Settings.check_password(%{}, "") == {:empty_password}
   end
 
   test "check_password/2 returns allowed when the received password is equal to the actual password" do

--- a/test/oli/delivery/settings_test.exs
+++ b/test/oli/delivery/settings_test.exs
@@ -329,7 +329,7 @@ defmodule Oli.Delivery.SettingsTest do
     assert Settings.check_password(%{}, nil) == {:allowed}
   end
 
-  test "check_password/2 returns allowed when the received password is empty" do
+  test "check_password/2 returns Empty password when the received password is empty" do
     assert Settings.check_password(%{}, "") == {:empty_password}
   end
 


### PR DESCRIPTION
[MER-2763](https://eliterate.atlassian.net/browse/MER-2763) 

- When the method **check_settings_before_attempt** in the module page_delivery_controller on the **with** when call **Settings.check_password/2** received_password == **nil**, not allow the student to start the attempt

[MER-2763]: https://eliterate.atlassian.net/browse/MER-2763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ