### PR TITLE
[FEATURE][MER-2930] Allow authors to download from datashop

### DIFF
--- a/lib/oli_web/live/projects/overview_live.ex
+++ b/lib/oli_web/live/projects/overview_live.ex
@@ -313,7 +313,7 @@ defmodule OliWeb.Projects.OverviewLive do
           <span>Download this project and its contents.</span>
         </div>
 
-        <div :if={@is_admin} class="d-flex align-items-center">
+        <div class="d-flex align-items-center">
           <%= case @latest_publication do %>
             <% nil -> %>
               <.button_link disabled>Datashop Analytics</.button_link>

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -1291,7 +1291,7 @@ defmodule OliWeb.Router do
       :browser,
       :authoring_protected,
       :workspace,
-      :authorize_project,
+      :authorize_project
     ])
 
     scope "/:project_id/history" do

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -1292,14 +1292,14 @@ defmodule OliWeb.Router do
       :authoring_protected,
       :workspace,
       :authorize_project,
-      :admin
     ])
 
-    live("/:project_id/history/slug/:slug", RevisionHistory)
+    scope "/:project_id/history" do
+      pipe_through([:admin])
 
-    live("/:project_id/history/resource_id/:resource_id", RevisionHistory,
-      as: :history_by_resource_id
-    )
+      live("/slug/:slug", RevisionHistory)
+      live("/resource_id/:resource_id", RevisionHistory, as: :history_by_resource_id)
+    end
 
     live("/:project_id/datashop", Datashop.AnalyticsLive)
   end

--- a/test/oli_web/live/datashop/analytics_live_test.exs
+++ b/test/oli_web/live/datashop/analytics_live_test.exs
@@ -21,19 +21,37 @@ defmodule OliWeb.Datashop.AnalyticsLiveTest do
     end
   end
 
-  describe "user cannot access when is logged in as an author but is not a system admin" do
+  describe "user can access when is logged in as an author but is not a system admin" do
     setup [:author_conn, :create_project]
 
-    test "redirects to new session when accessing the datashop analytics view", %{
+    test "loads correctly", %{
       conn: conn,
       author: author,
       project: project
     } do
       make_project_author(project, author)
+      {:ok, _view, html} = live(conn, live_view_analytics_route(project.slug))
 
       assert conn
              |> get(live_view_analytics_route(project.slug))
-             |> response(403)
+             |> response(200)
+
+      assert html =~ "Datashop Analytics"
+      assert html =~ "Generate Datashop Export"
+    end
+  end
+
+  describe "user cannot access when is logged in as a student" do
+    setup [:user_conn, :create_project]
+
+    test "redirects to new session when accessing the analytics view as student", %{
+      conn: conn,
+      project: project
+    } do
+      assert conn
+             |> get(live_view_analytics_route(project.slug))
+             |> html_response(302) =~
+               "You are being <a href=\"/authoring/session/new?request_path=%2Fproject%2F#{project.slug}%2Fdatashop\">redirected</a>"
     end
   end
 


### PR DESCRIPTION
[MER-2930](https://eliterate.atlassian.net/browse/MER-2930)

This PR allows authors to access the `Datashop Analytics` view so that they can download the datashop of a project. 


https://github.com/Simon-Initiative/oli-torus/assets/16328384/2ece5516-6bbb-4ed0-b2d1-a432c8278d58



[MER-2930]: https://eliterate.atlassian.net/browse/MER-2930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ