### PR TITLE
[BUG FIX] [MER-3857] Fix progress bar color

### DIFF
--- a/lib/oli_web/components/common.ex
+++ b/lib/oli_web/components/common.ex
@@ -596,12 +596,12 @@ defmodule OliWeb.Components.Common do
   )
 
   attr(:completed_colour, :string,
-    default: "bg-gray-600/20 dark:bg-white/20",
+    default: "bg-[#1E9531]",
     doc: "the colour of the progress bar when progress = 100%"
   )
 
   attr(:not_completed_colour, :string,
-    default: "bg-[#1E9531]",
+    default: "bg-gray-600/20 dark:bg-white/20",
     doc: "the colour of the not completed section of the progress bar"
   )
 


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-3857) to the ticket

The bug was introduced in [MER-3639](https://github.com/Simon-Initiative/oli-torus/pull/5119); when I extended the progress_bar component to support different colors and styling (height, rounded-corners, etc) I accidentally swapped the default color values.

### Before
![Screenshot 2024-09-27 at 9 37 40 AM](https://github.com/user-attachments/assets/de7b73c0-06d2-4614-a217-626a1c82b4c6)



### After
![Screenshot 2024-09-27 at 9 37 57 AM](https://github.com/user-attachments/assets/ca7821ef-b32c-49c3-a294-beb00829cd92)


[MER-3639]: https://eliterate.atlassian.net/browse/MER-3639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ