### PR TITLE
Mer 2859 captcha fix for tour it vr users support

### DIFF
--- a/lib/oli/accounts/schemas/vr_user_agent.ex
+++ b/lib/oli/accounts/schemas/vr_user_agent.ex
@@ -1,0 +1,20 @@
+defmodule Oli.Accounts.VrUserAgent do
+  use Ecto.Schema
+  import Ecto.Changeset
+  alias __MODULE__
+
+  schema "vr_user_agents" do
+    field :user_agent, :string
+  end
+
+  def new_changeset(attrs \\ %{}) do
+    changeset(%VrUserAgent{}, attrs)
+  end
+
+  def changeset(item, attrs \\ %{}) do
+    item
+    |> cast(attrs, [:user_agent])
+    |> validate_required([:user_agent])
+    |> unique_constraint(:user_agent, name: :vr_user_agents_user_agent_index)
+  end
+end

--- a/lib/oli/application.ex
+++ b/lib/oli/application.ex
@@ -60,7 +60,8 @@ defmodule Oli.Application do
         Oli.AccountLookupCache,
         # Starts Cachex to store datashop export info
         Oli.DatashopCache,
-
+        # Starts Cachex to store vr user agents
+        Oli.VrLookupCache,
         # a supervisor which can be used to dynamically supervise tasks
         {Task.Supervisor, name: Oli.TaskSupervisor}
       ] ++ maybe_node_js_config()

--- a/lib/oli/vr_lookup_cache.ex
+++ b/lib/oli/vr_lookup_cache.ex
@@ -1,0 +1,22 @@
+defmodule Oli.VrLookupCache do
+  use Agent
+  alias Oli.VrUserAgents
+
+  def start_link(_init_args) do
+    Agent.start_link(fn -> VrUserAgents.all() end, name: __MODULE__)
+  end
+
+  def exists(value) do
+    Agent.get(__MODULE__, fn state -> exists_user_agent_in_cache(state, value) end)
+  end
+
+  def reload() do
+    Agent.update(__MODULE__, fn _state -> VrUserAgents.all() end)
+  end
+
+  defp exists_user_agent_in_cache(state, value) do
+    Enum.reduce_while(state, false, fn %{user_agent: user_agent}, acc ->
+      if user_agent == value, do: {:halt, true}, else: {:cont, acc}
+    end)
+  end
+end

--- a/lib/oli/vr_user_agents.ex
+++ b/lib/oli/vr_user_agents.ex
@@ -1,0 +1,56 @@
+defmodule Oli.VrUserAgents do
+  @doc """
+  This module is responsible for managing the VR user agents.
+  """
+  import Ecto.Query, warn: false
+  alias Oli.Accounts.VrUserAgent
+  alias Oli.Repo
+
+  @spec count() :: integer()
+  def count(), do: Repo.aggregate(VrUserAgent, :count)
+
+  @spec get(integer) :: VrUserAgent.t() | nil
+  def get(user_id), do: Repo.get(VrUserAgent, user_id)
+
+  @spec insert(map()) :: {:ok, VrUserAgent.t()} | {:error, Ecto.Changeset.t()}
+  def insert(data) do
+    VrUserAgent.new_changeset(data)
+    |> Oli.Repo.insert()
+    |> tap(fn _ -> Oli.VrLookupCache.reload() end)
+  end
+
+  @spec delete(integer) :: {:ok, VrUserAgent.t()} | {:error, Ecto.Changeset.t()}
+  def delete(user_id) do
+    get(user_id)
+    |> Repo.delete()
+    |> tap(fn _ -> Oli.VrLookupCache.reload() end)
+  end
+
+  @spec vr_user_agents(Keyword.t()) :: [map()] | []
+  def vr_user_agents(opts \\ []) do
+    {order, column} =
+      case Keyword.get(opts, :sort) do
+        {order, column} when order in [:desc, :asc] and column in ["id", "user_agent"] ->
+          {order, String.to_existing_atom(column)}
+
+        _ ->
+          {:asc, :id}
+      end
+
+    %{limit: limit, offset: offset} =
+      case Keyword.get(opts, :paginate) do
+        %{limit: _limit, offset: _offset} = paginate -> paginate
+        _ -> %{limit: 10, offset: 0}
+      end
+
+    from(vrua in VrUserAgent,
+      order_by: [{^order, field(vrua, ^column)}],
+      select: %{id: vrua.id, user_agent: vrua.user_agent},
+      limit: ^limit,
+      offset: ^offset
+    )
+    |> Repo.all()
+  end
+
+  def all(), do: Repo.all(VrUserAgent)
+end

--- a/lib/oli/vr_user_agents.ex
+++ b/lib/oli/vr_user_agents.ex
@@ -16,14 +16,12 @@ defmodule Oli.VrUserAgents do
   def insert(data) do
     VrUserAgent.new_changeset(data)
     |> Oli.Repo.insert()
-    |> tap(fn _ -> Oli.VrLookupCache.reload() end)
   end
 
   @spec delete(integer) :: {:ok, VrUserAgent.t()} | {:error, Ecto.Changeset.t()}
   def delete(user_id) do
     get(user_id)
     |> Repo.delete()
-    |> tap(fn _ -> Oli.VrLookupCache.reload() end)
   end
 
   @spec vr_user_agents(Keyword.t()) :: [map()] | []

--- a/lib/oli_web/live/admin/admin_view.ex
+++ b/lib/oli_web/live/admin/admin_view.ex
@@ -60,11 +60,6 @@ defmodule OliWeb.Admin.AdminView do
                 Manage LTI 1.3 Registrations
               </a>
             </li>
-            <li>
-              <a href={~p"/admin/vr_user_agents"}>
-                Manage VR User Agents
-              </a>
-            </li>
           </ul>
         </Group.render>
       <% end %>
@@ -138,6 +133,11 @@ defmodule OliWeb.Admin.AdminView do
               <a href={Routes.live_dashboard_path(OliWeb.Endpoint, :home)} target="_blank">
                 <span>View System Performance Dashboard</span>
                 <i class="fas fa-external-link-alt self-center ml-1"></i>
+              </a>
+            </li>
+            <li>
+              <a href={~p"/admin/vr_user_agents"}>
+                Manage VR User Agents
               </a>
             </li>
           </ul>

--- a/lib/oli_web/live/admin/admin_view.ex
+++ b/lib/oli_web/live/admin/admin_view.ex
@@ -60,6 +60,11 @@ defmodule OliWeb.Admin.AdminView do
                 Manage LTI 1.3 Registrations
               </a>
             </li>
+            <li>
+              <a href={~p"/admin/vr_user_agents"}>
+                Manage VR User Agents
+              </a>
+            </li>
           </ul>
         </Group.render>
       <% end %>

--- a/lib/oli_web/live/admin/vr_user_agents_view.ex
+++ b/lib/oli_web/live/admin/vr_user_agents_view.ex
@@ -45,10 +45,7 @@ defmodule OliWeb.Admin.VrUserAgentsView do
             autofocus
             class="w-full focus:ring-2 focus:ring-blue-300 rounded-lg text-sm px-5 py-1.5 dark:bg-gray-800"
           />
-          <button
-            type="submit"
-            class="w-1/12 px-3 py-2 text-sm font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:outline-none dark:bg-blue-600 dark:hover:bg-blue-700"
-          >
+          <button type="submit" class="form-button btn btn-md btn-primary btn-block mt-3">
             Add
           </button>
         </div>
@@ -88,7 +85,7 @@ defmodule OliWeb.Admin.VrUserAgentsView do
                 type="button"
                 phx-click="delete_vr_entry"
                 phx-value-id={vr_user_agent.id}
-                class="focus:outline-none text-white bg-red-700 hover:bg-red-800 focus:ring-4 focus:ring-red-300 font-medium rounded-lg text-sm px-5 py-1.5 me-2 dark:bg-red-600 dark:hover:bg-red-700 dark:focus:ring-red-900"
+                class="form-button btn btn-md btn-danger btn-block mt-3"
               >
                 Delete
               </button>

--- a/lib/oli_web/live/admin/vr_user_agents_view.ex
+++ b/lib/oli_web/live/admin/vr_user_agents_view.ex
@@ -1,0 +1,201 @@
+defmodule OliWeb.Admin.VrUserAgentsView do
+  alias Oli.Accounts.VrUserAgent
+  use OliWeb, :live_view
+
+  alias Oli.VrUserAgents
+  alias OliWeb.Common.Breadcrumb
+  alias OliWeb.Common.Paging
+  alias Phoenix.LiveView.JS
+
+  @limit 10
+  @initial_sort {:asc, "user_agent"}
+  @initial_paginate %{limit: @limit, offset: 0}
+
+  defp columns_title_data, do: [{"id", "ID"}, {"user_agent", "User agent"}, {"nil", "Delete"}]
+
+  def mount(_, _session, socket) do
+    data_manager = %{sort: @initial_sort, paginate: @initial_paginate}
+
+    vr_user_agents =
+      VrUserAgents.vr_user_agents(sort: data_manager.sort, paginate: data_manager.paginate)
+
+    form = VrUserAgent.new_changeset() |> to_form()
+
+    socket =
+      socket
+      |> assign(breadcrumbs: breadcrumb())
+      |> assign(vr_user_agents: vr_user_agents)
+      |> assign(form: form)
+      |> assign(data_manager: data_manager)
+      |> assign(total_count: VrUserAgents.count())
+
+    {:ok, socket}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <div>
+      <.form for={@form} phx-submit="add_user_agent" phx-change="change_content">
+        <div class="flex flex-col gap-2 w-full">
+          <.input
+            id="entered_text"
+            type="textarea"
+            field={@form[:user_agent]}
+            placeholder="Enter user agent to add"
+            autofocus
+            class="w-full focus:ring-2 focus:ring-blue-300 rounded-lg text-sm px-5 py-1.5 dark:bg-gray-800"
+          />
+          <button
+            type="submit"
+            class="w-1/12 px-3 py-2 text-sm font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:outline-none dark:bg-blue-600 dark:hover:bg-blue-700"
+          >
+            Add
+          </button>
+        </div>
+      </.form>
+      <Paging.render
+        id="header_paging"
+        total_count={@total_count}
+        offset={@data_manager.paginate.offset}
+        limit={@data_manager.paginate.limit}
+        click={JS.push("paged_table_page_change")}
+      />
+      <table class="min-w-full border ">
+        <thead>
+          <tr>
+            <th
+              :for={{sort_field, col_title} <- columns_title_data()}
+              phx-click="sort_by"
+              phx-value-sort-column={sort_field}
+            >
+              <%= col_title %>
+              <% sort_data = @data_manager[:sort] %>
+              <i :if={match?(^sort_data, {:asc, sort_field})} class="fa fa-sort-up"></i>
+              <i :if={match?(^sort_data, {:desc, sort_field})} class="fa fa-sort-down"></i>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr :for={vr_user_agent <- @vr_user_agents}>
+            <td class="mx-auto text-center">
+              <%= vr_user_agent.id %>
+            </td>
+            <td class="mx-auto text-center">
+              <%= vr_user_agent.user_agent %>
+            </td>
+            <td class="mx-auto text-center">
+              <button
+                type="button"
+                phx-click="delete_vr_entry"
+                phx-value-id={vr_user_agent.id}
+                class="focus:outline-none text-white bg-red-700 hover:bg-red-800 focus:ring-4 focus:ring-red-300 font-medium rounded-lg text-sm px-5 py-1.5 me-2 dark:bg-red-600 dark:hover:bg-red-700 dark:focus:ring-red-900"
+              >
+                Delete
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    """
+  end
+
+  def handle_event("paged_table_page_change", %{"offset" => offset}, socket) do
+    data_manager = %{
+      socket.assigns.data_manager
+      | paginate: %{limit: @limit, offset: String.to_integer(offset)}
+    }
+
+    socket =
+      socket
+      |> reload_vr_user_agents(data_manager)
+      |> assign(data_manager: data_manager)
+
+    {:noreply, socket}
+  end
+
+  def handle_event("change_content", %{"vr_user_agent" => %{"user_agent" => user_agent}}, socket) do
+    form =
+      %VrUserAgent{}
+      |> VrUserAgent.changeset(%{user_agent: user_agent})
+      |> to_form()
+
+    {:noreply, assign(socket, form: form)}
+  end
+
+  def handle_event("sort_by", %{"sort-column" => column}, socket)
+      when column in ["id", "user_agent"] do
+    {previous_direction, previous_sort_column} = socket.assigns.data_manager.sort
+
+    data_manager =
+      if column == previous_sort_column do
+        %{socket.assigns.data_manager | sort: {i(previous_direction), column}}
+      else
+        %{socket.assigns.data_manager | sort: {:asc, column}}
+      end
+
+    socket =
+      socket
+      |> reload_vr_user_agents(data_manager)
+      |> assign(data_manager: data_manager)
+
+    {:noreply, socket}
+  end
+
+  def handle_event("sort_by", _, socket) do
+    {:noreply, socket}
+  end
+
+  def handle_event(
+        "add_user_agent",
+        %{"vr_user_agent" => %{"user_agent" => user_agent}},
+        socket
+      ) do
+    {socket.assigns.data_manager.sort, socket.assigns.data_manager.paginate}
+
+    case VrUserAgents.insert(%{user_agent: String.trim(user_agent)}) do
+      {:ok, _} ->
+        form = VrUserAgent.new_changeset() |> to_form()
+        {:noreply, reload_vr_user_agents(socket) |> assign(form: form)}
+
+      {:error, changeset} ->
+        {:noreply, assign(socket, form: to_form(changeset))}
+    end
+  end
+
+  def handle_event("delete_vr_entry", %{"id" => id}, socket) do
+    case VrUserAgents.delete(id) do
+      {:ok, _} ->
+        form = VrUserAgent.new_changeset() |> to_form()
+        {:noreply, reload_vr_user_agents(socket) |> assign(form: form)}
+
+      {:error, changeset} ->
+        {:noreply, assign(socket, form: changeset)}
+    end
+  end
+
+  def reload_vr_user_agents(socket) do
+    vr_user_agents =
+      VrUserAgents.vr_user_agents(
+        sort: socket.assigns.data_manager.sort,
+        paginate: socket.assigns.data_manager.paginate
+      )
+
+    assign(socket, vr_user_agents: vr_user_agents, total_count: VrUserAgents.count())
+  end
+
+  def reload_vr_user_agents(socket, data_manager) do
+    vr_user_agents =
+      VrUserAgents.vr_user_agents(sort: data_manager.sort, paginate: data_manager.paginate)
+
+    assign(socket, vr_user_agents: vr_user_agents, total_count: VrUserAgents.count())
+  end
+
+  defp i(:desc), do: :asc
+  defp i(:asc), do: :desc
+
+  defp breadcrumb(),
+    do:
+      OliWeb.Admin.AdminView.breadcrumb() ++
+        [Breadcrumb.new(%{full_title: "VR User Agents", link: ~p"/admin"})]
+end

--- a/lib/oli_web/live/admin/vr_user_agents_view.ex
+++ b/lib/oli_web/live/admin/vr_user_agents_view.ex
@@ -45,10 +45,10 @@ defmodule OliWeb.Admin.VrUserAgentsView do
             autofocus
             class="w-full focus:ring-2 focus:ring-blue-300 rounded-lg text-sm px-5 py-1.5 dark:bg-gray-800"
           />
-          <button type="submit" class="form-button btn btn-md btn-primary btn-block mt-3">
-            Add
-          </button>
         </div>
+        <button type="submit" class="form-button btn btn-md btn-primary mt-3">
+          Add
+        </button>
       </.form>
       <Paging.render
         id="header_paging"
@@ -85,7 +85,7 @@ defmodule OliWeb.Admin.VrUserAgentsView do
                 type="button"
                 phx-click="delete_vr_entry"
                 phx-value-id={vr_user_agent.id}
-                class="form-button btn btn-md btn-danger btn-block mt-3"
+                class="form-button btn btn-md btn-danger mt-3"
               >
                 Delete
               </button>
@@ -153,6 +153,9 @@ defmodule OliWeb.Admin.VrUserAgentsView do
     case VrUserAgents.insert(%{user_agent: String.trim(user_agent)}) do
       {:ok, _} ->
         form = VrUserAgent.new_changeset() |> to_form()
+
+        Oli.VrLookupCache.reload()
+
         {:noreply, reload_vr_user_agents(socket) |> assign(form: form)}
 
       {:error, changeset} ->
@@ -164,6 +167,9 @@ defmodule OliWeb.Admin.VrUserAgentsView do
     case VrUserAgents.delete(id) do
       {:ok, _} ->
         form = VrUserAgent.new_changeset() |> to_form()
+
+        Oli.VrLookupCache.reload()
+
         {:noreply, reload_vr_user_agents(socket) |> assign(form: form)}
 
       {:error, changeset} ->

--- a/lib/oli_web/plugs/set_vr_agent_value.ex
+++ b/lib/oli_web/plugs/set_vr_agent_value.ex
@@ -1,0 +1,22 @@
+defmodule Oli.Plugs.SetVrAgentValue do
+  import Plug.Conn
+
+  def init(_params), do: nil
+
+  def call(conn, _params) do
+    with user_agent when not is_nil(user_agent) <-
+           get_user_agent_from_req_headers?(conn.req_headers),
+         true <- Oli.VrLookupCache.exists(user_agent) do
+      assign(conn, :vr_agent_active, true)
+    else
+      _ ->
+        conn
+    end
+  end
+
+  defp get_user_agent_from_req_headers?(req_headers) do
+    Enum.reduce_while(req_headers, nil, fn {k, v}, acc ->
+      if k == "user-agent", do: {:halt, v}, else: {:cont, acc}
+    end)
+  end
+end

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -92,6 +92,7 @@ defmodule OliWeb.Router do
     )
 
     plug(Oli.Plugs.SetCurrentUser)
+    plug(Oli.Plugs.SetVrAgentValue)
   end
 
   # set the layout to be workspace
@@ -1172,6 +1173,7 @@ defmodule OliWeb.Router do
 
     # General
     live("/", Admin.AdminView)
+    live("/vr_user_agents", Admin.VrUserAgentsView)
     live("/products", Products.ProductsView)
     live("/products/:product_id/discounts", Products.Payments.Discounts.ProductsIndexView)
     live("/collaborative_spaces", CollaborationLive.IndexView, :admin, as: :collab_spaces_index)

--- a/lib/oli_web/templates/layout/chromeless.html.eex
+++ b/lib/oli_web/templates/layout/chromeless.html.eex
@@ -46,7 +46,6 @@
     <!-- Janus Part Component external CSS Files -->
     <link rel="stylesheet" href="/css/janus_image_carousel_delivery.css"/>
 
-<% Map.get(assigns, :vr_agent_active) |> IO.inspect(label: "---A1") %>
     <%= unless Map.get(assigns, :vr_agent_active, false) do %>
       <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
     <% end %>

--- a/lib/oli_web/templates/layout/chromeless.html.eex
+++ b/lib/oli_web/templates/layout/chromeless.html.eex
@@ -46,7 +46,10 @@
     <!-- Janus Part Component external CSS Files -->
     <link rel="stylesheet" href="/css/janus_image_carousel_delivery.css"/>
 
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<% Map.get(assigns, :vr_agent_active) |> IO.inspect(label: "---A1") %>
+    <%= unless Map.get(assigns, :vr_agent_active, false) do %>
+      <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+    <% end %>
 
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/citation-js"></script>
     <script>

--- a/lib/oli_web/templates/layout/delivery.html.heex
+++ b/lib/oli_web/templates/layout/delivery.html.heex
@@ -112,8 +112,11 @@
     >
     </script>
 
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6">
-    </script>
+    <% Map.get(assigns, :vr_agent_active) |> IO.inspect(label: "---A2") %>
+    <%= unless Map.get(assigns, :vr_agent_active, false) do %>
+      <script src="https://polyfill.io/v3/polyfill.min.js?features=es6">
+      </script>
+    <% end %>
     <!-- ReCAPTCHA -->
     <script src="https://www.google.com/recaptcha/api.js">
     </script>

--- a/lib/oli_web/templates/layout/delivery.html.heex
+++ b/lib/oli_web/templates/layout/delivery.html.heex
@@ -112,7 +112,6 @@
     >
     </script>
 
-    <% Map.get(assigns, :vr_agent_active) |> IO.inspect(label: "---A2") %>
     <%= unless Map.get(assigns, :vr_agent_active, false) do %>
       <script src="https://polyfill.io/v3/polyfill.min.js?features=es6">
       </script>

--- a/lib/oli_web/templates/layout/delivery_from_payment.html.heex
+++ b/lib/oli_web/templates/layout/delivery_from_payment.html.heex
@@ -93,8 +93,11 @@
     >
     </script>
 
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6">
-    </script>
+    <% Map.get(assigns, :vr_agent_active) |> IO.inspect(label: "---A3") %>
+    <%= unless Map.get(assigns, :vr_agent_active, false) do %>
+      <script src="https://polyfill.io/v3/polyfill.min.js?features=es6">
+      </script>
+    <% end %>
     <!-- ReCAPTCHA -->
     <script src="https://www.google.com/recaptcha/api.js">
     </script>

--- a/lib/oli_web/templates/layout/delivery_from_payment.html.heex
+++ b/lib/oli_web/templates/layout/delivery_from_payment.html.heex
@@ -93,7 +93,6 @@
     >
     </script>
 
-    <% Map.get(assigns, :vr_agent_active) |> IO.inspect(label: "---A3") %>
     <%= unless Map.get(assigns, :vr_agent_active, false) do %>
       <script src="https://polyfill.io/v3/polyfill.min.js?features=es6">
       </script>

--- a/priv/repo/migrations/20240306095920_create_vr_user_agents_table.exs
+++ b/priv/repo/migrations/20240306095920_create_vr_user_agents_table.exs
@@ -1,0 +1,11 @@
+defmodule Oli.Repo.Migrations.CreateVrUserAgentsTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:vr_user_agents) do
+      add :user_agent, :string, null: false
+    end
+
+    create unique_index(:vr_user_agents, :user_agent)
+  end
+end

--- a/test/oli/vr_user_agents_test.exs
+++ b/test/oli/vr_user_agents_test.exs
@@ -1,0 +1,100 @@
+defmodule Oli.VrUserAgentsTest do
+  alias Oli.VrLookupCache
+  alias Oli.VrUserAgents
+  alias Oli.Accounts.VrUserAgent
+  use Oli.DataCase
+  import Oli.Factory
+
+  setup do
+    user_agent_1 =
+      "Mozilla/5.0 (X11; Linux x86_64; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/16.0.0.4.13.298796165 SamsungBrowser/4.0 Chrome/91.0.4472.88 Safari/537.36"
+
+    user_agent_2 =
+      "Mozilla/5.0 (Linux; Android 10; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/16.6.0.1.52.314146309 SamsungBrowser/4.0 Chrome/91.0.4472.164 VR Safari/537.36"
+
+    %{user_agent_1: user_agent_1, user_agent_2: user_agent_2}
+  end
+
+  describe "count/0" do
+    test "returns the number of vr_user_agents", %{
+      user_agent_1: user_agent_1,
+      user_agent_2: user_agent_2
+    } do
+      assert VrUserAgents.count() == 0
+
+      for user_agent <- [user_agent_1, user_agent_2] do
+        insert(:vr_user_agent, user_agent: user_agent)
+      end
+
+      assert VrUserAgents.count() == 2
+    end
+  end
+
+  describe "get/1" do
+    test "returns the vr_user_agent with the given id", %{user_agent_1: user_agent_1} do
+      %{id: id} = vr_user_agent = insert(:vr_user_agent, user_agent: user_agent_1)
+
+      assert VrUserAgents.get(id) == vr_user_agent
+    end
+  end
+
+  describe "insert/1" do
+    test "inserts a new vr_user_agent", %{user_agent_1: user_agent_1} do
+      params = %{user_agent: user_agent_1}
+      {:ok, %{id: id, user_agent: user_agent}} = VrUserAgents.insert(params)
+
+      assert %VrUserAgent{id: ^id, user_agent: ^user_agent} = VrUserAgents.get(id)
+    end
+
+    test "returns an error changeset when the user_agent is not unique", %{
+      user_agent_1: user_agent_1
+    } do
+      insert(:vr_user_agent, user_agent: user_agent_1)
+
+      params = %{user_agent: user_agent_1}
+      {:error, changeset} = VrUserAgents.insert(params)
+
+      assert changeset.valid? == false
+      assert {"has already been taken", _} = changeset.errors[:user_agent]
+    end
+
+    test "returns an error changeset when the user_agent is not present", %{} do
+      params = %{user_agent: ""}
+      {:error, changeset} = VrUserAgents.insert(params)
+
+      assert changeset.valid? == false
+      assert {"can't be blank", _} = changeset.errors[:user_agent]
+    end
+  end
+
+  describe "delete/1" do
+    test "deletes the vr_user_agent with the given id", %{user_agent_1: user_agent_1} do
+      %{id: id} = _vr_user_agent = insert(:vr_user_agent, user_agent: user_agent_1)
+
+      VrUserAgents.delete(id)
+
+      assert VrUserAgents.get(id) == nil
+    end
+  end
+
+  # -----------------------
+  # Testing cache functions
+  # -----------------------
+
+  describe "reload/0" do
+    test "reloads the vr_user_agents cache", %{
+      user_agent_1: user_agent_1,
+      user_agent_2: user_agent_2
+    } do
+      for user_agent <- [user_agent_1, user_agent_2] do
+        insert(:vr_user_agent, user_agent: user_agent)
+      end
+
+      VrLookupCache.reload()
+
+      assert VrLookupCache.exists(user_agent_1)
+      assert VrLookupCache.exists(user_agent_2)
+      refute VrLookupCache.exists("unknown_value")
+    end
+  end
+end

--- a/test/oli_web/live/vr_user_agents_view_test.exs
+++ b/test/oli_web/live/vr_user_agents_view_test.exs
@@ -1,0 +1,94 @@
+defmodule OliWeb.Users.UsersDetailViewTest do
+  use OliWeb.ConnCase
+  import Phoenix.LiveViewTest
+  import Oli.Factory
+
+  @live_view_route Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.VrUserAgentsView)
+
+  describe "user cannot access when is not logged in" do
+    test "redirects to new session when accessing the vr_user_agents view", %{conn: conn} do
+      redirect_path = "/authoring/session/new?request_path=%2Fadmin%2Fvr_user_agents"
+
+      assert {:error, {:redirect, %{to: ^redirect_path}}} = live(conn, "/admin/vr_user_agents")
+    end
+  end
+
+  describe "users cannot access" do
+    setup [:user_conn]
+
+    test "redirects to authoring sign in", %{conn: conn} do
+      redirect_path = "/authoring/session/new?request_path=%2Fadmin%2Fvr_user_agents"
+
+      assert {:error, {:redirect, %{to: ^redirect_path}}} = live(conn, @live_view_route)
+    end
+  end
+
+  describe "admins can access" do
+    setup [:admin_conn]
+
+    test "loads vr_user_agents view correctly", %{conn: conn} do
+      {:ok, _view, html} = live(conn, @live_view_route)
+
+      assert html =~ "VR User Agents"
+    end
+  end
+
+  describe "Vr user agents view" do
+    setup [:admin_conn, :user_agents_data]
+
+    test "user interaction", %{
+      conn: conn,
+      user_agent_1: user_agent_1,
+      user_agent_2: user_agent_2
+    } do
+      %{id: id_1, user_agent: user_agent_value_1} =
+        insert(:vr_user_agent, user_agent: user_agent_1)
+
+      %{id: id_2, user_agent: user_agent_value_2} =
+        insert(:vr_user_agent, user_agent: user_agent_2)
+
+      {:ok, view, _html} = live(conn, @live_view_route)
+
+      assert [[^id_2, ^user_agent_value_2, "Delete"], [^id_1, ^user_agent_value_1, "Delete"]] =
+               extract_rows_data(view)
+
+      # Delete the second user agent
+      view |> element("tbody tr:nth-of-type(1) td:nth-of-type(3) button") |> render_click()
+
+      assert [[^id_1, ^user_agent_value_1, "Delete"]] = extract_rows_data(view)
+
+      # Adds back the user agent 2
+      view
+      |> element("form[phx-submit=\"add_user_agent\"]")
+      |> render_submit(%{"vr_user_agent" => %{"user_agent" => user_agent_value_2}})
+
+      assert [[_new_id_2, ^user_agent_value_2, "Delete"], [^id_1, ^user_agent_value_1, "Delete"]] =
+               extract_rows_data(view)
+    end
+  end
+
+  defp extract_rows_data(view) do
+    view
+    |> render()
+    |> Floki.parse_fragment!()
+    |> Floki.find("tbody tr:nth-of-type(n)")
+    |> Enum.map(fn tr -> Floki.children(tr) end)
+    |> Enum.map(fn [id, user_agent, delete] ->
+      [
+        String.to_integer(String.trim(Floki.text(id))),
+        String.trim(Floki.text(user_agent)),
+        String.trim(Floki.text(delete))
+      ]
+    end)
+  end
+
+  defp user_agents_data(_context) do
+    user_agent_1 =
+      "Mozilla/5.0 (X11; Linux x86_64; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/16.0.0.4.13.298796165 SamsungBrowser/4.0 Chrome/91.0.4472.88 Safari/537.36"
+
+    user_agent_2 =
+      "Mozilla/5.0 (Linux; Android 10; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/16.6.0.1.52.314146309 SamsungBrowser/4.0 Chrome/91.0.4472.164 VR Safari/537.36"
+
+    {:ok, user_agent_1: user_agent_1, user_agent_2: user_agent_2}
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1,11 +1,11 @@
 defmodule Oli.Factory do
   use ExMachina.Ecto, repo: Oli.Repo
 
+  alias Oli.Accounts.VrUserAgent
   alias Oli.Accounts.{Author, User, AuthorPreferences, UserPreferences}
   alias Oli.Authoring.Authors.{AuthorProject, ProjectRole}
   alias Oli.Authoring.Course.{Family, Project, ProjectVisibility, ProjectResource}
   alias Oli.Branding.Brand
-
   alias Oli.Delivery.Sections.ContainedObjective
 
   alias Oli.Delivery.Attempts.Core.{
@@ -575,6 +575,10 @@ defmodule Oli.Factory do
       resource: anonymous_build(:resource),
       collab_space_config: build(:collab_space_config)
     }
+  end
+
+  def vr_user_agent_factory() do
+    %VrUserAgent{}
   end
 
   # HELPERS


### PR DESCRIPTION
Ticket: [MER-2859](https://eliterate.atlassian.net/jira/software/c/projects/MER/issues/MER-2859)

This PR added the ability to control the addition of the polyfill.io script depending on a list of user agent stored in the DB/cache.

A UX view was implemented in order to add/delete user agents from the DB/cache.

Endpoint used to interact with vr_user_agents data: `localhost/admin/vr_user_agents`

The cache was implemented using a `Agent`.

[MER-2859]: https://eliterate.atlassian.net/browse/MER-2859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ