### PR TITLE
[BUG FIX] [MER-3422] Fix failure editing overview details when welcome title blank

### DIFF
--- a/assets/src/components/video_player/InitialPlayButton.tsx
+++ b/assets/src/components/video_player/InitialPlayButton.tsx
@@ -4,6 +4,7 @@ import { ControlButtonProps } from './ControlBar';
 export const InitialPlayButton: React.FC<ControlButtonProps> = ({ actions, player }) => {
   if (player?.hasStarted) return null;
   return (
+    // style to ensure visibility against light or dark backgrounds
     <button className="big-play-button" onClick={actions?.play}>
       <i className="fa-solid fa-circle-play"></i>
     </button>

--- a/assets/src/components/video_player/InitialPlayButton.tsx
+++ b/assets/src/components/video_player/InitialPlayButton.tsx
@@ -4,7 +4,6 @@ import { ControlButtonProps } from './ControlBar';
 export const InitialPlayButton: React.FC<ControlButtonProps> = ({ actions, player }) => {
   if (player?.hasStarted) return null;
   return (
-    // style to ensure visibility against light or dark backgrounds
     <button className="big-play-button" onClick={actions?.play}>
       <i className="fa-solid fa-circle-play"></i>
     </button>

--- a/assets/styles/common/video.scss
+++ b/assets/styles/common/video.scss
@@ -28,10 +28,13 @@
     top: 50%;
     transform: translate(-50%, -50%);
     z-index: 1; // gets it over the poster image
-    background: none;
-    border: none;
+    // colors & border get white triangle in black circle w/white border,
+    // ensuring visibility against both black & white backgrounds
+    color: black;
+    background: white;
+    border: 4px solid white;
+    border-radius: 50%;
     opacity: 0.7;
-    color: #fff;
     font-size: 5em;
 
     &:hover {

--- a/lib/oli_web/live/products/details_view.ex
+++ b/lib/oli_web/live/products/details_view.ex
@@ -302,8 +302,10 @@ defmodule OliWeb.Products.DetailsView do
     ext
   end
 
-  defp decode_welcome_title(%{"welcome_title" => nil} = project_params), do: project_params
-
-  defp decode_welcome_title(project_params),
-    do: Map.update(project_params, "welcome_title", nil, &Poison.decode!(&1))
+  defp decode_welcome_title(%{"welcome_title" => welcome_title} = project_params) do
+    cond do
+      welcome_title in [nil, ""] -> %{project_params | "welcome_title" => nil}
+      true -> Map.update(project_params, "welcome_title", nil, &Poison.decode!(&1))
+    end
+  end
 end

--- a/lib/oli_web/live/projects/overview_live.ex
+++ b/lib/oli_web/live/projects/overview_live.ex
@@ -562,10 +562,12 @@ defmodule OliWeb.Projects.OverviewLive do
   defp add_custom_license_details(project_params),
     do: Map.put(project_params, "custom_license_details", nil)
 
-  defp decode_welcome_title(%{"welcome_title" => nil} = project_params), do: project_params
-
-  defp decode_welcome_title(project_params),
-    do: Map.update(project_params, "welcome_title", nil, &Poison.decode!(&1))
+  defp decode_welcome_title(%{"welcome_title" => welcome_title} = project_params) do
+    cond do
+      welcome_title in [nil, ""] -> %{project_params | "welcome_title" => nil}
+      true -> Map.update(project_params, "welcome_title", nil, &Poison.decode!(&1))
+    end
+  end
 
   defp datashop_link(assigns) do
     ~H"""

--- a/lib/oli_web/live/sections/edit_view.ex
+++ b/lib/oli_web/live/sections/edit_view.ex
@@ -206,8 +206,10 @@ defmodule OliWeb.Sections.EditView do
     end
   end
 
-  defp decode_welcome_title(%{"welcome_title" => nil} = project_params), do: project_params
-
-  defp decode_welcome_title(project_params),
-    do: Map.update(project_params, "welcome_title", nil, &Poison.decode!(&1))
+  defp decode_welcome_title(%{"welcome_title" => welcome_title} = project_params) do
+    cond do
+      welcome_title in [nil, ""] -> %{project_params | "welcome_title" => nil}
+      true -> Map.update(project_params, "welcome_title", nil, &Poison.decode!(&1))
+    end
+  end
 end


### PR DESCRIPTION
Editing project details, e.g. title, from the Authoring Project Overview UI was failing in cases where the welcome title was blank, the usual default. In this case empty string gets sent in update message as value for welcome title, but code was not checking for this case and passing it to Poison.decode, which throws an error since empty string is not valid JSON. This change recodes to check for empty string before parsing, treating empty string as equivalent to nil to prevent rendering welcome title. 