### PR TITLE
[BUG FIX] [MER-3342] Ensure enough width for embedded activities on graded pages

### DIFF
--- a/assets/src/data/activities/model/responses.ts
+++ b/assets/src/data/activities/model/responses.ts
@@ -45,7 +45,9 @@ export const getResponseBy = (model: HasParts, predicate: (x: Response) => boole
 
 export const hasCustomScoring = (model: HasParts, partId?: string): boolean => {
   const outOf = getOutOfPoints(model, partId || model.authoring.parts[0].id);
-  return outOf !== null && outOf !== undefined;
+  // migrated qs may carry non-default point values but no outOf attribute
+  const maxResponse = getMaxScoreResponse(model, partId || model.authoring.parts[0].id);
+  return (outOf !== null && outOf !== undefined) || maxResponse.score > 1;
 };
 
 export const getOutOfPoints = (model: HasParts, partId: string) => {

--- a/assets/src/data/activities/model/responses.ts
+++ b/assets/src/data/activities/model/responses.ts
@@ -45,9 +45,7 @@ export const getResponseBy = (model: HasParts, predicate: (x: Response) => boole
 
 export const hasCustomScoring = (model: HasParts, partId?: string): boolean => {
   const outOf = getOutOfPoints(model, partId || model.authoring.parts[0].id);
-  // migrated qs may carry non-default point values but no outOf attribute
-  const maxResponse = getMaxScoreResponse(model, partId || model.authoring.parts[0].id);
-  return (outOf !== null && outOf !== undefined) || maxResponse.score > 1;
+  return outOf !== null && outOf !== undefined;
 };
 
 export const getOutOfPoints = (model: HasParts, partId: string) => {

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -728,7 +728,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
     <div class="flex pb-20 flex-col w-full items-center gap-15 flex-1 overflow-auto">
       <div class="flex flex-col items-center w-full">
         <.scored_page_banner />
-        <div class="flex-1 max-w-[720px] w-full pt-20 pb-10 mx-6 flex-col justify-start items-center gap-10 inline-flex">
+        <div class="flex-1 max-w-[1040px] w-full pt-20 pb-10 px-[80px] flex-col justify-start items-center gap-10 inline-flex">
           <.page_header
             page_context={@page_context}
             ctx={@ctx}
@@ -797,7 +797,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
     <div class="flex pb-20 flex-col w-full items-center gap-15 flex-1 overflow-auto">
       <div class="flex flex-col items-center w-full">
         <.scored_page_banner />
-        <div class="flex-1 max-w-[720px] w-full pt-20 pb-10 mx-6 flex-col justify-start items-stretch gap-10 inline-flex">
+        <div class="flex-1 max-w-[1040px] w-full pt-20 pb-10 px-[80px] flex-col justify-start items-stretch gap-10 inline-flex">
           <.page_header
             page_context={@page_context}
             ctx={@ctx}

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -728,7 +728,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
     <div class="flex pb-20 flex-col w-full items-center gap-15 flex-1 overflow-auto">
       <div class="flex flex-col items-center w-full">
         <.scored_page_banner />
-        <div class="flex-1 max-w-[720px] pt-20 pb-10 mx-6 flex-col justify-start items-center gap-10 inline-flex">
+        <div class="flex-1 max-w-[720px] w-full pt-20 pb-10 mx-6 flex-col justify-start items-center gap-10 inline-flex">
           <.page_header
             page_context={@page_context}
             ctx={@ctx}
@@ -736,7 +736,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
             index={@current_page["index"]}
             container_label={Utils.get_container_label(@current_page["id"], @section)}
           />
-          <div id="eventIntercept" class="content" phx-update="ignore" role="page content">
+          <div id="eventIntercept" class="content w-full" phx-update="ignore" role="page content">
             <%= raw(@html) %>
             <div class="flex w-full justify-center">
               <button
@@ -797,7 +797,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
     <div class="flex pb-20 flex-col w-full items-center gap-15 flex-1 overflow-auto">
       <div class="flex flex-col items-center w-full">
         <.scored_page_banner />
-        <div class="flex-1 max-w-[720px] pt-20 pb-10 mx-6 flex-col justify-start items-center gap-10 inline-flex">
+        <div class="flex-1 max-w-[720px] w-full pt-20 pb-10 mx-6 flex-col justify-start items-stretch gap-10 inline-flex">
           <.page_header
             page_context={@page_context}
             ctx={@ctx}
@@ -821,7 +821,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
             <div
               :if={!@show_loader?}
               id="raw_html"
-              class="content opacity-0"
+              class="content opacity-0 w-full"
               phx-update="ignore"
               role="page content"
             >
@@ -855,7 +855,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
     <.password_attempt_modal />
 
     <div class="flex pb-20 flex-col w-full items-center gap-15 flex-1 overflow-auto">
-      <div class="flex-1 max-w-[720px] pt-20 pb-10 mx-6 flex-col justify-start items-center inline-flex">
+      <div class="flex-1 max-w-[720px] w-full pt-20 pb-10 mx-6 flex-col justify-start items-center inline-flex">
         <.page_header
           page_context={@page_context}
           ctx={@ctx}

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -728,7 +728,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
     <div class="flex pb-20 flex-col w-full items-center gap-15 flex-1 overflow-auto">
       <div class="flex flex-col items-center w-full">
         <.scored_page_banner />
-        <div class="flex-1 max-w-[1040px] w-full pt-20 pb-10 px-[80px] flex-col justify-start items-center gap-10 inline-flex">
+        <div class="flex-1 w-full max-w-[1040px] px-[80px] pt-20 pb-10 flex-col justify-start items-center gap-10 inline-flex">
           <.page_header
             page_context={@page_context}
             ctx={@ctx}
@@ -797,7 +797,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
     <div class="flex pb-20 flex-col w-full items-center gap-15 flex-1 overflow-auto">
       <div class="flex flex-col items-center w-full">
         <.scored_page_banner />
-        <div class="flex-1 max-w-[1040px] w-full pt-20 pb-10 px-[80px] flex-col justify-start items-stretch gap-10 inline-flex">
+        <div class="flex-1 w-full max-w-[1040px] px-[80px] pt-20 pb-10 flex-col justify-start items-stretch gap-10 inline-flex">
           <.page_header
             page_context={@page_context}
             ctx={@ctx}
@@ -855,7 +855,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
     <.password_attempt_modal />
 
     <div class="flex pb-20 flex-col w-full items-center gap-15 flex-1 overflow-auto">
-      <div class="flex-1 max-w-[720px] w-full pt-20 pb-10 mx-6 flex-col justify-start items-center inline-flex">
+      <div class="flex-1 w-full max-w-[1040px] px-[80px] pt-20 pb-10 flex-col justify-start items-center inline-flex">
         <.page_header
           page_context={@page_context}
           ctx={@ctx}
@@ -1081,7 +1081,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
           Scored Activity
         </div>
       </div>
-      <div class="max-w-[720px] w-full mx-auto opacity-90 dark:text-white text-sm font-normal leading-6">
+      <div class="max-w-[880px] w-full mx-auto opacity-90 dark:text-white text-sm font-normal leading-6">
         You can start or stop at any time, and your progress will be saved. When you submit your answers using the Submit button, it will count as an attempt. So make sure you have answered all the questions before submitting.
       </div>
     </div>

--- a/lib/oli_web/live/delivery/student/review_live.ex
+++ b/lib/oli_web/live/delivery/student/review_live.ex
@@ -99,7 +99,7 @@ defmodule OliWeb.Delivery.Student.ReviewLive do
             objectives={@objectives}
             container_label={Utils.get_container_label(@current_page["id"], @section)}
           />
-          <div id="eventIntercept" phx-update="ignore" class="content" role="page_content">
+          <div id="eventIntercept" phx-update="ignore" class="content w-full" role="page_content">
             <%= raw(@html) %>
           </div>
           <.link

--- a/lib/oli_web/live/delivery/student/review_live.ex
+++ b/lib/oli_web/live/delivery/student/review_live.ex
@@ -91,7 +91,7 @@ defmodule OliWeb.Delivery.Student.ReviewLive do
             </div>
           </div>
         </div>
-        <div class="w-[720px] pt-20 pb-10 flex-col justify-start items-center gap-10 inline-flex">
+        <div class="w-[880px] pt-20 pb-10 flex-col justify-start items-center gap-10 inline-flex">
           <.page_header
             page_context={@page_context}
             ctx={@ctx}

--- a/lib/oli_web/live/delivery/student/review_live.ex
+++ b/lib/oli_web/live/delivery/student/review_live.ex
@@ -91,7 +91,7 @@ defmodule OliWeb.Delivery.Student.ReviewLive do
             </div>
           </div>
         </div>
-        <div class="w-[880px] pt-20 pb-10 flex-col justify-start items-center gap-10 inline-flex">
+        <div class="w-[720px] pt-20 pb-10 flex-col justify-start items-center gap-10 inline-flex">
           <.page_header
             page_context={@page_context}
             ctx={@ctx}

--- a/lib/oli_web/live/delivery/student/review_live.ex
+++ b/lib/oli_web/live/delivery/student/review_live.ex
@@ -91,7 +91,7 @@ defmodule OliWeb.Delivery.Student.ReviewLive do
             </div>
           </div>
         </div>
-        <div class="w-[720px] pt-20 pb-10 flex-col justify-start items-center gap-10 inline-flex">
+        <div class="w-full max-w-[1040px] px-[80px] pt-20 pb-10 flex-col justify-start items-center gap-10 inline-flex">
           <.page_header
             page_context={@page_context}
             ctx={@ctx}


### PR DESCRIPTION
Graded page layout was effectively centering page items within a container that took on the width of the widest content within it. This occasionally resulted in very narrow layouts: although items do stretch to fill the container width, the container winds up only as wide as the widest content. If the only item is narrow, so is the content area width. This is odd but tolerable for some questions, but intolerable for iframe-embedded activities such as LogicLab or StatTutor which expect to be stretched to substantial width but wind up only 300 px wide. There are cases where a graded page consists only of such activities, so they become unusable.

This PR adjusts layout parameters to ensure activities stretch to fill the full content area.

In addition, the maximum content area width on graded pages was smaller (720 px) than the width on practice pages (880 px). This PR also enlarges the maximum width of content on graded pages to be the same as on practice pages, standardizing on 880 px content width plus 80 px of padding on each side (in some places achieved via `max-w-[1040px] px-[80px]`). Used for consistency on all variants of graded page including the pre-attempt prologue and review mode page, even though the non-activity versions do not require this width.  

OLD: 

<img width="633" alt="Screenshot 2024-05-31 at 12 59 43 PM" src="https://github.com/Simon-Initiative/oli-torus/assets/7094628/7de09069-581b-466e-9b30-84d89654c622">

NEW:

![Screenshot 2024-06-11 at 2 58 24 PM](https://github.com/Simon-Initiative/oli-torus/assets/7094628/4e28e31d-5470-41fd-8cee-2684f1a2700d)

