### PR TITLE
[FEATURE] [MER-3594] Migrate activity bank liveview

### DIFF
--- a/assets/src/apps/Components.tsx
+++ b/assets/src/apps/Components.tsx
@@ -20,6 +20,7 @@ import { globalStore } from 'state/store';
 import { VideoPlayer } from '../components/video_player/VideoPlayer';
 import { OfflineDetector } from './OfflineDetector';
 import { References } from './bibliography/References';
+import ActivityBank from './bank/ActivityBank';
 
 registerApplication('ModalDisplay', ModalDisplay, globalStore);
 registerApplication('DarkModeSelector', DarkModeSelector);
@@ -41,3 +42,4 @@ registerApplication('OfflineDetector', OfflineDetector, globalStore);
 registerApplication('RichTextEditor', RichTextEditor, globalStore);
 registerApplication('VegaLiteRenderer', VegaLiteRenderer, globalStore);
 registerApplication('LikertReportRenderer', LikertReportRenderer, globalStore);
+registerApplication('ActivityBank', ActivityBank, globalStore);

--- a/assets/src/apps/Components.tsx
+++ b/assets/src/apps/Components.tsx
@@ -19,8 +19,8 @@ import { registerApplication } from 'apps/app';
 import { globalStore } from 'state/store';
 import { VideoPlayer } from '../components/video_player/VideoPlayer';
 import { OfflineDetector } from './OfflineDetector';
-import { References } from './bibliography/References';
 import ActivityBank from './bank/ActivityBank';
+import { References } from './bibliography/References';
 
 registerApplication('ModalDisplay', ModalDisplay, globalStore);
 registerApplication('DarkModeSelector', DarkModeSelector);

--- a/lib/oli_web/live/workspaces/course_author/activity_bank_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/activity_bank_live.ex
@@ -33,6 +33,11 @@ defmodule OliWeb.Workspaces.CourseAuthor.ActivityBankLive do
   end
 
   @impl Phoenix.LiveView
+  def handle_params(_params, _url, socket) do
+    {:noreply, socket}
+  end
+
+  @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
     <script type="text/javascript" src={Routes.static_path(OliWeb.Endpoint, "/js/activitybank.js")}>

--- a/lib/oli_web/live/workspaces/course_author/activity_bank_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/activity_bank_live.ex
@@ -51,6 +51,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.ActivityBankLive do
         id: "activity-bank"
       ) %>
     </div>
+    <%= React.component(@ctx, "Components.ModalDisplay", %{}, id: "modal-display") %>
     """
   end
 end

--- a/lib/oli_web/live/workspaces/course_author/activity_bank_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/activity_bank_live.ex
@@ -20,8 +20,8 @@ defmodule OliWeb.Workspaces.CourseAuthor.ActivityBankLive do
            is_admin?: is_admin?,
            revision_history_link: is_admin?,
            scripts: Oli.Activities.get_activity_scripts(),
-           project_slug: project.slug,
-           project_title: project.title,
+           resource_slug: project.slug,
+           resource_title: project.title,
            active_workspace: :course_author,
            active_view: :activity_bank,
            ctx: ctx

--- a/lib/oli_web/live/workspaces/course_author/activity_bank_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/activity_bank_live.ex
@@ -6,6 +6,8 @@ defmodule OliWeb.Workspaces.CourseAuthor.ActivityBankLive do
   alias OliWeb.Common.React
   alias OliWeb.Router.Helpers, as: Routes
 
+  on_mount {OliWeb.LiveSessionPlugs.AuthorizeProject, :default}
+
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
     %{project: project, current_author: author, ctx: ctx} = socket.assigns

--- a/test/oli_web/live/workspace/course_author_test.exs
+++ b/test/oli_web/live/workspace/course_author_test.exs
@@ -555,6 +555,17 @@ defmodule OliWeb.Workspace.CourseAuthorTest do
 
       assert has_element?(view, "button", "Create new Objective")
     end
+
+    test "activity bank menu is shown correctly", %{
+      conn: conn,
+      project: project
+    } do
+      {:ok, view, _html} = live(conn, ~p"/workspaces/course_author/#{project.slug}/activity_bank")
+
+      # Since the Activity Bank liveview renders a React component, we can only check for the presence of the div that contains the React component
+      assert has_element?(view, ~s(#activity-bank))
+      assert has_element?(view, ~s(div[data-live-react-class='Components.ActivityBank']))
+    end
   end
 
   defp create_project_with_owner(owner, attrs \\ %{}) do


### PR DESCRIPTION
Do not merge until https://github.com/Simon-Initiative/oli-torus/pull/5025 is merged

[MER-3594](https://eliterate.atlassian.net/browse/MER-3594)

This PR migrates the `Activity Bank` liveview to be accessible from the new menu for the course author workspace. 

The React component that was previously rendered from the `ActivityBank` controller is kept, but in this case it is called from a new liveview.

https://github.com/user-attachments/assets/11ce66df-6580-4c46-9b4b-08c8cd92652e



[MER-3594]: https://eliterate.atlassian.net/browse/MER-3594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ