### PR TITLE
[BUG FIX] [MER-3823] Convert numeric to text input

### DIFF
--- a/assets/src/components/activities/common/delivery/inputs/NumericInput.tsx
+++ b/assets/src/components/activities/common/delivery/inputs/NumericInput.tsx
@@ -16,7 +16,6 @@ interface Props {
 
 export const NumericInput: React.FC<Props> = (props) => {
   const numericInputRef = createRef<HTMLInputElement>();
-  const [uniqueId] = useState(Math.random().toString(36).substring(7));
   const [hasError, setHasError] = useState(false);
 
   useEffect(() => {
@@ -29,8 +28,6 @@ export const NumericInput: React.FC<Props> = (props) => {
 
   return (
     <input
-      id={uniqueId}
-      key={uniqueId}
       ref={numericInputRef}
       placeholder={props.placeholder}
       type="text"

--- a/assets/src/components/activities/common/delivery/inputs/NumericInput.tsx
+++ b/assets/src/components/activities/common/delivery/inputs/NumericInput.tsx
@@ -1,7 +1,8 @@
-import React, { createRef } from 'react';
+import React, { createRef, useEffect, useState } from 'react';
 import { MultiInputSize } from 'components/activities/multi_input/schema';
 import { disableScrollWheelChange } from 'components/activities/short_answer/utils';
 import { classNames } from 'utils/classNames';
+import { isValidNumber } from 'utils/number';
 
 interface Props {
   value: string;
@@ -12,20 +13,38 @@ interface Props {
   onBlur?: () => void;
   onKeyUp: (e: React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
 }
+
 export const NumericInput: React.FC<Props> = (props) => {
   const numericInputRef = createRef<HTMLInputElement>();
+  const [uniqueId] = useState(Math.random().toString(36).substring(7));
+  const [hasError, setHasError] = useState(false);
+
+  useEffect(() => {
+    if (props.value === '' || !isValidNumber(props.value)) {
+      setHasError(true);
+    } else {
+      setHasError(false);
+    }
+  }, [props.value]);
 
   return (
     <input
+      id={uniqueId}
+      key={uniqueId}
       ref={numericInputRef}
       placeholder={props.placeholder}
-      type="number"
+      type="text"
       aria-label="answer submission textbox"
       className={classNames(
-        'border-gray-300 rounded-md disabled:bg-gray-100 disabled:text-gray-600',
+        'rounded-md border-2 disabled:bg-gray-100 disabled:text-gray-600',
+        hasError ? 'input-error' : 'border-gray-300', // Use custom error class
+        'focus:outline-none', // Remove default focus outline
         props.size && `input-size-${props.size}`,
       )}
-      onChange={(e) => props.onChange(e.target.value)}
+      onChange={(e) => {
+        const value = e.target.value;
+        props.onChange(value);
+      }}
       onBlur={props.onBlur}
       onKeyUp={props.onKeyUp}
       value={props.value}

--- a/assets/src/components/activities/short_answer/sections/NumericInput.tsx
+++ b/assets/src/components/activities/short_answer/sections/NumericInput.tsx
@@ -12,6 +12,7 @@ import {
 } from 'data/activities/model/rules';
 import { classNames } from 'utils/classNames';
 import guid from 'utils/guid';
+import { isValidNumber } from 'utils/number';
 import { disableScrollWheelChange } from '../utils';
 
 // here we defined a "editable number" variant data type that contains information
@@ -38,10 +39,6 @@ export type EditableNumber = InvalidNumber | ValidNumber;
 
 const isVariable = (s: numberOrVar): boolean =>
   typeof s === 'string' && s.match(/^@@\w+@@$/) !== null;
-
-const isValidNumber = (s: string): boolean =>
-  // allowing .333 but not 33. Need disjunction to allow both
-  typeof s === 'string' && s.match(/^[+-]?\d*\.?\d+(?:[Ee][+-]?\d+)?$/) != null;
 
 const parsedNumberOrEmptyString = (num: number | undefined) =>
   num != undefined && !isNaN(num) ? num : '';

--- a/assets/src/utils/number.ts
+++ b/assets/src/utils/number.ts
@@ -1,0 +1,3 @@
+
+const regex = /^-?\d+(\.\d+)?([eE][-+]?\d+)?$/;
+export const isValidNumber = (value: string) => regex.test(value);

--- a/assets/src/utils/number.ts
+++ b/assets/src/utils/number.ts
@@ -1,2 +1,3 @@
-const regex = /^-?\d+(\.\d+)?([eE][-+]?\d+)?$/;
+// disjunction allows for both .300 and 300.
+const regex = /^[+-]?((\d+\.?\d*)|(\.\d+))([eE][-+]?\d+)?$/;
 export const isValidNumber = (value: string) => regex.test(value);

--- a/assets/src/utils/number.ts
+++ b/assets/src/utils/number.ts
@@ -1,3 +1,2 @@
-
 const regex = /^-?\d+(\.\d+)?([eE][-+]?\d+)?$/;
 export const isValidNumber = (value: string) => regex.test(value);

--- a/assets/styles/delivery/activity.scss
+++ b/assets/styles/delivery/activity.scss
@@ -2,6 +2,10 @@
   margin-top: 1em;
   margin-bottom: 4em;
 
+  .input-error {
+    border-color: red !important; /* Override any other border color */
+  }
+
   .activity-content {
     display: flex;
     flex-direction: column;

--- a/assets/test/utils/number_test.ts
+++ b/assets/test/utils/number_test.ts
@@ -1,4 +1,4 @@
-// isValidNumber.test.js
+
 import { isValidNumber } from '../../src/utils/number';
 
 describe('isValidNumber', () => {

--- a/assets/test/utils/number_test.ts
+++ b/assets/test/utils/number_test.ts
@@ -6,6 +6,7 @@ describe('isValidNumber', () => {
     expect(isValidNumber('0')).toBe(true);
     expect(isValidNumber('3')).toBe(true);
     expect(isValidNumber('-3')).toBe(true);
+    expect(isValidNumber('+3')).toBe(true);
     expect(isValidNumber('123456')).toBe(true);
   });
 
@@ -14,6 +15,9 @@ describe('isValidNumber', () => {
     expect(isValidNumber('3.14')).toBe(true);
     expect(isValidNumber('-3.14')).toBe(true);
     expect(isValidNumber('123.456')).toBe(true);
+    expect(isValidNumber('.456')).toBe(true);
+    // not allowed in HTML standard but desired in significant figure contexts:
+    expect(isValidNumber('320.')).toBe(true);
   });
 
   test('should return true for valid scientific notation', () => {
@@ -33,6 +37,7 @@ describe('isValidNumber', () => {
     expect(isValidNumber('3e+')).toBe(false);
     expect(isValidNumber('e3')).toBe(false);
     expect(isValidNumber('3e3e4')).toBe(false);
+    expect(isValidNumber('.')).toBe(false);
   });
 
   // Edge cases

--- a/assets/test/utils/number_test.ts
+++ b/assets/test/utils/number_test.ts
@@ -1,0 +1,59 @@
+// isValidNumber.test.js
+import { isValidNumber } from '../../src/utils/number';
+
+describe('isValidNumber', () => {
+  // Valid cases
+  test('should return true for valid integers', () => {
+    expect(isValidNumber("0")).toBe(true);
+    expect(isValidNumber("3")).toBe(true);
+    expect(isValidNumber("-3")).toBe(true);
+    expect(isValidNumber("123456")).toBe(true);
+  });
+
+  test('should return true for valid floating-point numbers', () => {
+    expect(isValidNumber("0.0")).toBe(true);
+    expect(isValidNumber("3.14")).toBe(true);
+    expect(isValidNumber("-3.14")).toBe(true);
+    expect(isValidNumber("123.456")).toBe(true);
+  });
+
+  test('should return true for valid scientific notation', () => {
+    expect(isValidNumber("3e10")).toBe(true);
+    expect(isValidNumber("-3e10")).toBe(true);
+    expect(isValidNumber("3.14e-2")).toBe(true);
+    expect(isValidNumber("2.5E+5")).toBe(true);
+  });
+
+  // Invalid cases
+  test('should return false for invalid numbers', () => {
+    expect(isValidNumber("3g")).toBe(false);
+    expect(isValidNumber("abc")).toBe(false);
+    expect(isValidNumber("3.14.15")).toBe(false);
+    expect(isValidNumber("++3")).toBe(false);
+    expect(isValidNumber("--3")).toBe(false);
+    expect(isValidNumber("3e+")).toBe(false);
+    expect(isValidNumber("e3")).toBe(false);
+    expect(isValidNumber("3e3e4")).toBe(false);
+  });
+
+  // Edge cases
+  test('should return false for empty strings', () => {
+    expect(isValidNumber("")).toBe(false);
+  });
+
+  test('should return false for whitespace', () => {
+    expect(isValidNumber(" ")).toBe(false);
+    expect(isValidNumber("\t")).toBe(false);
+    expect(isValidNumber("\n")).toBe(false);
+  });
+
+  test('should return false for only a decimal point', () => {
+    expect(isValidNumber(".")).toBe(false);
+    expect(isValidNumber("-")).toBe(false);
+  });
+
+  test('should return true for zero in different formats', () => {
+    expect(isValidNumber("0")).toBe(true);
+    expect(isValidNumber("0.0")).toBe(true);
+  });
+});

--- a/assets/test/utils/number_test.ts
+++ b/assets/test/utils/number_test.ts
@@ -1,59 +1,58 @@
-
 import { isValidNumber } from '../../src/utils/number';
 
 describe('isValidNumber', () => {
   // Valid cases
   test('should return true for valid integers', () => {
-    expect(isValidNumber("0")).toBe(true);
-    expect(isValidNumber("3")).toBe(true);
-    expect(isValidNumber("-3")).toBe(true);
-    expect(isValidNumber("123456")).toBe(true);
+    expect(isValidNumber('0')).toBe(true);
+    expect(isValidNumber('3')).toBe(true);
+    expect(isValidNumber('-3')).toBe(true);
+    expect(isValidNumber('123456')).toBe(true);
   });
 
   test('should return true for valid floating-point numbers', () => {
-    expect(isValidNumber("0.0")).toBe(true);
-    expect(isValidNumber("3.14")).toBe(true);
-    expect(isValidNumber("-3.14")).toBe(true);
-    expect(isValidNumber("123.456")).toBe(true);
+    expect(isValidNumber('0.0')).toBe(true);
+    expect(isValidNumber('3.14')).toBe(true);
+    expect(isValidNumber('-3.14')).toBe(true);
+    expect(isValidNumber('123.456')).toBe(true);
   });
 
   test('should return true for valid scientific notation', () => {
-    expect(isValidNumber("3e10")).toBe(true);
-    expect(isValidNumber("-3e10")).toBe(true);
-    expect(isValidNumber("3.14e-2")).toBe(true);
-    expect(isValidNumber("2.5E+5")).toBe(true);
+    expect(isValidNumber('3e10')).toBe(true);
+    expect(isValidNumber('-3e10')).toBe(true);
+    expect(isValidNumber('3.14e-2')).toBe(true);
+    expect(isValidNumber('2.5E+5')).toBe(true);
   });
 
   // Invalid cases
   test('should return false for invalid numbers', () => {
-    expect(isValidNumber("3g")).toBe(false);
-    expect(isValidNumber("abc")).toBe(false);
-    expect(isValidNumber("3.14.15")).toBe(false);
-    expect(isValidNumber("++3")).toBe(false);
-    expect(isValidNumber("--3")).toBe(false);
-    expect(isValidNumber("3e+")).toBe(false);
-    expect(isValidNumber("e3")).toBe(false);
-    expect(isValidNumber("3e3e4")).toBe(false);
+    expect(isValidNumber('3g')).toBe(false);
+    expect(isValidNumber('abc')).toBe(false);
+    expect(isValidNumber('3.14.15')).toBe(false);
+    expect(isValidNumber('++3')).toBe(false);
+    expect(isValidNumber('--3')).toBe(false);
+    expect(isValidNumber('3e+')).toBe(false);
+    expect(isValidNumber('e3')).toBe(false);
+    expect(isValidNumber('3e3e4')).toBe(false);
   });
 
   // Edge cases
   test('should return false for empty strings', () => {
-    expect(isValidNumber("")).toBe(false);
+    expect(isValidNumber('')).toBe(false);
   });
 
   test('should return false for whitespace', () => {
-    expect(isValidNumber(" ")).toBe(false);
-    expect(isValidNumber("\t")).toBe(false);
-    expect(isValidNumber("\n")).toBe(false);
+    expect(isValidNumber(' ')).toBe(false);
+    expect(isValidNumber('\t')).toBe(false);
+    expect(isValidNumber('\n')).toBe(false);
   });
 
   test('should return false for only a decimal point', () => {
-    expect(isValidNumber(".")).toBe(false);
-    expect(isValidNumber("-")).toBe(false);
+    expect(isValidNumber('.')).toBe(false);
+    expect(isValidNumber('-')).toBe(false);
   });
 
   test('should return true for zero in different formats', () => {
-    expect(isValidNumber("0")).toBe(true);
-    expect(isValidNumber("0.0")).toBe(true);
+    expect(isValidNumber('0')).toBe(true);
+    expect(isValidNumber('0.0')).toBe(true);
   });
 });


### PR DESCRIPTION
Converts the input from type `number` to type `text` and adds in regex based validation that what the user has entered is a number.  When it is not a number, displays a red border around the input to indicate the validation value.   In all cases, whatever they have entered into the input will round trip to the server and save. 