### PR TITLE
Mer 3016 unable to select assignment for lms synchronize grades tool

### DIFF
--- a/lib/oli_web/live/grades/grade_sync.ex
+++ b/lib/oli_web/live/grades/grade_sync.ex
@@ -41,13 +41,15 @@ defmodule OliWeb.Grades.GradeSync do
         </div>
 
         <select
+          phx-change="select_page"
           id="assignment_grade_sync_select"
+          name="resource_id"
           class="custom-select custom-select-lg mb-2"
-          phx-hook="SelectListener"
-          phx-value-change="select_page"
         >
           <%= for page <- @graded_pages do %>
-            <option value={page.resource_id}><%= page.title %></option>
+            <option value={page.resource_id} selected={@selected_page == page.resource_id}>
+              <%= page.title %>
+            </option>
           <% end %>
         </select>
 

--- a/lib/oli_web/live/grades/grades.ex
+++ b/lib/oli_web/live/grades/grades.ex
@@ -255,7 +255,7 @@ defmodule OliWeb.Grades.GradesLive do
     end
   end
 
-  def handle_event("select_page", %{"value" => resource_id}, socket) do
+  def handle_event("select_page", %{"resource_id" => resource_id}, socket) do
     {resource_id, _} = Integer.parse(resource_id)
     {:noreply, assign(socket, selected_page: resource_id)}
   end

--- a/test/oli/delivery/attempts_test.exs
+++ b/test/oli/delivery/attempts_test.exs
@@ -512,7 +512,11 @@ defmodule Oli.Delivery.AttemptsTest do
     test "get graded resource accesses where the last lms sync failed - returns empty when no failed sync exists" do
       user = insert(:user)
 
-      {:ok, section: section, unit_one_revision: _unit_one_revision, page_revision: page_revision} =
+      {:ok,
+       section: section,
+       unit_one_revision: _unit_one_revision,
+       page_revision: page_revision,
+       page_2_revision: _page_2_revision} =
         section_with_assessment(%{})
 
       last_grade_update = insert(:lms_grade_update)
@@ -532,7 +536,11 @@ defmodule Oli.Delivery.AttemptsTest do
       user1 = insert(:user)
       user2 = insert(:user)
 
-      {:ok, section: section, unit_one_revision: _unit_one_revision, page_revision: page_revision} =
+      {:ok,
+       section: section,
+       unit_one_revision: _unit_one_revision,
+       page_revision: page_revision,
+       page_2_revision: _page_2_revision} =
         section_with_assessment(%{})
 
       last_successful_grade_update = insert(:lms_grade_update)

--- a/test/oli_web/controllers/page_delivery_controller_test.exs
+++ b/test/oli_web/controllers/page_delivery_controller_test.exs
@@ -2084,7 +2084,11 @@ defmodule OliWeb.PageDeliveryControllerTest do
       conn: conn,
       user: user
     } do
-      {:ok, section: section, unit_one_revision: unit_one_revision, page_revision: _page_revision} =
+      {:ok,
+       section: section,
+       unit_one_revision: unit_one_revision,
+       page_revision: _page_revision,
+       page_2_revision: _page_2_revision} =
         section_with_assessment(%{})
 
       enroll_as_instructor(%{user: user, section: section})
@@ -2273,7 +2277,10 @@ defmodule OliWeb.PageDeliveryControllerTest do
       conn: conn
     } do
       {:ok,
-       section: section, unit_one_revision: _unit_one_revision, page_revision: _page_revision} =
+       section: section,
+       unit_one_revision: _unit_one_revision,
+       page_revision: _page_revision,
+       page_2_revision: _page_2_revision} =
         section_with_assessment(%{})
 
       user = insert(:user)
@@ -2290,7 +2297,10 @@ defmodule OliWeb.PageDeliveryControllerTest do
     test "do not show the 'exploration' access in the left navbar when the section has no explorations to show",
          %{conn: conn} do
       {:ok,
-       section: section, unit_one_revision: _unit_one_revision, page_revision: _page_revision} =
+       section: section,
+       unit_one_revision: _unit_one_revision,
+       page_revision: _page_revision,
+       page_2_revision: _page_2_revision} =
         section_with_assessment(%{})
 
       user = insert(:user)
@@ -2308,7 +2318,10 @@ defmodule OliWeb.PageDeliveryControllerTest do
     test "do not show the 'exploration' access in the Windowshade when the section does not have explorations to show",
          %{conn: conn} do
       {:ok,
-       section: section, unit_one_revision: _unit_one_revision, page_revision: _page_revision} =
+       section: section,
+       unit_one_revision: _unit_one_revision,
+       page_revision: _page_revision,
+       page_2_revision: _page_2_revision} =
         section_with_assessment(%{})
 
       user = insert(:user)
@@ -2410,7 +2423,10 @@ defmodule OliWeb.PageDeliveryControllerTest do
       conn: conn
     } do
       {:ok,
-       section: section, unit_one_revision: _unit_one_revision, page_revision: _page_revision} =
+       section: section,
+       unit_one_revision: _unit_one_revision,
+       page_revision: _page_revision,
+       page_2_revision: _page_2_revision} =
         section_with_assessment(%{})
 
       user = insert(:user)

--- a/test/oli_web/live/delivery/instructor_dashboard/reports/quiz_scores_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/reports/quiz_scores_tab_test.exs
@@ -83,7 +83,10 @@ defmodule OliWeb.Delivery.InstructorDashboard.QuizScoreTabTest do
       instructor: instructor
     } do
       {:ok,
-       section: section, unit_one_revision: _unit_one_revision, page_revision: _page_revision} =
+       section: section,
+       unit_one_revision: _unit_one_revision,
+       page_revision: _page_revision,
+       page_2_revision: _page_2_revision} =
         section_with_assessment(nil)
 
       Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])

--- a/test/oli_web/live/delivery/student_dashboard/components/quizz_scores_tab_test.exs
+++ b/test/oli_web/live/delivery/student_dashboard/components/quizz_scores_tab_test.exs
@@ -137,7 +137,11 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.QuizzScoresTabTest do
     } do
       student = insert(:user)
 
-      {:ok, section: section, unit_one_revision: _unit_one_revision, page_revision: page_revision} =
+      {:ok,
+       section: section,
+       unit_one_revision: _unit_one_revision,
+       page_revision: page_revision,
+       page_2_revision: _page_2_revision} =
         section_with_assessment(nil)
 
       Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])

--- a/test/oli_web/live/progress/student_resource_view_live_test.exs
+++ b/test/oli_web/live/progress/student_resource_view_live_test.exs
@@ -18,7 +18,11 @@ defmodule OliWeb.Progress.StudentResourceViewLiveTest do
   end
 
   defp setup_section_resource_access(%{:instructor => instructor}) do
-    {:ok, section: section, unit_one_revision: _unit_one_revision, page_revision: page_revision} =
+    {:ok,
+     section: section,
+     unit_one_revision: _unit_one_revision,
+     page_revision: page_revision,
+     page_2_revision: _page_2_revision} =
       section_with_assessment(%{})
 
     student = insert(:user)

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -639,8 +639,17 @@ defmodule Oli.TestHelpers do
         content: %{"advancedDelivery" => true}
       )
 
+    page_2_revision =
+      insert(:revision,
+        resource_type_id: Oli.Resources.ResourceType.id_for_page(),
+        title: "Other test revision",
+        graded: true,
+        content: %{"advancedDelivery" => true}
+      )
+
     # Associate nested graded page to the project
     insert(:project_resource, %{project_id: project.id, resource_id: page_revision.resource.id})
+    insert(:project_resource, %{project_id: project.id, resource_id: page_2_revision.resource.id})
 
     unit_one_resource = insert(:resource)
 
@@ -673,7 +682,7 @@ defmodule Oli.TestHelpers do
         resource: container_resource,
         objectives: %{},
         resource_type_id: Oli.Resources.ResourceType.id_for_container(),
-        children: [unit_one_resource.id, page_revision.resource.id],
+        children: [unit_one_resource.id, page_revision.resource.id, page_2_revision.resource.id],
         content: %{},
         deleted: false,
         title: "Root Container"
@@ -704,6 +713,13 @@ defmodule Oli.TestHelpers do
       publication: publication,
       resource: page_revision.resource,
       revision: page_revision,
+      author: author
+    })
+
+    insert(:published_resource, %{
+      publication: publication,
+      resource: page_2_revision.resource,
+      revision: page_2_revision,
       author: author
     })
 
@@ -757,7 +773,18 @@ defmodule Oli.TestHelpers do
       author: author
     })
 
-    {:ok, section: section, unit_one_revision: unit_one_revision, page_revision: page_revision}
+    insert(:published_resource, %{
+      publication: new_publication,
+      resource: page_2_revision.resource,
+      revision: page_2_revision,
+      author: author
+    })
+
+    {:ok,
+     section: section,
+     unit_one_revision: unit_one_revision,
+     page_revision: page_revision,
+     page_2_revision: page_2_revision}
   end
 
   def create_project_with_products(_conn) do


### PR DESCRIPTION
Ticket [MER-3016](https://eliterate.atlassian.net/browse/MER-3016)

This PR fixed an incorrect handle event called with an incorrect attribute when trying to select another graded page. It was added a test covering selecting other that the default --the first one--. 


[First commit](https://github.com/Simon-Initiative/oli-torus/pull/4655/commits/2772f95ba67429ea10b824a395d27c76e8d256e2) is the **actual fix** for the reported bug.

[Second commit](https://github.com/Simon-Initiative/oli-torus/pull/4655/commits/0b563b81752c43207af734234c1214c85c39f377) is the test above fix.

[Third commit](https://github.com/Simon-Initiative/oli-torus/pull/4655/commits/dba89b00a0b8d99a5425500b0e1d3cf0b649f25a) fixes some broken tests when developing the above test.

[MER-3016]: https://eliterate.atlassian.net/browse/MER-3016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ