### PR TITLE
[BUGFIX] [MER-2487] | BB Unit 8: Launch Simulator - finishedDialog in Launch Simulator is seemingly obscured, preventing the 'x' from being shown.

### DIFF
--- a/assets/src/apps/delivery/layouts/deck/LessonFinishedDialog.tsx
+++ b/assets/src/apps/delivery/layouts/deck/LessonFinishedDialog.tsx
@@ -113,10 +113,10 @@ const LessonFinishedDialog: React.FC<LessonFinishedDialogProps> = ({
         aria-hidden={!isOpen}
         style={{
           display: isOpen ? 'block' : 'none',
-          minHeight: '350px',
+          minHeight: '250px',
           height: 'unset',
           width: '500px',
-          top: '20%',
+          top: '25%',
           backgroundImage: imageUrl ? `url('${imageUrl}')` : '',
           left: '50%',
         }}

--- a/assets/src/apps/delivery/layouts/deck/components/ReviewModeHistoryPanel.tsx
+++ b/assets/src/apps/delivery/layouts/deck/components/ReviewModeHistoryPanel.tsx
@@ -109,6 +109,7 @@ const ReviewModeHistoryPanel: React.FC<ReviewModeHistoryPanelProps> = ({ items }
           <div className="title screenListTitle">
             Lesson History
             <a
+              className="review-mode-panel-close-button"
               onClick={() => handleToggleHistory(false)}
               style={{ float: 'right', color: 'white', cursor: 'pointer' }}
             >
@@ -116,7 +117,7 @@ const ReviewModeHistoryPanel: React.FC<ReviewModeHistoryPanelProps> = ({ items }
             </a>
           </div>
           <div
-            className="fixed top-0 w-72 text-black bg-white p-2 border-gray-500 border-2 max-h-[80vh] overflow-auto"
+            className="review-mode-screen-list fixed top-0 w-72 text-black bg-white p-2 border-gray-500 border-2 max-h-[80vh] overflow-auto"
             style={{
               transform: 'translate(-50%, 110px)',
             }}


### PR DESCRIPTION
Hey @bsparks, could you please look at the PR. Thanks