### PR TITLE
[ENHANCEMENT] [NG23-253] Optimize memory usage of lesson live

### DIFF
--- a/lib/oli_web/live/delivery/student/prologue_live.ex
+++ b/lib/oli_web/live/delivery/student/prologue_live.ex
@@ -4,9 +4,11 @@ defmodule OliWeb.Delivery.Student.PrologueLive do
   import OliWeb.Delivery.Student.Utils,
     only: [page_header: 1]
 
+  alias Oli.Accounts.User
   alias Oli.Delivery.Attempts.Core.ResourceAttempt
   alias Oli.Delivery.Attempts.PageLifecycle
   alias Oli.Delivery.Metrics
+  alias Oli.Delivery.Sections
   alias Oli.Delivery.Settings
   alias Oli.Publishing.DeliveryResolver, as: Resolver
   alias OliWeb.Common.FormatDateTime
@@ -19,15 +21,42 @@ defmodule OliWeb.Delivery.Student.PrologueLive do
   on_mount {OliWeb.LiveSessionPlugs.InitPage, :init_context_state}
   on_mount {OliWeb.LiveSessionPlugs.InitPage, :previous_next_index}
 
+  # this is an optimization to reduce the memory footprint of the liveview process
+  @required_keys_per_assign %{
+    section:
+      {[:id, :slug, :title, :brand, :lti_1p3_deployment, :resource_gating_index],
+       %Sections.Section{}},
+    current_user: {[:id, :name, :email], %User{}}
+  }
+
   def mount(params, _session, socket) do
+    %{page_context: page_context} = socket.assigns
+
+    if connected?(socket) do
+      send(self(), :gc)
+    end
+
     {:ok,
      socket
      |> assign_objectives()
-     |> assign(request_path: params["request_path"], selected_view: params["selected_view"])}
+     |> assign(
+       request_path: params["request_path"],
+       selected_view: params["selected_view"],
+       password: page_context.effective_settings.password,
+       page_revision: page_context.page,
+       effective_settings: page_context.effective_settings
+     )
+     |> slim_assigns(), temporary_assigns: [page_context: %{}]}
+  end
+
+  def handle_info(:gc, socket) do
+    :erlang.garbage_collect(socket.transport_pid)
+    :erlang.garbage_collect(self())
+    {:noreply, socket}
   end
 
   def handle_event("begin_attempt", %{"password" => password}, socket)
-      when password != socket.assigns.page_context.effective_settings.password do
+      when password != socket.assigns.password do
     {:noreply, put_flash(socket, :error, "Incorrect password")}
   end
 
@@ -35,13 +64,14 @@ defmodule OliWeb.Delivery.Student.PrologueLive do
     %{
       current_user: user,
       section: section,
-      page_context: %{effective_settings: effective_settings, page: revision},
+      page_revision: page_revision,
+      effective_settings: effective_settings,
       ctx: ctx
     } = socket.assigns
 
     case Settings.check_start_date(effective_settings) do
       {:allowed} ->
-        do_start_attempt(socket, section, user, revision, effective_settings)
+        do_start_attempt(socket, section, user, page_revision, effective_settings)
 
       {:before_start_date} ->
         {:noreply,
@@ -350,5 +380,19 @@ defmodule OliWeb.Delivery.Student.PrologueLive do
       [] -> :ok
       gates -> {:error, {:gates, gates}}
     end
+  end
+
+  defp slim_assigns(socket) do
+    Enum.reduce(@required_keys_per_assign, socket, fn {assign_name, {required_keys, struct}},
+                                                      socket ->
+      assign(
+        socket,
+        assign_name,
+        Map.merge(
+          struct,
+          Map.filter(socket.assigns[assign_name], fn {k, _v} -> k in required_keys end)
+        )
+      )
+    end)
   end
 end

--- a/lib/oli_web/live/delivery/student/review_live.ex
+++ b/lib/oli_web/live/delivery/student/review_live.ex
@@ -7,11 +7,19 @@ defmodule OliWeb.Delivery.Student.ReviewLive do
   import OliWeb.Delivery.Student.Utils,
     only: [page_header: 1, scripts: 1]
 
+  alias Oli.Accounts.User
   alias Oli.Delivery.Attempts.PageLifecycle
   alias Oli.Delivery.Page.PageContext
   alias Oli.Delivery.Metrics
+  alias Oli.Delivery.Sections
   alias Oli.Publishing.DeliveryResolver, as: Resolver
   alias OliWeb.Delivery.Student.Utils
+
+  # this is an optimization to reduce the memory footprint of the liveview process
+  @required_keys_per_assign %{
+    section: {[:id, :slug, :title, :brand, :lti_1p3_deployment], %Sections.Section{}},
+    current_user: {[:id, :name, :email], %User{}}
+  }
 
   def mount(
         %{
@@ -33,13 +41,31 @@ defmodule OliWeb.Delivery.Student.ReviewLive do
         |> assign(page_revision: page_revision)
         |> assign_html_and_scripts()
         |> assign_objectives()
+        |> slim_assigns()
       else
         socket
         |> put_flash(:error, "You are not allowed to review this attempt.")
         |> redirect(to: Utils.learn_live_path(section.slug))
       end
 
-    {:ok, socket}
+    if connected?(socket) do
+      send(self(), :gc)
+    end
+
+    {:ok, socket,
+     temporary_assigns: [
+       scripts: [],
+       html: [],
+       page_context: %{},
+       page_revision: %{},
+       objectives: []
+     ]}
+  end
+
+  def handle_info(:gc, socket) do
+    :erlang.garbage_collect(socket.transport_pid)
+    :erlang.garbage_collect(self())
+    {:noreply, socket}
   end
 
   defp assign_objectives(socket) do
@@ -127,5 +153,19 @@ defmodule OliWeb.Delivery.Student.ReviewLive do
     |> assign(
       scripts: Utils.get_required_activity_scripts(socket.assigns.page_context.activities || [])
     )
+  end
+
+  defp slim_assigns(socket) do
+    Enum.reduce(@required_keys_per_assign, socket, fn {assign_name, {required_keys, struct}},
+                                                      socket ->
+      assign(
+        socket,
+        assign_name,
+        Map.merge(
+          struct,
+          Map.filter(socket.assigns[assign_name], fn {k, _v} -> k in required_keys end)
+        )
+      )
+    end)
   end
 end


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/NG23-253) to the ticket

The base branch for this ticket is `NG23-246-content-on-page-is-not-visible-on-begin-attempt` because that branch has the refactor that splits the prologue from the lesson liveview. => This PR should be merged after the [NG23-246 PR](https://github.com/Simon-Initiative/oli-torus/pull/4895) gets merged.

The memory usage optimization was implemented for the lesson live -as the ticket asked- and also for the prologue live and the review live, since I noticed those 2 other liveviews also had high memory usage.

The strategy for the optimization was:

- slimming the assigns
- implementing temporary assigns (mainly for page_context which is a large map)
- manually triggering the garbage collection after the liveview was mounted.

### Lesson Live

#### On mount before
<img width="1127" alt="lesson_live_mount_before" src="https://github.com/Simon-Initiative/oli-torus/assets/74839302/d543da17-e8d0-4dc7-9b8f-331a19e487fc">

#### On mount after
<img width="1127" alt="lesson_live_mount_after" src="https://github.com/Simon-Initiative/oli-torus/assets/74839302/66bb55b3-64ac-47f6-8f04-32192ab46017">

#### Hibernation before
<img width="1127" alt="lesson_live_hibernate_before" src="https://github.com/Simon-Initiative/oli-torus/assets/74839302/b0290ec7-2a41-4c93-bf45-27b75f393331">

#### Hibernation after
<img width="1127" alt="lesson_live_hibernate_after" src="https://github.com/Simon-Initiative/oli-torus/assets/74839302/78e36afc-6a9c-4042-9235-15f1efcdcac8">



### Review Live

#### On mount before
<img width="1127" alt="review_live_mount_before" src="https://github.com/Simon-Initiative/oli-torus/assets/74839302/7e8a7704-0800-4bfb-a544-1e482f89c6ba">

#### On mount after
<img width="1127" alt="review_live_mount_after" src="https://github.com/Simon-Initiative/oli-torus/assets/74839302/4efb4674-1d87-488c-a9fe-75e8e5086f4e">

#### Hibernation before
<img width="1127" alt="review_live_hibernate_before" src="https://github.com/Simon-Initiative/oli-torus/assets/74839302/0c5b007e-1f69-4757-a79b-40470e82422b">

#### Hibernation after
<img width="1127" alt="review_live_hibernate_after" src="https://github.com/Simon-Initiative/oli-torus/assets/74839302/e9b6a09a-76f6-40b1-9f3d-9f30b7909459">



### Prologue Live

#### On mount before
<img width="1127" alt="prologue_live_mount_before" src="https://github.com/Simon-Initiative/oli-torus/assets/74839302/e9680e64-112a-47e8-b5bc-3ac60a94205d">

#### On mount after
<img width="1127" alt="prologue_live_mount_after" src="https://github.com/Simon-Initiative/oli-torus/assets/74839302/d144a470-b449-469a-b6a3-a623938d0a9a">

#### Hibernation before
<img width="1127" alt="prologue_live_hibernate_before" src="https://github.com/Simon-Initiative/oli-torus/assets/74839302/f22e0dd6-bbe1-4382-a40a-bb2656ead202">

#### Hibernation after
<img width="1127" alt="prologue_live_hibernate_after" src="https://github.com/Simon-Initiative/oli-torus/assets/74839302/9d2a4640-455c-4ddd-90b2-f28cd406e6b0">


