### PR TITLE
[BUG FIX] [MER-3627]  Change "Preview Course as Instructor" to "Preview Course as Student" typo

### DIFF
--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -166,7 +166,7 @@ defmodule OliWeb.Sections.OverviewView do
         <ul class="link-list">
           <li>
             <a target="_blank" href={~p"/sections/#{@section.slug}/preview"} class="btn btn-link">
-              <span>Preview Course as Instructor</span>
+              <span>Preview Course as Student</span>
               <i class="fas fa-external-link-alt self-center ml-1" />
             </a>
           </li>


### PR DESCRIPTION

<img width="735" alt="image" src="https://github.com/user-attachments/assets/f35271e5-3ee7-4dde-a15d-82db4d2bda31">

See: https://eliterate.atlassian.net/browse/MER-3627