### PR TITLE
[BUG FIX] [NG23-156] Create in context learning proficiency - part 2

### DIFF
--- a/lib/oli_web/live/delivery/student/utils.ex
+++ b/lib/oli_web/live/delivery/student/utils.ex
@@ -219,7 +219,7 @@ defmodule OliWeb.Delivery.Student.Utils do
     </div>
     <div
       id={"objective_#{@objective.resource_id}_tooltip"}
-      class="hidden absolute h-[57px] px-6 pt-[15px] pb-6 -top-[20px] -left-6 text-gray-800 dark:text-gray-700 text-base font-normal font-['Inter'] leading-normal bg-gray-300 dark:bg-white rounded-md border-2 border-gray-700 flex-col justify-start items-start gap-4 -translate-x-full"
+      class="hidden absolute min-h-[57px] max-w-[240px] -top-[20px] p-6 -left-6 text-gray-800 dark:text-gray-700 text-base font-normal font-['Inter'] leading-normal bg-gray-300 dark:bg-white rounded-md border-2 border-gray-700 flex-col justify-start items-center gap-4 z-10 -translate-x-full"
     >
       <%= proficiency_to_text(@objective.proficiency) %>
       <div class="absolute h-[40px] w-2 bg-gray-300 dark:bg-white top-2 right-0 z-20"></div>


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/NG23-156?focusedCommentId=23052) to the comment in the ticket

I could not reproduce the issue reported in any browser (tried Chrome, Firefox, Safari and Arc).
Anyway, this PR improves the responsiveness of the tooltip by rendering the text in more than one line in case the text overflows the tooltip width. So, although I couldn't reproduce the reported error in my local env, this improvement should have fixed it.

To test it, I hardcoded some longer texts in my local dev to validate the tooltip's expected behavior with different text lengths, as shown in the following video:

https://github.com/Simon-Initiative/oli-torus/assets/74839302/953a2b1b-90f9-4acb-b18a-08571d164379

**notice that the texts do not match the proficiency icons, as I tweaked them just for the video example purpose**


