### PR TITLE
[MER-3009] [ENHANCEMENT] Fix attempt links in Page Attempt Summary

### DIFF
--- a/lib/oli_web/live/progress/page_attempt_summary.ex
+++ b/lib/oli_web/live/progress/page_attempt_summary.ex
@@ -1,7 +1,7 @@
 defmodule OliWeb.Progress.PageAttemptSummary do
   use OliWeb, :live_component
-  alias OliWeb.Router.Helpers, as: Routes
   alias OliWeb.Common.Utils
+  alias OliWeb.Delivery.Student.Utils, as: StudentUtils
 
   attr(:attempt, :map, required: true)
   attr(:section, :map, required: true)
@@ -23,17 +23,7 @@ defmodule OliWeb.Progress.PageAttemptSummary do
       ) do
     ~H"""
     <div class="list-group-item list-group-action flex-column align-items-start">
-      <a
-        href={
-          Routes.instructor_review_path(
-            OliWeb.Endpoint,
-            :review_attempt,
-            @section.slug,
-            @attempt.attempt_guid
-          )
-        }
-        class="block"
-      >
+      <%= live_redirect to: StudentUtils.review_live_path(@section.slug, @revision.slug, @attempt.attempt_guid), class: "block" do %>
         <div class="d-flex w-100 justify-content-between">
           <h5 class="mb-1">Attempt <%= @attempt.attempt_number %></h5>
           <span>Not Submitted Yet</span>
@@ -42,7 +32,7 @@ defmodule OliWeb.Progress.PageAttemptSummary do
         <small class="text-muted">
           Time elapsed: <%= duration(@attempt.inserted_at, DateTime.utc_now()) %>.
         </small>
-      </a>
+      <% end %>
       <%= if @revision.graded do %>
         <button
           class="btn btn-danger btn-sm"
@@ -59,17 +49,7 @@ defmodule OliWeb.Progress.PageAttemptSummary do
   def do_render(%{attempt: %{lifecycle_state: :evaluated}} = assigns) do
     ~H"""
     <div class="list-group-item list-group-action flex-column align-items-start">
-      <a
-        href={
-          Routes.instructor_review_path(
-            OliWeb.Endpoint,
-            :review_attempt,
-            @section.slug,
-            @attempt.attempt_guid
-          )
-        }
-        class="block"
-      >
+      <%= live_redirect to: StudentUtils.review_live_path(@section.slug, @revision.slug, @attempt.attempt_guid), class: "block" do %>
         <div class="d-flex w-100 justify-content-between">
           <h5 class="mb-1">Attempt <%= @attempt.attempt_number %></h5>
           <span><%= Utils.format_score(@attempt.score) %> / <%= @attempt.out_of || "-" %></span>
@@ -90,7 +70,7 @@ defmodule OliWeb.Progress.PageAttemptSummary do
         <small class="text-muted">
           Time elapsed: <%= duration(@attempt.inserted_at, @attempt.date_evaluated) %>.
         </small>
-      </a>
+      <% end %>
     </div>
     """
   end
@@ -98,17 +78,7 @@ defmodule OliWeb.Progress.PageAttemptSummary do
   def do_render(%{attempt: %{lifecycle_state: :submitted}} = assigns) do
     ~H"""
     <div class="list-group-item list-group-action flex-column align-items-start">
-      <a
-        href={
-          Routes.instructor_review_path(
-            OliWeb.Endpoint,
-            :review_attempt,
-            @section.slug,
-            @attempt.attempt_guid
-          )
-        }
-        class="block"
-      >
+      <%= live_redirect to: StudentUtils.review_live_path(@section.slug, @revision.slug, @attempt.attempt_guid), class: "block" do %>
         <div class="d-flex w-100 justify-content-between">
           <h5 class="mb-1">Attempt <%= @attempt.attempt_number %></h5>
           <span>Submitted</span>
@@ -123,7 +93,7 @@ defmodule OliWeb.Progress.PageAttemptSummary do
         <small class="text-muted">
           Time elapsed: <%= duration(@attempt.inserted_at, @attempt.date_submitted) %>.
         </small>
-      </a>
+      <% end %>
     </div>
     """
   end

--- a/test/oli_web/live/progress/page_attempt_summary_test.exs
+++ b/test/oli_web/live/progress/page_attempt_summary_test.exs
@@ -1,0 +1,89 @@
+defmodule OliWeb.Progress.PageAttemptSummaryTest do
+  use OliWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias OliWeb.Common.SessionContext
+  alias OliWeb.Delivery.Student.Utils
+  alias OliWeb.Progress.PageAttemptSummary
+
+  describe "PageAttemptSummary component" do
+    setup do
+      attempt = %{
+        attempt_guid: "guid",
+        attempt_number: 1,
+        inserted_at: ~U[2024-07-01 10:20:00.0Z],
+        date_evaluated: ~U[2024-07-02 11:30:00.0Z],
+        date_submitted: ~U[2024-07-03 12:40:00.0Z],
+        lifecycle_state: :active,
+        was_late: false,
+        score: 10,
+        out_of: 20
+      }
+
+      section = %{slug: "section_slug"}
+      ctx = SessionContext.init()
+      revision = %{slug: "revision_slug", graded: true}
+
+      {:ok, attempt: attempt, section: section, ctx: ctx, revision: revision}
+    end
+
+    test "renders active attempt", %{
+      attempt: attempt,
+      section: section,
+      ctx: ctx,
+      revision: revision
+    } do
+      attempt = %{attempt | lifecycle_state: :active}
+      assigns = %{attempt: attempt, section: section, ctx: ctx, revision: revision}
+
+      html = render_component(PageAttemptSummary, assigns)
+
+      assert html =~ "Attempt #{attempt.attempt_number}"
+      assert html =~ "Not Submitted Yet"
+      assert html =~ "Started: July 1, 2024 10:20 AM UTC"
+      assert html =~ "Submit Attempt on Behalf of Student"
+
+      href = Utils.review_live_path(section.slug, revision.slug, attempt.attempt_guid)
+      assert html =~ ~r/href="#{href}"/
+    end
+
+    test "renders evaluated attempt", %{
+      attempt: attempt,
+      section: section,
+      ctx: ctx,
+      revision: revision
+    } do
+      attempt = %{attempt | lifecycle_state: :evaluated}
+      assigns = %{attempt: attempt, section: section, ctx: ctx, revision: revision}
+
+      html = render_component(PageAttemptSummary, assigns)
+
+      assert html =~ "Attempt #{attempt.attempt_number}"
+      assert html =~ "#{attempt.score} / #{attempt.out_of}"
+      assert html =~ "Submitted: July 2, 2024 11:30 AM UTC"
+
+      href = Utils.review_live_path(section.slug, revision.slug, attempt.attempt_guid)
+      assert html =~ ~r/href="#{href}"/
+    end
+
+    test "renders submitted attempt", %{
+      attempt: attempt,
+      section: section,
+      ctx: ctx,
+      revision: revision
+    } do
+      attempt = %{attempt | lifecycle_state: :submitted}
+      assigns = %{attempt: attempt, section: section, ctx: ctx, revision: revision}
+
+      html = render_component(PageAttemptSummary, assigns)
+
+      assert html =~ "Attempt #{attempt.attempt_number}"
+      assert html =~ "Submitted"
+      assert html =~ "Submitted: July 3, 2024 12:40 PM UTC"
+
+      href = Utils.review_live_path(section.slug, revision.slug, attempt.attempt_guid)
+      assert html =~ ~r/href="#{href}"/
+    end
+  end
+end


### PR DESCRIPTION
The attempts links were pointing to an outdated page when reviewing an attempt of a lesson. 

E.g:
Instead of linking to `/sections/{section_slug}/review/{attempt_guid}`, we now link to `/sections/{section_slug}/lesson/{revision_slug}/attempt/{attempt_guid}/review`

See: https://eliterate.atlassian.net/browse/MER-3009?focusedCommentId=23478


https://github.com/Simon-Initiative/oli-torus/assets/5324858/097df4c7-f895-45a8-a61d-e7df6ddf2702



