### PR TITLE
[BUG FIX] [MER-3565] 500 error when launching assessments from a page link

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
           cp oli.example.env oli.env
 
       - name: 🗄 Start test database
-        run: docker-compose up -d postgres
+        run: docker compose up -d postgres
 
       - name: 💾 Restore the deps cache
         id: mix-deps-cache

--- a/assets/src/components/activities/DeliveryElement.ts
+++ b/assets/src/components/activities/DeliveryElement.ts
@@ -64,6 +64,7 @@ export interface ActivityContext {
   renderPointMarkers: boolean;
   isAnnotationLevel: boolean;
   variables: any;
+  pageLinkParams: any;
 }
 
 /**

--- a/assets/src/components/activities/DeliveryElementProvider.tsx
+++ b/assets/src/components/activities/DeliveryElementProvider.tsx
@@ -37,6 +37,7 @@ export const DeliveryElementProvider: React.FC<DeliveryElementProps<any>> = (pro
     resourceAttemptGuid: props.context.pageAttemptGuid,
     renderPointMarkers: props.context.renderPointMarkers,
     isAnnotationLevel: props.context.isAnnotationLevel,
+    pageLinkParams: props.context.pageLinkParams,
   });
 
   return (

--- a/assets/src/components/activities/directed-discussion/discussion/MockDiscussionDeliveryProvider.tsx
+++ b/assets/src/components/activities/directed-discussion/discussion/MockDiscussionDeliveryProvider.tsx
@@ -46,6 +46,7 @@ export const MockDiscussionDeliveryProvider: React.FC<{
         renderPointMarkers: false,
         isAnnotationLevel: false,
         variables: {},
+        pageLinkParams: {},
       }}
       onSaveActivity={nullHandler}
       onSavePart={nullHandler}

--- a/assets/src/data/content/writers/context.ts
+++ b/assets/src/data/content/writers/context.ts
@@ -28,6 +28,7 @@ export interface WriterContext {
   };
   renderPointMarkers?: boolean;
   isAnnotationLevel?: boolean;
+  pageLinkParams?: any;
 }
 
 export const defaultWriterContext = (params: Partial<WriterContext> = {}): WriterContext =>

--- a/assets/src/data/content/writers/html.tsx
+++ b/assets/src/data/content/writers/html.tsx
@@ -530,7 +530,10 @@ export class HtmlParser implements WriterImpl {
       let internalHref = href;
       if (context.sectionSlug) {
         const revisionSlug = href.replace(/^\/course\/link\//, '');
-        internalHref = `/sections/${context.sectionSlug}/page/${revisionSlug}`;
+        const params = new URLSearchParams(context.pageLinkParams);
+        const queryString = params.toString();
+
+        internalHref = `/sections/${context.sectionSlug}/lesson/${revisionSlug}?${queryString}`;
       } else {
         internalHref = '#';
       }

--- a/assets/test/check_all_that_apply/cata_delivery_test.tsx
+++ b/assets/test/check_all_that_apply/cata_delivery_test.tsx
@@ -33,6 +33,7 @@ describe('check all that apply delivery', () => {
         renderPointMarkers: false,
         isAnnotationLevel: false,
         variables: {},
+        pageLinkParams: {},
       },
       preview: false,
     };

--- a/assets/test/multiple_choice/mc_delivery_test.tsx
+++ b/assets/test/multiple_choice/mc_delivery_test.tsx
@@ -34,6 +34,7 @@ describe('multiple choice delivery', () => {
         renderPointMarkers: false,
         isAnnotationLevel: false,
         variables: {},
+        pageLinkParams: {},
       },
       graded: false,
       preview: false,

--- a/assets/test/ordering/ordering_delivery_test.tsx
+++ b/assets/test/ordering/ordering_delivery_test.tsx
@@ -33,6 +33,7 @@ describe('ordering delivery', () => {
         renderPointMarkers: false,
         isAnnotationLevel: false,
         variables: {},
+        pageLinkParams: {},
       },
       preview: false,
     };

--- a/assets/test/short_answer/short_answer_delivery_test.tsx
+++ b/assets/test/short_answer/short_answer_delivery_test.tsx
@@ -33,6 +33,7 @@ describe('multiple choice delivery', () => {
         renderPointMarkers: false,
         isAnnotationLevel: false,
         variables: {},
+        pageLinkParams: {},
       },
       preview: false,
     };

--- a/assets/test/writer/writer_test.ts
+++ b/assets/test/writer/writer_test.ts
@@ -104,7 +104,7 @@ describe('parser', () => {
       screen.getByText((content, element) => {
         return (
           element?.tagName.toLowerCase() === 'a' &&
-          element.getAttribute('href') === '/sections/some_section/page/page_two' &&
+          element.getAttribute('href') === '/sections/some_section/lesson/page_two' &&
           content === 'Page Two'
         );
       }),

--- a/assets/test/writer/writer_test.ts
+++ b/assets/test/writer/writer_test.ts
@@ -99,12 +99,23 @@ describe('parser', () => {
   });
 
   it('renders internal link with context', () => {
-    render(parse(exampleContent, defaultWriterContext({ sectionSlug: 'some_section' })));
+    render(
+      parse(
+        exampleContent,
+        defaultWriterContext({
+          sectionSlug: 'some_section',
+          pageLinkParams: {
+            request_path: '/path/to/previous/page',
+          },
+        }),
+      ),
+    );
     expect(
       screen.getByText((content, element) => {
         return (
           element?.tagName.toLowerCase() === 'a' &&
-          element.getAttribute('href') === '/sections/some_section/lesson/page_two' &&
+          element.getAttribute('href') ===
+            '/sections/some_section/lesson/page_two?request_path=%2Fpath%2Fto%2Fprevious%2Fpage' &&
           content === 'Page Two'
         );
       }),

--- a/lib/oli/rendering/activity/html.ex
+++ b/lib/oli/rendering/activity/html.ex
@@ -194,7 +194,8 @@ defmodule Oli.Rendering.Activity.Html do
           end,
         renderPointMarkers: render_opts.render_point_markers,
         isAnnotationLevel: true,
-        variables: variables
+        variables: variables,
+        pageLinkParams: Enum.into(context.page_link_params, %{})
       }
       |> Poison.encode!()
       |> HtmlEntities.encode()

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -4,6 +4,9 @@ defmodule Oli.Rendering.Content.Html do
 
   Important: any changes to this file must be replicated in writers/html.ts for activity rendering.
   """
+
+  use OliWeb, :verified_routes
+
   import Oli.Utils
   import Oli.Rendering.Utils
 
@@ -710,7 +713,7 @@ defmodule Oli.Rendering.Content.Html do
   end
 
   defp internal_link(
-         %Context{section_slug: section_slug, mode: mode, project_slug: project_slug},
+         %Context{section_slug: section_slug, mode: mode, project_slug: project_slug} = context,
          next,
          href,
          opts \\ []
@@ -733,7 +736,7 @@ defmodule Oli.Rendering.Content.Html do
               "/sections/#{section_slug}/preview/page/#{revision_slug_from_course_link(href)}"
 
             _ ->
-              "/sections/#{section_slug}/page/#{revision_slug_from_course_link(href)}"
+              ~p"/sections/#{section_slug}/lesson/#{revision_slug_from_course_link(href)}?#{context.page_link_params}"
           end
       end
 

--- a/lib/oli/rendering/context.ex
+++ b/lib/oli/rendering/context.ex
@@ -32,5 +32,6 @@ defmodule Oli.Rendering.Context do
             learning_language: nil,
             effective_settings: nil,
             is_liveview: false,
-            is_annotation_level: true
+            is_annotation_level: true,
+            page_link_params: []
 end

--- a/lib/oli_web/live/delivery/student/utils.ex
+++ b/lib/oli_web/live/delivery/student/utils.ex
@@ -429,7 +429,14 @@ defmodule OliWeb.Delivery.Student.Utils do
       # to apparently not be used by the page template:
       #   project_slug: base_project_slug,
       #   submitted_surveys: submitted_surveys,
-      resource_attempt: hd(page_context.resource_attempts)
+      resource_attempt: hd(page_context.resource_attempts),
+      page_link_params:
+        build_page_link_params(
+          assigns.section.slug,
+          assigns.page_context.page,
+          assigns.request_path,
+          assigns.selected_view
+        )
     }
 
     attempt_content = get_attempt_content(page_context)
@@ -701,5 +708,26 @@ defmodule OliWeb.Delivery.Student.Utils do
       ) %>
     </div>
     """
+  end
+
+  def coalesce(first, second) do
+    case {first, second} do
+      {nil, nil} -> nil
+      {nil, s} -> s
+      {f, _s} -> f
+    end
+  end
+
+  defp build_page_link_params(section_slug, page, request_path, selected_view) do
+    current_page_path =
+      lesson_live_path(section_slug, page.slug,
+        request_path: request_path,
+        selected_view: selected_view
+      )
+
+    [
+      request_path: current_page_path,
+      selected_view: selected_view
+    ]
   end
 end

--- a/test/oli/rendering/content/html_test.exs
+++ b/test/oli/rendering/content/html_test.exs
@@ -32,7 +32,7 @@ defmodule Oli.Content.Content.HtmlTest do
                "<p data-point-marker=\"2652513352\">The American colonials proclaimed &quot;no taxation without representation"
 
       assert rendered_html_string =~
-               "<a class=\"internal-link\" href=\"/sections/some_section/page/page_two\">Page Two</a>"
+               "<a class=\"internal-link\" href=\"/sections/some_section/lesson/page_two\">Page Two</a>"
 
       assert rendered_html_string =~
                "<a class=\"external-link\" href=\"https://en.wikipedia.org/wiki/Stamp_Act_Congress\" target=\"_blank\" rel=\"noreferrer\">Stamp Act Congress</a>"


### PR DESCRIPTION
[MER-3565](https://eliterate.atlassian.net/browse/MER-3565)

Fixes Internal Server Error when launching assessments from page links. This PR considers links handling for both activity-rendered and page-rendered links. It also fixes the back button when visiting an assessment via a link.




https://github.com/user-attachments/assets/7fab519c-cdac-4475-b3ac-ac33cfd5bf1d



[MER-3565]: https://eliterate.atlassian.net/browse/MER-3565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ