### PR TITLE
[BUG FIX] [MER-3631] Trying to create a section from a product fails in certain cases

### DIFF
--- a/lib/oli/authoring/clone.ex
+++ b/lib/oli/authoring/clone.ex
@@ -11,8 +11,8 @@ defmodule Oli.Authoring.Clone do
   alias Oli.Authoring.Authors.AuthorProject
   alias Oli.Delivery.Sections.Blueprint
 
-  def clone_blueprints(blueprints) do
-    Enum.map(blueprints, &Blueprint.duplicate/1)
+  def clone_blueprints(blueprints, from_base_project_id) do
+    Enum.map(blueprints, &Blueprint.duplicate(&1, %{}, from_base_project_id))
   end
 
   def clone_project(project_slug, author, opts \\ []) do
@@ -54,7 +54,7 @@ defmodule Oli.Authoring.Clone do
            _ <- clone_all_project_activity_registrations(base_project.id, cloned_project.id),
            Blueprint.get_blueprint_by_base_project(base_project)
            |> Enum.map(fn blueprint -> %{blueprint | base_project_id: cloned_project.id} end)
-           |> clone_blueprints() do
+           |> clone_blueprints(base_project.id) do
         cloned_project
       else
         {:error, error} -> Repo.rollback(error)

--- a/lib/oli/authoring/clone.ex
+++ b/lib/oli/authoring/clone.ex
@@ -11,8 +11,8 @@ defmodule Oli.Authoring.Clone do
   alias Oli.Authoring.Authors.AuthorProject
   alias Oli.Delivery.Sections.Blueprint
 
-  def clone_blueprints(blueprints, cloned_publication_id) do
-    Enum.map(blueprints, &Blueprint.duplicate(&1, %{}, cloned_publication_id))
+  def clone_blueprints(blueprints) do
+    Enum.map(blueprints, &Blueprint.duplicate/1)
   end
 
   def clone_project(project_slug, author, opts \\ []) do
@@ -54,7 +54,7 @@ defmodule Oli.Authoring.Clone do
            _ <- clone_all_project_activity_registrations(base_project.id, cloned_project.id),
            Blueprint.get_blueprint_by_base_project(base_project)
            |> Enum.map(fn blueprint -> %{blueprint | base_project_id: cloned_project.id} end)
-           |> clone_blueprints(cloned_publication.id) do
+           |> clone_blueprints() do
         cloned_project
       else
         {:error, error} -> Repo.rollback(error)

--- a/lib/oli/utils/seeder/section.ex
+++ b/lib/oli/utils/seeder/section.ex
@@ -50,12 +50,14 @@ defmodule Oli.Utils.Seeder.Section do
   def create_section_from_product(
         seeds,
         product,
-        instructor,
-        institution,
+        instructor \\ nil,
+        institution \\ nil,
         attrs \\ %{},
         tags \\ []
       ) do
     [product, instructor, institution] = unpack(seeds, [product, instructor, institution])
+
+    section_tag = tags[:section_tag] || :section
 
     attrs =
       %{
@@ -82,7 +84,7 @@ defmodule Oli.Utils.Seeder.Section do
       end
 
     seeds
-    |> tag(tags[:section_tag], section)
+    |> tag(section_tag, section)
   end
 
   def create_and_enroll_learner(seeds, section, user_attrs \\ %{}, tags \\ []) do

--- a/test/oli/clone_test.exs
+++ b/test/oli/clone_test.exs
@@ -57,56 +57,65 @@ defmodule Oli.CloneTest do
       author2: author2,
       publication: publication
     } do
-      # Create a course section, one for each publication
-      {:ok, product} =
-        Sections.create_section(%{
-          title: "Product 1",
-          registration_open: true,
-          type: :blueprint,
-          context_id: UUID.uuid4(),
-          base_project_id: project.id,
-          publisher_id: project.publisher_id
-        })
-        |> then(fn {:ok, section} -> section end)
-        |> Sections.create_section_resources(publication)
+      # Create 2 products that are associated with the project
+      %{product_1: product_1, product_2: product_2} =
+        %{}
+        |> Oli.Utils.Seeder.Project.ensure_published(publication)
+        |> Oli.Utils.Seeder.Project.create_product("Product 1", project, product_tag: :product_1)
+        |> Oli.Utils.Seeder.Project.create_product("Product 2", project, product_tag: :product_2)
 
-      {:ok, cloned_project} = Clone.clone_project(project.slug, author2)
-      cloned_product = Sections.get_section_by(%{base_project_id: cloned_project.id})
-
-      assert cloned_project.title == project.title <> " Copy"
-      assert cloned_project.id != project.id
-
-      cloned_publication =
-        Sections.get_current_publication(cloned_product.id, cloned_project.id)
-
-      original_publication =
-        Sections.get_current_publication(product.id, project.id)
+      # Verify that the section_products_publications mapping is created and correct for the
+      # original products
+      assert Repo.get_by(Sections.SectionsProjectsPublications,
+               project_id: project.id,
+               section_id: product_1.id,
+               publication_id: publication.id
+             )
 
       assert Repo.get_by(Sections.SectionsProjectsPublications,
-               project_id: cloned_project.id,
-               section_id: cloned_product.id,
-               publication_id: cloned_publication.id
+               project_id: project.id,
+               section_id: product_2.id,
+               publication_id: publication.id
              )
 
-      refute Repo.get_by(Sections.SectionsProjectsPublications,
-               project_id: cloned_project.id,
-               section_id: cloned_product.id,
-               publication_id: original_publication.id
+      # Clone the project
+      {:ok, duplicated_project} = Clone.clone_project(project.slug, author2)
+
+      # Check if the products are cloned
+      duplicated_product_1 =
+        Sections.get_section_by(base_project_id: duplicated_project.id, title: "Product 1 Copy")
+
+      duplicated_product_2 =
+        Sections.get_section_by(base_project_id: duplicated_project.id, title: "Product 2 Copy")
+
+      assert duplicated_product_1
+      assert duplicated_product_2
+
+      # Verify that the section_products_publications mapping is created and correct for the
+      # duplicated products
+      assert Repo.get_by(Sections.SectionsProjectsPublications,
+               project_id: duplicated_project.id,
+               section_id: duplicated_product_1.id,
+               publication_id: publication.id
              )
 
-      project_id = project.id
-      cloned_project_id = cloned_project.id
+      assert Repo.get_by(Sections.SectionsProjectsPublications,
+               project_id: duplicated_project.id,
+               section_id: duplicated_product_2.id,
+               publication_id: publication.id
+             )
 
-      # SectionResources are created well
-      assert [^project_id] =
-               Sections.get_section_resources(product.id)
-               |> Enum.map(& &1.project_id)
-               |> Enum.uniq()
+      # Create a new section from duplicated product 1
+      %{section: section} =
+        %{}
+        |> Oli.Utils.Seeder.Section.create_section_from_product(duplicated_product_1)
 
-      assert [^cloned_project_id] =
-               Oli.Delivery.Sections.get_section_resources(cloned_product.id)
-               |> Enum.map(& &1.project_id)
-               |> Enum.uniq()
+      # Verify that the section_products_publications mapping is created and correct for the new section
+      assert Repo.get_by(Sections.SectionsProjectsPublications,
+               project_id: duplicated_project.id,
+               section_id: section.id,
+               publication_id: publication.id
+             )
     end
 
     test "already_has_clone?/2 and existing_clones/2 works", %{


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-3631

This PR fixes an issue with section creation from product by reverting some of the changes made in https://eliterate.atlassian.net/browse/MER-3635 (#5034)

The issue was blueprint duplication logic was attempting to duplicate/create create section_project_publication records, but the project id being used was not quite correct which was violating the uniqueness constraint of spp section_id and project_id.

This was resulting in an inability to create a new section from a Product with multiple other sibling products. This was apparent when testing the cogito/independent open and free section creation bug fixes by ETX.

The fix here is to identify the case where the spp record project_id equals the original base project id, and update the spp project id for the cloned spp records to be the base_project_id from the newly minted product/blueprint.

Also, a section created from a product should not use the latest publication available and instead should use the publication specified by the product, which is now accomplished by reverting some other changes from MER-3635.