### PR TITLE
[BUG FIX] [MER-3524] remove custom score UI from ImageCoding authoring

### DIFF
--- a/assets/src/components/activities/image_coding/ImageCodingAuthoring.tsx
+++ b/assets/src/components/activities/image_coding/ImageCodingAuthoring.tsx
@@ -14,7 +14,6 @@ import guid from 'utils/guid';
 import { AuthoringElement, AuthoringElementProps } from '../AuthoringElement';
 import { AuthoringElementProvider, useAuthoringElementContext } from '../AuthoringElementProvider';
 import { Explanation } from '../common/explanation/ExplanationAuthoring';
-import { ActivityScoring } from '../common/responses/ActivityScoring';
 import * as ActivityTypes from '../types';
 import { MediaItemRequest } from '../types';
 import { ICActions } from './actions';
@@ -193,7 +192,6 @@ const ImageCoding = (props: AuthoringElementProps<ImageCodingModelSchema>) => {
           <TabbedNavigation.Tabs>
             <TabbedNavigation.Tab label="Answer Key">
               {solutionParameters()}
-              <ActivityScoring partId={model.authoring.parts[0].id} />
               <Feedback
                 {...sharedProps}
                 projectSlug={props.projectSlug}


### PR DESCRIPTION
This removes the custom scoring UI component from ImageCoding authoring. Its presence was causing an error because client-evaluated activities like ImageCoding do not have the representation needed to support custom scoring in the standard way. The few other client-evaluated activities like the VirtualLab, LogicLab and embedded activity do not include this custom scoring interface.