### PR TITLE
[BUG FIX] [MER-3635] Fix 500 error copied project source materials

### DIFF
--- a/lib/oli/authoring/clone.ex
+++ b/lib/oli/authoring/clone.ex
@@ -11,8 +11,8 @@ defmodule Oli.Authoring.Clone do
   alias Oli.Authoring.Authors.AuthorProject
   alias Oli.Delivery.Sections.Blueprint
 
-  def clone_bluprints(blueprints) do
-    Enum.map(blueprints, &Blueprint.duplicate/1)
+  def clone_blueprints(blueprints, cloned_publication_id) do
+    Enum.map(blueprints, &Blueprint.duplicate(&1, %{}, cloned_publication_id))
   end
 
   def clone_project(project_slug, author, opts \\ []) do
@@ -54,7 +54,7 @@ defmodule Oli.Authoring.Clone do
            _ <- clone_all_project_activity_registrations(base_project.id, cloned_project.id),
            Blueprint.get_blueprint_by_base_project(base_project)
            |> Enum.map(fn blueprint -> %{blueprint | base_project_id: cloned_project.id} end)
-           |> clone_bluprints() do
+           |> clone_blueprints(cloned_publication.id) do
         cloned_project
       else
         {:error, error} -> Repo.rollback(error)


### PR DESCRIPTION
[MER-3635](https://eliterate.atlassian.net/browse/MER-3635)

This PR fixes the error happening when an user creates a section from a product which is contained in a cloned project.

We found two issues that have been fixed: 

- publication_id when a product is cloned. 

- project_id is fixed when section_resources for the new product are created.

@eliknebel we also noticed that when new materials are added, published, and then those updates are applied in the cloned product, the updates do not appear. This is a potential issue that we might need to follow up on.


[MER-3635]: https://eliterate.atlassian.net/browse/MER-3635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ