### PR TITLE
[BUG FIX] [MER-3847] Preserve attrs during scoring strategy application

### DIFF
--- a/lib/oli/delivery/attempts/scoring.ex
+++ b/lib/oli/delivery/attempts/scoring.ex
@@ -101,7 +101,7 @@ defmodule Oli.Delivery.Attempts.Scoring do
 
   defp translate_nils(items) do
     Enum.map(items, fn p ->
-      %{
+      Map.merge(p, %{
         score:
           if is_nil(p.score) do
             0
@@ -114,7 +114,7 @@ defmodule Oli.Delivery.Attempts.Scoring do
           else
             p.out_of
           end
-      }
+      })
     end)
   end
 

--- a/test/oli/delivery/attempts/scoring_test.exs
+++ b/test/oli/delivery/attempts/scoring_test.exs
@@ -30,6 +30,9 @@ defmodule Oli.Delivery.Attempts.ScoringTest do
       %{score: 9, out_of: 20, date_evaluated: nil}
     ]
 
+    most_recent_id = Oli.Resources.ScoringStrategy.get_id_by_type("most_recent")
+    assert %Result{score: 5, out_of: 10} = Scoring.calculate_score(most_recent_id, items)
+
     assert %Result{score: 5, out_of: 10} = Scoring.calculate_score("most_recent", items)
   end
 


### PR DESCRIPTION
Fix an issue uncovered from the last set of commits: namely that the `translate_nils` function in the `Scoring` module inadvertently was stripping out all attributes besides `out_of` and `score`. 

This changes preserves the mapping being done in `translate_nil`, but while preserving all the other attributes (which the "most_recent" strategy depends on) 