### PR TITLE
[ENHANCEMENT] [NG23-178] Improve navigation when prev or next resource is a section or subsection

### DIFF
--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -564,34 +564,38 @@ defmodule OliWeb.Components.Delivery.Layouts do
   end
 
   defp resource_navigation_url(
-         %{"slug" => slug, "type" => "page", "id" => resource_id},
+         %{"id" => resource_id, "slug" => slug, "type" => type, "level" => level},
          section_slug,
          request_path,
          selected_view
        ) do
-    # If the request_path is the Learn page and we navigate to a different lesson,
-    # we need to update the request_path to include the new target resource.
-    request_path =
-      if request_path && String.contains?(request_path, "/learn") do
+    case {type, Integer.parse(level)} do
+      # If the given resource is a unit or a module (level <= 2), we navigate to learn page.
+      {"container", {level, _}} when level <= 2 ->
         Utils.learn_live_path(section_slug,
           target_resource_id: resource_id,
           selected_view: selected_view
         )
-      else
-        request_path
-      end
 
-    Utils.lesson_live_path(section_slug, slug,
-      request_path: request_path,
-      selected_view: selected_view
-    )
-  end
+      # If the given resource is a page or a section/sub-section (level > 2), we navigate to lesson page.
+      _ ->
+        # If the request_path is the Learn page and we navigate to a different lesson,
+        # we need to update the request_path to include the new target resource.
+        request_path =
+          if request_path && String.contains?(request_path, "/learn") do
+            Utils.learn_live_path(section_slug,
+              target_resource_id: resource_id,
+              selected_view: selected_view
+            )
+          else
+            request_path
+          end
 
-  defp resource_navigation_url(%{"id" => container_id}, section_slug, _, selected_view) do
-    Utils.learn_live_path(section_slug,
-      target_resource_id: container_id,
-      selected_view: selected_view
-    )
+        Utils.lesson_live_path(section_slug, slug,
+          request_path: request_path,
+          selected_view: selected_view
+        )
+    end
   end
 
   attr(:to, :string)

--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -570,14 +570,14 @@ defmodule OliWeb.Components.Delivery.Layouts do
          selected_view
        ) do
     case {type, Integer.parse(level)} do
-      # If the given resource is a unit or a module (level <= 2), we navigate to learn page.
-      {"container", {level, _}} when level <= 2 ->
+      # If the given resource is a module (level == 2), we navigate to learn page.
+      {"container", {2, _}} ->
         Utils.learn_live_path(section_slug,
           target_resource_id: resource_id,
           selected_view: selected_view
         )
 
-      # If the given resource is a page or a section/sub-section (level > 2), we navigate to lesson page.
+      # If the given resource is other than a module (page, section/sub-section, unit), we navigate to lesson page.
       _ ->
         # If the request_path is the Learn page and we navigate to a different lesson,
         # we need to update the request_path to include the new target resource.

--- a/lib/oli_web/live_session_plugs/init_page.ex
+++ b/lib/oli_web/live_session_plugs/init_page.ex
@@ -37,7 +37,7 @@ defmodule OliWeb.LiveSessionPlugs.InitPage do
 
     # note will all be nil for case of "loose" linked pages not in hierarchy
     {:ok, {previous, next, current}, _} =
-      PreviousNextIndex.retrieve(assigns.section, resource_id, skip: [:unit, :section])
+      PreviousNextIndex.retrieve(assigns.section, resource_id, skip: [:section])
 
     socket =
       case assigns.view do

--- a/lib/oli_web/live_session_plugs/init_page.ex
+++ b/lib/oli_web/live_session_plugs/init_page.ex
@@ -37,7 +37,7 @@ defmodule OliWeb.LiveSessionPlugs.InitPage do
 
     # note will all be nil for case of "loose" linked pages not in hierarchy
     {:ok, {previous, next, current}, _} =
-      PreviousNextIndex.retrieve(assigns.section, resource_id)
+      PreviousNextIndex.retrieve(assigns.section, resource_id, skip: [:unit, :section])
 
     socket =
       case assigns.view do

--- a/test/oli/delivery/previous_next_index_test.exs
+++ b/test/oli/delivery/previous_next_index_test.exs
@@ -59,4 +59,75 @@ defmodule Oli.Delivery.PreviousNextIndexTest do
       refute is_nil(section.previous_next_index)
     end
   end
+
+  describe "retrieve/3 when there are containers to skip" do
+    test "returns no previous or next when the current resource is not in the index map" do
+      assert {:ok, {nil, nil, nil}, %{}} == PreviousNextIndex.retrieve(%{}, 1, skip: [:unit])
+    end
+
+    test "returns closest navigable resource when next or prev resource should be skipped" do
+      # Page 1, Unit 2, Page 3, Section 4, Page 5
+      {prev_next_index, _, _} =
+        attach_next("page")
+        |> attach_next("unit")
+        |> attach_next("page")
+        |> attach_next("section")
+        |> attach_next("page")
+
+      # Get Page 3, and its prev and next
+      {:ok, {prev, next, current}, _} =
+        PreviousNextIndex.retrieve(prev_next_index, 3, skip: [:unit, :section])
+
+      # Current is Page 3
+      assert current["id"] == "3"
+      assert current["title"] == "page 3"
+      assert current["type"] == "page"
+
+      # Prev is Page 1, it skips Unit 2
+      assert prev["id"] == "1"
+      assert prev["title"] == "page 1"
+      assert prev["type"] == "page"
+
+      # Next is Page 5, it skips Section 4
+      assert next["id"] == "5"
+      assert next["title"] == "page 5"
+      assert next["type"] == "page"
+    end
+  end
+
+  defp attach_next(type), do: attach_next({%{}, nil, 1}, type)
+
+  defp attach_next({prev_next_index, current, id}, type) do
+    {level, resource_type} =
+      case type do
+        "page" -> {"1", "page"}
+        "unit" -> {"1", "container"}
+        "module" -> {"2", "container"}
+        _ -> {"3", "container"}
+      end
+
+    next =
+      %{
+        "id" => "#{id}",
+        "index" => "#{id}",
+        "prev" => current["id"],
+        "next" => nil,
+        "slug" => "#{type}_#{id}",
+        "title" => "#{type} #{id}",
+        "children" => [],
+        "type" => resource_type,
+        "level" => level
+      }
+
+    prev_next_index =
+      if current do
+        current = Map.put(current, "next", "#{id}")
+        Map.put(prev_next_index, current["id"], current)
+      else
+        prev_next_index
+      end
+      |> Map.put(next["id"], next)
+
+    {prev_next_index, next, id + 1}
+  end
 end

--- a/test/oli_web/live/delivery/student/lesson_live_test.exs
+++ b/test/oli_web/live/delivery/student/lesson_live_test.exs
@@ -1059,7 +1059,7 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
       )
     end
 
-    test "redirects to the learn page when the next or previous page corresponds to a unit or module",
+    test "redirects to the learn page when the next or previous page corresponds to a module",
          %{
            conn: conn,
            user: user,
@@ -1102,68 +1102,6 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
         view,
         Utils.learn_live_path(section.slug,
           target_resource_id: module_1.resource_id,
-          selected_view: @default_selected_view
-        )
-      )
-    end
-
-    test "redirects to the lesson page when the next or previous page corresponds to a section or subsection",
-         %{
-           conn: conn,
-           user: user,
-           section: section,
-           page_4: page_4,
-           module_2: module_2,
-           section_1: section_1,
-           subsection_1: subsection_1
-         } do
-      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
-      Sections.mark_section_visited_for_student(section, user)
-
-      # next page is a section
-      {:ok, view, _html} =
-        live(
-          conn,
-          Utils.lesson_live_path(section.slug, module_2.slug,
-            selected_view: @default_selected_view
-          )
-        )
-
-      view
-      |> element(~s{div[role="next_page"] a})
-      |> render_click
-
-      request_path =
-        Utils.learn_live_path(section.slug,
-          target_resource_id: section_1.resource_id,
-          selected_view: @default_selected_view
-        )
-
-      assert_redirected(
-        view,
-        Utils.lesson_live_path(section.slug, section_1.slug,
-          request_path: request_path,
-          selected_view: @default_selected_view
-        )
-      )
-
-      # previous page is a subsection
-      {:ok, view, _html} = live(conn, Utils.lesson_live_path(section.slug, page_4.slug))
-
-      view
-      |> element(~s{div[role="prev_page"] a})
-      |> render_click
-
-      request_path =
-        Utils.learn_live_path(section.slug,
-          target_resource_id: subsection_1.resource_id,
-          selected_view: @default_selected_view
-        )
-
-      assert_redirected(
-        view,
-        Utils.lesson_live_path(section.slug, subsection_1.slug,
-          request_path: request_path,
           selected_view: @default_selected_view
         )
       )

--- a/test/oli_web/live/delivery/student/lesson_live_test.exs
+++ b/test/oli_web/live/delivery/student/lesson_live_test.exs
@@ -185,6 +185,47 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
         }
       )
 
+    page_4_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.get_id_by_type("page"),
+        title: "Page 4",
+        duration_minutes: 5,
+        graded: true,
+        max_attempts: 5,
+        content: %{
+          model: []
+        }
+      )
+
+    page_5_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.get_id_by_type("page"),
+        title: "Page 5",
+        duration_minutes: 5,
+        graded: true,
+        max_attempts: 5,
+        content: %{
+          model: []
+        }
+      )
+
+    ## sections and subsections...
+    subsection_1_revision =
+      insert(:revision, %{
+        resource_type_id: Oli.Resources.ResourceType.get_id_by_type("container"),
+        children: [
+          page_4_revision.resource_id
+        ],
+        title: "Erlang as a motivation"
+      })
+
+    section_1_revision =
+      insert(:revision, %{
+        resource_type_id: Oli.Resources.ResourceType.get_id_by_type("container"),
+        children: [subsection_1_revision.resource_id, page_5_revision.resource_id],
+        title: "Why Elixir?"
+      })
+
     ## modules...
     module_1_revision =
       insert(:revision, %{
@@ -209,7 +250,7 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
     module_2_revision =
       insert(:revision, %{
         resource_type_id: Oli.Resources.ResourceType.get_id_by_type("container"),
-        children: [page_3_revision.resource_id],
+        children: [section_1_revision.resource_id, page_3_revision.resource_id],
         title: "The second module is awesome!",
         poster_image: "module_2_custom_image_url",
         intro_content: %{
@@ -265,6 +306,10 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
         graded_adaptive_page_revision,
         page_2_revision,
         page_3_revision,
+        page_4_revision,
+        page_5_revision,
+        subsection_1_revision,
+        section_1_revision,
         module_1_revision,
         module_2_revision,
         unit_1_revision,
@@ -346,6 +391,10 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
       graded_adaptive_page_revision: graded_adaptive_page_revision,
       page_2: page_2_revision,
       page_3: page_3_revision,
+      page_4: page_4_revision,
+      page_5: page_5_revision,
+      section_1: section_1_revision,
+      subsection_1: subsection_1_revision,
       module_1: module_1_revision,
       module_2: module_2_revision,
       unit_1: unit_1_revision,
@@ -1010,13 +1059,14 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
       )
     end
 
-    test "redirects to the learn page when the next or previous page corresponds to a container",
+    test "redirects to the learn page when the next or previous page corresponds to a unit or module",
          %{
            conn: conn,
            user: user,
            section: section,
+           page_1: page_1,
            page_2: page_2,
-           page_3: page_3,
+           module_1: module_1,
            module_2: module_2
          } do
       Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
@@ -1042,7 +1092,7 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
       )
 
       # previous page is a container
-      {:ok, view, _html} = live(conn, Utils.lesson_live_path(section.slug, page_3.slug))
+      {:ok, view, _html} = live(conn, Utils.lesson_live_path(section.slug, page_1.slug))
 
       view
       |> element(~s{div[role="prev_page"] a})
@@ -1051,7 +1101,69 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
       assert_redirected(
         view,
         Utils.learn_live_path(section.slug,
-          target_resource_id: module_2.resource_id,
+          target_resource_id: module_1.resource_id,
+          selected_view: @default_selected_view
+        )
+      )
+    end
+
+    test "redirects to the lesson page when the next or previous page corresponds to a section or subsection",
+         %{
+           conn: conn,
+           user: user,
+           section: section,
+           page_4: page_4,
+           module_2: module_2,
+           section_1: section_1,
+           subsection_1: subsection_1
+         } do
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.mark_section_visited_for_student(section, user)
+
+      # next page is a section
+      {:ok, view, _html} =
+        live(
+          conn,
+          Utils.lesson_live_path(section.slug, module_2.slug,
+            selected_view: @default_selected_view
+          )
+        )
+
+      view
+      |> element(~s{div[role="next_page"] a})
+      |> render_click
+
+      request_path =
+        Utils.learn_live_path(section.slug,
+          target_resource_id: section_1.resource_id,
+          selected_view: @default_selected_view
+        )
+
+      assert_redirected(
+        view,
+        Utils.lesson_live_path(section.slug, section_1.slug,
+          request_path: request_path,
+          selected_view: @default_selected_view
+        )
+      )
+
+      # previous page is a subsection
+      {:ok, view, _html} = live(conn, Utils.lesson_live_path(section.slug, page_4.slug))
+
+      view
+      |> element(~s{div[role="prev_page"] a})
+      |> render_click
+
+      request_path =
+        Utils.learn_live_path(section.slug,
+          target_resource_id: subsection_1.resource_id,
+          selected_view: @default_selected_view
+        )
+
+      assert_redirected(
+        view,
+        Utils.lesson_live_path(section.slug, subsection_1.slug,
+          request_path: request_path,
           selected_view: @default_selected_view
         )
       )


### PR DESCRIPTION
[NG23-178](https://eliterate.atlassian.net/browse/NG23-178)

Set the following as a lesson navigation rule:
1. If the next or previous page is a **module**, redirect the student to the Learn view (`/sections/{SECTION_SLUG}/learn`), highlighting the container.
2. Otherwise, redirect to the specified resource view (`/sections/{SECTION_SLUG}/lesson/{RESOURCE_SLUG}`) (page or unit).
3. Remove sections and subsections from the footer navigation.

**Before:**

https://github.com/Simon-Initiative/oli-torus/assets/26532202/a373d684-a4b9-4a0c-ac28-333e7129a995



**After:**


https://github.com/Simon-Initiative/oli-torus/assets/26532202/11919794-4f30-4956-9b11-6719c93453bf



[NG23-178]: https://eliterate.atlassian.net/browse/NG23-178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ