### PR TITLE
[BUG FIX] [MER-3106] Handle when experiments are not set up in upgrade

### DIFF
--- a/lib/oli/delivery/experiments.ex
+++ b/lib/oli/delivery/experiments.ex
@@ -38,7 +38,7 @@ defmodule Oli.Delivery.Experiments do
          {:ok, assign_results} <- assign(enrollment_id) do
       case assign_results do
         # Upgrade returns an empty array payload in cases when no active
-        # experiment applies for this student
+        # experiment applies for this student.
         [] ->
           {:ok, nil}
 
@@ -103,7 +103,8 @@ defmodule Oli.Delivery.Experiments do
 
     case http().post(url("/api/assign"), body, headers()) do
       {:ok, %{status_code: 200, body: body}} -> Poison.decode(body)
-      e -> e
+      {:ok, %{status_code: 404}} -> {:error, "Experiment might not be set up correctly."}
+      e -> {:error, e}
     end
   end
 


### PR DESCRIPTION
The problem noted in the MER ticket arises when the corresponding steps to set up the experiment in Upgrade have not been performed, but a page is published which contains a decision point. 

This PR handles the specific failure to allow the page to still render. 