### PR TITLE
[BUG FIX] [NG23-208] Fix brand logo issue on Learn and Lesson views

### DIFF
--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -40,38 +40,41 @@ defmodule OliWeb.Components.Delivery.Layouts do
       <.link
         :if={@include_logo}
         id="header_logo_button"
+        class="w-48"
         navigate={logo_link_path(@preview_mode, @section, @ctx.user, @sidebar_expanded)}
       >
         <.logo_img section={@section} />
       </.link>
       <div class={[
-        if(!@sidebar_expanded, do: "md:!pl-[95px]"),
-        "flex md:pl-[226px] items-center flex-grow-1 dark:text-[#BAB8BF] text-base font-medium font-['Roboto']"
+        if(@sidebar_expanded, do: "md:!pl-[226px]"),
+        "w-full flex flex-row md:pl-[95px]"
       ]}>
-        <.title section={@section} project={@project} preview_mode={@preview_mode} />
-      </div>
-      <div class="justify-end items-center flex">
-        <div class={
-          if @force_show_user_menu, do: "block", else: "hidden md:flex justify-center items-center"
-        }>
-          <UserAccount.menu
-            id="user-account-menu"
-            ctx={@ctx}
-            section={@section}
-            is_system_admin={@is_system_admin}
-          />
+        <div class="flex items-center flex-grow-1 dark:text-[#BAB8BF] text-base font-medium font-['Roboto']">
+          <.title section={@section} project={@project} preview_mode={@preview_mode} />
         </div>
-      </div>
-      <div class="flex items-center p-2 ml-auto">
-        <button
-          class={[
-            "py-1.5 px-3 rounded border border-transparent hover:border-gray-300 active:bg-gray-100",
-            if(@force_show_user_menu, do: "hidden", else: "md:hidden")
-          ]}
-          phx-click={JS.toggle(to: "#mobile-nav-menu", display: "flex")}
-        >
-          <i class="fa-solid fa-bars"></i>
-        </button>
+        <div class="justify-end items-center flex">
+          <div class={
+            if @force_show_user_menu, do: "block", else: "hidden md:flex justify-center items-center"
+          }>
+            <UserAccount.menu
+              id="user-account-menu"
+              ctx={@ctx}
+              section={@section}
+              is_system_admin={@is_system_admin}
+            />
+          </div>
+        </div>
+        <div class="flex items-center p-2 ml-auto">
+          <button
+            class={[
+              "py-1.5 px-3 rounded border border-transparent hover:border-gray-300 active:bg-gray-100",
+              if(@force_show_user_menu, do: "hidden", else: "md:hidden")
+            ]}
+            phx-click={JS.toggle(to: "#mobile-nav-menu", display: "flex")}
+          >
+            <i class="fa-solid fa-bars"></i>
+          </button>
+        </div>
       </div>
     </div>
     """

--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -29,17 +29,25 @@ defmodule OliWeb.Components.Delivery.Layouts do
   )
 
   attr(:sidebar_expanded, :boolean, default: true)
+  attr(:include_logo, :boolean, default: false)
 
   def header(assigns) do
     ~H"""
     <div
       id="header"
-      class={[
-        "fixed z-50 w-full md:pl-[226px] py-2.5 h-14 flex flex-row bg-delivery-header dark:bg-black border-b border-[#0F0D0F]/5 dark:border-[#0F0D0F]",
-        if(!@sidebar_expanded, do: "md:!pl-[95px]")
-      ]}
+      class="fixed z-50 w-full py-2.5 h-14 flex flex-row bg-delivery-header dark:bg-black border-b border-[#0F0D0F]/5 dark:border-[#0F0D0F]"
     >
-      <div class="flex items-center flex-grow-1 dark:text-[#BAB8BF] text-base font-medium font-['Roboto']">
+      <.link
+        :if={@include_logo}
+        id="header_logo_button"
+        navigate={logo_link_path(@preview_mode, @section, @ctx.user, @sidebar_expanded)}
+      >
+        <.logo_img section={@section} />
+      </.link>
+      <div class={[
+        if(!@sidebar_expanded, do: "md:!pl-[95px]"),
+        "flex md:pl-[226px] items-center flex-grow-1 dark:text-[#BAB8BF] text-base font-medium font-['Roboto']"
+      ]}>
         <.title section={@section} project={@project} preview_mode={@preview_mode} />
       </div>
       <div class="justify-end items-center flex">

--- a/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
+++ b/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
@@ -40,11 +40,13 @@
 
 <div class="h-screen flex flex-col overscroll-none overflow-hidden">
   <Components.Delivery.Layouts.header
+    :if={@section}
     ctx={@ctx}
     is_system_admin={assigns[:is_system_admin] || false}
     section={@section}
     preview_mode={@preview_mode}
     force_show_user_menu={true}
+    include_logo={true}
   />
 
   <div class="flex-1 flex flex-col mt-14 overflow-hidden">

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -36,7 +36,8 @@ defmodule OliWeb.Delivery.Student.LearnLive do
          :lti_1p3_deployment,
          :contains_discussions,
          :contains_explorations,
-         :contains_deliberate_practice
+         :contains_deliberate_practice,
+         :open_and_free
        ], %Sections.Section{}},
     current_user: {[:id, :name, :email], %User{}}
   }

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -2553,6 +2553,26 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
   describe "sidebar menu" do
     setup [:user_conn, :create_elixir_project, :enroll_as_student, :mark_section_visited]
 
+    test "can see default logo", %{
+      conn: conn,
+      section: section
+    } do
+      Sections.update_section(section, %{brand_id: nil})
+
+      {:ok, view, _html} = live(conn, Utils.learn_live_path(section.slug))
+
+      assert element(view, "#logo_button") |> render() =~ "/images/oli_torus_logo.png"
+    end
+
+    test "can see brand logo", %{
+      conn: conn,
+      section: section
+    } do
+      {:ok, view, _html} = live(conn, Utils.learn_live_path(section.slug))
+
+      assert element(view, "#logo_button") |> render() =~ "www.logo.com"
+    end
+
     test "does not render Explorations, Practice and Collaboration links if those features are not enabled",
          %{conn: conn, section: section} do
       {:ok, view, _html} = live(conn, Utils.learn_live_path(section.slug))

--- a/test/oli_web/live/delivery/student/lesson_live_test.exs
+++ b/test/oli_web/live/delivery/student/lesson_live_test.exs
@@ -410,6 +410,35 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
                  "?request_path=some_request_path&selected_view=gallery"
     end
 
+    test "can see default logo", %{
+      conn: conn,
+      user: user,
+      section: section,
+      page_1: page_1
+    } do
+      Sections.update_section(section, %{brand_id: nil})
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.mark_section_visited_for_student(section, user)
+
+      {:ok, view, _html} = live(conn, Utils.lesson_live_path(section.slug, page_1.slug))
+
+      assert element(view, "#header_logo_button") |> render() =~ "/images/oli_torus_logo.png"
+    end
+
+    test "can see brand logo", %{
+      conn: conn,
+      user: user,
+      section: section,
+      page_1: page_1
+    } do
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.mark_section_visited_for_student(section, user)
+
+      {:ok, view, _html} = live(conn, Utils.lesson_live_path(section.slug, page_1.slug))
+
+      assert element(view, "#header_logo_button") |> render() =~ "www.logo.com"
+    end
+
     test "can access when enrolled to course", %{
       conn: conn,
       user: user,


### PR DESCRIPTION
[NG23-208](https://eliterate.atlassian.net/browse/NG23-208)

Fix the missing logo on the Lesson view.
Fix the display of the brand logo on the Learn view.

https://github.com/Simon-Initiative/oli-torus/assets/26532202/f56df330-f990-48e9-9f51-5b969b711398




[NG23-208]: https://eliterate.atlassian.net/browse/NG23-208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ