### PR TITLE
[Enhancement] Header padding [MER-2956] 

### DIFF
--- a/assets/css/bootstrap-shims.css
+++ b/assets/css/bootstrap-shims.css
@@ -531,6 +531,9 @@ table tr {
 table td {
   @apply border-r p-2 dark:border-gray-600;
 }
+table th {
+  @apply p-2;
+}
 
 table.table-striped tbody tr:nth-child(even) {
   @apply bg-gray-100 dark:bg-gray-700;


### PR DESCRIPTION
Added an 0.5rem padding to table headers (not inside a thead), to match table cells.

Before:
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/4dd7caa4-120f-49f1-9beb-053fe46553f7)


After: 
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/4be9e18f-265d-4251-897b-f3a94c09a4ec)
