### PR TITLE
[Bugfix] Could not "add expression" to activity banks in groups [MER-2913]

### DIFF
--- a/assets/src/apps/page-editor/PageEditor.tsx
+++ b/assets/src/apps/page-editor/PageEditor.tsx
@@ -434,7 +434,7 @@ export class PageEditor extends React.Component<PageEditorProps, PageEditorState
   // of content to be saved.  In this manner, we allow the user interface to display invalid, intermediate
   // states (as the user is creating a selection, for instance) that will always be saved
   // as valid states.
-  adjustContentForConstraints(content: PageEditorContent): PageEditorContent {
+  static adjustContentForConstraints(content: PageEditorContent): PageEditorContent {
     return content.updateAll((c: ResourceContent) => {
       if (c.type === 'selection') {
         return Object.assign({}, c, { logic: guaranteeValididty(c.logic) });
@@ -456,7 +456,7 @@ export class PageEditor extends React.Component<PageEditorProps, PageEditorState
   save() {
     const { projectSlug, resourceSlug } = this.props;
 
-    const adjusted = this.adjustContentForConstraints(this.state.content);
+    const adjusted = PageEditor.adjustContentForConstraints(this.state.content);
 
     const toSave: Persistence.ResourceUpdate = {
       objectives: { attached: this.state.objectives.toArray() },

--- a/assets/src/data/editor/PageEditorContent.ts
+++ b/assets/src/data/editor/PageEditorContent.ts
@@ -169,7 +169,7 @@ export class PageEditorContent extends Immutable.Record(defaultParams()) {
  * @param content
  * @returns
  */
-function withDefaultContent(
+export function withDefaultContent(
   content: Immutable.List<ResourceContent>,
 ): Immutable.List<ResourceContent> {
   if (content.size > 0) {
@@ -301,7 +301,11 @@ function updateAll(
 ): Immutable.List<ResourceContent> {
   return items.map((i) => {
     if (isResourceGroup(i)) {
-      (i as ResourceGroup).children = updateAll((i as ResourceGroup).children, fn);
+      const itemWithChildren = {
+        ...i,
+        children: updateAll((i as ResourceGroup).children, fn),
+      } as ResourceGroup;
+      return fn(itemWithChildren);
     }
 
     return fn(i);

--- a/assets/test/editor/page_editor_content_test.ts
+++ b/assets/test/editor/page_editor_content_test.ts
@@ -1,0 +1,146 @@
+import * as Immutable from 'immutable';
+import PageEditor from 'apps/page-editor/PageEditor';
+import { PageEditorContent, withDefaultContent } from 'data/editor/PageEditorContent';
+import * as Bank from '../../src/data/content/bank';
+import {
+  ActivityBankSelection,
+  PurposeGroupContent,
+  ResourceContent,
+} from '../../src/data/content/resource';
+
+describe('PageEditorContent', () => {
+  it('should be immutalble', () => {
+    const content = new PageEditorContent({
+      version: '1',
+      model: withDefaultContent(Immutable.List()),
+    });
+    expect(() => (content.version = '2')).toThrow();
+    const child: ActivityBankSelection = {
+      type: 'selection',
+      id: 'testChild',
+      logic: {
+        conditions: {
+          fact: Bank.Fact.objectives,
+          operator: Bank.ExpressionOperator.contains,
+          value: [],
+        },
+      },
+      count: 1,
+      children: undefined,
+    };
+    expect(content.model.size).toEqual(1);
+    const newContent1 = content.update('model', (model) => model.push(child));
+    expect(content.model.size).toBe(1);
+    expect(newContent1.model.size).toBe(2);
+
+    const newContent2 = newContent1.updateAll((item: ResourceContent) => {
+      if (item.type === 'selection') {
+        return { ...item, count: 2 };
+      }
+      return item;
+    });
+
+    expect((newContent1.model.get(1) as ActivityBankSelection)?.count).toBe(1);
+    expect((newContent2.model.get(1) as ActivityBankSelection)?.count).toBe(2);
+  });
+
+  it('should apply adjustContentForConstraints immutably', () => {
+    const content = new PageEditorContent({
+      version: '1',
+      model: withDefaultContent(Immutable.List()),
+    });
+    expect(() => (content.version = '2')).toThrow();
+    const child: ActivityBankSelection = {
+      type: 'selection',
+      id: 'testChild',
+      logic: {
+        conditions: {
+          fact: Bank.Fact.objectives,
+          operator: Bank.ExpressionOperator.contains,
+          value: [],
+        },
+      },
+      count: 1,
+      children: undefined,
+    };
+    expect(content.model.size).toEqual(1);
+    const newContent1 = content.update('model', (model) => model.push(child));
+    expect(content.model.size).toBe(1);
+    expect(newContent1.model.size).toBe(2);
+    const newContent2 = PageEditor.adjustContentForConstraints(newContent1);
+
+    expect((newContent1.model.get(1) as ActivityBankSelection)?.logic).toBe(child.logic);
+    expect(child.logic).toEqual({
+      conditions: {
+        fact: Bank.Fact.objectives,
+        operator: Bank.ExpressionOperator.contains,
+        value: [],
+      },
+    });
+    expect((newContent2.model.get(1) as ActivityBankSelection)?.logic).toEqual({
+      conditions: null,
+    });
+  });
+
+  it('should apply adjustContentForConstraints to groups immutably', () => {
+    const content = new PageEditorContent({
+      version: '1',
+      model: withDefaultContent(Immutable.List()),
+    });
+    expect(() => (content.version = '2')).toThrow();
+
+    const child: ActivityBankSelection = {
+      type: 'selection',
+      id: 'testChild',
+      logic: {
+        conditions: {
+          fact: Bank.Fact.objectives,
+          operator: Bank.ExpressionOperator.contains,
+          value: [],
+        },
+      },
+      count: 1,
+      children: undefined,
+    };
+
+    const group: PurposeGroupContent = {
+      type: 'group',
+      id: 'g1',
+      layout: 'vertical',
+      purpose: 'instruction',
+      children: Immutable.List([child]),
+    };
+
+    expect(content.model.size).toEqual(1);
+    const newContent1 = content.update('model', (model) => model.push(group));
+    expect(content.model.size).toBe(1);
+    expect(newContent1.model.size).toBe(2);
+
+    // At this point we have a PageEditorContent with a group inside it that has an activity bank selection inside the group
+
+    // Sanity check to make sure the child is in the right place before we call adjustContentForConstraints
+    expect((newContent1.model.get(1) as PurposeGroupContent)?.children.get(0)).toEqual(child);
+
+    const newContent2 = PageEditor.adjustContentForConstraints(newContent1);
+
+    // adjustContentForConstraints should not mutate it's input
+    expect((newContent1.model.get(1) as PurposeGroupContent)?.children.get(0)).toEqual(child);
+
+    // The original child should never be mutated
+    expect(child.logic).toEqual({
+      conditions: {
+        fact: Bank.Fact.objectives,
+        operator: Bank.ExpressionOperator.contains,
+        value: [],
+      },
+    });
+
+    // The new content should be modified by adjustContentForConstraints
+    expect(
+      ((newContent2.model.get(1) as PurposeGroupContent)?.children.get(0) as ActivityBankSelection)
+        .logic,
+    ).toEqual({
+      conditions: null,
+    });
+  });
+});


### PR DESCRIPTION
1. Create a group
2. Add an activity bank inside the group
3. Click the add-expression button

Expected: An expression is added
Actual: Nothing is added

Cause of bug: When we save the page, we pass it through PageEditor::adjustContentForConstraints before sending it to the server to make sure we don't have any invalid expressions.

That call to adjustContentForConstraints should have been an immutable operation that generated a new object with any changes. There was a bug in PageEditorContent::updateAll that caused a mutation of the original object instead of purely returning a new one. This caused the expression to be stripped out in-memory as well as in the version we sent to the server, which was not wanted. See notes in the new unit test for clarity