### PR TITLE
[FEATURE][MER-2985] Reduce number of clicks to launch lesson

### DIFF
--- a/lib/oli/publishing/delivery_resolver.ex
+++ b/lib/oli/publishing/delivery_resolver.ex
@@ -203,6 +203,7 @@ defmodule Oli.Publishing.DeliveryResolver do
   @doc """
   Returns the first page slug for a given section
   """
+  @spec get_first_page_slug(String.t()) :: String.t()
   def get_first_page_slug(section_slug) do
     page_id = Oli.Resources.ResourceType.id_for_page()
 

--- a/lib/oli/publishing/delivery_resolver.ex
+++ b/lib/oli/publishing/delivery_resolver.ex
@@ -200,6 +200,21 @@ defmodule Oli.Publishing.DeliveryResolver do
     |> emit([:oli, :resolvers, :delivery], :duration)
   end
 
+  @doc """
+  Returns the first page slug for a given section
+  """
+  def get_first_page_slug(section_slug) do
+    page_id = Oli.Resources.ResourceType.id_for_page()
+
+    from([s: s, sr: sr, rev: rev] in section_resource_revisions(section_slug),
+      where: rev.resource_type_id == ^page_id,
+      select: rev.slug,
+      order_by: [asc: sr.numbering_index],
+      limit: 1
+    )
+    |> Repo.one()
+  end
+
   def practice_pages_revisions_and_section_resources_with_surveys(section_slug) do
     from([sr, s, _spp, _pr, rev] in section_resource_revisions(section_slug),
       join: content_elem in fragment("jsonb_array_elements(?->'model')", rev.content),

--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -351,7 +351,8 @@ defmodule OliWeb.DeliveryController do
 
             render(conn, "enroll.html",
               section: section,
-              from_invitation_link?: params["from_invitation_link?"] || false
+              from_invitation_link?: params["from_invitation_link?"] || false,
+              auto_enroll_as_guest: params["auto_enroll_as_guest"] || false
             )
         end
 

--- a/lib/oli_web/controllers/launch_controller.ex
+++ b/lib/oli_web/controllers/launch_controller.ex
@@ -1,0 +1,101 @@
+defmodule OliWeb.LaunchController do
+  use OliWeb, :controller
+  use OliWeb, :verified_routes
+
+  alias Oli.{Accounts, Repo}
+  alias Oli.Accounts.User
+  alias Oli.Delivery.Sections
+  alias Oli.Delivery.Sections.Section
+  alias Oli.Publishing.DeliveryResolver
+  alias Lti_1p3.DataProviders.EctoProvider.Marshaler
+  alias Lti_1p3.Tool.{PlatformRoles, ContextRoles}
+  alias OliWeb.Router.Helpers, as: Routes
+
+  def join(conn, %{"section_slug" => section_slug}) do
+    section = conn.assigns.section
+    current_user = conn.assigns.current_user
+
+    case section do
+      %Section{open_and_free: true, requires_enrollment: false} ->
+        params = %{
+          auto_enroll_as_guest:
+            if(is_nil(current_user) || current_user.guest, do: true, else: false)
+        }
+
+        conn
+        |> redirect(to: ~p"/sections/#{section_slug}/enroll?#{params}")
+
+      _ ->
+        conn
+        |> redirect(to: Routes.static_page_path(OliWeb.Endpoint, :unauthorized))
+    end
+  end
+
+  def auto_enroll_as_guest(conn, params) do
+    g_recaptcha_response = Map.get(params, "g-recaptcha-response", "")
+
+    if Oli.Utils.LoadTesting.enabled?() or recaptcha_verified?(g_recaptcha_response) do
+      with {:available, section} <- Sections.available?(conn.assigns.section),
+           {:ok, user} <- current_or_guest_user(conn, section.requires_enrollment),
+           user <- Repo.preload(user, [:platform_roles]) do
+        first_page_slug = DeliveryResolver.get_first_page_slug(section.slug)
+        first_page_url = ~p"/sections/#{section.slug}/page/#{first_page_slug}"
+
+        if Sections.is_enrolled?(user.id, section.slug) do
+          redirect(conn,
+            to: first_page_url
+          )
+        else
+          Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+          Sections.mark_section_visited_for_student(section, user)
+
+          Accounts.update_user_platform_roles(
+            user,
+            Marshaler.from(user.platform_roles)
+            |> MapSet.new()
+            |> MapSet.put(PlatformRoles.get_role(:institution_learner))
+            |> MapSet.to_list()
+          )
+
+          conn
+          |> create_pow_user(:user, user)
+          |> redirect(to: first_page_url)
+        end
+      else
+        {:redirect, nil} ->
+          # guest user cant access courses that require enrollment
+          redirect_path =
+            "/session/new?request_path=#{Routes.delivery_path(conn, :show_enroll, conn.assigns.section.slug)}"
+
+          conn
+          |> put_flash(
+            :error,
+            "Cannot enroll guest users in a course section that requires enrollment"
+          )
+          |> redirect(to: redirect_path)
+
+        _error ->
+          render(conn, "enroll.html", error: "Something went wrong, please try again")
+      end
+    else
+      render(conn, "enroll.html", error: "ReCaptcha failed, please try again")
+    end
+  end
+
+  defp recaptcha_verified?(g_recaptcha_response) do
+    Oli.Utils.Recaptcha.verify(g_recaptcha_response) == {:success, true}
+  end
+
+  defp current_or_guest_user(conn, requires_enrollment) do
+    case conn.assigns.current_user do
+      nil ->
+        if requires_enrollment, do: {:redirect, nil}, else: Accounts.create_guest_user()
+
+      %User{guest: true} = guest ->
+        if requires_enrollment, do: {:redirect, nil}, else: {:ok, guest}
+
+      user ->
+        {:ok, user}
+    end
+  end
+end

--- a/lib/oli_web/controllers/launch_controller.ex
+++ b/lib/oli_web/controllers/launch_controller.ex
@@ -17,10 +17,7 @@ defmodule OliWeb.LaunchController do
 
     case section do
       %Section{open_and_free: true, requires_enrollment: false} ->
-        params = %{
-          auto_enroll_as_guest:
-            if(is_nil(current_user) || current_user.guest, do: true, else: false)
-        }
+        params = %{auto_enroll_as_guest: is_nil(current_user) || current_user.guest}
 
         conn
         |> redirect(to: ~p"/sections/#{section_slug}/enroll?#{params}")

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -1109,6 +1109,8 @@ defmodule OliWeb.Router do
 
     get("/:section_slug/enroll", DeliveryController, :show_enroll)
     post("/:section_slug/enroll", DeliveryController, :process_enroll)
+    get("/:section_slug/join", LaunchController, :join)
+    post("/:section_slug/auto_enroll", LaunchController, :auto_enroll_as_guest)
   end
 
   # Delivery Auth (Signin)

--- a/lib/oli_web/templates/delivery/enroll.html.heex
+++ b/lib/oli_web/templates/delivery/enroll.html.heex
@@ -14,7 +14,7 @@
         </div>
       </div>
 
-      <%= form_for @conn, Routes.delivery_path(@conn, :process_enroll, @section.slug), fn _f -> %>
+      <%= form_for @conn, if(assigns[:auto_enroll_as_guest], do: ~p"/sections/#{@section.slug}/auto_enroll", else: Routes.delivery_path(@conn, :process_enroll, @section.slug)), fn _f -> %>
         <div class="form-label-group">
           <%= if user_is_guest?(assigns) or assigns.current_user == nil do %>
             <p>
@@ -35,8 +35,15 @@
         </div>
 
         <%= if user_is_guest?(assigns) or assigns.current_user == nil do %>
-          <%= submit("Enroll as Guest", class: "btn btn-md btn-primary btn-block") %>
+          <%= submit(
+            if(assigns[:auto_enroll_as_guest],
+              do: "Begin Lesson",
+              else: "Enroll as Guest"
+            ),
+            class: "btn btn-md btn-primary btn-block"
+          ) %>
           <a
+            :if={!assigns[:auto_enroll_as_guest]}
             href={
               Routes.pow_session_path(@conn, :new,
                 section: @section.slug,

--- a/test/oli_web/controllers/launch_controller_test.exs
+++ b/test/oli_web/controllers/launch_controller_test.exs
@@ -1,0 +1,167 @@
+defmodule OliWeb.LaunchControllerTest do
+  use OliWeb.ConnCase
+
+  import Oli.Factory
+
+  describe "launch controller as guest user" do
+    setup [:guest_conn, :section_with_assessment]
+
+    test "join endpoint redirects correctly to the enrollment view", %{
+      conn: conn,
+      section: section
+    } do
+      conn = get(conn, ~p"/sections/#{section.slug}/join")
+
+      assert html_response(conn, 302) =~
+               "You are being <a href=\"/sections/#{section.slug}/enroll?auto_enroll_as_guest=true\">redirected"
+
+      conn = get(conn, ~p"/sections/#{section.slug}/enroll?auto_enroll_as_guest=true")
+
+      response = html_response(conn, 200)
+
+      assert response =~ "Begin Lesson"
+      assert response =~ "You will be enrolled as a <b>Guest</b>"
+    end
+
+    test "join endpoint redirects to unauthorized page if section is not open and free", %{
+      conn: conn
+    } do
+      section = insert(:section, open_and_free: false, requires_enrollment: true)
+
+      conn = get(conn, ~p"/sections/#{section.slug}/join")
+
+      assert html_response(conn, 302) =~
+               "You are being <a href=\"/unauthorized\">redirected"
+    end
+
+    test "auto enroll endpoint redirects to first page of course section", %{
+      conn: conn,
+      guest: guest,
+      section: section,
+      page_revision: page_revision
+    } do
+      insert(:enrollment, user: guest, section: section)
+      expect_recaptcha_http_post()
+
+      conn =
+        post(
+          conn,
+          ~p"/sections/#{section.slug}/auto_enroll?auto_enroll_as_guest=true",
+          %{
+            "g-recaptcha-response": "any"
+          }
+        )
+
+      assert html_response(conn, 302) =~
+               "You are being <a href=\"/sections/#{section.slug}/page/#{page_revision.slug}\">redirected"
+    end
+
+    test "join endpoint redirects to section overview page if user is already enrolled", %{
+      conn: conn,
+      guest: guest,
+      section: section
+    } do
+      insert(:enrollment, user: guest, section: section)
+
+      conn = get(conn, ~p"/sections/#{section.slug}/join")
+
+      assert html_response(conn, 302) =~
+               "You are being <a href=\"/sections/#{section.slug}/enroll?auto_enroll_as_guest=true\">redirected"
+
+      expect_recaptcha_http_post()
+
+      conn =
+        post(
+          conn,
+          ~p"/sections/#{section.slug}/enroll?auto_enroll_as_guest=true",
+          %{
+            "g-recaptcha-response": "any"
+          }
+        )
+
+      assert html_response(conn, 302) =~
+               "You are being <a href=\"/sections/#{section.slug}/overview\">redirected"
+    end
+  end
+
+  describe "launch controller as authenticated user" do
+    setup [:user_conn, :section_with_assessment]
+
+    test "join endpoint redirects correctly to the enrollment view",
+         %{
+           conn: conn,
+           section: section
+         } do
+      conn = get(conn, ~p"/sections/#{section.slug}/join")
+
+      assert html_response(conn, 302) =~
+               "You are being <a href=\"/sections/#{section.slug}/enroll?auto_enroll_as_guest=false\">redirected"
+
+      conn = get(conn, ~p"/sections/#{section.slug}/enroll?auto_enroll_as_guest=false")
+
+      response = html_response(conn, 200)
+
+      assert response =~ "Enroll"
+    end
+
+    test "join endpoint redirects to unauthorized page if section is not open and free", %{
+      conn: conn
+    } do
+      section = insert(:section, open_and_free: false, requires_enrollment: true)
+
+      conn = get(conn, ~p"/sections/#{section.slug}/join")
+
+      assert html_response(conn, 302) =~
+               "You are being <a href=\"/unauthorized\">redirected"
+    end
+
+    test "auto enroll endpoint redirects to first page of course section", %{
+      conn: conn,
+      user: user,
+      section: section,
+      page_revision: page_revision
+    } do
+      insert(:enrollment, user: user, section: section)
+      expect_recaptcha_http_post()
+
+      conn =
+        post(
+          conn,
+          ~p"/sections/#{section.slug}/auto_enroll?auto_enroll_as_guest=false",
+          %{
+            "g-recaptcha-response": "any"
+          }
+        )
+
+      assert html_response(conn, 302) =~
+               "You are being <a href=\"/sections/#{section.slug}/page/#{page_revision.slug}\">redirected"
+    end
+
+    test "join endpoint redirects to section overview page if user is already enrolled", %{
+      conn: conn,
+      user: user,
+      section: section
+    } do
+      insert(:enrollment, user: user, section: section)
+
+      conn = get(conn, ~p"/sections/#{section.slug}/join")
+
+      assert html_response(conn, 302) =~
+               "You are being <a href=\"/sections/#{section.slug}/enroll?auto_enroll_as_guest=false\">redirected"
+
+      expect_recaptcha_http_post()
+
+      conn =
+        post(
+          conn,
+          ~p"/sections/#{section.slug}/enroll?auto_enroll_as_guest=false",
+          %{
+            "g-recaptcha-response": "any"
+          }
+        )
+
+      assert html_response(conn, 302) =~
+               "You are being <a href=\"/sections/#{section.slug}/overview\">redirected"
+    end
+  end
+end


### PR DESCRIPTION
[MER-2985](https://eliterate.atlassian.net/browse/MER-2985)

This PR implements two new routes to enter a course section faster and with fewer clicks. 
A new controller is created that handles two endpoints needed to speed up this process. 

With this implementation, authenticated and non-authenticated users (guest users) of the application will be able to enroll in a course in a more direct way being redirected to the first page of the course section.

- Enroll as non-authenticated user (Guest)

https://github.com/Simon-Initiative/oli-torus/assets/16328384/1300e927-9f51-4e6d-8233-b3e8fa1a2d3a

- Enroll as authenticated user

https://github.com/Simon-Initiative/oli-torus/assets/16328384/61503580-ccbf-43c1-9200-08a9c13fdbfc


[MER-2985]: https://eliterate.atlassian.net/browse/MER-2985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ