### PR TITLE
[BUG FIX] [NG23-248] Fix incorrect module namespace call

### DIFF
--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -1032,7 +1032,7 @@ defmodule OliWeb.Router do
         ] do
         live("/", Delivery.Student.IndexLive, :preview)
         live("/learn", Delivery.Student.LearnLive, :preview)
-        live("/discussions", Delivery.Student.DiscussionLive, :preview)
+        live("/discussions", Delivery.Student.DiscussionsLive, :preview)
         live("/assignments", Delivery.Student.ScheduleLive, :preview)
         live("/explorations", Delivery.Student.ExplorationsLive, :preview)
         live("/practice", Delivery.Student.PracticeLive)

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -2759,6 +2759,26 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
     end
   end
 
+  describe "preview" do
+    setup [:user_conn, :create_elixir_project, :enroll_as_student, :mark_section_visited]
+
+    test "redirects and ensures navigation to the Notes page", %{conn: conn, section: section} do
+      stub_current_time(~U[2023-11-04 20:00:00Z])
+      {:ok, view, _html} = live(conn, "/sections/#{section.slug}/preview")
+
+      view
+      |> element(~s{nav[id="desktop-nav-menu"] a[id="discussions_nav_link"])})
+      |> render_click()
+
+      redirect_path = "/sections/#{section.slug}/preview/discussions"
+      assert_redirect(view, redirect_path)
+
+      {:ok, view, _html} = live(conn, redirect_path)
+
+      assert view |> element(~s{h3)}) |> render() =~ "My Notes"
+    end
+  end
+
   defp enable_all_sidebar_links(section, author, page_1, page_2, page_3) do
     # change the purpose of the pages to have an exploration page and a deliberate practice page
     Oli.Resources.update_revision(page_1, %{purpose: :application, author_id: author.id})


### PR DESCRIPTION
Ticket: [NG23-248](https://eliterate.atlassian.net/browse/NG23-248)

This PR fixes a bug where a user hits a 500 error page when trying to open a section in Preview Mode and clicks on the Notes page. The issue was due to a typo when calling the corresponding module.


[NG23-248]: https://eliterate.atlassian.net/browse/NG23-248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ