### PR TITLE
[BUG FIX] [MER-3711] Style tables within feedback to ensure legibility

### DIFF
--- a/assets/styles/delivery/activity.scss
+++ b/assets/styles/delivery/activity.scss
@@ -112,6 +112,12 @@
         margin-right: 3px;
       }
     }
+
+    // override tailwind styles to ensure borders, text visible against feedback background & no dark mode change
+    table {
+      color: black;
+      border-color: black;
+    }
   }
 }
 
@@ -162,8 +168,6 @@
     /* MER-2961 - Some wide content (specifically formulas) were getting cut off in hints, making it scrollable
     */
     overflow-x: auto;
-
-
   }
 
   p:last-of-type {

--- a/assets/styles/delivery/activity.scss
+++ b/assets/styles/delivery/activity.scss
@@ -115,8 +115,8 @@
 
     // override tailwind styles to ensure borders, text visible against feedback background & no dark mode change
     table {
-      color: black;
-      border-color: black;
+      color: var(--color-feedback-table-color);
+      border-color: var(--color-feedback-table-color);
     }
   }
 }

--- a/assets/styles/delivery/activity.scss
+++ b/assets/styles/delivery/activity.scss
@@ -113,7 +113,8 @@
       }
     }
 
-    // override tailwind styles to ensure borders, text visible against feedback background & no dark mode change
+    // override tailwind table styles to ensure table borders and text are
+    // legible against colored feedback background and no dark mode change
     table,
     th,
     tr,

--- a/assets/styles/delivery/activity.scss
+++ b/assets/styles/delivery/activity.scss
@@ -114,7 +114,10 @@
     }
 
     // override tailwind styles to ensure borders, text visible against feedback background & no dark mode change
-    table {
+    table,
+    th,
+    tr,
+    td {
       color: var(--color-feedback-table-color);
       border-color: var(--color-feedback-table-color);
     }

--- a/assets/tailwind.theme.js
+++ b/assets/tailwind.theme.js
@@ -155,6 +155,7 @@ module.exports = {
     'feedback-partially-correct-bg': colors.yellow['200'],
     'feedback-partially-correct-color': colors.black,
     'feedback-partially-correct-graphic-color': colors.yellow['500'],
+    'feedback-table-color': colors.black,
     toolbar: {
       bg: {
         DEFAULT: '#f8f9fb',


### PR DESCRIPTION
The default tailwind table styles were leading to illegible results for tables in the feedback context, particularly in dark mode. This adds custom styles to tables within feedback to ensure visibility of borders and text against the colored feedback background, and also ensure no dark mode changes (since feedback background/text color doesn't change). 

In theory the table text and borders should use css variables to render with the same color as text in the feedback context. Currently different css color variables are defined in `tailwind.theme.js` that would allow for potentially different text colors in correct, incorrect, and explanation feedback. Keeping to that model would require different table styles for each of these contexts as well. But currently these text colors are all just black. So decided this is excess generality we will likely never need and kept it simple, with just one variable for feedback-table-color. In any case the simple method is no worse than previous code which had no styling, just inheriting tailwind defaults.