### PR TITLE
[BUG FIX] [NG23-254] Fix back button overlaps content

### DIFF
--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -606,8 +606,8 @@ defmodule OliWeb.Components.Delivery.Layouts do
     ~H"""
     <div
       class={[
-        "flex justify-center items-center absolute top-2 left-2 p-4 z-50",
-        if(!@show_sidebar, do: "xl:top-10 xl:left-12")
+        "flex justify-center items-center absolute top-12 left-2 p-4 z-50",
+        if(!@show_sidebar, do: "2xl:top-12 2xl:left-8")
       ]}
       role="back_link"
     >


### PR DESCRIPTION
Ticket: [NG23-254](https://eliterate.atlassian.net/browse/NG23-254)

This ticket fixes the overlapping between the back button and the content.

### Old
https://github.com/Simon-Initiative/oli-torus/assets/47334502/fb231045-e08d-4f87-aeea-77aa12c20728


### New
https://github.com/Simon-Initiative/oli-torus/assets/47334502/fcde0055-582b-4b8b-b2d5-038f7dfc4e76



[NG23-254]: https://eliterate.atlassian.net/browse/NG23-254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ