### PR TITLE
[CHORE] [NG23-179] remove unnecessary ci environment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,6 @@ jobs:
     name: Elixir build and test
     runs-on: ubuntu-latest
 
-    environment: ci-build-test
-
     env:
       MIX_ENV: test
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/test/oli_web/live/grades_live_test.exs
+++ b/test/oli_web/live/grades_live_test.exs
@@ -154,6 +154,8 @@ defmodule OliWeb.GradesLiveTest do
       |> element("button[phx-click=\"test_connection\"]")
       |> render_click()
 
+      wait_while(fn -> not has_element?(view, "samp", "Requesting line items...") end)
+
       assert has_element?(view, "samp", "Starting test")
       assert has_element?(view, "samp", "Requesting access token...")
       assert has_element?(view, "samp", "Received access token")


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/NG23-179

While updating the ci/cd config, a new environment called ci-build-test was added to easily setup the oli.env for ci build test jobs. But because of the way Github injects this environment variable (includes '\r' characters), using this method made it unnecessarily difficult to process. As a result, the build jobs are simply using the example env file in the repository and the environment is no longer used.

However, this environment is now cluttering the deployment grid in Jira. This ticket is to just remove this environment for now.

Once this lands, we can remove the environment from Github