### PR TITLE
[BUG FIX] Ensure deleted resources in major publications are removed from section resources [MER-2987]

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -2439,45 +2439,49 @@ defmodule Oli.Delivery.Sections do
               new_published_resource = new_published_resources_map[resource_id]
               new_children = new_published_resource.children
 
-              updated_section_resource = case current_children do
-                nil ->
-                  # this section resource was just created so it can assume the newly published value
-                  %SectionResource{
-                    section_resource
-                    | children: Enum.map(new_children, &resource_id_to_sr_id[&1])
-                  }
+              updated_section_resource =
+                case current_children do
+                  nil ->
+                    # this section resource was just created so it can assume the newly published value
+                    %SectionResource{
+                      section_resource
+                      | children: Enum.map(new_children, &resource_id_to_sr_id[&1])
+                    }
 
-                current_children ->
-                  # ensure we are comparing resource_ids to resource_ids (and not section_resource_ids)
-                  # by translating the current section_resource children ids to resource_ids
-                  current_children_resource_ids =
-                    Enum.map(current_children, &sr_id_to_resource_id[&1])
+                  current_children ->
+                    # ensure we are comparing resource_ids to resource_ids (and not section_resource_ids)
+                    # by translating the current section_resource children ids to resource_ids
+                    current_children_resource_ids =
+                      Enum.map(current_children, &sr_id_to_resource_id[&1])
 
-                  # check if the children resource_ids have diverged from the new value
-                  if current_children_resource_ids != new_children do
-                    # There is a merge conflict between the current section resource and the new published resource.
-                    # Use the AIRRO three way merge algorithm to resolve
-                    base = prev_published_resource.children
-                    source = new_published_resource.children
-                    target = current_children_resource_ids
+                    # check if the children resource_ids have diverged from the new value
+                    if current_children_resource_ids != new_children do
+                      # There is a merge conflict between the current section resource and the new published resource.
+                      # Use the AIRRO three way merge algorithm to resolve
+                      base = prev_published_resource.children
+                      source = new_published_resource.children
+                      target = current_children_resource_ids
 
-                    case Oli.Publishing.Updating.Merge.merge(base, source, target) do
-                      {:ok, merged} ->
-                        %SectionResource{
+                      case Oli.Publishing.Updating.Merge.merge(base, source, target) do
+                        {:ok, merged} ->
+                          %SectionResource{
+                            section_resource
+                            | children: Enum.map(merged, &resource_id_to_sr_id[&1])
+                          }
+
+                        {:no_change} ->
                           section_resource
-                          | children: Enum.map(merged, &resource_id_to_sr_id[&1])
-                        }
-
-                      {:no_change} ->
-                        section_resource
+                      end
+                    else
+                      section_resource
                     end
-                  else
-                    section_resource
-                  end
-              end
+                end
 
-            clean_children(updated_section_resource, sr_id_to_resource_id, new_published_resources_map)
-
+              clean_children(
+                updated_section_resource,
+                sr_id_to_resource_id,
+                new_published_resources_map
+              )
             else
               section_resource
             end
@@ -2551,7 +2555,6 @@ defmodule Oli.Delivery.Sections do
   # 1. Any nil records are removed
   # 2. All non-nil sr id references map to a non-deleted revision in the new pub
   defp clean_children(section_resource, sr_id_to_resource_id, new_published_resources_map) do
-
     updated_children =
       section_resource.children
       |> Enum.filter(fn child_id -> !is_nil(child_id) end)

--- a/lib/oli/delivery/sections/minimal_hierarchy.ex
+++ b/lib/oli/delivery/sections/minimal_hierarchy.ex
@@ -32,7 +32,8 @@ defmodule Oli.Delivery.Sections.MinimalHierarchy do
       collab_space_config: r.collab_space_config,
       max_attempts: r.max_attempts,
       retake_mode: r.retake_mode,
-      project_id: p.project_id
+      project_id: p.project_id,
+      deleted: r.deleted
     })
     |> Repo.all()
     |> Enum.reduce(%{}, fn r, m -> Map.put(m, r.resource_id, r) end)
@@ -59,7 +60,8 @@ defmodule Oli.Delivery.Sections.MinimalHierarchy do
       scoring_strategy_id: r.scoring_strategy_id,
       collab_space_config: r.collab_space_config,
       max_attempts: r.max_attempts,
-      retake_mode: r.retake_mode
+      retake_mode: r.retake_mode,
+      deleted: r.deleted
     })
     |> Repo.all()
     |> Enum.map(fn pr -> Map.put(pr, :project_id, project_id) end)
@@ -84,7 +86,8 @@ defmodule Oli.Delivery.Sections.MinimalHierarchy do
     Map.put(
       node,
       :children,
-      Enum.map(children_ids, fn sr_id ->
+      Enum.filter(children_ids, fn sr_id -> !is_nil(Map.get(nodes_by_sr_id, sr_id)) end)
+      |> Enum.map(fn sr_id ->
         Map.get(nodes_by_sr_id, sr_id)
         |> hierarchy_node_with_children(nodes_by_sr_id)
       end)


### PR DESCRIPTION
The fix here was to add a step before the final full hierarchy "refetch" which “cleans” the `children` attribute of all section resource records, removing any SR id which no longer maps back to a currently published, non-deleted project resource.

Because it was not possible to reproduce locally this bug, the plan to verify this bug fix is to test it out on a copy of the production DB running on Heliotron, before we merge this to 26.3

UPDATE: I verified that these changes fix the problem faced by the affected course section (https://heliotron.oli.cmu.edu/sections/test_cmu_98179_student_taught_/instructor_dashboard/manage) on a Feb 1 copy of Prod. 
