### PR TITLE
[BUG FIX] [NG23-216] Fix dark mode in Scheduling page

### DIFF
--- a/assets/src/apps/scheduler/ScheduleGrid.tsx
+++ b/assets/src/apps/scheduler/ScheduleGrid.tsx
@@ -66,14 +66,14 @@ const LegendIconItem: React.FC<{ icon: string; text: string; color: string }> = 
   text,
   color,
 }) => (
-  <span className="inline-flex items-center mr-4 rounded-md bg-gray-100 py-1 px-3">
+  <span className="inline-flex items-center mr-4 rounded-md bg-gray-100 py-1 px-3 dark:bg-black">
     <i className={`fa fa-${icon} mr-3 ${color}`} />
     {text}
   </span>
 );
 
 const LegendBarItem: React.FC = () => (
-  <span className="inline-flex items-center mr-4 rounded-md bg-gray-100 py-1 px-3">
+  <span className="inline-flex items-center mr-4 rounded-md bg-gray-100 py-1 px-3 dark:bg-black">
     <span className="inline-block rounded bg-delivery-primary-300 dark:bg-delivery-primary-600 h-5 justify-between p-0.5 cursor-move w-10 mr-3" />
     Suggested Range
   </span>


### PR DESCRIPTION
[NG23-216](https://eliterate.atlassian.net/browse/NG23-216)

Fix text styling for dark mode in the Legend section of the Scheduling page (`/sections/{SECTION_SLUG}/schedule`).

**Before**:
<img width="1484" alt="Screenshot 2024-05-28 at 10 18 20 AM" src="https://github.com/Simon-Initiative/oli-torus/assets/26532202/d30e98ee-2e57-453b-94c8-8f646806691b">


**After:**
<img width="1495" alt="Screenshot 2024-05-28 at 10 16 58 AM" src="https://github.com/Simon-Initiative/oli-torus/assets/26532202/60e27a14-48fb-4fbc-be94-5c99b7ca287a">





[NG23-216]: https://eliterate.atlassian.net/browse/NG23-216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ