### PR TITLE
[BUGFIX] fix crash on author/admin add enrollment [MER-3072] (#4715)

### DIFF
--- a/lib/oli_web/components/delivery/students/students.ex
+++ b/lib/oli_web/components/delivery/students/students.ex
@@ -61,7 +61,7 @@ defmodule OliWeb.Components.Delivery.Students do
        add_enrollments_selected_role: :student,
        add_enrollments_emails: [],
        add_enrollments_users_not_found: [],
-       inviter: "user",
+       inviter: if(is_nil(ctx.author), do: "user", else: "author"),
        current_user: ctx.user,
        current_author: ctx.author
      )}

--- a/test/oli_web/live/delivery/instructor_dashboard/reports/students_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/reports/students_tab_test.exs
@@ -702,12 +702,14 @@ defmodule OliWeb.Delivery.InstructorDashboard.StudentsTabTest do
       assert has_element?(view, "p", "You're signed with two accounts.")
       assert has_element?(view, "p", "Please select the one to use as an inviter:")
 
-      refute view |> element("fieldset input#author") |> render() =~ "checked=\"checked\""
-      assert view |> element("fieldset input#user") |> render() =~ "checked=\"checked\""
-
-      view |> element("fieldset input#author") |> render_click()
+      # when logged in under two accounts, "author" selected by default
       assert view |> element("fieldset input#author") |> render() =~ "checked=\"checked\""
       refute view |> element("fieldset input#user") |> render() =~ "checked=\"checked\""
+
+      # can change to "user" account
+      view |> element("fieldset input#user") |> render_click()
+      refute view |> element("fieldset input#author") |> render() =~ "checked=\"checked\""
+      assert view |> element("fieldset input#user") |> render() =~ "checked=\"checked\""
 
       # Send the invitations (this mocks the POST request made by the form)
       conn =
@@ -717,7 +719,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.StudentsTabTest do
             emails: [user_1.email, user_2.email, non_existant_email_1],
             role: "instructor",
             "g-recaptcha-response": "any",
-            inviter: "author"
+            inviter: "user"
           )
         )
 


### PR DESCRIPTION
Pulled from https://github.com/Simon-Initiative/oli-torus/pull/4715 into v27

Original ticket: https://eliterate.atlassian.net/browse/MER-3072

* fix inviter type initialization for author-only case

* update add enrollment test

* comment test & make consistent
