### PR TITLE
[Feature] Insert content, and objectives improvements [MER-2888] [MER-2887]

### DIFF
--- a/assets/src/components/content/add_resource_content/AddResourceContent.modules.scss
+++ b/assets/src/components/content/add_resource_content/AddResourceContent.modules.scss
@@ -41,6 +41,10 @@
   }
 }
 
+.last {
+  opacity: 1;
+}
+
 .active {
   opacity: 1;
 
@@ -68,8 +72,8 @@
 .insertAdornment {
   display: block;
   width: 100%;
-  height: 2px;
-  background-color: var(--color-gray-500);
+  height: 1px;
+  background-color: var(--color-gray-400);
   opacity: inherit;
   transition: opacity 200ms ease-out;
 }

--- a/assets/src/components/content/add_resource_content/AddResourceContent.tsx
+++ b/assets/src/components/content/add_resource_content/AddResourceContent.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { OverlayTrigger, Popover } from 'react-bootstrap';
+import { Tooltip } from 'components/common/Tooltip';
 import { ActivityEditContext } from 'data/content/activity';
 import { ResourceContent } from 'data/content/resource';
 import { classNames } from 'utils/classNames';
@@ -46,14 +47,17 @@ export const AddResourceContent: React.FC<AddResourceContentProps> = ({
             styles.addResourceContent,
             !editMode && styles.disabled,
             isPopoverOpen && styles.active,
+            isLast && styles.last,
           )}
         >
           {editMode && (
             <>
               <div className={styles.insertButtonContainer}>
-                <div className={styles.insertButton}>
-                  <i className="fa fa-plus"></i>
-                </div>
+                <Tooltip placement="bottom" title="Insert Content">
+                  <div className={styles.insertButton}>
+                    <i className="fa fa-plus"></i>
+                  </div>
+                </Tooltip>
               </div>
               <div className={styles.insertAdornment}></div>
             </>

--- a/assets/src/components/resource/objectives/ObjectivesSelection.tsx
+++ b/assets/src/components/resource/objectives/ObjectivesSelection.tsx
@@ -87,7 +87,7 @@ export const ObjectivesSelection = (props: ObjectivesProps) => {
   // The current 'selected' state of Typeahead must be the same shape as
   // the options objects. So we look up from our list of slugs those objects.
   const map = Immutable.Map<ResourceId, Objective>(objectives.map((o) => [o.id, o]));
-  const asObjectives = selected.map((s) => map.get(s) as Objective);
+  const asObjectives = selected.map((s) => map.get(s) as Objective).filter((o) => !!o);
 
   const allowNewObjective = !!onRegisterNewObjective;
   const hasObjectives = objectives.length > 0;

--- a/assets/src/components/resource/objectives/ObjectivesSelection.tsx
+++ b/assets/src/components/resource/objectives/ObjectivesSelection.tsx
@@ -43,6 +43,16 @@ function createMapById(objectives: Objective[]) {
   }, {});
 }
 
+const getPlaceholderLabel = (hasObjectives: boolean, editMode: boolean) => {
+  if (editMode) {
+    return hasObjectives
+      ? 'Select or Create learning objectives...'
+      : 'Create a new learning objective';
+  } else {
+    return 'Select a learning objective';
+  }
+};
+
 export const ObjectivesSelection = (props: ObjectivesProps) => {
   const { objectives, editMode, selected, onEdit, onRegisterNewObjective } = props;
 
@@ -80,6 +90,8 @@ export const ObjectivesSelection = (props: ObjectivesProps) => {
   const asObjectives = selected.map((s) => map.get(s) as Objective);
 
   const allowNewObjective = !!onRegisterNewObjective;
+  const hasObjectives = objectives.length > 0;
+  const placeholder = getPlaceholderLabel(hasObjectives, editMode && !!onRegisterNewObjective);
 
   return (
     <div className={classNames(styles.objectivesSelection, 'flex-grow-1')}>
@@ -144,7 +156,7 @@ export const ObjectivesSelection = (props: ObjectivesProps) => {
         newSelectionPrefix="Create new objective: "
         labelKey="title"
         selected={asObjectives}
-        placeholder="Select learning objectives..."
+        placeholder={placeholder}
       />
     </div>
   );


### PR DESCRIPTION
This makes two small usability changes to authoring and fixes one bug.

1. The objectives editor has different placeholder text depending on the situation.

Basic page with no objectives:
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/3cd7fb30-5886-4ae9-803b-3d6bed17ddaa)

Basic page with existing objectives:
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/a3cdf8dd-8216-40bf-9c7e-2acfb8c0846d)

Adaptive page either way (they can't be added here):
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/087ea43f-e863-4f3f-82c7-5a7aa811254a)


2. The very last add-content control on a basic page is now always visible. Before, it only appeared when you hovered over it. 

![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/63821e2f-a8a8-48c3-b896-43b441ccec7c)


Bugfix:

If you add an objective to an adaptive screen, then delete that objective, the adaptive editor would crash the next time you tried to edit the objectives for that screen.



