### PR TITLE
[Feature][MER-2999] Separate admin functionality

### DIFF
--- a/lib/oli/accounts.ex
+++ b/lib/oli/accounts.ex
@@ -440,6 +440,21 @@ defmodule Oli.Accounts do
     Repo.exists?(query)
   end
 
+  def at_least_content_admin?(%Author{system_role_id: system_role_id}) do
+    SystemRole.role_id().content_admin == system_role_id
+    or SystemRole.role_id().account_admin == system_role_id
+    or SystemRole.role_id().system_admin == system_role_id
+  end
+
+  def at_least_content_admin?(_), do: false
+
+  def at_least_account_admin?(%Author{system_role_id: system_role_id}) do
+    SystemRole.role_id().account_admin == system_role_id
+    or SystemRole.role_id().system_admin == system_role_id
+  end
+
+  def at_least_account_admin?(_), do: false
+
   @doc """
   Returns true if an author is a content admin.
   """

--- a/lib/oli/accounts/schemas/system_role.ex
+++ b/lib/oli/accounts/schemas/system_role.ex
@@ -8,7 +8,9 @@ defmodule Oli.Accounts.SystemRole do
   def role_id,
     do: %{
       author: 1,
-      admin: 2
+      system_admin: 2,
+      account_admin: 3,
+      content_admin: 4
     }
 
   schema "system_roles" do

--- a/lib/oli/delivery/audience.ex
+++ b/lib/oli/delivery/audience.ex
@@ -38,7 +38,7 @@ defmodule Oli.Delivery.Audience do
   end
 
   def audience_role(%Author{} = author, _section_slug) do
-    if Accounts.is_admin?(author) do
+    if Accounts.is_system_admin?(author) do
       :instructor
     else
       :student

--- a/lib/oli/utils/seeder/project.ex
+++ b/lib/oli/utils/seeder/project.ex
@@ -61,7 +61,7 @@ defmodule Oli.Utils.Seeder.Project do
       Author.noauth_changeset(%Author{}, %{
         email: "#{Slug.slugify(name)}@test.com",
         given_name: name,
-        system_role_id: SystemRole.role_id().admin
+        system_role_id: SystemRole.role_id().system_admin
       })
       |> Repo.insert()
 

--- a/lib/oli_web/components/delivery/actions/actions.ex
+++ b/lib/oli_web/components/delivery/actions/actions.ex
@@ -43,7 +43,7 @@ defmodule OliWeb.Components.Delivery.Actions do
        user_role_data: @user_role_data,
        has_payment: has_payment,
        current_user: current_user,
-       is_admin: Accounts.is_admin?(current_user),
+       is_admin: Accounts.has_admin_role?(current_user),
        is_suspended?: is_suspended?
      )}
   end

--- a/lib/oli_web/components/delivery/user_account_menu.ex
+++ b/lib/oli_web/components/delivery/user_account_menu.ex
@@ -10,6 +10,12 @@ defmodule OliWeb.Components.Delivery.UserAccountMenu do
   alias OliWeb.Common.SessionContext
   alias OliWeb.Common.React
 
+  @system_admin_role_ids [
+    SystemRole.role_id().system_admin,
+    SystemRole.role_id().account_admin,
+    SystemRole.role_id().content_admin
+  ]
+
   attr(:ctx, SessionContext)
   attr(:section, Section)
   attr(:is_liveview, :boolean, default: false)
@@ -131,10 +137,8 @@ defmodule OliWeb.Components.Delivery.UserAccountMenu do
   end
 
   defp signout_path(%SessionContext{user: user_or_admin}) do
-    admin_role_id = SystemRole.role_id().admin
-
     case user_or_admin do
-      %Author{system_role_id: ^admin_role_id} ->
+      %Author{system_role_id: system_role_id} when system_role_id in @system_admin_role_ids ->
         Routes.authoring_session_path(OliWeb.Endpoint, :signout, type: :author)
 
       _ ->

--- a/lib/oli_web/components/delivery/utils.ex
+++ b/lib/oli_web/components/delivery/utils.ex
@@ -186,11 +186,15 @@ defmodule OliWeb.Components.Delivery.Utils do
     ContextRoles.get_role(:context_learner)
   ]
 
-  @system_admin_role_id SystemRole.role_id().admin
+  @system_admin_role_ids [
+    SystemRole.role_id().system_admin,
+    SystemRole.role_id().account_admin,
+    SystemRole.role_id().content_admin
+  ]
 
   def user_role(section, user) do
     case user do
-      %Author{system_role_id: @system_admin_role_id} ->
+      %Author{system_role_id: system_role_id} when system_role_id in @system_admin_role_ids ->
         :system_admin
 
       %Author{} ->

--- a/lib/oli_web/controllers/activity_bank_controller.ex
+++ b/lib/oli_web/controllers/activity_bank_controller.ex
@@ -15,7 +15,7 @@ defmodule OliWeb.ActivityBankController do
         "project_id" => project_slug
       }) do
     author = conn.assigns[:current_author]
-    is_admin? = Accounts.is_system_admin?(author)
+    is_admin? = Accounts.at_least_content_admin?(author)
 
     case Oli.Authoring.Editing.BankEditor.create_context(project_slug, author) do
       {:ok, context} ->
@@ -42,7 +42,7 @@ defmodule OliWeb.ActivityBankController do
       }) do
     user = conn.assigns.current_user
     author = conn.assigns.current_author
-    is_admin? = Accounts.is_system_admin?(author)
+    is_admin? = Accounts.at_least_content_admin?(author)
 
     offset =
       Map.get(conn.query_params, "offset", "0")

--- a/lib/oli_web/controllers/activity_bank_controller.ex
+++ b/lib/oli_web/controllers/activity_bank_controller.ex
@@ -15,7 +15,7 @@ defmodule OliWeb.ActivityBankController do
         "project_id" => project_slug
       }) do
     author = conn.assigns[:current_author]
-    is_admin? = Accounts.is_admin?(author)
+    is_admin? = Accounts.is_system_admin?(author)
 
     case Oli.Authoring.Editing.BankEditor.create_context(project_slug, author) do
       {:ok, context} ->
@@ -42,7 +42,7 @@ defmodule OliWeb.ActivityBankController do
       }) do
     user = conn.assigns.current_user
     author = conn.assigns.current_author
-    is_admin? = Accounts.is_admin?(author)
+    is_admin? = Accounts.is_system_admin?(author)
 
     offset =
       Map.get(conn.query_params, "offset", "0")

--- a/lib/oli_web/controllers/api/activity_controller.ex
+++ b/lib/oli_web/controllers/api/activity_controller.ex
@@ -2,6 +2,7 @@ defmodule OliWeb.Api.ActivityController do
   use OliWeb, :controller
   use OpenApiSpex.Controller
 
+  alias Oli.Accounts
   alias Oli.Authoring.Editing.ActivityEditor
   alias Oli.Delivery.Attempts.ActivityLifecycle.Evaluate, as: ActivityEvaluation
   alias Oli.Delivery.Attempts.ActivityLifecycle
@@ -430,12 +431,12 @@ defmodule OliWeb.Api.ActivityController do
   defp is_preview_mode?(_), do: false
 
   defp has_access?(conn, user, section_slug, is_preview_mode) do
-    if is_preview_mode do
-      is_admin? = Oli.Accounts.is_admin?(conn.assigns[:current_author])
-      Sections.is_instructor?(user, section_slug) or is_admin?
-    else
-      Sections.is_enrolled?(user.id, section_slug)
-    end
+    current_author = conn.assigns[:current_author]
+
+    if is_preview_mode,
+      do:
+        Sections.is_instructor?(user, section_slug) or Accounts.is_system_admin?(current_author),
+      else: Sections.is_enrolled?(user.id, section_slug)
   end
 
   # --------- END DELIVERY PREVIEW ---------

--- a/lib/oli_web/controllers/api/activity_controller.ex
+++ b/lib/oli_web/controllers/api/activity_controller.ex
@@ -435,7 +435,7 @@ defmodule OliWeb.Api.ActivityController do
 
     if is_preview_mode,
       do:
-        Sections.is_instructor?(user, section_slug) or Accounts.is_system_admin?(current_author),
+        Sections.is_instructor?(user, section_slug) or Accounts.at_least_content_admin?(current_author),
       else: Sections.is_enrolled?(user.id, section_slug)
   end
 

--- a/lib/oli_web/controllers/api/scheduling_controller.ex
+++ b/lib/oli_web/controllers/api/scheduling_controller.ex
@@ -192,7 +192,7 @@ defmodule OliWeb.Api.SchedulingController do
   # (authoring) admins
   defp can_access_section?(conn, section) do
     Sections.is_instructor?(conn.assigns.current_user, section.slug) or
-      Accounts.is_system_admin?(conn.assigns.current_author) or
+      Accounts.at_least_content_admin?(conn.assigns.current_author) or
       Sections.is_admin?(conn.assigns.current_user, section.slug)
   end
 

--- a/lib/oli_web/controllers/api/scheduling_controller.ex
+++ b/lib/oli_web/controllers/api/scheduling_controller.ex
@@ -9,6 +9,7 @@ defmodule OliWeb.Api.SchedulingController do
   alias Oli.Delivery.Sections.Scheduling
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.SectionResource
+  alias Oli.Accounts
 
   import OliWeb.Api.Helpers
 
@@ -191,7 +192,7 @@ defmodule OliWeb.Api.SchedulingController do
   # (authoring) admins
   defp can_access_section?(conn, section) do
     Sections.is_instructor?(conn.assigns.current_user, section.slug) or
-      Oli.Accounts.is_admin?(conn.assigns.current_author) or
+      Accounts.is_system_admin?(conn.assigns.current_author) or
       Sections.is_admin?(conn.assigns.current_user, section.slug)
   end
 

--- a/lib/oli_web/controllers/bibliography_controller.ex
+++ b/lib/oli_web/controllers/bibliography_controller.ex
@@ -9,7 +9,7 @@ defmodule OliWeb.BibliographyController do
         "project_id" => project_slug
       }) do
     author = conn.assigns[:current_author]
-    is_admin? = Accounts.is_admin?(author)
+    is_admin? = Accounts.has_admin_role?(author)
 
     case Oli.Authoring.Editing.BibliographyEditor.create_context(project_slug, author) do
       {:ok, context} ->

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -251,7 +251,7 @@ defmodule OliWeb.PageDeliveryController do
     author = conn.assigns.current_author
     section = conn.assigns.section
 
-    if Accounts.is_system_admin?(author) or Sections.is_enrolled?(user.id, section_slug) do
+    if Accounts.at_least_content_admin?(author) or Sections.is_enrolled?(user.id, section_slug) do
       container_type_id = Oli.Resources.ResourceType.id_for_container()
       page_type_id = Oli.Resources.ResourceType.id_for_page()
 
@@ -1246,7 +1246,7 @@ defmodule OliWeb.PageDeliveryController do
 
     section = conn.assigns.section
 
-    is_admin? = Accounts.is_system_admin?(author)
+    is_admin? = Accounts.at_least_content_admin?(author)
 
     if is_admin? or
          PageLifecycle.can_access_attempt?(attempt_guid, user, section) do

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -251,7 +251,7 @@ defmodule OliWeb.PageDeliveryController do
     author = conn.assigns.current_author
     section = conn.assigns.section
 
-    if Accounts.is_admin?(author) or Sections.is_enrolled?(user.id, section_slug) do
+    if Accounts.is_system_admin?(author) or Sections.is_enrolled?(user.id, section_slug) do
       container_type_id = Oli.Resources.ResourceType.id_for_container()
       page_type_id = Oli.Resources.ResourceType.id_for_page()
 
@@ -1246,9 +1246,9 @@ defmodule OliWeb.PageDeliveryController do
 
     section = conn.assigns.section
 
-    is_admin? = Oli.Accounts.is_admin?(author)
+    is_admin? = Accounts.is_system_admin?(author)
 
-    if Oli.Accounts.is_admin?(author) or
+    if is_admin? or
          PageLifecycle.can_access_attempt?(attempt_guid, user, section) do
       page_context = PageContext.create_for_review(section_slug, attempt_guid, user, is_admin?)
 
@@ -1407,13 +1407,6 @@ defmodule OliWeb.PageDeliveryController do
   defp get_discount_string(%Discount{type: :fixed_amount, amount: amount}) do
     {:ok, m} = Money.to_string(amount)
     m
-  end
-
-  def is_admin?(conn) do
-    case conn.assigns[:current_author] do
-      nil -> false
-      author -> Oli.Accounts.is_admin?(author)
-    end
   end
 
   defp simulate_node(

--- a/lib/oli_web/controllers/resource_controller.ex
+++ b/lib/oli_web/controllers/resource_controller.ex
@@ -19,7 +19,7 @@ defmodule OliWeb.ResourceController do
 
   def edit(conn, %{"project_id" => project_slug, "revision_slug" => revision_slug}) do
     author = conn.assigns[:current_author]
-    is_admin? = Accounts.is_system_admin?(author)
+    is_admin? = Accounts.at_least_content_admin?(author)
 
     case PageEditor.create_context(project_slug, revision_slug, conn.assigns[:current_author]) do
       {:ok, context} ->

--- a/lib/oli_web/controllers/resource_controller.ex
+++ b/lib/oli_web/controllers/resource_controller.ex
@@ -19,7 +19,7 @@ defmodule OliWeb.ResourceController do
 
   def edit(conn, %{"project_id" => project_slug, "revision_slug" => revision_slug}) do
     author = conn.assigns[:current_author]
-    is_admin? = Accounts.is_admin?(author)
+    is_admin? = Accounts.is_system_admin?(author)
 
     case PageEditor.create_context(project_slug, revision_slug, conn.assigns[:current_author]) do
       {:ok, context} ->

--- a/lib/oli_web/live/admin/admin_view.ex
+++ b/lib/oli_web/live/admin/admin_view.ex
@@ -1,7 +1,7 @@
 defmodule OliWeb.Admin.AdminView do
   use OliWeb, :live_view
 
-  alias Oli.Repo
+  alias Oli.{Accounts, Repo}
   alias OliWeb.Common.Properties.{Groups, Group}
   alias OliWeb.Common.Breadcrumb
   alias Oli.Accounts.{Author}
@@ -28,107 +28,116 @@ defmodule OliWeb.Admin.AdminView do
         <strong>Note:</strong>
         All administrative actions taken in the system are logged for auditing purposes.
       </div>
-      <Group.render label="Account Management" description="Access and manage all users and authors">
-        <ul class="link-list">
-          <li>
-            <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Users.UsersView)}>
-              Manage Students and Instructor Accounts
-            </a>
-          </li>
-          <li>
-            <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Users.AuthorsView)}>
-              Manage Authoring Accounts
-            </a>
-          </li>
-          <li>
-            <a href={~p"/admin/institutions"}>
-              Manage Institutions <%= badge(
-                assigns,
-                Oli.Institutions.count_pending_registrations() |> Oli.Utils.positive_or_nil()
-              ) %>
-            </a>
-          </li>
-          <li><a href={Routes.invite_path(OliWeb.Endpoint, :index)}>Invite New Authors</a></li>
-          <li>
-            <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.CommunityLive.IndexView)}>
-              Manage Communities
-            </a>
-          </li>
-        </ul>
-      </Group.render>
-      <Group.render label="Content Management" description="Access and manage created content">
-        <ul class="link-list">
-          <li>
-            <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.ProjectsLive)}>
-              Browse all Projects
-            </a>
-          </li>
-          <li>
-            <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Products.ProductsView)}>
-              Browse all Products
-            </a>
-          </li>
-          <li>
-            <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.SectionsView)}>
-              Browse all Course Sections
-            </a>
-          </li>
-          <li>
-            <a href={Routes.collab_spaces_index_path(OliWeb.Endpoint, :admin)}>
-              Browse all Collaborative Spaces
-            </a>
-          </li>
-          <li>
-            <a href={Routes.admin_open_and_free_path(OliWeb.Endpoint, :index)}>
-              Manage Open and Free Sections
-            </a>
-          </li>
-          <li><a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.Ingest)}>Ingest Project</a></li>
-          <li><a href={Routes.ingest_path(OliWeb.Endpoint, :index)}>V2 Ingest Project</a></li>
-          <li><a href={Routes.brand_path(OliWeb.Endpoint, :index)}>Manage Branding</a></li>
-          <li>
-            <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.PublisherLive.IndexView)}>
-              Manage Publishers
-            </a>
-          </li>
-        </ul>
-      </Group.render>
-      <Group.render
-        label="System Management"
-        description="Manage and support system level functionality"
-      >
-        <ul class="link-list">
-          <li>
-            <a href={Routes.activity_manage_path(OliWeb.Endpoint, :index)}>Manage Activities</a>
-          </li>
-          <li>
-            <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.SystemMessageLive.IndexView)}>
-              Manage System Message Banner
-            </a>
-          </li>
-          <li>
-            <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.RegistrationsView)}>
-              Manage LTI 1.3 Registrations
-            </a>
-          </li>
-          <li>
-            <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Features.FeaturesLive)}>
-              Feature Flags and Logging
-            </a>
-          </li>
-          <li>
-            <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.ApiKeys.ApiKeysLive)}>
-              Manage Third-Party API Keys
-            </a>
-          </li>
-          <li>
-            <a href={Routes.live_dashboard_path(OliWeb.Endpoint, :home)} target="_blank">
-              <span>View System Performance Dashboard</span>
-              <i class="fas fa-external-link-alt self-center ml-1"></i>
-            </a>
-          </li>
-        </ul>
-      </Group.render>
+      <%= if Accounts.is_system_admin?(@author) || Accounts.is_account_admin?(@author) do %>
+        <Group.render label="Account Management" description="Access and manage all users and authors">
+          <ul class="link-list">
+            <li>
+              <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Users.UsersView)}>
+                Manage Students and Instructor Accounts
+              </a>
+            </li>
+            <li>
+              <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Users.AuthorsView)}>
+                Manage Authoring Accounts
+              </a>
+            </li>
+            <li>
+              <a href={~p"/admin/institutions"}>
+                Manage Institutions <%= badge(
+                  assigns,
+                  Oli.Institutions.count_pending_registrations() |> Oli.Utils.positive_or_nil()
+                ) %>
+              </a>
+            </li>
+            <li><a href={Routes.invite_path(OliWeb.Endpoint, :index)}>Invite New Authors</a></li>
+            <li>
+              <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.CommunityLive.IndexView)}>
+                Manage Communities
+              </a>
+            </li>
+            <li>
+              <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.RegistrationsView)}>
+                Manage LTI 1.3 Registrations
+              </a>
+            </li>
+          </ul>
+        </Group.render>
+      <% end %>
+      <%= if Accounts.has_admin_role?(@author) do %>
+        <Group.render label="Content Management" description="Access and manage created content">
+          <ul class="link-list">
+            <li>
+              <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.ProjectsLive)}>
+                Browse all Projects
+              </a>
+            </li>
+            <li>
+              <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Products.ProductsView)}>
+                Browse all Products
+              </a>
+            </li>
+            <li>
+              <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.SectionsView)}>
+                Browse all Course Sections
+              </a>
+            </li>
+            <li>
+              <a href={Routes.collab_spaces_index_path(OliWeb.Endpoint, :admin)}>
+                Browse all Collaborative Spaces
+              </a>
+            </li>
+            <li>
+              <a href={Routes.admin_open_and_free_path(OliWeb.Endpoint, :index)}>
+                Manage Open and Free Sections
+              </a>
+            </li>
+            <li>
+              <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.Ingest)}>Ingest Project</a>
+            </li>
+            <li><a href={Routes.ingest_path(OliWeb.Endpoint, :index)}>V2 Ingest Project</a></li>
+            <li><a href={Routes.brand_path(OliWeb.Endpoint, :index)}>Manage Branding</a></li>
+            <li>
+              <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.PublisherLive.IndexView)}>
+                Manage Publishers
+              </a>
+            </li>
+          </ul>
+        </Group.render>
+      <% end %>
+      <%= if Accounts.is_system_admin?(@author) do %>
+        <Group.render
+          label="System Management"
+          description="Manage and support system level functionality"
+        >
+          <ul class="link-list">
+            <li>
+              <a href={Routes.activity_manage_path(OliWeb.Endpoint, :index)}>Manage Activities</a>
+            </li>
+            <li>
+              <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.SystemMessageLive.IndexView)}>
+                Manage System Message Banner
+              </a>
+            </li>
+
+            <li>
+              <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Features.FeaturesLive)}>
+                Feature Flags and Logging
+              </a>
+            </li>
+            <li>
+              <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.ApiKeys.ApiKeysLive)}>
+                Manage Third-Party API Keys
+              </a>
+            </li>
+            <li>
+              <a href={Routes.live_dashboard_path(OliWeb.Endpoint, :home)} target="_blank">
+                <span>View System Performance Dashboard</span>
+                <i class="fas fa-external-link-alt self-center ml-1"></i>
+              </a>
+            </li>
+          </ul>
+        </Group.render>
+      <% end %>
     </Groups.render>
     """
   end

--- a/lib/oli_web/live/curriculum/container/container_live.html.heex
+++ b/lib/oli_web/live/curriculum/container/container_live.html.heex
@@ -7,7 +7,7 @@
     </p>
     <div class="flex items-center gap-x-4">
       <.link
-        :if={@has_show_links_uri_hash and Accounts.is_admin?(@author)}
+        :if={@has_show_links_uri_hash and Accounts.is_system_admin?(@author)}
         navigate={~p[/project/#{@project.slug}/history/slug/#{@container.slug}]}
       >
         <i class="fas fa-history"></i> View revision history
@@ -75,7 +75,9 @@
             project={@project}
             view={@view}
             numberings={@numberings}
-            revision_history_link={@has_show_links_uri_hash and Accounts.is_admin?(@author)}
+            revision_history_link={
+              @has_show_links_uri_hash and Accounts.is_system_admin?(@author)
+            }
           />
         <% end %>
         <%!-- <DropTarget id="last" index={length(@children)} /> --%>

--- a/lib/oli_web/live/delivery/remix_section.ex
+++ b/lib/oli_web/live/delivery/remix_section.ex
@@ -154,7 +154,7 @@ defmodule OliWeb.Delivery.RemixSection do
     current_author = Accounts.get_author!(current_author_id)
 
     if Oli.Delivery.Sections.Blueprint.is_author_of_blueprint?(section.slug, current_author_id) or
-         Accounts.is_admin?(current_author) do
+         Accounts.is_system_admin?(current_author) do
       init_state(socket,
         breadcrumbs: set_breadcrumbs(:user, section),
         section: section,

--- a/lib/oli_web/live/delivery/remix_section.ex
+++ b/lib/oli_web/live/delivery/remix_section.ex
@@ -154,7 +154,7 @@ defmodule OliWeb.Delivery.RemixSection do
     current_author = Accounts.get_author!(current_author_id)
 
     if Oli.Delivery.Sections.Blueprint.is_author_of_blueprint?(section.slug, current_author_id) or
-         Accounts.is_system_admin?(current_author) do
+         Accounts.at_least_content_admin?(current_author) do
       init_state(socket,
         breadcrumbs: set_breadcrumbs(:user, section),
         section: section,

--- a/lib/oli_web/live/insights/insights.ex
+++ b/lib/oli_web/live/insights/insights.ex
@@ -1,7 +1,7 @@
 defmodule OliWeb.Insights do
   use OliWeb, :live_view
 
-  alias Oli.Publishing
+  alias Oli.{Accounts, Publishing}
   alias OliWeb.Insights.{TableHeader, TableRow}
   alias Oli.Authoring.Course
   alias OliWeb.Components.Project.AsyncExporter
@@ -34,7 +34,7 @@ defmodule OliWeb.Insights do
     {:ok,
      assign(socket,
        ctx: ctx,
-       is_admin?: Oli.Accounts.is_admin?(ctx.author),
+       is_admin?: Accounts.is_system_admin?(ctx.author),
        project: project,
        by_page_rows: nil,
        by_activity_rows: by_activity_rows,

--- a/lib/oli_web/live/objectives/objectives.ex
+++ b/lib/oli_web/live/objectives/objectives.ex
@@ -186,7 +186,7 @@ defmodule OliWeb.ObjectivesLive.Objectives do
           with_body={true}
         >
           <Listing.render
-            revision_history_link={@has_show_links_uri_hash and Accounts.is_system_admin?(@author)}
+            revision_history_link={@has_show_links_uri_hash and Accounts.at_least_content_admin?(@author)}
             rows={@table_model.rows}
             selected={@selected}
             project_slug={@project.slug}

--- a/lib/oli_web/live/objectives/objectives.ex
+++ b/lib/oli_web/live/objectives/objectives.ex
@@ -186,7 +186,7 @@ defmodule OliWeb.ObjectivesLive.Objectives do
           with_body={true}
         >
           <Listing.render
-            revision_history_link={@has_show_links_uri_hash and Accounts.is_admin?(@author)}
+            revision_history_link={@has_show_links_uri_hash and Accounts.is_system_admin?(@author)}
             rows={@table_model.rows}
             selected={@selected}
             project_slug={@project.slug}

--- a/lib/oli_web/live/products/details_view.ex
+++ b/lib/oli_web/live/products/details_view.ex
@@ -1,14 +1,11 @@
 defmodule OliWeb.Products.DetailsView do
   use OliWeb, :live_view
 
-  alias Oli.Repo
+  alias Oli.{Accounts, Branding, Inventories, Repo}
   alias OliWeb.Common.Breadcrumb
   alias Oli.Accounts.Author
-  alias Oli.Delivery.Sections.Section
   alias Oli.Delivery.Sections
-  alias Oli.Delivery.Sections.Blueprint
-  alias Oli.Branding
-  alias Oli.Inventories
+  alias Oli.Delivery.Sections.{Blueprint, Section}
   alias OliWeb.Router.Helpers, as: Routes
   alias OliWeb.Common.Confirm
   alias OliWeb.Sections.Mount
@@ -50,7 +47,7 @@ defmodule OliWeb.Products.DetailsView do
            updates: Sections.check_for_available_publication_updates(product),
            author: author,
            product: product,
-           is_admin: Oli.Accounts.is_admin?(author),
+           is_admin: Accounts.has_admin_role?(author),
            changeset: Section.changeset(product, %{}),
            title: "Edit Product",
            show_confirm: false,

--- a/lib/oli_web/live/projects/overview_live.ex
+++ b/lib/oli_web/live/projects/overview_live.ex
@@ -100,30 +100,32 @@ defmodule OliWeb.Projects.OverviewLive do
               required: true
             ) %>
           </div>
-          <%= if @can_enable_experiments do %>
-            <div class="form-label-group mb-3">
-              <div class="form-label-group mb-3 form-check">
-                <%= checkbox(f, :has_experiments, required: false) %>
-                <%= label(f, :has_experiments, "Enable Upgrade-based Experiments") %>
-              </div>
 
-              <%= if @project.has_experiments do %>
-                <a
-                  type="button"
-                  class="btn btn-link pl-0"
-                  href={
-                    Routes.live_path(
-                      OliWeb.Endpoint,
-                      OliWeb.Experiments.ExperimentsView,
-                      @project.slug
-                    )
-                  }
-                >
-                  Manage Experiments
-                </a>
-              <% end %>
+          <div class="form-label-group mb-3">
+            <%= if @can_enable_experiments do %>
+            <div class="form-label-group mb-3 form-check">
+              <%= checkbox(f, :has_experiments, required: false) %>
+              <%= label(f, :has_experiments, "Enable Upgrade-based Experiments") %>
             </div>
-          <% end %>
+            <% end %>
+
+            <%= if @project.has_experiments do %>
+              <a
+                type="button"
+                class="btn btn-link pl-0"
+                href={
+                  Routes.live_path(
+                    OliWeb.Endpoint,
+                    OliWeb.Experiments.ExperimentsView,
+                    @project.slug
+                  )
+                }
+              >
+                Manage Experiments
+              </a>
+            <% end %>
+          </div>
+
           <%= submit("Save", class: "btn btn-md btn-primary mt-2") %>
         </Overview.section>
         <Overview.section

--- a/lib/oli_web/live/projects/overview_live.ex
+++ b/lib/oli_web/live/projects/overview_live.ex
@@ -22,7 +22,7 @@ defmodule OliWeb.Projects.OverviewLive do
     project = socket.assigns.project
 
     author = socket.assigns[:current_author]
-    is_admin? = Accounts.is_admin?(author)
+    is_admin? = Accounts.has_admin_role?(author)
 
     latest_published_publication =
       Publishing.get_latest_published_publication_by_slug(project.slug)

--- a/lib/oli_web/live/projects/projects_live.ex
+++ b/lib/oli_web/live/projects/projects_live.ex
@@ -21,14 +21,12 @@ defmodule OliWeb.Projects.ProjectsLive do
 
   def mount(_, %{"current_author_id" => _} = session, socket) do
     %SessionContext{author: author} = ctx = SessionContext.init(socket, session)
-    is_admin = Accounts.is_admin?(author)
+    is_admin = Accounts.has_admin_role?(author)
 
     show_all =
-      if is_admin do
-        Accounts.get_author_preference(author, :admin_show_all_projects, true)
-      else
-        true
-      end
+      if is_admin,
+        do: Accounts.get_author_preference(author, :admin_show_all_projects, true),
+        else: true
 
     show_deleted = Accounts.get_author_preference(author, :admin_show_deleted_projects, false)
 

--- a/lib/oli_web/live/sections/mount.ex
+++ b/lib/oli_web/live/sections/mount.ex
@@ -58,7 +58,7 @@ defmodule OliWeb.Sections.Mount do
   defp ensure_admin(section, author_id) do
     author = Oli.Accounts.get_author!(author_id)
 
-    case Accounts.is_admin?(author) do
+    case Accounts.has_admin_role?(author) do
       true -> {:admin, author, section}
       _ -> {:error, :unauthorized}
     end
@@ -75,7 +75,7 @@ defmodule OliWeb.Sections.Mount do
   end
 
   def is_lms_or_system_admin?(user, section) do
-    admin_role_id = SystemRole.role_id().admin
+    admin_role_id = SystemRole.role_id().system_admin
 
     case user do
       %Author{system_role_id: ^admin_role_id} -> true

--- a/lib/oli_web/live/users/authors_table_model.ex
+++ b/lib/oli_web/live/users/authors_table_model.ex
@@ -4,8 +4,8 @@ defmodule OliWeb.Users.AuthorsTableModel do
   import OliWeb.Common.Utils
 
   alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
-  alias Oli.Accounts.SystemRole
   alias OliWeb.Router.Helpers, as: Routes
+  alias Oli.Accounts
 
   def render(assigns) do
     ~H"""
@@ -45,19 +45,17 @@ defmodule OliWeb.Users.AuthorsTableModel do
     )
   end
 
-  def render_role_column(assigns, %{system_role_id: system_role_id}, _) do
-    admin_role_id = SystemRole.role_id().admin
+  def render_role_column(assigns, author, _) do
+    has_admin_role? = Accounts.has_admin_role?(author)
 
-    case system_role_id do
-      ^admin_role_id ->
-        ~H"""
-        <span class="badge badge-warning">Administrator</span>
-        """
-
-      _ ->
-        ~H"""
-        <span class="badge badge-dark">Author</span>
-        """
+    if has_admin_role? do
+      ~H"""
+      <span class="badge badge-warning">Administrator</span>
+      """
+    else
+      ~H"""
+      <span class="badge badge-dark">Author</span>
+      """
     end
   end
 

--- a/lib/oli_web/live/users/user_actions.ex
+++ b/lib/oli_web/live/users/user_actions.ex
@@ -2,7 +2,6 @@ defmodule OliWeb.Users.Actions do
   use OliWeb, :html
 
   alias Oli.Accounts
-  alias Oli.Accounts.SystemRole
   alias OliWeb.Router.Helpers, as: Routes
 
   attr(:for_author, :boolean, default: false)
@@ -48,19 +47,6 @@ defmodule OliWeb.Users.Actions do
           Confirm email
         </button>
 
-        <div class="dropdown-divider"></div>
-      <% end %>
-
-      <%= if @for_author do %>
-        <%= if @user.system_role_id == SystemRole.role_id().system_admin do %>
-          <button class="btn btn-warning" phx-click="show_revoke_admin_modal" phx-value-id={@user.id}>
-            Revoke admin
-          </button>
-        <% else %>
-          <button class="btn btn-warning" phx-click="show_grant_admin_modal" phx-value-id={@user.id}>
-            Grant admin
-          </button>
-        <% end %>
         <div class="dropdown-divider"></div>
       <% end %>
 

--- a/lib/oli_web/live/users/user_actions.ex
+++ b/lib/oli_web/live/users/user_actions.ex
@@ -52,7 +52,7 @@ defmodule OliWeb.Users.Actions do
       <% end %>
 
       <%= if @for_author do %>
-        <%= if @user.system_role_id == SystemRole.role_id().admin do %>
+        <%= if @user.system_role_id == SystemRole.role_id().system_admin do %>
           <button class="btn btn-warning" phx-click="show_revoke_admin_modal" phx-value-id={@user.id}>
             Revoke admin
           </button>

--- a/lib/oli_web/plugs/authorize_community.ex
+++ b/lib/oli_web/plugs/authorize_community.ex
@@ -9,7 +9,7 @@ defmodule Oli.Plugs.AuthorizeCommunity do
   def call(conn, _opts) do
     author = conn.assigns.current_author
 
-    unless Accounts.is_admin?(author) do
+    unless Accounts.has_admin_role?(author) do
       case Groups.get_community_account_by!(%{
              author_id: author.id,
              community_id: conn.params["community_id"]

--- a/lib/oli_web/plugs/authorize_section.ex
+++ b/lib/oli_web/plugs/authorize_section.ex
@@ -2,15 +2,13 @@ defmodule Oli.Plugs.AuthorizeSection do
   import Plug.Conn
   import Phoenix.Controller
 
-  alias Oli.Accounts.SystemRole
+  alias Oli.Accounts
   alias Oli.Delivery.Sections
-
-  @admin_role_id SystemRole.role_id() |> Map.get(:admin)
 
   def init(opts), do: opts
 
   def call(conn, _opts) do
-    if is_admin?(conn) or is_instructor?(conn) do
+    if Accounts.has_admin_role?(conn.assigns[:current_author]) or is_instructor?(conn) do
       conn
     else
       conn
@@ -18,13 +16,6 @@ defmodule Oli.Plugs.AuthorizeSection do
       |> put_status(403)
       |> render("not_authorized.html")
       |> halt()
-    end
-  end
-
-  defp is_admin?(conn) do
-    case conn.assigns[:current_author] do
-      %{system_role_id: system_role_id} -> system_role_id == @admin_role_id
-      _ -> false
     end
   end
 

--- a/lib/oli_web/plugs/authorize_section_preview.ex
+++ b/lib/oli_web/plugs/authorize_section_preview.ex
@@ -17,7 +17,7 @@ defmodule Oli.Plugs.AuthorizeSectionPreview do
     section_slug = conn.path_params["section_slug"]
 
     cond do
-      Sections.is_instructor?(user, section_slug) or Accounts.is_admin?(author) ->
+      Sections.is_instructor?(user, section_slug) or Accounts.has_admin_role?(author) ->
         conn
         |> put_session(:preview_mode, true)
 

--- a/lib/oli_web/plugs/give_admin_priority.ex
+++ b/lib/oli_web/plugs/give_admin_priority.ex
@@ -16,7 +16,7 @@ defmodule Oli.Plugs.GiveAdminPriority do
     if author = Pow.Plug.current_user(conn, pow_config) do
       author = Repo.get(Author, author.id)
 
-      case Oli.Accounts.is_admin?(author) do
+      case Oli.Accounts.has_admin_role?(author) do
         true -> OliWeb.Pow.PowHelpers.use_pow_config(conn, :author)
         _ -> OliWeb.Pow.PowHelpers.use_pow_config(conn, :user)
       end

--- a/lib/oli_web/plugs/layout_based_on_user.ex
+++ b/lib/oli_web/plugs/layout_based_on_user.ex
@@ -6,7 +6,7 @@ defmodule Oli.Plugs.LayoutBasedOnUser do
   end
 
   def call(conn, _params) do
-    admin_role_id = SystemRole.role_id().admin
+    admin_role_id = SystemRole.role_id().system_admin
 
     # If someone is logged in as a system admin, prioritize that (although they
     # might be logged in as instructor) and set the root layout to be workspace.

--- a/lib/oli_web/plugs/set_user.ex
+++ b/lib/oli_web/plugs/set_user.ex
@@ -24,7 +24,7 @@ defmodule Oli.Plugs.SetCurrentUser do
       conn
       |> put_session(:current_author_id, current_author.id)
       |> put_session(:is_community_admin, current_author.community_admin_count > 0)
-      |> put_session(:is_system_admin, Accounts.is_admin?(current_author))
+      |> put_session(:is_system_admin, Accounts.has_admin_role?(current_author))
       |> assign(:current_author, current_author)
     else
       _ ->

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -8,6 +8,7 @@ defmodule OliWeb.Router do
 
   import Phoenix.LiveDashboard.Router
   import PhoenixStorybook.Router
+  import Oli.Plugs.EnsureAdmin
 
   @user_persistent_session_cookie_key "oli_user_persistent_session_v2"
   @author_persistent_session_cookie_key "oli_author_persistent_session_v2"
@@ -366,7 +367,7 @@ defmodule OliWeb.Router do
     put("/account", WorkspaceController, :update_author)
 
     scope "/communities" do
-      pipe_through([:community_admin])
+      pipe_through([:community_admin, :reject_content_admin])
 
       live("/", CommunityLive.IndexView)
 
@@ -1146,7 +1147,7 @@ defmodule OliWeb.Router do
 
   ### Admin Dashboard / Telemetry
   scope "/admin", OliWeb do
-    pipe_through([:browser, :authoring_protected, :admin])
+    pipe_through([:browser, :authoring_protected, :admin, :reject_content_or_account_admin])
 
     live_dashboard("/dashboard",
       metrics: {OliWeb.Telemetry, :non_distributed_metrics},
@@ -1167,14 +1168,8 @@ defmodule OliWeb.Router do
       :pow_email_layout
     ])
 
-    get("/activity_review", ActivityReviewController, :index)
-
     # General
     live("/", Admin.AdminView)
-    live("/features", Features.FeaturesLive)
-    live("/part_attempts", Admin.PartAttemptsView)
-    get("/spot_check/:activity_attempt_id", SpotCheckController, :index)
-    live("/api_keys", ApiKeys.ApiKeysLive)
     live("/products", Products.ProductsView)
     live("/products/:product_id/discounts", Products.Payments.Discounts.ProductsIndexView)
     live("/collaborative_spaces", CollaborationLive.IndexView, :admin, as: :collab_spaces_index)
@@ -1199,41 +1194,6 @@ defmodule OliWeb.Router do
     resources("/open_and_free", OpenAndFreeController, as: :admin_open_and_free)
     live("/open_and_free/:section_slug/remix", Delivery.RemixSection, as: :open_and_free_remix)
 
-    # Institutions, LTI Registrations and Deployments
-    resources("/institutions", InstitutionController, except: [:index])
-
-    live("/institutions/", Admin.Institutions.IndexLive)
-
-    live(
-      "/institutions/:institution_id/discount",
-      Products.Payments.Discounts.ShowView,
-      :institution,
-      as: :discount
-    )
-
-    live("/institutions/:institution_id/research_consent", Admin.Institutions.ResearchConsentView,
-      as: :institution
-    )
-
-    live(
-      "/institutions/:institution_id/sections_and_students/:selected_tab",
-      Admin.Institutions.SectionsAndStudentsView
-    )
-
-    live("/registrations", Admin.RegistrationsView)
-
-    resources("/registrations", RegistrationController, except: [:index]) do
-      resources("/deployments", DeploymentController, except: [:index, :show])
-    end
-
-    put("/approve_registration", InstitutionController, :approve_registration)
-
-    # Communities
-    live("/communities/new", CommunityLive.NewView)
-
-    # System Message Banner
-    live("/system_messages", SystemMessageLive.IndexView)
-
     # Publishers
     live("/publishers", PublisherLive.IndexView)
     live("/publishers/new", PublisherLive.NewView)
@@ -1245,48 +1205,113 @@ defmodule OliWeb.Router do
     live("/ingest", Admin.Ingest)
     live("/ingest/process", Admin.IngestV2)
 
-    # Authoring Activity Management
-    get("/manage_activities", ActivityManageController, :index)
-    put("/manage_activities/make_global/:activity_slug", ActivityManageController, :make_global)
-    put("/manage_activities/make_private/:activity_slug", ActivityManageController, :make_private)
-
-    put(
-      "/manage_activities/make_globally_visible/:activity_slug",
-      ActivityManageController,
-      :make_globally_visible
-    )
-
-    put(
-      "/manage_activities/make_admin_visible/:activity_slug",
-      ActivityManageController,
-      :make_admin_visible
-    )
-
     # Branding
     resources("/brands", BrandController)
 
-    # Admin Author/User Account Management
-    live("/authors", Users.AuthorsView)
-    live("/authors/:user_id", Users.AuthorsDetailView)
-    live("/users", Users.UsersView)
-    live("/users/:user_id", Users.UsersDetailView)
-    get("/invite", InviteController, :index)
-    post("/invite", InviteController, :create)
-    post("/accounts/resend_user_confirmation_link", PowController, :resend_user_confirmation_link)
+    # Routes rejected for content admin
+    scope "/" do
+      pipe_through([:reject_content_admin])
+      live("/users", Users.UsersView)
+      live("/users/:user_id", Users.UsersDetailView)
+      # Admin Author/User Account Management
+      live("/authors", Users.AuthorsView)
+      live("/authors/:user_id", Users.AuthorsDetailView)
 
-    post(
-      "/accounts/resend_author_confirmation_link",
-      PowController,
-      :resend_author_confirmation_link
-    )
+      # Institutions, LTI Registrations and Deployments
+      resources("/institutions", InstitutionController, except: [:index])
+      put("/approve_registration", InstitutionController, :approve_registration)
+      live("/institutions/", Admin.Institutions.IndexLive)
 
-    post("/accounts/send_user_password_reset_link", PowController, :send_user_password_reset_link)
+      live(
+        "/institutions/:institution_id/discount",
+        Products.Payments.Discounts.ShowView,
+        :institution,
+        as: :discount
+      )
 
-    post(
-      "/accounts/send_author_password_reset_link",
-      PowController,
-      :send_author_password_reset_link
-    )
+      live(
+        "/institutions/:institution_id/research_consent",
+        Admin.Institutions.ResearchConsentView,
+        as: :institution
+      )
+
+      live(
+        "/institutions/:institution_id/sections_and_students/:selected_tab",
+        Admin.Institutions.SectionsAndStudentsView
+      )
+
+      get("/invite", InviteController, :index)
+      post("/invite", InviteController, :create)
+
+      # Communities
+      live("/communities/new", CommunityLive.NewView)
+
+      live("/registrations", Admin.RegistrationsView)
+
+      resources("/registrations", RegistrationController, except: [:index]) do
+        resources("/deployments", DeploymentController, except: [:index, :show])
+      end
+
+      post(
+        "/accounts/resend_user_confirmation_link",
+        PowController,
+        :resend_user_confirmation_link
+      )
+
+      post(
+        "/accounts/resend_author_confirmation_link",
+        PowController,
+        :resend_author_confirmation_link
+      )
+
+      post(
+        "/accounts/send_user_password_reset_link",
+        PowController,
+        :send_user_password_reset_link
+      )
+
+      post(
+        "/accounts/send_author_password_reset_link",
+        PowController,
+        :send_author_password_reset_link
+      )
+    end
+
+    # Routes rejected for account and content admin
+    scope "/" do
+      pipe_through([:reject_content_or_account_admin])
+      get("/activity_review", ActivityReviewController, :index)
+      live("/part_attempts", Admin.PartAttemptsView)
+      get("/spot_check/:activity_attempt_id", SpotCheckController, :index)
+
+      # Authoring Activity Management
+      get("/manage_activities", ActivityManageController, :index)
+      put("/manage_activities/make_global/:activity_slug", ActivityManageController, :make_global)
+
+      put(
+        "/manage_activities/make_private/:activity_slug",
+        ActivityManageController,
+        :make_private
+      )
+
+      put(
+        "/manage_activities/make_globally_visible/:activity_slug",
+        ActivityManageController,
+        :make_globally_visible
+      )
+
+      put(
+        "/manage_activities/make_admin_visible/:activity_slug",
+        ActivityManageController,
+        :make_admin_visible
+      )
+
+      # System Message Banner
+      live("/system_messages", SystemMessageLive.IndexView)
+
+      live("/features", Features.FeaturesLive)
+      live("/api_keys", ApiKeys.ApiKeysLive)
+    end
   end
 
   scope "/project", OliWeb do

--- a/lib/oli_web/templates/layout/_project_sidebar.html.eex
+++ b/lib/oli_web/templates/layout/_project_sidebar.html.eex
@@ -19,7 +19,7 @@
       <hr class="dropdown-divider" />
 
       <li><a class="dropdown-item btn btn-lg" href="<%= Routes.live_path(OliWeb.Endpoint, OliWeb.Resources.PagesView, @project.slug) %>">All Pages</a></li>
-      <%= if Accounts.is_admin?(@current_author) do %>
+      <%= if Accounts.is_system_admin?(@current_author) do %>
         <li><a class="dropdown-item btn btn-lg" href="<%= Routes.live_path(OliWeb.Endpoint, OliWeb.Resources.ActivitiesView, @project.slug) %>">All Activities</a></li>
       <% end %>
 
@@ -48,7 +48,7 @@
     </div>
   </div>
 
-  <%= if Accounts.is_admin?(@current_author) do %>
+  <%= if Accounts.has_admin_role?(@current_author) do %>
     <%= render OliWeb.LayoutView, "_admin_sidebar.html", assigns %>
   <% end %>
 

--- a/lib/oli_web/templates/layout/_workspace_sidebar.html.eex
+++ b/lib/oli_web/templates/layout/_workspace_sidebar.html.eex
@@ -5,7 +5,7 @@
     <div aria-hidden="true" class="label mt-1">Projects</div>
   </a>
 
-  <%= if Accounts.is_admin?(@current_author) do %>
+  <%= if Accounts.has_admin_role?(@current_author) do %>
     <%= render OliWeb.LayoutView, "_admin_sidebar.html", assigns %>
   <% else %>
     <%= if Plug.Conn.get_session(@conn, :is_community_admin) do %>

--- a/lib/oli_web/views/authoring_view.ex
+++ b/lib/oli_web/views/authoring_view.ex
@@ -6,13 +6,13 @@ defmodule OliWeb.AuthoringView do
   alias Oli.Accounts.Author
 
   def author_role_text(author) do
-    if Accounts.is_admin?(author),
+    if Accounts.has_admin_role?(author),
       do: "Admin",
       else: "Author"
   end
 
   def author_role_color(author) do
-    if Accounts.is_admin?(author),
+    if Accounts.has_admin_role?(author),
       do: "admin-color",
       else: "author-color"
   end

--- a/lib/oli_web/views/view_helpers.ex
+++ b/lib/oli_web/views/view_helpers.ex
@@ -62,7 +62,7 @@ defmodule OliWeb.ViewHelpers do
   def is_section_instructor_or_admin?(section_slug, user_or_author) do
     Sections.is_instructor?(user_or_author, section_slug) ||
       Sections.is_admin?(user_or_author, section_slug) ||
-      Accounts.is_system_admin?(user_or_author)
+      Accounts.at_least_content_admin?(user_or_author)
   end
 
   def is_section_instructor?(section_slug, user) do

--- a/lib/oli_web/views/view_helpers.ex
+++ b/lib/oli_web/views/view_helpers.ex
@@ -62,7 +62,7 @@ defmodule OliWeb.ViewHelpers do
   def is_section_instructor_or_admin?(section_slug, user_or_author) do
     Sections.is_instructor?(user_or_author, section_slug) ||
       Sections.is_admin?(user_or_author, section_slug) ||
-      Accounts.is_admin?(user_or_author)
+      Accounts.is_system_admin?(user_or_author)
   end
 
   def is_section_instructor?(section_slug, user) do

--- a/priv/repo/migrations/20240216211634_populate_system_roles.exs
+++ b/priv/repo/migrations/20240216211634_populate_system_roles.exs
@@ -1,0 +1,39 @@
+defmodule Oli.Repo.Migrations.PopulateSystemRoles do
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    UPDATE system_roles SET type = 'system_admin' WHERE id = 2;
+    """)
+
+    execute("""
+    INSERT INTO system_roles (id, type, inserted_at, updated_at) VALUES
+    (3, 'account_admin', now(), now()),
+    (4, 'content_admin', now(), now())
+    ON CONFLICT(id)
+    DO UPDATE SET
+      type = EXCLUDED.type,
+      updated_at = EXCLUDED.updated_at;
+    """)
+  end
+
+  def down do
+    execute("""
+      UPDATE authors
+      SET system_role_id = (
+        SELECT id FROM system_roles WHERE type = 'system_admin'
+      )
+      WHERE system_role_id IN (
+        SELECT id FROM system_roles WHERE type IN ('account_admin', 'content_admin')
+      );
+    """)
+
+    execute("""
+    UPDATE system_roles SET type = 'admin' WHERE id = 2;
+    """)
+
+    execute("""
+    DELETE FROM system_roles WHERE type IN ('account_admin', 'content_admin');
+    """)
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -46,7 +46,7 @@ if !Oli.Repo.get_by(Oli.Accounts.Author,
            family_name: "",
            password: System.get_env("ADMIN_PASSWORD", "changeme"),
            password_confirmation: System.get_env("ADMIN_PASSWORD", "changeme"),
-           system_role_id: Oli.Accounts.SystemRole.role_id().admin
+           system_role_id: Oli.Accounts.SystemRole.role_id().system_admin
          },
          pow_config
        ) do

--- a/test/oli/accounts_test.exs
+++ b/test/oli/accounts_test.exs
@@ -23,7 +23,7 @@ defmodule Oli.AccountsTest do
         |> Repo.insert()
 
       assert author.system_role_id == Accounts.SystemRole.role_id().author
-      assert Accounts.is_admin?(author) == false
+      assert Accounts.is_system_admin?(author) == false
     end
 
     test "changeset accepts system role change", %{} do
@@ -37,16 +37,16 @@ defmodule Oli.AccountsTest do
         })
         |> Repo.insert()
 
-      assert Accounts.is_admin?(author) == false
+      assert Accounts.is_system_admin?(author) == false
 
       {:ok, author} =
         Accounts.insert_or_update_author(%{
           email: author.email,
-          system_role_id: Accounts.SystemRole.role_id().admin
+          system_role_id: Accounts.SystemRole.role_id().system_admin
         })
 
-      assert author.system_role_id == Accounts.SystemRole.role_id().admin
-      assert Accounts.is_admin?(author) == true
+      assert author.system_role_id == Accounts.SystemRole.role_id().system_admin
+      assert Accounts.is_system_admin?(author) == true
     end
 
     test "search_authors_matching/1 returns authors matching the input exactly" do

--- a/test/oli/course_browse_test.exs
+++ b/test/oli/course_browse_test.exs
@@ -34,7 +34,7 @@ defmodule Oli.CourseBrowseTest do
           given_name: "First",
           family_name: "Last",
           provider: "foo",
-          system_role_id: SystemRole.role_id().admin
+          system_role_id: SystemRole.role_id().system_admin
         })
         |> Repo.insert()
 

--- a/test/oli/resources/page_browse_test.exs
+++ b/test/oli/resources/page_browse_test.exs
@@ -59,7 +59,7 @@ defmodule Oli.Resources.PageBrowseTest do
           given_name: "First",
           family_name: "Last",
           provider: "foo",
-          system_role_id: SystemRole.role_id().admin
+          system_role_id: SystemRole.role_id().system_admin
         })
         |> Repo.insert()
 

--- a/test/oli_web/controllers/api/activity_bank_controller_test.exs
+++ b/test/oli_web/controllers/api/activity_bank_controller_test.exs
@@ -55,7 +55,7 @@ defmodule OliWeb.Api.ActivityBankControllerTest do
       assert html_response(conn, 200) =~ ~s[&quot;revisionHistoryLink&quot;:false]
 
       # as an admin we should see the revision history link
-      admin = author_fixture(%{system_role_id: SystemRole.role_id().admin})
+      admin = author_fixture(%{system_role_id: SystemRole.role_id().system_admin})
 
       conn =
         conn

--- a/test/oli_web/controllers/brand_controller_test.exs
+++ b/test/oli_web/controllers/brand_controller_test.exs
@@ -159,7 +159,7 @@ defmodule OliWeb.BrandControllerTest do
   end
 
   defp create_and_signin_admin(%{conn: conn}) do
-    admin = author_fixture(%{system_role_id: Oli.Accounts.SystemRole.role_id().admin})
+    admin = author_fixture(%{system_role_id: Oli.Accounts.SystemRole.role_id().system_admin})
 
     conn =
       conn

--- a/test/oli_web/controllers/deployment_controller_test.exs
+++ b/test/oli_web/controllers/deployment_controller_test.exs
@@ -188,7 +188,7 @@ defmodule OliWeb.DeploymentControllerTest do
         given_name: "First",
         family_name: "Last",
         provider: "foo",
-        system_role_id: SystemRole.role_id().admin
+        system_role_id: SystemRole.role_id().system_admin
       })
       |> Repo.insert()
 

--- a/test/oli_web/controllers/institution_controller_test.exs
+++ b/test/oli_web/controllers/institution_controller_test.exs
@@ -130,7 +130,7 @@ defmodule OliWeb.InstitutionControllerTest do
         given_name: "First",
         family_name: "Last",
         provider: "foo",
-        system_role_id: Accounts.SystemRole.role_id().admin
+        system_role_id: Accounts.SystemRole.role_id().system_admin
       })
       |> Repo.insert()
 

--- a/test/oli_web/controllers/invite_controller_test.exs
+++ b/test/oli_web/controllers/invite_controller_test.exs
@@ -113,7 +113,7 @@ defmodule OliWeb.InviteControllerTest do
         given_name: "First",
         family_name: "Last",
         provider: "foo",
-        system_role_id: Accounts.SystemRole.role_id().admin
+        system_role_id: Accounts.SystemRole.role_id().system_admin
       })
       |> Repo.insert()
 

--- a/test/oli_web/controllers/registration_controller_test.exs
+++ b/test/oli_web/controllers/registration_controller_test.exs
@@ -150,7 +150,7 @@ defmodule OliWeb.RegistrationControllerTest do
         given_name: "First",
         family_name: "Last",
         provider: "foo",
-        system_role_id: SystemRole.role_id().admin
+        system_role_id: SystemRole.role_id().system_admin
       })
       |> Repo.insert()
 

--- a/test/oli_web/live/admin_live_test.exs
+++ b/test/oli_web/live/admin_live_test.exs
@@ -1086,44 +1086,6 @@ defmodule OliWeb.AdminLiveTest do
       assert not is_nil(date)
     end
 
-    test "grant admin to author", %{
-      conn: conn,
-      author: %Author{id: id}
-    } do
-      {:ok, view, _html} = live(conn, live_view_author_detail_route(id))
-
-      view
-      |> element("button[phx-click=\"show_grant_admin_modal\"]")
-      |> render_click()
-
-      view
-      |> element("button[phx-click=\"grant_admin\"]")
-      |> render_click()
-
-      admin_role = Oli.Accounts.SystemRole.role_id().system_admin
-      assert %Author{system_role_id: ^admin_role} = Accounts.get_author!(id)
-    end
-
-    test "revoke admin to author", %{
-      conn: conn
-    } do
-      %Author{id: id} =
-        insert(:author, %{system_role_id: Oli.Accounts.SystemRole.role_id().system_admin})
-
-      {:ok, view, _html} = live(conn, live_view_author_detail_route(id))
-
-      view
-      |> element("button[phx-click=\"show_revoke_admin_modal\"]")
-      |> render_click()
-
-      view
-      |> element("button[phx-click=\"revoke_admin\"]")
-      |> render_click()
-
-      author_role = Oli.Accounts.SystemRole.role_id().author
-      assert %Author{system_role_id: ^author_role} = Accounts.get_author!(id)
-    end
-
     test "shows email confirmation buttons when author account was created but not confirmed yet",
          %{conn: conn} do
       non_confirmed_author = insert(:author, email_confirmation_token: "token")

--- a/test/oli_web/live/admin_live_test.exs
+++ b/test/oli_web/live/admin_live_test.exs
@@ -91,7 +91,7 @@ defmodule OliWeb.AdminLiveTest do
     end
   end
 
-  describe "index" do
+  describe "index as system admin" do
     setup [:admin_conn]
 
     test "loads account management links correctly", %{conn: conn} do
@@ -128,6 +128,11 @@ defmodule OliWeb.AdminLiveTest do
       assert has_element?(
                view,
                "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.CommunityLive.IndexView)}\"]"
+             )
+
+      assert has_element?(
+               view,
+               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.RegistrationsView)}\"]"
              )
     end
 
@@ -176,22 +181,332 @@ defmodule OliWeb.AdminLiveTest do
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.activity_manage_path(OliWeb.Endpoint, :index)}\"]"
+               "a[href=\"#{Routes.activity_manage_path(OliWeb.Endpoint, :index)}\"]",
+               "Manage Activities"
              )
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.RegistrationsView)}\"]"
+               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.SystemMessageLive.IndexView)}\"]",
+               "Manage System Message Banner"
              )
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Features.FeaturesLive)}\"]"
+               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Features.FeaturesLive)}\"]",
+               "Feature Flags and Logging"
              )
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.ApiKeys.ApiKeysLive)}\"]"
+               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.ApiKeys.ApiKeysLive)}\"]",
+               "Manage Third-Party API Keys"
+             )
+
+      assert has_element?(
+               view,
+               "a[href=\"#{~p"/admin/dashboard"}\"]",
+               "View System Performance Dashboard"
+             )
+    end
+  end
+
+  describe "index as account admin" do
+    setup [:account_admin_conn]
+
+    test "loads account management links correctly", %{conn: conn} do
+      {:ok, view, _html} = live(conn, @live_view_route)
+
+      assert view
+             |> element(".alert")
+             |> render() =~
+               "All administrative actions taken in the system are logged for auditing purposes."
+
+      assert render(view) =~ "Account Management"
+      assert render(view) =~ "Access and manage all users and authors"
+
+      assert has_element?(
+               view,
+               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Users.UsersView)}\"]",
+               "Manage Students and Instructor Accounts"
+             )
+
+      assert has_element?(
+               view,
+               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Users.AuthorsView)}\"]",
+               "Manage Authoring Accounts"
+             )
+
+      assert has_element?(
+               view,
+               "a[href=\"#{~p"/admin/institutions"}\"]",
+               "Manage Institutions"
+             )
+
+      assert has_element?(
+               view,
+               "a[href=\"#{Routes.invite_path(OliWeb.Endpoint, :index)}\"]",
+               "Invite New Authors"
+             )
+
+      assert has_element?(
+               view,
+               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.CommunityLive.IndexView)}\"]",
+               "Manage Communities"
+             )
+
+      assert has_element?(
+               view,
+               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.RegistrationsView)}\"]",
+               "Manage LTI 1.3 Registrations"
+             )
+    end
+
+    test "loads content management links correctly", %{conn: conn} do
+      {:ok, view, _html} = live(conn, @live_view_route)
+
+      assert render(view) =~ "Content Management"
+      assert render(view) =~ "Access and manage created content"
+
+      assert has_element?(
+               view,
+               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.ProjectsLive)}\"]",
+               "Browse all Projects"
+             )
+
+      assert has_element?(
+               view,
+               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Products.ProductsView)}\"]",
+               "Browse all Products"
+             )
+
+      assert has_element?(
+               view,
+               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.SectionsView)}\"]",
+               "Browse all Course Sections"
+             )
+
+      assert has_element?(
+               view,
+               "a[href=\"#{~p"/admin/collaborative_spaces"}\"]",
+               "Browse all Collaborative Spaces"
+             )
+
+      assert has_element?(
+               view,
+               "a[href=\"#{Routes.admin_open_and_free_path(OliWeb.Endpoint, :index)}\"]",
+               "Manage Open and Free Sections"
+             )
+
+      assert has_element?(
+               view,
+               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.Ingest)}\"]",
+               "Ingest Project"
+             )
+
+      assert has_element?(
+               view,
+               "a[href=\"#{~p"/admin/ingest/upload"}\"]",
+               "V2 Ingest Project"
+             )
+
+      assert has_element?(
+               view,
+               "a[href=\"#{Routes.brand_path(OliWeb.Endpoint, :index)}\"]",
+               "Manage Branding"
+             )
+
+      assert has_element?(
+               view,
+               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.PublisherLive.IndexView)}\"]",
+               "Manage Publishers"
+             )
+    end
+
+    test "system management links are not rendered", %{conn: conn} do
+      {:ok, view, _html} = live(conn, @live_view_route)
+
+      refute render(view) =~ "System Management"
+      refute render(view) =~ "Manage and support system level functionality"
+
+      refute has_element?(
+               view,
+               "a[href=\"#{Routes.activity_manage_path(OliWeb.Endpoint, :index)}\"]",
+               "Manage Activities"
+             )
+
+      refute has_element?(
+               view,
+               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.SystemMessageLive.IndexView)}\"]",
+               "Manage System Message Banner"
+             )
+
+      refute has_element?(
+               view,
+               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Features.FeaturesLive)}\"]",
+               "Feature Flags and Logging"
+             )
+
+      refute has_element?(
+               view,
+               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.ApiKeys.ApiKeysLive)}\"]",
+               "Manage Third-Party API Keys"
+             )
+
+      refute has_element?(
+               view,
+               "a[href=\"#{~p"/admin/dashboard"}\"]",
+               "View System Performance Dashboard "
+             )
+    end
+  end
+
+  describe "index as content admin" do
+    setup [:content_admin_conn]
+
+    test "account management links are not rendered", %{conn: conn} do
+      {:ok, view, _html} = live(conn, @live_view_route)
+
+      assert view
+             |> element(".alert")
+             |> render() =~
+               "All administrative actions taken in the system are logged for auditing purposes."
+
+      refute render(view) =~ "Account Management"
+      refute render(view) =~ "Access and manage all users and authors"
+
+      refute has_element?(
+               view,
+               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Users.UsersView)}\"]",
+               "Manage Students and Instructor Accounts"
+             )
+
+      refute has_element?(
+               view,
+               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Users.AuthorsView)}\"]",
+               "Manage Authoring Accounts"
+             )
+
+      refute has_element?(
+               view,
+               "a[href=\"#{~p"/admin/institutions"}\"]",
+               "Manage Institutions"
+             )
+
+      refute has_element?(
+               view,
+               "a[href=\"#{Routes.invite_path(OliWeb.Endpoint, :index)}\"]",
+               "Invite New Authors"
+             )
+
+      refute has_element?(
+               view,
+               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.CommunityLive.IndexView)}\"]",
+               "Manage Communities"
+             )
+
+      refute has_element?(
+               view,
+               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.RegistrationsView)}\"]",
+               "Manage LTI 1.3 Registrations"
+             )
+    end
+
+    test "loads content management links correctly", %{conn: conn} do
+      {:ok, view, _html} = live(conn, @live_view_route)
+
+      assert render(view) =~ "Content Management"
+      assert render(view) =~ "Access and manage created content"
+
+      assert has_element?(
+               view,
+               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.ProjectsLive)}\"]",
+               "Browse all Projects"
+             )
+
+      assert has_element?(
+               view,
+               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Products.ProductsView)}\"]",
+               "Browse all Products"
+             )
+
+      assert has_element?(
+               view,
+               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.SectionsView)}\"]",
+               "Browse all Course Sections"
+             )
+
+      assert has_element?(
+               view,
+               "a[href=\"#{~p"/admin/collaborative_spaces"}\"]",
+               "Browse all Collaborative Spaces"
+             )
+
+      assert has_element?(
+               view,
+               "a[href=\"#{Routes.admin_open_and_free_path(OliWeb.Endpoint, :index)}\"]",
+               "Manage Open and Free Sections"
+             )
+
+      assert has_element?(
+               view,
+               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.Ingest)}\"]",
+               "Ingest Project"
+             )
+
+      assert has_element?(
+               view,
+               "a[href=\"#{~p"/admin/ingest/upload"}\"]",
+               "V2 Ingest Project"
+             )
+
+      assert has_element?(
+               view,
+               "a[href=\"#{Routes.brand_path(OliWeb.Endpoint, :index)}\"]",
+               "Manage Branding"
+             )
+
+      assert has_element?(
+               view,
+               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.PublisherLive.IndexView)}\"]",
+               "Manage Publishers"
+             )
+    end
+
+    test "system management links are not rendered", %{conn: conn} do
+      {:ok, view, _html} = live(conn, @live_view_route)
+
+      refute render(view) =~ "System Management"
+      refute render(view) =~ "Manage and support system level functionality"
+
+      refute has_element?(
+               view,
+               "a[href=\"#{Routes.activity_manage_path(OliWeb.Endpoint, :index)}\"]",
+               "Manage Activities"
+             )
+
+      refute has_element?(
+               view,
+               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.SystemMessageLive.IndexView)}\"]",
+               "Manage System Message Banner"
+             )
+
+      refute has_element?(
+               view,
+               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Features.FeaturesLive)}\"]",
+               "Feature Flags and Logging"
+             )
+
+      refute has_element?(
+               view,
+               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.ApiKeys.ApiKeysLive)}\"]",
+               "Manage Third-Party API Keys"
+             )
+
+      refute has_element?(
+               view,
+               "a[href=\"#{~p"/admin/dashboard"}\"]",
+               "View System Performance Dashboard "
              )
     end
   end
@@ -658,7 +973,7 @@ defmodule OliWeb.AdminLiveTest do
       assert has_element?(view, "input[value=\"#{author.given_name}\"]")
       assert has_element?(view, "input[value=\"#{author.family_name}\"]")
       assert has_element?(view, "input[value=\"#{author.email}\"]")
-      assert has_element?(view, "input[value=\"Author\"]")
+      assert has_element?(view, "select option[value=\"#{author.system_role_id}\"]")
     end
 
     test "redirects to index view and displays error message when author does not exist", %{
@@ -785,7 +1100,7 @@ defmodule OliWeb.AdminLiveTest do
       |> element("button[phx-click=\"grant_admin\"]")
       |> render_click()
 
-      admin_role = Oli.Accounts.SystemRole.role_id().admin
+      admin_role = Oli.Accounts.SystemRole.role_id().system_admin
       assert %Author{system_role_id: ^admin_role} = Accounts.get_author!(id)
     end
 
@@ -793,7 +1108,7 @@ defmodule OliWeb.AdminLiveTest do
       conn: conn
     } do
       %Author{id: id} =
-        insert(:author, %{system_role_id: Oli.Accounts.SystemRole.role_id().admin})
+        insert(:author, %{system_role_id: Oli.Accounts.SystemRole.role_id().system_admin})
 
       {:ok, view, _html} = live(conn, live_view_author_detail_route(id))
 

--- a/test/oli_web/live/delivery/instructor_dashboard/reports/students_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/reports/students_tab_test.exs
@@ -783,7 +783,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.StudentsTabTest do
 
     admin =
       author_fixture(%{
-        system_role_id: Oli.Accounts.SystemRole.role_id().admin,
+        system_role_id: Oli.Accounts.SystemRole.role_id().system_admin,
         preferences:
           %Oli.Accounts.AuthorPreferences{show_relative_dates: false} |> Map.from_struct()
       })

--- a/test/oli_web/live/remix_section_test.exs
+++ b/test/oli_web/live/remix_section_test.exs
@@ -776,7 +776,7 @@ defmodule OliWeb.RemixSectionLiveTest do
   defp setup_admin_session(%{conn: conn}) do
     map = Seeder.base_project_with_resource4()
 
-    admin = author_fixture(%{system_role_id: Oli.Accounts.SystemRole.role_id().admin})
+    admin = author_fixture(%{system_role_id: Oli.Accounts.SystemRole.role_id().system_admin})
 
     conn =
       Plug.Test.init_test_session(conn, %{})

--- a/test/oli_web/live/sections/gating_and_scheduling_test.exs
+++ b/test/oli_web/live/sections/gating_and_scheduling_test.exs
@@ -615,7 +615,7 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
 
   defp setup_admin_session(%{conn: conn}) do
     map = Seeder.base_project_with_resource4()
-    admin = author_fixture(%{system_role_id: Oli.Accounts.SystemRole.role_id().admin})
+    admin = author_fixture(%{system_role_id: Oli.Accounts.SystemRole.role_id().system_admin})
 
     Seeder.create_schedule_gating_condition(
       DateTime.add(yesterday(), -(60 * 60 * 24), :second),

--- a/test/oli_web/live/users/user_detail_view_test.exs
+++ b/test/oli_web/live/users/user_detail_view_test.exs
@@ -601,7 +601,7 @@ defmodule OliWeb.Users.UsersDetailViewTest do
         lms_student.id
       )
 
-    admin = author_fixture(%{system_role_id: Oli.Accounts.SystemRole.role_id().admin})
+    admin = author_fixture(%{system_role_id: Oli.Accounts.SystemRole.role_id().system_admin})
 
     conn =
       Plug.Test.init_test_session(conn, lti_session: nil, section_slug: map.section_1.slug)

--- a/test/oli_web/views/layout_view_test.exs
+++ b/test/oli_web/views/layout_view_test.exs
@@ -15,7 +15,7 @@ defmodule OliWeb.LayoutViewTest do
     end
 
     test "renders admin info" do
-      author = insert(:author, system_role_id: Oli.Accounts.SystemRole.role_id().admin)
+      author = insert(:author, system_role_id: Oli.Accounts.SystemRole.role_id().system_admin)
 
       assert AuthoringView.author_role_text(author) == "Admin"
       assert AuthoringView.author_role_color(author) == "admin-color"

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -340,7 +340,7 @@ defmodule Oli.TestHelpers do
   def admin_conn(%{conn: conn}) do
     admin =
       author_fixture(%{
-        system_role_id: Accounts.SystemRole.role_id().admin,
+        system_role_id: Accounts.SystemRole.role_id().system_admin,
         preferences: %AuthorPreferences{show_relative_dates: false} |> Map.from_struct()
       })
 
@@ -348,6 +348,40 @@ defmodule Oli.TestHelpers do
       Pow.Plug.assign_current_user(conn, admin, OliWeb.Pow.PowHelpers.get_pow_config(:author))
 
     {:ok, conn: conn, admin: admin}
+  end
+
+  def account_admin_conn(%{conn: conn}) do
+    account_admin =
+      author_fixture(%{
+        system_role_id: Accounts.SystemRole.role_id().account_admin,
+        preferences: %AuthorPreferences{show_relative_dates: false} |> Map.from_struct()
+      })
+
+    conn =
+      Pow.Plug.assign_current_user(
+        conn,
+        account_admin,
+        OliWeb.Pow.PowHelpers.get_pow_config(:author)
+      )
+
+    {:ok, conn: conn, account_admin: account_admin}
+  end
+
+  def content_admin_conn(%{conn: conn}) do
+    content_admin =
+      author_fixture(%{
+        system_role_id: Accounts.SystemRole.role_id().content_admin,
+        preferences: %AuthorPreferences{show_relative_dates: false} |> Map.from_struct()
+      })
+
+    conn =
+      Pow.Plug.assign_current_user(
+        conn,
+        content_admin,
+        OliWeb.Pow.PowHelpers.get_pow_config(:author)
+      )
+
+    {:ok, conn: conn, content_admin: content_admin}
   end
 
   def recycle_author_session(conn, author) do


### PR DESCRIPTION
[MER-2999](https://eliterate.atlassian.net/browse/MER-2999)

This PR implements new administrator roles by adding the roles `System Admin`, `Account Admin` and `Content Admin`.

In addition, the router and some plugs are modified to handle access to certain views depending on the new roles.

Added the possibility to edit the role of an author from the author details view, as long as the logged in user is a system admin.

_**Edit author role is possible as system admin**_

https://github.com/Simon-Initiative/oli-torus/assets/16328384/f15a47e4-f61f-405a-9e95-b192bd5dfd70

_**Edit author role is not possible if admin is not a system admin**_

https://github.com/Simon-Initiative/oli-torus/assets/16328384/4915255f-49ad-4921-bf40-2413003f484f

With these changes, the admin index view should show: 

- **System Admin:** System Management, Account Management and Content Management.

![Captura de pantalla 2024-02-23 a la(s) 16 47 45](https://github.com/Simon-Initiative/oli-torus/assets/16328384/8f0eb21a-e631-4b73-ae17-d30f4d524292)

- **Account Admin:** Account Management and Content Management

![Captura de pantalla 2024-02-23 a la(s) 16 47 29](https://github.com/Simon-Initiative/oli-torus/assets/16328384/f15f2f25-bc5c-4884-9071-6e84a075a343)

- **Content Admin:** Content Management

![Captura de pantalla 2024-02-23 a la(s) 16 47 14](https://github.com/Simon-Initiative/oli-torus/assets/16328384/270d9f97-82c2-421d-a804-c1f7bd4ab307)


[MER-2999]: https://eliterate.atlassian.net/browse/MER-2999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ