### PR TITLE
[MER-3071] Fix datashop export database timeout issue

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -51,7 +51,7 @@ if config_env() == :prod do
   maybe_ipv6 = if System.get_env("ECTO_IPV6") in ~w(true 1), do: [:inet6], else: []
 
   db_timeout =
-    case get_env_as_string("DB_TIMEOUT", "600000") do
+    case get_env_as_string.("DB_TIMEOUT", "600000") do
       "infinity" -> :infinity
       val -> String.to_integer(val)
     end


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-3071

This is a fix for the datashop generation error related to database connection timing out on large courses. There are 2 changes here:

1. Add the ability to configure this timeout system-wide with an environment variable
2. Set the specific datashop query transaction timeout to infinity, thereby using as much time as needed to generate.

When tested on heliotron with the Chemistry course with ~300 enrollments, this operation took about 3 hours. While this effectively consumes a database connection for that period, we can limit the number of simultaneous datashop jobs that run at a time so that the system doesn't starve itself of database connections (currently, the `datashop_export` queue is configured to 3).

These changes were tested against v0.26.5 but rebased with master for this PR