### PR TITLE
[ENHANCEMENT] [MER-3179] Set navigation menu bar at the top of the page on vertical scroll

### DIFF
--- a/lib/oli_web/components/delivery/instructor_dashboard.ex
+++ b/lib/oli_web/components/delivery/instructor_dashboard.ex
@@ -169,7 +169,7 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard do
 
   def header(assigns) do
     ~H"""
-    <div class="w-full bg-delivery-instructor-dashboard-header text-white border-b border-slate-600">
+    <div class="w-full bg-delivery-instructor-dashboard-header text-white border-b border-slate-600 sticky top-0 z-50">
       <div class="container mx-auto flex flex-row">
         <div class="flex items-center">
           <a

--- a/lib/oli_web/components/delivery/instructor_dashboard.ex
+++ b/lib/oli_web/components/delivery/instructor_dashboard.ex
@@ -169,7 +169,7 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard do
 
   def header(assigns) do
     ~H"""
-    <div class="w-full bg-delivery-instructor-dashboard-header text-white border-b border-slate-600 sticky top-0 z-50">
+    <div class="w-full bg-delivery-instructor-dashboard-header text-white border-b border-slate-600 fixed top-0 z-50">
       <div class="container mx-auto flex flex-row">
         <div class="flex items-center">
           <a

--- a/lib/oli_web/components/delivery/instructor_dashboard.ex
+++ b/lib/oli_web/components/delivery/instructor_dashboard.ex
@@ -169,7 +169,7 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard do
 
   def header(assigns) do
     ~H"""
-    <div class="w-full bg-delivery-instructor-dashboard-header text-white border-b border-slate-600 fixed top-0 z-50">
+    <div class="w-full bg-delivery-instructor-dashboard-header text-white border-b border-slate-600 sticky top-0 z-50">
       <div class="container mx-auto flex flex-row">
         <div class="flex items-center">
           <a

--- a/lib/oli_web/components/layouts/instructor_dashboard.html.heex
+++ b/lib/oli_web/components/layouts/instructor_dashboard.html.heex
@@ -1,4 +1,4 @@
-<div class="flex-1 flex flex-col h-screen">
+<div class="flex-1 flex flex-col h-auto">
   <Components.Delivery.InstructorDashboard.header
     ctx={@ctx}
     is_system_admin={@is_system_admin}

--- a/lib/oli_web/components/layouts/instructor_dashboard.html.heex
+++ b/lib/oli_web/components/layouts/instructor_dashboard.html.heex
@@ -13,7 +13,7 @@
   />
 
   <div class="relative flex-1 flex flex-col pt-4 pb-[60px]">
-    <div class="container mx-auto sticky top-4">
+    <div class="container mx-auto sticky top-16 z-50">
       <.flash_group flash={@flash} />
     </div>
 

--- a/lib/oli_web/components/layouts/instructor_dashboard.html.heex
+++ b/lib/oli_web/components/layouts/instructor_dashboard.html.heex
@@ -1,4 +1,4 @@
-<div class="flex-1 flex flex-col h-auto">
+<div class="flex-1 flex flex-col min-h-screen">
   <Components.Delivery.InstructorDashboard.header
     ctx={@ctx}
     is_system_admin={@is_system_admin}

--- a/test/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live_test.exs
@@ -98,7 +98,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLiveTest do
       {:ok, view, _html} = live(conn, instructor_dashboard_path(section.slug, :overview))
 
       assert view
-             |> has_element?(".bg-delivery-instructor-dashboard-header.fixed.top-0.z-50")
+             |> has_element?(".bg-delivery-instructor-dashboard-header.sticky.top-0.z-50")
     end
 
     test "if enrolled, can access the overview page with the course content tab as the default tab",

--- a/test/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live_test.exs
@@ -97,8 +97,8 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLiveTest do
       Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
       {:ok, view, _html} = live(conn, instructor_dashboard_path(section.slug, :overview))
 
-      view
-      |> has_element?(".bg-delivery-instructor-dashboard-header.sticky.top-0.z-50")
+      assert view
+             |> has_element?(".bg-delivery-instructor-dashboard-header.fixed.top-0.z-50")
     end
 
     test "if enrolled, can access the overview page with the course content tab as the default tab",

--- a/test/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live_test.exs
@@ -89,6 +89,18 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLiveTest do
                live(conn, instructor_dashboard_path(section.slug, :discussions))
     end
 
+    test "ensures instructors have access to the top navigation menu bar on vertical scroll", %{
+      conn: conn,
+      instructor: instructor,
+      section: section
+    } do
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+      {:ok, view, _html} = live(conn, instructor_dashboard_path(section.slug, :overview))
+
+      view
+      |> has_element?(".bg-delivery-instructor-dashboard-header.sticky.top-0.z-50")
+    end
+
     test "if enrolled, can access the overview page with the course content tab as the default tab",
          %{
            instructor: instructor,


### PR DESCRIPTION
Ticket [MER-3179](https://eliterate.atlassian.net/browse/MER-3179).

This PR put the navigation menu bar at the top of the page even when scrolling down.


### New looking

https://github.com/Simon-Initiative/oli-torus/assets/47334502/ccf5832d-a548-4922-80b2-c9773160f0e8




[MER-3179]: https://eliterate.atlassian.net/browse/MER-3179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ