### PR TITLE
[FEATURE] [MER-3305] Direct delivery student sign in course enrollment info

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -116,7 +116,12 @@ config :oli, :vendor_property,
       "VENDOR_PROPERTY_COMPANY_ADDRESS",
       "5000 Forbes Ave, Pittsburgh, PA 15213 US"
     ),
-  support_email: System.get_env("VENDOR_PROPERTY_SUPPORT_EMAIL")
+  support_email: System.get_env("VENDOR_PROPERTY_SUPPORT_EMAIL"),
+  faq_url:
+    System.get_env(
+      "VENDOR_PROPERTY_FAQ_URL",
+      "https://olihelp.zohodesk.com/portal/en/kb/articles/frqu"
+    )
 
 config :oli, :stripe_provider,
   public_secret: System.get_env("STRIPE_PUBLIC_SECRET"),

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -188,7 +188,12 @@ if config_env() == :prod do
         "VENDOR_PROPERTY_COMPANY_ADDRESS",
         "5000 Forbes Ave, Pittsburgh, PA 15213 US"
       ),
-    support_email: System.get_env("VENDOR_PROPERTY_SUPPORT_EMAIL")
+    support_email: System.get_env("VENDOR_PROPERTY_SUPPORT_EMAIL"),
+    faq_url:
+      System.get_env(
+        "VENDOR_PROPERTY_FAQ_URL",
+        "https://olihelp.zohodesk.com/portal/en/kb/articles/frqu"
+      )
 
   # optional emerald cloudlab configuration
   config :oli,

--- a/lib/oli/vendor_properties.ex
+++ b/lib/oli/vendor_properties.ex
@@ -20,6 +20,8 @@ defmodule Oli.VendorProperties do
   def company_name(), do: Application.fetch_env!(:oli, :vendor_property)[:company_name]
   def company_address(), do: Application.fetch_env!(:oli, :vendor_property)[:company_address]
 
+  def company_faq_url(), do: Application.fetch_env!(:oli, :vendor_property)[:faq_url]
+
   def normalized_workspace_logo(host) do
     case workspace_logo() do
       "https://" <> rest -> "https://#{rest}"

--- a/lib/oli_web/templates/layout/authoring.html.leex
+++ b/lib/oli_web/templates/layout/authoring.html.leex
@@ -47,6 +47,11 @@
     href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,300;1,400;1,500;1,600;1,700;1,800&display=swap"
     rel="stylesheet">
 
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+
     <!-- Tabler Icons https://tabler.io/docs/icons/webfont -->
     <link
       rel="stylesheet"

--- a/lib/oli_web/templates/static_page/index.html.eex
+++ b/lib/oli_web/templates/static_page/index.html.eex
@@ -1,5 +1,5 @@
-<div class="relative h-[calc(100vh-180px)] flex justify-center items-center">
-    <div class="absolute h-[calc(100vh-180px)] w-full top-0 left-0">
+<div class="relative h-[calc(100vh-112px)] flex justify-center items-center">
+    <div class="absolute h-[calc(100vh-112px)] w-full top-0 left-0">
       <%= OliWeb.Backgrounds.student_sign_in(%{}) %>
     </div>
     <div class="flex flex-col gap-y-10 lg:flex-row w-full relative z-50 overflow-y-scroll lg:overflow-y-auto h-[calc(100vh-270px)] md:h-[calc(100vh-220px)] lg:h-auto py-4 sm:py-8 lg:py-0">
@@ -95,6 +95,34 @@
               ) %>
             </div>
           <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="relative h-screen flex justify-center items-center">
+    <div class="absolute h-screen w-full top-0 left-0">
+      <div class="flex flex-col w-full bg-black h-full">
+        <%= OliWeb.Backgrounds.enrollment_info(%{}) %>
+        <div class="text-left -top-24 md:-top-40 lg:-top-56 mx-20 lg:mx-48 relative text-white text-2xl lg:text-4xl font-normal font-['Open Sans'] leading-10">Course Enrollment</div>
+        <div style="min-height: 18rem;" class="flex flex-col lg:flex-row relative -top-16 lg:-top-28 w-full lg:h-auto self-center px-8 lg:px-32 gap-y-4 lg:gap-x-8 overflow-y-scroll">
+          <div class="w-auto lg:w-1/3 h-auto bg-white rounded-md py-8 px-10">
+            <div class="text-black text-xl font-bold font-['Inter']">Locate your Enrollment Link</div>
+            <p class="text-black text-base font-medium font-['Inter'] pt-10">Your instructor will provide an enrollment link to sign up and access your course. Please contact your instructor if you have not received this link or have misplaced it.</p>
+          </div>
+          <div class="w-auto lg:w-1/3 h-auto bg-white rounded-md py-8 px-10">
+            <div class="text-black text-xl !font-bold font-['Inter']">Create an Account</div>
+            <p class="text-black text-base font-medium font-['Inter'] pt-10">Follow your enrollment link to the account creation page where you will create a user ID and password.</p>
+          </div>
+          <div class="w-auto lg:w-1/3 h-auto bg-white rounded-md py-8 px-10">
+            <div class="text-black text-xl !font-bold font-['Inter']">Still need an account?</div>
+            <div class="pt-10">
+              <p class="text-stone-900 text-base font-medium font-['Inter']">
+                <a href="<%= Oli.VendorProperties.company_faq_url() %>" target="_blank" class="!text-blue-400 text-base font-bold font-['Inter']">Visit our FAQs document</a>
+                for help enrolling or setting up your Torus student account. If you require further assistance, please
+                <a onclick="window.showHelpModal();" class="text-blue-400 text-base font-bold font-['Inter']">contact our support team.</a>
+              </p>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/test/oli_web/controllers/static_page_controller_test.exs
+++ b/test/oli_web/controllers/static_page_controller_test.exs
@@ -134,4 +134,31 @@ defmodule OliWeb.StaticPageControllerTest do
       assert redirected_to(conn, 302) == Routes.static_page_path(conn, :index)
     end
   end
+
+  describe "enrollment info" do
+    test "shows enrollment info in students login", %{conn: conn} do
+      conn = get(conn, Routes.static_page_path(conn, :index))
+
+      assert response(conn, 200) =~ "Course Enrollment"
+      assert response(conn, 200) =~ "Locate your Enrollment Link"
+
+      assert response(conn, 200) =~
+               "Your instructor will provide an enrollment link to sign up and access your course. Please contact your instructor if you have not received this link or have misplaced it."
+
+      assert response(conn, 200) =~ "Create an Account"
+
+      assert response(conn, 200) =~
+               "Follow your enrollment link to the account creation page where you will create a user ID and password."
+
+      assert response(conn, 200) =~ "Still need an account?"
+
+      assert response(conn, 200) =~
+               "Visit our FAQs document"
+
+      assert response(conn, 200) =~
+               "for help enrolling or setting up your Torus student account. If you require further assistance, please"
+
+      assert response(conn, 200) =~ "contact our support team."
+    end
+  end
 end


### PR DESCRIPTION
[MER-3305](https://eliterate.atlassian.net/browse/MER-3305)

This PR introduce information about course enrollment in the student's login view following figma designs.

A link to the FAQ document is displayed and also a button to contact support if it's necessary.

https://github.com/user-attachments/assets/2da902c2-decf-45d1-8a87-693fefd5621b



[MER-3305]: https://eliterate.atlassian.net/browse/MER-3305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ