### PR TITLE
[BUGFIX] Fix multi-input custom score display on resetting default [MER-3117]

### DIFF
--- a/assets/src/components/activities/multi_input/sections/AnswerKeyTab.tsx
+++ b/assets/src/components/activities/multi_input/sections/AnswerKeyTab.tsx
@@ -20,7 +20,7 @@ import { InputEntry } from 'components/activities/short_answer/sections/InputEnt
 import { getTargetedResponses } from 'components/activities/short_answer/utils';
 import { Response, RichText, makeResponse } from 'components/activities/types';
 import { Radio } from 'components/misc/icons/radio/Radio';
-import { getCorrectResponse, hasCustomScoring } from 'data/activities/model/responses';
+import { getCorrectResponse } from 'data/activities/model/responses';
 import { containsRule, eqRule, equalsRule } from 'data/activities/model/rules';
 import { defaultWriterContext } from 'data/content/writers/context';
 import { MultiInputScoringMethod } from '../MultiInputScoringMethod';

--- a/assets/src/components/activities/multi_input/sections/AnswerKeyTab.tsx
+++ b/assets/src/components/activities/multi_input/sections/AnswerKeyTab.tsx
@@ -127,7 +127,7 @@ export const AnswerKeyTab: React.FC<Props> = (props) => {
           updateScore={(_id, score) =>
             dispatch(ResponseActions.editResponseScore(response.id, score))
           }
-          customScoring={hasCustomScoring(model, props.input.partId)}
+          customScoring={model.customScoring}
           removeResponse={(id) => dispatch(ResponseActions.removeResponse(id))}
           key={response.id}
         >


### PR DESCRIPTION
Targeted feedback authoring display for multi-inputs conditionally shows either:
 
  - a "Correct" checkbox (default);
  
 or, if custom scoring is set on the question,
 
  -  a "Score" box to enter custom score points for this response.
  
However, once custom scoring was checked for the question, the score box for targeted feedbacks was not reverting to checkbox when question scoring reset to default scoring. 

This fixes by conditionalizing the display on the question-wide customScoring flag.