### PR TITLE
[BUG FIX] [MER-3704] Wrong scheduling type label on pages

### DIFF
--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -1466,13 +1466,13 @@ defmodule OliWeb.Delivery.Student.LearnLive do
         intro_video_viewed={@intro_video_viewed}
       />
       <div
-        :for={grouped_due_date <- @page_due_dates}
+        :for={{grouped_scheduling_type, grouped_due_date} <- @page_due_dates}
         class="flex flex-col w-full"
-        id={"pages_grouped_by_#{grouped_due_date}"}
+        id={"pages_grouped_by_#{grouped_scheduling_type}_#{grouped_due_date}"}
       >
         <div class="h-[19px] mb-5">
           <span class="dark:text-white text-sm font-bold font-['Open Sans']">
-            <%= "Due: #{format_date(grouped_due_date, @ctx, "{WDshort} {Mshort} {D}, {YYYY}")}" %>
+            <%= "#{label_for_scheduling_type(grouped_scheduling_type)}#{format_date(grouped_due_date, @ctx, "{WDshort} {Mshort} {D}, {YYYY}")}" %>
           </span>
         </div>
         <.index_item
@@ -1481,6 +1481,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
             display_module_item?(
               @show_completed_pages,
               grouped_due_date,
+              grouped_scheduling_type,
               @student_end_date_exceptions_per_resource_id,
               child,
               @ctx
@@ -1505,6 +1506,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
           ctx={@ctx}
           student_end_date_exceptions_per_resource_id={@student_end_date_exceptions_per_resource_id}
           parent_due_date={grouped_due_date}
+          parent_scheduling_type={grouped_scheduling_type}
           due_date={
             get_due_date_for_student(
               child["section_resource"].end_date,
@@ -1542,6 +1544,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
   attr :student_progress_per_resource_id, :map
   attr :due_date, Date
   attr :parent_due_date, Date
+  attr :parent_scheduling_type, :atom
   attr :progress, :float
   attr :show_completed_pages, :boolean
 
@@ -1559,6 +1562,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
         display_module_item?(
           @show_completed_pages,
           @parent_due_date,
+          @parent_scheduling_type,
           @student_end_date_exceptions_per_resource_id,
           @section_attrs,
           @ctx
@@ -1566,7 +1570,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
       }
       role={"#{@type} #{@numbering_index} details"}
       class="w-full pl-[5px] pr-[7px] py-2.5 justify-start items-center gap-5 flex rounded-lg"
-      id={"index_item_#{@resource_id}_#{@parent_due_date}"}
+      id={"index_item_#{@resource_id}_#{@parent_scheduling_type}_#{@parent_due_date}"}
       phx-value-resource_id={@resource_id}
       phx-value-parent_due_date={@parent_due_date}
       phx-value-module_resource_id={@module_resource_id}
@@ -1600,6 +1604,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
           display_module_item?(
             @show_completed_pages,
             @parent_due_date,
+            @parent_scheduling_type,
             @student_end_date_exceptions_per_resource_id,
             child,
             @ctx
@@ -1624,6 +1629,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
         ctx={@ctx}
         student_end_date_exceptions_per_resource_id={@student_end_date_exceptions_per_resource_id}
         parent_due_date={@parent_due_date}
+        parent_scheduling_type={@parent_scheduling_type}
         due_date={
           get_due_date_for_student(
             child["section_resource"].end_date,
@@ -2384,6 +2390,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
   defp display_module_item?(
          _show_completed_pages,
          _grouped_due_date,
+         _grouped_scheduling_type,
          _student_end_date_exceptions_per_resource_id,
          %{"section_resource" => %{scheduling_type: :inclass_activity}} = _child,
          _ctx
@@ -2391,8 +2398,20 @@ defmodule OliWeb.Delivery.Student.LearnLive do
        do: false
 
   defp display_module_item?(
+         _show_completed_pages,
+         _grouped_due_date,
+         "Not yet scheduled" = _grouped_scheduling_type,
+         _student_end_date_exceptions_per_resource_id,
+         %{"section_resource" => %{end_date: end_date}} = _child,
+         _ctx
+       )
+       when end_date in [nil, ""],
+       do: true
+
+  defp display_module_item?(
          show_completed_pages,
          grouped_due_date,
+         grouped_scheduling_type,
          student_end_date_exceptions_per_resource_id,
          child,
          ctx
@@ -2403,6 +2422,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
         &display_module_item?(
           show_completed_pages,
           grouped_due_date,
+          grouped_scheduling_type,
           student_end_date_exceptions_per_resource_id,
           &1,
           ctx
@@ -2419,9 +2439,11 @@ defmodule OliWeb.Delivery.Student.LearnLive do
         |> then(&if is_nil(&1), do: "Not yet scheduled", else: to_localized_date(&1, ctx))
 
       if show_completed_pages do
-        student_due_date == grouped_due_date
+        student_due_date == grouped_due_date and
+          grouped_scheduling_type == child["section_resource"].scheduling_type
       else
-        !child["completed"] and student_due_date == grouped_due_date
+        !child["completed"] and student_due_date == grouped_due_date and
+          grouped_scheduling_type == child["section_resource"].scheduling_type
       end
     end
   end
@@ -2441,14 +2463,20 @@ defmodule OliWeb.Delivery.Student.LearnLive do
       ctx
     )
     |> Enum.uniq()
-    |> then(fn dates ->
-      if nil in dates do
-        dates
-        |> Enum.reject(&is_nil/1)
-        |> Enum.sort_by(& &1, {:asc, Date})
-        |> Enum.concat(["Not yet scheduled"])
+    |> then(fn scheduling_type_date_keywords ->
+      has_a_not_scheduled_resource =
+        Enum.any?(scheduling_type_date_keywords, fn {_scheduling_type, date} ->
+          is_nil(date)
+        end)
+
+      if has_a_not_scheduled_resource do
+        # this guarantees not scheduled pages are grouped at the bootom of the list
+        scheduling_type_date_keywords
+        |> Enum.reject(fn {_st, date} -> is_nil(date) end)
+        |> Enum.sort_by(fn {_st, date} -> date end, {:asc, Date})
+        |> Enum.concat([{"Not yet scheduled", "Not yet scheduled"}])
       else
-        Enum.sort_by(dates, & &1, {:asc, Date})
+        Enum.sort_by(scheduling_type_date_keywords, fn {_st, date} -> date end, {:asc, Date})
       end
     end)
   end
@@ -2477,15 +2505,16 @@ defmodule OliWeb.Delivery.Student.LearnLive do
           []
         else
           [
-            Map.get(student_end_date_exceptions_per_resource_id, resource_id, end_date) &&
-              to_localized_date(
-                Map.get(
-                  student_end_date_exceptions_per_resource_id,
-                  resource_id,
-                  end_date
-                ),
-                ctx
-              )
+            {scheduling_type,
+             Map.get(student_end_date_exceptions_per_resource_id, resource_id, end_date) &&
+               to_localized_date(
+                 Map.get(
+                   student_end_date_exceptions_per_resource_id,
+                   resource_id,
+                   end_date
+                 ),
+                 ctx
+               )}
           ]
         end
 
@@ -2630,6 +2659,11 @@ defmodule OliWeb.Delivery.Student.LearnLive do
        ) do
     Map.get(student_end_date_exceptions_per_resource_id, resource_id, end_date)
   end
+
+  defp label_for_scheduling_type(:due_by), do: "Due by: "
+  defp label_for_scheduling_type(:read_by), do: "Read by: "
+  defp label_for_scheduling_type(:inclass_activity), do: "In-class activity by: "
+  defp label_for_scheduling_type(_), do: ""
 
   defp format_date("Not yet scheduled", _context, _format), do: "Not yet scheduled"
 

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -1515,7 +1515,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
 
       assert has_element?(
                view,
-               "#index_item_#{section_1.resource_id}_2023-11-03"
+               "#index_item_#{section_1.resource_id}_due_by_2023-11-03"
              )
     end
 

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -473,6 +473,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
 
     Sections.get_section_resource(section.id, page_12_revision.resource_id)
     |> Sections.update_section_resource(%{
+      scheduling_type: :due_by,
       start_date: ~U[2023-11-02 20:00:00Z],
       end_date: ~U[2023-11-03 20:00:00Z]
     })
@@ -1987,13 +1988,13 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       section_1_element =
         element(
           view,
-          "#index_item_#{section_1.resource_id}_2023-11-03"
+          "#index_item_#{section_1.resource_id}_read_by_2023-11-03"
         )
 
       subsection_1_element =
         element(
           view,
-          "#index_item_#{subsection_1.resource_id}_2023-11-03"
+          "#index_item_#{subsection_1.resource_id}_read_by_2023-11-03"
         )
 
       assert render(section_1_element) =~ "Why Elixir?"
@@ -2003,7 +2004,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       assert render(subsection_1_element) =~ "ml-[20px]"
     end
 
-    test "groups pages within a module index by due date (even if some pages do not yet have a scheduled date)",
+    test "groups pages within a module index by due date or read by (even if some pages do not yet have a scheduled date)",
          %{conn: conn, section: section} do
       {:ok, view, _html} = live(conn, Utils.learn_live_path(section.slug))
 
@@ -2011,16 +2012,20 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       |> element(~s{div[role="unit_5"] div[role="card_4"]})
       |> render_click()
 
-      group_by_due_date_div = element(view, ~s{div[id="pages_grouped_by_2023-11-03"]})
+      group_by_read_by_date_div = element(view, ~s{div[id="pages_grouped_by_read_by_2023-11-03"]})
+
+      group_by_due_by_date_div = element(view, ~s{div[id="pages_grouped_by_due_by_2023-11-03"]})
 
       group_by_not_yet_scheduled_div =
-        element(view, ~s{div[id="pages_grouped_by_Not yet scheduled"]})
+        element(view, ~s{div[id="pages_grouped_by_Not yet scheduled_Not yet scheduled"]})
 
-      assert render(group_by_due_date_div) =~ "Due: Fri Nov 3, 2023"
-      assert render(group_by_due_date_div) =~ "Page 11"
-      assert render(group_by_due_date_div) =~ "Page 12"
+      assert render(group_by_read_by_date_div) =~ "Read by: Fri Nov 3, 2023"
+      assert render(group_by_read_by_date_div) =~ "Page 11"
 
-      assert render(group_by_not_yet_scheduled_div) =~ "Due: Not yet scheduled"
+      assert render(group_by_due_by_date_div) =~ "Due by: Fri Nov 3, 2023"
+      assert render(group_by_due_by_date_div) =~ "Page 12"
+
+      assert render(group_by_not_yet_scheduled_div) =~ "Not yet scheduled"
       assert render(group_by_not_yet_scheduled_div) =~ "Page 13"
       assert render(group_by_not_yet_scheduled_div) =~ "Page 14"
     end
@@ -2048,10 +2053,10 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       |> element(~s{div[role="unit_5"] div[role="card_4"]})
       |> render_click()
 
-      group_by_due_date_div = element(view, ~s{div[id="pages_grouped_by_2023-11-10"]})
+      group_by_due_date_div = element(view, ~s{div[id="pages_grouped_by_read_by_2023-11-10"]})
 
       # page 13 is due on Nov 10, 2023 as defined in the student exception
-      assert render(group_by_due_date_div) =~ "Due: Fri Nov 10, 2023"
+      assert render(group_by_due_date_div) =~ "Read by: Fri Nov 10, 2023"
       assert render(group_by_due_date_div) =~ "Page 13"
     end
 


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-3704) to the ticket

With this fix, we now list pages grouped by scheduling type (`:due_by` or `:read_by`) and end date. 
This fix still supports grouping pages that are not scheduled and hiding completed ones.



https://github.com/user-attachments/assets/6c0b511f-f1ea-4153-959f-615767e5d313

