### PR TITLE
[BUG FIX] [NG23-160] Lesson does not launch when clicking begin attempt

### DIFF
--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -511,6 +511,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
   def spinner(assigns) do
     ~H"""
     <svg
+      role="spinner"
       aria-hidden="true"
       class={[
         "w-8 h-8 text-gray-200 animate-spin dark:text-gray-600 fill-blue-600",

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -20,7 +20,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
 
   require Logger
 
-  on_mount {OliWeb.LiveSessionPlugs.InitPage, :page_context}
+  on_mount {OliWeb.LiveSessionPlugs.InitPage, :init_context_state}
   on_mount {OliWeb.LiveSessionPlugs.InitPage, :previous_next_index}
 
   def mount(_params, _session, %{assigns: %{view: :practice_page}} = socket) do
@@ -952,7 +952,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
         )
       }
       class={[
-        "cursor-pointer px-5 py-2.5 hover:bg-opacity-40 bg-blue-600 rounded-[3px] shadow justify-center items-center gap-2.5 inline-flex text-white text-sm font-normal font-['Open Sans'] leading-tight",
+        "mb-24 cursor-pointer px-5 py-2.5 hover:bg-opacity-40 bg-blue-600 rounded-[3px] shadow justify-center items-center gap-2.5 inline-flex text-white text-sm font-normal font-['Open Sans'] leading-tight",
         if(!@allow_attempt?, do: "opacity-50 dark:opacity-20 disabled !cursor-not-allowed")
       ]}
     >

--- a/lib/oli_web/live/delivery/student/review_live.ex
+++ b/lib/oli_web/live/delivery/student/review_live.ex
@@ -1,7 +1,7 @@
 defmodule OliWeb.Delivery.Student.ReviewLive do
   use OliWeb, :live_view
 
-  on_mount {OliWeb.LiveSessionPlugs.InitPage, :page_context}
+  on_mount {OliWeb.LiveSessionPlugs.InitPage, :init_context_state}
   on_mount {OliWeb.LiveSessionPlugs.InitPage, :previous_next_index}
 
   import OliWeb.Delivery.Student.Utils,

--- a/lib/oli_web/live_session_plugs/init_page.ex
+++ b/lib/oli_web/live_session_plugs/init_page.ex
@@ -153,10 +153,9 @@ defmodule OliWeb.LiveSessionPlugs.InitPage do
   defp init_context_state(
          %{
            assigns: %{
-             page_context:
-               %PageContext{
-                 page: %{graded: false}
-               } = page_context
+             page_context: %PageContext{
+               page: %{graded: false}
+             }
            }
          } =
            socket
@@ -180,7 +179,7 @@ defmodule OliWeb.LiveSessionPlugs.InitPage do
   defp init_context_state(
          %{
            assigns: %{
-             page_context: %PageContext{progress_state: :error} = page_context
+             page_context: %PageContext{progress_state: :error}
            }
          } =
            socket

--- a/lib/oli_web/live_session_plugs/init_page.ex
+++ b/lib/oli_web/live_session_plugs/init_page.ex
@@ -7,6 +7,26 @@ defmodule OliWeb.LiveSessionPlugs.InitPage do
   alias Oli.Delivery.Page.PageContext
   alias OliWeb.Router.Helpers, as: Routes
 
+  def on_mount(:set_page_context, :not_mounted_at_router, _session, socket) do
+    {:cont, socket}
+  end
+
+  def on_mount(:set_page_context, %{"revision_slug" => revision_slug}, _session, socket) do
+    %{section: section, current_user: current_user, datashop_session_id: datashop_session_id} =
+      socket.assigns
+
+    {:cont,
+     assign(socket,
+       page_context:
+         PageContext.create_for_visit(
+           section,
+           revision_slug,
+           current_user,
+           datashop_session_id
+         )
+     )}
+  end
+
   def on_mount(
         :previous_next_index,
         _params,
@@ -43,36 +63,32 @@ defmodule OliWeb.LiveSessionPlugs.InitPage do
   end
 
   def on_mount(
-        :page_context,
-        %{"revision_slug" => revision_slug},
+        :init_context_state,
+        _params,
         _session,
-        %{assigns: assigns} = socket
+        socket
       ) do
-    socket =
-      PageContext.create_for_visit(
-        assigns.section,
-        revision_slug,
-        assigns.current_user,
-        assigns.datashop_session_id
-      )
-      |> init_context_state(socket)
-
-    {:cont, socket}
+    {:cont, init_context_state(socket)}
   end
 
   # Handles the 2 cases of adaptive delivery
   #  1. A fullscreen chromeless version
   #  2. A version inside the torus navigation with an iframe pointing to #1
   defp init_context_state(
-         %PageContext{
-           page: %{
-             content:
-               %{
-                 "advancedDelivery" => true
-               } = content
+         %{
+           assigns: %{
+             page_context:
+               %PageContext{
+                 page: %{
+                   content:
+                     %{
+                       "advancedDelivery" => true
+                     } = content
+                 }
+               } = page_context
            }
-         } = page_context,
-         socket
+         } =
+           socket
        ) do
     view =
       if Map.get(content, "displayApplicationChrome", false) do
@@ -135,36 +151,41 @@ defmodule OliWeb.LiveSessionPlugs.InitPage do
 
   # Display practice pages
   defp init_context_state(
-         %PageContext{
-           page: %{graded: false}
-         } = page_context,
-         socket
+         %{
+           assigns: %{
+             page_context:
+               %PageContext{
+                 page: %{graded: false}
+               } = page_context
+           }
+         } =
+           socket
        ) do
-    assign(socket, %{
-      view: :practice_page,
-      page_context: page_context
-    })
+    assign(socket, %{view: :practice_page})
   end
 
   # Display the prologue view for graded pages
   defp init_context_state(
-         %PageContext{page: %{graded: true}} = page_context,
-         socket
+         %{
+           assigns: %{
+             page_context: %PageContext{page: %{graded: true}} = page_context
+           }
+         } =
+           socket
        ) do
-    assign(socket, %{
-      view: :graded_page
-    })
+    assign(socket, %{view: :graded_page})
     |> prologue_assigns(page_context)
   end
 
   defp init_context_state(
-         %PageContext{progress_state: :error} = page_context,
-         socket
+         %{
+           assigns: %{
+             page_context: %PageContext{progress_state: :error} = page_context
+           }
+         } =
+           socket
        ) do
-    assign(socket, %{
-      view: :error,
-      page_context: page_context
-    })
+    assign(socket, %{view: :error})
   end
 
   defp plural(1), do: ""

--- a/lib/oli_web/live_session_plugs/redirect_adaptive.ex
+++ b/lib/oli_web/live_session_plugs/redirect_adaptive.ex
@@ -1,9 +1,15 @@
 defmodule OliWeb.LiveSessionPlugs.RedirectAdaptiveChromeless do
+  @moduledoc """
+  Redirects the student to the adaptive chromeless url when the required adaptive chromeless page has :in_progress state.
+  Other casees are handled by the default live view (the prologue view where student can review previous attempts)
+  """
+
   use OliWeb, :verified_routes
 
   import Phoenix.LiveView, only: [redirect: 2]
   import Ecto.Query, only: [from: 2]
 
+  alias Oli.Delivery.Page.PageContext
   alias Oli.Repo
 
   def on_mount(
@@ -39,17 +45,27 @@ defmodule OliWeb.LiveSessionPlugs.RedirectAdaptiveChromeless do
         _session,
         socket
       ) do
-    if is_adaptive_chromeless_view?(revision_slug) do
-      {:halt,
-       redirect(socket,
-         to:
-           adaptive_chromeless_url(section_slug, revision_slug,
-             request_path: params["request_path"],
-             selected_view: params["selected_view"]
-           )
-       )}
-    else
-      {:cont, socket}
+    case socket.assigns.page_context do
+      %PageContext{
+        page: %{
+          content: %{
+            "advancedDelivery" => true,
+            "displayApplicationChrome" => false
+          }
+        },
+        progress_state: :in_progress
+      } ->
+        {:halt,
+         redirect(socket,
+           to:
+             adaptive_chromeless_url(section_slug, revision_slug,
+               request_path: params["request_path"],
+               selected_view: params["selected_view"]
+             )
+         )}
+
+      _ ->
+        {:cont, socket}
     end
   end
 

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -979,9 +979,10 @@ defmodule OliWeb.Router do
           root_layout: {OliWeb.LayoutView, :delivery},
           layout: {OliWeb.Layouts, :student_delivery_lesson},
           on_mount: [
-            OliWeb.LiveSessionPlugs.RedirectAdaptiveChromeless,
             OliWeb.LiveSessionPlugs.SetUser,
             OliWeb.LiveSessionPlugs.SetSection,
+            {OliWeb.LiveSessionPlugs.InitPage, :set_page_context},
+            OliWeb.LiveSessionPlugs.RedirectAdaptiveChromeless,
             OliWeb.LiveSessionPlugs.SetBrand,
             OliWeb.LiveSessionPlugs.SetPreviewMode,
             OliWeb.LiveSessionPlugs.RequireEnrollment,
@@ -999,6 +1000,7 @@ defmodule OliWeb.Router do
           on_mount: [
             OliWeb.LiveSessionPlugs.SetUser,
             OliWeb.LiveSessionPlugs.SetSection,
+            {OliWeb.LiveSessionPlugs.InitPage, :set_page_context},
             OliWeb.LiveSessionPlugs.SetBrand,
             OliWeb.LiveSessionPlugs.SetPreviewMode,
             OliWeb.LiveSessionPlugs.RequireEnrollment,

--- a/test/oli_web/live_session_plugs/redirect_adaptive_test.exs
+++ b/test/oli_web/live_session_plugs/redirect_adaptive_test.exs
@@ -10,10 +10,10 @@ defmodule OliWeb.LiveSessionPlugs.RedirectAdaptiveChromelessTest do
       resource_type_id: ResourceType.get_id_by_type("page"),
       graded: true,
       content: %{
-        model: [],
-        advancedDelivery: true,
-        displayApplicationChrome: false,
-        additionalStylesheets: [
+        "model" => [],
+        "advancedDelivery" => true,
+        "displayApplicationChrome" => false,
+        "additionalStylesheets" => [
           "/css/delivery_adaptive_themes_default_light.css"
         ]
       }
@@ -47,7 +47,15 @@ defmodule OliWeb.LiveSessionPlugs.RedirectAdaptiveChromelessTest do
           "selected_view" => "gallery"
         },
         %{},
-        %Phoenix.LiveView.Socket{}
+        %Phoenix.LiveView.Socket{
+          assigns: %{
+            page_context:
+              build(:page_context,
+                page: adaptive_chromeless_page_revision,
+                progress_state: :in_progress
+              )
+          }
+        }
       )
 
     assert updated_socket.redirected ==
@@ -58,7 +66,7 @@ defmodule OliWeb.LiveSessionPlugs.RedirectAdaptiveChromelessTest do
               }}
   end
 
-  test "redirects an adaptive chromeless page" do
+  test "redirects an adaptive chromeless page with an attempt in progress" do
     adaptive_chromeless_page_revision = adaptive_chromeless_page_revision()
 
     {:halt, updated_socket} =
@@ -71,7 +79,15 @@ defmodule OliWeb.LiveSessionPlugs.RedirectAdaptiveChromelessTest do
           "selected_view" => "gallery"
         },
         %{},
-        %Phoenix.LiveView.Socket{}
+        %Phoenix.LiveView.Socket{
+          assigns: %{
+            page_context:
+              build(:page_context,
+                page: adaptive_chromeless_page_revision,
+                progress_state: :in_progress
+              )
+          }
+        }
       )
 
     assert updated_socket.redirected ==
@@ -94,7 +110,15 @@ defmodule OliWeb.LiveSessionPlugs.RedirectAdaptiveChromelessTest do
           "attempt_guid" => "some-attempt-guid"
         },
         %{},
-        %Phoenix.LiveView.Socket{}
+        %Phoenix.LiveView.Socket{
+          assigns: %{
+            page_context:
+              build(:page_context,
+                page: non_adaptive_chromeless_page_revision,
+                progress_state: :in_progress
+              )
+          }
+        }
       )
 
     refute updated_socket.redirected
@@ -111,7 +135,40 @@ defmodule OliWeb.LiveSessionPlugs.RedirectAdaptiveChromelessTest do
           "revision_slug" => non_adaptive_chromeless_page_revision.slug
         },
         %{},
-        %Phoenix.LiveView.Socket{}
+        %Phoenix.LiveView.Socket{
+          assigns: %{
+            page_context:
+              build(:page_context,
+                page: non_adaptive_chromeless_page_revision,
+                progress_state: :in_progress
+              )
+          }
+        }
+      )
+
+    refute updated_socket.redirected
+  end
+
+  test "does not redirect an adaptive chromeless page with state not in progress" do
+    adaptive_chromeless_page_revision = adaptive_chromeless_page_revision()
+
+    {:cont, updated_socket} =
+      RedirectAdaptiveChromeless.on_mount(
+        :default,
+        %{
+          "section_slug" => "some-section-slug",
+          "revision_slug" => adaptive_chromeless_page_revision.slug
+        },
+        %{},
+        %Phoenix.LiveView.Socket{
+          assigns: %{
+            page_context:
+              build(:page_context,
+                page: adaptive_chromeless_page_revision,
+                progress_state: :not_started
+              )
+          }
+        }
       )
 
     refute updated_socket.redirected

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -14,6 +14,7 @@ defmodule Oli.Factory do
   }
 
   alias Oli.Branding.Brand
+  alias Oli.Delivery.Page.PageContext
   alias Oli.Delivery.Sections.ContainedObjective
 
   alias Oli.Delivery.Attempts.Core.{
@@ -45,7 +46,7 @@ defmodule Oli.Factory do
   alias Oli.Notifications.SystemMessage
   alias Oli.Publishing.{PublishedResource}
   alias Oli.Publishing.Publications.Publication
-  alias Oli.Resources.{Resource, Revision}
+  alias Oli.Resources.{Resource, ResourceType, Revision}
   alias Oli.Resources.Collaboration.{CollabSpaceConfig, Post, PostContent, UserReactionPost}
   alias Oli.Search.RevisionEmbedding
 
@@ -629,6 +630,25 @@ defmodule Oli.Factory do
     %ProjectAttributes.License{
       license_type: :none,
       custom_license_details: ""
+    }
+  end
+
+  def page_context_factory() do
+    %PageContext{
+      user: build(:user),
+      review_mode: false,
+      page: build(:revision, resource_type_id: ResourceType.get_id_by_type("page")),
+      progress_state: :in_progress,
+      resource_attempts: [build(:resource_attempt)],
+      activities: [],
+      objectives: [],
+      latest_attempts: [],
+      bib_revisions: [],
+      historical_attempts: [],
+      collab_space_config: build(:collab_space_config),
+      is_instructor: false,
+      is_student: true,
+      effective_settings: %Oli.Delivery.Settings.Combined{}
     }
   end
 


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/NG23-160) to the ticket

#### Bug root cause
The problem was that adaptive pages with no attempts in progress were redirected by the `RedirectAdaptiveChromeless` live session plug to another prologue view that was not correctly handling LiveView events (for instance, the "begin_attempt" event, or even the user menu interaction).

#### Solution
I split the `init_page` live_session plug and refactored the `RedirectAdaptiveChromeless` one to only redirect to the adaptive pages route when the attempt is in progress. All other page progress states are not redirected, so the student ends up seeing the "common" prologue page (the same that is used for graded pages that handles LiveView events correctly). 


##### Other fixes
Besides handling LiveView events correctly, now the prologue page for adaptive chromeless pages inherits the correct .css file, so we get the correct styling (even in dark mode).
Finally, a bottom margin was added to allow the user to see the "Begin Attempt" button that used to be covered by the bottom navigation bar when the page had many historical attempts.

#### Before

https://github.com/Simon-Initiative/oli-torus/assets/74839302/9879cb56-10fd-48a0-8426-5f9fa3f16a2f

#### After

https://github.com/Simon-Initiative/oli-torus/assets/74839302/10fbef45-3058-4037-b91e-c49a179210a4


#### Flaky Test validation
No flaky tests were introduced
![Screenshot 2024-05-15 at 3 57 49 PM](https://github.com/Simon-Initiative/oli-torus/assets/74839302/bb37ab9b-3c98-4757-985c-c466e7961c9f)

![Screenshot 2024-05-15 at 4 01 33 PM](https://github.com/Simon-Initiative/oli-torus/assets/74839302/6041874c-a55b-47aa-8721-580a71160c42)

