### PR TITLE
[NG23-64] Up next showing wrong week

### DIFF
--- a/lib/oli_web/components/delivery/utils.ex
+++ b/lib/oli_web/components/delivery/utils.ex
@@ -296,16 +296,26 @@ defmodule OliWeb.Components.Delivery.Utils do
   end
 
   @doc """
-  Returns the course week number of a resource based on the section start date
+  Returns the course week number of a resource based on the section start date.
+  It considers that weeks start on Sunday, regardless of the section start date that could be any day of the week.
   """
-  def week_number(_section_start_date, nil), do: "not yet scheduled"
-  def week_number(nil, _), do: "not yet scheduled"
-  def week_number(_section_start_date, "not yet scheduled"), do: "not yet scheduled"
 
-  def week_number(section_start_datetime, resource_datetime) do
+  def week_number(section_start_datetime, resource_datetime, week_start_date \\ :sunday)
+  def week_number(_section_start_datetime, nil, _week_start_date), do: "not yet scheduled"
+  def week_number(nil, _, _week_start_date), do: "not yet scheduled"
+
+  def week_number(_section_start_datetime, "not yet scheduled", _week_start_date),
+    do: "not yet scheduled"
+
+  def week_number(section_start_datetime, resource_datetime, week_start_date) do
+    course_first_sunday =
+      section_start_datetime
+      |> DateTime.to_date()
+      |> Date.beginning_of_week(week_start_date)
+
     case Date.diff(
            DateTime.to_date(resource_datetime),
-           DateTime.to_date(section_start_datetime)
+           course_first_sunday
          ) do
       0 ->
         1

--- a/test/oli/delivery/sections_test.exs
+++ b/test/oli/delivery/sections_test.exs
@@ -792,7 +792,7 @@ defmodule Oli.Delivery.SectionsTest do
         nil,
         %{
           slug: "section_#{UUID.uuid4()}",
-          start_date: ~U[2023-01-27 23:59:59Z]
+          start_date: ~U[2023-01-24 23:59:59Z]
         },
         section_tag: :section
       )
@@ -814,21 +814,21 @@ defmodule Oli.Delivery.SectionsTest do
                      %{
                        id: scheduled_resources[page3.resource_id].id,
                        scheduling_type: "due_by",
-                       start_date: "2023-02-03",
-                       end_date: "2023-02-06",
+                       start_date: "2023-01-25",
+                       end_date: "2023-01-27",
                        manually_scheduled: true
                      },
                      %{
                        id: scheduled_resources[page4.resource_id].id,
                        scheduling_type: "due_by",
-                       start_date: "2023-02-03",
-                       end_date: "2023-02-06",
+                       start_date: "2023-02-01",
+                       end_date: "2023-02-04",
                        manually_scheduled: true
                      },
                      %{
                        id: scheduled_resources[page5.resource_id].id,
                        scheduling_type: "due_by",
-                       start_date: "2023-02-05",
+                       start_date: "2023-02-06",
                        end_date: "2023-02-08",
                        manually_scheduled: true
                      }
@@ -863,50 +863,61 @@ defmodule Oli.Delivery.SectionsTest do
 
       assert [
                {
-                 {2, 2023},
+                 {1, 2023},
                  [
                    {1,
                     [
-                      {{~U[2023-02-03 23:59:59Z], ~U[2023-02-06 23:59:59Z]},
+                      {{~U[2023-01-25 23:59:59Z], ~U[2023-01-27 23:59:59Z]},
                        %{
                          {"Unit 1", true} => [
                            %Oli.Delivery.Sections.SectionResource{
                              scheduling_type: :due_by,
                              manually_scheduled: true,
-                             start_date: ~U[2023-02-03 23:59:59Z],
-                             end_date: ~U[2023-02-06 23:59:59Z],
+                             start_date: ~U[2023-01-25 23:59:59Z],
+                             end_date: ~U[2023-01-27 23:59:59Z],
                              resource_id: ^page3_resource_id,
                              title: "Assessment 3"
-                           },
-                           %Oli.Delivery.Sections.SectionResource{
-                             scheduling_type: :due_by,
-                             manually_scheduled: true,
-                             start_date: ~U[2023-02-03 23:59:59Z],
-                             end_date: ~U[2023-02-06 23:59:59Z],
-                             resource_id: ^page4_resource_id,
-                             title: "Assessment 4"
-                           }
-                         ]
-                       }}
-                    ]},
-                   {2,
-                    [
-                      {{~U[2023-02-05 23:59:59Z], ~U[2023-02-08 23:59:59Z]},
-                       %{
-                         {"Unit 1", true} => [
-                           %Oli.Delivery.Sections.SectionResource{
-                             scheduling_type: :due_by,
-                             manually_scheduled: true,
-                             start_date: ~U[2023-02-05 23:59:59Z],
-                             end_date: ~U[2023-02-08 23:59:59Z],
-                             resource_id: ^page5_resource_id,
-                             title: "Assessment 5"
                            }
                          ]
                        }}
                     ]}
                  ]
-               }
+               },
+               {{2, 2023},
+                [
+                  {2,
+                   [
+                     {{~U[2023-02-01 23:59:59Z], ~U[2023-02-04 23:59:59Z]},
+                      %{
+                        {"Unit 1", true} => [
+                          %Oli.Delivery.Sections.SectionResource{
+                            scheduling_type: :due_by,
+                            manually_scheduled: true,
+                            start_date: ~U[2023-02-01 23:59:59Z],
+                            end_date: ~U[2023-02-04 23:59:59Z],
+                            resource_id: ^page4_resource_id,
+                            title: "Assessment 4"
+                          }
+                        ]
+                      }}
+                   ]},
+                  {3,
+                   [
+                     {{~U[2023-02-06 23:59:59Z], ~U[2023-02-08 23:59:59Z]},
+                      %{
+                        {"Unit 1", true} => [
+                          %Oli.Delivery.Sections.SectionResource{
+                            scheduling_type: :due_by,
+                            manually_scheduled: true,
+                            start_date: ~U[2023-02-06 23:59:59Z],
+                            end_date: ~U[2023-02-08 23:59:59Z],
+                            resource_id: ^page5_resource_id,
+                            title: "Assessment 5"
+                          }
+                        ]
+                      }}
+                   ]}
+                ]}
              ] =
                Sections.get_ordered_schedule(section)
     end


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/NG23-64) to the ticket

Weeks were being counted starting on the section start date as the first day of the week instead of starting on a Sunday.
This made some assessments from the previous week were being listed (for example, if the Up Next was being visited on a Monday and the Section start date was not a Sunday).


## Before
![image](https://github.com/Simon-Initiative/oli-torus/assets/74839302/2e842949-2579-4a5a-ac5f-4b447e27608c)


## After
![image](https://github.com/Simon-Initiative/oli-torus/assets/74839302/6d63ae4a-071d-49a0-8463-aa8b7353689f)

