### PR TITLE
[BUG FIX] [NG23-157] Learning proficiency explanation modal - part 2

### DIFF
--- a/lib/oli_web/templates/layout/delivery.html.heex
+++ b/lib/oli_web/templates/layout/delivery.html.heex
@@ -88,6 +88,10 @@
       href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,300;1,400;1,500;1,600;1,700;1,800&display=swap"
       rel="stylesheet"
     />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
     <!-- Code Syntax Highlighting https://highlightjs.org/ -->
     <link
       rel="stylesheet"


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/NG23-157?focusedCommentId=23050) to the comment in the ticket

The issue was that the new designs require the Inter font, and I had forgotten to add that stylesheet in the root layout.

## Before
<img width="1397" alt="Screenshot 2024-06-03 at 2 56 16 PM" src="https://github.com/Simon-Initiative/oli-torus/assets/74839302/0bf94871-663f-4a97-a6b3-9d7154b3b670">
<img width="1397" alt="Screenshot 2024-06-03 at 2 56 10 PM" src="https://github.com/Simon-Initiative/oli-torus/assets/74839302/a0c52a80-074b-41a2-aab8-0ba3a6eb7ec2">


## After
<img width="1397" alt="Screenshot 2024-06-03 at 2 55 51 PM" src="https://github.com/Simon-Initiative/oli-torus/assets/74839302/265c2dee-e3f9-491f-aadf-6f7c9d82e2b1">
<img width="1397" alt="Screenshot 2024-06-03 at 2 55 43 PM" src="https://github.com/Simon-Initiative/oli-torus/assets/74839302/b88d78a7-7022-4435-804b-1440bb63d174">
