### PR TITLE
[BUG FIX] [MER-3771] Delay submission to ensure all save state calls have finished

### DIFF
--- a/assets/src/components/activities/common/delivery/persistence.ts
+++ b/assets/src/components/activities/common/delivery/persistence.ts
@@ -2,8 +2,8 @@ import { LockResult } from 'data/persistence//lock';
 import { DeferredPersistenceStrategy } from 'data/persistence/DeferredPersistenceStrategy';
 import { PersistenceState, PersistenceStrategy } from 'data/persistence/PersistenceStrategy';
 
-export function initializePersistence(): PersistenceStrategy {
-  const p = new DeferredPersistenceStrategy();
+export function initializePersistence(quietPeriodInMs = 2000, maxDeferredTimeInMs = 5000): PersistenceStrategy {
+  const p = new DeferredPersistenceStrategy(quietPeriodInMs, maxDeferredTimeInMs);
   const noOpLockAcquire = () => Promise.resolve({ type: 'acquired' } as LockResult);
   const noOpLockRelease = () => Promise.resolve({ type: 'released' } as LockResult);
   const noOpSuccess = () => {};

--- a/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
@@ -224,7 +224,7 @@ export const MultiInputComponent: React.FC = () => {
           }),
         );
 
-        const fn = () =>
+        const doSave = () =>
           onSaveActivity(uiState.attemptState.attemptGuid, [
             {
               attemptGuid: part.attemptGuid,
@@ -236,10 +236,10 @@ export const MultiInputComponent: React.FC = () => {
           if ((uiState.model as MultiInputSchema).submitPerPart && !context.graded) {
             handlePerPartSubmission(input.partId, value);
           } else {
-            fn();
+            doSave();
           }
         } else {
-          deferredSaves.current[id].save(fn);
+          doSave();
         }
       }
 

--- a/assets/src/components/activities/response_multi/ResponseMultiInputDelivery.tsx
+++ b/assets/src/components/activities/response_multi/ResponseMultiInputDelivery.tsx
@@ -62,7 +62,7 @@ export const ResponseMultiInputComponent: React.FC = () => {
 
   const deferredSaves = useRef(
     model.inputs.reduce((m: any, input: MultiInput) => {
-      const p = initializePersistence();
+      const p = initializePersistence(750, 1200);
       m[input.id] = p;
       return m;
     }, {}),

--- a/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
+++ b/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
@@ -77,7 +77,7 @@ export const ShortAnswerComponent: React.FC = () => {
   const uiState = useSelector((state: ActivityDeliveryState) => state);
   const { surveyId } = context;
   const dispatch = useDispatch();
-  const deferredSave = useRef(initializePersistence());
+  const deferredSave = useRef(initializePersistence(750, 1200));
 
   useEffect(() => {
     listenForParentSurveySubmit(surveyId, dispatch, onSubmitActivity);
@@ -121,11 +121,15 @@ export const ShortAnswerComponent: React.FC = () => {
       }),
     );
 
-    deferredSave.current.save(() =>
-      onSaveActivity(uiState.attemptState.attemptGuid, [
-        { attemptGuid: uiState.attemptState.parts[0].attemptGuid, response: { input } },
-      ]),
-    );
+    const doSave = () => onSaveActivity(uiState.attemptState.attemptGuid, [
+      { attemptGuid: uiState.attemptState.parts[0].attemptGuid, response: { input } },
+    ]);
+
+    if ((uiState.model as ShortAnswerModelSchema).inputType == 'textarea') {
+      deferredSave.current.save(doSave);
+    } else {
+      doSave();
+    }
   };
 
   return (

--- a/assets/src/hooks/delayed_submit.ts
+++ b/assets/src/hooks/delayed_submit.ts
@@ -3,6 +3,14 @@ export const DelayedSubmit = {
     this.el.addEventListener("click", (event: any) => {
       event.preventDefault(); // Prevent immediate click action
 
+      const inputs = document.querySelectorAll('input[type="text"], input[type="number"], textarea, select');
+
+      // Loop through each element and disable it.  This prevents students from making any
+      // edits in activities while the submission is processing.
+      inputs.forEach((input: any) => {
+        input.disabled = true;
+      });
+
       // Disable the button to prevent additional clicks
       this.el.disabled = true;
 

--- a/assets/src/hooks/delayed_submit.ts
+++ b/assets/src/hooks/delayed_submit.ts
@@ -1,0 +1,22 @@
+export const DelayedSubmit = {
+  mounted() {
+    this.el.addEventListener("click", (event: any) => {
+      event.preventDefault(); // Prevent immediate click action
+
+      // Disable the button to prevent additional clicks
+      this.el.disabled = true;
+
+      // Change the button label and show the spinner
+      this.el.querySelector(".button-text").textContent = "Submitting Answers...";
+      this.el.querySelector(".spinner").classList.remove("hidden");
+
+      // Delay the phx-click event by two full seconds
+      setTimeout(() => {
+        // Trigger the Phoenix event after the delay
+        this.pushEvent("finalize_attempt");
+
+        // Optionally, remove the spinner and reset button state if needed
+      }, 2000);
+    });
+  },
+};

--- a/assets/src/hooks/index.ts
+++ b/assets/src/hooks/index.ts
@@ -37,8 +37,10 @@ import { ToggleReadMore } from './toggle_read_more';
 import { TooltipInit, TooltipWithTarget } from './tooltip';
 import { VideoPlayer } from './video_player';
 import { PauseOthersOnSelected, VideoPreview } from './video_preview';
+import { DelayedSubmit } from './delayed_submit';
 
 export const Hooks = {
+  DelayedSubmit,
   GraphNavigation,
   DropTarget,
   DragSource,

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -834,10 +834,33 @@ defmodule OliWeb.Delivery.Student.LessonLive do
             <div class="flex w-full justify-center">
               <button
                 id="submit_answers"
-                phx-click="finalize_attempt"
+                phx-hook="DelayedSubmit"
                 class="cursor-pointer px-5 py-2.5 hover:bg-opacity-40 bg-blue-600 rounded-[3px] shadow justify-center items-center gap-2.5 inline-flex text-white text-sm font-normal font-['Open Sans'] leading-tight"
               >
-                Submit Answers
+                <span class="button-text">Submit Answers</span>
+                <span class="spinner hidden ml-2 animate-spin">
+                  <svg
+                    class="w-5 h-5 text-white"
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <circle
+                      class="opacity-25"
+                      cx="12"
+                      cy="12"
+                      r="10"
+                      stroke="currentColor"
+                      stroke-width="4"
+                    ></circle>
+                    <path
+                      class="opacity-75"
+                      fill="currentColor"
+                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                    ></path>
+                  </svg>
+                </span>
               </button>
             </div>
             <.references ctx={@ctx} bib_app_params={@bib_app_params} />


### PR DESCRIPTION
This PR does a couple of things:

1. It adds a full two second delay after clicking "Submit Answers" to when the submission actually takes place. 
2. It removes the deferred save strategy for text, numeric, math and vlab inputs across ShortAnswer and MultiInput questions.
3. It shortens the deferred save window down to max wait period of 1200ms for the other inputs and activities. 

In concert, these changes help ensure that after a student interacts with an input in a question, that any deferred/delayed saving will be completed by the time that the `finalize_attempt` is pushed and executed.

NOTE: This does not provide a 100% guarantee.  Network issues could cause a save event to take longer than the max expected of `800ms`, which would still cause this issue.  But by moving most of the saves over to non-deferred, it is mainly those questions that use `<textarea>` inputs that could still be at risk.    A more comprehensive solution (that for instance, deferred `finalize_attempt` until all pending saves were flushed) would be too risky for a hotfix. 