### PR TITLE
[NG23-68] improve module card colors and readability

### DIFF
--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -1021,6 +1021,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
     >
       <div class="z-10 rounded-xl overflow-hidden absolute h-[163px] w-[288px] cursor-pointer">
         <.progress_bar
+          :if={Map.get(@student_progress_per_resource_id, @module["resource_id"], 0.0) > 0.0}
           percent={
             parse_student_progress_for_resource(
               @student_progress_per_resource_id,

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -475,13 +475,13 @@ defmodule OliWeb.Delivery.Student.LearnLive do
         <div class="flex relative">
           <button
             id={"slider_left_button_#{@unit["resource_id"]}"}
-            class="hidden absolute items-center justify-start -top-1 -left-1 w-10 bg-gradient-to-r from-gray-100 dark:from-gray-900 h-[180px] z-20 text-gray-400 hover:text-gray-700 dark:text-gray-600 hover:text-xl hover:dark:text-gray-200 hover:w-16 cursor-pointer"
+            class="hidden absolute items-center justify-start -top-1 -left-1 w-10 bg-gradient-to-r from-gray-100 dark:from-gray-900 h-[180px] z-20 text-gray-700 dark:text-gray-600 hover:text-xl hover:dark:text-gray-200 hover:w-16 cursor-pointer"
           >
             <i class="fa-solid fa-chevron-left ml-3"></i>
           </button>
           <button
             id={"slider_right_button_#{@unit["resource_id"]}"}
-            class="hidden absolute items-center justify-end -top-1 -right-1 w-10 bg-gradient-to-l from-gray-100 dark:from-gray-900 h-[180px] z-20 text-gray-400 hover:text-gray-700 dark:text-gray-600 hover:text-xl hover:dark:text-gray-200 hover:w-16 cursor-pointer"
+            class="hidden absolute items-center justify-end -top-1 -right-1 w-10 bg-gradient-to-l from-gray-100 dark:from-gray-900 h-[180px] z-20 text-gray-700 dark:text-gray-600 hover:text-xl hover:dark:text-gray-200 hover:w-16 cursor-pointer"
           >
             <i class="fa-solid fa-chevron-right mr-3"></i>
           </button>
@@ -944,12 +944,12 @@ defmodule OliWeb.Delivery.Student.LearnLive do
           role="intro card progress"
         />
       </div>
-      <div class="rounded-xl absolute -top-[0.7px] -left-[0.7px] h-[163px] w-[289.5px] cursor-pointer bg-[linear-gradient(180deg,#D9D9D9_0%,rgba(217,217,217,0.00)_100%)] dark:bg-[linear-gradient(180deg,#223_0%,rgba(34,34,51,0.72)_52.6%,rgba(34,34,51,0.00)_100%)]" />
+      <div class="rounded-xl absolute -top-[0.7px] -left-[0.7px] h-[163px] w-[289.5px] cursor-pointer bg-[linear-gradient(180deg,#223_0%,rgba(34,34,51,0.72)_52.6%,rgba(34,34,51,0.00)_100%)]" />
       <div
         class="flex flex-col items-center rounded-xl h-[162px] w-[288px] bg-gray-200/50 shrink-0 px-5 pt-[15px] bg-cover bg-center"
         style={"background-image: url('#{build_image_url(@bg_image_url, @video_url)}');"}
       >
-        <h5 class="text-[13px] leading-[18px] font-bold opacity-60 text-gray-500 dark:text-white dark:text-opacity-50 self-start">
+        <h5 class="text-[13px] leading-[18px] font-bold opacity-60 text-gray-500 text-white dark:text-opacity-50 self-start">
           <%= @title %>
         </h5>
         <div
@@ -1035,7 +1035,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
           role={"card_#{@module_index}_progress"}
         />
       </div>
-      <div class="rounded-xl absolute h-[163px] w-[288px] cursor-pointer bg-[linear-gradient(180deg,#D9D9D9_0%,rgba(217,217,217,0.00)_100%)] dark:bg-[linear-gradient(180deg,#223_0%,rgba(34,34,51,0.72)_52.6%,rgba(34,34,51,0.00)_100%)]">
+      <div class="rounded-xl absolute h-[163px] w-[288px] cursor-pointer bg-[linear-gradient(180deg,#223_0%,rgba(34,34,51,0.72)_52.6%,rgba(34,34,51,0.00)_100%)]">
       </div>
       <.page_icon :if={is_page(@module)} graded={@module["graded"]} />
 
@@ -1049,10 +1049,10 @@ defmodule OliWeb.Delivery.Student.LearnLive do
           ]}
           style={"background-image: url('#{if(@bg_image_url in ["", nil], do: @default_image, else: @bg_image_url)}');"}
         >
-          <span class="text-[12px] leading-[16px] font-bold opacity-60 text-gray-500 dark:text-white dark:text-opacity-50">
+          <span class="text-[12px] leading-[16px] font-bold opacity-60 text-white dark:text-opacity-50">
             <%= "#{@unit_numbering_index}.#{@module_index}" %>
           </span>
-          <h5 class="text-[18px] leading-[25px] font-bold dark:text-white z-10">
+          <h5 class="text-[18px] leading-[25px] font-bold text-white z-10">
             <%= @module["title"] %>
           </h5>
         </div>

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -1021,7 +1021,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
     >
       <div class="z-10 rounded-xl overflow-hidden absolute h-[163px] w-[288px] cursor-pointer">
         <.progress_bar
-          :if={Map.get(@student_progress_per_resource_id, @module["resource_id"], 0.0) > 0.0}
+          :if={progress_started(@student_progress_per_resource_id, @module["resource_id"])}
           percent={
             parse_student_progress_for_resource(
               @student_progress_per_resource_id,
@@ -1205,6 +1205,10 @@ defmodule OliWeb.Delivery.Student.LearnLive do
         Map.put(page, "visited", Map.get(visited_pages, page["id"], false))
       end)
     )
+  end
+
+  defp progress_started(student_progress_per_resource_id, resource_id) do
+    Map.get(student_progress_per_resource_id, resource_id, 0.0) > 0.0
   end
 
   defp parse_student_progress_for_resource(student_progress_per_resource_id, resource_id) do

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -1270,7 +1270,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       assert_redirect(view, "/sections/#{section.slug}/lesson/#{page_8.slug}")
     end
 
-    test "can see card progress bar for modules at level 2 of hierarchy, and even for pages at level 2",
+    test "progress bar is not rendered when there is no progress",
          %{
            conn: conn,
            user: user,
@@ -1278,6 +1278,27 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
          } do
       Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
       Sections.mark_section_visited_for_student(section, user)
+
+      {:ok, view, _html} = live(conn, live_view_learn_live_route(section.slug))
+
+      # no progress yet, so progress bar is not rendered
+      refute has_element?(view, ~s{div[role="unit_1"] div[role="card_1_progress"]})
+      refute has_element?(view, ~s{div[role="unit_3"] div[role="card_1_progress"]})
+    end
+
+    test "can see card progress bar for modules at level 2 of hierarchy, and even for pages at level 2",
+         %{
+           conn: conn,
+           user: user,
+           section: section,
+           page_2: page_2,
+           page_7: page_7
+         } do
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.mark_section_visited_for_student(section, user)
+
+      set_progress(section.id, page_2.resource_id, user.id, 0.5, page_2)
+      set_progress(section.id, page_7.resource_id, user.id, 1.0, page_7)
 
       {:ok, view, _html} = live(conn, live_view_learn_live_route(section.slug))
 


### PR DESCRIPTION
Improves the colors and title readability of module cards on the learn live view. These became more apparent once we actually loaded in images.

From
<img width="1582" alt="Screenshot 2024-01-26 at 9 41 48 AM" src="https://github.com/Simon-Initiative/oli-torus/assets/6248894/c0b5a880-2aea-4189-9b2f-0482577242fe">

To
<img width="1582" alt="Screenshot 2024-01-26 at 9 55 47 AM" src="https://github.com/Simon-Initiative/oli-torus/assets/6248894/950e248b-fb2e-4cba-ac8e-d540802b8e0b">
