### PR TITLE
[BUG FIX] [MER-3751] prevent crash in onHtmlPaste

### DIFF
--- a/assets/src/components/editing/editor/paste/onHtmlPaste.ts
+++ b/assets/src/components/editing/editor/paste/onHtmlPaste.ts
@@ -30,7 +30,7 @@ type PartialTagDeserializer = {
   action: DeserializerAction;
 };
 
-const isJest = typeof process !== 'undefined' && process.env.JEST_WORKER_ID !== undefined;
+const isJest = typeof process !== 'undefined' && process.env?.JEST_WORKER_ID !== undefined;
 const DEBUG_OUTPUT = !isJest;
 
 export const filterNullModelElements = (arr: DeserializeTypes): arr is DeserializeTypesNoNull =>


### PR DESCRIPTION
Migrated course was seeing a student delivery page load trigger client-side error in OnHtmlPaste, breaking activities on the page (trace below). The error was caused by code to conditionally include debug output that tested `process.env.JEST_WORKER_ID`. Apparently `process.env` was undefined in this context. 

<img width="963" alt="Screenshot 2024-09-06 at 9 12 04 AM" src="https://github.com/user-attachments/assets/72ab0739-8f6e-41a1-a633-062f7ff55329">

It is unclear why onHtmlPaste was getting fired on loading a student delivery page at all.  But this blocks the error by guarding against undefined process.env.

Failing page titled "Process Mapping Symbols and Conventions" in CAHIMS course. Authoring view here: https://tokamak.oli.cmu.edu/authoring/project/healthcare_it_foundations__cah/resource/lyrdt_process_mapping_symbols_and_co_5khic
However, the error does not occur in authoring or author preview, only delivery.

