### PR TITLE
[BUG FIX] [NG23-256] No branding when not in a section

### DIFF
--- a/lib/oli_web/components/delivery/instructor_dashboard.ex
+++ b/lib/oli_web/components/delivery/instructor_dashboard.ex
@@ -176,7 +176,8 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard do
             class="navbar-brand dark torus-logo my-1 mr-auto"
             href={logo_link(@section, @preview_mode)}
           >
-            <%= brand_logo(Map.merge(assigns, %{class: "d-inline-block align-top mr-2"})) %>
+            <%= if assigns[:section],
+              do: brand_logo(Map.merge(assigns, %{class: "d-inline-block align-top mr-2"})) %>
           </a>
         </div>
 

--- a/lib/oli_web/views/view_helpers.ex
+++ b/lib/oli_web/views/view_helpers.ex
@@ -27,13 +27,11 @@ defmodule OliWeb.ViewHelpers do
   def brand_logo(assigns) do
     ~H"""
     <img
-      :if={assigns[:section]}
       src={brand_logo_url(assigns[:section])}
       class={[value_or(assigns[:class], ""), "inline-block dark:hidden"]}
       alt={brand_name(assigns[:section])}
     />
     <img
-      :if={assigns[:section]}
       src={brand_logo_url_dark(assigns[:section])}
       class={[value_or(assigns[:class], ""), "hidden dark:inline-block"]}
       alt={brand_name(assigns[:section])}


### PR DESCRIPTION
[NG23-256](https://eliterate.atlassian.net/browse/NG23-256)

Add missing brand logo image when not logged in.

**Before:**
![Screenshot 2024-06-27 at 3 18 00 PM](https://github.com/Simon-Initiative/oli-torus/assets/26532202/5d5a0168-b03d-4ec7-9a6e-e6f33b3d4527)


**After:**
![Screenshot 2024-06-27 at 3 18 54 PM](https://github.com/Simon-Initiative/oli-torus/assets/26532202/75d165f2-ae6b-4ce0-911d-c7731616e9c4)


[NG23-256]: https://eliterate.atlassian.net/browse/NG23-256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ