### PR TITLE
[BUG FIX] [MER-3848] anomaly when alternating between tabs in the expanded contracted sidebar

### DIFF
--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -317,7 +317,9 @@ defmodule OliWeb.Components.Delivery.Layouts do
             sidebar_expanded={@sidebar_expanded}
             active_workspace={@active_workspace}
           />
-          <div :if={!@sidebar_expanded} class="flex justify-center"><OliWeb.Icons.line_32 /></div>
+          <div :if={!@sidebar_expanded && @resource_slug} class="flex justify-center">
+            <OliWeb.Icons.line_32 />
+          </div>
           <WorkspaceUtils.sub_menu
             :if={@resource_slug}
             hierarchy={WorkspaceUtils.hierarchy(@active_workspace)}

--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -317,6 +317,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
             sidebar_expanded={@sidebar_expanded}
             active_workspace={@active_workspace}
           />
+          <div :if={!@sidebar_expanded} class="flex justify-center"><OliWeb.Icons.line_32 /></div>
           <WorkspaceUtils.sub_menu
             :if={@resource_slug}
             hierarchy={WorkspaceUtils.hierarchy(@active_workspace)}

--- a/lib/oli_web/icons.ex
+++ b/lib/oli_web/icons.ex
@@ -1484,4 +1484,22 @@ defmodule OliWeb.Icons do
   end
 
   ########## Instructor Navigation Bar Icons (end) ##########
+
+  ########## Start of Sidebar Icons  ##########
+  def line_32(assigns) do
+    ~H"""
+    <svg
+      width="36"
+      height="1"
+      viewBox="0 0 36 1"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      class="stroke-[#757682] dark:stroke-[#BAB8BF]"
+    >
+      <line x1="4.37114e-08" y1="0.5" x2="36" y2="0.500003" />
+    </svg>
+    """
+  end
+
+  ########## End of Sidebar Icons  ##########
 end

--- a/lib/oli_web/live/workspaces/student.ex
+++ b/lib/oli_web/live/workspaces/student.ex
@@ -18,10 +18,7 @@ defmodule OliWeb.Workspaces.Student do
 
   def mount(_params, _session, %{assigns: %{has_admin_role: true}} = socket) do
     # admin case...
-    {:ok,
-     assign(socket,
-       active_workspace: :student
-     )}
+    {:ok, assign(socket, active_workspace: :student)}
   end
 
   @impl Phoenix.LiveView
@@ -81,8 +78,9 @@ defmodule OliWeb.Workspaces.Student do
      )}
   end
 
-  def handle_params(params, _uri, socket),
-    do: {:noreply, assign(socket, params: decode_params(params))}
+  def handle_params(params, _uri, socket) do
+    {:noreply, assign(socket, params: decode_params(params))}
+  end
 
   @impl Phoenix.LiveView
 

--- a/lib/oli_web/live_session_plugs/set_sidebar.ex
+++ b/lib/oli_web/live_session_plugs/set_sidebar.ex
@@ -54,13 +54,13 @@ defmodule OliWeb.LiveSessionPlugs.SetSidebar do
   end
 
   defp is_same_workspace(previous_url, current_url) do
-    previous_workspace = process_url(previous_url)
-    current_workspace = process_url(current_url)
+    previous_workspace = extract_workspace(previous_url)
+    current_workspace = extract_workspace(current_url)
 
     previous_workspace == current_workspace
   end
 
-  defp process_url(url) do
+  defp extract_workspace(url) do
     URI.parse(url)
     |> Map.get(:path)
     |> String.split("/", trim: true)


### PR DESCRIPTION
Ticket: [MER-3848](https://eliterate.atlassian.net/browse/MER-3848)

This PR fixes the bug that occurs when toggling the sidebar and then switching to another workspace. The connection was halted in that scenario, but the only condition for a halt should be when it is in the same workspace. Triggering a halt when moving to another workspace interrupts the LiveView lifecycle, as mentioned in the documentation.

> Note that halting from a hook will halt the entire lifecycle stage. This means that when a hook returns {:halt, socket} then the LiveView callback will not be invoked. This has some implications.

This PR also adds a separator line between the workspace menu and the submenu, see commit 44942cfb0b8569734b7bd13ee95b1612ae23219d.

[MER-3848]: https://eliterate.atlassian.net/browse/MER-3848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ