### PR TITLE
[ENHANCEMENT] [NG23-164] Remove ability to collapse specific sections and subsections

### DIFF
--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -287,50 +287,6 @@ defmodule OliWeb.Delivery.Student.LearnLive do
     do: navigate_to_resource(values, socket)
 
   def handle_event(
-        "expand_section",
-        %{
-          "resource_id" => resource_id,
-          "module_resource_id" => module_resource_id,
-          "parent_due_date" => parent_due_date
-        },
-        socket
-      ) do
-    full_hierarchy = get_or_compute_full_hierarchy(socket.assigns.section)
-    resource_id = String.to_integer(resource_id)
-    module_resource_id = String.to_integer(module_resource_id)
-
-    selected_unit =
-      Oli.Delivery.Hierarchy.find_parent_in_hierarchy(
-        full_hierarchy,
-        &(&1["resource_id"] == module_resource_id)
-      )
-
-    # we concatenate the resource_id with the parent_due_date to create a unique key
-    # and allow the student to expand and collapse same sections grouping pages with different due dates independently
-    closed_sections =
-      socket.assigns.display_props_per_module_id
-      |> get_in([module_resource_id, :closed_sections], [])
-      |> then(
-        &if Enum.member?(&1, "#{resource_id}-#{parent_due_date}"),
-          do: List.delete(&1, "#{resource_id}-#{parent_due_date}"),
-          else: ["#{resource_id}-#{parent_due_date}" | &1]
-      )
-
-    display_props_per_module_id =
-      Map.update(
-        socket.assigns.display_props_per_module_id,
-        module_resource_id,
-        %{closed_sections: closed_sections, show_completed_pages: true},
-        &%{closed_sections: closed_sections, show_completed_pages: &1.show_completed_pages}
-      )
-
-    {:noreply,
-     socket
-     |> assign(display_props_per_module_id: display_props_per_module_id)
-     |> update(:units, fn units -> [selected_unit | units] end)}
-  end
-
-  def handle_event(
         "toggle_completed_pages",
         %{"module_resource_id" => module_resource_id},
         socket
@@ -352,8 +308,8 @@ defmodule OliWeb.Delivery.Student.LearnLive do
       Map.update(
         socket.assigns.display_props_per_module_id,
         module_resource_id,
-        %{closed_sections: [], show_completed_pages: show_completed_pages?},
-        &%{closed_sections: &1.closed_sections, show_completed_pages: show_completed_pages?}
+        %{show_completed_pages: show_completed_pages?},
+        fn _ -> %{show_completed_pages: show_completed_pages?} end
       )
 
     {:noreply,
@@ -1104,12 +1060,6 @@ defmodule OliWeb.Delivery.Student.LearnLive do
 
     assigns =
       Map.merge(assigns, %{
-        closed_sections:
-          get_in(
-            assigns.display_props_per_module_id,
-            [assigns.module["resource_id"], :closed_sections],
-            []
-          ),
         show_completed_pages: show_completed_pages,
         page_due_dates:
           get_contained_pages_due_dates(
@@ -1256,7 +1206,6 @@ defmodule OliWeb.Delivery.Student.LearnLive do
           raw_avg_score={Map.get(@student_raw_avg_score_per_page_id, child["resource_id"])}
           progress={Map.get(@student_progress_per_resource_id, child["resource_id"])}
           student_progress_per_resource_id={@student_progress_per_resource_id}
-          closed_sections={@closed_sections}
           show_completed_pages={@show_completed_pages}
         />
       </div>
@@ -1284,7 +1233,6 @@ defmodule OliWeb.Delivery.Student.LearnLive do
   attr :due_date, Date
   attr :parent_due_date, Date
   attr :progress, :float
-  attr :closed_sections, :list, default: []
   attr :show_completed_pages, :boolean
 
   def index_item(%{type: "section"} = assigns) do
@@ -1296,7 +1244,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
       })
 
     ~H"""
-    <button
+    <div
       :if={
         display_module_item?(
           @show_completed_pages,
@@ -1306,17 +1254,8 @@ defmodule OliWeb.Delivery.Student.LearnLive do
         )
       }
       role={"#{@type} #{@numbering_index} details"}
-      class="w-full pl-[5px] pr-[7px] py-2.5 rounded-lg justify-start items-center gap-5 flex rounded-lg focus:bg-[#000000]/5 hover:bg-[#000000]/5 dark:focus:bg-[#FFFFFF]/5 dark:hover:bg-[#FFFFFF]/5"
+      class="w-full pl-[5px] pr-[7px] py-2.5 rounded-lg justify-start items-center gap-5 flex rounded-lg"
       id={"index_item_#{@resource_id}_#{@parent_due_date}"}
-      phx-click={
-        JS.toggle(
-          to: "#section_group_#{@resource_id}_#{@parent_due_date}",
-          out: {"fade-out duration-300", "opacity-100", "opacity-0"},
-          in: {"fade-in duration-300", "opacity-0", "opacity-100"},
-          display: "flex"
-        )
-        |> JS.push("expand_section")
-      }
       phx-value-resource_id={@resource_id}
       phx-value-parent_due_date={@parent_due_date}
       phx-value-module_resource_id={@module_resource_id}
@@ -1339,13 +1278,10 @@ defmodule OliWeb.Delivery.Student.LearnLive do
           </div>
         </div>
       </div>
-    </button>
+    </div>
     <div
       id={"section_group_#{@resource_id}_#{@parent_due_date}"}
-      class={[
-        "flex relative flex-col items-center w-full",
-        maybe_hidden_section(@closed_sections, @resource_id, @parent_due_date)
-      ]}
+      class="flex relative flex-col items-center w-full"
     >
       <.index_item
         :for={child <- @children}
@@ -1387,7 +1323,6 @@ defmodule OliWeb.Delivery.Student.LearnLive do
         student_raw_avg_score_per_page_id={@student_raw_avg_score_per_page_id}
         progress={Map.get(@student_progress_per_resource_id, child["resource_id"])}
         student_progress_per_resource_id={@student_progress_per_resource_id}
-        closed_sections={@closed_sections}
         show_completed_pages={@show_completed_pages}
       />
     </div>
@@ -2430,9 +2365,5 @@ defmodule OliWeb.Delivery.Student.LearnLive do
       parent ->
         find_module_ancestor(hierarchy, parent["resource_id"], container_resource_type_id)
     end
-  end
-
-  defp maybe_hidden_section(closed_sections, resource_id, parent_due_date) do
-    if Enum.member?(closed_sections, "#{resource_id}-#{parent_due_date}"), do: "hidden", else: ""
   end
 end

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -1881,27 +1881,6 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
 
       assert render(subsection_1_element) =~ "Erlang as a motivation"
       assert render(subsection_1_element) =~ "ml-[20px]"
-
-      # Hides the sub-section content when it is clicked
-      render_click(subsection_1_element)
-
-      assert has_element?(
-               view,
-               ~s{div.hidden button[phx-click="navigate_to_resource"][phx-value-slug="#{page_11.slug}"]}
-             )
-
-      # Hides the section content when it is clicked
-      render_click(section_1_element)
-
-      assert has_element?(
-               view,
-               ~s{div.hidden button[phx-click="navigate_to_resource"][phx-value-slug="#{page_12.slug}"]}
-             )
-
-      assert has_element?(
-               view,
-               "div.hidden #index_item_#{subsection_1.resource_id}_2023-11-03"
-             )
     end
 
     test "groups pages within a module index by due date (even if some pages do not yet have a scheduled date)",

--- a/test/oli_web/live/delivery/student/lesson_live_test.exs
+++ b/test/oli_web/live/delivery/student/lesson_live_test.exs
@@ -15,12 +15,11 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
   defp live_view_adaptive_lesson_live_route(section_slug, revision_slug, request_path \\ nil)
 
   defp live_view_adaptive_lesson_live_route(section_slug, revision_slug, nil) do
-    ~p"/sections/#{section_slug}/adaptive_lesson/#{revision_slug}" |> IO.inspect()
+    ~p"/sections/#{section_slug}/adaptive_lesson/#{revision_slug}"
   end
 
   defp live_view_adaptive_lesson_live_route(section_slug, revision_slug, request_path) do
     ~p"/sections/#{section_slug}/adaptive_lesson/#{revision_slug}?request_path=#{request_path}"
-    |> IO.inspect()
   end
 
   defp create_attempt(student, section, revision, resource_attempt_data \\ %{}) do


### PR DESCRIPTION
[NG23-164](https://eliterate.atlassian.net/browse/NG23-164)

In the Learn view we currently allow to hide/show sections and subsections in two different ways:
1) Hide/Show Completed pages
2) By clicking a specific section or subsections.

This PR disables 2.

https://github.com/Simon-Initiative/oli-torus/assets/26532202/7101a826-6bab-4726-b9c8-d583a0f0901b



[NG23-164]: https://eliterate.atlassian.net/browse/NG23-164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ