### PR TITLE
[FEATURE] [MER-3160] Flexibility payment code infrastructure

### DIFF
--- a/lib/oli/authoring/course/project.ex
+++ b/lib/oli/authoring/course/project.ex
@@ -23,6 +23,7 @@ defmodule Oli.Authoring.Course.Project do
     field(:latest_datashop_snapshot_url, :string)
     field(:latest_datashop_snapshot_timestamp, :utc_datetime)
     field(:analytics_version, Ecto.Enum, values: [:v1, :v2], default: :v1)
+    field(:allow_transfer_payment_codes, :boolean, default: false)
 
     embeds_one(:customizations, CustomLabels, on_replace: :delete)
     embeds_one(:attributes, ProjectAttributes, on_replace: :delete)
@@ -81,7 +82,8 @@ defmodule Oli.Authoring.Course.Project do
       :latest_analytics_snapshot_url,
       :latest_analytics_snapshot_timestamp,
       :latest_datashop_snapshot_url,
-      :latest_datashop_snapshot_timestamp
+      :latest_datashop_snapshot_timestamp,
+      :allow_transfer_payment_codes
     ])
     |> cast_embed(:attributes, required: false)
     |> cast_embed(:customizations, required: false)

--- a/lib/oli_web/live/products/details/actions.ex
+++ b/lib/oli_web/live/products/details/actions.ex
@@ -4,6 +4,8 @@ defmodule OliWeb.Products.Details.Actions do
 
   attr(:product, :any, required: true)
   attr(:is_admin, :boolean, required: true)
+  attr(:base_project, :map, required: true)
+  attr(:has_payment_codes, :boolean, required: true)
 
   def render(assigns) do
     ~H"""
@@ -27,6 +29,18 @@ defmodule OliWeb.Products.Details.Actions do
           </a>
         </div>
         <div>Audit payments and manage payment codes.</div>
+      </div>
+
+      <div
+        :if={@base_project.allow_transfer_payment_codes && @has_payment_codes}
+        class="d-flex align-items-center"
+      >
+        <div>
+          <button class="btn btn-link action-button" phx-click="show_products_to_transfer">
+            Transfer Payment Codes
+          </button>
+        </div>
+        <div>Allow transfer of payment codes to another product.</div>
       </div>
 
       <div class="d-flex align-items-center">

--- a/lib/oli_web/live/products/details_view.ex
+++ b/lib/oli_web/live/products/details_view.ex
@@ -275,7 +275,7 @@ defmodule OliWeb.Products.DetailsView do
           socket = put_flash(socket, :info, "Payment codes transferred successfully")
 
           redirect(socket,
-            to: Routes.live_path(socket, OliWeb.Products.DetailsView, socket.assigns.product.slug)
+            to: ~p"/authoring/products/#{socket.assigns.product.slug}"
           )
       end
 

--- a/lib/oli_web/live/products/details_view.ex
+++ b/lib/oli_web/live/products/details_view.ex
@@ -1,16 +1,18 @@
 defmodule OliWeb.Products.DetailsView do
   use OliWeb, :live_view
+  use OliWeb.Common.Modal
 
   alias Oli.{Accounts, Branding, Inventories, Repo}
-  alias OliWeb.Common.Breadcrumb
   alias Oli.Accounts.Author
-  alias Oli.Delivery.Sections
+  alias Oli.Authoring.Course
+  alias Oli.Delivery.{Paywall, Sections}
   alias Oli.Delivery.Sections.{Blueprint, Section}
-  alias OliWeb.Router.Helpers, as: Routes
-  alias OliWeb.Common.Confirm
-  alias OliWeb.Sections.Mount
-  alias OliWeb.Products.Details.{Actions, Edit, Content, ImageUpload}
   alias Oli.Utils.S3Storage
+  alias OliWeb.Common.{Breadcrumb, Confirm}
+  alias OliWeb.Products.Details.{Actions, Edit, Content, ImageUpload}
+  alias OliWeb.Products.ProductsToTransferCodes
+  alias OliWeb.Router.Helpers, as: Routes
+  alias OliWeb.Sections.Mount
 
   require Logger
 
@@ -34,6 +36,8 @@ defmodule OliWeb.Products.DetailsView do
       {_, _, product} ->
         author = Repo.get(Author, author_id)
 
+        base_project = Course.get_project!(product.base_project_id)
+
         available_brands =
           Branding.list_brands()
           |> Enum.map(fn brand -> {brand.name, brand.id} end)
@@ -51,7 +55,8 @@ defmodule OliWeb.Products.DetailsView do
            changeset: Section.changeset(product, %{}),
            title: "Edit Product",
            show_confirm: false,
-           breadcrumbs: [Breadcrumb.new(%{full_title: "Product Overview"})]
+           breadcrumbs: [Breadcrumb.new(%{full_title: "Product Overview"})],
+           base_project: base_project
          )
          |> Phoenix.LiveView.allow_upload(:cover_image,
            accept: ~w(.jpg .jpeg .png),
@@ -64,6 +69,7 @@ defmodule OliWeb.Products.DetailsView do
 
   def render(assigns) do
     ~H"""
+    <%= render_modal(assigns) %>
     <div class="overview container">
       <div class="grid grid-cols-12 py-5 border-b">
         <div class="md:col-span-4">
@@ -125,7 +131,12 @@ defmodule OliWeb.Products.DetailsView do
           <h4>Actions</h4>
         </div>
         <div class="md:col-span-8">
-          <Actions.render product={@product} is_admin={@is_admin} />
+          <Actions.render
+            product={@product}
+            is_admin={@is_admin}
+            base_project={@base_project}
+            has_payment_codes={Paywall.has_payment_codes?(@product.id)}
+          />
         </div>
       </div>
       <%= if @show_confirm do %>
@@ -222,6 +233,53 @@ defmodule OliWeb.Products.DetailsView do
 
   def handle_event("cancel_upload", %{"ref" => ref}, socket) do
     {:noreply, cancel_upload(socket, :cover_image, ref)}
+  end
+
+  def handle_event("show_products_to_transfer", _, socket) do
+    products_to_transfer =
+      Oli.Delivery.Sections.get_sections_by(
+        base_project_id: socket.assigns.base_project.id,
+        type: :blueprint
+      )
+      |> Enum.filter(fn product -> product.id != socket.assigns.product.id end)
+
+    modal_assigns = %{
+      id: "products_to_transfer_modal",
+      products_to_transfer: products_to_transfer,
+      changeset: socket.assigns.changeset
+    }
+
+    modal = fn assigns ->
+      ~H"""
+      <ProductsToTransferCodes.render {@modal_assigns} />
+      """
+    end
+
+    {:noreply,
+     show_modal(
+       socket,
+       modal,
+       modal_assigns: modal_assigns
+     )}
+  end
+
+  def handle_event("submit_transfer_payment_codes", %{"product_id" => product_id}, socket) do
+    socket = clear_flash(socket)
+
+    socket =
+      case Paywall.transfer_payment_codes(socket.assigns.product.id, product_id) do
+        {0, _nil} ->
+          put_flash(socket, :error, "Could not transfer payment codes")
+
+        {_count, _} ->
+          socket = put_flash(socket, :info, "Payment codes transferred successfully")
+
+          redirect(socket,
+            to: Routes.live_path(socket, OliWeb.Products.DetailsView, socket.assigns.product.slug)
+          )
+      end
+
+    {:noreply, hide_modal(socket, modal_assigns: nil)}
   end
 
   defp ext(entry) do

--- a/lib/oli_web/live/products/products_to_transfer_codes.ex
+++ b/lib/oli_web/live/products/products_to_transfer_codes.ex
@@ -1,0 +1,68 @@
+defmodule OliWeb.Products.ProductsToTransferCodes do
+  use OliWeb, :html
+
+  attr(:id, :string, required: true)
+  attr(:products_to_transfer, :any, required: true)
+  attr(:changeset, :any, required: true)
+
+  def render(assigns) do
+    ~H"""
+    <div
+      class="modal fade fixed top-0 left-0 hidden w-full h-full outline-none overflow-x-hidden overflow-y-auto"
+      id={@id}
+      tabindex="-1"
+      aria-labelledby="exampleModalLgLabel"
+      aria-modal="true"
+      role="dialog"
+      phx-hook="ModalLaunch"
+    >
+      <div class="modal-dialog modal-dialog-centered modal-md relative w-auto pointer-events-none">
+        <div class="modal-content border-none shadow-lg relative flex flex-col w-full pointer-events-auto bg-white bg-clip-padding rounded-md outline-none">
+          <div class="modal-header flex flex-shrink-0 items-center justify-between p-4 border-b border-gray-200 rounded-t-md">
+            <h5 class="text-xl font-medium leading-normal" id="exampleModalLgLabel">
+              Transfer Payment Codes
+            </h5>
+            <button
+              type="button"
+              class="btn-close box-content p-1 border-none rounded-none opacity-50 focus:shadow-none focus:outline-none focus:opacity-100 hover:opacity-75 hover:no-underline"
+              data-bs-dismiss="modal"
+              aria-label="Close"
+            >
+              <i class="fa-solid fa-xmark fa-xl"></i>
+            </button>
+          </div>
+
+          <.form for={@changeset} phx-submit="submit_transfer_payment_codes">
+            <div class="modal-body relative px-4 py-8 flex flex-col gap-y-4">
+              <%= if @products_to_transfer not in [nil, []] do %>
+                <h6>Select a product to transfer payment codes from this product.</h6>
+
+                <div class="flex flex-row gap-x-2 items-center">
+                  <.input
+                    id="product"
+                    class="torus-select"
+                    aria-describedby="select_product"
+                    type="select"
+                    placeholder="Select a product"
+                    name="product_id"
+                    value={fetch_field(@changeset, :id)}
+                    options={Enum.map(@products_to_transfer, &{&1.title, &1.id})}
+                  />
+                </div>
+              <% else %>
+                <h6>There are no products available to transfer payment codes.</h6>
+              <% end %>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+              <button type="submit" class="btn btn-success">
+                Confirm
+              </button>
+            </div>
+          </.form>
+        </div>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/oli_web/live/projects/overview_live.ex
+++ b/lib/oli_web/live/projects/overview_live.ex
@@ -324,7 +324,7 @@ defmodule OliWeb.Projects.OverviewLive do
       </Overview.section>
 
       <Overview.section
-        title="Transfer payment codes"
+        title="Transfer Payment Codes"
         description="Allows to transfer payment codes between products of this project."
       >
         <.live_component

--- a/lib/oli_web/live/projects/overview_live.ex
+++ b/lib/oli_web/live/projects/overview_live.ex
@@ -14,7 +14,7 @@ defmodule OliWeb.Projects.OverviewLive do
   alias Oli.Publishing.AuthoringResolver
   alias Oli.Resources.Collaboration
   alias OliWeb.Components.Overview
-  alias OliWeb.Projects.RequiredSurvey
+  alias OliWeb.Projects.{RequiredSurvey, TransferPaymentCodes}
   alias OliWeb.Common.SessionContext
 
   def mount(_params, session, socket) do
@@ -320,6 +320,17 @@ defmodule OliWeb.Projects.OverviewLive do
           author_id={@current_author.id}
           enabled={@project.required_survey_resource_id}
           required_survey={@project.required_survey}
+        />
+      </Overview.section>
+
+      <Overview.section
+        title="Transfer payment codes"
+        description="Allows to transfer payment codes between products of this project."
+      >
+        <.live_component
+          module={TransferPaymentCodes}
+          id="transfer-payment-codes-section"
+          project={@project}
         />
       </Overview.section>
 

--- a/lib/oli_web/live/projects/transfer_payment_codes.ex
+++ b/lib/oli_web/live/projects/transfer_payment_codes.ex
@@ -1,0 +1,39 @@
+defmodule OliWeb.Projects.TransferPaymentCodes do
+  use Phoenix.LiveComponent
+  alias Oli.Authoring.Course
+
+  attr :project, :map, required: true
+
+  def render(assigns) do
+    ~H"""
+    <div class="flex items-center h-full">
+      <form phx-change="set_allow_transfer" phx-target={@myself}>
+        <div class="form-check">
+          <label class="form-check-label">
+            <input
+              id="transfer_payment_codes"
+              name="transfer_payment_codes"
+              type="checkbox"
+              checked={@project.allow_transfer_payment_codes}
+            />
+            <span>
+              Allow transfer of payment codes
+            </span>
+          </label>
+        </div>
+      </form>
+    </div>
+    """
+  end
+
+  def handle_event("set_allow_transfer", _params, socket) do
+    project = socket.assigns.project
+
+    {:ok, project} =
+      Course.update_project(project, %{
+        allow_transfer_payment_codes: !project.allow_transfer_payment_codes
+      })
+
+    {:noreply, assign(socket, project: project)}
+  end
+end

--- a/priv/repo/migrations/20240426181431_allow_transfer_payment_codes.exs
+++ b/priv/repo/migrations/20240426181431_allow_transfer_payment_codes.exs
@@ -1,0 +1,9 @@
+defmodule Oli.Repo.Migrations.AllowTransferPaymentCodes do
+  use Ecto.Migration
+
+  def change do
+    alter table(:projects) do
+      add(:allow_transfer_payment_codes, :boolean, default: false)
+    end
+  end
+end

--- a/test/oli_web/live/products_test.exs
+++ b/test/oli_web/live/products_test.exs
@@ -6,9 +6,10 @@ defmodule OliWeb.ProductsLiveTest do
   import Oli.Factory
   import Mox
 
-  alias Oli.Delivery.Sections
+  alias Oli.Delivery.{Paywall, Sections}
   alias OliWeb.Router.Helpers, as: Routes
   alias Oli.Utils.Seeder
+  alias Oli.Authoring.Course
 
   @live_view_all_products Routes.live_path(OliWeb.Endpoint, OliWeb.Products.ProductsView)
 
@@ -23,6 +24,15 @@ defmodule OliWeb.ProductsLiveTest do
   defp create_product(_conn) do
     product =
       insert(:section, type: :blueprint, requires_payment: true, amount: Money.new(:USD, 10))
+
+    [product: product]
+  end
+
+  defp create_product_with_payment_codes(_conn) do
+    product =
+      insert(:section, type: :blueprint, requires_payment: true, amount: Money.new(:USD, 10))
+
+    Paywall.create_payment_codes(product.slug, 20)
 
     [product: product]
   end
@@ -390,5 +400,139 @@ defmodule OliWeb.ProductsLiveTest do
 
       assert render(view) =~ "Create a new product with title"
     end
+  end
+
+  describe "product overview - transfer payment codes" do
+    setup [:admin_conn, :create_product_with_payment_codes]
+
+    test "shows transfer payment codes button if product has payment codes and project has this option enabled",
+         %{conn: conn, product: product} do
+      allow_transfer_payment_codes(product.base_project)
+
+      {:ok, view, _html} = live(conn, ~p"/authoring/products/#{product.slug}")
+
+      assert view
+             |> element("button[phx-click=\"show_products_to_transfer\"]")
+             |> render() =~ "Transfer Payment Codes"
+
+      assert has_element?(view, "div", "Allow transfer of payment codes to another product.")
+    end
+
+    test "does not show transfer payment codes button if project has this option disabled", %{
+      conn: conn,
+      product: product
+    } do
+      {:ok, view, _html} = live(conn, ~p"/authoring/products/#{product.slug}")
+
+      refute has_element?(view, "button", "Transfer Payment Codes")
+
+      refute has_element?(view, "div", "Allow transfer of payment codes to another product.")
+    end
+
+    test "does not show transfer payment codes button if product has no payment codes", %{
+      conn: conn
+    } do
+      product =
+        insert(:section, type: :blueprint, requires_payment: true, amount: Money.new(:USD, 10))
+
+      allow_transfer_payment_codes(product.base_project)
+
+      {:ok, view, _html} = live(conn, ~p"/authoring/products/#{product.slug}")
+
+      refute has_element?(view, "button", "Transfer Payment Codes")
+
+      refute has_element?(view, "div", "Allow transfer of payment codes to another product.")
+    end
+
+    test "shows a modal to select another product to transfer payment codes when clicking on transfer payment codes button",
+         %{conn: conn, product: product} do
+      product_2 =
+        insert(:section,
+          type: :blueprint,
+          requires_payment: true,
+          amount: Money.new(:USD, 10),
+          base_project: product.base_project,
+          base_project_id: product.base_project_id
+        )
+
+      allow_transfer_payment_codes(product.base_project)
+
+      {:ok, view, _html} = live(conn, ~p"/authoring/products/#{product.slug}")
+
+      view
+      |> element("button[phx-click=\"show_products_to_transfer\"]")
+      |> render_click()
+
+      assert has_element?(view, "h5", "Transfer Payment Codes")
+
+      assert has_element?(
+               view,
+               "h6",
+               "Select a product to transfer payment codes from this product."
+             )
+
+      assert has_element?(view, ".torus-select option", product_2.title)
+    end
+
+    test "shows a message when there are no products available to transfer payment codes", %{
+      conn: conn,
+      product: product
+    } do
+      allow_transfer_payment_codes(product.base_project)
+
+      {:ok, view, _html} = live(conn, ~p"/authoring/products/#{product.slug}")
+
+      view
+      |> element("button[phx-click=\"show_products_to_transfer\"]")
+      |> render_click()
+
+      assert has_element?(
+               view,
+               "h6",
+               "There are no products available to transfer payment codes."
+             )
+    end
+
+    test "transfers payment codes to another product", %{conn: conn, product: product} do
+      product_2 =
+        insert(:section,
+          type: :blueprint,
+          requires_payment: true,
+          amount: Money.new(:USD, 10),
+          base_project: product.base_project,
+          base_project_id: product.base_project_id
+        )
+
+      allow_transfer_payment_codes(product.base_project)
+
+      {:ok, view, _html} = live(conn, ~p"/authoring/products/#{product.slug}")
+
+      view
+      |> element("button[phx-click=\"show_products_to_transfer\"]")
+      |> render_click()
+
+      view
+      |> element("form[phx-submit=\"submit_transfer_payment_codes\"]")
+      |> render_submit(%{
+        "product_id" => product_2.id
+      })
+
+      refute Paywall.has_payment_codes?(product.id)
+      assert Paywall.has_payment_codes?(product_2.id)
+
+      flash =
+        assert_redirected(
+          view,
+          ~p"/authoring/products/#{product.slug}"
+        )
+
+      assert flash["info"] == "Payment codes transferred successfully"
+    end
+  end
+
+  defp allow_transfer_payment_codes(project) do
+    Course.update_project(project, %{
+      allow_transfer_payment_codes: true
+    })
   end
 end


### PR DESCRIPTION
[MER-3160](https://eliterate.atlassian.net/browse/MER-3160)

This PR adds the functionality to transfer payment codes from one product to another product of the same project. 

On the one hand, an author/admin will be able to enable or disable this functionality from the overview view of a project. 

Also, from the overview view of a product, another product of the same project can be selected to transfer the payment codes of the current product. 

- Project overview

![Captura de pantalla 2024-05-02 a la(s) 10 53 44 a  m](https://github.com/Simon-Initiative/oli-torus/assets/16328384/0469534a-33d0-402d-9a11-d9c06f608ceb)

- Product overview

![Captura de pantalla 2024-05-02 a la(s) 10 54 04 a  m](https://github.com/Simon-Initiative/oli-torus/assets/16328384/68fe22ca-e77d-421e-bb7a-a8e9eb71abec)

![Captura de pantalla 2024-05-02 a la(s) 10 54 23 a  m](https://github.com/Simon-Initiative/oli-torus/assets/16328384/f8d96724-fb4f-4ac0-bcca-e1b73e6cf6fa)

![Captura de pantalla 2024-05-02 a la(s) 10 54 37 a  m](https://github.com/Simon-Initiative/oli-torus/assets/16328384/cf7eb3c8-37ca-42fc-b8be-b9c9205a98d4)




[MER-3160]: https://eliterate.atlassian.net/browse/MER-3160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ