### PR TITLE
[FEATURE] [MER-3096] User enables AB testing with Upgrade

### DIFF
--- a/lib/oli/authoring/editing/resource_editor.ex
+++ b/lib/oli/authoring/editing/resource_editor.ex
@@ -7,31 +7,9 @@ defmodule Oli.Authoring.Editing.ResourceEditor do
   import Ecto.Query, warn: false
   import Oli.Authoring.Editing.Utils
 
-  alias Oli.Resources.ResourceType
-  alias Oli.Authoring.Course.Project
-  alias Oli.Authoring.Course.ProjectResource
-  alias Oli.Resources.Revision
   alias Oli.Authoring.Course
   alias Oli.Publishing.AuthoringResolver
-
-  @alternatives_type_id ResourceType.id_for_alternatives()
-  @experiment_id "upgrade_decision_point"
-
-  def get_latest_experiment(project_slug) do
-    from(pr in ProjectResource,
-      join: p in Project,
-      on: p.id == pr.project_id,
-      join: r in Revision,
-      on: r.resource_id == pr.resource_id,
-      where: p.slug == ^project_slug,
-      where: r.resource_type_id == @alternatives_type_id,
-      where: fragment("?->>'strategy' = ?", r.content, @experiment_id),
-      select: r,
-      limit: 1,
-      order_by: [desc: r.inserted_at]
-    )
-    |> Oli.Repo.one()
-  end
+  alias Oli.Resources.Revision
 
   @doc """
   Retrieves a list of all (non-deleted) resources of the specified type for a given project.

--- a/lib/oli/authoring/editing/resource_editor.ex
+++ b/lib/oli/authoring/editing/resource_editor.ex
@@ -17,7 +17,7 @@ defmodule Oli.Authoring.Editing.ResourceEditor do
   @alternatives_type_id ResourceType.id_for_alternatives()
   @experiment_id "upgrade_decision_point"
 
-  def get_experiment(project_slug) do
+  def get_latest_experiment(project_slug) do
     from(pr in ProjectResource,
       join: p in Project,
       on: p.id == pr.project_id,
@@ -26,7 +26,9 @@ defmodule Oli.Authoring.Editing.ResourceEditor do
       where: p.slug == ^project_slug,
       where: r.resource_type_id == @alternatives_type_id,
       where: fragment("?->>'strategy' = ?", r.content, @experiment_id),
-      select: r
+      select: r,
+      limit: 1,
+      order_by: [desc: r.inserted_at]
     )
     |> Oli.Repo.one()
   end

--- a/lib/oli/authoring/experiments.ex
+++ b/lib/oli/authoring/experiments.ex
@@ -1,0 +1,38 @@
+defmodule Oli.Authoring.Experiments do
+  @moduledoc """
+  This module provides a context around experiments.
+  """
+
+  import Ecto.Query, warn: false
+  import Oli.Publishing.AuthoringResolver, only: [project_working_publication: 1]
+
+  alias Oli.Publishing.PublishedResource
+  alias Oli.Repo
+  alias Oli.Resources.Revision
+  alias Oli.Resources.ResourceType
+
+  @alternatives_type_id ResourceType.id_for_alternatives()
+  @experiment_id "upgrade_decision_point"
+
+  @doc """
+  Retrieve the revision associated with the experiment for a given project.
+
+  Returns:
+
+  .`%Revision{}` when the resource is retrieved
+  . `nil` when the resource is not found
+  . Raises if more than one resource.
+  """
+  @spec get_latest_experiment(String.t()) :: {:ok, %Revision{}} | nil | term()
+  def get_latest_experiment(project_slug) do
+    from(pr in PublishedResource,
+      join: revision in Revision,
+      on: revision.id == pr.revision_id,
+      where: pr.publication_id in subquery(project_working_publication(project_slug)),
+      where: fragment("?->>'strategy' = ?", revision.content, @experiment_id),
+      where: revision.resource_type_id == @alternatives_type_id,
+      select: revision
+    )
+    |> Repo.one()
+  end
+end

--- a/lib/oli/publishing/authoring_resolver.ex
+++ b/lib/oli/publishing/authoring_resolver.ex
@@ -170,7 +170,7 @@ defmodule Oli.Publishing.AuthoringResolver do
     |> emit([:oli, :resolvers, :authoring], :duration)
   end
 
-  defp project_working_publication(project_slug) do
+  def project_working_publication(project_slug) do
     from(p in Publication,
       join: c in Project,
       on: p.project_id == c.id,

--- a/lib/oli_web/live/experiments/experiments_live.ex
+++ b/lib/oli_web/live/experiments/experiments_live.ex
@@ -8,8 +8,9 @@ defmodule OliWeb.Experiments.ExperimentsView do
   import OliWeb.ErrorHelpers
   import OliWeb.Resources.AlternativesEditor.GroupOption
 
-  alias Oli.Resources.ResourceType
   alias Oli.Authoring.Editing.ResourceEditor
+  alias Oli.Authoring.Experiments
+  alias Oli.Resources.ResourceType
   alias Oli.Resources.Revision
   alias OliWeb.Common.Modal.DeleteModal
   alias OliWeb.Common.Modal.FormModal
@@ -21,7 +22,7 @@ defmodule OliWeb.Experiments.ExperimentsView do
   @alternatives_type_id ResourceType.id_for_alternatives()
 
   def mount(_params, _session, socket) do
-    experiment = ResourceEditor.get_latest_experiment(socket.assigns.project.slug)
+    experiment = Experiments.get_latest_experiment(socket.assigns.project.slug)
 
     socket =
       socket

--- a/lib/oli_web/live/experiments/experiments_live.ex
+++ b/lib/oli_web/live/experiments/experiments_live.ex
@@ -48,7 +48,7 @@ defmodule OliWeb.Experiments.ExperimentsView do
         type="checkbox"
         class="form-check-input"
         name="experiments"
-        value={nil}
+        value={@is_upgrade_enabled}
         label="Enable A/B testing with UpGrade"
         phx-click="enable_upgrade"
         checked={@is_upgrade_enabled}
@@ -65,7 +65,7 @@ defmodule OliWeb.Experiments.ExperimentsView do
     """
   end
 
-  def handle_event("enable_upgrade", params, socket) do
+  def handle_event("enable_upgrade", _params, socket) do
     socket =
       case socket.assigns.experiment do
         nil ->
@@ -75,11 +75,7 @@ defmodule OliWeb.Experiments.ExperimentsView do
           assign(socket, experiment: experiment, is_upgrade_enabled: true)
 
         %Revision{} ->
-          if Map.get(params, "value") do
-            assign(socket, :is_upgrade_enabled, true)
-          else
-            assign(socket, :is_upgrade_enabled, false)
-          end
+          assign(socket, :is_upgrade_enabled, !socket.assigns.is_upgrade_enabled)
       end
 
     {:noreply, socket}

--- a/lib/oli_web/live/experiments/experiments_live.ex
+++ b/lib/oli_web/live/experiments/experiments_live.ex
@@ -23,9 +23,11 @@ defmodule OliWeb.Experiments.ExperimentsView do
   def mount(_params, _session, socket) do
     experiment = ResourceEditor.get_latest_experiment(socket.assigns.project.slug)
 
-    socket = assign(socket, is_upgrade_enabled: false)
-    socket = assign(socket, title: @title)
-    socket = assign(socket, experiment: experiment)
+    socket =
+      socket
+      |> assign(is_upgrade_enabled: false)
+      |> assign(title: @title)
+      |> assign(experiment: experiment)
 
     {:ok, socket}
   end

--- a/lib/oli_web/live/experiments/experiments_live.ex
+++ b/lib/oli_web/live/experiments/experiments_live.ex
@@ -1,10 +1,24 @@
 defmodule OliWeb.Experiments.ExperimentsView do
   use Phoenix.LiveView, layout: {OliWeb.LayoutView, :live}
 
+  import Oli.Utils, only: [uuid: 0]
   import OliWeb.Components.Common
 
+  alias Oli.Resources.ResourceType
+  alias Oli.Authoring.Editing.ResourceEditor
+  alias Oli.Resources.Revision
+
+  @title "Experiments"
+  @alternatives_type_id ResourceType.id_for_alternatives()
+
   def mount(_params, _session, socket) do
-    {:ok, assign(socket, title: "Experiments")}
+    experiment = ResourceEditor.get_experiment(socket.assigns.project.slug)
+
+    socket = assign(socket, is_upgrade_enabled: false)
+    socket = assign(socket, title: @title)
+    socket = assign(socket, experiment: experiment)
+
+    {:ok, socket}
   end
 
   def render(assigns) do
@@ -26,8 +40,52 @@ defmodule OliWeb.Experiments.ExperimentsView do
         name="experiments"
         value={nil}
         label="Enable A/B testing with UpGrade"
+        phx-click="enable_upgrade"
+        checked={@is_upgrade_enabled}
       />
+
+      <%= if @experiment do %>
+        <OliWeb.Resources.AlternativesEditor.group
+          group={@experiment}
+          editing_enabled={@is_upgrade_enabled}
+          source={:experiments}
+        />
+      <% end %>
     </div>
     """
+  end
+
+  def handle_event("enable_upgrade", params, socket) do
+    socket =
+      case socket.assigns.experiment do
+        nil ->
+          {:ok, experiment} =
+            create_experiment(socket.assigns.project, socket.assigns.current_author)
+
+          assign(socket, experiment: experiment, is_upgrade_enabled: true)
+
+        %Revision{} ->
+          if Map.get(params, "value") do
+            assign(socket, :is_upgrade_enabled, true)
+          else
+            assign(socket, :is_upgrade_enabled, false)
+          end
+      end
+
+    {:noreply, socket}
+  end
+
+  defp create_experiment(project, author) do
+    initial_opts = [
+      %{"id" => uuid(), "name" => "Option 1"},
+      %{"id" => uuid(), "name" => "Option 2"}
+    ]
+
+    attrs = %{
+      title: "Decision Point",
+      content: %{"options" => initial_opts, "strategy" => "upgrade_decision_point"}
+    }
+
+    ResourceEditor.create(project.slug, author, @alternatives_type_id, attrs)
   end
 end

--- a/lib/oli_web/live/resources/alternatives_editor.ex
+++ b/lib/oli_web/live/resources/alternatives_editor.ex
@@ -91,6 +91,10 @@ defmodule OliWeb.Resources.AlternativesEditor do
     """
   end
 
+  attr(:editing_enabled, :boolean, default: true)
+  attr(:source, :atom, default: :alternatives)
+  attr(:group, :any)
+
   def group(assigns) do
     ~H"""
     <div class="alternatives-group bg-gray-100 dark:bg-neutral-800 dark:border-gray-700 border p-3 my-2">
@@ -103,12 +107,14 @@ defmodule OliWeb.Resources.AlternativesEditor do
         </div>
         <div class="flex-grow-1"></div>
         <.icon_button
+          :if={@editing_enabled}
           class="mr-1"
           icon="fa-solid fa-pencil"
           on_click="show_edit_group_modal"
           values={["phx-value-resource-id": @group.resource_id]}
         />
         <button
+          :if={@source == :alternatives}
           class="btn btn-danger btn-sm mr-2"
           phx-click="show_delete_group_modal"
           phx-value-resource_id={@group.resource_id}
@@ -120,7 +126,7 @@ defmodule OliWeb.Resources.AlternativesEditor do
         <%= if Enum.count(@group.content["options"]) > 0 do %>
           <ul class="list-group">
             <%= for option <- @group.content["options"] do %>
-              <.group_option group={@group} option={option} show_actions={true} />
+              <.group_option group={@group} option={option} show_actions={@editing_enabled} />
             <% end %>
           </ul>
         <% else %>
@@ -129,6 +135,7 @@ defmodule OliWeb.Resources.AlternativesEditor do
           </div>
         <% end %>
         <button
+          :if={@editing_enabled}
           class="btn btn-link btn-sm my-2"
           phx-click="show_create_option_modal"
           phx-value-resource_id={@group.resource_id}

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -418,16 +418,9 @@ defmodule OliWeb.Router do
 
     # Experiment management
 
-    live_session :another_load_projects,
-      on_mount: [
-        OliWeb.LiveSessionPlugs.SetUser,
-        OliWeb.LiveSessionPlugs.SetProject
-      ] do
-      live("/:project_id/experiments", Experiments.ExperimentsView)
-    end
-
     get("/:project_id/experiments/segment.json", ExperimentController, :segment_download)
     get("/:project_id/experiments/experiment.json", ExperimentController, :experiment_download)
+    live("/:project_id/experiments", Experiments.ExperimentsView)
 
     # Curriculum
     live(

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -417,7 +417,15 @@ defmodule OliWeb.Router do
     live("/:project_id/objectives", ObjectivesLive.Objectives)
 
     # Experiment management
-    live("/:project_id/experiments", Experiments.ExperimentsView)
+
+    live_session :another_load_projects,
+      on_mount: [
+        OliWeb.LiveSessionPlugs.SetUser,
+        OliWeb.LiveSessionPlugs.SetProject
+      ] do
+      live("/:project_id/experiments", Experiments.ExperimentsView)
+    end
+
     get("/:project_id/experiments/segment.json", ExperimentController, :segment_download)
     get("/:project_id/experiments/experiment.json", ExperimentController, :experiment_download)
 

--- a/test/oli/authoring/experiments_test.exs
+++ b/test/oli/authoring/experiments_test.exs
@@ -1,0 +1,56 @@
+defmodule Oli.Authoring.ExperimentsTest do
+  use Oli.DataCase
+
+  import Oli.Factory
+
+  alias Oli.Authoring.Experiments
+  alias Oli.Resources.ResourceType
+
+  @alternatives_type_id ResourceType.id_for_alternatives()
+  @container_type_id ResourceType.id_for_container()
+  @experiment_id "upgrade_decision_point"
+  @another_id "another_id"
+
+  describe "get_latest_experiment/1" do
+    test "returns revision (experiment) for a given project slug" do
+      project = insert(:project, slug: "some_project")
+      publication = insert(:publication, project: project, published: nil)
+      content = %{"strategy" => @experiment_id}
+      revision = insert(:revision, content: content, resource_type_id: @alternatives_type_id)
+      insert(:published_resource, revision: revision, publication: publication)
+
+      assert %Oli.Resources.Revision{content: %{"strategy" => @experiment_id}} =
+               Experiments.get_latest_experiment(project.slug)
+    end
+
+    test "returns nil when not in the current publication" do
+      project = insert(:project, slug: "some_project")
+      publication = insert(:publication, project: project)
+      content = %{"strategy" => @experiment_id}
+      revision = insert(:revision, content: content, resource_type_id: @alternatives_type_id)
+      insert(:published_resource, revision: revision, publication: publication)
+
+      assert nil == Experiments.get_latest_experiment(project.slug)
+    end
+
+    test "returns nil when strategy is different to upgrade_decision_point" do
+      project = insert(:project, slug: "some_project")
+      publication = insert(:publication, project: project, published: nil)
+      content = %{"strategy" => @another_id}
+      revision = insert(:revision, content: content, resource_type_id: @alternatives_type_id)
+      insert(:published_resource, revision: revision, publication: publication)
+
+      assert nil == Experiments.get_latest_experiment(project.slug)
+    end
+
+    test "returns nil when resource_type_id is different to alternatives_type_id" do
+      project = insert(:project, slug: "some_project")
+      publication = insert(:publication, project: project, published: nil)
+      content = %{"strategy" => @experiment_id}
+      revision = insert(:revision, content: content, resource_type_id: @container_type_id)
+      insert(:published_resource, revision: revision, publication: publication)
+
+      assert nil == Experiments.get_latest_experiment(project.slug)
+    end
+  end
+end

--- a/test/oli_web/live/experiments_live_test.exs
+++ b/test/oli_web/live/experiments_live_test.exs
@@ -144,7 +144,7 @@ defmodule OliWeb.ExperimentsLiveTest do
         |> step(:put_resource_id)
         |> step(:put_options)
 
-      # # Reloads page
+      # Reloads page
       {:ok, view, _html} = live(conn, live_view_experiments_route(project.slug))
 
       {view, context}

--- a/test/oli_web/live/experiments_live_test.exs
+++ b/test/oli_web/live/experiments_live_test.exs
@@ -122,6 +122,8 @@ defmodule OliWeb.ExperimentsLiveTest do
     test "when checkbox is off then disable the ability to modify experiment", %{view: view} do
       {view, %{}}
       |> step(:click_on_checkbox)
+      |> step(:put_resource_id)
+      |> step(:put_options)
       |> step(:click_on_checkbox)
       |> step(:test_has_button_show_edit_group_modal, :refute)
       |> step(:test_has_button_show_edit_option_1_modal, :refute)
@@ -136,13 +138,16 @@ defmodule OliWeb.ExperimentsLiveTest do
       conn: conn,
       project: project
     } do
-      {view, %{}}
-      |> step(:click_on_checkbox)
+      {_old_view, context} =
+        {view, %{}}
+        |> step(:click_on_checkbox)
+        |> step(:put_resource_id)
+        |> step(:put_options)
 
-      # Reloads page
+      # # Reloads page
       {:ok, view, _html} = live(conn, live_view_experiments_route(project.slug))
 
-      {view, %{}}
+      {view, context}
       |> step(:test_has_alternatives_group)
       |> step(:test_has_options)
       |> step(:test_has_button_show_edit_group_modal, :refute)
@@ -171,6 +176,7 @@ defmodule OliWeb.ExperimentsLiveTest do
 
   defp step({view, ctx}, :test_has_button_show_edit_group_modal, assert_or_refute) do
     resource_id = Map.get(ctx, :resource_id)
+    assert resource_id
 
     to_evaluate =
       has_element?(
@@ -215,6 +221,7 @@ defmodule OliWeb.ExperimentsLiveTest do
 
   defp step({view, ctx}, :test_has_button_show_edit_option_1_modal, assert_or_refute) do
     option_1 = Map.get(ctx, :option_1)
+    assert option_1
 
     to_evaluate =
       has_element?(
@@ -229,6 +236,7 @@ defmodule OliWeb.ExperimentsLiveTest do
 
   defp step({view, ctx}, :test_has_button_show_edit_option_2_modal, assert_or_refute) do
     option_2 = Map.get(ctx, :option_2)
+    assert option_2
 
     to_evaluate =
       has_element?(
@@ -242,6 +250,7 @@ defmodule OliWeb.ExperimentsLiveTest do
 
   defp step({view, ctx}, :test_has_button_show_delete_option_1_modal, assert_or_refute) do
     option_1 = Map.get(ctx, :option_1)
+    assert option_1
 
     to_evaluate =
       has_element?(
@@ -255,6 +264,7 @@ defmodule OliWeb.ExperimentsLiveTest do
 
   defp step({view, ctx}, :test_has_button_show_delete_option_2_modal, assert_or_refute) do
     option_2 = Map.get(ctx, :option_2)
+    assert option_2
 
     to_evaluate =
       has_element?(
@@ -268,6 +278,7 @@ defmodule OliWeb.ExperimentsLiveTest do
 
   defp step({view, ctx}, :test_has_new_option_link, assert_or_refute) do
     resource_id = Map.get(ctx, :resource_id)
+    assert resource_id
 
     to_evaluate =
       has_element?(
@@ -287,6 +298,7 @@ defmodule OliWeb.ExperimentsLiveTest do
 
   defp step({view, ctx}, :put_options, _assert_or_refute) do
     resource_id = Map.get(ctx, :resource_id)
+    assert resource_id
 
     [option_1, option_2] =
       Oli.Repo.get_by!(Revision, resource_id: resource_id).content["options"]

--- a/test/oli_web/live/experiments_live_test.exs
+++ b/test/oli_web/live/experiments_live_test.exs
@@ -10,7 +10,7 @@ defmodule OliWeb.ExperimentsLiveTest do
     ~p"/authoring/project/#{project_slug}/experiments"
   end
 
-  defp put_route(context) do
+  defp put_view(context) do
     {:ok, view, _html} = live(context.conn, live_view_experiments_route(context.project.slug))
     [view: view]
   end
@@ -94,7 +94,7 @@ defmodule OliWeb.ExperimentsLiveTest do
   end
 
   describe "experiments view" do
-    setup [:admin_conn, :create_project, :put_route]
+    setup [:admin_conn, :create_project, :put_view]
 
     test "loads experiments view correctly", %{view: view} do
       {view, %{}}
@@ -106,7 +106,7 @@ defmodule OliWeb.ExperimentsLiveTest do
     test "when clicked on checkbox creates and displays experiment with 2 options", %{view: view} do
       {view, %{}}
       |> step(:test_has_alternatives_group, :refute)
-      |> step(:check_on_checkbox)
+      |> step(:click_on_checkbox)
       |> step(:test_has_alternatives_group)
       |> step(:test_has_options)
       |> step(:put_resource_id)
@@ -121,8 +121,8 @@ defmodule OliWeb.ExperimentsLiveTest do
 
     test "when checkbox is off then disable the ability to modify experiment", %{view: view} do
       {view, %{}}
-      |> step(:check_on_checkbox)
-      |> step(:check_on_checkbox)
+      |> step(:click_on_checkbox)
+      |> step(:click_on_checkbox)
       |> step(:test_has_button_show_edit_group_modal, :refute)
       |> step(:test_has_button_show_edit_option_1_modal, :refute)
       |> step(:test_has_button_show_edit_option_2_modal, :refute)
@@ -137,7 +137,7 @@ defmodule OliWeb.ExperimentsLiveTest do
       project: project
     } do
       {view, %{}}
-      |> step(:check_on_checkbox)
+      |> step(:click_on_checkbox)
 
       # Reloads page
       {:ok, view, _html} = live(conn, live_view_experiments_route(project.slug))
@@ -280,7 +280,7 @@ defmodule OliWeb.ExperimentsLiveTest do
     {view, ctx}
   end
 
-  defp step({view, ctx}, :check_on_checkbox, _assert_or_refute) do
+  defp step({view, ctx}, :click_on_checkbox, _assert_or_refute) do
     view |> element("input[phx-click=\"enable_upgrade\"]") |> render_click()
     {view, ctx}
   end

--- a/test/oli_web/live/resources/alternatives_editor_test.exs
+++ b/test/oli_web/live/resources/alternatives_editor_test.exs
@@ -127,6 +127,39 @@ defmodule OliWeb.Resources.AlternativesEditorTest do
       # verify alternatives group contains new option
       assert has_element?(view, "div", "Excel")
       refute has_element?(view, "em", "There are no options in this group")
+
+      # show edit option modal
+      view
+      |> element(~s|button[phx-click="show_edit_option_modal"]|)
+      |> render_click()
+
+      assert has_element?(view, ~s|div[class="modal-dialog"]|)
+      assert has_element?(view, "h5", "Edit Option")
+
+      # edit option
+      view
+      |> element(~s|form[phx-submit="edit_option"|)
+      |> render_submit(%{"params" => %{"name" => "Shine"}})
+
+      # verify alternatives group contains the edited option
+      assert has_element?(view, "div", "Shine")
+      refute has_element?(view, "div", "Excel")
+
+      # show delete option modal
+      view
+      |> element(~s|button[phx-click="show_delete_option_modal"]|)
+      |> render_click()
+
+      assert has_element?(view, ~s|div[class="modal-dialog"]|)
+      assert has_element?(view, "h5", "Delete Option")
+
+      # delete option
+      view
+      |> element(~s|button[phx-click="delete_option"]|)
+      |> render_click()
+
+      # verify alternatives group doesn't contain the deleted option
+      assert has_element?(view, "em", "There are no options in this group")
     end
   end
 end


### PR DESCRIPTION
Ticket: [MER-3096](https://eliterate.atlassian.net/browse/MER-3096)

This PR introduces the capability to enable/disable A/B testing. When enabled for the first time, a revision is created. Subsequent actions on the checkbox only toggle the ability to edit the content of the revision.

Endpoint: 
`http://localhost/authoring/project/__SOME_PROJECT__/experiments`


https://github.com/Simon-Initiative/oli-torus/assets/47334502/575ac111-d7d1-476c-829a-48bbb001e3cf




Note: A significant portion of code was copied and adapted for the OliWeb.Resources.AlternativesEditor module. I recognize that some refactoring could reduce complexity. However, I refrained from doing so as this PR is currently blocking others.

[MER-3096]: https://eliterate.atlassian.net/browse/MER-3096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ