### PR TITLE
[BUG FIX] [MER-3422] Fix failure editing overview details when welcome title blank

### DIFF
--- a/lib/oli_web/live/products/details_view.ex
+++ b/lib/oli_web/live/products/details_view.ex
@@ -302,10 +302,11 @@ defmodule OliWeb.Products.DetailsView do
     ext
   end
 
-  defp decode_welcome_title(%{"welcome_title" => welcome_title} = project_params) do
-    cond do
-      welcome_title in [nil, ""] -> %{project_params | "welcome_title" => nil}
-      true -> Map.update(project_params, "welcome_title", nil, &Poison.decode!(&1))
-    end
-  end
+  defp decode_welcome_title(%{"welcome_title" => nil} = project_params), do: project_params
+
+  defp decode_welcome_title(%{"welcome_title" => ""} = project_params),
+    do: %{project_params | "welcome_title" => nil}
+
+  defp decode_welcome_title(project_params),
+    do: Map.update(project_params, "welcome_title", nil, &Poison.decode!(&1))
 end

--- a/lib/oli_web/live/products/details_view.ex
+++ b/lib/oli_web/live/products/details_view.ex
@@ -302,8 +302,10 @@ defmodule OliWeb.Products.DetailsView do
     ext
   end
 
-  defp decode_welcome_title(%{"welcome_title" => nil} = project_params), do: project_params
-
-  defp decode_welcome_title(project_params),
-    do: Map.update(project_params, "welcome_title", nil, &Poison.decode!(&1))
+  defp decode_welcome_title(%{"welcome_title" => welcome_title} = project_params) do
+    cond do
+      welcome_title in [nil, ""] -> %{project_params | "welcome_title" => nil}
+      true -> Map.update(project_params, "welcome_title", nil, &Poison.decode!(&1))
+    end
+  end
 end

--- a/lib/oli_web/live/projects/overview_live.ex
+++ b/lib/oli_web/live/projects/overview_live.ex
@@ -562,10 +562,12 @@ defmodule OliWeb.Projects.OverviewLive do
   defp add_custom_license_details(project_params),
     do: Map.put(project_params, "custom_license_details", nil)
 
-  defp decode_welcome_title(%{"welcome_title" => nil} = project_params), do: project_params
-
-  defp decode_welcome_title(project_params),
-    do: Map.update(project_params, "welcome_title", nil, &Poison.decode!(&1))
+  defp decode_welcome_title(%{"welcome_title" => welcome_title} = project_params) do
+    cond do
+      welcome_title in [nil, ""] -> %{project_params | "welcome_title" => nil}
+      true -> Map.update(project_params, "welcome_title", nil, &Poison.decode!(&1))
+    end
+  end
 
   defp datashop_link(assigns) do
     ~H"""

--- a/lib/oli_web/live/projects/overview_live.ex
+++ b/lib/oli_web/live/projects/overview_live.ex
@@ -562,12 +562,13 @@ defmodule OliWeb.Projects.OverviewLive do
   defp add_custom_license_details(project_params),
     do: Map.put(project_params, "custom_license_details", nil)
 
-  defp decode_welcome_title(%{"welcome_title" => welcome_title} = project_params) do
-    cond do
-      welcome_title in [nil, ""] -> %{project_params | "welcome_title" => nil}
-      true -> Map.update(project_params, "welcome_title", nil, &Poison.decode!(&1))
-    end
-  end
+  defp decode_welcome_title(%{"welcome_title" => nil} = project_params), do: project_params
+
+  defp decode_welcome_title(%{"welcome_title" => ""} = project_params),
+    do: %{project_params | "welcome_title" => nil}
+
+  defp decode_welcome_title(project_params),
+    do: Map.update(project_params, "welcome_title", nil, &Poison.decode!(&1))
 
   defp datashop_link(assigns) do
     ~H"""

--- a/lib/oli_web/live/sections/edit_view.ex
+++ b/lib/oli_web/live/sections/edit_view.ex
@@ -210,10 +210,11 @@ defmodule OliWeb.Sections.EditView do
     end
   end
 
-  defp decode_welcome_title(%{"welcome_title" => welcome_title} = project_params) do
-    cond do
-      welcome_title in [nil, ""] -> %{project_params | "welcome_title" => nil}
-      true -> Map.update(project_params, "welcome_title", nil, &Poison.decode!(&1))
-    end
-  end
+  defp decode_welcome_title(%{"welcome_title" => nil} = project_params), do: project_params
+
+  defp decode_welcome_title(%{"welcome_title" => ""} = project_params),
+    do: %{project_params | "welcome_title" => nil}
+
+  defp decode_welcome_title(project_params),
+    do: Map.update(project_params, "welcome_title", nil, &Poison.decode!(&1))
 end

--- a/lib/oli_web/live/sections/edit_view.ex
+++ b/lib/oli_web/live/sections/edit_view.ex
@@ -210,8 +210,10 @@ defmodule OliWeb.Sections.EditView do
     end
   end
 
-  defp decode_welcome_title(%{"welcome_title" => nil} = project_params), do: project_params
-
-  defp decode_welcome_title(project_params),
-    do: Map.update(project_params, "welcome_title", nil, &Poison.decode!(&1))
+  defp decode_welcome_title(%{"welcome_title" => welcome_title} = project_params) do
+    cond do
+      welcome_title in [nil, ""] -> %{project_params | "welcome_title" => nil}
+      true -> Map.update(project_params, "welcome_title", nil, &Poison.decode!(&1))
+    end
+  end
 end


### PR DESCRIPTION
Editing project details, e.g. title, from the Authoring Project Overview UI was failing in cases where the welcome title was unset, the usual initial default. In this case, seems empty string gets sent in update message as value for welcome title, which is neither nil nor JSONified rich content structure. Code was not checking for this case and was passing it to Poison.decode, which throws an error since empty string is not valid JSON. This change recodes to check for empty string before parsing, treating empty string as equivalent to nil to prevent rendering welcome title in this case. 