### PR TITLE
[BUGFIX][MER-2641] Project export-import does not preserve language and custom labels

### DIFF
--- a/lib/oli/interop/export.ex
+++ b/lib/oli/interop/export.ex
@@ -19,7 +19,7 @@ defmodule Oli.Interop.Export do
     ([
        create_project_file(project),
        create_media_manifest_file(project),
-       create_hierarchy_file(resources, publication)
+       create_hierarchy_file(resources, publication, project)
      ] ++
        tags(resources) ++
        objectives(resources) ++
@@ -356,8 +356,7 @@ defmodule Oli.Interop.Export do
       description: project.description,
       type: "Manifest",
       required_student_survey: required_survey_resource_id,
-      attributes: Map.get(project, :attributes),
-      customizations: Map.get(project, :customizations)
+      attributes: Map.get(project, :attributes)
     }
     |> entry("_project.json")
   end
@@ -387,9 +386,10 @@ defmodule Oli.Interop.Export do
   end
 
   # create the singular hierarchy file
-  defp create_hierarchy_file(resources, publication) do
+  defp create_hierarchy_file(resources, publication, project) do
     revisions_by_id = Enum.reduce(resources, %{}, fn r, m -> Map.put(m, r.resource_id, r) end)
     root = Map.get(revisions_by_id, publication.root_resource_id)
+    customizations = Map.get(project, :customizations)
 
     %{
       type: "Hierarchy",
@@ -397,7 +397,19 @@ defmodule Oli.Interop.Export do
       originalFile: "",
       title: "",
       tags: transform_tags(root),
-      children: Enum.map(root.children, fn id -> full_hierarchy(revisions_by_id, id) end)
+      children:
+        Enum.map(root.children, fn id -> full_hierarchy(revisions_by_id, id) end) ++
+          unless(is_nil(customizations),
+            do: [
+              Map.merge(
+                %{
+                  type: "labels"
+                },
+                Map.from_struct(customizations)
+              )
+            ],
+            else: []
+          )
     }
     |> entry("_hierarchy.json")
   end

--- a/lib/oli/interop/export.ex
+++ b/lib/oli/interop/export.ex
@@ -355,7 +355,9 @@ defmodule Oli.Interop.Export do
       title: project.title,
       description: project.description,
       type: "Manifest",
-      required_student_survey: required_survey_resource_id
+      required_student_survey: required_survey_resource_id,
+      attributes: Map.get(project, :attributes),
+      customizations: Map.get(project, :customizations)
     }
     |> entry("_project.json")
   end

--- a/lib/oli/interop/ingest.ex
+++ b/lib/oli/interop/ingest.ex
@@ -103,7 +103,7 @@ defmodule Oli.Interop.Ingest do
            media_details <- Map.get(resource_map, @media_key),
            hierarchy_details <- Map.get(resource_map, @hierarchy_key),
            {:ok, %{project: project, resource_revision: root_revision}} <-
-             create_project(project_details, as_author, hierarchy_details),
+             create_project(project_details, as_author),
            {:ok, tag_map} <- create_tags(project, resource_map, as_author),
            {:ok, objective_map} <- create_objectives(project, resource_map, tag_map, as_author),
            {:ok, bib_map} <- create_bibentries(project, resource_map, as_author),
@@ -318,7 +318,7 @@ defmodule Oli.Interop.Ingest do
   end
 
   # Process the _project file to create the project structure
-  defp create_project(project_details, as_author, hierarchy) do
+  defp create_project(project_details, as_author) do
     case Map.get(project_details, "title") do
       nil ->
         {:error, :missing_project_title}
@@ -327,27 +327,11 @@ defmodule Oli.Interop.Ingest do
         {:error, :empty_project_title}
 
       title ->
-        labels =
-          Map.get(hierarchy, "children")
-          |> Enum.filter(fn c -> c["type"] == "labels" end)
-          |> Enum.reduce(%{}, fn item, acc ->
-            Map.merge(acc, %{
-              unit: Map.get(item, "unit"),
-              module: Map.get(item, "module"),
-              section: Map.get(item, "section")
-            })
-          end)
-
-        custom_labels =
-          case Map.equal?(labels, %{}) do
-            true -> nil
-            _ -> labels
-          end
-
         Oli.Authoring.Course.create_project(title, as_author, %{
           description: Map.get(project_details, "description"),
           legacy_svn_root: Map.get(project_details, "svnRoot"),
-          customizations: custom_labels
+          customizations: Map.get(project_details, "customizations"),
+          attributes: Map.get(project_details, "attributes")
         })
     end
   end

--- a/lib/oli/interop/ingest/processor/hierarchy.ex
+++ b/lib/oli/interop/ingest/processor/hierarchy.ex
@@ -38,11 +38,30 @@ defmodule Oli.Interop.Ingest.Processor.Hierarchy do
         end
       end)
 
+    labels =
+      Map.get(hierarchy_details, "children")
+      |> Enum.filter(fn c -> c["type"] == "labels" end)
+      |> Enum.reduce(%{}, fn item, acc ->
+        Map.merge(acc, %{
+          unit: Map.get(item, "unit"),
+          module: Map.get(item, "module"),
+          section: Map.get(item, "section")
+        })
+      end)
+
+    custom_labels =
+      case Map.equal?(labels, %{}) do
+        true -> nil
+        _ -> labels
+      end
+
+    {:ok, updated_project} =
+      Oli.Authoring.Course.update_project(project, %{customizations: custom_labels})
+
     # wire those newly created top-level containers into the root resource
     ChangeTracker.track_revision(project.slug, root_revision, %{children: children})
 
-    # %{state | container_id_map: container_id_map, project: updated_project}
-    %{state | container_id_map: container_id_map}
+    %{state | container_id_map: container_id_map, project: updated_project}
   end
 
   # This is the recursive container creation routine.  It processes a hierarchy by

--- a/lib/oli/interop/ingest/processor/hierarchy.ex
+++ b/lib/oli/interop/ingest/processor/hierarchy.ex
@@ -38,30 +38,11 @@ defmodule Oli.Interop.Ingest.Processor.Hierarchy do
         end
       end)
 
-    labels =
-      Map.get(hierarchy_details, "children")
-      |> Enum.filter(fn c -> c["type"] == "labels" end)
-      |> Enum.reduce(%{}, fn item, acc ->
-        Map.merge(acc, %{
-          unit: Map.get(item, "unit"),
-          module: Map.get(item, "module"),
-          section: Map.get(item, "section")
-        })
-      end)
-
-    custom_labels =
-      case Map.equal?(labels, %{}) do
-        true -> nil
-        _ -> labels
-      end
-
-    {:ok, updated_project} =
-      Oli.Authoring.Course.update_project(project, %{customizations: custom_labels})
-
     # wire those newly created top-level containers into the root resource
     ChangeTracker.track_revision(project.slug, root_revision, %{children: children})
 
-    %{state | container_id_map: container_id_map, project: updated_project}
+    # %{state | container_id_map: container_id_map, project: updated_project}
+    %{state | container_id_map: container_id_map}
   end
 
   # This is the recursive container creation routine.  It processes a hierarchy by

--- a/lib/oli/interop/ingest/processor/project.ex
+++ b/lib/oli/interop/ingest/processor/project.ex
@@ -28,8 +28,7 @@ defmodule Oli.Interop.Ingest.Processor.Project do
       Oli.Authoring.Course.create_project(title, author, %{
         description: Map.get(project_details, "description"),
         legacy_svn_root: Map.get(project_details, "svnRoot"),
-        attributes: Map.get(project_details, "attributes"),
-        customizations: Map.get(project_details, "customizations")
+        attributes: Map.get(project_details, "attributes")
       })
 
     # create alternatives groups

--- a/lib/oli/interop/ingest/processor/project.ex
+++ b/lib/oli/interop/ingest/processor/project.ex
@@ -27,7 +27,9 @@ defmodule Oli.Interop.Ingest.Processor.Project do
     {:ok, %{project: project, publication: publication, resource_revision: root_revision}} =
       Oli.Authoring.Course.create_project(title, author, %{
         description: Map.get(project_details, "description"),
-        legacy_svn_root: Map.get(project_details, "svnRoot")
+        legacy_svn_root: Map.get(project_details, "svnRoot"),
+        attributes: Map.get(project_details, "attributes"),
+        customizations: Map.get(project_details, "customizations")
       })
 
     # create alternatives groups

--- a/test/oli/interop/digest/_project.json
+++ b/test/oli/interop/digest/_project.json
@@ -1,5 +1,13 @@
 {
   "description": "An introduction to the food and drink of the Northern Spanish regions of Galicia and Asturias",
   "title": "The Cuisine of Northern Spain",
-  "type": "Manifest"
+  "type": "Manifest",
+  "attributes": {
+    "learning_language": "es"
+  },
+  "customizations": {
+    "module": "Module_New",
+    "unit": "Unit_New",
+    "section": "Section_New"
+  }
 }

--- a/test/oli/interop/digest/_project.json
+++ b/test/oli/interop/digest/_project.json
@@ -4,10 +4,5 @@
   "type": "Manifest",
   "attributes": {
     "learning_language": "es"
-  },
-  "customizations": {
-    "module": "Module_New",
-    "unit": "Unit_New",
-    "section": "Section_New"
   }
 }

--- a/test/oli/interop/ingest_test.exs
+++ b/test/oli/interop/ingest_test.exs
@@ -74,6 +74,8 @@ defmodule Oli.Interop.IngestTest do
       project = Repo.get(Oli.Authoring.Course.Project, p.id)
       assert project.title == "The Cuisine of Northern Spain"
       assert p.title == project.title
+      assert p.attributes == project.attributes
+      assert p.customizations == project.customizations
 
       # verify project access for author
       access =

--- a/test/oli/interop/ingest_test.exs
+++ b/test/oli/interop/ingest_test.exs
@@ -28,7 +28,7 @@ defmodule Oli.Interop.IngestTest do
       Map.get(m, ~c"_hierarchy.json")
       |> Jason.decode!()
 
-    assert length(Map.get(hierarchy, "children")) == 1
+    assert length(Map.get(hierarchy, "children")) == 2
     unit = Map.get(hierarchy, "children") |> hd
     assert Map.get(unit, "title") == "Unit 1"
     assert length(Map.get(unit, "children")) == 6


### PR DESCRIPTION
[MER-2641](https://eliterate.atlassian.net/browse/MER-2641)

This PR aims to add support for exporting a project to include the `attributes` and `customizations` fields. 

Within the `attributes` field the `learning language` feature will be included if the author made changes to it. 
In addition, `customizations` will include any changes to the customisation of labels for containers, **_units_**, **_modules_** and _**sections**_.

Also, support is added to be able to include these project features(attributes and customizations) when ingesting a project(in both versions of the ingest functionality) and have them reflected in the new imported project.


https://github.com/Simon-Initiative/oli-torus/assets/16328384/036cb1d0-9688-41c3-8283-8c888107d34f



[MER-2641]: https://eliterate.atlassian.net/browse/MER-2641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ