### PR TITLE
[PERFORMANCE] Address performance concerns regarding publishing updates and system resources

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -338,4 +338,20 @@ if config_env() == :prod do
 
   config :oli, :datashop,
     cache_limit: String.to_integer(System.get_env("DATASHOP_CACHE_LIMIT", "200"))
+
+  config :oli, Oban,
+  repo: Oli.Repo,
+  plugins: [Oban.Plugins.Pruner],
+  queues: [
+    default: String.to_integer(System.get_env("OBAN_QUEUE_SIZE_DEFAULT", "10")),
+    snapshots: String.to_integer(System.get_env("OBAN_QUEUE_SIZE_SNAPSHOTS", "20")),
+    s3_uploader: String.to_integer(System.get_env("OBAN_QUEUE_SIZE_S3UPLOADER", "20")),
+    selections: String.to_integer(System.get_env("OBAN_QUEUE_SIZE_SELECTIONS", "20")),
+    updates: String.to_integer(System.get_env("OBAN_QUEUE_SIZE_UPDATES", "2")),
+    grades: String.to_integer(System.get_env("OBAN_QUEUE_SIZE_GRADES", "30")),
+    auto_submit: String.to_integer(System.get_env("OBAN_QUEUE_SIZE_AUTOSUBMIT", "3")),
+    analytics_export: String.to_integer(System.get_env("OBAN_QUEUE_SIZE_ANALYTICS", "1")),
+    datashop_export: String.to_integer(System.get_env("OBAN_QUEUE_SIZE_DATASHOP", "1")),
+    objectives: String.to_integer(System.get_env("OBAN_QUEUE_SIZE_OBJECTIVES", "3"))
+  ]
 end

--- a/lib/oli/delivery/previous_next_index.ex
+++ b/lib/oli/delivery/previous_next_index.ex
@@ -85,4 +85,16 @@ defmodule Oli.Delivery.PreviousNextIndex do
       {:error, e} -> e
     end
   end
+
+  def rebuild(%Section{} = section, hierarchy) do
+    case Repo.transaction(fn _ ->
+           Hierarchy.build_navigation_link_map(hierarchy)
+           |> then(fn previous_next_index ->
+             Sections.update_section(section, %{previous_next_index: previous_next_index})
+           end)
+         end) do
+      {:ok, result} -> result
+      {:error, e} -> e
+    end
+  end
 end

--- a/lib/oli/delivery/sections/minimal_hierarchy.ex
+++ b/lib/oli/delivery/sections/minimal_hierarchy.ex
@@ -1,0 +1,103 @@
+defmodule Oli.Delivery.Sections.MinimalHierarchy do
+
+  import Ecto.Query, warn: false
+
+  alias Oli.Delivery.Sections
+  alias Oli.Delivery.Hierarchy.HierarchyNode
+  alias Oli.Resources.Numbering
+  alias Oli.Branding.CustomLabels
+  alias Oli.Repo
+
+  import Oli.Utils
+
+  require Logger
+
+  def full_hierarchy(section_slug) do
+
+    mark = Oli.Timing.mark()
+
+    {hierarchy_nodes, root_hierarchy_node} = hierarchy_nodes_by_sr_id(section_slug)
+    result = hierarchy_node_with_children(root_hierarchy_node, hierarchy_nodes)
+
+    Logger.info("MinimalHierarchy.full_hierarchy: #{Oli.Timing.elapsed(mark) / 1000 / 1000}ms")
+
+    result
+  end
+
+  defp hierarchy_node_with_children(
+        %HierarchyNode{children: children_ids} = node,
+        nodes_by_sr_id
+      ) do
+    Map.put(
+      node,
+      :children,
+      Enum.map(children_ids, fn sr_id ->
+        Map.get(nodes_by_sr_id, sr_id)
+        |> hierarchy_node_with_children(nodes_by_sr_id)
+      end)
+    )
+  end
+
+  # Returns a map of resource ids to hierarchy nodes and the root hierarchy node
+  defp hierarchy_nodes_by_sr_id(section_slug) do
+    page_id = Oli.Resources.ResourceType.get_id_by_type("page")
+    container_id = Oli.Resources.ResourceType.get_id_by_type("container")
+
+    section = Sections.get_section_by(slug: section_slug)
+
+    labels =
+      case section.customizations do
+        nil -> Map.from_struct(CustomLabels.default())
+        l -> Map.from_struct(l)
+      end
+
+    from(
+      [sr: sr, rev: rev, spp: spp] in Oli.Publishing.DeliveryResolver.section_resource_revisions(section_slug),
+      join: p in Oli.Authoring.Course.Project,
+      on: p.id == spp.project_id,
+      where:
+        rev.resource_type_id == ^page_id or
+          rev.resource_type_id == ^container_id,
+      select:
+        {sr, %{
+          id: rev.id,
+          resource_id: rev.resource_id,
+          resource_type_id: rev.resource_type_id,
+          slug: rev.slug,
+          title: rev.title,
+          graded: rev.graded
+        }, p.slug}
+    )
+    |> Repo.all()
+    |> Enum.reduce({%{}, nil}, fn {sr, rev, proj_slug}, {nodes, root} ->
+
+      is_root? = section.root_section_resource_id == sr.id
+
+      node = %HierarchyNode{
+        uuid: uuid(),
+        numbering: %Numbering{
+          index: sr.numbering_index,
+          level: sr.numbering_level,
+          labels: labels
+        },
+        children: sr.children,
+        resource_id: rev.resource_id,
+        project_id: sr.project_id,
+        project_slug: proj_slug,
+        revision: rev,
+        section_resource: sr
+      }
+
+      {
+        Map.put(
+          nodes,
+          sr.id,
+          node
+        ),
+        if(is_root?, do: node, else: root)
+      }
+    end)
+
+  end
+
+end

--- a/lib/oli_web/live/delivery/manage_source_materials.ex
+++ b/lib/oli_web/live/delivery/manage_source_materials.ex
@@ -182,9 +182,11 @@ defmodule OliWeb.Delivery.ManageSourceMaterials do
       updates_in_progress: updates_in_progress
     } = socket.assigns
 
-    %{"section_slug" => section.slug, "publication_id" => publication_id}
-    |> Worker.new()
-    |> Oban.insert!()
+   # %{"section_slug" => section.slug, "publication_id" => publication_id}
+   # |> Worker.new()
+   # |> Oban.insert!()
+
+    Worker.perform_now(section.slug, publication_id)
 
     updates_in_progress = Map.put_new(updates_in_progress, publication_id, true)
 

--- a/lib/oli_web/live/delivery/manage_source_materials.ex
+++ b/lib/oli_web/live/delivery/manage_source_materials.ex
@@ -182,11 +182,9 @@ defmodule OliWeb.Delivery.ManageSourceMaterials do
       updates_in_progress: updates_in_progress
     } = socket.assigns
 
-   # %{"section_slug" => section.slug, "publication_id" => publication_id}
-   # |> Worker.new()
-   # |> Oban.insert!()
-
-    Worker.perform_now(section.slug, publication_id)
+    %{"section_slug" => section.slug, "publication_id" => publication_id}
+    |> Worker.new()
+    |> Oban.insert!()
 
     updates_in_progress = Map.put_new(updates_in_progress, publication_id, true)
 

--- a/lib/oli_web/live/insights/insights.ex
+++ b/lib/oli_web/live/insights/insights.ex
@@ -34,6 +34,7 @@ defmodule OliWeb.Insights do
     {:ok,
      assign(socket,
        ctx: ctx,
+       is_admin?: Oli.Accounts.is_admin?(ctx.author),
        project: project,
        by_page_rows: nil,
        by_activity_rows: by_activity_rows,
@@ -89,15 +90,17 @@ defmodule OliWeb.Insights do
         Insights can help you improve your course by providing a statistical analysis of
         the skills covered by each question to find areas where students are struggling.
       </p>
-      <div class="d-flex align-items-center my-3">
-        <AsyncExporter.raw_analytics
-          ctx={@ctx}
-          latest_publication={@latest_publication}
-          analytics_export_status={@analytics_export_status}
-          analytics_export_url={@analytics_export_url}
-          analytics_export_timestamp={@analytics_export_timestamp}
-        />
-      </div>
+      <%= if @is_admin? do %>
+        <div class="d-flex align-items-center my-3">
+          <AsyncExporter.raw_analytics
+            ctx={@ctx}
+            latest_publication={@latest_publication}
+            analytics_export_status={@analytics_export_status}
+            analytics_export_url={@analytics_export_url}
+            analytics_export_timestamp={@analytics_export_timestamp}
+          />
+        </div>
+      <% end %>
     </div>
     <ul class="nav nav-pills">
       <li class="nav-item my-2 mr-2">


### PR DESCRIPTION
This PR attempts to alleviate pressure on the system's DB connection pools.  Our working theory is that long running publication updates tie up a database connection for 20 seconds, and given that the size of the concurrency for that queue is `10`, this means that when pushing out a "forced" update to dozens of sections (like for Chemistry), we have the system pinned to using a third of all DB connections for several minutes while that queue clears. This has downstream on end users who are vying for DB connection cycles now from a smaller pool. 

This PR does three minor things and one major thing.  The minor things are:
1. Exposes the Oban queue concurrency sizes to be driven from environment variables.  This will allow us to tweak these as needed with a simple restart. It dials down the default of a few key ones: `updates` down to `2`, datashop export and analytics exports each down to `1`.
2. Puts a check whether or not experiments are enabled **outside** of the `Experiments.LogWorker`.  This avoids scheduling all of these jobs when they just simply aren't necessary. 
3. Changes the "Raw Data Download" feature to be only accessible to admins

The major thing this PR does is to streamline the application of `:minor` and `:major` publications.  A common theme seen here was the use of library functions that pull much more data than is necessary.  The `DeliveryResolver.full_hierarchy` is one of these, as the update logic uses this in a few places to get the hierarchy of the course section.  That function, though, returns the full revisions which includes the `content` in JSONB form, even though none of the logic in update needs that content.  This happens again with calls to `published_resources_map`, which end up querying for ALL published resources for a publication, PRELOADING the revision (but still, again, not using the content). 

Work was done to clone the `full_hierarchy` and `published_resources_map` functions, then customize them to pair down the data that these queries return. 

Testing locally with the chemistry course shows a reduction in clock time for a major update processing from 2.3 seconds down to about 1 second.  Minor updates process in about 800ms.  



