### PR TITLE
[BUG FIX] [MER-2907] Show Content Browser for LMS sections, fix CollabSpace rendering issue

### DIFF
--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -629,6 +629,7 @@ defmodule OliWeb.PageDeliveryController do
       conn,
       "page.html",
       %{
+        user: user,
         adaptive: adaptive,
         context: context,
         page: context.page,

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -289,6 +289,7 @@ defmodule OliWeb.PageDeliveryController do
           numbered_revisions = Sections.get_revision_indexes(section.slug)
 
           render(conn, "container.html",
+            user: user,
             scripts: [],
             section: section,
             title: title,
@@ -446,6 +447,7 @@ defmodule OliWeb.PageDeliveryController do
     numbered_revisions = Sections.get_revision_indexes(section.slug)
 
     render(conn, "prologue.html", %{
+      user: user,
       resource_access: resource_access,
       section_slug: section_slug,
       scripts: Activities.get_activity_scripts(),
@@ -935,6 +937,7 @@ defmodule OliWeb.PageDeliveryController do
             |> render(
               "instructor_page_preview.html",
               %{
+                user: nil,
                 summary: %{title: section.title},
                 section_slug: section_slug,
                 scripts: [],
@@ -972,6 +975,7 @@ defmodule OliWeb.PageDeliveryController do
             |> put_root_layout({OliWeb.LayoutView, "chromeless.html"})
             |> put_view(OliWeb.ResourceView)
             |> render("advanced_page_preview.html",
+              user: user,
               additional_stylesheets: Map.get(revision.content, "additionalStylesheets", []),
               activity_types: activity_types,
               scripts: Activities.get_activity_scripts(:delivery_script),
@@ -1097,6 +1101,7 @@ defmodule OliWeb.PageDeliveryController do
     |> render(
       "instructor_page_preview.html",
       %{
+        user: if is_nil(conn.assigns.current_user) do nil else conn.assigns.current_user end,
         summary: %{title: section.title},
         section_slug: section_slug,
         scripts: Enum.map(all_activities, fn a -> a.authoring_script end),

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -1101,7 +1101,12 @@ defmodule OliWeb.PageDeliveryController do
     |> render(
       "instructor_page_preview.html",
       %{
-        user: if is_nil(conn.assigns.current_user) do nil else conn.assigns.current_user end,
+        user:
+          if is_nil(conn.assigns.current_user) do
+            nil
+          else
+            conn.assigns.current_user
+          end,
         summary: %{title: section.title},
         section_slug: section_slug,
         scripts: Enum.map(all_activities, fn a -> a.authoring_script end),

--- a/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
@@ -14,7 +14,6 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive do
   @impl Phoenix.LiveView
   def mount(_params, session, socket) do
     ctx = SessionContext.init(socket, session)
-
     {:ok, assign(socket, ctx: ctx)}
   end
 
@@ -647,10 +646,25 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive do
         assigns.section_slug
       )
 
+    current_user_id = case assigns.ctx.user do
+      %Oli.Accounts.User{id: id} -> id
+      _ -> nil
+    end
+
+    current_author_id = case assigns.ctx.author do
+      %Oli.Accounts.Author{id: id} -> id
+      _ -> nil
+    end
+
     assigns =
       Map.merge(
         assigns,
-        %{revision_slug: revision_slug, collab_space_config: collab_space_config}
+        %{
+          current_user_id: current_user_id,
+          current_author_id: current_author_id,
+          revision_slug: revision_slug,
+          collab_space_config: collab_space_config
+        }
       )
 
     ~H"""
@@ -666,7 +680,9 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive do
               "section_slug" => @section_slug,
               "resource_slug" => @revision_slug,
               "is_instructor" => true,
-              "title" => "Course Discussion"
+              "title" => "Course Discussion",
+              "current_user_id" => @current_user_id,
+              "current_author_id" => @current_author_id
             }
           ) %>
         <% else %>

--- a/lib/oli_web/templates/layout/page.html.heex
+++ b/lib/oli_web/templates/layout/page.html.heex
@@ -50,7 +50,12 @@
                   "is_instructor" => @is_instructor,
                   "is_student" => @is_student,
                   "title" => "Page Discussion",
-                  "current_user_id" => if !is_nil(@user) do @user.id else nil end
+                  "current_user_id" =>
+                    if !is_nil(@user) do
+                      @user.id
+                    else
+                      nil
+                    end
                 }
               ) %>
             </div>

--- a/lib/oli_web/templates/layout/page.html.heex
+++ b/lib/oli_web/templates/layout/page.html.heex
@@ -49,7 +49,8 @@
                   "resource_slug" => @resource_slug,
                   "is_instructor" => @is_instructor,
                   "is_student" => @is_student,
-                  "title" => "Page Discussion"
+                  "title" => "Page Discussion",
+                  "current_user_id" => @user.id
                 }
               ) %>
             </div>

--- a/lib/oli_web/templates/layout/page.html.heex
+++ b/lib/oli_web/templates/layout/page.html.heex
@@ -50,7 +50,7 @@
                   "is_instructor" => @is_instructor,
                   "is_student" => @is_student,
                   "title" => "Page Discussion",
-                  "current_user_id" => @user.id
+                  "current_user_id" => if !is_nil(@user) do @user.id else nil end
                 }
               ) %>
             </div>

--- a/lib/oli_web/templates/page_delivery/index.html.heex
+++ b/lib/oli_web/templates/page_delivery/index.html.heex
@@ -42,22 +42,21 @@
       </div>
 
       <div class="flex flex-col gap-x-4 lg:flex-row">
-        <%= if @independent_learner do %>
-          <div class={
-            if @collab_space_config && assigns.collab_space_config.status != :disabled,
-              do: "lg:basis-2/3 mt-3",
-              else: "w-full"
-          }>
-            <%= live_render(@conn, OliWeb.Delivery.StudentDashboard.CourseContentLive,
-              session: %{
-                "section_slug" => @section_slug,
-                "current_user_id" => @current_user_id,
-                "preview_mode" => @preview_mode,
-                "scheduled_dates" => @scheduled_dates
-              }
-            ) %>
-          </div>
-        <% end %>
+
+        <div class={
+          if @collab_space_config && assigns.collab_space_config.status != :disabled,
+            do: "lg:basis-2/3 mt-3",
+            else: "w-full"
+        }>
+          <%= live_render(@conn, OliWeb.Delivery.StudentDashboard.CourseContentLive,
+            session: %{
+              "section_slug" => @section_slug,
+              "current_user_id" => @current_user_id,
+              "preview_mode" => @preview_mode,
+              "scheduled_dates" => @scheduled_dates
+            }
+          ) %>
+        </div>
 
         <%= if @collab_space_config && assigns.collab_space_config.status != :disabled do %>
           <div class="mt-3 mb-5 lg:basis-1/3">
@@ -67,7 +66,8 @@
                 "section_slug" => @section_slug,
                 "resource_slug" => @revision_slug,
                 "is_instructor" => @is_instructor,
-                "is_student" => @is_student
+                "is_student" => @is_student,
+                "current_user_id" => @current_user_id
               }
             ) %>
           </div>


### PR DESCRIPTION
This PR fixes two issues:

1. The student facing "Content Browser", on the home screen, was conditionally being rendered for **only open and free sections**.  It needs to be exist for LMS sections as well. This PR removes the `<%= if @independent_learner do %>` which guarded the rendering of it. 

2. AppSignal has been reporting many instances of a `** (ArgumentError) cannot perform Ecto.Repo.get/2 because the given value is nil` error.  The stack trace points to a problem during the mount of the `CollabSpaceView`, where both `current_user_id` and `current_author_id` attributes of the LV session are `nil`.  My theory is that these session attributes aren't getting populated in certain usage patterns where the user **first** visits a rendered page.  The page rendering comes from a standard controller which directly renders the LV CollabSpaceView.  That direct rendering augments an existing LV session, but there isn't one in this case.  The solution here is to always add in the `current_user_id` value as a session augmentation. 