### PR TITLE
[MER-3150] Fix deployment tokamak due to broken runtime config

### DIFF
--- a/lib/oli_web/controllers/pow.ex
+++ b/lib/oli_web/controllers/pow.ex
@@ -8,12 +8,6 @@ defmodule OliWeb.PowController do
   alias PowResetPassword.Phoenix.ResetPasswordController
   alias Oli.Repo
 
-  @secret_key_base Application.compile_env(:oli, OliWeb.Endpoint)[:secret_key_base]
-  @basic_conn_for_pow %Plug.Conn{
-    private: %{phoenix_router: OliWeb.Router, phoenix_endpoint: OliWeb.Endpoint, otp_app: :oli},
-    secret_key_base: @secret_key_base
-  }
-
   @ttl :timer.minutes(24 * 60)
   @cache_config {PowResetPassword.Store.ResetTokenCache, ttl: @ttl}
 
@@ -21,7 +15,12 @@ defmodule OliWeb.PowController do
     %{email: email} = _user = Repo.get(User, id)
     params = %{"user" => %{"email" => email}}
 
-    @basic_conn_for_pow
+    secret_key_base = Application.get_env(:oli, OliWeb.Endpoint)[:secret_key_base]
+
+    %Plug.Conn{
+      private: %{phoenix_router: OliWeb.Router, phoenix_endpoint: OliWeb.Endpoint, otp_app: :oli},
+      secret_key_base: secret_key_base
+    }
     |> use_pow_config(:user)
     |> put_reset_password_token_store_into_pow_config()
     |> ResetPasswordController.process_create(params)


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-3150

The root cause is the module attributes and call to `Application.compile_env` in https://github.com/Simon-Initiative/oli-torus/pull/4736

The solution is to move this logic out of compile-time module attributes and instead use `Application.get_env`

[Validating compile/runtime configuration - ERROR! the application :backend has a different value set for key :basic_auth during runtime](https://elixirforum.com/t/validating-compile-runtime-configuration-error-the-application-backend-has-a-different-value-set-for-key-basic-auth-during-runtime/32373)