### PR TITLE
HotFix Flaky tests coming from the CourseDetailsTest module

### DIFF
--- a/test/oli_web/live/new_course/course_details_test.exs
+++ b/test/oli_web/live/new_course/course_details_test.exs
@@ -5,6 +5,8 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
   import Ecto.Query, warn: false
   import Phoenix.LiveViewTest
 
+  alias OliWeb.Sections.OverviewView
+
   @live_view_admin_route Routes.select_source_path(OliWeb.Endpoint, :admin)
   @live_view_independent_learner_route Routes.select_source_path(
                                          OliWeb.Endpoint,
@@ -107,11 +109,10 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
         "current_step" => 3
       })
 
-      flash =
-        assert_redirect(
-          view,
-          Routes.live_path(conn, OliWeb.Sections.OverviewView, "new_admin_course")
-        )
+      wait_for_completion()
+
+      redirect_to = Routes.live_path(conn, OverviewView, "new_admin_course")
+      flash = assert_redirect(view, redirect_to)
 
       assert flash["info"] == "Section successfully created."
     end
@@ -135,11 +136,10 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
         "current_step" => 3
       })
 
-      flash =
-        assert_redirect(
-          view,
-          Routes.live_path(conn, OliWeb.Sections.OverviewView, "new_admin_course")
-        )
+      wait_for_completion()
+
+      redirect_to = Routes.live_path(conn, OverviewView, "new_admin_course")
+      flash = assert_redirect(view, redirect_to)
 
       assert flash["info"] == "Section successfully created."
     end
@@ -201,11 +201,10 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
         "current_step" => 3
       })
 
-      flash =
-        assert_redirect(
-          view,
-          Routes.live_path(conn, OliWeb.Sections.OverviewView, "new_instructor_course")
-        )
+      wait_for_completion()
+
+      redirect_to = Routes.live_path(conn, OverviewView, "new_instructor_course")
+      flash = assert_redirect(view, redirect_to)
 
       assert flash["info"] == "Section successfully created."
     end
@@ -229,11 +228,10 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
         "current_step" => 3
       })
 
-      flash =
-        assert_redirect(
-          view,
-          Routes.live_path(conn, OliWeb.Sections.OverviewView, "new_instructor_course")
-        )
+      wait_for_completion()
+
+      redirect_to = Routes.live_path(conn, OverviewView, "new_instructor_course")
+      flash = assert_redirect(view, redirect_to)
 
       assert flash["info"] == "Section successfully created."
     end
@@ -294,7 +292,11 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
         "current_step" => 3
       })
 
-      flash = assert_redirect(view, Routes.delivery_path(OliWeb.Endpoint, :index))
+      wait_for_completion()
+
+      redirect_to = Routes.delivery_path(OliWeb.Endpoint, :index)
+      flash = assert_redirect(view, redirect_to)
+
       assert flash["info"] == "Section successfully created."
     end
 
@@ -324,9 +326,12 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
         |> where([s], s.blueprint_id == ^section.id)
         |> Oli.Repo.one()
 
+      wait_for_completion()
+
       assert blueprint_section.contains_explorations == true
 
-      flash = assert_redirect(view, Routes.delivery_path(OliWeb.Endpoint, :index))
+      redirect_to = Routes.delivery_path(OliWeb.Endpoint, :index)
+      flash = assert_redirect(view, redirect_to)
 
       assert flash["info"] == "Section successfully created."
     end

--- a/test/oli_web/live/new_course/course_details_test.exs
+++ b/test/oli_web/live/new_course/course_details_test.exs
@@ -5,8 +5,6 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
   import Ecto.Query, warn: false
   import Phoenix.LiveViewTest
 
-  alias OliWeb.Sections.OverviewView
-
   @live_view_admin_route Routes.select_source_path(OliWeb.Endpoint, :admin)
   @live_view_independent_learner_route Routes.select_source_path(
                                          OliWeb.Endpoint,
@@ -111,10 +109,8 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
 
       wait_for_completion()
 
-      redirect_to = Routes.live_path(conn, OverviewView, "new_admin_course")
-      flash = assert_redirect(view, redirect_to)
-
-      assert flash["info"] == "Section successfully created."
+      assert %{"info" => "Section successfully created."} ==
+               assert_redirect(view, ~p"/sections/new_admin_course")
     end
 
     test "successfully creates a section from a product", %{conn: conn} = context do
@@ -138,10 +134,8 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
 
       wait_for_completion()
 
-      redirect_to = Routes.live_path(conn, OverviewView, "new_admin_course")
-      flash = assert_redirect(view, redirect_to)
-
-      assert flash["info"] == "Section successfully created."
+      assert %{"info" => "Section successfully created."} ==
+               assert_redirect(view, ~p"/sections/new_admin_course")
     end
   end
 
@@ -203,10 +197,8 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
 
       wait_for_completion()
 
-      redirect_to = Routes.live_path(conn, OverviewView, "new_instructor_course")
-      flash = assert_redirect(view, redirect_to)
-
-      assert flash["info"] == "Section successfully created."
+      assert %{"info" => "Section successfully created."} ==
+               assert_redirect(view, ~p"/sections/new_instructor_course")
     end
 
     test "successfully creates a section from a product", %{conn: conn} = context do
@@ -230,10 +222,8 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
 
       wait_for_completion()
 
-      redirect_to = Routes.live_path(conn, OverviewView, "new_instructor_course")
-      flash = assert_redirect(view, redirect_to)
-
-      assert flash["info"] == "Section successfully created."
+      assert %{"info" => "Section successfully created."} ==
+               assert_redirect(view, ~p"/sections/new_instructor_course")
     end
   end
 
@@ -294,10 +284,7 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
 
       wait_for_completion()
 
-      redirect_to = Routes.delivery_path(OliWeb.Endpoint, :index)
-      flash = assert_redirect(view, redirect_to)
-
-      assert flash["info"] == "Section successfully created."
+      assert %{"info" => "Section successfully created."} == assert_redirect(view, ~p"/course")
     end
 
     test "successfully creates a section from a product", %{conn: conn} = context do
@@ -330,10 +317,7 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
 
       assert blueprint_section.contains_explorations == true
 
-      redirect_to = Routes.delivery_path(OliWeb.Endpoint, :index)
-      flash = assert_redirect(view, redirect_to)
-
-      assert flash["info"] == "Section successfully created."
+      assert %{"info" => "Section successfully created."} == assert_redirect(view, ~p"/course")
     end
   end
 

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -3103,7 +3103,8 @@ defmodule Oli.TestHelpers do
     insert(:published_resource, %{
       publication: publication,
       resource: page_revision.resource,
-      revision: page_revision
+      revision: page_revision,
+      author: insert(:author, email: "some_email@email.com")
     })
 
     section =
@@ -3297,4 +3298,101 @@ defmodule Oli.TestHelpers do
         activity_provider
       )
   end
+
+  ### Begins helpers to create resources ###
+
+  def create_bundle_for(type_id, project, author, publication, resource, opts)
+
+  def create_bundle_for(type_id, project, author, nil, nil, opts) do
+    resource = insert(:resource)
+    publication = insert(:publication, project: project, root_resource_id: resource.id)
+
+    create_bundle_for(type_id, project, author, publication, resource, opts)
+    |> Map.merge(%{publication: publication})
+  end
+
+  def create_bundle_for(type_id, project, author, publication, nil, opts),
+    do: create_bundle_for(type_id, project, author, publication, insert(:resource), opts)
+
+  def create_bundle_for(type_id, project, author, publication, resource, opts) do
+    insert(:project_resource, project_id: project.id, resource_id: resource.id)
+    title = Keyword.get(opts, :title, title_for(resource.id))
+    slug = Keyword.get(opts, :slug, slug_for(resource.id))
+    graded = Keyword.get(opts, :graded, false)
+
+    revision =
+      insert(:revision,
+        resource: resource,
+        author: author,
+        resource_type_id: type_id,
+        title: title,
+        slug: slug,
+        graded: graded
+      )
+
+    insert(:published_resource,
+      publication: publication,
+      resource: resource,
+      revision: revision
+    )
+
+    %{resource: resource, revision: revision}
+  end
+
+  def create_project_with_assocs(opts \\ [])
+  def create_project_with_assocs([]), do: insert(:project, authors: [insert(:author)])
+
+  def create_project_with_assocs([{:authors, []}]), do: create_project_with_assocs()
+
+  def create_project_with_assocs([{:authors, authors}]) when is_list(authors),
+    do: insert(:project, authors: authors)
+
+  def assoc_resources(resources, container_revision, container_resource, publication) do
+    resources
+    |> Enum.map(& &1.id)
+    |> Enum.concat(container_revision.children)
+    |> set_container_children(container_resource, container_revision, publication)
+  end
+
+  defp set_container_children(children, container, container_revision, publication) do
+    {:ok, updated_revision} =
+      Oli.Resources.create_revision_from_previous(container_revision, %{children: children})
+
+    Publishing.get_published_resource!(publication.id, container.id)
+    |> Publishing.update_published_resource(%{revision_id: updated_revision.id})
+
+    updated_revision
+  end
+
+  def get_section_resource_by_resource(resource) do
+    from(sr in SectionResource,
+      join: s in assoc(sr, :section),
+      join: r in assoc(sr, :resource),
+      where: r.id == ^resource.id
+    )
+    |> Repo.one()
+  end
+
+  defp title_for(resource_id), do: "Container title for resource_id-#{resource_id}"
+  defp slug_for(resource_id), do: "slug_for_resource_id_#{resource_id}"
+
+  ### Ends helpers to create resources ###
+
+  ### Begins helper that waits for Tasks to complete ###
+
+  def wait_for_completion() do
+    pids = Task.Supervisor.children(Oli.TaskSupervisor)
+    Enum.each(pids, &Process.monitor/1)
+    wait_for_pids(pids)
+  end
+
+  defp wait_for_pids([]), do: nil
+
+  defp wait_for_pids(pids) do
+    receive do
+      {:DOWN, _ref, :process, pid, _reason} -> wait_for_pids(List.delete(pids, pid))
+    end
+  end
+
+  ### Ends helper that waits for Tasks to complete ###
 end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -11,6 +11,7 @@ defmodule Oli.TestHelpers do
   alias Oli.Authoring.Course.Project
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.Section
+  alias Oli.Delivery.Sections.SectionResource
   alias Oli.Institutions
   alias Oli.PartComponents
   alias Oli.Publishing

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -11,7 +11,6 @@ defmodule Oli.TestHelpers do
   alias Oli.Authoring.Course.Project
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.Section
-  alias Oli.Delivery.Sections.SectionResource
   alias Oli.Institutions
   alias Oli.PartComponents
   alias Oli.Publishing
@@ -3299,85 +3298,6 @@ defmodule Oli.TestHelpers do
         activity_provider
       )
   end
-
-  ### Begins helpers to create resources ###
-
-  def create_bundle_for(type_id, project, author, publication, resource, opts)
-
-  def create_bundle_for(type_id, project, author, nil, nil, opts) do
-    resource = insert(:resource)
-    publication = insert(:publication, project: project, root_resource_id: resource.id)
-
-    create_bundle_for(type_id, project, author, publication, resource, opts)
-    |> Map.merge(%{publication: publication})
-  end
-
-  def create_bundle_for(type_id, project, author, publication, nil, opts),
-    do: create_bundle_for(type_id, project, author, publication, insert(:resource), opts)
-
-  def create_bundle_for(type_id, project, author, publication, resource, opts) do
-    insert(:project_resource, project_id: project.id, resource_id: resource.id)
-    title = Keyword.get(opts, :title, title_for(resource.id))
-    slug = Keyword.get(opts, :slug, slug_for(resource.id))
-    graded = Keyword.get(opts, :graded, false)
-
-    revision =
-      insert(:revision,
-        resource: resource,
-        author: author,
-        resource_type_id: type_id,
-        title: title,
-        slug: slug,
-        graded: graded
-      )
-
-    insert(:published_resource,
-      publication: publication,
-      resource: resource,
-      revision: revision
-    )
-
-    %{resource: resource, revision: revision}
-  end
-
-  def create_project_with_assocs(opts \\ [])
-  def create_project_with_assocs([]), do: insert(:project, authors: [insert(:author)])
-
-  def create_project_with_assocs([{:authors, []}]), do: create_project_with_assocs()
-
-  def create_project_with_assocs([{:authors, authors}]) when is_list(authors),
-    do: insert(:project, authors: authors)
-
-  def assoc_resources(resources, container_revision, container_resource, publication) do
-    resources
-    |> Enum.map(& &1.id)
-    |> Enum.concat(container_revision.children)
-    |> set_container_children(container_resource, container_revision, publication)
-  end
-
-  defp set_container_children(children, container, container_revision, publication) do
-    {:ok, updated_revision} =
-      Oli.Resources.create_revision_from_previous(container_revision, %{children: children})
-
-    Publishing.get_published_resource!(publication.id, container.id)
-    |> Publishing.update_published_resource(%{revision_id: updated_revision.id})
-
-    updated_revision
-  end
-
-  def get_section_resource_by_resource(resource) do
-    from(sr in SectionResource,
-      join: s in assoc(sr, :section),
-      join: r in assoc(sr, :resource),
-      where: r.id == ^resource.id
-    )
-    |> Repo.one()
-  end
-
-  defp title_for(resource_id), do: "Container title for resource_id-#{resource_id}"
-  defp slug_for(resource_id), do: "slug_for_resource_id_#{resource_id}"
-
-  ### Ends helpers to create resources ###
 
   ### Begins helper that waits for Tasks to complete ###
 


### PR DESCRIPTION
Ticket: [MER-2898](https://eliterate.atlassian.net/browse/MER-2898)

This PR fixes some flaky tests when running the `OliWeb.NewCourse.CourseDetailsTest` module. It looks like there was a race between the execution of [this Task](https://github.com/Simon-Initiative/oli-torus/blob/cfd475aad89d1c363dec46bf311cfaf315225268/lib/oli_web/live/new_course/new_course.ex#L265) and the events happening inside --check [this](https://github.com/Simon-Initiative/oli-torus/blob/cfd475aad89d1c363dec46bf311cfaf315225268/lib/oli_web/live/new_course/new_course.ex#L297) and [this](https://github.com/Simon-Initiative/oli-torus/blob/cfd475aad89d1c363dec46bf311cfaf315225268/lib/oli_web/live/new_course/new_course.ex#L301) and [this](https://github.com/Simon-Initiative/oli-torus/blob/cfd475aad89d1c363dec46bf311cfaf315225268/lib/oli_web/live/new_course/new_course.ex#L332) and [this](https://github.com/Simon-Initiative/oli-torus/blob/cfd475aad89d1c363dec46bf311cfaf315225268/lib/oli_web/live/new_course/new_course.ex#L337).

Reference where I got the solution: https://elixirforum.com/t/best-way-of-doing-an-integration-test-that-spans-a-task-start/39429/2



[MER-2898]: https://eliterate.atlassian.net/browse/MER-2898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ