### PR TITLE
[BUGFIX] [MER-3613] Grade Passback Issue

### DIFF
--- a/lib/oli_web/live/grades/grade_sync.ex
+++ b/lib/oli_web/live/grades/grade_sync.ex
@@ -40,11 +40,13 @@ defmodule OliWeb.Grades.GradeSync do
           were manually adjusted or overridden by the instructor.") %>
         </div>
 
+        <form id="grade_sync_form" />
         <select
           phx-change="select_page"
           id="assignment_grade_sync_select"
           name="resource_id"
           class="custom-select custom-select-lg mb-2"
+          form="grade_sync_form"
         >
           <%= for page <- @graded_pages do %>
             <option value={page.resource_id} selected={@selected_page == page.resource_id}>

--- a/lib/oli_web/live/grades/grade_sync.ex
+++ b/lib/oli_web/live/grades/grade_sync.ex
@@ -70,7 +70,7 @@ defmodule OliWeb.Grades.GradeSync do
       </div>
 
       <div class="card-footer mt-4">
-        <a class="btn btn-primary" phx-click="send_grades" {@disabled}>
+        <a class="btn btn-primary" phx-click="send_grades" phx-throttle={3000} {@disabled}>
           <%= dgettext("grades", "Synchronize Grades") %>
         </a>
       </div>

--- a/lib/oli_web/live/grades/grade_sync.ex
+++ b/lib/oli_web/live/grades/grade_sync.ex
@@ -1,7 +1,6 @@
 defmodule OliWeb.Grades.GradeSync do
   use OliWeb, :html
 
-  attr(:task_queue, :list)
   attr(:total_jobs, :list)
   attr(:failed_jobs, :list)
   attr(:succeeded_jobs, :list)
@@ -9,11 +8,16 @@ defmodule OliWeb.Grades.GradeSync do
   attr(:selected_page, :map)
 
   def render(assigns) do
+    %{total_jobs: total_jobs, failed_jobs: failed_jobs, succeeded_jobs: succeeded_jobs} = assigns
+
+    started_sync? = Enum.all?([total_jobs, failed_jobs, succeeded_jobs], &(!is_nil(&1)))
+    completed_sync? = started_sync? and total_jobs == failed_jobs + succeeded_jobs
+
     assigns =
       assign(
         assigns,
         :disabled,
-        if length(assigns.task_queue) > 0 or assigns.selected_page == nil do
+        if (started_sync? and not completed_sync?) or assigns.selected_page == nil do
           [disabled: true]
         else
           []

--- a/lib/oli_web/live/grades/grades.ex
+++ b/lib/oli_web/live/grades/grades.ex
@@ -112,7 +112,6 @@ defmodule OliWeb.Grades.GradesLive do
       </div>
       <div class="my-2">
         <GradeSync.render
-          task_queue={@task_queue}
           total_jobs={@total_jobs}
           failed_jobs={@failed_jobs}
           succeeded_jobs={@succeeded_jobs}
@@ -297,7 +296,14 @@ defmodule OliWeb.Grades.GradesLive do
 
   def handle_event("select_page", %{"resource_id" => resource_id}, socket) do
     {resource_id, _} = Integer.parse(resource_id)
-    {:noreply, assign(socket, selected_page: resource_id)}
+
+    {:noreply,
+     assign(socket,
+       selected_page: resource_id,
+       total_jobs: nil,
+       failed_jobs: nil,
+       succeeded_jobs: nil
+     )}
   end
 
   def handle_event("test_connection", _, socket) do

--- a/test/oli_web/live/grades_live_test.exs
+++ b/test/oli_web/live/grades_live_test.exs
@@ -271,6 +271,30 @@ defmodule OliWeb.GradesLiveTest do
       |> render_click()
 
       assert has_element?(view, "p", "Pending grade updates: 1")
+
+      # Button disabled until it is finished
+      assert view
+             |> has_element?(
+               "a[phx-click=\"send_grades\"][disabled]",
+               "Synchronize Grades"
+             )
+
+      payload = %Oli.Delivery.Attempts.PageLifecycle.GradeUpdatePayload{
+        resource_access_id: resource_access.id,
+        job: %{id: 1},
+        status: :success,
+        details: nil
+      }
+
+      # Send success grade update message
+      send(view.pid, {:lms_grade_update_result, payload})
+
+      # Button is enabled again once the sync is finished
+      refute view
+             |> has_element?(
+               "a[phx-click=\"send_grades\"][disabled]",
+               "Synchronize Grades"
+             )
     end
 
     test "sync grades - select other resource", %{
@@ -455,26 +479,6 @@ defmodule OliWeb.GradesLiveTest do
       |> render_click()
 
       assert has_element?(view, "div#flash", "Error getting LMS access token")
-    end
-
-    test "sync grades - shows error on failure to obtain access token",
-         %{
-           conn: conn,
-           section: section
-         } do
-      user = insert(:user)
-      enroll_user_to_section(user, section, :context_learner)
-
-      {:ok, view, _html} = live(conn, live_view_grades_route(section.slug))
-
-      view
-      |> element(
-        "a[phx-click=\"send_grades\"]",
-        "Synchronize Grades"
-      )
-      |> render_click()
-
-      assert has_element?(view, "div#flash", "error fetching access token")
     end
   end
 end


### PR DESCRIPTION
[MER-3682](https://eliterate.atlassian.net/browse/MER-3682)

This PR addresses an issue and mitigates the risk of another when synchronizing course grades with an LMS:

1. Resolves and eliminates LiveView-related console errors in the browser (see attached gif).
2. Lowers the likelihood of encountering a Rate Limit Error when fetching an LMS access token. This is achieved by disabling grade passback when already in progress, removing unnecessary access token requests, and applying a throttle to the relevant button.

![Screen Recording 2024-09-16 at 3](https://github.com/user-attachments/assets/e9d7f400-2386-487f-ab62-8010c7ad29d5)


[MER-3682]: https://eliterate.atlassian.net/browse/MER-3682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ