### PR TITLE
[BUG FIX][NG23-231] Ng student reports link fails

### DIFF
--- a/lib/oli_web/live/delivery/student_dashboard/initial_assigns.ex
+++ b/lib/oli_web/live/delivery/student_dashboard/initial_assigns.ex
@@ -70,7 +70,7 @@ defmodule OliWeb.Delivery.StudentDashboard.InitialAssigns do
     url_params =
       if !is_nil(params["container_id"]), do: %{container_id: params["container_id"]}, else: %{}
 
-    case socket.assigns[:route_name] |> IO.inspect(label: "--- A2 ---") do
+    case socket.assigns[:route_name] do
       :student_dashboard_preview ->
         [
           Breadcrumb.new(%{

--- a/lib/oli_web/live/delivery/student_dashboard/initial_assigns.ex
+++ b/lib/oli_web/live/delivery/student_dashboard/initial_assigns.ex
@@ -2,6 +2,8 @@ defmodule OliWeb.Delivery.StudentDashboard.InitialAssigns do
   @moduledoc """
   Ensure common assigns are applied to all StudentDashboard LiveViews attaching this hook.
   """
+  use OliWeb, :verified_routes
+
   alias OliWeb.Sections.Mount
   alias OliWeb.Common.{Breadcrumb, SessionContext}
   alias OliWeb.Components.Delivery.Utils
@@ -68,7 +70,7 @@ defmodule OliWeb.Delivery.StudentDashboard.InitialAssigns do
     url_params =
       if !is_nil(params["container_id"]), do: %{container_id: params["container_id"]}, else: %{}
 
-    case socket.assigns[:route_name] do
+    case socket.assigns[:route_name] |> IO.inspect(label: "--- A2 ---") do
       :student_dashboard_preview ->
         [
           Breadcrumb.new(%{
@@ -93,14 +95,7 @@ defmodule OliWeb.Delivery.StudentDashboard.InitialAssigns do
           Breadcrumb.new(%{
             full_title: "Student reports",
             link:
-              Routes.live_path(
-                socket,
-                OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive,
-                socket.assigns.section.slug,
-                :reports,
-                :students,
-                url_params
-              )
+              ~p"/sections/#{socket.assigns.section.slug}/instructor_dashboard/overview/students"
           }),
           Breadcrumb.new(%{
             full_title: "#{Utils.user_name(socket.assigns.student)} information"

--- a/test/oli_web/live/delivery/student_dashboard/student_dashboard_live_test.exs
+++ b/test/oli_web/live/delivery/student_dashboard/student_dashboard_live_test.exs
@@ -126,7 +126,7 @@ defmodule OliWeb.Delivery.StudentDashboard.StudentDashboardLiveTest do
         live(conn, live_view_students_dashboard_route(section.slug, student.id))
 
       assert html =~
-               ~s(<a href="/sections/#{section.slug}/instructor_dashboard/reports/students">Student reports</a>)
+               ~s(<a href="/sections/#{section.slug}/instructor_dashboard/overview/students">Student reports</a>)
 
       assert html =~ ~s(#{student.name} information)
     end


### PR DESCRIPTION
Ticket: [NG23-231](https://eliterate.atlassian.net/browse/NG23-231)

This PR fixed an incorrect URL link when navigating back to the Student Reports from the Student Dashboard Content page.

Endpoint: `/sections/__SECTION_SLUG__/student_dashboard/__STUDENT_ID__/content`

[NG23-231]: https://eliterate.atlassian.net/browse/NG23-231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ