### PR TITLE
Mer 2748 fix bug render license in pages different from learning pages

### DIFF
--- a/lib/oli_web/live/projects/overview_live.ex
+++ b/lib/oli_web/live/projects/overview_live.ex
@@ -158,10 +158,12 @@ defmodule OliWeb.Projects.OverviewLive do
                   required: false
                 ) %>
                 <div :if={open_custom_type?(@changeset)} class="form-label-group mb-3">
-                  <%= label(fpp, :custom_license_details, "Custom license", class: "control-label") %>
+                  <%= label(fpp, :custom_license_details, "Custom license (URL)",
+                    class: "control-label"
+                  ) %>
                   <%= text_input(fpp, :custom_license_details,
                     class: "form-control",
-                    placeholder: "The custom license of your project...",
+                    placeholder: "https://creativecommons.org/licenses/by/4.0/",
                     required: false
                   ) %>
                 </div>

--- a/lib/oli_web/plugs/set_license.ex
+++ b/lib/oli_web/plugs/set_license.ex
@@ -1,0 +1,8 @@
+defmodule OliWeb.Plugs.SetLicense do
+  import Plug.Conn
+  def init(_params), do: nil
+
+  def call(conn, _params) do
+    assign(conn, :has_license, true)
+  end
+end

--- a/lib/oli_web/plugs/set_license.ex
+++ b/lib/oli_web/plugs/set_license.ex
@@ -1,8 +1,0 @@
-defmodule OliWeb.Plugs.SetLicense do
-  import Plug.Conn
-  def init(_params), do: nil
-
-  def call(conn, _params) do
-    assign(conn, :has_license, true)
-  end
-end

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -228,9 +228,8 @@ defmodule OliWeb.Router do
     plug(Oli.Plugs.DeliveryPreview)
   end
 
-  pipeline :put_license do
-    plug(OliWeb.Plugs.SetLicense)
-  end
+  pipeline :put_license, do: plug(:set_license)
+  def set_license(conn, _), do: Plug.Conn.assign(conn, :has_license, true)
 
   ### HELPERS ###
 

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -228,6 +228,10 @@ defmodule OliWeb.Router do
     plug(Oli.Plugs.DeliveryPreview)
   end
 
+  pipeline :put_license do
+    plug(OliWeb.Plugs.SetLicense)
+  end
+
   ### HELPERS ###
 
   defp put_pow_mailer_layout(conn, layout), do: put_private(conn, :pow_mailer_layouts, layout)
@@ -957,10 +961,20 @@ defmodule OliWeb.Router do
     get("/discussion", PageDeliveryController, :discussion)
     get("/my_assignments", PageDeliveryController, :assignments)
     get("/container/:revision_slug", PageDeliveryController, :container)
-    get("/page/:revision_slug", PageDeliveryController, :page)
-    get("/page_fullscreen/:revision_slug", PageDeliveryController, :page_fullscreen)
-    get("/page/:revision_slug/page/:page", PageDeliveryController, :page)
-    get("/page/:revision_slug/attempt", PageDeliveryController, :start_attempt)
+
+    scope "/" do
+      pipe_through([:put_license])
+      get("/page/:revision_slug", PageDeliveryController, :page)
+      get("/page_fullscreen/:revision_slug", PageDeliveryController, :page_fullscreen)
+      get("/page/:revision_slug/page/:page", PageDeliveryController, :page)
+      get("/page/:revision_slug/attempt", PageDeliveryController, :start_attempt)
+
+      get(
+        "/page/:revision_slug/attempt/:attempt_guid/review",
+        PageDeliveryController,
+        :review_attempt
+      )
+    end
 
     post(
       "/page/:revision_slug/attempt_protected",
@@ -968,17 +982,7 @@ defmodule OliWeb.Router do
       :start_attempt_protected
     )
 
-    post(
-      "/page",
-      PageDeliveryController,
-      :navigate_by_index
-    )
-
-    get(
-      "/page/:revision_slug/attempt/:attempt_guid/review",
-      PageDeliveryController,
-      :review_attempt
-    )
+    post("/page", PageDeliveryController, :navigate_by_index)
   end
 
   ### Sections - Preview
@@ -1000,9 +1004,13 @@ defmodule OliWeb.Router do
     get("/discussion", PageDeliveryController, :discussion_preview)
     get("/my_assignments", PageDeliveryController, :assignments_preview)
     get("/container/:revision_slug", PageDeliveryController, :container_preview)
-    get("/page/:revision_slug", PageDeliveryController, :page_preview)
-    get("/page/:revision_slug/page/:page", PageDeliveryController, :page_preview)
-    get("/page/:revision_slug/selection/:selection_id", ActivityBankController, :preview)
+
+    scope "/" do
+      pipe_through([:put_license])
+      get("/page/:revision_slug", PageDeliveryController, :page_preview)
+      get("/page/:revision_slug/page/:page", PageDeliveryController, :page_preview)
+      get("/page/:revision_slug/selection/:selection_id", ActivityBankController, :preview)
+    end
   end
 
   scope "/sections", OliWeb do

--- a/lib/oli_web/templates/layout/_delivery_footer.html.eex
+++ b/lib/oli_web/templates/layout/_delivery_footer.html.eex
@@ -17,7 +17,9 @@
     </div>
     <div class="text-right">
     </div>
-    <%= render_license(assigns[:license]) %>
+    <%= if Map.get(assigns, :has_license) do %>
+      <%= render_license(assigns[:license]) %>
+    <% end %>
   </div>
 
   <script>

--- a/lib/oli_web/views/layout_view.ex
+++ b/lib/oli_web/views/layout_view.ex
@@ -130,14 +130,35 @@ defmodule OliWeb.LayoutView do
   defp show_collab_space?(%CollabSpaceConfig{status: :disabled}), do: false
   defp show_collab_space?(_), do: true
 
-  def render_license(%{license_type: :custom} = assigns) do
+  def is_only_url?(url) do
+
+    trimmed = String.trim(url)
+    !String.contains?(trimmed, " ") and (String.starts_with?(trimmed, "http://") or String.starts_with?(trimmed, "https://"))
+  end
+
+  defp render_as_link(assigns) do
     ~H"""
     <.license_wrapper>
-      <a href={@custom_license_details} , target="_blank">
-        <%= @custom_license_details %>
+      <a href={String.trim(@custom_license_details)} , target="_blank">
+        <%= String.trim(@custom_license_details) %>
       </a>
     </.license_wrapper>
     """
+  end
+
+  defp render_as_text(assigns) do
+    ~H"""
+    <.license_wrapper>
+      <%= @custom_license_details %>
+    </.license_wrapper>
+    """
+  end
+
+  def render_license(%{license_type: :custom} = assigns) do
+    case is_only_url?(assigns[:custom_license_details]) do
+      true -> render_as_link(assigns)
+      false -> render_as_text(assigns)
+    end
   end
 
   def render_license(%{license_type: cc_license} = assigns)

--- a/lib/oli_web/views/layout_view.ex
+++ b/lib/oli_web/views/layout_view.ex
@@ -131,9 +131,10 @@ defmodule OliWeb.LayoutView do
   defp show_collab_space?(_), do: true
 
   def is_only_url?(url) do
-
     trimmed = String.trim(url)
-    !String.contains?(trimmed, " ") and (String.starts_with?(trimmed, "http://") or String.starts_with?(trimmed, "https://"))
+
+    !String.contains?(trimmed, " ") and
+      (String.starts_with?(trimmed, "http://") or String.starts_with?(trimmed, "https://"))
   end
 
   defp render_as_link(assigns) do

--- a/lib/oli_web/views/layout_view.ex
+++ b/lib/oli_web/views/layout_view.ex
@@ -133,7 +133,9 @@ defmodule OliWeb.LayoutView do
   def render_license(%{license_type: :custom} = assigns) do
     ~H"""
     <.license_wrapper>
-      <p class="h-full"><%= @custom_license_details %></p>
+      <a href={@custom_license_details} , target="_blank">
+        <%= @custom_license_details %>
+      </a>
     </.license_wrapper>
     """
   end

--- a/test/oli_web/live/admin/vr_user_agents_view_test.exs
+++ b/test/oli_web/live/admin/vr_user_agents_view_test.exs
@@ -1,4 +1,4 @@
-defmodule OliWeb.Users.UsersDetailViewTest do
+defmodule OliWeb.Admin.VrUserAgentsViewTest do
   use OliWeb.ConnCase
   import Phoenix.LiveViewTest
   import Oli.Factory

--- a/test/oli_web/views/layout_view_test.exs
+++ b/test/oli_web/views/layout_view_test.exs
@@ -40,6 +40,5 @@ defmodule OliWeb.LayoutViewTest do
       refute LayoutView.is_only_url?("foo.com")
       refute LayoutView.is_only_url?("https://foo.com bar")
     end
-
   end
 end

--- a/test/oli_web/views/layout_view_test.exs
+++ b/test/oli_web/views/layout_view_test.exs
@@ -4,6 +4,7 @@ defmodule OliWeb.LayoutViewTest do
   import Oli.Factory
 
   alias OliWeb.AuthoringView
+  alias OliWeb.LayoutView
 
   describe "authoring view" do
     test "renders author info" do
@@ -30,5 +31,15 @@ defmodule OliWeb.LayoutViewTest do
       assert user
       assert user.id == user_associated.id
     end
+
+    test "is_only_url?/1" do
+      assert LayoutView.is_only_url?("http://foo")
+      assert LayoutView.is_only_url?("https://foo")
+      assert LayoutView.is_only_url?(" https://foo ")
+      refute LayoutView.is_only_url?("foo")
+      refute LayoutView.is_only_url?("foo.com")
+      refute LayoutView.is_only_url?("https://foo.com bar")
+    end
+
   end
 end


### PR DESCRIPTION
Ticket: [MER-2748](https://eliterate.atlassian.net/browse/MER-2748)

This PR fixed 3 bugs:

- License is only render for _learning pages_.
- License renders a URL for custom licenses.
- Two tests were sharing the same name and a warning appeared in the console when running the test suite.

Related PR: [4671](https://github.com/Simon-Initiative/oli-torus/pull/4671)

[MER-2748]: https://eliterate.atlassian.net/browse/MER-2748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ