### PR TITLE
[NG23-35] Lesson view with navigation

### DIFF
--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -283,6 +283,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
   attr(:current_page, :map)
   attr(:previous_page, :map)
   attr(:next_page, :map)
+  attr(:section_slug, :string)
 
   def previous_next_nav(assigns) do
     ~H"""

--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -309,6 +309,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
       <div
         :if={!is_nil(@previous_page)}
         class="grow shrink basis-0 h-10 justify-start items-center gap-6 flex z-10"
+        role="prev_page"
       >
         <div class="px-6 py-2 rounded justify-end items-center gap-2 flex">
           <.link navigate={previous_url(@previous_page, @section_slug)}>
@@ -325,6 +326,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
       <div
         :if={!is_nil(@next_page)}
         class="grow shrink basis-0 h-10 justify-end items-center gap-6 flex z-10"
+        role="next_page"
       >
         <div class="grow shrink basis-0 text-right dark:text-white text-xs font-normal">
           <%= next_title(@next_page) %>
@@ -360,7 +362,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
 
   def back_arrow(assigns) do
     ~H"""
-    <div class="flex justify-center items-center absolute top-10 left-12 z-50 p-4">
+    <div class="flex justify-center items-center absolute top-10 left-12 z-50 p-4" role="back_link">
       <.link navigate={@to} class="hover:no-underline">
         <svg
           width="34"

--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -288,9 +288,9 @@ defmodule OliWeb.Components.Delivery.Layouts do
     ~H"""
     <div
       :if={!is_nil(@current_page)}
-      class="fixed bottom-0 left-1/2 transform -translate-x-1/2 w-[720px] h-[74px] py-[17px] shadow-lg bg-white dark:bg-black rounded-tl-[40px] rounded-tr-[40px] flex justify-start items-center gap-6"
+      class="fixed bottom-0 left-1/2 -translate-x-1/2 h-[74px] py-4 shadow-lg bg-white dark:bg-black rounded-tl-[40px] rounded-tr-[40px] flex items-center gap-3 md:w-[720px] w-full"
     >
-      <div class="absolute -left-[114px] z-0">
+      <div class="hidden md:block absolute -left-[114px] z-0">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           width="170"
@@ -316,7 +316,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
             </div>
           </.link>
         </div>
-        <div class="grow shrink basis-0 dark:text-white text-xs font-normal font-['Open Sans']">
+        <div class="grow shrink basis-0 dark:text-white text-xs font-normal">
           <%= previous_title(@previous_page) %>
         </div>
       </div>
@@ -325,7 +325,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
         :if={!is_nil(@next_page)}
         class="grow shrink basis-0 h-10 justify-end items-center gap-6 flex z-10"
       >
-        <div class="grow shrink basis-0 text-right dark:text-white text-xs font-normal font-['Open Sans']">
+        <div class="grow shrink basis-0 text-right dark:text-white text-xs font-normal">
           <%= next_title(@next_page) %>
         </div>
         <div class="px-6 py-2 rounded justify-end items-center gap-2 flex">
@@ -337,7 +337,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
         </div>
       </div>
 
-      <div class="absolute -right-[114px] z-0">
+      <div class="hidden md:block absolute -right-[114px] z-0">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           width="170"
@@ -409,7 +409,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
         <div class="w-6 h-6 relative opacity-50">
           <i class="fa-solid fa-eye" />
         </div>
-        <div class="w-[132px] dark:text-white text-xs font-bold font-['Open Sans'] uppercase tracking-wide">
+        <div class="w-[132px] dark:text-white text-xs font-bold uppercase tracking-wide">
           All annotations
         </div>
       </div>

--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -280,6 +280,100 @@ defmodule OliWeb.Components.Delivery.Layouts do
     """
   end
 
+  attr(:current_page, :map)
+  attr(:previous_page, :map)
+  attr(:next_page, :map)
+
+  def previous_next_nav(assigns) do
+    ~H"""
+    <div
+      :if={!is_nil(@current_page)}
+      class="fixed bottom-0 left-1/2 transform -translate-x-1/2 w-[720px] h-[74px] py-[17px] shadow-lg bg-white dark:bg-black rounded-tl-[40px] rounded-tr-[40px] flex justify-start items-center gap-6"
+    >
+      <div class="absolute -left-[114px] z-0">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="170"
+          height="74"
+          viewBox="0 0 170 74"
+          fill="none"
+        >
+          <path
+            class="fill-white dark:fill-black"
+            d="M170 0H134C107 0 92.5 13 68.5 37C44.5 61 24.2752 74 0 74H170V0Z"
+          />
+        </svg>
+      </div>
+
+      <div
+        :if={!is_nil(@previous_page)}
+        class="grow shrink basis-0 h-10 justify-start items-center gap-6 flex z-10"
+      >
+        <div class="px-6 py-2 rounded justify-end items-center gap-2 flex">
+          <div class="w-[72px] h-10 bg-blue-600 flex items-center justify-center">
+            <.left_arrow />
+          </div>
+        </div>
+        <div class="grow shrink basis-0 dark:text-white text-xs font-normal font-['Open Sans']">
+          <%= previous_title(@previous_page) %>
+        </div>
+      </div>
+
+      <div
+        :if={!is_nil(@next_page)}
+        class="grow shrink basis-0 h-10 justify-end items-center gap-6 flex z-10"
+      >
+        <div class="grow shrink basis-0 text-right dark:text-white text-xs font-normal font-['Open Sans']">
+          <%= next_title(@next_page) %>
+        </div>
+        <div class="px-6 py-2 rounded justify-end items-center gap-2 flex">
+          <div class="w-[72px] h-10 bg-blue-600 flex items-center justify-center">
+            <.right_arrow />
+          </div>
+        </div>
+      </div>
+
+      <div class="absolute -right-[114px] z-0">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="170"
+          height="74"
+          viewBox="0 0 170 74"
+          fill="none"
+        >
+          <path
+            class="fill-white dark:fill-black"
+            d="M0 0H36C63 0 77.5 13 101.5 37C125.5 61 145.725 74 170 74H0V0Z"
+          />
+        </svg>
+      </div>
+    </div>
+    """
+  end
+
+  defp left_arrow(assigns) do
+    ~H"""
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+      <path d="M7.825 13H20V11H7.825L13.425 5.4L12 4L4 12L12 20L13.425 18.6L7.825 13Z" fill="white" />
+    </svg>
+    """
+  end
+
+  defp right_arrow(assigns) do
+    ~H"""
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      class="rotate-180"
+    >
+      <path d="M7.825 13H20V11H7.825L13.425 5.4L12 4L4 12L12 20L13.425 18.6L7.825 13Z" fill="white" />
+    </svg>
+    """
+  end
+
   def user_given_name(%SessionContext{user: user, author: author}) do
     case {user, author} do
       {%User{guest: true}, _} ->

--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -310,9 +310,11 @@ defmodule OliWeb.Components.Delivery.Layouts do
         class="grow shrink basis-0 h-10 justify-start items-center gap-6 flex z-10"
       >
         <div class="px-6 py-2 rounded justify-end items-center gap-2 flex">
-          <div class="w-[72px] h-10 bg-blue-600 flex items-center justify-center">
-            <.left_arrow />
-          </div>
+          <.link navigate={previous_url(@previous_page, @section_slug)}>
+            <div class="w-[72px] h-10 opacity-30 hover:opacity-40 bg-blue-600 flex items-center justify-center">
+              <.left_arrow />
+            </div>
+          </.link>
         </div>
         <div class="grow shrink basis-0 dark:text-white text-xs font-normal font-['Open Sans']">
           <%= previous_title(@previous_page) %>
@@ -327,9 +329,11 @@ defmodule OliWeb.Components.Delivery.Layouts do
           <%= next_title(@next_page) %>
         </div>
         <div class="px-6 py-2 rounded justify-end items-center gap-2 flex">
-          <div class="w-[72px] h-10 bg-blue-600 flex items-center justify-center">
-            <.right_arrow />
-          </div>
+          <.link navigate={next_url(@next_page, @section_slug)}>
+            <div class="w-[72px] h-10 opacity-90 hover:opacity-100 bg-blue-600 flex items-center justify-center">
+              <.right_arrow />
+            </div>
+          </.link>
         </div>
       </div>
 
@@ -347,6 +351,30 @@ defmodule OliWeb.Components.Delivery.Layouts do
           />
         </svg>
       </div>
+    </div>
+    """
+  end
+
+  attr(:to, :string)
+
+  def back_arrow(assigns) do
+    ~H"""
+    <div class="flex justify-center items-center absolute top-10 left-12 z-50 p-4">
+      <.link navigate={@to} class="hover:no-underline">
+        <svg
+          width="34"
+          height="33"
+          viewBox="0 0 34 33"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          class="hover:opacity-90 hover:cursor-pointer"
+        >
+          <path
+            d="M17.0459 32.5278C8.19971 32.5278 0.884277 25.2124 0.884277 16.3662C0.884277 7.50391 8.18359 0.20459 17.0298 0.20459C25.8921 0.20459 33.2075 7.50391 33.2075 16.3662C33.2075 25.2124 25.8921 32.5278 17.0459 32.5278ZM17.0459 30.4331C24.8447 30.4331 31.1289 24.1489 31.1289 16.3662C31.1289 8.56738 24.8286 2.2832 17.0298 2.2832C9.24707 2.2832 2.979 8.56738 2.979 16.3662C2.979 24.1489 9.24707 30.4331 17.0459 30.4331ZM20.1235 24.2778C19.7852 24.6162 19.1567 24.6001 18.7861 24.2456L11.8252 17.5747C11.1162 16.9141 11.1001 15.8184 11.8252 15.1416L18.7861 8.4707C19.189 8.1001 19.7529 8.1001 20.1235 8.43848C20.5103 8.79297 20.5103 9.42139 20.1235 9.79199L13.2593 16.3501L20.1235 22.9404C20.5103 23.2949 20.5103 23.8911 20.1235 24.2778Z"
+            fill="#9D9D9D"
+          />
+        </svg>
+      </.link>
     </div>
     """
   end
@@ -371,6 +399,24 @@ defmodule OliWeb.Components.Delivery.Layouts do
     >
       <path d="M7.825 13H20V11H7.825L13.425 5.4L12 4L4 12L12 20L13.425 18.6L7.825 13Z" fill="white" />
     </svg>
+    """
+  end
+
+  def annotations_dropdown(assigns) do
+    ~H"""
+    <div class="flex items-center gap-2.5 absolute top-10 right-12 z-50 p-4 hidden">
+      <div class="flex py-1.5 pl-[18px] items-center gap-2.5">
+        <div class="w-6 h-6 relative opacity-50">
+          <i class="fa-solid fa-eye" />
+        </div>
+        <div class="w-[132px] dark:text-white text-xs font-bold font-['Open Sans'] uppercase tracking-wide">
+          All annotations
+        </div>
+      </div>
+      <div class="w-6 h-6 justify-center items-center gap-2.5 inline-flex">
+        <i class="fa-solid fa-caret-down" />
+      </div>
+    </div>
     """
   end
 

--- a/lib/oli_web/components/layouts/student_delivery.html.heex
+++ b/lib/oli_web/components/layouts/student_delivery.html.heex
@@ -7,36 +7,16 @@
     preview_mode={@preview_mode}
   />
 
-  <%= if Map.get(assigns, :page_view?) do %>
-    <div class="flex-1 flex flex-col mt-14">
-      <div id="page-content" class="relative justify-center items-start inline-flex">
-        <.back_arrow to={~p"/sections/#{@section.slug}/content"} />
-
-        <%!-- This feature will not be implemented in the first release. This is just a placeholder--%>
-        <.annotations_dropdown />
-
-        <%= @inner_content %>
-      </div>
-
-      <Components.Delivery.Layouts.previous_next_nav
-        current_page={@current_page}
-        previous_page={@previous_page}
-        next_page={@next_page}
-        section_slug={@section.slug}
-      />
+  <main role="main" class="flex-1 flex flex-col relative md:flex-row overscroll-contain">
+    <Components.Delivery.Layouts.sidebar_nav
+      ctx={@ctx}
+      is_system_admin={assigns[:is_system_admin] || false}
+      section={@section}
+      active_tab={assigns[:active_tab]}
+      preview_mode={@preview_mode}
+    />
+    <div class="md:w-[calc(100%-192px)] flex-1 flex flex-col md:ml-48 mt-14">
+      <%= @inner_content %>
     </div>
-  <% else %>
-    <main role="main" class="flex-1 flex flex-col relative md:flex-row overscroll-contain">
-      <Components.Delivery.Layouts.sidebar_nav
-        ctx={@ctx}
-        is_system_admin={assigns[:is_system_admin] || false}
-        section={@section}
-        active_tab={assigns[:active_tab]}
-        preview_mode={@preview_mode}
-      />
-      <div class="md:w-[calc(100%-192px)] flex-1 flex flex-col md:ml-48 mt-14">
-        <%= @inner_content %>
-      </div>
-    </main>
-  <% end %>
+  </main>
 </div>

--- a/lib/oli_web/components/layouts/student_delivery.html.heex
+++ b/lib/oli_web/components/layouts/student_delivery.html.heex
@@ -7,63 +7,36 @@
     preview_mode={@preview_mode}
   />
 
-  <main role="main" class="flex-1 flex flex-col relative md:flex-row overscroll-contain">
-    <Components.Delivery.Layouts.sidebar_nav
-      :if={!Map.get(assigns, :page_view?)}
-      ctx={@ctx}
-      is_system_admin={assigns[:is_system_admin] || false}
-      section={@section}
-      active_tab={assigns[:active_tab]}
-      preview_mode={@preview_mode}
-    />
+  <%= if Map.get(assigns, :page_view?) do %>
+    <div class="flex-1 flex flex-col mt-14">
+      <div id="page-content" class="relative justify-center items-start inline-flex">
+        <.back_arrow to={~p"/sections/#{@section.slug}/content"} />
 
-    <%= if Map.get(assigns, :page_view?) do %>
-      <div class="flex-1 flex flex-col mt-14">
-        <div id="page-content" class="relative justify-center items-start inline-flex">
-          <div class="flex justify-center items-center absolute top-10 left-12 z-50 p-4">
-            <.link navigate={~p"/sections/#{@section.slug}/content"} class="hover:no-underline">
-              <svg
-                width="34"
-                height="33"
-                viewBox="0 0 34 33"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-                class="hover:opacity-90 hover:cursor-pointer"
-              >
-                <path
-                  d="M17.0459 32.5278C8.19971 32.5278 0.884277 25.2124 0.884277 16.3662C0.884277 7.50391 8.18359 0.20459 17.0298 0.20459C25.8921 0.20459 33.2075 7.50391 33.2075 16.3662C33.2075 25.2124 25.8921 32.5278 17.0459 32.5278ZM17.0459 30.4331C24.8447 30.4331 31.1289 24.1489 31.1289 16.3662C31.1289 8.56738 24.8286 2.2832 17.0298 2.2832C9.24707 2.2832 2.979 8.56738 2.979 16.3662C2.979 24.1489 9.24707 30.4331 17.0459 30.4331ZM20.1235 24.2778C19.7852 24.6162 19.1567 24.6001 18.7861 24.2456L11.8252 17.5747C11.1162 16.9141 11.1001 15.8184 11.8252 15.1416L18.7861 8.4707C19.189 8.1001 19.7529 8.1001 20.1235 8.43848C20.5103 8.79297 20.5103 9.42139 20.1235 9.79199L13.2593 16.3501L20.1235 22.9404C20.5103 23.2949 20.5103 23.8911 20.1235 24.2778Z"
-                  fill="#9D9D9D"
-                />
-              </svg>
-            </.link>
-          </div>
-          <%!-- This feature will not be implemented in the first release. --%>
-          <div class="flex items-center gap-2.5 absolute top-10 right-12 z-50 p-4 hidden">
-            <div class="flex py-1.5 pl-[18px] items-center gap-2.5">
-              <div class="w-6 h-6 relative opacity-50">
-                <i class="fa-solid fa-eye" />
-              </div>
-              <div class="w-[132px] dark:text-white text-xs font-bold font-['Open Sans'] uppercase tracking-wide">
-                All annotations
-              </div>
-            </div>
-            <div class="w-6 h-6 justify-center items-center gap-2.5 inline-flex">
-              <i class="fa-solid fa-caret-down" />
-            </div>
-          </div>
-          <%= @inner_content %>
-        </div>
+        <%!-- This feature will not be implemented in the first release. This is just a placeholder--%>
+        <.annotations_dropdown />
 
-        <Components.Delivery.Layouts.previous_next_nav
-          current_page={@current_page}
-          previous_page={@previous_page}
-          next_page={@next_page}
-        />
+        <%= @inner_content %>
       </div>
-    <% else %>
+
+      <Components.Delivery.Layouts.previous_next_nav
+        current_page={@current_page}
+        previous_page={@previous_page}
+        next_page={@next_page}
+        section_slug={@section.slug}
+      />
+    </div>
+  <% else %>
+    <main role="main" class="flex-1 flex flex-col relative md:flex-row overscroll-contain">
+      <Components.Delivery.Layouts.sidebar_nav
+        ctx={@ctx}
+        is_system_admin={assigns[:is_system_admin] || false}
+        section={@section}
+        active_tab={assigns[:active_tab]}
+        preview_mode={@preview_mode}
+      />
       <div class="md:w-[calc(100%-192px)] flex-1 flex flex-col md:ml-48 mt-14">
         <%= @inner_content %>
       </div>
-    <% end %>
-  </main>
+    </main>
+  <% end %>
 </div>

--- a/lib/oli_web/components/layouts/student_delivery.html.heex
+++ b/lib/oli_web/components/layouts/student_delivery.html.heex
@@ -16,6 +16,10 @@
       preview_mode={@preview_mode}
     />
     <div class="md:w-[calc(100%-192px)] flex-1 flex flex-col md:ml-48 mt-14">
+      <div class="container mx-auto sticky top-4">
+        <.flash_group flash={@flash} />
+      </div>
+
       <%= @inner_content %>
     </div>
   </main>

--- a/lib/oli_web/components/layouts/student_delivery.html.heex
+++ b/lib/oli_web/components/layouts/student_delivery.html.heex
@@ -9,6 +9,7 @@
 
   <main role="main" class="flex-1 flex flex-col relative md:flex-row overscroll-contain">
     <Components.Delivery.Layouts.sidebar_nav
+      :if={!Map.get(assigns, :page_view?)}
       ctx={@ctx}
       is_system_admin={assigns[:is_system_admin] || false}
       section={@section}
@@ -16,12 +17,53 @@
       preview_mode={@preview_mode}
     />
 
-    <div class="md:w-[calc(100%-192px)] flex-1 flex flex-col md:ml-48 mt-14">
-      <div class="container mx-auto sticky top-4">
-        <.flash_group flash={@flash} />
-      </div>
+    <%= if Map.get(assigns, :page_view?) do %>
+      <div class="flex-1 flex flex-col mt-14">
+        <div id="page-content" class="relative justify-center items-start inline-flex">
+          <div class="flex justify-center items-center absolute top-10 left-12 z-50 p-4">
+            <.link navigate={~p"/sections/#{@section.slug}/content"} class="hover:no-underline">
+              <svg
+                width="34"
+                height="33"
+                viewBox="0 0 34 33"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                class="hover:opacity-90 hover:cursor-pointer"
+              >
+                <path
+                  d="M17.0459 32.5278C8.19971 32.5278 0.884277 25.2124 0.884277 16.3662C0.884277 7.50391 8.18359 0.20459 17.0298 0.20459C25.8921 0.20459 33.2075 7.50391 33.2075 16.3662C33.2075 25.2124 25.8921 32.5278 17.0459 32.5278ZM17.0459 30.4331C24.8447 30.4331 31.1289 24.1489 31.1289 16.3662C31.1289 8.56738 24.8286 2.2832 17.0298 2.2832C9.24707 2.2832 2.979 8.56738 2.979 16.3662C2.979 24.1489 9.24707 30.4331 17.0459 30.4331ZM20.1235 24.2778C19.7852 24.6162 19.1567 24.6001 18.7861 24.2456L11.8252 17.5747C11.1162 16.9141 11.1001 15.8184 11.8252 15.1416L18.7861 8.4707C19.189 8.1001 19.7529 8.1001 20.1235 8.43848C20.5103 8.79297 20.5103 9.42139 20.1235 9.79199L13.2593 16.3501L20.1235 22.9404C20.5103 23.2949 20.5103 23.8911 20.1235 24.2778Z"
+                  fill="#9D9D9D"
+                />
+              </svg>
+            </.link>
+          </div>
+          <%!-- This feature will not be implemented in the first release. --%>
+          <div class="flex items-center gap-2.5 absolute top-10 right-12 z-50 p-4 hidden">
+            <div class="flex py-1.5 pl-[18px] items-center gap-2.5">
+              <div class="w-6 h-6 relative opacity-50">
+                <i class="fa-solid fa-eye" />
+              </div>
+              <div class="w-[132px] dark:text-white text-xs font-bold font-['Open Sans'] uppercase tracking-wide">
+                All annotations
+              </div>
+            </div>
+            <div class="w-6 h-6 justify-center items-center gap-2.5 inline-flex">
+              <i class="fa-solid fa-caret-down" />
+            </div>
+          </div>
+          <%= @inner_content %>
+        </div>
 
-      <%= @inner_content %>
-    </div>
+        <Components.Delivery.Layouts.previous_next_nav
+          current_page={@current_page}
+          previous_page={@previous_page}
+          next_page={@next_page}
+        />
+      </div>
+    <% else %>
+      <div class="md:w-[calc(100%-192px)] flex-1 flex flex-col md:ml-48 mt-14">
+        <%= @inner_content %>
+      </div>
+    <% end %>
   </main>
 </div>

--- a/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
+++ b/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
@@ -9,7 +9,7 @@
 
   <div class="flex-1 flex flex-col mt-14">
     <div :if={@section} id="page-content" class="relative justify-center items-start inline-flex">
-      <.back_arrow to={~p"/sections/#{@section.slug}/content"} />
+      <.back_arrow to={~p"/sections/#{@section.slug}/learn"} />
 
       <%!-- This feature will not be implemented in the first release. This is just a placeholder--%>
       <.annotations_dropdown />

--- a/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
+++ b/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
@@ -1,0 +1,28 @@
+<div class="h-screen flex flex-col overscroll-none">
+  <Components.Delivery.Layouts.header
+    ctx={@ctx}
+    is_system_admin={assigns[:is_system_admin] || false}
+    section={@section}
+    brand={@brand}
+    preview_mode={@preview_mode}
+  />
+
+  <div class="flex-1 flex flex-col mt-14">
+    <div :if={@section} id="page-content" class="relative justify-center items-start inline-flex">
+      <.back_arrow to={~p"/sections/#{@section.slug}/content"} />
+
+      <%!-- This feature will not be implemented in the first release. This is just a placeholder--%>
+      <.annotations_dropdown />
+
+      <%= @inner_content %>
+    </div>
+
+    <Components.Delivery.Layouts.previous_next_nav
+      :if={assigns[:page_context]}
+      current_page={@current_page}
+      previous_page={@previous_page}
+      next_page={@next_page}
+      section_slug={@section.slug}
+    />
+  </div>
+</div>

--- a/lib/oli_web/components/utils.ex
+++ b/lib/oli_web/components/utils.ex
@@ -68,4 +68,34 @@ defmodule OliWeb.Components.Utils do
         false
     end
   end
+
+  # defp url_from_desc(conn, %{"type" => "container", "slug" => slug}),
+  #   do: conn.assigns.container_link_url.(slug)
+
+  # defp url_from_desc(conn, %{"type" => "page", "slug" => slug}),
+  #   do: conn.assigns.page_link_url.(slug)
+
+  # def previous_url(conn) do
+  #   url_from_desc(conn, conn.assigns.previous_page)
+  # end
+
+  # def previous_url(conn, %{"slug" => slug} = previous_page, preview_mode, section_slug) do
+  #   Routes.page_delivery_path(conn, action(preview_mode, previous_page), section_slug, slug)
+  # end
+
+  def previous_title(%{"title" => title}) do
+    title
+  end
+
+  # def next_url(conn) do
+  #   url_from_desc(conn, conn.assigns.next_page)
+  # end
+
+  # def next_url(conn, %{"slug" => slug} = next_page, preview_mode, section_slug) do
+  #   Routes.page_delivery_path(conn, action(preview_mode, next_page), section_slug, slug)
+  # end
+
+  def next_title(%{"title" => title}) do
+    title
+  end
 end

--- a/lib/oli_web/components/utils.ex
+++ b/lib/oli_web/components/utils.ex
@@ -70,7 +70,7 @@ defmodule OliWeb.Components.Utils do
     end
   end
 
-  def previous_url(%{"slug" => slug} = previous_page, section_slug) do
+  def previous_url(%{"slug" => slug}, section_slug) do
     ~p"/sections/#{section_slug}/page-ng/#{slug}"
   end
 
@@ -78,7 +78,7 @@ defmodule OliWeb.Components.Utils do
     title
   end
 
-  def next_url(%{"slug" => slug} = next_page, section_slug) do
+  def next_url(%{"slug" => slug}, section_slug) do
     ~p"/sections/#{section_slug}/page-ng/#{slug}"
   end
 

--- a/lib/oli_web/components/utils.ex
+++ b/lib/oli_web/components/utils.ex
@@ -71,7 +71,7 @@ defmodule OliWeb.Components.Utils do
   end
 
   def previous_url(%{"slug" => slug}, section_slug) do
-    ~p"/sections/#{section_slug}/page-ng/#{slug}"
+    ~p"/sections/#{section_slug}/lesson/#{slug}"
   end
 
   def previous_title(%{"title" => title}) do
@@ -79,7 +79,7 @@ defmodule OliWeb.Components.Utils do
   end
 
   def next_url(%{"slug" => slug}, section_slug) do
-    ~p"/sections/#{section_slug}/page-ng/#{slug}"
+    ~p"/sections/#{section_slug}/lesson/#{slug}"
   end
 
   def next_title(%{"title" => title}) do

--- a/lib/oli_web/components/utils.ex
+++ b/lib/oli_web/components/utils.ex
@@ -1,6 +1,7 @@
 defmodule OliWeb.Components.Utils do
-  alias Phoenix.LiveView.JS
+  use OliWeb, :verified_routes
 
+  alias Phoenix.LiveView.JS
   alias OliWeb.Common.SessionContext
   alias Oli.Accounts.{User, Author}
   alias Oli.Delivery.Sections.Section
@@ -69,31 +70,17 @@ defmodule OliWeb.Components.Utils do
     end
   end
 
-  # defp url_from_desc(conn, %{"type" => "container", "slug" => slug}),
-  #   do: conn.assigns.container_link_url.(slug)
-
-  # defp url_from_desc(conn, %{"type" => "page", "slug" => slug}),
-  #   do: conn.assigns.page_link_url.(slug)
-
-  # def previous_url(conn) do
-  #   url_from_desc(conn, conn.assigns.previous_page)
-  # end
-
-  # def previous_url(conn, %{"slug" => slug} = previous_page, preview_mode, section_slug) do
-  #   Routes.page_delivery_path(conn, action(preview_mode, previous_page), section_slug, slug)
-  # end
+  def previous_url(%{"slug" => slug} = previous_page, section_slug) do
+    ~p"/sections/#{section_slug}/page-ng/#{slug}"
+  end
 
   def previous_title(%{"title" => title}) do
     title
   end
 
-  # def next_url(conn) do
-  #   url_from_desc(conn, conn.assigns.next_page)
-  # end
-
-  # def next_url(conn, %{"slug" => slug} = next_page, preview_mode, section_slug) do
-  #   Routes.page_delivery_path(conn, action(preview_mode, next_page), section_slug, slug)
-  # end
+  def next_url(%{"slug" => slug} = next_page, section_slug) do
+    ~p"/sections/#{section_slug}/page-ng/#{slug}"
+  end
 
   def next_title(%{"title" => title}) do
     title

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -1093,7 +1093,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
   # TODO: for other courses with other hierarchy, the url might be a container url:
   # ~p"/sections/#{section_slug}/container/:revision_slug
   defp resource_url(resource_slug, section_slug) do
-    ~p"/sections/#{section_slug}/page/#{resource_slug}"
+    ~p"/sections/#{section_slug}/lesson/#{resource_slug}"
   end
 
   defp get_student_metrics(section, current_user_id) do

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -262,7 +262,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
 
   def handle_event("navigate_to_resource", %{"slug" => resource_slug}, socket) do
     {:noreply,
-     push_navigate(socket, to: resource_url(resource_slug, socket.assigns.section.slug))}
+     push_redirect(socket, to: resource_url(resource_slug, socket.assigns.section.slug))}
   end
 
   def handle_info(

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -1,18 +1,18 @@
-defmodule OliWeb.Delivery.Student.PageLive do
+defmodule OliWeb.Delivery.Student.LessonLive do
   use OliWeb, :live_view
 
   on_mount {OliWeb.LiveSessionPlugs.InitPage, :page_context}
   on_mount {OliWeb.LiveSessionPlugs.InitPage, :previous_next_index}
 
   def mount(_params, _session, socket) do
-    {:ok, assign(socket, :page_view?, true)}
+    {:ok, socket}
   end
 
   def render(%{view: :page} = assigns) do
     ~H"""
     <div class="flex pb-20 flex-col items-center gap-15 flex-1">
       <div class="flex flex-col items-center w-full">
-        <.scored_page_banner />
+        <.scored_page_banner :if={@revision.graded} />
         <div>
           <%!-- PAGE CONTENT --%>
         </div>

--- a/lib/oli_web/live/delivery/student/page_live.ex
+++ b/lib/oli_web/live/delivery/student/page_live.ex
@@ -1,0 +1,66 @@
+defmodule OliWeb.Delivery.Student.PageLive do
+  use OliWeb, :live_view
+
+  alias Oli.Delivery.{Paywall, PreviousNextIndex, Sections, Settings}
+  alias Oli.Delivery.Page.PageContext
+  alias Phoenix.LiveView.JS
+  alias Oli.Delivery.Paywall.AccessSummary
+
+  on_mount {OliWeb.LiveSessionPlugs.InitPage, :page_context}
+  on_mount {OliWeb.LiveSessionPlugs.InitPage, :previous_next_index}
+
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, :page_view?, true)}
+  end
+
+  def render(%{view: :prologue} = assigns) do
+    ~H"""
+    <div class="inline-flex flex-col items-center gap-40">
+      PROLOGUE
+      <button id="begin-attempt" class="flex px-20 py-10 justify-center items-center gap-[10px]">
+        Start Attempt
+      </button>
+    </div>
+    """
+  end
+
+  def render(%{view: :page} = assigns) do
+    ~H"""
+    <div id="all" class="flex pb-[80px] flex-col items-center gap-[60px] flex-1">
+      <div class="flex flex-col items-center self-stretch">
+        <div
+          id="disclaimer"
+          class="w-full px-[164px] py-9 bg-orange-500 bg-opacity-10 flex-col justify-center items-center gap-2.5 inline-flex"
+        >
+          <div class="px-3 py-1.5 rounded-[3px] justify-start items-start gap-2.5 inline-flex">
+            <div class="dark:text-white text-sm font-bold font-['Open Sans'] uppercase tracking-wider">
+              Scored Activity
+            </div>
+          </div>
+          <div
+            id="disclaimer-text"
+            class="w-[720px] mx-auto opacity-90 dark:text-white text-sm font-normal font-['Open Sans'] leading-[25.20px]"
+          >
+            You can start or stop at any time, and your progress will be saved. When you submit your answers using the Submit button, it will count as an attempt. So make sure you have answered all the questions before submitting.
+          </div>
+        </div>
+        <div>
+          <%!-- PAGE CONTENT --%>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  def render(%{view: :adaptive_chromeless} = assigns) do
+    ~H"""
+    ADAPTIVE CHROMELESS
+    """
+  end
+
+  def render(%{view: :error} = assigns) do
+    ~H"""
+    ERROR
+    """
+  end
+end

--- a/lib/oli_web/live/delivery/student/page_live.ex
+++ b/lib/oli_web/live/delivery/student/page_live.ex
@@ -1,11 +1,6 @@
 defmodule OliWeb.Delivery.Student.PageLive do
   use OliWeb, :live_view
 
-  alias Oli.Delivery.{Paywall, PreviousNextIndex, Sections, Settings}
-  alias Oli.Delivery.Page.PageContext
-  alias Phoenix.LiveView.JS
-  alias Oli.Delivery.Paywall.AccessSummary
-
   on_mount {OliWeb.LiveSessionPlugs.InitPage, :page_context}
   on_mount {OliWeb.LiveSessionPlugs.InitPage, :previous_next_index}
 
@@ -13,37 +8,11 @@ defmodule OliWeb.Delivery.Student.PageLive do
     {:ok, assign(socket, :page_view?, true)}
   end
 
-  def render(%{view: :prologue} = assigns) do
-    ~H"""
-    <div class="inline-flex flex-col items-center gap-40">
-      PROLOGUE
-      <button id="begin-attempt" class="flex px-20 py-10 justify-center items-center gap-[10px]">
-        Start Attempt
-      </button>
-    </div>
-    """
-  end
-
   def render(%{view: :page} = assigns) do
     ~H"""
-    <div id="all" class="flex pb-[80px] flex-col items-center gap-[60px] flex-1">
+    <div class="flex pb-[80px] flex-col items-center gap-[60px] flex-1">
       <div class="flex flex-col items-center self-stretch">
-        <div
-          id="disclaimer"
-          class="w-full px-[164px] py-9 bg-orange-500 bg-opacity-10 flex-col justify-center items-center gap-2.5 inline-flex"
-        >
-          <div class="px-3 py-1.5 rounded-[3px] justify-start items-start gap-2.5 inline-flex">
-            <div class="dark:text-white text-sm font-bold font-['Open Sans'] uppercase tracking-wider">
-              Scored Activity
-            </div>
-          </div>
-          <div
-            id="disclaimer-text"
-            class="w-[720px] mx-auto opacity-90 dark:text-white text-sm font-normal font-['Open Sans'] leading-[25.20px]"
-          >
-            You can start or stop at any time, and your progress will be saved. When you submit your answers using the Submit button, it will count as an attempt. So make sure you have answered all the questions before submitting.
-          </div>
-        </div>
+        <.scored_page_banner />
         <div>
           <%!-- PAGE CONTENT --%>
         </div>
@@ -52,15 +21,25 @@ defmodule OliWeb.Delivery.Student.PageLive do
     """
   end
 
-  def render(%{view: :adaptive_chromeless} = assigns) do
+  # As we implement more scenarios we can add more clauses to this function depending on the :view key.
+  def render(assigns) do
     ~H"""
-    ADAPTIVE CHROMELESS
+    <div></div>
     """
   end
 
-  def render(%{view: :error} = assigns) do
+  def scored_page_banner(assigns) do
     ~H"""
-    ERROR
+    <div class="w-full px-[164px] py-9 bg-orange-500 bg-opacity-10 flex-col justify-center items-center gap-2.5 inline-flex">
+      <div class="px-3 py-1.5 rounded-[3px] justify-start items-start gap-2.5 inline-flex">
+        <div class="dark:text-white text-sm font-bold font-['Open Sans'] uppercase tracking-wider">
+          Scored Activity
+        </div>
+      </div>
+      <div class="w-[720px] mx-auto opacity-90 dark:text-white text-sm font-normal font-['Open Sans'] leading-[25.20px]">
+        You can start or stop at any time, and your progress will be saved. When you submit your answers using the Submit button, it will count as an attempt. So make sure you have answered all the questions before submitting.
+      </div>
+    </div>
     """
   end
 end

--- a/lib/oli_web/live/delivery/student/page_live.ex
+++ b/lib/oli_web/live/delivery/student/page_live.ex
@@ -10,8 +10,8 @@ defmodule OliWeb.Delivery.Student.PageLive do
 
   def render(%{view: :page} = assigns) do
     ~H"""
-    <div class="flex pb-[80px] flex-col items-center gap-[60px] flex-1">
-      <div class="flex flex-col items-center self-stretch">
+    <div class="flex pb-20 flex-col items-center gap-15 flex-1">
+      <div class="flex flex-col items-center w-full">
         <.scored_page_banner />
         <div>
           <%!-- PAGE CONTENT --%>
@@ -30,13 +30,13 @@ defmodule OliWeb.Delivery.Student.PageLive do
 
   def scored_page_banner(assigns) do
     ~H"""
-    <div class="w-full px-[164px] py-9 bg-orange-500 bg-opacity-10 flex-col justify-center items-center gap-2.5 inline-flex">
-      <div class="px-3 py-1.5 rounded-[3px] justify-start items-start gap-2.5 inline-flex">
-        <div class="dark:text-white text-sm font-bold font-['Open Sans'] uppercase tracking-wider">
+    <div class="w-full lg:px-20 px-40 py-9 bg-orange-500 bg-opacity-10 flex flex-col justify-center items-center gap-2.5">
+      <div class="px-3 py-1.5 rounded justify-start items-start gap-2.5 flex">
+        <div class="dark:text-white text-sm font-bold uppercase tracking-wider">
           Scored Activity
         </div>
       </div>
-      <div class="w-[720px] mx-auto opacity-90 dark:text-white text-sm font-normal font-['Open Sans'] leading-[25.20px]">
+      <div class="max-w-[720px] w-full mx-auto opacity-90 dark:text-white text-sm font-normal leading-6">
         You can start or stop at any time, and your progress will be saved. When you submit your answers using the Submit button, it will count as an attempt. So make sure you have answered all the questions before submitting.
       </div>
     </div>

--- a/lib/oli_web/live_session_plugs/init_page.ex
+++ b/lib/oli_web/live_session_plugs/init_page.ex
@@ -5,7 +5,6 @@ defmodule OliWeb.LiveSessionPlugs.InitPage do
 
   alias Oli.Delivery.{PreviousNextIndex, Sections}
   alias Oli.Delivery.Page.PageContext
-  alias OliWeb.Common.FormatDateTime
 
   def on_mount(
         :page_context,

--- a/lib/oli_web/live_session_plugs/init_page.ex
+++ b/lib/oli_web/live_session_plugs/init_page.ex
@@ -1,0 +1,218 @@
+defmodule OliWeb.LiveSessionPlugs.InitPage do
+  use OliWeb, :verified_routes
+
+  import Phoenix.Component, only: [assign: 2]
+
+  alias Oli.Delivery.{PreviousNextIndex, Sections}
+  alias Oli.Delivery.Page.PageContext
+  alias OliWeb.Common.FormatDateTime
+
+  def on_mount(
+        :page_context,
+        %{"revision_slug" => revision_slug},
+        _session,
+        %{assigns: assigns} = socket
+      ) do
+    numbered_revisions = Sections.get_revision_indexes(assigns.section.slug)
+
+    socket =
+      PageContext.create_for_visit(
+        assigns.section,
+        revision_slug,
+        assigns.current_user,
+        assigns.datashop_session_id
+      )
+      |> init_context_state(socket)
+      |> assign(%{numbered_revisions: numbered_revisions})
+
+    {:cont, socket}
+  end
+
+  def on_mount(
+        :previous_next_index,
+        _params,
+        _session,
+        %{assigns: assigns} = socket
+      ) do
+    {:ok, {previous, next, current}, _} =
+      PreviousNextIndex.retrieve(assigns.section, assigns.page_context.page.resource_id)
+
+    IO.inspect(previous, label: "previous")
+    IO.inspect(next, label: "next")
+    IO.inspect(current, label: "current")
+
+    {:cont,
+     assign(socket,
+       previous_page: previous,
+       next_page: next,
+       current_page: current
+     )}
+  end
+
+  # Display the prologue view
+  defp init_context_state(
+         %PageContext{
+           progress_state: :not_started,
+           page: page
+         } = page_context,
+         socket
+       ) do
+    section = socket.assigns.section
+
+    # # Only consider graded attempts
+    # resource_attempts = Enum.filter(resource_attempts, & &1.revision.graded)
+    # attempts_taken = length(resource_attempts)
+
+    preview_mode = Map.get(socket.assigns, :preview_mode, false)
+
+    # # The Oli.Plugs.MaybeGatedResource plug sets the blocking_gates assign if there is a blocking
+    # # gate that prevents this learning from starting another attempt of this resource
+    # blocking_gates = Map.get(socket.assigns, :blocking_gates, [])
+
+    # new_attempt_allowed =
+    #   Settings.new_attempt_allowed(
+    #     effective_settings,
+    #     attempts_taken,
+    #     blocking_gates
+    #   )
+
+    # allow_attempt? = new_attempt_allowed == {:allowed}
+
+    # message =
+    #   case new_attempt_allowed do
+    #     {:blocking_gates} ->
+    #       Oli.Delivery.Gating.details(blocking_gates,
+    #         format_datetime: format_datetime_fn(socket.assigns.ctx)
+    #       )
+
+    #     {:no_attempts_remaining} ->
+    #       "You have no attempts remaining out of #{effective_settings.max_attempts} total attempt#{plural(effective_settings.max_attempts)}."
+
+    #     {:before_start_date} ->
+    #       before_start_date_message(socket.assigns.ctx, effective_settings)
+
+    #     {:end_date_passed} ->
+    #       "The deadline for this assignment has passed."
+
+    #     {:allowed} ->
+    #       if effective_settings.max_attempts == 0 do
+    #         "You can take this scored page an unlimited number of times"
+    #       else
+    #         attempts_remaining = effective_settings.max_attempts - attempts_taken
+
+    #         "You have #{attempts_remaining} #{Gettext.ngettext(OliWeb.Gettext, "attempt", "attempts", attempts_remaining)} remaining out of #{effective_settings.max_attempts} #{Gettext.ngettext(OliWeb.Gettext, "attempt", "attempts", effective_settings.max_attempts)}."
+    #       end
+    #   end
+
+    # resource_attempts =
+    #   Enum.filter(resource_attempts, &(&1.date_submitted != nil))
+    #   |> Enum.sort(&DateTime.before?(&1.date_submitted, &2.date_submitted))
+
+    # {:ok, {previous, next, current}, _} = PreviousNextIndex.retrieve(section, page.resource_id)
+
+    # resource_access = Core.get_resource_access(page.resource_id, section.slug, user.id)
+
+    section_resource = Sections.get_section_resource(section.id, page.resource_id)
+
+    # assign(socket, %{
+    #   view: :prologue,
+    #   resource_access: resource_access,
+    #   section_slug: section_slug,
+    #   scripts: Activities.get_activity_scripts(),
+    #   preview_mode: preview_mode,
+    #   resource_attempts: resource_attempts,
+    #   previous_page: previous,
+    #   next_page: next,
+    #   numbered_revisions: numbered_revisions,
+    #   current_page: current,
+    # page_number: section_resource.numbering_index,
+    #   title: context.page.title,
+    #   allow_attempt?: allow_attempt?,
+    #   message: message,
+    #   resource_id: page.resource_id,
+    #   slug: context.page.slug,
+    #   max_attempts: effective_settings.max_attempts,
+    #   effective_settings: effective_settings,
+    #   requires_password?:
+    #     effective_settings.password != nil and effective_settings.password != "",
+    #   section: section,
+    #   page_link_url: &Routes.page_delivery_path(conn, :page, section_slug, &1),
+    #   container_link_url: &Routes.page_delivery_path(conn, :container, section_slug, &1),
+    # revision: page_context.page,
+    #   resource_slug: context.page.slug,
+    #   bib_app_params: %{
+    #     bibReferences: context.bib_revisions
+    #   }
+    # })
+    assign(socket, %{
+      view: :prologue,
+      page_number: section_resource.numbering_index,
+      revision: page,
+      resource_slug: page.slug,
+      page_context: page_context
+    })
+  end
+
+  # Handles the 2 cases of adaptive delivery
+  #  1. A fullscreen chromeless version
+  #  2. A version inside the torus navigation with an iframe pointing to #1
+  defp init_context_state(
+         %PageContext{
+           page: %{
+             content:
+               %{
+                 "advancedDelivery" => true
+               } = content
+           }
+         } = page_context,
+         socket
+       ) do
+    view =
+      if Map.get(content, "displayApplicationChrome", false) do
+        :page
+      else
+        :adaptive_chromeless
+      end
+
+    assign(socket, %{
+      view: view,
+      page_context: page_context
+    })
+  end
+
+  defp init_context_state(
+         %PageContext{progress_state: :error} = page_context,
+         socket
+       ) do
+    assign(socket, %{
+      view: :error,
+      page_context: page_context
+    })
+  end
+
+  defp init_context_state(page_context, socket) do
+    section = socket.assigns.section
+
+    section_resource = Sections.get_section_resource(section.id, page_context.page.resource_id)
+
+    preview_mode = Map.get(socket.assigns, :preview_mode, false)
+
+    assign(socket, %{
+      view: :page,
+      page_number: section_resource.numbering_index,
+      revision: page_context.page,
+      resource_slug: page_context.page.slug,
+      page_context: page_context
+    })
+  end
+
+  defp before_start_date_message(session_context, effective_settings) do
+    "This assessment is not yet available. It will be available on #{format_datetime_fn(session_context).(effective_settings.start_date)}."
+  end
+
+  defp format_datetime_fn(session_context) do
+    fn datetime ->
+      FormatDateTime.date(datetime, ctx: session_context, precision: :minutes)
+    end
+  end
+end

--- a/lib/oli_web/live_session_plugs/init_page.ex
+++ b/lib/oli_web/live_session_plugs/init_page.ex
@@ -37,10 +37,6 @@ defmodule OliWeb.LiveSessionPlugs.InitPage do
     {:ok, {previous, next, current}, _} =
       PreviousNextIndex.retrieve(assigns.section, assigns.page_context.page.resource_id)
 
-    IO.inspect(previous, label: "previous")
-    IO.inspect(next, label: "next")
-    IO.inspect(current, label: "current")
-
     {:cont,
      assign(socket,
        previous_page: previous,
@@ -59,91 +55,8 @@ defmodule OliWeb.LiveSessionPlugs.InitPage do
        ) do
     section = socket.assigns.section
 
-    # # Only consider graded attempts
-    # resource_attempts = Enum.filter(resource_attempts, & &1.revision.graded)
-    # attempts_taken = length(resource_attempts)
-
-    preview_mode = Map.get(socket.assigns, :preview_mode, false)
-
-    # # The Oli.Plugs.MaybeGatedResource plug sets the blocking_gates assign if there is a blocking
-    # # gate that prevents this learning from starting another attempt of this resource
-    # blocking_gates = Map.get(socket.assigns, :blocking_gates, [])
-
-    # new_attempt_allowed =
-    #   Settings.new_attempt_allowed(
-    #     effective_settings,
-    #     attempts_taken,
-    #     blocking_gates
-    #   )
-
-    # allow_attempt? = new_attempt_allowed == {:allowed}
-
-    # message =
-    #   case new_attempt_allowed do
-    #     {:blocking_gates} ->
-    #       Oli.Delivery.Gating.details(blocking_gates,
-    #         format_datetime: format_datetime_fn(socket.assigns.ctx)
-    #       )
-
-    #     {:no_attempts_remaining} ->
-    #       "You have no attempts remaining out of #{effective_settings.max_attempts} total attempt#{plural(effective_settings.max_attempts)}."
-
-    #     {:before_start_date} ->
-    #       before_start_date_message(socket.assigns.ctx, effective_settings)
-
-    #     {:end_date_passed} ->
-    #       "The deadline for this assignment has passed."
-
-    #     {:allowed} ->
-    #       if effective_settings.max_attempts == 0 do
-    #         "You can take this scored page an unlimited number of times"
-    #       else
-    #         attempts_remaining = effective_settings.max_attempts - attempts_taken
-
-    #         "You have #{attempts_remaining} #{Gettext.ngettext(OliWeb.Gettext, "attempt", "attempts", attempts_remaining)} remaining out of #{effective_settings.max_attempts} #{Gettext.ngettext(OliWeb.Gettext, "attempt", "attempts", effective_settings.max_attempts)}."
-    #       end
-    #   end
-
-    # resource_attempts =
-    #   Enum.filter(resource_attempts, &(&1.date_submitted != nil))
-    #   |> Enum.sort(&DateTime.before?(&1.date_submitted, &2.date_submitted))
-
-    # {:ok, {previous, next, current}, _} = PreviousNextIndex.retrieve(section, page.resource_id)
-
-    # resource_access = Core.get_resource_access(page.resource_id, section.slug, user.id)
-
     section_resource = Sections.get_section_resource(section.id, page.resource_id)
 
-    # assign(socket, %{
-    #   view: :prologue,
-    #   resource_access: resource_access,
-    #   section_slug: section_slug,
-    #   scripts: Activities.get_activity_scripts(),
-    #   preview_mode: preview_mode,
-    #   resource_attempts: resource_attempts,
-    #   previous_page: previous,
-    #   next_page: next,
-    #   numbered_revisions: numbered_revisions,
-    #   current_page: current,
-    # page_number: section_resource.numbering_index,
-    #   title: context.page.title,
-    #   allow_attempt?: allow_attempt?,
-    #   message: message,
-    #   resource_id: page.resource_id,
-    #   slug: context.page.slug,
-    #   max_attempts: effective_settings.max_attempts,
-    #   effective_settings: effective_settings,
-    #   requires_password?:
-    #     effective_settings.password != nil and effective_settings.password != "",
-    #   section: section,
-    #   page_link_url: &Routes.page_delivery_path(conn, :page, section_slug, &1),
-    #   container_link_url: &Routes.page_delivery_path(conn, :container, section_slug, &1),
-    # revision: page_context.page,
-    #   resource_slug: context.page.slug,
-    #   bib_app_params: %{
-    #     bibReferences: context.bib_revisions
-    #   }
-    # })
     assign(socket, %{
       view: :prologue,
       page_number: section_resource.numbering_index,
@@ -195,8 +108,6 @@ defmodule OliWeb.LiveSessionPlugs.InitPage do
 
     section_resource = Sections.get_section_resource(section.id, page_context.page.resource_id)
 
-    preview_mode = Map.get(socket.assigns, :preview_mode, false)
-
     assign(socket, %{
       view: :page,
       page_number: section_resource.numbering_index,
@@ -204,15 +115,5 @@ defmodule OliWeb.LiveSessionPlugs.InitPage do
       resource_slug: page_context.page.slug,
       page_context: page_context
     })
-  end
-
-  defp before_start_date_message(session_context, effective_settings) do
-    "This assessment is not yet available. It will be available on #{format_datetime_fn(session_context).(effective_settings.start_date)}."
-  end
-
-  defp format_datetime_fn(session_context) do
-    fn datetime ->
-      FormatDateTime.date(datetime, ctx: session_context, precision: :minutes)
-    end
   end
 end

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -957,6 +957,7 @@ defmodule OliWeb.Router do
         live("/assignments", Delivery.Student.ScheduleLive)
         live("/explorations", Delivery.Student.ExplorationsLive)
         live("/practice", Delivery.Student.PracticeLive)
+        live("/page-ng/:revision_slug", Delivery.Student.PageLive)
       end
     end
 

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -957,7 +957,19 @@ defmodule OliWeb.Router do
         live("/assignments", Delivery.Student.ScheduleLive)
         live("/explorations", Delivery.Student.ExplorationsLive)
         live("/practice", Delivery.Student.PracticeLive)
-        live("/page-ng/:revision_slug", Delivery.Student.PageLive)
+      end
+
+      live_session :delivery_lesson,
+        root_layout: {OliWeb.LayoutView, :delivery},
+        layout: {OliWeb.Layouts, :student_delivery_lesson},
+        on_mount: [
+          OliWeb.LiveSessionPlugs.SetUser,
+          OliWeb.LiveSessionPlugs.SetSection,
+          OliWeb.LiveSessionPlugs.SetBrand,
+          OliWeb.LiveSessionPlugs.SetPreviewMode,
+          OliWeb.LiveSessionPlugs.RequireEnrollment
+        ] do
+        live("/lesson/:revision_slug", Delivery.Student.LessonLive)
       end
     end
 

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -1119,7 +1119,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       |> element(~s{div[phx-click="navigate_to_resource"][phx-value-slug="#{page_1.slug}"]})
       |> render_click()
 
-      assert_redirect(view, "/sections/#{section.slug}/page/#{page_1.slug}")
+      assert_redirect(view, "/sections/#{section.slug}/lesson/#{page_1.slug}")
     end
 
     test "can see the unit schedule details considering if the instructor has already scheduled it",
@@ -1195,7 +1195,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       |> element(~s{div[role="unit_3"] div[role="card_1"]})
       |> render_click()
 
-      assert_redirect(view, "/sections/#{section.slug}/page/#{page_7.slug}")
+      assert_redirect(view, "/sections/#{section.slug}/lesson/#{page_7.slug}")
     end
 
     test "can see icon that identifies graded pages at level 2 of hierarchy (and can navigate to them)",
@@ -1220,7 +1220,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       |> element(~s{div[role="unit_3"] div[role="card_2"]})
       |> render_click()
 
-      assert_redirect(view, "/sections/#{section.slug}/page/#{page_8.slug}")
+      assert_redirect(view, "/sections/#{section.slug}/lesson/#{page_8.slug}")
     end
 
     test "can see card progress bar for modules at level 2 of hierarchy, but not for pages at level 2",

--- a/test/oli_web/live/delivery/student/lesson_live_test.exs
+++ b/test/oli_web/live/delivery/student/lesson_live_test.exs
@@ -1,0 +1,247 @@
+defmodule OliWeb.Delivery.Student.LessonLiveTest do
+  use ExUnit.Case, async: true
+  use OliWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+  import Oli.Factory
+  import Ecto.Query, warn: false
+
+  alias Lti_1p3.Tool.ContextRoles
+  alias Oli.Delivery.Sections
+  alias Oli.Resources.ResourceType
+
+  defp live_view_content_live_route(section_slug) do
+    ~p"/sections/#{section_slug}/content"
+  end
+
+  defp live_view_lesson_live_route(section_slug, revision_slug) do
+    ~p"/sections/#{section_slug}/lesson/#{revision_slug}"
+  end
+
+  defp create_elixir_project(_) do
+    author = insert(:author)
+    project = insert(:project, authors: [author])
+
+    # revisions...
+    ## pages...
+    page_1_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.get_id_by_type("page"),
+        title: "Page 1",
+        duration_minutes: 10
+      )
+
+    page_2_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.get_id_by_type("page"),
+        title: "Page 2",
+        duration_minutes: 15
+      )
+
+    ## modules...
+    module_1_revision =
+      insert(:revision, %{
+        resource_type_id: Oli.Resources.ResourceType.get_id_by_type("container"),
+        children: [page_1_revision.resource_id, page_2_revision.resource_id],
+        title: "How to use this course",
+        poster_image: "module_1_custom_image_url",
+        intro_content: %{
+          children: [
+            %{
+              type: "p",
+              children: [
+                %{
+                  text: "Thoughout this unit you will learn how to use this course."
+                }
+              ]
+            }
+          ]
+        }
+      })
+
+    ## units...
+    unit_1_revision =
+      insert(:revision, %{
+        resource_type_id: Oli.Resources.ResourceType.get_id_by_type("container"),
+        children: [module_1_revision.resource_id],
+        title: "Introduction",
+        poster_image: "some_image_url",
+        intro_video: "some_video_url"
+      })
+
+    ## root container...
+    container_revision =
+      insert(:revision, %{
+        resource_type_id: Oli.Resources.ResourceType.get_id_by_type("container"),
+        children: [
+          unit_1_revision.resource_id
+        ],
+        title: "Root Container"
+      })
+
+    all_revisions =
+      [
+        page_1_revision,
+        page_2_revision,
+        module_1_revision,
+        unit_1_revision,
+        container_revision
+      ]
+
+    # asociate resources to project
+    Enum.each(all_revisions, fn revision ->
+      insert(:project_resource, %{
+        project_id: project.id,
+        resource_id: revision.resource_id
+      })
+    end)
+
+    # publish project
+    publication =
+      insert(:publication, %{project: project, root_resource_id: container_revision.resource_id})
+
+    # publish resources
+    Enum.each(all_revisions, fn revision ->
+      insert(:published_resource, %{
+        publication: publication,
+        resource: revision.resource,
+        revision: revision,
+        author: author
+      })
+    end)
+
+    # create section...
+    section =
+      insert(:section,
+        base_project: project,
+        title: "The best course ever!",
+        start_date: ~U[2023-10-30 20:00:00Z]
+      )
+
+    {:ok, section} = Sections.create_section_resources(section, publication)
+    {:ok, _} = Sections.rebuild_contained_pages(section)
+
+    # schedule start and end date for unit 1 section resource
+    Sections.get_section_resource(section.id, unit_1_revision.resource_id)
+    |> Sections.update_section_resource(%{
+      start_date: ~U[2023-10-31 20:00:00Z],
+      end_date: ~U[2023-12-31 20:00:00Z]
+    })
+
+    {:ok, _} = Sections.rebuild_full_hierarchy(section)
+
+    %{
+      section: section,
+      page_1: page_1_revision,
+      page_2: page_2_revision,
+      module_1: module_1_revision,
+      unit_1: unit_1_revision
+    }
+  end
+
+  describe "user" do
+    setup [:create_elixir_project]
+
+    test "can not access page when it is not logged in", %{
+      conn: conn,
+      section: section,
+      page_1: page_1
+    } do
+      student = insert(:user)
+
+      Sections.enroll(student.id, section.id, [ContextRoles.get_role(:context_learner)])
+
+      {:error, {:redirect, %{to: redirect_path}}} =
+        live(conn, live_view_lesson_live_route(section.slug, page_1.slug))
+
+      assert redirect_path ==
+               "/session/new?request_path=%2Fsections%2F#{section.slug}%2Flesson%2F#{page_1.slug}&section=#{section.slug}"
+    end
+  end
+
+  describe "student" do
+    setup [:user_conn, :create_elixir_project]
+
+    test "can not access when not enrolled to course", %{
+      conn: conn,
+      section: section,
+      page_1: page_1
+    } do
+      {:error, {:redirect, %{to: redirect_path, flash: _flash_msg}}} =
+        live(conn, live_view_lesson_live_route(section.slug, page_1.slug))
+
+      assert redirect_path == "/unauthorized"
+    end
+
+    test "can access when enrolled to course", %{
+      conn: conn,
+      user: user,
+      section: section,
+      page_1: page_1,
+      page_2: page_2,
+      module_1: module_1
+    } do
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.mark_section_visited_for_student(section, user)
+
+      {:ok, view, _html} = live(conn, live_view_lesson_live_route(section.slug, page_1.slug))
+
+      assert has_element?(view, "span", "The best course ever!")
+
+      assert has_element?(
+               view,
+               ~s{div[role="prev_page"]},
+               module_1.title
+             )
+
+      assert has_element?(
+               view,
+               ~s{div[role="next_page"]},
+               page_2.title
+             )
+    end
+
+    test "can navigate between pages", %{
+      conn: conn,
+      user: user,
+      section: section,
+      page_1: page_1,
+      page_2: page_2
+    } do
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.mark_section_visited_for_student(section, user)
+
+      {:ok, view, _html} = live(conn, live_view_lesson_live_route(section.slug, page_1.slug))
+
+      view
+      |> element(~s{div[role="next_page"] a})
+      |> render_click
+
+      assert_redirected(
+        view,
+        live_view_lesson_live_route(section.slug, page_2.slug)
+      )
+    end
+
+    test "back link returns to content page", %{
+      conn: conn,
+      user: user,
+      section: section,
+      page_1: page_1
+    } do
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.mark_section_visited_for_student(section, user)
+
+      {:ok, view, _html} = live(conn, live_view_lesson_live_route(section.slug, page_1.slug))
+
+      view
+      |> element(~s{div[role="back_link"] a})
+      |> render_click
+
+      assert_redirected(
+        view,
+        live_view_content_live_route(section.slug)
+      )
+    end
+  end
+end

--- a/test/oli_web/live/delivery/student/lesson_live_test.exs
+++ b/test/oli_web/live/delivery/student/lesson_live_test.exs
@@ -11,7 +11,7 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
   alias Oli.Resources.ResourceType
 
   defp live_view_content_live_route(section_slug) do
-    ~p"/sections/#{section_slug}/content"
+    ~p"/sections/#{section_slug}/learn"
   end
 
   defp live_view_lesson_live_route(section_slug, revision_slug) do


### PR DESCRIPTION
[NG23-35](https://eliterate.atlassian.net/browse/NG23-35)

This PR lays the foundation for the new lesson view, which will handle a section page rendering and interactions in its final version.
Now it does not render a lesson content but displays the general layout (back button, navigation between pages).
In the following iteration, it will consider the recent changes in the content view, so that it focuses on the right page, unit, or module while navigating back or between pages.



https://github.com/Simon-Initiative/oli-torus/assets/26532202/88b1f1b3-2a8b-407d-a9de-c3a272a5d467



[NG23-35]: https://eliterate.atlassian.net/browse/NG23-35?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ