### PR TITLE
[ENHANCEMENT] [MER-3855] Change Submit to Submit And Compare on migrated SubmitAndCompare questions

### DIFF
--- a/assets/src/components/activities/common/delivery/SubmitReset.tsx
+++ b/assets/src/components/activities/common/delivery/SubmitReset.tsx
@@ -5,12 +5,19 @@ import { SubmitButtonConnected } from './submit_button/SubmitButtonConnected';
 interface Props {
   onReset: () => void;
   submitDisabled?: boolean;
+  submitLabel?: string;
 }
 
-export const SubmitResetConnected: React.FC<Props> = ({ onReset, submitDisabled }) => {
+export const SubmitResetConnected: React.FC<Props> = ({ onReset, submitDisabled, submitLabel }) => {
   return (
     <SubmitResetLayout
-      submitButton={<SubmitButtonConnected hideOnSubmitted={false} disabled={submitDisabled} />}
+      submitButton={
+        <SubmitButtonConnected
+          hideOnSubmitted={false}
+          disabled={submitDisabled}
+          label={submitLabel}
+        />
+      }
       resetButton={<ResetButtonConnected hideBeforeSubmit={false} onReset={onReset} />}
     />
   );

--- a/assets/src/components/activities/common/delivery/submit_button/SubmitButton.tsx
+++ b/assets/src/components/activities/common/delivery/submit_button/SubmitButton.tsx
@@ -4,8 +4,14 @@ interface Props {
   shouldShow?: boolean;
   disabled?: boolean;
   onClick: () => void;
+  label?: string;
 }
-export const SubmitButton: React.FC<Props> = ({ shouldShow = true, disabled = false, onClick }) => {
+export const SubmitButton: React.FC<Props> = ({
+  shouldShow = true,
+  disabled = false,
+  onClick,
+  label = 'Submit',
+}) => {
   if (!shouldShow) {
     return null;
   }
@@ -17,7 +23,7 @@ export const SubmitButton: React.FC<Props> = ({ shouldShow = true, disabled = fa
       disabled={disabled}
       onClick={onClick}
     >
-      Submit
+      {label}
     </button>
   );
 };

--- a/assets/src/components/activities/common/delivery/submit_button/SubmitButtonConnected.tsx
+++ b/assets/src/components/activities/common/delivery/submit_button/SubmitButtonConnected.tsx
@@ -7,6 +7,7 @@ import { ActivityDeliveryState, isSubmitted, submit } from 'data/activities/Deli
 export interface SubmitButtonConnectedProps {
   disabled?: boolean;
   hideOnSubmitted?: boolean;
+  label?: string;
 }
 export const SubmitButtonConnected: React.FC<SubmitButtonConnectedProps> = (props) => {
   const { context, onSubmitActivity } = useDeliveryElementContext();
@@ -35,6 +36,7 @@ export const SubmitButtonConnected: React.FC<SubmitButtonConnectedProps> = (prop
       shouldShow={shouldShow}
       disabled={shouldDisable}
       onClick={() => dispatch(submit(onSubmitActivity))}
+      label={props.label}
     />
   );
 };

--- a/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
+++ b/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
@@ -154,7 +154,10 @@ export const ShortAnswerComponent: React.FC = () => {
           onBlur={() => deferredSave.current.flushPendingChanges(false)}
         />
 
-        <SubmitResetConnected onReset={() => dispatch(resetAction(onResetActivity, resetParts))} />
+        <SubmitResetConnected
+          onReset={() => dispatch(resetAction(onResetActivity, resetParts))}
+          submitLabel={model.submitAndCompare ? 'Submit and Compare' : undefined}
+        />
 
         <HintsDeliveryConnected
           partId={castPartId(activityState.parts[0].partId)}

--- a/assets/src/components/activities/short_answer/schema.ts
+++ b/assets/src/components/activities/short_answer/schema.ts
@@ -7,6 +7,7 @@ export const isInputType = (s: string): s is InputType =>
 export interface ShortAnswerModelSchema extends ActivityModelSchema {
   stem: Stem;
   inputType: InputType;
+  submitAndCompare?: boolean;
   authoring: {
     parts: Part[];
     transformations: Transformation[];


### PR DESCRIPTION
Legacy OLI had a type of short answer text question called "Submit and Compare". These had no incorrect answer; the purpose was for the student to compose an answer then submit it in order to compare their answer to a correct answer shown as feedback.  The migration tool migrates these to torus short answer questions in which every answer is correct. The migration script includes a "submitAndCompare: true" attribute in the question model to flag these questions. 

This PR changes the Submit button for these questions to read "Submit and Compare" to more closely recreate the legacy experience with these questions. 

To do this it was necessary to pass an optional label parameter through several layers of components. In all cases omitting the parameter or setting it explicitly to "undefined" should get the default "Submit". Only short answer activities apply a non-default setting. 

Note the submitAndCompare flag is not exposed on the authoring interface, so it will only be set to true in migrated questions using this feature, or by directly editing the underlying JSON.