### PR TITLE
[BUGFIX] style terms distinctively in text content [MER-3066]

### DIFF
--- a/assets/styles/common/elements.scss
+++ b/assets/styles/common/elements.scss
@@ -241,6 +241,12 @@ $element-margin-bottom: 1.5em;
     float: left;
   }
 
+  // MER-3066: Highlight terms outside of definitions, but leave normal size
+  .term {
+    color: var(--color-green-400);
+    font-weight: bold;
+  }
+
   .definition {
     margin-bottom: $element-margin-bottom;
 


### PR DESCRIPTION
“Term” is available in Torus as an inline style like underline, strikethrough, etc. When used within definitions, terms are styled in green, heavy-weight and slightly larger font. But term-tagged text was not being styled in other contexts.  Legacy course Logic and Proofs makes frequent use of term styling to highlight technical terms when they are introduced in text content.

This styles terms in content in the same green and bold as in definitions, though it keeps the normal size. Sample showing terms outside and inside a definition:



![Screenshot 2024-03-13 at 8 24 50 PM](https://github.com/Simon-Initiative/oli-torus/assets/7094628/fda45922-2ba9-4527-8025-5205afe33668)

