### PR TITLE
[BUG] Response_multi fixes MER-2935,MER-2936,MER-2937,MER-2938,MER-2939,MER-2940,MER-2941

### DIFF
--- a/assets/src/components/activities/common/responses/responseActions.ts
+++ b/assets/src/components/activities/common/responses/responseActions.ts
@@ -1,4 +1,5 @@
 import { remove } from 'components/activities/common/utils';
+import { updateRule } from 'components/activities/response_multi/rules';
 import {
   ChoiceIdsToResponseId,
   HasParts,
@@ -56,7 +57,13 @@ export const ResponseActions = {
 
   editResponseMatchStyle(responseId: ResponseId, matchStyle: MatchStyle) {
     return (model: HasParts) => {
-      getResponseBy(model, (r) => r.id === responseId).matchStyle = matchStyle;
+      const r = getResponseBy(model, (r) => r.id === responseId);
+      r.matchStyle = matchStyle;
+
+      // force regeneration of existing rule with new match style, no additions/modifications
+      // On change to 'all' type will ensure dropdown inputs have only one selected choice
+      r.rule = updateRule(r.rule, matchStyle, '', '', false);
+      // console.log('editMatchStyle: ' + r.rule);
     };
   },
 

--- a/assets/src/components/activities/common/responses/responseActions.ts
+++ b/assets/src/components/activities/common/responses/responseActions.ts
@@ -59,11 +59,9 @@ export const ResponseActions = {
     return (model: HasParts) => {
       const r = getResponseBy(model, (r) => r.id === responseId);
       r.matchStyle = matchStyle;
-
       // force regeneration of existing rule with new match style, no additions/modifications
       // On change to 'all' type will ensure dropdown inputs have only one selected choice
-      r.rule = updateRule(r.rule, matchStyle, '', '', false);
-      // console.log('editMatchStyle: ' + r.rule);
+      r.rule = updateRule(r.rule, matchStyle, '', '', 'setStyle');
     };
   },
 

--- a/assets/src/components/activities/response_multi/actions.ts
+++ b/assets/src/components/activities/response_multi/actions.ts
@@ -27,7 +27,7 @@ import { elementsAdded, elementsOfType, elementsRemoved } from 'components/editi
 import { Choices } from 'data/activities/model/choices';
 import { List } from 'data/activities/model/list';
 import { getCorrectResponse, getResponseBy } from 'data/activities/model/responses';
-import { andRules, containsRule, matchRule } from 'data/activities/model/rules';
+import { containsRule, matchRule } from 'data/activities/model/rules';
 import { getByUnsafe, getPartById, getParts } from 'data/activities/model/utils';
 import { InputRef } from 'data/content/model/elements/types';
 import { clone } from 'utils/common';

--- a/assets/src/components/activities/response_multi/actions.ts
+++ b/assets/src/components/activities/response_multi/actions.ts
@@ -170,12 +170,6 @@ export const ResponseMultiInputActions = {
     };
   },
 
-  toggleChoiceCorrectness(id: string, partId: string, inputId: string) {
-    return (model: HasParts, _post: PostUndoable) => {
-      getCorrectResponse(model, partId).rule = toInputRule(inputId, matchRule(id));
-    };
-  },
-
   editResponseResponseMultiRule(id: ResponseId, inputId: string, rule: string) {
     return (draftState: HasParts) => {
       const response: Response = getResponseBy(draftState, (r) => r.id === id);

--- a/assets/src/components/activities/response_multi/actions.ts
+++ b/assets/src/components/activities/response_multi/actions.ts
@@ -32,7 +32,13 @@ import { getByUnsafe, getPartById, getParts } from 'data/activities/model/utils'
 import { InputRef } from 'data/content/model/elements/types';
 import { clone } from 'utils/common';
 import { Operations } from 'utils/pathOperations';
-import { indexResponseMultiRule, ruleInputRefs, toInputRule, updateRule } from './rules';
+import {
+  indexResponseMultiRule,
+  ruleInputRefs,
+  ruleIsCatchAll,
+  toInputRule,
+  updateRule,
+} from './rules';
 import { ResponseMultiInputSchema } from './schema';
 import { ResponseMultiInputResponses } from './utils';
 
@@ -150,7 +156,7 @@ export const ResponseMultiInputActions = {
       partFrom.responses = partFrom.responses.filter((r) => r.rule !== '');
 
       // if dest has a catchall response, append wildcard clause for new input
-      const response = partTo.responses.find((r) => r.catchAll);
+      const response = partTo.responses.find((r) => ruleIsCatchAll(r.rule));
       if (response) {
         response.rule = updateRule(response.rule, 'all', input.id, matchRule('.*'), 'add');
       }
@@ -294,7 +300,7 @@ export const ResponseMultiInputActions = {
 
       if (existingResponses.length > 0) {
         existingResponses.forEach((r) => {
-          if (r.catchAll) return;
+          if (ruleIsCatchAll(r.rule)) return;
           const updatedRule: string = updateRule(
             r.rule,
             r.matchStyle,

--- a/assets/src/components/activities/response_multi/actions.ts
+++ b/assets/src/components/activities/response_multi/actions.ts
@@ -134,9 +134,8 @@ export const ResponseMultiInputActions = {
       partTo.targets ? partTo.targets.push(input.id) : (partTo.targets = [input.id]);
       input.partId = partTo.id;
 
-      // many response rules in from part may involve this id. This picks the first one.
-      // Perhaps trying to move correct answer for this input?
-      // !!! Try to find the correct one
+      // Copy input rule for this id  from first response in old part to first
+      // response in new, on assumption that first response is correct one
       const fromRules = indexResponseMultiRule(partFrom.responses[0].rule);
 
       // merge the rules

--- a/assets/src/components/activities/response_multi/rules.ts
+++ b/assets/src/components/activities/response_multi/rules.ts
@@ -97,7 +97,7 @@ export const ruleInputRefs = (r: MultiRule): string[] => [
   ...new Set(ruleInputRules(r).map(inputRuleInput).filter(isDefined)),
 ];
 
-export const isCatchAll = (r: MultiRule): boolean =>
+export const ruleIsCatchAll = (r: MultiRule): boolean =>
   ruleInputRules(r).every((ir: InputRule) => inputRuleValue(ir) === '.*');
 
 // update given rule by adding/removing/modifying a single input rule

--- a/assets/src/components/activities/response_multi/rules.ts
+++ b/assets/src/components/activities/response_multi/rules.ts
@@ -1,0 +1,132 @@
+import { andRules, orRules } from 'data/activities/model/rules';
+import { MatchStyle } from '../types';
+
+// In response_multi context, we use following terms:
+// An inputRule, variable ir, is a single input matching rule of form
+//         input_ref_inputID op {value}
+// although it may be as follows for "does not contain" string match:
+//         (!(input_ref_inputID op {value}))
+//
+// A response_multi response rule in general, variable r, consists logically
+// of a set of one or more input rules plus a match style.
+// We represent both in their torus rule string form, parsing out constitutents as needed.
+//
+// For response rules with a disjunctive match style (any or none), we allow
+// multiple input rules for dropdown inputs to represent different possible values.
+// Other inputs should have a single input rule per input
+
+// convert regular torus match rule to inputRule
+export const toInputRule = (inputId: string, rule: string) =>
+  rule.replace(/input /, `input_ref_${inputId} `);
+
+export const inputRuleInput = (ir: string): string | undefined =>
+  ir.match(/(?<=input_ref_)[^ ]+/)?.[0];
+
+export const inputRuleValue = (ir: string): string => {
+  const match = ir.match(/input_ref_[^ ]+ \w+ {([^}]|\\})*}/);
+  if (!match) {
+    console.error('inputRuleValue: not single input rule ' + ir);
+  }
+  return match ? match[1] : '';
+};
+
+export const combineRules = (matchStyle: MatchStyle, inputRules: string[]) => {
+  const joined = matchStyle === 'all' ? andRules(...inputRules) : orRules(...inputRules);
+  return matchStyle === 'none' ? `!(${joined})` : joined;
+};
+
+// Extract component single input rules from possibly compound response_multi rule
+// Assumes rule string combines input rules according to one of our matchStyles
+// Strictly correct parsing complicated to allow
+//   (1) && or || could occur inside {...} so can't just split on them
+//   (2) right-brace can appear inside {...} if escaped as \}
+//   (3) does-not-contain rule has form (!(input_ref_foo like {..}))
+//   (4) brackets may be empty on some uninitialized text rules
+export const ruleInputRules = (r: string): string[] => {
+  // inside brackets allow either non-} OR escaped \}
+  const rules = r.match(/(?:!\()?input_ref_[^ ]+ [^ ]+ {(?:[^}]|\\})*}\)?/g);
+  console.log('split rules: ' + rules);
+  return rules === null ? [] : rules;
+};
+
+export const ruleMatchStyle = (r: string): MatchStyle =>
+  r.startsWith('!') ? 'none' : r.includes('||') ? 'any' : 'all';
+
+export const getRulesForInput = (r: string, id: string): string[] =>
+  ruleInputRules(r).filter((ir: string) => inputRuleInput(ir) === id);
+
+export const getUniqueRuleForInput = (r: string, id: string): string => {
+  const inputRules = ruleInputRules(r).filter((ir: string) => inputRuleInput(ir) === id);
+  if (inputRules.length > 1) console.error('unexpected multiple rules for input ' + id);
+  return inputRules[0];
+};
+
+// get all values for this input id in compound rule, mainly for dropdowns
+export const getInputValues = (r: string, id: string): string[] =>
+  getRulesForInput(r, id).map(inputRuleValue);
+
+// generic type guard enabling TypeScript to narrow filtered types to non-undefined
+function isDefined<T>(value: T | undefined): value is T {
+  return value !== undefined;
+}
+
+// get list of unique inputRefs used in compound rule
+export const ruleInputRefs = (r: string): string[] => [
+  ...new Set(ruleInputRules(r).map(inputRuleInput).filter(isDefined)),
+];
+
+// update given rule by modifying/adding/removing a single input rule
+//
+// append=false: replace existing rule for inputId with given rule
+//       should only be used for inputs w/unique rule for each input
+// append=true  => add rule for inputId if not already present
+// exclude=true => remove rule for inputId
+export const updateRule = (
+  rule: string,
+  style: MatchStyle | undefined,
+  inputId: string,
+  newRule: string,
+  append: boolean,
+  exclude?: boolean,
+): string => {
+  const inputRules: Map<string, string> = parseResponseMultiInputRule(rule);
+
+  const matchStyle: MatchStyle = style ? style : 'all';
+
+  const editedRule: string = toInputRule(inputId, newRule);
+
+  let updatedRule = '';
+  let alreadyIncluded = false;
+  Array.from(inputRules.keys()).forEach((k) => {
+    if (k === inputId) {
+      alreadyIncluded = true;
+      if (!exclude) {
+        updatedRule =
+          updatedRule === '' ? editedRule : combineRules(matchStyle, [updatedRule, editedRule]);
+      }
+    } else {
+      updatedRule =
+        updatedRule === ''
+          ? '' + inputRules.get(k)
+          : combineRules(matchStyle, [updatedRule, inputRules.get(k)!]);
+    }
+  });
+
+  if (append && !alreadyIncluded) {
+    updatedRule =
+      updatedRule === '' ? '' + editedRule : combineRules(matchStyle, [updatedRule, editedRule]);
+  }
+  if (style === 'none' && updatedRule !== '') {
+    updatedRule = '!(' + updatedRule + ')';
+  }
+  return updatedRule;
+};
+
+// builds map from input ids to rules. Will reduce multiple input rules for dropdown to single one
+export const parseResponseMultiInputRule = (rule: string): any => {
+  return ruleInputRules(rule).reduce((entries, ir) => {
+    const input = inputRuleInput(ir);
+    if (input) entries.set(input, ir);
+    return entries;
+  }, new Map<string, string>());
+};

--- a/assets/src/components/activities/response_multi/rules.ts
+++ b/assets/src/components/activities/response_multi/rules.ts
@@ -66,7 +66,6 @@ export const ruleInputRules = (r: MultiRule): InputRule[] => {
   const RE_RULE = new RegExp(INPUT_RULE, 'g');
 
   const matches = r.match(RE_RULE);
-  // console.log('ruleInputRules ' + r + ' =>\n   ' + matches);
   if (matches === null) throw new Error('no input Rules');
   return (matches ? matches : []) as InputRule[];
 };
@@ -79,7 +78,7 @@ export const getRulesForInput = (r: MultiRule, id: string): InputRule[] =>
 
 export const getUniqueRuleForInput = (r: MultiRule, id: string): InputRule => {
   const inputRules = getRulesForInput(r, id);
-  if (inputRules.length > 1) console.error('unexpected multiple rules for input ' + id);
+  if (inputRules.length > 1) console.trace('unexpected multiple rules for input ' + id);
   return inputRules[0];
 };
 
@@ -104,6 +103,7 @@ export const ruleIsCatchAll = (r: MultiRule): boolean =>
 //
 // remove op removes any rule for specified input
 // remove/modify ops should only be used in cases with unique rule for given input
+// Returns '' if ruleset empty after remove or toggle. Caller should check and handle
 export const updateRule = (
   rule: MultiRule,
   style: MatchStyle | undefined,
@@ -130,7 +130,6 @@ export const updateRule = (
       return combineRules(matchStyle, indexResponseMultiRule(rule).values());
   }
 
-  // Can have empty ruleset after remove. Caller should handle
   return inputRules.length === 0 ? '' : combineRules(matchStyle, inputRules);
 };
 

--- a/assets/src/components/activities/response_multi/rules.ts
+++ b/assets/src/components/activities/response_multi/rules.ts
@@ -16,8 +16,9 @@ import { MatchStyle } from '../types';
 // Other inputs should have a single InputRule per input, as should an "all" rule
 
 // We represent both in their torus rule string form, parsing out constitutents as needed.
-// Type aliases for parameter documentation only, do not provide type checking:
+// Following trick defines distinct nominal type for static type checking:
 type InputRule = string & { __type: 'InputRule' };
+// Type alias for parameter documentation only, no type checking:
 type MultiRule = string;
 
 // convert regular torus match rule to inputRule. no effect if already InputRule

--- a/assets/src/components/activities/response_multi/sections/PartsTab.tsx
+++ b/assets/src/components/activities/response_multi/sections/PartsTab.tsx
@@ -10,7 +10,6 @@ import { ResponseMultiInputSchema } from 'components/activities/response_multi/s
 import { ResponseTab } from 'components/activities/response_multi/sections/ResponseTab';
 import { Part, Response, makeResponse } from 'components/activities/types';
 import { Card } from 'components/misc/Card';
-import { hasCustomScoring } from 'data/activities/model/responses';
 import { containsRule, eqRule, equalsRule, matchRule } from 'data/activities/model/rules';
 import { getPartById } from 'data/activities/model/utils';
 import { ResponseMultiInputScoringMethod } from '../ResponseMultiInputScoringMethod';
@@ -52,6 +51,7 @@ interface Props {
 
 export const PartsTab: React.FC<Props> = (props) => {
   const { model, dispatch } = useAuthoringElementContext<ResponseMultiInputSchema>();
+  const part = getPartById(model, props.input.partId);
 
   const getResponsesBody = (part: Part) => {
     return part.responses.map((response) =>
@@ -59,8 +59,8 @@ export const PartsTab: React.FC<Props> = (props) => {
         <ResponseTab
           key={response.id}
           response={response}
-          partId={props.input.partId}
-          customScoring={hasCustomScoring(model, props.input.partId)}
+          partId={part.id}
+          customScoring={model.customScoring}
           removeResponse={(id) => dispatch(ResponseActions.removeResponse(id))}
           updateScore={(_id, score) =>
             dispatch(ResponseActions.editResponseScore(response.id, score))
@@ -88,18 +88,16 @@ export const PartsTab: React.FC<Props> = (props) => {
       <Card.Title></Card.Title>
       <Card.Content>
         <ResponseMultiInputScoringMethod />
-        {model.customScoring && (
-          <ActivityScoring partId={props.input.partId} promptForDefault={false} />
-        )}
-        {getResponsesBody(getPartById(model, props.input.partId))}
-        {getPartById(model, props.input.partId)
-          .responses.filter((r) => r.targeted)
+        {model.customScoring && <ActivityScoring partId={part.id} promptForDefault={false} />}
+        {getResponsesBody(part)}
+        {part.responses
+          .filter((r) => r.targeted)
           .map((response: Response) => (
             <ResponseTab
               key={response.id}
               response={response}
-              partId={props.input.partId}
-              customScoring={hasCustomScoring(model, props.input.partId)}
+              partId={part.id}
+              customScoring={model.customScoring}
               removeResponse={(id) => dispatch(ResponseActions.removeResponse(id))}
               updateScore={(_id, score) =>
                 dispatch(ResponseActions.editResponseScore(response.id, score))

--- a/assets/src/components/activities/response_multi/sections/PartsTab.tsx
+++ b/assets/src/components/activities/response_multi/sections/PartsTab.tsx
@@ -24,7 +24,7 @@ const defaultRuleForInputType = (inputType: string | undefined) => {
       return equalsRule('');
     case 'text':
     default:
-      return containsRule('');
+      return containsRule('answer');
   }
 };
 
@@ -90,8 +90,6 @@ export const PartsTab: React.FC<Props> = (props) => {
     <Card.Card key={props.input.id}>
       <Card.Title></Card.Title>
       <Card.Content>
-        <ResponseMultiInputScoringMethod />
-        {model.customScoring && <ActivityScoring partId={part.id} promptForDefault={false} />}
         {getResponse(correct, part, 'Correct Answer')}
         {catchAll && getResponse(catchAll, part, 'Feedback for Incorrect Answers')}
         {targeted.map((response: Response) => getResponse(response, part, 'Targeted Feedback'))}
@@ -102,6 +100,8 @@ export const PartsTab: React.FC<Props> = (props) => {
         >
           Add targeted feedback
         </AuthoringButtonConnected>
+        <ResponseMultiInputScoringMethod />
+        {model.customScoring && <ActivityScoring partId={part.id} promptForDefault={false} />}
       </Card.Content>
     </Card.Card>
   );

--- a/assets/src/components/activities/response_multi/sections/PartsTab.tsx
+++ b/assets/src/components/activities/response_multi/sections/PartsTab.tsx
@@ -14,7 +14,7 @@ import { hasCustomScoring } from 'data/activities/model/responses';
 import { containsRule, eqRule, equalsRule, matchRule } from 'data/activities/model/rules';
 import { getPartById } from 'data/activities/model/utils';
 import { ResponseMultiInputScoringMethod } from '../ResponseMultiInputScoringMethod';
-import { addRef, replaceWithInputRef } from '../utils';
+import { toInputRule } from '../rules';
 
 const defaultRuleForInputType = (inputType: string | undefined) => {
   switch (inputType) {
@@ -29,19 +29,17 @@ const defaultRuleForInputType = (inputType: string | undefined) => {
 };
 
 export const addResponseMultiTargetedFeedbackFillInTheBlank = (input: FillInTheBlank) => {
-  const response: Response = addRef(
-    input.id,
-    makeResponse(replaceWithInputRef(input.id, defaultRuleForInputType(input.inputType)), 0, ''),
+  const response: Response = makeResponse(
+    toInputRule(input.id, defaultRuleForInputType(input.inputType)),
+    0,
+    '',
   );
   response.targeted = true;
   return ResponseActions.addResponse(response, input.partId);
 };
 
 export const addResponseMultiTargetedDropdown = (input: Dropdown, choiceId: string) => {
-  const response: Response = addRef(
-    input.id,
-    makeResponse(replaceWithInputRef(input.id, matchRule(choiceId)), 0, ''),
-  );
+  const response: Response = makeResponse(toInputRule(input.id, matchRule(choiceId)), 0, '');
   response.targeted = true;
   return ResponseActions.addResponse(response, input.partId);
 };

--- a/assets/src/components/activities/response_multi/sections/ResponseTab.tsx
+++ b/assets/src/components/activities/response_multi/sections/ResponseTab.tsx
@@ -44,7 +44,6 @@ export const ResponseTab: React.FC<Props> = (props) => {
   // update method used on dropdown choice click
   const toggleCorrectness = (id: string, partId: string, inputId: string) => {
     if (response.matchStyle === 'any' || response.matchStyle === 'none') {
-      console.log(`toggling choice ${id} for input ${inputId}`);
       // disjunctive rule allows multiple correct options.
       // Treat as CATA checkbox: toggle clicked choice in/out of correct set
       const newRule = updateRule(
@@ -54,14 +53,12 @@ export const ResponseTab: React.FC<Props> = (props) => {
         matchRule(id),
         'toggle',
       );
-      console.log('new rule after toggle: |' + newRule + '|');
       // prevent change to totally empty rule or one w/no inputRules for this input:
       if (newRule !== '' && getRulesForInput(newRule, inputId).length > 0) {
-        console.log('dispatching update');
         dispatch(
           ResponseMultiInputActions.editResponseResponseMultiRule(response.id, inputId, newRule),
         );
-      } else console.log('ignoring update');
+      }
       return;
     }
 

--- a/assets/src/components/activities/response_multi/sections/ResponseTab.tsx
+++ b/assets/src/components/activities/response_multi/sections/ResponseTab.tsx
@@ -6,7 +6,6 @@ import { FeedbackCard } from 'components/activities/common/responses/FeedbackCar
 import { ScoreInput } from 'components/activities/common/responses/ScoreInput';
 import { ShowPage } from 'components/activities/common/responses/ShowPage';
 import { ResponseActions } from 'components/activities/common/responses/responseActions';
-import { addOrRemove } from 'components/activities/common/utils';
 import { Dropdown, MultiInput } from 'components/activities/multi_input/schema';
 import { ResponseMultiInputSchema } from 'components/activities/response_multi/schema';
 import { RulesTab } from 'components/activities/response_multi/sections/RulesTab';
@@ -22,6 +21,7 @@ import { getRulesForInput, ruleInputRefs, updateRule } from '../rules';
 import { defaultRuleForInputType, inputLabel } from '../utils';
 
 interface Props {
+  title: string;
   response: Response;
   partId: string;
   customScoring?: boolean;
@@ -181,12 +181,32 @@ export const ResponseTab: React.FC<Props> = (props) => {
     </div>
   );
 
+  // if showing catchall incorrect response, just show feedback card
+  if (props.title.toLowerCase().includes('incorrect'))
+    return (
+      <FeedbackCard
+        key={`feedb-${response.id}`}
+        title={props.title}
+        feedback={response.feedback}
+        updateTextDirection={(textDirection) => updateTextDirection(response.id, textDirection)}
+        update={(_id, content) => updateFeedback(response.id, content as RichText)}
+        updateEditor={(editor) => updateFeedbackEditor(response.id, editor)}
+        placeholder="Encourage students or explain why the answer is correct"
+      >
+        {authoringContext.contentBreaksExist ? (
+          <ShowPage
+            editMode={editMode}
+            index={response.showPage}
+            onChange={(v) => updateShowPage(response.id, v)}
+          />
+        ) : null}
+      </FeedbackCard>
+    );
+
   return (
     <Card.Card key={response.id}>
       <Card.Title>
-        <div className="d-flex justify-content-between w-100">
-          {response.targeted ? 'Targeted Feedback' : 'Feedback'}
-        </div>
+        <div className="d-flex justify-content-between w-100">{props.title}</div>
 
         <div className="flex-grow-1"></div>
         {!props.customScoring ? (

--- a/assets/src/components/activities/response_multi/sections/ResponseTab.tsx
+++ b/assets/src/components/activities/response_multi/sections/ResponseTab.tsx
@@ -45,7 +45,6 @@ export const ResponseTab: React.FC<Props> = (props) => {
   });
 
   const toggleCorrectness = (id: string, partId: string, inputId: string) => {
-    console.log(`toggleCorrectness dropdown Id:${inputId} choiceId:${id}`);
     const inputRule = toInputRule(inputId, matchRule(id));
 
     if (response.matchStyle !== 'all') {
@@ -60,16 +59,13 @@ export const ResponseTab: React.FC<Props> = (props) => {
     }
     // else this indicates unique value selection, not toggling in or out
     const newRule = updateRule(response.rule, response.matchStyle, inputId, inputRule, false);
-    console.log(` constructRule => ${newRule}`);
     dispatch(
       ResponseMultiInputActions.editResponseResponseMultiRule(response.id, inputId, newRule),
     );
   };
 
   const editRule = (id: ResponseId, inputId: string, rule: string) => {
-    console.log(`editRule inputId:${inputId} rule:  ${rule}`);
     const newRule = updateRule(response.rule, response.matchStyle, inputId, rule, false);
-    console.log(` constructRule => ${newRule}`);
     dispatch(
       ResponseMultiInputActions.editResponseResponseMultiRule(
         id,

--- a/assets/src/components/activities/response_multi/sections/RulesTab.tsx
+++ b/assets/src/components/activities/response_multi/sections/RulesTab.tsx
@@ -27,29 +27,33 @@ export const RulesTab: React.FC<Props> = (props) => {
   };
 
   if (props.input.inputType === 'dropdown') {
+    // get choice set for this input
     const choices = model.choices.filter((choice) =>
       (props.input as Dropdown).choiceIds.includes(choice.id),
     );
-    // Rule may combine many input rules, and have multiple matches for this input
+    // Rule may combine many input rules to have multiple matches for this input
     const values = getInputValues(props.response.rule, props.input.id);
-
-    // questionable what to do with wildcard. Here select all choices
-    const selectedValues = values[0] === '.*' ? choices.map((c) => c.id) : values;
 
     // disjunctive rules allow multiple checked choices for dropdowns, so show as Checkbox
     const orRule = props.response.matchStyle === 'any' || props.response.matchStyle === 'none';
     return (
       <div className="d-flex flex-row">
         {props.label}&nbsp;
-        <ChoicesDelivery
-          unselectedIcon={orRule ? <Checkbox.Unchecked /> : <Radio.Unchecked />}
-          selectedIcon={orRule ? <Checkbox.Checked /> : <Radio.Checked />}
-          choices={choices}
-          selected={selectedValues}
-          onSelect={(id) => props.toggleCorrectness(id, props.input.partId, props.input.id)}
-          isEvaluated={false}
-          context={defaultWriterContext({ projectSlug: projectSlug })}
-        />
+        {values[0] === '.*' ? (
+          // Wildcard dropdown rule unnecessary outside of catchall, but could occur
+          // This odd case display changeable by deleting & adding back rule for input
+          <span>[ Any ]</span>
+        ) : (
+          <ChoicesDelivery
+            unselectedIcon={orRule ? <Checkbox.Unchecked /> : <Radio.Unchecked />}
+            selectedIcon={orRule ? <Checkbox.Checked /> : <Radio.Checked />}
+            choices={choices}
+            selected={values}
+            onSelect={(id) => props.toggleCorrectness(id, props.input.partId, props.input.id)}
+            isEvaluated={false}
+            context={defaultWriterContext({ projectSlug: projectSlug })}
+          />
+        )}
         <div className="choicesAuthoring__removeButtonContainer">
           {<RemoveButtonConnected onClick={removeInputFromResponse} />}
         </div>

--- a/assets/src/components/activities/response_multi/sections/RulesTab.tsx
+++ b/assets/src/components/activities/response_multi/sections/RulesTab.tsx
@@ -14,6 +14,7 @@ import { getInputValues, getUniqueRuleForInput } from '../rules';
 
 interface Props {
   input: MultiInput;
+  label?: string;
   response: Response;
   toggleCorrectness: (id: string, partId: string, inputId: string) => void;
   editRule: (id: ResponseId, inputId: string, rule: string) => void;
@@ -39,6 +40,7 @@ export const RulesTab: React.FC<Props> = (props) => {
     const orRule = props.response.matchStyle === 'any' || props.response.matchStyle === 'none';
     return (
       <div className="d-flex flex-row">
+        {props.label}&nbsp;
         <ChoicesDelivery
           unselectedIcon={orRule ? <Checkbox.Unchecked /> : <Radio.Unchecked />}
           selectedIcon={orRule ? <Checkbox.Checked /> : <Radio.Checked />}
@@ -59,14 +61,15 @@ export const RulesTab: React.FC<Props> = (props) => {
   const inputRule = getUniqueRuleForInput(props.response.rule, props.input.id);
   return (
     <div className="d-flex flex-row mb-2">
+      {props.label}&nbsp;
       <div className="flex-grow-1">
         <InputEntry
           key={props.response.id}
           inputType={props.input.inputType}
-          // InputEntry edits a response's rule (operation and matching text/number/regexp).
+          // InputEntry takes a response to edit its rule (op and matching text/number/regexp).
           // Our response may have compound rule, so pass a dummy response object with just
           // the single input rule to be edited. editRule will apply edits to real response
-          response={{ id: props.response.id, rule: inputRule } as Response}
+          response={{ id: props.response.id, rule: inputRule as string } as Response}
           onEditResponseRule={(id, rule) => props.editRule(id, props.input.id, rule)}
         />
       </div>

--- a/assets/src/components/activities/response_multi/sections/RulesTab.tsx
+++ b/assets/src/components/activities/response_multi/sections/RulesTab.tsx
@@ -31,7 +31,6 @@ export const RulesTab: React.FC<Props> = (props) => {
     );
     // Rule may combine many input rules, and have multiple matches for this input
     const values = getInputValues(props.response.rule, props.input.id);
-    if (values.length > 1) console.log(`input ${props.input.id} w/multiple values: ` + values);
 
     // questionable what to do with wildcard. Here select all choices
     const selectedValues = values[0] === '.*' ? choices.map((c) => c.id) : values;

--- a/assets/src/components/activities/response_multi/utils.tsx
+++ b/assets/src/components/activities/response_multi/utils.tsx
@@ -131,3 +131,15 @@ export const inputTitle = (input: MultiInput, index: number) => (
     <span className="text-muted">{friendlyType(input.inputType)}</span>
   </div>
 );
+
+export const inputLabel = (id: string, model: ResponseMultiInputSchema, type: boolean = false) => {
+  const index = model.inputs.findIndex((inp) => inp.id === id);
+  if (index < 0) {
+    console.error('input not found: ' + id);
+    return 'Unknown Input';
+  }
+
+  const input = model.inputs[index];
+  const label = `Input ${index + 1}`;
+  return type ? label + `(${friendlyType(input.inputType)})` : label;
+};

--- a/assets/src/components/activities/response_multi/utils.tsx
+++ b/assets/src/components/activities/response_multi/utils.tsx
@@ -131,7 +131,7 @@ export const inputTitle = (input: MultiInput, index: number) => (
   </div>
 );
 
-export const inputLabel = (id: string, model: ResponseMultiInputSchema, type: boolean = false) => {
+export const inputLabel = (id: string, model: ResponseMultiInputSchema, type = false) => {
   const index = model.inputs.findIndex((inp) => inp.id === id);
   if (index < 0) {
     console.error('input not found: ' + id);

--- a/assets/src/components/activities/response_multi/utils.tsx
+++ b/assets/src/components/activities/response_multi/utils.tsx
@@ -51,7 +51,6 @@ export const defaultRuleForInputType = (inputType: string | undefined, choiceId?
 export const ResponseMultiInputResponses = {
   catchAll: (inputId: string, text = 'Incorrect') => {
     const catchAllRespose = makeResponse(toInputRule(inputId, matchRule('.*')), 0, text);
-    catchAllRespose.catchAll = true;
     return catchAllRespose;
   },
   forTextInput: (inputId: string, correctText = 'Correct', incorrectText = 'Incorrect') => [

--- a/assets/src/components/activities/response_multi/utils.tsx
+++ b/assets/src/components/activities/response_multi/utils.tsx
@@ -1,32 +1,20 @@
 import React from 'react';
 import { SelectOption } from 'components/activities/common/authoring/InputTypeDropdown';
-import { setDifference, setUnion } from 'components/activities/common/utils';
 import { ResponseMultiInputSchema } from 'components/activities/response_multi/schema';
 import {
   ChoiceId,
-  MatchStyle,
-  Part,
-  Response,
   Transform,
-  makeChoice,
   makeHint,
   makePart,
   makeResponse,
   makeTransformation,
 } from 'components/activities/types';
-import {
-  containsRule,
-  eqRule,
-  equalsRule,
-  isTextRule,
-  matchRule,
-} from 'data/activities/model/rules';
+import { containsRule, eqRule, equalsRule, matchRule } from 'data/activities/model/rules';
 import { Model } from 'data/content/model/elements/factories';
 import { InputRef, Paragraph } from 'data/content/model/elements/types';
-import { elementsOfType } from 'data/content/utils';
-import { clone } from 'utils/common';
 import guid from 'utils/guid';
 import { MultiInput, MultiInputType } from '../multi_input/schema';
+import { toInputRule } from './rules';
 
 export const multiInputOptions: SelectOption<'text' | 'numeric'>[] = [
   { value: 'numeric', displayValue: 'Number' },
@@ -60,67 +48,22 @@ export const defaultRuleForInputType = (inputType: string | undefined, choiceId?
   }
 };
 
-export const constructRule = (
-  inputRule: string,
-  inputMatchStyle: MatchStyle | undefined,
-  inputId: string,
-  rule: string,
-  append: boolean,
-  exclude?: boolean,
-): string => {
-  const inputRules: Map<string, string> = purseResponseMultiInputRule(inputRule);
-
-  const matchStyle: MatchStyle = inputMatchStyle ? inputMatchStyle : 'all';
-  let ruleSeparator = ' && ';
-  if (matchStyle === 'any' || matchStyle === 'none') {
-    ruleSeparator = ' || ';
-  }
-  const editedRule: string = replaceWithInputRef(inputId, rule);
-
-  let updatedRule = '';
-  let alreadyIncluded = false;
-  Array.from(inputRules.keys()).forEach((k) => {
-    if (k === inputId) {
-      alreadyIncluded = true;
-      if (!exclude) {
-        updatedRule = updatedRule === '' ? editedRule : updatedRule + ruleSeparator + editedRule;
-      }
-    } else {
-      updatedRule =
-        updatedRule === ''
-          ? '' + inputRules.get(k)
-          : updatedRule + ruleSeparator + inputRules.get(k);
-    }
-  });
-
-  if (append && !alreadyIncluded) {
-    updatedRule = updatedRule === '' ? '' + editedRule : updatedRule + ruleSeparator + editedRule;
-  }
-  if (matchStyle === 'none' && updatedRule !== '') {
-    updatedRule = '!(' + updatedRule + ')';
-  }
-  return updatedRule;
-};
-
 export const ResponseMultiInputResponses = {
   catchAll: (inputId: string, text = 'Incorrect') => {
-    const catchAllRespose = makeResponse(replaceWithInputRef(inputId, matchRule('.*')), 0, text);
+    const catchAllRespose = makeResponse(toInputRule(inputId, matchRule('.*')), 0, text);
     catchAllRespose.catchAll = true;
-    return addRef(inputId, catchAllRespose);
+    return catchAllRespose;
   },
   forTextInput: (inputId: string, correctText = 'Correct', incorrectText = 'Incorrect') => [
-    addRef(
-      inputId,
-      makeResponse(replaceWithInputRef(inputId, containsRule('answer')), 1, correctText),
-    ),
+    makeResponse(toInputRule(inputId, containsRule('answer')), 1, correctText),
     ResponseMultiInputResponses.catchAll(inputId, incorrectText),
   ],
   forNumericInput: (inputId: string, correctText = 'Correct', incorrectText = 'Incorrect') => [
-    addRef(inputId, makeResponse(replaceWithInputRef(inputId, eqRule(1)), 1, correctText)),
+    makeResponse(toInputRule(inputId, eqRule(1)), 1, correctText),
     ResponseMultiInputResponses.catchAll(inputId, incorrectText),
   ],
   forMathInput: (inputId: string, correctText = 'Correct', incorrectText = 'Incorrect') => [
-    addRef(inputId, makeResponse(replaceWithInputRef(inputId, equalsRule('')), 1, correctText)),
+    makeResponse(toInputRule(inputId, equalsRule('')), 1, correctText),
     ResponseMultiInputResponses.catchAll(inputId, incorrectText),
   ],
   forResponseMultipleChoice: (
@@ -129,23 +72,9 @@ export const ResponseMultiInputResponses = {
     correctText = 'Correct',
     incorrectText = 'Incorrect',
   ) => [
-    addRef(
-      inputId,
-      makeResponse(replaceWithInputRef(inputId, matchRule(correctChoiceId)), 1, correctText),
-    ),
-    addRef(inputId, makeResponse(replaceWithInputRef(inputId, matchRule('.*')), 0, incorrectText)),
+    makeResponse(toInputRule(inputId, matchRule(correctChoiceId)), 1, correctText),
+    makeResponse(toInputRule(inputId, matchRule('.*')), 0, incorrectText),
   ],
-};
-
-export const replaceWithInputRef = (inputId: string, rule: string) => {
-  if (rule.includes('input_ref_')) return rule;
-  return rule.replace(/input/g, 'input_ref_' + inputId);
-};
-
-export const addRef = (inputId: string, response: Response): Response => {
-  if (!response.inputRefs) response.inputRefs = [];
-  if (!response.inputRefs.includes(inputId)) response.inputRefs.push(inputId);
-  return response;
 };
 
 export const defaultModel = (): ResponseMultiInputSchema => {
@@ -202,207 +131,3 @@ export const inputTitle = (input: MultiInput, index: number) => (
     <span className="text-muted">{friendlyType(input.inputType)}</span>
   </div>
 );
-
-export const purseResponseMultiInputRule = (rule: string): any => {
-  const ruleRegex = RegExp('input_ref_.*?}', 'g');
-
-  let reg;
-  const entries: Map<string, string> = new Map<string, string>();
-
-  while ((reg = ruleRegex.exec(rule)) !== null) {
-    entries.set(reg[0].split('_')[2].split(' ')[0], reg[0]);
-  }
-  return entries;
-};
-
-export function guaranteeResponseMultiInputValidity(
-  model: ResponseMultiInputSchema,
-): ResponseMultiInputSchema {
-  // Check whether model is valid first to save unnecessarily cloning the model
-  if (isValidModel(model)) {
-    return model;
-  }
-
-  // Model must be cloned before being passed to these mutable functions.
-  return ensureHasInput(
-    matchInputsToChoices(matchInputsToParts(matchInputsToInputRefs(clone(model)))),
-  );
-}
-
-function inputsMatchInputRefs(model: ResponseMultiInputSchema) {
-  const inputRefs = elementsOfType(model.stem.content, 'input_ref');
-  const union = setUnion(
-    inputRefs.map(({ id }) => id),
-    model.inputs.map(({ id }) => id),
-  );
-  return union.length === inputRefs.length && union.length === model.inputs.length;
-}
-
-function inputsMatchParts(model: ResponseMultiInputSchema) {
-  if (model.multInputsPerPart) return true;
-  const parts = model.authoring.parts;
-  const union = setUnion(
-    model.inputs.map(({ partId }) => partId),
-    parts.map(({ id }) => id),
-  );
-  return union.length === model.inputs.length && union.length === parts.length;
-}
-
-function inputsMatchChoices(model: ResponseMultiInputSchema) {
-  const inputChoiceIds = model.inputs.reduce(
-    (acc, curr) => (curr.inputType === 'dropdown' ? acc.concat(curr.choiceIds) : acc),
-    [] as string[],
-  );
-  const union = setUnion(
-    model.choices.map(({ id }) => id),
-    inputChoiceIds,
-  );
-  return union.length === model.choices.length && union.length === inputChoiceIds.length;
-}
-
-function hasAnInput(model: ResponseMultiInputSchema) {
-  return model.inputs.length > 0;
-}
-
-function isValidModel(model: ResponseMultiInputSchema): boolean {
-  return (
-    hasAnInput(model) &&
-    inputsMatchInputRefs(model) &&
-    inputsMatchParts(model) &&
-    inputsMatchChoices(model)
-  );
-}
-
-function ensureHasInput(model: ResponseMultiInputSchema) {
-  if (hasAnInput(model)) {
-    return model;
-  }
-
-  // Make new input ref, add to first paragraph of stem, add new input to model.inputs,
-  // add new part.
-  const ref = Model.inputRef();
-  const part = makePart(ResponseMultiInputResponses.forTextInput(ref.id), [makeHint('')]);
-  const input: MultiInput = { id: ref.id, inputType: 'text', partId: part.id };
-
-  const firstParagraph = model.stem.content.find((elem) => elem.type === 'p') as
-    | Paragraph
-    | undefined;
-  firstParagraph?.children.push(ref);
-  firstParagraph?.children.push({ text: '' });
-
-  model.inputs.push(input);
-  model.authoring.parts.push(part);
-
-  return model;
-}
-
-function matchInputsToChoices(model: ResponseMultiInputSchema) {
-  if (inputsMatchChoices(model)) {
-    return model;
-  }
-
-  const choiceIds = model.choices.map(({ id }) => id);
-  const inputChoiceIds = model.inputs.reduce(
-    (acc, curr) => (curr.inputType === 'dropdown' ? acc.concat(curr.choiceIds) : acc),
-    [] as string[],
-  );
-
-  const unmatchedInputChoiceIds = setDifference(inputChoiceIds, choiceIds);
-
-  const unmatchedChoices = setDifference(choiceIds, inputChoiceIds).map((id) =>
-    model.choices.find((c) => c.id === id),
-  );
-
-  unmatchedInputChoiceIds.forEach((id) => {
-    model.choices.push(makeChoice('Choice', id));
-  });
-
-  model.choices = model.choices.filter((choice) => !unmatchedChoices.includes(choice));
-
-  return model;
-}
-
-function matchInputsToParts(model: ResponseMultiInputSchema) {
-  if (inputsMatchParts(model)) {
-    return model;
-  }
-
-  const inputIds = model.inputs.map(({ id }) => id);
-  const partIds = model.authoring.parts.map(({ id }) => id);
-
-  const unmatchedInputs = setDifference(inputIds, partIds).map((id) =>
-    model.inputs.find((input) => input.id === id),
-  );
-
-  const unmatchedParts = setDifference(inputIds, partIds).map((id) =>
-    model.authoring.parts.find((part) => part.id === id),
-  );
-
-  unmatchedInputs.forEach((input: MultiInput) => {
-    if (model.multInputsPerPart) return;
-    const choices = [makeChoice('Choice A'), makeChoice('Choice B')];
-    const part = makePart(
-      input.inputType === 'dropdown'
-        ? ResponseMultiInputResponses.forResponseMultipleChoice(input.id, choices[0].id)
-        : input.inputType === 'numeric'
-        ? ResponseMultiInputResponses.forNumericInput(input.id)
-        : ResponseMultiInputResponses.forTextInput(input.id),
-    );
-    model.authoring.parts.push(part);
-  });
-
-  unmatchedParts.forEach((part: Part) => {
-    const rule = part.responses[0].rule;
-    const type = rule.match(/{\d+}/) ? 'dropdown' : isTextRule(rule) ? 'text' : 'numeric';
-    const ref = Model.inputRef();
-    // If it's a dropdown, change the part to a text input.
-    model.inputs.push({
-      id: ref.id,
-      inputType: type === 'dropdown' ? 'text' : type,
-      partId: part.id,
-    });
-    part.responses =
-      type === 'dropdown' ? ResponseMultiInputResponses.forTextInput(ref.id) : part.responses;
-    // add inputRef to end of first paragraph in stem
-    const firstParagraph = model.stem.content.find((elem) => elem.type === 'p') as
-      | Paragraph
-      | undefined;
-    firstParagraph?.children.push(ref);
-    firstParagraph?.children.push({ text: '' });
-  });
-
-  return model;
-}
-
-function matchInputsToInputRefs(model: ResponseMultiInputSchema) {
-  if (inputsMatchInputRefs(model)) {
-    return model;
-  }
-
-  const inputRefIds = elementsOfType(model.stem.content, 'input_ref').map(({ id }) => id);
-  const inputIds = model.inputs.map(({ id }) => id);
-
-  const unmatchedInputs = setDifference(inputIds, inputRefIds).map((id) =>
-    model.inputs.find((input) => input.id === id),
-  );
-
-  const unmatchedInputRefs = setDifference(inputRefIds, inputIds).map(
-    (id) => ({ id, type: 'input_ref' } as InputRef),
-  );
-
-  unmatchedInputs.forEach((input: MultiInput) => {
-    // add inputRef to end of first paragraph in stem
-    const firstParagraph = model.stem.content.find((e) => e.type === 'p') as Paragraph | undefined;
-    firstParagraph?.children.push({ ...Model.inputRef(), id: input.id });
-    firstParagraph?.children.push({ text: '' });
-  });
-
-  unmatchedInputRefs.forEach((ref) => {
-    if (model.multInputsPerPart) return;
-    // create new input and part for the input ref in the stem
-    const part = makePart(ResponseMultiInputResponses.forTextInput(ref.id), [makeHint('')]);
-    model.inputs.push({ id: ref.id, inputType: 'text', partId: part.id } as MultiInput);
-    model.authoring.parts.push(part);
-  });
-  return model;
-}

--- a/assets/src/components/activities/types.ts
+++ b/assets/src/components/activities/types.ts
@@ -493,8 +493,6 @@ export interface Response extends Identifiable {
 
   matchStyle?: MatchStyle;
 
-  inputRefs?: string[];
-
   catchAll?: boolean;
 
   targeted?: boolean;

--- a/assets/src/components/activities/types.ts
+++ b/assets/src/components/activities/types.ts
@@ -491,11 +491,10 @@ export interface Response extends Identifiable {
    */
   showPage?: number;
 
+  /*
+   * For Response_multi: matching style to apply to rule
+   */
   matchStyle?: MatchStyle;
-
-  catchAll?: boolean;
-
-  targeted?: boolean;
 }
 
 /**

--- a/assets/src/data/activities/model/responses.ts
+++ b/assets/src/data/activities/model/responses.ts
@@ -82,6 +82,12 @@ export const getIncorrectResponse = (model: HasParts, partId: string) => {
   ).valueOrThrow(new Error('Could not find incorrect response'));
 };
 
+export const getMaxScoreResponse = (model: HasParts, partId: string) => {
+  return getResponsesByPartId(model, partId).reduce((prev, current) =>
+    prev && current.score > prev.score ? current : prev,
+  );
+};
+
 export interface ResponseMapping {
   response: Response;
   choiceIds: ChoiceId[];

--- a/assets/src/data/activities/model/rules.ts
+++ b/assets/src/data/activities/model/rules.ts
@@ -114,7 +114,7 @@ export function rangeOperator(s: string): RangeOperator {
 }
 
 const escapeInput = (s: string) => s.replace(/[\\{}]/g, (i) => `\\${i}`);
-const unescapeInput = (s: string) => s.replace(/\\[\\{}]/g, (i) => i.substring(1));
+export const unescapeInput = (s: string) => s.replace(/\\[\\{}]/g, (i) => i.substring(1));
 
 const valueWithPrecision = (value: numberOrVar, precision?: number) =>
   precision !== undefined ? `${value}#${precision}` : `${value}`;

--- a/assets/test/response_multi/response_multi_authoring_test.tsx
+++ b/assets/test/response_multi/response_multi_authoring_test.tsx
@@ -126,7 +126,7 @@ describe('multi input question - default (with text input)', () => {
     }
     const responses = model.authoring.parts[0].responses;
     expect(responses).toHaveLength(3);
-    expect(responses[1]).toHaveProperty('rule', 'input_ref_' + t + ' contains {}');
+    expect(responses[1]).toHaveProperty('rule', 'input_ref_' + t + ' contains {answer}');
     expect(responses[1]).toHaveProperty('score', 0);
   });
 


### PR DESCRIPTION
This batches fixes and enhancements for several issues in the new response_muti activity, primarily in the authoring interface:

- Fixes errors in parsing rules, e.g. not handling ids with underscores (used in Logic and Proofs course) Rule parsing functions now centralized in a new file, rules.ts using a quasi-type of "InputRule".  

- Fixes to generate legally parenthesized torus rules which do not allow n-ary conjunction/disjunction without parens. 

- Allows for multiple rules for dropdown choices when type is disjunctive (used in Logic and Proofs), showing as multi-select checkboxes in this case. 

- Shows feedback for incorrect answer (catchall) so it can be modified, as in multi_input, multiple choice, etc.

- Uses labels "Input 1", "Input 2" in add rule dropdown and rule display to help tell which input is being referenced.

- Correctly updates rule on matchStyle change.

- Works around dropdown UI glitch preventing adding rule for last input by using hidden rather than disabled for dummy option.

- Restores correct checkbox on targeted feedbacks. Also correctly handles custom scoring reset.

This revision also simplifies some code by dropping response flags for targeted feedbacks, catchalls, and rule input refs in favor of deriving these as needed.  Adopts the view that after primary correct answer and catchAll responses, any other responses must be "targeted feedback".