### PR TITLE
[FEATURE] [MER-3593] Migrate objectives liveview

### DIFF
--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -266,7 +266,9 @@ defmodule OliWeb.Components.Delivery.Layouts do
   def workspace_sidebar_nav(assigns) do
     ~H"""
     <div>
-      <nav id="desktop-workspace-nav-menu" class={["
+      <nav
+        id="desktop-workspace-nav-menu"
+        class={["
         transition-all
         duration-100
         fixed
@@ -282,8 +284,9 @@ defmodule OliWeb.Components.Delivery.Layouts do
         shadow-sm
         bg-delivery-navbar
         dark:bg-delivery-navbar-dark
-        overflow-y-scroll
-      ", if(!@sidebar_expanded, do: "md:!w-[60px]")]} aria-expanded={"#{@sidebar_expanded}"}>
+      ", if(!@sidebar_expanded, do: "md:!w-[60px]", else: "overflow-y-scroll")]}
+        aria-expanded={"#{@sidebar_expanded}"}
+      >
         <div class="w-full">
           <div
             class={[

--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -282,6 +282,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
         shadow-sm
         bg-delivery-navbar
         dark:bg-delivery-navbar-dark
+        overflow-y-scroll
       ", if(!@sidebar_expanded, do: "md:!w-[60px]")]} aria-expanded={"#{@sidebar_expanded}"}>
         <div class="w-full">
           <div

--- a/lib/oli_web/live/workspaces/course_author/objectives/actions.ex
+++ b/lib/oli_web/live/workspaces/course_author/objectives/actions.ex
@@ -1,0 +1,53 @@
+defmodule OliWeb.Workspaces.CourseAuthor.Objectives.Actions do
+  use Phoenix.Component
+
+  import OliWeb.Components.Common
+
+  attr :slug, :string, required: true
+
+  def actions(assigns) do
+    ~H"""
+    <div class="flex flex-row-reverse p-2">
+      <.button
+        variant={:light}
+        size={:sm}
+        phx-click="display_new_sub_modal"
+        phx-value-slug={@slug}
+        class="ml-1"
+      >
+        <i class="fas fa-plus fa-lg"></i> Create new Sub-Objective
+      </.button>
+
+      <.button
+        variant={:light}
+        size={:sm}
+        phx-click="display_add_existing_sub_modal"
+        phx-value-slug={@slug}
+        class="ml-1"
+      >
+        <i class="fas fa-plus fa-lg"></i> Add existing Sub-Objective
+      </.button>
+
+      <.button
+        variant={:light}
+        size={:sm}
+        phx-click="display_edit_modal"
+        phx-value-slug={@slug}
+        class="ml-1"
+      >
+        <i class="fas fa-i-cursor"></i> Reword
+      </.button>
+
+      <.button
+        variant={:danger}
+        size={:sm}
+        phx-click="display_delete_modal"
+        phx-value-slug={@slug}
+        class="ml-1"
+      >
+        <i class="fas fa-trash-alt fa-lg"></i> Remove
+      </.button>
+    </div>
+    """
+  end
+end

--- a/lib/oli_web/live/workspaces/course_author/objectives/attachments.ex
+++ b/lib/oli_web/live/workspaces/course_author/objectives/attachments.ex
@@ -1,0 +1,144 @@
+defmodule OliWeb.Workspaces.CourseAuthor.Objectives.Attachments do
+  use OliWeb, :live_component
+
+  alias OliWeb.Router.Helpers, as: Routes
+
+  def update(
+        %{
+          attachment_summary: %{
+            attachments: {pages, activities},
+            locked_by: locked_by,
+            parent_pages: parent_pages
+          }
+        } = assigns,
+        socket
+      ) do
+    all = pages ++ activities
+
+    is_locked? = fn id ->
+      case Map.get(parent_pages, id) do
+        nil -> Map.get(locked_by, id) != nil
+        %{id: parent_id} -> Map.get(locked_by, parent_id) != nil
+      end
+    end
+
+    {:ok,
+     assign(socket,
+       id: assigns.id,
+       locked_by: locked_by,
+       parent_pages: parent_pages,
+       project: assigns.project,
+       resources_locked: Enum.filter(all, fn r -> is_locked?.(r.resource_id) end),
+       resources_not_locked: Enum.filter(all, fn r -> !is_locked?.(r.resource_id) end)
+     )}
+  end
+
+  attr(:attachment_summary, :any, required: true)
+  attr(:id, :string)
+  attr(:locked_by, :any)
+  attr(:parent_pages, :list)
+  attr(:project, :any, required: true)
+  attr(:resources_locked, :list, default: [])
+  attr(:resources_not_locked, :list, default: [])
+
+  def render(assigns) do
+    ~H"""
+    <div id={@id}>
+      <%= if length(@resources_not_locked) == 0 and length(@resources_locked) == 0 do %>
+        <p class="mb-4">
+          Are you sure you want to delete this objective? This action cannot be undone.
+        </p>
+      <% end %>
+
+      <%= if length(@resources_not_locked) > 0 do %>
+        <p class="mb-4">
+          Proceeding will automatically remove this objective from the following resources:
+        </p>
+
+        <table class="table table-sm table-bordered">
+          <thead class="thead-dark">
+            <tr>
+              <th>Title</th>
+              <th>Resource Type</th>
+            </tr>
+          </thead>
+          <tbody>
+            <%= for r <- @resources_not_locked do %>
+              <tr>
+                <td>
+                  <a
+                    href={link_route(@project.slug, @parent_pages, r.resource_id, r.slug)}
+                    target="_blank"
+                  >
+                    <%= r.title %>
+                  </a>
+                </td>
+                <td><%= get_type(r) %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      <% end %>
+
+      <%= if length(@resources_locked) > 0 do %>
+        <p class="mb-4">
+          Deleting this objective is <strong>blocked</strong>
+          because the following resources that have this objective
+          attached to it are currently being edited:
+        </p>
+
+        <table class="table table-sm table-bordered">
+          <thead class="thead-dark">
+            <tr>
+              <th>Title</th>
+              <th>Resource Type</th>
+              <th>Edited By</th>
+            </tr>
+          </thead>
+          <tbody>
+            <%= for r <- @resources_locked do %>
+              <tr>
+                <td>
+                  <a
+                    href={link_route(@project.slug, @parent_pages, r.resource_id, r.slug)}
+                    target="_blank"
+                  >
+                    <%= r.title %>
+                  </a>
+                </td>
+                <td><%= get_type(r) %></td>
+                <td><%= locked_by_email(@parent_pages, @locked_by, r.resource_id) %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      <% end %>
+    </div>
+    """
+  end
+
+  defp locked_by_email(parent_pages, locked_by, id) do
+    case Map.get(parent_pages, id) do
+      nil -> Map.get(locked_by, id).author.email
+      %{id: parent_id} -> Map.get(locked_by, parent_id).author.email
+    end
+  end
+
+  defp get_type(r) do
+    if Map.get(r, :part) == "attached" do
+      "Page"
+    else
+      "Activity"
+    end
+  end
+
+  # Helper to formulate link to edit a resource. It is intentional that
+  # activities link to the parent page.  That is how the user will gain
+  # a lock to be able to then edit an activity.
+  defp link_route(project_slug, parent_pages, id, revision_slug) do
+    case Map.get(parent_pages, id) do
+      nil -> Routes.resource_path(OliWeb.Endpoint, :edit, project_slug, revision_slug)
+      %{slug: slug} -> Routes.resource_path(OliWeb.Endpoint, :edit, project_slug, slug)
+    end
+  end
+end

--- a/lib/oli_web/live/workspaces/course_author/objectives/delete_modal.ex
+++ b/lib/oli_web/live/workspaces/course_author/objectives/delete_modal.ex
@@ -1,0 +1,47 @@
+defmodule OliWeb.Workspaces.CourseAuthor.Objectives.DeleteModal do
+  use OliWeb, :html
+
+  alias OliWeb.Workspaces.CourseAuthor.Objectives.Attachments
+
+  attr(:attachment_summary, :any, required: true)
+  attr(:id, :string, required: true)
+  attr(:project, :any, required: true)
+  attr(:slug, :string, required: true)
+
+  def render(assigns) do
+    ~H"""
+    <div
+      class="modal fade show"
+      id={@id}
+      tabindex="-1"
+      role="dialog"
+      aria-hidden="true"
+      phx-hook="ModalLaunch"
+    >
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">Delete Objective</h5>
+            <button type="button" class="btn-close" phx-click="hide_modal" aria-label="Close">
+            </button>
+          </div>
+          <div class="modal-body">
+            <.live_component
+              module={Attachments}
+              attachment_summary={@attachment_summary}
+              project={@project}
+              id="attachments"
+            />
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-link" phx-click="hide_modal">Cancel</button>
+            <button phx-click="delete" phx-value-slug={@slug} phx-key="enter" class="btn btn-danger">
+              Delete
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/oli_web/live/workspaces/course_author/objectives/form_modal.ex
+++ b/lib/oli_web/live/workspaces/course_author/objectives/form_modal.ex
@@ -1,0 +1,62 @@
+defmodule OliWeb.Workspaces.CourseAuthor.Objectives.FormModal do
+  use OliWeb, :html
+
+  attr(:action, :atom, default: :new)
+  attr(:form, :any, required: true)
+  attr(:id, :string, required: true)
+  attr(:on_click, :any, required: true)
+
+  def render(assigns) do
+    ~H"""
+    <div
+      class="modal fade show"
+      id={@id}
+      style="display: block"
+      tabindex="-1"
+      role="dialog"
+      aria-labelledby="show-existing-sub-modal"
+      aria-hidden="true"
+      phx-hook="ModalLaunch"
+    >
+      <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title"><%= title(@action) %></h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
+            </button>
+          </div>
+          <div class="modal-body">
+            <p>At the end of the course, students should be able to...</p>
+            <div class="col-span-12 mt-4">
+              <.form id={"#{@id}_form"} for={@form} phx-submit={@on_click}>
+                <.input hidden field={@form[:slug]} />
+                <.input hidden field={@form[:parent_slug]} />
+                <div class=".f-group">
+                  <.input
+                    field={@form[:title]}
+                    class="form-control"
+                    placeholder="e.g. Recognize the structures of amino acids, carbohydrates, lipids..."
+                  />
+                </div>
+
+                <button
+                  class="form-button btn btn-md btn-primary btn-block w-auto float-right mt-4"
+                  type="submit"
+                >
+                  <%= button_text(@action) %>
+                </button>
+              </.form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  defp title(:edit), do: "Edit Objective"
+  defp title(_), do: "New Objective"
+
+  defp button_text(:edit), do: "Save"
+  defp button_text(_), do: "Create"
+end

--- a/lib/oli_web/live/workspaces/course_author/objectives/listing.ex
+++ b/lib/oli_web/live/workspaces/course_author/objectives/listing.ex
@@ -1,0 +1,111 @@
+defmodule OliWeb.Workspaces.CourseAuthor.Objectives.Listing do
+  use OliWeb, :html
+
+  import OliWeb.Components.Common
+
+  alias OliWeb.Router.Helpers, as: Routes
+  alias OliWeb.Workspaces.CourseAuthor.Objectives.Actions
+
+  attr(:project_slug, :string, required: true)
+  attr(:revision_history_link, :boolean, required: true)
+  attr(:rows, :list, required: true)
+  attr(:selected, :string, required: true)
+
+  def render(assigns) do
+    ~H"""
+    <div id="accordion" class="accordion">
+      <%= for {item, index} <- Enum.with_index(@rows) do %>
+        <div id={item.slug} class="card max-w-full border mb-3 p-0">
+          <div class="card-header d-flex justify-content-between p-2" id={"heading#{index}"}>
+            <button
+              class="flex-1 btn w-75 text-left"
+              data-bs-toggle="collapse"
+              data-bs-target={"#collapse#{index}"}
+              aria-expanded="true"
+              aria-controls={"collapse#{index}"}
+              phx-click="set_selected"
+              phx-value-slug={item.slug}
+            >
+              <%= item.title %>
+            </button>
+            <div class="d-flex flex-column font-weight-light small p-2 pr-4">
+              <div>
+                <i class="fa fa-cubes c0183 mr-1"></i><%= "Sub-Objectives #{item.sub_objectives_count}" %>
+              </div>
+              <div>
+                <i class="far fa-file c0183 mr-1"></i><%= "Pages #{item.page_attachments_count}" %>
+              </div>
+              <div>
+                <i class="fa fa-list mr-1"></i><%= "Activities #{item.activity_attachments_count}" %>
+              </div>
+              <.link
+                :if={@revision_history_link}
+                navigate={~p[/project/#{@project_slug}/history/slug/#{item.slug}]}
+              >
+                <i class="fas fa-history"></i> View revision history
+              </.link>
+            </div>
+          </div>
+
+          <div
+            id={"collapse#{index}"}
+            class={"collapse" <> if item.slug == @selected, do: " show", else: ""}
+            aria-labelledby={"heading#{index}"}
+            data-parent="#accordion"
+          >
+            <div class="card-body p-4">
+              <div class="mb-3">
+                <div class="font-bold">Sub-Objectives</div>
+                <ul class="list-group list-group-flush">
+                  <%= for sub_objective <- item.children do %>
+                    <li :if={!is_nil(sub_objective)} class="list-group-item p-2 d-flex group/item">
+                      <div class="py-1.5 w-75"><%= sub_objective.title %></div>
+                      <div class="ml-2 invisible group-hover/item:visible">
+                        <.button
+                          variant={:tertiary}
+                          size={:xs}
+                          phx-click="display_edit_modal"
+                          phx-value-slug={sub_objective.slug}
+                        >
+                          <i class="fas fa-i-cursor"></i> Rename
+                        </.button>
+                        <.button
+                          variant={:danger}
+                          size={:xs}
+                          phx-click="delete"
+                          phx-value-slug={sub_objective.slug}
+                          phx-value-parent_slug={item.slug}
+                        >
+                          <i class="fas fa-trash-alt fa-lg"></i> Delete
+                        </.button>
+                      </div>
+                    </li>
+                  <% end %>
+                </ul>
+              </div>
+              <div class="mb-3">
+                <div class="font-bold">Pages</div>
+                <ul class="list-group list-group-flush">
+                  <%= for page <- item.page_attachments do %>
+                    <li class="list-group-item p-2">
+                      <a
+                        href={Routes.resource_path(OliWeb.Endpoint, :edit, @project_slug, page.slug)}
+                        target="_blank"
+                        class="text-primary"
+                      >
+                        <%= page.title %>
+                      </a>
+                    </li>
+                  <% end %>
+                </ul>
+              </div>
+
+              <Actions.actions slug={item.slug} />
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+    """
+  end
+end

--- a/lib/oli_web/live/workspaces/course_author/objectives/select_existing_sub_modal.ex
+++ b/lib/oli_web/live/workspaces/course_author/objectives/select_existing_sub_modal.ex
@@ -1,0 +1,98 @@
+defmodule OliWeb.Workspaces.CourseAuthor.Objectives.SelectExistingSubModal do
+  use OliWeb, :live_component
+
+  alias OliWeb.Common.TextSearch
+
+  def update(assigns, socket) do
+    {:ok,
+     assign(socket,
+       add: assigns.add,
+       filtered_sub_objectives: assigns.sub_objectives,
+       id: assigns.id,
+       parent_slug: assigns.parent_slug,
+       sub_objectives: assigns.sub_objectives
+     )}
+  end
+
+  attr(:add, :string, required: true)
+  attr(:filtered_sub_objectives, :list, default: [])
+  attr(:id, :string)
+  attr(:parent_slug, :string, required: true)
+  attr(:query, :string, default: "")
+  attr(:sub_objectives, :list, default: [])
+
+  def render(assigns) do
+    ~H"""
+    <div
+      class="modal fade show"
+      id={@id}
+      style="display: block"
+      tabindex="-1"
+      role="dialog"
+      aria-labelledby="show-existing-sub-modal"
+      aria-hidden="true"
+      phx-hook="ModalLaunch"
+    >
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">Select existing Sub-Objective</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
+            </button>
+          </div>
+          <div class="modal-body">
+            <div class="container form-container">
+              <TextSearch.render
+                id="text-search"
+                text={@query}
+                event_target={@myself}
+                reset="text_search_reset"
+              />
+              <div class="d-flex flex-column mt-3">
+                <%= for sub_objective <- @filtered_sub_objectives do %>
+                  <div class="my-2 d-flex">
+                    <div class="p-1 mr-3 flex-grow-1 overflow-auto text-truncate">
+                      <%= sub_objective.title %>
+                    </div>
+                    <button
+                      class="btn btn-outline-primary py-1"
+                      phx-value-slug={sub_objective.slug}
+                      phx-value-parent_slug={@parent_slug}
+                      phx-click={@add}
+                    >
+                      Add
+                    </button>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  def handle_event("text_search_change", %{"value" => query}, socket) do
+    query_str = String.downcase(query)
+
+    filtered_sub_objectives =
+      Enum.filter(socket.assigns.sub_objectives, fn sub ->
+        String.contains?(String.downcase(sub.title), query_str)
+      end)
+
+    {:noreply,
+     assign(socket,
+       filtered_sub_objectives: filtered_sub_objectives,
+       query: query
+     )}
+  end
+
+  def handle_event("text_search_reset", _, socket) do
+    {:noreply,
+     assign(socket,
+       filtered_sub_objectives: socket.assigns.sub_objectives,
+       query: ""
+     )}
+  end
+end

--- a/lib/oli_web/live/workspaces/course_author/objectives/selections.ex
+++ b/lib/oli_web/live/workspaces/course_author/objectives/selections.ex
@@ -1,0 +1,50 @@
+defmodule OliWeb.Workspaces.CourseAuthor.Objectives.SelectionsModal do
+  use OliWeb, :html
+
+  alias OliWeb.Router.Helpers, as: Routes
+
+  attr(:project_slug, :string, required: true)
+  attr(:selections, :list, required: true)
+
+  def render(assigns) do
+    ~H"""
+    <div
+      class="modal fade show"
+      id={"selection_#{@project_slug}"}
+      tabindex="-1"
+      role="dialog"
+      aria-hidden="true"
+      phx-hook="ModalLaunch"
+    >
+      <div class="modal-dialog modal-dialog-centered modal-lg" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">Cannot Delete Objective</h5>
+          </div>
+          <div class="modal-body">
+            <p class="mb-4">
+              This objective is in use within activity bank sections in the following pages. Remove the references
+              to this objective from these pages before deleting this objective.
+            </p>
+            <ul>
+              <%= for %{slug: slug, title: title} <- @selections do %>
+                <li>
+                  <a
+                    href={Routes.resource_path(OliWeb.Endpoint, :edit, @project_slug, slug)}
+                    target="_blank"
+                  >
+                    <%= title %>
+                  </a>
+                </li>
+              <% end %>
+            </ul>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Done</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/oli_web/live/workspaces/course_author/objectives/table_model.ex
+++ b/lib/oli_web/live/workspaces/course_author/objectives/table_model.ex
@@ -1,0 +1,33 @@
+defmodule OliWeb.Workspaces.CourseAuthor.Objectives.TableModel do
+  alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
+
+  def new(objectives) do
+    SortableTableModel.new(
+      rows: objectives,
+      column_specs: [
+        %ColumnSpec{
+          name: :title,
+          label: "Title",
+          sort_fn: &__MODULE__.sort_title_column/2
+        },
+        %ColumnSpec{
+          name: :sub_objectives_count,
+          label: "# of Sub-Objectives"
+        },
+        %ColumnSpec{
+          name: :page_attachments_count,
+          label: "# of Page Attachments"
+        },
+        %ColumnSpec{
+          name: :activity_attachments_count,
+          label: "# of Activity Attachments"
+        }
+      ],
+      event_suffix: "",
+      id_field: [:id]
+    )
+  end
+
+  def sort_title_column(sort_order, _sort_spec),
+    do: {fn r -> String.downcase(r.title) end, sort_order}
+end

--- a/lib/oli_web/live/workspaces/course_author/objectives_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/objectives_live.ex
@@ -1,30 +1,564 @@
 defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLive do
+  @moduledoc """
+    LiveView implementation of an objective editor.
+  """
   use OliWeb, :live_view
+  use OliWeb.Common.SortableTable.TableHandlers
+  use OliWeb.Common.Modal
+
+  alias Oli.Accounts
+  alias Oli.Authoring.Editing.ObjectiveEditor
+  alias Oli.Publishing
+  alias Oli.Publishing.AuthoringResolver
+  alias Oli.Resources
+  alias Oli.Resources.{Revision, ResourceType}
+  alias OliWeb.Common.{Filter, FilterBox}
+  alias OliWeb.Common.Listing, as: Table
+  alias OliWeb.Router.Helpers, as: Routes
+
+  alias OliWeb.Workspaces.CourseAuthor.Objectives.{
+    DeleteModal,
+    FormModal,
+    Listing,
+    SelectExistingSubModal,
+    SelectionsModal,
+    TableModel
+  }
+
+  @table_filter_fn &__MODULE__.filter_rows/3
+  @table_push_patch_path &__MODULE__.live_path/2
+
+  def live_path(socket, params),
+    do: Routes.live_path(socket, __MODULE__, socket.assigns.project.slug, params)
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
     project = socket.assigns.project
+    author = socket.assigns.current_author
+
+    {all_objectives, all_children, objectives, table_model} =
+      build_objectives(project, [], fn socket -> socket end, true)
 
     {:ok,
      assign(socket,
+       project: project,
+       author: author,
+       objectives: objectives,
+       table_model: table_model,
+       total_count: length(objectives),
+       all_objectives: all_objectives,
+       all_children: all_children,
+       objective_attachments: [],
+       query: "",
+       offset: 0,
+       limit: 20,
        resource_slug: project.slug,
        resource_title: project.title,
        active_workspace: :course_author,
        active_view: :objectives
-     )}
-  end
-
-  @impl Phoenix.LiveView
-  def handle_params(_params, _url, socket) do
-    {:noreply, socket}
+     )
+     |> attach_hook(:has_show_links_uri_hash, :handle_params, fn _params, uri, socket ->
+       {:cont,
+        assign_new(socket, :has_show_links_uri_hash, fn ->
+          String.contains?(uri, "#show_links")
+        end)}
+     end)}
   end
 
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
-    <h1 class="flex flex-col w-full h-screen items-center justify-center">
-      Placeholder for Objectives
-    </h1>
+    <%= render_modal(assigns) %>
+
+    <div class="container mx-auto p-8">
+      <FilterBox.render
+        table_model={@table_model}
+        show_more_opts={false}
+        card_header_text="Learning Objectives"
+        card_body_text={card_body_text(assigns)}
+      >
+        <Filter.render
+          change="change_search"
+          reset="reset_search"
+          apply="apply_search"
+          query={@query}
+        />
+      </FilterBox.render>
+
+      <div class="d-flex flex-row-reverse">
+        <button class="btn btn-primary" phx-click="display_new_modal">Create new Objective</button>
+      </div>
+
+      <div id="objectives-table" class="my-4">
+        <Table.render
+          filter={@query}
+          table_model={@table_model}
+          total_count={@total_count}
+          offset={@offset}
+          limit={@limit}
+          sort="sort"
+          page_change="page_change"
+          show_bottom_paging={false}
+          additional_table_class="table-sm text-center"
+          with_body={true}
+        >
+          <Listing.render
+            revision_history_link={
+              @has_show_links_uri_hash and Accounts.at_least_content_admin?(@author)
+            }
+            rows={@table_model.rows}
+            selected={@selected}
+            project_slug={@project.slug}
+          />
+        </Table.render>
+      </div>
+    </div>
     """
   end
+
+  defp build_objectives(project, objectives_attachments, flash_fn, first_load \\ false) do
+    all_objectives =
+      project
+      |> ObjectiveEditor.fetch_objective_mappings()
+      |> Enum.map(& &1.revision)
+
+    all_children =
+      all_objectives
+      |> Enum.reduce([], fn rev, acc -> rev.children ++ acc end)
+      |> Enum.uniq()
+
+    objectives =
+      Enum.reduce(all_objectives, [], fn rev, acc ->
+        case Enum.find(all_children, fn child_id -> child_id == rev.resource_id end) do
+          nil ->
+            mapped_children =
+              Enum.map(rev.children, fn resource_id ->
+                Enum.find(all_objectives, fn rev -> rev.resource_id == resource_id end)
+              end)
+
+            [
+              Map.merge(
+                rev,
+                %{
+                  children: mapped_children,
+                  sub_objectives_count: length(mapped_children),
+                  page_attachments_count: 0,
+                  page_attachments: [],
+                  activity_attachments_count: 0
+                }
+              )
+            ] ++ acc
+
+          _ ->
+            acc
+        end
+      end)
+
+    {:ok, table_model} = TableModel.new(objectives)
+
+    pid = self()
+
+    if first_load do
+      Task.async(fn ->
+        publication = Publishing.project_working_publication(project.slug)
+        objectives_attachments = Publishing.find_attached_objectives(publication.id)
+
+        send(pid, {:finish_attachments, {objectives_attachments, flash_fn}})
+      end)
+    else
+      send(pid, {:finish_attachments, {objectives_attachments, flash_fn}})
+    end
+
+    {all_objectives, all_children, objectives, table_model}
+  end
+
+  def filter_rows(socket, query, _filter) do
+    query_str = String.downcase(query)
+
+    Enum.filter(socket.assigns.objectives, fn obj ->
+      String.contains?(String.downcase(obj.title), query_str)
+    end)
+  end
+
+  defp return_updated_data(project, flash_fn, socket) do
+    {all_objectives, all_children, objectives, table_model} =
+      build_objectives(project, socket.assigns.objectives_attachments, flash_fn)
+
+    {:noreply,
+     socket
+     |> assign(
+       objectives: objectives,
+       table_model: table_model,
+       total_count: length(objectives),
+       all_objectives: all_objectives,
+       all_children: all_children
+     )
+     |> hide_modal(modal_assigns: nil)
+     |> push_patch(to: live_path(socket, socket.assigns.params))}
+  end
+
+  defp card_body_text(assigns) do
+    ~H"""
+    Learning objectives help you to organize course content and determine appropriate assessments and instructional strategies.
+    <br /> Refer to the
+    <a
+      class="external"
+      href="https://www.cmu.edu/teaching/designteach/design/learningobjectives.html"
+      target="_blank"
+    >
+      CMU Eberly Center guide on learning objectives
+    </a> to learn more about the importance of attaching learning objectives to pages and activities.
+    """
+  end
+
+  defp new_modal(form, socket) do
+    modal_assigns = %{
+      id: "new_objective_modal",
+      form: form,
+      action: :new,
+      on_click: "new"
+    }
+
+    modal = fn assigns ->
+      ~H"""
+      <FormModal.render {@modal_assigns} />
+      """
+    end
+
+    {:noreply,
+     show_modal(
+       socket,
+       modal,
+       modal_assigns: modal_assigns
+     )}
+  end
+
+  def handle_event("hide_modal", _, socket),
+    do: {:noreply, hide_modal(socket, modal_assigns: nil)}
+
+  def handle_event("display_new_modal", _, socket),
+    do: new_modal(Resources.change_revision(%Revision{}) |> to_form(), socket)
+
+  def handle_event("display_new_sub_modal", %{"slug" => slug}, socket),
+    do: new_modal(Resources.change_revision(%Revision{parent_slug: slug}) |> to_form(), socket)
+
+  def handle_event("set_selected", %{"slug" => slug}, socket) do
+    {:noreply,
+     push_patch(socket,
+       to: live_path(socket, Map.merge(socket.assigns.params, %{"selected" => slug}))
+     )}
+  end
+
+  def handle_event(
+        "new",
+        %{"revision" => %{"title" => title, "parent_slug" => parent_slug}},
+        socket
+      ) do
+    socket = clear_flash(socket)
+
+    project = socket.assigns.project
+
+    flash_fn =
+      case ObjectiveEditor.add_new(
+             %{title: title},
+             socket.assigns.author,
+             project,
+             parent_slug
+           ) do
+        {:ok, _} ->
+          fn socket -> put_flash(socket, :info, "Objective successfully created") end
+
+        {:error, _error} ->
+          fn socket -> put_flash(socket, :error, "Could not create objective") end
+      end
+
+    return_updated_data(project, flash_fn, socket)
+  end
+
+  def handle_event("display_edit_modal", %{"slug" => slug}, socket) do
+    changeset =
+      socket.assigns.project.slug
+      |> AuthoringResolver.from_revision_slug(slug)
+      |> Resources.change_revision()
+
+    modal_assigns = %{
+      id: "edit_objective_modal",
+      form: to_form(changeset),
+      action: :edit,
+      on_click: "edit"
+    }
+
+    modal = fn assigns ->
+      ~H"""
+      <FormModal.render {@modal_assigns} />
+      """
+    end
+
+    {:noreply,
+     show_modal(
+       socket,
+       modal,
+       modal_assigns: modal_assigns
+     )}
+  end
+
+  def handle_event("edit", %{"revision" => %{"title" => title, "slug" => slug}}, socket) do
+    socket = clear_flash(socket)
+
+    project = socket.assigns.project
+
+    flash_fn =
+      case ObjectiveEditor.edit(
+             slug,
+             %{title: title},
+             socket.assigns.author,
+             project
+           ) do
+        {:ok, _} ->
+          fn socket -> put_flash(socket, :info, "Objective successfully updated") end
+
+        {:error, %Ecto.Changeset{} = _changeset} ->
+          fn socket -> put_flash(socket, :error, "Could not update objective") end
+      end
+
+    return_updated_data(project, flash_fn, socket)
+  end
+
+  def handle_event("display_add_existing_sub_modal", %{"slug" => slug}, socket) do
+    %{project: project, all_children: all_children, all_objectives: all_objectives} =
+      socket.assigns
+
+    %{children: objective_children} = AuthoringResolver.from_revision_slug(project.slug, slug)
+
+    sub_objectives =
+      Enum.map(all_children -- objective_children, fn resource_id ->
+        Enum.find(all_objectives, fn obj -> obj.resource_id == resource_id end)
+      end)
+
+    modal_assigns = %{
+      id: "select_existing_sub_modal",
+      parent_slug: slug,
+      sub_objectives: sub_objectives,
+      add: "add_existing_sub"
+    }
+
+    modal = fn assigns ->
+      ~H"""
+      <.live_component id="select_existing_sub_modal" module={SelectExistingSubModal} {@modal_assigns} />
+      """
+    end
+
+    {:noreply,
+     show_modal(
+       socket,
+       modal,
+       modal_assigns: modal_assigns
+     )}
+  end
+
+  def handle_event("display_delete_modal", %{"slug" => slug}, socket) do
+    socket = clear_flash(socket)
+
+    project = socket.assigns.project
+
+    %{children: children, resource_id: resource_id} =
+      AuthoringResolver.from_revision_slug(project.slug, slug)
+
+    if length(children) > 0 do
+      {:noreply,
+       put_flash(socket, :error, "Could not remove objective if it has sub-objectives associated")}
+    else
+      publication_id = Oli.Publishing.get_unpublished_publication_id!(project.id)
+
+      case Oli.Publishing.find_objective_in_selections(resource_id, publication_id) do
+        [] ->
+          modal_assigns = %{
+            id: "delete_objective_modal",
+            slug: slug,
+            project: project,
+            attachment_summary:
+              ObjectiveEditor.preview_objective_detatchment(resource_id, project)
+          }
+
+          modal = fn assigns ->
+            ~H"""
+            <DeleteModal.render {@modal_assigns} />
+            """
+          end
+
+          {:noreply,
+           show_modal(
+             socket,
+             modal,
+             modal_assigns: modal_assigns
+           )}
+
+        selections ->
+          modal_assigns = %{
+            id: "selections_modal",
+            selections: selections,
+            project_slug: project.slug
+          }
+
+          modal = fn assigns ->
+            ~H"""
+            <SelectionsModal.render {@modal_assigns} />
+            """
+          end
+
+          {:noreply,
+           assign(
+             socket,
+             modal,
+             modal_assigns: modal_assigns
+           )}
+      end
+    end
+  end
+
+  def handle_event("delete", %{"slug" => slug} = params, socket) do
+    socket = clear_flash(socket)
+
+    parent_slug = Map.get(params, "parent_slug", "")
+    %{project: project, author: author, objectives: objectives} = socket.assigns
+    %{resource_id: resource_id} = AuthoringResolver.from_revision_slug(project.slug, slug)
+
+    ObjectiveEditor.detach_objective(resource_id, project, author)
+
+    {parents, parent_to_detach_slug} =
+      Enum.reduce(objectives, {[], ""}, fn objective, {parents, parent_to_detach_slug} ->
+        case Enum.find(objective.children, fn child -> !is_nil(child) && child.slug == slug end) do
+          nil ->
+            {parents, parent_to_detach_slug}
+
+          _ ->
+            if objective.slug == parent_slug,
+              do: {[objective | parents], objective.slug},
+              else: {[objective | parents], parent_to_detach_slug}
+        end
+      end)
+
+    delete_fn =
+      if length(parents) <= 1 do
+        fn ->
+          ObjectiveEditor.delete(
+            slug,
+            author,
+            project,
+            AuthoringResolver.from_revision_slug(project.slug, parent_to_detach_slug)
+          )
+        end
+      else
+        fn ->
+          ObjectiveEditor.remove_sub_objective_from_parent(
+            slug,
+            author,
+            project,
+            AuthoringResolver.from_revision_slug(project.slug, parent_to_detach_slug)
+          )
+        end
+      end
+
+    flash_fn =
+      case delete_fn.() do
+        {:ok, _} ->
+          fn socket -> put_flash(socket, :info, "Objective successfully removed") end
+
+        {:error, _error} ->
+          fn socket -> put_flash(socket, :error, "Could not remove objective") end
+      end
+
+    return_updated_data(project, flash_fn, socket)
+  end
+
+  def handle_event(
+        "add_existing_sub",
+        %{"slug" => slug, "parent_slug" => parent_slug} = _params,
+        socket
+      ) do
+    socket = clear_flash(socket)
+
+    %{project: project, author: author} = socket.assigns
+
+    flash_fn =
+      case ObjectiveEditor.add_new_parent_for_sub_objective(
+             slug,
+             parent_slug,
+             project.slug,
+             author
+           ) do
+        {:ok, _revision} ->
+          fn socket -> put_flash(socket, :info, "Sub-objective successfully added") end
+
+        {:error, _} ->
+          fn socket -> put_flash(socket, :error, "Could not add sub-objective") end
+      end
+
+    return_updated_data(project, flash_fn, socket)
+  end
+
+  @impl Phoenix.LiveView
+  def handle_info({:finish_attachments, {objectives_attachments, flash_fn}}, socket) do
+    page_id = ResourceType.id_for_page()
+    activity_id = ResourceType.id_for_activity()
+
+    objectives =
+      Enum.reduce(socket.assigns.objectives, [], fn rev, acc ->
+        resource_id = rev.resource_id
+
+        children =
+          rev.children
+          |> Enum.filter(&(!is_nil(&1)))
+          |> Enum.map(& &1.resource_id)
+
+        all_page_attachments =
+          Enum.filter(objectives_attachments, fn
+            %{resource_type_id: ^page_id, attached_objective: resource_id} ->
+              Enum.member?(children, resource_id)
+
+            _ ->
+              false
+          end) ++
+            for pa = %{
+                  attached_objective: ^resource_id,
+                  resource_type_id: ^page_id
+                } <- objectives_attachments,
+                do: pa
+
+        page_attachments = Enum.uniq_by(all_page_attachments, & &1.slug)
+
+        activity_attachments =
+          for aa = %{
+                attached_objective: ^resource_id,
+                resource_type_id: ^activity_id
+              } <- objectives_attachments,
+              do: aa
+
+        [
+          Map.merge(
+            rev,
+            %{
+              page_attachments_count: length(page_attachments),
+              page_attachments: page_attachments,
+              activity_attachments_count: length(activity_attachments)
+            }
+          )
+        ] ++ acc
+      end)
+
+    {:ok, table_model} = TableModel.new(objectives)
+
+    {:noreply,
+     socket
+     |> assign(
+       objectives: objectives,
+       table_model: table_model,
+       objectives_attachments: objectives_attachments
+     )
+     |> flash_fn.()
+     |> push_patch(to: live_path(socket, socket.assigns.params), replace: true)}
+  end
+
+  # needed to ignore results of Task invocation
+  def handle_info(_, socket), do: {:noreply, socket}
 end

--- a/lib/oli_web/live/workspaces/course_author/objectives_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/objectives_live.ex
@@ -25,6 +25,8 @@ defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLive do
     TableModel
   }
 
+  on_mount {OliWeb.LiveSessionPlugs.AuthorizeProject, :default}
+
   @table_filter_fn &__MODULE__.filter_rows/3
   @table_push_patch_path &__MODULE__.live_path/2
 

--- a/lib/oli_web/live_session_plugs/authorize_project.ex
+++ b/lib/oli_web/live_session_plugs/authorize_project.ex
@@ -17,14 +17,21 @@ defmodule OliWeb.LiveSessionPlugs.AuthorizeProject do
          |> redirect(to: ~p"/workspaces/course_author")}
 
       %Author{} ->
-        if Accounts.can_access?(current_author, project) &&
-             project.status === :active do
-          {:cont, socket}
-        else
-          {:halt,
-           socket
-           |> put_flash(:error, "You don't have access to that project")
-           |> redirect(to: ~p"/workspaces/course_author")}
+        case {Accounts.can_access?(current_author, project), project.status} do
+          {true, :active} ->
+            {:cont, socket}
+
+          {false, _} ->
+            {:halt,
+             socket
+             |> put_flash(:error, "You don't have access to that project")
+             |> redirect(to: ~p"/workspaces/course_author")}
+
+          {_, :deleted} ->
+            {:halt,
+             socket
+             |> put_flash(:error, "That project is not active")
+             |> redirect(to: ~p"/workspaces/course_author")}
         end
     end
   end

--- a/lib/oli_web/live_session_plugs/authorize_project.ex
+++ b/lib/oli_web/live_session_plugs/authorize_project.ex
@@ -1,0 +1,31 @@
+defmodule OliWeb.LiveSessionPlugs.AuthorizeProject do
+  use OliWeb, :verified_routes
+  import Phoenix.LiveView, only: [redirect: 2, put_flash: 3]
+
+  alias Oli.Accounts
+  alias Oli.Accounts.Author
+
+  def on_mount(:default, _params, _session, socket) do
+    project = Map.get(socket.assigns, :project)
+    current_author = Map.get(socket.assigns, :current_author)
+
+    case current_author do
+      nil ->
+        {:halt,
+         socket
+         |> put_flash(:error, "You must be logged in to access that project")
+         |> redirect(to: ~p"/workspaces/course_author")}
+
+      %Author{} ->
+        if Accounts.can_access?(current_author, project) &&
+             project.status === :active do
+          {:cont, socket}
+        else
+          {:halt,
+           socket
+           |> put_flash(:error, "You don't have access to that project")
+           |> redirect(to: ~p"/workspaces/course_author")}
+        end
+    end
+  end
+end

--- a/test/oli_web/live/workspace/course_author/objectives_live_test.exs
+++ b/test/oli_web/live/workspace/course_author/objectives_live_test.exs
@@ -1,0 +1,687 @@
+defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLiveTest do
+  use OliWeb.ConnCase
+
+  import Oli.Factory
+  import Phoenix.ConnTest
+  import Phoenix.LiveViewTest
+
+  alias Oli.Authoring.Editing.ObjectiveEditor
+  alias Oli.Resources.ResourceType
+
+  defp live_view_route(project_slug, params \\ %{}),
+    do: ~p"/workspaces/course_author/#{project_slug}/objectives?#{params}"
+
+  defp create_project(_conn) do
+    author = insert(:author)
+    project = insert(:project, authors: [author])
+    # root container
+    container_resource = insert(:resource)
+
+    container_revision =
+      insert(:revision, %{
+        resource: container_resource,
+        objectives: %{},
+        resource_type_id: ResourceType.id_for_container(),
+        children: [],
+        content: %{},
+        deleted: false,
+        slug: "root_container",
+        title: "Root Container"
+      })
+
+    # Associate root container to the project
+    insert(:project_resource, %{project_id: project.id, resource_id: container_resource.id})
+    # Publication of project with root container
+    publication =
+      insert(:publication, %{
+        project: project,
+        published: nil,
+        root_resource_id: container_resource.id
+      })
+
+    # Publish root container resource
+    insert(:published_resource, %{
+      publication: publication,
+      resource: container_resource,
+      revision: container_revision,
+      author: author
+    })
+
+    [project: project, publication: publication]
+  end
+
+  defp create_objective(project, publication, slug, title, children \\ []) do
+    # Create objective
+    obj_resource = insert(:resource)
+
+    obj_revision =
+      insert(:revision, %{
+        resource: obj_resource,
+        objectives: %{},
+        resource_type_id: ResourceType.id_for_objective(),
+        children: children,
+        content: %{},
+        deleted: false,
+        slug: slug,
+        title: title
+      })
+
+    # Associate objective to the project
+    insert(:project_resource, %{project_id: project.id, resource_id: obj_resource.id})
+    # Publish objective resource
+    insert(:published_resource, %{
+      author: hd(project.authors),
+      publication: publication,
+      resource: obj_resource,
+      revision: obj_revision
+    })
+
+    {:ok, obj_revision}
+  end
+
+  defp create_page_with_objective(project, publication, objectives, slug \\ "slug") do
+    # Create page
+    page_resource = insert(:resource)
+
+    page_revision =
+      insert(:revision, %{
+        objectives: %{"attached" => objectives},
+        scoring_strategy_id: Oli.Resources.ScoringStrategy.get_id_by_type("average"),
+        resource_type_id: ResourceType.id_for_page(),
+        children: [],
+        content: %{"model" => []},
+        deleted: false,
+        title: "Page 1",
+        resource: page_resource,
+        slug: slug
+      })
+
+    # Associate page to the project
+    insert(:project_resource, %{project_id: project.id, resource_id: page_resource.id})
+    # Publish page resource
+    insert(:published_resource, %{
+      author: hd(project.authors),
+      publication: publication,
+      resource: page_resource,
+      revision: page_revision
+    })
+
+    {:ok, page_revision}
+  end
+
+  describe "user cannot access when is not logged in" do
+    setup [:create_project]
+
+    test "redirects to new session when accessing the objectives view", %{
+      conn: conn,
+      project: project
+    } do
+      redirect_path =
+        "/workspaces/course_author"
+
+      {:error, {:redirect, %{to: ^redirect_path}}} = live(conn, live_view_route(project.slug))
+    end
+  end
+
+  describe "user cannot access when is logged in as an author but is not an author of the project" do
+    setup [:author_conn, :create_project]
+
+    test "redirects to projects view when accessing the objectives view", %{
+      conn: conn,
+      project: project
+    } do
+      redirect_path = "/workspaces/course_author"
+
+      {:error, {:redirect, %{to: ^redirect_path}}} = live(conn, live_view_route(project.slug))
+    end
+  end
+
+  describe "objectives" do
+    setup [:admin_conn, :create_project]
+
+    test "loads correctly when there are no objectives", %{conn: conn, project: project} do
+      {:ok, view, _html} = live(conn, live_view_route(project.slug))
+
+      assert has_element?(view, "#objectives-table")
+      assert has_element?(view, "p", "None exist")
+
+      assert_receive {:finish_attachments, {_attachments, _flash_fn}}
+      assert_receive {:DOWN, _ref, :process, _pid, :normal}
+    end
+
+    test "applies searching", %{conn: conn, project: project, publication: publication} do
+      {:ok, first_obj} = create_objective(project, publication, "first_obj", "First Objective")
+      {:ok, second_obj} = create_objective(project, publication, "second_obj", "Second Objective")
+
+      {:ok, view, _html} = live(conn, live_view_route(project.slug))
+
+      assert has_element?(view, "#objectives-table")
+      assert has_element?(view, "##{first_obj.slug}")
+      assert has_element?(view, "##{second_obj.slug}")
+
+      view
+      |> element("input[phx-blur=\"change_search\"]")
+      |> render_blur(%{value: "first"})
+
+      view
+      |> element("button[phx-click=\"apply_search\"]")
+      |> render_click()
+
+      assert has_element?(view, "##{first_obj.slug}")
+      refute has_element?(view, "##{second_obj.slug}")
+
+      view
+      |> element("button[phx-click=\"reset_search\"]")
+      |> render_click()
+
+      assert has_element?(view, "##{first_obj.slug}")
+      assert has_element?(view, "##{second_obj.slug}")
+
+      assert_receive {:finish_attachments, {_attachments, _flash_fn}}
+      assert_receive {:DOWN, _ref, :process, _pid, :normal}
+    end
+
+    test "applies sorting", %{conn: conn, project: project, publication: publication} do
+      {:ok, _first_obj} = create_objective(project, publication, "first_obj", "First Objective")
+
+      {:ok, _second_obj} =
+        create_objective(project, publication, "second_obj", "Second Objective")
+
+      {:ok, view, _html} = live(conn, live_view_route(project.slug))
+
+      assert view
+             |> element(".card:first-child")
+             |> render() =~
+               "First Objective"
+
+      view
+      |> element("form[phx-change=\"sort\"")
+      |> render_change(%{sort_by: "title"})
+
+      assert view
+             |> element(".card:first-child")
+             |> render() =~
+               "Second Objective"
+
+      assert_receive {:finish_attachments, {_attachments, _flash_fn}}
+      assert_receive {:DOWN, _ref, :process, _pid, :normal}
+    end
+
+    test "applies paging", %{conn: conn, project: project, publication: publication} do
+      [first_obj | tail] =
+        1..21
+        |> Enum.to_list()
+        |> Enum.map(fn i ->
+          create_objective(project, publication, "#{i}_obj", "#{i} Objective") |> elem(1)
+        end)
+        |> Enum.sort_by(& &1.title)
+
+      last_obj = List.last(tail)
+
+      {:ok, view, _html} = live(conn, live_view_route(project.slug))
+
+      assert has_element?(view, "##{first_obj.slug}")
+      refute has_element?(view, "##{last_obj.slug}")
+
+      view
+      |> element(
+        "#header_paging > nav > ul > li:nth-child(4) > button",
+        "2"
+      )
+      |> render_click()
+
+      refute has_element?(view, "##{first_obj.slug}")
+      assert has_element?(view, "##{last_obj.slug}")
+
+      assert_receive {:finish_attachments, {_attachments, _flash_fn}}
+      assert_receive {:DOWN, _ref, :process, _pid, :normal}
+    end
+
+    @tag :skip
+    test "show objective", %{conn: conn, project: project, publication: publication} do
+      {:ok, sub_obj} = create_objective(project, publication, "sub_obj", "Sub Objective")
+      {:ok, sub_obj_2} = create_objective(project, publication, "sub_obj_2", "Sub Objective 2")
+
+      {:ok, obj} =
+        create_objective(project, publication, "obj", "Objective", [
+          sub_obj.resource_id,
+          sub_obj_2.resource_id
+        ])
+
+      {:ok, page_1} =
+        create_page_with_objective(project, publication, [obj.resource_id], "other_slug")
+
+      {:ok, page_2} =
+        create_page_with_objective(project, publication, [
+          sub_obj.resource_id,
+          sub_obj_2.resource_id
+        ])
+
+      {:ok, view, _html} = live(conn, live_view_route(project.slug, %{selected: obj.slug}))
+
+      assert has_element?(view, "##{obj.slug}")
+      assert has_element?(view, "##{obj.slug}", "Sub-Objectives 2")
+      assert has_element?(view, "##{obj.slug}", "Pages 2")
+      assert has_element?(view, "##{obj.slug}", "Activities 0")
+      assert has_element?(view, ".collapse", "Sub-Objectives")
+      assert has_element?(view, ".collapse", "#{sub_obj.title}")
+      assert has_element?(view, ".collapse", "Pages")
+
+      assert has_element?(
+               view,
+               ".collapse a[href=\"#{Routes.resource_path(OliWeb.Endpoint, :edit, project.slug, page_1.slug)}\"]",
+               "#{page_1.title}"
+             )
+
+      assert has_element?(
+               view,
+               ".collapse a[href=\"#{Routes.resource_path(OliWeb.Endpoint, :edit, project.slug, page_2.slug)}\"]",
+               "#{page_2.title}"
+             )
+
+      assert_receive {:finish_attachments, {_attachments, _flash_fn}}
+      assert_receive {:DOWN, _ref, :process, _pid, :normal}
+    end
+
+    test "new objective", %{conn: conn, project: project} do
+      title = "New Objective"
+
+      {:ok, view, _html} = live(conn, live_view_route(project.slug))
+
+      refute has_element?(view, "#{title}")
+
+      view
+      |> element("button[phx-click=\"display_new_modal\"]")
+      |> render_click(%{})
+
+      view
+      |> element("form[phx-submit=\"new\"")
+      |> render_submit(%{"revision" => %{"title" => title, "parent_slug" => ""}})
+
+      assert view
+             |> element("p.alert.alert-info")
+             |> render() =~
+               "Objective successfully created"
+
+      [%{revision: revision} | _tail] = ObjectiveEditor.fetch_objective_mappings(project)
+
+      assert has_element?(view, "##{revision.slug}")
+      assert has_element?(view, "button[phx-value-slug=#{revision.slug}]", "#{revision.title}")
+
+      assert_receive {:finish_attachments, {_attachments, _flash_fn}}
+      assert_receive {:DOWN, _ref, :process, _pid, :normal}
+    end
+
+    test "edit objective", %{conn: conn, project: project, publication: publication} do
+      title = "New title"
+      {:ok, obj} = create_objective(project, publication, "obj", "Objective")
+
+      {:ok, view, _html} = live(conn, live_view_route(project.slug, %{selected: obj.slug}))
+
+      assert has_element?(view, "##{obj.slug}")
+      assert has_element?(view, "button[phx-value-slug=#{obj.slug}]", "#{obj.title}")
+
+      view
+      |> element("button[phx-click=\"display_edit_modal\"]")
+      |> render_click(%{"slug" => obj.slug})
+
+      view
+      |> element("form[phx-submit=\"edit\"")
+      |> render_submit(%{"revision" => %{"title" => title, "slug" => obj.slug}})
+
+      assert view
+             |> element("p.alert.alert-info")
+             |> render() =~
+               "Objective successfully updated"
+
+      [%{revision: new_obj} | _tail] = ObjectiveEditor.fetch_objective_mappings(project)
+
+      refute has_element?(view, "button[phx-value-slug=#{obj.slug}]", "#{obj.title}")
+      assert has_element?(view, "button[phx-value-slug=#{new_obj.slug}]", "#{title}")
+
+      assert_receive {:finish_attachments, {_attachments, _flash_fn}}
+      assert_receive {:DOWN, _ref, :process, _pid, :normal}
+    end
+
+    test "remove objective", %{conn: conn, project: project, publication: publication} do
+      {:ok, sub_obj} = create_objective(project, publication, "sub_obj", "Sub Objective")
+
+      {:ok, obj_a} =
+        create_objective(project, publication, "obj_a", "Objective A", [sub_obj.resource_id])
+
+      {:ok, obj_b} = create_objective(project, publication, "obj_b", "Objective B")
+      {:ok, page} = create_page_with_objective(project, publication, [obj_b.resource_id])
+
+      removal_title = "Objective C"
+      {:ok, obj_c} = create_objective(project, publication, "obj_c", removal_title)
+
+      {:ok, view, _html} = live(conn, live_view_route(project.slug))
+
+      view
+      |> element("button[phx-click=\"set_selected\"][phx-value-slug=#{obj_a.slug}]")
+      |> render_click(%{"slug" => obj_a.slug})
+
+      view
+      |> element("button[phx-click=\"display_delete_modal\"][phx-value-slug=#{obj_a.slug}]")
+      |> render_click(%{"slug" => obj_a.slug})
+
+      assert view
+             |> element("p.alert.alert-danger")
+             |> render() =~
+               "Could not remove objective if it has sub-objectives associated"
+
+      view
+      |> element("button[phx-click=\"set_selected\"][phx-value-slug=#{obj_b.slug}]")
+      |> render_click(%{"slug" => obj_b.slug})
+
+      view
+      |> element("button[phx-click=\"display_delete_modal\"][phx-value-slug=#{obj_b.slug}]")
+      |> render_click(%{"slug" => obj_b.slug})
+
+      assert has_element?(
+               view,
+               "#delete_objective_modal",
+               "Deleting this objective is"
+             )
+
+      assert has_element?(
+               view,
+               "#delete_objective_modal strong",
+               "blocked"
+             )
+
+      assert has_element?(
+               view,
+               "#delete_objective_modal",
+               "attached to it are currently being edited"
+             )
+
+      assert has_element?(view, "#delete_objective_modal", "Page")
+      assert has_element?(view, "#delete_objective_modal", "#{page.title}")
+
+      view
+      |> element("button[phx-click=\"set_selected\"][phx-value-slug=#{obj_c.slug}]")
+      |> render_click(%{"slug" => obj_c.slug})
+
+      view
+      |> element("button[phx-click=\"display_delete_modal\"][phx-value-slug=#{obj_c.slug}]")
+      |> render_click(%{"slug" => obj_c.slug})
+
+      view
+      |> element("button[phx-click=\"delete\"][phx-value-slug=#{obj_c.slug}]")
+      |> render_click(%{"slug" => obj_c.slug, "parent_slug" => ""})
+
+      assert view
+             |> element("p.alert.alert-info")
+             |> render() =~
+               "Objective successfully removed"
+
+      assert 3 ==
+               project
+               |> ObjectiveEditor.fetch_objective_mappings()
+               |> length()
+
+      refute has_element?(view, ".collapse", "#{removal_title}")
+
+      assert_receive {:finish_attachments, {_attachments, _flash_fn}}
+      assert_receive {:DOWN, _ref, :process, _pid, :normal}
+    end
+
+    test "add existing sub objective", %{conn: conn, project: project, publication: publication} do
+      {:ok, sub_obj_a} = create_objective(project, publication, "sub_obj_a", "Sub Objective A")
+
+      {:ok, sub_obj_b} =
+        create_objective(project, publication, "sub_obj_b", "Testing Sub Objective B")
+
+      {:ok, sub_obj_c} = create_objective(project, publication, "sub_obj_c", "Sub Objective C")
+
+      {:ok, first_obj} =
+        create_objective(project, publication, "first_obj", "Objective 1", [sub_obj_a.resource_id])
+
+      {:ok, _second_obj} =
+        create_objective(project, publication, "second_obj", "Objective 2", [
+          sub_obj_b.resource_id,
+          sub_obj_c.resource_id
+        ])
+
+      {:ok, view, _html} = live(conn, live_view_route(project.slug, %{selected: first_obj.slug}))
+
+      refute has_element?(view, "#collapse0", "#{sub_obj_b.title}")
+
+      view
+      |> element(
+        "button[phx-click=\"display_add_existing_sub_modal\"][phx-value-slug=#{first_obj.slug}]"
+      )
+      |> render_click(%{slug: first_obj.slug})
+
+      refute has_element?(
+               view,
+               "button[phx-click=\"add_existing_sub\"][phx-value-slug=#{sub_obj_a.slug}]",
+               "Add"
+             )
+
+      assert has_element?(
+               view,
+               "button[phx-click=\"add_existing_sub\"][phx-value-slug=#{sub_obj_b.slug}]",
+               "Add"
+             )
+
+      assert has_element?(
+               view,
+               "button[phx-click=\"add_existing_sub\"][phx-value-slug=#{sub_obj_c.slug}]",
+               "Add"
+             )
+
+      view
+      |> element("#select_existing_sub_modal #text-search-input")
+      |> render_hook("text_search_change", %{value: "testing"})
+
+      assert has_element?(
+               view,
+               "button[phx-click=\"add_existing_sub\"][phx-value-slug=#{sub_obj_b.slug}]",
+               "Add"
+             )
+
+      refute has_element?(
+               view,
+               "button[phx-click=\"add_existing_sub\"][phx-value-slug=#{sub_obj_c.slug}]",
+               "Add"
+             )
+
+      view
+      |> element(
+        "button[phx-click=\"add_existing_sub\"][phx-value-slug=#{sub_obj_b.slug}]",
+        "Add"
+      )
+      |> render_click(%{"slug" => sub_obj_b.slug, "parent_slug" => first_obj.slug})
+
+      assert has_element?(view, ".collapse", "#{sub_obj_b.title}")
+      assert has_element?(view, ".collapse", "#{sub_obj_b.title}")
+
+      assert view
+             |> element("p.alert.alert-info")
+             |> render() =~
+               "Sub-objective successfully added"
+
+      assert 5 ==
+               project
+               |> ObjectiveEditor.fetch_objective_mappings()
+               |> length()
+
+      assert_receive {:finish_attachments, {_attachments, _flash_fn}}
+      assert_receive {:DOWN, _ref, :process, _pid, :normal}
+    end
+
+    test "new sub objective", %{conn: conn, project: project, publication: publication} do
+      title = "Sub Objective"
+      {:ok, obj} = create_objective(project, publication, "obj", "Objective")
+
+      {:ok, view, _html} = live(conn, live_view_route(project.slug, %{selected: obj.slug}))
+
+      view
+      |> element("button[phx-click=\"display_new_sub_modal\"][phx-value-slug=#{obj.slug}]")
+      |> render_click(%{slug: obj.slug})
+
+      view
+      |> element("form[phx-submit=\"new\"")
+      |> render_submit(%{"revision" => %{"title" => title, "parent_slug" => obj.slug}})
+
+      assert view
+             |> element("p.alert.alert-info")
+             |> render() =~
+               "Objective successfully created"
+
+      assert 2 ==
+               project
+               |> ObjectiveEditor.fetch_objective_mappings()
+               |> length()
+
+      assert has_element?(view, ".collapse", "#{title}")
+
+      assert_receive {:finish_attachments, {_attachments, _flash_fn}}
+      assert_receive {:DOWN, _ref, :process, _pid, :normal}
+    end
+
+    test "edit sub objective", %{conn: conn, project: project, publication: publication} do
+      title = "New title"
+      {:ok, sub_obj} = create_objective(project, publication, "sub_obj", "Sub Objective")
+
+      {:ok, obj} =
+        create_objective(project, publication, "obj", "Objective", [sub_obj.resource_id])
+
+      {:ok, view, _html} = live(conn, live_view_route(project.slug, %{selected: obj.slug}))
+
+      assert has_element?(view, "##{obj.slug}")
+      assert has_element?(view, ".collapse", "#{sub_obj.title}")
+
+      view
+      |> element("button[phx-click=\"display_edit_modal\"][phx-value-slug=#{sub_obj.slug}]")
+      |> render_click(%{"slug" => sub_obj.slug})
+
+      view
+      |> element("form[phx-submit=\"edit\"")
+      |> render_submit(%{"revision" => %{"title" => title, "slug" => sub_obj.slug}})
+
+      assert view
+             |> element("p.alert.alert-info")
+             |> render() =~
+               "Objective successfully updated"
+
+      assert 2 ==
+               project
+               |> ObjectiveEditor.fetch_objective_mappings()
+               |> length()
+
+      refute has_element?(view, ".collapse", "#{sub_obj.title}")
+      assert has_element?(view, ".collapse", "#{title}")
+
+      assert_receive {:finish_attachments, {_attachments, _flash_fn}}
+      assert_receive {:DOWN, _ref, :process, _pid, :normal}
+    end
+
+    test "remove sub objective with one parent", %{
+      conn: conn,
+      project: project,
+      publication: publication
+    } do
+      {:ok, sub_obj} = create_objective(project, publication, "sub_obj", "Sub Objective")
+
+      {:ok, obj} =
+        create_objective(project, publication, "obj", "Objective", [sub_obj.resource_id])
+
+      {:ok, view, _html} = live(conn, live_view_route(project.slug, %{selected: obj.slug}))
+
+      assert has_element?(view, "##{obj.slug}")
+      assert has_element?(view, ".collapse", "#{sub_obj.title}")
+
+      view
+      |> element("button[phx-click=\"delete\"][phx-value-slug=#{sub_obj.slug}]")
+      |> render_click(%{"slug" => sub_obj.slug, "parent_slug" => obj.slug})
+
+      assert view
+             |> element("p.alert.alert-info")
+             |> render() =~
+               "Objective successfully removed"
+
+      assert 1 ==
+               project
+               |> ObjectiveEditor.fetch_objective_mappings()
+               |> length()
+
+      refute has_element?(view, ".collapse", "#{sub_obj.title}")
+
+      assert_receive {:finish_attachments, {_attachments, _flash_fn}}
+      assert_receive {:DOWN, _ref, :process, _pid, :normal}
+    end
+
+    test "remove sub objective with more than one parent", %{
+      conn: conn,
+      project: project,
+      publication: publication
+    } do
+      {:ok, sub_obj} = create_objective(project, publication, "sub_obj", "Sub Objective")
+
+      {:ok, obj_a} =
+        create_objective(project, publication, "obj_a", "Objective A", [sub_obj.resource_id])
+
+      {:ok, obj_b} =
+        create_objective(project, publication, "obj_b", "Objective B", [sub_obj.resource_id])
+
+      {:ok, view, _html} = live(conn, live_view_route(project.slug, %{selected: obj_a.slug}))
+
+      assert has_element?(view, "##{obj_a.slug}")
+      assert has_element?(view, "##{obj_b.slug}")
+      assert has_element?(view, "##{obj_a.slug} .collapse", "#{sub_obj.title}")
+      assert has_element?(view, "##{obj_b.slug} .collapse", "#{sub_obj.title}")
+
+      view
+      |> element(
+        "button[phx-click=\"delete\"][phx-value-slug=#{sub_obj.slug}][phx-value-parent_slug=#{obj_a.slug}]"
+      )
+      |> render_click(%{"slug" => sub_obj.slug, "parent_slug" => obj_a.slug})
+
+      assert view
+             |> element("p.alert.alert-info")
+             |> render() =~
+               "Objective successfully removed"
+
+      assert 3 ==
+               project
+               |> ObjectiveEditor.fetch_objective_mappings()
+               |> length()
+
+      refute has_element?(view, "##{obj_a.slug} .collapse", "#{sub_obj.title}")
+      assert has_element?(view, "##{obj_b.slug} .collapse", "#{sub_obj.title}")
+
+      assert_receive {:finish_attachments, {_attachments, _flash_fn}}
+      assert_receive {:DOWN, _ref, :process, _pid, :normal}
+    end
+
+    test "renders links to revision history if #show_links is added to the url (being an admin)",
+         %{conn: conn, project: project, publication: publication} do
+      create_objective(project, publication, "obj_a", "Objective A")
+
+      conn =
+        get(conn, "/authoring/project/#{project.slug}/objectives#show_links")
+        |> Map.put(
+          :request_path,
+          "/authoring/project/#{project.slug}/curriculum#show_links"
+        )
+
+      {:ok, view, _html} = live(conn)
+
+      assert render(view) =~ "View revision history"
+    end
+
+    test "does not render links to revision history if #show_links is not added to the url (being an admin)",
+         %{conn: conn, project: project, publication: publication} do
+      create_objective(project, publication, "obj_a", "Objective A")
+
+      conn = get(conn, "/authoring/project/#{project.slug}/objectives")
+
+      {:ok, view, _html} = live(conn)
+
+      refute render(view) =~ "View revision history"
+    end
+  end
+end

--- a/test/oli_web/live/workspace/course_author_test.exs
+++ b/test/oli_web/live/workspace/course_author_test.exs
@@ -538,6 +538,23 @@ defmodule OliWeb.Workspace.CourseAuthorTest do
       assert has_element?(view, "div", "Improve")
       assert has_element?(view, "div", "Insights")
     end
+
+    test "objectives menu is shown correctly", %{
+      conn: conn,
+      project: project
+    } do
+      {:ok, view, _html} = live(conn, ~p"/workspaces/course_author/#{project.slug}/objectives")
+
+      assert has_element?(view, "h3", "Learning Objectives")
+
+      assert has_element?(
+               view,
+               "p",
+               "Learning objectives help you to organize course content and determine appropriate assessments and instructional strategies."
+             )
+
+      assert has_element?(view, "button", "Create new Objective")
+    end
   end
 
   defp create_project_with_owner(owner, attrs \\ %{}) do


### PR DESCRIPTION
[MER-3593](https://eliterate.atlassian.net/browse/MER-3593)

This PR migrates the `Objectives` liveview to be accessible from the new menu for the course author.

Also, it fixes an overflow bug where the `Exit Project` button was hidden in the sidebar if you expand the course author menu items. 


https://github.com/user-attachments/assets/9b0576a4-b7e1-435a-989e-75933f044c15



[MER-3303]: https://eliterate.atlassian.net/browse/MER-3303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MER-3593]: https://eliterate.atlassian.net/browse/MER-3593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ