### PR TITLE
[BUG FIX] [NG23-227] Fix Contained Objectives Builder

### DIFF
--- a/lib/oli/delivery/sections/contained_objectives_builder.ex
+++ b/lib/oli/delivery/sections/contained_objectives_builder.ex
@@ -4,6 +4,8 @@ defmodule Oli.Delivery.Sections.ContainedObjectivesBuilder do
     unique: [keys: [:section_slug]],
     max_attempts: 1
 
+  import Ecto.Query, only: [from: 2]
+
   alias Oli.Delivery.Sections.{ContainedObjective, Section}
   alias Oli.Delivery.Sections
   alias Oli.Repo

--- a/lib/oli/delivery/sections/contained_objectives_builder.ex
+++ b/lib/oli/delivery/sections/contained_objectives_builder.ex
@@ -21,9 +21,14 @@ defmodule Oli.Delivery.Sections.ContainedObjectivesBuilder do
     }
 
     Multi.new()
+    |> Multi.run(:section, &find_section_by_slug(&1, &2, section_slug))
     |> Multi.run(
       :contained_objectives,
       &Sections.build_contained_objectives(&1, &2, section_slug)
+    )
+    |> Multi.delete_all(
+      :delete_all_objectives,
+      &from(ContainedObjective, where: [section_id: ^&1.section.id])
     )
     |> Multi.insert_all(
       :inserted_contained_objectives,
@@ -31,7 +36,6 @@ defmodule Oli.Delivery.Sections.ContainedObjectivesBuilder do
       &objectives_with_timestamps(&1, timestamps),
       placeholders: placeholders
     )
-    |> Multi.run(:section, &find_section_by_slug(&1, &2, section_slug))
     |> Multi.update(
       :done_section,
       &Section.changeset(&1.section, %{v25_migration: :done})

--- a/lib/oli_web/components/delivery/learning_objectives/learning_objectives.ex
+++ b/lib/oli_web/components/delivery/learning_objectives/learning_objectives.ex
@@ -5,6 +5,7 @@ defmodule OliWeb.Components.Delivery.LearningObjectives do
   alias OliWeb.Common.Params
   alias OliWeb.Common.SearchInput
   alias OliWeb.Components.Delivery.CardHighlights
+  alias Oli.Delivery.Sections.Section
   alias OliWeb.Delivery.LearningObjectives.ObjectivesTableModel
   alias OliWeb.Router.Helpers, as: Routes
   alias Phoenix.LiveView.JS
@@ -93,7 +94,7 @@ defmodule OliWeb.Components.Delivery.LearningObjectives do
        patch_url_type: assigns.patch_url_type,
        section_slug: section.slug,
        units_modules: objectives_tab.filter_options,
-       filter_disabled?: filter_by_module_disabled?(section, objectives_tab.objectives),
+       filter_disabled?: filter_by_module_disabled?(section),
        view: assigns[:view],
        proficiency_options: proficiency_options,
        selected_proficiency_options: selected_proficiency_options,
@@ -672,11 +673,6 @@ defmodule OliWeb.Components.Delivery.LearningObjectives do
   This happens when the contained objectives for the section were not yet created.
   """
 
-  defp filter_by_module_disabled?(section, objectives) do
-    section.v25_migration != :done or
-      Enum.any?(
-        objectives,
-        &(&1.container_ids == [] or &1.container_ids == nil)
-      )
-  end
+  defp filter_by_module_disabled?(%Section{v25_migration: :done}), do: false
+  defp filter_by_module_disabled?(_), do: true
 end

--- a/priv/repo/migrations/20240621171337_create_get_activity_references_function.exs
+++ b/priv/repo/migrations/20240621171337_create_get_activity_references_function.exs
@@ -1,0 +1,62 @@
+defmodule Oli.Repo.Migrations.CreateGetActivityReferencesFunction do
+  use Ecto.Migration
+
+  @doc """
+  Defines a recursive function to search for activities within the content of a page.
+
+  The migration creates two PostgreSQL functions:
+
+  1. `get_activity_references(content jsonb)`: This function processes the JSONB content recursively.
+     It searches for objects with the type `activity-reference` and returns their `activity_id`.
+     If the object has children, it recursively processes each child.
+
+  2. `get_all_activity_references(content jsonb)`: This function processes the top-level `model` array
+     in the JSONB content and uses `get_activity_references` to find all `activity_id` values in the content.
+
+  These functions help in extracting all activity references from nested content structures in a page.
+  """
+  def up do
+    execute """
+        CREATE OR REPLACE FUNCTION get_activity_references(content jsonb)
+        RETURNS TABLE(activity_id int) AS $$
+        DECLARE
+            child jsonb;
+        BEGIN
+            -- Process the current level
+            IF content @> '{"type": "activity-reference"}' THEN
+                RETURN QUERY SELECT (content->>'activity_id')::int;
+            END IF;
+
+            -- Process children if exists
+            FOR child IN SELECT * FROM jsonb_array_elements(content->'children')
+            LOOP
+                RETURN QUERY SELECT * FROM get_activity_references(child);
+            END LOOP;
+
+            RETURN;
+        END;
+        $$ LANGUAGE plpgsql;
+    """
+
+    flush()
+
+    execute """
+    CREATE OR REPLACE FUNCTION get_all_activity_references(content jsonb)
+    RETURNS TABLE(activity_id int) AS $$
+    BEGIN
+        RETURN QUERY
+        SELECT ar.activity_id
+        FROM jsonb_array_elements(content->'model') AS model_element,
+        LATERAL get_activity_references(model_element) AS ar;
+    END;
+    $$ LANGUAGE plpgsql;
+    """
+  end
+
+  def down do
+    execute """
+    DROP FUNCTION IF EXISTS get_all_activity_references(content jsonb);
+    DROP FUNCTION IF EXISTS get_activity_references(content jsonb);
+    """
+  end
+end

--- a/test/mix/tasks/create_contained_objectives_test.exs
+++ b/test/mix/tasks/create_contained_objectives_test.exs
@@ -57,5 +57,46 @@ defmodule Mix.Tasks.CreateContainedObjectivesTest do
       assert Sections.get_section_by(slug: section_2.slug).v25_migration ==
                section_2.v25_migration
     end
+
+    test "enqueues all sections and set them as pending when --all flag is passed" do
+      [section_1, section_2] = Factory.insert_list(2, :section, v25_migration: :not_started)
+      section_3 = Factory.insert(:section, v25_migration: :pending)
+      section_4 = Factory.insert(:section, v25_migration: :done)
+
+      assert :ok == CreateContainedObjectives.run(["--all"])
+
+      assert_enqueued(
+        worker: ContainedObjectivesBuilder,
+        args: %{
+          "section_slug" => section_1.slug
+        }
+      )
+
+      assert_enqueued(
+        worker: ContainedObjectivesBuilder,
+        args: %{
+          "section_slug" => section_2.slug
+        }
+      )
+
+      assert_enqueued(
+        worker: ContainedObjectivesBuilder,
+        args: %{
+          "section_slug" => section_3.slug
+        }
+      )
+
+      assert_enqueued(
+        worker: ContainedObjectivesBuilder,
+        args: %{
+          "section_slug" => section_4.slug
+        }
+      )
+
+      assert Sections.get_section_by(slug: section_1.slug).v25_migration == :pending
+      assert Sections.get_section_by(slug: section_2.slug).v25_migration == :pending
+      assert Sections.get_section_by(slug: section_3.slug).v25_migration == :pending
+      assert Sections.get_section_by(slug: section_4.slug).v25_migration == :pending
+    end
   end
 end

--- a/test/oli/delivery/sections/contained_objectives_builder_test.exs
+++ b/test/oli/delivery/sections/contained_objectives_builder_test.exs
@@ -112,6 +112,32 @@ defmodule Oli.Delivery.Sections.ContainedObjectivesBuilderTest do
 
       assert Sections.get_section_by(slug: section.slug).v25_migration == :done
     end
+
+    test "it is idempotent", %{
+      section: section,
+      resources: resources
+    } do
+      for _ <- 1..2 do
+        assert {:ok, _} = perform_job(ContainedObjectivesBuilder, %{section_slug: section.slug})
+
+        # Check all contained objectives
+        root_container_objectives = Sections.get_section_contained_objectives(section.id, nil)
+
+        # C, C1, D, E and F are the objectives attached to the inner activities
+        assert length(root_container_objectives) == 5
+
+        assert Enum.sort(root_container_objectives) ==
+                 Enum.sort([
+                   resources.obj_resource_c.id,
+                   resources.obj_resource_c1.id,
+                   resources.obj_resource_d.id,
+                   resources.obj_resource_e.id,
+                   resources.obj_resource_f.id
+                 ])
+
+        assert Sections.get_section_by(slug: section.slug).v25_migration == :done
+      end
+    end
   end
 
   describe "given a section without objectives" do

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -1333,12 +1333,22 @@ defmodule Oli.TestHelpers do
         obj_resource_a.id
       ])
 
+    # Page with grouped activities
+    page_2_model = [
+      %{
+        "type" => "group",
+        "id" => 1,
+        "purpose" => "didigetthis",
+        "children" => build_content_for_page.([act_resource_y.id, act_resource_z.id])
+      }
+    ]
+
     {page_resource_2, page_revision_2} =
       create_page(
         "Page 2",
         "page_2",
         project,
-        build_content_for_page.([act_resource_y.id, act_resource_z.id]),
+        page_2_model,
         [obj_resource_b.id]
       )
 


### PR DESCRIPTION
[NG23-227](https://eliterate.atlassian.net/browse/NG23-227)

Fixes the issue where many contained objectives records were not inserted when running the Contained Objectives creation task or remixing a course section.
The cause was a bad assumption of the page's content structure: the logic assumed that objects with the `activity-reference` type were only at the top level of the model, and they could be at any level.


## Technical notes:
The bugfix consists of a recursive function written in PostgreSQL, that receives a `jsonb` representing a page's content and recursively iterates over the nested structure to find all the activity ids. Another solution could be to implement the same function in Elixir, which would force the query to load all the page contents for a course in memory, and in big courses that could not be optimal. The SQL function not only avoids that, but it also reduces the query's processing time.

Here are the results when running the query for the RealCHEM course locally, before and after  the solution. Note that the processing times decrease after the fix, except for the contained-objectives-creation time that obviously increased since we are inserting 800 more rows.

 ### **Without `psql` function**
 build_contained_objectives pages: **717.81075ms**
 build_contained_objectives activities: **199.85220800000002ms**
 build_contained_objectives contained_objectives: **0.147708ms**
contained_objectives_count: **48**

 ### **With `psql` function**
 build_contained_objectives pages: **155.04484200000002ms**
 build_contained_objectives activities: **24.20246ms**
 build_contained_objectives contained_objectives: **1.038736ms**
 contained_objectives_count: **848**

## Testing notes:
For testing and running the fix in prod, someone with console access should run the mix task again but with the `--all` flag to remove all the existing contained objectives and create new ones.

`mix create_contained_objectives --all`

[NG23-227]: https://eliterate.atlassian.net/browse/NG23-227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ