### PR TITLE
[MER-2875] Fix admin cannot lock/unlock an author

### DIFF
--- a/lib/oli_web/pow/author_context.ex
+++ b/lib/oli_web/pow/author_context.ex
@@ -16,7 +16,7 @@ defmodule OliWeb.Pow.AuthorContext do
     user
     |> Author.lock_changeset()
     |> Repo.update()
-    |> update_cache()
+    |> maybe_delete_author_cached()
   end
 
   @spec unlock(map()) :: {:ok, map()} | {:error, map()}
@@ -24,13 +24,13 @@ defmodule OliWeb.Pow.AuthorContext do
     user
     |> Author.noauth_changeset(%{locked_at: nil})
     |> Repo.update()
-    |> update_cache()
+    |> maybe_delete_author_cached()
   end
 
-  defp update_cache(db_resutl) do
-    case db_resutl do
+  defp maybe_delete_author_cached(db_result) do
+    case db_result do
       {:ok, author} = result ->
-        Oli.AccountLookupCache.put("author_#{author.id}", author)
+        Oli.AccountLookupCache.delete("author_#{author.id}")
         result
 
       error ->

--- a/lib/oli_web/pow/author_context.ex
+++ b/lib/oli_web/pow/author_context.ex
@@ -16,6 +16,7 @@ defmodule OliWeb.Pow.AuthorContext do
     user
     |> Author.lock_changeset()
     |> Repo.update()
+    |> update_cache()
   end
 
   @spec unlock(map()) :: {:ok, map()} | {:error, map()}
@@ -23,6 +24,18 @@ defmodule OliWeb.Pow.AuthorContext do
     user
     |> Author.noauth_changeset(%{locked_at: nil})
     |> Repo.update()
+    |> update_cache()
+  end
+
+  defp update_cache(db_resutl) do
+    case db_resutl do
+      {:ok, author} = result ->
+        Oli.AccountLookupCache.put("author_#{author.id}", author)
+        result
+
+      error ->
+        error
+    end
   end
 
   @impl true

--- a/test/oli_web/live/admin_live_test.exs
+++ b/test/oli_web/live/admin_live_test.exs
@@ -756,6 +756,9 @@ defmodule OliWeb.AdminLiveTest do
 
       %Author{locked_at: date} = Accounts.get_author!(id)
       assert not is_nil(date)
+
+      {:ok, author} = Cachex.get(:cache_account_lookup, "author_#{id}")
+      assert author.locked_at
     end
 
     test "unlocks the author", %{
@@ -775,6 +778,9 @@ defmodule OliWeb.AdminLiveTest do
       |> render_click()
 
       assert %Author{locked_at: nil} = Accounts.get_author!(id)
+
+      {:ok, author} = Cachex.get(:cache_account_lookup, "author_#{id}")
+      refute author.locked_at
     end
 
     test "confirms author email", %{

--- a/test/oli_web/live/admin_live_test.exs
+++ b/test/oli_web/live/admin_live_test.exs
@@ -742,8 +742,10 @@ defmodule OliWeb.AdminLiveTest do
 
     test "locks the author", %{
       conn: conn,
-      author: %Author{id: id}
+      author: %Author{id: id} = author
     } do
+      # Next line emulates the target author is cached in the system
+      Cachex.put(:cache_account_lookup, "author_#{id}", author)
       {:ok, view, _html} = live(conn, live_view_author_detail_route(id))
 
       view
@@ -757,15 +759,17 @@ defmodule OliWeb.AdminLiveTest do
       %Author{locked_at: date} = Accounts.get_author!(id)
       assert not is_nil(date)
 
-      {:ok, author} = Cachex.get(:cache_account_lookup, "author_#{id}")
-      assert author.locked_at
+      assert {:ok, nil} = Cachex.get(:cache_account_lookup, "author_#{id}")
     end
 
     test "unlocks the author", %{
       conn: conn
     } do
       {:ok, date, _timezone} = DateTime.from_iso8601("2019-05-22 20:30:00Z")
-      %Author{id: id} = insert(:author, %{locked_at: date})
+      %Author{id: id} = author = insert(:author, %{locked_at: date})
+
+      # Next line emulates the target author is cached in the system
+      Cachex.put(:cache_account_lookup, "author_#{id}", author)
 
       {:ok, view, _html} = live(conn, live_view_author_detail_route(id))
 
@@ -779,8 +783,7 @@ defmodule OliWeb.AdminLiveTest do
 
       assert %Author{locked_at: nil} = Accounts.get_author!(id)
 
-      {:ok, author} = Cachex.get(:cache_account_lookup, "author_#{id}")
-      refute author.locked_at
+      assert {:ok, nil} = Cachex.get(:cache_account_lookup, "author_#{id}")
     end
 
     test "confirms author email", %{


### PR DESCRIPTION
Ticket: [MER-2875](https://eliterate.atlassian.net/browse/MER-2875)

When an Author is logged in the application, our cache is triggered storing its data in the session in order to save future extra DB calls. If an Admin tries to lock/unlock that author, a DB call changes the `locked_at` field but it doesn't delete the cache (if any). This makes an Author (potentially blocked by an Admin) able to navigate on the app.

This PR also tackled the issue mentioned in the ticket. An Admin can locked and then unlocked an Author and the Author should be able to log in.

[MER-2875]: https://eliterate.atlassian.net/browse/MER-2875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ