### PR TITLE
[BUG FIX] [MER-3227] Remove cookie preferences and version number in email footer

### DIFF
--- a/lib/oli_web/components/footer.ex
+++ b/lib/oli_web/components/footer.ex
@@ -36,6 +36,19 @@ defmodule OliWeb.Components.Footer do
     """
   end
 
+  def email_footer(assigns) do
+    ~H"""
+    <footer class="absolute bottom-0 left-0 right-0 pb-4 w-full md:container md:mx-auto lg:px-10 text-xs bg-delivery-footer dark:bg-delivery-footer-dark">
+      <div class="flex flex-col w-full px-10">
+        <div class="flex flex-col sm:flex-row gap-2">
+          <.footer_part_1 />
+          <.footer_part_2 />
+        </div>
+      </div>
+    </footer>
+    """
+  end
+
   defp footer_part_1(assigns) do
     assigns =
       assign(assigns,

--- a/lib/oli_web/templates/layout/email.html.eex
+++ b/lib/oli_web/templates/layout/email.html.eex
@@ -238,7 +238,7 @@
 
         <!-- Email Footer : BEGIN -->
 
-        <%= OliWeb.Components.Footer.global_footer(%{}) %>
+        <%= OliWeb.Components.Footer.email_footer(%{}) %>
 
         <!-- Email Footer : END -->
 


### PR DESCRIPTION
Remove the Cookie Preferences link and version/build number from the email templates.

Before:
![Screenshot 2024-06-20 at 14 01 57](https://github.com/Simon-Initiative/oli-torus/assets/5324858/8a62c56b-f834-4e50-ad34-c1ae9f96855f)

Now:
![Screenshot 2024-06-20 at 14 01 27](https://github.com/Simon-Initiative/oli-torus/assets/5324858/7a14b667-ec2a-4dbf-876b-9c394614e321)


Other fixed email templates:

![Screenshot 2024-06-20 at 13 56 19](https://github.com/Simon-Initiative/oli-torus/assets/5324858/d812cd50-d5e2-4599-acdc-c5ea2f31e92f)
![Screenshot 2024-06-20 at 13 56 25](https://github.com/Simon-Initiative/oli-torus/assets/5324858/44d228a2-6609-4d9f-b0fb-ddad36a23e57)
![Screenshot 2024-06-20 at 13 56 41](https://github.com/Simon-Initiative/oli-torus/assets/5324858/86947eb4-2fef-4b1e-ace4-a609e0ed0100)
