### PR TITLE
[MER-3068] Bug fix where accessing course material give a 500 error

### DIFF
--- a/lib/oli/authoring/clone.ex
+++ b/lib/oli/authoring/clone.ex
@@ -144,9 +144,19 @@ defmodule Oli.Authoring.Clone do
     attributes =
       case base_project.attributes do
         nil -> nil
-        base_attributes -> Map.from_struct(base_attributes)
+        base_attributes -> from_struct(base_attributes)
       end
 
     {:ok, customizations, attributes}
   end
+
+  defp from_struct(attribute) when is_map(attribute) do
+    Map.from_struct(attribute)
+    |> Map.keys()
+    |> Enum.reduce(%{}, fn key, acc ->
+      Map.put(acc, key, from_struct(Map.get(attribute, key)))
+    end)
+  end
+
+  defp from_struct(attribute), do: attribute
 end

--- a/lib/oli/authoring/course.ex
+++ b/lib/oli/authoring/course.ex
@@ -574,16 +574,17 @@ defmodule Oli.Authoring.Course do
 
   @type license_types ::
           :none | :cc_by | :cc_by_sa | :cc_by_nd | :cc_by_nc | :cc_by_nc_sa | :cc_by_nc_nd
-  @spec get_project_license(integer()) ::
+  @spec get_project_license(integer(), String.t()) ::
           %{license_type: :custom, custom_license_details: String.t()}
           | %{license_type: license_types, custom_license_details: <<>>}
           | nil
-  def get_project_license(revision_id) do
+  def get_project_license(revision_id, section_slug) do
     from(pr in PublishedResource,
       join: spp in SectionsProjectsPublications,
       on: pr.publication_id == spp.publication_id,
       join: p in assoc(spp, :project),
-      where: pr.revision_id == ^revision_id,
+      join: s in assoc(spp, :section),
+      where: pr.revision_id == ^revision_id and s.slug == ^section_slug,
       distinct: true,
       select: p.attributes
     )

--- a/lib/oli/delivery/page/page_context.ex
+++ b/lib/oli/delivery/page/page_context.ex
@@ -232,7 +232,7 @@ defmodule Oli.Delivery.Page.PageContext do
 
     user_roles = Sections.get_user_roles(user, section_slug)
 
-    license = Oli.Authoring.Course.get_project_license(page_revision.id)
+    license = Oli.Authoring.Course.get_project_license(page_revision.id, section_slug)
 
     %PageContext{
       license: license,

--- a/test/oli/course_test.exs
+++ b/test/oli/course_test.exs
@@ -267,7 +267,7 @@ defmodule Oli.CourseTest do
       Sections.update_section_project_publication(section, project.id, publication.id)
 
       assert %{license_type: :cc_by, custom_license_details: nil} =
-               Oli.Authoring.Course.get_project_license(page.id)
+               Oli.Authoring.Course.get_project_license(page.id, section.slug)
     end
 
     test "returns map for custom license", %{
@@ -288,11 +288,11 @@ defmodule Oli.CourseTest do
       Sections.update_section_project_publication(section, project.id, publication.id)
 
       assert %{license_type: :custom, custom_license_details: ^custom_license_msg} =
-               Oli.Authoring.Course.get_project_license(page.id)
+               Oli.Authoring.Course.get_project_license(page.id, section.slug)
     end
 
-    test "returns nil when no attributes are present", %{page: page} do
-      refute Oli.Authoring.Course.get_project_license(page.id)
+    test "returns nil when no attributes are present", %{page: page, section: section} do
+      refute Oli.Authoring.Course.get_project_license(page.id, section.slug)
     end
   end
 end


### PR DESCRIPTION
This PR addresses an issue where the query to fetch a project license results in multiple results where one is expected. It also addresses an issue where cloning a project fails when a license is added to it.