### PR TITLE
[MER-3014] Video settings button

### DIFF
--- a/assets/src/components/activities/AuthoringElementProvider.tsx
+++ b/assets/src/components/activities/AuthoringElementProvider.tsx
@@ -2,9 +2,9 @@ import React, { useContext, useRef } from 'react';
 import produce from 'immer';
 import { Maybe } from 'tsmonad';
 import { ErrorBoundary } from 'components/common/ErrorBoundary';
+import { ModalDisplay } from 'components/modal/ModalDisplay';
 import { AuthoringElementProps } from './AuthoringElement';
 import { ActivityModelSchema, MediaItemRequest, PostUndoable } from './types';
-import { ModalDisplay } from 'components/modal/ModalDisplay';
 
 export interface AuthoringElementState<T> {
   projectSlug: string;

--- a/assets/src/components/activities/AuthoringElementProvider.tsx
+++ b/assets/src/components/activities/AuthoringElementProvider.tsx
@@ -4,6 +4,7 @@ import { Maybe } from 'tsmonad';
 import { ErrorBoundary } from 'components/common/ErrorBoundary';
 import { AuthoringElementProps } from './AuthoringElement';
 import { ActivityModelSchema, MediaItemRequest, PostUndoable } from './types';
+import { ModalDisplay } from 'components/modal/ModalDisplay';
 
 export interface AuthoringElementState<T> {
   projectSlug: string;
@@ -53,6 +54,7 @@ export const AuthoringElementProvider: React.FC<AuthoringElementProps<ActivityMo
     <AuthoringElementContext.Provider
       value={{ projectSlug, editMode, dispatch, model, onRequestMedia, authoringContext }}
     >
+      <ModalDisplay />
       <ErrorBoundary>{children}</ErrorBoundary>
     </AuthoringElementContext.Provider>
   );


### PR DESCRIPTION
Bug: 

1. Insert a video inside an activity (such as MCQ stem)
2. Click the video settings button

Expected: Settings window appears
Actual: Nothing happens

This was caused by the activity introducing a redux-container that did not have the modal logic built in.