### PR TITLE
[DO NOT MERGE] [WIP] add ability to remove pages from hierarchy in section remix

### DIFF
--- a/lib/oli/delivery/hierarchy.ex
+++ b/lib/oli/delivery/hierarchy.ex
@@ -438,6 +438,29 @@ defmodule Oli.Delivery.Hierarchy do
     end
   end
 
+  def find_and_unlink_node(hierarchy, uuid) do
+    node = find_in_hierarchy(hierarchy, uuid)
+
+    hierarchy
+    |> add_to_unordered_pages(node)
+    |> find_and_remove_node_r(uuid)
+    |> mark_unfinalized()
+  end
+
+  defp add_to_unordered_pages(hierarchy, node) do
+    %HierarchyNode{
+      hierarchy
+      | unordered_pages: [node | hierarchy.unordered_pages]
+    }
+  end
+
+  defp remove_from_unordered_pages(hierarchy, uuid) do
+    %HierarchyNode{
+      hierarchy
+      | unordered_pages: Enum.filter(hierarchy.unordered_pages, fn page -> page.uuid != uuid end)
+    }
+  end
+
   @doc """
   Moves a node to a given container given by destination uuid
   """

--- a/lib/oli/delivery/hierarchy/hierarchy_node.ex
+++ b/lib/oli/delivery/hierarchy/hierarchy_node.ex
@@ -23,7 +23,11 @@ defmodule Oli.Delivery.Hierarchy.HierarchyNode do
             section_resource: nil,
             ancestors: [],
             finalized: true,
-            visited: false
+            visited: false,
+            # a root node may specify a list of pages that are not in the hierarchy but
+            # should be included in the final set of section resources. This is only valid for the
+            # top-most root node and is only used in the delivery context.
+            unordered_pages: []
 
   def simplify(%Oli.Delivery.Hierarchy.HierarchyNode{} = node) do
     %{

--- a/lib/oli/publishing/delivery_resolver.ex
+++ b/lib/oli/publishing/delivery_resolver.ex
@@ -330,7 +330,7 @@ defmodule Oli.Publishing.DeliveryResolver do
     # TODO: FIX this is not quite right, we need just the unordered pages but this will
     # include *all* pages that are not in the hierarchy, including those that
     # are linked to from the hierarchy. We likely need to add a field to the root section resource
-    # record to track unordered pages to properly track these
+    # record to properly track thees unordered pages
     hierarchy_nodes_set = Hierarchy.flatten_pages(hierarchy) |> MapSet.new()
     all_nodes_set = Enum.map(all_nodes, fn {_, node} -> node end) |> MapSet.new()
 

--- a/lib/oli/publishing/delivery_resolver.ex
+++ b/lib/oli/publishing/delivery_resolver.ex
@@ -330,7 +330,7 @@ defmodule Oli.Publishing.DeliveryResolver do
     # TODO: FIX this is not quite right, we need just the unordered pages but this will
     # include *all* pages that are not in the hierarchy, including those that
     # are linked to from the hierarchy. We likely need to add a field to the root section resource
-    # record to properly track thees unordered pages
+    # record to properly track these unordered pages
     hierarchy_nodes_set = Hierarchy.flatten_pages(hierarchy) |> MapSet.new()
     all_nodes_set = Enum.map(all_nodes, fn {_, node} -> node end) |> MapSet.new()
 

--- a/lib/oli_web/live/delivery/remix_section.html.heex
+++ b/lib/oli_web/live/delivery/remix_section.html.heex
@@ -42,42 +42,64 @@
     </div>
   </div>
 
-  <div class="curriculum-navigation">
+  <div class="curriculum-navigation flex flex-row ">
+    <.browse_mode_selector browse_mode={@browse_mode} />
     <%= render_breadcrumb(assigns) %>
   </div>
 
   <div class="grid grid-cols-12" phx-window-keydown="keydown">
     <div class="col-span-12">
-      <div class="curriculum-entries">
-        <%= if Enum.count(@active.children) == 0 do %>
-          <div style="margin-top: 15px">
-            <p>There's nothing here.</p>
+      <%= case @browse_mode do %>
+        <% :curriculum -> %>
+          <div class="curriculum-entries">
+            <%= if Enum.count(@active.children) == 0 do %>
+              <div style="margin-top: 15px">
+                <p>There's nothing here.</p>
+              </div>
+            <% end %>
+            <%= for {node, index} <- filter_items(@active.children, @dragging) do %>
+              <DropTarget.droptarget id={index} index={index} />
+              <Entry.entry
+                index={index}
+                selected={@selected == node.uuid}
+                node={node}
+                is_product={assigns[:is_product]}
+              />
+            <% end %>
+            <DropTarget.droptarget id="last" index={length(@active.children)} />
           </div>
-        <% end %>
-        <%= for {node, index} <- filter_items(@active.children, @dragging) do %>
-          <DropTarget.droptarget id={index} index={index} />
-          <Entry.entry
-            index={index}
-            selected={@selected == node.uuid}
-            node={node}
-            is_product={assigns[:is_product]}
-          />
-        <% end %>
-        <DropTarget.droptarget id="last" index={length(@active.children)} />
-      </div>
-      <div class="mt-5">
-        <button
-          phx-click="show_add_materials_modal"
-          `
-          class="btn btn-xs btn-primary p-2 mr-1"
-          type="button"
-        >
-          Add Materials
-        </button>
-        <% # <button phx-click="add_container" class="btn btn-xs btn-outline-primary p-2 mr-1" type="button">
-        #  <%= new_container_name(@active)
-        # </button> %>
-      </div>
+          <div class="mt-5">
+            <button
+              phx-click="show_add_materials_modal"
+              `
+              class="btn btn-xs btn-primary p-2 mr-1"
+              type="button"
+            >
+              Add Materials
+            </button>
+            <% # <button phx-click="add_container" class="btn btn-xs btn-outline-primary p-2 mr-1" type="button">
+            #  <%= new_container_name(@active)
+            # </button> %>
+          </div>
+        <% :unordered_pages -> %>
+          <div class="curriculum-entries">
+            <%= if Enum.count(@hierarchy.unordered_pages) == 0 do %>
+              <div style="margin-top: 15px">
+                <p>There are no unordered materials.</p>
+              </div>
+            <% end %>
+            <div style="margin-top: 15px">
+              <%= for {node, index} <- Enum.with_index(@hierarchy.unordered_pages) do %>
+                <Entry.entry
+                  index={index}
+                  selected={@selected == node.uuid}
+                  node={node}
+                  is_product={assigns[:is_product]}
+                />
+              <% end %>
+            </div>
+          </div>
+      <% end %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Adds ability to remove pages from hierarchy but keep them in the set of section resources in section remix.

The missing piece here is loading these unordered pages back in when section remix is opened. We likely need to add some sort of field to the database for the root node to easily save/load these nodes.