### PR TITLE
[BUGFIX] [MER-3024] | Advanced Author Next button behaves differently in different lessons

### DIFF
--- a/assets/src/apps/delivery/layouts/deck/DeckLayoutFooter.tsx
+++ b/assets/src/apps/delivery/layouts/deck/DeckLayoutFooter.tsx
@@ -613,7 +613,7 @@ const DeckLayoutFooter: React.FC = () => {
         if (activityHistoryTimeStamp === 0) {
           updateActivityHistoryTimeStamp();
         }
-        //** there are cases when wrong trap state gets trigger but user is still allowed to jump to another activity */
+        //** there are cases when wrong trap state gets trigger but user is still allowed to jump to another activity  */
         //** if we don't do this then, every time Next button will trigger a check events instead of navigating user to respective activity */
         dispatch(
           nextActivityId === 'next' ? navigateToNextActivity() : navigateToActivity(nextActivityId),

--- a/assets/src/apps/delivery/layouts/deck/DeckLayoutFooter.tsx
+++ b/assets/src/apps/delivery/layouts/deck/DeckLayoutFooter.tsx
@@ -43,7 +43,6 @@ import {
   selectCurrentActivityTreeAttemptState,
 } from '../../store/features/groups/selectors/deck';
 import {
-  selectEnableHistory,
   selectIsLegacyTheme,
   selectPageContent,
   selectPreviewMode,
@@ -229,7 +228,6 @@ const DeckLayoutFooter: React.FC = () => {
   const isGoodFeedback = useSelector(selectIsGoodFeedback);
   const currentFeedbacks = useSelector(selectCurrentFeedbacks);
   const nextActivityId: string = useSelector(selectNextActivityId);
-  const enableHistory = useSelector(selectEnableHistory);
   const lastCheckTimestamp = useSelector(selectLastCheckTriggered);
   const lastCheckResults = useSelector(selectLastCheckResults);
   const initPhaseComplete = useSelector(selectInitPhaseComplete);

--- a/assets/src/apps/delivery/layouts/deck/DeckLayoutFooter.tsx
+++ b/assets/src/apps/delivery/layouts/deck/DeckLayoutFooter.tsx
@@ -619,7 +619,7 @@ const DeckLayoutFooter: React.FC = () => {
           nextActivityId === 'next' ? navigateToNextActivity() : navigateToActivity(nextActivityId),
         );
         dispatch(setNextActivityId({ nextActivityId: '' }));
-      } else if (!enableHistory) {
+      } else if (!currentActivity?.custom?.showCheckBtn) {
         dispatch(triggerCheck({ activityId: currentActivity?.id }));
       } else {
         dispatch(setIsGoodFeedback({ isGoodFeedback: false }));


### PR DESCRIPTION
Hey @bsparks can you please look at this PR.

I have tracked down the commit where this change was made (way back in Janus) and it looks like, it was added to fix "[PMP-1249 | BLOCKED: Phases of the Moon 112892: User stuck on screen 2 after validation](https://jira.unicon.net/jira/browse/[PMP-1249](https://jira.unicon.net/jira/browse/PMP-1249)) ". We don't need this to controlled based on the "EnableHistory". 

It should be based on the whether "currentActivity?.custom?.showCheckBtn" is available on the screen.
