### PR TITLE
[FEATURE] [NG23-83] user searches within notes panel

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -140,3 +140,7 @@ https://tailwindcss.com/docs/utility-first
   -ms-overflow-style: none; /* IE and Edge */
   scrollbar-width: none; /* Firefox */
 }
+
+.search-result em {
+  @apply not-italic bg-yellow-50;
+}

--- a/assets/src/hooks/scroller.ts
+++ b/assets/src/hooks/scroller.ts
@@ -6,7 +6,7 @@ export const Scroller = {
   // It is triggered from the backend as follows:
   //
   //    def handle_event(..., socket) do
-  //      {:no_reply, push_event(socket, "scroll-y-to-target", %{id: "element-id", offset: 50, scroll: true, scroll_delay: 500})
+  //      {:no_reply, push_event(socket, "scroll-y-to-target", %{id: "element-id", offset: 50, scroll: true, scroll_delay: 500})}
   //    end
   //
   // Expects the id of the element to scroll to, an optional offset

--- a/lib/oli/resources/collaboration.ex
+++ b/lib/oli/resources/collaboration.ex
@@ -1118,10 +1118,15 @@ defmodule Oli.Resources.Collaboration do
         point_block_id \\ nil
       ) do
     filter_by_point_block_id =
-      if is_nil(point_block_id) do
-        dynamic([p], is_nil(p.annotated_block_id))
-      else
-        dynamic([p], p.annotated_block_id == ^point_block_id)
+      case point_block_id do
+        nil ->
+          true
+
+        :page ->
+          dynamic([p], is_nil(p.annotated_block_id))
+
+        point_block_id ->
+          dynamic([p], p.annotated_block_id == ^point_block_id)
       end
 
     Repo.all(
@@ -1172,10 +1177,15 @@ defmodule Oli.Resources.Collaboration do
         search_term
       ) do
     filter_by_point_block_id =
-      if is_nil(point_block_id) do
-        dynamic([p], is_nil(p.annotated_block_id))
-      else
-        dynamic([p], p.annotated_block_id == ^point_block_id)
+      case point_block_id do
+        nil ->
+          true
+
+        :page ->
+          dynamic([p], is_nil(p.annotated_block_id))
+
+        point_block_id ->
+          dynamic([p], p.annotated_block_id == ^point_block_id)
       end
 
     Repo.all(

--- a/lib/oli/resources/collaboration.ex
+++ b/lib/oli/resources/collaboration.ex
@@ -1127,12 +1127,12 @@ defmodule Oli.Resources.Collaboration do
 
     filter_by_search_term =
       if is_nil(search_term) do
-        true
+        dynamic([p], is_nil(p.parent_post_id) and is_nil(p.thread_root_id))
       else
         dynamic(
           [p],
           fragment(
-            "to_tsvector('english', ?) @@ to_tsquery('english', ?)",
+            "to_tsvector('english', ?) @@ websearch_to_tsquery('english', ?)",
             p.content,
             ^search_term
           )
@@ -1150,7 +1150,6 @@ defmodule Oli.Resources.Collaboration do
         left_join: user in assoc(post, :user),
         where:
           post.section_id == ^section_id and post.resource_id == ^resource_id and
-            is_nil(post.parent_post_id) and is_nil(post.thread_root_id) and
             (post.status in [:approved, :archived] or
                (post.status == :submitted and post.user_id == ^user_id)),
         where: ^filter_by_point_block_id,

--- a/lib/oli/resources/collaboration/post.ex
+++ b/lib/oli/resources/collaboration/post.ex
@@ -39,6 +39,8 @@ defmodule Oli.Resources.Collaboration.Post do
     has_many :reactions, Oli.Resources.Collaboration.UserReactionPost
 
     field :reaction_summaries, :map, virtual: true
+    field :headline, :string, virtual: true
+    field :replies, :any, virtual: true
 
     timestamps(type: :utc_datetime)
   end

--- a/lib/oli_web/live/delivery/student/lesson/annotations.ex
+++ b/lib/oli_web/live/delivery/student/lesson/annotations.ex
@@ -105,7 +105,14 @@ defmodule OliWeb.Delivery.Student.Lesson.Annotations do
           <div class="text-center p-4 text-gray-500">No results found</div>
         <% annotations -> %>
           <%= for annotation <- annotations do %>
-            <.search_result post={annotation} current_user={@current_user} />
+            <div
+              class="flex flex-col cursor-pointer"
+              phx-click="reveal_post"
+              phx-value-point-marker-id={annotation.annotated_block_id}
+              phx-value-post-id={annotation.id}
+            >
+              <.search_result post={annotation} current_user={@current_user} />
+            </div>
           <% end %>
       <% end %>
     </div>
@@ -147,16 +154,6 @@ defmodule OliWeb.Delivery.Student.Lesson.Annotations do
             <% end %>
           </div>
       <% end %>
-      <div :if={not @is_reply} class="flex flex-row justify-end">
-        <Common.button
-          variant={:link}
-          phx-click="reveal_post"
-          phx-value-point-marker-id={@post.annotated_block_id}
-          phx-value-post-id={@post.id}
-        >
-          View original post <i class="fa-solid fa-arrow-right"></i>
-        </Common.button>
-      </div>
     </div>
     """
   end

--- a/lib/oli_web/live/delivery/student/lesson/annotations.ex
+++ b/lib/oli_web/live/delivery/student/lesson/annotations.ex
@@ -98,7 +98,7 @@ defmodule OliWeb.Delivery.Student.Lesson.Annotations do
         <% :loading -> %>
           <Common.loading_spinner />
         <% [] -> %>
-          <div class="text-center p-4 text-gray-500">No results found for '<%= @search_term %>'</div>
+          <div class="text-center p-4 text-gray-500">No results found</div>
         <% annotations -> %>
           <%= for annotation <- annotations do %>
             <.search_result post={annotation} current_user={@current_user} />
@@ -320,8 +320,17 @@ defmodule OliWeb.Delivery.Student.Lesson.Annotations do
           type="text"
           name="search_term"
           value={@search_term}
-          class="w-full border border-gray-400 dark:border-gray-700 rounded-lg pl-12 pr-3 py-3"
+          class="w-full border border-gray-400 dark:border-gray-700 rounded-lg px-12 py-3"
+          phx-change="search_term_change"
         />
+        <button
+          :if={@search_term != ""}
+          type="button"
+          class="absolute right-0 top-0 bottom-0 py-3 px-4"
+          phx-click="clear_search"
+        >
+          <i class="fa-solid fa-xmark text-lg"></i>
+        </button>
       </div>
     </form>
     """

--- a/lib/oli_web/live/delivery/student/lesson/annotations.ex
+++ b/lib/oli_web/live/delivery/student/lesson/annotations.ex
@@ -144,9 +144,14 @@ defmodule OliWeb.Delivery.Student.Lesson.Annotations do
           </div>
       <% end %>
       <div :if={not @is_reply} class="flex flex-row justify-end">
-        <a href="#" class="text-primary">
+        <Common.button
+          variant={:link}
+          phx-click="reveal_post"
+          phx-value-point-marker-id={@post.annotated_block_id}
+          phx-value-post-id={@post.id}
+        >
           View original post <i class="fa-solid fa-arrow-right"></i>
-        </a>
+        </Common.button>
       </div>
     </div>
     """
@@ -608,7 +613,7 @@ defmodule OliWeb.Delivery.Student.Lesson.Annotations do
     <button
       class="absolute right-[-15px] cursor-pointer group"
       style={"top: #{@point_marker.top}px"}
-      phx-click="select_annotation_point"
+      phx-click="toggle_annotation_point"
       phx-value-point-marker-id={@point_marker.id}
     >
       <.chat_bubble selected={@selected} count={@count} />

--- a/lib/oli_web/live/delivery/student/lesson/annotations.ex
+++ b/lib/oli_web/live/delivery/student/lesson/annotations.ex
@@ -7,6 +7,7 @@ defmodule OliWeb.Delivery.Student.Lesson.Annotations do
   attr :create_new_annotation, :boolean, default: false
   attr :annotations, :any, required: true
   attr :current_user, Oli.Accounts.User, required: true
+  attr :selected_point, :any, required: true
   attr :active_tab, :atom, default: :my_notes
   attr :search_results, :any, default: nil
   attr :search_term, :string, default: ""
@@ -36,6 +37,7 @@ defmodule OliWeb.Delivery.Student.Lesson.Annotations do
               annotations={@annotations}
               current_user={@current_user}
               create_new_annotation={@create_new_annotation}
+              selected_point={@selected_point}
             />
           <% _ -> %>
             <.search_results
@@ -53,12 +55,14 @@ defmodule OliWeb.Delivery.Student.Lesson.Annotations do
   attr :create_new_annotation, :boolean, default: false
   attr :annotations, :any, required: true
   attr :current_user, Oli.Accounts.User, required: true
+  attr :selected_point, :any, required: true
   attr :active_tab, :atom, default: :my_notes
 
   defp annotations(assigns) do
     ~H"""
     <div class="flex-1 flex flex-col gap-3 overflow-y-auto pb-[80px]">
       <.add_new_annotation_input
+        :if={@selected_point}
         class="my-2"
         active={@create_new_annotation}
         disable_anonymous_option={@active_tab == :my_notes || is_guest(@current_user)}
@@ -604,9 +608,20 @@ defmodule OliWeb.Delivery.Student.Lesson.Annotations do
     """
   end
 
-  attr :point_marker, :map, required: true
+  attr :point_marker, :any, required: true
   attr :selected, :boolean, default: false
   attr :count, :integer, default: nil
+
+  def annotation_bubble(%{point_marker: :page} = assigns) do
+    ~H"""
+    <button
+      class="absolute top-0 right-[-15px] cursor-pointer group"
+      phx-click="toggle_annotation_point"
+    >
+      <.chat_bubble selected={@selected} count={@count} />
+    </button>
+    """
+  end
 
   def annotation_bubble(assigns) do
     ~H"""

--- a/lib/oli_web/live/delivery/student/lesson/annotations.ex
+++ b/lib/oli_web/live/delivery/student/lesson/annotations.ex
@@ -321,7 +321,8 @@ defmodule OliWeb.Delivery.Student.Lesson.Annotations do
           name="search_term"
           value={@search_term}
           class="w-full border border-gray-400 dark:border-gray-700 rounded-lg px-12 py-3"
-          phx-change="search_term_change"
+          phx-change="search_annotations"
+          phx-debounce="500"
         />
         <button
           :if={@search_term != ""}

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -450,6 +450,10 @@ defmodule OliWeb.Delivery.Student.LessonLive do
     end
   end
 
+  def handle_event("search_term_change", %{"search_term" => search_term}, socket) do
+    {:noreply, assign_annotations(socket, search_term: search_term)}
+  end
+
   def handle_event("search_annotations", %{"search_term" => ""}, socket) do
     {:noreply, assign_annotations(socket, search_results: nil, search_term: "")}
   end
@@ -477,6 +481,10 @@ defmodule OliWeb.Delivery.Student.LessonLive do
     )
 
     {:noreply, assign_annotations(socket, search_results: :loading, search_term: search_term)}
+  end
+
+  def handle_event("clear_search", _, socket) do
+    {:noreply, assign_annotations(socket, search_results: nil, search_term: "")}
   end
 
   # handle assigns directly from async tasks

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -450,10 +450,6 @@ defmodule OliWeb.Delivery.Student.LessonLive do
     end
   end
 
-  def handle_event("search_term_change", %{"search_term" => search_term}, socket) do
-    {:noreply, assign_annotations(socket, search_term: search_term)}
-  end
-
   def handle_event("search_annotations", %{"search_term" => ""}, socket) do
     {:noreply, assign_annotations(socket, search_results: nil, search_term: "")}
   end


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/NG23-83

Implements the ability for a user to search their notes and posts in the sidebar. When a search result it clicked, the point block that contains the note is selected and the replies for the particular post are loaded.

<img width="1654" alt="Screenshot 2024-04-16 at 5 05 06 PM" src="https://github.com/Simon-Initiative/oli-torus/assets/6248894/3dbf4a73-0ecd-4c7e-9e0a-87eaa8a4fa15">


This PR also includes some changes specified by the designers to allow a bubble to be deselected, showing all notes for a page regardless of point block annotations, however a block must be selected in order to create a note. Seen in the mockup video below.

https://github.com/Simon-Initiative/oli-torus/assets/6248894/64cb0c9f-c258-404d-af24-7f1cb4aa04fa

It's worth mentioning this PR does not pre-compute an index column for the ts_vector used by postgres to facilitate search. This can be added later if performance becomes a concern or if we deem it to be necessary as part of this work.
