### PR TITLE
[ENHANCEMENT] [NG23-183] [NG23-202] Fix light mode style issues and restore styles lost in prev merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ npm-debug.log
 
 # Since we are building assets from assets/ we ignore priv/static
 /priv/static/
+/test_bundles/
 
 # Ignore generated flame graph stack files
 /_flame_graph_stacks/

--- a/config/test.exs
+++ b/config/test.exs
@@ -20,7 +20,7 @@ config :oli,
   ]
 
 config :oli, :xapi_upload_pipeline,
-  producer_module: Broadway.DummyProducer,
+  producer_module: Oli.Analytics.XAPI.QueueProducer,
   uploader_module: Oli.Analytics.XAPI.FileWriterUploader,
   batcher_concurrency: 1,
   batch_size: 10,

--- a/lib/oli/analytics/xapi.ex
+++ b/lib/oli/analytics/xapi.ex
@@ -4,10 +4,8 @@ defmodule Oli.Analytics.XAPI do
   @chars "abcdefghijklmnopqrstuvwxyz1234567890" |> String.split("", trim: true)
 
   def emit(%StatementBundle{} = bundle) do
-
     # if we are in :test mode, do nothing
     if Mix.env() != :test do
-
       producer =
         Oli.Analytics.XAPI.UploadPipeline
         |> Broadway.producer_names()

--- a/lib/oli/analytics/xapi.ex
+++ b/lib/oli/analytics/xapi.ex
@@ -4,12 +4,17 @@ defmodule Oli.Analytics.XAPI do
   @chars "abcdefghijklmnopqrstuvwxyz1234567890" |> String.split("", trim: true)
 
   def emit(%StatementBundle{} = bundle) do
-    producer =
-      Oli.Analytics.XAPI.UploadPipeline
-      |> Broadway.producer_names()
-      |> Enum.random()
 
-    GenStage.cast(producer, {:insert, bundle})
+    # if we are in :test mode, do nothing
+    if Mix.env() != :test do
+
+      producer =
+        Oli.Analytics.XAPI.UploadPipeline
+        |> Broadway.producer_names()
+        |> Enum.random()
+
+      GenStage.cast(producer, {:insert, bundle})
+    end
   end
 
   def emit(category, events) when is_list(events) do

--- a/lib/oli_web/components/delivery/user_account.ex
+++ b/lib/oli_web/components/delivery/user_account.ex
@@ -24,7 +24,7 @@ defmodule OliWeb.Components.Delivery.UserAccount do
     <div class="relative">
       <button
         id={@id}
-        class={"flex flex-row items-center justify-center rounded-full outline outline-2 outline-primary-800 dark:outline-neutral-700 hover:outline-4 hover:dark:outline-zinc-600 focus:outline-4 focus:outline-primary-800 dark:focus:outline-zinc-600 #{@class}"}
+        class={"flex flex-row items-center justify-center rounded-full outline outline-2 outline-neutral-300 dark:outline-neutral-700 hover:outline-4 hover:dark:outline-zinc-600 focus:outline-4 focus:outline-primary-300 dark:focus:outline-zinc-600 #{@class}"}
         phx-click={toggle_menu("##{@id}-dropdown")}
       >
         <.user_icon ctx={@ctx} />
@@ -55,14 +55,6 @@ defmodule OliWeb.Components.Delivery.UserAccount do
       in: {"ease-out duration-300", "opacity-0 top-[40px]", "opacity-100"},
       out: {"ease-out duration-300", "opacity-100", "opacity-0 top-[40px]"}
     )
-    |> JS.remove_class("dark:bg-black bg-delivery-header", to: "#header")
-    |> JS.add_class("dark:!bg-[#0F0D0F] !bg-gray-100", to: "#header")
-  end
-
-  def reset_header_color(js \\ %JS{}) do
-    js
-    |> JS.add_class("dark:bg-black bg-delivery-header", to: "#header")
-    |> JS.remove_class("dark:!bg-[#0F0D0F] !bg-gray-100", to: "#header")
   end
 
   attr(:id, :string, required: true)
@@ -139,7 +131,7 @@ defmodule OliWeb.Components.Delivery.UserAccount do
     ~H"""
     <div
       id={@id}
-      phx-click-away={JS.hide() |> reset_header_color()}
+      phx-click-away={JS.hide()}
       class={"hidden absolute top-[51px] -right-[9px] z-50 p-[10px] whitespace-nowrap bg-gray-100 border-gray-300 w-[220px] dark:bg-[#0F0D0F] rounded-xl border dark:border-zinc-800 #{@class}"}
     >
       <ul>
@@ -183,7 +175,7 @@ defmodule OliWeb.Components.Delivery.UserAccount do
 
       _method ->
         ~H"""
-        <%= link to: @href, method: @method, class: "w-[190px] text-gray-800 hover:text-white dark:text-white text-sm font-normal font-['Roboto'] h-8 px-1.5 py-2 mt-[10px] m-[5px] rounded-md border border-rose-400 justify-center items-center gap-2.5 inline-flex cursor-pointer hover:no-underline hover:bg-[#33181A] hover:border-red-500", target: @target do %>
+        <%= link to: @href, method: @method, class: "w-[190px] text-gray-800 hover:text-white dark:text-white text-sm font-normal font-['Roboto'] h-8 px-1.5 py-2 mt-[10px] m-[5px] rounded-md border border-rose-400 justify-center items-center gap-2.5 inline-flex cursor-pointer hover:no-underline hover:bg-red-300 hover:border-red-500 dark:hover:bg-[#33181A]", target: @target do %>
           <%= render_slot(@inner_block) %>
         <% end %>
         """

--- a/lib/oli_web/live/delivery/student/index_live.ex
+++ b/lib/oli_web/live/delivery/student/index_live.ex
@@ -83,7 +83,7 @@ defmodule OliWeb.Delivery.Student.IndexLive do
       <div class="w-full absolute p-8 justify-start items-start gap-6 inline-flex">
         <.course_progress has_visited_section={@has_visited_section} progress={@section_progress} />
         <div class="w-3/4 h-full flex-col justify-start items-start gap-6 inline-flex">
-          <div class="w-full h-fit overflow-y-auto p-6 bg-[#1C1A20] bg-opacity-20 dark:bg-opacity-100 rounded-2xl justify-start items-start gap-32 inline-flex">
+          <div class="w-full h-fit overflow-y-auto p-6 bg-zinc-400 bg-opacity-20 dark:bg-[#1C1A20] dark:bg-opacity-100 rounded-2xl justify-start items-start gap-32 inline-flex">
             <div class="flex-col justify-start items-start gap-7 inline-flex grow">
               <div class="self-stretch justify-between items-baseline inline-flex gap-2.5">
                 <div class="text-2xl font-bold leading-loose tracking-tight">
@@ -300,7 +300,7 @@ defmodule OliWeb.Delivery.Student.IndexLive do
   defp course_progress(assigns) do
     ~H"""
     <div class="w-1/4 h-48 flex-col justify-start items-start gap-6 inline-flex">
-      <div class="w-full h-96 p-6 bg-[#1C1A20] bg-opacity-20 dark:bg-opacity-100 rounded-2xl justify-start items-start gap-32 inline-flex">
+      <div class="w-full h-96 p-6 bg-zinc-400 bg-opacity-20 dark:bg-[#1C1A20] dark:bg-opacity-100 rounded-2xl justify-start items-start gap-32 inline-flex">
         <div class="flex-col justify-start items-start gap-5 inline-flex grow">
           <div class="justify-start items-start gap-2.5 inline-flex">
             <div class="text-2xl font-bold leading-loose tracking-tight">


### PR DESCRIPTION
This PR restores the color changes made in NG23-183 that were lost in a recent merge to master.

<img width="1580" alt="Screenshot 2024-05-17 at 12 33 58 PM" src="https://github.com/Simon-Initiative/oli-torus/assets/6248894/189d60b9-dc9b-4b00-bfa1-855d250899f3">

While I was in here I also addressed [NG23-202](https://eliterate.atlassian.net/browse/NG23-202), an issue where they entire header color changes in light mode when opening the user menu

[NG23-202]: https://eliterate.atlassian.net/browse/NG23-202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

This PR also includes some fixes related to Broadway tests that were failing the CI build