### PR TITLE
Mer 2827 products assessment settings arent being honored in course setup

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -1550,7 +1550,7 @@ defmodule Oli.Delivery.Sections do
         numbering_level: level,
         slug: slug,
         collab_space_config: revision.collab_space_config,
-        max_attempts: revision.max_attempts,
+        max_attempts: revision.max_attempts || 0,
         resource_id: revision.resource_id,
         project_id: publication.project_id,
         scoring_strategy_id: revision.scoring_strategy_id,

--- a/lib/oli/delivery/sections/section_resource.ex
+++ b/lib/oli/delivery/sections/section_resource.ex
@@ -2,6 +2,8 @@ defmodule Oli.Delivery.Sections.SectionResource do
   use Ecto.Schema
   import Ecto.Changeset
 
+  alias Oli.Resources.Resource
+  alias Oli.Delivery.Settings.Combined
   alias Oli.Delivery.Sections.SectionResource
   alias Oli.Authoring.Course.Project
   alias Oli.Delivery.Sections.Section
@@ -50,11 +52,12 @@ defmodule Oli.Delivery.Sections.SectionResource do
 
     # the resource slug, resource and project mapping
     field :slug, :string
-    field :resource_id, :integer
+    # field :resource_id, :integer
     belongs_to :project, Project
 
     # the section this section resource belongs to
     belongs_to :section, Section
+    belongs_to :resource, Resource
 
     # resource delivery policy
     belongs_to :delivery_policy, DeliveryPolicy
@@ -106,26 +109,34 @@ defmodule Oli.Delivery.Sections.SectionResource do
     |> unique_constraint([:section_id, :resource_id])
   end
 
+  @initial_keys [
+    :id,
+    :numbering_index,
+    :numbering_level,
+    :scheduling_type,
+    :start_date,
+    :end_date,
+    :children,
+    :contained_page_count,
+    :slug,
+    :resource_id,
+    :project_id,
+    :section_id,
+    :delivery_policy_id,
+    :scoring_strategy_id,
+    :inserted_at,
+    :updated_at
+  ]
+
   def to_map(%SectionResource{} = section_resource) do
     section_resource
     |> Map.from_struct()
-    |> Map.take([
-      :id,
-      :numbering_index,
-      :numbering_level,
-      :scheduling_type,
-      :start_date,
-      :end_date,
-      :children,
-      :contained_page_count,
-      :slug,
-      :resource_id,
-      :project_id,
-      :section_id,
-      :delivery_policy_id,
-      :scoring_strategy_id,
-      :inserted_at,
-      :updated_at
-    ])
+    |> Map.take(keys_to_take())
+  end
+
+  defp keys_to_take() do
+    @initial_keys
+    |> Enum.concat(Map.keys(Map.from_struct(%Combined{})))
+    |> Enum.uniq()
   end
 end

--- a/lib/oli/delivery/sections/section_resource.ex
+++ b/lib/oli/delivery/sections/section_resource.ex
@@ -52,7 +52,6 @@ defmodule Oli.Delivery.Sections.SectionResource do
 
     # the resource slug, resource and project mapping
     field :slug, :string
-    # field :resource_id, :integer
     belongs_to :project, Project
 
     # the section this section resource belongs to

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -11,6 +11,7 @@ defmodule Oli.TestHelpers do
   alias Oli.Authoring.Course.Project
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.Section
+  alias Oli.Delivery.Sections.SectionResource
   alias Oli.Institutions
   alias Oli.PartComponents
   alias Oli.Publishing
@@ -3297,4 +3298,83 @@ defmodule Oli.TestHelpers do
         activity_provider
       )
   end
+
+  ### Begins helpers to create resources ###
+
+  def create_bundle_for(type_id, project, author, publication, resource, opts)
+
+  def create_bundle_for(type_id, project, author, nil, nil, opts) do
+    resource = insert(:resource)
+    publication = insert(:publication, project: project, root_resource_id: resource.id)
+
+    create_bundle_for(type_id, project, author, publication, resource, opts)
+    |> Map.merge(%{publication: publication})
+  end
+
+  def create_bundle_for(type_id, project, author, publication, nil, opts),
+    do: create_bundle_for(type_id, project, author, publication, insert(:resource), opts)
+
+  def create_bundle_for(type_id, project, author, publication, resource, opts) do
+    insert(:project_resource, project_id: project.id, resource_id: resource.id)
+    title = Keyword.get(opts, :title, title_for(resource.id))
+    slug = Keyword.get(opts, :slug, slug_for(resource.id))
+    graded = Keyword.get(opts, :graded, false)
+
+    revision =
+      insert(:revision,
+        resource: resource,
+        author: author,
+        resource_type_id: type_id,
+        title: title,
+        slug: slug,
+        graded: graded
+      )
+
+    insert(:published_resource,
+      publication: publication,
+      resource: resource,
+      revision: revision
+    )
+
+    %{resource: resource, revision: revision}
+  end
+
+  def create_project_with_assocs(opts \\ [])
+  def create_project_with_assocs([]), do: insert(:project, authors: [insert(:author)])
+
+  def create_project_with_assocs([{:authors, []}]), do: create_project_with_assocs()
+
+  def create_project_with_assocs([{:authors, authors}]) when is_list(authors),
+    do: insert(:project, authors: authors)
+
+  def assoc_resources(resources, container_revision, container_resource, publication) do
+    resources
+    |> Enum.map(& &1.id)
+    |> Enum.concat(container_revision.children)
+    |> set_container_children(container_resource, container_revision, publication)
+  end
+
+  defp set_container_children(children, container, container_revision, publication) do
+    {:ok, updated_revision} =
+      Oli.Resources.create_revision_from_previous(container_revision, %{children: children})
+
+    Publishing.get_published_resource!(publication.id, container.id)
+    |> Publishing.update_published_resource(%{revision_id: updated_revision.id})
+
+    updated_revision
+  end
+
+  def get_section_resource_by_resource(resource) do
+    from(sr in SectionResource,
+      join: s in assoc(sr, :section),
+      join: r in assoc(sr, :resource),
+      where: r.id == ^resource.id
+    )
+    |> Repo.one()
+  end
+
+  defp title_for(resource_id), do: "Container title for resource_id-#{resource_id}"
+  defp slug_for(resource_id), do: "slug_for_resource_id_#{resource_id}"
+
+  ### Ends helpers to create resources ###
 end


### PR DESCRIPTION
This PR fixed ticket [MER-2827](https://eliterate.atlassian.net/jira/software/c/projects/MER/issues/MER-2827) where some values were not inherited after creating a section from a product. 

In [these lines](https://github.com/Simon-Initiative/oli-torus/blob/f11379eb4ad9f52aa8060c616f7ebc3e7583ec3d/lib/oli/delivery/sections/section_resource.ex#L113-L128) some values were excluded such as `max_attempts`, `retake_mode` and so on. By doing that, those values were not passed to the created section.




[MER-2827]: https://eliterate.atlassian.net/browse/MER-2827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ