### PR TITLE
[BUG FIX] [MER-3526] restore header visibility in light mode

### DIFF
--- a/lib/oli_web/components/header.ex
+++ b/lib/oli_web/components/header.ex
@@ -97,7 +97,7 @@ defmodule OliWeb.Components.Header do
 
   def delivery_header(assigns) do
     ~H"""
-    <nav class="bg-primary-24 h-[111px] flex items-center pl-4 pr-10">
+    <nav class="bg-primary-24 dark h-[111px] flex items-center pl-4 pr-10">
       <a class="navbar-brand torus-logo my-1 mr-auto" href={~p"/"}>
         <%= brand_logo(Map.merge(assigns, %{class: "d-inline-block align-top mr-2"})) %>
       </a>


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-3526

Restores the header logo visibility in light mode

Before:
<img width="1574" alt="Screenshot 2024-07-23 at 12 57 31 PM" src="https://github.com/user-attachments/assets/cbe8c630-d58c-46e0-ac9e-729d527413a2">


After:
<img width="1338" alt="Screenshot 2024-07-23 at 1 26 53 PM" src="https://github.com/user-attachments/assets/f3a2b438-baa2-4c8c-9774-f6508aa0bd4e">
