### PR TITLE
 [BUGFIX] allow deletion of of migrated mcq choices [MER-2998]

### DIFF
--- a/assets/src/components/activities/common/authoring/actions/multipleChoiceActions.ts
+++ b/assets/src/components/activities/common/authoring/actions/multipleChoiceActions.ts
@@ -17,16 +17,10 @@ import { Operations } from 'utils/pathOperations';
 
 export const MCActions = {
   removeChoice(id: string, partId: string) {
-    console.log(`Making removeChoice action: id='${id}'`);
     return (model: any & HasParts, post: PostUndoable) => {
       const choice = Choices.getOne(model, id);
       const index = Choices.getAll(model).findIndex((c) => c.id === id);
-      console.log('removeChoice model.choices: ' + JSON.stringify(model.choices, null, 2));
-      console.log(
-        `removing one choice id='${id}' index=${index}: ${JSON.stringify(choice, null, 2)}`,
-      );
       Choices.removeOne(id)(model);
-      console.log('model.choices now: ' + JSON.stringify(model.choices, null, 2));
 
       // if the choice being removed is the correct choice, a new correct choice
       // must be set

--- a/assets/src/components/activities/common/authoring/actions/multipleChoiceActions.ts
+++ b/assets/src/components/activities/common/authoring/actions/multipleChoiceActions.ts
@@ -17,10 +17,16 @@ import { Operations } from 'utils/pathOperations';
 
 export const MCActions = {
   removeChoice(id: string, partId: string) {
+    console.log(`Making removeChoice action: id='${id}'`);
     return (model: any & HasParts, post: PostUndoable) => {
       const choice = Choices.getOne(model, id);
       const index = Choices.getAll(model).findIndex((c) => c.id === id);
+      console.log('removeChoice model.choices: ' + JSON.stringify(model.choices, null, 2));
+      console.log(
+        `removing one choice id='${id}' index=${index}: ${JSON.stringify(choice, null, 2)}`,
+      );
       Choices.removeOne(id)(model);
+      console.log('model.choices now: ' + JSON.stringify(model.choices, null, 2));
 
       // if the choice being removed is the correct choice, a new correct choice
       // must be set

--- a/assets/src/components/activities/common/delivery/evaluation/Evaluation.tsx
+++ b/assets/src/components/activities/common/delivery/evaluation/Evaluation.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { isDefined } from 'components/activities/response_multi/rules';
 import { ActivityState, PartState, makeContent, makeFeedback } from 'components/activities/types';
 import { WriterContext } from 'data/content/writers/context';
 import { HtmlContentModelRenderer } from 'data/content/writers/renderer';
+import { isDefined } from 'utils/common';
 
 interface Props {
   shouldShow?: boolean;
@@ -77,10 +77,12 @@ export const Evaluation: React.FC<Props> = ({
     return renderPartFeedback(parts[0], context);
   }
 
-  // for migrated multi-inputs: allow caller to specify order different from part order
-  const orderedParts = partOrder
-    ? partOrder.map((id) => parts.find((ps) => ps.partId === id)).filter(isDefined)
-    : parts;
+  // part order for migrated multi-inputs may be random, so allow caller to specify appropriate one
+  let orderedParts = parts;
+  if (partOrder) {
+    const newOrder = partOrder.map((id) => parts.find((ps) => ps.partId === id)).filter(isDefined);
+    if (newOrder.length === parts.length) orderedParts = newOrder;
+  }
 
   return <>{orderedParts.map((partState) => renderPartFeedback(partState, context))}</>;
 };

--- a/assets/src/components/activities/common/delivery/evaluation/Evaluation.tsx
+++ b/assets/src/components/activities/common/delivery/evaluation/Evaluation.tsx
@@ -77,7 +77,7 @@ export const Evaluation: React.FC<Props> = ({
     return renderPartFeedback(parts[0], context);
   }
 
-  // allow migrated multi-input to show feedback in input order, different from part order
+  // for migrated multi-inputs: allow caller to specify order different from part order
   const orderedParts = partOrder
     ? partOrder.map((id) => parts.find((ps) => ps.partId === id)).filter(isDefined)
     : parts;

--- a/assets/src/components/activities/common/delivery/evaluation/Evaluation.tsx
+++ b/assets/src/components/activities/common/delivery/evaluation/Evaluation.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { isDefined } from 'components/activities/response_multi/rules';
 import { ActivityState, PartState, makeContent, makeFeedback } from 'components/activities/types';
 import { WriterContext } from 'data/content/writers/context';
 import { HtmlContentModelRenderer } from 'data/content/writers/renderer';
@@ -7,6 +8,7 @@ interface Props {
   shouldShow?: boolean;
   attemptState: ActivityState;
   context: WriterContext;
+  partOrder?: string[];
 }
 
 export function renderPartFeedback(partState: PartState, context: WriterContext) {
@@ -60,7 +62,12 @@ export function renderPartFeedback(partState: PartState, context: WriterContext)
   );
 }
 
-export const Evaluation: React.FC<Props> = ({ shouldShow = true, attemptState, context }) => {
+export const Evaluation: React.FC<Props> = ({
+  shouldShow = true,
+  attemptState,
+  context,
+  partOrder,
+}) => {
   const { parts } = attemptState;
   if (!shouldShow) {
     return null;
@@ -70,7 +77,12 @@ export const Evaluation: React.FC<Props> = ({ shouldShow = true, attemptState, c
     return renderPartFeedback(parts[0], context);
   }
 
-  return <>{parts.map((partState) => renderPartFeedback(partState, context))}</>;
+  // allow migrated multi-input to show feedback in input order, different from part order
+  const orderedParts = partOrder
+    ? partOrder.map((id) => parts.find((ps) => ps.partId === id)).filter(isDefined)
+    : parts;
+
+  return <>{orderedParts.map((partState) => renderPartFeedback(partState, context))}</>;
 };
 
 interface ComponentProps {

--- a/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
@@ -33,7 +33,7 @@ import { configureStore } from 'state/store';
 import { DeliveryElementProvider, useDeliveryElementContext } from '../DeliveryElementProvider';
 import { SubmitResetConnected } from '../common/delivery/SubmitReset';
 import { initializePersistence } from '../common/delivery/persistence';
-import { orderedPartIds } from './utils';
+import { getOrderedPartIds } from './utils';
 
 export const MultiInputComponent: React.FC = () => {
   const {
@@ -52,6 +52,8 @@ export const MultiInputComponent: React.FC = () => {
   const { surveyId, sectionSlug, bibParams } = context;
   const uiState = useSelector((state: ActivityDeliveryState) => state);
   const [hintsShown, setHintsShown] = React.useState<PartId[]>([]);
+
+  const [orderedPartIds] = React.useState(getOrderedPartIds(model));
 
   const [isInputDirty, setInputDirty] = React.useState(
     activityState.parts.reduce((acc: any, part) => {
@@ -345,7 +347,7 @@ export const MultiInputComponent: React.FC = () => {
           }
           attemptState={uiState.attemptState}
           context={writerContext}
-          partOrder={orderedPartIds(model)}
+          partOrder={orderedPartIds}
         />
         <Submission attemptState={uiState.attemptState} surveyId={surveyId} />
       </div>

--- a/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
@@ -33,6 +33,7 @@ import { configureStore } from 'state/store';
 import { DeliveryElementProvider, useDeliveryElementContext } from '../DeliveryElementProvider';
 import { SubmitResetConnected } from '../common/delivery/SubmitReset';
 import { initializePersistence } from '../common/delivery/persistence';
+import { orderedPartIds } from './utils';
 
 export const MultiInputComponent: React.FC = () => {
   const {
@@ -344,6 +345,7 @@ export const MultiInputComponent: React.FC = () => {
           }
           attemptState={uiState.attemptState}
           context={writerContext}
+          partOrder={orderedPartIds(model)}
         />
         <Submission attemptState={uiState.attemptState} surveyId={surveyId} />
       </div>

--- a/assets/src/components/activities/multi_input/utils.tsx
+++ b/assets/src/components/activities/multi_input/utils.tsx
@@ -21,6 +21,7 @@ import { InputRef, Paragraph } from 'data/content/model/elements/types';
 import { elementsOfType } from 'data/content/utils';
 import { clone } from 'utils/common';
 import guid from 'utils/guid';
+import { isDefined } from '../response_multi/rules';
 
 export const multiInputOptions: SelectOption<'text' | 'numeric'>[] = [
   { value: 'numeric', displayValue: 'Number' },
@@ -79,6 +80,15 @@ export const partTitle = (input: MultiInput, index: number) => (
     <span className="text-muted">{friendlyType(input.inputType)}</span>
   </div>
 );
+
+// return part ids in order of input occurrence in stem
+export const orderedPartIds = (model: MultiInputSchema) =>
+  elementsOfType(model.stem.content, 'input_ref')
+    .map((iref) => inputRefToPartId(model, iref))
+    .filter(isDefined);
+
+const inputRefToPartId = (model: MultiInputSchema, inputRef: any) =>
+  model.inputs.find((input: any) => input.id === inputRef.input)?.partId;
 
 export function guaranteeMultiInputValidity(model: MultiInputSchema): MultiInputSchema {
   // Check whether model is valid first to save unnecessarily cloning the model

--- a/assets/src/components/activities/multi_input/utils.tsx
+++ b/assets/src/components/activities/multi_input/utils.tsx
@@ -82,7 +82,7 @@ export const partTitle = (input: MultiInput, index: number) => (
 );
 
 // return part ids in order of input occurrence in stem
-export const orderedPartIds = (model: MultiInputSchema) =>
+export const getOrderedPartIds = (model: MultiInputSchema) =>
   elementsOfType(model.stem.content, 'input_ref')
     .map((iref) => inputRefToPartId(model, iref))
     .filter(isDefined);

--- a/assets/src/components/activities/multi_input/utils.tsx
+++ b/assets/src/components/activities/multi_input/utils.tsx
@@ -20,8 +20,8 @@ import { Model } from 'data/content/model/elements/factories';
 import { InputRef, Paragraph } from 'data/content/model/elements/types';
 import { elementsOfType } from 'data/content/utils';
 import { clone } from 'utils/common';
+import { isDefined } from 'utils/common';
 import guid from 'utils/guid';
-import { isDefined } from '../response_multi/rules';
 
 export const multiInputOptions: SelectOption<'text' | 'numeric'>[] = [
   { value: 'numeric', displayValue: 'Number' },
@@ -88,7 +88,7 @@ export const orderedPartIds = (model: MultiInputSchema) =>
     .filter(isDefined);
 
 const inputRefToPartId = (model: MultiInputSchema, inputRef: any) =>
-  model.inputs.find((input: any) => input.id === inputRef.input)?.partId;
+  model.inputs.find((input: any) => input.id === inputRef.id)?.partId;
 
 export function guaranteeMultiInputValidity(model: MultiInputSchema): MultiInputSchema {
   // Check whether model is valid first to save unnecessarily cloning the model

--- a/assets/src/components/activities/response_multi/rules.ts
+++ b/assets/src/components/activities/response_multi/rules.ts
@@ -1,4 +1,5 @@
 import { andRules, orRules, unescapeInput } from 'data/activities/model/rules';
+import { isDefined } from 'utils/common';
 import { addOrRemove, remove } from '../common/utils';
 import { MatchStyle } from '../types';
 
@@ -86,11 +87,6 @@ export const getUniqueRuleForInput = (r: MultiRule, id: string): InputRule => {
 // get all values for this input id in compound rule. Mainly for dropdowns
 export const getInputValues = (r: MultiRule, id: string): string[] =>
   getRulesForInput(r, id).map(inputRuleValue);
-
-// generic type guard enabling TypeScript to narrow filtered types to non-undefined
-export function isDefined<T>(value: T | undefined): value is T {
-  return value !== undefined;
-}
 
 // get list of unique inputRefs used in compound rule
 export const ruleInputRefs = (r: MultiRule): string[] => [

--- a/assets/src/data/activities/model/list.ts
+++ b/assets/src/data/activities/model/list.ts
@@ -43,7 +43,7 @@ export const List: <T>(path: string) => List<T> = (path) => ({
 
   removeOne(id: string) {
     return (model: any) => {
-      Operations.apply(model, Operations.filter(path, `[?(@.id!=${id})]`));
+      Operations.apply(model, Operations.filter(path, ID_PATH(id)));
     };
   },
 });

--- a/assets/src/utils/common.ts
+++ b/assets/src/utils/common.ts
@@ -301,3 +301,8 @@ export const padLeft = (inp: string | number, length: number, char = '0') => {
   const str = String(inp);
   return str.length >= length ? str : new Array(length - str.length + 1).join(char) + str;
 };
+
+// generic type guard enabling TypeScript to narrow filtered types to non-undefined
+export function isDefined<T>(value: T | undefined): value is T {
+  return value !== undefined;
+}


### PR DESCRIPTION
Authors found deleting a choice in a migrated MCQ would remove all choices, breaking the question model, preventing further authoring. This was due to the JSON path filter expression used in the removeOne list operation used to delete choices. didnt happen on torus-authored MCQs because they generate id strings consisting of numbers, and the predicate was inadvertently doing a numeric comparison when matching ids.  Migrated courses frequently have choice ids of the form "A", "B" "C" (perhaps echo-generated) so this operation was failing on these.

This corrects that expression to include quotes needed to get a string comparison on ids, using the correct ID_PATH utility already used elsewhere in this module.