### PR TITLE
[FEATURE] [MER-3186] Instructors summary highlights filter learning objectives report

### DIFF
--- a/lib/oli_web/components/delivery/content/card_highlights.ex
+++ b/lib/oli_web/components/delivery/content/card_highlights.ex
@@ -6,7 +6,7 @@ defmodule OliWeb.Components.Delivery.CardHighlights do
   attr :is_selected, :boolean, default: false
   attr :value, :string, required: true
   attr :on_click, :map, required: true
-  attr :container_filter_by, :atom
+  attr :container_filter_by, :atom, default: nil
 
   def render(assigns) do
     ~H"""
@@ -28,8 +28,10 @@ defmodule OliWeb.Components.Delivery.CardHighlights do
               Units
             <% :modules -> %>
               Modules
-            <% _ -> %>
+            <% :students -> %>
               Students
+            <% _ -> %>
+              <%= @container_filter_by %>
           <% end %>
         </div>
       </div>

--- a/test/oli_web/live/delivery/instructor_dashboard/insights/learning_objectives_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/insights/learning_objectives_tab_test.exs
@@ -20,6 +20,18 @@ defmodule OliWeb.Delivery.InstructorDashboard.LearningObjectivesTabTest do
     )
   end
 
+  defp set_snapshot(section, resource, objective, user, result) do
+    insert(:snapshot, %{
+      section: section,
+      resource: resource,
+      user: user,
+      correct: result,
+      objective: objective,
+      attempt_number: 1,
+      part_attempt_number: 1
+    })
+  end
+
   describe "user" do
     test "can not access page when it is not logged in", %{conn: conn} do
       section = insert(:section)
@@ -334,6 +346,110 @@ defmodule OliWeb.Delivery.InstructorDashboard.LearningObjectivesTabTest do
       assert has_element?(view, "span", "#{revisions.obj_revision_a.title}")
       assert has_element?(view, "span", "#{revisions.obj_revision_b.title}")
       assert has_element?(view, "span", "#{revisions.obj_revision_c.title}")
+    end
+
+    test "cards to filter works correctly", %{
+      conn: conn,
+      instructor: instructor,
+      section: section,
+      resources: %{
+        page_resource_1: page_resource_1,
+        obj_resource_a: obj_resource_a,
+        obj_resource_b: obj_resource_b
+      },
+      revisions: %{
+        obj_revision_a: obj_revision_a,
+        obj_revision_b: obj_revision_b,
+        obj_revision_c: obj_revision_c
+      }
+    } do
+      student_1 = insert(:user)
+      Sections.enroll(student_1.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+
+      set_snapshot(section, page_resource_1, obj_resource_a, student_1, true)
+      set_snapshot(section, page_resource_1, obj_resource_a, student_1, false)
+      set_snapshot(section, page_resource_1, obj_resource_a, student_1, false)
+      set_snapshot(section, page_resource_1, obj_resource_a, student_1, false)
+
+      set_snapshot(section, page_resource_1, obj_resource_b, student_1, true)
+      set_snapshot(section, page_resource_1, obj_resource_b, student_1, false)
+      set_snapshot(section, page_resource_1, obj_resource_b, student_1, false)
+      set_snapshot(section, page_resource_1, obj_resource_b, student_1, false)
+
+      {:ok, view, _html} = live(conn, live_view_learning_objectives_route(section.slug))
+
+      assert has_element?(view, "span", "#{obj_revision_a.title}")
+      assert has_element?(view, "span", "#{obj_revision_b.title}")
+      assert has_element?(view, "span", "#{obj_revision_c.title}")
+
+      # ## Filtering by Low Proficiency Outcomes card
+      element(view, "div[phx-value-selected=\"low_proficiency_outcomes\"]") |> render_click()
+
+      assert has_element?(view, "span", "#{obj_revision_a.title}")
+      assert has_element?(view, "span", "#{obj_revision_b.title}")
+      refute has_element?(view, "span", "#{obj_revision_c.title}")
+
+      # ## Deactivating Low Proficiency Outcomes card
+      element(view, "div[phx-value-selected=\"low_proficiency_outcomes\"]") |> render_click()
+
+      assert has_element?(view, "span", "#{obj_revision_a.title}")
+      assert has_element?(view, "span", "#{obj_revision_b.title}")
+      assert has_element?(view, "span", "#{obj_revision_c.title}")
+
+      # ## Filtering by Low Proficiency Skills card
+      element(view, "div[phx-value-selected=\"low_proficiency_skills\"]") |> render_click()
+
+      assert has_element?(view, "h6", "There are no objectives to show")
+    end
+
+    test "cards to filter works correctly combined with input search", %{
+      conn: conn,
+      instructor: instructor,
+      section: section,
+      resources: %{
+        page_resource_1: page_resource_1,
+        obj_resource_a: obj_resource_a,
+        obj_resource_b: obj_resource_b
+      },
+      revisions: %{
+        obj_revision_a: obj_revision_a,
+        obj_revision_b: obj_revision_b,
+        obj_revision_c: obj_revision_c
+      }
+    } do
+      student_1 = insert(:user)
+      Sections.enroll(student_1.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+
+      set_snapshot(section, page_resource_1, obj_resource_a, student_1, true)
+      set_snapshot(section, page_resource_1, obj_resource_a, student_1, false)
+      set_snapshot(section, page_resource_1, obj_resource_a, student_1, false)
+      set_snapshot(section, page_resource_1, obj_resource_a, student_1, false)
+
+      set_snapshot(section, page_resource_1, obj_resource_b, student_1, true)
+      set_snapshot(section, page_resource_1, obj_resource_b, student_1, false)
+      set_snapshot(section, page_resource_1, obj_resource_b, student_1, false)
+      set_snapshot(section, page_resource_1, obj_resource_b, student_1, false)
+
+      {:ok, view, _html} = live(conn, live_view_learning_objectives_route(section.slug))
+
+      ## Filtering by Low Proficiency Outcomes card
+      element(view, "div[phx-value-selected=\"low_proficiency_outcomes\"]") |> render_click()
+
+      assert has_element?(view, "span", "#{obj_revision_a.title}")
+      assert has_element?(view, "span", "#{obj_revision_b.title}")
+      refute has_element?(view, "span", "#{obj_revision_c.title}")
+
+      ## Search for "Objetive A" string
+      view
+      |> element("form[phx-change=\"search_objective\"]")
+      |> render_change(%{objective_name: "Objective A"})
+
+      ## Checks that only Objective A is displayed
+      assert has_element?(view, "span", "#{obj_revision_a.title}")
+      refute has_element?(view, "span", "#{obj_revision_b.title}")
+      refute has_element?(view, "span", "#{obj_revision_c.title}")
     end
   end
 


### PR DESCRIPTION
[MER-3186](https://eliterate.atlassian.net/browse/MER-3186)

This PR adds cards in `Learning Objectives` tab in the instructor dashboard, which will allow to filter the content of the tables by different metrics.

Each of the cards corresponds to a different metric and they can be selected and deselected in order to filter the content of the table showing the data corresponding to each card.


https://github.com/Simon-Initiative/oli-torus/assets/16328384/70b2d37a-2418-43e4-a14a-e80c710b057d



[MER-3186]: https://eliterate.atlassian.net/browse/MER-3186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ