### PR TITLE
[BUG FIX] [MER-3733] Fix popup rendering

### DIFF
--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -812,7 +812,8 @@ defmodule Oli.Rendering.Content.Html do
           "inline" => true
         },
         html_element: "span",
-        container_tag: "span",
+        container_tag: :span,
+        receiver_tag: :span,
         id: "popup_#{UUID.uuid4()}"
       )
 


### PR DESCRIPTION
This PR fixes delivery view of popups that are inline to paragraphs.  The internal phoenix_react needed to have `:receiver_tag` specified as `:span` to override the default `:div`