### PR TITLE
[BUG FIX] Restore ugprade functionality [MER-2949]

### DIFF
--- a/lib/oli/delivery/experiments.ex
+++ b/lib/oli/delivery/experiments.ex
@@ -134,7 +134,7 @@ defmodule Oli.Delivery.Experiments do
   def log(enrollment_id, correctness, slug) do
 
     # format right now DateTime.utc_now() as
-    # "2020-03-20T14:00:59"
+    # "2020-03-20 14:00:59"
     now = DateTime.utc_now()
     date = "#{now.year()}-#{now.month()}-#{now.day()}"
     time = "#{now.hour()}:#{now.minute()}:#{now.second()}"

--- a/lib/oli/delivery/experiments.ex
+++ b/lib/oli/delivery/experiments.ex
@@ -73,7 +73,7 @@ defmodule Oli.Delivery.Experiments do
   """
   def init(enrollment_id, project_slug) do
     body = %{
-      "id" => enrollment_id,
+      "id" => Integer.to_string(enrollment_id),
       "group" => %{
         "add-group1" => [project_slug]
       },
@@ -83,8 +83,10 @@ defmodule Oli.Delivery.Experiments do
     }
 
     case http().post(url("/api/init"), encode_body(body), headers()) do
-      {:ok, %{status_code: 200, body: result}} -> Poison.decode(result)
-      e -> e
+      {:ok, %{status_code: 200, body: result}} ->
+        Poison.decode(result)
+      e ->
+        e
     end
   end
 
@@ -94,7 +96,7 @@ defmodule Oli.Delivery.Experiments do
   def assign(enrollment_id) do
     body =
       encode_body(%{
-        "userId" => enrollment_id,
+        "userId" => Integer.to_string(enrollment_id),
         "context" => "add"
       })
 
@@ -110,7 +112,7 @@ defmodule Oli.Delivery.Experiments do
   def mark(enrollment_id, %{decision_point: decision_point, target: target, condition: condition}) do
     body =
       encode_body(%{
-        "userId" => enrollment_id,
+        "userId" => Integer.to_string(enrollment_id),
         "site" => decision_point,
         "target" => target,
         "condition" => condition,
@@ -129,16 +131,27 @@ defmodule Oli.Delivery.Experiments do
   @doc """
   Posts a metrics result to Upgrade.
   """
-  def log(enrollment_id, correctness) do
+  def log(enrollment_id, correctness, slug) do
+
+    # format right now DateTime.utc_now() as
+    # "2020-03-20T14:00:59"
+    now = DateTime.utc_now()
+    date = "#{now.year()}-#{now.month()}-#{now.day()}"
+    time = "#{now.hour()}:#{now.minute()}:#{now.second()}"
+    timestamp = "#{date} #{time}"
+
     body =
       encode_body(%{
-        "userId" => enrollment_id,
+        "userId" => Integer.to_string(enrollment_id),
+        "timestamp" => timestamp,
         "value" => [
           %{
-            "userId" => enrollment_id,
+            "timestamp" => timestamp,
+            "userId" => Integer.to_string(enrollment_id),
             "metrics" => %{
               "groupedMetrics" => [
                 %{
+                  "groupUniquifier" => slug <> "_" <> Integer.to_string(enrollment_id),
                   "groupClass" => "mastery",
                   "groupKey" => "activities",
                   "attributes" => %{
@@ -151,7 +164,7 @@ defmodule Oli.Delivery.Experiments do
         ]
       })
 
-    case http().post(url("/api/v1/log"), body, headers()) do
+    case http().post(url("/api/log"), body, headers()) do
       {:ok, %{status_code: 200, body: body}} ->
         Logger.info("Logged experiment for [#{enrollment_id}]")
         Poison.decode(body)


### PR DESCRIPTION
This PR restores the integration of Torus and Upgrade. 

The version of Upgrade that we deployed had changed aspects of their API.  Two things had to be updated:
1. The `userId` field changed data type from integer to string. 
2. The Log endpoint added required `timestamp` and `groupUniquifier` fields. 

Also, to get the Upgrade metrics to actually display, the endpoint for the log API had to changed from `/api/v1/log` to `/api/log`.  I have no idea why. 