### PR TITLE
[PERFORMANCE] [MER-3821] Eliminate extra queries in IndexLive.mount/3

### DIFF
--- a/lib/oli/delivery/previous_next_index.ex
+++ b/lib/oli/delivery/previous_next_index.ex
@@ -122,6 +122,15 @@ defmodule Oli.Delivery.PreviousNextIndex do
     end
   end
 
+  def get(section) do
+    case section.previous_next_index do
+      nil ->
+        {:ok, section} = rebuild(section)
+        section.previous_next_index
+      index -> index
+    end
+  end
+
   @doc """
   Rebuilds the previous_next_index for the given %Section{}, updating the section
   with the newly rebuilt index.

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -1816,10 +1816,17 @@ defmodule Oli.Delivery.Sections do
   def get_ordered_schedule(section, current_user_id, combined_settings_for_all_resources, :v1) do
     container_titles = container_titles(section)
 
-    combined_settings_for_all_resources = case combined_settings_for_all_resources do
-      nil -> Oli.Delivery.Settings.get_combined_settings_for_all_resources(section.id, current_user_id)
-      _ -> combined_settings_for_all_resources
-    end
+    combined_settings_for_all_resources =
+      case combined_settings_for_all_resources do
+        nil ->
+          Oli.Delivery.Settings.get_combined_settings_for_all_resources(
+            section.id,
+            current_user_id
+          )
+
+        _ ->
+          combined_settings_for_all_resources
+      end
 
     containers_data_map =
       get_ordered_container_labels(section.slug, short_label: true)
@@ -1910,10 +1917,17 @@ defmodule Oli.Delivery.Sections do
      raw_avg_score_per_page_id, user_resource_attempt_counts,
      last_attempt_per_page_id} = build_user_data_for_section_schedule(section, current_user_id)
 
-     combined_settings_for_all_resources = case combined_settings_for_all_resources do
-      nil -> Oli.Delivery.Settings.get_combined_settings_for_all_resources(section.id, current_user_id)
-      _ -> combined_settings_for_all_resources
-    end
+    combined_settings_for_all_resources =
+      case combined_settings_for_all_resources do
+        nil ->
+          Oli.Delivery.Settings.get_combined_settings_for_all_resources(
+            section.id,
+            current_user_id
+          )
+
+        _ ->
+          combined_settings_for_all_resources
+      end
 
     scheduled_section_resources =
       Scheduling.retrieve(section, :pages)
@@ -1973,10 +1987,17 @@ defmodule Oli.Delivery.Sections do
      raw_avg_score_per_page_id, user_resource_attempt_counts,
      last_attempt_per_page_id} = build_user_data_for_section_schedule(section, current_user_id)
 
-    combined_settings_for_all_resources = case combined_settings_for_all_resources do
-      nil -> Oli.Delivery.Settings.get_combined_settings_for_all_resources(section.id, current_user_id)
-      _ -> combined_settings_for_all_resources
-    end
+    combined_settings_for_all_resources =
+      case combined_settings_for_all_resources do
+        nil ->
+          Oli.Delivery.Settings.get_combined_settings_for_all_resources(
+            section.id,
+            current_user_id
+          )
+
+        _ ->
+          combined_settings_for_all_resources
+      end
 
     sorted_container_groups =
       Scheduling.retrieve(section, :pages)
@@ -4563,9 +4584,12 @@ defmodule Oli.Delivery.Sections do
   """
 
   def get_resource_ids_group_by_resource_type(section) do
-    result = PreviousNextIndex.get(section)
-    |> Map.values()
-    |> Enum.group_by(fn item -> item["type"] end, fn item -> item["id"] |> String.to_integer() end)
+    result =
+      PreviousNextIndex.get(section)
+      |> Map.values()
+      |> Enum.group_by(fn item -> item["type"] end, fn item ->
+        item["id"] |> String.to_integer()
+      end)
 
     # Ensure each key is present in the result
     Map.put(result, "container", result["container"] || [])

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -57,7 +57,6 @@ defmodule Oli.Delivery.Sections do
   alias Oli.Delivery.Paywall
   alias Oli.Delivery.Sections.PostProcessing
   alias Oli.Branding.CustomLabels
-  alias Oli.Delivery.Settings
 
   require Logger
 
@@ -1807,9 +1806,9 @@ defmodule Oli.Delivery.Sections do
   This function is being used for the v1 and v2 versions of the schedule.
   In the short term when all views use the v2 version, the version param will be removed and v2 will prevale.
   """
-  def get_ordered_schedule(section, current_user_id, version \\ :v1)
+  def get_ordered_schedule(section, current_user_id, combined_settings_for_all_resources, version \\ :v1)
 
-  def get_ordered_schedule(section, current_user_id, :v1) do
+  def get_ordered_schedule(section, current_user_id, combined_settings_for_all_resources, :v1) do
     container_titles = container_titles(section.slug)
 
     containers_data_map =
@@ -1825,7 +1824,7 @@ defmodule Oli.Delivery.Sections do
       end)
 
     %{"container" => container_ids, "page" => page_ids} =
-      Sections.get_resource_ids_group_by_resource_type(section.slug)
+      Sections.get_resource_ids_group_by_resource_type(section)
 
     progress_per_container_id =
       Metrics.progress_across(section.id, container_ids, current_user_id)
@@ -1849,9 +1848,6 @@ defmodule Oli.Delivery.Sections do
 
     user_resource_attempt_counts =
       Metrics.get_all_user_resource_attempt_counts(section, current_user_id)
-
-    combined_settings_for_all_resources =
-      Settings.get_combined_settings_for_all_resources(section.id, current_user_id)
 
     #      {containers_data_map, page_to_containers_map, progress_per_resource_id,
     #     raw_avg_score_per_page_id, user_resource_attempt_counts, combined_settings_for_all_resources,
@@ -1899,9 +1895,9 @@ defmodule Oli.Delivery.Sections do
     scheduled_section_resources
   end
 
-  def get_ordered_schedule(section, current_user_id, :v2) do
+  def get_ordered_schedule(section, current_user_id, combined_settings_for_all_resources, :v2) do
     {containers_data_map, page_to_containers_map, progress_per_resource_id,
-     raw_avg_score_per_page_id, user_resource_attempt_counts, combined_settings_for_all_resources,
+     raw_avg_score_per_page_id, user_resource_attempt_counts,
      last_attempt_per_page_id} = build_user_data_for_section_schedule(section, current_user_id)
 
     scheduled_section_resources =
@@ -1953,9 +1949,9 @@ defmodule Oli.Delivery.Sections do
   and we need to respect the same expected output format as get_ordered_schedule/3.
   """
 
-  def get_not_scheduled_agenda(%Section{analytics_version: :v1} = section, current_user_id) do
+  def get_not_scheduled_agenda(%Section{analytics_version: :v1} = section, combined_settings_for_all_resources, current_user_id) do
     {containers_data_map, page_to_containers_map, progress_per_resource_id,
-     raw_avg_score_per_page_id, user_resource_attempt_counts, combined_settings_for_all_resources,
+     raw_avg_score_per_page_id, user_resource_attempt_counts,
      last_attempt_per_page_id} = build_user_data_for_section_schedule(section, current_user_id)
 
     sorted_container_groups =
@@ -1985,9 +1981,9 @@ defmodule Oli.Delivery.Sections do
     %{{nil, nil} => sorted_container_groups}
   end
 
-  def get_not_scheduled_agenda(%Section{analytics_version: :v2} = section, current_user_id) do
+  def get_not_scheduled_agenda(%Section{analytics_version: :v2} = section, combined_settings_for_all_resources, current_user_id) do
     {containers_data_map, page_to_containers_map, progress_per_resource_id,
-     raw_avg_score_per_page_id, user_resource_attempt_counts, combined_settings_for_all_resources,
+     raw_avg_score_per_page_id, user_resource_attempt_counts,
      last_attempt_per_page_id} = build_user_data_for_section_schedule(section, current_user_id)
 
     sorted_container_groups =
@@ -2018,7 +2014,8 @@ defmodule Oli.Delivery.Sections do
   end
 
   defp build_user_data_for_section_schedule(section, current_user_id) do
-    container_titles = container_titles(section.slug)
+
+    container_titles = container_titles(section)
 
     containers_data_map =
       get_ordered_container_labels(section.slug, short_label: true)
@@ -2033,7 +2030,7 @@ defmodule Oli.Delivery.Sections do
       end)
 
     %{"container" => container_ids, "page" => page_ids} =
-      Sections.get_resource_ids_group_by_resource_type(section.slug)
+      Sections.get_resource_ids_group_by_resource_type(section)
 
     progress_per_container_id =
       Metrics.progress_across(section.id, container_ids, current_user_id)
@@ -2058,11 +2055,8 @@ defmodule Oli.Delivery.Sections do
     user_resource_attempt_counts =
       Metrics.get_all_user_resource_attempt_counts(section, current_user_id)
 
-    combined_settings_for_all_resources =
-      Settings.get_combined_settings_for_all_resources(section.id, current_user_id)
-
     {containers_data_map, page_to_containers_map, progress_per_resource_id,
-     raw_avg_score_per_page_id, user_resource_attempt_counts, combined_settings_for_all_resources,
+     raw_avg_score_per_page_id, user_resource_attempt_counts,
      last_attempt_per_page_id}
   end
 
@@ -2321,8 +2315,8 @@ defmodule Oli.Delivery.Sections do
     end
   end
 
-  defp get_schedule_for_week_slice(section, current_user_id, week_fn) do
-    schedule = get_ordered_schedule(section, current_user_id, :v2)
+  defp get_schedule_for_week_slice(section, settings, current_user_id, week_fn) do
+    schedule = get_ordered_schedule(section, current_user_id, settings, :v2)
 
     schedule
     |> Enum.reduce(%{}, fn {{_month, _year}, weeks}, acc ->
@@ -2336,16 +2330,14 @@ defmodule Oli.Delivery.Sections do
   @doc """
   Returns the schedule for the current week and the next week for the given section and user.
   """
-  @spec get_schedule_for_current_and_next_week(Section.t(), integer()) ::
-          any()
-  def get_schedule_for_current_and_next_week(section, current_user_id) do
+  def get_schedule_for_current_and_next_week(section, settings, current_user_id) do
     current_week_number =
       OliWeb.Components.Delivery.Utils.week_number(
         section.start_date,
         Oli.DateTime.utc_now()
       )
 
-    get_schedule_for_week_slice(section, current_user_id, fn week_number ->
+    get_schedule_for_week_slice(section, settings, current_user_id, fn week_number ->
       week_number in [current_week_number, current_week_number + 1]
     end)
   end
@@ -4535,29 +4527,19 @@ defmodule Oli.Delivery.Sections do
   end
 
   @doc """
-  Returns all the resource_ids of a section grouped by resource type.
+  Returns all the resource_ids of a section grouped by resource type
+  for pages and containers in the hierarchy.
 
   %{
-    "activity" => [4630, 6927, 593],
     "container" => [7742, 7743, 7744, 7745],
-    "objective" => [4260, 4249, 4308, 4309, 4277, 4254, 4316],
-    "page" => [7400, 7568, 7436, 7714, 7165, 7433, 7181, 7451, 7592, 7449, 7587,
-    7638, 7286, 7564, 7244, 7172, 7404, 7424],
-    "tag" => [3986, 4035, 4102, 3959, 4205, 3975, 4235, 4134, 4087, 4075, 4165,
-    4036, 4052, 3973, 4023, 4030]
+    "page" => [7400, 7568, 7436, 7714, 7165, 7433, 7181, 7451, 7592, 7449, 7587]
   }
   """
 
-  def get_resource_ids_group_by_resource_type(section_slug) do
-    from([_sr, _s, _spp, _pr, rev] in DeliveryResolver.section_resource_revisions(section_slug),
-      join: rt in ResourceType,
-      on: rt.id == rev.resource_type_id,
-      select: {rt.type, rev.resource_id}
-    )
-    |> Repo.all()
-    |> Enum.group_by(fn {resource_type, _resource_id} -> resource_type end, fn {_, resource_id} ->
-      resource_id
-    end)
+  def get_resource_ids_group_by_resource_type(section) do
+    PreviousNextIndex.get(section)
+    |> Map.values()
+    |> Enum.group_by(fn item -> item["type"] end, fn item -> item["id"] end)
   end
 
   @doc """
@@ -5217,15 +5199,11 @@ defmodule Oli.Delivery.Sections do
   @doc """
   Returns a map from resource_id to the current revision title for all container resources.
   """
-  @spec container_titles(String.t()) :: map()
-  def container_titles(section_slug) do
-    container_type_id = Oli.Resources.ResourceType.get_id_by_type("container")
-
-    from([s: s, sr: sr, rev: rev] in DeliveryResolver.section_resource_revisions(section_slug),
-      where: rev.resource_type_id == ^container_type_id and rev.deleted == false,
-      select: {rev.resource_id, rev.title}
-    )
-    |> Repo.all()
+  def container_titles(section) do
+    PreviousNextIndex.get(section)
+    |> Map.values()
+    |> Enum.filter(fn item -> item["type"] == "container" end)
+    |> Enum.map(fn item -> {item["id"], item["title"]} end)
     |> Enum.into(%{})
   end
 

--- a/lib/oli_web/live/delivery/student/index_live.ex
+++ b/lib/oli_web/live/delivery/student/index_live.ex
@@ -15,9 +15,7 @@ defmodule OliWeb.Delivery.Student.IndexLive do
 
   @decorate transaction_event("IndexLive")
   def mount(_params, _session, socket) do
-
     if connected?(socket) do
-
       section = socket.assigns[:section]
       current_user_id = socket.assigns[:current_user].id
 
@@ -30,7 +28,12 @@ defmodule OliWeb.Delivery.Student.IndexLive do
 
       grouped_agenda_resources =
         if has_scheduled_resources?,
-          do: Sections.get_schedule_for_current_and_next_week(section, combined_settings, current_user_id),
+          do:
+            Sections.get_schedule_for_current_and_next_week(
+              section,
+              combined_settings,
+              current_user_id
+            ),
           else: Sections.get_not_scheduled_agenda(section, combined_settings, current_user_id)
 
       nearest_upcoming_lesson =
@@ -85,25 +88,25 @@ defmodule OliWeb.Delivery.Student.IndexLive do
         end)
 
       {:ok,
-      assign(socket,
-        active_tab: :index,
-        loaded: true,
-        grouped_agenda_resources: grouped_agenda_resources,
-        section_slug: section.slug,
-        section_start_date: section.start_date,
-        historical_graded_attempt_summary: nil,
-        has_visited_section:
-          Sections.has_visited_section(section, socket.assigns[:current_user],
-            enrollment_state: false
-          ),
-        last_open_and_unfinished_page: last_open_and_unfinished_page,
-        nearest_upcoming_lesson: nearest_upcoming_lesson,
-        upcoming_assignments: combine_settings(upcoming_assignments, combined_settings),
-        latest_assignments: combine_settings(latest_assignments, combined_settings),
-        containers_per_page: containers_per_page,
-        section_progress: section_progress(section.id, current_user_id),
-        assignments_tab: :upcoming
-      )}
+       assign(socket,
+         active_tab: :index,
+         loaded: true,
+         grouped_agenda_resources: grouped_agenda_resources,
+         section_slug: section.slug,
+         section_start_date: section.start_date,
+         historical_graded_attempt_summary: nil,
+         has_visited_section:
+           Sections.has_visited_section(section, socket.assigns[:current_user],
+             enrollment_state: false
+           ),
+         last_open_and_unfinished_page: last_open_and_unfinished_page,
+         nearest_upcoming_lesson: nearest_upcoming_lesson,
+         upcoming_assignments: combine_settings(upcoming_assignments, combined_settings),
+         latest_assignments: combine_settings(latest_assignments, combined_settings),
+         containers_per_page: containers_per_page,
+         section_progress: section_progress(section.id, current_user_id),
+         assignments_tab: :upcoming
+       )}
     else
       {:ok, assign(socket, active_tab: :index, loaded: false)}
     end

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -2236,7 +2236,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
     visited_pages_map = Sections.get_visited_pages(section.id, current_user_id)
 
     %{"container" => container_ids, "page" => page_ids} =
-      Sections.get_resource_ids_group_by_resource_type(section.slug)
+      Sections.get_resource_ids_group_by_resource_type(section)
 
     progress_per_container_id =
       Metrics.progress_across(section.id, container_ids, current_user_id)

--- a/lib/oli_web/live/delivery/student/schedule_live.ex
+++ b/lib/oli_web/live/delivery/student/schedule_live.ex
@@ -9,42 +9,54 @@ defmodule OliWeb.Delivery.Student.ScheduleLive do
   alias Oli.Delivery.Attempts.{HistoricalGradedAttemptSummary}
 
   def mount(_params, _session, socket) do
-    section = socket.assigns[:section]
-    current_user_id = socket.assigns[:current_user].id
 
-    combined_settings =
-      Appsignal.instrument("ScheduleLive: combined_settings", fn ->
-        Settings.get_combined_settings_for_all_resources(section.id, current_user_id)
-      end)
+    if connected?(socket) do
 
-    has_scheduled_resources? = Scheduling.has_scheduled_resources?(section.id)
+      section = socket.assigns[:section]
+      current_user_id = socket.assigns[:current_user].id
 
-    schedule =
-      if has_scheduled_resources?,
-        do: Sections.get_ordered_schedule(section, current_user_id, combined_settings),
-        else: Sections.get_not_scheduled_agenda(section, combined_settings, current_user_id) |> Map.values() |> hd()
+      combined_settings =
+        Appsignal.instrument("ScheduleLive: combined_settings", fn ->
+          Settings.get_combined_settings_for_all_resources(section.id, current_user_id)
+        end)
 
-    current_datetime = DateTime.utc_now()
-    current_week = Utils.week_number(section.start_date, current_datetime)
-    current_month = current_datetime.month
+      has_scheduled_resources? = Scheduling.has_scheduled_resources?(section.id)
 
-    if connected?(socket),
-      do: async_scroll_to_current_week(self())
+      schedule =
+        if has_scheduled_resources?,
+          do: Sections.get_ordered_schedule(section, current_user_id, combined_settings),
+          else: Sections.get_not_scheduled_agenda(section, combined_settings, current_user_id) |> Map.values() |> hd()
 
-    {:ok,
-     assign(socket,
-       active_tab: :schedule,
-       schedule: schedule,
-       section_slug: section.slug,
-       current_week: current_week,
-       current_month: current_month,
-       historical_graded_attempt_summary: nil,
-       has_scheduled_resources?: has_scheduled_resources?
-     )}
+      current_datetime = DateTime.utc_now()
+      current_week = Utils.week_number(section.start_date, current_datetime)
+      current_month = current_datetime.month
+
+      async_scroll_to_current_week(self())
+
+      {:ok,
+      assign(socket,
+        active_tab: :schedule,
+        loaded: true,
+        schedule: schedule,
+        section_slug: section.slug,
+        current_week: current_week,
+        current_month: current_month,
+        historical_graded_attempt_summary: nil,
+        has_scheduled_resources?: has_scheduled_resources?
+      )}
+    else
+      {:ok, assign(socket, active_tab: :schedule, loaded: false)}
+    end
   end
 
   def handle_params(_params, _uri, socket) do
     {:noreply, socket}
+  end
+
+  def render(%{loaded: false} = assigns) do
+    ~H"""
+    <div></div>
+    """
   end
 
   def render(%{has_scheduled_resources?: true} = assigns) do

--- a/lib/oli_web/live/delivery/student/schedule_live.ex
+++ b/lib/oli_web/live/delivery/student/schedule_live.ex
@@ -21,7 +21,7 @@ defmodule OliWeb.Delivery.Student.ScheduleLive do
 
     schedule =
       if has_scheduled_resources?,
-        do: Sections.get_ordered_schedule(section, combined_settings, current_user_id),
+        do: Sections.get_ordered_schedule(section, current_user_id, combined_settings),
         else: Sections.get_not_scheduled_agenda(section, combined_settings, current_user_id) |> Map.values() |> hd()
 
     current_datetime = DateTime.utc_now()

--- a/lib/oli_web/live/delivery/student/schedule_live.ex
+++ b/lib/oli_web/live/delivery/student/schedule_live.ex
@@ -9,9 +9,7 @@ defmodule OliWeb.Delivery.Student.ScheduleLive do
   alias Oli.Delivery.Attempts.{HistoricalGradedAttemptSummary}
 
   def mount(_params, _session, socket) do
-
     if connected?(socket) do
-
       section = socket.assigns[:section]
       current_user_id = socket.assigns[:current_user].id
 
@@ -25,7 +23,10 @@ defmodule OliWeb.Delivery.Student.ScheduleLive do
       schedule =
         if has_scheduled_resources?,
           do: Sections.get_ordered_schedule(section, current_user_id, combined_settings),
-          else: Sections.get_not_scheduled_agenda(section, combined_settings, current_user_id) |> Map.values() |> hd()
+          else:
+            Sections.get_not_scheduled_agenda(section, combined_settings, current_user_id)
+            |> Map.values()
+            |> hd()
 
       current_datetime = DateTime.utc_now()
       current_week = Utils.week_number(section.start_date, current_datetime)
@@ -34,16 +35,16 @@ defmodule OliWeb.Delivery.Student.ScheduleLive do
       async_scroll_to_current_week(self())
 
       {:ok,
-      assign(socket,
-        active_tab: :schedule,
-        loaded: true,
-        schedule: schedule,
-        section_slug: section.slug,
-        current_week: current_week,
-        current_month: current_month,
-        historical_graded_attempt_summary: nil,
-        has_scheduled_resources?: has_scheduled_resources?
-      )}
+       assign(socket,
+         active_tab: :schedule,
+         loaded: true,
+         schedule: schedule,
+         section_slug: section.slug,
+         current_week: current_week,
+         current_month: current_month,
+         historical_graded_attempt_summary: nil,
+         has_scheduled_resources?: has_scheduled_resources?
+       )}
     else
       {:ok, assign(socket, active_tab: :schedule, loaded: false)}
     end

--- a/test/oli/delivery/sections_test.exs
+++ b/test/oli/delivery/sections_test.exs
@@ -2165,14 +2165,12 @@ defmodule Oli.Delivery.SectionsTest do
       module_2: module_2,
       unit_1: unit_1
     } do
-
       result = Sections.container_titles(section)
 
       assert Map.get(result, unit_1.resource_id) == unit_1.title
       assert Map.get(result, module_1.resource_id) == module_1.title
       assert Map.get(result, module_2.resource_id) == module_2.title
     end
-
   end
 
   describe "get_last_completed_or_started_assignments/3" do

--- a/test/oli/delivery/sections_test.exs
+++ b/test/oli/delivery/sections_test.exs
@@ -1314,7 +1314,7 @@ defmodule Oli.Delivery.SectionsTest do
                    ]}
                 ]}
              ] =
-               Sections.get_ordered_schedule(section, student1.id)
+               Sections.get_ordered_schedule(section, student1.id, nil)
     end
   end
 
@@ -1417,7 +1417,7 @@ defmodule Oli.Delivery.SectionsTest do
                  }
                ]
              } =
-               Sections.get_not_scheduled_agenda(section, student1.id)
+               Sections.get_not_scheduled_agenda(section, nil, student1.id)
 
       # verify that the resources are sorted by hierarchy (numbering index)
       assert [
@@ -2163,23 +2163,16 @@ defmodule Oli.Delivery.SectionsTest do
       section: section,
       module_1: module_1,
       module_2: module_2,
-      unit_1: unit_1,
-      container_revision: root_container
+      unit_1: unit_1
     } do
-      expected_map = %{
-        root_container.resource_id => root_container.title,
-        unit_1.resource_id => unit_1.title,
-        module_1.resource_id => module_1.title,
-        module_2.resource_id => module_2.title
-      }
 
-      result = Sections.container_titles(section.slug)
-      assert result == expected_map
+      result = Sections.container_titles(section)
+
+      assert Map.get(result, unit_1.resource_id) == unit_1.title
+      assert Map.get(result, module_1.resource_id) == module_1.title
+      assert Map.get(result, module_2.resource_id) == module_2.title
     end
 
-    test "returns an empty map when there are no container resources" do
-      assert Sections.container_titles("non-existent-section") == %{}
-    end
   end
 
   describe "get_last_completed_or_started_assignments/3" do

--- a/test/oli_web/live/delivery/student/home/components/schedule_component_test.exs
+++ b/test/oli_web/live/delivery/student/home/components/schedule_component_test.exs
@@ -280,7 +280,7 @@ defmodule OliWeb.Delivery.Student.Home.Components.ScheduleComponentTest do
       stub_current_time(~U[2024-05-07 20:00:00Z])
 
       grouped_agenda_resources =
-        Sections.get_schedule_for_current_and_next_week(section, user.id)
+        Sections.get_schedule_for_current_and_next_week(section, nil, user.id)
 
       {:ok, lcd, _html} =
         live_component_isolated(conn, ScheduleComponent, %{
@@ -356,7 +356,7 @@ defmodule OliWeb.Delivery.Student.Home.Components.ScheduleComponentTest do
       set_progress(section.id, practice_1.resource_id, user.id, 1.0, practice_1)
 
       grouped_agenda_resources =
-        Sections.get_schedule_for_current_and_next_week(section, user.id)
+        Sections.get_schedule_for_current_and_next_week(section, nil, user.id)
 
       {:ok, lcd, _html} =
         live_component_isolated(conn, ScheduleComponent, %{
@@ -390,7 +390,7 @@ defmodule OliWeb.Delivery.Student.Home.Components.ScheduleComponentTest do
       set_progress(section.id, exploration_1.resource_id, user.id, 1.0, exploration_1, :active)
 
       grouped_agenda_resources =
-        Sections.get_schedule_for_current_and_next_week(section, user.id)
+        Sections.get_schedule_for_current_and_next_week(section, nil, user.id)
 
       {:ok, lcd, _html} =
         live_component_isolated(conn, ScheduleComponent, %{
@@ -423,7 +423,7 @@ defmodule OliWeb.Delivery.Student.Home.Components.ScheduleComponentTest do
       set_progress(section.id, practice_1.resource_id, user.id, 1.0, practice_1)
 
       grouped_agenda_resources =
-        Sections.get_schedule_for_current_and_next_week(section, user.id)
+        Sections.get_schedule_for_current_and_next_week(section, nil, user.id)
 
       {:ok, lcd, _html} =
         live_component_isolated(conn, ScheduleComponent, %{


### PR DESCRIPTION
This eliminates 3 out of 4 queries mentioned in the original ticket. 

It also ensures that for `IndexLive` and `ScheduleLive` that we only run the meaty part of `on_mount` one time. 