### PR TITLE
[FEATURE] [MER-3307] infiniscope: First time user enters Torus through SSO

### DIFF
--- a/lib/oli/accounts/schemas/author.ex
+++ b/lib/oli/accounts/schemas/author.ex
@@ -114,7 +114,7 @@ defmodule Oli.Accounts.Author do
     |> pow_assent_user_identity_changeset(user_identity, attrs, user_id_attrs)
   end
 
-  @spec invite_changeset(%User{} | Ecto.Changeset.t(), integer(), map()) :: Ecto.Changeset.t()
+  @spec invite_changeset(Author.t() | Ecto.Changeset.t(), integer(), map()) :: Ecto.Changeset.t()
   def invite_changeset(user_or_changeset, nil, attrs) do
     user_or_changeset
     |> Ecto.Changeset.cast(attrs, [:name, :email, :invitation_token, :given_name, :family_name])

--- a/lib/oli/accounts/schemas/author.ex
+++ b/lib/oli/accounts/schemas/author.ex
@@ -12,6 +12,9 @@ defmodule Oli.Accounts.Author do
   import Ecto.Changeset
   import Oli.Utils
 
+  import PowInvitation.Ecto.Schema,
+    only: [invitation_token_changeset: 1]
+
   alias Oli.Accounts.SystemRole
 
   schema "authors" do
@@ -109,6 +112,13 @@ defmodule Oli.Accounts.Author do
     user_or_changeset
     |> Ecto.Changeset.cast(attrs, [:name, :given_name, :family_name, :picture])
     |> pow_assent_user_identity_changeset(user_identity, attrs, user_id_attrs)
+  end
+
+  @spec invite_changeset(%User{} | Ecto.Changeset.t(), integer(), map()) :: Ecto.Changeset.t()
+  def invite_changeset(user_or_changeset, nil, attrs) do
+    user_or_changeset
+    |> Ecto.Changeset.cast(attrs, [:name, :email, :invitation_token, :given_name, :family_name])
+    |> invitation_token_changeset()
   end
 
   def invite_changeset(user_or_changeset, invited_by, attrs) do

--- a/lib/oli/email.ex
+++ b/lib/oli/email.ex
@@ -13,6 +13,14 @@ defmodule Oli.Email do
     |> html_text_body()
   end
 
+  def invitation_email(recipient_email, :infiniscope_invitation, assigns) do
+    base_email()
+    |> to(recipient_email)
+    |> subject("Create Course Author Password")
+    |> render(:infiniscope_invitation, assigns)
+    |> html_text_body()
+  end
+
   def invitation_email(recipient_email, view, assigns) do
     base_email()
     |> to(recipient_email)

--- a/lib/oli_web/controllers/cognito_controller.ex
+++ b/lib/oli_web/controllers/cognito_controller.ex
@@ -19,10 +19,11 @@ defmodule OliWeb.CognitoController do
           "community_id" => community_id
         } = params
       ) do
-    case Accounts.setup_sso_user(conn.assigns.claims, community_id) do
-      {:ok, user} ->
+    case Accounts.setup_sso_user(conn.assigns.claims, community_id, link_author: true) do
+      {:ok, user, author} ->
         conn
         |> create_pow_user(:user, user)
+        |> maybe_send_invite_email(author)
         |> redirect(to: ~p"/sections")
 
       {:error, %Ecto.Changeset{}} ->
@@ -43,7 +44,7 @@ defmodule OliWeb.CognitoController do
         } = params
       ) do
     with anchor when not is_nil(anchor) <- fetch_product_or_project(params),
-         {:ok, user} <- Accounts.setup_sso_user(conn.assigns.claims, community_id) do
+         {:ok, user, _} <- Accounts.setup_sso_user(conn.assigns.claims, community_id) do
       conn
       |> create_pow_user(:user, user)
       |> create_or_prompt(user, anchor)
@@ -197,5 +198,27 @@ defmodule OliWeb.CognitoController do
       {:error, error} ->
         redirect_with_error(conn, error_url, snake_case_to_friendly(error))
     end
+  end
+
+  defp maybe_send_invite_email(conn, nil), do: conn
+
+  defp maybe_send_invite_email(conn, author) do
+    brand_name = Application.get_env(:oli, :branding)[:name]
+
+    if not is_nil(author.invitation_token) and is_nil(author.invitation_accepted_at) do
+      token = PowInvitation.Plug.sign_invitation_token(conn, author)
+
+      Oli.Email.invitation_email(
+        author.email,
+        :infiniscope_invitation,
+        %{
+          brand_name: brand_name,
+          url: ~p"/authoring/invitations/#{token}/edit"
+        }
+      )
+      |> Oli.Mailer.deliver_now()
+    end
+
+    conn
   end
 end

--- a/lib/oli_web/templates/email/infiniscope_invitation.html.heex
+++ b/lib/oli_web/templates/email/infiniscope_invitation.html.heex
@@ -1,0 +1,49 @@
+<table
+  align="center"
+  role="presentation"
+  cellspacing="0"
+  cellpadding="0"
+  border="0"
+  width="100%"
+  style="margin: auto;"
+>
+  <tr>
+    <td style="background-color: #ffffff; padding: 20px 10px;">
+      <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+        <tr>
+          <td style="padding: 20px; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555;">
+            <p style="margin: 0;">
+              We received notice that you have been approved as an Infiniscope instructor. To enable you to design courses, we have created a <%= @brand_name %> course author account using this email address. Please create a password for your authoring account by clicking the button below. Once your password is set, you can sign in and start creating courses from anywhere.
+            </p>
+          </td>
+        </tr>
+        <tr>
+          <td style="padding: 0 20px;">
+            <table
+              align="center"
+              role="presentation"
+              cellspacing="0"
+              cellpadding="0"
+              border="0"
+              style="margin: auto;"
+            >
+              <tr>
+                <td
+                  class="button-td button-td-primary"
+                  style="border-radius: 4px; background: #2C67C4;"
+                >
+                  <%= link("Create Password",
+                    to: @url,
+                    class: "button-a button-a-primary",
+                    style:
+                      "background: #2C67C4; border: 1px solid #2C67C4; font-family: sans-serif; font-size: 15px; line-height: 15px; text-decoration: none; padding: 13px 17px; color: #ffffff; display: block; border-radius: 4px;"
+                  ) %>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>

--- a/lib/oli_web/templates/email/infiniscope_invitation.text.eex
+++ b/lib/oli_web/templates/email/infiniscope_invitation.text.eex
@@ -1,0 +1,4 @@
+THIS FILE IS NOT USED
+
+But it is required to be here by Pow.Phoenix.Mailer. Email text is generated from the
+corresponding html template. See OliWeb.Pow.Mailer for details.

--- a/test/oli_web/controllers/cognito_controller_test.exs
+++ b/test/oli_web/controllers/cognito_controller_test.exs
@@ -1,5 +1,6 @@
 defmodule OliWeb.CognitoControllerTest do
   use OliWeb.ConnCase
+  use Bamboo.Test
 
   import Oli.Factory
   import Mox
@@ -52,11 +53,60 @@ defmodule OliWeb.CognitoControllerTest do
                "<html><body>You are being <a href=\"/sections\">redirected</a>.</body></html>"
     end
 
-    test "creates new user and redirects user to my courses", %{
-      conn: conn,
-      community: community
-    } do
+    test "creates new user and author, sends author setup email and redirects user to my courses",
+         %{
+           conn: conn,
+           community: community
+         } do
       email = "new_user@email.com"
+      {id_token, jwk, issuer} = generate_token(email)
+      jwks_url = issuer <> "/.well-known/jwks.json"
+
+      expect(Oli.Test.MockHTTP, :get, 2, mock_jwks_endpoint(jwks_url, jwk, :ok))
+
+      params = valid_index_params(community.id, id_token)
+
+      refute Accounts.get_user_by(email: email)
+
+      assert conn
+             |> get(Routes.cognito_path(conn, :index, params))
+             |> html_response(302) =~
+               "<html><body>You are being <a href=\"/sections\">redirected</a>.</body></html>"
+
+      {:ok, claims} = Joken.peek_claims(id_token)
+      user = Accounts.get_user_by(email: email)
+      author = Accounts.get_author_by_email(email)
+
+      assert user.sub == claims["sub"]
+      assert user.preferred_username == claims["cognito:username"]
+      assert user.name == claims["name"]
+      assert user.can_create_sections == true
+      assert user.author_id == author.id
+
+      assert author.email == email
+      assert author.name == claims["cognito:username"]
+      assert author.invitation_token
+      refute author.invitation_accepted_at
+
+      assert_delivered_email_matches(%{to: [{_, ^email}], subject: subject, text_body: text_body})
+
+      assert subject == "Create Course Author Password"
+
+      assert text_body =~
+               "We received notice that you have been approved as an Infiniscope\ninstructor"
+
+      assert text_body =~ "Create Password"
+      assert text_body =~ ~r{/authoring/invitations/.*/edit}
+    end
+
+    test "creates new user but does not create author nor send email when it already exists",
+         %{
+           conn: conn,
+           community: community
+         } do
+      email = "new_user@email.com"
+      author = insert(:author, email: email)
+
       {id_token, jwk, issuer} = generate_token(email)
       jwks_url = issuer <> "/.well-known/jwks.json"
 
@@ -78,6 +128,9 @@ defmodule OliWeb.CognitoControllerTest do
       assert user.preferred_username == claims["cognito:username"]
       assert user.name == claims["name"]
       assert user.can_create_sections == true
+      assert user.author_id == author.id
+
+      assert_no_emails_delivered()
     end
 
     test "redirects to provided error_url with missing params", %{


### PR DESCRIPTION
[MER-3307](https://eliterate.atlassian.net/browse/MER-3307)

This PR enhances the current functionality for the use case when a user enters Torus from Infiniscope via SSO for the first time. In addition to creating an instructor account, it now also creates and links an authoring account to the instructor. Furthermore, it sends an email to the new author to set up the password.


https://github.com/user-attachments/assets/1d829b3e-c39a-471f-befb-3023d80e5456



[MER-3307]: https://eliterate.atlassian.net/browse/MER-3307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ