### PR TITLE
[FEATURE] [NG23-89] add a link to go to a content page from a post

### DIFF
--- a/lib/oli/resources/collaboration.ex
+++ b/lib/oli/resources/collaboration.ex
@@ -633,6 +633,14 @@ defmodule Oli.Resources.Collaboration do
     results =
       from(
         post in Post,
+        join: sr in SectionResource,
+        on: sr.resource_id == post.resource_id and sr.section_id == post.section_id,
+        join: spp in SectionsProjectsPublications,
+        on: spp.section_id == post.section_id and spp.project_id == sr.project_id,
+        join: pr in PublishedResource,
+        on: pr.publication_id == spp.publication_id and pr.resource_id == post.resource_id,
+        join: rev in Revision,
+        on: rev.id == pr.revision_id,
         join: user in User,
         on: post.user_id == user.id,
         left_join: replies in subquery(replies_subquery()),
@@ -652,7 +660,8 @@ defmodule Oli.Resources.Collaboration do
           post: %{
             post
             | replies_count: coalesce(replies.count, 0),
-              read_replies_count: coalesce(read_replies.count, 0)
+              read_replies_count: coalesce(read_replies.count, 0),
+              resource_slug: rev.slug
           },
           total_count: over(count(post.id))
         }
@@ -1193,6 +1202,14 @@ defmodule Oli.Resources.Collaboration do
     Repo.all(
       from(
         post in Post,
+        join: sr in SectionResource,
+        on: sr.resource_id == post.resource_id and sr.section_id == post.section_id,
+        join: spp in SectionsProjectsPublications,
+        on: spp.section_id == post.section_id and spp.project_id == sr.project_id,
+        join: pr in PublishedResource,
+        on: pr.publication_id == spp.publication_id and pr.resource_id == post.resource_id,
+        join: rev in Revision,
+        on: rev.id == pr.revision_id,
         left_join: replies in subquery(replies_subquery()),
         on: replies.thread_root_id == post.id,
         left_join: read_replies in subquery(read_replies_subquery(user_id)),
@@ -1224,6 +1241,7 @@ defmodule Oli.Resources.Collaboration do
           post
           | replies_count: coalesce(replies.count, 0),
             read_replies_count: coalesce(read_replies.count, 0),
+            resource_slug: rev.slug,
             headline:
               fragment(
                 """

--- a/lib/oli/resources/collaboration/post.ex
+++ b/lib/oli/resources/collaboration/post.ex
@@ -35,6 +35,7 @@ defmodule Oli.Resources.Collaboration.Post do
     has_many :reactions, Oli.Resources.Collaboration.UserReactionPost
 
     field :resource_type_id, :id, virtual: true
+    field :resource_slug, :id, virtual: true
     field :replies_count, :integer, virtual: true
     field :read_replies_count, :integer, virtual: true
     field :is_read, :boolean, virtual: true

--- a/lib/oli_web/live/delivery/student/discussions_live.ex
+++ b/lib/oli_web/live/delivery/student/discussions_live.ex
@@ -507,6 +507,7 @@ defmodule OliWeb.Delivery.Student.DiscussionsLive do
       />
       <.notes_section
         ctx={@ctx}
+        section_slug={@section.slug}
         current_user={@current_user}
         notes={@notes}
         note_params={@note_params}
@@ -660,6 +661,7 @@ defmodule OliWeb.Delivery.Student.DiscussionsLive do
 
   attr :notes, :list
   attr :ctx, :map
+  attr :section_slug, :string
   attr :current_user, :any
   attr :note_params, :map
   attr :more_notes_exist?, :boolean
@@ -682,7 +684,12 @@ defmodule OliWeb.Delivery.Student.DiscussionsLive do
           <div role="notes list" class="w-full">
             <%= for post <- @notes do %>
               <div class="mb-3">
-                <Annotations.post class="bg-white" post={post} current_user={@ctx.user} />
+                <Annotations.post
+                  class="bg-white"
+                  post={post}
+                  current_user={@ctx.user}
+                  go_to_post_href={~p"/sections/#{@section_slug}/lesson/#{post.resource_slug}"}
+                />
               </div>
             <% end %>
             <div :if={@notes == []} class="flex p-4 text-center w-full">
@@ -704,7 +711,12 @@ defmodule OliWeb.Delivery.Student.DiscussionsLive do
           </div>
         <% results -> %>
           <div role="search-results list" class="w-full">
-            <Annotations.search_results search_results={results} current_user={@current_user} />
+            <Annotations.search_results
+              section_slug={@section_slug}
+              search_results={results}
+              current_user={@current_user}
+              show_go_to_post_link={true}
+            />
           </div>
       <% end %>
     </section>

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -631,6 +631,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
 
       <:sidebar>
         <Annotations.panel
+          section_slug={@section.slug}
           create_new_annotation={@annotations.create_new_annotation}
           annotations={@annotations.posts}
           current_user={@current_user}

--- a/test/oli_web/live/grades_live_test.exs
+++ b/test/oli_web/live/grades_live_test.exs
@@ -154,6 +154,8 @@ defmodule OliWeb.GradesLiveTest do
       |> element("button[phx-click=\"test_connection\"]")
       |> render_click()
 
+      wait_while(fn -> not has_element?(view, "samp", "Requesting line items...") end)
+
       assert has_element?(view, "samp", "Starting test")
       assert has_element?(view, "samp", "Requesting access token...")
       assert has_element?(view, "samp", "Received access token")
@@ -382,7 +384,7 @@ defmodule OliWeb.GradesLiveTest do
                """
     end
 
-    test "download gradebook - download file without grades succesfully", %{
+    test "download gradebook - download file without grades successfully", %{
       conn: conn,
       section: section
     } do


### PR DESCRIPTION
Adds a "Go to Page" link to notes that links to the page where a note was created. Also adds a virtual field to facilitate link creation and updates the queries used to populate the new field.

This feature adds a bit of overhead to the simplified queries to gather the necessary slug in order to facilitate link creation. Now these queries must also join through the section resource, spp, published resource to revision records. This query however, is similar to the queries that were already in place before the social annotation work.

<img width="1826" alt="Screenshot 2024-05-08 at 2 31 03 PM" src="https://github.com/Simon-Initiative/oli-torus/assets/6248894/ed9db863-1a37-4bec-9e26-fc25cacaf52d">
