### PR TITLE
Mer 2758 cannot add enrollment of a student

### DIFF
--- a/lib/oli/accounts.ex
+++ b/lib/oli/accounts.ex
@@ -100,12 +100,7 @@ defmodule Oli.Accounts do
       Enum.map(user_emails, fn email ->
         %{changes: changes} = User.invite_changeset(%User{}, inviter_user, %{email: email})
 
-        case inviter_user do
-          %Author{} -> Map.delete(changes, :invite_by_id)
-          %User{} -> Map.put(changes, :invite_by_id, inviter_user.id)
-        end
-        |> Map.put(:inserted_at, now)
-        |> Map.put(:updated_at, now)
+        Enum.into(changes, %{inserted_at: now, updated_at: now})
       end)
 
     Repo.insert_all(User, users, returning: [:id, :invitation_token, :email])

--- a/lib/oli/accounts.ex
+++ b/lib/oli/accounts.ex
@@ -93,27 +93,20 @@ defmodule Oli.Accounts do
       iex> bulk_invite_users(["email_1@test.com", "email_2@test.com"], %Author{id: 1})
       [%User{id: 3}, %User{id: 4}]
   """
-  def bulk_invite_users(user_emails, %Author{} = inviter_user) do
-    date = DateTime.utc_now() |> DateTime.truncate(:second)
+  def bulk_invite_users(user_emails, inviter_user) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
 
     users =
-      Enum.map(
-        user_emails,
-        fn email ->
-          User
-          |> struct()
-          |> User.invite_changeset(inviter_user, %{
-            email: email
-          })
-          |> Map.get(:changes)
-          |> Map.delete(:invited_by_id)
-          |> Map.merge(%{
-            state: %{},
-            inserted_at: date,
-            updated_at: date
-          })
+      Enum.map(user_emails, fn email ->
+        %{changes: changes} = User.invite_changeset(%User{}, inviter_user, %{email: email})
+
+        case inviter_user do
+          %Author{} -> Map.delete(changes, :invite_by_id)
+          %User{} -> Map.put(changes, :invite_by_id, inviter_user.id)
         end
-      )
+        |> Map.put(:inserted_at, now)
+        |> Map.put(:updated_at, now)
+      end)
 
     Repo.insert_all(User, users, returning: [:id, :invitation_token, :email])
   end

--- a/lib/oli_web/components/delivery/students/students.ex
+++ b/lib/oli_web/components/delivery/students/students.ex
@@ -3,6 +3,8 @@ defmodule OliWeb.Components.Delivery.Students do
 
   alias Phoenix.LiveView.JS
 
+  alias Oli.Accounts.Author
+  alias Oli.Accounts.User
   alias OliWeb.Common.{PagedTable, SearchInput, Params, Utils}
   alias OliWeb.Delivery.Sections.EnrollmentsTableModel
   alias OliWeb.Router.Helpers, as: Routes
@@ -58,7 +60,10 @@ defmodule OliWeb.Components.Delivery.Students do
        add_enrollments_step: :step_1,
        add_enrollments_selected_role: :student,
        add_enrollments_emails: [],
-       add_enrollments_users_not_found: []
+       add_enrollments_users_not_found: [],
+       inviter: "user",
+       current_user: ctx.user,
+       current_author: ctx.author
      )}
   end
 
@@ -182,6 +187,10 @@ defmodule OliWeb.Components.Delivery.Students do
   attr(:add_enrollments_selected_role, :atom, default: :student)
   attr(:add_enrollments_emails, :list, default: [])
   attr(:add_enrollments_users_not_found, :list, default: [])
+  attr(:current_user, :any, required: false)
+  attr(:current_author, :any, required: false)
+  attr(:inviter, :string, required: false)
+  attr(:myself, :string, required: false)
 
   def render(assigns) do
     ~H"""
@@ -213,6 +222,10 @@ defmodule OliWeb.Components.Delivery.Students do
           add_enrollments_users_not_found={@add_enrollments_users_not_found}
           section_slug={@section_slug}
           target={@id}
+          current_user={@current_user}
+          current_author={@current_author}
+          inviter={@inviter}
+          myself={@myself}
         />
       </.live_component>
       <div class="bg-white dark:bg-gray-800 shadow-sm">
@@ -375,14 +388,68 @@ defmodule OliWeb.Components.Delivery.Students do
       <% end %>
       <input name="role" value={@add_enrollments_selected_role} />
       <input name="section_slug" value={@section_slug} />
+      <input name="inviter" value={@inviter} />
       <button type="submit" class="hidden" />
     </.form>
     <div class="px-4">
       <p>
         Are you sure you want to enroll <%= "#{if length(@add_enrollments_emails) == 1, do: "one user", else: "#{length(@add_enrollments_emails)} users"}" %>?
       </p>
+      <.render_inviter
+        current_author={@current_author}
+        current_user={@current_user}
+        inviter={@inviter}
+        myself={@myself}
+      />
     </div>
     """
+  end
+
+  attr(:current_author, :any, required: true)
+  attr(:current_user, :any, required: true)
+  attr(:inviter, :string, required: true)
+  attr(:myself, :string, required: true)
+
+  defp render_inviter(assigns) do
+    ~H"""
+    <div
+      :if={show_senders(@current_author, @current_user)}
+      class="mt-5 p-5 border-solid border-2 border-blue-400 rounded"
+    >
+      <p>You're signed with two accounts.</p>
+      <p>Please select the one to use as an inviter:</p>
+      <fieldset class="mt-2">
+        <div class="ml-2">
+          <input
+            type="radio"
+            id="author"
+            name="inviter"
+            phx-value-inviter="author"
+            phx-click="select_inviter"
+            phx-target={@myself}
+            checked={if @inviter == "author", do: true, else: false}
+          />
+          <label for="author" class="ml-2"><%= Map.get(@current_author, :name) %></label>
+        </div>
+        <div class="ml-2">
+          <input
+            type="radio"
+            id="user"
+            name="inviter"
+            phx-value-inviter="user"
+            phx-click="select_inviter"
+            phx-target={@myself}
+            checked={if @inviter == "user", do: true, else: false}
+          />
+          <label for="user" class="ml-2"><%= Map.get(@current_user, :name) %></label>
+        </div>
+      </fieldset>
+    </div>
+    """
+  end
+
+  def handle_event("select_inviter", %{"inviter" => inviter}, socket) do
+    {:noreply, assign(socket, :inviter, inviter)}
   end
 
   def handle_event("add_enrollments_go_to_step_1", _, socket) do
@@ -623,4 +690,7 @@ defmodule OliWeb.Components.Delivery.Students do
       @default_params[key] != value
     end)
   end
+
+  defp show_senders(%Author{} = _current_author, %User{} = _current_user), do: true
+  defp show_senders(_current_author, _current_user), do: false
 end

--- a/lib/oli_web/components/delivery/students/students.ex
+++ b/lib/oli_web/components/delivery/students/students.ex
@@ -395,7 +395,7 @@ defmodule OliWeb.Components.Delivery.Students do
       <p>
         Are you sure you want to enroll <%= "#{if length(@add_enrollments_emails) == 1, do: "one user", else: "#{length(@add_enrollments_emails)} users"}" %>?
       </p>
-      <.render_inviter
+      <.inviter
         current_author={@current_author}
         current_user={@current_user}
         inviter={@inviter}
@@ -410,7 +410,7 @@ defmodule OliWeb.Components.Delivery.Students do
   attr(:inviter, :string, required: true)
   attr(:myself, :string, required: true)
 
-  defp render_inviter(assigns) do
+  defp inviter(assigns) do
     ~H"""
     <div
       :if={show_senders(@current_author, @current_user)}
@@ -427,7 +427,7 @@ defmodule OliWeb.Components.Delivery.Students do
             phx-value-inviter="author"
             phx-click="select_inviter"
             phx-target={@myself}
-            checked={if @inviter == "author", do: true, else: false}
+            checked={@inviter == "author"}
           />
           <label for="author" class="ml-2"><%= Map.get(@current_author, :name) %></label>
         </div>
@@ -439,7 +439,7 @@ defmodule OliWeb.Components.Delivery.Students do
             phx-value-inviter="user"
             phx-click="select_inviter"
             phx-target={@myself}
-            checked={if @inviter == "user", do: true, else: false}
+            checked={@inviter == "user"}
           />
           <label for="user" class="ml-2"><%= Map.get(@current_user, :name) %></label>
         </div>

--- a/lib/oli_web/controllers/invite_controller.ex
+++ b/lib/oli_web/controllers/invite_controller.ex
@@ -78,18 +78,22 @@ defmodule OliWeb.InviteController do
       Enum.each(emails, fn email -> Oli.Mailer.deliver_now(email) end)
     end)
 
+    redirect_after_enrollment(conn, section_slug)
+  end
+
+  defp redirect_after_enrollment(conn, section_slug) do
+    path =
+      Routes.live_path(
+        OliWeb.Endpoint,
+        OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive,
+        section_slug,
+        :reports,
+        :students
+      )
+
     conn
     |> put_flash(:info, "Users were enrolled successfully")
-    |> redirect(
-      to:
-        Routes.live_path(
-          OliWeb.Endpoint,
-          OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive,
-          section_slug,
-          :reports,
-          :students
-        )
-    )
+    |> redirect(to: path)
   end
 
   defp render_invite_page(conn, page, keywords) do

--- a/lib/oli_web/controllers/invite_controller.ex
+++ b/lib/oli_web/controllers/invite_controller.ex
@@ -23,9 +23,9 @@ defmodule OliWeb.InviteController do
     end
   end
 
-  def create_bulk(conn, %{"emails" => users, "role" => role, "section_slug" => section_slug}) do
-    existing_users = Oli.Accounts.get_users_by_email(users)
-    non_found_users = users -- Enum.map(existing_users, & &1.email)
+  def create_bulk(conn, %{"emails" => emails, "role" => role, "section_slug" => section_slug}) do
+    existing_users = Oli.Accounts.get_users_by_email(emails)
+    non_found_users = emails -- Enum.map(existing_users, & &1.email)
     inviter_user = conn.assigns.current_author
     section = Sections.get_section_by_slug(section_slug)
 

--- a/lib/oli_web/controllers/invite_controller.ex
+++ b/lib/oli_web/controllers/invite_controller.ex
@@ -2,6 +2,7 @@ defmodule OliWeb.InviteController do
   use OliWeb, :controller
 
   alias Oli.Accounts
+  alias Oli.Delivery.Sections
 
   @spec index(Plug.Conn.t(), any) :: Plug.Conn.t()
   def index(conn, _params) do
@@ -26,7 +27,7 @@ defmodule OliWeb.InviteController do
     existing_users = Oli.Accounts.get_users_by_email(users)
     non_found_users = users -- Enum.map(existing_users, & &1.email)
     inviter_user = conn.assigns.current_author
-    section = conn.assigns.section
+    section = Sections.get_section_by_slug(section_slug)
 
     # Enroll users
     Oli.Repo.transaction(fn ->

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -915,6 +915,8 @@ defmodule OliWeb.Router do
       :instructor_dashboard
     )
 
+    post("/enrollments", InviteController, :create_bulk)
+
     live_session :instructor_dashboard,
       on_mount: OliWeb.Delivery.InstructorDashboard.InitialAssigns,
       root_layout: {OliWeb.LayoutView, :delivery_dashboard} do
@@ -1042,7 +1044,6 @@ defmodule OliWeb.Router do
     live("/:section_slug/source_materials", Delivery.ManageSourceMaterials, as: :source_materials)
     live("/:section_slug/remix", Delivery.RemixSection)
     live("/:section_slug/remix/:section_resource_slug", Delivery.RemixSection)
-    post("/:section_slug/enrollments", InviteController, :create_bulk)
 
     post("/:section_slug/enrollments/export", PageDeliveryController, :export_enrollments)
     live("/:section_slug/invitations", Sections.InviteView)

--- a/test/oli_web/controllers/invite_controller_test.exs
+++ b/test/oli_web/controllers/invite_controller_test.exs
@@ -53,7 +53,8 @@ defmodule OliWeb.InviteControllerTest do
           Routes.invite_path(conn, :create_bulk, section.slug,
             emails: ["invite@example.com", "invite2@example.com"],
             role: "instructor",
-            "g-recaptcha-response": "any"
+            "g-recaptcha-response": "any",
+            inviter: "author"
           )
         )
 

--- a/test/oli_web/live/delivery/instructor_dashboard/reports/students_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/reports/students_tab_test.exs
@@ -704,7 +704,8 @@ defmodule OliWeb.Delivery.InstructorDashboard.StudentsTabTest do
           Routes.invite_path(conn, :create_bulk, section.slug,
             emails: [user_1.email, user_2.email, non_existant_email_1],
             role: "instructor",
-            "g-recaptcha-response": "any"
+            "g-recaptcha-response": "any",
+            inviter: "author"
           )
         )
 

--- a/test/oli_web/live/delivery/instructor_dashboard/reports/students_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/reports/students_tab_test.exs
@@ -638,6 +638,10 @@ defmodule OliWeb.Delivery.InstructorDashboard.StudentsTabTest do
       non_existant_email_1 = "non_existant_user_1@test.com"
       non_existant_email_2 = "non_existant_user_2@test.com"
 
+      assert [] ==
+               [user_1.email, user_2.email, non_existant_email_1, non_existant_email_2]
+               |> get_emails_of_users_enrolled_in_section(section.slug)
+
       # Open "Add enrollments modal"
       view
       |> with_target("#students_table_add_enrollments_modal")
@@ -695,7 +699,15 @@ defmodule OliWeb.Delivery.InstructorDashboard.StudentsTabTest do
       |> with_target("#students_table")
       |> render_hook("add_enrollments_go_to_step_3")
 
-      assert has_element?(view, "p", "Are you sure you want to enroll 3 users?")
+      assert has_element?(view, "p", "You're signed with two accounts.")
+      assert has_element?(view, "p", "Please select the one to use as an inviter:")
+
+      refute view |> element("fieldset input#author") |> render() =~ "checked=\"checked\""
+      assert view |> element("fieldset input#user") |> render() =~ "checked=\"checked\""
+
+      view |> element("fieldset input#author") |> render_click()
+      assert view |> element("fieldset input#author") |> render() =~ "checked=\"checked\""
+      refute view |> element("fieldset input#user") |> render() =~ "checked=\"checked\""
 
       # Send the invitations (this mocks the POST request made by the form)
       conn =
@@ -709,7 +721,10 @@ defmodule OliWeb.Delivery.InstructorDashboard.StudentsTabTest do
           )
         )
 
-      assert redirected_to(conn, 302) =~ students_url
+      emails_sent = [user_1.email, user_2.email, non_existant_email_1] |> Enum.sort()
+      assert emails_sent == get_emails_of_users_enrolled_in_section(emails_sent, section.slug)
+
+      assert redirected_to(conn) == students_url
 
       new_users =
         Oli.Accounts.User
@@ -731,6 +746,17 @@ defmodule OliWeb.Delivery.InstructorDashboard.StudentsTabTest do
 
       refute html =~ "Add Enrollments"
     end
+  end
+
+  defp get_emails_of_users_enrolled_in_section(emails, section_slug) when is_list(emails) do
+    from(s in Oli.Delivery.Sections.Section,
+      join: e in assoc(s, :enrollments),
+      join: u in assoc(e, :user),
+      where: s.slug == ^section_slug and u.email in ^emails,
+      select: u.email
+    )
+    |> Repo.all()
+    |> Enum.sort()
   end
 
   defp set_progress(section_id, resource_id, user_id, progress) do
@@ -762,9 +788,12 @@ defmodule OliWeb.Delivery.InstructorDashboard.StudentsTabTest do
           %Oli.Accounts.AuthorPreferences{show_relative_dates: false} |> Map.from_struct()
       })
 
+    user = user_fixture()
+
     conn =
       Plug.Test.init_test_session(conn, [])
       |> Pow.Plug.assign_current_user(admin, OliWeb.Pow.PowHelpers.get_pow_config(:author))
+      |> Pow.Plug.assign_current_user(user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
 
     map
     |> Map.merge(%{


### PR DESCRIPTION
This PR covers the bug reported in ticket [MER-2758](https://eliterate.atlassian.net/browse/MER-2758) where students cannot be enrolled by an instructor/admin.

The endpoint `post("/:section_slug/enrollments", InviteController, :create_bulk)` was moved from an admin scope to the `/sections/:section_slug/instructor_dashboard` one, otherwise only admins can do the operation and an instructor might not have that type of role.

I would like to understand more the role of the `invited_by_id` field. The current implementation does not have that field set up. It would be helpful to know the function of this field to know best how to set it up. Do they want/need to know whether it was another user or an author? Is it a requirement to identify either the category (user or author) or the specific individual. Is it important to the completion of the enrollment operation? We can make a better recommendation if we have this information.



[MER-2758]: https://eliterate.atlassian.net/browse/MER-2758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ