### PR TITLE
[MER-2163] archive media items

### DIFF
--- a/assets/src/components/media/manager/MediaManager.tsx
+++ b/assets/src/components/media/manager/MediaManager.tsx
@@ -638,8 +638,9 @@ export class MediaManager extends React.PureComponent<MediaManagerProps, MediaMa
             {showConfirmDelete && (
               <ConfirmDelete
                 show={showConfirmDelete}
+                title="Archive Media"
                 elementType="Media"
-                elementName="file"
+                explanation="Are you sure you want to archive the file(s)? Note that archived media items are no longer available in the media library and the archiving process is not reversible"
                 deleteHandler={() => {
                   this.onDelete();
                   this.setShowConfirmDelete(false);

--- a/assets/src/components/media/manager/MediaManager.tsx
+++ b/assets/src/components/media/manager/MediaManager.tsx
@@ -4,6 +4,7 @@ import * as Immutable from 'immutable';
 import { Maybe } from 'tsmonad';
 import { formatDate } from 'components/activities/common/utils';
 import { LoadingSpinner, LoadingSpinnerSize } from 'components/common/LoadingSpinner';
+import ConfirmDelete from 'apps/authoring/components/Modal/DeleteConfirmationModal';
 import { MediaItem } from 'types/media';
 import { classNames } from 'utils/classNames';
 import { relativeToNow } from 'utils/date';
@@ -13,6 +14,7 @@ import { OrderedMediaLibrary } from '../OrderedMediaLibrary';
 import { MediaIcon } from './MediaIcon';
 import './MediaManager.scss';
 import { VideoUploadWarning } from './VideoUploadWarning';
+import { deleteFiles } from './delete';
 import { uploadFiles } from './upload';
 
 const PAGELOAD_TRIGGER_MARGIN_PX = 100;
@@ -126,6 +128,7 @@ export interface MediaManagerState {
   filteredMimeTypes: string[] | undefined;
   uploading: boolean;
   duplicateWarning: string[];
+  showConfirmDelete: boolean;
 }
 
 const setMediaManagerLayoutSetting = (layout: LAYOUTS) => {
@@ -164,6 +167,7 @@ export class MediaManager extends React.PureComponent<MediaManagerProps, MediaMa
       filteredMimeTypes: props.mimeFilter,
       uploading: false,
       duplicateWarning: [],
+      showConfirmDelete: false,
     };
 
     this.onScroll = this.onScroll.bind(this);
@@ -227,6 +231,35 @@ export class MediaManager extends React.PureComponent<MediaManagerProps, MediaMa
 
   onUploadClick(id: string) {
     (window as any).$('#' + id).trigger('click');
+  }
+
+  onDelete() {
+    const { mimeFilter, onLoadCourseMediaNextPage, onResetMedia } = this.props;
+    const { searchText, orderBy, order, selection } = this.state;
+
+    deleteFiles(this.props.projectSlug, selection.toArray())
+      .then((result: any) => {
+        onResetMedia();
+        onLoadCourseMediaNextPage(
+          this.props.projectSlug,
+          mimeFilter as string[],
+          searchText as string,
+          orderBy,
+          order,
+        );
+        this.setState({ selection: Immutable.List<string>() });
+      })
+      .catch((e: Error | string) => {
+        if (typeof e === 'string') {
+          this.setState({ error: Maybe.just(e) });
+        } else {
+          this.setState({ error: Maybe.just(e.message) });
+        }
+      });
+  }
+
+  setShowConfirmDelete(showConfirmDelete: boolean) {
+    this.setState({ showConfirmDelete });
   }
 
   setupScrollListener(scrollView: HTMLElement) {
@@ -530,7 +563,7 @@ export class MediaManager extends React.PureComponent<MediaManagerProps, MediaMa
 
   renderMediaSelectionDetails(disabled: boolean) {
     const { media } = this.props;
-    const { selection, showDetails } = this.state;
+    const { selection, showDetails, showConfirmDelete } = this.state;
 
     const selectedMediaItems = selection
       .map((guid) => media.data.get(guid))
@@ -538,8 +571,19 @@ export class MediaManager extends React.PureComponent<MediaManagerProps, MediaMa
 
     if (selectedMediaItems.size > 1) {
       return (
-        <div className="media-selection-details">
-          <div className="details-title">Multiple Items Selected</div>
+        <div className="flex">
+          <div className="media-selection-details flex-grow-1">
+            <div className="details-title">Multiple Items Selected</div>
+          </div>
+          <div>
+            <button
+              className="btn p-0 ml-1"
+              onClick={() => this.setShowConfirmDelete(true)}
+              title="Archive Media"
+            >
+              <i className="fa fa-trash" />
+            </button>
+          </div>
         </div>
       );
     }
@@ -550,46 +594,71 @@ export class MediaManager extends React.PureComponent<MediaManagerProps, MediaMa
       const selectedItem = selectedMediaItems.first() as MediaItem;
 
       return (
-        <div className="media-selection-details">
-          <div className="details-title">
-            <span>
-              Selected:{' '}
-              <a
-                href={selectedItem.url}
-                rel="noreferrer"
-                target="_blank"
-                onClick={(e) => {
-                  if (!disabled) {
-                    popOpenImage(e);
-                  }
-                }}
-              >
-                {stringFormat.ellipsize(selectedItem.fileName, 65, 5)}
-              </a>
-            </span>
-            {showDetails ? (
-              <i className="fa-solid fa-angle-down"></i>
-            ) : (
-              <i className="fa-solid fa-angle-up"></i>
-            )}
-          </div>
-          {showDetails && (
-            <div className="details-content">
-              <MediaIcon
-                filename={selectedItem.fileName}
-                mimeType={selectedItem.mimeType}
-                url={selectedItem.url}
-              />
-              <div className="details-info">
-                <div className="detail-row date-created">
-                  <b>Uploaded:</b> {relativeToNow(new Date(selectedItem.dateCreated))}
-                </div>
-                <div className="detail-row file-size">
-                  <b>Size:</b> {convert.toByteNotation(selectedItem.fileSize)}
+        <div className="flex">
+          <div className="media-selection-details flex-grow-1">
+            <div className="details-title">
+              <span>
+                Selected:{' '}
+                <a
+                  href={selectedItem.url}
+                  rel="noreferrer"
+                  target="_blank"
+                  onClick={(e) => {
+                    if (!disabled) {
+                      popOpenImage(e);
+                    }
+                  }}
+                >
+                  {stringFormat.ellipsize(selectedItem.fileName, 65, 5)}
+                </a>
+              </span>
+              {showDetails ? (
+                <i className="fa-solid fa-angle-down"></i>
+              ) : (
+                <i className="fa-solid fa-angle-up"></i>
+              )}
+            </div>
+            {showDetails && (
+              <div className="details-content">
+                <MediaIcon
+                  filename={selectedItem.fileName}
+                  mimeType={selectedItem.mimeType}
+                  url={selectedItem.url}
+                />
+                <div className="details-info">
+                  <div className="detail-row date-created">
+                    <b>Uploaded:</b> {relativeToNow(new Date(selectedItem.dateCreated))}
+                  </div>
+                  <div className="detail-row file-size">
+                    <b>Size:</b> {convert.toByteNotation(selectedItem.fileSize)}
+                  </div>
                 </div>
               </div>
-            </div>
-          )}
+            )}
+            {showConfirmDelete && (
+              <ConfirmDelete
+                show={showConfirmDelete}
+                elementType="Media"
+                elementName="file"
+                deleteHandler={() => {
+                  this.onDelete();
+                  this.setShowConfirmDelete(false);
+                }}
+                cancelHandler={() => {
+                  this.setShowConfirmDelete(false);
+                }}
+              />
+            )}
+          </div>
+          <div>
+            <button
+              className="btn p-0 ml-1"
+              onClick={() => this.setShowConfirmDelete(true)}
+              title="Archive Media"
+            >
+              <i className="fa fa-trash" />
+            </button>
+          </div>
         </div>
       );
     }

--- a/assets/src/components/media/manager/delete.ts
+++ b/assets/src/components/media/manager/delete.ts
@@ -1,0 +1,7 @@
+import * as persistence from 'data/persistence/media';
+
+export const deleteFiles = async (projectSlug: string, files: string[]) => {
+  return persistence.deleteMedia(projectSlug, files).then((result) => {
+    return result;
+  });
+};

--- a/assets/src/data/persistence/media.ts
+++ b/assets/src/data/persistence/media.ts
@@ -7,6 +7,11 @@ export type MediaItemCreated = {
   url: string;
 };
 
+export type MediaItemsDeleted = {
+  type: 'success';
+  count: number;
+};
+
 export function getFileName(file: File) {
   const fileNameWithDot = file.name.slice(
     0,
@@ -63,6 +68,19 @@ export function createMedia(
 
     return makeRequest<MediaItemCreated>(params);
   });
+}
+
+export function deleteMedia(
+  project: ProjectSlug,
+  mediaIds: string[],
+): Promise<MediaItemsDeleted | ServerError> {
+  const params = {
+    method: 'POST',
+    url: `/media/project/${project}/delete`,
+    body: JSON.stringify({ mediaItemIds: mediaIds }),
+  };
+
+  return makeRequest<MediaItemsDeleted>(params);
 }
 
 export function fetchMedia(

--- a/lib/oli_web/controllers/api/media_controller.ex
+++ b/lib/oli_web/controllers/api/media_controller.ex
@@ -15,7 +15,7 @@ defmodule OliWeb.Api.MediaController do
   use OliWeb, :controller
   use OpenApiSpex.Controller
 
-  plug(:fetch_project when action not in [:index, :create])
+  plug(:fetch_project when action not in [:index, :create, :delete])
 
   defmodule MediaItemUpload do
     require OpenApiSpex
@@ -32,6 +32,41 @@ defmodule OliWeb.Api.MediaController do
       example: %{
         "file" => "QSBob2xsb3cgdm9pY2Ugc2F5cyBQbHVnaCE=",
         "name" => "untitled.jpg"
+      }
+    })
+  end
+
+  defmodule MediaItemsDelete do
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "Media Items Delete",
+      description: "Deleted media items",
+      type: :object,
+      properties: %{
+        mediaItemIds: %Schema{type: :list, description: "The media items ids"}
+      },
+      required: [:mediaItemIds],
+      example: %{
+        "mediaItemIds" => [1, 2, 3]
+      }
+    })
+  end
+
+  defmodule MediaItemsDeleteResponse do
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "Media Items Delete Response",
+      description: "Deleted media items response",
+      type: :object,
+      properties: %{
+        type: %Schema{type: :string, description: "Success"},
+        count: %Schema{type: :integer, description: "Count of media deleted"}
+      },
+      required: [:result],
+      example: %{
+        "result" => "success"
       }
     })
   end
@@ -228,6 +263,35 @@ defmodule OliWeb.Api.MediaController do
 
       _ ->
         error(conn, 400, "invalid encoded file")
+    end
+  end
+
+  @doc """
+  Create a new media library entry by uploading the encoded media file to an Amazon S3 storage bucket.
+  """
+  @doc parameters: [
+         project: [
+           in: :url,
+           schema: %OpenApiSpex.Schema{type: :string},
+           required: true,
+           description: "The project id"
+         ]
+       ],
+       request_body:
+         {"Request body to delete a list of media items", "application/json",
+          OliWeb.Api.MediaController.MediaItemsDelete, required: true},
+       responses: %{
+         200 =>
+           {"Media Items Delete Response", "application/json",
+            OliWeb.Api.MediaController.MediaItemsDeleteResponse}
+       }
+  def delete(conn, %{"project" => project_slug, "mediaItemIds" => media_item_ids}) do
+    case MediaLibrary.delete_media_items(project_slug, media_item_ids) do
+      {:ok, count} ->
+        json(conn, %{type: "success", count: count})
+
+      {:error, err_msg} ->
+        error(conn, 400, err_msg)
     end
   end
 

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -542,6 +542,7 @@ defmodule OliWeb.Router do
     pipe_through([:api, :authoring_protected])
 
     post("/", Api.MediaController, :create)
+    post("/delete", Api.MediaController, :delete)
     get("/", Api.MediaController, :index)
   end
 

--- a/test/oli/authoring/media_libary_test.exs
+++ b/test/oli/authoring/media_libary_test.exs
@@ -63,6 +63,22 @@ defmodule Oli.Authoring.MediaLibraryTest do
       assert item.file_name == "9"
     end
 
+    test "delete/2 delete media items", %{project1: project1} do
+      {:ok, {[item1 | _tail1], 1}} =
+        MediaLibrary.items(project1.slug, %ItemOptions{
+          url_filter: "2"
+        })
+
+      {:ok, {[item2 | _tail2], 1}} =
+        MediaLibrary.items(project1.slug, %ItemOptions{
+          url_filter: "3"
+        })
+
+      {:ok, changes_count} = MediaLibrary.delete_media_items(project1.slug, [item1.id, item2.id])
+      assert changes_count == 2
+      assert {:ok, 7} == MediaLibrary.size(project1.slug)
+    end
+
     test "items/2 limits and offsets correctly", %{project1: project1} do
       {:ok, {items, 9}} =
         MediaLibrary.items(project1.slug, %ItemOptions{


### PR DESCRIPTION
The following changes have been implemented in this PR to provide support for archiving media items from the media library:

1. Authors can now label a media item as “archived” which will remove it from the media library.
2. When an author tries to archive a media item in the library, there will be a prompt asking them to confirm the process. The prompt will inform them that archived media items will no longer be available in the media library and the archiving process is not reversible.
3. The archived media item will still remain in the database and can be used for reference in older sections.
4. Once the media item has been archived, the author can upload a new media item with the same name.