### PR TITLE
[BUG FIX] [MER-3173] hide hint icon on graded page for multi-input/response-multi/vlab

### DIFF
--- a/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
@@ -140,7 +140,7 @@ export const MultiInputComponent: React.FC = () => {
               }
             : { id: input.id, inputType: input.inputType, size: input.size },
         value: (uiState.partState[input.partId]?.studentInput || [''])[0],
-        hasHints: uiState.partState[input.partId].hasMoreHints,
+        hasHints: !context.graded && uiState.partState[input.partId].hasMoreHints,
       },
     ]),
   );

--- a/assets/src/components/activities/response_multi/ResponseMultiInputDelivery.tsx
+++ b/assets/src/components/activities/response_multi/ResponseMultiInputDelivery.tsx
@@ -154,7 +154,7 @@ export const ResponseMultiInputComponent: React.FC = () => {
           input.id,
           (uiState.partState[input.partId]?.studentInput as string[]) || [''],
         ),
-        hasHints: uiState.partState[input.partId].hasMoreHints,
+        hasHints: !context.graded && uiState.partState[input.partId].hasMoreHints,
       },
     ]),
   );

--- a/assets/src/components/activities/vlab/VlabDelivery.tsx
+++ b/assets/src/components/activities/vlab/VlabDelivery.tsx
@@ -168,7 +168,7 @@ export const VlabComponent: React.FC = () => {
               }
             : { id: input.id, inputType: input.inputType },
         value: (uiState.partState[input.partId]?.studentInput || [''])[0],
-        hasHints: uiState.partState[input.partId].hasMoreHints,
+        hasHints: !context.graded && uiState.partState[input.partId].hasMoreHints,
       },
     ]),
   );


### PR DESCRIPTION
Request hint lightbulb icon was being shown on graded pages for multi-input, response multi, and vlab questions, though hints do not show on clicking.  This hides it on graded pages for those activity types. 