### PR TITLE
[BUG FIX] [MER-3324] Recommended action remind students of deadline link breaks

### DIFF
--- a/lib/oli_web/components/delivery/recommended_actions.ex
+++ b/lib/oli_web/components/delivery/recommended_actions.ex
@@ -84,13 +84,7 @@ defmodule OliWeb.Components.Delivery.RecommendedActions do
       <% end %>
       <%= if @has_due_soon_activities do %>
         <.action_card to={
-          Routes.live_path(
-            OliWeb.Endpoint,
-            OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive,
-            @section_slug,
-            :overview,
-            :scored_activities
-          )
+          ~p"/sections/#{@section_slug}/instructor_dashboard/insights/scored_activities"
         }>
           <:icon><i class="fa-solid fa-hourglass-half" /></:icon>
           <:title>Remind Students of Deadlines</:title>
@@ -110,8 +104,8 @@ defmodule OliWeb.Components.Delivery.RecommendedActions do
 
   defp action_card(assigns) do
     ~H"""
-    <a
-      href={@to}
+    <.link
+      navigate={@to}
       class="group border border-gray-200 dark:border-gray-600 rounded p-3 pl-8 flex flex-col justify-center cursor-pointer hover:bg-delivery-primary-50 active:bg-delivery-primary active:text-white hover:no-underline"
     >
       <div class="flex items-center gap-2">
@@ -121,7 +115,7 @@ defmodule OliWeb.Components.Delivery.RecommendedActions do
       <span class="torus-span group-hover:text-gray-500 group-active:text-white">
         <%= render_slot(@description) %>
       </span>
-    </a>
+    </.link>
     """
   end
 end

--- a/test/oli_web/live/delivery/instructor_dashboard/overview/recommended_actions_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/overview/recommended_actions_tab_test.exs
@@ -225,7 +225,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.Overview.RecommendedActionsTest do
       section: section,
       section_page: section_page
     } do
-      set_schedule_for_page(10, section_page)
+      set_schedule_for_page(10, section_page, section.id)
 
       {:ok, view, _html} = live(conn, instructor_course_content_path(section.slug))
 
@@ -243,7 +243,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.Overview.RecommendedActionsTest do
       section: section,
       section_page: section_page
     } do
-      set_schedule_for_page(10, section_page)
+      set_schedule_for_page(10, section_page, section.id)
 
       {:ok, view, _html} = live(conn, instructor_course_content_path(section.slug))
 
@@ -277,7 +277,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.Overview.RecommendedActionsTest do
       section: section,
       section_page: section_page
     } do
-      set_schedule_for_page(25, section_page)
+      set_schedule_for_page(25, section_page, section.id)
 
       {:ok, view, _html} = live(conn, instructor_course_content_path(section.slug))
 
@@ -291,7 +291,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.Overview.RecommendedActionsTest do
     end
   end
 
-  defp set_schedule_for_page(hours, section_page) do
+  defp set_schedule_for_page(hours, section_page, section_id) do
     end_date = DateTime.utc_now() |> DateTime.add(hours, :hour) |> DateTime.truncate(:second)
 
     section_page
@@ -299,7 +299,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.Overview.RecommendedActionsTest do
     |> Repo.update()
 
     Oli.Delivery.Sections.SectionResource
-    |> where([sr], sr.resource_id == ^section_page.resource.id)
+    |> where([sr], sr.resource_id == ^section_page.resource.id and sr.section_id == ^section_id)
     |> select([sr], sr)
     |> limit(1)
     |> Repo.one()

--- a/test/oli_web/live/delivery/instructor_dashboard/overview/recommended_actions_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/overview/recommended_actions_tab_test.exs
@@ -225,19 +225,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.Overview.RecommendedActionsTest do
       section: section,
       section_page: section_page
     } do
-      end_date = DateTime.utc_now() |> DateTime.add(10, :hour) |> DateTime.truncate(:second)
-
-      section_page
-      |> Ecto.Changeset.change(%{graded: true})
-      |> Repo.update()
-
-      Oli.Delivery.Sections.SectionResource
-      |> where([sr], sr.resource_id == ^section_page.resource.id)
-      |> select([sr], sr)
-      |> limit(1)
-      |> Repo.one()
-      |> Ecto.Changeset.change(%{scheduling_type: :due_by, end_date: end_date})
-      |> Repo.update()
+      set_schedule_for_page(10, section_page)
 
       {:ok, view, _html} = live(conn, instructor_course_content_path(section.slug))
 
@@ -250,24 +238,46 @@ defmodule OliWeb.Delivery.InstructorDashboard.Overview.RecommendedActionsTest do
              )
     end
 
+    test "\"remind student of deadlines\" action redirects to Scored Activities tab correctly", %{
+      conn: conn,
+      section: section,
+      section_page: section_page
+    } do
+      set_schedule_for_page(10, section_page)
+
+      {:ok, view, _html} = live(conn, instructor_course_content_path(section.slug))
+
+      assert has_element?(view, "h4", "Remind Students of Deadlines")
+
+      assert has_element?(
+               view,
+               "span",
+               "There are assessments due soon, review and remind students"
+             )
+
+      assert has_element?(
+               view,
+               "a[href=\"/sections/#{section.slug}/instructor_dashboard/insights/scored_activities\"]"
+             )
+
+      element(
+        view,
+        "a[href=\"/sections/#{section.slug}/instructor_dashboard/insights/scored_activities\"]"
+      )
+      |> render_click()
+
+      assert_redirected(
+        view,
+        ~p"/sections/#{section.slug}/instructor_dashboard/insights/scored_activities"
+      )
+    end
+
     test "does not render the \"remind student of deadlines\" action when not necessary", %{
       conn: conn,
       section: section,
       section_page: section_page
     } do
-      end_date = DateTime.utc_now() |> DateTime.add(25, :hour) |> DateTime.truncate(:second)
-
-      section_page
-      |> Ecto.Changeset.change(%{graded: true})
-      |> Repo.update()
-
-      Oli.Delivery.Sections.SectionResource
-      |> where([sr], sr.resource_id == ^section_page.resource.id)
-      |> select([sr], sr)
-      |> limit(1)
-      |> Repo.one()
-      |> Ecto.Changeset.change(%{scheduling_type: :due_by, end_date: end_date})
-      |> Repo.update()
+      set_schedule_for_page(25, section_page)
 
       {:ok, view, _html} = live(conn, instructor_course_content_path(section.slug))
 
@@ -279,5 +289,21 @@ defmodule OliWeb.Delivery.InstructorDashboard.Overview.RecommendedActionsTest do
                "There are assessments due soon, review and remind students"
              )
     end
+  end
+
+  defp set_schedule_for_page(hours, section_page) do
+    end_date = DateTime.utc_now() |> DateTime.add(hours, :hour) |> DateTime.truncate(:second)
+
+    section_page
+    |> Ecto.Changeset.change(%{graded: true})
+    |> Repo.update()
+
+    Oli.Delivery.Sections.SectionResource
+    |> where([sr], sr.resource_id == ^section_page.resource.id)
+    |> select([sr], sr)
+    |> limit(1)
+    |> Repo.one()
+    |> Ecto.Changeset.change(%{scheduling_type: :due_by, end_date: end_date})
+    |> Repo.update()
   end
 end


### PR DESCRIPTION
[MER-3324](https://eliterate.atlassian.net/browse/MER-3324)

This PR addresses an issue with the `Remind Students of Deadline` link in the Instructor Insights → Recommended Actions section. 

Previously, clicking this link resulted in a “Page Not Found” error due to a change in the URL structure. The URL was changed from `instructor_dashboard/overview/scored_activities` to `instructor_dashboard/insights/scored_activities`.


https://github.com/Simon-Initiative/oli-torus/assets/16328384/591281c5-f783-4c47-9051-b78cf12ea41f



[MER-3324]: https://eliterate.atlassian.net/browse/MER-3324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ