### PR TITLE
MER-2839 adding repeated email addresses crash enrollment invitation modal

### DIFF
--- a/assets/src/hooks/email_list.ts
+++ b/assets/src/hooks/email_list.ts
@@ -14,16 +14,16 @@ const isEmailAlreadyIncluded = (email: string): boolean => {
   return emailList.includes(email);
 };
 
-export const EmailList = {
-  maybePushEventToTarget(phxTarget: string | null, phxEvent: string | null, value: string) {
-    console.log(phxTarget);
-    if (phxTarget) {
-      this.pushEventTo(`#${phxTarget}`, phxEvent, { value: value });
-    } else {
-      this.pushEvent(phxEvent, { value });
-    }
-  },
+const pushEventToTarget = (
+  element: any,
+  phxTarget: string | null,
+  phxEvent: string | null,
+  value: string | string[],
+) => {
+  element.pushEventTo(`#${phxTarget}`, phxEvent, { value: value });
+};
 
+export const EmailList = {
   refresh() {
     const element = this.el as HTMLDivElement;
     const phxEvent = element.getAttribute('phx-event');
@@ -47,13 +47,11 @@ export const EmailList = {
     input.addEventListener('blur', () => {
       const value = input.value.trim();
 
-      if (isEmailAlreadyIncluded(value)) {
-        input.value = '';
-      }
+      if (isEmailAlreadyIncluded(value) || !isValidEmail(value)) input.value = '';
 
       if (isValidEmail(value)) {
-        this.maybePushEventToTarget(phxTarget, phxEvent, value);
-      } else {
+        pushEventToTarget(this, phxTarget, phxEvent, value);
+        // Don't delete the next line otherwise the event is send twice
         input.value = '';
       }
     });
@@ -65,9 +63,7 @@ export const EmailList = {
 
       const emails = parseEmails(pastedText);
 
-      if (emails.length) {
-        this.maybePushEventToTarget(phxTarget, phxEvent, emails);
-      }
+      if (emails.length) pushEventToTarget(this, phxTarget, phxEvent, emails);
     });
   },
   mounted() {

--- a/assets/src/hooks/email_list.ts
+++ b/assets/src/hooks/email_list.ts
@@ -51,7 +51,7 @@ export const EmailList = {
 
       if (isValidEmail(value)) {
         pushEventToTarget(this, phxTarget, phxEvent, value);
-        // Don't delete the next line otherwise the event is send twice
+        // Don't delete the next line otherwise the event is sent twice
         input.value = '';
       }
     });

--- a/assets/src/hooks/email_list.ts
+++ b/assets/src/hooks/email_list.ts
@@ -4,6 +4,16 @@ const isValidEmail = (email: string): boolean =>
 const parseEmails = (content: string): string[] =>
   content.match(/[a-zA-Z0-9._+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,6}/g) || [];
 
+const isEmailAlreadyIncluded = (email: string): boolean => {
+  const enrollments_email_list_div = document.getElementById(
+    'enrollments_email_list',
+  ) as HTMLDivElement;
+  const divCollection = enrollments_email_list_div!.getElementsByTagName('div') as HTMLCollection;
+  const arr = [].slice.call(divCollection);
+  const emailList = arr.map((element: any) => element.querySelector('p').innerHTML);
+  return emailList.includes(email);
+};
+
 export const EmailList = {
   maybePushEventToTarget(phxTarget: string | null, phxEvent: string | null, value: string) {
     console.log(phxTarget);
@@ -36,6 +46,11 @@ export const EmailList = {
     });
     input.addEventListener('blur', () => {
       const value = input.value.trim();
+
+      if (isEmailAlreadyIncluded(value)) {
+        input.value = '';
+      }
+
       if (isValidEmail(value)) {
         this.maybePushEventToTarget(phxTarget, phxEvent, value);
       } else {

--- a/lib/oli_web/components/delivery/students/students.ex
+++ b/lib/oli_web/components/delivery/students/students.ex
@@ -615,15 +615,11 @@ defmodule OliWeb.Components.Delivery.Students do
     end)
   end
 
-  defp remove_duplicates(current_elements, new_elements) when is_list(new_elements) do
-    MapSet.union(MapSet.new(current_elements), MapSet.new(new_elements))
-    |> MapSet.to_list()
-  end
-
   defp remove_duplicates(current_elements, new_elements) do
-    current_elements
+    new_elements
+    |> List.wrap()
     |> MapSet.new()
-    |> MapSet.put(new_elements)
+    |> MapSet.union(MapSet.new(current_elements))
     |> MapSet.to_list()
   end
 end

--- a/lib/oli_web/components/delivery/students/students.ex
+++ b/lib/oli_web/components/delivery/students/students.ex
@@ -306,7 +306,7 @@ defmodule OliWeb.Components.Delivery.Students do
       </p>
       <OliWeb.Components.EmailList.render
         id="enrollments_email_list"
-        users_list={@add_enrollments_emails}
+        emails_list={@add_enrollments_emails}
         on_update="add_enrollments_update_list"
         on_remove="add_enrollments_remove_from_list"
         target={@target}
@@ -442,11 +442,11 @@ defmodule OliWeb.Components.Delivery.Students do
     {:noreply, socket}
   end
 
-  def handle_event("add_enrollments_remove_from_list", %{"user" => user}, socket) do
-    add_enrollments_emails = Enum.filter(socket.assigns.add_enrollments_emails, &(&1 != user))
+  def handle_event("add_enrollments_remove_from_list", %{"email" => email}, socket) do
+    add_enrollments_emails = Enum.filter(socket.assigns.add_enrollments_emails, &(&1 != email))
 
     add_enrollments_users_not_found =
-      Enum.filter(socket.assigns.add_enrollments_users_not_found, &(&1 != user))
+      Enum.filter(socket.assigns.add_enrollments_users_not_found, &(&1 != email))
 
     step =
       cond do

--- a/lib/oli_web/components/delivery/students/students.ex
+++ b/lib/oli_web/components/delivery/students/students.ex
@@ -423,31 +423,21 @@ defmodule OliWeb.Components.Delivery.Students do
 
   def handle_event("add_enrollments_update_list", %{"value" => list}, socket)
       when is_list(list) do
-    add_enrollments_emails = socket.assigns.add_enrollments_emails
+    current_emails = socket.assigns.add_enrollments_emails
 
-    socket =
-      if list != [] do
-        add_enrollments_emails = Enum.concat(add_enrollments_emails, list) |> Enum.uniq()
+    maybe_updated_add_enrollments_emails = remove_duplicates(current_emails, list)
 
-        assign(socket, %{
-          add_enrollments_emails: add_enrollments_emails
-        })
-      end
+    socket = assign(socket, add_enrollments_emails: maybe_updated_add_enrollments_emails)
 
     {:noreply, socket}
   end
 
   def handle_event("add_enrollments_update_list", %{"value" => value}, socket) do
-    add_enrollments_emails = socket.assigns.add_enrollments_emails
+    current_emails = socket.assigns.add_enrollments_emails
 
-    socket =
-      if String.length(value) != 0 && !Enum.member?(add_enrollments_emails, value) do
-        add_enrollments_emails = add_enrollments_emails ++ [String.downcase(value)]
+    maybe_updated_add_enrollments_emails = remove_duplicates(current_emails, value)
 
-        assign(socket, %{
-          add_enrollments_emails: add_enrollments_emails
-        })
-      end
+    socket = assign(socket, add_enrollments_emails: maybe_updated_add_enrollments_emails)
 
     {:noreply, socket}
   end
@@ -622,5 +612,17 @@ defmodule OliWeb.Components.Delivery.Students do
     Map.filter(params, fn {key, value} ->
       @default_params[key] != value
     end)
+  end
+
+  defp remove_duplicates(current_elements, new_elements) when is_list(new_elements) do
+    MapSet.union(MapSet.new(current_elements), MapSet.new(new_elements))
+    |> MapSet.to_list()
+  end
+
+  defp remove_duplicates(current_elements, new_elements) do
+    current_elements
+    |> MapSet.new()
+    |> MapSet.put(new_elements)
+    |> MapSet.to_list()
   end
 end

--- a/lib/oli_web/components/delivery/students/students.ex
+++ b/lib/oli_web/components/delivery/students/students.ex
@@ -213,6 +213,7 @@ defmodule OliWeb.Components.Delivery.Students do
           add_enrollments_users_not_found={@add_enrollments_users_not_found}
           section_slug={@section_slug}
           target={@id}
+          myself={@myself}
         />
       </.live_component>
       <div class="bg-white dark:bg-gray-800 shadow-sm">
@@ -313,7 +314,7 @@ defmodule OliWeb.Components.Delivery.Students do
       />
       <label class="flex flex-col mt-4 w-40 ml-auto">
         <small class="torus-small uppercase">Role</small>
-        <form class="w-full" phx-change="add_enrollments_change_selected_role">
+        <form class="w-full" phx-change="add_enrollments_change_selected_role" phx-target={@myself}>
           <select name="role" class="torus-select w-full">
             <option selected={:instructor == @add_enrollments_selected_role} value={:instructor}>
               Instructor

--- a/lib/oli_web/components/email_list.ex
+++ b/lib/oli_web/components/email_list.ex
@@ -2,16 +2,16 @@ defmodule OliWeb.Components.EmailList do
   use Phoenix.Component
 
   attr :id, :string, required: true
-  attr :users_list, :list, required: true
+  attr :emails_list, :list, required: true
   attr :on_update, :string, required: true
   attr :on_remove, :string, required: true
   attr :target, :string, required: false, default: nil
 
   attr :is_list_empty, :boolean, default: true
-  attr :current_user, :string, default: ""
+  attr :current_email, :string, default: ""
 
   def render(assigns) do
-    assigns = assign(assigns, :is_list_empty, List.first(assigns.users_list) == nil)
+    assigns = assign(assigns, :is_list_empty, List.first(assigns.emails_list) == nil)
 
     ~H"""
     <div
@@ -21,13 +21,13 @@ defmodule OliWeb.Components.EmailList do
       phx-event={@on_update}
       phx-target-id={@target}
     >
-      <%= for user <- @users_list do %>
+      <%= for email <- @emails_list do %>
         <div class="rounded-md bg-gray-100 dark:bg-neutral-600 cursor-default p-2 shadow-md flex items-center gap-2 user-email max-h-80 scroll-y-overflow">
-          <p><%= user %></p>
+          <p><%= email %></p>
           <button
             phx-click={@on_remove}
             phx-target={if @target, do: "##{@target}"}
-            phx-value-user={user}
+            phx-value-email={email}
             class="close"
           >
             <i class="fa-solid fa-xmark mt-0" />
@@ -37,7 +37,7 @@ defmodule OliWeb.Components.EmailList do
       <input
         placeholder={if @is_list_empty, do: "user@email.com", else: nil}
         class="p-2 outline-none"
-        value={@current_user}
+        value={@current_email}
       />
     </div>
     """

--- a/test/oli_web/live/delivery/instructor_dashboard/reports/students_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/reports/students_tab_test.exs
@@ -683,7 +683,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.StudentsTabTest do
       # Remove an email from the "Users not found" list
       view
       |> with_target("#students_table")
-      |> render_hook("add_enrollments_remove_from_list", %{user: non_existant_email_2})
+      |> render_hook("add_enrollments_remove_from_list", %{email: non_existant_email_2})
 
       refute has_element?(
                view,


### PR DESCRIPTION
This PR should fix the bug reported in [MER-2839](https://eliterate.atlassian.net/browse/MER-2839) and others.

The list of bugs found are:
1. When an email is duplicate in the list
2. When an email is added, deleted and added it again
3. When triggering the Role dropdown

These can be tested on the UI.

Another bug that can only be seen on the backend or using the devs tool on a browser is sending 2 `add_enrollments_update_list` events for conditions 1 and 2 from the previous list.



[MER-2839]: https://eliterate.atlassian.net/browse/MER-2839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ