### PR TITLE
[BUGFIX] Prevent export crashes on migrated image hotspots [MER-3076]

### DIFF
--- a/lib/oli/interop/export.ex
+++ b/lib/oli/interop/export.ex
@@ -121,6 +121,9 @@ defmodule Oli.Interop.Export do
         {results, _} = rewire_elements(adjusted_content, project)
         content = Map.put(map, "model", results["children"])
         Map.put(content_as_list, "content", content)
+
+      nil ->
+        content_as_list
     end
   end
 


### PR DESCRIPTION
Export function crashes on any migrated course with image hotspots because migration tool writes them as choices without content, but the reference rewiring process searches choices in activities and is not prepared for them to lack content.  This change has the relevant function ignore activity elements without a content attribute, returning them unchanged. 