### PR TITLE
[BUG FIX] Add missing migration

### DIFF
--- a/priv/repo/migrations/20240118214656_oban_12.exs
+++ b/priv/repo/migrations/20240118214656_oban_12.exs
@@ -1,0 +1,13 @@
+defmodule Oli.Repo.Migrations.Oban12 do
+  use Ecto.Migration
+
+  def up do
+    Oban.Migration.up(version: 12)
+  end
+
+  # We specify `version: 1` in `down`, ensuring that we'll roll all the way back down if
+  # necessary, regardless of which version we've migrated `up` to.
+  def down do
+    Oban.Migration.down(version: 1)
+  end
+end


### PR DESCRIPTION
A previous PR bumped the Oban version, but didn't realize that the new version required a migration (to add an "oban_peers" table, among other changes).  This PR adds that migration. 