### PR TITLE
[ENHANCEMENT] show multi-input feedbacks in order of inputs in stem [MER-2995]

### DIFF
--- a/assets/src/components/activities/common/authoring/actions/multipleChoiceActions.ts
+++ b/assets/src/components/activities/common/authoring/actions/multipleChoiceActions.ts
@@ -17,10 +17,16 @@ import { Operations } from 'utils/pathOperations';
 
 export const MCActions = {
   removeChoice(id: string, partId: string) {
+    console.log(`Making removeChoice action: id='${id}'`);
     return (model: any & HasParts, post: PostUndoable) => {
       const choice = Choices.getOne(model, id);
       const index = Choices.getAll(model).findIndex((c) => c.id === id);
+      console.log('removeChoice model.choices: ' + JSON.stringify(model.choices, null, 2));
+      console.log(
+        `removing one choice id='${id}' index=${index}: ${JSON.stringify(choice, null, 2)}`,
+      );
       Choices.removeOne(id)(model);
+      console.log('model.choices now: ' + JSON.stringify(model.choices, null, 2));
 
       // if the choice being removed is the correct choice, a new correct choice
       // must be set

--- a/assets/src/components/activities/common/delivery/evaluation/Evaluation.tsx
+++ b/assets/src/components/activities/common/delivery/evaluation/Evaluation.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { isDefined } from 'components/activities/response_multi/rules';
 import { ActivityState, PartState, makeContent, makeFeedback } from 'components/activities/types';
 import { WriterContext } from 'data/content/writers/context';
 import { HtmlContentModelRenderer } from 'data/content/writers/renderer';
+import { isDefined } from 'utils/common';
 
 interface Props {
   shouldShow?: boolean;
@@ -77,10 +77,12 @@ export const Evaluation: React.FC<Props> = ({
     return renderPartFeedback(parts[0], context);
   }
 
-  // for migrated multi-inputs: allow caller to specify order different from part order
-  const orderedParts = partOrder
-    ? partOrder.map((id) => parts.find((ps) => ps.partId === id)).filter(isDefined)
-    : parts;
+  // part order for migrated multi-inputs may be random, so allow caller to specify appropriate one
+  let orderedParts = parts;
+  if (partOrder) {
+    const newOrder = partOrder.map((id) => parts.find((ps) => ps.partId === id)).filter(isDefined);
+    if (newOrder.length === parts.length) orderedParts = newOrder;
+  }
 
   return <>{orderedParts.map((partState) => renderPartFeedback(partState, context))}</>;
 };

--- a/assets/src/components/activities/common/delivery/evaluation/Evaluation.tsx
+++ b/assets/src/components/activities/common/delivery/evaluation/Evaluation.tsx
@@ -77,7 +77,7 @@ export const Evaluation: React.FC<Props> = ({
     return renderPartFeedback(parts[0], context);
   }
 
-  // allow migrated multi-input to show feedback in input order, different from part order
+  // for migrated multi-inputs: allow caller to specify order different from part order
   const orderedParts = partOrder
     ? partOrder.map((id) => parts.find((ps) => ps.partId === id)).filter(isDefined)
     : parts;

--- a/assets/src/components/activities/common/delivery/evaluation/Evaluation.tsx
+++ b/assets/src/components/activities/common/delivery/evaluation/Evaluation.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { isDefined } from 'components/activities/response_multi/rules';
 import { ActivityState, PartState, makeContent, makeFeedback } from 'components/activities/types';
 import { WriterContext } from 'data/content/writers/context';
 import { HtmlContentModelRenderer } from 'data/content/writers/renderer';
@@ -7,6 +8,7 @@ interface Props {
   shouldShow?: boolean;
   attemptState: ActivityState;
   context: WriterContext;
+  partOrder?: string[];
 }
 
 export function renderPartFeedback(partState: PartState, context: WriterContext) {
@@ -60,7 +62,12 @@ export function renderPartFeedback(partState: PartState, context: WriterContext)
   );
 }
 
-export const Evaluation: React.FC<Props> = ({ shouldShow = true, attemptState, context }) => {
+export const Evaluation: React.FC<Props> = ({
+  shouldShow = true,
+  attemptState,
+  context,
+  partOrder,
+}) => {
   const { parts } = attemptState;
   if (!shouldShow) {
     return null;
@@ -70,7 +77,12 @@ export const Evaluation: React.FC<Props> = ({ shouldShow = true, attemptState, c
     return renderPartFeedback(parts[0], context);
   }
 
-  return <>{parts.map((partState) => renderPartFeedback(partState, context))}</>;
+  // allow migrated multi-input to show feedback in input order, different from part order
+  const orderedParts = partOrder
+    ? partOrder.map((id) => parts.find((ps) => ps.partId === id)).filter(isDefined)
+    : parts;
+
+  return <>{orderedParts.map((partState) => renderPartFeedback(partState, context))}</>;
 };
 
 interface ComponentProps {

--- a/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
@@ -33,6 +33,7 @@ import { configureStore } from 'state/store';
 import { DeliveryElementProvider, useDeliveryElementContext } from '../DeliveryElementProvider';
 import { SubmitResetConnected } from '../common/delivery/SubmitReset';
 import { initializePersistence } from '../common/delivery/persistence';
+import { orderedPartIds } from './utils';
 
 export const MultiInputComponent: React.FC = () => {
   const {
@@ -344,6 +345,7 @@ export const MultiInputComponent: React.FC = () => {
           }
           attemptState={uiState.attemptState}
           context={writerContext}
+          partOrder={orderedPartIds(model)}
         />
         <Submission attemptState={uiState.attemptState} surveyId={surveyId} />
       </div>

--- a/assets/src/components/activities/multi_input/utils.tsx
+++ b/assets/src/components/activities/multi_input/utils.tsx
@@ -21,6 +21,7 @@ import { InputRef, Paragraph } from 'data/content/model/elements/types';
 import { elementsOfType } from 'data/content/utils';
 import { clone } from 'utils/common';
 import guid from 'utils/guid';
+import { isDefined } from '../response_multi/rules';
 
 export const multiInputOptions: SelectOption<'text' | 'numeric'>[] = [
   { value: 'numeric', displayValue: 'Number' },
@@ -79,6 +80,15 @@ export const partTitle = (input: MultiInput, index: number) => (
     <span className="text-muted">{friendlyType(input.inputType)}</span>
   </div>
 );
+
+// return part ids in order of input occurrence in stem
+export const orderedPartIds = (model: MultiInputSchema) =>
+  elementsOfType(model.stem.content, 'input_ref')
+    .map((iref) => inputRefToPartId(model, iref))
+    .filter(isDefined);
+
+const inputRefToPartId = (model: MultiInputSchema, inputRef: any) =>
+  model.inputs.find((input: any) => input.id === inputRef.input)?.partId;
 
 export function guaranteeMultiInputValidity(model: MultiInputSchema): MultiInputSchema {
   // Check whether model is valid first to save unnecessarily cloning the model

--- a/assets/src/components/activities/multi_input/utils.tsx
+++ b/assets/src/components/activities/multi_input/utils.tsx
@@ -20,8 +20,8 @@ import { Model } from 'data/content/model/elements/factories';
 import { InputRef, Paragraph } from 'data/content/model/elements/types';
 import { elementsOfType } from 'data/content/utils';
 import { clone } from 'utils/common';
+import { isDefined } from 'utils/common';
 import guid from 'utils/guid';
-import { isDefined } from '../response_multi/rules';
 
 export const multiInputOptions: SelectOption<'text' | 'numeric'>[] = [
   { value: 'numeric', displayValue: 'Number' },
@@ -88,7 +88,7 @@ export const orderedPartIds = (model: MultiInputSchema) =>
     .filter(isDefined);
 
 const inputRefToPartId = (model: MultiInputSchema, inputRef: any) =>
-  model.inputs.find((input: any) => input.id === inputRef.input)?.partId;
+  model.inputs.find((input: any) => input.id === inputRef.id)?.partId;
 
 export function guaranteeMultiInputValidity(model: MultiInputSchema): MultiInputSchema {
   // Check whether model is valid first to save unnecessarily cloning the model

--- a/assets/src/components/activities/response_multi/rules.ts
+++ b/assets/src/components/activities/response_multi/rules.ts
@@ -1,4 +1,5 @@
 import { andRules, orRules, unescapeInput } from 'data/activities/model/rules';
+import { isDefined } from 'utils/common';
 import { addOrRemove, remove } from '../common/utils';
 import { MatchStyle } from '../types';
 
@@ -86,11 +87,6 @@ export const getUniqueRuleForInput = (r: MultiRule, id: string): InputRule => {
 // get all values for this input id in compound rule. Mainly for dropdowns
 export const getInputValues = (r: MultiRule, id: string): string[] =>
   getRulesForInput(r, id).map(inputRuleValue);
-
-// generic type guard enabling TypeScript to narrow filtered types to non-undefined
-export function isDefined<T>(value: T | undefined): value is T {
-  return value !== undefined;
-}
 
 // get list of unique inputRefs used in compound rule
 export const ruleInputRefs = (r: MultiRule): string[] => [

--- a/assets/src/utils/common.ts
+++ b/assets/src/utils/common.ts
@@ -301,3 +301,8 @@ export const padLeft = (inp: string | number, length: number, char = '0') => {
   const str = String(inp);
   return str.length >= length ? str : new Array(length - str.length + 1).join(char) + str;
 };
+
+// generic type guard enabling TypeScript to narrow filtered types to non-undefined
+export function isDefined<T>(value: T | undefined): value is T {
+  return value !== undefined;
+}


### PR DESCRIPTION
For multi-part questions, the torus Evaluation component shows multiple feedbacks in order of occurrence of parts in the question model. However, migrated questions may list parts in arbitrary order (in fact, order corresponding to order in the inputs section of the legacy XML), leading to confusion for students in matching feedbacks to parts on these questions. For example, if a question has 3 inputs on successive lines 1, 2, 3, feedbacks may be listed in order 3,1,2.

This PR sorts multi-input feedbacks in order of occurrence of the input_refs in the question stem. This is taken to be order in which they are listed by elementsOType function which effectively does an in-order traversal of the stem content tree. This generally finds them in reading order from left-to-right then top-to-bottom. Makes no attempt to account for different text direction. 

In cases of tabular layout, left-to-right top-to-bottom might not be the most obvious order, but most questions seen are not of this form, and there is no unambiguous order to use for those in any case. 

Implementation uses an optional partOrder prop which is only set by multiInputDelivery, so should leave other activity's feedback unchanged. 

This also moves a small utility function `isDefined` into a common module. 