### PR TITLE
[ENHANCEMENT] [MER-3300] Open and Free sections: If student, hide sidebar and display student workspace

### DIFF
--- a/test/oli_web/live/delivery/open_and_free_index_test.exs
+++ b/test/oli_web/live/delivery/open_and_free_index_test.exs
@@ -492,6 +492,23 @@ defmodule OliWeb.Delivery.OpenAndFreeIndexTest do
 
       assert_redirect(view, "/sections?active_workspace=student_workspace&sidebar_expanded=false")
     end
+
+    test "if user is only a student, display student workspace with hidden sidebar",
+         %{
+           conn: conn,
+           user: user
+         } do
+      section = insert(:section, %{open_and_free: true, title: "The best course ever!"})
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+
+      {:ok, view, _html} = live(conn, ~p"/sections")
+
+      assert has_element?(view, "h3", "Courses available")
+      assert has_element?(view, "h5", "The best course ever!")
+      assert has_element?(view, ~s{a[href="/sections/#{section.slug}?sidebar_expanded=false"]})
+
+      assert has_element?(view, ~s{nav[id=desktop-workspace-nav-menu][aria-expanded=false]})
+    end
   end
 
   describe "user as instructor" do


### PR DESCRIPTION
When a user is only enrolled in open and free sections as a student, they are taken to the student-enrolled courses page, and the sidebar is hidden.

The sign-in flow remains unchanged for all other users.

See: https://eliterate.atlassian.net/browse/MER-3300


https://github.com/user-attachments/assets/633811dc-4fa2-4c43-84b2-2212dfedb8f4


