### PR TITLE
[FEATURE] [MER-3597] Migrate Curriculum to new author workspace

### DIFF
--- a/lib/oli_web/common/links.ex
+++ b/lib/oli_web/common/links.ex
@@ -2,6 +2,7 @@ defmodule OliWeb.Common.Links do
   use Phoenix.HTML
   alias OliWeb.Router.Helpers, as: Routes
   alias Oli.Resources.Numbering
+  alias OliWeb.Workspaces.CourseAuthor.CurriculumLive
 
   @doc """
   Returns a path uri for a given revision. If the revision type is not
@@ -39,12 +40,7 @@ defmodule OliWeb.Common.Links do
         end
 
       "container" ->
-        Routes.container_path(
-          OliWeb.Endpoint,
-          :index,
-          project_slug,
-          revision.slug
-        )
+        Routes.live_path(OliWeb.Endpoint, CurriculumLive, project_slug, revision.slug)
 
       "tag" ->
         Routes.activity_bank_path(

--- a/lib/oli_web/live/curriculum/entries/entry.ex
+++ b/lib/oli_web/live/curriculum/entries/entry.ex
@@ -7,7 +7,6 @@ defmodule OliWeb.Curriculum.Entry do
   import OliWeb.Curriculum.Utils
 
   alias OliWeb.Curriculum.{Actions, Details, LearningSummary}
-  alias OliWeb.Router.Helpers, as: Routes
   alias OliWeb.Common.Links
 
   attr(:ctx, :map, required: true)

--- a/lib/oli_web/live/curriculum/entries/entry.ex
+++ b/lib/oli_web/live/curriculum/entries/entry.ex
@@ -53,14 +53,7 @@ defmodule OliWeb.Curriculum.Entry do
             <span class="ml-1 mr-1 entry-title"><%= @child.title %></span>
             <.link
               class="entry-title mx-3"
-              href={
-                Routes.resource_path(
-                  OliWeb.Endpoint,
-                  :edit,
-                  @project.slug,
-                  @child.slug
-                )
-              }
+              href={~p"/workspaces/course_author/#{@project.slug}/curriculum/#{@child.slug}"}
             >
               Edit Page
             </.link>

--- a/lib/oli_web/live/workspaces/course_author/curriculum_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/curriculum_live.ex
@@ -55,12 +55,12 @@ defmodule OliWeb.Workspaces.CourseAuthor.CurriculumLive do
     cond do
       # Explicitly routing to root_container, strip off the container param
       container_slug == root_container.slug && socket.assigns.live_action == :index ->
-        {:ok, redirect(socket, to: Routes.container_path(socket, :index, project_slug))}
+        {:ok, redirect(socket, to: Routes.live_path(socket, __MODULE__, project_slug))}
 
       # Routing to missing container
       container_slug && is_nil(AuthoringResolver.from_revision_slug(project_slug, container_slug)) ->
         {:ok,
-         redirect(socket, to: Routes.resource_path(socket, :edit, project_slug, container_slug))}
+         redirect(socket, to: Routes.live_path(socket, __MODULE__, project_slug, container_slug))}
 
       # Implicitly routing to root container or explicitly routing to sub-container
       true ->
@@ -147,7 +147,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.CurriculumLive do
     %{container: container, project: project, children: children} =
       socket.assigns
 
-    redirect_url = ContainerLiveHelpers.build_redirect_url(socket, project.slug, container.slug)
+    redirect_url = Routes.live_path(socket, __MODULE__, project.slug, container.slug)
 
     {:noreply,
      assign(socket,
@@ -671,7 +671,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.CurriculumLive do
   defp proceed_with_deletion_warning(socket, container, project, author, item) do
     modal_assigns = %{
       id: "delete_#{item.slug}",
-      redirect_url: Routes.container_path(socket, :index, project.slug, container.slug),
+      redirect_url: Routes.live_path(socket, __MODULE__, project.slug, container.slug),
       revision: item,
       container: container,
       project: project,

--- a/lib/oli_web/live/workspaces/course_author/curriculum_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/curriculum_live.ex
@@ -1,30 +1,848 @@
 defmodule OliWeb.Workspaces.CourseAuthor.CurriculumLive do
   use OliWeb, :live_view
+  use OliWeb.Common.Modal
+
+  import Oli.Utils, only: [value_or: 2]
+  import Oli.Authoring.Editing.Utils
+  import OliWeb.Curriculum.Utils
+
+  alias Oli.Authoring.Editing.ContainerEditor
+  alias Oli.Authoring.Course
+
+  alias OliWeb.Curriculum.{
+    Rollup,
+    ActivityDelta,
+    DropTarget,
+    Entry,
+    OptionsModalContent,
+    DeleteModal,
+    NotEmptyModal,
+    HyperlinkDependencyModal
+  }
+
+  alias OliWeb.Common.Hierarchy.MoveModal
+  alias Oli.Publishing.ChangeTracker
+  alias Oli.Publishing.AuthoringResolver
+  alias Oli.Accounts
+  alias Oli.Repo
+  alias Oli.Publishing
+  alias Oli.Accounts
+  alias Oli.Authoring.Broadcaster.Subscriber
+  alias Oli.Resources.Numbering
+  alias OliWeb.Router.Helpers, as: Routes
+  alias OliWeb.Common.Breadcrumb
+  alias Oli.Delivery.Hierarchy
+  alias Oli.Resources.Revision
+  alias OliWeb.Common.SessionContext
+  alias Oli.Resources
+  alias Oli.Delivery.Hierarchy.HierarchyNode
+  alias OliWeb.Components.Modal
+  alias OliWeb.Curriculum.Container.ContainerLiveHelpers
+
+  on_mount {OliWeb.LiveSessionPlugs.AuthorizeProject, :default}
 
   @impl Phoenix.LiveView
-  def mount(_params, _session, socket) do
+  def mount(params, session, socket) do
     project = socket.assigns.project
+    project_slug = project.slug
 
-    {:ok,
-     assign(socket,
-       resource_slug: project.slug,
-       resource_title: project.title,
-       active_workspace: :course_author,
-       active_view: :curriculum
-     )}
+    %SessionContext{author: author} = ctx = SessionContext.init(socket, session)
+
+    root_container = AuthoringResolver.root_container(project_slug)
+    container_slug = Map.get(params, "container_slug")
+
+    project_hierarchy = AuthoringResolver.full_hierarchy(project_slug) |> HierarchyNode.simplify()
+
+    cond do
+      # Explicitly routing to root_container, strip off the container param
+      container_slug == root_container.slug && socket.assigns.live_action == :index ->
+        {:ok, redirect(socket, to: Routes.container_path(socket, :index, project_slug))}
+
+      # Routing to missing container
+      container_slug && is_nil(AuthoringResolver.from_revision_slug(project_slug, container_slug)) ->
+        {:ok,
+         redirect(socket, to: Routes.resource_path(socket, :edit, project_slug, container_slug))}
+
+      # Implicitly routing to root container or explicitly routing to sub-container
+      true ->
+        {:ok, container} = load_and_scrub_container(container_slug, project_slug, root_container)
+
+        children = ContainerEditor.list_all_container_children(container, project)
+
+        {:ok, rollup} = Rollup.new(children, project.slug)
+
+        subscriptions = subscribe(container, children, rollup, project.slug)
+
+        view_pref =
+          case author.preferences do
+            %{curriculum_view: curriculum_view} ->
+              curriculum_view
+
+            _ ->
+              "Basic"
+          end
+
+        {:ok,
+         assign(socket,
+           resource_slug: project_slug,
+           resource_title: project.title,
+           active_workspace: :course_author,
+           active_view: :curriculum,
+           ctx: ctx,
+           children: children,
+           active: :curriculum,
+           breadcrumbs:
+             Breadcrumb.trail_to(
+               project_slug,
+               container.slug,
+               Oli.Publishing.AuthoringResolver,
+               project.customizations
+             ),
+           adaptivity_flag: Oli.Features.enabled?("adaptivity"),
+           rollup: rollup,
+           container: container,
+           project: project,
+           project_hierarchy: project_hierarchy,
+           subscriptions: subscriptions,
+           author: author,
+           view: view_pref,
+           selected: nil,
+           resources_being_edited: get_resources_being_edited(container.children, project.id),
+           numberings:
+             Numbering.number_full_tree(
+               Oli.Publishing.AuthoringResolver,
+               project_slug,
+               project.customizations
+             ),
+           dragging: nil,
+           page_title: "Curriculum | " <> project.title,
+           options_modal_assigns: nil
+         )
+         |> attach_hook(:has_show_links_uri_hash, :handle_params, fn _params, uri, socket ->
+           {:cont,
+            assign_new(socket, :has_show_links_uri_hash, fn ->
+              String.contains?(uri, "#show_links")
+            end)}
+         end)}
+    end
   end
 
   @impl Phoenix.LiveView
-  def handle_params(_params, _url, socket) do
+  def handle_params(%{"view" => view}, _, socket) do
+    %{author: author} = socket.assigns
+    {:ok, _updated} = update_author_view_pref(author, view)
+
+    {:noreply, assign(socket, view: view)}
+  end
+
+  def handle_params(params, _url, %{assigns: %{live_action: live_action}} = socket) do
+    {:noreply, apply_action(socket, live_action, params)}
+  end
+
+  def handle_params(_, _, socket) do
     {:noreply, socket}
   end
 
-  @impl Phoenix.LiveView
-  def render(assigns) do
-    ~H"""
-    <h1 class="flex flex-col w-full h-screen items-center justify-center">
-      Placeholder for Curriculum
-    </h1>
-    """
+  # Load either a specific container, or if the slug is nil the root. After loaded,
+  # scrub the container's children to ensure that there a no duplicate ids that may
+  # have crept in.
+  defp load_and_scrub_container(container_slug, project_slug, root_container) do
+    container =
+      if is_nil(container_slug) do
+        root_container
+      else
+        AuthoringResolver.from_revision_slug(project_slug, container_slug)
+      end
+
+    {deduped, _} =
+      Enum.reduce(container.children, {[], MapSet.new()}, fn id, {all, map} ->
+        case MapSet.member?(map, id) do
+          true -> {all, map}
+          false -> {[id | all], MapSet.put(map, id)}
+        end
+      end)
+
+    # Now see if the deduping actually led to any change in the number of children,
+    # remembering though that the deduped children ids are in reverse order.
+    if length(deduped) != length(container.children) do
+      Repo.transaction(fn ->
+        ChangeTracker.track_revision(project_slug, container, %{
+          # restore correct order
+          children: Enum.reverse(deduped)
+        })
+      end)
+    else
+      {:ok, container}
+    end
+  end
+
+  defp apply_action(socket, :edit, %{"project_id" => project_id, "revision_slug" => revision_slug}) do
+    socket
+    |> assign(:page_title, "Options")
+    |> assign(:revision, AuthoringResolver.from_revision_slug(project_id, revision_slug))
+  end
+
+  defp apply_action(socket, _action, _params) do
+    socket
+    |> assign(:page_title, "Curriculum | " <> socket.assigns.project.title)
+    |> assign(:revision, nil)
+  end
+
+  # spin up subscriptions for the container and for all of its children, activities and attached objectives
+  defp subscribe(
+         container,
+         children,
+         %Rollup{activity_map: activity_map, objective_map: objective_map},
+         project_slug
+       ) do
+    Enum.each(children, fn child ->
+      Subscriber.subscribe_to_locks_acquired(project_slug, child.resource_id)
+      Subscriber.subscribe_to_locks_released(project_slug, child.resource_id)
+    end)
+
+    activity_ids = Enum.map(activity_map, fn {id, _} -> id end)
+    objective_ids = Enum.map(objective_map, fn {id, _} -> id end)
+
+    ids =
+      [container.resource_id] ++
+        Enum.map(children, fn c -> c.resource_id end) ++ activity_ids ++ objective_ids
+
+    Enum.each(ids, fn id ->
+      Subscriber.subscribe_to_new_revisions_in_project(id, project_slug)
+    end)
+
+    Subscriber.subscribe_to_new_resources_of_type(
+      Oli.Resources.ResourceType.id_for_objective(),
+      project_slug
+    )
+
+    ids
+  end
+
+  # release a collection of subscriptions
+  defp unsubscribe(ids, children, project_slug) do
+    Subscriber.unsubscribe_to_new_resources_of_type(
+      Oli.Resources.ResourceType.id_for_objective(),
+      project_slug
+    )
+
+    Enum.each(ids, &Subscriber.unsubscribe_to_new_revisions_in_project(&1, project_slug))
+
+    Enum.each(children, fn child ->
+      Subscriber.unsubscribe_to_locks_acquired(project_slug, child.resource_id)
+      Subscriber.unsubscribe_to_locks_released(project_slug, child.resource_id)
+    end)
+  end
+
+  def handle_event("show_options_modal", %{"slug" => slug}, socket) do
+    %{container: container, project: project, children: children} =
+      socket.assigns
+
+    redirect_url = ContainerLiveHelpers.build_redirect_url(socket, project.slug, container.slug)
+
+    {:noreply,
+     assign(socket,
+       options_modal_assigns:
+         ContainerLiveHelpers.build_option_modal_assigns(redirect_url, children, slug)
+     )
+     |> push_event("js-exec", %{
+       to: "#options-modal-assigns-trigger",
+       attr: "data-show_modal"
+     })}
+  end
+
+  def handle_event("restart_options_modal", _, socket) do
+    {:noreply, assign(socket, options_modal_assigns: nil)}
+  end
+
+  def handle_event("validate-options", %{"revision" => revision_params}, socket) do
+    %{options_modal_assigns: %{revision: revision} = modal_assigns} = socket.assigns
+
+    revision_params = ContainerLiveHelpers.decode_revision_params(revision_params)
+
+    changeset =
+      revision
+      |> Resources.change_revision(revision_params)
+      |> Map.put(:action, :validate)
+      |> to_form()
+
+    {:noreply, assign(socket, options_modal_assigns: %{modal_assigns | form: changeset})}
+  end
+
+  def handle_event("save-options", %{"revision" => revision_params}, socket) do
+    %{options_modal_assigns: %{redirect_url: redirect_url, revision: revision}, project: project} =
+      socket.assigns
+
+    revision_params = ContainerLiveHelpers.decode_revision_params(revision_params)
+
+    case ContainerEditor.edit_page(project, revision.slug, revision_params) do
+      {:ok, _} ->
+        {:noreply,
+         socket
+         |> put_flash(
+           :info,
+           "#{resource_type_label(revision) |> String.capitalize()} options saved"
+         )
+         |> push_navigate(to: redirect_url)}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign(socket, :changeset, changeset)}
+    end
+  end
+
+  def handle_event("show_move_modal", %{"slug" => slug}, socket) do
+    %{container: container, project: project} = socket.assigns
+
+    modal_assigns = ContainerLiveHelpers.build_modal_assigns(container.slug, project.slug, slug)
+
+    modal = fn assigns ->
+      ~H"""
+      <MoveModal.render {@modal_assigns} />
+      """
+    end
+
+    {:noreply,
+     show_modal(
+       socket,
+       modal,
+       modal_assigns: modal_assigns
+     )}
+  end
+
+  def handle_event("HierarchyPicker.update_active", %{"uuid" => uuid}, socket) do
+    %{modal_assigns: %{hierarchy: hierarchy} = modal_assigns} = socket.assigns
+
+    active = Hierarchy.find_in_hierarchy(hierarchy, uuid)
+
+    modal_assigns = %{
+      modal_assigns
+      | active: active
+    }
+
+    {:noreply, assign(socket, modal_assigns: modal_assigns)}
+  end
+
+  def handle_event(
+        "MoveModal.move_item",
+        %{"uuid" => uuid, "from_uuid" => from_uuid, "to_uuid" => to_uuid},
+        socket
+      ) do
+    %{
+      author: author,
+      project: project,
+      modal_assigns: %{hierarchy: hierarchy}
+    } = socket.assigns
+
+    %{revision: revision} = Hierarchy.find_in_hierarchy(hierarchy, uuid)
+    %{revision: from_container} = Hierarchy.find_in_hierarchy(hierarchy, from_uuid)
+    %{revision: to_container} = Hierarchy.find_in_hierarchy(hierarchy, to_uuid)
+
+    {:ok, _} = ContainerEditor.move_to(revision, from_container, to_container, author, project)
+
+    {:noreply, hide_modal(socket, modal_assigns: nil)}
+  end
+
+  def handle_event("MoveModal.remove", %{"uuid" => uuid, "from_uuid" => from_uuid}, socket) do
+    %{
+      author: author,
+      project: project,
+      modal_assigns: %{hierarchy: hierarchy}
+    } = socket.assigns
+
+    %{revision: revision} = Hierarchy.find_in_hierarchy(hierarchy, uuid)
+    %{revision: from_container} = Hierarchy.find_in_hierarchy(hierarchy, from_uuid)
+    to_container = nil
+
+    {:ok, _} = ContainerEditor.move_to(revision, from_container, to_container, author, project)
+
+    {:noreply, hide_modal(socket, modal_assigns: nil)}
+  end
+
+  def handle_event("MoveModal.cancel", _, socket) do
+    {:noreply, hide_modal(socket, modal_assigns: nil)}
+  end
+
+  def handle_event("show_delete_modal", %{"slug" => slug}, socket) do
+    %{container: container, project: project, author: author} = socket.assigns
+
+    case Enum.find(socket.assigns.children, fn r -> r.slug == slug end) do
+      %{children: []} = item ->
+        case AuthoringResolver.find_hyperlink_references(project.slug, slug) do
+          [] ->
+            proceed_with_deletion_warning(socket, container, project, author, item)
+
+          references ->
+            show_hyperlink_dependency_modal(socket, container, project, references, item)
+        end
+
+      item ->
+        notify_not_empty(socket, container, project, author, item)
+    end
+  end
+
+  def handle_event("DeleteModal.delete", %{"slug" => slug}, socket) do
+    %{
+      modal_assigns: %{
+        container: container,
+        project: project,
+        author: author,
+        revision: revision,
+        redirect_url: redirect_url
+      }
+    } = socket.assigns
+
+    case container do
+      nil ->
+        result =
+          Oli.Repo.transaction(fn ->
+            revision =
+              Oli.Publishing.AuthoringResolver.from_revision_slug(project.slug, revision.slug)
+
+            Oli.Publishing.ChangeTracker.track_revision(project.slug, revision, %{deleted: true})
+          end)
+
+        case result do
+          {:ok, _} ->
+            {:noreply,
+             socket
+             |> push_patch(to: redirect_url)
+             |> hide_modal(modal_assigns: nil)}
+
+          _ ->
+            {:noreply,
+             socket
+             |> put_flash(
+               :error,
+               "Could not delete #{resource_type_label(revision)} \"#{revision.title}\""
+             )
+             |> hide_modal(modal_assigns: nil)}
+        end
+
+      _ ->
+        case ContainerEditor.remove_child(container, project, author, slug) do
+          {:ok, _} ->
+            {:noreply,
+             socket
+             |> push_patch(to: redirect_url)
+             |> hide_modal(modal_assigns: nil)}
+
+          {:error, _} ->
+            {:noreply,
+             socket
+             |> put_flash(
+               :error,
+               "Could not delete #{resource_type_label(revision)} \"#{revision.title}\""
+             )
+             |> hide_modal(modal_assigns: nil)}
+        end
+    end
+  end
+
+  def handle_event("duplicate_page", %{"id" => page_id}, socket) do
+    %{container: container, project: project, author: author} = socket.assigns
+
+    socket =
+      case ContainerEditor.duplicate_page(container, page_id, author, project) do
+        {:ok, _result} ->
+          socket
+
+        {:error, %Ecto.Changeset{} = _changeset} ->
+          socket
+          |> put_flash(:error, "Could not duplicate page")
+      end
+
+    {:noreply,
+     assign(socket,
+       numberings:
+         Numbering.number_full_tree(
+           Oli.Publishing.AuthoringResolver,
+           socket.assigns.project.slug,
+           socket.assigns.project.customizations
+         )
+     )}
+  end
+
+  def handle_event("dismiss", _, socket) do
+    {:noreply, hide_modal(socket, modal_assigns: nil)}
+  end
+
+  # handle change of selection
+  def handle_event("select", %{"slug" => slug}, socket) do
+    selected = Enum.find(socket.assigns.children, fn r -> r.slug == slug end)
+    {:noreply, assign(socket, :selected, selected)}
+  end
+
+  def handle_event("keydown", %{"key" => key, "shiftKey" => shiftKeyPressed?} = params, socket) do
+    focused_index =
+      case params["index"] do
+        nil -> nil
+        stringIndex -> String.to_integer(stringIndex)
+      end
+
+    last_index = length(socket.assigns.children) - 1
+    children = socket.assigns.children
+
+    case {focused_index, key, shiftKeyPressed?} do
+      {nil, _, _} ->
+        {:noreply, socket}
+
+      {^last_index, "ArrowDown", _} ->
+        {:noreply, socket}
+
+      {0, "ArrowUp", _} ->
+        {:noreply, socket}
+
+      # Each drop target has a corresponding entry after it with a matching index.
+      # That means that the "drop index" is the index of where you'd like to place the item AHEAD OF
+      # So to reorder an item below its current position, we add +2 ->
+      # +1 would mean insert it BEFORE the next item, but +2 means insert it before the item after the next item.
+      # See the logic in container editor that does the adjustment based on the positions of the drop targets.
+      {focused_index, "ArrowDown", true} ->
+        handle_event(
+          "reorder",
+          %{
+            "sourceIndex" => Integer.to_string(focused_index),
+            "dropIndex" => Integer.to_string(focused_index + 2)
+          },
+          socket
+        )
+
+      {focused_index, "ArrowUp", true} ->
+        handle_event(
+          "reorder",
+          %{
+            "sourceIndex" => Integer.to_string(focused_index),
+            "dropIndex" => Integer.to_string(focused_index - 1)
+          },
+          socket
+        )
+
+      {focused_index, "Enter", _} ->
+        {:noreply, assign(socket, :selected, Enum.at(children, focused_index))}
+
+      {_, _, _} ->
+        {:noreply, socket}
+    end
+  end
+
+  # handle reordering event
+  def handle_event("reorder", %{"sourceIndex" => source_index, "dropIndex" => index}, socket) do
+    source = Enum.at(socket.assigns.children, String.to_integer(source_index))
+
+    socket =
+      case ContainerEditor.reorder_child(
+             socket.assigns.container,
+             socket.assigns.project,
+             socket.assigns.author,
+             source.slug,
+             String.to_integer(index)
+           ) do
+        {:ok, _} ->
+          socket
+
+        {:error, _} ->
+          socket
+          |> put_flash(:error, "Could not edit page")
+      end
+
+    {:noreply, socket}
+  end
+
+  # handle drag events
+  def handle_event("dragstart", drag_slug, socket) do
+    {:noreply, assign(socket, dragging: drag_slug)}
+  end
+
+  def handle_event("dragend", _, socket) do
+    {:noreply, assign(socket, dragging: nil)}
+  end
+
+  def handle_event("add", %{"type" => type, "scored" => scored}, socket) do
+    case ContainerEditor.add_new(
+           socket.assigns.container,
+           type,
+           scored,
+           socket.assigns.author,
+           socket.assigns.project,
+           socket.assigns.numberings
+         ) do
+      {:ok, _} ->
+        {:noreply,
+         assign(socket,
+           numberings:
+             Numbering.number_full_tree(
+               Oli.Publishing.AuthoringResolver,
+               socket.assigns.project.slug,
+               socket.assigns.project.customizations
+             )
+         )}
+
+      {:error, %Ecto.Changeset{} = _changeset} ->
+        {:noreply, put_flash(socket, :error, "Could not create new item")}
+    end
+  end
+
+  def handle_event("change-view", %{"view" => view}, socket) do
+    {:noreply,
+     push_patch(socket,
+       to:
+         Routes.container_path(
+           socket,
+           :index,
+           socket.assigns.project.slug,
+           socket.assigns.container.slug,
+           %{view: view}
+         )
+     )}
+  end
+
+  defp proceed_with_deletion_warning(socket, container, project, author, item) do
+    modal_assigns = %{
+      id: "delete_#{item.slug}",
+      redirect_url: Routes.container_path(socket, :index, project.slug, container.slug),
+      revision: item,
+      container: container,
+      project: project,
+      author: author
+    }
+
+    modal = fn assigns ->
+      ~H"""
+      <DeleteModal.render {@modal_assigns} />
+      """
+    end
+
+    {:noreply, show_modal(socket, modal, modal_assigns: modal_assigns)}
+  end
+
+  defp show_hyperlink_dependency_modal(socket, container, project, hyperlinks, item) do
+    modal_assigns = %{
+      id: "not_empty_#{item.slug}",
+      revision: item,
+      container: container,
+      project: project,
+      hyperlinks: hyperlinks
+    }
+
+    modal = fn assigns ->
+      ~H"""
+      <HyperlinkDependencyModal.render {@modal_assigns} />
+      """
+    end
+
+    {:noreply, show_modal(socket, modal, modal_assigns: modal_assigns)}
+  end
+
+  defp notify_not_empty(socket, container, project, author, item) do
+    modal_assigns = %{
+      id: "not_empty_#{item.slug}",
+      revision: item,
+      container: container,
+      project: project,
+      author: author
+    }
+
+    modal = fn assigns ->
+      ~H"""
+      <NotEmptyModal.render {@modal_assigns} />
+      """
+    end
+
+    {:noreply, show_modal(socket, modal, modal_assigns: modal_assigns)}
+  end
+
+  defp update_author_view_pref(author, curriculum_view) do
+    updated_preferences =
+      value_or(author.preferences, %Accounts.AuthorPreferences{})
+      |> Map.put(:curriculum_view, curriculum_view)
+      |> Map.from_struct()
+
+    Accounts.update_author(author, %{preferences: updated_preferences})
+  end
+
+  defp has_renderable_change?(page1, page2) do
+    page1.title != page2.title or
+      page1.graded != page2.graded or
+      page1.max_attempts != page2.max_attempts or
+      page1.scoring_strategy_id != page2.scoring_strategy_id
+  end
+
+  # We need to monitor for changes in the title of an objective
+  defp handle_updated_objective(socket, revision) do
+    assign(socket, rollup: Rollup.objective_updated(socket.assigns.rollup, revision))
+  end
+
+  # We need to monitor for changes in the title of an objective
+  defp handle_updated_activity(socket, revision) do
+    assign(socket,
+      rollup:
+        Rollup.activity_updated(socket.assigns.rollup, revision, socket.assigns.project.slug)
+    )
+  end
+
+  defp handle_updated_page(socket, revision) do
+    id = revision.resource_id
+
+    old_page =
+      Enum.find(socket.assigns.children, fn p -> p.resource_id == revision.resource_id end)
+
+    # check to see if the activities in that page have changed since our last view of it
+    {:ok, activities_delta} = ActivityDelta.new(revision, old_page)
+
+    # We only track this update if it affects our rendering.  So we check to see if the
+    # title or settings has changed of if the activities in this page haven't been added/removed
+    if has_renderable_change?(old_page, revision) or
+         ActivityDelta.have_activities_changed?(activities_delta) do
+      # we splice that page into its location
+      children =
+        case Enum.find_index(socket.assigns.children, fn p -> p.resource_id == id end) do
+          nil -> socket.assigns.children
+          index -> List.replace_at(socket.assigns.children, index, revision)
+        end
+
+      # update our selection to reflect the latest model
+      selected =
+        case socket.assigns.selected do
+          nil -> nil
+          s -> Enum.find(children, fn r -> r.resource_id == s.resource_id end)
+        end
+
+      # update the relevant maps that allow us to show roll ups
+      rollup =
+        Rollup.page_updated(
+          socket.assigns.rollup,
+          revision,
+          activities_delta,
+          socket.assigns.project.slug
+        )
+
+      assign(socket, selected: selected, children: children, rollup: rollup)
+    else
+      socket
+    end
+  end
+
+  defp handle_updated_container(socket, revision) do
+    %{container: %Revision{resource_id: container_resource_id}} = socket.assigns
+
+    # only update when the container that changed is the container in view
+    if revision.resource_id == container_resource_id do
+      # in the case of a change to the container, we simplify by just pulling a new view of
+      # the container and its contents. This handles addition, removal, reordering from the
+      # local user as well as a collaborator
+      children = ContainerEditor.list_all_container_children(revision, socket.assigns.project)
+
+      {:ok, rollup} = Rollup.new(children, socket.assigns.project.slug)
+
+      selected =
+        case socket.assigns.selected do
+          nil -> nil
+          s -> Enum.find(children, fn r -> r.resource_id == s.resource_id end)
+        end
+
+      assign(socket,
+        selected: selected,
+        container: revision,
+        children: children,
+        rollup: rollup,
+        numberings:
+          Numbering.number_full_tree(
+            Oli.Publishing.AuthoringResolver,
+            socket.assigns.project.slug,
+            socket.assigns.project.customizations
+          )
+      )
+    else
+      socket
+    end
+  end
+
+  # Here we respond to notifications for edits made
+  # to the container or to its child children, contained activities and attached objectives
+  def handle_info({:updated, revision, _}, socket) do
+    socket =
+      case Oli.Resources.ResourceType.get_type_by_id(revision.resource_type_id) do
+        "activity" -> handle_updated_activity(socket, revision)
+        "objective" -> handle_updated_objective(socket, revision)
+        "page" -> handle_updated_page(socket, revision)
+        "container" -> handle_updated_container(socket, revision)
+      end
+
+    # redo all subscriptions
+    unsubscribe(
+      socket.assigns.subscriptions,
+      socket.assigns.children,
+      socket.assigns.project.slug
+    )
+
+    subscriptions =
+      subscribe(
+        socket.assigns.container,
+        socket.assigns.children,
+        socket.assigns.rollup,
+        socket.assigns.project.slug
+      )
+
+    {:noreply, assign(socket, subscriptions: subscriptions)}
+  end
+
+  # listens for creation of new objectives
+  def handle_info({:new_resource, revision, _}, socket) do
+    # include it in our objective map
+    rollup = Rollup.objective_updated(socket.assigns.rollup, revision)
+
+    # now listen to it for future edits
+    Subscriber.subscribe_to_new_revisions_in_project(
+      revision.resource_id,
+      socket.assigns.project.slug
+    )
+
+    subscriptions = [revision.resource_id | socket.assigns.subscriptions]
+
+    {:noreply, assign(socket, rollup: rollup, subscriptions: subscriptions)}
+  end
+
+  def handle_info(
+        {:lock_acquired, publication_id, resource_id, author_id},
+        %{assigns: %{resources_being_edited: resources_being_edited, project: %{id: project_id}}} =
+          socket
+      ) do
+    # Check to see if the lock_acquired message is intended for this specific project/publication's resource.
+    # This check could be optimized by crafting a more specific message that embeds the publication_id, but then the
+    # latest active publication_id would need to be tracked in the assigns and updated if a project is published.
+    # Same thing applies to the :lock_released handler below.
+    if Publishing.get_unpublished_publication_id!(project_id) == publication_id do
+      author = Accounts.get_author(author_id)
+
+      new_resources_being_edited = Map.put(resources_being_edited, resource_id, author)
+      {:noreply, assign(socket, resources_being_edited: new_resources_being_edited)}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  def handle_info(
+        {:lock_released, publication_id, resource_id},
+        %{assigns: %{resources_being_edited: resources_being_edited, project: %{id: project_id}}} =
+          socket
+      ) do
+    if Publishing.get_unpublished_publication_id!(project_id) == publication_id do
+      new_resources_being_edited = Map.delete(resources_being_edited, resource_id)
+      {:noreply, assign(socket, resources_being_edited: new_resources_being_edited)}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  # Resources currently being edited by an author (has a lock present)
+  # : %{ resource_id => author }
+  def get_resources_being_edited(resource_ids, project_id) do
+    project_id
+    |> Publishing.get_unpublished_publication_id!()
+    |> (&Publishing.retrieve_lock_info(resource_ids, &1)).()
+    |> Enum.map(fn published_resource ->
+      {published_resource.resource_id, published_resource.author}
+    end)
+    |> Enum.into(%{})
   end
 end

--- a/lib/oli_web/live/workspaces/course_author/curriculum_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/curriculum_live.ex
@@ -295,10 +295,11 @@ defmodule OliWeb.Workspaces.CourseAuthor.CurriculumLive do
         container: container,
         project: project,
         author: author,
-        revision: revision,
-        redirect_url: redirect_url
+        revision: revision
       }
     } = socket.assigns
+
+    redirect_url = Routes.live_path(socket, __MODULE__, socket.assigns.project.slug)
 
     case container do
       nil ->
@@ -491,17 +492,10 @@ defmodule OliWeb.Workspaces.CourseAuthor.CurriculumLive do
     end
   end
 
-  def handle_event("change-view", %{"view" => view}, socket) do
+  def handle_event("change-view", params, socket) do
     {:noreply,
      push_patch(socket,
-       to:
-         Routes.container_path(
-           socket,
-           :index,
-           socket.assigns.project.slug,
-           socket.assigns.container.slug,
-           %{view: view}
-         )
+       to: Routes.live_path(socket, __MODULE__, socket.assigns.project.slug, params)
      )}
   end
 

--- a/lib/oli_web/live/workspaces/course_author/curriculum_live.html.heex
+++ b/lib/oli_web/live/workspaces/course_author/curriculum_live.html.heex
@@ -1,0 +1,198 @@
+<%= render_modal(assigns) %>
+
+<Modal.modal
+  id="options_modal"
+  class="w-auto min-w-[50%]"
+  body_class="px-6"
+  on_cancel={JS.push("restart_options_modal")}
+>
+  <:title>
+    <%= @options_modal_assigns[:title] %>
+  </:title>
+
+  <%= if @options_modal_assigns do %>
+    <.live_component
+      module={OptionsModalContent}
+      ctx={@ctx}
+      id="modal_content"
+      redirect_url={@options_modal_assigns.redirect_url}
+      revision={@options_modal_assigns.revision}
+      project={@project}
+      project_hierarchy={@project_hierarchy}
+      validate={JS.push("validate-options")}
+      submit={JS.push("save-options")}
+      cancel={Modal.hide_modal("options_modal") |> JS.push("restart_options_modal")}
+      form={@options_modal_assigns.form}
+    />
+  <% end %>
+  <div id="options-modal-assigns-trigger" data-show_modal={Modal.show_modal("options_modal")}>
+  </div>
+</Modal.modal>
+
+<div id="curriculum-container" class="container mx-auto curriculum-editor">
+  <div class="flex justify-between items-center mb-3">
+    <p>
+      Create and arrange your learning materials below.
+    </p>
+    <div class="flex items-center gap-x-4">
+      <.link
+        :if={@has_show_links_uri_hash and Accounts.is_system_admin?(@author)}
+        navigate={~p[/project/#{@project.slug}/history/slug/#{@container.slug}]}
+      >
+        <i class="fas fa-history"></i> View revision history
+      </.link>
+      <.link href={~p"/authoring/project/#{@project.slug}/pages"} role="go_to_all_pages">
+        All Pages
+      </.link>
+    </div>
+  </div>
+  <div class="grid grid-cols-12">
+    <div class="col-span-12">
+      <div class="change-view-buttons">
+        <div class="btn-group btn-group-toggle" data-bs-toggle="buttons">
+          <label
+            phx-click="change-view"
+            phx-value-view="Basic"
+            class={"btn btn-xs #{if @view == "Basic", do: "active"}"}
+          >
+            <input type="radio" name="options" id="view-1" checked={@view == "Basic"} />
+            <span>Basic</span>
+          </label>
+
+          <label
+            phx-click="change-view"
+            phx-value-view="Detailed"
+            class={"btn btn-xs #{if @view == "Detailed", do: "active"}"}
+          >
+            <input type="radio" name="options" id="view-2" checked={@view == "Detailed"} />
+            <span>Detailed</span>
+          </label>
+
+          <label
+            phx-click="change-view"
+            phx-value-view="Learning Summary"
+            class={"btn btn-xs #{if @view === "Learning Summary", do: "active"}"}
+          >
+            <input type="radio" name="options" id="view-3" checked={@view == "Learning Summary"} />
+            <span>Learning</span>
+          </label>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="grid grid-cols-12" phx-window-keydown="keydown">
+    <div class="col-span-12">
+      <div class="curriculum-entries">
+        <%= if Enum.count(@children) == 0 do %>
+          <div style="margin-top: 15px">
+            <p>There's nothing here.</p>
+          </div>
+        <% end %>
+        <%= for {child, index} <- Enum.with_index(@children) |> Enum.filter(fn {c, _i} -> c.slug != @dragging end) do %>
+          <DropTarget.render index={index} />
+          <Entry.render
+            ctx={@ctx}
+            editor={Map.get(@resources_being_edited, child.resource_id)}
+            author={@author}
+            selected={child == @selected}
+            container={@container}
+            child={child}
+            activity_ids={Map.get(@rollup.page_activity_map, child.resource_id)}
+            activity_map={@rollup.activity_map}
+            objective_map={@rollup.objective_map}
+            index={index}
+            project={@project}
+            view={@view}
+            numberings={@numberings}
+            revision_history_link={
+              @has_show_links_uri_hash and Accounts.is_system_admin?(@author)
+            }
+          />
+        <% end %>
+        <%!-- <DropTarget id="last" index={length(@children)} /> --%>
+      </div>
+      <div class="mt-5">
+        <div class="flex mb-3">
+          <div class="border rounded shadow-md p-2">
+            <div class="text-secondary mb-3">Create a page:</div>
+            <div class="flex mb-2">
+              <div class="grid grid-cols-3 gap-x-4">
+                <%= if @adaptivity_flag do %>
+                  <div class="flex flex-col">
+                    <div
+                      class="mb-2"
+                      title="Contains basic elements such as paragraphs, images, and activities"
+                    >
+                      Basic
+                    </div>
+                    <div title="Contains rich content, images, styles and layouts and can be used to create adaptive learning experiences based on rules defined for a lesson">
+                      Adaptive
+                    </div>
+                  </div>
+                <% end %>
+                <div class="flex flex-col">
+                  <button
+                    phx-click="add"
+                    phx-value-type="Basic"
+                    phx-value-scored="Unscored"
+                    title="Questions on the page will not be scored"
+                    class="btn btn-xs btn-outline-primary mb-2"
+                    type="button"
+                  >
+                    Practice
+                  </button>
+                  <%= if @adaptivity_flag do %>
+                    <button
+                      phx-click="add"
+                      phx-value-type="Adaptive"
+                      phx-value-scored="Unscored"
+                      title="Questions on the page will not be scored"
+                      class="btn btn-xs btn-outline-primary"
+                      type="button"
+                    >
+                      Practice
+                    </button>
+                  <% end %>
+                </div>
+                <div class="flex flex-col">
+                  <button
+                    phx-click="add"
+                    phx-value-type="Basic"
+                    phx-value-scored="Scored"
+                    title="Questions on the page will be scored"
+                    class="btn btn-xs btn-outline-primary mb-2"
+                    type="button"
+                  >
+                    Scored
+                  </button>
+                  <%= if @adaptivity_flag do %>
+                    <button
+                      phx-click="add"
+                      phx-value-type="Adaptive"
+                      phx-value-scored="Scored"
+                      title="Questions on the page will be scored"
+                      class="btn btn-xs btn-outline-primary"
+                      type="button"
+                    >
+                      Scored
+                    </button>
+                  <% end %>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <button
+          phx-click="add"
+          phx-value-type="Container"
+          phx-value-scored="Unscored"
+          title="A grouping of pages"
+          class="btn btn-xs btn-outline-primary mr-0.5"
+          type="button"
+        >
+          Create a <%= new_container_name(@numberings, @container) %>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/lib/oli_web/live/workspaces/course_author/curriculum_live.html.heex
+++ b/lib/oli_web/live/workspaces/course_author/curriculum_live.html.heex
@@ -29,7 +29,7 @@
   </div>
 </Modal.modal>
 
-<div id="curriculum-container" class="container mx-auto curriculum-editor">
+<div id="curriculum-container" class="container flex flex-col gap-y-6 p-8 curriculum-editor">
   <div class="flex justify-between items-center mb-3">
     <p>
       Create and arrange your learning materials below.
@@ -40,9 +40,6 @@
         navigate={~p[/project/#{@project.slug}/history/slug/#{@container.slug}]}
       >
         <i class="fas fa-history"></i> View revision history
-      </.link>
-      <.link href={~p"/authoring/project/#{@project.slug}/pages"} role="go_to_all_pages">
-        All Pages
       </.link>
     </div>
   </div>

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -807,6 +807,7 @@ defmodule OliWeb.Router do
         live("/:project_id/experiments", ExperimentsLive)
         live("/:project_id/bibliography", BibliographyLive)
         live("/:project_id/curriculum", CurriculumLive)
+        live("/:project_id/curriculum/:container_slug", CurriculumLive)
         live("/:project_id/pages", PagesLive)
         live("/:project_id/activities", ActivitiesLive)
         live("/:project_id/review", ReviewLive)

--- a/test/oli_web/live/workspace/course_author/curriculum_live_test.exs
+++ b/test/oli_web/live/workspace/course_author/curriculum_live_test.exs
@@ -1,0 +1,825 @@
+defmodule OliWeb.Workspaces.CourseAuthor.CurriculumLiveTest do
+  use OliWeb.ConnCase
+
+  alias Oli.Seeder
+  alias Oli.Publishing
+  alias Oli.Resources.ResourceType
+
+  import Oli.Factory
+  import Phoenix.ConnTest
+  import Phoenix.LiveViewTest
+
+  @endpoint OliWeb.Endpoint
+
+  describe "cannot access when is not logged in" do
+    test "redirect to new session when accessing the curriculum view", %{
+      conn: conn
+    } do
+      project = insert(:project)
+
+      {:error, {:redirect, %{to: "/workspaces/course_author"}}} =
+        live(conn, live_view_route(project.slug))
+    end
+  end
+
+  describe "cannot access when is not an author" do
+    setup [:user_conn]
+
+    test "redirect to new session when accessing the curriculum view", %{
+      conn: conn
+    } do
+      project = insert(:project)
+
+      {:error, {:redirect, %{to: "/workspaces/course_author"}}} =
+        live(conn, live_view_route(project.slug))
+    end
+  end
+
+  describe "user cannot access when is logged in as an author but is not an author of the project" do
+    setup [:author_conn]
+
+    test "redirects to projects view when accessing the objectives view", %{
+      conn: conn
+    } do
+      project = insert(:project)
+
+      {:error, {:redirect, %{to: "/workspaces/course_author"}}} =
+        live(conn, live_view_route(project.slug))
+    end
+  end
+
+  describe "curriculum live test" do
+    setup [:setup_session]
+
+    test "shows the author name editing the page correctly", %{
+      conn: conn,
+      project: project,
+      map: %{
+        published_resource1: published_resource1
+      }
+    } do
+      editing_author = insert(:author)
+
+      Publishing.update_published_resource(published_resource1, %{
+        locked_by_id: editing_author.id,
+        lock_updated_at: now()
+      })
+
+      {:ok, view, _} = live(conn, live_view_route(project.slug))
+
+      assert has_element?(view, "span", "#{editing_author.name} is editing")
+    end
+
+    test "shows duplicate action for pages", %{
+      conn: conn,
+      author: author,
+      project: project,
+      revision1: revision_page_one,
+      revision2: revision_page_two
+    } do
+      conn =
+        recycle(conn)
+        |> Pow.Plug.assign_current_user(
+          author,
+          OliWeb.Pow.PowHelpers.get_pow_config(:author)
+        )
+        |> get("/workspaces/course_author/#{project.slug}/curriculum/")
+
+      {:ok, view, _html} = live(conn)
+
+      # Duplicate action is present with the right revision id
+      assert view
+             |> element(
+               "div[phx-value-slug=\"#{revision_page_one.slug}\"] button[role=\"duplicate_page\"]"
+             )
+             |> render =~ "phx-value-id=\"#{revision_page_one.id}\""
+
+      # Clicking on duplicate action creates a new entry with the right title name
+      view
+      |> element(
+        "div[phx-value-slug=\"#{revision_page_two.slug}\"] button[role=\"duplicate_page\"]"
+      )
+      |> render_click =~
+        "entry-title\">Copy of #{revision_page_two.title}</span>"
+    end
+
+    test "does not show duplicate action for adaptive pages", %{
+      conn: conn,
+      author: author,
+      project: project,
+      adaptive_page_revision: adaptive_page_revision
+    } do
+      conn =
+        recycle(conn)
+        |> Pow.Plug.assign_current_user(
+          author,
+          OliWeb.Pow.PowHelpers.get_pow_config(:author)
+        )
+        |> get("/workspaces/course_author/#{project.slug}/curriculum/")
+
+      {:ok, view, _html} = live(conn)
+
+      assert view
+             |> has_element?("div[phx-value-slug=\"#{adaptive_page_revision.slug}\"]")
+
+      refute view
+             |> has_element?(
+               "div[phx-value-slug=\"#{adaptive_page_revision.slug}\"] button[phx-click=\"duplicate_page\"]"
+             )
+    end
+
+    test "show the correct fields for the page option modal", %{
+      conn: conn,
+      author: author,
+      project: project,
+      revision1: revision_page_one
+    } do
+      conn =
+        recycle(conn)
+        |> Pow.Plug.assign_current_user(
+          author,
+          OliWeb.Pow.PowHelpers.get_pow_config(:author)
+        )
+        |> get("/workspaces/course_author/#{project.slug}/curriculum/")
+
+      {:ok, view, _html} = live(conn)
+
+      view
+      |> element(
+        "div[phx-value-slug=\"#{revision_page_one.slug}\"] button[role=\"show_options_modal\"]"
+      )
+      |> render_click() =~ "Page Options"
+
+      assert has_element?(
+               view,
+               "form#revision-settings-form [name=\"revision[title]\"]"
+             )
+
+      assert has_element?(
+               view,
+               "form#revision-settings-form [name=\"revision[graded]\"]"
+             )
+
+      assert has_element?(
+               view,
+               "form#revision-settings-form [name=\"revision[explanation_strategy][type]\"]"
+             )
+
+      assert has_element?(
+               view,
+               "form#revision-settings-form [name=\"revision[max_attempts]\"]"
+             )
+
+      assert has_element?(
+               view,
+               "form#revision-settings-form [name=\"revision[scoring_strategy_id]\"]"
+             )
+
+      assert has_element?(
+               view,
+               "form#revision-settings-form [name=\"revision[retake_mode]\"]"
+             )
+
+      assert has_element?(
+               view,
+               "form#revision-settings-form [name=\"revision[assessment_mode]\"]"
+             )
+
+      assert has_element?(
+               view,
+               "form#revision-settings-form [name=\"revision[purpose]\"]"
+             )
+
+      assert has_element?(
+               view,
+               "form#revision-settings-form div#related-resources-selector"
+             )
+    end
+
+    test "when the page is of type 'foundation', the related resources selector is disabled",
+         %{
+           conn: conn,
+           author: author,
+           project: project,
+           revision1: revision_page_one
+         } do
+      conn =
+        recycle(conn)
+        |> Pow.Plug.assign_current_user(
+          author,
+          OliWeb.Pow.PowHelpers.get_pow_config(:author)
+        )
+        |> get("/workspaces/course_author/#{project.slug}/curriculum/")
+
+      {:ok, view, _html} = live(conn)
+
+      view
+      |> element(
+        "div[phx-value-slug=\"#{revision_page_one.slug}\"] button[role=\"show_options_modal\"]"
+      )
+      |> render_click()
+
+      view
+      |> form("form#revision-settings-form", %{
+        "revision" => %{
+          "purpose" => "foundation"
+        }
+      })
+
+      assert view
+             |> element("div#related-resources-selector")
+             |> render() =~ "disabled"
+    end
+
+    test "the related resources get updated in the database", %{
+      conn: conn,
+      author: author,
+      project: project,
+      revision1: revision_page_one,
+      revision2: revision_page_two
+    } do
+      conn =
+        recycle(conn)
+        |> Pow.Plug.assign_current_user(
+          author,
+          OliWeb.Pow.PowHelpers.get_pow_config(:author)
+        )
+        |> get("/workspaces/course_author/#{project.slug}/curriculum/")
+
+      {:ok, view, _html} = live(conn)
+
+      view
+      |> element(
+        "div[phx-value-slug=\"#{revision_page_one.slug}\"] button[role=\"show_options_modal\"]"
+      )
+      |> render_click()
+
+      view
+      |> form("form#revision-settings-form")
+      |> render_submit(%{
+        "revision" => %{
+          "purpose" => "application",
+          "relates_to" => [revision_page_two.resource_id]
+        }
+      })
+
+      assert Oli.Publishing.AuthoringResolver.from_revision_slug(
+               project.slug,
+               revision_page_one.slug
+             )
+             |> Map.get(:relates_to) == [revision_page_two.resource_id]
+    end
+
+    test "an author can not see the `view revision history` link", %{
+      conn: conn,
+      author: author,
+      project: project
+    } do
+      conn =
+        recycle(conn)
+        |> Pow.Plug.assign_current_user(
+          author,
+          OliWeb.Pow.PowHelpers.get_pow_config(:author)
+        )
+        |> get("/workspaces/course_author/#{project.slug}/curriculum/")
+        |> Map.put(
+          :request_path,
+          "/workspaces/course_author/#{project.slug}/curriculum#show_links"
+        )
+
+      {:ok, view, _html} = live(conn)
+
+      refute render(view) =~ "View revision history"
+    end
+  end
+
+  describe "curriculum live test (as admin)" do
+    setup [:setup_session, :admin_conn]
+
+    test "can see the `view revision history` link if the url has #show_links",
+         %{
+           conn: conn,
+           project: project
+         } do
+      conn =
+        conn
+        |> get("/workspaces/course_author/#{project.slug}/curriculum/")
+        |> Map.put(
+          :request_path,
+          "/workspaces/course_author/#{project.slug}/curriculum#show_links"
+        )
+
+      {:ok, view, _html} = live(conn)
+
+      assert render(view) =~ "View revision history"
+    end
+
+    test "can not see the `view revision history` link if the url does not have #show_links",
+         %{
+           conn: conn,
+           project: project
+         } do
+      conn =
+        conn
+        |> get("/workspaces/course_author/#{project.slug}/curriculum/")
+
+      {:ok, view, _html} = live(conn)
+
+      refute render(view) =~ "View revision history"
+    end
+
+    @tag :skip
+    test "can navigate to all pages view", %{conn: conn, project: project} do
+      conn =
+        conn
+        |> get("/workspaces/course_author/#{project.slug}/curriculum/")
+
+      {:ok, view, _html} = live(conn)
+
+      view
+      |> element("a[role='go_to_all_pages']", "All Pages")
+      |> render_click()
+
+      assert_redirect(
+        view,
+        ~p"/workspaces/course_author/#{project.slug}/pages"
+      )
+    end
+  end
+
+  describe "options modal" do
+    setup [:create_project, :admin_conn]
+
+    test "can be opened for a page", %{
+      conn: conn,
+      project: project,
+      page_2: page_2
+    } do
+      {:ok, view, _html} =
+        live(conn, ~p"/workspaces/course_author/#{project.slug}/curriculum")
+
+      refute view
+             |> has_element?(
+               ~s{div[id='options_modal-container'] h1[id="options_modal-title"]},
+               "Page Options"
+             )
+
+      view
+      |> element(
+        ~s{button[role="show_options_modal"][phx-value-slug="#{page_2.slug}"]},
+        "Options"
+      )
+      |> render_click()
+
+      assert view
+             |> has_element?(
+               ~s{div[id='options_modal-container'] h1[id="options_modal-title"]},
+               "Page Options"
+             )
+    end
+
+    test "can be opened for a container", %{
+      conn: conn,
+      project: project,
+      unit: unit
+    } do
+      {:ok, view, _html} =
+        live(conn, ~p"/workspaces/course_author/#{project.slug}/curriculum")
+
+      refute view
+             |> has_element?(
+               ~s{div[id='options_modal-container'] h1[id="options_modal-title"]},
+               "Container Options"
+             )
+
+      view
+      |> element(
+        ~s{button[role="show_options_modal"][phx-value-slug="#{unit.slug}"]},
+        "Options"
+      )
+      |> render_click()
+
+      assert view
+             |> has_element?(
+               ~s{div[id='options_modal-container'] h1[id="options_modal-title"]},
+               "Container Options"
+             )
+    end
+
+    test "updates a revision data when a `save-options` event is handled after submitting the options modal",
+         %{
+           conn: conn,
+           project: project,
+           page_2: page_2
+         } do
+      {:ok, view, _html} =
+        live(conn, ~p"/workspaces/course_author/#{project.slug}/curriculum")
+
+      assert has_element?(view, "span", "Page 2")
+
+      assert %Oli.Resources.Revision{
+               retake_mode: :normal,
+               assessment_mode: :traditional,
+               duration_minutes: nil,
+               graded: false,
+               max_attempts: 0,
+               purpose: :foundation,
+               scoring_strategy_id: 1,
+               explanation_strategy: nil
+             } =
+               _initial_revision =
+               Oli.Publishing.AuthoringResolver.from_revision_slug(
+                 project.slug,
+                 page_2.slug
+               )
+
+      view
+      |> element(
+        ~s{button[role="show_options_modal"][phx-value-slug="#{page_2.slug}"]},
+        "Options"
+      )
+      |> render_click()
+
+      view
+      |> render_hook("save-options", %{
+        "revision" => %{
+          "duration_minutes" => "5",
+          "explanation_strategy" => %{"type" => "after_max_resource_attempts_exhausted"},
+          "graded" => "true",
+          "max_attempts" => "10",
+          "poster_image" => "some_poster_image_url",
+          "purpose" => "application",
+          "retake_mode" => "targeted",
+          "assessment_mode" => "one_at_a_time",
+          "scoring_strategy_id" => "2",
+          "title" => "New Title!!",
+          "intro_content" =>
+            Jason.encode!(%{
+              "type" => "p",
+              "children" => [
+                %{
+                  "id" => "3477687079",
+                  "type" => "p",
+                  "children" => [%{"text" => "Some new intro content text!"}]
+                }
+              ]
+            })
+        }
+      })
+
+      {path, flash} = assert_redirect(view)
+
+      assert path =~ "/workspaces/course_author/#{project.slug}/curriculum/root_container"
+      assert flash == %{"info" => "Page options saved"}
+
+      {:ok, view, _html} =
+        live(conn, ~p"/workspaces/course_author/#{project.slug}/curriculum")
+
+      assert has_element?(view, "span", "New Title!!")
+
+      assert %Oli.Resources.Revision{
+               retake_mode: :targeted,
+               assessment_mode: :one_at_a_time,
+               duration_minutes: 5,
+               graded: true,
+               max_attempts: 10,
+               purpose: :application,
+               scoring_strategy_id: 2,
+               explanation_strategy: %Oli.Resources.ExplanationStrategy{
+                 type: :after_max_resource_attempts_exhausted,
+                 set_num_attempts: nil
+               },
+               poster_image: "some_poster_image_url",
+               intro_content: %{
+                 "children" => [
+                   %{
+                     "children" => [%{"text" => "Some new intro content text!"}],
+                     "id" => "3477687079",
+                     "type" => "p"
+                   }
+                 ],
+                 "type" => "p"
+               }
+             } =
+               _updated_revision =
+               Oli.Publishing.AuthoringResolver.from_revision_slug(
+                 project.slug,
+                 page_2.slug
+               )
+    end
+
+    test "updates a revision data when a `save-options` event is handled after submitting the options modal with no intro content defined (when submitting a page, for instance)",
+         %{
+           conn: conn,
+           project: project,
+           page_2: page_2
+         } do
+      {:ok, view, _html} =
+        live(conn, ~p"/workspaces/course_author/#{project.slug}/curriculum")
+
+      assert has_element?(view, "span", "Page 2")
+
+      assert %Oli.Resources.Revision{
+               retake_mode: :normal,
+               assessment_mode: :traditional,
+               duration_minutes: nil,
+               graded: false,
+               max_attempts: 0,
+               purpose: :foundation,
+               scoring_strategy_id: 1,
+               explanation_strategy: nil
+             } =
+               _initial_revision =
+               Oli.Publishing.AuthoringResolver.from_revision_slug(
+                 project.slug,
+                 page_2.slug
+               )
+
+      view
+      |> element(
+        ~s{button[role="show_options_modal"][phx-value-slug="#{page_2.slug}"]},
+        "Options"
+      )
+      |> render_click()
+
+      view
+      |> render_hook("save-options", %{
+        "revision" => %{
+          "duration_minutes" => "5",
+          "explanation_strategy" => %{"type" => "after_max_resource_attempts_exhausted"},
+          "graded" => "true",
+          "max_attempts" => "10",
+          "poster_image" => "some_poster_image_url",
+          "purpose" => "application",
+          "retake_mode" => "targeted",
+          "assessment_mode" => "one_at_a_time",
+          "scoring_strategy_id" => "2",
+          "title" => "New Title!!"
+        }
+      })
+
+      {path, flash} = assert_redirect(view)
+
+      assert path =~ "/workspaces/course_author/#{project.slug}/curriculum/root_container"
+      assert flash == %{"info" => "Page options saved"}
+
+      {:ok, view, _html} =
+        live(conn, ~p"/workspaces/course_author/#{project.slug}/curriculum")
+
+      assert has_element?(view, "span", "New Title!!")
+
+      assert %Oli.Resources.Revision{
+               retake_mode: :targeted,
+               assessment_mode: :one_at_a_time,
+               duration_minutes: 5,
+               graded: true,
+               max_attempts: 10,
+               purpose: :application,
+               scoring_strategy_id: 2,
+               explanation_strategy: %Oli.Resources.ExplanationStrategy{
+                 type: :after_max_resource_attempts_exhausted,
+                 set_num_attempts: nil
+               },
+               poster_image: "some_poster_image_url"
+             } =
+               _updated_revision =
+               Oli.Publishing.AuthoringResolver.from_revision_slug(
+                 project.slug,
+                 page_2.slug
+               )
+    end
+  end
+
+  describe "Delete page" do
+    setup [:admin_conn]
+
+    test "renders deletion restriction message and lists linking resources", %{conn: conn} do
+      author = insert(:author)
+
+      project = insert(:project, authors: [author])
+
+      page_1_revision =
+        insert(:revision, %{
+          slug: "page_1",
+          title: "Page 1",
+          resource_type_id: ResourceType.id_for_page(),
+          author_id: author.id
+        })
+
+      page_2_revision =
+        insert(:revision, %{
+          slug: "page_2",
+          title: "Page 2",
+          resource_type_id: ResourceType.id_for_page(),
+          author_id: author.id
+        })
+
+      page_3_revision =
+        insert(:revision, %{
+          slug: "page_3",
+          title: "Page 3",
+          resource_type_id: ResourceType.id_for_page(),
+          author_id: author.id
+        })
+
+      container_revision =
+        insert(:revision, %{
+          objectives: %{},
+          resource_type_id: ResourceType.id_for_container(),
+          children: [
+            page_1_revision.resource_id,
+            page_2_revision.resource_id,
+            page_3_revision.resource_id
+          ],
+          content: %{},
+          slug: "root_container",
+          title: "Root Container",
+          author_id: author.id
+        })
+
+      all_revisions = [page_1_revision, page_2_revision, page_3_revision, container_revision]
+
+      # asociate resources to project
+      Enum.each(all_revisions, fn revision ->
+        insert(:project_resource, %{project_id: project.id, resource_id: revision.resource_id})
+      end)
+
+      # publish project
+      publication =
+        insert(:publication, %{
+          project: project,
+          root_resource_id: container_revision.resource_id,
+          published: nil
+        })
+
+      # publish resources
+      Enum.each(all_revisions, fn revision ->
+        insert(:published_resource, %{
+          publication: publication,
+          resource: revision.resource,
+          revision: revision,
+          author: author
+        })
+      end)
+
+      # Replace content to have a hyperlink pointing to page 3
+      Oli.Resources.update_revision(page_1_revision, %{
+        content: create_hyperlink_content("page_3")
+      })
+
+      # Replace content to have a page link pointing to page 3
+      Oli.Resources.update_revision(page_2_revision, %{
+        content: create_page_link_content(page_3_revision.resource_id)
+      })
+
+      {:ok, view, _html} = live(conn, ~p"/workspaces/course_author/#{project.slug}/curriculum")
+
+      render_click(view, "show_delete_modal", %{"slug" => "#{page_3_revision.slug}"})
+
+      # Extract titles and hyperlinks all in one list
+      results =
+        view
+        |> element("#not_empty_#{page_3_revision.slug}")
+        |> render()
+        |> Floki.parse_document!()
+        |> Floki.find("li")
+        |> Enum.reduce([], fn a_tag, acc ->
+          href = Floki.find(a_tag, "a") |> Floki.attribute("href") |> List.first()
+          text = Floki.text(a_tag)
+          [text, href | acc]
+        end)
+
+      assert Enum.any?(results, fn result -> result =~ page_1_revision.title end)
+      assert Enum.any?(results, fn result -> result =~ page_2_revision.title end)
+      assert Enum.any?(results, fn result -> result =~ page_1_revision.slug end)
+      assert Enum.any?(results, fn result -> result =~ page_2_revision.slug end)
+    end
+  end
+
+  defp setup_session(%{conn: conn}) do
+    map =
+      Seeder.base_project_with_resource2()
+      |> Seeder.add_adaptive_page()
+
+    conn =
+      Plug.Test.init_test_session(conn, lti_session: nil)
+      |> Pow.Plug.assign_current_user(
+        map.author,
+        OliWeb.Pow.PowHelpers.get_pow_config(:author)
+      )
+
+    {:ok,
+     conn: conn,
+     map: map,
+     author: map.author,
+     project: map.project,
+     adaptive_page_revision: map.adaptive_page_revision,
+     revision1: map.revision1,
+     revision2: map.revision2,
+     container: map.container.revision}
+  end
+
+  defp create_project(_) do
+    author = insert(:author)
+
+    project = insert(:project, authors: [author])
+
+    page_revision =
+      insert(:revision, %{
+        objectives: %{"attached" => []},
+        scoring_strategy_id: Oli.Resources.ScoringStrategy.get_id_by_type("average"),
+        resource_type_id: Oli.Resources.ResourceType.id_for_page(),
+        children: [],
+        content: %{"model" => []},
+        deleted: false,
+        title: "Page 1",
+        author_id: author.id
+      })
+
+    page_2_revision =
+      insert(:revision, %{
+        objectives: %{"attached" => []},
+        scoring_strategy_id: Oli.Resources.ScoringStrategy.get_id_by_type("average"),
+        resource_type_id: Oli.Resources.ResourceType.id_for_page(),
+        children: [],
+        content: %{"model" => []},
+        deleted: false,
+        title: "Page 2",
+        author_id: author.id
+      })
+
+    unit_revision =
+      insert(:revision, %{
+        objectives: %{},
+        resource_type_id: Oli.Resources.ResourceType.id_for_container(),
+        children: [page_revision.resource_id],
+        content: %{"model" => []},
+        deleted: false,
+        title: "The first unit",
+        slug: "first_unit",
+        author_id: author.id
+      })
+
+    container_revision =
+      insert(:revision, %{
+        objectives: %{},
+        resource_type_id: Oli.Resources.ResourceType.id_for_container(),
+        children: [unit_revision.resource_id, page_2_revision.resource_id],
+        content: %{},
+        deleted: false,
+        slug: "root_container",
+        title: "Root Container",
+        author_id: author.id
+      })
+
+    all_revisions =
+      [
+        page_revision,
+        page_2_revision,
+        unit_revision,
+        container_revision
+      ]
+
+    # asociate resources to project
+    Enum.each(all_revisions, fn revision ->
+      insert(:project_resource, %{
+        project_id: project.id,
+        resource_id: revision.resource_id
+      })
+    end)
+
+    # publish project
+    publication =
+      insert(:publication, %{
+        project: project,
+        root_resource_id: container_revision.resource_id,
+        published: nil
+      })
+
+    # publish resources
+    Enum.each(all_revisions, fn revision ->
+      insert(:published_resource, %{
+        publication: publication,
+        resource: revision.resource,
+        revision: revision,
+        author: author
+      })
+    end)
+
+    %{
+      publication: publication,
+      project: project,
+      unit: unit_revision,
+      page: page_revision,
+      page_2: page_2_revision
+    }
+  end
+
+  defp live_view_route(project_slug, container_slug \\ nil, params \\ %{}) do
+    if container_slug do
+      ~p"/workspaces/course_author/#{project_slug}/curriculum/#{container_slug}?#{params}"
+    else
+      ~p"/workspaces/course_author/#{project_slug}/curriculum?#{params}"
+    end
+  end
+end


### PR DESCRIPTION
Migrate authoring Curriculum LiveView to new workspace layout.

See: https://eliterate.atlassian.net/browse/MER-3597


https://github.com/user-attachments/assets/0864d97c-9ff7-4bfe-a1f2-82f05894a81e

