### PR TITLE
[Feature] Editor error boundary improvements [MER-2847]

### DIFF
--- a/assets/src/components/common/ErrorBoundary.tsx
+++ b/assets/src/components/common/ErrorBoundary.tsx
@@ -50,22 +50,11 @@ export class ErrorBoundary extends React.Component<
     try {
       if (this.state.hasError) {
         return (
-          <div className="alert alert-warning" role="alert">
-            {this.props.errorMessage}
-
-            <Collapse caption="Show error message">
-              <div
-                style={{
-                  fontFamily: 'monospace',
-                  wordBreak: 'break-word',
-                }}
-              >
-                <h4>{this.state.error?.message}</h4>
-                <p>{this.state.error?.stack}</p>
-                <p>{this.state.info?.componentStack}</p>
-              </div>
-            </Collapse>
-          </div>
+          <ErrorMessage
+            errorMessage={this.state.error?.message || ''}
+            error={this.state.error}
+            info={this.state.info}
+          />
         );
       }
       return this.props.children;
@@ -75,5 +64,35 @@ export class ErrorBoundary extends React.Component<
     }
   }
 }
+
+interface ErrorMessageProps {
+  errorMessage: string;
+  error: Error | null;
+  info?: React.ErrorInfo | null;
+}
+
+export const ErrorMessage: React.FC<ErrorMessageProps> = ({
+  errorMessage,
+  error,
+  info,
+  children,
+}) => (
+  <div className="alert alert-warning" role="alert">
+    {errorMessage}
+    <Collapse caption="Show error message">
+      <div
+        style={{
+          fontFamily: 'monospace',
+          wordBreak: 'break-word',
+        }}
+      >
+        <h4>{error?.message}</h4>
+        <p>{error?.stack}</p>
+        <p>{info?.componentStack}</p>
+      </div>
+    </Collapse>
+    {children}
+  </div>
+);
 
 ErrorBoundary.contextType = AppsignalContext;

--- a/assets/src/components/editing/SlateOrMarkdownEditor.tsx
+++ b/assets/src/components/editing/SlateOrMarkdownEditor.tsx
@@ -47,6 +47,11 @@ export class SlateOrMarkdownEditor extends React.Component<
   SlateOrMarkdownEditorProps,
   ErrorBoundaryState
 > {
+  static defaultProps = {
+    allowBlockElements: true,
+    textDirection: 'ltr',
+  };
+
   constructor(props: Readonly<SlateOrMarkdownEditorProps>) {
     super(props);
     this.state = { contentHistory: [props.content], content: props.content, hadEdit: false };
@@ -222,9 +227,4 @@ const InternalSlateOrMarkdownEditor: React.FC<SlateOrMarkdownEditorProps> = ({
       </>
     );
   }
-};
-
-SlateOrMarkdownEditor.defaultProps = {
-  allowBlockElements: true,
-  textDirection: 'ltr',
 };

--- a/assets/src/components/editing/SlateOrMarkdownEditor.tsx
+++ b/assets/src/components/editing/SlateOrMarkdownEditor.tsx
@@ -75,6 +75,7 @@ export class SlateOrMarkdownEditor extends React.Component<
       newHistory.pop(); // The breaking change
       const previousContent = newHistory.pop() || []; // The previous content before the breaking change
       console.info('Reverting editor to', previousContent);
+      this.props.onEdit(previousContent);
       return { contentHistory: newHistory, error: undefined, content: previousContent };
     });
   };

--- a/assets/src/components/editing/elements/image/block/ImageElement.tsx
+++ b/assets/src/components/editing/elements/image/block/ImageElement.tsx
@@ -33,6 +33,7 @@ export const ImageEditor = (props: Props) => {
 
   if (props.model.src === undefined) return <ImagePlaceholder {...props} />;
 
+  throw new Error('FAKE ERROR FROM IMAGE');
   return (
     <div {...props.attributes} contentEditable={false}>
       {props.children}

--- a/assets/src/components/editing/elements/image/block/ImageElement.tsx
+++ b/assets/src/components/editing/elements/image/block/ImageElement.tsx
@@ -33,7 +33,6 @@ export const ImageEditor = (props: Props) => {
 
   if (props.model.src === undefined) return <ImagePlaceholder {...props} />;
 
-  throw new Error('FAKE ERROR FROM IMAGE');
   return (
     <div {...props.attributes} contentEditable={false}>
       {props.children}


### PR DESCRIPTION
Before, if a component in the slate editor threw an error, the editor would crash with an error message and the user might end up being stuck with unrecoverable content.

Now, when this happens, there is a new revert option to go back a step in the editing process.

Demo:

https://github.com/Simon-Initiative/oli-torus/assets/333265/bdd03096-b947-45bf-bf7f-fcf0ad4d8253

