### PR TITLE
[MER-2920] Extend live session plugs

### DIFF
--- a/lib/oli_web/live_session_plugs/set_ctx.ex
+++ b/lib/oli_web/live_session_plugs/set_ctx.ex
@@ -1,4 +1,10 @@
 defmodule OliWeb.LiveSessionPlugs.SetCtx do
+  @moduledoc """
+  This "live" plug is responsible for setting the session context in the socket assigns.
+  It is generally used after OliWeb.LiveSessionPlugs.SetCurrentUser to guarantee there is already
+  a current_user assigned to the socket.
+  """
+
   import Phoenix.Component, only: [assign: 2]
   alias OliWeb.Common.SessionContext
 
@@ -7,7 +13,7 @@ defmodule OliWeb.LiveSessionPlugs.SetCtx do
       assign(socket,
         ctx:
           SessionContext.init(socket, session,
-            user: socket.assigns.current_user,
+            user: socket.assigns[:current_user],
             is_liveview: true
           )
       )

--- a/lib/oli_web/live_session_plugs/set_current_author.ex
+++ b/lib/oli_web/live_session_plugs/set_current_author.ex
@@ -1,9 +1,22 @@
 defmodule OliWeb.LiveSessionPlugs.SetCurrentAuthor do
+  @moduledoc """
+  This plug is responsible for setting the current author in the socket assigns, so it expects
+  to have a current_author_id in the session.
+  If there is no current_author_id  we redirect the author to the login.
+  """
+  use OliWeb, :verified_routes
+
   import Phoenix.Component, only: [assign: 2]
+  import Phoenix.LiveView, only: [redirect: 2]
 
   def on_mount(:default, _params, %{"current_author_id" => current_author_id}, socket) do
     socket = assign(socket, current_author: Oli.Accounts.get_author(current_author_id))
 
     {:cont, socket}
+  end
+
+  def on_mount(_, _params, _session, socket) do
+    # when there is no current_author_id in the session we redirect the user to the login
+    {:halt, redirect(socket, to: ~p"/authoring/session/new")}
   end
 end

--- a/lib/oli_web/live_session_plugs/set_current_user.ex
+++ b/lib/oli_web/live_session_plugs/set_current_user.ex
@@ -1,5 +1,14 @@
 defmodule OliWeb.LiveSessionPlugs.SetCurrentUser do
+  @moduledoc """
+  This plug is responsible for setting the current user in the socket assigns, so it expects
+  to have a current_user_id in the session.
+  If there is no current_user_id  we redirect the user to the login.
+  """
+
+  use OliWeb, :verified_routes
+
   import Phoenix.Component, only: [assign: 2]
+  import Phoenix.LiveView, only: [redirect: 2]
 
   alias Oli.Accounts
   alias Oli.Accounts.User
@@ -16,7 +25,8 @@ defmodule OliWeb.LiveSessionPlugs.SetCurrentUser do
   end
 
   def on_mount(_, _params, _session, socket) do
-    {:cont, socket}
+    # when there is no current_user_id in the session we redirect the user to the login
+    {:halt, redirect(socket, to: ~p"/session/new")}
   end
 
   defp get_user(user_id) do

--- a/test/oli_web/live/new_course/course_details_test.exs
+++ b/test/oli_web/live/new_course/course_details_test.exs
@@ -107,6 +107,8 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
         "current_step" => 3
       })
 
+      wait_for_completion()
+
       flash =
         assert_redirect(
           view,
@@ -134,6 +136,8 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
         },
         "current_step" => 3
       })
+
+      wait_for_completion()
 
       flash =
         assert_redirect(
@@ -201,6 +205,8 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
         "current_step" => 3
       })
 
+      wait_for_completion()
+
       flash =
         assert_redirect(
           view,
@@ -228,6 +234,8 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
         },
         "current_step" => 3
       })
+
+      wait_for_completion()
 
       flash =
         assert_redirect(
@@ -294,6 +302,8 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
         "current_step" => 3
       })
 
+      wait_for_completion()
+
       flash = assert_redirect(view, Routes.delivery_path(OliWeb.Endpoint, :index))
       assert flash["info"] == "Section successfully created."
     end
@@ -325,6 +335,8 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
         |> Oli.Repo.one()
 
       assert blueprint_section.contains_explorations == true
+
+      wait_for_completion()
 
       flash = assert_redirect(view, Routes.delivery_path(OliWeb.Endpoint, :index))
 

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -3377,4 +3377,22 @@ defmodule Oli.TestHelpers do
   defp slug_for(resource_id), do: "slug_for_resource_id_#{resource_id}"
 
   ### Ends helpers to create resources ###
+
+  ### Begins helper that waits for Tasks to complete ###
+
+  def wait_for_completion() do
+    pids = Task.Supervisor.children(Oli.TaskSupervisor)
+    Enum.each(pids, &Process.monitor/1)
+    wait_for_pids(pids)
+  end
+
+  defp wait_for_pids([]), do: nil
+
+  defp wait_for_pids(pids) do
+    receive do
+      {:DOWN, _ref, :process, pid, _reason} -> wait_for_pids(List.delete(pids, pid))
+    end
+  end
+
+  ### Ends helper that waits for Tasks to complete ###
 end


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-2920) to the ticket

Both AppSignal errors had similar root causes. In both cases, the used live plugs were expecting a `current_user/author_id`, but were not handling cases where those values were not yet in the session. So, the fix was to handle those cases and redirect the user to the login page.

On the other hand, the SetCtx plug was incorrectly assuming there was already a user set in the assigns and, if this plug is not used after the SetCurrentUser plug, the mentioned assigned may not exist. 
The SetCtx module docs were expanded to explain this case.