### PR TITLE
[ENHANCEMENT] [MER-3291] Style direct delivery header

### DIFF
--- a/assets/tailwind.theme.js
+++ b/assets/tailwind.theme.js
@@ -316,6 +316,8 @@ module.exports = {
       hv2xl: { raw: '(min-width: 1536px) and (min-height: 950px)' },
     },
     colors: {
+      'high-24': { DEFAULT: '#EEEBF5' },
+      'primary-24': { DEFAULT: '#0D0C0F' },
       checkpoint: {
         DEFAULT: '#B27307',
         dark: '#FF8F40',

--- a/lib/oli_web/components/header.ex
+++ b/lib/oli_web/components/header.ex
@@ -95,6 +95,47 @@ defmodule OliWeb.Components.Header do
     """
   end
 
+  def delivery_header(assigns) do
+    ~H"""
+    <nav class="bg-primary-24 h-[111px] flex items-center pl-4 pr-10">
+      <a class="navbar-brand torus-logo my-1 mr-auto" href={~p"/"}>
+        <%= brand_logo(Map.merge(assigns, %{class: "d-inline-block align-top mr-2"})) %>
+      </a>
+      <.sign_in_button href="/authoring/session/new" request_path={assigns.conn.request_path}>
+        For Course Authors
+      </.sign_in_button>
+      <.sign_in_button href="/session/new" request_path={assigns.conn.request_path}>
+        For Instructors
+      </.sign_in_button>
+      <.button
+        id="support-button"
+        href="#"
+        class="pt-[12px] text-high-24 hover:text-high-24 hover:underline hover:underline-offset-8"
+        onclick="window.showHelpModal();"
+        phx-click={JS.dispatch("maybe_add_underline_classes", to: "#help-modal")}
+      >
+        Support
+      </.button>
+    </nav>
+    """
+  end
+
+  attr :href, :string, required: true
+  attr :request_path, :string, required: true
+
+  slot :inner_block, required: true
+
+  def sign_in_button(assigns) do
+    ~H"""
+    <.button
+      href={@href}
+      class={"pt-[12px] text-high-24 hover:text-high-24 hover:underline hover:underline-offset-8" <> maybe_add_underlined_classes(@request_path, @href)}
+    >
+      <%= render_slot(@inner_block) %>
+    </.button>
+    """
+  end
+
   attr(:breadcrumbs, :list, required: true)
   attr(:socket_or_conn, :any, required: true)
 
@@ -114,4 +155,7 @@ defmodule OliWeb.Components.Header do
     <% end %>
     """
   end
+
+  defp maybe_add_underlined_classes(path, path), do: " underline underline-offset-8"
+  defp maybe_add_underlined_classes(_request_path, _href), do: ""
 end

--- a/lib/oli_web/templates/layout/default.html.heex
+++ b/lib/oli_web/templates/layout/default.html.heex
@@ -4,7 +4,7 @@
   </a>
 
   <div class="default">
-    <Components.Header.header {assigns} />
+    <Components.Header.delivery_header {assigns} />
 
     <main role="main" id="main-content" class="pb-20">
       <%= @inner_content %>

--- a/lib/oli_web/templates/shared/_help.html.heex
+++ b/lib/oli_web/templates/shared/_help.html.heex
@@ -7,9 +7,13 @@
   tabindex="-1"
   aria-labelledby="exampleModalLabel"
   aria-hidden="true"
+  style="display: none;"
 >
   <div class="modal-dialog modal-lg relative w-auto pointer-events-none">
-    <div class="modal-content border-none shadow-lg relative flex flex-col w-full pointer-events-auto bg-white bg-clip-padding rounded-md outline-none">
+    <div
+      id="inside_modal"
+      class="modal-content border-none shadow-lg relative flex flex-col w-full pointer-events-auto bg-white bg-clip-padding rounded-md outline-none"
+    >
       <%= form_for :help, "#", [id: "form-request-help"], fn f -> %>
         <div class="modal-header flex flex-shrink-0 items-center justify-between p-4 border-b border-gray-200 rounded-t-md">
           <h5 class="modal-title text-xl font-medium leading-normal inline-flex">
@@ -20,6 +24,7 @@
             class="btn-close box-content w-4 h-4 p-1 border-none rounded-none opacity-50 focus:shadow-none focus:outline-none focus:opacity-100 hover:opacity-75 hover:no-underline"
             data-bs-dismiss="modal"
             aria-label="Close"
+            onclick="maybe_remove_undeline_classes()"
           >
             <i class="fa-solid fa-xmark fa-xl"></i>
           </button>
@@ -100,7 +105,12 @@
         </div>
         <div class="modal-footer flex flex-shrink-0 flex-wrap items-center justify-end p-4 border-t border-gray-200 rounded-b-md">
           <div id="help-form-buttons">
-            <button type="button" class="btn btn-link ml-2" data-bs-dismiss="modal">
+            <button
+              type="button"
+              class="btn btn-link ml-2"
+              data-bs-dismiss="modal"
+              onclick="maybe_remove_undeline_classes()"
+            >
               Cancel
             </button>
             <%= submit("Send Request",
@@ -187,6 +197,7 @@
                 const okButton = document.getElementById('help-form-ok-button');
                 okButton.classList.remove('hidden');
 
+                document.getElementById("support-button").classList.remove('underline', 'underline-offset-8');
                 return json
               })
               .catch((error) => {
@@ -195,6 +206,20 @@
                 errorElement.classList.remove('hidden');
                 return error
               });
-    });
-  }
+      });
+    }
+
+  window.addEventListener("maybe_add_underline_classes", e => {
+    document.getElementById("support-button").classList.add('underline', 'underline-offset-8');
+  });
+
+  function maybe_remove_undeline_classes() {
+    document.getElementById("support-button").classList.remove('underline', 'underline-offset-8');
+  };
+
+  document.addEventListener('click', (event) => {
+    const target = document.querySelector('#inside_modal');
+    const withinBoundaries = event.composedPath().includes(target);
+    if (!withinBoundaries) {maybe_remove_undeline_classes();}
+  });
 </script>

--- a/test/oli_web/controllers/static_page_controller_test.exs
+++ b/test/oli_web/controllers/static_page_controller_test.exs
@@ -7,8 +7,8 @@ defmodule OliWeb.StaticPageControllerTest do
     conn = get(conn, "/")
 
     assert html_response(conn, 200) =~ "Welcome to"
-    assert html_response(conn, 200) =~ "Learner/Educator Sign In"
-    assert html_response(conn, 200) =~ "Authoring Sign In"
+    assert html_response(conn, 200) =~ "For Instructors"
+    assert html_response(conn, 200) =~ "For Course Authors"
   end
 
   describe "set_session" do


### PR DESCRIPTION
Ticket [MER-3291](https://eliterate.atlassian.net/browse/MER-3291)

This PR adds new styling corresponding to the epic mentioned in the ticket.

Two colors were defined in `tailwind.theme.js` for future use --`high-24` & `primary-24`.

The following video shows the new styling on the sign-in pages; otherwise, the style remains the same.

https://github.com/Simon-Initiative/oli-torus/assets/47334502/749775e1-5c16-4c1f-9946-76970151cf06



[MER-3291]: https://eliterate.atlassian.net/browse/MER-3291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ