### PR TITLE
[BUG FIX] [NG23-259] Custom container labels not honored on Learn Page

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -4761,7 +4761,8 @@ defmodule Oli.Delivery.Sections do
            {nil, nil}
 
          c ->
-           {c.id, ~s{#{get_container_label_and_numbering(c, c.customizations)}: #{c.title}}}
+           {c.id,
+            ~s{#{get_container_label_and_numbering(c.numbering_level, c.numbering_index, c.customizations)}: #{c.title}}}
        end}
     end)
     |> Enum.into(%{})
@@ -4770,13 +4771,27 @@ defmodule Oli.Delivery.Sections do
   @doc """
   Returns the container label and numbering for a given container.
   If the container has any customizations, they are considered in the label.
+
   Examples:
-  "Module 2"
-  "Unit 1"
-  "Section 1"
+
+  customizations = %{
+    unit: "Unidad",
+    module: "Módulo",
+    section: "Sección"
+  }
+
+  iex> get_container_label_and_numbering(0, 1, customizations)
+  "Curriculum 1"
+  iex> get_container_label_and_numbering(1, 10, customizations)
+  "Unidad 10"
+  iex> get_container_label_and_numbering(0, 1, nil)
+  "Curriculum 1"
+  iex> get_container_label_and_numbering(1, 10, nil)
+  "Unit 10"
   """
-  def get_container_label_and_numbering(container, customizations) do
-    ~s{#{get_container_label(container.numbering_level, customizations || Map.from_struct(CustomLabels.default()))} #{container.numbering_index}}
+  @spec get_container_label_and_numbering(integer(), integer(), map()) :: String.t()
+  def get_container_label_and_numbering(numbering_level, numbering, customizations) do
+    ~s{#{get_container_label(numbering_level, customizations || Map.from_struct(CustomLabels.default()))} #{numbering}}
   end
 
   defp get_container_label(

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -909,7 +909,11 @@ defmodule OliWeb.Delivery.Student.LearnLive do
       <div class="md:p-[25px] md:pl-[50px]" role={"unit_#{@unit["numbering"]["index"]}"}>
         <div class="flex flex-col md:flex-row md:gap-[30px]">
           <div class="text-[14px] leading-[19px] tracking-[1.4px] uppercase mt-[7px] mb-1 whitespace-nowrap opacity-60">
-            <%= "UNIT #{@unit["numbering"]["index"]}" %>
+            <%= container_label_and_numbering(
+              @unit["numbering"]["level"],
+              @unit["numbering"]["index"],
+              @section.customizations
+            ) %>
           </div>
           <div class="mb-6 flex flex-col items-start gap-[6px] w-full">
             <div class="flex w-full">
@@ -980,6 +984,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
                 :for={module <- @unit["children"]}
                 card={module}
                 module_index={module["numbering"]["index"]}
+                section_customizations={@section.customizations}
                 unit_resource_id={@unit["resource_id"]}
                 unit_numbering_index={@unit["numbering"]["index"]}
                 bg_image_url={module["poster_image"]}
@@ -1027,9 +1032,15 @@ defmodule OliWeb.Delivery.Student.LearnLive do
           >
             <div class="justify-start items-start gap-1 inline-flex">
               <div class="opacity-60 dark:text-white text-sm font-bold font-['Open Sans'] uppercase tracking-tight">
-                Module <%= Map.get(@selected_module_per_unit_resource_id, @unit["resource_id"])[
-                  "numbering"
-                ]["index"] %>
+                <%= container_label_and_numbering(
+                  Map.get(@selected_module_per_unit_resource_id, @unit["resource_id"])["numbering"][
+                    "level"
+                  ],
+                  Map.get(@selected_module_per_unit_resource_id, @unit["resource_id"])["numbering"][
+                    "index"
+                  ],
+                  @section.customizations
+                ) %>
               </div>
             </div>
             <h2 class="self-stretch opacity-90 text-center text-[26px] font-normal font-['Open Sans'] leading-loose tracking-tight dark:text-white">
@@ -1186,7 +1197,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
       <div class="md:p-[25px] md:pl-[125px] md:pr-[175px]" role={"row_#{@row["numbering"]["index"]}"}>
         <div class="flex flex-col md:flex-row md:gap-[30px]">
           <div class="dark:text-white text-xl font-bold font-['Open Sans']">
-            <%= "Unit #{@row["numbering"]["index"]}: #{@row["title"]}" %>
+            <%= "#{Sections.get_container_label_and_numbering(1, @row["numbering"]["index"], @section.customizations)}: #{@row["title"]}" %>
           </div>
         </div>
         <div class="flex flex-col mt-6">
@@ -1964,6 +1975,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
   attr :card, :map
   attr :module_index, :integer
   attr :unit_numbering_index, :integer
+  attr :section_customizations, :map
   attr :unit_resource_id, :string
   attr :selected, :boolean, default: false
   attr :bg_image_url, :string, doc: "the background image url for the card"
@@ -2036,7 +2048,12 @@ defmodule OliWeb.Delivery.Student.LearnLive do
           >
             <%= if @is_page,
               do: "PAGE",
-              else: "MODULE #{@module_index}" %>
+              else:
+                container_label_and_numbering(
+                  @card["numbering"]["level"],
+                  @module_index,
+                  @section_customizations
+                ) %>
           </span>
           <h5 class="pointer-events-none text-[18px] leading-[25px] font-bold text-white z-10">
             <%= @card["title"] %>
@@ -2801,4 +2818,9 @@ defmodule OliWeb.Delivery.Student.LearnLive do
   end
 
   defp parse_card_badge_minutes(_, _), do: nil
+
+  defp container_label_and_numbering(numbering_level, numbering, customizations) do
+    Sections.get_container_label_and_numbering(numbering_level, numbering, customizations)
+    |> String.upcase()
+  end
 end

--- a/lib/oli_web/live/delivery/student/utils.ex
+++ b/lib/oli_web/live/delivery/student/utils.ex
@@ -381,7 +381,8 @@ defmodule OliWeb.Delivery.Student.Utils do
       end
 
     Sections.get_container_label_and_numbering(
-      container,
+      container.numbering_level,
+      container.numbering_index,
       section.customizations
     )
   end

--- a/lib/oli_web/live/sections/edit_view.ex
+++ b/lib/oli_web/live/sections/edit_view.ex
@@ -4,6 +4,7 @@ defmodule OliWeb.Sections.EditView do
   alias Oli.Branding
   alias OliWeb.Sections.StartEnd
   alias Oli.Delivery.Sections
+  alias Oli.Delivery.Sections.SectionCache
   alias OliWeb.Common.{Breadcrumb, SessionContext, FormatDateTime, CustomLabelsForm}
   alias OliWeb.Common.Properties.{Groups, Group}
   alias OliWeb.Router.Helpers, as: Routes
@@ -165,6 +166,9 @@ defmodule OliWeb.Sections.EditView do
 
     case Sections.update_section(socket.assigns.section, %{customizations: params}) do
       {:ok, section} ->
+        # we need to update the order container labels on the cache
+        SectionCache.clear(section.slug, [:ordered_container_labels])
+
         socket = put_flash(socket, :info, "Section changes saved")
 
         {:noreply,

--- a/test/oli/delivery/sections_test.exs
+++ b/test/oli/delivery/sections_test.exs
@@ -1647,7 +1647,7 @@ defmodule Oli.Delivery.SectionsTest do
     end
   end
 
-  describe "get_container_label_and_numbering/2" do
+  describe "get_container_label_and_numbering/3" do
     setup _ do
       author = insert(:author)
       project = insert(:project, authors: [author])
@@ -1781,32 +1781,38 @@ defmodule Oli.Delivery.SectionsTest do
         Sections.get_section_resource(section.id, unit_2.resource_id)
 
       assert Sections.get_container_label_and_numbering(
-               section_1_section_resource,
+               section_1_section_resource.numbering_level,
+               section_1_section_resource.numbering_index,
                section.customizations
              ) == "Section 1"
 
       assert Sections.get_container_label_and_numbering(
-               section_2_section_resource,
+               section_2_section_resource.numbering_level,
+               section_2_section_resource.numbering_index,
                section.customizations
              ) == "Section 2"
 
       assert Sections.get_container_label_and_numbering(
-               module_1_section_resource,
+               module_1_section_resource.numbering_level,
+               module_1_section_resource.numbering_index,
                section.customizations
              ) == "Module 1"
 
       assert Sections.get_container_label_and_numbering(
-               module_2_section_resource,
+               module_2_section_resource.numbering_level,
+               module_2_section_resource.numbering_index,
                section.customizations
              ) == "Module 2"
 
       assert Sections.get_container_label_and_numbering(
-               unit_1_section_resource,
+               unit_1_section_resource.numbering_level,
+               unit_1_section_resource.numbering_index,
                section.customizations
              ) == "Unit 1"
 
       assert Sections.get_container_label_and_numbering(
-               unit_2_section_resource,
+               unit_2_section_resource.numbering_level,
+               unit_2_section_resource.numbering_index,
                section.customizations
              ) == "Unit 2"
     end
@@ -1841,32 +1847,38 @@ defmodule Oli.Delivery.SectionsTest do
       custom_labels = %{unit: "Volume", module: "Chapter", section: "Lesson"}
 
       assert Sections.get_container_label_and_numbering(
-               section_1_section_resource,
+               section_1_section_resource.numbering_level,
+               section_1_section_resource.numbering_index,
                custom_labels
              ) == "Lesson 1"
 
       assert Sections.get_container_label_and_numbering(
-               section_2_section_resource,
+               section_2_section_resource.numbering_level,
+               section_2_section_resource.numbering_index,
                custom_labels
              ) == "Lesson 2"
 
       assert Sections.get_container_label_and_numbering(
-               module_1_section_resource,
+               module_1_section_resource.numbering_level,
+               module_1_section_resource.numbering_index,
                custom_labels
              ) == "Chapter 1"
 
       assert Sections.get_container_label_and_numbering(
-               module_2_section_resource,
+               module_2_section_resource.numbering_level,
+               module_2_section_resource.numbering_index,
                custom_labels
              ) == "Chapter 2"
 
       assert Sections.get_container_label_and_numbering(
-               unit_1_section_resource,
+               unit_1_section_resource.numbering_level,
+               unit_1_section_resource.numbering_index,
                custom_labels
              ) == "Volume 1"
 
       assert Sections.get_container_label_and_numbering(
-               unit_2_section_resource,
+               unit_2_section_resource.numbering_level,
+               unit_2_section_resource.numbering_index,
                custom_labels
              ) == "Volume 2"
     end


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/NG23-259) to the ticket

With this fix container labels are correctly shown on the Learn Page. 

https://github.com/Simon-Initiative/oli-torus/assets/74839302/01a813fc-95e9-4b7d-9c7d-55e39baea407

I also checked that all the other pages -Home, Schedule, etc- display container labels correctly.

While working on the ticket I realized that when the instructor changed the container labels, the new values weren't updated on the student delivery pages (I needed to restart the server to see the updated values). This was because some section fields, including the labels, are cached. To fix this the SectionCache module was updated to clear the desired cache keys.

**Suggestion:** 
Instructors can edit labels for "Unit", "Module" and "Section". Since our new NG UI renders some other labels -such as "Page", "Intro", "Explorations", etc- we should consider creating a ticket to expand the custom labels to consider those values.

![image](https://github.com/Simon-Initiative/oli-torus/assets/74839302/25d4936f-24be-4bf6-b6aa-6a2e205fe471)
