### PR TITLE
[BUG] provide Jason.Encoder for License [MER-3075]

### DIFF
--- a/lib/oli/authoring/course/project_attributes.ex
+++ b/lib/oli/authoring/course/project_attributes.ex
@@ -30,6 +30,7 @@ defmodule Oli.Authoring.Course.ProjectAttributes.License do
 
   @license_opts Map.keys(CreativeCommons.cc_options())
 
+  @derive Jason.Encoder
   @primary_key false
   embedded_schema do
     field(:license_type, Ecto.Enum, values: @license_opts, default: :none)


### PR DESCRIPTION
Adds directive to derive Jason.Encoder for License now included in Project Attributes. Without this, export function crashes on attempt to write project file.