### PR TITLE
[BUGFIX] [MER-2917] Fix additional activity summarization in practice and surveys activities

### DIFF
--- a/lib/oli_web/components/delivery/practice_activities/practice_activities.ex
+++ b/lib/oli_web/components/delivery/practice_activities/practice_activities.ex
@@ -833,7 +833,9 @@ defmodule OliWeb.Components.Delivery.PracticeActivities do
           %{
             text: response_summary.response,
             user_name: OliWeb.Common.Utils.name(response_summary.user),
-            type: mapper[response_summary.part_id]
+            type: mapper[response_summary.part_id],
+            part_id: response_summary.part_id,
+            count: response_summary.count
           }
           | acc_responses
         ]

--- a/lib/oli_web/components/delivery/surveys/surveys.ex
+++ b/lib/oli_web/components/delivery/surveys/surveys.ex
@@ -849,7 +849,9 @@ defmodule OliWeb.Components.Delivery.Surveys do
           %{
             text: response_summary.response,
             user_name: OliWeb.Common.Utils.name(response_summary.user),
-            type: mapper[response_summary.part_id]
+            type: mapper[response_summary.part_id],
+            part_id: response_summary.part_id,
+            count: response_summary.count
           }
           | acc_responses
         ]

--- a/test/oli_web/live/delivery/instructor_dashboard/overview/surveys_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/overview/surveys_tab_test.exs
@@ -1454,7 +1454,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.SurveysTabTest do
              )
 
       assert selected_activity_model =~
-               "{\"authoring\":{\"responses\":[{\"type\":\"text\",\"text\":\"unsupported\",\"user_name\":\"#{student_1.family_name}, #{student_1.given_name}\"}]},\"inputs\":[{\"id\":\"1458555427\",\"inputType\":\"text\",\"partId\":\"1\"}]}"
+               "{\"authoring\":{\"responses\":[{\"count\":1,\"type\":\"text\",\"text\":\"unsupported\",\"user_name\":\"#{student_1.family_name}, #{student_1.given_name}\",\"part_id\":\"1\"}]},\"inputs\":[{\"id\":\"1458555427\",\"inputType\":\"text\",\"partId\":\"1\"}]}"
     end
 
     test "likert activity details get rendered correctly when page is selected",


### PR DESCRIPTION
[MER-2917](https://eliterate.atlassian.net/browse/MER-2917)

This PR fixes the bug that is happening in both text and numeric response inputs in the `Practice Activities` and `Surveys` tabs. 

With these changes, the students' answers are displayed correctly.

https://github.com/Simon-Initiative/oli-torus/assets/16328384/1b7800ab-5d06-4389-b245-c5f2df1d816a



[MER-2917]: https://eliterate.atlassian.net/browse/MER-2917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ