### PR TITLE
[NG23-65] ordering of exploration pages is not correct

### DIFF
--- a/lib/oli/delivery.ex
+++ b/lib/oli/delivery.ex
@@ -161,7 +161,6 @@ defmodule Oli.Delivery do
       enroll(user.id, section.id, lti_params)
 
       {:ok, updated_section} = maybe_update_section_contains_explorations(section)
-      {:ok, _} = Sections.update_page_to_container_map(section)
 
       updated_section
     end)

--- a/lib/oli/delivery.ex
+++ b/lib/oli/delivery.ex
@@ -161,7 +161,7 @@ defmodule Oli.Delivery do
       enroll(user.id, section.id, lti_params)
 
       {:ok, updated_section} = maybe_update_section_contains_explorations(section)
-      {:ok, _} = Sections.update_resource_to_container_map(section)
+      {:ok, _} = Sections.update_page_to_container_map(section)
 
       updated_section
     end)

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -1419,7 +1419,7 @@ defmodule Oli.Delivery.Sections do
 
     container_ids = Enum.map(all_containers, fn c -> c.resource_id end)
 
-    # get all explorations in the section and group them by their container title
+    # build a map of all pages to their first hierarchical container resource id
     all_pages
     |> Enum.reduce(%{}, fn page, acc ->
       {container_id, _seen} =
@@ -1462,8 +1462,8 @@ defmodule Oli.Delivery.Sections do
          seen
        ) do
     if MapSet.member?(seen, resource_id) do
-      # we've already seen this page, so we've reached a cycle in the recursion and it is not linked
-      # from any page in the hierarchy
+      # we've already seen this page, so we've reached a cycle in the recursion so we should
+      # treat it as not linked from any page in this part of the hierarchy
       {nil, seen}
     else
       if MapSet.member?(container_ids, resource_id) do
@@ -1647,7 +1647,7 @@ defmodule Oli.Delivery.Sections do
     end
 
     ordered_containers =
-      SectionCache.get_or_compute(section_slug, :ordered_containers, fn ->
+      SectionCache.get_or_compute(section_slug, :ordered_container_labels, fn ->
         fetch_ordered_containers(section_slug)
       end)
 
@@ -4094,6 +4094,7 @@ defmodule Oli.Delivery.Sections do
          customizations
        ) do
     case numbering_level do
+      0 -> "Curriculum"
       1 -> Map.get(customizations, :unit)
       2 -> Map.get(customizations, :module)
       _ -> Map.get(customizations, :section)

--- a/lib/oli/delivery/sections/section.ex
+++ b/lib/oli/delivery/sections/section.ex
@@ -63,7 +63,6 @@ defmodule Oli.Delivery.Sections.Section do
 
     field(:resource_gating_index, :map, default: %{})
     field(:previous_next_index, :map, default: nil)
-    field(:resource_to_container_map, :map, default: nil)
     field(:display_curriculum_item_numbering, :boolean, default: true)
     field(:contains_discussions, :boolean, default: false)
     field(:contains_explorations, :boolean, default: false)
@@ -180,7 +179,6 @@ defmodule Oli.Delivery.Sections.Section do
       :nrps_context_memberships_url,
       :resource_gating_index,
       :previous_next_index,
-      :resource_to_container_map,
       :lti_1p3_deployment_id,
       :institution_id,
       :base_project_id,

--- a/lib/oli/delivery/sections/section_cache.ex
+++ b/lib/oli/delivery/sections/section_cache.ex
@@ -17,6 +17,7 @@ defmodule Oli.Delivery.Sections.SectionCache do
 
   @cache_keys [
     :ordered_container_labels,
+    :page_to_container_map,
     :full_hierarchy
   ]
 

--- a/lib/oli/delivery/sections/section_cache.ex
+++ b/lib/oli/delivery/sections/section_cache.ex
@@ -52,7 +52,7 @@ defmodule Oli.Delivery.Sections.SectionCache do
         "computed_value"
 
   """
-  def get_or_compute(section_slug, key, fun) do
+  def get_or_compute(section_slug, key, fun) when key in @cache_keys do
     cache_id = cache_id(section_slug, key)
 
     case get(cache_id) do

--- a/lib/oli/publishing/delivery_resolver.ex
+++ b/lib/oli/publishing/delivery_resolver.ex
@@ -279,7 +279,6 @@ defmodule Oli.Publishing.DeliveryResolver do
   end
 
   @impl Resolver
-  @spec full_hierarchy(String.t()) :: %HierarchyNode{}
   def full_hierarchy(section_slug) do
     {hierarchy_nodes, root_hierarchy_node} = hierarchy_nodes_by_sr_id(section_slug)
 

--- a/lib/oli/utils/seeder/project.ex
+++ b/lib/oli/utils/seeder/project.ex
@@ -172,8 +172,213 @@ defmodule Oli.Utils.Seeder.Project do
     |> tag(:scored_page2_tag, scored_page2_tag)
   end
 
+  def create_large_sample_project(seeds, author) do
+    [author] = unpack(seeds, [author])
+
+    seeds
+    |> Seeder.Project.create_project(
+      author,
+      %{},
+      project_tag: :project,
+      publication_tag: :publication,
+      curriculum_revision_tag: :curriculum
+    )
+    |> Seeder.Project.create_container(
+      author,
+      ref(:project),
+      ref(:curriculum),
+      %{
+        title: "Unit 1"
+      },
+      revision_tag: :unit1,
+      container_revision_tag: :curriculum
+    )
+    |> Seeder.Project.create_page(
+      author,
+      ref(:project),
+      ref(:unit1),
+      %{
+        title: "Course Introduction Page 1",
+        graded: false
+      },
+      revision_tag: :unit1_page1,
+      container_revision_tag: :unit1
+    )
+    |> Seeder.Project.create_container(
+      ref(:author),
+      ref(:project),
+      ref(:unit1),
+      %{
+        title: "Unit 1 Module 1"
+      },
+      revision_tag: :unit1_module1,
+      container_revision_tag: :unit1
+    )
+    |> Seeder.Project.create_page(
+      author,
+      ref(:project),
+      ref(:unit1_module1),
+      %{
+        title: "Page 2",
+        graded: false
+      },
+      revision_tag: :unit1_module1_page2,
+      container_revision_tag: :unit1_module1
+    )
+    |> Seeder.Project.create_page(
+      author,
+      ref(:project),
+      ref(:unit1_module1),
+      %{
+        title: "Page 3",
+        graded: false
+      },
+      revision_tag: :unit1_module1_page2,
+      container_revision_tag: :unit1_module1
+    )
+    |> Seeder.Project.create_container(
+      ref(:author),
+      ref(:project),
+      ref(:unit1_module1),
+      %{
+        title: "Unit 1 Module 1 Section 1"
+      },
+      revision_tag: :unit1_module1_section1,
+      container_revision_tag: :unit1_module1
+    )
+    |> Seeder.Project.create_page(
+      author,
+      ref(:project),
+      ref(:unit1_module1_section1),
+      %{
+        title: "Page 4",
+        graded: false
+      },
+      revision_tag: :unit1_module1_page4,
+      container_revision_tag: :unit1_module1_section1
+    )
+    |> Seeder.Project.create_page(
+      author,
+      ref(:project),
+      ref(:unit1_module1_section1),
+      %{
+        title: "Page 5",
+        graded: false
+      },
+      revision_tag: :unit1_module1_section1_page5,
+      container_revision_tag: :unit1_module1_section1
+    )
+    |> Seeder.Project.create_page(
+      ref(:author),
+      ref(:project),
+      ref(:unit1_module1),
+      %{
+        title: "Unit 1 Module 1 Exploration Page 6",
+        purpose: :application
+      },
+      revision_tag: :unit1_module1_exploration_page6,
+      container_revision_tag: :unit1_module1
+    )
+    |> Seeder.Project.create_page(
+      author,
+      ref(:project),
+      ref(:unit1_module1),
+      %{
+        title: "Unit 1 Module 1 Scored Page 7",
+        graded: true
+      },
+      revision_tag: :unit1_module1_scored_page7,
+      container_revision_tag: :unit1_module1
+    )
+    |> Seeder.Project.create_container(
+      ref(:author),
+      ref(:project),
+      ref(:unit1),
+      %{
+        title: "Unit 1 Module 2"
+      },
+      revision_tag: :unit1_module2,
+      container_revision_tag: :unit1
+    )
+    |> Seeder.Project.create_page(
+      author,
+      ref(:project),
+      ref(:unit1_module2),
+      %{
+        title: "Page 8",
+        graded: false
+      },
+      revision_tag: :unit1_module2_page8,
+      container_revision_tag: :unit1_module2
+    )
+    |> Seeder.Project.create_page(
+      ref(:author),
+      ref(:project),
+      ref(:unit1),
+      %{
+        title: "Unit 1 Exploration Page 9",
+        purpose: :application
+      },
+      revision_tag: :unit1_exploration_page9,
+      container_revision_tag: :unit1
+    )
+    |> Seeder.Project.create_page(
+      author,
+      ref(:project),
+      ref(:unit1),
+      %{
+        title: "Unit 1 Scored Page 10",
+        graded: true
+      },
+      revision_tag: :unit1_scored_page10,
+      container_revision_tag: :unit1
+    )
+    |> Seeder.Project.create_container(
+      author,
+      ref(:project),
+      ref(:curriculum),
+      %{
+        title: "Unit 2"
+      },
+      revision_tag: :unit2,
+      container_revision_tag: :curriculum
+    )
+    |> Seeder.Project.create_page(
+      author,
+      ref(:project),
+      ref(:unit2),
+      %{
+        title: "Page 11",
+        graded: false
+      },
+      revision_tag: :unit2_page11,
+      container_revision_tag: :unit2
+    )
+    |> Seeder.Project.create_container(
+      ref(:author),
+      ref(:project),
+      ref(:unit2),
+      %{
+        title: "Unit 2 Module 3"
+      },
+      revision_tag: :unit2_module3,
+      container_revision_tag: :unit2
+    )
+    |> Seeder.Project.create_page(
+      author,
+      ref(:project),
+      ref(:unit2_module3),
+      %{
+        title: "Page 12",
+        graded: false
+      },
+      revision_tag: :unit2_module3_page12,
+      container_revision_tag: :unit2_module3
+    )
+  end
+
   @doc """
-  Creates a sample project
+  Creates a product from a project
   """
   def create_product(seeds, title, project, tags \\ []) do
     [project] = unpack(seeds, [project])

--- a/lib/oli/utils/seeder/project.ex
+++ b/lib/oli/utils/seeder/project.ex
@@ -254,7 +254,7 @@ defmodule Oli.Utils.Seeder.Project do
         title: "Page 4",
         graded: false
       },
-      revision_tag: :unit1_module1_page4,
+      revision_tag: :unit1_module1_section_1_page4,
       container_revision_tag: :unit1_module1_section1
     )
     |> Seeder.Project.create_page(
@@ -374,6 +374,28 @@ defmodule Oli.Utils.Seeder.Project do
       },
       revision_tag: :unit2_module3_page12,
       container_revision_tag: :unit2_module3
+    )
+    |> Seeder.Project.create_page(
+      ref(:author),
+      ref(:project),
+      ref(:unit2),
+      %{
+        title: "Unit 2 Exploration Page 13",
+        purpose: :application
+      },
+      revision_tag: :unit2_exploration_page13,
+      container_revision_tag: :unit2
+    )
+    |> Seeder.Project.create_page(
+      author,
+      ref(:project),
+      ref(:unit2),
+      %{
+        title: "Final Exam Page 14",
+        graded: false
+      },
+      revision_tag: :unit2_scored_page14,
+      container_revision_tag: :unit2
     )
   end
 

--- a/lib/oli/utils/seeder/utils.ex
+++ b/lib/oli/utils/seeder/utils.ex
@@ -51,7 +51,7 @@ defmodule Oli.Utils.Seeder.Utils do
     case(Map.get(seeds, tag)) do
       nil ->
         throw(
-          "Failed to load #{to_string(tag)} from seeds. Please make sure the tag is correct and the value has previously been created."
+          "Failed to load :#{to_string(tag)} from seeds. Please make sure the tag is correct and the value has previously been created."
         )
 
       value ->
@@ -66,7 +66,7 @@ defmodule Oli.Utils.Seeder.Utils do
         case(Map.get(seeds, tag)) do
           nil ->
             throw(
-              "Failed to load #{to_string(tag)} from seeds. Please make sure the tag is correct and the value has previously been created."
+              "Failed to load :#{to_string(tag)} from seeds. Please make sure the tag is correct and the value has previously been created."
             )
 
           value ->

--- a/lib/oli_web/live/delivery/student/discussions_live.ex
+++ b/lib/oli_web/live/delivery/student/discussions_live.ex
@@ -28,7 +28,7 @@ defmodule OliWeb.Delivery.Student.DiscussionsLive do
       Sections.get_ordered_container_labels(socket.assigns.section.slug)
       |> Enum.into(%{})
 
-    resource_to_container_map = Sections.get_resource_to_container_map(socket.assigns.section)
+    resource_to_container_map = Sections.get_page_to_container_map(socket.assigns.section)
 
     {posts, more_posts_exist?} =
       get_posts(

--- a/lib/oli_web/live/delivery/student/discussions_live.ex
+++ b/lib/oli_web/live/delivery/student/discussions_live.ex
@@ -1025,12 +1025,20 @@ defmodule OliWeb.Delivery.Student.DiscussionsLive do
               "Page #{post.resource_numbering_index}"
 
             container_resource_id ->
-              container_with_numbering_index =
-                Map.get(ordered_containers_map, container_resource_id)
-                |> String.split(":")
-                |> hd()
+              case Map.get(ordered_containers_map, container_resource_id) do
+                nil ->
+                  # if the container is not in the ordered_containers_map, it means it is a
+                  # container in the curriculum root level
+                  "Page #{post.resource_numbering_index}"
 
-              "#{container_with_numbering_index}: Page #{post.resource_numbering_index}"
+                container_with_numbering_index ->
+                  container_with_numbering_index =
+                    container_with_numbering_index
+                    |> String.split(":")
+                    |> hd()
+
+                  "#{container_with_numbering_index}: Page #{post.resource_numbering_index}"
+              end
           end
 
         post

--- a/lib/oli_web/live/delivery/student/discussions_live.ex
+++ b/lib/oli_web/live/delivery/student/discussions_live.ex
@@ -28,7 +28,7 @@ defmodule OliWeb.Delivery.Student.DiscussionsLive do
       Sections.get_ordered_container_labels(socket.assigns.section.slug)
       |> Enum.into(%{})
 
-    resource_to_container_map = Sections.get_page_to_container_map(socket.assigns.section)
+    resource_to_container_map = Sections.get_page_to_container_map(socket.assigns.section.slug)
 
     {posts, more_posts_exist?} =
       get_posts(

--- a/priv/repo/migrations/20240125210747_remove_resource_to_container_map.exs
+++ b/priv/repo/migrations/20240125210747_remove_resource_to_container_map.exs
@@ -1,0 +1,15 @@
+defmodule Oli.Repo.Migrations.RemoveResourceToContainerMap do
+  use Ecto.Migration
+
+  def up do
+    alter table(:sections) do
+      remove :resource_to_container_map, :map
+    end
+  end
+
+  def down do
+    alter table(:sections) do
+      add :resource_to_container_map, :map
+    end
+  end
+end

--- a/test/oli/delivery/sections_test.exs
+++ b/test/oli/delivery/sections_test.exs
@@ -579,6 +579,55 @@ defmodule Oli.Delivery.SectionsTest do
     end
   end
 
+  describe "get_ordered_container_labels/1" do
+    setup(_) do
+      %{}
+      |> Seeder.Project.create_author(author_tag: :author)
+      |> Seeder.Project.create_large_sample_project(ref(:author))
+      |> Seeder.Project.ensure_published(ref(:publication))
+      |> Seeder.Section.create_section(
+        ref(:project),
+        ref(:publication),
+        nil,
+        %{},
+        section_tag: :section
+      )
+    end
+
+    test "returns the correct ordered container labels for a section", %{
+      section: section,
+      curriculum: curriculum,
+      unit1: unit1,
+      unit1_module1: unit1_module1,
+      unit1_module1_section1: unit1_module1_section1,
+      unit1_module2: unit1_module2,
+      unit2: unit2,
+      unit2_module3: unit2_module3
+    } do
+      ordered_labels = Sections.get_ordered_container_labels(section.slug)
+
+      assert Enum.count(ordered_labels) == 7
+
+      assert Enum.at(ordered_labels, 0) == {curriculum.resource_id, "Curriculum 1: Curriculum"}
+
+      assert Enum.at(ordered_labels, 1) == {unit1.resource_id, "Unit 1: Unit 1"}
+
+      assert Enum.at(ordered_labels, 2) ==
+               {unit1_module1.resource_id, "Module 1: Unit 1 Module 1"}
+
+      assert Enum.at(ordered_labels, 3) ==
+               {unit1_module1_section1.resource_id, "Section 1: Unit 1 Module 1 Section 1"}
+
+      assert Enum.at(ordered_labels, 4) ==
+               {unit1_module2.resource_id, "Module 2: Unit 1 Module 2"}
+
+      assert Enum.at(ordered_labels, 6) == {unit2.resource_id, "Unit 2: Unit 2"}
+
+      assert Enum.at(ordered_labels, 5) ==
+               {unit2_module3.resource_id, "Module 3: Unit 2 Module 3"}
+    end
+  end
+
   describe "get_ordered_schedule/1" do
     setup do
       %{}

--- a/test/oli/delivery/sections_test.exs
+++ b/test/oli/delivery/sections_test.exs
@@ -9,6 +9,7 @@ defmodule Oli.Delivery.SectionsTest do
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.PostProcessing
   alias Oli.Delivery.Sections.SectionResource
+  alias Oli.Publishing.DeliveryResolver
 
   describe "maybe_update_contains_discusssions/1" do
     alias Oli.Resources.ResourceType
@@ -351,35 +352,31 @@ defmodule Oli.Delivery.SectionsTest do
     setup(_) do
       %{}
       |> Seeder.Project.create_author(author_tag: :author)
-      |> Seeder.Project.create_sample_project(
+      |> Seeder.Project.create_large_sample_project(ref(:author))
+      |> Seeder.Project.create_page(
         ref(:author),
-        project_tag: :proj,
-        publication_tag: :pub,
-        curriculum_revision_tag: :curriculum,
-        unit1_tag: :unit1,
-        unscored_page1_tag: :unscored_page1,
-        unscored_page1_activity_tag: :unscored_page1_activity,
-        scored_page2_tag: :scored_page2,
-        scored_page2_activity_tag: :scored_page2_activity
+        ref(:project),
+        nil,
+        %{
+          title: "Non-Hierarchical Page 15",
+          graded: false
+        },
+        revision_tag: :non_hierarchical_page15
       )
       |> Seeder.Project.create_page(
         ref(:author),
-        ref(:proj),
+        ref(:project),
         nil,
-        %{},
-        revision_tag: :non_hierarchical_page3
-      )
-      |> Seeder.Project.create_page(
-        ref(:author),
-        ref(:proj),
-        nil,
-        %{},
-        revision_tag: :non_hierarchical_page5
+        %{
+          title: "Non-Hierarchical Exploration Page 16",
+          purpose: :application
+        },
+        revision_tag: :non_hierarchical_page16
       )
       |> Seeder.Project.edit_page(
-        ref(:proj),
-        ref(:scored_page2),
-        refs([:non_hierarchical_page3], fn [non_hierarchical_page3] ->
+        ref(:project),
+        ref(:unit1_module1_page2),
+        refs([:non_hierarchical_page15], fn [non_hierarchical_page15] ->
           %{
             content: %{
               "model" => [
@@ -388,7 +385,7 @@ defmodule Oli.Delivery.SectionsTest do
                   "children" => [
                     %{
                       "type" => "page_link",
-                      "idref" => non_hierarchical_page3.resource_id,
+                      "idref" => non_hierarchical_page15.resource_id,
                       "purpose" => "none",
                       "children" => [%{"text" => "Link to detached page"}]
                     }
@@ -398,12 +395,12 @@ defmodule Oli.Delivery.SectionsTest do
             }
           }
         end),
-        revision_tag: :scored_page2
+        revision_tag: :unit1_module1_page2
       )
       |> Seeder.Project.edit_page(
-        ref(:proj),
-        ref(:non_hierarchical_page3),
-        refs([:non_hierarchical_page5], fn [non_hierarchical_page5] ->
+        ref(:project),
+        ref(:unit1_module1_section1_page5),
+        refs([:non_hierarchical_page16], fn [non_hierarchical_page16] ->
           %{
             content: %{
               "model" => [
@@ -412,7 +409,7 @@ defmodule Oli.Delivery.SectionsTest do
                   "children" => [
                     %{
                       "type" => "page_link",
-                      "idref" => non_hierarchical_page5.resource_id,
+                      "idref" => non_hierarchical_page16.resource_id,
                       "purpose" => "none",
                       "children" => [%{"text" => "Link to detached page"}]
                     }
@@ -422,12 +419,12 @@ defmodule Oli.Delivery.SectionsTest do
             }
           }
         end),
-        revision_tag: :non_hierarchical_page3
+        revision_tag: :unit1_module1_section1_page5
       )
-      |> Seeder.Project.ensure_published(ref(:pub))
+      |> Seeder.Project.ensure_published(ref(:publication))
       |> Seeder.Section.create_section(
-        ref(:proj),
-        ref(:pub),
+        ref(:project),
+        ref(:publication),
         nil,
         %{},
         section_tag: :section
@@ -435,24 +432,132 @@ defmodule Oli.Delivery.SectionsTest do
     end
 
     test "returns a map with linked page resource ids", %{
-      pub: pub,
+      publication: publication,
       curriculum: curriculum,
       unit1: unit1,
-      unscored_page1: unscored_page1,
-      scored_page2: scored_page2,
-      non_hierarchical_page3: non_hierarchical_page3,
-      non_hierarchical_page5: non_hierarchical_page5
+      unit1_page1: unit1_page1,
+      unit1_module1: unit1_module1,
+      unit1_module1_page2: unit1_module1_page2,
+      unit1_module1_section1: unit1_module1_section1,
+      unit1_module1_section_1_page4: unit1_module1_section_1_page4,
+      unit1_module1_section1_page5: unit1_module1_section1_page5,
+      unit1_module1_exploration_page6: unit1_module1_exploration_page6,
+      unit1_module1_scored_page7: unit1_module1_scored_page7,
+      unit1_module2: unit1_module2,
+      unit1_module2_page8: unit1_module2_page8,
+      unit1_exploration_page9: unit1_exploration_page9,
+      unit1_scored_page10: unit1_scored_page10,
+      unit2: unit2,
+      unit2_page11: unit2_page11,
+      unit2_module3: unit2_module3,
+      unit2_module3_page12: unit2_module3_page12,
+      unit2_exploration_page13: unit2_exploration_page13,
+      unit2_scored_page14: unit2_scored_page14,
+      non_hierarchical_page15: non_hierarchical_page15,
+      non_hierarchical_page16: non_hierarchical_page16
     } do
-      page_link_map = Sections.build_resource_link_map([pub.id])
+      page_link_map = Sections.build_resource_link_map([publication.id])
 
       assert page_link_map[unit1.resource_id] == [curriculum.resource_id]
-      assert page_link_map[unscored_page1.resource_id] == [unit1.resource_id]
-      assert page_link_map[scored_page2.resource_id] == [unit1.resource_id]
-      assert page_link_map[non_hierarchical_page3.resource_id] == [scored_page2.resource_id]
+      assert page_link_map[unit1_page1.resource_id] == [unit1.resource_id]
+      assert page_link_map[unit1_module1.resource_id] == [unit1.resource_id]
+      assert page_link_map[unit1_module1_page2.resource_id] == [unit1_module1.resource_id]
+      assert page_link_map[unit1_module1_section1.resource_id] == [unit1_module1.resource_id]
 
-      assert page_link_map[non_hierarchical_page5.resource_id] == [
-               non_hierarchical_page3.resource_id
+      assert page_link_map[unit1_module1_section_1_page4.resource_id] == [
+               unit1_module1_section1.resource_id
              ]
+
+      assert page_link_map[unit1_module1_section1_page5.resource_id] == [
+               unit1_module1_section1.resource_id
+             ]
+
+      assert page_link_map[unit1_module1_exploration_page6.resource_id] == [
+               unit1_module1.resource_id
+             ]
+
+      assert page_link_map[unit1_module1_scored_page7.resource_id] == [
+               unit1_module1.resource_id
+             ]
+
+      assert page_link_map[unit1_module2.resource_id] == [
+               unit1.resource_id
+             ]
+
+      assert page_link_map[unit1_module2_page8.resource_id] == [
+               unit1_module2.resource_id
+             ]
+
+      assert page_link_map[unit1_exploration_page9.resource_id] == [unit1.resource_id]
+      assert page_link_map[unit1_scored_page10.resource_id] == [unit1.resource_id]
+      assert page_link_map[unit2.resource_id] == [curriculum.resource_id]
+      assert page_link_map[unit2_page11.resource_id] == [unit2.resource_id]
+      assert page_link_map[unit2_module3.resource_id] == [unit2.resource_id]
+      assert page_link_map[unit2_module3_page12.resource_id] == [unit2_module3.resource_id]
+      assert page_link_map[unit2_exploration_page13.resource_id] == [unit2.resource_id]
+      assert page_link_map[unit2_scored_page14.resource_id] == [unit2.resource_id]
+
+      assert page_link_map[non_hierarchical_page15.resource_id] == [
+               unit1_module1_page2.resource_id
+             ]
+
+      assert page_link_map[non_hierarchical_page15.resource_id] == [
+               unit1_module1_page2.resource_id
+             ]
+
+      assert page_link_map[non_hierarchical_page16.resource_id] == [
+               unit1_module1_section1_page5.resource_id
+             ]
+    end
+
+    test "find_parent_container/4", %{
+      section: section,
+      publication: publication,
+      unit1: unit1,
+      unit1_page1: unit1_page1,
+      unit1_module1: unit1_module1,
+      unit1_exploration_page9: unit1_exploration_page9,
+      non_hierarchical_page15: non_hierarchical_page15
+    } do
+      page_link_map = Sections.build_resource_link_map([publication.id])
+
+      all_containers =
+        DeliveryResolver.revisions_of_type(
+          section.slug,
+          Oli.Resources.ResourceType.get_id_by_type("container")
+        )
+
+      container_ids = Enum.map(all_containers, fn c -> c.resource_id end)
+
+      {parent_resource_id, _} =
+        Sections.find_parent_container(
+          unit1_exploration_page9.resource_id,
+          page_link_map,
+          MapSet.new(container_ids),
+          MapSet.new()
+        )
+
+      assert parent_resource_id == unit1.resource_id
+
+      {parent_resource_id, _} =
+        Sections.find_parent_container(
+          non_hierarchical_page15.resource_id,
+          page_link_map,
+          MapSet.new(container_ids),
+          MapSet.new()
+        )
+
+      assert parent_resource_id == unit1_module1.resource_id
+
+      {parent_resource_id, _} =
+        Sections.find_parent_container(
+          unit1_page1.resource_id,
+          page_link_map,
+          MapSet.new(container_ids),
+          MapSet.new()
+        )
+
+      assert parent_resource_id == unit1.resource_id
     end
   end
 
@@ -596,7 +701,6 @@ defmodule Oli.Delivery.SectionsTest do
 
     test "returns the correct ordered container labels for a section", %{
       section: section,
-      curriculum: curriculum,
       unit1: unit1,
       unit1_module1: unit1_module1,
       unit1_module1_section1: unit1_module1_section1,
@@ -604,24 +708,22 @@ defmodule Oli.Delivery.SectionsTest do
       unit2: unit2,
       unit2_module3: unit2_module3
     } do
-      ordered_labels = Sections.get_ordered_container_labels(section.slug)
+      ordered_labels = Sections.fetch_ordered_container_labels(section.slug)
 
-      assert Enum.count(ordered_labels) == 7
+      assert Enum.count(ordered_labels) == 6
 
-      assert Enum.at(ordered_labels, 0) == {curriculum.resource_id, "Curriculum 1: Curriculum"}
+      assert Enum.at(ordered_labels, 0) == {unit1.resource_id, "Unit 1: Unit 1"}
 
-      assert Enum.at(ordered_labels, 1) == {unit1.resource_id, "Unit 1: Unit 1"}
-
-      assert Enum.at(ordered_labels, 2) ==
+      assert Enum.at(ordered_labels, 1) ==
                {unit1_module1.resource_id, "Module 1: Unit 1 Module 1"}
 
-      assert Enum.at(ordered_labels, 3) ==
+      assert Enum.at(ordered_labels, 2) ==
                {unit1_module1_section1.resource_id, "Section 1: Unit 1 Module 1 Section 1"}
 
-      assert Enum.at(ordered_labels, 4) ==
+      assert Enum.at(ordered_labels, 3) ==
                {unit1_module2.resource_id, "Module 2: Unit 1 Module 2"}
 
-      assert Enum.at(ordered_labels, 6) == {unit2.resource_id, "Unit 2: Unit 2"}
+      assert Enum.at(ordered_labels, 4) == {unit2.resource_id, "Unit 2: Unit 2"}
 
       assert Enum.at(ordered_labels, 5) ==
                {unit2_module3.resource_id, "Module 3: Unit 2 Module 3"}

--- a/test/oli_web/live/delivery/student/discussions_live_test.exs
+++ b/test/oli_web/live/delivery/student/discussions_live_test.exs
@@ -150,7 +150,6 @@ defmodule OliWeb.Delivery.Student.DiscussionsLiveTest do
 
     {:ok, section} = Sections.create_section_resources(section, publication)
     {:ok, _} = Sections.rebuild_contained_pages(section)
-    {:ok, _} = Sections.update_page_to_container_map(section)
 
     # enable course collab space
     root_container_sr =

--- a/test/oli_web/live/delivery/student/discussions_live_test.exs
+++ b/test/oli_web/live/delivery/student/discussions_live_test.exs
@@ -150,7 +150,7 @@ defmodule OliWeb.Delivery.Student.DiscussionsLiveTest do
 
     {:ok, section} = Sections.create_section_resources(section, publication)
     {:ok, _} = Sections.rebuild_contained_pages(section)
-    {:ok, _} = Sections.update_resource_to_container_map(section)
+    {:ok, _} = Sections.update_page_to_container_map(section)
 
     # enable course collab space
     root_container_sr =


### PR DESCRIPTION
Fixes a couple of different issues related to the ordering of explorations and practice pages and categorization of which containers they are in:

1. Original ordering determination using a single database query and numbering index and level was flawed. In order to properly sort according to the hierarchy, the hierarchy structure must be loaded and used for sorting. Because this code path still makes use of a section level caching mechanism, this cost only needs to be paid a single time for a course section (and whenever the section is remixed, updated, etc.)
2. The key being used to cache the labels was not matching up with the key expected by the SectionCache module and therefore was not being properly cleared as expected. I fixed that and added a guard so that any key used must match a key expected by the module
3. The cache was originally being stored in the section record as JSON and therefore being loaded anytime a section is queried. This approach was also different than the other ways we were caching section level things so I standardized this with the other items in the section-level cache
4. The all_page_links map being used to find the parent container were also including unnecessary links such as activity_references and relates_to, which was throwing off the algorithm which finds the parent container for resources such as the adaptive pages.
5. Added better unit test coverage to test all these cases
6. `fetch_ordered_container_labels` no longer returns the "Curriculum" root container due to how the full_hierarchy/flatten functions work and changing that seems like more of a risk than updating the latest code paths that now use `fetch_ordered_container_labels`. Really the only place that needed to be updated to handle this change was the discussions view

This solution is a bit inefficient in that it uses the existing full_hierarchy call when it really doesn't need any of the actual content of the revisions. We should update this to use the new MinimalHierarchy module present in hotfix 0.26.2 once that becomes available. Since this call is part of the section cached data, the impact on performance is minimal and only paid when a section is first loaded

<img width="1581" alt="Screenshot 2024-01-25 at 4 27 59 PM" src="https://github.com/Simon-Initiative/oli-torus/assets/6248894/b1b638e9-d74f-47d3-b5ef-560c3dbf13fa">
