### PR TITLE
[FEATURE] [MER-3550] Hide agenda home screen

### DIFF
--- a/lib/oli/delivery/sections/section.ex
+++ b/lib/oli/delivery/sections/section.ex
@@ -159,6 +159,8 @@ defmodule Oli.Delivery.Sections.Section do
 
     field(:encouraging_subtitle, :string)
 
+    field(:agenda, :boolean, default: false)
+
     timestamps(type: :utc_datetime)
   end
 
@@ -219,7 +221,8 @@ defmodule Oli.Delivery.Sections.Section do
       :apply_major_updates,
       :assistant_enabled,
       :welcome_title,
-      :encouraging_subtitle
+      :encouraging_subtitle,
+      :agenda
     ])
     |> cast_embed(:customizations, required: false)
     |> validate_required(@required_fields)

--- a/lib/oli_web/live/delivery/student/index_live.ex
+++ b/lib/oli_web/live/delivery/student/index_live.ex
@@ -17,7 +17,9 @@ defmodule OliWeb.Delivery.Student.IndexLive do
     current_user_id = socket.assigns[:current_user].id
 
     schedule_for_current_week_and_next_week =
-      Sections.get_schedule_for_current_and_next_week(section, current_user_id)
+      if section.agenda,
+        do: Sections.get_schedule_for_current_and_next_week(section, current_user_id),
+        else: nil
 
     nearest_upcoming_lesson =
       section
@@ -138,7 +140,10 @@ defmodule OliWeb.Delivery.Student.IndexLive do
           />
         </div>
 
-        <div class="w-3/4 h-full flex-col justify-start items-start gap-6 inline-flex">
+        <div
+          :if={not is_nil(@schedule_for_current_week_and_next_week)}
+          class="w-3/4 h-full flex-col justify-start items-start gap-6 inline-flex"
+        >
           <.agenda
             section_slug={@section_slug}
             schedule_for_current_week_and_next_week={@schedule_for_current_week_and_next_week}

--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -292,6 +292,20 @@ defmodule OliWeb.Sections.OverviewView do
         }
       ) %>
 
+      <Group.render label="Agenda" description="Include Schedule on Home Screen">
+        <section>
+          <div class="inline-flex py-2 mb-2">
+            <span>Enable Agenda</span>
+            <.toggle_switch
+              class="ml-4"
+              checked={@section.agenda}
+              on_toggle="toggle_agenda"
+              name="toggle_agenda"
+            />
+          </div>
+        </section>
+      </Group.render>
+
       <Group.render
         label="Grading"
         description="View and manage student grades and progress"
@@ -601,6 +615,14 @@ defmodule OliWeb.Sections.OverviewView do
     socket =
       socket
       |> put_flash(:info, "Assistant settings updated successfully")
+
+    {:noreply, assign(socket, section: section)}
+  end
+
+  def handle_event("toggle_agenda", _params, socket) do
+    section = socket.assigns.section
+
+    {:ok, section} = Sections.update_section(section, %{agenda: !section.agenda})
 
     {:noreply, assign(socket, section: section)}
   end

--- a/priv/repo/migrations/20240731170918_add_agenda_flag_to_section.exs
+++ b/priv/repo/migrations/20240731170918_add_agenda_flag_to_section.exs
@@ -1,0 +1,9 @@
+defmodule Oli.Repo.Migrations.AddAgendaFlagToSection do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sections) do
+      add(:agenda, :boolean, default: false)
+    end
+  end
+end

--- a/test/oli_web/live/delivery/instructor_dashboard/manage/manage_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/manage/manage_tab_test.exs
@@ -68,5 +68,35 @@ defmodule OliWeb.Delivery.InstructorDashboard.ManageTabTest do
       # Collab Space Group gets rendered
       assert render(view) =~ "Collaborative Space"
     end
+
+    test "can enable and disable agenda", %{
+      instructor: instructor,
+      section: section,
+      conn: conn
+    } do
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+
+      {:ok, view, _html} =
+        live_isolated(
+          conn,
+          OliWeb.Sections.OverviewView,
+          session: %{
+            "section_slug" => section.slug,
+            "current_user_id" => instructor.id
+          }
+        )
+
+      refute has_element?(view, "input[name=\"toggle_agenda\"][checked]")
+
+      element(view, "form[phx-change=\"toggle_agenda\"]")
+      |> render_change(%{})
+
+      assert has_element?(view, "input[name=\"toggle_agenda\"][checked]")
+
+      element(view, "form[phx-change=\"toggle_agenda\"]")
+      |> render_change(%{})
+
+      refute has_element?(view, "input[name=\"toggle_agenda\"][checked]")
+    end
   end
 end

--- a/test/oli_web/live/delivery/student/index_live_test.exs
+++ b/test/oli_web/live/delivery/student/index_live_test.exs
@@ -670,6 +670,10 @@ defmodule OliWeb.Delivery.Student.IndexLiveTest do
     test "can access when enrolled to course", %{conn: conn, section: section} do
       stub_current_time(~U[2023-11-04 20:00:00Z])
 
+      Sections.update_section(section, %{
+        agenda: true
+      })
+
       {:ok, view, _html} = live(conn, ~p"/sections/#{section.slug}")
 
       assert has_element?(view, "span", "The best course ever!")
@@ -701,7 +705,8 @@ defmodule OliWeb.Delivery.Student.IndexLiveTest do
 
       Sections.update_section(section, %{
         welcome_title: welcome_title,
-        encouraging_subtitle: encouraging_subtitle
+        encouraging_subtitle: encouraging_subtitle,
+        agenda: true
       })
 
       {:ok, view, _html} = live(conn, ~p"/sections/#{section.slug}")
@@ -970,6 +975,42 @@ defmodule OliWeb.Delivery.Student.IndexLiveTest do
       assert has_element?(view, "div", "Course Progress")
 
       assert has_element?(view, "div", "17%")
+    end
+
+    test "can see upcoming agenda if this option is enabled", %{
+      conn: conn,
+      section: section,
+      page_1: page_1,
+      page_2: page_2,
+      page_3: page_3,
+      page_4: page_4
+    } do
+      Sections.update_section(section, %{
+        agenda: true
+      })
+
+      stub_current_time(~U[2023-11-03 21:00:00Z])
+      {:ok, view, _html} = live(conn, ~p"/sections/#{section.slug}")
+
+      assert has_element?(view, "div", "Upcoming Agenda")
+      assert has_element?(view, "div", "This Week")
+      assert has_element?(view, "div", page_1.title)
+      assert has_element?(view, "div", page_2.title)
+      assert has_element?(view, "div", page_3.title)
+      assert has_element?(view, "div", page_4.title)
+    end
+
+    test "can not see upcoming agenda if this option is disabled", %{
+      conn: conn,
+      section: section,
+      page_1: page_1
+    } do
+      stub_current_time(~U[2023-11-03 21:00:00Z])
+      {:ok, view, _html} = live(conn, ~p"/sections/#{section.slug}")
+
+      refute has_element?(view, "div", "Upcoming Agenda")
+      refute has_element?(view, "div", "This Week")
+      refute has_element?(view, "div", page_1.title)
     end
   end
 


### PR DESCRIPTION
[MER-3550](https://eliterate.atlassian.net/browse/MER-3550)

This PR adds an `agenda` field to the sections table in order to enable or disable the display of a section agenda to students. 

On the other hand, it adds logic to render the agenda in the student home screen of a course section, depending on the value of this new field.

_Feel free to suggest changes or improvements to the code or functionality._


https://github.com/user-attachments/assets/b55a161a-5afc-485e-93bf-38e2e7d7dc6f







[MER-3550]: https://eliterate.atlassian.net/browse/MER-3550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ