### PR TITLE
[ENHANCEMENT] [NG23-183] soften the colors to increase contrast and readability in light mode

### DIFF
--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -180,7 +180,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
       role="toggle sidebar"
       phx-click={JS.patch(path_for(@active_tab, @section, @preview_mode, !@sidebar_expanded))}
       title={if @sidebar_expanded, do: "Minimize", else: "Expand"}
-      class="flex items-center justify-center ml-auto w-6 h-6 bg-gray-400 dark:bg-neutral-800 rounded-tl-[52px] rounded-bl-[52px] stroke-black/70 hover:stroke-black/90 dark:stroke-[#B8B4BF] hover:dark:stroke-white"
+      class="flex items-center justify-center ml-auto w-6 h-6 bg-zinc-400 bg-opacity-20 hover:bg-opacity-40 rounded-tl-[52px] rounded-bl-[52px] stroke-black/70 hover:stroke-black/90 dark:stroke-[#B8B4BF] hover:dark:stroke-white"
     >
       <div class={if !@sidebar_expanded, do: "rotate-180"}>
         <Icons.left_chevron />
@@ -352,12 +352,14 @@ defmodule OliWeb.Components.Delivery.Layouts do
       class={["w-full h-11 flex-col justify-center items-center flex hover:no-underline"]}
     >
       <div class={[
-        "w-full h-9 px-3 py-3 hover:bg-gray-300 hover:dark:bg-neutral-800/60 rounded-lg justify-start items-center gap-3 inline-flex",
+        "w-full h-9 px-3 py-3 hover:bg-zinc-400 hover:bg-opacity-40 rounded-lg justify-start items-center gap-3 inline-flex",
         if(@is_active,
-          do: "bg-gray-400 hover:!bg-gray-400 dark:bg-neutral-800 hover:dark:!bg-neutral-800"
+          do: "bg-zinc-400 bg-opacity-20"
         )
       ]}>
-        <div class="w-5 h-5 flex items-center justify-center"><%= render_slot(@icon) %></div>
+        <div class="w-5 h-5 flex items-center justify-center">
+          <%= render_slot(@icon) %>
+        </div>
         <div
           :if={@sidebar_expanded}
           class={[
@@ -419,7 +421,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
       navigate={~p"/sections"}
       class="w-full h-11 flex-col justify-center items-center flex hover:no-underline text-black/70 hover:text-black/90 dark:text-gray-400 hover:dark:text-white stroke-black/70 hover:stroke-black/90 dark:stroke-[#B8B4BF] hover:dark:stroke-white"
     >
-      <div class="w-full h-9 px-3 py-3 bg-gray-400 dark:bg-neutral-800 rounded-lg justify-start items-center gap-3 inline-flex">
+      <div class="w-full h-9 px-3 py-3 bg-zinc-400 bg-opacity-20 hover:bg-opacity-40 rounded-lg justify-start items-center gap-3 inline-flex">
         <div class="w-5 h-5 flex items-center justify-center"><Icons.exit /></div>
         <div :if={@sidebar_expanded} class="text-sm font-medium tracking-tight">
           Exit Course

--- a/lib/oli_web/live/delivery/student/index_live.ex
+++ b/lib/oli_web/live/delivery/student/index_live.ex
@@ -82,7 +82,7 @@ defmodule OliWeb.Delivery.Student.IndexLive do
       <div class="w-full absolute p-8 justify-start items-start gap-6 inline-flex">
         <.course_progress has_visited_section={@has_visited_section} progress={@section_progress} />
         <div class="w-3/4 h-full flex-col justify-start items-start gap-6 inline-flex">
-          <div class="w-full h-fit overflow-y-auto p-6 bg-zinc-900 bg-opacity-20 dark:bg-opacity-100 rounded-2xl justify-start items-start gap-32 inline-flex">
+          <div class="w-full h-fit overflow-y-auto p-6 bg-zinc-400 bg-opacity-20 rounded-2xl justify-start items-start gap-32 inline-flex">
             <div class="flex-col justify-start items-start gap-7 inline-flex grow">
               <div class="justify-start items-start gap-2.5 inline-flex">
                 <div class="text-2xl font-bold leading-loose tracking-tight">
@@ -296,7 +296,7 @@ defmodule OliWeb.Delivery.Student.IndexLive do
   defp course_progress(assigns) do
     ~H"""
     <div class="w-1/4 h-48 flex-col justify-start items-start gap-6 inline-flex">
-      <div class="w-full h-96 p-6 bg-zinc-900 bg-opacity-20 dark:bg-opacity-100 rounded-2xl justify-start items-start gap-32 inline-flex">
+      <div class="w-full h-96 p-6 bg-zinc-400 bg-opacity-20 rounded-2xl justify-start items-start gap-32 inline-flex">
         <div class="flex-col justify-start items-start gap-5 inline-flex grow">
           <div class="justify-start items-start gap-2.5 inline-flex">
             <div class="text-2xl font-bold leading-loose tracking-tight">


### PR DESCRIPTION
This PR softens the colors to increase contrast and readability in light mode.

**Before:**
<img width="1582" alt="Screenshot 2024-05-15 at 4 21 44 PM" src="https://github.com/Simon-Initiative/oli-torus/assets/6248894/56bf1e10-1eca-4230-afe6-ee551f25360a">

**After:**
<img width="1578" alt="Screenshot 2024-05-15 at 4 30 42 PM" src="https://github.com/Simon-Initiative/oli-torus/assets/6248894/080613e8-f277-4d5a-8408-e7b11ed36f3e">

**Before:**
<img width="1582" alt="Screenshot 2024-05-15 at 4 21 17 PM" src="https://github.com/Simon-Initiative/oli-torus/assets/6248894/18f3b25b-2f24-40c7-a48b-f02d41c59949">

**After:**
<img width="1578" alt="Screenshot 2024-05-15 at 4 30 33 PM" src="https://github.com/Simon-Initiative/oli-torus/assets/6248894/76cb16a7-a29a-4f22-857b-f80b97cda751">
