### PR TITLE
[BUGFIX] [MER-2947] | Into the Cell Error: Failed to execute 'getGamepad()'

### DIFF
--- a/assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx
+++ b/assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx
@@ -1135,7 +1135,7 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
       title={title}
       src={frameSrc}
       scrolling={scrolling}
-      allow="accelerometer; magnetometer; gyroscope; fullscreen; autoplay; clipboard-write; encrypted-media; xr-spatial-tracking; gamepad;"
+      allow="accelerometer *; magnetometer; gyroscope; fullscreen; autoplay; clipboard-write; encrypted-media; xr-spatial-tracking; gamepad *;"
     />
   ) : null;
 };


### PR DESCRIPTION
This issue was coming due the changes requested for https://eliterate.atlassian.net/browse/MER-2735. The iFrame was applying the permission policy thus preventing the Unity SIM to load.