### PR TITLE
[FEATURE] [MER-3295] Course enrollment error

### DIFF
--- a/lib/oli_web/live/sections/enrollments/invalid_section_invite_view.ex
+++ b/lib/oli_web/live/sections/enrollments/invalid_section_invite_view.ex
@@ -8,7 +8,7 @@ defmodule OliWeb.Sections.InvalidSectionInviteView do
   def render(assigns) do
     ~H"""
     <div class="p-10">
-      This enrollment link has expired or is invalid. If you already have a Torus student account, please <a href="/session/new">sign in</a>.
+      This enrollment link has expired or is invalid. If you already have a student account, please <a href="/session/new">sign in</a>.
     </div>
     """
   end

--- a/lib/oli_web/live/sections/enrollments/invalid_section_invite_view.ex
+++ b/lib/oli_web/live/sections/enrollments/invalid_section_invite_view.ex
@@ -7,8 +7,8 @@ defmodule OliWeb.Sections.InvalidSectionInviteView do
 
   def render(assigns) do
     ~H"""
-    <div>
-      This section invitation link has expired or is invalid.
+    <div class="p-10">
+      This enrollment link has expired or is invalid. If you already have a Torus student account, please <a href="/session/new">sign in</a>.
     </div>
     """
   end

--- a/lib/oli_web/plugs/require_section.ex
+++ b/lib/oli_web/plugs/require_section.ex
@@ -1,10 +1,11 @@
 defmodule Oli.Plugs.RequireSection do
+  use OliWeb, :verified_routes
+
   import Plug.Conn
   import Phoenix.Controller
 
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.SectionInvites
-  alias OliWeb.Router.Helpers, as: Routes
 
   def init(opts), do: opts
 
@@ -37,9 +38,7 @@ defmodule Oli.Plugs.RequireSection do
           end
         else
           conn
-          |> redirect(
-            to: Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.InvalidSectionInviteView)
-          )
+          |> redirect(to: ~p"/sections/join/invalid")
           |> halt()
         end
 

--- a/lib/oli_web/plugs/require_section.ex
+++ b/lib/oli_web/plugs/require_section.ex
@@ -1,50 +1,46 @@
 defmodule Oli.Plugs.RequireSection do
   use OliWeb, :verified_routes
 
-  import Plug.Conn
   import Phoenix.Controller
+  import Plug.Conn
 
   alias Oli.Delivery.Sections
+  alias Oli.Delivery.Sections.SectionInvite
   alias Oli.Delivery.Sections.SectionInvites
+  alias Oli.Repo
 
   def init(opts), do: opts
 
-  def call(conn, _opts) do
-    case conn.path_params do
-      %{"section_slug" => section_slug} ->
-        case Sections.get_section_by_slug(section_slug) do
-          nil ->
-            section_not_found(conn)
-
-          section ->
-            conn
-            |> assign(:section, section)
-            |> assign(:brand, Oli.Branding.get_section_brand(section))
-            |> put_session(:section_slug, section_slug)
-        end
-
-      %{"section_invite_slug" => section_invite_slug} ->
-        section_invite = SectionInvites.get_section_invite(section_invite_slug)
-
-        unless SectionInvites.link_expired?(section_invite) do
-          case SectionInvites.get_section_by_invite_slug(section_invite_slug) do
-            nil ->
-              section_not_found(conn)
-
-            section ->
-              conn
-              |> assign(:section, section)
-              |> assign(:brand, Oli.Branding.get_section_brand(section))
-          end
-        else
-          conn
-          |> redirect(to: ~p"/sections/join/invalid")
-          |> halt()
-        end
-
-      _ ->
+  def call(%{path_params: %{"section_slug" => section_slug}} = conn, _opts) do
+    case Sections.get_section_by_slug(section_slug) do
+      nil ->
         section_not_found(conn)
+
+      section ->
+        conn
+        |> assign_section_and_brand(section)
+        |> put_session(:section_slug, section_slug)
     end
+  end
+
+  def call(%{path_params: %{"section_invite_slug" => section_invite_slug}} = conn, _opts) do
+    with sec_inv = %SectionInvite{} <- SectionInvites.get_section_invite(section_invite_slug),
+         false <- SectionInvites.link_expired?(sec_inv) do
+      case SectionInvites.get_section_by_invite_slug(section_invite_slug) do
+        nil -> section_not_found(conn)
+        section -> assign_section_and_brand(conn, section)
+      end
+    else
+      _ -> redirect(conn, to: ~p"/sections/join/invalid") |> halt()
+    end
+  end
+
+  defp assign_section_and_brand(conn, section) do
+    section = Repo.preload(section, [:brand, lti_1p3_deployment: [institution: [:default_brand]]])
+
+    conn
+    |> assign(:section, section)
+    |> assign(:brand, Oli.Branding.get_section_brand(section))
   end
 
   defp section_not_found(conn) do

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -779,6 +779,10 @@ defmodule OliWeb.Router do
     ])
 
     live("/", Delivery.OpenAndFreeIndex)
+  end
+
+  scope "/sections", OliWeb do
+    pipe_through([:browser])
 
     live("/join/invalid", Sections.InvalidSectionInviteView)
   end

--- a/test/oli_web/live/sections/enrollments/invalid_section_invite_view_test.exs
+++ b/test/oli_web/live/sections/enrollments/invalid_section_invite_view_test.exs
@@ -1,0 +1,70 @@
+defmodule OliWeb.Sections.InvalidSectionInviteViewTest do
+  use ExUnit.Case, async: true
+  use OliWeb.ConnCase
+
+  import Oli.Factory
+  import Phoenix.LiveViewTest
+
+  describe "course invitation with no student account" do
+    test "redirects to the invalid message view if the link is invalid", %{conn: conn} do
+      conn = get(conn, ~p"/sections/join/12345")
+
+      assert conn.halted
+
+      redirect_to = ~p"/sections/join/invalid"
+
+      assert redirected_to(conn, 302) == redirect_to
+
+      {:ok, view, _html} = live(conn, redirect_to)
+
+      assert render(view) =~
+               "This enrollment link has expired or is invalid. If you already have a Torus student account, please <a href=\"/session/new\">sign in</a>."
+
+      assert element(view, "a[href=\"/session/new\"]") |> render() =~ "sign in"
+    end
+
+    test "redirects to the Student Sign In page if the invitation link is valid", %{conn: conn} do
+      section_invite_slig = "12345"
+      %{section: section} = insert(:section_invite, slug: section_invite_slig)
+
+      conn = get(conn, ~p"/sections/join/#{section_invite_slig}")
+
+      assert conn.halted
+
+      redirect_to =
+        ~p"/session/new?request_path=%2Fsections%2Fjoin%2F#{section_invite_slig}&section=#{section.slug}&from_invitation_link%3F=true"
+
+      assert redirected_to(conn, 302) == redirect_to
+
+      conn = get(conn, redirect_to)
+
+      assert html_response(conn, 200) =~ "Student Sign In"
+    end
+  end
+
+  describe "course invitation with student account" do
+    setup [:user_conn]
+
+    test "redirects to the invalid message view if the link is invalid", %{conn: conn} do
+      conn = get(conn, ~p"/sections/join/12345")
+
+      redirect_to = ~p"/sections/join/invalid"
+
+      assert redirected_to(conn, 302) == redirect_to
+
+      {:ok, view, _html} = live(conn, redirect_to)
+
+      assert render(view) =~
+               "This enrollment link has expired or is invalid. If you already have a Torus student account, please <a href=\"/session/new\">sign in</a>."
+    end
+
+    test "shows enroll view", %{conn: conn} do
+      section_invite_slig = "12345"
+      insert(:section_invite, slug: section_invite_slig)
+
+      conn = get(conn, ~p"/sections/join/#{section_invite_slig}")
+
+      assert html_response(conn, 200) =~ "Enroll in Course Section"
+    end
+  end
+end

--- a/test/oli_web/live/sections/enrollments/invalid_section_invite_view_test.exs
+++ b/test/oli_web/live/sections/enrollments/invalid_section_invite_view_test.exs
@@ -18,7 +18,7 @@ defmodule OliWeb.Sections.InvalidSectionInviteViewTest do
       {:ok, view, _html} = live(conn, redirect_to)
 
       assert render(view) =~
-               "This enrollment link has expired or is invalid. If you already have a Torus student account, please <a href=\"/session/new\">sign in</a>."
+               "This enrollment link has expired or is invalid. If you already have a student account, please <a href=\"/session/new\">sign in</a>.\n</div></div>"
 
       assert element(view, "a[href=\"/session/new\"]") |> render() =~ "sign in"
     end
@@ -55,7 +55,7 @@ defmodule OliWeb.Sections.InvalidSectionInviteViewTest do
       {:ok, view, _html} = live(conn, redirect_to)
 
       assert render(view) =~
-               "This enrollment link has expired or is invalid. If you already have a Torus student account, please <a href=\"/session/new\">sign in</a>."
+               "This enrollment link has expired or is invalid. If you already have a student account, please <a href=\"/session/new\">sign in</a>.\n</div></div>"
     end
 
     test "shows enroll view", %{conn: conn} do


### PR DESCRIPTION
Ticket: [MER-3295](https://eliterate.atlassian.net/browse/MER-3295)

This PR modifies the text message shown when an enrollment course link is invalid or expired. It also moves the invalid enrollment link endpoint to avoid an unnecessary account check-in. Additionally, it includes a refactor of the `RequireSection` module to improve readability.

https://github.com/Simon-Initiative/oli-torus/assets/47334502/fbb0a031-c7c3-4dc1-bcf3-88913f65bc94

[MER-3295]: https://eliterate.atlassian.net/browse/MER-3295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ