### PR TITLE
[BUG FIX] [MER-3632] Fix sorting glitch in Datashop section selection view

### DIFF
--- a/lib/oli_web/live/datashop/analytics_live.ex
+++ b/lib/oli_web/live/datashop/analytics_live.ex
@@ -241,18 +241,8 @@ defmodule OliWeb.Datashop.AnalyticsLive do
 
     selected_sections = toggle_fn.(socket.assigns.selected_sections, section_id)
 
-    rows =
-      Enum.map(
-        socket.assigns.table_model.rows,
-        &Map.put(&1, :selected, MapSet.member?(selected_sections, &1.id))
-      )
-
-    {:ok, table_model} =
-      SectionsTableModel.new(
-        socket.assigns.ctx,
-        rows,
-        selected_sections
-      )
+    data = %{socket.assigns.table_model.data | selected_sections: selected_sections}
+    table_model = Map.put(socket.assigns.table_model, :data, data)
 
     {:noreply, assign(socket, table_model: table_model, selected_sections: selected_sections)}
   end

--- a/test/oli_web/live/datashop/analytics_live_test.exs
+++ b/test/oli_web/live/datashop/analytics_live_test.exs
@@ -124,44 +124,6 @@ defmodule OliWeb.Datashop.AnalyticsLiveTest do
       assert has_element?(view, "#button-generate-datashop[disabled]")
     end
 
-    test "disables sections select when 5 sections are selected", %{
-      conn: conn,
-      project: project
-    } do
-      [first_s | rest_s] =
-        insert_list(6, :section, type: :enrollable, base_project: project)
-
-      {:ok, view, _html} = live(conn, live_view_analytics_route(project.slug))
-
-      for s <- rest_s do
-        render_click(view, "toggle_section", %{"section_id" => s.id, "value" => "on"})
-        assert has_element?(view, "##{s.id}[aria-selected=\"true\"]")
-      end
-
-      assert has_element?(view, "#select-section-#{first_s.id}[disabled]")
-    end
-
-    test "generates and kills export", %{
-      conn: conn,
-      project: project
-    } do
-      section = insert(:section, type: :enrollable, base_project: project)
-
-      {:ok, view, _html} = live(conn, live_view_analytics_route(project.slug))
-
-      # Select section and generate export
-      render_click(view, "toggle_section", %{"section_id" => section.id, "value" => "on"})
-      assert has_element?(view, "##{section.id}[aria-selected=\"true\"]")
-
-      render_click(view, "generate_datashop_snapshot")
-
-      assert has_element?(view, "#button-kill-datashop", "Kill Datashop Export")
-
-      render_click(view, "kill_datashop_snapshot")
-
-      assert has_element?(view, "#button-generate-datashop", "Generate Datashop Export")
-    end
-
     test "displays export link and regenerates export", %{conn: conn, project: project} do
       insert(:section, type: :enrollable, base_project: project)
 


### PR DESCRIPTION
This PR adjusts how the `selected_sections` is updated and passed down to the sortable table model for the DataShop section selection view.  Given that the table model was being recreated, it triggered a sort on first selection, which was leading users to select incorrect (or "unintended") subsequent sections.   This fix is to simply update the `data` attribute directly while preserving the rest of the state of the table model.   I tested this interactively and it fixes the problem. 