### PR TITLE
[FEATURE] [NG23-86] [NG23-88] user can search course discussions in discussion menu

### DIFF
--- a/lib/oli/resources/collaboration.ex
+++ b/lib/oli/resources/collaboration.ex
@@ -528,6 +528,7 @@ defmodule Oli.Resources.Collaboration do
   def list_root_posts_for_section(
         user_id,
         section_id,
+        root_section_resource_resource_id,
         limit,
         offset,
         sort_by,
@@ -571,6 +572,7 @@ defmodule Oli.Resources.Collaboration do
           post.section_id == ^section_id and post.visibility == :public and
             (post.status in [:approved, :archived] or
                (post.status == :submitted and post.user_id == ^user_id)) and
+            post.resource_id == ^root_section_resource_resource_id and
             is_nil(post.parent_post_id) and is_nil(post.thread_root_id),
         order_by: ^order_clause,
         limit: ^limit,
@@ -1158,6 +1160,15 @@ defmodule Oli.Resources.Collaboration do
         point_block_id,
         search_term
       ) do
+    filter_by_resource_id =
+      case resource_id do
+        nil ->
+          true
+
+        _ ->
+          dynamic([p], p.resource_id == ^resource_id)
+      end
+
     filter_by_point_block_id =
       case point_block_id do
         nil ->
@@ -1190,9 +1201,10 @@ defmodule Oli.Resources.Collaboration do
         left_join: reactions in assoc(post, :reactions),
         left_join: user in assoc(post, :user),
         where:
-          post.section_id == ^section_id and post.resource_id == ^resource_id and
+          post.section_id == ^section_id and
             (post.status in [:approved, :archived] or
                (post.status == :submitted and post.user_id == ^user_id)),
+        where: ^filter_by_resource_id,
         where: ^filter_by_point_block_id,
         where: ^filter_by_visibility,
         where:

--- a/lib/oli_web/live/delivery/student/lesson/annotations.ex
+++ b/lib/oli_web/live/delivery/student/lesson/annotations.ex
@@ -493,7 +493,7 @@ defmodule OliWeb.Delivery.Student.Lesson.Annotations do
             phx-value-post-id={assigns.post.id}
             phx-value-parent-post-id={assigns.post.parent_post_id}
           >
-            <%= case Map.get(reaction_summaries, :like) do %>
+            <%= case Map.get(@post.reaction_summaries, :like) do %>
               <% nil -> %>
                 <.like_icon />
               <% %{count: count, reacted: reacted} -> %>

--- a/lib/oli_web/live/delivery/student/lesson/annotations.ex
+++ b/lib/oli_web/live/delivery/student/lesson/annotations.ex
@@ -42,9 +42,8 @@ defmodule OliWeb.Delivery.Student.Lesson.Annotations do
           <% _ -> %>
             <.search_results
               search_results={@search_results}
-              search_term={@search_term}
               current_user={@current_user}
-              active_tab={@active_tab}
+              on_reveal_post="reveal_post"
             />
         <% end %>
       </div>
@@ -91,11 +90,10 @@ defmodule OliWeb.Delivery.Student.Lesson.Annotations do
   end
 
   attr :current_user, Oli.Accounts.User, required: true
-  attr :active_tab, :atom, default: :my_notes
   attr :search_results, :any, default: nil
-  attr :search_term, :string, default: ""
+  attr :on_reveal_post, :string, default: nil
 
-  defp search_results(assigns) do
+  def search_results(assigns) do
     ~H"""
     <div class="flex-1 flex flex-col gap-3 overflow-y-auto pb-[80px]">
       <%= case @search_results do %>
@@ -106,8 +104,8 @@ defmodule OliWeb.Delivery.Student.Lesson.Annotations do
         <% annotations -> %>
           <%= for annotation <- annotations do %>
             <div
-              class="flex flex-col cursor-pointer"
-              phx-click="reveal_post"
+              class={["flex flex-col", if(@on_reveal_post, do: "cursor-pointer")]}
+              phx-click={@on_reveal_post}
               phx-value-point-marker-id={annotation.annotated_block_id}
               phx-value-post-id={annotation.id}
             >
@@ -126,7 +124,7 @@ defmodule OliWeb.Delivery.Student.Lesson.Annotations do
   defp search_result(assigns) do
     ~H"""
     <div class={[
-      "search-result flex flex-col border-gray-200 dark:border-gray-800 rounded",
+      "search-result flex flex-col bg-white border-gray-200 dark:border-gray-800 rounded",
       if(@is_reply, do: "my-2 pl-4 border-l-2", else: "p-4 border-2")
     ]}>
       <div class="flex flex-row justify-between mb-1">
@@ -314,11 +312,13 @@ defmodule OliWeb.Delivery.Student.Lesson.Annotations do
   end
 
   attr :search_term, :string, default: ""
+  attr :on_search, :string, default: "search"
+  attr :on_clear_search, :string, default: "clear_search"
   attr :rest, :global, include: ~w(class)
 
   def search_box(assigns) do
     ~H"""
-    <form class={["flex flex-row", @rest[:class]]} phx-submit="search_annotations">
+    <form class={["flex flex-row", @rest[:class]]} phx-submit={@on_search}>
       <div class="flex-1 relative">
         <i class="fa-solid fa-search absolute left-4 top-4 text-gray-400 pointer-events-none text-lg">
         </i>
@@ -327,14 +327,14 @@ defmodule OliWeb.Delivery.Student.Lesson.Annotations do
           name="search_term"
           value={@search_term}
           class="w-full border border-gray-400 dark:border-gray-700 rounded-lg px-12 py-3"
-          phx-change="search_annotations"
+          phx-change={@on_search}
           phx-debounce="500"
         />
         <button
           :if={@search_term != ""}
           type="button"
           class="absolute right-0 top-0 bottom-0 py-3 px-4"
-          phx-click="clear_search"
+          phx-click={@on_clear_search}
         >
           <i class="fa-solid fa-xmark text-lg"></i>
         </button>
@@ -477,7 +477,11 @@ defmodule OliWeb.Delivery.Student.Lesson.Annotations do
         </div>
         """
 
-      %Oli.Resources.Collaboration.Post{visibility: :public} ->
+      %Oli.Resources.Collaboration.Post{
+        visibility: :public,
+        reaction_summaries: reaction_summaries
+      }
+      when not is_nil(reaction_summaries) ->
         ~H"""
         <div class="flex flex-row gap-3 my-2" role="post actions">
           <button
@@ -489,7 +493,7 @@ defmodule OliWeb.Delivery.Student.Lesson.Annotations do
             phx-value-post-id={assigns.post.id}
             phx-value-parent-post-id={assigns.post.parent_post_id}
           >
-            <%= case Map.get(@post.reaction_summaries, :like) do %>
+            <%= case Map.get(reaction_summaries, :like) do %>
               <% nil -> %>
                 <.like_icon />
               <% %{count: count, reacted: reacted} -> %>

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -494,11 +494,11 @@ defmodule OliWeb.Delivery.Student.LessonLive do
     end
   end
 
-  def handle_event("search_annotations", %{"search_term" => ""}, socket) do
+  def handle_event("search", %{"search_term" => ""}, socket) do
     {:noreply, assign_annotations(socket, search_results: nil, search_term: "")}
   end
 
-  def handle_event("search_annotations", %{"search_term" => search_term}, socket) do
+  def handle_event("search", %{"search_term" => search_term}, socket) do
     %{
       current_user: current_user,
       section: section,

--- a/test/oli_web/live/delivery/student/discussions_live_test.exs
+++ b/test/oli_web/live/delivery/student/discussions_live_test.exs
@@ -481,6 +481,8 @@ defmodule OliWeb.Delivery.Student.DiscussionsLiveTest do
 
       toggle_post_replies(view, course_discussion.id)
 
+      wait_while(fn -> has_element?(view, "svg.loading") end)
+
       assert render(view) =~ "My first discussion"
       assert render(view) =~ "This is a reply to the first discussion"
 

--- a/test/oli_web/live/delivery/student/discussions_live_test.exs
+++ b/test/oli_web/live/delivery/student/discussions_live_test.exs
@@ -249,9 +249,11 @@ defmodule OliWeb.Delivery.Student.DiscussionsLiveTest do
 
       {:ok, view, _html} = live(conn, live_view_discussions_live_route(section.slug))
 
-      assert view
+      # page posts are not shown in discussions view
+      refute view
              |> has_element?("div[id=\"post-#{page_post.id}\"]")
 
+      # course discussions are shown
       assert view
              |> element("div[id=\"post-#{course_discussion.id}\"]")
              |> render() =~ "My first discussion"


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/NG23-86
https://eliterate.atlassian.net/browse/NG23-88

Adds the ability for a user to search course discussions and private notes no the discussions page.

<img width="1554" alt="Screenshot 2024-05-07 at 11 49 04 AM" src="https://github.com/Simon-Initiative/oli-torus/assets/6248894/3adfbd36-a971-4b7a-8cd7-395b32789f38">
