### PR TITLE
[Bugfix] Fix whitespace issues around short answer MER-3020

### DIFF
--- a/assets/src/data/activities/model/rules.ts
+++ b/assets/src/data/activities/model/rules.ts
@@ -195,17 +195,18 @@ export const notRangeRule = (
 
 export const makeRule = (input: Input): string => {
   if (input.kind === InputKind.Text) {
+    const trimmedValue = input.value.trim();
     switch (input.operator) {
       case 'contains':
-        return containsRule(input.value);
+        return containsRule(trimmedValue);
       case 'notcontains':
-        return notContainsRule(input.value);
+        return notContainsRule(trimmedValue);
       case 'regex':
-        return matchRule(input.value);
+        return matchRule(trimmedValue);
       case 'equals':
-        return equalsRule(input.value);
+        return equalsRule(trimmedValue);
       case 'iequals':
-        return iequalsRule(input.value);
+        return iequalsRule(trimmedValue);
     }
   }
 


### PR DESCRIPTION
Bug in the short answer around whitespace.

>`When the correct answer contains a trailing space ("sábado domingo "), 
> entering the correct answer with or without a trailing space = incorrect.
>
> When the correct answer does not contain a trailing space ("sábado domingo"), 
> entering the correct answer with or without a trailing space = correct (as expected).
>
> The trailing space seems to be trimmed in the student answer but not in authoring.

Now both of these scenarios work as expected. I ended up putting the fix down in makeRule so no future components would run into this as well since the whitespace is baked in more at that level.