### PR TITLE
[FEATURE] [MER-3599] Migrate All Activities liveview

### DIFF
--- a/lib/oli/resources/activity_browse.ex
+++ b/lib/oli/resources/activity_browse.ex
@@ -32,10 +32,10 @@ defmodule Oli.Resources.ActivityBrowse do
           |> Enum.join(" & ")
 
         dynamic(
-          [rev, _, _, _],
+          [rev, ar, _, _, _],
           fragment(
             "to_tsvector('simple', ?) @@ to_tsquery('simple', ?)",
-            rev.title,
+            ar.petite_label,
             ^search_term
           )
         )
@@ -59,15 +59,20 @@ defmodule Oli.Resources.ActivityBrowse do
 
     query =
       Revision
-      |> join(:left, [rev], pr in Oli.Publishing.PublishedResource, on: pr.revision_id == rev.id)
-      |> join(:left, [_, pr], pub in Oli.Publishing.Publications.Publication,
+      |> join(:left, [rev], ar in Oli.Activities.ActivityRegistration,
+        on: ar.id == rev.activity_type_id
+      )
+      |> join(:left, [rev, _ar], pr in Oli.Publishing.PublishedResource,
+        on: pr.revision_id == rev.id
+      )
+      |> join(:left, [_, _, pr], pub in Oli.Publishing.Publications.Publication,
         on: pr.publication_id == pub.id
       )
-      |> join(:left, [_, _, pub], proj in Oli.Authoring.Course.Project,
+      |> join(:left, [_, _, _, pub], proj in Oli.Authoring.Course.Project,
         on: pub.project_id == proj.id
       )
       |> where(
-        [rev, _, pub, proj],
+        [rev, _, _, pub, proj],
         proj.id == ^project_id and is_nil(pub.published) and
           rev.resource_type_id == ^activity_resource_type_id
       )

--- a/lib/oli_web/live/workspaces/course_author/activities/activities_table_model.ex
+++ b/lib/oli_web/live/workspaces/course_author/activities/activities_table_model.ex
@@ -1,0 +1,118 @@
+defmodule OliWeb.Workspaces.CourseAuthor.Activities.ActivitiesTableModel do
+  alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
+  alias Oli.Resources.Revision
+  alias OliWeb.Router.Helpers, as: Routes
+
+  use Phoenix.Component
+
+  def render(assigns) do
+    ~H"""
+    <div>nothing</div>
+    """
+  end
+
+  def new(activities, project, ctx, activities_by_type_id, parent_pages) do
+    column_specs = [
+      %ColumnSpec{
+        name: :activity_type_id,
+        label: "Type",
+        render_fn: &OliWeb.Resources.ActivitiesTableModel.render_type_column/3
+      },
+      %ColumnSpec{
+        name: :scope,
+        label: "Scope"
+      },
+      %ColumnSpec{
+        name: :content,
+        label: "Stem",
+        render_fn: &OliWeb.Resources.ActivitiesTableModel.render_content_column/3
+      },
+      %ColumnSpec{
+        name: :resource_id,
+        label: "Page",
+        render_fn: &OliWeb.Resources.ActivitiesTableModel.render_page_column/3
+      },
+      %ColumnSpec{
+        name: :updated_at,
+        label: "Last Updated",
+        render_fn: &OliWeb.Common.Table.Common.render_date/3
+      }
+    ]
+
+    SortableTableModel.new(
+      rows: activities,
+      column_specs: column_specs,
+      event_suffix: "",
+      id_field: [:id],
+      data: %{
+        ctx: ctx,
+        project_slug: project.slug,
+        activities_by_type_id: activities_by_type_id,
+        parent_pages: parent_pages
+      }
+    )
+  end
+
+  def render_page_column(
+        assigns,
+        %Revision{
+          resource_id: resource_id
+        },
+        _
+      ) do
+    case Map.get(assigns.parent_pages, resource_id) do
+      nil ->
+        ""
+
+      %{title: title, slug: slug} ->
+        assigns = Map.merge(assigns, %{slug: slug, title: title})
+
+        ~H"""
+        <a href={Routes.resource_path(OliWeb.Endpoint, :edit, @project_slug, @slug)}><%= @title %></a>
+        """
+    end
+  end
+
+  def render_type_column(
+        assigns,
+        %Revision{
+          activity_type_id: activity_type_id
+        },
+        _
+      ) do
+    Map.get(assigns.activities_by_type_id, activity_type_id).petite_label
+  end
+
+  def render_content_column(
+        _,
+        %Revision{
+          content: content
+        },
+        _
+      ) do
+    Map.get(content, "stem", %{"content" => []})
+    |> Map.get("content", [%{"type" => "p", "children" => [%{"text" => "Unknown stem"}]}])
+    |> best_effort_stem_extract()
+  end
+
+  defp best_effort_stem_extract(%{"model" => items}), do: best_effort_stem_extract(items)
+  defp best_effort_stem_extract([]), do: "[Empty]"
+  defp best_effort_stem_extract([item | _]), do: extract(item)
+  defp best_effort_stem_extract(_), do: "[Empty]"
+
+  defp extract(%{"type" => "p", "children" => children}) do
+    value =
+      Enum.reduce(children, "", fn c, s ->
+        s <> Map.get(c, "text", "")
+      end)
+
+    cond do
+      String.length(value) > 75 -> String.slice(value, 0..75) <> "..."
+      true -> value
+    end
+  end
+
+  defp extract(%{"text" => t}), do: t
+  defp extract(%{"type" => t}), do: "[#{t}]"
+  defp extract(_), do: "[Unknown]"
+end

--- a/lib/oli_web/live/workspaces/course_author/activities/activity_review_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/activities/activity_review_live.ex
@@ -1,0 +1,72 @@
+defmodule OliWeb.Workspaces.CourseAuthor.Activities.ActivityReviewLive do
+  use OliWeb, :live_view
+
+  @impl Phoenix.LiveView
+  def mount(_params, _session, socket) do
+    project = socket.assigns.project
+
+    {:ok,
+     assign(socket,
+       resource_slug: project.slug,
+       resource_title: project.title,
+       active_workspace: :course_author,
+       active_view: :activities,
+       scripts: Oli.Activities.get_activity_scripts()
+     )}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_params(_params, _url, socket) do
+    {:noreply, socket}
+  end
+
+  @impl Phoenix.LiveView
+  def render(assigns) do
+    ~H"""
+    <div class="container mx-auto p-8">
+      <%= for script <- @scripts do %>
+        <script type="text/javascript" src={Routes.static_path(OliWeb.Endpoint, "/js/#{script}")}>
+        </script>
+      <% end %>
+
+      <small>Enter your local path for the SVN source</small>
+      <input type="text" id="local" />
+
+      <hr />
+
+      <h3 id="title"></h3>
+      <h4 id="slug"></h4>
+      <div id="history"></div>
+      <div id="svn"></div>
+      <div id="vscode"></div>
+      <div id="reference"></div>
+
+      <div
+        id="container"
+        style="padding: 20px; border: 2px inset rgba(28,110,164,0.17); border-radius: 12px; margin-top: 30px;"
+      >
+      </div>
+
+      <script>
+        const bc = new BroadcastChannel('activity_selected');
+        bc.onmessage = (event) => {
+        document.getElementById('container').innerHTML = event.data.rendered;
+        document.getElementById('title').innerHTML = event.data.title;
+        document.getElementById('slug').innerHTML = event.data.slug;
+        document.getElementById('svn').innerHTML =`View SVN: <a href="${event.data.svn_path}" target="editor">${event.data.svn_path}</a>`;
+
+        const root = document.getElementById('local').value;
+        document.getElementById('vscode').innerHTML =`View in VSCode: <a href="vscode://file/${root}/${event.data.svn_relative_path}" target="editor">vscode://file/${root}/${event.data.svn_relative_path}</a>`;
+
+        document.getElementById('history').innerHTML =`Edit History: <a href="${event.data.history}" target="editor">${event.data.history}</a>`;
+        document.getElementById('reference').innerHTML =
+        event.data.reference === null
+        ? ""
+        : `Edit Page: <a href="${event.data.reference}" target="editor">${event.data.reference}</a>`;
+
+        }
+      </script>
+    </div>
+    """
+  end
+end

--- a/lib/oli_web/live/workspaces/course_author/activities_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/activities_live.ex
@@ -1,30 +1,330 @@
 defmodule OliWeb.Workspaces.CourseAuthor.ActivitiesLive do
   use OliWeb, :live_view
 
+  import OliWeb.Common.Params
+  import OliWeb.DelegatedEvents
+
+  alias Oli.{Activities, Publishing}
+  alias Oli.Repo.{Paging, Sorting}
+  alias Oli.Resources.{ActivityBrowse, ActivityBrowseOptions}
+  alias OliWeb.Common.{FilterBox, PagedTable, TextSearch}
+  alias OliWeb.Common.Table.SortableTableModel
+  alias OliWeb.Resources.ActivitiesTableModel
+  alias OliWeb.Router.Helpers, as: Routes
+  alias OliWeb.Workspaces.CourseAuthor.Activities.ActivitiesTableModel
+
+  on_mount {OliWeb.LiveSessionPlugs.AuthorizeProject, :default}
+
+  @limit 25
+  @default_options %ActivityBrowseOptions{
+    activity_type_id: nil,
+    deleted: false,
+    text_search: nil
+  }
+
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    project = socket.assigns.project
+    %{project: project, current_author: author, ctx: ctx} = socket.assigns
+
+    activities =
+      ActivityBrowse.browse_activities(
+        project,
+        %Paging{offset: 0, limit: @limit},
+        %Sorting{direction: :asc, field: :title},
+        @default_options
+      )
+
+    publication_id = Publishing.get_unpublished_publication_id!(project.id)
+
+    parent_pages = Publishing.determine_parent_pages(publication_id)
+
+    registered_activities = Activities.list_activity_registrations()
+
+    tags_by_id =
+      Enum.reduce(registered_activities, %{}, fn a, m -> Map.put(m, a.id, a.authoring_element) end)
+
+    activities_by_id =
+      Enum.reduce(registered_activities, %{}, fn a, m -> Map.put(m, a.id, a) end)
+
+    total_count = determine_total(activities)
+
+    {:ok, table_model} =
+      ActivitiesTableModel.new(activities, project, ctx, activities_by_id, parent_pages)
 
     {:ok,
      assign(socket,
+       active_view: :activities,
+       active_workspace: :course_author,
+       author: author,
+       ctx: ctx,
+       options: @default_options,
+       parent_pages: parent_pages,
+       project: project,
+       publication_id: publication_id,
        resource_slug: project.slug,
        resource_title: project.title,
-       active_workspace: :course_author,
-       active_view: :activities
+       table_model: table_model,
+       tags_by_id: tags_by_id,
+       total_count: total_count
      )}
   end
 
   @impl Phoenix.LiveView
-  def handle_params(_params, _url, socket) do
-    {:noreply, socket}
+  def handle_params(params, _, socket) do
+    table_model =
+      SortableTableModel.update_from_params(
+        socket.assigns.table_model,
+        params
+      )
+
+    selected = get_param(params, "selected", nil)
+    offset = get_int_param(params, "offset", 0)
+    table_model = Map.put(table_model, :selected, selected)
+
+    options = %ActivityBrowseOptions{
+      text_search: get_param(params, "text_search", ""),
+      deleted: false,
+      activity_type_id: get_int_param(params, "activity_type_id", nil)
+    }
+
+    if only_selection_changed(socket.assigns, table_model, options, offset) do
+      table_model = Map.put(socket.assigns.table_model, :selected, selected)
+
+      socket =
+        push_sync_event(socket, table_model)
+        |> assign(table_model: table_model)
+
+      {:noreply, socket}
+    else
+      activities =
+        ActivityBrowse.browse_activities(
+          socket.assigns.project,
+          %Paging{offset: offset, limit: @limit},
+          %Sorting{direction: table_model.sort_order, field: table_model.sort_by_spec.name},
+          options
+        )
+
+      selected =
+        case selected do
+          "-2" ->
+            Enum.at(activities, 0).id |> Integer.to_string()
+
+          "-1" ->
+            Enum.at(activities, Enum.count(activities) - 1).id |> Integer.to_string()
+
+          _ ->
+            case Enum.find(activities, fn r -> Integer.to_string(r.id) == selected end) do
+              nil -> nil
+              _ -> selected
+            end
+        end
+
+      table_model =
+        Map.put(table_model, :rows, activities)
+        |> Map.put(:selected, selected)
+
+      total_count = determine_total(activities)
+
+      {:noreply,
+       push_sync_event(socket, table_model)
+       |> assign(
+         offset: offset,
+         table_model: table_model,
+         total_count: total_count,
+         options: options
+       )}
+    end
   end
+
+  attr(:project, :any)
+  attr(:limit, :integer, default: @limit)
+  attr(:offset, :integer, default: 0)
+  attr(:total_count, :integer, default: 0)
+  attr(:table_model, :any)
+  attr(:options, :map)
 
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
-    <h1 class="flex flex-col w-full h-screen items-center justify-center">
-      Placeholder for All Activities
-    </h1>
+    <div id="activity_review" class="container mx-auto p-8" phx-hook="ReviewActivity">
+      <FilterBox.render
+        card_header_text="Browse All Activities"
+        card_body_text=""
+        table_model={@table_model}
+        show_sort={false}
+        show_more_opts={false}
+      >
+        <TextSearch.render id="text-search" text={@options.text_search} />
+      </FilterBox.render>
+
+      <div class="mb-3" />
+
+      <PagedTable.render
+        allow_selection={true}
+        filter={@options.text_search}
+        table_model={@table_model}
+        total_count={@total_count}
+        offset={@offset}
+        limit={@limit}
+      />
+
+      <.link navigate={~p"/workspaces/course_author/#{@project.slug}/activities/activity_review"}>
+        Open Sync View
+      </.link>
+    </div>
     """
+  end
+
+  # If there is a selected item in the table, push down an event to the client-side ReviewActivity hook
+  # giving it the information that it needs to broadcast a client-side sync event to other tabs
+  defp push_sync_event(socket, table_model) do
+    if !is_nil(table_model.selected) do
+      revision =
+        Enum.find(table_model.rows, fn r -> Integer.to_string(r.id) == table_model.selected end)
+
+      rendered =
+        render_authoring(revision, socket.assigns.tags_by_id, socket.assigns.project.slug)
+
+      legacy_svn_root = socket.assigns.project.legacy_svn_root || ""
+      legacy_path = (revision.legacy && revision.legacy.path) || ""
+
+      Phoenix.LiveView.push_event(socket, "activity_selected", %{
+        rendered: rendered,
+        title: revision.title,
+        slug: revision.slug,
+        svn_path: legacy_svn_root <> legacy_path,
+        svn_relative_path: legacy_path,
+        history:
+          Routes.live_url(
+            OliWeb.Endpoint,
+            OliWeb.RevisionHistory,
+            socket.assigns.project.slug,
+            revision.slug
+          ),
+        reference:
+          case Map.get(socket.assigns.parent_pages, revision.resource_id, nil) do
+            nil ->
+              nil
+
+            %{slug: slug} ->
+              Routes.resource_url(OliWeb.Endpoint, :edit, socket.assigns.project.slug, slug)
+          end
+      })
+    else
+      socket
+    end
+  end
+
+  defp render_authoring(nil, _, _) do
+    []
+  end
+
+  defp render_authoring(revision, tags_by_id, project_slug) do
+    tag = Map.get(tags_by_id, revision.activity_type_id)
+
+    [
+      "<",
+      tag,
+      " model=\"",
+      encode_model(revision.content),
+      "\" editMode=\"false\" projectSlug=\"",
+      project_slug,
+      "\"/>"
+    ]
+    |> IO.iodata_to_binary()
+  end
+
+  defp encode_model(model) do
+    {:safe, encoded} = Jason.encode!(model) |> Phoenix.HTML.html_escape()
+    IO.iodata_to_binary(encoded)
+  end
+
+  defp determine_total(projects) do
+    case(projects) do
+      [] -> 0
+      [hd | _] -> hd.total_count
+    end
+  end
+
+  def patch_with(socket, changes) do
+    {:noreply,
+     push_patch(socket,
+       to:
+         Routes.live_path(
+           socket,
+           __MODULE__,
+           socket.assigns.project.slug,
+           Map.merge(
+             %{
+               sort_by: socket.assigns.table_model.sort_by_spec.name,
+               sort_order: socket.assigns.table_model.sort_order,
+               selected: socket.assigns.table_model.selected,
+               offset: socket.assigns.offset,
+               text_search: socket.assigns.options.text_search,
+               activity_type_id: socket.assigns.options.activity_type_id
+             },
+             changes
+           )
+         ),
+       replace: true
+     )}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("keyboard-navigation", %{"direction" => direction}, socket) do
+    selected = socket.assigns.table_model.selected
+
+    index =
+      Enum.find_index(socket.assigns.table_model.rows, fn r ->
+        Integer.to_string(r.id) == selected
+      end)
+
+    new_index = direction + index
+
+    # The logic for allowing keyboard arrow navigation to change the selection *and* to
+    # switch pages (when the current item is the first or last item)
+    changes =
+      cond do
+        new_index < 0 ->
+          if socket.assigns.offset != 0 do
+            %{offset: socket.assigns.offset - @limit, selected: Integer.to_string(-1)}
+          else
+            %{selected: Enum.at(socket.assigns.table_model.rows, index).id |> Integer.to_string()}
+          end
+
+        new_index + socket.assigns.offset >= socket.assigns.total_count ->
+          %{selected: Enum.at(socket.assigns.table_model.rows, index).id |> Integer.to_string()}
+
+        new_index >= @limit ->
+          %{offset: socket.assigns.offset + @limit, selected: Integer.to_string(-2)}
+
+        true ->
+          %{
+            selected:
+              Enum.at(socket.assigns.table_model.rows, new_index).id |> Integer.to_string()
+          }
+      end
+
+    patch_with(socket, changes)
+  end
+
+  def handle_event(event, params, socket) do
+    {event, params, socket, &__MODULE__.patch_with/2}
+    |> delegate_to([
+      &TextSearch.handle_delegated/4,
+      &PagedTable.handle_delegated/4
+    ])
+  end
+
+  # Determines if the change after parsing the URL params is strictly a selection change,
+  # relative to the current assigns
+  defp only_selection_changed(assigns, model_after, options_after, offset_after) do
+    assigns.table_model.selected != model_after.selected and
+      assigns.table_model.sort_by_spec == model_after.sort_by_spec and
+      assigns.table_model.sort_order == model_after.sort_order and
+      assigns.options.text_search == options_after.text_search and
+      assigns.options.deleted == options_after.deleted and
+      assigns.options.activity_type_id == options_after.activity_type_id and
+      assigns.offset == offset_after
   end
 end

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -809,6 +809,7 @@ defmodule OliWeb.Router do
         live("/:project_id/curriculum", CurriculumLive)
         live("/:project_id/pages", PagesLive)
         live("/:project_id/activities", ActivitiesLive)
+        live("/:project_id/activities/activity_review", Activities.ActivityReviewLive)
         live("/:project_id/review", ReviewLive)
         live("/:project_id/publish", PublishLive)
         live("/:project_id/products", ProductsLive)

--- a/test/oli_web/live/workspace/course_author_test.exs
+++ b/test/oli_web/live/workspace/course_author_test.exs
@@ -566,6 +566,17 @@ defmodule OliWeb.Workspace.CourseAuthorTest do
       assert has_element?(view, ~s(#activity-bank))
       assert has_element?(view, ~s(div[data-live-react-class='Components.ActivityBank']))
     end
+
+    test "all activities menu is shown correctly", %{
+      conn: conn,
+      project: project
+    } do
+      {:ok, view, _html} = live(conn, ~p"/workspaces/course_author/#{project.slug}/activities")
+
+      assert has_element?(view, "h3", "Browse All Activities")
+      assert has_element?(view, ~s(input[id='text-search-input']))
+      assert has_element?(view, "a", "Open Sync View")
+    end
   end
 
   defp create_project_with_owner(owner, attrs \\ %{}) do


### PR DESCRIPTION
[MER-3599](https://eliterate.atlassian.net/browse/MER-3599)

This PR migrates the `All Activities` liveview to be accessible from the new menu for the course author workspace.

In addition, the browse activities query is modified to be able to filter the table by the `petite_label` field (e.g. MCQ, Input, CATA, etc). 

So far, this query was filtering by the title of the revision, but it was not in accordance with the labels shown in the `type` column of the table. 


https://github.com/user-attachments/assets/9e2b32f0-99d6-4709-8e14-a7efa3556743



[MER-3599]: https://eliterate.atlassian.net/browse/MER-3599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ