### PR TITLE
[BUG FIX] [MER-3591] Error `no function clause matching in OliWeb.Delivery.Student.LearnLive.scroll_to_target_resource/4`

### DIFF
--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -108,36 +108,13 @@ defmodule OliWeb.Delivery.Student.LearnLive do
 
     send(self(), :gc)
 
-    case params do
-      %{"selected_view" => selected_view, "target_resource_id" => resource_id} ->
-        selected_view = String.to_existing_atom(selected_view)
-
-        {:noreply,
-         socket
-         |> assign(selected_view: selected_view)
-         |> stream(:units, full_hierarchy["children"], reset: true)
-         |> scroll_to_target_resource(resource_id, full_hierarchy, selected_view)}
-
-      %{"selected_view" => selected_view} ->
-        selected_view = String.to_existing_atom(selected_view)
-
-        {
-          :noreply,
-          socket
-          |> assign(selected_view: selected_view)
-          |> stream(:units, full_hierarchy["children"], reset: true)
-        }
-
-      %{"target_resource_id" => resource_id} ->
-        {:noreply,
-         socket
-         |> stream(:units, full_hierarchy["children"], reset: true)
-         |> scroll_to_target_resource(resource_id, full_hierarchy, :gallery)}
-
-      _ ->
-        {:noreply,
-         socket
-         |> stream(:units, full_hierarchy["children"], reset: true)}
+    with selected_view <- get_selected_view(params),
+         resource_id <- params["target_resource_id"] do
+      {:noreply,
+       socket
+       |> maybe_assign_selected_view(selected_view)
+       |> stream(:units, full_hierarchy["children"], reset: true)
+       |> maybe_scroll_to_target_resource(resource_id, full_hierarchy, selected_view)}
     end
   end
 
@@ -2793,4 +2770,23 @@ defmodule OliWeb.Delivery.Student.LearnLive do
     Sections.get_container_label_and_numbering(numbering_level, numbering, customizations)
     |> String.upcase()
   end
+
+  defp get_selected_view(params) do
+    case params["selected_view"] do
+      nil -> nil
+      view when view not in ~w(gallery outline) -> @default_selected_view
+      view -> String.to_existing_atom(view)
+    end
+  end
+
+  defp maybe_assign_selected_view(socket, nil), do: socket
+  defp maybe_assign_selected_view(socket, view), do: assign(socket, selected_view: view)
+
+  defp maybe_scroll_to_target_resource(socket, nil, _full_hierarchy, _selected_view), do: socket
+
+  defp maybe_scroll_to_target_resource(socket, resource_id, full_hierarchy, nil),
+    do: scroll_to_target_resource(socket, resource_id, full_hierarchy, @default_selected_view)
+
+  defp maybe_scroll_to_target_resource(socket, resource_id, full_hierarchy, selected_view),
+    do: scroll_to_target_resource(socket, resource_id, full_hierarchy, selected_view)
 end

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -2841,6 +2841,32 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
     end
   end
 
+  describe "when view mode is invalid" do
+    setup [:user_conn, :create_elixir_project, :enroll_as_student, :mark_section_visited]
+
+    test "shows default view if selected_view is not a valid option", %{
+      conn: conn,
+      section: section
+    } do
+      {:ok, view, _html} =
+        live(conn, Utils.learn_live_path(section.slug, selected_view: "invalid"))
+
+      assert has_element?(view, "span", "The best course ever!")
+      assert has_element?(view, "h3", "Introduction")
+      assert has_element?(view, "h3", "Building a Phoenix app")
+      assert has_element?(view, "h3", "Implementing LiveView")
+    end
+
+    test "shows default view if selected_view is an empty string", %{conn: conn, section: section} do
+      {:ok, view, _html} = live(conn, Utils.learn_live_path(section.slug, selected_view: ""))
+
+      assert has_element?(view, "span", "The best course ever!")
+      assert has_element?(view, "h3", "Introduction")
+      assert has_element?(view, "h3", "Building a Phoenix app")
+      assert has_element?(view, "h3", "Implementing LiveView")
+    end
+  end
+
   defp enable_all_sidebar_links(section, author, page_1, page_2, page_3) do
     # change the purpose of the pages to have an exploration page and a deliberate practice page
     Oli.Resources.update_revision(page_1, %{purpose: :application, author_id: author.id})


### PR DESCRIPTION
Fixes the following error happening in proton:
`** (FunctionClauseError) no function clause matching in OliWeb.Delivery.Student.LearnLive.scroll_to_target_resource/4`

If an invalid `selected_view` parameter is received, use the default view mode.

Related:
- https://eliterate.atlassian.net/browse/MER-3591
- https://appsignal.com/open-learning-initiative/sites/618539ab2cf81d7e3cd051ca/exceptions/incidents/62