### PR TITLE
WIP - Eliminate double view

### DIFF
--- a/lib/oli/delivery/page/page_context.ex
+++ b/lib/oli/delivery/page/page_context.ex
@@ -174,8 +174,7 @@ defmodule Oli.Delivery.Page.PageContext do
         %Section{slug: section_slug, id: section_id},
         page_slug,
         user,
-        datashop_session_id,
-        opts \\ [track_access: true]
+        datashop_session_id
       ) do
     # resolve the page revision per section
     page_revision = DeliveryResolver.from_revision_slug(section_slug, page_slug)
@@ -183,8 +182,7 @@ defmodule Oli.Delivery.Page.PageContext do
     effective_settings =
       Oli.Delivery.Settings.get_combined_settings(page_revision, section_id, user.id)
 
-    if opts[:track_access],
-      do: Attempts.track_access(page_revision.resource_id, section_id, user.id)
+    Attempts.track_access(page_revision.resource_id, section_id, user.id)
 
     activity_provider = &Oli.Delivery.ActivityProvider.provide/6
 

--- a/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
+++ b/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
@@ -1,7 +1,6 @@
 <%= if assigns[:loading?] do %>
   <div></div>
 <% else %>
-
   <div id="live_flash_container" class="fixed top-14 w-full mx-auto z-50">
     <%= if live_flash(@flash, :info) do %>
       <div class="alert alert-info flex flex-row" role="alert">

--- a/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
+++ b/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
@@ -1,119 +1,124 @@
-<div id="live_flash_container" class="fixed top-14 w-full mx-auto z-50">
-  <%= if live_flash(@flash, :info) do %>
-    <div class="alert alert-info flex flex-row" role="alert">
-      <div class="flex-1">
-        <%= live_flash(@flash, :info) %>
-      </div>
+<%= if assigns[:loading?] do %>
+  <div></div>
+<% else %>
 
-      <button
-        type="button"
-        class="close"
-        data-bs-dismiss="alert"
-        aria-label="Close"
-        phx-click="lv:clear-flash"
-        phx-value-key="info"
-      >
-        <i class="fa-solid fa-xmark fa-lg"></i>
-      </button>
-    </div>
-  <% end %>
+  <div id="live_flash_container" class="fixed top-14 w-full mx-auto z-50">
+    <%= if live_flash(@flash, :info) do %>
+      <div class="alert alert-info flex flex-row" role="alert">
+        <div class="flex-1">
+          <%= live_flash(@flash, :info) %>
+        </div>
 
-  <%= if live_flash(@flash, :error) do %>
-    <div class="alert alert-danger flex flex-row" role="alert">
-      <div class="flex-1">
-        <%= live_flash(@flash, :error) %>
-      </div>
-
-      <button
-        type="button"
-        class="close"
-        data-bs-dismiss="alert"
-        aria-label="Close"
-        phx-click="lv:clear-flash"
-        phx-value-key="error"
-      >
-        <i class="fa-solid fa-xmark fa-lg"></i>
-      </button>
-    </div>
-  <% end %>
-</div>
-
-<div class="h-screen flex flex-col overscroll-none overflow-hidden">
-  <Components.Delivery.Layouts.header
-    :if={@section}
-    ctx={@ctx}
-    is_system_admin={assigns[:is_system_admin] || false}
-    section={@section}
-    preview_mode={@preview_mode}
-    force_show_user_menu={true}
-    include_logo={true}
-  />
-
-  <div class="flex-1 flex flex-col mt-14 overflow-hidden">
-    <div
-      :if={assigns[:paywall_summary] && OliWeb.LayoutView.show_pay_early(@paywall_summary)}
-      id="pay_early_message"
-      class="absolute z-50 system-banner flex flex-row alert alert-warning ml-32 m-6"
-      role="alert"
-    >
-      <%= OliWeb.LayoutView.pay_early_message(@paywall_summary) %>
-      <div class="flex whitespace-nowrap items-center">
-        <.link class="ml-8" href={Routes.payment_path(@socket, :guard, @section.slug)}>
-          Pay Now
-        </.link>
         <button
-          class="ml-10 stroke-gray-500 hover:stroke-gray-400"
-          phx-click={JS.hide(to: "#pay_early_message")}
+          type="button"
+          class="close"
+          data-bs-dismiss="alert"
+          aria-label="Close"
+          phx-click="lv:clear-flash"
+          phx-value-key="info"
         >
-          <OliWeb.Icons.close />
+          <i class="fa-solid fa-xmark fa-lg"></i>
         </button>
       </div>
-    </div>
+    <% end %>
 
-    <div
-      :if={@section}
-      id="page-content"
-      class="flex-1 flex flex-col relative justify-center items-start overflow-hidden"
-    >
-      <div
-        :if={@view in [:graded_page, :practice_page] and @page_progress_state == :in_progress}
-        id="offline_detector"
-      >
-        <%= react_component("Components.OfflineDetector") %>
+    <%= if live_flash(@flash, :error) do %>
+      <div class="alert alert-danger flex flex-row" role="alert">
+        <div class="flex-1">
+          <%= live_flash(@flash, :error) %>
+        </div>
+
+        <button
+          type="button"
+          class="close"
+          data-bs-dismiss="alert"
+          aria-label="Close"
+          phx-click="lv:clear-flash"
+          phx-value-key="error"
+        >
+          <i class="fa-solid fa-xmark fa-lg"></i>
+        </button>
       </div>
-      <.back_arrow
-        to={
-          if assigns[:request_path] in [""],
-            do: ~p"/sections/#{@section.slug}/learn?target_resource_id=#{@current_page["id"]}",
-            else: assigns[:request_path]
-        }
-        show_sidebar={assigns[:show_sidebar]}
-        view={assigns[:view]}
-      />
-
-      <%= @inner_content %>
-    </div>
-
-    <Components.Delivery.Layouts.previous_next_nav
-      :if={assigns[:page_context]}
-      current_page={@current_page}
-      previous_page={@previous_page}
-      next_page={@next_page}
-      section_slug={@section.slug}
-      request_path={assigns[:request_path]}
-      selected_view={assigns[:selected_view]}
-    />
+    <% end %>
   </div>
 
-  <%= if @section do %>
-    <%= live_render(@socket, OliWeb.Dialogue.WindowLive,
-      session: %{
-        "section_slug" => @section.slug,
-        "resource_id" => @current_page["id"],
-        "revision_id" => @page_context.page.id,
-        "is_page" => true
-      },
-      id: "dialogue-window"
-    ) %>
-  <% end %>
-</div>
+  <div class="h-screen flex flex-col overscroll-none overflow-hidden">
+    <Components.Delivery.Layouts.header
+      :if={@section}
+      ctx={@ctx}
+      is_system_admin={assigns[:is_system_admin] || false}
+      section={@section}
+      preview_mode={@preview_mode}
+      force_show_user_menu={true}
+      include_logo={true}
+    />
+
+    <div class="flex-1 flex flex-col mt-14 overflow-hidden">
+      <div
+        :if={assigns[:paywall_summary] && OliWeb.LayoutView.show_pay_early(@paywall_summary)}
+        id="pay_early_message"
+        class="absolute z-50 system-banner flex flex-row alert alert-warning ml-32 m-6"
+        role="alert"
+      >
+        <%= OliWeb.LayoutView.pay_early_message(@paywall_summary) %>
+        <div class="flex whitespace-nowrap items-center">
+          <.link class="ml-8" href={Routes.payment_path(@socket, :guard, @section.slug)}>
+            Pay Now
+          </.link>
+          <button
+            class="ml-10 stroke-gray-500 hover:stroke-gray-400"
+            phx-click={JS.hide(to: "#pay_early_message")}
+          >
+            <OliWeb.Icons.close />
+          </button>
+        </div>
+      </div>
+
+      <div
+        :if={@section}
+        id="page-content"
+        class="flex-1 flex flex-col relative justify-center items-start overflow-hidden"
+      >
+        <div
+          :if={@view in [:graded_page, :practice_page] and @page_progress_state == :in_progress}
+          id="offline_detector"
+        >
+          <%= react_component("Components.OfflineDetector") %>
+        </div>
+        <.back_arrow
+          to={
+            if assigns[:request_path] in [""],
+              do: ~p"/sections/#{@section.slug}/learn?target_resource_id=#{@current_page["id"]}",
+              else: assigns[:request_path]
+          }
+          show_sidebar={assigns[:show_sidebar]}
+          view={assigns[:view]}
+        />
+
+        <%= @inner_content %>
+      </div>
+
+      <Components.Delivery.Layouts.previous_next_nav
+        :if={assigns[:page_context]}
+        current_page={@current_page}
+        previous_page={@previous_page}
+        next_page={@next_page}
+        section_slug={@section.slug}
+        request_path={assigns[:request_path]}
+        selected_view={assigns[:selected_view]}
+      />
+    </div>
+
+    <%= if @section do %>
+      <%= live_render(@socket, OliWeb.Dialogue.WindowLive,
+        session: %{
+          "section_slug" => @section.slug,
+          "resource_id" => @current_page["id"],
+          "revision_id" => @page_context.page.id,
+          "is_page" => true
+        },
+        id: "dialogue-window"
+      ) %>
+    <% end %>
+  </div>
+<% end %>

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -31,18 +31,15 @@ defmodule OliWeb.Delivery.Student.LessonLive do
   }
 
   def mount(_params, _session, %{assigns: %{view: :practice_page}} = socket) do
-
     %{current_user: current_user, section: section, page_context: page_context} = socket.assigns
     is_instructor = Sections.has_instructor_role?(current_user, section.slug)
 
-    IO.inspect "mounting practice page"
-    IO.inspect connected?(socket)
-
+    IO.inspect("mounting practice page")
+    IO.inspect(connected?(socket))
 
     # when updating to Liveview 0.20 we should replace this with assign_async/3
     # https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html#assign_async/3
     if connected?(socket) do
-
       async_load_annotations(
         section,
         page_context.page.resource_id,
@@ -57,21 +54,19 @@ defmodule OliWeb.Delivery.Student.LessonLive do
       emit_page_viewed_event(socket)
 
       {:ok,
-      socket
-      |> assign_html_and_scripts()
-      |> annotations_assigns(page_context.collab_space_config, is_instructor)
-      |> assign(loading?: false, is_instructor: is_instructor, page_resource_id: page_context.page.resource_id)
-      |> assign_objectives()
-      |> slim_assigns(), temporary_assigns: [scripts: [], html: [], page_context: %{}]}
-
-
-
+       socket
+       |> assign_html_and_scripts()
+       |> annotations_assigns(page_context.collab_space_config, is_instructor)
+       |> assign(
+         loading?: false,
+         is_instructor: is_instructor,
+         page_resource_id: page_context.page.resource_id
+       )
+       |> assign_objectives()
+       |> slim_assigns(), temporary_assigns: [scripts: [], html: [], page_context: %{}]}
     else
       {:ok, assign(socket, loading?: true)}
-
     end
-
-
   end
 
   def mount(
@@ -642,7 +637,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
     {:noreply, socket}
   end
 
-  def render(%{loading?: :true} = assigns) do
+  def render(%{loading?: true} = assigns) do
     ~H"""
     <div></div>
     """

--- a/lib/oli_web/live_session_plugs/init_page.ex
+++ b/lib/oli_web/live_session_plugs/init_page.ex
@@ -12,10 +12,8 @@ defmodule OliWeb.LiveSessionPlugs.InitPage do
   end
 
   def on_mount(:set_page_context, %{"revision_slug" => revision_slug}, _session, socket) do
-
     if Phoenix.LiveView.connected?(socket) do
-
-      IO.inspect "Setting page context"
+      IO.inspect("Setting page context")
 
       %{section: section, current_user: current_user, datashop_session_id: datashop_session_id} =
         socket.assigns
@@ -29,17 +27,15 @@ defmodule OliWeb.LiveSessionPlugs.InitPage do
         )
 
       {:cont,
-        assign(socket,
-          page_context: page_context,
-          # the page context will be a temporary assign,
-          # that is why we need to "duplicate" the page context progress state in another socket assign
-          page_progress_state: page_context.progress_state
-        )}
-
+       assign(socket,
+         page_context: page_context,
+         # the page context will be a temporary assign,
+         # that is why we need to "duplicate" the page context progress state in another socket assign
+         page_progress_state: page_context.progress_state
+       )}
     else
       {:cont, socket}
     end
-
   end
 
   def on_mount(
@@ -48,11 +44,8 @@ defmodule OliWeb.LiveSessionPlugs.InitPage do
         _session,
         %{assigns: assigns} = socket
       ) do
-
     if Phoenix.LiveView.connected?(socket) do
-
-
-      IO.inspect "Setting page prev and next"
+      IO.inspect("Setting page prev and next")
       resource_id = assigns.page_context.page.resource_id
 
       # note will all be nil for case of "loose" linked pages not in hierarchy
@@ -76,15 +69,14 @@ defmodule OliWeb.LiveSessionPlugs.InitPage do
         end
 
       {:cont,
-      assign(socket,
-        previous_page: previous,
-        next_page: next,
-        current_page: current
-      )}
+       assign(socket,
+         previous_page: previous,
+         next_page: next,
+         current_page: current
+       )}
     else
       {:cont, socket}
     end
-
   end
 
   def on_mount(
@@ -93,13 +85,11 @@ defmodule OliWeb.LiveSessionPlugs.InitPage do
         _session,
         socket
       ) do
-
     if Phoenix.LiveView.connected?(socket) do
       {:cont, init_context_state(socket, params)}
     else
       {:cont, socket}
     end
-
   end
 
   # Handles the 2 cases of adaptive delivery

--- a/lib/oli_web/live_session_plugs/redirect_adaptive.ex
+++ b/lib/oli_web/live_session_plugs/redirect_adaptive.ex
@@ -41,7 +41,6 @@ defmodule OliWeb.LiveSessionPlugs.RedirectAdaptiveChromeless do
     else
       {:cont, socket}
     end
-
   end
 
   def on_mount(
@@ -63,13 +62,13 @@ defmodule OliWeb.LiveSessionPlugs.RedirectAdaptiveChromeless do
         }
         when progress_state in [:revised, :in_progress] ->
           {:halt,
-          redirect(socket,
-            to:
-              adaptive_chromeless_url(section_slug, revision_slug,
-                request_path: params["request_path"],
-                selected_view: params["selected_view"]
-              )
-          )}
+           redirect(socket,
+             to:
+               adaptive_chromeless_url(section_slug, revision_slug,
+                 request_path: params["request_path"],
+                 selected_view: params["selected_view"]
+               )
+           )}
 
         _ ->
           {:cont, socket}

--- a/lib/oli_web/live_session_plugs/redirect_to_lesson.ex
+++ b/lib/oli_web/live_session_plugs/redirect_to_lesson.ex
@@ -21,21 +21,26 @@ defmodule OliWeb.LiveSessionPlugs.RedirectToLesson do
         _session,
         socket
       ) do
-    case socket.assigns.page_context do
-      %PageContext{progress_state: progress_state}
-      when progress_state in [:revised, :in_progress] ->
-        {:halt,
-         redirect(socket,
-           to:
-             Utils.lesson_live_path(section_slug, revision_slug,
-               request_path: params["request_path"],
-               selected_view: params["selected_view"]
-             )
-         )}
+    if Phoenix.LiveView.connected?(socket) do
+      case socket.assigns.page_context do
+        %PageContext{progress_state: progress_state}
+        when progress_state in [:revised, :in_progress] ->
+          {:halt,
+           redirect(socket,
+             to:
+               Utils.lesson_live_path(section_slug, revision_slug,
+                 request_path: params["request_path"],
+                 selected_view: params["selected_view"]
+               )
+           )}
 
-      _ ->
-        {:cont, socket}
+        _ ->
+          {:cont, socket}
+      end
+    else
+      {:cont, socket}
     end
+
   end
 
   def on_mount(:default, _params, _session, socket) do

--- a/lib/oli_web/live_session_plugs/redirect_to_lesson.ex
+++ b/lib/oli_web/live_session_plugs/redirect_to_lesson.ex
@@ -40,7 +40,6 @@ defmodule OliWeb.LiveSessionPlugs.RedirectToLesson do
     else
       {:cont, socket}
     end
-
   end
 
   def on_mount(:default, _params, _session, socket) do

--- a/lib/oli_web/live_session_plugs/redirect_to_prologue.ex
+++ b/lib/oli_web/live_session_plugs/redirect_to_prologue.ex
@@ -40,7 +40,6 @@ defmodule OliWeb.LiveSessionPlugs.RedirectToPrologue do
     else
       {:cont, socket}
     end
-
   end
 
   def on_mount(:default, _params, _session, socket) do

--- a/lib/oli_web/live_session_plugs/redirect_to_prologue.ex
+++ b/lib/oli_web/live_session_plugs/redirect_to_prologue.ex
@@ -21,21 +21,26 @@ defmodule OliWeb.LiveSessionPlugs.RedirectToPrologue do
         _session,
         socket
       ) do
-    case socket.assigns.page_context do
-      %PageContext{progress_state: progress_state}
-      when progress_state not in [:revised, :in_progress] ->
-        {:halt,
-         redirect(socket,
-           to:
-             Utils.prologue_live_path(section_slug, revision_slug,
-               request_path: params["request_path"],
-               selected_view: params["selected_view"]
-             )
-         )}
+    if Phoenix.LiveView.connected?(socket) do
+      case socket.assigns.page_context do
+        %PageContext{progress_state: progress_state}
+        when progress_state not in [:revised, :in_progress] ->
+          {:halt,
+           redirect(socket,
+             to:
+               Utils.prologue_live_path(section_slug, revision_slug,
+                 request_path: params["request_path"],
+                 selected_view: params["selected_view"]
+               )
+           )}
 
-      _ ->
-        {:cont, socket}
+        _ ->
+          {:cont, socket}
+      end
+    else
+      {:cont, socket}
     end
+
   end
 
   def on_mount(:default, _params, _session, socket) do


### PR DESCRIPTION
This is a candidate for a `v0.28.5` hotfix.  It eliminates the "double load" problem within the lesson view by only loading page context when the socket has connected, as opposed to doing it twice. 

I originally tried to load the page context during the first `mount`, but by the second call to `mount` the original assigns were no longer present.  