### PR TITLE
[FEATURE] [MER-3600] Migrate Review liveview

### DIFF
--- a/lib/oli_web/live/workspaces/course_author/qa/state.ex
+++ b/lib/oli_web/live/workspaces/course_author/qa/state.ex
@@ -1,6 +1,5 @@
 defmodule OliWeb.Workspaces.CourseAuthor.Qa.State do
   alias OliWeb.Common.SessionContext
-  alias OliWeb.Common.Breadcrumb
 
   @default_filters MapSet.new(["pedagogy", "content", "accessibility", "equity"])
 
@@ -13,7 +12,6 @@ defmodule OliWeb.Workspaces.CourseAuthor.Qa.State do
     parent_pages: %{},
     warnings_by_type: %{},
     warning_types: [],
-    breadcrumbs: [Breadcrumb.new(%{full_title: "Review"})],
     project: nil,
     author: nil
   }

--- a/lib/oli_web/live/workspaces/course_author/qa/state.ex
+++ b/lib/oli_web/live/workspaces/course_author/qa/state.ex
@@ -1,0 +1,173 @@
+defmodule OliWeb.Workspaces.CourseAuthor.Qa.State do
+  alias OliWeb.Common.SessionContext
+  alias OliWeb.Common.Breadcrumb
+
+  @default_filters MapSet.new(["pedagogy", "content", "accessibility", "equity"])
+
+  @default_state %{
+    active: :review,
+    filters: @default_filters,
+    filtered_warnings: [],
+    warnings: [],
+    qa_reviews: [],
+    parent_pages: %{},
+    warnings_by_type: %{},
+    warning_types: [],
+    breadcrumbs: [Breadcrumb.new(%{full_title: "Review"})],
+    project: nil,
+    author: nil
+  }
+
+  def from_params(state, params) do
+    filters =
+      case params["filters"] do
+        nil -> @default_filters
+        s -> String.split(s, ",") |> MapSet.new()
+      end
+
+    selected_id =
+      case params["selected"] do
+        nil ->
+          if is_nil(state.selected), do: nil, else: state.selected.id
+
+        id ->
+          id
+      end
+
+    state = Map.merge(state, Map.new(selection_changed(state, selected_id)))
+    set_filters(state, filters)
+  end
+
+  @spec to_params(MapSet.t(any), any) :: %{filters: binary, selected: any}
+  def to_params(filters, selected) do
+    %{
+      filters: MapSet.to_list(filters) |> Enum.join(","),
+      selected: selected
+    }
+  end
+
+  def initialize_state(
+        %SessionContext{author: author} = ctx,
+        project,
+        initial_review
+      ) do
+    changes =
+      Keyword.merge(
+        [
+          project: project,
+          author: author,
+          ctx: ctx,
+          title: "Review | " <> project.title
+        ],
+        new_review_ran(@default_state, initial_review)
+      )
+      |> Enum.reduce(%{}, fn {k, v}, m -> Map.put(m, k, v) end)
+
+    Map.merge(@default_state, changes)
+  end
+
+  def new_review_ran(state, {warnings, parent_pages, qa_reviews}) do
+    Keyword.merge(
+      [
+        selected: nil,
+        qa_reviews: qa_reviews,
+        parent_pages: parent_pages
+      ],
+      update_warnings(state, warnings)
+    )
+  end
+
+  def toggle_filter(state, filter_type) do
+    if MapSet.member?(state.filters, filter_type) do
+      MapSet.delete(state.filters, filter_type)
+    else
+      MapSet.put(state.filters, filter_type)
+    end
+  end
+
+  def set_filters(state, filters) do
+    filtered_warnings = filter_warnings(filters, state.warnings)
+
+    selected =
+      case Enum.find(filtered_warnings, fn w -> w == state.selected end) do
+        nil -> Enum.at(filtered_warnings, 0, nil)
+        item -> item
+      end
+
+    [
+      filtered_warnings: filtered_warnings,
+      filters: filters,
+      selected: selected
+    ]
+  end
+
+  def selection_changed(_, nil), do: []
+  def selection_changed(_, ""), do: []
+
+  def selection_changed(state, warning_id) do
+    warning_id = if is_binary(warning_id), do: String.to_integer(warning_id), else: warning_id
+    [selected: Enum.find(state.warnings, fn r -> r.id == warning_id end)]
+  end
+
+  def warning_dismissed(state, warning_id) do
+    warnings = Enum.filter(state.warnings, fn %{id: id} -> id !== warning_id end)
+
+    selected =
+      case state.selected do
+        nil -> nil
+        %{id: ^warning_id} -> select_another(state.filtered_warnings, state.selected)
+        _ -> state.selected
+      end
+
+    Keyword.merge(
+      [
+        selected: selected
+      ],
+      update_warnings(state, warnings)
+    )
+  end
+
+  def warning_arrived(state, warning) do
+    warnings =
+      case Enum.find(state.warnings, nil, fn %{id: id} -> id == warning.id end) do
+        nil -> state.warnings
+        _ -> [warning | state.warnings]
+      end
+
+    update_warnings(state, warnings)
+  end
+
+  defp filter_warnings(filters, warnings) do
+    Enum.filter(warnings, fn w -> MapSet.member?(filters, w.review.type) end)
+  end
+
+  defp update_warnings(state, active_warnings) do
+    warnings =
+      active_warnings
+      |> Enum.sort_by(&{&1.review.type, &1.subtype})
+
+    warnings_by_type =
+      warnings
+      |> Enum.group_by(& &1.review.type)
+
+    warning_types = Map.keys(warnings_by_type)
+
+    [
+      filtered_warnings: filter_warnings(state.filters, warnings),
+      warnings: warnings,
+      warnings_by_type: warnings_by_type,
+      warning_types: warning_types
+    ]
+  end
+
+  defp select_another(warnings, item) do
+    index = Enum.find_index(warnings, fn w -> w == item end)
+    last_index = length(warnings) - 1
+
+    case {last_index, index} do
+      {0, _} -> nil
+      {last, last} -> Enum.at(warnings, last - 1)
+      {_, index} -> Enum.at(warnings, index + 1)
+    end
+  end
+end

--- a/lib/oli_web/live/workspaces/course_author/qa/utils.ex
+++ b/lib/oli_web/live/workspaces/course_author/qa/utils.ex
@@ -1,0 +1,145 @@
+defmodule OliWeb.Workspaces.CourseAuthor.Qa.Utils do
+  use Phoenix.HTML
+
+  def warning_icon(type) do
+    case type do
+      "accessibility" -> {"fa-brands fa-accessible-icon", "#ffd868"}
+      "content" -> {"fa-regular fa-image", "#ffa351ff"}
+      "pedagogy" -> {"fa-solid fa-person-chalkboard", "#ffbe7bff"}
+      _ -> {"fa-solid fa-triangle-exclamation", "#eed971ff"}
+    end
+    |> icon()
+    |> raw()
+  end
+
+  def icon({name, color}) do
+    ~s|<i style="color: #{color}" class="#{name}"></i>|
+  end
+
+  def warning_selected?(selected, warning) do
+    case selected == warning do
+      true -> " active"
+      false -> ""
+    end
+  end
+
+  def explanatory_text(subtype, context \\ %{}) do
+    case subtype do
+      "missing alt text" ->
+        """
+        <p>
+          Providing alternative text for non-text content such as images and videos enables users
+          with visual impairments to understand the reason and context for the provided content.
+        </p>
+        <p>
+          For more information on the importance of providing contextual alternative text to non-text content, see the
+          <a href="https://webaim.org/techniques/alttext/#basics" target="_blank">alt text accessibility guide</a> on WebAIM.org.
+        </p>
+        """
+
+      "nondescriptive link text" ->
+        """
+        <p>
+          Links are more useful to users when they are provided with descriptive context instead of a raw URL or
+          generic text such as "click here" or "learn more."
+        </p>
+        <p>
+          For more information on the importance of providing textual context for links, see the
+          <a href="https://webaim.org/techniques/hypertext/link_text#text" target="_blank">Link text accessibility guide</a> on WebAIM.org.
+        </p>
+        """
+
+      "broken remote resource" ->
+        """
+        <p>
+          A link or an image hosted on another website was not able to be found. This might be a temporary problem, or it could
+          mean the link or image path is broken and needs to be updated.
+        </p>
+        """
+
+      "no attached objectives" ->
+        """
+        <p>
+          One of the Open Learning Initiative's core features is providing analytics on course content to identify
+          areas in the course that can be improved. This only works when pages and activities have objectives attached to them.
+        </p>
+        <p>
+          You can publish a course without linking objectives to course content, but no analytics will be generated for this content.
+        </p>
+        <p>
+          For more information on the importance of attaching learning objectives to pages and activities, see the
+          <a class="external" href="https://www.cmu.edu/teaching/designteach/design/learningobjectives.html" target="_blank">guide on learning objectives</a> from the CMU Eberly Center.
+        </p>
+        """
+
+      "no attached activities" ->
+        case context[:graded] do
+          true ->
+            """
+            <p>
+              This graded page does not have any attached activities. In order to provide a grade, the page must have at least one activity.
+            </p>
+            """
+
+          _ ->
+            """
+            <p>
+              This page does not provide any practice opportunities in the form of activities for the material students may have learned on the page.
+              That's fine for introductory or conclusory pages, but pages with learning content should generally provide practice opportunities.
+            </p>
+            <p>
+              For more information on the importance of providing practice opportunities in pages, see the
+              <a class="external" href="https://www.cmu.edu/teaching/designteach/design/assessments.html" target="_blank">guide on assessments</a> from the CMU Eberly Center.
+            </p>
+            """
+        end
+
+      _ ->
+        ""
+    end
+    |> raw()
+  end
+
+  def action_item(subtype, context \\ %{}) do
+    case subtype do
+      "missing alt text" ->
+        """
+        <p>Add alternative text to this content</p>
+        """
+
+      "nondescriptive link text" ->
+        """
+        <p>Provide more descriptive text for this link</p>
+        """
+
+      "broken remote resource" ->
+        """
+        <p>Check to make sure this link or image is not broken</p>
+        """
+
+      "no attached objectives" ->
+        """
+        <p>Attach a learning objective to this page or activity</p>
+        """
+
+      "no attached activities" ->
+        case context[:graded] do
+          true ->
+            """
+            <p>Add an activity to this page or change it to an ungraded page</p>
+            """
+
+          _ ->
+            """
+            <p>Consider adding an activity to this page if it provides learning content</p>
+            """
+        end
+
+      _ ->
+        """
+        <p>This content has an issue</p>
+        """
+    end
+    |> raw()
+  end
+end

--- a/lib/oli_web/live/workspaces/course_author/qa/warning_details.ex
+++ b/lib/oli_web/live/workspaces/course_author/qa/warning_details.ex
@@ -1,0 +1,108 @@
+defmodule OliWeb.Workspaces.CourseAuthor.Qa.WarningDetails do
+  use OliWeb, :html
+  import OliWeb.Workspaces.CourseAuthor.Qa.Utils
+  alias OliWeb.Common.Links
+
+  def render(assigns) do
+    ~H"""
+    <style>
+      .delivery-container img {
+        max-width: 300px;
+      }
+      .delivery-container iframe {
+        max-width: 300px;
+      }
+    </style>
+    <div class="review-card active" id={"#{@selected.id}"}>
+      <h4 class="d-flex">
+        <div>
+          Improvement opportunity on <%= Links.resource_link(
+            @selected.revision,
+            @parent_pages,
+            @project
+          ) %>
+        </div>
+        <div class="flex-fill"></div>
+        <button class="btn btn-sm btn-secondary" phx-click="dismiss">
+          <i class="fa fa-times"></i> Dismiss
+        </button>
+      </h4>
+      <div class="bd-callout bd-callout-info">
+        <h3>
+          <%= String.capitalize(@selected.subtype) %> on <%= @selected.revision.resource_type.type %>
+        </h3>
+        <%= explanatory_text(@selected.subtype, %{graded: @selected.revision.graded}) %>
+      </div>
+      <div class="alert alert-info">
+        <strong>Action item</strong> <%= action_item(@selected.subtype, %{
+          graded: @selected.revision.graded
+        }) %>
+        <div class="delivery-container">
+          <.warning
+            :if={@selected.content}
+            selected={@selected}
+            project_slug={@project.slug}
+            author={@author}
+          />
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  attr(:selected, :map, required: true)
+  attr(:project_slug, :string, required: true)
+  attr(:author, :map, required: true)
+
+  def warning(
+        %{selected: %{subtype: "No value provided for criteria in bank selection logic"}} =
+          assigns
+      ) do
+    ~H"""
+    <p>
+      This page contains an activity bank selection whose logic, when tested by this QA Review run,
+      did not yield activities to satisfy the specified criteria in the selection.
+    </p>
+    <p>
+      Fix this issue by adding a value for the criteria in the
+      <.link navigate={~p"/authoring/project/#{@project_slug}/resource/#{@selected.revision.slug}"}>
+        selection logic in the page.
+      </.link>
+    </p>
+    """
+  end
+
+  def warning(%{selected: %{content: %{"type" => "selection"}}} = assigns) do
+    ~H"""
+    <p>
+      This page contains an activity bank selection whose logic, when tested by this QA Review run,
+      did not yield enough activities to satisfy the specified count in the selection.
+    </p>
+    <p>
+      Fix this issue by one of two ways:
+    </p>
+    <ol>
+      <li>
+        Edit the
+        <.link navigate={~p"/authoring/project/#{@project_slug}/resource/#{@selected.revision.slug}"}>
+          selection logic in the page
+        </.link>
+        to allow it to select more activities
+      </li>
+      <li>Create more banked activities to allow the selection to fill the specified count</li>
+    </ol>
+    """
+  end
+
+  def warning(assigns) do
+    ~H"""
+    <%= Phoenix.HTML.raw(
+      Oli.Rendering.Content.render(
+        %Oli.Rendering.Context{user: @author},
+        @selected.content,
+        Oli.Rendering.Content.Html
+      )
+    ) %>
+    """
+  end
+end

--- a/lib/oli_web/live/workspaces/course_author/qa/warning_filter.ex
+++ b/lib/oli_web/live/workspaces/course_author/qa/warning_filter.ex
@@ -1,0 +1,25 @@
+defmodule OliWeb.Workspaces.CourseAuthor.Qa.WarningFilter do
+  use Phoenix.LiveComponent
+
+  def render(assigns) do
+    ~H"""
+    <div class="m-2">
+      <div class="flex flex-row items-center">
+        <input
+          class="warning-filter w-[20px] h-[20px]"
+          id={"filter-#{@type}"}
+          phx-click="filter"
+          phx-value-type={"#{@type}"}
+          {if @active do [checked: true] else [] end}
+          type="checkbox"
+          aria-label={"Checkbox for #{@type}"}
+        />
+        <label for={"filter-#{@type}"} class="flex flex-row align-items-center ml-2">
+          <%= String.capitalize(@type) %>
+          <span class="badge badge-info ml-2"><%= length(@warnings) %></span>
+        </label>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/oli_web/live/workspaces/course_author/qa/warning_summary.ex
+++ b/lib/oli_web/live/workspaces/course_author/qa/warning_summary.ex
@@ -1,0 +1,26 @@
+defmodule OliWeb.Workspaces.CourseAuthor.Qa.WarningSummary do
+  use OliWeb, :html
+  import OliWeb.Workspaces.CourseAuthor.Qa.Utils
+
+  attr(:warning, :map, required: true)
+  attr(:selected, :map, required: true)
+
+  def render(assigns) do
+    ~H"""
+    <li
+      tabindex="0"
+      class={"review-link #{warning_selected?(@warning, @selected)}"}
+      phx-click="select"
+      phx-value-warning={@warning.id}
+      phx-keydown="keydown"
+    >
+      <span class="review-link-header">
+        <%= warning_icon(@warning.review.type) %> <%= String.capitalize(@warning.subtype) %>
+      </span>
+      <span class="d-flex justify-content-between review-link-subheader">
+        <%= @warning.revision.title %>
+      </span>
+    </li>
+    """
+  end
+end

--- a/lib/oli_web/live/workspaces/course_author/review_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/review_live.ex
@@ -1,30 +1,221 @@
 defmodule OliWeb.Workspaces.CourseAuthor.ReviewLive do
   use OliWeb, :live_view
 
+  alias Oli.Authoring.Broadcaster
+  alias Oli.Authoring.Broadcaster.Subscriber
+  alias Oli.{Publishing, Qa, Repo}
+  alias Oli.Resources.ResourceType
+  alias OliWeb.Common.Utils
+  alias OliWeb.Workspaces.CourseAuthor.Qa.{State, WarningFilter, WarningSummary, WarningDetails}
+
+  on_mount {OliWeb.LiveSessionPlugs.AuthorizeProject, :default}
+
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    project = socket.assigns.project
+    %{project: project, ctx: ctx} = socket.assigns
+
+    subscribe(project.slug)
+
+    initial_state =
+      Map.merge(State.initialize_state(ctx, project, read_current_review(project)), %{
+        resource_slug: project.slug,
+        resource_title: project.title,
+        active_workspace: :course_author,
+        active_view: :review
+      })
 
     {:ok,
-     assign(socket,
-       resource_slug: project.slug,
-       resource_title: project.title,
-       active_workspace: :course_author,
-       active_view: :review
+     assign(
+       socket,
+       initial_state
      )}
   end
 
   @impl Phoenix.LiveView
-  def handle_params(_params, _url, socket) do
-    {:noreply, socket}
+  def handle_params(params, _, socket) do
+    {:noreply, assign(socket, State.from_params(socket.assigns, params))}
   end
 
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
-    <h1 class="flex flex-col w-full h-screen items-center justify-center">
-      Placeholder for Review
-    </h1>
+    <div class="container review p-8">
+      <div class="grid grid-cols-12">
+        <div class="col-span-12">
+          <p>
+            Run an automated review before publishing to check for broken links and other common issues that may be present in your course.
+          </p>
+
+          <button
+            class="btn btn-primary mt-3"
+            id="button-publish"
+            phx-click="review"
+            phx-disable-with="Reviewing..."
+          >
+            Run Review
+          </button>
+
+          <.link
+            class="btn btn-outline-primary mt-3 ml-2"
+            href={~p"/authoring/project/#{@project.slug}/preview"}
+            target={"preview-#{@project.slug}"}
+          >
+            Preview Course <i class="fas fa-external-link-alt ml-1"></i>
+          </.link>
+        </div>
+      </div>
+
+      <%= if !Enum.empty?(@qa_reviews) do %>
+        <div class="grid grid-cols-12 mt-4">
+          <div class="col-span-12">
+            <p class="mb-3">
+              Last reviewed <strong><%= Utils.render_date(hd(@qa_reviews), :inserted_at, @ctx) %></strong>,
+              with <strong><%= length(@warnings) %></strong>
+              potential improvement <%= if length(@warnings) == 1,
+                do: "opportunity",
+                else: "opportunities" %> found.
+            </p>
+            <%= if !Enum.empty?(@warnings_by_type) do %>
+              <div class="d-flex">
+                <%= for type <- @warning_types do %>
+                  <.live_component
+                    module={WarningFilter}
+                    active={MapSet.member?(@filters, type)}
+                    type={type}
+                    warnings={Map.get(@warnings_by_type, type)}
+                    id={"filter-#{type}"}
+                  />
+                <% end %>
+              </div>
+
+              <div class="reviews">
+                <ul class="review-links">
+                  <WarningSummary.render
+                    :for={warning <- @filtered_warnings}
+                    warning={warning}
+                    selected={@selected}
+                  />
+                </ul>
+                <div class="review-cards">
+                  <WarningDetails.render
+                    :if={@selected != nil}
+                    parent_pages={@parent_pages}
+                    selected={@selected}
+                    author={@author}
+                    project={@project}
+                    warning={@selected}
+                  />
+                </div>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    </div>
     """
+  end
+
+  # spin up subscriptions for running of reviews and dismissal of warnings
+  defp subscribe(project_slug) do
+    Subscriber.subscribe_to_new_reviews(project_slug)
+    Subscriber.subscribe_to_warning_dismissals(project_slug)
+    Subscriber.subscribe_to_warning_new(project_slug)
+  end
+
+  def read_current_review(project) do
+    warnings = Qa.Warnings.list_active_warnings(project.id)
+    qa_reviews = Qa.Reviews.list_reviews(project.id)
+
+    parent_pages =
+      warnings
+      |> Enum.filter(fn w -> w.revision.resource_type_id == ResourceType.id_for_activity() end)
+      |> Enum.map(fn w -> w.revision.resource_id end)
+      |> Publishing.determine_parent_pages(
+        Publishing.project_working_publication(project.slug).id
+      )
+
+    {warnings, parent_pages, qa_reviews}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("dismiss", _, socket) do
+    warning_id = socket.assigns.selected.id
+
+    socket =
+      case Qa.Warnings.dismiss_warning(warning_id) do
+        {:ok, _} ->
+          Broadcaster.broadcast_dismiss_warning(
+            warning_id,
+            socket.assigns.project.slug
+          )
+
+          socket
+
+        {:error, _changeset} ->
+          socket
+          |> put_flash(:error, "Could not dimiss warning")
+      end
+
+    {:noreply, socket}
+  end
+
+  def handle_event("filter", %{"type" => type}, socket) do
+    %{selected: selected, project: project} = assigns = socket.assigns
+    filters = State.toggle_filter(assigns, type)
+
+    selected_id =
+      if is_nil(selected), do: "", else: selected.id
+
+    params = State.to_params(filters, selected_id)
+
+    {:noreply,
+     push_patch(socket,
+       to: ~p"/workspaces/course_author/#{project.slug}/review?#{params}",
+       replace: true
+     )}
+  end
+
+  def handle_event("select", %{"warning" => warning_id}, socket) do
+    %{filters: filters, project: project} = socket.assigns
+    params = State.to_params(filters, warning_id)
+
+    {:noreply,
+     push_patch(socket,
+       to: ~p"/workspaces/course_author/#{project.slug}/review?#{params}",
+       replace: true
+     )}
+  end
+
+  def handle_event("review", _, socket) do
+    project_slug = socket.assigns.project.slug
+    Qa.review_project(project_slug)
+    Broadcaster.broadcast_review(project_slug)
+
+    {:noreply, socket}
+  end
+
+  def handle_event("keydown", %{"warning" => warning_id, "key" => key}, socket) do
+    case key do
+      "Enter" -> handle_event("select", %{"warning" => warning_id}, socket)
+      _ -> {:noreply, socket}
+    end
+  end
+
+  @impl Phoenix.LiveView
+  def handle_info({:new_review, _}, socket) do
+    {:noreply,
+     assign(
+       socket,
+       State.new_review_ran(socket.assigns, read_current_review(socket.assigns.project))
+     )}
+  end
+
+  def handle_info({:dismiss_warning, warning_id, _}, socket) do
+    {:noreply, assign(socket, State.warning_dismissed(socket.assigns, warning_id))}
+  end
+
+  def handle_info({:new_warning, warning_id, _}, socket) do
+    warning = Qa.Warnings.get_warning!(warning_id) |> Repo.preload([:review, :revision])
+    {:noreply, assign(socket, State.warning_arrived(socket.assigns, warning))}
   end
 end

--- a/test/oli_web/live/workspace/course_author/qa_logic_test.exs
+++ b/test/oli_web/live/workspace/course_author/qa_logic_test.exs
@@ -1,0 +1,279 @@
+defmodule OliWeb.Workspaces.CourseAuthor.StateLogicTest do
+  use Oli.DataCase
+
+  alias Oli.Qa.Reviewers.Pedagogy
+  alias Oli.Qa.Reviewers.Content
+  alias Oli.Publishing
+
+  alias OliWeb.Common.SessionContext
+  alias OliWeb.Workspaces.CourseAuthor.ReviewLive
+  alias OliWeb.Workspaces.CourseAuthor.Qa.State
+
+  def merge_changes(changes, state) do
+    Map.merge(state, Enum.reduce(changes, %{}, fn {k, v}, m -> Map.put(m, k, v) end))
+  end
+
+  describe "qa live state" do
+    setup do
+      map =
+        Seeder.base_project_with_resource2()
+        |> Seeder.add_objective("I love writing objectives", :o1)
+        |> Seeder.add_review("pedagogy", :review)
+        |> Seeder.add_review("content", :content)
+
+      map
+      |> Seeder.add_page(%{objectives: %{"attached" => []}}, :page_no_objectives)
+      |> Seeder.add_page(
+        %{objectives: %{"attached" => [Map.get(map, :o1).resource.id]}},
+        :page_has_objectives
+      )
+      |> Seeder.add_page(
+        %{
+          content: %{
+            "model" => [
+              %{
+                "children" => [
+                  %{
+                    "children" => [
+                      %{"text" => " "},
+                      %{
+                        "children" => [%{"text" => "link"}],
+                        "href" => "gg",
+                        "id" => "1914651063",
+                        "target" => "self",
+                        "type" => "a"
+                      },
+                      %{"text" => ""}
+                    ],
+                    "id" => "3636822762",
+                    "type" => "p"
+                  }
+                ],
+                "id" => "481882791",
+                "purpose" => "None",
+                "type" => "content"
+              },
+              %{
+                "activity_id" => 10,
+                "children" => [],
+                "id" => "3781635590",
+                "purpose" => "None",
+                "type" => "activity-reference"
+              }
+            ]
+          }
+        },
+        :page_has_activities
+      )
+      |> Seeder.add_activity(%{objectives: %{}}, :activity_no_objectives)
+      |> Seeder.add_activity(%{objectives: %{}}, :activity_no_objectives)
+      |> Seeder.add_activity(%{objectives: %{}}, :activity_no_objectives)
+      |> Seeder.add_activity(
+        %{objectives: %{"1" => [Map.get(map, :o1).resource.id]}},
+        :activity_has_objectives
+      )
+      |> Map.put(
+        :pages,
+        Publishing.get_unpublished_revisions_by_type(Map.get(map, :project).slug, "page")
+      )
+      |> Map.put(
+        :activities,
+        Publishing.get_unpublished_revisions_by_type(Map.get(map, :project).slug, "activity")
+      )
+    end
+
+    test "filtering", %{
+      project: project,
+      review: review,
+      content: content,
+      activities: activities,
+      author: author
+    } do
+      Pedagogy.no_attached_objectives(review, activities)
+      Content.broken_uris(content, project.slug)
+
+      current_review = ReviewLive.read_current_review(project)
+      context = SessionContext.init() |> Map.put(:author, author)
+
+      state = State.initialize_state(context, project, current_review)
+
+      # test filtering out of pedagogy, and ensure that a selected pedagogy item gets converted to the content warning
+      first_pedagogy_warning =
+        Enum.filter(state.warnings, fn w -> w.review.type == "pedagogy" end) |> hd
+
+      first_content_warning =
+        Enum.filter(state.warnings, fn w -> w.review.type == "content" end) |> hd
+
+      state =
+        State.selection_changed(state, Integer.to_string(first_pedagogy_warning.id))
+        |> merge_changes(state)
+
+      assert state.filters == MapSet.new(["pedagogy", "content", "equity", "accessibility"])
+      assert length(state.filtered_warnings) == length(state.warnings)
+
+      state =
+        State.set_filters(state, State.toggle_filter(state, "pedagogy")) |> merge_changes(state)
+
+      assert state.filters == MapSet.new(["content", "equity", "accessibility"])
+      assert length(state.filtered_warnings) != length(state.warnings)
+      assert state.selected == first_content_warning
+
+      # turn off content filter, which should result then in zero warnings being displayed
+      state =
+        State.set_filters(state, State.toggle_filter(state, "content")) |> merge_changes(state)
+
+      assert state.filters == MapSet.new(["accessibility", "equity"])
+      assert length(state.filtered_warnings) == 0
+
+      # bring back pedagody and select the first pedagogy, then bring back content,
+      # ensuring that the selection of that pedagogy item remains
+      state =
+        State.set_filters(state, State.toggle_filter(state, "pedagogy")) |> merge_changes(state)
+
+      assert state.filters == MapSet.new(["pedagogy", "accessibility", "equity"])
+
+      state =
+        State.selection_changed(state, Integer.to_string(first_pedagogy_warning.id))
+        |> merge_changes(state)
+
+      assert state.selected == first_pedagogy_warning
+
+      state =
+        State.set_filters(state, State.toggle_filter(state, "content")) |> merge_changes(state)
+
+      assert state.filters == MapSet.new(["pedagogy", "content", "accessibility", "equity"])
+      assert state.selected == first_pedagogy_warning
+    end
+
+    test "dismissal when the item is first selected", %{
+      project: project,
+      review: review,
+      content: content,
+      activities: activities,
+      author: author
+    } do
+      Pedagogy.no_attached_objectives(review, activities)
+      Content.broken_uris(content, project.slug)
+
+      current_review = ReviewLive.read_current_review(project)
+      context = SessionContext.init() |> Map.put(:author, author)
+
+      state = State.initialize_state(context, project, current_review)
+
+      # if we have the first one selected, it selects the second
+      pedagogy_warnings = Enum.filter(state.warnings, fn w -> w.review.type == "pedagogy" end)
+      first = Enum.at(pedagogy_warnings, 0)
+      second = Enum.at(pedagogy_warnings, 1)
+      state = State.selection_changed(state, Integer.to_string(first.id)) |> merge_changes(state)
+
+      state = State.warning_dismissed(state, first.id) |> merge_changes(state)
+      assert state.selected == second
+    end
+
+    test "dismissal when the item is last selected", %{
+      project: project,
+      review: review,
+      content: content,
+      activities: activities,
+      author: author
+    } do
+      Pedagogy.no_attached_objectives(review, activities)
+      Content.broken_uris(content, project.slug)
+
+      current_review = ReviewLive.read_current_review(project)
+      context = SessionContext.init() |> Map.put(:author, author)
+
+      state = State.initialize_state(context, project, current_review)
+
+      # if we have the last one selected, it selects the next to last
+      pedagogy_warnings = Enum.filter(state.warnings, fn w -> w.review.type == "pedagogy" end)
+      last = Enum.at(pedagogy_warnings, length(pedagogy_warnings) - 1)
+      next_to_last = Enum.at(pedagogy_warnings, length(pedagogy_warnings) - 2)
+      state = State.selection_changed(state, Integer.to_string(last.id)) |> merge_changes(state)
+
+      state = State.warning_dismissed(state, last.id) |> merge_changes(state)
+      assert state.selected == next_to_last
+    end
+
+    test "dismissal when the item is not first or last, but selected", %{
+      project: project,
+      review: review,
+      content: content,
+      activities: activities,
+      author: author
+    } do
+      Pedagogy.no_attached_objectives(review, activities)
+      Content.broken_uris(content, project.slug)
+
+      current_review = ReviewLive.read_current_review(project)
+      context = SessionContext.init() |> Map.put(:author, author)
+
+      state = State.initialize_state(context, project, current_review)
+
+      # if we have the second one selected, it selects the next (third)
+      pedagogy_warnings = Enum.filter(state.warnings, fn w -> w.review.type == "pedagogy" end)
+      third = Enum.at(pedagogy_warnings, 2)
+      second = Enum.at(pedagogy_warnings, 1)
+      state = State.selection_changed(state, Integer.to_string(second.id)) |> merge_changes(state)
+
+      state = State.warning_dismissed(state, second.id) |> merge_changes(state)
+      assert state.selected == third
+    end
+
+    test "dismissal when the dismissed is not selected", %{
+      project: project,
+      review: review,
+      content: content,
+      activities: activities,
+      author: author
+    } do
+      Pedagogy.no_attached_objectives(review, activities)
+      Content.broken_uris(content, project.slug)
+
+      current_review = ReviewLive.read_current_review(project)
+      context = SessionContext.init() |> Map.put(:author, author)
+
+      state = State.initialize_state(context, project, current_review)
+
+      # if we have the second one selected, it selects the next (third)
+      pedagogy_warnings = Enum.filter(state.warnings, fn w -> w.review.type == "pedagogy" end)
+      third = Enum.at(pedagogy_warnings, 2)
+      second = Enum.at(pedagogy_warnings, 1)
+      state = State.selection_changed(state, Integer.to_string(second.id)) |> merge_changes(state)
+
+      state = State.warning_dismissed(state, third.id) |> merge_changes(state)
+      assert state.selected == second
+    end
+
+    test "dismissing the last warning in a filtered state should not select a new warning for display",
+         %{
+           project: project,
+           review: review,
+           content: content,
+           activities: activities,
+           author: author
+         } do
+      Pedagogy.no_attached_objectives(review, activities)
+      Content.broken_uris(content, project.slug)
+
+      current_review = ReviewLive.read_current_review(project)
+      context = SessionContext.init() |> Map.put(:author, author)
+
+      state = State.initialize_state(context, project, current_review)
+
+      state =
+        State.set_filters(state, State.toggle_filter(state, "pedagogy")) |> merge_changes(state)
+
+      assert state.filters == MapSet.new(["content", "accessibility", "equity"])
+
+      assert length(state.filtered_warnings) == 1
+
+      # if we dismiss the last warning in a filtered state when there are other warnings that are filtered out,
+      # the UI should not select and show one of the filtered out warnings, the selection should be nil
+      state =
+        State.warning_dismissed(state, hd(state.filtered_warnings).id) |> merge_changes(state)
+
+      assert state.selected == nil
+    end
+  end
+end

--- a/test/oli_web/live/workspace/course_author_test.exs
+++ b/test/oli_web/live/workspace/course_author_test.exs
@@ -566,6 +566,22 @@ defmodule OliWeb.Workspace.CourseAuthorTest do
       assert has_element?(view, ~s(#activity-bank))
       assert has_element?(view, ~s(div[data-live-react-class='Components.ActivityBank']))
     end
+
+    test "review menu is shown correctly", %{
+      conn: conn,
+      project: project
+    } do
+      {:ok, view, _html} = live(conn, ~p"/workspaces/course_author/#{project.slug}/review")
+
+      assert has_element?(
+               view,
+               "p",
+               "Run an automated review before publishing to check for broken links and other common issues that may be present in your course."
+             )
+
+      assert has_element?(view, "button", "Run Review")
+      assert has_element?(view, "a", "Preview Course")
+    end
   end
 
   defp create_project_with_owner(owner, attrs \\ %{}) do


### PR DESCRIPTION
[MER-3600](https://eliterate.atlassian.net/browse/MER-3600)

This PR migrates the `Review` liveview to be accessible from the new menu for the course author workspace.

In addition to the liveview, the necessary components used by the main liveview are migrated, as well as the existing logic tests.


https://github.com/user-attachments/assets/6d5935e7-3901-4860-9216-b8c84670b800





[MER-3600]: https://eliterate.atlassian.net/browse/MER-3600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ