### PR TITLE
[ENHANCEMENT] [MER-3300] Don't show sidebar after login if user is only enrolled as student

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
           cp oli.example.env oli.env
 
       - name: 🗄 Start test database
-        run: docker-compose up -d postgres
+        run: docker compose up -d postgres
 
       - name: 💾 Restore the deps cache
         id: mix-deps-cache

--- a/lib/oli_web/components/layouts/workspace.html.heex
+++ b/lib/oli_web/components/layouts/workspace.html.heex
@@ -1,5 +1,8 @@
 <main role="main" class="relative flex flex-col">
-  <div class="fixed z-50 w-full py-2.5 h-14 flex flex-row bg-delivery-header dark:bg-black border-b border-[#0F0D0F]/5 dark:border-[#0F0D0F]">
+  <div
+    :if={!@disable_sidebar?}
+    class="fixed z-50 w-full py-2.5 h-14 flex flex-row bg-delivery-header dark:bg-black border-b border-[#0F0D0F]/5 dark:border-[#0F0D0F]"
+  >
     <div class="max-w-[400px] my-auto ml-auto mr-3">
       <Components.Delivery.UserAccount.menu
         id="user-account-menu"
@@ -8,69 +11,48 @@
       />
     </div>
   </div>
-  <%= if assigns[:disable_sidebar?] do %>
-    <div class="w-full">
-      <Components.Delivery.Layouts.header
-        ctx={@ctx}
-        include_logo
-        is_system_admin={assigns[:is_system_admin] || false}
-        preview_mode={@preview_mode}
-        sidebar_expanded={@sidebar_expanded}
-      />
-      <div
-        id="content"
-        class={[
-          "transition-all duration-100 mt-14 min-h-screen dark:bg-[#0F0D0F] bg-[#F3F4F8]",
-          "md:w-[calc(100%-0px)] md:ml-[0px]"
-        ]}
-      >
-        <%= @inner_content %>
-      </div>
-      <div
-        id="footer_contaner"
-        class={[
-          "relative transition-all duration-100 mt-14",
-          "md:w-[calc(100%-0px)] md:ml-[0px]"
-        ]}
-      >
-        <OliWeb.Components.Footer.delivery_footer license={
-          Map.get(assigns, :has_license) && assigns[:license]
-        } />
-      </div>
-    </div>
-  <% else %>
-    <Components.Delivery.Layouts.workspace_sidebar_nav
-      ctx={@ctx}
-      is_system_admin={assigns[:is_system_admin] || false}
-      active_workspace={assigns[:active_workspace] || :student}
-      preview_mode={@preview_mode}
-      sidebar_expanded={@sidebar_expanded}
-    />
-    <div
-      id="content"
-      class={[
-        "transition-all duration-100 mt-14 min-h-screen dark:bg-[#0F0D0F] bg-[#F3F4F8]",
-        if(@sidebar_expanded,
-          do: "md:w-[calc(100%-200px)] md:ml-[200px]",
-          else: "md:w-[calc(100%-60px)] md:ml-[60px]"
-        )
-      ]}
-    >
-      <%= @inner_content %>
-    </div>
-    <div
-      id="footer_contaner"
-      class={[
-        "relative transition-all duration-100 mt-14",
-        if(@sidebar_expanded,
-          do: "md:w-[calc(100%-200px)] md:ml-[200px]",
-          else: "md:w-[calc(100%-60px)] md:ml-[60px]"
-        )
-      ]}
-    >
-      <OliWeb.Components.Footer.delivery_footer license={
-        Map.get(assigns, :has_license) && assigns[:license]
-      } />
-    </div>
-  <% end %>
+  <Components.Delivery.Layouts.workspace_sidebar_nav
+    :if={!@disable_sidebar?}
+    ctx={@ctx}
+    is_system_admin={assigns[:is_system_admin] || false}
+    active_workspace={assigns[:active_workspace] || :student}
+    preview_mode={@preview_mode}
+    sidebar_expanded={@sidebar_expanded}
+  />
+  <Components.Delivery.Layouts.header
+    :if={@disable_sidebar?}
+    ctx={@ctx}
+    include_logo
+    is_system_admin={assigns[:is_system_admin] || false}
+    preview_mode={@preview_mode}
+    sidebar_expanded={@sidebar_expanded}
+  />
+  <div
+    id="content"
+    class={[
+      "transition-all duration-100 mt-14 min-h-screen dark:bg-[#0F0D0F] bg-[#F3F4F8]",
+      if(@sidebar_expanded,
+        do: "md:w-[calc(100%-200px)] md:ml-[200px]",
+        else: "md:w-[calc(100%-60px)] md:ml-[60px]"
+      ),
+      if(@disable_sidebar?, do: "md:!w-full md:!ml-0")
+    ]}
+  >
+    <%= @inner_content %>
+  </div>
+  <div
+    id="footer_contaner"
+    class={[
+      "relative transition-all duration-100 mt-14",
+      if(@sidebar_expanded,
+        do: "md:w-[calc(100%-200px)] md:ml-[200px]",
+        else: "md:w-[calc(100%-60px)] md:ml-[60px]"
+      ),
+      if(@disable_sidebar?, do: "md:!w-full md:!ml-0")
+    ]}
+  >
+    <OliWeb.Components.Footer.delivery_footer license={
+      Map.get(assigns, :has_license) && assigns[:license]
+    } />
+  </div>
 </main>

--- a/lib/oli_web/components/layouts/workspace.html.heex
+++ b/lib/oli_web/components/layouts/workspace.html.heex
@@ -8,37 +8,69 @@
       />
     </div>
   </div>
-  <Components.Delivery.Layouts.workspace_sidebar_nav
-    ctx={@ctx}
-    is_system_admin={assigns[:is_system_admin] || false}
-    active_workspace={assigns[:active_workspace] || :student}
-    preview_mode={@preview_mode}
-    sidebar_expanded={@sidebar_expanded}
-  />
-  <div
-    id="content"
-    class={[
-      "transition-all duration-100 mt-14 min-h-screen dark:bg-[#0F0D0F] bg-[#F3F4F8]",
-      if(@sidebar_expanded,
-        do: "md:w-[calc(100%-200px)] md:ml-[200px]",
-        else: "md:w-[calc(100%-60px)] md:ml-[60px]"
-      )
-    ]}
-  >
-    <%= @inner_content %>
-  </div>
-  <div
-    id="footer_contaner"
-    class={[
-      "relative transition-all duration-100 mt-14",
-      if(@sidebar_expanded,
-        do: "md:w-[calc(100%-200px)] md:ml-[200px]",
-        else: "md:w-[calc(100%-60px)] md:ml-[60px]"
-      )
-    ]}
-  >
-    <OliWeb.Components.Footer.delivery_footer license={
-      Map.get(assigns, :has_license) && assigns[:license]
-    } />
-  </div>
+  <%= if assigns[:disable_sidebar?] do %>
+    <div class="w-full">
+      <Components.Delivery.Layouts.header
+        ctx={@ctx}
+        include_logo
+        is_system_admin={assigns[:is_system_admin] || false}
+        preview_mode={@preview_mode}
+        sidebar_expanded={@sidebar_expanded}
+      />
+      <div
+        id="content"
+        class={[
+          "transition-all duration-100 mt-14 min-h-screen dark:bg-[#0F0D0F] bg-[#F3F4F8]",
+          "md:w-[calc(100%-0px)] md:ml-[0px]"
+        ]}
+      >
+        <%= @inner_content %>
+      </div>
+      <div
+        id="footer_contaner"
+        class={[
+          "relative transition-all duration-100 mt-14",
+          "md:w-[calc(100%-0px)] md:ml-[0px]"
+        ]}
+      >
+        <OliWeb.Components.Footer.delivery_footer license={
+          Map.get(assigns, :has_license) && assigns[:license]
+        } />
+      </div>
+    </div>
+  <% else %>
+    <Components.Delivery.Layouts.workspace_sidebar_nav
+      ctx={@ctx}
+      is_system_admin={assigns[:is_system_admin] || false}
+      active_workspace={assigns[:active_workspace] || :student}
+      preview_mode={@preview_mode}
+      sidebar_expanded={@sidebar_expanded}
+    />
+    <div
+      id="content"
+      class={[
+        "transition-all duration-100 mt-14 min-h-screen dark:bg-[#0F0D0F] bg-[#F3F4F8]",
+        if(@sidebar_expanded,
+          do: "md:w-[calc(100%-200px)] md:ml-[200px]",
+          else: "md:w-[calc(100%-60px)] md:ml-[60px]"
+        )
+      ]}
+    >
+      <%= @inner_content %>
+    </div>
+    <div
+      id="footer_contaner"
+      class={[
+        "relative transition-all duration-100 mt-14",
+        if(@sidebar_expanded,
+          do: "md:w-[calc(100%-200px)] md:ml-[200px]",
+          else: "md:w-[calc(100%-60px)] md:ml-[60px]"
+        )
+      ]}
+    >
+      <OliWeb.Components.Footer.delivery_footer license={
+        Map.get(assigns, :has_license) && assigns[:license]
+      } />
+    </div>
+  <% end %>
 </main>

--- a/lib/oli_web/live/workspace/student.ex
+++ b/lib/oli_web/live/workspace/student.ex
@@ -269,13 +269,5 @@ defmodule OliWeb.Workspace.Student do
     }
   end
 
-  defp user_is_only_a_student?(sections) do
-    sections
-    |> Enum.map(& &1.user_role)
-    |> Enum.uniq()
-    |> case do
-      ["student"] -> true
-      _ -> false
-    end
-  end
+  defp user_is_only_a_student?(sections), do: Enum.all?(sections, &(&1.user_role == "student"))
 end

--- a/lib/oli_web/live/workspace/student.ex
+++ b/lib/oli_web/live/workspace/student.ex
@@ -17,9 +17,12 @@ defmodule OliWeb.Workspace.Student do
 
   @impl Phoenix.LiveView
   def mount(params, _session, socket) do
-    sections =
+    all_sections =
       Sections.list_user_open_and_free_sections(socket.assigns.current_user)
       |> add_user_role(socket.assigns.current_user)
+
+    sections =
+      all_sections
       |> filter_by_role(:student)
       |> add_instructors()
       |> add_sections_progress(socket.assigns.current_user.id)
@@ -28,6 +31,7 @@ defmodule OliWeb.Workspace.Student do
      assign(socket,
        sections: sections,
        params: params,
+       disable_sidebar?: user_is_only_a_student?(all_sections),
        filtered_sections: sections,
        active_workspace: :student
      )}
@@ -36,7 +40,7 @@ defmodule OliWeb.Workspace.Student do
   @impl Phoenix.LiveView
   def handle_params(params, _uri, socket) do
     %{sections: sections} = socket.assigns
-    params = decode_params(params, sections)
+    params = decode_params(params)
 
     {:noreply,
      assign(socket,
@@ -257,9 +261,7 @@ defmodule OliWeb.Workspace.Student do
   defp get_course_url(%{slug: slug}, sidebar_expanded),
     do: ~p"/sections/#{slug}/instructor_dashboard/manage?#{%{sidebar_expanded: sidebar_expanded}}"
 
-  defp decode_params(params, sections) do
-    params = user_role_dependent_params(params, sections)
-
+  defp decode_params(params) do
     %{
       text_search: Params.get_param(params, "text_search", @default_params.text_search),
       sidebar_expanded:
@@ -267,17 +269,13 @@ defmodule OliWeb.Workspace.Student do
     }
   end
 
-  defp user_role_dependent_params(params, sections) do
+  defp user_is_only_a_student?(sections) do
     sections
     |> Enum.map(& &1.user_role)
+    |> Enum.uniq()
     |> case do
-      ["student"] ->
-        params
-        |> Map.put_new("active_workspace", "student_workspace")
-        |> Map.put_new("sidebar_expanded", "false")
-
-      _ ->
-        params
+      ["student"] -> true
+      _ -> false
     end
   end
 end

--- a/lib/oli_web/live_session_plugs/set_sidebar.ex
+++ b/lib/oli_web/live_session_plugs/set_sidebar.ex
@@ -16,6 +16,7 @@ defmodule OliWeb.LiveSessionPlugs.SetSidebar do
       socket
       |> assign_notes_and_discussions_enabled(session["section_slug"])
       |> assign(sidebar_expanded: session["sidebar_expanded"])
+      |> assign(disable_sidebar?: false)
 
     if connected?(socket) do
       socket =

--- a/test/oli_web/live/workspace/instructor_test.exs
+++ b/test/oli_web/live/workspace/instructor_test.exs
@@ -195,8 +195,15 @@ defmodule OliWeb.Workspace.InstructorTest do
     end
 
     test "can navigate between the different workspaces through the left navbar", %{
-      conn: conn
+      conn: conn,
+      user: user
     } do
+      section_1 = insert(:section, %{open_and_free: true, title: "The best course ever!"})
+      section_2 = insert(:section, %{open_and_free: true, title: "Maths"})
+
+      Sections.enroll(user.id, section_1.id, [ContextRoles.get_role(:context_learner)])
+      Sections.enroll(user.id, section_2.id, [ContextRoles.get_role(:context_instructor)])
+
       {:ok, view, _html} = live(conn, ~p"/sections/workspace/student")
 
       assert has_element?(

--- a/test/oli_web/live/workspace/student_test.exs
+++ b/test/oli_web/live/workspace/student_test.exs
@@ -202,5 +202,35 @@ defmodule OliWeb.Workspace.StudentTest do
       assert has_element?(view, "h5", "The best course ever!")
       refute has_element?(view, "h5", "Maths")
     end
+
+    test "shows sidebar if user is not only enrolled as student", %{conn: conn, user: user} do
+      section_1 = insert(:section, %{open_and_free: true, title: "The best course ever!"})
+      section_2 = insert(:section, %{open_and_free: true, title: "Maths"})
+
+      Sections.enroll(user.id, section_1.id, [ContextRoles.get_role(:context_learner)])
+      Sections.enroll(user.id, section_2.id, [ContextRoles.get_role(:context_instructor)])
+
+      {:ok, view, _html} = live(conn, ~p"/sections/workspace/student")
+
+      assert render(view) =~ "desktop-workspace-nav-menu"
+
+      assert has_element?(view, "h5", "The best course ever!")
+      refute has_element?(view, "h5", "Maths")
+    end
+
+    test "does not show sidebar if user is only enrolled as student", %{conn: conn, user: user} do
+      section_1 = insert(:section, %{open_and_free: true, title: "The best course ever!"})
+      section_2 = insert(:section, %{open_and_free: true, title: "Maths"})
+
+      Sections.enroll(user.id, section_1.id, [ContextRoles.get_role(:context_learner)])
+      Sections.enroll(user.id, section_2.id, [ContextRoles.get_role(:context_learner)])
+
+      {:ok, view, _html} = live(conn, ~p"/sections/workspace/student")
+
+      refute render(view) =~ "desktop-workspace-nav-menu"
+
+      assert has_element?(view, "h5", "The best course ever!")
+      assert has_element?(view, "h5", "Maths")
+    end
   end
 end


### PR DESCRIPTION
Do not show sidebar for users that are only enrolled as students


---- 
https://github.com/user-attachments/assets/8a018ef2-d9e1-40bb-b66f-cecf24bc7c65


_In the video above we first log-in with a user that is a student and instructor and can see the sidebar. Then we log in with a user that is only enrolled as a student and the sidebar is not displayed._


---

See: https://eliterate.atlassian.net/browse/MER-3300