### PR TITLE
[BUG FIX] [MER-3666] Mark as deleted instead of trying to hard delete course section

### DIFF
--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -569,7 +569,7 @@ defmodule OliWeb.Sections.OverviewView do
           if socket.assigns.section_has_student_data do
             {&Sections.update_section(&1, %{status: :archived}), "archived"}
           else
-            {&Sections.delete_section/1, "deleted"}
+            {&Sections.update_section(&1, %{status: :deleted}), "deleted"}
           end
 
         case action_function.(socket.assigns.section) do


### PR DESCRIPTION
This PR changes the attempt to hard delete a course section to the soft delete mechanism. 