### PR TITLE
[FEATURE] [MER-3596] Migrate authoring bibliography live view to new workspace layout and live session

### DIFF
--- a/lib/oli_web/live/workspaces/course_author/bibliography_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/bibliography_live.ex
@@ -1,30 +1,64 @@
 defmodule OliWeb.Workspaces.CourseAuthor.BibliographyLive do
   use OliWeb, :live_view
 
+  alias Oli.Accounts
+  alias OliWeb.Common.React
+
+  on_mount {OliWeb.LiveSessionPlugs.AuthorizeProject, :default}
+
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
     project = socket.assigns.project
+    author = socket.assigns.current_author
+    is_admin? = Accounts.has_admin_role?(author)
+    ctx = socket.assigns.ctx
 
-    {:ok,
-     assign(socket,
-       resource_slug: project.slug,
-       resource_title: project.title,
-       active_workspace: :course_author,
-       active_view: :bibliography
-     )}
-  end
+    socket =
+      assign(socket,
+        resource_slug: project.slug,
+        resource_title: project.title,
+        project_slug: project.slug,
+        active_workspace: :course_author,
+        active_view: :bibliography,
+        is_admin?: is_admin?,
+        active: :bibliography,
+        ctx: ctx
+      )
 
-  @impl Phoenix.LiveView
-  def handle_params(_params, _url, socket) do
-    {:noreply, socket}
+    case Oli.Authoring.Editing.BibliographyEditor.create_context(project.slug, author) do
+      {:ok, context} ->
+        socket = assign(socket, context: context, scripts: Oli.Activities.get_activity_scripts())
+        {:ok, socket}
+
+      _ ->
+        socket =
+          socket
+          |> assign(context: %{}, scripts: [])
+          |> put_flash(:error, "Publication not found. Please check the URL and try again.")
+
+        {:ok, socket}
+    end
   end
 
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
-    <h1 class="flex flex-col w-full h-screen items-center justify-center">
-      Placeholder for Bibliography
-    </h1>
+    <div>
+      <script type="text/javascript" src={Routes.static_path(OliWeb.Endpoint, "/js/bibliography.js")}>
+      </script>
+      <script
+        :for={script <- @scripts}
+        type="text/javascript"
+        src={Routes.static_path(OliWeb.Endpoint, "/js/" <> script)}
+      >
+      </script>
+
+      <div id="editor" phx-update="ignore">
+        <%= React.component(@ctx, "Components.Bibliography", @context, id: "bibliography") %>
+      </div>
+
+      <%= React.component(@context, "Components.ModalDisplay", %{}, id: "modal-display") %>
+    </div>
     """
   end
 end

--- a/lib/oli_web/live_session_plugs/set_project.ex
+++ b/lib/oli_web/live_session_plugs/set_project.ex
@@ -1,25 +1,33 @@
 defmodule OliWeb.LiveSessionPlugs.SetProject do
+  use OliWeb, :verified_routes
+
   import Phoenix.Component, only: [assign: 2]
+  import Phoenix.LiveView, only: [redirect: 2, put_flash: 3]
+
+  alias Oli.Authoring.Course
+  alias Oli.Authoring.Course.Project
 
   def on_mount(:default, %{"project_id" => project_id}, _session, socket) do
-    project = Oli.Authoring.Course.get_project_by_slug(project_id)
+    project = Course.get_project_by_slug(project_id)
 
-    project =
-      case project.required_survey_resource_id do
-        nil ->
-          Map.put(project, :required_survey, nil)
+    case project do
+      nil ->
+        halt("Project not found", socket)
 
-        _ ->
-          required_survey = Oli.Authoring.Course.get_project_survey(project.id)
-          Map.put(project, :required_survey, required_survey)
-      end
+      %Project{required_survey_resource_id: nil} = project ->
+        {:cont, assign(socket, project: %{project | required_survey: nil})}
 
-    socket = assign(socket, project: project)
-
-    {:cont, socket}
+      %Project{required_survey_resource_id: _} = project ->
+        required_survey = Course.get_project_survey(project.id)
+        {:cont, assign(socket, project: %{project | required_survey: required_survey})}
+    end
   end
 
   def on_mount(:default, _params, _session, socket) do
     {:cont, socket}
+  end
+
+  defp halt(message, socket) do
+    {:halt, socket |> put_flash(:error, message) |> redirect(to: ~p"/workspaces/course_author")}
   end
 end

--- a/test/oli_web/live/workspace/course_author/bibliography_test.exs
+++ b/test/oli_web/live/workspace/course_author/bibliography_test.exs
@@ -1,0 +1,100 @@
+defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLiveTest do
+  use OliWeb.ConnCase
+
+  import Oli.Factory
+  import Phoenix.LiveViewTest
+
+  alias Oli.Resources.ResourceType
+
+  defp live_view_route(project_slug, params \\ %{}),
+    do: ~p"/workspaces/course_author/#{project_slug}/bibliography?#{params}"
+
+  describe "user cannot access when is not logged in" do
+    setup [:create_project]
+
+    test "redirects to new session when accessing the bibliography view", %{
+      conn: conn,
+      project: project
+    } do
+      {:error, {:redirect, %{to: redirect_path, flash: %{"error" => error_msg}}}} =
+        live(conn, live_view_route(project.slug))
+
+      assert redirect_path == "/workspaces/course_author"
+      assert error_msg == "You must be logged in to access that project"
+
+      {:ok, _view, html} = live(conn, redirect_path)
+
+      assert html =~
+               "<span class=\"text-white font-normal font-[&#39;Open Sans&#39;] leading-10\">\n            Welcome to\n          </span><span class=\"text-white font-bold font-[&#39;Open Sans&#39;] leading-10\">\n            OLI Torus\n          </span>"
+    end
+  end
+
+  describe "user cannot access when is logged in as an author but is not an author of the project" do
+    setup [:author_conn, :create_project]
+
+    test "redirects to projects view when accessing the bibliography view", %{
+      conn: conn,
+      project: project
+    } do
+      {:error, {:redirect, %{to: redirect_path, flash: %{"error" => error_msg}}}} =
+        live(conn, live_view_route(project.slug))
+
+      assert redirect_path == "/workspaces/course_author"
+      assert error_msg == "You don't have access to that project"
+
+      {:ok, view, _html} = live(conn, redirect_path)
+
+      assert view
+             |> element("#button-new-project")
+             |> render() =~ "New Project"
+    end
+  end
+
+  describe "bibliography" do
+    setup [:admin_conn, :create_project]
+
+    test "renders React component", %{conn: conn, project: project} do
+      {:ok, view, _html} = live(conn, live_view_route(project.slug))
+
+      assert has_element?(view, ~s(div[data-live-react-class='Components.Bibliography']))
+    end
+  end
+
+  ##### HELPER FUNCTIONS #####
+
+  defp create_project(_conn) do
+    author = insert(:author)
+    project = insert(:project, authors: [author])
+    # root container
+    container_resource = insert(:resource)
+
+    container_revision =
+      insert(:revision, %{
+        resource: container_resource,
+        resource_type_id: ResourceType.id_for_container(),
+        content: %{},
+        slug: "root_container",
+        title: "Root Container"
+      })
+
+    # Associate root container to the project
+    insert(:project_resource, %{project_id: project.id, resource_id: container_resource.id})
+    # Publication of project with root container
+    publication =
+      insert(:publication, %{
+        project: project,
+        published: nil,
+        root_resource_id: container_resource.id
+      })
+
+    # Publish root container resource
+    insert(:published_resource, %{
+      publication: publication,
+      resource: container_resource,
+      revision: container_revision,
+      author: author
+    })
+
+    [project: project, publication: publication]
+  end
+end


### PR DESCRIPTION
Ticket: [MER-3596](https://eliterate.atlassian.net/browse/MER-3596)

This PR migrated the authoring bibliography page to LiveView for use as part of the course author space.

[MER-3596]: https://eliterate.atlassian.net/browse/MER-3596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ