### PR TITLE
[BUG FIX] [NG23-111] Module tiles and cards improvements learn page - part 2

### DIFF
--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -2224,8 +2224,8 @@ defmodule OliWeb.Delivery.Student.LearnLive do
     )
   end
 
-  defp completed_page?(true = _graded, visited?, raw_avg_score, _progress),
-    do: visited? and not is_nil(raw_avg_score)
+  defp completed_page?(true = _graded, visited?, raw_avg_score, progress),
+    do: visited? and not is_nil(raw_avg_score) and progress == 1.0
 
   defp completed_page?(false = _graded, visited?, _score, progress),
     do: visited? and progress == 1.0

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -786,11 +786,11 @@ defmodule OliWeb.Delivery.Student.LearnLive do
             <%= "PAGE #{@unit["numbering"]["index"]}" %>
           </div>
           <div class="mb-6 flex flex-col items-start gap-[6px] w-full">
-            <h3 class="text-[26px] leading-[32px] tracking-[0.02px] font-normal dark:text-[#DDD]">
-              <%= @unit["title"] %>
-            </h3>
-            <div class="flex items-center w-full gap-3">
-              <div class="flex items-center gap-3" role="schedule_details">
+            <div class="flex w-full">
+              <h3 class="text-[26px] leading-[32px] tracking-[0.02px] font-normal dark:text-[#DDD]">
+                <%= @unit["title"] %>
+              </h3>
+              <div class="ml-auto flex items-center gap-3" role="schedule_details">
                 <div class="text-[14px] leading-[32px] tracking-[0.02px] font-semibold">
                   <span class="text-gray-400 opacity-80 dark:text-[#696974] dark:opacity-100 mr-1">
                     Due:
@@ -802,22 +802,19 @@ defmodule OliWeb.Delivery.Student.LearnLive do
                   ) %>
                 </div>
               </div>
-              <div class="ml-auto flex items-center gap-6">
-                <Student.score_summary :if={@progress == 100} raw_avg_score={@unit_raw_avg_score} />
-                <.progress_bar
-                  percent={@progress}
-                  width="100px"
-                  on_going_colour="bg-[#0CAF61]"
-                  completed_colour="bg-[#0CAF61]"
-                  role={"unit_#{@unit["numbering"]["index"]}_progress"}
-                  show_percent={@progress != 100}
-                />
-                <Icons.check progress={@progress / 100} role="unit completed check icon" />
-              </div>
+            </div>
+            <div class="flex items-center gap-6">
+              <.progress_bar
+                percent={@progress}
+                width="194px"
+                on_going_colour="bg-[#0CAF61]"
+                completed_colour="bg-[#0CAF61]"
+                role={"unit_#{@unit["numbering"]["index"]}_progress"}
+              />
             </div>
           </div>
         </div>
-        <div class="w-[294px]">
+        <div class="flex">
           <.card
             card={@unit}
             module_index={1}
@@ -874,10 +871,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
                 on_going_colour="bg-[#0CAF61]"
                 completed_colour="bg-[#0CAF61]"
                 role={"unit_#{@unit["numbering"]["index"]}_progress"}
-                show_percent={@progress != 100}
               />
-              <Icons.check progress={@progress / 100} role="unit completed check icon" />
-              <Student.score_summary :if={@progress == 100} raw_avg_score={@unit_raw_avg_score} />
             </div>
           </div>
         </div>

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -1844,10 +1844,10 @@ defmodule OliWeb.Delivery.Student.LearnLive do
           />
         </div>
       </div>
-      <div class="relative flex flex-col items-center rounded-xl h-[170px] w-[294px] bg-gray-200/50 shrink-0 px-5 pt-[15px] bg-cover bg-center">
+      <div class="flex flex-col items-center rounded-xl h-[170px] w-[294px] bg-gray-200/50 shrink-0 px-5 pt-[15px] bg-cover bg-center">
         <video
           id={"video_preview_image_#{@video_url}"}
-          class="rounded-xl object-cover absolute h-[170px] w-[294px]"
+          class="rounded-xl object-cover absolute h-[170px] w-[294px] top-0 pointer-events-none"
           preload="metadata"
         >
           <source src={"#{@video_url}#t=0.5"} /> Your browser does not support the video tag.
@@ -1872,7 +1872,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
           <div class="w-full h-full rounded-full backdrop-blur bg-gray/50"></div>
           <div
             role="play_unit_intro_video"
-            class="z-30 w-full h-full absolute top-0 left-0 flex items-center justify-center"
+            class="w-full h-full absolute top-0 left-0 flex items-center justify-center"
           >
             <Icons.play class="scale-110 ml-[6px] mt-[9px]" />
           </div>

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -1211,7 +1211,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       assert render(learning_objectives_tooltip) =~ "Objective 4"
     end
 
-    test "can see unit check icon and score summary when all pages are completed",
+    test "can see unit correct progress when all pages are completed",
          %{
            conn: conn,
            user: user,
@@ -1256,16 +1256,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       # when the slider buttons are enabled we know the student async metrics were loaded
       assert_receive({_ref, {:push_event, "enable-slider-buttons", _}}, 2_000)
 
-      assert has_element?(
-               view,
-               ~s{div[role="unit_1"] div[role="score summary"]},
-               "1 / 2"
-             )
-
-      assert has_element?(
-               view,
-               ~s{div[role="unit_1"] svg[role="unit completed check icon"]}
-             )
+      assert has_element?(view, ~s{div[role="unit_1_progress"]}, "100%")
     end
 
     test "can expand more than one module card", %{

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -902,10 +902,10 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
            project: project,
            publication: publication
          } do
-      # complete all pages
-      [page_1, page_2, practice_page, graded_page]
-      |> Enum.each(fn page ->
-        set_progress(section.id, page.resource_id, user.id, 1.0, page)
+      # complete all pages except the graded one
+      [{page_1, 1.0}, {page_2, 1.0}, {practice_page, 1.0}, {graded_page, 0.75}]
+      |> Enum.each(fn {page, progress} ->
+        set_progress(section.id, page.resource_id, user.id, progress, page)
 
         set_activity_attempt(
           page,
@@ -939,7 +939,8 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
                ~s{div[id="page_#{practice_page.resource_id}"] div[role="card badge"] div[role="check icon"]}
              )
 
-      assert has_element?(
+      # this page is not yet completed, so we do not expect to see the check icon
+      refute has_element?(
                view,
                ~s{div[id="page_#{graded_page.resource_id}"] div[role="card badge"] div[role="check icon"]}
              )


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/NG23-111?focusedCommentId=22963) to the ticket comment

As confirmed in the [last demo](https://youtu.be/hP8K9WcJMg0?list=PLxXjewniGhOtUH5fW079AcQdw_JRSx8tA&t=553), the page icon on the cards should not be there.


### Top Level Page Before
https://github.com/Simon-Initiative/oli-torus/assets/74839302/3d627dfd-c4a2-49f6-a5d3-29f5e93850f4


### Top Level Page After
https://github.com/Simon-Initiative/oli-torus/assets/74839302/5fd9b9d6-f72d-4ec0-aa4d-27f7ea3c2558


### Intro Video Before
https://github.com/Simon-Initiative/oli-torus/assets/74839302/088be8c2-3c72-40a6-8101-de39a86a6fce


### Intro Video After
https://github.com/Simon-Initiative/oli-torus/assets/74839302/8f7c88ef-1c31-415e-ac91-c2c99b64d1c4


### Page in progress/not completed before
https://github.com/Simon-Initiative/oli-torus/assets/74839302/78876238-6e01-48d2-ad77-1fc97a695c84


### Page in progress/not completed after
https://github.com/Simon-Initiative/oli-torus/assets/74839302/319cbe15-345d-46af-9390-1352087e3f78






