### PR TITLE
[Bugfix] Fix date-handling bug when today's date is later than the target month

### DIFF
--- a/assets/src/apps/scheduler/PageScheduleLine.tsx
+++ b/assets/src/apps/scheduler/PageScheduleLine.tsx
@@ -56,7 +56,7 @@ export const PageScheduleLine: React.FC<ScheduleLineProps> = ({ item, indent, da
 
       // On a drag, need to change the date, but preserve the end time if one exists.
       if (item.endDateTime) {
-        targetEndDate = new Date(2024,1,1);
+        targetEndDate = new Date(2024, 1, 1);
         targetEndDate.setFullYear(endDate.getFullYear());
         targetEndDate.setMonth(endDate.getMonth());
         targetEndDate.setDate(endDate.getDate());

--- a/assets/src/apps/scheduler/PageScheduleLine.tsx
+++ b/assets/src/apps/scheduler/PageScheduleLine.tsx
@@ -56,10 +56,8 @@ export const PageScheduleLine: React.FC<ScheduleLineProps> = ({ item, indent, da
 
       // On a drag, need to change the date, but preserve the end time if one exists.
       if (item.endDateTime) {
-        targetEndDate = new Date(2024, 1, 1);
-        targetEndDate.setFullYear(endDate.getFullYear());
-        targetEndDate.setMonth(endDate.getMonth());
-        targetEndDate.setDate(endDate.getDate());
+        targetEndDate = new Date();
+        targetEndDate.setFullYear(endDate.getFullYear(), endDate.getMonth(), endDate.getDate());
         targetEndDate.setHours(
           item.endDateTime.getHours(),
           item.endDateTime.getMinutes(),

--- a/assets/src/apps/scheduler/PageScheduleLine.tsx
+++ b/assets/src/apps/scheduler/PageScheduleLine.tsx
@@ -36,11 +36,12 @@ export const PageScheduleLine: React.FC<ScheduleLineProps> = ({ item, indent, da
       let targetStartDate: Date | DateWithoutTime | null = startDate;
 
       if (item.startDateTime && startDate) {
-        targetStartDate = new Date(2024, 1, 1);
-        // Important: Important to set these in order
-        targetStartDate.setFullYear(startDate.getFullYear());
-        targetStartDate.setMonth(startDate.getMonth());
-        targetStartDate.setDate(startDate.getDate());
+        targetStartDate = new Date();
+        targetStartDate.setFullYear(
+          startDate.getFullYear(),
+          startDate.getMonth(),
+          startDate.getDate(),
+        );
         targetStartDate.setHours(
           item.startDateTime.getHours(),
           item.startDateTime.getMinutes(),

--- a/assets/src/apps/scheduler/PageScheduleLine.tsx
+++ b/assets/src/apps/scheduler/PageScheduleLine.tsx
@@ -36,7 +36,7 @@ export const PageScheduleLine: React.FC<ScheduleLineProps> = ({ item, indent, da
       let targetStartDate: Date | DateWithoutTime | null = startDate;
 
       if (item.startDateTime && startDate) {
-        targetStartDate = new Date();
+        targetStartDate = new Date(2024, 1, 1);
         // Important: Important to set these in order
         targetStartDate.setFullYear(startDate.getFullYear());
         targetStartDate.setMonth(startDate.getMonth());
@@ -56,7 +56,7 @@ export const PageScheduleLine: React.FC<ScheduleLineProps> = ({ item, indent, da
 
       // On a drag, need to change the date, but preserve the end time if one exists.
       if (item.endDateTime) {
-        targetEndDate = new Date();
+        targetEndDate = new Date(2024,1,1);
         targetEndDate.setFullYear(endDate.getFullYear());
         targetEndDate.setMonth(endDate.getMonth());
         targetEndDate.setDate(endDate.getDate());

--- a/assets/src/apps/scheduler/scheduler-slice.ts
+++ b/assets/src/apps/scheduler/scheduler-slice.ts
@@ -210,10 +210,12 @@ const schedulerSlice = createSlice({
 
           mutableItem.startDate = action.payload.startDate;
 
-          mutableItem.startDateTime = new Date(2020, 1, 1);
-          mutableItem.startDateTime.setFullYear(action.payload.startDate.getFullYear());
-          mutableItem.startDateTime.setMonth(action.payload.startDate.getMonth());
-          mutableItem.startDateTime.setDate(action.payload.startDate.getDate());
+          mutableItem.startDateTime = new Date();
+          mutableItem.startDateTime.setFullYear(
+            action.payload.startDate.getFullYear(),
+            action.payload.startDate.getMonth(),
+            action.payload.startDate.getDate(),
+          );
 
           mutableItem.startDateTime.setHours(
             state.preferredSchedulingTime.hour,
@@ -251,10 +253,12 @@ const schedulerSlice = createSlice({
           if (action.payload.endDate) {
             // Need to be careful when converting from a timezone-less DateWithoutTime to a Date
             // Just doing a simple new Date(d.utcMidnightDateObj) will result in a date that may be off by a day
-            mutableItem.endDateTime = new Date(2020, 1, 1);
-            mutableItem.endDateTime.setFullYear(action.payload.endDate.getFullYear());
-            mutableItem.endDateTime.setMonth(action.payload.endDate.getMonth());
-            mutableItem.endDateTime.setDate(action.payload.endDate.getDate());
+            mutableItem.endDateTime = new Date();
+            mutableItem.endDateTime.setFullYear(
+              action.payload.endDate.getFullYear(),
+              action.payload.endDate.getMonth(),
+              action.payload.endDate.getDate(),
+            );
             mutableItem.endDateTime.setHours(
               state.preferredSchedulingTime.hour,
               state.preferredSchedulingTime.minute,

--- a/assets/src/apps/scheduler/scheduler-slice.ts
+++ b/assets/src/apps/scheduler/scheduler-slice.ts
@@ -210,7 +210,7 @@ const schedulerSlice = createSlice({
 
           mutableItem.startDate = action.payload.startDate;
 
-          mutableItem.startDateTime = new Date();
+          mutableItem.startDateTime = new Date(2020,1,1);
           mutableItem.startDateTime.setFullYear(action.payload.startDate.getFullYear());
           mutableItem.startDateTime.setMonth(action.payload.startDate.getMonth());
           mutableItem.startDateTime.setDate(action.payload.startDate.getDate());
@@ -233,7 +233,7 @@ const schedulerSlice = createSlice({
           datesChanged =
             datesChanged || action.payload.endDate.getTime() !== mutableItem.endDateTime?.getTime();
 
-          mutableItem.endDate = new DateWithoutTime();
+          mutableItem.endDate = new DateWithoutTime(2020,1,1);
           mutableItem.endDate.setFullYear(action.payload.endDate.getFullYear());
           mutableItem.endDate.setMonth(action.payload.endDate.getMonth());
           mutableItem.endDate.setDate(action.payload.endDate.getDate());
@@ -251,7 +251,7 @@ const schedulerSlice = createSlice({
           if (action.payload.endDate) {
             // Need to be careful when converting from a timezone-less DateWithoutTime to a Date
             // Just doing a simple new Date(d.utcMidnightDateObj) will result in a date that may be off by a day
-            mutableItem.endDateTime = new Date();
+            mutableItem.endDateTime = new Date(2020,1,1);
             mutableItem.endDateTime.setFullYear(action.payload.endDate.getFullYear());
             mutableItem.endDateTime.setMonth(action.payload.endDate.getMonth());
             mutableItem.endDateTime.setDate(action.payload.endDate.getDate());

--- a/assets/src/apps/scheduler/scheduler-slice.ts
+++ b/assets/src/apps/scheduler/scheduler-slice.ts
@@ -210,7 +210,7 @@ const schedulerSlice = createSlice({
 
           mutableItem.startDate = action.payload.startDate;
 
-          mutableItem.startDateTime = new Date(2020,1,1);
+          mutableItem.startDateTime = new Date(2020, 1, 1);
           mutableItem.startDateTime.setFullYear(action.payload.startDate.getFullYear());
           mutableItem.startDateTime.setMonth(action.payload.startDate.getMonth());
           mutableItem.startDateTime.setDate(action.payload.startDate.getDate());
@@ -233,7 +233,7 @@ const schedulerSlice = createSlice({
           datesChanged =
             datesChanged || action.payload.endDate.getTime() !== mutableItem.endDateTime?.getTime();
 
-          mutableItem.endDate = new DateWithoutTime(2020,1,1);
+          mutableItem.endDate = new DateWithoutTime(2020, 1, 1);
           mutableItem.endDate.setFullYear(action.payload.endDate.getFullYear());
           mutableItem.endDate.setMonth(action.payload.endDate.getMonth());
           mutableItem.endDate.setDate(action.payload.endDate.getDate());
@@ -251,7 +251,7 @@ const schedulerSlice = createSlice({
           if (action.payload.endDate) {
             // Need to be careful when converting from a timezone-less DateWithoutTime to a Date
             // Just doing a simple new Date(d.utcMidnightDateObj) will result in a date that may be off by a day
-            mutableItem.endDateTime = new Date(2020,1,1);
+            mutableItem.endDateTime = new Date(2020, 1, 1);
             mutableItem.endDateTime.setFullYear(action.payload.endDate.getFullYear());
             mutableItem.endDateTime.setMonth(action.payload.endDate.getMonth());
             mutableItem.endDateTime.setDate(action.payload.endDate.getDate());


### PR DESCRIPTION
If today's date has a date-part that's bigger than the number of days in the target month, you could not set the schedule to that date because of the way the Date object validates dates.

Explanation of bug:

const d = new Date();  // ex: Date is 1/30/2024
d.setFullYear(2025) // Date is now 1/30/2025
d.setMonth(2); // Date tries to be 2/30/2025, which doesn't exist, and rolls over to 3/1/2025
d.setDate(15); // Date is now 3/15/2025 instead of 2/15/2025 as expected
