### PR TITLE
[BUG FIX] [MER-3543] Invite students via email link sends user to sign-up/enroll page (part 1)

### DIFF
--- a/lib/oli_web/controllers/invite_controller.ex
+++ b/lib/oli_web/controllers/invite_controller.ex
@@ -53,11 +53,11 @@ defmodule OliWeb.InviteController do
         {button_label, url} =
           case user.status do
             :new_user ->
-              token = PowInvitation.Plug.sign_invitation_token(conn, user)
-              {"Join now", Routes.delivery_pow_invitation_invitation_path(conn, :edit, token)}
+              {"Join now",
+               ~p"/registration/new?#{[section: section.slug, from_invitation_link?: true]}"}
 
             :existing_user ->
-              {"Go to the course", ~p"/sections/#{section.slug}"}
+              {"Go to the course", ~p"/sections/#{section.slug}?#{[from_invitation_link?: true]}"}
           end
 
         Oli.Email.invitation_email(user.email, :enrollment_invitation, %{


### PR DESCRIPTION
This PR is the first part of ensuring that when a user is sent an email invitation (whereas that user is existing or new), the link directs to the correct page (if new, to the sign up page, if existing to the section enroll).
Before this fix, the email invites links directed to the create author account page.


https://github.com/user-attachments/assets/def7d6dc-ceef-4a29-9b1b-e3468841bc57



See: https://eliterate.atlassian.net/browse/MER-3543

