### PR TITLE
[BUGFIX] Correctly delete migrated MCQ choices w/non-numeric id strings [MER-2998]

### DIFF
--- a/assets/src/components/activities/likert/actions.ts
+++ b/assets/src/components/activities/likert/actions.ts
@@ -59,7 +59,7 @@ export const LikertActions = {
   removeItem(id: string) {
     return (model: any & HasParts, post: PostUndoable) => {
       // remove part associated with this item
-      Operations.apply(model, Operations.filter('authoring.parts', `[?(@.id!=${id})]`));
+      Operations.apply(model, Operations.filter('authoring.parts', `[?(@.id!='${id}')]`));
 
       // remove the specified item
       Items.removeOne(id)(model);

--- a/assets/src/components/activities/multi_input/actions.ts
+++ b/assets/src/components/activities/multi_input/actions.ts
@@ -152,7 +152,7 @@ export const MultiInputActions = {
       post(
         makeUndoable('Removed a choice', [
           Operations.replace('$.authoring', authoringClone),
-          Operations.insert(`$.inputs[?(@.id==${input.id})].choiceIds`, choiceId, inputIndex),
+          Operations.insert(`$.inputs[?(@.id=='${input.id}')].choiceIds`, choiceId, inputIndex),
           Operations.insert(Choices.path, clone(choice), choiceIndex),
         ]),
       );
@@ -261,8 +261,8 @@ export const MultiInputActions = {
       }
 
       Operations.applyAll(model, [
-        Operations.filter('$..parts', `[?(@.id!=${part.id})]`),
-        Operations.filter('$.inputs', `[?(@.id!=${inputId})]`),
+        Operations.filter('$..parts', `[?(@.id!='${part.id}')]`),
+        Operations.filter('$.inputs', `[?(@.id!='${inputId}')]`),
       ]);
 
       post(undoables);

--- a/assets/src/components/activities/response_multi/actions.ts
+++ b/assets/src/components/activities/response_multi/actions.ts
@@ -126,7 +126,7 @@ export const ResponseMultiInputActions = {
       const targets = partFrom.targets?.filter((value) => value !== input.id);
       // if no targets left, remove partFrom
       if (!targets || targets.length < 1) {
-        Operations.applyAll(model, [Operations.filter('$..parts', `[?(@.id!=${partFrom.id})]`)]);
+        Operations.applyAll(model, [Operations.filter('$..parts', `[?(@.id!='${partFrom.id}')]`)]);
       } else {
         partFrom.targets = targets;
       }
@@ -246,7 +246,7 @@ export const ResponseMultiInputActions = {
       post(
         makeUndoable('Removed a choice', [
           Operations.replace('$.authoring', authoringClone),
-          Operations.insert(`$.inputs[?(@.id==${input.id})].choiceIds`, choiceId, inputIndex),
+          Operations.insert(`$.inputs[?(@.id=='${input.id}')].choiceIds`, choiceId, inputIndex),
           Operations.insert(Choices.path, clone(choice), choiceIndex),
         ]),
       );
@@ -389,11 +389,11 @@ export const ResponseMultiInputActions = {
       const targets = part.targets?.filter((v) => v != input.id);
       if (!targets || targets.length < 1) {
         Operations.applyAll(model, [
-          Operations.filter('$..parts', `[?(@.id!=${part.id})]`),
-          Operations.filter('$.inputs', `[?(@.id!=${inputId})]`),
+          Operations.filter('$..parts', `[?(@.id!='${part.id}')]`),
+          Operations.filter('$.inputs', `[?(@.id!='${inputId}')]`),
         ]);
       } else {
-        Operations.applyAll(model, [Operations.filter('$.inputs', `[?(@.id!=${inputId})]`)]);
+        Operations.applyAll(model, [Operations.filter('$.inputs', `[?(@.id!='${inputId}')]`)]);
       }
 
       post(undoables);

--- a/assets/src/components/activities/vlab/actions.ts
+++ b/assets/src/components/activities/vlab/actions.ts
@@ -181,7 +181,7 @@ export const VlabActions = {
       post(
         makeUndoable('Removed a choice', [
           Operations.replace('$.authoring', authoringClone),
-          Operations.insert(`$.inputs[?(@.id==${input.id})].choiceIds`, choiceId, inputIndex),
+          Operations.insert(`$.inputs[?(@.id=='${input.id}')].choiceIds`, choiceId, inputIndex),
           Operations.insert(Choices.path, clone(choice), choiceIndex),
         ]),
       );
@@ -296,8 +296,8 @@ export const VlabActions = {
       }
 
       Operations.applyAll(model, [
-        Operations.filter('$..parts', `[?(@.id!=${part.id})]`),
-        Operations.filter('$.inputs', `[?(@.id!=${inputId})]`),
+        Operations.filter('$..parts', `[?(@.id!=$'{part.id}')]`),
+        Operations.filter('$.inputs', `[?(@.id!=$'{inputId}')]`),
       ]);
 
       post(undoables);

--- a/assets/src/components/activities/vlab/actions.ts
+++ b/assets/src/components/activities/vlab/actions.ts
@@ -296,8 +296,8 @@ export const VlabActions = {
       }
 
       Operations.applyAll(model, [
-        Operations.filter('$..parts', `[?(@.id!=$'{part.id}')]`),
-        Operations.filter('$.inputs', `[?(@.id!=$'{inputId}')]`),
+        Operations.filter('$..parts', `[?(@.id!='${part.id}')]`),
+        Operations.filter('$.inputs', `[?(@.id!='${inputId}')]`),
       ]);
 
       post(undoables);

--- a/assets/src/data/activities/model/list.ts
+++ b/assets/src/data/activities/model/list.ts
@@ -1,6 +1,7 @@
 import { Operations } from 'utils/pathOperations';
 
 const ID_PATH = (id: string) => `[?(@.id=='${id}')]`;
+const NOT_ID_PATH = (id: string) => `[?(@.id!='${id}')]`;
 
 type Predicate<T> = (x: T) => boolean;
 export interface List<T> {
@@ -43,7 +44,7 @@ export const List: <T>(path: string) => List<T> = (path) => ({
 
   removeOne(id: string) {
     return (model: any) => {
-      Operations.apply(model, Operations.filter(path, `[?(@.id!=${id})]`));
+      Operations.apply(model, Operations.filter(path, NOT_ID_PATH(id)));
     };
   },
 });


### PR DESCRIPTION
Authors found deleting a choice in a migrated MCQ would remove all choices, breaking the question model, preventing further authoring. This was due to the JSON path filter expression used in the removeOne list operation used to delete choices. It never happened on torus-authored MCQs because they carry generated id strings consisting of numbers, and the id filter predicate inadvertently wound doing a comparison against a numeric value when matching ids of this form, which apparently worked against id strings that can be coerced to numbers. But migrated courses frequently have choice ids of the form "A", "B" "C" (perhaps echo-generated), so the removeOne operation was failing on these.

Other List operations used the ID_PATH definition which correctly quoted the id argument, so have always worked correctly. However, the removeOne operation needs its negation, so did not use the ID_PATH definition. 

This corrects the relevant expression in the removeOne List operation to include quotes needed to get a string comparison on ids, which fixes the problem at hand. 

Also corrects the JSONpath id filter expression in all other places in code where it was constructed without quotes around the id argument.


