### PR TITLE
Mer 1886 discussions remove them from student view if the feature is not turned on

### DIFF
--- a/lib/oli/delivery.ex
+++ b/lib/oli/delivery.ex
@@ -153,6 +153,7 @@ defmodule Oli.Delivery do
         )
 
       {:ok, %Section{} = section} = Sections.create_section_resources(section, publication)
+      section = Sections.maybe_update_contains_discusssions(section)
       {:ok, _} = Sections.rebuild_contained_pages(section)
       {:ok, _} = Sections.rebuild_contained_objectives(section)
 

--- a/lib/oli/delivery.ex
+++ b/lib/oli/delivery.ex
@@ -1,8 +1,9 @@
 defmodule Oli.Delivery do
   alias Lti_1p3.Tool.ContextRoles
   alias Lti_1p3.Tool.Services.{AGS, NRPS}
-  alias Oli.Delivery.Settings.StudentException
   alias Oli.Delivery.Sections
+  alias Oli.Delivery.Sections.PostProcessing
+  alias Oli.Delivery.Settings.StudentException
   alias Oli.Delivery.Sections.{Section, SectionsProjectsPublications}
   alias Oli.Institutions
   alias Oli.Lti.LtiParams
@@ -153,7 +154,7 @@ defmodule Oli.Delivery do
         )
 
       {:ok, %Section{} = section} = Sections.create_section_resources(section, publication)
-      section = Sections.maybe_update_contains_discusssions(section)
+      section = PostProcessing.apply(section, [:discussions])
       {:ok, _} = Sections.rebuild_contained_pages(section)
       {:ok, _} = Sections.rebuild_contained_objectives(section)
 

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -1476,6 +1476,7 @@ defmodule Oli.Delivery.Sections do
       join: sr in assoc(s, :section_resources),
       where: s.id == ^section.id,
       where: fragment("?->>'status' = ?", sr.collab_space_config, "enabled"),
+      limit: 1,
       select: sr.id
     )
     |> Oli.Repo.all()

--- a/lib/oli/delivery/sections/post_processing.ex
+++ b/lib/oli/delivery/sections/post_processing.ex
@@ -1,0 +1,73 @@
+defmodule Oli.Delivery.Sections.PostProcessing do
+  import Ecto.Query, warn: false
+  alias Oli.Repo
+
+  alias Oli.Delivery.Sections
+  alias Oli.Delivery.Sections.Section
+  alias Oli.Publishing.DeliveryResolver
+  alias Oli.Resources.ResourceType
+
+  @type options :: [option]
+  @type option :: :all | :discussions | :explorations | :deliberate_practice
+
+  @page_type_id ResourceType.get_id_by_type("page")
+
+  @spec apply(Section.t(), options()) :: Section.t()
+  def apply(section, actions \\ []) do
+    all = [:discussions, :explorations, :deliberate_practice]
+    actions = if actions == :all, do: all, else: actions
+
+    result =
+      Enum.reduce(Enum.uniq(actions), %{}, fn action, acc ->
+        case action do
+          :discussions ->
+            Map.put(acc, :contains_discussions, maybe_update_contains_discusssions(section))
+
+          :explorations ->
+            Map.put(acc, :contains_explorations, maybe_update_contains_explorations(section))
+
+          :deliberate_practice ->
+            Map.put(acc, :deliberate_practice, contains_deliberate_practice(section))
+
+          _ ->
+            acc
+        end
+      end)
+
+    Sections.update_section!(section, result)
+  end
+
+  # Updates contains_discussions flag if an active discussion is present.
+  @spec maybe_update_contains_discusssions(Section.t()) :: boolean()
+  defp maybe_update_contains_discusssions(section) do
+    from(s in Section,
+      join: sr in assoc(s, :section_resources),
+      where: s.id == ^section.id,
+      where: fragment("?->>'status' = ?", sr.collab_space_config, "enabled"),
+      limit: 1,
+      select: sr.id
+    )
+    |> Repo.exists?()
+  end
+
+  @spec maybe_update_contains_explorations(Section.t()) :: boolean()
+  defp maybe_update_contains_explorations(section) do
+    from([rev: rev] in base_query(section), where: rev.purpose == :application)
+    |> Repo.exists?()
+  end
+
+  @spec contains_deliberate_practice(Section.t()) :: boolean()
+  defp contains_deliberate_practice(section) do
+    from([rev: rev] in base_query(section), where: rev.purpose == :deliberate_practice)
+    |> Repo.exists?()
+  end
+
+  defp base_query(section) do
+    from([sr: sr, rev: rev] in DeliveryResolver.section_resource_revisions(section.slug),
+      where: rev.deleted == false,
+      where: rev.resource_type_id == ^@page_type_id,
+      limit: 1,
+      select: rev.id
+    )
+  end
+end

--- a/lib/oli/delivery/sections/section.ex
+++ b/lib/oli/delivery/sections/section.ex
@@ -64,6 +64,7 @@ defmodule Oli.Delivery.Sections.Section do
     field(:resource_gating_index, :map, default: %{})
     field(:previous_next_index, :map, default: nil)
     field(:display_curriculum_item_numbering, :boolean, default: true)
+    field(:contains_discussions, :boolean, default: false)
     field(:contains_explorations, :boolean, default: false)
     field(:contains_deliberate_practice, :boolean, default: false)
 
@@ -185,6 +186,7 @@ defmodule Oli.Delivery.Sections.Section do
       :skip_email_verification,
       :publisher_id,
       :display_curriculum_item_numbering,
+      :contains_discussions,
       :contains_explorations,
       :contains_deliberate_practice,
       :required_survey_resource_id,

--- a/lib/oli/delivery/sections/section_resource.ex
+++ b/lib/oli/delivery/sections/section_resource.ex
@@ -67,7 +67,7 @@ defmodule Oli.Delivery.Sections.SectionResource do
   end
 
   @doc false
-  def changeset(section_resource, attrs) do
+  def changeset(section_resource, attrs \\ %{}) do
     section_resource
     |> cast(attrs, [
       :numbering_index,

--- a/priv/repo/migrations/20240109143456_add_contains_discussions_column.exs
+++ b/priv/repo/migrations/20240109143456_add_contains_discussions_column.exs
@@ -1,0 +1,26 @@
+defmodule Oli.Repo.Migrations.AddContainsDiscussionsColumn do
+  use Ecto.Migration
+
+  def up do
+    alter table(:sections) do
+      add :contains_discussions, :boolean, default: false
+    end
+
+    flush()
+
+    execute("""
+    UPDATE sections SET contains_discussions = true WHERE id IN (
+      SELECT sr.section_id
+      FROM section_resources sr
+      WHERE sr.collab_space_config ->>'status' = 'enabled'
+      GROUP BY sr.section_id
+    )
+    """)
+  end
+
+  def down do
+    alter table(:sections) do
+      remove :contains_discussions
+    end
+  end
+end

--- a/test/oli/delivery/sections_test.exs
+++ b/test/oli/delivery/sections_test.exs
@@ -6,6 +6,7 @@ defmodule Oli.Delivery.SectionsTest do
   alias Oli.Utils.Seeder
   alias Oli.Factory
   alias Oli.Delivery.Sections
+  alias Oli.Delivery.Sections.PostProcessing
   alias Oli.Delivery.Sections.SectionResource
 
   describe "maybe_update_contains_discusssions/1" do
@@ -91,7 +92,7 @@ defmodule Oli.Delivery.SectionsTest do
       |> Ecto.Changeset.put_embed(:collab_space_config, archived_collab_space_config)
       |> Oli.Repo.update!()
 
-      Sections.maybe_update_contains_discusssions(section)
+      PostProcessing.apply(section, [:discussions])
 
       assert Oli.Repo.reload!(section).contains_discussions
     end
@@ -166,7 +167,7 @@ defmodule Oli.Delivery.SectionsTest do
       |> Ecto.Changeset.put_embed(:collab_space_config, archived_collab_space_config)
       |> Oli.Repo.update!()
 
-      Sections.maybe_update_contains_discusssions(section)
+      PostProcessing.apply(section, [:discussions])
 
       refute Oli.Repo.reload!(section).contains_discussions
     end

--- a/test/oli/delivery/sections_test.exs
+++ b/test/oli/delivery/sections_test.exs
@@ -6,6 +6,171 @@ defmodule Oli.Delivery.SectionsTest do
   alias Oli.Utils.Seeder
   alias Oli.Factory
   alias Oli.Delivery.Sections
+  alias Oli.Delivery.Sections.SectionResource
+
+  describe "maybe_update_contains_discusssions/1" do
+    alias Oli.Resources.ResourceType
+    alias Oli.Resources.Collaboration.CollabSpaceConfig
+    import Oli.Factory
+    import Oli.TestHelpers
+    @page_type_id ResourceType.get_id_by_type("page")
+    @container_type_id ResourceType.get_id_by_type("container")
+
+    test "sets contains_discussions to true when having active discussions" do
+      # Project and Author
+      %{authors: [author]} = project = create_project_with_assocs()
+
+      # Root container
+      %{resource: container_resource, revision: container_revision, publication: publication} =
+        create_bundle_for(@container_type_id, project, author, nil, nil, title: "Root container")
+
+      # Resources
+      pages =
+        for _x <- 1..3, do: create_bundle_for(@page_type_id, project, author, publication)
+
+      others =
+        for _x <- 1..2, do: create_bundle_for(@container_type_id, project, author, publication)
+
+      pages_resources = Enum.map(pages, & &1.resource)
+      others_resources = Enum.map(others, & &1.resource)
+      # Links container - page
+      assoc_resources(
+        pages_resources ++ others_resources,
+        container_revision,
+        container_resource,
+        publication
+      )
+
+      # Section and its section_resources
+      {:ok, section} =
+        insert(:section, base_project: project, open_and_free: true)
+        |> Sections.create_section_resources(publication)
+
+      refute section.contains_discussions
+
+      all_section_resources =
+        section |> Oli.Repo.preload(:section_resources) |> Map.get(:section_resources)
+
+      {pages_section_resources, _rest_section_resources} =
+        Enum.split_with(all_section_resources, fn sr ->
+          sr.resource_id in Enum.map(pages_resources, & &1.id)
+        end)
+
+      [id_sec_res_1, id_sec_res_2, id_sec_res_3] = Enum.map(pages_section_resources, & &1.id)
+
+      enabled_collab_space_config =
+        %CollabSpaceConfig{}
+        |> CollabSpaceConfig.changeset(%{status: :enabled})
+        |> Ecto.Changeset.apply_changes()
+
+      disabled_collab_space_config =
+        %CollabSpaceConfig{}
+        |> CollabSpaceConfig.changeset(%{status: :disabled})
+        |> Ecto.Changeset.apply_changes()
+
+      archived_collab_space_config =
+        %CollabSpaceConfig{}
+        |> CollabSpaceConfig.changeset(%{status: :archived})
+        |> Ecto.Changeset.apply_changes()
+
+      SectionResource
+      |> Oli.Repo.get!(id_sec_res_1)
+      |> SectionResource.changeset()
+      |> Ecto.Changeset.put_embed(:collab_space_config, enabled_collab_space_config)
+      |> Oli.Repo.update!()
+
+      SectionResource
+      |> Oli.Repo.get!(id_sec_res_2)
+      |> SectionResource.changeset()
+      |> Ecto.Changeset.put_embed(:collab_space_config, disabled_collab_space_config)
+      |> Oli.Repo.update!()
+
+      SectionResource
+      |> Oli.Repo.get!(id_sec_res_3)
+      |> SectionResource.changeset()
+      |> Ecto.Changeset.put_embed(:collab_space_config, archived_collab_space_config)
+      |> Oli.Repo.update!()
+
+      Sections.maybe_update_contains_discusssions(section)
+
+      assert Oli.Repo.reload!(section).contains_discussions
+    end
+
+    test "sets contains_discussions to false when NO having active discussions" do
+      # Project and Author
+      %{authors: [author]} = project = create_project_with_assocs()
+
+      # Root container
+      %{resource: container_resource, revision: container_revision, publication: publication} =
+        create_bundle_for(@container_type_id, project, author, nil, nil, title: "Root container")
+
+      # Resources
+      pages =
+        for _x <- 1..3, do: create_bundle_for(@page_type_id, project, author, publication)
+
+      others =
+        for _x <- 1..2, do: create_bundle_for(@container_type_id, project, author, publication)
+
+      pages_resources = Enum.map(pages, & &1.resource)
+      others_resources = Enum.map(others, & &1.resource)
+      # Links container - page
+      assoc_resources(
+        pages_resources ++ others_resources,
+        container_revision,
+        container_resource,
+        publication
+      )
+
+      # Section and its section_resources
+      {:ok, section} =
+        insert(:section, base_project: project, open_and_free: true)
+        |> Sections.create_section_resources(publication)
+
+      refute section.contains_discussions
+
+      all_section_resources =
+        section |> Oli.Repo.preload(:section_resources) |> Map.get(:section_resources)
+
+      {pages_section_resources, _rest_section_resources} =
+        Enum.split_with(all_section_resources, fn sr ->
+          sr.resource_id in Enum.map(pages_resources, & &1.id)
+        end)
+
+      [id_sec_res_1, id_sec_res_2, id_sec_res_3] = Enum.map(pages_section_resources, & &1.id)
+
+      disabled_collab_space_config =
+        %CollabSpaceConfig{}
+        |> CollabSpaceConfig.changeset(%{status: :disabled})
+        |> Ecto.Changeset.apply_changes()
+
+      archived_collab_space_config =
+        %CollabSpaceConfig{}
+        |> CollabSpaceConfig.changeset(%{status: :archived})
+        |> Ecto.Changeset.apply_changes()
+
+      SectionResource
+      |> Oli.Repo.get!(id_sec_res_1)
+      |> SectionResource.changeset()
+      |> Ecto.Changeset.put_embed(:collab_space_config, disabled_collab_space_config)
+      |> Oli.Repo.update!()
+
+      SectionResource
+      |> Oli.Repo.get!(id_sec_res_2)
+      |> SectionResource.changeset()
+      |> Ecto.Changeset.put_embed(:collab_space_config, disabled_collab_space_config)
+      |> Oli.Repo.update!()
+
+      SectionResource
+      |> Oli.Repo.get!(id_sec_res_3)
+      |> SectionResource.changeset()
+      |> Ecto.Changeset.put_embed(:collab_space_config, archived_collab_space_config)
+      |> Oli.Repo.update!()
+
+      Sections.maybe_update_contains_discusssions(section)
+
+      refute Oli.Repo.reload!(section).contains_discussions
+    end
+  end
 
   describe "sections" do
     setup(%{conn: conn}) do

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -11,6 +11,7 @@ defmodule Oli.TestHelpers do
   alias Oli.Authoring.Course.Project
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.Section
+  alias Oli.Delivery.Sections.SectionResource
   alias Oli.Institutions
   alias Oli.PartComponents
   alias Oli.Publishing
@@ -3329,6 +3330,85 @@ defmodule Oli.TestHelpers do
         activity_provider
       )
   end
+
+  ### Begins helpers to create resources ###
+
+  def create_bundle_for(type_id, project, author, publication, resource \\ nil, opts \\ [])
+
+  def create_bundle_for(type_id, project, author, nil, nil, opts) do
+    resource = insert(:resource)
+    publication = insert(:publication, project: project, root_resource_id: resource.id)
+
+    create_bundle_for(type_id, project, author, publication, resource, opts)
+    |> Map.merge(%{publication: publication})
+  end
+
+  def create_bundle_for(type_id, project, author, publication, nil, opts),
+    do: create_bundle_for(type_id, project, author, publication, insert(:resource), opts)
+
+  def create_bundle_for(type_id, project, author, publication, resource, opts) do
+    insert(:project_resource, project_id: project.id, resource_id: resource.id)
+    title = Keyword.get(opts, :title, title_for(resource.id))
+    slug = Keyword.get(opts, :slug, slug_for(resource.id))
+    graded = Keyword.get(opts, :graded, false)
+
+    revision =
+      insert(:revision,
+        resource: resource,
+        author: author,
+        resource_type_id: type_id,
+        title: title,
+        slug: slug,
+        graded: graded
+      )
+
+    insert(:published_resource,
+      publication: publication,
+      resource: resource,
+      revision: revision
+    )
+
+    %{resource: resource, revision: revision}
+  end
+
+  def create_project_with_assocs(opts \\ [])
+  def create_project_with_assocs([]), do: insert(:project, authors: [insert(:author)])
+
+  def create_project_with_assocs([{:authors, []}]), do: create_project_with_assocs()
+
+  def create_project_with_assocs([{:authors, authors}]) when is_list(authors),
+    do: insert(:project, authors: authors)
+
+  def assoc_resources(resources, container_revision, container_resource, publication) do
+    resources
+    |> Enum.map(& &1.id)
+    |> Enum.concat(container_revision.children)
+    |> set_container_children(container_resource, container_revision, publication)
+  end
+
+  defp set_container_children(children, container, container_revision, publication) do
+    {:ok, updated_revision} =
+      Oli.Resources.create_revision_from_previous(container_revision, %{children: children})
+
+    Publishing.get_published_resource!(publication.id, container.id)
+    |> Publishing.update_published_resource(%{revision_id: updated_revision.id})
+
+    updated_revision
+  end
+
+  def get_section_resource_by_resource(resource) do
+    from(sr in SectionResource,
+      join: s in assoc(sr, :section),
+      join: r in assoc(sr, :resource),
+      where: r.id == ^resource.id
+    )
+    |> Repo.one()
+  end
+
+  defp title_for(resource_id), do: "Container title for resource_id-#{resource_id}"
+  defp slug_for(resource_id), do: "slug_for_resource_id_#{resource_id}"
+
+  ### Ends helpers to create resources ###
 
   ### Begins helper that waits for Tasks to complete ###
 


### PR DESCRIPTION
Reference: [MER-1886](https://eliterate.atlassian.net/browse/MER-1886)

This PR added the ability to show/hide the discussion part from the navbar. The logic that controls it is based on the `status` field on the `collab_space_config` column in the `section` table.

The flag is trigger by 3 cases: creation of a section, remix of a project or defined by an instructor.

[MER-1886]: https://eliterate.atlassian.net/browse/MER-1886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ