### PR TITLE
[FEATURE] [MER-3598] Revision Editor Liveview

### DIFF
--- a/assets/src/apps/page-editor/PageEditor.tsx
+++ b/assets/src/apps/page-editor/PageEditor.tsx
@@ -90,7 +90,11 @@ function prepareSaveFn(
     Persistence.edit(project, resource, update, releaseLock).then((result) => {
       // check if the slug has changed as a result of the edit and reload the page if it has
       if (result.type === 'success' && result.revision_slug !== resource) {
-        window.location.replace(`/authoring/project/${project}/resource/${result.revision_slug}`);
+        if (window.location.pathname.startsWith('/authoring/project')) {
+          window.location.replace(`/authoring/project/${project}/resource/${result.revision_slug}`);
+        } else if (window.location.pathname.startsWith('/workspaces/course_author')) {
+          window.location.replace(`/workspaces/course_author/${project}/curriculum/${result.revision_slug}/edit`);
+        }
         return result;
       }
       return result;

--- a/assets/src/apps/page-editor/PageEditor.tsx
+++ b/assets/src/apps/page-editor/PageEditor.tsx
@@ -93,7 +93,9 @@ function prepareSaveFn(
         if (window.location.pathname.startsWith('/authoring/project')) {
           window.location.replace(`/authoring/project/${project}/resource/${result.revision_slug}`);
         } else if (window.location.pathname.startsWith('/workspaces/course_author')) {
-          window.location.replace(`/workspaces/course_author/${project}/curriculum/${result.revision_slug}/edit`);
+          window.location.replace(
+            `/workspaces/course_author/${project}/curriculum/${result.revision_slug}/edit`,
+          );
         }
         return result;
       }

--- a/lib/oli_web/live/workspaces/course_author/curriculum/entry.ex
+++ b/lib/oli_web/live/workspaces/course_author/curriculum/entry.ex
@@ -52,7 +52,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.Curriculum.Entry do
             <span class="ml-1 mr-1 entry-title"><%= @child.title %></span>
             <.link
               class="entry-title mx-3"
-              href={~p"/workspaces/course_author/#{@project.slug}/curriculum/#{@child.slug}"}
+              href={~p"/workspaces/course_author/#{@project.slug}/curriculum/#{@child.slug}/edit"}
             >
               Edit Page
             </.link>

--- a/lib/oli_web/live/workspaces/course_author/editor_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/editor_live.ex
@@ -53,7 +53,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.EditorLive do
         </div>
 
         <div>
-          <%= link class: "toolbar-link", to: Routes.live_path(OliWeb.Endpoint, OliWeb.RevisionHistory, @project_slug,@revision_slug) do %>
+          <%= link class: "toolbar-link", to: Routes.live_path(OliWeb.Endpoint, OliWeb.RevisionHistory, @project_slug, @revision_slug) do %>
             <span style="margin-right: 5px"><i class="fas fa-history"></i></span><span>View History</span>
           <% end %>
         </div>
@@ -78,13 +78,9 @@ defmodule OliWeb.Workspaces.CourseAuthor.EditorLive do
         }
       ) %>
     </div>
-    """
 
-    # TODO: Adding this component crashes the liveview.
-    # <%= render(OliWeb.ResourceView, "_preview_previous_next_nav.html", %{
-    #   context: @raw_context,
-    #   action: :edit
-    # }) %>
+    <%= render_prev_next_nav(assigns) %>
+    """
   end
 
   defp render_advanced(assigns) do
@@ -107,13 +103,9 @@ defmodule OliWeb.Workspaces.CourseAuthor.EditorLive do
     <div id="editor" class="container">
       <%= React.component(@ctx, "Components.Authoring", @app_params, id: "authoring_editor") %>
     </div>
-    """
 
-    # TODO: Adding this component crashes the liveview.
-    # <%= render(OliWeb.ResourceView, "_preview_previous_next_nav.html", %{
-    #   context: @raw_context,
-    #   action: :edit
-    # }) %>
+    <%= render_prev_next_nav(assigns) %>
+    """
   end
 
   defp live_edit(socket, project, context, project_slug, revision_slug, is_admin?) do
@@ -137,6 +129,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.EditorLive do
       part_component_types: part_component_types,
       part_scripts: PartComponents.get_part_component_scripts(:authoring_script),
       project_slug: project_slug,
+      context: context,
       raw_context: context,
       revision_slug: revision_slug,
       scripts: Activities.get_activity_scripts(:authoring_script),
@@ -165,5 +158,58 @@ defmodule OliWeb.Workspaces.CourseAuthor.EditorLive do
       end
 
     {:ok, assign(socket, content)}
+  end
+
+  defp render_prev_next_nav(assigns) do
+    ~H"""
+    <nav class="previous-next-nav d-flex flex-row" aria-label="Page navigation">
+      <%= if @context.previous_page do %>
+        <%= link to: Routes.live_path(OliWeb.Endpoint, __MODULE__, @project_slug, @context.previous_page["slug"]), class: "page-nav-link btn", onclick: assigns[:onclick] do %>
+          <div class="flex items-center justify-between">
+            <div class="mr-4">
+              <i class="fas fa-arrow-left nav-icon"></i>
+            </div>
+            <div class="flex flex-col text-right overflow-hidden">
+              <div class="nav-label"><%= "Previous" %></div>
+              <div class="nav-title"><%= @context.previous_page["title"] %></div>
+            </div>
+          </div>
+        <% end %>
+      <% else %>
+        <div class="page-nav-link-placeholder"></div>
+      <% end %>
+
+      <div class="flex-grow-1"></div>
+
+      <%= cond do %>
+        <% @context.next_page != nil -> %>
+          <%= link to: Routes.live_path(OliWeb.Endpoint, __MODULE__, @project_slug, @context.next_page["slug"]), class: "page-nav-link btn", onclick: assigns[:onclick] do %>
+            <div class="flex items-center justify-between">
+              <div class="flex flex-col text-left overflow-hidden">
+                <div class="nav-label"><%= "Next" %></div>
+                <div class="nav-title"><%= @context.next_page["title"] %></div>
+              </div>
+              <div class="ml-4">
+                <i class="fas fa-arrow-right nav-icon"></i>
+              </div>
+            </div>
+          <% end %>
+        <% @action != :edit -> %>
+          <%= link to: "#", class: "page-nav-link btn", onclick: "window.close();" do %>
+            <div class="d-flex flex-row">
+              <div class="d-flex flex-column flex-fill text-left overflow-hidden">
+                <div class="nav-label">Complete</div>
+                <div class="nav-title"><%= @context.project.title %></div>
+              </div>
+              <div>
+                <i class="fas fa-check nav-icon"></i>
+              </div>
+            </div>
+          <% end %>
+        <% true -> %>
+          <div class="page-nav-link-placeholder"></div>
+      <% end %>
+    </nav>
+    """
   end
 end

--- a/lib/oli_web/live/workspaces/course_author/editor_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/editor_live.ex
@@ -181,33 +181,20 @@ defmodule OliWeb.Workspaces.CourseAuthor.EditorLive do
 
       <div class="flex-grow-1"></div>
 
-      <%= cond do %>
-        <% @context.next_page != nil -> %>
-          <%= link to: Routes.live_path(OliWeb.Endpoint, __MODULE__, @project_slug, @context.next_page["slug"]), class: "page-nav-link btn", onclick: assigns[:onclick] do %>
-            <div class="flex items-center justify-between">
-              <div class="flex flex-col text-left overflow-hidden">
-                <div class="nav-label"><%= "Next" %></div>
-                <div class="nav-title"><%= @context.next_page["title"] %></div>
-              </div>
-              <div class="ml-4">
-                <i class="fas fa-arrow-right nav-icon"></i>
-              </div>
+      <%= if @context.next_page do %>
+        <%= link to: Routes.live_path(OliWeb.Endpoint, __MODULE__, @project_slug, @context.next_page["slug"]), class: "page-nav-link btn", onclick: assigns[:onclick] do %>
+          <div class="flex items-center justify-between">
+            <div class="flex flex-col text-left overflow-hidden">
+              <div class="nav-label"><%= "Next" %></div>
+              <div class="nav-title"><%= @context.next_page["title"] %></div>
             </div>
-          <% end %>
-        <% @action != :edit -> %>
-          <%= link to: "#", class: "page-nav-link btn", onclick: "window.close();" do %>
-            <div class="d-flex flex-row">
-              <div class="d-flex flex-column flex-fill text-left overflow-hidden">
-                <div class="nav-label">Complete</div>
-                <div class="nav-title"><%= @context.project.title %></div>
-              </div>
-              <div>
-                <i class="fas fa-check nav-icon"></i>
-              </div>
+            <div class="ml-4">
+              <i class="fas fa-arrow-right nav-icon"></i>
             </div>
-          <% end %>
-        <% true -> %>
-          <div class="page-nav-link-placeholder"></div>
+          </div>
+        <% end %>
+      <% else %>
+        <div class="page-nav-link-placeholder"></div>
       <% end %>
     </nav>
     """

--- a/lib/oli_web/live/workspaces/course_author/editor_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/editor_live.ex
@@ -64,7 +64,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.EditorLive do
       </div>
     <% end %>
 
-    <div id="editor" class="container mx-auto">
+    <div id="editor" style="width: 95%;" class="container mx-auto">
       <%= React.component(@ctx, "Components.PageEditor", @raw_context, id: "page_editor") %>
     </div>
 

--- a/lib/oli_web/live/workspaces/course_author/editor_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/editor_live.ex
@@ -1,0 +1,108 @@
+defmodule OliWeb.Workspaces.CourseAuthor.EditorLive do
+  use OliWeb, :live_view
+  use Phoenix.HTML
+
+  import OliWeb.ProjectPlugs
+  alias Oli.Activities.Realizer.Query.Source
+  alias Oli.Authoring.Editing.PageEditor
+  alias Oli.Accounts
+  alias Oli.Activities
+  alias Oli.Publishing.AuthoringResolver
+  alias OliWeb.Common.Breadcrumb
+  alias Oli.PartComponents
+  alias Oli.Delivery.Hierarchy
+  alias Oli.Resources.ResourceType
+  alias OliWeb.Components.Delivery.AdaptiveIFrame
+  alias OliWeb.Common.React
+
+  @impl true
+  def mount(%{"project_id" => project_slug, "revision_slug" => revision_slug}, _session, socket) do
+    author = socket.assigns[:current_author]
+    project = socket.assigns.project
+    is_admin? = Accounts.at_least_content_admin?(author)
+
+    case PageEditor.create_context(project_slug, revision_slug, author) do
+      {:ok, context} ->
+        context = Map.put(context, :hasExperiments, project.has_experiments)
+
+        breadcrumbs =
+          Breadcrumb.trail_to(
+            project_slug,
+            revision_slug,
+            AuthoringResolver,
+            project.customizations
+          )
+
+        # Set initial state in the socket
+        {:ok,
+         assign(socket,
+           active: :curriculum,
+           breadcrumbs: breadcrumbs,
+           is_admin?: is_admin?,
+           raw_context: context,
+           scripts: Activities.get_activity_scripts(:authoring_script),
+           part_scripts: PartComponents.get_part_component_scripts(:authoring_script),
+           project_slug: project_slug,
+           revision_slug: revision_slug,
+           activity_types: Activities.activities_for_project(project),
+           part_component_types: PartComponents.part_components_for_project(project),
+           graded: context.graded,
+           title: "Edit | " <> context.title,
+           collab_space_config: context.collab_space_config
+         )}
+
+      {:error, :not_found} ->
+        # In case of not found, we can redirect or handle error accordingly
+        {:ok,
+         socket
+         |> put_flash(:error, "Not Found")
+         |> assign(
+           breadcrumbs: [
+             Breadcrumb.curriculum(project_slug),
+             Breadcrumb.new(%{full_title: "Not Found"})
+           ],
+           title: "Not Found"
+         )
+         |> push_redirect(to: Routes.shared_path(socket, :not_found))}
+    end
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <script type="text/javascript" src={Routes.static_path(OliWeb.Endpoint, "/js/pageeditor.js")}>
+    </script>
+    <%= for script <- @scripts do %>
+      <script type="text/javascript" src={Routes.static_path(OliWeb.Endpoint, "/js/#{script}")}>
+      </script>
+    <% end %>
+
+    <%= render(OliWeb.SharedView, "_admin_edit_banner.html", %{
+      is_admin?: @is_admin?,
+      project_slug: @project_slug,
+      revision_slug: @revision_slug
+    }) %>
+
+    <div id="editor" class="container mx-auto">
+      <%= React.component(@ctx, "Components.PageEditor", @raw_context, id: "page_editor") %>
+    </div>
+
+    <div class="container mx-auto mt-5">
+      <%= live_render(@socket, OliWeb.CollaborationLive.CollabSpaceConfigView,
+        id: "collab-space-#{@project_slug}-#{@revision_slug}",
+        session: %{
+          "collab_space_config" => @collab_space_config,
+          "project_slug" => @project_slug,
+          "resource_slug" => @revision_slug
+        }
+      ) %>
+    </div>
+    """
+
+    # TODO: Adding this component crashes the liveview.
+    # <%= render(OliWeb.ResourceView, "_preview_previous_next_nav.html", %{
+    #   context: @raw_context,
+    #   action: :edit
+    # }) %>
+  end
+end

--- a/lib/oli_web/live/workspaces/course_author/editor_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/editor_live.ex
@@ -20,7 +20,10 @@ defmodule OliWeb.Workspaces.CourseAuthor.EditorLive do
         live_edit(socket, project, context, project_slug, revision_slug, is_admin?)
 
       {:error, :not_found} ->
-        OliWeb.ResourceController.render_not_found(OliWeb.Endpoint, project_slug)
+        {:ok,
+         socket
+         |> put_flash(:error, "Revision not found")
+         |> push_navigate(to: ~p"/workspaces/course_author")}
     end
   end
 

--- a/lib/oli_web/live/workspaces/course_author/editor_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/editor_live.ex
@@ -2,17 +2,11 @@ defmodule OliWeb.Workspaces.CourseAuthor.EditorLive do
   use OliWeb, :live_view
   use Phoenix.HTML
 
-  import OliWeb.ProjectPlugs
-  alias Oli.Activities.Realizer.Query.Source
-  alias Oli.Authoring.Editing.PageEditor
   alias Oli.Accounts
   alias Oli.Activities
-  alias Oli.Publishing.AuthoringResolver
-  alias OliWeb.Common.Breadcrumb
+  alias Oli.Authoring.Editing.PageEditor
   alias Oli.PartComponents
-  alias Oli.Delivery.Hierarchy
-  alias Oli.Resources.ResourceType
-  alias OliWeb.Components.Delivery.AdaptiveIFrame
+  alias OliWeb.Common.Breadcrumb
   alias OliWeb.Common.React
 
   @impl true
@@ -23,52 +17,19 @@ defmodule OliWeb.Workspaces.CourseAuthor.EditorLive do
 
     case PageEditor.create_context(project_slug, revision_slug, author) do
       {:ok, context} ->
-        context = Map.put(context, :hasExperiments, project.has_experiments)
-
-        breadcrumbs =
-          Breadcrumb.trail_to(
-            project_slug,
-            revision_slug,
-            AuthoringResolver,
-            project.customizations
-          )
-
-        # Set initial state in the socket
-        {:ok,
-         assign(socket,
-           active: :curriculum,
-           breadcrumbs: breadcrumbs,
-           is_admin?: is_admin?,
-           raw_context: context,
-           scripts: Activities.get_activity_scripts(:authoring_script),
-           part_scripts: PartComponents.get_part_component_scripts(:authoring_script),
-           project_slug: project_slug,
-           revision_slug: revision_slug,
-           activity_types: Activities.activities_for_project(project),
-           part_component_types: PartComponents.part_components_for_project(project),
-           graded: context.graded,
-           title: "Edit | " <> context.title,
-           collab_space_config: context.collab_space_config
-         )}
+        live_edit(socket, project, context, project_slug, revision_slug, is_admin?)
 
       {:error, :not_found} ->
-        # In case of not found, we can redirect or handle error accordingly
-        {:ok,
-         socket
-         |> put_flash(:error, "Not Found")
-         |> assign(
-           breadcrumbs: [
-             Breadcrumb.curriculum(project_slug),
-             Breadcrumb.new(%{full_title: "Not Found"})
-           ],
-           title: "Not Found"
-         )
-         |> push_redirect(to: Routes.shared_path(socket, :not_found))}
+        OliWeb.ResourceController.render_not_found(OliWeb.Endpoint, project_slug)
     end
   end
 
   @impl true
   def render(assigns) do
+    if assigns[:app_params], do: render_advanced(assigns), else: render_basic(assigns)
+  end
+
+  defp render_basic(assigns) do
     ~H"""
     <script type="text/javascript" src={Routes.static_path(OliWeb.Endpoint, "/js/pageeditor.js")}>
     </script>
@@ -77,11 +38,26 @@ defmodule OliWeb.Workspaces.CourseAuthor.EditorLive do
       </script>
     <% end %>
 
-    <%= render(OliWeb.SharedView, "_admin_edit_banner.html", %{
-      is_admin?: @is_admin?,
-      project_slug: @project_slug,
-      revision_slug: @revision_slug
-    }) %>
+    <%= if @is_admin? do %>
+      <div
+        class="alert alert-warning alert-dismissible flex flex-row fade show container mt-2 mx-auto"
+        role="alert"
+      >
+        <div class="flex-1">
+          <strong>You are editing as an administrator</strong>
+        </div>
+
+        <div>
+          <%= link class: "toolbar-link", to: Routes.live_path(OliWeb.Endpoint, OliWeb.RevisionHistory, @project_slug,@revision_slug) do %>
+            <span style="margin-right: 5px"><i class="fas fa-history"></i></span><span>View History</span>
+          <% end %>
+        </div>
+
+        <button type="button" class="close ml-4" data-bs-dismiss="alert" aria-label="Close">
+          <i class="fa-solid fa-xmark fa-lg"></i>
+        </button>
+      </div>
+    <% end %>
 
     <div id="editor" class="container mx-auto">
       <%= React.component(@ctx, "Components.PageEditor", @raw_context, id: "page_editor") %>
@@ -104,5 +80,85 @@ defmodule OliWeb.Workspaces.CourseAuthor.EditorLive do
     #   context: @raw_context,
     #   action: :edit
     # }) %>
+  end
+
+  defp render_advanced(assigns) do
+    ~H"""
+    <script type="text/javascript" src={Routes.static_path(OliWeb.Endpoint, "/js/authoring.js")}>
+    </script>
+
+    <%= for %{slug: slug, authoring_script: script} <- @activity_types do %>
+      <%= if slug == "oli_adaptive" do %>
+        <script type="text/javascript" src={Routes.static_path(OliWeb.Endpoint, "/js/#{script}")}>
+        </script>
+      <% end %>
+    <% end %>
+
+    <%= for script <- @part_scripts do %>
+      <script type="text/javascript" src={Routes.static_path(OliWeb.Endpoint, "/js/#{script}")}>
+      </script>
+    <% end %>
+
+    <div id="editor" class="container">
+      <%= React.component(@ctx, "Components.Authoring", @app_params, id: "authoring_editor") %>
+    </div>
+    """
+
+    # TODO: Adding this component crashes the liveview.
+    # <%= render(OliWeb.ResourceView, "_preview_previous_next_nav.html", %{
+    #   context: @raw_context,
+    #   action: :edit
+    # }) %>
+  end
+
+  defp live_edit(socket, project, context, project_slug, revision_slug, is_admin?) do
+    context = Map.put(context, :hasExperiments, project.has_experiments)
+    activity_types = Activities.activities_for_project(project)
+    part_component_types = PartComponents.part_components_for_project(project)
+
+    content = %{
+      active: :curriculum,
+      activity_types: activity_types,
+      breadcrumbs:
+        Breadcrumb.trail_to(
+          project_slug,
+          revision_slug,
+          Oli.Publishing.AuthoringResolver,
+          project.customizations
+        ),
+      collab_space_config: context.collab_space_config,
+      graded: context.graded,
+      is_admin?: is_admin?,
+      part_component_types: part_component_types,
+      part_scripts: PartComponents.get_part_component_scripts(:authoring_script),
+      project_slug: project_slug,
+      raw_context: context,
+      revision_slug: revision_slug,
+      scripts: Activities.get_activity_scripts(:authoring_script),
+      title: "Edit | " <> context.title
+    }
+
+    content =
+      case context do
+        %{content: %{"advancedAuthoring" => true}} ->
+          Map.put(content, :app_params, %{
+            isAdmin: is_admin?,
+            revisionSlug: revision_slug,
+            projectSlug: project_slug,
+            graded: context.graded,
+            content: context,
+            paths: %{
+              images: Routes.static_path(socket, "/images")
+            },
+            activityTypes: activity_types,
+            partComponentTypes: part_component_types,
+            appsignalKey: Application.get_env(:appsignal, :client_key)
+          })
+
+        _ ->
+          content
+      end
+
+    {:ok, assign(socket, content)}
   end
 end

--- a/lib/oli_web/live/workspaces/course_author/editor_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/editor_live.ex
@@ -25,6 +25,11 @@ defmodule OliWeb.Workspaces.CourseAuthor.EditorLive do
   end
 
   @impl true
+  def handle_params(_params, _url, socket) do
+    {:noreply, socket}
+  end
+
+  @impl true
   def render(assigns) do
     if assigns[:app_params], do: render_advanced(assigns), else: render_basic(assigns)
   end

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -808,6 +808,7 @@ defmodule OliWeb.Router do
         live("/:project_id/bibliography", BibliographyLive)
         live("/:project_id/curriculum", CurriculumLive)
         live("/:project_id/curriculum/:container_slug", CurriculumLive)
+        live("/:project_id/curriculum/:revision_slug/edit", EditorLive)
         live("/:project_id/pages", PagesLive)
         live("/:project_id/activities", ActivitiesLive)
         live("/:project_id/activities/activity_review", Activities.ActivityReviewLive)

--- a/test/oli_web/live/workspaces/course_author/editor_live_test.exs
+++ b/test/oli_web/live/workspaces/course_author/editor_live_test.exs
@@ -1,0 +1,91 @@
+defmodule OliWeb.Workspaces.CourseAuthor.EditorLiveTest do
+  use OliWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  alias Oli.Seeder
+
+  defp live_view_route(project_slug, revision_slug, params \\ %{}),
+    do: ~p"/workspaces/course_author/#{project_slug}/curriculum/#{revision_slug}/edit?#{params}"
+
+  describe "when user is not logged in" do
+    setup [:create_project_with_units_and_modules]
+
+    test "redirects to overview", %{
+      conn: conn,
+      project: project,
+      revisions: revisions
+    } do
+      redirect_path = "/workspaces/course_author"
+
+      {:error, {:redirect, %{to: ^redirect_path}}} =
+        live(conn, live_view_route(project.slug, revisions.page_revision_1))
+    end
+  end
+
+  describe "when user is logged in as an instructor" do
+    setup [:instructor_conn, :create_project_with_units_and_modules]
+
+    test "redirects to overview", %{
+      conn: conn,
+      project: project,
+      revisions: revisions
+    } do
+      redirect_path = "/workspaces/course_author"
+
+      {:error, {:redirect, %{to: ^redirect_path}}} =
+        live(conn, live_view_route(project.slug, revisions.page_revision_1))
+    end
+  end
+
+  describe "when user is logged in as an author but not an author of the project" do
+    setup [:author_conn, :create_project_with_units_and_modules]
+
+    test "redirects to overview", %{
+      conn: conn,
+      project: project,
+      revisions: revisions
+    } do
+      redirect_path = "/workspaces/course_author"
+
+      {:error, {:redirect, %{to: ^redirect_path}}} =
+        live(conn, live_view_route(project.slug, revisions.page_revision_1))
+    end
+  end
+
+  describe "when author is logged in" do
+    setup :create_author_project_conn
+
+    test "redirects to overview if revision not found", %{
+      conn: conn,
+      project: project
+    } do
+      redirect_path = "/workspaces/course_author"
+
+      {:error, {:live_redirect, %{to: ^redirect_path}}} =
+        live(conn, live_view_route(project.slug, "non-existent-slug"))
+    end
+
+    test "displays revision editor", %{
+      conn: conn,
+      project: project,
+      revision: revision
+    } do
+      {:ok, view, _html} = live(conn, live_view_route(project.slug, revision.slug))
+
+      assert element(view, "#page_editor-container")
+      assert element(view, "#collab-space-#{project.slug}-#{revision.slug}")
+      assert element(view, "#content > nav")
+    end
+  end
+
+  defp create_author_project_conn(%{conn: conn}) do
+    %{project: project, author: author, revision1: revision} =
+      Seeder.base_project_with_resource2()
+
+    conn =
+      Pow.Plug.assign_current_user(conn, author, OliWeb.Pow.PowHelpers.get_pow_config(:author))
+
+    %{project: project, author: author, revision: revision, conn: conn}
+  end
+end


### PR DESCRIPTION
Migrate the revision edit page to a new liveview under the `workspaces/course_author` scope.

https://github.com/user-attachments/assets/d5ea507e-7922-40ad-ae6e-2080f0d25a09



Related: https://eliterate.atlassian.net/browse/MER-3598
Note: The background for each edition block must be changed in `assets/styles/authoring/model-editors.scss` once there is a design for it .