### PR TITLE
[NG23-118] Group module content by due date

### DIFF
--- a/lib/oli/delivery/settings.ex
+++ b/lib/oli/delivery/settings.ex
@@ -85,14 +85,18 @@ defmodule Oli.Delivery.Settings do
   iex> Oli.Delivery.Settings.get_student_exception_setting_for_all_resources(1, 5)
   %{}
   """
-  def get_student_exception_setting_for_all_resources(section_id, user_id, fields \\ nil) do
-    fields =
-      if !fields do
-        %Oli.Delivery.Settings.StudentException{} |> Map.from_struct() |> Map.keys()
-      else
-        fields
-      end
 
+  def get_student_exception_setting_for_all_resources(section_id, user_id, fields \\ nil)
+
+  def get_student_exception_setting_for_all_resources(section_id, user_id, nil) do
+    fields = %Oli.Delivery.Settings.StudentException{} |> Map.from_struct() |> Map.keys()
+
+    get_all_student_exceptions(section_id, user_id)
+    |> Enum.reduce(%{}, fn se, acc -> Map.put(acc, se.resource_id, Map.take(se, fields)) end)
+  end
+
+  def get_student_exception_setting_for_all_resources(section_id, user_id, fields)
+      when is_list(fields) do
     get_all_student_exceptions(section_id, user_id)
     |> Enum.reduce(%{}, fn se, acc -> Map.put(acc, se.resource_id, Map.take(se, fields)) end)
   end

--- a/lib/oli/delivery/settings.ex
+++ b/lib/oli/delivery/settings.ex
@@ -46,6 +46,57 @@ defmodule Oli.Delivery.Settings do
     end)
   end
 
+  @doc """
+  For a course section id and user id, return a map of resource_id to student exception settings.
+  The third argument allows to specific the field/s to be returned in the map.
+  If no fields are specified, all fields from the Oli.Delivery.Settings.Combined struct are returned.
+
+  If the are no student exception for a specific resource id, that resource id won't be included in the map.
+  (so if there are no student exceptions for any resources, an empty map will be returned)
+
+  Example:
+
+  ```
+  iex> Oli.Delivery.Settings.get_student_exception_setting_for_all_resources(1, 2)
+  %{
+  22433 => %{
+    max_attempts: nil,
+    password: nil,
+    end_date: ~U[2024-05-25 13:41:00Z],
+    time_limit: 30,
+    collab_space_config: nil,
+    start_date: nil,
+    resource_id: 22433,
+    retake_mode: nil,
+    late_submit: nil,
+    late_start: nil,
+    grace_period: nil,
+    scoring_strategy_id: nil,
+    review_submission: nil,
+    feedback_mode: nil,
+    feedback_scheduled_date: nil,
+    explanation_strategy: nil
+  }
+  }
+
+  iex> Oli.Delivery.Settings.get_student_exception_setting_for_all_resources(1, 2, [:end_date, :time_limit])
+  %{22433 => %{end_date: ~U[2024-05-25 13:41:00Z], time_limit: 30}}
+
+  iex> Oli.Delivery.Settings.get_student_exception_setting_for_all_resources(1, 5)
+  %{}
+  """
+  def get_student_exception_setting_for_all_resources(section_id, user_id, fields \\ nil) do
+    fields =
+      if !fields do
+        %Oli.Delivery.Settings.StudentException{} |> Map.from_struct() |> Map.keys()
+      else
+        fields
+      end
+
+    get_all_student_exceptions(section_id, user_id)
+    |> Enum.reduce(%{}, fn se, acc -> Map.put(acc, se.resource_id, Map.take(se, fields)) end)
+  end
+
   defp get_page_resources_with_settings(section_slug) do
     page_id = Oli.Resources.ResourceType.id_for_page()
 

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -1033,7 +1033,11 @@ defmodule OliWeb.Delivery.Student.LearnLive do
         video_url={@module["intro_video"]}
         intro_video_viewed={@intro_video_viewed}
       />
-      <div :for={grouped_due_date <- @page_due_dates} class="flex flex-col w-full">
+      <div
+        :for={grouped_due_date <- @page_due_dates}
+        class="flex flex-col w-full"
+        id={"pages_grouped_by_#{grouped_due_date}"}
+      >
         <div class="h-[19px] mb-[10px]">
           <span class="text-[#3399FF] text-[14px] leading-[19px]">
             <%= "Due: #{format_date(grouped_due_date, @ctx, "{WDshort} {Mshort} {D}, {YYYY}")}" %>

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -948,7 +948,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
     ~H"""
     <div
       id={"index_for_#{@module["resource_id"]}"}
-      class="relative flex flex-col gap-[6px] items-start"
+      class="relative flex flex-col gap-[25px] items-start"
     >
       <div
         :if={@module["learning_objectives"] != []}
@@ -1034,7 +1034,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
         intro_video_viewed={@intro_video_viewed}
       />
       <div :for={grouped_due_date <- @page_due_dates} class="flex flex-col w-full">
-        <div class="h-[19px] mb-[10px] mt-[25px]">
+        <div class="h-[19px] mb-[10px]">
           <span class="text-[#3399FF] text-[14px] leading-[19px]">
             <%= "Due: #{format_date(grouped_due_date, @ctx, "{WDshort} {Mshort} {D}, {YYYY}")}" %>
           </span>
@@ -1163,7 +1163,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
     <div
       id={"section_group_#{@resource_id}_#{@parent_due_date}"}
       class={[
-        "flex relative flex-col items-center gap-3 w-full",
+        "flex relative flex-col items-center w-full",
         maybe_hidden_section(@closed_sections, @resource_id, @parent_due_date)
       ]}
     >
@@ -1719,7 +1719,6 @@ defmodule OliWeb.Delivery.Student.LearnLive do
       |> Enum.reduce(%{}, fn {resource_id, settings}, acc ->
         Map.put(acc, resource_id, settings[:end_date])
       end)
-      |> IO.inspect(label: "Aca!!!")
 
     visited_pages_map = Sections.get_visited_pages(section.id, current_user_id)
 

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -1012,22 +1012,12 @@ defmodule OliWeb.Delivery.Student.LearnLive do
           Introduction and Learning Objectives
         </h3>
       </div>
-      <.index_item
+      <.intro_video_item
         :if={module_has_intro_video(@module)}
-        title="Introduction"
-        type="intro"
-        numbering_index={1}
-        numbering_level={3}
-        was_visited={false}
-        graded={@module["graded"]}
         duration_minutes={@module["duration_minutes"]}
-        revision_slug={@module["slug"]}
         module_resource_id={@module["resource_id"]}
-        resource_id="intro"
-        raw_avg_score={%{}}
         video_url={@module["intro_video"]}
         intro_video_viewed={@intro_video_viewed}
-        progress={0.0}
       />
 
       <.index_item
@@ -1093,7 +1083,6 @@ defmodule OliWeb.Delivery.Student.LearnLive do
   attr :student_end_date_exceptions_per_resource_id, :map
   attr :student_progress_per_resource_id, :map
   attr :due_date, :string
-  attr :intro_video_viewed, :boolean
   attr :video_url, :string, default: nil
   attr :progress, :float
   attr :closed_sections, :list, default: []
@@ -1182,7 +1171,6 @@ defmodule OliWeb.Delivery.Student.LearnLive do
         }
         raw_avg_score={Map.get(@student_raw_avg_score_per_page_id, child["resource_id"])}
         student_raw_avg_score_per_page_id={@student_raw_avg_score_per_page_id}
-        intro_video_viewed={@intro_video_viewed}
         progress={Map.get(@student_progress_per_resource_id, child["resource_id"])}
         student_progress_per_resource_id={@student_progress_per_resource_id}
         closed_sections={@closed_sections}
@@ -1202,19 +1190,16 @@ defmodule OliWeb.Delivery.Student.LearnLive do
       <.index_item_icon
         item_type={@type}
         was_visited={@was_visited}
-        intro_video_viewed={@intro_video_viewed}
         graded={@graded}
         raw_avg_score={@raw_avg_score[:score]}
         progress={@progress}
       />
       <div
         id={"index_item_#{@numbering_index}_#{@resource_id}"}
-        phx-click={if @type != "intro", do: "navigate_to_resource", else: "play_video"}
+        phx-click="navigate_to_resource"
         phx-value-slug={@revision_slug}
         phx-value-resource_id={@resource_id}
         phx-value-module_resource_id={@module_resource_id}
-        phx-value-video_url={@video_url}
-        phx-value-is_intro_video="false"
         class="flex shrink items-center gap-3 w-full dark:text-white cursor-pointer hover:bg-gray-200/70 dark:hover:bg-gray-800"
       >
         <.numbering_index type={@type} index={@numbering_index} />
@@ -1224,8 +1209,8 @@ defmodule OliWeb.Delivery.Student.LearnLive do
             <span class={
               [
                 "text-[16px] leading-[22px] pr-2 dark:text-white",
-                # Opacity is set if the item is visited or the intro video is viewed, but not necessarily completed
-                if(@was_visited or (@intro_video_viewed and @type == "intro"), do: "opacity-50")
+                # Opacity is set if the item is visited, but not necessarily completed
+                if(@was_visited, do: "opacity-50")
               ]
             }>
               <%= "#{@title}" %>
@@ -1252,11 +1237,74 @@ defmodule OliWeb.Delivery.Student.LearnLive do
     """
   end
 
+  attr :duration_minutes, :integer
+  attr :module_resource_id, :integer
+  attr :intro_video_viewed, :boolean
+  attr :video_url, :string, default: nil
+
+  def intro_video_item(assigns) do
+    ~H"""
+    <div
+      role="intro video details"
+      class="flex items-center gap-[14px] w-full"
+      id={"intro_video_for_module_#{@module_resource_id}"}
+    >
+      <div
+        role={"#{if @intro_video_viewed, do: "seen", else: "unseen"} video icon"}
+        class="flex justify-center items-center h-7 w-7 shrink-0"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          class="fill-black dark:fill-white"
+        >
+          <path
+            opacity="0.5"
+            d="M9.5 16.5L16.5 12L9.5 7.5V16.5ZM4 20C3.45 20 2.97917 19.8042 2.5875 19.4125C2.19583 19.0208 2 18.55 2 18V6C2 5.45 2.19583 4.97917 2.5875 4.5875C2.97917 4.19583 3.45 4 4 4H20C20.55 4 21.0208 4.19583 21.4125 4.5875C21.8042 4.97917 22 5.45 22 6V18C22 18.55 21.8042 19.0208 21.4125 19.4125C21.0208 19.8042 20.55 20 20 20H4Z"
+            fill={if @intro_video_viewed, do: "#0CAF61"}
+          />
+        </svg>
+      </div>
+      <div
+        phx-click="play_video"
+        phx-value-module_resource_id={@module_resource_id}
+        phx-value-video_url={@video_url}
+        phx-value-is_intro_video="false"
+        class="flex shrink items-center gap-3 w-full dark:text-white cursor-pointer hover:bg-gray-200/70 dark:hover:bg-gray-800"
+      >
+        <div class="flex flex-col gap-1 w-full ml-0">
+          <div class="flex">
+            <span class={
+              [
+                "text-[16px] leading-[22px] pr-2 dark:text-white",
+                # Opacity is set if the intro video is viewed, but not necessarily completed
+                if(@intro_video_viewed, do: "opacity-50")
+              ]
+            }>
+              Introduction
+            </span>
+
+            <div class="text-right dark:text-white opacity-50 whitespace-nowrap ml-auto">
+              <span class="text-[12px] leading-[16px] font-bold uppercase tracking-[0.96px] text-right">
+                <%= parse_minutes(@duration_minutes) %>
+                <span class="text-[9px] font-bold uppercase tracking-[0.72px] text-right">
+                  min
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
   attr :item_type, :string
   attr :was_visited, :boolean
   attr :graded, :boolean
   attr :raw_avg_score, :map
-  attr :intro_video_viewed, :boolean
   attr :progress, :float
 
   def index_item_icon(assigns) do
@@ -1296,29 +1344,6 @@ defmodule OliWeb.Delivery.Student.LearnLive do
         <div role="orange flag icon" class="flex justify-center items-center h-7 w-7 shrink-0">
           <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
             <path d="M5 21V4H14L14.4 6H20V16H13L12.6 14H7V21H5Z" fill="#F68E2E" />
-          </svg>
-        </div>
-        """
-
-      {_, "intro", _, _} ->
-        # intro video
-        ~H"""
-        <div
-          role={"#{if @intro_video_viewed, do: "seen", else: "unseen"} video icon"}
-          class="flex justify-center items-center h-7 w-7 shrink-0"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="24"
-            height="24"
-            viewBox="0 0 24 24"
-            class="fill-black dark:fill-white"
-          >
-            <path
-              opacity="0.5"
-              d="M9.5 16.5L16.5 12L9.5 7.5V16.5ZM4 20C3.45 20 2.97917 19.8042 2.5875 19.4125C2.19583 19.0208 2 18.55 2 18V6C2 5.45 2.19583 4.97917 2.5875 4.5875C2.97917 4.19583 3.45 4 4 4H20C20.55 4 21.0208 4.19583 21.4125 4.5875C21.8042 4.97917 22 5.45 22 6V18C22 18.55 21.8042 19.0208 21.4125 19.4125C21.0208 19.8042 20.55 20 20 20H4Z"
-              fill={if @intro_video_viewed, do: "#0CAF61"}
-            />
           </svg>
         </div>
         """

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -1805,7 +1805,13 @@ defmodule OliWeb.Delivery.Student.LearnLive do
     end)
   end
 
-  # defp display_module_item?(true, grouped_due_date, child), do: true
+  defp display_module_item?(
+         _show_completed_pages,
+         _grouped_due_date,
+         _student_end_date_exceptions_per_resource_id,
+         %{"section_resource" => %{scheduling_type: :inclass_activity}} = _child
+       ),
+       do: false
 
   defp display_module_item?(
          show_completed_pages,

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -222,6 +222,13 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
         duration_minutes: 15
       )
 
+    page_15_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.get_id_by_type("page"),
+        title: "Page 15 - in class activity",
+        duration_minutes: 15
+      )
+
     # sections and sub-sections...
 
     subsection_1_revision =
@@ -230,7 +237,8 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
         children: [
           page_11_revision.resource_id,
           page_13_revision.resource_id,
-          page_14_revision.resource_id
+          page_14_revision.resource_id,
+          page_15_revision.resource_id
         ],
         title: "Erlang as a motivation"
       })
@@ -377,6 +385,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
         page_12_revision,
         page_13_revision,
         page_14_revision,
+        page_15_revision,
         section_1_revision,
         subsection_1_revision,
         module_1_revision,
@@ -461,6 +470,17 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       end_date: ~U[2023-11-03 20:00:00Z]
     })
 
+    # set page 15 to in class activity and page 14 to due by
+    Sections.get_section_resource(section.id, page_15_revision.resource_id)
+    |> Sections.update_section_resource(%{
+      scheduling_type: :inclass_activity
+    })
+
+    Sections.get_section_resource(section.id, page_14_revision.resource_id)
+    |> Sections.update_section_resource(%{
+      scheduling_type: :due_by
+    })
+
     %{
       author: author,
       section: section,
@@ -481,6 +501,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       top_level_page: top_level_page_revision,
       page_11: page_11_revision,
       page_12: page_12_revision,
+      page_13: page_13_revision,
       section_1: section_1_revision,
       subsection_1: subsection_1_revision,
       module_1: module_1_revision,
@@ -1904,6 +1925,58 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       assert render(group_by_not_yet_scheduled_div) =~ "Due: Not yet scheduled"
       assert render(group_by_not_yet_scheduled_div) =~ "Page 13"
       assert render(group_by_not_yet_scheduled_div) =~ "Page 14"
+    end
+
+    test "considers student exceptions when grouping pages in index by due date", %{
+      conn: conn,
+      user: user,
+      section: section,
+      page_13: page_13
+    } do
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.mark_section_visited_for_student(section, user)
+
+      # add a student exception for page 13
+      insert(:student_exception, %{
+        section: section,
+        user: user,
+        resource: page_13.resource,
+        end_date: ~U[2023-11-10 00:00:00Z]
+      })
+
+      {:ok, view, _html} = live(conn, Utils.learn_live_path(section.slug))
+
+      # when the slider buttons are enabled we know the student async metrics (including student exceptions) were loaded
+      assert_receive({_ref, {:push_event, "enable-slider-buttons", _}}, 2_000)
+
+      view
+      |> element(~s{div[role="unit_5"] div[role="card_4"]})
+      |> render_click()
+
+      group_by_due_date_div = element(view, ~s{div[id="pages_grouped_by_2023-11-10"]})
+
+      # page 13 is due on Nov 10, 2023 as defined in the student exception
+      assert render(group_by_due_date_div) =~ "Due: Fri Nov 10, 2023"
+      assert render(group_by_due_date_div) =~ "Page 13"
+    end
+
+    test "in class activities pages are not listed in the module index", %{
+      conn: conn,
+      user: user,
+      section: section
+    } do
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.mark_section_visited_for_student(section, user)
+
+      {:ok, view, _html} = live(conn, Utils.learn_live_path(section.slug))
+
+      view
+      |> element(~s{div[role="unit_5"] div[role="card_4"]})
+      |> render_click()
+
+      assert render(view) =~ "Page 13"
+      assert render(view) =~ "Page 14"
+      refute render(view) =~ "Page 15"
     end
   end
 

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -1526,6 +1526,9 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
 
       {:ok, view, _html} = live(conn, Utils.learn_live_path(section.slug))
 
+      # when the slider buttons are enabled we know the student async metrics (including progress) were loaded
+      assert_receive({_ref, {:push_event, "enable-slider-buttons", _}}, 2_000)
+
       # Progress in module 1 (which has page 2)
       assert has_element?(view, ~s{div[role="unit_1"] div[role="card_1_progress"]})
 
@@ -1590,7 +1593,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
              |> element(
                ~s{div[id="top_level_page_#{top_level_page.resource_id}"] div[role="header"]}
              )
-             |> render() =~ "PAGE 14"
+             |> render() =~ "PAGE 17"
 
       assert view
              |> element(

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -428,6 +428,19 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       end_date: ~U[2023-11-03 20:00:00Z]
     })
 
+    # schedule start and end date for page 11 and 12 section_resource
+    Sections.get_section_resource(section.id, page_11_revision.resource_id)
+    |> Sections.update_section_resource(%{
+      start_date: ~U[2023-11-02 20:00:00Z],
+      end_date: ~U[2023-11-03 20:00:00Z]
+    })
+
+    Sections.get_section_resource(section.id, page_12_revision.resource_id)
+    |> Sections.update_section_resource(%{
+      start_date: ~U[2023-11-02 20:00:00Z],
+      end_date: ~U[2023-11-03 20:00:00Z]
+    })
+
     %{
       author: author,
       section: section,
@@ -841,12 +854,12 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       |> render_click()
 
       assert view
-             |> element(~s{div[role="intro 1 details"]})
+             |> element(~s{div[role="intro video details"]})
              |> render() =~ "Introduction"
 
       assert has_element?(
                view,
-               ~s{div[role="intro 1 details"] div[role="unseen video icon"]}
+               ~s{div[role="intro video details"] div[role="unseen video icon"]}
              )
 
       # module 2 has no intro video
@@ -854,7 +867,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       |> element(~s{div[role="unit_1"] div[role="card_2"]})
       |> render_click()
 
-      refute has_element?(view, ~s{div[role="intro 1 details"] div[role="unseen video icon"]})
+      refute has_element?(view, ~s{div[role="intro video details"] div[role="unseen video icon"]})
     end
 
     test "intro video is marked as seen after playing it",
@@ -880,11 +893,11 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
 
       assert has_element?(
                view,
-               ~s{div[role="intro 1 details"] div[role="unseen video icon"]}
+               ~s{div[role="intro video details"] div[role="unseen video icon"]}
              )
 
       view
-      |> element(~s{div[role="intro 1 details"] div[phx-click="play_video"]})
+      |> element(~s{div[role="intro video details"] div[phx-click="play_video"]})
       |> render_click()
 
       # since the video is marked as seen in an async way, we revisit the page to check if the icon changed
@@ -901,7 +914,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
 
       assert has_element?(
                view,
-               ~s{div[role="intro 1 details"] div[role="seen video icon"]}
+               ~s{div[role="intro video details"] div[role="seen video icon"]}
              )
     end
 
@@ -1270,7 +1283,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
 
       assert has_element?(
                view,
-               "#index_item_1_#{section_1.resource_id}"
+               "#index_item_1_#{section_1.resource_id}_2023-11-03"
              )
     end
 
@@ -1807,13 +1820,13 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       section_1_element =
         element(
           view,
-          "#index_item_1_#{section_1.resource_id}"
+          "#index_item_1_#{section_1.resource_id}_2023-11-03"
         )
 
       subsection_1_element =
         element(
           view,
-          "#index_item_1_#{subsection_1.resource_id}"
+          "#index_item_1_#{subsection_1.resource_id}_2023-11-03"
         )
 
       assert render(section_1_element) =~ "Why Elixir?"
@@ -1840,7 +1853,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
 
       assert has_element?(
                view,
-               "div.hidden #index_item_1_#{subsection_1.resource_id}"
+               "div.hidden #index_item_1_#{subsection_1.resource_id}_2023-11-03"
              )
     end
   end


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/NG23-118) to the ticket. See also [comments](https://eliterate.atlassian.net/browse/NG23-113?focusedCommentId=22404) left on parent ticket


### Hides/Shows completed pages
When all pages of a given due date are completed the whole group is hidden.

https://github.com/Simon-Initiative/oli-torus/assets/74839302/1c73effb-6b00-42b9-a3b3-5c4f874aaf4d

### Collapse/expand section or subsections
They collapse/expand independently of other date-groupers. Ex, if the same subsection is grouped in more than one due date, they can be collapsed independently and the collapsed "state" persists after toggling completed pages

https://github.com/Simon-Initiative/oli-torus/assets/74839302/348c4749-90a2-462b-b61e-5029ad7b2077

### In-class activities are not listed

https://github.com/Simon-Initiative/oli-torus/assets/74839302/f573f868-8474-4bbf-a7eb-4d612070cbbc

### Considers changes in schedule and any student due date exception when grouping by date

https://github.com/Simon-Initiative/oli-torus/assets/74839302/27ce6c82-7d7a-4bd5-aa7f-49e61f5b3f41


