### PR TITLE
[Bugfix] Cut off formulas [MER-2961]

### DIFF
--- a/assets/styles/common/elements.scss
+++ b/assets/styles/common/elements.scss
@@ -335,6 +335,7 @@ $element-margin-bottom: 1.5em;
     /* The mathjax formulas were rendering out much larger than the surrounding text, so we're scaling them down to better match the
        legacy content, but the callouts should not be scaled down since that made them look too small. */
     font-size: 0.9em;
+
     /* MER-2961 - Formulas that were too wide were being cut off. */
     overflow-x: auto;
   }

--- a/assets/styles/common/elements.scss
+++ b/assets/styles/common/elements.scss
@@ -335,6 +335,8 @@ $element-margin-bottom: 1.5em;
     /* The mathjax formulas were rendering out much larger than the surrounding text, so we're scaling them down to better match the
        legacy content, but the callouts should not be scaled down since that made them look too small. */
     font-size: 0.9em;
+    /* MER-2961 - Formulas that were too wide were being cut off. */
+    overflow-x: auto;
   }
 
   .callout-block,

--- a/assets/styles/common/purpose.scss
+++ b/assets/styles/common/purpose.scss
@@ -24,6 +24,8 @@
 
   & > .content-purpose-content {
     padding: 32px;
+    /* MER-2961 - Some wide content (specifically formulas) were getting cut off in groups, adding a scrollbar */
+    overflow-x: auto;
   }
 
   &.none {

--- a/assets/styles/delivery/activity.scss
+++ b/assets/styles/delivery/activity.scss
@@ -22,6 +22,7 @@
     padding: 12px 16px;
     border-style: none;
     border-radius: 4px;
+    overflow-x: auto;
 
     &.correct {
       background-color: var(--color-feedback-correct-bg);
@@ -158,6 +159,11 @@
     background-color: var(--color-delivery-hints-bg);
     border: 2px solid var(--color-delivery-hints-border);
     border-radius: 0;
+    /* MER-2961 - Some wide content (specifically formulas) were getting cut off in hints, making it scrollable
+    */
+    overflow-x: auto;
+
+
   }
 
   p:last-of-type {


### PR DESCRIPTION
Bug: Exceptionally long formulas would get truncated in the display.

I went through a ton of examples and found a few more than reported. Unfortunately, there wasn't a single global fix for this one, so there may be undiscovered combinations of formatting that still cause this to happen.



## Formulas in body:

Before:
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/18493af0-cc8c-4153-9160-5d2c5b14c033)

After:
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/264fd81e-dce9-4a2a-a20e-5a9417bf63d3)


## In the body of a group

Before:
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/ea5cf395-aad9-4e41-9038-c7b2745f3005)

After:
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/7905b8af-f856-4b10-a1bd-d294243460ba)


## Formulas in hints inside groups:

Before:
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/228faabf-ef0b-4a1c-badd-c2711381520c)


After:
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/45fb3399-402e-46a2-b46c-dcc34a639617)


## Formulas in MCQ options inside groups:

Before:
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/0fbec52f-718f-48c7-8241-cc6d6eb8fa98)

After:
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/2a3c7551-c975-4888-be66-beb4daaedd4b)


## In Feedback

Before:
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/acc0ce8f-d5b0-4688-b926-2b65db1a9998)

After:
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/c94ea565-c513-4683-a262-dfc1d171acb0)

## In Explanations

Before:
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/6d0ed134-3943-4c69-a338-2b626fada4dc)


After:
![image](https://github.com/Simon-Initiative/oli-torus/assets/333265/b7201c84-ff05-494f-ae80-afc3c9abb5b3)
