### PR TITLE
[BUGFIX][MER-3008] Attempts sort out of order

### DIFF
--- a/lib/oli/authoring/course.ex
+++ b/lib/oli/authoring/course.ex
@@ -592,6 +592,9 @@ defmodule Oli.Authoring.Course do
       %{license: %{license_type: license_type} = license} when license_type in @cc_options ->
         Map.from_struct(license)
 
+      %{license: nil} ->
+        nil
+
       nil ->
         nil
     end

--- a/lib/oli_web/live/common/utils.ex
+++ b/lib/oli_web/live/common/utils.ex
@@ -73,6 +73,14 @@ defmodule OliWeb.Common.Utils do
     Float.round(score, 2)
   end
 
+  def format_score(score) when is_integer(score) do
+    score
+  end
+
+  def format_score(score) when is_nil(score) do
+    "-"
+  end
+
   defp has_value(v) do
     !is_nil(v) and v != ""
   end

--- a/lib/oli_web/live/progress/attempt_history.ex
+++ b/lib/oli_web/live/progress/attempt_history.ex
@@ -9,7 +9,7 @@ defmodule OliWeb.Progress.AttemptHistory do
 
   def render(assigns) do
     ~H"""
-    <div class="list-group">
+    <div class="list-group mb-5">
       <%= for attempt <- @resource_attempts do %>
         <PageAttemptSummary.render
           revision={@revision}

--- a/lib/oli_web/live/progress/page_attempt_summary.ex
+++ b/lib/oli_web/live/progress/page_attempt_summary.ex
@@ -72,7 +72,7 @@ defmodule OliWeb.Progress.PageAttemptSummary do
       >
         <div class="d-flex w-100 justify-content-between">
           <h5 class="mb-1">Attempt <%= @attempt.attempt_number %></h5>
-          <span><%= Utils.format_score(@attempt.score) %> / <%= @attempt.out_of %></span>
+          <span><%= Utils.format_score(@attempt.score) %> / <%= @attempt.out_of || "-" %></span>
         </div>
         <div class="d-flex flex-row">
           <%= if @attempt.was_late do %>

--- a/lib/oli_web/live/progress/student_resource_view.ex
+++ b/lib/oli_web/live/progress/student_resource_view.ex
@@ -44,6 +44,13 @@ defmodule OliWeb.Progress.StudentResourceView do
             ctx = SessionContext.init(socket, session)
             resource_access = get_resource_access(resource_id, section_slug, user_id)
 
+            resource_attempts =
+              unless is_nil(resource_access),
+                do:
+                  resource_access.resource_attempts
+                  |> Enum.sort(&(&1.attempt_number < &2.attempt_number)),
+                else: []
+
             changeset =
               case resource_access do
                 nil ->
@@ -68,6 +75,7 @@ defmodule OliWeb.Progress.StudentResourceView do
                breadcrumbs: set_breadcrumbs(type, section, user_id),
                section: section,
                resource_access: resource_access,
+               resource_attempts: resource_attempts,
                revision: revision,
                last_failed: fetch_last_failed(resource_access),
                user: user,
@@ -211,7 +219,7 @@ defmodule OliWeb.Progress.StudentResourceView do
         <AttemptHistory.render
           revision={@revision}
           section={@section}
-          resource_attempts={@resource_access.resource_attempts}
+          resource_attempts={@resource_attempts}
           ctx={@ctx}
         />
       </Group.render>

--- a/test/oli_web/live/progress_live_test.exs
+++ b/test/oli_web/live/progress_live_test.exs
@@ -133,38 +133,53 @@ defmodule OliWeb.ProgressLiveTest do
 
       date_now = DateTime.utc_now()
 
-      insert(:resource_attempt,
-        revision: revision,
-        resource_access: resource_access,
-        score: first_attempt.score,
-        out_of: out_of,
-        lifecycle_state: "evaluated",
-        date_submitted: date_now,
-        date_evaluated: date_now
-      )
+      attempt_1 =
+        insert(:resource_attempt,
+          revision: revision,
+          resource_access: resource_access,
+          score: first_attempt.score,
+          out_of: out_of,
+          lifecycle_state: "evaluated",
+          date_submitted: date_now,
+          date_evaluated: date_now
+        )
 
-      insert(:resource_attempt,
-        revision: revision,
-        resource_access: resource_access,
-        score: second_attempt.score,
-        out_of: out_of,
-        lifecycle_state: "evaluated",
-        date_submitted: date_now,
-        date_evaluated: date_now
-      )
+      attempt_2 =
+        insert(:resource_attempt,
+          revision: revision,
+          resource_access: resource_access,
+          score: second_attempt.score,
+          out_of: out_of,
+          lifecycle_state: "evaluated",
+          date_submitted: date_now,
+          date_evaluated: date_now
+        )
 
-      insert(:resource_attempt,
-        revision: revision,
-        resource_access: resource_access,
-        score: third_attempt.score,
-        out_of: out_of,
-        lifecycle_state: "evaluated",
-        date_submitted: date_now,
-        date_evaluated: date_now
-      )
+      attempt_3 =
+        insert(:resource_attempt,
+          revision: revision,
+          resource_access: resource_access,
+          score: third_attempt.score,
+          out_of: out_of,
+          lifecycle_state: "evaluated",
+          date_submitted: date_now,
+          date_evaluated: date_now
+        )
 
       {:ok, view, _html} =
         live(conn, live_view_student_resource_route(section.slug, student.id, resource.id))
+
+      assert view
+             |> element(".list-group .list-group-item:nth-child(1)")
+             |> render =~ "Attempt #{attempt_1.attempt_number}"
+
+      assert view
+             |> element(".list-group .list-group-item:nth-child(2)")
+             |> render =~ "Attempt #{attempt_2.attempt_number}"
+
+      assert view
+             |> element(".list-group .list-group-item:nth-child(3)")
+             |> render =~ "Attempt #{attempt_3.attempt_number}"
 
       assert has_element?(view, "span", "#{first_attempt.formatted} / #{out_of}")
       assert has_element?(view, "span", "#{second_attempt.formatted} / #{out_of}")


### PR DESCRIPTION
[MER-3008](https://eliterate.atlassian.net/browse/MER-3008)

This PR fixes the order of the list of student attempts in the resource progress view. 

For this, the resource attempts are obtained and ordered by attempt number, and then displayed in order when they are rendered.

![Captura de pantalla 2024-03-14 a la(s) 10 49 29](https://github.com/Simon-Initiative/oli-torus/assets/16328384/fec5c538-5600-48a7-b385-3edff8a4d502)


[MER-3008]: https://eliterate.atlassian.net/browse/MER-3008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ