### PR TITLE
[BUGFIX] [MER-2915] Additional activity summarization only visible when answering more than once

### DIFF
--- a/assets/src/phoenix/activity_bridge.ts
+++ b/assets/src/phoenix/activity_bridge.ts
@@ -74,7 +74,7 @@ export const initActivityBridge = (elementId: string) => {
       makeRequest(
         `/api/v1/state/course/${e.detail.sectionSlug}/activity_attempt/${e.detail.attemptGuid}`,
         'POST',
-        {},
+        { survey_id: e.detail.props.context.surveyId },
         e.detail.continuation,
       );
     },

--- a/lib/oli/delivery/attempts/activity_lifecycle.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle.ex
@@ -93,7 +93,8 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle do
         section_slug,
         activity_attempt_guid,
         datashop_session_id,
-        seed_state_from_previous \\ false
+        seed_state_from_previous \\ false,
+        survey_id \\ nil
       ) do
     activity_attempt = get_activity_attempt_by(attempt_guid: activity_attempt_guid)
     resource_attempt = get_resource_attempt_and_revision(activity_attempt.resource_attempt_id)
@@ -139,7 +140,8 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle do
                      resource_id: activity_attempt.resource_id,
                      group_id: activity_attempt.group_id,
                      revision_id: revision.id,
-                     resource_attempt_id: activity_attempt.resource_attempt_id
+                     resource_attempt_id: activity_attempt.resource_attempt_id,
+                     survey_id: survey_id
                    }) do
               # simulate preloading of the revision
               new_activity_attempt = Map.put(new_activity_attempt, :revision, revision)

--- a/lib/oli_web/components/delivery/practice_activities/practice_activities.ex
+++ b/lib/oli_web/components/delivery/practice_activities/practice_activities.ex
@@ -616,7 +616,6 @@ defmodule OliWeb.Components.Delivery.PracticeActivities do
       select: map(rev, [:id, :resource_id, :title])
     )
     |> Repo.all()
-    |> IO.inspect(label: "practiceactivity")
   end
 
   def get_activities_details(activity_resource_ids, section, activity_types_map, page_resource_id) do

--- a/lib/oli_web/controllers/api/attempt_controller.ex
+++ b/lib/oli_web/controllers/api/attempt_controller.ex
@@ -641,7 +641,8 @@ defmodule OliWeb.Api.AttemptController do
         conn,
         %{
           "section_slug" => section_slug,
-          "activity_attempt_guid" => activity_attempt_guid
+          "activity_attempt_guid" => activity_attempt_guid,
+          "survey_id" => survey_id
         } = params
       ) do
     seed_state_from_previous = Map.get(params, "seedResponsesWithPrevious", false)
@@ -651,7 +652,8 @@ defmodule OliWeb.Api.AttemptController do
            section_slug,
            activity_attempt_guid,
            datashop_session_id,
-           seed_state_from_previous
+           seed_state_from_previous,
+           survey_id
          ) do
       {:ok, {attempt_state, model}} ->
         json(conn, %{"type" => "success", "attemptState" => attempt_state, "model" => model})

--- a/test/oli_web/controllers/api/attempt_controller_test.exs
+++ b/test/oli_web/controllers/api/attempt_controller_test.exs
@@ -3,6 +3,7 @@ defmodule OliWeb.AttemptControllerTest do
 
   alias Oli.Seeder
   alias Oli.Activities.Model.Part
+  alias Oli.Delivery.Attempts.Core
 
   describe "bulk activity attempt request" do
     setup [:setup_session]
@@ -43,6 +44,36 @@ defmodule OliWeb.AttemptControllerTest do
 
       part3_attempt = Enum.find(part_attempts, fn p -> p["partId"] == "3" end)
       assert part3_attempt["attemptNumber"] == 2
+    end
+  end
+
+  describe "reset activity attempt" do
+    setup [:setup_session]
+
+    test "use reset button sets survey_id field correctly", %{
+      conn: conn,
+      map: map
+    } do
+      # Simulate the user clicking the reset button
+      conn =
+        post(
+          conn,
+          Routes.attempt_path(
+            conn,
+            :new_activity,
+            map.section.slug,
+            map.activity_attempt1.attempt_guid
+          ),
+          %{survey_id: "1010"}
+        )
+
+      # Verify that the response is successful
+      assert %{"type" => "success", "attemptState" => attempt_state, "model" => _model} =
+               json_response(conn, 200)
+
+      # Verify that the survey_id was set correctly
+      assert Core.get_activity_attempt_by(attempt_guid: attempt_state["attemptGuid"]).survey_id ==
+               "1010"
     end
   end
 


### PR DESCRIPTION
[MER-2915](https://eliterate.atlassian.net/browse/MER-2915)

This PR seeks to correct the error mentioned in the ticket above. 

To do so, it was necessary to add to the actions that are executed when pressing the `Reset` button (to reset the activity) the `survey_id` information that ends up propagating to the Activity Attempts table in the database. 

It's necessary to set the `survey_id` whenever the activity is reset as this data must be added to the records created for that activity in the `Activity Attempts` table.

This change was necessary because the `Practice Activities` tab should NOT show the details of the activities that are contained within a survey.

[MER-2915]: https://eliterate.atlassian.net/browse/MER-2915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ