### PR TITLE
[ENHANCEMENT] ignore correct choice in mcq targeted feedback list [MER-3034]

### DIFF
--- a/assets/src/components/activities/common/responses/TargetedFeedback.tsx
+++ b/assets/src/components/activities/common/responses/TargetedFeedback.tsx
@@ -4,7 +4,6 @@ import { AuthoringButtonConnected } from 'components/activities/common/authoring
 import { ChoicesDelivery } from 'components/activities/common/choices/delivery/ChoicesDelivery';
 import { ResponseCard } from 'components/activities/common/responses/ResponseCard';
 import { ResponseActions } from 'components/activities/common/responses/responseActions';
-import { getCorrectChoiceId } from 'components/activities/multiple_choice/utils';
 import {
   Choice,
   ChoiceId,

--- a/assets/src/components/activities/common/responses/TargetedFeedback.tsx
+++ b/assets/src/components/activities/common/responses/TargetedFeedback.tsx
@@ -4,6 +4,7 @@ import { AuthoringButtonConnected } from 'components/activities/common/authoring
 import { ChoicesDelivery } from 'components/activities/common/choices/delivery/ChoicesDelivery';
 import { ResponseCard } from 'components/activities/common/responses/ResponseCard';
 import { ResponseActions } from 'components/activities/common/responses/responseActions';
+import { getCorrectChoiceId } from 'components/activities/multiple_choice/utils';
 import {
   Choice,
   ChoiceId,
@@ -14,6 +15,7 @@ import {
 } from 'components/activities/types';
 import {
   ResponseMapping,
+  getCorrectResponse,
   getTargetedResponseMappings,
   hasCustomScoring,
 } from 'data/activities/model/responses';
@@ -81,11 +83,15 @@ export const TargetedFeedback: React.FC<Props> = (props) => {
 
   // only show feedbacks for relevant choice set, presumably current part's on multipart
   const partMappings = getFeedbackForChoices(props.choices || model.choices, hook.targetedMappings);
+  // some migrated qs erroneously included correct answer in targeted feedback map: ignore
+  const firstCorrect = partMappings.find((m) => m.response.score > 0);
+  const mappings = partMappings.filter((m) => m !== firstCorrect);
+
   const customScoring = hasCustomScoring(model);
 
   return (
     <>
-      {partMappings.map((mapping) => (
+      {mappings.map((mapping) => (
         <ResponseCard
           key={mapping.response.id}
           title="Targeted feedback"

--- a/assets/src/components/activities/common/responses/TargetedFeedback.tsx
+++ b/assets/src/components/activities/common/responses/TargetedFeedback.tsx
@@ -15,7 +15,6 @@ import {
 } from 'components/activities/types';
 import {
   ResponseMapping,
-  getCorrectResponse,
   getTargetedResponseMappings,
   hasCustomScoring,
 } from 'data/activities/model/responses';


### PR DESCRIPTION
Migrated courses erroneously included the correct choice in targeted feedback mapping for multiple choice and multi-input dropdown items. This provides a path for author to delete the correct answer in authoring by deleting that targeted feedback, which puts the question in an invalid state, blocking any further editing. This change defends against that for already-migrated courses by filtering the correct response from the targeted feedback display. 

This check is added in the common `<TargetedFeedback>` component which is used in authoring of Multiple Choice, CATA, Multi-input, Image Hotspot, Ordering, and Likert activities. 