### PR TITLE
[BUG FIX] Handle quasi dupes during migration [MER-2954]

### DIFF
--- a/priv/repo/migrations/20240125204755_fix_revision_parts.exs
+++ b/priv/repo/migrations/20240125204755_fix_revision_parts.exs
@@ -2,7 +2,6 @@ defmodule Oli.Repo.Migrations.FixRevisionParts do
   use Ecto.Migration
 
   def change do
-
     # Extract the unique entries in a new table.  This will take records
     # like this:
     #

--- a/priv/repo/migrations/20240125204755_fix_revision_parts.exs
+++ b/priv/repo/migrations/20240125204755_fix_revision_parts.exs
@@ -2,12 +2,53 @@ defmodule Oli.Repo.Migrations.FixRevisionParts do
   use Ecto.Migration
 
   def change do
+
+    # Extract the unique entries in a new table.  This will take records
+    # like this:
+    #
+    # revision_id | part_id | grading_approach
+    # 1           | 1       | automatic
+    # 1           | 1       | NULL
+    # 1           | 1       | NULL
+    # 1           | 2       | NULL
+    # 1           | 2       | NULL
+    # 1           | 2       | NULL
+    # 1           | 2       | NULL
+    # 1           | 2       | NULL
+    # 1           | 2       | NULL
+    # 1           | 2       | NULL
+    #
+    # To:
+    # revision_id | part_id | grading_approach
+    # 1           | 1       | automatic
+    # 1           | 1       | NULL
+    # 1           | 2       | NULL
     execute """
     CREATE TABLE temp_revision_parts AS
     SELECT DISTINCT ON (revision_id, grading_approach, part_id) *
     FROM revision_parts;
     """
 
+    # Delete the duplicate entries that have a NULL grading_approach
+    # This will take records like this and delete the record with the NULL:
+    #
+    # revision_id | part_id | grading_approach
+    # 1           | 1       | automatic
+    # 1           | 1       | NULL
+    execute """
+    DELETE FROM temp_revision_parts
+    WHERE (revision_id, part_id) IN (
+        SELECT revision_id, part_id
+        FROM temp_revision_parts
+        GROUP BY revision_id, part_id
+        HAVING COUNT(*) > 1
+    )
+    AND grading_approach IS NULL;
+    """
+
+    # At this point we have a correctly structured copy of revision_parts, so
+    # we can backup the origin, drop its indices and rename the new table to
+    # to be revision_parts:
     execute """
     ALTER TABLE revision_parts RENAME TO backup_revision_parts;
     """
@@ -30,6 +71,7 @@ defmodule Oli.Repo.Migrations.FixRevisionParts do
 
     flush()
 
+    # Finally, add back in the indices on the new revision_parts table:
     create unique_index(:revision_parts, [:revision_id, :part_id, :grading_approach])
     create index(:revision_parts, [:revision_id])
   end


### PR DESCRIPTION
This updates that latest migration (which has only been applied to garbage heliotron) to account for a case of bad data as seen on ETX QA DB.

Basically there is a situation where for a handful of `part_id` and `revision_id` combinations there is one record with a `NULL` grading approach and another record with a non `NULL` grading approach (i.e. "manual" or "automatic").  This should have never been possible, and was probably due to an old bug that was fixed a while ago.  But this data situation prevents the unique index from being re-added (after we change all `NULL` values to "automatic").  

The solution is to add a step which identifies all pairs of revision_id and part_id which have more than 1 record.  Because of the previous indices, and the fact that we have deduped in the first step to eliminate all extra NULL records, this really leaves us with situations where there are exactly 2 records for the same revision_id and part_id, with one grading_approach as `NULL` and the other as non `NULL`.  We just need to delete the `NULL` ones before proceeding. 