### PR TITLE
[Enhancement] Submit/Reset button UI changes [MER-2512]

### DIFF
--- a/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyDelivery.tsx
+++ b/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyDelivery.tsx
@@ -5,8 +5,6 @@ import { CATASchema } from 'components/activities/check_all_that_apply/schema';
 import { ChoicesDeliveryConnected } from 'components/activities/common/choices/delivery/ChoicesDeliveryConnected';
 import { EvaluationConnected } from 'components/activities/common/delivery/evaluation/EvaluationConnected';
 import { GradedPointsConnected } from 'components/activities/common/delivery/graded_points/GradedPointsConnected';
-import { ResetButtonConnected } from 'components/activities/common/delivery/reset_button/ResetButtonConnected';
-import { SubmitButtonConnected } from 'components/activities/common/delivery/submit_button/SubmitButtonConnected';
 import { HintsDeliveryConnected } from 'components/activities/common/hints/delivery/HintsDeliveryConnected';
 import { StemDeliveryConnected } from 'components/activities/common/stem/delivery/StemDelivery';
 import { Manifest } from 'components/activities/types';
@@ -26,8 +24,8 @@ import { initialPartInputs, isCorrect } from 'data/activities/utils';
 import { configureStore } from 'state/store';
 import { DeliveryElement, DeliveryElementProps } from '../DeliveryElement';
 import { DeliveryElementProvider, useDeliveryElementContext } from '../DeliveryElementProvider';
-import { castPartId } from '../common/utils';
 import { SubmitResetConnected } from '../common/delivery/SubmitReset';
+import { castPartId } from '../common/utils';
 
 export const CheckAllThatApplyComponent: React.FC = () => {
   const {

--- a/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyDelivery.tsx
+++ b/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyDelivery.tsx
@@ -27,6 +27,7 @@ import { configureStore } from 'state/store';
 import { DeliveryElement, DeliveryElementProps } from '../DeliveryElement';
 import { DeliveryElementProvider, useDeliveryElementContext } from '../DeliveryElementProvider';
 import { castPartId } from '../common/utils';
+import { SubmitReset } from '../common/delivery/SubmitReset';
 
 export const CheckAllThatApplyComponent: React.FC = () => {
   const {
@@ -90,8 +91,10 @@ export const CheckAllThatApplyComponent: React.FC = () => {
             )
           }
         />
-        <ResetButtonConnected onReset={() => dispatch(resetAction(onResetActivity, resetInputs))} />
-        <SubmitButtonConnected />
+
+        <SubmitReset onReset={() => dispatch(resetAction(onResetActivity, resetInputs))} />
+        {/* <ResetButtonConnected onReset={() => dispatch(resetAction(onResetActivity, resetInputs))} />
+        <SubmitButtonConnected /> */}
         <HintsDeliveryConnected
           partId={castPartId(activityState.parts[0].partId)}
           resetPartInputs={resetInputs}

--- a/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyDelivery.tsx
+++ b/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyDelivery.tsx
@@ -27,7 +27,7 @@ import { configureStore } from 'state/store';
 import { DeliveryElement, DeliveryElementProps } from '../DeliveryElement';
 import { DeliveryElementProvider, useDeliveryElementContext } from '../DeliveryElementProvider';
 import { castPartId } from '../common/utils';
-import { SubmitReset } from '../common/delivery/SubmitReset';
+import { SubmitResetConnected } from '../common/delivery/SubmitReset';
 
 export const CheckAllThatApplyComponent: React.FC = () => {
   const {
@@ -92,9 +92,7 @@ export const CheckAllThatApplyComponent: React.FC = () => {
           }
         />
 
-        <SubmitReset onReset={() => dispatch(resetAction(onResetActivity, resetInputs))} />
-        {/* <ResetButtonConnected onReset={() => dispatch(resetAction(onResetActivity, resetInputs))} />
-        <SubmitButtonConnected /> */}
+        <SubmitResetConnected onReset={() => dispatch(resetAction(onResetActivity, resetInputs))} />
         <HintsDeliveryConnected
           partId={castPartId(activityState.parts[0].partId)}
           resetPartInputs={resetInputs}

--- a/assets/src/components/activities/common/delivery/SubmitReset.tsx
+++ b/assets/src/components/activities/common/delivery/SubmitReset.tsx
@@ -1,23 +1,43 @@
 import React, { ReactNode } from 'react';
 import { ResetButtonConnected } from './reset_button/ResetButtonConnected';
-import { SubmitButtonConnected } from './submit_button/SubmitButtonConnected';
+import {
+  SubmitButtonConnected,
+  SubmitButtonConnectedProps,
+} from './submit_button/SubmitButtonConnected';
 
 interface Props {
   onReset: () => void;
+  submitDisabled?: boolean;
 }
 
-export const SubmitReset: React.FC<Props> = ({ onReset }) => {
+export const SubmitResetConnected: React.FC<Props> = ({ onReset, submitDisabled }) => {
+  return (
+    <SubmitResetLayout
+      submitButton={<SubmitButtonConnected hideOnSubmitted={false} disabled={submitDisabled} />}
+      resetButton={<ResetButtonConnected hideBeforeSubmit={false} onReset={onReset} />}
+    />
+  );
+};
+
+interface SubmitResetLayoutProps {
+  submitButton: ReactNode;
+  resetButton: ReactNode;
+}
+export const SubmitResetLayout: React.FC<SubmitResetLayoutProps> = ({
+  submitButton,
+  resetButton,
+}) => {
   return (
     <Row>
-      <Col>
-        <SubmitButtonConnected hideOnSubmitted={false} />
-      </Col>
-      <Col>
-        <ResetButtonConnected hideBeforeSubmit={false} onReset={onReset} />
-      </Col>
+      <Col>{submitButton}</Col>
+      <Col>{resetButton}</Col>
     </Row>
   );
 };
 
-const Col: React.FC<{ children: ReactNode }> = ({ children }) => <div className='inline-block'>{children}</div>;
-const Row: React.FC<{ children: ReactNode }> = ({ children }) => <div className='flex justify-between flex-row w-auto'>{children}</div>;
+const Col: React.FC<{ children: ReactNode }> = ({ children }) => (
+  <div className="inline-block">{children}</div>
+);
+const Row: React.FC<{ children: ReactNode }> = ({ children }) => (
+  <div className="flex justify-between flex-row w-auto">{children}</div>
+);

--- a/assets/src/components/activities/common/delivery/SubmitReset.tsx
+++ b/assets/src/components/activities/common/delivery/SubmitReset.tsx
@@ -1,9 +1,6 @@
 import React, { ReactNode } from 'react';
 import { ResetButtonConnected } from './reset_button/ResetButtonConnected';
-import {
-  SubmitButtonConnected,
-  SubmitButtonConnectedProps,
-} from './submit_button/SubmitButtonConnected';
+import { SubmitButtonConnected } from './submit_button/SubmitButtonConnected';
 
 interface Props {
   onReset: () => void;

--- a/assets/src/components/activities/common/delivery/SubmitReset.tsx
+++ b/assets/src/components/activities/common/delivery/SubmitReset.tsx
@@ -1,0 +1,23 @@
+import React, { ReactNode } from 'react';
+import { ResetButtonConnected } from './reset_button/ResetButtonConnected';
+import { SubmitButtonConnected } from './submit_button/SubmitButtonConnected';
+
+interface Props {
+  onReset: () => void;
+}
+
+export const SubmitReset: React.FC<Props> = ({ onReset }) => {
+  return (
+    <Row>
+      <Col>
+        <SubmitButtonConnected hideOnSubmitted={false} />
+      </Col>
+      <Col>
+        <ResetButtonConnected hideBeforeSubmit={false} onReset={onReset} />
+      </Col>
+    </Row>
+  );
+};
+
+const Col: React.FC<{ children: ReactNode }> = ({ children }) => <div className='inline-block'>{children}</div>;
+const Row: React.FC<{ children: ReactNode }> = ({ children }) => <div className='flex justify-between flex-row w-auto'>{children}</div>;

--- a/assets/src/components/activities/common/delivery/reset_button/ResetButtonConnected.tsx
+++ b/assets/src/components/activities/common/delivery/reset_button/ResetButtonConnected.tsx
@@ -6,16 +6,31 @@ import { ActivityDeliveryState, isEvaluated, isSubmitted } from 'data/activities
 
 interface Props {
   onReset: () => void;
+  hideBeforeSubmit?: boolean;
 }
-export const ResetButtonConnected: React.FC<Props> = ({ onReset }) => {
+export const ResetButtonConnected: React.FC<Props> = ({ onReset, hideBeforeSubmit }) => {
   const { graded, surveyId } = useDeliveryElementContext().context;
   const uiState = useSelector((state: ActivityDeliveryState) => state);
 
+  const disabled = !uiState.attemptState.hasMoreAttempts
+  const evaluated = (isEvaluated(uiState) || isSubmitted(uiState)) && !graded && surveyId === null
+
+  // If the activity is graded or a survey, then we should never show the reset button.
+  // If the hideBeforeSubmit flag is set, then we should only show the reset button if the activity has been submitted.
+  // If the hideBeforeSubmit flag is not set, then we should always show the reset button, but disable it if the activity has been submitted.
+  const shouldShow  = hideBeforeSubmit ? evaluated : !graded && surveyId === null;
+  const shouldDisable = hideBeforeSubmit ? disabled : !evaluated || disabled;
+
   return (
     <ResetButton
-      shouldShow={(isEvaluated(uiState) || isSubmitted(uiState)) && !graded && surveyId === null}
-      disabled={!uiState.attemptState.hasMoreAttempts}
+      shouldShow={shouldShow}
+      disabled={shouldDisable}
       action={onReset}
     />
   );
+};
+
+
+ResetButtonConnected.defaultProps = {
+  hideBeforeSubmit: true,
 };

--- a/assets/src/components/activities/common/delivery/reset_button/ResetButtonConnected.tsx
+++ b/assets/src/components/activities/common/delivery/reset_button/ResetButtonConnected.tsx
@@ -12,24 +12,17 @@ export const ResetButtonConnected: React.FC<Props> = ({ onReset, hideBeforeSubmi
   const { graded, surveyId } = useDeliveryElementContext().context;
   const uiState = useSelector((state: ActivityDeliveryState) => state);
 
-  const disabled = !uiState.attemptState.hasMoreAttempts
-  const evaluated = (isEvaluated(uiState) || isSubmitted(uiState)) && !graded && surveyId === null
+  const disabled = !uiState.attemptState.hasMoreAttempts;
+  const evaluated = (isEvaluated(uiState) || isSubmitted(uiState)) && !graded && surveyId === null;
 
   // If the activity is graded or a survey, then we should never show the reset button.
   // If the hideBeforeSubmit flag is set, then we should only show the reset button if the activity has been submitted.
   // If the hideBeforeSubmit flag is not set, then we should always show the reset button, but disable it if the activity has been submitted.
-  const shouldShow  = hideBeforeSubmit ? evaluated : !graded && surveyId === null;
+  const shouldShow = hideBeforeSubmit ? evaluated : !graded && surveyId === null;
   const shouldDisable = hideBeforeSubmit ? disabled : !evaluated || disabled;
 
-  return (
-    <ResetButton
-      shouldShow={shouldShow}
-      disabled={shouldDisable}
-      action={onReset}
-    />
-  );
+  return <ResetButton shouldShow={shouldShow} disabled={shouldDisable} action={onReset} />;
 };
-
 
 ResetButtonConnected.defaultProps = {
   hideBeforeSubmit: true,

--- a/assets/src/components/activities/common/delivery/submit_button/SubmitButtonConnected.tsx
+++ b/assets/src/components/activities/common/delivery/submit_button/SubmitButtonConnected.tsx
@@ -22,7 +22,7 @@ export const SubmitButtonConnected: React.FC<SubmitButtonConnectedProps> = (prop
       : props.disabled;
 
   const notGradedOrSurvey = !graded && surveyId === null;
-  const shouldShowFlag = !isSubmitted(uiState) && notGradedOrSurvey
+  const shouldShowFlag = !isSubmitted(uiState) && notGradedOrSurvey;
 
   // If the activity is graded or a survey, then we should never show the submit button.
   // If the hideOnSubmitted flag is set, then we should only show the submit button if the activity has not been submitted.
@@ -38,7 +38,6 @@ export const SubmitButtonConnected: React.FC<SubmitButtonConnectedProps> = (prop
     />
   );
 };
-
 
 SubmitButtonConnected.defaultProps = {
   hideOnSubmitted: true,

--- a/assets/src/components/activities/common/delivery/submit_button/SubmitButtonConnected.tsx
+++ b/assets/src/components/activities/common/delivery/submit_button/SubmitButtonConnected.tsx
@@ -6,23 +6,40 @@ import { ActivityDeliveryState, isSubmitted, submit } from 'data/activities/Deli
 
 interface Props {
   disabled?: boolean;
+  hideOnSubmitted?: boolean;
 }
-export const SubmitButtonConnected: React.FC<Props> = ({ disabled }) => {
+export const SubmitButtonConnected: React.FC<Props> = (props) => {
   const { context, onSubmitActivity } = useDeliveryElementContext();
   const { graded, surveyId } = context;
   const uiState = useSelector((state: ActivityDeliveryState) => state);
   const dispatch = useDispatch();
+
+  const disabled =
+    props.disabled === undefined
+      ? Object.values(uiState.partState)
+          .map((partState) => partState.studentInput)
+          .every((input) => input.length === 0)
+      : props.disabled;
+
+  const notGradedOrSurvey = !graded && surveyId === null;
+  const shouldShowFlag = !isSubmitted(uiState) && notGradedOrSurvey
+
+  // If the activity is graded or a survey, then we should never show the submit button.
+  // If the hideOnSubmitted flag is set, then we should only show the submit button if the activity has not been submitted.
+  // If the hideOnSubmitted flag is not set, then we should always show the submit button, but disable it if the activity has been submitted.
+  const shouldShow = props.hideOnSubmitted ? shouldShowFlag : notGradedOrSurvey;
+  const shouldDisable = props.hideOnSubmitted ? disabled : !shouldShowFlag || disabled;
+
   return (
     <SubmitButton
-      shouldShow={!isSubmitted(uiState) && !graded && surveyId === null}
-      disabled={
-        disabled === undefined
-          ? Object.values(uiState.partState)
-              .map((partState) => partState.studentInput)
-              .every((input) => input.length === 0)
-          : disabled
-      }
+      shouldShow={shouldShow}
+      disabled={shouldDisable}
       onClick={() => dispatch(submit(onSubmitActivity))}
     />
   );
+};
+
+
+SubmitButtonConnected.defaultProps = {
+  hideOnSubmitted: true,
 };

--- a/assets/src/components/activities/common/delivery/submit_button/SubmitButtonConnected.tsx
+++ b/assets/src/components/activities/common/delivery/submit_button/SubmitButtonConnected.tsx
@@ -4,11 +4,11 @@ import { useDeliveryElementContext } from 'components/activities/DeliveryElement
 import { SubmitButton } from 'components/activities/common/delivery/submit_button/SubmitButton';
 import { ActivityDeliveryState, isSubmitted, submit } from 'data/activities/DeliveryState';
 
-interface Props {
+export interface SubmitButtonConnectedProps {
   disabled?: boolean;
   hideOnSubmitted?: boolean;
 }
-export const SubmitButtonConnected: React.FC<Props> = (props) => {
+export const SubmitButtonConnected: React.FC<SubmitButtonConnectedProps> = (props) => {
   const { context, onSubmitActivity } = useDeliveryElementContext();
   const { graded, surveyId } = context;
   const uiState = useSelector((state: ActivityDeliveryState) => state);

--- a/assets/src/components/activities/file_upload/FileUploadDelivery.tsx
+++ b/assets/src/components/activities/file_upload/FileUploadDelivery.tsx
@@ -309,7 +309,7 @@ export const FileUploadComponent: React.FC = () => {
           submitButton={
             <SubmitButton
               shouldShow={!graded && (surveyId === undefined || surveyId === null)}
-              disabled={ isSubmitted(uiState) || getFilesFromState(uiState).length === 0}
+              disabled={isSubmitted(uiState) || getFilesFromState(uiState).length === 0}
               onClick={() => dispatch(submitFiles(onSubmitActivity, getFilesFromState))}
             />
           }

--- a/assets/src/components/activities/file_upload/FileUploadDelivery.tsx
+++ b/assets/src/components/activities/file_upload/FileUploadDelivery.tsx
@@ -40,6 +40,7 @@ import { uploadActivityFile } from 'data/persistence/state/intrinsic';
 import { configureStore } from 'state/store';
 import { DeliveryElementProvider, useDeliveryElementContext } from '../DeliveryElementProvider';
 import { RemoveButton } from '../common/authoring/RemoveButton';
+import { SubmitResetLayout } from '../common/delivery/SubmitReset';
 import { castPartId } from '../common/utils';
 import { fileName, getReadableFileSizeString } from './utils';
 import { defaultMaxFileSize } from './utils';
@@ -298,14 +299,22 @@ export const FileUploadComponent: React.FC = () => {
           }
         />
 
-        <ResetButtonConnected onReset={() => dispatch(resetAction(onResetActivity, resetParts))} />
-        <SubmitButton
-          shouldShow={
-            !isSubmitted(uiState) && !graded && (surveyId === undefined || surveyId === null)
+        <SubmitResetLayout
+          resetButton={
+            <ResetButtonConnected
+              hideBeforeSubmit={false}
+              onReset={() => dispatch(resetAction(onResetActivity, resetParts))}
+            />
           }
-          disabled={getFilesFromState(uiState).length === 0}
-          onClick={() => dispatch(submitFiles(onSubmitActivity, getFilesFromState))}
+          submitButton={
+            <SubmitButton
+              shouldShow={!graded && (surveyId === undefined || surveyId === null)}
+              disabled={ isSubmitted(uiState) || getFilesFromState(uiState).length === 0}
+              onClick={() => dispatch(submitFiles(onSubmitActivity, getFilesFromState))}
+            />
+          }
         />
+
         <HintsDeliveryConnected
           partId={castPartId(state.parts[0].partId)}
           resetPartInputs={resetParts}

--- a/assets/src/components/activities/image_hotspot/ImageHotspotDelivery.tsx
+++ b/assets/src/components/activities/image_hotspot/ImageHotspotDelivery.tsx
@@ -158,7 +158,9 @@ const ImageHotspotComponent: React.FC = () => {
 
         <GradedPointsConnected />
 
-        <SubmitResetConnected onReset={() => dispatch(resetAction(onResetActivity, { [partId]: [] }))} />
+        <SubmitResetConnected
+          onReset={() => dispatch(resetAction(onResetActivity, { [partId]: [] }))}
+        />
 
         <HintsDeliveryConnected partId={castPartId(activityState.parts[0].partId)} />
         <EvaluationConnected />

--- a/assets/src/components/activities/image_hotspot/ImageHotspotDelivery.tsx
+++ b/assets/src/components/activities/image_hotspot/ImageHotspotDelivery.tsx
@@ -17,10 +17,9 @@ import { configureStore } from 'state/store';
 import guid from 'utils/guid';
 import { DeliveryElement, DeliveryElementProps } from '../DeliveryElement';
 import { DeliveryElementProvider, useDeliveryElementContext } from '../DeliveryElementProvider';
+import { SubmitResetConnected } from '../common/delivery/SubmitReset';
 import { EvaluationConnected } from '../common/delivery/evaluation/EvaluationConnected';
 import { GradedPointsConnected } from '../common/delivery/graded_points/GradedPointsConnected';
-import { ResetButtonConnected } from '../common/delivery/reset_button/ResetButtonConnected';
-import { SubmitButtonConnected } from '../common/delivery/submit_button/SubmitButtonConnected';
 import { HintsDeliveryConnected } from '../common/hints/delivery/HintsDeliveryConnected';
 import { StemDelivery } from '../common/stem/delivery/StemDelivery';
 import { castPartId } from '../common/utils';
@@ -158,10 +157,9 @@ const ImageHotspotComponent: React.FC = () => {
         </div>
 
         <GradedPointsConnected />
-        <ResetButtonConnected
-          onReset={() => dispatch(resetAction(onResetActivity, { [partId]: [] }))}
-        />
-        <SubmitButtonConnected />
+
+        <SubmitResetConnected onReset={() => dispatch(resetAction(onResetActivity, { [partId]: [] }))} />
+
         <HintsDeliveryConnected partId={castPartId(activityState.parts[0].partId)} />
         <EvaluationConnected />
       </div>

--- a/assets/src/components/activities/likert/LikertDelivery.tsx
+++ b/assets/src/components/activities/likert/LikertDelivery.tsx
@@ -27,6 +27,7 @@ import { castPartId } from '../common/utils';
 import * as ActivityTypes from '../types';
 import { LikertTable } from './Sections/LikertTable';
 import { LikertModelSchema } from './schema';
+import { SubmitResetConnected } from '../common/delivery/SubmitReset';
 
 const LikertComponent: React.FC = () => {
   const {
@@ -81,10 +82,11 @@ const LikertComponent: React.FC = () => {
           context={writerContext}
         />
         <GradedPointsConnected />
-        <ResetButtonConnected
+
+        <SubmitResetConnected
           onReset={() => dispatch(resetAction(onResetActivity, emptySelectionMap))}
         />
-        <SubmitButtonConnected />
+
         <HintsDeliveryConnected
           partId={castPartId(activityState.parts[0].partId)}
           resetPartInputs={emptySelectionMap}

--- a/assets/src/components/activities/likert/LikertDelivery.tsx
+++ b/assets/src/components/activities/likert/LikertDelivery.tsx
@@ -17,17 +17,15 @@ import { initialPartInputs } from 'data/activities/utils';
 import { configureStore } from 'state/store';
 import { DeliveryElement, DeliveryElementProps } from '../DeliveryElement';
 import { DeliveryElementProvider, useDeliveryElementContext } from '../DeliveryElementProvider';
+import { SubmitResetConnected } from '../common/delivery/SubmitReset';
 import { EvaluationConnected } from '../common/delivery/evaluation/EvaluationConnected';
 import { GradedPointsConnected } from '../common/delivery/graded_points/GradedPointsConnected';
-import { ResetButtonConnected } from '../common/delivery/reset_button/ResetButtonConnected';
-import { SubmitButtonConnected } from '../common/delivery/submit_button/SubmitButtonConnected';
 import { HintsDeliveryConnected } from '../common/hints/delivery/HintsDeliveryConnected';
 import { StemDelivery } from '../common/stem/delivery/StemDelivery';
 import { castPartId } from '../common/utils';
 import * as ActivityTypes from '../types';
 import { LikertTable } from './Sections/LikertTable';
 import { LikertModelSchema } from './schema';
-import { SubmitResetConnected } from '../common/delivery/SubmitReset';
 
 const LikertComponent: React.FC = () => {
   const {

--- a/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
@@ -32,6 +32,7 @@ import { safelySelectStringInputs } from 'data/activities/utils';
 import { defaultWriterContext } from 'data/content/writers/context';
 import { configureStore } from 'state/store';
 import { DeliveryElementProvider, useDeliveryElementContext } from '../DeliveryElementProvider';
+import { SubmitResetConnected } from '../common/delivery/SubmitReset';
 import { initializePersistence } from '../common/delivery/persistence';
 
 export const MultiInputComponent: React.FC = () => {
@@ -301,6 +302,8 @@ export const MultiInputComponent: React.FC = () => {
     },
   });
 
+  const submitPerPart = (uiState.model as MultiInputSchema).submitPerPart;
+
   return (
     <div className="activity multi-input-activity">
       <div className="activity-content">
@@ -310,12 +313,22 @@ export const MultiInputComponent: React.FC = () => {
           context={writerContext}
         />
         <GradedPointsConnected />
-        <ResetButtonConnected
-          onReset={() => dispatch(resetAction(onResetActivity, emptyPartInputs))}
-        />
-        {(uiState.model as MultiInputSchema).submitPerPart ? null : (
-          <SubmitButtonConnected disabled={false} />
+        {/*
+          When submitPerPart is active, we don't show the submit button, only reset
+          When submitPerPart is not active, we show both
+         */}
+        {submitPerPart && (
+          <ResetButtonConnected
+            onReset={() => dispatch(resetAction(onResetActivity, emptyPartInputs))}
+          />
         )}
+        {submitPerPart || (
+          <SubmitResetConnected
+            onReset={() => dispatch(resetAction(onResetActivity, emptyPartInputs))}
+            submitDisabled={false}
+          />
+        )}
+
         {hintsShown.map((partId) => (
           <HintsDeliveryConnected
             key={partId}

--- a/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
@@ -6,7 +6,6 @@ import { Evaluation } from 'components/activities/common/delivery/evaluation/Eva
 import { Submission } from 'components/activities/common/delivery/evaluation/Submission';
 import { GradedPointsConnected } from 'components/activities/common/delivery/graded_points/GradedPointsConnected';
 import { ResetButtonConnected } from 'components/activities/common/delivery/reset_button/ResetButtonConnected';
-import { SubmitButtonConnected } from 'components/activities/common/delivery/submit_button/SubmitButtonConnected';
 import { HintsDeliveryConnected } from 'components/activities/common/hints/delivery/HintsDeliveryConnected';
 import { StemDelivery } from 'components/activities/common/stem/delivery/StemDelivery';
 import { MultiInput, MultiInputSchema } from 'components/activities/multi_input/schema';

--- a/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
@@ -303,7 +303,6 @@ export const MultiInputComponent: React.FC = () => {
   });
 
   const submitPerPart = (uiState.model as MultiInputSchema).submitPerPart;
-
   return (
     <div className="activity multi-input-activity">
       <div className="activity-content">

--- a/assets/src/components/activities/ordering/OrderingDelivery.tsx
+++ b/assets/src/components/activities/ordering/OrderingDelivery.tsx
@@ -3,8 +3,6 @@ import ReactDOM from 'react-dom';
 import { Provider, useDispatch, useSelector } from 'react-redux';
 import { EvaluationConnected } from 'components/activities/common/delivery/evaluation/EvaluationConnected';
 import { GradedPointsConnected } from 'components/activities/common/delivery/graded_points/GradedPointsConnected';
-import { ResetButtonConnected } from 'components/activities/common/delivery/reset_button/ResetButtonConnected';
-import { SubmitButtonConnected } from 'components/activities/common/delivery/submit_button/SubmitButtonConnected';
 import { HintsDeliveryConnected } from 'components/activities/common/hints/delivery/HintsDeliveryConnected';
 import { StemDeliveryConnected } from 'components/activities/common/stem/delivery/StemDelivery';
 import { ResponseChoices } from 'components/activities/ordering/sections/ResponseChoices';
@@ -25,10 +23,10 @@ import { elementsOfType } from 'data/content/utils';
 import { configureStore } from 'state/store';
 import { DeliveryElement, DeliveryElementProps } from '../DeliveryElement';
 import { DeliveryElementProvider, useDeliveryElementContext } from '../DeliveryElementProvider';
+import { SubmitResetConnected } from '../common/delivery/SubmitReset';
 import { castPartId } from '../common/utils';
 import * as ActivityTypes from '../types';
 import { OrderingSchema } from './schema';
-import { SubmitResetConnected } from '../common/delivery/SubmitReset';
 
 export const OrderingComponent: React.FC = () => {
   const {
@@ -162,7 +160,9 @@ export const OrderingComponent: React.FC = () => {
           </div>
         )}
 
-        <SubmitResetConnected onReset={() => dispatch(resetAction(onResetActivity, defaultPartInputs))} />
+        <SubmitResetConnected
+          onReset={() => dispatch(resetAction(onResetActivity, defaultPartInputs))}
+        />
 
         <HintsDeliveryConnected
           partId={castPartId(activityState.parts[0].partId)}

--- a/assets/src/components/activities/ordering/OrderingDelivery.tsx
+++ b/assets/src/components/activities/ordering/OrderingDelivery.tsx
@@ -28,6 +28,7 @@ import { DeliveryElementProvider, useDeliveryElementContext } from '../DeliveryE
 import { castPartId } from '../common/utils';
 import * as ActivityTypes from '../types';
 import { OrderingSchema } from './schema';
+import { SubmitResetConnected } from '../common/delivery/SubmitReset';
 
 export const OrderingComponent: React.FC = () => {
   const {
@@ -160,10 +161,9 @@ export const OrderingComponent: React.FC = () => {
             <audio ref={player} />
           </div>
         )}
-        <ResetButtonConnected
-          onReset={() => dispatch(resetAction(onResetActivity, defaultPartInputs))}
-        />
-        <SubmitButtonConnected />
+
+        <SubmitResetConnected onReset={() => dispatch(resetAction(onResetActivity, defaultPartInputs))} />
+
         <HintsDeliveryConnected
           partId={castPartId(activityState.parts[0].partId)}
           resetPartInputs={defaultPartInputs}

--- a/assets/src/components/activities/response_multi/ResponseMultiInputDelivery.tsx
+++ b/assets/src/components/activities/response_multi/ResponseMultiInputDelivery.tsx
@@ -6,7 +6,6 @@ import { Evaluation } from 'components/activities/common/delivery/evaluation/Eva
 import { Submission } from 'components/activities/common/delivery/evaluation/Submission';
 import { GradedPointsConnected } from 'components/activities/common/delivery/graded_points/GradedPointsConnected';
 import { ResetButtonConnected } from 'components/activities/common/delivery/reset_button/ResetButtonConnected';
-import { SubmitButtonConnected } from 'components/activities/common/delivery/submit_button/SubmitButtonConnected';
 import { HintsDeliveryConnected } from 'components/activities/common/hints/delivery/HintsDeliveryConnected';
 import { StemDelivery } from 'components/activities/common/stem/delivery/StemDelivery';
 import { ResponseMultiInputSchema } from 'components/activities/response_multi/schema';
@@ -32,6 +31,7 @@ import { safelySelectStringInputs } from 'data/activities/utils';
 import { defaultWriterContext } from 'data/content/writers/context';
 import { configureStore } from 'state/store';
 import { DeliveryElementProvider, useDeliveryElementContext } from '../DeliveryElementProvider';
+import { SubmitResetConnected } from '../common/delivery/SubmitReset';
 import { initializePersistence } from '../common/delivery/persistence';
 import { MultiInput } from '../multi_input/schema';
 
@@ -343,6 +343,8 @@ export const ResponseMultiInputComponent: React.FC = () => {
     },
   });
 
+  const submitPerPart = (uiState.model as ResponseMultiInputSchema).submitPerPart;
+
   return (
     <div className="activity response-multi-input-activity">
       <div className="activity-content">
@@ -352,12 +354,24 @@ export const ResponseMultiInputComponent: React.FC = () => {
           context={writerContext}
         />
         <GradedPointsConnected />
-        <ResetButtonConnected
-          onReset={() => dispatch(resetAction(onResetActivity, emptyPartInputs))}
-        />
-        {(uiState.model as ResponseMultiInputSchema).submitPerPart ? null : (
-          <SubmitButtonConnected disabled={false} />
+
+        {/*
+          When submitPerPart - only display reset button
+          When not submitPerPart - display reset & submit buttons
+        */}
+        {submitPerPart && (
+          <ResetButtonConnected
+            onReset={() => dispatch(resetAction(onResetActivity, emptyPartInputs))}
+          />
         )}
+
+        {submitPerPart || (
+          <SubmitResetConnected
+            onReset={() => dispatch(resetAction(onResetActivity, emptyPartInputs))}
+            submitDisabled={false}
+          />
+        )}
+
         {hintsShown.map((partId) => (
           <HintsDeliveryConnected
             key={partId}

--- a/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
+++ b/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
@@ -8,8 +8,6 @@ import { GradedPointsConnected } from 'components/activities/common/delivery/gra
 import { NumericInput } from 'components/activities/common/delivery/inputs/NumericInput';
 import { TextInput } from 'components/activities/common/delivery/inputs/TextInput';
 import { TextareaInput } from 'components/activities/common/delivery/inputs/TextareaInput';
-import { ResetButtonConnected } from 'components/activities/common/delivery/reset_button/ResetButtonConnected';
-import { SubmitButtonConnected } from 'components/activities/common/delivery/submit_button/SubmitButtonConnected';
 import { HintsDeliveryConnected } from 'components/activities/common/hints/delivery/HintsDeliveryConnected';
 import { StemDeliveryConnected } from 'components/activities/common/stem/delivery/StemDelivery';
 import { InputType, ShortAnswerModelSchema } from 'components/activities/short_answer/schema';
@@ -29,10 +27,10 @@ import { safelySelectStringInputs } from 'data/activities/utils';
 import { configureStore } from 'state/store';
 import { assertNever, valueOr } from 'utils/common';
 import { DeliveryElementProvider, useDeliveryElementContext } from '../DeliveryElementProvider';
+import { SubmitResetConnected } from '../common/delivery/SubmitReset';
 import { MathInput } from '../common/delivery/inputs/MathInput';
 import { initializePersistence } from '../common/delivery/persistence';
 import { castPartId } from '../common/utils';
-import { SubmitResetConnected } from '../common/delivery/SubmitReset';
 
 type InputProps = {
   input: string;

--- a/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
+++ b/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
@@ -32,6 +32,7 @@ import { DeliveryElementProvider, useDeliveryElementContext } from '../DeliveryE
 import { MathInput } from '../common/delivery/inputs/MathInput';
 import { initializePersistence } from '../common/delivery/persistence';
 import { castPartId } from '../common/utils';
+import { SubmitReset } from '../common/delivery/SubmitReset';
 
 type InputProps = {
   input: string;
@@ -150,8 +151,9 @@ export const ShortAnswerComponent: React.FC = () => {
           onBlur={() => deferredSave.current.flushPendingChanges(false)}
         />
 
-        <ResetButtonConnected onReset={() => dispatch(resetAction(onResetActivity, resetParts))} />
-        <SubmitButtonConnected />
+        <SubmitReset onReset={() => dispatch(resetAction(onResetActivity, resetParts))} />
+        {/* <ResetButtonConnected onReset={() => dispatch(resetAction(onResetActivity, resetParts))} />
+        <SubmitButtonConnected /> */}
         <HintsDeliveryConnected
           partId={castPartId(activityState.parts[0].partId)}
           resetPartInputs={resetParts}

--- a/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
+++ b/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
@@ -32,7 +32,7 @@ import { DeliveryElementProvider, useDeliveryElementContext } from '../DeliveryE
 import { MathInput } from '../common/delivery/inputs/MathInput';
 import { initializePersistence } from '../common/delivery/persistence';
 import { castPartId } from '../common/utils';
-import { SubmitReset } from '../common/delivery/SubmitReset';
+import { SubmitResetConnected } from '../common/delivery/SubmitReset';
 
 type InputProps = {
   input: string;
@@ -151,9 +151,8 @@ export const ShortAnswerComponent: React.FC = () => {
           onBlur={() => deferredSave.current.flushPendingChanges(false)}
         />
 
-        <SubmitReset onReset={() => dispatch(resetAction(onResetActivity, resetParts))} />
-        {/* <ResetButtonConnected onReset={() => dispatch(resetAction(onResetActivity, resetParts))} />
-        <SubmitButtonConnected /> */}
+        <SubmitResetConnected onReset={() => dispatch(resetAction(onResetActivity, resetParts))} />
+
         <HintsDeliveryConnected
           partId={castPartId(activityState.parts[0].partId)}
           resetPartInputs={resetParts}

--- a/assets/src/components/activities/vlab/VlabDelivery.tsx
+++ b/assets/src/components/activities/vlab/VlabDelivery.tsx
@@ -4,8 +4,6 @@ import { Provider, useDispatch, useSelector } from 'react-redux';
 import { DeliveryElement, DeliveryElementProps } from 'components/activities/DeliveryElement';
 import { EvaluationConnected } from 'components/activities/common/delivery/evaluation/EvaluationConnected';
 import { GradedPointsConnected } from 'components/activities/common/delivery/graded_points/GradedPointsConnected';
-import { ResetButtonConnected } from 'components/activities/common/delivery/reset_button/ResetButtonConnected';
-import { SubmitButtonConnected } from 'components/activities/common/delivery/submit_button/SubmitButtonConnected';
 import { HintsDeliveryConnected } from 'components/activities/common/hints/delivery/HintsDeliveryConnected';
 import { StemDelivery } from 'components/activities/common/stem/delivery/StemDelivery';
 import { Manifest, PartId } from 'components/activities/types';
@@ -247,13 +245,10 @@ export const VlabComponent: React.FC = () => {
         />
         <GradedPointsConnected />
 
-
         <SubmitResetConnected
           onReset={() => dispatch(resetAction(onResetActivity, emptyPartInputs))}
           submitDisabled={false}
         />
-
-
 
         {hintsShown.map((partId) => (
           <HintsDeliveryConnected

--- a/assets/src/components/activities/vlab/VlabDelivery.tsx
+++ b/assets/src/components/activities/vlab/VlabDelivery.tsx
@@ -27,6 +27,7 @@ import { safelySelectStringInputs } from 'data/activities/utils';
 import { defaultWriterContext } from 'data/content/writers/context';
 import { configureStore } from 'state/store';
 import { DeliveryElementProvider, useDeliveryElementContext } from '../DeliveryElementProvider';
+import { SubmitResetConnected } from '../common/delivery/SubmitReset';
 
 export const VlabComponent: React.FC = () => {
   const {
@@ -245,10 +246,15 @@ export const VlabComponent: React.FC = () => {
           context={writerContext}
         />
         <GradedPointsConnected />
-        <ResetButtonConnected
+
+
+        <SubmitResetConnected
           onReset={() => dispatch(resetAction(onResetActivity, emptyPartInputs))}
+          submitDisabled={false}
         />
-        <SubmitButtonConnected disabled={false} />
+
+
+
         {hintsShown.map((partId) => (
           <HintsDeliveryConnected
             key={partId}


### PR DESCRIPTION
On practice pages many activities have a submit button.
Before this change, the submit button would dissapear and a reset button would appear in the same location.
A learner who accidently double-clicked might submit and then mistakenly reset the activity.

This change moves us to a model where the submit & reset buttons are always visible, however they are disabled when they shouldn't be used.

![resetbutton](https://github.com/Simon-Initiative/oli-torus/assets/333265/145c0148-e287-4171-835e-b4b75782d577)

This affects:

- Check all that apply
- Short Answer
- LikerT
- Multi Input
- Ordering
- File Upload
- Image Hotspot
- Response Multi Input
- VLab