### PR TITLE
[BUGFIX][MER-2994] Fix additional activity summarization

### DIFF
--- a/assets/src/components/activities/multi_input/schema.ts
+++ b/assets/src/components/activities/multi_input/schema.ts
@@ -60,6 +60,6 @@ export interface MultiInputSchema extends ActivityModelSchema, ActivityLevelScor
     parts: Part[];
     transformations: Transformation[];
     previewText: string;
-    responses?: { user_name: string; text: string; type: string }[];
+    responses?: { user_name: string; text: string; type: string; part_id: string; count: number }[];
   };
 }

--- a/assets/src/components/activities/multi_input/sections/QuestionTab.tsx
+++ b/assets/src/components/activities/multi_input/sections/QuestionTab.tsx
@@ -53,13 +53,19 @@ export const QuestionTab: React.FC<Props> = (props) => {
               </tr>
               <tbody>
                 {model.authoring.responses
-                  ?.filter((response) => response.type === props.input.inputType)
-                  .map((response, index) => (
-                    <tr key={index}>
-                      <td className="whitespace-nowrap">{response.user_name}</td>
-                      <td>{response.text}</td>
-                    </tr>
-                  ))}
+                  ?.filter(
+                    (response) =>
+                      response.type === props.input.inputType &&
+                      response.part_id === props.input.partId,
+                  )
+                  .map((response, index) =>
+                    Array.from({ length: response.count }).map((_, i) => (
+                      <tr key={`${index}-${i}`}>
+                        <td className="whitespace-nowrap">{response.user_name}</td>
+                        <td>{response.text}</td>
+                      </tr>
+                    )),
+                  )}
               </tbody>
             </table>
           </div>

--- a/lib/oli_web/components/delivery/scored_activities/scored_activities.ex
+++ b/lib/oli_web/components/delivery/scored_activities/scored_activities.ex
@@ -804,7 +804,9 @@ defmodule OliWeb.Components.Delivery.ScoredActivities do
           %{
             text: response_summary.response,
             user_name: OliWeb.Common.Utils.name(response_summary.user),
-            type: mapper[response_summary.part_id]
+            type: mapper[response_summary.part_id],
+            part_id: response_summary.part_id,
+            count: response_summary.count
           }
           | acc_responses
         ]


### PR DESCRIPTION
[MER-2994](https://eliterate.atlassian.net/browse/MER-2994)

This PR fixes the aditional activity summarization when there are activities multi input with numeric and text inputs.

With these changes, when an input is selected, only its answers are shown and not the answers of the whole activity.


https://github.com/Simon-Initiative/oli-torus/assets/16328384/ff710f72-fa93-45f4-b613-baeafc413c1f


[MER-2994]: https://eliterate.atlassian.net/browse/MER-2994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ