### PR TITLE
[BUG FIX] [MER-3625] duplicated pages retain previous revision id to the parent resource

### DIFF
--- a/lib/oli/authoring/editing/container_editor.ex
+++ b/lib/oli/authoring/editing/container_editor.ex
@@ -394,6 +394,7 @@ defmodule Oli.Authoring.Editing.ContainerEditor do
       |> Map.drop([:slug, :inserted_at, :updated_at, :resource_id, :resource])
       |> Map.put(:title, "#{original_page.title} (copy)")
       |> Map.put(:content, nil)
+      |> Map.put(:previous_revision_id, nil)
       |> then(fn map ->
         if is_nil(map.legacy) do
           map

--- a/lib/oli/versioning/revision_tree/tree.ex
+++ b/lib/oli/versioning/revision_tree/tree.ex
@@ -78,32 +78,41 @@ defmodule Oli.Versioning.RevisionTree.Tree do
         nodes
 
       id ->
-        # There is a previous revision, so lets first check to see if the previous
-        # is a revision that we have encountered before (by tracing back from another head).
-        previous = Map.get(by_id, id)
-
-        case Map.get(nodes, previous.id) do
-          # We haven't encountered it yet, so we simply create a new tree node, store it and
-          # continue tracking backwards into the previous
+        # Identified in MER-3625, duplicate revisions created in the system prior to the
+        # fix will have a previous revision that points to the old resource revision. This
+        # is a special case where we simply ignore the previous revision that is not in the
+        # set of revisions we are tracking for the current resource.
+        case Map.get(by_id, id) do
           nil ->
-            previous_node = %Node{
-              revision: previous,
-              children: [child_node.revision.id],
-              project_id: project.id
-            }
+            nodes
 
-            nodes = Map.put(nodes, previous.id, previous_node)
-            track_back(previous_node, by_id, project, nodes)
+          previous ->
+            # There is a previous revision, so lets first check to see if the previous
+            # is a revision that we have encountered before (by tracing back from another head).
 
-          # We have encountered this previous revision already so this previous represents a
-          # "fork" point in our revision history - simply update the children node to wire in this
-          # new descendent path
-          node ->
-            Map.put(nodes, previous.id, %Node{
-              revision: node.revision,
-              children: node.children ++ [child_node.revision.id],
-              project_id: node.project_id
-            })
+            case Map.get(nodes, previous.id) do
+              # We haven't encountered it yet, so we simply create a new tree node, store it and
+              # continue tracking backwards into the previous
+              nil ->
+                previous_node = %Node{
+                  revision: previous,
+                  children: [child_node.revision.id],
+                  project_id: project.id
+                }
+
+                nodes = Map.put(nodes, previous.id, previous_node)
+                track_back(previous_node, by_id, project, nodes)
+
+              # We have encountered this previous revision already so this previous represents a
+              # "fork" point in our revision history - simply update the children node to wire in this
+              # new descendent path
+              node ->
+                Map.put(nodes, previous.id, %Node{
+                  revision: node.revision,
+                  children: node.children ++ [child_node.revision.id],
+                  project_id: node.project_id
+                })
+            end
         end
     end
   end

--- a/lib/oli_web/live/history/revision_history.ex
+++ b/lib/oli_web/live/history/revision_history.ex
@@ -59,7 +59,21 @@ defmodule OliWeb.RevisionHistory do
     Subscriber.subscribe_to_new_publications(project_slug)
 
     revisions = fetch_all_revisions(resource_id)
-    root = Enum.filter(revisions, fn r -> is_nil(r.previous_revision_id) end) |> hd
+
+    dbg(revisions)
+
+    root =
+      case Enum.filter(revisions, fn r -> is_nil(r.previous_revision_id) end) do
+        [r | _] ->
+          r
+
+        _ ->
+          # revisions are returned in descending order, so the last one is considered the root
+          List.last(revisions)
+      end
+
+    dbg(root)
+
     tree = Oli.Versioning.RevisionTree.Tree.build(revisions, resource_id)
 
     mappings = Publishing.get_all_mappings_for_resource(resource_id, project_slug)


### PR DESCRIPTION
Fixes an issue where duplicated pages retain the previous revision id by setting this field to nil on duplication. This PR also addresses the fact that there are instances of this out in the wild and the revision history tool is now more resilient to handling these cases