### PR TITLE
[BUG FIX] [NG23-174] Scroring inconsistency

### DIFF
--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -399,30 +399,6 @@ defmodule Oli.Delivery.Metrics do
   This exists primarily to exclude instructors.
   """
 
-  def raw_avg_score_across_for_pages(
-        %Section{id: section_id, analytics_version: :v2} = _section,
-        pages_ids,
-        user_ids
-      ) do
-    page_type_id = Oli.Resources.ResourceType.get_id_by_type("page")
-
-    from(rs in ResourceSummary,
-      where:
-        rs.section_id == ^section_id and rs.resource_id in ^pages_ids and rs.user_id in ^user_ids and
-          rs.publication_id == -1 and rs.project_id == -1 and rs.resource_type_id == ^page_type_id,
-      group_by: rs.resource_id,
-      select: {
-        rs.resource_id,
-        %{
-          score: fragment("CAST(SUM(?) as float)", rs.num_correct),
-          out_of: fragment("CAST(SUM(?) as float)", rs.num_attempts)
-        }
-      }
-    )
-    |> Repo.all()
-    |> Enum.into(%{})
-  end
-
   def raw_avg_score_across_for_pages(%Section{id: section_id} = _section, pages_ids, user_ids) do
     from(ra in ResourceAccess,
       where:

--- a/lib/oli_web/components/delivery/student.ex
+++ b/lib/oli_web/components/delivery/student.ex
@@ -5,6 +5,7 @@ defmodule OliWeb.Components.Delivery.Student do
   alias Oli.Delivery.Attempts.HistoricalGradedAttemptSummary
   alias Oli.Delivery.Attempts.Core.ResourceAttempt
   alias OliWeb.Components.Common
+  alias OliWeb.Delivery.Student.Utils
   alias OliWeb.Icons
 
   attr(:raw_avg_score, :map)
@@ -19,16 +20,12 @@ defmodule OliWeb.Components.Delivery.Student do
         />
       </svg>
       <span class="text-[12px] leading-[16px] tracking-[0.02px] text-[#0CAF61] dark:text-[#12E56A] font-semibold whitespace-nowrap">
-        <%= format_float(@raw_avg_score[:score]) %> / <%= format_float(@raw_avg_score[:out_of]) %>
+        <%= Utils.parse_score(@raw_avg_score[:score]) %> / <%= Utils.parse_score(
+          @raw_avg_score[:out_of]
+        ) %>
       </span>
     </div>
     """
-  end
-
-  defp format_float(float) do
-    float
-    |> round()
-    |> trunc()
   end
 
   attr(:ctx, OliWeb.Common.SessionContext)

--- a/test/oli/delivery/metrics/avg_score_test.exs
+++ b/test/oli/delivery/metrics/avg_score_test.exs
@@ -380,5 +380,151 @@ defmodule Oli.Delivery.Metrics.AvgScoreTest do
                p10.published_resource.resource_id
              ) == nil
     end
+
+    test "raw_avg_score_across_for_pages/3 calculates correctly",
+         %{
+           section: section,
+           user_1: user_1,
+           user_2: user_2,
+           mod1_pages: mod1_pages,
+           mod2_pages: mod2_pages,
+           mod3_pages: mod3_pages
+         } do
+      [p1, p2, p3] = mod1_pages
+      [p4, p5, p6] = mod2_pages
+      [p7, p8, p9, p10] = mod3_pages
+
+      pages_raw_avg_score =
+        Metrics.raw_avg_score_across_for_pages(
+          section,
+          [
+            p1.published_resource.resource_id,
+            p2.published_resource.resource_id,
+            p3.published_resource.resource_id,
+            p4.published_resource.resource_id,
+            p5.published_resource.resource_id,
+            p6.published_resource.resource_id,
+            p7.published_resource.resource_id,
+            p8.published_resource.resource_id,
+            p9.published_resource.resource_id,
+            p10.published_resource.resource_id
+          ],
+          [user_1.id, user_2.id]
+        )
+
+      assert Map.get(pages_raw_avg_score, p1.published_resource.resource_id) == %{
+               score: 4.0,
+               out_of: 8.0
+             }
+
+      assert Map.get(pages_raw_avg_score, p2.published_resource.resource_id) == %{
+               score: 7.0,
+               out_of: 8.0
+             }
+
+      assert Map.get(pages_raw_avg_score, p3.published_resource.resource_id) == %{
+               score: 3.0,
+               out_of: 8.0
+             }
+
+      assert Map.get(pages_raw_avg_score, p4.published_resource.resource_id) == %{
+               score: 1.0,
+               out_of: 4.0
+             }
+
+      assert Map.get(pages_raw_avg_score, p5.published_resource.resource_id) == %{
+               score: 0.0,
+               out_of: 4.0
+             }
+
+      assert Map.get(pages_raw_avg_score, p6.published_resource.resource_id) == %{
+               score: 4.0,
+               out_of: 4.0
+             }
+
+      assert Map.get(pages_raw_avg_score, p7.published_resource.resource_id) == %{
+               score: 4.0,
+               out_of: 4.0
+             }
+
+      assert Map.get(pages_raw_avg_score, p8.published_resource.resource_id) == %{
+               score: 3.0,
+               out_of: 4.0
+             }
+
+      refute Map.get(pages_raw_avg_score, p9.published_resource.resource_id)
+
+      refute Map.get(pages_raw_avg_score, p10.published_resource.resource_id)
+
+      pages_raw_avg_score_excluding_user_2 =
+        Metrics.raw_avg_score_across_for_pages(
+          section,
+          [
+            p1.published_resource.resource_id,
+            p2.published_resource.resource_id,
+            p3.published_resource.resource_id,
+            p4.published_resource.resource_id,
+            p5.published_resource.resource_id,
+            p6.published_resource.resource_id,
+            p7.published_resource.resource_id,
+            p8.published_resource.resource_id,
+            p9.published_resource.resource_id,
+            p10.published_resource.resource_id
+          ],
+          [user_1.id]
+        )
+
+      assert Map.get(pages_raw_avg_score_excluding_user_2, p1.published_resource.resource_id) ==
+               %{
+                 score: 4.0,
+                 out_of: 4.0
+               }
+
+      assert Map.get(pages_raw_avg_score_excluding_user_2, p2.published_resource.resource_id) ==
+               %{
+                 score: 3.0,
+                 out_of: 4.0
+               }
+
+      assert Map.get(pages_raw_avg_score_excluding_user_2, p3.published_resource.resource_id) ==
+               %{
+                 score: 2.0,
+                 out_of: 4.0
+               }
+
+      assert Map.get(pages_raw_avg_score_excluding_user_2, p4.published_resource.resource_id) ==
+               %{
+                 score: 1.0,
+                 out_of: 4.0
+               }
+
+      assert Map.get(pages_raw_avg_score_excluding_user_2, p5.published_resource.resource_id) ==
+               %{
+                 score: 0.0,
+                 out_of: 4.0
+               }
+
+      assert Map.get(pages_raw_avg_score_excluding_user_2, p6.published_resource.resource_id) ==
+               %{
+                 score: 4.0,
+                 out_of: 4.0
+               }
+
+      assert Map.get(pages_raw_avg_score_excluding_user_2, p7.published_resource.resource_id) ==
+               %{
+                 score: 4.0,
+                 out_of: 4.0
+               }
+
+      assert Map.get(pages_raw_avg_score_excluding_user_2, p8.published_resource.resource_id) ==
+               %{
+                 score: 3.0,
+                 out_of: 4.0
+               }
+
+      refute Map.get(pages_raw_avg_score_excluding_user_2, p9.published_resource.resource_id)
+
+      refute Map.get(pages_raw_avg_score_excluding_user_2, p10.published_resource.resource_id)
+    end
   end
 end

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -26,7 +26,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
   defp set_progress(section_id, resource_id, user_id, progress, revision) do
     {:ok, resource_access} =
       Core.track_access(resource_id, section_id, user_id)
-      |> Core.update_resource_access(%{progress: progress})
+      |> Core.update_resource_access(%{progress: progress, score: 1.0, out_of: 2.0})
 
     insert(:resource_attempt, %{
       resource_access: resource_access,


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/NG23-174) to the ticket

The issue was that we were getting the raw average score for a page (`score` and `out_of`) from the `resource_summary` table instead of the `resource_attempt`

### Before

https://github.com/Simon-Initiative/oli-torus/assets/74839302/652ad83f-5c01-404d-b01f-989350dc2380


### After

https://github.com/Simon-Initiative/oli-torus/assets/74839302/ba566faf-d0fe-4943-a585-586e6eeb1bd5


