### PR TITLE
[BUG FIX] [MER-3792] FIx Insights search bar

### DIFF
--- a/lib/oli_web/live/insights/insights.ex
+++ b/lib/oli_web/live/insights/insights.ex
@@ -251,11 +251,11 @@ defmodule OliWeb.Insights do
 
     <div class="card">
       <div class="card-header">
-        <form phx-change="search">
+        <form phx-change="text_search_change">
           <input
             type="text"
             class="form-control"
-            name="query"
+            name="value"
             value={@query}
             placeholder="Search by title..."
           />
@@ -301,8 +301,8 @@ defmodule OliWeb.Insights do
 
     table_model = SortableTableModel.update_from_params(socket.assigns.table_model, changes)
 
-    options = socket.assigns.options
-    offset = get_int_param(changes, "offset", 0)
+    options = Map.put(socket.assigns.options, :text_search, Map.get(changes, "text_search", ""))
+    offset = get_param(changes, "offset", 0)
 
     insights =
       BrowseInsights.browse_insights(


### PR DESCRIPTION
[MER-3792](https://eliterate.atlassian.net/browse/MER-3792)

This PR fixes the search bar that filters the results table in the `Insights` liveview.


https://github.com/user-attachments/assets/2c2ab2bc-f32c-46b1-b288-65d49d41d266



[MER-3792]: https://eliterate.atlassian.net/browse/MER-3792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ