### PR TITLE
[BUG FIX] [MER-3814] Clear section cache

### DIFF
--- a/lib/oli/delivery/sections/updates.ex
+++ b/lib/oli/delivery/sections/updates.ex
@@ -73,6 +73,8 @@ defmodule Oli.Delivery.Sections.Updates do
 
     case result do
       {:ok, _} ->
+        Oli.Delivery.Sections.SectionCache.clear(section.slug)
+
         Broadcaster.broadcast_update_progress(section.id, new_publication.id, :complete)
 
       _ ->
@@ -265,8 +267,6 @@ defmodule Oli.Delivery.Sections.Updates do
       Logger.info(
         "perform_update.MAJOR: section[#{section.slug}] #{Oli.Timing.elapsed(mark) / 1000 / 1000}ms"
       )
-
-      Oli.Delivery.Sections.SectionCache.clear(section.slug)
 
       {:ok, :ok}
     else

--- a/lib/oli/delivery/sections/updates.ex
+++ b/lib/oli/delivery/sections/updates.ex
@@ -266,6 +266,8 @@ defmodule Oli.Delivery.Sections.Updates do
         "perform_update.MAJOR: section[#{section.slug}] #{Oli.Timing.elapsed(mark) / 1000 / 1000}ms"
       )
 
+      Oli.Delivery.Sections.SectionCache.clear(section.slug)
+
       {:ok, :ok}
     else
       e -> e


### PR DESCRIPTION
Clears the section cache for the section that has just applied the update. 

This is placed outside of the transaction to guarantee that there are no race conditions. There is a subtle race condition here if we did this clearing inside the transaction.  Consider the steps to do this during the transaction:

1. Transaction begins to apply update
2. All the code runs to apply the update
3. As a final step we clear the cache
4. Transaction ends

The race condition is that between steps 3 and 4, any call from another process to the `SectionCache.get_or_compute` would see that the cache is empty and it could reinitialize it to the old entries.   Instead, we do this:

1. Transaction begins to apply update
2. All the code runs to apply the update
3. Transaction ends
4. We clear the cache
