### PR TITLE
[BUG FIX] [MER-3670] Every page is loaded twice

### DIFF
--- a/lib/oli/delivery/page/page_context.ex
+++ b/lib/oli/delivery/page/page_context.ex
@@ -166,12 +166,16 @@ defmodule Oli.Delivery.Page.PageContext do
   and activities that may be present in the content of the page. This
   information is collected and then assembled in a fashion that can be given
   to a renderer.
+
+  The `opts` parameter is a keyword list that can contain the following options:
+  - track_access: a boolean that determines whether to track access to the page. Defaults to true.
   """
   def create_for_visit(
         %Section{slug: section_slug, id: section_id},
         page_slug,
         user,
-        datashop_session_id
+        datashop_session_id,
+        opts \\ [track_access: true]
       ) do
     # resolve the page revision per section
     page_revision = DeliveryResolver.from_revision_slug(section_slug, page_slug)
@@ -179,7 +183,8 @@ defmodule Oli.Delivery.Page.PageContext do
     effective_settings =
       Oli.Delivery.Settings.get_combined_settings(page_revision, section_id, user.id)
 
-    Attempts.track_access(page_revision.resource_id, section_id, user.id)
+    if opts[:track_access],
+      do: Attempts.track_access(page_revision.resource_id, section_id, user.id)
 
     activity_provider = &Oli.Delivery.ActivityProvider.provide/6
 

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -46,10 +46,9 @@ defmodule OliWeb.Delivery.Student.LessonLive do
         nil
       )
 
+      emit_page_viewed_event(socket)
       send(self(), :gc)
     end
-
-    emit_page_viewed_event(socket)
 
     {:ok,
      socket
@@ -67,9 +66,8 @@ defmodule OliWeb.Delivery.Student.LessonLive do
       ) do
     %{page_context: page_context} = socket.assigns
 
-    emit_page_viewed_event(socket)
-
     if connected?(socket) do
+      emit_page_viewed_event(socket)
       send(self(), :gc)
     end
 
@@ -102,9 +100,8 @@ defmodule OliWeb.Delivery.Student.LessonLive do
         %{assigns: %{view: :adaptive_chromeless, page_context: %{progress_state: :in_progress}}} =
           socket
       ) do
-    emit_page_viewed_event(socket)
-
     if connected?(socket) do
+      emit_page_viewed_event(socket)
       send(self(), :gc)
     end
 

--- a/lib/oli_web/live_session_plugs/init_page.ex
+++ b/lib/oli_web/live_session_plugs/init_page.ex
@@ -21,9 +21,10 @@ defmodule OliWeb.LiveSessionPlugs.InitPage do
         revision_slug,
         current_user,
         datashop_session_id,
-        # LiveView lifecycle will pass twice through this function when mounting the page,
-        # so we want to avoid tracking the access twice for the same page access.
-        track_access: Phoenix.LiveView.connected?(socket)
+        # to avoid triggering the tracking of the page access twice, we will only track it
+        # in the initial stateless HTTP Request (when the socket is not yet mounted)
+        # see https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html#module-life-cycle
+        track_access: !Phoenix.LiveView.connected?(socket)
       )
 
     {:cont,

--- a/lib/oli_web/live_session_plugs/init_page.ex
+++ b/lib/oli_web/live_session_plugs/init_page.ex
@@ -20,7 +20,10 @@ defmodule OliWeb.LiveSessionPlugs.InitPage do
         section,
         revision_slug,
         current_user,
-        datashop_session_id
+        datashop_session_id,
+        # LiveView lifecycle will pass twice through this function when mounting the page,
+        # so we want to avoid tracking the access twice for the same page access.
+        track_access: Phoenix.LiveView.connected?(socket)
       )
 
     {:cont,


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-3670) to the ticket

When a liveview is mounted the `mount` callback is called twice; one time when the HTTP request is received and then when the websocket connection is established (see [docs](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html#module-life-cycle)).
So, to avoid triggering the access track twice, I adapted the logic to do it when the HTTP request is first received.


### Before

https://github.com/user-attachments/assets/091cae4c-3b2c-4419-a2ca-3fabdcd0d839



### After

https://github.com/user-attachments/assets/e0baa8ca-8478-4b64-834f-c1ceb745658f



While working on the ticket I found that we were having a similar issue with the XAPI Events being sent twice. To fix this I wrapped the execution of that function in the `connected?(socket)` conditional.