### PR TITLE
[BUG FIX] [MER-3535] Fixes text style on hover

### DIFF
--- a/lib/oli_web/icons.ex
+++ b/lib/oli_web/icons.ex
@@ -1473,9 +1473,8 @@ defmodule OliWeb.Icons do
     ~H"""
     <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path
-        class="hover:stroke-zinc-300"
         d="M5 12H19M19 12L15 16M19 12L15 8"
-        stroke="white"
+        stroke="currentColor"
         stroke-width="2"
         stroke-linecap="round"
         stroke-linejoin="round"

--- a/lib/oli_web/icons.ex
+++ b/lib/oli_web/icons.ex
@@ -1473,6 +1473,7 @@ defmodule OliWeb.Icons do
     ~H"""
     <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path
+        class="hover:stroke-zinc-300"
         d="M5 12H19M19 12L15 16M19 12L15 8"
         stroke="white"
         stroke-width="2"

--- a/lib/oli_web/templates/static_page/index_logged_in.html.heex
+++ b/lib/oli_web/templates/static_page/index_logged_in.html.heex
@@ -25,7 +25,10 @@
         </div>
         <%= unless Oli.Accounts.is_lms_user?(@conn.assigns.current_user.email) do %>
           <div class="flex justify-center max-w-max items-center mt-12 gap-x-1 border-white border-b hover:border-zinc-300">
-            <.link class="flex items-center gap-x-1 no-underline hover:no-underline text-white hover:text-zinc-300" navigate={~p"/workspaces/student"}>
+            <.link
+              class="flex items-center gap-x-1 no-underline hover:no-underline text-white hover:text-zinc-300"
+              navigate={~p"/workspaces/student"}
+            >
               <div class="text-xl font-normal font-['Inter'] leading-normal">
                 Access my courses
               </div>

--- a/lib/oli_web/templates/static_page/index_logged_in.html.heex
+++ b/lib/oli_web/templates/static_page/index_logged_in.html.heex
@@ -25,8 +25,8 @@
         </div>
         <%= unless Oli.Accounts.is_lms_user?(@conn.assigns.current_user.email) do %>
           <div class="flex justify-center max-w-max items-center mt-12 gap-x-1 border-white border-b hover:border-zinc-300">
-            <.link class="flex items-center gap-x-1 no-underline hover:no-underline" navigate={~p"/workspaces/student"}>
-              <div class="text-white text-xl font-normal font-['Inter'] leading-normal hover:text-zinc-300">
+            <.link class="flex items-center gap-x-1 no-underline hover:no-underline text-white hover:text-zinc-300" navigate={~p"/workspaces/student"}>
+              <div class="text-xl font-normal font-['Inter'] leading-normal">
                 Access my courses
               </div>
               <div>

--- a/lib/oli_web/templates/static_page/index_logged_in.html.heex
+++ b/lib/oli_web/templates/static_page/index_logged_in.html.heex
@@ -24,9 +24,9 @@
           </div>
         </div>
         <%= unless Oli.Accounts.is_lms_user?(@conn.assigns.current_user.email) do %>
-          <div class="flex justify-center max-w-max items-center mt-12 gap-x-1 border-white border-b">
-            <.link class="flex items-center gap-x-1" navigate={~p"/workspaces/student"}>
-              <div class="text-white text-xl font-normal font-['Inter'] leading-normal">
+          <div class="flex justify-center max-w-max items-center mt-12 gap-x-1 border-white border-b hover:border-zinc-300">
+            <.link class="flex items-center gap-x-1 no-underline hover:no-underline" navigate={~p"/workspaces/student"}>
+              <div class="text-white text-xl font-normal font-['Inter'] leading-normal hover:text-zinc-300">
                 Access my courses
               </div>
               <div>


### PR DESCRIPTION
[MER-3535](https://eliterate.atlassian.net/browse/MER-3535)

This PR fixes the styling of hovering over the `Access my courses` text in the login view when a student is already logged into the application, so that the blue underline of the link containing that text is not shown. 

As the text and the arrow are separate components, both have their own styling when hovering over the element. 
 
 

[MER-3535]: https://eliterate.atlassian.net/browse/MER-3535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ