### PR TITLE
[BUG FIX] [NG23-265] Correct typo on Gating page

### DIFF
--- a/lib/oli_web/live/sections/gating_and_scheduling/form.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling/form.ex
@@ -386,7 +386,7 @@ defmodule OliWeb.Sections.GatingAndScheduling.Form do
 
     ~H"""
     <div class="form-group">
-      <label for="source">Resource That Must Has Progress</label>
+      <label for="source">Resource That Must Have Progress</label>
       <div class="input-group mb-3">
         <input
           type="text"

--- a/test/oli_web/live/sections/gating_and_scheduling_test.exs
+++ b/test/oli_web/live/sections/gating_and_scheduling_test.exs
@@ -620,7 +620,7 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
       assert view
              |> element("label[for=\"source\"]")
              |> render() =~
-               "Resource That Must Has Progress"
+               "Resource That Must Have Progress"
 
       assert view
              |> element("input[phx-click=\"toggle-min-score\"]")


### PR DESCRIPTION
Link to the ticket

### Before
![Screenshot 2024-07-01 at 8 56 59 AM](https://github.com/Simon-Initiative/oli-torus/assets/74839302/0c62371e-a247-4d1d-8d69-1a2c2e9d5001)


### After
![Screenshot 2024-07-01 at 8 56 09 AM](https://github.com/Simon-Initiative/oli-torus/assets/74839302/d67c4fbe-f8a2-44fd-b593-05e37f48b7e0)
