### PR TITLE
[ENHANCEMENT] [MER-3294] Create an Account link in Student Sign In page when following enrollment link

### DIFF
--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -397,7 +397,7 @@ defmodule OliWeb.DeliveryController do
       # guest user cannot access courses that require enrollment
       {:redirect, nil} ->
         redirect(conn,
-          to: ~p"/?#{[section: section.slug, from_invitation_link?: from_invitation_link?]}"
+          to: ~p"/?#{[section: section.slug, from_invitation_link?: true]}"
         )
     end
   end

--- a/lib/oli_web/templates/static_page/index.html.eex
+++ b/lib/oli_web/templates/static_page/index.html.eex
@@ -95,9 +95,20 @@
             <div class="flex justify-center">
               <%= submit("Sign In",
                 class:
-                  "w-80 h-11 bg-[#0062f2] mx-auto text-white text-xl font-normal leading-7 rounded-md btn btn-md btn-block mb-16 mt-2"
+                  "w-80 h-11 bg-[#0062f2] mx-auto text-white text-xl font-normal leading-7 rounded-md btn btn-md btn-block mb-10 mt-2"
               ) %>
             </div>
+
+            <%= if @conn.params["from_invitation_link?"] == "true" do %>
+              <hr class="mt-0 mb-6 h-0.5 w-3/4 mx-auto border-t-0 bg-neutral-100 dark:bg-white/10" />
+              <div class="flex justify-center mb-8">
+                  <%= link("Create an Account",
+                    to: Routes.pow_registration_path(@conn, :new, @conn.params),
+                    class:
+                      "text-center text-[#4ca6ff] text-lg font-bold font-['Open Sans'] leading-snug"
+                  ) %>
+              </div>
+            <% end %>
           <% end %>
         </div>
       </div>

--- a/test/oli_web/controllers/delivery_controller_test.exs
+++ b/test/oli_web/controllers/delivery_controller_test.exs
@@ -694,7 +694,7 @@ defmodule OliWeb.DeliveryControllerTest do
       conn = get(conn, Routes.delivery_path(conn, :show_enroll, section.slug))
 
       assert html_response(conn, 302) =~
-               "<html><body>You are being <a href=\"/?section=#{section.slug}&amp;from_invitation_link%3F=false\">redirected</a>.</body></html>"
+               "<html><body>You are being <a href=\"/?section=#{section.slug}&amp;from_invitation_link%3F=true\">redirected</a>.</body></html>"
 
       conn = mock_captcha(conn, section)
 

--- a/test/oli_web/controllers/static_page_controller_test.exs
+++ b/test/oli_web/controllers/static_page_controller_test.exs
@@ -211,4 +211,13 @@ defmodule OliWeb.StaticPageControllerTest do
                "You are being <a href=\"/workspaces/course_author\">redirected"
     end
   end
+
+  describe "enrollment link" do
+    test "displays 'Create an Account' link if from_invitation_link?", %{conn: conn} do
+      conn = get(conn, Routes.static_page_path(conn, :index, from_invitation_link?: true))
+
+      assert html_response(conn, 200) =~
+               "href=\"/registration/new?from_invitation_link%3F=true\">Create an Account"
+    end
+  end
 end


### PR DESCRIPTION
On the student sign in page, display 'Create an Account' link if from_invitation_link? param is set to true


https://github.com/user-attachments/assets/55c0f799-c6eb-4dd4-bc6a-e0c99677020f



See: https://eliterate.atlassian.net/browse/MER-3294