### PR TITLE
[FEATURE] [MER-2904] Add missing error logging for activity editing error

### DIFF
--- a/lib/oli/utils/appsignal.ex
+++ b/lib/oli/utils/appsignal.ex
@@ -21,6 +21,8 @@ defmodule Oli.Utils.Appsignal do
       raise e
     catch
       kind, reason ->
+        metadata = unless is_nil(metadata), do: inspect(metadata)
+
         case metadata do
           nil ->
             Appsignal.send_error(kind, reason, __STACKTRACE__)


### PR DESCRIPTION
[MER-2904](https://eliterate.atlassian.net/browse/MER-2904)

This PR aims to get and send a more accurate error message to AppSignal if an error occurs in the execution flow when editing an activity.

After analyzing the code, and trying to force all the errors that can happen in this flow, I found that it can be sent in the `send_error` function of the `AppSignal` module, as metadata a tuple, but the function `Appsignal.Span.set_attribute` does not allow this type of data (only allows data types such as String, integer, boolean or float), so I think it would not be receiving correctly. 

https://hexdocs.pm/appsignal/2.7.10/Appsignal.Span.html#set_attribute/3

Feel free to add any comments in order to get better options for logging errors in AppSignal in a more efficient and clear way.


[MER-2904]: https://eliterate.atlassian.net/browse/MER-2904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ