### PR TITLE
[ENHANCEMENT] [MER-3396] Async project export to fix gateway timeout

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -165,6 +165,7 @@ config :oli, Oban,
     updates: 10,
     grades: 30,
     auto_submit: 3,
+    project_export: 3,
     analytics_export: 3,
     datashop_export: 3,
     objectives: 3

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -375,6 +375,7 @@ if config_env() == :prod do
       auto_submit: String.to_integer(System.get_env("OBAN_QUEUE_SIZE_AUTOSUBMIT", "3")),
       analytics_export: String.to_integer(System.get_env("OBAN_QUEUE_SIZE_ANALYTICS", "1")),
       datashop_export: String.to_integer(System.get_env("OBAN_QUEUE_SIZE_DATASHOP", "1")),
+      project_export: String.to_integer(System.get_env("OBAN_QUEUE_SIZE_PROJECT_EXPORT", "3")),
       objectives: String.to_integer(System.get_env("OBAN_QUEUE_SIZE_OBJECTIVES", "3"))
     ]
 end

--- a/lib/oli/authoring/broadcasting/broadcaster.ex
+++ b/lib/oli/authoring/broadcasting/broadcaster.ex
@@ -116,6 +116,17 @@ defmodule Oli.Authoring.Broadcaster do
   end
 
   @doc """
+  Broadcasts a project export status update
+  """
+  def broadcast_project_export_status(project_slug, status) do
+    PubSub.broadcast(
+      Oli.PubSub,
+      message_project_export_status(project_slug),
+      {:project_export_status, status}
+    )
+  end
+
+  @doc """
   Broadcasts a raw analytics export status update
   """
   def broadcast_analytics_export_status(project_slug, status) do

--- a/lib/oli/authoring/broadcasting/messages.ex
+++ b/lib/oli/authoring/broadcasting/messages.ex
@@ -41,6 +41,10 @@ defmodule Oli.Authoring.Broadcaster.Messages do
     ["lock_released", project(project_slug), resource(resource_id)] |> join
   end
 
+  def message_project_export_status(project_slug) do
+    ["project_export_status", project(project_slug)] |> join
+  end
+
   def message_analytics_export_status(project_slug) do
     ["analytics_export_status", project(project_slug)] |> join
   end

--- a/lib/oli/authoring/broadcasting/subscriber.ex
+++ b/lib/oli/authoring/broadcasting/subscriber.ex
@@ -43,6 +43,10 @@ defmodule Oli.Authoring.Broadcaster.Subscriber do
     PubSub.subscribe(Oli.PubSub, message_lock_released(project_slug, resource_id))
   end
 
+  def subscribe_to_project_export_status(project_slug) do
+    PubSub.subscribe(Oli.PubSub, message_project_export_status(project_slug))
+  end
+
   def subscribe_to_analytics_export_status(project_slug) do
     PubSub.subscribe(Oli.PubSub, message_analytics_export_status(project_slug))
   end

--- a/lib/oli/authoring/course.ex
+++ b/lib/oli/authoring/course.ex
@@ -563,46 +563,6 @@ defmodule Oli.Authoring.Course do
   end
 
   @doc """
-  Generates a project export for the given project if one is not already in progress
-  """
-  def generate_project_export(project) do
-    case project_export_status(project) do
-      {:in_progress} ->
-        {:error, "Project export is already in progress"}
-
-      _ ->
-        generate_project_export!(project)
-    end
-  end
-
-  defp generate_project_export!(project) do
-    %{project_slug: project.slug}
-    |> Oli.Authoring.ProjectExportWorker.new()
-    |> Oban.insert()
-  end
-
-  def project_export_status(project) do
-    if export_in_progress?(project.slug, "project_export") do
-      # export is in progress
-      {:in_progress}
-    else
-      case project do
-        # export is created and completed
-        %Project{
-          latest_export_url: export_url,
-          latest_export_timestamp: export_timestamp
-        }
-        when not is_nil(export_url) and not is_nil(export_timestamp) ->
-          {:available, export_url, export_timestamp}
-
-        # export has not been created yet
-        _ ->
-          {:not_available}
-      end
-    end
-  end
-
-  @doc """
   Returns an `%Ecto.Changeset{}` for tracking project changes.
   ## Examples
       iex> change_project(project, params)

--- a/lib/oli/authoring/course/project.ex
+++ b/lib/oli/authoring/course/project.ex
@@ -18,6 +18,8 @@ defmodule Oli.Authoring.Course.Project do
     field(:has_experiments, :boolean, default: false)
     field(:legacy_svn_root, :string)
     field(:allow_ecl_content_type, :boolean, default: false)
+    field(:latest_export_url, :string)
+    field(:latest_export_timestamp, :utc_datetime)
     field(:latest_analytics_snapshot_url, :string)
     field(:latest_analytics_snapshot_timestamp, :utc_datetime)
     field(:latest_datashop_snapshot_url, :string)
@@ -82,6 +84,8 @@ defmodule Oli.Authoring.Course.Project do
       :analytics_version,
       :publisher_id,
       :required_survey_resource_id,
+      :latest_export_url,
+      :latest_export_timestamp,
       :latest_analytics_snapshot_url,
       :latest_analytics_snapshot_timestamp,
       :latest_datashop_snapshot_url,

--- a/lib/oli/authoring/project_export_worker.ex
+++ b/lib/oli/authoring/project_export_worker.ex
@@ -44,9 +44,7 @@ defmodule Oli.Authoring.ProjectExportWorker do
 
     random_string = Oli.Utils.random_string(16)
 
-    {:ok, file_timestamp} = timestamp |> Timex.format("%Y-%m-%d-%H%M%S", :strftime)
-
-    filename = "export_#{project_slug}_#{file_timestamp}.zip"
+    filename = "export_#{project_slug}.zip"
 
     bucket_name = Application.fetch_env!(:oli, :s3_media_bucket_name)
     project_export_path = Path.join(["exports", project_slug, random_string, filename])

--- a/lib/oli/authoring/project_export_worker.ex
+++ b/lib/oli/authoring/project_export_worker.ex
@@ -1,0 +1,62 @@
+defmodule Oli.Authoring.ProjectExportWorker do
+  use Oban.Worker,
+    queue: :project_export,
+    priority: 3,
+    max_attempts: 1
+
+  require Logger
+
+  alias Oli.Utils
+  alias Oli.Authoring.Broadcaster
+  alias Oli.Authoring.Course
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"project_slug" => project_slug} = _args}) do
+    try do
+      {full_upload_url, timestamp} = export(project_slug)
+
+      # notify subscribers that the export is available
+      Broadcaster.broadcast_project_export_status(
+        project_slug,
+        {:available, full_upload_url, timestamp}
+      )
+    rescue
+      e ->
+        # notify subscribers that the export failed
+        Broadcaster.broadcast_project_export_status(
+          project_slug,
+          {:error, e}
+        )
+
+        Logger.error(Exception.format(:error, e, __STACKTRACE__))
+        reraise e, __STACKTRACE__
+    end
+
+    :ok
+  end
+
+  def export(project_slug) do
+    timestamp = DateTime.utc_now()
+
+    project = Course.get_project_by_slug(project_slug)
+
+    export_zip_content = Oli.Interop.Export.export(project)
+
+    random_string = Oli.Utils.random_string(16)
+
+    {:ok, file_timestamp} = timestamp |> Timex.format("%Y-%m-%d-%H%M%S", :strftime)
+
+    filename = "export_#{project_slug}_#{file_timestamp}.zip"
+
+    bucket_name = Application.fetch_env!(:oli, :s3_media_bucket_name)
+    project_export_path = Path.join(["exports", project_slug, random_string, filename])
+
+    {:ok, full_upload_url} =
+      Utils.S3Storage.put(bucket_name, project_export_path, export_zip_content)
+
+    # update the project's last_exported_at timestamp
+    Course.update_project_latest_export_url(project_slug, full_upload_url, timestamp)
+
+    {full_upload_url, timestamp}
+  end
+end

--- a/lib/oli/authoring/project_export_worker.ex
+++ b/lib/oli/authoring/project_export_worker.ex
@@ -9,6 +9,7 @@ defmodule Oli.Authoring.ProjectExportWorker do
   alias Oli.Utils
   alias Oli.Authoring.Broadcaster
   alias Oli.Authoring.Course
+  alias Oli.Authoring.Course.Project
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"project_slug" => project_slug} = _args}) do
@@ -56,5 +57,41 @@ defmodule Oli.Authoring.ProjectExportWorker do
     Course.update_project_latest_export_url(project_slug, full_upload_url, timestamp)
 
     {full_upload_url, timestamp}
+  end
+
+  @doc """
+  Generates a project export for the given project if one is not already in progress
+  """
+  def generate_project_export(project) do
+    case project_export_status(project) do
+      {:in_progress} ->
+        {:error, "Project export is already in progress"}
+
+      _ ->
+        %{project_slug: project.slug}
+        |> Oli.Authoring.ProjectExportWorker.new()
+        |> Oban.insert()
+    end
+  end
+
+  def project_export_status(project) do
+    if Course.export_in_progress?(project.slug, "project_export") do
+      # export is in progress
+      {:in_progress}
+    else
+      case project do
+        # export is created and completed
+        %Project{
+          latest_export_url: export_url,
+          latest_export_timestamp: export_timestamp
+        }
+        when not is_nil(export_url) and not is_nil(export_timestamp) ->
+          {:available, export_url, export_timestamp}
+
+        # export has not been created yet
+        _ ->
+          {:not_available}
+      end
+    end
   end
 end

--- a/lib/oli_web/components/project/async_exporter.ex
+++ b/lib/oli_web/components/project/async_exporter.ex
@@ -173,4 +173,55 @@ defmodule OliWeb.Components.Project.AsyncExporter do
     </button>
     """
   end
+
+  attr(:ctx, SessionContext, required: true)
+  attr(:project_export_status, :atom, values: [:not_available, :in_progress, :available, :error])
+  attr(:project_export_url, :string)
+  attr(:project_export_timestamp, :string)
+  attr(:on_generate_project_export, :string, default: "generate_project_export")
+
+  def project_export(assigns) do
+    ~H"""
+    <%= case @project_export_status do %>
+      <% status when status in [:not_available, :expired] -> %>
+        <.button variant={:link} phx-click={@on_generate_project_export}>
+          Export
+        </.button>
+        <div>Download this project and its contents</div>
+      <% :in_progress -> %>
+        <.button variant={:link} disabled>Export</.button>
+        <div class="flex flex-col">
+          <div>Download this project and its contents</div>
+          <div class="text-sm text-gray-500">
+            <i class="fa-solid fa-circle-notch fa-spin text-primary"></i>
+            Generating project export... this might take a while.
+          </div>
+        </div>
+      <% :available -> %>
+        <.button variant={:link} href={@project_export_url} download>
+          <i class="fa-solid fa-download mr-1"></i> Download Latest Export
+        </.button>
+        <div class="flex flex-col">
+          <div>Download this project and its contents.</div>
+          <div class="text-sm text-gray-500">
+            Created <%= date(@project_export_timestamp, @ctx) %>.
+            <.button variant={:link} phx-click={@on_generate_project_export}>
+              <i class="fa-solid fa-rotate-right mr-1"></i>Regenerate
+            </.button>
+          </div>
+        </div>
+      <% :error -> %>
+        <.button variant={:link} phx-click={@on_generate_project_export}>
+          Export
+        </.button>
+        <div class="flex flex-col">
+          <div>Download this project and its contents</div>
+          <div class="text-sm text-gray-500">
+            <i class="fa-solid fa-exclamation-circle text-red-500"></i>
+            Error generating project export. Please try again later or contact support.
+          </div>
+        </div>
+    <% end %>
+    """
+  end
 end

--- a/lib/oli_web/components/project/async_exporter.ex
+++ b/lib/oli_web/components/project/async_exporter.ex
@@ -184,12 +184,12 @@ defmodule OliWeb.Components.Project.AsyncExporter do
     ~H"""
     <%= case @project_export_status do %>
       <% status when status in [:not_available, :expired] -> %>
-        <.button variant={:link} phx-click={@on_generate_project_export}>
+        <.button variant={:link} class="!px-3" phx-click={@on_generate_project_export}>
           Export
         </.button>
         <div>Download this project and its contents</div>
       <% :in_progress -> %>
-        <.button variant={:link} disabled>Export</.button>
+        <.button variant={:link} class="!px-3" disabled>Export in Progress</.button>
         <div class="flex flex-col">
           <div>Download this project and its contents</div>
           <div class="text-sm text-gray-500">
@@ -198,7 +198,7 @@ defmodule OliWeb.Components.Project.AsyncExporter do
           </div>
         </div>
       <% :available -> %>
-        <.button variant={:link} href={@project_export_url} download>
+        <.button variant={:link} class="!px-3" href={@project_export_url} download>
           <i class="fa-solid fa-download mr-1"></i> Download Latest Export
         </.button>
         <div class="flex flex-col">
@@ -211,7 +211,7 @@ defmodule OliWeb.Components.Project.AsyncExporter do
           </div>
         </div>
       <% :error -> %>
-        <.button variant={:link} phx-click={@on_generate_project_export}>
+        <.button variant={:link} class="!px-3" phx-click={@on_generate_project_export}>
           Export
         </.button>
         <div class="flex flex-col">

--- a/lib/oli_web/controllers/project_controller.ex
+++ b/lib/oli_web/controllers/project_controller.ex
@@ -33,15 +33,6 @@ defmodule OliWeb.ProjectController do
     end
   end
 
-  def download_export(conn, _project_params) do
-    project = conn.assigns.project
-
-    conn
-    |> send_download({:binary, Oli.Interop.Export.export(project)},
-      filename: "export_#{project.slug}.zip"
-    )
-  end
-
   def clone_project(conn, _project_params) do
     case Clone.clone_project(conn.assigns.project.slug, conn.assigns.current_author) do
       {:ok, project} ->

--- a/lib/oli_web/live/projects/overview_live.ex
+++ b/lib/oli_web/live/projects/overview_live.ex
@@ -9,12 +9,13 @@ defmodule OliWeb.Projects.OverviewLive do
   alias Oli.Authoring.Course.Project
   alias Oli.Inventories
   alias Oli.Publishing
-  alias OliWeb.Common.Breadcrumb
   alias Oli.Activities
   alias Oli.Publishing.AuthoringResolver
   alias Oli.Resources.Collaboration
   alias Oli.Authoring.Broadcaster
   alias Oli.Authoring.Broadcaster.Subscriber
+  alias Oli.Authoring.ProjectExportWorker
+  alias OliWeb.Common.Breadcrumb
   alias OliWeb.Components.Overview
   alias OliWeb.Projects.{RequiredSurvey, TransferPaymentCodes}
   alias OliWeb.Common.SessionContext
@@ -41,7 +42,7 @@ defmodule OliWeb.Projects.OverviewLive do
       |> Enum.sort(:desc)
 
     {project_export_status, project_export_url, project_export_timestamp} =
-      case Course.project_export_status(project) do
+      case ProjectExportWorker.project_export_status(project) do
         {:available, url, timestamp} -> {:available, url, timestamp}
         {status} -> {status, nil, nil}
       end
@@ -422,7 +423,7 @@ defmodule OliWeb.Projects.OverviewLive do
               </span>
             <% _pub -> %>
               <.button
-                class="btn btn-link action-button"
+                class="btn btn-link action-button !px-3"
                 href={~p"/project/#{@project.slug}/datashop"}
               >
                 Datashop Analytics
@@ -431,7 +432,7 @@ defmodule OliWeb.Projects.OverviewLive do
           <% end %>
         </div>
 
-        <div class="d-flex align-items-center">
+        <div class="d-flex align-items-center mt-8">
           <button
             type="button"
             class="btn btn-link text-danger action-button"
@@ -598,7 +599,7 @@ defmodule OliWeb.Projects.OverviewLive do
   def handle_event("generate_project_export", _params, socket) do
     project = socket.assigns.project
 
-    case Course.generate_project_export(project) do
+    case ProjectExportWorker.generate_project_export(project) do
       {:ok, _job} ->
         Broadcaster.broadcast_project_export_status(project.slug, {:in_progress})
 

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -398,8 +398,6 @@ defmodule OliWeb.Router do
 
     # Project display pages
     live("/:project_id/publish", Projects.PublishView)
-    post("/:project_id/datashop", ProjectController, :download_datashop)
-    post("/:project_id/export", ProjectController, :download_export)
     post("/:project_id/duplicate", ProjectController, :clone_project)
 
     live("/:project_id/embeddings", Search.EmbeddingsLive)

--- a/priv/repo/migrations/20240709205804_async_project_export.exs
+++ b/priv/repo/migrations/20240709205804_async_project_export.exs
@@ -1,0 +1,10 @@
+defmodule Oli.Repo.Migrations.AsyncProjectExport do
+  use Ecto.Migration
+
+  def change do
+    alter table(:projects) do
+      add :latest_export_url, :string
+      add :latest_export_timestamp, :utc_datetime
+    end
+  end
+end

--- a/test/oli/analytics/xapi/pipeline_test.exs
+++ b/test/oli/analytics/xapi/pipeline_test.exs
@@ -59,16 +59,11 @@ defmodule Oli.Analytics.XAPI.PipelineTest do
       bundle2b = make_bundle("2", map.upload_directory)
 
       ref = Broadway.test_batch(UploadPipeline, [bundle1a, bundle1b, bundle2a, bundle2b])
-      assert_receive {:ack, ^ref, success, failure}, 1000
+      assert_receive {:ack, ^ref, success, failure}, 5000
 
       # Verify that the two common messages were handled each in separate batches
       assert length(success) == 2
       assert length(failure) == 0
-
-      wait_while(fn ->
-        !(File.exists?("#{map.upload_directory}/1.jsonl") &&
-            File.exists?("#{map.upload_directory}/2.jsonl"))
-      end)
 
       # assert that #{map.upload_directory}/1.jsonl and #{map.upload_directory}/2.jsonl exist
       assert File.exists?("#{map.upload_directory}/1.jsonl")

--- a/test/oli/analytics/xapi/pipeline_test.exs
+++ b/test/oli/analytics/xapi/pipeline_test.exs
@@ -65,6 +65,11 @@ defmodule Oli.Analytics.XAPI.PipelineTest do
       assert length(success) == 2
       assert length(failure) == 0
 
+      wait_while(fn ->
+        !(File.exists?("#{map.upload_directory}/1.jsonl") &&
+            File.exists?("#{map.upload_directory}/2.jsonl"))
+      end)
+
       # assert that #{map.upload_directory}/1.jsonl and #{map.upload_directory}/2.jsonl exist
       assert File.exists?("#{map.upload_directory}/1.jsonl")
       assert File.exists?("#{map.upload_directory}/2.jsonl")

--- a/test/oli_web/controllers/project_controller_test.exs
+++ b/test/oli_web/controllers/project_controller_test.exs
@@ -64,7 +64,6 @@ defmodule OliWeb.ProjectControllerTest do
     setup [:admin_conn, :create_project_with_products]
 
     test "export a project with products works correctly", %{
-      conn: conn,
       project: project,
       product_1: product_1,
       product_2: product_2,
@@ -90,7 +89,6 @@ defmodule OliWeb.ProjectControllerTest do
 
     test "export a project with products works correctly by filtering out products that have publications from other projects.",
          %{
-           conn: conn,
            project: project,
            product_1: product_1,
            product_2: product_2,

--- a/test/oli_web/controllers/project_controller_test.exs
+++ b/test/oli_web/controllers/project_controller_test.exs
@@ -86,9 +86,6 @@ defmodule OliWeb.ProjectControllerTest do
       assert Map.has_key?(m, ~c"#{product_2.id}.json")
       assert Map.has_key?(m, ~c"#{page_resource_1.id}.json")
       assert Map.has_key?(m, ~c"#{page_resource_2.id}.json")
-
-      conn = post(conn, Routes.project_path(conn, :download_export, project.id))
-      assert html_response(conn, 302) =~ "/authoring/projects"
     end
 
     test "export a project with products works correctly by filtering out products that have publications from other projects.",
@@ -116,9 +113,6 @@ defmodule OliWeb.ProjectControllerTest do
       assert Map.has_key?(m, ~c"#{product_1.id}.json")
       assert Map.has_key?(m, ~c"#{page_resource_1.id}.json")
       assert Map.has_key?(m, ~c"#{page_resource_2.id}.json")
-
-      conn = post(conn, Routes.project_path(conn, :download_export, project.id))
-      assert html_response(conn, 302) =~ "/authoring/projects"
     end
   end
 


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-3396

This PR fixes an issue with exporting very large courses where the export processing takes longer than a browser connection (and default Phoenix/cowboy) can handle, resulting in a Gateway Timeout error and no way to download the export for a course.

Adjusting the HAProxy setting to a longer time window did not fix the issue on stellarator, so this required a code fix.

Now the export process is handled as a asynchronous background job using the existing AsyncExporter module. It will be important that users understand that in order to get the latest version of their project, they must first "Regenerate" before clicking the download button. This is likely not the best UX, but will work for the short term and unblocks the ability to download large projects.

When a job is in progress, a spinner is shown .
![Screenshot 2024-07-10 at 12 27 22 PM](https://github.com/Simon-Initiative/oli-torus/assets/6248894/264cd548-3c2f-44ca-9214-2152d2c49618)

When finished, LiveViews are notified and the exported project can be download via S3 link.
![Screenshot 2024-07-10 at 12 27 30 PM](https://github.com/Simon-Initiative/oli-torus/assets/6248894/1acb79c0-223b-484d-96e5-7afe7d9de1d2)
