### PR TITLE
[BUG FIX] [MER-3624] Page objectives :resource_id not found in: nil

### DIFF
--- a/lib/oli/delivery/page/objectives_rollup.ex
+++ b/lib/oli/delivery/page/objectives_rollup.ex
@@ -20,7 +20,9 @@ defmodule Oli.Delivery.Page.ObjectivesRollup do
   end
 
   defp rollup(attached_objective_ids, resolver, section_slug) do
-    all = resolver.from_resource_id(section_slug, attached_objective_ids)
+    all =
+      resolver.from_resource_id(section_slug, attached_objective_ids)
+      |> Enum.reject(&is_nil(&1))
 
     parents = resolver.find_parent_objectives(section_slug, attached_objective_ids)
 

--- a/test/oli/delivery/page/objectives_rollup_test.exs
+++ b/test/oli/delivery/page/objectives_rollup_test.exs
@@ -68,9 +68,26 @@ defmodule Oli.Delivery.Page.ObjectivesRollupTest do
         objectives: %{}
       }
 
+      map_2 =
+        Seeder.base_project_with_resource2()
+        |> Seeder.add_objective("objective from other project", :objective_from_other_project)
+
+      attrs4 = %{
+        title: "page1",
+        content: %{
+          "model" => [
+            %{"type" => "activity-reference", "activity_id" => Map.get(map, :a1).resource.id},
+            %{"type" => "activity-reference", "activity_id" => Map.get(map, :a2).resource.id}
+          ]
+        },
+        objectives: %{"attached" => [map_2.objective_from_other_project.resource.id]}
+      }
+
       Seeder.add_page(map, attrs, :p1)
       |> Seeder.add_page(attrs2, :p2)
       |> Seeder.add_page(attrs3, :p3)
+      |> Seeder.add_page(attrs4, :p3)
+      |> Seeder.add_page(attrs4, :p4)
     end
 
     test "rolls up correctly when directly attached to page",
@@ -79,6 +96,7 @@ defmodule Oli.Delivery.Page.ObjectivesRollupTest do
            p1: p1,
            p2: p2,
            p3: p3,
+           p4: p4,
            a1: a1,
            a2: a2
          } do
@@ -106,6 +124,15 @@ defmodule Oli.Delivery.Page.ObjectivesRollupTest do
       assert [] ==
                ObjectivesRollup.rollup_objectives(
                  p3.revision,
+                 activity_revisions,
+                 Oli.Publishing.AuthoringResolver,
+                 project.slug
+               )
+
+      # Tests when objectives map contains objectives from other project
+      assert [] ==
+               ObjectivesRollup.rollup_objectives(
+                 p4.revision,
                  activity_revisions,
                  Oli.Publishing.AuthoringResolver,
                  project.slug


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-3624) to the ticket

As the ticket explained, the fix filters out any nil values returned by the objectives resolver call.