### PR TITLE
[BUGFIX][MER-2916] Instructor view no additional activity summarization for scored activities

### DIFF
--- a/test/oli_web/live/delivery/instructor_dashboard/scored_activities/scored_activities_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/scored_activities/scored_activities_tab_test.exs
@@ -70,6 +70,12 @@ defmodule OliWeb.Delivery.InstructorDashboard.ScoredActivitiesTabTest do
 
     transformed_model =
       case activity_registration.slug do
+        "oli_multi_input" ->
+          %{
+            "authoring" => %{},
+            "inputs" => [%{"id" => "1458555427", "inputType" => "text", "partId" => "1"}]
+          }
+
         "oli_multiple_choice" ->
           %{choices: generate_choices(activity_revision.id)}
 
@@ -123,6 +129,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.ScoredActivitiesTabTest do
       context: context,
       part_attempts: [
         %{
+          id: part_attempt.id,
           part_id: part_attempt.part_id,
           response: part_attempt.response,
           score: activity_attempt.score,
@@ -328,6 +335,189 @@ defmodule OliWeb.Delivery.InstructorDashboard.ScoredActivitiesTabTest do
     }
   end
 
+  defp generate_multi_input_content(title) do
+    %{
+      "authoring" => %{
+        "parts" => [
+          %{
+            "gradingApproach" => "automatic",
+            "hints" => [
+              %{
+                "content" => [
+                  %{
+                    "children" => [%{"text" => ""}],
+                    "id" => "3144326996",
+                    "type" => "p"
+                  }
+                ],
+                "editor" => "slate",
+                "id" => "2324370830",
+                "textDirection" => "ltr"
+              }
+            ],
+            "id" => "1",
+            "outOf" => nil,
+            "responses" => [
+              %{
+                "feedback" => %{
+                  "content" => [
+                    %{
+                      "children" => [%{"text" => "Correct"}],
+                      "id" => "1443012830",
+                      "type" => "p"
+                    }
+                  ],
+                  "editor" => "slate",
+                  "id" => "4023967540",
+                  "textDirection" => "ltr"
+                },
+                "id" => "3595683503",
+                "rule" => "input = {1}",
+                "score" => 1
+              },
+              %{
+                "feedback" => %{
+                  "content" => [
+                    %{
+                      "children" => [%{"text" => "Incorrect"}],
+                      "id" => "862813719",
+                      "type" => "p"
+                    }
+                  ],
+                  "editor" => "slate",
+                  "id" => "409522953",
+                  "textDirection" => "ltr"
+                },
+                "id" => "2117868767",
+                "rule" => "input like {.*}",
+                "score" => 0
+              }
+            ],
+            "scoringStrategy" => "average"
+          }
+        ],
+        "previewText" => "Write NUMBER .",
+        "targeted" => [],
+        "transformations" => [
+          %{
+            "firstAttemptOnly" => true,
+            "id" => "273348963",
+            "operation" => "shuffle",
+            "path" => "choices"
+          }
+        ]
+      },
+      "bibrefs" => [],
+      "choices" => [],
+      "inputs" => [%{"id" => "1458555427", "inputType" => "text", "partId" => 1}],
+      "stem" => %{
+        "content" => [
+          %{
+            "children" => [
+              %{"text" => title},
+              %{
+                "children" => [%{"text" => ""}],
+                "id" => "763756970",
+                "type" => "input_ref"
+              },
+              %{"text" => "."}
+            ],
+            "id" => "1622099819",
+            "type" => "p"
+          }
+        ],
+        "id" => "3205611195"
+      },
+      "submitPerPart" => false
+    }
+  end
+
+  defp generate_likert_content(title) do
+    %{
+      "stem" => %{
+        "id" => "2028833010",
+        "content" => [
+          %{"id" => "280825708", "type" => "p", "children" => [%{"text" => title}]}
+        ]
+      },
+      "choices" => generate_choices("2028833010"),
+      "authoring" => %{
+        "parts" => [
+          %{
+            "id" => "1",
+            "hints" => [
+              %{
+                "id" => "540968727",
+                "content" => [
+                  %{"id" => "2256338253", "type" => "p", "children" => [%{"text" => ""}]}
+                ]
+              },
+              %{
+                "id" => "2627194758",
+                "content" => [
+                  %{"id" => "3013119256", "type" => "p", "children" => [%{"text" => ""}]}
+                ]
+              },
+              %{
+                "id" => "2413327578",
+                "content" => [
+                  %{"id" => "3742562774", "type" => "p", "children" => [%{"text" => ""}]}
+                ]
+              }
+            ],
+            "outOf" => nil,
+            "responses" => [
+              %{
+                "id" => "4122423546",
+                "rule" => "(!(input like {1968053412})) && (input like {1436663133})",
+                "score" => 1,
+                "feedback" => %{
+                  "id" => "685174561",
+                  "content" => [
+                    %{
+                      "id" => "2621700133",
+                      "type" => "p",
+                      "children" => [%{"text" => "Correct"}]
+                    }
+                  ]
+                }
+              },
+              %{
+                "id" => "3738563441",
+                "rule" => "input like {.*}",
+                "score" => 0,
+                "feedback" => %{
+                  "id" => "3796426513",
+                  "content" => [
+                    %{
+                      "id" => "1605260471",
+                      "type" => "p",
+                      "children" => [%{"text" => "Incorrect"}]
+                    }
+                  ]
+                }
+              }
+            ],
+            "gradingApproach" => "automatic",
+            "scoringStrategy" => "average"
+          }
+        ],
+        "correct" => [["1436663133"], "4122423546"],
+        "version" => 2,
+        "targeted" => [],
+        "previewText" => "",
+        "transformations" => [
+          %{
+            "id" => "1349799137",
+            "path" => "choices",
+            "operation" => "shuffle",
+            "firstAttemptOnly" => true
+          }
+        ]
+      }
+    }
+  end
+
   defp generate_choices(id),
     do: [
       %{
@@ -395,6 +585,8 @@ defmodule OliWeb.Delivery.InstructorDashboard.ScoredActivitiesTabTest do
     ## activities...
     mcq_reg = Oli.Activities.get_registration_by_slug("oli_multiple_choice")
     single_response_reg = Oli.Activities.get_registration_by_slug("oli_short_answer")
+    multi_input_reg = Oli.Activities.get_registration_by_slug("oli_multi_input")
+    likert_reg = Oli.Activities.get_registration_by_slug("oli_likert")
 
     mcq_activity_1_revision =
       insert(:revision,
@@ -432,6 +624,28 @@ defmodule OliWeb.Delivery.InstructorDashboard.ScoredActivitiesTabTest do
         activity_type_id: single_response_reg.id,
         title: "The Single Response question",
         content: generate_single_response_content("This is a single response question")
+      )
+
+    multi_input_activity_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.get_id_by_type("activity"),
+        objectives: %{
+          "1" => []
+        },
+        activity_type_id: multi_input_reg.id,
+        title: "The Multi Input question",
+        content: generate_multi_input_content("This is a multi input question")
+      )
+
+    likert_activity_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.get_id_by_type("activity"),
+        objectives: %{
+          "1" => []
+        },
+        activity_type_id: likert_reg.id,
+        title: "The Likert question",
+        content: generate_likert_content("This is a likert question")
       )
 
     ## graded pages (assessments)...
@@ -475,6 +689,18 @@ defmodule OliWeb.Delivery.InstructorDashboard.ScoredActivitiesTabTest do
               type: "activity-reference",
               children: [],
               activity_id: single_response_activity_revision.resource.id
+            },
+            %{
+              id: "3330767714",
+              type: "activity-reference",
+              children: [],
+              activity_id: multi_input_activity_revision.resource.id
+            },
+            %{
+              id: "3330767714",
+              type: "activity-reference",
+              children: [],
+              activity_id: likert_activity_revision.resource.id
             }
           ],
           bibrefs: [],
@@ -614,6 +840,16 @@ defmodule OliWeb.Delivery.InstructorDashboard.ScoredActivitiesTabTest do
 
     insert(:project_resource, %{
       project_id: project.id,
+      resource_id: multi_input_activity_revision.resource_id
+    })
+
+    insert(:project_resource, %{
+      project_id: project.id,
+      resource_id: likert_activity_revision.resource_id
+    })
+
+    insert(:project_resource, %{
+      project_id: project.id,
       resource_id: page_1_revision.resource_id
     })
 
@@ -715,6 +951,20 @@ defmodule OliWeb.Delivery.InstructorDashboard.ScoredActivitiesTabTest do
       publication: publication,
       resource: single_response_activity_revision.resource,
       revision: single_response_activity_revision,
+      author: author
+    })
+
+    insert(:published_resource, %{
+      publication: publication,
+      resource: multi_input_activity_revision.resource,
+      revision: multi_input_activity_revision,
+      author: author
+    })
+
+    insert(:published_resource, %{
+      publication: publication,
+      resource: likert_activity_revision.resource,
+      revision: likert_activity_revision,
       author: author
     })
 
@@ -858,6 +1108,8 @@ defmodule OliWeb.Delivery.InstructorDashboard.ScoredActivitiesTabTest do
       mcq_activity_1: mcq_activity_1_revision,
       mcq_activity_2: mcq_activity_2_revision,
       single_response_activity: single_response_activity_revision,
+      multi_input_activity: multi_input_activity_revision,
+      likert_activity: likert_activity_revision,
       page_1: page_1_revision,
       page_2: page_2_revision,
       page_3: page_3_revision,
@@ -966,7 +1218,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.ScoredActivitiesTabTest do
       {:ok, view, _html} = live(conn, live_view_scored_activities_route(section.slug))
 
       assert has_element?(view, "h4", "Scored Activities")
-      assert has_element?(view, "p", "None exist")
+      assert has_element?(view, "p", "There are no activities to show")
     end
   end
 
@@ -1046,7 +1298,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.ScoredActivitiesTabTest do
              |> has_element?()
 
       assert view
-             |> element("p", "None exist")
+             |> element("p", "There are no activities to show")
              |> has_element?()
     end
   end
@@ -1068,7 +1320,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.ScoredActivitiesTabTest do
         )
 
       assert has_element?(view, "h4", "Orphaned Page")
-      assert has_element?(view, "p", "None exist")
+      assert has_element?(view, "p", "There are no activities to show")
     end
 
     @tag :skip
@@ -1289,7 +1541,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.ScoredActivitiesTabTest do
       # and the question details are rendered
       # including the frequency per choice
       assert selected_activity_model =~
-               "{\"choices\":[{\"content\":[{\"children\":[{\"text\":\"Choice 1 for #{mcq_activity_1.id}\"}],\"id\":\"1866911747\",\"type\":\"p\"}],\"frequency\":1,\"id\":\"id_for_option_a\"},{\"content\":[{\"children\":[{\"text\":\"Choice 2 for #{mcq_activity_1.id}\"}],\"id\":\"3926142114\",\"type\":\"p\"}],\"frequency\":1,\"id\":\"id_for_option_b\"},{\"content\":[{\"children\":[{\"text\":\"Blank attempt (user submitted assessment without selecting any choice for this activity)\"}],\"type\":\"p\"}],\"frequency\":1}]}"
+               "{\"choices\":[{\"content\":[{\"children\":[{\"text\":\"Blank attempt (user submitted assessment without selecting any choice for this activity)\"}],\"type\":\"p\"}],\"frequency\":1},{\"content\":[{\"children\":[{\"text\":\"Choice 1 for #{mcq_activity_1.id}\"}],\"id\":\"1866911747\",\"type\":\"p\"}],\"frequency\":1,\"id\":\"id_for_option_a\"},{\"content\":[{\"children\":[{\"text\":\"Choice 2 for #{mcq_activity_1.id}\"}],\"id\":\"3926142114\",\"type\":\"p\"}],\"frequency\":1,\"id\":\"id_for_option_b\"}]}"
     end
 
     test "single response details get rendered correctly when activity is selected",
@@ -1373,6 +1625,99 @@ defmodule OliWeb.Delivery.InstructorDashboard.ScoredActivitiesTabTest do
 
       assert selected_activity_model =~
                "\"responses\":[{\"text\":\"This is an incorrect answer from student 2\",\"user_name\":\"Di Maria, Angel\"},{\"text\":\"This is the second answer (correct) from student 2\",\"user_name\":\"Di Maria, Angel\"},{\"text\":\"This is the first answer (correct) from the GOAT\",\"user_name\":\"Messi, Lionel\"}]"
+    end
+
+    test "multi input activity details get rendered correctly when activity is selected",
+         %{
+           conn: conn,
+           section: section,
+           page_1: page_1,
+           student_1: student_1,
+           multi_input_activity: multi_input_activity,
+           project: project,
+           publication: publication
+         } do
+      set_activity_attempt(
+        page_1,
+        multi_input_activity,
+        student_1,
+        section,
+        project.id,
+        publication.id,
+        "Answer for input 1",
+        true
+      )
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_scored_activities_route(section.slug, %{
+            assessment_id: page_1.id
+          })
+        )
+
+      # check that the multi input details render correctly
+      _selected_activity_model =
+        view
+        |> render()
+        |> Floki.parse_fragment!()
+        |> Floki.find(~s{oli-multi-input-authoring})
+        |> Floki.attribute("model")
+        |> hd
+
+      assert has_element?(
+               view,
+               ~s(div[role="activity_title"]),
+               "Question details"
+             )
+    end
+
+    test "likert activity details get rendered correctly when activity is selected",
+         %{
+           conn: conn,
+           section: section,
+           page_1: page_1,
+           student_1: student_1,
+           likert_activity: likert_activity,
+           project: project,
+           publication: publication
+         } do
+      set_activity_attempt(
+        page_1,
+        likert_activity,
+        student_1,
+        section,
+        project.id,
+        publication.id,
+        "id_for_option_a",
+        true
+      )
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_scored_activities_route(section.slug, %{
+            assessment_id: page_1.id
+          })
+        )
+
+      # check that the likert details render correctly
+      selected_activity_model =
+        view
+        |> render()
+        |> Floki.parse_fragment!()
+        |> Floki.find(~s{oli-likert-authoring})
+        |> Floki.attribute("model")
+        |> hd
+
+      assert has_element?(
+               view,
+               ~s(div[role="activity_title"]),
+               "Question details"
+             )
+
+      assert selected_activity_model =~
+               "{\"activityTitle\":\"The Likert question\",\"authoring\":{\"correct\":[[\"1436663133\"],\"4122423546\"],\"parts\":[{\"gradingApproach\":\"automatic\",\"hints\":[{\"content\":[{\"children\":[{\"text\":\"\"}],\"id\":\"2256338253\",\"type\":\"p\"}],\"id\":\"540968727\"},{\"content\":[{\"children\":[{\"text\":\"\"}],\"id\":\"3013119256\",\"type\":\"p\"}],\"id\":\"2627194758\"},{\"content\":[{\"children\":[{\"text\":\"\"}],\"id\":\"3742562774\",\"type\":\"p\"}],\"id\":\"2413327578\"}],\"id\":\"1\",\"outOf\":null,\"responses\":[{\"feedback\":{\"content\":[{\"children\":[{\"text\":\"Correct\"}],\"id\":\"2621700133\",\"type\":\"p\"}],\"id\":\"685174561\"},\"id\":\"4122423546\",\"rule\":\"(!(input like {1968053412})) && (input like {1436663133})\",\"score\":1},{\"feedback\":{\"content\":[{\"children\":[{\"text\":\"Incorrect\"}],\"id\":\"1605260471\",\"type\":\"p\"}],\"id\":\"3796426513\"},\"id\":\"3738563441\",\"rule\":\"input like {.*}\",\"score\":0}],\"scoringStrategy\":\"average\"}],\"previewText\":\"\",\"targeted\":[],\"transformations\":[{\"firstAttemptOnly\":true,\"id\":\"1349799137\",\"operation\":\"shuffle\",\"path\":\"choices\"}],\"version\":2},\"choices\":[{\"content\":[{\"children\":[{\"text\":\"Choice 1 for 2028833010\"}],\"id\":\"1866911747\",\"type\":\"p\"}],\"frequency\":1,\"id\":\"id_for_option_a\"},{\"content\":[{\"children\":[{\"text\":\"Choice 2 for 2028833010\"}],\"id\":\"3926142114\",\"type\":\"p\"}],\"frequency\":0,\"id\":\"id_for_option_b\"}],\"stem\":{\"content\":[{\"children\":[{\"text\":\"This is a likert question\"}],\"id\":\"280825708\",\"type\":\"p\"}],\"id\":\"2028833010\"}}"
     end
 
     test "single response details get rendered for a section with analytics_version :v2 but not for :v1",
@@ -1518,6 +1863,89 @@ defmodule OliWeb.Delivery.InstructorDashboard.ScoredActivitiesTabTest do
         |> hd
 
       assert selected_activity_model =~ ~s{"frequency":1,"id":"id_for_option_a"}
+    end
+
+    test "multi input details get not rendered for a section with analytics_version :v1",
+         %{
+           conn: conn,
+           section_v1: section_v1,
+           page_1: page_1,
+           student_1: student_1,
+           multi_input_activity: multi_input_activity,
+           project: project,
+           publication: publication
+         } do
+      ## section with analytics_version :v1
+      set_activity_attempt(
+        page_1,
+        multi_input_activity,
+        student_1,
+        section_v1,
+        project.id,
+        publication.id,
+        "Incorrect answer",
+        false
+      )
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_scored_activities_route(section_v1.slug, %{
+            assessment_id: page_1.id
+          })
+        )
+
+      selected_activity_model =
+        view
+        |> render()
+        |> Floki.parse_fragment!()
+        |> Floki.find(~s{oli-multi-input-authoring})
+        |> Floki.attribute("model")
+        |> hd
+
+      refute selected_activity_model =~ "Incorrect answer"
+    end
+
+    test "likert activity details get not rendered for a section with analytics_version :v1",
+         %{
+           conn: conn,
+           section_v1: section_v1,
+           page_1: page_1,
+           student_1: student_1,
+           likert_activity: likert_activity,
+           project: project,
+           publication: publication
+         } do
+      ## section with analytics_version :v1
+      set_activity_attempt(
+        page_1,
+        likert_activity,
+        student_1,
+        section_v1,
+        project.id,
+        publication.id,
+        "id_for_option_a",
+        false
+      )
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_scored_activities_route(section_v1.slug, %{
+            assessment_id: page_1.id
+          })
+        )
+
+      selected_activity_model =
+        view
+        |> render()
+        |> Floki.parse_fragment!()
+        |> Floki.find(~s{oli-likert-authoring})
+        |> Floki.attribute("model")
+        |> hd
+
+      assert selected_activity_model =~ ~s{"id":"id_for_option_a"}
+      refute selected_activity_model =~ ~s{"frequency":}
     end
 
     test "question details responds to user click on an activity", %{


### PR DESCRIPTION
[MER-2916](https://eliterate.atlassian.net/browse/MER-2916)

This PR adds support to show response details for rendered activities in the `Scored Activities` tab. 

Activity response details are added for `Multi input activity` and `Likert activity`. 

- Multi Input Activity

![Captura de pantalla 2024-01-26 a la(s) 20 32 45](https://github.com/Simon-Initiative/oli-torus/assets/16328384/48e884af-d9de-4dbc-8c94-fd16f35088f8)

- Likert Activity

![Captura de pantalla 2024-01-26 a la(s) 20 24 18](https://github.com/Simon-Initiative/oli-torus/assets/16328384/193b9c77-40fb-4369-8a38-9975b9a00120)


[MER-2916]: https://eliterate.atlassian.net/browse/MER-2916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ