### PR TITLE
[ENHANCEMENT] [MER-3294] User can create an account through a course enrollment link

### DIFF
--- a/lib/oli_web/templates/delivery/enroll.html.heex
+++ b/lib/oli_web/templates/delivery/enroll.html.heex
@@ -14,7 +14,7 @@
         </div>
       </div>
 
-      <%= form_for @conn, if(assigns[:auto_enroll_as_guest], do: ~p"/sections/#{@section.slug}/auto_enroll", else: Routes.delivery_path(@conn, :process_enroll, @section.slug)), fn _f -> %>
+      <%= form_for @conn, if(assigns[:auto_enroll_as_guest], do: ~p"/sections/#{@section.slug}/auto_enroll", else: ~p"/sections/#{@section.slug}/enroll"), fn _f -> %>
         <div class="form-label-group">
           <%= if user_is_guest?(assigns) or assigns.current_user == nil do %>
             <p>
@@ -45,10 +45,7 @@
           <a
             :if={!assigns[:auto_enroll_as_guest]}
             href={
-              Routes.pow_session_path(@conn, :new,
-                section: @section.slug,
-                from_invitation_link?: assigns[:from_invitation_link?]
-              )
+              ~p"/session/new?#{[section: @section.slug, from_invitation_link?: assigns[:from_invitation_link?]]}"
             }
             class="btn btn-md btn-outline-primary btn-block mt-2"
           >
@@ -57,10 +54,7 @@
           <a
             :if={!assigns[:auto_enroll_as_guest]}
             href={
-              Routes.pow_registration_path(@conn, :new,
-                section: @section.slug,
-                from_invitation_link?: assigns[:from_invitation_link?]
-              )
+              ~p"/registration/new?#{[section: @section.slug, from_invitation_link?: assigns[:from_invitation_link?]]}"
             }
             class="btn btn-md btn-outline-primary btn-block mt-2"
           >

--- a/lib/oli_web/templates/delivery/enroll.html.heex
+++ b/lib/oli_web/templates/delivery/enroll.html.heex
@@ -54,6 +54,18 @@
           >
             Sign In
           </a>
+          <a
+            :if={!assigns[:auto_enroll_as_guest]}
+            href={
+              Routes.pow_registration_path(@conn, :new,
+                section: @section.slug,
+                from_invitation_link?: assigns[:from_invitation_link?]
+              )
+            }
+            class="btn btn-md btn-outline-primary btn-block mt-2"
+          >
+            Sign Up
+          </a>
         <% else %>
           <%= submit("Enroll", class: "btn btn-md btn-primary btn-block") %>
         <% end %>

--- a/test/oli_web/controllers/delivery_controller_test.exs
+++ b/test/oli_web/controllers/delivery_controller_test.exs
@@ -539,6 +539,18 @@ defmodule OliWeb.DeliveryControllerTest do
 
       assert html_response(conn, 200) =~ "Enroll in Course Section"
     end
+
+    test "does not display Sign Up link", %{conn: conn} do
+      section = insert(:section)
+      section_invite = insert(:section_invite, %{section: section})
+
+      conn = get(conn, Routes.delivery_path(conn, :enroll_independent, section_invite.slug))
+
+      refute html_response(conn, 200) =~ "Sign Up"
+
+      refute html_response(conn, 200) =~
+               ~s(<a href="/registration/new?section=#{section.slug}&amp;from_invitation_link%3F=true")
+    end
   end
 
   describe "enroll independent (as guest user)" do
@@ -620,6 +632,24 @@ defmodule OliWeb.DeliveryControllerTest do
 
       assert html_response(conn, 200) =~
                ~s(<a href="/session/new?section=#{section.slug}&amp;from_invitation_link%3F=true" )
+    end
+
+    test "shows enroll view and Sign Up link", %{conn: conn} do
+      section = insert(:section)
+      section_invite = insert(:section_invite, %{section: section})
+
+      conn =
+        get(
+          conn,
+          Routes.delivery_path(conn, :enroll_independent, section_invite.slug,
+            from_invitation_link?: true
+          )
+        )
+
+      assert html_response(conn, 200) =~ "Sign Up"
+
+      assert html_response(conn, 200) =~
+               ~s(<a href="/registration/new?section=#{section.slug}&amp;from_invitation_link%3F=true")
     end
   end
 


### PR DESCRIPTION
Add `Sign up` button in enrollment page.

User flow preview:

https://github.com/Simon-Initiative/oli-torus/assets/5324858/695d0478-8ab8-456e-ad31-7797b419beec

See: https://eliterate.atlassian.net/browse/MER-3294

