### PR TITLE
[NG23-187] Practice pages links lead to old page layout

### DIFF
--- a/lib/oli_web/components/delivery/deliberate_practice_card.ex
+++ b/lib/oli_web/components/delivery/deliberate_practice_card.ex
@@ -2,6 +2,7 @@ defmodule OliWeb.Components.Delivery.DeliberatePractice do
   use OliWeb, :html
 
   alias Oli.Rendering.Content
+  alias OliWeb.Delivery.Student.Utils
 
   attr :dark, :boolean, default: false
   attr :practice, :map
@@ -36,7 +37,9 @@ defmodule OliWeb.Components.Delivery.DeliberatePractice do
     if preview_mode do
       ~p"/sections/#{section_slug}/preview/page/#{practice.slug}"
     else
-      ~p"/sections/#{section_slug}/page/#{practice.slug}"
+      Utils.lesson_live_path(section_slug, practice.slug,
+        request_path: ~p"/sections/#{section_slug}/practice"
+      )
     end
   end
 

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -349,16 +349,9 @@ defmodule OliWeb.PageDeliveryController do
   end
 
   def page(conn, %{"section_slug" => section_slug, "revision_slug" => revision_slug}) do
-    user = conn.assigns.current_user
-    section = conn.assigns.section
-    datashop_session_id = Plug.Conn.get_session(conn, :datashop_session_id)
-
-    if Sections.is_enrolled?(user.id, section_slug) do
-      PageContext.create_for_visit(section, revision_slug, user, datashop_session_id)
-      |> render_page(conn, section_slug, false)
-    else
-      render(conn, "not_authorized.html")
-    end
+    # redirect request to old page view to the new lesson live view
+    conn
+    |> redirect(to: ~p"/sections/#{section_slug}/lesson/#{revision_slug}")
   end
 
   def render_content_html(

--- a/lib/oli_web/live/delivery/student/explorations_live.ex
+++ b/lib/oli_web/live/delivery/student/explorations_live.ex
@@ -1,9 +1,10 @@
 defmodule OliWeb.Delivery.Student.ExplorationsLive do
   use OliWeb, :live_view
 
-  alias OliWeb.Common.SessionContext
   alias Oli.Rendering.Content
   alias Oli.Delivery.Sections
+  alias OliWeb.Common.SessionContext
+  alias OliWeb.Delivery.Student.Utils
 
   def mount(_params, _session, socket) do
     explorations_by_container =
@@ -86,7 +87,9 @@ defmodule OliWeb.Delivery.Student.ExplorationsLive do
     if preview_mode do
       ~p"/sections/#{section_slug}/preview/page/#{exploration.slug}"
     else
-      ~p"/sections/#{section_slug}/lesson/#{exploration.slug}"
+      Utils.lesson_live_path(section_slug, exploration.slug,
+        request_path: ~p"/sections/#{section_slug}/explorations"
+      )
     end
   end
 

--- a/oli.example.env
+++ b/oli.example.env
@@ -1,4 +1,4 @@
-## default  administrator
+## default administrator
 ADMIN_EMAIL=admin@example.edu
 ADMIN_PASSWORD=changeme
 

--- a/oli.example.env
+++ b/oli.example.env
@@ -1,4 +1,4 @@
-## default administrator
+## default  administrator
 ADMIN_EMAIL=admin@example.edu
 ADMIN_PASSWORD=changeme
 

--- a/test/oli_web/controllers/legacy_superactivity_controller_test.exs
+++ b/test/oli_web/controllers/legacy_superactivity_controller_test.exs
@@ -35,7 +35,7 @@ defmodule OliWeb.LegacySuperactivityControllerTest do
 
       Activities.list_activity_registrations()
 
-      conn = get(conn, Routes.page_delivery_path(conn, :page, section.slug, page_revision.slug))
+      conn = get(conn, ~p"/sections/#{section.slug}/lesson/#{page_revision.slug}")
 
       activity_attempt = Attempts.get_activity_attempt_by(resource_id: activity_id)
 

--- a/test/oli_web/controllers/page_delivery_controller_test.exs
+++ b/test/oli_web/controllers/page_delivery_controller_test.exs
@@ -196,12 +196,13 @@ defmodule OliWeb.PageDeliveryControllerTest do
 
       conn =
         conn
-        |> get(Routes.page_delivery_path(conn, :page, section.slug, revision.slug))
+        |> get(~p"/sections/#{section.slug}/lesson/#{revision.slug}")
 
       assert html_response(conn, 200) =~ "Page one"
       assert html_response(conn, 200) =~ section.title
     end
 
+    @tag :skip
     test "shows the related exploration pages for a given page", %{
       conn: conn,
       user: user,
@@ -212,13 +213,14 @@ defmodule OliWeb.PageDeliveryControllerTest do
 
       conn =
         conn
-        |> get(Routes.page_delivery_path(conn, :page, section.slug, page_revision.slug))
+        |> get(~p"/sections/#{section.slug}/lesson/#{page_revision.slug}")
 
       assert html_response(conn, 200) =~ "exploration page 1"
       assert html_response(conn, 200) =~ "exploration page 2"
       assert html_response(conn, 200) =~ section.title
     end
 
+    @tag :skip
     test "shows a 'no exploration pages' message when the page doesn't have any related exploration pages",
          %{
            conn: conn,
@@ -230,12 +232,13 @@ defmodule OliWeb.PageDeliveryControllerTest do
 
       conn =
         conn
-        |> get(Routes.page_delivery_path(conn, :page, section.slug, ungraded_page_revision.slug))
+        |> get(~p"/sections/#{section.slug}/lesson/#{ungraded_page_revision.slug}")
 
       assert html_response(conn, 200) =~ "There are no explorations related to this page"
       assert html_response(conn, 200) =~ section.title
     end
 
+    @tag :skip
     test "handles student adaptive page access by an enrolled student", %{
       conn: conn,
       map: %{adaptive_page_revision: revision},
@@ -246,7 +249,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
 
       conn =
         conn
-        |> get(Routes.page_delivery_path(conn, :page, section.slug, revision.slug))
+        |> get(~p"/sections/#{section.slug}/lesson/#{revision.slug}")
 
       assert html_response(conn, 200) =~
                "<div data-react-class=\"Components.Delivery\" data-react-props=\""
@@ -259,7 +262,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
     } do
       conn =
         conn
-        |> get(Routes.page_delivery_path(conn, :page, section.slug, revision.slug))
+        |> get(~p"/sections/#{section.slug}/lesson/#{revision.slug}")
 
       assert html_response(conn, 302) =~ "You are being <a href=\"/unauthorized\">redirected</a>"
     end
@@ -343,6 +346,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert html_response(conn, 200) =~ section.title
     end
 
+    @tag :skip
     @tag isolation: "serializable"
     test "shows the prologue page on an assessment", %{
       user: user,
@@ -352,7 +356,9 @@ defmodule OliWeb.PageDeliveryControllerTest do
     } do
       enroll_as_student(%{section: section, user: user})
 
-      conn = get(conn, Routes.page_delivery_path(conn, :page, section.slug, page_revision.slug))
+      conn =
+        conn
+        |> get(~p"/sections/#{section.slug}/lesson/#{page_revision.slug}")
 
       assert html_response(conn, 200) =~ "When you are ready to begin, you may"
 
@@ -422,7 +428,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
 
       {:ok, conn: conn, ctx: session_context} = set_timezone(%{conn: conn})
 
-      conn = get(conn, Routes.page_delivery_path(conn, :page, section.slug, page_revision.slug))
+      conn = get(conn, ~p"/sections/#{section.slug}/lesson/#{page_revision.slug}")
 
       assert html_response(conn, 200) =~ "You have no attempts remaining out of 1 total attempt"
 
@@ -461,7 +467,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
     } do
       enroll_as_student(%{section: section, user: user})
 
-      conn = get(conn, Routes.page_delivery_path(conn, :page, section.slug, page_revision.slug))
+      conn = get(conn, ~p"/sections/#{section.slug}/lesson/#{page_revision.slug}")
 
       # now start the attempt
       conn =
@@ -518,7 +524,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       {:ok, section} = Sections.update_section(section, %{grade_passback_enabled: true})
       enroll_as_student(%{section: section, user: user})
 
-      conn = get(conn, Routes.page_delivery_path(conn, :page, section.slug, page_revision.slug))
+      conn = get(conn, ~p"/sections/#{section.slug}/lesson/#{page_revision.slug}")
 
       # now start the attempt
       conn =
@@ -565,6 +571,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert Oli.Delivery.Attempts.PageLifecycle.GradeUpdateWorker.get_jobs() |> length() == 1
     end
 
+    @tag :skip
     @tag isolation: "serializable"
     test "requires correct password to start an attempt", %{
       user: user,
@@ -577,7 +584,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       sr = Sections.get_section_resource(section.id, page_revision.resource_id)
       Sections.update_section_resource(sr, %{password: "password"})
 
-      conn = get(conn, Routes.page_delivery_path(conn, :page, section.slug, page_revision.slug))
+      conn = get(conn, ~p"/sections/#{section.slug}/lesson/#{page_revision.slug}")
 
       assert html_response(conn, 200) =~ "This assessment requires a password to begin"
 
@@ -637,6 +644,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert html_response(conn, 200) =~ "Submit Answers"
     end
 
+    @tag :skip
     test "renders custom license in footer for started page", %{
       conn: conn,
       user: user,
@@ -664,6 +672,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
              |> Floki.text() =~ "This is a custom license"
     end
 
+    @tag :skip
     test "renders :none license case in footer for started page", %{
       conn: conn,
       user: user,
@@ -691,6 +700,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
              |> Floki.text() =~ "Non-CC / Copyrighted / Other"
     end
 
+    @tag :skip
     test "renders custom license in footer for a not_started page -- prologue", %{
       conn: conn,
       user: user,
@@ -718,6 +728,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
              |> Floki.text() =~ "This is a custom license"
     end
 
+    @tag :skip
     test "renders creative commons license in footer for a not_started page -- prologue", %{
       conn: conn,
       user: user,
@@ -754,6 +765,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert Floki.find(license, "img") |> Floki.attribute("src") == ["/images/cc_logos/by.svg"]
     end
 
+    @tag :skip
     # This tests the edge case for when a student goes to a page that is available to start and the instructor changes the start date
     # to a future date simultaneously and before the student refreshes the page.
     # The student should be redirected back to the page and see a message that the page is not yet available when trying to start an attempt.
@@ -767,7 +779,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
 
       sr = Sections.get_section_resource(section.id, page_revision.resource_id)
 
-      conn = get(conn, Routes.page_delivery_path(conn, :page, section.slug, page_revision.slug))
+      conn = get(conn, ~p"/sections/#{section.slug}/lesson/#{page_revision.slug}")
 
       assert html_response(conn, 200) =~ "Start Attempt"
 
@@ -799,6 +811,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
                "This assessment is not yet available. It will be available on #{FormatDateTime.date(tomorrow, conn: conn, precision: :minutes)}."
     end
 
+    @tag :skip
     @tag isolation: "serializable"
     test "shows 'Start Attempt' button when start date has passed", %{
       user: user,
@@ -813,7 +826,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       tomorrow = DateTime.utc_now() |> DateTime.add(-1, :day)
       Sections.update_section_resource(sr, %{start_date: tomorrow})
 
-      conn = get(conn, Routes.page_delivery_path(conn, :page, section.slug, page_revision.slug))
+      conn = get(conn, ~p"/sections/#{section.slug}/lesson/#{page_revision.slug}")
 
       assert html_response(conn, 200) =~ "When you are ready to begin, you may"
 
@@ -842,6 +855,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert html_response(conn, 200) =~ "Submit Answers"
     end
 
+    @tag :skip
     test "does not show 'Start Attempt' button when start date has not passed yet", %{
       user: user,
       conn: conn,
@@ -855,7 +869,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       tomorrow = DateTime.utc_now() |> DateTime.add(1, :day)
       Sections.update_section_resource(sr, %{start_date: tomorrow})
 
-      conn = get(conn, Routes.page_delivery_path(conn, :page, section.slug, page_revision.slug))
+      conn = get(conn, ~p"/sections/#{section.slug}/lesson/#{page_revision.slug}")
       html_response = html_response(conn, 200)
 
       assert html_response =~
@@ -864,6 +878,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       refute html_response =~ "Start Attempt"
     end
 
+    @tag :skip
     @tag isolation: "serializable"
     test "changing a page from graded to ungraded allows the graded attempt to continue", %{
       map: map,
@@ -875,7 +890,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
     } do
       enroll_as_student(%{section: section, user: user})
 
-      conn = get(conn, Routes.page_delivery_path(conn, :page, section.slug, page_revision.slug))
+      conn = get(conn, ~p"/sections/#{section.slug}/lesson/#{page_revision.slug}")
 
       assert html_response(conn, 200) =~ "When you are ready to begin, you may"
 
@@ -944,7 +959,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
         recycle(conn)
         |> Pow.Plug.assign_current_user(user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
 
-      conn = get(conn, Routes.page_delivery_path(conn, :page, section.slug, page_revision.slug))
+      conn = get(conn, ~p"/sections/#{section.slug}/lesson/#{page_revision.slug}")
       assert html_response(conn, 200) =~ "Submit Answers"
 
       # Submit the assessment
@@ -972,11 +987,12 @@ defmodule OliWeb.PageDeliveryControllerTest do
         recycle(conn)
         |> Pow.Plug.assign_current_user(user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
 
-      conn = get(conn, Routes.page_delivery_path(conn, :page, section.slug, page_revision.slug))
+      conn = get(conn, ~p"/sections/#{section.slug}/lesson/#{page_revision.slug}")
       assert html_response(conn, 200) =~ "This is now ungraded"
       refute html_response(conn, 200) =~ "Submit Answers"
     end
 
+    @tag :skip
     @tag isolation: "serializable"
     test "changing a page from ungraded to graded shows the prologue even with an ungraded attempt present",
          %{
@@ -1016,7 +1032,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       Oli.Delivery.Sections.rebuild_section_resources(section: section, publication: pub)
 
       # Visit the page in its ungraded state, thus generating a resource attempt
-      conn = get(conn, Routes.page_delivery_path(conn, :page, section.slug, page_revision.slug))
+      conn = get(conn, ~p"/sections/#{section.slug}/lesson/#{page_revision.slug}")
       assert html_response(conn, 200) =~ "This is now ungraded"
       refute html_response(conn, 200) =~ "Submit Answers"
 
@@ -1052,7 +1068,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
         recycle(conn)
         |> Pow.Plug.assign_current_user(user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
 
-      conn = get(conn, Routes.page_delivery_path(conn, :page, section.slug, page_revision.slug))
+      conn = get(conn, ~p"/sections/#{section.slug}/lesson/#{page_revision.slug}")
       assert html_response(conn, 200) =~ "When you are ready to begin, you may"
 
       # now start the graded attempt
@@ -1080,6 +1096,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert html_response(conn, 200) =~ "Submit Answers"
     end
 
+    @tag :skip
     @tag isolation: "serializable"
     test "multiple requests to start attempt only results in single active attempt record", %{
       user: user,
@@ -1090,7 +1107,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       enroll_as_student(%{section: section, user: user})
 
       # visit the page verifying that we are presented with the prologue page
-      conn = get(conn, Routes.page_delivery_path(conn, :page, section.slug, page_revision.slug))
+      conn = get(conn, ~p"/sections/#{section.slug}/lesson/#{page_revision.slug}")
       assert html_response(conn, 200) =~ "When you are ready to begin, you may"
 
       effective_settings = Settings.get_combined_settings(page_revision, section.id, user.id)
@@ -1127,7 +1144,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
         recycle(conn)
         |> Pow.Plug.assign_current_user(user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
 
-      conn = get(conn, Routes.page_delivery_path(conn, :page, section.slug, page_revision.slug))
+      conn = get(conn, ~p"/sections/#{section.slug}/lesson/#{page_revision.slug}")
 
       assert html_response(conn, 200) =~ "Submit Answers"
 
@@ -1144,6 +1161,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
                Core.get_resource_attempt_history(page_revision.resource_id, section.slug, user.id)
     end
 
+    @tag :skip
     @tag isolation: "serializable"
     test "page with content breaks renders pagination controls", %{
       map: map,
@@ -1183,7 +1201,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
 
       enroll_as_student(%{section: section, user: user})
 
-      conn = get(conn, Routes.page_delivery_path(conn, :page, section.slug, page_revision.slug))
+      conn = get(conn, ~p"/sections/#{section.slug}/lesson/#{page_revision.slug}")
 
       assert html_response(conn, 200) =~ "When you are ready to begin, you may"
 
@@ -1216,6 +1234,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert html_response(conn, 200) =~ ~s|<div data-react-class="Components.PaginationControls"|
     end
 
+    @tag :skip
     @tag isolation: "serializable"
     test "page renders learning objectives in ungraded pages but not graded, except for review mode",
          %{
@@ -1228,7 +1247,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       enroll_as_student(%{section: section, user: user})
 
       conn =
-        get(conn, Routes.page_delivery_path(conn, :page, section.slug, graded_page_revision.slug))
+        get(conn, ~p"/sections/#{section.slug}/lesson/#{graded_page_revision.slug}")
 
       assert html_response(conn, 200) =~ "When you are ready to begin, you may"
 
@@ -1259,52 +1278,10 @@ defmodule OliWeb.PageDeliveryControllerTest do
       conn =
         recycle(conn)
         |> Pow.Plug.assign_current_user(user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
-        |> get(Routes.page_delivery_path(conn, :page, section.slug, ungraded_page_revision.slug))
+        |> get(~p"/sections/#{section.slug}/lesson/#{ungraded_page_revision.slug}")
 
       assert html_response(conn, 200) =~ "Learning Objectives"
       assert html_response(conn, 200) =~ "objective one"
-    end
-
-    test "page renders the collab space if configured",
-         %{
-           user: user,
-           conn: conn,
-           section: section,
-           collab_space_page_revision: page_revision
-         } do
-      enroll_as_student(%{section: section, user: user})
-
-      conn = get(conn, Routes.page_delivery_path(conn, :page, section.slug, page_revision.slug))
-
-      assert html_response(conn, 200) =~ "<h3 class=\"text-xl font-bold\">Page Discussion</h3>"
-    end
-
-    test "page does not render the collab space if it's not configured",
-         %{
-           user: user,
-           conn: conn,
-           section: section,
-           page_revision: page_revision
-         } do
-      enroll_as_student(%{section: section, user: user})
-
-      conn = get(conn, Routes.page_delivery_path(conn, :page, section.slug, page_revision.slug))
-
-      refute html_response(conn, 200) =~ "<h3 class=\"text-xl font-bold\">Discussion</h3>"
-    end
-
-    test "page does not render the collab space if it's disabled",
-         %{
-           user: user,
-           conn: conn,
-           section: section,
-           disabled_collab_space_page_revision: page_revision
-         } do
-      enroll_as_student(%{section: section, user: user})
-
-      conn = get(conn, Routes.page_delivery_path(conn, :page, section.slug, page_revision.slug))
-
-      refute html_response(conn, 200) =~ "<h3 class=\"text-xl font-bold\">Discussion</h3>"
     end
 
     @tag :skip
@@ -1353,6 +1330,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       refute html_response(conn, 200) =~ "A graded container?"
     end
 
+    @tag :skip
     test "shows page index based navigation", %{
       conn: conn,
       revision: revision,
@@ -1363,7 +1341,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
 
       conn =
         conn
-        |> get(Routes.page_delivery_path(conn, :page, section.slug, revision.slug))
+        |> get(~p"/sections/#{section.slug}/lesson/#{revision.slug}")
 
       assert html_response(conn, 200) =~ "id=\"top_page_navigator\""
       assert html_response(conn, 200) =~ "id=\"bottom_page_navigator\""
@@ -1406,12 +1384,13 @@ defmodule OliWeb.PageDeliveryControllerTest do
 
       conn =
         conn
-        |> get(Routes.page_delivery_path(conn, :page, section.slug, ungraded_page.revision.slug))
+        |> get(~p"/sections/#{section.slug}/lesson/#{ungraded_page.revision.slug}")
 
       assert html_response(conn, 200) =~ ungraded_page.revision.title
       refute html_response(conn, 200) =~ "<div id=\"countdown_timer_display\""
     end
 
+    @tag :skip
     @tag isolation: "serializable"
     test "timer will be shown it if revision is graded", %{
       conn: conn,
@@ -1449,7 +1428,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
 
       conn =
         conn
-        |> get(Routes.page_delivery_path(conn, :page, section.slug, page.revision.slug))
+        |> get(~p"/sections/#{section.slug}/lesson/#{page.revision.slug}")
 
       assert html_response(conn, 200) =~ page.revision.title
       assert html_response(conn, 200) =~ "<div id=\"countdown_timer_display\""
@@ -2110,6 +2089,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
                Routes.page_delivery_path(conn, :container, section.slug, unit_one_revision)
     end
 
+    @tag :skip
     test "page preview redirects ok", %{
       conn: conn,
       section: section,
@@ -2119,7 +2099,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
         get(conn, Routes.page_delivery_path(conn, :page_preview, section.slug, page_revision))
 
       assert redirected_to(conn) ==
-               Routes.page_delivery_path(conn, :page, section.slug, page_revision)
+               ~p"/sections/#{section.slug}/lesson/#{page_revision.slug}"
     end
   end
 
@@ -2820,7 +2800,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       conn =
         get(
           conn,
-          Routes.page_delivery_path(conn, :page, section.slug, page_with_audience_groups.slug)
+          ~p"/sections/#{section.slug}/lesson/#{page_with_audience_groups.slug}"
         )
 
       assert html_response(conn, 200) =~ "group content with unset audience"
@@ -2843,7 +2823,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       conn =
         get(
           conn,
-          Routes.page_delivery_path(conn, :page, section.slug, page_with_audience_groups.slug)
+          ~p"/sections/#{section.slug}/lesson/#{page_with_audience_groups.slug}"
         )
 
       assert html_response(conn, 200) =~ "group content with unset audience"

--- a/test/oli_web/live/collaboration_live_test.exs
+++ b/test/oli_web/live/collaboration_live_test.exs
@@ -276,23 +276,6 @@ defmodule OliWeb.CollaborationLiveTest do
     end
   end
 
-  describe "user cannot access collab space config when is logged in as a instructor but is not preview" do
-    setup [:user_conn, :create_project_and_section]
-
-    test "returns just the page when accessing the view", %{
-      conn: conn,
-      user: user,
-      section: section,
-      page_revision: page_revision
-    } do
-      enroll_user_to_section(user, section, :context_instructor)
-      ensure_user_visit(user, section)
-
-      conn = get(conn, Routes.page_delivery_path(conn, :page, section.slug, page_revision.slug))
-      refute html_response(conn, 200) =~ "<div class=\"card-title h5\">Collaborative Space</div>"
-    end
-  end
-
   describe "user cannot access when is logged in as an author but is not a system admin or author of the project" do
     setup [:author_conn, :create_project_and_section]
 

--- a/test/oli_web/live/delivery/student/explorations_live_test.exs
+++ b/test/oli_web/live/delivery/student/explorations_live_test.exs
@@ -154,7 +154,10 @@ defmodule OliWeb.Delivery.Student.ExplorationsLiveTest do
       |> element("div[id=exploration_card_#{exploration_1.id}] a", "Let's Begin")
       |> render_click()
 
-      assert_redirected(view, ~p"/sections/#{section.slug}/lesson/#{exploration_1.slug}")
+      assert_redirected(
+        view,
+        "/sections/#{section.slug}/lesson/#{exploration_1.slug}?request_path=%2Fsections%2F#{section.slug}%2Fexplorations"
+      )
 
       # the redirected page will show the prologue or go directly to the exploration
       # if there is an attempt in progress

--- a/test/oli_web/plugs/maybe_gated_resource_test.exs
+++ b/test/oli_web/plugs/maybe_gated_resource_test.exs
@@ -6,7 +6,6 @@ defmodule Oli.Plugs.MaybeGatedResourceTest do
   alias Oli.Seeder
   alias Oli.Delivery.Attempts.Core
   alias Lti_1p3.Tool.ContextRoles
-  alias OliWeb.Router.Helpers, as: Routes
 
   def insert_resource_attempt(resource_access, revision_id, attrs) do
     Core.create_resource_attempt(
@@ -62,7 +61,7 @@ defmodule Oli.Plugs.MaybeGatedResourceTest do
 
       conn =
         conn
-        |> get(Routes.page_delivery_path(conn, :page, section.slug, revision.slug))
+        |> get(~p"/sections/#{section.slug}/lesson/#{revision.slug}")
 
       assert html_response(conn, 200) =~ "Page one"
     end
@@ -86,7 +85,7 @@ defmodule Oli.Plugs.MaybeGatedResourceTest do
 
       conn =
         conn
-        |> get(Routes.page_delivery_path(conn, :page, section.slug, revision.slug))
+        |> get(~p"/sections/#{section.slug}/lesson/#{revision.slug}")
 
       assert html_response(conn, 403) =~
                "You are trying to access a resource that is gated by the following condition"
@@ -118,7 +117,7 @@ defmodule Oli.Plugs.MaybeGatedResourceTest do
 
       conn =
         conn
-        |> get(Routes.page_delivery_path(conn, :page, section.slug, revision.slug))
+        |> get(~p"/sections/#{section.slug}/lesson/#{revision.slug}")
 
       assert html_response(conn, 403) =~
                "You are trying to access a resource that is gated by the following condition"
@@ -159,7 +158,7 @@ defmodule Oli.Plugs.MaybeGatedResourceTest do
 
       conn =
         conn
-        |> get(Routes.page_delivery_path(conn, :page, section.slug, revision.slug))
+        |> get(~p"/sections/#{section.slug}/lesson/#{revision.slug}")
 
       assert html_response(conn, 403) =~
                "You are trying to access a resource that is gated by the following condition"
@@ -191,7 +190,7 @@ defmodule Oli.Plugs.MaybeGatedResourceTest do
 
       conn =
         conn
-        |> get(Routes.page_delivery_path(conn, :page, section.slug, revision.slug))
+        |> get(~p"/sections/#{section.slug}/lesson/#{revision.slug}")
 
       assert html_response(conn, 403) =~
                "You are trying to access a resource that is gated by the following condition"
@@ -237,10 +236,9 @@ defmodule Oli.Plugs.MaybeGatedResourceTest do
 
       conn =
         conn
-        |> get(Routes.page_delivery_path(conn, :page, section.slug, revision.slug))
+        |> get(~p"/sections/#{section.slug}/lesson/#{revision.slug}")
 
-      assert html_response(conn, 200) =~ "Attempt 1 of 2"
-      assert html_response(conn, 200) =~ "Page one is scheduled to end"
+      assert html_response(conn, 200) =~ "Attempts 1/2"
     end
 
     test "allows student to resume an active attempt with :allows_review policy and active attempt present",
@@ -275,7 +273,7 @@ defmodule Oli.Plugs.MaybeGatedResourceTest do
 
       conn =
         conn
-        |> get(Routes.page_delivery_path(conn, :page, section.slug, revision.slug))
+        |> get(~p"/sections/#{section.slug}/lesson/#{revision.slug}")
 
       assert html_response(conn, 200) =~ "Page one"
     end


### PR DESCRIPTION
Changes the links in the Deliberate Practice view to link to the new lesson LiveView, as opposed to the old page delivery view.

Also updates the page_delivery_controller `:page` route to redirect to the new lesson live view and fixes tests where it makes sense and skips other now obsolete tests.

A followup task to reconcile these obsolete tests with tests in the new lesson liveview has been created https://eliterate.atlassian.net/browse/NG23-195