### PR TITLE
[NG23-39] Lesson page: render content

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -4081,11 +4081,22 @@ defmodule Oli.Delivery.Sections do
            {nil, nil}
 
          c ->
-           {c.id,
-            ~s{#{get_container_label(c.numbering_level, c.customizations || Map.from_struct(CustomLabels.default()))} #{c.numbering_index}: #{c.title}}}
+           {c.id, ~s{#{get_container_label_and_numbering(c, c.customizations)}: #{c.title}}}
        end}
     end)
     |> Enum.into(%{})
+  end
+
+  @doc """
+  Returns the container label and numbering for a given container.
+  If the container has any customizations, they are considered in the label.
+  Examples:
+  "Module 2"
+  "Unit 1"
+  "Section 1"
+  """
+  def get_container_label_and_numbering(container, customizations) do
+    ~s{#{get_container_label(container.numbering_level, customizations || Map.from_struct(CustomLabels.default()))} #{container.numbering_index}}
   end
 
   defp get_container_label(

--- a/lib/oli_web/common/format_date_time.ex
+++ b/lib/oli_web/common/format_date_time.ex
@@ -280,6 +280,28 @@ defmodule OliWeb.Common.FormatDateTime do
     |> value_or(@utc_timezone)
   end
 
+  def to_formatted_datetime(datetime, ctx, format \\ "{WDshort} {Mshort} {D}, {YYYY}")
+
+  def to_formatted_datetime(nil, _ctx, _format), do: "not yet scheduled"
+
+  def to_formatted_datetime(datetime, ctx, format) do
+    if is_binary(datetime) do
+      datetime
+      |> to_datetime
+      |> parse_datetime(ctx, format)
+    else
+      parse_datetime(datetime, ctx, format)
+    end
+  end
+
+  defp to_datetime(nil), do: "not yet scheduled"
+
+  defp to_datetime(string_datetime) do
+    {:ok, datetime, _} = DateTime.from_iso8601(string_datetime)
+
+    datetime
+  end
+
   @doc """
   Parses a DateTime (UTC) considering the given context to localize it,
   and formats it using the given format string.

--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -286,6 +286,15 @@ defmodule OliWeb.Components.Delivery.Layouts do
   attr(:section_slug, :string)
 
   def previous_next_nav(assigns) do
+    # <.links /> were changed from "navigate" to "href" to force a page reload
+    # to fix a bug where the page content would render incorrectly some components
+    # (for instance, the popup or the formula component from Oli.Rendering.Content.Html)
+    # and the page would not react to interactions after navigatint to other page
+    # ("working" loader kept spinning after interacting with an activity)
+    # drawback: we loose the speed of the liveview navigation
+    # (but do not increase time to first paint vs the previous page controller approach)
+    # HINT to increase speed: in every page reload ALL oli-delivery scripts are loaded (~1.5mb each)
+    # instead of only the scripts for the current page
     ~H"""
     <div
       :if={!is_nil(@current_page)}
@@ -312,7 +321,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
         role="prev_page"
       >
         <div class="px-6 py-2 rounded justify-end items-center gap-2 flex">
-          <.link navigate={resource_navigation_url(@previous_page, @section_slug)}>
+          <.link href={resource_navigation_url(@previous_page, @section_slug)}>
             <div class="w-[72px] h-10 opacity-30 hover:opacity-40 bg-blue-600 flex items-center justify-center">
               <.left_arrow />
             </div>
@@ -332,7 +341,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
           <%= @next_page["title"] %>
         </div>
         <div class="px-6 py-2 rounded justify-end items-center gap-2 flex">
-          <.link navigate={resource_navigation_url(@next_page, @section_slug)}>
+          <.link href={resource_navigation_url(@next_page, @section_slug)}>
             <div class="w-[72px] h-10 opacity-90 hover:opacity-100 bg-blue-600 flex items-center justify-center">
               <.right_arrow />
             </div>

--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -291,10 +291,6 @@ defmodule OliWeb.Components.Delivery.Layouts do
     # (for instance, the popup or the formula component from Oli.Rendering.Content.Html)
     # and the page would not react to interactions after navigatint to other page
     # ("working" loader kept spinning after interacting with an activity)
-    # drawback: we loose the speed of the liveview navigation
-    # (but do not increase time to first paint vs the previous page controller approach)
-    # HINT to increase speed: in every page reload ALL oli-delivery scripts are loaded (~1.5mb each)
-    # instead of only the scripts for the current page
     ~H"""
     <div
       :if={!is_nil(@current_page)}

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -369,7 +369,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
                 <span class="text-gray-400 opacity-80 dark:text-[#696974] dark:opacity-100 mr-1">
                   Due:
                 </span>
-                <%= to_formatted_datetime(
+                <%= FormatDateTime.to_formatted_datetime(
                   @unit["section_resource"]["end_date"],
                   @ctx,
                   "{WDshort}, {Mshort} {D}, {YYYY} ({h12}:{m}{am})"
@@ -467,7 +467,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
           ] %>
         </h2>
         <span class="text-[12px] leading-[16px] opacity-50 dark:text-white">
-          Due: <%= to_formatted_datetime(
+          Due: <%= FormatDateTime.to_formatted_datetime(
             Map.get(@selected_module_per_unit_resource_id, @unit["resource_id"])["section_resource"][
               "end_date"
             ],
@@ -1059,26 +1059,6 @@ defmodule OliWeb.Delivery.Student.LearnLive do
     if !String.contains?(Jason.encode!(content), "\"type\":\"h1\""), do: "mt-[52px]"
   end
 
-  defp to_formatted_datetime(nil, _ctx, _format), do: "not yet scheduled"
-
-  defp to_formatted_datetime(datetime, ctx, format) do
-    if is_binary(datetime) do
-      datetime
-      |> to_datetime
-      |> FormatDateTime.parse_datetime(ctx, format)
-    else
-      FormatDateTime.parse_datetime(datetime, ctx, format)
-    end
-  end
-
-  defp to_datetime(nil), do: "not yet scheduled"
-
-  defp to_datetime(string_datetime) do
-    {:ok, datetime, _} = DateTime.from_iso8601(string_datetime)
-
-    datetime
-  end
-
   defp get_module(hierarchy, unit_resource_id, module_resource_id) do
     unit =
       Enum.find(hierarchy["children"], fn unit ->
@@ -1203,7 +1183,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
       student_exception ->
         student_exception.end_date
     end
-    |> to_formatted_datetime(context, format)
+    |> FormatDateTime.to_formatted_datetime(context, format)
   end
 
   defp get_viewed_intro_video_resource_ids(section_slug, current_user_id) do

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -13,11 +13,20 @@ defmodule OliWeb.Delivery.Student.LessonLive do
     <div class="flex pb-20 flex-col items-center gap-15 flex-1">
       <div class="flex flex-col items-center w-full">
         <.scored_page_banner :if={@revision.graded} />
-        <div>
-          <%!-- PAGE CONTENT --%>
+        <div phx-update="ignore" id="eventIntercept" class="content py-20 px-32">
+          <%= raw(@html) %>
         </div>
       </div>
     </div>
+
+    <script>
+      window.userToken = "<%= @user_token %>";
+    </script>
+    <script>
+      OLI.initActivityBridge('eventIntercept');
+    </script>
+    <script :for={script <- @scripts} type="text/javascript" src={"/js/#{script}"}>
+    </script>
     """
   end
 

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -24,7 +24,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
             index={@current_page["index"]}
             container_label={get_container_label(@current_page["id"], @section)}
           />
-          <div phx-update="ignore" id="eventIntercept" class="content">
+          <div phx-update="ignore" id="eventIntercept" class="content" role="page_content">
             <%= raw(@html) %>
           </div>
         </div>
@@ -73,32 +73,27 @@ defmodule OliWeb.Delivery.Student.LessonLive do
 
   def page_header(assigns) do
     ~H"""
-    <div class="flex-col justify-start items-start gap-9 flex w-full">
+    <div id="page_header" class="flex-col justify-start items-start gap-9 flex w-full">
       <div class="flex-col justify-start items-start gap-3 flex w-full">
         <div class="self-stretch flex-col justify-start items-start flex">
           <div class="self-stretch justify-between items-center inline-flex">
             <div class="grow shrink basis-0 self-stretch justify-start items-center gap-3 flex">
-              <div class="opacity-50 dark:text-white text-sm font-bold font-['Open Sans'] uppercase tracking-wider">
+              <div
+                role="container label"
+                class="opacity-50 dark:text-white text-sm font-bold font-['Open Sans'] uppercase tracking-wider"
+              >
                 <%= @container_label %>
               </div>
 
               <div :if={@revision.graded} class="w-px self-stretch opacity-40 bg-black dark:bg-white">
               </div>
-              <div :if={@revision.graded} class="justify-start items-center gap-1.5 flex">
+              <div
+                :if={@revision.graded}
+                class="justify-start items-center gap-1.5 flex"
+                role="graded page marker"
+              >
                 <div class="w-[18px] h-[18px] relative">
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="18"
-                    height="18"
-                    viewBox="0 0 18 18"
-                    fill="none"
-                    role="flag icon"
-                  >
-                    <path
-                      d="M3.75 15.75V3H10.5L10.8 4.5H15V12H9.75L9.45 10.5H5.25V15.75H3.75Z"
-                      fill="#F68E2E"
-                    />
-                  </svg>
+                  <.flag_icon />
                 </div>
                 <div class="opacity-50 dark:text-white text-sm font-bold font-['Open Sans'] uppercase tracking-wider">
                   Graded Page
@@ -108,40 +103,33 @@ defmodule OliWeb.Delivery.Student.LessonLive do
             <div
               :if={@page_context.activities != %{}}
               class="px-2 py-1 bg-black bg-opacity-10 dark:bg-white dark:bg-opacity-10 rounded-xl shadow justify-start items-center gap-1 flex"
+              role="assignment marker"
             >
               <div class="dark:text-white text-[10px] font-normal font-['Open Sans']">
                 Assignment requirement
               </div>
             </div>
           </div>
-          <div class="self-stretch justify-start items-start gap-2.5 inline-flex">
-            <div class="opacity-50 dark:text-white text-[38px] font-bold font-['Open Sans']">
+          <div role="page label" class="self-stretch justify-start items-start gap-2.5 inline-flex">
+            <div
+              role="page numbering index"
+              class="opacity-50 dark:text-white text-[38px] font-bold font-['Open Sans']"
+            >
               <%= @index %>.
             </div>
-            <div class="grow shrink basis-0 dark:text-white text-[38px] font-bold font-['Open Sans']">
+            <div
+              role="page title"
+              class="grow shrink basis-0 dark:text-white text-[38px] font-bold font-['Open Sans']"
+            >
               <%= @revision.title %>
             </div>
           </div>
         </div>
         <div class="justify-start items-center gap-3 inline-flex">
           <div class="opacity-50 justify-start items-center gap-1.5 flex">
-            <div class="justify-end items-center gap-1 flex">
+            <div role="page read time" class="justify-end items-center gap-1 flex">
               <div class="w-[18px] h-[18px] relative opacity-80">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="18"
-                  height="18"
-                  viewBox="0 0 18 18"
-                  fill="none"
-                  role="time icon"
-                >
-                  <g opacity="0.8">
-                    <path
-                      class="fill-black dark:fill-white"
-                      d="M11.475 12.525L12.525 11.475L9.75 8.7V5.25H8.25V9.3L11.475 12.525ZM9 16.5C7.9625 16.5 6.9875 16.3031 6.075 15.9094C5.1625 15.5156 4.36875 14.9813 3.69375 14.3063C3.01875 13.6313 2.48438 12.8375 2.09063 11.925C1.69688 11.0125 1.5 10.0375 1.5 9C1.5 7.9625 1.69688 6.9875 2.09063 6.075C2.48438 5.1625 3.01875 4.36875 3.69375 3.69375C4.36875 3.01875 5.1625 2.48438 6.075 2.09063C6.9875 1.69688 7.9625 1.5 9 1.5C10.0375 1.5 11.0125 1.69688 11.925 2.09063C12.8375 2.48438 13.6313 3.01875 14.3063 3.69375C14.9813 4.36875 15.5156 5.1625 15.9094 6.075C16.3031 6.9875 16.5 7.9625 16.5 9C16.5 10.0375 16.3031 11.0125 15.9094 11.925C15.5156 12.8375 14.9813 13.6313 14.3063 14.3063C13.6313 14.9813 12.8375 15.5156 11.925 15.9094C11.0125 16.3031 10.0375 16.5 9 16.5ZM9 15C10.6625 15 12.0781 14.4156 13.2469 13.2469C14.4156 12.0781 15 10.6625 15 9C15 7.3375 14.4156 5.92188 13.2469 4.75313C12.0781 3.58438 10.6625 3 9 3C7.3375 3 5.92188 3.58438 4.75313 4.75313C3.58438 5.92188 3 7.3375 3 9C3 10.6625 3.58438 12.0781 4.75313 13.2469C5.92188 14.4156 7.3375 15 9 15Z"
-                    />
-                  </g>
-                </svg>
+                <.time_icon />
               </div>
               <div class="justify-end items-end gap-0.5 flex">
                 <div class="text-right dark:text-white text-xs font-bold font-['Open Sans'] uppercase tracking-wide">
@@ -153,7 +141,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
               </div>
             </div>
           </div>
-          <div class="justify-start items-start gap-1 flex">
+          <div role="page schedule" class="justify-start items-start gap-1 flex">
             <div class="opacity-50 dark:text-white text-xs font-normal font-['Open Sans']">Due:</div>
             <div class="dark:text-white text-xs font-normal font-['Open Sans']">
               <%= FormatDateTime.to_formatted_datetime(
@@ -168,6 +156,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
       <div
         :if={@page_context.objectives not in [nil, []]}
         class="flex-col justify-start items-start gap-3 flex w-full"
+        role="page objectives"
       >
         <div class="self-stretch justify-start items-start gap-6 inline-flex">
           <div class="opacity-80 dark:text-white text-sm font-bold font-['Open Sans'] uppercase tracking-wider">
@@ -178,6 +167,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
         <div
           :for={{objective, index} <- Enum.with_index(@page_context.objectives, 1)}
           class="self-stretch flex-col justify-start items-start flex"
+          role={"objective #{index}"}
         >
           <div class="self-stretch py-1 justify-start items-start inline-flex">
             <div class="grow shrink basis-0 h-6 justify-start items-start flex">
@@ -192,6 +182,41 @@ defmodule OliWeb.Delivery.Student.LessonLive do
         </div>
       </div>
     </div>
+    """
+  end
+
+  def flag_icon(assigns) do
+    ~H"""
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="18"
+      height="18"
+      viewBox="0 0 18 18"
+      fill="none"
+      role="flag icon"
+    >
+      <path d="M3.75 15.75V3H10.5L10.8 4.5H15V12H9.75L9.45 10.5H5.25V15.75H3.75Z" fill="#F68E2E" />
+    </svg>
+    """
+  end
+
+  def time_icon(assigns) do
+    ~H"""
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="18"
+      height="18"
+      viewBox="0 0 18 18"
+      fill="none"
+      role="time icon"
+    >
+      <g opacity="0.8">
+        <path
+          class="fill-black dark:fill-white"
+          d="M11.475 12.525L12.525 11.475L9.75 8.7V5.25H8.25V9.3L11.475 12.525ZM9 16.5C7.9625 16.5 6.9875 16.3031 6.075 15.9094C5.1625 15.5156 4.36875 14.9813 3.69375 14.3063C3.01875 13.6313 2.48438 12.8375 2.09063 11.925C1.69688 11.0125 1.5 10.0375 1.5 9C1.5 7.9625 1.69688 6.9875 2.09063 6.075C2.48438 5.1625 3.01875 4.36875 3.69375 3.69375C4.36875 3.01875 5.1625 2.48438 6.075 2.09063C6.9875 1.69688 7.9625 1.5 9 1.5C10.0375 1.5 11.0125 1.69688 11.925 2.09063C12.8375 2.48438 13.6313 3.01875 14.3063 3.69375C14.9813 4.36875 15.5156 5.1625 15.9094 6.075C16.3031 6.9875 16.5 7.9625 16.5 9C16.5 10.0375 16.3031 11.0125 15.9094 11.925C15.5156 12.8375 14.9813 13.6313 14.3063 14.3063C13.6313 14.9813 12.8375 15.5156 11.925 15.9094C11.0125 16.3031 10.0375 16.5 9 16.5ZM9 15C10.6625 15 12.0781 14.4156 13.2469 13.2469C14.4156 12.0781 15 10.6625 15 9C15 7.3375 14.4156 5.92188 13.2469 4.75313C12.0781 3.58438 10.6625 3 9 3C7.3375 3 5.92188 3.58438 4.75313 4.75313C3.58438 5.92188 3 7.3375 3 9C3 10.6625 3.58438 12.0781 4.75313 13.2469C5.92188 14.4156 7.3375 15 9 15Z"
+        />
+      </g>
+    </svg>
     """
   end
 

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -4,6 +4,9 @@ defmodule OliWeb.Delivery.Student.LessonLive do
   on_mount {OliWeb.LiveSessionPlugs.InitPage, :page_context}
   on_mount {OliWeb.LiveSessionPlugs.InitPage, :previous_next_index}
 
+  alias Oli.Delivery.Sections
+  alias OliWeb.Common.FormatDateTime
+
   def mount(_params, _session, socket) do
     {:ok, socket}
   end
@@ -13,8 +16,17 @@ defmodule OliWeb.Delivery.Student.LessonLive do
     <div class="flex pb-20 flex-col items-center gap-15 flex-1">
       <div class="flex flex-col items-center w-full">
         <.scored_page_banner :if={@revision.graded} />
-        <div phx-update="ignore" id="eventIntercept" class="content py-20 px-32">
-          <%= raw(@html) %>
+        <div class="w-[720px] pt-20 pb-10 flex-col justify-start items-center gap-10 inline-flex">
+          <.page_header
+            revision={@revision}
+            page_context={@page_context}
+            ctx={@ctx}
+            index={@current_page["index"]}
+            container_label={get_container_label(@current_page["id"], @section)}
+          />
+          <div phx-update="ignore" id="eventIntercept" class="content">
+            <%= raw(@html) %>
+          </div>
         </div>
       </div>
     </div>
@@ -50,5 +62,149 @@ defmodule OliWeb.Delivery.Student.LessonLive do
       </div>
     </div>
     """
+  end
+
+  attr :revision, Oli.Resources.Revision
+  attr :page_context, Oli.Delivery.Page.PageContext
+  attr :ctx, OliWeb.Common.SessionContext
+  attr :index, :string
+  attr :container_label, :string
+  attr :has_assignments?, :boolean
+
+  def page_header(assigns) do
+    ~H"""
+    <div class="flex-col justify-start items-start gap-9 flex w-full">
+      <div class="flex-col justify-start items-start gap-3 flex w-full">
+        <div class="self-stretch flex-col justify-start items-start flex">
+          <div class="self-stretch justify-between items-center inline-flex">
+            <div class="grow shrink basis-0 self-stretch justify-start items-center gap-3 flex">
+              <div class="opacity-50 dark:text-white text-sm font-bold font-['Open Sans'] uppercase tracking-wider">
+                <%= @container_label %>
+              </div>
+
+              <div :if={@revision.graded} class="w-px self-stretch opacity-40 bg-black dark:bg-white">
+              </div>
+              <div :if={@revision.graded} class="justify-start items-center gap-1.5 flex">
+                <div class="w-[18px] h-[18px] relative">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="18"
+                    height="18"
+                    viewBox="0 0 18 18"
+                    fill="none"
+                    role="flag icon"
+                  >
+                    <path
+                      d="M3.75 15.75V3H10.5L10.8 4.5H15V12H9.75L9.45 10.5H5.25V15.75H3.75Z"
+                      fill="#F68E2E"
+                    />
+                  </svg>
+                </div>
+                <div class="opacity-50 dark:text-white text-sm font-bold font-['Open Sans'] uppercase tracking-wider">
+                  Graded Page
+                </div>
+              </div>
+            </div>
+            <div
+              :if={@page_context.activities != %{}}
+              class="px-2 py-1 bg-black bg-opacity-10 dark:bg-white dark:bg-opacity-10 rounded-xl shadow justify-start items-center gap-1 flex"
+            >
+              <div class="dark:text-white text-[10px] font-normal font-['Open Sans']">
+                Assignment requirement
+              </div>
+            </div>
+          </div>
+          <div class="self-stretch justify-start items-start gap-2.5 inline-flex">
+            <div class="opacity-50 dark:text-white text-[38px] font-bold font-['Open Sans']">
+              <%= @index %>.
+            </div>
+            <div class="grow shrink basis-0 dark:text-white text-[38px] font-bold font-['Open Sans']">
+              <%= @revision.title %>
+            </div>
+          </div>
+        </div>
+        <div class="justify-start items-center gap-3 inline-flex">
+          <div class="opacity-50 justify-start items-center gap-1.5 flex">
+            <div class="justify-end items-center gap-1 flex">
+              <div class="w-[18px] h-[18px] relative opacity-80">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="18"
+                  height="18"
+                  viewBox="0 0 18 18"
+                  fill="none"
+                  role="time icon"
+                >
+                  <g opacity="0.8">
+                    <path
+                      class="fill-black dark:fill-white"
+                      d="M11.475 12.525L12.525 11.475L9.75 8.7V5.25H8.25V9.3L11.475 12.525ZM9 16.5C7.9625 16.5 6.9875 16.3031 6.075 15.9094C5.1625 15.5156 4.36875 14.9813 3.69375 14.3063C3.01875 13.6313 2.48438 12.8375 2.09063 11.925C1.69688 11.0125 1.5 10.0375 1.5 9C1.5 7.9625 1.69688 6.9875 2.09063 6.075C2.48438 5.1625 3.01875 4.36875 3.69375 3.69375C4.36875 3.01875 5.1625 2.48438 6.075 2.09063C6.9875 1.69688 7.9625 1.5 9 1.5C10.0375 1.5 11.0125 1.69688 11.925 2.09063C12.8375 2.48438 13.6313 3.01875 14.3063 3.69375C14.9813 4.36875 15.5156 5.1625 15.9094 6.075C16.3031 6.9875 16.5 7.9625 16.5 9C16.5 10.0375 16.3031 11.0125 15.9094 11.925C15.5156 12.8375 14.9813 13.6313 14.3063 14.3063C13.6313 14.9813 12.8375 15.5156 11.925 15.9094C11.0125 16.3031 10.0375 16.5 9 16.5ZM9 15C10.6625 15 12.0781 14.4156 13.2469 13.2469C14.4156 12.0781 15 10.6625 15 9C15 7.3375 14.4156 5.92188 13.2469 4.75313C12.0781 3.58438 10.6625 3 9 3C7.3375 3 5.92188 3.58438 4.75313 4.75313C3.58438 5.92188 3 7.3375 3 9C3 10.6625 3.58438 12.0781 4.75313 13.2469C5.92188 14.4156 7.3375 15 9 15Z"
+                    />
+                  </g>
+                </svg>
+              </div>
+              <div class="justify-end items-end gap-0.5 flex">
+                <div class="text-right dark:text-white text-xs font-bold font-['Open Sans'] uppercase tracking-wide">
+                  <%= @revision.duration_minutes %>
+                </div>
+                <div class="dark:text-white text-[9px] font-bold font-['Open Sans'] uppercase tracking-wide">
+                  min
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="justify-start items-start gap-1 flex">
+            <div class="opacity-50 dark:text-white text-xs font-normal font-['Open Sans']">Due:</div>
+            <div class="dark:text-white text-xs font-normal font-['Open Sans']">
+              <%= FormatDateTime.to_formatted_datetime(
+                @page_context.effective_settings.end_date,
+                @ctx,
+                "{WDshort} {Mshort} {D}, {YYYY}"
+              ) %>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        :if={@page_context.objectives not in [nil, []]}
+        class="flex-col justify-start items-start gap-3 flex w-full"
+      >
+        <div class="self-stretch justify-start items-start gap-6 inline-flex">
+          <div class="opacity-80 dark:text-white text-sm font-bold font-['Open Sans'] uppercase tracking-wider">
+            Learning objectives
+          </div>
+          <div class="hidden text-blue-500 text-sm font-semibold font-['Open Sans']">View More</div>
+        </div>
+        <div
+          :for={{objective, index} <- Enum.with_index(@page_context.objectives, 1)}
+          class="self-stretch flex-col justify-start items-start flex"
+        >
+          <div class="self-stretch py-1 justify-start items-start inline-flex">
+            <div class="grow shrink basis-0 h-6 justify-start items-start flex">
+              <div class="w-[30px] opacity-40 dark:text-white text-xs font-bold font-['Open Sans'] leading-normal">
+                L<%= index %>
+              </div>
+              <div class="grow shrink basis-0 opacity-80 dark:text-white text-sm font-normal font-['Open Sans'] leading-normal">
+                <%= objective %>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  defp get_container_label(page_id, section) do
+    container =
+      Oli.Delivery.Hierarchy.find_parent_in_hierarchy(
+        section.full_hierarchy,
+        fn node -> node["resource_id"] == String.to_integer(page_id) end
+      )["numbering"]
+
+    Sections.get_container_label_and_numbering(
+      %{numbering_level: container["level"], numbering_index: container["index"]},
+      section.customizations
+    )
   end
 end

--- a/lib/oli_web/live_session_plugs/init_page.ex
+++ b/lib/oli_web/live_session_plugs/init_page.ex
@@ -3,7 +3,6 @@ defmodule OliWeb.LiveSessionPlugs.InitPage do
 
   import Phoenix.Component, only: [assign: 2]
 
-  alias Oli.Activities
   alias Oli.Delivery.{PreviousNextIndex, Sections}
   alias Oli.Delivery.Page.PageContext
   alias Oli.Publishing.DeliveryResolver, as: Resolver

--- a/lib/oli_web/live_session_plugs/init_page.ex
+++ b/lib/oli_web/live_session_plugs/init_page.ex
@@ -153,13 +153,19 @@ defmodule OliWeb.LiveSessionPlugs.InitPage do
 
     assign(socket,
       html: Page.render(render_context, attempt_content, Page.Html),
-      # TODO improvement: do not load all delivery scripts (~1.5mb each)
-      # but just the one needed by the page
-      scripts: Activities.get_activity_scripts(:delivery_script)
+      scripts: get_required_activity_scripts(socket.assigns.page_context.activities)
     )
   end
 
   defp maybe_init_page_body(socket), do: socket
+
+  defp get_required_activity_scripts(activity_mapper) do
+    # this is an optimization to exclude not needed activity scripts (~1.5mb each)
+    Enum.map(activity_mapper, fn {_activity_id, activity} ->
+      activity.script
+    end)
+    |> Enum.uniq()
+  end
 
   defp get_attempt_content(socket) do
     this_attempt = socket.assigns.page_context.resource_attempts |> hd


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/NG23-39) to the ticket

This PR renders the page content (for non-graded pages) with its corresponding header.

To render the content correctly I had to replace the "navigate" with the common "href" in the navigation links.  With this change, we lost the speed of live navigation within a live_session, but the change was needed to correctly render the different components of the raw page HTML content.
On the other hand, an optimization was made to load only the activity scripts needed for the current page (in the previous page delivery controller version all scripts were loaded without checking which ones were needed, and each script is ~1.5 MB). This optimization compensates (in part) for the speed we lost when removing live_session navigation.

https://github.com/Simon-Initiative/oli-torus/assets/74839302/492c62a0-22d9-45d5-8c02-c44bf8e1bca6

### Next steps for [Lesson Epic](https://eliterate.atlassian.net/browse/NG23-40):
1) Build the [prologue view](https://eliterate.atlassian.net/browse/NG23-41) (for "begin attempt" and for "continue attempt")
2) Build the [review view](https://eliterate.atlassian.net/browse/NG23-42) for graded pages





 