### PR TITLE
[Bugfix] Authoring page jumps on tab click [MER-2914]

### DIFF
--- a/assets/src/components/tabbed_navigation/Tabs.tsx
+++ b/assets/src/components/tabbed_navigation/Tabs.tsx
@@ -31,21 +31,20 @@ const TabsComponent: React.FC<TabsComponentProps> = ({ children }) => {
           if (React.isValidElement(child) && isValidChild(child, TabbedNavigation)) {
             return (
               <li key={'tab-' + index} className="nav-item" role="presentation">
-                <a
+                <button
                   onClick={(e) => {
                     e.preventDefault();
                     e.stopPropagation();
                     setActiveTab(index);
                   }}
-                  className={'nav-link' + (index === activeTab ? ' active' : '')}
+                  className={'text-primary nav-link' + (index === activeTab ? ' active' : '')}
                   data-bs-toggle="tab"
-                  href="#"
                   role="tab"
                   aria-controls={'tab-' + index}
                   aria-selected="true"
                 >
                   {child.props.label}
-                </a>
+                </button>
               </li>
             );
           }


### PR DESCRIPTION
The labels for our tabs were anchors with "#" set as the href. In firefox, this caused the page to scroll to the top when they were clicked.

![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/30f75708-69a7-44d9-bf72-22c78829613a)

Now, those labels are buttons styled the same so they don't do this. Added bonus that it is probably more semantically right anyways.