### PR TITLE
[NG23-67] Display video thumbnail for Youtube links

### DIFF
--- a/assets/src/hooks/video_player.ts
+++ b/assets/src/hooks/video_player.ts
@@ -29,7 +29,7 @@ export const VideoPlayer = {
 
       The expression consists of two main parts:
       - The first part (youtu\.be\/|v\/|u\/\w\/|embed\/|watch\?v=|\&v=) captures the various URL structures preceding the video ID.
-      = The second part ([^#\&\?]*).*, which corresponds to match[2], captures the actual video ID.
+      - The second part ([^#\&\?]*).*, which corresponds to match[2], captures the actual video ID.
 
       YouTube video IDs typically have a length of exactly 11 characters. This standardization is a part of YouTube's design.
       The check match[2].length == 11 is employed to ensure that the extracted string is indeed a valid YouTube video ID.

--- a/lib/oli_web/live/common/utils.ex
+++ b/lib/oli_web/live/common/utils.ex
@@ -182,4 +182,47 @@ defmodule OliWeb.Common.Utils do
         {new_start_date, new_end_date, :start_date}
     end
   end
+
+  @doc """
+  Checks if a given URL is a YouTube video.
+
+  ## Examples
+
+      iex> is_youtube_video?("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+      true
+
+      iex> is_youtube_video?("https://youtu.be/dQw4w9WgXcQ")
+      true
+
+      iex> is_youtube_video?("https://www.example.com/video.mp4")
+      false
+  """
+  def is_youtube_video?(video_url),
+    do: String.contains?(video_url, "youtube.com") or String.contains?(video_url, "youtu.be")
+
+  @doc """
+  Converts a YouTube video URL to a YouTube preview image URL.
+
+  ## Examples
+
+      iex> convert_to_youtube_image_url("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+      "https://img.youtube.com/vi/dQw4w9WgXcQ/hqdefault.jpg"
+
+      iex> convert_to_youtube_image_url("https://youtu.be/dQw4w9WgXcQ")
+      "https://img.youtube.com/vi/dQw4w9WgXcQ/hqdefault.jpg"
+
+      iex> convert_to_youtube_image_url("https://www.example.com/video.mp4")
+      nil
+  """
+  def convert_to_youtube_image_url(video_url) do
+    regex = ~r/^.*(youtu\.be\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=)([^#&?]*).*/
+
+    case Regex.run(regex, video_url) do
+      [_, _, video_id] when byte_size(video_id) == 11 ->
+        "https://img.youtube.com/vi/#{video_id}/hqdefault.jpg"
+
+      _ ->
+        nil
+    end
+  end
 end

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -7,9 +7,11 @@ defmodule OliWeb.Delivery.Student.LearnLive do
   alias Phoenix.LiveView.JS
   alias Oli.Authoring.Course.Project
   alias Oli.Delivery.Sections.SectionCache
+  alias OliWeb.Common.Utils, as: WebUtils
 
   import Ecto.Query, warn: false, only: [from: 2]
 
+  @default_image "/images/course_default.jpg"
   # this is an optimization to reduce the memory footprint of the liveview process
   @required_keys_per_assign %{
     section:
@@ -944,8 +946,8 @@ defmodule OliWeb.Delivery.Student.LearnLive do
       </div>
       <div class="rounded-xl absolute -top-[0.7px] -left-[0.7px] h-[163px] w-[289.5px] cursor-pointer bg-[linear-gradient(180deg,#D9D9D9_0%,rgba(217,217,217,0.00)_100%)] dark:bg-[linear-gradient(180deg,#223_0%,rgba(34,34,51,0.72)_52.6%,rgba(34,34,51,0.00)_100%)]" />
       <div
-        class="flex flex-col items-center rounded-xl h-[162px] w-[288px] bg-gray-200/50 shrink-0 px-5 pt-[15px]"
-        style={"background-image: url('#{if(@bg_image_url in ["", nil], do: "/images/course_default.jpg", else: @bg_image_url)}');"}
+        class="flex flex-col items-center rounded-xl h-[162px] w-[288px] bg-gray-200/50 shrink-0 px-5 pt-[15px] bg-cover bg-center"
+        style={"background-image: url('#{build_image_url(@bg_image_url, @video_url)}');"}
       >
         <h5 class="text-[13px] leading-[18px] font-bold opacity-60 text-gray-500 dark:text-white dark:text-opacity-50 self-start">
           <%= @title %>
@@ -988,6 +990,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
   attr :selected, :boolean, default: false
   attr :bg_image_url, :string, doc: "the background image url for the card"
   attr :student_progress_per_resource_id, :map
+  attr :default_image, :string, default: @default_image
 
   def module_card(assigns) do
     ~H"""
@@ -1039,12 +1042,12 @@ defmodule OliWeb.Delivery.Student.LearnLive do
       <div class="h-[170px] w-[288px]">
         <div
           class={[
-            "flex flex-col gap-[5px] cursor-pointer rounded-xl h-[162px] w-[288px] shrink-0 mb-1 px-5 pt-[15px] bg-gray-200 z-10",
+            "flex flex-col gap-[5px] cursor-pointer rounded-xl h-[162px] w-[288px] shrink-0 mb-1 px-5 pt-[15px] bg-gray-200 z-10 bg-cover bg-center",
             if(@selected,
               do: "bg-gray-400 outline outline-2 outline-gray-800 dark:outline-white"
             )
           ]}
-          style={"background-image: url('#{if(@bg_image_url in ["", nil], do: "/images/course_default.jpg", else: @bg_image_url)}');"}
+          style={"background-image: url('#{if(@bg_image_url in ["", nil], do: @default_image, else: @bg_image_url)}');"}
         >
           <span class="text-[12px] leading-[16px] font-bold opacity-60 text-gray-500 dark:text-white dark:text-opacity-50">
             <%= "#{@unit_numbering_index}.#{@module_index}" %>
@@ -1434,5 +1437,18 @@ defmodule OliWeb.Delivery.Student.LearnLive do
         if(item["is_root?"], do: item, else: root)
       }
     end)
+  end
+
+  defp build_image_url(bg_image_url, video_url) when video_url not in ["", nil],
+    do: maybe_convert_to_image(video_url) || build_image_url(bg_image_url, nil)
+
+  defp build_image_url(bg_image_url, _) when bg_image_url not in ["", nil], do: bg_image_url
+
+  defp build_image_url(_, _), do: @default_image
+
+  defp maybe_convert_to_image(video_url) do
+    if WebUtils.is_youtube_video?(video_url) do
+      WebUtils.convert_to_youtube_image_url(video_url)
+    end
   end
 end


### PR DESCRIPTION
[NG23-67](https://eliterate.atlassian.net/browse/NG23-67)

When a YouTube intro video is set for a Course Unit, use the video preview image as the poster image of the Unit.
It also fixes a small bug where background images on cards were not fitting into the specified area.

https://github.com/Simon-Initiative/oli-torus/assets/26532202/639a2043-233b-47e2-a0ca-bdcc14a9a076



[NG23-67]: https://eliterate.atlassian.net/browse/NG23-67?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ