### PR TITLE
[ENHANCEMENT] [MER-3110] Download Segment and Experiment JSON files

### DIFF
--- a/lib/oli_web/live/experiments/experiments_live.ex
+++ b/lib/oli_web/live/experiments/experiments_live.ex
@@ -16,6 +16,7 @@ defmodule OliWeb.Experiments.ExperimentsView do
   alias Oli.Resources.Revision
   alias OliWeb.Common.Modal.DeleteModal
   alias OliWeb.Common.Modal.FormModal
+  alias OliWeb.Router.Helpers, as: Routes
 
   on_mount {OliWeb.LiveSessionPlugs.SetUser, :default}
   on_mount {OliWeb.LiveSessionPlugs.SetProject, :default}
@@ -68,8 +69,19 @@ defmodule OliWeb.Experiments.ExperimentsView do
       <% end %>
 
       <div :if={@is_upgrade_enabled} class="flex gap-4">
-        <.button class="btn btn-md btn-primary mt-2">Download Segment JSON</.button>
-        <.button class="btn btn-md btn-primary mt-2">Download Experiment JSON</.button>
+        <.button
+          class="btn btn-md btn-primary mt-2"
+          href={Routes.experiment_path(OliWeb.Endpoint, :segment_download, assigns.project.slug)}
+        >
+          Download Segment JSON
+        </.button>
+
+        <.button
+          class="btn btn-md btn-primary mt-2"
+          href={Routes.experiment_path(OliWeb.Endpoint, :experiment_download, assigns.project.slug)}
+        >
+          Download Experiment JSON
+        </.button>
       </div>
     </div>
     """

--- a/test/oli_web/live/experiments_live_test.exs
+++ b/test/oli_web/live/experiments_live_test.exs
@@ -182,7 +182,7 @@ defmodule OliWeb.ExperimentsLiveTest do
     to_evaluate =
       view
       |> render()
-      |> Floki.find("button:fl-contains('Download Experiment JSON')")
+      |> Floki.find("a:fl-contains('Download Experiment JSON')")
       |> Floki.text() =~ "Download Experiment JSON"
 
     evaluate_assertion(to_evaluate, assert_or_refute)
@@ -194,7 +194,7 @@ defmodule OliWeb.ExperimentsLiveTest do
     to_evaluate =
       view
       |> render()
-      |> Floki.find("button:fl-contains('Download Segment JSON')")
+      |> Floki.find("a:fl-contains('Download Segment JSON')")
       |> Floki.text() =~ "Download Segment JSON"
 
     evaluate_assertion(to_evaluate, assert_or_refute)


### PR DESCRIPTION
Link the existing buttons in the experiments page to the experiments controller endpoints, so when a user clicks “Download Segment JSON” or “Download Experiment JSON” buttons, the JSON file should be downloaded to their computer.


See: https://eliterate.atlassian.net/browse/MER-3110