### PR TITLE
[ENHANCEMENT] [MER-3134] make range checking order independent

### DIFF
--- a/lib/oli/delivery/evaluation/rule.ex
+++ b/lib/oli/delivery/evaluation/rule.ex
@@ -119,12 +119,13 @@ defmodule Oli.Delivery.Evaluation.Rule do
         l_value = parse_number(left)
 
         case parse_range(right) do
+          # allow bounds in any order (may have come from dynamic variables)
           {:inclusive, lower, upper, precision} ->
-            lower <= l_value && l_value <= upper &&
+            min(lower, upper) <= l_value && l_value <= max(lower, upper) &&
               check_precision(left, precision)
 
           {:exclusive, lower, upper, precision} ->
-            lower < l_value && l_value < upper &&
+            min(lower, upper) < l_value && l_value < max(lower, upper) &&
               check_precision(left, precision)
         end
 

--- a/test/oli/delivery/evaluation/rule_eval_test.exs
+++ b/test/oli/delivery/evaluation/rule_eval_test.exs
@@ -109,6 +109,14 @@ defmodule Oli.Delivery.Evaluation.RuleEvalTest do
     assert eval("attemptNumber = {1} && input = {(-1, 1)#1}", "0.0") == false
     assert eval("attemptNumber = {1} && input = {(-1, 1)#1}", "0.5") == true
     assert eval("attemptNumber = {1} && input = {(-1, 1)#1}", "0.50") == false
+
+    # handle ranges in wrong order
+    assert eval("attemptNumber = {1} && input = {[3e-3, 4e-5]}", "3e-4") == true
+    assert eval("attemptNumber = {1} && input = {(4, 3.0)}", "3.1") == true
+    assert eval("attemptNumber = {1} && input = {(4, 3)}", "2.0") == false
+    assert eval("attemptNumber = {1} && input = {[4,3]}", "3") == true
+    assert eval("attemptNumber = {1} && input = {[5, -3]}", "0") == true
+    assert eval("attemptNumber = {1} && input = {[5, -3.0]}", "-3.1") == false
   end
 
   test "evaluating like" do


### PR DESCRIPTION
This makes range answer evaluation independent of the order in which the bounds are listed in the rule. While torus authoring sorts range bounds values into low, high order when they are constants, it cannot do this when dynamic variables are used. In this case the order of bounds could depend on randomly selected values. It would be possible for authors to handle this by including jasvascript code to sort bound values in the dynamic variable generation script, but there is no reason to put this burden on authors and allow unexpected errors when the system can easily handle bounds in any order.