### PR TITLE
[BUG FIX] [MER-3835] very short timeout results in need to re-authenticate often

### DIFF
--- a/assets/src/phoenix/keep-alive.ts
+++ b/assets/src/phoenix/keep-alive.ts
@@ -17,7 +17,7 @@
  * https://elixirforum.com/t/get-user-id-with-pow-from-session-for-live-view/24206/4
  */
 
-// Wait time to renew session set to 10 min. Default Pow session rewnew is at 15 min (session_ttl_renewal)
+// Wait time to renew session set to 10 min. Default Pow session renew is at 15 min
 const waitTime = 600000; // 10 min in ms
 
 if (!window.keepAlive) {
@@ -26,14 +26,15 @@ if (!window.keepAlive) {
     const isAuthoring = $('#layout-id').data('layout-id') === 'authoring';
     const keepAliveUrl = `${isAuthoring ? '/authoring' : ''}/keep-alive`;
 
-    const wait = (ms: number) => {
-      return () =>
-        new Promise((resolve) => {
-          setTimeout(resolve, ms);
-        });
-    };
-
-    fetch(keepAliveUrl).then(wait(waitTime)).then(window.keepAlive);
+    fetch(keepAliveUrl).then((res: any) => {
+      if (res.status === 401 || res.status === 302) {
+        window.location.href = `${
+          isAuthoring ? '/authoring' : ''
+        }/session/new?request_path=${encodeURIComponent(window.location.pathname)}`;
+      } else {
+        setTimeout(window.keepAlive, waitTime);
+      }
+    });
   };
 
   window.keepAlive();

--- a/lib/oli_web/pow/pow_helpers.ex
+++ b/lib/oli_web/pow/pow_helpers.ex
@@ -11,7 +11,7 @@ defmodule OliWeb.Pow.PowHelpers do
       current_user_assigns_key: :current_user,
       session_key: "user_auth",
       # session_ttl_renewal: :timer.minutes(15),    # default is 15 minutes
-      # credentials_cache_store: {Pow.Store.CredentialsCache, ttl: :timer.minutes(30)}, # default is 30 minutes
+      credentials_cache_store: {Pow.Store.CredentialsCache, ttl: :timer.hours(24)}, # default is 30 minutes
       plug: Pow.Plug.Session,
       web_module: OliWeb,
       routes_backend: OliWeb.Pow.UserRoutes,
@@ -36,7 +36,7 @@ defmodule OliWeb.Pow.PowHelpers do
       current_user_assigns_key: :current_author,
       session_key: "author_auth",
       # session_ttl_renewal: :timer.minutes(15),    # default is 15 minutes
-      # credentials_cache_store: {Pow.Store.CredentialsCache, ttl: :timer.minutes(30)}, # default is 30 minutes
+      credentials_cache_store: {Pow.Store.CredentialsCache, ttl: :timer.hours(24)}, # default is 30 minutes
       plug: Pow.Plug.Session,
       web_module: OliWeb,
       routes_backend: OliWeb.Pow.AuthorRoutes,

--- a/lib/oli_web/pow/pow_helpers.ex
+++ b/lib/oli_web/pow/pow_helpers.ex
@@ -11,7 +11,8 @@ defmodule OliWeb.Pow.PowHelpers do
       current_user_assigns_key: :current_user,
       session_key: "user_auth",
       # session_ttl_renewal: :timer.minutes(15),    # default is 15 minutes
-      credentials_cache_store: {Pow.Store.CredentialsCache, ttl: :timer.hours(24)}, # default is 30 minutes
+      # default is 30 minutes
+      credentials_cache_store: {Pow.Store.CredentialsCache, ttl: :timer.hours(24)},
       plug: Pow.Plug.Session,
       web_module: OliWeb,
       routes_backend: OliWeb.Pow.UserRoutes,
@@ -36,7 +37,8 @@ defmodule OliWeb.Pow.PowHelpers do
       current_user_assigns_key: :current_author,
       session_key: "author_auth",
       # session_ttl_renewal: :timer.minutes(15),    # default is 15 minutes
-      credentials_cache_store: {Pow.Store.CredentialsCache, ttl: :timer.hours(24)}, # default is 30 minutes
+      # default is 30 minutes
+      credentials_cache_store: {Pow.Store.CredentialsCache, ttl: :timer.hours(24)},
       plug: Pow.Plug.Session,
       web_module: OliWeb,
       routes_backend: OliWeb.Pow.AuthorRoutes,

--- a/lib/oli_web/pow/pow_helpers.ex
+++ b/lib/oli_web/pow/pow_helpers.ex
@@ -11,8 +11,7 @@ defmodule OliWeb.Pow.PowHelpers do
       current_user_assigns_key: :current_user,
       session_key: "user_auth",
       # session_ttl_renewal: :timer.minutes(15),    # default is 15 minutes
-      # default is 30 minutes
-      credentials_cache_store: {Pow.Store.CredentialsCache, ttl: :timer.hours(24)},
+      # credentials_cache_store: {Pow.Store.CredentialsCache, ttl: :timer.minutes(30)}, # default is 30 minutes
       plug: Pow.Plug.Session,
       web_module: OliWeb,
       routes_backend: OliWeb.Pow.UserRoutes,
@@ -37,8 +36,7 @@ defmodule OliWeb.Pow.PowHelpers do
       current_user_assigns_key: :current_author,
       session_key: "author_auth",
       # session_ttl_renewal: :timer.minutes(15),    # default is 15 minutes
-      # default is 30 minutes
-      credentials_cache_store: {Pow.Store.CredentialsCache, ttl: :timer.hours(24)},
+      # credentials_cache_store: {Pow.Store.CredentialsCache, ttl: :timer.minutes(30)}, # default is 30 minutes
       plug: Pow.Plug.Session,
       web_module: OliWeb,
       routes_backend: OliWeb.Pow.AuthorRoutes,

--- a/lib/oli_web/templates/layout/delivery.html.heex
+++ b/lib/oli_web/templates/layout/delivery.html.heex
@@ -150,6 +150,13 @@
     <% end %>
     <script type="text/javascript" src={Routes.static_path(@conn, "/js/dark.js")}>
     </script>
+
+    <script
+      id="keep-alive"
+      type="text/javascript"
+      src={Routes.static_path(OliWeb.Endpoint, "/js/keepalive.js")}
+    >
+    </script>
   </head>
   <body class="min-h-screen flex flex-col bg-delivery-body text-delivery-body-color dark:bg-delivery-body-dark dark:text-delivery-body-color-dark">
     <input type="hidden" id="layout-id" data-layout-id="delivery" />


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-3835

This PR effectively increases the session re-authentication window by changing the ttl value for the Pow Credentials Cache.

By default, the ttl is set to 15 mins which means unless there is some kind of activity at least every 15 mins then the user/author session will timeout and require re-authentication. This ttl has been adjusted to 24 hours now.

I tested this out by setting this value to 1 min, 2mins, and 15mins and 24 hrs (though I did not test the full 24 hrs). In all cases, the timeout window expired when expected and extending the time made the session window last up until the new tlt value. This was also the case for social logins, i.e. Sign in with Google.

Furthermore, some investigation shows that active LiveView sessions remain active indefinitely until a new route or API endpoint is accessed (though API endpoints will still not redirect a user to sign in like a browsers navigation will). By extending this credentials cache store ttl, there doesn't really seem to be any benefit/need to run a keep alive script, since 24 hours should be sufficiently long enough time that a user will either navigate to another view or take some API action to renew the session, or the session will timeout as expected. Furthermore, direct delivery users can still opt in (for non-social account logins) to use a persistent session (30 days ttl) using the "Remember me" checkbox, or the system configuration can still be set globally via env. variable so that this is always the case.

This fix also will alleviate the issue identified in https://eliterate.atlassian.net/browse/MER-3830, however we should still take a followup task to make the session timeout experience more user friendly when it does exceed 24 hours.