### PR TITLE
MER-2604-student-emails-never-exposed

### DIFF
--- a/lib/oli_web/live/delivery/student_dashboard/components/helpers.ex
+++ b/lib/oli_web/live/delivery/student_dashboard/components/helpers.ex
@@ -195,9 +195,15 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.Helpers do
     <div id="student_details_card" class="flex flex-col sm:flex-row items-center mx-10">
       <div class="flex shrink-0 mb-6 sm:mb-0 sm:mr-6">
         <%= if @student.picture do %>
-          <img src={@student.picture} class="rounded-full h-52 w-52" referrerPolicy="no-referrer" />
+          <div class="text-center">
+            <img src={@student.picture} class="rounded-full h-52 w-52" referrerPolicy="no-referrer" />
+            <p class="text-gray-500 mt-2"><%= @student.email %></p>
+          </div>
         <% else %>
-          <i class="fa-solid fa-circle-user text-[208px] text-gray-200"></i>
+          <div class="text-center">
+            <i class="fa-solid fa-circle-user text-[208px] text-gray-200"></i>
+            <p class="text-gray-500 mt-2"><%= @student.email %></p>
+          </div>
         <% end %>
       </div>
       <div class="flex flex-col divide-y divide-gray-100 dark:divide-gray-700 w-full bg-white dark:bg-neutral-800">


### PR DESCRIPTION
[MER-2604](https://eliterate.atlassian.net/browse/MER-2604) This pull request addresses the second point of the ticket; now, the student's email is exposed below the profile photo 

[MER-2604]: https://eliterate.atlassian.net/browse/MER-2604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ