### PR TITLE
[BUG FIX] [MER-3775] Allow embedded page links to open

### DIFF
--- a/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
+++ b/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
@@ -89,7 +89,7 @@
           </div>
           <.back_arrow
             to={
-              if assigns[:request_path] in [nil, ""] and @current_page["id"] != nil,
+              if assigns[:request_path] in [nil, ""] and @current_page != nil,
                 do:
                   ~p"/sections/#{@section.slug}/learn?target_resource_id=#{@current_page["id"]}",
                 else: assigns[:request_path]
@@ -116,7 +116,7 @@
         <%= live_render(@socket, OliWeb.Dialogue.WindowLive,
           session: %{
             "section_slug" => @section.slug,
-            "resource_id" => @current_page["id"],
+            "resource_id" => @page_context.page.resource_id,
             "revision_id" => @page_context.page.id,
             "is_page" => true
           },

--- a/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
+++ b/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
@@ -89,7 +89,7 @@
           </div>
           <.back_arrow
             to={
-              if assigns[:request_path] in [nil, ""],
+              if assigns[:request_path] in [nil, ""] and @current_page["id"] != nil,
                 do:
                   ~p"/sections/#{@section.slug}/learn?target_resource_id=#{@current_page["id"]}",
                 else: assigns[:request_path]


### PR DESCRIPTION
The logic here to determine how to wire up the "back button" did not consider that `@current_page` will be `nil` when the current page is NOT in the hierarchy. 

There was one other usage of `@current_page` that I adjusted also in this template. 