### PR TITLE
[BUG FIX] [MER-3155] Prevents nil revision exporting project

### DIFF
--- a/lib/oli/interop/export.ex
+++ b/lib/oli/interop/export.ex
@@ -467,22 +467,25 @@ defmodule Oli.Interop.Export do
   defp full_hierarchy(revisions_by_id, resource_id) do
     revision = Map.get(revisions_by_id, resource_id)
 
-    case ResourceType.get_type_by_id(revision.resource_type_id) do
-      "container" ->
-        %{
-          type: "container",
-          id: "#{resource_id}",
-          title: revision.title,
-          tags: transform_tags(revision),
-          children: Enum.map(revision.children, fn id -> full_hierarchy(revisions_by_id, id) end)
-        }
+    if revision do
+      case ResourceType.get_type_by_id(revision.resource_type_id) do
+        "container" ->
+          %{
+            type: "container",
+            id: "#{resource_id}",
+            title: revision.title,
+            tags: transform_tags(revision),
+            children:
+              Enum.map(revision.children, fn id -> full_hierarchy(revisions_by_id, id) end)
+          }
 
-      "page" ->
-        %{
-          type: "item",
-          children: [],
-          idref: "#{resource_id}"
-        }
+        "page" ->
+          %{
+            type: "item",
+            children: [],
+            idref: "#{resource_id}"
+          }
+      end
     end
   end
 

--- a/test/oli/interop/export.exs
+++ b/test/oli/interop/export.exs
@@ -2,6 +2,8 @@ defmodule Oli.Interop.ExportTest do
   use OliWeb.ConnCase
 
   alias Oli.Interop.Export
+  alias Oli.Publishing.AuthoringResolver
+  alias Oli.Resources
   import Oli.Factory
 
   describe "export" do
@@ -49,6 +51,27 @@ defmodule Oli.Interop.ExportTest do
       assert type_labels["module"] == project.customizations.module
 
       assert type_labels["section"] == project.customizations.section
+    end
+
+    test "export a project with nil revisions does not fail", %{project: project} do
+      author = hd(project.authors)
+
+      root_revision = AuthoringResolver.root_container(project.slug)
+
+      ## Modify the root revision to have a non-revision child resource
+      Resources.update_revision(root_revision, %{
+        children: [1000],
+        author_id: author.id
+      })
+
+      export =
+        Export.export(project)
+        |> unzip_to_memory()
+        |> Enum.reduce(%{}, fn {f, c}, m -> Map.put(m, f, c) end)
+
+      {:ok, hierarchy_json} = Jason.decode(Map.get(export, ~c"_hierarchy.json"))
+
+      assert hierarchy_json["children"] |> Enum.filter(&(&1 == nil)) |> length() == 1
     end
   end
 


### PR DESCRIPTION
[MER-3155](https://eliterate.atlassian.net/browse/MER-3155)

This PR try to fix the bug that is happening when a project that contain nil revisions is exported. 

We want to check if the revisions exist at the time of creating the hierarchy file, although I'm not sure these changes is what will fix the issue and if it's the best way to fix it

As mentioned in the ticket, this would be happening in a specific project within the Proton environment.

Looking at the AppSignal logs, I deduce that the cause of this problem may be what I'm trying to fix with this PR.

[MER-3155]: https://eliterate.atlassian.net/browse/MER-3155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ