### PR TITLE
[FEATURE][MER-2891] Add link on curriculum page to all pages and vice versa

### DIFF
--- a/lib/oli_web/live/curriculum/container/container_live.html.heex
+++ b/lib/oli_web/live/curriculum/container/container_live.html.heex
@@ -13,11 +13,10 @@
         <i class="fas fa-history"></i> View revision history
       </.link>
       <.link
-        class="torus-button primary"
         href={~p"/authoring/project/#{@project.slug}/pages"}
         role="go_to_all_pages"
       >
-        Go to all pages
+        All Pages
       </.link>
     </div>
   </div>

--- a/lib/oli_web/live/curriculum/container/container_live.html.heex
+++ b/lib/oli_web/live/curriculum/container/container_live.html.heex
@@ -1,16 +1,25 @@
 <%= render_modal(assigns) %>
 
 <div id="curriculum-container" class="container mx-auto curriculum-editor">
-  <div class="flex justify-between">
-    <p class="mb-3">
+  <div class="flex justify-between items-center mb-3">
+    <p>
       Create and arrange your learning materials below.
     </p>
-    <.link
-      :if={@has_show_links_uri_hash and Accounts.is_admin?(@author)}
-      navigate={~p[/project/#{@project.slug}/history/slug/#{@container.slug}]}
-    >
-      <i class="fas fa-history"></i> View revision history
-    </.link>
+    <div class="flex items-center gap-x-4">
+      <.link
+        :if={@has_show_links_uri_hash and Accounts.is_admin?(@author)}
+        navigate={~p[/project/#{@project.slug}/history/slug/#{@container.slug}]}
+      >
+        <i class="fas fa-history"></i> View revision history
+      </.link>
+      <.link
+        class="torus-button primary"
+        href={~p"/authoring/project/#{@project.slug}/pages"}
+        role="go_to_all_pages"
+      >
+        Go to all pages
+      </.link>
+    </div>
   </div>
   <div class="grid grid-cols-12">
     <div class="col-span-12">

--- a/lib/oli_web/live/resources/pages_view.ex
+++ b/lib/oli_web/live/resources/pages_view.ex
@@ -149,104 +149,107 @@ defmodule OliWeb.Resources.PagesView do
     ~H"""
     <%= render_modal(assigns) %>
     <div class="container mx-auto">
-      <FilterBox.render
-        card_header_text="Browse All Pages"
-        card_body_text=""
-        table_model={@table_model}
-        show_sort={false}
-        show_more_opts={true}
-      >
-        <TextSearch.render
-          id="text-search"
-          text={@options.text_search}
-          event_target="#text-search-input"
-        />
+      <div class="flex flex-row justify-between">
+        <FilterBox.render
+          card_header_text="Browse All Pages"
+          card_body_text=""
+          table_model={@table_model}
+          show_sort={false}
+          show_more_opts={true}
+        >
+          <TextSearch.render
+            id="text-search"
+            text={@options.text_search}
+            event_target="#text-search-input"
+          />
 
-        <:extra_opts>
-          <form phx-change="change_graded" class="d-flex">
-            <select
-              name="graded"
-              id="select_graded"
-              class="custom-select custom-select mr-2"
-              style="width: 170px;"
-            >
-              <option value="" selected>Grading Type</option>
-              <option
-                :for={
-                  {value, str} <-
-                    graded_opts()
-                }
-                value={Kernel.to_string(value)}
-                selected={@options.graded == value}
+          <:extra_opts>
+            <form phx-change="change_graded" class="d-flex">
+              <select
+                name="graded"
+                id="select_graded"
+                class="custom-select custom-select mr-2"
+                style="width: 170px;"
               >
-                <%= str %>
-              </option>
-            </select>
-          </form>
+                <option value="" selected>Grading Type</option>
+                <option
+                  :for={
+                    {value, str} <-
+                      graded_opts()
+                  }
+                  value={Kernel.to_string(value)}
+                  selected={@options.graded == value}
+                >
+                  <%= str %>
+                </option>
+              </select>
+            </form>
 
-          <form phx-change="change_type" class="d-flex">
-            <select
-              name="type"
-              id="select_type"
-              class="custom-select custom-select mr-2"
-              style="width: 170px;"
-            >
-              <option value="" selected>Page Type</option>
-              <option
-                :for={
-                  {value, str} <-
-                    type_opts()
-                }
-                value={Kernel.to_string(value)}
-                selected={@options.basic == value}
+            <form phx-change="change_type" class="d-flex">
+              <select
+                name="type"
+                id="select_type"
+                class="custom-select custom-select mr-2"
+                style="width: 170px;"
               >
-                <%= str %>
-              </option>
-            </select>
-          </form>
-        </:extra_opts>
-      </FilterBox.render>
+                <option value="" selected>Page Type</option>
+                <option
+                  :for={
+                    {value, str} <-
+                      type_opts()
+                  }
+                  value={Kernel.to_string(value)}
+                  selected={@options.basic == value}
+                >
+                  <%= str %>
+                </option>
+              </select>
+            </form>
+          </:extra_opts>
+        </FilterBox.render>
+        <div>
+          <.link
+            class="torus-button primary self-start w-max"
+            href={~p"/authoring/project/#{@project.slug}/curriculum"}
+            role="go_to_curriculum"
+          >
+            Go to curriculum
+          </.link>
+        </div>
+      </div>
 
-      <div class="my-3 d-flex flex-row">
-        <div class="flex-grow-1" />
-        <div class="dropdown btn-group">
+      <div class="dropdown btn-group flex justify-end">
+        <button
+          type="button"
+          class="btn btn-primary dropdown-toggle"
+          data-bs-toggle="dropdown"
+          aria-haspopup="true"
+          aria-expanded="false"
+        >
+          Create <i class="fa-solid fa-caret-down ml-2"></i>
+        </button>
+        <div class="dropdown-menu dropdown-menu-right">
           <button
             type="button"
-            class="btn btn-primary dropdown-toggle"
-            data-bs-toggle="dropdown"
-            aria-haspopup="true"
-            aria-expanded="false"
+            class="dropdown-item"
+            phx-click="create_page"
+            phx-value-type="Unscored"
           >
-            Create <i class="fa-solid fa-caret-down ml-2"></i>
+            Practice Page
           </button>
-          <div class="dropdown-menu dropdown-menu-right">
+          <button type="button" class="dropdown-item" phx-click="create_page" phx-value-type="Scored">
+            Graded Assessment
+          </button>
+          <%= if Oli.Features.enabled?("adaptivity") do %>
             <button
               type="button"
               class="dropdown-item"
               phx-click="create_page"
-              phx-value-type="Unscored"
+              phx-value-type="Adaptive"
             >
-              Practice Page
+              Adaptive Page
             </button>
-            <button
-              type="button"
-              class="dropdown-item"
-              phx-click="create_page"
-              phx-value-type="Scored"
-            >
-              Graded Assessment
-            </button>
-            <%= if Oli.Features.enabled?("adaptivity") do %>
-              <button
-                type="button"
-                class="dropdown-item"
-                phx-click="create_page"
-                phx-value-type="Adaptive"
-              >
-                Adaptive Page
-              </button>
-            <% end %>
-          </div>
+          <% end %>
         </div>
       </div>
 
@@ -257,6 +260,7 @@ defmodule OliWeb.Resources.PagesView do
         offset={@offset}
         limit={limit()}
         scrollable={false}
+        no_records_message="There are no pages in this project"
       />
     </div>
     """

--- a/lib/oli_web/live/resources/pages_view.ex
+++ b/lib/oli_web/live/resources/pages_view.ex
@@ -209,11 +209,10 @@ defmodule OliWeb.Resources.PagesView do
         </FilterBox.render>
         <div>
           <.link
-            class="torus-button primary self-start w-max"
             href={~p"/authoring/project/#{@project.slug}/curriculum"}
             role="go_to_curriculum"
           >
-            Go to curriculum
+            Curriculum
           </.link>
         </div>
       </div>

--- a/test/oli_web/live/all_pages_live_test.exs
+++ b/test/oli_web/live/all_pages_live_test.exs
@@ -109,7 +109,7 @@ defmodule OliWeb.AllPagesLiveTest do
       assert has_element?(
                view,
                "a[href=\"/authoring/project/#{project.slug}/curriculum\"]",
-               "Go to curriculum"
+               "Curriculum"
              )
 
       assert has_element?(view, "button", "Create")
@@ -290,7 +290,7 @@ defmodule OliWeb.AllPagesLiveTest do
         live(conn, live_view_all_pages_route(project.slug))
 
       view
-      |> element("a[role='go_to_curriculum']", "Go to curriculum")
+      |> element("a[role='go_to_curriculum']", "Curriculum")
       |> render_click()
 
       assert_redirect(

--- a/test/oli_web/live/all_pages_live_test.exs
+++ b/test/oli_web/live/all_pages_live_test.exs
@@ -1,0 +1,302 @@
+defmodule OliWeb.AllPagesLiveTest do
+  use ExUnit.Case, async: true
+  use OliWeb.ConnCase
+
+  import Oli.Factory
+  import Phoenix.LiveViewTest
+
+  defp live_view_all_pages_route(project_slug) do
+    Routes.live_path(
+      OliWeb.Endpoint,
+      OliWeb.Resources.PagesView,
+      project_slug
+    )
+  end
+
+  defp insert_pages(project, publication, count) do
+    Enum.map(3..count, fn index ->
+      nested_page_resource = insert(:resource)
+
+      nested_page_revision =
+        insert(:revision, %{
+          objectives: %{"attached" => []},
+          scoring_strategy_id: Oli.Resources.ScoringStrategy.get_id_by_type("average"),
+          resource_type_id: Oli.Resources.ResourceType.get_id_by_type("page"),
+          children: [],
+          content: %{"model" => []},
+          deleted: false,
+          title: "Nested page #{index}",
+          resource: nested_page_resource
+        })
+
+      insert(:project_resource, %{project_id: project.id, resource_id: nested_page_resource.id})
+
+      insert(:published_resource, %{
+        publication: publication,
+        resource: nested_page_resource,
+        revision: nested_page_revision
+      })
+    end)
+  end
+
+  defp create_project_without_pages(_conn) do
+    project = insert(:project)
+    container_resource = insert(:resource)
+
+    insert(:project_resource, %{project_id: project.id, resource_id: container_resource.id})
+
+    container_revision =
+      insert(:revision, %{
+        resource: container_resource,
+        objectives: %{},
+        resource_type_id: Oli.Resources.ResourceType.get_id_by_type("container"),
+        children: [],
+        content: %{},
+        deleted: false,
+        slug: "root_container",
+        title: "Root Container"
+      })
+
+    publication =
+      insert(:publication, %{
+        project: project,
+        published: nil,
+        root_resource_id: container_resource.id
+      })
+
+    insert(:published_resource, %{
+      publication: publication,
+      resource: container_resource,
+      revision: container_revision
+    })
+
+    [project: project]
+  end
+
+  describe "user cannot access when is not logged in" do
+    test "redirects to new session when accessing the all pages view", %{
+      conn: conn
+    } do
+      project = insert(:project)
+
+      redirect_path =
+        "/authoring/session/new?request_path=%2Fauthoring%2Fproject%2F#{project.slug}%2Fpages"
+
+      {:error,
+       {:redirect,
+        %{
+          to: ^redirect_path
+        }}} =
+        live(conn, live_view_all_pages_route(project.slug))
+    end
+  end
+
+  describe "all pages view" do
+    setup [:admin_conn, :base_project_with_curriculum]
+
+    test "loads all pages view correctly", %{
+      conn: conn,
+      project: project,
+      nested_page_revision: nested_page_revision
+    } do
+      {:ok, view, _html} = live(conn, live_view_all_pages_route(project.slug))
+
+      assert view
+             |> element("h3")
+             |> render() =~
+               "Browse All Pages"
+
+      assert has_element?(
+               view,
+               "a[href=\"/authoring/project/#{project.slug}/curriculum\"]",
+               "Go to curriculum"
+             )
+
+      assert has_element?(view, "button", "Create")
+
+      assert has_element?(
+               view,
+               "input[id=\"text-search-input\"]"
+             )
+
+      assert has_element?(
+               view,
+               "select[name=\"graded\"][id=\"select_graded\"]"
+             )
+
+      assert has_element?(
+               view,
+               "select[name=\"type\"][id=\"select_type\"]"
+             )
+
+      assert has_element?(
+               view,
+               "table tbody tr:nth-child(1) td:nth-child(1)",
+               nested_page_revision.title
+             )
+    end
+
+    test "loads correctly when there are no pages in the project", %{
+      conn: conn
+    } do
+      [project: project] = create_project_without_pages(conn)
+
+      {:ok, view, _html} =
+        live(conn, live_view_all_pages_route(project.slug))
+
+      assert has_element?(view, "p", "There are no pages in this project")
+    end
+
+    test "applies filtering", %{
+      conn: conn,
+      project: project,
+      nested_page_revision: nested_page_revision,
+      nested_page_revision_2: nested_page_revision_2
+    } do
+      {:ok, view, _html} =
+        live(conn, live_view_all_pages_route(project.slug))
+
+      assert has_element?(
+               view,
+               "table tbody tr:nth-child(1) td:nth-child(1)",
+               nested_page_revision.title
+             )
+
+      assert has_element?(
+               view,
+               "table tbody tr:nth-child(2) td:nth-child(1)",
+               nested_page_revision_2.title
+             )
+
+      view
+      |> element("form[phx-change=\"change_graded\"")
+      |> render_change(%{"graded" => true})
+
+      assert has_element?(
+               view,
+               "table tbody tr:nth-child(1) td:nth-child(1)",
+               nested_page_revision_2.title
+             )
+
+      refute has_element?(
+               view,
+               nested_page_revision.title
+             )
+    end
+
+    test "applies searching", %{
+      conn: conn,
+      project: project,
+      nested_page_revision: nested_page_revision,
+      nested_page_revision_2: nested_page_revision_2
+    } do
+      {:ok, view, _html} =
+        live(conn, live_view_all_pages_route(project.slug))
+
+      assert has_element?(
+               view,
+               "table tbody tr:nth-child(1) td:nth-child(1)",
+               nested_page_revision.title
+             )
+
+      assert has_element?(
+               view,
+               "table tbody tr:nth-child(2) td:nth-child(1)",
+               nested_page_revision_2.title
+             )
+
+      view
+      |> element("#text-search-input")
+      |> render_hook("text_search_change", %{value: nested_page_revision.title})
+
+      assert has_element?(
+               view,
+               "table tbody tr:nth-child(1) td:nth-child(1)",
+               nested_page_revision.title
+             )
+
+      refute has_element?(
+               view,
+               nested_page_revision_2.title
+             )
+    end
+
+    test "applies sorting", %{
+      conn: conn,
+      project: project,
+      nested_page_revision: nested_page_revision,
+      nested_page_revision_2: nested_page_revision_2
+    } do
+      {:ok, view, _html} =
+        live(conn, live_view_all_pages_route(project.slug))
+
+      assert view
+             |> element("tr:first-child > td:first-child > div")
+             |> render() =~
+               nested_page_revision.title
+
+      # Sort by title desc
+      view
+      |> element("th[phx-click=\"paged_table_sort\"]:first-of-type")
+      |> render_click(%{sort_by: "title"})
+
+      assert view
+             |> element("tr:first-child > td:first-child > div")
+             |> render() =~
+               nested_page_revision_2.title
+    end
+
+    test "applies paging", %{
+      conn: conn,
+      project: project,
+      publication: publication,
+      nested_page_revision: nested_page_revision
+    } do
+      [_first_page | tail] =
+        insert_pages(project, publication, 26) |> Enum.sort_by(& &1.revision.title)
+
+      last_page = List.last(tail)
+
+      {:ok, view, _html} =
+        live(conn, live_view_all_pages_route(project.slug))
+
+      assert view
+             |> element("tr:first-child > td:first-child")
+             |> render() =~
+               nested_page_revision.title
+
+      refute view
+             |> element("tr:first-child > td:first-child")
+             |> render() =~
+               last_page.revision.title
+
+      view
+      |> element("#header_paging button[phx-click=\"paged_table_page_change\"]", "2")
+      |> render_click()
+
+      refute view
+             |> element("tr:first-child > td:first-child")
+             |> render() =~
+               nested_page_revision.title
+
+      assert view
+             |> element("tr:first-child > td:first-child")
+             |> render() =~
+               last_page.revision.title
+    end
+
+    test "can navigate to curriculum view", %{conn: conn, project: project} do
+      {:ok, view, _html} =
+        live(conn, live_view_all_pages_route(project.slug))
+
+      view
+      |> element("a[role='go_to_curriculum']", "Go to curriculum")
+      |> render_click()
+
+      assert_redirect(
+        view,
+        ~p"/authoring/project/#{project.slug}/curriculum"
+      )
+    end
+  end
+end

--- a/test/oli_web/live/curriculum/container_test.exs
+++ b/test/oli_web/live/curriculum/container_test.exs
@@ -356,6 +356,23 @@ defmodule OliWeb.Curriculum.ContainerLiveTest do
 
       refute render(view) =~ "View revision history"
     end
+
+    test "can navigate to all pages view", %{conn: conn, project: project} do
+      conn =
+        conn
+        |> get("/authoring/project/#{project.slug}/curriculum")
+
+      {:ok, view, _html} = live(conn)
+
+      view
+      |> element("a[role='go_to_all_pages']", "Go to all pages")
+      |> render_click()
+
+      assert_redirect(
+        view,
+        ~p"/authoring/project/#{project.slug}/pages"
+      )
+    end
   end
 
   defp setup_session(%{conn: conn}) do

--- a/test/oli_web/live/curriculum/container_test.exs
+++ b/test/oli_web/live/curriculum/container_test.exs
@@ -365,7 +365,7 @@ defmodule OliWeb.Curriculum.ContainerLiveTest do
       {:ok, view, _html} = live(conn)
 
       view
-      |> element("a[role='go_to_all_pages']", "Go to all pages")
+      |> element("a[role='go_to_all_pages']", "All Pages")
       |> render_click()
 
       assert_redirect(

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -520,6 +520,24 @@ defmodule Oli.TestHelpers do
     # Associate nested page to the project
     insert(:project_resource, %{project_id: project.id, resource_id: nested_page_resource.id})
 
+    nested_page_resource_2 = insert(:resource)
+
+    nested_page_revision_2 =
+      insert(:revision, %{
+        objectives: %{"attached" => []},
+        scoring_strategy_id: Oli.Resources.ScoringStrategy.get_id_by_type("average"),
+        resource_type_id: Oli.Resources.ResourceType.get_id_by_type("page"),
+        children: [],
+        content: %{"model" => []},
+        deleted: false,
+        title: "Nested page 2",
+        resource: nested_page_resource_2,
+        graded: true
+      })
+
+    # Associate nested page to the project
+    insert(:project_resource, %{project_id: project.id, resource_id: nested_page_resource_2.id})
+
     unit_one_resource = insert(:resource)
 
     # Associate unit to the project
@@ -532,7 +550,7 @@ defmodule Oli.TestHelpers do
       insert(:revision, %{
         objectives: %{},
         resource_type_id: Oli.Resources.ResourceType.get_id_by_type("container"),
-        children: [nested_page_resource.id],
+        children: [nested_page_resource.id, nested_page_resource_2.id],
         content: %{"model" => []},
         deleted: false,
         title: "The first unit",
@@ -580,6 +598,13 @@ defmodule Oli.TestHelpers do
       revision: nested_page_revision
     })
 
+    # Publish nested page resource 2
+    insert(:published_resource, %{
+      publication: publication,
+      resource: nested_page_resource_2,
+      revision: nested_page_revision_2
+    })
+
     # Publish unit one resource
     insert(
       :published_resource,
@@ -590,7 +615,13 @@ defmodule Oli.TestHelpers do
       }
     )
 
-    %{publication: publication, project: project, unit_one_revision: unit_one_revision}
+    %{
+      publication: publication,
+      project: project,
+      unit_one_revision: unit_one_revision,
+      nested_page_revision: nested_page_revision,
+      nested_page_revision_2: nested_page_revision_2
+    }
   end
 
   def section_with_assessment(_context, deployment \\ nil) do


### PR DESCRIPTION
[MER-2891](https://eliterate.atlassian.net/browse/MER-2891)

This PR adds buttons to navigate from the `Curriculum` view on the author side to the view that shows `All Pages` of the project and vice versa.

- Curriculum view: Added a button to go to the `All Pages` view.

- All pages view: Added a button to go to the `Curriculum` view.

Also, added some basic tests for the All Pages view.


https://github.com/Simon-Initiative/oli-torus/assets/16328384/02390f95-eeae-4109-bf1d-e508fcbdc1e7



[MER-2891]: https://eliterate.atlassian.net/browse/MER-2891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ