### PR TITLE
[MER-3077] fix missing render_opts render_point_markers

### DIFF
--- a/lib/oli_web/components/delivery/deliberate_practice_card.ex
+++ b/lib/oli_web/components/delivery/deliberate_practice_card.ex
@@ -50,7 +50,9 @@ defmodule OliWeb.Components.Delivery.DeliberatePractice do
           nil
         else
           Content.render(
-            %Oli.Rendering.Context{render_opts: %{render_errors: true}},
+            %Oli.Rendering.Context{
+              render_opts: %{render_errors: true, render_point_markers: false}
+            },
             intro_content,
             Content.Html
           )

--- a/lib/oli_web/live/delivery/student/explorations_live.ex
+++ b/lib/oli_web/live/delivery/student/explorations_live.ex
@@ -107,7 +107,9 @@ defmodule OliWeb.Delivery.Student.ExplorationsLive do
           nil
         else
           Content.render(
-            %Oli.Rendering.Context{render_opts: %{render_errors: true}},
+            %Oli.Rendering.Context{
+              render_opts: %{render_errors: true, render_point_markers: false}
+            },
             intro_content,
             Content.Html
           )


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-3077

Fixes an issue where missing `render_point_markers` crashes exploration and practice views.

This is likely just a short term fix to address the immediate issue, rendering logic should better handle this case so that `render_point_markers` doesn't need to be explicitly specified.
