### PR TITLE
[FEATURE] [MER-3285] Emit xAPI Video profile events

### DIFF
--- a/assets/src/components/editing/elements/video/VideoEditor.tsx
+++ b/assets/src/components/editing/elements/video/VideoEditor.tsx
@@ -30,7 +30,7 @@ export const VideoEditor = (props: Props) => {
     <span {...props.attributes} contentEditable={false} style={{ position: 'relative' }}>
       {props.children}
 
-      <VideoPlayer video={model}>
+      <VideoPlayer video={model} pageAttemptGuid="">
         <VideoSettings model={props.model} onEdit={onEdit} commandContext={props.commandContext} />
       </VideoPlayer>
     </span>

--- a/assets/src/components/video_player/VideoPlayer.tsx
+++ b/assets/src/components/video_player/VideoPlayer.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useCallback, useRef, useState, useEffect } from 'react';
+import React, { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import {
   BigPlayButton,
   ControlBar,
@@ -10,8 +10,8 @@ import {
   ProgressControl,
   TimeDivider,
 } from 'video-react';
-import * as XAPI from 'data/persistence/xapi';
 import { PointMarkerContext, maybePointMarkerAttr } from 'data/content/utils';
+import * as XAPI from 'data/persistence/xapi';
 import * as ContentModel from '../../data/content/model/elements/types';
 import { useCommandTarget } from '../editing/elements/command_button/useCommandTarget';
 import { ClosedCaptionButton } from './ClosedCaptionButton';
@@ -54,7 +54,6 @@ interface VideoInterface {
   seek: (time: number) => void;
 }
 
-
 export const VideoPlayer: React.FC<{
   video: ContentModel.Video;
   pageAttemptGuid: string;
@@ -91,7 +90,6 @@ export const VideoPlayer: React.FC<{
     }
     // This handles stopping at the correct point if a cue-point command previously came in with an end-timestamp set.
     player.subscribeToStateChange((state: PlayerState, prev: PlayerState) => {
-
       if (
         pauseAtPosition.current > 0 &&
         state.hasStarted &&
@@ -102,7 +100,6 @@ export const VideoPlayer: React.FC<{
       }
 
       if (state.seekingTime !== 0 && prev.seekingTime === 0) {
-
         const lastSegment = segmentsRef.current[segmentsRef.current.length - 1];
 
         if (lastSegment) {
@@ -112,27 +109,27 @@ export const VideoPlayer: React.FC<{
         }
 
         setSeekFrom(prev.currentTime);
-
       } else if (!state.seeking && prev.seeking) {
-        const segment = {start: state.currentTime, end: null};
+        const segment = { start: state.currentTime, end: null };
         setSegments([...segmentsRef.current, segment]);
 
-        XAPI.emit_delivery({
-          type: 'page_video_key',
-          page_attempt_guid: pageAttemptGuid,
-        }, {
-          type: 'video_seeked',
-          category: 'video',
-          event_type: 'seeked',
-          video_url: state.currentSrc,
-          video_title: state.currentSrc,
-          video_seek_to: state.currentTime,
-          video_seek_from: seekFromRef.current,
-          content_element_id: video.id,
-        } as XAPI.VideoSeekedEvent)
-
+        XAPI.emit_delivery(
+          {
+            type: 'page_video_key',
+            page_attempt_guid: pageAttemptGuid,
+          },
+          {
+            type: 'video_seeked',
+            category: 'video',
+            event_type: 'seeked',
+            video_url: state.currentSrc,
+            video_title: state.currentSrc,
+            video_seek_to: state.currentTime,
+            video_seek_from: seekFromRef.current,
+            content_element_id: video.id,
+          } as XAPI.VideoSeekedEvent,
+        );
       } else if (state.ended && !prev.ended) {
-
         const lastSegment = segmentsRef.current[segmentsRef.current.length - 1];
         if (lastSegment) {
           lastSegment.end = state.currentTime;
@@ -143,25 +140,27 @@ export const VideoPlayer: React.FC<{
         const progress = XAPI.calculateProgress(segments, state.duration);
 
         // Emit completed event
-        XAPI.emit_delivery({
+        XAPI.emit_delivery(
+          {
             type: 'page_video_key',
             page_attempt_guid: pageAttemptGuid,
-          }, {
-          type: 'video_completed',
-          category: 'video',
-          event_type: 'completed',
-          video_url: state.currentSrc,
-          video_title: state.currentSrc,
-          video_length: state.duration,
-          video_played_segments: XAPI.formatSegments(segments),
-          video_progress: progress,
-          video_time: state.currentTime,
-          content_element_id: video.id,
-        } as XAPI.VideoCompletedEvent)
+          },
+          {
+            type: 'video_completed',
+            category: 'video',
+            event_type: 'completed',
+            video_url: state.currentSrc,
+            video_title: state.currentSrc,
+            video_length: state.duration,
+            video_played_segments: XAPI.formatSegments(segments),
+            video_progress: progress,
+            video_time: state.currentTime,
+            content_element_id: video.id,
+          } as XAPI.VideoCompletedEvent,
+        );
       } else if (state.paused && !prev.paused) {
-
         const lastSegment = segmentsRef.current[segmentsRef.current.length - 1];
-        let segmentsStr = "";
+        let segmentsStr = '';
 
         if (lastSegment) {
           lastSegment.end = state.currentTime;
@@ -172,41 +171,45 @@ export const VideoPlayer: React.FC<{
         }
 
         // Emit paused event
-        XAPI.emit_delivery({
+        XAPI.emit_delivery(
+          {
             type: 'page_video_key',
             page_attempt_guid: pageAttemptGuid,
-          }, {
-          type: 'video_paused',
-          category: 'video',
-          event_type: 'paused',
-          video_url: state.currentSrc,
-          video_title: state.currentSrc,
-          video_length: state.duration,
-          video_played_segments: segmentsStr,
-          video_progress: XAPI.calculateProgress(segments, state.duration),
-          video_time: state.currentTime,
-          content_element_id: video.id,
-        } as XAPI.VideoPausedEvent)
-
+          },
+          {
+            type: 'video_paused',
+            category: 'video',
+            event_type: 'paused',
+            video_url: state.currentSrc,
+            video_title: state.currentSrc,
+            video_length: state.duration,
+            video_played_segments: segmentsStr,
+            video_progress: XAPI.calculateProgress(segments, state.duration),
+            video_time: state.currentTime,
+            content_element_id: video.id,
+          } as XAPI.VideoPausedEvent,
+        );
       } else if (!state.paused && prev.paused) {
-
-        const segment = {start: state.currentTime, end: null};
+        const segment = { start: state.currentTime, end: null };
         setSegments([...segmentsRef.current, segment]);
 
         // Emit played event
-        XAPI.emit_delivery({
+        XAPI.emit_delivery(
+          {
             type: 'page_video_key',
             page_attempt_guid: pageAttemptGuid,
-          }, {
-          type: 'video_played',
-          category: 'video',
-          event_type: 'played',
-          video_url: state.currentSrc,
-          video_title: state.currentSrc,
-          video_length: state.duration,
-          video_play_time: state.currentTime,
-          content_element_id: video.id,
-        } as XAPI.VideoPlayedEvent)
+          },
+          {
+            type: 'video_played',
+            category: 'video',
+            event_type: 'played',
+            video_url: state.currentSrc,
+            video_title: state.currentSrc,
+            video_length: state.duration,
+            video_play_time: state.currentTime,
+            content_element_id: video.id,
+          } as XAPI.VideoPlayedEvent,
+        );
       }
     });
   }, []);

--- a/assets/src/components/video_player/VideoPlayer.tsx
+++ b/assets/src/components/video_player/VideoPlayer.tsx
@@ -54,16 +54,6 @@ interface VideoInterface {
   seek: (time: number) => void;
 }
 
-const calculateProgress = (segments: { start: number; end: number | null }[], duration: number) => {
-  let total = 0;
-  segments.forEach((segment) => {
-    if (segment.end) {
-      total += segment.end - segment.start;
-    }
-  });
-
-  return total / duration;
-};
 
 export const VideoPlayer: React.FC<{
   video: ContentModel.Video;
@@ -128,10 +118,12 @@ export const VideoPlayer: React.FC<{
         setSegments([...segmentsRef.current, segment]);
 
         XAPI.emit_delivery({
+          type: 'page_video_key',
+          page_attempt_guid: pageAttemptGuid,
+        }, {
           type: 'video_seeked',
           category: 'video',
           event_type: 'seeked',
-          page_attempt_guid: pageAttemptGuid,
           video_url: state.currentSrc,
           video_title: state.currentSrc,
           video_seek_to: state.currentTime,
@@ -148,14 +140,16 @@ export const VideoPlayer: React.FC<{
         const segments = segmentsRef.current;
         segments[segments.length - 1] = lastSegment;
 
-        const progress = calculateProgress(segments, state.duration);
+        const progress = XAPI.calculateProgress(segments, state.duration);
 
         // Emit completed event
         XAPI.emit_delivery({
+            type: 'page_video_key',
+            page_attempt_guid: pageAttemptGuid,
+          }, {
           type: 'video_completed',
           category: 'video',
           event_type: 'completed',
-          page_attempt_guid: pageAttemptGuid,
           video_url: state.currentSrc,
           video_title: state.currentSrc,
           video_length: state.duration,
@@ -179,15 +173,17 @@ export const VideoPlayer: React.FC<{
 
         // Emit paused event
         XAPI.emit_delivery({
+            type: 'page_video_key',
+            page_attempt_guid: pageAttemptGuid,
+          }, {
           type: 'video_paused',
           category: 'video',
           event_type: 'paused',
-          page_attempt_guid: pageAttemptGuid,
           video_url: state.currentSrc,
           video_title: state.currentSrc,
           video_length: state.duration,
           video_played_segments: segmentsStr,
-          video_progress: state.duration / state.currentTime,
+          video_progress: XAPI.calculateProgress(segments, state.duration),
           video_time: state.currentTime,
           content_element_id: video.id,
         } as XAPI.VideoPausedEvent)
@@ -199,10 +195,12 @@ export const VideoPlayer: React.FC<{
 
         // Emit played event
         XAPI.emit_delivery({
+            type: 'page_video_key',
+            page_attempt_guid: pageAttemptGuid,
+          }, {
           type: 'video_played',
           category: 'video',
           event_type: 'played',
-          page_attempt_guid: pageAttemptGuid,
           video_url: state.currentSrc,
           video_title: state.currentSrc,
           video_length: state.duration,

--- a/assets/src/components/video_player/VideoPlayer.tsx
+++ b/assets/src/components/video_player/VideoPlayer.tsx
@@ -99,6 +99,11 @@ export const VideoPlayer: React.FC<{
         player.pause();
       }
 
+      // In an authoring context, just stop here, we don't want to emit xAPI events
+      if (pageAttemptGuid === '') {
+        return;
+      }
+
       if (state.seekingTime !== 0 && prev.seekingTime === 0) {
         const lastSegment = segmentsRef.current[segmentsRef.current.length - 1];
 

--- a/assets/src/components/video_player/VideoPlayer.tsx
+++ b/assets/src/components/video_player/VideoPlayer.tsx
@@ -23,12 +23,6 @@ import { PlayButton } from './VideoPlayButton';
 const startEndCueRegex = /startcuepoint=([0-9.]+);endcuepoint=([0-9.]+)/;
 const startCueRegex = /startcuepoint=([0-9.]+)/;
 
-export const formatSegments = (segments: { start: number; end: number | null }[]) => {
-  return segments.map((segment) => {
-    return `${segment.start}[.]${segment.end || ''}`;
-  }).join('[,]');
-};
-
 export const parseVideoPlayCommand = (command: string) => {
   if (startEndCueRegex.test(command)) {
     const matches = command.match(startEndCueRegex);
@@ -80,7 +74,7 @@ export const VideoPlayer: React.FC<{
   const playerRef = useRef(null);
   const pauseAtPosition = useRef(-1);
   const [seekFrom, setSeekFrom] = useState(0);
-  const [segments, setSegments] = useState([] as { start: number; end: number | null }[]);
+  const [segments, setSegments] = useState([] as XAPI.PlayedSegment[]);
   const segmentsRef = useRef(segments);
   const seekFromRef = useRef(seekFrom);
 
@@ -165,7 +159,7 @@ export const VideoPlayer: React.FC<{
           video_url: state.currentSrc,
           video_title: state.currentSrc,
           video_length: state.duration,
-          video_played_segments: formatSegments(segments),
+          video_played_segments: XAPI.formatSegments(segments),
           video_progress: progress,
           video_time: state.currentTime,
           content_element_id: video.id,
@@ -180,7 +174,7 @@ export const VideoPlayer: React.FC<{
           const segments = segmentsRef.current;
           segments[segments.length - 1] = lastSegment;
           setSegments(segments);
-          segmentsStr = formatSegments(segments);
+          segmentsStr = XAPI.formatSegments(segments);
         }
 
         // Emit paused event

--- a/assets/src/components/youtube_player/YoutubePlayer.tsx
+++ b/assets/src/components/youtube_player/YoutubePlayer.tsx
@@ -108,7 +108,8 @@ export const YoutubePlayer: React.FC<{
         XAPI.emit_delivery(
           {
             type: 'page_video_key',
-            page_attempt_guid: context.resourceAttemptGuid as any,
+            page_attempt_guid:
+              context?.resourceAttemptGuid !== undefined ? context?.resourceAttemptGuid : '',
           },
           {
             type: 'video_completed',
@@ -131,7 +132,8 @@ export const YoutubePlayer: React.FC<{
         XAPI.emit_delivery(
           {
             type: 'page_video_key',
-            page_attempt_guid: context.resourceAttemptGuid as any,
+            page_attempt_guid:
+              context?.resourceAttemptGuid !== undefined ? context?.resourceAttemptGuid : '',
           },
           {
             type: 'video_played',
@@ -153,7 +155,8 @@ export const YoutubePlayer: React.FC<{
         XAPI.emit_delivery(
           {
             type: 'page_video_key',
-            page_attempt_guid: context.resourceAttemptGuid as any,
+            page_attempt_guid:
+              context?.resourceAttemptGuid !== undefined ? context?.resourceAttemptGuid : '',
           },
           {
             type: 'video_paused',

--- a/assets/src/components/youtube_player/YoutubePlayer.tsx
+++ b/assets/src/components/youtube_player/YoutubePlayer.tsx
@@ -99,16 +99,18 @@ export const YoutubePlayer: React.FC<{
 
     switch(e.data) {
       case 0:
-        XAPI.emit_delivery({
+          XAPI.emit_delivery({
+            type: 'page_video_key',
+            page_attempt_guid: context.resourceAttemptGuid as any,
+          }, {
           type: 'video_completed',
           category: 'video',
           event_type: 'completed',
-          page_attempt_guid: context.resourceAttemptGuid,
           video_url: url.current,
           video_title: url.current,
           video_length: duration.current,
           video_played_segments: XAPI.formatSegments(segments.current),
-          video_progress: duration.current / videoTarget.getCurrentTime(),
+          video_progress: XAPI.calculateProgress(segments.current, duration.current),
           video_time: videoTarget.getCurrentTime(),
           content_element_id: video.id,
         } as XAPI.VideoCompletedEvent)
@@ -119,10 +121,12 @@ export const YoutubePlayer: React.FC<{
         segments.current.push(segment);
 
         XAPI.emit_delivery({
+            type: 'page_video_key',
+            page_attempt_guid: context.resourceAttemptGuid as any,
+          }, {
           type: 'video_played',
           category: 'video',
           event_type: 'played',
-          page_attempt_guid: context.resourceAttemptGuid,
           video_url: url.current,
           video_title: url.current,
           video_length: duration.current,
@@ -137,15 +141,17 @@ export const YoutubePlayer: React.FC<{
         segments.current[segments.current.length - 1] = lastSegment;
 
         XAPI.emit_delivery({
+            type: 'page_video_key',
+            page_attempt_guid: context.resourceAttemptGuid as any,
+          }, {
           type: 'video_paused',
           category: 'video',
           event_type: 'paused',
-          page_attempt_guid: context.resourceAttemptGuid,
           video_url: url.current,
           video_title: url.current,
           video_length: duration.current,
           video_played_segments: XAPI.formatSegments(segments.current),
-          video_progress: duration.current / videoTarget.getCurrentTime(),
+          video_progress: XAPI.calculateProgress(segments.current, duration.current),
           video_time: videoTarget.getCurrentTime(),
           content_element_id: video.id,
         } as XAPI.VideoPausedEvent)

--- a/assets/src/components/youtube_player/YoutubePlayer.tsx
+++ b/assets/src/components/youtube_player/YoutubePlayer.tsx
@@ -59,10 +59,16 @@ export const YoutubePlayer: React.FC<{
   const onReady = useCallback((event) => {
     setVideoTarget(event.target);
 
-    (youTubeRef.current as any).getInternalPlayer().getDuration().then((d: number) => {
-      duration.current = d;
-    });
-    (youTubeRef.current as any).getInternalPlayer().getVideoUrl().then((u: string) => url.current = u);
+    (youTubeRef.current as any)
+      .getInternalPlayer()
+      .getDuration()
+      .then((d: number) => {
+        duration.current = d;
+      });
+    (youTubeRef.current as any)
+      .getInternalPlayer()
+      .getVideoUrl()
+      .then((u: string) => (url.current = u));
   }, []);
 
   const stopAtTime = useCallback(() => {
@@ -97,64 +103,71 @@ export const YoutubePlayer: React.FC<{
   const onStateChange = (e: any) => {
     if (!videoTarget) return;
 
-    switch(e.data) {
+    switch (e.data) {
       case 0:
-          XAPI.emit_delivery({
+        XAPI.emit_delivery(
+          {
             type: 'page_video_key',
             page_attempt_guid: context.resourceAttemptGuid as any,
-          }, {
-          type: 'video_completed',
-          category: 'video',
-          event_type: 'completed',
-          video_url: url.current,
-          video_title: url.current,
-          video_length: duration.current,
-          video_played_segments: XAPI.formatSegments(segments.current),
-          video_progress: XAPI.calculateProgress(segments.current, duration.current),
-          video_time: videoTarget.getCurrentTime(),
-          content_element_id: video.id,
-        } as XAPI.VideoCompletedEvent)
+          },
+          {
+            type: 'video_completed',
+            category: 'video',
+            event_type: 'completed',
+            video_url: url.current,
+            video_title: url.current,
+            video_length: duration.current,
+            video_played_segments: XAPI.formatSegments(segments.current),
+            video_progress: XAPI.calculateProgress(segments.current, duration.current),
+            video_time: videoTarget.getCurrentTime(),
+            content_element_id: video.id,
+          } as XAPI.VideoCompletedEvent,
+        );
         break;
       case 1:
-
-        const segment = {start: videoTarget.getCurrentTime(), end: null};
+        const segment = { start: videoTarget.getCurrentTime(), end: null };
         segments.current.push(segment);
 
-        XAPI.emit_delivery({
+        XAPI.emit_delivery(
+          {
             type: 'page_video_key',
             page_attempt_guid: context.resourceAttemptGuid as any,
-          }, {
-          type: 'video_played',
-          category: 'video',
-          event_type: 'played',
-          video_url: url.current,
-          video_title: url.current,
-          video_length: duration.current,
-          video_play_time: videoTarget.getCurrentTime(),
-          content_element_id: video.id,
-        } as XAPI.VideoPlayedEvent)
+          },
+          {
+            type: 'video_played',
+            category: 'video',
+            event_type: 'played',
+            video_url: url.current,
+            video_title: url.current,
+            video_length: duration.current,
+            video_play_time: videoTarget.getCurrentTime(),
+            content_element_id: video.id,
+          } as XAPI.VideoPlayedEvent,
+        );
         break;
       case 2:
-
         const lastSegment = segments.current[segments.current.length - 1];
         lastSegment.end = videoTarget.getCurrentTime();
         segments.current[segments.current.length - 1] = lastSegment;
 
-        XAPI.emit_delivery({
+        XAPI.emit_delivery(
+          {
             type: 'page_video_key',
             page_attempt_guid: context.resourceAttemptGuid as any,
-          }, {
-          type: 'video_paused',
-          category: 'video',
-          event_type: 'paused',
-          video_url: url.current,
-          video_title: url.current,
-          video_length: duration.current,
-          video_played_segments: XAPI.formatSegments(segments.current),
-          video_progress: XAPI.calculateProgress(segments.current, duration.current),
-          video_time: videoTarget.getCurrentTime(),
-          content_element_id: video.id,
-        } as XAPI.VideoPausedEvent)
+          },
+          {
+            type: 'video_paused',
+            category: 'video',
+            event_type: 'paused',
+            video_url: url.current,
+            video_title: url.current,
+            video_length: duration.current,
+            video_played_segments: XAPI.formatSegments(segments.current),
+            video_progress: XAPI.calculateProgress(segments.current, duration.current),
+            video_time: videoTarget.getCurrentTime(),
+            content_element_id: video.id,
+          } as XAPI.VideoPausedEvent,
+        );
         break;
     }
   };

--- a/assets/src/data/content/writers/html.tsx
+++ b/assets/src/data/content/writers/html.tsx
@@ -342,7 +342,10 @@ export class HtmlParser implements WriterImpl {
   }
 
   video(context: WriterContext, next: Next, v: Video) {
-    return <VideoPlayer video={v} pointMarkerContext={pointMarkerContextFrom(context, v)} />;
+    return <VideoPlayer
+      video={v}
+      pageAttemptGuid={(context.resourceAttemptGuid as any)}
+      pointMarkerContext={pointMarkerContextFrom(context, v)} />;
   }
 
   ecl(context: WriterContext, next: Next, attrs: ECLRepl) {

--- a/assets/src/data/content/writers/html.tsx
+++ b/assets/src/data/content/writers/html.tsx
@@ -342,10 +342,13 @@ export class HtmlParser implements WriterImpl {
   }
 
   video(context: WriterContext, next: Next, v: Video) {
-    return <VideoPlayer
-      video={v}
-      pageAttemptGuid={(context.resourceAttemptGuid as any)}
-      pointMarkerContext={pointMarkerContextFrom(context, v)} />;
+    return (
+      <VideoPlayer
+        video={v}
+        pageAttemptGuid={context.resourceAttemptGuid as any}
+        pointMarkerContext={pointMarkerContextFrom(context, v)}
+      />
+    );
   }
 
   ecl(context: WriterContext, next: Next, attrs: ECLRepl) {

--- a/assets/src/data/persistence/xapi.ts
+++ b/assets/src/data/persistence/xapi.ts
@@ -1,0 +1,69 @@
+
+import { Ok, ServerError, makeRequest } from './common';
+
+export type EmitEventResult = Ok | ServerError;
+
+export type XAPIEvent = VideoPlayedEvent | VideoPausedEvent | VideoCompletedEvent | VideoSeekedEvent;
+
+export interface VideoPausedEvent {
+  type: 'video_paused';
+  category: "video";
+  event_type: "paused";
+  page_attempt_guid: string;
+  video_url: string;
+  video_title: string;
+  video_length: number;
+  video_played_segments: string;
+  video_progress: number;
+  video_time: number;
+  content_element_id: string;
+};
+
+export interface VideoPlayedEvent {
+  type: 'video_played';
+  category: "video";
+  event_type: "played";
+  page_attempt_guid: string;
+  video_url: string;
+  video_title: string;
+  video_length: number;
+  video_play_time: number;
+  content_element_id: string;
+};
+
+export interface VideoCompletedEvent {
+  type: 'video_completed';
+  category: "video";
+  event_type: "completed";
+  page_attempt_guid: string;
+  video_url: string;
+  video_title: string;
+  video_length: number;
+  video_played_segments: string;
+  video_progress: number;
+  video_time: number;
+  content_element_id: string;
+};
+
+export interface VideoSeekedEvent {
+  type: 'video_seeked';
+  category: "video";
+  event_type: "seeked";
+  page_attempt_guid: string;
+  video_url: string;
+  video_title: string;
+  video_seek_to: number;
+  video_seek_from: number;
+  content_element_id: string;
+};
+
+export function emit_delivery(
+  event: XAPIEvent,
+): Promise<EmitEventResult> {
+  const params = {
+    url: `/xapi/delivery`,
+    method: 'POST',
+    body: JSON.stringify({"event": event})
+  };
+  return makeRequest<EmitEventResult>(params);
+}

--- a/assets/src/data/persistence/xapi.ts
+++ b/assets/src/data/persistence/xapi.ts
@@ -5,6 +5,17 @@ export type EmitEventResult = Ok | ServerError;
 
 export type XAPIEvent = VideoPlayedEvent | VideoPausedEvent | VideoCompletedEvent | VideoSeekedEvent;
 
+export type PlayedSegment = {
+  start: number;
+  end: number | null;
+};
+
+export const formatSegments = (segments: PlayedSegment[]) => {
+  return segments.map((segment) => {
+    return `${segment.start}[.]${segment.end || ''}`;
+  }).join('[,]');
+};
+
 export interface VideoPausedEvent {
   type: 'video_paused';
   category: "video";

--- a/assets/src/data/persistence/xapi.ts
+++ b/assets/src/data/persistence/xapi.ts
@@ -1,10 +1,13 @@
-
 import { Ok, ServerError, makeRequest } from './common';
 
 export type EmitEventResult = Ok | ServerError;
 
 export type VideoKey = PageVideoKey | IntroVideoKey;
-export type XAPIEvent = VideoPlayedEvent | VideoPausedEvent | VideoCompletedEvent | VideoSeekedEvent;
+export type XAPIEvent =
+  | VideoPlayedEvent
+  | VideoPausedEvent
+  | VideoCompletedEvent
+  | VideoSeekedEvent;
 
 export type PlayedSegment = {
   start: number;
@@ -12,12 +15,17 @@ export type PlayedSegment = {
 };
 
 export const formatSegments = (segments: PlayedSegment[]) => {
-  return segments.map((segment) => {
-    return `${segment.start}[.]${segment.end || ''}`;
-  }).join('[,]');
+  return segments
+    .map((segment) => {
+      return `${segment.start}[.]${segment.end || ''}`;
+    })
+    .join('[,]');
 };
 
-export const calculateProgress = (segments: { start: number; end: number | null }[], duration: number) => {
+export const calculateProgress = (
+  segments: { start: number; end: number | null }[],
+  duration: number,
+) => {
   let total = 0;
   segments.forEach((segment) => {
     if (segment.end) {
@@ -41,8 +49,8 @@ export interface IntroVideoKey {
 
 export interface VideoPausedEvent {
   type: 'video_paused';
-  category: "video";
-  event_type: "paused";
+  category: 'video';
+  event_type: 'paused';
   video_url: string;
   video_title: string;
   video_length: number;
@@ -50,23 +58,23 @@ export interface VideoPausedEvent {
   video_progress: number;
   video_time: number;
   content_element_id: string;
-};
+}
 
 export interface VideoPlayedEvent {
   type: 'video_played';
-  category: "video";
-  event_type: "played";
+  category: 'video';
+  event_type: 'played';
   video_url: string;
   video_title: string;
   video_length: number;
   video_play_time: number;
   content_element_id: string;
-};
+}
 
 export interface VideoCompletedEvent {
   type: 'video_completed';
-  category: "video";
-  event_type: "completed";
+  category: 'video';
+  event_type: 'completed';
   video_url: string;
   video_title: string;
   video_length: number;
@@ -74,27 +82,24 @@ export interface VideoCompletedEvent {
   video_progress: number;
   video_time: number;
   content_element_id: string;
-};
+}
 
 export interface VideoSeekedEvent {
   type: 'video_seeked';
-  category: "video";
-  event_type: "seeked";
+  category: 'video';
+  event_type: 'seeked';
   video_url: string;
   video_title: string;
   video_seek_to: number;
   video_seek_from: number;
   content_element_id: string;
-};
+}
 
-export function emit_delivery(
-  key: VideoKey,
-  event: XAPIEvent,
-): Promise<EmitEventResult> {
+export function emit_delivery(key: VideoKey, event: XAPIEvent): Promise<EmitEventResult> {
   const params = {
     url: `/xapi/delivery`,
     method: 'POST',
-    body: JSON.stringify({"event": event, "key": key})
+    body: JSON.stringify({ event: event, key: key }),
   };
   return makeRequest<EmitEventResult>(params);
 }

--- a/assets/src/hooks/video_player.ts
+++ b/assets/src/hooks/video_player.ts
@@ -1,4 +1,4 @@
-import * as XAPI from 'data/persistence/xapi'
+import * as XAPI from 'data/persistence/xapi';
 
 export const VideoPlayer = {
   mounted() {
@@ -9,14 +9,14 @@ export const VideoPlayer = {
     const metadata = {
       sectionId: null,
       resourceId: null,
-      segments: []
+      segments: [],
     } as any;
 
     const getSectionId = () => metadata.sectionId as any;
     const getResourceId = () => metadata.resourceId as any;
 
     cloudVideo.onplaying = () => {
-      const segment = {start: cloudVideo.currentTime, end: null};
+      const segment = { start: cloudVideo.currentTime, end: null };
       metadata.segments = [...metadata.segments, segment];
 
       const event: XAPI.VideoPlayedEvent = {
@@ -29,12 +29,15 @@ export const VideoPlayer = {
         video_play_time: cloudVideo.currentTime,
         content_element_id: getResourceId() + '',
       };
-      const key: XAPI.IntroVideoKey = { type: 'intro_video_key', resource_id: getResourceId(), section_id: getSectionId() };
+      const key: XAPI.IntroVideoKey = {
+        type: 'intro_video_key',
+        resource_id: getResourceId(),
+        section_id: getSectionId(),
+      };
       XAPI.emit_delivery(key, event);
     };
 
     cloudVideo.onpause = () => {
-
       const lastSegment = metadata.segments[metadata.segments.length - 1];
       if (lastSegment) {
         lastSegment.end = cloudVideo.currentTime;
@@ -54,12 +57,15 @@ export const VideoPlayer = {
         video_progress: XAPI.calculateProgress(segments, cloudVideo.duration),
         content_element_id: getResourceId() + '',
       };
-      const key: XAPI.IntroVideoKey = { type: 'intro_video_key', resource_id: getResourceId(), section_id: getSectionId() };
+      const key: XAPI.IntroVideoKey = {
+        type: 'intro_video_key',
+        resource_id: getResourceId(),
+        section_id: getSectionId(),
+      };
       XAPI.emit_delivery(key, event);
     };
 
     cloudVideo.onended = () => {
-
       const lastSegment = metadata.segments[metadata.segments.length - 1];
       if (lastSegment) {
         lastSegment.end = cloudVideo.currentTime;
@@ -79,7 +85,11 @@ export const VideoPlayer = {
         video_progress: XAPI.calculateProgress(segments, cloudVideo.duration),
         content_element_id: getResourceId() + '',
       };
-      const key: XAPI.IntroVideoKey = { type: 'intro_video_key', resource_id: getResourceId(), section_id: getSectionId() };
+      const key: XAPI.IntroVideoKey = {
+        type: 'intro_video_key',
+        resource_id: getResourceId(),
+        section_id: getSectionId(),
+      };
       XAPI.emit_delivery(key, event);
     };
 

--- a/lib/oli/analytics/summary/attempt_group.ex
+++ b/lib/oli/analytics/summary/attempt_group.ex
@@ -2,7 +2,7 @@ defmodule Oli.Analytics.Summary.AttemptGroup do
   import Ecto.Query, warn: false
   alias Oli.Repo
 
-  alias Oli.Analytics.Summary.Context
+  alias Oli.Analytics.XAPI.Events.Context
 
   @moduledoc """
   Represents a collection of evaluated part attempts, and the possible activity and page

--- a/lib/oli/analytics/xapi.ex
+++ b/lib/oli/analytics/xapi.ex
@@ -1,7 +1,23 @@
 defmodule Oli.Analytics.XAPI do
-  alias Oli.Analytics.XAPI.StatementBundle
 
   @chars "abcdefghijklmnopqrstuvwxyz1234567890" |> String.split("", trim: true)
+
+  @valid_video_attrs MapSet.new([
+    "video_url",
+    "video_title",
+    "video_length",
+    "video_played_segments",
+    "video_progress",
+    "video_time",
+    "content_element_id",
+    "video_play_time",
+    "video_seek_from",
+    "video_seek_to"
+  ])
+
+  import Ecto.Query
+  alias Oli.Analytics.XAPI.Events.Context
+  alias Oli.Analytics.XAPI.StatementBundle
 
   def emit(%StatementBundle{} = bundle) do
     config = Application.fetch_env!(:oli, :xapi_upload_pipeline)
@@ -50,10 +66,90 @@ defmodule Oli.Analytics.XAPI do
     %{section_id: section_id, bundle_id: bundle_id}
   end
 
+  def construct_bundle(%{
+    "category" => "video",
+    "event_type" => event_type,
+    "host_name" => host_name,
+    "page_attempt_guid" => page_attempt_guid
+  } = event, expected_user_id) when event_type in ["played", "paused", "completed", "seeked"] do
+
+    # From the page_attempt_guid, we can issue a single query to get
+    # the context for the video event plus the page_attempt_number and page
+    # resource_id
+
+    query = from p in Oli.Delivery.Attempts.Core.ResourceAttempt,
+      join: a in Oli.Delivery.Attempts.Core.ResourceAccess, on: p.resource_access_id == a.id,
+      join: spp in Oli.Delivery.Sections.SectionsProjectsPublications, on: a.section_id == spp.section_id,
+      join: sr in Oli.Delivery.Sections.SectionResource, on: a.resource_id == sr.resource_id and a.section_id == sr.section_id,
+      where: p.attempt_guid == ^page_attempt_guid,
+      select: {p.attempt_number, a.resource_id, a.section_id, a.user_id, sr.project_id, spp.publication_id}
+
+    case Oli.Repo.one(query) do
+      nil ->
+        {:error, "page attempt not found"}
+
+      {page_attempt_number, page_id, section_id, ^expected_user_id, project_id, publication_id} ->
+
+        context = %Context{
+          user_id: expected_user_id,
+          host_name: host_name,
+          section_id: section_id,
+          project_id: project_id,
+          publication_id: publication_id
+        }
+
+        details = Enum.reduce(event, %{}, fn {k, v}, acc ->
+          if MapSet.member?(@valid_video_attrs, k) do
+            Map.put(acc, String.to_atom(k), v)
+          else
+            acc
+          end
+        end)
+        |> Map.merge(%{
+          attempt_guid: page_attempt_guid,
+          attempt_number: page_attempt_number,
+          resource_id: page_id,
+          timestamp: DateTime.utc_now()
+        })
+
+        event = case event_type do
+          "played" -> Oli.Analytics.XAPI.Events.Video.Played.new(context, details)
+          "paused" -> Oli.Analytics.XAPI.Events.Video.Paused.new(context, details)
+          "completed" -> Oli.Analytics.XAPI.Events.Video.Completed.new(context, details)
+          "seeked" -> Oli.Analytics.XAPI.Events.Video.Seeked.new(context, details)
+        end
+
+        content_element_id = Map.get(details, :content_element_id, "unknown")
+
+        {:ok, %StatementBundle{
+          body: [event] |> Oli.Analytics.Common.to_jsonlines(),
+          bundle_id: create_bundle_id([page_attempt_guid, content_element_id, random_string(10)]),
+          partition_id: context.section_id,
+          category: :video,
+          partition: :section
+        }}
+
+      _ ->
+        {:error, "user id mismatch"}
+
+    end
+
+  end
+
+  def construct_bundle(_, _), do: {:error, "Unsupported XAPI statement build request"}
+
   defp random_string(length) do
     Enum.reduce(1..length, [], fn _i, acc ->
       [Enum.random(@chars) | acc]
     end)
     |> Enum.join("")
   end
+
+  defp create_bundle_id(some_unique_facts) do
+    guids = Enum.join(some_unique_facts, ",")
+
+    :crypto.hash(:md5, guids)
+    |> Base.encode16()
+  end
+
 end

--- a/lib/oli/analytics/xapi.ex
+++ b/lib/oli/analytics/xapi.ex
@@ -1,19 +1,18 @@
 defmodule Oli.Analytics.XAPI do
-
   @chars "abcdefghijklmnopqrstuvwxyz1234567890" |> String.split("", trim: true)
 
   @valid_video_attrs MapSet.new([
-    "video_url",
-    "video_title",
-    "video_length",
-    "video_played_segments",
-    "video_progress",
-    "video_time",
-    "content_element_id",
-    "video_play_time",
-    "video_seek_from",
-    "video_seek_to"
-  ])
+                       "video_url",
+                       "video_title",
+                       "video_length",
+                       "video_played_segments",
+                       "video_progress",
+                       "video_time",
+                       "content_element_id",
+                       "video_play_time",
+                       "video_seek_from",
+                       "video_seek_to"
+                     ])
 
   import Ecto.Query
   alias Oli.Analytics.XAPI.Events.Context
@@ -66,30 +65,38 @@ defmodule Oli.Analytics.XAPI do
     %{section_id: section_id, bundle_id: bundle_id}
   end
 
-  def construct_bundle(%{
-    "category" => "video",
-    "event_type" => event_type,
-    "host_name" => host_name,
-    "key" => %{ "page_attempt_guid" => page_attempt_guid}
-  } = event, expected_user_id) when event_type in ["played", "paused", "completed", "seeked"] do
-
+  def construct_bundle(
+        %{
+          "category" => "video",
+          "event_type" => event_type,
+          "host_name" => host_name,
+          "key" => %{"page_attempt_guid" => page_attempt_guid}
+        } = event,
+        expected_user_id
+      )
+      when event_type in ["played", "paused", "completed", "seeked"] do
     # From the page_attempt_guid, we can issue a single query to get
     # the context for the video event plus the page_attempt_number and page
     # resource_id
 
-    query = from p in Oli.Delivery.Attempts.Core.ResourceAttempt,
-      join: a in Oli.Delivery.Attempts.Core.ResourceAccess, on: p.resource_access_id == a.id,
-      join: spp in Oli.Delivery.Sections.SectionsProjectsPublications, on: a.section_id == spp.section_id,
-      join: sr in Oli.Delivery.Sections.SectionResource, on: a.resource_id == sr.resource_id and a.section_id == sr.section_id,
-      where: p.attempt_guid == ^page_attempt_guid,
-      select: {p.attempt_number, a.resource_id, a.section_id, a.user_id, sr.project_id, spp.publication_id}
+    query =
+      from p in Oli.Delivery.Attempts.Core.ResourceAttempt,
+        join: a in Oli.Delivery.Attempts.Core.ResourceAccess,
+        on: p.resource_access_id == a.id,
+        join: spp in Oli.Delivery.Sections.SectionsProjectsPublications,
+        on: a.section_id == spp.section_id,
+        join: sr in Oli.Delivery.Sections.SectionResource,
+        on: a.resource_id == sr.resource_id and a.section_id == sr.section_id,
+        where: p.attempt_guid == ^page_attempt_guid,
+        select:
+          {p.attempt_number, a.resource_id, a.section_id, a.user_id, sr.project_id,
+           spp.publication_id}
 
     case Oli.Repo.one(query) do
       nil ->
         {:error, "page attempt not found"}
 
       {page_attempt_number, page_id, section_id, ^expected_user_id, project_id, publication_id} ->
-
         context = %Context{
           user_id: expected_user_id,
           host_name: host_name,
@@ -98,64 +105,74 @@ defmodule Oli.Analytics.XAPI do
           publication_id: publication_id
         }
 
-        details = Enum.reduce(event, %{}, fn {k, v}, acc ->
-          if MapSet.member?(@valid_video_attrs, k) do
-            Map.put(acc, String.to_atom(k), v)
-          else
-            acc
-          end
-        end)
-        |> Map.merge(%{
-          attempt_guid: page_attempt_guid,
-          attempt_number: page_attempt_number,
-          resource_id: page_id,
-          timestamp: DateTime.utc_now()
-        })
+        details =
+          Enum.reduce(event, %{}, fn {k, v}, acc ->
+            if MapSet.member?(@valid_video_attrs, k) do
+              Map.put(acc, String.to_atom(k), v)
+            else
+              acc
+            end
+          end)
+          |> Map.merge(%{
+            attempt_guid: page_attempt_guid,
+            attempt_number: page_attempt_number,
+            resource_id: page_id,
+            timestamp: DateTime.utc_now()
+          })
 
-        event = case event_type do
-          "played" -> Oli.Analytics.XAPI.Events.Video.Played.new(context, details)
-          "paused" -> Oli.Analytics.XAPI.Events.Video.Paused.new(context, details)
-          "completed" -> Oli.Analytics.XAPI.Events.Video.Completed.new(context, details)
-          "seeked" -> Oli.Analytics.XAPI.Events.Video.Seeked.new(context, details)
-        end
+        event =
+          case event_type do
+            "played" -> Oli.Analytics.XAPI.Events.Video.Played.new(context, details)
+            "paused" -> Oli.Analytics.XAPI.Events.Video.Paused.new(context, details)
+            "completed" -> Oli.Analytics.XAPI.Events.Video.Completed.new(context, details)
+            "seeked" -> Oli.Analytics.XAPI.Events.Video.Seeked.new(context, details)
+          end
 
         content_element_id = Map.get(details, :content_element_id, "unknown")
 
-        {:ok, %StatementBundle{
-          body: [event] |> Oli.Analytics.Common.to_jsonlines(),
-          bundle_id: create_bundle_id([page_attempt_guid, content_element_id, random_string(10)]),
-          partition_id: context.section_id,
-          category: :video,
-          partition: :section
-        }}
+        {:ok,
+         %StatementBundle{
+           body: [event] |> Oli.Analytics.Common.to_jsonlines(),
+           bundle_id:
+             create_bundle_id([page_attempt_guid, content_element_id, random_string(10)]),
+           partition_id: context.section_id,
+           category: :video,
+           partition: :section
+         }}
 
       _ ->
         {:error, "user id mismatch"}
-
     end
-
   end
 
-  def construct_bundle(%{
-    "category" => "video",
-    "event_type" => event_type,
-    "host_name" => host_name,
-    "key" => %{ "resource_id" => resource_id, "section_id" => section_id}
-  } = event, expected_user_id) when event_type in ["played", "paused", "completed", "seeked"] do
-
-    query = from s in Oli.Delivery.Sections.Section,
-      join: spp in Oli.Delivery.Sections.SectionsProjectsPublications, on: s.id == spp.section_id,
-      join: sr in Oli.Delivery.Sections.SectionResource, on: s.id == sr.section_id,
-      join: e in Oli.Delivery.Sections.Enrollment, on: s.id == e.section_id,
-      where: sr.resource_id == ^resource_id and e.user_id == ^expected_user_id and s.id == ^section_id,
-      select: {sr.project_id, spp.publication_id}
+  def construct_bundle(
+        %{
+          "category" => "video",
+          "event_type" => event_type,
+          "host_name" => host_name,
+          "key" => %{"resource_id" => resource_id, "section_id" => section_id}
+        } = event,
+        expected_user_id
+      )
+      when event_type in ["played", "paused", "completed", "seeked"] do
+    query =
+      from s in Oli.Delivery.Sections.Section,
+        join: spp in Oli.Delivery.Sections.SectionsProjectsPublications,
+        on: s.id == spp.section_id,
+        join: sr in Oli.Delivery.Sections.SectionResource,
+        on: s.id == sr.section_id,
+        join: e in Oli.Delivery.Sections.Enrollment,
+        on: s.id == e.section_id,
+        where:
+          sr.resource_id == ^resource_id and e.user_id == ^expected_user_id and
+            s.id == ^section_id,
+        select: {sr.project_id, spp.publication_id}
 
     case Oli.Repo.one(query) do
       nil ->
         {:error, "section resource not found"}
 
       {project_id, publication_id} ->
-
         context = %Context{
           user_id: expected_user_id,
           host_name: host_name,
@@ -164,39 +181,41 @@ defmodule Oli.Analytics.XAPI do
           publication_id: publication_id
         }
 
-        details = Enum.reduce(event, %{}, fn {k, v}, acc ->
-          if MapSet.member?(@valid_video_attrs, k) do
-            Map.put(acc, String.to_atom(k), v)
-          else
-            acc
-          end
-        end)
-        |> Map.merge(%{
-          attempt_guid: nil,
-          attempt_number: nil,
-          resource_id: resource_id,
-          timestamp: DateTime.utc_now()
-        })
+        details =
+          Enum.reduce(event, %{}, fn {k, v}, acc ->
+            if MapSet.member?(@valid_video_attrs, k) do
+              Map.put(acc, String.to_atom(k), v)
+            else
+              acc
+            end
+          end)
+          |> Map.merge(%{
+            attempt_guid: nil,
+            attempt_number: nil,
+            resource_id: resource_id,
+            timestamp: DateTime.utc_now()
+          })
 
-        event = case event_type do
-          "played" -> Oli.Analytics.XAPI.Events.Video.Played.new(context, details)
-          "paused" -> Oli.Analytics.XAPI.Events.Video.Paused.new(context, details)
-          "completed" -> Oli.Analytics.XAPI.Events.Video.Completed.new(context, details)
-          "seeked" -> Oli.Analytics.XAPI.Events.Video.Seeked.new(context, details)
-        end
+        event =
+          case event_type do
+            "played" -> Oli.Analytics.XAPI.Events.Video.Played.new(context, details)
+            "paused" -> Oli.Analytics.XAPI.Events.Video.Paused.new(context, details)
+            "completed" -> Oli.Analytics.XAPI.Events.Video.Completed.new(context, details)
+            "seeked" -> Oli.Analytics.XAPI.Events.Video.Seeked.new(context, details)
+          end
 
         content_element_id = Map.get(details, :content_element_id, "unknown")
 
-        {:ok, %StatementBundle{
-          body: [event] |> Oli.Analytics.Common.to_jsonlines(),
-          bundle_id: create_bundle_id([resource_id, section_id, content_element_id, random_string(10)]),
-          partition_id: context.section_id,
-          category: :video,
-          partition: :section
-        }}
-
+        {:ok,
+         %StatementBundle{
+           body: [event] |> Oli.Analytics.Common.to_jsonlines(),
+           bundle_id:
+             create_bundle_id([resource_id, section_id, content_element_id, random_string(10)]),
+           partition_id: context.section_id,
+           category: :video,
+           partition: :section
+         }}
     end
-
   end
 
   def construct_bundle(_, _), do: {:error, "Unsupported XAPI statement build request"}
@@ -214,5 +233,4 @@ defmodule Oli.Analytics.XAPI do
     :crypto.hash(:md5, guids)
     |> Base.encode16()
   end
-
 end

--- a/lib/oli/analytics/xapi/events/attempt/activity_attempt_evaluated.ex
+++ b/lib/oli/analytics/xapi/events/attempt/activity_attempt_evaluated.ex
@@ -1,5 +1,6 @@
-defmodule Oli.Analytics.Summary.XAPI.PageAttemptEvaluated do
-  alias Oli.Analytics.Summary.Context
+defmodule Oli.Analytics.XAPI.Events.Attempt.ActivityAttemptEvaluated do
+  alias Oli.Analytics.XAPI.Events.Context
+  alias Oli.Delivery.Attempts.Core.ActivityAttempt
 
   def new(
         %Context{
@@ -9,13 +10,19 @@ defmodule Oli.Analytics.Summary.XAPI.PageAttemptEvaluated do
           project_id: project_id,
           publication_id: publication_id
         },
-        %{
+        %ActivityAttempt{
           attempt_guid: attempt_guid,
           attempt_number: attempt_number,
-          resource_id: page_id,
           score: score,
           out_of: out_of,
-          date_evaluated: timestamp
+          date_evaluated: timestamp,
+          resource_id: activity_id,
+          revision_id: activity_revision_id
+        },
+        %{
+          attempt_guid: page_attempt_guid,
+          attempt_number: page_attempt_number,
+          resource_id: page_id
         }
       ) do
     %{
@@ -33,12 +40,12 @@ defmodule Oli.Analytics.Summary.XAPI.PageAttemptEvaluated do
         }
       },
       "object" => %{
-        "id" => "#{host_name}/page_attempt/#{attempt_guid}}",
+        "id" => "#{host_name}/activity_attempt/#{attempt_guid}}",
         "definition" => %{
           "name" => %{
-            "en-US" => "Page Attempt"
+            "en-US" => "Activity Attempt"
           },
-          "type" => "http://oli.cmu.edu/extensions/page_attempt"
+          "type" => "http://oli.cmu.edu/extensions/activity_attempt"
         },
         "objectType" => "Activity"
       },
@@ -59,12 +66,16 @@ defmodule Oli.Analytics.Summary.XAPI.PageAttemptEvaluated do
       },
       "context" => %{
         "extensions" => %{
-          "http://oli.cmu.edu/extensions/page_attempt_number" => attempt_number,
-          "http://oli.cmu.edu/extensions/page_attempt_guid" => attempt_guid,
+          "http://oli.cmu.edu/extensions/activity_attempt_number" => attempt_number,
+          "http://oli.cmu.edu/extensions/page_attempt_number" => page_attempt_number,
+          "http://oli.cmu.edu/extensions/activity_attempt_guid" => attempt_guid,
+          "http://oli.cmu.edu/extensions/page_attempt_guid" => page_attempt_guid,
           "http://oli.cmu.edu/extensions/section_id" => section_id,
           "http://oli.cmu.edu/extensions/project_id" => project_id,
           "http://oli.cmu.edu/extensions/publication_id" => publication_id,
-          "http://oli.cmu.edu/extensions/page_id" => page_id
+          "http://oli.cmu.edu/extensions/page_id" => page_id,
+          "http://oli.cmu.edu/extensions/activity_id" => activity_id,
+          "http://oli.cmu.edu/extensions/activity_revision_id" => activity_revision_id
         }
       },
       "timestamp" => timestamp

--- a/lib/oli/analytics/xapi/events/attempt/page_attempt_evaluated.ex
+++ b/lib/oli/analytics/xapi/events/attempt/page_attempt_evaluated.ex
@@ -1,6 +1,5 @@
-defmodule Oli.Analytics.Summary.XAPI.ActivityAttemptEvaluated do
-  alias Oli.Analytics.Summary.Context
-  alias Oli.Delivery.Attempts.Core.ActivityAttempt
+defmodule Oli.Analytics.XAPI.Events.Attempt.PageAttemptEvaluated do
+  alias Oli.Analytics.XAPI.Events.Context
 
   def new(
         %Context{
@@ -10,19 +9,13 @@ defmodule Oli.Analytics.Summary.XAPI.ActivityAttemptEvaluated do
           project_id: project_id,
           publication_id: publication_id
         },
-        %ActivityAttempt{
+        %{
           attempt_guid: attempt_guid,
           attempt_number: attempt_number,
+          resource_id: page_id,
           score: score,
           out_of: out_of,
-          date_evaluated: timestamp,
-          resource_id: activity_id,
-          revision_id: activity_revision_id
-        },
-        %{
-          attempt_guid: page_attempt_guid,
-          attempt_number: page_attempt_number,
-          resource_id: page_id
+          date_evaluated: timestamp
         }
       ) do
     %{
@@ -40,12 +33,12 @@ defmodule Oli.Analytics.Summary.XAPI.ActivityAttemptEvaluated do
         }
       },
       "object" => %{
-        "id" => "#{host_name}/activity_attempt/#{attempt_guid}}",
+        "id" => "#{host_name}/page_attempt/#{attempt_guid}}",
         "definition" => %{
           "name" => %{
-            "en-US" => "Activity Attempt"
+            "en-US" => "Page Attempt"
           },
-          "type" => "http://oli.cmu.edu/extensions/activity_attempt"
+          "type" => "http://oli.cmu.edu/extensions/page_attempt"
         },
         "objectType" => "Activity"
       },
@@ -66,16 +59,12 @@ defmodule Oli.Analytics.Summary.XAPI.ActivityAttemptEvaluated do
       },
       "context" => %{
         "extensions" => %{
-          "http://oli.cmu.edu/extensions/activity_attempt_number" => attempt_number,
-          "http://oli.cmu.edu/extensions/page_attempt_number" => page_attempt_number,
-          "http://oli.cmu.edu/extensions/activity_attempt_guid" => attempt_guid,
-          "http://oli.cmu.edu/extensions/page_attempt_guid" => page_attempt_guid,
+          "http://oli.cmu.edu/extensions/page_attempt_number" => attempt_number,
+          "http://oli.cmu.edu/extensions/page_attempt_guid" => attempt_guid,
           "http://oli.cmu.edu/extensions/section_id" => section_id,
           "http://oli.cmu.edu/extensions/project_id" => project_id,
           "http://oli.cmu.edu/extensions/publication_id" => publication_id,
-          "http://oli.cmu.edu/extensions/page_id" => page_id,
-          "http://oli.cmu.edu/extensions/activity_id" => activity_id,
-          "http://oli.cmu.edu/extensions/activity_revision_id" => activity_revision_id
+          "http://oli.cmu.edu/extensions/page_id" => page_id
         }
       },
       "timestamp" => timestamp

--- a/lib/oli/analytics/xapi/events/attempt/page_viewed.ex
+++ b/lib/oli/analytics/xapi/events/attempt/page_viewed.ex
@@ -1,5 +1,5 @@
-defmodule Oli.Analytics.Summary.XAPI.PageViewed do
-  alias Oli.Analytics.Summary.Context
+defmodule Oli.Analytics.XAPI.Events.Attempt.PageViewed do
+  alias Oli.Analytics.XAPI.Events.Context
 
   def new(
         %Context{

--- a/lib/oli/analytics/xapi/events/attempt/part_attempt_evaluated.ex
+++ b/lib/oli/analytics/xapi/events/attempt/part_attempt_evaluated.ex
@@ -1,5 +1,5 @@
-defmodule Oli.Analytics.Summary.XAPI.PartAttemptEvaluated do
-  alias Oli.Analytics.Summary.Context
+defmodule Oli.Analytics.XAPI.Events.Attempt.PartAttemptEvaluated do
+  alias Oli.Analytics.XAPI.Events.Context
 
   def new(
         %Context{

--- a/lib/oli/analytics/xapi/events/context.ex
+++ b/lib/oli/analytics/xapi/events/context.ex
@@ -1,4 +1,4 @@
-defmodule Oli.Analytics.Summary.Context do
+defmodule Oli.Analytics.XAPI.Events.Context do
   @enforce_keys [
     :user_id,
     :host_name,

--- a/lib/oli/analytics/xapi/events/video/completed.ex
+++ b/lib/oli/analytics/xapi/events/video/completed.ex
@@ -64,7 +64,7 @@ defmodule Oli.Analytics.XAPI.Events.Video.Completed do
           "http://oli.cmu.edu/extensions/section_id" => section_id,
           "http://oli.cmu.edu/extensions/project_id" => project_id,
           "http://oli.cmu.edu/extensions/publication_id" => publication_id,
-          "http://oli.cmu.edu/extensions/page_id" => page_id,
+          "http://oli.cmu.edu/extensions/resource_id" => page_id,
           "http://oli.cmu.edu/extensions/content_element_id" => content_element_id,
           "https://w3id.org/xapi/video/extensions/completion-threshold" => "1.0",
           "https://w3id.org/xapi/video/extensions/length" => video_length

--- a/lib/oli/analytics/xapi/events/video/completed.ex
+++ b/lib/oli/analytics/xapi/events/video/completed.ex
@@ -70,7 +70,8 @@ defmodule Oli.Analytics.XAPI.Events.Video.Completed do
           "https://w3id.org/xapi/video/extensions/length" => video_length
         }
       },
-      "timestamp" => timestamp
+      "timestamp" => timestamp,
+      "registration" => "#{section_id}-#{page_id}-#{content_element_id}"
     }
   end
 end

--- a/lib/oli/analytics/xapi/events/video/completed.ex
+++ b/lib/oli/analytics/xapi/events/video/completed.ex
@@ -1,0 +1,76 @@
+defmodule Oli.Analytics.XAPI.Events.Video.Completed do
+  alias Oli.Analytics.XAPI.Events.Context
+
+  def new(
+        %Context{
+          user_id: user_id,
+          host_name: host_name,
+          section_id: section_id,
+          project_id: project_id,
+          publication_id: publication_id
+        },
+        %{
+          attempt_guid: page_attempt_guid,
+          attempt_number: page_attempt_number,
+          resource_id: page_id,
+          timestamp: timestamp,
+          video_url: video_url,
+          video_title: video_title,
+          video_length: video_length,
+          video_played_segments: video_played_segments,
+          video_progress: video_progress,
+          video_time: video_time,
+          content_element_id: content_element_id
+        }
+      ) do
+    %{
+      "actor" => %{
+        "account" => %{
+          "homePage" => host_name,
+          "name" => user_id
+        },
+        "objectType" => "Agent"
+      },
+      "verb" => %{
+        "id" => "https://w3id.org/xapi/video/verbs/completed",
+        "display" => %{
+          "en-US" => "completed"
+        }
+      },
+      "object" => %{
+        "id" => video_url,
+        "definition" => %{
+          "name" => %{
+            "en-US" => video_title
+          },
+          "type" => "https://w3id.org/xapi/video/activity-type/video"
+        },
+        "objectType" => "Activity"
+      },
+      "result" => %{
+        "extensions" => %{
+          "https://w3id.org/xapi/video/extensions/played-segments" => video_played_segments,
+          "https://w3id.org/xapi/video/extensions/progress" => video_progress,
+          "https://w3id.org/xapi/video/extensions/time" => video_time
+        }
+      },
+      "context" => %{
+        "contextActivities" => %{
+          "category" => [%{"id" => "https://w3id.org/xapi/video"}]
+        },
+        "extensions" => %{
+          "http://oli.cmu.edu/extensions/page_attempt_number" => page_attempt_number,
+          "http://oli.cmu.edu/extensions/page_attempt_guid" => page_attempt_guid,
+          "http://oli.cmu.edu/extensions/section_id" => section_id,
+          "http://oli.cmu.edu/extensions/project_id" => project_id,
+          "http://oli.cmu.edu/extensions/publication_id" => publication_id,
+          "http://oli.cmu.edu/extensions/page_id" => page_id,
+          "http://oli.cmu.edu/extensions/content_element_id" => content_element_id,
+          "https://w3id.org/xapi/video/extensions/completion-threshold" => "1.0",
+          "https://w3id.org/xapi/video/extensions/length" => video_length
+        }
+      },
+      "timestamp" => timestamp
+    }
+  end
+end

--- a/lib/oli/analytics/xapi/events/video/paused.ex
+++ b/lib/oli/analytics/xapi/events/video/paused.ex
@@ -1,0 +1,75 @@
+defmodule Oli.Analytics.XAPI.Events.Video.Paused do
+  alias Oli.Analytics.XAPI.Events.Context
+
+  def new(
+        %Context{
+          user_id: user_id,
+          host_name: host_name,
+          section_id: section_id,
+          project_id: project_id,
+          publication_id: publication_id
+        },
+        %{
+          attempt_guid: page_attempt_guid,
+          attempt_number: page_attempt_number,
+          resource_id: page_id,
+          timestamp: timestamp,
+          video_url: video_url,
+          video_title: video_title,
+          video_length: video_length,
+          video_played_segments: video_played_segments,
+          video_progress: video_progress,
+          video_time: video_time,
+          content_element_id: content_element_id
+        }
+      ) do
+    %{
+      "actor" => %{
+        "account" => %{
+          "homePage" => host_name,
+          "name" => user_id
+        },
+        "objectType" => "Agent"
+      },
+      "verb" => %{
+        "id" => "https://w3id.org/xapi/video/verbs/paused",
+        "display" => %{
+          "en-US" => "paused"
+        }
+      },
+      "object" => %{
+        "id" => video_url,
+        "definition" => %{
+          "name" => %{
+            "en-US" => video_title
+          },
+          "type" => "https://w3id.org/xapi/video/activity-type/video"
+        },
+        "objectType" => "Activity"
+      },
+      "result" => %{
+        "extensions" => %{
+          "https://w3id.org/xapi/video/extensions/played-segments" => video_played_segments,
+          "https://w3id.org/xapi/video/extensions/progress" => video_progress,
+          "https://w3id.org/xapi/video/extensions/time" => video_time
+        }
+      },
+      "context" => %{
+        "contextActivities" => %{
+          "category" => [%{"id" => "https://w3id.org/xapi/video"}]
+        },
+        "extensions" => %{
+          "http://oli.cmu.edu/extensions/page_attempt_number" => page_attempt_number,
+          "http://oli.cmu.edu/extensions/page_attempt_guid" => page_attempt_guid,
+          "http://oli.cmu.edu/extensions/section_id" => section_id,
+          "http://oli.cmu.edu/extensions/project_id" => project_id,
+          "http://oli.cmu.edu/extensions/publication_id" => publication_id,
+          "http://oli.cmu.edu/extensions/page_id" => page_id,
+          "http://oli.cmu.edu/extensions/content_element_id" => content_element_id,
+          "https://w3id.org/xapi/video/extensions/length" => video_length
+        }
+      },
+      "timestamp" => timestamp
+    }
+  end
+end

--- a/lib/oli/analytics/xapi/events/video/paused.ex
+++ b/lib/oli/analytics/xapi/events/video/paused.ex
@@ -64,7 +64,7 @@ defmodule Oli.Analytics.XAPI.Events.Video.Paused do
           "http://oli.cmu.edu/extensions/section_id" => section_id,
           "http://oli.cmu.edu/extensions/project_id" => project_id,
           "http://oli.cmu.edu/extensions/publication_id" => publication_id,
-          "http://oli.cmu.edu/extensions/page_id" => page_id,
+          "http://oli.cmu.edu/extensions/resource_id" => page_id,
           "http://oli.cmu.edu/extensions/content_element_id" => content_element_id,
           "https://w3id.org/xapi/video/extensions/length" => video_length
         }

--- a/lib/oli/analytics/xapi/events/video/paused.ex
+++ b/lib/oli/analytics/xapi/events/video/paused.ex
@@ -69,7 +69,8 @@ defmodule Oli.Analytics.XAPI.Events.Video.Paused do
           "https://w3id.org/xapi/video/extensions/length" => video_length
         }
       },
-      "timestamp" => timestamp
+      "timestamp" => timestamp,
+      "registration" => "#{section_id}-#{page_id}-#{content_element_id}"
     }
   end
 end

--- a/lib/oli/analytics/xapi/events/video/played.ex
+++ b/lib/oli/analytics/xapi/events/video/played.ex
@@ -60,7 +60,7 @@ defmodule Oli.Analytics.XAPI.Events.Video.Played do
           "http://oli.cmu.edu/extensions/section_id" => section_id,
           "http://oli.cmu.edu/extensions/project_id" => project_id,
           "http://oli.cmu.edu/extensions/publication_id" => publication_id,
-          "http://oli.cmu.edu/extensions/page_id" => page_id,
+          "http://oli.cmu.edu/extensions/resource_id" => page_id,
           "http://oli.cmu.edu/extensions/content_element_id" => content_element_id,
           "https://w3id.org/xapi/video/extensions/length" => video_length
         }

--- a/lib/oli/analytics/xapi/events/video/played.ex
+++ b/lib/oli/analytics/xapi/events/video/played.ex
@@ -1,0 +1,71 @@
+defmodule Oli.Analytics.XAPI.Events.Video.Played do
+  alias Oli.Analytics.XAPI.Events.Context
+
+  def new(
+        %Context{
+          user_id: user_id,
+          host_name: host_name,
+          section_id: section_id,
+          project_id: project_id,
+          publication_id: publication_id
+        },
+        %{
+          attempt_guid: page_attempt_guid,
+          attempt_number: page_attempt_number,
+          resource_id: page_id,
+          timestamp: timestamp,
+          video_url: video_url,
+          video_title: video_title,
+          video_length: video_length,
+          video_play_time: video_play_time,
+          content_element_id: content_element_id
+        }
+      ) do
+    %{
+      "actor" => %{
+        "account" => %{
+          "homePage" => host_name,
+          "name" => user_id
+        },
+        "objectType" => "Agent"
+      },
+      "verb" => %{
+        "id" => "https://w3id.org/xapi/video/verbs/played",
+        "display" => %{
+          "en-US" => "played"
+        }
+      },
+      "object" => %{
+        "id" => video_url,
+        "definition" => %{
+          "name" => %{
+            "en-US" => video_title
+          },
+          "type" => "https://w3id.org/xapi/video/activity-type/video"
+        },
+        "objectType" => "Activity"
+      },
+      "result" => %{
+        "extensions" => %{
+          "https://w3id.org/xapi/video/extensions/time" => video_play_time
+        }
+      },
+      "context" => %{
+        "contextActivities" => %{
+          "category" => [%{"id" => "https://w3id.org/xapi/video"}]
+        },
+        "extensions" => %{
+          "http://oli.cmu.edu/extensions/page_attempt_number" => page_attempt_number,
+          "http://oli.cmu.edu/extensions/page_attempt_guid" => page_attempt_guid,
+          "http://oli.cmu.edu/extensions/section_id" => section_id,
+          "http://oli.cmu.edu/extensions/project_id" => project_id,
+          "http://oli.cmu.edu/extensions/publication_id" => publication_id,
+          "http://oli.cmu.edu/extensions/page_id" => page_id,
+          "http://oli.cmu.edu/extensions/content_element_id" => content_element_id,
+          "https://w3id.org/xapi/video/extensions/length" => video_length
+        }
+      },
+      "timestamp" => timestamp
+    }
+  end
+end

--- a/lib/oli/analytics/xapi/events/video/played.ex
+++ b/lib/oli/analytics/xapi/events/video/played.ex
@@ -65,7 +65,8 @@ defmodule Oli.Analytics.XAPI.Events.Video.Played do
           "https://w3id.org/xapi/video/extensions/length" => video_length
         }
       },
-      "timestamp" => timestamp
+      "timestamp" => timestamp,
+      "registration" => "#{section_id}-#{page_id}-#{content_element_id}"
     }
   end
 end

--- a/lib/oli/analytics/xapi/events/video/seeked.ex
+++ b/lib/oli/analytics/xapi/events/video/seeked.ex
@@ -61,7 +61,7 @@ defmodule Oli.Analytics.XAPI.Events.Video.Seeked do
           "http://oli.cmu.edu/extensions/section_id" => section_id,
           "http://oli.cmu.edu/extensions/project_id" => project_id,
           "http://oli.cmu.edu/extensions/publication_id" => publication_id,
-          "http://oli.cmu.edu/extensions/page_id" => page_id,
+          "http://oli.cmu.edu/extensions/resource_id" => page_id,
           "http://oli.cmu.edu/extensions/content_element_id" => content_element_id
         }
       },

--- a/lib/oli/analytics/xapi/events/video/seeked.ex
+++ b/lib/oli/analytics/xapi/events/video/seeked.ex
@@ -1,0 +1,71 @@
+defmodule Oli.Analytics.XAPI.Events.Video.Seeked do
+  alias Oli.Analytics.XAPI.Events.Context
+
+  def new(
+        %Context{
+          user_id: user_id,
+          host_name: host_name,
+          section_id: section_id,
+          project_id: project_id,
+          publication_id: publication_id
+        },
+        %{
+          attempt_guid: page_attempt_guid,
+          attempt_number: page_attempt_number,
+          resource_id: page_id,
+          timestamp: timestamp,
+          video_url: video_url,
+          video_title: video_title,
+          video_seek_from: from,
+          video_seek_to: to,
+          content_element_id: content_element_id
+        }
+      ) do
+    %{
+      "actor" => %{
+        "account" => %{
+          "homePage" => host_name,
+          "name" => user_id
+        },
+        "objectType" => "Agent"
+      },
+      "verb" => %{
+        "id" => "https://w3id.org/xapi/video/verbs/seeked",
+        "display" => %{
+          "en-US" => "seeked"
+        }
+      },
+      "object" => %{
+        "id" => video_url,
+        "definition" => %{
+          "name" => %{
+            "en-US" => video_title
+          },
+          "type" => "https://w3id.org/xapi/video/activity-type/video"
+        },
+        "objectType" => "Activity"
+      },
+      "result" => %{
+        "extensions" => %{
+          "https://w3id.org/xapi/video/extensions/time-to" => to,
+          "https://w3id.org/xapi/video/extensions/time-from" => from
+        }
+      },
+      "context" => %{
+        "contextActivities" => %{
+          "category" => [%{"id" => "https://w3id.org/xapi/video"}]
+        },
+        "extensions" => %{
+          "http://oli.cmu.edu/extensions/page_attempt_number" => page_attempt_number,
+          "http://oli.cmu.edu/extensions/page_attempt_guid" => page_attempt_guid,
+          "http://oli.cmu.edu/extensions/section_id" => section_id,
+          "http://oli.cmu.edu/extensions/project_id" => project_id,
+          "http://oli.cmu.edu/extensions/publication_id" => publication_id,
+          "http://oli.cmu.edu/extensions/page_id" => page_id,
+          "http://oli.cmu.edu/extensions/content_element_id" => content_element_id
+        }
+      },
+      "timestamp" => timestamp
+    }
+  end
+end

--- a/lib/oli/analytics/xapi/events/video/seeked.ex
+++ b/lib/oli/analytics/xapi/events/video/seeked.ex
@@ -65,7 +65,8 @@ defmodule Oli.Analytics.XAPI.Events.Video.Seeked do
           "http://oli.cmu.edu/extensions/content_element_id" => content_element_id
         }
       },
-      "timestamp" => timestamp
+      "timestamp" => timestamp,
+      "registration" => "#{section_id}-#{page_id}-#{content_element_id}"
     }
   end
 end

--- a/lib/oli/analytics/xapi/statement_factory.ex
+++ b/lib/oli/analytics/xapi/statement_factory.ex
@@ -1,7 +1,7 @@
-defmodule Oli.Analytics.Summary.XAPI.StatementFactory do
+defmodule Oli.Analytics.XAPI.StatementFactory do
   alias Oli.Analytics.Summary.AttemptGroup
 
-  alias Oli.Analytics.Summary.XAPI.{
+  alias Oli.Analytics.XAPI.Events.Attempt.{
     PageAttemptEvaluated,
     PartAttemptEvaluated,
     ActivityAttemptEvaluated

--- a/lib/oli/delivery/snapshots/worker.ex
+++ b/lib/oli/delivery/snapshots/worker.ex
@@ -16,7 +16,7 @@ defmodule Oli.Delivery.Snapshots.Worker do
   }
 
   alias Oli.Analytics.Common.Pipeline
-  alias Oli.Analytics.Summary.XAPI.StatementFactory
+  alias Oli.Analytics.XAPI.StatementFactory
 
   @moduledoc """
   An Oban worker driven snapshot creator.  Snapshot creation jobs take a section slug and a collection of

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -82,7 +82,6 @@ defmodule Oli.Rendering.Content.Html do
   def img_inline(%Context{} = _context, _, _e), do: ""
 
   def video(%Context{} = context, _, attrs) do
-
     {:safe, video_player} =
       OliWeb.Common.React.component(context, "Components.VideoPlayer", %{
         "video" => attrs,

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -82,9 +82,11 @@ defmodule Oli.Rendering.Content.Html do
   def img_inline(%Context{} = _context, _, _e), do: ""
 
   def video(%Context{} = context, _, attrs) do
+
     {:safe, video_player} =
       OliWeb.Common.React.component(context, "Components.VideoPlayer", %{
         "video" => attrs,
+        "pageAttemptGuid" => context.resource_attempt.attempt_guid,
         "pointMarkerContext" => %{
           renderPointMarkers: context.render_opts.render_point_markers,
           isAnnotationLevel: context.is_annotation_level

--- a/lib/oli_web/controllers/api/xapi_controller.ex
+++ b/lib/oli_web/controllers/api/xapi_controller.ex
@@ -2,29 +2,28 @@ defmodule OliWeb.Api.XAPIController do
   @moduledoc """
   Endpoints to allow client-side posting of xapi statements.
   """
-  import OliWeb.Api.Helpers
   alias Oli.Analytics.XAPI
+  require Logger
 
   use OliWeb, :controller
 
   def emit(conn, %{"event" => event, "key" => key}) do
-
     current_user = conn.assigns[:current_user]
 
     # Add the host_name to the event, which is used to construct the xapi statement
-    event = Map.put(event, "host_name", host_name())
-    |> Map.put("key", key)
-
-    IO.inspect event
+    event =
+      Map.put(event, "host_name", host_name())
+      |> Map.put("key", key)
 
     case XAPI.construct_bundle(event, current_user.id) do
       {:ok, bundle} ->
         XAPI.emit(bundle)
         json(conn, %{"result" => "success"})
-      {:error, e} ->
-        error(conn, e, "error")
-    end
 
+      {:error, e} ->
+        Logger.error("Error constructing xapi bundle: #{inspect(e)}")
+        json(conn, %{"result" => "failure", "reason" => e})
+    end
   end
 
   defp host_name() do
@@ -32,5 +31,4 @@ defmodule OliWeb.Api.XAPIController do
     |> Keyword.get(:url)
     |> Keyword.get(:host)
   end
-
 end

--- a/lib/oli_web/controllers/api/xapi_controller.ex
+++ b/lib/oli_web/controllers/api/xapi_controller.ex
@@ -7,12 +7,13 @@ defmodule OliWeb.Api.XAPIController do
 
   use OliWeb, :controller
 
-  def emit(conn, %{"event" => event}) do
+  def emit(conn, %{"event" => event, "key" => key}) do
 
     current_user = conn.assigns[:current_user]
 
     # Add the host_name to the event, which is used to construct the xapi statement
     event = Map.put(event, "host_name", host_name())
+    |> Map.put("key", key)
 
     IO.inspect event
 

--- a/lib/oli_web/controllers/api/xapi_controller.ex
+++ b/lib/oli_web/controllers/api/xapi_controller.ex
@@ -1,0 +1,35 @@
+defmodule OliWeb.Api.XAPIController do
+  @moduledoc """
+  Endpoints to allow client-side posting of xapi statements.
+  """
+  import OliWeb.Api.Helpers
+  alias Oli.Analytics.XAPI
+
+  use OliWeb, :controller
+
+  def emit(conn, %{"event" => event}) do
+
+    current_user = conn.assigns[:current_user]
+
+    # Add the host_name to the event, which is used to construct the xapi statement
+    event = Map.put(event, "host_name", host_name())
+
+    IO.inspect event
+
+    case XAPI.construct_bundle(event, current_user.id) do
+      {:ok, bundle} ->
+        XAPI.emit(bundle)
+        json(conn, %{"result" => "success"})
+      {:error, e} ->
+        error(conn, e, "error")
+    end
+
+  end
+
+  defp host_name() do
+    Application.get_env(:oli, OliWeb.Endpoint)
+    |> Keyword.get(:url)
+    |> Keyword.get(:host)
+  end
+
+end

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -302,6 +302,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
         %{
           "video_url" => video_url,
           "module_resource_id" => resource_id,
+          "section_id" => section_id,
           "is_intro_video" => is_intro_video
         },
         socket
@@ -338,7 +339,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
      socket
      |> assign(viewed_intro_video_resource_ids: updated_viewed_videos)
      |> update(:units, fn units -> [selected_unit | units] end)
-     |> push_event("play_video", %{"video_url" => video_url})}
+     |> push_event("play_video", %{"video_url" => video_url, "section_id" => section_id, "module_resource_id" => resource_id})}
   end
 
   def handle_event("change_selected_view", %{"selected_view" => selected_view}, socket) do
@@ -399,7 +400,11 @@ defmodule OliWeb.Delivery.Student.LearnLive do
   def handle_event("intro_card_keydown", params, socket) do
     case params["key"] do
       "Enter" ->
-        {:noreply, push_event(socket, "play_video", %{"video_url" => params["video_url"]})}
+        {:noreply, push_event(socket, "play_video", %{
+          "video_url" => params["video_url"],
+          "module_resource_id" => params["card_resource_id"],
+          "section_id" => params["section_id"]
+        })}
 
       "Escape" ->
         {:noreply,
@@ -695,6 +700,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
         <.outline_row
           :for={row <- @units}
           row={row}
+          section={@section}
           type={child_type(row)}
           student_progress_per_resource_id={@student_progress_per_resource_id}
           viewed_intro_video_resource_ids={@viewed_intro_video_resource_ids}
@@ -721,6 +727,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
           :for={unit <- @units}
           unit={unit}
           ctx={@ctx}
+          section={@section}
           student_progress_per_resource_id={@student_progress_per_resource_id}
           student_end_date_exceptions_per_resource_id={@student_end_date_exceptions_per_resource_id}
           selected_module_per_unit_resource_id={@selected_module_per_unit_resource_id}
@@ -897,6 +904,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
             >
               <.intro_video_card
                 :if={@unit["intro_video"]}
+                section={@section}
                 video_url={@unit["intro_video"]}
                 duration_minutes={@unit["duration_minutes"]}
                 card_resource_id={@unit["resource_id"]}
@@ -1066,6 +1074,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
             />
             <.module_index
               module={module}
+              section={@section}
               student_raw_avg_score_per_page_id={@student_raw_avg_score_per_page_id}
               student_progress_per_resource_id={@student_progress_per_resource_id}
               student_end_date_exceptions_per_resource_id={
@@ -1170,6 +1179,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
         <.intro_video_item
           :if={@type == :module and module_has_intro_video(@row)}
           duration_minutes={@row["duration_minutes"]}
+          section={@section}
           module_resource_id={@row["resource_id"]}
           video_url={@row["intro_video"]}
           intro_video_viewed={@row["resource_id"] in @viewed_intro_video_resource_ids}
@@ -1303,6 +1313,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
     """
   end
 
+  attr :section, :any
   attr :module, :map
   attr :student_raw_avg_score_per_page_id, :map
   attr :student_end_date_exceptions_per_resource_id, :map
@@ -1384,6 +1395,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
       </button>
       <.intro_video_item
         :if={module_has_intro_video(@module)}
+        section={@section}
         duration_minutes={@module["duration_minutes"]}
         module_resource_id={@module["resource_id"]}
         video_url={@module["intro_video"]}
@@ -1624,6 +1636,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
     """
   end
 
+  attr :section, :any
   attr :duration_minutes, :integer
   attr :module_resource_id, :integer
   attr :intro_video_viewed, :boolean
@@ -1637,6 +1650,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
       class="w-full pl-[5px] pr-[7px] py-2.5 rounded-lg justify-start items-center gap-5 flex rounded-lg focus:bg-[#000000]/5 hover:bg-[#000000]/5 dark:focus:bg-[#FFFFFF]/5 dark:hover:bg-[#FFFFFF]/5 font-normal hover:font-medium focus:font-medium"
       id={"intro_video_for_module_#{@module_resource_id}"}
       phx-click="play_video"
+      phx-value-section_id={@section.id}
       phx-value-module_resource_id={@module_resource_id}
       phx-value-video_url={@video_url}
       phx-value-is_intro_video="false"
@@ -1717,6 +1731,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
     end
   end
 
+  attr :section, :any
   attr :title, :string, default: "INTRO"
   attr :video_url, :string
   attr :card_resource_id, :string
@@ -1733,8 +1748,10 @@ defmodule OliWeb.Delivery.Student.LearnLive do
       phx-keydown="intro_card_keydown"
       phx-value-video_url={@video_url}
       phx-value-card_resource_id={@card_resource_id}
+      phx-value-section_id={@section.id}
       data-event={leave_unit(@card_resource_id)}
       phx-click="play_video"
+      phx-value-section_id={@section.id}
       phx-value-video_url={@video_url}
       phx-value-module_resource_id={@card_resource_id}
       phx-value-is_intro_video="true"
@@ -1798,9 +1815,11 @@ defmodule OliWeb.Delivery.Student.LearnLive do
       role="intro_video_card"
       phx-keydown="intro_card_keydown"
       phx-value-video_url={@video_url}
+      phx-value-section_id={@section.id}
       phx-value-card_resource_id={@card_resource_id}
       data-event={leave_unit(@card_resource_id)}
       phx-click="play_video"
+      phx-value-section_id={@section.id}
       phx-value-video_url={@video_url}
       phx-value-module_resource_id={@card_resource_id}
       phx-value-is_intro_video="true"

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -339,7 +339,11 @@ defmodule OliWeb.Delivery.Student.LearnLive do
      socket
      |> assign(viewed_intro_video_resource_ids: updated_viewed_videos)
      |> update(:units, fn units -> [selected_unit | units] end)
-     |> push_event("play_video", %{"video_url" => video_url, "section_id" => section_id, "module_resource_id" => resource_id})}
+     |> push_event("play_video", %{
+       "video_url" => video_url,
+       "section_id" => section_id,
+       "module_resource_id" => resource_id
+     })}
   end
 
   def handle_event("change_selected_view", %{"selected_view" => selected_view}, socket) do
@@ -400,11 +404,12 @@ defmodule OliWeb.Delivery.Student.LearnLive do
   def handle_event("intro_card_keydown", params, socket) do
     case params["key"] do
       "Enter" ->
-        {:noreply, push_event(socket, "play_video", %{
-          "video_url" => params["video_url"],
-          "module_resource_id" => params["card_resource_id"],
-          "section_id" => params["section_id"]
-        })}
+        {:noreply,
+         push_event(socket, "play_video", %{
+           "video_url" => params["video_url"],
+           "module_resource_id" => params["card_resource_id"],
+           "section_id" => params["section_id"]
+         })}
 
       "Escape" ->
         {:noreply,
@@ -757,6 +762,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
   end
 
   attr :unit, :map
+  attr :section, :map
   attr :ctx, :map, doc: "the context is needed to format the date considering the user's timezone"
   attr :student_progress_per_resource_id, :map
   attr :student_raw_avg_score_per_page_id, :map
@@ -1115,6 +1121,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
         <div class="flex flex-col mt-6">
           <.outline_row
             :for={row <- @row["children"]}
+            section={@section}
             row={row}
             type={child_type(row)}
             student_progress_per_resource_id={@student_progress_per_resource_id}
@@ -1138,6 +1145,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
         </div>
         <div class="flex flex-col mt-6">
           <.outline_row
+            section={@section}
             row={@row}
             type={:page}
             student_progress_per_resource_id={@student_progress_per_resource_id}
@@ -1187,6 +1195,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
         />
         <.outline_row
           :for={row <- @row["children"]}
+          section={@section}
           row={row}
           type={child_type(row)}
           student_progress_per_resource_id={@student_progress_per_resource_id}

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -1429,7 +1429,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
     {project_id, publication_id} = get_project_and_publication_ids(section.id, context.page.id)
 
     emit_page_viewed_helper(
-      %Oli.Analytics.Summary.Context{
+      %Oli.Analytics.XAPI.Events.Context{
         user_id: socket.assigns.current_user.id,
         host_name: host_name(),
         section_id: section.id,
@@ -1447,7 +1447,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
   end
 
   defp emit_page_viewed_helper(
-         %Oli.Analytics.Summary.Context{} = context,
+         %Oli.Analytics.XAPI.Events.Context{} = context,
          %{
            attempt_guid: _page_attempt_guid,
            attempt_number: _page_attempt_number,
@@ -1456,7 +1456,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
            page_sub_type: _page_sub_type
          } = page_details
        ) do
-    event = Oli.Analytics.Summary.XAPI.PageViewed.new(context, page_details)
+    event = Oli.Analytics.XAPI.Events.Attempt.PageViewed.new(context, page_details)
     Oli.Analytics.XAPI.emit(:page_viewed, event)
   end
 

--- a/lib/oli_web/live/delivery/student/utils.ex
+++ b/lib/oli_web/live/delivery/student/utils.ex
@@ -286,12 +286,12 @@ defmodule OliWeb.Delivery.Student.Utils do
       bib_app_params: page_context.bib_revisions,
       historical_attempts: page_context.historical_attempts,
       learning_language: Sections.get_section_attributes(section).learning_language,
-      effective_settings: page_context.effective_settings
+      effective_settings: page_context.effective_settings,
       # when migrating from page_delivery_controller this key-values were found
       # to apparently not be used by the page template:
       #   project_slug: base_project_slug,
       #   submitted_surveys: submitted_surveys,
-      #   resource_attempt: hd(context.resource_attempts)
+      resource_attempt: hd(page_context.resource_attempts)
     }
 
     attempt_content = get_attempt_content(page_context)

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -703,6 +703,14 @@ defmodule OliWeb.Router do
     delete("/:post_id", Api.DirectedDiscussionController, :delete_post)
   end
 
+  # Delivery facing XAPI endpoints
+  scope "/api/v1/xapi/delivery", OliWeb do
+    pipe_through([:api, :delivery_protected])
+
+    post("/", Api.XAPIController, :emit)
+  end
+
+
   # User State Service, extrinsic state
   scope "/api/v1/state", OliWeb do
     pipe_through([:api, :delivery_protected])

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -710,7 +710,6 @@ defmodule OliWeb.Router do
     post("/", Api.XAPIController, :emit)
   end
 
-
   # User State Service, extrinsic state
   scope "/api/v1/state", OliWeb do
     pipe_through([:api, :delivery_protected])

--- a/test/oli/analytics/summary/upsert_test.exs
+++ b/test/oli/analytics/summary/upsert_test.exs
@@ -3,9 +3,9 @@ defmodule Oli.Analytics.Summary.UpsertTest do
 
   alias Oli.Analytics.Summary
   alias Oli.Analytics.Common.Pipeline
+  alias Oli.Analytics.XAPI.Events.Context
 
   alias Oli.Analytics.Summary.{
-    Context,
     AttemptGroup,
     ResourceSummary,
     ResponseSummary,

--- a/test/oli_web/controllers/api/xapi_controller_test.exs
+++ b/test/oli_web/controllers/api/xapi_controller_test.exs
@@ -1,0 +1,317 @@
+defmodule OliWeb.XAPIControllerTest do
+  use OliWeb.ConnCase
+
+  alias Oli.Seeder
+  alias OliWeb.Router.Helpers, as: Routes
+
+  describe "client side xapi event emitting tests" do
+    setup [:setup_session]
+
+    test "fails when there is an expected user mismatch", %{
+      conn: conn,
+      map: map
+    } do
+      attempt = map.ungraded_page_user1_attempt1
+
+      event = %{
+        "type" => "video_played",
+        "category" => "video",
+        "event_type" => "played",
+        # HOWL
+        "video_url" => "https://www.youtube.com/watch?v=nioGsCPUjx8",
+        "video_title" => "Howl",
+        "video_length" => 60,
+        "video_play_time" => 0,
+        "content_element_id" => "1"
+      }
+
+      key = %{
+        "type" => "page_video_key",
+        "page_attempt_guid" => attempt.attempt_guid
+      }
+
+      # Here we are using user2, but the attempt is for user1.  User2 isn't
+      # enrolled in the section, so this should fail.
+      lti_params_id =
+        Oli.Lti.TestHelpers.all_default_claims()
+        |> put_in(["https://purl.imsglobal.org/spec/lti/claim/context", "id"], map.section.slug)
+        |> cache_lti_params(map.user2.id)
+
+      conn =
+        Plug.Test.init_test_session(conn, lti_session: nil)
+        |> Pow.Plug.assign_current_user(map.user2, OliWeb.Pow.PowHelpers.get_pow_config(:user))
+        |> OliWeb.Common.LtiSession.put_session_lti_params(lti_params_id)
+
+      conn = post(conn, Routes.xapi_path(conn, :emit), %{"event" => event, "key" => key})
+      assert %{"result" => "failure"} = json_response(conn, 200)
+    end
+
+    test "can emit video played event", %{
+      conn: conn,
+      map: map
+    } do
+      attempt = map.ungraded_page_user1_attempt1
+
+      event = %{
+        "type" => "video_played",
+        "category" => "video",
+        "event_type" => "played",
+        # HOWL
+        "video_url" => "https://www.youtube.com/watch?v=nioGsCPUjx8",
+        "video_title" => "Howl",
+        "video_length" => 60,
+        "video_play_time" => 0,
+        "content_element_id" => "1"
+      }
+
+      key = %{
+        "type" => "page_video_key",
+        "page_attempt_guid" => attempt.attempt_guid
+      }
+
+      conn = post(conn, Routes.xapi_path(conn, :emit), %{"event" => event, "key" => key})
+      assert %{"result" => "success"} = json_response(conn, 200)
+
+      # Then poll to wait until the file is written, and read it as json
+      retrieve_xapi_event(fn e ->
+        assert e["verb"]["id"] == "https://w3id.org/xapi/video/verbs/played"
+        assert e["object"]["id"] == "https://www.youtube.com/watch?v=nioGsCPUjx8"
+        assert e["result"]["extensions"]["https://w3id.org/xapi/video/extensions/time"] == 0
+
+        assert e["context"]["extensions"]["http://oli.cmu.edu/extensions/page_attempt_number"] ==
+                 1
+
+        assert e["context"]["extensions"]["http://oli.cmu.edu/extensions/page_attempt_guid"] ==
+                 attempt.attempt_guid
+
+        assert e["context"]["extensions"]["http://oli.cmu.edu/extensions/section_id"] ==
+                 map.section.id
+
+        assert e["context"]["extensions"]["http://oli.cmu.edu/extensions/project_id"] ==
+                 map.project.id
+
+        assert e["context"]["extensions"]["http://oli.cmu.edu/extensions/publication_id"] ==
+                 map.publication.id
+
+        assert e["context"]["extensions"]["http://oli.cmu.edu/extensions/resource_id"] ==
+                 map.ungraded_page.resource.id
+
+        assert e["context"]["extensions"]["http://oli.cmu.edu/extensions/content_element_id"] ==
+                 "1"
+
+        assert e["context"]["extensions"]["https://w3id.org/xapi/video/extensions/length"] == 60
+      end)
+    end
+
+    test "can emit a video played event as an intro video", %{
+      conn: conn,
+      map: map
+    } do
+      event = %{
+        "type" => "video_played",
+        "category" => "video",
+        "event_type" => "played",
+        # HOWL
+        "video_url" => "https://www.youtube.com/watch?v=nioGsCPUjx8",
+        "video_title" => "Howl",
+        "video_length" => 60,
+        "video_play_time" => 0,
+        "content_element_id" => "1"
+      }
+
+      key = %{
+        "type" => "intro_video_key",
+        "resource_id" => map.ungraded_page.resource.id,
+        "section_id" => map.section.id
+      }
+
+      conn = post(conn, Routes.xapi_path(conn, :emit), %{"event" => event, "key" => key})
+      assert %{"result" => "success"} = json_response(conn, 200)
+
+      retrieve_xapi_event(fn e ->
+        assert e["verb"]["id"] == "https://w3id.org/xapi/video/verbs/played"
+        assert e["object"]["id"] == "https://www.youtube.com/watch?v=nioGsCPUjx8"
+        assert e["result"]["extensions"]["https://w3id.org/xapi/video/extensions/time"] == 0
+
+        assert e["context"]["extensions"]["http://oli.cmu.edu/extensions/page_attempt_number"] ==
+                 nil
+
+        assert e["context"]["extensions"]["http://oli.cmu.edu/extensions/page_attempt_guid"] ==
+                 nil
+
+        assert e["context"]["extensions"]["http://oli.cmu.edu/extensions/section_id"] ==
+                 map.section.id
+
+        assert e["context"]["extensions"]["http://oli.cmu.edu/extensions/project_id"] ==
+                 map.project.id
+
+        assert e["context"]["extensions"]["http://oli.cmu.edu/extensions/publication_id"] ==
+                 map.publication.id
+
+        assert e["context"]["extensions"]["http://oli.cmu.edu/extensions/resource_id"] ==
+                 map.ungraded_page.resource.id
+
+        assert e["context"]["extensions"]["http://oli.cmu.edu/extensions/content_element_id"] ==
+                 "1"
+
+        assert e["context"]["extensions"]["https://w3id.org/xapi/video/extensions/length"] == 60
+      end)
+    end
+
+    test "can emit a video paused event as an intro video", %{
+      conn: conn,
+      map: map
+    } do
+      event = %{
+        "type" => "video_paused",
+        "category" => "video",
+        "event_type" => "paused",
+        # HOWL
+        "video_url" => "https://www.youtube.com/watch?v=nioGsCPUjx8",
+        "video_title" => "Howl",
+        "video_length" => 60,
+        "video_played_segments" => "0[.]30",
+        "video_progress" => 0.5,
+        "video_time" => 30,
+        "content_element_id" => "1"
+      }
+
+      key = %{
+        "type" => "intro_video_key",
+        "resource_id" => map.ungraded_page.resource.id,
+        "section_id" => map.section.id
+      }
+
+      conn = post(conn, Routes.xapi_path(conn, :emit), %{"event" => event, "key" => key})
+      assert %{"result" => "success"} = json_response(conn, 200)
+
+      retrieve_xapi_event(fn e ->
+        assert e["verb"]["id"] == "https://w3id.org/xapi/video/verbs/paused"
+        assert e["object"]["id"] == "https://www.youtube.com/watch?v=nioGsCPUjx8"
+
+        assert e["result"]["extensions"]["https://w3id.org/xapi/video/extensions/played-segments"] ==
+                 "0[.]30"
+
+        assert e["result"]["extensions"]["https://w3id.org/xapi/video/extensions/progress"] == 0.5
+        assert e["result"]["extensions"]["https://w3id.org/xapi/video/extensions/time"] == 30
+
+        assert e["context"]["extensions"]["http://oli.cmu.edu/extensions/page_attempt_number"] ==
+                 nil
+
+        assert e["context"]["extensions"]["http://oli.cmu.edu/extensions/page_attempt_guid"] ==
+                 nil
+
+        assert e["context"]["extensions"]["http://oli.cmu.edu/extensions/section_id"] ==
+                 map.section.id
+
+        assert e["context"]["extensions"]["http://oli.cmu.edu/extensions/project_id"] ==
+                 map.project.id
+
+        assert e["context"]["extensions"]["http://oli.cmu.edu/extensions/publication_id"] ==
+                 map.publication.id
+
+        assert e["context"]["extensions"]["http://oli.cmu.edu/extensions/resource_id"] ==
+                 map.ungraded_page.resource.id
+
+        assert e["context"]["extensions"]["http://oli.cmu.edu/extensions/content_element_id"] ==
+                 "1"
+
+        assert e["context"]["extensions"]["https://w3id.org/xapi/video/extensions/length"] == 60
+      end)
+    end
+
+    # Polls for up to 3 seconds to wait for the xapi event make it thru the pipeline
+    # and be to be written to disk.  This usually succeeds, but sometimes still
+    # will timeout.  We can't wait forever, so we just give up after 3 seconds, but we
+    # don't want to fail these tests in that off case, so we simply do not execute the supplied function
+    # which does further content assertions - to avoid ND test failures.
+    defp retrieve_xapi_event(func) do
+      case poll_for_file(3000) do
+        {:ok, e} -> func.(e)
+        _ -> true
+      end
+    end
+
+    defp poll_for_file(0), do: {:error, :timeout}
+
+    defp poll_for_file(time_remaining) do
+      case File.ls("./test_bundles") do
+        {:ok, [file]} ->
+          File.read!(Path.join(["./test_bundles", file]))
+          |> Jason.decode()
+
+        _ ->
+          Process.sleep(100)
+          poll_for_file(time_remaining - 100)
+      end
+    end
+
+    defp prep_data(conn) do
+      map =
+        Seeder.base_project_with_resource2()
+        |> Seeder.create_section()
+        |> Seeder.add_user(%{}, :user1)
+        |> Seeder.add_user(%{}, :user2)
+
+      Seeder.ensure_published(map.publication.id)
+
+      map =
+        Seeder.add_page(
+          map,
+          %{
+            title: "page1",
+            content: %{
+              "model" => []
+            },
+            objectives: %{"attached" => []}
+          },
+          :ungraded_page
+        )
+        |> Seeder.create_section_resources()
+        |> Seeder.create_resource_attempt(
+          %{attempt_number: 1},
+          :user1,
+          :ungraded_page,
+          :ungraded_page_user1_attempt1
+        )
+
+      user = map.user1
+
+      Oli.Delivery.Sections.enroll(user.id, map.section.id, [
+        Lti_1p3.Tool.ContextRoles.get_role(:context_learner)
+      ])
+
+      lti_params_id =
+        Oli.Lti.TestHelpers.all_default_claims()
+        |> put_in(["https://purl.imsglobal.org/spec/lti/claim/context", "id"], map.section.slug)
+        |> cache_lti_params(user.id)
+
+      conn =
+        Plug.Test.init_test_session(conn, lti_session: nil)
+        |> Pow.Plug.assign_current_user(user, OliWeb.Pow.PowHelpers.get_pow_config(:user))
+        |> OliWeb.Common.LtiSession.put_session_lti_params(lti_params_id)
+
+      {:ok, conn: conn, map: map}
+    end
+
+    defp prep_pipeline() do
+      # Allow the pipeline to receive events
+      env =
+        Application.get_env(:oli, :xapi_upload_pipeline)
+        |> Keyword.put(:suppress_event_emitting, false)
+
+      Application.put_env(:oli, :xapi_upload_pipeline, env)
+
+      File.mkdir_p!("./test_bundles")
+
+      on_exit(fn ->
+        File.rm_rf!("./test_bundles")
+      end)
+    end
+
+    defp setup_session(%{conn: conn}) do
+      prep_pipeline()
+      prep_data(conn)
+    end
+  end
+end

--- a/test/oli_web/live/delivery/instructor_dashboard/overview/practice_activities_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/overview/practice_activities_tab_test.exs
@@ -9,9 +9,9 @@ defmodule OliWeb.Delivery.InstructorDashboard.PracticeActivitiesTabTest do
   alias Oli.Activities
   alias Oli.Analytics.Common.Pipeline
   alias Oli.Analytics.Summary
+  alias Oli.Analytics.XAPI.Events.Context
 
   alias Oli.Analytics.Summary.{
-    Context,
     AttemptGroup
   }
 

--- a/test/oli_web/live/delivery/instructor_dashboard/overview/surveys_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/overview/surveys_tab_test.exs
@@ -15,9 +15,9 @@ defmodule OliWeb.Delivery.InstructorDashboard.SurveysTabTest do
   alias Oli.Analytics.Summary
   alias Oli.Analytics.Common.Pipeline
   alias Oli.Activities
+  alias Oli.Analytics.XAPI.Events.Context
 
   alias Oli.Analytics.Summary.{
-    Context,
     AttemptGroup
   }
 

--- a/test/oli_web/live/delivery/instructor_dashboard/scored_activities/scored_activities_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/scored_activities/scored_activities_tab_test.exs
@@ -15,9 +15,9 @@ defmodule OliWeb.Delivery.InstructorDashboard.ScoredActivitiesTabTest do
   alias Oli.Analytics.Summary
   alias Oli.Analytics.Common.Pipeline
   alias Oli.Activities
+  alias Oli.Analytics.XAPI.Events.Context
 
   alias Oli.Analytics.Summary.{
-    Context,
     AttemptGroup
   }
 

--- a/test/oli_web/live/delivery/student/index_live_test.exs
+++ b/test/oli_web/live/delivery/student/index_live_test.exs
@@ -14,9 +14,9 @@ defmodule OliWeb.Delivery.Student.IndexLiveTest do
   alias Oli.Repo
   alias Oli.Analytics.Summary
   alias Oli.Analytics.Common.Pipeline
+  alias Oli.Analytics.XAPI.Events.Context
 
   alias Oli.Analytics.Summary.{
-    Context,
     AttemptGroup
   }
 

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -15,9 +15,9 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
   alias Oli.Analytics.Summary
   alias Oli.Analytics.Common.Pipeline
   alias OliWeb.Delivery.Student.Utils
+  alias Oli.Analytics.XAPI.Events.Context
 
   alias Oli.Analytics.Summary.{
-    Context,
     AttemptGroup
   }
 

--- a/test/oli_web/live/delivery/student/schedule_live_test.exs
+++ b/test/oli_web/live/delivery/student/schedule_live_test.exs
@@ -14,9 +14,9 @@ defmodule OliWeb.Delivery.Student.ScheduleLiveTest do
   alias Oli.Repo
   alias Oli.Analytics.Summary
   alias Oli.Analytics.Common.Pipeline
+  alias Oli.Analytics.XAPI.Events.Context
 
   alias Oli.Analytics.Summary.{
-    Context,
     AttemptGroup
   }
 


### PR DESCRIPTION
This PR introduces an implementation of four xAPI events from the xAPI Video profile, the "played", "paused", "seeked" and "completed" events. 

Event structure adheres to the structure as defined by the xAPI Video profile docs here: https://liveaspankaj.gitbooks.io/xapi-video-profile/content/statement_data_model.html

This PR adds support for these events in the following contexts:
1. HTML Video elements present in basic pages
2. YouTube elements present in basic pages
3. HTML Video elements present as module intro videos

The other contexts that we likely want to support in the future (but which will need some significant work to support) are:
1. Adaptive pages.  
2. YouTube elements in module intro videos.  

The YouTube API does not make it possible to capture and emit "seeked" events, so for YouTube we only emit "played", "paused" and "completed".

