### PR TITLE
[ENHANCEMENT] [MER-3126] Removing availability date for student exception doesnt make assignment available

### DIFF
--- a/assets/css/table.css
+++ b/assets/css/table.css
@@ -66,7 +66,7 @@
 }
 
 .instructor_dashboard_table td:has(div.highlight-exception) {
-  @apply bg-blue-100 rounded-md bg-opacity-50;
+  @apply rounded-md shadow-[inset_0px_0px_0px_8px_rgba(0,0,0,0.0)] shadow-blue-100/50;
 }
 
 div:has(.instructor_dashboard_table) #header_paging {

--- a/lib/oli_web/live/sections/assessment_settings/student_exceptions_table.ex
+++ b/lib/oli_web/live/sections/assessment_settings/student_exceptions_table.ex
@@ -146,6 +146,9 @@ defmodule OliWeb.Sections.AssessmentSettings.StudentExceptionsTable do
           </button>
         </div>
       </div>
+      <p class="pl-9 pr-6">
+        Note: Setting an availability date in the past will effectively allow a student to access the page.
+      </p>
       <Paging.render
         id="header_paging"
         total_count={@total_count}

--- a/lib/oli_web/live/sections/assessment_settings/student_exceptions_table_model.ex
+++ b/lib/oli_web/live/sections/assessment_settings/student_exceptions_table_model.ex
@@ -157,18 +157,22 @@ defmodule OliWeb.Sections.AssessmentSettings.StudentExceptionsTableModel do
       })
 
     ~H"""
-    <button
-      class="hover:underline whitespace-nowrap"
-      type="button"
-      phx-click={edit_date_and_show_modal(@on_edit_date, "available_date")}
-      phx-value-user_id={@id}
-    >
-      <%= if is_nil(@available_date) do %>
-        Always available
-      <% else %>
-        <%= value_from_datetime(@available_date, @ctx) %>
-      <% end %>
-    </button>
+    <div class={data_class(@selected_assessment.start_date, @available_date)}>
+      <div class="relative">
+        <button
+          class="hover:underline whitespace-nowrap"
+          type="button"
+          phx-click={edit_date_and_show_modal(@on_edit_date, "available_date")}
+          phx-value-user_id={@id}
+        >
+          <%= if is_nil(@available_date) do %>
+            Always available
+          <% else %>
+            <%= value_from_datetime(@available_date, @ctx) %>
+          <% end %>
+        </button>
+      </div>
+    </div>
     """
   end
 
@@ -180,18 +184,22 @@ defmodule OliWeb.Sections.AssessmentSettings.StudentExceptionsTableModel do
       })
 
     ~H"""
-    <button
-      class="hover:underline whitespace-nowrap"
-      type="button"
-      phx-click={edit_date_and_show_modal(@on_edit_date, "due_date")}
-      phx-value-user_id={@id}
-    >
-      <%= if @due_date do %>
-        <%= value_from_datetime(@due_date, @ctx) %>
-      <% else %>
-        No due date
-      <% end %>
-    </button>
+    <div class={data_class(@selected_assessment.end_date, @due_date)}>
+      <div class="relative">
+        <button
+          class="hover:underline whitespace-nowrap"
+          type="button"
+          phx-click={edit_date_and_show_modal(@on_edit_date, "due_date")}
+          phx-value-user_id={@id}
+        >
+          <%= if @due_date do %>
+            <%= value_from_datetime(@due_date, @ctx) %>
+          <% else %>
+            No due date
+          <% end %>
+        </button>
+      </div>
+    </div>
     """
   end
 
@@ -425,8 +433,9 @@ defmodule OliWeb.Sections.AssessmentSettings.StudentExceptionsTableModel do
   end
 
   defp data_class(assessment_data, student_exception_data)
-       when assessment_data != student_exception_data and student_exception_data != nil,
-       do: "highlight-exception"
+       when assessment_data != student_exception_data and student_exception_data != nil do
+    "highlight-exception"
+  end
 
   defp data_class(_assessment_data, _student_exception_data), do: ""
 


### PR DESCRIPTION
Ticket: [MER-3126](https://eliterate.atlassian.net/browse/MER-3126)

This PR added a note above the table of Student Exceptions (commit 361febd3c8200538a613f57381a1f08a584f947d) and fixed a bug where the **Available Date** and **Due Date** exceptions were not highlighted when they should have been (commit: bb2d880e637232013fad102164af45a7b1f6d8be).

https://github.com/Simon-Initiative/oli-torus/assets/47334502/e18f9888-2807-4e51-9844-1659e969d68d




[MER-3126]: https://eliterate.atlassian.net/browse/MER-3126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ