### PR TITLE
[BUGFIX][MER-2433] Fixes recommended action link to approve pending posts 

### DIFF
--- a/lib/oli_web/components/delivery/recommended_actions.ex
+++ b/lib/oli_web/components/delivery/recommended_actions.ex
@@ -1,4 +1,5 @@
 defmodule OliWeb.Components.Delivery.RecommendedActions do
+  use OliWeb, :verified_routes
   use Phoenix.Component
 
   alias OliWeb.Router.Helpers, as: Routes
@@ -55,7 +56,7 @@ defmodule OliWeb.Components.Delivery.RecommendedActions do
         </.action_card>
       <% end %>
       <%= if @approval_pending_posts_count > 0 do %>
-        <.action_card to={Routes.page_delivery_path(OliWeb.Endpoint, :discussion, @section_slug)}>
+        <.action_card to={~p"/sections/#{@section_slug}/instructor_dashboard/discussions"}>
           <:icon><i class="fa-solid fa-circle-check" /></:icon>
           <:title>Approve Pending Posts</:title>
           <:description>

--- a/test/oli_web/live/delivery/instructor_dashboard/overview/recommended_actions_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/overview/recommended_actions_tab_test.exs
@@ -102,6 +102,47 @@ defmodule OliWeb.Delivery.InstructorDashboard.Overview.RecommendedActionsTest do
              )
     end
 
+    test "redirects to discussion activity tab when click to approve pending posts", %{
+      conn: conn,
+      section: section,
+      section_page: section_page
+    } do
+      user = insert(:user)
+
+      # create a pending post
+      post =
+        insert(:post,
+          content: %{message: "Example Post Content 1"},
+          section: section,
+          resource: section_page.resource,
+          user: user,
+          status: :submitted
+        )
+
+      # access to recommended actions tab to see the pending post
+      {:ok, view, _html} = live(conn, instructor_course_content_path(section.slug))
+
+      assert has_element?(view, "h4", "Approve Pending Posts")
+
+      assert has_element?(
+               view,
+               "span",
+               "You have 1 discussion post that is pending your approval"
+             )
+
+      # click to approve pending posts (redirect to discussion activity tab)
+      view
+      |> element("a[href=\"/sections/#{section.slug}/instructor_dashboard/discussions\"]")
+      |> render_click()
+
+      # check if the pending post is displayed in the discussion activity tab
+      {:ok, view, _html} =
+        live(conn, ~p"/sections/#{section.slug}/instructor_dashboard/discussions")
+
+      assert has_element?(view, "h4", "Discussion Activity")
+      assert has_element?(view, "p[class=\"torus-p\"]", post.content.message)
+    end
+
     test "renders the \"score questions\" action when necessary", %{
       conn: conn,
       section: section,


### PR DESCRIPTION
[MER-2433](https://eliterate.atlassian.net/browse/MER-2433)

This PR fixes the route that has the access to `Approve Pending Posts` within the `Recommended Actions` tab in the instructor dashboard view. 

The issue was that this element was redirected to a student route, in a wrong way.

https://github.com/Simon-Initiative/oli-torus/assets/16328384/d2b5b82d-c20f-43b0-b54e-c027fe40c4b8



[MER-2433]: https://eliterate.atlassian.net/browse/MER-2433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ