### PR TITLE
[Buffix] fixed accessibility issues in left sidebar [MER-2799]

### DIFF
--- a/assets/styles/authoring/layout/workspace.scss
+++ b/assets/styles/authoring/layout/workspace.scss
@@ -190,7 +190,7 @@ $workspace-sidebar-width: 65px;
     }
 
     .sidebar-item:focus {
-      outline: none !important;
+      outline: 1px solid #000;
       box-shadow: none;
     }
 

--- a/lib/oli_web/templates/layout/_admin_sidebar.html.eex
+++ b/lib/oli_web/templates/layout/_admin_sidebar.html.eex
@@ -1,4 +1,4 @@
-<a class="sidebar-item btn my-1" href="<%= Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.AdminView) %>">
-  <img src="/images/icons/icon-admin-light.svg" height="36px" width="32px"/>
-  <div class="label mt-1">Admin</div>
+<a tabindex="0" aria-label="Admin" class="sidebar-item btn my-1" href="<%= Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.AdminView) %>">
+  <img aria-hidden="true" src="/images/icons/icon-admin-light.svg" height="36px" width="32px"/>
+  <div aria-hidden="true" class="label mt-1">Admin</div>
 </a>

--- a/lib/oli_web/templates/layout/_community_admin_sidebar.html.eex
+++ b/lib/oli_web/templates/layout/_community_admin_sidebar.html.eex
@@ -1,4 +1,4 @@
-<a class="sidebar-item btn my-1" href="<%= Routes.live_path(OliWeb.Endpoint, OliWeb.CommunityLive.IndexView) %>">
-  <img src="/images/icons/icon-admin-light.svg" height="36px" width="32px"/>
-  <div class="label mt-1">Community</div>
+<a tabindex="0" aria-label="Community" class="sidebar-item btn my-1" href="<%= Routes.live_path(OliWeb.Endpoint, OliWeb.CommunityLive.IndexView) %>">
+  <img aria-hidden="true" src="/images/icons/icon-admin-light.svg" height="36px" width="32px"/>
+  <div aria-hidden="true" class="label mt-1">Community</div>
 </a>

--- a/lib/oli_web/templates/layout/_project_sidebar.html.eex
+++ b/lib/oli_web/templates/layout/_project_sidebar.html.eex
@@ -1,13 +1,13 @@
 <div class="workspace-sidebar pt-2">
-  <a class="sidebar-item btn my-1" href="<%= Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.ProjectsLive) %>">
-    <img src="/images/icons/icon-projects-light.svg" height="30px" width="32px"/>
-    <div class="label mt-1">Projects</div>
+  <a tabindex="0" tab aria-label="Projects Link" class="sidebar-item btn my-1" href="<%= Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.ProjectsLive) %>">
+    <img aria-hidden="true" src="/images/icons/icon-projects-light.svg" height="30px" width="32px"/>
+    <div aria-hidden="true" class="label mt-1">Projects</div>
   </a>
 
   <div class="btn-group dropend relative hoverdriven my-1">
-    <button type="button" class="sidebar-item btn" data-bs-toggle="dropdown" data-bs-offset="0,-1" aria-haspopup="true" aria-expanded="false">
-      <img src="/images/icons/icon-create-light.svg" height="35px" width="32px"/>
-      <div class="label mt-1">Create</div>
+    <button aria-label="Create" tabindex="0" type="button" class="sidebar-item btn" data-bs-toggle="dropdown" data-bs-offset="0,-1" aria-haspopup="true" aria-expanded="false">
+      <img aria-hidden="true" src="/images/icons/icon-create-light.svg" height="35px" width="32px"/>
+      <div aria-hidden="true" class="label mt-1">Create</div>
     </button>
     <ul class="dropdown-menu">
       <li><a class="dropdown-item btn btn-lg" href="<%= Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.OverviewLive, @project.slug) %>">Overview</a></li>
@@ -27,9 +27,9 @@
   </div>
 
   <div class="btn-group dropend relative hoverdriven my-1">
-    <button type="button" class="sidebar-item btn" data-bs-toggle="dropdown" data-bs-offset="0,-1" aria-haspopup="true" aria-expanded="false">
-      <img src="/images/icons/icon-publish-light.svg" height="32px" width="32px"/>
-      <div class="label mt-1">Publish</div>
+    <button tabindex="0" aria-label="Publish" type="button" class="sidebar-item btn" data-bs-toggle="dropdown" data-bs-offset="0,-1" aria-haspopup="true" aria-expanded="false">
+      <img aria-hidden="true" src="/images/icons/icon-publish-light.svg" height="32px" width="32px"/>
+      <div aria-hidden="true" class="label mt-1">Publish</div>
     </button>
     <div class="dropdown-menu">
       <a class="dropdown-item btn btn-lg" href="<%= Routes.live_path(OliWeb.Endpoint, OliWeb.Qa.QaLive, @project.slug) %>">Review</a>
@@ -39,9 +39,9 @@
   </div>
 
   <div class="btn-group dropend relative hoverdriven my-1">
-    <button type="button" class="sidebar-item btn" data-bs-toggle="dropdown" data-bs-offset="0,-1" aria-haspopup="true" aria-expanded="false">
-      <img src="/images/icons/icon-improve-light.svg" height="35px" width="32px"/>
-      <div class="label mt-1">Improve</div>
+    <button tabindex="0" aria-label="Improve" type="button" class="sidebar-item btn" data-bs-toggle="dropdown" data-bs-offset="0,-1" aria-haspopup="true" aria-expanded="false">
+      <img aria-hidden="true" src="/images/icons/icon-improve-light.svg" height="35px" width="32px"/>
+      <div aria-hidden="true" class="label mt-1">Improve</div>
     </button>
     <div class="dropdown-menu">
       <li><a class="dropdown-item btn btn-lg" href="<%= Routes.project_path(@conn, :insights, @project) %>">Insights</a></li>

--- a/lib/oli_web/templates/layout/_workspace_sidebar.html.eex
+++ b/lib/oli_web/templates/layout/_workspace_sidebar.html.eex
@@ -1,8 +1,8 @@
 <div class="workspace-sidebar pt-2 dark:bg-gray-700">
 
-  <a class="sidebar-item btn my-1" href="<%= Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.ProjectsLive) %>">
-    <img src="/images/icons/icon-projects-light.svg" height="30px" width="32px"/>
-    <div class="label mt-1">Projects</div>
+  <a aria-label="Projects" tabindex="0" class="sidebar-item btn my-1" href="<%= Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.ProjectsLive) %>">
+    <img aria-hidden="true" src="/images/icons/icon-projects-light.svg" height="30px" width="32px"/>
+    <div aria-hidden="true" class="label mt-1">Projects</div>
   </a>
 
   <%= if Accounts.is_admin?(@current_author) do %>


### PR DESCRIPTION
Fixes two accessibility issues with the left hand toolbar.

1. They can now be navigated to via keyboard and there is new a focus-outline around them.
2. The aria-labels have been cleaned up and set to be more useful to users with screenreaders.