### PR TITLE
[BUG FIX] [MER-3294] Enrollment link redirects to new Student Sign-In page

### DIFF
--- a/lib/oli_web/live/sections/enrollments/invalid_section_invite_view.ex
+++ b/lib/oli_web/live/sections/enrollments/invalid_section_invite_view.ex
@@ -8,7 +8,7 @@ defmodule OliWeb.Sections.InvalidSectionInviteView do
   def render(assigns) do
     ~H"""
     <div class="p-10">
-      This enrollment link has expired or is invalid. If you already have a student account, please <a href="/session/new">sign in</a>.
+      This enrollment link has expired or is invalid. If you already have a student account, please <a href="/">sign in</a>.
     </div>
     """
   end

--- a/lib/oli_web/templates/delivery/enroll.html.heex
+++ b/lib/oli_web/templates/delivery/enroll.html.heex
@@ -45,7 +45,7 @@
           <a
             :if={!assigns[:auto_enroll_as_guest]}
             href={
-              ~p"/session/new?#{[section: @section.slug, from_invitation_link?: assigns[:from_invitation_link?]]}"
+              ~p"/?#{[section: @section.slug, from_invitation_link?: assigns[:from_invitation_link?]]}"
             }
             class="btn btn-md btn-outline-primary btn-block mt-2"
           >

--- a/test/oli_web/controllers/delivery_controller_test.exs
+++ b/test/oli_web/controllers/delivery_controller_test.exs
@@ -631,7 +631,7 @@ defmodule OliWeb.DeliveryControllerTest do
       assert html_response(conn, 200) =~ "Enroll in Course Section"
 
       assert html_response(conn, 200) =~
-               ~s(<a href="/session/new?section=#{section.slug}&amp;from_invitation_link%3F=true" )
+               ~s(<a href="/?section=#{section.slug}&amp;from_invitation_link%3F=true" )
     end
 
     test "shows enroll view and Sign Up link", %{conn: conn} do

--- a/test/oli_web/live/sections/enrollments/invalid_section_invite_view_test.exs
+++ b/test/oli_web/live/sections/enrollments/invalid_section_invite_view_test.exs
@@ -18,9 +18,9 @@ defmodule OliWeb.Sections.InvalidSectionInviteViewTest do
       {:ok, view, _html} = live(conn, redirect_to)
 
       assert render(view) =~
-               "This enrollment link has expired or is invalid. If you already have a student account, please <a href=\"/session/new\">sign in</a>.\n</div></div>"
+               "This enrollment link has expired or is invalid. If you already have a student account, please <a href=\"/\">sign in</a>.\n</div></div>"
 
-      assert element(view, "a[href=\"/session/new\"]") |> render() =~ "sign in"
+      assert element(view, "a[href=\"/\"]") |> render() =~ "sign in"
     end
 
     test "redirects to the Student Sign In page if the invitation link is valid", %{conn: conn} do
@@ -51,7 +51,7 @@ defmodule OliWeb.Sections.InvalidSectionInviteViewTest do
       {:ok, view, _html} = live(conn, redirect_to)
 
       assert render(view) =~
-               "This enrollment link has expired or is invalid. If you already have a student account, please <a href=\"/session/new\">sign in</a>.\n</div></div>"
+               "This enrollment link has expired or is invalid. If you already have a student account, please <a href=\"/\">sign in</a>.\n</div></div>"
     end
 
     test "shows enroll view", %{conn: conn} do


### PR DESCRIPTION
Fixed the Sign-In link when following an enrollment link to ensure students are directed to the Student sign-in page instead of the Instructor sign-in page.


https://github.com/user-attachments/assets/95809ec0-12cd-47d5-8148-32f513979ccf




See: https://eliterate.atlassian.net/browse/MER-3294?focusedCommentId=23742