### PR TITLE
[BUGFIX][MER-2824] Pagination is broken in manage section assignments view

### DIFF
--- a/lib/oli_web/live/sections/assessment_settings/settings_table.ex
+++ b/lib/oli_web/live/sections/assessment_settings/settings_table.ex
@@ -5,7 +5,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTable do
   import OliWeb.ErrorHelpers
   import Ecto.Query, only: [from: 2]
 
-  alias OliWeb.Common.{FormatDateTime, PagedTable, SearchInput, Params}
+  alias OliWeb.Common.{FormatDateTime, PagedTable, SearchInput, Params, Paging}
   alias OliWeb.Common.Utils, as: CommonUtils
 
   alias OliWeb.Sections.AssessmentSettings.SettingsTableModel
@@ -135,6 +135,13 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTable do
           />
         </form>
       </div>
+      <Paging.render
+        id="header_paging"
+        total_count={@total_count}
+        offset={@params.offset}
+        limit={@params.limit}
+        click={JS.push("paged_table_page_change", target: @myself)}
+      />
       <form
         id={"form-#{@form_id}"}
         for="settings_table"
@@ -146,10 +153,10 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTable do
           total_count={@total_count}
           offset={@params.offset}
           limit={@params.limit}
-          page_change={JS.push("paged_table_page_change", target: @myself)}
           sort={JS.push("paged_table_sort", target: @myself)}
           additional_table_class="instructor_dashboard_table"
           show_bottom_paging={false}
+          show_top_paging={false}
           render_top_info={false}
         />
       </form>


### PR DESCRIPTION
[MER-2824](https://eliterate.atlassian.net/browse/MER-2824)

This PR fixes the pagination error that was happening in the `Assignments Settings` view. 

It seems to be conflicting with events that are executed within the same table.

The solution was to move the paging component outside the form that wrap the table to avoid such conflicts.

https://github.com/Simon-Initiative/oli-torus/assets/16328384/57bf3116-dcd2-4555-b862-d3bc603953ed



[MER-2824]: https://eliterate.atlassian.net/browse/MER-2824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ