### PR TITLE
[BUG FIX] [MER-3516] 500 error when-re-accessing a manually graded assessment

### DIFF
--- a/lib/oli_web/live/delivery/student/prologue_live.ex
+++ b/lib/oli_web/live/delivery/student/prologue_live.ex
@@ -214,15 +214,27 @@ defmodule OliWeb.Delivery.Student.PrologueLive do
           Attempt <%= @index %>:
         </div>
         <div class="py-1 justify-end items-center gap-1.5 flex text-green-700 dark:text-green-500">
+          <div
+            :if={@attempt.lifecycle_state == :submitted}
+            class="justify-end items-center gap-1 flex text-xs font-semibold tracking-tight"
+          >
+            Submitted
+          </div>
+        </div>
+
+        <div
+          :if={@attempt.lifecycle_state == :evaluated}
+          class="py-1 justify-end items-center gap-1.5 flex text-green-700 dark:text-green-500"
+        >
           <div class="w-4 h-4 relative"><Icons.star /></div>
-          <div class="justify-end items-center gap-1 flex">
-            <div role="attempt score" class="text-xs font-semibold tracking-tight">
+          <div class="justify-end items-center gap-1 flex text-xs font-semibold tracking-tight">
+            <div role="attempt score">
               <%= Float.round(@attempt.score, 2) %>
             </div>
-            <div class="text-xs font-semibold tracking-[4px]">
+            <div class="tracking-[4px]">
               /
             </div>
-            <div role="attempt out of" lass="text-xs font-semibold tracking-tight">
+            <div role="attempt out of">
               <%= Float.round(@attempt.out_of, 2) %>
             </div>
           </div>

--- a/lib/oli_web/live/delivery/student/prologue_live.ex
+++ b/lib/oli_web/live/delivery/student/prologue_live.ex
@@ -217,6 +217,7 @@ defmodule OliWeb.Delivery.Student.PrologueLive do
           <div
             :if={@attempt.lifecycle_state == :submitted}
             class="justify-end items-center gap-1 flex text-xs font-semibold tracking-tight"
+            role="attempt status"
           >
             Submitted
           </div>

--- a/test/oli_web/live/delivery/student/prologue_live_test.exs
+++ b/test/oli_web/live/delivery/student/prologue_live_test.exs
@@ -630,7 +630,8 @@ defmodule OliWeb.Delivery.Student.PrologueLiveTest do
           date_submitted: ~U[2023-11-15 20:00:00Z],
           date_evaluated: ~U[2023-11-15 20:10:00Z],
           score: 10,
-          out_of: 10
+          out_of: 10,
+          lifecycle_state: :evaluated
         })
 
       {:ok, view, _html} = live(conn, Utils.prologue_live_path(section.slug, page_3.slug))
@@ -640,20 +641,8 @@ defmodule OliWeb.Delivery.Student.PrologueLiveTest do
 
       assert has_element?(
                view,
-               "div[id='attempt_1_summary'] div[role='attempt score']",
-               "5.0"
-             )
-
-      assert has_element?(
-               view,
-               "div[id='attempt_1_summary'] div[role='attempt out of']",
-               "10.0"
-             )
-
-      assert has_element?(
-               view,
-               "div[id='attempt_1_summary'] div[role='attempt submission']",
-               "Tue Nov 14, 2023"
+               "div[id='attempt_1_summary'] div[role='attempt status']",
+               "Submitted"
              )
 
       assert has_element?(


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-3516

**NOTE** Targeted to prerelease-v0.28.0 branch since that is the base (in order to properly see diffs for PR review), but we may want to target to master or a different hotfix branch.

Fixes an issue where re-accessing a manually graded page summary throws 500 when an attempt in in the "submitted" state and not "evaluated" yet.

<img width="1266" alt="Screenshot 2024-07-17 at 12 35 04 PM" src="https://github.com/user-attachments/assets/350fbbc0-a09a-4628-b018-c710a63dd334">
