### PR TITLE
[BUG FIX] [MER-3596] Add handle_params to Bibliography

### DIFF
--- a/lib/oli_web/live/workspaces/course_author/bibliography_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/bibliography_live.ex
@@ -41,6 +41,11 @@ defmodule OliWeb.Workspaces.CourseAuthor.BibliographyLive do
   end
 
   @impl Phoenix.LiveView
+  def handle_params(_params, _url, socket) do
+    {:noreply, socket}
+  end
+
+  @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
     <div>


### PR DESCRIPTION
Ticket: [MER-3596](https://eliterate.atlassian.net/browse/MER-3596)

This PR adds a catch-all `handle_params` callback to manage the sidebar collapser. The collapser triggers a `JS.patch`, which in turn invokes `handle_params`, as specified in the [documentation](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html#push_patch/2):

> When navigating to the current LiveView, handle_params/3 is immediately invoked to handle the change of params and URL state.

[MER-3596]: https://eliterate.atlassian.net/browse/MER-3596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ