### PR TITLE
[BUGFIX] [MER-3138] | Nongraded Adaptive Pages Attempts Don't Finalize

### DIFF
--- a/assets/src/apps/delivery/layouts/deck/LessonFinishedDialog.tsx
+++ b/assets/src/apps/delivery/layouts/deck/LessonFinishedDialog.tsx
@@ -2,7 +2,6 @@ import React, { Fragment, useCallback, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { ActionFailure, ActionResult, finalizePageAttempt } from 'data/persistence/page_lifecycle';
 import {
-  selectIsGraded,
   selectPageSlug,
   selectPreviewMode,
   selectResourceAttemptGuid,
@@ -24,7 +23,6 @@ const LessonFinishedDialog: React.FC<LessonFinishedDialogProps> = ({
   const [redirectURL, setRedirectURL] = useState('');
   const [finalizeError, setFinalizeError] = useState<string | null>(null);
   const isPreviewMode = useSelector(selectPreviewMode);
-  const graded = useSelector(selectIsGraded);
   const revisionSlug = useSelector(selectPageSlug);
   const sectionSlug = useSelector(selectSectionSlug);
   const resourceAttemptGuid = useSelector(selectResourceAttemptGuid);
@@ -39,7 +37,7 @@ const LessonFinishedDialog: React.FC<LessonFinishedDialogProps> = ({
       return;
     }
     setIsOpen(false);
-    if (!graded || isPreviewMode) {
+    if (isPreviewMode) {
       window.location.reload();
     } else {
       window.location.href = redirectURL;
@@ -48,7 +46,7 @@ const LessonFinishedDialog: React.FC<LessonFinishedDialogProps> = ({
 
   const handleFinalization = useCallback(async () => {
     setFinalizationCalled(true);
-    if (!isPreviewMode && graded) {
+    if (!isPreviewMode) {
       // only graded pages are finalized
       try {
         const finalizeResult = await finalizePageAttempt(
@@ -86,7 +84,7 @@ const LessonFinishedDialog: React.FC<LessonFinishedDialogProps> = ({
       }
     }
     setIsFinalized(true);
-  }, [sectionSlug, revisionSlug, resourceAttemptGuid, graded, isPreviewMode]);
+  }, [sectionSlug, revisionSlug, resourceAttemptGuid, isPreviewMode]);
 
   useEffect(() => {
     // TODO: maybe we should call finalization elsewhere than in this modal


### PR DESCRIPTION
Nongraded adaptive pages needs to call the same finalized end point that graded pages call.