### PR TITLE
[BUG FIX] [NG23-228] social annotation point blocks not working for some pages

### DIFF
--- a/lib/oli/interop/ingest.ex
+++ b/lib/oli/interop/ingest.ex
@@ -130,6 +130,7 @@ defmodule Oli.Interop.Ingest do
                hierarchy_details,
                as_author
              ),
+           {:ok, _} <- Oli.Ingest.RewireLinks.rewire_all_hyperlinks(page_map, project, page_map),
            {:ok, _} <-
              create_products(
                project,
@@ -138,8 +139,7 @@ defmodule Oli.Interop.Ingest do
                page_map,
                container_map,
                as_author
-             ),
-           {:ok, _} <- Oli.Ingest.RewireLinks.rewire_all_hyperlinks(page_map, project, page_map) do
+             ) do
         project
       else
         {:error, error} -> Repo.rollback(error)

--- a/lib/oli/publishing.ex
+++ b/lib/oli/publishing.ex
@@ -485,8 +485,7 @@ defmodule Oli.Publishing do
       with {:ok, publication} <-
              create_publication(%{
                project_id: project.id,
-               root_resource_id: resource.id,
-               ids_added: true
+               root_resource_id: resource.id
              }),
            {:ok, published_resource} <-
              create_published_resource(%{
@@ -1029,8 +1028,7 @@ defmodule Oli.Publishing do
                {:ok, new_publication} <-
                  create_publication(%{
                    root_resource_id: active_publication.root_resource_id,
-                   project_id: active_publication.project_id,
-                   ids_added: true
+                   project_id: active_publication.project_id
                  }),
 
                # Release all locks
@@ -1051,8 +1049,7 @@ defmodule Oli.Publishing do
                      description: description,
                      edition: edition,
                      major: major,
-                     minor: minor,
-                     ids_added: true
+                     minor: minor
                    }
                  ) do
             Oli.Authoring.Broadcaster.broadcast_publication(publication, project.slug)

--- a/lib/oli/publishing/publications/publication.ex
+++ b/lib/oli/publishing/publications/publication.ex
@@ -8,7 +8,6 @@ defmodule Oli.Publishing.Publications.Publication do
     field :edition, :integer, default: 0
     field :major, :integer, default: 0
     field :minor, :integer, default: 0
-    field :ids_added, :boolean, default: false
 
     belongs_to :root_resource, Oli.Resources.Resource
     belongs_to :project, Oli.Authoring.Course.Project
@@ -25,7 +24,6 @@ defmodule Oli.Publishing.Publications.Publication do
       :edition,
       :major,
       :minor,
-      :ids_added,
       :root_resource_id,
       :project_id
     ])

--- a/lib/oli/resources.ex
+++ b/lib/oli/resources.ex
@@ -319,6 +319,7 @@ defmodule Oli.Resources do
           objectives: previous_revision.objectives,
           children: previous_revision.children,
           deleted: previous_revision.deleted,
+          ids_added: previous_revision.ids_added,
           slug: previous_revision.slug,
           title: previous_revision.title,
           graded: previous_revision.graded,

--- a/lib/oli/resources/revision.ex
+++ b/lib/oli/resources/revision.ex
@@ -37,6 +37,7 @@ defmodule Oli.Resources.Revision do
     field :title, :string
     field :slug, :string
     field :deleted, :boolean, default: false
+    field :ids_added, :boolean, default: false
     belongs_to :author, Oli.Accounts.Author
     belongs_to :resource, Oli.Resources.Resource
     belongs_to :previous_revision, Oli.Resources.Revision
@@ -96,6 +97,7 @@ defmodule Oli.Resources.Revision do
       :title,
       :slug,
       :deleted,
+      :ids_added,
       :author_id,
       :resource_id,
       :primary_resource_id,

--- a/lib/oli/utils/db_seeder.ex
+++ b/lib/oli/utils/db_seeder.ex
@@ -1248,7 +1248,8 @@ defmodule Oli.Seeder do
         content: content,
         deleted: false,
         title: title,
-        resource_id: resource.id
+        resource_id: resource.id,
+        ids_added: true
       })
 
     {:ok, _} =
@@ -1607,7 +1608,8 @@ defmodule Oli.Seeder do
           content: %{},
           deleted: false,
           title: "test",
-          resource_id: resource.id
+          resource_id: resource.id,
+          ids_added: true
         },
         attrs
       )
@@ -1646,7 +1648,8 @@ defmodule Oli.Seeder do
           content: %{},
           deleted: false,
           title: "test",
-          resource_id: resource.id
+          resource_id: resource.id,
+          ids_added: true
         },
         attrs
       )

--- a/lib/oli/utils/db_seeder.ex
+++ b/lib/oli/utils/db_seeder.ex
@@ -1516,7 +1516,8 @@ defmodule Oli.Seeder do
           content: %{"model" => []},
           deleted: false,
           title: "title",
-          resource_id: resource.id
+          resource_id: resource.id,
+          ids_added: true
         },
         attrs
       )
@@ -1711,7 +1712,8 @@ defmodule Oli.Seeder do
           content: %{},
           deleted: false,
           title: "test",
-          resource_id: resource.id
+          resource_id: resource.id,
+          ids_added: true
         },
         attrs
       )

--- a/lib/oli/utils/seeder/project.ex
+++ b/lib/oli/utils/seeder/project.ex
@@ -502,8 +502,7 @@ defmodule Oli.Utils.Seeder.Project do
     {:ok, publication} =
       Publication.changeset(%Publication{}, %{
         root_resource_id: curriculum_resource.id,
-        project_id: project.id,
-        ids_added: true
+        project_id: project.id
       })
       |> Repo.insert()
 
@@ -548,7 +547,8 @@ defmodule Oli.Utils.Seeder.Project do
         title: "New Page",
         objectives: %{"attached" => []},
         scoring_strategy_id: Oli.Resources.ScoringStrategy.get_id_by_type("average"),
-        content: %{"model" => []}
+        content: %{"model" => []},
+        ids_added: true
       }
       |> Map.merge(attrs)
       |> Map.merge(%{
@@ -677,7 +677,20 @@ defmodule Oli.Utils.Seeder.Project do
     activity_tag = tags[:activity_tag] || random_tag()
 
     content = %{
-      "stem" => "Example MCQ activity. Correct answer is 'Choice A'",
+      "stem" => %{
+        "id" => "1231233",
+        "content" => [
+          %{
+            "children" => [
+              %{
+                "text" => "Example MCQ activity. Correct answer is 'Choice A'"
+              }
+            ],
+            "id" => "2624267864",
+            "type" => "p"
+          }
+        ]
+      },
       "authoring" => %{
         "parts" => [
           maybe_add_explanation(
@@ -846,7 +859,8 @@ defmodule Oli.Utils.Seeder.Project do
         objectives: %{},
         scoring_strategy_id: Oli.Resources.ScoringStrategy.get_id_by_type("best"),
         content: %{},
-        title: "test"
+        title: "test",
+        ids_added: true
       }
       |> Map.merge(attrs)
       |> Map.merge(%{

--- a/priv/repo/migrations/20240624202150_revision_ids_added.exs
+++ b/priv/repo/migrations/20240624202150_revision_ids_added.exs
@@ -1,0 +1,14 @@
+defmodule Oli.Repo.Migrations.RevisionIdsAdded do
+  use Ecto.Migration
+
+  def change do
+    # track ids at the revision level instead of the publication level
+    alter table(:revisions) do
+      add :ids_added, :boolean, default: false
+    end
+
+    alter table(:publications) do
+      remove :ids_added, :boolean, default: false
+    end
+  end
+end

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -2245,9 +2245,13 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       {:ok, view, _html} =
         live(conn, Utils.learn_live_path(section.slug, selected_view: :outline))
 
-      # when the garbage collection message is recieved we know the async metrics were loaded
+      # when the garbage collection message is received we know the async metrics were loaded
       # since the gc message is sent from the handle_info that loads the async metrics
       assert_receive(:gc, 2_000)
+
+      wait_while(fn ->
+        !has_element?(view, ~s{button[role="page 11 details"] div[role="check icon"]})
+      end)
 
       assert has_element?(view, ~s{button[role="page 11 details"] div[role="check icon"]})
     end

--- a/test/oli_web/live/publish_live_test.exs
+++ b/test/oli_web/live/publish_live_test.exs
@@ -34,14 +34,16 @@ defmodule OliWeb.PublishLiveTest do
             objective_1_revision.resource_id
           ]
         },
-        title: "revision A"
+        title: "revision A",
+        ids_added: true
       )
 
     page_2_revision =
       insert(:revision,
         resource_type_id: ResourceType.id_for_page(),
         content: %{"model" => []},
-        title: "revision B"
+        title: "revision B",
+        ids_added: true
       )
 
     container_revision =
@@ -75,8 +77,7 @@ defmodule OliWeb.PublishLiveTest do
       insert(:publication, %{
         project: project,
         root_resource_id: container_revision.resource_id,
-        published: nil,
-        ids_added: true
+        published: nil
       })
 
     # publish resources
@@ -331,7 +332,8 @@ defmodule OliWeb.PublishLiveTest do
               resource: page_resource,
               resource_type_id: ResourceType.id_for_page(),
               content: %{"model" => []},
-              title: "revision#{elem}"
+              title: "revision#{elem}",
+              ids_added: true
             )
 
           insert(:project_resource, %{project_id: project.id, resource_id: page_resource.id})

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -335,7 +335,8 @@ defmodule Oli.Factory do
       collab_space_config: build(:collab_space_config),
       content: %{
         "model" => []
-      }
+      },
+      ids_added: true
     }
   end
 


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/NG23-228

This PR fixes an issue where social annotation point markers were not showing up for some pages, specifically identified in the chemistry course.

The root cause of the issue was due to the `ids_added` attribute on the publication not taking into account pages which may not have been processed as part of the publication process when ids were fixed, leading to the possibility that certain pages added in after the fact may not have been processed to ensure these ids exist.

The fix here is to remove the `ids_added` attribute from the publication record and instead add it to the revision record, and run the `ensure_ids` logic on every publish. Once a revision has been processed and has this flag set, it no longer needs to be processed going forward because the system guarantees at that point that these ids exists at the authoring level.

The risk here is medium since it involves adding an attribute to the revisions table, but special care was used to ensure that this attribute is also included in the revision_from_previous logic and there is a decent amount of unit test coverage around revisions. We will want to spend some extra time in QA testing the publishing process, authoring then republishing to ensure everything is still working correctly here.

This is an important fix for social annotation feature, but also in general to close this gap where the content is assumed to have the required ids based on this flag, however in the current state that assumption is not always correct.