### PR TITLE
[PERFORMANCE] Optimize contained objectives creation

### DIFF
--- a/lib/oli_web/live/new_course/new_course.ex
+++ b/lib/oli_web/live/new_course/new_course.ex
@@ -1,6 +1,5 @@
 defmodule OliWeb.Delivery.NewCourse do
   use OliWeb, :live_view
-  require Logger
   alias Oli.Accounts
   alias Oli.Delivery
   alias Oli.Lti.LtiParams
@@ -295,11 +294,9 @@ defmodule OliWeb.Delivery.NewCourse do
 
           case create_from_publication(socket, publication, section_params) do
             {:ok, section} ->
-              Logger.info("Created section DONE")
               send(liveview_pid, {:section_created, section.slug})
 
             {:error, error} ->
-              Logger.info("Created section FAILED")
               {_error_id, error_msg} = log_error("Failed to create new section", error)
               send(liveview_pid, {:section_created_error, error_msg})
           end

--- a/lib/oli_web/live/new_course/new_course.ex
+++ b/lib/oli_web/live/new_course/new_course.ex
@@ -1,6 +1,6 @@
 defmodule OliWeb.Delivery.NewCourse do
   use OliWeb, :live_view
-
+  require Logger
   alias Oli.Accounts
   alias Oli.Delivery
   alias Oli.Lti.LtiParams
@@ -10,7 +10,7 @@ defmodule OliWeb.Delivery.NewCourse do
   alias OliWeb.Common.{Breadcrumb, Stepper}
   alias OliWeb.Common.Stepper.Step
   alias OliWeb.Delivery.NewCourse.{CourseDetails, NameCourse, SelectSource}
-
+  import Oli.Timing
   alias Lti_1p3.Tool.ContextRoles
 
   alias Phoenix.LiveView.JS
@@ -296,9 +296,11 @@ defmodule OliWeb.Delivery.NewCourse do
 
           case create_from_publication(socket, publication, section_params) do
             {:ok, section} ->
+              Logger.info("Created section DONE")
               send(liveview_pid, {:section_created, section.slug})
 
             {:error, error} ->
+              Logger.info("Created section FAILED")
               {_error_id, error_msg} = log_error("Failed to create new section", error)
               send(liveview_pid, {:section_created_error, error_msg})
           end
@@ -363,19 +365,32 @@ defmodule OliWeb.Delivery.NewCourse do
   end
 
   defp create_from_publication(socket, publication, section_params) do
+
+    mark = mark()
+
+    ms = fn v -> elapsed(v) / 1000 / 1000 end
+
     Repo.transaction(fn ->
       with {:ok, section} <- Sections.create_section(section_params),
+           _ <- Logger.info("Created section in #{ms.(mark)} ms"),
            {:ok, section} <- Sections.create_section_resources(section, publication),
+           _ <- Logger.info("Created section resources in #{ms.(mark)} ms"),
            {:ok, _} <- Sections.rebuild_contained_pages(section),
+           _ <- Logger.info("Rebuild contained pages #{ms.(mark)} ms"),
            {:ok, _} <- Sections.rebuild_contained_objectives(section),
+           _ <- Logger.info("Rebuild contained objectives #{ms.(mark)} ms"),
            {:ok, _enrollment} <- enroll(socket, section),
+           _ <- Logger.info("Enrolled #{ms.(mark)} ms"),
            {:ok, section} <-
              Oli.Delivery.maybe_update_section_contains_explorations(section),
+             _ <- Logger.info("Maybe update section contains explor #{ms.(mark)} ms"),
            {:ok, updated_section} <-
-             Oli.Delivery.maybe_update_section_contains_deliberate_practice(section) do
+             Oli.Delivery.maybe_update_section_contains_deliberate_practice(section),
+              _ <- Logger.info("Maybe update section deliberate practice #{ms.(mark)} ms") do
         updated_section
       else
         {:error, changeset} ->
+          Logger.error("Failed to create section: #{inspect(changeset)}")
           Repo.rollback(changeset)
       end
     end)
@@ -406,7 +421,7 @@ defmodule OliWeb.Delivery.NewCourse do
 
   def handle_info({:section_created, section_slug}, socket) do
     socket = put_flash(socket, :info, "Section successfully created.")
-
+    Logger.info("Handle info succeeded")
     {:noreply,
      redirect(socket,
        to: Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.OverviewView, section_slug)
@@ -415,6 +430,7 @@ defmodule OliWeb.Delivery.NewCourse do
 
   def handle_info({:section_created_error, error_msg}, socket) do
     socket = put_flash(socket, :form_error, error_msg)
+    Logger.info("Handle info failed")
     {:noreply, socket}
   end
 

--- a/lib/oli_web/live/new_course/new_course.ex
+++ b/lib/oli_web/live/new_course/new_course.ex
@@ -361,7 +361,6 @@ defmodule OliWeb.Delivery.NewCourse do
   end
 
   defp create_from_publication(socket, publication, section_params) do
-
     Repo.transaction(fn ->
       with {:ok, section} <- Sections.create_section(section_params),
            {:ok, section} <- Sections.create_section_resources(section, publication),
@@ -405,6 +404,7 @@ defmodule OliWeb.Delivery.NewCourse do
 
   def handle_info({:section_created, section_slug}, socket) do
     socket = put_flash(socket, :info, "Section successfully created.")
+
     {:noreply,
      redirect(socket,
        to: Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.OverviewView, section_slug)


### PR DESCRIPTION
The query that extracted the "contained objectives" from within `Sections.build_contained_objectives` was far too complex (a total cost of over 760 according to the postgres explain).  When run locally in dev environments with little data, the query executed quickly, but when run against realistic data sets (tokamak, heliotron) and over large courses (chem) this query was taking several minutes to execute.  On tokamak, it took 7 minutes. 

This PR breaks apart that single query into individual queries.  One to fetch the section id, one to fetch current contained pages, another to fetch the page-to-activity mapping, and a fourth to fetch the activity-to-objectives mapping.  The two that we really care about are the last two, and now on Tokamak these run very quickly:

```
Dec 20 13:06:22 tokamak oli: 13:06:22.357 [info] build_contained_objectives pages: 33.093438ms
Dec 20 13:06:22 tokamak oli: 13:06:22.406 [info] build_contained_objectives activities: 49.320548ms
```

The overall process to create a course section is now much quicker for large courses (seconds instead of several minutes). 
