### PR TITLE
[ENHANCEMENT] [MER-3597] Curriculum workspace migration links backwards compatibility

### DIFF
--- a/lib/oli_web/common/links.ex
+++ b/lib/oli_web/common/links.ex
@@ -2,7 +2,6 @@ defmodule OliWeb.Common.Links do
   use Phoenix.HTML
   alias OliWeb.Router.Helpers, as: Routes
   alias Oli.Resources.Numbering
-  alias OliWeb.Workspaces.CourseAuthor.CurriculumLive
 
   @doc """
   Returns a path uri for a given revision. If the revision type is not
@@ -40,7 +39,12 @@ defmodule OliWeb.Common.Links do
         end
 
       "container" ->
-        Routes.live_path(OliWeb.Endpoint, CurriculumLive, project_slug, revision.slug)
+        Routes.container_path(
+          OliWeb.Endpoint,
+          :index,
+          project_slug,
+          revision.slug
+        )
 
       "tag" ->
         Routes.activity_bank_path(

--- a/lib/oli_web/live/workspaces/course_author/curriculum/entry.ex
+++ b/lib/oli_web/live/workspaces/course_author/curriculum/entry.ex
@@ -1,4 +1,4 @@
-defmodule OliWeb.Curriculum.Entry do
+defmodule OliWeb.Workspaces.CourseAuthor.Curriculum.Entry do
   @moduledoc """
   Curriculum item entry component.
   """
@@ -7,8 +7,7 @@ defmodule OliWeb.Curriculum.Entry do
   import OliWeb.Curriculum.Utils
 
   alias OliWeb.Curriculum.{Actions, Details, LearningSummary}
-  alias OliWeb.Router.Helpers, as: Routes
-  alias OliWeb.Common.Links
+  alias Oli.Resources.Numbering
 
   attr(:ctx, :map, required: true)
   attr(:child, :map, required: true)
@@ -48,19 +47,12 @@ defmodule OliWeb.Curriculum.Entry do
         <div class="flex-1">
           <%= entry_icon(assigns) %>
           <%= if Oli.Resources.ResourceType.get_type_by_id(@child.resource_type_id) == "container" do %>
-            <%= Links.resource_link(@child, [], @project, @numberings, "ml-1 mr-1 entry-title") %>
+            <%= container_link(@child, @project, @numberings, "ml-1 mr-1 entry-title") %>
           <% else %>
             <span class="ml-1 mr-1 entry-title"><%= @child.title %></span>
             <.link
               class="entry-title mx-3"
-              href={
-                Routes.resource_path(
-                  OliWeb.Endpoint,
-                  :edit,
-                  @project.slug,
-                  @child.slug
-                )
-              }
+              href={~p"/workspaces/course_author/#{@project.slug}/curriculum/#{@child.slug}"}
             >
               Edit Page
             </.link>
@@ -113,5 +105,19 @@ defmodule OliWeb.Curriculum.Entry do
         """
       end
     end
+  end
+
+  defp container_link(revision, project, numberings, class) do
+    path = ~p"/workspaces/course_author/#{project.slug}/curriculum/#{revision.slug}"
+    numbering = Map.get(numberings, revision.id)
+
+    title =
+      if numbering do
+        Numbering.prefix(numbering) <> ": " <> revision.title
+      else
+        revision.title
+      end
+
+    link(title, to: path, class: class)
   end
 end

--- a/lib/oli_web/live/workspaces/course_author/curriculum_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/curriculum_live.ex
@@ -12,12 +12,13 @@ defmodule OliWeb.Workspaces.CourseAuthor.CurriculumLive do
     Rollup,
     ActivityDelta,
     DropTarget,
-    Entry,
     OptionsModalContent,
     DeleteModal,
     NotEmptyModal,
     HyperlinkDependencyModal
   }
+
+  alias OliWeb.Workspaces.CourseAuthor.Curriculum.Entry
 
   alias OliWeb.Common.Hierarchy.MoveModal
   alias Oli.Publishing.ChangeTracker


### PR DESCRIPTION
Ensure that when accessing curriculum links to sections from the old-style view, we link to the old-style section/containers and not the ones in the course author workspace

See: https://eliterate.atlassian.net/browse/MER-3597