### PR TITLE
[BUG FIX] [MER-2932] Filter insights by product course section - part 2

### DIFF
--- a/lib/oli/analytics/by_activity.ex
+++ b/lib/oli/analytics/by_activity.ex
@@ -18,8 +18,9 @@ defmodule Oli.Analytics.ByActivity do
   defp get_base_query(project_slug, filtered_sections) do
     subquery =
       if filtered_sections != [] do
-        DeliveryResolver.revisions_by_section_ids(
+        DeliveryResolver.project_revisions_by_section_ids(
           filtered_sections,
+          project_slug,
           ResourceType.id_for_activity()
         )
       else

--- a/lib/oli/analytics/by_objective.ex
+++ b/lib/oli/analytics/by_objective.ex
@@ -20,8 +20,9 @@ defmodule Oli.Analytics.ByObjective do
   defp get_base_query(project_slug, activity_objectives, filtered_sections) do
     subquery =
       if filtered_sections != [] do
-        DeliveryResolver.revisions_by_section_ids(
+        DeliveryResolver.project_revisions_by_section_ids(
           filtered_sections,
+          project_slug,
           ResourceType.id_for_objective()
         )
       else

--- a/lib/oli/analytics/by_objective.ex
+++ b/lib/oli/analytics/by_objective.ex
@@ -42,7 +42,7 @@ defmodule Oli.Analytics.ByObjective do
         slice: objective,
         eventually_correct: analytics.eventually_correct,
         first_try_correct: analytics.first_try_correct,
-        number_of_attempts: pairing.number_of_attempts,
+        number_of_attempts: analytics.number_of_attempts,
         relative_difficulty: analytics.relative_difficulty
       },
       preload: [:resource_type]
@@ -56,8 +56,7 @@ defmodule Oli.Analytics.ByObjective do
       on: snapshot.project_id == project.id,
       group_by: [snapshot.objective_id],
       select: %{
-        objective_id: snapshot.objective_id,
-        number_of_attempts: count(snapshot.id)
+        objective_id: snapshot.objective_id
       }
     )
   end

--- a/lib/oli/analytics/by_page.ex
+++ b/lib/oli/analytics/by_page.ex
@@ -22,8 +22,9 @@ defmodule Oli.Analytics.ByPage do
   defp get_base_query(project_slug, activity_pages, filtered_sections) do
     subquery =
       if filtered_sections != [] do
-        DeliveryResolver.revisions_by_section_ids(
+        DeliveryResolver.project_revisions_by_section_ids(
           filtered_sections,
+          project_slug,
           ResourceType.id_for_page()
         )
       else
@@ -35,8 +36,9 @@ defmodule Oli.Analytics.ByPage do
 
     subquery_activity =
       if filtered_sections != [] do
-        DeliveryResolver.revisions_by_section_ids(
+        DeliveryResolver.project_revisions_by_section_ids(
           filtered_sections,
+          project_slug,
           ResourceType.id_for_activity()
         )
       else

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -823,6 +823,23 @@ defmodule Oli.Delivery.Sections do
   end
 
   @doc """
+  Gets all sections that have any resource that belongs to a given project
+  (The section could have been created using the given project as a base project,
+  or have been created from another project and then adding resources of the given one by remixing the course)
+  """
+  def get_sections_containing_resources_of_given_project(project_id) do
+    from(
+      s in Section,
+      join: spp in SectionsProjectsPublications,
+      on: s.id == spp.section_id,
+      where: spp.project_id == ^project_id and s.status == :active,
+      distinct: [s],
+      select: s
+    )
+    |> Repo.all()
+  end
+
+  @doc """
   Gets all sections that use a particular project when their 'end_date' attribute is not nil and is later than the current date.
 
   ## Examples

--- a/lib/oli/publishing.ex
+++ b/lib/oli/publishing.ex
@@ -126,7 +126,7 @@ defmodule Oli.Publishing do
 
   def query_unpublished_revisions_by_type_and_section(project_slug, type, list_section_ids) do
     publication_ids =
-      project_working_publication_by_setion_list(project_slug, list_section_ids)
+      project_working_publication_by_section_list(project_slug, list_section_ids)
 
     resource_type_id = ResourceType.get_id_by_type(type)
 
@@ -523,7 +523,7 @@ defmodule Oli.Publishing do
     )
   end
 
-  def project_working_publication_by_setion_list(project_slug, list_section_ids) do
+  def project_working_publication_by_section_list(project_slug, list_section_ids) do
     Repo.all(
       from pub in Publication,
         join: proj in Project,

--- a/lib/oli/publishing/delivery_resolver.ex
+++ b/lib/oli/publishing/delivery_resolver.ex
@@ -263,7 +263,7 @@ defmodule Oli.Publishing.DeliveryResolver do
     |> emit([:oli, :resolvers, :delivery], :duration)
   end
 
-  def revisions_by_section_ids(section_ids, resource_type_id) do
+  def project_revisions_by_section_ids(section_ids, project_slug, resource_type_id) do
     from(sr in SectionResource,
       join: s in Section,
       on: s.id == sr.section_id,
@@ -271,6 +271,9 @@ defmodule Oli.Publishing.DeliveryResolver do
       join: spp in SectionsProjectsPublications,
       on: s.id == spp.section_id,
       where: sr.project_id == spp.project_id,
+      join: p in Project,
+      on: p.id == spp.project_id,
+      where: p.slug == ^project_slug,
       join: pr in PublishedResource,
       on: pr.publication_id == spp.publication_id,
       where: pr.resource_id == sr.resource_id,

--- a/lib/oli/publishing/delivery_resolver.ex
+++ b/lib/oli/publishing/delivery_resolver.ex
@@ -263,6 +263,11 @@ defmodule Oli.Publishing.DeliveryResolver do
     |> emit([:oli, :resolvers, :delivery], :duration)
   end
 
+  @doc """
+  Returns the revisions of a given list of section ids that are of the given resource type
+  and belong to the given project
+  """
+  @spec project_revisions_by_section_ids([integer()], String.t(), integer()) :: [Revision.t()]
   def project_revisions_by_section_ids(section_ids, project_slug, resource_type_id) do
     from(sr in SectionResource,
       join: s in Section,

--- a/lib/oli_web/controllers/project_controller.ex
+++ b/lib/oli_web/controllers/project_controller.ex
@@ -3,7 +3,6 @@ defmodule OliWeb.ProjectController do
 
   alias Oli.Authoring.Course
   alias Oli.Qa
-  alias OliWeb.Common.Breadcrumb
   alias Oli.Authoring.Clone
 
   def unpublished(pub), do: pub.published == nil
@@ -18,13 +17,6 @@ defmodule OliWeb.ProjectController do
 
     conn
     |> redirect(to: Routes.project_path(conn, :publish, project))
-  end
-
-  def insights(conn, _project_params) do
-    render(conn, "insights.html",
-      breadcrumbs: [Breadcrumb.new(%{full_title: "Insights"})],
-      active: :insights
-    )
   end
 
   def create(conn, %{"project" => %{"title" => title} = _project_params}) do

--- a/lib/oli_web/live/common/multi_select_options.ex
+++ b/lib/oli_web/live/common/multi_select_options.ex
@@ -1,17 +1,16 @@
-defmodule OliWeb.Common.MultiSelectOptions do
+defmodule OliWeb.Common.MultiSelect do
   use Ecto.Schema
 
   embedded_schema do
-    embeds_many :options, OliWeb.Common.MultiSelectOptions.SelectOption
+    embeds_many :options, OliWeb.Common.MultiSelect.Option
   end
 
-  defmodule SelectOption do
+  defmodule Option do
     use Ecto.Schema
 
     embedded_schema do
       field :selected, :boolean, default: false
-      field :label, :string
-      field :is_product, :boolean
+      field :name, :string
     end
   end
 

--- a/lib/oli_web/live/insights/insights.ex
+++ b/lib/oli_web/live/insights/insights.ex
@@ -21,7 +21,7 @@ defmodule OliWeb.Insights do
     project = Course.get_project_by_slug(project_slug)
 
     {sections, products} =
-      Sections.get_sections_by_base_project(project)
+      Sections.get_sections_containing_resources_of_given_project(project.id)
       |> Enum.reduce({[], []}, fn section, {sections, products} ->
         if section.type == :blueprint do
           {sections, [%Option{id: section.id, name: section.title} | products]}

--- a/lib/oli_web/live/insights/insights.ex
+++ b/lib/oli_web/live/insights/insights.ex
@@ -1,7 +1,8 @@
 defmodule OliWeb.Insights do
+  use OliWeb, :live_view
+
   alias OliWeb.Common.MultiSelectOptions
   alias Oli.Delivery.Sections
-  use OliWeb, :live_view
   alias OliWeb.Common.MultiSelect
   alias OliWeb.Common.MultiSelectOptions.SelectOption
   alias Oli.{Accounts, Publishing}
@@ -470,7 +471,7 @@ defmodule OliWeb.Insights do
 
   def handle_info(:init_by_page, socket) do
     by_page_rows =
-      get_by_page_row(socket, :by_page)
+      get_rows_by(socket, :by_page)
 
     active_rows =
       apply_filter_sort(
@@ -486,7 +487,7 @@ defmodule OliWeb.Insights do
 
   def handle_info(:init_by_objective, socket) do
     by_objective_rows =
-      get_by_page_row(socket, :by_objective)
+      get_rows_by(socket, :by_objective)
       |> arrange_rows_into_objective_hierarchy()
 
     active_rows =
@@ -503,7 +504,7 @@ defmodule OliWeb.Insights do
 
   def handle_info(:init_by_activity, socket) do
     by_activity_rows =
-      get_by_page_row(socket, :by_activity)
+      get_rows_by(socket, :by_activity)
 
     active_rows =
       apply_filter_sort(
@@ -517,7 +518,7 @@ defmodule OliWeb.Insights do
     {:noreply, assign(socket, by_activity_rows: by_activity_rows, active_rows: active_rows)}
   end
 
-  defp get_by_page_row(socket, :by_activity) do
+  defp get_rows_by(socket, :by_activity) do
     if socket.assigns.is_product do
       section_by_product_ids =
         Oli.Publishing.DeliveryResolver.get_sections_for_products(socket.assigns.product_ids)
@@ -534,7 +535,7 @@ defmodule OliWeb.Insights do
     end
   end
 
-  defp get_by_page_row(socket, :by_objective) do
+  defp get_rows_by(socket, :by_objective) do
     if socket.assigns.is_product do
       section_by_product_ids =
         Oli.Publishing.DeliveryResolver.get_sections_for_products(socket.assigns.product_ids)
@@ -551,7 +552,7 @@ defmodule OliWeb.Insights do
     end
   end
 
-  defp get_by_page_row(socket, :by_page) do
+  defp get_rows_by(socket, :by_page) do
     if socket.assigns.is_product do
       section_by_product_ids =
         Oli.Publishing.DeliveryResolver.get_sections_for_products(socket.assigns.product_ids)
@@ -562,7 +563,7 @@ defmodule OliWeb.Insights do
       )
     else
       Oli.Analytics.ByPage.query_against_project_slug(
-        socket.assigns.project,
+        socket.assigns.project.slug,
         socket.assigns.section_ids
       )
     end

--- a/lib/oli_web/live/insights/insights.ex
+++ b/lib/oli_web/live/insights/insights.ex
@@ -131,6 +131,9 @@ defmodule OliWeb.Insights do
           class="btn btn-primary"
           phx-click="filter_by_activity"
         >
+          <%= if is_loading?(assigns) and @selected == :by_activity do %>
+            <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+          <% end %>
           By Activity
         </button>
       </li>
@@ -216,6 +219,11 @@ defmodule OliWeb.Insights do
               <% end %>
             </tbody>
           </table>
+        <% else %>
+          <div class="w-full h-40 flex items-center justify-center">
+            <span class="spinner-border spinner-border-sm w-16 h-16" role="status" aria-hidden="true">
+            </span>
+          </div>
         <% end %>
       </div>
     </div>

--- a/lib/oli_web/live/insights/insights.ex
+++ b/lib/oli_web/live/insights/insights.ex
@@ -7,12 +7,13 @@ defmodule OliWeb.Insights do
   alias Oli.{Accounts, Publishing}
   alias OliWeb.Insights.{TableHeader, TableRow}
   alias Oli.Authoring.Course
+  alias OliWeb.Common.Breadcrumb
   alias OliWeb.Components.Project.AsyncExporter
   alias Oli.Authoring.Broadcaster
   alias Oli.Authoring.Broadcaster.Subscriber
   alias OliWeb.Common.SessionContext
 
-  def mount(_params, %{"project_slug" => project_slug} = session, socket) do
+  def mount(%{"project_id" => project_slug}, session, socket) do
     ctx = SessionContext.init(socket, session)
 
     by_activity_rows =
@@ -48,6 +49,8 @@ defmodule OliWeb.Insights do
 
     {:ok,
      assign(socket,
+       breadcrumbs: [Breadcrumb.new(%{full_title: "Insights"})],
+       active: :insights,
        ctx: ctx,
        is_admin?: Accounts.is_system_admin?(ctx.author),
        project: project,
@@ -60,7 +63,6 @@ defmodule OliWeb.Insights do
        query: "",
        sort_by: "title",
        sort_order: :asc,
-       title: "Insights | " <> project.title,
        latest_publication: latest_publication,
        analytics_export_status: analytics_export_status,
        analytics_export_url: analytics_export_url,

--- a/lib/oli_web/live/insights/insights.ex
+++ b/lib/oli_web/live/insights/insights.ex
@@ -164,7 +164,7 @@ defmodule OliWeb.Insights do
       <li class="nav-item my-2 mr-2 ">
         <div class="flex gap-10">
           <.live_component
-            id="multi_sections"
+            id="sections"
             module={MultiSelectInput}
             options={@sections}
             disabled={@sections == []}
@@ -173,7 +173,7 @@ defmodule OliWeb.Insights do
             uuid={@form_uuid_for_section}
           />
           <.live_component
-            id="multi_products"
+            id="products"
             module={MultiSelectInput}
             options={@products}
             disabled={@products == []}

--- a/lib/oli_web/live/insights/insights.ex
+++ b/lib/oli_web/live/insights/insights.ex
@@ -156,12 +156,16 @@ defmodule OliWeb.Insights do
     </div>
     <ul class="nav nav-pills">
       <li class="nav-item my-2 mr-2">
-        <button {is_disabled(@selected, :by_activity)} class="btn btn-primary" phx-click="by-activity">
+        <button
+          {is_disabled(@selected, :by_activity)}
+          class="btn btn-primary"
+          phx-click="filter_by_activity"
+        >
           By Activity
         </button>
       </li>
       <li class="nav-item my-2 mr-2">
-        <button {is_disabled(@selected, :by_page)} class="btn btn-primary" phx-click="by-page">
+        <button {is_disabled(@selected, :by_page)} class="btn btn-primary" phx-click="filter_by_page">
           <%= if is_loading?(assigns) and @selected == :by_page do %>
             <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
           <% end %>
@@ -173,7 +177,7 @@ defmodule OliWeb.Insights do
         <button
           {is_disabled(@selected, :by_objective)}
           class="btn btn-primary"
-          phx-click="by-objective"
+          phx-click="filter_by_objective"
         >
           <%= if is_loading?(assigns) and @selected == :by_objective do %>
             <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
@@ -273,54 +277,13 @@ defmodule OliWeb.Insights do
     rows |> Enum.filter(&String.match?(&1.slice.title, ~r/#{String.trim(query)}/i))
   end
 
-  # data splits
-  def handle_event("by-activity", _event, socket) do
-    active_rows =
-      apply_filter_sort(
-        :by_activity,
-        socket.assigns.by_activity_rows,
-        socket.assigns.query,
-        socket.assigns.sort_by,
-        socket.assigns.sort_order
-      )
+  def handle_event("filter_" <> filter_criteria, _event, socket) do
+    selected = String.to_existing_atom(filter_criteria)
 
-    {:noreply, assign(socket, selected: :by_activity, active_rows: active_rows)}
-  end
+    # do the query and assign the results in an async way
+    filter_type(selected)
 
-  def handle_event("by-page", _event, socket) do
-    active_rows =
-      if is_nil(socket.assigns.by_page_rows) do
-        send(self(), :init_by_page)
-        nil
-      else
-        apply_filter_sort(
-          :by_page,
-          socket.assigns.by_page_rows,
-          socket.assigns.query,
-          socket.assigns.sort_by,
-          socket.assigns.sort_order
-        )
-      end
-
-    {:noreply, assign(socket, selected: :by_page, active_rows: active_rows)}
-  end
-
-  def handle_event("by-objective", _event, socket) do
-    active_rows =
-      if is_nil(socket.assigns.by_objective_rows) do
-        send(self(), :init_by_objective)
-        nil
-      else
-        apply_filter_sort(
-          :by_objective,
-          socket.assigns.by_objective_rows,
-          socket.assigns.query,
-          socket.assigns.sort_by,
-          socket.assigns.sort_order
-        )
-      end
-
-    {:noreply, assign(socket, selected: :by_objective, active_rows: active_rows)}
+    {:noreply, assign(socket, selected: selected, active_rows: nil)}
   end
 
   # search

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -470,11 +470,7 @@ defmodule OliWeb.Router do
     )
 
     # Insights
-    get("/:project_id/insights", ProjectController, :insights)
-    # Ideally, analytics should be live-routed to preserve forward/back button when toggling
-    # between analytics groupings and sorting. I could not get it to run through the project authorization
-    # plugs when live-routing, however.
-    # live "/:project_id/insights", Insights
+    live "/:project_id/insights", Insights
   end
 
   if Application.compile_env!(:oli, :env) == :dev or Application.compile_env!(:oli, :env) == :test do

--- a/lib/oli_web/templates/layout/_project_sidebar.html.eex
+++ b/lib/oli_web/templates/layout/_project_sidebar.html.eex
@@ -45,7 +45,7 @@
       <div aria-hidden="true" class="label mt-1">Improve</div>
     </button>
     <div class="dropdown-menu">
-      <li><a class="dropdown-item btn btn-lg" href="<%= Routes.project_path(@conn, :insights, @project) %>">Insights</a></li>
+      <a class="dropdown-item btn btn-lg" href="<%= Routes.live_path(OliWeb.Endpoint, OliWeb.Insights, @project.slug) %>">Insights</a>
     </div>
   </div>
 

--- a/lib/oli_web/templates/project/insights.html.eex
+++ b/lib/oli_web/templates/project/insights.html.eex
@@ -1,7 +1,0 @@
-<div class="insights container">
-  <div class="grid grid-cols-12 mt-4">
-    <div class="col-span-12">
-      <%= live_render @conn, OliWeb.Insights, session: %{ "project_slug" => @project.slug } %>
-    </div>
-  </div>
-</div>

--- a/test/oli_web/controllers/project_controller_test.exs
+++ b/test/oli_web/controllers/project_controller_test.exs
@@ -13,20 +13,6 @@ defmodule OliWeb.ProjectControllerTest do
   @valid_attrs %{title: "default title"}
   @invalid_attrs %{title: ""}
 
-  describe "authorization" do
-    test "all get routes redirect to workspace path when attempting to view a project that does not exist",
-         %{conn: conn} do
-      unauthorized_redirect(conn, :insights, "does not exist")
-    end
-  end
-
-  test "author can not access projects that do not belong to them", %{conn: conn, author: author} do
-    {:ok, author: _author2, project: project2} = author_project_fixture()
-    conn = Plug.Test.init_test_session(conn, current_author_id: author.id)
-
-    unauthorized_redirect(conn, :insights, project2.slug)
-  end
-
   describe "projects" do
     # this test demonstrates the valid case where an author has multiple user accounts associated
     # (consider an authoring account shared across lms or independent instructor accounts)
@@ -59,13 +45,6 @@ defmodule OliWeb.ProjectControllerTest do
       assert response =~ "Overview"
       assert response =~ project.title
       assert response =~ publisher.name
-    end
-  end
-
-  describe "insights" do
-    test "displays the page", %{conn: conn, project: project} do
-      conn = get(conn, Routes.project_path(conn, :insights, project.slug))
-      assert html_response(conn, 200) =~ "Insights"
     end
   end
 
@@ -201,10 +180,5 @@ defmodule OliWeb.ProjectControllerTest do
 
     {:ok, product_2} = Sections.create_section_resources(product_2, new_publication)
     Sections.rebuild_contained_pages(product_2)
-  end
-
-  defp unauthorized_redirect(conn, path, project) do
-    conn = get(conn, Routes.project_path(conn, path, project))
-    assert redirected_to(conn) == Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.ProjectsLive)
   end
 end

--- a/test/oli_web/live/insights/insights_test.exs
+++ b/test/oli_web/live/insights/insights_test.exs
@@ -1,0 +1,256 @@
+defmodule OliWeb.Insights.InsightsTest do
+  use OliWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+  import Oli.Factory
+
+  alias Oli.Delivery.Sections
+  alias Oli.Resources.ResourceType
+
+  defp insights_path(project_slug) do
+    ~p"/authoring/project/#{project_slug}/insights"
+  end
+
+  defp create_elixir_project(%{author: author}) do
+    project = insert(:project, authors: [author])
+
+    # revisions...
+
+    ## pages...
+    page_1_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.get_id_by_type("page"),
+        title: "Page 1",
+        duration_minutes: 10
+      )
+
+    page_2_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.get_id_by_type("page"),
+        title: "Page 2",
+        duration_minutes: 15
+      )
+
+    page_3_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.get_id_by_type("page"),
+        title: "Page 3",
+        graded: true,
+        purpose: :application
+      )
+
+    page_4_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.get_id_by_type("page"),
+        title: "Page 4",
+        graded: true
+      )
+
+    ## modules...
+    module_1_revision =
+      insert(:revision, %{
+        resource_type_id: ResourceType.get_id_by_type("container"),
+        children: [page_1_revision.resource_id, page_2_revision.resource_id],
+        title: "How to use this course"
+      })
+
+    module_2_revision =
+      insert(:revision, %{
+        resource_type_id: ResourceType.get_id_by_type("container"),
+        children: [page_3_revision.resource_id],
+        title: "Configure your setup"
+      })
+
+    ## units...
+    unit_1_revision =
+      insert(:revision, %{
+        resource_type_id: ResourceType.get_id_by_type("container"),
+        children: [
+          module_1_revision.resource_id,
+          module_2_revision.resource_id
+        ],
+        title: "Introduction"
+      })
+
+    ## root container...
+    container_revision =
+      insert(:revision, %{
+        resource_type_id: ResourceType.get_id_by_type("container"),
+        intro_content: %{
+          "children" => [
+            %{
+              "children" => [%{"text" => "Welcome to the best course ever!"}],
+              "id" => "3477687079",
+              "type" => "p"
+            }
+          ],
+          "type" => "p"
+        },
+        children: [
+          unit_1_revision.resource_id,
+          page_4_revision.resource_id
+        ],
+        title: "Root Container"
+      })
+
+    all_revisions =
+      [
+        page_1_revision,
+        page_2_revision,
+        page_3_revision,
+        page_4_revision,
+        module_1_revision,
+        module_2_revision,
+        unit_1_revision,
+        container_revision
+      ]
+
+    # asociate resources to project
+    Enum.each(all_revisions, fn revision ->
+      insert(:project_resource, %{
+        project_id: project.id,
+        resource_id: revision.resource_id
+      })
+    end)
+
+    # publish project
+    publication =
+      insert(:publication, %{
+        project: project,
+        root_resource_id: container_revision.resource_id,
+        published: nil
+      })
+
+    # publish resources
+    Enum.each(all_revisions, fn revision ->
+      insert(:published_resource, %{
+        publication: publication,
+        resource: revision.resource,
+        revision: revision,
+        author: author
+      })
+    end)
+
+    # create sections...
+    section_1 =
+      insert(:section,
+        base_project: project,
+        title: "The best course ever!",
+        start_date: ~U[2023-10-30 20:00:00Z],
+        analytics_version: :v2,
+        type: :enrollable
+      )
+
+    section_2 =
+      insert(:section,
+        base_project: project,
+        title: "Another best course ever!",
+        start_date: ~U[2023-10-30 20:00:00Z],
+        analytics_version: :v2,
+        type: :enrollable
+      )
+
+    # create a product...
+    product =
+      insert(:section,
+        base_project: project,
+        title: "The best product ever!",
+        start_date: ~U[2023-10-30 20:00:00Z],
+        analytics_version: :v2
+      )
+
+    # build section resources...
+    Enum.each([section_1, section_2, product], fn section ->
+      {:ok, section} = Sections.create_section_resources(section, publication)
+      {:ok, _} = Sections.rebuild_contained_pages(section)
+      {:ok, _} = Sections.rebuild_contained_objectives(section)
+    end)
+
+    %{
+      author: author,
+      section_1: section_1,
+      project: project,
+      publication: publication,
+      page_1: page_1_revision,
+      page_2: page_2_revision,
+      page_3: page_3_revision,
+      page_4: page_4_revision,
+      module_1: module_1_revision,
+      module_2: module_2_revision,
+      unit_1: unit_1_revision,
+      container_revision: container_revision
+    }
+  end
+
+  describe "author cannot access when is not logged in" do
+    test "redirects to new session", %{conn: conn} do
+      assert {:error,
+              {:redirect,
+               %{
+                 to:
+                   "/authoring/session/new?request_path=%2Fauthoring%2Fproject%2Ftestproject%2Finsights"
+               }}} =
+               live(conn, insights_path("testproject"))
+    end
+  end
+
+  describe "author can not access projects that do not belong to him" do
+    setup [:author_conn]
+
+    test "and gets redirected to the projects path", %{conn: conn} do
+      another_author = insert(:author)
+      another_project = insert(:project, authors: [another_author])
+
+      assert {:error,
+              {:redirect,
+               %{
+                 to: "/authoring/projects",
+                 flash: %{"info" => "You don't have access to that project"}
+               }}} =
+               live(conn, insights_path(another_project.slug))
+    end
+  end
+
+  describe "project insights as author" do
+    setup [:author_conn, :create_elixir_project]
+
+    test "loads correctly", %{conn: conn, project: project} do
+      {:ok, view, _html} = live(conn, insights_path(project.slug))
+
+      assert has_element?(view, "h5", "Viewing analytics by activity")
+    end
+
+    test "lists all sections and products in corresponding multiselect", %{
+      conn: conn,
+      project: project
+    } do
+      {:ok, view, _html} = live(conn, insights_path(project.slug))
+
+      # sections are listed in the sections multiselect
+      assert view
+             |> element("#sections-options-container")
+             |> render() =~ "The best course ever!"
+
+      assert view
+             |> element("#sections-options-container")
+             |> render() =~ "Another best course ever!"
+
+      refute view
+             |> element("#sections-options-container")
+             |> render() =~ "The best product ever!"
+
+      # products are listed in the product multiselect
+      refute view
+             |> element("#products-options-container")
+             |> render() =~ "The best course ever!"
+
+      refute view
+             |> element("#products-options-container")
+             |> render() =~ "Another best course ever!"
+
+      assert view
+             |> element("#products-options-container")
+             |> render() =~ "The best product ever!"
+    end
+  end
+end


### PR DESCRIPTION
This PR finishes the work done in a series of PRs ([PR1](https://github.com/Simon-Initiative/oli-torus/pull/4643), [PR2](https://github.com/Simon-Initiative/oli-torus/pull/4725), [PR3](https://github.com/Simon-Initiative/oli-torus/pull/4777), [PR4](https://github.com/Simon-Initiative/oli-torus/pull/4845)), by fixing the latest bugs reported in [the ticket](https://eliterate.atlassian.net/browse/MER-2932?focusedCommentId=23199)

### Before

https://github.com/Simon-Initiative/oli-torus/assets/74839302/1a92b036-0c15-49eb-901a-04897ed7383f

### After

https://github.com/Simon-Initiative/oli-torus/assets/74839302/eb779bc2-ab97-49ee-bf43-c0f0a09d5174


## Other Improvements
- The multiselect `live_component` was refactored to handle its own state (as suggested in the [docs](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveComponent.html)) which ended up cleaning the code of the Insights  liveview (that had many handle_info callbacks and private functions to manage the multiselect interaction).
- The muliselect now shows the selected options, and allows the user to remove any selected option by pressing the "X".
- The router was improved to avoid passing through the page_controller and then rendering the liveview. Now we directly mount the Insights liveview. (some comments were left a long time ago about this in the router).


## Other bugs found and fixed
### Multiselect filter persistence
When some sections were filtered in the multiselect and then the resource criteria (by activity, by page or by objectives) was changed, those filtered sections weren't correctly being used to filter the results (they were ignored)



## Other notes
With the current implementation, only resources of the current project will be shown while combining the filter options in the Insights page.
For example, imagine an instructor creates an "Elixir 2.0" course from the corresponding Elixir project and then remixes its content to add a page, let's say, the "Learn how to sum" page that belongs to the Maths project. In this case, when the author visits the Elixir project Insights, all the metrics corresponding to the attempts made in the "Learn how to sum" page from that "Elixir 2.0" course will NOT be shown there, since this insights page is supposed to show metrics about the Elixir *project*.
On the other hand, if the author visits the Maths project Insights, then metrics about how that "Learn how to sum" page will be taken into account since that page belongs to the current project (although it was added to an Elixir course)


https://github.com/Simon-Initiative/oli-torus/assets/74839302/975c3f9e-b309-4ca4-a46f-a7eb3dc71ac0



