### PR TITLE
[BUG FIX] [MER-2932] filter-insights-by-product-course-section

### DIFF
--- a/lib/oli/analytics/by_activity.ex
+++ b/lib/oli/analytics/by_activity.ex
@@ -30,7 +30,8 @@ defmodule Oli.Analytics.ByActivity do
       end
 
     from activity in subquery(subquery),
-      left_join: analytics in subquery(Common.analytics_by_activity(project_slug)),
+      left_join:
+        analytics in subquery(Common.analytics_by_activity(project_slug, filtered_sections)),
       on: activity.resource_id == analytics.activity_id,
       select: %{
         slice: activity,

--- a/lib/oli/analytics/by_objective.ex
+++ b/lib/oli/analytics/by_objective.ex
@@ -35,7 +35,8 @@ defmodule Oli.Analytics.ByObjective do
       objective in subquery(subquery),
       left_join: pairing in subquery(activity_objectives),
       on: objective.resource_id == pairing.objective_id,
-      left_join: analytics in subquery(Common.analytics_by_objective(project_slug)),
+      left_join:
+        analytics in subquery(Common.analytics_by_objective(project_slug, filtered_sections)),
       on: pairing.objective_id == analytics.objective_id,
       select: %{
         slice: objective,

--- a/lib/oli/analytics/by_page.ex
+++ b/lib/oli/analytics/by_page.ex
@@ -52,7 +52,8 @@ defmodule Oli.Analytics.ByPage do
       on: page.resource_id == pairing.page_id,
       left_join: activity in subquery(subquery_activity),
       on: pairing.activity_id == activity.resource_id,
-      left_join: analytics in subquery(Common.analytics_by_activity(project_slug)),
+      left_join:
+        analytics in subquery(Common.analytics_by_activity(project_slug, filtered_sections)),
       on: pairing.activity_id == analytics.activity_id,
       select: %{
         slice: page,

--- a/lib/oli/publishing/delivery_resolver.ex
+++ b/lib/oli/publishing/delivery_resolver.ex
@@ -468,4 +468,12 @@ defmodule Oli.Publishing.DeliveryResolver do
       )
     )
   end
+
+  def get_sections_for_products(product_ids) do
+    from(section in Section,
+      where: section.blueprint_id in ^product_ids,
+      select: section.id
+    )
+    |> Repo.all()
+  end
 end

--- a/lib/oli_web/live/insights/insights.ex
+++ b/lib/oli_web/live/insights/insights.ex
@@ -519,9 +519,12 @@ defmodule OliWeb.Insights do
 
   defp get_by_page_row(socket, :by_activity) do
     if socket.assigns.is_product do
+      section_by_product_ids =
+        Oli.Publishing.DeliveryResolver.get_sections_for_products(socket.assigns.product_ids)
+
       Oli.Analytics.ByActivity.query_against_project_slug(
         socket.assigns.project.slug,
-        socket.assigns.product_ids
+        section_by_product_ids
       )
     else
       Oli.Analytics.ByActivity.query_against_project_slug(
@@ -533,9 +536,12 @@ defmodule OliWeb.Insights do
 
   defp get_by_page_row(socket, :by_objective) do
     if socket.assigns.is_product do
+      section_by_product_ids =
+        Oli.Publishing.DeliveryResolver.get_sections_for_products(socket.assigns.product_ids)
+
       Oli.Analytics.ByObjective.query_against_project_slug(
         socket.assigns.project.slug,
-        socket.assigns.product_ids
+        section_by_product_ids
       )
     else
       Oli.Analytics.ByObjective.query_against_project_slug(

--- a/lib/oli_web/live/insights/insights.ex
+++ b/lib/oli_web/live/insights/insights.ex
@@ -547,13 +547,16 @@ defmodule OliWeb.Insights do
 
   defp get_by_page_row(socket, :by_page) do
     if socket.assigns.is_product do
+      section_by_product_ids =
+        Oli.Publishing.DeliveryResolver.get_sections_for_products(socket.assigns.product_ids)
+
       Oli.Analytics.ByPage.query_against_project_slug(
         socket.assigns.project.slug,
-        socket.assigns.product_ids
+        section_by_product_ids
       )
     else
       Oli.Analytics.ByPage.query_against_project_slug(
-        socket.assigns.project.slug,
+        socket.assigns.project,
         socket.assigns.section_ids
       )
     end


### PR DESCRIPTION
This PR [MER-2932](https://eliterate.atlassian.net/browse/MER-2932) fixes the filter by section by adding a new argument to the analytics_by_activity function in the Common module. 
The new argument specifies the section to filter in the query. 
Additionally, the courses for the product are obtained using Oli.Publishing.DeliveryResolver.get_sections_for_products, and these are passed to the function to filter all analytics.

[MER-2932]: https://eliterate.atlassian.net/browse/MER-2932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ