### PR TITLE
[NG23-53] Welcome page images fix for guest account

### DIFF
--- a/assets/tailwind.theme.js
+++ b/assets/tailwind.theme.js
@@ -288,5 +288,32 @@ module.exports = {
         'slide-in-right': 'slide-in-right 0.5s ease-out',
       },
     },
+    screens: {
+      // horizontal breakpoints
+      sm: '640px',
+      // => @media (min-width: 640px) { ... }
+      md: '768px',
+      // => @media (min-width: 768px) { ... }
+      lg: '1024px',
+      // => @media (min-width: 1024px) { ... }
+      xl: '1280px',
+      // => @media (min-width: 1280px) { ... }
+      '2xl': '1536px',
+      // => @media (min-width: 1536px) { ... }
+
+      // vertical breakpoints
+      vsm: { raw: '(min-height: 350px)' },
+      vmd: { raw: '(min-height: 500px)' },
+      vlg: { raw: '(min-height: 650px)' },
+      vxl: { raw: '(min-height: 800px)' },
+      v2xl: { raw: '(min-height: 950px)' },
+
+      // horizontal-vertical breakpoints (triggered when the horizontal or vertical conditions are met)
+      hvsm: { raw: '(min-width: 640px) and (min-height: 350px)' },
+      hvmd: { raw: '(min-width: 768px) and (min-height: 500px)' },
+      hvlg: { raw: '(min-width: 1024px) and (min-height: 650px)' },
+      hvxl: { raw: '(min-width: 1280px) and (min-height: 800px)' },
+      hv2xl: { raw: '(min-width: 1536px) and (min-height: 950px)' },
+    },
   },
 };

--- a/lib/oli_web/live/common/stepper/stepper.ex
+++ b/lib/oli_web/live/common/stepper/stepper.ex
@@ -37,19 +37,22 @@ defmodule OliWeb.Common.Stepper do
 
     ~H"""
     <div id={@id} class="flex md:flex-row flex-col-reverse h-full w-full">
-      <div class="bg-blue-700 dark:bg-black h-2/5 w-full md:h-full md:w-2/5" />
+      <div class="bg-blue-700 dark:bg-black w-full h-full md:w-2/5" />
       <div class="dark:bg-gray-900 h-3/5 w-full md:h-full md:w-3/5" />
-      <div class="flex md:flex-row flex-col-reverse absolute px-8 sm:px-16 lg:pl-24 lg:pr-16 xl:px-32 top-14 bottom-0 left-0 right-0 m-auto">
+      <div class="flex md:flex-row flex-col-reverse absolute px-4 sm:px-16 lg:pl-24 lg:pr-16 xl:px-32 top-14 bottom-0 left-0 right-0 m-auto">
         <div class="w-full md:w-1/3 my-auto z-20">
-          <div class="flex md:flex-col flex-row gap-[42px] md:-mr-[30px] scrollbar-hide overflow-x-auto md:overflow-x-hidden">
+          <div class="flex flex-col md:mt-auto gap-[42px] md:-mr-[30px] scrollbar-hide overflow-x-auto md:overflow-x-hidden">
             <%= for {step, index} <- @steps do %>
               <.step index={index + 1} step={step} active={index == @current_step} />
             <% end %>
           </div>
         </div>
         <div class={[
-          "bg-white dark:bg-[#0B0C11] w-full md:w-2/3 flex flex-col overflow-y-scroll shadow-xl",
-          if(@id == "course_creation_stepper", do: "my-10", else: "my-16 xl:my-32")
+          "bg-white dark:bg-[#0B0C11] w-full h-4/5 md:h-none md:w-2/3 flex flex-col overflow-y-scroll shadow-xl",
+          if(@id == "course_creation_stepper",
+            do: "my-10",
+            else: "mt-4 hvxs:my-8 hvmd:my-16 hvlg:my-20 hvxl:my-24"
+          )
         ]}>
           <div id="stepper_content" class="flex flex-col h-[calc(100%-64px)] w-full">
             <%= @selected_step.render_fn.(@data) %>
@@ -72,8 +75,8 @@ defmodule OliWeb.Common.Stepper do
                   }
                   class="torus-button secondary !py-[10px] !px-5 !rounded-[3px] !text-sm flex items-center justify-center  dark:!text-white dark:!bg-black dark:hover:!bg-gray-900"
                 >
-                  <i class="fa-solid fa-arrow-left mr-2"></i><%= @selected_step.previous_button_label ||
-                    "Previous step" %>
+                  <i class="fa-solid fa-arrow-left sm:mr-2"></i><span class="hidden sm:flex"><%= @selected_step.previous_button_label ||
+                    "Previous step" %></span>
                 </button>
               <% end %>
               <button
@@ -117,14 +120,19 @@ defmodule OliWeb.Common.Stepper do
 
   def step(%{index: _index, step: %Step{}, active: _active} = assigns) do
     ~H"""
-    <div class="flex gap-6 items-center justify-between shrink-0 md:w-auto">
+    <div class={[
+      "gap-2 md:gap-6 items-center justify-between shrink-0 md:w-auto",
+      if(!@active, do: "hidden md:flex", else: "flex")
+    ]}>
       <div class={"flex flex-col text-white #{if !@active, do: "opacity-50"}"}>
-        <h4 class="font-bold text-[20px] tracking-[0.02px] leading-5 mb-[9px]"><%= @step.title %></h4>
-        <p class="font-normal text-[16px] tracking-[0.02px] leading-[24px]">
+        <h4 class="font-bold text-md md:text-[20px] tracking-[0.02px] md:leading-5 mb-[9px]">
+          <%= @step.title %>
+        </h4>
+        <p class="font-normal text-sm md:text-[16px] tracking-[0.02px] md:leading-[24px]">
           <%= @step.description %>
         </p>
       </div>
-      <div class={"flex self-start shrink-0 items-center justify-center text-xl font-extrabold h-[60px] w-[60px] rounded-full shadow-sm #{if @active, do: "bg-primary text-white", else: "bg-white dark:bg-black border text-gray-400 border-gray-300 dark:border-gray-600"}"}>
+      <div class={"flex self-start shrink-0 items-center justify-center font-extrabold text-lg h-[30px] w-[30px] sm:text-xl sm:h-[60px] sm:w-[60px] rounded-full shadow-sm #{if @active, do: "bg-primary text-white", else: "bg-white dark:bg-black border text-gray-400 border-gray-300 dark:border-gray-600"}"}>
         <%= @index %>
       </div>
     </div>

--- a/lib/oli_web/live/delivery/student_onboarding/explorations.ex
+++ b/lib/oli_web/live/delivery/student_onboarding/explorations.ex
@@ -4,7 +4,7 @@ defmodule OliWeb.Delivery.StudentOnboarding.Explorations do
   def render(assigns) do
     ~H"""
     <div class="h-full">
-      <div class="flex pt-12 pb-6 px-[84px] gap-3">
+      <div class="flex py-6 px-[20px] hvsm:px-[70px] hvxl:px-[84px] gap-3">
         <div class="flex relative">
           <img
             src={~p"/images/assistant/dot_ai_icon.png"}
@@ -13,7 +13,7 @@ defmodule OliWeb.Delivery.StudentOnboarding.Explorations do
           />
           <div class="w-14 shrink-0 mr-5"></div>
           <div class="flex flex-col gap-3">
-            <h2 class="text-[40px] leading-[54px] tracking-[0.02px] dark:text-white">
+            <h2 class="text-[18xl] leading-[24px] hvsm:text-[30px] hvsm:leading-[40px] hvxl:text-[40px] hvxl:leading-[54px] tracking-[0.02px] dark:text-white">
               Exploration Activities
             </h2>
             <span class="text-[14px] leading-[20px] tracking-[0.02px] dark:text-white">
@@ -22,8 +22,11 @@ defmodule OliWeb.Delivery.StudentOnboarding.Explorations do
           </div>
         </div>
       </div>
-      <img class="aspect-video w-full h-[334px]" src="/images/exploration.gif" />
-      <p class="text-[14px] leading-[20px] tracking-[0.02px] dark:text-white px-[84px] py-9">
+      <img
+        class="aspect-video w-full hidden hvxl:block hvxl:h-[200px] hv2xl:h-[350px]"
+        src="/images/exploration.gif"
+      />
+      <p class="text-[14px] leading-[20px] tracking-[0.02px] dark:text-white px-[20px] hvsm:px-[70px] hvxl:px-[84px] pt-9 pb-2">
         You will have access to both simulations and digital versions of tools used in the real world to help you explore the topics brought up in the course from a real-world perspective.
       </p>
     </div>

--- a/lib/oli_web/live/delivery/student_onboarding/intro.ex
+++ b/lib/oli_web/live/delivery/student_onboarding/intro.ex
@@ -10,9 +10,12 @@ defmodule OliWeb.Delivery.StudentOnboarding.Intro do
 
   def render(assigns) do
     ~H"""
-    <img class="object-cover h-[386px] w-full" src={cover_image(@section)} />
-    <div class="flex flex-col gap-3 px-[84px] py-9 dark:text-white">
-      <h2 class="font-semibold text-[40px] leading-[54px] tracking-[0.02px]">
+    <img
+      class="object-cover hidden hvxl:block hvxl:h-[150px] hv2xl:h-[300px] w-full"
+      src={cover_image(@section)}
+    />
+    <div class="flex flex-col gap-3 px-[50px] hvsm:px-[70px] hvxl:px-[84px] py-9 dark:text-white">
+      <h2 class="font-semibold text-[18xl] leading-[24px] hvsm:text-[30px] hvsm:leading-[40px] hvxl:text-[40px] hvxl:leading-[54px] tracking-[0.02px]">
         Welcome to <%= @section.title %>!
       </h2>
       <div class="text-[14px] leading-5 tracking-[0.02px] dark:text-opacity-80">

--- a/lib/oli_web/live/delivery/student_onboarding/survey.ex
+++ b/lib/oli_web/live/delivery/student_onboarding/survey.ex
@@ -110,7 +110,7 @@ defmodule OliWeb.Delivery.StudentOnboarding.Survey do
           Something went wrong when loading the survey
         </div>
       <% else %>
-        <div class="flex pt-12 pb-6 px-[84px] gap-3">
+        <div class="flex py-6 px-[20px] hvsm:px-[70px] hvxl:px-[84px] gap-3">
           <div class="flex relative">
             <img
               src={~p"/images/assistant/dot_ai_icon.png"}
@@ -119,7 +119,7 @@ defmodule OliWeb.Delivery.StudentOnboarding.Survey do
             />
             <div class="w-14 shrink-0 mr-5" />
             <div class="flex flex-col gap-3">
-              <h2 class="text-[40px] leading-[54px] tracking-[0.02px] dark:text-white">
+              <h2 class="text-[18xl] leading-[24px] hvsm:text-[30px] hvsm:leading-[40px] hvxl:text-[40px] hvxl:leading-[54px] tracking-[0.02px] dark:text-white">
                 <%= @title %>
               </h2>
               <span class="text-[14px] leading-[20px] tracking-[0.02px] dark:text-white">
@@ -129,7 +129,7 @@ defmodule OliWeb.Delivery.StudentOnboarding.Survey do
           </div>
         </div>
         <%= if @loaded do %>
-          <div class="px-[84px] py-9 my-10 h-[334px]">
+          <div class="px-[20px] hvsm:px-[70px] hvxl:px-[84px] py-9 h-[334px]">
             <%= Phoenix.HTML.raw(@html) %>
           </div>
         <% else %>


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/NG23-53) to the ticket

I could not reproduce the appearance of the scrollbar in the white container (I tried in 4 different browsers with different combinations of screen sizes and resolutions).

So I worked on adapting the image size, the padding, and the margins to prioritize the text content of the white container, reducing the possibility of the scrollbar need. Some custom breakpoints in the horizontal and vertical directions were defined to achieve this.

This does not guarantee that the scrollbar will appear in some cases, for example, if the onboarding wizard has a survey step where the survey content is very long. But in those cases having a scrollbar makes sense.

Finally, I also worked on a mobile version adapting the background sizes and position, button sizes, and step text sizes.


https://github.com/Simon-Initiative/oli-torus/assets/74839302/cf1d6d3d-b7e3-4c4e-afc4-c00c283d1d14

