### PR TITLE
[BUG FIX] [MER-3567] Quiz Scores are incorrect

### DIFF
--- a/lib/oli/grading.ex
+++ b/lib/oli/grading.ex
@@ -232,9 +232,13 @@ defmodule Oli.Grading do
         join: rev in Revision,
         on: rev.id == pr.revision_id,
         left_join: ra in ResourceAccess,
-        on: ra.resource_id == rev.resource_id and ra.user_id == ^student_id,
+        on:
+          ra.section_id == ^section_id and ra.resource_id == sr.resource_id and
+            ra.user_id == ^student_id,
         where:
-          sec.id == ^section_id and rev.deleted == false and
+          sec.id == ^section_id and
+            sr.section_id == ^section_id and
+            rev.deleted == false and
             rev.resource_type_id == ^resource_type_id and
             rev.graded == true,
         select: %GradebookScore{


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-3567

This PR fixes an issue with the query that powers the quiz scores view. The issue appears to be that `resource_accesses` records that are JOINed in were being pulled from all sections, as opposed to the single particular section being queried.

The results in the quiz scores view now match the values in the gradebook and scores exports, which was how the issue (discrepancy) was originally identified.