### PR TITLE
[BUG FIX] [NG23-90] fix an issue where offset was not being properly reset on sorting change

### DIFF
--- a/lib/oli_web/live/delivery/student/discussions_live.ex
+++ b/lib/oli_web/live/delivery/student/discussions_live.ex
@@ -109,7 +109,8 @@ defmodule OliWeb.Delivery.Student.DiscussionsLive do
             socket.assigns.post_params.sort_by,
             sort_by,
             socket.assigns.post_params.sort_order
-          )
+          ),
+        offset: 0
       })
 
     {posts, more_posts_exist?} =
@@ -138,7 +139,8 @@ defmodule OliWeb.Delivery.Student.DiscussionsLive do
             socket.assigns.note_params.sort_by,
             sort_by,
             socket.assigns.note_params.sort_order
-          )
+          ),
+        offset: 0
       })
 
     {notes, more_notes_exist?} =


### PR DESCRIPTION
This PR fixes an issue with the "Load more posts" function for discussions and note where applying a sort would break the ability to load more notes due to this assign not properly being reset.

![2024-06-04 15 58 25](https://github.com/Simon-Initiative/oli-torus/assets/6248894/48ea0699-4078-4784-8a4e-4906da814326)
