### PR TITLE
[BUG FIX] [MER-3390] Only include enrolled students in section enrollment count

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -376,7 +376,10 @@ defmodule Oli.Delivery.Sections do
             enrollment_context_roles
         end)
 
-      Repo.insert_all(EnrollmentContextRole, enrollment_context_roles, on_conflict: :nothing)
+      Repo.insert_all(EnrollmentContextRole, enrollment_context_roles,
+        on_conflict: :nothing,
+        conflict_target: [:enrollment_id, :context_role_id]
+      )
 
       {:ok, enrollments}
     end)

--- a/lib/oli/delivery/sections/browse.ex
+++ b/lib/oli/delivery/sections/browse.ex
@@ -106,7 +106,7 @@ defmodule Oli.Delivery.Sections.Browse do
       from e in Enrollment,
         join: ecr in EnrollmentContextRole,
         on: ecr.enrollment_id == e.id,
-        where: ecr.context_role_id == ^student_role_id,
+        where: ecr.context_role_id == ^student_role_id and e.status == :enrolled,
         select: %{
           id: e.id,
           section_id: e.section_id

--- a/priv/repo/migrations/20240719181530_enrollments_context_roles_unique_index.exs
+++ b/priv/repo/migrations/20240719181530_enrollments_context_roles_unique_index.exs
@@ -1,0 +1,36 @@
+defmodule Oli.Repo.Migrations.EnrollmentsContextRolesUniqueIndex do
+  use Ecto.Migration
+
+  def up do
+    # add temporary auto incrementing primary key column for duplicates removal operation
+    execute("ALTER TABLE enrollments_context_roles ADD COLUMN id SERIAL PRIMARY KEY")
+
+    # delete duplicate enrollments_context_roles
+    execute("""
+      DELETE FROM enrollments_context_roles
+      WHERE id IN (
+          SELECT id FROM (
+              SELECT id, ROW_NUMBER() OVER (PARTITION BY enrollment_id, context_role_id ORDER BY id) AS rnum
+              FROM enrollments_context_roles
+          ) t
+          WHERE t.rnum > 1
+      )
+    """)
+
+    # drop existing non-unique index
+    drop index(:enrollments_context_roles, [:enrollment_id, :context_role_id])
+
+    # create unique index
+    create unique_index(:enrollments_context_roles, [:enrollment_id, :context_role_id])
+
+    # drop temporary primary key column
+    execute("ALTER TABLE enrollments_context_roles DROP COLUMN id")
+  end
+
+  def down do
+    # drop unique index
+    drop unique_index(:enrollments_context_roles, [:enrollment_id, :context_role_id])
+
+    create index(:enrollments_context_roles, [:enrollment_id, :context_role_id])
+  end
+end


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-3390

https://github.com/user-attachments/assets/0522b298-aa39-43f4-989b-4c76d8d8673f

This PR fixes 2 separate issue regarding enrollment counts outlined in the ticket.
1. First, the browse sections query was modified to only count enrollments with status of `enrolled` (excluding `suspended`) which fixes an issue where the count was including "unenrolled" students
2. Second, when adding a duplicate enrollment, most of the operations were taking into account the possibility that a duplicate, or already enrolled, student may have been entered again, and upserting user and enrollment records in that case, However, there was a gap here were duplicate `enrollments_context_roles` records were being created, which was affecting the count being returned by the enrollments count query. The fix here was to remove these duplicate records and create a constraint on the table that ensures no duplicates and also adding the proper conflict handler into the application code so that when a conflict is detected, no record is created.

**NOTE** This PR contains a required migration that removes duplicate `enrollments_context_roles`. This represents a somewhat risky change and should be thoroughly tested after the migration is deployed to ensure that only the intended duplicates are being deleted. This means that all enrollments should still exist as expected and the enrollment counts should reflect the correct amount after the migration is executed/deployed.