### PR TITLE
[BUG FIX] [MER-3716] Ensure same promise is used for all MathJax typesetting

### DIFF
--- a/assets/src/hooks/evaluate_mathjax_expressions.ts
+++ b/assets/src/hooks/evaluate_mathjax_expressions.ts
@@ -5,6 +5,27 @@ export const EvaluateMathJaxExpressions = {
   mounted() {
     const elements = document.querySelectorAll('.formula');
 
-    window.MathJax.typesetPromise(Array.from(elements) as HTMLElement[]);
+    const getGlobalLastPromise = () => {
+      /* istanbul ignore next */
+      let lastPromise = window?.MathJax?.startup?.promise;
+      /* istanbul ignore next */
+      if (!lastPromise) {
+        console.info('NO LAST PROMISE');
+        typeof jest === 'undefined' &&
+          console.warn(
+            'Load the MathJax script before this one or unpredictable rendering might occur.',
+          );
+        lastPromise = Promise.resolve();
+      }
+      return lastPromise;
+    };
+
+    const setGlobalLastPromise = (promise: Promise<any>) => {
+      window.MathJax.startup.promise = promise;
+    };
+
+    let lastPromise = getGlobalLastPromise();
+    lastPromise = lastPromise.then(() => window.MathJax.typesetPromise(Array.from(elements) as HTMLElement[]));
+    setGlobalLastPromise(lastPromise);
   },
 };

--- a/assets/src/hooks/evaluate_mathjax_expressions.ts
+++ b/assets/src/hooks/evaluate_mathjax_expressions.ts
@@ -25,7 +25,9 @@ export const EvaluateMathJaxExpressions = {
     };
 
     let lastPromise = getGlobalLastPromise();
-    lastPromise = lastPromise.then(() => window.MathJax.typesetPromise(Array.from(elements) as HTMLElement[]));
+    lastPromise = lastPromise.then(() =>
+      window.MathJax.typesetPromise(Array.from(elements) as HTMLElement[]),
+    );
     setGlobalLastPromise(lastPromise);
   },
 };

--- a/assets/src/hooks/evaluate_mathjax_expressions.ts
+++ b/assets/src/hooks/evaluate_mathjax_expressions.ts
@@ -3,7 +3,7 @@
 
 export const EvaluateMathJaxExpressions = {
   mounted() {
-    const elements = document.querySelectorAll('.formula');
+    const elements = document.querySelectorAll('.formula, .formula-inline');
 
     const getGlobalLastPromise = () => {
       /* istanbul ignore next */


### PR DESCRIPTION
28.6 hotfix added a new spot of MathJAX typesetting, but didn't honor the requirement that the same global promise is used (as was fixed in https://eliterate.atlassian.net/browse/MER-1782?atlOrigin=eyJpIjoiYjdlOGFmMDhhYTRhNGNlMzk4MjMxZTNmY2E5YTAzNzQiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

This PR applies the same logic in this new phoenix liveview hook