### PR TITLE
[NG23-62] ai agent enable toggle at section level

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -4340,8 +4340,4 @@ defmodule Oli.Delivery.Sections do
   def assistant_enabled?(%Section{} = section) do
     section.assistant_enabled
   end
-
-  def assistant_enabled?(section_slug) when is_binary(section_slug) do
-    from([s] in Section, where: s.slug == ^section_slug, select: s.assistant_enabled)
-  end
 end

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -4333,4 +4333,15 @@ defmodule Oli.Delivery.Sections do
 
   defp maybe_select_section_fields(query, select_fields),
     do: select(query, [s], struct(s, ^select_fields))
+
+  @doc """
+  Returns true if the section has the ai assistant feature enabled.
+  """
+  def assistant_enabled?(%Section{} = section) do
+    section.assistant_enabled
+  end
+
+  def assistant_enabled?(section_slug) when is_binary(section_slug) do
+    from([s] in Section, where: s.slug == ^section_slug, select: s.assistant_enabled)
+  end
 end

--- a/lib/oli/delivery/sections/section.ex
+++ b/lib/oli/delivery/sections/section.ex
@@ -143,6 +143,9 @@ defmodule Oli.Delivery.Sections.Section do
     # Allow major project publications to be applied to course sections created from this product
     field(:apply_major_updates, :boolean, default: false)
 
+    # enable/disable the ai chatbot assistant for this section
+    field(:assistant_enabled, :boolean, default: true)
+
     timestamps(type: :utc_datetime)
   end
 
@@ -200,7 +203,8 @@ defmodule Oli.Delivery.Sections.Section do
       :preferred_scheduling_time,
       :v25_migration,
       :page_prompt_template,
-      :apply_major_updates
+      :apply_major_updates,
+      :assistant_enabled
     ])
     |> cast_embed(:customizations, required: false)
     |> validate_required([

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -21,20 +21,22 @@ defmodule OliWeb.Delivery.Student.LearnLive do
   }
 
   def mount(_params, _session, socket) do
+    section = socket.assigns.section
+
     # when updating to Liveview 0.20 we should replace this with assign_async/3
     # https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html#assign_async/3
     if connected?(socket),
       do:
         async_calculate_student_metrics_and_enable_slider_buttons(
           self(),
-          socket.assigns.section,
+          section,
           socket.assigns[:current_user]
         )
 
     socket =
       assign(socket,
         active_tab: :learn,
-        units: get_or_compute_full_hierarchy(socket.assigns.section)["children"],
+        units: get_or_compute_full_hierarchy(section)["children"],
         selected_module_per_unit_resource_id: %{},
         student_visited_pages: %{},
         student_progress_per_resource_id: %{},
@@ -42,9 +44,10 @@ defmodule OliWeb.Delivery.Student.LearnLive do
         student_raw_avg_score_per_container_id: %{},
         viewed_intro_video_resource_ids:
           get_viewed_intro_video_resource_ids(
-            socket.assigns.section.slug,
+            section.slug,
             socket.assigns.current_user.id
-          )
+          ),
+        assistant_enabled: Sections.assistant_enabled?(section)
       )
       |> slim_assigns()
 
@@ -407,6 +410,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
               %{}
             )
           }
+          assistant_enabled={@assistant_enabled}
         />
       </div>
     </div>
@@ -422,6 +426,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
   attr :student_id, :integer
   attr :viewed_intro_video_resource_ids, :list
   attr :unit_raw_avg_score, :map
+  attr :assistant_enabled, :boolean, required: true
 
   def unit(assigns) do
     ~H"""
@@ -582,6 +587,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
               ) %>
             </div>
             <button
+              :if={@assistant_enabled}
               phx-click={JS.dispatch("click", to: "#ai_bot_collapsed_button")}
               class="rounded-[4px] p-[10px] flex justify-center items-center ml-auto mt-[42px] text-[14px] leading-[19px] tracking-[0.024px] font-normal text-white bg-blue-500 hover:bg-blue-600 dark:text-white dark:bg-[rgba(255,255,255,0.10);] dark:hover:bg-gray-800"
             >

--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -14,7 +14,6 @@ defmodule OliWeb.Sections.OverviewView do
   alias OliWeb.Projects.RequiredSurvey
   alias OliWeb.Common.MonacoEditor
   alias Oli.Repo
-  alias OliWeb.Components.Common
 
   def set_breadcrumbs(:admin, section) do
     OliWeb.Sections.SectionsView.set_breadcrumbs()

--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -415,7 +415,7 @@ defmodule OliWeb.Sections.OverviewView do
           description="Edit the GenAI prompt templates"
           is_last={true}
         >
-          <div :if={assistant_enabled?(@section)}>
+          <div :if={Sections.assistant_enabled?(@section)}>
             <MonacoEditor.render
               id="attribute-monaco-editor"
               height="200px"
@@ -591,7 +591,7 @@ defmodule OliWeb.Sections.OverviewView do
 
   def assistant_toggle_button(assigns) do
     ~H"""
-    <%= if assistant_enabled?(@section) do %>
+    <%= if Sections.assistant_enabled?(@section) do %>
       <.button variant={:warning} phx-click="toggle_assistant">
         Disable Assistant
       </.button>
@@ -601,9 +601,5 @@ defmodule OliWeb.Sections.OverviewView do
       </.button>
     <% end %>
     """
-  end
-
-  defp assistant_enabled?(section) do
-    section.assistant_enabled
   end
 end

--- a/priv/repo/migrations/20240129151601_add_section_assistant_enable.exs
+++ b/priv/repo/migrations/20240129151601_add_section_assistant_enable.exs
@@ -1,0 +1,15 @@
+defmodule Oli.Repo.Migrations.AddSectionAssistantEnable do
+  use Ecto.Migration
+
+  def up do
+    alter table(:sections) do
+      add :assistant_enabled, :boolean, default: true
+    end
+  end
+
+  def down do
+    alter table(:sections) do
+      remove :assistant_enabled, :boolean, default: true
+    end
+  end
+end

--- a/test/oli_web/live/sections/overview_live_test.exs
+++ b/test/oli_web/live/sections/overview_live_test.exs
@@ -459,4 +459,30 @@ defmodule OliWeb.Sections.OverviewLiveTest do
   end
 
   defp section_with_disabled_survey(conn), do: section_with_survey(conn, survey_enabled: false)
+
+  describe "overview live shows assistant enable/disable" do
+    setup [:admin_conn, :section_with_assessment]
+
+    test "can enable and disable assistant", %{conn: conn, section: section} do
+      {:ok, view, _html} = live(conn, live_view_overview_route(section.slug))
+
+      assert has_element?(view, "button[phx-click=\"toggle_assistant\"]", "Disable Assistant")
+
+      element(view, "button[phx-click=\"toggle_assistant\"]")
+      |> render_click()
+
+      update_section = Oli.Delivery.Sections.get_section!(section.id)
+      assert update_section.assistant_enabled == false
+
+      refute has_element?(view, "button[phx-click=\"toggle_assistant\"]", "Disable Assistant")
+
+      element(view, "button[phx-click=\"toggle_assistant\"]")
+      |> render_click()
+
+      update_section = Oli.Delivery.Sections.get_section!(section.id)
+      assert update_section.assistant_enabled == true
+
+      refute has_element?(view, "button[phx-click=\"toggle_assistant\"]", "Enable Assistant")
+    end
+  end
 end


### PR DESCRIPTION
Adds the ability to enable/disable the ai agent for a section in the manage view.

<img width="1247" alt="Screenshot 2024-01-30 at 9 26 17 AM" src="https://github.com/Simon-Initiative/oli-torus/assets/6248894/562fcdc0-ccfb-4048-ba5e-5c5fab9fe7a2">
<img width="1285" alt="Screenshot 2024-01-30 at 9 26 08 AM" src="https://github.com/Simon-Initiative/oli-torus/assets/6248894/354a7981-5f10-486c-90f6-de261ca471d5">
