### PR TITLE
[BUG FIX] [NG23-212] fix an issue where loading all activity scripts when beginning attempt crashes page

### DIFF
--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -1117,6 +1117,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
       {:noreply,
        socket
        |> assign(page_context: page_context)
+       |> assign(scripts: Utils.get_required_activity_scripts(page_context))
        |> assign(begin_attempt?: true, show_loader?: true)
        |> clear_flash()
        |> assign_html()

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -1117,10 +1117,9 @@ defmodule OliWeb.Delivery.Student.LessonLive do
       {:noreply,
        socket
        |> assign(page_context: page_context)
-       |> assign(scripts: Utils.get_required_activity_scripts(page_context))
        |> assign(begin_attempt?: true, show_loader?: true)
        |> clear_flash()
-       |> assign_html()
+       |> assign_html_and_scripts()
        |> load_scripts_on_client_side()
        |> emit_page_viewed_event()}
     else


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/NG23-212

This PR fixes an issue where beginning an attempt tried to load all activity scripts, which ultimately fails and shows an error message to the user because of another issue which was identified and captured in https://eliterate.atlassian.net/browse/NG23-233

The fix here is to actually be smarter about which scripts are being loaded when beginning an attempt. By assigning only the scripts required by the page when starting the attempt, we can avoid the error and optimize the assets being loaded.