### PR TITLE
[PERFORMANCE] [MER-3692] Improve "Manage Section" view loading

### DIFF
--- a/lib/oli/delivery/attempts/manual_grading.ex
+++ b/lib/oli/delivery/attempts/manual_grading.ex
@@ -20,7 +20,6 @@ defmodule Oli.Delivery.Attempts.ManualGrading do
   }
 
   def has_submitted_attempts(%Section{id: section_id}) do
-
     query =
       ActivityAttempt
       |> join(:left, [aa], resource_attempt in ResourceAttempt,
@@ -35,7 +34,6 @@ defmodule Oli.Delivery.Attempts.ManualGrading do
       )
 
     Repo.exists?(query)
-
   end
 
   @doc """

--- a/lib/oli/delivery/attempts/manual_grading.ex
+++ b/lib/oli/delivery/attempts/manual_grading.ex
@@ -19,22 +19,23 @@ defmodule Oli.Delivery.Attempts.ManualGrading do
     ActivityAttempt
   }
 
-  def count_submitted_attempts(%Section{} = section) do
-    case browse_submitted_attempts(
-           section,
-           %Paging{limit: 1, offset: 0},
-           %Sorting{field: :date_submitted, direction: :asc},
-           %BrowseOptions{
-             user_id: nil,
-             activity_id: nil,
-             text_search: nil,
-             page_id: nil,
-             graded: nil
-           }
-         ) do
-      [] -> 0
-      [item] -> item.total_count
-    end
+  def has_submitted_attempts(%Section{id: section_id}) do
+
+    query =
+      ActivityAttempt
+      |> join(:left, [aa], resource_attempt in ResourceAttempt,
+        on: aa.resource_attempt_id == resource_attempt.id
+      )
+      |> join(:left, [_, resource_attempt], ra in ResourceAccess,
+        on: resource_attempt.resource_access_id == ra.id
+      )
+      |> where(
+        [aa, _resource_attempt, resource_access],
+        resource_access.section_id == ^section_id and aa.lifecycle_state == :submitted
+      )
+
+    Repo.exists?(query)
+
   end
 
   @doc """

--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -84,8 +84,8 @@ defmodule OliWeb.Sections.OverviewView do
            user: user,
            section: section,
            updates_count: updates_count,
-           submission_count:
-             Oli.Delivery.Attempts.ManualGrading.count_submitted_attempts(section),
+           has_submitted_attempts:
+             Oli.Delivery.Attempts.ManualGrading.has_submitted_attempts(section),
            collab_space_config: collab_space_config,
            resource_slug: revision_slug,
            show_required_section_config: show_required_section_config,
@@ -114,7 +114,7 @@ defmodule OliWeb.Sections.OverviewView do
   attr(:section, :any, default: nil)
   attr(:instructors, :list, default: [])
   attr(:updates_count, :integer)
-  attr(:submission_count, :integer)
+  attr(:has_submitted_attempts, :boolean)
   attr(:section_has_student_data, :boolean)
 
   def render(assigns) do
@@ -324,8 +324,8 @@ defmodule OliWeb.Sections.OverviewView do
               class="btn btn-link"
             >
               Score Manually Graded Activities
-              <%= if @submission_count > 0 do %>
-                <span class="badge badge-primary"><%= @submission_count %></span>
+              <%= if @has_submitted_attempts do %>
+                <span class="badge badge-primary">*</span>
               <% end %>
             </a>
           </li>


### PR DESCRIPTION
AppSignal shows many instances of slow loading times for the "Manage Section" view of the Instructor Dashboard.  The culprit is the query that counts the number of manually scored activity attempts that are awaiting the instructors' attention to manually score.  This PR optimizes this query by converting it to an "exists" style query, which necessitated moving away from including the count in the badge on the Manage Section view.  For now, a simple "*" is present in the badge. 