### PR TITLE
[CHORE] [MER-3605] update devmode script for recent docker versions

### DIFF
--- a/devmode.sh
+++ b/devmode.sh
@@ -19,7 +19,7 @@ if [ ! -f .devmode ]; then
   printf "\n\nDB_HOST=localhost" >> oli.env
 
   echo "## Starting postgres database..."
-  docker-compose up -d postgres && sleep 5
+  docker compose up -d postgres && sleep 5
 
   echo "## Creating database and running migration..."
   set -a
@@ -35,9 +35,9 @@ else
 fi
 
 # start database if it's not running
-if ! docker-compose ps | grep -iq "oli_postgres.\+Up"; then
+if ! docker compose ps | grep -iq "oli_postgres.\+Up"; then
   echo "## Starting postgres database..."
-  docker-compose up -d postgres && sleep 5
+  docker compose up -d postgres && sleep 5
 fi
 
 echo "## NOTICE: Running 'reload-env' will apply any configuration set in oli.env"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.5"
 services:
   app:
     build: .


### PR DESCRIPTION
Torus source includes a utility script, devmode.sh, for use by developers to launch a containerized version locally. This updates the script for more recent docker versions, in which it was giving an error for using `docker-compose` now replaced by `docker compose`.