### PR TITLE
[BUG FIX] [MER-3152] Remove prevention of submission on already submitted attempts

### DIFF
--- a/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
@@ -28,78 +28,71 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
     activity_model = select_model(activity_attempt)
     part_attempts = get_latest_part_attempts(activity_attempt_guid)
 
-    if activity_attempt.lifecycle_state in [:submitted, :evaluated] do
-      Logger.info(
-        "These changes could not be saved as this attempt may have already been submitted"
-      )
 
-      {:error, :already_submitted}
-    else
-      case Model.parse(activity_model) do
-        {:ok, %Model{rules: []}} ->
-          evaluate_from_input(
-            section_slug,
-            activity_attempt_guid,
-            part_inputs,
-            datashop_session_id
-          )
+    case Model.parse(activity_model) do
+      {:ok, %Model{rules: []}} ->
+        evaluate_from_input(
+          section_slug,
+          activity_attempt_guid,
+          part_inputs,
+          datashop_session_id
+        )
 
-        {:ok, %Model{rules: rules, delivery: delivery, authoring: authoring}} ->
-          part_attempts_submitted = submit_active_part_attempts(part_attempts)
+      {:ok, %Model{rules: rules, delivery: delivery, authoring: authoring}} ->
+        part_attempts_submitted = submit_active_part_attempts(part_attempts)
 
-          custom = Map.get(delivery, "custom", %{})
+        custom = Map.get(delivery, "custom", %{})
 
-          is_manually_graded =
-            Enum.any?(part_attempts, fn pa -> pa.grading_approach == :manual end)
+        is_manually_graded =
+          Enum.any?(part_attempts, fn pa -> pa.grading_approach == :manual end)
 
-          # count the manual max score, and use that as the default instead of zero if there is no maxScore set by the author
-          max_score =
-            case is_manually_graded do
-              true ->
-                manual_max = Enum.reduce(part_attempts, fn sum, pa -> sum + pa.out_of end)
-                Map.get(custom, "maxScore", manual_max)
+        # count the manual max score, and use that as the default instead of zero if there is no maxScore set by the author
+        max_score =
+          case is_manually_graded do
+            true ->
+              manual_max = Enum.reduce(part_attempts, fn sum, pa -> sum + pa.out_of end)
+              Map.get(custom, "maxScore", manual_max)
 
-              false ->
-                Map.get(custom, "maxScore", 0)
-            end
+            false ->
+              Map.get(custom, "maxScore", 0)
+          end
 
-          scoringContext = %{
-            maxScore: max_score,
-            maxAttempt: Map.get(custom, "maxAttempt", 1),
-            trapStateScoreScheme: Map.get(custom, "trapStateScoreScheme", false),
-            negativeScoreAllowed: Map.get(custom, "negativeScoreAllowed", false),
-            currentAttemptNumber: attempt_number,
-            isManuallyGraded: is_manually_graded
-          }
+        scoringContext = %{
+          maxScore: max_score,
+          maxAttempt: Map.get(custom, "maxAttempt", 1),
+          trapStateScoreScheme: Map.get(custom, "trapStateScoreScheme", false),
+          negativeScoreAllowed: Map.get(custom, "negativeScoreAllowed", false),
+          currentAttemptNumber: attempt_number,
+          isManuallyGraded: is_manually_graded
+        }
 
-          activitiesRequiredForEvaluation =
-            Map.get(authoring, "activitiesRequiredForEvaluation", [])
+        activitiesRequiredForEvaluation =
+          Map.get(authoring, "activitiesRequiredForEvaluation", [])
 
-          # Logger.debug("ACTIVITIES REQUIRED: #{activitiesRequiredForEvaluation}")
+        # Logger.debug("ACTIVITIES REQUIRED: #{activitiesRequiredForEvaluation}")
 
-          variablesRequiredForEvaluation =
-            Map.get(authoring, "variablesRequiredForEvaluation", nil)
+        variablesRequiredForEvaluation =
+          Map.get(authoring, "variablesRequiredForEvaluation", nil)
 
-          # Logger.debug("VARIABLES REQUIRED: #{Jason.encode!(variablesRequiredForEvaluation)}")
+        # Logger.debug("VARIABLES REQUIRED: #{Jason.encode!(variablesRequiredForEvaluation)}")
 
-          Logger.debug("SCORE CONTEXT: #{Jason.encode!(scoringContext)}")
+        Logger.debug("SCORE CONTEXT: #{Jason.encode!(scoringContext)}")
 
-          evaluate_from_rules(
-            section_slug,
-            resource_attempt,
-            activity_attempt_guid,
-            part_inputs,
-            scoringContext,
-            rules,
-            activitiesRequiredForEvaluation,
-            variablesRequiredForEvaluation,
-            datashop_session_id,
-            part_attempts_submitted
-          )
+        evaluate_from_rules(
+          section_slug,
+          resource_attempt,
+          activity_attempt_guid,
+          part_inputs,
+          scoringContext,
+          rules,
+          activitiesRequiredForEvaluation,
+          variablesRequiredForEvaluation,
+          datashop_session_id,
+          part_attempts_submitted
+        )
 
-        e ->
-          e
-      end
+      e ->
+        e
     end
   end
 

--- a/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
@@ -28,7 +28,6 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
     activity_model = select_model(activity_attempt)
     part_attempts = get_latest_part_attempts(activity_attempt_guid)
 
-
     case Model.parse(activity_model) do
       {:ok, %Model{rules: []}} ->
         evaluate_from_input(

--- a/lib/oli_web/controllers/api/attempt_controller.ex
+++ b/lib/oli_web/controllers/api/attempt_controller.ex
@@ -571,15 +571,6 @@ defmodule OliWeb.Api.AttemptController do
       {:ok, evaluations} ->
         json(conn, %{"type" => "success", "actions" => evaluations})
 
-      {:error, :already_submitted} ->
-        conn
-        |> put_status(403)
-        |> json(%{
-          "error" => true,
-          "message" =>
-            "These changes could not be saved as this attempt may have already been submitted"
-        })
-
       {:error, message} ->
         {_, msg} = Oli.Utils.log_error("Could not submit activity", message)
         error(conn, 500, msg)


### PR DESCRIPTION
Reverts the changes from MER-3000 as this causes problems for adaptive pages.

Note, in `evaluate.ex` the only real change is the removal of the outermost `if...then`, to remove:

```
if activity_attempt.lifecycle_state in [:submitted, :evaluated] do
      Logger.info(
        "These changes could not be saved as this attempt may have already been submitted"
      )
     {:error, :already_submitted}
else
```

The rest of the diff is unfortunately just simply whitespace change. 

To verify this change:

**Without this fix in place**

1. Ingest the attached course project, publish and create an Open and Free course
2. As a student, visit the adaptive page that is in the course section (the only one).
3. Visit any screen, then use Table Of Contents to navigate back to first screen. Click another screen.
Expect: View transitions to selected screen
Actual: 403 failure is thrown by server and screen does not transition

Then **with this fix in place**
1. As a student, visit the adaptive page that is in the course section (the only one).
2. Visit any screen, then use Table Of Contents to navigate back to first screen. Click another screen.
Expect: View transitions to selected screen
Actual: View transitions to selected screen

[export_component_library_for_testing (1).zip](https://github.com/Simon-Initiative/oli-torus/files/14949223/export_component_library_for_testing.1.zip)


