### PR TITLE
[NG23-72] Fix back button on the Lesson view to consider different request paths

### DIFF
--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -372,16 +372,18 @@ defmodule OliWeb.Components.Delivery.Layouts do
        ) do
     # If the request_path is the Learn page and we navigate to a different lesson,
     # we need to update the request_path to include the new target resource.
-    if request_path && String.contains?(request_path, "/learn") do
-      request_path = Utils.learn_live_path(section_slug, resource_id)
-      Utils.lesson_live_path(section_slug, slug, request_path)
-    else
-      Utils.lesson_live_path(section_slug, slug, request_path)
-    end
+    request_path =
+      if request_path && String.contains?(request_path, "/learn") do
+        Utils.learn_live_path(section_slug, target_resource_id: resource_id)
+      else
+        request_path
+      end
+
+    Utils.lesson_live_path(section_slug, slug, request_path: request_path)
   end
 
   defp resource_navigation_url(%{"id" => container_id}, section_slug, _) do
-    Utils.learn_live_path(section_slug, container_id)
+    Utils.learn_live_path(section_slug, target_resource_id: container_id)
   end
 
   attr(:to, :string)

--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -16,6 +16,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
   alias Oli.Branding.Brand
   alias OliWeb.Components.Delivery.UserAccount
   alias Oli.Resources.Collaboration.CollabSpaceConfig
+  alias OliWeb.Delivery.Student.Utils
 
   attr(:ctx, SessionContext)
   attr(:is_system_admin, :boolean, required: true)
@@ -284,6 +285,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
   attr(:previous_page, :map)
   attr(:next_page, :map)
   attr(:section_slug, :string)
+  attr(:request_path, :string)
 
   def previous_next_nav(assigns) do
     # <.links /> were changed from "navigate" to "href" to force a page reload
@@ -317,7 +319,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
         role="prev_page"
       >
         <div class="px-2 lg:px-6 rounded justify-end items-center gap-2 flex">
-          <.link href={resource_navigation_url(@previous_page, @section_slug)}>
+          <.link href={resource_navigation_url(@previous_page, @section_slug, @request_path)}>
             <div class="w-[72px] h-10 opacity-30 hover:opacity-40 bg-blue-600 flex items-center justify-center cursor-pointer">
               <.left_arrow />
             </div>
@@ -337,7 +339,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
           <%= @next_page["title"] %>
         </div>
         <div class="px-2 lg:px-6 py-2 rounded justify-end items-center gap-2 flex">
-          <.link href={resource_navigation_url(@next_page, @section_slug)}>
+          <.link href={resource_navigation_url(@next_page, @section_slug, @request_path)}>
             <div class="w-[72px] h-10 opacity-90 hover:opacity-100 bg-blue-600 flex items-center justify-center cursor-pointer">
               <.right_arrow />
             </div>
@@ -363,12 +365,23 @@ defmodule OliWeb.Components.Delivery.Layouts do
     """
   end
 
-  defp resource_navigation_url(%{"slug" => slug, "type" => "page"}, section_slug) do
-    ~p"/sections/#{section_slug}/lesson/#{slug}"
+  defp resource_navigation_url(
+         %{"slug" => slug, "type" => "page", "id" => resource_id},
+         section_slug,
+         request_path
+       ) do
+    # If the request_path is the Learn page and we navigate to a different lesson,
+    # we need to update the request_path to include the new target resource.
+    if request_path && String.contains?(request_path, "/learn") do
+      request_path = Utils.learn_live_path(section_slug, resource_id)
+      Utils.lesson_live_path(section_slug, slug, request_path)
+    else
+      Utils.lesson_live_path(section_slug, slug, request_path)
+    end
   end
 
-  defp resource_navigation_url(%{"id" => container_id}, section_slug) do
-    ~p"/sections/#{section_slug}/learn?target_resource_id=#{container_id}"
+  defp resource_navigation_url(%{"id" => container_id}, section_slug, _) do
+    Utils.learn_live_path(section_slug, container_id)
   end
 
   attr(:to, :string)

--- a/lib/oli_web/components/delivery/schedule.ex
+++ b/lib/oli_web/components/delivery/schedule.ex
@@ -2,11 +2,13 @@ defmodule OliWeb.Components.Delivery.Schedule do
   use OliWeb, :html
 
   alias OliWeb.Common.SessionContext
+  alias OliWeb.Delivery.Student.Utils
 
   attr(:ctx, SessionContext, required: true)
   attr(:week_number, :any, required: true)
   attr(:schedule_ranges, :any, required: true)
   attr(:section_slug, :string, required: true)
+  attr(:request_path, :string, required: false)
 
   def week(assigns) do
     ~H"""
@@ -35,7 +37,9 @@ defmodule OliWeb.Components.Delivery.Schedule do
                     <div class="flex flex-col mb-4">
                       <div>
                         <.link
-                          href={~p"/sections/#{@section_slug}/lesson/#{resource.revision_slug}"}
+                          href={
+                            Utils.lesson_live_path(@section_slug, resource.revision_slug, @request_path)
+                          }
                           class="hover:no-underline"
                         >
                           <%= resource.title %>

--- a/lib/oli_web/components/delivery/schedule.ex
+++ b/lib/oli_web/components/delivery/schedule.ex
@@ -38,7 +38,9 @@ defmodule OliWeb.Components.Delivery.Schedule do
                       <div>
                         <.link
                           href={
-                            Utils.lesson_live_path(@section_slug, resource.revision_slug, @request_path)
+                            Utils.lesson_live_path(@section_slug, resource.revision_slug,
+                              request_path: @request_path
+                            )
                           }
                           class="hover:no-underline"
                         >

--- a/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
+++ b/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
@@ -49,9 +49,7 @@
 
   <div class="flex-1 flex flex-col mt-14">
     <div :if={@section} id="page-content" class="relative justify-center items-start inline-flex">
-      <.back_arrow to={
-        ~p"/sections/#{@section.slug}/learn?target_resource_id=#{@current_page["id"]}"
-      } />
+      <.back_arrow to={@request_path} />
 
       <%!-- This feature will not be implemented in the first release. This is just a placeholder--%>
       <.annotations_dropdown />
@@ -65,6 +63,7 @@
       previous_page={@previous_page}
       next_page={@next_page}
       section_slug={@section.slug}
+      request_path={@request_path}
     />
   </div>
 

--- a/lib/oli_web/live/delivery/student/index_live.ex
+++ b/lib/oli_web/live/delivery/student/index_live.ex
@@ -36,6 +36,7 @@ defmodule OliWeb.Delivery.Student.IndexLive do
               week_number={week}
               schedule_ranges={schedule_ranges}
               section_slug={@section_slug}
+              request_path={~p"/sections/#{@section_slug}"}
             />
           <% _ -> %>
             <div class="text-xl">No schedule for this week.</div>

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -8,6 +8,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
   alias Oli.Authoring.Course.Project
   alias Oli.Delivery.Sections.SectionCache
   alias OliWeb.Common.Utils, as: WebUtils
+  alias OliWeb.Delivery.Student.Utils
 
   import Ecto.Query, warn: false, only: [from: 2]
 
@@ -320,11 +321,16 @@ defmodule OliWeb.Delivery.Student.LearnLive do
 
   def handle_event(
         "navigate_to_resource",
-        %{"slug" => resource_slug, "purpose" => purpose},
+        %{"slug" => resource_slug} = values,
         socket
       ) do
+    section_slug = socket.assigns.section.slug
+    resource_id = values["resource_id"] || values["module_resource_id"]
+
     {:noreply,
-     push_redirect(socket, to: resource_url(resource_slug, socket.assigns.section.slug, purpose))}
+     push_redirect(socket,
+       to: resource_url(resource_slug, section_slug, resource_id, purpose)
+     )}
   end
 
   def handle_info(:gc, socket) do
@@ -802,6 +808,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
         id={"index_item_#{@numbering_index}_#{@resource_id}"}
         phx-click={if @type != "intro", do: "navigate_to_resource", else: "play_video"}
         phx-value-slug={@revision_slug}
+        phx-value-resource_id={@resource_id}
         phx-value-module_resource_id={@module_resource_id}
         phx-value-video_url={@video_url}
         phx-value-is_intro_video="false"
@@ -1177,12 +1184,16 @@ defmodule OliWeb.Delivery.Student.LearnLive do
   # This implies that the v26 prologue page will be shown when there is no attempt in course.
   # We need to extend the NG23 prologue to support adaptive pages.
 
-  defp resource_url(resource_slug, section_slug, "application") do
+  defp resource_url(resource_slug, section_slug, _, "application") do
     ~p"/sections/#{section_slug}/page/#{resource_slug}"
   end
 
-  defp resource_url(resource_slug, section_slug, _purpose) do
-    ~p"/sections/#{section_slug}/lesson/#{resource_slug}"
+  defp resource_url(resource_slug, section_slug, resource_id, _purpose) do
+    Utils.lesson_live_path(
+      section_slug,
+      resource_slug,
+      Utils.learn_live_path(section_slug, resource_id)
+    )
   end
 
   defp get_student_metrics(section, current_user_id) do

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -321,7 +321,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
 
   def handle_event(
         "navigate_to_resource",
-        %{"slug" => resource_slug} = values,
+        %{"slug" => resource_slug, "purpose" => purpose} = values,
         socket
       ) do
     section_slug = socket.assigns.section.slug

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -328,9 +328,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
     resource_id = values["resource_id"] || values["module_resource_id"]
 
     {:noreply,
-     push_redirect(socket,
-       to: resource_url(resource_slug, section_slug, resource_id, purpose)
-     )}
+     push_redirect(socket, to: resource_url(resource_slug, section_slug, resource_id, purpose))}
   end
 
   def handle_info(:gc, socket) do
@@ -1192,7 +1190,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
     Utils.lesson_live_path(
       section_slug,
       resource_slug,
-      Utils.learn_live_path(section_slug, resource_id)
+      request_path: Utils.learn_live_path(section_slug, target_resource_id: resource_id)
     )
   end
 

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -109,10 +109,12 @@ defmodule OliWeb.Delivery.Student.LessonLive do
         redirect_to =
           case effective_settings.review_submission do
             :allow ->
-              Utils.review_live_path(section.slug, revision_slug, attempt_guid, request_path)
+              Utils.review_live_path(section.slug, revision_slug, attempt_guid,
+                request_path: request_path
+              )
 
             _ ->
-              Utils.lesson_live_path(section.slug, revision_slug, request_path)
+              Utils.lesson_live_path(section.slug, revision_slug, request_path: request_path)
           end
 
         {:noreply, redirect(socket, to: redirect_to)}
@@ -120,7 +122,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
       {:ok, %FinalizationSummary{graded: false}} ->
         {:noreply,
          redirect(socket,
-           to: Utils.lesson_live_path(section.slug, revision_slug, request_path)
+           to: Utils.lesson_live_path(section.slug, revision_slug, request_path: request_path)
          )}
 
       {:error, {reason}}
@@ -414,7 +416,12 @@ defmodule OliWeb.Delivery.Student.LessonLive do
         >
           <.link
             href={
-              Utils.review_live_path(@section_slug, @page_revision_slug, @attempt.attempt_guid, @request_path)
+              Utils.review_live_path(
+                @section_slug,
+                @page_revision_slug,
+                @attempt.attempt_guid,
+                request_path: @request_path
+              )
             }
             role="review_attempt_link"
           >

--- a/lib/oli_web/live/delivery/student/review_live.ex
+++ b/lib/oli_web/live/delivery/student/review_live.ex
@@ -65,7 +65,9 @@ defmodule OliWeb.Delivery.Student.ReviewLive do
             <%= raw(@html) %>
           </div>
           <.link
-            href={Utils.lesson_live_path(@section.slug, @page_revision.slug, @request_path)}
+            href={
+              Utils.lesson_live_path(@section.slug, @page_revision.slug, request_path: @request_path)
+            }
             role="back_to_summary_link"
           >
             <div class="h-10 px-5 py-2.5 hover:bg-opacity-40 bg-blue-600 rounded shadow justify-center items-center gap-2.5 inline-flex">

--- a/lib/oli_web/live/delivery/student/review_live.ex
+++ b/lib/oli_web/live/delivery/student/review_live.ex
@@ -34,7 +34,7 @@ defmodule OliWeb.Delivery.Student.ReviewLive do
       else
         socket
         |> put_flash(:error, "You are not allowed to review this attempt.")
-        |> redirect(to: ~p"/sections/#{section.slug}/learn")
+        |> redirect(to: Utils.learn_live_path(section.slug))
       end
 
     {:ok, socket}
@@ -65,7 +65,7 @@ defmodule OliWeb.Delivery.Student.ReviewLive do
             <%= raw(@html) %>
           </div>
           <.link
-            href={~p"/sections/#{@section.slug}/lesson/#{@page_revision.slug}"}
+            href={Utils.lesson_live_path(@section.slug, @page_revision.slug, @request_path)}
             role="back_to_summary_link"
           >
             <div class="h-10 px-5 py-2.5 hover:bg-opacity-40 bg-blue-600 rounded shadow justify-center items-center gap-2.5 inline-flex">

--- a/lib/oli_web/live/delivery/student/schedule_live.ex
+++ b/lib/oli_web/live/delivery/student/schedule_live.ex
@@ -56,6 +56,7 @@ defmodule OliWeb.Delivery.Student.ScheduleLive do
                     week_number={week}
                     schedule_ranges={schedule_ranges}
                     section_slug={@section_slug}
+                    request_path={~p"/sections/#{@section_slug}/assignments"}
                   />
                 </div>
               <% end %>

--- a/lib/oli_web/live/delivery/student/utils.ex
+++ b/lib/oli_web/live/delivery/student/utils.ex
@@ -205,6 +205,26 @@ defmodule OliWeb.Delivery.Student.Utils do
     """
   end
 
+  def learn_live_path(section_slug, target_resource_id \\ nil)
+
+  def learn_live_path(section_slug, nil), do: ~p"/sections/#{section_slug}/learn"
+
+  def learn_live_path(section_slug, target_resource_id),
+    do: ~p"/sections/#{section_slug}/learn?target_resource_id=#{target_resource_id}"
+
+  def lesson_live_path(section_slug, revision_slug, nil),
+    do: ~p"/sections/#{section_slug}/lesson/#{revision_slug}"
+
+  def lesson_live_path(section_slug, revision_slug, request_path),
+    do: ~p"/sections/#{section_slug}/lesson/#{revision_slug}?request_path=#{request_path}"
+
+  def review_live_path(section_slug, revision_slug, attempt_guid, nil),
+    do: ~p"/sections/#{section_slug}/lesson/#{revision_slug}/attempt/#{attempt_guid}/review"
+
+  def review_live_path(section_slug, revision_slug, attempt_guid, request_path),
+    do:
+      ~p"/sections/#{section_slug}/lesson/#{revision_slug}/attempt/#{attempt_guid}/review?request_path=#{request_path}"
+
   def get_container_label(page_id, section) do
     section_id = section.id
 

--- a/lib/oli_web/live/delivery/student/utils.ex
+++ b/lib/oli_web/live/delivery/student/utils.ex
@@ -209,19 +209,19 @@ defmodule OliWeb.Delivery.Student.Utils do
   Generates a URL for the Learn view.
 
   ## Parameters
-  - `section_slug`: The unique identifier for the section.
-  - `target_resource_id`: (Optional) The ID of the target resource. If omitted, a URL is generated without this parameter.
+    - `section_slug`: The unique identifier for the section.
+    - `params`: (Optional) Additional query parameters in a list or map format. If omitted, a URL is generated without additional parameters.
 
   ## Examples
-  - `learn_live_path("math")` returns `"/sections/math/learn"`.
-  - `learn_live_path("math", "123")` returns `"/sections/math/learn?target_resource_id=123"`.
+    - `learn_live_path("math")` returns `"/sections/math/learn"`.
+    - `learn_live_path("math", target_resource_id: "123")` returns `"/sections/math/learn?target_resource_id=123"`.
   """
-  def learn_live_path(section_slug, target_resource_id \\ nil)
+  def learn_live_path(section_slug, params \\ [])
 
-  def learn_live_path(section_slug, nil), do: ~p"/sections/#{section_slug}/learn"
+  def learn_live_path(section_slug, []), do: ~p"/sections/#{section_slug}/learn"
 
-  def learn_live_path(section_slug, target_resource_id),
-    do: ~p"/sections/#{section_slug}/learn?target_resource_id=#{target_resource_id}"
+  def learn_live_path(section_slug, params),
+    do: ~p"/sections/#{section_slug}/learn?#{params}"
 
   @doc """
   Generates a URL for a specific lesson.
@@ -229,19 +229,19 @@ defmodule OliWeb.Delivery.Student.Utils do
   ## Parameters
     - `section_slug`: The unique identifier for the section.
     - `revision_slug`: The unique identifier for the lesson revision.
-    - `request_path`: (Optional) The request path. If omitted, a URL is generated without this parameter.
+    - `params`: (Optional) Additional query parameters in a list or map format. If omitted, a URL is generated without additional parameters.
 
   ## Examples
     - `lesson_live_path("math", "intro")` returns `"/sections/math/lesson/intro"`.
-    - `lesson_live_path("math", "intro", "some/previous/url")` returns `"/sections/math/lesson/intro?request_path=some/previous/url"`.
+    - `lesson_live_path("math", "intro", request_path: "some/previous/url")` returns `"/sections/math/lesson/intro?request_path=some/previous/url"`.
   """
-  def lesson_live_path(section_slug, revision_slug, request_path \\ nil)
+  def lesson_live_path(section_slug, revision_slug, params \\ [])
 
-  def lesson_live_path(section_slug, revision_slug, nil),
+  def lesson_live_path(section_slug, revision_slug, []),
     do: ~p"/sections/#{section_slug}/lesson/#{revision_slug}"
 
-  def lesson_live_path(section_slug, revision_slug, request_path),
-    do: ~p"/sections/#{section_slug}/lesson/#{revision_slug}?request_path=#{request_path}"
+  def lesson_live_path(section_slug, revision_slug, params),
+    do: ~p"/sections/#{section_slug}/lesson/#{revision_slug}?#{params}"
 
   @doc """
   Generates a URL for reviewing an attempt of a lesson.
@@ -250,20 +250,20 @@ defmodule OliWeb.Delivery.Student.Utils do
     - `section_slug`: The unique identifier for the section.
     - `revision_slug`: The unique identifier for the lesson revision.
     - `attempt_guid`: The unique identifier for the attempt.
-    - `request_path`: (Optional) The request path. If omitted, a URL is generated without this parameter.
+    - `params`: (Optional) Additional query parameters in a list or map format. If omitted, a URL is generated without additional parameters.
 
   ## Examples
     - `review_live_path("math", "intro", "abcd")` returns `"/sections/math/lesson/intro/attempt/abcd/review"`.
-    - `review_live_path("math", "intro", "abcd", "some/previous/url")` returns `"/sections/math/lesson/intro/attempt/abcd/review?request_path=some/previous/url"`.
+    - `review_live_path("math", "intro", "abcd", request_path: "some/previous/url")` returns `"/sections/math/lesson/intro/attempt/abcd/review?request_path=some/previous/url"`.
   """
-  def review_live_path(section_slug, revision_slug, attempt_guid, request_path \\ nil)
+  def review_live_path(section_slug, revision_slug, attempt_guid, params \\ [])
 
-  def review_live_path(section_slug, revision_slug, attempt_guid, nil),
+  def review_live_path(section_slug, revision_slug, attempt_guid, []),
     do: ~p"/sections/#{section_slug}/lesson/#{revision_slug}/attempt/#{attempt_guid}/review"
 
-  def review_live_path(section_slug, revision_slug, attempt_guid, request_path),
+  def review_live_path(section_slug, revision_slug, attempt_guid, params),
     do:
-      ~p"/sections/#{section_slug}/lesson/#{revision_slug}/attempt/#{attempt_guid}/review?request_path=#{request_path}"
+      ~p"/sections/#{section_slug}/lesson/#{revision_slug}/attempt/#{attempt_guid}/review?#{params}"
 
   def get_container_label(page_id, section) do
     section_id = section.id

--- a/lib/oli_web/live/delivery/student/utils.ex
+++ b/lib/oli_web/live/delivery/student/utils.ex
@@ -205,6 +205,17 @@ defmodule OliWeb.Delivery.Student.Utils do
     """
   end
 
+  @doc """
+  Generates a URL for the Learn view.
+
+  ## Parameters
+  - `section_slug`: The unique identifier for the section.
+  - `target_resource_id`: (Optional) The ID of the target resource. If omitted, a URL is generated without this parameter.
+
+  ## Examples
+  - `learn_live_path("math")` returns `"/sections/math/learn"`.
+  - `learn_live_path("math", "123")` returns `"/sections/math/learn?target_resource_id=123"`.
+  """
   def learn_live_path(section_slug, target_resource_id \\ nil)
 
   def learn_live_path(section_slug, nil), do: ~p"/sections/#{section_slug}/learn"
@@ -212,11 +223,40 @@ defmodule OliWeb.Delivery.Student.Utils do
   def learn_live_path(section_slug, target_resource_id),
     do: ~p"/sections/#{section_slug}/learn?target_resource_id=#{target_resource_id}"
 
+  @doc """
+  Generates a URL for a specific lesson.
+
+  ## Parameters
+    - `section_slug`: The unique identifier for the section.
+    - `revision_slug`: The unique identifier for the lesson revision.
+    - `request_path`: (Optional) The request path. If omitted, a URL is generated without this parameter.
+
+  ## Examples
+    - `lesson_live_path("math", "intro")` returns `"/sections/math/lesson/intro"`.
+    - `lesson_live_path("math", "intro", "some/previous/url")` returns `"/sections/math/lesson/intro?request_path=some/previous/url"`.
+  """
+  def lesson_live_path(section_slug, revision_slug, request_path \\ nil)
+
   def lesson_live_path(section_slug, revision_slug, nil),
     do: ~p"/sections/#{section_slug}/lesson/#{revision_slug}"
 
   def lesson_live_path(section_slug, revision_slug, request_path),
     do: ~p"/sections/#{section_slug}/lesson/#{revision_slug}?request_path=#{request_path}"
+
+  @doc """
+  Generates a URL for reviewing an attempt of a lesson.
+
+  ## Parameters
+    - `section_slug`: The unique identifier for the section.
+    - `revision_slug`: The unique identifier for the lesson revision.
+    - `attempt_guid`: The unique identifier for the attempt.
+    - `request_path`: (Optional) The request path. If omitted, a URL is generated without this parameter.
+
+  ## Examples
+    - `review_live_path("math", "intro", "abcd")` returns `"/sections/math/lesson/intro/attempt/abcd/review"`.
+    - `review_live_path("math", "intro", "abcd", "some/previous/url")` returns `"/sections/math/lesson/intro/attempt/abcd/review?request_path=some/previous/url"`.
+  """
+  def review_live_path(section_slug, revision_slug, attempt_guid, request_path \\ nil)
 
   def review_live_path(section_slug, revision_slug, attempt_guid, nil),
     do: ~p"/sections/#{section_slug}/lesson/#{revision_slug}/attempt/#{attempt_guid}/review"

--- a/lib/oli_web/live_session_plugs/set_request_path.ex
+++ b/lib/oli_web/live_session_plugs/set_request_path.ex
@@ -1,0 +1,18 @@
+defmodule OliWeb.LiveSessionPlugs.SetRequestPath do
+  use OliWeb, :verified_routes
+
+  import Phoenix.Component, only: [assign: 2]
+
+  alias OliWeb.Delivery.Student.Utils
+
+  def on_mount(:default, :not_mounted_at_router, _session, socket) do
+    {:cont, socket}
+  end
+
+  def on_mount(:default, params, _session, socket) do
+    section_slug = socket.assigns.section.slug
+    request_path = Map.get(params, "request_path", Utils.learn_live_path(section_slug))
+
+    {:cont, assign(socket, request_path: request_path)}
+  end
+end

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -971,7 +971,8 @@ defmodule OliWeb.Router do
             OliWeb.LiveSessionPlugs.SetSection,
             OliWeb.LiveSessionPlugs.SetBrand,
             OliWeb.LiveSessionPlugs.SetPreviewMode,
-            OliWeb.LiveSessionPlugs.RequireEnrollment
+            OliWeb.LiveSessionPlugs.RequireEnrollment,
+            OliWeb.LiveSessionPlugs.SetRequestPath
           ] do
           live("/", Delivery.Student.LessonLive)
           live("/attempt/:attempt_guid/review", Delivery.Student.ReviewLive)

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -1312,7 +1312,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       set_progress(section.id, page_2.resource_id, user.id, 0.5, page_2)
       set_progress(section.id, page_7.resource_id, user.id, 1.0, page_7)
 
-      {:ok, view, _html} = live(conn, live_view_learn_live_route(section.slug))
+      {:ok, view, _html} = live(conn, Utils.learn_live_path(section.slug))
 
       assert has_element?(view, ~s{div[role="unit_1"] div[role="card_1_progress"]})
       assert has_element?(view, ~s{div[role="unit_3"] div[role="card_1_progress"]})

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -21,10 +21,6 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
     AttemptGroup
   }
 
-  defp live_view_learn_live_route(section_slug, params \\ %{}) do
-    ~p"/sections/#{section_slug}/learn?#{params}"
-  end
-
   defp set_progress(section_id, resource_id, user_id, progress, revision) do
     {:ok, resource_access} =
       Core.track_access(resource_id, section_id, user_id)
@@ -621,7 +617,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       Sections.enroll(student.id, section.id, [ContextRoles.get_role(:context_learner)])
 
       {:error, {:redirect, %{to: redirect_path}}} =
-        live(conn, live_view_learn_live_route(section.slug))
+        live(conn, Utils.learn_live_path(section.slug))
 
       assert redirect_path ==
                "/session/new?request_path=%2Fsections%2F#{section.slug}%2Flearn&section=#{section.slug}"
@@ -633,7 +629,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
 
     test "can not access when not enrolled to course", %{conn: conn, section: section} do
       {:error, {:redirect, %{to: redirect_path, flash: _flash_msg}}} =
-        live(conn, live_view_learn_live_route(section.slug))
+        live(conn, Utils.learn_live_path(section.slug))
 
       assert redirect_path == "/unauthorized"
     end
@@ -642,7 +638,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
       Sections.mark_section_visited_for_student(section, user)
 
-      {:ok, view, _html} = live(conn, live_view_learn_live_route(section.slug))
+      {:ok, view, _html} = live(conn, Utils.learn_live_path(section.slug))
 
       assert has_element?(view, "span", "The best course ever!")
       assert has_element?(view, "h3", "Introduction")
@@ -658,7 +654,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
       Sections.mark_section_visited_for_student(section, user)
 
-      {:ok, view, _html} = live(conn, live_view_learn_live_route(section.slug))
+      {:ok, view, _html} = live(conn, Utils.learn_live_path(section.slug))
 
       # unit 1 has an intro card with a video url provided, so there must be a play button
       assert has_element?(
@@ -695,7 +691,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
       Sections.mark_section_visited_for_student(section, user)
 
-      {:ok, view, _html} = live(conn, live_view_learn_live_route(section.slug))
+      {:ok, view, _html} = live(conn, Utils.learn_live_path(section.slug))
 
       refute has_element?(
                view,
@@ -753,7 +749,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
       Sections.mark_section_visited_for_student(section, user)
 
-      {:ok, view, _html} = live(conn, live_view_learn_live_route(section.slug))
+      {:ok, view, _html} = live(conn, Utils.learn_live_path(section.slug))
 
       # module 1 has intro video
       view
@@ -790,7 +786,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       %{state: enrollment_state} =
         Sections.get_enrollment(section.slug, user.id)
 
-      {:ok, view, _html} = live(conn, live_view_learn_live_route(section.slug))
+      {:ok, view, _html} = live(conn, Utils.learn_live_path(section.slug))
 
       refute enrollment_state["viewed_intro_video_resource_ids"]
 
@@ -808,7 +804,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       |> render_click()
 
       # since the video is marked as seen in an async way, we revisit the page to check if the icon changed
-      {:ok, view, _html} = live(conn, live_view_learn_live_route(section.slug))
+      {:ok, view, _html} = live(conn, Utils.learn_live_path(section.slug))
 
       %{state: enrollment_state} =
         Sections.get_enrollment(section.slug, user.id)
@@ -834,7 +830,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
       Sections.mark_section_visited_for_student(section, user)
 
-      {:ok, view, _html} = live(conn, live_view_learn_live_route(section.slug))
+      {:ok, view, _html} = live(conn, Utils.learn_live_path(section.slug))
 
       view
       |> element(~s{div[role="unit_1"] div[role="card_2"]})
@@ -890,7 +886,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
         false
       )
 
-      {:ok, view, _html} = live(conn, live_view_learn_live_route(section.slug))
+      {:ok, view, _html} = live(conn, Utils.learn_live_path(section.slug))
       # when the slider buttons are enabled we know the student async metrics were loaded
       assert_receive({_ref, {:push_event, "enable-slider-buttons", _}}, 2_000)
 
@@ -928,7 +924,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
       Sections.mark_section_visited_for_student(section, user)
 
-      {:ok, view, _html} = live(conn, live_view_learn_live_route(section.slug))
+      {:ok, view, _html} = live(conn, Utils.learn_live_path(section.slug))
 
       # expand unit 1/module 1 details
       view
@@ -1009,7 +1005,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
         true
       )
 
-      {:ok, view, _html} = live(conn, live_view_learn_live_route(section.slug))
+      {:ok, view, _html} = live(conn, Utils.learn_live_path(section.slug))
 
       # when the slider buttons are enabled we know the student async metrics were loaded
       assert_receive({_ref, {:push_event, "enable-slider-buttons", _}}, 2_000)
@@ -1036,7 +1032,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
       Sections.mark_section_visited_for_student(section, user)
 
-      {:ok, view, _html} = live(conn, live_view_learn_live_route(section.slug))
+      {:ok, view, _html} = live(conn, Utils.learn_live_path(section.slug))
 
       # page 1 belongs to module 1 (of unit 1) and page 5 belongs to module 3 (of unit 2)
       # Both should not be visible since they are not expanded yet
@@ -1091,7 +1087,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
       Sections.mark_section_visited_for_student(section, user)
 
-      {:ok, _view, _html} = live(conn, live_view_learn_live_route(section.slug))
+      {:ok, _view, _html} = live(conn, Utils.learn_live_path(section.slug))
     end
 
     test "sees a check icon on visited and completed pages", %{
@@ -1104,7 +1100,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       Sections.mark_section_visited_for_student(section, user)
 
       set_progress(section.id, page_1.resource_id, user.id, 1.0, page_1)
-      {:ok, view, _html} = live(conn, live_view_learn_live_route(section.slug))
+      {:ok, view, _html} = live(conn, Utils.learn_live_path(section.slug))
 
       # when the slider buttons are enabled we know the student async metrics were loaded
       assert_receive({_ref, {:push_event, "enable-slider-buttons", _}}, 2_000)
@@ -1130,7 +1126,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       Sections.mark_section_visited_for_student(section, user)
 
       set_progress(section.id, page_1.resource_id, user.id, 0.5, page_1)
-      {:ok, view, _html} = live(conn, live_view_learn_live_route(section.slug))
+      {:ok, view, _html} = live(conn, Utils.learn_live_path(section.slug))
 
       # expand unit 1/module 1 details
       view
@@ -1147,7 +1143,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
       Sections.mark_section_visited_for_student(section, user)
 
-      {:ok, view, _html} = live(conn, live_view_learn_live_route(section.slug))
+      {:ok, view, _html} = live(conn, Utils.learn_live_path(section.slug))
 
       # expand unit 1/module 1 details
       view
@@ -1159,8 +1155,12 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       |> element(~s{div[phx-click="navigate_to_resource"][phx-value-slug="#{page_1.slug}"]})
       |> render_click()
 
-      request_path = Utils.learn_live_path(section.slug, page_1.resource_id)
-      assert_redirect(view, Utils.lesson_live_path(section.slug, page_1.slug, request_path))
+      request_path = Utils.learn_live_path(section.slug, target_resource_id: page_1.resource_id)
+
+      assert_redirect(
+        view,
+        Utils.lesson_live_path(section.slug, page_1.slug, request_path: request_path)
+      )
     end
 
     test "can see the unit schedule details considering if the instructor has already scheduled it",
@@ -1172,7 +1172,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
       Sections.mark_section_visited_for_student(section, user)
 
-      {:ok, view, _html} = live(conn, live_view_learn_live_route(section.slug))
+      {:ok, view, _html} = live(conn, Utils.learn_live_path(section.slug))
 
       # unit 1 has been scheduled by instructor, so there must be schedule details data
       assert view
@@ -1200,7 +1200,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       set_progress(section.id, page_1.resource_id, user.id, 1.0, page_1)
       set_progress(section.id, page_2.resource_id, user.id, 0.5, page_2)
       set_progress(section.id, page_7.resource_id, user.id, 1.0, page_7)
-      {:ok, view, _html} = live(conn, live_view_learn_live_route(section.slug))
+      {:ok, view, _html} = live(conn, Utils.learn_live_path(section.slug))
 
       # when the slider buttons are enabled we know the student async metrics were loaded
       assert_receive({_ref, {:push_event, "enable-slider-buttons", _}}, 2_000)
@@ -1235,7 +1235,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
       Sections.mark_section_visited_for_student(section, user)
 
-      {:ok, view, _html} = live(conn, live_view_learn_live_route(section.slug))
+      {:ok, view, _html} = live(conn, Utils.learn_live_path(section.slug))
 
       assert has_element?(view, ~s{div[role="unit_3"] div[role="card_1"] div[role="page icon"]})
 
@@ -1244,9 +1244,12 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       |> element(~s{div[role="unit_3"] div[role="card_1"]})
       |> render_click()
 
-      request_path = Utils.learn_live_path(section.slug, page_7.resource_id)
+      request_path = Utils.learn_live_path(section.slug, target_resource_id: page_7.resource_id)
 
-      assert_redirect(view, Utils.lesson_live_path(section.slug, page_7.slug, request_path))
+      assert_redirect(
+        view,
+        Utils.lesson_live_path(section.slug, page_7.slug, request_path: request_path)
+      )
     end
 
     test "can see icon that identifies graded pages at level 2 of hierarchy (and can navigate to them)",
@@ -1259,7 +1262,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
       Sections.mark_section_visited_for_student(section, user)
 
-      {:ok, view, _html} = live(conn, live_view_learn_live_route(section.slug))
+      {:ok, view, _html} = live(conn, Utils.learn_live_path(section.slug))
 
       assert has_element?(
                view,
@@ -1271,9 +1274,12 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       |> element(~s{div[role="unit_3"] div[role="card_2"]})
       |> render_click()
 
-      request_path = Utils.learn_live_path(section.slug, page_8.resource_id)
+      request_path = Utils.learn_live_path(section.slug, target_resource_id: page_8.resource_id)
 
-      assert_redirect(view, Utils.lesson_live_path(section.slug, page_8.slug, request_path))
+      assert_redirect(
+        view,
+        Utils.lesson_live_path(section.slug, page_8.slug, request_path: request_path)
+      )
     end
 
     test "progress bar is not rendered when there is no progress",
@@ -1285,7 +1291,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
       Sections.mark_section_visited_for_student(section, user)
 
-      {:ok, view, _html} = live(conn, live_view_learn_live_route(section.slug))
+      {:ok, view, _html} = live(conn, Utils.learn_live_path(section.slug))
 
       # no progress yet, so progress bar is not rendered
       refute has_element?(view, ~s{div[role="unit_1"] div[role="card_1_progress"]})
@@ -1321,7 +1327,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
       Sections.mark_section_visited_for_student(section, user)
 
-      {:ok, view, _html} = live(conn, live_view_learn_live_route(section.slug))
+      {:ok, view, _html} = live(conn, Utils.learn_live_path(section.slug))
 
       assert view
              |> element(~s{div[role="unit_1"] div[role="card_1"]"})
@@ -1341,7 +1347,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
       Sections.mark_section_visited_for_student(section, user)
 
-      {:ok, view, _html} = live(conn, live_view_learn_live_route(section.slug))
+      {:ok, view, _html} = live(conn, Utils.learn_live_path(section.slug))
 
       assert view
              |> element(~s{div[role="unit_1"] div[role="intro_card"]"})
@@ -1373,7 +1379,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       {:ok, view, _html} =
         live(
           conn,
-          live_view_learn_live_route(section.slug, %{target_resource_id: unit_2.resource_id})
+          Utils.learn_live_path(section.slug, %{target_resource_id: unit_2.resource_id})
         )
 
       # scrolling and pulse animation are triggered
@@ -1402,7 +1408,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       {:ok, view, _html} =
         live(
           conn,
-          live_view_learn_live_route(section.slug, %{target_resource_id: module_3.resource_id})
+          Utils.learn_live_path(section.slug, %{target_resource_id: module_3.resource_id})
         )
 
       # scrolling and pulse animations are triggered
@@ -1443,7 +1449,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       {:ok, view, _html} =
         live(
           conn,
-          live_view_learn_live_route(section.slug, %{target_resource_id: page_8.resource_id})
+          Utils.learn_live_path(section.slug, %{target_resource_id: page_8.resource_id})
         )
 
       # scrolling and pulse animations are triggered
@@ -1477,7 +1483,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       {:ok, view, _html} =
         live(
           conn,
-          live_view_learn_live_route(section.slug, %{target_resource_id: page_6.resource_id})
+          Utils.learn_live_path(section.slug, %{target_resource_id: page_6.resource_id})
         )
 
       # scrolling and pulse animations are triggered

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -14,6 +14,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
   alias Oli.Repo
   alias Oli.Analytics.Summary
   alias Oli.Analytics.Common.Pipeline
+  alias OliWeb.Delivery.Student.Utils
 
   alias Oli.Analytics.Summary.{
     Context,
@@ -1158,7 +1159,8 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       |> element(~s{div[phx-click="navigate_to_resource"][phx-value-slug="#{page_1.slug}"]})
       |> render_click()
 
-      assert_redirect(view, "/sections/#{section.slug}/lesson/#{page_1.slug}")
+      request_path = Utils.learn_live_path(section.slug, page_1.resource_id)
+      assert_redirect(view, Utils.lesson_live_path(section.slug, page_1.slug, request_path))
     end
 
     test "can see the unit schedule details considering if the instructor has already scheduled it",
@@ -1242,7 +1244,9 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       |> element(~s{div[role="unit_3"] div[role="card_1"]})
       |> render_click()
 
-      assert_redirect(view, "/sections/#{section.slug}/lesson/#{page_7.slug}")
+      request_path = Utils.learn_live_path(section.slug, page_7.resource_id)
+
+      assert_redirect(view, Utils.lesson_live_path(section.slug, page_7.slug, request_path))
     end
 
     test "can see icon that identifies graded pages at level 2 of hierarchy (and can navigate to them)",
@@ -1267,7 +1271,9 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       |> element(~s{div[role="unit_3"] div[role="card_2"]})
       |> render_click()
 
-      assert_redirect(view, "/sections/#{section.slug}/lesson/#{page_8.slug}")
+      request_path = Utils.learn_live_path(section.slug, page_8.resource_id)
+
+      assert_redirect(view, Utils.lesson_live_path(section.slug, page_8.slug, request_path))
     end
 
     test "progress bar is not rendered when there is no progress",

--- a/test/oli_web/live/delivery/student/lesson_live_test.exs
+++ b/test/oli_web/live/delivery/student/lesson_live_test.exs
@@ -469,10 +469,10 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
 
       attempt = create_attempt(user, section, page_3)
 
-      request_path = Utils.learn_live_path(section.slug, page_3.resource_id)
+      request_path = Utils.learn_live_path(section.slug, target_resource_id: page_3.resource_id)
 
       {:ok, view, _html} =
-        live(conn, Utils.lesson_live_path(section.slug, page_3.slug, request_path))
+        live(conn, Utils.lesson_live_path(section.slug, page_3.slug, request_path: request_path))
 
       view
       |> element(~s{a[role="review_attempt_link"]})
@@ -480,7 +480,9 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
 
       assert_redirected(
         view,
-        Utils.review_live_path(section.slug, page_3.slug, attempt.attempt_guid, request_path)
+        Utils.review_live_path(section.slug, page_3.slug, attempt.attempt_guid,
+          request_path: request_path
+        )
       )
     end
 
@@ -613,11 +615,11 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
       |> render_click
 
       # It redirects to the next page, but still referencing the targeted Learn view in the URL with the next page resource
-      request_path = Utils.learn_live_path(section.slug, page_2.resource_id)
+      request_path = Utils.learn_live_path(section.slug, target_resource_id: page_2.resource_id)
 
       assert_redirected(
         view,
-        Utils.lesson_live_path(section.slug, page_2.slug, request_path)
+        Utils.lesson_live_path(section.slug, page_2.slug, request_path: request_path)
       )
     end
 
@@ -635,7 +637,7 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
       request_path = ~p"/sections/#{section.slug}/assignments"
 
       {:ok, view, _html} =
-        live(conn, Utils.lesson_live_path(section.slug, page_1.slug, request_path))
+        live(conn, Utils.lesson_live_path(section.slug, page_1.slug, request_path: request_path))
 
       view
       |> element(~s{div[role="next_page"] a})
@@ -643,7 +645,7 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
 
       assert_redirected(
         view,
-        Utils.lesson_live_path(section.slug, page_2.slug, request_path)
+        Utils.lesson_live_path(section.slug, page_2.slug, request_path: request_path)
       )
     end
 
@@ -668,7 +670,7 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
 
       assert_redirected(
         view,
-        Utils.learn_live_path(section.slug, module_2.resource_id)
+        Utils.learn_live_path(section.slug, target_resource_id: module_2.resource_id)
       )
 
       # previous page is a container
@@ -680,7 +682,7 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
 
       assert_redirected(
         view,
-        Utils.learn_live_path(section.slug, module_2.resource_id)
+        Utils.learn_live_path(section.slug, target_resource_id: module_2.resource_id)
       )
     end
 
@@ -714,10 +716,10 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
       Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
       Sections.mark_section_visited_for_student(section, user)
 
-      request_path = Utils.learn_live_path(section.slug, page_1.resource_id)
+      request_path = Utils.learn_live_path(section.slug, target_resource_id: page_1.resource_id)
 
       {:ok, view, _html} =
-        live(conn, Utils.lesson_live_path(section.slug, page_1.slug, request_path))
+        live(conn, Utils.lesson_live_path(section.slug, page_1.slug, request_path: request_path))
 
       view
       |> element(~s{div[role="back_link"] a})


### PR DESCRIPTION
[NG23-72](https://eliterate.atlassian.net/browse/NG23-72)

Fix the back button in the Lesson and Review pages to allow different request paths.

https://github.com/Simon-Initiative/oli-torus/assets/26532202/b34194d9-40ae-4981-b88a-e647e9a3375d



[NG23-72]: https://eliterate.atlassian.net/browse/NG23-72?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ