### PR TITLE
[Bugfix] Allow tablemenu to overflow groups [MER-2957]

### DIFF
--- a/assets/styles/common/purpose.scss
+++ b/assets/styles/common/purpose.scss
@@ -186,6 +186,10 @@
   }
 }
 
+.resource-editor .content-purpose {
+  overflow: visible; // During authoring, let content overflow
+}
+
 .content-page-link {
   $color: #3d81f6;
   $bg: rgba(#64748b, 0.2);


### PR DESCRIPTION
The table-menu would get clipped when it tried to overflow a group. Made the simplest fix to change overflow:hidden to overflow:visible of groups during authoring time.

![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/a2af653a-5d90-431c-916d-cd13c3336eba)
