### PR TITLE
[BUG FIX] [MER-3704] Wrong scheduling type label on graded pages and top level pages

### DIFF
--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -828,7 +828,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
               <div class="ml-auto flex items-center gap-3" role="schedule_details">
                 <div class="text-[14px] leading-[32px] tracking-[0.02px] font-semibold">
                   <span class="text-gray-400 opacity-80 dark:text-[#696974] dark:opacity-100 mr-1">
-                    Due:
+                    <%= Utils.label_for_scheduling_type(@unit["section_resource"].scheduling_type) %>
                   </span>
                   <%= format_date(
                     @unit["section_resource"].end_date,
@@ -1699,7 +1699,11 @@ defmodule OliWeb.Delivery.Student.LearnLive do
           </div>
           <div :if={@graded} role="due date and score" class="flex">
             <span class="opacity-60 text-[13px] font-normal font-['Open Sans'] !font-normal opacity-60 dark:text-white">
-              Due: <%= format_date(@due_date, @ctx, "{WDshort} {Mshort} {D}, {YYYY}") %>
+              <%= Utils.label_for_scheduling_type(@parent_scheduling_type) %><%= format_date(
+                @due_date,
+                @ctx,
+                "{WDshort} {Mshort} {D}, {YYYY}"
+              ) %>
             </span>
             <Student.score_summary raw_avg_score={@raw_avg_score} />
           </div>

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -1175,7 +1175,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       assert has_element?(
                view,
                ~s{button[role="page 4 details"] div[role="due date and score"]},
-               "Due: Fri Nov 3, 2023"
+               "Read by: Fri Nov 3, 2023"
              )
     end
 
@@ -1231,7 +1231,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       assert has_element?(
                view,
                ~s{button[role="page 4 details"] div[role="due date and score"]},
-               "Due: Fri Nov 3, 2023"
+               "Read by: Fri Nov 3, 2023"
              )
 
       # and correct score summary


### PR DESCRIPTION
[Link to the comment](https://eliterate.atlassian.net/browse/MER-3704?focusedCommentId=24270) in the ticket


https://github.com/user-attachments/assets/42fd7908-e953-43e9-a56c-c2a2ddd37ea2

