### PR TITLE
[ENHANCEMENT] [MER-3078] Where present, show student exceptions in schedule instead of the primary schedule

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -4386,7 +4386,7 @@ defmodule Oli.Delivery.Sections do
       left_join: r_att in ResourceAttempt,
       on: r_att.resource_access_id == ra.id,
       left_join: se in Oli.Delivery.Settings.StudentException,
-      on: se.resource_id == ra.resource_id and se.user_id == ^user_id,
+      on: se.resource_id == ra.resource_id and se.user_id == ^user_id and se.section_id == ^section.id,
       where:
         rev.resource_type_id == ^page_resource_type_id and
           coalesce(se.start_date, se.end_date) |> coalesce(sr.start_date) |> coalesce(sr.end_date) >=

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -4386,7 +4386,9 @@ defmodule Oli.Delivery.Sections do
       left_join: r_att in ResourceAttempt,
       on: r_att.resource_access_id == ra.id,
       left_join: se in Oli.Delivery.Settings.StudentException,
-      on: se.resource_id == ra.resource_id and se.user_id == ^user_id and se.section_id == ^section.id,
+      on:
+        se.resource_id == ra.resource_id and se.user_id == ^user_id and
+          se.section_id == ^section.id,
       where:
         rev.resource_type_id == ^page_resource_type_id and
           coalesce(se.start_date, se.end_date) |> coalesce(sr.start_date) |> coalesce(sr.end_date) >=

--- a/lib/oli_web/components/delivery/schedule.ex
+++ b/lib/oli_web/components/delivery/schedule.ex
@@ -86,11 +86,23 @@ defmodule OliWeb.Components.Delivery.Schedule do
                         </.link>
 
                         <div class="text-sm text-gray-700 dark:text-gray-300 group-[.past-start]:text-gray-400 dark:group-[.past-start]:text-gray-700">
-                          <%= resource_scheduling_label(resource.scheduling_type) %> <%= date(
-                            resource.end_date,
-                            ctx: @ctx,
-                            precision: :date
-                          ) %>
+                          <%= resource_scheduling_label(resource.scheduling_type) %>
+                          <%= if is_nil(effective_settings),
+                            do:
+                              date(
+                                Utils.coalesce(resource.end_date, resource.start_date),
+                                ctx: @ctx,
+                                precision: :date
+                              ),
+                            else:
+                              date(
+                                Utils.coalesce(
+                                  effective_settings.end_date,
+                                  effective_settings.start_date
+                                ),
+                                ctx: @ctx,
+                                precision: :date
+                              ) %>
                         </div>
                       </div>
                       <div :if={graded} class="flex flex-col">

--- a/lib/oli_web/live/delivery/student/home/components/schedule_component.ex
+++ b/lib/oli_web/live/delivery/student/home/components/schedule_component.ex
@@ -292,7 +292,12 @@ defmodule OliWeb.Delivery.Student.Home.Components.ScheduleComponent do
             <%= if @completed do %>
               Completed
             <% else %>
-              <%= Utils.days_difference(hd(@resources).end_date) %>
+              <%= if is_nil(hd(@resources).effective_settings),
+                do: Utils.days_difference(hd(@resources).end_date),
+                else:
+                  Utils.coalesce(hd(@resources).effective_settings.end_date, hd(@resources).end_date)
+                  |> Utils.coalesce(hd(@resources).effective_settings.start_date)
+                  |> Utils.days_difference() %>
             <% end %>
           </div>
           <Icons.check :if={@completed} progress={1.0} />

--- a/lib/oli_web/live/delivery/student/index_live.ex
+++ b/lib/oli_web/live/delivery/student/index_live.ex
@@ -518,7 +518,13 @@ defmodule OliWeb.Delivery.Student.IndexLive do
       <div class="pr-2 pl-1 self-end">
         <div class="flex items-end gap-1">
           <div class="text-right dark:text-white text-opacity-90 text-xs font-semibold">
-            <%= Utils.days_difference(@lesson.end_date) %>
+            <%= if is_nil(@lesson.settings),
+              do: Utils.coalesce(@lesson.end_date, @lesson.start_date) |> Utils.days_difference(),
+              else:
+                Utils.coalesce(@lesson.settings.end_date, @lesson.end_date)
+                |> Utils.coalesce(@lesson.settings.start_date)
+                |> Utils.coalesce(@lesson.start_date)
+                |> Utils.days_difference() %>
           </div>
         </div>
       </div>

--- a/lib/oli_web/live/delivery/student/utils.ex
+++ b/lib/oli_web/live/delivery/student/utils.ex
@@ -525,4 +525,12 @@ defmodule OliWeb.Delivery.Student.Utils do
       score
     end
   end
+
+  def coalesce(first, second) do
+    case {first, second} do
+      {nil, nil} -> nil
+      {nil, s} -> s
+      {f, _s} -> f
+    end
+  end
 end


### PR DESCRIPTION
This PR displays student exceptions in schedule instead of the primary schedule at the following locations:

![Screenshot 2024-07-01 at 11 06 11 AM](https://github.com/Simon-Initiative/oli-torus/assets/11138398/d778dc93-f79d-4b70-86fa-81d74e1b96b9)
![Screenshot 2024-07-01 at 11 05 47 AM](https://github.com/Simon-Initiative/oli-torus/assets/11138398/00d03996-4e74-42a5-946f-56a8a3321d45)
![Screenshot 2024-07-01 at 11 05 35 AM](https://github.com/Simon-Initiative/oli-torus/assets/11138398/ba53e5dd-b605-452b-9832-9e5fca3bd84b)
![Screenshot 2024-07-01 at 11 05 11 AM](https://github.com/Simon-Initiative/oli-torus/assets/11138398/dddb81d5-8ffc-4bb5-b524-993500e53db9)
