### PR TITLE
[CHORE] [MER-3717] Load polyfill script from cloudflare cdn 

### DIFF
--- a/lib/oli_web/templates/layout/chromeless.html.heex
+++ b/lib/oli_web/templates/layout/chromeless.html.heex
@@ -96,7 +96,7 @@
     <% end %>
 
     <%= unless Map.get(assigns, :vr_agent_active, false) do %>
-      <script src="https://polyfill.io/v3/polyfill.min.js?features=es6">
+      <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6">
       </script>
     <% end %>
 

--- a/lib/oli_web/templates/layout/delivery.html.heex
+++ b/lib/oli_web/templates/layout/delivery.html.heex
@@ -124,7 +124,7 @@
     </script>
 
     <%= unless Map.get(assigns, :vr_agent_active, false) do %>
-      <script src="https://polyfill.io/v3/polyfill.min.js?features=es6">
+      <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6">
       </script>
     <% end %>
     <!-- ReCAPTCHA -->

--- a/lib/oli_web/templates/layout/delivery_from_payment.html.heex
+++ b/lib/oli_web/templates/layout/delivery_from_payment.html.heex
@@ -94,7 +94,7 @@
     </script>
 
     <%= unless Map.get(assigns, :vr_agent_active, false) do %>
-      <script src="https://polyfill.io/v3/polyfill.min.js?features=es6">
+      <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6">
       </script>
     <% end %>
     <!-- ReCAPTCHA -->

--- a/lib/oli_web/templates/payment_providers/stripe/index.html.heex
+++ b/lib/oli_web/templates/payment_providers/stripe/index.html.heex
@@ -1,4 +1,6 @@
-<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?version=3.52.1&features=fetch">
+<script
+  src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?version=3.52.1&features=fetch"
+>
 </script>
 <script type="text/javascript" src={Routes.static_path(@conn, "/js/stripeclient.js")}>
 </script>

--- a/lib/oli_web/templates/payment_providers/stripe/index.html.heex
+++ b/lib/oli_web/templates/payment_providers/stripe/index.html.heex
@@ -1,4 +1,4 @@
-<script src="https://polyfill.io/v3/polyfill.min.js?version=3.52.1&features=fetch">
+<script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?version=3.52.1&features=fetch">
 </script>
 <script type="text/javascript" src={Routes.static_path(@conn, "/js/stripeclient.js")}>
 </script>


### PR DESCRIPTION
[Ticket](https://eliterate.atlassian.net/browse/MER-3717)
This changes the URLs from which polyfill.js script is loaded from the now insecure polyfill.io to the cloudflare cdn, which implements a compatible service.