### PR TITLE
[BUG FIX] [MER-3740] Suppress revised state change

### DIFF
--- a/lib/oli/delivery/attempts/page_lifecycle/ungraded.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/ungraded.ex
@@ -38,7 +38,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Ungraded do
           page_revision: page_revision
         } = context
       ) do
-    if is_nil(latest_resource_attempt) or latest_resource_attempt.revision_id != page_revision.id or
+    if is_nil(latest_resource_attempt) or
          latest_resource_attempt.lifecycle_state == :evaluated do
       case start(context) do
         {:ok, %AttemptState{} = attempt_state} ->

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -1780,16 +1780,10 @@ defmodule OliWeb.Delivery.Student.LearnLive do
 
   def index_item_icon(assigns) do
     case {assigns.was_visited, assigns.item_type, assigns.graded, assigns.raw_avg_score} do
-      {true, "page", false, _} ->
+      {_, "page", false, _} ->
         # visited practice page (check icon shown when progress = 100%)
         ~H"""
         <Icons.check progress={@progress} />
-        """
-
-      {false, "page", false, _} ->
-        # not visited practice page
-        ~H"""
-        <.no_icon />
         """
 
       {true, "page", true, raw_avg_score} when not is_nil(raw_avg_score) ->

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -1417,48 +1417,6 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
              )
     end
 
-    test "sees a check icon on visited and completed pages", %{
-      conn: conn,
-      user: user,
-      section: section,
-      page_1: page_1
-    } do
-      set_progress(section.id, page_1.resource_id, user.id, 1.0, page_1)
-      {:ok, view, _html} = live(conn, Utils.learn_live_path(section.slug))
-
-      # when the slider buttons are enabled we know the student async metrics were loaded
-      assert_receive({_ref, {:push_event, "enable-slider-buttons", _}}, 2_000)
-
-      # expand unit 1/module 1 details
-      view
-      |> element(~s{div[role="unit_1"] div[role="card_1"]})
-      |> render_click()
-
-      assert has_element?(view, ~s{button[role="page 1 details"] div[role="check icon"]})
-      assert has_element?(view, ~s{button[role="page 2 details"]})
-      refute has_element?(view, ~s{button[role="page 2 details"] div[role="check icon"]})
-    end
-
-    test "sees a check icon on visited and completed pages within a section", %{
-      conn: conn,
-      user: user,
-      section: section,
-      page_11: page_11
-    } do
-      set_progress(section.id, page_11.resource_id, user.id, 1.0, page_11)
-      {:ok, view, _html} = live(conn, Utils.learn_live_path(section.slug))
-
-      # when the slider buttons are enabled we know the student async metrics were loaded
-      assert_receive({_ref, {:push_event, "enable-slider-buttons", _}}, 2_000)
-
-      # expand unit 5/module 3 details
-      view
-      |> element(~s{div[role="unit_5"] div[role="card_4"]})
-      |> render_click()
-
-      assert has_element?(view, ~s{button[role="page 11 details"] div[role="check icon"]})
-    end
-
     test "hides/shows completed pages", %{
       conn: conn,
       user: user,
@@ -2248,48 +2206,6 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
                ~s{div[id="index_item_4_#{page_4.resource_id}"] span[role="duration in minutes"]},
                "22"
              )
-    end
-
-    test "sees a check icon on visited and completed pages", %{
-      conn: conn,
-      user: user,
-      section: section,
-      page_1: page_1
-    } do
-      set_progress(section.id, page_1.resource_id, user.id, 1.0, page_1)
-
-      {:ok, view, _html} =
-        live(conn, Utils.learn_live_path(section.slug, selected_view: :outline))
-
-      # when the garbage collection message is recieved we know the async metrics were loaded
-      # since the gc message is sent from the handle_info that loads the async metrics
-      assert_receive(:gc, 2_000)
-
-      assert has_element?(view, ~s{button[role="page 1 details"] div[role="check icon"]})
-      assert has_element?(view, ~s{button[role="page 2 details"]})
-      refute has_element?(view, ~s{button[role="page 2 details"] div[role="check icon"]})
-    end
-
-    test "sees a check icon on visited and completed pages within a section", %{
-      conn: conn,
-      user: user,
-      section: section,
-      page_11: page_11
-    } do
-      set_progress(section.id, page_11.resource_id, user.id, 1.0, page_11)
-
-      {:ok, view, _html} =
-        live(conn, Utils.learn_live_path(section.slug, selected_view: :outline))
-
-      # when the garbage collection message is received we know the async metrics were loaded
-      # since the gc message is sent from the handle_info that loads the async metrics
-      assert_receive(:gc, 2_000)
-
-      wait_while(fn ->
-        !has_element?(view, ~s{button[role="page 11 details"] div[role="check icon"]})
-      end)
-
-      assert has_element?(view, ~s{button[role="page 11 details"] div[role="check icon"]})
     end
 
     test "does not see a check icon on visited pages that are not fully completed", %{


### PR DESCRIPTION
This PR does two things:
1. Removes the logic clause that automatically triggers in practice pages a "move forward" to a new available published revision of the page.  Students will be pinned to the original revision for the lifetime of that page attempt.  They can still click "reset answers" - which will move them forward to the latest revision in the new page attempt.
2. Removes the logic that required a "page to have been visited" to show the green check.  This was just bad impl, as it relied on Revision ID and not resource ID.  But it is enough to only require 100% progress.
