### PR TITLE
[PERFORMANCE] [MER-3691] Improve schedule assembly speed by eliminating expensive ancestral query

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -1488,57 +1488,70 @@ defmodule Oli.Delivery.Sections do
   end
 
   @doc """
-  Fetches containers per page, grouping them by page ID, and orders the containers by their numbering level within each page for a given section.
+  Assembles containers per page, grouping them by page ID, and orders the containers by their numbering level within each page for a given section.
 
   ## Parameters
-    - `section_slug`: The slug of the section for which container data is fetched.
+    - `section`: The section for which container data is fetched.
 
   ## Returns
     - A list of maps containing page IDs and their associated containers, with containers sorted by numbering level.
 
   ## Examples
-      iex> get_ordered_containers_per_page("chemistry")
+      iex> get_ordered_containers_per_page(section)
       [%{page_id: 1, containers: [%{id: 10, title: "Introduction", numbering_level: 1}]}]
   """
+  def get_ordered_containers_per_page(section, page_ids \\ []) do
 
-  @spec get_ordered_containers_per_page(String.t(), list(integer())) :: [
-          %{page_id: integer(), containers: list(map())}
-        ]
-  def get_ordered_containers_per_page(section_slug, page_ids \\ []) do
-    container_type_id = Oli.Resources.ResourceType.get_id_by_type("container")
+    section = case section.previous_next_index do
+      nil ->
+        {:ok, section} = Oli.Delivery.PreviousNextIndex.rebuild(section)
+        section
+      _ -> section
+    end
 
-    pages_filter =
-      if Enum.empty?(page_ids),
-        do: true,
-        else: dynamic([_sr, _s, _spp, _pr, _rev, cp], cp.page_id in ^page_ids)
+    child_to_parent = Map.values(section.previous_next_index)
+    |> Enum.reduce(%{}, fn item, map ->
+      Map.get(item, "children")
+      |> Enum.reduce(map, fn child, map ->
+        Map.put(map, child, Map.get(item, "id"))
+      end)
+    end)
 
-    from(
-      [sr: sr, rev: rev, s: s] in DeliveryResolver.section_resource_revisions(section_slug),
-      join: cp in ContainedPage,
-      on: cp.container_id == rev.resource_id,
-      where:
-        rev.deleted == false and s.slug == ^section_slug and
-          rev.resource_type_id == ^container_type_id,
-      where: ^pages_filter,
-      group_by: [cp.page_id],
-      select: %{
-        page_id: cp.page_id,
-        containers:
-          fragment(
-            """
-            array_agg(
-              json_build_object('id', ?, 'title', ?, 'numbering_level', ?)
-              ORDER BY ? ASC
-            )
-            """,
-            rev.resource_id,
-            rev.title,
-            sr.numbering_level,
-            sr.numbering_level
-          )
+    all_pages = Map.values(section.previous_next_index)
+    |> Enum.filter(fn item -> Map.get(item, "type") == "page" end)
+    |> Enum.map(fn item ->
+      page_id = Map.get(item, "id")
+      ancestors = build_ancestors(page_id, [], child_to_parent)
+
+      %{
+        page_id: String.to_integer(page_id),
+        containers: Enum.map(ancestors, fn ancestor_id ->
+
+          a = Map.get(section.previous_next_index, ancestor_id)
+          %{
+            "id" => String.to_integer(ancestor_id),
+            "title" => a["title"],
+            "numbering_level" => a["level"] |> String.to_integer()
+          }
+        end)
       }
-    )
-    |> Repo.all()
+
+    end)
+
+    case page_ids do
+      [] -> all_pages
+      _ ->
+        page_ids_mapset = MapSet.new(page_ids)
+        Enum.filter(all_pages, fn page -> Enum.member?(page_ids_mapset, page.page_id) end)
+    end
+
+  end
+
+  def build_ancestors(resource_id, entries, child_to_parent) do
+    case Map.get(child_to_parent, resource_id) do
+      nil -> entries
+      parent_id -> build_ancestors(parent_id, [parent_id | entries], child_to_parent)
+    end
   end
 
   defp section_publication_ids(section_slug) do
@@ -1797,7 +1810,7 @@ defmodule Oli.Delivery.Sections do
       end)
 
     page_to_containers_map =
-      get_ordered_containers_per_page(section.slug)
+      get_ordered_containers_per_page(section)
       |> Enum.reduce(%{}, fn elem, acc ->
         Map.put(acc, elem[:page_id], elem[:containers])
       end)
@@ -1882,7 +1895,7 @@ defmodule Oli.Delivery.Sections do
       end)
 
     page_to_containers_map =
-      get_ordered_containers_per_page(section.slug)
+      get_ordered_containers_per_page(section)
       |> Enum.reduce(%{}, fn elem, acc ->
         Map.put(acc, elem[:page_id], elem[:containers])
       end)

--- a/lib/oli_web/live/delivery/student/index_live.ex
+++ b/lib/oli_web/live/delivery/student/index_live.ex
@@ -33,7 +33,7 @@ defmodule OliWeb.Delivery.Student.IndexLive do
       Sections.get_nearest_upcoming_lessons(section, current_user_id, 3, only_graded: true)
 
     page_ids = Enum.map(upcoming_assignments ++ latest_assignments, & &1.resource_id)
-    containers_per_page = build_containers_per_page(section.slug, page_ids)
+    containers_per_page = build_containers_per_page(section, page_ids)
 
     combined_settings =
       Settings.get_combined_settings_for_all_resources(section.id, current_user_id, page_ids)
@@ -737,9 +737,9 @@ defmodule OliWeb.Delivery.Student.IndexLive do
   defp max_attempts(0), do: "∞"
   defp max_attempts(max_attempts), do: max_attempts
 
-  defp build_containers_per_page(section_slug, page_ids) do
+  defp build_containers_per_page(section, page_ids) do
     containers_label_map =
-      Sections.get_ordered_container_labels(section_slug, short_label: true)
+      Sections.get_ordered_container_labels(section.slug, short_label: true)
       |> Enum.reduce(%{}, fn {container_id, label}, acc ->
         Map.put(acc, container_id, label)
       end)
@@ -749,7 +749,7 @@ defmodule OliWeb.Delivery.Student.IndexLive do
         Map.put(container, "label", containers_label_map[container["id"]])
       end)
 
-    Sections.get_ordered_containers_per_page(section_slug, page_ids)
+    Sections.get_ordered_containers_per_page(section, page_ids)
     |> Enum.reduce(%{}, fn elem, acc ->
       Map.put(acc, elem[:page_id], add_label_to_containers.(elem[:containers]))
     end)

--- a/test/oli/delivery/sections_test.exs
+++ b/test/oli/delivery/sections_test.exs
@@ -2041,7 +2041,6 @@ defmodule Oli.Delivery.SectionsTest do
         refute Enum.member?(result, fn pc -> pc[:page_id] == page.resource_id end)
       end
     end
-
   end
 
   describe "container_titles/1" do

--- a/test/oli/delivery/sections_test.exs
+++ b/test/oli/delivery/sections_test.exs
@@ -1970,7 +1970,7 @@ defmodule Oli.Delivery.SectionsTest do
     setup [:create_elixir_project]
 
     test "fetches and orders containers by numbering level", %{section: section} = context do
-      result = Sections.get_ordered_containers_per_page(section.slug)
+      result = Sections.get_ordered_containers_per_page(section)
       # There are exactly 4 pages
       assert length(result) == 4
 
@@ -2016,7 +2016,7 @@ defmodule Oli.Delivery.SectionsTest do
 
     test "fetches only specified page ids",
          %{section: section, page_1: page_1} = context do
-      result = Sections.get_ordered_containers_per_page(section.slug, [page_1.resource_id])
+      result = Sections.get_ordered_containers_per_page(section, [page_1.resource_id])
       assert length(result) == 1
 
       # Only Page 1 is returned
@@ -2042,9 +2042,6 @@ defmodule Oli.Delivery.SectionsTest do
       end
     end
 
-    test "returns an empty list for non-existent sections", %{section: _section} do
-      assert Sections.get_ordered_containers_per_page("non-existent-section") == []
-    end
   end
 
   describe "container_titles/1" do

--- a/test/oli_web/live/delivery/student/index_live_test.exs
+++ b/test/oli_web/live/delivery/student/index_live_test.exs
@@ -1,5 +1,6 @@
 defmodule OliWeb.Delivery.Student.IndexLiveTest do
   use ExUnit.Case, async: true
+  alias Oli.Delivery.PreviousNextIndex
   use OliWeb.ConnCase
 
   import Phoenix.LiveViewTest


### PR DESCRIPTION
`Sections.get_ordered_containers_per_page/2` ran an expensive query in order to fetch a list of "page to ordered containers" for all (or a subset) of page ids in a course hierarchy.  This function was being used inside of the code that calculates the full ordered schedule, which means it gets called in both the "Schedule" view and the "Home" view (when the Agenda is enabled).  It is also called directly from the `IndexLive` module of the "Home" view.   So, that means for the "Home" view with "Agenda" enabled we call this expensive query *twice*.     There are numerous examples within AppSignal of the Home screen taking 1-2 *seconds* to load, where these two queries comprise around 90% of the total time. 

Worse, everything that is needed to calculate the list of "page to ordered containers" exists already in memory within the section's `previous_next_index`.   This PR rewrites this function to make 0 queries, and instead build this representation from memory.   

A metric ton of unit tests failed, though, when that `previous_next_index` was `nil` due to how Sections were manually constructed in those unit tests.  I added a call to `Oli.Delivery.PreviousNextIndex.rebuild(section)` to fix that.  In theory this could get tripped in production if this is the very first time any student has visited a course section.  