### PR TITLE
[BUG FIX] [MER-3506] After completing a lesson the back arrow does not work

### DIFF
--- a/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
+++ b/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
@@ -62,7 +62,11 @@
         <%= react_component("Components.OfflineDetector") %>
       </div>
       <.back_arrow
-        to={assigns[:request_path]}
+        to={
+          if assigns[:request_path] in [""],
+            do: ~p"/sections/#{@section.slug}/learn?target_resource_id=#{@current_page["id"]}",
+            else: assigns[:request_path]
+        }
         show_sidebar={assigns[:show_sidebar]}
         view={assigns[:view]}
       />

--- a/lib/oli_web/live_session_plugs/set_request_path.ex
+++ b/lib/oli_web/live_session_plugs/set_request_path.ex
@@ -11,14 +11,18 @@ defmodule OliWeb.LiveSessionPlugs.SetRequestPath do
 
   def on_mount(:default, params, _session, socket) do
     section_slug = socket.assigns.section.slug
-    selected_view = Map.get(params, "selected_view", "gallery")
+
+    selected_view =
+      if params["selected_view"] in [nil, ""], do: "gallery", else: params["selected_view"]
 
     request_path =
-      Map.get(
-        params,
-        "request_path",
-        Utils.learn_live_path(section_slug, selected_view: selected_view)
-      )
+      case params["request_path"] do
+        request_path when request_path in ["", nil] ->
+          Utils.learn_live_path(section_slug, selected_view: selected_view)
+
+        request_path ->
+          request_path
+      end
 
     {:cont, assign(socket, request_path: request_path, selected_view: selected_view)}
   end


### PR DESCRIPTION
Ticket: [MER-3506](https://eliterate.atlassian.net/browse/MER-3506)

This PR adds a fix for an issue that occurred after completing a lesson where the back arrow didn't work. The problem was that it failed to consider cases when the `request_path` was `""`. After completing an adaptive page, React called an endpoint in our backend that redirects twice to different endpoints, and we never filled out the `request_path`. The back link wasn't prepared for this scenario.

[MER-3506]: https://eliterate.atlassian.net/browse/MER-3506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ