### PR TITLE
[BUG FIX] [MER-3293] avoid error on linked pages not in hierarchy

### DIFF
--- a/lib/oli_web/live/delivery/student/utils.ex
+++ b/lib/oli_web/live/delivery/student/utils.ex
@@ -328,6 +328,9 @@ defmodule OliWeb.Delivery.Student.Utils do
   def schedule_live_path(section_slug, params),
     do: ~p"/sections/#{section_slug}/assignments?#{params}"
 
+  # nil case arises for linked loose pages not in in hierarchy index
+  def get_container_label(nil, section), do: section.title
+
   def get_container_label(page_id, section) do
     section_id = section.id
 

--- a/lib/oli_web/live_session_plugs/init_page.ex
+++ b/lib/oli_web/live_session_plugs/init_page.ex
@@ -35,6 +35,7 @@ defmodule OliWeb.LiveSessionPlugs.InitPage do
       ) do
     resource_id = assigns.page_context.page.resource_id
 
+    # note will all be nil for case of "loose" linked pages not in hierarchy
     {:ok, {previous, next, current}, _} =
       PreviousNextIndex.retrieve(assigns.section, resource_id)
 


### PR DESCRIPTION
Attempts to follow links to "loose" pages not in the hierarchy were triggering an exception. Such linked pages are used frequently in migrated courses. This PR implements a provisional fix that prevents the exception and allows these pages to be rendered without error so that testing of these courses can continue. However, a smarter solution might be desired in the longer term.

The error arose because:

- LiveView assigns `current_page, next_page, prev_page` are initialized from the PreviousNextIndex in`lib/oli_web/live_session_plugs/init_page.ex`
- When following link to a "loose" page (one not in the curriculum) these wind up all nil because loose pages are not in the PreviousNextIndex, which is derived from the flattened hierarchy.
- The page rendering templates in` lib/oli_web/live/delivery/student/lesson_live.ex `use
   ` container_label={Utils.get_container_label(@current_page["id"], @section)}`
to get a label to include in the page header. 
- This results in a nil page id getting passed to `Utils.get_container_label.`
- The nil gets into a query, which trips an Ecto exception about queries comparing with nil. 

The fix adds code to handle the nil case arising from loose pages, returning the section title for use in the page header. 

In the longer term, some way of including "loose" pages in the PreviousNextIndex might be desired to avoid the need for special case code. And for the very common case of pages linked from exactly one location, it would make sense to associate the container label of the linking page. 