### PR TITLE
[BUG FIX] [MER-3571] fixes explanation strategy ui fields bug

### DIFF
--- a/lib/oli/resources/explanation_strategy.ex
+++ b/lib/oli/resources/explanation_strategy.ex
@@ -15,6 +15,7 @@ defmodule Oli.Resources.ExplanationStrategy do
   embedded_schema do
     field :type, Ecto.Enum,
       values: [
+        :none,
         :after_max_resource_attempts_exhausted,
         :after_set_num_attempts
       ]

--- a/lib/oli_web/live/curriculum/container/container_live_helpers.ex
+++ b/lib/oli_web/live/curriculum/container/container_live_helpers.ex
@@ -26,18 +26,7 @@ defmodule OliWeb.Curriculum.Container.ContainerLiveHelpers do
 
   def decode_revision_params(revision_params) do
     revision_params
-    |> maybe_decode_explanation_strategy
     |> maybe_decode_intro_content
-  end
-
-  defp maybe_decode_explanation_strategy(revision_params) do
-    case revision_params do
-      %{"explanation_strategy" => %{"type" => "none"}} ->
-        Map.put(revision_params, "explanation_strategy", nil)
-
-      _ ->
-        revision_params
-    end
   end
 
   defp maybe_decode_intro_content(revision_params) do

--- a/lib/oli_web/live/curriculum/entries/options_modal.ex
+++ b/lib/oli_web/live/curriculum/entries/options_modal.ex
@@ -384,19 +384,26 @@ defmodule OliWeb.Curriculum.OptionsModalContent do
                         )
                       }
                     />
-                    <%= case Map.get(@form[:explanation_strategy].value || %{}, :type) do %>
-                      <% :after_set_num_attempts -> %>
-                        <div class="ml-2">
-                          <.input
-                            name="revision[explanation_strategy][set_num_attempts]"
-                            type="number"
-                            class="form-control"
-                            placeholder="# of Attempts"
-                            field={es[:set_num_attempts]}
-                          />
-                        </div>
-                      <% _ -> %>
-                    <% end %>
+                    <div class="ml-2">
+                      <.input
+                        :if={
+                          Ecto.Changeset.get_field(
+                            @form.source,
+                            :explanation_strategy
+                          ) &&
+                            Ecto.Changeset.get_field(
+                              @form.source,
+                              :explanation_strategy
+                            ).type == :after_set_num_attempts
+                        }
+                        name="revision[explanation_strategy][set_num_attempts]"
+                        type="number"
+                        class="form-control"
+                        placeholder="# of Attempts"
+                        min={1}
+                        field={es[:set_num_attempts]}
+                      />
+                    </div>
                   </.inputs_for>
                 </div>
                 <small id="explanation_strategy_description" class="form-text text-muted">


### PR DESCRIPTION
This PR fixes an issue where, when an author tries to set the Explanation Strategy for a page in authoring, the inputs disappear when a value is input.