### PR TITLE
[MER-2953] Upgrade user edit form to be a form component

### DIFF
--- a/lib/oli/accounts.ex
+++ b/lib/oli/accounts.ex
@@ -294,45 +294,20 @@ defmodule Oli.Accounts do
     end
   end
 
-  def update_user_from_admin(%User{} = user, attrs) do
-    user
-    |> User.update_changeset_for_admin(attrs)
-    |> Repo.update()
-    |> case do
+  @doc """
+  Updates a user from an admin.
+  """
+  def update_user_from_admin(changeset) do
+    case Repo.update(changeset) do
       {:ok, %User{id: user_id}} = res ->
         AccountLookupCache.delete("user_#{user_id}")
 
         res
 
       error ->
-        handle_user_changeset_errors(error)
-    end
-  end
-
-  defp handle_user_changeset_errors(
-         {:error, %Ecto.Changeset{changes: %{independent_learner: true}} = _changeset} = _error
-       ) do
-    {:error, :email_already_been_taken_by_independent_learner,
-     "Email has already been taken by another independent learner"}
-  end
-
-  defp handle_user_changeset_errors({:error, %Ecto.Changeset{errors: errors} = changeset} = error) do
-    case Keyword.get(errors, :email) do
-      {"has already been taken" = message, _constraint} ->
-        {:error, :email_already_been_taken, "Email #{changeset.changes.email} #{message}"}
-
-      {"can't be blank" = message, _constraint} ->
-        {:error, :email_cannot_be_blank, "Email #{message}"}
-
-      {"has invalid format" = message, _constraint} ->
-        {:error, :email_invalid_format, "Email #{changeset.changes.email} #{message}"}
-
-      _other_constraints ->
         error
     end
   end
-
-  defp handle_user_changeset_errors(error), do: error
 
   @doc """
   Deletes a user.

--- a/lib/oli/accounts/schemas/user.ex
+++ b/lib/oli/accounts/schemas/user.ex
@@ -282,9 +282,6 @@ defmodule Oli.Accounts.User do
 
         guest = Map.get(changes, :guest) || Map.get(data, :guest)
 
-        independent_learner |> IO.inspect(label: "independent_learner")
-        !guest |> IO.inspect(label: "!guest")
-        (independent_learner && !guest) |> IO.inspect(label: "TOTAL")
         independent_learner && !guest
 
       _ ->

--- a/lib/oli/accounts/schemas/user.ex
+++ b/lib/oli/accounts/schemas/user.ex
@@ -172,7 +172,7 @@ defmodule Oli.Accounts.User do
 
   def update_changeset_for_admin(%__MODULE__{} = user, attrs \\ %{}) do
     user
-    |> cast(attrs, [:given_name, :family_name])
+    |> cast(attrs, [:given_name, :family_name, :independent_learner, :can_create_sections])
     |> validate_required([:given_name, :family_name])
     |> maybe_name_from_given_and_family()
     |> validate_required_if([:email], &is_independent_learner_not_guest/1)

--- a/lib/oli/accounts/schemas/user.ex
+++ b/lib/oli/accounts/schemas/user.ex
@@ -172,10 +172,9 @@ defmodule Oli.Accounts.User do
 
   def update_changeset_for_admin(%__MODULE__{} = user, attrs \\ %{}) do
     user
-    |> cast(attrs, [:given_name, :family_name, :independent_learner, :can_create_sections])
+    |> cast(attrs, [:given_name, :family_name, :independent_learner, :can_create_sections, :email])
     |> validate_required([:given_name, :family_name])
     |> maybe_name_from_given_and_family()
-    |> validate_required_if([:email], &is_independent_learner_not_guest/1)
     |> lowercase_email()
     |> pow_user_id_field_changeset(attrs)
     |> unique_constraint(:email,
@@ -283,6 +282,9 @@ defmodule Oli.Accounts.User do
 
         guest = Map.get(changes, :guest) || Map.get(data, :guest)
 
+        independent_learner |> IO.inspect(label: "independent_learner")
+        !guest |> IO.inspect(label: "!guest")
+        (independent_learner && !guest) |> IO.inspect(label: "TOTAL")
         independent_learner && !guest
 
       _ ->

--- a/lib/oli/accounts/schemas/user.ex
+++ b/lib/oli/accounts/schemas/user.ex
@@ -170,11 +170,18 @@ defmodule Oli.Accounts.User do
     |> maybe_name_from_given_and_family()
   end
 
-  def update_changeset_for_admin(user, attrs \\ %{}) do
+  def update_changeset_for_admin(%__MODULE__{} = user, attrs \\ %{}) do
     user
-    |> noauth_changeset(attrs)
+    |> cast(attrs, [:given_name, :family_name])
+    |> validate_required([:given_name, :family_name])
+    |> maybe_name_from_given_and_family()
+    |> validate_required_if([:email], &is_independent_learner_not_guest/1)
+    |> lowercase_email()
     |> pow_user_id_field_changeset(attrs)
-    |> unique_constraint(:email, name: :users_email_independent_learner_index)
+    |> unique_constraint(:email,
+      name: :users_email_independent_learner_index,
+      message: "Email has already been taken by another independent learner"
+    )
   end
 
   @doc """

--- a/lib/oli/utils.ex
+++ b/lib/oli/utils.ex
@@ -179,7 +179,10 @@ defmodule Oli.Utils do
   end
 
   def lowercase_email(changeset) do
-    Ecto.Changeset.update_change(changeset, :email, &String.downcase/1)
+    case changeset.changes[:email] do
+      nil -> changeset
+      _ -> Ecto.Changeset.update_change(changeset, :email, &String.downcase/1)
+    end
   end
 
   def validate_required_if(changeset, fields, condition) do

--- a/lib/oli_web/components/common.ex
+++ b/lib/oli_web/components/common.ex
@@ -259,6 +259,8 @@ defmodule OliWeb.Components.Common do
                 multiple pattern placeholder readonly required rows size step)
   )
 
+  attr(:error_position, :atom, default: :bottom, values: [:top, :bottom])
+
   slot(:inner_block)
 
   def input(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
@@ -437,6 +439,7 @@ defmodule OliWeb.Components.Common do
 
     ~H"""
     <div class={@group_class} phx-feedback-for={@name}>
+      <.error :for={msg <- @errors} :if={@error_position == :top}><%= msg %></.error>
       <input
         type={@type}
         name={@name}
@@ -447,7 +450,7 @@ defmodule OliWeb.Components.Common do
         {@rest}
       />
       <.label :if={@label} class={@label_class} for={@id}><%= @label %></.label>
-      <.error :for={msg <- @errors}><%= msg %></.error>
+      <.error :for={msg <- @errors} :if={@error_position == :bottom}><%= msg %></.error>
     </div>
     """
   end

--- a/lib/oli_web/live/users/user_detail_view.ex
+++ b/lib/oli_web/live/users/user_detail_view.ex
@@ -23,13 +23,6 @@ defmodule OliWeb.Users.UsersDetailView do
   alias OliWeb.Router.Helpers, as: Routes
   alias OliWeb.Users.Actions
 
-  @email_changeset_errors [
-    :email_already_been_taken,
-    :email_cannot_be_blank,
-    :email_invalid_format,
-    :email_already_been_taken_by_independent_learner
-  ]
-
   defp set_breadcrumbs(user) do
     OliWeb.Admin.AdminView.breadcrumb()
     |> OliWeb.Users.UsersView.breadcrumb()
@@ -70,21 +63,24 @@ defmodule OliWeb.Users.UsersDetailView do
            breadcrumbs: set_breadcrumbs(user),
            user: user,
            csrf_token: csrf_token,
-           changeset: user_changeset(user),
+           form: user_form(user),
            user_lti_params: LtiParams.all_user_lti_params(user.id),
            enrolled_sections: enrolled_sections,
-           disabled_edit: true
+           disabled_edit: true,
+           user_name: user.name
          )}
     end
   end
 
   attr(:breadcrumbs, :any)
-  attr(:changeset, :map)
+  attr(:form, :map)
   attr(:csrf_token, :any)
   attr(:modal, :any, default: nil)
   attr(:title, :string, default: "User Details")
   attr(:user, :map, default: nil)
   attr(:disabled_edit, :boolean, default: true)
+  attr(:disabled_submit, :boolean, default: false)
+  attr(:user_name, :string)
 
   def render(assigns) do
     ~H"""
@@ -92,37 +88,34 @@ defmodule OliWeb.Users.UsersDetailView do
       <%= render_modal(assigns) %>
       <Groups.render>
         <Group.render label="Details" description="User details">
-          <.form for={@changeset} phx-change="change" phx-submit="submit" autocomplete="off">
+          <.form for={@form} phx-change="change" phx-submit="submit" autocomplete="off">
             <ReadOnly.render label="Sub" value={@user.sub} />
-            <ReadOnly.render label="Name" value={@user.name} />
+            <ReadOnly.render label="Name" value={@user_name} />
             <div class="form-group">
-              <label for="given_name">Given Name</label>
-              <input
-                value={Map.merge(@changeset.data, @changeset.changes).given_name}
-                id="given_name"
-                name="user[given_name]"
+              <.input
+                field={@form[:given_name]}
+                label="Given Name"
                 class="form-control"
                 disabled={@disabled_edit}
+                error_position={:top}
               />
             </div>
             <div class="form-group">
-              <label for="family_name">Last Name</label>
-              <input
-                value={Map.merge(@changeset.data, @changeset.changes).family_name}
-                id="family_name"
-                name="user[family_name]"
+              <.input
+                field={@form[:family_name]}
+                label="Last Name"
                 class="form-control"
                 disabled={@disabled_edit}
+                error_position={:top}
               />
             </div>
             <div class="form-group">
-              <label for="email">Email</label>
-              <input
-                value={Map.merge(@changeset.data, @changeset.changes).email}
-                id="email"
-                name="user[email]"
+              <.input
+                field={@form[:email]}
+                label="Email"
                 class="form-control"
                 disabled={@disabled_edit}
+                error_position={:top}
               />
             </div>
             <ReadOnly.render label="Guest" value={boolean(@user.guest)} />
@@ -133,17 +126,13 @@ defmodule OliWeb.Users.UsersDetailView do
               />
             <% end %>
             <div class="form-control mb-3">
-              <input
-                id="independent_learner"
-                name="user[independent_learner]"
+              <.input
+                field={@form[:independent_learner]}
                 type="checkbox"
+                label="Independent Learner"
                 class="form-check-input"
-                checked={fetch_field(@changeset, :independent_learner)}
                 disabled={@disabled_edit}
               />
-              <label for="independent_learner" class="form-check-label mr-2">
-                Independent Learner
-              </label>
             </div>
             <section class="mb-2">
               <heading>
@@ -153,17 +142,13 @@ defmodule OliWeb.Users.UsersDetailView do
                 </small>
               </heading>
               <div class="form-control">
-                <input
-                  id="can_create_sections"
-                  name="user[can_create_sections]"
+                <.input
+                  field={@form[:can_create_sections]}
                   type="checkbox"
+                  label="Can Create Sections"
                   class="form-check-input"
-                  checked={fetch_field(@changeset, :can_create_sections)}
                   disabled={@disabled_edit}
                 />
-                <label for="can_create_sections" class="form-check-label mr-2">
-                  Can Create Sections
-                </label>
               </div>
             </section>
             <ReadOnly.render label="Research Opt Out" value={boolean(@user.research_opt_out)} />
@@ -174,7 +159,13 @@ defmodule OliWeb.Users.UsersDetailView do
             <ReadOnly.render label="Created" value={render_date(@user, :inserted_at, @ctx)} />
             <ReadOnly.render label="Last Updated" value={render_date(@user, :updated_at, @ctx)} />
             <%= unless @disabled_edit do %>
-              <button type="submit" class="float-right btn btn-md btn-primary mt-2">Save</button>
+              <button
+                type="submit"
+                class="float-right btn btn-md btn-primary mt-2"
+                disabled={@disabled_submit}
+              >
+                Save
+              </button>
             <% end %>
           </.form>
           <%= if @disabled_edit do %>
@@ -248,11 +239,7 @@ defmodule OliWeb.Users.UsersDetailView do
     {:noreply, show_modal(socket, modal, modal_assigns: modal_assigns)}
   end
 
-  def handle_event(
-        "confirm_email",
-        _,
-        socket
-      ) do
+  def handle_event("confirm_email", _, socket) do
     email_confirmed_at = DateTime.truncate(DateTime.utc_now(), :second)
 
     case Accounts.update_user(socket.assigns.user, %{email_confirmed_at: email_confirmed_at}) do
@@ -268,9 +255,7 @@ defmodule OliWeb.Users.UsersDetailView do
   end
 
   def handle_event("show_lock_account_modal", _, socket) do
-    modal_assigns = %{
-      user: socket.assigns.user
-    }
+    modal_assigns = %{user: socket.assigns.user}
 
     modal = fn assigns ->
       ~H"""
@@ -281,11 +266,7 @@ defmodule OliWeb.Users.UsersDetailView do
     {:noreply, show_modal(socket, modal, modal_assigns: modal_assigns)}
   end
 
-  def handle_event(
-        "lock_account",
-        %{"id" => id},
-        socket
-      ) do
+  def handle_event("lock_account", %{"id" => id}, socket) do
     user = user_with_platform_roles(id)
     UserContext.lock(user)
 
@@ -310,11 +291,7 @@ defmodule OliWeb.Users.UsersDetailView do
     {:noreply, show_modal(socket, modal, modal_assigns: modal_assigns)}
   end
 
-  def handle_event(
-        "unlock_account",
-        %{"id" => id},
-        socket
-      ) do
+  def handle_event("unlock_account", %{"id" => id}, socket) do
     user = user_with_platform_roles(id)
     UserContext.unlock(user)
 
@@ -339,11 +316,7 @@ defmodule OliWeb.Users.UsersDetailView do
     {:noreply, show_modal(socket, modal, modal_assigns: modal_assigns)}
   end
 
-  def handle_event(
-        "delete_account",
-        %{"id" => id},
-        socket
-      ) do
+  def handle_event("delete_account", %{"id" => id}, socket) do
     user = user_with_platform_roles(id)
 
     case Accounts.delete_user(user) do
@@ -359,23 +332,35 @@ defmodule OliWeb.Users.UsersDetailView do
   end
 
   def handle_event("change", %{"user" => params}, socket) do
-    {:noreply,
-     assign(socket, changeset: user_changeset(socket.assigns.user, cast_params(params)))}
+    form = user_form(socket.assigns.user, params)
+
+    socket =
+      socket
+      |> assign(form: form)
+      |> assign(disabled_submit: !Enum.empty?(form.errors))
+      |> assign(user_name: "#{params["given_name"]} #{params["family_name"]}")
+
+    {:noreply, socket}
   end
 
   def handle_event("submit", %{"user" => params}, socket) do
-    with {:ok, user} <- Accounts.update_user_from_admin(socket.assigns.user, cast_params(params)) do
-      {:noreply,
-       socket
-       |> put_flash(:info, "User successfully updated.")
-       |> assign(user: user, changeset: user_changeset(user, params), disabled_edit: true)}
-    else
-      {:error, errors, message}
-      when errors in @email_changeset_errors ->
-        {:noreply, put_flash(socket, :error, message)}
+    case Accounts.update_user_from_admin(user_form(socket.assigns.user, params).source) do
+      {:ok, user} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "User successfully updated.")
+         |> assign(user: user)
+         |> assign(form: user_form(user, params))
+         |> assign(disabled_edit: true)
+         |> assign(user_name: "#{params["given_name"]} #{params["family_name"]}")}
 
-      {:error, _error} ->
-        {:noreply, put_flash(socket, :error, "User couldn't be updated.")}
+      {:error, error} ->
+        form = to_form(error)
+
+        {:noreply,
+         socket
+         |> assign(form: form)
+         |> assign(disabled_submit: !Enum.empty?(form.errors))}
     end
   end
 
@@ -383,19 +368,15 @@ defmodule OliWeb.Users.UsersDetailView do
     {:noreply, socket |> assign(disabled_edit: false)}
   end
 
-  defp cast_params(params) do
-    params
-    |> Map.put("independent_learner", if(params["independent_learner"], do: true, else: false))
-    |> Map.put("can_create_sections", if(params["can_create_sections"], do: true, else: false))
-  end
-
   defp user_with_platform_roles(id) do
     Accounts.get_user(id, preload: [:platform_roles])
   end
 
-  defp user_changeset(user, attrs \\ %{}) do
-    User.noauth_changeset(user, attrs)
+  defp user_form(user, attrs \\ %{}) do
+    user
+    |> User.update_changeset_for_admin(attrs)
     |> Map.put(:action, :update)
+    |> to_form()
   end
 
   defp add_necessary_information(sections, user) do

--- a/test/oli/accounts/user_test.exs
+++ b/test/oli/accounts/user_test.exs
@@ -1,0 +1,81 @@
+defmodule Oli.Accounts.UserTest do
+  alias Oli.Accounts
+  use Oli.DataCase
+  alias Oli.Accounts.User
+  import Oli.Factory
+
+  describe "update_changeset_for_admin/2" do
+    setup do
+      user =
+        insert(:user,
+          name: "CurrentName",
+          given_name: "CurrentGivenName",
+          family_name: "CurrentFamilyName",
+          email: "CurrentEmail@oli.com",
+          independent_learner: true,
+          can_create_sections: true,
+          guest: false
+        )
+
+      {:ok, %{user: user}}
+    end
+
+    test "success: admin can update a user with valid values", %{user: user} do
+      attrs =
+        %{
+          given_name: "UpdatedGivenName",
+          family_name: "UpdatedFamilyName",
+          email: "UpdatedEmail@oli.com",
+          independent_learner: false,
+          can_create_sections: false
+        }
+
+      updated_user = User.update_changeset_for_admin(user, attrs) |> apply_changes()
+      assert updated_user.given_name == attrs.given_name
+      assert updated_user.family_name == attrs.family_name
+      # Assert that also checks for downcasing email
+      assert updated_user.email == String.downcase(attrs.email)
+      assert updated_user.independent_learner == attrs.independent_learner
+      assert updated_user.can_create_sections == attrs.can_create_sections
+      # Check name has been well formed
+      assert updated_user.name == "#{attrs.given_name} #{attrs.family_name}"
+    end
+
+    test "error: validate_required", %{user: user} do
+      attrs =
+        %{
+          given_name: "",
+          family_name: "",
+          email: "UpdatedEmail@oli.com",
+          independent_learner: false,
+          can_create_sections: false
+        }
+
+      changeset = User.update_changeset_for_admin(user, attrs)
+
+      refute changeset.valid?
+
+      assert changeset.errors[:given_name] == {"can't be blank", [validation: :required]}
+      assert changeset.errors[:family_name] == {"can't be blank", [validation: :required]}
+    end
+
+    test "error: hits users_email_independent_learner_index DB constraint", %{user: user} do
+      email = "alreay_in_use@email.com"
+      _another_user = insert(:user, email: email)
+      attrs = %{email: email}
+
+      {:error, changeset} =
+        User.update_changeset_for_admin(user, attrs)
+        |> Accounts.update_user_from_admin()
+
+      refute changeset.valid?
+
+      assert changeset.errors[:email] ==
+               {"Email has already been taken by another independent learner",
+                [
+                  constraint: :unique,
+                  constraint_name: "users_email_independent_learner_index"
+                ]}
+    end
+  end
+end

--- a/test/oli_web/live/admin_live_test.exs
+++ b/test/oli_web/live/admin_live_test.exs
@@ -357,8 +357,8 @@ defmodule OliWeb.AdminLiveTest do
       assert has_element?(view, "input[value=\"#{user.family_name}\"]")
       assert has_element?(view, "input[value=\"#{user.email}\"]")
       assert has_element?(view, "input[value=\"#{boolean(user.guest)}\"]")
-      assert has_element?(view, "#independent_learner")
-      assert has_element?(view, "#can_create_sections")
+      assert has_element?(view, "#user_independent_learner")
+      assert has_element?(view, "#user_can_create_sections")
       assert has_element?(view, "input[value=\"#{boolean(user.research_opt_out)}\"]")
 
       assert has_element?(
@@ -375,40 +375,6 @@ defmodule OliWeb.AdminLiveTest do
                view,
                "input[value=\"#{Utils.render_date(user, :updated_at, session_context)}\"]"
              )
-    end
-
-    test "displays error message when submit fails", %{
-      conn: conn,
-      user: %User{id: id}
-    } do
-      {:ok, view, _html} = live(conn, live_view_user_detail_route(id))
-
-      view
-      |> element("form[phx-submit=\"submit\"")
-      |> render_submit(%{user: %{email: ""}})
-
-      assert view
-             |> element("div.alert.alert-danger")
-             |> render() =~
-               "Email can&#39;t be blank"
-
-      refute Accounts.get_user!(id).name == ""
-    end
-
-    test "updates a user correctly when data is valid", %{
-      conn: conn,
-      user: %User{id: id}
-    } do
-      {:ok, view, _html} = live(conn, live_view_user_detail_route(id))
-
-      new_attributes = params_for(:user)
-
-      view
-      |> element("form[phx-submit=\"submit\"")
-      |> render_submit(%{user: new_attributes})
-
-      %User{name: new_name} = Accounts.get_user!(id)
-      assert new_attributes.name == new_name
     end
 
     test "redirects to index view and displays error message when user does not exist", %{

--- a/test/oli_web/live/users/user_detail_view_test.exs
+++ b/test/oli_web/live/users/user_detail_view_test.exs
@@ -10,6 +10,9 @@ defmodule OliWeb.Users.UsersDetailViewTest do
   alias Lti_1p3.Tool.ContextRoles
   alias Oli.Delivery.Sections
 
+  @role_institution_instructor Lti_1p3.Tool.PlatformRoles.get_role(:institution_instructor)
+  @author_pow_config OliWeb.Pow.PowHelpers.get_pow_config(:author)
+
   describe "user details live test" do
     setup [:setup_session]
 
@@ -36,9 +39,7 @@ defmodule OliWeb.Users.UsersDetailViewTest do
 
       conn =
         recycle_author_session(conn, admin)
-        |> get(
-          Routes.live_path(OliWeb.Endpoint, OliWeb.Users.UsersDetailView, independent_student.id)
-        )
+        |> get(~p"/admin/users/#{independent_student.id}")
 
       {:ok, _view, html} = live(conn)
 
@@ -90,43 +91,76 @@ defmodule OliWeb.Users.UsersDetailViewTest do
       assert html =~ "LTI users are managed by the LMS" == false
     end
 
-    test "admin fails to update with an invalid email", ctx do
+    test "admin fails to update with an invalid user data", ctx do
       {:ok, view, _html} =
         Plug.Test.init_test_session(ctx.conn, [])
-        |> Pow.Plug.assign_current_user(ctx.admin, OliWeb.Pow.PowHelpers.get_pow_config(:author))
+        |> Pow.Plug.assign_current_user(ctx.admin, @author_pow_config)
         |> live(~p"/admin/users/#{ctx.independent_student.id}")
 
       view
       |> element("button[phx-click=\"start_edit\"]", "Edit")
       |> render_click()
 
-      # Email cannot be blank
-      params = %{"email" => ""}
-      assert submit_and_get_flash_msg(view, params) == "Email can't be blank"
+      # Params with invalid data to display errors
+      params = %{
+        "user" => %{
+          "can_create_sections" => "false",
+          "email" => "@test.com",
+          "family_name" => "",
+          "given_name" => "",
+          "independent_learner" => "false"
+        }
+      }
 
-      # Email with invalid format
-      params = %{"email" => "@bad_email"}
+      document =
+        view
+        |> element("form[phx-change=\"change\"")
+        |> render_change(params)
+        |> Floki.parse_document!()
 
-      assert submit_and_get_flash_msg(view, params) ==
-               "Email #{params["email"]} has invalid format"
+      assert document
+             |> Floki.find("[phx-feedback-for='user[family_name]'] > p")
+             |> Floki.text() =~
+               "can't be blank"
 
-      # Email hits users_email_independent_learner_index db constraint
-      params = %{"email" => ctx.instructor.email}
+      assert document
+             |> Floki.find("[phx-feedback-for='user[given_name]'] > p")
+             |> Floki.text() =~
+               "can't be blank"
 
-      assert submit_and_get_flash_msg(view, params) ==
-               "Email #{ctx.instructor.email} has already been taken"
-    end
+      assert document
+             |> Floki.find("[phx-feedback-for='user[email]'] > p")
+             |> Floki.text() =~
+               "has invalid format"
 
-    defp submit_and_get_flash_msg(view, params) do
-      view
-      |> element("form[phx-submit=\"submit\"")
-      |> render_submit(%{"user" => params})
+      assert has_element?(view, "[type='submit'][disabled]")
 
-      view
-      |> element("#live_flash_container")
-      |> render()
-      |> Floki.text()
-      |> String.trim()
+      {:ok, instructor_2} =
+        Accounts.update_user_platform_roles(
+          user_fixture(%{can_create_sections: true, independent_learner: true}),
+          [@role_institution_instructor]
+        )
+
+      # Params to hit the users_email_independent_learner_index DB constraint
+      params = %{
+        "user" => %{
+          "can_create_sections" => "false",
+          "email" => "#{instructor_2.email}",
+          "family_name" => "John",
+          "given_name" => "Doe",
+          "independent_learner" => "true"
+        }
+      }
+
+      assert view
+             |> element("form[phx-submit=\"submit\"")
+             |> render_submit(params)
+             |> Floki.parse_document!()
+             |> Floki.find("[phx-feedback-for='user[email]'] > p")
+             |> Floki.text() =~
+               "Email has already been taken by another independent learner"
+
+      assert has_element?(view, "[type='submit'][disabled]")
     end
 
     test "edit author details", %{


### PR DESCRIPTION
Ticket: [MER-2953](https://eliterate.atlassian.net/browse/MER-2953)


This PR upgrades the form used to change user information from an admin account. The advantage of this upgrade is that now the admin get immediate feedback the interacting with the form and something goes wrong, like having an empty field.

The `update_changeset_for_admin` changeset was also changed to avoid extra casting.

[MER-2953]: https://eliterate.atlassian.net/browse/MER-2953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ