### PR TITLE
[FEATURE] [MER-3065] Track assessment settings audit log

### DIFF
--- a/lib/oli/delivery/settings.ex
+++ b/lib/oli/delivery/settings.ex
@@ -326,6 +326,10 @@ defmodule Oli.Delivery.Settings do
 
   def check_password(_, _), do: {:invalid_password}
 
+  @doc """
+  Insert a new settings change record.
+  """
+  @spec insert_settings_change(map()) :: {:ok, SettingsChanges.t()} | {:error, Ecto.Changeset.t()}
   def insert_settings_change(attrs) do
     SettingsChanges.changeset(
       %SettingsChanges{},
@@ -334,10 +338,19 @@ defmodule Oli.Delivery.Settings do
     |> Repo.insert()
   end
 
+  @doc """
+  Insert multiple settings change records.
+  """
+  @spec bulk_insert_settings_changes([map()]) ::
+          {:ok, [SettingsChanges.t()]} | {:error, Ecto.Changeset.t()}
   def bulk_insert_settings_changes(settings_changes) do
     Repo.insert_all(SettingsChanges, settings_changes)
   end
 
+  @doc """
+  Fetch all settings changes.
+  """
+  @spec fetch_all_settings_changes() :: [SettingsChanges.t()]
   def fetch_all_settings_changes(),
     do:
       SettingsChanges

--- a/lib/oli/delivery/settings.ex
+++ b/lib/oli/delivery/settings.ex
@@ -5,6 +5,7 @@ defmodule Oli.Delivery.Settings do
   alias Oli.Resources.Revision
   alias Oli.Delivery.Settings.Combined
   alias Oli.Delivery.Settings.StudentException
+  alias Oli.Delivery.Settings.SettingsChanges
   alias Oli.Delivery.Attempts.Core.ResourceAttempt
   alias Oli.Publishing.DeliveryResolver
 
@@ -324,4 +325,12 @@ defmodule Oli.Delivery.Settings do
     do: {:allowed}
 
   def check_password(_, _), do: {:invalid_password}
+
+  def insert_settings_change(attrs) do
+    SettingsChanges.changeset(
+      %SettingsChanges{},
+      attrs
+    )
+    |> Repo.insert()
+  end
 end

--- a/lib/oli/delivery/settings.ex
+++ b/lib/oli/delivery/settings.ex
@@ -333,4 +333,13 @@ defmodule Oli.Delivery.Settings do
     )
     |> Repo.insert()
   end
+
+  def bulk_insert_settings_changes(settings_changes) do
+    Repo.insert_all(SettingsChanges, settings_changes)
+  end
+
+  def fetch_all_settings_changes(),
+    do:
+      SettingsChanges
+      |> Repo.all()
 end

--- a/lib/oli/delivery/settings/settings_changes.ex
+++ b/lib/oli/delivery/settings/settings_changes.ex
@@ -8,6 +8,7 @@ defmodule Oli.Delivery.Settings.SettingsChanges do
     belongs_to(:section, Oli.Delivery.Sections.Section)
     belongs_to(:user, Oli.Accounts.User)
 
+    field(:user_type, Ecto.Enum, values: [:author, :instructor])
     field(:key, :string)
     field(:new_value, :string)
     field(:old_value, :string)
@@ -21,6 +22,7 @@ defmodule Oli.Delivery.Settings.SettingsChanges do
       :user_id,
       :section_id,
       :resource_id,
+      :user_type,
       :key,
       :new_value,
       :old_value

--- a/lib/oli/delivery/settings/settings_changes.ex
+++ b/lib/oli/delivery/settings/settings_changes.ex
@@ -6,8 +6,8 @@ defmodule Oli.Delivery.Settings.SettingsChanges do
   schema "settings_changes" do
     belongs_to(:resource, Oli.Resources.Resource)
     belongs_to(:section, Oli.Delivery.Sections.Section)
-    belongs_to(:user, Oli.Accounts.User)
 
+    field(:user_id, :integer)
     field(:user_type, Ecto.Enum, values: [:author, :instructor])
     field(:key, :string)
     field(:new_value, :string)

--- a/lib/oli/delivery/settings/settings_changes.ex
+++ b/lib/oli/delivery/settings/settings_changes.ex
@@ -1,0 +1,30 @@
+defmodule Oli.Delivery.Settings.SettingsChanges do
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  schema "settings_changes" do
+    belongs_to(:resource, Oli.Resources.Resource)
+    belongs_to(:section, Oli.Delivery.Sections.Section)
+    belongs_to(:user, Oli.Accounts.User)
+
+    field(:key, :string)
+    field(:new_value, :string)
+    field(:old_value, :string)
+
+    timestamps(type: :utc_datetime)
+  end
+
+  def changeset(settings_change, attrs) do
+    settings_change
+    |> cast(attrs, [
+      :user_id,
+      :section_id,
+      :resource_id,
+      :key,
+      :new_value,
+      :old_value
+    ])
+    |> validate_required([:user_id, :section_id, :resource_id])
+  end
+end

--- a/lib/oli_web/components/layouts/instructor_dashboard.html.heex
+++ b/lib/oli_web/components/layouts/instructor_dashboard.html.heex
@@ -13,7 +13,10 @@
   />
 
   <div class="relative flex-1 flex flex-col pt-4 pb-[60px]">
-    <div class="container mx-auto sticky top-16 z-50">
+    <div
+      :if={assigns[:params]["active_tab"] != "settings"}
+      class="container mx-auto sticky top-16 z-50"
+    >
       <.flash_group flash={@flash} />
     </div>
 

--- a/lib/oli_web/live/sections/assessment_settings/settings_live.ex
+++ b/lib/oli_web/live/sections/assessment_settings/settings_live.ex
@@ -299,7 +299,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLive do
     <% end %>
     <%= if live_flash(@flash, :error) do %>
       <div class="alert alert-danger flex flex-row justify-between" role="alert">
-        {live_flash(@flash, :error)}
+        <%= live_flash(@flash, :error) %>
         <button
           type="button"
           class="close ml-4"

--- a/lib/oli_web/live/sections/assessment_settings/settings_table.ex
+++ b/lib/oli_web/live/sections/assessment_settings/settings_table.ex
@@ -11,7 +11,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTable do
   alias OliWeb.Sections.AssessmentSettings.SettingsTableModel
   alias Phoenix.LiveView.JS
   alias OliWeb.Router.Helpers, as: Routes
-  alias Oli.Delivery.Sections
+  alias Oli.Delivery.{Sections, Settings}
   alias Oli.Delivery.Sections.SectionResource
   alias Oli.Publishing.DeliveryResolver
   alias Oli.{Repo, Utils}
@@ -640,13 +640,17 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTable do
         },
         socket
       ) do
+    %{section: section, ctx: %{user: user}} = socket.assigns
+
     utc_datetime =
       FormatDateTime.datestring_to_utc_datetime(
         feedback_scheduled_date,
         socket.assigns.ctx
       )
 
-    socket.assigns.modal_assigns.assessment_for_scheduled
+    assessment = socket.assigns.modal_assigns.assessment_for_scheduled
+
+    assessment
     |> SectionResource.changeset(%{
       feedback_scheduled_date: utc_datetime,
       feedback_mode: :scheduled
@@ -661,21 +665,39 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTable do
          )}
 
       {:ok, _section_resource} ->
-        {
-          :noreply,
-          socket
-          |> update_assessments(
-            socket.assigns.modal_assigns.changeset.data.resource_id,
-            [
-              {:feedback_scheduled_date, utc_datetime},
-              {:feedback_mode, :scheduled}
-            ],
-            false
-          )
-          |> flash_to_liveview(:info, "Setting updated!")
-          |> assign(modal_assigns: %{show: false})
-          |> assign(form_id: UUID.uuid4())
-        }
+        old_value =
+          get_old_value(socket.assigns.assessments, assessment.resource_id, :feedback_mode)
+
+        case Settings.insert_settings_change(%{
+               resource_id: 1,
+               section_id: section.id,
+               user_id: user.id,
+               key: Atom.to_string(:feedback_mode),
+               new_value: Kernel.to_string(feedback_scheduled_date),
+               old_value: Kernel.to_string(old_value)
+             }) do
+          {:ok, _} ->
+            {
+              :noreply,
+              socket
+              |> update_assessments(
+                socket.assigns.modal_assigns.changeset.data.resource_id,
+                [
+                  {:feedback_scheduled_date, utc_datetime},
+                  {:feedback_mode, :scheduled}
+                ],
+                false
+              )
+              |> flash_to_liveview(:info, "Setting updated!")
+              |> assign(modal_assigns: %{show: false})
+              |> assign(form_id: UUID.uuid4())
+            }
+
+          {:error, _} ->
+            {:noreply,
+             socket
+             |> flash_to_liveview(:error, "ERROR: Setting change not be inserted")}
+        end
     end
   end
 
@@ -745,24 +767,42 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTable do
 
   defp on_edit_date(date_field, new_date, socket) do
     assessment = socket.assigns.selected_assessment
+    %{section: section, ctx: %{user: user}} = socket.assigns
 
     {new_start_date, new_end_date, message} =
       maybe_adjust_dates(date_field, new_date, assessment, socket.assigns.ctx)
 
     case perform_edits(assessment, date_field, new_start_date, new_end_date, socket) do
       {:ok, {section_resource, additional_message}} ->
-        {:noreply,
-         socket
-         |> update_assessments(
-           assessment.resource_id,
-           [
-             {:start_date, new_start_date},
-             {:end_date, new_end_date}
-             | maybe_add_scheduling_type(date_field, section_resource)
-           ],
-           false
-         )
-         |> flash_to_liveview(:info, "Setting updated. #{message}#{additional_message}")}
+        old_value = get_old_value(socket.assigns.assessments, assessment.resource_id, date_field)
+
+        case Settings.insert_settings_change(%{
+               resource_id: assessment.resource_id,
+               section_id: section.id,
+               user_id: user.id,
+               key: Atom.to_string(date_field),
+               new_value: Kernel.to_string(new_date),
+               old_value: Kernel.to_string(old_value)
+             }) do
+          {:ok, _} ->
+            {:noreply,
+             socket
+             |> update_assessments(
+               assessment.resource_id,
+               [
+                 {:start_date, new_start_date},
+                 {:end_date, new_end_date}
+                 | maybe_add_scheduling_type(date_field, section_resource)
+               ],
+               false
+             )
+             |> flash_to_liveview(:info, "Setting updated. #{message}#{additional_message}")}
+
+          {:error, _} ->
+            {:noreply,
+             socket
+             |> flash_to_liveview(:error, "ERROR: Setting change not be inserted")}
+        end
 
       _ ->
         {:noreply,
@@ -792,6 +832,8 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTable do
   defp maybe_add_scheduling_type(:start_date, _section_resource), do: []
 
   defp do_update(key, assessment_setting_id, new_value, socket) do
+    %{section: section, ctx: %{user: user}} = socket.assigns
+
     Sections.get_section_resource(
       socket.assigns.section.id,
       assessment_setting_id
@@ -804,12 +846,38 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTable do
          |> flash_to_liveview(:error, "ERROR: Setting could not be updated")}
 
       {:ok, _section_resource} ->
-        {
-          :noreply,
-          socket
-          |> update_assessments(assessment_setting_id, [{key, new_value}], false)
-          |> flash_to_liveview(:info, "Setting updated!")
-        }
+        old_value = get_old_value(socket.assigns.assessments, assessment_setting_id, key)
+
+        case Settings.insert_settings_change(%{
+               resource_id: assessment_setting_id,
+               section_id: section.id,
+               user_id: user.id,
+               key: Atom.to_string(key),
+               new_value: Kernel.to_string(new_value),
+               old_value: Kernel.to_string(old_value)
+             }) do
+          {:ok, _} ->
+            {
+              :noreply,
+              socket
+              |> update_assessments(assessment_setting_id, [{key, new_value}], false)
+              |> flash_to_liveview(:info, "Setting updated!")
+            }
+
+          {:error, _} ->
+            {:noreply,
+             socket
+             |> flash_to_liveview(:error, "ERROR: Setting change not be inserted")}
+        end
+    end
+  end
+
+  def get_old_value(assessments_list, resource_id, key) do
+    assessments_list
+    |> Enum.find(fn assessment -> assessment.resource_id == resource_id end)
+    |> case do
+      nil -> nil
+      assessment -> Map.get(assessment, key)
     end
   end
 

--- a/priv/repo/migrations/20240620202825_create_settings_changes.exs
+++ b/priv/repo/migrations/20240620202825_create_settings_changes.exs
@@ -1,0 +1,16 @@
+defmodule Oli.Repo.Migrations.CreateSettingsChanges do
+  use Ecto.Migration
+
+  def change do
+    create table(:settings_changes) do
+      add :resource_id, references(:resources)
+      add :section_id, references(:sections)
+      add :user_id, references(:users)
+      add :key, :string
+      add :new_value, :string
+      add :old_value, :string
+
+      timestamps()
+    end
+  end
+end

--- a/priv/repo/migrations/20240620202825_create_settings_changes.exs
+++ b/priv/repo/migrations/20240620202825_create_settings_changes.exs
@@ -6,6 +6,7 @@ defmodule Oli.Repo.Migrations.CreateSettingsChanges do
       add :resource_id, references(:resources)
       add :section_id, references(:sections)
       add :user_id, references(:users)
+      add :user_type, :string
       add :key, :string
       add :new_value, :string
       add :old_value, :string

--- a/priv/repo/migrations/20240620202825_create_settings_changes.exs
+++ b/priv/repo/migrations/20240620202825_create_settings_changes.exs
@@ -5,7 +5,7 @@ defmodule Oli.Repo.Migrations.CreateSettingsChanges do
     create table(:settings_changes) do
       add :resource_id, references(:resources)
       add :section_id, references(:sections)
-      add :user_id, references(:users)
+      add :user_id, :integer
       add :user_type, :string
       add :key, :string
       add :new_value, :string


### PR DESCRIPTION
[MER-3065](https://eliterate.atlassian.net/browse/MER-3065)

This PR implements a tracking of all changes made in the `Assessment Settings` view, both for the individual changes of each setting and for the existing bulk apply option.

This new functionality will store the changes in a new table called `settings_changes` in the database.

[MER-3065]: https://eliterate.atlassian.net/browse/MER-3065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ