### PR TITLE
Mer 2929 discussions leftover work

### DIFF
--- a/lib/oli/delivery.ex
+++ b/lib/oli/delivery.ex
@@ -105,6 +105,7 @@ defmodule Oli.Delivery do
           )
         )
 
+      section = PostProcessing.apply(section, :discussions)
       {:ok, _} = Sections.rebuild_contained_pages(section)
       {:ok, _} = Sections.rebuild_contained_objectives(section)
 
@@ -154,7 +155,7 @@ defmodule Oli.Delivery do
         )
 
       {:ok, %Section{} = section} = Sections.create_section_resources(section, publication)
-      section = PostProcessing.apply(section, [:discussions])
+      section = PostProcessing.apply(section, :discussions)
       {:ok, _} = Sections.rebuild_contained_pages(section)
       {:ok, _} = Sections.rebuild_contained_objectives(section)
 
@@ -298,24 +299,6 @@ defmodule Oli.Delivery do
     end
   end
 
-  defp contains_deliberate_practice(section_slug) do
-    page_id = Oli.Resources.ResourceType.get_id_by_type("page")
-
-    Repo.one(
-      from([sr: sr, rev: rev] in DeliveryResolver.section_resource_revisions(section_slug),
-        where:
-          rev.purpose == :deliberate_practice and rev.deleted == false and
-            rev.resource_type_id == ^page_id,
-        select: rev.id,
-        limit: 1
-      )
-    )
-    |> case do
-      nil -> false
-      _ -> true
-    end
-  end
-
   defp update_contains_explorations(section, value) do
     section
     |> Section.changeset(%{contains_explorations: value})
@@ -334,30 +317,6 @@ defmodule Oli.Delivery do
 
       {false, true} ->
         update_contains_explorations(section, false)
-
-      _ ->
-        {:ok, section}
-    end
-  end
-
-  defp update_contains_deliberate_practice(section, value) do
-    section
-    |> Section.changeset(%{contains_deliberate_practice: value})
-    |> Repo.update()
-  end
-
-  def maybe_update_section_contains_deliberate_practice(
-        %Section{
-          slug: section_slug,
-          contains_deliberate_practice: contains_deliberate_practice
-        } = section
-      ) do
-    case {contains_deliberate_practice(section_slug), contains_deliberate_practice} do
-      {true, false} ->
-        update_contains_deliberate_practice(section, true)
-
-      {false, true} ->
-        update_contains_deliberate_practice(section, false)
 
       _ ->
         {:ok, section}

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -36,16 +36,15 @@ defmodule Oli.Delivery.Sections do
   alias Lti_1p3.Tool.PlatformRoles
   alias Oli.Delivery.Updates.Broadcaster
   alias Oli.Delivery.Sections.EnrollmentBrowseOptions
+  alias Oli.Delivery.Sections.PostProcessing
   alias Oli.Utils.Slug
   alias OliWeb.Common.FormatDateTime
   alias Oli.Delivery.PreviousNextIndex
-  alias Oli.Delivery
   alias Ecto.Multi
   alias Oli.Delivery.Gating.GatingCondition
   alias Oli.Delivery.Attempts.Core.ResourceAccess
   alias Oli.Delivery.Metrics
   alias Oli.Delivery.Paywall
-  alias Oli.Delivery.Sections.PostProcessing
 
   require Logger
 
@@ -1760,8 +1759,7 @@ defmodule Oli.Delivery.Sections do
       |> Multi.run(
         :side_effects,
         fn _repo, _ ->
-          actions = [:discussions, :explorations, :deliberate_practice]
-          {:ok, PostProcessing.apply(section, actions)}
+          {:ok, PostProcessing.apply(section, :all)}
         end
       )
       |> Repo.transaction()
@@ -2511,8 +2509,8 @@ defmodule Oli.Delivery.Sections do
       # resources and cleaning up any deleted ones
       pinned_project_publications = get_pinned_project_publications(section.id)
       rebuild_section_curriculum(section, new_hierarchy, pinned_project_publications)
-      Delivery.maybe_update_section_contains_explorations(section)
-      Delivery.maybe_update_section_contains_deliberate_practice(section)
+
+      PostProcessing.apply(section, :all)
 
       {:ok}
     end)

--- a/lib/oli/delivery/sections/blueprint.ex
+++ b/lib/oli/delivery/sections/blueprint.ex
@@ -5,9 +5,9 @@ defmodule Oli.Delivery.Sections.Blueprint do
   alias Oli.Authoring.Course.Project
   alias Oli.Authoring.Course.ProjectVisibility
   alias Oli.Publishing.Publications.Publication
-  alias Oli.Delivery
-  alias Oli.Delivery.Sections.Section
   alias Oli.Delivery.Sections
+  alias Oli.Delivery.Sections.PostProcessing
+  alias Oli.Delivery.Sections.Section
   alias Oli.Delivery.Sections.BlueprintBrowseOptions
   alias Oli.Groups.CommunityVisibility
   alias Oli.Institutions.Institution
@@ -169,16 +169,8 @@ defmodule Oli.Delivery.Sections.Blueprint do
                 Oli.Publishing.get_latest_published_publication_by_slug(base_project_slug)
 
               case Sections.create_section_resources(blueprint, publication, hierarchy_definition) do
-                {:ok, section} ->
-                  {:ok, section} = Delivery.maybe_update_section_contains_explorations(section)
-
-                  {:ok, section} =
-                    Delivery.maybe_update_section_contains_deliberate_practice(section)
-
-                  section
-
-                {:error, e} ->
-                  Repo.rollback(e)
+                {:ok, section} -> PostProcessing.apply(section, :all)
+                {:error, e} -> Repo.rollback(e)
               end
 
             {:error, e} ->

--- a/lib/oli/delivery/sections/post_processing.ex
+++ b/lib/oli/delivery/sections/post_processing.ex
@@ -11,13 +11,18 @@ defmodule Oli.Delivery.Sections.PostProcessing do
   @type option :: :all | :discussions | :explorations | :deliberate_practice
 
   @page_type_id ResourceType.get_id_by_type("page")
+  @all_actions [:discussions, :explorations, :deliberate_practice]
 
-  @spec apply(Section.t(), options()) :: Section.t()
+  @spec apply(Section.t(), options() | option()) :: Section.t()
   def apply(section, actions \\ []) do
-    all = [:discussions, :explorations, :deliberate_practice]
-    actions = if actions == :all, do: all, else: actions
+    actions =
+      case actions do
+        :all -> @all_actions
+        action when action in @all_actions -> List.wrap(action)
+        actions -> actions
+      end
 
-    result =
+    changes =
       Enum.reduce(Enum.uniq(actions), %{}, fn action, acc ->
         case action do
           :discussions ->
@@ -34,7 +39,7 @@ defmodule Oli.Delivery.Sections.PostProcessing do
         end
       end)
 
-    Sections.update_section!(section, result)
+    Sections.update_section!(section, changes)
   end
 
   # Updates contains_discussions flag if an active discussion is present.

--- a/lib/oli_web/controllers/open_and_free_controller.ex
+++ b/lib/oli_web/controllers/open_and_free_controller.ex
@@ -2,8 +2,8 @@ defmodule OliWeb.OpenAndFreeController do
   use OliWeb, :controller
 
   alias Oli.{Repo, Publishing, Branding}
-  alias Oli.Delivery
   alias Oli.Delivery.Sections
+  alias Oli.Delivery.Sections.PostProcessing
   alias Oli.Delivery.Sections.Section
   alias Oli.Authoring.Course
   alias OliWeb.Common.{Breadcrumb, FormatDateTime}
@@ -353,11 +353,8 @@ defmodule OliWeb.OpenAndFreeController do
            {:ok, section} <- Sections.create_section_resources(section, publication),
            {:ok, _} <- Sections.rebuild_contained_pages(section),
            {:ok, _} <- Sections.rebuild_contained_objectives(section),
-           {:ok, _enrollment} <- enroll(conn, section),
-           {:ok, section} <- Delivery.maybe_update_section_contains_explorations(section),
-           {:ok, updated_section} <-
-             Delivery.maybe_update_section_contains_deliberate_practice(section) do
-        updated_section
+           {:ok, _enrollment} <- enroll(conn, section) do
+        PostProcessing.apply(section, :all)
       else
         {:error, changeset} -> Repo.rollback(changeset)
       end

--- a/test/oli/delivery/sections_test.exs
+++ b/test/oli/delivery/sections_test.exs
@@ -92,7 +92,7 @@ defmodule Oli.Delivery.SectionsTest do
       |> Ecto.Changeset.put_embed(:collab_space_config, archived_collab_space_config)
       |> Oli.Repo.update!()
 
-      PostProcessing.apply(section, [:discussions])
+      PostProcessing.apply(section, :discussions)
 
       assert Oli.Repo.reload!(section).contains_discussions
     end
@@ -167,7 +167,7 @@ defmodule Oli.Delivery.SectionsTest do
       |> Ecto.Changeset.put_embed(:collab_space_config, archived_collab_space_config)
       |> Oli.Repo.update!()
 
-      PostProcessing.apply(section, [:discussions])
+      PostProcessing.apply(section, :discussions)
 
       refute Oli.Repo.reload!(section).contains_discussions
     end


### PR DESCRIPTION
Ticket: [MER-2929](https://eliterate.atlassian.net/browse/MER-2929)

This is a leftover work from [PR-4561](https://github.com/Simon-Initiative/oli-torus/pull/4561). It contains some improvements in the PostProcessing module and promote it uses over the `maybe_update_contains_exploration` and `maybe_update_section_contains_deliberate_practice` functions that were also get rid of in this PR.

A proposal is to move all side effects into the `PostProcessing` module --`rebuild_contained_pages` and `rebuild_contained_objectives`. Doing this we can centralize them.