### PR TITLE
[FEATURE] [MER-3299] Instructor dashboard course view Rework 1

### DIFF
--- a/lib/oli_web/components/layouts/workspace.html.heex
+++ b/lib/oli_web/components/layouts/workspace.html.heex
@@ -6,7 +6,7 @@
     <div class={"mr-3 my-auto #{if assigns[:resource_title], do: "flex items-center justify-between w-full", else: "ml-auto"}"}>
       <div
         :if={assigns[:resource_title]}
-        class={"text-[#757682] font-medium #{if @sidebar_expanded, do: "ml-60", else: "ml-20"}"}
+        class={"text-[#757682] dark:text-[#FFF] font-medium #{if @sidebar_expanded, do: "ml-60", else: "ml-20"}"}
       >
         <%= @resource_title %>
       </div>

--- a/lib/oli_web/components/layouts/workspace.html.heex
+++ b/lib/oli_web/components/layouts/workspace.html.heex
@@ -6,7 +6,7 @@
     <div class={"mr-3 my-auto #{if assigns[:resource_title], do: "flex items-center justify-between w-full", else: "ml-auto"}"}>
       <div
         :if={assigns[:resource_title]}
-        class={"#{if @sidebar_expanded, do: "ml-60", else: "ml-20"}"}
+        class={"text-[#757682] font-medium #{if @sidebar_expanded, do: "ml-60", else: "ml-20"}"}
       >
         <%= @resource_title %>
       </div>

--- a/lib/oli_web/live/workspaces/utils.ex
+++ b/lib/oli_web/live/workspaces/utils.ex
@@ -117,7 +117,7 @@ defmodule OliWeb.Workspace.Utils do
   attr :is_active, :boolean, default: false
   attr :sidebar_expanded, :boolean, default: true
   attr :badge, :integer, default: nil
-  attr :on_active_bg, :string, default: "bg-zinc-400 bg-opacity-20"
+  attr :on_active_bg, :string, default: "bg-[#E6E9F2]"
   attr :sub_menu_item, :map
   attr :active_view, :atom, default: nil
 
@@ -127,7 +127,7 @@ defmodule OliWeb.Workspace.Utils do
 
     ~H"""
     <div class={[
-      "relative w-full h-9 px-3 py-3 dark:hover:bg-[#141416] hover:bg-zinc-400/10 rounded-lg justify-start items-center gap-3 inline-flex",
+      "relative w-full h-9 px-3 py-3 dark:hover:bg-[#141416] hover:bg-[#E6E9F2] rounded-lg justify-start items-center gap-3 inline-flex",
       if(@is_active, do: @on_active_bg)
     ]}>
       <div :if={@sub_menu_item.icon} class="w-5 h-5 flex items-center justify-center">
@@ -344,6 +344,16 @@ defmodule OliWeb.Workspace.Utils do
           %SubMenuItem{
             text: "Students",
             view: :students,
+            parent_view: :overview
+          },
+          %SubMenuItem{
+            text: "Quiz Scores",
+            view: :quiz_cores,
+            parent_view: :overview
+          },
+          %SubMenuItem{
+            text: "Recommended Actions",
+            view: :recommended_actions,
             parent_view: :overview
           }
         ]

--- a/lib/oli_web/live/workspaces/utils.ex
+++ b/lib/oli_web/live/workspaces/utils.ex
@@ -117,7 +117,7 @@ defmodule OliWeb.Workspace.Utils do
   attr :is_active, :boolean, default: false
   attr :sidebar_expanded, :boolean, default: true
   attr :badge, :integer, default: nil
-  attr :on_active_bg, :string, default: "bg-[#E6E9F2]"
+  attr :on_active_bg, :string, default: "bg-[#E6E9F2] dark:bg-[#222126]"
   attr :sub_menu_item, :map
   attr :active_view, :atom, default: nil
 
@@ -127,7 +127,7 @@ defmodule OliWeb.Workspace.Utils do
 
     ~H"""
     <div class={[
-      "relative w-full h-9 px-3 py-3 dark:hover:bg-[#141416] hover:bg-[#E6E9F2] rounded-lg justify-start items-center gap-3 inline-flex",
+      "relative w-full h-9 px-3 py-3 dark:hover:bg-[#222126] hover:bg-[#E6E9F2] rounded-lg justify-start items-center gap-3 inline-flex",
       if(@is_active, do: @on_active_bg)
     ]}>
       <div :if={@sub_menu_item.icon} class="w-5 h-5 flex items-center justify-center">

--- a/lib/oli_web/live/workspaces/utils.ex
+++ b/lib/oli_web/live/workspaces/utils.ex
@@ -221,64 +221,47 @@ defmodule OliWeb.Workspace.Utils do
       %SubMenuItem{
         text: "Overview",
         icon: "author_overview",
-        view: :overview,
-        parent_view: nil,
-        children: []
+        view: :overview
       },
       %SubMenuItem{
         text: "Create",
         icon: "author_create",
         view: :create,
-        parent_view: nil,
         children: [
           %SubMenuItem{
             text: "Objectives",
-            icon: nil,
             view: :objectives,
-            parent_view: :create,
-            children: []
+            parent_view: :create
           },
           %SubMenuItem{
             text: "Activity Bank",
-            icon: nil,
             view: :activity_bank,
-            parent_view: :create,
-            children: []
+            parent_view: :create
           },
           %SubMenuItem{
             text: "Experiments",
-            icon: nil,
             view: :experiments,
-            parent_view: :create,
-            children: []
+            parent_view: :create
           },
           %SubMenuItem{
             text: "Bibliography",
-            icon: nil,
             view: :bibliography,
-            parent_view: :create,
-            children: []
+            parent_view: :create
           },
           %SubMenuItem{
             text: "Curriculum",
-            icon: nil,
             view: :curriculum,
-            parent_view: :create,
-            children: []
+            parent_view: :create
           },
           %SubMenuItem{
             text: "All Pages",
-            icon: nil,
             view: :pages,
-            parent_view: :create,
-            children: []
+            parent_view: :create
           },
           %SubMenuItem{
             text: "All Activities",
-            icon: nil,
             view: :activities,
-            parent_view: :create,
-            children: []
+            parent_view: :create
           }
         ]
       },
@@ -286,28 +269,21 @@ defmodule OliWeb.Workspace.Utils do
         text: "Publish",
         icon: "author_publish",
         view: :author_publish,
-        parent_view: nil,
         children: [
           %SubMenuItem{
             text: "Review",
-            icon: nil,
             view: :review,
-            parent_view: :author_publish,
-            children: []
+            parent_view: :author_publish
           },
           %SubMenuItem{
             text: "Publish",
-            icon: nil,
             view: :publish,
-            parent_view: :author_publish,
-            children: []
+            parent_view: :author_publish
           },
           %SubMenuItem{
             text: "Products",
-            icon: nil,
             view: :products,
-            parent_view: :author_publish,
-            children: []
+            parent_view: :author_publish
           }
         ]
       },
@@ -315,14 +291,11 @@ defmodule OliWeb.Workspace.Utils do
         text: "Improve",
         icon: "author_improve",
         view: :improve,
-        parent_view: nil,
         children: [
           %SubMenuItem{
             text: "Insights",
-            icon: nil,
             view: :insights,
-            parent_view: :improve,
-            children: []
+            parent_view: :improve
           }
         ]
       }

--- a/test/oli_web/live/workspace/instructor/dashboard_live_test.exs
+++ b/test/oli_web/live/workspace/instructor/dashboard_live_test.exs
@@ -21,34 +21,34 @@ defmodule OliWeb.Workspace.Instructor.DashboardLiveTest do
       data_expected = %{
         1 =>
           {"Course Content",
-           "/workspaces/instructor/examplesection0/overview/course_content?sidebar_expanded=true"},
+           "/workspaces/instructor/#{section.slug}/overview/course_content?sidebar_expanded=true"},
         2 =>
           {"Students",
-           "/workspaces/instructor/examplesection0/overview/students?sidebar_expanded=true"},
+           "/workspaces/instructor/#{section.slug}/overview/students?sidebar_expanded=true"},
         3 =>
           {"Quiz Scores",
-           "/workspaces/instructor/examplesection0/overview/quiz_cores?sidebar_expanded=true"},
+           "/workspaces/instructor/#{section.slug}/overview/quiz_cores?sidebar_expanded=true"},
         4 =>
           {"Recommended Actions",
-           "/workspaces/instructor/examplesection0/overview/recommended_actions?sidebar_expanded=true"},
+           "/workspaces/instructor/#{section.slug}/overview/recommended_actions?sidebar_expanded=true"},
         5 =>
           {"Content",
-           "/workspaces/instructor/examplesection0/insights/content?sidebar_expanded=true"},
+           "/workspaces/instructor/#{section.slug}/insights/content?sidebar_expanded=true"},
         6 =>
           {"Learning Objectives",
-           "/workspaces/instructor/examplesection0/insights/learning_objectives?sidebar_expanded=true"},
+           "/workspaces/instructor/#{section.slug}/insights/learning_objectives?sidebar_expanded=true"},
         7 =>
           {"Scored Activities",
-           "/workspaces/instructor/examplesection0/insights/scored_activities?sidebar_expanded=true"},
+           "/workspaces/instructor/#{section.slug}/insights/scored_activities?sidebar_expanded=true"},
         8 =>
           {"Practice Activities",
-           "/workspaces/instructor/examplesection0/insights/practice_activities?sidebar_expanded=true"},
+           "/workspaces/instructor/#{section.slug}/insights/practice_activities?sidebar_expanded=true"},
         9 =>
           {"Surveys",
-           "/workspaces/instructor/examplesection0/insights/surveys?sidebar_expanded=true"},
-        10 => {"Manage", "/workspaces/instructor/examplesection0/manage?sidebar_expanded=true"},
+           "/workspaces/instructor/#{section.slug}/insights/surveys?sidebar_expanded=true"},
+        10 => {"Manage", "/workspaces/instructor/#{section.slug}/manage?sidebar_expanded=true"},
         11 =>
-          {"Activity", "/workspaces/instructor/examplesection0/activity?sidebar_expanded=true"}
+          {"Activity", "/workspaces/instructor/#{section.slug}/activity?sidebar_expanded=true"}
       }
 
       data_obtained =

--- a/test/oli_web/live/workspace/instructor/dashboard_live_test.exs
+++ b/test/oli_web/live/workspace/instructor/dashboard_live_test.exs
@@ -18,21 +18,38 @@ defmodule OliWeb.Workspace.Instructor.DashboardLiveTest do
 
       {:ok, view, _html} = live(conn, ~p"/workspaces/instructor/#{section.slug}/overview")
 
-      common = "/workspaces/instructor/#{section.slug}"
-      url_params = "?sidebar_expanded=true"
-
-      data_expected =
-        %{
-          1 => {"Course Content", "#{common}/overview/course_content#{url_params}"},
-          2 => {"Students", "#{common}/overview/students#{url_params}"},
-          3 => {"Content", "#{common}/insights/content#{url_params}"},
-          4 => {"Learning Objectives", "#{common}/insights/learning_objectives#{url_params}"},
-          5 => {"Scored Activities", "#{common}/insights/scored_activities#{url_params}"},
-          6 => {"Practice Activities", "#{common}/insights/practice_activities#{url_params}"},
-          7 => {"Surveys", "#{common}/insights/surveys#{url_params}"},
-          8 => {"Manage", "#{common}/manage#{url_params}"},
-          9 => {"Activity", "#{common}/activity#{url_params}"}
-        }
+      data_expected = %{
+        1 =>
+          {"Course Content",
+           "/workspaces/instructor/examplesection0/overview/course_content?sidebar_expanded=true"},
+        2 =>
+          {"Students",
+           "/workspaces/instructor/examplesection0/overview/students?sidebar_expanded=true"},
+        3 =>
+          {"Quiz Scores",
+           "/workspaces/instructor/examplesection0/overview/quiz_cores?sidebar_expanded=true"},
+        4 =>
+          {"Recommended Actions",
+           "/workspaces/instructor/examplesection0/overview/recommended_actions?sidebar_expanded=true"},
+        5 =>
+          {"Content",
+           "/workspaces/instructor/examplesection0/insights/content?sidebar_expanded=true"},
+        6 =>
+          {"Learning Objectives",
+           "/workspaces/instructor/examplesection0/insights/learning_objectives?sidebar_expanded=true"},
+        7 =>
+          {"Scored Activities",
+           "/workspaces/instructor/examplesection0/insights/scored_activities?sidebar_expanded=true"},
+        8 =>
+          {"Practice Activities",
+           "/workspaces/instructor/examplesection0/insights/practice_activities?sidebar_expanded=true"},
+        9 =>
+          {"Surveys",
+           "/workspaces/instructor/examplesection0/insights/surveys?sidebar_expanded=true"},
+        10 => {"Manage", "/workspaces/instructor/examplesection0/manage?sidebar_expanded=true"},
+        11 =>
+          {"Activity", "/workspaces/instructor/examplesection0/activity?sidebar_expanded=true"}
+      }
 
       data_obtained =
         view


### PR DESCRIPTION
Ticket: [MER-3299](https://eliterate.atlassian.net/browse/MER-3299)

This PR handled a rework based on [feedback](https://eliterate.atlassian.net/browse/MER-3299?focusedCommentId=24041) from QA:
1. Both the title of a course section and the title of a project now follow the Figma-designed color: #757682. 
2. Two missing sub-items were added: "Quiz Scores and Recommended Actions". 

Also, a commit: e3ab1f89ac4a8f7910a2516544444c364b632c7a was added to remove default values for the `course_author` hierarchy tree.
### After rework -- Light mode
<img width="878" alt="image" src="https://github.com/user-attachments/assets/fb157131-e9f3-4396-aeec-6b40d440cfb4">


### After rework -- Dark mode

<img width="873" alt="image" src="https://github.com/user-attachments/assets/dc747634-ab7f-4163-bff4-bb3e065606be">



[MER-3299]: https://eliterate.atlassian.net/browse/MER-3299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ