### PR TITLE
[BUG FIX] [NG23-124] Render clock icon for graded pages

### DIFF
--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -806,14 +806,14 @@ defmodule OliWeb.Delivery.Student.LearnLive do
         <div class="flex relative">
           <button
             id={"slider_left_button_#{@unit["resource_id"]}"}
-            class="hidden absolute items-center justify-start -top-1 -left-1 w-10 bg-gradient-to-r from-gray-100 dark:from-gray-900 h-[180px] z-20 text-gray-700 dark:text-gray-600 hover:text-xl hover:dark:text-gray-200 hover:w-16 cursor-pointer"
+            class="hidden absolute items-center justify-start -top-1 -left-1 w-10 bg-gradient-to-r from-gray-100 dark:from-[#0D0C0F] h-[180px] z-20 text-gray-700 dark:text-gray-600 hover:text-xl hover:dark:text-gray-200 hover:w-16 cursor-pointer"
             tabindex="-1"
           >
             <i class="fa-solid fa-chevron-left ml-3"></i>
           </button>
           <button
             id={"slider_right_button_#{@unit["resource_id"]}"}
-            class="hidden absolute items-center justify-end -top-1 -right-1 w-10 bg-gradient-to-l from-gray-100 dark:from-gray-900 h-[180px] z-20 text-gray-700 dark:text-gray-600 hover:text-xl hover:dark:text-gray-200 hover:w-16 cursor-pointer"
+            class="hidden absolute items-center justify-end -top-1 -right-1 w-10 bg-gradient-to-l from-gray-100 dark:from-[#0D0C0F] h-[180px] z-20 text-gray-700 dark:text-gray-600 hover:text-xl hover:dark:text-gray-200 hover:w-16 cursor-pointer"
             tabindex="-1"
           >
             <i class="fa-solid fa-chevron-right mr-3"></i>

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -1442,7 +1442,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
               <%= "#{@title}" %>
             </span>
 
-            <.duration_in_minutes duration_minutes={@duration_minutes} />
+            <.duration_in_minutes duration_minutes={@duration_minutes} graded={@graded} />
           </div>
           <div :if={@graded} role="due date and score" class="flex">
             <span class="opacity-60 text-[13px] font-normal font-['Open Sans'] !font-normal opacity-60 dark:text-white">
@@ -1466,7 +1466,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
         <.clock_icon />
       </div>
       <div class="text-right dark:text-white opacity-60 whitespace-nowrap">
-        <span class="text-sm font-semibold font-['Open Sans']">
+        <span class="text-sm font-semibold font-['Open Sans']" role="duration in minutes">
           <%= parse_minutes(@duration_minutes) %>
           <span class="w-[25px] self-stretch text-[13px] font-semibold font-['Open Sans']">
             min
@@ -1923,6 +1923,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
       stroke-linecap="round"
       stroke-linejoin="round"
       class="icon icon-tabler icons-tabler-outline icon-tabler-clock"
+      role="clock icon"
     >
       <path stroke="none" d="M0 0h24v24H0z" fill="none" />
       <path d="M3 12a9 9 0 1 0 18 0a9 9 0 0 0 -18 0" />

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -119,6 +119,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
         resource_type_id: ResourceType.get_id_by_type("page"),
         title: "Page 4",
         graded: true,
+        duration_minutes: 22,
         content: %{
           model: [
             %{
@@ -1227,6 +1228,34 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       Sections.mark_section_visited_for_student(section, user)
 
       {:ok, _view, _html} = live(conn, Utils.learn_live_path(section.slug))
+    end
+
+    test "sees a clock icon beside the duration in minutes for graded pages", %{
+      conn: conn,
+      user: user,
+      section: section,
+      page_4: page_4
+    } do
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.mark_section_visited_for_student(section, user)
+
+      {:ok, view, _html} = live(conn, Utils.learn_live_path(section.slug))
+
+      # expand unit 1/module 2 details
+      view
+      |> element(~s{div[role="unit_1"] div[role="card_2"]})
+      |> render_click()
+
+      assert has_element?(
+               view,
+               ~s{div[id="index_item_4_#{page_4.resource_id}"] svg[role="clock icon"]}
+             )
+
+      assert has_element?(
+               view,
+               ~s{div[id="index_item_4_#{page_4.resource_id}"] span[role="duration in minutes"]},
+               "22"
+             )
     end
 
     test "sees a check icon on visited and completed pages", %{


### PR DESCRIPTION
While working on [NG23-124](https://github.com/Simon-Initiative/oli-torus/pull/4758) I did a small refactor that introduced a small bug: the clock icon was not being shown for graded pages.

### Before
<img width="1375" alt="image" src="https://github.com/Simon-Initiative/oli-torus/assets/74839302/31429981-de80-4925-9788-9e278b2fd679">


### After
<img width="1375" alt="image" src="https://github.com/Simon-Initiative/oli-torus/assets/74839302/4c3f9237-99ae-4381-bb1d-4adae20d2ec2">


On the other hand, slider fade background color was updated to match the new page background color.

### Before
![image](https://github.com/Simon-Initiative/oli-torus/assets/74839302/694f5f74-e753-44c3-bdab-a3f673bec0fd)


### After
![image](https://github.com/Simon-Initiative/oli-torus/assets/74839302/74ddf397-2175-4691-b344-7bd2da7a35a4)


[NG23-124]: https://eliterate.atlassian.net/browse/NG23-124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ