### PR TITLE
[NG23-66] intro content for explorations and practice pages is not displaying

### DIFF
--- a/lib/oli_web/components/delivery/deliberate_practice_card.ex
+++ b/lib/oli_web/components/delivery/deliberate_practice_card.ex
@@ -9,26 +9,6 @@ defmodule OliWeb.Components.Delivery.DeliberatePractice do
   attr :preview_mode, :boolean, default: false
 
   def practice_card(assigns) do
-    assigns =
-      assign(
-        assigns,
-        :description,
-        case assigns.practice.intro_content do
-          nil ->
-            nil
-
-          %{} ->
-            nil
-
-          intro_content ->
-            Content.render(
-              %Oli.Rendering.Context{render_opts: %{render_errors: true}},
-              intro_content,
-              Content.Html
-            )
-        end
-      )
-
     ~H"""
     <div class="flex flex-col lg:flex-row-reverse items-center rounded-lg bg-black/5 dark:bg-white/5 mb-4">
       <img
@@ -40,7 +20,7 @@ defmodule OliWeb.Components.Delivery.DeliberatePractice do
           <%= @practice.title %>
         </h5>
         <div class="text-sm mb-3">
-          <%= raw(@description) %>
+          <%= intro_content(@practice) %>
         </div>
         <div class="flex flex-row justify-end items-center space-x-6">
           <.button variant={:primary} href={practice_link(@section_slug, @practice, @preview_mode)}>
@@ -57,6 +37,25 @@ defmodule OliWeb.Components.Delivery.DeliberatePractice do
       ~p"/sections/#{section_slug}/preview/page/#{practice.slug}"
     else
       ~p"/sections/#{section_slug}/page/#{practice.slug}"
+    end
+  end
+
+  defp intro_content(practice) do
+    case practice.intro_content do
+      nil ->
+        nil
+
+      intro_content ->
+        if Enum.empty?(intro_content) do
+          nil
+        else
+          Content.render(
+            %Oli.Rendering.Context{render_opts: %{render_errors: true}},
+            intro_content,
+            Content.Html
+          )
+          |> raw()
+        end
     end
   end
 

--- a/lib/oli_web/live/delivery/student/explorations_live.ex
+++ b/lib/oli_web/live/delivery/student/explorations_live.ex
@@ -53,26 +53,6 @@ defmodule OliWeb.Delivery.Student.ExplorationsLive do
   attr :preview_mode, :boolean, default: false
 
   defp exploration_card(assigns) do
-    assigns =
-      assign(
-        assigns,
-        :description,
-        case assigns.exploration.intro_content do
-          nil ->
-            nil
-
-          %{} ->
-            nil
-
-          intro_content ->
-            Content.render(
-              %Oli.Rendering.Context{render_opts: %{render_errors: true}},
-              intro_content,
-              Content.Html
-            )
-        end
-      )
-
     ~H"""
     <div class="flex flex-col lg:flex-row-reverse items-center rounded-lg bg-black/5 dark:bg-white/5 mb-4">
       <img
@@ -84,7 +64,7 @@ defmodule OliWeb.Delivery.Student.ExplorationsLive do
           <%= @exploration.title %>
         </h5>
         <div class="text-sm mb-3">
-          <%= raw(@description) %>
+          <%= intro_content(@exploration) %>
         </div>
         <div class="flex flex-row justify-end items-center space-x-6">
           <.button
@@ -114,6 +94,25 @@ defmodule OliWeb.Delivery.Student.ExplorationsLive do
 
       image ->
         image
+    end
+  end
+
+  defp intro_content(exploration) do
+    case exploration.intro_content do
+      nil ->
+        nil
+
+      intro_content ->
+        if Enum.empty?(intro_content) do
+          nil
+        else
+          Content.render(
+            %Oli.Rendering.Context{render_opts: %{render_errors: true}},
+            intro_content,
+            Content.Html
+          )
+          |> raw()
+        end
     end
   end
 


### PR DESCRIPTION
Fixes an issue where explorations and practice pages weren't rendering intro content description.

<img width="1582" alt="Screenshot 2024-01-25 at 5 02 46 PM" src="https://github.com/Simon-Initiative/oli-torus/assets/6248894/a6be4fdd-5b8b-419c-ab6f-2b738ada4cb7">
