### PR TITLE
[BUG FIX] [MER-3683] convert start/end dates to UTC before storing

### DIFF
--- a/lib/oli_web/live/new_course/new_course.ex
+++ b/lib/oli_web/live/new_course/new_course.ex
@@ -492,7 +492,6 @@ defmodule OliWeb.Delivery.NewCourse do
           section
       end
       |> convert_dates(socket.assigns.ctx)
-      |> IO.inspect(label: "section after converting:")
 
     changeset =
       socket.assigns.changeset

--- a/lib/oli_web/live/new_course/new_course.ex
+++ b/lib/oli_web/live/new_course/new_course.ex
@@ -588,6 +588,6 @@ defmodule OliWeb.Delivery.NewCourse do
   defp validate_course_dates(changeset) do
     {_, start_date} = Ecto.Changeset.fetch_field(changeset, :start_date)
     {_, end_date} = Ecto.Changeset.fetch_field(changeset, :end_date)
-    Date.diff(start_date, end_date) < 0
+    DateTime.compare(start_date, end_date) == :lt
   end
 end

--- a/lib/oli_web/live/new_course/new_course.ex
+++ b/lib/oli_web/live/new_course/new_course.ex
@@ -12,7 +12,7 @@ defmodule OliWeb.Delivery.NewCourse do
   alias Oli.Delivery.Sections.Section
   alias Oli.Delivery.Sections
   alias Oli.Repo
-  alias OliWeb.Common.{Breadcrumb, Stepper, SessionContext, FormatDateTime}
+  alias OliWeb.Common.{Breadcrumb, Stepper, FormatDateTime}
   alias OliWeb.Common.Stepper.Step
   alias OliWeb.Components.Common
   alias OliWeb.Delivery.NewCourse.{CourseDetails, NameCourse, SelectSource}

--- a/test/oli_web/live/new_course/course_details_test.exs
+++ b/test/oli_web/live/new_course/course_details_test.exs
@@ -105,9 +105,9 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
       |> render_hook("js_form_data_response", %{
         "section" => %{
           class_days: [:monday, :friday],
-          start_date: DateTime.add(DateTime.utc_now(), 2, :day),
-          end_date: DateTime.add(DateTime.utc_now(), 62, :day),
-          preferred_scheduling_time: ~T[23:59:59]
+          start_date: "2024-09-10T18:19",
+          end_date: "2024-09-18T18:19",
+          preferred_scheduling_time: "23:59:59"
         },
         "current_step" => 3
       })
@@ -131,9 +131,9 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
       |> render_hook("js_form_data_response", %{
         "section" => %{
           class_days: [:monday, :friday],
-          start_date: DateTime.add(DateTime.utc_now(), 2, :day),
-          end_date: DateTime.add(DateTime.utc_now(), 62, :day),
-          preferred_scheduling_time: ~T[23:59:59]
+          start_date: "2024-09-10T18:19",
+          end_date: "2024-09-18T18:19",
+          preferred_scheduling_time: "23:59:59"
         },
         "current_step" => 3
       })
@@ -197,9 +197,9 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
       |> render_hook("js_form_data_response", %{
         "section" => %{
           class_days: [:monday, :friday],
-          start_date: DateTime.add(DateTime.utc_now(), 2, :day),
-          end_date: DateTime.add(DateTime.utc_now(), 62, :day),
-          preferred_scheduling_time: ~T[23:59:59]
+          start_date: "2024-09-10T18:19",
+          end_date: "2024-09-18T18:19",
+          preferred_scheduling_time: "23:59:59"
         },
         "current_step" => 3
       })
@@ -223,9 +223,9 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
       |> render_hook("js_form_data_response", %{
         "section" => %{
           class_days: [:monday, :friday],
-          start_date: DateTime.add(DateTime.utc_now(), 2, :day),
-          end_date: DateTime.add(DateTime.utc_now(), 62, :day),
-          preferred_scheduling_time: ~T[23:59:59]
+          start_date: "2024-09-10T18:19",
+          end_date: "2024-09-18T18:19",
+          preferred_scheduling_time: "23:59:59"
         },
         "current_step" => 3
       })
@@ -315,9 +315,9 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
       |> render_hook("js_form_data_response", %{
         "section" => %{
           class_days: [:monday, :friday],
-          start_date: DateTime.add(DateTime.utc_now(), 2, :day),
-          end_date: DateTime.add(DateTime.utc_now(), 62, :day),
-          preferred_scheduling_time: ~T[23:59:59]
+          start_date: "2024-09-10T18:19",
+          end_date: "2024-09-18T18:19",
+          preferred_scheduling_time: "23:59:59"
         },
         "current_step" => 3
       })
@@ -351,9 +351,9 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
       |> render_hook("js_form_data_response", %{
         "section" => %{
           class_days: [:monday, :friday],
-          start_date: DateTime.add(DateTime.utc_now(), 2, :day),
-          end_date: DateTime.add(DateTime.utc_now(), 62, :day),
-          preferred_scheduling_time: ~T[23:59:59]
+          start_date: "2024-09-10T18:19",
+          end_date: "2024-09-18T18:19",
+          preferred_scheduling_time: "23:59:59"
         },
         "current_step" => 3
       })


### PR DESCRIPTION
This corrects the new section form to convert user-entered start and end date/times from the user's time zone to UTC before storing.  This issue appears to be handled correctly in the edit section details view which allows for modifying the dates after creation. Failure to convert the dates on creation was leading to the initial times being treated as UTC times. Then these appeared adjusted to the user's time zone in the later editing form. 

Note two validation failures can occur on this step of the new section creation form: missing one or both of the date/times, or having the start and end date be the same (regardless of times). 