### PR TITLE
[BUG FIX] [MER-3291] Swap tabs in header

### DIFF
--- a/lib/oli_web/components/header.ex
+++ b/lib/oli_web/components/header.ex
@@ -101,11 +101,11 @@ defmodule OliWeb.Components.Header do
       <a class="navbar-brand torus-logo my-1 mr-auto" href={~p"/"}>
         <%= brand_logo(Map.merge(assigns, %{class: "d-inline-block align-top mr-2"})) %>
       </a>
-      <.sign_in_button href="/authoring/session/new" request_path={assigns.conn.request_path}>
-        For Course Authors
-      </.sign_in_button>
       <.sign_in_button href="/session/new" request_path={assigns.conn.request_path}>
         For Instructors
+      </.sign_in_button>
+      <.sign_in_button href="/authoring/session/new" request_path={assigns.conn.request_path}>
+        For Course Authors
       </.sign_in_button>
       <.button
         id="support-button"


### PR DESCRIPTION
Ticket: [MER-3291](https://eliterate.atlassian.net/browse/MER-3291)

This PR swapped the tabs on the navbar. This bug was reported in the ticket during QA.

### Old

<img width="978" alt="image" src="https://github.com/Simon-Initiative/oli-torus/assets/47334502/600d0c17-0e09-40f6-92b2-6b6a8ce79925">


### New
<img width="972" alt="image" src="https://github.com/Simon-Initiative/oli-torus/assets/47334502/673f09c9-fd4d-4b2b-a338-42b749e7cf67">


[MER-3291]: https://eliterate.atlassian.net/browse/MER-3291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ