### PR TITLE
[BUG FIX] [MER-3853] ensure MathLive keyboard shows in authoring

### DIFF
--- a/assets/src/components/activities/short_answer/sections/MathInput.tsx
+++ b/assets/src/components/activities/short_answer/sections/MathInput.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { useAuthoringElementContext } from 'components/activities/AuthoringElementProvider';
 import { MathLive } from 'components/common/MathLive';
 import { InputText } from 'data/activities/model/rules';

--- a/assets/src/components/activities/short_answer/sections/MathInput.tsx
+++ b/assets/src/components/activities/short_answer/sections/MathInput.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useAuthoringElementContext } from 'components/activities/AuthoringElementProvider';
 import { MathLive } from 'components/common/MathLive';
 import { InputText } from 'data/activities/model/rules';
@@ -16,6 +16,10 @@ export const MathInput: React.FC<MathInputProps> = ({ input, onEditInput }) => {
         value={input.value}
         options={{
           readOnly: !editMode,
+          // need this because while keyboard toggle gets hidden if readonly, it apparently
+          // isn't automatically restored on change back to nonReadOnly, and authoring context
+          // routinely passes through readonly renders before becoming editable
+          virtualKeyboardMode: editMode ? 'manual' : 'off',
         }}
         onChange={(latex: string) => onEditInput({ ...input, value: latex, operator: 'equals' })}
       />


### PR DESCRIPTION
MathLive keyboard is used to edit math input questions, but the keyboard toggle button was disappearing on return or reload in authoring. Cause seems to be that our React wrapper uses editMode from authoring context to set mathfield's readOnly property, which hides the keyboard toggle, but changing mathfield to non-readonly is apparently not sufficient to show the keyboard toggle again (arguably a defect in the MathLive version we are using).  Logging shows author mode rendering may pass through initial renders with editMode=false before finally becoming editable, but keyboard toggle was not being re-shown. Always explicitly including the appropriate keyboard option fixes.