### PR TITLE
[BUG FIX] [MER-3119] Favicons table row in Brands looks wrong

### DIFF
--- a/lib/oli_web/templates/brand/show.html.eex
+++ b/lib/oli_web/templates/brand/show.html.eex
@@ -52,38 +52,38 @@
         <td><strong>Favicons:</strong></td>
         <td>
           <div><%= @brand.favicons %></div>
-          <div class="icons my-2">
-            <figure class="figure align-top text-center d-inline-block">
-              <img src="<%= @brand.favicons %>/favicon.ico" class="figure-img img-fluid text-center" alt="favicon.ico">
+          <div class="icons my-2 inline-flex gap-2">
+            <figure class="figure align-top text-center">
+              <img src="<%= @brand.favicons %>/favicon.ico" class="mx-auto" alt="favicon.ico">
               <figcaption class="figure-caption">favicon.ico</figcaption>
             </figure>
 
-            <figure class="figure align-top text-center d-inline-block">
-              <img src="<%= @brand.favicons %>/favicon-32x32.png" class="figure-img img-fluid text-center" alt="favicon-32x32.png">
+            <figure class="figure align-top text-center">
+              <img src="<%= @brand.favicons %>/favicon-32x32.png" class="mx-auto" alt="favicon-32x32.png">
               <figcaption class="figure-caption">favicon-32x32.png</figcaption>
             </figure>
 
 
-            <figure class="figure align-top text-center d-inline-block">
-              <img src="<%= @brand.favicons %>/favicon-16x16.png" class="figure-img img-fluid text-center" alt="favicon-16x16.png">
+            <figure class="figure align-top text-center">
+              <img src="<%= @brand.favicons %>/favicon-16x16.png" class="mx-auto" alt="favicon-16x16.png">
               <figcaption class="figure-caption">favicon-16x16.png</figcaption>
             </figure>
 
 
-            <figure class="figure align-top text-center d-inline-block">
-              <img src="<%= @brand.favicons %>/apple-touch-icon.png" class="figure-img img-fluid text-center" alt="apple-touch-icon.png">
+            <figure class="figure align-top text-center">
+              <img src="<%= @brand.favicons %>/apple-touch-icon.png" class="mx-auto" alt="apple-touch-icon.png">
               <figcaption class="figure-caption">apple-touch-icon.png</figcaption>
             </figure>
 
 
-            <figure class="figure align-top text-center d-inline-block">
-              <img src="<%= @brand.favicons %>/android-chrome-512x512.png" class="figure-img img-fluid text-center" alt="android-chrome-512x512.png">
+            <figure class="figure align-top text-center">
+              <img src="<%= @brand.favicons %>/android-chrome-512x512.png" class="mx-auto" alt="android-chrome-512x512.png">
               <figcaption class="figure-caption">android-chrome-512x512.png</figcaption>
             </figure>
 
 
-            <figure class="figure align-top text-center d-inline-block">
-              <img src="<%= @brand.favicons %>/android-chrome-192x192.png" class="figure-img img-fluid text-center" alt="android-chrome-192x192.png">
+            <figure class="figure align-top text-center">
+              <img src="<%= @brand.favicons %>/android-chrome-192x192.png" class="mx-auto" alt="android-chrome-192x192.png">
               <figcaption class="figure-caption">android-chrome-192x192.png</figcaption>
             </figure>
 


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-3119

Fixes an issue where branding favicons were not being rendered quite right within the table.

Before:
![image-20240322-170528](https://github.com/user-attachments/assets/a2c6c4dd-116a-4c8b-a395-d1782f62d419)

After:
<img width="1902" alt="Screenshot 2024-07-24 at 3 24 29 PM" src="https://github.com/user-attachments/assets/c6ff8def-eed7-4c5c-827e-e80039cfc239">
