### PR TITLE
[FEATURE] [MER-2629] timeout loss of authentication messaging

### DIFF
--- a/assets/src/phoenix/app.ts
+++ b/assets/src/phoenix/app.ts
@@ -31,6 +31,8 @@ import { finalize } from './finalize';
 import { showModal } from './modal';
 import { enableSubmitWhenTitleMatches } from './package_delete';
 import { onReady } from './ready';
+import { sessionTimeout } from './session_timeout';
+
 
 (window as any).Alert = Alert;
 (window as any).Button = Button;
@@ -95,6 +97,7 @@ window.OLI = {
   onReady,
   finalize,
   initCountdownTimer,
+  sessionTimeout,
   initEndDateTimer,
   CreateAccountPopup: (node: any, props: any) => mount(CreateAccountPopup, node, props),
 };
@@ -175,6 +178,7 @@ declare global {
     toggleAudio: (element: HTMLAudioElement) => void;
     OLI: {
       initActivityBridge: typeof initActivityBridge;
+      sessionTimeout: typeof sessionTimeout;
       initPreviewActivityBridge: typeof initPreviewActivityBridge;
       showModal: typeof showModal;
       enableSubmitWhenTitleMatches: typeof enableSubmitWhenTitleMatches;

--- a/assets/src/phoenix/app.ts
+++ b/assets/src/phoenix/app.ts
@@ -33,7 +33,6 @@ import { enableSubmitWhenTitleMatches } from './package_delete';
 import { onReady } from './ready';
 import { sessionTimeout } from './session_timeout';
 
-
 (window as any).Alert = Alert;
 (window as any).Button = Button;
 (window as any).Dropdown = Dropdown;

--- a/assets/src/phoenix/session_timeout.tsx
+++ b/assets/src/phoenix/session_timeout.tsx
@@ -24,9 +24,8 @@ const SessionExpirationWarningComponent = (props: any) => {
   return (
     <div id="sessionExpirationId" className="fixed right-0" style={{ zIndex: 99 }}>
       <div
-        className={`${isEntering ? 'opacity-100' : 'opacity-0'} ${
-          isEntering ? 'translate-y-[0px]' : 'translate-y-[-25px]'
-        } transform transition duration-700 ease-in flex gap-2 items-center p-4 mb-4 text-sm text-yellow-800 rounded-lg bg-yellow-50 dark:bg-gray-800 dark:text-yellow-300 border-2 border-solid border-yellow-300`}
+        className={`${isEntering ? 'opacity-100' : 'opacity-0'} ${isEntering ? 'translate-y-[0px]' : 'translate-y-[-25px]'
+          } transform transition duration-700 ease-in flex gap-2 items-center p-4 mb-4 text-sm text-yellow-800 rounded-lg bg-yellow-50 dark:bg-gray-800 dark:text-yellow-300 border-2 border-solid border-yellow-300`}
         role="alert"
       >
         <svg
@@ -128,7 +127,6 @@ function triggerTimers() {
   const result = computeTimes();
   if (result !== undefined) {
     const { remainingTime, timeBeforeWarning } = result;
-    console.log(`remainingTime: ${remainingTime}, timeBeforeWarning: ${timeBeforeWarning}`);
     if (timeBeforeWarning > 0) {
       setTimeout(() => renderSessionExpirationWarning(), timeBeforeWarning);
     }

--- a/assets/src/phoenix/session_timeout.tsx
+++ b/assets/src/phoenix/session_timeout.tsx
@@ -1,6 +1,6 @@
-import React, { ReactElement, useState, useEffect } from 'react';
-import ReactDOM from 'react-dom';
+import React, { ReactElement, useEffect, useState } from 'react';
 import { Modal } from 'react-bootstrap';
+import ReactDOM from 'react-dom';
 
 // Constant value used to configure the time before the warning message is displayed
 // ms * sec * min example: 1000 * 60 * 5 = 5 minutes
@@ -11,34 +11,58 @@ export function sessionTimeout() {
   setTimeout(triggerTimers, 1000);
 }
 
-const unmountReactSessionExpContainer = () => { ReactDOM.unmountComponentAtNode(document.getElementById("sessionExpirationContainerId")!); }
+const unmountReactSessionExpContainer = () => {
+  ReactDOM.unmountComponentAtNode(document.getElementById('sessionExpirationContainerId')!);
+};
 
 const SessionExpirationWarningComponent = (props: any) => {
   const [isEntering, setIsEntering] = React.useState<boolean>(false);
 
-  setTimeout(() => { setIsEntering(true); });
+  setTimeout(() => {
+    setIsEntering(true);
+  });
   return (
-    <div id="sessionExpirationId" className='fixed right-0' style={{ zIndex: 99 }}>
-      <div className={`${isEntering ? "opacity-100" : "opacity-0"} ${isEntering ? "translate-y-[0px]" : "translate-y-[-25px]"} transform transition duration-700 ease-in flex gap-2 items-center p-4 mb-4 text-sm text-yellow-800 rounded-lg bg-yellow-50 dark:bg-gray-800 dark:text-yellow-300 border-2 border-solid border-yellow-300`} role="alert">
-        <svg className="flex-shrink-0 inline w-4 h-4 me-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+    <div id="sessionExpirationId" className="fixed right-0" style={{ zIndex: 99 }}>
+      <div
+        className={`${isEntering ? 'opacity-100' : 'opacity-0'} ${
+          isEntering ? 'translate-y-[0px]' : 'translate-y-[-25px]'
+        } transform transition duration-700 ease-in flex gap-2 items-center p-4 mb-4 text-sm text-yellow-800 rounded-lg bg-yellow-50 dark:bg-gray-800 dark:text-yellow-300 border-2 border-solid border-yellow-300`}
+        role="alert"
+      >
+        <svg
+          className="flex-shrink-0 inline w-4 h-4 me-3"
+          aria-hidden="true"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="currentColor"
+          viewBox="0 0 20 20"
+        >
           <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM9.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM12 15H8a1 1 0 0 1 0-2h1v-3H8a1 1 0 0 1 0-2h2a1 1 0 0 1 1 1v4h1a1 1 0 0 1 0 2Z" />
         </svg>
         <span className="sr-only">Info</span>
         <div>
           <span>{props.message}</span>
-
-          <span className="font-medium">Warning!</span> Your session will expire in <Timer initialMinute={props.minutes} initialSeconds={props.seconds} /> due to inactivity.
+          <span className="font-medium">Warning!</span> Your session will expire in{' '}
+          <Timer initialMinute={props.minutes} initialSeconds={props.seconds} /> due to inactivity.
         </div>
-        <button type="button" onClick={unmountReactSessionExpContainer} className="text-yellow-800 bg-transparent border border-yellow-800 hover:bg-yellow-900 hover:text-white focus:ring-4 focus:outline-none focus:ring-yellow-300 font-medium rounded-lg text-xs px-3 py-1.5 text-center dark:hover:bg-yellow-300 dark:border-yellow-300 dark:text-yellow-300 dark:hover:text-gray-800 dark:focus:ring-yellow-800" data-dismiss-target="#alert-additional-content-4" aria-label="Close">
+        <button
+          type="button"
+          onClick={unmountReactSessionExpContainer}
+          className="text-yellow-800 bg-transparent border border-yellow-800 hover:bg-yellow-900 hover:text-white focus:ring-4 focus:outline-none focus:ring-yellow-300 font-medium rounded-lg text-xs px-3 py-1.5 text-center dark:hover:bg-yellow-300 dark:border-yellow-300 dark:text-yellow-300 dark:hover:text-gray-800 dark:focus:ring-yellow-800"
+          data-dismiss-target="#alert-additional-content-4"
+          aria-label="Close"
+        >
           Close
         </button>
       </div>
-    </div >
+    </div>
   );
 };
 
 const SessionTimeoutComponent = () => {
-  const reloadPage = () => { unmountReactSessionExpContainer(); window.location.reload(); }
+  const reloadPage = () => {
+    unmountReactSessionExpContainer();
+    window.location.reload();
+  };
   return (
     <Modal
       dialogClassName={`session-modal`}
@@ -46,10 +70,17 @@ const SessionTimeoutComponent = () => {
       enforceFocus={true}
       style={{ overflow: 'auto' }}
     >
-      <Modal.Header><span className="title">Your session has expired</span></Modal.Header>
+      <Modal.Header>
+        <span className="title">Your session has expired</span>
+      </Modal.Header>
       <Modal.Body>Please log in again.</Modal.Body>
       <Modal.Footer>
-        <button type="button" onClick={reloadPage} className="btn btn-secondary" data-dismiss="modal">
+        <button
+          type="button"
+          onClick={reloadPage}
+          className="btn btn-secondary"
+          data-dismiss="modal"
+        >
           Close
         </button>
       </Modal.Footer>
@@ -63,19 +94,19 @@ const Timer = (props: any) => {
   const [minutes, setMinutes] = useState(initialMinute);
   const [seconds, setSeconds] = useState(initialSeconds);
   useEffect(() => {
-    let myInterval = setInterval(() => {
+    const myInterval = setInterval(() => {
       if (seconds > 0) {
         setSeconds(seconds - 1);
       }
       if (seconds === 0) {
         if (minutes === 0) {
-          clearInterval(myInterval)
+          clearInterval(myInterval);
         } else {
           setMinutes(minutes - 1);
           setSeconds(59);
         }
       }
-    }, 1000)
+    }, 1000);
     return () => {
       clearInterval(myInterval);
     };
@@ -83,13 +114,15 @@ const Timer = (props: any) => {
 
   return (
     <span>
-      {minutes === 0 && seconds === 0
-        ? null
-        : <span> {minutes}:{seconds < 10 ? `0${seconds}` : seconds}</span>
-      }
+      {minutes === 0 && seconds === 0 ? null : (
+        <span>
+          {' '}
+          {minutes}:{seconds < 10 ? `0${seconds}` : seconds}
+        </span>
+      )}
     </span>
-  )
-}
+  );
+};
 
 function triggerTimers() {
   const result = computeTimes();
@@ -106,7 +139,8 @@ function triggerTimers() {
 }
 
 const computeRemainingTime = (expirationTime: number): number => expirationTime - Date.now();
-const computeTimeBeforeWarning = (remainingTime: number): number => remainingTime - timeBeforeWarningMs;
+const computeTimeBeforeWarning = (remainingTime: number): number =>
+  remainingTime - timeBeforeWarningMs;
 const computeTimes = (): { remainingTime: number; timeBeforeWarning: number } | undefined => {
   const expirationTime = getCookie('_oli_session_expiration_time');
   if (expirationTime != undefined) {
@@ -115,20 +149,23 @@ const computeTimes = (): { remainingTime: number; timeBeforeWarning: number } | 
     return { remainingTime, timeBeforeWarning };
   }
   return undefined;
-}
+};
 
 function renderSessionExpirationWarning() {
   const result = computeTimes();
   if (result !== undefined) {
     const minutes = Math.floor(result.remainingTime / 60000);
     const seconds = Math.floor((result.remainingTime % 60000) / 1000);
-    renderComponent("sessionExpirationContainerId", <SessionExpirationWarningComponent minutes={minutes} seconds={seconds} />);
+    renderComponent(
+      'sessionExpirationContainerId',
+      <SessionExpirationWarningComponent minutes={minutes} seconds={seconds} />,
+    );
   }
 }
 
 function renderSessionExpirated() {
   unmountReactSessionExpContainer();
-  renderComponent("sessionExpirationContainerId", <SessionTimeoutComponent />);
+  renderComponent('sessionExpirationContainerId', <SessionTimeoutComponent />);
 }
 
 function renderComponent(id: string, component: ReactElement<any>) {
@@ -136,9 +173,9 @@ function renderComponent(id: string, component: ReactElement<any>) {
 }
 
 function getCookie(cname: string) {
-  let name = cname + "=";
-  let decodedCookie = decodeURIComponent(document.cookie);
-  let ca = decodedCookie.split(';');
+  const name = cname + '=';
+  const decodedCookie = decodeURIComponent(document.cookie);
+  const ca = decodedCookie.split(';');
   for (let i = 0; i < ca.length; i++) {
     let c = ca[i];
     while (c.charAt(0) == ' ') {

--- a/assets/src/phoenix/session_timeout.tsx
+++ b/assets/src/phoenix/session_timeout.tsx
@@ -24,8 +24,9 @@ const SessionExpirationWarningComponent = (props: any) => {
   return (
     <div id="sessionExpirationId" className="fixed right-0" style={{ zIndex: 99 }}>
       <div
-        className={`${isEntering ? 'opacity-100' : 'opacity-0'} ${isEntering ? 'translate-y-[0px]' : 'translate-y-[-25px]'
-          } transform transition duration-700 ease-in flex gap-2 items-center p-4 mb-4 text-sm text-yellow-800 rounded-lg bg-yellow-50 dark:bg-gray-800 dark:text-yellow-300 border-2 border-solid border-yellow-300`}
+        className={`${isEntering ? 'opacity-100' : 'opacity-0'} ${
+          isEntering ? 'translate-y-[0px]' : 'translate-y-[-25px]'
+        } transform transition duration-700 ease-in flex gap-2 items-center p-4 mb-4 text-sm text-yellow-800 rounded-lg bg-yellow-50 dark:bg-gray-800 dark:text-yellow-300 border-2 border-solid border-yellow-300`}
         role="alert"
       >
         <svg

--- a/assets/src/phoenix/session_timeout.tsx
+++ b/assets/src/phoenix/session_timeout.tsx
@@ -1,0 +1,152 @@
+import React, { ReactElement, useState, useEffect } from 'react';
+import ReactDOM from 'react-dom';
+import { Modal } from 'react-bootstrap';
+
+// Constant value used to configure the time before the warning message is displayed
+// ms * sec * min example: 1000 * 60 * 5 = 5 minutes
+const timeBeforeWarningMs = 1000 * 60 * 5;
+
+// This is the entry point for the session timeout feature.
+export function sessionTimeout() {
+  setTimeout(triggerTimers, 1000);
+}
+
+const unmountReactSessionExpContainer = () => { ReactDOM.unmountComponentAtNode(document.getElementById("sessionExpirationContainerId")!); }
+
+const SessionExpirationWarningComponent = (props: any) => {
+  const [isEntering, setIsEntering] = React.useState<boolean>(false);
+
+  setTimeout(() => { setIsEntering(true); });
+  return (
+    <div id="sessionExpirationId" className='fixed right-0' style={{ zIndex: 99 }}>
+      <div className={`${isEntering ? "opacity-100" : "opacity-0"} ${isEntering ? "translate-y-[0px]" : "translate-y-[-25px]"} transform transition duration-700 ease-in flex gap-2 items-center p-4 mb-4 text-sm text-yellow-800 rounded-lg bg-yellow-50 dark:bg-gray-800 dark:text-yellow-300 border-2 border-solid border-yellow-300`} role="alert">
+        <svg className="flex-shrink-0 inline w-4 h-4 me-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+          <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM9.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM12 15H8a1 1 0 0 1 0-2h1v-3H8a1 1 0 0 1 0-2h2a1 1 0 0 1 1 1v4h1a1 1 0 0 1 0 2Z" />
+        </svg>
+        <span className="sr-only">Info</span>
+        <div>
+          <span>{props.message}</span>
+
+          <span className="font-medium">Warning!</span> Your session will expire in <Timer initialMinute={props.minutes} initialSeconds={props.seconds} /> due to inactivity.
+        </div>
+        <button type="button" onClick={unmountReactSessionExpContainer} className="text-yellow-800 bg-transparent border border-yellow-800 hover:bg-yellow-900 hover:text-white focus:ring-4 focus:outline-none focus:ring-yellow-300 font-medium rounded-lg text-xs px-3 py-1.5 text-center dark:hover:bg-yellow-300 dark:border-yellow-300 dark:text-yellow-300 dark:hover:text-gray-800 dark:focus:ring-yellow-800" data-dismiss-target="#alert-additional-content-4" aria-label="Close">
+          Close
+        </button>
+      </div>
+    </div >
+  );
+};
+
+const SessionTimeoutComponent = () => {
+  const reloadPage = () => { unmountReactSessionExpContainer(); window.location.reload(); }
+  return (
+    <Modal
+      dialogClassName={`session-modal`}
+      show={true}
+      enforceFocus={true}
+      style={{ overflow: 'auto' }}
+    >
+      <Modal.Header><span className="title">Your session has expired</span></Modal.Header>
+      <Modal.Body>Please log in again.</Modal.Body>
+      <Modal.Footer>
+        <button type="button" onClick={reloadPage} className="btn btn-secondary" data-dismiss="modal">
+          Close
+        </button>
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+// https://stackoverflow.com/questions/40885923/countdown-timer-in-react
+const Timer = (props: any) => {
+  const { initialMinute = 0, initialSeconds = 0 } = props;
+  const [minutes, setMinutes] = useState(initialMinute);
+  const [seconds, setSeconds] = useState(initialSeconds);
+  useEffect(() => {
+    let myInterval = setInterval(() => {
+      if (seconds > 0) {
+        setSeconds(seconds - 1);
+      }
+      if (seconds === 0) {
+        if (minutes === 0) {
+          clearInterval(myInterval)
+        } else {
+          setMinutes(minutes - 1);
+          setSeconds(59);
+        }
+      }
+    }, 1000)
+    return () => {
+      clearInterval(myInterval);
+    };
+  });
+
+  return (
+    <span>
+      {minutes === 0 && seconds === 0
+        ? null
+        : <span> {minutes}:{seconds < 10 ? `0${seconds}` : seconds}</span>
+      }
+    </span>
+  )
+}
+
+function triggerTimers() {
+  const result = computeTimes();
+  if (result !== undefined) {
+    const { remainingTime, timeBeforeWarning } = result;
+    console.log(`remainingTime: ${remainingTime}, timeBeforeWarning: ${timeBeforeWarning}`);
+    if (timeBeforeWarning > 0) {
+      setTimeout(() => renderSessionExpirationWarning(), timeBeforeWarning);
+    }
+    if (remainingTime > 0) {
+      setTimeout(renderSessionExpirated, remainingTime);
+    }
+  }
+}
+
+const computeRemainingTime = (expirationTime: number): number => expirationTime - Date.now();
+const computeTimeBeforeWarning = (remainingTime: number): number => remainingTime - timeBeforeWarningMs;
+const computeTimes = (): { remainingTime: number; timeBeforeWarning: number } | undefined => {
+  const expirationTime = getCookie('_oli_session_expiration_time');
+  if (expirationTime != undefined) {
+    const remainingTime = computeRemainingTime(expirationTime);
+    const timeBeforeWarning = computeTimeBeforeWarning(remainingTime);
+    return { remainingTime, timeBeforeWarning };
+  }
+  return undefined;
+}
+
+function renderSessionExpirationWarning() {
+  const result = computeTimes();
+  if (result !== undefined) {
+    const minutes = Math.floor(result.remainingTime / 60000);
+    const seconds = Math.floor((result.remainingTime % 60000) / 1000);
+    renderComponent("sessionExpirationContainerId", <SessionExpirationWarningComponent minutes={minutes} seconds={seconds} />);
+  }
+}
+
+function renderSessionExpirated() {
+  unmountReactSessionExpContainer();
+  renderComponent("sessionExpirationContainerId", <SessionTimeoutComponent />);
+}
+
+function renderComponent(id: string, component: ReactElement<any>) {
+  ReactDOM.render(component, document.getElementById(id));
+}
+
+function getCookie(cname: string) {
+  let name = cname + "=";
+  let decodedCookie = decodeURIComponent(document.cookie);
+  let ca = decodedCookie.split(';');
+  for (let i = 0; i < ca.length; i++) {
+    let c = ca[i];
+    while (c.charAt(0) == ' ') {
+      c = c.substring(1);
+    }
+    if (c.indexOf(name) == 0) {
+      return Number(c.substring(name.length, c.length));
+    }
+  }
+  return undefined;
+}

--- a/assets/styles/authoring/advanced-authoring.scss
+++ b/assets/styles/authoring/advanced-authoring.scss
@@ -849,6 +849,38 @@ $font-family-sans-serif: var(--font-sans);
   }
 }
 
+.modal-dialog.session-modal {
+  .modal-content {
+    box-shadow: 3px 3px 6px 1px rgba(#000, 0.5);
+  }
+  .modal-header {
+    background: $panel-section-title-bar-color;
+    border-top: 1px solid $ui-border-color;
+    border-bottom: 1px solid $ui-border-color;
+    display: flex;
+    font-family: 'Raleway', $font-family-sans-serif;
+    font-size: 12px;
+    color: $panel-font-color-light;
+    height: $panel-section-title-bar-height;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0 16px 0 4px;
+    i {
+      font-size: 1rem;
+    }
+
+    .title {
+      font-weight: 700;
+      text-transform: uppercase;
+    }
+  }
+  .modal-footer {
+    background-color: $panel-bg-color-light;
+    box-shadow: 0 2px 4px 0 rgba(#000, 0.1);
+    border-bottom: 1px solid $ui-border-color;
+  }
+}
+
 .modal-dialog.diagnostic-modal {
   &.advanced-authoring {
     opacity: 1;
@@ -929,5 +961,18 @@ $font-family-sans-serif: var(--font-sans);
 .toast-body {
   .list-group-item {
     margin: 5px;
+  }
+}
+
+.dark .modal-dialog.session-modal {
+  .modal-header {
+    background-color: $panel-bg-color-dark;
+    color: #f5f6f7;
+  }
+  .modal-footer {
+    background-color: $panel-bg-color-dark;
+  }
+  .modal-body {
+    color: white;
   }
 }

--- a/lib/oli_web/plugs/put_session_expiration_time_cookie.ex
+++ b/lib/oli_web/plugs/put_session_expiration_time_cookie.ex
@@ -1,0 +1,31 @@
+defmodule OliWeb.Plugs.PutSessionExpirationTimeCookie do
+  import Plug.Conn
+  alias Pow.Store.Backend.MnesiaCache
+
+  def init(_params), do: nil
+
+  def call(conn, _params) do
+    with [_, fingerprint: fingerprint] <- Map.get(conn.private, :pow_session_metadata),
+         {:atomic, [expire]} <- search_expiration_by_fingerprint(fingerprint) do
+      conn
+      |> delete_resp_cookie("_oli_session_expiration_time", http_only: false)
+      |> put_resp_cookie("_oli_session_expiration_time", "#{expire}", http_only: false)
+    else
+      _ ->
+        conn
+    end
+  end
+
+  defp search_expiration_by_fingerprint(fingerprint) do
+    :mnesia.transaction(fn ->
+      :mnesia.select(
+        MnesiaCache,
+        [
+          {{MnesiaCache, ["credentials", :_],
+            {{:_, [inserted_at: :_, fingerprint: :"$1"]}, :"$2"}}, [{:==, :"$1", fingerprint}],
+           [:"$2"]}
+        ]
+      )
+    end)
+  end
+end

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -31,6 +31,7 @@ defmodule OliWeb.Router do
     plug(OliWeb.SetLiveCSRF)
     plug(Plug.Telemetry, event_prefix: [:oli, :plug])
     plug(OliWeb.Plugs.SessionContext)
+    plug(OliWeb.Plugs.PutSessionExpirationTimeCookie)
   end
 
   # pipline for REST api endpoint routes

--- a/lib/oli_web/templates/layout/authoring.html.leex
+++ b/lib/oli_web/templates/layout/authoring.html.leex
@@ -68,8 +68,11 @@
       <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/timezone.js") %>"></script>
     <% end %>
     <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/dark.js") %>"></script>
+    <script>OLI.sessionTimeout();</script>
   </head>
   <body class="dark:bg-body-dark dark:text-white">
+  <div id="sessionExpirationContainerId"></div>
+  </div>
     <input type="hidden" id="layout-id" data-layout-id="authoring">
 
     <%= live_render(@conn, OliWeb.SystemMessageLive.ShowView) %>

--- a/lib/oli_web/templates/layout/chromeless.html.heex
+++ b/lib/oli_web/templates/layout/chromeless.html.heex
@@ -111,8 +111,12 @@
     </script>
 
     <%= additional_stylesheets(assigns) %>
+    <script>
+      OLI.sessionTimeout();
+    </script>
   </head>
   <body>
+    <div id="sessionExpirationContainerId"></div>
     <%= Map.get(assigns, :inner_layout) || @inner_content %>
   </body>
 </html>

--- a/lib/oli_web/templates/layout/delivery.html.heex
+++ b/lib/oli_web/templates/layout/delivery.html.heex
@@ -139,8 +139,12 @@
     <% end %>
     <script type="text/javascript" src={Routes.static_path(@conn, "/js/dark.js")}>
     </script>
+    <script>
+      OLI.sessionTimeout();
+    </script>
   </head>
   <body class="min-h-screen flex flex-col bg-delivery-body text-delivery-body-color dark:bg-delivery-body-dark dark:text-delivery-body-color-dark">
+    <div id="sessionExpirationContainerId"></div>
     <input type="hidden" id="layout-id" data-layout-id="delivery" />
 
     <%= live_render(@conn, OliWeb.SystemMessageLive.ShowView) %>

--- a/lib/oli_web/templates/layout/delivery_from_payment.html.heex
+++ b/lib/oli_web/templates/layout/delivery_from_payment.html.heex
@@ -118,8 +118,12 @@
     <% end %>
     <script type="text/javascript" src={Routes.static_path(@conn, "/js/dark.js")}>
     </script>
+    <script>
+      OLI.sessionTimeout();
+    </script>
   </head>
   <body class="min-h-screen flex flex-col bg-delivery-body text-delivery-body-color dark:bg-delivery-body-dark dark:text-delivery-body-color-dark">
+    <div id="sessionExpirationContainerId"></div>
     <%= @inner_content %>
   </body>
 </html>

--- a/lib/oli_web/templates/layout/error.html.eex
+++ b/lib/oli_web/templates/layout/error.html.eex
@@ -14,8 +14,10 @@
 
     <!-- Tailwind CSS -->
     <link id="app" rel="stylesheet" href="/css/app.css" />
+    <script>OLI.sessionTimeout();</script>
   </head>
   <body class="min-h-screen flex flex-col bg-delivery-body text-delivery-body-color dark:bg-delivery-body-dark dark:text-delivery-body-color-dark">
+  <div id="sessionExpirationContainerId"></div>
 
     <%= Map.get(assigns, :inner_layout) || @inner_content %>
 

--- a/lib/oli_web/templates/layout/lti.html.eex
+++ b/lib/oli_web/templates/layout/lti.html.eex
@@ -43,8 +43,10 @@
     <script>
       window.cite = require('citation-js')
     </script>
+    <script>OLI.sessionTimeout();</script>
   </head>
   <body>
+  <div id="sessionExpirationContainerId"></div>
 
     <main role="main" class="container mx-auto">
 


### PR DESCRIPTION
Ticket [MER-2629](https://eliterate.atlassian.net/jira/software/c/projects/MER/issues/MER-2629)

This PR introduces the logic for displaying session timeouts. The expiration time is retrieved directly from Pow via its Genserver MnesiaCache. Subsequently, this expiration time is transmitted to the client as a cookie. On the client side, a JavaScript code segment is executed to manage the rendering of two messages: a countdown warning set to activate 5 minutes before expiration, and a modal that appears upon expiration. The modal includes a "Close" button, which when clicked, reloads the page, redirecting the user to the Login page.

### Warning message:
<img width="830" alt="image" src="https://github.com/Simon-Initiative/oli-torus/assets/47334502/74448cb3-5b44-411e-a5cd-9f33dc5d8ce2">

### Expiration message:
<img width="833" alt="image" src="https://github.com/Simon-Initiative/oli-torus/assets/47334502/3e36677d-5c6c-424b-9f86-75506518030f">


[MER-2629]: https://eliterate.atlassian.net/browse/MER-2629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ