### PR TITLE
[FEATURE] [NG23-167] Intro content input for explorations and practice pages

### DIFF
--- a/lib/oli_web/live/curriculum/container/container_live.ex
+++ b/lib/oli_web/live/curriculum/container/container_live.ex
@@ -255,6 +255,8 @@ defmodule OliWeb.Curriculum.ContainerLive do
   def handle_event("validate-options", %{"revision" => revision_params}, socket) do
     %{options_modal_assigns: %{revision: revision} = modal_assigns} = socket.assigns
 
+    revision_params = ContainerLiveHelpers.decode_revision_params(revision_params)
+
     changeset =
       revision
       |> Resources.change_revision(revision_params)

--- a/lib/oli_web/live/curriculum/entries/options_modal.ex
+++ b/lib/oli_web/live/curriculum/entries/options_modal.ex
@@ -352,6 +352,7 @@ defmodule OliWeb.Curriculum.OptionsModalContent do
                   The title is used to identify this <%= resource_type_label(@revision) %>.
                 </small>
               </div>
+              <.intro_content_input form={@form} target={@myself} />
               <div class="form-group">
                 <label for="grading_type">Grading Type</label>
                 <.input
@@ -524,33 +525,7 @@ defmodule OliWeb.Curriculum.OptionsModalContent do
               The title is used to identify this <%= resource_type_label(@revision) %>.
             </small>
           </div>
-          <div class="form-group">
-            <label for="introduction_content">Introduction content</label>
-            <.input type="hidden" name="revision[intro_content]" field={@form[:intro_content] || %{}} />
-            <div class="form-control overflow-hidden truncate-form-control min-h-[34px]">
-              <div :if={fetch_field(@form.source, :intro_content) not in [nil, "", %{}]}>
-                <%= Phoenix.HTML.raw(
-                  Oli.Rendering.Content.render(
-                    %Oli.Rendering.Context{},
-                    fetch_field(@form.source, :intro_content)[
-                      "children"
-                    ],
-                    Oli.Rendering.Content.Html
-                  )
-                ) %>
-              </div>
-            </div>
-
-            <.button
-              phx-click="change_step"
-              phx-target={@myself}
-              phx-value-target_step="intro_content"
-              type="button"
-              class="btn btn-primary mt-2"
-            >
-              Edit
-            </.button>
-          </div>
+          <.intro_content_input form={@form} target={@myself} />
           <div class="flex gap-10 justify-center">
             <.poster_image_selection
               target={@myself}
@@ -711,7 +686,7 @@ defmodule OliWeb.Curriculum.OptionsModalContent do
   attr :intro_video, :string
   attr :target, :map
 
-  def intro_video_selection(%{intro_video: nil} = assigns) do
+  def intro_video_selection(%{intro_video: url} = assigns) when url in [nil, ""] do
     ~H"""
     <div class="form-group flex flex-col gap-2">
       <label>Intro video</label>
@@ -793,6 +768,41 @@ defmodule OliWeb.Curriculum.OptionsModalContent do
       >
         Select
       </button>
+    </div>
+    """
+  end
+
+  attr :form, :map
+  attr :target, :map
+
+  def intro_content_input(assigns) do
+    ~H"""
+    <div class="form-group">
+      <label for="introduction_content">Introduction content</label>
+      <.input type="hidden" name="revision[intro_content]" field={@form[:intro_content] || %{}} />
+      <div class="form-control overflow-hidden truncate-form-control min-h-[34px]">
+        <div :if={fetch_field(@form.source, :intro_content) not in [nil, "", %{}]}>
+          <%= Phoenix.HTML.raw(
+            Oli.Rendering.Content.render(
+              %Oli.Rendering.Context{},
+              fetch_field(@form.source, :intro_content)[
+                "children"
+              ],
+              Oli.Rendering.Content.Html
+            )
+          ) %>
+        </div>
+      </div>
+
+      <.button
+        phx-click="change_step"
+        phx-target={@target}
+        phx-value-target_step="intro_content"
+        type="button"
+        class="btn btn-primary mt-2"
+      >
+        Edit
+      </.button>
     </div>
     """
   end

--- a/lib/oli_web/live/curriculum/entries/options_modal.ex
+++ b/lib/oli_web/live/curriculum/entries/options_modal.ex
@@ -527,7 +527,7 @@ defmodule OliWeb.Curriculum.OptionsModalContent do
           <div class="form-group">
             <label for="introduction_content">Introduction content</label>
             <.input type="hidden" name="revision[intro_content]" field={@form[:intro_content] || %{}} />
-            <div class="form-control overflow-hidden truncate-form-control">
+            <div class="form-control overflow-hidden truncate-form-control min-h-[34px]">
               <div :if={fetch_field(@form.source, :intro_content) not in [nil, "", %{}]}>
                 <%= Phoenix.HTML.raw(
                   Oli.Rendering.Content.render(

--- a/lib/oli_web/live/resources/pages_view.ex
+++ b/lib/oli_web/live/resources/pages_view.ex
@@ -28,6 +28,7 @@ defmodule OliWeb.Resources.PagesView do
   alias Oli.Authoring.Course.Project
   alias OliWeb.Curriculum.OptionsModalContent
   alias OliWeb.Components.Modal
+  alias OliWeb.Curriculum.Container.ContainerLiveHelpers
 
   @limit 25
 
@@ -174,6 +175,7 @@ defmodule OliWeb.Resources.PagesView do
         <.live_component
           module={OptionsModalContent}
           id="modal_content"
+          ctx={@ctx}
           redirect_url={@options_modal_assigns.redirect_url}
           revision={@options_modal_assigns.revision}
           changeset={@options_modal_assigns.changeset}
@@ -483,6 +485,8 @@ defmodule OliWeb.Resources.PagesView do
   def handle_event("validate-options", %{"revision" => revision_params}, socket) do
     %{options_modal_assigns: %{revision: revision} = modal_assigns} = socket.assigns
 
+    revision_params = ContainerLiveHelpers.decode_revision_params(revision_params)
+
     changeset =
       revision
       |> Resources.change_revision(revision_params)
@@ -495,14 +499,7 @@ defmodule OliWeb.Resources.PagesView do
     %{options_modal_assigns: %{redirect_url: redirect_url, revision: revision}, project: project} =
       socket.assigns
 
-    revision_params =
-      case revision_params do
-        %{"explanation_strategy" => %{"type" => "none"}} ->
-          Map.put(revision_params, "explanation_strategy", nil)
-
-        _ ->
-          revision_params
-      end
+    revision_params = ContainerLiveHelpers.decode_revision_params(revision_params)
 
     case ContainerEditor.edit_page(project, revision.slug, revision_params) do
       {:ok, _} ->

--- a/test/oli_web/live/curriculum/entries/options_modal_content_test.exs
+++ b/test/oli_web/live/curriculum/entries/options_modal_content_test.exs
@@ -1287,12 +1287,13 @@ defmodule OliWeb.Curriculum.OptionsModalContentTest do
       refute has_element?(lcd, "video[data-filename='b.mp4']")
     end
 
-    test "renders no intro content if the revision is a not a container", %{
-      conn: conn,
-      project: project,
-      page_revision: revision,
-      project_hierarchy: project_hierarchy
-    } do
+    test "renders the intro content if the revision is a page (practice, graded, exploration, etc)",
+         %{
+           conn: conn,
+           project: project,
+           page_revision: revision,
+           project_hierarchy: project_hierarchy
+         } do
       form =
         revision
         |> Oli.Resources.change_revision()
@@ -1310,7 +1311,7 @@ defmodule OliWeb.Curriculum.OptionsModalContentTest do
           form: form
         })
 
-      refute has_element?(
+      assert has_element?(
                lcd,
                "label",
                "Introduction content"


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/NG23-167) to the ticket

This feature allows an author to set an intro content to a page (both from the curriculum or the page view).


https://github.com/Simon-Initiative/oli-torus/assets/74839302/92d6f4d4-5654-41de-8eaf-2c548292f805

## Other minor bugs fixed
Some minor bugs were found and fixed while working on the ticket

### Edit container name
A validation in the form was not correctly being done, so the form didn't allowed the user to save it
#### Before

https://github.com/Simon-Initiative/oli-torus/assets/74839302/f9289a10-d486-44e6-b5a8-72bcacc6bf40


#### After

https://github.com/Simon-Initiative/oli-torus/assets/74839302/b0042999-4dc0-448c-9ae2-b7d0bce7eda9


### "Ghost" intro video
When changing any form input, an intro video (with no content at all) appeared.

#### Before

https://github.com/Simon-Initiative/oli-torus/assets/74839302/9c101c5e-d84c-4ebd-bc8a-b4659a0725b3


#### After

https://github.com/Simon-Initiative/oli-torus/assets/74839302/6546bd26-7553-411a-85fd-54de96e46a48



