### PR TITLE
[BUG FIX] [MER-3131] Change onChange to onBlur to avoid unnecessary parsing that breaks the date-time picker

### DIFF
--- a/assets/src/apps/scheduler/SchedulerSaveBar.tsx
+++ b/assets/src/apps/scheduler/SchedulerSaveBar.tsx
@@ -66,8 +66,8 @@ const PageDetailEditor: React.FC<PageDetailEditorProps> = ({
               <input
                 className="form-control text-sm"
                 type="datetime-local"
-                onChange={onChangeAvailableFromHandler}
-                value={dateWithTimeLabel(selectedItem.startDateTime) || ''}
+                onBlur={onChangeAvailableFromHandler}
+                defaultValue={dateWithTimeLabel(selectedItem.startDateTime) || ''}
               />
             </InputField>
           </InputRow>
@@ -89,8 +89,8 @@ const PageDetailEditor: React.FC<PageDetailEditorProps> = ({
               <input
                 className="form-control text-sm"
                 type="date"
-                onChange={onChangeEndHandler}
-                value={dateWithoutTimeLabel(selectedItem.endDate) || ''}
+                onBlur={onChangeEndHandler}
+                defaultValue={dateWithoutTimeLabel(selectedItem.endDate) || ''}
               />
             )}
 
@@ -98,8 +98,8 @@ const PageDetailEditor: React.FC<PageDetailEditorProps> = ({
               <input
                 className="form-control text-sm"
                 type="datetime-local"
-                onChange={onChangeDueEndHandler}
-                value={dateWithTimeLabel(selectedItem.endDateTime) || ''}
+                onBlur={onChangeDueEndHandler}
+                defaultValue={dateWithTimeLabel(selectedItem.endDateTime) || ''}
               />
             )}
           </InputField>


### PR DESCRIPTION
Ticket: [MER-3131](https://eliterate.atlassian.net/browse/MER-3131)

This PR fixes a bug that occurred when trying to change the date in the Scheduling page. The issue was caused by our date picker being triggered with every change to the date input, which attempted to parse the date prematurely. To avoid this behavior, we changed the onChange event to the onBlur event. This allows the user to complete entering the date before it is parsed.

[MER-3131]: https://eliterate.atlassian.net/browse/MER-3131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ