### PR TITLE
[DO NOT MERGE] activity variable population

### DIFF
--- a/assets/src/apps/bank/ActivityBank.tsx
+++ b/assets/src/apps/bank/ActivityBank.tsx
@@ -520,6 +520,7 @@ export class ActivityBank extends React.Component<ActivityBankProps, ActivityBan
             const editorDesc = this.editorById[r.activity_type_id];
 
             return {
+              variables: editorDesc.variables,
               authoringElement: editorDesc.authoringElement,
               friendlyName: editorDesc.friendlyName,
               description: editorDesc.description,

--- a/assets/src/apps/bank/CreateActivity.tsx
+++ b/assets/src/apps/bank/CreateActivity.tsx
@@ -43,6 +43,7 @@ const create = (
         model,
         objectives,
         tags: [],
+        variables: editorDesc.variables,
       };
 
       onAdded(activity);

--- a/assets/src/components/activities/DeliveryElement.ts
+++ b/assets/src/components/activities/DeliveryElement.ts
@@ -63,6 +63,7 @@ export interface ActivityContext {
   resourceId?: number;
   renderPointMarkers: boolean;
   isAnnotationLevel: boolean;
+  variables: any;
 }
 
 /**

--- a/assets/src/components/activities/directed-discussion/discussion/MockDiscussionDeliveryProvider.tsx
+++ b/assets/src/components/activities/directed-discussion/discussion/MockDiscussionDeliveryProvider.tsx
@@ -45,6 +45,7 @@ export const MockDiscussionDeliveryProvider: React.FC<{
         showFeedback: false,
         renderPointMarkers: false,
         isAnnotationLevel: false,
+        variables: {},
       }}
       onSaveActivity={nullHandler}
       onSavePart={nullHandler}

--- a/assets/src/components/activities/multiple_choice/MultipleChoiceAuthoring.tsx
+++ b/assets/src/components/activities/multiple_choice/MultipleChoiceAuthoring.tsx
@@ -31,7 +31,7 @@ import { MCSchema } from './schema';
 const store = configureStore();
 
 const MultipleChoice: React.FC = () => {
-  const { dispatch, model, editMode, projectSlug } = useAuthoringElementContext<MCSchema>();
+  const { dispatch, model, editMode, projectSlug, authoringContext } = useAuthoringElementContext<MCSchema>();
   const writerContext = defaultWriterContext({
     projectSlug: projectSlug,
   });

--- a/assets/src/components/activities/multiple_choice/MultipleChoiceAuthoring.tsx
+++ b/assets/src/components/activities/multiple_choice/MultipleChoiceAuthoring.tsx
@@ -31,7 +31,7 @@ import { MCSchema } from './schema';
 const store = configureStore();
 
 const MultipleChoice: React.FC = () => {
-  const { dispatch, model, editMode, projectSlug, authoringContext } = useAuthoringElementContext<MCSchema>();
+  const { dispatch, model, editMode, projectSlug } = useAuthoringElementContext<MCSchema>();
   const writerContext = defaultWriterContext({
     projectSlug: projectSlug,
   });

--- a/assets/src/components/activity/InlineActivityEditor.tsx
+++ b/assets/src/components/activity/InlineActivityEditor.tsx
@@ -136,7 +136,7 @@ export class InlineActivityEditor extends React.Component<
   }
 
   render() {
-    const { authoringElement, contentBreaksExist } = this.props;
+    const { authoringElement, contentBreaksExist, variables } = this.props;
 
     const onTitleEdit = (title: string) => {
       this.update({ title });
@@ -147,7 +147,7 @@ export class InlineActivityEditor extends React.Component<
       model: JSON.stringify(this.props.model),
       editmode: new Boolean(this.props.editMode).toString(),
       projectslug: this.props.projectSlug,
-      authoringcontext: JSON.stringify({ contentBreaksExist }),
+      authoringcontext: JSON.stringify({ contentBreaksExist, variables }),
     };
 
     const parts = valueOr(this.props.model.authoring.parts, []);

--- a/assets/src/components/content/add_resource_content/AddActivity.tsx
+++ b/assets/src/components/content/add_resource_content/AddActivity.tsx
@@ -98,6 +98,7 @@ const addActivity = (
         model,
         objectives,
         tags: [],
+        variables: editorDesc.variables
       });
     })
     .catch((err) => {

--- a/assets/src/components/content/add_resource_content/AddActivity.tsx
+++ b/assets/src/components/content/add_resource_content/AddActivity.tsx
@@ -98,7 +98,7 @@ const addActivity = (
         model,
         objectives,
         tags: [],
-        variables: editorDesc.variables
+        variables: editorDesc.variables,
       });
     })
     .catch((err) => {

--- a/assets/src/components/resource/editors/ActivityEditor.tsx
+++ b/assets/src/components/resource/editors/ActivityEditor.tsx
@@ -37,6 +37,7 @@ export const ActivityEditor = ({
         onRemove={onRemove}
       >
         <InlineActivityEditor
+          variables={activity.variables}
           model={activity.model}
           activitySlug={activity.activitySlug}
           typeSlug={activity.typeSlug}

--- a/assets/src/data/content/activity.ts
+++ b/assets/src/data/content/activity.ts
@@ -23,6 +23,7 @@ export type ActivityEditContext = {
   model: ActivityModelSchema; // Content of the resource
   objectives: ObjectiveMap; // Attached objectives, based on part id
   tags: ResourceId[]; // Attached tags
+  variables: any;
 };
 
 export type ProjectResourceContext = {

--- a/assets/src/data/content/editors.ts
+++ b/assets/src/data/content/editors.ts
@@ -11,6 +11,7 @@ export type EditorDesc = {
   globallyAvailable: boolean;
   enabledForProject: boolean;
   id: number;
+  variables: any;
 };
 
 export interface ActivityEditorMap {

--- a/assets/test/check_all_that_apply/cata_delivery_test.tsx
+++ b/assets/test/check_all_that_apply/cata_delivery_test.tsx
@@ -32,6 +32,7 @@ describe('check all that apply delivery', () => {
         showFeedback: true,
         renderPointMarkers: false,
         isAnnotationLevel: false,
+        variables: {},
       },
       preview: false,
     };

--- a/assets/test/multiple_choice/mc_delivery_test.tsx
+++ b/assets/test/multiple_choice/mc_delivery_test.tsx
@@ -33,6 +33,7 @@ describe('multiple choice delivery', () => {
         showFeedback: true,
         renderPointMarkers: false,
         isAnnotationLevel: false,
+        variables: {},
       },
       graded: false,
       preview: false,

--- a/assets/test/ordering/ordering_delivery_test.tsx
+++ b/assets/test/ordering/ordering_delivery_test.tsx
@@ -32,6 +32,7 @@ describe('ordering delivery', () => {
         showFeedback: true,
         renderPointMarkers: false,
         isAnnotationLevel: false,
+        variables: {},
       },
       preview: false,
     };

--- a/assets/test/short_answer/short_answer_delivery_test.tsx
+++ b/assets/test/short_answer/short_answer_delivery_test.tsx
@@ -32,6 +32,7 @@ describe('multiple choice delivery', () => {
         showFeedback: true,
         renderPointMarkers: false,
         isAnnotationLevel: false,
+        variables: {},
       },
       preview: false,
     };

--- a/lib/oli/activities.ex
+++ b/lib/oli/activities.ex
@@ -26,7 +26,8 @@ defmodule Oli.Activities do
       title: manifest.friendlyName,
       petite_label: manifest.petiteLabel,
       icon: manifest.icon,
-      slug: manifest.id
+      slug: manifest.id,
+      variables: manifest.variables
     }
 
     case get_registration_by_slug(attrs.slug) do

--- a/lib/oli/activities/activity_map_entry.ex
+++ b/lib/oli/activities/activity_map_entry.ex
@@ -39,7 +39,7 @@ defmodule Oli.Activities.ActivityMapEntry do
       deliveryElement: delivery_element,
       globallyAvailable: globally_available,
       enabledForProject: globally_available,
-      variables: Oli.Delivery.Page.ActivityContext.build_variables_map(variables)
+      variables: Oli.Delivery.Page.ActivityContext.build_variables_map(variables, petite_label)
     }
   end
 end

--- a/lib/oli/activities/activity_map_entry.ex
+++ b/lib/oli/activities/activity_map_entry.ex
@@ -12,6 +12,7 @@ defmodule Oli.Activities.ActivityMapEntry do
     :petiteLabel,
     :slug,
     :globallyAvailable,
+    :variables,
     enabledForProject: false
   ]
 
@@ -24,7 +25,8 @@ defmodule Oli.Activities.ActivityMapEntry do
         petite_label: petite_label,
         authoring_element: authoring_element,
         delivery_element: delivery_element,
-        globally_available: globally_available
+        globally_available: globally_available,
+        variables: variables
       }) do
     %Oli.Activities.ActivityMapEntry{
       id: id,
@@ -36,7 +38,8 @@ defmodule Oli.Activities.ActivityMapEntry do
       icon: icon,
       deliveryElement: delivery_element,
       globallyAvailable: globally_available,
-      enabledForProject: globally_available
+      enabledForProject: globally_available,
+      variables: Oli.Delivery.Page.ActivityContext.build_variables_map(variables)
     }
   end
 end

--- a/lib/oli/activities/activity_registration.ex
+++ b/lib/oli/activities/activity_registration.ex
@@ -15,6 +15,7 @@ defmodule Oli.Activities.ActivityRegistration do
     field :allow_client_evaluation, :boolean, default: false
     field :globally_available, :boolean, default: false
     field :globally_visible, :boolean, default: true
+    field :variables, {:array, :string}, default: []
 
     many_to_many :projects, Oli.Authoring.Course.Project,
       join_through: Oli.Activities.ActivityRegistrationProject
@@ -37,7 +38,8 @@ defmodule Oli.Activities.ActivityRegistration do
       :authoring_script,
       :allow_client_evaluation,
       :globally_available,
-      :globally_visible
+      :globally_visible,
+      :variables
     ])
     |> validate_required([
       :slug,

--- a/lib/oli/activities/manifest.ex
+++ b/lib/oli/activities/manifest.ex
@@ -10,7 +10,8 @@ defmodule Oli.Activities.Manifest do
     :authoring,
     :allowClientEvaluation,
     :icon,
-    :global
+    :global,
+    :variables
   ]
 
   def parse(
@@ -33,7 +34,8 @@ defmodule Oli.Activities.Manifest do
        delivery: Oli.Activities.ModeSpecification.parse(delivery),
        authoring: Oli.Activities.ModeSpecification.parse(authoring),
        allowClientEvaluation: value_or(json["allowClientEvaluation"], false),
-       global: false
+       global: false,
+       variables: value_or(json["variables"], [])
      }}
   end
 

--- a/lib/oli/authoring/editing/activity_context.ex
+++ b/lib/oli/authoring/editing/activity_context.ex
@@ -17,6 +17,7 @@ defmodule Oli.Authoring.Editing.ActivityContext do
     :objectives,
     :allObjectives,
     :typeSlug,
-    :tags
+    :tags,
+    :variables
   ]
 end

--- a/lib/oli/authoring/editing/activity_editor.ex
+++ b/lib/oli/authoring/editing/activity_editor.ex
@@ -717,7 +717,8 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
         objectives: objectives,
         allObjectives: PageEditor.construct_parent_references(all_objectives),
         typeSlug: activity_type.slug,
-        tags: tags
+        tags: tags,
+        variables: Oli.Delivery.Page.ActivityContext.build_variables_map(activity_type.variables)
       }
 
       {:ok, context}
@@ -749,7 +750,8 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
         model: r.content,
         objectives: r.objectives,
         typeSlug: activity_type.slug,
-        tags: r.tags
+        tags: r.tags,
+        variables: Oli.Delivery.Page.ActivityContext.build_variables_map(activity_type.variables)
       }
     end)
   end

--- a/lib/oli/authoring/editing/activity_editor.ex
+++ b/lib/oli/authoring/editing/activity_editor.ex
@@ -718,7 +718,11 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
         allObjectives: PageEditor.construct_parent_references(all_objectives),
         typeSlug: activity_type.slug,
         tags: tags,
-        variables: Oli.Delivery.Page.ActivityContext.build_variables_map(activity_type.variables, activity_type.petite_label)
+        variables:
+          Oli.Delivery.Page.ActivityContext.build_variables_map(
+            activity_type.variables,
+            activity_type.petite_label
+          )
       }
 
       {:ok, context}
@@ -751,7 +755,11 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
         objectives: r.objectives,
         typeSlug: activity_type.slug,
         tags: r.tags,
-        variables: Oli.Delivery.Page.ActivityContext.build_variables_map(activity_type.variables, activity_type.petite_label)
+        variables:
+          Oli.Delivery.Page.ActivityContext.build_variables_map(
+            activity_type.variables,
+            activity_type.petite_label
+          )
       }
     end)
   end

--- a/lib/oli/authoring/editing/activity_editor.ex
+++ b/lib/oli/authoring/editing/activity_editor.ex
@@ -718,7 +718,7 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
         allObjectives: PageEditor.construct_parent_references(all_objectives),
         typeSlug: activity_type.slug,
         tags: tags,
-        variables: Oli.Delivery.Page.ActivityContext.build_variables_map(activity_type.variables)
+        variables: Oli.Delivery.Page.ActivityContext.build_variables_map(activity_type.variables, activity_type.petite_label)
       }
 
       {:ok, context}
@@ -751,7 +751,7 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
         objectives: r.objectives,
         typeSlug: activity_type.slug,
         tags: r.tags,
-        variables: Oli.Delivery.Page.ActivityContext.build_variables_map(activity_type.variables)
+        variables: Oli.Delivery.Page.ActivityContext.build_variables_map(activity_type.variables, activity_type.petite_label)
       }
     end)
   end

--- a/lib/oli/authoring/editing/page_editor.ex
+++ b/lib/oli/authoring/editing/page_editor.ex
@@ -370,7 +370,8 @@ defmodule Oli.Authoring.Editing.PageEditor do
            script: type.delivery_script,
            graded: graded,
            bib_refs: Map.get(content, "bibrefs", []),
-           ordinal: Map.get(ordinal_map, resource_id)
+           ordinal: Map.get(ordinal_map, resource_id),
+           variables: Oli.Delivery.Page.ActivityContext.build_variables_map(type.variables)
          }
        end)
        |> Enum.reduce(%{}, fn summary, acc -> Map.put(acc, summary.id, summary) end)}

--- a/lib/oli/authoring/editing/page_editor.ex
+++ b/lib/oli/authoring/editing/page_editor.ex
@@ -371,7 +371,11 @@ defmodule Oli.Authoring.Editing.PageEditor do
            graded: graded,
            bib_refs: Map.get(content, "bibrefs", []),
            ordinal: Map.get(ordinal_map, resource_id),
-           variables: Oli.Delivery.Page.ActivityContext.build_variables_map(type.variables, type.petite_label)
+           variables:
+             Oli.Delivery.Page.ActivityContext.build_variables_map(
+               type.variables,
+               type.petite_label
+             )
          }
        end)
        |> Enum.reduce(%{}, fn summary, acc -> Map.put(acc, summary.id, summary) end)}

--- a/lib/oli/authoring/editing/page_editor.ex
+++ b/lib/oli/authoring/editing/page_editor.ex
@@ -371,7 +371,7 @@ defmodule Oli.Authoring.Editing.PageEditor do
            graded: graded,
            bib_refs: Map.get(content, "bibrefs", []),
            ordinal: Map.get(ordinal_map, resource_id),
-           variables: Oli.Delivery.Page.ActivityContext.build_variables_map(type.variables)
+           variables: Oli.Delivery.Page.ActivityContext.build_variables_map(type.variables, type.petite_label)
          }
        end)
        |> Enum.reduce(%{}, fn summary, acc -> Map.put(acc, summary.id, summary) end)}

--- a/lib/oli/delivery/page/activity_context.ex
+++ b/lib/oli/delivery/page/activity_context.ex
@@ -57,15 +57,22 @@ defmodule Oli.Delivery.Page.ActivityContext do
          graded: graded,
          bib_refs: Map.get(model, "bibrefs", []),
          ordinal: ordinal_assign_fn.(id),
-         variables: build_variables_map(type.variables)
+         variables: build_variables_map(type.variables, type.petite_label)
        }}
     end)
     |> Map.new()
   end
 
-  def build_variables_map(variables) do
+  def build_variables_map(variables, petite_label) do
+
+    whitelist_prefix = "ACTIVITY_" <> String.upcase(petite_label) <> "_"
+
     Enum.reduce(variables, %{}, fn variable_name, acc ->
-      Map.put(acc, variable_name, System.get_env(variable_name, ""))
+      if String.starts_with?(variable_name, whitelist_prefix) do
+        Map.put(acc, variable_name, System.get_env(variable_name, ""))
+      else
+        acc
+      end
     end)
   end
 

--- a/lib/oli/delivery/page/activity_context.ex
+++ b/lib/oli/delivery/page/activity_context.ex
@@ -56,10 +56,17 @@ defmodule Oli.Delivery.Page.ActivityContext do
          script: type.delivery_script,
          graded: graded,
          bib_refs: Map.get(model, "bibrefs", []),
-         ordinal: ordinal_assign_fn.(id)
+         ordinal: ordinal_assign_fn.(id),
+         variables: build_variables_map(type.variables)
        }}
     end)
     |> Map.new()
+  end
+
+  def build_variables_map(variables) do
+    Enum.reduce(variables, %{}, fn variable_name, acc ->
+      Map.put(acc, variable_name, System.get_env(variable_name, ""))
+    end)
   end
 
   defp prune_feedback_from_state(state, true), do: state

--- a/lib/oli/delivery/page/activity_context.ex
+++ b/lib/oli/delivery/page/activity_context.ex
@@ -64,7 +64,6 @@ defmodule Oli.Delivery.Page.ActivityContext do
   end
 
   def build_variables_map(variables, petite_label) do
-
     whitelist_prefix = "ACTIVITY_" <> String.upcase(petite_label) <> "_"
 
     Enum.reduce(variables, %{}, fn variable_name, acc ->

--- a/lib/oli/rendering/activity/activity_summary.ex
+++ b/lib/oli/rendering/activity/activity_summary.ex
@@ -42,6 +42,10 @@ defmodule Oli.Rendering.Activity.ActivitySummary do
     :bib_refs,
 
     # The ordinal position of this activity within the page
-    :ordinal
+    :ordinal,
+
+    # Map of key-value pairs that can be used to pass additional data to the activity
+    # for client-side use
+    :variables
   ]
 end

--- a/lib/oli/rendering/activity/html.ex
+++ b/lib/oli/rendering/activity/html.ex
@@ -56,7 +56,8 @@ defmodule Oli.Rendering.Activity.Html do
          %ActivitySummary{
            authoring_element: authoring_element,
            delivery_element: delivery_element,
-           model: model
+           model: model,
+           variables: variables
          } = summary,
          %{"activity_id" => activity_id}
        ) do
@@ -79,8 +80,14 @@ defmodule Oli.Rendering.Activity.Html do
         {:ok, bib_params_json} = Jason.encode(bib_params)
         activity_html_id = get_activity_html_id(activity_id, model_json)
 
+        activity_context = %{
+          variables: variables
+        }
+        |> Poison.encode!()
+        |> HtmlEntities.encode()
+
         [
-          ~s|<#{tag} section_slug=\"#{section_slug}\" activity_id=\"#{activity_html_id}\" model="#{model_json}" activityId="#{activity_id}" editmode="false" projectSlug="#{section_slug}" bib_params="#{Base.encode64(bib_params_json)}"></#{tag}>\n|
+          ~s|<#{tag} authoringcontext="#{activity_context}" section_slug=\"#{section_slug}\" activity_id=\"#{activity_html_id}\" model="#{model_json}" activityId="#{activity_id}" editmode="false" projectSlug="#{section_slug}" bib_params="#{Base.encode64(bib_params_json)}"></#{tag}>\n|
         ]
 
       :review ->
@@ -155,7 +162,8 @@ defmodule Oli.Rendering.Activity.Html do
          } = context,
          %ActivitySummary{
            state: state,
-           graded: graded
+           graded: graded,
+           variables: variables
          },
          bib_params,
          model_json
@@ -184,7 +192,8 @@ defmodule Oli.Rendering.Activity.Html do
             resource_attempt.state
           end,
         renderPointMarkers: render_opts.render_point_markers,
-        isAnnotationLevel: true
+        isAnnotationLevel: true,
+        variables: variables
       }
       |> Poison.encode!()
       |> HtmlEntities.encode()

--- a/priv/repo/migrations/20240321140533_activity_variables.exs
+++ b/priv/repo/migrations/20240321140533_activity_variables.exs
@@ -1,0 +1,9 @@
+defmodule Oli.Repo.Migrations.ActivityVariables do
+  use Ecto.Migration
+
+  def change do
+    alter table(:activity_registrations) do
+      add :variables, {:array, :string}, default: [], null: false
+    end
+  end
+end

--- a/test/oli/delivery/attempts_test.exs
+++ b/test/oli/delivery/attempts_test.exs
@@ -668,7 +668,8 @@ defmodule Oli.Delivery.AttemptsTest do
             entry: "./authoring-entry.ts"
           },
           allowClientEvaluation: true,
-          global: true
+          global: true,
+          variables: []
         })
 
       # create an example project with the activity in a graded page
@@ -788,7 +789,8 @@ defmodule Oli.Delivery.AttemptsTest do
             entry: "./authoring-entry.ts"
           },
           allowClientEvaluation: false,
-          global: true
+          global: true,
+          variables: []
         })
 
       # create an example project with the activity in a graded page

--- a/test/oli/delivery/page/activity_context_test.exs
+++ b/test/oli/delivery/page/activity_context_test.exs
@@ -63,19 +63,25 @@ defmodule Oli.Delivery.Page.ActivityContextTest do
     end
 
     test "build_variables_map/2 returns correct vars", %{} do
-
       System.put_env("ACTIVITY_MCQ_TEST1", "1")
       System.put_env("ACTIVITY_MCQ_TEST2", "2")
       System.put_env("MY_SECRET", "secret")
 
-      vars = ActivityContext.build_variables_map(["ACTIVITY_MCQ_TEST1", "ACTIVITY_MCQ_TEST2"], "mcq")
+      vars =
+        ActivityContext.build_variables_map(["ACTIVITY_MCQ_TEST1", "ACTIVITY_MCQ_TEST2"], "mcq")
+
       assert Map.keys(vars) |> Enum.count() == 2
 
       assert Map.get(vars, "ACTIVITY_MCQ_TEST1") == "1"
       assert Map.get(vars, "ACTIVITY_MCQ_TEST2") == "2"
 
       # Verify the secret is not included
-      vars = ActivityContext.build_variables_map(["ACTIVITY_MCQ_TEST1", "ACTIVITY_MCQ_TEST2", "MY_SECRET"], "mcq")
+      vars =
+        ActivityContext.build_variables_map(
+          ["ACTIVITY_MCQ_TEST1", "ACTIVITY_MCQ_TEST2", "MY_SECRET"],
+          "mcq"
+        )
+
       assert Map.keys(vars) |> Enum.count() == 2
 
       assert Map.get(vars, "ACTIVITY_MCQ_TEST1") == "1"

--- a/test/oli/delivery/page/activity_context_test.exs
+++ b/test/oli/delivery/page/activity_context_test.exs
@@ -61,5 +61,30 @@ defmodule Oli.Delivery.Page.ActivityContextTest do
       assert Map.get(m, a1.resource.id).delivery_element == "oli-multiple-choice-delivery"
       assert Map.get(m, a1.resource.id).script == "oli_multiple_choice_delivery.js"
     end
+
+    test "build_variables_map/2 returns correct vars", %{} do
+
+      System.put_env("ACTIVITY_MCQ_TEST1", "1")
+      System.put_env("ACTIVITY_MCQ_TEST2", "2")
+      System.put_env("MY_SECRET", "secret")
+
+      vars = ActivityContext.build_variables_map(["ACTIVITY_MCQ_TEST1", "ACTIVITY_MCQ_TEST2"], "mcq")
+      assert Map.keys(vars) |> Enum.count() == 2
+
+      assert Map.get(vars, "ACTIVITY_MCQ_TEST1") == "1"
+      assert Map.get(vars, "ACTIVITY_MCQ_TEST2") == "2"
+
+      # Verify the secret is not included
+      vars = ActivityContext.build_variables_map(["ACTIVITY_MCQ_TEST1", "ACTIVITY_MCQ_TEST2", "MY_SECRET"], "mcq")
+      assert Map.keys(vars) |> Enum.count() == 2
+
+      assert Map.get(vars, "ACTIVITY_MCQ_TEST1") == "1"
+      assert Map.get(vars, "ACTIVITY_MCQ_TEST2") == "2"
+
+      # ensure one that does not exist gets the empty string
+      vars = ActivityContext.build_variables_map(["ACTIVITY_MCQ_DOES_NOT_EXIST"], "mcq")
+      assert Map.keys(vars) |> Enum.count() == 1
+      assert Map.get(vars, "ACTIVITY_MCQ_DOES_NOT_EXIST") == ""
+    end
   end
 end


### PR DESCRIPTION
This PR adds infrastructure to allow native activities to specify a list of environment variables whose values then are made available to it for client side use.

To use, in the `manifest.json`, add a `variables` key that is a string array.   

Then, in both authoring and delivery contexts, a `variables` object with keys being the variable name and the value being the server environment variable value will be available in the appropriate context. 
