### PR TITLE
[PERFORMANCE] [MER-3710] Add AppSignal instrumentation for event timeline details

### DIFF
--- a/lib/oli/delivery/attempts/page_lifecycle.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle.ex
@@ -90,7 +90,6 @@ defmodule Oli.Delivery.Attempts.PageLifecycle do
             {:error, error} -> Repo.rollback(error)
           end
       end
-
     end)
   end
 

--- a/lib/oli/delivery/attempts/page_lifecycle.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle.ex
@@ -130,8 +130,10 @@ defmodule Oli.Delivery.Attempts.PageLifecycle do
         update_latest_visited_page(section_slug, user.id, page_revision.resource_id)
 
       {graded, latest_resource_attempt} =
-        get_latest_resource_attempt(page_revision.resource_id, section_slug, user.id)
-        |> handle_type_transitions(page_revision)
+        Appsignal.instrument("PageLifeCycle: get_latest_resource_attempt", fn ->
+          get_latest_resource_attempt(page_revision.resource_id, section_slug, user.id)
+          |> handle_type_transitions(page_revision)
+        end)
 
       publication_id =
         Publishing.get_publication_id_for_resource(section_slug, page_revision.resource_id)

--- a/lib/oli/delivery/attempts/page_lifecycle/graded.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/graded.ex
@@ -11,6 +11,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Graded do
     Lifecycle,
     Hierarchy
   }
+
   use Appsignal.Instrumentation.Decorators
   alias Oli.Delivery.Settings
   alias Oli.Delivery.Settings.Combined

--- a/lib/oli/delivery/attempts/page_lifecycle/ungraded.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/ungraded.ex
@@ -39,7 +39,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Ungraded do
         } = context
       ) do
     if is_nil(latest_resource_attempt) or latest_resource_attempt.revision_id != page_revision.id or
-        latest_resource_attempt.lifecycle_state == :evaluated do
+         latest_resource_attempt.lifecycle_state == :evaluated do
       case start(context) do
         {:ok, %AttemptState{} = attempt_state} ->
           {:ok, {:in_progress, attempt_state}}
@@ -72,13 +72,13 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Ungraded do
     })
 
     {:ok,
-    %FinalizationSummary{
-      graded: false,
-      lifecycle_state: :evaluated,
-      resource_access: nil,
-      part_attempt_guids: nil,
-      effective_settings: effective_settings
-    }}
+     %FinalizationSummary{
+       graded: false,
+       lifecycle_state: :evaluated,
+       resource_access: nil,
+       part_attempt_guids: nil,
+       effective_settings: effective_settings
+     }}
   end
 
   @impl Lifecycle
@@ -123,7 +123,6 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Ungraded do
     |> do_update_progress(number_of_scorable_activities)
 
     {:ok, state}
-
   end
 
   defp update_progress(other, _) do

--- a/lib/oli/delivery/attempts/page_lifecycle/ungraded.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/ungraded.ex
@@ -47,7 +47,9 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Ungraded do
       end
     else
       {:ok, attempt_state} =
-        AttemptState.fetch_attempt_state(latest_resource_attempt, page_revision)
+        Appsignal.instrument("Ungraded: AttemptState.fetch_attempt_state", fn ->
+          AttemptState.fetch_attempt_state(latest_resource_attempt, page_revision)
+        end)
 
       {:ok, {:in_progress, attempt_state}}
     end

--- a/lib/oli/delivery/page/activity_context.ex
+++ b/lib/oli/delivery/page/activity_context.ex
@@ -2,6 +2,7 @@ defmodule Oli.Delivery.Page.ActivityContext do
   @moduledoc """
   Defines the context required to render an activity in delivery mode.
   """
+  use Appsignal.Instrumentation.Decorators
 
   alias Oli.Delivery.Page.ModelPruner
   alias Oli.Rendering.Activity.ActivitySummary
@@ -23,6 +24,7 @@ defmodule Oli.Delivery.Page.ActivityContext do
           Oli.Delivery.Attempts.Core.ResourceAttempt.t(),
           Oli.Resources.Revision.t()
         ) :: %{}
+  @decorate transaction_event()
   def create_context_map(graded, latest_attempts, resource_attempt, page_revision, opts \\ []) do
     # get a view of all current registered activity types
     registrations = Activities.list_activity_registrations()

--- a/lib/oli/delivery/page/page_context.ex
+++ b/lib/oli/delivery/page/page_context.ex
@@ -2,6 +2,7 @@ defmodule Oli.Delivery.Page.PageContext do
   @moduledoc """
   Defines the context required to render a page in delivery mode.
   """
+  use Appsignal.Instrumentation.Decorators
 
   @enforce_keys [
     :user,
@@ -58,6 +59,7 @@ defmodule Oli.Delivery.Page.PageContext do
   information is collected and then assembled in a fashion that can be given
   to a renderer.
   """
+  @decorate transaction_event()
   def create_for_review(section_slug, attempt_guid, user, is_admin?) do
     section = Oli.Delivery.Sections.get_section_by_slug(section_slug)
 
@@ -149,6 +151,7 @@ defmodule Oli.Delivery.Page.PageContext do
   # For the given resource attempt, retrieve all historical activity attempt records,
   # assembling them into a map of activity_id to a list of the activity attempts, including
   # the latest attempt
+  @decorate transaction_event()
   defp retrieve_historical_attempts(resource_attempt) do
     Oli.Delivery.Attempts.Core.get_all_activity_attempts(resource_attempt.id)
     |> Enum.sort(fn a1, a2 -> a1.attempt_number < a2.attempt_number end)
@@ -170,6 +173,7 @@ defmodule Oli.Delivery.Page.PageContext do
   The `opts` parameter is a keyword list that can contain the following options:
   - track_access: a boolean that determines whether to track access to the page. Defaults to true.
   """
+  @decorate transaction_event()
   def create_for_visit(
         %Section{slug: section_slug, id: section_id},
         page_slug,
@@ -191,7 +195,8 @@ defmodule Oli.Delivery.Page.PageContext do
     activity_provider = &Oli.Delivery.ActivityProvider.provide/6
 
     {progress_state, resource_attempts, latest_attempts, activities} =
-      case PageLifecycle.visit(
+      Appsignal.instrument("PageLifecycle.visit", fn ->
+        case PageLifecycle.visit(
              page_revision,
              section_slug,
              datashop_session_id,
@@ -209,7 +214,9 @@ defmodule Oli.Delivery.Page.PageContext do
 
         {:error, _} ->
           {:error, [], %{}}
-      end
+        end
+      end)
+
 
     # Fetch the revision pinned to the resource attempt if it was revised since this attempt began. This
     # is what enables existing attempts that are being revisited after a change was published to the page
@@ -235,7 +242,9 @@ defmodule Oli.Delivery.Page.PageContext do
       |> Enum.map(fn {summary, ordinal} -> BibUtils.serialize_revision(summary, ordinal) end)
 
     {:ok, collab_space_config} =
-      Collaboration.get_collab_space_config_for_page_in_section(page_revision.slug, section_slug)
+      Appsignal.instrument("get collab space config", fn ->
+        Collaboration.get_collab_space_config_for_page_in_section(page_revision.slug, section_slug)
+      end)
 
     user_roles = Sections.get_user_roles(user, section_slug)
 
@@ -273,6 +282,7 @@ defmodule Oli.Delivery.Page.PageContext do
     {state, [resource_attempt], latest_attempts, latest_attempts}
   end
 
+  @decorate transaction_event()
   defp assemble_final_context(
          state,
          resource_attempt,
@@ -286,16 +296,14 @@ defmodule Oli.Delivery.Page.PageContext do
         t -> t
       end
 
-    final_context = Appsignal.instrument("ActivityContext.create_context_map", fn ->
-      ActivityContext.create_context_map(
-        page_revision.graded,
-        latest_attempts,
-        resource_attempt,
-        page_revision,
-        assign_ordinals_from: content_for_ordinal_assignment,
-        show_feedback: show_feedback
-      )
-    end)
+    final_context = ActivityContext.create_context_map(
+      page_revision.graded,
+      latest_attempts,
+      resource_attempt,
+      page_revision,
+      assign_ordinals_from: content_for_ordinal_assignment,
+      show_feedback: show_feedback
+    )
 
     {state, [resource_attempt], latest_attempts, final_context}
   end
@@ -307,12 +315,11 @@ defmodule Oli.Delivery.Page.PageContext do
     []
   end
 
+  @decorate transaction_event()
   defp rollup_objectives(page_rev, latest_attempts, resolver, section_slug) do
     activity_revisions =
       Enum.map(latest_attempts, fn {_, {%{revision: revision}, _}} -> revision end)
 
-    Appsignal.instrument("rollup objectives", fn ->
-      ObjectivesRollup.rollup_objectives(page_rev, activity_revisions, resolver, section_slug)
-    end)
+    ObjectivesRollup.rollup_objectives(page_rev, activity_revisions, resolver, section_slug)
   end
 end

--- a/lib/oli/utils.ex
+++ b/lib/oli/utils.ex
@@ -480,5 +480,4 @@ defmodule Oli.Utils do
       value -> value
     end
   end
-
 end

--- a/lib/oli/utils.ex
+++ b/lib/oli/utils.ex
@@ -480,4 +480,5 @@ defmodule Oli.Utils do
       value -> value
     end
   end
+
 end

--- a/lib/oli_web/live/delivery/student/index_live.ex
+++ b/lib/oli_web/live/delivery/student/index_live.ex
@@ -22,50 +22,55 @@ defmodule OliWeb.Delivery.Student.IndexLive do
         do: Sections.get_schedule_for_current_and_next_week(section, current_user_id),
         else: nil
 
-    nearest_upcoming_lesson = Appsignal.instrument("IndexLive: nearest_upcoming_lesson", fn ->
-      section
-      |> Sections.get_nearest_upcoming_lessons(current_user_id, 1)
-      |> List.first()
-    end)
+    nearest_upcoming_lesson =
+      Appsignal.instrument("IndexLive: nearest_upcoming_lesson", fn ->
+        section
+        |> Sections.get_nearest_upcoming_lessons(current_user_id, 1)
+        |> List.first()
+      end)
 
-    latest_assignments = Appsignal.instrument("IndexLive: latest_assignments", fn ->
-      Sections.get_last_completed_or_started_assignments(section, current_user_id, 3)
-    end)
+    latest_assignments =
+      Appsignal.instrument("IndexLive: latest_assignments", fn ->
+        Sections.get_last_completed_or_started_assignments(section, current_user_id, 3)
+      end)
 
-    upcoming_assignments = Appsignal.instrument("IndexLive: upcoming_assignments", fn ->
-      Sections.get_nearest_upcoming_lessons(section, current_user_id, 3, only_graded: true)
-    end)
+    upcoming_assignments =
+      Appsignal.instrument("IndexLive: upcoming_assignments", fn ->
+        Sections.get_nearest_upcoming_lessons(section, current_user_id, 3, only_graded: true)
+      end)
 
     page_ids = Enum.map(upcoming_assignments ++ latest_assignments, & &1.resource_id)
     containers_per_page = build_containers_per_page(section, page_ids)
 
-    combined_settings = Appsignal.instrument("IndexLive: combined_settings", fn ->
-      Settings.get_combined_settings_for_all_resources(section.id, current_user_id, page_ids)
-    end)
+    combined_settings =
+      Appsignal.instrument("IndexLive: combined_settings", fn ->
+        Settings.get_combined_settings_for_all_resources(section.id, current_user_id, page_ids)
+      end)
 
-    [last_open_and_unfinished_page, nearest_upcoming_lesson] = Appsignal.instrument("IndexLive: last_open_and_unfinished_page", fn ->
-      Enum.map(
-        [
-          Sections.get_last_open_and_unfinished_page(section, current_user_id),
-          nearest_upcoming_lesson
-        ],
-        fn
-          nil ->
-            nil
+    [last_open_and_unfinished_page, nearest_upcoming_lesson] =
+      Appsignal.instrument("IndexLive: last_open_and_unfinished_page", fn ->
+        Enum.map(
+          [
+            Sections.get_last_open_and_unfinished_page(section, current_user_id),
+            nearest_upcoming_lesson
+          ],
+          fn
+            nil ->
+              nil
 
-          page ->
-            page_module_index =
-              section
-              |> get_or_compute_full_hierarchy()
-              |> Hierarchy.find_module_ancestor(
-                page[:resource_id],
-                Oli.Resources.ResourceType.get_id_by_type("container")
-              )
-              |> get_in(["numbering", "index"])
+            page ->
+              page_module_index =
+                section
+                |> get_or_compute_full_hierarchy()
+                |> Hierarchy.find_module_ancestor(
+                  page[:resource_id],
+                  Oli.Resources.ResourceType.get_id_by_type("container")
+                )
+                |> get_in(["numbering", "index"])
 
-            Map.put(page, :module_index, page_module_index)
-        end
-      )
+              Map.put(page, :module_index, page_module_index)
+          end
+        )
       end)
 
     {:ok,

--- a/lib/oli_web/live/delivery/student/index_live.ex
+++ b/lib/oli_web/live/delivery/student/index_live.ex
@@ -1,6 +1,6 @@
 defmodule OliWeb.Delivery.Student.IndexLive do
   use OliWeb, :live_view
-
+  use Appsignal.Instrumentation.Decorators
   import OliWeb.Components.Delivery.Layouts
 
   alias Oli.Delivery.{Attempts, Hierarchy, Metrics, Sections, Settings}
@@ -12,6 +12,7 @@ defmodule OliWeb.Delivery.Student.IndexLive do
   alias OliWeb.Delivery.Student.Home.Components.ScheduleComponent
   alias OliWeb.Icons
 
+  @decorate transaction_event("IndexLive")
   def mount(_params, _session, socket) do
     section = socket.assigns[:section]
     current_user_id = socket.assigns[:current_user].id
@@ -21,24 +22,28 @@ defmodule OliWeb.Delivery.Student.IndexLive do
         do: Sections.get_schedule_for_current_and_next_week(section, current_user_id),
         else: nil
 
-    nearest_upcoming_lesson =
+    nearest_upcoming_lesson = Appsignal.instrument("IndexLive: nearest_upcoming_lesson", fn ->
       section
       |> Sections.get_nearest_upcoming_lessons(current_user_id, 1)
       |> List.first()
+    end)
 
-    latest_assignments =
+    latest_assignments = Appsignal.instrument("IndexLive: latest_assignments", fn ->
       Sections.get_last_completed_or_started_assignments(section, current_user_id, 3)
+    end)
 
-    upcoming_assignments =
+    upcoming_assignments = Appsignal.instrument("IndexLive: upcoming_assignments", fn ->
       Sections.get_nearest_upcoming_lessons(section, current_user_id, 3, only_graded: true)
+    end)
 
     page_ids = Enum.map(upcoming_assignments ++ latest_assignments, & &1.resource_id)
     containers_per_page = build_containers_per_page(section, page_ids)
 
-    combined_settings =
+    combined_settings = Appsignal.instrument("IndexLive: combined_settings", fn ->
       Settings.get_combined_settings_for_all_resources(section.id, current_user_id, page_ids)
+    end)
 
-    [last_open_and_unfinished_page, nearest_upcoming_lesson] =
+    [last_open_and_unfinished_page, nearest_upcoming_lesson] = Appsignal.instrument("IndexLive: last_open_and_unfinished_page", fn ->
       Enum.map(
         [
           Sections.get_last_open_and_unfinished_page(section, current_user_id),
@@ -61,6 +66,7 @@ defmodule OliWeb.Delivery.Student.IndexLive do
             Map.put(page, :module_index, page_module_index)
         end
       )
+      end)
 
     {:ok,
      assign(socket,

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -1,5 +1,6 @@
 defmodule OliWeb.Delivery.Student.LessonLive do
   use OliWeb, :live_view
+  use Appsignal.Instrumentation.Decorators
 
   import OliWeb.Delivery.Student.Utils,
     only: [page_header: 1, scripts: 1, references: 1, reset_attempts_button: 1]
@@ -30,6 +31,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
     current_user: {[:id, :name, :email], %User{}}
   }
 
+  @decorate transaction_event()
   def mount(_params, _session, %{assigns: %{view: :practice_page}} = socket) do
     %{current_user: current_user, section: section, page_context: page_context} = socket.assigns
     is_instructor = Sections.has_instructor_role?(current_user, section.slug)
@@ -895,18 +897,21 @@ defmodule OliWeb.Delivery.Student.LessonLive do
     |> assign_html()
   end
 
+  @decorate transaction_event()
   defp assign_scripts(socket) do
     assign(socket,
       scripts: Utils.get_required_activity_scripts(socket.assigns.page_context)
     )
   end
 
+  @decorate transaction_event()
   defp assign_html(socket) do
     assign(socket,
       html: Utils.build_html(socket.assigns, :delivery)
     )
   end
 
+  @decorate transaction_event()
   defp assign_objectives(socket) do
     %{page_context: %{page: page}, current_user: current_user, section: section} =
       socket.assigns

--- a/lib/oli_web/live/delivery/student/utils.ex
+++ b/lib/oli_web/live/delivery/student/utils.ex
@@ -4,6 +4,7 @@ defmodule OliWeb.Delivery.Student.Utils do
   """
   use Phoenix.Component
   use OliWeb, :verified_routes
+  use Appsignal.Instrumentation.Decorators
 
   import Ecto.Query, warn: false
 
@@ -444,7 +445,9 @@ defmodule OliWeb.Delivery.Student.Utils do
     # Cache the page as text to allow the AI agent LV to access it.
     cache_page_as_text(render_context, attempt_content, page_context.page.id)
 
-    Page.render(render_context, attempt_content, Page.Html)
+    Appsignal.instrument("Page.render", fn ->
+      Page.render(render_context, attempt_content, Page.Html)
+    end)
   end
 
   defp cache_page_as_text(render_context, content, page_id) do
@@ -464,6 +467,7 @@ defmodule OliWeb.Delivery.Student.Utils do
     |> Enum.uniq()
   end
 
+  @decorate transaction_event()
   def get_required_activity_scripts(_page_context) do
     # TODO Optimization: get only activity scripts of activities contained in the page.
     # We could infer the contained activities from the page revision content model.

--- a/lib/oli_web/live_session_plugs/set_brand.ex
+++ b/lib/oli_web/live_session_plugs/set_brand.ex
@@ -1,10 +1,11 @@
 defmodule OliWeb.LiveSessionPlugs.SetBrand do
   use OliWeb, :verified_routes
-
+  use Appsignal.Instrumentation.Decorators
   import Phoenix.Component, only: [assign: 2]
 
   alias Oli.Branding
 
+  @decorate transaction_event("SetBrand")
   def on_mount(:default, _params, _session, socket) do
     {:cont, assign(socket, brand: Branding.get_section_brand(socket.assigns[:section]))}
   end

--- a/lib/oli_web/live_session_plugs/set_notification_badges.ex
+++ b/lib/oli_web/live_session_plugs/set_notification_badges.ex
@@ -2,7 +2,7 @@ defmodule OliWeb.LiveSessionPlugs.SetNotificationBadges do
   use OliWeb, :verified_routes
 
   import Phoenix.Component, only: [assign: 2]
-
+  use Appsignal.Instrumentation.Decorators
   alias Oli.Resources.Collaboration
   alias Oli.Publishing.DeliveryResolver
 
@@ -22,6 +22,7 @@ defmodule OliWeb.LiveSessionPlugs.SetNotificationBadges do
   defp maybe_load_discussions_badge(socket, nil, _user), do: socket
   defp maybe_load_discussions_badge(socket, _section, nil), do: socket
 
+  @decorate transaction_event()
   defp maybe_load_discussions_badge(socket, section, user) do
     # Load the discussions badge
     %{resource_id: root_curriculum_resource_id} =

--- a/lib/oli_web/live_session_plugs/set_paywall_summary.ex
+++ b/lib/oli_web/live_session_plugs/set_paywall_summary.ex
@@ -12,9 +12,9 @@ defmodule OliWeb.LiveSessionPlugs.SetPaywallSummary do
       )
       when not is_nil(section) and not is_nil(current_user) do
     {:cont,
-    assign(socket,
-      paywall_summary: Paywall.summarize_access(current_user, section)
-    )}
+     assign(socket,
+       paywall_summary: Paywall.summarize_access(current_user, section)
+     )}
   end
 
   def on_mount(:default, _params, _session, socket), do: {:cont, socket}

--- a/lib/oli_web/live_session_plugs/set_paywall_summary.ex
+++ b/lib/oli_web/live_session_plugs/set_paywall_summary.ex
@@ -1,8 +1,9 @@
 defmodule OliWeb.LiveSessionPlugs.SetPaywallSummary do
   import Phoenix.Component, only: [assign: 2]
-
+  use Appsignal.Instrumentation.Decorators
   alias Oli.Delivery.Paywall
 
+  @decorate transaction_event("SetPaywallSummary")
   def on_mount(
         :default,
         _params,
@@ -11,9 +12,9 @@ defmodule OliWeb.LiveSessionPlugs.SetPaywallSummary do
       )
       when not is_nil(section) and not is_nil(current_user) do
     {:cont,
-     assign(socket,
-       paywall_summary: Paywall.summarize_access(current_user, section)
-     )}
+    assign(socket,
+      paywall_summary: Paywall.summarize_access(current_user, section)
+    )}
   end
 
   def on_mount(:default, _params, _session, socket), do: {:cont, socket}

--- a/lib/oli_web/live_session_plugs/set_user.ex
+++ b/lib/oli_web/live_session_plugs/set_user.ex
@@ -8,21 +8,21 @@ defmodule OliWeb.LiveSessionPlugs.SetUser do
   @decorate transaction_event("SetUser")
   def on_mount(:with_preloads, _, session, socket) do
     {:cont,
-      socket
-      |> set_author(session)
-      |> set_user(session, preload: [:platform_roles, :author])
-      |> set_user_token
-      |> update_ctx(session)}
+     socket
+     |> set_author(session)
+     |> set_user(session, preload: [:platform_roles, :author])
+     |> set_user_token
+     |> update_ctx(session)}
   end
 
   @decorate transaction_event("SetUser")
   def on_mount(_default, _, session, socket) do
     {:cont,
-      socket
-      |> set_author(session)
-      |> set_user(session)
-      |> set_user_token
-      |> update_ctx(session)}
+     socket
+     |> set_author(session)
+     |> set_user(session)
+     |> set_user_token
+     |> update_ctx(session)}
   end
 
   def set_author(socket, %{"current_author_id" => current_author_id})

--- a/lib/oli_web/live_session_plugs/set_user.ex
+++ b/lib/oli_web/live_session_plugs/set_user.ex
@@ -1,26 +1,28 @@
 defmodule OliWeb.LiveSessionPlugs.SetUser do
   import Phoenix.Component, only: [assign: 2]
-
+  use Appsignal.Instrumentation.Decorators
   alias Oli.Accounts
   alias Oli.Accounts.{User, Author}
   alias Oli.AccountLookupCache
 
+  @decorate transaction_event("SetUser")
   def on_mount(:with_preloads, _, session, socket) do
     {:cont,
-     socket
-     |> set_author(session)
-     |> set_user(session, preload: [:platform_roles, :author])
-     |> set_user_token
-     |> update_ctx(session)}
+      socket
+      |> set_author(session)
+      |> set_user(session, preload: [:platform_roles, :author])
+      |> set_user_token
+      |> update_ctx(session)}
   end
 
+  @decorate transaction_event("SetUser")
   def on_mount(_default, _, session, socket) do
     {:cont,
-     socket
-     |> set_author(session)
-     |> set_user(session)
-     |> set_user_token
-     |> update_ctx(session)}
+      socket
+      |> set_author(session)
+      |> set_user(session)
+      |> set_user_token
+      |> update_ctx(session)}
   end
 
   def set_author(socket, %{"current_author_id" => current_author_id})


### PR DESCRIPTION
This PR adds Appsignal instrumentation so that some key event timelines are annotated with pointers back to the code.  This will make troubleshooting and future optimization work much easier.  

Docs for this: https://docs.appsignal.com/elixir/instrumentation/instrumentation.html

This current impl will more fully annotate the timeline as compared to the following screenshot, but at least you can get the idea of what these changes will do:

 
<img width="1222" alt="Screenshot 2024-08-29 at 2 51 58 PM" src="https://github.com/user-attachments/assets/e2d7530f-d83a-4085-a5b7-10de665190ba">

