### PR TITLE
[FEATURE] [NG23-141] Learn Page Outline View

### DIFF
--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -286,6 +286,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
   attr(:next_page, :map)
   attr(:section_slug, :string)
   attr(:request_path, :string)
+  attr(:selected_view, :string, doc: "The selected view for the Learn page (gallery or outline)")
 
   def previous_next_nav(assigns) do
     # <.links /> were changed from "navigate" to "href" to force a page reload
@@ -319,7 +320,9 @@ defmodule OliWeb.Components.Delivery.Layouts do
         role="prev_page"
       >
         <div class="px-2 lg:px-6 rounded justify-end items-center gap-2 flex">
-          <.link href={resource_navigation_url(@previous_page, @section_slug, @request_path)}>
+          <.link href={
+            resource_navigation_url(@previous_page, @section_slug, @request_path, @selected_view)
+          }>
             <div class="w-[72px] h-10 opacity-30 hover:opacity-40 bg-blue-600 flex items-center justify-center cursor-pointer">
               <.left_arrow />
             </div>
@@ -339,7 +342,9 @@ defmodule OliWeb.Components.Delivery.Layouts do
           <%= @next_page["title"] %>
         </div>
         <div class="px-2 lg:px-6 py-2 rounded justify-end items-center gap-2 flex">
-          <.link href={resource_navigation_url(@next_page, @section_slug, @request_path)}>
+          <.link href={
+            resource_navigation_url(@next_page, @section_slug, @request_path, @selected_view)
+          }>
             <div class="w-[72px] h-10 opacity-90 hover:opacity-100 bg-blue-600 flex items-center justify-center cursor-pointer">
               <.right_arrow />
             </div>
@@ -368,22 +373,32 @@ defmodule OliWeb.Components.Delivery.Layouts do
   defp resource_navigation_url(
          %{"slug" => slug, "type" => "page", "id" => resource_id},
          section_slug,
-         request_path
+         request_path,
+         selected_view
        ) do
     # If the request_path is the Learn page and we navigate to a different lesson,
     # we need to update the request_path to include the new target resource.
     request_path =
       if request_path && String.contains?(request_path, "/learn") do
-        Utils.learn_live_path(section_slug, target_resource_id: resource_id)
+        Utils.learn_live_path(section_slug,
+          target_resource_id: resource_id,
+          selected_view: selected_view
+        )
       else
         request_path
       end
 
-    Utils.lesson_live_path(section_slug, slug, request_path: request_path)
+    Utils.lesson_live_path(section_slug, slug,
+      request_path: request_path,
+      selected_view: selected_view
+    )
   end
 
-  defp resource_navigation_url(%{"id" => container_id}, section_slug, _) do
-    Utils.learn_live_path(section_slug, target_resource_id: container_id)
+  defp resource_navigation_url(%{"id" => container_id}, section_slug, _, selected_view) do
+    Utils.learn_live_path(section_slug,
+      target_resource_id: container_id,
+      selected_view: selected_view
+    )
   end
 
   attr(:to, :string)

--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -323,9 +323,9 @@ defmodule OliWeb.Components.Delivery.Layouts do
           <.link href={
             resource_navigation_url(@previous_page, @section_slug, @request_path, @selected_view)
           }>
-            <div class="w-[72px] h-10 opacity-30 hover:opacity-40 bg-blue-600 flex items-center justify-center cursor-pointer">
+            <button class="w-[72px] h-10 opacity-90 hover:opacity-100 bg-blue-600 flex items-center justify-center">
               <.left_arrow />
-            </div>
+            </button>
           </.link>
         </div>
         <div class="grow shrink basis-0 dark:text-white text-xs font-normal overflow-hidden text-ellipsis">
@@ -345,9 +345,9 @@ defmodule OliWeb.Components.Delivery.Layouts do
           <.link href={
             resource_navigation_url(@next_page, @section_slug, @request_path, @selected_view)
           }>
-            <div class="w-[72px] h-10 opacity-90 hover:opacity-100 bg-blue-600 flex items-center justify-center cursor-pointer">
+            <button class="w-[72px] h-10 opacity-90 hover:opacity-100 bg-blue-600 flex items-center justify-center">
               <.right_arrow />
-            </div>
+            </button>
           </.link>
         </div>
       </div>

--- a/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
+++ b/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
@@ -68,6 +68,7 @@
       next_page={@next_page}
       section_slug={@section.slug}
       request_path={@request_path}
+      selected_view={@selected_view}
     />
   </div>
 

--- a/lib/oli_web/live/delivery/student/learn/components/view_selector.ex
+++ b/lib/oli_web/live/delivery/student/learn/components/view_selector.ex
@@ -11,7 +11,7 @@ defmodule OliWeb.Delivery.Student.Learn.Components.ViewSelector do
 
   def render(%{expanded: true} = assigns) do
     ~H"""
-    <div class="relative" phx-click-away="collapse_select" phx-target={@myself}>
+    <div id={@id} class="relative" phx-click-away="collapse_select" phx-target={@myself}>
       <button
         id="select_view_button"
         phx-click="collapse_select"
@@ -49,19 +49,21 @@ defmodule OliWeb.Delivery.Student.Learn.Components.ViewSelector do
 
   def render(%{expanded: false} = assigns) do
     ~H"""
-    <button
-      phx-click="expand_select"
-      phx-target={@myself}
-      class="h-[31px] justify-center items-center gap-2 inline-flex"
-    >
-      <div class="pl-2.5 pr-[7px] py-2.5 justify-center items-center gap-[5px] flex">
-        <div class="justify-center items-center flex"><.view_icon option={@selected_view} /></div>
-        <div class="ml-1 dark:text-white text-base font-normal font-['Open Sans']">
-          <%= to_capitalized_string(@selected_view) %> View
+    <div id={@id}>
+      <button
+        phx-click="expand_select"
+        phx-target={@myself}
+        class="h-[31px] justify-center items-center gap-2 inline-flex"
+      >
+        <div class="pl-2.5 pr-[7px] py-2.5 justify-center items-center gap-[5px] flex">
+          <div class="justify-center items-center flex"><.view_icon option={@selected_view} /></div>
+          <div class="ml-1 dark:text-white text-base font-normal font-['Open Sans']">
+            <%= to_capitalized_string(@selected_view) %> View
+          </div>
         </div>
-      </div>
-      <div class="w-8 h-[26px] px-2.5 justify-center items-center flex"><.chevron_icon /></div>
-    </button>
+        <div class="w-8 h-[26px] px-2.5 justify-center items-center flex"><.chevron_icon /></div>
+      </button>
+    </div>
     """
   end
 

--- a/lib/oli_web/live/delivery/student/learn/components/view_selector.ex
+++ b/lib/oli_web/live/delivery/student/learn/components/view_selector.ex
@@ -1,0 +1,125 @@
+defmodule OliWeb.Delivery.Student.Learn.Components.ViewSelector do
+  use OliWeb, :live_component
+
+  @view_options [:outline, :gallery]
+
+  def mount(socket) do
+    {:ok, assign(socket, view_options: @view_options, expanded: false)}
+  end
+
+  attr :selected_view, :atom
+
+  def render(%{expanded: true} = assigns) do
+    ~H"""
+    <div class="relative" phx-click-away="collapse_select" phx-target={@myself}>
+      <button
+        id="select_view_button"
+        phx-click="collapse_select"
+        phx-target={@myself}
+        class="h-[31px] justify-center items-center gap-2 inline-flex"
+      >
+        <div class="w-[114px] pl-2.5 pr-[7px] py-2.5 justify-center items-center gap-2.5 flex">
+          <div class="dark:text-white text-base font-normal font-['Open Sans']">View page as</div>
+        </div>
+        <div class="w-8 h-[26px] px-2.5 justify-center items-center flex rotate-180">
+          <.chevron_icon />
+        </div>
+      </button>
+
+      <div class="absolute w-[171px] flex flex-col -ml-2 mt-2 bg-white shadow-lg dark:bg-black rounded-[5px] divide-y divide-gray-300 dark:divide-white/20 overflow-hidden">
+        <button
+          :for={option <- @view_options}
+          phx-click={
+            JS.push("change_selected_view") |> JS.dispatch("click", to: "#select_view_button")
+          }
+          phx-value-selected_view={option}
+          class="flex gap-2 items-center h-[42px] px-[11px] w-full hover:bg-gray-300 hover:dark:bg-[#262626]"
+        >
+          <div class="w-6 flex items-center justify-center">
+            <.view_icon option={option} />
+          </div>
+          <div class="dark:text-white text-base font-normal font-['Open Sans']">
+            <%= to_capitalized_string(option) %>
+          </div>
+        </button>
+      </div>
+    </div>
+    """
+  end
+
+  def render(%{expanded: false} = assigns) do
+    ~H"""
+    <button
+      phx-click="expand_select"
+      phx-target={@myself}
+      class="h-[31px] justify-center items-center gap-2 inline-flex"
+    >
+      <div class="pl-2.5 pr-[7px] py-2.5 justify-center items-center gap-[5px] flex">
+        <div class="justify-center items-center flex"><.view_icon option={@selected_view} /></div>
+        <div class="ml-1 dark:text-white text-base font-normal font-['Open Sans']">
+          <%= to_capitalized_string(@selected_view) %> View
+        </div>
+      </div>
+      <div class="w-8 h-[26px] px-2.5 justify-center items-center flex"><.chevron_icon /></div>
+    </button>
+    """
+  end
+
+  def handle_event("expand_select", _, socket) do
+    {:noreply, assign(socket, expanded: true)}
+  end
+
+  def handle_event("collapse_select", _, socket) do
+    {:noreply, assign(socket, expanded: false)}
+  end
+
+  defp chevron_icon(assigns) do
+    ~H"""
+    <svg width="14" height="9" viewBox="0 0 14 9" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M1 1.5L7 7.5L13 1.5"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        class="stroke-black/60 dark:stroke-white"
+      />
+    </svg>
+    """
+  end
+
+  attr :option, :atom, required: true
+
+  defp view_icon(%{option: :outline} = assigns) do
+    ~H"""
+    <svg width="16" height="20" viewBox="0 0 16 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M5 5H11M5 9H11M5 13H9M1 3C1 2.46957 1.21071 1.96086 1.58579 1.58579C1.96086 1.21071 2.46957 1 3 1H13C13.5304 1 14.0391 1.21071 14.4142 1.58579C14.7893 1.96086 15 2.46957 15 3V17C15 17.5304 14.7893 18.0391 14.4142 18.4142C14.0391 18.7893 13.5304 19 13 19H3C2.46957 19 1.96086 18.7893 1.58579 18.4142C1.21071 18.0391 1 17.5304 1 17V3Z"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        class="stroke-black/60 dark:stroke-white"
+      />
+    </svg>
+    """
+  end
+
+  defp view_icon(%{option: :gallery} = assigns) do
+    ~H"""
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M15 8H15.01M3 16L8 11C8.928 10.107 10.072 10.107 11 11L16 16M14 14L15 13C15.928 12.107 17.072 12.107 18 13L21 16M3 6C3 5.20435 3.31607 4.44129 3.87868 3.87868C4.44129 3.31607 5.20435 3 6 3H18C18.7956 3 19.5587 3.31607 20.1213 3.87868C20.6839 4.44129 21 5.20435 21 6V18C21 18.7956 20.6839 19.5587 20.1213 20.1213C19.5587 20.6839 18.7956 21 18 21H6C5.20435 21 4.44129 20.6839 3.87868 20.1213C3.31607 19.5587 3 18.7956 3 18V6Z"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        class="stroke-black/60 dark:stroke-white"
+      />
+    </svg>
+    """
+  end
+
+  defp to_capitalized_string(atom) do
+    atom
+    |> Atom.to_string()
+    |> String.capitalize()
+  end
+end

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -92,42 +92,43 @@ defmodule OliWeb.Delivery.Student.LearnLive do
   end
 
   def handle_params(
-        %{"selected_view" => selected_view, "target_resource_id" => resource_id},
+        params,
         _uri,
         socket
       ) do
     full_hierarchy = get_or_compute_full_hierarchy(socket.assigns.section)
-    selected_view = String.to_existing_atom(selected_view)
 
     send(self(), :gc)
 
-    {:noreply,
-     socket
-     |> assign(selected_view: selected_view)
-     |> update(:units, fn _units -> full_hierarchy["children"] end)
-     |> maybe_enable_gallery_slider_buttons(full_hierarchy, selected_view)
-     |> scroll_to_target_resource(resource_id, full_hierarchy, selected_view)}
-  end
+    case params do
+      %{"selected_view" => selected_view, "target_resource_id" => resource_id} ->
+        selected_view = String.to_existing_atom(selected_view)
 
-  def handle_params(
-        %{"selected_view" => selected_view},
-        _uri,
-        socket
-      ) do
-    full_hierarchy = get_or_compute_full_hierarchy(socket.assigns.section)
-    selected_view = String.to_existing_atom(selected_view)
+        {:noreply,
+         socket
+         |> assign(selected_view: selected_view)
+         |> update(:units, fn _units -> full_hierarchy["children"] end)
+         |> maybe_enable_gallery_slider_buttons(full_hierarchy, selected_view)
+         |> scroll_to_target_resource(resource_id, full_hierarchy, selected_view)}
 
-    send(self(), :gc)
+      %{"selected_view" => selected_view} ->
+        selected_view = String.to_existing_atom(selected_view)
 
-    {:noreply,
-     socket
-     |> assign(selected_view: selected_view)
-     |> update(:units, fn _units -> full_hierarchy["children"] end)
-     |> maybe_enable_gallery_slider_buttons(full_hierarchy, selected_view)}
-  end
+        {:noreply,
+         socket
+         |> assign(selected_view: selected_view)
+         |> update(:units, fn _units -> full_hierarchy["children"] end)
+         |> maybe_enable_gallery_slider_buttons(full_hierarchy, selected_view)}
 
-  def handle_params(_params, _uri, socket) do
-    {:noreply, socket}
+      %{"target_resource_id" => resource_id} ->
+        {:noreply,
+         socket
+         |> maybe_enable_gallery_slider_buttons(full_hierarchy, :gallery)
+         |> scroll_to_target_resource(resource_id, full_hierarchy, :gallery)}
+
+      _ ->
+        {:noreply, socket}
+    end
   end
 
   _docp = """

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -152,7 +152,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
           end
 
         push_event(socket, "scroll-y-to-target", %{
-          id: "#{resource_type}_#{resource_id}" |> IO.inspect(label: "target scroll id"),
+          id: "#{resource_type}_#{resource_id}",
           offset: 10,
           pulse: true,
           pulse_delay: 500
@@ -1144,7 +1144,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
     ~H"""
     <div id={"top_level_page_#{@row["resource_id"]}"}>
       <div class="md:p-[25px] md:pl-[125px] md:pr-[175px]" role={"row_#{@row["numbering"]["index"]}"}>
-        <div class="flex flex-col md:flex-row md:gap-[30px]">
+        <div role="header" class="flex flex-col md:flex-row md:gap-[30px]">
           <div class="dark:text-white text-xl font-bold font-['Open Sans']">
             <%= @row["title"] %>
           </div>
@@ -1244,7 +1244,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
         </div>
 
         <div
-          id={"index_item_#{@row["numbering"]["index"]}_#{@row["id"]}"}
+          id={"index_item_#{@row["numbering"]["index"]}_#{@row["resource_id"]}"}
           class="flex shrink items-center gap-3 w-full dark:text-white"
         >
           <div class={[
@@ -1252,13 +1252,16 @@ defmodule OliWeb.Delivery.Student.LearnLive do
             left_indentation(@row["numbering"]["level"], :outline)
           ]}>
             <div class="flex">
-              <span class={
-                [
-                  "text-left dark:text-white opacity-90 text-base font-['Open Sans']",
-                  # Opacity is set if the item is visited, but not necessarily completed
-                  if(@row["visited"], do: "opacity-60")
-                ]
-              }>
+              <span
+                role="page title"
+                class={
+                  [
+                    "text-left dark:text-white opacity-90 text-base font-['Open Sans']",
+                    # Opacity is set if the item is visited, but not necessarily completed
+                    if(@row["visited"], do: "opacity-60")
+                  ]
+                }
+              >
                 <%= "#{@row["title"]}" %>
               </span>
 

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -1008,16 +1008,12 @@ defmodule OliWeb.Delivery.Student.LearnLive do
               class="text-sm font-normal font-['Open Sans'] leading-[30px] max-w-[760px] overflow-hidden dark:text-white"
               style="display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical;"
             >
-              <%= Phoenix.HTML.raw(
-                Oli.Rendering.Content.render(
-                  %Oli.Rendering.Context{},
-                  Map.get(@selected_module_per_unit_resource_id, @unit["resource_id"])[
-                    "intro_content"
-                  ][
-                    "children"
-                  ],
-                  Oli.Rendering.Content.Html
-                )
+              <%= render_intro_content(
+                Map.get(@selected_module_per_unit_resource_id, @unit["resource_id"])[
+                  "intro_content"
+                ][
+                  "children"
+                ]
               ) %>
             </span>
             <div
@@ -1166,6 +1162,16 @@ defmodule OliWeb.Delivery.Student.LearnLive do
     """
   end
 
+  defp render_intro_content(intro_content) do
+    Phoenix.HTML.raw(
+      Oli.Rendering.Content.render(
+        %Oli.Rendering.Context{},
+        intro_content,
+        Oli.Rendering.Content.Html
+      )
+    )
+  end
+
   def outline_row(%{type: type} = assigns) when type in [:module, :section] do
     ~H"""
     <div id={"#{@type}_#{@row["resource_id"]}"}>
@@ -1182,7 +1188,13 @@ defmodule OliWeb.Delivery.Student.LearnLive do
           "text-white text-base font-bold font-['Open Sans']",
           left_indentation(@row["numbering"]["level"], :outline)
         ]}>
-          <%= @row["title"] %>
+          <span><%= @row["title"] %></span>
+          <div
+            :if={@type == :module and @row["intro_content"]["children"] not in ["", nil]}
+            class="mt-3 text-white text-base font-normal font-['Open Sans']"
+          >
+            <%= render_intro_content(@row["intro_content"]["children"]) %>
+          </div>
         </div>
       </div>
       <div class="flex flex-col">

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -1097,6 +1097,29 @@ defmodule OliWeb.Delivery.Student.LearnLive do
     """
   end
 
+  def outline_row(%{type: :top_level_page} = assigns) do
+    ~H"""
+    <div id={"top_level_page_#{@row["resource_id"]}"}>
+      <div class="md:p-[25px] md:pl-[125px] md:pr-[175px]" role={"row_#{@row["numbering"]["index"]}"}>
+        <div class="flex flex-col md:flex-row md:gap-[30px]">
+          <div class="text-white text-xl font-bold font-['Open Sans']">
+            <%= @row["title"] %>
+          </div>
+        </div>
+        <div class="flex flex-col mt-6">
+          <.outline_row
+            row={@row}
+            type={:page}
+            student_progress_per_resource_id={@student_progress_per_resource_id}
+            viewed_intro_video_resource_ids={@viewed_intro_video_resource_ids}
+            student_id={@student_id}
+          />
+        </div>
+      </div>
+    </div>
+    """
+  end
+
   def outline_row(%{type: type} = assigns) when type in [:module, :section] do
     ~H"""
     <div id={"#{@type}_#{@row["resource_id"]}"}>
@@ -2577,6 +2600,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
       {"container", 1} -> :unit
       {"container", 2} -> :module
       {"container", _} -> :section
+      {"page", 1} -> :top_level_page
       {"page", _} -> :page
     end
   end

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -1162,16 +1162,6 @@ defmodule OliWeb.Delivery.Student.LearnLive do
     """
   end
 
-  defp render_intro_content(intro_content) do
-    Phoenix.HTML.raw(
-      Oli.Rendering.Content.render(
-        %Oli.Rendering.Context{},
-        intro_content,
-        Oli.Rendering.Content.Html
-      )
-    )
-  end
-
   def outline_row(%{type: type} = assigns) when type in [:module, :section] do
     ~H"""
     <div id={"#{@type}_#{@row["resource_id"]}"}>
@@ -1198,6 +1188,14 @@ defmodule OliWeb.Delivery.Student.LearnLive do
         </div>
       </div>
       <div class="flex flex-col">
+        <.intro_video_item
+          :if={@type == :module and module_has_intro_video(@row)}
+          duration_minutes={@row["duration_minutes"]}
+          module_resource_id={@row["resource_id"]}
+          video_url={@row["intro_video"]}
+          intro_video_viewed={@row["resource_id"] in @viewed_intro_video_resource_ids}
+          view={:outline}
+        />
         <.outline_row
           :for={row <- @row["children"]}
           row={row}
@@ -1703,6 +1701,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
   attr :module_resource_id, :integer
   attr :intro_video_viewed, :boolean
   attr :video_url, :string, default: nil
+  attr :view, :atom, default: @default_selected_view
 
   def intro_video_item(assigns) do
     ~H"""
@@ -1736,7 +1735,10 @@ defmodule OliWeb.Delivery.Student.LearnLive do
         </svg>
       </div>
       <div class="flex shrink items-center gap-3 w-full dark:text-white">
-        <div class="flex flex-col gap-1 w-full ml-0">
+        <div class={[
+          "flex flex-col gap-1 w-full",
+          if(@view == :outline, do: "ml-[60px]", else: "ml-10")
+        ]}>
           <div class="flex">
             <span class={
               [
@@ -2152,6 +2154,16 @@ defmodule OliWeb.Delivery.Student.LearnLive do
       <path d="M12 7v5l3 3" />
     </svg>
     """
+  end
+
+  defp render_intro_content(intro_content) do
+    Phoenix.HTML.raw(
+      Oli.Rendering.Content.render(
+        %Oli.Rendering.Context{},
+        intro_content,
+        Oli.Rendering.Content.Html
+      )
+    )
   end
 
   defp get_module(hierarchy, unit_resource_id, module_resource_id) do

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -1121,7 +1121,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
     <div id={"unit_#{@row["resource_id"]}"}>
       <div class="md:p-[25px] md:pl-[125px] md:pr-[175px]" role={"row_#{@row["numbering"]["index"]}"}>
         <div class="flex flex-col md:flex-row md:gap-[30px]">
-          <div class="text-white text-xl font-bold font-['Open Sans']">
+          <div class="dark:text-white text-xl font-bold font-['Open Sans']">
             <%= "Unit #{@row["numbering"]["index"]}: #{@row["title"]}" %>
           </div>
         </div>
@@ -1145,7 +1145,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
     <div id={"top_level_page_#{@row["resource_id"]}"}>
       <div class="md:p-[25px] md:pl-[125px] md:pr-[175px]" role={"row_#{@row["numbering"]["index"]}"}>
         <div class="flex flex-col md:flex-row md:gap-[30px]">
-          <div class="text-white text-xl font-bold font-['Open Sans']">
+          <div class="dark:text-white text-xl font-bold font-['Open Sans']">
             <%= @row["title"] %>
           </div>
         </div>
@@ -1170,19 +1170,19 @@ defmodule OliWeb.Delivery.Student.LearnLive do
         <div class="justify-start items-start gap-5 flex">
           <.no_icon />
           <div class="w-[26px] justify-start items-center">
-            <div class="grow shrink basis-0 opacity-60 text-white text-[13px] font-semibold font-['Open Sans'] capitalize">
+            <div class="grow shrink basis-0 opacity-60 dark:text-white text-[13px] font-semibold font-['Open Sans'] capitalize">
               <.numbering_index type={Atom.to_string(@type)} />
             </div>
           </div>
         </div>
         <div class={[
-          "text-white text-base font-bold font-['Open Sans']",
+          "dark:text-white text-base font-bold font-['Open Sans']",
           left_indentation(@row["numbering"]["level"], :outline)
         ]}>
           <span><%= @row["title"] %></span>
           <div
             :if={@type == :module and @row["intro_content"]["children"] not in ["", nil]}
-            class="mt-3 text-white text-base font-normal font-['Open Sans']"
+            class="mt-3 dark:text-white text-base font-normal font-['Open Sans']"
           >
             <%= render_intro_content(@row["intro_content"]["children"]) %>
           </div>
@@ -1237,7 +1237,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
             progress={@row["progress"]}
           />
           <div class="w-[26px] justify-start items-center">
-            <div class="grow shrink basis-0 opacity-60 text-white text-[13px] font-semibold font-['Open Sans'] capitalize">
+            <div class="grow shrink basis-0 opacity-60 dark:text-white text-[13px] font-semibold font-['Open Sans'] capitalize">
               <.numbering_index type={Atom.to_string(@type)} index={@row["numbering"]["index"]} />
             </div>
           </div>

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -525,6 +525,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
   def navigate_to_resource(values, socket) do
     section_slug = socket.assigns.section.slug
     resource_id = values["resource_id"] || values["module_resource_id"]
+    selected_view = values["view"] || :gallery
 
     {:noreply,
      push_redirect(socket,
@@ -532,7 +533,8 @@ defmodule OliWeb.Delivery.Student.LearnLive do
          resource_url(
            values["slug"],
            section_slug,
-           resource_id
+           resource_id,
+           selected_view
          )
      )}
   end
@@ -2107,11 +2109,16 @@ defmodule OliWeb.Delivery.Student.LearnLive do
     end)
   end
 
-  defp resource_url(resource_slug, section_slug, resource_id) do
+  defp resource_url(resource_slug, section_slug, resource_id, selected_view) do
     Utils.lesson_live_path(
       section_slug,
       resource_slug,
-      request_path: Utils.learn_live_path(section_slug, target_resource_id: resource_id)
+      request_path:
+        Utils.learn_live_path(section_slug,
+          target_resource_id: resource_id,
+          selected_view: selected_view
+        ),
+      selected_view: selected_view
     )
   end
 

--- a/lib/oli_web/live_session_plugs/redirect_adaptive.ex
+++ b/lib/oli_web/live_session_plugs/redirect_adaptive.ex
@@ -24,7 +24,8 @@ defmodule OliWeb.LiveSessionPlugs.RedirectAdaptiveChromeless do
              section_slug,
              revision_slug,
              attempt_guid,
-             params["request_path"]
+             request_path: params["request_path"],
+             selected_view: params["selected_view"]
            )
        )}
     else
@@ -41,7 +42,11 @@ defmodule OliWeb.LiveSessionPlugs.RedirectAdaptiveChromeless do
     if is_adaptive_chromeless_view?(revision_slug) do
       {:halt,
        redirect(socket,
-         to: adaptive_chromeless_url(section_slug, revision_slug, params["request_path"])
+         to:
+           adaptive_chromeless_url(section_slug, revision_slug,
+             request_path: params["request_path"],
+             selected_view: params["selected_view"]
+           )
        )}
     else
       {:cont, socket}
@@ -52,19 +57,12 @@ defmodule OliWeb.LiveSessionPlugs.RedirectAdaptiveChromeless do
     {:cont, socket}
   end
 
-  def adaptive_chromeless_revision_url(section_slug, revision_slug, attempt_guid, nil),
-    do: ~p"/sections/#{section_slug}/page/#{revision_slug}/attempt/#{attempt_guid}/review"
-
-  def adaptive_chromeless_revision_url(section_slug, revision_slug, attempt_guid, request_path),
+  def adaptive_chromeless_revision_url(section_slug, revision_slug, attempt_guid, params),
     do:
-      ~p"/sections/#{section_slug}/page/#{revision_slug}/attempt/#{attempt_guid}/review?#{%{request_path: request_path}}"
+      ~p"/sections/#{section_slug}/page/#{revision_slug}/attempt/#{attempt_guid}/review?#{params}"
 
-  def adaptive_chromeless_url(section_slug, revision_slug, nil),
-    do: ~p"/sections/#{section_slug}/adaptive_lesson/#{revision_slug}"
-
-  def adaptive_chromeless_url(section_slug, revision_slug, request_path),
-    do:
-      ~p"/sections/#{section_slug}/adaptive_lesson/#{revision_slug}?#{%{request_path: request_path}}"
+  def adaptive_chromeless_url(section_slug, revision_slug, params),
+    do: ~p"/sections/#{section_slug}/adaptive_lesson/#{revision_slug}?#{params}"
 
   defp is_adaptive_chromeless_view?(revision_slug) do
     Repo.exists?(

--- a/lib/oli_web/live_session_plugs/set_request_path.ex
+++ b/lib/oli_web/live_session_plugs/set_request_path.ex
@@ -11,8 +11,15 @@ defmodule OliWeb.LiveSessionPlugs.SetRequestPath do
 
   def on_mount(:default, params, _session, socket) do
     section_slug = socket.assigns.section.slug
-    request_path = Map.get(params, "request_path", Utils.learn_live_path(section_slug))
+    selected_view = Map.get(params, "selected_view", "gallery")
 
-    {:cont, assign(socket, request_path: request_path)}
+    request_path =
+      Map.get(
+        params,
+        "request_path",
+        Utils.learn_live_path(section_slug, selected_view: selected_view)
+      )
+
+    {:cont, assign(socket, request_path: request_path, selected_view: selected_view)}
   end
 end

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -21,6 +21,8 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
     AttemptGroup
   }
 
+  @default_selected_view :gallery
+
   defp set_progress(section_id, resource_id, user_id, progress, revision) do
     {:ok, resource_access} =
       Core.track_access(resource_id, section_id, user_id)
@@ -1399,11 +1401,18 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       |> element(~s{button[phx-click="navigate_to_resource"][phx-value-slug="#{page_1.slug}"]})
       |> render_click()
 
-      request_path = Utils.learn_live_path(section.slug, target_resource_id: page_1.resource_id)
+      request_path =
+        Utils.learn_live_path(section.slug,
+          target_resource_id: page_1.resource_id,
+          selected_view: @default_selected_view
+        )
 
       assert_redirect(
         view,
-        Utils.lesson_live_path(section.slug, page_1.slug, request_path: request_path)
+        Utils.lesson_live_path(section.slug, page_1.slug,
+          request_path: request_path,
+          selected_view: @default_selected_view
+        )
       )
     end
 
@@ -1488,11 +1497,18 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       |> element(~s{div[role="unit_3"] div[role="card_7"]})
       |> render_click()
 
-      request_path = Utils.learn_live_path(section.slug, target_resource_id: page_7.resource_id)
+      request_path =
+        Utils.learn_live_path(section.slug,
+          target_resource_id: page_7.resource_id,
+          selected_view: @default_selected_view
+        )
 
       assert_redirect(
         view,
-        Utils.lesson_live_path(section.slug, page_7.slug, request_path: request_path)
+        Utils.lesson_live_path(section.slug, page_7.slug,
+          request_path: request_path,
+          selected_view: @default_selected_view
+        )
       )
     end
 
@@ -1518,11 +1534,18 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       |> element(~s{div[role="unit_3"] div[role="card_8"]})
       |> render_click()
 
-      request_path = Utils.learn_live_path(section.slug, target_resource_id: page_8.resource_id)
+      request_path =
+        Utils.learn_live_path(section.slug,
+          target_resource_id: page_8.resource_id,
+          selected_view: @default_selected_view
+        )
 
       assert_redirect(
         view,
-        Utils.lesson_live_path(section.slug, page_8.slug, request_path: request_path)
+        Utils.lesson_live_path(section.slug, page_8.slug,
+          request_path: request_path,
+          selected_view: @default_selected_view
+        )
       )
     end
 

--- a/test/oli_web/live/delivery/student/lesson_live_test.exs
+++ b/test/oli_web/live/delivery/student/lesson_live_test.exs
@@ -12,6 +12,8 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
   alias Oli.Resources.ResourceType
   alias OliWeb.Delivery.Student.Utils
 
+  @default_selected_view :gallery
+
   defp live_view_adaptive_lesson_live_route(section_slug, revision_slug, request_path \\ nil)
 
   defp live_view_adaptive_lesson_live_route(section_slug, revision_slug, nil) do
@@ -357,10 +359,17 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
       Sections.mark_section_visited_for_student(section, user)
 
       {:error, {:redirect, %{to: redirect_path}}} =
-        live(conn, Utils.lesson_live_path(section.slug, exploration_1.slug))
+        live(
+          conn,
+          Utils.lesson_live_path(section.slug, exploration_1.slug,
+            request_path: "some_request_path",
+            selected_view: @default_selected_view
+          )
+        )
 
       assert redirect_path ==
-               live_view_adaptive_lesson_live_route(section.slug, exploration_1.slug)
+               live_view_adaptive_lesson_live_route(section.slug, exploration_1.slug) <>
+                 "?request_path=some_request_path&selected_view=gallery"
     end
 
     test "can access when enrolled to course", %{
@@ -766,11 +775,18 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
       |> render_click
 
       # It redirects to the next page, but still referencing the targeted Learn view in the URL with the next page resource
-      request_path = Utils.learn_live_path(section.slug, target_resource_id: page_2.resource_id)
+      request_path =
+        Utils.learn_live_path(section.slug,
+          target_resource_id: page_2.resource_id,
+          selected_view: @default_selected_view
+        )
 
       assert_redirected(
         view,
-        Utils.lesson_live_path(section.slug, page_2.slug, request_path: request_path)
+        Utils.lesson_live_path(section.slug, page_2.slug,
+          request_path: request_path,
+          selected_view: @default_selected_view
+        )
       )
     end
 
@@ -788,7 +804,13 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
       request_path = ~p"/sections/#{section.slug}/assignments"
 
       {:ok, view, _html} =
-        live(conn, Utils.lesson_live_path(section.slug, page_1.slug, request_path: request_path))
+        live(
+          conn,
+          Utils.lesson_live_path(section.slug, page_1.slug,
+            request_path: request_path,
+            selected_view: @default_selected_view
+          )
+        )
 
       view
       |> element(~s{div[role="next_page"] a})
@@ -796,7 +818,10 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
 
       assert_redirected(
         view,
-        Utils.lesson_live_path(section.slug, page_2.slug, request_path: request_path)
+        Utils.lesson_live_path(section.slug, page_2.slug,
+          request_path: request_path,
+          selected_view: @default_selected_view
+        )
       )
     end
 
@@ -813,7 +838,11 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
       Sections.mark_section_visited_for_student(section, user)
 
       # next page is a container
-      {:ok, view, _html} = live(conn, Utils.lesson_live_path(section.slug, page_2.slug))
+      {:ok, view, _html} =
+        live(
+          conn,
+          Utils.lesson_live_path(section.slug, page_2.slug, selected_view: @default_selected_view)
+        )
 
       view
       |> element(~s{div[role="next_page"] a})
@@ -821,7 +850,10 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
 
       assert_redirected(
         view,
-        Utils.learn_live_path(section.slug, target_resource_id: module_2.resource_id)
+        Utils.learn_live_path(section.slug,
+          target_resource_id: module_2.resource_id,
+          selected_view: @default_selected_view
+        )
       )
 
       # previous page is a container
@@ -833,7 +865,10 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
 
       assert_redirected(
         view,
-        Utils.learn_live_path(section.slug, target_resource_id: module_2.resource_id)
+        Utils.learn_live_path(section.slug,
+          target_resource_id: module_2.resource_id,
+          selected_view: @default_selected_view
+        )
       )
     end
 
@@ -846,7 +881,11 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
       Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
       Sections.mark_section_visited_for_student(section, user)
 
-      {:ok, view, _html} = live(conn, Utils.lesson_live_path(section.slug, page_1.slug))
+      {:ok, view, _html} =
+        live(
+          conn,
+          Utils.lesson_live_path(section.slug, page_1.slug, selected_view: @default_selected_view)
+        )
 
       view
       |> element(~s{div[role="back_link"] a})
@@ -854,7 +893,7 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
 
       assert_redirected(
         view,
-        Utils.learn_live_path(section.slug)
+        Utils.learn_live_path(section.slug, selected_view: @default_selected_view)
       )
     end
 
@@ -938,7 +977,7 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
 
       assert_redirected(
         view,
-        Utils.learn_live_path(section.slug)
+        Utils.learn_live_path(section.slug, selected_view: @default_selected_view)
       )
     end
   end

--- a/test/oli_web/live/delivery/student/review_live_test.exs
+++ b/test/oli_web/live/delivery/student/review_live_test.exs
@@ -11,6 +11,8 @@ defmodule OliWeb.Delivery.Student.ReviewLiveTest do
   alias Oli.Resources.ResourceType
   alias OliWeb.Delivery.Student.Utils
 
+  @default_selected_view :gallery
+
   defp create_attempt(student, section, revision) do
     resource_access =
       insert(:resource_access, %{
@@ -421,11 +423,18 @@ defmodule OliWeb.Delivery.Student.ReviewLiveTest do
       |> render_click
 
       # It redirects to the next page, but still referencing the targeted Learn view in the URL with the next page resource
-      request_path = Utils.learn_live_path(section.slug, target_resource_id: page_2.resource_id)
+      request_path =
+        Utils.learn_live_path(section.slug,
+          target_resource_id: page_2.resource_id,
+          selected_view: @default_selected_view
+        )
 
       assert_redirected(
         view,
-        Utils.lesson_live_path(section.slug, page_2.slug, request_path: request_path)
+        Utils.lesson_live_path(section.slug, page_2.slug,
+          request_path: request_path,
+          selected_view: @default_selected_view
+        )
       )
     end
 
@@ -447,7 +456,8 @@ defmodule OliWeb.Delivery.Student.ReviewLiveTest do
         live(
           conn,
           Utils.review_live_path(section.slug, page_1.slug, attempt.attempt_guid,
-            request_path: request_path
+            request_path: request_path,
+            selected_view: @default_selected_view
           )
         )
 
@@ -457,7 +467,10 @@ defmodule OliWeb.Delivery.Student.ReviewLiveTest do
 
       assert_redirected(
         view,
-        Utils.lesson_live_path(section.slug, page_2.slug, request_path: request_path)
+        Utils.lesson_live_path(section.slug, page_2.slug,
+          request_path: request_path,
+          selected_view: @default_selected_view
+        )
       )
     end
 
@@ -476,7 +489,12 @@ defmodule OliWeb.Delivery.Student.ReviewLiveTest do
 
       # next page is a container
       {:ok, view, _html} =
-        live(conn, Utils.review_live_path(section.slug, page_2.slug, attempt.attempt_guid))
+        live(
+          conn,
+          Utils.review_live_path(section.slug, page_2.slug, attempt.attempt_guid,
+            selected_view: @default_selected_view
+          )
+        )
 
       view
       |> element(~s{div[role="next_page"] a})
@@ -484,11 +502,18 @@ defmodule OliWeb.Delivery.Student.ReviewLiveTest do
 
       assert_redirected(
         view,
-        Utils.learn_live_path(section.slug, target_resource_id: module_2.resource_id)
+        Utils.learn_live_path(section.slug,
+          target_resource_id: module_2.resource_id,
+          selected_view: @default_selected_view
+        )
       )
 
       # previous page is a container
-      {:ok, view, _html} = live(conn, Utils.lesson_live_path(section.slug, page_3.slug))
+      {:ok, view, _html} =
+        live(
+          conn,
+          Utils.lesson_live_path(section.slug, page_3.slug, selected_view: @default_selected_view)
+        )
 
       view
       |> element(~s{div[role="prev_page"] a})
@@ -496,7 +521,10 @@ defmodule OliWeb.Delivery.Student.ReviewLiveTest do
 
       assert_redirected(
         view,
-        Utils.learn_live_path(section.slug, target_resource_id: module_2.resource_id)
+        Utils.learn_live_path(section.slug,
+          target_resource_id: module_2.resource_id,
+          selected_view: @default_selected_view
+        )
       )
     end
 

--- a/test/oli_web/live_session_plugs/redirect_adaptive_test.exs
+++ b/test/oli_web/live_session_plugs/redirect_adaptive_test.exs
@@ -42,7 +42,9 @@ defmodule OliWeb.LiveSessionPlugs.RedirectAdaptiveChromelessTest do
         %{
           "section_slug" => "some-section-slug",
           "revision_slug" => adaptive_chromeless_page_revision.slug,
-          "attempt_guid" => "some-attempt-guid"
+          "attempt_guid" => "some-attempt-guid",
+          "request_path" => "some-request-path",
+          "selected_view" => "gallery"
         },
         %{},
         %Phoenix.LiveView.Socket{}
@@ -52,7 +54,7 @@ defmodule OliWeb.LiveSessionPlugs.RedirectAdaptiveChromelessTest do
              {:redirect,
               %{
                 to:
-                  "/sections/some-section-slug/page/#{adaptive_chromeless_page_revision.slug}/attempt/some-attempt-guid/review"
+                  "/sections/some-section-slug/page/#{adaptive_chromeless_page_revision.slug}/attempt/some-attempt-guid/review?request_path=some-request-path&selected_view=gallery"
               }}
   end
 
@@ -64,7 +66,9 @@ defmodule OliWeb.LiveSessionPlugs.RedirectAdaptiveChromelessTest do
         :default,
         %{
           "section_slug" => "some-section-slug",
-          "revision_slug" => adaptive_chromeless_page_revision.slug
+          "revision_slug" => adaptive_chromeless_page_revision.slug,
+          "request_path" => "some-request-path",
+          "selected_view" => "gallery"
         },
         %{},
         %Phoenix.LiveView.Socket{}
@@ -74,7 +78,7 @@ defmodule OliWeb.LiveSessionPlugs.RedirectAdaptiveChromelessTest do
              {:redirect,
               %{
                 to:
-                  "/sections/some-section-slug/adaptive_lesson/#{adaptive_chromeless_page_revision.slug}"
+                  "/sections/some-section-slug/adaptive_lesson/#{adaptive_chromeless_page_revision.slug}?request_path=some-request-path&selected_view=gallery"
               }}
   end
 


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/NG23-141) to the ticket

#### The new view was implemented (being the Gallery mode the default view)
https://github.com/Simon-Initiative/oli-torus/assets/74839302/33a2278b-d19f-4e32-ad5d-69b3cb32d4c4


#### The selected view is "remembered" while navigating to a page and going back to the learn page
*Outline mode*

https://github.com/Simon-Initiative/oli-torus/assets/74839302/ca70a8b4-d188-4f9b-ad72-1696b98daf25

*Gallery mode*

https://github.com/Simon-Initiative/oli-torus/assets/74839302/765ffbae-b40b-434a-aafe-77a953e4adf7


#### The auto-scroll-to-resource behavior was implemented (to match the same behavior of the Gallery View)
https://github.com/Simon-Initiative/oli-torus/assets/74839302/f8765973-817e-42f5-b1cd-551a6fe97307

#### The previous navigation button was fixed to match the style of the next navigation button
This is a thing that was mentioned in the last Demo.

*Before*
![image](https://github.com/Simon-Initiative/oli-torus/assets/74839302/746858e0-56a1-42cd-9355-852f1aa223d1)


*After*
![image](https://github.com/Simon-Initiative/oli-torus/assets/74839302/e9bad221-19ab-47b6-a49a-f500bc33df0a)



#### No flaky tests were introduced (used the same script as in [this PR](https://github.com/Simon-Initiative/oli-torus/pull/3804))
![image](https://github.com/Simon-Initiative/oli-torus/assets/74839302/87221155-e4cb-434e-9178-1d2d97cff431)

