### PR TITLE
[NG23-59] Learn poster images not rendering

### DIFF
--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -880,13 +880,10 @@ defmodule OliWeb.Delivery.Student.LearnLive do
         />
       </div>
       <div class="rounded-xl absolute -top-[0.7px] -left-[0.7px] h-[163px] w-[289.5px] cursor-pointer bg-[linear-gradient(180deg,#D9D9D9_0%,rgba(217,217,217,0.00)_100%)] dark:bg-[linear-gradient(180deg,#223_0%,rgba(34,34,51,0.72)_52.6%,rgba(34,34,51,0.00)_100%)]" />
-      <div class={[
-        "flex flex-col items-center rounded-xl h-[162px] w-[288px] bg-gray-200/50 shrink-0 px-5 pt-[15px]",
-        if(@bg_image_url in ["", nil],
-          do: "bg-[url('/images/course_default.jpg')]",
-          else: "bg-[url('#{@bg_image_url}')]"
-        )
-      ]}>
+      <div
+        class="flex flex-col items-center rounded-xl h-[162px] w-[288px] bg-gray-200/50 shrink-0 px-5 pt-[15px]"
+        style={"background-image: url('#{if(@bg_image_url in ["", nil], do: "/images/course_default.jpg", else: @bg_image_url)}');"}
+      >
         <h5 class="text-[13px] leading-[18px] font-bold opacity-60 text-gray-500 dark:text-white dark:text-opacity-50 self-start">
           <%= @title %>
         </h5>
@@ -976,16 +973,15 @@ defmodule OliWeb.Delivery.Student.LearnLive do
       <.page_icon :if={is_page(@module)} graded={@module["graded"]} />
 
       <div class="h-[170px] w-[288px]">
-        <div class={[
-          "flex flex-col gap-[5px] cursor-pointer rounded-xl h-[162px] w-[288px] shrink-0 mb-1 px-5 pt-[15px] bg-gray-200 z-10",
-          if(@selected,
-            do: "bg-gray-400 outline outline-2 outline-gray-800 dark:outline-white"
-          ),
-          if(@bg_image_url in ["", nil],
-            do: "bg-[url('/images/course_default.jpg')]",
-            else: "bg-[url('#{@bg_image_url}')]"
-          )
-        ]}>
+        <div
+          class={[
+            "flex flex-col gap-[5px] cursor-pointer rounded-xl h-[162px] w-[288px] shrink-0 mb-1 px-5 pt-[15px] bg-gray-200 z-10",
+            if(@selected,
+              do: "bg-gray-400 outline outline-2 outline-gray-800 dark:outline-white"
+            )
+          ]}
+          style={"background-image: url('#{if(@bg_image_url in ["", nil], do: "/images/course_default.jpg", else: @bg_image_url)}');"}
+        >
           <span class="text-[12px] leading-[16px] font-bold opacity-60 text-gray-500 dark:text-white dark:text-opacity-50">
             <%= "#{@unit_numbering_index}.#{@module_index}" %>
           </span>

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -1258,11 +1258,11 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
 
       assert view
              |> element(~s{div[role="unit_1"] div[role="card_1"]"})
-             |> render =~ "bg-[url(&#39;module_1_custom_image_url&#39;)]"
+             |> render =~ "style=\"background-image: url(&#39;module_1_custom_image_url&#39;)"
 
       assert view
              |> element(~s{div[role="unit_1"] div[role="card_2"]"})
-             |> render =~ "bg-[url(&#39;/images/course_default.jpg&#39;)]"
+             |> render =~ "style=\"background-image: url(&#39;/images/course_default.jpg&#39;)"
     end
 
     test "can navigate to a unit through url params",


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/NG23-59) to the ticket

Instead of using the Tailwind's `bg-[url(...)]` [arbitrary value](https://tailwindcss.com/docs/background-image#arbitrary-values) (that [sometimes does not work](https://stackoverflow.com/questions/63658218/tailwind-css-backgroundimage-doesnt-work-for-me)), I used [CSS `background-image` property](https://developer.mozilla.org/en-US/docs/Web/CSS/background-image) and applied it as `style` directly to the div.

<img width="930" alt="image" src="https://github.com/Simon-Initiative/oli-torus/assets/74839302/70d5ed5a-16fc-4455-8b7c-fa47bb377f85">

The same module card fix was applied to intro video cards as well.