### PR TITLE
[ENHANCEMENT] [MER-3503] Add support for accessing research consent form

### DIFF
--- a/lib/oli/delivery.ex
+++ b/lib/oli/delivery.ex
@@ -11,6 +11,7 @@ defmodule Oli.Delivery do
   alias Oli.Repo
   alias Oli.Publishing.{DeliveryResolver, PublishedResource}
   alias Oli.Delivery.Attempts.Core.{ResourceAttempt, ActivityAttempt, ResourceAccess}
+  alias Oli.Delivery.ResearchConsent
 
   import Ecto.Query, warn: false
   import Oli.Utils
@@ -431,6 +432,31 @@ defmodule Oli.Delivery do
           end
         end)
         |> Enum.all?(&(elem(&1, 1) == :evaluated))
+    end
+  end
+
+  @doc """
+  Returns the research consent form setting.
+
+  This record is created during migration so a single record is always expected to exist.
+  """
+  def get_research_consent_form_setting() do
+    Repo.one(ResearchConsent)
+    |> Map.get(:research_consent)
+  end
+
+  @doc """
+  Updates the research consent form setting.
+  """
+  def update_research_consent_form_setting(research_consent) do
+    case Repo.one(ResearchConsent) do
+      nil ->
+        Repo.insert!(%ResearchConsent{research_consent: research_consent})
+
+      %ResearchConsent{} = research_consent_form ->
+        research_consent_form
+        |> ResearchConsent.changeset(%{research_consent: research_consent})
+        |> Repo.update()
     end
   end
 end

--- a/lib/oli/delivery/research_consent.ex
+++ b/lib/oli/delivery/research_consent.ex
@@ -1,0 +1,15 @@
+defmodule Oli.Delivery.ResearchConsent do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "research_consent" do
+    field :research_consent, Ecto.Enum, values: [:oli_form, :no_form], default: :oli_form
+  end
+
+  @doc false
+  def changeset(research_consent, attrs) do
+    research_consent
+    |> cast(attrs, [:research_consent])
+    |> validate_required([:research_consent])
+  end
+end

--- a/lib/oli/institutions.ex
+++ b/lib/oli/institutions.ex
@@ -82,6 +82,28 @@ defmodule Oli.Institutions do
   end
 
   @doc """
+  Returns the institution that an LTI user is associated with.
+  """
+  def get_institution_by_lti_user(user) do
+    # using enrollment records, we can infer the user's institution. This is because
+    # an LTI user can be enrolled in multiple sections, but all sections must be from
+    # the same institution.
+    from(e in Enrollment,
+      join: s in Section,
+      on: e.section_id == s.id,
+      join: u in User,
+      on: e.user_id == u.id,
+      join: institution in Institution,
+      on: s.institution_id == institution.id,
+      where: u.id == ^user.id and s.status == :active and e.status == :enrolled,
+      limit: 1,
+      select: institution
+    )
+    |> Repo.all()
+    |> List.first()
+  end
+
+  @doc """
   Gets an institution by clauses. Will raise an error if
   more than one matches the criteria.
 

--- a/lib/oli_web/components/delivery/user_account.ex
+++ b/lib/oli_web/components/delivery/user_account.ex
@@ -435,7 +435,7 @@ defmodule OliWeb.Components.Delivery.UserAccount do
         false
 
       # Direct delivery user
-      %User{independent_learner: true} = user ->
+      %User{independent_learner: true} ->
         case Delivery.get_research_consent_form_setting() do
           :oli_form ->
             true

--- a/lib/oli_web/components/delivery/user_account.ex
+++ b/lib/oli_web/components/delivery/user_account.ex
@@ -6,6 +6,8 @@ defmodule OliWeb.Components.Delivery.UserAccount do
   alias Phoenix.LiveView.JS
   alias Oli.Accounts.{User, Author}
   alias OliWeb.Router.Helpers, as: Routes
+  alias Oli.Institutions
+  alias Oli.Delivery
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.Section
   alias OliWeb.Common.SessionContext
@@ -93,6 +95,7 @@ defmodule OliWeb.Components.Delivery.UserAccount do
     <.menu_divider />
     <.menu_item_timezone_selector id={"#{@id}-tz-selector"} ctx={@ctx} />
     <.menu_divider />
+    <.maybe_research_consent_link ctx={@ctx} />
     <.menu_item_link
       href={Routes.session_path(OliWeb.Endpoint, :signout, type: :user)}
       method={:delete}
@@ -117,6 +120,7 @@ defmodule OliWeb.Components.Delivery.UserAccount do
       Create account or sign in
     </.menu_item_link>
     <.menu_divider />
+    <.maybe_research_consent_link ctx={@ctx} />
     <.menu_item_link href={signout_path(@ctx)} method={:delete}>
       <%= if @ctx.user.guest, do: "Leave course", else: "Sign out" %>
     </.menu_item_link>
@@ -300,6 +304,19 @@ defmodule OliWeb.Components.Delivery.UserAccount do
 
   attr(:ctx, SessionContext, required: true)
 
+  defp maybe_research_consent_link(assigns) do
+    ~H"""
+    <%= if show_research_consent_link?(@ctx.user) do %>
+      <.menu_item_link href={~p"/research_consent"}>
+        Research Consent
+      </.menu_item_link>
+      <.menu_divider />
+    <% end %>
+    """
+  end
+
+  attr(:ctx, SessionContext, required: true)
+
   def user_icon(assigns) do
     ~H"""
     <%= case @ctx do %>
@@ -411,4 +428,34 @@ defmodule OliWeb.Components.Delivery.UserAccount do
   end
 
   defp to_initials(_), do: "?"
+
+  defp show_research_consent_link?(user) do
+    case user do
+      nil ->
+        false
+
+      # Direct delivery user
+      %User{independent_learner: true} = user ->
+        case Delivery.get_research_consent_form_setting() do
+          :oli_form ->
+            true
+
+          _ ->
+            false
+        end
+
+      # LTI user
+      user ->
+        # check institution research consent setting
+        institution = Institutions.get_institution_by_lti_user(user)
+
+        case institution.research_consent do
+          :oli_form ->
+            true
+
+          _ ->
+            false
+        end
+    end
+  end
 end

--- a/lib/oli_web/components/delivery/user_account.ex
+++ b/lib/oli_web/components/delivery/user_account.ex
@@ -7,6 +7,7 @@ defmodule OliWeb.Components.Delivery.UserAccount do
   alias Oli.Accounts.{User, Author}
   alias OliWeb.Router.Helpers, as: Routes
   alias Oli.Institutions
+  alias Oli.Institutions.Institution
   alias Oli.Delivery
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.Section
@@ -449,10 +450,12 @@ defmodule OliWeb.Components.Delivery.UserAccount do
         # check institution research consent setting
         institution = Institutions.get_institution_by_lti_user(user)
 
-        case institution.research_consent do
-          :oli_form ->
+        case institution do
+          %Institution{research_consent: :oli_form} ->
             true
 
+          # if research consent is set to anything else or institution was
+          # not found for LTI user, do not show the link
           _ ->
             false
         end

--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -10,6 +10,7 @@ defmodule OliWeb.DeliveryController do
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.EnrollmentBrowseOptions
   alias Oli.Institutions
+  alias Oli.Institutions.Institution
   alias Oli.Lti.LtiParams
   alias Oli.Repo
   alias Oli.Repo.{Paging, Sorting}
@@ -120,8 +121,8 @@ defmodule OliWeb.DeliveryController do
         # check institution research consent setting
         institution = Institutions.get_institution_by_lti_user(user)
 
-        case institution.research_consent do
-          :oli_form ->
+        case institution do
+          %Institution{research_consent: :oli_form} ->
             conn
             |> assign(:research_opt_out, user_research_opt_out?(user))
             |> assign(:redirect_url, redirect_url)

--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -150,7 +150,7 @@ defmodule OliWeb.DeliveryController do
     )
   end
 
-  def show_research_consent(conn, params) do
+  def show_research_consent(conn, _params) do
     user = conn.assigns.current_user
 
     redirect_url =

--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -6,6 +6,7 @@ defmodule OliWeb.DeliveryController do
   alias Oli.Accounts
   alias Oli.Accounts.{User, Author}
   alias Oli.Analytics.DataTables.DataTable
+  alias Oli.Delivery
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.EnrollmentBrowseOptions
   alias Oli.Institutions
@@ -77,7 +78,7 @@ defmodule OliWeb.DeliveryController do
           )
 
         if institution.research_consent != :no_form and is_nil(user.research_opt_out) do
-          render_research_consent(conn)
+          render_research_consent(conn, ~p"/sections/#{section.slug}")
         else
           redirect_to_page_delivery(conn, section)
         end
@@ -92,11 +93,50 @@ defmodule OliWeb.DeliveryController do
     render(conn, "getting_started.html")
   end
 
-  defp render_research_consent(conn) do
-    conn
-    |> assign(:opt_out, nil)
-    |> render("research_consent.html")
+  defp render_research_consent(conn, redirect_url) do
+    case conn.assigns.current_user do
+      nil ->
+        conn
+        |> put_flash(:error, "User not found")
+        |> redirect(to: Routes.delivery_path(conn, :index))
+
+      # Direct delivery users
+      %User{independent_learner: true} = user ->
+        case Delivery.get_research_consent_form_setting() do
+          :oli_form ->
+            conn
+            |> assign(:research_opt_out, user_research_opt_out?(user))
+            |> assign(:redirect_url, redirect_url)
+            |> render("research_consent.html")
+
+          _ ->
+            conn
+            |> put_flash(:error, "Research consent is not enabled for this platform")
+            |> redirect(to: Routes.delivery_path(conn, :index))
+        end
+
+      # LTI users
+      user ->
+        # check institution research consent setting
+        institution = Institutions.get_institution_by_lti_user(user)
+
+        case institution.research_consent do
+          :oli_form ->
+            conn
+            |> assign(:research_opt_out, user_research_opt_out?(user))
+            |> assign(:redirect_url, redirect_url)
+            |> render("research_consent.html")
+
+          _ ->
+            conn
+            |> put_flash(:error, "Research consent is not enabled for your institution")
+            |> redirect(to: Routes.delivery_path(conn, :index))
+        end
+    end
   end
+
+  defp user_research_opt_out?(%User{research_opt_out: true}), do: true
+  defp user_research_opt_out?(_), do: false
 
   defp redirect_to_page_delivery(conn, section) do
     redirect(conn,
@@ -110,19 +150,38 @@ defmodule OliWeb.DeliveryController do
     )
   end
 
-  def research_consent(conn, %{"consent" => consent}) do
+  def show_research_consent(conn, params) do
     user = conn.assigns.current_user
-    lti_params = conn.assigns.lti_params
-    section = Sections.get_section_from_lti_params(lti_params)
+
+    redirect_url =
+      case user do
+        %User{independent_learner: true} ->
+          case Map.get(conn.assigns, :section) do
+            nil -> ~p"/sections"
+            section -> ~p"/sections/#{section.slug}"
+          end
+
+        _ ->
+          ~p"/course"
+      end
+
+    conn
+    |> assign(:research_opt_out, user.research_opt_out)
+    |> render_research_consent(redirect_url)
+  end
+
+  def research_consent(conn, %{"consent" => consent, "redirect_url" => redirect_url}) do
+    user = conn.assigns.current_user
 
     case Accounts.update_user(user, %{research_opt_out: consent !== "true"}) do
       {:ok, _} ->
-        redirect_to_page_delivery(conn, section)
+        conn
+        |> redirect(to: redirect_url)
 
       {:error, _} ->
         conn
         |> put_flash(:error, "Unable to persist research consent option")
-        |> redirect_to_page_delivery(section)
+        |> redirect(to: redirect_url)
     end
   end
 

--- a/lib/oli_web/live/features/features_live.ex
+++ b/lib/oli_web/live/features/features_live.ex
@@ -156,7 +156,7 @@ defmodule OliWeb.Features.FeaturesLive do
         </h2>
       </div>
       <div class="flex flex-row">
-        <.form :let={f} phx-change="change_research_consent_form">
+        <.form :let={f} for={%{}} phx-change="change_research_consent_form">
           <label for="countries" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
             Direct Delivery Research Consent Form
           </label>

--- a/lib/oli_web/live/features/features_live.ex
+++ b/lib/oli_web/live/features/features_live.ex
@@ -7,6 +7,7 @@ defmodule OliWeb.Features.FeaturesLive do
 
   alias OliWeb.Common.Breadcrumb
   alias Oli.Features
+  alias Oli.Delivery
 
   defp set_breadcrumbs() do
     OliWeb.Admin.AdminView.breadcrumb() ++
@@ -16,13 +17,16 @@ defmodule OliWeb.Features.FeaturesLive do
   end
 
   def mount(_, _, socket) do
+    research_consent_form_setting = Delivery.get_research_consent_form_setting()
+
     {:ok,
      assign(socket,
        title: "Feature Flags",
        log_level: Logger.level(),
        active: :features,
        features: Features.list_features_and_states(),
-       breadcrumbs: set_breadcrumbs()
+       breadcrumbs: set_breadcrumbs(),
+       research_consent_form_setting: research_consent_form_setting
      )}
   end
 
@@ -145,6 +149,28 @@ defmodule OliWeb.Features.FeaturesLive do
           </table>
         </div>
       </div>
+
+      <div class="mt-5">
+        <h2 class="mb-5">
+          Research Consent
+        </h2>
+      </div>
+      <div class="flex flex-row">
+        <.form :let={f} phx-change="change_research_consent_form">
+          <label for="countries" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
+            Direct Delivery Research Consent Form
+          </label>
+
+          <.input
+            field={f[:research_consent_form]}
+            type="select"
+            value={@research_consent_form_setting}
+            options={[{"OLI Form", :oli_form}, {"No Form", :no_form}]}
+            class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
+          >
+          </.input>
+        </.form>
+      </div>
     </div>
     """
   end
@@ -168,5 +194,17 @@ defmodule OliWeb.Features.FeaturesLive do
       end
 
     {:noreply, socket}
+  end
+
+  def handle_event(
+        "change_research_consent_form",
+        %{"research_consent_form" => research_consent_form},
+        socket
+      ) do
+    research_consent_form_selection = String.to_existing_atom(research_consent_form)
+
+    Delivery.update_research_consent_form_setting(research_consent_form_selection)
+
+    {:noreply, assign(socket, research_consent_form_setting: research_consent_form_selection)}
   end
 end

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -253,6 +253,9 @@ defmodule OliWeb.Router do
 
     # keep a session active by periodically calling this endpoint
     get("/keep-alive", StaticPageController, :keep_alive)
+
+    get("/research_consent", DeliveryController, :show_research_consent)
+    post("/research_consent", DeliveryController, :research_consent)
   end
 
   scope "/authoring", as: :authoring do
@@ -1285,8 +1288,6 @@ defmodule OliWeb.Router do
 
     get("/", DeliveryController, :index)
     live("/select_project", Delivery.NewCourse, :lms_instructor, as: :select_source)
-
-    post("/research_consent", DeliveryController, :research_consent)
   end
 
   ### Admin Dashboard / Telemetry

--- a/lib/oli_web/templates/delivery/research_consent.html.eex
+++ b/lib/oli_web/templates/delivery/research_consent.html.eex
@@ -40,23 +40,24 @@
 </div>
 
 <%= form_for @conn, Routes.delivery_path(@conn, :research_consent), fn _f -> %>
-<div class="text-center">
-  <div class="form-check form-check-inline">
-    <label class="form-check-label">
-      <input class="form-check-input" type="radio" name="consent" id="consentRadio1"
-             value="true" checked="true"> I Agree
-    </label>
+  <input type="hidden" name="redirect_url" value="<%= @redirect_url %>">
+  <div class="text-center">
+    <div class="form-check form-check-inline">
+      <label class="form-check-label">
+        <input class="form-check-input" type="radio" name="consent" id="consentRadio1"
+              value="true" <%= if not assigns[:research_opt_out], do: "checked" %>> I Agree
+      </label>
+    </div>
+    <div class="form-check form-check-inline">
+      <label class="form-check-label">
+        <input class="form-check-input" type="radio" name="consent" id="consentRadio2"
+              value="false" <%= if assigns[:research_opt_out], do: "checked" %>> I Disagree
+      </label>
+    </div>
   </div>
-  <div class="form-check form-check-inline">
-    <label class="form-check-label">
-      <input class="form-check-input" type="radio" name="consent" id="consentRadio2"
-             value="false"> I Disagree
-    </label>
-  </div>
-</div>
 
-<div class="mt-2 text-center">
-  <%= submit "Submit", id: "select-submit", class: "btn btn-primary" %>
-</div>
+  <div class="mt-2 text-center">
+    <%= submit "Submit", id: "select-submit", class: "btn btn-primary" %>
+  </div>
 
 <% end %>

--- a/priv/repo/migrations/20240711170055_create_research_consent.exs
+++ b/priv/repo/migrations/20240711170055_create_research_consent.exs
@@ -1,0 +1,24 @@
+defmodule Oli.Repo.Migrations.CreateResearchConsent do
+  use Ecto.Migration
+
+  import Ecto.Query, warn: false
+
+  alias Oli.Repo
+
+  def up do
+    create table(:research_consent) do
+      add :research_consent, :string, default: "oli_form", null: false
+    end
+
+    flush()
+
+    Repo.insert_all(
+      "research_consent",
+      [%{research_consent: "oli_form"}]
+    )
+  end
+
+  def down do
+    drop table(:research_consent)
+  end
+end

--- a/test/oli/analytics/xapi/pipeline_test.exs
+++ b/test/oli/analytics/xapi/pipeline_test.exs
@@ -59,7 +59,7 @@ defmodule Oli.Analytics.XAPI.PipelineTest do
       bundle2b = make_bundle("2", map.upload_directory)
 
       ref = Broadway.test_batch(UploadPipeline, [bundle1a, bundle1b, bundle2a, bundle2b])
-      assert_receive {:ack, ^ref, success, failure}, 5000
+      assert_receive {:ack, ^ref, success, failure}, 10_000
 
       # Verify that the two common messages were handled each in separate batches
       assert length(success) == 2


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-3503

Adds support for accessing research consent form from the user menu in delivery.

System admin can configure whether or not to use the consent form for direct delivery at the system level under Feature Flags. LTI users consent form will still be driven by the institution-specific setting.
![Screenshot 2024-07-11 at 5 16 21 PM](https://github.com/user-attachments/assets/d01fb5fe-e531-4564-8c91-ecdddf3cafcf)

If enabled, a "Research Consent" link will show in the user menu, which takes the user to the consent form where the previous set value for the user selection is shown. If not set, the value will default to "I Agree".
![Screenshot 2024-07-11 at 5 18 00 PM](https://github.com/user-attachments/assets/1af597a9-6b00-4986-adfe-9abc4bba968f)

I tested the different scenarios including direct delivery student, LTI launch from Canvas as both instructor and student.