### PR TITLE
[BUGFIX] fix crash on author/admin add enrollment [MER-3072]

### DIFF
--- a/lib/oli_web/components/delivery/students/students.ex
+++ b/lib/oli_web/components/delivery/students/students.ex
@@ -61,7 +61,7 @@ defmodule OliWeb.Components.Delivery.Students do
        add_enrollments_selected_role: :student,
        add_enrollments_emails: [],
        add_enrollments_users_not_found: [],
-       inviter: "user",
+       inviter: if(is_nil(ctx.author), do: "user", else: "author"),
        current_user: ctx.user,
        current_author: ctx.author
      )}


### PR DESCRIPTION
Attempts to Add Enrollment from Manage/Students/Report) when logged in with Author account (which includes Admins) caused 500 error. Happened because "inviter" account type initialized to "user" as default. There is code in the process to present user with a choice of inviter accounts, which could change it to "author" for an authoring account. But this is only used in case logged in under two accounts. So when only Author account logged in, back-end winds up looking for logged-in  "user" type account and fails to find it. 

Fix is to conditionally initialize the "inviter" account type string appropriately. 