### PR TITLE
[BUG FIX] [NG23-208] branding not working properly part 2

### DIFF
--- a/lib/oli_web/live/delivery/student_onboarding/wizard.ex
+++ b/lib/oli_web/live/delivery/student_onboarding/wizard.ex
@@ -108,6 +108,7 @@ defmodule OliWeb.Delivery.StudentOnboarding.Wizard do
       is_system_admin={@is_system_admin}
       section={@section}
       preview_mode={@preview_mode}
+      include_logo={true}
     />
     <div id="content" class="mt-14 h-[calc(100vh-56px)] transition-all duration-100">
       <.live_component

--- a/lib/oli_web/views/view_helpers.ex
+++ b/lib/oli_web/views/view_helpers.ex
@@ -27,11 +27,13 @@ defmodule OliWeb.ViewHelpers do
   def brand_logo(assigns) do
     ~H"""
     <img
+      :if={assigns[:section]}
       src={brand_logo_url(assigns[:section])}
       class={[value_or(assigns[:class], ""), "inline-block dark:hidden"]}
       alt={brand_name(assigns[:section])}
     />
     <img
+      :if={assigns[:section]}
       src={brand_logo_url_dark(assigns[:section])}
       class={[value_or(assigns[:class], ""), "hidden dark:inline-block"]}
       alt={brand_name(assigns[:section])}


### PR DESCRIPTION
Ticket: [NG23-208](https://eliterate.atlassian.net/browse/NG23-208)

This PR fixes two issues:

1. A missing branding logo on the wizard page
2. A glitch that displays the default torus logo instead of the branded one.


[NG23-208]: https://eliterate.atlassian.net/browse/NG23-208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ