### PR TITLE
[BUG FIX] [MER-3292] Fix color of buttons in student sign in

### DIFF
--- a/lib/oli_web/templates/static_page/index.html.eex
+++ b/lib/oli_web/templates/static_page/index.html.eex
@@ -83,7 +83,7 @@
                   to: Routes.pow_reset_password_reset_password_path(@conn, :new),
                   tabindex: "1",
                   class:
-                    "text-center text-blue-400 text-base font-bold font-['Open Sans'] leading-snug"
+                    "text-center text-[#4ca6ff] text-base font-bold font-['Open Sans'] leading-snug"
                 ) %>
               </div>
             </div>
@@ -95,7 +95,7 @@
             <div class="flex justify-center">
               <%= submit("Sign In",
                 class:
-                  "w-80 h-11 bg-blue-600 mx-auto text-white text-xl font-normal leading-7 rounded-md btn btn-md btn-block mb-16 mt-2"
+                  "w-80 h-11 bg-[#0062f2] mx-auto text-white text-xl font-normal leading-7 rounded-md btn btn-md btn-block mb-16 mt-2"
               ) %>
             </div>
           <% end %>


### PR DESCRIPTION
[MER-3292](https://eliterate.atlassian.net/browse/MER-3292)

This PR fixes the color of the `Forgot password` and `Sign In` buttons in the `Student` login view. 

This is consistent with the other login views for **Instructors** and **Authors.** 

<img width="1440" alt="Captura de pantalla 2024-08-13 a la(s) 9 49 17 a  m" src="https://github.com/user-attachments/assets/0f2d1492-2169-41fd-aa2c-5c8e92fad265">


[MER-3292]: https://eliterate.atlassian.net/browse/MER-3292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ