### PR TITLE
[BUG FIX] [MER-3153] Re-implement lost quiz answers second tab

### DIFF
--- a/assets/src/phoenix/activity_bridge.ts
+++ b/assets/src/phoenix/activity_bridge.ts
@@ -49,7 +49,7 @@ export const initActivityBridge = (elementId: string) => {
         'PATCH',
         { partInputs: e.detail.payload },
         e.detail.continuation,
-        saveTransform
+        saveTransform,
       );
     },
     false,
@@ -97,7 +97,7 @@ export const initActivityBridge = (elementId: string) => {
         'PATCH',
         { response: e.detail.payload },
         e.detail.continuation,
-        saveTransform
+        saveTransform,
       );
     },
     false,

--- a/assets/src/phoenix/activity_bridge.ts
+++ b/assets/src/phoenix/activity_bridge.ts
@@ -25,7 +25,9 @@ function makeRequest(
     .then((result) => continuation(result))
     .catch((error) => continuation(undefined, error));
 }
-
+const saveTransform = (result: any) => {
+  return result.error ? Promise.reject({ message: result.message }) : Promise.resolve(result);
+};
 const nothingTransform = (result: any) => Promise.resolve(result);
 const submissionTransform = (key: string, result: any) => {
   return result.error
@@ -47,6 +49,7 @@ export const initActivityBridge = (elementId: string) => {
         'PATCH',
         { partInputs: e.detail.payload },
         e.detail.continuation,
+        saveTransform
       );
     },
     false,
@@ -94,6 +97,7 @@ export const initActivityBridge = (elementId: string) => {
         'PATCH',
         { response: e.detail.payload },
         e.detail.continuation,
+        saveTransform
       );
     },
     false,

--- a/lib/oli_web/controllers/api/attempt_controller.ex
+++ b/lib/oli_web/controllers/api/attempt_controller.ex
@@ -411,6 +411,15 @@ defmodule OliWeb.Api.AttemptController do
       {:ok, _} ->
         json(conn, %{"type" => "success"})
 
+      {:error, :already_submitted} ->
+        conn
+        |> put_status(403)
+        |> json(%{
+          "error" => true,
+          "message" =>
+            "These changes could not be saved as this attempt may have already been submitted"
+        })
+
       {:error, e} ->
         {_, msg} = Oli.Utils.log_error("Could not save part", e)
         error(conn, 500, msg)
@@ -531,6 +540,15 @@ defmodule OliWeb.Api.AttemptController do
     case Activity.save_student_input(parsed) do
       {:ok, _} ->
         json(conn, %{"type" => "success"})
+
+      {:error, :already_submitted} ->
+        conn
+        |> put_status(403)
+        |> json(%{
+          "error" => true,
+          "message" =>
+            "These changes could not be saved as this attempt may have already been submitted"
+        })
 
       {:error, e} ->
         {_, msg} = Oli.Utils.log_error("Could not save activity", e)

--- a/test/oli_web/controllers/api/attempt_controller_test.exs
+++ b/test/oli_web/controllers/api/attempt_controller_test.exs
@@ -77,13 +77,225 @@ defmodule OliWeb.AttemptControllerTest do
     end
   end
 
+  describe "activity and attempt already submitted" do
+    setup [:setup_session]
+
+    test "cannot submit an already submitted activity in a graded page", %{
+      conn: conn,
+      map: map
+    } do
+      # Mark activity attempt as submitted
+      {:ok, activity_attempt} =
+        Core.get_latest_activity_attempts(map.attempt1.id)
+        |> hd
+        |> Core.update_activity_attempt(%{
+          lifecycle_state: "submitted",
+          date_submitted: DateTime.utc_now()
+        })
+
+      # Submit activity attempt endpoint
+      conn =
+        put(
+          conn,
+          ~p"/api/v1/state/course/#{map.section.slug}/activity_attempt/#{activity_attempt.attempt_guid}",
+          %{
+            "section_slug" => map.section.slug,
+            "activity_attempt_guid" => activity_attempt.attempt_guid,
+            "partInputs" => []
+          }
+        )
+
+      assert %{
+               "message" =>
+                 "These changes could not be saved as this attempt may have already been submitted",
+               "error" => true
+             } =
+               json_response(conn, 403)
+    end
+
+    test "cannot change an already input submitted in a graded page", %{
+      conn: conn,
+      map: map
+    } do
+      # Mark part attempt as submitted
+      {:ok, part_attempt} =
+        Core.get_latest_part_attempts(map.activity_attempt1.attempt_guid)
+        |> hd
+        |> Core.update_part_attempt(%{
+          lifecycle_state: "submitted",
+          date_submitted: DateTime.utc_now()
+        })
+
+      # Save activity attempt endpoint
+      conn =
+        patch(
+          conn,
+          ~p"/api/v1/state/course/#{map.section.slug}/activity_attempt/#{map.activity_attempt1.attempt_guid}",
+          %{
+            "activity_attempt_guid" => map.activity_attempt1.attempt_guid,
+            "partInputs" => [
+              %{
+                "attemptGuid" => part_attempt.attempt_guid,
+                "response" => %{"input" => "Hello World"}
+              }
+            ]
+          }
+        )
+
+      assert %{
+               "message" =>
+                 "These changes could not be saved as this attempt may have already been submitted",
+               "error" => true
+             } =
+               json_response(conn, 403)
+    end
+
+    test "cannot save an already part attempt submitted in a graded page", %{
+      conn: conn,
+      map: map
+    } do
+      # Mark part attempt as submitted
+      {:ok, part_attempt} =
+        Core.get_latest_part_attempts(map.activity_attempt1.attempt_guid)
+        |> hd
+        |> Core.update_part_attempt(%{
+          lifecycle_state: "submitted",
+          date_submitted: DateTime.utc_now()
+        })
+
+      # Save part attempt endpoint
+      conn =
+        patch(
+          conn,
+          ~p"/api/v1/state/course/#{map.section.slug}/activity_attempt/#{map.activity_attempt1.attempt_guid}/part_attempt/#{part_attempt.attempt_guid}",
+          %{
+            "activity_attempt_guid" => map.activity_attempt1.attempt_guid,
+            "part_attempt_guid" => part_attempt.attempt_guid,
+            "response" => "Hello World"
+          }
+        )
+
+      assert %{
+               "message" =>
+                 "These changes could not be saved as this attempt may have already been submitted",
+               "error" => true
+             } =
+               json_response(conn, 403)
+    end
+
+    test "cannot submit an already submitted activity in a adaptive page", %{
+      conn: conn,
+      map: map
+    } do
+      # Mark activity attempt as submitted
+      {:ok, activity_attempt} =
+        Core.get_latest_activity_attempts(map.adaptive_attempt1.id)
+        |> hd
+        |> Core.update_activity_attempt(%{
+          lifecycle_state: "submitted",
+          date_submitted: DateTime.utc_now()
+        })
+
+      # Submit activity attempt endpoint
+      conn =
+        put(
+          conn,
+          ~p"/api/v1/state/course/#{map.section.slug}/activity_attempt/#{activity_attempt.attempt_guid}",
+          %{
+            "section_slug" => map.section.slug,
+            "activity_attempt_guid" => activity_attempt.attempt_guid,
+            "partInputs" => []
+          }
+        )
+
+      assert %{
+               "message" =>
+                 "These changes could not be saved as this attempt may have already been submitted",
+               "error" => true
+             } =
+               json_response(conn, 403)
+    end
+
+    test "cannot change an already input submitted in a adaptive page", %{
+      conn: conn,
+      map: map
+    } do
+      # Mark part attempt as submitted
+      {:ok, part_attempt} =
+        Core.get_latest_part_attempts(map.adaptive_activity_attempt1.attempt_guid)
+        |> hd
+        |> Core.update_part_attempt(%{
+          lifecycle_state: "submitted",
+          date_submitted: DateTime.utc_now()
+        })
+
+      # Save activity attempt endpoint
+      conn =
+        patch(
+          conn,
+          ~p"/api/v1/state/course/#{map.section.slug}/activity_attempt/#{map.adaptive_activity_attempt1.attempt_guid}",
+          %{
+            "activity_attempt_guid" => map.adaptive_activity_attempt1.attempt_guid,
+            "partInputs" => [
+              %{
+                "attemptGuid" => part_attempt.attempt_guid,
+                "response" => %{"input" => "Hello World"}
+              }
+            ]
+          }
+        )
+
+      assert %{
+               "message" =>
+                 "These changes could not be saved as this attempt may have already been submitted",
+               "error" => true
+             } =
+               json_response(conn, 403)
+    end
+
+    test "cannot save an already part attempt submitted in a adaptive page", %{
+      conn: conn,
+      map: map
+    } do
+      # Mark part attempt as submitted
+      {:ok, part_attempt} =
+        Core.get_latest_part_attempts(map.adaptive_activity_attempt1.attempt_guid)
+        |> hd
+        |> Core.update_part_attempt(%{
+          lifecycle_state: "submitted",
+          date_submitted: DateTime.utc_now()
+        })
+
+      # Save part attempt endpoint
+      conn =
+        patch(
+          conn,
+          ~p"/api/v1/state/course/#{map.section.slug}/activity_attempt/#{map.adaptive_activity_attempt1.attempt_guid}/part_attempt/#{part_attempt.attempt_guid}",
+          %{
+            "activity_attempt_guid" => map.adaptive_activity_attempt1.attempt_guid,
+            "part_attempt_guid" => part_attempt.attempt_guid,
+            "response" => "Hello World"
+          }
+        )
+
+      assert %{
+               "message" =>
+                 "These changes could not be saved as this attempt may have already been submitted",
+               "error" => true
+             } =
+               json_response(conn, 403)
+    end
+  end
+
   defp setup_session(%{conn: conn}) do
     map =
       Seeder.base_project_with_resource2()
       |> Seeder.create_section()
       |> Seeder.add_user(%{}, :user1)
       |> Seeder.add_activity(%{}, :publication, :project, :author, :activity_a)
+      |> Seeder.add_activity(%{}, :publication, :project, :author, :adaptive_activity)
       |> Seeder.add_page(%{graded: true}, :graded_page)
+      |> Seeder.add_adaptive_page(:adaptive_page)
       |> Seeder.create_section_resources()
       |> Seeder.create_resource_attempt(
         %{attempt_number: 1},
@@ -152,6 +364,25 @@ defmodule OliWeb.AttemptControllerTest do
         %Part{id: "3", responses: [], hints: []},
         :activity_attempt2,
         :part3_attempt2
+      )
+      |> Seeder.create_resource_attempt(
+        %{attempt_number: 1},
+        :user1,
+        :adaptive_page,
+        :adaptive_page_revision,
+        :adaptive_attempt1
+      )
+      |> Seeder.create_activity_attempt(
+        %{attempt_number: 1, transformed_model: nil},
+        :adaptive_activity,
+        :adaptive_attempt1,
+        :adaptive_activity_attempt1
+      )
+      |> Seeder.create_part_attempt(
+        %{attempt_number: 1},
+        %Part{id: "1", responses: [], hints: []},
+        :adaptive_activity_attempt1,
+        :adaptive_part1_attempt1
       )
 
     user = map.user1


### PR DESCRIPTION
[MER-3153](https://eliterate.atlassian.net/browse/MER-3153)

This PR adds checks to see if an activity or part has already been submitted or evaluated at the time of saving. 
A message will be displayed to the student if this happens.

Feel free to suggest any changes to the texts shown to the student in case he/she tries to submit or save an activity or part that has been previously submitted or evaluated, as well as suggest other test cases.

[MER-3153]: https://eliterate.atlassian.net/browse/MER-3153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ