### PR TITLE
[BUG FIX] [MER-3286] [MER-3315] Fix evaluation of e-notation with positive exponent, no decimal point

### DIFF
--- a/lib/oli/delivery/evaluation/rule.ex
+++ b/lib/oli/delivery/evaluation/rule.ex
@@ -188,11 +188,11 @@ defmodule Oli.Delivery.Evaluation.Rule do
   defp is_range?(str), do: String.starts_with?(str, ["[", "("])
 
   defp is_float?(str),
-    do: String.contains?(str, ".") or String.contains?(str, "e")
+    do: String.contains?(str, ".") or String.contains?(str, "e") or String.contains?(str, "E")
 
   defp parse_range(range_str) do
     case Regex.run(
-           ~r/([[(])\s*(-?[-+01234567890e.]+)\s*,\s*(-?[-+01234567890e.]+)\s*[\])]#?(\d+)?/,
+           ~r/([[(])\s*(-?[-+01234567890eE.]+)\s*,\s*(-?[-+01234567890eE.]+)\s*[\])]#?(\d+)?/,
            range_str
          ) do
       [_, "[", lower, upper | maybe_precision] ->

--- a/lib/oli/delivery/evaluation/rule.ex
+++ b/lib/oli/delivery/evaluation/rule.ex
@@ -121,6 +121,8 @@ defmodule Oli.Delivery.Evaluation.Rule do
         case parse_range(right) do
           # allow bounds in any order (may have come from dynamic variables)
           {:inclusive, lower, upper, precision} ->
+            IO.puts(~c"checking #{l_value} in range l=#{lower} u=#{upper} prec=#{precision}")
+
             min(lower, upper) <= l_value && l_value <= max(lower, upper) &&
               check_precision(left, precision)
 
@@ -188,7 +190,7 @@ defmodule Oli.Delivery.Evaluation.Rule do
   defp is_range?(str), do: String.starts_with?(str, ["[", "("])
 
   defp is_float?(str),
-    do: String.contains?(str, ".") or String.contains?(str, "e-")
+    do: String.contains?(str, ".") or String.contains?(str, "e")
 
   defp parse_range(range_str) do
     case Regex.run(

--- a/lib/oli/delivery/evaluation/rule.ex
+++ b/lib/oli/delivery/evaluation/rule.ex
@@ -121,8 +121,6 @@ defmodule Oli.Delivery.Evaluation.Rule do
         case parse_range(right) do
           # allow bounds in any order (may have come from dynamic variables)
           {:inclusive, lower, upper, precision} ->
-            IO.puts(~c"checking #{l_value} in range l=#{lower} u=#{upper} prec=#{precision}")
-
             min(lower, upper) <= l_value && l_value <= max(lower, upper) &&
               check_precision(left, precision)
 

--- a/test/oli/delivery/evaluation/rule_eval_test.exs
+++ b/test/oli/delivery/evaluation/rule_eval_test.exs
@@ -60,6 +60,11 @@ defmodule Oli.Delivery.Evaluation.RuleEvalTest do
     assert eval("attemptNumber = {1} && input = {[3.0e+5,4.0e+5]}", "3.5e5") == true
     assert eval("attemptNumber = {1} && input = {[3.0e5,4.0e5]}", "3.5e5") == true
 
+    # test bug parsing scientific notation w/positive exponent and no decimal point
+    assert eval("attemptNumber = {1} && input = {[3e+5,4e+5]}", "3.5e5") == true
+    assert eval("attemptNumber = {1} && input = {[3.0e5,5.0e5]}", "4e5") == true
+    assert eval("attemptNumber = {1} && input = {[3e5,5e5]}", "4e6") == false
+
     # float inside the range, evaluates to true
     assert eval("attemptNumber = {1} && input = {(3,4)}", "3.1") == true
     assert eval("attemptNumber = {1} && input = {(3.0,4)}", "3.1") == true

--- a/test/oli/delivery/evaluation/rule_eval_test.exs
+++ b/test/oli/delivery/evaluation/rule_eval_test.exs
@@ -65,6 +65,12 @@ defmodule Oli.Delivery.Evaluation.RuleEvalTest do
     assert eval("attemptNumber = {1} && input = {[3.0e5,5.0e5]}", "4e5") == true
     assert eval("attemptNumber = {1} && input = {[3e5,5e5]}", "4e6") == false
 
+    # scientific notation using capital E
+    assert eval("attemptNumber = {1} && input = {[4E-5,3E-3]}", "3E-4") == true
+
+    assert eval("attemptNumber = {1} && input = {[3.0E+5,4.0e+5]}", "3.5E5") == true
+    assert eval("attemptNumber = {1} && input = {[3.0e5,4.0E5]}", "3.5e5") == true
+
     # float inside the range, evaluates to true
     assert eval("attemptNumber = {1} && input = {(3,4)}", "3.1") == true
     assert eval("attemptNumber = {1} && input = {(3.0,4)}", "3.1") == true


### PR DESCRIPTION
Torus answer rule evaluation was incorrectly parsing numbers in e-notation with positive exponent, but no decimal point. For example, a number entered as 5e35 or 5e+35 would be parsed and evaluated as the integer 5, both in author answer specs and in answers typed by student. This led to errors evaluating answers in Chemistry II course using large values specified that way. For example, if the answer range was specified as [4e35, 6e35], torus evaluation would reject an answer of 4.1e35 as incorrect, but accept 5e36 or simply 5 as correct. 

This also corrects errors processing exponential notation using capital E, which can arise from migration and also lead to evaluation errors in Chemistry II. Capital E is quite standard and is allowed in the torus authoring interface. But code in rule evaluation was not handling it, for example, using a regexp that would not match ranges with bounds specified using capital E.

This fix treats all numbers using e or E as floats and adds unit tests for the previously buggy cases. 
