### PR TITLE
[BUG FIX] [NG23-222] Fix Due Date in Homepage

### DIFF
--- a/lib/oli/datetime.ex
+++ b/lib/oli/datetime.ex
@@ -1,8 +1,13 @@
 defmodule Oli.DateTime do
   @callback utc_now :: DateTime.t()
+  @callback now!(String.t()) :: DateTime.t()
 
   def utc_now() do
     date_time().utc_now()
+  end
+
+  def now!(timezone) do
+    date_time().now!(timezone)
   end
 
   defp date_time(), do: Application.get_env(:oli, :date_time_module, DateTime)

--- a/lib/oli_web/live/delivery/student/home/components/schedule_component.ex
+++ b/lib/oli_web/live/delivery/student/home/components/schedule_component.ex
@@ -289,7 +289,7 @@ defmodule OliWeb.Delivery.Student.Home.Components.ScheduleComponent do
             <%= if @completed do %>
               Completed
             <% else %>
-              <%= Utils.days_difference(hd(@resources).end_date) %>
+              <%= Utils.days_difference(hd(@resources).end_date, @ctx) %>
             <% end %>
           </div>
           <Icons.check :if={@completed} progress={1.0} />

--- a/lib/oli_web/live/delivery/student/index_live.ex
+++ b/lib/oli_web/live/delivery/student/index_live.ex
@@ -134,6 +134,7 @@ defmodule OliWeb.Delivery.Student.IndexLive do
             section_slug={@section_slug}
             assignments_tab={@assignments_tab}
             containers_per_page={@containers_per_page}
+            ctx={@ctx}
           />
         </div>
 
@@ -365,6 +366,7 @@ defmodule OliWeb.Delivery.Student.IndexLive do
   attr(:section_slug, :string, required: true)
   attr(:assignments_tab, :atom, required: true)
   attr(:containers_per_page, :map, required: true)
+  attr(:ctx, :map, required: true)
 
   defp assignments(assigns) do
     lessons =
@@ -415,6 +417,7 @@ defmodule OliWeb.Delivery.Student.IndexLive do
               lesson={lesson}
               containers={@containers_per_page[lesson.resource_id] || []}
               section_slug={@section_slug}
+              ctx={@ctx}
             />
           <% end %>
         </div>
@@ -436,6 +439,7 @@ defmodule OliWeb.Delivery.Student.IndexLive do
   attr(:upcoming, :boolean, required: true)
   attr(:section_slug, :string, required: true)
   attr(:containers, :list, required: true)
+  attr(:ctx, :map, required: true)
 
   defp lesson_card(assigns) do
     assigns =
@@ -483,7 +487,7 @@ defmodule OliWeb.Delivery.Student.IndexLive do
           <Student.resource_type type={@lesson_type} long={false} />
         </div>
 
-        <.lesson_details upcoming={@upcoming} lesson={@lesson} completed={@completed} />
+        <.lesson_details upcoming={@upcoming} lesson={@lesson} completed={@completed} ctx={@ctx} />
       </div>
     </.link>
     """
@@ -505,6 +509,7 @@ defmodule OliWeb.Delivery.Student.IndexLive do
   attr :lesson, :map, required: true
   attr :upcoming, :boolean, required: true
   attr :completed, :boolean, required: true
+  attr :ctx, :map, required: true
 
   defp lesson_details(%{upcoming: true} = assigns) do
     ~H"""
@@ -512,7 +517,7 @@ defmodule OliWeb.Delivery.Student.IndexLive do
       <div class="pr-2 pl-1 self-end">
         <div class="flex items-end gap-1">
           <div class="text-right dark:text-white text-opacity-90 text-xs font-semibold">
-            <%= Utils.days_difference(@lesson.end_date) %>
+            <%= Utils.days_difference(@lesson.end_date, @ctx) %>
           </div>
         </div>
       </div>

--- a/test/oli_web/live/delivery/student/home/components/schedule_component_test.exs
+++ b/test/oli_web/live/delivery/student/home/components/schedule_component_test.exs
@@ -241,8 +241,8 @@ defmodule OliWeb.Delivery.Student.Home.Components.ScheduleComponentTest do
     })
 
     session_context = %OliWeb.Common.SessionContext{
-      browser_timezone: "Etc/UTC",
-      local_tz: "Etc/UTC",
+      browser_timezone: "America/Montevideo",
+      local_tz: "America/Montevideo",
       author: author,
       user: author,
       is_liveview: true

--- a/test/oli_web/live/delivery/student/index_live_test.exs
+++ b/test/oli_web/live/delivery/student/index_live_test.exs
@@ -659,7 +659,13 @@ defmodule OliWeb.Delivery.Student.IndexLiveTest do
   end
 
   describe "student" do
-    setup [:user_conn, :create_elixir_project, :enroll_as_student, :mark_section_visited]
+    setup [
+      :user_conn,
+      :set_timezone,
+      :create_elixir_project,
+      :enroll_as_student,
+      :mark_section_visited
+    ]
 
     test "can access when enrolled to course", %{conn: conn, section: section} do
       stub_current_time(~U[2023-11-04 20:00:00Z])
@@ -968,7 +974,13 @@ defmodule OliWeb.Delivery.Student.IndexLiveTest do
   end
 
   describe "my assignments" do
-    setup [:user_conn, :create_elixir_project, :enroll_as_student, :mark_section_visited]
+    setup [
+      :user_conn,
+      :set_timezone,
+      :create_elixir_project,
+      :enroll_as_student,
+      :mark_section_visited
+    ]
 
     test "displays default message when there are no upcoming assignments", %{
       conn: conn,
@@ -1036,7 +1048,7 @@ defmodule OliWeb.Delivery.Student.IndexLiveTest do
                first_assignment <> ~s{div[role=resource_type][aria-label=exploration]}
              )
 
-      assert has_element?(view, first_assignment <> ~s{div[role=details]}, "1 day left")
+      assert has_element?(view, first_assignment <> ~s{div[role=details]}, "2 days left")
 
       # Second upcoming assignment
       assert element(
@@ -1055,7 +1067,7 @@ defmodule OliWeb.Delivery.Student.IndexLiveTest do
                second_assignment <> ~s{div[role=resource_type][aria-label=checkpoint]}
              )
 
-      assert has_element?(view, second_assignment <> ~s{div[role=details]}, "2 days left")
+      assert has_element?(view, second_assignment <> ~s{div[role=details]}, "3 days left")
 
       # Third upcoming assignment
       assert element(
@@ -1074,7 +1086,7 @@ defmodule OliWeb.Delivery.Student.IndexLiveTest do
                third_assignment <> ~s{div[role=resource_type][aria-label=checkpoint]}
              )
 
-      assert has_element?(view, third_assignment <> ~s{div[role=details]}, "3 days left")
+      assert has_element?(view, third_assignment <> ~s{div[role=details]}, "4 days left")
     end
 
     test "displays three latest assignments", %{

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -2760,7 +2760,13 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
   end
 
   describe "preview" do
-    setup [:user_conn, :create_elixir_project, :enroll_as_student, :mark_section_visited]
+    setup [
+      :user_conn,
+      :set_timezone,
+      :create_elixir_project,
+      :enroll_as_student,
+      :mark_section_visited
+    ]
 
     test "redirects and ensures navigation to the preview Notes page", %{
       conn: conn,

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -49,9 +49,14 @@ defmodule Oli.TestHelpers do
     end
   end
 
-  def stub_current_time(now) do
-    Mox.stub(Oli.Test.DateTimeMock, :utc_now, fn -> now end)
-    Mox.stub(Oli.Test.DateMock, :utc_today, fn -> DateTime.to_date(now) end)
+  def stub_current_time(utc_now) do
+    Mox.stub(Oli.Test.DateTimeMock, :utc_now, fn -> utc_now end)
+
+    Mox.stub(Oli.Test.DateTimeMock, :now!, fn timezone ->
+      DateTime.shift_zone!(utc_now, timezone)
+    end)
+
+    Mox.stub(Oli.Test.DateMock, :utc_today, fn -> DateTime.to_date(utc_now) end)
   end
 
   def yesterday() do


### PR DESCRIPTION
[NG23-222](https://eliterate.atlassian.net/browse/NG23-222)

Fixes how the Due Date description is calculated on the student's homepage.
There was an edge case where a resource's end date and the current date were on the same day in the UTC timezone, but in the user's timezone, they were not. With the fix, we now consider the user's timezone for the calculation. 

[NG23-222]: https://eliterate.atlassian.net/browse/NG23-222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ