### PR TITLE
[NG23-95] user can see chat icons to create browse discussions

### DIFF
--- a/assets/src/components/ContentTable.tsx
+++ b/assets/src/components/ContentTable.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
+import { PointMarkerContext, maybePointMarkerAttr } from 'data/content/utils';
 import { classNames } from 'utils/classNames';
 import * as ContentTypes from '../data/content/model/elements/types';
 
 export const ContentTable: React.FC<{
   model: ContentTypes.Table;
   children: React.ReactNode;
-}> = ({ model, children }) => {
+  pointMarkerContext?: PointMarkerContext;
+}> = ({ model, children, pointMarkerContext }) => {
   return (
     <table
       className={classNames(
@@ -13,6 +15,7 @@ export const ContentTable: React.FC<{
         model.border === 'hidden' ? 'table-borderless' : 'table-bordered',
         model.rowstyle === 'alternating' && 'table-striped',
       )}
+      {...maybePointMarkerAttr(model, pointMarkerContext)}
     >
       {children}
     </table>

--- a/assets/src/components/Dialog.tsx
+++ b/assets/src/components/Dialog.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import * as ContentModel from 'data/content/model/elements/types';
+import { PointMarkerContext, maybePointMarkerAttr } from 'data/content/utils';
 import { WriterContext } from '../data/content/writers/context';
 import { HtmlContentModelRenderer } from '../data/content/writers/renderer';
 
@@ -42,9 +43,10 @@ const DialogLine: React.FC<{
 export const Dialog: React.FC<{
   dialog: ContentModel.Dialog;
   context: WriterContext;
-}> = ({ dialog, context }) => {
+  pointMarkerContext?: PointMarkerContext;
+}> = ({ dialog, context, pointMarkerContext }) => {
   return (
-    <div className="dialog">
+    <div className="dialog" {...maybePointMarkerAttr(dialog, pointMarkerContext)}>
       {dialog.title && <h1>{dialog.title}</h1>}
       {dialog.lines.map((line, index) => (
         <DialogLine key={index} context={context} speakers={dialog.speakers} line={line} />

--- a/assets/src/components/activities/DeliveryElement.ts
+++ b/assets/src/components/activities/DeliveryElement.ts
@@ -62,7 +62,7 @@ export interface ActivityContext {
   showFeedback: boolean | null;
   resourceId?: number;
   renderPointMarkers: boolean;
-  isBlockLevel: boolean;
+  isAnnotationLevel: boolean;
 }
 
 /**

--- a/assets/src/components/activities/DeliveryElement.ts
+++ b/assets/src/components/activities/DeliveryElement.ts
@@ -61,6 +61,8 @@ export interface ActivityContext {
   pageState?: any;
   showFeedback: boolean | null;
   resourceId?: number;
+  renderPointMarkers: boolean;
+  isBlockLevel: boolean;
 }
 
 /**

--- a/assets/src/components/activities/DeliveryElementProvider.tsx
+++ b/assets/src/components/activities/DeliveryElementProvider.tsx
@@ -35,6 +35,8 @@ export const DeliveryElementProvider: React.FC<DeliveryElementProps<any>> = (pro
     bibParams: props.context.bibParams,
     learningLanguage: props.context.learningLanguage,
     resourceAttemptGuid: props.context.pageAttemptGuid,
+    renderPointMarkers: props.context.renderPointMarkers,
+    isBlockLevel: props.context.isBlockLevel,
   });
 
   return (

--- a/assets/src/components/activities/DeliveryElementProvider.tsx
+++ b/assets/src/components/activities/DeliveryElementProvider.tsx
@@ -36,7 +36,7 @@ export const DeliveryElementProvider: React.FC<DeliveryElementProps<any>> = (pro
     learningLanguage: props.context.learningLanguage,
     resourceAttemptGuid: props.context.pageAttemptGuid,
     renderPointMarkers: props.context.renderPointMarkers,
-    isBlockLevel: props.context.isBlockLevel,
+    isAnnotationLevel: props.context.isAnnotationLevel,
   });
 
   return (

--- a/assets/src/components/activities/directed-discussion/discussion/MockDiscussionDeliveryProvider.tsx
+++ b/assets/src/components/activities/directed-discussion/discussion/MockDiscussionDeliveryProvider.tsx
@@ -43,6 +43,8 @@ export const MockDiscussionDeliveryProvider: React.FC<{
         surveyId: '',
         groupId: '',
         showFeedback: false,
+        renderPointMarkers: false,
+        isAnnotationLevel: false,
       }}
       onSaveActivity={nullHandler}
       onSavePart={nullHandler}

--- a/assets/src/components/common/Conjugation.tsx
+++ b/assets/src/components/common/Conjugation.tsx
@@ -1,14 +1,20 @@
 import React, { MouseEventHandler, ReactNode } from 'react';
 import * as ContentModel from 'data/content/model/elements/types';
+import { PointMarkerContext, maybePointMarkerAttr } from 'data/content/utils';
 
 export const Conjugation: React.FC<{
   conjugation: ContentModel.Conjugation;
   pronunciation: ReactNode;
   table: ReactNode;
+  pointMarkerContext?: PointMarkerContext;
   onClick?: MouseEventHandler<HTMLDivElement>;
-}> = ({ conjugation, pronunciation, table, onClick }) => {
+}> = ({ conjugation, pronunciation, table, pointMarkerContext, onClick }) => {
   return (
-    <div className="conjugation" onClick={onClick}>
+    <div
+      className="conjugation"
+      onClick={onClick}
+      {...maybePointMarkerAttr(conjugation, pointMarkerContext)}
+    >
       <div className="title">{conjugation.title}</div>
       <div className="term">
         {conjugation.verb} {pronunciation}

--- a/assets/src/components/common/ECLRepl.tsx
+++ b/assets/src/components/common/ECLRepl.tsx
@@ -1,6 +1,8 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import debounce from 'lodash/debounce';
 import { WrappedMonaco } from 'components/activities/common/variables/WrappedMonaco';
+import * as ContentModel from 'data/content/model/elements/types';
+import { PointMarkerContext, maybePointMarkerAttr } from 'data/content/utils';
 import { ServerError, makeRequest } from 'data/persistence/common';
 import * as Extrinsic from 'data/persistence/extrinsic';
 
@@ -10,6 +12,7 @@ interface Props {
   slug: string;
   attemptGuid: string;
   children?: React.ReactNode;
+  pointMarkerContext?: PointMarkerContext;
 }
 
 export type EvalResult = Evaluation | ServerError;
@@ -108,7 +111,9 @@ export const ECLRepl: React.FC<Props> = (props) => {
     ) : null;
 
   return (
-    <div>
+    <div
+      {...maybePointMarkerAttr({ id: props.id } as ContentModel.ECLRepl, props.pointMarkerContext)}
+    >
       {maybeShowEditor}
       <div className="mt-2 mb-2 d-flex flex-row-reverse">
         <button className="btn btn-sm btn-secondary" onClick={onReset}>

--- a/assets/src/components/common/Formula.tsx
+++ b/assets/src/components/common/Formula.tsx
@@ -2,16 +2,18 @@ import React from 'react';
 import { MathJaxLatexFormula, MathJaxMathMLFormula } from './MathJaxFormula';
 
 export const Formula: React.FC<{
+  id: string;
   type?: string;
   subtype: string;
   src: string;
   onClick?: () => void;
   style?: Record<string, string>;
-}> = ({ type, subtype, src, style, onClick }) => {
+}> = ({ id, type, subtype, src, style, onClick }) => {
   switch (subtype) {
     case 'latex':
       return (
         <MathJaxLatexFormula
+          id={id}
           onClick={onClick}
           style={style}
           inline={type === 'formula_inline'}
@@ -21,6 +23,7 @@ export const Formula: React.FC<{
     case 'mathml':
       return (
         <MathJaxMathMLFormula
+          id={id}
           onClick={onClick}
           style={style}
           inline={type === 'formula_inline'}

--- a/assets/src/components/common/MathJaxFormula.tsx
+++ b/assets/src/components/common/MathJaxFormula.tsx
@@ -99,17 +99,25 @@ const fixNL = (s: string) =>
     : s;
 
 export const MathJaxLatexFormula: React.FC<MathJaxFormulaProps> = ({
+  id,
   src,
   inline,
   style,
   onClick,
+  pointMarkerContext,
 }) => {
   const ref = useMathJax(src);
   const fixed = fixNL(src);
   const wrapped = inline ? `\\(${fixed}\\)` : `\\[${fixed}\\]`;
 
   return (
-    <span onClick={onClick} style={style} className={cssClass(inline)} ref={ref}>
+    <span
+      onClick={onClick}
+      style={style}
+      className={cssClass(inline)}
+      ref={ref}
+      {...maybePointMarkerAttr({ id: id } as ContentModel.FormulaBlock, pointMarkerContext)}
+    >
       {wrapped}
     </span>
   );

--- a/assets/src/components/common/MathJaxFormula.tsx
+++ b/assets/src/components/common/MathJaxFormula.tsx
@@ -1,4 +1,6 @@
 import React, { useCallback } from 'react';
+import * as ContentModel from 'data/content/model/elements/types';
+import { PointMarkerContext, maybePointMarkerAttr } from 'data/content/utils';
 import { sanitizeMathML } from '../../utils/mathmlSanitizer';
 
 /**
@@ -58,16 +60,20 @@ const useMathJax = (src: string) => {
 };
 
 interface MathJaxFormulaProps {
+  id: string;
   src: string;
   inline: boolean;
   style?: Record<string, string>;
+  pointMarkerContext?: PointMarkerContext;
   onClick?: () => void;
 }
 
 export const MathJaxMathMLFormula: React.FC<MathJaxFormulaProps> = ({
+  id,
   src,
   inline,
   style,
+  pointMarkerContext,
   onClick,
 }) => {
   const ref = useMathJax(src);
@@ -78,6 +84,7 @@ export const MathJaxMathMLFormula: React.FC<MathJaxFormulaProps> = ({
       className={cssClass(inline)}
       ref={ref}
       dangerouslySetInnerHTML={{ __html: sanitizeMathML(src) }}
+      {...maybePointMarkerAttr({ id: id } as ContentModel.FormulaBlock, pointMarkerContext)}
     />
   );
 };

--- a/assets/src/components/editing/elements/formula/FormulaEditor.tsx
+++ b/assets/src/components/editing/elements/formula/FormulaEditor.tsx
@@ -42,6 +42,7 @@ export const FormulaEditor = (props: Props) => {
       {props.children}
 
       <Formula
+        id={props.model.id}
         onClick={onFormulaClick}
         style={{ cursor: 'pointer' }}
         type={props.model.legacyBlockRendered ? 'formula' : props.model.type}

--- a/assets/src/components/editing/elements/formula/FormulaModal.tsx
+++ b/assets/src/components/editing/elements/formula/FormulaModal.tsx
@@ -62,7 +62,7 @@ export const FormulaModal = ({ onDone, onCancel, model }: ModalProps) => {
           </div>
           <div className="preview">
             <h4>Preview</h4>
-            <Formula src={src} subtype={subtype} />
+            <Formula id={model.id} src={src} subtype={subtype} />
           </div>
         </div>
       </div>

--- a/assets/src/components/video_player/VideoPlayer.tsx
+++ b/assets/src/components/video_player/VideoPlayer.tsx
@@ -10,6 +10,7 @@ import {
   ProgressControl,
   TimeDivider,
 } from 'video-react';
+import { PointMarkerContext, maybePointMarkerAttr } from 'data/content/utils';
 import * as ContentModel from '../../data/content/model/elements/types';
 import { useCommandTarget } from '../editing/elements/command_button/useCommandTarget';
 import { ClosedCaptionButton } from './ClosedCaptionButton';
@@ -52,92 +53,96 @@ interface VideoInterface {
   seek: (time: number) => void;
 }
 
-export const VideoPlayer: React.FC<{ video: ContentModel.Video; children?: ReactNode }> =
-  React.memo(({ video, children }) => {
-    const playerRef = useRef(null);
-    const pauseAtPosition = useRef(-1);
-    const sizeAttributes = isValidSize(video)
-      ? { width: video.width, height: video.height, fluid: false }
-      : { fluid: true };
+export const VideoPlayer: React.FC<{
+  video: ContentModel.Video;
+  pointMarkerContext?: PointMarkerContext;
+  children?: ReactNode;
+}> = React.memo(({ video, pointMarkerContext, children }) => {
+  const playerRef = useRef(null);
+  const pauseAtPosition = useRef(-1);
+  const sizeAttributes = isValidSize(video)
+    ? { width: video.width, height: video.height, fluid: false }
+    : { fluid: true };
 
-    const hasCaptions = video.captions && video.captions.length > 0;
+  const hasCaptions = video.captions && video.captions.length > 0;
 
-    const onPlayer = useCallback((player) => {
-      playerRef.current = player;
+  const onPlayer = useCallback((player) => {
+    playerRef.current = player;
 
-      if (!player) {
-        return;
+    if (!player) {
+      return;
+    }
+    // This handles stopping at the correct point if a cue-point command previously came in with an end-timestamp set.
+    player.subscribeToStateChange((state: PlayerState) => {
+      if (
+        pauseAtPosition.current > 0 &&
+        state.hasStarted &&
+        state.currentTime >= pauseAtPosition.current
+      ) {
+        pauseAtPosition.current = -1;
+        player.pause();
       }
-      // This handles stopping at the correct point if a cue-point command previously came in with an end-timestamp set.
-      player.subscribeToStateChange((state: PlayerState) => {
-        if (
-          pauseAtPosition.current > 0 &&
-          state.hasStarted &&
-          state.currentTime >= pauseAtPosition.current
-        ) {
-          pauseAtPosition.current = -1;
-          player.pause();
-        }
-      });
-    }, []);
+    });
+  }, []);
 
-    const preventDefault = useCallback((e) => {
-      e.preventDefault(); // fixes https://eliterate.atlassian.net/browse/MER-1503
-    }, []);
+  const preventDefault = useCallback((e) => {
+    e.preventDefault(); // fixes https://eliterate.atlassian.net/browse/MER-1503
+  }, []);
 
-    const onCommandReceived = useCallback((message: string) => {
-      if (!playerRef.current) return;
-      const player = playerRef.current as VideoInterface;
-      const { start, end } = parseVideoPlayCommand(message);
-      pauseAtPosition.current = end;
-      if (start >= 0) {
-        player.seek(start);
-        player.play();
-      }
-    }, []);
+  const onCommandReceived = useCallback((message: string) => {
+    if (!playerRef.current) return;
+    const player = playerRef.current as VideoInterface;
+    const { start, end } = parseVideoPlayCommand(message);
+    pauseAtPosition.current = end;
+    if (start >= 0) {
+      player.seek(start);
+      player.play();
+    }
+  }, []);
 
-    useCommandTarget(video.id, onCommandReceived);
+  useCommandTarget(video.id, onCommandReceived);
 
-    return (
-      <div
-        className="video-player"
-        aria-role="img"
-        aria-roledescription="Video Player"
-        aria-aria-label={video.alt}
-        onClick={preventDefault}
-      >
-        <Player poster={video.poster} {...sizeAttributes} ref={onPlayer} crossOrigin="anonymous">
-          {/* Hide the video-react big play button so we can render our own that fits with our icon styles */}
-          <BigPlayButton className="big-play-button-hide" />
-          <InitialPlayButton />
+  return (
+    <div
+      className="video-player"
+      aria-role="img"
+      aria-roledescription="Video Player"
+      aria-aria-label={video.alt}
+      onClick={preventDefault}
+      {...maybePointMarkerAttr(video, pointMarkerContext)}
+    >
+      <Player poster={video.poster} {...sizeAttributes} ref={onPlayer} crossOrigin="anonymous">
+        {/* Hide the video-react big play button so we can render our own that fits with our icon styles */}
+        <BigPlayButton className="big-play-button-hide" />
+        <InitialPlayButton />
 
-          {video.src.map((src) => (
-            <source key={src.url} src={src.url} type={src.contenttype} />
-          ))}
-          {video.captions?.map((caption, idx) => (
-            <track
-              key={idx}
-              src={caption.src}
-              kind="captions"
-              label={caption.label}
-              srcLang={caption.language_code}
-            />
-          ))}
-          <ControlBar disableDefaultControls={true} autoHide={true} className="control-bar">
-            <PlayButton key="play-toggle" order={1} />
-            <MuteButton key="volume-menu-button" order={4} />
-            <CurrentTimeDisplay key="current-time-display" order={5.1} />
-            <TimeDivider key="time-divider" order={5.2} />
-            <DurationDisplay key="duration-display" order={5.3} />
-            <ProgressControl key="progress-control" order={6} />
-            <PlaybackRateMenuButton key="playback-spoeed" order={8} />
-            <FullScreenButton key="fullscreen-toggle" order={9} />
-            {hasCaptions && <ClosedCaptionButton order={10} />}
-          </ControlBar>
-        </Player>
-        {children}
-      </div>
-    );
-  });
+        {video.src.map((src) => (
+          <source key={src.url} src={src.url} type={src.contenttype} />
+        ))}
+        {video.captions?.map((caption, idx) => (
+          <track
+            key={idx}
+            src={caption.src}
+            kind="captions"
+            label={caption.label}
+            srcLang={caption.language_code}
+          />
+        ))}
+        <ControlBar disableDefaultControls={true} autoHide={true} className="control-bar">
+          <PlayButton key="play-toggle" order={1} />
+          <MuteButton key="volume-menu-button" order={4} />
+          <CurrentTimeDisplay key="current-time-display" order={5.1} />
+          <TimeDivider key="time-divider" order={5.2} />
+          <DurationDisplay key="duration-display" order={5.3} />
+          <ProgressControl key="progress-control" order={6} />
+          <PlaybackRateMenuButton key="playback-spoeed" order={8} />
+          <FullScreenButton key="fullscreen-toggle" order={9} />
+          {hasCaptions && <ClosedCaptionButton order={10} />}
+        </ControlBar>
+      </Player>
+      {children}
+    </div>
+  );
+});
 
 VideoPlayer.displayName = 'VideoPlayer';

--- a/assets/src/components/youtube_player/YoutubePlayer.tsx
+++ b/assets/src/components/youtube_player/YoutubePlayer.tsx
@@ -5,6 +5,7 @@ import { useCommandTarget } from 'components/editing/elements/command_button/use
 import { CUTE_OTTERS } from 'components/editing/elements/youtube/YoutubeElement';
 import { parseVideoPlayCommand } from 'components/video_player/VideoPlayer';
 import * as ContentModel from 'data/content/model/elements/types';
+import { PointMarkerContext, maybePointMarkerAttr } from 'data/content/utils';
 import { WriterContext, defaultWriterContext } from 'data/content/writers/context';
 import { HtmlContentModelRenderer } from 'data/content/writers/renderer';
 
@@ -21,7 +22,8 @@ export const YoutubePlayer: React.FC<{
   children?: React.ReactNode;
   context?: WriterContext;
   authorMode: boolean;
-}> = ({ video, children, authorMode, context }) => {
+  pointMarkerContext?: PointMarkerContext;
+}> = ({ video, children, authorMode, context, pointMarkerContext }) => {
   const stopInterval = useRef<number | undefined>();
   const [videoTarget, setVideoTarget] = useState<Player | null>(null);
   const pauseAtPosition = useRef(video.endTime || -1);
@@ -116,7 +118,11 @@ export const YoutubePlayer: React.FC<{
 
   return (
     <ErrorBoundary errorMessage={<YoutubeError videoId={videoId} />}>
-      <div className="embed-responsive embed-responsive-16by9" data-video-id={videoId}>
+      <div
+        className="embed-responsive embed-responsive-16by9"
+        data-video-id={videoId}
+        {...maybePointMarkerAttr(video, pointMarkerContext)}
+      >
         <YouTube
           className="embed-responsive-item"
           videoId={videoId}

--- a/assets/src/data/content/utils.tsx
+++ b/assets/src/data/content/utils.tsx
@@ -188,23 +188,32 @@ export const isEmptyContent = (content: (AllModelElements | Text)[]): boolean =>
 
 export interface PointMarkerContext {
   renderPointMarkers: boolean;
-  isTopLevelBlock: boolean;
+  isAnnotationLevel: boolean;
 }
 
-export function maybePointMarkerAttr(x: ModelElement, context?: PointMarkerContext) {
-  if (!context || !context.renderPointMarkers || !context.isTopLevelBlock) {
+export function maybePointMarkerAttr(el: ModelElement, context?: PointMarkerContext) {
+  if (
+    !context ||
+    !context.renderPointMarkers ||
+    !context.isAnnotationLevel ||
+    isEmptyParagraph(el)
+  ) {
     return {};
   }
 
-  if (x['id'] === undefined) {
+  if (el['id'] === undefined) {
     console.warn(
       'Content element missing id attribute which is required for point marker. Point marker will not be rendered.',
-      x,
+      el,
     );
     return {};
   }
 
   return {
-    ['data-point-marker']: x.id,
+    ['data-point-marker']: el.id,
   };
+}
+
+function isEmptyParagraph(el: ModelElement) {
+  return el.type === 'p' && el.children.every((c) => Text.isText(c) && c.text.trim() === '');
 }

--- a/assets/src/data/content/utils.tsx
+++ b/assets/src/data/content/utils.tsx
@@ -185,3 +185,26 @@ export const isEmptyContent = (content: (AllModelElements | Text)[]): boolean =>
       ('type' in c && !shouldIgnore(c.type)), // Any other non-paragraph/header element is considered not empty
   );
 };
+
+export interface PointMarkerContext {
+  renderPointMarkers: boolean;
+  isTopLevelBlock: boolean;
+}
+
+export function maybePointMarkerAttr(x: ModelElement, context?: PointMarkerContext) {
+  if (!context || !context.renderPointMarkers || !context.isTopLevelBlock) {
+    return {};
+  }
+
+  if (x['id'] === undefined) {
+    console.warn(
+      'Content element missing id attribute which is required for point marker. Point marker will not be rendered.',
+      x,
+    );
+    return {};
+  }
+
+  return {
+    ['data-point-marker']: x.id,
+  };
+}

--- a/assets/src/data/content/writers/context.ts
+++ b/assets/src/data/content/writers/context.ts
@@ -26,9 +26,9 @@ export interface WriterContext {
     >;
     disabled: boolean;
   };
-  renderPointMarkers: boolean;
-  isAnnotationLevel: boolean;
+  renderPointMarkers?: boolean;
+  isAnnotationLevel?: boolean;
 }
 
 export const defaultWriterContext = (params: Partial<WriterContext> = {}): WriterContext =>
-  Object.assign({ renderPointMarkers: true, isAnnotationLevel: false }, params);
+  Object.assign({}, params);

--- a/assets/src/data/content/writers/context.ts
+++ b/assets/src/data/content/writers/context.ts
@@ -26,6 +26,8 @@ export interface WriterContext {
     >;
     disabled: boolean;
   };
+  renderPointMarkers?: boolean;
+  isBlockLevel?: boolean;
 }
 
 export const defaultWriterContext = (params: Partial<WriterContext> = {}): WriterContext =>

--- a/assets/src/data/content/writers/context.ts
+++ b/assets/src/data/content/writers/context.ts
@@ -26,9 +26,9 @@ export interface WriterContext {
     >;
     disabled: boolean;
   };
-  renderPointMarkers?: boolean;
-  isBlockLevel?: boolean;
+  renderPointMarkers: boolean;
+  isAnnotationLevel: boolean;
 }
 
 export const defaultWriterContext = (params: Partial<WriterContext> = {}): WriterContext =>
-  Object.assign({}, params);
+  Object.assign({ renderPointMarkers: true, isAnnotationLevel: false }, params);

--- a/assets/src/data/content/writers/html.tsx
+++ b/assets/src/data/content/writers/html.tsx
@@ -656,7 +656,7 @@ export class HtmlParser implements WriterImpl {
 
 function pointMarkerContextFrom(context: WriterContext, x: ModelElement): PointMarkerContext {
   return {
-    renderPointMarkers: context.renderPointMarkers,
-    isAnnotationLevel: context.isAnnotationLevel,
+    renderPointMarkers: !!context.renderPointMarkers,
+    isAnnotationLevel: !!context.isAnnotationLevel,
   };
 }

--- a/assets/src/data/content/writers/html.tsx
+++ b/assets/src/data/content/writers/html.tsx
@@ -120,7 +120,11 @@ export class HtmlParser implements WriterImpl {
       attrs.caption &&
       (typeof attrs.caption === 'string'
         ? this.escapeXml(attrs.caption)
-        : new ContentWriter().render(context, attrs.caption, new HtmlParser()));
+        : new ContentWriter().render(
+            { ...context, isBlockLevel: false },
+            attrs.caption,
+            new HtmlParser(),
+          ));
 
     const width = attrs.width ? { width: this.escapeXml(String(attrs.width)) + 'px' } : {};
 
@@ -134,8 +138,8 @@ export class HtmlParser implements WriterImpl {
     );
   }
 
-  p(context: WriterContext, next: Next, _x: Paragraph) {
-    return <p>{next()}</p>;
+  p(context: WriterContext, next: Next, x: Paragraph) {
+    return <p {...maybe_point_marker_attr(context, x)}>{next()}</p>;
   }
   h1(context: WriterContext, next: Next, _x: HeadingOne) {
     return <h1>{next()}</h1>;
@@ -281,6 +285,7 @@ export class HtmlParser implements WriterImpl {
         alt={attrs.alt ? this.escapeXml(attrs.alt) : ''}
         width={attrs.width ? this.escapeXml(String(attrs.width)) : undefined}
         src={this.escapeXml(attrs.src)}
+        {...maybe_point_marker_attr(context, attrs)}
       />,
     );
   }
@@ -361,7 +366,11 @@ export class HtmlParser implements WriterImpl {
       attrs.caption &&
       (typeof attrs.caption === 'string'
         ? this.escapeXml(attrs.caption)
-        : new ContentWriter().render(context, attrs.caption, new HtmlParser()));
+        : new ContentWriter().render(
+            { ...context, isBlockLevel: false },
+            attrs.caption,
+            new HtmlParser(),
+          ));
 
     return (
       <ContentTable model={attrs}>
@@ -574,4 +583,22 @@ export class HtmlParser implements WriterImpl {
     console.error('Content element ' + JSON.stringify(x) + ' is invalid and could not display.');
     return <div className="content invalid">Content element is invalid</div>;
   }
+}
+
+function maybe_point_marker_attr(context: WriterContext, x: ModelElement) {
+  if (!context.renderPointMarkers || !context.isBlockLevel) {
+    return {};
+  }
+
+  if (x['id'] === undefined) {
+    console.warn(
+      'Content element missing id attribute which is required for point marker. Point marker will not be rendered.',
+      x,
+    );
+    return {};
+  }
+
+  return {
+    ['data-point-marker']: x.id,
+  };
 }

--- a/assets/src/data/content/writers/renderer.tsx
+++ b/assets/src/data/content/writers/renderer.tsx
@@ -17,9 +17,10 @@ export const HtmlContentModelRenderer: React.FC<Props> = (props) => {
   const content = (props.content as any).model ? (props.content as any).model : props.content;
   const className = props.inline ? 'inline' : '';
 
-  const dispatchPageContentChange = useCallback(() => {
-    Events.dispatch(Events.Registry.PageContentChange, Events.makePageContentChangeEvent({}));
-  }, []);
+  const dispatchPageContentChange = useCallback(
+    () => Events.dispatch(Events.Registry.PageContentChange, Events.makePageContentChangeEvent({})),
+    [],
+  );
 
   // notify when page content has changed
   useEffect(() => {
@@ -31,6 +32,7 @@ export const HtmlContentModelRenderer: React.FC<Props> = (props) => {
   }, [content]);
 
   const rendered = new ContentWriter().render(props.context, content, new HtmlParser());
+
   return (
     <div dir={props.direction} className={className}>
       {rendered}

--- a/assets/src/data/content/writers/renderer.tsx
+++ b/assets/src/data/content/writers/renderer.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { RichText } from 'components/activities/types';
+import * as Events from 'data/events';
 import { CaptionV2, Pronunciation, TextBlock, TextDirection } from '../model/elements/types';
 import { WriterContext } from './context';
 import { HtmlParser } from './html';
@@ -15,6 +16,19 @@ export const HtmlContentModelRenderer: React.FC<Props> = (props) => {
   // Support content persisted when RichText had a `model` property.
   const content = (props.content as any).model ? (props.content as any).model : props.content;
   const className = props.inline ? 'inline' : '';
+
+  const dispatchPageContentChange = useCallback(() => {
+    Events.dispatch(Events.Registry.PageContentChange, Events.makePageContentChangeEvent({}));
+  }, []);
+
+  // notify when page content has changed
+  useEffect(() => {
+    dispatchPageContentChange();
+
+    return () => {
+      dispatchPageContentChange();
+    };
+  }, [content]);
 
   const rendered = new ContentWriter().render(props.context, content, new HtmlParser());
   return (

--- a/assets/src/data/content/writers/writer.tsx
+++ b/assets/src/data/content/writers/writer.tsx
@@ -119,7 +119,7 @@ export class ContentWriter {
 
     const next = () =>
       this.render(
-        { ...context, isBlockLevel: false },
+        { ...context, isAnnotationLevel: false },
         content.children as AllModelElements[],
         impl,
       );

--- a/assets/src/data/content/writers/writer.tsx
+++ b/assets/src/data/content/writers/writer.tsx
@@ -117,7 +117,12 @@ export class ContentWriter {
       return impl.text(context, content);
     }
 
-    const next = () => this.render(context, content.children as AllModelElements[], impl);
+    const next = () =>
+      this.render(
+        { ...context, isBlockLevel: false },
+        content.children as AllModelElements[],
+        impl,
+      );
 
     switch (content.type) {
       case 'p':

--- a/assets/src/data/events.ts
+++ b/assets/src/data/events.ts
@@ -34,6 +34,8 @@ export interface AlternativesPreferenceSelection {
   value: string;
 }
 
+export interface PageContentChange {}
+
 export interface TorusEventMap {
   'oli-survey-submit': CustomEvent<SurveyDetails>;
   'oli-survey-reset': CustomEvent<SurveyDetails>;
@@ -42,6 +44,7 @@ export interface TorusEventMap {
   'oli-command-button-click': CustomEvent<CommandButtonClick>;
   'oli-command-inventory': CustomEvent<CommandInventory>;
   'oli-alternatives-preference-selection': CustomEvent<AlternativesPreferenceSelection>;
+  'oli-page-content-change': CustomEvent<PageContentChange>;
 }
 
 export enum Registry {
@@ -52,6 +55,7 @@ export enum Registry {
   CommandButtonClick = 'oli-command-button-click',
   CommandInventory = 'oli-command-inventory',
   AlternativesPreferenceSelection = 'oli-alternatives-preference-selection',
+  PageContentChange = 'oli-page-content-change',
 }
 
 export function makeCommandInventoryEvent(detail: CommandInventory) {
@@ -80,6 +84,10 @@ export function makeReviewModeAttemptChange(detail: ReviewModeAttemptChange) {
 
 export function makeAlternativesPreferenceSelectionEvent(detail: AlternativesPreferenceSelection) {
   return new CustomEvent(Registry.AlternativesPreferenceSelection, { detail });
+}
+
+export function makePageContentChangeEvent(detail: PageContentChange) {
+  return new CustomEvent(Registry.PageContentChange, { detail });
 }
 
 declare global {

--- a/assets/src/hooks/index.ts
+++ b/assets/src/hooks/index.ts
@@ -16,6 +16,7 @@ import { LoadSurveyScripts } from './load_survey_scripts';
 import { LtiConnectInstructions } from './lti_connect_instructions';
 import { ModalLaunch } from './modal';
 import { MonacoEditor } from './monaco_editor';
+import { PointMarkers } from './point_markers';
 import { ProjectsTypeahead } from './projects_typeahead';
 import { ResizeListener } from './resize_listener';
 import { ReviewActivity } from './review_activity';
@@ -64,4 +65,5 @@ export const Hooks = {
   KeepScrollAtBottom,
   SliderScroll,
   VideoPlayer,
+  PointMarkers,
 };

--- a/assets/src/hooks/point_markers.ts
+++ b/assets/src/hooks/point_markers.ts
@@ -1,27 +1,39 @@
+import { debounce } from 'lodash';
+import * as Events from 'data/events';
+
 export const PointMarkers = {
   mounted() {
     const el = this.el as HTMLElement;
 
-    this.pushEvent('update_point_markers', { ['point_markers']: get_point_markers(el) });
+    const UPDATE_DEBOUNCE_INTERVAL = 200;
+    const updatePointMarkers = debounce(() => {
+      this.pushEvent('update_point_markers', { ['point_markers']: queryPointMarkers(el) });
+    }, UPDATE_DEBOUNCE_INTERVAL);
 
-    // listen for end of resize events and update the marker positions accordingly
-    const RESIZE_UPDATE_INTERVAL = 200;
-    let resizeTimeout: any;
+    // update the marker positions immediately when the page is mounted
+    updatePointMarkers();
 
+    // listen for other page content changes and update the marker positions
+    document.addEventListener(
+      Events.Registry.PageContentChange,
+      (e: CustomEvent<Events.PageContentChange>) => {
+        updatePointMarkers();
+      },
+    );
+
+    // listen for end of resize events and update the marker positions
     window.addEventListener('resize', () => {
-      clearTimeout(resizeTimeout);
-      resizeTimeout = setTimeout(() => {
-        this.pushEvent('update_point_markers', { ['point_markers']: get_point_markers(el) });
-      }, RESIZE_UPDATE_INTERVAL);
+      updatePointMarkers();
     });
 
+    // listen for server request to update the marker positions
     this.handleEvent('request_point_markers', () => {
-      this.pushEvent('update_point_markers', { ['point_markers']: get_point_markers(el) });
+      updatePointMarkers();
     });
   },
 };
 
-function get_point_markers(el: HTMLElement) {
+function queryPointMarkers(el: HTMLElement) {
   const markerElements = el.querySelectorAll('[data-point-marker]');
 
   const OFFSET_TOP = 110;

--- a/assets/src/hooks/point_markers.ts
+++ b/assets/src/hooks/point_markers.ts
@@ -1,0 +1,29 @@
+export const PointMarkers = {
+  mounted() {
+    const el = this.el as HTMLElement;
+
+    this.pushEvent('update_point_markers', { ['point_markers']: get_point_markers(el) });
+
+    // listen for end of resize events and update the marker positions accordingly
+    const RESIZE_UPDATE_INTERVAL = 200;
+    let resizeTimeout: any;
+
+    window.addEventListener('resize', () => {
+      clearTimeout(resizeTimeout);
+      resizeTimeout = setTimeout(() => {
+        this.pushEvent('update_point_markers', { ['point_markers']: get_point_markers(el) });
+      }, RESIZE_UPDATE_INTERVAL);
+    });
+  },
+};
+
+function get_point_markers(el: HTMLElement) {
+  const markerElements = el.querySelectorAll('[data-point-marker]');
+
+  const OFFSET_TOP = 110;
+
+  return Array.from(markerElements).map((markerEl) => ({
+    id: markerEl.getAttribute('data-point-marker'),
+    top: markerEl.getBoundingClientRect().top - el.getBoundingClientRect().top + OFFSET_TOP,
+  }));
+}

--- a/assets/src/hooks/point_markers.ts
+++ b/assets/src/hooks/point_markers.ts
@@ -14,6 +14,10 @@ export const PointMarkers = {
         this.pushEvent('update_point_markers', { ['point_markers']: get_point_markers(el) });
       }, RESIZE_UPDATE_INTERVAL);
     });
+
+    this.handleEvent('request_point_markers', () => {
+      this.pushEvent('update_point_markers', { ['point_markers']: get_point_markers(el) });
+    });
   },
 };
 

--- a/assets/test/check_all_that_apply/cata_delivery_test.tsx
+++ b/assets/test/check_all_that_apply/cata_delivery_test.tsx
@@ -30,6 +30,8 @@ describe('check all that apply delivery', () => {
         projectSlug: '',
         bibParams: [],
         showFeedback: true,
+        renderPointMarkers: false,
+        isAnnotationLevel: false,
       },
       preview: false,
     };

--- a/assets/test/formula/mathjaxformula_test.tsx
+++ b/assets/test/formula/mathjaxformula_test.tsx
@@ -26,6 +26,7 @@ describe('MathJaxFormula', () => {
     test('renders a mathml block expression', () => {
       const { container } = render(
         <MathJaxMathMLFormula
+          id="1"
           src="<math><mfrac><mi>x</mi><mi>y</mi></mfrac></math>"
           inline={false}
         />,
@@ -39,6 +40,7 @@ describe('MathJaxFormula', () => {
     test('renders a mathml inline expression', () => {
       const { container } = render(
         <MathJaxMathMLFormula
+          id="1"
           src="<math><mfrac><mi>x</mi><mi>y</mi></mfrac></math>"
           inline={true}
         />,
@@ -52,6 +54,7 @@ describe('MathJaxFormula', () => {
     test('does not expose an xss vulnerability', () => {
       const { container } = render(
         <MathJaxMathMLFormula
+          id="1"
           src="<math><script>alert('breaking the law');</script></math>"
           inline={true}
         />,
@@ -65,7 +68,9 @@ describe('MathJaxFormula', () => {
 
   describe('MathJaxLatexFormula', () => {
     test('renders a latex block expression', () => {
-      const { container } = render(<MathJaxLatexFormula src="x^2 + y^2 = z^2" inline={false} />);
+      const { container } = render(
+        <MathJaxLatexFormula id="1" src="x^2 + y^2 = z^2" inline={false} />,
+      );
 
       const e = container.querySelector('span');
       expect(e).toBeTruthy();
@@ -74,7 +79,9 @@ describe('MathJaxFormula', () => {
     });
 
     test('renders a latex inline expression', () => {
-      const { container } = render(<MathJaxLatexFormula src="x^2 + y^2 = z^2" inline={true} />);
+      const { container } = render(
+        <MathJaxLatexFormula id="1" src="x^2 + y^2 = z^2" inline={true} />,
+      );
 
       const e = container.querySelector('span');
       expect(e).toBeTruthy();
@@ -84,7 +91,11 @@ describe('MathJaxFormula', () => {
 
     test('does not expose an xss vulnerability', () => {
       const { container } = render(
-        <MathJaxLatexFormula src="<script>alert('Breaking the law');</script>" inline={true} />,
+        <MathJaxLatexFormula
+          id="1"
+          src="<script>alert('Breaking the law');</script>"
+          inline={true}
+        />,
       );
 
       const e = container.querySelector('span');

--- a/assets/test/multiple_choice/mc_delivery_test.tsx
+++ b/assets/test/multiple_choice/mc_delivery_test.tsx
@@ -31,6 +31,8 @@ describe('multiple choice delivery', () => {
         projectSlug: '',
         bibParams: [],
         showFeedback: true,
+        renderPointMarkers: false,
+        isAnnotationLevel: false,
       },
       graded: false,
       preview: false,

--- a/assets/test/ordering/ordering_delivery_test.tsx
+++ b/assets/test/ordering/ordering_delivery_test.tsx
@@ -30,6 +30,8 @@ describe('ordering delivery', () => {
         projectSlug: '',
         bibParams: [],
         showFeedback: true,
+        renderPointMarkers: false,
+        isAnnotationLevel: false,
       },
       preview: false,
     };

--- a/assets/test/short_answer/short_answer_delivery_test.tsx
+++ b/assets/test/short_answer/short_answer_delivery_test.tsx
@@ -30,6 +30,8 @@ describe('multiple choice delivery', () => {
         projectSlug: '',
         bibParams: [],
         showFeedback: true,
+        renderPointMarkers: false,
+        isAnnotationLevel: false,
       },
       preview: false,
     };

--- a/lib/oli/rendering/activity/html.ex
+++ b/lib/oli/rendering/activity/html.ex
@@ -150,7 +150,8 @@ defmodule Oli.Rendering.Activity.Html do
            group_id: group_id,
            survey_id: survey_id,
            learning_language: learning_language,
-           effective_settings: effective_settings
+           effective_settings: effective_settings,
+           render_opts: render_opts
          } = context,
          %ActivitySummary{
            state: state,
@@ -181,7 +182,9 @@ defmodule Oli.Rendering.Activity.Html do
             "{}"
           else
             resource_attempt.state
-          end
+          end,
+        renderPointMarkers: render_opts.render_point_markers,
+        isBlockLevel: true
       }
       |> Poison.encode!()
       |> HtmlEntities.encode()

--- a/lib/oli/rendering/activity/html.ex
+++ b/lib/oli/rendering/activity/html.ex
@@ -184,7 +184,7 @@ defmodule Oli.Rendering.Activity.Html do
             resource_attempt.state
           end,
         renderPointMarkers: render_opts.render_point_markers,
-        isBlockLevel: true
+        isAnnotationLevel: true
       }
       |> Poison.encode!()
       |> HtmlEntities.encode()

--- a/lib/oli/rendering/content.ex
+++ b/lib/oli/rendering/content.ex
@@ -276,11 +276,16 @@ defmodule Oli.Rendering.Content do
         %{"type" => type, "children" => children} = element,
         writer
       ) do
-    next = fn -> render(context, children, writer) end
+    next = fn -> render(%Context{context | is_block_level: false}, children, writer) end
 
     case type do
       "p" ->
-        writer.p(context, next, element)
+        # check if the paragraph is empty and if so, don't render it
+        if is_empty_paragraph?(element) do
+          []
+        else
+          writer.p(context, next, element)
+        end
 
       "h1" ->
         writer.h1(context, next, element)
@@ -425,4 +430,12 @@ defmodule Oli.Rendering.Content do
       []
     end
   end
+
+  defp is_empty_paragraph?(%{"type" => "p", "children" => children}) do
+    Enum.all?(children, fn child ->
+      child["text"] && String.trim(child["text"]) == ""
+    end)
+  end
+
+  defp is_empty_paragraph?(_), do: false
 end

--- a/lib/oli/rendering/content.ex
+++ b/lib/oli/rendering/content.ex
@@ -175,14 +175,14 @@ defmodule Oli.Rendering.Content do
     render_table = fn ->
       case element["table"] do
         nil -> []
-        table -> render(context, table, writer)
+        table -> render(%Context{context | is_block_level: false}, table, writer)
       end
     end
 
     render_pronunciation = fn ->
       case element["pronunciation"] do
         nil -> []
-        pronunciation -> render(context, pronunciation, writer)
+        pronunciation -> render(%Context{context | is_block_level: false}, pronunciation, writer)
       end
     end
 

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -59,7 +59,9 @@ defmodule Oli.Rendering.Content.Html do
       context,
       attrs,
       [
-        ~s|<img class="figure-img img-fluid"#{maybeAlt(attrs)}#{maybeWidth(attrs)} src="#{escape_xml!(src)}"/>\n|
+        ~s|<img class="figure-img img-fluid"#{maybeAlt(attrs)}#{maybeWidth(attrs)} src="#{escape_xml!(src)}"|,
+        maybe_point_marker_attr(context, attrs),
+        ~s| />\n|
       ],
       "image"
     )

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -560,10 +560,10 @@ defmodule Oli.Rendering.Content.Html do
        else: src
   end
 
-  def figure(%Context{} = _context, render_children, render_title, el) do
+  def figure(%Context{} = context, render_children, render_title, el) do
     [
       "<div class='figure'",
-      maybe_point_marker_attr(_context, el),
+      maybe_point_marker_attr(context, el),
       "><figure><figcaption>",
       render_title.(),
       "</figcaption><div class='figure-content'>",

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -59,7 +59,7 @@ defmodule Oli.Rendering.Content.Html do
       context,
       attrs,
       [
-        ~s|<img class="figure-img img-fluid"#{maybeAlt(attrs)}#{maybeWidth(attrs)} src="#{escape_xml!(src)}"|,
+        ~s|<img class="figure-img img-fluid"#{maybe_alt(attrs)}#{maybe_width(attrs)} src="#{escape_xml!(src)}"|,
         maybe_point_marker_attr(context, attrs),
         ~s| />\n|
       ],
@@ -71,7 +71,7 @@ defmodule Oli.Rendering.Content.Html do
 
   def img_inline(%Context{} = _context, _, %{"src" => src} = attrs) do
     [
-      ~s|<img class="img-fluid"#{maybeAlt(attrs)}#{maybeWidth(attrs)} src="#{escape_xml!(src)}"/>\n|
+      ~s|<img class="img-fluid"#{maybe_alt(attrs)}#{maybe_width(attrs)} src="#{escape_xml!(src)}"/>\n|
     ]
   end
 
@@ -79,7 +79,13 @@ defmodule Oli.Rendering.Content.Html do
 
   def video(%Context{} = context, _, attrs) do
     {:safe, video_player} =
-      OliWeb.Common.React.component(context, "Components.VideoPlayer", %{"video" => attrs})
+      OliWeb.Common.React.component(context, "Components.VideoPlayer", %{
+        "video" => attrs,
+        "pointMarkerContext" => %{
+          renderPointMarkers: context.render_opts.render_point_markers,
+          isTopLevelBlock: context.is_block_level
+        }
+      })
 
     video_player
   end
@@ -152,7 +158,7 @@ defmodule Oli.Rendering.Content.Html do
       """
       <div class="#{container_class}">
         <div class="embed-wrapper">
-          <iframe#{maybeAlt(attrs)} class="#{iframe_class}" #{dimensions} allowfullscreen src="#{escape_xml!(src)}"></iframe>
+          <iframe#{maybe_alt(attrs)} class="#{iframe_class}" #{dimensions} allowfullscreen src="#{escape_xml!(src)}"></iframe>
         </div>
       </div>
       """
@@ -799,7 +805,7 @@ defmodule Oli.Rendering.Content.Html do
 
   def example(%Context{} = _context, next, element) do
     [
-      ~s|<div class="content-purpose example"><div class="content-purpose-label">Example</div><div #{directionAttr(element)} class="content-purpose-content">|,
+      ~s|<div class="content-purpose example"><div class="content-purpose-label">Example</div><div #{direction_attr(element)} class="content-purpose-content">|,
       next.(),
       "</div></div>\n"
     ]
@@ -807,7 +813,7 @@ defmodule Oli.Rendering.Content.Html do
 
   def learn_more(%Context{} = _context, next, element) do
     [
-      ~s|<div class="content-purpose learnmore"><div class="content-purpose-label">Learn more</div><div #{directionAttr(element)} class="content-purpose-content">|,
+      ~s|<div class="content-purpose learnmore"><div class="content-purpose-label">Learn more</div><div #{direction_attr(element)} class="content-purpose-content">|,
       next.(),
       "</div></div>\n"
     ]
@@ -815,7 +821,7 @@ defmodule Oli.Rendering.Content.Html do
 
   def manystudentswonder(%Context{} = _context, next, element) do
     [
-      ~s|<div class="content-purpose manystudentswonder"><div class="content-purpose-label">Many Students Wonder</div><div #{directionAttr(element)} class="content-purpose-content">|,
+      ~s|<div class="content-purpose manystudentswonder"><div class="content-purpose-label">Many Students Wonder</div><div #{direction_attr(element)} class="content-purpose-content">|,
       next.(),
       "</div></div>\n"
     ]
@@ -823,13 +829,13 @@ defmodule Oli.Rendering.Content.Html do
 
   def content(%Context{} = _context, next, element) do
     [
-      ~s|<div class="content" #{directionAttr(element)}>|,
+      ~s|<div class="content" #{direction_attr(element)}>|,
       next.(),
       "</div>"
     ]
   end
 
-  defp directionAttr(element) do
+  defp direction_attr(element) do
     case Map.get(element, "textDirection", "ltr") do
       "ltr" -> ""
       "rtl" -> " dir=\"rtl\""
@@ -945,14 +951,14 @@ defmodule Oli.Rendering.Content.Html do
     end
   end
 
-  defp maybeAlt(attrs) do
+  defp maybe_alt(attrs) do
     case attrs do
       %{"alt" => alt} -> " alt=\"#{escape_xml!(alt)}\""
       _ -> ""
     end
   end
 
-  defp maybeWidth(attrs) do
+  defp maybe_width(attrs) do
     case attrs do
       %{"width" => width} -> " width=\"#{escape_xml!(width)}\""
       _ -> ""

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -1009,12 +1009,13 @@ defmodule Oli.Rendering.Content.Html do
     end
   end
 
-  defp maybe_point_marker_attr(%Context{is_annotation_level: true} = context, _attrs) do
-    if context.render_opts.render_point_markers,
-      do:
-        Logger.warning(
-          "Content element missing id attribute which is required for point marker. Point marker will not be rendered."
-        )
+  defp maybe_point_marker_attr(%Context{is_annotation_level: true} = context, attrs) do
+    if context.render_opts.render_point_markers do
+      Logger.warning(
+        "Content element missing id attribute which is required for point marker. Point marker will not be rendered.\n" <>
+          Jason.encode!(attrs)
+      )
+    end
 
     ""
   end

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -7,6 +7,8 @@ defmodule Oli.Rendering.Content.Html do
   import Oli.Utils
   import Oli.Rendering.Utils
 
+  require Logger
+
   alias Oli.Rendering.Context
   alias Phoenix.HTML
   alias Oli.Rendering.Content.MathMLSanitizer
@@ -24,8 +26,8 @@ defmodule Oli.Rendering.Content.Html do
     ["<span class=\"callout-inline\">", next.(), "</span>\n"]
   end
 
-  def p(%Context{} = _context, next, _) do
-    ["<p>", next.(), "</p>\n"]
+  def p(%Context{} = context, next, attrs) do
+    ["<p", maybe_point_marker_attr(context, attrs), ">", next.(), "</p>\n"]
   end
 
   def h1(%Context{} = _context, next, _) do
@@ -954,4 +956,24 @@ defmodule Oli.Rendering.Content.Html do
       _ -> ""
     end
   end
+
+  defp maybe_point_marker_attr(%Context{is_block_level: true} = context, %{"id" => id}) do
+    if context.render_opts.render_point_markers do
+      " data-point-marker=\"#{id}\""
+    else
+      ""
+    end
+  end
+
+  defp maybe_point_marker_attr(%Context{is_block_level: true} = context, _attrs) do
+    if context.render_opts.render_point_markers,
+      do:
+        Logger.warning(
+          "Content element missing id attribute which is required for point marker. Point marker will not be rendered."
+        )
+
+    ""
+  end
+
+  defp maybe_point_marker_attr(_context, _attrs), do: ""
 end

--- a/lib/oli/rendering/context.ex
+++ b/lib/oli/rendering/context.ex
@@ -31,5 +31,5 @@ defmodule Oli.Rendering.Context do
             learning_language: nil,
             effective_settings: nil,
             is_liveview: false,
-            is_block_level: true
+            is_annotation_level: true
 end

--- a/lib/oli/rendering/context.ex
+++ b/lib/oli/rendering/context.ex
@@ -7,7 +7,8 @@ defmodule Oli.Rendering.Context do
             user: nil,
             activity_map: %{},
             render_opts: %{
-              render_errors: true
+              render_errors: true,
+              render_point_markers: true
             },
             # Mode can be one of  [:delivery, :review, :author_preview, :instructor_preview]
             mode: :delivery,
@@ -29,5 +30,6 @@ defmodule Oli.Rendering.Context do
             extrinsic_read_section_fn: nil,
             learning_language: nil,
             effective_settings: nil,
-            is_liveview: false
+            is_liveview: false,
+            is_block_level: true
 end

--- a/lib/oli/rendering/group.ex
+++ b/lib/oli/rendering/group.ex
@@ -25,7 +25,12 @@ defmodule Oli.Rendering.Group do
     if should_render?(mode, element) do
       next = fn ->
         writer.elements(
-          %Context{context | group_id: id, pagination_mode: pagination_mode},
+          %Context{
+            context
+            | group_id: id,
+              pagination_mode: pagination_mode,
+              is_block_level: true
+          },
           children
         )
       end

--- a/lib/oli/rendering/group.ex
+++ b/lib/oli/rendering/group.ex
@@ -29,13 +29,13 @@ defmodule Oli.Rendering.Group do
             context
             | group_id: id,
               pagination_mode: pagination_mode,
-              is_block_level: true
+              is_annotation_level: true
           },
           children
         )
       end
 
-      writer.group(context, next, element)
+      writer.group(%Context{context | is_annotation_level: true}, next, element)
     else
       []
     end

--- a/lib/oli/rendering/survey.ex
+++ b/lib/oli/rendering/survey.ex
@@ -22,7 +22,7 @@ defmodule Oli.Rendering.Survey do
       ) do
     next = fn ->
       writer.elements(
-        %Context{context | survey_id: id, pagination_mode: "normal", is_block_level: true},
+        %Context{context | survey_id: id, pagination_mode: "normal", is_annotation_level: true},
         children
       )
     end

--- a/lib/oli/rendering/survey.ex
+++ b/lib/oli/rendering/survey.ex
@@ -22,7 +22,7 @@ defmodule Oli.Rendering.Survey do
       ) do
     next = fn ->
       writer.elements(
-        %Context{context | survey_id: id, pagination_mode: "normal"},
+        %Context{context | survey_id: id, pagination_mode: "normal", is_block_level: true},
         children
       )
     end

--- a/lib/oli_web/live/delivery/student/lesson/annotations.ex
+++ b/lib/oli_web/live/delivery/student/lesson/annotations.ex
@@ -1,4 +1,4 @@
-defmodule OliWeb.Delivery.Student.Lesson.Notes do
+defmodule OliWeb.Delivery.Student.Lesson.Annotations do
   use OliWeb, :html
 
   def panel(assigns) do
@@ -38,7 +38,7 @@ defmodule OliWeb.Delivery.Student.Lesson.Notes do
     """
   end
 
-  def chat_icon(assigns) do
+  def annotations_icon(assigns) do
     ~H"""
     <svg
       width="24"
@@ -197,6 +197,44 @@ defmodule OliWeb.Delivery.Student.Lesson.Notes do
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla nec dui in odio.
       </p>
     </div>
+    """
+  end
+
+  attr :point_marker, :map
+
+  def annotation_bubble(assigns) do
+    ~H"""
+    <button class="absolute right-[-15px] cursor-pointer group" style={"top: #{@point_marker.top}px"}>
+      <.chat_bubble>
+        +
+      </.chat_bubble>
+    </button>
+    """
+  end
+
+  slot :inner_block
+
+  def chat_bubble(assigns) do
+    ~H"""
+    <svg
+      width="31"
+      height="31"
+      viewBox="0 0 31 31"
+      fill="none"
+      class="group-hover:scale-110 group-active:scale-100"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M30 14.6945C30.0055 16.8209 29.5087 18.9186 28.55 20.8167C27.4132 23.0912 25.6657 25.0042 23.5031 26.3416C21.3405 27.679 18.8483 28.3879 16.3055 28.3889C14.1791 28.3944 12.0814 27.8976 10.1833 26.9389L1 30L4.06111 20.8167C3.10239 18.9186 2.60556 16.8209 2.61111 14.6945C2.61209 12.1517 3.32098 9.65951 4.65837 7.49692C5.99577 5.33433 7.90884 3.58679 10.1833 2.45004C12.0814 1.49132 14.1791 0.994502 16.3055 1.00005H17.1111C20.4692 1.18531 23.641 2.60271 26.0191 4.98087C28.3973 7.35902 29.8147 10.5308 30 13.8889V14.6945Z"
+        class="fill-white stroke-gray-300"
+        stroke-width="1.61111"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <text x="11" y="22" class="text-xl fill-gray-500">
+        <%= render_slot(@inner_block) %>
+      </text>
+    </svg>
     """
   end
 end

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -151,7 +151,10 @@ defmodule OliWeb.Delivery.Student.LessonLive do
   def handle_event("toggle_sidebar", _params, socket) do
     %{show_sidebar: show_sidebar} = socket.assigns
 
-    {:noreply, assign(socket, show_sidebar: !show_sidebar)}
+    {:noreply,
+     socket
+     |> assign(show_sidebar: !show_sidebar)
+     |> push_event("request_point_markers", %{})}
   end
 
   def render(%{view: :practice_page} = assigns) do

--- a/test/oli/datashop_test.exs
+++ b/test/oli/datashop_test.exs
@@ -830,7 +830,7 @@ defmodule Oli.DatashopTest do
       datashop_file: datashop_file
     } do
       regex =
-        ~r/<context_message name="START_PROBLEM" context_message_id="(.*)".*<\/context_message>.*<tool_message context_message_id="\1">.*<\/tool_message>.*<tutor_message context_message_id="\1">.*<\/tutor_message>/s
+        ~r/<context_message name="START_PROBLEM" context_message_id="(.*)".*<tool_message context_message_id="\1">.*<tutor_message context_message_id="\1">/s
 
       assert String.match?(datashop_file, regex)
     end

--- a/test/oli/editing/page_editor_test.exs
+++ b/test/oli/editing/page_editor_test.exs
@@ -491,7 +491,15 @@ defmodule Oli.EditingTest do
 
       assert html == [
                "<div class=\"content\" >",
-               [["<p>", [[[[], "Here" | "&#39;"] | "s some test content"]], "</p>\n"]],
+               [
+                 [
+                   "<p",
+                   " data-point-marker=\"3371710400\"",
+                   ">",
+                   [[[[], "Here" | "&#39;"] | "s some test content"]],
+                   "</p>\n"
+                 ]
+               ],
                "</div>"
              ]
     end

--- a/test/oli/rendering/alternatives/html_test.exs
+++ b/test/oli/rendering/alternatives/html_test.exs
@@ -155,7 +155,7 @@ defmodule Oli.Rendering.Alternatives.HtmlTest do
 
       # renders R alternative
       assert rendered_html_string =~
-               ~s|<div class="alternative alternative-DhY8ERStw7vXActR5U5BqR"><div class="content" ><p>R</p>|
+               ~s|<div class="alternative alternative-DhY8ERStw7vXActR5U5BqR"><div class="content" ><p data-point-marker="19094070">R</p>|
 
       # renders activity embedded in R alternative
       assert rendered_html_string =~
@@ -163,11 +163,11 @@ defmodule Oli.Rendering.Alternatives.HtmlTest do
 
       # renders Excel alternative
       assert rendered_html_string =~
-               ~s|<div class="alternative alternative-kQqFWsHyXeMenEDzT9rymP"><div class=\"content\" ><p>Excel</p>\n</div>|
+               ~s|<div class="alternative alternative-kQqFWsHyXeMenEDzT9rymP"><div class=\"content\" ><p data-point-marker="1742467879">Excel</p>\n</div>|
 
       # renders Python alternative
       assert rendered_html_string =~
-               ~s|<div class="alternative alternative-bdaqYkKs8RFE4LWLmPCLnf"><div class=\"content\" ><p>Python</p>\n</div>|
+               ~s|<div class="alternative alternative-bdaqYkKs8RFE4LWLmPCLnf"><div class=\"content\" ><p data-point-marker="378189886">Python</p>\n</div>|
     end
   end
 end

--- a/test/oli/rendering/content/example_content.json
+++ b/test/oli/rendering/content/example_content.json
@@ -426,7 +426,11 @@
     },
     {
       "type": "callout",
-      "children": [{ "text": "a richtext callout" }]
+      "children": [
+        {
+          "text": "a richtext callout"
+        }
+      ]
     },
     {
       "type": "formula",
@@ -436,17 +440,29 @@
     {
       "type": "formula",
       "subtype": "latex",
-      "src": "x^2 + y^2 = z^2"
+      "src": "x^2 + y^2 = z^2",
+      "id": 169365460
     },
     {
       "type": "conjugation",
       "title": "My Term",
       "verb": "El Verbo",
-      "children": [{ "text": "" }],
+      "children": [
+        {
+          "text": ""
+        }
+      ],
       "pronunciation": {
         "type": "pronunciation",
         "children": [
-          { "type": "p", "children": [{ "text": "my pronunciation" }] }
+          {
+            "type": "p",
+            "children": [
+              {
+                "text": "my pronunciation"
+              }
+            ]
+          }
         ]
       },
       "table": {
@@ -455,19 +471,48 @@
           {
             "type": "tr",
             "children": [
-              { "type": "th", "children": [{ "text": "form" }] },
-              { "type": "th", "children": [{ "text": "meaning" }] }
+              {
+                "type": "th",
+                "children": [
+                  {
+                    "text": "form"
+                  }
+                ]
+              },
+              {
+                "type": "th",
+                "children": [
+                  {
+                    "text": "meaning"
+                  }
+                ]
+              }
             ]
           },
           {
             "type": "tr",
             "children": [
-              { "type": "td", "children": [{ "text": "my form" }] },
-              { "type": "td", "children": [{ "text": "my meaning" }] }
+              {
+                "type": "td",
+                "children": [
+                  {
+                    "text": "my form"
+                  }
+                ]
+              },
+              {
+                "type": "td",
+                "children": [
+                  {
+                    "text": "my meaning"
+                  }
+                ]
+              }
             ]
           }
         ]
-      }
+      },
+      "id": 169365461
     },
     {
       "type": "dialog",
@@ -490,7 +535,11 @@
           "children": [
             {
               "type": "p",
-              "children": [{ "text": "Hello Speaker 2" }]
+              "children": [
+                {
+                  "text": "Hello Speaker 2"
+                }
+              ]
             }
           ]
         },
@@ -499,7 +548,11 @@
           "children": [
             {
               "type": "p",
-              "children": [{ "text": "Hello Speaker 1" }]
+              "children": [
+                {
+                  "text": "Hello Speaker 1"
+                }
+              ]
             }
           ]
         },
@@ -508,24 +561,51 @@
           "children": [
             {
               "type": "p",
-              "children": [{ "text": "This speaker does not exist." }]
+              "children": [
+                {
+                  "text": "This speaker does not exist."
+                }
+              ]
             }
           ]
         }
-      ]
+      ],
+      "id": 169365462
     },
     {
       "type": "figure",
-      "title": [{ "type": "p", "children": [{ "text": "Figure Title" }] }],
-      "children": [{ "type": "p", "children": [{ "text": "Figure Content" }] }]
+      "title": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "Figure Title"
+            }
+          ]
+        }
+      ],
+      "children": [
+        {
+          "type": "p",
+          "children": [
+            {
+              "text": "Figure Content"
+            }
+          ]
+        }
+      ],
+      "id": 169365463
     },
-
     {
       "type": "p",
       "children": [
         {
           "type": "callout_inline",
-          "children": [{ "text": "a richtext inline callout" }]
+          "children": [
+            {
+              "text": "a richtext inline callout"
+            }
+          ]
         },
         {
           "type": "formula_inline",
@@ -549,7 +629,8 @@
           "target": "3603298117",
           "type": "command_button"
         }
-      ]
+      ],
+      "id": 169365464
     }
   ]
 }

--- a/test/oli/rendering/content/html_test.exs
+++ b/test/oli/rendering/content/html_test.exs
@@ -23,13 +23,13 @@ defmodule Oli.Content.Content.HtmlTest do
       assert rendered_html_string =~ "<h3>Introduction</h3>"
 
       assert rendered_html_string =~
-               ~r/<img.*src="https:\/\/upload.wikimedia.org\/wikipedia\/commons\/thumb\/f\/f9\/Declaration_of_Independence_%281819%29%2C_by_John_Trumbull.jpg\/480px-Declaration_of_Independence_%281819%29%2C_by_John_Trumbull.jpg"\/>/
+               ~r/<img.*src="https:\/\/upload.wikimedia.org\/wikipedia\/commons\/thumb\/f\/f9\/Declaration_of_Independence_%281819%29%2C_by_John_Trumbull.jpg\/480px-Declaration_of_Independence_%281819%29%2C_by_John_Trumbull.jpg" data-point-marker="1856577103" \/>/
 
       assert rendered_html_string =~
                ~r/<figcaption.*>John Trumbull&#39;s &lt;b&gt;Declaration of Independence&lt;\/b&gt;,/
 
       assert rendered_html_string =~
-               "<p>The American colonials proclaimed &quot;no taxation without representation"
+               "<p data-point-marker=\"2652513352\">The American colonials proclaimed &quot;no taxation without representation"
 
       assert rendered_html_string =~
                "<a class=\"internal-link\" href=\"/sections/some_section/page/page_two\">Page Two</a>"
@@ -40,26 +40,27 @@ defmodule Oli.Content.Content.HtmlTest do
       assert rendered_html_string =~ "<h3>1651–1748: Early seeds</h3>"
 
       assert rendered_html_string =~
-               "<ol class=\"list-inside pl-2\"><li>one</li>\n<li><em>two</em></li>\n<li><em><strong>three</strong></em></li>\n</ol>"
+               "<ol class=\"list-inside pl-2\"><li data-point-marker=\"1896247178\">one</li>\n<li data-point-marker=\"1896247178\"><em>two</em></li>\n<li data-point-marker=\"1896247178\"><em><strong>three</strong></em></li>\n</ol>"
 
       assert rendered_html_string =~
-               "<ul class=\"list-inside pl-2\"><li>alpha</li>\n<li>beta</li>\n<li>gamma</li>\n</ul>"
+               "<ul class=\"list-inside pl-2\"><li data-point-marker=\"18868465\">alpha</li>\n<li data-point-marker=\"18868465\">beta</li>\n<li data-point-marker=\"18868465\">gamma</li>\n</ul>"
 
       assert rendered_html_string =~
                ~r/<div data-react-class="Components.YoutubePlayer"/
 
       assert rendered_html_string =~
-               "<pre><code class=\"torus-code language-python\">import fresh-pots</code></pre>"
+               "<pre><code class=\"torus-code language-python\" data-point-marker=\"4076323894\">import fresh-pots</code></pre>"
 
       assert rendered_html_string =~
-               ~r/<iframe class=".*"  allowfullscreen src="https:\/\/www.wikipedia.org"><\/iframe>/
+               ~r/<iframe class=".*"  allowfullscreen src="https:\/\/www.wikipedia.org" data-point-marker="1713634991"><\/iframe>/
 
       assert rendered_html_string =~ "<span class=\"callout-block\">a richtext callout</span>"
 
       assert rendered_html_string =~
                "<span class=\"formula\"><mrow><mi>a</mi><mo>+</mo><mi>b</mi></mrow></span>"
 
-      assert rendered_html_string =~ "<span class=\"formula\">\\[x^2 + y^2 = z^2\\]</span>"
+      assert rendered_html_string =~
+               "<span class=\"formula\" data-point-marker=\"169365460\">\\[x^2 + y^2 = z^2\\]</span>"
 
       assert rendered_html_string =~
                "<span class=\"callout-inline\">a richtext inline callout</span>"
@@ -79,10 +80,10 @@ defmodule Oli.Content.Content.HtmlTest do
                "<div class=\"dialog-speaker\" ><img src=\"https://www.example.com/image.png\" class=\"img-fluid speaker-portrait\"/><div class=\"speaker-name\">Speaker 2</div></div>"
 
       assert rendered_html_string =~
-               "<div class='figure'><figure><figcaption><p>Figure Title</p>\n</figcaption><div class='figure-content'><p>Figure Content</p>\n</div></figure></div>"
+               "<div class='figure' data-point-marker=\"169365463\"><figure><figcaption><p>Figure Title</p>\n</figcaption><div class='figure-content'><p>Figure Content</p>\n</div></figure></div>"
 
       assert rendered_html_string =~
-               "<div class=\"conjugation\"><div class=\"title\">My Term</div><div class=\"term\">El Verbo<span class='pronunciation'><p>my pronunciation</p>\n</span>\n</div><figure class=\"figure embed-responsive\"><div class=\"figure-content\"><table class='table-bordered '><tr><th>form</th>\n<th>meaning</th>\n</tr>\n<tr><td>my form</td>\n<td>my meaning</td>\n</tr>\n</table>\n</div></figure></div>"
+               "<div class=\"conjugation\" data-point-marker=\"169365461\"><div class=\"title\">My Term</div><div class=\"term\">El Verbo<span class='pronunciation'><p>my pronunciation</p>\n</span>\n</div><figure class=\"figure embed-responsive\"><div class=\"figure-content\"><table class='table-bordered '><tr><th>form</th>\n<th>meaning</th>\n</tr>\n<tr><td>my form</td>\n<td>my meaning</td>\n</tr>\n</table>\n</div></figure></div>"
 
       assert rendered_html_string =~
                "<span class=\"btn btn-primary command-button\" data-action=\"command-button\" data-target=\"3603298117\" data-message=\"startcuepoint=5.0;endcuepoint=10.0\">Play Intro</span>"

--- a/test/oli/rendering/survey/html_test.exs
+++ b/test/oli/rendering/survey/html_test.exs
@@ -69,7 +69,7 @@ defmodule Oli.Content.Survey.HtmlTest do
                ~s|<div id="1855946510" class="survey"><div class="survey-label">Survey</div><div class="survey-content">|
 
       assert rendered_html_string =~
-               ~s|<p>Please complete the following survey:</p>\n</div><oli-multiple-choice-delivery phx-update="ignore" class="activity-container" state="{ "active": true }" model="{ "choices": [ "A", "B", "C", "D" ], "feedback": [ "A", "B", "C", "D" ], "stem": ""}" mode="delivery"|
+               ~s|<p data-point-marker=\"3166489545\">Please complete the following survey:</p>\n</div><oli-multiple-choice-delivery phx-update="ignore" class="activity-container" state="{ "active": true }" model="{ "choices": [ "A", "B", "C", "D" ], "feedback": [ "A", "B", "C", "D" ], "stem": ""}" mode="delivery"|
 
       assert rendered_html_string =~
                ~s|</oli-multiple-choice-delivery>|

--- a/test/oli_web/live/admin/institutions/index_live_test.exs
+++ b/test/oli_web/live/admin/institutions/index_live_test.exs
@@ -144,6 +144,7 @@ defmodule OliWeb.Admin.Institutions.IndexLiveTest do
              )
     end
 
+    @tag capture_log: true
     test "can approve pending registrations", %{conn: conn} do
       pending_registration =
         insert(:pending_registration, %{
@@ -192,6 +193,7 @@ defmodule OliWeb.Admin.Institutions.IndexLiveTest do
              |> Repo.one() != nil
     end
 
+    @tag capture_log: true
     test "when a pending registration is approved by setting a `New Institution`, the new institution is created correctly",
          %{conn: conn} do
       insert(:institution, %{
@@ -258,6 +260,7 @@ defmodule OliWeb.Admin.Institutions.IndexLiveTest do
       assert new_institution.institution_url == "www.existing_institution.com"
     end
 
+    @tag capture_log: true
     test "when a pending registration contains the url of an existing institution, the existing institution is used instead",
          %{conn: conn} do
       existing_institution =

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -186,10 +186,11 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
         intro_content: %{
           children: [
             %{
+              id: "2905665054",
               type: "p",
               children: [
                 %{
-                  text: "Thoughout this unit you will learn how to use this course."
+                  text: "Throughout this unit you will learn how to use this course."
                 }
               ]
             }
@@ -724,7 +725,11 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       assert render(page_2_element) =~ "min"
 
       # intro content is shown
-      assert has_element?(view, "p", "Thoughout this unit you will learn how to use this course.")
+      assert has_element?(
+               view,
+               "p",
+               "Throughout this unit you will learn how to use this course."
+             )
 
       # header is shown with title and due date
       assert has_element?(

--- a/test/oli_web/live/delivery/student/lesson_live_test.exs
+++ b/test/oli_web/live/delivery/student/lesson_live_test.exs
@@ -139,7 +139,7 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
               type: "p",
               children: [
                 %{
-                  text: "Thoughout this unit you will learn how to use this course."
+                  text: "Throughout this unit you will learn how to use this course."
                 }
               ]
             }

--- a/test/oli_web/live/delivery/student/review_live_test.exs
+++ b/test/oli_web/live/delivery/student/review_live_test.exs
@@ -106,7 +106,7 @@ defmodule OliWeb.Delivery.Student.ReviewLiveTest do
               type: "p",
               children: [
                 %{
-                  text: "Thoughout this unit you will learn how to use this course."
+                  text: "Throughout this unit you will learn how to use this course."
                 }
               ]
             }


### PR DESCRIPTION
Implements https://eliterate.atlassian.net/browse/NG23-95

Users can now see chat icons next to annotatable content blocks, specifically:
```
  p
  img
  video
  youtube
  iframe
  audio
  table
  code
  blockquote
  dialog
  conjugation
  ecl (emerald cloud lab)
  page-link
  li
  group -> ..AnnotationSupportedElements
  survey -> ..AnnotationSupportedElements
```

<img width="1803" alt="Screenshot 2024-02-29 at 10 56 43 AM" src="https://github.com/Simon-Initiative/oli-torus/assets/6248894/539560b1-5541-411f-86a3-28c3acb5016a">

We can add/remove elements to this list as we receive feedback or see fit. This was the balance struck in order to give a good amount of annotation point while not overloading the page with chat bubbles