### PR TITLE
[FEATURE] [MER-3181] Instructors switch units modules tabs

### DIFF
--- a/lib/oli_web/components/delivery/content/content.ex
+++ b/lib/oli_web/components/delivery/content/content.ex
@@ -69,29 +69,33 @@ defmodule OliWeb.Components.Delivery.Content do
 
   def render(assigns) do
     ~H"""
-    <div class="flex flex-col gap-2 mb-10">
+    <div class="flex flex-col mb-10">
+      <div class="w-full h-9 relative my-7">
+        <button
+          id="filter_units_button"
+          class={"w-[6.5rem] h-9 left-0 top-0 absolute rounded-tl-lg rounded-bl-lg border border-slate-300 #{set_button_background(@params.container_filter_by, :units)} text-xs #{set_button_text(@params.container_filter_by, :units)}"}
+          phx-click="filter_container"
+          phx-value-filter="units"
+          phx-target={@myself}
+        >
+          Units
+        </button>
+        <button
+          id="filter_modules_button"
+          class={"w-28 h-9 left-[100.52px] top-0 absolute rounded-tr-lg rounded-br-lg border border-slate-300 #{set_button_background(@params.container_filter_by, :modules)} text-xs #{set_button_text(@params.container_filter_by, :modules)}"}
+          phx-click="filter_container"
+          phx-value-filter="modules"
+          phx-target={@myself}
+        >
+          Modules
+        </button>
+      </div>
       <div class="bg-white dark:bg-gray-800 shadow-sm">
         <div
           style="min-height: 83px;"
           class="flex justify-between gap-2 items-end px-4 sm:px-9 py-4 instructor_dashboard_table"
         >
           <div>
-            <.form
-              for={%{}}
-              id="container-select-form"
-              phx-change="filter_container"
-              phx-target={@myself}
-              class="mr-auto mb-2"
-            >
-              <.input
-                type="select"
-                name="container_type"
-                id="container_select"
-                options={@options_for_container_select}
-                value={@params.container_filter_by}
-                class="text-delivery-body-color text-xl font-bold tracking-wide pl-0 underline underline-offset-4 border-none focus:!border-none"
-              />
-            </.form>
             <a
               href={
                 Routes.delivery_path(OliWeb.Endpoint, :download_course_content_info, @section_slug,
@@ -130,18 +134,14 @@ defmodule OliWeb.Components.Delivery.Content do
     """
   end
 
-  def handle_event(
-        "filter_container",
-        %{"_target" => ["container_type"], "container_type" => container_type},
-        socket
-      ) do
+  def handle_event("filter_container", %{"filter" => filter}, socket) do
     {:noreply,
      push_patch(socket,
        to:
          route_for(
            socket,
            %{
-             container_filter_by: container_type,
+             container_filter_by: filter,
              text_search: @default_params.text_search
            },
            socket.assigns.patch_url_type
@@ -357,4 +357,14 @@ defmodule OliWeb.Components.Delivery.Content do
       update_params(socket.assigns.params, new_params)
     )
   end
+
+  defp set_button_background(container_filter_by, filter),
+    do: if(container_filter_by == filter, do: "bg-blue-500 dark:bg-gray-800", else: "bg-white")
+
+  defp set_button_text(container_filter_by, filter),
+    do:
+      if(container_filter_by == filter,
+        do: "text-white font-bold",
+        else: "text-zinc-700 font-normal"
+      )
 end

--- a/test/oli_web/live/delivery/student_dashboard/components/content_tab_test.exs
+++ b/test/oli_web/live/delivery/student_dashboard/components/content_tab_test.exs
@@ -67,7 +67,7 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.ContentTabTest do
                "Content"
              )
 
-      assert has_element?(view, "option", "Units")
+      assert has_element?(view, "button[id=\"filter_units_button\"]", "Units")
     end
 
     test "gets sorted by module through url query params", %{
@@ -215,10 +215,10 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.ContentTabTest do
         view
         |> render()
         |> Floki.parse_fragment!()
-        |> Floki.find(~s{#container_select option})
-        |> Floki.attribute("value")
+        |> Floki.find(~s{button[phx-click="filter_container"]})
+        |> Floki.attribute("phx-value-filter")
 
-      assert options_for_select == ["modules", "units"]
+      assert options_for_select == ["units", "modules"]
     end
   end
 

--- a/test/oli_web/live/delivery/student_dashboard/student_dashboard_live_test.exs
+++ b/test/oli_web/live/delivery/student_dashboard/student_dashboard_live_test.exs
@@ -91,7 +91,7 @@ defmodule OliWeb.Delivery.StudentDashboard.StudentDashboardLiveTest do
                "Content"
              )
 
-      assert has_element?(view, "option", "Units")
+      assert has_element?(view, "button[id=\"filter_units_button\"]", "Units")
     end
 
     test "can see the student details card correctly", %{


### PR DESCRIPTION
[MER-3181](https://eliterate.atlassian.net/browse/MER-3181)

This PR visually modifies the input dropdown that allows to select the type of container (Units or Modules) in the `Content` view within the instructor dashboard turning it into a switch button which will still allow to select between `Units` and `Modules` in order to filter the results of the course content. 

- Before

https://github.com/Simon-Initiative/oli-torus/assets/16328384/b58ae943-033a-4c7f-9fdd-7bcf6d1909f6

- After

https://github.com/Simon-Initiative/oli-torus/assets/16328384/0cd53729-c005-4918-a433-b92be8ad5c45
