### PR TITLE
[BUG FIX] [NG23-159] Adaptive pages back button

### DIFF
--- a/assets/src/apps/delivery/layouts/deck/DeckLayoutHeader.tsx
+++ b/assets/src/apps/delivery/layouts/deck/DeckLayoutHeader.tsx
@@ -16,6 +16,7 @@ import ReviewModeNavigation from './components/ReviewModeNavigation';
 
 interface DeckLayoutHeaderProps {
   pageName?: string;
+  backUrl?: string;
   activityName?: string;
   showScore?: boolean;
   themeId?: string;
@@ -25,6 +26,7 @@ interface DeckLayoutHeaderProps {
 const DeckLayoutHeader: React.FC<DeckLayoutHeaderProps> = ({
   pageName,
   activityName,
+  backUrl,
   showScore = false,
   themeId,
   userName,
@@ -44,7 +46,7 @@ const DeckLayoutHeader: React.FC<DeckLayoutHeaderProps> = ({
   const isPreviewMode = useSelector(selectPreviewMode);
   const isInstructor = useSelector(selectIsInstructor);
   const isReviewMode = useSelector(selectReviewMode);
-  const [backButtonUrl, setBackButtonUrl] = useState('');
+  const [backButtonUrl, setBackButtonUrl] = useState(backUrl);
   const [backButtonText, setBackButtonText] = useState('Back to Overview');
 
   const projectSlug = useSelector(selectSectionSlug);
@@ -56,8 +58,12 @@ const DeckLayoutHeader: React.FC<DeckLayoutHeaderProps> = ({
       setBackButtonUrl(`/authoring/project/${projectSlug}/resource/${resourceSlug}`);
       setBackButtonText('Back to Authoring');
     } else {
-      setBackButtonUrl(window.location.href.split('/adaptive_lesson')[0] + '/explorations');
-      setBackButtonText('Back to Explorations');
+      // if no backUrl is provided, then set it to the section root url
+      if (!backUrl) {
+        setBackButtonUrl(window.location.href.split('/adaptive_lesson')[0]);
+      }
+
+      setBackButtonText('Back');
     }
   }, [isPreviewMode]);
 

--- a/assets/src/apps/delivery/layouts/deck/DeckLayoutView.tsx
+++ b/assets/src/apps/delivery/layouts/deck/DeckLayoutView.tsx
@@ -669,6 +669,7 @@ const DeckLayoutView: React.FC<LayoutProps> = ({ pageTitle, pageContent, preview
       <style>{`style { display: none !important; }`}</style>
       <DeckLayoutHeader
         pageName={pageTitle}
+        backUrl={pageContent?.backUrl}
         userName={currentUserName}
         activityName=""
         showScore={true}


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/NG23-159) to the ticket

With this fix, the adaptive page's back button redirects the student to the page from which they accessed the adaptive page.
Before the fix the student was always redirected to the explorations page, not considering that an adaptive page may not necessarily be an exploration.

## Adaptive page (not an exploration)

https://github.com/Simon-Initiative/oli-torus/assets/74839302/77ca1491-3089-49a8-a454-89cf31b19c36

_**Note:**_ It may lead to confusion that when accessing the page we read at the center of the screen a title that says "Climate Exploration" and we were supposed to be accessing an adaptive page that was **not** an exploration. The reason is that I built an adaptive page (not an exploration) by grabbing the "Climate Exploration" page and changing its purpose from `:application` to `:foundation`.
You may validate this by looking at the card icon on the home page, that has a flag icon (graded page icon) instead of a world icon (exploration icon)

## Adaptive page (an exploration)

https://github.com/Simon-Initiative/oli-torus/assets/74839302/2ec14c7b-ed63-4326-ad3f-128197826665


