### PR TITLE
[BUG FIX] [MER-3170] cannot change certain assessment options

### DIFF
--- a/lib/oli_web/components/hierarchy_selector.ex
+++ b/lib/oli_web/components/hierarchy_selector.ex
@@ -147,4 +147,8 @@ defmodule OliWeb.Components.HierarchySelector do
       {:noreply, socket}
     end
   end
+
+  def handle_event("validate-options", _params, socket) do
+    {:noreply, socket}
+  end
 end


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-3170

The cause of the issue here was "validation-options" event being fired in the HierarchyPicker LiveComponent. While it's not exactly clear to me why this was happening, handling this event with a NoOp seems to resolve the issue and restore correct function of the form.

The only downside to this approach is that HierarchyPicker now seems to have some implementation details from it's parent components leaking into it, but this should not cause any harm.

Longer term we should try to investigate why this is occurring and consider refactoring this view and component so that the HierarchyPicker can remain implementation agnostic to the parent components that are using it.