### PR TITLE
[BUG FIX] [MER-3176] guard against division by zero in proficiency queries

### DIFF
--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -895,7 +895,7 @@ defmodule Oli.Delivery.Metrics do
         select:
           {summary.user_id,
            fragment(
-             "CAST(SUM(?) as float) / CAST(SUM(?) as float)",
+             "CAST(SUM(?) as float) / NULLIF(CAST(SUM(?) as float), 0.0)",
              summary.num_first_attempts_correct,
              summary.num_first_attempts
            )}
@@ -1020,7 +1020,7 @@ defmodule Oli.Delivery.Metrics do
         select: {
           summary.resource_id,
           fragment(
-            "CAST(? as float) / CAST(? as float)",
+            "CAST(? as float) / NULLIF(CAST(? as float), 0.0)",
             summary.num_first_attempts_correct,
             summary.num_first_attempts
           )
@@ -1085,7 +1085,7 @@ defmodule Oli.Delivery.Metrics do
         select:
           {summary.user_id,
            fragment(
-             "CAST(? as float) / CAST(? as float)",
+             "CAST(? as float) / NULLIF(CAST(? as float), 0.0)",
              summary.num_first_attempts_correct,
              summary.num_first_attempts
            )}
@@ -1146,7 +1146,7 @@ defmodule Oli.Delivery.Metrics do
         select:
           {summary.resource_id,
            fragment(
-             "? / ?",
+             "? / NULLIF(?, 0)",
              summary.num_first_attempts_correct,
              summary.num_first_attempts
            )}
@@ -1217,7 +1217,7 @@ defmodule Oli.Delivery.Metrics do
         select:
           {summary.resource_id,
            fragment(
-             "CAST(SUM(?) as float) / CAST(SUM(?) as float)",
+             "CAST(SUM(?) as float) / NULLIF(CAST(SUM(?) as float), 0.0)",
              summary.num_first_attempts_correct,
              summary.num_first_attempts
            )}


### PR DESCRIPTION
Got division by zero errors from a proficiency query in `Oli.Delivery.Metrics.proficiency_per_student_across/2` . Such an error prevents display of the Students page, and probably other displays showing proficiencies.  

This PR adds NULLIF guards around proficiency calculation denominators using `ResourceSummary.num_first_attempts` to prevent possible division by zero.  

The source of the error is not understood. The queries evidently were written on the assumption they will never get a 0 valued sum of `num_first_attempts` (though might get null). The error suggests some resource is unexpectedly causing an explicit 0 to be recorded in `num_first_attempts` in the resource summary table, rather than leaving it null. 

The error was observed in a somewhat unusual situation: a client-side evaluated activity, the LogicLab, which asynchronously resets part attempts and submits activity evaluations, in context of a containing graded page that was never itself submitted, with this being done by a unique guest student who can never return to complete it. 

But since this can happen in the system, should protect against it. Change should be harmless.