### PR TITLE
[NG23-76] user opens and closes notes panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ _imports
 # the directory for AWS S3 uploads (for dev)
 /data
 MnesiaCore.nonode@nohost_1698_943806_800396
+.envrc

--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -296,7 +296,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
     ~H"""
     <div
       :if={!is_nil(@current_page)}
-      class="fixed bottom-0 left-1/2 -translate-x-1/2 h-[74px] py-4 shadow-lg bg-white dark:bg-black lg:rounded-tl-[40px] lg:rounded-tr-[40px] flex items-center gap-3 lg:w-[720px] w-full"
+      class="fixed bottom-0 left-1/2 -translate-x-1/2 h-[74px] lg:py-4 shadow-lg bg-white dark:bg-black lg:rounded-tl-[40px] lg:rounded-tr-[40px] flex items-center gap-3 lg:w-[720px] w-full"
     >
       <div class="hidden lg:block absolute -left-[114px] z-0">
         <svg
@@ -387,11 +387,15 @@ defmodule OliWeb.Components.Delivery.Layouts do
   end
 
   attr(:to, :string)
+  attr(:show_sidebar, :boolean, default: false)
 
   def back_arrow(assigns) do
     ~H"""
     <div
-      class="flex justify-center items-center absolute top-2 lg:top-10 left-2 lg:left-12 p-4"
+      class={[
+        "flex justify-center items-center absolute top-2 left-2 p-4",
+        if(!@show_sidebar, do: "xl:top-10 xl:left-12")
+      ]}
       role="back_link"
     >
       <.link navigate={@to} class="hover:no-underline hover:scale-105 cursor-pointer">

--- a/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
+++ b/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
@@ -53,7 +53,7 @@
       id="page-content"
       class="flex-1 flex flex-col relative justify-center items-start overflow-hidden"
     >
-      <.back_arrow to={@request_path} />
+      <.back_arrow to={@request_path} show_sidebar={assigns[:show_sidebar]} />
 
       <%!-- This feature will not be implemented in the first release. This is just a placeholder--%>
       <.annotations_dropdown />
@@ -76,7 +76,8 @@
       session: %{
         "section_slug" => @section.slug,
         "resource_id" => @current_page["id"],
-        "revision_id" => @page_context.page.id
+        "revision_id" => @page_context.page.id,
+        "is_page" => true
       },
       id: "dialogue-window"
     ) %>

--- a/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
+++ b/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
@@ -38,7 +38,7 @@
   <% end %>
 </div>
 
-<div class="h-screen flex flex-col overscroll-none">
+<div class="h-screen flex flex-col overscroll-none overflow-hidden">
   <Components.Delivery.Layouts.header
     ctx={@ctx}
     is_system_admin={assigns[:is_system_admin] || false}
@@ -47,8 +47,12 @@
     preview_mode={@preview_mode}
   />
 
-  <div class="flex-1 flex flex-col mt-14">
-    <div :if={@section} id="page-content" class="relative justify-center items-start inline-flex">
+  <div class="flex-1 flex flex-col mt-14 overflow-hidden">
+    <div
+      :if={@section}
+      id="page-content"
+      class="flex-1 flex flex-col relative justify-center items-start overflow-hidden"
+    >
       <.back_arrow to={@request_path} />
 
       <%!-- This feature will not be implemented in the first release. This is just a placeholder--%>

--- a/lib/oli_web/live/delivery/student/lesson/notes.ex
+++ b/lib/oli_web/live/delivery/student/lesson/notes.ex
@@ -3,7 +3,7 @@ defmodule OliWeb.Delivery.Student.Lesson.Notes do
 
   def panel(assigns) do
     ~H"""
-    <div class="flex-1 flex flex-row ml-24">
+    <div class="flex-1 flex flex-row">
       <div class="justify-start">
         <.toggle_notes_button>
           <i class="fa-solid fa-xmark group-hover:scale-110"></i>

--- a/lib/oli_web/live/delivery/student/lesson/notes.ex
+++ b/lib/oli_web/live/delivery/student/lesson/notes.ex
@@ -1,0 +1,202 @@
+defmodule OliWeb.Delivery.Student.Lesson.Notes do
+  use OliWeb, :html
+
+  def panel(assigns) do
+    ~H"""
+    <div class="flex-1 flex flex-row ml-24">
+      <div class="justify-start">
+        <.toggle_notes_button>
+          <i class="fa-solid fa-xmark group-hover:scale-110"></i>
+        </.toggle_notes_button>
+      </div>
+      <div class="flex-1 flex flex-col bg-white p-5">
+        <.tab_group class="py-3">
+          <.tab selected={true}><.user_icon class="mr-2" /> My Notes</.tab>
+          <.tab><.users_icon class="mr-2" /> Class Notes</.tab>
+        </.tab_group>
+        <.search_box class="mt-2" />
+        <hr class="m-6 border-b border-b-gray-200" />
+        <div class="flex-1 flex flex-col gap-3">
+          <.note></.note>
+          <.note></.note>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  slot :inner_block, required: true
+
+  def toggle_notes_button(assigns) do
+    ~H"""
+    <button
+      class="flex flex-col items-center rounded-l-lg bg-white px-6 py-12 text-xl group"
+      phx-click="toggle_sidebar"
+    >
+      <%= render_slot(@inner_block) %>
+    </button>
+    """
+  end
+
+  def chat_icon(assigns) do
+    ~H"""
+    <svg
+      width="24"
+      height="25"
+      viewBox="0 0 24 25"
+      xmlns="http://www.w3.org/2000/svg"
+      class="group-hover:scale-110"
+    >
+      <path
+        id="Path"
+        fill="#0064ed"
+        fill-rule="evenodd"
+        stroke="none"
+        d="M 9.51568 1.826046 C 5.766479 1.826046 2.727119 4.889919 2.727119 8.669355 C 2.727119 9.763306 2.98112 10.79484 3.432001 11.709678 C 3.53856 11.925805 3.55584 12.175646 3.48008 12.404678 L 2.330881 15.88008 L 5.81328 14.748066 C 6.03848 14.674919 6.283121 14.693466 6.494881 14.799678 C 7.40368 15.255725 8.42864 15.51266 9.51568 15.51266 C 13.264959 15.51266 16.304239 12.448791 16.304239 8.669355 C 16.304239 4.889919 13.264959 1.826046 9.51568 1.826046 Z M 0.91568 8.669355 C 0.91568 3.881369 4.76608 0 9.51568 0 C 14.26536 0 18.115759 3.881369 18.115759 8.669355 C 18.115759 13.457338 14.26536 17.338711 9.51568 17.338711 C 8.276159 17.338711 7.09592 17.073872 6.02928 16.596533 L 1.183681 18.171612 C 0.85872 18.277258 0.5024 18.189596 0.26216 17.945 C 0.021919 17.700485 -0.06144 17.340405 0.04648 17.01387 L 1.6472 12.173065 C 1.17672 11.100726 0.91568 9.914679 0.91568 8.669355 Z"
+      />
+      <path
+        id="path1"
+        fill="#0064ed"
+        fill-rule="evenodd"
+        stroke="none"
+        d="M 23.192719 16.158226 C 23.192719 11.929112 19.79184 8.500807 15.59664 8.500807 C 11.401441 8.500807 8.000481 11.929112 8.000481 16.158226 C 8.000481 20.387257 11.401441 23.815567 15.59664 23.815567 C 16.691441 23.815567 17.733999 23.581615 18.676081 23.16 L 22.955999 24.551207 C 23.243038 24.644514 23.55776 24.567179 23.77 24.351126 C 23.982239 24.135078 24.055841 23.817099 23.96048 23.528627 L 22.54664 19.252899 C 22.962162 18.305725 23.192719 17.258146 23.192719 16.158226 Z"
+      />
+    </svg>
+    """
+  end
+
+  slot :inner_block, required: true
+  attr :rest, :global, include: ~w(class)
+
+  defp tab_group(assigns) do
+    ~H"""
+    <div class={["flex flex-row", @rest[:class]]}>
+      <%= render_slot(@inner_block) %>
+    </div>
+    """
+  end
+
+  attr :selected, :boolean, default: false
+  slot :inner_block, required: true
+
+  defp tab(assigns) do
+    ~H"""
+    <button class={[
+      "flex-1 inline-flex justify-center border-l border-t border-b first:rounded-l-lg last:rounded-r-lg last:border-r px-4 py-3 inline-flex items-center",
+      if(@selected,
+        do: "bg-primary border-primary text-white stroke-white font-semibold",
+        else: "stroke-[#383A44] border-gray-400 hover:bg-gray-100"
+      )
+    ]}>
+      <%= render_slot(@inner_block) %>
+    </button>
+    """
+  end
+
+  attr :rest, :global, include: ~w(class)
+
+  defp user_icon(assigns) do
+    ~H"""
+    <svg
+      class={@rest[:class]}
+      width="20"
+      height="20"
+      viewBox="0 0 20 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M16.6666 17.5V15.8333C16.6666 14.9493 16.3154 14.1014 15.6903 13.4763C15.0652 12.8512 14.2173 12.5 13.3333 12.5H6.66659C5.78253 12.5 4.93468 12.8512 4.30956 13.4763C3.68444 14.1014 3.33325 14.9493 3.33325 15.8333V17.5"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M10.0001 9.16667C11.841 9.16667 13.3334 7.67428 13.3334 5.83333C13.3334 3.99238 11.841 2.5 10.0001 2.5C8.15913 2.5 6.66675 3.99238 6.66675 5.83333C6.66675 7.67428 8.15913 9.16667 10.0001 9.16667Z"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+    """
+  end
+
+  attr :rest, :global, include: ~w(class)
+
+  defp users_icon(assigns) do
+    ~H"""
+    <svg
+      class={@rest[:class]}
+      width="20"
+      height="20"
+      viewBox="0 0 20 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g clip-path="url(#clip0_270_13479)">
+        <path
+          d="M14.1666 17.5V15.8333C14.1666 14.9493 13.8154 14.1014 13.1903 13.4763C12.5652 12.8512 11.7173 12.5 10.8333 12.5H4.16659C3.28253 12.5 2.43468 12.8512 1.80956 13.4763C1.18444 14.1014 0.833252 14.9493 0.833252 15.8333V17.5"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+        <path
+          d="M7.50008 9.16667C9.34103 9.16667 10.8334 7.67428 10.8334 5.83333C10.8334 3.99238 9.34103 2.5 7.50008 2.5C5.65913 2.5 4.16675 3.99238 4.16675 5.83333C4.16675 7.67428 5.65913 9.16667 7.50008 9.16667Z"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+        <path
+          d="M19.1667 17.4991V15.8324C19.1662 15.0939 18.9204 14.3764 18.4679 13.7927C18.0154 13.209 17.3819 12.7921 16.6667 12.6074"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+        <path
+          d="M13.3333 2.60742C14.0503 2.79101 14.6858 3.20801 15.1396 3.79268C15.5935 4.37736 15.8398 5.09645 15.8398 5.83659C15.8398 6.57673 15.5935 7.29582 15.1396 7.8805C14.6858 8.46517 14.0503 8.88217 13.3333 9.06576"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </g>
+      <defs>
+        <clipPath id="clip0_270_13479">
+          <rect width="20" height="20" fill="white" />
+        </clipPath>
+      </defs>
+    </svg>
+    """
+  end
+
+  attr :rest, :global, include: ~w(class)
+
+  defp search_box(assigns) do
+    ~H"""
+    <div class={["flex flex-row", @rest[:class]]}>
+      <div class="flex-1 relative">
+        <i class="fa-solid fa-search absolute left-4 top-4 text-gray-400 pointer-events-none text-lg">
+        </i>
+        <input type="text" class="w-full border border-gray-400 rounded-lg pl-12 pr-3 py-3" />
+      </div>
+    </div>
+    """
+  end
+
+  defp note(assigns) do
+    ~H"""
+    <div class="flex flex-col p-4 border-2 border-gray-200 rounded">
+      <div class="flex flex-row justify-between mb-3">
+        <div class="font-semibold">
+          Me
+        </div>
+        <div class="text-sm text-gray-500">
+          1d
+        </div>
+      </div>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla nec dui in odio.
+      </p>
+    </div>
+    """
+  end
+end

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -314,11 +314,17 @@ defmodule OliWeb.Delivery.Student.LessonLive do
   defp page_content_layout(assigns) do
     ~H"""
     <div class={[
-      "flex-1 flex flex-col w-full overflow-hidden pb-20"
+      "flex-1 flex flex-col w-full overflow-hidden"
     ]}>
-      <div class={["flex-1 flex flex-col overflow-auto", if(@show_sidebar, do: "mr-[520px]")]}>
-        <div class={["flex-1 mt-20", if(@show_sidebar, do: "border-r border-gray-300 mr-[80px]")]}>
-          <div class="container mx-auto max-w-[720px]">
+      <div class={[
+        "flex-1 flex flex-col overflow-auto",
+        if(@show_sidebar, do: "xl:mr-[520px]")
+      ]}>
+        <div class={[
+          "flex-1 mt-20 px-[80px]",
+          if(@show_sidebar, do: "border-r border-gray-300 xl:mr-[80px]")
+        ]}>
+          <div class="container mx-auto max-w-[880px] pb-20">
             <%= render_slot(@header) %>
 
             <%= render_slot(@inner_block) %>

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -21,7 +21,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
   on_mount {OliWeb.LiveSessionPlugs.InitPage, :previous_next_index}
 
   def mount(_params, _session, %{assigns: %{view: :practice_page}} = socket) do
-    {:ok, socket |> assign_html_and_scripts() |> assign(show_sidebar: true)}
+    {:ok, socket |> assign_html_and_scripts() |> assign(show_sidebar: false)}
   end
 
   def mount(
@@ -30,7 +30,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
         %{assigns: %{view: :graded_page, page_context: %{progress_state: :in_progress}}} = socket
       ) do
     {:ok,
-     socket |> assign_html_and_scripts() |> assign(begin_attempt?: false, show_sidebar: true)}
+     socket |> assign_html_and_scripts() |> assign(begin_attempt?: false, show_sidebar: false)}
   end
 
   def mount(_params, _session, %{assigns: %{view: :graded_page}} = socket) do
@@ -42,7 +42,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
     {:ok,
      socket
      |> assign_scripts()
-     |> assign(begin_attempt?: false, show_sidebar: true)}
+     |> assign(begin_attempt?: false, show_sidebar: false)}
   end
 
   def handle_event("begin_attempt", %{"password" => password}, socket)

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -328,7 +328,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
     </div>
     <div
       :if={@sidebar && @show_sidebar}
-      class="flex flex-col w-[600px] absolute top-20 right-0 bottom-0"
+      class="flex flex-col w-[520px] absolute top-20 right-0 bottom-0"
     >
       <%= render_slot(@sidebar) %>
     </div>

--- a/lib/oli_web/live/delivery/student/review_live.ex
+++ b/lib/oli_web/live/delivery/student/review_live.ex
@@ -45,7 +45,7 @@ defmodule OliWeb.Delivery.Student.ReviewLive do
 
   def render(assigns) do
     ~H"""
-    <div class="flex pb-20 flex-col items-center gap-15 flex-1">
+    <div class="flex pb-20 flex-col w-full items-center gap-15 flex-1 overflow-auto">
       <div class="flex flex-col items-center w-full">
         <div class="w-full h-[120px] lg:px-20 px-40 py-9 bg-blue-600 bg-opacity-10 flex flex-col justify-center items-center gap-2.5">
           <div class="px-3 py-1.5 rounded justify-start items-start gap-2.5 flex">

--- a/lib/oli_web/live/dialogue/window_live.ex
+++ b/lib/oli_web/live/dialogue/window_live.ex
@@ -315,7 +315,7 @@ defmodule OliWeb.Dialogue.WindowLive do
   def left_to_right_fade_in_icon(assigns) do
     ~H"""
     <svg
-      class={["lg:block fill-black dark:opacity-100", if(@is_page, do: "hidden", else: "block")]}
+      class={["fill-black dark:opacity-100", if(@is_page, do: "hidden lg:block", else: "block")]}
       width="170"
       height="74"
       viewBox="0 0 170 74"


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/NG23-76

Adds the annotations panel to the side of a page allowing a student to open/close the panel.

Currently it just contains placeholder controls and content

<img width="1622" alt="Screenshot 2024-02-21 at 3 02 01 PM" src="https://github.com/Simon-Initiative/oli-torus/assets/6248894/268fdc7f-d38f-431c-9398-4c1fc55e399c">
