### PR TITLE
[PERFORMANCE] [MER-3709] Streamline course section update application

### DIFF
--- a/lib/oli/delivery/previous_next_index.ex
+++ b/lib/oli/delivery/previous_next_index.ex
@@ -3,6 +3,7 @@ defmodule Oli.Delivery.PreviousNextIndex do
   alias Oli.Delivery.Sections
   alias Oli.Publishing.DeliveryResolver
   alias Oli.Delivery.Hierarchy
+  alias Oli.Resources.Numbering
   alias Oli.Repo
 
   @doc """
@@ -127,8 +128,10 @@ defmodule Oli.Delivery.PreviousNextIndex do
   """
   def rebuild(%Section{slug: slug} = section) do
     case Repo.transaction(fn _ ->
-           DeliveryResolver.full_hierarchy(slug)
-           |> Hierarchy.build_navigation_link_map()
+           {new_hierarchy, _} = DeliveryResolver.full_hierarchy(slug)
+           |> Numbering.renumber_hierarchy()
+
+           Hierarchy.build_navigation_link_map(new_hierarchy)
            |> then(fn previous_next_index ->
              Sections.update_section(section, %{previous_next_index: previous_next_index})
            end)

--- a/lib/oli/delivery/previous_next_index.ex
+++ b/lib/oli/delivery/previous_next_index.ex
@@ -128,8 +128,9 @@ defmodule Oli.Delivery.PreviousNextIndex do
   """
   def rebuild(%Section{slug: slug} = section) do
     case Repo.transaction(fn _ ->
-           {new_hierarchy, _} = DeliveryResolver.full_hierarchy(slug)
-           |> Numbering.renumber_hierarchy()
+           {new_hierarchy, _} =
+             DeliveryResolver.full_hierarchy(slug)
+             |> Numbering.renumber_hierarchy()
 
            Hierarchy.build_navigation_link_map(new_hierarchy)
            |> then(fn previous_next_index ->

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -1237,7 +1237,7 @@ defmodule Oli.Delivery.Sections do
   # determine and return the list of page resource ids that are not reachable from that
   # hierarchy, taking into account links from pages to other pages and the 'relates_to'
   # relationship between pages.
-  defp determine_unreachable_pages(publication_ids, hierarchy_ids) do
+  def determine_unreachable_pages(publication_ids, hierarchy_ids) do
     # Start with all pages
     unreachable =
       Oli.Publishing.all_page_resource_ids(publication_ids)

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -3655,7 +3655,7 @@ defmodule Oli.Delivery.Sections do
   # For a given section resource, clean the children attribute to ensure that:
   # 1. Any nil records are removed
   # 2. All non-nil sr id references map to a non-deleted revision in the new pub
-  defp clean_children(section_resource, sr_id_to_resource_id, new_published_resources_map) do
+  def clean_children(section_resource, sr_id_to_resource_id, new_published_resources_map) do
     updated_children =
       section_resource.children
       |> Enum.filter(fn child_id -> !is_nil(child_id) end)

--- a/lib/oli/delivery/sections/updates.ex
+++ b/lib/oli/delivery/sections/updates.ex
@@ -1,0 +1,328 @@
+defmodule Oli.Delivery.Sections.Updates do
+
+  require Logger
+  import Ecto.Query, warn: false
+
+  alias Oli.Delivery.Sections.MinimalHierarchy
+  alias Oli.Repo
+  alias Oli.Delivery.Sections
+  alias Oli.Publishing
+  alias Oli.Resources.ResourceType
+  alias Oli.Publishing.Publications.PublicationDiff
+  alias Oli.Delivery.Updates.Broadcaster
+  alias Oli.Delivery.Sections.PostProcessing
+  alias Oli.Delivery.Sections.{
+    Section,
+    SectionResource,
+  }
+
+  @section_resources_on_conflict {:replace_all_except,
+    [
+      :inserted_at,
+      :scoring_strategy_id,
+      :scheduling_type,
+      :manually_scheduled,
+      :start_date,
+      :end_date,
+      :collab_space_config,
+      :explanation_strategy,
+      :max_attempts,
+      :retake_mode,
+      :assessment_mode,
+      :password,
+      :late_submit,
+      :late_start,
+      :time_limit,
+      :grace_period,
+      :review_submission,
+      :feedback_mode,
+      :feedback_scheduled_date
+    ]
+  }
+
+  @doc """
+  Gracefully applies the specified publication update to a given section by leaving the existing
+  curriculum and section modifications in-tact while applying the structural changes that
+  occurred between the old and new publication.
+
+  This implementation makes the assumption that a resource_id is unique within a curriculum.
+  That is, a resource can only allowed to be added once in a single location within a curriculum.
+  This makes it simpler to apply changes to the existing curriculum but if necessary, this implementation
+  could be extended to not just apply the changes to the first node found that contains the changed resource,
+  but any/all nodes in the hierarchy which reference the changed resource.
+  """
+  def apply_publication_update(
+        %Section{id: section_id} = section,
+        publication_id
+      ) do
+
+    Broadcaster.broadcast_update_progress(section.id, publication_id, 0)
+
+    new_publication = Publishing.get_publication!(publication_id)
+    project = Oli.Repo.get(Oli.Authoring.Course.Project, new_publication.project_id)
+    current_publication = Sections.get_current_publication(section_id, project.id)
+
+    result = Oli.Repo.transaction(fn ->
+      case do_update(section, project.id, current_publication, new_publication) do
+        {:ok, _} ->
+          do_post_processing_steps(section, project)
+        e ->
+          Oli.Repo.rollback(e)
+      end
+    end)
+
+    case result do
+      {:ok, _} ->
+        Broadcaster.broadcast_update_progress(section.id, new_publication.id, :complete)
+      _ ->
+        Broadcaster.broadcast_update_progress(section.id, new_publication.id, 0)
+    end
+
+    result
+  end
+
+  defp do_post_processing_steps(section, project) do
+    # For a section based on this project, update the has_experiments in the section to match that
+    # setting in the project.
+    if section.base_project_id == project.id and
+          project.has_experiments != section.has_experiments do
+      Oli.Delivery.Sections.update_section(section, %{has_experiments: project.has_experiments})
+    end
+
+    PostProcessing.apply(section, :all)
+
+    Oli.Delivery.maybe_update_section_contains_explorations(section)
+    Oli.Delivery.maybe_update_section_contains_deliberate_practice(section)
+  end
+
+  defp do_update(section, project_id, current_publication, new_publication) do
+
+    case Publishing.get_publication_diff(current_publication, new_publication) do
+      %PublicationDiff{classification: :minor} = diff ->
+        do_minor_update(diff, section, project_id, new_publication)
+
+      %PublicationDiff{classification: :major} = diff ->
+        cond do
+          # Case 1: The course section is based on this project, but is not a product and is not seeded from a product
+          section.base_project_id == project_id and section.type == :enrollable and is_nil(section.blueprint_id) ->
+            do_major_update(diff, section, project_id, current_publication, new_publication)
+
+          # Case 2: The course section is based on this project and was seeded from a product
+          section.base_project_id == project_id and !is_nil(section.blueprint_id) ->
+            if section.blueprint.apply_major_updates do
+              do_major_update(diff, section, project_id, current_publication, new_publication)
+            else
+              do_minor_update(diff, section, project_id, new_publication)
+            end
+
+          # Case 3: The course section is a product based on this project
+          section.base_project_id == project_id and section.type == :blueprint ->
+            do_minor_update(diff, section, project_id, new_publication)
+
+          # Case 4: The course section is not based on this project (but it remixes some materials from project)
+          true ->
+            do_minor_update(diff, section, project_id, new_publication)
+        end
+    end
+  end
+
+  defp do_minor_update(%PublicationDiff{} = diff, section, project_id, new_publication) do
+
+    mark = Oli.Timing.mark()
+
+    diff
+    |> filter_for_revisions(:added)
+    |> bulk_create_section_resources(section, project_id)
+
+    diff
+    |> filter_for_revisions(:deleted)
+    |> bulk_delete_section_resources(section)
+
+    Sections.update_section_project_publication(section, project_id, new_publication.id)
+
+    Logger.info(
+      "perform_update.MINOR: section[#{section.slug}] #{Oli.Timing.elapsed(mark) / 1000 / 1000}ms"
+    )
+
+  end
+
+  defp filter_for_revisions(%PublicationDiff{} = diff, desired_type) do
+    Map.filter(diff.changes, fn {_k, {this_type, _}} -> this_type == desired_type end)
+    |> Map.values()
+    |> Enum.map(fn {_, {_, %{revision: r}}} -> r end)
+  end
+
+  defp bulk_create_section_resources(revisions, section, project_id) do
+
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    placeholders = %{timestamp: now}
+
+    section_resource_rows = Enum.map(revisions, fn r ->
+      %{
+        resource_id: r.resource_id,
+        project_id: project_id,
+        section_id: section.id,
+        children: nil,
+        scoring_strategy_id: r.scoring_strategy_id,
+        slug: Oli.Utils.Slug.generate("section_resources", r.title),
+        inserted_at: {:placeholder, :timestamp},
+        updated_at: {:placeholder, :timestamp}
+      }
+    end)
+
+    Oli.Utils.Database.batch_insert_all(SectionResource, section_resource_rows,
+      placeholders: placeholders,
+      on_conflict: @section_resources_on_conflict,
+      conflict_target: [:section_id, :resource_id]
+    )
+  end
+
+  defp bulk_delete_section_resources(revisions, %Section{id: section_id}) do
+    resource_ids = Enum.map(revisions, & &1.resource_id)
+
+    from(sr in SectionResource,
+      where: sr.section_id == ^section_id and sr.resource_id in ^resource_ids
+    )
+    |> Repo.delete_all()
+  end
+
+  defp do_major_update(%PublicationDiff{} = diff, section, project_id, prev_publication, new_publication) do
+
+    mark = Oli.Timing.mark()
+
+    with {:ok, _} <- do_minor_update(diff, section, project_id, new_publication),
+      {:ok, _} <- update_container_children(section, prev_publication, new_publication),
+      {:ok, _} <- Oli.Delivery.PreviousNextIndex.rebuild(section),
+      {:ok, _} <- Sections.rebuild_contained_pages(section),
+      {:ok, _} <- Sections.rebuild_contained_objectives(section) do
+        Logger.info(
+          "perform_update.MAJOR: section[#{section.slug}] #{Oli.Timing.elapsed(mark) / 1000 / 1000}ms"
+        )
+      {:ok, :ok}
+    else
+      e -> e
+    end
+
+  end
+
+  defp update_container_children(section, prev_publication, new_publication) do
+    container = ResourceType.id_for_container()
+
+    prev_published_resources_map =
+      MinimalHierarchy.published_resources_map(prev_publication.id)
+
+    new_published_resources_map =
+      MinimalHierarchy.published_resources_map(new_publication.id)
+
+    # get all section resources including freshly minted ones
+    section_resources = Sections.get_section_resources(section.id)
+
+    # build mappings from section_resource_id to resource_id and the inverse
+    {sr_id_to_resource_id, resource_id_to_sr_id} =
+      section_resources
+      |> Enum.reduce({%{}, %{}}, fn %SectionResource{id: id, resource_id: resource_id},
+                                    {sr_id_to_resource_id, resource_id_to_sr_id} ->
+        {Map.put(sr_id_to_resource_id, id, resource_id),
+          Map.put(resource_id_to_sr_id, resource_id, id)}
+      end)
+
+    # For all container section resources in the course project whose children attribute differs
+    # from the new publication’s container children, execute the three way merge algorithm
+    merged_section_resources =
+      section_resources
+      |> Enum.map(fn section_resource ->
+        %SectionResource{
+          resource_id: resource_id,
+          children: current_children
+        } = section_resource
+
+        prev_published_resource = prev_published_resources_map[resource_id]
+
+        is_container? =
+          case prev_published_resource do
+            %{resource_type_id: ^container} ->
+              true
+
+            _ ->
+              false
+          end
+
+        if is_container? or is_nil(current_children) do
+          new_published_resource = new_published_resources_map[resource_id]
+          new_children = new_published_resource.children
+
+          updated_section_resource =
+            case current_children do
+              nil ->
+                # this section resource was just created so it can assume the newly published value
+                %SectionResource{
+                  section_resource
+                  | children: Enum.map(new_children, &resource_id_to_sr_id[&1])
+                }
+
+              current_children ->
+                # ensure we are comparing resource_ids to resource_ids (and not section_resource_ids)
+                # by translating the current section_resource children ids to resource_ids
+                current_children_resource_ids =
+                  Enum.map(current_children, &sr_id_to_resource_id[&1])
+
+                # check if the children resource_ids have diverged from the new value
+                if current_children_resource_ids != new_children do
+                  # There is a merge conflict between the current section resource and the new published resource.
+                  # Use the AIRRO three way merge algorithm to resolve
+                  base = prev_published_resource.children
+                  source = new_published_resource.children
+                  target = current_children_resource_ids
+
+                  case Oli.Publishing.Updating.Merge.merge(base, source, target) do
+                    {:ok, merged} ->
+                      %SectionResource{
+                        section_resource
+                        | children: Enum.map(merged, &resource_id_to_sr_id[&1])
+                      }
+
+                    {:no_change} ->
+                      section_resource
+                  end
+                else
+                  section_resource
+                end
+            end
+
+          Sections.clean_children(
+            updated_section_resource,
+            sr_id_to_resource_id,
+            new_published_resources_map
+          )
+        else
+          section_resource
+        end
+      end)
+
+    # Upsert all merged section resource records. Some of these records may have just been created
+    # and some may not have been changed, but that's okay we will just update them again. There
+    # isn't a lot of them as these are just the container resources.
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    placeholders = %{timestamp: now}
+
+    section_resource_rows =
+      merged_section_resources
+      |> Enum.map(fn section_resource ->
+        %{
+          SectionResource.to_map(section_resource)
+          | updated_at: {:placeholder, :timestamp}
+        }
+      end)
+
+    expected_count = Enum.count(section_resource_rows)
+
+    case Oli.Utils.Database.batch_insert_all(SectionResource, section_resource_rows,
+      placeholders: placeholders,
+      on_conflict: @section_resources_on_conflict,
+      conflict_target: [:section_id, :resource_id]) do
+      {^expected_count, _} -> {:ok, expected_count}
+      _ -> {:error, :unexpected_count}
+    end
+  end
+
+end

--- a/lib/oli/delivery/updates/worker.ex
+++ b/lib/oli/delivery/updates/worker.ex
@@ -4,7 +4,7 @@ defmodule Oli.Delivery.Updates.Worker do
   """
   use Oban.Worker, queue: :updates, max_attempts: 3
 
-  alias Oli.Delivery.Sections
+  alias Oli.Delivery.Sections.Updates
 
   @impl Oban.Worker
   def perform(%Oban.Job{
@@ -14,9 +14,9 @@ defmodule Oli.Delivery.Updates.Worker do
   end
 
   def perform_now(section_slug, publication_id) do
-    section = Sections.get_section_by_slug(section_slug)
+    section = Oli.Delivery.Sections.get_section_by_slug(section_slug)
 
-    Sections.apply_publication_update(
+    Updates.apply_publication_update(
       section,
       publication_id
     )

--- a/test/oli/sections_test.exs
+++ b/test/oli/sections_test.exs
@@ -859,7 +859,7 @@ defmodule Oli.SectionsTest do
       # verify the curriculum precondition
       hierarchy = DeliveryResolver.full_hierarchy(section.slug)
       original_flattened = Oli.Delivery.Hierarchy.flatten(hierarchy)
-      IO.inspect hierarchy
+
       assert hierarchy.children |> Enum.count() == 2
       assert hierarchy.children |> Enum.at(0) |> Map.get(:resource_id) == page1.id
       assert hierarchy.children |> Enum.at(1) |> Map.get(:resource_id) == page2.id
@@ -941,13 +941,8 @@ defmodule Oli.SectionsTest do
 
       # reload latest hierarchy
       hierarchy = DeliveryResolver.full_hierarchy(section.slug)
-      IO.inspect hierarchy
 
       updated_flattened = Oli.Delivery.Hierarchy.flatten(hierarchy)
-
-      IO.inspect Enum.count(original_flattened)
-      IO.inspect Enum.count(updated_flattened)
-
 
       # verify non-structural changes are applied as expected
       assert hierarchy.children |> Enum.at(0) |> then(& &1.revision.content) ==
@@ -1731,8 +1726,8 @@ defmodule Oli.SectionsTest do
         )
 
       # remove page 2
-      #_deleted_revision =
-       # Seeder.delete_page(page2, revision2, container_resource, container_revision, working_pub)
+      _deleted_revision =
+        Seeder.delete_page(page2, revision2, container_resource, container_revision, working_pub)
 
       # publish changes
       {:ok, latest_publication} = Publishing.publish_project(project, "some changes", author.id)

--- a/test/oli/sections_test.exs
+++ b/test/oli/sections_test.exs
@@ -858,7 +858,8 @@ defmodule Oli.SectionsTest do
 
       # verify the curriculum precondition
       hierarchy = DeliveryResolver.full_hierarchy(section.slug)
-
+      original_flattened = Oli.Delivery.Hierarchy.flatten(hierarchy)
+      IO.inspect hierarchy
       assert hierarchy.children |> Enum.count() == 2
       assert hierarchy.children |> Enum.at(0) |> Map.get(:resource_id) == page1.id
       assert hierarchy.children |> Enum.at(1) |> Map.get(:resource_id) == page2.id
@@ -928,7 +929,7 @@ defmodule Oli.SectionsTest do
           working_pub
         )
 
-      # remove page 2
+      # remove page
       _deleted_revision =
         Seeder.delete_page(page2, revision2, container_resource, container_revision, working_pub)
 
@@ -940,13 +941,19 @@ defmodule Oli.SectionsTest do
 
       # reload latest hierarchy
       hierarchy = DeliveryResolver.full_hierarchy(section.slug)
+      IO.inspect hierarchy
+
+      updated_flattened = Oli.Delivery.Hierarchy.flatten(hierarchy)
+
+      IO.inspect Enum.count(original_flattened)
+      IO.inspect Enum.count(updated_flattened)
+
 
       # verify non-structural changes are applied as expected
       assert hierarchy.children |> Enum.at(0) |> then(& &1.revision.content) ==
                page1_changes["content"]
 
       # verify the updated curriculum structure matches the expected result
-
       assert hierarchy.children |> Enum.count() == 4
       assert hierarchy.children |> Enum.at(0) |> Map.get(:resource_id) == page1.id
       assert hierarchy.children |> Enum.at(1) |> Map.get(:resource_id) == p1_new_page1.id
@@ -979,6 +986,8 @@ defmodule Oli.SectionsTest do
 
       # there is only seven since one of the pages is unreachable
       assert section_resources |> Enum.count() == 7
+
+
     end
 
     @tag capture_log: true
@@ -1513,8 +1522,8 @@ defmodule Oli.SectionsTest do
       hierarchy = DeliveryResolver.full_hierarchy(section.slug)
 
       # verify non-structural changes are applied as expected
-      #assert hierarchy.children |> Enum.at(0) |> then(& &1.revision.content) ==
-      #        page1_changes["content"]
+      assert hierarchy.children |> Enum.at(0) |> then(& &1.revision.content) ==
+               page1_changes["content"]
 
       # verify the updated curriculum structure matches the expected result
 
@@ -1722,8 +1731,8 @@ defmodule Oli.SectionsTest do
         )
 
       # remove page 2
-      _deleted_revision =
-        Seeder.delete_page(page2, revision2, container_resource, container_revision, working_pub)
+      #_deleted_revision =
+       # Seeder.delete_page(page2, revision2, container_resource, container_revision, working_pub)
 
       # publish changes
       {:ok, latest_publication} = Publishing.publish_project(project, "some changes", author.id)

--- a/test/oli/sections_test.exs
+++ b/test/oli/sections_test.exs
@@ -981,8 +981,6 @@ defmodule Oli.SectionsTest do
 
       # there is only seven since one of the pages is unreachable
       assert section_resources |> Enum.count() == 7
-
-
     end
 
     @tag capture_log: true

--- a/test/oli/sections_test.exs
+++ b/test/oli/sections_test.exs
@@ -936,7 +936,7 @@ defmodule Oli.SectionsTest do
       {:ok, latest_publication} = Publishing.publish_project(project, "some changes", author.id)
 
       # apply the new publication update to the section
-      Sections.apply_publication_update(section, latest_publication.id)
+      Oli.Delivery.Sections.Updates.apply_publication_update(section, latest_publication.id)
 
       # reload latest hierarchy
       hierarchy = DeliveryResolver.full_hierarchy(section.slug)
@@ -1087,7 +1087,7 @@ defmodule Oli.SectionsTest do
       assert latest_publication.minor == 1
 
       # apply the new publication update to the section
-      Sections.apply_publication_update(section, latest_publication.id)
+      Oli.Delivery.Sections.Updates.apply_publication_update(section, latest_publication.id)
 
       # reload latest hierarchy
       hierarchy = DeliveryResolver.full_hierarchy(section.slug)
@@ -1257,7 +1257,7 @@ defmodule Oli.SectionsTest do
       {:ok, latest_publication} = Publishing.publish_project(project, "some changes", author.id)
 
       # apply the new publication update to the product
-      Sections.apply_publication_update(product, latest_publication.id)
+      Oli.Delivery.Sections.Updates.apply_publication_update(product, latest_publication.id)
 
       # reload latest hierarchy
       product_hierarchy = DeliveryResolver.full_hierarchy(product.slug)
@@ -1284,7 +1284,7 @@ defmodule Oli.SectionsTest do
       assert product_section_resources |> Enum.count() == 3
 
       # apply the new publication update to the section
-      Sections.apply_publication_update(section, latest_publication.id)
+      Oli.Delivery.Sections.Updates.apply_publication_update(section, latest_publication.id)
 
       # reload latest hierarchy
       hierarchy = DeliveryResolver.full_hierarchy(section.slug)
@@ -1507,14 +1507,14 @@ defmodule Oli.SectionsTest do
       {:ok, latest_publication} = Publishing.publish_project(project, "some changes", author.id)
 
       # apply the new publication update to the section
-      Sections.apply_publication_update(section, latest_publication.id)
+      Oli.Delivery.Sections.Updates.apply_publication_update(section, latest_publication.id)
 
       # reload latest hierarchy
       hierarchy = DeliveryResolver.full_hierarchy(section.slug)
 
       # verify non-structural changes are applied as expected
-      assert hierarchy.children |> Enum.at(0) |> then(& &1.revision.content) ==
-               page1_changes["content"]
+      #assert hierarchy.children |> Enum.at(0) |> then(& &1.revision.content) ==
+      #        page1_changes["content"]
 
       # verify the updated curriculum structure matches the expected result
 
@@ -1729,7 +1729,7 @@ defmodule Oli.SectionsTest do
       {:ok, latest_publication} = Publishing.publish_project(project, "some changes", author.id)
 
       # apply the new publication update to the section
-      Sections.apply_publication_update(section, latest_publication.id)
+      Oli.Delivery.Sections.Updates.apply_publication_update(section, latest_publication.id)
 
       # reload latest hierarchy
       section_hierarchy = DeliveryResolver.full_hierarchy(section.slug)


### PR DESCRIPTION
Large course sections (like REAM CHEM) can take 5-10 seconds to apply an update.  The root cause is in the cost of creating and deleting all of the `SectionResource` records.  The original course section update logic deletes and then recreates **all** of the non-hierarchical SR records, regardless of if they were changed or not.  So in a course like REAL CHEM where there are maybe 3000 non-hierarchical SR records (all activities, tags, objectives) we are deleting and recreating 3000 records even in the case where the publication update simply changed the content of 1 single page. 

This rewrite of the update logic (into a new module `Oli.Delivery.Sections.Updates`) eliminates this wasteful step.  It also cleans up the code to make it more readable and approachable for future editing. 

This is a very high risk change, but it does pass all of the existing unit tests that were in place to safeguard the original logic.  I've left the original logic in place, because some of it is intertwined and reused by the "course remix" logic. 