### PR TITLE
[BUG FIX] [NG23-266] Unable to create a notes from learn page

### DIFF
--- a/lib/oli_web/live/delivery/student/lesson/annotations.ex
+++ b/lib/oli_web/live/delivery/student/lesson/annotations.ex
@@ -457,11 +457,11 @@ defmodule OliWeb.Delivery.Student.Lesson.Annotations do
             :if={@enable_unread_badge && @post.unread_replies_count > 0}
             class="w-2 h-2 my-2 mr-3 bg-primary rounded-full"
           />
-          <div role="post creator" class="font-semibold" role="user name">
+          <div class="font-semibold" role="user name">
             <%= post_creator(@post, @current_user) %>
           </div>
         </div>
-        <div role="post posted at" class="text-sm text-gray-500">
+        <div role="posted at" class="text-sm text-gray-500">
           <%= Timex.from_now(@post.inserted_at) %>
         </div>
       </div>

--- a/lib/oli_web/live/delivery/student/lesson/annotations.ex
+++ b/lib/oli_web/live/delivery/student/lesson/annotations.ex
@@ -457,11 +457,11 @@ defmodule OliWeb.Delivery.Student.Lesson.Annotations do
             :if={@enable_unread_badge && @post.unread_replies_count > 0}
             class="w-2 h-2 my-2 mr-3 bg-primary rounded-full"
           />
-          <div class="font-semibold" role="user name">
+          <div role="post creator" class="font-semibold" role="user name">
             <%= post_creator(@post, @current_user) %>
           </div>
         </div>
-        <div class="text-sm text-gray-500">
+        <div role="post posted at" class="text-sm text-gray-500">
           <%= Timex.from_now(@post.inserted_at) %>
         </div>
       </div>

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -519,7 +519,19 @@ defmodule OliWeb.Delivery.Student.LessonLive do
   end
 
   def handle_event("clear_search", _, socket) do
-    {:noreply, assign_annotations(socket, search_results: nil, search_term: "")}
+    async_load_annotations(
+      socket.assigns.section,
+      socket.assigns.page_resource_id,
+      socket.assigns.current_user,
+      socket.assigns.collab_space_config,
+      visibility_for_active_tab(
+        socket.assigns.annotations.active_tab,
+        socket.assigns.is_instructor
+      ),
+      socket.assigns.annotations.selected_point
+    )
+
+    {:noreply, assign_annotations(socket, search_results: nil, posts: nil, search_term: "")}
   end
 
   def handle_event(

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -192,7 +192,12 @@ defmodule OliWeb.Delivery.Student.LessonLive do
   end
 
   def handle_event("toggle_annotation_point", params, socket) do
-    %{is_instructor: is_instructor, annotations: %{selected_point: selected_point}} =
+    %{
+      is_instructor: is_instructor,
+      annotations: %{selected_point: selected_point},
+      page_resource_id: page_resource_id,
+      collab_space_config: collab_space_config
+    } =
       socket.assigns
 
     point_marker_id =
@@ -205,9 +210,9 @@ defmodule OliWeb.Delivery.Student.LessonLive do
       # unselect the point marker and load all annotations
       async_load_annotations(
         socket.assigns.section,
-        socket.assigns.page_context.page.resource_id,
+        page_resource_id,
         socket.assigns.current_user,
-        socket.assigns.page_context,
+        collab_space_config,
         visibility_for_active_tab(socket.assigns.annotations.active_tab, is_instructor),
         nil
       )
@@ -220,9 +225,9 @@ defmodule OliWeb.Delivery.Student.LessonLive do
       # select the point marker and load annotations for that point
       async_load_annotations(
         socket.assigns.section,
-        socket.assigns.page_context.page.resource_id,
+        page_resource_id,
         socket.assigns.current_user,
-        socket.assigns.page_context,
+        collab_space_config,
         visibility_for_active_tab(socket.assigns.annotations.active_tab, is_instructor),
         point_marker_id
       )
@@ -251,7 +256,8 @@ defmodule OliWeb.Delivery.Student.LessonLive do
       current_user: current_user,
       is_instructor: is_instructor,
       section: section,
-      page_context: page_context,
+      page_resource_id: page_resource_id,
+      collab_space_config: collab_space_config,
       annotations: %{
         selected_point: selected_point,
         active_tab: active_tab,
@@ -267,12 +273,11 @@ defmodule OliWeb.Delivery.Student.LessonLive do
       status: if(auto_approve_annotations, do: :approved, else: :submitted),
       user_id: current_user.id,
       section_id: section.id,
-      resource_id: page_context.page.resource_id,
-      annotated_resource_id: page_context.page.resource_id,
+      resource_id: page_resource_id,
+      annotated_resource_id: page_resource_id,
       annotated_block_id: selected_point,
       annotation_type: if(selected_point, do: :point, else: :none),
-      anonymous:
-        page_context.collab_space_config.anonymous_posting && params["anonymous"] == "true",
+      anonymous: collab_space_config.anonymous_posting && params["anonymous"] == "true",
       visibility: visibility_for_active_tab(active_tab, is_instructor),
       content: %Collaboration.PostContent{message: value}
     }
@@ -303,9 +308,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
       %{
         current_user: current_user,
         section: section,
-        page_context: %{
-          page: %{resource_id: resource_id}
-        },
+        page_resource_id: page_resource_id,
         annotations: %{
           selected_point: selected_point,
           search_term: search_term
@@ -314,7 +317,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
 
       async_search_annotations(
         section,
-        resource_id,
+        page_resource_id,
         current_user,
         visibility_for_active_tab(tab, is_instructor),
         selected_point,
@@ -444,7 +447,8 @@ defmodule OliWeb.Delivery.Student.LessonLive do
       current_user: current_user,
       is_instructor: is_instructor,
       section: section,
-      page_context: page_context,
+      page_resource_id: page_resource_id,
+      collab_space_config: collab_space_config,
       annotations: %{
         selected_point: selected_point,
         active_tab: active_tab,
@@ -460,12 +464,11 @@ defmodule OliWeb.Delivery.Student.LessonLive do
       status: if(auto_approve_annotations, do: :approved, else: :submitted),
       user_id: current_user.id,
       section_id: section.id,
-      resource_id: page_context.page.resource_id,
-      annotated_resource_id: page_context.page.resource_id,
+      resource_id: page_resource_id,
+      annotated_resource_id: page_resource_id,
       annotated_block_id: selected_point,
       annotation_type: if(selected_point, do: :point, else: :none),
-      anonymous:
-        page_context.collab_space_config.anonymous_posting && params["anonymous"] == "true",
+      anonymous: collab_space_config.anonymous_posting && params["anonymous"] == "true",
       visibility: visibility_for_active_tab(active_tab, is_instructor),
       content: %Collaboration.PostContent{message: value},
       parent_post_id: parent_post_id,
@@ -496,9 +499,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
       current_user: current_user,
       is_instructor: is_instructor,
       section: section,
-      page_context: %{
-        page: %{resource_id: resource_id}
-      },
+      page_resource_id: page_resource_id,
       annotations: %{
         selected_point: selected_point,
         active_tab: active_tab
@@ -507,7 +508,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
 
     async_search_annotations(
       section,
-      resource_id,
+      page_resource_id,
       current_user,
       visibility_for_active_tab(active_tab, is_instructor),
       selected_point,
@@ -528,12 +529,13 @@ defmodule OliWeb.Delivery.Student.LessonLive do
       ) do
     %{
       section: section,
-      page_context: page_context,
+      page_resource_id: page_resource_id,
       current_user: current_user,
       is_instructor: is_instructor,
       annotations: %{
         active_tab: active_tab
-      }
+      },
+      collab_space_config: collab_space_config
     } = socket.assigns
 
     point_marker_id =
@@ -544,9 +546,9 @@ defmodule OliWeb.Delivery.Student.LessonLive do
 
     async_load_annotations(
       section,
-      page_context.page.resource_id,
+      page_resource_id,
       current_user,
-      page_context,
+      collab_space_config,
       visibility_for_active_tab(active_tab, is_instructor),
       point_marker_id,
       String.to_integer(post_id)

--- a/test/oli_web/live/delivery/student/lesson_live_test.exs
+++ b/test/oli_web/live/delivery/student/lesson_live_test.exs
@@ -1195,6 +1195,52 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
       # verify the like button is styled as primary since it was liked by the current user
       assert like_button_html =~ "<path class=\"stroke-primary\""
     end
+
+    test "posts a note", %{
+      conn: conn,
+      section: section,
+      user: user,
+      page_1: page_1
+    } do
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.mark_section_visited_for_student(section, user)
+
+      {:ok, view, _html} = live(conn, Utils.lesson_live_path(section.slug, page_1.slug))
+
+      view
+      |> element(~s{button[phx-click='toggle_sidebar']})
+      |> render_click
+
+      assert_push_event(view, "request_point_markers", %{})
+
+      # when we handle the event "toggle_sidebar", the "request_point_markers" event is pushed to the client.
+      # The client then responds back with the "update_point_markers" event
+      # that is handled by the server and finally used to show the point marks on the annotations panel.
+      # We need to trigger the "update_point_markers" event manually because no js is executed while testing the liveview
+
+      render_hook(view, "update_point_markers", %{
+        point_markers: [
+          %{"id" => "158828742", "top" => 100.0000},
+          %{"id" => "3371710400", "top" => 150.0000}
+        ]
+      })
+
+      view
+      |> element(
+        ~s{button[phx-click='toggle_annotation_point'][phx-value-point-marker-id='158828742']}
+      )
+      |> render_click
+
+      render_hook(view, "begin_create_annotation", %{})
+
+      view
+      |> form(~s{form[phx-submit='create_annotation']}, %{content: "some new post content"})
+      |> render_submit()
+
+      assert has_element?(view, "div[role='post creator']", "Me")
+      assert has_element?(view, "div[role='post posted at']", "now")
+      assert has_element?(view, "p[role='post content']", "some new post content")
+    end
   end
 
   defp create_post(user, section, page, message, attrs \\ %{}) do


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/NG23-266) to the ticket

The bug was introduced in [NG23-253](https://github.com/Simon-Initiative/oli-torus/pull/4929), where some values needed for the annotation features were accidentally erased from the socket (the mentioned PR temporarily assigned the `page_context` into the socket).
The fix involved assigning to the socket those needed values, to handle all the user interaction with the annotations panel correctly.

### After
https://github.com/Simon-Initiative/oli-torus/assets/74839302/f792dadc-d341-467f-9649-fc73d147f6b4


## Bug on clearing search after changing selected tab

While working on the fix another bug was found, where after clearing a note search the notes rendered didn't match the selected tab. The steps to reproduce the bug are:
1. Search for some text while being on "My notes".
2. Switch to the "Class Notes" tab while keeping the search.
3. Clear the search -> "My notes" posts will be shown instead of the "Class notes" ones.

### Before
https://github.com/Simon-Initiative/oli-torus/assets/74839302/6af232f6-698d-4cff-bce7-84ad041b784e

### After
https://github.com/Simon-Initiative/oli-torus/assets/74839302/cd52f402-8eb7-413c-8573-be772181fe4b







[NG23-253]: https://eliterate.atlassian.net/browse/NG23-253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ