### PR TITLE
[BUG FIX] [NG23-205] ng dumps lti new instructors into student interface after course creation

### DIFF
--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -64,6 +64,9 @@ defmodule OliWeb.DeliveryController do
       nil ->
         render_course_not_configured(conn)
 
+      section when allow_configure_section ->
+        redirect_to_instructor_dashboard(conn, section)
+
       # section has been configured
       section ->
         {institution, _registration, _deployment} =
@@ -98,6 +101,12 @@ defmodule OliWeb.DeliveryController do
   defp redirect_to_page_delivery(conn, section) do
     redirect(conn,
       to: ~p"/sections/#{section.slug}"
+    )
+  end
+
+  defp redirect_to_instructor_dashboard(conn, section) do
+    redirect(conn,
+      to: ~p"/sections/#{section.slug}/instructor_dashboard/manage"
     )
   end
 

--- a/test/oli_web/controllers/delivery_controller_test.exs
+++ b/test/oli_web/controllers/delivery_controller_test.exs
@@ -75,8 +75,9 @@ defmodule OliWeb.DeliveryControllerTest do
       assert html_response(conn, 200) =~ "<h3>Create Course Section</h3>"
     end
 
-    test "handles instructor with section and research consent form", %{
+    test "handles LMS instructor with section and redirects to instructor dashboard", %{
       conn: conn,
+      section: section,
       lti_param_ids: lti_param_ids,
       user: user
     } do
@@ -92,21 +93,8 @@ defmodule OliWeb.DeliveryControllerTest do
         |> LtiSession.put_session_lti_params(lti_param_ids.instructor)
         |> get(Routes.delivery_path(conn, :index))
 
-      assert html_response(conn, 200) =~ "Online Consent Form"
-    end
-
-    test "handles instructor with section and no research consent form", %{
-      conn: conn,
-      section_no_rc: section_no_rc,
-      lti_param_ids: lti_param_ids
-    } do
-      conn =
-        conn
-        |> LtiSession.put_session_lti_params(lti_param_ids.instructor_no_rc)
-        |> get(Routes.delivery_path(conn, :index))
-
       assert html_response(conn, 302) =~
-               "You are being <a href=\"/sections/#{section_no_rc.slug}\">redirected"
+               "You are being <a href=\"/sections/#{section.slug}/instructor_dashboard/manage\">redirected"
     end
   end
 


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/NG23-205

Fixes an issue where instructor would be redirected to student view on subsequent launches. Now when an instructor launches, they will be directed to the instructor dashboard view.