### PR TITLE
[BUGFIX][MER-2614] Trying to add an institution to community fails

### DIFF
--- a/lib/oli/groups.ex
+++ b/lib/oli/groups.ex
@@ -640,6 +640,29 @@ defmodule Oli.Groups do
   end
 
   @doc """
+  Creates a community institution from an institution id (gets the institution first).
+
+  ## Examples
+
+      iex> create_community_institution_from_institution_id(1, %{community_id: 1})
+      {:ok, %CommunityInstitution{}}
+
+      iex> create_community_institution_from_institution_id(0, %{community_id: 1})
+      {:error, :institution_not_found}
+
+  """
+
+  def create_community_institution_from_institution_id(institution_id, attrs \\ %{}) do
+    case Institutions.get_institution_by!(%{id: institution_id}) do
+      %Institution{} ->
+        attrs |> Map.put(:institution_id, institution_id) |> create_community_institution()
+
+      nil ->
+        {:error, :institution_not_found}
+    end
+  end
+
+  @doc """
   Creates community institutions from names.
   ## Examples
       iex> create_community_institutions_from_names(["Institution 1", "Institution 2"], %{community_id: 1})
@@ -654,6 +677,23 @@ defmodule Oli.Groups do
         names,
         attrs,
         &create_community_institution_from_institution_name/2
+      )
+
+  @doc """
+  Creates community institutions from ids.
+  ## Examples
+      iex> create_community_institutions_from_ids([1], %{community_id: 1})
+      {:ok, [%CommunityInstitution{}, %CommunityInstitution{}]}
+      iex> create_community_institutions_from_ids([1], %{community_id: bad_value})
+      {:error, %Ecto.Changeset{}}
+  """
+
+  def create_community_institutions_from_ids(ids, attrs),
+    do:
+      create_community_associations_from_fields(
+        ids,
+        attrs,
+        &create_community_institution_from_institution_id/2
       )
 
   @doc """

--- a/lib/oli_web/live/community_live/invitation.ex
+++ b/lib/oli_web/live/community_live/invitation.ex
@@ -4,7 +4,7 @@ defmodule OliWeb.CommunityLive.Invitation do
   attr(:list_id, :string, required: true)
   attr(:invite, :any, required: true)
   attr(:remove, :any, required: true)
-  attr(:suggest, :any)
+  attr(:suggest, :any, default: nil)
   attr(:collaborators, :any, default: [])
   attr(:matches, :any, default: [])
   attr(:to_invite, :any, default: :collaborator)
@@ -13,6 +13,7 @@ defmodule OliWeb.CommunityLive.Invitation do
   attr(:placeholder, :string, default: "collaborator@example.edu")
   attr(:button_text, :string, default: "Send invite")
   attr(:allow_removal, :boolean, default: true)
+  attr(:available_institutions, :list, default: [])
 
   def render(assigns) do
     ~H"""
@@ -22,17 +23,35 @@ defmodule OliWeb.CommunityLive.Invitation do
       as={@to_invite}
       phx-submit={@invite}
       phx-change={@suggest}
-      class="d-flex mb-5"
+      class="flex items-center gap-x-4 mb-5"
     >
       <div class="w-100">
-        <.input
-          name={@search_field}
-          value=""
-          class="form-control"
-          placeholder={@placeholder}
-          autocomplete="off"
-          list={@list_id}
-        />
+        <%= if @list_id == "institution_matches" do %>
+          <select class="torus-select" name="institution_id">
+            <option value="" selected hidden>Select an institution</option>
+            <option
+              :for={institution <- @available_institutions}
+              value={institution.id}
+              disabled={
+                if institution.id in Enum.map(@collaborators, & &1.id),
+                  do: true,
+                  else: false
+              }
+            >
+              <%= institution.name %>
+            </option>
+          </select>
+        <% else %>
+          <.input
+            name={@search_field}
+            value=""
+            class="form-control"
+            placeholder={@placeholder}
+            autocomplete="off"
+            list={@list_id}
+          />
+        <% end %>
+
         <datalist id={@list_id}>
           <%= for match <- @matches do %>
             <option value={Map.get(match, @search_field)}>

--- a/lib/oli_web/live/community_live/show_view.ex
+++ b/lib/oli_web/live/community_live/show_view.ex
@@ -369,7 +369,7 @@ defmodule OliWeb.CommunityLive.ShowView do
       {:noreply, socket}
     else
       socket =
-        case Groups.create_community_institutions_from_ids(institution_id |> List.wrap(), %{
+        case Groups.create_community_institutions_from_ids([institution_id], %{
                community_id: community_id
              }) do
           {:ok, _community_institutions} ->

--- a/lib/oli_web/live/community_live/show_view.ex
+++ b/lib/oli_web/live/community_live/show_view.ex
@@ -46,6 +46,10 @@ defmodule OliWeb.CommunityLive.ShowView do
           community_members = Groups.list_community_members(community_id, 3)
           community_institutions = Groups.list_community_institutions(community_id)
 
+          available_institutions =
+            Institutions.list_institutions()
+            |> Enum.sort_by(& &1.name)
+
           assign(socket,
             community: community,
             form: to_form(changeset),
@@ -55,7 +59,8 @@ defmodule OliWeb.CommunityLive.ShowView do
             community_members: community_members,
             community_institutions: community_institutions,
             is_system_admin: is_system_admin,
-            matches: %{"admin" => [], "member" => [], "institution" => []}
+            matches: %{"admin" => [], "member" => [], "institution" => []},
+            available_institutions: available_institutions
           )
       end
 
@@ -133,12 +138,12 @@ defmodule OliWeb.CommunityLive.ShowView do
           search_field={:name}
           invite="add_institution"
           remove="remove_institution"
-          suggest="suggest_institution"
           matches={@matches["institution"]}
           main_fields={[primary: :name, secondary: :institution_email]}
           placeholder="Institution name"
           button_text="Add"
           collaborators={@community_institutions}
+          available_institutions={@available_institutions}
         />
       </ShowSection.render>
 
@@ -338,31 +343,50 @@ defmodule OliWeb.CommunityLive.ShowView do
     {:noreply, socket}
   end
 
-  def handle_event("add_institution", %{"name" => name}, socket) do
+  def handle_event(
+        "add_institution",
+        %{"institution_id" => ""},
+        socket
+      ) do
+    socket = clear_flash(socket)
+    socket = put_flash(socket, :error, "Please select an institution.")
+    {:noreply, socket}
+  end
+
+  def handle_event(
+        "add_institution",
+        %{"institution_id" => institution_id},
+        socket
+      ) do
     socket = clear_flash(socket)
     community_id = socket.assigns.community.id
+    institution_id = String.to_integer(institution_id)
 
-    names =
-      name
-      |> String.split(",")
-      |> Enum.map(&String.trim(&1))
+    institutions_added = socket.assigns.community_institutions |> Enum.map(& &1.id)
 
-    socket =
-      case Groups.create_community_institutions_from_names(names, %{
-             community_id: community_id
-           }) do
-        {:ok, _community_institutions} ->
-          put_flash(socket, :info, "Community institution(s) successfully added.")
+    if institution_id in institutions_added do
+      socket = put_flash(socket, :error, "Institution has already been added to the community.")
+      {:noreply, socket}
+    else
+      socket =
+        case Groups.create_community_institutions_from_ids(institution_id |> List.wrap(), %{
+               community_id: community_id
+             }) do
+          {:ok, _community_institutions} ->
+            put_flash(socket, :info, "Community institution(s) successfully added.")
 
-        {:error, _error} ->
-          message =
-            "Some of the community institutions couldn't be added because the institutions don't exist in the system or are already associated."
+          {:error, _error} ->
+            message =
+              "Some of the community institutions couldn't be added because the institutions don't exist in the system or are already associated."
 
-          put_flash(socket, :error, message)
-      end
+            put_flash(socket, :error, message)
+        end
 
-    {:noreply,
-     assign(socket, community_institutions: Groups.list_community_institutions(community_id))}
+      {:noreply,
+       assign(socket,
+         community_institutions: Groups.list_community_institutions(community_id)
+       )}
+    end
   end
 
   def handle_event("remove_institution", %{"collaborator-id" => institution_id}, socket) do


### PR DESCRIPTION
[MER-2614](https://eliterate.atlassian.net/browse/MER-2614)

This PR modifies the input used to add an institution to a community in the community overview view. 

it changes that input making it dropdown, to allow users to choose among the available institutions that have already been created.

If an institution has already been added to a community, it will be shown as disabled in the dropdown list so that the user cannot add it again.


https://github.com/Simon-Initiative/oli-torus/assets/16328384/6613f445-0f39-453c-a618-b7f0f314166c



[MER-2614]: https://eliterate.atlassian.net/browse/MER-2614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ