### PR TITLE
MER-2912-practice-activity-pages-displayed-in-random-order-in-navigation

### DIFF
--- a/lib/oli/publishing/delivery_resolver.ex
+++ b/lib/oli/publishing/delivery_resolver.ex
@@ -408,7 +408,7 @@ defmodule Oli.Publishing.DeliveryResolver do
           rev.purpose == ^purpose and rev.deleted == false and
             rev.resource_type_id == ^page_id,
         select: rev,
-        order_by: [asc: :resource_id]
+        order_by: [asc: sr.numbering_index]
       )
     )
   end


### PR DESCRIPTION
[MER-2912](https://eliterate.atlassian.net/browse/MER-2912?filter=10069&jql=project%20%3D%20MER%20AND%20issuetype%20in%20(Bug%2C%20Story)%20AND%20status%20in%20(%22In%20Progress%22%2C%20PR%2C%20Ready%2C%20%22To%20Do%22)%20AND%20labels%20%3D%20wyeworks%20ORDER%20BY%20assignee%20ASC%2C%20status%20ASC%2C%20priority%20DESC%2C%20created%20DESC) This pr changes the ordering criteria of the practice activities by numbering index

[MER-2912]: https://eliterate.atlassian.net/browse/MER-2912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ