### PR TITLE
[BUGFIX][MER-2776] Cannot create finished gate as instructor

### DIFF
--- a/assets/src/hooks/select_listener.ts
+++ b/assets/src/hooks/select_listener.ts
@@ -1,6 +1,6 @@
 export const SelectListener = {
   mounted() {
-    const change_event = this.el.getAttribute('phx-value-change') || 'change';
+    const change_event = this.el.getAttribute('phx-change') || 'change';
     this.el.addEventListener('change', (e: any) => {
       this.pushEvent(change_event, { id: e.target.id, value: e.target.value });
     });

--- a/lib/oli_web/live/sections/gating_and_scheduling.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling.ex
@@ -47,7 +47,7 @@ defmodule OliWeb.Sections.GatingAndScheduling do
     previous ++
       [
         Breadcrumb.new(%{
-          full_title: "Gating and Scheduling",
+          full_title: "Advanced Gating",
           link: Routes.live_path(OliWeb.Endpoint, __MODULE__, section.slug)
         })
       ]
@@ -92,7 +92,7 @@ defmodule OliWeb.Sections.GatingAndScheduling do
     {parent_gate, title} =
       case Map.get(params, "parent_gate_id") do
         nil ->
-          {nil, "Gating and Scheduling"}
+          {nil, "Advanced Gating"}
 
         id ->
           {int_id, _} = Integer.parse(id)
@@ -202,6 +202,7 @@ defmodule OliWeb.Sections.GatingAndScheduling do
         total_count={@total_count}
         offset={@offset}
         limit={@limit}
+        no_records_message="There are no gating conditions to show"
       />
 
       <div class="alert bg-gray-100 border-gray-400 dark:bg-gray-600">

--- a/lib/oli_web/live/sections/gating_and_scheduling/form.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling/form.ex
@@ -26,7 +26,7 @@ defmodule OliWeb.Sections.GatingAndScheduling.Form do
           class="form-control"
           id="conditionTypeSelect"
           phx-hook="SelectListener"
-          phx-value-change="select-condition"
+          phx-change="select-condition"
         >
           <option {maybe_type_selected(assigns, :default)} disabled hidden>
             Choose a condition...
@@ -47,7 +47,7 @@ defmodule OliWeb.Sections.GatingAndScheduling.Form do
           class="form-control"
           id="gradingPolicySelect"
           phx-hook="SelectListener"
-          phx-value-change="select-grading-policy"
+          phx-change="select-grading-policy"
         >
           <option
             :for={policy <- Oli.Delivery.Gating.GatingCondition.graded_resource_policies()}
@@ -324,6 +324,8 @@ defmodule OliWeb.Sections.GatingAndScheduling.Form do
   end
 
   def render_condition_options(%{gating_condition: %{type: :finished, data: _data}} = assigns) do
+    assigns = assign(assigns, :data, assigns.gating_condition.data)
+
     ~H"""
     <div class="form-group">
       <label for="source">Resource That Must Be Finished</label>

--- a/test/oli_web/live/sections/gating_and_scheduling_test.exs
+++ b/test/oli_web/live/sections/gating_and_scheduling_test.exs
@@ -69,7 +69,7 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
         live(conn, Routes.live_path(@endpoint, OliWeb.Sections.GatingAndScheduling, section.slug))
 
       assert html =~ "Admin"
-      assert html =~ "Gating and Scheduling"
+      assert html =~ "Advanced Gating"
     end
 
     test "renders ok description", %{conn: conn, section_1: section} do
@@ -96,7 +96,7 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
         live(conn, Routes.live_path(@endpoint, OliWeb.Sections.GatingAndScheduling, section.slug))
 
       refute html =~ "Admin"
-      assert html =~ "Gating and Scheduling"
+      assert html =~ "Advanced Gating"
     end
 
     test "mount new for instructor", %{conn: conn, section_1: section} do
@@ -486,6 +486,61 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
                created_gating_condition.data.end_datetime,
                timezone
              ) == input_end_date
+    end
+
+    test "select a type works correctly", %{conn: conn, section_1: section} do
+      {:ok, view, _html} =
+        live(
+          conn,
+          gating_condition_new_route(section.slug)
+        )
+
+      # change select option to "schedule"
+      view
+      |> element("select[phx-change=\"select-condition\"]")
+      |> render_change(%{"value" => "schedule"})
+
+      assert view
+             |> element("div[id=\"start_date\"]")
+
+      assert view
+             |> element("div[id=\"end_date\"]")
+
+      # change select option to "always open"
+      view
+      |> element("select[phx-change=\"select-condition\"]")
+      |> render_change(%{"value" => "always_open"})
+
+      assert view
+             |> element("div[class=\"alert alert-secondary\"][role=\"alert\"]")
+             |> render() =~
+               "This will always be open to this student."
+
+      # change select option to "started"
+      view
+      |> element("select[phx-change=\"select-condition\"]")
+      |> render_change(%{"value" => "started"})
+
+      assert view
+             |> element("label[for=\"source\"]")
+             |> render() =~
+               "Resource That Must Be Started"
+
+      # change select option to "finished"
+      view
+      |> element("select[phx-change=\"select-condition\"]")
+      |> render_change(%{"value" => "finished"})
+
+      assert view
+             |> element("label[for=\"source\"]")
+             |> render() =~
+               "Resource That Must Be Finished"
+
+      assert view
+             |> element("input[phx-click=\"toggle-min-score\"]")
+
+      assert view
+             |> element("input[phx-value-change=\"change-min-score\"]")
     end
   end
 


### PR DESCRIPTION
[MER-2776](https://eliterate.atlassian.net/browse/MER-2776)

This PR fixes the error that happened in the **create gating condition** view.

When changing the dropdown type to `Finished` the page would crash. 

Also changed the title, breadcrumb and the message that is passed to the paged table when there is nothing to display.

https://github.com/Simon-Initiative/oli-torus/assets/16328384/308a06e0-b0b3-4e67-9aa7-97c6642c4d93



[MER-2776]: https://eliterate.atlassian.net/browse/MER-2776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ