### PR TITLE
[BUG FIX] [MER-3299] Adjust long text in submenu

### DIFF
--- a/lib/oli_web/live/workspaces/utils.ex
+++ b/lib/oli_web/live/workspaces/utils.ex
@@ -58,7 +58,7 @@ defmodule OliWeb.Workspaces.Utils do
     ~H"""
     <.link
       navigate={@route}
-      class={["w-full h-[35px] flex-col justify-center items-center flex hover:no-underline"]}
+      class={["w-full flex-col justify-center items-center flex hover:no-underline"]}
     >
       <.nav_link_content
         is_active={@active_view == @item.view}
@@ -127,20 +127,17 @@ defmodule OliWeb.Workspaces.Utils do
 
     ~H"""
     <div class={[
-      "relative w-full h-9 px-3 py-3 dark:hover:bg-[#404044] hover:bg-[#D9D9DD] rounded-lg justify-start items-center gap-3 inline-flex",
+      "w-full px-3 py-2 dark:hover:bg-[#404044] hover:bg-[#D9D9DD] rounded-lg justify-start items-center gap-3 inline-flex",
       if(@is_active, do: @on_active_bg)
     ]}>
-      <div :if={@sub_menu_item.icon} class="w-5 h-5 flex items-center justify-center">
+      <div :if={@sub_menu_item.icon} class="w-5 flex items-center justify-center">
         <%= apply(Icons, String.to_existing_atom(@sub_menu_item.icon), [assigns]) %>
       </div>
       <div class={[
         "text-[#757682] dark:text-[#BAB8BF] text-sm font-medium tracking-tight flex flex-row justify-between",
         if(@is_active, do: "!font-semibold dark:!text-white !text-[#353740]")
       ]}>
-        <div
-          :if={@sidebar_expanded or not is_nil(@sub_menu_item.parent_view)}
-          class="whitespace-nowrap"
-        >
+        <div :if={@sidebar_expanded or not is_nil(@sub_menu_item.parent_view)} class="">
           <%= @sub_menu_item.text %>
         </div>
 

--- a/lib/oli_web/live/workspaces/utils.ex
+++ b/lib/oli_web/live/workspaces/utils.ex
@@ -97,7 +97,7 @@ defmodule OliWeb.Workspaces.Utils do
       <div
         role="expandable_submenu"
         id={"#{@item_id}_children"}
-        class={"pl-4 #{if active_view_in_children?(@item.children, @active_view), do: "block", else: "hidden"} #{if !@sidebar_expanded, do: "absolute top-0 left-12 bg-white dark:bg-[#222126] pl-0 rounded-md"}"}
+        class={"pl-4 #{if active_view_in_children?(@item.children, @active_view), do: "block", else: "hidden"} #{if !@sidebar_expanded, do: "absolute top-0 left-[52px] bg-white dark:bg-[#222126] pl-0 rounded-md"}"}
         phx-click-away={!@sidebar_expanded && JS.hide(to: "##{@item_id}_children")}
       >
         <.sub_menu_item
@@ -137,7 +137,10 @@ defmodule OliWeb.Workspaces.Utils do
         "text-[#757682] dark:text-[#BAB8BF] text-sm font-medium tracking-tight flex flex-row justify-between",
         if(@is_active, do: "!font-semibold dark:!text-white !text-[#353740]")
       ]}>
-        <div :if={@sidebar_expanded or not is_nil(@sub_menu_item.parent_view)} class="">
+        <div
+          :if={@sidebar_expanded || @sub_menu_item.parent_view}
+          class={if(!@sidebar_expanded, do: "whitespace-nowrap")}
+        >
           <%= @sub_menu_item.text %>
         </div>
 

--- a/lib/oli_web/live_session_plugs/assign_active_menu.ex
+++ b/lib/oli_web/live_session_plugs/assign_active_menu.ex
@@ -15,6 +15,20 @@ defmodule OliWeb.LiveSessionPlugs.AssignActiveMenu do
   where the active_workspace will be :course_author and the active_view will be :activities."
   """
 
+  @valid_views_for_instructor [
+    "course_content",
+    "students",
+    "quiz_scores",
+    "recommended_actions",
+    "content",
+    "learning_objectives",
+    "scored_activities",
+    "practice_activities",
+    "surveys",
+    "manage",
+    "activity"
+  ]
+
   def on_mount(:default, params, _session, socket) do
     socket =
       case Module.split(socket.view) do
@@ -31,12 +45,12 @@ defmodule OliWeb.LiveSessionPlugs.AssignActiveMenu do
 
         ["OliWeb", "Workspaces", "Instructor" | _rest] ->
           case params["active_tab"] || params["view"] do
-            nil ->
-              socket
-
-            active_view_string ->
-              active_view = String.to_existing_atom(active_view_string)
+            active_view_string when active_view_string in @valid_views_for_instructor ->
+              active_view = String.to_atom(active_view_string)
               assign(socket, active_workspace: :instructor, active_view: active_view)
+
+            _ ->
+              socket
           end
 
         _ ->


### PR DESCRIPTION
Ticket: [MER-3299](https://eliterate.atlassian.net/browse/MER-3299)

This PR addresses the comment regarding the display of long text in the submenu (see [here](https://eliterate.atlassian.net/browse/MER-3299?focusedCommentId=24291)). Instead of showing it in a single line, it is now displayed across multiple lines based on the text length. See the "Recommended Actions" in the images below.

Note: Commit 33a18dba3996b383c8c3134df161d876ba4bf67f is a refactor made to the `AssignActiveMenu` live plug. For some weird reason when working on this ticket, the `String.to_existing_atom(active_view_string)` was failing to convert the view. As a workaround, we now validate against `valid_views_for_instructor` before attempting the conversion. This should avoid creating more atoms other than the defined in the `valid_views_for_instructor` list.


### Before

<img width="199" alt="image" src="https://github.com/user-attachments/assets/8e75c5da-ad3e-444f-bf6a-2b317690f052">

<img width="234" alt="image" src="https://github.com/user-attachments/assets/3f07a095-5b35-4bf7-a84d-d404598d3a4f">


### After

<img width="200" alt="image" src="https://github.com/user-attachments/assets/a5587272-808d-48f9-a646-fc72fef3c235">

<img width="235" alt="image" src="https://github.com/user-attachments/assets/f05556fe-a49b-4888-9c56-f74cfe5a8f9f">



[MER-3299]: https://eliterate.atlassian.net/browse/MER-3299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ