### PR TITLE
[BUG FIX] [MER-3704] Wrong scheduling type label on page header

### DIFF
--- a/lib/oli/delivery/settings.ex
+++ b/lib/oli/delivery/settings.ex
@@ -154,6 +154,7 @@ defmodule Oli.Delivery.Settings do
 
     %Combined{
       resource_id: resolved_revision.resource_id,
+      scheduling_type: section_resource.scheduling_type,
       start_date: combine_field(:start_date, section_resource, student_exception),
       end_date: combine_field(:end_date, section_resource, student_exception),
       max_attempts: max_attempts,

--- a/lib/oli/delivery/settings/combined.ex
+++ b/lib/oli/delivery/settings/combined.ex
@@ -1,5 +1,6 @@
 defmodule Oli.Delivery.Settings.Combined do
   defstruct resource_id: nil,
+            scheduling_type: :read_by,
             start_date: nil,
             end_date: nil,
             max_attempts: 0,
@@ -19,6 +20,7 @@ defmodule Oli.Delivery.Settings.Combined do
 
   @type t() :: %__MODULE__{
           resource_id: integer(),
+          scheduling_type: :due_by | :read_by | :inclass_activity,
           start_date: DateTime.t(),
           end_date: DateTime.t(),
           max_attempts: integer(),

--- a/lib/oli_web/common/format_date_time.ex
+++ b/lib/oli_web/common/format_date_time.ex
@@ -282,7 +282,7 @@ defmodule OliWeb.Common.FormatDateTime do
 
   def to_formatted_datetime(datetime, ctx, format \\ "{WDshort} {Mshort} {D}, {YYYY}")
 
-  def to_formatted_datetime(nil, _ctx, _format), do: "not yet scheduled"
+  def to_formatted_datetime(nil, _ctx, _format), do: "Not yet scheduled"
 
   def to_formatted_datetime(datetime, ctx, format) do
     if is_binary(datetime) do
@@ -294,7 +294,7 @@ defmodule OliWeb.Common.FormatDateTime do
     end
   end
 
-  defp to_datetime(nil), do: "not yet scheduled"
+  defp to_datetime(nil), do: "Not yet scheduled"
 
   defp to_datetime(string_datetime) do
     {:ok, datetime, _} = DateTime.from_iso8601(string_datetime)

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -1472,7 +1472,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
       >
         <div class="h-[19px] mb-5">
           <span class="dark:text-white text-sm font-bold font-['Open Sans']">
-            <%= "#{label_for_scheduling_type(grouped_scheduling_type)}#{format_date(grouped_due_date, @ctx, "{WDshort} {Mshort} {D}, {YYYY}")}" %>
+            <%= "#{Utils.label_for_scheduling_type(grouped_scheduling_type)}#{format_date(grouped_due_date, @ctx, "{WDshort} {Mshort} {D}, {YYYY}")}" %>
           </span>
         </div>
         <.index_item
@@ -2659,11 +2659,6 @@ defmodule OliWeb.Delivery.Student.LearnLive do
        ) do
     Map.get(student_end_date_exceptions_per_resource_id, resource_id, end_date)
   end
-
-  defp label_for_scheduling_type(:due_by), do: "Due by: "
-  defp label_for_scheduling_type(:read_by), do: "Read by: "
-  defp label_for_scheduling_type(:inclass_activity), do: "In-class activity by: "
-  defp label_for_scheduling_type(_), do: ""
 
   defp format_date("Not yet scheduled", _context, _format), do: "Not yet scheduled"
 

--- a/lib/oli_web/live/delivery/student/utils.ex
+++ b/lib/oli_web/live/delivery/student/utils.ex
@@ -93,7 +93,12 @@ defmodule OliWeb.Delivery.Student.Utils do
             </div>
           </div>
           <div role="page schedule" class="justify-start items-start gap-1 flex">
-            <div class="opacity-50 dark:text-white text-xs font-normal">Due:</div>
+            <div
+              :if={@page_context.effective_settings.end_date}
+              class="opacity-50 dark:text-white text-xs font-normal"
+            >
+              <%= label_for_scheduling_type(@page_context.effective_settings.scheduling_type) %>
+            </div>
             <div class="dark:text-white text-xs font-normal">
               <%= FormatDateTime.to_formatted_datetime(
                 @page_context.effective_settings.end_date,
@@ -149,6 +154,11 @@ defmodule OliWeb.Delivery.Student.Utils do
     </div>
     """
   end
+
+  def label_for_scheduling_type(:due_by), do: "Due by: "
+  def label_for_scheduling_type(:read_by), do: "Read by: "
+  def label_for_scheduling_type(:inclass_activity), do: "In-class activity by: "
+  def label_for_scheduling_type(_), do: ""
 
   def proficiency_explanation_modal(assigns) do
     assigns =

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -1580,7 +1580,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       # unit 2 has not been scheduled by instructor, so there must not be a schedule details data
       assert view
              |> element(~s{div[role="unit_2"] div[role="schedule_details"]})
-             |> render() =~ "Due:\n              </span>\n              not yet scheduled"
+             |> render() =~ "Due:\n              </span>\n              Not yet scheduled"
     end
 
     test "can see units, modules and page (at module level) progresses", %{
@@ -1751,7 +1751,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
              |> element(
                ~s{div[id="top_level_page_#{top_level_page.resource_id}"] div[role="schedule_details"]}
              )
-             |> render() =~ "Due:\n              </span>\n              not yet scheduled"
+             |> render() =~ "Not yet scheduled"
 
       assert view
              |> element(~s{div[id="page_#{top_level_page.resource_id}"][role="card_1"]})

--- a/test/oli_web/live/delivery/student/lesson_live_test.exs
+++ b/test/oli_web/live/delivery/student/lesson_live_test.exs
@@ -839,6 +839,7 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
       assert has_element?(view, ~s{div[role="page numbering index"]}, "2.")
       assert has_element?(view, ~s{div[role="page title"]}, "Page 2")
       assert has_element?(view, ~s{div[role="page read time"]}, "15")
+      assert has_element?(view, ~s{div[role="page schedule"]}, "Read by:")
       assert has_element?(view, ~s{div[role="page schedule"]}, "Tue Nov 14, 2023")
     end
 


### PR DESCRIPTION
[Link ](https://eliterate.atlassian.net/browse/MER-3704?focusedCommentId=24248)to the comment in the ticket

This PR extends [the same fix implemented on the "Learn" page](https://github.com/Simon-Initiative/oli-torus/pull/5078) into page headers.

https://github.com/user-attachments/assets/876ac494-a5a8-4680-ab74-863207028bcf

