### PR TITLE
[BUG FIX] [MER-3630] ensure all required non hierarchical resource records are created when remixing

### DIFF
--- a/lib/oli/analytics/by_activity.ex
+++ b/lib/oli/analytics/by_activity.ex
@@ -41,6 +41,7 @@ defmodule Oli.Analytics.ByActivity do
         number_of_attempts: analytics.number_of_attempts,
         relative_difficulty: analytics.relative_difficulty
       },
-      preload: [:resource_type]
+      preload: [:resource_type],
+      distinct: [activity]
   end
 end

--- a/lib/oli/analytics/by_page.ex
+++ b/lib/oli/analytics/by_page.ex
@@ -65,7 +65,8 @@ defmodule Oli.Analytics.ByPage do
         number_of_attempts: analytics.number_of_attempts,
         relative_difficulty: analytics.relative_difficulty
       },
-      preload: [:resource_type]
+      preload: [:resource_type],
+      distinct: [activity]
     )
   end
 

--- a/lib/oli/delivery/page/objectives_rollup.ex
+++ b/lib/oli/delivery/page/objectives_rollup.ex
@@ -20,9 +20,7 @@ defmodule Oli.Delivery.Page.ObjectivesRollup do
   end
 
   defp rollup(attached_objective_ids, resolver, section_slug) do
-    all =
-      resolver.from_resource_id(section_slug, attached_objective_ids)
-      |> Enum.reject(&is_nil(&1))
+    all = resolver.from_resource_id(section_slug, attached_objective_ids)
 
     parents = resolver.find_parent_objectives(section_slug, attached_objective_ids)
 

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -2358,8 +2358,7 @@ defmodule Oli.Delivery.Sections do
       # create any remaining section resources which are not in the hierarchy
       create_nonstructural_section_resources(section.id, [publication_id],
         skip_resource_ids: processed_ids,
-        required_survey_resource_id: survey_id,
-        reference_activity_ids: []
+        required_survey_resource_id: survey_id
       )
 
       root_section_resource_id = section_resources_by_resource_id[root_resource_id].id
@@ -2857,15 +2856,10 @@ defmodule Oli.Delivery.Sections do
         |> select([p], p.required_survey_resource_id)
         |> Repo.one()
 
-      reference_activity_ids = build_reference_activity_ids(hierarchy.children)
-
-      if length(processed_resource_ids) != 1 do
-        create_nonstructural_section_resources(section_id, publication_ids,
-          skip_resource_ids: processed_resource_ids,
-          required_survey_resource_id: survey_id,
-          reference_activity_ids: reference_activity_ids
-        )
-      end
+      create_nonstructural_section_resources(section_id, publication_ids,
+        skip_resource_ids: processed_resource_ids,
+        required_survey_resource_id: survey_id
+      )
 
       # Rebuild section previous next index
       PreviousNextIndex.rebuild(section, hierarchy)
@@ -2876,62 +2870,6 @@ defmodule Oli.Delivery.Sections do
       section_resources
     end)
   end
-
-  defp build_reference_activity_ids([]), do: []
-
-  defp build_reference_activity_ids(children_activities) do
-    tuple_of_children_activities =
-      process_activity_ids(children_activities)
-
-    tuple_of_children_activities
-    |> Tuple.to_list()
-    |> Enum.concat()
-  end
-
-  defp process_activity_ids(children_activities) do
-    children_activities
-    |> Enum.reduce({[], []}, fn r, {children_unit_activities_ids, children_activities_ids} ->
-      new_children_unit_activities_ids = build_child_activity_ids_for_units(r.children)
-
-      if Map.has_key?(r.revision, :content) do
-        new_children_activities_ids = build_child_activity_ids(r.revision.content)
-
-        {children_unit_activities_ids ++ new_children_unit_activities_ids,
-         children_activities_ids ++ new_children_activities_ids}
-      else
-        {children_unit_activities_ids ++ new_children_unit_activities_ids,
-         children_activities_ids ++ []}
-      end
-    end)
-  end
-
-  defp build_child_activity_ids_for_units([]), do: []
-
-  defp build_child_activity_ids_for_units(children) do
-    children
-    |> Enum.map(fn c ->
-      if Map.has_key?(c.revision, :content) do
-        build_child_activity_ids(c.revision.content)
-      else
-        []
-      end
-    end)
-    |> List.flatten()
-  end
-
-  defp build_child_activity_ids(%{"model" => nil}), do: []
-
-  defp build_child_activity_ids(%{"model" => model}) do
-    model
-    |> Enum.reduce([], fn item, activity_ids ->
-      case item["activity_id"] do
-        nil -> activity_ids
-        activity_id -> [activity_id | activity_ids]
-      end
-    end)
-  end
-
-  defp build_child_activity_ids(_), do: []
 
   def get_contained_pages(%Section{id: section_id}) do
     from(cp in ContainedPage,
@@ -3722,11 +3660,10 @@ defmodule Oli.Delivery.Sections do
   # any that belong to the resource ids in skip_resource_ids
   defp create_nonstructural_section_resources(section_id, publication_ids,
          skip_resource_ids: skip_resource_ids,
-         required_survey_resource_id: required_survey_resource_id,
-         reference_activity_ids: reference_activity_ids
+         required_survey_resource_id: required_survey_resource_id
        ) do
     published_resources_by_resource_id =
-      build_published_resources_by_resource_id(publication_ids, reference_activity_ids)
+      MinimalHierarchy.published_resources_map(publication_ids)
 
     now = DateTime.utc_now() |> DateTime.truncate(:second)
 
@@ -3769,14 +3706,6 @@ defmodule Oli.Delivery.Sections do
 
     Database.batch_insert_all(SectionResource, section_resource_rows)
   end
-
-  defp build_published_resources_by_resource_id(publication_ids, []),
-    do: MinimalHierarchy.published_resources_map(publication_ids)
-
-  defp build_published_resources_by_resource_id(publication_ids, list_children_section_ids),
-    do:
-      MinimalHierarchy.published_resources_map(publication_ids)
-      |> Map.take(list_children_section_ids)
 
   def is_structural?(%Revision{resource_type_id: resource_type_id}) do
     container = ResourceType.id_for_container()

--- a/lib/oli/publishing/delivery_resolver.ex
+++ b/lib/oli/publishing/delivery_resolver.ex
@@ -287,8 +287,7 @@ defmodule Oli.Publishing.DeliveryResolver do
       join: rev in Revision,
       on: rev.id == pr.revision_id,
       where: rev.resource_type_id == ^resource_type_id and rev.deleted == false,
-      select: rev,
-      distinct: [rev]
+      select: rev
     )
   end
 

--- a/lib/oli/utils/db_seeder.ex
+++ b/lib/oli/utils/db_seeder.ex
@@ -198,34 +198,14 @@ defmodule Oli.Seeder do
 
     create_published_resource(publication, container_resource, container_revision)
 
-    %{resource: _activity_resource, revision: activity_revision} =
-      create_activity(
-        %{
-          activity_type_id: Activities.get_registration_by_slug("oli_short_answer").id,
-          content: %{}
-        },
-        publication,
-        project,
-        author
-      )
-
     %{resource: page1, revision: revision1} =
       create_page("Page one", publication, project, author)
 
     %{resource: page2, revision: revision2} =
       create_page("Page two", publication, project, author, create_sample_content())
 
-    %{resource: page3, revision: revision3} =
-      create_page(
-        "Page three",
-        publication,
-        project,
-        author,
-        create_activity_content(activity_revision.resource_id)
-      )
-
     container_revision =
-      attach_pages_to([page1, page2, page3], container_resource, container_revision, publication)
+      attach_pages_to([page1, page2], container_resource, container_revision, publication)
 
     {:ok, pub1} = Publishing.publish_project(project, "some changes", author.id)
 
@@ -249,10 +229,8 @@ defmodule Oli.Seeder do
     |> Map.put(:container, %{resource: container_resource, revision: container_revision})
     |> Map.put(:page1, page1)
     |> Map.put(:page2, page2)
-    |> Map.put(:page3, page3)
     |> Map.put(:revision1, revision1)
     |> Map.put(:revision2, revision2)
-    |> Map.put(:revision3, revision3)
     |> Map.put(:section, section)
   end
 
@@ -1312,19 +1290,6 @@ defmodule Oli.Seeder do
           ]
         }
       ]
-    }
-  end
-
-  def create_activity_content(activity_resource_id) do
-    %{
-      "model" => [
-        %{
-          "type" => "activity-reference",
-          "activity_id" => activity_resource_id,
-          "custom" => %{}
-        }
-      ],
-      "advancedDelivery" => false
     }
   end
 

--- a/test/oli/delivery/analytics/analytics_test.exs
+++ b/test/oli/delivery/analytics/analytics_test.exs
@@ -100,7 +100,7 @@ defmodule Oli.Delivery.Analytics.AnalyticsTest do
     } do
       assert length(activity_query) == 4
       assert length(objective_query) == 2
-      assert length(page_query) == 5
+      assert length(page_query) == 4
     end
   end
 
@@ -310,7 +310,7 @@ defmodule Oli.Delivery.Analytics.AnalyticsTest do
       # Parent course should still have analytics after duplicating project
       assert Enum.count(objective_query) == 2
       assert Enum.count(activity_query) == 4
-      assert Enum.count(page_query) == 5
+      assert Enum.count(page_query) == 4
 
       # Duplicated course should not have analytics
 
@@ -341,7 +341,7 @@ defmodule Oli.Delivery.Analytics.AnalyticsTest do
 
       # 3 pages with no analytics
       page_insights = ByPage.query_against_project_slug(duplicated.slug, [])
-      assert Enum.count(page_insights) == 3
+      assert Enum.count(page_insights) == 1
 
       assert Enum.all?(page_insights, fn obj ->
                Enum.all?(insights_from_struct.(obj), &is_nil(&1))

--- a/test/oli/delivery/page/objectives_rollup_test.exs
+++ b/test/oli/delivery/page/objectives_rollup_test.exs
@@ -68,26 +68,9 @@ defmodule Oli.Delivery.Page.ObjectivesRollupTest do
         objectives: %{}
       }
 
-      map_2 =
-        Seeder.base_project_with_resource2()
-        |> Seeder.add_objective("objective from other project", :objective_from_other_project)
-
-      attrs4 = %{
-        title: "page1",
-        content: %{
-          "model" => [
-            %{"type" => "activity-reference", "activity_id" => Map.get(map, :a1).resource.id},
-            %{"type" => "activity-reference", "activity_id" => Map.get(map, :a2).resource.id}
-          ]
-        },
-        objectives: %{"attached" => [map_2.objective_from_other_project.resource.id]}
-      }
-
       Seeder.add_page(map, attrs, :p1)
       |> Seeder.add_page(attrs2, :p2)
       |> Seeder.add_page(attrs3, :p3)
-      |> Seeder.add_page(attrs4, :p3)
-      |> Seeder.add_page(attrs4, :p4)
     end
 
     test "rolls up correctly when directly attached to page",
@@ -124,15 +107,6 @@ defmodule Oli.Delivery.Page.ObjectivesRollupTest do
       assert [] ==
                ObjectivesRollup.rollup_objectives(
                  p3.revision,
-                 activity_revisions,
-                 Oli.Publishing.AuthoringResolver,
-                 project.slug
-               )
-
-      # Tests when objectives map contains objectives from other project
-      assert [] ==
-               ObjectivesRollup.rollup_objectives(
-                 p4.revision,
                  activity_revisions,
                  Oli.Publishing.AuthoringResolver,
                  project.slug

--- a/test/oli/delivery/page/objectives_rollup_test.exs
+++ b/test/oli/delivery/page/objectives_rollup_test.exs
@@ -79,7 +79,6 @@ defmodule Oli.Delivery.Page.ObjectivesRollupTest do
            p1: p1,
            p2: p2,
            p3: p3,
-           p4: p4,
            a1: a1,
            a2: a2
          } do

--- a/test/oli_web/live/delivery/instructor_dashboard/insights/content_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/insights/content_tab_test.exs
@@ -343,15 +343,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.ContentTabTest do
            instructor: instructor,
            conn: conn
          } do
-      %{
-        page1: page1,
-        revision1: revision1,
-        page2: page2,
-        revision2: revision2,
-        page3: page3,
-        revision3: revision3,
-        section: section
-      } =
+      %{page1: page1, revision1: revision1, page2: page2, revision2: revision2, section: section} =
         Oli.Seeder.base_project_with_pages()
 
       user_1 = insert(:user, %{given_name: "Lionel", family_name: "Messi"})
@@ -377,11 +369,6 @@ defmodule OliWeb.Delivery.InstructorDashboard.ContentTabTest do
       set_progress(section.id, page2.id, user_3.id, 0.8, revision2)
       set_progress(section.id, page2.id, user_4.id, 0.8, revision2)
 
-      set_progress(section.id, page3.id, user_1.id, 0.9, revision3)
-      set_progress(section.id, page3.id, user_2.id, 0.6, revision3)
-      set_progress(section.id, page3.id, user_3.id, 0, revision3)
-      set_progress(section.id, page3.id, user_4.id, 0.3, revision3)
-
       {:ok, view, _html} = live(conn, live_view_content_route(section.slug))
 
       progress =
@@ -391,7 +378,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.ContentTabTest do
         |> Floki.find(~s{.instructor_dashboard_table tr [data-progress-check]})
         |> Enum.map(fn div_tag -> Floki.text(div_tag) |> String.trim() end)
 
-      assert progress == ["45%", "80%", "45%"]
+      assert progress == ["45%", "80%"]
 
       ### links to students tab with page_id as url param
       links =

--- a/test/oli_web/live/delivery/instructor_dashboard/insights/content_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/insights/content_tab_test.exs
@@ -406,14 +406,6 @@ defmodule OliWeb.Delivery.InstructorDashboard.ContentTabTest do
           :insights,
           :content,
           %{page_id: page2.id}
-        ),
-        Routes.live_path(
-          OliWeb.Endpoint,
-          OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive,
-          section.slug,
-          :insights,
-          :content,
-          %{page_id: page3.id}
         )
       ]
 

--- a/test/oli_web/live/remix_section_test.exs
+++ b/test/oli_web/live/remix_section_test.exs
@@ -14,41 +14,6 @@ defmodule OliWeb.RemixSectionLiveTest do
   describe "remix section as admin" do
     setup [:setup_admin_session]
 
-    test "remix section remove a pege and verify activities of this page has been deleted", %{
-      conn: conn
-    } do
-      map =
-        Seeder.base_project_with_pages()
-
-      assert Sections.get_section_resource(map.section.id, map.revision3.resource_id).resource_id ==
-               map.revision3.resource_id
-
-      conn =
-        get(
-          conn,
-          Routes.live_path(OliWeb.Endpoint, OliWeb.Delivery.RemixSection, map.section.slug)
-        )
-
-      {:ok, view, _html} = live(conn)
-
-      node_children_uuids =
-        view
-        |> render()
-        |> Floki.parse_fragment!()
-        |> Floki.find(~s{button[phx-click="show_remove_modal"]})
-        |> Floki.attribute("phx-value-uuid")
-
-      open_modal_and_confirm_removal(node_children_uuids, view)
-
-      assert render(view) =~ "<p>There&#39;s nothing here.</p>"
-
-      view
-      |> element("#save")
-      |> render_click()
-
-      assert Sections.get_section_resource(map.section.id, map.revision3.resource_id) == nil
-    end
-
     test "mount as admin", %{
       conn: conn,
       map: %{
@@ -808,26 +773,7 @@ defmodule OliWeb.RemixSectionLiveTest do
   end
 
   defp setup_admin_session(%{conn: conn}) do
-    map =
-      Seeder.base_project_with_resource4()
-      |> Seeder.add_activity(%{title: "one"}, :publication, :project, :author, :a1)
-
-    attrs = %{
-      title: "page1",
-      content: %{
-        "model" => [
-          %{
-            "type" => "activity-reference",
-            "activity_id" => Map.get(map, :a1).resource.id,
-            "custom" => %{}
-          }
-        ],
-        "advancedDelivery" => false
-      },
-      graded: false
-    }
-
-    map = Seeder.add_page(map, attrs, :p1)
+    map = Seeder.base_project_with_resource4()
 
     admin = author_fixture(%{system_role_id: Oli.Accounts.SystemRole.role_id().system_admin})
 
@@ -855,9 +801,7 @@ defmodule OliWeb.RemixSectionLiveTest do
 
     author = insert(:author, %{email: "my_custom@email.com"})
 
-    proj_1 =
-      insert(:project, title: "Project 1", authors: [author])
-
+    proj_1 = insert(:project, title: "Project 1", authors: [author])
     proj_2 = insert(:project, title: "Project 2", authors: [author])
     proj_3 = insert(:project, title: "Project 3", authors: [author])
     proj_4 = insert(:project, title: "Project 4", authors: [author])
@@ -974,8 +918,7 @@ defmodule OliWeb.RemixSectionLiveTest do
   end
 
   defp setup_instructor_session(%{conn: conn}) do
-    map =
-      Seeder.base_project_with_resource4()
+    map = Seeder.base_project_with_resource4()
 
     {:ok, instructor} =
       Accounts.update_user_platform_roles(


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-3630

Fixes an issue where delivery resolver was not properly including all required resources remixed into a section, such as objectives and nested activities. This was resulting in resolver failures in delivery, cause 500 errors for students.

The fix here is to revert commit https://github.com/Simon-Initiative/oli-torus/commit/32498051478aaab4ccd54d27525b2a10899cc336

Once deployed, an admin will have to take the additional step of "remixing" the affected course section(s). It is sufficient to drag/move an item around, then move it back and click "Save" which will trigger the required rebuild_section_resources step and resolve the issue.

Finally, this PR reverts the changes made in https://eliterate.atlassian.net/browse/MER-3624 since they are no longer necessary.