### PR TITLE
[Bugfix] Max posts can't be less than required posts [MER-2809]

### DIFF
--- a/assets/src/components/activities/directed-discussion/ParticipationInput.tsx
+++ b/assets/src/components/activities/directed-discussion/ParticipationInput.tsx
@@ -16,7 +16,7 @@ export const ParticipationInput: React.FC<{
         disabled={!editMode}
         onChange={(e) => onChange(parseInt(e.target.value || '0'))}
         value={value}
-        step={0.1}
+        step={1}
       />
     </div>
   );

--- a/assets/src/components/activities/directed-discussion/actions.ts
+++ b/assets/src/components/activities/directed-discussion/actions.ts
@@ -1,8 +1,22 @@
 import { DDParticipationDefinition, DirectedDiscussionActivitySchema } from './schema';
 
+// Returns value 0 or more
+const minZero = (value: number) => Math.max(0, value);
+
+// If max is 0 or less, returns 0  (ie: there is no max value)
+// If max is less than min, returns min  (ie. Max is never lower than min)
+// Otherwise returns max
+const minMax = (min: number, max: number) => minZero(max === 0 ? 0 : Math.max(min, max));
+
 export const DirectedDiscussionActions = {
   editParticipation:
     (participation: DDParticipationDefinition) => (model: DirectedDiscussionActivitySchema) => {
-      model.participation = participation;
+      model.participation = {
+        minPosts: minZero(participation.minPosts),
+        minReplies: minZero(participation.minReplies),
+        maxWordLength: minZero(participation.maxWordLength),
+        maxPosts: minMax(participation.minPosts, participation.maxPosts),
+        maxReplies: minMax(participation.minReplies, participation.maxReplies),
+      };
     },
 };


### PR DESCRIPTION
Before, you could set the number of required posts or replies higher than the max number of posts or replies allowed, making the activity impossible to complete. Now, if you try to do that, the max-replies number is automatically adjusted.

Also: 

1. You can no longer specify a negative value for any of these inputs
2. The step has been set to 1 from 0.1, so the up/down controls make sense.


![minmax](https://github.com/Simon-Initiative/oli-torus/assets/333265/95c50e66-6595-4fe5-92f8-6b966b7838fd)

