### PR TITLE
[BUG FIX] [MER-3707] Add Cashnet enrollment check

### DIFF
--- a/lib/oli_web/controllers/payment_controller.ex
+++ b/lib/oli_web/controllers/payment_controller.ex
@@ -16,47 +16,52 @@ defmodule OliWeb.PaymentController do
     user = conn.assigns.current_user
     section = conn.assigns.section
 
-    if user.guest do
-      render(conn, "require_account.html", section_slug: section_slug)
+    if Sections.is_enrolled?(user.id, section_slug) do
+      if user.guest do
+        render(conn, "require_account.html", section_slug: section_slug)
+      else
+        context = SessionContext.init(conn)
+
+        section =
+          section
+          |> Sections.localize_section_start_end_datetimes(context)
+
+        summary = Paywall.summarize_access(user, section)
+
+        grace_period_seconds =
+          if summary.grace_period_remaining == nil, do: 0, else: summary.grace_period_remaining
+
+        now_date = FormatDateTime.convert_datetime(DateTime.utc_now(), context)
+        payment_due_date = DateTime.add(now_date, grace_period_seconds, :second)
+
+        {:ok, amount} = Money.to_string(section.amount)
+
+        instructors =
+          Sections.fetch_instructors(section.slug)
+          |> Enum.reduce([], fn a, m ->
+            m ++ [a.name]
+          end)
+
+        render(conn, "guard.html",
+          context: context,
+          pay_by_card?:
+            direct_payments_enabled?() and
+              (section.payment_options == :direct or section.payment_options == :direct_and_deferred),
+          pay_by_code?:
+            section.payment_options == :deferred or section.payment_options == :direct_and_deferred,
+          section_slug: section_slug,
+          section_title: section.title,
+          section: section,
+          instructors: Enum.join(instructors, ", "),
+          amount: amount,
+          payment_due_date: %{payment_due_date: payment_due_date},
+          grace_period_days: not is_nil(summary.grace_period_remaining)
+        )
+      end
     else
-      context = SessionContext.init(conn)
-
-      section =
-        section
-        |> Sections.localize_section_start_end_datetimes(context)
-
-      summary = Paywall.summarize_access(user, section)
-
-      grace_period_seconds =
-        if summary.grace_period_remaining == nil, do: 0, else: summary.grace_period_remaining
-
-      now_date = FormatDateTime.convert_datetime(DateTime.utc_now(), context)
-      payment_due_date = DateTime.add(now_date, grace_period_seconds, :second)
-
-      {:ok, amount} = Money.to_string(section.amount)
-
-      instructors =
-        Sections.fetch_instructors(section.slug)
-        |> Enum.reduce([], fn a, m ->
-          m ++ [a.name]
-        end)
-
-      render(conn, "guard.html",
-        context: context,
-        pay_by_card?:
-          direct_payments_enabled?() and
-            (section.payment_options == :direct or section.payment_options == :direct_and_deferred),
-        pay_by_code?:
-          section.payment_options == :deferred or section.payment_options == :direct_and_deferred,
-        section_slug: section_slug,
-        section_title: section.title,
-        section: section,
-        instructors: Enum.join(instructors, ", "),
-        amount: amount,
-        payment_due_date: %{payment_due_date: payment_due_date},
-        grace_period_days: not is_nil(summary.grace_period_remaining)
-      )
+      render(conn, "not_enrolled.html", section_slug: section_slug)
     end
+
   end
 
   # Returns the module for the configured payment provider

--- a/lib/oli_web/controllers/payment_providers/cashnet_controller.ex
+++ b/lib/oli_web/controllers/payment_providers/cashnet_controller.ex
@@ -27,25 +27,34 @@ defmodule OliWeb.PaymentProviders.CashnetController do
         _ -> Decimal.to_string(decimal)
       end
 
-    case Cashnet.create_form(section, user, conn.host) do
-      {:ok, %{payment_ref: _payment_ref, cashnet_form: cashnet_form}} ->
-        # This is necessary since this controller has been delegated by PaymentController
-        Phoenix.Controller.put_view(conn, OliWeb.PaymentProviders.CashnetView)
-        |> render("index.html",
-          api_key: Application.fetch_env!(:oli, :stripe_provider)[:public_secret],
-          purchase: Jason.encode!(%{user_id: user.id, section_slug: section.slug}),
-          section: section,
-          cost: cost,
-          cashnet_form: cashnet_form,
-          user: user,
-          user_name:
-            safe_get(user.family_name, "Unknown") <> ", " <> safe_get(user.given_name, "Unknown")
-        )
+    if Sections.is_enrolled?(user.id, section.slug) do
+      # Now ask Cashnet to create a payment form, which also results in a %Payment record
+      # created in the system but in a "pending" state
+      case Cashnet.create_form(section, user, conn.host) do
+        {:ok, %{payment_ref: _payment_ref, cashnet_form: cashnet_form}} ->
+          # This is necessary since this controller has been delegated by PaymentController
+          Phoenix.Controller.put_view(conn, OliWeb.PaymentProviders.CashnetView)
+          |> render("index.html",
+            api_key: Application.fetch_env!(:oli, :stripe_provider)[:public_secret],
+            purchase: Jason.encode!(%{user_id: user.id, section_slug: section.slug}),
+            section: section,
+            cost: cost,
+            cashnet_form: cashnet_form,
+            user: user,
+            user_name:
+              safe_get(user.family_name, "Unknown") <> ", " <> safe_get(user.given_name, "Unknown")
+          )
 
-      e ->
-        {_, msg} = Oli.Utils.log_error("CashnetController:init_form failed.", e)
-        error(conn, 500, msg)
+        e ->
+          {_, msg} = Oli.Utils.log_error("CashnetController:init_form failed.", e)
+          error(conn, 500, msg)
+      end
+    else
+      Logger.error(
+        "CashnetController caught attempt to initialize payment for non-enrolled student"
+      )
     end
+
   end
 
   defp safe_get(item, default_value) do

--- a/lib/oli_web/controllers/payment_providers/cashnet_controller.ex
+++ b/lib/oli_web/controllers/payment_providers/cashnet_controller.ex
@@ -46,13 +46,14 @@ defmodule OliWeb.PaymentProviders.CashnetController do
           )
 
         e ->
-          {_, msg} = Oli.Utils.log_error("CashnetController:init_form failed.", e)
+          {_, msg} = Oli.Utils.log_error("CashnetController:show failed.", e)
           error(conn, 500, msg)
       end
     else
       Logger.error(
         "CashnetController caught attempt to initialize payment for non-enrolled student"
       )
+      render(conn, "not_enrolled.html", section_slug: section.slug)
     end
 
   end

--- a/lib/oli_web/templates/payment/not_enrolled.html.eex
+++ b/lib/oli_web/templates/payment/not_enrolled.html.eex
@@ -1,0 +1,14 @@
+
+<div class="configure-section mt-5">
+  <h3>Not Enrolled</h3>
+  <p class="mt-3">
+    You are not enrolled in this course section.
+  </p>
+
+  <p class="mt-3">
+    If you have accessed this course from your LMS, please make sure you are logged in from your LMS account. It is a
+    common mistake to directly create a student account and try to access and pay for the course.  Please make sure you
+    are accessing this course section from the account that you were enrolled in with.
+  </p>
+
+</div>

--- a/test/oli_web/controllers/payment_providers/cashnet_controller_test.exs
+++ b/test/oli_web/controllers/payment_providers/cashnet_controller_test.exs
@@ -79,11 +79,33 @@ defmodule OliWeb.PaymentProviders.CashnetControllerTest do
       assert html_response(conn, 302) =~
                "You are being <a href=\"/sections/#{section.slug}\">redirected"
     end
+
+
   end
 
   @moduletag :capture_log
   describe "init intent" do
     setup [:user_conn, :create_section]
+
+    test "displays not enrolled message when not enrolled", %{
+      conn: conn
+    } do
+      product = insert(:section)
+
+      section =
+        insert(:section, %{
+          type: :enrollable,
+          open_and_free: true,
+          requires_enrollment: true,
+          requires_payment: true,
+          amount: Money.new(:USD, 25),
+          blueprint: product
+        })
+
+      conn = get(conn, Routes.payment_path(conn, :guard, section.slug))
+      assert html_response(conn, 200) =~ "You are not enrolled in this course section"
+
+    end
 
     test "return unauthorized if user is not enrolled", %{
       conn: conn,


### PR DESCRIPTION
The Cashnet impl was not enforcing the "enrollment check" in the correct place.  This PR adds that check to the `:show` endpoint and also adds it upfront within the payment provider framework at the `:guard` endpoint.  Now, if a student is confused and uses the wrong account, they will see a message indicating that they are not enrolled in that course section.  