### PR TITLE
[BUG FIX] [NG23-206] user enables disables notes

### DIFF
--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -100,6 +100,8 @@ defmodule OliWeb.Components.Delivery.Layouts do
   attr(:section, Section, default: nil)
   attr(:active_tab, :atom)
   attr(:sidebar_expanded, :boolean, default: true)
+  attr(:notes_enabled, :boolean, default: false)
+  attr(:discussions_enabled, :boolean, default: false)
   attr(:preview_mode, :boolean)
   attr :notification_badges, :map, default: %{}
 
@@ -147,6 +149,8 @@ defmodule OliWeb.Components.Delivery.Layouts do
             section={@section}
             preview_mode={@preview_mode}
             sidebar_expanded={@sidebar_expanded}
+            notes_enabled={@notes_enabled}
+            discussions_enabled={@discussions_enabled}
             notification_badges={@notification_badges}
           />
         </div>
@@ -171,7 +175,13 @@ defmodule OliWeb.Components.Delivery.Layouts do
       "
         phx-click-away={JS.hide()}
       >
-        <.sidebar_links active_tab={@active_tab} section={@section} preview_mode={@preview_mode} />
+        <.sidebar_links
+          active_tab={@active_tab}
+          section={@section}
+          preview_mode={@preview_mode}
+          notes_enabled={@notes_enabled}
+          discussions_enabled={@discussions_enabled}
+        />
         <div class="px-4 py-2 flex flex-row align-center justify-between border-t border-gray-300 dark:border-gray-800">
           <div class="flex items-center">
             <.tech_support_button id="mobile-tech-support" ctx={@ctx} />
@@ -214,6 +224,8 @@ defmodule OliWeb.Components.Delivery.Layouts do
   attr(:active_tab, :atom)
   attr(:preview_mode, :boolean)
   attr(:sidebar_expanded, :boolean, default: true)
+  attr(:notes_enabled, :boolean, default: true)
+  attr(:discussions_enabled, :boolean, default: true)
   attr(:notification_badges, :map, default: %{})
 
   def sidebar_links(assigns) do
@@ -250,6 +262,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
       </.nav_link>
 
       <.nav_link
+        :if={@notes_enabled || @discussions_enabled}
         id="discussions_nav_link"
         href={path_for(:discussions, @section, @preview_mode, @sidebar_expanded)}
         is_active={@active_tab == :discussions}

--- a/lib/oli_web/components/layouts/student_delivery.html.heex
+++ b/lib/oli_web/components/layouts/student_delivery.html.heex
@@ -17,6 +17,8 @@
       preview_mode={@preview_mode}
       notification_badges={assigns[:notification_badges] || %{}}
       sidebar_expanded={@sidebar_expanded}
+      notes_enabled={@notes_enabled}
+      discussions_enabled={@discussions_enabled}
     />
     <div class={[
       "md:w-[calc(100%-190px)] flex-1 flex flex-col md:ml-[190px] mt-14 relative",

--- a/lib/oli_web/live_session_plugs/set_sidebar.ex
+++ b/lib/oli_web/live_session_plugs/set_sidebar.ex
@@ -35,6 +35,9 @@ defmodule OliWeb.LiveSessionPlugs.SetSidebar do
     end
   end
 
+  defp assign_notes_and_discussions_enabled(socket, nil),
+    do: assign(socket, notes_enabled: false, discussions_enabled: false)
+
   defp assign_notes_and_discussions_enabled(socket, section_slug) do
     {collab_space_pages_count, _pages_count} =
       Collaboration.count_collab_spaces_enabled_in_pages_for_section(section_slug)

--- a/lib/oli_web/live_session_plugs/set_sidebar.ex
+++ b/lib/oli_web/live_session_plugs/set_sidebar.ex
@@ -7,7 +7,15 @@ defmodule OliWeb.LiveSessionPlugs.SetSidebar do
   import Phoenix.Component, only: [assign: 2]
   import Phoenix.LiveView, only: [attach_hook: 4, connected?: 1]
 
-  def on_mount(:default, _params, _session, socket) do
+  alias Oli.Resources.Collaboration.CollabSpaceConfig
+  alias Oli.Resources.Collaboration
+  alias Oli.Publishing.{DeliveryResolver}
+
+  def on_mount(:default, _params, session, socket) do
+    socket =
+      socket
+      |> assign_notes_and_discussions_enabled(session["section_slug"])
+
     if connected?(socket) do
       socket =
         socket
@@ -25,5 +33,28 @@ defmodule OliWeb.LiveSessionPlugs.SetSidebar do
        socket
        |> assign(sidebar_expanded: true)}
     end
+  end
+
+  defp assign_notes_and_discussions_enabled(socket, section_slug) do
+    {collab_space_pages_count, _pages_count} =
+      Collaboration.count_collab_spaces_enabled_in_pages_for_section(section_slug)
+
+    notes_enabled = collab_space_pages_count > 0
+
+    %{slug: revision_slug} = DeliveryResolver.root_container(section_slug)
+
+    discussions_enabled =
+      case Collaboration.get_collab_space_config_for_page_in_section(
+             revision_slug,
+             section_slug
+           ) do
+        {:ok, %CollabSpaceConfig{status: :enabled}} ->
+          true
+
+        _ ->
+          false
+      end
+
+    assign(socket, notes_enabled: notes_enabled, discussions_enabled: discussions_enabled)
   end
 end

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -2764,8 +2764,14 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
 
     test "redirects and ensures navigation to the preview Notes page", %{
       conn: conn,
-      section: section
+      author: author,
+      section: section,
+      page_1: page_1,
+      page_2: page_2,
+      page_3: page_3
     } do
+      enable_all_sidebar_links(section, author, page_1, page_2, page_3)
+
       stub_current_time(~U[2023-11-04 20:00:00Z])
       {:ok, view, _html} = live(conn, "/sections/#{section.slug}/preview")
 


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/NG23-206

Fixes an issue where Notes tab still shows even when both notes and discussions are disabled.

- Only show notes tab when either notes are enabled for a single page or course discussions are enabled
- Load notes_enabled and discussions_enabled as live plug
- Add handle_params to discussions to prevent crash if params change