### PR TITLE
[BUG FIX] [MER-3763] Dropdown/Num/Text Input Components contain dark background

### DIFF
--- a/assets/styles/adaptive/activities/dropdown.scss
+++ b/assets/styles/adaptive/activities/dropdown.scss
@@ -68,3 +68,10 @@ janus-input-number .unitsLabel {
   margin-left: 10px;
   margin-top: 5px;
 }
+
+//As per the requirment, dropdown / select needs to be in light mode even if the current theme is Dark.
+// This can be customized from any external CSS file.
+.dark select {
+  background-color: #fff;
+  color: #333333;
+}

--- a/assets/styles/adaptive/activities/popup.scss
+++ b/assets/styles/adaptive/activities/popup.scss
@@ -150,3 +150,10 @@ janus-popup:has(input) {
     }
   }
 }
+
+.dark janus-popup:has(input) {
+  input[src*='data']:focus,
+  input[src*='data']:active {
+    background-color: rgba(0, 0, 0, 0);
+  }
+}

--- a/assets/styles/adaptive/activities/text-input.scss
+++ b/assets/styles/adaptive/activities/text-input.scss
@@ -73,3 +73,12 @@ janus-input-number .unitsLabel {
   margin-left: 10px;
   margin-top: 10px;
 }
+
+//As per the requirment, text & number input needs to be in light mode even if the current theme is Dark.
+// This can be customized from any external CSS file.
+.dark input[type='datetime-local'],
+.dark input[type='number'],
+.dark input[type='text'] {
+  background-color: #fff;
+  color: #333333;
+}

--- a/assets/styles/adaptive/activities/text-input.scss
+++ b/assets/styles/adaptive/activities/text-input.scss
@@ -75,7 +75,7 @@ janus-input-number .unitsLabel {
 }
 
 //As per the requirment, text & number input needs to be in light mode even if the current theme is Dark.
-// This can be customized from any external CSS file.
+// This can be customized from any external CSS file
 .dark input[type='datetime-local'],
 .dark input[type='number'],
 .dark input[type='text'] {

--- a/assets/styles/adaptive/activities/text-input.scss
+++ b/assets/styles/adaptive/activities/text-input.scss
@@ -75,7 +75,7 @@ janus-input-number .unitsLabel {
 }
 
 //As per the requirment, text & number input needs to be in light mode even if the current theme is Dark.
-// This can be customized from any external CSS file
+// This can be customized from any external CSS file.
 .dark input[type='datetime-local'],
 .dark input[type='number'],
 .dark input[type='text'] {

--- a/assets/styles/preview/preview-tools.scss
+++ b/assets/styles/preview/preview-tools.scss
@@ -180,6 +180,9 @@
       .list-group {
         margin-left: 1rem !important;
       }
+      .list-group {
+        margin: 0px !important;
+      }
       button {
         font-size: 0.9rem;
       }
@@ -213,4 +216,7 @@
     white-space: nowrap;
     width: 1px;
   }
+}
+.dark .inspector .stateKey {
+  color: white !important;
 }


### PR DESCRIPTION
This PR contains the change for the following tickets:

1. [Popup component remains dark](https://eliterate.atlassian.net/browse/MER-3763)
2. [Dropdown/Num/Text Input Components contain dark background](https://eliterate.atlassian.net/browse/MER-3762)
3. [Inspector text/background visibility in Dark Mode](https://eliterate.atlassian.net/browse/MER-3760)