### PR TITLE
[DEVOPS] Add new deployment target

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,7 @@ on:
           - tokamak.oli.cmu.edu
           - stellarator.oli.cmu.edu
           - heliotron.oli.cmu.edu
+          - neutron.oli.cmu.edu
           - loadtest.oli.cmu.edu
           - proton.oli.cmu.edu
 


### PR DESCRIPTION
Adds neutron to the list of deployment targets.

Github CI requires the config to be present in the branch you are trying to deploy.