### PR TITLE
[NG23-81] user reacts to an existing note

### DIFF
--- a/lib/oli/resources/collaboration.ex
+++ b/lib/oli/resources/collaboration.ex
@@ -7,7 +7,7 @@ defmodule Oli.Resources.Collaboration do
   alias Oli.Delivery.Sections.{Section, SectionResource, SectionsProjectsPublications}
   alias Oli.Resources
   alias Oli.Resources.{ResourceType, Revision}
-  alias Oli.Resources.Collaboration.{CollabSpaceConfig, Post, UserReadPost}
+  alias Oli.Resources.Collaboration.{CollabSpaceConfig, Post, UserReadPost, UserReactionPost}
   alias Oli.Repo
   alias Oli.Accounts.User
 
@@ -1131,6 +1131,8 @@ defmodule Oli.Resources.Collaboration do
         on: replies.thread_root_id == post.id,
         left_join: read_replies in subquery(read_replies_subquery(user_id)),
         on: read_replies.thread_root_id == post.id,
+        left_join: reactions in assoc(post, :reactions),
+        left_join: user in assoc(post, :user),
         where:
           post.section_id == ^section_id and post.resource_id == ^resource_id and
             is_nil(post.parent_post_id) and is_nil(post.thread_root_id) and
@@ -1139,7 +1141,7 @@ defmodule Oli.Resources.Collaboration do
         where: ^filter_by_point_block_id,
         where: post.visibility == ^visibility,
         order_by: [desc: :inserted_at],
-        preload: [:user],
+        preload: [user: user, reactions: reactions],
         select: %{
           post
           | replies_count: coalesce(replies.count, 0),
@@ -1147,6 +1149,19 @@ defmodule Oli.Resources.Collaboration do
         }
       )
     )
+    |> count_reactions()
+  end
+
+  defp count_reactions(posts) do
+    Enum.map(posts, fn post ->
+      %{
+        post
+        | reaction_counts:
+            Enum.reduce(post.reactions, %{}, fn r, acc ->
+              Map.update(acc, r.reaction, 1, &(&1 + 1))
+            end)
+      }
+    end)
   end
 
   @doc """
@@ -1189,10 +1204,46 @@ defmodule Oli.Resources.Collaboration do
           post.parent_post_id == ^post_id and
             (post.status in [:approved, :archived] or
                (post.status == :submitted and post.user_id == ^user_id)),
-        select: post,
-        order_by: [asc: :updated_at]
+        order_by: [asc: :updated_at],
+        preload: [user: user],
+        select: post
       )
     )
     |> build_metrics_for_reply_posts(user_id)
+  end
+
+  def toggle_reaction(post_id, user_id, reaction) do
+    case get_reaction(post_id, user_id, reaction) do
+      nil ->
+        case create_reaction(post_id, user_id, reaction) do
+          {:ok, _} ->
+            {:ok, 1}
+
+          error ->
+            error
+        end
+
+      reaction ->
+        case delete_reaction(reaction) do
+          {:ok, _} ->
+            {:ok, -1}
+
+          error ->
+            error
+        end
+    end
+  end
+
+  def get_reaction(post_id, user_id, reaction) do
+    Repo.get_by(UserReactionPost, post_id: post_id, user_id: user_id, reaction: reaction)
+  end
+
+  def create_reaction(post_id, user_id, reaction) do
+    %UserReactionPost{post_id: post_id, user_id: user_id, reaction: reaction}
+    |> Repo.insert()
+  end
+
+  def delete_reaction(%UserReactionPost{} = reaction) do
+    Repo.delete(reaction)
   end
 end

--- a/lib/oli/resources/collaboration.ex
+++ b/lib/oli/resources/collaboration.ex
@@ -1104,10 +1104,10 @@ defmodule Oli.Resources.Collaboration do
 
   ## Examples
 
-      iex> list_posts_for_user_in_point_block(1, 1, 1, "1"))
+      iex> list_posts_for_user_in_point_block(1, 1, 1, :private, "1"))
       [%Post{status: :archived}, ...]
 
-      iex> list_posts_for_user_in_point_block(2, 2, 2, "2")
+      iex> list_posts_for_user_in_point_block(2, 2, 2, :private, "2")
       []
   """
   def list_posts_for_user_in_point_block(

--- a/lib/oli/resources/collaboration/post.ex
+++ b/lib/oli/resources/collaboration/post.ex
@@ -36,6 +36,10 @@ defmodule Oli.Resources.Collaboration.Post do
 
     field :anonymous, :boolean, default: false
 
+    has_many :reactions, Oli.Resources.Collaboration.UserReactionPost
+
+    field :reaction_counts, :map, virtual: true
+
     timestamps(type: :utc_datetime)
   end
 

--- a/lib/oli/resources/collaboration/user_reaction_post.ex
+++ b/lib/oli/resources/collaboration/user_reaction_post.ex
@@ -1,0 +1,28 @@
+defmodule Oli.Resources.Collaboration.UserReactionPost do
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  schema "user_reaction_posts" do
+    field :reaction, Ecto.Enum, values: [:like], default: :like
+
+    belongs_to :user, Oli.Accounts.User
+    belongs_to :post, Oli.Resources.Collaboration.Post
+
+    timestamps(type: :utc_datetime)
+  end
+
+  def changeset(post, attrs \\ %{}) do
+    post
+    |> cast(attrs, [
+      :reaction,
+      :user_id,
+      :post_id
+    ])
+    |> validate_required([
+      :reaction,
+      :user_id,
+      :post_id
+    ])
+  end
+end

--- a/lib/oli_web/live/delivery/student/lesson/annotations.ex
+++ b/lib/oli_web/live/delivery/student/lesson/annotations.ex
@@ -47,7 +47,12 @@ defmodule OliWeb.Delivery.Student.Lesson.Annotations do
               <div class="text-center p-4 text-gray-500"><%= empty_label(@active_tab) %></div>
             <% annotations -> %>
               <%= for annotation <- annotations do %>
-                <.post post={annotation} current_user={@current_user} post_replies={@post_replies} />
+                <.post
+                  post={annotation}
+                  current_user={@current_user}
+                  post_replies={@post_replies}
+                  disable_anonymous_option={@active_tab == :my_notes || is_guest(@current_user)}
+                />
               <% end %>
           <% end %>
         </div>
@@ -289,6 +294,7 @@ defmodule OliWeb.Delivery.Student.Lesson.Annotations do
   attr :post, Oli.Resources.Collaboration.Post, required: true
   attr :current_user, Oli.Accounts.User, required: true
   attr :post_replies, :any, required: true
+  attr :disable_anonymous_option, :boolean, default: false
 
   defp post(assigns) do
     ~H"""
@@ -305,7 +311,12 @@ defmodule OliWeb.Delivery.Student.Lesson.Annotations do
         <%= @post.content.message %>
       </p>
       <.post_actions post={@post} />
-      <.post_replies post={@post} replies={@post_replies} current_user={@current_user} />
+      <.post_replies
+        post={@post}
+        replies={@post_replies}
+        current_user={@current_user}
+        disable_anonymous_option={@disable_anonymous_option}
+      />
     </div>
     """
   end
@@ -347,15 +358,28 @@ defmodule OliWeb.Delivery.Student.Lesson.Annotations do
 
       %Oli.Resources.Collaboration.Post{visibility: :public} ->
         ~H"""
-        <div class="flex flex-row gap-2 my-2">
+        <div class="flex flex-row gap-3 my-2">
+          <button
+            class="inline-flex gap-1 text-sm text-gray-500 bold py-1 px-2 rounded-lg hover:bg-gray-100"
+            phx-click="toggle_reaction"
+            phx-value-reaction={:like}
+            phx-value-post-id={assigns.post.id}
+          >
+            <.like_icon />
+            <%= case Map.get(@post.reaction_counts, :like) do %>
+              <% nil -> %>
+              <% count -> %>
+                <%= if(count > 0, do: count) %>
+            <% end %>
+          </button>
           <button
             class="inline-flex gap-1 text-sm text-gray-500 bold py-1 px-2 rounded-lg hover:bg-gray-100"
             phx-click="toggle_post_replies"
             phx-value-post-id={assigns.post.id}
           >
-            <.replies_bubble_icon /> <%= if(@post.replies_count > 0,
-              do: @post.replies_count,
-              else: "Reply"
+            <.replies_bubble_icon />
+            <%= if(@post.replies_count > 0,
+              do: @post.replies_count
             ) %>
           </button>
         </div>
@@ -539,6 +563,20 @@ defmodule OliWeb.Delivery.Student.Lesson.Annotations do
         clip-rule="evenodd"
         d="M11.7869 2.27309C7.1428 2.27309 3.37805 6.03784 3.37805 10.6819C3.37805 12.0261 3.69262 13.2936 4.25113 14.4177C4.38308 14.6833 4.4045 14.9903 4.31072 15.2717L2.8872 19.5421L7.20077 18.1512C7.47968 18.0613 7.78271 18.084 8.04505 18.2146C9.17069 18.775 10.4403 19.0907 11.7869 19.0907C16.4309 19.0907 20.1957 15.3259 20.1957 10.6819C20.1957 6.03784 16.4309 2.27309 11.7869 2.27309ZM1.13425 10.6819C1.13425 4.79863 5.90359 0.0292969 11.7869 0.0292969C17.6701 0.0292969 22.4395 4.79863 22.4395 10.6819C22.4395 16.5652 17.6701 21.3345 11.7869 21.3345C10.2515 21.3345 8.78951 21.009 7.46835 20.4225L1.46623 22.3579C1.06368 22.4877 0.622338 22.38 0.324734 22.0795C0.0271304 21.779 -0.0761506 21.3366 0.0576046 20.9353L2.04039 14.9871C1.45758 13.6695 1.13425 12.2121 1.13425 10.6819Z"
         fill="#2D3648"
+      />
+    </svg>
+    """
+  end
+
+  defp like_icon(assigns) do
+    ~H"""
+    <svg width="22" height="24" viewBox="0 0 22 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M6 10.6466L10 1.11719C10.7956 1.11719 11.5587 1.45185 12.1213 2.04755C12.6839 2.64326 13 3.45121 13 4.29366V8.52895H18.66C18.9499 8.52548 19.2371 8.58878 19.5016 8.71448C19.7661 8.84017 20.0016 9.02526 20.1919 9.25691C20.3821 9.48856 20.5225 9.76123 20.6033 10.056C20.6842 10.3508 20.7035 10.6607 20.66 10.9642L19.28 20.4937C19.2077 20.9986 18.9654 21.4589 18.5979 21.7897C18.2304 22.1204 17.7623 22.2994 17.28 22.2937H6M6 10.6466V22.2937M6 10.6466H3C2.46957 10.6466 1.96086 10.8697 1.58579 11.2668C1.21071 11.664 1 12.2026 1 12.7642V20.176C1 20.7376 1.21071 21.2763 1.58579 21.6734C1.96086 22.0705 2.46957 22.2937 3 22.2937H6"
+        stroke="#383A44"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
       />
     </svg>
     """

--- a/lib/oli_web/live/delivery/student/lesson/annotations.ex
+++ b/lib/oli_web/live/delivery/student/lesson/annotations.ex
@@ -404,7 +404,10 @@ defmodule OliWeb.Delivery.Student.Lesson.Annotations do
         <% {_, :loading} -> %>
           <Common.loading_spinner />
         <% {_, []} -> %>
-          <.add_new_reply_input parent_post_id={@post.id} />
+          <.add_new_reply_input
+            parent_post_id={@post.id}
+            disable_anonymous_option={@disable_anonymous_option}
+          />
         <% {_, replies} -> %>
           <div class="flex flex-col gap-2 pl-4">
             <%= for reply <- replies do %>

--- a/priv/repo/migrations/20240328190716_user_reaction_posts.exs
+++ b/priv/repo/migrations/20240328190716_user_reaction_posts.exs
@@ -1,0 +1,15 @@
+defmodule Oli.Repo.Migrations.UserReactionPosts do
+  use Ecto.Migration
+
+  def change do
+    create table(:user_reaction_posts) do
+      add :reaction, :string, default: "like"
+      add :post_id, references(:posts, on_delete: :delete_all)
+      add :user_id, references(:users, on_delete: :delete_all)
+
+      timestamps(type: :timestamptz)
+    end
+
+    create unique_index(:user_reaction_posts, [:reaction, :post_id, :user_id])
+  end
+end


### PR DESCRIPTION
**NOTE:** Changes are currently based on [NG23-82 branch](https://github.com/Simon-Initiative/oli-torus/pull/4721) and includes those changes as well

https://eliterate.atlassian.net/browse/NG23-81

Implements the ability for a user to react to an existing note. Currently the only supported reaction is "like" however this could be expanded to other reaction types in the future.

<img width="1573" alt="Screenshot 2024-03-29 at 9 36 52 AM" src="https://github.com/Simon-Initiative/oli-torus/assets/6248894/c7e8bb80-50df-40a7-a4dd-9b397c13a742">
