### PR TITLE
[FEATURE] [MER-3604] Update projects table routes

### DIFF
--- a/lib/oli_web/controllers/project_controller.ex
+++ b/lib/oli_web/controllers/project_controller.ex
@@ -38,18 +38,14 @@ defmodule OliWeb.ProjectController do
       {:ok, project} ->
         conn
         |> put_flash(:info, "Project duplicated. You've been redirected to your new project.")
-        |> redirect(
-          to: Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.OverviewLive, project.slug)
-        )
+        |> redirect(to: ~p"/workspaces/course_author/#{project.slug}/overview")
 
       {:error, message} ->
         project = conn.assigns.project
 
         conn
         |> put_flash(:error, "Project could not be copied: " <> message)
-        |> redirect(
-          to: Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.OverviewLive, project.slug)
-        )
+        |> redirect(to: ~p"/workspaces/course_author/#{project.slug}/overview")
     end
   end
 end

--- a/lib/oli_web/live/workspaces/course_author/alternatives_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/alternatives_live.ex
@@ -42,9 +42,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.AlternativesLive do
        alternatives: Enum.reverse(alternatives),
        subscriptions: subscriptions,
        resource_slug: project.slug,
-       resource_title: project.title,
-       active_workspace: :course_author,
-       active_view: :overview
+       resource_title: project.title
      )}
   end
 

--- a/lib/oli_web/live/workspaces/course_author/alternatives_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/alternatives_live.ex
@@ -1,0 +1,727 @@
+defmodule OliWeb.Workspaces.CourseAuthor.AlternativesLive do
+  use OliWeb, :live_view
+  use Phoenix.HTML
+  use OliWeb.Common.Modal
+
+  import Oli.Utils, only: [uuid: 0]
+  import OliWeb.Common.Components
+  import OliWeb.ErrorHelpers
+  import OliWeb.Resources.AlternativesEditor.GroupOption
+
+  alias Oli.Authoring.Broadcaster.Subscriber
+  alias Oli.Authoring.Editing.ResourceEditor
+  alias Oli.Publishing
+  alias Oli.Resources.{ResourceType, Revision}
+  alias OliWeb.Common.Modal.{FormModal, DeleteModal}
+  alias OliWeb.Resources.AlternativesEditor.PreventDeletionModal
+
+  @alternatives_type_id ResourceType.id_for_alternatives()
+
+  @impl Phoenix.LiveView
+  def mount(_params, _session, socket) do
+    %{ctx: ctx, project: project} = socket.assigns
+
+    {:ok, alternatives} =
+      ResourceEditor.list(
+        project.slug,
+        ctx.author,
+        @alternatives_type_id
+      )
+
+    alternatives =
+      Enum.filter(alternatives, fn a -> a.content["strategy"] != "upgrade_decision_point" end)
+
+    subscriptions = subscribe(alternatives, project.slug)
+
+    {:ok,
+     assign(socket,
+       ctx: ctx,
+       project: project,
+       author: ctx.author,
+       title: "Alternatives | " <> project.title,
+       alternatives: Enum.reverse(alternatives),
+       subscriptions: subscriptions,
+       resource_slug: project.slug,
+       resource_title: project.title,
+       active_workspace: :course_author,
+       active_view: :overview
+     )}
+  end
+
+  @impl Phoenix.LiveView
+  def render(assigns) do
+    ~H"""
+    <%= render_modal(assigns) %>
+
+    <div class="alternatives-groups container p-8">
+      <h2>Alternatives</h2>
+      <div class="d-flex flex-row">
+        <div class="flex-grow-1"></div>
+        <button class="btn btn-primary" phx-click="show_create_modal">
+          <i class="fa fa-plus"></i> New Alternative
+        </button>
+      </div>
+      <div class="d-flex flex-column my-4">
+        <%= if Enum.count(@alternatives) > 0 do %>
+          <%= for group <- @alternatives do %>
+            <.group group={group} />
+          <% end %>
+        <% else %>
+          <div class="text-center"><em>There are no alternatives groups</em></div>
+        <% end %>
+      </div>
+    </div>
+    """
+  end
+
+  attr(:editing_enabled, :boolean, default: true)
+  attr(:source, :atom, default: :alternatives)
+  attr(:group, :any)
+
+  def group(assigns) do
+    ~H"""
+    <div class="alternatives-group bg-gray-100 dark:bg-neutral-800 dark:border-gray-700 border p-3 my-2">
+      <div class="d-flex flex-row align-items-center">
+        <div>
+          <b><%= @group.title %></b>
+        </div>
+        <div class="flex-grow-1"></div>
+        <.icon_button
+          :if={@editing_enabled}
+          class="mr-1"
+          icon="fa-solid fa-pencil"
+          on_click="show_edit_group_modal"
+          values={["phx-value-resource-id": @group.resource_id]}
+        />
+        <button
+          :if={@source == :alternatives}
+          class="btn btn-danger btn-sm mr-2"
+          phx-click="show_delete_group_modal"
+          phx-value-resource_id={@group.resource_id}
+        >
+          Delete
+        </button>
+      </div>
+      <div class="mt-3">
+        <%= if Enum.count(@group.content["options"]) > 0 do %>
+          <ul class="list-group">
+            <%= for option <- @group.content["options"] do %>
+              <.group_option group={@group} option={option} show_actions={@editing_enabled} />
+            <% end %>
+          </ul>
+        <% else %>
+          <div class="my-2">
+            <div class="text-center"><em>There are no options in this group</em></div>
+          </div>
+        <% end %>
+        <button
+          :if={@editing_enabled}
+          class="btn btn-link btn-sm my-2"
+          phx-click="show_create_option_modal"
+          phx-value-resource_id={@group.resource_id}
+        >
+          <i class="fa fa-plus"></i> New Option
+        </button>
+      </div>
+    </div>
+    """
+  end
+
+  def handle_event("show_create_experiment", _, socket) do
+    changeset =
+      {%{}, %{name: :string}}
+      |> Ecto.Changeset.cast(%{}, [:name])
+
+    form_body_fn = fn assigns ->
+      ~H"""
+      <div class="form-group">
+        <%= text_input(
+          @form,
+          :name,
+          class: "form-control my-2" <> error_class(@form, :name, "is-invalid"),
+          placeholder: "Enter the name of the experiment decision point from Upgrade",
+          phx_hook: "InputAutoSelect",
+          required: true
+        ) %>
+      </div>
+      """
+    end
+
+    modal_assigns = %{
+      id: "create_modal",
+      title: "Create Experiment Decision Point",
+      submit_label: "Create",
+      changeset: changeset,
+      form_body_fn: form_body_fn,
+      on_validate: "validate_group",
+      on_submit: "create_experiment"
+    }
+
+    modal = fn assigns ->
+      ~H"""
+      <FormModal.modal {@modal_assigns} />
+      """
+    end
+
+    {:noreply, show_modal(socket, modal, modal_assigns: modal_assigns)}
+  end
+
+  def handle_event("show_create_modal", _, socket) do
+    changeset =
+      {%{}, %{name: :string}}
+      |> Ecto.Changeset.cast(%{}, [:name])
+
+    form_body_fn = fn assigns ->
+      ~H"""
+      <div class="form-group">
+        <%= text_input(
+          @form,
+          :name,
+          class: "form-control my-2" <> error_class(@form, :name, "is-invalid"),
+          placeholder: "Enter a name for the alternative",
+          phx_hook: "InputAutoSelect",
+          required: true
+        ) %>
+      </div>
+      """
+    end
+
+    modal_assigns = %{
+      id: "create_modal",
+      title: "Create Alternative",
+      submit_label: "Create",
+      changeset: changeset,
+      form_body_fn: form_body_fn,
+      on_validate: "validate_group",
+      on_submit: "create_group"
+    }
+
+    modal = fn assigns ->
+      ~H"""
+      <FormModal.modal {@modal_assigns} />
+      """
+    end
+
+    {:noreply, show_modal(socket, modal, modal_assigns: modal_assigns)}
+  end
+
+  def handle_event("validate_group", %{"params" => %{"name" => _}}, socket) do
+    {:noreply, socket}
+  end
+
+  def handle_event("create_group", %{"params" => %{"name" => name}}, socket) do
+    %{project: project, author: author, alternatives: alternatives} = socket.assigns
+
+    {:ok, group} =
+      ResourceEditor.create(
+        project.slug,
+        author,
+        @alternatives_type_id,
+        %{title: name, content: %{"options" => [], "strategy" => "user_section_preference"}}
+      )
+
+    {:noreply, hide_modal(socket) |> assign(alternatives: [group | alternatives])}
+  end
+
+  def handle_event("show_create_option_modal", %{"resource_id" => resource_id}, socket) do
+    changeset =
+      {%{id: uuid(), resource_id: resource_id}, %{id: :string, resource_id: :int, name: :string}}
+      |> Ecto.Changeset.cast(%{}, [:id, :resource_id, :name])
+
+    form_body_fn = fn assigns ->
+      ~H"""
+      <div class="form-group">
+        <%= hidden_input(@form, :id) %>
+        <%= hidden_input(@form, :resource_id) %>
+
+        <%= text_input(
+          @form,
+          :name,
+          class: "form-control my-2" <> error_class(@form, :name, "is-invalid"),
+          placeholder: "Enter a name",
+          phx_hook: "InputAutoSelect",
+          required: true
+        ) %>
+      </div>
+      """
+    end
+
+    modal_assigns = %{
+      id: "create_modal",
+      title: "Create Option",
+      submit_label: "Create",
+      changeset: changeset,
+      form_body_fn: form_body_fn,
+      on_validate: "validate_option",
+      on_submit: "create_option"
+    }
+
+    modal = fn assigns ->
+      ~H"""
+      <FormModal.modal {@modal_assigns} />
+      """
+    end
+
+    {:noreply, show_modal(socket, modal, modal_assigns: modal_assigns)}
+  end
+
+  def handle_event("validate_option", %{"params" => %{"name" => _}}, socket) do
+    {:noreply, socket}
+  end
+
+  def handle_event(
+        "create_option",
+        %{"params" => %{"id" => option_id, "name" => name, "resource_id" => resource_id}},
+        socket
+      ) do
+    %{project: project, author: author, alternatives: alternatives} = socket.assigns
+    resource_id = ensure_integer(resource_id)
+
+    %{content: %{"options" => options} = content} =
+      Enum.find(alternatives, fn g -> g.resource_id == resource_id end)
+
+    new_options = [%{"id" => option_id, "name" => name} | options]
+
+    case edit_group_options(
+           project.slug,
+           author,
+           alternatives,
+           resource_id,
+           content,
+           new_options
+         ) do
+      {:ok, alternatives, _group} ->
+        {:noreply, hide_modal(socket) |> assign(alternatives: alternatives)}
+
+      _ ->
+        show_error(socket)
+    end
+  end
+
+  def handle_event(
+        "show_delete_group_modal",
+        %{"resource_id" => resource_id},
+        socket
+      ) do
+    %{project: project, alternatives: alternatives} = socket.assigns
+    resource_id = ensure_integer(resource_id)
+
+    publication_id = Publishing.get_unpublished_publication_id!(project.id)
+
+    case Publishing.find_alternatives_group_references_in_pages(resource_id, publication_id) do
+      [] ->
+        preview_fn = fn assigns ->
+          ~H"""
+          <div class="text-center mt-3"><b><%= @group.title %></b></div>
+          """
+        end
+
+        modal_assigns = %{
+          id: "delete_modal",
+          title: "Delete Group",
+          message: "Are you sure you want to delete this alternatives group?",
+          preview_fn: preview_fn,
+          group: find_group(alternatives, resource_id),
+          on_delete: "delete_group",
+          phx_values: ["phx-value-resource-id": resource_id]
+        }
+
+        modal = fn assigns ->
+          ~H"""
+          <DeleteModal.modal {@modal_assigns} />
+          """
+        end
+
+        {:noreply, show_modal(socket, modal, modal_assigns: modal_assigns)}
+
+      references ->
+        modal_assigns = %{
+          id: "prevent_deletion_modal",
+          references: references,
+          project_slug: project.slug
+        }
+
+        modal = fn assigns ->
+          ~H"""
+          <PreventDeletionModal.modal {@modal_assigns} />
+          """
+        end
+
+        {:noreply, show_modal(socket, modal, modal_assigns: modal_assigns)}
+    end
+  end
+
+  def handle_event("delete_group", %{"resource-id" => resource_id}, socket) do
+    %{project: project, author: author, alternatives: alternatives} = socket.assigns
+
+    {:ok, deleted} = ResourceEditor.delete(project.slug, resource_id, author)
+
+    alternatives = Enum.filter(alternatives, fn r -> r.resource_id != deleted.resource_id end)
+
+    {:noreply,
+     socket
+     |> hide_modal()
+     |> assign(alternatives: alternatives)}
+  end
+
+  def handle_event(
+        "show_edit_group_modal",
+        %{"resource-id" => resource_id},
+        socket
+      ) do
+    %{alternatives: alternatives} = socket.assigns
+
+    resource_id = ensure_integer(resource_id)
+    group = find_group(alternatives, resource_id)
+
+    # {%{resource_id: resource_id}, %{id: :string, resource_id: :int, title: :string}}
+    # |> Ecto.Changeset.cast(group, [:id, :resource_id, :title])
+    changeset = Revision.changeset(group)
+
+    form_body_fn = fn assigns ->
+      ~H"""
+      <div class="form-group">
+        <%= hidden_input(@form, :id) %>
+        <%= hidden_input(@form, :resource_id) %>
+
+        <%= text_input(
+          @form,
+          :title,
+          class: "form-control my-2" <> error_class(@form, :name, "is-invalid"),
+          placeholder: "Enter a title",
+          phx_hook: "InputAutoSelect",
+          required: true
+        ) %>
+      </div>
+      """
+    end
+
+    modal_assigns = %{
+      id: "edit_modal",
+      title: "Edit",
+      submit_label: "Save",
+      changeset: changeset,
+      form_body_fn: form_body_fn,
+      on_validate: "validate_group",
+      on_submit: "edit_group"
+    }
+
+    modal = fn assigns ->
+      ~H"""
+      <FormModal.modal {@modal_assigns} />
+      """
+    end
+
+    {:noreply, show_modal(socket, modal, modal_assigns: modal_assigns)}
+  end
+
+  def handle_event("validate_group", %{"params" => %{"title" => _}}, socket) do
+    {:noreply, socket}
+  end
+
+  def handle_event(
+        "edit_group",
+        %{"params" => %{"resource_id" => resource_id, "title" => title}},
+        socket
+      ) do
+    %{project: project, author: author, alternatives: alternatives} = socket.assigns
+    resource_id = ensure_integer(resource_id)
+
+    case edit_group_title(
+           project.slug,
+           author,
+           alternatives,
+           resource_id,
+           title
+         ) do
+      {:ok, alternatives, _group} ->
+        {:noreply, hide_modal(socket) |> assign(alternatives: alternatives)}
+
+      {:error, _} ->
+        show_error(socket)
+    end
+  end
+
+  def handle_event(
+        "show_edit_option_modal",
+        %{"resource-id" => resource_id, "option-id" => option_id},
+        socket
+      ) do
+    %{alternatives: alternatives} = socket.assigns
+
+    resource_id = ensure_integer(resource_id)
+    option = find_group_option(alternatives, resource_id, option_id)
+
+    changeset =
+      {%{resource_id: resource_id}, %{id: :string, resource_id: :int, name: :string}}
+      |> Ecto.Changeset.cast(option, [:id, :resource_id, :name])
+
+    form_body_fn = fn assigns ->
+      ~H"""
+      <div class="form-group">
+        <%= hidden_input(@form, :id) %>
+        <%= hidden_input(@form, :resource_id) %>
+
+        <%= text_input(
+          @form,
+          :name,
+          class: "form-control my-2" <> error_class(@form, :name, "is-invalid"),
+          placeholder: "Enter a name",
+          phx_hook: "InputAutoSelect",
+          required: true
+        ) %>
+      </div>
+      """
+    end
+
+    modal_assigns = %{
+      id: "edit_modal",
+      title: "Edit Option",
+      submit_label: "Save",
+      changeset: changeset,
+      form_body_fn: form_body_fn,
+      on_validate: "validate_option",
+      on_submit: "edit_option"
+    }
+
+    modal = fn assigns ->
+      ~H"""
+      <FormModal.modal {@modal_assigns} />
+      """
+    end
+
+    {:noreply, show_modal(socket, modal, modal_assigns: modal_assigns)}
+  end
+
+  def handle_event(
+        "edit_option",
+        %{"params" => %{"resource_id" => resource_id, "id" => option_id, "name" => name}},
+        socket
+      ) do
+    %{project: project, author: author, alternatives: alternatives} = socket.assigns
+    resource_id = ensure_integer(resource_id)
+
+    %{content: %{"options" => options} = content} =
+      Enum.find(alternatives, fn g -> g.resource_id == resource_id end)
+
+    # new_options = Enum.filter(options, fn o -> o["id"] != option_id end)
+    updated_options =
+      Enum.map(options, fn o ->
+        if o["id"] == option_id do
+          %{o | "name" => name}
+        else
+          o
+        end
+      end)
+
+    case edit_group_options(
+           project.slug,
+           author,
+           alternatives,
+           resource_id,
+           content,
+           updated_options
+         ) do
+      {:ok, alternatives, _group} ->
+        {:noreply, hide_modal(socket) |> assign(alternatives: alternatives)}
+
+      {:error, _} ->
+        show_error(socket)
+    end
+  end
+
+  def handle_event(
+        "show_delete_option_modal",
+        %{"resource-id" => resource_id, "option-id" => option_id},
+        socket
+      ) do
+    %{alternatives: alternatives} = socket.assigns
+
+    resource_id = ensure_integer(resource_id)
+    option = find_group_option(alternatives, resource_id, option_id)
+
+    preview_fn = fn assigns ->
+      ~H"""
+      <ul class="list-group">
+        <.group_option group={@group} option={@option} show_actions={false} />
+      </ul>
+      """
+    end
+
+    modal_assigns = %{
+      id: "delete_modal",
+      title: "Delete Option",
+      message: "Are you sure you want to delete this option?",
+      preview_fn: preview_fn,
+      group: find_group(alternatives, resource_id),
+      option: option,
+      on_delete: "delete_option",
+      phx_values: ["phx-value-resource-id": resource_id, "phx-value-option-id": option_id]
+    }
+
+    modal = fn assigns ->
+      ~H"""
+      <DeleteModal.modal {@modal_assigns} />
+      """
+    end
+
+    {:noreply, show_modal(socket, modal, modal_assigns: modal_assigns)}
+  end
+
+  def handle_event(
+        "delete_option",
+        %{"resource-id" => resource_id, "option-id" => option_id},
+        socket
+      ) do
+    %{project: project, author: author, alternatives: alternatives} = socket.assigns
+    resource_id = ensure_integer(resource_id)
+
+    %{content: %{"options" => options} = content} =
+      Enum.find(alternatives, fn g -> g.resource_id == resource_id end)
+
+    new_options = Enum.filter(options, fn o -> o["id"] != option_id end)
+
+    case edit_group_options(
+           project.slug,
+           author,
+           alternatives,
+           resource_id,
+           content,
+           new_options
+         ) do
+      {:ok, alternatives, _group} ->
+        {:noreply, hide_modal(socket) |> assign(alternatives: alternatives)}
+
+      {:error, _} ->
+        show_error(socket)
+    end
+  end
+
+  def handle_event("cancel_modal", _, socket) do
+    {:noreply, hide_modal(socket)}
+  end
+
+  @impl Phoenix.LiveView
+  def terminate(_reason, socket) do
+    %{project: project, subscriptions: subscriptions} = socket.assigns
+
+    unsubscribe(subscriptions, project.slug)
+  end
+
+  # spin up subscriptions for the alternatives resources
+  defp subscribe(alternatives, project_slug) do
+    ids = Enum.map(alternatives, fn p -> p.resource_id end)
+    Enum.each(ids, &Subscriber.subscribe_to_new_revisions_in_project(&1, project_slug))
+
+    Subscriber.subscribe_to_new_resources_of_type(
+      @alternatives_type_id,
+      project_slug
+    )
+
+    ids
+  end
+
+  # release a collection of subscriptions
+  defp unsubscribe(ids, project_slug) do
+    Subscriber.unsubscribe_to_new_resources_of_type(
+      @alternatives_type_id,
+      project_slug
+    )
+
+    Enum.each(ids, &Subscriber.unsubscribe_to_new_revisions_in_project(&1, project_slug))
+  end
+
+  defp edit_group_title(
+         project_slug,
+         author,
+         alternatives,
+         resource_id,
+         title
+       ) do
+    case ResourceEditor.edit(project_slug, resource_id, author, %{
+           title: title
+         }) do
+      {:ok, updated_group} ->
+        # update groups list to reflect latest update
+        alternatives =
+          Enum.map(alternatives, fn g ->
+            if g.resource_id == updated_group.resource_id do
+              updated_group
+            else
+              g
+            end
+          end)
+
+        {:ok, alternatives, updated_group}
+
+      error ->
+        error
+    end
+  end
+
+  defp edit_group_options(
+         project_slug,
+         author,
+         alternatives,
+         resource_id,
+         content,
+         updated_options
+       ) do
+    case ResourceEditor.edit(project_slug, resource_id, author, %{
+           content: %{content | "options" => updated_options}
+         }) do
+      {:ok, updated_group} ->
+        # update groups list to reflect latest update
+        alternatives =
+          Enum.map(alternatives, fn g ->
+            if g.resource_id == updated_group.resource_id do
+              updated_group
+            else
+              g
+            end
+          end)
+
+        {:ok, alternatives, updated_group}
+
+      error ->
+        error
+    end
+  end
+
+  defp find_group(
+         alternatives,
+         resource_id
+       ) do
+    Enum.find(alternatives, fn g ->
+      g.resource_id == resource_id
+    end)
+  end
+
+  defp find_group_option(
+         alternatives,
+         resource_id,
+         option_id
+       ) do
+    Enum.find_value(alternatives, fn g ->
+      if g.resource_id == resource_id do
+        Enum.find(g.content["options"], fn o -> o["id"] === option_id end)
+      else
+        nil
+      end
+    end)
+  end
+
+  defp ensure_integer(i) when is_integer(i), do: i
+
+  defp ensure_integer(s) when is_binary(s) do
+    case Integer.parse(s) do
+      {i, _rem} -> i
+      _ -> throw("Invalid integer")
+    end
+  end
+
+  defp show_error(socket) do
+    {:noreply,
+     put_flash(socket, :error, "Something went wrong. Please refresh the page and try again.")}
+  end
+end

--- a/lib/oli_web/live/workspaces/course_author/analytics_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/analytics_live.ex
@@ -1,0 +1,344 @@
+defmodule OliWeb.Workspaces.CourseAuthor.AnalyticsLive do
+  @moduledoc """
+  LiveView implementation of datashop analytics view.
+  """
+
+  use OliWeb, :live_view
+  use OliWeb.Common.Modal
+
+  import OliWeb.Common.Params
+  import OliWeb.DelegatedEvents
+
+  alias Oli.Authoring.Broadcaster.Subscriber
+  alias Oli.Authoring.{Broadcaster, Course}
+  alias Oli.Delivery.Sections.{Browse, BrowseOptions}
+  alias Oli.Repo.{Paging, Sorting}
+  alias OliWeb.Common.{PagedTable, SessionContext, TextSearch}
+  alias OliWeb.Common.Table.SortableTableModel
+  alias OliWeb.Components.Modal
+  alias OliWeb.Components.Project.AsyncExporter
+  alias OliWeb.Router.Helpers, as: Routes
+  alias OliWeb.Workspaces.CourseAuthor.Datashop.SectionsTableModel
+  alias Phoenix.LiveView.JS
+
+  @limit 25
+
+  on_mount(OliWeb.LiveSessionPlugs.SetProject)
+
+  def mount(_params, session, socket) do
+    ctx = SessionContext.init(socket, session)
+    project = socket.assigns.project
+    selected_sections = MapSet.new([])
+
+    ## Setup table data
+    # Sections whose base project is the current project
+    sections =
+      Browse.browse_sections(
+        %Paging{offset: 0, limit: @limit},
+        %Sorting{direction: :asc, field: :title},
+        %BrowseOptions{
+          project_id: project.id,
+          blueprint_id: nil,
+          text_search: nil,
+          active_today: false,
+          filter_status: :active,
+          filter_type: nil,
+          institution_id: nil
+        }
+      )
+
+    {:ok, table_model} = SectionsTableModel.new(ctx, sections, selected_sections)
+
+    total_count = determine_total(sections)
+
+    ## Setup Datashop export status and Pub/Sub subscription
+    {datashop_export_status, datashop_export_url, datashop_export_timestamp} =
+      case Course.datashop_export_status(project) do
+        {:available, url, timestamp} -> {:available, url, timestamp}
+        {:expired, _, _} -> {:expired, nil, nil}
+        {status} -> {status, nil, nil}
+      end
+
+    # Subscribe to any raw analytics snapshot progress updates for this project
+    Subscriber.subscribe_to_datashop_export_status(project.slug)
+    Subscriber.subscribe_to_datashop_export_batch_started(project.slug)
+
+    socket =
+      assign(socket,
+        ctx: ctx,
+        title: "Datashop Analytics | " <> project.title,
+        table_model: table_model,
+        total_count: total_count,
+        datashop_export_status: datashop_export_status,
+        datashop_export_url: datashop_export_url,
+        datashop_export_timestamp: datashop_export_timestamp,
+        datashop_export_current_batch: nil,
+        datashop_export_batch_count: nil,
+        selected_sections: selected_sections,
+        active_workspace: :course_author,
+        active_view: :overview,
+        resource_title: project.title,
+        resource_slug: project.slug
+      )
+
+    {:ok, socket}
+  end
+
+  defp determine_total(sections) do
+    case(sections) do
+      [] -> 0
+      [hd | _] -> hd.total_count
+    end
+  end
+
+  def handle_params(params, _, socket) do
+    table_model =
+      SortableTableModel.update_from_params(
+        socket.assigns.table_model,
+        params
+      )
+
+    offset = get_int_param(params, "offset", 0)
+    text_search = get_param(params, "text_search", "")
+    project = socket.assigns.project
+
+    sections =
+      Browse.browse_sections(
+        %Paging{offset: offset, limit: @limit},
+        %Sorting{direction: table_model.sort_order, field: table_model.sort_by_spec.name},
+        %BrowseOptions{
+          project_id: project.id,
+          blueprint_id: nil,
+          text_search: text_search,
+          active_today: false,
+          filter_status: :active,
+          filter_type: nil,
+          institution_id: nil
+        }
+      )
+
+    displayed_sections = Enum.map(sections, & &1.id)
+
+    selected_sections =
+      MapSet.filter(socket.assigns.selected_sections, fn s -> s in displayed_sections end)
+
+    table_model =
+      table_model
+      |> Map.put(:rows, sections)
+      |> Map.update!(:data, fn data ->
+        %{data | selected_sections: selected_sections}
+      end)
+
+    total_count = determine_total(sections)
+
+    {:noreply,
+     assign(socket,
+       offset: offset,
+       table_model: table_model,
+       total_count: total_count,
+       text_search: text_search,
+       selected_sections: selected_sections
+     )}
+  end
+
+  attr(:title, :string, default: "Datashop Analytics")
+
+  attr(:tabel_model, :map)
+  attr(:total_count, :integer, default: 0)
+  attr(:offset, :integer, default: 0)
+  attr(:limit, :integer, default: @limit)
+  attr(:text_search, :string, default: "")
+  attr(:selected_sections, :map, default: MapSet.new([]))
+
+  def render(assigns) do
+    ~H"""
+    <Modal.modal
+      id="generate_datashop_export_modal"
+      class="w-1/2"
+      on_confirm={
+        JS.push("generate_datashop_snapshot")
+        |> Modal.hide_modal("generate_datashop_export_modal")
+      }
+    >
+      <:title>Generate Datashop Export</:title>
+      <div class="flex flex-col items-center justify-center text-center p-4">
+        <div class="text-xl">
+          Are you sure you want to generate a Datashop export?
+        </div>
+      </div>
+
+      <:confirm>Confirm</:confirm>
+    </Modal.modal>
+    <div class="container mx-auto p-8">
+      <div class="container mb-4">
+        <div class="flex justify-between items-center">
+          <div class="flex-grow">
+            <TextSearch.render
+              id="text-search"
+              reset="text_search_reset"
+              change="text_search_change"
+              text={@text_search}
+              event_target={nil}
+            />
+          </div>
+
+          <AsyncExporter.datashop
+            ctx={@ctx}
+            on_generate_datashop_snapshot={Modal.show_modal("generate_datashop_export_modal")}
+            on_kill="kill_datashop_snapshot"
+            datashop_export_status={@datashop_export_status}
+            datashop_export_url={@datashop_export_url}
+            datashop_export_timestamp={@datashop_export_timestamp}
+            datashop_export_current_batch={@datashop_export_current_batch}
+            datashop_export_batch_count={@datashop_export_batch_count}
+            disabled={Enum.empty?(@selected_sections)}
+          />
+        </div>
+      </div>
+
+      <div class="grid grid-cols-12">
+        <div id="projects-table" class="col-span-12">
+          <PagedTable.render
+            page_change="paged_table_page_change"
+            sort="paged_table_sort"
+            total_count={@total_count}
+            filter={@text_search}
+            limit={@limit}
+            offset={@offset}
+            table_model={@table_model}
+          />
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  def patch_with(socket, changes) do
+    {:noreply,
+     push_patch(socket,
+       to:
+         Routes.live_path(
+           socket,
+           OliWeb.Workspaces.CourseAuthor.AnalyticsLive,
+           socket.assigns.project.slug,
+           Map.merge(
+             %{
+               sort_by: socket.assigns.table_model.sort_by_spec.name,
+               sort_order: socket.assigns.table_model.sort_order,
+               offset: socket.assigns.offset,
+               text_search: socket.assigns.text_search
+             },
+             changes
+           )
+         ),
+       replace: true
+     )}
+  end
+
+  def handle_event("toggle_section", %{"section_id" => section_id} = params, socket) do
+    toggle_fn =
+      case params["value"] do
+        "on" -> &MapSet.put/2
+        _ -> &MapSet.delete/2
+      end
+
+    selected_sections = toggle_fn.(socket.assigns.selected_sections, section_id)
+
+    data = %{socket.assigns.table_model.data | selected_sections: selected_sections}
+    table_model = Map.put(socket.assigns.table_model, :data, data)
+
+    {:noreply, assign(socket, table_model: table_model, selected_sections: selected_sections)}
+  end
+
+  def handle_event("generate_datashop_snapshot", _params, socket) do
+    project = socket.assigns.project
+
+    selected_sections = MapSet.to_list(socket.assigns.selected_sections)
+
+    case Course.generate_datashop_snapshot(project, selected_sections) do
+      {:ok, _job} ->
+        Broadcaster.broadcast_datashop_export_status(project.slug, {:in_progress})
+
+        {:noreply, socket}
+
+      {:error, _changeset} ->
+        socket =
+          socket
+          |> put_flash(:error, "Datashop snapshot could not be generated.")
+
+        {:noreply, socket}
+    end
+  end
+
+  def handle_event("kill_datashop_snapshot", _params, socket) do
+    Course.kill_datashop_export(socket.assigns.project.slug, "datashop_export")
+    Broadcaster.broadcast_datashop_export_status(socket.assigns.project.slug, {:not_available})
+
+    socket =
+      socket
+      |> put_flash(:info, "Snapshots killed")
+
+    {:noreply, socket}
+  end
+
+  def handle_event(event, params, socket) do
+    {event, params, socket, &__MODULE__.patch_with/2}
+    |> delegate_to([
+      &TextSearch.handle_delegated/4,
+      &PagedTable.handle_delegated/4
+    ])
+  end
+
+  def handle_info(
+        {:datashop_export_status, {:available, datashop_export_url, datashop_export_timestamp}},
+        socket
+      ) do
+    socket =
+      socket
+      |> assign(
+        datashop_export_status: :available,
+        datashop_export_url: datashop_export_url,
+        datashop_export_timestamp: datashop_export_timestamp
+      )
+      |> maybe_reset_current_batch(:available)
+
+    {:noreply, socket}
+  end
+
+  def handle_info(
+        {:datashop_export_status, {:error, _e}},
+        socket
+      ) do
+    socket =
+      socket
+      |> assign(datashop_export_status: :error)
+      |> maybe_reset_current_batch(:error)
+
+    {:noreply, socket}
+  end
+
+  def handle_info({:datashop_export_status, {status}}, socket) do
+    socket =
+      socket
+      |> assign(datashop_export_status: status)
+      |> maybe_reset_current_batch(status)
+
+    {:noreply, socket}
+  end
+
+  def handle_info(
+        {:datashop_export_batch_started, {:batch_started, current_batch, batch_count}},
+        socket
+      ) do
+    {:noreply,
+     assign(socket,
+       datashop_export_current_batch: current_batch,
+       datashop_export_batch_count: batch_count
+     )}
+  end
+
+  defp maybe_reset_current_batch(socket, :in_progress), do: socket
+
+  defp maybe_reset_current_batch(socket, _status),
+    do: assign(socket, datashop_export_current_batch: nil, datashop_export_batch_count: nil)
+end

--- a/lib/oli_web/live/workspaces/course_author/analytics_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/analytics_live.ex
@@ -75,8 +75,6 @@ defmodule OliWeb.Workspaces.CourseAuthor.AnalyticsLive do
         datashop_export_current_batch: nil,
         datashop_export_batch_count: nil,
         selected_sections: selected_sections,
-        active_workspace: :course_author,
-        active_view: :overview,
         resource_title: project.title,
         resource_slug: project.slug
       )

--- a/lib/oli_web/live/workspaces/course_author/datashop/table_model.ex
+++ b/lib/oli_web/live/workspaces/course_author/datashop/table_model.ex
@@ -1,0 +1,172 @@
+defmodule OliWeb.Workspaces.CourseAuthor.Datashop.SectionsTableModel do
+  use Phoenix.Component
+
+  alias OliWeb.Common.SessionContext
+  alias OliWeb.Common.Table.{ColumnSpec, Common, SortableTableModel}
+  alias OliWeb.Router.Helpers, as: Routes
+  alias Phoenix.LiveView.JS
+
+  def new(%SessionContext{} = ctx, sections, selected_sections, max_checked \\ 5) do
+    SortableTableModel.new(
+      rows: sections,
+      column_specs: [
+        %ColumnSpec{
+          name: :title,
+          label: "Title",
+          render_fn: &custom_render/3
+        },
+        %ColumnSpec{
+          name: :type,
+          label: "Type",
+          render_fn: &custom_render/3
+        },
+        %ColumnSpec{
+          name: :enrollments_count,
+          label: "# Enrolled"
+        },
+        %ColumnSpec{
+          name: :requires_payment,
+          label: "Cost",
+          render_fn: &custom_render/3
+        },
+        %ColumnSpec{
+          name: :start_date,
+          label: "Start",
+          render_fn: &Common.render_date/3,
+          sort_fn: &Common.sort_date/2
+        },
+        %ColumnSpec{
+          name: :end_date,
+          label: "End",
+          render_fn: &Common.render_date/3,
+          sort_fn: &Common.sort_date/2
+        },
+        %ColumnSpec{
+          name: :status,
+          label: "Status",
+          render_fn: &custom_render/3
+        },
+        %ColumnSpec{
+          name: :instructor,
+          label: "Instructors",
+          render_fn: &custom_render/3
+        },
+        %ColumnSpec{
+          name: :institution,
+          label: "Institution",
+          render_fn: &custom_render/3
+        },
+        %ColumnSpec{
+          name: :blueprint,
+          label: "Product",
+          render_fn: &custom_render/3,
+          sortable: false
+        },
+        %ColumnSpec{
+          name: :select,
+          label: "Select",
+          td_class: "hover:cursor-auto",
+          render_fn: &custom_render/3,
+          sortable: false
+        }
+      ],
+      event_suffix: "",
+      id_field: [:id],
+      data: %{
+        ctx: ctx,
+        fade_data: true,
+        selected_sections: selected_sections,
+        max_checked: max_checked
+      }
+    )
+  end
+
+  def custom_render(assigns, section, %ColumnSpec{name: :select}) do
+    assigns =
+      Map.merge(assigns, %{
+        section: section,
+        checked: MapSet.member?(assigns.selected_sections, section.id)
+      })
+
+    ~H"""
+    <div class="form-check flex justify-center items-center">
+      <input
+        id={"select-section-#{@section.id}"}
+        type="checkbox"
+        class="form-check-input hover:cursor-pointer"
+        checked={@checked}
+        phx-click={JS.push("toggle_section", value: %{section_id: @section.id})}
+        disabled={!@checked and MapSet.size(@selected_sections) >= @max_checked}
+      />
+    </div>
+    """
+  end
+
+  def custom_render(assigns, section, %ColumnSpec{name: :title}) do
+    assigns = Map.merge(assigns, %{section: section})
+
+    ~H"""
+    <a href={
+      Routes.live_path(
+        OliWeb.Endpoint,
+        OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive,
+        @section.slug,
+        :manage
+      )
+    }>
+      <%= @section.title %>
+    </a>
+    """
+  end
+
+  def custom_render(_assigns, section, %ColumnSpec{name: :type}),
+    do: if(section.open_and_free, do: "Open", else: "LMS")
+
+  def custom_render(assigns, section, %ColumnSpec{name: :blueprint}) do
+    product = if section.blueprint, do: section.blueprint.title, else: ""
+    assigns = Map.merge(assigns, %{product: product})
+
+    ~H"""
+    <div class="flex space-x-2 items-center">
+      <div>
+        <%= @product %>
+      </div>
+    </div>
+    """
+  end
+
+  def custom_render(_assigns, section, %ColumnSpec{name: :requires_payment}) do
+    if section.requires_payment do
+      case Money.to_string(section.amount) do
+        {:ok, m} -> m
+        _ -> "Yes"
+      end
+    else
+      "None"
+    end
+  end
+
+  def custom_render(assigns, section, %ColumnSpec{name: :institution}) do
+    assigns = Map.merge(assigns, %{section: section})
+
+    ~H"""
+    <div class="flex space-x-2 items-center">
+      <div>
+        <%= @section.institution && @section.institution.name %>
+      </div>
+    </div>
+    """
+  end
+
+  def custom_render(_assigns, section, %ColumnSpec{name: :status}),
+    do: Phoenix.Naming.humanize(section.status)
+
+  def custom_render(_assigns, section, %ColumnSpec{name: :instructor}),
+    do: Map.get(section, :instructor_name, "")
+
+  def render(assigns) do
+    ~H"""
+    <div>nothing</div>
+    """
+  end
+end

--- a/lib/oli_web/live/workspaces/course_author/index_csv_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/index_csv_live.ex
@@ -1,0 +1,88 @@
+defmodule OliWeb.Workspaces.CourseAuthor.IndexCsvLive do
+  use OliWeb, :live_view
+
+  @impl Phoenix.LiveView
+  def mount(_params, _session, socket) do
+    project = socket.assigns.project
+
+    {:ok,
+     assign(socket,
+       resource_slug: project.slug,
+       resource_title: project.title,
+       active_workspace: :course_author,
+       active_view: :overview
+     )
+     |> allow_upload(:csv, accept: ~w(.csv))}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_params(_params, _url, socket) do
+    {:noreply, socket}
+  end
+
+  @impl Phoenix.LiveView
+  def render(assigns) do
+    ~H"""
+    <div class="container mx-auto p-8">
+      <h3 class="display-6">CSV Import</h3>
+      <p class="lead">Upload a <code>.csv</code> file to inject data into existing project.</p>
+      <hr class="my-4" />
+
+      <.form for={%{}} phx-submit="upload_csv" phx-change="validate_upload" multipart>
+        <div class="form-group">
+          <label>Select a CSV file</label>
+          <.live_file_input upload={@uploads.csv} class="form-control" />
+        </div>
+        <div class="form-group">
+          <div><button type="submit" class="btn btn-primary">Import</button></div>
+        </div>
+      </.form>
+
+      <hr class="my-4" />
+
+      <div>
+        <.link class="btn btn-link px-0" href={~p"/admin/#{@project.slug}/import/download"}>
+          Download
+        </.link>
+        a <code>.csv</code>
+        file for this project with all pages and containers and current values for nextgen attrs
+      </div>
+    </div>
+    """
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("validate_upload", _params, socket) do
+    {:noreply, socket}
+  end
+
+  def handle_event("upload_csv", _params, socket) do
+    %{current_author: author, project: project} = socket.assigns
+
+    uploaded_files =
+      consume_uploaded_entries(socket, :csv, fn %{path: path}, entry ->
+        unless File.exists?("_imports") do
+          File.mkdir!("_imports")
+        end
+
+        File.cp(path, "_imports/#{author.id}-import.csv")
+
+        {:ok,
+         %{
+           "path" => path,
+           "content_type" => entry.client_type,
+           "filename" => entry.client_name
+         }}
+      end)
+
+    action =
+      if length(uploaded_files) > 0,
+        do: {:info, "File uploaded successfully"},
+        else: {:error, "A valid file must be attached"}
+
+    {:noreply,
+     socket
+     |> put_flash(elem(action, 0), elem(action, 1))
+     |> push_navigate(to: ~p"/workspaces/course_author/#{project.slug}/index_csv")}
+  end
+end

--- a/lib/oli_web/live/workspaces/course_author/index_csv_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/index_csv_live.ex
@@ -8,9 +8,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.IndexCsvLive do
     {:ok,
      assign(socket,
        resource_slug: project.slug,
-       resource_title: project.title,
-       active_workspace: :course_author,
-       active_view: :overview
+       resource_title: project.title
      )
      |> allow_upload(:csv, accept: ~w(.csv))}
   end

--- a/lib/oli_web/live/workspaces/course_author/overview_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/overview_live.ex
@@ -562,8 +562,8 @@ defmodule OliWeb.Workspaces.CourseAuthor.OverviewLive do
     case Course.update_project(project, %{status: :deleted}) do
       {:ok, _project} ->
         {:noreply,
-         push_navigate(socket,
-           to: Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.ProjectsLive)
+         redirect(socket,
+           to: ~p"/workspaces/course_author"
          )}
 
       {:error, %Ecto.Changeset{} = changeset} ->

--- a/lib/oli_web/live/workspaces/course_author/overview_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/overview_live.ex
@@ -4,30 +4,23 @@ defmodule OliWeb.Workspaces.CourseAuthor.OverviewLive do
   import Phoenix.Component
   import OliWeb.Components.Common
 
-  alias Oli.Accounts
-  alias Oli.Authoring.Course
-  alias Oli.Authoring.Course.Project
-  alias Oli.Inventories
-  alias Oli.Publishing
-  alias Oli.Activities
+  alias Oli.{Accounts, Activities, Inventories, Publishing}
+  alias Oli.Authoring.{Broadcaster, Course, ProjectExportWorker}
+  alias Oli.Authoring.Broadcaster.Subscriber
+  alias Oli.Authoring.Course.{CreativeCommons, Project}
+  alias Oli.Delivery.Experiments
+  alias Oli.LanguageCodesIso639
   alias Oli.Publishing.AuthoringResolver
   alias Oli.Resources.Collaboration
-  alias Oli.Authoring.Broadcaster
-  alias Oli.Authoring.Broadcaster.Subscriber
-  alias Oli.Authoring.ProjectExportWorker
-  alias OliWeb.Common.Breadcrumb
-  alias OliWeb.Components.Overview
-  alias OliWeb.Projects.{RequiredSurvey, TransferPaymentCodes}
-  alias OliWeb.Common.SessionContext
-  alias OliWeb.Components.Common
+  alias OliWeb.Common.Utils
+  alias OliWeb.Components.{Common, Overview}
   alias OliWeb.Components.Project.AsyncExporter
+  alias OliWeb.Projects.{RequiredSurvey, TransferPaymentCodes}
 
   @impl Phoenix.LiveView
-  def mount(_params, session, socket) do
-    ctx = SessionContext.init(socket, session)
-    project = socket.assigns.project
+  def mount(_params, _session, socket) do
+    %{project: project, current_author: author, ctx: ctx} = socket.assigns
 
-    author = socket.assigns[:current_author]
     is_admin? = Accounts.has_admin_role?(author)
 
     latest_published_publication =
@@ -38,7 +31,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.OverviewLive do
     latest_publication = Publishing.get_latest_published_publication_by_slug(project.slug)
 
     cc_options =
-      Oli.Authoring.Course.CreativeCommons.cc_options()
+      CreativeCommons.cc_options()
       |> Enum.map(fn {k, v} -> {v.text, k} end)
       |> Enum.sort(:desc)
 
@@ -51,39 +44,35 @@ defmodule OliWeb.Workspaces.CourseAuthor.OverviewLive do
     # Subscribe to any project export progress updates for this project
     Subscriber.subscribe_to_project_export_status(project.slug)
 
-    socket =
-      assign(socket,
-        ctx: ctx,
-        breadcrumbs: [Breadcrumb.new(%{full_title: "Project Overview"})],
-        active: :overview,
-        collaborators: Accounts.project_authors(project),
-        activities_enabled: Activities.advanced_activities(project, is_admin?),
-        can_enable_experiments: is_admin? and Oli.Delivery.Experiments.experiments_enabled?(),
-        is_admin: is_admin?,
-        changeset: Project.changeset(project),
-        latest_published_publication: latest_published_publication,
-        publishers: Inventories.list_publishers(),
-        resource_title: project.title,
-        resource_slug: project.slug,
-        attributes: project.attributes,
-        language_codes: Oli.LanguageCodesIso639.codes(),
-        license_opts: cc_options,
-        collab_space_config: collab_space_config,
-        revision_slug: revision_slug,
-        latest_publication: latest_publication,
-        notes_config: %{},
-        project_export_status: project_export_status,
-        project_export_url: project_export_url,
-        project_export_timestamp: project_export_timestamp
-      )
-
-    {:ok, socket}
+    {:ok,
+     assign(socket,
+       ctx: ctx,
+       collaborators: Accounts.project_authors(project),
+       activities_enabled: Activities.advanced_activities(project, is_admin?),
+       can_enable_experiments: is_admin? and Experiments.experiments_enabled?(),
+       is_admin: is_admin?,
+       changeset: Project.changeset(project),
+       latest_published_publication: latest_published_publication,
+       publishers: Inventories.list_publishers(),
+       resource_title: project.title,
+       resource_slug: project.slug,
+       attributes: project.attributes,
+       language_codes: LanguageCodesIso639.codes(),
+       license_opts: cc_options,
+       collab_space_config: collab_space_config,
+       revision_slug: revision_slug,
+       latest_publication: latest_publication,
+       notes_config: %{},
+       project_export_status: project_export_status,
+       project_export_url: project_export_url,
+       project_export_timestamp: project_export_timestamp
+     )}
   end
 
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
-    <div class="overview">
+    <div class="overview container mx-auto p-8">
       <.form :let={f} for={@changeset} phx-submit="update" phx-change="validate">
         <Overview.section
           title="Details"
@@ -142,7 +131,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.OverviewLive do
             <%= case @latest_published_publication do %>
               <% %{edition: edition, major: major, minor: minor} -> %>
                 <p class="text-secondary">
-                  <%= OliWeb.Common.Utils.render_version(edition, major, minor) %>
+                  <%= Utils.render_version(edition, major, minor) %>
                 </p>
               <% _ -> %>
                 <p class="text-secondary">This project has not been published</p>
@@ -171,20 +160,13 @@ defmodule OliWeb.Workspaces.CourseAuthor.OverviewLive do
               />
             </div>
 
-            <a
+            <.link
               :if={@project.has_experiments}
-              type="button"
               class="btn btn-link pl-0"
-              href={
-                Routes.live_path(
-                  OliWeb.Endpoint,
-                  OliWeb.Experiments.ExperimentsView,
-                  @project.slug
-                )
-              }
+              navigate={~p"/workspaces/course_author/#{@project.slug}/experiments"}
             >
               Manage Experiments
-            </a>
+            </.link>
           </div>
 
           <%= submit("Save", class: "btn btn-md btn-primary mt-2") %>
@@ -236,19 +218,9 @@ defmodule OliWeb.Workspaces.CourseAuthor.OverviewLive do
           </div>
           <div class="mt-5">
             <div>
-              <a
-                type="button"
-                class="btn btn-link pl-0"
-                href={
-                  Routes.live_path(
-                    OliWeb.Endpoint,
-                    OliWeb.Resources.AlternativesEditor,
-                    @project.slug
-                  )
-                }
-              >
+              <.link navigate={~p"/workspaces/course_author/#{@project.slug}/alternatives"}>
                 Manage Alternatives
-              </a>
+              </.link>
             </div>
             <small>
               Alternatives define the different flavors of content which can be authored. Students can then select which alternative they prefer to use.
@@ -384,19 +356,18 @@ defmodule OliWeb.Workspaces.CourseAuthor.OverviewLive do
 
       <Overview.section title="Actions" is_last={true}>
         <%= if @is_admin do %>
-          <div class="d-flex align-items-center">
-            <div>
-              <%= button("Bulk Resource Attribute Edit",
-                to: Routes.ingest_path(@socket, :index_csv, @project.slug),
-                method: :get,
-                class: "btn btn-link action-button"
-              ) %>
-            </div>
+          <div class="flex items-center">
+            <.link
+              class="btn btn-link action-button"
+              href={~p"/workspaces/course_author/#{@project.slug}/index_csv"}
+            >
+              Bulk Resource Attribute Edit
+            </.link>
             <span>Imports a <code>.csv</code> file to set new attributes.</span>
           </div>
         <% end %>
 
-        <div class="d-flex align-items-center">
+        <div class="flex items-center">
           <div>
             <%= button("Duplicate",
               to: Routes.project_path(@socket, :clone_project, @project),
@@ -408,7 +379,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.OverviewLive do
           <span>Create a complete copy of this project.</span>
         </div>
 
-        <div class="d-flex align-items-center">
+        <div class="flex items-center">
           <AsyncExporter.project_export
             ctx={@ctx}
             project_export_status={@project_export_status}
@@ -417,25 +388,27 @@ defmodule OliWeb.Workspaces.CourseAuthor.OverviewLive do
           />
         </div>
 
-        <div :if={@is_admin} class="d-flex align-items-center">
+        <div :if={@is_admin} class="flex items-center">
           <%= case @latest_publication do %>
             <% nil -> %>
-              <.button variant={:link} disabled>Datashop Analytics</.button>
+              <.button variant={:link} class="btn btn-link action-button !px-3" disabled>
+                Datashop Analytics
+              </.button>
               <span>
                 Project must be published to create a <.datashop_link /> snapshot for download
               </span>
             <% _pub -> %>
-              <.button
-                class="btn btn-link action-button !px-3"
-                href={~p"/project/#{@project.slug}/datashop"}
+              <.link
+                class="btn btn-link action-button"
+                navigate={~p"/workspaces/course_author/#{@project.slug}/datashop"}
               >
                 Datashop Analytics
-              </.button>
+              </.link>
               <span>Create a <.datashop_link /> snapshot for download</span>
           <% end %>
         </div>
 
-        <div class="d-flex align-items-center mt-8">
+        <div class="flex items-center mt-8">
           <button
             type="button"
             class="btn btn-link text-danger action-button"

--- a/lib/oli_web/live/workspaces/course_author/overview_table_model.ex
+++ b/lib/oli_web/live/workspaces/course_author/overview_table_model.ex
@@ -1,9 +1,9 @@
 defmodule OliWeb.Workspaces.CourseAuthor.OverviewTableModel do
   use Phoenix.Component
+  use OliWeb, :verified_routes
 
   alias OliWeb.Common.SessionContext
-  alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
-  alias OliWeb.Router.Helpers, as: Routes
+  alias OliWeb.Common.Table.{ColumnSpec, Common, SortableTableModel}
 
   def new(%SessionContext{} = ctx, sections) do
     column_specs = [
@@ -15,7 +15,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.OverviewTableModel do
       %ColumnSpec{
         name: :inserted_at,
         label: "Created",
-        render_fn: &OliWeb.Common.Table.Common.render_date/3
+        render_fn: &Common.render_date/3
       },
       %ColumnSpec{
         name: :name,
@@ -46,7 +46,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.OverviewTableModel do
     case name do
       :title ->
         ~H"""
-        <.link href={Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.OverviewLive, @project.slug)}>
+        <.link navigate={~p"/workspaces/course_author/#{@project.slug}/overview"}>
           <%= @project.title %>
         </.link>
         """

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -818,6 +818,9 @@ defmodule OliWeb.Router do
       scope "/course_author", CourseAuthor do
         live("/", IndexLive)
         live("/:project_id/overview", OverviewLive)
+        live("/:project_id/alternatives", AlternativesLive)
+        live("/:project_id/index_csv", IndexCsvLive)
+        live("/:project_id/datashop", AnalyticsLive)
         live("/:project_id/activity_bank", ActivityBankLive)
         live("/:project_id/objectives", ObjectivesLive)
         live("/:project_id/experiments", ExperimentsLive)

--- a/test/oli_web/live/workspaces/course_author/overview_live_test.exs
+++ b/test/oli_web/live/workspaces/course_author/overview_live_test.exs
@@ -220,7 +220,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.OverviewLiveTest do
       assert has_element?(view, "h4", "Course Discussions")
       assert has_element?(view, "h4", "Actions")
 
-      assert has_element?(view, "button", "Bulk Resource Attribute Edit")
+      assert has_element?(view, "a", "Bulk Resource Attribute Edit")
       assert has_element?(view, "label", "Calculate embeddings on publish")
     end
 
@@ -240,7 +240,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.OverviewLiveTest do
 
       assert has_element?(
                view,
-               "a[href=\"/project/#{project.slug}/datashop\"]",
+               "a[href=\"/workspaces/course_author/#{project.slug}/datashop\"]",
                "Datashop Analytics"
              )
     end

--- a/test/oli_web/live/workspaces/course_author/overview_live_test.exs
+++ b/test/oli_web/live/workspaces/course_author/overview_live_test.exs
@@ -1,0 +1,291 @@
+defmodule OliWeb.Workspaces.CourseAuthor.OverviewLiveTest do
+  use OliWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+  import Oli.Factory
+
+  alias Oli.Authoring.Course
+
+  defp live_view_route(project_slug, params \\ %{}),
+    do: ~p"/workspaces/course_author/#{project_slug}/overview?#{params}"
+
+  describe "author cannot access when is not logged in" do
+    test "redirects to new session when accessing the index view", %{conn: conn} do
+      {:error,
+       {:redirect,
+        %{
+          flash: %{},
+          to: "/workspaces/course_author"
+        }}} = live(conn, live_view_route("project-slug"))
+    end
+  end
+
+  describe "project overview as author" do
+    setup [:author_conn]
+
+    test "loads the project correctly", %{conn: conn, author: author} do
+      project = create_project_with_author(author)
+
+      {:ok, view, _html} = live(conn, live_view_route(project.slug))
+
+      assert has_element?(view, "h4", "Details")
+      assert has_element?(view, "h4", "Project Attributes")
+      assert has_element?(view, "h4", "Project Labels")
+      assert has_element?(view, "h4", "Collaborators")
+      assert has_element?(view, "h4", "Advanced Activities")
+      assert has_element?(view, "h4", "Allow Duplication")
+      assert has_element?(view, "h4", "Publishing Visibility")
+      assert has_element?(view, "h4", "Notes")
+      assert has_element?(view, "h4", "Course Discussions")
+      assert has_element?(view, "h4", "Transfer Payment Codes")
+      assert has_element?(view, "h4", "Actions")
+
+      refute has_element?(view, "button", "Bulk Resource Attribute Edit")
+      refute has_element?(view, "label", "Calculate embeddings on publish")
+    end
+
+    test "project gets deleted correctly", %{conn: conn, author: author} do
+      project = create_project_with_author(author)
+
+      {:ok, view, _html} = live(conn, live_view_route(project.slug))
+
+      element(view, "form[phx-submit=\"delete\"]")
+      |> render_submit()
+      |> follow_redirect(conn, "/workspaces/course_author")
+
+      assert Course.get_project_by_slug(project.slug).status == :deleted
+      {:ok, view, _html} = live(conn, ~p"/workspaces/course_author")
+      assert has_element?(view, "button#button-new-project")
+      refute has_element?(view, "a", project.title)
+    end
+
+    test "project gets updated correctly", %{conn: conn, author: author} do
+      project = create_project_with_author(author)
+
+      welcome_title = %{
+        "type" => "p",
+        "children" => [
+          %{
+            "id" => "2748906063",
+            "type" => "p",
+            "children" => [%{"text" => "Welcome Title"}]
+          }
+        ]
+      }
+
+      {:ok, view, _html} = live(conn, live_view_route(project.slug))
+
+      element(view, "form[phx-submit=\"update\"]")
+      |> render_submit(%{
+        "project" => %{
+          "title" => "updated title",
+          "description" => "updated description",
+          "welcome_title" => Poison.encode!(welcome_title),
+          "encouraging_subtitle" => "updated encouraging subtitle"
+        }
+      })
+
+      assert has_element?(view, "div.alert-info", "Project updated successfully.")
+      assert has_element?(view, "input[name=\"project[title]\"][value=\"updated title\"]")
+      assert has_element?(view, "textarea[name=\"project[description]\"]", "updated description")
+
+      assert has_element?(
+               view,
+               "textarea[name=\"project[encouraging_subtitle]\"]",
+               "updated encouraging subtitle"
+             )
+
+      view
+      |> render()
+      |> Floki.parse_fragment!()
+      |> Floki.find(~s{div[data-live-react-class="Components.RichTextEditor"]})
+      |> Floki.attribute("data-live-react-props")
+      |> hd() =~ "Welcome Title"
+    end
+
+    test "project gets validated correctly", %{conn: conn, author: author} do
+      project = create_project_with_author(author)
+
+      {:ok, view, _html} = live(conn, live_view_route(project.slug))
+
+      assert view
+             |> element("form[phx-change=\"validate\"]")
+             |> render_change(%{
+               "project" => %{
+                 "title" => nil
+               }
+             }) =~ "can&#39;t be blank"
+    end
+
+    test "project can enable required surveys", %{conn: conn, author: author} do
+      project = create_project_with_author(author)
+
+      {:ok, view, _html} = live(conn, live_view_route(project.slug))
+
+      refute has_element?(view, "input[name=\"survey\"][checked]")
+
+      element(view, "form[phx-change=\"set-required-survey\"]")
+      |> render_change(%{
+        survey: "on"
+      })
+
+      updated_project = Course.get_project!(project.id)
+      assert updated_project.required_survey_resource_id != nil
+      assert has_element?(view, "input[name=\"survey\"][checked]")
+      assert has_element?(view, "a", "Edit survey")
+    end
+
+    test "project can disable required surveys", %{conn: conn, author: author} do
+      project = create_project_with_author(author)
+      Course.create_project_survey(project, author.id)
+
+      {:ok, view, _html} = live(conn, live_view_route(project.slug))
+
+      assert has_element?(view, "input[name=\"survey\"][checked]")
+
+      element(view, "form[phx-change=\"set-required-survey\"]")
+      |> render_change(%{})
+
+      updated_project = Course.get_project!(project.id)
+      assert updated_project.required_survey_resource_id == nil
+      refute has_element?(view, "input[name=\"survey\"][checked]")
+      refute has_element?(view, "a", "Edit survey")
+    end
+
+    test "project can enable transfer payment codes", %{conn: conn, author: author} do
+      project = create_project_with_author(author)
+
+      {:ok, view, _html} = live(conn, live_view_route(project.slug))
+
+      refute project.allow_transfer_payment_codes
+
+      element(view, "form[phx-change=\"set_allow_transfer\"]")
+      |> render_change(%{})
+
+      assert Course.get_project!(project.id).allow_transfer_payment_codes
+    end
+
+    test "project can disable transfer payment codes", %{conn: conn, author: author} do
+      project = create_project_with_author(author)
+
+      {:ok, project} = Course.update_project(project, %{allow_transfer_payment_codes: true})
+
+      {:ok, view, _html} = live(conn, live_view_route(project.slug))
+
+      assert project.allow_transfer_payment_codes
+
+      element(view, "form[phx-change=\"set_allow_transfer\"]")
+      |> render_change(%{})
+
+      refute Course.get_project!(project.id).allow_transfer_payment_codes
+    end
+
+    test "does not display datashop analytics link when author is not admin", %{
+      conn: conn,
+      author: author
+    } do
+      project = create_project_with_author(author)
+
+      {:ok, view, _html} = live(conn, live_view_route(project.slug))
+
+      refute has_element?(
+               view,
+               "a[href=#{~p"/project/#{project.slug}/datashop"}]",
+               "Datashop Analytics"
+             )
+    end
+
+    defp create_project_with_author(author) do
+      %{project: project} = base_project_with_curriculum(nil)
+      insert(:author_project, project_id: project.id, author_id: author.id)
+      project
+    end
+  end
+
+  describe "project overview as admin" do
+    setup [:admin_conn]
+
+    test "loads the project correctly", %{conn: conn, admin: admin} do
+      project = create_project_with_author(admin)
+
+      {:ok, view, _html} = live(conn, live_view_route(project.slug))
+      assert has_element?(view, "h4", "Details")
+      assert has_element?(view, "h4", "Project Attributes")
+      assert has_element?(view, "h4", "Project Labels")
+      assert has_element?(view, "h4", "Collaborators")
+      assert has_element?(view, "h4", "Advanced Activities")
+      assert has_element?(view, "h4", "Allow Duplication")
+      assert has_element?(view, "h4", "Publishing Visibility")
+      assert has_element?(view, "h4", "Notes")
+      assert has_element?(view, "h4", "Course Discussions")
+      assert has_element?(view, "h4", "Actions")
+
+      assert has_element?(view, "button", "Bulk Resource Attribute Edit")
+      assert has_element?(view, "label", "Calculate embeddings on publish")
+    end
+
+    test "displays datashop analytics link when the project is published", %{
+      conn: conn,
+      admin: admin
+    } do
+      project = create_project_with_author(admin)
+
+      Oli.Publishing.publish_project(
+        project,
+        "Datashop test",
+        admin.id
+      )
+
+      {:ok, view, _html} = live(conn, live_view_route(project.slug))
+
+      assert has_element?(
+               view,
+               "a[href=\"/project/#{project.slug}/datashop\"]",
+               "Datashop Analytics"
+             )
+    end
+
+    test "can update calculate_embeddings_on_publish attribute (false by default)", %{
+      conn: conn,
+      admin: admin
+    } do
+      project = create_project_with_author(admin)
+
+      Oli.Publishing.publish_project(
+        project,
+        "Datashop test",
+        admin.id
+      )
+
+      refute project.attributes.calculate_embeddings_on_publish
+
+      {:ok, view, _html} = live(conn, live_view_route(project.slug))
+
+      element(view, "form[phx-submit=\"update\"]")
+      |> render_submit(%{
+        "project" => %{
+          "attributes" => %{
+            "calculate_embeddings_on_publish" => "true"
+          }
+        }
+      })
+
+      assert Course.get_project!(project.id).attributes.calculate_embeddings_on_publish
+    end
+
+    test "disables datashop analytics link when the project is not published", %{
+      conn: conn,
+      admin: admin
+    } do
+      project = create_project_with_author(admin)
+
+      {:ok, view, _html} = live(conn, live_view_route(project.slug))
+
+      assert has_element?(
+               view,
+               "button[disabled=\"disabled\"]",
+               "Datashop Analytics"
+             )
+    end
+  end
+end

--- a/test/oli_web/live/workspaces/course_author_test.exs
+++ b/test/oli_web/live/workspaces/course_author_test.exs
@@ -474,7 +474,7 @@ defmodule OliWeb.Workspaces.CourseAuthorTest do
       |> element("a", project.title)
       |> render_click()
 
-      assert_redirected(view, "/authoring/project/#{project.slug}")
+      assert_redirected(view, "/workspaces/course_author/#{project.slug}/overview")
     end
 
     test "exit project button works well by navigating to course author index", %{
@@ -537,6 +537,27 @@ defmodule OliWeb.Workspaces.CourseAuthorTest do
 
       assert has_element?(view, "div", "Improve")
       assert has_element?(view, "div", "Insights")
+    end
+
+    test "overview menu is shown correctly", %{
+      conn: conn,
+      project: project
+    } do
+      {:ok, view, _html} = live(conn, ~p"/workspaces/course_author/#{project.slug}/overview")
+
+      assert has_element?(view, ~s(div[class="overview container mx-auto"]))
+      assert has_element?(view, "h4", "Details")
+      assert has_element?(view, "h4", "Project Attributes")
+      assert has_element?(view, "h4", "Content Types")
+      assert has_element?(view, "h4", "Project Labels")
+      assert has_element?(view, "h4", "Collaborators")
+      assert has_element?(view, "h4", "Advanced Activities")
+      assert has_element?(view, "h4", "Allow Duplication")
+      assert has_element?(view, "h4", "Notes")
+      assert has_element?(view, "h4", "Course Discussions")
+      assert has_element?(view, "h4", "Required Survey")
+      assert has_element?(view, "h4", "Transfer Payment Codes")
+      assert has_element?(view, "h4", "Actions")
     end
 
     test "objectives menu is shown correctly", %{

--- a/test/oli_web/live/workspaces/course_author_test.exs
+++ b/test/oli_web/live/workspaces/course_author_test.exs
@@ -545,7 +545,7 @@ defmodule OliWeb.Workspaces.CourseAuthorTest do
     } do
       {:ok, view, _html} = live(conn, ~p"/workspaces/course_author/#{project.slug}/overview")
 
-      assert has_element?(view, ~s(div[class="overview container mx-auto"]))
+      assert has_element?(view, ~s(div[class="overview container mx-auto p-8"]))
       assert has_element?(view, "h4", "Details")
       assert has_element?(view, "h4", "Project Attributes")
       assert has_element?(view, "h4", "Content Types")


### PR DESCRIPTION
[MER-3604](https://eliterate.atlassian.net/browse/MER-3604)

This PR updates the routes in the project table so that when entering a project the author/admin is redirected to use the new workspace.

The `Alternatives`, `CSV import` and `Datashop Analytics` liveviews are also migrated, as they were not migrated when working on the `Overview` liveview migration.


https://github.com/user-attachments/assets/4659d48c-47d2-49ef-b6f7-9b94a95b11db



[MER-3598]: https://eliterate.atlassian.net/browse/MER-3598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MER-3604]: https://eliterate.atlassian.net/browse/MER-3604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ