### PR TITLE
[ENHANCEMENT] [MER-3368] make score authoring handle implicit custom scoring on migrated questions

### DIFF
--- a/assets/src/components/activities/common/authoring/actions/multipleChoiceActions.ts
+++ b/assets/src/components/activities/common/authoring/actions/multipleChoiceActions.ts
@@ -16,7 +16,6 @@ import {
   getResponseId,
 } from 'data/activities/model/responses';
 import { matchRule } from 'data/activities/model/rules';
-import { getPartById } from 'data/activities/model/utils';
 import { clone } from 'utils/common';
 import { Operations } from 'utils/pathOperations';
 

--- a/assets/src/components/activities/common/authoring/actions/multipleChoiceActions.ts
+++ b/assets/src/components/activities/common/authoring/actions/multipleChoiceActions.ts
@@ -9,7 +9,12 @@ import {
   makeUndoable,
 } from 'components/activities/types';
 import { Choices } from 'data/activities/model/choices';
-import { getCorrectResponse, getResponseBy, getResponseId } from 'data/activities/model/responses';
+import {
+  getCorrectResponse,
+  getMaxPoints,
+  getResponseBy,
+  getResponseId,
+} from 'data/activities/model/responses';
 import { matchRule } from 'data/activities/model/rules';
 import { getPartById } from 'data/activities/model/utils';
 import { clone } from 'utils/common';
@@ -41,7 +46,8 @@ export const MCActions = {
   toggleChoiceCorrectness(id: string, partId: string) {
     return (model: HasParts, _post: PostUndoable) => {
       const part = getPartById(model, partId);
-      const correctScore = part.outOf || 1;
+      // migrated qs may have custom score but no outOf attribute
+      const correctScore = part.outOf ?? getMaxPoints(model, partId);
       const correctResponse = getCorrectResponse(model, partId);
       correctResponse.rule = matchRule(id);
       correctResponse.score = correctScore;

--- a/assets/src/components/activities/common/authoring/actions/multipleChoiceActions.ts
+++ b/assets/src/components/activities/common/authoring/actions/multipleChoiceActions.ts
@@ -45,8 +45,6 @@ export const MCActions = {
 
   toggleChoiceCorrectness(id: string, partId: string) {
     return (model: HasParts, _post: PostUndoable) => {
-      const part = getPartById(model, partId);
-      // migrated qs may have custom score but no outOf attribute
       const correctScore = getOutOfPoints(model, partId);
       const correctResponse = getCorrectResponse(model, partId);
       correctResponse.rule = matchRule(id);

--- a/assets/src/components/activities/common/authoring/actions/multipleChoiceActions.ts
+++ b/assets/src/components/activities/common/authoring/actions/multipleChoiceActions.ts
@@ -11,7 +11,7 @@ import {
 import { Choices } from 'data/activities/model/choices';
 import {
   getCorrectResponse,
-  getMaxPoints,
+  getOutOfPoints,
   getResponseBy,
   getResponseId,
 } from 'data/activities/model/responses';
@@ -47,7 +47,7 @@ export const MCActions = {
     return (model: HasParts, _post: PostUndoable) => {
       const part = getPartById(model, partId);
       // migrated qs may have custom score but no outOf attribute
-      const correctScore = part.outOf ?? getMaxPoints(model, partId);
+      const correctScore = getOutOfPoints(model, partId);
       const correctResponse = getCorrectResponse(model, partId);
       correctResponse.rule = matchRule(id);
       correctResponse.score = correctScore;

--- a/assets/src/components/activities/common/authoring/actions/scoringActions.ts
+++ b/assets/src/components/activities/common/authoring/actions/scoringActions.ts
@@ -3,7 +3,6 @@ import {
   getCorrectResponse,
   getIncorrectResponse,
   getMaxPoints,
-  getMaxScoreResponse,
 } from 'data/activities/model/responses';
 
 // Migrated qs may have non-default point values but no customScoring attribute. To allow for this,

--- a/assets/src/components/activities/common/authoring/actions/scoringActions.ts
+++ b/assets/src/components/activities/common/authoring/actions/scoringActions.ts
@@ -3,6 +3,7 @@ import {
   getCorrectResponse,
   getIncorrectResponse,
   getMaxPoints,
+  getOutOfPoints,
 } from 'data/activities/model/responses';
 
 // Migrated qs may have non-default point values but no customScoring attribute. To allow for this,
@@ -27,8 +28,7 @@ export const ScoringActions = {
         // When going from custom to default, we need to reset the scores for each part to 1 or 0
         model.scoringStrategy = ScoringStrategy.average;
         model.authoring?.parts?.forEach((part: Part) => {
-          // outOf attribute may not exist on migrated qs, use max score instead
-          const oldCorrectScore = part.outOf ?? getMaxPoints(model, part.id);
+          const oldCorrectScore = getOutOfPoints(model, part.id);
           part.outOf = 1;
           part.incorrectScore = 0;
           part.responses?.forEach((response) => {

--- a/assets/src/components/activities/common/authoring/actions/scoringActions.ts
+++ b/assets/src/components/activities/common/authoring/actions/scoringActions.ts
@@ -1,13 +1,26 @@
-import { ActivityLevelScoring, Part, ScoringStrategy } from 'components/activities/types';
-import { getCorrectResponse, getIncorrectResponse } from 'data/activities/model/responses';
+import { ActivityLevelScoring, Part, Response, ScoringStrategy } from 'components/activities/types';
+import {
+  getCorrectResponse,
+  getIncorrectResponse,
+  getMaxPoints,
+  getMaxScoreResponse,
+} from 'data/activities/model/responses';
+
+// Migrated qs may have non-default point values but no customScoring attribute. To allow for this,
+// this method should be used rather than checking attribute. Attribute will get set if toggled
+export const usesCustomScoring = (model: ActivityLevelScoring) =>
+  model.customScoring ||
+  model.authoring.parts.some((part: Part) => part.responses.some((r: Response) => r.score > 1));
 
 export const ScoringActions = {
   toggleActivityDefaultScoring() {
     // This toggles an activity-level default scoring flag, currently only used for multi input questions.
     return (model: ActivityLevelScoring) => {
-      model.customScoring = !model.customScoring;
+      // attribute may not exist on migrated qs; this will set it
+      model.customScoring = !usesCustomScoring(model);
 
       if (model.customScoring) {
+        // going from default to custom, so all responses should already be 1 or 0.
         model.authoring?.parts?.forEach((part: Part) => {
           part.outOf = 1;
         });
@@ -15,11 +28,12 @@ export const ScoringActions = {
         // When going from custom to default, we need to reset the scores for each part to 1 or 0
         model.scoringStrategy = ScoringStrategy.average;
         model.authoring?.parts?.forEach((part: Part) => {
-          const correctScore = part.outOf;
+          // outOf attribute may not exist on migrated qs, use max score instead
+          const oldCorrectScore = part.outOf ?? getMaxPoints(model, part.id);
           part.outOf = 1;
           part.incorrectScore = 0;
           part.responses?.forEach((response) => {
-            response.score = response.score === correctScore ? 1 : 0;
+            response.score = response.score === oldCorrectScore ? 1 : 0;
           });
         });
       }
@@ -56,6 +70,7 @@ export const ScoringActions = {
         console.warn('Could not set score for part', partId);
         return;
       }
+      const oldOutOf = part.outOf;
       part.outOf = correctScore;
       part.incorrectScore = incorrectScore;
 
@@ -63,24 +78,35 @@ export const ScoringActions = {
         part.scoringStrategy = scoringStrategy;
       }
 
-      // When we change the correct & incorrect scores, we also need to update the responses for the correct & incorrect answers
+      // if changing to default, reset the scores for each part to 1 or 0
+      if (part.outOf == null) {
+        model.authoring?.parts?.forEach((part: Part) => {
+          // outOf attribute may not exist on migrated qs, use max score instead
+          const oldCorrectScore = oldOutOf ?? getMaxPoints(model, part.id);
+          part.responses?.forEach((response) => {
+            response.score = response.score === oldCorrectScore ? 1 : 0;
+          });
+        });
+      } else {
+        // When we change the correct & incorrect scores, we also need to update the responses for the correct & incorrect answers
 
-      try {
-        const correctResponse = getCorrectResponse(model, partId);
-        if (correctResponse) {
-          correctResponse.score = correctScore ?? 1;
+        try {
+          const correctResponse = getCorrectResponse(model, partId);
+          if (correctResponse) {
+            correctResponse.score = correctScore ?? 1;
+          }
+        } catch (e) {
+          console.warn('Could not find correct response for part', partId);
         }
-      } catch (e) {
-        console.warn('Could not find correct response for part', partId);
-      }
 
-      try {
-        const incorrectResponse = getIncorrectResponse(model, partId);
-        if (incorrectResponse) {
-          incorrectResponse.score = incorrectScore ?? 0;
+        try {
+          const incorrectResponse = getIncorrectResponse(model, partId);
+          if (incorrectResponse) {
+            incorrectResponse.score = incorrectScore ?? 0;
+          }
+        } catch (e) {
+          console.warn('Could not find incorrect response for part', partId);
         }
-      } catch (e) {
-        console.warn('Could not find incorrect response for part', partId);
       }
     };
   },

--- a/assets/src/components/activities/common/authoring/actions/scoringActions.ts
+++ b/assets/src/components/activities/common/authoring/actions/scoringActions.ts
@@ -2,7 +2,6 @@ import { ActivityLevelScoring, Part, Response, ScoringStrategy } from 'component
 import {
   getCorrectResponse,
   getIncorrectResponse,
-  getMaxPoints,
   getOutOfPoints,
 } from 'data/activities/model/responses';
 
@@ -69,7 +68,8 @@ export const ScoringActions = {
         console.warn('Could not set score for part', partId);
         return;
       }
-      const oldOutOf = part.outOf;
+      // outOf attribute may not exist on migrated questions
+      const oldCorrectScore = getOutOfPoints(model, part.id);
       part.outOf = correctScore;
       part.incorrectScore = incorrectScore;
 
@@ -80,8 +80,6 @@ export const ScoringActions = {
       // if changing to default, reset the scores for each part to 1 or 0
       if (part.outOf == null) {
         model.authoring?.parts?.forEach((part: Part) => {
-          // outOf attribute may not exist on migrated qs, use max score instead
-          const oldCorrectScore = oldOutOf ?? getMaxPoints(model, part.id);
           part.responses?.forEach((response) => {
             response.score = response.score === oldCorrectScore ? 1 : 0;
           });

--- a/assets/src/components/activities/common/responses/ActivityScoring.tsx
+++ b/assets/src/components/activities/common/responses/ActivityScoring.tsx
@@ -44,7 +44,8 @@ export const ActivityScoring: React.FC<ActivityScoreProps> = ({ partId, promptFo
   };
 
   const onCorrectScoreChange = (score: number) => {
-    if (score >= 0) {
+    // disallow changing correct to zero, can cause problems finding correct answer on migrated qs
+    if (score > 0) {
       dispatch(ScoringActions.editPartScore(partId, score, incorrectPoints || null));
     }
   };

--- a/assets/src/components/activities/common/responses/ActivityScoring.tsx
+++ b/assets/src/components/activities/common/responses/ActivityScoring.tsx
@@ -4,7 +4,6 @@ import { HasParts } from 'components/activities/types';
 import { Card } from 'components/misc/Card';
 import {
   getIncorrectPoints,
-  getMaxPoints,
   getOutOfPoints,
   hasCustomScoring,
 } from 'data/activities/model/responses';
@@ -23,14 +22,12 @@ interface ActivityScoreProps {
 export const ActivityScoring: React.FC<ActivityScoreProps> = ({ partId, promptForDefault }) => {
   const { model, dispatch, editMode } = useAuthoringElementContext<HasParts>();
   const checkboxInputId = useMemo(() => guid(), []);
-  const outOf = getOutOfPoints(model, partId);
+  const outOfPoints = getOutOfPoints(model, partId);
   const incorrect = getIncorrectPoints(model, partId);
   const [useDefaultScoring, setDefaultScoring] = useState(
     !hasCustomScoring(model) && promptForDefault,
   );
   const incorrectPoints = incorrect || 0;
-  // migrated qs may have no outOf attribute but non-default points
-  const outOfPoints = outOf ?? getMaxPoints(model, partId);
 
   const onChangeDefault = (e: React.ChangeEvent<HTMLInputElement>) => {
     setDefaultScoring(e.target.checked);

--- a/assets/src/components/activities/multi_input/MultiInputScoringMethod.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputScoringMethod.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import { Card } from 'components/misc/Card';
 import guid from 'utils/guid';
 import { useAuthoringElementContext } from '../AuthoringElementProvider';
-import { ScoringActions } from '../common/authoring/actions/scoringActions';
+import { ScoringActions, usesCustomScoring } from '../common/authoring/actions/scoringActions';
 import { ScoringStrategy } from '../types';
 import { MultiInputSchema } from './schema';
 
@@ -11,7 +11,7 @@ interface MultiInputScoringMethodProps {}
 export const MultiInputScoringMethod: React.FC<MultiInputScoringMethodProps> = () => {
   const { model, dispatch, editMode } = useAuthoringElementContext<MultiInputSchema>();
   const checkboxInputId = useMemo(guid, []);
-  const defaultScoring = !model.customScoring;
+  const defaultScoring = !usesCustomScoring(model);
   const scoringStrategy = model.scoringStrategy || ScoringStrategy.total;
 
   const onChangeDefault = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/assets/src/components/activities/multi_input/sections/AnswerKeyTab.tsx
+++ b/assets/src/components/activities/multi_input/sections/AnswerKeyTab.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useAuthoringElementContext } from 'components/activities/AuthoringElementProvider';
 import { AuthoringButtonConnected } from 'components/activities/common/authoring/AuthoringButton';
 import { MCActions } from 'components/activities/common/authoring/actions/multipleChoiceActions';
+import { usesCustomScoring } from 'components/activities/common/authoring/actions/scoringActions';
 import { ChoicesDelivery } from 'components/activities/common/choices/delivery/ChoicesDelivery';
 import { ActivityScoring } from 'components/activities/common/responses/ActivityScoring';
 import { ResponseCard } from 'components/activities/common/responses/ResponseCard';
@@ -75,7 +76,7 @@ export const AnswerKeyTab: React.FC<Props> = (props) => {
         <SimpleFeedback partId={props.input.partId} />
 
         <MultiInputScoringMethod />
-        {model.customScoring && (
+        {usesCustomScoring(model) && (
           <ActivityScoring partId={props.input.partId} promptForDefault={false} />
         )}
 
@@ -105,7 +106,7 @@ export const AnswerKeyTab: React.FC<Props> = (props) => {
       />
       <SimpleFeedback partId={props.input.partId} />
       <MultiInputScoringMethod />
-      {model.customScoring && (
+      {usesCustomScoring(model) && (
         <ActivityScoring partId={props.input.partId} promptForDefault={false} />
       )}
       {getTargetedResponses(model, props.input.partId).map((response: Response) => (
@@ -127,7 +128,7 @@ export const AnswerKeyTab: React.FC<Props> = (props) => {
           updateScore={(_id, score) =>
             dispatch(ResponseActions.editResponseScore(response.id, score))
           }
-          customScoring={model.customScoring}
+          customScoring={usesCustomScoring(model)}
           removeResponse={(id) => dispatch(ResponseActions.removeResponse(id))}
           key={response.id}
         >

--- a/assets/src/components/activities/response_multi/ResponseMultiInputScoringMethod.tsx
+++ b/assets/src/components/activities/response_multi/ResponseMultiInputScoringMethod.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import { Card } from 'components/misc/Card';
 import guid from 'utils/guid';
 import { useAuthoringElementContext } from '../AuthoringElementProvider';
-import { ScoringActions } from '../common/authoring/actions/scoringActions';
+import { ScoringActions, usesCustomScoring } from '../common/authoring/actions/scoringActions';
 import { ScoringStrategy } from '../types';
 import { ResponseMultiInputSchema } from './schema';
 
@@ -13,7 +13,7 @@ export const ResponseMultiInputScoringMethod: React.FC<
 > = () => {
   const { model, dispatch, editMode } = useAuthoringElementContext<ResponseMultiInputSchema>();
   const checkboxInputId = useMemo(guid, []);
-  const defaultScoring = !model.customScoring;
+  const defaultScoring = !usesCustomScoring(model);
   const scoringStrategy = model.scoringStrategy || ScoringStrategy.total;
 
   const onChangeDefault = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/assets/src/components/activities/response_multi/sections/PartsTab.tsx
+++ b/assets/src/components/activities/response_multi/sections/PartsTab.tsx
@@ -3,6 +3,7 @@ import { Editor } from 'slate';
 import { ReactEditor } from 'slate-react';
 import { useAuthoringElementContext } from 'components/activities/AuthoringElementProvider';
 import { AuthoringButtonConnected } from 'components/activities/common/authoring/AuthoringButton';
+import { usesCustomScoring } from 'components/activities/common/authoring/actions/scoringActions';
 import { ActivityScoring } from 'components/activities/common/responses/ActivityScoring';
 import { ResponseActions } from 'components/activities/common/responses/responseActions';
 import { Dropdown, FillInTheBlank, MultiInput } from 'components/activities/multi_input/schema';
@@ -64,7 +65,7 @@ export const PartsTab: React.FC<Props> = (props) => {
         title={title}
         response={response}
         partId={part.id}
-        customScoring={model.customScoring}
+        customScoring={usesCustomScoring(model)}
         removeResponse={(id) => dispatch(ResponseActions.removeResponse(id))}
         updateScore={(_id, score) =>
           dispatch(ResponseActions.editResponseScore(response.id, score))
@@ -101,7 +102,7 @@ export const PartsTab: React.FC<Props> = (props) => {
           Add targeted feedback
         </AuthoringButtonConnected>
         <ResponseMultiInputScoringMethod />
-        {model.customScoring && <ActivityScoring partId={part.id} promptForDefault={false} />}
+        {usesCustomScoring(model) && <ActivityScoring partId={part.id} promptForDefault={false} />}
       </Card.Content>
     </Card.Card>
   );

--- a/assets/src/data/activities/model/responses.ts
+++ b/assets/src/data/activities/model/responses.ts
@@ -44,15 +44,18 @@ export const getResponseBy = (model: HasParts, predicate: (x: Response) => boole
   getByUnsafe(getResponses(model), predicate);
 
 export const hasCustomScoring = (model: HasParts, partId?: string): boolean => {
-  const outOf = getOutOfPoints(model, partId || model.authoring.parts[0].id);
+  const pId = partId || model.authoring.parts[0].id;
+  // new questions carry outOf attribute for custom scoring
+  const outOf = getPartById(model, pId)?.outOf;
   // migrated qs may carry non-default point values but no outOf attribute
-  const maxScore = getMaxPoints(model, partId || model.authoring.parts[0].id);
+  const maxScore = getMaxPoints(model, pId);
   return (outOf !== null && outOf !== undefined) || maxScore > 1;
 };
 
 export const getOutOfPoints = (model: HasParts, partId: string) => {
-  const part = getPartById(model, partId);
-  return part?.outOf;
+  const outOf = getPartById(model, partId)?.outOf;
+  // migrated qs may carry non-default point values but no outOf attribute
+  return outOf ?? getMaxPoints(model, partId);
 };
 
 export const getScoringStrategy = (model: HasParts, partId: string) => {

--- a/assets/src/data/activities/model/responses.ts
+++ b/assets/src/data/activities/model/responses.ts
@@ -45,7 +45,9 @@ export const getResponseBy = (model: HasParts, predicate: (x: Response) => boole
 
 export const hasCustomScoring = (model: HasParts, partId?: string): boolean => {
   const outOf = getOutOfPoints(model, partId || model.authoring.parts[0].id);
-  return outOf !== null && outOf !== undefined;
+  // migrated qs may carry non-default point values but no outOf attribute
+  const maxScore = getMaxPoints(model, partId || model.authoring.parts[0].id);
+  return (outOf !== null && outOf !== undefined) || maxScore > 1;
 };
 
 export const getOutOfPoints = (model: HasParts, partId: string) => {
@@ -87,6 +89,9 @@ export const getMaxScoreResponse = (model: HasParts, partId: string) => {
     prev && current.score > prev.score ? current : prev,
   );
 };
+
+export const getMaxPoints = (model: HasParts, partId: string) =>
+  getMaxScoreResponse(model, partId).score;
 
 export interface ResponseMapping {
   response: Response;


### PR DESCRIPTION
Migrated legacy questions may carry non-standard point values for correct responses and partial credit scores for incorrect responses. These get used by torus in scoring. However, since custom score editing was added to torus authoring, these migrated questions have problems because they do not include the flags being used by the newer torus authoring code to detect custom scoring:

- They display in authoring incorrectly as using default scoring when in fact they carry custom scores. So authors can't tell accurately what points are being assigned. This has been a problem for instructors in one class who add new questions to a quiz (picking up default 1 or 0 scoring) and have them mixed with migrated questions that have invisible non-default point values, so not all questions have equal point values as desired. 

- For multi-input questions, attempts to edit the scoring type, for example changing custom to default, can break the question model, leading to runtime error on question in authoring, making the question uneditable.  (Possibly an independent bug applying even to new torus-authored questions)

This PR changes torus score authoring to treat migrated questions with “implicit custom scoring” as having custom scoring. The idea is to package the test for custom scoring into subroutines, `hasCustomScoring` (for single-part questions) and `usesCustomScoring` (for multi-inputs), and use these everywhere in place of testing flags directly. Similarly,`getOutOfPoints` should be used to get the effective correct score value for both representations.

Also the handling of multi-input score type changes was corrected to reset all scores where needed. 

Note in the torus implementation, multi-input questions use a different representation of custom scoring (an activity-wide customScoring flag) than single-part questions do (a defined outOf value in the part), so both types of question should be tested. For test cases one may export and ingest the questions from the [FCDS course](https://proton.oli.cmu.edu/authoring/project/fcds__foundations_of_computati_pyoe8) and look at activity bank questions. Searching by item type can find multi-input questions. Some CATA questions reveal partial credit responses.

Note 2: the torus custom score authoring interface does not enforce consistency, in that it allows a user to assign a point value to a wrong answer that is greater than the designated correct answer point value. Such a situation may lead to unexpected scoring behavior. But this is an independent issue.