### PR TITLE
[BUG FIX] [MER-3146] Advanced Author and Simple Author/Flowchart: Keyboard Shortcuts Request on Canvas

### DIFF
--- a/assets/src/apps/authoring/components/ComponentToolbar/UndoRedoToolbar.tsx
+++ b/assets/src/apps/authoring/components/ComponentToolbar/UndoRedoToolbar.tsx
@@ -45,7 +45,7 @@ const UndoRedoToolbar: React.FC = () => {
       }
     },
     ['KeyZ'],
-    { ctrlKey: true, shiftKey: true },
+    { ctrlKey: true },
   );
   return (
     <>

--- a/assets/src/apps/authoring/components/ComponentToolbar/UndoRedoToolbar.tsx
+++ b/assets/src/apps/authoring/components/ComponentToolbar/UndoRedoToolbar.tsx
@@ -22,9 +22,31 @@ const UndoRedoToolbar: React.FC = () => {
     dispatch(redo(null));
   };
 
-  useKeyDown(handleUndo, ['KeyZ'], { ctrlKey: true });
-  useKeyDown(handleRedo, ['KeyY'], { ctrlKey: true });
-  useKeyDown(handleRedo, ['KeyZ'], { ctrlKey: false, shiftKey: true });
+  useKeyDown(
+    (ctrlKey, metaKey, shiftKey) => {
+      if (ctrlKey && !shiftKey) {
+        handleUndo();
+      }
+    },
+    ['KeyZ'],
+    { ctrlKey: true },
+  );
+  useKeyDown(
+    (ctrlKey, metaKey) => {
+      if (ctrlKey && !metaKey) handleRedo();
+    },
+    ['KeyY'],
+    { ctrlKey: true },
+  );
+  useKeyDown(
+    (ctrlKey, metaKey, shiftKey) => {
+      if (!ctrlKey && metaKey && shiftKey) {
+        handleRedo();
+      }
+    },
+    ['KeyZ'],
+    { ctrlKey: true, shiftKey: true },
+  );
   return (
     <>
       <OverlayTrigger

--- a/assets/src/apps/authoring/components/ComponentToolbar/UndoRedoToolbar.tsx
+++ b/assets/src/apps/authoring/components/ComponentToolbar/UndoRedoToolbar.tsx
@@ -22,8 +22,30 @@ const UndoRedoToolbar: React.FC = () => {
     dispatch(redo(null));
   };
 
-  useKeyDown(handleUndo, ['KeyZ'], { ctrlKey: true });
-  useKeyDown(handleRedo, ['KeyY'], { ctrlKey: true });
+  useKeyDown(
+    () => {
+      if (hasUndo) handleUndo();
+    },
+    ['KeyZ'],
+    { ctrlKey: true },
+    [hasUndo],
+  );
+  useKeyDown(
+    () => {
+      if (hasRedo) handleRedo();
+    },
+    ['KeyY'],
+    { ctrlKey: true },
+    [hasRedo],
+  );
+  useKeyDown(
+    () => {
+      if (hasRedo) handleRedo();
+    },
+    ['KeyZ'],
+    { ctrlKey: false, shiftKey: true },
+    [hasRedo],
+  );
   return (
     <>
       <OverlayTrigger

--- a/assets/src/apps/authoring/components/ComponentToolbar/UndoRedoToolbar.tsx
+++ b/assets/src/apps/authoring/components/ComponentToolbar/UndoRedoToolbar.tsx
@@ -22,30 +22,9 @@ const UndoRedoToolbar: React.FC = () => {
     dispatch(redo(null));
   };
 
-  useKeyDown(
-    () => {
-      if (hasUndo) handleUndo();
-    },
-    ['KeyZ'],
-    { ctrlKey: true },
-    [hasUndo],
-  );
-  useKeyDown(
-    () => {
-      if (hasRedo) handleRedo();
-    },
-    ['KeyY'],
-    { ctrlKey: true },
-    [hasRedo],
-  );
-  useKeyDown(
-    () => {
-      if (hasRedo) handleRedo();
-    },
-    ['KeyZ'],
-    { ctrlKey: false, shiftKey: true },
-    [hasRedo],
-  );
+  useKeyDown(handleUndo, ['KeyZ'], { ctrlKey: true });
+  useKeyDown(handleRedo, ['KeyY'], { ctrlKey: true });
+  useKeyDown(handleRedo, ['KeyZ'], { ctrlKey: false, shiftKey: true });
   return (
     <>
       <OverlayTrigger

--- a/assets/src/apps/authoring/components/Flowchart/toolbar/FlowchartHeaderNav.tsx
+++ b/assets/src/apps/authoring/components/Flowchart/toolbar/FlowchartHeaderNav.tsx
@@ -203,7 +203,7 @@ export const FlowchartHeaderNav: React.FC<HeaderNavProps> = () => {
       }
     },
     ['KeyZ'],
-    { ctrlKey: true, shiftKey: true },
+    { ctrlKey: true },
   );
   useKeyDown(handlePartPasteClick, ['KeyV'], { ctrlKey: true }, [copiedPart]);
 

--- a/assets/src/apps/authoring/components/Flowchart/toolbar/FlowchartHeaderNav.tsx
+++ b/assets/src/apps/authoring/components/Flowchart/toolbar/FlowchartHeaderNav.tsx
@@ -178,9 +178,33 @@ export const FlowchartHeaderNav: React.FC<HeaderNavProps> = () => {
     dispatch(setShowScoringOverview({ show: true }));
   };
 
-  useKeyDown(handleUndo, ['KeyZ'], { ctrlKey: true });
-  useKeyDown(handleRedo, ['KeyY'], { ctrlKey: true });
-  useKeyDown(handleRedo, ['KeyZ'], { ctrlKey: false, metaKey: true, shiftKey: true });
+  useKeyDown(
+    (ctrlKey, metaKey, shiftKey) => {
+      if (ctrlKey && !shiftKey) {
+        handleUndo();
+      }
+    },
+    ['KeyZ'],
+    { ctrlKey: true },
+  );
+  useKeyDown(
+    (ctrlKey, metaKey) => {
+      if (ctrlKey && !metaKey) {
+        handleRedo();
+      }
+    },
+    ['KeyY'],
+    { ctrlKey: true },
+  );
+  useKeyDown(
+    (ctrlKey, metaKey, shiftKey) => {
+      if (!ctrlKey && metaKey && shiftKey) {
+        handleRedo();
+      }
+    },
+    ['KeyZ'],
+    { ctrlKey: true, shiftKey: true },
+  );
   useKeyDown(handlePartPasteClick, ['KeyV'], { ctrlKey: true }, [copiedPart]);
 
   const handleAddComponent = useCallback(

--- a/assets/src/apps/authoring/components/Flowchart/toolbar/FlowchartHeaderNav.tsx
+++ b/assets/src/apps/authoring/components/Flowchart/toolbar/FlowchartHeaderNav.tsx
@@ -178,27 +178,9 @@ export const FlowchartHeaderNav: React.FC<HeaderNavProps> = () => {
     dispatch(setShowScoringOverview({ show: true }));
   };
 
-  useKeyDown(
-    () => {
-      if (hasUndo) handleUndo();
-    },
-    ['KeyZ'],
-    { ctrlKey: true },
-  );
-  useKeyDown(
-    () => {
-      if (hasRedo) handleRedo();
-    },
-    ['KeyY'],
-    { ctrlKey: true },
-  );
-  useKeyDown(
-    () => {
-      if (hasRedo) handleRedo();
-    },
-    ['KeyZ'],
-    { ctrlKey: false, shiftKey: true },
-  );
+  useKeyDown(handleUndo, ['KeyZ'], { ctrlKey: true });
+  useKeyDown(handleRedo, ['KeyY'], { ctrlKey: true });
+  useKeyDown(handleRedo, ['KeyZ'], { ctrlKey: false, metaKey: true, shiftKey: true });
   useKeyDown(handlePartPasteClick, ['KeyV'], { ctrlKey: true }, [copiedPart]);
 
   const handleAddComponent = useCallback(

--- a/assets/src/apps/authoring/components/Flowchart/toolbar/FlowchartHeaderNav.tsx
+++ b/assets/src/apps/authoring/components/Flowchart/toolbar/FlowchartHeaderNav.tsx
@@ -178,8 +178,27 @@ export const FlowchartHeaderNav: React.FC<HeaderNavProps> = () => {
     dispatch(setShowScoringOverview({ show: true }));
   };
 
-  useKeyDown(handleUndo, ['KeyZ'], { ctrlKey: true });
-  useKeyDown(handleRedo, ['KeyY'], { ctrlKey: true });
+  useKeyDown(
+    () => {
+      if (hasUndo) handleUndo();
+    },
+    ['KeyZ'],
+    { ctrlKey: true },
+  );
+  useKeyDown(
+    () => {
+      if (hasRedo) handleRedo();
+    },
+    ['KeyY'],
+    { ctrlKey: true },
+  );
+  useKeyDown(
+    () => {
+      if (hasRedo) handleRedo();
+    },
+    ['KeyZ'],
+    { ctrlKey: false, shiftKey: true },
+  );
   useKeyDown(handlePartPasteClick, ['KeyV'], { ctrlKey: true }, [copiedPart]);
 
   const handleAddComponent = useCallback(

--- a/assets/src/components/activities/adaptive/components/authoring/LayoutEditor.tsx
+++ b/assets/src/components/activities/adaptive/components/authoring/LayoutEditor.tsx
@@ -401,7 +401,7 @@ const LayoutEditor: React.FC<LayoutEditorProps> = (props) => {
       }
     },
     ['Delete', 'Backspace'],
-    {},
+    { ctrlKey: true },
     [selectedPartAndCapabilities, configurePartId],
   );
   useKeyDown(handleCopyComponent, ['KeyC'], { ctrlKey: true }, [

--- a/assets/src/hooks/useKeyDown.tsx
+++ b/assets/src/hooks/useKeyDown.tsx
@@ -3,16 +3,20 @@ import { useEffect } from 'react';
 export function useKeyDown(
   callback: () => void,
   keyCodes: string[],
-  options: { ctrlKey?: boolean; shiftKey?: boolean } = {},
+  options: { ctrlKey?: boolean; shiftKey?: boolean; metaKey?: boolean } = {},
   dependencies: any = [],
 ): void {
   const handler = ({ metaKey, ctrlKey, shiftKey, code }: KeyboardEvent) => {
-    const { ctrlKey: ctrlRequired, shiftKey: shiftRequired } = options;
+    const { ctrlKey: ctrlRequired, shiftKey: shiftRequired, metaKey: metaRequired } = options;
 
-    const ctrlMatch =
-      ctrlRequired === undefined || ctrlKey === ctrlRequired || metaKey === ctrlRequired;
-    const shiftMatch = shiftRequired === undefined || shiftKey === shiftRequired;
-    if (ctrlMatch && shiftMatch && keyCodes.includes(code)) {
+    let ctrlMatch = ctrlRequired === undefined || ctrlKey === ctrlRequired;
+    const metaMatch = metaKey === metaRequired;
+    const shiftMatch = shiftKey === shiftRequired;
+
+    if (!ctrlMatch && metaKey && shiftRequired === undefined) {
+      ctrlMatch = metaKey === ctrlRequired;
+    }
+    if (((metaMatch && shiftMatch) || (ctrlMatch && !shiftKey)) && keyCodes.includes(code)) {
       callback();
     }
   };

--- a/assets/src/hooks/useKeyDown.tsx
+++ b/assets/src/hooks/useKeyDown.tsx
@@ -3,15 +3,16 @@ import { useEffect } from 'react';
 export function useKeyDown(
   callback: () => void,
   keyCodes: string[],
-  options: { ctrlKey?: boolean } = {},
+  options: { ctrlKey?: boolean; shiftKey?: boolean } = {},
   dependencies: any = [],
 ): void {
-  const handler = ({ metaKey, ctrlKey, code }: KeyboardEvent) => {
-    const { ctrlKey: ctrlRequired } = options;
+  const handler = ({ metaKey, ctrlKey, shiftKey, code }: KeyboardEvent) => {
+    const { ctrlKey: ctrlRequired, shiftKey: shiftRequired } = options;
 
     const ctrlMatch =
       ctrlRequired === undefined || ctrlKey === ctrlRequired || metaKey === ctrlRequired;
-    if (ctrlMatch && keyCodes.includes(code)) {
+    const shiftMatch = shiftRequired === undefined || shiftKey === shiftRequired;
+    if (ctrlMatch && shiftMatch && keyCodes.includes(code)) {
       callback();
     }
   };

--- a/assets/src/hooks/useKeyDown.tsx
+++ b/assets/src/hooks/useKeyDown.tsx
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 export function useKeyDown(
   callback: (ctrlKey?: boolean, metaKey?: boolean, shiftKey?: boolean) => any,
   keyCodes: string[],
-  options: { ctrlKey?: boolean; shiftKey?: boolean } = {},
+  options: { ctrlKey?: boolean } = {},
   dependencies: any = [],
 ): void {
   const handler = ({ metaKey, ctrlKey, shiftKey, code }: KeyboardEvent) => {

--- a/assets/src/hooks/useKeyDown.tsx
+++ b/assets/src/hooks/useKeyDown.tsx
@@ -1,23 +1,18 @@
 import { useEffect } from 'react';
 
 export function useKeyDown(
-  callback: () => void,
+  callback: (ctrlKey?: boolean, metaKey?: boolean, shiftKey?: boolean) => any,
   keyCodes: string[],
-  options: { ctrlKey?: boolean; shiftKey?: boolean; metaKey?: boolean } = {},
+  options: { ctrlKey?: boolean; shiftKey?: boolean } = {},
   dependencies: any = [],
 ): void {
   const handler = ({ metaKey, ctrlKey, shiftKey, code }: KeyboardEvent) => {
-    const { ctrlKey: ctrlRequired, shiftKey: shiftRequired, metaKey: metaRequired } = options;
+    const { ctrlKey: ctrlRequired } = options;
 
-    let ctrlMatch = ctrlRequired === undefined || ctrlKey === ctrlRequired;
-    const metaMatch = metaKey === metaRequired;
-    const shiftMatch = shiftKey === shiftRequired;
-
-    if (!ctrlMatch && metaKey && shiftRequired === undefined) {
-      ctrlMatch = metaKey === ctrlRequired;
-    }
-    if (((metaMatch && shiftMatch) || (ctrlMatch && !shiftKey)) && keyCodes.includes(code)) {
-      callback();
+    const ctrlMatch =
+      ctrlRequired === undefined || ctrlKey === ctrlRequired || metaKey === ctrlRequired;
+    if (ctrlMatch && keyCodes.includes(code)) {
+      callback(ctrlKey, metaKey, shiftKey);
     }
   };
 


### PR DESCRIPTION
Hey @bsparks please look at the PR. Thanks

There was a request to handle some shortcuts specific to Mac and Windows:

1. On Mac,` cmd+y` works but it also opens chrome history, so it makes it unusable, can we remove this keyboard control for Mac?
2. Implement `cmd+shift+z` is the “traditional” redo on Mac