### PR TITLE
[NG23-97] fix a bug where paragraphs created in editor have identical ids

### DIFF
--- a/assets/src/components/editing/editor/normalizers/root.ts
+++ b/assets/src/components/editing/editor/normalizers/root.ts
@@ -1,5 +1,6 @@
 import { Descendant, Editor, Element, Path, Transforms } from 'slate';
 import { Model } from 'data/content/model/elements/factories';
+import guid from 'utils/guid';
 
 const blockTexts = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p'];
 const isBlockText = (e: Descendant) => Element.isElement(e) && blockTexts.includes(e.type);
@@ -29,5 +30,24 @@ export const normalize = (editor: Editor, node: Editor, _path: Path) => {
     });
     console.warn('Normalizing content: Inserted paragraph at end of document');
     return;
+  }
+
+  // ensure all block node ids are unique
+  const blockIds = new Set<string>();
+  for (const [node, path] of Editor.nodes(editor, { at: [], match: isBlockText })) {
+    if (Element.isElement(node)) {
+      if (blockIds.has(node.id)) {
+        const newId = guid();
+        Transforms.setNodes(editor, { id: newId }, { at: path });
+
+        console.warn(
+          `Normalizing content: Duplicate block id found: ${node.id}, changed to ${newId}`,
+        );
+
+        return;
+      } else {
+        blockIds.add(node.id);
+      }
+    }
   }
 };

--- a/assets/src/components/editing/editor/normalizers/root.ts
+++ b/assets/src/components/editing/editor/normalizers/root.ts
@@ -33,8 +33,10 @@ export const normalize = (editor: Editor, node: Editor, _path: Path) => {
   }
 
   // ensure all block node ids are unique
+  const isBlockElement = (e: Descendant) => Element.isElement(e) && Editor.isBlock(editor, e);
+
   const blockIds = new Set<string>();
-  for (const [node, path] of Editor.nodes(editor, { at: [], match: isBlockText })) {
+  for (const [node, path] of Editor.nodes(editor, { at: [], match: isBlockElement })) {
     if (Element.isElement(node)) {
       if (blockIds.has(node.id)) {
         const newId = guid();

--- a/assets/test/editor/normalize_root_test.ts
+++ b/assets/test/editor/normalize_root_test.ts
@@ -29,5 +29,28 @@ describe('editor / root normalizer', () => {
       const { editor } = runNormalizer(original);
       expect(editor.children).toEqual(expected);
     });
+
+    it('Should fix duplicate block ids.', () => {
+      const original = [
+        { ...Model.p(), id: 'identical' },
+        { ...Model.p(), id: 'identical' },
+        Model.p(),
+      ];
+
+      const originalParagraphOne = original[0] as any;
+      const originalParagraphTwo = original[1] as any;
+      const originalParagraphThree = original[2] as any;
+
+      expect(originalParagraphOne.id).toEqual(originalParagraphTwo.id);
+
+      const { editor } = runNormalizer(original);
+
+      const normalizedParagraphOne = editor.children[0] as any;
+      const normalizedParagraphTwo = editor.children[1] as any;
+      const normalizedParagraphThree = editor.children[2] as any;
+
+      expect(normalizedParagraphOne.id).not.toEqual(normalizedParagraphTwo.id);
+      expect(originalParagraphThree.id).toEqual(normalizedParagraphThree.id);
+    });
   });
 });


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/NG23-97

Fixes an issue where paragraphs created in the editor have duplicate identifiers. This fix, along side the publishing fix, is required for the social annotation to work properly.

The solution here is to add another slate normalizer at the editor root which builds a set of ids from all block level nodes and checks the set for any duplicates. If a dup is found, then a new id is issued for the duplicate node.