### PR TITLE
[BUG FIX] [MER-3837] Restore Upgrade integration

### DIFF
--- a/lib/oli_web/live/delivery/student/utils.ex
+++ b/lib/oli_web/live/delivery/student/utils.ex
@@ -424,6 +424,7 @@ defmodule OliWeb.Delivery.Student.Utils do
         ),
       user: current_user,
       section_slug: section.slug,
+      project_slug: Oli.Repo.get(Oli.Authoring.Course.Project, section.base_project_id).slug,
       mode: mode,
       activity_map: page_context.activities,
       resource_summary_fn: &Oli.Resources.resource_summary(&1, section.slug, Resolver),


### PR DESCRIPTION
The LessonLive migration in V28 lost the setting of `project_slug` for rendering context, which is necessary for the DecisionPointStrategy to enroll students into Upgrade experiments.  I verified this fixes the issue by running an experiment locally in my dev env. 