### PR TITLE
[BUG FIX] [NG23-251] Fix Exploration Image on Course Entry

### DIFF
--- a/lib/oli_web/live/delivery/student_onboarding/explorations.ex
+++ b/lib/oli_web/live/delivery/student_onboarding/explorations.ex
@@ -23,7 +23,7 @@ defmodule OliWeb.Delivery.StudentOnboarding.Explorations do
         </div>
       </div>
       <img
-        class="aspect-video w-full hidden hvxl:block hvxl:h-[200px] hv2xl:h-[350px]"
+        class="aspect-video hidden hvxl:block hvxl:h-[200px] hv2xl:h-[350px] mx-auto"
         src="/images/exploration.gif"
       />
       <p class="text-[14px] leading-[20px] tracking-[0.02px] dark:text-white px-[20px] hvsm:px-[70px] hvxl:px-[84px] pt-9 pb-2">


### PR DESCRIPTION
[NG23-251](https://eliterate.atlassian.net/browse/NG23-251)

Fix exploration gif width when joining a course as a student.

**Before:**

https://github.com/Simon-Initiative/oli-torus/assets/26532202/e9d1ac2f-e9a7-473b-aee1-bd0306346bfe

**After:**

https://github.com/Simon-Initiative/oli-torus/assets/26532202/3b374fc9-0490-40e1-aa07-9b6b2e2f9db3




[NG23-251]: https://eliterate.atlassian.net/browse/NG23-251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ