### PR TITLE
[BUGFIX][MER-2765] Module and unit numbers still displayed after hiding them

### DIFF
--- a/assets/src/components/delivery/CourseContentOutline.tsx
+++ b/assets/src/components/delivery/CourseContentOutline.tsx
@@ -8,6 +8,7 @@ interface CourseContentOutlineProps {
   projectSlug: MaybeSlug;
   hierarchy: any;
   isPreview?: boolean;
+  displayItemNumbering?: boolean;
 }
 
 export const CourseContentOutline = ({
@@ -15,6 +16,7 @@ export const CourseContentOutline = ({
   projectSlug,
   hierarchy,
   isPreview,
+  displayItemNumbering,
 }: CourseContentOutlineProps) => {
   const items = flatten({ ...hierarchy, type: 'root' }, sectionSlug, projectSlug, isPreview);
   const active = items.find((i: FlattenedItem) => i.isActive);
@@ -43,6 +45,7 @@ export const CourseContentOutline = ({
             projectSlug={projectSlug}
             isPreview={isPreview}
             activeContainerSlug={activeContainerSlug}
+            displayItemNumbering={displayItemNumbering}
           />
         ))}
       </div>
@@ -167,6 +170,7 @@ interface PageItemProps extends FlattenedItem {
   sectionSlug: MaybeSlug;
   projectSlug: MaybeSlug;
   isPreview: boolean | undefined;
+  displayItemNumbering: boolean | undefined;
 }
 
 const PageItem = ({
@@ -181,6 +185,7 @@ const PageItem = ({
   containerSlug,
   activeContainerSlug,
   isPreview,
+  displayItemNumbering,
 }: PageItemProps) => (
   <a
     id={`outline-item-${slug}`}
@@ -197,7 +202,7 @@ const PageItem = ({
   >
     {type === 'container' ? (
       <div className="font-bold" style={{ marginLeft: level * 20 }}>
-        {label + ' ' + index + ': ' + title}
+        {`${label}${displayItemNumbering ? ` ${index}:` : ':'} ${title}`}
       </div>
     ) : (
       <div

--- a/lib/oli_web/components/delivery/nav_sidebar.ex
+++ b/lib/oli_web/components/delivery/nav_sidebar.ex
@@ -83,7 +83,12 @@ defmodule OliWeb.Components.Delivery.NavSidebar do
         name: "Course Content",
         popout: %{
           component: "Components.CourseContentOutline",
-          props: %{hierarchy: hierarchy, sectionSlug: section.slug, isPreview: true}
+          props: %{
+            hierarchy: hierarchy,
+            sectionSlug: section.slug,
+            isPreview: true,
+            displayItemNumbering: section.display_curriculum_item_numbering
+          }
         },
         active: is_active(assigns.path_info, :content)
       },
@@ -177,7 +182,11 @@ defmodule OliWeb.Components.Delivery.NavSidebar do
         name: "Course Content",
         popout: %{
           component: "Components.CourseContentOutline",
-          props: %{hierarchy: hierarchy, sectionSlug: assigns[:section].slug}
+          props: %{
+            hierarchy: hierarchy,
+            sectionSlug: assigns[:section].slug,
+            displayItemNumbering: assigns[:section].display_curriculum_item_numbering
+          }
         },
         active: is_active(path_info, :content)
       },


### PR DESCRIPTION
[MER-2765](https://eliterate.atlassian.net/browse/MER-2765)

This PR aims to fix the issue caused when an instructor modifies the option `Display curriculum item numbers`, so, if this option is enabled, the curriculum items should be displayed numbered and if it is disabled, they should not be displayed numbered. 

It happened that in the sidebar, when the course content menu was displayed, this functionality did not work.  


https://github.com/Simon-Initiative/oli-torus/assets/16328384/ca6ba364-6e02-4fbe-aa11-d1d35e38e8a9




[MER-2765]: https://eliterate.atlassian.net/browse/MER-2765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ