### PR TITLE
[BUG FIX] [MER-3715] Fix sidebar nil error

### DIFF
--- a/lib/oli_web/live_session_plugs/set_sidebar.ex
+++ b/lib/oli_web/live_session_plugs/set_sidebar.ex
@@ -52,18 +52,23 @@ defmodule OliWeb.LiveSessionPlugs.SetSidebar do
 
     notes_enabled = collab_space_pages_count > 0
 
-    %{slug: revision_slug} = DeliveryResolver.root_container(section_slug)
+    revision_slug =
+      case DeliveryResolver.root_container(section_slug) do
+        %{slug: slug} -> slug
+        _ -> nil
+      end
 
     discussions_enabled =
-      case Collaboration.get_collab_space_config_for_page_in_section(
-             revision_slug,
-             section_slug
-           ) do
-        {:ok, %CollabSpaceConfig{status: :enabled}} ->
-          true
-
-        _ ->
-          false
+      if revision_slug do
+        case Collaboration.get_collab_space_config_for_page_in_section(
+               revision_slug,
+               section_slug
+             ) do
+          {:ok, %CollabSpaceConfig{status: :enabled}} -> true
+          _ -> false
+        end
+      else
+        false
       end
 
     assign(socket, notes_enabled: notes_enabled, discussions_enabled: discussions_enabled)


### PR DESCRIPTION
[MER-3715](https://eliterate.atlassian.net/browse/MER-3715)

 This PR tries to fix the error that occasionally happens in the `set_sidebar` plugin, when trying to match a nil value. 

This seems to be an edge case and apparently happens when in the session structure we have a value for the `section_slug` key for which no root container is found. 

The changes introduced try to avoid the case mentioned above, by handling more securely values that may be nil.


[MER-3715]: https://eliterate.atlassian.net/browse/MER-3715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ