### PR TITLE
[MER-2988] Adds manual testing to Oban config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -162,7 +162,8 @@ config :oli, Oban,
     analytics_export: 3,
     datashop_export: 3,
     objectives: 3
-  ]
+  ],
+  testing: :manual
 
 config :ex_money,
   auto_start_exchange_rate_service: false,


### PR DESCRIPTION
[MER-2988](https://eliterate.atlassian.net/browse/MER-2988)

This PR adds configuration to Oban to prevent error messages from being displayed when running application tests. 

**image after apply config**

![Captura de pantalla 2024-02-06 a la(s) 10 09 46](https://github.com/Simon-Initiative/oli-torus/assets/16328384/7421aa21-9b8f-43dd-a1d6-178c0f8cf54d)


[MER-2988]: https://eliterate.atlassian.net/browse/MER-2988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ