### PR TITLE
[BUG FIX] [MER-3401] Fixes instructor course search bug

### DIFF
--- a/lib/oli_web/live/delivery/open_and_free_index.ex
+++ b/lib/oli_web/live/delivery/open_and_free_index.ex
@@ -78,7 +78,7 @@ defmodule OliWeb.Delivery.OpenAndFreeIndex do
               <.form for={%{}} phx-change="search_section" class="w-[330px]">
                 <SearchInput.render
                   id="section_search_input"
-                  name="search"
+                  name="text_search"
                   placeholder="Search by course or instructor name"
                   text={@params.text_search}
                 />
@@ -158,7 +158,7 @@ defmodule OliWeb.Delivery.OpenAndFreeIndex do
   end
 
   @impl Phoenix.LiveView
-  def handle_event("search_section", %{"search" => text_search}, socket) do
+  def handle_event("search_section", %{"text_search" => text_search}, socket) do
     {:noreply, push_patch(socket, to: ~p"/sections?#{%{text_search: text_search}}")}
   end
 

--- a/test/oli_web/live/delivery/open_and_free_index_test.exs
+++ b/test/oli_web/live/delivery/open_and_free_index_test.exs
@@ -176,21 +176,21 @@ defmodule OliWeb.Delivery.OpenAndFreeIndexTest do
 
       view
       |> form("form[phx-change=search_section]")
-      |> render_change(%{search: "best"})
+      |> render_change(%{text_search: "best"})
 
       assert has_element?(view, "h5", "The best course ever!")
       refute has_element?(view, "h5", "Maths")
 
       view
       |> form("form[phx-change=search_section]")
-      |> render_change(%{search: ""})
+      |> render_change(%{text_search: ""})
 
       assert has_element?(view, "h5", "The best course ever!")
       assert has_element?(view, "h5", "Maths")
 
       view
       |> form("form[phx-change=search_section]")
-      |> render_change(%{search: "a not existing course"})
+      |> render_change(%{text_search: "a not existing course"})
 
       refute has_element?(view, "h5", "The best course ever!")
       refute has_element?(view, "h5", "Maths")
@@ -222,7 +222,7 @@ defmodule OliWeb.Delivery.OpenAndFreeIndexTest do
 
       view
       |> form("form[phx-change=search_section]")
-      |> render_change(%{search: "messi"})
+      |> render_change(%{text_search: "messi"})
 
       assert has_element?(view, "h5", "The best course ever!")
       assert has_element?(view, "h5", "Maths")
@@ -230,7 +230,7 @@ defmodule OliWeb.Delivery.OpenAndFreeIndexTest do
 
       view
       |> form("form[phx-change=search_section]")
-      |> render_change(%{search: "maria"})
+      |> render_change(%{text_search: "maria"})
 
       refute has_element?(view, "h5", "The best course ever!")
       assert has_element?(view, "h5", "Maths")
@@ -238,7 +238,7 @@ defmodule OliWeb.Delivery.OpenAndFreeIndexTest do
 
       view
       |> form("form[phx-change=search_section]")
-      |> render_change(%{search: "a not existing instructor"})
+      |> render_change(%{text_search: "a not existing instructor"})
 
       refute has_element?(view, "h5", "The best course ever!")
       refute has_element?(view, "h5", "Maths")


### PR DESCRIPTION
This PR fixes an issue where hitting the enter button after typing text in the course search field reloads the instructor dashboard without applying the search criterion. 