### PR TITLE
[BUG FIX] [MER-3686] Student index_live crashes when lesson end date is not set (nil)

### DIFF
--- a/lib/oli_web/live/delivery/student/index_live.ex
+++ b/lib/oli_web/live/delivery/student/index_live.ex
@@ -522,7 +522,11 @@ defmodule OliWeb.Delivery.Student.IndexLive do
       <div class="pr-2 pl-1 self-end">
         <div class="flex items-end gap-1">
           <div class="text-right dark:text-white text-opacity-90 text-xs font-semibold">
-            <%= Utils.days_difference(@lesson.end_date, @ctx) %>
+            <%= case @lesson do %>
+              <% %{end_date: nil} -> %>
+              <% %{end_date: end_date} -> %>
+                <%= Utils.days_difference(end_date, @ctx) %>
+            <% end %>
           </div>
         </div>
       </div>

--- a/lib/oli_web/live/delivery/student/index_live.ex
+++ b/lib/oli_web/live/delivery/student/index_live.ex
@@ -522,11 +522,7 @@ defmodule OliWeb.Delivery.Student.IndexLive do
       <div class="pr-2 pl-1 self-end">
         <div class="flex items-end gap-1">
           <div class="text-right dark:text-white text-opacity-90 text-xs font-semibold">
-            <%= case @lesson do %>
-              <% %{end_date: nil} -> %>
-              <% %{end_date: end_date} -> %>
-                <%= Utils.days_difference(end_date, @ctx) %>
-            <% end %>
+            <%= Utils.days_difference(@lesson.end_date, @ctx) %>
           </div>
         </div>
       </div>

--- a/lib/oli_web/live/delivery/student/utils.ex
+++ b/lib/oli_web/live/delivery/student/utils.ex
@@ -524,7 +524,8 @@ defmodule OliWeb.Delivery.Student.Utils do
       iex> days_difference(~U[2024-05-12T00:00:00Z], %SessionContext{local_tz: "America/Montevideo"})
       "1 day left"
   """
-  @spec days_difference(DateTime.t(), SessionContext.t()) :: String.t()
+  def days_difference(nil, _context), do: nil
+
   def days_difference(resource_end_date, context) do
     {localized_end_date, today} =
       case FormatDateTime.maybe_localized_datetime(resource_end_date, context) do


### PR DESCRIPTION
This PR handles case where lesson end date might be nil when the start by date is set to some point in the future. The results was a 500 crash on the main student index page.