### PR TITLE
[BUG FIX] [MER-3055] Restrict zero activity score override to basic pages

### DIFF
--- a/lib/oli/delivery/attempts/page_lifecycle/graded.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/graded.ex
@@ -252,9 +252,14 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Graded do
     end
   end
 
-  defp apply_evaluation(resource_attempt, activity_attempts, %Combined{} = effective_settings, is_adaptive?) do
+  defp apply_evaluation(
+         resource_attempt,
+         activity_attempts,
+         %Combined{} = effective_settings,
+         is_adaptive?
+       ) do
     {score, out_of} =
-      if !is_adaptive? and Enum.empty?(activity_attempts)  do
+      if !is_adaptive? and Enum.empty?(activity_attempts) do
         # For basic page assessments with no activities, grant a score of 1.0/1.0
         {1.0, 1.0}
       else


### PR DESCRIPTION
The logic that was added to be able to score basic pages which contain zero activities did not take into account the fact that adaptive page evaluation only looks at "non active" activities.  So, if a user submits an attempt on the first screen in an adaptive page, that page attempt will contain zero "non active" activities and thus trip this case and get scored 1 out of 1.  Instead, we always want adaptive pages to go thru the standard scoring flow where it will likely get a content driven score override.  