### PR TITLE
[Bugfix] Switched to a patched version of epoq library [MER-2927]

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -51,7 +51,7 @@
     "chroma-js": "^2.1.1",
     "dagre": "^0.8.5",
     "deep-object-diff": "^1.1.0",
-    "epoq": "^1.0.4",
+    "epoq": "npm:epoq-january-fix",
     "file-loader": "^6.2.0",
     "immer": "^9.0.5",
     "immutable": "^4.0.0-rc.12",

--- a/assets/test/utils/date_utils_test.ts
+++ b/assets/test/utils/date_utils_test.ts
@@ -1,0 +1,19 @@
+import { DateWithoutTime } from 'epoq';
+import { stringToDateWithoutTime } from 'apps/scheduler/date-utils';
+
+describe('date_utils', () => {
+  describe('DateWithoutTime', () => {
+    it('Should work with january dates', () => {
+      const d = new DateWithoutTime(2024, 0, 18);
+      expect(d.getFullYear()).toEqual(2024);
+    });
+  });
+  describe('stringToDateWithoutTime', () => {
+    it('Should work with january dates', () => {
+      const d = stringToDateWithoutTime('2024-01-18');
+      expect(d.getFullYear()).toEqual(2024);
+      expect(d.getMonth()).toEqual(0);
+      expect(d.getDate()).toEqual(18);
+    });
+  });
+});

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -9257,10 +9257,10 @@ envinfo@^7.7.3:
   resolved "https://registry.npmjs.org/envinfo/-/envinfo-7.8.1.tgz"
   integrity sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==
 
-epoq@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.npmjs.org/epoq/-/epoq-1.0.4.tgz"
-  integrity sha512-K48x+7J565Y5rzfVgdjvcrLy33PmKbixQfT8AjeRhp0y1qlDzqy8jCohsisyU4UrmXCM7zBOM8Zquv23s+bWtA==
+"epoq@npm:epoq-january-fix":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/epoq-january-fix/-/epoq-january-fix-1.0.5.tgz#7c210e3450af0861bdeaa8f4193096ecdc16475c"
+  integrity sha512-Fy3Bd5n3Mh17RKqDfAmCoUxWDDwZDWY3rTaDOpyK1btJCupTRBIvS52cX0lRL09+Jph9+sM9qPRwPPCwEBJ4KQ==
 
 errno@^0.1.3, errno@~0.1.7:
   version "0.1.8"


### PR DESCRIPTION
The epoq library we were using was not working correctly if you used the numeric based constructor with a january date. I've fixed the bug in a fork and temporarily published a fixed package which this PR switches to.

See actual fix here: https://github.com/bbsimonbb/epoq/pull/3

If/when that PR is merged, we can go back to using the official epoq library.

This was preventing us from choosing dates in january for suggested-by or in-class-activity-on dates.

![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/c79c81a0-8ecd-435e-9cb8-f67caf2bd501)
