### PR TITLE
[ENHANCEMENT] remove horizontal padding on inline formulas [MER-3052]

### DIFF
--- a/assets/styles/common/elements.scss
+++ b/assets/styles/common/elements.scss
@@ -318,12 +318,20 @@ $element-margin-bottom: 1.5em;
   .callout-inline,
   .formula-inline {
     display: inline-block;
-    padding: 2px 0.5em;
 
     mjx-container[display='true'] {
       pointer-events: none;
       margin: 0px !important;
     }
+  }
+
+  .formula-inline {
+    /* no padding on left and right, some use to mix symbols with surrounding punctuation */
+    padding: 2px 0em;
+  }
+
+  .callout-inline {
+    padding: 2px 0.5em;
   }
 
   .callout-inline,


### PR DESCRIPTION
Authors noted excessive padding around inline formulas in the body of text, causing an odd appearance when formulas interspersed in body of text, particularly when formula for symbols are followed immediately by punctuation. This change removes the 0.5em horizontal padding applied to formula-inline. Examples:

Current:

<img width="725" alt="Screenshot 2024-02-21 at 11 30 45 AM" src="https://github.com/Simon-Initiative/oli-torus/assets/7094628/db29c937-d10f-4f54-aefe-090f5ff53bc7">


New:

![Screenshot 2024-03-01 at 12 23 46 PM](https://github.com/Simon-Initiative/oli-torus/assets/7094628/e59a872a-57c4-44fd-a37c-eded13b60221)

