### PR TITLE
[CHORE] Track deleted parts during cleaning, batch the activity id fetching, spot check [MER-2951]

### DIFF
--- a/lib/oli/delivery/attempts/core/activity_attempt.ex
+++ b/lib/oli/delivery/attempts/core/activity_attempt.ex
@@ -21,7 +21,7 @@ defmodule Oli.Delivery.Attempts.Core.ActivityAttempt do
     field(:group_id, :string, default: nil)
     field(:survey_id, :string, default: nil)
     field(:selection_id, :string, default: nil)
-    field(:cleanup, :integer, default: 0)
+    field(:cleanup, :integer, default: -1)
 
     belongs_to(:resource, Oli.Resources.Resource)
     belongs_to(:revision, Oli.Resources.Revision)

--- a/lib/oli/delivery/attempts/part_attempt_cleaner.ex
+++ b/lib/oli/delivery/attempts/part_attempt_cleaner.ex
@@ -37,6 +37,7 @@ defmodule Oli.Delivery.Attempts.PartAttemptCleaner do
 
   def init(_) do
     initial_state = %{
+      id_queue: [],
       running: false,
       batches_complete: 0,
       records_visited: 0,
@@ -56,22 +57,30 @@ defmodule Oli.Delivery.Attempts.PartAttemptCleaner do
   def handle_call({attribute, value}, _from, state) do
     Logger.info("PartAttemptCleaner setting #{attribute} to #{value}")
 
-    if attribute == :running and value do
-      next(self())
+    state = if attribute == :running and value do
+      case next(self(), state) do
+        {:ok, state} -> Map.put(state, :running, true)
+        {:error, :no_more_attempts} -> Map.put(state, :running, false)
+      end
+    else
+      Map.put(state, attribute, value)
     end
 
-    state = Map.put(state, attribute, value)
     {:reply, state, state}
   end
 
   def handle_info({:batch_finished, details}, state) do
     Logger.info("PartAttemptCleaner batch finished")
 
-    if state.running do
+    state = if state.running do
       if state.wait_time > 0 do
         Process.send_after(self(), {:quiet_period_elapsed}, state.wait_time)
+        state
       else
-        next(self())
+        case next(self(), state) do
+          {:ok, state} -> state
+          {:error, :no_more_attempts} -> Map.put(state, :running, false)
+        end
       end
     end
 
@@ -98,8 +107,16 @@ defmodule Oli.Delivery.Attempts.PartAttemptCleaner do
   def handle_info({:quiet_period_elapsed}, state) do
     Logger.info("PartAttemptCleaner quiet period elapsed")
 
-    if state.running do
-      next(self())
+    state = case state.running do
+      true ->
+        case next(self(), state) do
+          {:ok, state} -> state
+          {:error, :no_more_attempts} ->
+            state = Map.put(state, :running, false)
+            PubSub.broadcast(Oli.PubSub, "part_attempt_cleaner", {:no_more_attempts, state})
+            state
+        end
+      false -> state
     end
 
     {:noreply, state}
@@ -109,43 +126,50 @@ defmodule Oli.Delivery.Attempts.PartAttemptCleaner do
     {:noreply, state}
   end
 
-  def next(pid) do
-    Task.async(fn ->
-      case do_next() do
-        {:ok, {id, count, visited}} ->
-          Logger.info("PartAttemptCleaner deleted #{count} part attempts")
+  def next(pid, state) do
 
-          Process.send(
-            pid,
-            {:batch_finished, %{id: id, records_deleted: count, records_visited: visited}},
-            []
-          )
+    case pop_attempt_id_from_queue(state) do
 
-        {:error, :no_more_attempts} ->
-          Logger.warning("PartAttemptCleaner cannot find attempts to process")
-          Process.send(pid, {:no_more_attempts}, [])
+      {:ok, {activity_attempt_id, state}} ->
+        Task.async(fn ->
+          case do_next(activity_attempt_id) do
+            {:ok, {id, count, visited}} ->
+              Logger.info("PartAttemptCleaner deleted #{count} part attempts")
 
-        {:error, e} ->
-          Logger.error("PartAttemptCleaner encountered error [#{e}]")
-      end
-    end)
+              Process.send(
+                pid,
+                {:batch_finished, %{id: id, records_deleted: count, records_visited: visited}},
+                []
+              )
+
+            {:error, :no_more_attempts} ->
+              Logger.warning("PartAttemptCleaner cannot find attempts to process")
+              Process.send(pid, {:no_more_attempts}, [])
+
+            {:error, e} ->
+              Logger.error("PartAttemptCleaner encountered error [#{e}]")
+          end
+        end)
+
+        {:ok, state}
+
+      e ->
+        e
+    end
+
   end
 
-  def do_next() do
+  def do_next(activity_attempt_id) do
     Repo.transaction(fn ->
-      with {:ok, id} <- get_next_attempt_id(),
-           {:ok, part_attempts} <- read_part_attempts(id),
+      with {:ok, part_attempts} <- read_part_attempts(activity_attempt_id),
            {:ok, to_delete} <- determine_which_to_delete(part_attempts) do
         total = length(part_attempts)
         count = issue_delete(to_delete)
 
-        mark_as_done(id, count)
+        mark_as_done(activity_attempt_id, count)
 
-        {id, count, total}
+        {activity_attempt_id, count, total}
       else
-        {:error, :no_more_attempts} ->
-          Repo.rollback(:no_more_attempts)
-
         e ->
           Repo.rollback(e)
       end
@@ -279,7 +303,7 @@ defmodule Oli.Delivery.Attempts.PartAttemptCleaner do
     {:ok, results}
   end
 
-  defp get_next_attempt_id() do
+  defp get_attempt_id_batch() do
     # Any attempts newer than this do not have the bloat problem
     marker_date = ~U[2024-02-28 00:00:00Z]
 
@@ -290,15 +314,28 @@ defmodule Oli.Delivery.Attempts.PartAttemptCleaner do
              where: a.cleanup == -1 and a.inserted_at < ^marker_date,
              order_by: [asc: a.id],
              select: a.id,
-             limit: 1
+             limit: 1000
            )
          ) do
-      [id] -> {:ok, id}
       [] -> {:error, :no_more_attempts}
+      ids -> {:ok, ids}
     end
 
     Logger.debug("PartAttemptCleaner get_next_attempt_id in #{Oli.Timing.elapsed(mark) / 1000 / 1000}ms")
 
     result
+  end
+
+  # Attempts to pop an attempt_id from the queue, but when empty
+  # it will attempt to get a new batch of ids from the database to refill the queue
+  defp pop_attempt_id_from_queue(state) do
+    case state.id_queue do
+      [] ->
+        case get_attempt_id_batch() do
+          {:error, :no_more_attempts} -> {:error, :no_more_attempts}
+          {:ok, ids} -> {:ok, {Enum.at(ids, 0), Map.put(state, :id_queue, Enum.drop(ids, 1))}}
+        end
+      [id | rest] -> {:ok, {id, Map.put(state, :id_queue, rest)}}
+    end
   end
 end

--- a/lib/oli/delivery/attempts/part_attempt_cleaner.ex
+++ b/lib/oli/delivery/attempts/part_attempt_cleaner.ex
@@ -57,14 +57,15 @@ defmodule Oli.Delivery.Attempts.PartAttemptCleaner do
   def handle_call({attribute, value}, _from, state) do
     Logger.info("PartAttemptCleaner setting #{attribute} to #{value}")
 
-    state = if attribute == :running and value do
-      case next(self(), state) do
-        {:ok, state} -> Map.put(state, :running, true)
-        {:error, :no_more_attempts} -> Map.put(state, :running, false)
+    state =
+      if attribute == :running and value do
+        case next(self(), state) do
+          {:ok, state} -> Map.put(state, :running, true)
+          {:error, :no_more_attempts} -> Map.put(state, :running, false)
+        end
+      else
+        Map.put(state, attribute, value)
       end
-    else
-      Map.put(state, attribute, value)
-    end
 
     {:reply, state, state}
   end
@@ -72,17 +73,18 @@ defmodule Oli.Delivery.Attempts.PartAttemptCleaner do
   def handle_info({:batch_finished, details}, state) do
     Logger.info("PartAttemptCleaner batch finished")
 
-    state = if state.running do
-      if state.wait_time > 0 do
-        Process.send_after(self(), {:quiet_period_elapsed}, state.wait_time)
-        state
-      else
-        case next(self(), state) do
-          {:ok, state} -> state
-          {:error, :no_more_attempts} -> Map.put(state, :running, false)
+    state =
+      if state.running do
+        if state.wait_time > 0 do
+          Process.send_after(self(), {:quiet_period_elapsed}, state.wait_time)
+          state
+        else
+          case next(self(), state) do
+            {:ok, state} -> state
+            {:error, :no_more_attempts} -> Map.put(state, :running, false)
+          end
         end
       end
-    end
 
     state =
       Map.put(state, :batches_complete, state.batches_complete + 1)
@@ -107,17 +109,22 @@ defmodule Oli.Delivery.Attempts.PartAttemptCleaner do
   def handle_info({:quiet_period_elapsed}, state) do
     Logger.info("PartAttemptCleaner quiet period elapsed")
 
-    state = case state.running do
-      true ->
-        case next(self(), state) do
-          {:ok, state} -> state
-          {:error, :no_more_attempts} ->
-            state = Map.put(state, :running, false)
-            PubSub.broadcast(Oli.PubSub, "part_attempt_cleaner", {:no_more_attempts, state})
-            state
-        end
-      false -> state
-    end
+    state =
+      case state.running do
+        true ->
+          case next(self(), state) do
+            {:ok, state} ->
+              state
+
+            {:error, :no_more_attempts} ->
+              state = Map.put(state, :running, false)
+              PubSub.broadcast(Oli.PubSub, "part_attempt_cleaner", {:no_more_attempts, state})
+              state
+          end
+
+        false ->
+          state
+      end
 
     {:noreply, state}
   end
@@ -127,9 +134,7 @@ defmodule Oli.Delivery.Attempts.PartAttemptCleaner do
   end
 
   def next(pid, state) do
-
     case pop_attempt_id_from_queue(state) do
-
       {:ok, {activity_attempt_id, state}} ->
         Task.async(fn ->
           case do_next(activity_attempt_id) do
@@ -156,7 +161,6 @@ defmodule Oli.Delivery.Attempts.PartAttemptCleaner do
       e ->
         e
     end
-
   end
 
   def do_next(activity_attempt_id) do
@@ -179,7 +183,6 @@ defmodule Oli.Delivery.Attempts.PartAttemptCleaner do
   defp issue_delete([]), do: 0
 
   defp issue_delete(part_attempt_ids) do
-
     mark = Oli.Timing.mark()
 
     {count, _} =
@@ -189,13 +192,14 @@ defmodule Oli.Delivery.Attempts.PartAttemptCleaner do
         )
       )
 
-    Logger.debug("PartAttemptCleaner deleted #{count} part attempts in #{Oli.Timing.elapsed(mark) / 1000 / 1000}ms")
+    Logger.debug(
+      "PartAttemptCleaner deleted #{count} part attempts in #{Oli.Timing.elapsed(mark) / 1000 / 1000}ms"
+    )
 
     count
   end
 
   defp mark_as_done(id, count) do
-
     mark = Oli.Timing.mark()
 
     Repo.update_all(
@@ -209,7 +213,6 @@ defmodule Oli.Delivery.Attempts.PartAttemptCleaner do
   # Given a list of part attempts details, determine which to delete
   # and return a list of their ids.
   def determine_which_to_delete(part_attempts) do
-
     mark = Oli.Timing.mark()
 
     # separate into groups by part_id
@@ -243,7 +246,9 @@ defmodule Oli.Delivery.Attempts.PartAttemptCleaner do
       |> List.flatten()
       |> Enum.map(& &1.id)
 
-    Logger.debug("PartAttemptCleaner determine_which_to_delete in #{Oli.Timing.elapsed(mark) / 1000 / 1000}ms")
+    Logger.debug(
+      "PartAttemptCleaner determine_which_to_delete in #{Oli.Timing.elapsed(mark) / 1000 / 1000}ms"
+    )
 
     {:ok, to_delete}
   end
@@ -282,7 +287,6 @@ defmodule Oli.Delivery.Attempts.PartAttemptCleaner do
   # obviously would be a record that contained current state or
   # history that we need to keep.
   defp read_part_attempts(id) do
-
     mark = Oli.Timing.mark()
 
     results =
@@ -298,7 +302,9 @@ defmodule Oli.Delivery.Attempts.PartAttemptCleaner do
         )
       )
 
-    Logger.debug("PartAttemptCleaner read_part_attempts in #{Oli.Timing.elapsed(mark) / 1000 / 1000}ms")
+    Logger.debug(
+      "PartAttemptCleaner read_part_attempts in #{Oli.Timing.elapsed(mark) / 1000 / 1000}ms"
+    )
 
     {:ok, results}
   end
@@ -309,19 +315,22 @@ defmodule Oli.Delivery.Attempts.PartAttemptCleaner do
 
     mark = Oli.Timing.mark()
 
-    result = case Repo.all(
-           from(a in ActivityAttempt,
-             where: a.cleanup == -1 and a.inserted_at < ^marker_date,
-             order_by: [asc: a.id],
-             select: a.id,
-             limit: 1000
-           )
-         ) do
-      [] -> {:error, :no_more_attempts}
-      ids -> {:ok, ids}
-    end
+    result =
+      case Repo.all(
+             from(a in ActivityAttempt,
+               where: a.cleanup == -1 and a.inserted_at < ^marker_date,
+               order_by: [asc: a.id],
+               select: a.id,
+               limit: 1000
+             )
+           ) do
+        [] -> {:error, :no_more_attempts}
+        ids -> {:ok, ids}
+      end
 
-    Logger.debug("PartAttemptCleaner get_next_attempt_id in #{Oli.Timing.elapsed(mark) / 1000 / 1000}ms")
+    Logger.debug(
+      "PartAttemptCleaner get_next_attempt_id in #{Oli.Timing.elapsed(mark) / 1000 / 1000}ms"
+    )
 
     result
   end
@@ -335,7 +344,9 @@ defmodule Oli.Delivery.Attempts.PartAttemptCleaner do
           {:error, :no_more_attempts} -> {:error, :no_more_attempts}
           {:ok, ids} -> {:ok, {Enum.at(ids, 0), Map.put(state, :id_queue, Enum.drop(ids, 1))}}
         end
-      [id | rest] -> {:ok, {id, Map.put(state, :id_queue, rest)}}
+
+      [id | rest] ->
+        {:ok, {id, Map.put(state, :id_queue, rest)}}
     end
   end
 end

--- a/lib/oli/delivery/attempts/part_attempt_cleaner.ex
+++ b/lib/oli/delivery/attempts/part_attempt_cleaner.ex
@@ -139,7 +139,7 @@ defmodule Oli.Delivery.Attempts.PartAttemptCleaner do
         total = length(part_attempts)
         count = issue_delete(to_delete)
 
-        mark_as_done(id)
+        mark_as_done(id, count)
 
         {id, count, total}
       else
@@ -165,10 +165,10 @@ defmodule Oli.Delivery.Attempts.PartAttemptCleaner do
     count
   end
 
-  defp mark_as_done(id) do
+  defp mark_as_done(id, count) do
     Repo.update_all(
       from(a in ActivityAttempt, where: a.id == ^id),
-      set: [cleanup: 1]
+      set: [cleanup: count]
     )
   end
 
@@ -265,7 +265,7 @@ defmodule Oli.Delivery.Attempts.PartAttemptCleaner do
 
     case Repo.all(
            from(a in ActivityAttempt,
-             where: a.cleanup == 0 and a.inserted_at < ^marker_date,
+             where: a.cleanup == -1 and a.inserted_at < ^marker_date,
              order_by: [asc: a.id],
              select: a.id,
              limit: 1

--- a/lib/oli_web/controllers/spot_check_controller.ex
+++ b/lib/oli_web/controllers/spot_check_controller.ex
@@ -1,0 +1,21 @@
+defmodule OliWeb.SpotCheckController do
+  use OliWeb, :controller
+
+  import Ecto.Query, warn: false
+
+  def index(conn, %{"activity_attempt_id" => attempt_id}) do
+
+    {section_slug, attempt_guid} = from(a in Oli.Delivery.Attempts.Core.ActivityAttempt,
+      join: r in Oli.Delivery.Attempts.Core.ResourceAttempt, on: a.resource_attempt_id == r.id,
+      join: ra in Oli.Delivery.Attempts.Core.ResourceAccess, on: r.resource_access_id == ra.id,
+      join: s in Oli.Delivery.Sections.Section, on: s.id == ra.section_id,
+      where: a.id == ^attempt_id,
+      select: {s.slug, r.attempt_guid}
+    )
+    |> Oli.Repo.one()
+
+    conn
+    |> redirect(to: Routes.instructor_review_path(conn, :review_attempt, section_slug, attempt_guid))
+  end
+
+end

--- a/lib/oli_web/controllers/spot_check_controller.ex
+++ b/lib/oli_web/controllers/spot_check_controller.ex
@@ -4,18 +4,22 @@ defmodule OliWeb.SpotCheckController do
   import Ecto.Query, warn: false
 
   def index(conn, %{"activity_attempt_id" => attempt_id}) do
-
-    {section_slug, attempt_guid} = from(a in Oli.Delivery.Attempts.Core.ActivityAttempt,
-      join: r in Oli.Delivery.Attempts.Core.ResourceAttempt, on: a.resource_attempt_id == r.id,
-      join: ra in Oli.Delivery.Attempts.Core.ResourceAccess, on: r.resource_access_id == ra.id,
-      join: s in Oli.Delivery.Sections.Section, on: s.id == ra.section_id,
-      where: a.id == ^attempt_id,
-      select: {s.slug, r.attempt_guid}
-    )
-    |> Oli.Repo.one()
+    {section_slug, attempt_guid} =
+      from(a in Oli.Delivery.Attempts.Core.ActivityAttempt,
+        join: r in Oli.Delivery.Attempts.Core.ResourceAttempt,
+        on: a.resource_attempt_id == r.id,
+        join: ra in Oli.Delivery.Attempts.Core.ResourceAccess,
+        on: r.resource_access_id == ra.id,
+        join: s in Oli.Delivery.Sections.Section,
+        on: s.id == ra.section_id,
+        where: a.id == ^attempt_id,
+        select: {s.slug, r.attempt_guid}
+      )
+      |> Oli.Repo.one()
 
     conn
-    |> redirect(to: Routes.instructor_review_path(conn, :review_attempt, section_slug, attempt_guid))
+    |> redirect(
+      to: Routes.instructor_review_path(conn, :review_attempt, section_slug, attempt_guid)
+    )
   end
-
 end

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -1171,6 +1171,7 @@ defmodule OliWeb.Router do
     live("/", Admin.AdminView)
     live("/features", Features.FeaturesLive)
     live("/part_attempts", Admin.PartAttemptsView)
+    get("/spot_check/:activity_attempt_id", SpotCheckController, :index)
     live("/api_keys", ApiKeys.ApiKeysLive)
     live("/products", Products.ProductsView)
     live("/products/:product_id/discounts", Products.Payments.Discounts.ProductsIndexView)

--- a/priv/repo/migrations/20240129162557_add_cleanup_state.exs
+++ b/priv/repo/migrations/20240129162557_add_cleanup_state.exs
@@ -3,7 +3,7 @@ defmodule Oli.Repo.Migrations.AddCleanupState do
 
   def change do
     alter table(:activity_attempts) do
-      add(:cleanup, :integer, default: 0)
+      add(:cleanup, :integer, default: -1)
     end
 
     create(index(:activity_attempts, [:cleanup]))


### PR DESCRIPTION
This PR changes the part cleaner implementation in two ways:

1. It now records in the `cleanup` field the number of deleted part attempt records
2. The "fetch next id" step was proving to be the bottleneck in performance. This PR adds in an in-memory queue of size 1000

Also, this adds the "spot check" route to make it easier to review page attempts of affected activity attempts