### PR TITLE
[BUG FIX] [MER-3619] Fix an issue where account creation silently fails in certain cases

### DIFF
--- a/lib/oli/accounts.ex
+++ b/lib/oli/accounts.ex
@@ -200,6 +200,16 @@ defmodule Oli.Accounts do
   def get_user_by(clauses), do: Repo.get_by(User, clauses)
 
   @doc """
+  Gets a single independent user by query parameter
+  ## Examples
+      iex> get_independent_user_by(email: "student1@example.com")
+      %User{independent_learner: true, ...}
+      iex> get_independent_user_by(email: "student2@example.com")
+      nil
+  """
+  def get_independent_user_by(clauses), do: Repo.get_by(User, Enum.into([independent_learner: true], clauses))
+
+  @doc """
   Gets a single user with platform roles and author preloaded
   Returns `nil` if the User does not exist.
   ## Examples

--- a/lib/oli/accounts.ex
+++ b/lib/oli/accounts.ex
@@ -207,7 +207,8 @@ defmodule Oli.Accounts do
       iex> get_independent_user_by(email: "student2@example.com")
       nil
   """
-  def get_independent_user_by(clauses), do: Repo.get_by(User, Enum.into([independent_learner: true], clauses))
+  def get_independent_user_by(clauses),
+    do: Repo.get_by(User, Enum.into([independent_learner: true], clauses))
 
   @doc """
   Gets a single user with platform roles and author preloaded

--- a/lib/oli_web/pow/messages.ex
+++ b/lib/oli_web/pow/messages.ex
@@ -58,17 +58,5 @@ defmodule OliWeb.Pow.Messages do
   end
 
   def pow_assent_login_with_provider(conn),
-    do:
-      interpolate("Continue with %{provider}", provider: Naming.humanize(conn.params["provider"]))
-
-  defp interpolate(msg, opts) do
-    Enum.reduce(opts, msg, fn {key, value}, msg ->
-      token = "%{#{key}}"
-
-      case String.contains?(msg, token) do
-        true -> String.replace(msg, token, to_string(value), global: false)
-        false -> msg
-      end
-    end)
-  end
+    do: "Continue with #{Naming.humanize(conn.params["provider"])}"
 end

--- a/lib/oli_web/pow/user_context.ex
+++ b/lib/oli_web/pow/user_context.ex
@@ -61,7 +61,7 @@ defmodule OliWeb.Pow.UserContext do
   """
   @impl true
   def create(params) do
-    case Accounts.get_user_by(%{email: params["email"]}) do
+    case Accounts.get_independent_user_by(%{email: params["email"]}) do
       %User{email: email} = user ->
         if user.email_confirmed_at,
           do:
@@ -70,8 +70,8 @@ defmodule OliWeb.Pow.UserContext do
               "Account already exists",
               "account_already_exists.html",
               %{
-                url: Utils.ensure_absolute_url(Routes.pow_session_path(OliWeb.Endpoint, :new)),
-                forgot_password:
+                login_url: Utils.ensure_absolute_url(Routes.pow_session_path(OliWeb.Endpoint, :new)),
+                forgot_password_url:
                   Utils.ensure_absolute_url(
                     Routes.pow_reset_password_reset_password_path(OliWeb.Endpoint, :new)
                   )

--- a/lib/oli_web/pow/user_context.ex
+++ b/lib/oli_web/pow/user_context.ex
@@ -70,7 +70,8 @@ defmodule OliWeb.Pow.UserContext do
               "Account already exists",
               "account_already_exists.html",
               %{
-                login_url: Utils.ensure_absolute_url(Routes.pow_session_path(OliWeb.Endpoint, :new)),
+                login_url:
+                  Utils.ensure_absolute_url(Routes.pow_session_path(OliWeb.Endpoint, :new)),
                 forgot_password_url:
                   Utils.ensure_absolute_url(
                     Routes.pow_reset_password_reset_password_path(OliWeb.Endpoint, :new)

--- a/lib/oli_web/pow/user_identities_context.ex
+++ b/lib/oli_web/pow/user_identities_context.ex
@@ -12,7 +12,7 @@ defmodule OliWeb.Pow.UserIdentities do
         %{"email" => email, "email_verified" => true} = user_params,
         user_id_params
       ) do
-    case Accounts.get_independent_user_by(email: email, independent_learner: true) do
+    case Accounts.get_independent_user_by(email: email) do
       nil ->
         # user account with the given email doesnt exist, so create it
         pow_assent_create_user(user_identity_params, user_params, user_id_params)

--- a/lib/oli_web/pow/user_identities_context.ex
+++ b/lib/oli_web/pow/user_identities_context.ex
@@ -12,10 +12,9 @@ defmodule OliWeb.Pow.UserIdentities do
         %{"email" => email, "email_verified" => true} = user_params,
         user_id_params
       ) do
-    case Accounts.get_user_by(email: email) do
+    case Accounts.get_independent_user_by(email: email, independent_learner: true) do
       nil ->
         # user account with the given email doesnt exist, so create it
-        # user_params = Map.merge(user_params, %{"sub" => UUID.uuid4()})
         pow_assent_create_user(user_identity_params, user_params, user_id_params)
 
       user ->

--- a/lib/oli_web/templates/email/account_already_exists.html.eex
+++ b/lib/oli_web/templates/email/account_already_exists.html.eex
@@ -1,12 +1,23 @@
-<div class="flex flex-column gap-y-4">
-  <h3>Are you trying to create a new account?</h3>
-  <p>
-    Someone tried to create an account with this email but an account already exists.
-    If this was you, you can login <%= link "here", to: @url, target: "_blank" %> with your existing email and password.
-    If you forgot your password, you can reset it by clicking <%= link "Forgot Password?", to: @forgot_password, target: "_blank" %>.
-  </p>
-  <p>If this was not you, you can disregard this email.</p>
-</div>
-
-
-
+<table align="center" role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin: auto;">
+    <tr>
+        <td style="background-color: #ffffff; padding: 20px 10px;">
+            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+                <tr>
+                    <td style="padding: 20px; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555;">
+                        <h1 style="margin: 0 0 10px 0; font-family: sans-serif; font-size: 25px; line-height: 30px; color: #333333; font-weight: normal;">Trying to create a new account?</h1>
+                        <p style="margin: 20px 0;">
+                            We noticed there was an attempt to create a new account with this email but an account already exists.
+                        </p>
+                        <p style="margin: 20px 0;">
+                            If this was you, <%= link "sign in to your existing account", to: @login_url, target: "_blank", style: "color: #2C67C4;" %>.
+                            If you forgot your password, you can reset it <%= link "here", to: @forgot_password_url, target: "_blank", style: "color: #2C67C4;" %>.
+                        </p>
+                        <p style="margin: 20px 0;">
+                            If this was not you, you can ignore this email.
+                        </p>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-3619

This PR fixes 2 issues related to LTI and direct delivery accounts being intermingled if they have the same email address.

The issue is that the system is not properly constraining the existing account checks to `independent_learner: true` in 2 important places in the code:
- `lib/oli_web/pow/user_context.ex`
- `lib/oli_web/pow/user_identities_context.ex`

This is preventing torus from creating a new account when one already exists in the LTI domain with the same email.

~~Further, my suspicion is that the callback to user_identities_context is being triggered during an LTI launch. This callback pattern matches on “email_verified: true” assuming that only social login providers can meet that condition, however on LTI launch this email_verified is explicity set to true before the Pow session is created, effectively triggering this callback codepath for every LTI launch in. Furthermore, when this condition is met, an upsert is performed with the LTI details, which effectively converts the direct delivery user to an LTI user.~~ I verified this is not the case. However, I have left in the change here to ensure this function only runs for independent learners, as we never want a user to be able to add a social login capability to their existing LMS account. It could be that this was part of the confusion with the one-off account mentioned in the ticket.

I also updated the email template here to be better client compatible (tailwind is not available in email renderers) and match the existing email styles. This email message especially should match the rest of the email styles to not help assure a user that the email is valid.

One other note to make here: I noticed that the identification of a unique LTI account relies solely on the uniqueness of a given "sub" field. In most (if not all) cases, this is a UUID supplied by an LMS. However, because this is technically  outside of our control, it would be better to constrain this `insert_or_update_lms_user` function to also only consider users for a given institution. I didn't make this change here though, as it seemed a bit more risky. I filed a followup ticket https://eliterate.atlassian.net/browse/MER-3824