### PR TITLE
[NG23-38] Lesson view navigation improvements

### DIFF
--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -312,14 +312,14 @@ defmodule OliWeb.Components.Delivery.Layouts do
         role="prev_page"
       >
         <div class="px-6 py-2 rounded justify-end items-center gap-2 flex">
-          <.link navigate={previous_url(@previous_page, @section_slug)}>
+          <.link navigate={resource_navigation_url(@previous_page, @section_slug)}>
             <div class="w-[72px] h-10 opacity-30 hover:opacity-40 bg-blue-600 flex items-center justify-center">
               <.left_arrow />
             </div>
           </.link>
         </div>
         <div class="grow shrink basis-0 dark:text-white text-xs font-normal">
-          <%= previous_title(@previous_page) %>
+          <%= @previous_page["title"] %>
         </div>
       </div>
 
@@ -329,10 +329,10 @@ defmodule OliWeb.Components.Delivery.Layouts do
         role="next_page"
       >
         <div class="grow shrink basis-0 text-right dark:text-white text-xs font-normal">
-          <%= next_title(@next_page) %>
+          <%= @next_page["title"] %>
         </div>
         <div class="px-6 py-2 rounded justify-end items-center gap-2 flex">
-          <.link navigate={next_url(@next_page, @section_slug)}>
+          <.link navigate={resource_navigation_url(@next_page, @section_slug)}>
             <div class="w-[72px] h-10 opacity-90 hover:opacity-100 bg-blue-600 flex items-center justify-center">
               <.right_arrow />
             </div>
@@ -356,6 +356,14 @@ defmodule OliWeb.Components.Delivery.Layouts do
       </div>
     </div>
     """
+  end
+
+  defp resource_navigation_url(%{"slug" => slug, "type" => "page"}, section_slug) do
+    ~p"/sections/#{section_slug}/lesson/#{slug}"
+  end
+
+  defp resource_navigation_url(%{"id" => container_id}, section_slug) do
+    ~p"/sections/#{section_slug}/learn?target_resource_id=#{container_id}"
   end
 
   attr(:to, :string)

--- a/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
+++ b/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
@@ -9,7 +9,9 @@
 
   <div class="flex-1 flex flex-col mt-14">
     <div :if={@section} id="page-content" class="relative justify-center items-start inline-flex">
-      <.back_arrow to={~p"/sections/#{@section.slug}/learn"} />
+      <.back_arrow to={
+        ~p"/sections/#{@section.slug}/learn?target_resource_id=#{@current_page["id"]}"
+      } />
 
       <%!-- This feature will not be implemented in the first release. This is just a placeholder--%>
       <.annotations_dropdown />

--- a/lib/oli_web/components/utils.ex
+++ b/lib/oli_web/components/utils.ex
@@ -70,16 +70,24 @@ defmodule OliWeb.Components.Utils do
     end
   end
 
-  def previous_url(%{"slug" => slug}, section_slug) do
+  def previous_url(%{"slug" => slug, "type" => "page"}, section_slug) do
     ~p"/sections/#{section_slug}/lesson/#{slug}"
+  end
+
+  def previous_url(%{"id" => container_id}, section_slug) do
+    ~p"/sections/#{section_slug}/learn?target_resource_id=#{container_id}"
   end
 
   def previous_title(%{"title" => title}) do
     title
   end
 
-  def next_url(%{"slug" => slug}, section_slug) do
+  def next_url(%{"slug" => slug, "type" => "page"}, section_slug) do
     ~p"/sections/#{section_slug}/lesson/#{slug}"
+  end
+
+  def next_url(%{"id" => container_id}, section_slug) do
+    ~p"/sections/#{section_slug}/learn?target_resource_id=#{container_id}"
   end
 
   def next_title(%{"title" => title}) do

--- a/lib/oli_web/components/utils.ex
+++ b/lib/oli_web/components/utils.ex
@@ -69,28 +69,4 @@ defmodule OliWeb.Components.Utils do
         false
     end
   end
-
-  def previous_url(%{"slug" => slug, "type" => "page"}, section_slug) do
-    ~p"/sections/#{section_slug}/lesson/#{slug}"
-  end
-
-  def previous_url(%{"id" => container_id}, section_slug) do
-    ~p"/sections/#{section_slug}/learn?target_resource_id=#{container_id}"
-  end
-
-  def previous_title(%{"title" => title}) do
-    title
-  end
-
-  def next_url(%{"slug" => slug, "type" => "page"}, section_slug) do
-    ~p"/sections/#{section_slug}/lesson/#{slug}"
-  end
-
-  def next_url(%{"id" => container_id}, section_slug) do
-    ~p"/sections/#{section_slug}/learn?target_resource_id=#{container_id}"
-  end
-
-  def next_title(%{"title" => title}) do
-    title
-  end
 end

--- a/test/oli_web/live/delivery/student/lesson_live_test.exs
+++ b/test/oli_web/live/delivery/student/lesson_live_test.exs
@@ -254,16 +254,19 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
       )
     end
 
-    test "redirects to the learn page when the next page corresponds to a container", %{
-      conn: conn,
-      user: user,
-      section: section,
-      page_2: page_2,
-      module_2: module_2
-    } do
+    test "redirects to the learn page when the next or previous page corresponds to a container",
+         %{
+           conn: conn,
+           user: user,
+           section: section,
+           page_2: page_2,
+           page_3: page_3,
+           module_2: module_2
+         } do
       Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
       Sections.mark_section_visited_for_student(section, user)
 
+      # next page is a container
       {:ok, view, _html} = live(conn, live_view_lesson_live_route(section.slug, page_2.slug))
 
       view
@@ -274,18 +277,8 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
         view,
         live_view_learn_live_route(section.slug, module_2.resource_id)
       )
-    end
 
-    test "redirects to the learn page when the previous page corresponds to a container", %{
-      conn: conn,
-      user: user,
-      section: section,
-      page_3: page_3,
-      module_2: module_2
-    } do
-      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
-      Sections.mark_section_visited_for_student(section, user)
-
+      # previous page is a container
       {:ok, view, _html} = live(conn, live_view_lesson_live_route(section.slug, page_3.slug))
 
       view

--- a/test/oli_web/live/delivery/student/lesson_live_test.exs
+++ b/test/oli_web/live/delivery/student/lesson_live_test.exs
@@ -10,8 +10,8 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
   alias Oli.Delivery.Sections
   alias Oli.Resources.ResourceType
 
-  defp live_view_content_live_route(section_slug) do
-    ~p"/sections/#{section_slug}/learn"
+  defp live_view_learn_live_route(section_slug, resource_id) do
+    ~p"/sections/#{section_slug}/learn?target_resource_id=#{resource_id}"
   end
 
   defp live_view_lesson_live_route(section_slug, revision_slug) do
@@ -38,6 +38,13 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
         duration_minutes: 15
       )
 
+    page_3_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.get_id_by_type("page"),
+        title: "Page 3",
+        duration_minutes: 5
+      )
+
     ## modules...
     module_1_revision =
       insert(:revision, %{
@@ -59,11 +66,31 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
         }
       })
 
+    module_2_revision =
+      insert(:revision, %{
+        resource_type_id: Oli.Resources.ResourceType.get_id_by_type("container"),
+        children: [page_3_revision.resource_id],
+        title: "The second module is awesome!",
+        poster_image: "module_2_custom_image_url",
+        intro_content: %{
+          children: [
+            %{
+              type: "p",
+              children: [
+                %{
+                  text: "Thoughout this unit you will have a lot of fun."
+                }
+              ]
+            }
+          ]
+        }
+      })
+
     ## units...
     unit_1_revision =
       insert(:revision, %{
         resource_type_id: Oli.Resources.ResourceType.get_id_by_type("container"),
-        children: [module_1_revision.resource_id],
+        children: [module_1_revision.resource_id, module_2_revision.resource_id],
         title: "Introduction",
         poster_image: "some_image_url",
         intro_video: "some_video_url"
@@ -83,7 +110,9 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
       [
         page_1_revision,
         page_2_revision,
+        page_3_revision,
         module_1_revision,
+        module_2_revision,
         unit_1_revision,
         container_revision
       ]
@@ -134,7 +163,9 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
       section: section,
       page_1: page_1_revision,
       page_2: page_2_revision,
+      page_3: page_3_revision,
       module_1: module_1_revision,
+      module_2: module_2_revision,
       unit_1: unit_1_revision
     }
   end
@@ -223,6 +254,50 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
       )
     end
 
+    test "redirects to the learn page when the next page corresponds to a container", %{
+      conn: conn,
+      user: user,
+      section: section,
+      page_2: page_2,
+      module_2: module_2
+    } do
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.mark_section_visited_for_student(section, user)
+
+      {:ok, view, _html} = live(conn, live_view_lesson_live_route(section.slug, page_2.slug))
+
+      view
+      |> element(~s{div[role="next_page"] a})
+      |> render_click
+
+      assert_redirected(
+        view,
+        live_view_learn_live_route(section.slug, module_2.resource_id)
+      )
+    end
+
+    test "redirects to the learn page when the previous page corresponds to a container", %{
+      conn: conn,
+      user: user,
+      section: section,
+      page_3: page_3,
+      module_2: module_2
+    } do
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.mark_section_visited_for_student(section, user)
+
+      {:ok, view, _html} = live(conn, live_view_lesson_live_route(section.slug, page_3.slug))
+
+      view
+      |> element(~s{div[role="prev_page"] a})
+      |> render_click
+
+      assert_redirected(
+        view,
+        live_view_learn_live_route(section.slug, module_2.resource_id)
+      )
+    end
+
     test "back link returns to content page", %{
       conn: conn,
       user: user,
@@ -240,7 +315,7 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
 
       assert_redirected(
         view,
-        live_view_content_live_route(section.slug)
+        live_view_learn_live_route(section.slug, page_1.resource_id)
       )
     end
   end


### PR DESCRIPTION
[NG23-38](https://eliterate.atlassian.net/browse/NG23-38)

Include changes introduced in https://github.com/Simon-Initiative/oli-torus/pull/4520, in a way that when navigating through the lesson view footer and the next or previous page is a container, it redirects to the learn view targeting that unit or module.


https://github.com/Simon-Initiative/oli-torus/assets/26532202/203beace-dbf9-4603-a795-50a1b9c2d862



[NG23-38]: https://eliterate.atlassian.net/browse/NG23-38?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ