### PR TITLE
[BUG FIX] [MER-3330] students see deadline message with suggested by dates

### DIFF
--- a/lib/oli/delivery/settings.ex
+++ b/lib/oli/delivery/settings.ex
@@ -268,11 +268,18 @@ defmodule Oli.Delivery.Settings do
   def check_end_date(%Combined{end_date: end_date} = effective_settings) do
     effective_end_date = DateTime.add(end_date, effective_settings.grace_period, :minute)
 
-    if DateTime.compare(effective_end_date, DateTime.utc_now()) == :gt or
-         effective_settings.late_start == :allow do
-      {:allowed}
-    else
-      {:end_date_passed}
+    cond do
+      DateTime.compare(effective_end_date, DateTime.utc_now()) == :gt ->
+        {:allowed}
+
+      effective_settings.late_start == :allow ->
+        {:allowed}
+
+      effective_settings.scheduling_type == :read_by ->
+        {:allowed}
+
+      true ->
+        {:end_date_passed}
     end
   end
 

--- a/test/oli/delivery/settings_test.exs
+++ b/test/oli/delivery/settings_test.exs
@@ -15,14 +15,16 @@ defmodule Oli.Delivery.SettingsTest do
     assert {:no_attempts_remaining} ==
              Settings.new_attempt_allowed(%Combined{max_attempts: 5}, 5, [])
 
-    assert {:blocking_gates} == Settings.new_attempt_allowed(%Combined{max_attempts: 5}, 1, [1])
+    assert {:blocking_gates} ==
+             Settings.new_attempt_allowed(%Combined{max_attempts: 5}, 1, [1])
 
     assert {:end_date_passed} ==
              Settings.new_attempt_allowed(
                %Combined{
                  max_attempts: 5,
                  late_start: :disallow,
-                 end_date: ~U[2020-01-01 00:00:00Z]
+                 end_date: ~U[2020-01-01 00:00:00Z],
+                 scheduling_type: :due_by
                },
                1,
                []


### PR DESCRIPTION
Ticket: [MER-3330](https://eliterate.atlassian.net/browse/MER-3330)

This PR fixes a bug where an activity set to 'Suggested By' with a past date was incorrectly blocking attempts to that activity.

[MER-3330]: https://eliterate.atlassian.net/browse/MER-3330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ