### PR TITLE
[BUGFIX][MER-2761] Sticky flash messages look wrong after update timezone

### DIFF
--- a/lib/oli_web/templates/layout/live.html.heex
+++ b/lib/oli_web/templates/layout/live.html.heex
@@ -1,32 +1,52 @@
-<div :if={@flash not in [nil, %{}]} id="live_flash_container" class="flash container mx-auto px-0 top-[80px]">
+<div
+  :if={@flash not in [nil, %{}]}
+  id="live_flash_container"
+  class="flash container mx-auto px-0 top-[80px]"
+>
   <%= if live_flash(@flash, :info) do %>
     <div class="alert alert-info flex flex-row" role="alert">
       <div class="flex-1">
         <%= live_flash(@flash, :info) %>
       </div>
 
-      <button type="button" class="close" data-bs-dismiss="alert" aria-label="Close" phx-click="lv:clear-flash" phx-value-key="info">
+      <button
+        type="button"
+        class="close"
+        data-bs-dismiss="alert"
+        aria-label="Close"
+        phx-click="lv:clear-flash"
+        phx-value-key="info"
+      >
         <i class="fa-solid fa-xmark fa-lg"></i>
       </button>
-
     </div>
   <% end %>
 
   <%= if live_flash(@flash, :error) do %>
     <div class="alert alert-danger flex flex-row" role="alert">
-
       <div class="flex-1">
         <%= live_flash(@flash, :error) %>
       </div>
 
-      <button type="button" class="close" data-bs-dismiss="alert" aria-label="Close" phx-click="lv:clear-flash" phx-value-key="error">
+      <button
+        type="button"
+        class="close"
+        data-bs-dismiss="alert"
+        aria-label="Close"
+        phx-click="lv:clear-flash"
+        phx-value-key="error"
+      >
         <i class="fa-solid fa-xmark fa-lg"></i>
       </button>
-
     </div>
   <% end %>
 </div>
 
-<script id="keep-alive" type="text/javascript" src={Routes.static_path(OliWeb.Endpoint, "/js/keepalive.js")}></script>
+<script
+  id="keep-alive"
+  type="text/javascript"
+  src={Routes.static_path(OliWeb.Endpoint, "/js/keepalive.js")}
+>
+</script>
 
 <%= @inner_content %>

--- a/lib/oli_web/templates/layout/live.html.heex
+++ b/lib/oli_web/templates/layout/live.html.heex
@@ -1,5 +1,4 @@
-
-<div id="live_flash_container" class="flash container mx-auto px-0 top-[80px]">
+<div :if={@flash not in [nil, %{}]} id="live_flash_container" class="flash container mx-auto px-0 top-[80px]">
   <%= if live_flash(@flash, :info) do %>
     <div class="alert alert-info flex flex-row" role="alert">
       <div class="flex-1">
@@ -28,6 +27,6 @@
   <% end %>
 </div>
 
-<script id="keep-alive" type="text/javascript" src="<%= Routes.static_path(OliWeb.Endpoint, "/js/keepalive.js") %>"></script>
+<script id="keep-alive" type="text/javascript" src={Routes.static_path(OliWeb.Endpoint, "/js/keepalive.js")}></script>
 
 <%= @inner_content %>

--- a/lib/oli_web/templates/page_delivery/index.html.heex
+++ b/lib/oli_web/templates/page_delivery/index.html.heex
@@ -47,7 +47,7 @@
             do: "lg:basis-2/3 mt-3",
             else: "w-full"
         }>
-          <%= live_render(@conn, OliWeb.Delivery.StudentDashboard.CourseContentLive,
+          <%= live_render(%{@conn | assigns: Map.delete(@conn.assigns, :flash)}, OliWeb.Delivery.StudentDashboard.CourseContentLive,
             session: %{
               "section_slug" => @section_slug,
               "current_user_id" => @current_user_id,

--- a/lib/oli_web/templates/page_delivery/index.html.heex
+++ b/lib/oli_web/templates/page_delivery/index.html.heex
@@ -47,7 +47,9 @@
             do: "lg:basis-2/3 mt-3",
             else: "w-full"
         }>
-          <%= live_render(%{@conn | assigns: Map.delete(@conn.assigns, :flash)}, OliWeb.Delivery.StudentDashboard.CourseContentLive,
+          <%= live_render(
+            %{@conn | assigns: Map.delete(@conn.assigns, :flash)},
+            OliWeb.Delivery.StudentDashboard.CourseContentLive,
             session: %{
               "section_slug" => @section_slug,
               "current_user_id" => @current_user_id,

--- a/test/oli_web/controllers/static_page_controller_test.exs
+++ b/test/oli_web/controllers/static_page_controller_test.exs
@@ -87,6 +87,9 @@ defmodule OliWeb.StaticPageControllerTest do
           }
         })
 
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) ==
+               "Timezone updated successfully."
+
       assert Accounts.get_author_preference(author.id, :timezone) == new_timezone
       assert redirected_to(conn, 302) == redirect_to
     end
@@ -104,6 +107,9 @@ defmodule OliWeb.StaticPageControllerTest do
           }
         })
 
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) ==
+               "Timezone updated successfully."
+
       assert Accounts.get_user_preference(user.id, :timezone) == new_timezone
       assert redirected_to(conn, 302) == redirect_to
     end
@@ -120,6 +126,9 @@ defmodule OliWeb.StaticPageControllerTest do
             redirect_to: "invalid_path"
           }
         })
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) ==
+               "Timezone updated successfully."
 
       assert Accounts.get_user_preference(user.id, :timezone) == new_timezone
       assert redirected_to(conn, 302) == Routes.static_page_path(conn, :index)

--- a/test/oli_web/live/delivery/student_dashboard/course_content_live_test.exs
+++ b/test/oli_web/live/delivery/student_dashboard/course_content_live_test.exs
@@ -514,6 +514,32 @@ defmodule OliWeb.Delivery.StudentDashboard.CourseContentLiveTest do
       assert has_element?(view, "h4", "Module 1")
       assert has_element?(view, "h4", "Module 2")
     end
+
+    test "does not show flash message after update timezone", %{
+      conn: conn,
+      user: user,
+      section: section
+    } do
+      {:ok, view, _html} = isolated_live_view_course_content(conn, section.slug, user.id)
+      redirect_to = ~p"/sections/#{section.slug}/overview"
+      new_timezone = "America/Montevideo"
+
+      conn =
+        post(conn, ~p"/update_timezone", %{
+          timezone: %{
+            timezone: new_timezone,
+            redirect_to: redirect_to
+          }
+        })
+
+      assert redirected_to(conn, 302) == redirect_to
+
+      refute has_element?(
+               view,
+               "div.alert.alert-info[id=\"live_flash_container\"]",
+               "Timezone updated successfully."
+             )
+    end
   end
 
   defp breadcrumbs_length(view) do


### PR DESCRIPTION
[MER-2761](https://eliterate.atlassian.net/browse/MER-2761)

This PR fixes the bug where the flash message is shown twice when updating the timezone as student.

The problem that caused this is that the flash message was displayed both in the controller view and in the liveview that renders the course content. This prevents the message from being displayed for the liveview.

https://github.com/Simon-Initiative/oli-torus/assets/16328384/bcc416fb-eeb3-4b46-bc5e-3cdc0814397d

[MER-2761]: https://eliterate.atlassian.net/browse/MER-2761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ