### PR TITLE
[BUG FIX] [MER-3129] Ensure absolute URLs

### DIFF
--- a/lib/oli_web/pow/author_context.ex
+++ b/lib/oli_web/pow/author_context.ex
@@ -7,7 +7,7 @@ defmodule OliWeb.Pow.AuthorContext do
     repo: Oli.Repo,
     user: Oli.Accounts.Author
 
-  alias Oli.Repo
+  alias Oli.{Repo, Utils}
   alias Oli.Accounts
   alias Oli.Accounts.Author
   alias OliWeb.Router.Helpers, as: Routes
@@ -42,9 +42,14 @@ defmodule OliWeb.Pow.AuthorContext do
               "Account already exists",
               "account_already_exists.html",
               %{
-                url: Routes.authoring_pow_session_path(OliWeb.Endpoint, :new),
+                url:
+                  Utils.ensure_absolute_url(
+                    Routes.authoring_pow_session_path(OliWeb.Endpoint, :new)
+                  ),
                 forgot_password:
-                  Routes.authoring_pow_reset_password_reset_password_path(OliWeb.Endpoint, :new)
+                  Utils.ensure_absolute_url(
+                    Routes.authoring_pow_reset_password_reset_password_path(OliWeb.Endpoint, :new)
+                  )
               }
             )
             |> Oli.Mailer.deliver_now()

--- a/lib/oli_web/pow/user_context.ex
+++ b/lib/oli_web/pow/user_context.ex
@@ -11,7 +11,7 @@ defmodule OliWeb.Pow.UserContext do
   alias Oli.Accounts.User
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.Section
-  alias Oli.Repo
+  alias Oli.{Repo, Utils}
   alias OliWeb.Router.Helpers, as: Routes
 
   require Logger
@@ -70,9 +70,11 @@ defmodule OliWeb.Pow.UserContext do
               "Account already exists",
               "account_already_exists.html",
               %{
-                url: Routes.pow_session_path(OliWeb.Endpoint, :new),
+                url: Utils.ensure_absolute_url(Routes.pow_session_path(OliWeb.Endpoint, :new)),
                 forgot_password:
-                  Routes.pow_reset_password_reset_password_path(OliWeb.Endpoint, :new)
+                  Utils.ensure_absolute_url(
+                    Routes.pow_reset_password_reset_password_path(OliWeb.Endpoint, :new)
+                  )
               }
             )
             |> Oli.Mailer.deliver_now()


### PR DESCRIPTION
[MER-3129](https://eliterate.atlassian.net/browse/MER-3129)

This PR aims to ensure that the URLs to the `login` and `password reset` views that are added in the email that a learner or author receives when trying to create an existing account are absolute paths. 

This would ensure a link to a known path in `Torus`, regardless of the environment where the application is running.

[MER-3129]: https://eliterate.atlassian.net/browse/MER-3129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ