### PR TITLE
[MER-2986] Formatting difficult

### DIFF
--- a/assets/src/components/content/TitleBar.tsx
+++ b/assets/src/components/content/TitleBar.tsx
@@ -51,7 +51,7 @@ export const TitleBar = (props: TitleBarProps) => {
             setTitleBarHeight(boundingClientRect.height);
           }
         }}
-        className={classNames('TitleBar', 'sticky w-100 align-items-baseline z-40', className)}
+        className={classNames('TitleBar', 'w-100 align-items-baseline z-40', className)}
         style={{ top: workspaceHeaderHeight }}
       >
         <div

--- a/lib/oli_web/live/breadcrumb/breadcrumb_live.ex
+++ b/lib/oli_web/live/breadcrumb/breadcrumb_live.ex
@@ -10,7 +10,7 @@ defmodule OliWeb.Breadcrumb.BreadcrumbLive do
 
   defp render_breadcrumb(%{is_last: true} = assigns) do
     ~H"""
-    <li class="breadcrumb-item active" aria-current="page">
+    <li class="breadcrumb-item active truncate" aria-current="page">
       <%= get_title(@breadcrumb, @show_short) %>
     </li>
     """

--- a/lib/oli_web/templates/layout/_workspace_header.html.eex
+++ b/lib/oli_web/templates/layout/_workspace_header.html.eex
@@ -1,7 +1,7 @@
 
-<div class="workspace-header-container flex-1 flex flex-column shadow">
+<div class="workspace-header-container flex-1 flex flex-column shadow overflow-x-clip">
   <div class="workspace-header flex-grow-1 flex flex-row flex-nowrap px-6 <%= if Map.has_key?(@conn.assigns, :breadcrumbs) and length(@breadcrumbs) > 0, do: "with-breadcrumbs", else: "" %>">
-    <h3><%= if Map.has_key?(@conn.assigns, :breadcrumbs) and length(@breadcrumbs) > 0, do: hd(Enum.reverse(@breadcrumbs)).short_title, else: @title %></h3>
+    <h3 class="truncate"><%= if Map.has_key?(@conn.assigns, :breadcrumbs) and length(@breadcrumbs) > 0, do: hd(Enum.reverse(@breadcrumbs)).short_title, else: @title %></h3>
     <div class="flex-1"></div>
     <div>
       <%= render OliWeb.SharedView, "_help_button.html", conn: @conn %>

--- a/lib/oli_web/templates/shared/_help_button.html.eex
+++ b/lib/oli_web/templates/shared/_help_button.html.eex
@@ -1,4 +1,4 @@
 <!-- Button trigger modal -->
-<button type="button" class="btn btn-xs btn-light inline-flex items-center help-btn m-1" onclick="window.showHelpModal();">
+<button type="button" class="btn btn-xs btn-light inline-flex items-center help-btn m-1 whitespace-nowrap" onclick="window.showHelpModal();">
   <span>Tech Support</span>
 </button>

--- a/test/oli_web/controllers/project_controller_test.exs
+++ b/test/oli_web/controllers/project_controller_test.exs
@@ -36,7 +36,7 @@ defmodule OliWeb.ProjectControllerTest do
 
       conn = get(conn, Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.ProjectsLive))
 
-      assert html_response(conn, 200) =~ "<h3>Projects</h3>"
+      assert html_response(conn, 200) =~ "<h3 class=\"truncate\">Projects</h3>"
     end
   end
 

--- a/test/oli_web/controllers/resource_controller_test.exs
+++ b/test/oli_web/controllers/resource_controller_test.exs
@@ -13,6 +13,28 @@ defmodule OliWeb.ResourceControllerTest do
                "<div data-react-class=\"Components.PageEditor\" data-react-props=\""
     end
 
+    test "renders truncate title when page title is too long", %{
+      conn: conn,
+      project: project,
+      revision1: revision
+    } do
+      conn = get(conn, Routes.resource_path(conn, :edit, project.slug, revision.slug))
+
+      assert html_response(conn, 200) =~
+               "<h3 class=\"truncate\">#{revision.title}</h3>"
+    end
+
+    test "renders truncate breadcrumbs when page title is too long", %{
+      conn: conn,
+      project: project,
+      revision1: revision
+    } do
+      conn = get(conn, Routes.resource_path(conn, :edit, project.slug, revision.slug))
+
+      assert html_response(conn, 200) =~
+               "<li class=\"breadcrumb-item active truncate\" aria-current=\"page\">\n  #{revision.title}\n</li>"
+    end
+
     test "renders adaptive editor", %{
       conn: conn,
       project: project,


### PR DESCRIPTION
[MER-2986](https://eliterate.atlassian.net/browse/MER-2986)

This PR performs some styling changes on elements of the edit view of a project curriculum page. 

- Remove the `sticky` class so that the page title is not always fixed at the top of the view.
- Added a `truncate` class to the view title so that ellipses are added to the page title if it is too long.
- A`truncate` class is added to the page breadcrumb title so that ellipses are added to the title if it is too long.


https://github.com/Simon-Initiative/oli-torus/assets/16328384/7f259458-c07f-48a8-9bd3-f32819720fe3





[MER-2986]: https://eliterate.atlassian.net/browse/MER-2986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ