### PR TITLE
[BUG FIX] [MER-3797] Fix Youtube XAPI emitting 

### DIFF
--- a/assets/src/components/editing/elements/youtube/YoutubeElement.tsx
+++ b/assets/src/components/editing/elements/youtube/YoutubeElement.tsx
@@ -84,7 +84,7 @@ export const YouTubeEditor = (props: YouTubeProps) => {
           <Settings model={props.model} onEdit={onEdit} commandContext={props.commandContext} />
         }
       >
-        <YoutubePlayer video={model} authorMode={true} pageAttemptGuid=''/>
+        <YoutubePlayer video={model} authorMode={true} pageAttemptGuid="" />
       </HoverContainer>
 
       <CaptionEditor

--- a/assets/src/components/editing/elements/youtube/YoutubeElement.tsx
+++ b/assets/src/components/editing/elements/youtube/YoutubeElement.tsx
@@ -84,7 +84,7 @@ export const YouTubeEditor = (props: YouTubeProps) => {
           <Settings model={props.model} onEdit={onEdit} commandContext={props.commandContext} />
         }
       >
-        <YoutubePlayer video={model} authorMode={true} />
+        <YoutubePlayer video={model} authorMode={true} pageAttemptGuid=''/>
       </HoverContainer>
 
       <CaptionEditor

--- a/assets/src/components/youtube_player/YoutubePlayer.tsx
+++ b/assets/src/components/youtube_player/YoutubePlayer.tsx
@@ -104,8 +104,6 @@ export const YoutubePlayer: React.FC<{
   const onStateChange = (e: any) => {
     if (!videoTarget || pageAttemptGuid == '') return;
 
-
-
     switch (e.data) {
       case 0:
         XAPI.emit_delivery(

--- a/assets/src/components/youtube_player/YoutubePlayer.tsx
+++ b/assets/src/components/youtube_player/YoutubePlayer.tsx
@@ -22,9 +22,10 @@ export const YoutubePlayer: React.FC<{
   video: ContentModel.YouTube;
   children?: React.ReactNode;
   context?: WriterContext;
+  pageAttemptGuid: string;
   authorMode: boolean;
   pointMarkerContext?: PointMarkerContext;
-}> = ({ video, children, authorMode, context, pointMarkerContext }) => {
+}> = ({ video, children, authorMode, context, pointMarkerContext, pageAttemptGuid }) => {
   const stopInterval = useRef<number | undefined>();
   const [videoTarget, setVideoTarget] = useState<Player | null>(null);
   const segments = useRef<XAPI.PlayedSegment[]>([]);
@@ -101,15 +102,16 @@ export const YoutubePlayer: React.FC<{
   }, [authorMode, video.endTime, video.startTime, videoTarget]);
 
   const onStateChange = (e: any) => {
-    if (!videoTarget) return;
+    if (!videoTarget || pageAttemptGuid == '') return;
+
+
 
     switch (e.data) {
       case 0:
         XAPI.emit_delivery(
           {
             type: 'page_video_key',
-            page_attempt_guid:
-              context?.resourceAttemptGuid !== undefined ? context?.resourceAttemptGuid : '',
+            page_attempt_guid: pageAttemptGuid,
           },
           {
             type: 'video_completed',
@@ -132,8 +134,7 @@ export const YoutubePlayer: React.FC<{
         XAPI.emit_delivery(
           {
             type: 'page_video_key',
-            page_attempt_guid:
-              context?.resourceAttemptGuid !== undefined ? context?.resourceAttemptGuid : '',
+            page_attempt_guid: pageAttemptGuid,
           },
           {
             type: 'video_played',
@@ -155,8 +156,7 @@ export const YoutubePlayer: React.FC<{
         XAPI.emit_delivery(
           {
             type: 'page_video_key',
-            page_attempt_guid:
-              context?.resourceAttemptGuid !== undefined ? context?.resourceAttemptGuid : '',
+            page_attempt_guid: pageAttemptGuid,
           },
           {
             type: 'video_paused',

--- a/assets/src/data/content/writers/html.tsx
+++ b/assets/src/data/content/writers/html.tsx
@@ -365,11 +365,16 @@ export class HtmlParser implements WriterImpl {
 
   youtube(context: WriterContext, next: Next, attrs: YouTube) {
     if (!attrs.src) return <></>;
+    let guid = '';
+    if (context.resourceAttemptGuid !== undefined) {
+      guid = context.resourceAttemptGuid;
+    }
     return (
       <YoutubePlayer
         video={attrs}
         authorMode={false}
         context={context}
+        pageAttemptGuid={guid}
         pointMarkerContext={pointMarkerContextFrom(context, attrs)}
       />
     );

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -131,9 +131,17 @@ defmodule Oli.Rendering.Content.Html do
   end
 
   def youtube(%Context{} = context, _, %{"src" => _} = attrs) do
+
+    attempt_guid =
+      case context.resource_attempt do
+        nil -> ""
+        attempt -> attempt.attempt_guid
+      end
+
     {:safe, video_player} =
       OliWeb.Common.React.component(context, "Components.YoutubePlayer", %{
         "video" => attrs,
+        "pageAttemptGuid" => attempt_guid,
         "pointMarkerContext" => %{
           renderPointMarkers: context.render_opts.render_point_markers,
           isAnnotationLevel: context.is_annotation_level

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -131,7 +131,6 @@ defmodule Oli.Rendering.Content.Html do
   end
 
   def youtube(%Context{} = context, _, %{"src" => _} = attrs) do
-
     attempt_guid =
       case context.resource_attempt do
         nil -> ""

--- a/lib/oli_web/controllers/api/xapi_controller.ex
+++ b/lib/oli_web/controllers/api/xapi_controller.ex
@@ -22,6 +22,8 @@ defmodule OliWeb.Api.XAPIController do
 
       {:error, e} ->
         Logger.error("Error constructing xapi bundle: #{inspect(e)}")
+        Oli.Utils.Appsignal.capture_error("Error constructing xapi bundle: #{inspect(e)}")
+
         json(conn, %{"result" => "failure", "reason" => e})
     end
   end


### PR DESCRIPTION
When a Youtube video was present in the page (as opposed to being in an activity) it was NOT correctly emitting XAPI events from the front end for play, pause, stop, etc.  It was missing the page attempt guid, which broke the bundle creation on the server and prevented the XAPI bundle from going to S3. 

This PR fixes the problem by mirroring the solution present for HTML5 video (which does work), namely to simply specify and pass down the attempt guid as a React param. 