### PR TITLE
[BUG FIX] [MER-3202] change ingested activity scoring strategy to "total", not "average"

### DIFF
--- a/lib/oli/interop/ingest/processor/activities.ex
+++ b/lib/oli/interop/ingest/processor/activities.ex
@@ -41,7 +41,7 @@ defmodule Oli.Interop.Ingest.Processor.Activities do
       children: {:placeholder, :children},
       resource_type_id: {:placeholder, :resource_type_id},
       activity_type_id: Map.get(state.registration_by_subtype, Map.get(resource, "subType")),
-      scoring_strategy_id: Oli.Resources.ScoringStrategy.get_id_by_type("average"),
+      scoring_strategy_id: Oli.Resources.ScoringStrategy.get_id_by_type("total"),
       inserted_at: {:placeholder, :now},
       updated_at: {:placeholder, :now}
     }


### PR DESCRIPTION
All ingested activities were getting a hardcoded default scoring strategy of "average". This caused unexpected and undesired behavior on multi-input questions in migrated/ingested courses. For example, on a two-part question with the default 1 point per part, the score for two correct answers would be 1 out of 1, when instructors expect 2 out of 2. This PR corrects the code to set the "total" scoring strategy on ingested activities, which is the natural default. That is also the default applied elsewhere in the code, for example to newly created activities and on updates setting default scoring strategy (see `maybe_update_scoring_strategy`). 

The main is use for ingestion of migrated courses.  The strategy remains changeable after ingestion through custom scoring interface in the unlikely event something different is wanted for activity-level scoring. 