### PR TITLE
[FEATURE] [NG23-230] Correctly display time remaining on assignment card

### DIFF
--- a/assets/src/hooks/countdown.ts
+++ b/assets/src/hooks/countdown.ts
@@ -4,14 +4,14 @@ export const Countdown = {
    *
    * This TypeScript module implements a countdown functionality for web elements with the `role="countdown"`
    * attribute. It updates each element's display in real-time, decrementing the time every second from a
-   * specified starting point in "HH:MM:SS" format until it reaches zero.
+   * specified starting point in "DD:HH:MM:SS" or "HH:MM:SS" format until it reaches zero.
    *
    * Use Case:
    * - Suitable for real-time events like timers where a countdown is needed.
    *
    * Features:
    * - Automatically finds and manages multiple countdowns on a single page.
-   * - Converts time format from "HH:MM:SS" to seconds for countdown operation, and updates the display accordingly.
+   * - Converts time format from "DD:HH:MM:SS" or "HH:MM:SS" to seconds for countdown operation, and updates the display accordingly.
    * - Stops the countdown at zero and displays "00:00:00".
    */
 
@@ -45,12 +45,20 @@ export const Countdown = {
   },
 
   timeToSeconds(time: string): number {
-    const [hours, minutes, seconds] = time.split(':').map(Number);
-    return hours * 3600 + minutes * 60 + seconds;
+    const parts = time.split(':').map(Number);
+
+    if (parts.length === 4) {
+      const [days, hours, minutes, seconds] = parts;
+      return days * 86400 + hours * 3600 + minutes * 60 + seconds;
+    } else {
+      const [hours, minutes, seconds] = time.split(':').map(Number);
+      return hours * 3600 + minutes * 60 + seconds;
+    }
   },
 
   secondsToTime(totalSeconds: number): string {
-    const hours = Math.floor(totalSeconds / 3600);
+    const days = Math.floor(totalSeconds / 86400);
+    const hours = Math.floor((totalSeconds % 86400) / 3600);
     const minutes = Math.floor((totalSeconds % 3600) / 60);
     const seconds = totalSeconds % 60;
 
@@ -58,6 +66,11 @@ export const Countdown = {
     const paddedMinutes = minutes.toString().padStart(2, '0');
     const paddedSeconds = seconds.toString().padStart(2, '0');
 
-    return `${paddedHours}:${paddedMinutes}:${paddedSeconds}`;
+    if (days > 0) {
+      const paddedDays = days.toString().padStart(2, '0');
+      return `${paddedDays}:${paddedHours}:${paddedMinutes}:${paddedSeconds}`;
+    } else {
+      return `${paddedHours}:${paddedMinutes}:${paddedSeconds}`;
+    }
   },
 };

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -4320,7 +4320,13 @@ defmodule Oli.Delivery.Sections do
         where:
           ra.section_id == ^section.id and ra.user_id == ^user_id and rev.graded and
             rev.resource_type_id == ^page_resource_type_id and last_att.row_number == 1,
-        group_by: [rev.id, sr.numbering_index, sr.end_date, last_att.lifecycle_state],
+        group_by: [
+          rev.id,
+          sr.numbering_index,
+          sr.end_date,
+          last_att.lifecycle_state,
+          last_att.inserted_at
+        ],
         select:
           map(rev, [
             :id,
@@ -4340,6 +4346,7 @@ defmodule Oli.Delivery.Sections do
           score: max(ra.score),
           out_of: max(ra.out_of),
           progress: max(ra.progress),
+          last_attempt_started_at: last_att.inserted_at,
           last_attempt_state: last_att.lifecycle_state
         }
       )

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -5101,15 +5101,22 @@ defmodule Oli.Delivery.Sections do
   - `user_id`: The ID of the user.
 
   ## Returns
-  A list of tuples, each containing the resource ID and a map with the state and submission date of the last attempt.
+  A list of tuples, each containing the resource ID and a map with the state, submission date and date of insertion of the last attempt.
 
   ## Examples
       iex> get_last_attempt_per_page_id("intro-to-chemistry", 42)
-      [{123, %{state: "completed", date_submitted: ~N[2021-05-23 18:00:00]}}]
+      [{123, %{state: "completed", date_submitted: ~U[2024-06-21 14:11:00Z], inserted_at: ~U[2024-06-21 13:21:59Z]}}]
   """
 
   @spec get_last_attempt_per_page_id(String.t(), integer()) ::
-          list({integer(), %{state: String.t(), date_submitted: NaiveDateTime.t()}})
+          list(
+            {integer(),
+             %{
+               state: String.t(),
+               date_submitted: DateTime.t(),
+               inserted_at: DateTime.t()
+             }}
+          )
   def get_last_attempt_per_page_id(section_slug, user_id) do
     Repo.all(
       ResourceAttempt
@@ -5127,7 +5134,12 @@ defmodule Oli.Delivery.Sections do
       )
       |> select(
         [ra1, a, _, _],
-        {a.resource_id, %{state: ra1.lifecycle_state, date_submitted: ra1.date_submitted}}
+        {a.resource_id,
+         %{
+           state: ra1.lifecycle_state,
+           date_submitted: ra1.date_submitted,
+           inserted_at: ra1.inserted_at
+         }}
       )
     )
   end

--- a/lib/oli_web/components/delivery/student.ex
+++ b/lib/oli_web/components/delivery/student.ex
@@ -303,17 +303,20 @@ defmodule OliWeb.Components.Delivery.Student do
   end
 
   @doc """
-  Calculates the time remaining from the current moment until a specified end date and formats it as "HH:MM:SS".
+  Calculates the time remaining from the current moment until a specified end date
+  and formats it as "DD:HH:MM:SS" or "HH:MM:SS" depending on the duration.
 
   ## Parameters
   - `end_date`: The resource `end_date` as a `DateTime`.
 
   ## Returns
-  - A string representing the formatted time remaining as "HH:MM:SS". If the time difference is negative, it returns "00:00:00".
+  - A string representing the formatted time remaining as "DD:HH:MM:SS" or "HH:MM:SS". If the time difference is negative, it returns "00:00:00".
 
   ## Examples
       iex> format_time_remaining(Timex.shift(Timex.now(), seconds: 3661))
       "01:01:01"
+      iex> format_time_remaining(Timex.shift(Timex.now(), seconds: 266460))
+      "03:02:01:00"
   """
 
   @spec format_time_remaining(DateTime.t()) :: String.t()
@@ -326,15 +329,23 @@ defmodule OliWeb.Components.Delivery.Student do
       Timex.diff(end_date, current_time, :seconds)
       |> max(0)
 
-    # Calculate hours, minutes and seconds
-    hours = div(diff_seconds, 3600)
+    # Calculate days, hours, minutes and seconds
+    days = div(diff_seconds, 86400)
+    hours = div(rem(diff_seconds, 86400), 3600)
     minutes = div(rem(diff_seconds, 3600), 60)
     seconds = rem(diff_seconds, 60)
 
-    # format duration as HH:MM:SS
-    (hours
-     |> Integer.to_string()
-     |> String.pad_leading(2, "0")) <>
+    # Format the duration based on the number of days remaining (DD:HH:MM:SS or HH:MM:SS)
+    days_parsed =
+      (days
+       |> Integer.to_string()
+       |> String.pad_leading(2, "0")) <>
+        ":"
+
+    if(days > 0, do: days_parsed, else: "") <>
+      (hours
+       |> Integer.to_string()
+       |> String.pad_leading(2, "0")) <>
       ":" <>
       (minutes
        |> Integer.to_string()

--- a/lib/oli_web/live/delivery/student/home/components/schedule_component.ex
+++ b/lib/oli_web/live/delivery/student/home/components/schedule_component.ex
@@ -37,7 +37,7 @@ defmodule OliWeb.Delivery.Student.Home.Components.ScheduleComponent do
           <% week_range = Utils.week_range(week, @section_start_date) %>
           <div
             id={"schedule_week_#{week_idx}"}
-            class="flex self-stretch h-fit flex flex-col justify-start items-start gap-3.5 pb-7"
+            class="flex self-stretch h-fit flex-col justify-start items-start gap-3.5 pb-7"
           >
             <div class="flex self-stretch justify-between items-baseline">
               <div role="schedule_title" class="dark:text-white text-lg font-bold tracking-tight">
@@ -243,15 +243,12 @@ defmodule OliWeb.Delivery.Student.Home.Components.ScheduleComponent do
       </div>
       <%= if @resource.last_attempt[:state] == :active do %>
         <div class="justify-end items-end gap-1 flex ml-auto">
-          <div
-            :if={has_end_date?(@resource.effective_settings)}
-            class="justify-end items-end gap-1 flex ml-auto"
-          >
+          <div :if={attempt_expires?(@resource)} class="justify-end items-end gap-1 flex ml-auto">
             <div class="dark:text-white text-opacity-60 text-xs font-semibold ">
               Time Remaining:
             </div>
             <div role="countdown" class="dark:text-white text-xs font-semibold">
-              <%= Student.format_time_remaining(@resource.effective_settings.end_date) %>
+              <%= effective_attempt_expiration_date(@resource) |> Utils.format_time_remaining() %>
             </div>
           </div>
         </div>
@@ -422,10 +419,21 @@ defmodule OliWeb.Delivery.Student.Home.Components.ScheduleComponent do
   defp ordinal_indicator(number) when rem(number, 10) == 3, do: "rd"
   defp ordinal_indicator(_number), do: "th"
 
-  defp has_end_date?(effective_settings) do
-    case effective_settings.end_date do
-      nil -> false
-      _ -> true
-    end
+  defp attempt_expires?(resource) do
+    Utils.attempt_expires?(
+      resource.last_attempt[:state],
+      resource.effective_settings.time_limit,
+      resource.effective_settings.late_submit,
+      resource.effective_settings.end_date
+    )
+  end
+
+  defp effective_attempt_expiration_date(resource) do
+    Utils.effective_attempt_expiration_date(
+      resource.last_attempt[:inserted_at],
+      resource.effective_settings.time_limit,
+      resource.effective_settings.late_submit,
+      resource.effective_settings.end_date
+    )
   end
 end

--- a/lib/oli_web/live/delivery/student/index_live.ex
+++ b/lib/oli_web/live/delivery/student/index_live.ex
@@ -556,7 +556,7 @@ defmodule OliWeb.Delivery.Student.IndexLive do
         </div>
       <% else %>
         <div
-          :if={@lesson.end_date}
+          :if={lesson_expires?(@lesson)}
           class="w-fit h-4 pl-1 justify-center items-start gap-1 inline-flex"
         >
           <div class="opacity-50 text-black dark:text-white text-xs font-normal">
@@ -572,7 +572,7 @@ defmodule OliWeb.Delivery.Student.IndexLive do
               "text-xs font-normal"
             ]}
           >
-            <%= Student.format_time_remaining(@lesson.end_date) %>
+            <%= effective_lesson_expiration_date(@lesson) |> Utils.format_time_remaining() %>
           </div>
         </div>
       <% end %>
@@ -601,16 +601,37 @@ defmodule OliWeb.Delivery.Student.IndexLive do
   defp lesson_details(assigns) do
     ~H"""
     <div role="details" class="pt-2 pb-1 px-1 flex self-stretch justify-between gap-5">
-      <div :if={@lesson.end_date} class="w-fit h-4 pl-1 justify-center items-start gap-1 inline-flex">
+      <div
+        :if={lesson_expires?(@lesson)}
+        class="w-fit h-4 pl-1 justify-center items-start gap-1 inline-flex"
+      >
         <div class="opacity-50 text-black dark:text-white text-xs font-normal">
           Time Remaining:
         </div>
         <div role="countdown" class="text-practice dark:text-practice-dark text-xs font-normal">
-          <%= Student.format_time_remaining(@lesson.end_date) %>
+          <%= effective_lesson_expiration_date(@lesson) |> Utils.format_time_remaining() %>
         </div>
       </div>
     </div>
     """
+  end
+
+  defp lesson_expires?(lesson) do
+    Utils.attempt_expires?(
+      lesson.last_attempt_state,
+      lesson.settings.time_limit,
+      lesson.settings.late_submit,
+      lesson.end_date
+    )
+  end
+
+  defp effective_lesson_expiration_date(lesson) do
+    Utils.effective_attempt_expiration_date(
+      lesson.last_attempt_started_at,
+      lesson.settings.time_limit,
+      lesson.settings.late_submit,
+      lesson.end_date
+    )
   end
 
   defp completed_lesson?(%{graded: true} = assignment),

--- a/lib/oli_web/live/delivery/student/schedule_live.ex
+++ b/lib/oli_web/live/delivery/student/schedule_live.ex
@@ -43,7 +43,7 @@ defmodule OliWeb.Delivery.Student.ScheduleLive do
 
     <div
       id="schedule-view"
-      class="overflow-x-scroll md:overflow-x-auto container mx-auto"
+      class="overflow-x-scroll md:overflow-x-auto container mx-auto h-full"
       phx-hook="Scroller"
     >
       <.schedule
@@ -67,7 +67,7 @@ defmodule OliWeb.Delivery.Student.ScheduleLive do
 
   def schedule(assigns) do
     ~H"""
-    <div class="my-8 px-16">
+    <div class="my-8 px-16" id="schedule_live" phx-hook="Countdown">
       <div class="mb-8">
         Scroll though your course schedule to find all critical due dates and when assignments are due.
         Use this schedule view to see which activities you've completed throughout your time in the course.

--- a/lib/oli_web/live/delivery/student/utils.ex
+++ b/lib/oli_web/live/delivery/student/utils.ex
@@ -525,4 +525,121 @@ defmodule OliWeb.Delivery.Student.Utils do
       score
     end
   end
+
+  @doc """
+  Evaluates if an attempt is expired based on the attempt state and the time limit, late submission policy, and end date.
+  An attempt can expire if its state is :active and either has a time limit and/or disallows late submissions.
+  """
+  @spec attempt_expires?(atom(), integer(), atom(), DateTime.t()) :: boolean()
+  def attempt_expires?(state, time_limit, late_submit, end_date) do
+    case {state, time_limit, late_submit, end_date} do
+      {state, _time_limit, _late_submit, _end_date} when state != :active ->
+        false
+
+      {:active, 0, :allow, _end_date} ->
+        false
+
+      {:active, time_limit, _late_submit, _end_date} when time_limit > 0 ->
+        true
+
+      {:active, _time_limit, :disallow, end_date} when end_date != nil ->
+        true
+
+      {_, _, _, _} ->
+        false
+    end
+  end
+
+  @doc """
+    Calculates the effective expiration date for an attempt based on the inserted date, time limit, late submission policy, and end date.
+
+    ## Parameters:
+    - `inserted_at`: The `DateTime` representing the time the attempt was inserted (when the attempt started).
+    - `time_limit`: The time limit in minutes for the attempt.
+    - `late_submit`: The policy for late submission, either `:allow` or `:disallow`.
+    - `end_date`: The `DateTime` representing the end date of the resource.
+
+    ## Returns:
+    - The effective expiration date for the attempt, which is the earlier of the time limit expiration and the end date (for the case late submissions are not allowed).
+
+    ## Examples:
+        iex> effective_attempt_expiration_date(~U[2024-05-12T00:00:00Z], 60, :allow, ~U[2024-05-12T00:30:00Z])
+        ~U[2024-05-12 01:00:00Z]
+        iex> effective_attempt_expiration_date(~U[2024-05-12T00:00:00Z], 60, :disallow, ~U[2024-05-12T00:30:00Z])
+        ~U[2024-05-12 00:30:00Z]
+        iex> effective_attempt_expiration_date(~U[2024-05-12T00:00:00Z], 15, :disallow, ~U[2024-05-12T00:30:00Z])
+        ~U[2024-05-12 00:15:00Z]
+  """
+  @spec effective_attempt_expiration_date(DateTime.t(), integer(), atom(), DateTime.t()) ::
+          DateTime.t()
+  def effective_attempt_expiration_date(inserted_at, time_limit, late_submit, end_date) do
+    case {inserted_at, time_limit, late_submit, end_date} do
+      {_inserted_at, 0, :disallow, end_date} ->
+        end_date
+
+      {inserted_at, time_limit, :allow, _end_date} when time_limit > 0 ->
+        Timex.shift(inserted_at, minutes: time_limit)
+
+      {inserted_at, time_limit, :disallow, end_date} when time_limit > 0 ->
+        datetime_with_limit = Timex.shift(inserted_at, minutes: time_limit)
+
+        if DateTime.compare(datetime_with_limit, end_date) == :lt,
+          do: datetime_with_limit,
+          else: end_date
+    end
+  end
+
+  @doc """
+  Calculates the time remaining from the current moment until a specified end date
+  and formats it as "DD:HH:MM:SS" or "HH:MM:SS" depending on the duration.
+
+  ## Parameters
+  - `end_date`: The resource `end_date` as a `DateTime`.
+
+  ## Returns
+  - A string representing the formatted time remaining as "DD:HH:MM:SS" or "HH:MM:SS". If the time difference is negative, it returns "00:00:00".
+
+  ## Examples
+      iex> format_time_remaining(Timex.shift(Timex.now(), seconds: 3661))
+      "01:01:01"
+      iex> format_time_remaining(Timex.shift(Timex.now(), seconds: 266460))
+      "03:02:01:00"
+  """
+
+  @spec format_time_remaining(DateTime.t()) :: String.t()
+  def format_time_remaining(end_date) do
+    # Get the current time
+    current_time = Oli.DateTime.utc_now()
+
+    # Calculate the difference in seconds, clamp negative values to 0
+    diff_seconds =
+      Timex.diff(end_date, current_time, :seconds)
+      |> max(0)
+
+    # Calculate days, hours, minutes and seconds
+    days = div(diff_seconds, 86400)
+    hours = div(rem(diff_seconds, 86400), 3600)
+    minutes = div(rem(diff_seconds, 3600), 60)
+    seconds = rem(diff_seconds, 60)
+
+    # Format the duration based on the number of days remaining (DD:HH:MM:SS or HH:MM:SS)
+    days_parsed =
+      (days
+       |> Integer.to_string()
+       |> String.pad_leading(2, "0")) <>
+        ":"
+
+    if(days > 0, do: days_parsed, else: "") <>
+      (hours
+       |> Integer.to_string()
+       |> String.pad_leading(2, "0")) <>
+      ":" <>
+      (minutes
+       |> Integer.to_string()
+       |> String.pad_leading(2, "0")) <>
+      ":" <>
+      (seconds
+       |> Integer.to_string()
+       |> String.pad_leading(2, "0"))
+  end
 end

--- a/test/oli_web/live/delivery/student/home/components/schedule_component_test.exs
+++ b/test/oli_web/live/delivery/student/home/components/schedule_component_test.exs
@@ -405,9 +405,9 @@ defmodule OliWeb.Delivery.Student.Home.Components.ScheduleComponentTest do
       assert has_element?(lcd, ~s{#schedule_item_1_1 div[role="details"]}, "Last Submitted")
       assert has_element?(lcd, ~s{#schedule_item_1_1 div[role="details"]}, "Tue May 7, 2024")
 
-      # Exploration 1 is in progress and displays remaining time
+      # Exploration 1 is in progress and does not display remaining time (since the attempt does not have time limit)
       assert has_element?(lcd, ~s{#schedule_item_2_1 div[role="details"]}, "Attempt 1 of ∞")
-      assert has_element?(lcd, ~s{#schedule_item_2_1 div[role="details"]}, "Time Remaining")
+      refute has_element?(lcd, ~s{#schedule_item_2_1 div[role="details"]}, "Time Remaining")
     end
 
     test "it expands a lesson group", %{

--- a/test/oli_web/live/delivery/student/index_live_test.exs
+++ b/test/oli_web/live/delivery/student/index_live_test.exs
@@ -299,7 +299,8 @@ defmodule OliWeb.Delivery.Student.IndexLiveTest do
     Sections.get_section_resource(section.id, page_4_revision.resource_id)
     |> Sections.update_section_resource(%{
       start_date: ~U[2023-11-04 20:00:00Z],
-      end_date: ~U[2023-11-05 20:00:00Z]
+      end_date: ~U[2023-11-05 20:00:00Z],
+      time_limit: 75
     })
 
     Sections.get_section_resource(section.id, page_5_revision.resource_id)
@@ -475,6 +476,7 @@ defmodule OliWeb.Delivery.Student.IndexLiveTest do
       :resource_attempt,
       Map.merge(attempt_attrs, %{
         resource_access: resource_access,
+        inserted_at: opts[:inserted_at] || DateTime.utc_now(),
         revision: revision,
         lifecycle_state: opts[:attempt_state],
         date_submitted:
@@ -1056,7 +1058,8 @@ defmodule OliWeb.Delivery.Student.IndexLiveTest do
 
       set_progress(section.id, page_4.resource_id, user.id, 0.5, page_4,
         attempt_state: :active,
-        updated_at: ~U[2023-11-01 21:00:00Z]
+        updated_at: ~U[2023-11-01 21:00:00Z],
+        inserted_at: ~U[2024-04-22 21:00:00Z]
       )
 
       set_progress(section.id, page_3.resource_id, user.id, 0.3, page_3,
@@ -1120,7 +1123,7 @@ defmodule OliWeb.Delivery.Student.IndexLiveTest do
       assert has_element?(
                view,
                second_assignment <> ~s{div[role=details] div[role=countdown]},
-               "00:00:00"
+               "01:15:00"
              )
 
       # Third latest assignment


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/NG23-230) to the ticket

#### Different time-remaining formats
![image](https://github.com/Simon-Initiative/oli-torus/assets/74839302/47c84053-9c5c-4804-aae6-d6869dcfb3ef)

#### Transition countdown from day-time-remaining to hour-time-remaining format
https://github.com/Simon-Initiative/oli-torus/assets/74839302/0706647a-bdb7-4bcf-9d2f-3852ea05704b

#### Show time-remaining when there is an active attempt with a time limit (late submission allowed)
https://github.com/Simon-Initiative/oli-torus/assets/74839302/7624ca2c-10de-488a-a5f3-3b6d27191c6f

#### Show time-remaining when there is an active attempt with late submission disallowed (and no time limit)
https://github.com/Simon-Initiative/oli-torus/assets/74839302/4f886ee5-aef9-4f84-814b-4d92c3ea2f8b

#### Time remaining when the end date (with late submission disallowed) is before the date considering the time limit
https://github.com/Simon-Initiative/oli-torus/assets/74839302/5893ed63-3b96-4750-ae7a-67861989d08e

#### Time remaining when the date considering the time limit is before the end date (with late submission disallowed).
https://github.com/Simon-Initiative/oli-torus/assets/74839302/6ae7b6c4-55e7-4116-8d6b-fbc5acf88cd1

#### This time-remaining logic and formatting were implemented/homologated across components
https://github.com/Simon-Initiative/oli-torus/assets/74839302/d4792d36-ab7d-48aa-ae53-b4c4c6fa00dc
