### PR TITLE
[BUG FIX] [MER-3847] Sort attempts by date_evaluated

### DIFF
--- a/lib/oli/delivery/attempts/scoring.ex
+++ b/lib/oli/delivery/attempts/scoring.ex
@@ -71,7 +71,7 @@ defmodule Oli.Delivery.Attempts.Scoring do
     # the natural database order - or somehow the query doesn't return
     # in database order.
     [most_recent | _] =
-      Enum.filter(items, & &1.date_evaluated != nil)
+      Enum.filter(items, &(&1.date_evaluated != nil))
       |> Enum.sort_by(& &1.date_evaluated, &(DateTime.compare(&1, &2) != :lt))
 
     %Result{

--- a/lib/oli/delivery/attempts/scoring.ex
+++ b/lib/oli/delivery/attempts/scoring.ex
@@ -70,7 +70,7 @@ defmodule Oli.Delivery.Attempts.Scoring do
     # attempts where somehow the most recent attempt does not match
     # the natural database order - or somehow the query doesn't return
     # in database order.
-    [most_recent | _] = Enum.sort_by(items, & &1.date_evaluated, &>=/2)
+    [most_recent | _] = Enum.sort_by(items, & &1.date_evaluated, &(DateTime.compare(&1, &2) != :lt))
 
     %Result{
       score: Map.get(most_recent, :score),

--- a/lib/oli/delivery/attempts/scoring.ex
+++ b/lib/oli/delivery/attempts/scoring.ex
@@ -71,7 +71,8 @@ defmodule Oli.Delivery.Attempts.Scoring do
     # the natural database order - or somehow the query doesn't return
     # in database order.
     [most_recent | _] =
-      Enum.sort_by(items, & &1.date_evaluated, &(DateTime.compare(&1, &2) != :lt))
+      Enum.filter(items, & &1.date_evaluated != nil)
+      |> Enum.sort_by(& &1.date_evaluated, &(DateTime.compare(&1, &2) != :lt))
 
     %Result{
       score: Map.get(most_recent, :score),

--- a/lib/oli/delivery/attempts/scoring.ex
+++ b/lib/oli/delivery/attempts/scoring.ex
@@ -70,7 +70,8 @@ defmodule Oli.Delivery.Attempts.Scoring do
     # attempts where somehow the most recent attempt does not match
     # the natural database order - or somehow the query doesn't return
     # in database order.
-    [most_recent | _] = Enum.sort_by(items, & &1.date_evaluated, &(DateTime.compare(&1, &2) != :lt))
+    [most_recent | _] =
+      Enum.sort_by(items, & &1.date_evaluated, &(DateTime.compare(&1, &2) != :lt))
 
     %Result{
       score: Map.get(most_recent, :score),

--- a/lib/oli/delivery/attempts/scoring.ex
+++ b/lib/oli/delivery/attempts/scoring.ex
@@ -63,7 +63,6 @@ defmodule Oli.Delivery.Attempts.Scoring do
 
   # The most recent is assumed to be the last item in the list
   def calculate_score("most_recent", items) do
-
     # Sort the resource_attemmpts by the date_evaluated field, so that
     # the most recent evaluated attempt is the first item in the list.
     #

--- a/lib/oli/delivery/attempts/scoring.ex
+++ b/lib/oli/delivery/attempts/scoring.ex
@@ -63,7 +63,15 @@ defmodule Oli.Delivery.Attempts.Scoring do
 
   # The most recent is assumed to be the last item in the list
   def calculate_score("most_recent", items) do
-    most_recent = Enum.reverse(items) |> hd
+
+    # Sort the resource_attemmpts by the date_evaluated field, so that
+    # the most recent evaluated attempt is the first item in the list.
+    #
+    # This makes this scoring strategy a little more robust in the face of
+    # attempts where somehow the most recent attempt does not match
+    # the natural database order - or somehow the query doesn't return
+    # in database order.
+    [most_recent | _] = Enum.sort_by(items, & &1.date_evaluated, &>=/2)
 
     %Result{
       score: Map.get(most_recent, :score),

--- a/test/oli/delivery/attempts/scoring_test.exs
+++ b/test/oli/delivery/attempts/scoring_test.exs
@@ -20,11 +20,15 @@ defmodule Oli.Delivery.Attempts.ScoringTest do
   end
 
   test "most recent" do
-    items = [%{score: 5, out_of: 10}]
+    items = [%{score: 5, out_of: 10, date_evaluated: ~U[2021-01-01 00:00:00Z]}]
     assert %Result{score: 5, out_of: 10} = Scoring.calculate_score("most_recent", items)
 
-    items = [%{score: 5, out_of: 10}, %{score: 1, out_of: 20}]
-    assert %Result{score: 1, out_of: 20} = Scoring.calculate_score("most_recent", items)
+    items = [
+      %{score: 5, out_of: 10, date_evaluated: ~U[2023-01-01 00:00:00Z]},
+      %{score: 1, out_of: 20, date_evaluated: ~U[2021-01-01 00:00:00Z]},
+      %{score: 9, out_of: 20, date_evaluated: nil},
+    ]
+    assert %Result{score: 5, out_of: 10} = Scoring.calculate_score("most_recent", items)
   end
 
   test "best" do

--- a/test/oli/delivery/attempts/scoring_test.exs
+++ b/test/oli/delivery/attempts/scoring_test.exs
@@ -24,6 +24,7 @@ defmodule Oli.Delivery.Attempts.ScoringTest do
     assert %Result{score: 5, out_of: 10} = Scoring.calculate_score("most_recent", items)
 
     items = [
+      %{score: 2, out_of: 10, date_evaluated: ~U[2019-01-01 00:00:00Z]},
       %{score: 5, out_of: 10, date_evaluated: ~U[2023-01-01 00:00:00Z]},
       %{score: 1, out_of: 20, date_evaluated: ~U[2021-01-01 00:00:00Z]},
       %{score: 9, out_of: 20, date_evaluated: nil},

--- a/test/oli/delivery/attempts/scoring_test.exs
+++ b/test/oli/delivery/attempts/scoring_test.exs
@@ -27,8 +27,9 @@ defmodule Oli.Delivery.Attempts.ScoringTest do
       %{score: 2, out_of: 10, date_evaluated: ~U[2019-01-01 00:00:00Z]},
       %{score: 5, out_of: 10, date_evaluated: ~U[2023-01-01 00:00:00Z]},
       %{score: 1, out_of: 20, date_evaluated: ~U[2021-01-01 00:00:00Z]},
-      %{score: 9, out_of: 20, date_evaluated: nil},
+      %{score: 9, out_of: 20, date_evaluated: nil}
     ]
+
     assert %Result{score: 5, out_of: 10} = Scoring.calculate_score("most_recent", items)
   end
 


### PR DESCRIPTION
The comments in the code explain what this PR does - but essentially it strengthens the guarantee that we take the "most recently evaluated page attempt" for the `most_recent` scoring strategy.  