### PR TITLE
[BUG FIX] [SIM - CAPI Issue] | variable added in configData section of a SIM not getting replaced before sending it to SIM

### DIFF
--- a/assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx
+++ b/assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx
@@ -163,6 +163,7 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
       setScriptEnv(env);
     }
     simLife.domain = initResult.context.domain || 'stage';
+    simLife.simId = id;
     processInitStateVariable(currentStateSnapshot, simLife.domain);
   }, []);
 
@@ -681,6 +682,7 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
         configData: filterVars,
       });
       Object.keys(filterVars).forEach((variable: any) => {
+        const simKey = `${simLife.domain}.${simLife.simId}.${variable}`;
         const formatted: Record<string, any> = {};
         formatted[variable] = filterVars[variable];
         if (context !== contexts.REVIEW) {
@@ -697,7 +699,7 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
                   scriptEnv,
                   true,
                   false,
-                  variable,
+                  simKey,
                 );
           } else if (typeof value === 'string' && isMathExpr) {
             if (value.search(/app\.|variables\.|stage\.|session\./) >= 0) {
@@ -707,7 +709,8 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
                 simLife.snapshot,
                 scriptEnv,
                 true,
-                variable,
+                false,
+                simKey,
               );
             }
           }


### PR DESCRIPTION
Hey @bsparks, please look at the PR.

To enhance performance, we've introduced an `"conditionsNeedEvaluation"` array in the authoring system. This array contains a list of variables that require evaluation. During delivery, the system checks if a given variable is present in this list to determine whether it should be evaluated or ignored.

In the authoring process, if a configuration data variable has an expression, it is added to the `"conditionsNeedEvaluation"` list as `'stage.simId.simVariable'`. However, when passing the `'Key'` from the external activity page, we were only passing 'simVariable' as the key to the `'templatizeText'` function. As a result, when the system checked if '`simVariable'` was present in '`conditionsNeedEvaluation`', it couldn't find it. Therefore, we need to send the entire key.