### PR TITLE
[FEATURE] [MER-3187] Instructors custom filters learning objectives report

### DIFF
--- a/lib/oli_web/components/common.ex
+++ b/lib/oli_web/components/common.ex
@@ -281,6 +281,7 @@ defmodule OliWeb.Components.Common do
 
   attr(:errors, :list, default: [])
   attr(:class, :string, default: nil)
+  attr(:class_label, :string, default: "")
   attr(:checked, :boolean, doc: "the checked flag for checkbox inputs")
   attr(:ctx, :map, default: nil)
   attr(:prompt, :string, default: nil, doc: "the prompt for select inputs")
@@ -312,7 +313,7 @@ defmodule OliWeb.Components.Common do
 
     ~H"""
     <div class="contents" phx-feedback-for={@name}>
-      <label class="flex gap-2 items-center">
+      <label class={"flex gap-2 items-center #{@class_label}"}>
         <input type="hidden" name={@name} value="false" />
         <input
           type="checkbox"

--- a/test/oli_web/live/delivery/instructor_dashboard/insights/learning_objectives_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/insights/learning_objectives_tab_test.exs
@@ -302,6 +302,39 @@ defmodule OliWeb.Delivery.InstructorDashboard.LearningObjectivesTabTest do
       # Select is disabled
       assert has_element?(view, ".torus-select[disabled]")
     end
+
+    test "filter by proficiency works correctly", %{
+      conn: conn,
+      instructor: instructor,
+      section: section,
+      revisions: revisions
+    } do
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+
+      {:ok, view, _html} = live(conn, live_view_learning_objectives_route(section.slug))
+
+      ## Checks that all objectives are displayed
+      assert has_element?(view, "span", "#{revisions.obj_revision_a.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_b.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_c.title}")
+
+      ## Set proficiency filter to Low
+      params = %{
+        selected_proficiency_ids: Jason.encode!([1])
+      }
+
+      {:ok, view, _html} = live(conn, live_view_learning_objectives_route(section.slug, params))
+      ## Checks that there are no objectives displayed since none of them have proficiency Low
+      assert has_element?(view, "h6", "There are no objectives to show")
+
+      ## Click on Clear All Filters button
+      element(view, "button[phx-click=\"clear_all_filters\"]") |> render_click()
+
+      ## Checks that all objectives are displayed again
+      assert has_element?(view, "span", "#{revisions.obj_revision_a.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_b.title}")
+      assert has_element?(view, "span", "#{revisions.obj_revision_c.title}")
+    end
   end
 
   describe "page size change" do


### PR DESCRIPTION
[MER-3187](https://eliterate.atlassian.net/browse/MER-3187)

This PR adds a multi select input filter to the `Learning Objectives` view within the `Instructor Dashboard`. 

It can be selected by one or more proficiency types (Low, Medium and High) and the data in the table showing the learning objectives will be filtered.

In addition, a button is added to clear all applied filters in this view.

- Light Mode

https://github.com/Simon-Initiative/oli-torus/assets/16328384/84ea65eb-42bc-4891-9692-bac172555d12

- Dark Mode

https://github.com/Simon-Initiative/oli-torus/assets/16328384/79962236-3a52-4b02-8427-48a3902f4e32


[MER-3187]: https://eliterate.atlassian.net/browse/MER-3187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ