### PR TITLE
[BUG FIX] Fix 1 for part attempt bloat: stop creating unnecessary part attempt records [MER-2950]

### DIFF
--- a/lib/oli/delivery/experiments.ex
+++ b/lib/oli/delivery/experiments.ex
@@ -132,7 +132,7 @@ defmodule Oli.Delivery.Experiments do
   @doc """
   Posts a metrics result to Upgrade.
   """
-  def log(enrollment_id, correctness, slug) do
+  def log(enrollment_id, correctness, _slug) do
     # format right now DateTime.utc_now() as
     # "2020-03-20 14:00:59"
     now = DateTime.utc_now()
@@ -151,7 +151,7 @@ defmodule Oli.Delivery.Experiments do
             "metrics" => %{
               "groupedMetrics" => [
                 %{
-                  "groupUniquifier" => slug <> "_" <> Integer.to_string(enrollment_id),
+                  "groupUniquifier" => timestamp,
                   "groupClass" => "mastery",
                   "groupKey" => "activities",
                   "attributes" => %{

--- a/lib/oli/publishing.ex
+++ b/lib/oli/publishing.ex
@@ -1017,7 +1017,10 @@ defmodule Oli.Publishing do
   def insert_revision_part_records(publication_id) do
     query = """
       INSERT INTO revision_parts(part_id, grading_approach, revision_id)
-      SELECT DISTINCT t.parts->>'id' as part_id, t.parts->>'gradingApproach' as grading_approach, t.revision_id as revision_id FROM (
+      SELECT DISTINCT
+         t.parts->>'id' as part_id,
+         COALESCE(t.parts->>'gradingApproach', 'automatic') as grading_approach,
+         t.revision_id as revision_id FROM (
         SELECT jsonb_path_query(r.content, '$."authoring"."parts"[*]') as parts,
           r.id as revision_id
         FROM published_resources pr

--- a/priv/repo/migrations/20240125204755_fix_revision_parts.exs
+++ b/priv/repo/migrations/20240125204755_fix_revision_parts.exs
@@ -25,6 +25,10 @@ defmodule Oli.Repo.Migrations.FixRevisionParts do
     ALTER TABLE temp_revision_parts RENAME TO revision_parts;
     """
 
+    execute """
+    UPDATE revision_parts SET grading_approach = 'automatic' WHERE grading_approach IS NULL;
+    """
+
     flush()
 
     create unique_index(:revision_parts, [:revision_id, :part_id, :grading_approach])

--- a/priv/repo/migrations/20240125204755_fix_revision_parts.exs
+++ b/priv/repo/migrations/20240125204755_fix_revision_parts.exs
@@ -1,0 +1,34 @@
+defmodule Oli.Repo.Migrations.FixRevisionParts do
+  use Ecto.Migration
+
+  def change do
+
+    execute """
+    CREATE TABLE temp_revision_parts AS
+    SELECT DISTINCT ON (revision_id, grading_approach, part_id) *
+    FROM revision_parts;
+    """
+
+    execute """
+    ALTER TABLE revision_parts RENAME TO backup_revision_parts;
+    """
+
+    execute """
+    DROP INDEX revision_parts_revision_id_index;
+    """
+
+    execute """
+    DROP INDEX revision_parts_revision_id_part_id_grading_approach_index;
+    """
+
+    execute """
+    ALTER TABLE temp_revision_parts RENAME TO revision_parts;
+    """
+
+    flush()
+
+    create unique_index(:revision_parts, [:revision_id, :part_id, :grading_approach])
+    create index(:revision_parts, [:revision_id])
+  end
+
+end


### PR DESCRIPTION
This PR is part 1 of the complete fix for the dreaded "part attempt bloat" publishing problem.   Part 2 likely will target 26.3.

What this PR does:
1. Adds a migration which recreates the `revision_parts` table, but by excluding duplicate values.  Tested locally by adding a bunch of duplicate values, then ran the migration and the new `revision_parts` table has deduped them.
2. Changes the `INSERT` statement that upserts `revision_parts` records to use "automatic" in place of `NULL` values. 

With those two fixes above, all future part attempts created during page attempt creation will be done with the correct number of part attempts. 

After getting some feedback from the Upgrade team, I snuck in one minor change to the value of `groupUniqueifier` which is supposed to be a timestamp.  I tested this against our Upgrade and it continues to work correctly. 
