### PR TITLE
[FEATURE] [NG23-201] Remove the intro and LO pop-up for modules

### DIFF
--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -1373,9 +1373,10 @@ defmodule OliWeb.Delivery.Student.LearnLive do
       <button
         :if={@module["learning_objectives"] != []}
         role="module learning objectives"
-        class="flex items-center gap-[14px] px-[10px] w-full p-1 cursor-pointer"
+        class="hidden items-center gap-[14px] px-[10px] w-full p-1 cursor-pointer"
         phx-click={JS.toggle(to: "#learning_objectives_#{@module["resource_id"]}", display: "flex")}
       >
+        <%!-- This button was hidden in ticket NG-201 but will be reactivated with NG23-199 --%>
         <Icons.learning_objectives class="fill-black dark:fill-white" />
         <h3 class="text-[16px] leading-[22px] font-semibold dark:text-white">
           Introduction and Learning Objectives

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -1167,6 +1167,8 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
              )
     end
 
+    @tag :skip
+    # This feature was disabled in ticket NG-201 but will be reactivated with NG23-199
     test "can see module learning objectives (if any) in the tooltip", %{
       conn: conn,
       section: section


### PR DESCRIPTION
Link to the ticket

#### Before

https://github.com/Simon-Initiative/oli-torus/assets/74839302/5bb8dc14-3ec9-4b3d-8bfc-3472f630b958



#### After

https://github.com/Simon-Initiative/oli-torus/assets/74839302/59f68c80-c825-4211-a6ff-9b0f4de260f4

