### PR TITLE
[BUG FIX] [MER-3253] implements necessary rollback

### DIFF
--- a/assets/src/phoenix/activity_bridge.ts
+++ b/assets/src/phoenix/activity_bridge.ts
@@ -25,14 +25,9 @@ function makeRequest(
     .then((result) => continuation(result))
     .catch((error) => continuation(undefined, error));
 }
-const saveTransform = (result: any) => {
-  return result.error ? Promise.reject({ message: result.message }) : Promise.resolve(result);
-};
 const nothingTransform = (result: any) => Promise.resolve(result);
 const submissionTransform = (key: string, result: any) => {
-  return result.error
-    ? Promise.reject({ message: result.message })
-    : Promise.resolve({ actions: result[key] });
+  return Promise.resolve({ actions: result[key] });
 };
 
 export const initActivityBridge = (elementId: string) => {
@@ -49,7 +44,6 @@ export const initActivityBridge = (elementId: string) => {
         'PATCH',
         { partInputs: e.detail.payload },
         e.detail.continuation,
-        saveTransform,
       );
     },
     false,
@@ -97,7 +91,6 @@ export const initActivityBridge = (elementId: string) => {
         'PATCH',
         { response: e.detail.payload },
         e.detail.continuation,
-        saveTransform,
       );
     },
     false,

--- a/lib/oli/delivery/attempts/activity_lifecycle.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle.ex
@@ -344,19 +344,10 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle do
           VALUES
           #{part_input_values}
       ) AS batch_values (attempt_guid, response)
-      WHERE part_attempts.attempt_guid = batch_values.attempt_guid and lifecycle_state = 'active'
+      WHERE part_attempts.attempt_guid = batch_values.attempt_guid
     """
 
-    case Ecto.Adapters.SQL.query(Oli.Repo, sql, params) do
-      {:ok, %Postgrex.Result{num_rows: n}} when n > 0 ->
-        {:ok, %{num_rows: n}}
-
-      {:ok, %Postgrex.Result{num_rows: 0}} ->
-        {:error, :already_submitted}
-
-      {:error, _} ->
-        {:error, "Failed to save student input"}
-    end
+    Ecto.Adapters.SQL.query(Oli.Repo, sql, params)
   end
 
   @doc """

--- a/lib/oli_web/controllers/api/attempt_controller.ex
+++ b/lib/oli_web/controllers/api/attempt_controller.ex
@@ -411,15 +411,6 @@ defmodule OliWeb.Api.AttemptController do
       {:ok, _} ->
         json(conn, %{"type" => "success"})
 
-      {:error, :already_submitted} ->
-        conn
-        |> put_status(403)
-        |> json(%{
-          "error" => true,
-          "message" =>
-            "These changes could not be saved as this attempt may have already been submitted"
-        })
-
       {:error, e} ->
         {_, msg} = Oli.Utils.log_error("Could not save part", e)
         error(conn, 500, msg)
@@ -541,15 +532,6 @@ defmodule OliWeb.Api.AttemptController do
       {:ok, _} ->
         json(conn, %{"type" => "success"})
 
-      {:error, :already_submitted} ->
-        conn
-        |> put_status(403)
-        |> json(%{
-          "error" => true,
-          "message" =>
-            "These changes could not be saved as this attempt may have already been submitted"
-        })
-
       {:error, e} ->
         {_, msg} = Oli.Utils.log_error("Could not save activity", e)
         error(conn, 500, msg)
@@ -588,15 +570,6 @@ defmodule OliWeb.Api.AttemptController do
          ) do
       {:ok, evaluations} ->
         json(conn, %{"type" => "success", "actions" => evaluations})
-
-      {:error, :already_submitted} ->
-        conn
-        |> put_status(403)
-        |> json(%{
-          "error" => true,
-          "message" =>
-            "These changes could not be saved as this attempt may have already been submitted"
-        })
 
       {:error, message} ->
         {_, msg} = Oli.Utils.log_error("Could not submit activity", message)

--- a/test/oli_web/controllers/api/attempt_controller_test.exs
+++ b/test/oli_web/controllers/api/attempt_controller_test.exs
@@ -80,6 +80,7 @@ defmodule OliWeb.AttemptControllerTest do
   describe "activity and attempt already submitted" do
     setup [:setup_session]
 
+    @tag :skip
     test "cannot submit an already submitted activity in a graded page", %{
       conn: conn,
       map: map
@@ -113,6 +114,7 @@ defmodule OliWeb.AttemptControllerTest do
                json_response(conn, 403)
     end
 
+    @tag :skip
     test "cannot change an already input submitted in a graded page", %{
       conn: conn,
       map: map
@@ -150,6 +152,7 @@ defmodule OliWeb.AttemptControllerTest do
                json_response(conn, 403)
     end
 
+    @tag :skip
     test "cannot save an already part attempt submitted in a graded page", %{
       conn: conn,
       map: map
@@ -183,6 +186,7 @@ defmodule OliWeb.AttemptControllerTest do
                json_response(conn, 403)
     end
 
+    @tag :skip
     test "cannot submit an already submitted activity in a adaptive page", %{
       conn: conn,
       map: map
@@ -216,6 +220,7 @@ defmodule OliWeb.AttemptControllerTest do
                json_response(conn, 403)
     end
 
+    @tag :skip
     test "cannot change an already input submitted in a adaptive page", %{
       conn: conn,
       map: map
@@ -253,6 +258,7 @@ defmodule OliWeb.AttemptControllerTest do
                json_response(conn, 403)
     end
 
+    @tag :skip
     test "cannot save an already part attempt submitted in a adaptive page", %{
       conn: conn,
       map: map


### PR DESCRIPTION
[MER-3253](https://eliterate.atlassian.net/browse/MER-3253)

This PR roll back the changes made in [MER-3000](https://eliterate.atlassian.net/browse/MER-3000) and [MER-3153](https://eliterate.atlassian.net/browse/MER-3153), in order to ensure that adaptive pages do not break when browsing them.

I have skipped some tests, as they may be needed when we re-implement MER-3000 requirements.

[MER-3253]: https://eliterate.atlassian.net/browse/MER-3253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MER-3000]: https://eliterate.atlassian.net/browse/MER-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MER-3153]: https://eliterate.atlassian.net/browse/MER-3153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ