### PR TITLE
[BUG FIX] [MER-3671] Adaptive page styles broken after lesson publishing - part 2

### DIFF
--- a/lib/oli_web/live_session_plugs/redirect_adaptive.ex
+++ b/lib/oli_web/live_session_plugs/redirect_adaptive.ex
@@ -53,8 +53,9 @@ defmodule OliWeb.LiveSessionPlugs.RedirectAdaptiveChromeless do
             "displayApplicationChrome" => false
           }
         },
-        progress_state: :in_progress
-      } ->
+        progress_state: progress_state
+      }
+      when progress_state in [:revised, :in_progress] ->
         {:halt,
          redirect(socket,
            to:

--- a/lib/oli_web/live_session_plugs/redirect_to_lesson.ex
+++ b/lib/oli_web/live_session_plugs/redirect_to_lesson.ex
@@ -22,7 +22,8 @@ defmodule OliWeb.LiveSessionPlugs.RedirectToLesson do
         socket
       ) do
     case socket.assigns.page_context do
-      %PageContext{progress_state: :in_progress} ->
+      %PageContext{progress_state: progress_state}
+      when progress_state in [:revised, :in_progress] ->
         {:halt,
          redirect(socket,
            to:

--- a/test/oli_web/live_session_plugs/redirect_adaptive_test.exs
+++ b/test/oli_web/live_session_plugs/redirect_adaptive_test.exs
@@ -98,6 +98,38 @@ defmodule OliWeb.LiveSessionPlugs.RedirectAdaptiveChromelessTest do
               }}
   end
 
+  test "redirects an adaptive chromeless page with an attempt in revised state" do
+    adaptive_chromeless_page_revision = adaptive_chromeless_page_revision()
+
+    {:halt, updated_socket} =
+      RedirectAdaptiveChromeless.on_mount(
+        :default,
+        %{
+          "section_slug" => "some-section-slug",
+          "revision_slug" => adaptive_chromeless_page_revision.slug,
+          "request_path" => "some-request-path",
+          "selected_view" => "gallery"
+        },
+        %{},
+        %Phoenix.LiveView.Socket{
+          assigns: %{
+            page_context:
+              build(:page_context,
+                page: adaptive_chromeless_page_revision,
+                progress_state: :revised
+              )
+          }
+        }
+      )
+
+    assert updated_socket.redirected ==
+             {:redirect,
+              %{
+                to:
+                  "/sections/some-section-slug/adaptive_lesson/#{adaptive_chromeless_page_revision.slug}?request_path=some-request-path&selected_view=gallery"
+              }}
+  end
+
   test "does not redirect a non-adaptive chromeless page review" do
     non_adaptive_chromeless_page_revision = page_revision()
 

--- a/test/oli_web/live_session_plugs/redirect_to_lesson_test.exs
+++ b/test/oli_web/live_session_plugs/redirect_to_lesson_test.exs
@@ -44,6 +44,38 @@ defmodule OliWeb.LiveSessionPlugs.RedirectToLessonTest do
               }}
   end
 
+  test "redirects a graded page to lesson page when page state is revised" do
+    graded_page_revision = graded_page_revision()
+
+    {:halt, updated_socket} =
+      RedirectToLesson.on_mount(
+        :default,
+        %{
+          "section_slug" => "some-section-slug",
+          "revision_slug" => graded_page_revision.slug,
+          "request_path" => "some-request-path",
+          "selected_view" => "gallery"
+        },
+        %{},
+        %Phoenix.LiveView.Socket{
+          assigns: %{
+            page_context:
+              build(:page_context,
+                page: graded_page_revision,
+                progress_state: :revised
+              )
+          }
+        }
+      )
+
+    assert updated_socket.redirected ==
+             {:redirect,
+              %{
+                to:
+                  "/sections/some-section-slug/lesson/#{graded_page_revision.slug}?request_path=some-request-path&selected_view=gallery"
+              }}
+  end
+
   test "does not redirect a graded page when page state is not in progress" do
     graded_page_revision = graded_page_revision()
 


### PR DESCRIPTION
[Link to the comment](https://eliterate.atlassian.net/browse/MER-3671?focusedCommentId=24029) in the ticket

#### Before

https://github.com/user-attachments/assets/8d2d38f3-046b-4a63-bb39-f6852fa19e22

#### After
https://github.com/user-attachments/assets/3e1bb083-26fa-441b-b628-bc9b72ca1fd3

The issue was identified after editing and publishing a page. So, when that event occurs, all active attempts of the edited page change their state from `:in_progress` to `revised`.
Since the `RedirectAdaptiveChromeless` livesession plug was not considering `:revised` states to perform the redirect, the user ended up in the `/lesson` route instead of the `/adaptive_lesson` one. Both layout templates for those routes are very similar, but the first one includes a modal, and that hidden modal was the one preventing the click from being correctly targeted to the dropdown.

The same fix was extended to the `RedirectToLesson` livesession plug.

All other cases were already addressed in [this PR](https://github.com/Simon-Initiative/oli-torus/pull/5036)


