### PR TITLE
[BUGFIX][MER-2778] Fix hyperlink to another page

### DIFF
--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -667,8 +667,8 @@ defmodule Oli.Rendering.Content.Html do
          opts \\ []
        ) do
     href =
-      case section_slug do
-        nil ->
+      cond do
+        section_slug in [nil, project_slug] ->
           case mode do
             :author_preview ->
               "/authoring/project/#{project_slug}/preview/#{revision_slug_from_course_link(href)}"
@@ -677,7 +677,7 @@ defmodule Oli.Rendering.Content.Html do
               "#"
           end
 
-        section_slug ->
+        section_slug != project_slug ->
           # rewrite internal link using section slug and revision slug
           case mode do
             :instructor_preview ->

--- a/test/oli_web/controllers/resource_controller_test.exs
+++ b/test/oli_web/controllers/resource_controller_test.exs
@@ -133,6 +133,23 @@ defmodule OliWeb.ResourceControllerTest do
       assert html_response(conn, 200) =~ "<div class=\"nav-title\">#{revision1.title}</div>"
     end
 
+    test "renders page preview with hyperlink to another page", %{
+      conn: conn,
+      project: project,
+      revision1: revision1,
+      revision2: revision2
+    } do
+      {:ok, revision} =
+        Oli.Resources.update_revision(revision1, %{
+          content: create_hyperlink_content(revision2.slug)
+        })
+
+      conn = get(conn, Routes.resource_path(conn, :preview, project.slug, revision.slug))
+
+      assert html_response(conn, 200) =~
+               "<a class=\"internal-link\" href=\"/authoring/project/#{project.slug}/preview/#{revision2.slug}\">"
+    end
+
     test "renders error when resource does not exist", %{conn: conn, project: project} do
       conn = get(conn, Routes.resource_path(conn, :preview, project.slug, "does_not_exist"))
       assert html_response(conn, 200) =~ "Not Found"
@@ -163,5 +180,34 @@ defmodule OliWeb.ResourceControllerTest do
       )
 
     {:ok, Map.merge(%{conn: conn}, seeds)}
+  end
+
+  def create_hyperlink_content(revision_2_slug) do
+    %{
+      "model" => [
+        %{
+          "children" => [
+            %{
+              "children" => [
+                %{"text" => " "},
+                %{
+                  "children" => [%{"text" => "link"}],
+                  "href" => "/course/link/#{revision_2_slug}",
+                  "id" => "1914651063",
+                  "target" => "self",
+                  "type" => "a"
+                },
+                %{"text" => ""}
+              ],
+              "id" => "3636822762",
+              "type" => "p"
+            }
+          ],
+          "id" => "481882791",
+          "purpose" => "None",
+          "type" => "content"
+        }
+      ]
+    }
   end
 end


### PR DESCRIPTION
[MER-2778](https://eliterate.atlassian.net/browse/MER-2778)

This PR aims to fix the error that happens when accessing a `hyperlink` from the preview page of a page in a curriculum.

The change fixes the URL that is generated when adding a hyperlink to another section of the course. 



https://github.com/Simon-Initiative/oli-torus/assets/16328384/f35301dc-3568-4e26-8eda-96ebec2ba975





[MER-2778]: https://eliterate.atlassian.net/browse/MER-2778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ