### PR TITLE
MER 2918 instructor role incorrect sorting of practice activities

### DIFF
--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -262,18 +262,11 @@ defmodule Oli.Delivery.Metrics do
   """
   def progress_across_for_pages(section_id, pages_ids, user_ids) when is_list(user_ids) do
     from(ra in ResourceAccess,
-      where:
-        ra.resource_id in ^pages_ids and ra.section_id == ^section_id and
-          ra.user_id in ^user_ids,
+      where: ra.resource_id in ^pages_ids,
+      where: ra.section_id == ^section_id,
+      where: ra.user_id in ^user_ids,
       group_by: ra.resource_id,
-      select: {
-        ra.resource_id,
-        fragment(
-          "SUM(?) / (?)",
-          ra.progress,
-          ^Enum.count(user_ids)
-        )
-      }
+      select: {ra.resource_id, fragment("SUM(?) / (?)", ra.progress, ^Enum.count(user_ids))}
     )
     |> Repo.all()
     |> Enum.into(%{})

--- a/lib/oli/publishing/delivery_resolver.ex
+++ b/lib/oli/publishing/delivery_resolver.ex
@@ -59,7 +59,7 @@ defmodule Oli.Publishing.DeliveryResolver do
         map(rev, [:id, :resource_id, :title]),
         map(sr, [:scheduling_type, :end_date])
       },
-      order_by: [asc: sr.numbering_level, asc: sr.numbering_index]
+      order_by: [asc: sr.numbering_index, asc: sr.numbering_level]
     )
     |> Repo.all()
   end

--- a/lib/oli_web/components/delivery/practice_activities/practice_assessments_table_model.ex
+++ b/lib/oli_web/components/delivery/practice_activities/practice_assessments_table_model.ex
@@ -109,13 +109,9 @@ defmodule OliWeb.Delivery.PracticeActivities.PracticeAssessmentsTableModel do
       })
 
     ~H"""
-    <%= if @avg_score != nil do %>
-      <div class={if @students_completion < 0.40, do: "text-red-600 font-bold"}>
-        <%= format_value(@students_completion) %>
-      </div>
-    <% else %>
-      -
-    <% end %>
+    <div class={if @students_completion < 0.40, do: "text-red-600 font-bold"}>
+      <%= format_value(@students_completion) %>
+    </div>
     """
   end
 

--- a/lib/oli_web/live/delivery/instructor_dashboard/helpers.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/helpers.ex
@@ -63,41 +63,21 @@ defmodule OliWeb.Delivery.InstructorDashboard.Helpers do
     graded_pages_and_section_resources =
       DeliveryResolver.graded_pages_revisions_and_section_resources(section.slug)
 
-    return_page(
-      graded_pages_and_section_resources,
-      section,
-      students
-    )
+    return_page(graded_pages_and_section_resources, section, students)
   end
 
-  defp return_page(
-         graded_pages_and_section_resources,
-         section,
-         students
-       ) do
+  defp return_page(graded_pages_and_section_resources, section, students) do
     student_ids = Enum.map(students, & &1.id)
     page_ids = Enum.map(graded_pages_and_section_resources, fn {rev, _} -> rev.resource_id end)
 
     progress_across_for_pages =
-      Metrics.progress_across_for_pages(
-        section.id,
-        page_ids,
-        student_ids
-      )
+      Metrics.progress_across_for_pages(section.id, page_ids, student_ids)
 
     avg_score_across_for_pages =
-      Metrics.avg_score_across_for_pages(
-        section,
-        page_ids,
-        student_ids
-      )
+      Metrics.avg_score_across_for_pages(section, page_ids, student_ids)
 
     attempts_across_for_pages =
-      Metrics.attempts_across_for_pages(
-        section,
-        page_ids,
-        student_ids
-      )
+      Metrics.attempts_across_for_pages(section, page_ids, student_ids)
 
     container_labels = Sections.map_resources_with_container_labels(section.slug, page_ids)
 
@@ -121,22 +101,14 @@ defmodule OliWeb.Delivery.InstructorDashboard.Helpers do
     ungraded_pages_and_section_resources =
       DeliveryResolver.ungraded_pages_revisions_and_section_resources(section.slug)
 
-    return_page(
-      ungraded_pages_and_section_resources,
-      section,
-      students
-    )
+    return_page(ungraded_pages_and_section_resources, section, students)
   end
 
   def get_assessments_with_surveys(section, students) do
     graded_pages_and_section_resources =
       DeliveryResolver.practice_pages_revisions_and_section_resources_with_surveys(section.slug)
 
-    return_page(
-      graded_pages_and_section_resources,
-      section,
-      students
-    )
+    return_page(graded_pages_and_section_resources, section, students)
   end
 
   def get_students(section, params \\ %{container_id: nil}) do

--- a/test/oli_web/live/delivery/instructor_dashboard/overview/practice_activities_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/overview/practice_activities_tab_test.exs
@@ -1082,6 +1082,16 @@ defmodule OliWeb.Delivery.InstructorDashboard.PracticeActivitiesTabTest do
       ContextRoles.get_role(:context_instructor)
     ])
 
+    # Data to feed progress_across_for_pages/3
+    for student <- [student_1, student_2, student_3, student_4] do
+      insert(:resource_access,
+        user: student,
+        section: section,
+        resource: page_1_revision.resource,
+        progress: 0.25
+      )
+    end
+
     %{
       section: section,
       section_v1: section_v1,
@@ -1211,6 +1221,9 @@ defmodule OliWeb.Delivery.InstructorDashboard.PracticeActivitiesTabTest do
       assert a2.title == "Module 2: BasicsPage 3"
       assert a3.title == "Module 2: BasicsPage 4"
       assert a4.title == "Orphaned Page"
+
+      # Checks for displaying student progress with a value different from null
+      assert a0.total_attempts == "25%"
     end
 
     @tag :skip

--- a/test/oli_web/live/delivery/instructor_dashboard/overview/practice_activities_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/overview/practice_activities_tab_test.exs
@@ -1206,11 +1206,11 @@ defmodule OliWeb.Delivery.InstructorDashboard.PracticeActivitiesTabTest do
       [a0, a1, a2, a3, a4] = table_as_list_of_maps(view)
 
       assert has_element?(view, "h4", "Practice Activities")
-      assert a0.title == "Orphaned Page"
-      assert a1.title == "Module 1: IntroductionPage 1"
-      assert a2.title == "Module 1: IntroductionPage 2"
-      assert a3.title == "Module 2: BasicsPage 3"
-      assert a4.title == "Module 2: BasicsPage 4"
+      assert a0.title == "Module 1: IntroductionPage 1"
+      assert a1.title == "Module 1: IntroductionPage 2"
+      assert a2.title == "Module 2: BasicsPage 3"
+      assert a3.title == "Module 2: BasicsPage 4"
+      assert a4.title == "Orphaned Page"
     end
 
     @tag :skip
@@ -2000,11 +2000,11 @@ defmodule OliWeb.Delivery.InstructorDashboard.PracticeActivitiesTabTest do
 
       [a0, a1, a2, a3, a4] = table_as_list_of_maps(view)
 
-      assert a0.title == "Orphaned Page"
-      assert a1.title == "Module 1: IntroductionPage 1"
-      assert a2.title == "Module 1: IntroductionPage 2"
-      assert a3.title == "Module 2: BasicsPage 3"
-      assert a4.title == "Module 2: BasicsPage 4"
+      assert a0.title == "Module 1: IntroductionPage 1"
+      assert a1.title == "Module 1: IntroductionPage 2"
+      assert a2.title == "Module 2: BasicsPage 3"
+      assert a3.title == "Module 2: BasicsPage 4"
+      assert a4.title == "Orphaned Page"
 
       # It does not display pagination options
       refute has_element?(view, "nav[aria-label=\"Paging\"]")
@@ -2027,8 +2027,8 @@ defmodule OliWeb.Delivery.InstructorDashboard.PracticeActivitiesTabTest do
       [a0, a1] = table_as_list_of_maps(view)
 
       # Page 1
-      assert a0.title == "Orphaned Page"
-      assert a1.title == "Module 1: IntroductionPage 1"
+      assert a0.title == "Module 1: IntroductionPage 1"
+      assert a1.title == "Module 1: IntroductionPage 2"
     end
 
     test "keeps showing the same elements when changing the page size", %{
@@ -2046,9 +2046,9 @@ defmodule OliWeb.Delivery.InstructorDashboard.PracticeActivitiesTabTest do
 
       [a2, a3] = table_as_list_of_maps(view)
 
-      # Page 2
-      assert a2.title == "Module 1: IntroductionPage 2"
-      assert a3.title == "Module 2: BasicsPage 3"
+      # Pages 3 and 4
+      assert a2.title == "Module 2: BasicsPage 3"
+      assert a3.title == "Module 2: BasicsPage 4"
 
       # Change page size from 2 to 1
       view
@@ -2058,7 +2058,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.PracticeActivitiesTabTest do
       [a2] = table_as_list_of_maps(view)
 
       # Page 3. It keeps showing the same element.
-      assert a2.title == "Module 1: IntroductionPage 2"
+      assert a2.title == "Module 2: BasicsPage 3"
     end
   end
 end


### PR DESCRIPTION
Ticket [MER-2918](https://eliterate.atlassian.net/browse/MER-2918)

This PR addressed 2 issues:
1. Fixed the ordering for the practice activities listing page.
2. Removed the dependency over average score data to display student progress, otherwise the student progress data might renders a dash if its average score is nil.

[MER-2918]: https://eliterate.atlassian.net/browse/MER-2918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ