### PR TITLE
Make the objectives search case insensitive

### DIFF
--- a/assets/src/components/resource/objectives/ObjectivesSelection.tsx
+++ b/assets/src/components/resource/objectives/ObjectivesSelection.tsx
@@ -25,12 +25,14 @@ export type ObjectivesProps = {
 // Custom filterBy function for the Typeahead. This allows searches to
 // pick up child objectives for text that matches the parent
 function filterBy(byId: any, option: Objective, props: AllTypeaheadOwnAndInjectedProps<Objective>) {
-  if (option.title.indexOf(props.text) > -1) {
+  if (option.title.toLocaleLowerCase().indexOf(props.text.toLocaleLowerCase()) > -1) {
     return true;
   }
 
   if (option.parentId !== null) {
-    return byId[option.parentId].title.indexOf(props.text) > -1;
+    return (
+      byId[option.parentId].title.toLocaleLowerCase().indexOf(props.text.toLocaleLowerCase()) > -1
+    );
   }
 
   return false;


### PR DESCRIPTION
When searching for objectives, the list was previously case-sensitive. Now it's case insensitive.

![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/5572bff8-6cdf-4961-9491-f76b13b94390)

When testing, also note that when you search for a parent objective, it returns the children objectives for it. This appears to be intentional.

![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/17e010b7-fa46-4da7-ad57-c15e0f255ebe)
