### PR TITLE
[BUG FIX] [MER-3297] Instructor sign in fixes

### DIFF
--- a/lib/oli_web/controllers/pow/session_html/new.html.heex
+++ b/lib/oli_web/controllers/pow/session_html/new.html.heex
@@ -201,7 +201,7 @@
                   to: Routes.pow_reset_password_reset_password_path(@conn, :new),
                   tabindex: "1",
                   class:
-                    "text-center text-blue-400 text-base font-bold font-['Open Sans'] leading-snug"
+                    "text-center text-[#4ca6ff] text-base font-bold font-['Open Sans'] leading-snug"
                 ) %>
               </div>
             </div>
@@ -213,7 +213,7 @@
             <div class="flex flex-col justify-center">
               <%= submit("Sign In",
                 class:
-                  "w-80 h-11 bg-blue-600 mx-auto text-white text-xl font-normal leading-7 rounded-md btn btn-md btn-block mb-8 mt-2"
+                  "w-80 h-11 bg-[#0062f2] mx-auto text-white text-xl font-normal leading-7 rounded-md btn btn-md btn-block mb-8 mt-2"
               ) %>
               <div class="w-80 h-px border border-white mx-auto"></div>
             </div>
@@ -229,7 +229,7 @@
             <%= link("Create an Account",
               to: registration_path,
               class:
-                "btn btn-md btn-link btn-block text-blue-400 text-lg font-bold font-['Open Sans'] leading-7 mt-3 pb-8"
+                "btn btn-block text-[#4ca6ff] text-lg font-bold font-['Open Sans'] leading-7 mt-3 pb-8"
             ) %>
           <% end %>
         </div>

--- a/lib/oli_web/controllers/static_page_controller.ex
+++ b/lib/oli_web/controllers/static_page_controller.ex
@@ -4,9 +4,10 @@ defmodule OliWeb.StaticPageController do
   import Oli.Branding
 
   alias Oli.Accounts
+  alias OliWeb.Pow.PowHelpers
 
   def index(conn, _params) do
-    render(conn, "index.html")
+    render(PowHelpers.use_pow_config(conn, :user), "index.html")
   end
 
   def unauthorized(conn, _params) do


### PR DESCRIPTION
[MER-3297](https://eliterate.atlassian.net/browse/MER-3297)

This PR fixes some bugs found during the QA process.

- Colors of some texts have been fixed.

- User config is used to show login providers for students correctly (Github and Google).

In the different environments where this code is deployed, the following environment variables must be set correctly:

`USER_GITHUB_CLIENT_ID`
`USER_GITHUB_CLIENT_SECRET`

_**I think that in Tokamak they are not set correctly so the login link to Github for students and instructors is not being displayed.**_

![instructor_sign_in](https://github.com/user-attachments/assets/de26e2f6-213f-43a0-9603-67008b81af06)


[MER-3305]: https://eliterate.atlassian.net/browse/MER-3305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MER-3297]: https://eliterate.atlassian.net/browse/MER-3297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ