### PR TITLE
[BUGFIX][MER-2765] Module and unit numbers still displayed after hiding them in course content

### DIFF
--- a/lib/oli_web/components/delivery/course_content.ex
+++ b/lib/oli_web/components/delivery/course_content.ex
@@ -117,7 +117,7 @@ defmodule OliWeb.Components.Delivery.CourseContent do
               phx-value-selected_resource_index={index}
               phx-value-resource_type={resource["type"]}
             >
-              <%= if resource["type"] == "container",
+              <%= if resource["type"] == "container" and @section.display_curriculum_item_numbering,
                 do:
                   "#{get_current_node(@current_level_nodes, @current_position)["index"]}.#{resource["index"]} #{resource["title"]}",
                 else: resource["title"] %>

--- a/test/oli_web/live/delivery/student_dashboard/course_content_live_test.exs
+++ b/test/oli_web/live/delivery/student_dashboard/course_content_live_test.exs
@@ -428,6 +428,36 @@ defmodule OliWeb.Delivery.StudentDashboard.CourseContentLiveTest do
         )
       )
     end
+
+    test "units and modules correctly display and hide item numbering", %{
+      conn: conn,
+      user: user,
+      section: section
+    } do
+      {:ok, view, _html} = isolated_live_view_course_content(conn, section.slug, user.id, true)
+
+      # Checks that the resource are rendered correctly with item numbering
+
+      navigate_to_unit_1(view)
+      assert has_element?(view, "#course_browser_node_title", "Unit 1: Unit 1")
+      assert has_element?(view, "h4", "1.1 Module 1")
+      assert has_element?(view, "h4", "1.2 Module 2")
+
+      # Updates section to not display item numbering
+
+      Sections.update_section(section, %{
+        display_curriculum_item_numbering: false
+      })
+
+      {:ok, view, _html} = isolated_live_view_course_content(conn, section.slug, user.id, true)
+
+      # Checks that the resource are rendered correctly without item numbering
+
+      navigate_to_unit_1(view)
+      assert has_element?(view, "#course_browser_node_title", "Unit: Unit 1")
+      assert has_element?(view, "h4", "Module 1")
+      assert has_element?(view, "h4", "Module 2")
+    end
   end
 
   defp breadcrumbs_length(view) do


### PR DESCRIPTION
[MER-2765](https://eliterate.atlassian.net/browse/MER-2765)

This PR is to fix the bug that was persisting when displaying the course content in the student view. 

With these changes, if the section does not have the option to display item numbering enabled, the resources should not display the numbering mentioned above.


https://github.com/Simon-Initiative/oli-torus/assets/16328384/c91ff196-83e0-4d1b-9f7f-35167c9722d5



[MER-2765]: https://eliterate.atlassian.net/browse/MER-2765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ