### PR TITLE
[FEATURE] [MER-3535] Student logged in visits index home page

### DIFF
--- a/lib/oli_web/controllers/static_page_controller.ex
+++ b/lib/oli_web/controllers/static_page_controller.ex
@@ -7,7 +7,9 @@ defmodule OliWeb.StaticPageController do
   alias OliWeb.Pow.PowHelpers
 
   def index(conn, _params) do
-    render(PowHelpers.use_pow_config(conn, :user), "index.html")
+    if conn.assigns.current_user,
+      do: render(PowHelpers.use_pow_config(conn, :user), "index_logged_in.html"),
+      else: render(PowHelpers.use_pow_config(conn, :user), "index.html")
   end
 
   def unauthorized(conn, _params) do

--- a/lib/oli_web/icons.ex
+++ b/lib/oli_web/icons.ex
@@ -1469,5 +1469,19 @@ defmodule OliWeb.Icons do
     """
   end
 
+  def right_arrow_login(assigns) do
+    ~H"""
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M5 12H19M19 12L15 16M19 12L15 8"
+        stroke="white"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+    """
+  end
+
   ########## Instructor Navigation Bar Icons (end) ##########
 end

--- a/lib/oli_web/templates/static_page/index_logged_in.html.heex
+++ b/lib/oli_web/templates/static_page/index_logged_in.html.heex
@@ -1,0 +1,45 @@
+<div class="relative h-[calc(100vh-112px)] flex justify-center items-center">
+    <div class="absolute h-[calc(100vh-112px)] w-full top-0 left-0">
+      <%= OliWeb.Backgrounds.student_sign_in(%{}) %>
+    </div>
+    <div class="flex flex-col gap-y-10 self-start pt-32 w-full relative z-50">
+      <div class="w-full flex justify-center">
+        <div class="flex flex-col gap-y-8 items-center">
+          <div class="text-center px-4">
+            <span class="text-white text-4xl font-normal font-['Open Sans'] leading-10">
+              Welcome back to
+            </span>
+            <span class="text-white text-4xl font-bold font-['Open Sans'] leading-10">
+              <%= Oli.VendorProperties.product_short_name() %>
+            </span>
+          </div>
+          <div class="">
+            <div class="justify-center items-end gap-px flex">
+              <div class="self-start px-1 py-2 justify-center items-center flex">
+                <%= OliWeb.Icons.graduation_cap(%{}) %>
+              </div>
+              <div class="w-40 h-11 text-center text-white text-4xl font-bold font-['Open Sans']">
+                Student
+              </div>
+            </div>
+          </div>
+          <%= unless Oli.Accounts.is_lms_user?(@conn.assigns.current_user.email) do %>
+            <div class="flex justify-center max-w-max items-center mt-12 gap-x-1 border-white border-b">
+              <.link class="flex items-center gap-x-1" navigate={~p"/workspaces/student"}>
+                <div class="text-white text-xl font-normal font-['Inter'] leading-normal">Access my courses</div>
+                <div>
+                  <%= OliWeb.Icons.right_arrow_login(%{}) %>
+                </div>
+              </.link>
+            </div>
+          <% else %>
+            <div class="flex justify-center max-w-max items-center mt-12 px-8">
+              <div class="justify-start items-center gap-[5px] inline-flex">
+                <div class="w-[328px] text-center text-white text-xl font-normal font-['Inter'] leading-normal">Navigate to your institution’s LMS to access your online course.</div>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>

--- a/lib/oli_web/templates/static_page/index_logged_in.html.heex
+++ b/lib/oli_web/templates/static_page/index_logged_in.html.heex
@@ -1,45 +1,49 @@
 <div class="relative h-[calc(100vh-112px)] flex justify-center items-center">
-    <div class="absolute h-[calc(100vh-112px)] w-full top-0 left-0">
-      <%= OliWeb.Backgrounds.student_sign_in(%{}) %>
-    </div>
-    <div class="flex flex-col gap-y-10 self-start pt-32 w-full relative z-50">
-      <div class="w-full flex justify-center">
-        <div class="flex flex-col gap-y-8 items-center">
-          <div class="text-center px-4">
-            <span class="text-white text-4xl font-normal font-['Open Sans'] leading-10">
-              Welcome back to
-            </span>
-            <span class="text-white text-4xl font-bold font-['Open Sans'] leading-10">
-              <%= Oli.VendorProperties.product_short_name() %>
-            </span>
-          </div>
-          <div class="">
-            <div class="justify-center items-end gap-px flex">
-              <div class="self-start px-1 py-2 justify-center items-center flex">
-                <%= OliWeb.Icons.graduation_cap(%{}) %>
-              </div>
-              <div class="w-40 h-11 text-center text-white text-4xl font-bold font-['Open Sans']">
-                Student
-              </div>
-            </div>
-          </div>
-          <%= unless Oli.Accounts.is_lms_user?(@conn.assigns.current_user.email) do %>
-            <div class="flex justify-center max-w-max items-center mt-12 gap-x-1 border-white border-b">
-              <.link class="flex items-center gap-x-1" navigate={~p"/workspaces/student"}>
-                <div class="text-white text-xl font-normal font-['Inter'] leading-normal">Access my courses</div>
-                <div>
-                  <%= OliWeb.Icons.right_arrow_login(%{}) %>
-                </div>
-              </.link>
-            </div>
-          <% else %>
-            <div class="flex justify-center max-w-max items-center mt-12 px-8">
-              <div class="justify-start items-center gap-[5px] inline-flex">
-                <div class="w-[328px] text-center text-white text-xl font-normal font-['Inter'] leading-normal">Navigate to your institution’s LMS to access your online course.</div>
-              </div>
-            </div>
-          <% end %>
+  <div class="absolute h-[calc(100vh-112px)] w-full top-0 left-0">
+    <%= OliWeb.Backgrounds.student_sign_in(%{}) %>
+  </div>
+  <div class="flex flex-col gap-y-10 self-start pt-32 w-full relative z-50">
+    <div class="w-full flex justify-center">
+      <div class="flex flex-col gap-y-8 items-center">
+        <div class="text-center px-4">
+          <span class="text-white text-4xl font-normal font-['Open Sans'] leading-10">
+            Welcome back to
+          </span>
+          <span class="text-white text-4xl font-bold font-['Open Sans'] leading-10">
+            <%= Oli.VendorProperties.product_short_name() %>
+          </span>
         </div>
+        <div class="">
+          <div class="justify-center items-end gap-px flex">
+            <div class="self-start px-1 py-2 justify-center items-center flex">
+              <%= OliWeb.Icons.graduation_cap(%{}) %>
+            </div>
+            <div class="w-40 h-11 text-center text-white text-4xl font-bold font-['Open Sans']">
+              Student
+            </div>
+          </div>
+        </div>
+        <%= unless Oli.Accounts.is_lms_user?(@conn.assigns.current_user.email) do %>
+          <div class="flex justify-center max-w-max items-center mt-12 gap-x-1 border-white border-b">
+            <.link class="flex items-center gap-x-1" navigate={~p"/workspaces/student"}>
+              <div class="text-white text-xl font-normal font-['Inter'] leading-normal">
+                Access my courses
+              </div>
+              <div>
+                <%= OliWeb.Icons.right_arrow_login(%{}) %>
+              </div>
+            </.link>
+          </div>
+        <% else %>
+          <div class="flex justify-center max-w-max items-center mt-12 px-8">
+            <div class="justify-start items-center gap-[5px] inline-flex">
+              <div class="w-[328px] text-center text-white text-xl font-normal font-['Inter'] leading-normal">
+                Navigate to your institution’s LMS to access your online course.
+              </div>
+            </div>
+          </div>
+        <% end %>
       </div>
     </div>
   </div>
+</div>

--- a/test/oli_web/controllers/static_page_controller_test.exs
+++ b/test/oli_web/controllers/static_page_controller_test.exs
@@ -1,6 +1,8 @@
 defmodule OliWeb.StaticPageControllerTest do
   use OliWeb.ConnCase
 
+  import Oli.Factory
+
   alias Oli.Accounts
 
   test "GET /", %{conn: conn} do
@@ -143,6 +145,27 @@ defmodule OliWeb.StaticPageControllerTest do
 
       assert response(conn, 200) =~ "Easily access and participate in your enrolled courses"
       assert response(conn, 200) =~ "Need an account?"
+    end
+
+    test "shows 'access my courses' link if user is logged in and is an independent learner",
+         conn do
+      {:ok, conn: conn, user: _user} = user_conn(conn)
+
+      conn = get(conn, Routes.static_page_path(conn, :index))
+
+      assert response(conn, 200) =~ "Access my courses"
+    end
+
+    test "shows informative text if user is logged in and is an LMS user", %{conn: conn} do
+      {:ok, conn: conn, user: user} =
+        user_conn(%{conn: conn}, %{name: "Kevin Durant", independent_learner: false})
+
+      insert(:lti_params, user_id: user.id)
+
+      conn = get(conn, Routes.static_page_path(conn, :index))
+
+      assert response(conn, 200) =~
+               "Navigate to your institution’s LMS to access your online course."
     end
   end
 


### PR DESCRIPTION
[MER-3535](https://eliterate.atlassian.net/browse/MER-3535)

This PR implements a new view used when a student is logged into the application, but visits the login screen again. 

Depending on whether the user is an `Independent Student` or an `LMS Student` we will show different information to the user. 

- View for already logged in user who is an independent student

![Captura de pantalla 2024-09-20 a la(s) 3 29 26 p  m](https://github.com/user-attachments/assets/9340320a-6605-44e8-ace5-2bc5a71837fc)

- View for already logged in user who is an LMS student

![Captura de pantalla 2024-09-20 a la(s) 3 29 56 p  m](https://github.com/user-attachments/assets/ddf85882-b45e-4f66-b8b3-01c46b9fddbc)


[MER-3535]: https://eliterate.atlassian.net/browse/MER-3535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ