### PR TITLE
[BUGFIX][MER-2980] Fix due date sorting for scored activities

### DIFF
--- a/lib/oli_web/components/delivery/scored_activities/assessments_table_model.ex
+++ b/lib/oli_web/components/delivery/scored_activities/assessments_table_model.ex
@@ -123,9 +123,12 @@ defmodule OliWeb.Delivery.ScoredActivities.AssessmentsTableModel do
   end
 
   defp parse_due_date(datetime, ctx, :due_by) do
-    datetime
-    |> FormatDateTime.convert_datetime(ctx)
-    |> Timex.format!("{Mshort}. {0D}, {YYYY} - {h12}:{m} {AM}")
+    if is_nil(datetime),
+      do: "No due date",
+      else:
+        datetime
+        |> FormatDateTime.convert_datetime(ctx)
+        |> Timex.format!("{Mshort}. {0D}, {YYYY} - {h12}:{m} {AM}")
   end
 
   defp parse_due_date(_datetime, _ctx, _scheduling_type), do: "No due date"

--- a/lib/oli_web/components/delivery/scored_activities/scored_activities.ex
+++ b/lib/oli_web/components/delivery/scored_activities/scored_activities.ex
@@ -425,15 +425,19 @@ defmodule OliWeb.Components.Delivery.ScoredActivities do
   defp sort_by(assessments, sort_by, sort_order) do
     case sort_by do
       :due_date ->
-        Enum.sort_by(assessments, & &1.end_date, sort_order)
-
         Enum.sort_by(
           assessments,
           fn
-            %{scheduling_type: :due_by} = assessment -> assessment.end_date
-            _ -> nil
+            %{scheduling_type: :due_by, end_date: nil} = _assessment ->
+              DateTime.from_unix(0, :second) |> elem(1)
+
+            %{scheduling_type: :due_by} = assessment ->
+              assessment.end_date
+
+            _ ->
+              DateTime.from_unix(0, :second) |> elem(1)
           end,
-          sort_order
+          {sort_order, DateTime}
         )
 
       sb when sb in [:avg_score, :students_completion, :total_attempts] ->

--- a/test/oli_web/live/delivery/instructor_dashboard/scored_activities/scored_activities_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/scored_activities/scored_activities_tab_test.exs
@@ -1246,13 +1246,16 @@ defmodule OliWeb.Delivery.InstructorDashboard.ScoredActivitiesTabTest do
       section: section,
       page_1: page_1,
       page_2: page_2,
-      page_3: page_3
+      page_3: page_3,
+      page_4: page_4
     } do
       # Only section resources of scheduling_type = due_by are considered when sorting by Due Date
+      # It's considered also in the case that the scheduling_type is read_by, but the end_date is nil
       [
         {page_1, %{end_date: ~U[2000-01-21 12:00:00.00Z], scheduling_type: :due_by}},
         {page_2, %{end_date: ~U[2000-01-22 12:00:00.00Z], scheduling_type: :read_by}},
-        {page_3, %{end_date: ~U[2000-01-23 12:00:00.00Z], scheduling_type: :due_by}}
+        {page_3, %{end_date: ~U[2000-01-23 12:00:00.00Z], scheduling_type: :due_by}},
+        {page_4, %{end_date: nil, scheduling_type: :due_by}}
       ]
       |> Enum.each(fn {page, params} ->
         Sections.get_section_resource(section.id, page.resource_id)


### PR DESCRIPTION
[MER-2980](https://eliterate.atlassian.net/browse/MER-2980)

This PR aims to fix the issue sorting the table by due date column for the `Scored Activities` tab.

Also, it's included the case when the resource has a **scheduling type = due by** and their **end date is nil** (border case)


https://github.com/Simon-Initiative/oli-torus/assets/16328384/bf5bc02e-f848-49de-b368-e61479064c22



[MER-2980]: https://eliterate.atlassian.net/browse/MER-2980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ