### PR TITLE
[BUG FIX] Restore survey-less reset endpoint [MER-3013]

### DIFF
--- a/lib/oli_web/controllers/api/attempt_controller.ex
+++ b/lib/oli_web/controllers/api/attempt_controller.ex
@@ -664,6 +664,31 @@ defmodule OliWeb.Api.AttemptController do
     end
   end
 
+  def new_activity(
+        conn,
+        %{
+          "section_slug" => section_slug,
+          "activity_attempt_guid" => activity_attempt_guid
+        } = params
+      ) do
+    seed_state_from_previous = Map.get(params, "seedResponsesWithPrevious", false)
+    datashop_session_id = Plug.Conn.get_session(conn, :datashop_session_id)
+
+    case Activity.reset_activity(
+           section_slug,
+           activity_attempt_guid,
+           datashop_session_id,
+           seed_state_from_previous
+         ) do
+      {:ok, {attempt_state, model}} ->
+        json(conn, %{"type" => "success", "attemptState" => attempt_state, "model" => model})
+
+      {:error, e} ->
+        {_, msg} = Oli.Utils.log_error("Could not reset activity", e)
+        error(conn, 500, msg)
+    end
+  end
+
   def file_upload(conn, %{
         "section_slug" => section_slug,
         "activity_attempt_guid" => activity_guid,


### PR DESCRIPTION
This PR https://github.com/Simon-Initiative/oli-torus/pull/4628 added "survey_id" as a param to the `:new_activity` endpoint.  But the adaptive player also uses this endpoint and does not provide it, so every call to it results in a `400` error due to the failed pattern match. 

This adds back in a `new_activity` endpoint that does not pattern match for "survey_id" in the params, leaving the other one in place for the basic page.  Tested locally and this restores adaptive player functionality. 