### PR TITLE
[BUG FIX] [NG23-212] [NG23-213] fix an issue where graded pages fail to load activities on first visit

### DIFF
--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -1114,11 +1114,14 @@ defmodule OliWeb.Delivery.Student.LessonLive do
           socket.assigns.datashop_session_id
         )
 
+      socket =
+        socket
+        |> assign(page_context: page_context)
+
       emit_page_viewed_event(socket)
 
       {:noreply,
        socket
-       |> assign(page_context: page_context)
        |> assign(begin_attempt?: true, show_loader?: true)
        |> clear_flash()
        |> assign_html()


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/NG23-212
https://eliterate.atlassian.net/browse/NG23-213

This PR fixes 2 issues that were identified related to the initial load of a graded page:

1. Graded page activities weren't loading on first visit after attempt creation. A reload of the page would resolve the issue
2. The system would throw an error when trying to emit a page viewed event

Both of these issues were caused by the socket not being updated with the latest page context and crashing before proceeding with the remaining logic during the start attempt phase.