### PR TITLE
[FEATURE] [MER-3320] Hide content during course remix

### DIFF
--- a/lib/oli/delivery/hierarchy.ex
+++ b/lib/oli/delivery/hierarchy.ex
@@ -338,7 +338,7 @@ defmodule Oli.Delivery.Hierarchy do
       ),
       join: p in Project,
       on: p.id == spp.project_id,
-      where: rev.resource_type_id in ^[page_id, container_id],
+      where: rev.resource_type_id in ^[page_id, container_id] and not sr.hidden,
       select: %{
         "id" => rev.id,
         "numbering" => %{"index" => sr.numbering_index, "level" => sr.numbering_level},
@@ -366,10 +366,9 @@ defmodule Oli.Delivery.Hierarchy do
   end
 
   defp build_updated_children(children_ids, nodes_by_sr_id) do
-    Enum.map(
-      children_ids,
-      &(Map.get(nodes_by_sr_id, &1) |> hierarchy_node_with_children(nodes_by_sr_id))
-    )
+    children_ids
+    |> Enum.filter(&Map.has_key?(nodes_by_sr_id, &1))
+    |> Enum.map(&(Map.get(nodes_by_sr_id, &1) |> hierarchy_node_with_children(nodes_by_sr_id)))
   end
 
   def reorder_children(

--- a/lib/oli/delivery/hierarchy.ex
+++ b/lib/oli/delivery/hierarchy.ex
@@ -438,6 +438,36 @@ defmodule Oli.Delivery.Hierarchy do
   end
 
   @doc """
+  Toggles the hidden attribute of a node in the hierarchy with the given uuid
+  """
+
+  def find_and_toggle_hidden(hierarchy, uuid) do
+    find_and_toggle_hidden_r(hierarchy, uuid)
+    |> mark_unfinalized()
+  end
+
+  defp find_and_toggle_hidden_r(hierarchy, uuid) do
+    if hierarchy.uuid == uuid do
+      updated_section_resource =
+        case hierarchy.section_resource do
+          nil -> nil
+          sr -> Map.put(sr, :hidden, !sr.hidden)
+        end
+
+      %HierarchyNode{
+        hierarchy
+        | section_resource: updated_section_resource
+      }
+    else
+      %HierarchyNode{
+        hierarchy
+        | children:
+            Enum.map(hierarchy.children, fn child -> find_and_toggle_hidden_r(child, uuid) end)
+      }
+    end
+  end
+
+  @doc """
   Moves a node to a given container given by destination uuid
   """
   def move_node(hierarchy, node, destination_uuid) do

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -1839,6 +1839,7 @@ defmodule Oli.Delivery.Sections do
       |> Enum.filter(fn section_resource ->
         case section_resource do
           %SectionResource{start_date: nil, end_date: nil} -> false
+          %SectionResource{hidden: true} -> false
           _ -> true
         end
       end)
@@ -1924,6 +1925,7 @@ defmodule Oli.Delivery.Sections do
       |> Enum.filter(fn section_resource ->
         case section_resource do
           %SectionResource{start_date: nil, end_date: nil} -> false
+          %SectionResource{hidden: true} -> false
           _ -> true
         end
       end)
@@ -4328,7 +4330,8 @@ defmodule Oli.Delivery.Sections do
         left_join: ra in assoc(r_att, :resource_access),
         where:
           ra.section_id == ^section.id and ra.user_id == ^user_id and rev.graded and
-            rev.resource_type_id == ^page_resource_type_id and last_att.row_number == 1,
+            rev.resource_type_id == ^page_resource_type_id and last_att.row_number == 1 and
+            not sr.hidden,
         group_by: [
           rev.id,
           sr.numbering_index,
@@ -4409,7 +4412,7 @@ defmodule Oli.Delivery.Sections do
         rev.resource_type_id == ^page_resource_type_id and
           coalesce(se.start_date, se.end_date) |> coalesce(sr.start_date) |> coalesce(sr.end_date) >=
             ^today and coalesce(ra.progress, 0) == 0 and
-          is_nil(r_att.id),
+          is_nil(r_att.id) and not sr.hidden,
       order_by: [
         asc:
           coalesce(se.start_date, se.end_date) |> coalesce(sr.start_date) |> coalesce(sr.end_date),

--- a/lib/oli/delivery/sections/section_resource.ex
+++ b/lib/oli/delivery/sections/section_resource.ex
@@ -137,7 +137,8 @@ defmodule Oli.Delivery.Sections.SectionResource do
     :delivery_policy_id,
     :scoring_strategy_id,
     :inserted_at,
-    :updated_at
+    :updated_at,
+    :hidden
   ]
 
   def to_map(%SectionResource{} = section_resource) do

--- a/lib/oli/delivery/sections/section_resource.ex
+++ b/lib/oli/delivery/sections/section_resource.ex
@@ -51,6 +51,7 @@ defmodule Oli.Delivery.Sections.SectionResource do
     field :review_submission, Ecto.Enum, values: [:allow, :disallow], default: :allow
     field :feedback_mode, Ecto.Enum, values: [:allow, :disallow, :scheduled], default: :allow
     field :feedback_scheduled_date, :utc_datetime
+    field :hidden, :boolean, default: false
 
     # an array of ids to other section resources
     field :children, {:array, :id}, default: []
@@ -102,6 +103,7 @@ defmodule Oli.Delivery.Sections.SectionResource do
       :review_submission,
       :feedback_mode,
       :feedback_scheduled_date,
+      :hidden,
       :scoring_strategy_id,
       :resource_id,
       :project_id,

--- a/lib/oli_web/live/delivery/remix/actions.ex
+++ b/lib/oli_web/live/delivery/remix/actions.ex
@@ -4,6 +4,7 @@ defmodule OliWeb.Delivery.Remix.Actions do
   """
 
   use OliWeb, :live_component
+  alias Oli.Resources.ResourceType
 
   def render(assigns) do
     ~H"""
@@ -15,6 +16,17 @@ defmodule OliWeb.Delivery.Remix.Actions do
         phx-value-uuid={@uuid}
       >
         <i class="fas fa-arrow-circle-right"></i> Move
+      </button>
+      <button
+        :if={@resource_type == ResourceType.id_for_page()}
+        type="button"
+        class="btn btn-outline-primary btn-sm ml-2"
+        phx-click="show_hide_resource_modal"
+        phx-value-uuid={@uuid}
+      >
+        <i class={"fa-solid #{if @hidden, do: "fa-eye", else: "fa-eye-slash"}"}></i> <%= if @hidden,
+          do: "Show",
+          else: "Hide" %>
       </button>
       <button
         type="button"

--- a/lib/oli_web/live/delivery/remix/entry.ex
+++ b/lib/oli_web/live/delivery/remix/entry.ex
@@ -65,7 +65,13 @@ defmodule OliWeb.Delivery.Remix.Entry do
       </div>
 
       <div draggable="true" ondragstart="event.preventDefault(); event.stopPropagation();">
-        <.live_component module={Actions} uuid={@node.uuid} id={"remix_actions_#{@node.uuid}"} />
+        <.live_component
+          module={Actions}
+          uuid={@node.uuid}
+          hidden={(@node.section_resource && @node.section_resource.hidden) || false}
+          resource_type={@node.revision.resource_type_id}
+          id={"remix_actions_#{@node.uuid}"}
+        />
       </div>
     </div>
     """

--- a/lib/oli_web/live/delivery/remix/hide_resource_modal.ex
+++ b/lib/oli_web/live/delivery/remix/hide_resource_modal.ex
@@ -2,6 +2,8 @@ defmodule OliWeb.Delivery.Remix.HideResourceModal do
   use Phoenix.LiveComponent
   use Phoenix.HTML
 
+  import OliWeb.Components.Common
+
   alias Oli.Delivery.Hierarchy.HierarchyNode
 
   def render(%{node: %HierarchyNode{}} = assigns) do
@@ -28,22 +30,23 @@ defmodule OliWeb.Delivery.Remix.HideResourceModal do
             Are you sure you want to <%= get_label_action(@node) %> <b><%= @node.revision.title %></b>?
           </div>
           <div class="modal-footer">
-            <button
+            <.button
               type="button"
-              class="btn btn-secondary"
+              variant={:info}
               data-bs-dismiss="modal"
               phx-click="HideResourceModal.cancel"
             >
               Cancel
-            </button>
-            <button
-              phx-click="HideResourceModal.toggle"
-              phx-key="enter"
+            </.button>
+            <.button
+              type="button"
+              variant={:danger}
               phx-value-uuid={@node.uuid}
-              class="btn btn-danger"
+              phx-key="enter"
+              phx-click="HideResourceModal.toggle"
             >
               <%= get_label_action(@node) |> String.capitalize() %>
-            </button>
+            </.button>
           </div>
         </div>
       </div>

--- a/lib/oli_web/live/delivery/remix/hide_resource_modal.ex
+++ b/lib/oli_web/live/delivery/remix/hide_resource_modal.ex
@@ -1,0 +1,55 @@
+defmodule OliWeb.Delivery.Remix.HideResourceModal do
+  use Phoenix.LiveComponent
+  use Phoenix.HTML
+
+  alias Oli.Delivery.Hierarchy.HierarchyNode
+
+  def render(%{node: %HierarchyNode{}} = assigns) do
+    ~H"""
+    <div
+      class="modal fade show"
+      id={"hide_#{@node.uuid}"}
+      tabindex="-1"
+      role="dialog"
+      aria-hidden="true"
+      phx-hook="ModalLaunch"
+    >
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">
+              <%= get_label_action(@node) |> String.capitalize() %>
+              <%= @node.revision.title |> String.capitalize() %>
+            </h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
+            </button>
+          </div>
+          <div class="modal-body">
+            Are you sure you want to <%= get_label_action(@node) %> <b><%= @node.revision.title %></b>?
+          </div>
+          <div class="modal-footer">
+            <button
+              type="button"
+              class="btn btn-secondary"
+              data-bs-dismiss="modal"
+              phx-click="HideResourceModal.cancel"
+            >
+              Cancel
+            </button>
+            <button
+              phx-click="HideResourceModal.toggle"
+              phx-key="enter"
+              phx-value-uuid={@node.uuid}
+              class="btn btn-danger"
+            >
+              <%= get_label_action(@node) |> String.capitalize() %>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  defp get_label_action(node), do: if(node.section_resource.hidden, do: "show", else: "hide")
+end

--- a/lib/oli_web/live/delivery/remix_section.ex
+++ b/lib/oli_web/live/delivery/remix_section.ex
@@ -873,17 +873,18 @@ defmodule OliWeb.Delivery.RemixSection do
   end
 
   def handle_event("HideResourceModal.toggle", %{"uuid" => uuid}, socket) do
-    %{hierarchy: hierarchy, section: section} = socket.assigns
+    %{hierarchy: hierarchy, active: active} = socket.assigns
 
-    section_resource = Hierarchy.find_in_hierarchy(hierarchy, uuid).section_resource
+    hierarchy =
+      Hierarchy.find_and_toggle_hidden(hierarchy, uuid)
+      |> Hierarchy.finalize()
 
-    Sections.update_section_resource(section_resource, %{hidden: !section_resource.hidden})
-
-    hierarchy = DeliveryResolver.full_hierarchy(section.slug)
+    # refresh active node
+    active = Hierarchy.find_in_hierarchy(hierarchy, active.uuid)
 
     {:noreply,
      socket
-     |> assign(hierarchy: hierarchy, active: hierarchy)
+     |> assign(hierarchy: hierarchy, active: active, has_unsaved_changes: true)
      |> hide_modal(modal_assigns: nil)}
   end
 

--- a/priv/repo/migrations/20240716154202_add_hidden_field_to_section_resources.exs
+++ b/priv/repo/migrations/20240716154202_add_hidden_field_to_section_resources.exs
@@ -1,0 +1,9 @@
+defmodule Oli.Repo.Migrations.AddHiddenFieldToSectionResources do
+  use Ecto.Migration
+
+  def change do
+    alter table(:section_resources) do
+      add :hidden, :boolean, default: false
+    end
+  end
+end

--- a/test/oli_web/live/delivery/student/index_live_test.exs
+++ b/test/oli_web/live/delivery/student/index_live_test.exs
@@ -971,6 +971,30 @@ defmodule OliWeb.Delivery.Student.IndexLiveTest do
 
       assert has_element?(view, "div", "17%")
     end
+
+    test "do not show hidden pages in upcoming agenda", %{
+      conn: conn,
+      section: section,
+      page_3: page_3
+    } do
+      stub_current_time(~U[2023-11-03 00:00:00Z])
+
+      {:ok, view, _html} = live(conn, ~p"/sections/#{section.slug}")
+
+      first_assignment = ~s{div[role=assignments] a:nth-child(1) }
+
+      assert has_element?(view, first_assignment <> ~s{div[role=container_label]}, "Unit 1")
+      assert has_element?(view, first_assignment <> ~s{div[role=container_label]}, "Module 2")
+      assert has_element?(view, first_assignment <> ~s{div[role=title]}, page_3.title)
+
+      # Set page 3 as hidden
+      section_resource = Sections.get_section_resource(section.id, page_3.resource_id)
+      Sections.update_section_resource(section_resource, %{hidden: !section_resource.hidden})
+
+      {:ok, view, _html} = live(conn, ~p"/sections/#{section.slug}")
+
+      refute has_element?(view, first_assignment <> ~s{div[role=title]}, page_3.title)
+    end
   end
 
   describe "my assignments" do
@@ -1195,6 +1219,92 @@ defmodule OliWeb.Delivery.Student.IndexLiveTest do
              )
 
       assert has_element?(view, third_assignment <> ~s{div[role=details]}, "Completed")
+    end
+
+    test "do not show hidden pages in latest assignments", %{
+      conn: conn,
+      section: section,
+      user: user,
+      page_3: page_3
+    } do
+      stub_current_time(~U[2024-04-22 21:00:00Z])
+
+      set_progress(section.id, page_3.resource_id, user.id, 0.3, page_3,
+        attempt_state: :evaluated,
+        updated_at: ~U[2023-11-01 22:00:00Z]
+      )
+
+      {:ok, view, _html} = live(conn, ~p"/sections/#{section.slug}")
+
+      view
+      |> element("#latest_tab")
+      |> render_click()
+
+      first_assignment = ~s{div[role=assignments] a:nth-child(1) }
+
+      # First latest assignment
+      assert has_element?(
+               view,
+               first_assignment <> ~s{div[role=resource_type][aria-label=exploration]}
+             )
+
+      assert has_element?(
+               view,
+               first_assignment <> ~s{div[role=details] div[role=count]},
+               "Attempt 1/∞"
+             )
+
+      # Set page 3 as hidden
+      section_resource = Sections.get_section_resource(section.id, page_3.resource_id)
+      Sections.update_section_resource(section_resource, %{hidden: !section_resource.hidden})
+
+      {:ok, view, _html} = live(conn, ~p"/sections/#{section.slug}")
+
+      # First latest assignment
+      refute has_element?(
+               view,
+               first_assignment <> ~s{div[role=resource_type][aria-label=exploration]}
+             )
+
+      refute has_element?(
+               view,
+               first_assignment <> ~s{div[role=details] div[role=count]},
+               "Attempt 1/∞"
+             )
+    end
+
+    test "do not show hidden pages in upcoming assignments", %{
+      conn: conn,
+      section: section,
+      page_3: page_3
+    } do
+      stub_current_time(~U[2023-11-03 00:00:00Z])
+
+      {:ok, view, _html} = live(conn, ~p"/sections/#{section.slug}")
+
+      first_assignment = ~s{div[role=assignments] a:nth-child(1) }
+
+      # First upcoming assignment
+      assert element(
+               view,
+               first_assignment
+             )
+             |> render() =~
+               ~s{href="/sections/#{section.slug}/lesson/#{page_3.slug}?request_path=%2Fsections%2F#{section.slug}"}
+
+      # Set page 3 as hidden
+      section_resource = Sections.get_section_resource(section.id, page_3.resource_id)
+      Sections.update_section_resource(section_resource, %{hidden: !section_resource.hidden})
+
+      {:ok, view, _html} = live(conn, ~p"/sections/#{section.slug}")
+
+      # First upcoming assignment
+      refute element(
+               view,
+               first_assignment
+             )
+             |> render() =~
+               ~s{href="/sections/#{section.slug}/lesson/#{page_3.slug}?request_path=%2Fsections%2F#{section.slug}"}
     end
   end
 end

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -2033,6 +2033,20 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       assert render(view) =~ "Page 14"
       refute render(view) =~ "Page 15"
     end
+
+    test "do not show hidden pages", %{
+      conn: conn,
+      section: section,
+      page_7: page_7
+    } do
+      # Set page 7 as hidden
+      section_resource = Sections.get_section_resource(section.id, page_7.resource_id)
+      Sections.update_section_resource(section_resource, %{hidden: !section_resource.hidden})
+
+      {:ok, view, _html} = live(conn, Utils.learn_live_path(section.slug))
+
+      refute render(view) =~ "Page 7"
+    end
   end
 
   describe "student" do

--- a/test/oli_web/live/remix_section_test.exs
+++ b/test/oli_web/live/remix_section_test.exs
@@ -458,6 +458,14 @@ defmodule OliWeb.RemixSectionLiveTest do
 
       # Assert the button is showing "Show", as the page is hidden
       assert has_element?(view, "button[phx-value-uuid=\"#{node_uuid}\"]", "Show")
+
+      # Save the changes
+      view |> element("#save") |> render_click()
+
+      # Check the page is hidden
+      sr_updated = Sections.get_section_resource(section.id, revision1.resource_id)
+
+      assert sr_updated.hidden == true
     end
 
     test "cancel button in hide/show page modal works correctly", %{
@@ -511,6 +519,72 @@ defmodule OliWeb.RemixSectionLiveTest do
 
       # Assert the button is showing "Hide", as the page is not hidden
       assert has_element?(view, "button[phx-value-uuid=\"#{node_uuid}\"]", "Hide")
+
+      # Check the page is not hidden
+      sr_updated = Sections.get_section_resource(section.id, revision1.resource_id)
+
+      assert sr_updated.hidden == false
+    end
+
+    test "cancel button after hide/show page works correctly", %{
+      conn: conn,
+      map: %{section_1: section, revision1: revision1}
+    } do
+      conn =
+        get(conn, Routes.live_path(OliWeb.Endpoint, OliWeb.Delivery.RemixSection, section.slug))
+
+      {:ok, view, _html} = live(conn)
+
+      # Find the uuid of the first node
+      node_uuid =
+        view
+        |> render()
+        |> Floki.parse_fragment!()
+        |> Floki.find(~s{button[phx-click="show_hide_resource_modal"]})
+        |> Floki.attribute("phx-value-uuid")
+        |> hd()
+
+      # Assert the button is showing "Hide", as the page is not hidden
+      assert has_element?(view, "button[phx-value-uuid=\"#{node_uuid}\"]", "Hide")
+
+      # Click the button to show the modal to hide the page
+      view
+      |> element(
+        "button[phx-click=\"show_hide_resource_modal\"][phx-value-uuid=\"#{node_uuid}\"]"
+      )
+      |> render_click()
+
+      # Assert the modal is showing the correct title
+      assert has_element?(
+               view,
+               ".modal-body",
+               "Are you sure you want to hide #{revision1.title}?"
+             )
+
+      # Click the button to hide the page and confirm the action
+      view
+      |> element("button[phx-click=\"HideResourceModal.toggle\"]", "Hide")
+      |> render_click()
+
+      # Find again the uuid of the first node
+      node_uuid =
+        view
+        |> render()
+        |> Floki.parse_fragment!()
+        |> Floki.find(~s{button[phx-click="show_hide_resource_modal"]})
+        |> Floki.attribute("phx-value-uuid")
+        |> hd()
+
+      # Assert the button is showing "Show", as the page is hidden
+      assert has_element?(view, "button[phx-value-uuid=\"#{node_uuid}\"]", "Show")
+
+      # Cancel the changes
+      view |> element("#cancel") |> render_click()
+
+      # Check the page is not hidden
+      sr_updated = Sections.get_section_resource(section.id, revision1.resource_id)
+
+      assert sr_updated.hidden == false
     end
   end
 

--- a/test/oli_web/live/remix_section_test.exs
+++ b/test/oli_web/live/remix_section_test.exs
@@ -406,6 +406,112 @@ defmodule OliWeb.RemixSectionLiveTest do
         ~p"/sections/#{section.slug}/remix"
       )
     end
+
+    test "show and hide pages works correctly", %{
+      conn: conn,
+      map: %{section_1: section, revision1: revision1}
+    } do
+      conn =
+        get(conn, Routes.live_path(OliWeb.Endpoint, OliWeb.Delivery.RemixSection, section.slug))
+
+      {:ok, view, _html} = live(conn)
+
+      # Find the uuid of the first node
+      node_uuid =
+        view
+        |> render()
+        |> Floki.parse_fragment!()
+        |> Floki.find(~s{button[phx-click="show_hide_resource_modal"]})
+        |> Floki.attribute("phx-value-uuid")
+        |> hd()
+
+      # Assert the button is showing "Hide", as the page is not hidden
+      assert has_element?(view, "button[phx-value-uuid=\"#{node_uuid}\"]", "Hide")
+
+      # Click the button to show the modal to hide the page
+      view
+      |> element(
+        "button[phx-click=\"show_hide_resource_modal\"][phx-value-uuid=\"#{node_uuid}\"]"
+      )
+      |> render_click()
+
+      # Assert the modal is showing the correct title
+      assert has_element?(
+               view,
+               ".modal-body",
+               "Are you sure you want to hide #{revision1.title}?"
+             )
+
+      # Click the button to hide the page and confirm the action
+      view
+      |> element("button[phx-click=\"HideResourceModal.toggle\"]", "Hide")
+      |> render_click()
+
+      # Find again the uuid of the first node
+      node_uuid =
+        view
+        |> render()
+        |> Floki.parse_fragment!()
+        |> Floki.find(~s{button[phx-click="show_hide_resource_modal"]})
+        |> Floki.attribute("phx-value-uuid")
+        |> hd()
+
+      # Assert the button is showing "Show", as the page is hidden
+      assert has_element?(view, "button[phx-value-uuid=\"#{node_uuid}\"]", "Show")
+    end
+
+    test "cancel button in hide/show page modal works correctly", %{
+      conn: conn,
+      map: %{section_1: section, revision1: revision1}
+    } do
+      conn =
+        get(conn, Routes.live_path(OliWeb.Endpoint, OliWeb.Delivery.RemixSection, section.slug))
+
+      {:ok, view, _html} = live(conn)
+
+      # Find the uuid of the first node
+      node_uuid =
+        view
+        |> render()
+        |> Floki.parse_fragment!()
+        |> Floki.find(~s{button[phx-click="show_hide_resource_modal"]})
+        |> Floki.attribute("phx-value-uuid")
+        |> hd()
+
+      # Assert the button is showing "Hide", as the page is not hidden
+      assert has_element?(view, "button[phx-value-uuid=\"#{node_uuid}\"]", "Hide")
+
+      # Click the button to show the modal to hide the page
+      view
+      |> element(
+        "button[phx-click=\"show_hide_resource_modal\"][phx-value-uuid=\"#{node_uuid}\"]"
+      )
+      |> render_click()
+
+      # Assert the modal is showing the correct title
+      assert has_element?(
+               view,
+               ".modal-body",
+               "Are you sure you want to hide #{revision1.title}?"
+             )
+
+      # Click the button to cancel
+      view
+      |> element("button[phx-click=\"HideResourceModal.cancel\"]", "Cancel")
+      |> render_click()
+
+      # Find again the uuid of the first node
+      node_uuid =
+        view
+        |> render()
+        |> Floki.parse_fragment!()
+        |> Floki.find(~s{button[phx-click="show_hide_resource_modal"]})
+        |> Floki.attribute("phx-value-uuid")
+        |> hd()
+
+      # Assert the button is showing "Hide", as the page is not hidden
+      assert has_element?(view, "button[phx-value-uuid=\"#{node_uuid}\"]", "Hide")
+    end
   end
 
   describe "remix section as product manager" do


### PR DESCRIPTION
[MER-3320](https://eliterate.atlassian.net/browse/MER-3320)

This PR allows authors and instructors to show and hide materials from the hierarchy during the course remix.

Materials that are hidden should not be accessible by students within a course. 

_*If you think there is somewhere else where access to hidden materials should be restricted, please let me know._


https://github.com/user-attachments/assets/461928bb-441a-4c7d-a38f-c73b2fd0bd97





[MER-3320]: https://eliterate.atlassian.net/browse/MER-3320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ