### PR TITLE
[BUG FIX] [NG23-145] Back arrow on pages does not work

### DIFF
--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -396,7 +396,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
     ~H"""
     <div
       class={[
-        "flex justify-center items-center absolute top-2 left-2 p-4",
+        "flex justify-center items-center absolute top-2 left-2 p-4 z-50",
         if(!@show_sidebar, do: "xl:top-10 xl:left-12")
       ]}
       role="back_link"


### PR DESCRIPTION
[Link ](https://eliterate.atlassian.net/browse/NG23-145)to the ticket

### Before
https://github.com/Simon-Initiative/oli-torus/assets/74839302/36ff04e1-3280-4ba4-8930-72841dc277a1

### After
https://github.com/Simon-Initiative/oli-torus/assets/74839302/28bac693-1bd3-4279-9262-9f97126e66f3

