### PR TITLE
[FEATURE] [MER-3219] Allow page progress trigger practice gating

### DIFF
--- a/lib/oli/delivery/gating/condition_types.ex
+++ b/lib/oli/delivery/gating/condition_types.ex
@@ -8,7 +8,8 @@ defmodule Oli.Delivery.Gating.ConditionTypes do
       {"Schedule", Oli.Delivery.Gating.ConditionTypes.Schedule},
       {"AlwaysOpen", Oli.Delivery.Gating.ConditionTypes.AlwaysOpen},
       {"Started", Oli.Delivery.Gating.ConditionTypes.Started},
-      {"Finished", Oli.Delivery.Gating.ConditionTypes.Finished}
+      {"Finished", Oli.Delivery.Gating.ConditionTypes.Finished},
+      {"Progress", Oli.Delivery.Gating.ConditionTypes.Progress}
     ]
   end
 end

--- a/lib/oli/delivery/gating/condition_types/progress.ex
+++ b/lib/oli/delivery/gating/condition_types/progress.ex
@@ -1,0 +1,74 @@
+defmodule Oli.Delivery.Gating.ConditionTypes.Progress do
+  @moduledoc """
+  The progress strategy provides a condition that requires a practice page type source resource to have a
+  certain percentage of progress in its content.
+  """
+
+  alias Oli.Delivery.Gating.GatingCondition
+  alias Oli.Delivery.Gating.GatingConditionData
+  alias Oli.Delivery.Gating.ConditionTypes.ConditionContext
+  alias Oli.Delivery.Sections
+  alias Oli.Publishing.DeliveryResolver
+
+  @behaviour Oli.Delivery.Gating.ConditionTypes.ConditionType
+
+  def type do
+    :progress
+  end
+
+  def evaluate(
+        %GatingCondition{
+          data: %GatingConditionData{
+            resource_id: resource_id,
+            minimum_percentage: minimum_percentage
+          }
+        },
+        %ConditionContext{} = context
+      ) do
+    {resource_accesses, context} = ConditionContext.resource_accesses(context)
+
+    result =
+      case Map.get(resource_accesses, resource_id) do
+        nil ->
+          false
+
+        %{resource_attempts_count: 0} ->
+          false
+
+        %{progress: progress} ->
+          case minimum_percentage do
+            nil -> true
+            min -> progress >= min
+          end
+      end
+
+    {result, context}
+  end
+
+  def details(
+        %GatingCondition{
+          section_id: section_id,
+          resource_id: resource_id,
+          data: %GatingConditionData{
+            resource_id: source_id,
+            minimum_percentage: minimum_percentage
+          }
+        },
+        _ \\ []
+      ) do
+    section = Sections.get_section!(section_id)
+
+    [revision, revision_source] =
+      DeliveryResolver.from_resource_id(section.slug, [resource_id, source_id])
+
+    case minimum_percentage do
+      nil ->
+        "#{revision.title} cannot be accessed until #{revision_source.title} is completed"
+
+      min ->
+        {percentage, _} = (min * 100) |> Float.to_string() |> Integer.parse()
+
+        "#{revision.title} cannot be accessed until #{percentage}% of #{revision_source.title} activities have been completed"
+    end
+  end
+end

--- a/lib/oli/delivery/gating/gating_condition.ex
+++ b/lib/oli/delivery/gating/gating_condition.ex
@@ -18,7 +18,8 @@ defmodule Oli.Delivery.Gating.GatingCondition do
         :schedule,
         :always_open,
         :started,
-        :finished
+        :finished,
+        :progress
       ]
 
     # The ways in which this gate affects access to graded resources

--- a/lib/oli_web/live/sections/gating_and_scheduling/form.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling/form.ex
@@ -381,6 +381,50 @@ defmodule OliWeb.Sections.GatingAndScheduling.Form do
     """
   end
 
+  def render_condition_options(%{gating_condition: %{type: :progress}} = assigns) do
+    assigns = assign(assigns, :data, assigns.gating_condition.data)
+
+    ~H"""
+    <div class="form-group">
+      <label for="source">Resource That Must Has Progress</label>
+      <div class="input-group mb-3">
+        <input
+          type="text"
+          id="source"
+          readonly
+          class="form-control"
+          placeholder="Select a source resource..."
+          aria-label="resource-title"
+          aria-describedby="basic-addon2"
+          phx-click="show-ungraded-picker"
+          {maybe_source_value(assigns)}
+        />
+        <div class="input-group-append">
+          <button class="btn btn-outline-primary" type="button" phx-click="show-ungraded-picker">
+            Select
+          </button>
+        </div>
+      </div>
+    </div>
+    <div class="flex flex-row items-center w-full gap-x-2 mb-4 mt-2">
+      <div class="sm:col-span-2 w-full">
+        <input
+          type="number"
+          class="form-control"
+          id="min-score-value"
+          disabled={assigns.gating_condition.data[:resource_id] == nil}
+          min="0"
+          max="100"
+          value={value_from_min_score(@data)}
+          phx-hook="TextInputListener"
+          phx-value-change="change_min_score"
+        />
+      </div>
+      <label for="min-score-value" class="sm:col-span-1 col-form-label">%</label>
+    </div>
+    """
+  end
+
   def render_condition_options(%{gating_condition: %{type: :always_open}} = assigns) do
     ~H"""
     <div class="alert alert-secondary" role="alert">

--- a/lib/oli_web/live/sections/gating_and_scheduling/table_model.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling/table_model.ex
@@ -171,6 +171,37 @@ defmodule OliWeb.Delivery.Sections.GatingAndScheduling.TableModel do
   end
 
   def render_details_column(
+        %{ctx: _} = assigns,
+        %GatingCondition{
+          type: :progress,
+          data: %GatingConditionData{
+            minimum_percentage: nil
+          }
+        },
+        _
+      ) do
+    ~H"""
+    <div>
+      A resource must be completed
+    </div>
+    """
+  end
+
+  def render_details_column(
+        %{ctx: _} = assigns,
+        %GatingCondition{
+          type: :progress
+        },
+        _
+      ) do
+    ~H"""
+    <div>
+      A resource must be completed with a minimum of progress
+    </div>
+    """
+  end
+
+  def render_details_column(
         %{ctx: _ctx} = assigns,
         %GatingCondition{
           type: :always_open

--- a/test/oli/delivery/gating/strategies/progress_test.exs
+++ b/test/oli/delivery/gating/strategies/progress_test.exs
@@ -1,0 +1,161 @@
+defmodule Oli.Delivery.Gating.ConditionTypes.ProgressTest do
+  use Oli.DataCase
+
+  alias Oli.Delivery.Attempts.Core
+  alias Oli.Delivery.Gating
+  alias Oli.Delivery.Gating.ConditionTypes.{ConditionContext, Progress}
+
+  def insert_resource_attempt(resource_access, revision_id, attrs) do
+    Core.create_resource_attempt(
+      Map.merge(
+        %{
+          attempt_guid: UUID.uuid4(),
+          attempt_number: 1,
+          content: %{},
+          resource_access_id: resource_access.id,
+          revision_id: revision_id
+        },
+        attrs
+      )
+    )
+  end
+
+  describe "progress condition type" do
+    setup do
+      Seeder.base_project_with_resource4()
+      |> Seeder.add_users_to_section(:section_1, [:user_a, :user_b])
+    end
+
+    test "evaluate/2 returns false when the source page has not been visited", %{
+      page1: resource,
+      section_1: section,
+      user_a: user,
+      page2: resource2
+    } do
+      context = ConditionContext.init(user, section)
+
+      {:ok, gating_condition} =
+        Gating.create_gating_condition(%{
+          type: :progress,
+          data: %{
+            resource_id: resource2.id
+          },
+          resource_id: resource.id,
+          section_id: section.id
+        })
+
+      assert {false, _} = Progress.evaluate(gating_condition, context)
+    end
+
+    test "evaluate/2 returns false when only a resource access record exists", %{
+      page1: resource,
+      section_1: section,
+      user_a: user,
+      page2: resource2
+    } do
+      context = ConditionContext.init(user, section)
+
+      Core.track_access(resource2.id, section.id, user.id)
+
+      {:ok, gating_condition} =
+        Gating.create_gating_condition(%{
+          type: :progress,
+          data: %{
+            resource_id: resource2.id
+          },
+          resource_id: resource.id,
+          section_id: section.id
+        })
+
+      assert {false, _} = Progress.evaluate(gating_condition, context)
+    end
+
+    test "evaluate/2 returns true when one resource attempt exists and minimum progress is not set",
+         %{
+           page1: resource,
+           section_1: section,
+           user_a: user,
+           page2: resource2,
+           revision2: revision2
+         } do
+      context = ConditionContext.init(user, section)
+
+      ra = Core.track_access(resource2.id, section.id, user.id)
+      insert_resource_attempt(ra, revision2.id, %{})
+
+      {:ok, gating_condition} =
+        Gating.create_gating_condition(%{
+          type: :progress,
+          data: %{
+            resource_id: resource2.id
+          },
+          resource_id: resource.id,
+          section_id: section.id
+        })
+
+      assert {true, _} = Progress.evaluate(gating_condition, context)
+    end
+
+    test "evaluate/2 returns false when minimum progress is not met", %{
+      page1: resource,
+      section_1: section,
+      user_a: user,
+      page2: resource2,
+      revision2: revision2
+    } do
+      context = ConditionContext.init(user, section)
+
+      ra = Core.track_access(resource2.id, section.id, user.id)
+      Core.update_resource_access(ra, %{progress: 0.5})
+
+      insert_resource_attempt(ra, revision2.id, %{
+        date_evaluated: DateTime.utc_now(),
+        progress: 0.5
+      })
+
+      {:ok, gating_condition} =
+        Gating.create_gating_condition(%{
+          type: :progress,
+          data: %{
+            resource_id: resource2.id,
+            minimum_percentage: 0.8
+          },
+          resource_id: resource.id,
+          section_id: section.id
+        })
+
+      assert {false, _} = Progress.evaluate(gating_condition, context)
+    end
+
+    test "evaluate/2 returns true when minimum progress is met", %{
+      page1: resource,
+      section_1: section,
+      user_a: user,
+      page2: resource2,
+      revision2: revision2
+    } do
+      context = ConditionContext.init(user, section)
+
+      ra = Core.track_access(resource2.id, section.id, user.id)
+      Core.update_resource_access(ra, %{progress: 0.7})
+
+      insert_resource_attempt(ra, revision2.id, %{
+        date_evaluated: DateTime.utc_now(),
+        progress: 0.7
+      })
+
+      {:ok, gating_condition} =
+        Gating.create_gating_condition(%{
+          type: :finished,
+          data: %{
+            resource_id: resource2.id,
+            minimum_percentage: 0.5
+          },
+          resource_id: resource.id,
+          section_id: section.id
+        })
+
+      assert {true, _} = Progress.evaluate(gating_condition, context)
+    end
+  end
+end

--- a/test/oli_web/live/sections/gating_and_scheduling_test.exs
+++ b/test/oli_web/live/sections/gating_and_scheduling_test.exs
@@ -611,6 +611,22 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
 
       assert view
              |> element("input[phx-value-change=\"change-min-score\"]")
+
+      # change select option to "progress"
+      view
+      |> element("select[phx-change=\"select-condition\"]")
+      |> render_change(%{"value" => "progress"})
+
+      assert view
+             |> element("label[for=\"source\"]")
+             |> render() =~
+               "Resource That Must Has Progress"
+
+      assert view
+             |> element("input[phx-click=\"toggle-min-score\"]")
+
+      assert view
+             |> element("input[phx-value-change=\"change-min-score\"]")
     end
   end
 


### PR DESCRIPTION
[MER-3219](https://eliterate.atlassian.net/browse/MER-3219)

This RP adds a new type of `Gating Condition` so that it can be defined in a product.  

It adds a `Progress` type that will evaluate the progress of a source resource of type `Practice Page`.

This will evaluate the progress that is stored in ResourceAccess for the source resource to determine if the learner has access to a target resource defined in the Gating Condition.


https://github.com/Simon-Initiative/oli-torus/assets/16328384/40476b49-f340-437e-81ed-17e1068fd562

![Captura de pantalla 2024-05-17 a la(s) 10 08 45 a  m](https://github.com/Simon-Initiative/oli-torus/assets/16328384/d3300ae6-8166-44d3-83b3-a595614a52e7)


[MER-3219]: https://eliterate.atlassian.net/browse/MER-3219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ