### PR TITLE
[CHORE] [MER-3172] Make LogicLab not include full CreationContext in model

### DIFF
--- a/assets/src/components/activities/logic_lab/LogicLabDelivery.tsx
+++ b/assets/src/components/activities/logic_lab/LogicLabDelivery.tsx
@@ -41,7 +41,6 @@ const LogicLab: React.FC<LogicLabDeliveryProps> = () => {
   } = useDeliveryElementContext<LogicLabModelSchema>();
   const dispatch = useDispatch();
   const [activity, setActivity] = useState<string>(model.activity);
-  const [modelContext, setModelContext] = useState(model.context);
 
   useEffect(() => {
     // This looks like boilerplate code for dealing with embedded activities.
@@ -50,7 +49,6 @@ const LogicLab: React.FC<LogicLabDeliveryProps> = () => {
     listenForReviewAttemptChange(model, activityState.activityId as number, dispatch, context);
 
     setActivity(model.activity);
-    setModelContext(model.context);
     let partGuid = activityState.parts[0].attemptGuid; // Moving to higher scope which helps state saving to work.
 
     const onMessage = async (e: MessageEvent) => {
@@ -195,7 +193,7 @@ const LogicLab: React.FC<LogicLabDeliveryProps> = () => {
       )}
       {loading === 'loaded' && (
         <iframe
-          title={`LogicLab Activity ${modelContext?.title}`}
+          title={`LogicLab Activity ${model.context?.title}`}
           src={baseUrl}
           allow="fullscreen"
           height="800"

--- a/assets/src/components/activities/logic_lab/LogicLabModelSchema.tsx
+++ b/assets/src/components/activities/logic_lab/LogicLabModelSchema.tsx
@@ -1,7 +1,7 @@
 /*
   Models for Torus LogicLab activity data and data exchange.
 */
-import { ActivityModelSchema, CreationContext, Feedback, Part, Transformation } from '../types';
+import { ActivityModelSchema, Feedback, Part, Transformation } from '../types';
 
 // Typing and type checking for existence of variables in a context.
 type ContextVariables = { variables: Record<string, string> };
@@ -25,7 +25,7 @@ export function getLabServer(context: ContextVariables | unknown): string {
 
 export interface LogicLabModelSchema extends ActivityModelSchema {
   activity: string; // Have to set at higher level as not all information in authoring.parts (eg) targets, are available in all contexts
-  context?: CreationContext;
+  context?: ContextInfo;
   authoring: {
     version: 1;
     parts: Part[]; // required in use
@@ -33,6 +33,11 @@ export interface LogicLabModelSchema extends ActivityModelSchema {
     previewText: string;
   };
   feedback: Feedback[];
+}
+
+// info saved from Creation Context
+export interface ContextInfo {
+  title: string;
 }
 
 export interface Score {

--- a/assets/src/components/activities/logic_lab/authoring-entry.ts
+++ b/assets/src/components/activities/logic_lab/authoring-entry.ts
@@ -21,7 +21,7 @@ const manifest: Manifest = require('./manifest.json');
 registerCreationFunc(manifest, async (context: CreationContext): Promise<LogicLabModelSchema> => {
   return {
     activity: '',
-    context, // For future work so that lab activity can reference context.
+    context: { title: context.title },
     authoring: {
       version: 1,
       parts: [


### PR DESCRIPTION
Externally written LogicLab was batching the entire large activity CreationContext object into the activity model for convenience. This is inappropriate, it bloats the object and includes a very large and unnecessary data structure, for example including everything else on the page, that will be noise on viewing its JSON or web page inspection. The only info used is the activity title (as it was at activity creation time)

This PR changes to only extract the info used, currently the title. 

This should not change the behavior in any way. 