### PR TITLE
[BUG FIX] [NG23-252] Learning objective proficiency at page does not consider child learning objective

### DIFF
--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -665,6 +665,96 @@ defmodule Oli.Delivery.Metrics do
     |> Enum.into(%{})
   end
 
+  @doc """
+  Given a list of objective revisions it calculates the aggregated proficiency for each of those objectives
+  for a given student in a given course.
+
+  It returns a map:
+
+  %{
+    objective_1_resource_id: "Low",
+    ...
+    objective_n_resource_id: "Medium"
+  }
+
+  This implementation considers that an objective may have sub-objectives.
+  In that case, the proficiency for the given objectives will result from the aggregated raw proficiency of its contained sub-objectives.
+
+  Example:
+    Given the following parent-child learning objectives relationship:
+      - Objective 1:
+        - Sub-objective A (1 correct out of 1 attempt - resource_id: 1)
+        - Sub-objective B (0 correct out of 1 attempt - resource_id: 2)
+        - Sub-objective C (1 correct out of 1 attempt - resource_id: 3)
+
+      - Objective 2 (0 correct out of 1 attempt)
+
+      - Objective 3 (1 correct out of 1 attempt)
+
+    The student proficiency per objective will be:
+      - Objective 1: 2 correct out of 3 => 0.66 => "Low" (this proficiency is the result of agregating its sub-objectives)
+      - Objective 2: 0 correct out of 1 => 0.00 => "Medium"
+      - Objective 3: 1 correct out of 1 => 1.00 => "High"
+
+      %{1 => "Low", 2 => "Medium", 3 => "High"}
+  """
+
+  @spec proficiency_for_student_per_learning_objective(
+          learning_objectives :: [%Revision{}],
+          student_id :: integer,
+          section :: %Oli.Delivery.Sections.Section{}
+        ) :: map
+  def proficiency_for_student_per_learning_objective(
+        learning_objectives,
+        student_id,
+        section
+      ) do
+    unique_objective_and_subobjective_ids =
+      Enum.flat_map(learning_objectives, fn rev -> [rev.resource_id | rev.children] end)
+      |> Enum.uniq()
+
+    raw_proficiency_per_learning_objective =
+      raw_proficiency_for_student_per_learning_objective(
+        section,
+        student_id,
+        unique_objective_and_subobjective_ids
+      )
+
+    Enum.into(learning_objectives, %{}, fn rev ->
+      aggregated_proficiency =
+        if rev.children == [] do
+          [
+            Map.get(
+              raw_proficiency_per_learning_objective,
+              rev.resource_id,
+              nil
+            )
+          ]
+        else
+          Enum.map(rev.children, fn subobjective_id ->
+            Map.get(raw_proficiency_per_learning_objective, subobjective_id)
+          end)
+        end
+        |> Enum.reject(&is_nil/1)
+        |> aggregate_raw_proficiency()
+
+      {rev.resource_id, aggregated_proficiency}
+    end)
+  end
+
+  defp aggregate_raw_proficiency([]), do: proficiency_range(nil)
+
+  defp aggregate_raw_proficiency(raw_values) do
+    {total_correct, total_count} =
+      Enum.reduce(raw_values, {0, 0}, fn {correct, count}, acc ->
+        {correct + elem(acc, 0), count + elem(acc, 1)}
+      end)
+
+    proficiency_value = if total_count == 0, do: 0, else: total_correct / total_count
+
+    proficiency_range(proficiency_value)
+  end
+
   def raw_proficiency_per_learning_objective(%Section{analytics_version: :v1, slug: section_slug}) do
     query =
       from(sn in Snapshot,
@@ -709,9 +799,25 @@ defmodule Oli.Delivery.Metrics do
   end
 
   def raw_proficiency_for_student_per_learning_objective(
+        section,
+        studend_id,
+        objective_ids \\ nil
+      )
+
+  def raw_proficiency_for_student_per_learning_objective(
         %Section{analytics_version: :v1, slug: section_slug},
-        student_id
+        student_id,
+        objective_ids
       ) do
+    filter_by_objective_id =
+      case objective_ids do
+        nil ->
+          true
+
+        _ ->
+          dynamic([sn, _s], sn.objective_id in ^objective_ids)
+      end
+
     query =
       from(sn in Snapshot,
         join: s in Section,
@@ -719,6 +825,7 @@ defmodule Oli.Delivery.Metrics do
         where:
           sn.attempt_number == 1 and sn.part_attempt_number == 1 and s.slug == ^section_slug and
             sn.user_id == ^student_id,
+        where: ^filter_by_objective_id,
         group_by: sn.objective_id,
         select:
           {sn.objective_id,
@@ -734,9 +841,19 @@ defmodule Oli.Delivery.Metrics do
 
   def raw_proficiency_for_student_per_learning_objective(
         %Section{analytics_version: :v2, id: section_id},
-        student_id
+        student_id,
+        objective_ids
       ) do
     objective_type_id = Oli.Resources.ResourceType.id_for_objective()
+
+    filter_by_objective_id =
+      case objective_ids do
+        nil ->
+          true
+
+        _ ->
+          dynamic([summary], summary.resource_id in ^objective_ids)
+      end
 
     query =
       from(summary in Oli.Analytics.Summary.ResourceSummary,
@@ -746,6 +863,7 @@ defmodule Oli.Delivery.Metrics do
             summary.publication_id == -1 and
             summary.user_id == ^student_id and
             summary.resource_type_id == ^objective_type_id,
+        where: ^filter_by_objective_id,
         select: {
           summary.resource_id,
           summary.num_first_attempts_correct,
@@ -1155,77 +1273,6 @@ defmodule Oli.Delivery.Metrics do
     Repo.all(query)
     |> Enum.into(%{}, fn {page_id, proficiency} ->
       {page_id, proficiency_range(proficiency)}
-    end)
-  end
-
-  @doc """
-  Calculates the learning proficiency ("High", "Medium", "Low", "Not enough data")
-  for a given student in a given section.
-
-      It returns a map:
-
-      %{objective_id_1 => "High",
-        ...
-        objective_id_n => "Low"
-      }
-  """
-  @spec proficiency_for_student_per_learning_objective(
-          section :: %Oli.Delivery.Sections.Section{},
-          student_id :: integer
-        ) :: map
-  def proficiency_for_student_per_learning_objective(
-        %Section{slug: section_slug, analytics_version: :v1},
-        student_id
-      ) do
-    query =
-      from(sn in Snapshot,
-        join: s in Section,
-        on: sn.section_id == s.id,
-        where:
-          sn.attempt_number == 1 and sn.part_attempt_number == 1 and s.slug == ^section_slug and
-            sn.user_id == ^student_id,
-        group_by: sn.objective_id,
-        select:
-          {sn.objective_id,
-           fragment(
-             "CAST(COUNT(CASE WHEN ? THEN 1 END) as float) / CAST(COUNT(*) as float)",
-             sn.correct
-           )}
-      )
-
-    Repo.all(query)
-    |> Enum.into(%{}, fn {objective_id, proficiency} ->
-      {objective_id, proficiency_range(proficiency)}
-    end)
-  end
-
-  def proficiency_for_student_per_learning_objective(
-        %Section{id: section_id, analytics_version: :v2},
-        student_id
-      ) do
-    objective_type_id = Oli.Resources.ResourceType.id_for_objective()
-
-    query =
-      from(summary in Oli.Analytics.Summary.ResourceSummary,
-        where:
-          summary.section_id == ^section_id and
-            summary.project_id == -1 and
-            summary.publication_id == -1 and
-            summary.user_id == ^student_id and
-            summary.resource_type_id == ^objective_type_id,
-        group_by: summary.resource_id,
-        select:
-          {summary.resource_id,
-           fragment(
-             "CAST(SUM(?) as float) / NULLIF(CAST(SUM(?) as float), 0.0)",
-             summary.num_first_attempts_correct,
-             summary.num_first_attempts
-           )}
-      )
-
-    Repo.all(query)
-    |> Enum.into(%{}, fn {objective_id, proficiency} ->
-      {objective_id, proficiency_range(proficiency)}
     end)
   end
 

--- a/lib/oli/publishing/delivery_resolver.ex
+++ b/lib/oli/publishing/delivery_resolver.ex
@@ -97,6 +97,8 @@ defmodule Oli.Publishing.DeliveryResolver do
     |> Repo.all()
   end
 
+  def objectives_by_resource_ids(nil, _section_slug), do: []
+
   def objectives_by_resource_ids(resource_ids, section_slug) do
     from([_sr, _s, _spp, _pr, rev] in section_resource_revisions(section_slug),
       where: rev.resource_id in ^resource_ids,

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -799,34 +799,34 @@ defmodule OliWeb.Delivery.Student.LessonLive do
     %{page_context: %{page: page}, current_user: current_user, section: section} =
       socket.assigns
 
+    page_attached_objectives =
+      Resolver.objectives_by_resource_ids(page.objectives["attached"], section.slug)
+
+    student_proficiency_per_page_level_learning_objective =
+      Metrics.proficiency_for_student_per_learning_objective(
+        page_attached_objectives,
+        current_user.id,
+        section
+      )
+
     objectives =
-      case page.objectives["attached"] do
-        objective_ids when objective_ids in [nil, []] ->
-          []
-
-        objective_resource_ids ->
-          student_proficiency_per_learning_objective =
-            Metrics.proficiency_for_student_per_learning_objective(
-              section,
-              current_user.id
+      page_attached_objectives
+      |> Enum.map(fn rev ->
+        %{
+          resource_id: rev.resource_id,
+          title: rev.title,
+          proficiency:
+            Map.get(
+              student_proficiency_per_page_level_learning_objective,
+              rev.resource_id,
+              "Not enough data"
             )
+        }
+      end)
 
-          Resolver.objectives_by_resource_ids(objective_resource_ids, section.slug)
-          |> Enum.map(fn rev ->
-            %{
-              resource_id: rev.resource_id,
-              title: rev.title,
-              proficiency:
-                Map.get(
-                  student_proficiency_per_learning_objective,
-                  rev.resource_id,
-                  "Not enough data"
-                )
-            }
-          end)
-      end
-
-    assign(socket, objectives: objectives)
+    assign(socket,
+      objectives: objectives
+    )
   end
 
   defp get_post(socket, post_id) do

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -11,7 +11,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
   alias Oli.Delivery.Metrics
   alias Oli.Delivery.Page.PageContext
   alias Oli.Delivery.Sections
-  alias Oli.Resources
+  alias Oli.Publishing.DeliveryResolver, as: Resolver
   alias Oli.Resources.Collaboration
   alias Oli.Resources.Collaboration.CollabSpaceConfig
   alias OliWeb.Delivery.Student.Utils
@@ -811,7 +811,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
               current_user.id
             )
 
-          Resources.get_revisions_by_resource_id(objective_resource_ids)
+          Resolver.objectives_by_resource_ids(objective_resource_ids, section.slug)
           |> Enum.map(fn rev ->
             %{
               resource_id: rev.resource_id,

--- a/lib/oli_web/live/delivery/student/prologue_live.ex
+++ b/lib/oli_web/live/delivery/student/prologue_live.ex
@@ -291,34 +291,34 @@ defmodule OliWeb.Delivery.Student.PrologueLive do
     %{page_context: %{page: page}, current_user: current_user, section: section} =
       socket.assigns
 
+    page_attached_objectives =
+      Resolver.objectives_by_resource_ids(page.objectives["attached"], section.slug)
+
+    student_proficiency_per_page_level_learning_objective =
+      Metrics.proficiency_for_student_per_learning_objective(
+        page_attached_objectives,
+        current_user.id,
+        section
+      )
+
     objectives =
-      case page.objectives["attached"] do
-        objective_ids when objective_ids in [nil, []] ->
-          []
-
-        objective_resource_ids ->
-          student_proficiency_per_learning_objective =
-            Metrics.proficiency_for_student_per_learning_objective(
-              section,
-              current_user.id
+      page_attached_objectives
+      |> Enum.map(fn rev ->
+        %{
+          resource_id: rev.resource_id,
+          title: rev.title,
+          proficiency:
+            Map.get(
+              student_proficiency_per_page_level_learning_objective,
+              rev.resource_id,
+              "Not enough data"
             )
+        }
+      end)
 
-          Resolver.objectives_by_resource_ids(objective_resource_ids, section.slug)
-          |> Enum.map(fn rev ->
-            %{
-              resource_id: rev.resource_id,
-              title: rev.title,
-              proficiency:
-                Map.get(
-                  student_proficiency_per_learning_objective,
-                  rev.resource_id,
-                  "Not enough data"
-                )
-            }
-          end)
-      end
-
-    assign(socket, objectives: objectives)
+    assign(socket,
+      objectives: objectives
+    )
   end
 
   defp get_max_attempts(%{effective_settings: %{max_attempts: 0}} = _page_context),

--- a/lib/oli_web/live/delivery/student/prologue_live.ex
+++ b/lib/oli_web/live/delivery/student/prologue_live.ex
@@ -8,7 +8,7 @@ defmodule OliWeb.Delivery.Student.PrologueLive do
   alias Oli.Delivery.Attempts.PageLifecycle
   alias Oli.Delivery.Metrics
   alias Oli.Delivery.Settings
-  alias Oli.Resources
+  alias Oli.Publishing.DeliveryResolver, as: Resolver
   alias OliWeb.Common.FormatDateTime
   alias OliWeb.Components.Modal
   alias OliWeb.Delivery.Student.Utils
@@ -303,7 +303,7 @@ defmodule OliWeb.Delivery.Student.PrologueLive do
               current_user.id
             )
 
-          Resources.get_revisions_by_resource_id(objective_resource_ids)
+          Resolver.objectives_by_resource_ids(objective_resource_ids, section.slug)
           |> Enum.map(fn rev ->
             %{
               resource_id: rev.resource_id,

--- a/lib/oli_web/live/delivery/student/review_live.ex
+++ b/lib/oli_web/live/delivery/student/review_live.ex
@@ -46,34 +46,34 @@ defmodule OliWeb.Delivery.Student.ReviewLive do
     %{page_context: %{page: page}, current_user: current_user, section: section} =
       socket.assigns
 
+    page_attached_objectives =
+      Resolver.objectives_by_resource_ids(page.objectives["attached"], section.slug)
+
+    student_proficiency_per_page_level_learning_objective =
+      Metrics.proficiency_for_student_per_learning_objective(
+        page_attached_objectives,
+        current_user.id,
+        section
+      )
+
     objectives =
-      case page.objectives["attached"] do
-        objective_ids when objective_ids in [nil, []] ->
-          []
-
-        objective_resource_ids ->
-          student_proficiency_per_learning_objective =
-            Metrics.proficiency_for_student_per_learning_objective(
-              section,
-              current_user.id
+      page_attached_objectives
+      |> Enum.map(fn rev ->
+        %{
+          resource_id: rev.resource_id,
+          title: rev.title,
+          proficiency:
+            Map.get(
+              student_proficiency_per_page_level_learning_objective,
+              rev.resource_id,
+              "Not enough data"
             )
+        }
+      end)
 
-          Resolver.objectives_by_resource_ids(objective_resource_ids, section.slug)
-          |> Enum.map(fn rev ->
-            %{
-              resource_id: rev.resource_id,
-              title: rev.title,
-              proficiency:
-                Map.get(
-                  student_proficiency_per_learning_objective,
-                  rev.resource_id,
-                  "Not enough data"
-                )
-            }
-          end)
-      end
-
-    assign(socket, objectives: objectives)
+    assign(socket,
+      objectives: objectives
+    )
   end
 
   defp review_allowed?(page_context),

--- a/lib/oli_web/live/delivery/student/review_live.ex
+++ b/lib/oli_web/live/delivery/student/review_live.ex
@@ -11,7 +11,6 @@ defmodule OliWeb.Delivery.Student.ReviewLive do
   alias Oli.Delivery.Page.PageContext
   alias Oli.Delivery.Metrics
   alias Oli.Publishing.DeliveryResolver, as: Resolver
-  alias Oli.Resources
   alias OliWeb.Delivery.Student.Utils
 
   def mount(
@@ -59,7 +58,7 @@ defmodule OliWeb.Delivery.Student.ReviewLive do
               current_user.id
             )
 
-          Resources.get_revisions_by_resource_id(objective_resource_ids)
+          Resolver.objectives_by_resource_ids(objective_resource_ids, section.slug)
           |> Enum.map(fn rev ->
             %{
               resource_id: rev.resource_id,

--- a/test/oli/delivery/metrics/learning_proficiency_test.exs
+++ b/test/oli/delivery/metrics/learning_proficiency_test.exs
@@ -25,6 +25,26 @@ defmodule Oli.Delivery.Metrics.LearningProficiencyTest do
     project = insert(:project, authors: [author])
 
     # revisions...
+
+    ## subobjectives
+    subobjective_a_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.id_for_objective(),
+        title: "Sub-objective A"
+      )
+
+    subobjective_b_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.id_for_objective(),
+        title: "Sub-objective B"
+      )
+
+    subobjective_c_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.id_for_objective(),
+        title: "Sub-objective C"
+      )
+
     ## objectives
     objective_1_revision =
       insert(:revision,
@@ -48,6 +68,17 @@ defmodule Oli.Delivery.Metrics.LearningProficiencyTest do
       insert(:revision,
         resource_type_id: ResourceType.id_for_objective(),
         title: "Objective 4"
+      )
+
+    objective_5_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.id_for_objective(),
+        title: "Objective 5",
+        children: [
+          subobjective_a_revision.resource_id,
+          subobjective_b_revision.resource_id,
+          subobjective_c_revision.resource_id
+        ]
       )
 
     ## pages...
@@ -79,6 +110,13 @@ defmodule Oli.Delivery.Metrics.LearningProficiencyTest do
         title: "Page 4"
       )
 
+    page_5_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.id_for_page(),
+        objectives: %{"attached" => [objective_5_revision.resource_id]},
+        title: "Page 5"
+      )
+
     ## modules...
     module_1_revision =
       insert(:revision, %{
@@ -96,7 +134,11 @@ defmodule Oli.Delivery.Metrics.LearningProficiencyTest do
         resource: insert(:resource),
         objectives: %{},
         resource_type_id: Oli.Resources.ResourceType.id_for_container(),
-        children: [page_3_revision.resource_id, page_4_revision.resource_id],
+        children: [
+          page_3_revision.resource_id,
+          page_4_revision.resource_id,
+          page_5_revision.resource_id
+        ],
         content: %{},
         deleted: false,
         title: "Module 2"
@@ -137,166 +179,49 @@ defmodule Oli.Delivery.Metrics.LearningProficiencyTest do
         title: "Root Container"
       })
 
+    all_revisions =
+      [
+        subobjective_a_revision,
+        subobjective_b_revision,
+        subobjective_c_revision,
+        objective_1_revision,
+        objective_2_revision,
+        objective_3_revision,
+        objective_4_revision,
+        objective_5_revision,
+        page_1_revision,
+        page_2_revision,
+        page_3_revision,
+        page_4_revision,
+        page_5_revision,
+        module_1_revision,
+        module_2_revision,
+        unit_1_revision,
+        unit_2_revision,
+        container_revision
+      ]
+
     # asociate resources to project
-    insert(:project_resource, %{
-      project_id: project.id,
-      resource_id: objective_1_revision.resource_id
-    })
+    Enum.each(all_revisions, fn revision ->
+      insert(:project_resource, %{
+        project_id: project.id,
+        resource_id: revision.resource_id
+      })
+    end)
 
-    insert(:project_resource, %{
-      project_id: project.id,
-      resource_id: objective_2_revision.resource_id
-    })
-
-    insert(:project_resource, %{
-      project_id: project.id,
-      resource_id: objective_3_revision.resource_id
-    })
-
-    insert(:project_resource, %{
-      project_id: project.id,
-      resource_id: objective_4_revision.resource_id
-    })
-
-    insert(:project_resource, %{
-      project_id: project.id,
-      resource_id: page_1_revision.resource_id
-    })
-
-    insert(:project_resource, %{
-      project_id: project.id,
-      resource_id: page_2_revision.resource_id
-    })
-
-    insert(:project_resource, %{
-      project_id: project.id,
-      resource_id: page_3_revision.resource_id
-    })
-
-    insert(:project_resource, %{
-      project_id: project.id,
-      resource_id: page_4_revision.resource_id
-    })
-
-    insert(:project_resource, %{
-      project_id: project.id,
-      resource_id: module_1_revision.resource_id
-    })
-
-    insert(:project_resource, %{
-      project_id: project.id,
-      resource_id: module_2_revision.resource_id
-    })
-
-    insert(:project_resource, %{
-      project_id: project.id,
-      resource_id: unit_1_revision.resource_id
-    })
-
-    insert(:project_resource, %{
-      project_id: project.id,
-      resource_id: unit_2_revision.resource_id
-    })
-
-    insert(:project_resource, %{
-      project_id: project.id,
-      resource_id: container_revision.resource_id
-    })
-
-    # publish project and resources
+    # publish project
     publication =
       insert(:publication, %{project: project, root_resource_id: container_revision.resource_id})
 
-    insert(:published_resource, %{
-      publication: publication,
-      resource: objective_1_revision.resource,
-      revision: objective_1_revision,
-      author: author
-    })
-
-    insert(:published_resource, %{
-      publication: publication,
-      resource: objective_2_revision.resource,
-      revision: objective_2_revision,
-      author: author
-    })
-
-    insert(:published_resource, %{
-      publication: publication,
-      resource: objective_3_revision.resource,
-      revision: objective_3_revision,
-      author: author
-    })
-
-    insert(:published_resource, %{
-      publication: publication,
-      resource: objective_4_revision.resource,
-      revision: objective_4_revision,
-      author: author
-    })
-
-    insert(:published_resource, %{
-      publication: publication,
-      resource: page_1_revision.resource,
-      revision: page_1_revision,
-      author: author
-    })
-
-    insert(:published_resource, %{
-      publication: publication,
-      resource: page_2_revision.resource,
-      revision: page_2_revision,
-      author: author
-    })
-
-    insert(:published_resource, %{
-      publication: publication,
-      resource: page_3_revision.resource,
-      revision: page_3_revision,
-      author: author
-    })
-
-    insert(:published_resource, %{
-      publication: publication,
-      resource: page_4_revision.resource,
-      revision: page_4_revision,
-      author: author
-    })
-
-    insert(:published_resource, %{
-      publication: publication,
-      resource: module_1_revision.resource,
-      revision: module_1_revision,
-      author: author
-    })
-
-    insert(:published_resource, %{
-      publication: publication,
-      resource: module_2_revision.resource,
-      revision: module_2_revision,
-      author: author
-    })
-
-    insert(:published_resource, %{
-      publication: publication,
-      resource: unit_1_revision.resource,
-      revision: unit_1_revision,
-      author: author
-    })
-
-    insert(:published_resource, %{
-      publication: publication,
-      resource: unit_2_revision.resource,
-      revision: unit_2_revision,
-      author: author
-    })
-
-    insert(:published_resource, %{
-      publication: publication,
-      resource: container_revision.resource,
-      revision: container_revision,
-      author: author
-    })
+    # publish resources
+    Enum.each(all_revisions, fn revision ->
+      insert(:published_resource, %{
+        publication: publication,
+        resource: revision.resource,
+        revision: revision,
+        author: author
+      })
+    end)
 
     # create section...
     section =
@@ -338,10 +263,15 @@ defmodule Oli.Delivery.Metrics.LearningProficiencyTest do
       page_2: page_2_revision,
       page_3: page_3_revision,
       page_4: page_4_revision,
+      page_5: page_5_revision,
+      subobjective_a: subobjective_a_revision,
+      subobjective_b: subobjective_b_revision,
+      subobjective_c: subobjective_c_revision,
       page_1_objective: objective_1_revision,
       page_2_objective: objective_2_revision,
       page_3_objective: objective_3_revision,
       page_4_objective: objective_4_revision,
+      page_5_objective: objective_5_revision,
       module_1: module_1_revision,
       module_2: module_2_revision,
       unit_1: unit_1_revision,
@@ -662,26 +592,77 @@ defmodule Oli.Delivery.Metrics.LearningProficiencyTest do
       assert proficiency_for_student_per_page[page_3.resource_id] == "Low"
     end
 
-    test "proficiency_for_student_per_learning_objective/2 calculates correctly", %{
+    test "proficiency_for_student_per_learning_objective/3 calculates correctly", %{
       section: section,
       student_1: student_1,
+      student_2: student_2,
+      student_3: student_3,
       page_1: page_1,
       page_2: page_2,
       page_3: page_3,
+      page_5: page_5,
+      subobjective_a: subobjective_a,
+      subobjective_b: subobjective_b,
+      subobjective_c: subobjective_c,
       page_1_objective: page_1_obj,
       page_2_objective: page_2_obj,
-      page_3_objective: page_3_obj
+      page_3_objective: page_3_obj,
+      page_4_objective: page_4_obj,
+      page_5_objective: page_5_obj
     } do
       set_snapshot(section, page_1.resource, page_1_obj.resource, student_1, true)
       set_snapshot(section, page_2.resource, page_2_obj.resource, student_1, false)
       set_snapshot(section, page_3.resource, page_3_obj.resource, student_1, false)
+      set_snapshot(section, page_5.resource, subobjective_a.resource, student_1, true)
+      set_snapshot(section, page_5.resource, subobjective_b.resource, student_1, true)
+      set_snapshot(section, page_5.resource, subobjective_c.resource, student_1, true)
 
       proficiency_for_student_per_learning_objective =
-        Metrics.proficiency_for_student_per_learning_objective(section, student_1.id)
+        Metrics.proficiency_for_student_per_learning_objective(
+          [page_1_obj, page_2_obj, page_3_obj, page_4_obj, page_5_obj],
+          student_1.id,
+          section
+        )
 
       assert proficiency_for_student_per_learning_objective[page_1_obj.resource_id] == "High"
       assert proficiency_for_student_per_learning_objective[page_2_obj.resource_id] == "Low"
       assert proficiency_for_student_per_learning_objective[page_3_obj.resource_id] == "Low"
+
+      assert proficiency_for_student_per_learning_objective[page_4_obj.resource_id] ==
+               "Not enough data"
+
+      assert proficiency_for_student_per_learning_objective[page_5_obj.resource_id] == "High"
+
+      set_snapshot(section, page_5.resource, subobjective_a.resource, student_2, true)
+      set_snapshot(section, page_5.resource, subobjective_b.resource, student_2, false)
+      set_snapshot(section, page_5.resource, subobjective_c.resource, student_2, true)
+
+      proficiency_for_student_2_per_learning_objective =
+        Metrics.proficiency_for_student_per_learning_objective(
+          [page_1_obj, page_5_obj],
+          student_2.id,
+          section
+        )
+
+      assert proficiency_for_student_2_per_learning_objective[page_1_obj.resource_id] ==
+               "Not enough data"
+
+      refute proficiency_for_student_2_per_learning_objective[page_2_obj.resource_id]
+
+      assert proficiency_for_student_2_per_learning_objective[page_5_obj.resource_id] == "Medium"
+
+      set_snapshot(section, page_5.resource, subobjective_a.resource, student_3, true)
+      set_snapshot(section, page_5.resource, subobjective_b.resource, student_3, false)
+      set_snapshot(section, page_5.resource, subobjective_c.resource, student_3, false)
+
+      proficiency_for_student_3_per_learning_objective =
+        Metrics.proficiency_for_student_per_learning_objective(
+          [page_5_obj],
+          student_3.id,
+          section
+        )
+
+      assert proficiency_for_student_3_per_learning_objective[page_5_obj.resource_id] == "Low"
     end
   end
 end


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/NG23-252) to the ticket.

Take into account that this PR points to `NG23-246-content-on-page-is-not-visible-on-begin-attempt` instead of `prerelease-v0.28.0` because the target branch has changes applied to the lesson and prologue view that was needed for this ticket (to prevent future merge conflicts)

### Before
![image](https://github.com/Simon-Initiative/oli-torus/assets/74839302/3c69674e-cd14-4f5a-8dff-1d57437b0407)


### After
![image](https://github.com/Simon-Initiative/oli-torus/assets/74839302/9f3df193-0752-421f-9202-8d88633ddf9d)
