### PR TITLE
[BUG FIX] [MER-2917] Fix duplicated answers

### DIFF
--- a/assets/src/components/activities/multi_input/sections/QuestionTab.tsx
+++ b/assets/src/components/activities/multi_input/sections/QuestionTab.tsx
@@ -58,19 +58,16 @@ export const QuestionTab: React.FC<Props> = (props) => {
                       response.type === props.input.inputType &&
                       response.part_id === props.input.partId,
                   )
-                  .map((response, index) =>
-                    Array.from({ length: response.count }).map((_, i) => (
-                      <tr key={`${index}-${i}`}>
-                        <td className="whitespace-nowrap">{response.user_name}</td>
-                        <td>{response.text}</td>
-                      </tr>
-                    )),
-                  )}
+                  .map((response, index) => (
+                    <tr key={`${index}`}>
+                      <td className="whitespace-nowrap">{response.user_name}</td>
+                      <td>{response.text}</td>
+                    </tr>
+                  ))}
               </tbody>
             </table>
           </div>
         ) : null}
-
         {props.input.inputType === 'dropdown' && <DropdownQuestionEditor input={props.input} />}
       </Card.Content>
     </Card.Card>

--- a/lib/oli_web/components/delivery/practice_activities/practice_activities.ex
+++ b/lib/oli_web/components/delivery/practice_activities/practice_activities.ex
@@ -834,8 +834,7 @@ defmodule OliWeb.Components.Delivery.PracticeActivities do
             text: response_summary.response,
             user_name: OliWeb.Common.Utils.name(response_summary.user),
             type: mapper[response_summary.part_id],
-            part_id: response_summary.part_id,
-            count: response_summary.count
+            part_id: response_summary.part_id
           }
           | acc_responses
         ]

--- a/lib/oli_web/components/delivery/surveys/surveys.ex
+++ b/lib/oli_web/components/delivery/surveys/surveys.ex
@@ -850,8 +850,7 @@ defmodule OliWeb.Components.Delivery.Surveys do
             text: response_summary.response,
             user_name: OliWeb.Common.Utils.name(response_summary.user),
             type: mapper[response_summary.part_id],
-            part_id: response_summary.part_id,
-            count: response_summary.count
+            part_id: response_summary.part_id
           }
           | acc_responses
         ]

--- a/test/oli_web/live/delivery/instructor_dashboard/overview/surveys_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/overview/surveys_tab_test.exs
@@ -1454,7 +1454,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.SurveysTabTest do
              )
 
       assert selected_activity_model =~
-               "{\"authoring\":{\"responses\":[{\"count\":1,\"type\":\"text\",\"text\":\"unsupported\",\"user_name\":\"#{student_1.family_name}, #{student_1.given_name}\",\"part_id\":\"1\"}]},\"inputs\":[{\"id\":\"1458555427\",\"inputType\":\"text\",\"partId\":\"1\"}]}"
+               "{\"authoring\":{\"responses\":[{\"type\":\"text\",\"text\":\"unsupported\",\"user_name\":\"#{student_1.family_name}, #{student_1.given_name}\",\"part_id\":\"1\"}]},\"inputs\":[{\"id\":\"1458555427\",\"inputType\":\"text\",\"partId\":\"1\"}]}"
     end
 
     test "likert activity details get rendered correctly when page is selected",


### PR DESCRIPTION
[MER-2917](https://eliterate.atlassian.net/browse/MER-2917)

This PR fixes a bug that happening when displaying students' text and numeric responses for `Multi Input` activities in the `Scored Activities` and `Surveys` tabs.

It happened that if 2 or more students answered the same thing, the answers were displayed as many times as the total number of answers for all students.

With these changes, the answers made by the students will be displayed, but without specifying the number of times they were answered by each of the students.

https://github.com/Simon-Initiative/oli-torus/assets/16328384/5e8520d1-6f4e-49bd-822d-00af9b195d91



[MER-2917]: https://eliterate.atlassian.net/browse/MER-2917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ