### PR TITLE
[BUG FIX] [MER-3665] Properly handle `:revised` page attempt states

### DIFF
--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -63,8 +63,8 @@ defmodule OliWeb.Delivery.Student.LessonLive do
   def mount(
         _params,
         _session,
-        %{assigns: %{view: :graded_page, page_context: %{progress_state: :in_progress}}} = socket
-      ) do
+        %{assigns: %{view: :graded_page, page_context: %{progress_state: progress_state}}} = socket
+      ) when progress_state in [:revised, :in_progress] do
     %{page_context: page_context} = socket.assigns
 
     emit_page_viewed_event(socket)
@@ -99,9 +99,9 @@ defmodule OliWeb.Delivery.Student.LessonLive do
   def mount(
         _params,
         _session,
-        %{assigns: %{view: :adaptive_chromeless, page_context: %{progress_state: :in_progress}}} =
+        %{assigns: %{view: :adaptive_chromeless, page_context: %{progress_state: progress_state}}} =
           socket
-      ) do
+      ) when progress_state in [:revised, :in_progress] do
     emit_page_viewed_event(socket)
 
     if connected?(socket) do
@@ -732,7 +732,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
     """
   end
 
-  def render(%{view: :graded_page, page_context: %{progress_state: :in_progress}} = assigns) do
+  def render(%{view: :graded_page, page_context: %{progress_state: progress_state}} = assigns) when progress_state in [:revised, :in_progress] do
     # For graded page with attempt in progress the activity scripts and activity_bridge script are needed as soon as the page loads.
     ~H"""
     <div class="flex pb-20 flex-col w-full items-center gap-15 flex-1 overflow-auto">
@@ -797,8 +797,8 @@ defmodule OliWeb.Delivery.Student.LessonLive do
   end
 
   def render(
-        %{view: :adaptive_chromeless, page_context: %{progress_state: :in_progress}} = assigns
-      ) do
+        %{view: :adaptive_chromeless, page_context: %{progress_state: progress_state}} = assigns
+      ) when progress_state in [:revised, :in_progress] do
     ~H"""
     <!-- ACTIVITIES -->
     <%= for %{slug: slug, authoring_script: script} <- @activity_types do %>

--- a/lib/oli_web/live_session_plugs/redirect_to_prologue.ex
+++ b/lib/oli_web/live_session_plugs/redirect_to_prologue.ex
@@ -22,7 +22,7 @@ defmodule OliWeb.LiveSessionPlugs.RedirectToPrologue do
         socket
       ) do
     case socket.assigns.page_context do
-      %PageContext{progress_state: progress_state} when progress_state != :in_progress ->
+      %PageContext{progress_state: progress_state} when progress_state not in [:revised, :in_progress] ->
         {:halt,
          redirect(socket,
            to:


### PR DESCRIPTION
During a visit to a lesson page, the `progress_state` field of the `PageContext` gets loaded with the current state of the page attempt for that student.  The valid states here are `[:in_progress, :not_started, :revised]`.   The first two are fairly obvious in the meaning, but the `:revised` state indicates that while there is a page attempt in progress, the underlying revision of the page has changed in a new publication since the students last visit to the page.  This state indicator allows downstream code to create a new page attempts (for practice pages) and to allow a student to still finish their existing attempt (for graded pages). 

The new `LessonLive` infrastructure did not take into account this `:revised` state.  So any student that goes back into a page attempt after it has been revised ends up being unable to proceed - as the `RedirectToPrologue` live session plug erroneously would redirect to the prologue page.  

The fix here is to handle both `:in_progress` and `:revised` states in that live session plug and also in a few places in the `LessonLive`.  