### PR TITLE
[BUG FIX] [NG23-263] likert activity not restoring state beyond first item

### DIFF
--- a/assets/src/data/activities/utils.ts
+++ b/assets/src/data/activities/utils.ts
@@ -66,7 +66,10 @@ export const safelySelectFiles = (activityState: ActivityState | undefined): May
 export const initialPartInputs = (
   model: ActivityModelSchema,
   activityState: ActivityState,
-  defaultPartInputs: PartInputs = { [activityState.parts[0].partId]: [] },
+  defaultPartInputs: PartInputs = activityState.parts.reduce((acc, part) => {
+    acc[part.partId] = [];
+    return acc;
+  }, {} as PartInputs),
 ): PartInputs => {
   const savedPartInputs = activityState?.parts
     .filter((part) => part?.response?.input !== undefined)


### PR DESCRIPTION
Fixes an issue where activities with multiple part inputs were not being reinitialized past the first part input.

The issue here was the `defaultPartInputs` being calculated is used to derive the actual part inputs from the `activityState`. However, this initialization was hard coded to only generate a default part input for the first part in an activity, an assumption that was likely baked in before activities with multiple parts (such as Likert) existed.

The fix here generates default part inputs from all parts in the activity state.