### PR TITLE
[ENHANCEMENT] [NG23-194] Icons visual improvements

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -40,6 +40,7 @@
     "@rjsf/bootstrap-4": "^3.2.1",
     "@rjsf/core": "^4.2.0",
     "@stripe/stripe-js": "^1.18.0",
+    "@tabler/icons-react": "^3.5.0",
     "@tailwindcss/container-queries": "^0.1.0",
     "@tailwindui/react": "^0.1.1",
     "@uiw/react-md-editor": "^3.23.5",

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -4852,6 +4852,18 @@
   resolved "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-1.18.0.tgz"
   integrity sha512-yBRHAMKHnF3kbzv0tpKB82kSow43wW5qXLK8ofg3V9NaaCyObSTO7wJfktWAtG/NBgkJOdUL+pV8dHBj0qvDkQ==
 
+"@tabler/icons-react@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@tabler/icons-react/-/icons-react-3.5.0.tgz#71925d527bb50a3b5bb23cc0154acc8b0ed65214"
+  integrity sha512-bn05XKZV3ZfOv5Jr1FCTmVPOQGBVJoA4NefrnR919rqg6WGXAa08NovONHJGSuMxXUMV3b9Cni85diIW/E9yuw==
+  dependencies:
+    "@tabler/icons" "3.5.0"
+
+"@tabler/icons@3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@tabler/icons/-/icons-3.5.0.tgz#29d0dbf100c8cb392dd64f1fe8efdcfcd1f57e44"
+  integrity sha512-I53dC3ZSHQ2MZFGvDYJelfXm91L2bTTixS4w5jTAulLhHbCZso5Bih4Rk/NYZxlngLQMKHvEYwZQ+6w/WluKiA==
+
 "@tailwindcss/container-queries@^0.1.0":
   version "0.1.0"
   resolved "https://registry.npmjs.org/@tailwindcss/container-queries/-/container-queries-0.1.0.tgz"

--- a/lib/oli_web/live/delivery/student/learn/components/view_selector.ex
+++ b/lib/oli_web/live/delivery/student/learn/components/view_selector.ex
@@ -95,29 +95,13 @@ defmodule OliWeb.Delivery.Student.Learn.Components.ViewSelector do
 
   defp view_icon(%{option: :outline} = assigns) do
     ~H"""
-    <svg width="16" height="20" viewBox="0 0 16 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path
-        d="M5 5H11M5 9H11M5 13H9M1 3C1 2.46957 1.21071 1.96086 1.58579 1.58579C1.96086 1.21071 2.46957 1 3 1H13C13.5304 1 14.0391 1.21071 14.4142 1.58579C14.7893 1.96086 15 2.46957 15 3V17C15 17.5304 14.7893 18.0391 14.4142 18.4142C14.0391 18.7893 13.5304 19 13 19H3C2.46957 19 1.96086 18.7893 1.58579 18.4142C1.21071 18.0391 1 17.5304 1 17V3Z"
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        class="stroke-black/60 dark:stroke-white"
-      />
-    </svg>
+    <i class="ti ti-list"></i>
     """
   end
 
   defp view_icon(%{option: :gallery} = assigns) do
     ~H"""
-    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path
-        d="M15 8H15.01M3 16L8 11C8.928 10.107 10.072 10.107 11 11L16 16M14 14L15 13C15.928 12.107 17.072 12.107 18 13L21 16M3 6C3 5.20435 3.31607 4.44129 3.87868 3.87868C4.44129 3.31607 5.20435 3 6 3H18C18.7956 3 19.5587 3.31607 20.1213 3.87868C20.6839 4.44129 21 5.20435 21 6V18C21 18.7956 20.6839 19.5587 20.1213 20.1213C19.5587 20.6839 18.7956 21 18 21H6C5.20435 21 4.44129 20.6839 3.87868 20.1213C3.31607 19.5587 3 18.7956 3 18V6Z"
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        class="stroke-black/60 dark:stroke-white"
-      />
-    </svg>
+    <i class="ti ti-layout-grid"></i>
     """
   end
 

--- a/lib/oli_web/templates/layout/authoring.html.leex
+++ b/lib/oli_web/templates/layout/authoring.html.leex
@@ -43,7 +43,15 @@
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,300;1,400;1,500;1,600;1,700;1,800&display=swap" rel="stylesheet">
+    <link
+    href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,300;1,400;1,500;1,600;1,700;1,800&display=swap"
+    rel="stylesheet">
+
+    <!-- Tabler Icons https://tabler.io/docs/icons/webfont -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@latest/dist/tabler-icons.min.css"
+    />
 
     <!-- Code Syntax Highlighting https://highlightjs.org/ -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.4.0/styles/atom-one-light.min.css" integrity="sha512-o5v54Kh5PH0dgnf9ei0L+vMRsbm5fvIvnR/XkrZZjN4mqdaeH7PW66tumBoQVIaKNVrLCZiBEfHzRY4JJSMK/Q==" crossorigin="anonymous" referrerpolicy="no-referrer" />

--- a/lib/oli_web/templates/layout/delivery.html.heex
+++ b/lib/oli_web/templates/layout/delivery.html.heex
@@ -81,6 +81,11 @@
       crossorigin="anonymous"
       referrerpolicy="no-referrer"
     />
+    <!-- Tabler Icons https://tabler.io/docs/icons/webfont -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@latest/dist/tabler-icons.min.css"
+    />
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/NG23-194

Adds the new tabler icon webfont link to authoring and delivery and modifies the learn page view selector icon to use the new library.

![2024-06-03 10-06-05 2024-06-03 10_06_34](https://github.com/Simon-Initiative/oli-torus/assets/6248894/c4002ab0-5683-49a6-be53-a46d3edef05f)


For other future icon variations which are custom or do not directly exist in the webfont or React library, the SVG should be copied in the Icons module (or JSX) and used that way.