### PR TITLE
[FEATURE] [MER-3098] Add download buttons to experiments

### DIFF
--- a/lib/oli_web/live/experiments/experiments_live.ex
+++ b/lib/oli_web/live/experiments/experiments_live.ex
@@ -63,6 +63,11 @@ defmodule OliWeb.Experiments.ExperimentsView do
           source={:experiments}
         />
       <% end %>
+
+      <div :if={@is_upgrade_enabled} class="flex gap-4">
+        <.button class="btn btn-md btn-primary mt-2">Download Segment JSON</.button>
+        <.button class="btn btn-md btn-primary mt-2">Download Experiment JSON</.button>
+      </div>
     </div>
     """
   end

--- a/test/oli_web/live/experiments_live_test.exs
+++ b/test/oli_web/live/experiments_live_test.exs
@@ -152,6 +152,15 @@ defmodule OliWeb.ExperimentsLiveTest do
       |> step(:test_has_button_show_delete_option_2_modal, :refute)
       |> step(:test_has_new_option_link, :refute)
     end
+
+    test "hide/show download buttons when checkbox is checked/unchecked", %{view: view} do
+      {view, %{}}
+      |> step(:test_has_button_download_segment_json, :refute)
+      |> step(:test_has_button_download_experiment_json, :refute)
+      |> step(:click_on_checkbox)
+      |> step(:test_has_button_download_segment_json)
+      |> step(:test_has_button_download_experiment_json)
+    end
   end
 
   defp evaluate_assertion(to_evaluate, assert_or_refute) do
@@ -162,6 +171,30 @@ defmodule OliWeb.ExperimentsLiveTest do
   end
 
   defp step(_view_and_ctx, _operation, assert_or_refute \\ :assert)
+
+  defp step({view, ctx}, :test_has_button_download_experiment_json, assert_or_refute) do
+    to_evaluate =
+      view
+      |> render()
+      |> Floki.find("button:fl-contains('Download Experiment JSON')")
+      |> Floki.text() =~ "Download Experiment JSON"
+
+    evaluate_assertion(to_evaluate, assert_or_refute)
+
+    {view, ctx}
+  end
+
+  defp step({view, ctx}, :test_has_button_download_segment_json, assert_or_refute) do
+    to_evaluate =
+      view
+      |> render()
+      |> Floki.find("button:fl-contains('Download Segment JSON')")
+      |> Floki.text() =~ "Download Segment JSON"
+
+    evaluate_assertion(to_evaluate, assert_or_refute)
+
+    {view, ctx}
+  end
 
   defp step({view, ctx}, :test_has_alternatives_group, assert_or_refute) do
     to_evaluate = has_element?(view, ".alternatives-group", "Decision Point")


### PR DESCRIPTION
Ticket: [MER-3098](https://eliterate.atlassian.net/jira/software/c/projects/MER/issues/MER-3098)

This PR added 2 buttons to the experiment page. However, there is no functionality triggered by them yet, as per the instructions of the ticket.

Endpoint:
`http://localhost/authoring/project/__SOME_PROJECT__/experiments`

https://github.com/Simon-Initiative/oli-torus/assets/47334502/d8ce1051-7b93-4d2c-b42d-ed08d8109fe1

Note: This PR has been branched off from [PR-4788](https://github.com/Simon-Initiative/oli-torus/pull/4788).

[MER-3098]: https://eliterate.atlassian.net/browse/MER-3098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ