### PR TITLE
[NG23-94] Change assistant enabled default value

### DIFF
--- a/lib/oli/delivery/sections/section.ex
+++ b/lib/oli/delivery/sections/section.ex
@@ -18,6 +18,13 @@ defmodule Oli.Delivery.Sections.Section do
     Section
   }
 
+  @required_fields [
+    :type,
+    :title,
+    :registration_open,
+    :base_project_id
+  ]
+
   schema "sections" do
     field(:type, Ecto.Enum, values: [:enrollable, :blueprint], default: :enrollable)
 
@@ -209,12 +216,7 @@ defmodule Oli.Delivery.Sections.Section do
       :assistant_enabled
     ])
     |> cast_embed(:customizations, required: false)
-    |> validate_required([
-      :type,
-      :title,
-      :registration_open,
-      :base_project_id
-    ])
+    |> validate_required(@required_fields)
     |> validate_required_if([:amount], &requires_payment?/1)
     |> validate_required_if([:grace_period_days], &has_grace_period?/1)
     |> validate_required_if([:publisher_id, :apply_major_updates], &is_product?/1)
@@ -239,6 +241,12 @@ defmodule Oli.Delivery.Sections.Section do
       end
     end)
   end
+
+  @doc """
+  Returns the required fields for a section.
+  """
+  @spec required_fields() :: [atom()]
+  def required_fields, do: @required_fields
 
   defp requires_payment?(changeset) do
     case changeset do

--- a/lib/oli/delivery/sections/section.ex
+++ b/lib/oli/delivery/sections/section.ex
@@ -146,7 +146,7 @@ defmodule Oli.Delivery.Sections.Section do
     field(:apply_major_updates, :boolean, default: false)
 
     # enable/disable the ai chatbot assistant for this section
-    field(:assistant_enabled, :boolean, default: true)
+    field(:assistant_enabled, :boolean, default: false)
 
     timestamps(type: :utc_datetime)
   end

--- a/test/oli/delivery/sections/section_test.exs
+++ b/test/oli/delivery/sections/section_test.exs
@@ -1,0 +1,99 @@
+defmodule Oli.Delivery.Sections.SectionTest do
+  use Oli.DataCase
+
+  import Oli.Factory
+
+  alias Oli.Delivery.Sections.Section
+
+  @valid_section_attrs %{
+    type: :enrollable,
+    title: "Section Title",
+    registration_open: true,
+    base_project_id: 1,
+    start_date: nil,
+    end_date: nil
+  }
+
+  describe "changeset/2" do
+    for required_field <- Section.required_fields() do
+      @required_field required_field
+      test "validates #{required_field} is required" do
+        attrs = Map.put(@valid_section_attrs, @required_field, nil)
+        changeset = Section.changeset(%Section{}, attrs)
+
+        assert changeset.errors[@required_field] == {"can't be blank", [validation: :required]}
+      end
+    end
+
+    test "validates publisher_id is required if it is a product" do
+      section = build(:section, @valid_section_attrs)
+      changeset = Section.changeset(section, %{type: :blueprint, publisher_id: nil})
+
+      assert changeset.errors[:publisher_id] == {"can't be blank", [validation: :required]}
+    end
+
+    test "validates apply_major_updates is required if it is a product" do
+      section = build(:section, @valid_section_attrs)
+      changeset = Section.changeset(section, %{type: :blueprint, apply_major_updates: nil})
+
+      assert changeset.errors[:apply_major_updates] == {"can't be blank", [validation: :required]}
+    end
+
+    test "validates positive grace period" do
+      section = build(:section, @valid_section_attrs)
+
+      changeset =
+        Section.changeset(section, %{
+          has_grace_period: true,
+          requires_payment: true,
+          grace_period_days: 0
+        })
+
+      assert changeset.errors[:grace_period_days] ==
+               {"must be greater than or equal to one", []}
+    end
+
+    test "validates positive money" do
+      section = build(:section, @valid_section_attrs)
+
+      changeset = Section.changeset(section, %{amount: Money.new(:USD, -1)})
+
+      assert changeset.errors[:amount] ==
+               {"must be greater than or equal to zero", []}
+    end
+
+    test "validates dates consistency" do
+      # validate end_date
+      section = build(:section, %{@valid_section_attrs | start_date: ~U[2024-01-01 00:00:00Z]})
+
+      changeset = Section.changeset(section, %{end_date: ~U[2023-01-01 00:00:00Z]})
+
+      assert changeset.errors[:end_date] ==
+               {"must be after the start date", []}
+
+      # validate start_date
+      section = build(:section, %{@valid_section_attrs | end_date: ~U[2023-01-01 00:00:00Z]})
+
+      changeset = Section.changeset(section, %{start_date: ~U[2024-01-01 00:00:00Z]})
+
+      assert changeset.errors[:start_date] ==
+               {"must be before the end date", []}
+    end
+
+    test "validates title length" do
+      section = build(:section, @valid_section_attrs)
+
+      changeset = Section.changeset(section, %{title: String.duplicate("a", 256)})
+
+      assert changeset.errors[:title] |> elem(0) =~ ~r/should be at most .* character/
+    end
+
+    test "default assistant_enabled is false" do
+      changeset =
+        build(:section, @valid_section_attrs)
+        |> Section.changeset()
+
+      refute Ecto.Changeset.get_field(changeset, :assistant_enabled)
+    end
+  end
+end

--- a/test/oli_web/live/dialogue/window_live_test.exs
+++ b/test/oli_web/live/dialogue/window_live_test.exs
@@ -84,7 +84,8 @@ defmodule OliWeb.Dialogue.WindowLiveTest do
     section =
       insert(:section,
         base_project: project,
-        analytics_version: :v2
+        analytics_version: :v2,
+        assistant_enabled: true
       )
 
     {:ok, section} = Sections.create_section_resources(section, publication)

--- a/test/oli_web/live/sections/overview_live_test.exs
+++ b/test/oli_web/live/sections/overview_live_test.exs
@@ -466,23 +466,23 @@ defmodule OliWeb.Sections.OverviewLiveTest do
     test "can enable and disable assistant", %{conn: conn, section: section} do
       {:ok, view, _html} = live(conn, live_view_overview_route(section.slug))
 
-      assert has_element?(view, "button[phx-click=\"toggle_assistant\"]", "Disable Assistant")
+      assert has_element?(view, "button[phx-click=\"toggle_assistant\"]", "Enable Assistant")
 
       element(view, "button[phx-click=\"toggle_assistant\"]")
       |> render_click()
 
       update_section = Oli.Delivery.Sections.get_section!(section.id)
-      assert update_section.assistant_enabled == false
-
-      refute has_element?(view, "button[phx-click=\"toggle_assistant\"]", "Disable Assistant")
-
-      element(view, "button[phx-click=\"toggle_assistant\"]")
-      |> render_click()
-
-      update_section = Oli.Delivery.Sections.get_section!(section.id)
-      assert update_section.assistant_enabled == true
+      assert update_section.assistant_enabled
 
       refute has_element?(view, "button[phx-click=\"toggle_assistant\"]", "Enable Assistant")
+
+      element(view, "button[phx-click=\"toggle_assistant\"]")
+      |> render_click()
+
+      update_section = Oli.Delivery.Sections.get_section!(section.id)
+      refute update_section.assistant_enabled
+
+      refute has_element?(view, "button[phx-click=\"toggle_assistant\"]", "Disable Assistant")
     end
   end
 end


### PR DESCRIPTION
[NG23-94](https://eliterate.atlassian.net/browse/NG23-94)

Update the default value of the `assistant_enabled` field in the Section schema to `false`.
Add changeset tests to the Section schema.

**Note:**
The AC states: _"Also, only an Admin should be able to access the UX to enable and disable the Agent. "_.
However, that is the current behavior according to https://github.com/Simon-Initiative/oli-torus/blob/nextgen-ux/lib/oli_web/live/sections/overview_view.ex#L411. No changes should be required here.

[NG23-94]: https://eliterate.atlassian.net/browse/NG23-94?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ