### PR TITLE
[ENHANCEMENT] [NG23-234] Style initial video play button to ensure visibility

### DIFF
--- a/assets/src/components/video_player/InitialPlayButton.tsx
+++ b/assets/src/components/video_player/InitialPlayButton.tsx
@@ -4,6 +4,7 @@ import { ControlButtonProps } from './ControlBar';
 export const InitialPlayButton: React.FC<ControlButtonProps> = ({ actions, player }) => {
   if (player?.hasStarted) return null;
   return (
+    // style to ensure visibility against light or dark backgrounds
     <button className="big-play-button" onClick={actions?.play}>
       <i className="fa-solid fa-circle-play"></i>
     </button>

--- a/assets/src/components/video_player/InitialPlayButton.tsx
+++ b/assets/src/components/video_player/InitialPlayButton.tsx
@@ -4,7 +4,6 @@ import { ControlButtonProps } from './ControlBar';
 export const InitialPlayButton: React.FC<ControlButtonProps> = ({ actions, player }) => {
   if (player?.hasStarted) return null;
   return (
-    // style to ensure visibility against light or dark backgrounds
     <button className="big-play-button" onClick={actions?.play}>
       <i className="fa-solid fa-circle-play"></i>
     </button>

--- a/assets/styles/common/video.scss
+++ b/assets/styles/common/video.scss
@@ -28,10 +28,13 @@
     top: 50%;
     transform: translate(-50%, -50%);
     z-index: 1; // gets it over the poster image
-    background: none;
-    border: none;
+    // colors & border get white triangle in black circle w/white border,
+    // ensuring visibility against both black & white backgrounds
+    color: black;
+    background: white;
+    border: 4px solid white;
+    border-radius: 50%;
     opacity: 0.7;
-    color: #fff;
     font-size: 5em;
 
     &:hover {


### PR DESCRIPTION
This adjusts the colors and borders of the initial play button shown in the middle of the video player to ensure visibility against both white and black video backgrounds, so that students will be sure to see an affordance for playing. 

Old: button is there but nvisible against white background
![Screenshot 2024-06-04 at 12 38 03 PM](https://github.com/Simon-Initiative/oli-torus/assets/7094628/dab0f0b9-b4d5-4899-adcc-fb91ce460fd1)

New:
<img width="909" alt="Screenshot 2024-06-25 at 3 21 18 PM" src="https://github.com/Simon-Initiative/oli-torus/assets/7094628/490941fe-05a6-47f3-8b4a-d92e9db0532f">
