### PR TITLE
[BUG FIX] [MER-3010] fixes sparse likert and multiple likert attempts

### DIFF
--- a/lib/oli/activities/reports/providers/OliLikert.ex
+++ b/lib/oli/activities/reports/providers/OliLikert.ex
@@ -126,7 +126,9 @@ defmodule Oli.Activities.Reports.Providers.OliLikert do
             group = Map.get(a, "group")
 
             {:ok, choice} =
-              Enum.at(choices, r - 1) |> JSONPointer.get("/content/0/children/0/text")
+              if is_integer(r),
+                do: Enum.at(choices, r - 1) |> JSONPointer.get("/content/0/children/0/text"),
+                else: {:ok, ""}
 
             {color, c} =
               case Map.get(Map.get(c, :colors), group) do

--- a/lib/oli/delivery/attempts/core.ex
+++ b/lib/oli/delivery/attempts/core.ex
@@ -594,7 +594,7 @@ defmodule Oli.Delivery.Attempts.Core do
       from(aa in ActivityAttempt,
         left_join: aa2 in ActivityAttempt,
         on:
-          aa.resource_attempt_id == aa2.resource_attempt_id and
+          aa.resource_id == aa2.resource_id and
             aa.id < aa2.id,
         join: ra in ResourceAttempt,
         on: ra.id == aa.resource_attempt_id,


### PR DESCRIPTION
This PR addresses two issues:

- Resetting and retaking a survey likert causes the report to throw an internal server error.
- If you miss an answer in the Likert, the report throws an internal server error.