### PR TITLE
[BUG FIX] [MER-3631] Fix rendering issues with cognito/open and free routes (Re-targeted to v0.28.4)

### DIFF
--- a/lib/oli_web/templates/open_and_free/form.html.eex
+++ b/lib/oli_web/templates/open_and_free/form.html.eex
@@ -6,7 +6,7 @@
   <% end %>
 
   <% # Only show source if creating a new section (not editing) %>
-  <%= @action == Routes.independent_sections_path(@conn, :create) do %>
+  <%= if @action == Routes.independent_sections_path(@conn, :create) do %>
     <%= hidden_input f, :source_id, value: @source_id %>
 
     <div class="form-label-group">

--- a/lib/oli_web/templates/open_and_free/show.html.eex
+++ b/lib/oli_web/templates/open_and_free/show.html.eex
@@ -21,7 +21,7 @@
       </tr>
       <tr>
         <td><strong>URL:</strong></td>
-        <td><%= external_link Routes.page_delivery_url(@conn, :index, @section.slug), to: Routes.page_delivery_url(@conn, :index, @section.slug) %></td>
+        <td><%= url(~p"/sections/#{@section.slug}") %></td>
       </tr>
       <tr>
         <td><strong>Start Date:</strong></td>
@@ -57,7 +57,7 @@
   </table>
   <p class="mb-2">
     <h5>Remix</h5>
-    <%= link "Curriculum Remix", to: Routes.open_and_free_remix_path(OliWeb.Endpoint, OliWeb.Delivery.RemixSection, @section.slug), class: "btn btn-sm btn-primary" %>
+    <%= link "Curriculum Remix", to: Routes.live_path(OliWeb.Endpoint, OliWeb.Delivery.RemixSection, @section.slug), class: "btn btn-sm btn-primary" %>
   </p>
   <p>
     <h5>Manage Source Materials</h5>

--- a/test/oli_web/controllers/open_and_free_controller_test.exs
+++ b/test/oli_web/controllers/open_and_free_controller_test.exs
@@ -1,0 +1,74 @@
+defmodule OliWeb.OpenAndFreeControllerTest do
+  use OliWeb.ConnCase
+
+  @create_attrs %{
+    end_date: ~U[2010-04-17 00:00:00.000000Z],
+    open_and_free: true,
+    registration_open: true,
+    start_date: ~U[2010-04-17 00:00:00.000000Z],
+    title: "some title",
+    context_id: "some context_id"
+  }
+
+  @invalid_attrs %{
+    end_date: nil,
+    open_and_free: nil,
+    registration_open: nil,
+    start_date: nil,
+    title: nil,
+    context_id: nil
+  }
+
+  describe "create independent section" do
+    setup [:create_project_with_products, :instructor_conn]
+
+    test "show create form for product", %{
+      conn: conn,
+      product_1: product_1
+    } do
+      conn =
+        get(conn, ~p"/sections/independent/new?source_id=product%3A#{product_1.id}")
+
+      assert html_response(conn, 200) =~ "Create Section"
+
+      assert html_response(conn, 200) =~
+               "<input id=\"section_source_id\" name=\"section[source_id]\" type=\"hidden\" value=\"product:#{product_1.id}\">"
+
+      assert html_response(conn, 200) =~ "<input type=\"text\" value=\"Product 1\""
+    end
+
+    test "create section from product redirects to instructor dashboard manage page", %{
+      conn: conn,
+      product_1: product_1
+    } do
+      conn =
+        post(conn, ~p"/sections/independent",
+          section:
+            Enum.into(@create_attrs, %{
+              product_slug: product_1.slug,
+              source_id: "product:#{product_1.id}"
+            })
+        )
+
+      %{section_slug: section_slug} = redirected_params(conn)
+
+      assert redirected_to(conn) == ~p"/sections/#{section_slug}/manage"
+    end
+
+    test "renders errors when data is invalid", %{
+      conn: conn,
+      product_1: product_1
+    } do
+      conn =
+        post(conn, ~p"/sections/independent",
+          section:
+            Enum.into(@invalid_attrs, %{
+              product_slug: product_1.slug,
+              source_id: "product:#{product_1.id}"
+            })
+        )
+
+      assert html_response(conn, 200) =~ "Create Section"
+    end
+  end
+end


### PR DESCRIPTION
**Re-targeted to v0.28.4**

https://eliterate.atlassian.net/browse/MER-3631

Fixes a rendering issue with cognito workflow in the open and free routes, resulting in 500 error. I added some basic test coverage here around these routes as well.

I suspect some of the resources routes that exist for /sections/independent such as :show and :edit are now obsolete with the new system workflows, as section viewing/editing now takes place from the instructor dashboard live view. I left these in for now but we likely want to remove them in the future.