### PR TITLE
[BUG FIX] [MER-3375] prevent exception previewing pages with video

### DIFF
--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -82,10 +82,16 @@ defmodule Oli.Rendering.Content.Html do
   def img_inline(%Context{} = _context, _, _e), do: ""
 
   def video(%Context{} = context, _, attrs) do
+    attempt_guid =
+      case context.resource_attempt do
+        nil -> ""
+        attempt -> attempt.attempt_guid
+      end
+
     {:safe, video_player} =
       OliWeb.Common.React.component(context, "Components.VideoPlayer", %{
         "video" => attrs,
-        "pageAttemptGuid" => context.resource_attempt.attempt_guid,
+        "pageAttemptGuid" => attempt_guid,
         "pointMarkerContext" => %{
           renderPointMarkers: context.render_opts.render_point_markers,
           isAnnotationLevel: context.is_annotation_level


### PR DESCRIPTION
Previewing expository pages containing video was causing 500 error due accessing nil resource_attempt. This prevents, using same code from following `ecl `rendering routine. 