### PR TITLE
[FEATURE] [MER-3182] Summary card highlights filter content - Part 1

### DIFF
--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -1234,6 +1234,11 @@ defmodule Oli.Delivery.Metrics do
   def proficiency_range(proficiency) when proficiency <= 0.8, do: "Medium"
   def proficiency_range(_proficiency), do: "High"
 
+  def progress_range(nil), do: "Not enough data"
+  def progress_range(progress) when progress <= 0.5, do: "Low"
+  def progress_range(progress) when progress <= 0.8, do: "Medium"
+  def progress_range(_progress), do: "High"
+
   @doc """
   Updates page progress to be 100% complete.
   """

--- a/lib/oli_web/components/delivery/content/card_highlights.ex
+++ b/lib/oli_web/components/delivery/content/card_highlights.ex
@@ -1,0 +1,39 @@
+defmodule OliWeb.Components.Delivery.CardHighLights do
+  use Phoenix.Component
+
+  attr :title, :string, required: true
+  attr :count, :integer, required: true
+  attr :is_selected, :boolean, default: false
+  attr :value, :string, required: true
+  attr :on_click, :map, required: true
+  attr :container_filter_by, :atom
+
+  def render(assigns) do
+    ~H"""
+    <div
+      phx-click={@on_click}
+      phx-value-selected={@value}
+      class={"w-56 h-auto rounded-md #{if @is_selected, do: "shadow border-2 border-blue-500 bg-slate-50", else: "bg-white border border-blue-500/30 hover:border-blue-500/80"} flex-col justify-start items-start px-4 py-3 hover:cursor-pointer"}
+    >
+      <div class="text-slate-500 text-xs font-normal leading-none">
+        <%= @title %>
+      </div>
+      <div class="flex items-baseline space-x-2 mt-2">
+        <div class={"text-3xl font-semibold leading-10 #{if @is_selected, do: "text-blue-500", else: "text-slate-800"}"}>
+          <%= @count %>
+        </div>
+        <div class="text-gray-400 text-xs font-normal leading-none">
+          <%= case @container_filter_by do %>
+            <% :units -> %>
+              Units
+            <% :modules -> %>
+              Modules
+            <% _ -> %>
+              Students
+          <% end %>
+        </div>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/oli_web/components/delivery/content/card_highlights.ex
+++ b/lib/oli_web/components/delivery/content/card_highlights.ex
@@ -1,4 +1,4 @@
-defmodule OliWeb.Components.Delivery.CardHighLights do
+defmodule OliWeb.Components.Delivery.CardHighlights do
   use Phoenix.Component
 
   attr :title, :string, required: true
@@ -13,16 +13,16 @@ defmodule OliWeb.Components.Delivery.CardHighLights do
     <div
       phx-click={@on_click}
       phx-value-selected={@value}
-      class={"w-56 h-auto rounded-md #{if @is_selected, do: "shadow border-2 border-blue-500 bg-slate-50", else: "bg-white border border-blue-500/30 hover:border-blue-500/80"} flex-col justify-start items-start px-4 py-3 hover:cursor-pointer"}
+      class={"w-56 h-auto rounded-md dark:bg-gray-800 flex-col justify-start items-start px-4 py-3 hover:cursor-pointer #{if @is_selected, do: "shadow border-2 border-blue-500 bg-slate-50", else: "bg-white border border-blue-500/30 hover:border-blue-500/80 dark:border-white"}"}
     >
-      <div class="text-slate-500 text-xs font-normal leading-none">
+      <div class="text-slate-500 text-xs font-normal leading-none dark:text-white">
         <%= @title %>
       </div>
       <div class="flex items-baseline space-x-2 mt-2">
-        <div class={"text-3xl font-semibold leading-10 #{if @is_selected, do: "text-blue-500", else: "text-slate-800"}"}>
+        <div class={"text-3xl font-semibold leading-10 dark:text-white #{if @is_selected, do: "text-blue-500", else: "text-slate-800"}"}>
           <%= @count %>
         </div>
-        <div class="text-gray-400 text-xs font-normal leading-none">
+        <div class="text-gray-400 text-xs font-normal leading-none dark:text-white">
           <%= case @container_filter_by do %>
             <% :units -> %>
               Units

--- a/lib/oli_web/components/delivery/content/content.ex
+++ b/lib/oli_web/components/delivery/content/content.ex
@@ -186,7 +186,8 @@ defmodule OliWeb.Components.Delivery.Content do
            socket,
            %{
              container_filter_by: filter,
-             text_search: @default_params.text_search
+             text_search: @default_params.text_search,
+             selected_card_value: @default_params.selected_card_value
            },
            socket.assigns.patch_url_type
          )

--- a/lib/oli_web/components/delivery/students/students.ex
+++ b/lib/oli_web/components/delivery/students/students.ex
@@ -4,12 +4,10 @@ defmodule OliWeb.Components.Delivery.Students do
 
   alias Phoenix.LiveView.JS
 
-  alias Oli.Accounts.Author
-  alias Oli.Accounts.User
-  alias OliWeb.Common.InstructorDashboardPagedTable
-  alias OliWeb.Common.Params
-  alias OliWeb.Common.SearchInput
-  alias OliWeb.Common.Utils
+  alias Oli.Accounts.{Author, User}
+  alias Oli.Delivery.Metrics
+  alias OliWeb.Common.{SearchInput, Params, Utils}
+  alias OliWeb.Components.Delivery.CardHighLights
   alias OliWeb.Delivery.Sections.EnrollmentsTableModel
   alias OliWeb.Router.Helpers, as: Routes
 
@@ -23,7 +21,9 @@ defmodule OliWeb.Components.Delivery.Students do
     sort_by: :name,
     text_search: nil,
     filter_by: :enrolled,
-    payment_status: nil
+    payment_status: nil,
+    selected_card_value: nil,
+    container_filter_by: :students
   }
 
   def update(
@@ -48,6 +48,30 @@ defmodule OliWeb.Components.Delivery.Students do
           Enum.find(table_model.column_specs, fn col_spec -> col_spec.name == params.sort_by end)
       })
 
+    selected_card_value = Map.get(assigns.params, :selected_card_value, nil)
+    students_count = students_count(students, params.filter_by)
+
+    card_props = [
+      %{
+        title: "Low Progress",
+        count: Map.get(students_count, :low_progress),
+        is_selected: selected_card_value == "1",
+        value: "1"
+      },
+      %{
+        title: "Low Proficiency",
+        count: Map.get(students_count, :low_proficiency),
+        is_selected: selected_card_value == "2",
+        value: "2"
+      },
+      %{
+        title: "Zero interaction in a week",
+        count: Map.get(students_count, :zero_interaction_in_a_week),
+        is_selected: selected_card_value == "3",
+        value: "3"
+      }
+    ]
+
     {:ok,
      assign(socket,
        id: assigns.id,
@@ -67,7 +91,8 @@ defmodule OliWeb.Components.Delivery.Students do
        add_enrollments_users_not_found: [],
        inviter: if(is_nil(ctx.author), do: "user", else: "author"),
        current_user: ctx.user,
-       current_author: ctx.author
+       current_author: ctx.author,
+       card_props: card_props
      )}
   end
 
@@ -76,6 +101,7 @@ defmodule OliWeb.Components.Delivery.Students do
       students
       |> maybe_filter_by_text(params.text_search)
       |> maybe_filter_by_option(params.filter_by)
+      |> maybe_filter_by_card(params.selected_card_value, params.filter_by)
       |> sort_by(params.sort_by, params.sort_order)
 
     {length(students), students |> Enum.drop(params.offset) |> Enum.take(params.limit)}
@@ -91,6 +117,38 @@ defmodule OliWeb.Components.Delivery.Students do
         String.downcase(text_search)
       )
     end)
+  end
+
+  defp maybe_filter_by_card(students, nil, _), do: students
+  defp maybe_filter_by_card(students, "", _), do: students
+
+  defp maybe_filter_by_card(students, selected_card_value, filter_by) do
+    case selected_card_value do
+      "1" ->
+        Enum.filter(students, fn student ->
+          Metrics.progress_range(student.progress) == "Low" ||
+            (is_nil(student.progress) and
+               (student.enrollment_status == filter_by and
+                  student.user_role_id == 4))
+        end)
+
+      "2" ->
+        Enum.filter(students, fn student ->
+          Metrics.proficiency_range(student.overall_proficiency) == "Low" ||
+            (is_nil(student.overall_proficiency) and
+               (student.enrollment_status == filter_by and
+                  student.user_role_id == 4))
+        end)
+
+      "3" ->
+        Enum.filter(students, fn student ->
+          diff_days = Timex.Comparable.diff(DateTime.utc_now(), student.last_interaction, :days)
+
+          diff_days > 7 and
+            (student.enrollment_status == filter_by and
+               student.user_role_id == 4)
+        end)
+    end
   end
 
   defp maybe_filter_by_option(students, dropdown_value) do
@@ -195,6 +253,7 @@ defmodule OliWeb.Components.Delivery.Students do
   attr(:current_author, :any, required: false)
   attr(:inviter, :string, required: false)
   attr(:myself, :string, required: false)
+  attr(:card_props, :list)
 
   def render(assigns) do
     ~H"""
@@ -235,7 +294,7 @@ defmodule OliWeb.Components.Delivery.Students do
       <div class="bg-white dark:bg-gray-800 shadow-sm">
         <div class="flex justify-between sm:items-end px-4 sm:px-9 py-4 instructor_dashboard_table">
           <div>
-            <h4 class="torus-h4 !py-0 sm:mr-auto mb-2"><%= @title %></h4>
+            <h4 class="torus-h4 !py-0 sm:mr-auto mb-2">Students Enrolled in <%= @title %></h4>
             <%= if @show_progress_csv_download do %>
               <a
                 class="self-end"
@@ -295,6 +354,18 @@ defmodule OliWeb.Components.Delivery.Students do
               />
             </form>
           </div>
+        </div>
+        <div class="flex flex-row mx-9 gap-x-4">
+          <%= for card <- @card_props do %>
+            <CardHighLights.render
+              title={card.title}
+              count={card.count}
+              is_selected={card.is_selected}
+              value={card.value}
+              on_click={JS.push("select_card", target: @myself)}
+              container_filter_by={@params.container_filter_by}
+            />
+          <% end %>
         </div>
 
         <InstructorDashboardPagedTable.render
@@ -450,6 +521,14 @@ defmodule OliWeb.Components.Delivery.Students do
       </fieldset>
     </div>
     """
+  end
+
+  def handle_event("select_card", %{"selected" => value}, socket) do
+    value = if value == Map.get(socket.assigns.params, :selected_card_value), do: nil, else: value
+
+    send(self(), {:selected_card_students, {value, socket.assigns.params.container_id}})
+
+    {:noreply, socket}
   end
 
   def handle_event("select_inviter", %{"inviter" => inviter}, socket) do
@@ -661,6 +740,15 @@ defmodule OliWeb.Components.Delivery.Students do
           "filter_by",
           [:enrolled, :suspended, :paid, :not_paid, :grace_period, :non_students],
           @default_params.filter_by
+        ),
+      selected_card_value:
+        Params.get_param(params, "selected_card_value", @default_params.selected_card_value),
+      container_filter_by:
+        Params.get_atom_param(
+          params,
+          "container_filter_by",
+          [:students],
+          @default_params.container_filter_by
         )
     }
   end
@@ -694,5 +782,32 @@ defmodule OliWeb.Components.Delivery.Students do
     |> MapSet.new()
     |> MapSet.union(MapSet.new(current_elements))
     |> MapSet.to_list()
+  end
+
+  defp students_count(students, filter_by) do
+    %{
+      low_progress:
+        Enum.count(students, fn student ->
+          Metrics.progress_range(student.progress) == "Low" ||
+            (is_nil(student.progress) and
+               (student.enrollment_status == filter_by and
+                  student.user_role_id == 4))
+        end),
+      low_proficiency:
+        Enum.count(students, fn student ->
+          Metrics.proficiency_range(student.overall_proficiency) == "Low" ||
+            (is_nil(student.overall_proficiency) and
+               (student.enrollment_status == filter_by and
+                  student.user_role_id == 4))
+        end),
+      zero_interaction_in_a_week:
+        Enum.count(students, fn student ->
+          diff_days = Timex.Comparable.diff(DateTime.utc_now(), student.last_interaction, :days)
+
+          diff_days > 7 and
+            (student.enrollment_status == filter_by and
+               student.user_role_id == 4)
+        end)
+    }
   end
 end

--- a/lib/oli_web/components/delivery/students/students.ex
+++ b/lib/oli_web/components/delivery/students/students.ex
@@ -355,7 +355,7 @@ defmodule OliWeb.Components.Delivery.Students do
             </form>
           </div>
         </div>
-        <div class="flex flex-row mx-9 gap-x-4">
+        <div class="flex flex-row mx-9 my-4 gap-x-4">
           <%= for card <- @card_props do %>
             <CardHighLights.render
               title={card.title}

--- a/lib/oli_web/icons.ex
+++ b/lib/oli_web/icons.ex
@@ -1017,5 +1017,19 @@ defmodule OliWeb.Icons do
     """
   end
 
+  def download(assigns) do
+    ~H"""
+    <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M3.56934 14.9318V16.6791C3.56934 17.1425 3.75343 17.587 4.08111 17.9147C4.4088 18.2423 4.85324 18.4264 5.31666 18.4264H15.8006C16.264 18.4264 16.7084 18.2423 17.0361 17.9147C17.3638 17.587 17.5479 17.1425 17.5479 16.6791V14.9318M6.19032 9.68984L10.5586 14.0581M10.5586 14.0581L14.9269 9.68984M10.5586 14.0581V3.57422"
+        stroke="#5B8FF9"
+        stroke-width="1.74732"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+    """
+  end
+
   ########## Studend Delivery Icons (end) ##########
 end

--- a/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
@@ -750,10 +750,12 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive do
         {:selected_card_containers, value},
         socket
       ) do
+    params = Map.merge(socket.assigns.params, %{"selected_card_value" => value})
+
     {:noreply,
      push_patch(socket,
        to:
-         ~p"/sections/#{socket.assigns.section.slug}/instructor_dashboard/insights/content?#{%{selected_card_value: value}}"
+         ~p"/sections/#{socket.assigns.section.slug}/instructor_dashboard/insights/content?#{params}"
      )}
   end
 
@@ -761,10 +763,16 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive do
         {:selected_card_students, {value, container_id}},
         socket
       ) do
+    params =
+      Map.merge(socket.assigns.params, %{
+        "selected_card_value" => value,
+        "container_id" => container_id
+      })
+
     {:noreply,
      push_patch(socket,
        to:
-         ~p"/sections/#{socket.assigns.section.slug}/instructor_dashboard/insights/content?#{%{selected_card_value: value, container_id: container_id}}"
+         ~p"/sections/#{socket.assigns.section.slug}/instructor_dashboard/insights/content?#{params}"
      )}
   end
 

--- a/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
@@ -746,6 +746,28 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive do
      )}
   end
 
+  def handle_info(
+        {:selected_card_containers, value},
+        socket
+      ) do
+    {:noreply,
+     push_patch(socket,
+       to:
+         ~p"/sections/#{socket.assigns.section.slug}/instructor_dashboard/insights/content?#{%{selected_card_value: value}}"
+     )}
+  end
+
+  def handle_info(
+        {:selected_card_students, {value, container_id}},
+        socket
+      ) do
+    {:noreply,
+     push_patch(socket,
+       to:
+         ~p"/sections/#{socket.assigns.section.slug}/instructor_dashboard/insights/content?#{%{selected_card_value: value, container_id: container_id}}"
+     )}
+  end
+
   @impl Phoenix.LiveView
   def handle_info(_any, socket) do
     {:noreply, socket}

--- a/test/oli_web/live/delivery/instructor_dashboard/insights/content_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/insights/content_tab_test.exs
@@ -534,6 +534,139 @@ defmodule OliWeb.Delivery.InstructorDashboard.ContentTabTest do
       assert unit_for_tr_1 =~ "Unit 1"
       assert unit_for_tr_2 =~ "Unit 2"
     end
+
+    test "cards to filter works correctly", %{
+      conn: conn,
+      instructor: instructor
+    } do
+      %{
+        section: section,
+        mod1_pages: mod1_pages
+      } = Seeder.base_project_with_larger_hierarchy()
+
+      [page_1, page_2, page_3] = mod1_pages
+      user_1 = insert(:user, %{given_name: "Diego", family_name: "Forlán"})
+
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+      Sections.enroll(user_1.id, section.id, [ContextRoles.get_role(:context_learner)])
+
+      {:ok, _} = Sections.rebuild_contained_pages(section)
+
+      set_progress(
+        section.id,
+        page_1.published_resource.resource_id,
+        user_1.id,
+        1,
+        page_1.revision
+      )
+
+      set_progress(
+        section.id,
+        page_2.published_resource.resource_id,
+        user_1.id,
+        1,
+        page_2.revision
+      )
+
+      set_progress(
+        section.id,
+        page_3.published_resource.resource_id,
+        user_1.id,
+        1,
+        page_3.revision
+      )
+
+      {:ok, view, _html} = live(conn, live_view_content_route(section.slug))
+
+      [unit_for_tr_1, unit_for_tr_2] =
+        view
+        |> render()
+        |> Floki.parse_fragment!()
+        |> Floki.find(~s{.instructor_dashboard_table tr a})
+        |> Enum.map(fn a_tag -> Floki.text(a_tag) end)
+
+      assert unit_for_tr_1 =~ "Unit 1"
+      assert unit_for_tr_2 =~ "Unit 2"
+
+      ## Filtering by zero student progress card
+      element(view, "div[phx-value-selected=\"2\"]") |> render_click()
+
+      refute has_element?(view, "table tr td div a", unit_for_tr_1)
+      assert has_element?(view, "table tr td div a", unit_for_tr_2)
+
+      ## Filtering by High Progress, Low Proficiency card
+      element(view, "div[phx-value-selected=\"1\"]") |> render_click()
+      refute has_element?(view, "table tr td div a", unit_for_tr_1)
+      refute has_element?(view, "table tr td div a", unit_for_tr_2)
+    end
+
+    test "cards to filter works correctly combined with input search", %{
+      conn: conn,
+      instructor: instructor
+    } do
+      %{
+        section: section,
+        mod1_pages: mod1_pages
+      } = Seeder.base_project_with_larger_hierarchy()
+
+      [page_1, page_2, page_3] = mod1_pages
+      user_1 = insert(:user, %{given_name: "Diego", family_name: "Forlán"})
+
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+      Sections.enroll(user_1.id, section.id, [ContextRoles.get_role(:context_learner)])
+
+      {:ok, _} = Sections.rebuild_contained_pages(section)
+
+      set_progress(
+        section.id,
+        page_1.published_resource.resource_id,
+        user_1.id,
+        1,
+        page_1.revision
+      )
+
+      set_progress(
+        section.id,
+        page_2.published_resource.resource_id,
+        user_1.id,
+        1,
+        page_2.revision
+      )
+
+      set_progress(
+        section.id,
+        page_3.published_resource.resource_id,
+        user_1.id,
+        1,
+        page_3.revision
+      )
+
+      {:ok, view, _html} = live(conn, live_view_content_route(section.slug))
+
+      [unit_for_tr_1, unit_for_tr_2] =
+        view
+        |> render()
+        |> Floki.parse_fragment!()
+        |> Floki.find(~s{.instructor_dashboard_table tr a})
+        |> Enum.map(fn a_tag -> Floki.text(a_tag) end)
+
+      assert unit_for_tr_1 =~ "Unit 1"
+      assert unit_for_tr_2 =~ "Unit 2"
+
+      ## Filtering by zero student progress card
+      element(view, "div[phx-value-selected=\"2\"]") |> render_click()
+
+      assert has_element?(view, "table tr td div a", unit_for_tr_2)
+      refute has_element?(view, "table tr td div a", unit_for_tr_1)
+
+      ## Search for "Unit" string
+      view
+      |> element("form[phx-change=\"search_container\"]")
+      |> render_change(%{container_name: "Unit"})
+
+      assert has_element?(view, "table tr td div a", unit_for_tr_2)
+      refute has_element?(view, "table tr td div a", unit_for_tr_1)
+    end
   end
 
   defp set_progress(section_id, resource_id, user_id, progress, revision) do

--- a/test/oli_web/live/delivery/instructor_dashboard/insights/content_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/insights/content_tab_test.exs
@@ -589,13 +589,13 @@ defmodule OliWeb.Delivery.InstructorDashboard.ContentTabTest do
       assert unit_for_tr_2 =~ "Unit 2"
 
       ## Filtering by zero student progress card
-      element(view, "div[phx-value-selected=\"2\"]") |> render_click()
+      element(view, "div[phx-value-selected=\"zero_student_progress\"]") |> render_click()
 
       refute has_element?(view, "table tr td div a", unit_for_tr_1)
       assert has_element?(view, "table tr td div a", unit_for_tr_2)
 
       ## Filtering by High Progress, Low Proficiency card
-      element(view, "div[phx-value-selected=\"1\"]") |> render_click()
+      element(view, "div[phx-value-selected=\"high_progress_low_proficiency\"]") |> render_click()
       refute has_element?(view, "table tr td div a", unit_for_tr_1)
       refute has_element?(view, "table tr td div a", unit_for_tr_2)
     end
@@ -654,7 +654,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.ContentTabTest do
       assert unit_for_tr_2 =~ "Unit 2"
 
       ## Filtering by zero student progress card
-      element(view, "div[phx-value-selected=\"2\"]") |> render_click()
+      element(view, "div[phx-value-selected=\"zero_student_progress\"]") |> render_click()
 
       assert has_element?(view, "table tr td div a", unit_for_tr_2)
       refute has_element?(view, "table tr td div a", unit_for_tr_1)

--- a/test/oli_web/live/delivery/instructor_dashboard/insights/students_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/insights/students_tab_test.exs
@@ -537,24 +537,33 @@ defmodule OliWeb.Delivery.InstructorDashboard.StudentsTabTest do
         live(conn, live_view_students_route(section.slug, params))
 
       # Low Progress card it should have 3 students
-      assert element(view, "div[phx-value-selected=\"1\"]") |> render() =~ "Low Progress"
-      assert element(view, "div[phx-value-selected=\"1\"]") |> render() =~ "3"
-      assert element(view, "div[phx-value-selected=\"1\"]") |> render() =~ "Students"
+      assert element(view, "div[phx-value-selected=\"low_progress\"]") |> render() =~
+               "Low Progress"
+
+      assert element(view, "div[phx-value-selected=\"low_progress\"]") |> render() =~ "3"
+      assert element(view, "div[phx-value-selected=\"low_progress\"]") |> render() =~ "Students"
 
       # Low Proficiency card it should have 0 students
-      assert element(view, "div[phx-value-selected=\"2\"]") |> render() =~ "Low Proficiency"
-      assert element(view, "div[phx-value-selected=\"2\"]") |> render() =~ "0"
-      assert element(view, "div[phx-value-selected=\"2\"]") |> render() =~ "Students"
+      assert element(view, "div[phx-value-selected=\"low_proficiency\"]") |> render() =~
+               "Low Proficiency"
+
+      assert element(view, "div[phx-value-selected=\"low_proficiency\"]") |> render() =~ "0"
+
+      assert element(view, "div[phx-value-selected=\"low_proficiency\"]") |> render() =~
+               "Students"
 
       # Zero Interaction in a week card it should have 2 students
-      assert element(view, "div[phx-value-selected=\"3\"]") |> render() =~
+      assert element(view, "div[phx-value-selected=\"zero_interaction_in_a_week\"]") |> render() =~
                "Zero interaction in a week"
 
-      assert element(view, "div[phx-value-selected=\"3\"]") |> render() =~ "0"
-      assert element(view, "div[phx-value-selected=\"3\"]") |> render() =~ "Students"
+      assert element(view, "div[phx-value-selected=\"zero_interaction_in_a_week\"]") |> render() =~
+               "0"
+
+      assert element(view, "div[phx-value-selected=\"zero_interaction_in_a_week\"]") |> render() =~
+               "Students"
 
       ## Filtering by Low Progress
-      element(view, "div[phx-value-selected=\"1\"]") |> render_click()
+      element(view, "div[phx-value-selected=\"low_progress\"]") |> render_click()
 
       assert has_element?(view, "table tr td div a", user_2.family_name)
       assert has_element?(view, "table tr td div a", user_3.family_name)
@@ -562,12 +571,12 @@ defmodule OliWeb.Delivery.InstructorDashboard.StudentsTabTest do
       refute has_element?(view, "table tr td div a", user_1.family_name)
 
       ## Filtering by Low Proficiency
-      element(view, "div[phx-value-selected=\"2\"]") |> render_click()
+      element(view, "div[phx-value-selected=\"low_proficiency\"]") |> render_click()
       assert has_element?(view, "p", "None exist")
 
       ## Filtering by Zero Interaction in a week
 
-      element(view, "div[phx-value-selected=\"3\"]") |> render_click()
+      element(view, "div[phx-value-selected=\"zero_interaction_in_a_week\"]") |> render_click()
 
       refute has_element?(view, "table tr td div a", user_1.family_name)
       refute has_element?(view, "table tr td div a", user_2.family_name)
@@ -607,12 +616,14 @@ defmodule OliWeb.Delivery.InstructorDashboard.StudentsTabTest do
         live(conn, live_view_students_route(section.slug, params))
 
       # Low Progress card it should have 3 students
-      assert element(view, "div[phx-value-selected=\"1\"]") |> render() =~ "Low Progress"
-      assert element(view, "div[phx-value-selected=\"1\"]") |> render() =~ "3"
-      assert element(view, "div[phx-value-selected=\"1\"]") |> render() =~ "Students"
+      assert element(view, "div[phx-value-selected=\"low_progress\"]") |> render() =~
+               "Low Progress"
+
+      assert element(view, "div[phx-value-selected=\"low_progress\"]") |> render() =~ "3"
+      assert element(view, "div[phx-value-selected=\"low_progress\"]") |> render() =~ "Students"
 
       ## Select Low Progress card
-      element(view, "div[phx-value-selected=\"1\"]") |> render_click()
+      element(view, "div[phx-value-selected=\"low_progress\"]") |> render_click()
 
       ## Check that only 3 students are displayed
       assert has_element?(view, "table tr td div a", user_2.family_name)
@@ -621,7 +632,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.StudentsTabTest do
       refute has_element?(view, "table tr td div a", user_1.family_name)
 
       ## Click again to deselect Low Progress card
-      element(view, "div[phx-value-selected=\"1\"]") |> render_click()
+      element(view, "div[phx-value-selected=\"low_progress\"]") |> render_click()
 
       ## Check that all students are displayed
       assert has_element?(view, "table tr td div a", user_2.family_name)


### PR DESCRIPTION
[MER-3182](https://eliterate.atlassian.net/browse/MER-3182)

This PR adds cards to the `Content` and `Student` views in the instructor dashboard, which will allow to filter the content of the tables by different metrics. 

Each of the cards corresponds to a different metric and they can be selected and deselected in order to filter the content of the table showing the data corresponding to each tab.


https://github.com/Simon-Initiative/oli-torus/assets/16328384/096bca4d-b96f-4737-ada4-ea5039071702





[MER-3182]: https://eliterate.atlassian.net/browse/MER-3182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ