### PR TITLE
[BUG FIX] [MER-3423] Using keyboard shortcut (ctrl-del) to delete after a component has been copied causes issues

### DIFF
--- a/assets/src/apps/authoring/components/AdaptiveRulesList/AdaptiveRulesList.tsx
+++ b/assets/src/apps/authoring/components/AdaptiveRulesList/AdaptiveRulesList.tsx
@@ -11,6 +11,7 @@ import {
   selectCopiedItem,
   selectCopiedType,
 } from 'apps/authoring/store/clipboard/slice';
+import { setCurrentPartPropertyFocus } from 'apps/authoring/store/parts/slice';
 import guid from 'utils/guid';
 import { useToggle } from '../../../../components/hooks/useToggle';
 import { clone } from '../../../../utils/common';
@@ -467,8 +468,14 @@ const IRulesList: React.FC<any> = (props: any) => {
                         value={ruleToEdit.name}
                         onClick={(e) => e.preventDefault()}
                         onChange={(e) => setRuleToEdit({ ...rule, name: e.target.value })}
-                        onFocus={(e) => e.target.select()}
-                        onBlur={() => handleRenameRule(rule)}
+                        onFocus={(e) => {
+                          e.target.select();
+                          dispatch(setCurrentPartPropertyFocus({ focus: false }));
+                        }}
+                        onBlur={() => {
+                          handleRenameRule(rule);
+                          dispatch(setCurrentPartPropertyFocus({ focus: true }));
+                        }}
                         onKeyDown={(e) => {
                           if (e.key === 'Enter') handleRenameRule(rule);
                           if (e.key === 'Escape') setRuleToEdit(undefined);

--- a/assets/src/apps/authoring/components/AdaptivityEditor/ConditionItemEditor.tsx
+++ b/assets/src/apps/authoring/components/AdaptivityEditor/ConditionItemEditor.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { OverlayTrigger, Tooltip } from 'react-bootstrap';
+import { useDispatch } from 'react-redux';
+import { setCurrentPartPropertyFocus } from 'apps/authoring/store/parts/slice';
 import { CapiVariableTypes, JanusConditionProperties } from '../../../../adaptivity/capi';
 import ConfirmDelete from '../Modal/DeleteConfirmationModal';
 import {
@@ -22,7 +24,7 @@ interface ConditionItemEditorProps {
 
 const ConditionItemEditor: React.FC<ConditionItemEditorProps> = (props) => {
   const { condition, parentIndex, onChange, onDelete } = props;
-
+  const dispatch = useDispatch();
   const [fact, setFact] = useState<string>(condition.fact);
   const [targetType, setTargetType] = useState<CapiVariableTypes>(
     condition.type || inferTypeFromOperatorAndValue(condition.operator, condition.value),
@@ -120,7 +122,11 @@ const ConditionItemEditor: React.FC<ConditionItemEditorProps> = (props) => {
           placeholder="Target"
           value={fact}
           onChange={(e) => setFact(e.target.value)}
-          onBlur={(e) => handleFactChange(e.target.value)}
+          onFocus={(e) => dispatch(setCurrentPartPropertyFocus({ focus: false }))}
+          onBlur={(e) => {
+            handleFactChange(e.target.value);
+            dispatch(setCurrentPartPropertyFocus({ focus: true }));
+          }}
           title={fact.toString()}
           tabIndex={0}
         />
@@ -171,7 +177,11 @@ const ConditionItemEditor: React.FC<ConditionItemEditorProps> = (props) => {
         key={`value-${parentIndex}`}
         id={`value-${parentIndex}`}
         defaultValue={value}
-        onBlur={(e) => handleValueChange(e)}
+        onBlur={(e) => {
+          handleValueChange(e);
+          dispatch(setCurrentPartPropertyFocus({ focus: true }));
+        }}
+        onFocus={(e) => dispatch(setCurrentPartPropertyFocus({ focus: false }))}
         title={value.toString()}
         placeholder="Value"
         tabIndex={0}

--- a/assets/src/apps/authoring/components/ComponentToolbar/AddComponentToolbar.tsx
+++ b/assets/src/apps/authoring/components/ComponentToolbar/AddComponentToolbar.tsx
@@ -115,7 +115,16 @@ const AddComponentToolbar: React.FC<{
     dispatch(setCopiedPart({ copiedPart: null }));
   };
 
-  useKeyDown(handlePartPasteClick, ['KeyV'], { ctrlKey: true }, [copiedPart, currentActivityTree]);
+  useKeyDown(
+    () => {
+      if (copiedPart) {
+        handlePartPasteClick();
+      }
+    },
+    ['KeyV'],
+    { ctrlKey: true },
+    [copiedPart, currentActivityTree],
+  );
 
   return (
     <Fragment>

--- a/assets/src/apps/authoring/components/EditingCanvas/EditingCanvas.tsx
+++ b/assets/src/apps/authoring/components/EditingCanvas/EditingCanvas.tsx
@@ -156,7 +156,7 @@ const EditingCanvas: React.FC = () => {
           payload: { id: currentSelectedPartId, type: 'Copy' },
         });
       } else if (!_currentPartPropertyFocus) {
-        //if user first copies a part and then before pasting it,  if they click on the properties and do a cntrl+c, we need to clear the existing cntrl+c for part
+        //if user first copies a part and then before pasting it, if they click on the properties and do a cntrl+c, we need to clear the existing cntrl+c for part
         dispatch(setCopiedPart({ copiedPart: null }));
       }
     },

--- a/assets/src/apps/authoring/components/EditingCanvas/EditingCanvas.tsx
+++ b/assets/src/apps/authoring/components/EditingCanvas/EditingCanvas.tsx
@@ -156,7 +156,7 @@ const EditingCanvas: React.FC = () => {
           payload: { id: currentSelectedPartId, type: 'Copy' },
         });
       } else if (!_currentPartPropertyFocus) {
-        //if user first copies a part and then before pasting it, if they click on the properties and do a cntrl+c, we need to clear the existing cntrl+c for part
+        //if user first copies a part and then before pasting it,  if they click on the properties and do a cntrl+c, we need to clear the existing cntrl+c for part
         dispatch(setCopiedPart({ copiedPart: null }));
       }
     },

--- a/assets/src/apps/authoring/components/EditingCanvas/EditingCanvas.tsx
+++ b/assets/src/apps/authoring/components/EditingCanvas/EditingCanvas.tsx
@@ -145,7 +145,6 @@ const EditingCanvas: React.FC = () => {
   useKeyDown(
     () => {
       if (currentSelectedPartId && !configPartId?.length) {
-        console.log('Trigger Cntrl + C');
         setNotificationStream({
           stamp: Date.now(),
           type: NotificationType.CHECK_SHORTCUT_ACTIONS,

--- a/assets/src/apps/authoring/components/Flowchart/toolbar/FlowchartHeaderNav.tsx
+++ b/assets/src/apps/authoring/components/Flowchart/toolbar/FlowchartHeaderNav.tsx
@@ -207,7 +207,16 @@ export const FlowchartHeaderNav: React.FC<HeaderNavProps> = () => {
     ['KeyZ'],
     { ctrlKey: true },
   );
-  useKeyDown(handlePartPasteClick, ['KeyV'], { ctrlKey: true }, [copiedPart, currentActivityTree]);
+  useKeyDown(
+    () => {
+      if (copiedPart) {
+        handlePartPasteClick();
+      }
+    },
+    ['KeyV'],
+    { ctrlKey: true },
+    [copiedPart, currentActivityTree],
+  );
 
   const handleAddComponent = useCallback(
     (partComponentType: string) => () => {

--- a/assets/src/apps/authoring/components/PropertyEditor/PropertyEditor.tsx
+++ b/assets/src/apps/authoring/components/PropertyEditor/PropertyEditor.tsx
@@ -24,6 +24,7 @@ interface PropertyEditorProps {
   value: unknown;
   onClickHandler?: (changes: unknown) => void;
   triggerOnChange?: boolean | string[];
+  onfocusHandler?: (changes: boolean) => void;
 }
 
 const widgets: any = {
@@ -47,6 +48,7 @@ const PropertyEditor: React.FC<PropertyEditorProps> = ({
   value,
   onChangeHandler,
   triggerOnChange = false,
+  onfocusHandler,
 }) => {
   const [formData, setFormData] = useState<any>(value);
 
@@ -94,7 +96,9 @@ const PropertyEditor: React.FC<PropertyEditorProps> = ({
         }
       }}
       onFocus={() => {
-        console.log('I am on focus now');
+        if (onfocusHandler) {
+          onfocusHandler(false);
+        }
       }}
       onBlur={(key, changed) => {
         // key will look like root_Position_x
@@ -110,6 +114,8 @@ const PropertyEditor: React.FC<PropertyEditorProps> = ({
           // console.log('ONBLUR TRIGGER SAVE');
 
           onChangeHandler(formData);
+        } else if (onfocusHandler) {
+          onfocusHandler(true);
         }
       }}
       uiSchema={uiSchema}

--- a/assets/src/apps/authoring/components/PropertyEditor/PropertyEditor.tsx
+++ b/assets/src/apps/authoring/components/PropertyEditor/PropertyEditor.tsx
@@ -22,6 +22,7 @@ interface PropertyEditorProps {
   uiSchema: UiSchema;
   onChangeHandler: (changes: unknown) => void;
   value: unknown;
+  onClickHandler?: (changes: unknown) => void;
   triggerOnChange?: boolean | string[];
 }
 
@@ -91,6 +92,9 @@ const PropertyEditor: React.FC<PropertyEditorProps> = ({
             onChangeHandler(updatedData);
           }
         }
+      }}
+      onFocus={() => {
+        console.log('I am on focus now');
       }}
       onBlur={(key, changed) => {
         // key will look like root_Position_x

--- a/assets/src/apps/authoring/components/PropertyEditor/custom/MCQCustomErrorFeedbackAuthoring.tsx
+++ b/assets/src/apps/authoring/components/PropertyEditor/custom/MCQCustomErrorFeedbackAuthoring.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useMemo } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { getNodeText } from '../../../../../components/parts/janus-mcq/mcq-util';
 import { selectCurrentActivityTree } from '../../../../delivery/store/features/groups/selectors/deck';
-import { selectCurrentSelection } from '../../../store/parts/slice';
+import { selectCurrentSelection, setCurrentPartPropertyFocus } from '../../../store/parts/slice';
 
 /*
  This component handles editing advanced feedback for a question type that has a fixed set of options.
@@ -115,15 +115,22 @@ const OptionFeedback: React.FC<OptionFeedbackProps> = ({
   feedback,
   onChange,
 }) => {
+  const dispatch = useDispatch();
   const labelOption = option || `Option ${index + 1}`;
   return (
     <div className="form-group">
       <label>{labelOption}</label>
       <input
-        onBlur={onBlur}
+        onBlur={() => {
+          onBlur();
+          dispatch(setCurrentPartPropertyFocus({ focus: true }));
+        }}
         className="form-control"
         value={feedback}
         onChange={(e) => onChange(e.target.value)}
+        onFocus={() => {
+          dispatch(setCurrentPartPropertyFocus({ focus: false }));
+        }}
       />
     </div>
   );

--- a/assets/src/apps/authoring/components/PropertyEditor/custom/MCQOptionsEditor.tsx
+++ b/assets/src/apps/authoring/components/PropertyEditor/custom/MCQOptionsEditor.tsx
@@ -1,5 +1,7 @@
 import React, { useCallback, useState } from 'react';
 import { Modal } from 'react-bootstrap';
+import { useDispatch } from 'react-redux';
+import { setCurrentPartPropertyFocus } from 'apps/authoring/store/parts/slice';
 import { useToggle } from '../../../../../components/hooks/useToggle';
 import { getNodeText } from '../../../../../components/parts/janus-mcq/mcq-util';
 import { QuillEditor } from '../../../../../components/parts/janus-text-flow/QuillEditor';
@@ -76,6 +78,7 @@ const OptionsEditor: React.FC<{
 }> = ({ value, onChange, onDelete }) => {
   const [editorOpen, , openEditor, closeEditor] = useToggle(false);
   const [tempValue, setTempValue] = useState<{ value: OptionsNodes }>({ value: [] });
+  const dispatch = useDispatch();
 
   const onSave = useCallback(() => {
     closeEditor();
@@ -85,11 +88,13 @@ const OptionsEditor: React.FC<{
     };
     onChange(newValue);
     console.info('onSave', newValue);
+    dispatch(setCurrentPartPropertyFocus({ focus: true }));
   }, [closeEditor, onChange, tempValue.value, value]);
 
   const onEdit = useCallback(() => {
     openEditor();
     setTempValue({ value: value.nodes });
+    dispatch(setCurrentPartPropertyFocus({ focus: false }));
   }, [openEditor, value.nodes]);
 
   return (

--- a/assets/src/apps/authoring/components/RightMenu/PartPropertyEditor.tsx
+++ b/assets/src/apps/authoring/components/RightMenu/PartPropertyEditor.tsx
@@ -10,7 +10,7 @@ import { clone } from '../../../../utils/common';
 import { IActivity } from '../../../delivery/store/features/activities/slice';
 import { saveActivity } from '../../store/activities/actions/saveActivity';
 import { selectAppMode, setCopiedPart, setRightPanelActiveTab } from '../../store/app/slice';
-import { setCurrentSelection } from '../../store/parts/slice';
+import { setCurrentPartPropertyFocus, setCurrentSelection } from '../../store/parts/slice';
 import ConfirmDelete from '../Modal/DeleteConfirmationModal';
 import PropertyEditor from '../PropertyEditor/PropertyEditor';
 import AccordionTemplate from '../PropertyEditor/custom/AccordionTemplate';
@@ -317,6 +317,13 @@ export const PartPropertyEditor: React.FC<Props> = ({
     [currentActivity.id, currentPartInstance, currentPartSelection, dispatch],
   );
 
+  const componentPropertyFocusHandler = useCallback(
+    (partPropertyElementFocus: boolean) => {
+      dispatch(setCurrentPartPropertyFocus({ focus: partPropertyElementFocus }));
+    },
+    [currentActivity.id, currentPartInstance, currentPartSelection, dispatch],
+  );
+
   if (!partDef) return null;
 
   return (
@@ -360,6 +367,7 @@ export const PartPropertyEditor: React.FC<Props> = ({
         value={currentComponentData}
         onChangeHandler={componentPropertyChangeHandler}
         triggerOnChange={true}
+        onfocusHandler={componentPropertyFocusHandler}
       />
     </div>
   );

--- a/assets/src/apps/authoring/components/SequenceEditor/SequenceEditor.tsx
+++ b/assets/src/apps/authoring/components/SequenceEditor/SequenceEditor.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Accordion, Dropdown, ListGroup, OverlayTrigger, Tooltip } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
 import { saveActivity } from 'apps/authoring/store/activities/actions/saveActivity';
+import { setCurrentPartPropertyFocus } from 'apps/authoring/store/parts/slice';
 import { clone } from 'utils/common';
 import guid from 'utils/guid';
 import { useToggle } from '../../../../components/hooks/useToggle';
@@ -88,6 +89,7 @@ const SequenceEditor: React.FC<any> = (props: any) => {
 
   const handleItemClick = (e: any, entry: SequenceEntry<SequenceEntryChild>) => {
     e.stopPropagation();
+    dispatch(setCurrentPartPropertyFocus({ focus: true }));
     dispatch(setCurrentActivityFromSequence(entry.custom.sequenceId));
     dispatch(
       setRightPanelActiveTab({
@@ -505,8 +507,14 @@ const SequenceEditor: React.FC<any> = (props: any) => {
                           custom: { ...itemToRename.custom, sequenceName: e.target.value },
                         })
                       }
-                      onFocus={(e) => e.target.select()}
-                      onBlur={() => handleRenameItem(item)}
+                      onFocus={(e) => {
+                        e.target.select();
+                        dispatch(setCurrentPartPropertyFocus({ focus: false }));
+                      }}
+                      onBlur={() => {
+                        handleRenameItem(item);
+                        dispatch(setCurrentPartPropertyFocus({ focus: true }));
+                      }}
                       onKeyDown={(e) => {
                         if (e.key === 'Enter') handleRenameItem(item);
                         if (e.key === 'Escape') setItemToRename(undefined);

--- a/assets/src/apps/authoring/store/parts/slice.ts
+++ b/assets/src/apps/authoring/store/parts/slice.ts
@@ -4,10 +4,12 @@ import PartsSlice from './name';
 
 export interface PartState {
   currentSelection: string;
+  currentPartPropertyFocus?: boolean;
 }
 
 const initialState: PartState = {
   currentSelection: '',
+  currentPartPropertyFocus: false,
 };
 
 const slice: Slice<PartState> = createSlice({
@@ -17,12 +19,19 @@ const slice: Slice<PartState> = createSlice({
     setCurrentSelection(state, action: PayloadAction<{ selection: string }>) {
       state.currentSelection = action.payload.selection;
     },
+    setCurrentPartPropertyFocus(state, action: PayloadAction<{ focus: boolean }>) {
+      state.currentPartPropertyFocus = action.payload.focus;
+    },
   },
 });
 
-export const { setCurrentSelection } = slice.actions;
+export const { setCurrentSelection, setCurrentPartPropertyFocus } = slice.actions;
 
 export const selectState = (state: AuthoringRootState): PartState => state[PartsSlice] as PartState;
 export const selectCurrentSelection = createSelector(selectState, (s) => s.currentSelection);
+export const selectCurrentPartPropertyFocus = createSelector(
+  selectState,
+  (s) => s.currentPartPropertyFocus,
+);
 
 export default slice.reducer;

--- a/assets/src/apps/delivery/components/NotificationContext.tsx
+++ b/assets/src/apps/delivery/components/NotificationContext.tsx
@@ -11,6 +11,7 @@ export enum NotificationType {
   CONFIGURE = 'configure',
   CONFIGURE_SAVE = 'configureSave',
   CONFIGURE_CANCEL = 'configureCancel',
+  CHECK_SHORTCUT_ACTIONS = 'checkShortcutActions',
 }
 
 type UnsubscribeFn = () => void;

--- a/assets/src/components/activities/adaptive/AdaptiveAuthoring.tsx
+++ b/assets/src/components/activities/adaptive/AdaptiveAuthoring.tsx
@@ -35,6 +35,7 @@ const Adaptive = (
       NotificationType.CONFIGURE,
       NotificationType.CONFIGURE_CANCEL,
       NotificationType.CONFIGURE_SAVE,
+      NotificationType.CHECK_SHORTCUT_ACTIONS,
     ];
     const notifications = notificationsHandled.map((notificationType: NotificationType) => {
       const handler = (e: any) => {

--- a/assets/src/components/activities/adaptive/components/authoring/LayoutEditor.tsx
+++ b/assets/src/components/activities/adaptive/components/authoring/LayoutEditor.tsx
@@ -12,7 +12,6 @@ import {
   NotificationType,
   subscribeToNotification,
 } from 'apps/delivery/components/NotificationContext';
-import { useKeyDown } from 'hooks/useKeyDown';
 import { clone } from 'utils/common';
 import { contexts } from '../../../../../types/applicationContext';
 import PartComponent from '../common/PartComponent';
@@ -329,6 +328,14 @@ const LayoutEditor: React.FC<LayoutEditorProps> = (props) => {
     }
   };
 
+  const handleShortcutActionNotifications = (payload: any) => {
+    const { type } = payload;
+    if (type === 'Delete') {
+      setShowConfirmDelete(true);
+    } else if (type === 'Copy') {
+      handleCopyComponent();
+    }
+  };
   useEffect(() => {
     if (!pusher) {
       return;
@@ -337,6 +344,7 @@ const LayoutEditor: React.FC<LayoutEditorProps> = (props) => {
       NotificationType.CONFIGURE,
       NotificationType.CONFIGURE_CANCEL,
       NotificationType.CONFIGURE_SAVE,
+      NotificationType.CHECK_SHORTCUT_ACTIONS,
     ];
     const notifications = notificationsHandled.map((notificationType: NotificationType) => {
       const handler = (payload: any) => {
@@ -346,6 +354,9 @@ const LayoutEditor: React.FC<LayoutEditorProps> = (props) => {
         switch (notificationType) {
           case NotificationType.CONFIGURE_CANCEL:
             handlePartCancelConfigure(payload);
+            break;
+          case NotificationType.CHECK_SHORTCUT_ACTIONS:
+            handleShortcutActionNotifications(payload);
             break;
           case NotificationType.CONFIGURE_SAVE:
             // maybe layout editor should *only* do this for both cancel and save
@@ -364,7 +375,7 @@ const LayoutEditor: React.FC<LayoutEditorProps> = (props) => {
         unsub();
       });
     };
-  }, [configurePartId, handlePartCancelConfigure, pusher]);
+  }, [configurePartId, handlePartCancelConfigure, selectedPartAndCapabilities, pusher]);
 
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -393,22 +404,6 @@ const LayoutEditor: React.FC<LayoutEditorProps> = (props) => {
     },
     [dragSize, isDragging, selectedPartId],
   );
-
-  useKeyDown(
-    () => {
-      if (selectedPartAndCapabilities && !configurePartId.length) {
-        setShowConfirmDelete(true);
-      }
-    },
-    ['Delete', 'Backspace'],
-    { ctrlKey: true },
-    [selectedPartAndCapabilities, configurePartId],
-  );
-  useKeyDown(handleCopyComponent, ['KeyC'], { ctrlKey: true }, [
-    selectedPartAndCapabilities,
-    parts,
-    handleCopyComponent,
-  ]);
 
   return parts && parts.length ? (
     <NotificationContext.Provider value={pusher}>


### PR DESCRIPTION
Hey @bsparks Could you please look at this PR.

This PR contains fix for the following things:

1. [Using keyboard shortcut (ctrl-v) to paste after a component has been copied causes issues](https://eliterate.atlassian.net/browse/MER-3420)
2. [Using keyboard shortcut (ctrl-del) to delete after a component has been copied causes issues](https://eliterate.atlassian.net/browse/MER-3423)

Apart from this, I also fixed the original request to delete a selected component when user press `'Delete / Backspace'` keys. In the past, there were issues related to `'Delete / Backspace'` so we used `'Cntrl + Delete / Backspace'` but now I have fixed all the issues and now we can use `'Delete / Backspace'` to delete a component.

I had to handle the `'Delete / Backspace'` key press at all the places in the simple as well as Advance authoring.