### PR TITLE
[ENHANCEMENT] [MER-3246] Emit the new page_viewed xapi event

### DIFF
--- a/lib/oli/analytics/event_emitter.ex
+++ b/lib/oli/analytics/event_emitter.ex
@@ -1,0 +1,29 @@
+defmodule Oli.Analytics.EventEmitter do
+
+  @chars "abcdefghijklmnopqrstuvwxyz1234567890" |> String.split("", trim: true)
+
+  def emit_page_viewed(event) do
+
+    section_id = event["context"]["extensions"]["http://oli.cmu.edu/extensions/section_id"]
+    guid = event["context"]["extensions"]["http://oli.cmu.edu/extensions/page_attempt_guid"]
+
+    bundle_id = :crypto.hash(:md5, guid <> "-" <> random_string(10))
+    |> Base.encode16()
+
+    Oli.Delivery.Snapshots.S3UploaderWorker.new(%{
+      body: [event] |> Oli.Analytics.Common.to_jsonlines(),
+      bundle_id: bundle_id,
+      partition_id: section_id,
+      category: :page_viewed
+    })
+    |> Oban.insert()
+  end
+
+  def random_string(length) do
+    Enum.reduce(1..length, [], fn _i, acc ->
+      [Enum.random(@chars) | acc]
+    end)
+    |> Enum.join("")
+  end
+
+end

--- a/lib/oli/analytics/summary/xapi/page_viewed.ex
+++ b/lib/oli/analytics/summary/xapi/page_viewed.ex
@@ -1,0 +1,63 @@
+defmodule Oli.Analytics.Summary.XAPI.PageViewed do
+  alias Oli.Analytics.Summary.Context
+
+  def new(
+        %Context{
+          user_id: user_id,
+          host_name: host_name,
+          section_id: section_id,
+          project_id: project_id,
+          publication_id: publication_id
+        },
+        %{
+          attempt_guid: page_attempt_guid,
+          attempt_number: page_attempt_number,
+          resource_id: page_id,
+          timestamp: timestamp,
+          page_sub_type: page_sub_type
+        }
+      ) do
+
+    %{
+      "actor" => %{
+        "account" => %{
+          "homePage" => host_name,
+          "name" => user_id
+        },
+        "objectType" => "Agent"
+      },
+      "verb" => %{
+        "id" => "http://id.tincanapi.com/verb/viewed",
+        "display" => %{
+          "en-US" => "viewed"
+        }
+      },
+      "object" => %{
+        "id" => "#{host_name}/page/#{page_id}}",
+        "definition" => %{
+          "name" => %{
+            "en-US" => "Page"
+          },
+          "type" => "http://oli.cmu.edu/extensions/types/page",
+          "subType" => page_sub_type
+        },
+        "objectType" => "Page"
+      },
+      "result" => %{
+        "completion" => true,
+        "success" => true
+      },
+      "context" => %{
+        "extensions" => %{
+          "http://oli.cmu.edu/extensions/page_attempt_number" => page_attempt_number,
+          "http://oli.cmu.edu/extensions/page_attempt_guid" => page_attempt_guid,
+          "http://oli.cmu.edu/extensions/section_id" => section_id,
+          "http://oli.cmu.edu/extensions/project_id" => project_id,
+          "http://oli.cmu.edu/extensions/publication_id" => publication_id,
+          "http://oli.cmu.edu/extensions/page_id" => page_id
+        }
+      },
+      "timestamp" => timestamp
+    }
+  end
+end

--- a/lib/oli/delivery/snapshots/s3_uploader_worker.ex
+++ b/lib/oli/delivery/snapshots/s3_uploader_worker.ex
@@ -4,15 +4,31 @@ defmodule Oli.Delivery.Snapshots.S3UploaderWorker do
   alias Oli.Analytics.XAPI.{StatementBundle, Uploader}
 
   @moduledoc """
-  An Oban worker to upload the snapshot details to S3 for cases where analytics v2 is supported.
-  This worker finishes the work that was initialized in the SnapshotWorker (Oli.Delivery.Snapshots.Worker).
+  An Oban worker to upload a bundy of xAPI events.
 
   If the job fails, it will be retried up to a total of the configured maximum attempts.
   """
+  def perform(%Oban.Job{
+    args: %{"category" => category, "body" => body, "bundle_id" => bundle_id, "partition_id" => partition_id}
+    }) do
+
+    %StatementBundle{
+      partition: :section,
+      partition_id: partition_id,
+      category: category,
+      bundle_id: bundle_id,
+      body: body
+    }
+    |> Uploader.upload()
+  end
+
   @impl Oban.Worker
   def perform(%Oban.Job{
         args: %{"body" => body, "bundle_id" => bundle_id, "partition_id" => partition_id}
       }) do
+
+    # No category specified, so default to :attempt_evaluated
+
     %StatementBundle{
       partition: :section,
       partition_id: partition_id,

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -1424,7 +1424,6 @@ defmodule OliWeb.Delivery.Student.LessonLive do
        ) do
     Oli.Analytics.Summary.XAPI.PageViewed.new(context, page_details)
     |> Oli.Analytics.EventEmitter.emit_page_viewed()
-
   end
 
   defp get_project_and_publication_ids(section_id, revision_id) do

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -3,6 +3,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
 
   import OliWeb.Delivery.Student.Utils,
     only: [page_header: 1, scripts: 1]
+  import Ecto.Query
 
   alias Oli.Delivery.Attempts.Core.ResourceAttempt
   alias Oli.Delivery.Attempts.PageLifecycle
@@ -46,6 +47,8 @@ defmodule OliWeb.Delivery.Student.LessonLive do
       )
     end
 
+    emit_page_viewed_event(socket)
+
     {:ok,
      socket
      |> assign_html_and_scripts()
@@ -61,6 +64,9 @@ defmodule OliWeb.Delivery.Student.LessonLive do
         _session,
         %{assigns: %{view: :graded_page, page_context: %{progress_state: :in_progress}}} = socket
       ) do
+
+    emit_page_viewed_event(socket)
+
     {:ok,
      socket
      |> assign_html_and_scripts()
@@ -73,6 +79,9 @@ defmodule OliWeb.Delivery.Student.LessonLive do
         %{assigns: %{view: :adaptive_chromeless, page_context: %{progress_state: :in_progress}}} =
           socket
       ) do
+
+    emit_page_viewed_event(socket)
+
     {:ok,
      socket
      |> assign_scripts()
@@ -1080,6 +1089,8 @@ defmodule OliWeb.Delivery.Student.LessonLive do
           socket.assigns.datashop_session_id
         )
 
+      emit_page_viewed_event(socket)
+
       {:noreply,
        socket
        |> assign(page_context: page_context)
@@ -1370,4 +1381,69 @@ defmodule OliWeb.Delivery.Student.LessonLive do
     do: {:redirect, ~p"/sections/#{section_slug}/adaptive_lesson/#{revision_slug}"}
 
   defp maybe_redirect_adaptive(_, _, _), do: :ok
+
+  defp emit_page_viewed_event(socket) do
+
+    section = socket.assigns.section
+    context = socket.assigns.page_context
+    page_sub_type = if Map.get(context.page.content, "advancedDelivery", false) do
+      "advanced"
+    else
+      "basic"
+    end
+
+    {project_id, publication_id} = get_project_and_publication_ids(section.id, context.page.id)
+
+    emit_page_viewed_helper(%Oli.Analytics.Summary.Context{
+      user_id: socket.assigns.current_user.id,
+      host_name: host_name(),
+      section_id: section.id,
+      project_id: project_id,
+      publication_id: publication_id
+    }, %{
+      attempt_guid: hd(context.resource_attempts).attempt_guid,
+      attempt_number: hd(context.resource_attempts).attempt_number,
+      resource_id: context.page.resource_id,
+      timestamp: DateTime.utc_now(),
+      page_sub_type: page_sub_type
+    })
+  end
+
+  defp emit_page_viewed_helper(%Oli.Analytics.Summary.Context{} = context, %{
+    attempt_guid: _page_attempt_guid,
+    attempt_number: _page_attempt_number,
+    resource_id: _page_id,
+    timestamp: _timestamp,
+    page_sub_type: _page_sub_type
+  } = page_details) do
+
+    Oli.Analytics.Summary.XAPI.PageViewed.new(context, page_details)
+    |> Oli.Analytics.EventEmitter.emit()
+
+  end
+
+  defp get_project_and_publication_ids(section_id, revision_id) do
+    # From the SectionProjectPublication table, get the project_id and publication_id
+    # where a published resource exists for revision_id
+    # and the section_id matches the section_id
+
+    query = from sp in Oli.Delivery.Sections.SectionsProjectsPublications,
+      join: pr in Oli.Publishing.PublishedResource, on: pr.publication_id == sp.publication_id,
+      where: sp.section_id == ^section_id and pr.revision_id == ^revision_id,
+      select: {sp.project_id, sp.publication_id}
+
+    # Return nil if somehow we cannot resolve this resource.  This is just a guaranteed that
+    # we can never throw an error here
+    case Oli.Repo.all(query) do
+      [] -> {nil, nil}
+      other -> hd(other)
+    end
+
+  end
+
+  defp host_name() do
+    Application.get_env(:oli, OliWeb.Endpoint)
+    |> Keyword.get(:url)
+    |> Keyword.get(:host)
+  end
 end

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -1418,7 +1418,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
   } = page_details) do
 
     Oli.Analytics.Summary.XAPI.PageViewed.new(context, page_details)
-    |> Oli.Analytics.EventEmitter.emit()
+    |> Oli.Analytics.EventEmitter.emit_page_viewed()
 
   end
 


### PR DESCRIPTION
This PR instruments the LessonLive view to emit a new "Page Viewed" xAPI event to S3 event storage.  This is critical to get into place so that starting post V28 some interested parties can do some analysis involving the complete history of all page views. 

There will be a follow on piece of work in MER-3251 that will replace the current event emitting approach with an optimized impl