### PR TITLE
[FEATURE] [MER-3604] Fix redirect after creating a project

### DIFF
--- a/lib/oli_web/controllers/project_controller.ex
+++ b/lib/oli_web/controllers/project_controller.ex
@@ -23,13 +23,13 @@ defmodule OliWeb.ProjectController do
     case Course.create_project(title, conn.assigns.current_author) do
       {:ok, %{project: project}} ->
         redirect(conn,
-          to: Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.OverviewLive, project.slug)
+          to: ~p"/workspaces/course_author/#{project.slug}/overview"
         )
 
       {:error, _changeset} ->
         conn
         |> put_flash(:error, "Could not create project. Please try again")
-        |> redirect(to: Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.ProjectsLive))
+        |> redirect(to: ~p"/workspaces/course_author")
     end
   end
 

--- a/test/oli_web/controllers/project_controller_test.exs
+++ b/test/oli_web/controllers/project_controller_test.exs
@@ -10,7 +10,7 @@ defmodule OliWeb.ProjectControllerTest do
   import Oli.Factory
 
   setup [:author_project_conn]
-  @valid_attrs %{title: "default title"}
+  @valid_attrs %{title: "default title", slug: "default_title"}
   @invalid_attrs %{title: ""}
 
   describe "projects" do
@@ -51,12 +51,14 @@ defmodule OliWeb.ProjectControllerTest do
   describe "create project" do
     test "redirects to page index when data is valid", %{conn: conn} do
       conn = post(conn, Routes.project_path(conn, :create), project: @valid_attrs)
-      assert html_response(conn, 302) =~ "/project/"
+
+      assert html_response(conn, 302) =~
+               "/workspaces/course_author/#{@valid_attrs.slug}/overview"
     end
 
     test "redirects back to workspace when data is invalid", %{conn: conn} do
       conn = post(conn, Routes.project_path(conn, :create), project: @invalid_attrs)
-      assert html_response(conn, 302) =~ "/projects"
+      assert html_response(conn, 302) =~ "/workspaces/course_author"
     end
   end
 


### PR DESCRIPTION
[MER-3604](https://eliterate.atlassian.net/browse/MER-3604)

This PR fixes the redirection after creating a project so that the user is redirected to the overview of the newly created project within the course author's workspace. 

https://github.com/user-attachments/assets/8d020a14-3a5c-4c51-892c-5f2728aaf518



[MER-3604]: https://eliterate.atlassian.net/browse/MER-3604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ