### PR TITLE
[FEATURE] [NG23-206] User enables/disables both Notes and Course Discussions

### DIFF
--- a/test/oli_web/live/delivery/student/discussions_live_test.exs
+++ b/test/oli_web/live/delivery/student/discussions_live_test.exs
@@ -215,8 +215,8 @@ defmodule OliWeb.Delivery.Student.DiscussionsLiveTest do
 
       assert has_element?(
                view,
-               ~s{section[id="posts"] div[role="posts header"] h3},
-               "Course Discussions"
+               ~s{div[id="discussions_content"] div[phx-value-tab='discussions']},
+               "Course Discussion"
              )
     end
 
@@ -249,6 +249,11 @@ defmodule OliWeb.Delivery.Student.DiscussionsLiveTest do
         })
 
       {:ok, view, _html} = live(conn, live_view_discussions_live_route(section.slug))
+
+      # select course discussions tab
+      view
+      |> element("div[phx-click='select_tab'][phx-value-tab='discussions']")
+      |> render_click
 
       # page posts are not shown in discussions view
       refute view
@@ -309,6 +314,11 @@ defmodule OliWeb.Delivery.Student.DiscussionsLiveTest do
 
       {:ok, view, _html} = live(conn, live_view_discussions_live_route(section.slug))
 
+      # select course discussions tab
+      view
+      |> element("div[phx-click='select_tab'][phx-value-tab='discussions']")
+      |> render_click
+
       ## post header
       # student name (Me)
       assert view
@@ -344,6 +354,11 @@ defmodule OliWeb.Delivery.Student.DiscussionsLiveTest do
 
       {:ok, view, _html} = live(conn, live_view_discussions_live_route(section.slug))
 
+      # select course discussions tab
+      view
+      |> element("div[phx-click='select_tab'][phx-value-tab='discussions']")
+      |> render_click
+
       refute render(view) =~ "My first discussion :)"
 
       form(view, "form[id=\"new_discussion_form\"]")
@@ -372,6 +387,11 @@ defmodule OliWeb.Delivery.Student.DiscussionsLiveTest do
       Sections.mark_section_visited_for_student(section, student)
 
       {:ok, view, _html} = live(conn, live_view_discussions_live_route(section.slug))
+
+      # select course discussions tab
+      view
+      |> element("div[phx-click='select_tab'][phx-value-tab='discussions']")
+      |> render_click
 
       refute render(view) =~ "My first anon discussion :)"
 
@@ -427,6 +447,11 @@ defmodule OliWeb.Delivery.Student.DiscussionsLiveTest do
 
       {:ok, view, _html} = live(conn, live_view_discussions_live_route(section.slug))
 
+      # select course discussions tab
+      view
+      |> element("div[phx-click='select_tab'][phx-value-tab='discussions']")
+      |> render_click
+
       assert render(view) =~ "My first discussion"
       refute render(view) =~ "This is a reply to the first discussion"
 
@@ -478,6 +503,11 @@ defmodule OliWeb.Delivery.Student.DiscussionsLiveTest do
 
       {:ok, view, _html} = live(conn, live_view_discussions_live_route(section.slug))
 
+      # select course discussions tab
+      view
+      |> element("div[phx-click='select_tab'][phx-value-tab='discussions']")
+      |> render_click
+
       assert render(view) =~ "My first discussion"
       refute render(view) =~ "This is a reply to the first discussion"
       refute render(view) =~ "This is a reply to the reply"
@@ -514,10 +544,16 @@ defmodule OliWeb.Delivery.Student.DiscussionsLiveTest do
           content: %{message: "My first anonymous discussion"},
           inserted_at: ~U[2023-12-01 00:00:00Z],
           updated_at: ~U[2023-12-01 00:00:00Z],
-          anonymous: true
+          anonymous: true,
+          status: :approved
         })
 
       {:ok, view, _html} = live(conn, live_view_discussions_live_route(section.slug))
+
+      view
+      |> element("div[phx-click='select_tab'][phx-value-tab='discussions']")
+      |> render_click
+
       assert render(view) =~ "My first anonymous discussion"
       assert render(view) =~ "Anonymous"
       refute render(view) =~ student_2.name
@@ -533,6 +569,11 @@ defmodule OliWeb.Delivery.Student.DiscussionsLiveTest do
       Sections.mark_section_visited_for_student(section, student)
 
       {:ok, view, _html} = live(conn, live_view_discussions_live_route(section.slug))
+
+      # select course discussions tab
+      view
+      |> element("div[phx-click='select_tab'][phx-value-tab='discussions']")
+      |> render_click
 
       assert render(view) =~ "There are no discussions to show."
     end
@@ -562,6 +603,11 @@ defmodule OliWeb.Delivery.Student.DiscussionsLiveTest do
       )
 
       {:ok, view, _html} = live(conn, live_view_discussions_live_route(section.slug))
+
+      # select course discussions tab
+      view
+      |> element("div[phx-click='select_tab'][phx-value-tab='discussions']")
+      |> render_click
 
       refute render(view) =~ "Discussion 1 :)"
       refute render(view) =~ "Discussion 2 :)"
@@ -623,6 +669,11 @@ defmodule OliWeb.Delivery.Student.DiscussionsLiveTest do
       Sections.mark_section_visited_for_student(section, student)
 
       {:ok, view, _html} = live(conn, live_view_discussions_live_route(section.slug))
+
+      # select course discussions tab
+      view
+      |> element("div[phx-click='select_tab'][phx-value-tab='discussions']")
+      |> render_click
 
       assert has_element?(view, "button[role=\"new discussion\"]", "New Discussion")
 

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -2779,7 +2779,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       {:ok, view, _html} = live(conn, redirect_path)
 
       assert view |> element(~s{#header span}) |> render() =~ "(Preview Mode)"
-      assert view |> element(~s{h3)}) |> render() =~ "My Notes"
+      assert view |> has_element?(~s{h1}, "Notes")
     end
 
     test "redirects and ensures navigation to the preview Practice page", %{
@@ -2804,7 +2804,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       {:ok, view, _html} = live(conn, redirect_path)
 
       assert view |> element(~s{#header span}) |> render() =~ "(Preview Mode)"
-      assert view |> element(~s{h1)}) |> render() =~ "Your Practice Pages"
+      assert view |> element(~s{h1}) |> render() =~ "Your Practice Pages"
     end
   end
 


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/NG23-206

Adds a tabbed interface for My Notes and Course Discussion. When course discussion is disabled, only the notes tab is displayed.

<img width="1440" alt="Screenshot 2024-06-20 at 4 19 35 PM" src="https://github.com/Simon-Initiative/oli-torus/assets/6248894/45482599-7376-419f-8472-4899166dcfb6">

<img width="1438" alt="Screenshot 2024-06-20 at 4 19 46 PM" src="https://github.com/Simon-Initiative/oli-torus/assets/6248894/99d4987d-454d-4785-98e8-2901af8183aa">
