### PR TITLE
[BUG FIX] [MER-3300] Show sidebar if user can create sections

### DIFF
--- a/lib/oli_web/live/workspaces/student.ex
+++ b/lib/oli_web/live/workspaces/student.ex
@@ -38,7 +38,7 @@ defmodule OliWeb.Workspaces.Student do
      assign(socket,
        sections: sections,
        params: params,
-       disable_sidebar?: user_is_only_a_student?(all_sections),
+       disable_sidebar?: user_is_only_a_student?(current_user, all_sections),
        filtered_sections: sections,
        active_workspace: :student
      )}
@@ -429,5 +429,8 @@ defmodule OliWeb.Workspaces.Student do
     }
   end
 
-  defp user_is_only_a_student?(sections), do: Enum.all?(sections, &(&1.user_role == "student"))
+  defp user_is_only_a_student?(%{can_create_sections: true}, _sections), do: false
+
+  defp user_is_only_a_student?(_user, sections),
+    do: Enum.all?(sections, &(&1.user_role == "student"))
 end

--- a/test/oli_web/live/workspaces/student_test.exs
+++ b/test/oli_web/live/workspaces/student_test.exs
@@ -283,6 +283,13 @@ defmodule OliWeb.Workspaces.StudentTest do
       assert has_element?(view, "h5", "Maths")
     end
 
+    test "does show sidebar if user can create_sections", ctx do
+      {:ok, conn: conn, user: _} = user_conn(ctx, %{can_create_sections: true})
+      {:ok, view, _html} = live(conn, ~p"/workspaces/student")
+
+      assert render(view) =~ "desktop-workspace-nav-menu"
+    end
+
     test "can signout from student account and return to student workspace (and author account stays signed in)",
          %{conn: conn, user: user} do
       section_1 = insert(:section, %{open_and_free: true, title: "The best course ever!"})


### PR DESCRIPTION
If a user can create sections, then the user is considered and instructor and the navigation sidebar should be displayed.

See: https://eliterate.atlassian.net/browse/MER-3300
