### PR TITLE
[BUGFIX] correct latex newline workaround [MER-2926]

### DIFF
--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -516,7 +516,7 @@ defmodule Oli.Rendering.Content.Html do
     if String.match?(src, ~r/\\\\./) and
          not (String.starts_with?(src, "\\displaylines") or
                 String.starts_with?(src, "\\begin{array}")),
-       do: "\displaylines{#{src}}",
+       do: "\\displaylines{#{src}}",
        else: src
   end
 


### PR DESCRIPTION
This corrects code that attempted to apply a workaround for MathJax 3 limitation handling multi-line LaText formulas to correctly escape the initial backslash in the prepended string. 