### PR TITLE
[ENHANCEMENT] [MER-3181] Allow progress to be set from client

### DIFF
--- a/lib/oli/delivery/attempts/core.ex
+++ b/lib/oli/delivery/attempts/core.ex
@@ -405,6 +405,19 @@ defmodule Oli.Delivery.Attempts.Core do
     )
   end
 
+  def get_resource_access_from_guid(resource_attempt_guid) do
+    Repo.one(
+      from(a in ResourceAccess,
+        left_join: ra in ResourceAttempt,
+        on: a.id == ra.resource_access_id,
+        where: ra.attempt_guid == ^resource_attempt_guid,
+        select: a
+      )
+    )
+  end
+
+
+
   @doc """
   For a given project id, this retrieves part attempts and user information, for those part attempts
   that are evaluated and that have snapshots defined. This is a key query for powering analytics

--- a/lib/oli/delivery/attempts/core.ex
+++ b/lib/oli/delivery/attempts/core.ex
@@ -416,8 +416,6 @@ defmodule Oli.Delivery.Attempts.Core do
     )
   end
 
-
-
   @doc """
   For a given project id, this retrieves part attempts and user information, for those part attempts
   that are evaluated and that have snapshots defined. This is a key query for powering analytics

--- a/lib/oli/delivery/attempts/page_lifecycle/ungraded.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/ungraded.ex
@@ -60,7 +60,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Ungraded do
       }) do
     now = DateTime.utc_now()
 
-    {:ok, _} = update_resource_attempt(resource_attempt, %{
+    update_resource_attempt(resource_attempt, %{
       date_evaluated: now,
       date_submitted: now,
       lifecycle_state: :evaluated

--- a/lib/oli/delivery/attempts/page_lifecycle/ungraded.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/ungraded.ex
@@ -60,24 +60,17 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Ungraded do
       }) do
     now = DateTime.utc_now()
 
-    {:ok, {:ok, resource_access}} = Repo.transaction(fn ->
-
-      {:ok, _} = update_resource_attempt(resource_attempt, %{
-        date_evaluated: now,
-        date_submitted: now,
-        lifecycle_state: :evaluated
-      })
-
-      get_resource_access(resource_attempt.resource_access_id)
-      |> Oli.Delivery.Metrics.mark_progress_completed()
-
-    end)
+    {:ok, _} = update_resource_attempt(resource_attempt, %{
+      date_evaluated: now,
+      date_submitted: now,
+      lifecycle_state: :evaluated
+    })
 
     {:ok,
      %FinalizationSummary{
        graded: false,
        lifecycle_state: :evaluated,
-       resource_access: resource_access,
+       resource_access: nil,
        part_attempt_guids: nil,
        effective_settings: effective_settings
      }}

--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -1167,8 +1167,10 @@ defmodule Oli.Delivery.Metrics do
   Updates page progress to be 100% complete.
   """
   def mark_progress_completed(resource_attempt_guid) when is_binary(resource_attempt_guid) do
-    Core.get_resource_access_from_guid(resource_attempt_guid)
-    |> mark_progress_completed()
+    case Core.get_resource_access_from_guid(resource_attempt_guid) do
+      nil -> {:error, :resource_access_not_found}
+      ra -> mark_progress_completed(ra)
+    end
   end
 
   def mark_progress_completed(%ResourceAccess{} = ra) do

--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -1166,6 +1166,11 @@ defmodule Oli.Delivery.Metrics do
   @doc """
   Updates page progress to be 100% complete.
   """
+  def mark_progress_completed(resource_attempt_guid) when is_binary(resource_attempt_guid) do
+    Core.get_resource_access_from_guid(resource_attempt_guid)
+    |> mark_progress_completed()
+  end
+
   def mark_progress_completed(%ResourceAccess{} = ra) do
     Core.update_resource_access(ra, %{progress: 1.0})
   end

--- a/lib/oli_web/controllers/api/page_lifecycle_controller.ex
+++ b/lib/oli_web/controllers/api/page_lifecycle_controller.ex
@@ -87,6 +87,28 @@ defmodule OliWeb.Api.PageLifecycleController do
     end
   end
 
+  def transition(conn, %{
+    "action" => "mark_completed",
+    "attempt_guid" => attempt_guid
+  }) do
+
+    case Oli.Delivery.Metrics.mark_progress_completed(attempt_guid) do
+      {:ok, _} ->
+        json(conn, %{
+          result: "success",
+          commandResult: "success"
+        })
+
+      {:error, reason} ->
+        json(conn, %{
+          result: "success",
+          commandResult: "failure",
+          reason: reason
+        })
+    end
+
+  end
+
   defp command_failure(conn, reason, section_slug, revision_slug) do
     json(conn, %{
       result: "success",

--- a/lib/oli_web/controllers/api/page_lifecycle_controller.ex
+++ b/lib/oli_web/controllers/api/page_lifecycle_controller.ex
@@ -88,10 +88,9 @@ defmodule OliWeb.Api.PageLifecycleController do
   end
 
   def transition(conn, %{
-    "action" => "mark_completed",
-    "attempt_guid" => attempt_guid
-  }) do
-
+        "action" => "mark_completed",
+        "attempt_guid" => attempt_guid
+      }) do
     case Oli.Delivery.Metrics.mark_progress_completed(attempt_guid) do
       {:ok, _} ->
         json(conn, %{
@@ -106,7 +105,6 @@ defmodule OliWeb.Api.PageLifecycleController do
           reason: reason
         })
     end
-
   end
 
   defp command_failure(conn, reason, section_slug, revision_slug) do

--- a/test/oli_web/controllers/api/page_lifecycle_controller_test.exs
+++ b/test/oli_web/controllers/api/page_lifecycle_controller_test.exs
@@ -1,0 +1,134 @@
+defmodule OliWeb.PageLifecycleTest do
+  use OliWeb.ConnCase
+
+  alias Oli.Activities.Model.Part
+  alias Oli.Delivery.Attempts.Core
+  alias Oli.Seeder
+  alias OliWeb.Router.Helpers, as: Routes
+
+  describe "set progress completed tests" do
+    setup [:setup_session]
+
+    test "can set progress", %{
+      conn: conn,
+      map: map
+    } do
+
+      attempt = map.ungraded_page_user1_attempt1
+
+      assert_progress(0.0, attempt.attempt_guid)
+
+      conn =
+        post(
+          conn,
+          Routes.page_lifecycle_path(conn, :transition),
+          %{"attempt_guid" => attempt.attempt_guid, "action" => "mark_completed"}
+        )
+
+      assert %{"result" => "success", "commandResult" => "success"} = json_response(conn, 200)
+
+      assert_progress(1.0, attempt.attempt_guid)
+
+    end
+
+  end
+
+  defp assert_progress(progress, guid) do
+    assert Core.get_resource_access_from_guid(guid).progress == progress
+  end
+
+  defp setup_session(%{conn: conn}) do
+
+    content = %{
+      "stem" => "1",
+      "authoring" => %{
+        "parts" => [
+          %{
+            "id" => "1",
+            "responses" => [
+              %{
+                "rule" => "input like {a}",
+                "score" => 10,
+                "id" => "r1",
+                "feedback" => %{"id" => "1", "content" => "yes"}
+              },
+              %{
+                "rule" => "input like {b}",
+                "score" => 1,
+                "id" => "r2",
+                "feedback" => %{"id" => "2", "content" => "almost"}
+              },
+              %{
+                "rule" => "input like {c}",
+                "score" => 0,
+                "id" => "r3",
+                "feedback" => %{"id" => "3", "content" => "no"}
+              }
+            ],
+            "scoringStrategy" => "best",
+            "evaluationStrategy" => "regex"
+          }
+        ]
+      }
+    }
+
+
+    map =
+      Seeder.base_project_with_resource2()
+      |> Seeder.add_activity(%{title: "one", max_attempts: 2, content: content}, :activity)
+      |> Seeder.create_section()
+      |> Seeder.add_user(%{}, :user1)
+
+    Seeder.ensure_published(map.publication.id)
+
+    map = Seeder.add_page(
+        map,
+        %{
+          title: "page1",
+          content: %{
+            "model" => [
+              %{
+                "type" => "activity-reference",
+                "activity_id" => Map.get(map, :activity).revision.resource_id
+              }
+            ]
+          },
+          objectives: %{"attached" => []}
+        },
+        :ungraded_page
+      )
+      |> Seeder.create_section_resources()
+      |> Seeder.create_resource_attempt(
+        %{attempt_number: 1},
+        :user1,
+        :ungraded_page,
+        :ungraded_page_user1_attempt1
+      )
+      |> Seeder.create_activity_attempt(
+        %{attempt_number: 1, transformed_model: content},
+        :activity,
+        :ungraded_page_user1_attempt1,
+        :ungraded_page_user1_activity_attempt1
+      )
+      |> Seeder.create_part_attempt(
+        %{attempt_number: 1},
+        %Part{id: "1", responses: [], hints: []},
+        :ungraded_page_user1_activity_attempt1,
+        :ungraded_page_user1_activity_attempt1_part1_attempt1
+      )
+
+    user = map.user1
+
+    lti_params_id =
+      Oli.Lti.TestHelpers.all_default_claims()
+      |> put_in(["https://purl.imsglobal.org/spec/lti/claim/context", "id"], map.section.slug)
+      |> cache_lti_params(user.id)
+
+    conn =
+      Plug.Test.init_test_session(conn, lti_session: nil)
+      |> Pow.Plug.assign_current_user(user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
+      |> OliWeb.Common.LtiSession.put_session_lti_params(lti_params_id)
+
+    {:ok, conn: conn, map: map}
+  end
+end

--- a/test/oli_web/controllers/api/page_lifecycle_controller_test.exs
+++ b/test/oli_web/controllers/api/page_lifecycle_controller_test.exs
@@ -13,7 +13,6 @@ defmodule OliWeb.PageLifecycleTest do
       conn: conn,
       map: map
     } do
-
       attempt = map.ungraded_page_user1_attempt1
 
       assert_progress(0.0, attempt.attempt_guid)
@@ -28,13 +27,11 @@ defmodule OliWeb.PageLifecycleTest do
       assert %{"result" => "success", "commandResult" => "success"} = json_response(conn, 200)
 
       assert_progress(1.0, attempt.attempt_guid)
-
     end
 
     test "fails when guid is bad", %{
       conn: conn
     } do
-
       conn =
         post(
           conn,
@@ -43,9 +40,7 @@ defmodule OliWeb.PageLifecycleTest do
         )
 
       assert %{"result" => "success", "commandResult" => "failure"} = json_response(conn, 200)
-
     end
-
   end
 
   defp assert_progress(progress, guid) do
@@ -53,7 +48,6 @@ defmodule OliWeb.PageLifecycleTest do
   end
 
   defp setup_session(%{conn: conn}) do
-
     content = %{
       "stem" => "1",
       "authoring" => %{
@@ -87,7 +81,6 @@ defmodule OliWeb.PageLifecycleTest do
       }
     }
 
-
     map =
       Seeder.base_project_with_resource2()
       |> Seeder.add_activity(%{title: "one", max_attempts: 2, content: content}, :activity)
@@ -96,7 +89,8 @@ defmodule OliWeb.PageLifecycleTest do
 
     Seeder.ensure_published(map.publication.id)
 
-    map = Seeder.add_page(
+    map =
+      Seeder.add_page(
         map,
         %{
           title: "page1",

--- a/test/oli_web/controllers/api/page_lifecycle_controller_test.exs
+++ b/test/oli_web/controllers/api/page_lifecycle_controller_test.exs
@@ -31,6 +31,21 @@ defmodule OliWeb.PageLifecycleTest do
 
     end
 
+    test "fails when guid is bad", %{
+      conn: conn
+    } do
+
+      conn =
+        post(
+          conn,
+          Routes.page_lifecycle_path(conn, :transition),
+          %{"attempt_guid" => "this_guid_does_not_exist", "action" => "mark_completed"}
+        )
+
+      assert %{"result" => "success", "commandResult" => "failure"} = json_response(conn, 200)
+
+    end
+
   end
 
   defp assert_progress(progress, guid) do


### PR DESCRIPTION
This adds a page lifecycle transition action to allow the client side adaptive player to mark the progress on a page to be complete.  This only adds the server side, the client side work will follow up in another PR.