### PR TITLE
[BUG FIX] [MER-3218] Fix incorrect footer call

### DIFF
--- a/lib/oli_web/templates/layout/default.html.heex
+++ b/lib/oli_web/templates/layout/default.html.heex
@@ -9,9 +9,6 @@
     <main role="main" id="main-content" class="pb-20">
       <%= @inner_content %>
     </main>
-
-    <OliWeb.Components.Footer.delivery_footer license={
-      Map.get(assigns, :has_license) && assigns[:license]
-    } />
+    <%= OliWeb.Components.Footer.global_footer(%{}) %>
   </div>
 <% end %>


### PR DESCRIPTION
Ticket: [MER-3218](https://eliterate.atlassian.net/browse/MER-3218)

This PR added the correct footer to the login page so that it can show the version information on the bottom-right corner.

<img width="780" alt="image" src="https://github.com/Simon-Initiative/oli-torus/assets/47334502/173d4aed-a570-4c9b-ac92-92576fd546fa">


[MER-3218]: https://eliterate.atlassian.net/browse/MER-3218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ