### PR TITLE
[BUG FIX] [MER-3811] bibliography function does not allow for any input sidebar collapse arrow kicks user to sign in page

### DIFF
--- a/lib/oli_web/components/layouts/workspace.html.heex
+++ b/lib/oli_web/components/layouts/workspace.html.heex
@@ -29,7 +29,6 @@
     resource_title={assigns[:resource_title]}
     resource_slug={assigns[:resource_slug]}
     active_tab={assigns[:active_tab]}
-    url_params={assigns[:url_params] || %{}}
     uri={assigns[:uri] || ""}
   />
   <Components.Delivery.Layouts.header

--- a/lib/oli_web/live/workspaces/course_author/bibliography_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/bibliography_live.ex
@@ -20,18 +20,19 @@ defmodule OliWeb.Workspaces.CourseAuthor.BibliographyLive do
         active_view: :bibliography,
         is_admin?: is_admin?,
         active: :bibliography,
-        ctx: ctx
+        ctx: ctx,
+        context: %{},
+        error: false
       )
 
     case Oli.Authoring.Editing.BibliographyEditor.create_context(project.slug, author) do
       {:ok, context} ->
-        socket = assign(socket, context: context, scripts: Oli.Activities.get_activity_scripts())
-        {:ok, socket}
+        {:ok, assign(socket, context: context)}
 
       _ ->
         socket =
           socket
-          |> assign(context: %{}, scripts: [])
+          |> assign(error: true)
           |> put_flash(:error, "Publication not found. Please check the URL and try again.")
 
         {:ok, socket}
@@ -39,28 +40,14 @@ defmodule OliWeb.Workspaces.CourseAuthor.BibliographyLive do
   end
 
   @impl Phoenix.LiveView
-  def handle_params(_params, _url, socket) do
-    {:noreply, socket}
-  end
-
-  @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
-    <div>
-      <script type="text/javascript" src={Routes.static_path(OliWeb.Endpoint, "/js/bibliography.js")}>
-      </script>
-      <script
-        :for={script <- @scripts}
-        type="text/javascript"
-        src={Routes.static_path(OliWeb.Endpoint, "/js/" <> script)}
-      >
-      </script>
-
+    <div :if={!@error}>
       <div id="editor" phx-update="ignore">
         <%= React.component(@ctx, "Components.Bibliography", @context, id: "bibliography") %>
       </div>
 
-      <%= React.component(@context, "Components.ModalDisplay", %{}, id: "modal-display") %>
+      <%= React.component(@ctx, "Components.ModalDisplay", @context, id: "modal-display") %>
     </div>
     """
   end

--- a/lib/oli_web/live/workspaces/course_author/products_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/products_live.ex
@@ -50,30 +50,11 @@ defmodule OliWeb.Workspaces.CourseAuthor.ProductsLive do
   end
 
   @impl Phoenix.LiveView
-  def handle_params(params, _, socket) do
-    # If the sidebar was toggled, we don't need to update the table model
-    sidebar_was_toggled = Map.keys(socket.assigns.__changed__) == [:sidebar_expanded]
-
-    if sidebar_was_toggled do
-      {:noreply, socket}
-    else
-      table_model =
-        SortableTableModel.update_from_params(socket.assigns.table_model, params)
-
-      offset = Params.get_int_param(params, "offset", @initial_offset)
-      include_archived = Params.get_boolean_param(params, "include_archived", false)
-
-      products = get_products(socket.assigns)
-
-      table_model = Map.put(table_model, :rows, products)
-
-      {:noreply,
-       assign(socket,
-         offset: offset,
-         table_model: table_model,
-         include_archived: include_archived
-       )}
-    end
+  def handle_params(params, _uri, socket) do
+    table_model = SortableTableModel.update_from_params(socket.assigns.table_model, params)
+    table_model = Map.put(table_model, :rows, table_model.rows)
+    socket = assign(socket, table_model: table_model)
+    {:noreply, socket}
   end
 
   @impl Phoenix.LiveView

--- a/lib/oli_web/live/workspaces/instructor/dashboard_live.ex
+++ b/lib/oli_web/live/workspaces/instructor/dashboard_live.ex
@@ -10,75 +10,68 @@ defmodule OliWeb.Workspaces.Instructor.DashboardLive do
        resource_slug: section.slug,
        resource_title: section.title,
        active_workspace: :instructor,
-       active_view: :students,
        active_tab: :course_content
      )}
   end
 
   @impl Phoenix.LiveView
-  def handle_params(
-        %{"view" => "overview", "active_tab" => "students"} = _params,
-        _uri,
-        socket
-      ) do
-    socket = assign(socket, active_view: :students, active_tab: :students)
+
+  def handle_params(%{"view" => "overview", "active_tab" => "course_content"}, _, socket) do
+    socket = assign(socket, active_view: :course_content)
     {:noreply, socket}
   end
 
-  def handle_params(%{"view" => "overview", "section_slug" => _section_slug} = _params, _, socket) do
-    socket = assign(socket, active_view: :course_content, active_tab: :course_content)
+  def handle_params(%{"view" => "overview", "active_tab" => "students"}, _, socket) do
+    socket = assign(socket, active_view: :students)
     {:noreply, socket}
   end
 
-  def handle_params(%{"view" => "insights", "active_tab" => "content"} = _params, _uri, socket) do
-    socket = assign(socket, active_view: :content, active_tab: :content)
+  def handle_params(%{"view" => "overview", "active_tab" => "quiz_scores"}, _, socket) do
+    socket = assign(socket, active_view: :quiz_scores)
     {:noreply, socket}
   end
 
-  def handle_params(
-        %{"view" => "insights", "active_tab" => "learning_objectives"} = _params,
-        _uri,
-        socket
-      ) do
-    socket = assign(socket, active_view: :learning_objectives, active_tab: :learning_objectives)
+  def handle_params(%{"view" => "overview", "active_tab" => "recommended_actions"}, _, socket) do
+    socket = assign(socket, active_view: :recommended_actions)
     {:noreply, socket}
   end
 
-  def handle_params(
-        %{"view" => "insights", "active_tab" => "scored_activities"} = _params,
-        _uri,
-        socket
-      ) do
-    socket = assign(socket, active_view: :scored_activities, active_tab: :scored_activities)
+  def handle_params(%{"view" => "insights", "active_tab" => "content"}, _, socket) do
+    socket = assign(socket, active_view: :content)
     {:noreply, socket}
   end
 
-  def handle_params(
-        %{"view" => "insights", "active_tab" => "practice_activities"} = _params,
-        _uri,
-        socket
-      ) do
-    socket = assign(socket, active_view: :practice_activities, active_tab: :practice_activities)
+  def handle_params(%{"view" => "insights", "active_tab" => "learning_objectives"}, _, socket) do
+    socket = assign(socket, active_view: :learning_objectives)
     {:noreply, socket}
   end
 
-  def handle_params(%{"view" => "insights", "active_tab" => "surveys"} = _params, _uri, socket) do
-    socket = assign(socket, active_view: :surveys, active_tab: :surveys)
+  def handle_params(%{"view" => "insights", "active_tab" => "scored_activities"}, _, socket) do
+    socket = assign(socket, active_view: :scored_activities)
+    {:noreply, socket}
+  end
+
+  def handle_params(%{"view" => "insights", "active_tab" => "practice_activities"}, _, socket) do
+    socket = assign(socket, active_view: :practice_activities)
+    {:noreply, socket}
+  end
+
+  def handle_params(%{"view" => "insights", "active_tab" => "surveys"}, _, socket) do
+    socket = assign(socket, active_view: :surveys)
     {:noreply, socket}
   end
 
   def handle_params(%{"view" => "manage"} = _params, _uri, socket) do
-    socket = assign(socket, active_view: :manage, active_tab: :manage)
+    socket = assign(socket, active_view: :manage)
     {:noreply, socket}
   end
 
   def handle_params(%{"view" => "activity"} = _params, _uri, socket) do
-    socket = assign(socket, active_view: :activity, active_tab: :activity)
+    socket = assign(socket, active_view: :activity)
     {:noreply, socket}
   end
 
-  def handle_params(_params, _url, socket) do
-    # socket = assign(socket, active_view: :students)
+  def handle_params(_params, _uri, socket) do
     {:noreply, socket}
   end
 

--- a/lib/oli_web/live/workspaces/utils.ex
+++ b/lib/oli_web/live/workspaces/utils.ex
@@ -321,7 +321,7 @@ defmodule OliWeb.Workspace.Utils do
           },
           %SubMenuItem{
             text: "Quiz Scores",
-            view: :quiz_cores,
+            view: :quiz_scores,
             parent_view: :overview
           },
           %SubMenuItem{

--- a/lib/oli_web/live_session_plugs/set_sidebar.ex
+++ b/lib/oli_web/live_session_plugs/set_sidebar.ex
@@ -6,6 +6,7 @@ defmodule OliWeb.LiveSessionPlugs.SetSidebar do
 
   import Phoenix.Component, only: [assign: 2]
   import Phoenix.LiveView, only: [attach_hook: 4, connected?: 1]
+  import Oli.Utils, only: [string_to_boolean: 1]
 
   alias Oli.Resources.Collaboration.CollabSpaceConfig
   alias Oli.Resources.Collaboration
@@ -24,11 +25,16 @@ defmodule OliWeb.LiveSessionPlugs.SetSidebar do
       socket =
         attach_hook(socket, :sidebar_hook, :handle_params, fn
           params, uri, socket ->
-            sidebar_expanded = Oli.Utils.string_to_boolean(params["sidebar_expanded"] || "true")
+            sidebar_expanded_from_assigns = socket.assigns.sidebar_expanded
+            sidebar_expanded_from_params = string_to_boolean(params["sidebar_expanded"] || "true")
 
-            socket = assign(socket, uri: uri, sidebar_expanded: sidebar_expanded)
+            socket = assign(socket, uri: uri, sidebar_expanded: sidebar_expanded_from_params)
 
-            {:cont, socket}
+            if sidebar_expanded_from_assigns != sidebar_expanded_from_params do
+              {:halt, socket}
+            else
+              {:cont, socket}
+            end
         end)
 
       {:cont, socket}

--- a/lib/oli_web/plugs/set_sidebar.ex
+++ b/lib/oli_web/plugs/set_sidebar.ex
@@ -11,7 +11,7 @@ defmodule Oli.Plugs.SetSidebar do
     conn
     |> put_session(
       :sidebar_expanded,
-      Oli.Utils.string_to_boolean(conn.params["sidebar_expanded"] || "false")
+      Oli.Utils.string_to_boolean(conn.params["sidebar_expanded"] || "true")
     )
   end
 end

--- a/test/oli_web/live/workspaces/course_author/products_live_test.exs
+++ b/test/oli_web/live/workspaces/course_author/products_live_test.exs
@@ -65,6 +65,27 @@ defmodule OliWeb.Workspace.CourseAuthor.ProductsLiveTest do
   describe "products" do
     setup [:admin_conn, :create_project, :publish_project]
 
+    test "toggle sidebar", %{conn: conn, project: project} do
+      {:ok, view, _html} = live(conn, live_view_route(project.slug))
+
+      path_with_expanded_sidebar_false =
+        "/workspaces/course_author/#{project.slug}/products?sidebar_expanded=false"
+
+      assert view
+             |> element(~s{button[role="toggle sidebar"]})
+             |> render() =~ path_with_expanded_sidebar_false
+
+      path_with_expanded_sidebar_true =
+        "/workspaces/course_author/#{project.slug}/products?sidebar_expanded=true"
+
+      # Click to toggle sidebar
+      view |> element(~s{button[role="toggle sidebar"]}) |> render_click()
+
+      assert view
+             |> element(~s{button[role="toggle sidebar"]})
+             |> render() =~ path_with_expanded_sidebar_true
+    end
+
     test "render message when no products exists", %{conn: conn, project: project} do
       {:ok, view, _html} = live(conn, live_view_route(project.slug))
 

--- a/test/oli_web/live/workspaces/instructor/dashboard_live_test.exs
+++ b/test/oli_web/live/workspaces/instructor/dashboard_live_test.exs
@@ -27,7 +27,7 @@ defmodule OliWeb.Workspace.Instructor.DashboardLiveTest do
            "/workspaces/instructor/#{section.slug}/overview/students?sidebar_expanded=true"},
         3 =>
           {"Quiz Scores",
-           "/workspaces/instructor/#{section.slug}/overview/quiz_cores?sidebar_expanded=true"},
+           "/workspaces/instructor/#{section.slug}/overview/quiz_scores?sidebar_expanded=true"},
         4 =>
           {"Recommended Actions",
            "/workspaces/instructor/#{section.slug}/overview/recommended_actions?sidebar_expanded=true"},


### PR DESCRIPTION
Ticket: [MER-3811](https://eliterate.atlassian.net/browse/MER-3811)

This PR fixes three bugs:

- The bibliography modal not rendering correctly when switching between resources in the submenu.
- The collapser was redirecting to the sign-in page instead of just collapsing or expanding it. This issue occurred on several pages, but with the new approach, all pages should now behave correctly.
- The issue with the highlighting menu (see [this comment](https://eliterate.atlassian.net/browse/MER-3299?focusedCommentId=24291))  when navigating between resources in the Instructor workspace.

