### PR TITLE
[FEATURE] [MER-3798] update scheduling type labels

### DIFF
--- a/lib/oli/delivery/hierarchy.ex
+++ b/lib/oli/delivery/hierarchy.ex
@@ -737,7 +737,7 @@ defmodule Oli.Delivery.Hierarchy do
       1 => [:inclass_activity, :due_by, :read_by],
       3 => [:due_by, :read_by],
       6 => [:read_by, :due_by],
-      7 => [:read_by],
+      7 => [:read_by, :due_by],
       10 => [:due_by]
     }
   """

--- a/lib/oli/delivery/hierarchy.ex
+++ b/lib/oli/delivery/hierarchy.ex
@@ -713,4 +713,90 @@ defmodule Oli.Delivery.Hierarchy do
     |> Map.put_new(:inspect_revision_title, node.revision.title)
     |> Map.put_new(:inspect_revision_slug, node.revision.slug)
   end
+
+  @doc """
+    Builds a map of resource_id to unique contained scheduling types for all containers in the hierarchy.
+
+    For example, given this hierarchy:
+
+    Root Container (resource_id = 1):
+      |_ Page 1 (resource_id = 2, scheduling_type = :inclass_activity)
+      |_ Unit 1 (resource_id = 3):
+        |_ Page 2 (resource_id = 4, scheduling_type = :due_by)
+        |_ Page 3 (resource_id = 5, scheduling_type = :read_by)
+      |_ Unit 2 (resource_id = 6):
+        |_ Module 1 (resource_id = 7):
+          |_ Page 4 (resource_id = 8, scheduling_type = :read_by)
+          |_ Page 5 (resource_id = 9, scheduling_type = :read_by)
+          |_ Section 1 (resource_id = 10):
+            |_ Page 6 (resource_id = 11, scheduling_type = :due_by)
+            |_ Page 7 (resource_id = 12, scheduling_type = :due_by)
+
+    The map would be:
+    %{
+      1 => [:inclass_activity, :due_by, :read_by],
+      3 => [:due_by, :read_by],
+      6 => [:read_by, :due_by],
+      7 => [:read_by],
+      10 => [:due_by]
+    }
+  """
+
+  def contained_scheduling_types(full_hierarchy) do
+    contained_scheduling_types(full_hierarchy["children"], [], full_hierarchy["resource_id"], %{})
+  end
+
+  @container_resource_type_id Oli.Resources.ResourceType.id_for_container()
+  defp contained_scheduling_types([] = _children, acum_list, current_container_id, result_map),
+    do:
+      Map.put(
+        result_map,
+        current_container_id,
+        acum_list
+        |> List.flatten()
+        |> Enum.uniq()
+      )
+
+  defp contained_scheduling_types(
+         [%{"children" => [], "resource_type_id" => @container_resource_type_id} = child | rest],
+         acum_list,
+         current_container_id,
+         result_map
+       ) do
+    # an edge case of a container with no children
+    contained_scheduling_types(
+      rest,
+      acum_list,
+      current_container_id,
+      Map.put(result_map, child["resource_id"], [])
+    )
+  end
+
+  defp contained_scheduling_types(
+         [%{"children" => []} = child | rest],
+         acum_list,
+         current_container_id,
+         result_map
+       ) do
+    # a page case
+    contained_scheduling_types(
+      rest,
+      [child["section_resource"].scheduling_type | acum_list],
+      current_container_id,
+      result_map
+    )
+  end
+
+  defp contained_scheduling_types([child | rest], acum_list, current_container_id, result_map) do
+    # a container with children case
+    result_map_for_current_child =
+      contained_scheduling_types(child["children"], [], child["resource_id"], %{})
+
+    contained_scheduling_types(
+      rest,
+      [Map.get(result_map_for_current_child, child["resource_id"]) | acum_list],
+      current_container_id,
+      Map.merge(result_map, result_map_for_current_child)
+    )
+  end
 end

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -4580,7 +4580,8 @@ defmodule Oli.Delivery.Sections do
       select_merge: %{
         numbering_index: sr.numbering_index,
         start_date: coalesce(se.start_date, sr.start_date),
-        end_date: coalesce(se.end_date, sr.end_date)
+        end_date: coalesce(se.end_date, sr.end_date),
+        scheduling_type: sr.scheduling_type
       }
     )
     |> where(^graded_filter)

--- a/lib/oli/delivery/sections/section_cache.ex
+++ b/lib/oli/delivery/sections/section_cache.ex
@@ -17,6 +17,7 @@ defmodule Oli.Delivery.Sections.SectionCache do
 
   @cache_keys [
     :ordered_container_labels,
+    :contained_scheduling_types,
     :page_to_container_map,
     :full_hierarchy
   ]

--- a/lib/oli_web/live/delivery/student/home/components/schedule_component.ex
+++ b/lib/oli_web/live/delivery/student/home/components/schedule_component.ex
@@ -319,18 +319,12 @@ defmodule OliWeb.Delivery.Student.Home.Components.ScheduleComponent do
   defp grouped_scheduling_type(scheduled_section_resources) do
     scheduling_types =
       Enum.map(scheduled_section_resources, fn scheduled_section_resource ->
-        if !is_nil(scheduled_section_resource.effective_settings) do
-          scheduled_section_resource.effective_settings.scheduling_type
-        else
-          scheduled_section_resource.resource.scheduling_type
-        end
+        if !is_nil(scheduled_section_resource.effective_settings),
+          do: scheduled_section_resource.effective_settings.scheduling_type,
+          else: scheduled_section_resource.resource.scheduling_type
       end)
 
-    if Enum.all?(scheduling_types, &(&1 == :read_by)) do
-      :read_by
-    else
-      :due_by
-    end
+    if Enum.all?(scheduling_types, &(&1 == :read_by)), do: :read_by, else: :due_by
   end
 
   attr :item_id, :string, required: true

--- a/lib/oli_web/live/delivery/student/home/components/schedule_component.ex
+++ b/lib/oli_web/live/delivery/student/home/components/schedule_component.ex
@@ -292,11 +292,16 @@ defmodule OliWeb.Delivery.Student.Home.Components.ScheduleComponent do
               Completed
             <% else %>
               <%= if is_nil(hd(@resources).effective_settings),
-                do: Utils.days_difference(hd(@resources).end_date, @ctx),
+                do:
+                  Utils.days_difference(
+                    hd(@resources).end_date,
+                    grouped_scheduling_type(@resources),
+                    @ctx
+                  ),
                 else:
                   Utils.coalesce(hd(@resources).effective_settings.end_date, hd(@resources).end_date)
                   |> Utils.coalesce(hd(@resources).effective_settings.start_date)
-                  |> Utils.days_difference(@ctx) %>
+                  |> Utils.days_difference(grouped_scheduling_type(@resources), @ctx) %>
             <% end %>
           </div>
           <Icons.check :if={@completed} progress={1.0} />
@@ -304,6 +309,28 @@ defmodule OliWeb.Delivery.Student.Home.Components.ScheduleComponent do
       </div>
     </div>
     """
+  end
+
+  _docp = """
+  If all the resources have a :read_by scheduling type, the group is considered to be :read_by,
+  so the label will end up being "Suggested by"
+  """
+
+  defp grouped_scheduling_type(scheduled_section_resources) do
+    scheduling_types =
+      Enum.map(scheduled_section_resources, fn scheduled_section_resource ->
+        if !is_nil(scheduled_section_resource.effective_settings) do
+          scheduled_section_resource.effective_settings.scheduling_type
+        else
+          scheduled_section_resource.resource.scheduling_type
+        end
+      end)
+
+    if Enum.all?(scheduling_types, &(&1 == :read_by)) do
+      :read_by
+    else
+      :due_by
+    end
   end
 
   attr :item_id, :string, required: true

--- a/lib/oli_web/live/delivery/student/index_live.ex
+++ b/lib/oli_web/live/delivery/student/index_live.ex
@@ -561,12 +561,14 @@ defmodule OliWeb.Delivery.Student.IndexLive do
             class="text-right dark:text-white text-opacity-90 text-xs font-semibold"
           >
             <%= if is_nil(@lesson.settings),
-              do: Utils.coalesce(@lesson.end_date, @lesson.start_date) |> Utils.days_difference(@ctx),
+              do:
+                Utils.coalesce(@lesson.end_date, @lesson.start_date)
+                |> Utils.days_difference(@lesson.scheduling_type, @ctx),
               else:
                 Utils.coalesce(@lesson.settings.end_date, @lesson.end_date)
                 |> Utils.coalesce(@lesson.settings.start_date)
                 |> Utils.coalesce(@lesson.start_date)
-                |> Utils.days_difference(@ctx) %>
+                |> Utils.days_difference(@lesson.settings.scheduling_type, @ctx) %>
           </div>
         </div>
       </div>

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -1035,7 +1035,9 @@ defmodule OliWeb.Delivery.Student.LearnLive do
               ] %>
             </h2>
             <span class="opacity-50 dark:text-white text-xs font-normal font-['Open Sans']">
-              Due: <%= format_date(
+              <%= Utils.container_label_for_scheduling_type(
+                Map.get(@contained_scheduling_types, selected_module["resource_id"])
+              ) %><%= format_date(
                 selected_module[
                   "section_resource"
                 ].end_date,

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -122,7 +122,8 @@ defmodule OliWeb.Delivery.Student.LearnLive do
 
   defp maybe_assign_contained_scheduling_types(socket, :gallery, full_hierarchy) do
     assign(socket,
-      contained_scheduling_types: Hierarchy.contained_scheduling_types(full_hierarchy)
+      contained_scheduling_types:
+        get_or_compute_contained_scheduling_types(socket.assigns.section.slug, full_hierarchy)
     )
   end
 
@@ -2759,6 +2760,12 @@ defmodule OliWeb.Delivery.Student.LearnLive do
   def get_or_compute_full_hierarchy(section) do
     SectionCache.get_or_compute(section.slug, :full_hierarchy, fn ->
       Hierarchy.full_hierarchy(section)
+    end)
+  end
+
+  def get_or_compute_contained_scheduling_types(section_slug, full_hierarchy) do
+    SectionCache.get_or_compute(section_slug, :contained_scheduling_types, fn ->
+      Hierarchy.contained_scheduling_types(full_hierarchy)
     end)
   end
 

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -907,9 +907,12 @@ defmodule OliWeb.Delivery.Student.LearnLive do
               <div class="ml-auto flex items-center gap-3" role="schedule_details">
                 <div class="text-[14px] leading-[32px] tracking-[0.02px] font-semibold">
                   <span class="text-gray-400 opacity-80 dark:text-[#696974] dark:opacity-100 mr-1">
-                    <%= Utils.container_label_for_scheduling_type(
-                      Map.get(@contained_scheduling_types, @unit["resource_id"])
-                    ) %>
+                    <%= if @unit["section_resource"].end_date in [nil, "Not yet scheduled"],
+                      do: "Due by:",
+                      else:
+                        Utils.container_label_for_scheduling_type(
+                          Map.get(@contained_scheduling_types, @unit["resource_id"])
+                        ) %>
                   </span>
                   <%= format_date(
                     @unit["section_resource"].end_date,

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -996,6 +996,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
           }
           phx-key="Escape"
         >
+          <% selected_module = Map.get(@selected_module_per_unit_resource_id, @unit["resource_id"]) %>
           <div
             role="expanded module header"
             class="self-stretch px-6 py-0.5 flex-col justify-start items-center gap-2 flex"
@@ -1003,10 +1004,10 @@ defmodule OliWeb.Delivery.Student.LearnLive do
             <div class="justify-start items-start gap-1 inline-flex">
               <div class="opacity-60 dark:text-white text-sm font-bold font-['Open Sans'] uppercase tracking-tight">
                 <%= container_label_and_numbering(
-                  Map.get(@selected_module_per_unit_resource_id, @unit["resource_id"])["numbering"][
+                  selected_module["numbering"][
                     "level"
                   ],
-                  Map.get(@selected_module_per_unit_resource_id, @unit["resource_id"])["numbering"][
+                  selected_module["numbering"][
                     "index"
                   ],
                   @section.customizations
@@ -1014,13 +1015,13 @@ defmodule OliWeb.Delivery.Student.LearnLive do
               </div>
             </div>
             <h2 class="self-stretch opacity-90 text-center text-[26px] font-normal font-['Open Sans'] leading-loose tracking-tight dark:text-white">
-              <%= Map.get(@selected_module_per_unit_resource_id, @unit["resource_id"])[
+              <%= selected_module[
                 "title"
               ] %>
             </h2>
             <span class="opacity-50 dark:text-white text-xs font-normal font-['Open Sans']">
               Due: <%= format_date(
-                Map.get(@selected_module_per_unit_resource_id, @unit["resource_id"])[
+                selected_module[
                   "section_resource"
                 ].end_date,
                 @ctx,
@@ -1030,7 +1031,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
           </div>
           <div
             :if={
-              Map.get(@selected_module_per_unit_resource_id, @unit["resource_id"])[
+              selected_module[
                 "intro_content"
               ][
                 "children"
@@ -1042,24 +1043,21 @@ defmodule OliWeb.Delivery.Student.LearnLive do
           >
             <div class="flex flex-col opacity-80">
               <span
-                data-toggle_read_more_button_id={"toggle_read_more_#{Map.get(@selected_module_per_unit_resource_id, @unit["resource_id"])["resource_id"]}"}
+                data-toggle_read_more_button_id={"toggle_read_more_#{selected_module["resource_id"]}"}
                 phx-hook="ToggleReadMore"
                 id={"selected_module_in_unit_#{@unit["resource_id"]}_intro_content"}
                 class="text-sm font-normal font-['Open Sans'] leading-[30px] max-w-[760px] overflow-hidden dark:text-white"
                 style="display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical;"
               >
                 <%= render_intro_content(
-                  Map.get(@selected_module_per_unit_resource_id, @unit["resource_id"])[
+                  selected_module[
                     "intro_content"
                   ][
                     "children"
                   ]
                 ) %>
               </span>
-              <div
-                id={"toggle_read_more_#{Map.get(@selected_module_per_unit_resource_id, @unit["resource_id"])["resource_id"]}"}
-                class="ml-auto"
-              >
+              <div id={"toggle_read_more_#{selected_module["resource_id"]}"} class="ml-auto">
                 <button
                   id={"read_more_module_intro_in_unit_#{@unit["resource_id"]}"}
                   phx-click={
@@ -1105,7 +1103,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
           >
             <div class="w-full">
               <% module =
-                Map.get(@selected_module_per_unit_resource_id, @unit["resource_id"]) %>
+                selected_module %>
               <.module_content_header
                 module={module}
                 page_metrics={
@@ -1130,7 +1128,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
                 ctx={@ctx}
                 student_id={@student_id}
                 intro_video_viewed={
-                  Map.get(@selected_module_per_unit_resource_id, @unit["resource_id"])["resource_id"] in @viewed_intro_video_resource_ids
+                  selected_module["resource_id"] in @viewed_intro_video_resource_ids
                 }
                 display_props_per_module_id={@display_props_per_module_id}
               />

--- a/lib/oli_web/live/delivery/student/utils.ex
+++ b/lib/oli_web/live/delivery/student/utils.ex
@@ -156,6 +156,14 @@ defmodule OliWeb.Delivery.Student.Utils do
     """
   end
 
+  @doc """
+  Returns the scheduling type label for the container.
+  When all the contained resources are of :read_by type, then
+  the label will be "Read by: "
+  """
+  def container_label_for_scheduling_type([:read_by]), do: "Read by: "
+  def container_label_for_scheduling_type(_), do: "Due by: "
+
   def label_for_scheduling_type(:due_by), do: "Due by: "
   def label_for_scheduling_type(:read_by), do: "Read by: "
   def label_for_scheduling_type(:inclass_activity), do: "In-class activity by: "

--- a/test/oli_web/live/delivery/student/home/components/schedule_component_test.exs
+++ b/test/oli_web/live/delivery/student/home/components/schedule_component_test.exs
@@ -300,7 +300,12 @@ defmodule OliWeb.Delivery.Student.Home.Components.ScheduleComponentTest do
       assert has_element?(lcd, ~s{#schedule_item_1_1 div[role="container_label"]}, "Unit 1")
       assert has_element?(lcd, ~s{#schedule_item_1_1 div[role="resource_type"]}, "Assignment")
       assert has_element?(lcd, ~s{#schedule_item_1_1 div[role="title"]}, "Graded 1")
-      assert has_element?(lcd, ~s{#schedule_item_1_1 div[role="details"]}, "Past Due")
+
+      assert has_element?(
+               lcd,
+               ~s{#schedule_item_1_1 div[role="details"]},
+               "Past suggested date by"
+             )
 
       # Displays Lesson group in Unit 1 > Module 1 (contains Graded 2 and Practice 1)
       assert has_element?(lcd, ~s{#schedule_item_1_2 div[role="container_label"]}, "Unit 1")
@@ -314,7 +319,7 @@ defmodule OliWeb.Delivery.Student.Home.Components.ScheduleComponentTest do
                "2 pages"
              )
 
-      assert has_element?(lcd, ~s{#schedule_item_1_2 div[role="details"]}, "Due Today")
+      assert has_element?(lcd, ~s{#schedule_item_1_2 div[role="details"]}, "Suggested for Today")
 
       ## Displays next week
       assert has_element?(lcd, ~s{#schedule_week_2 div[role="schedule_title"]}, "Next Week")

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -1059,7 +1059,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       assert has_element?(
                view,
                ~s{div[role="expanded module header"] span},
-               "Due: Wed Nov 15, 2023"
+               "Read by: Wed Nov 15, 2023"
              )
     end
 
@@ -1533,12 +1533,12 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       assert view
              |> element(~s{div[role="unit_1"] div[role="schedule_details"]})
              |> render() =~
-               "Due:\n              </span>\n              Sun, Dec 31, 2023 (8:00pm)"
+               "Read by: \n              </span>\n              Sun, Dec 31, 2023 (8:00pm)"
 
       # unit 2 has not been scheduled by instructor, so there must not be a schedule details data
       assert view
              |> element(~s{div[role="unit_2"] div[role="schedule_details"]})
-             |> render() =~ "Due:\n              </span>\n              Not yet scheduled"
+             |> render() =~ "Due by:\n              </span>\n              Not yet scheduled"
     end
 
     test "can see units, modules and page (at module level) progresses", %{

--- a/test/oli_web/live/delivery/student/utils_test.exs
+++ b/test/oli_web/live/delivery/student/utils_test.exs
@@ -37,7 +37,7 @@ defmodule OliWeb.Delivery.Student.UtilsTest do
     end
   end
 
-  describe "days_difference/1" do
+  describe "days_difference/3" do
     setup do
       stub_real_current_time()
 
@@ -54,23 +54,23 @@ defmodule OliWeb.Delivery.Student.UtilsTest do
 
     test "returns 'Due Today' when the resource end date is today", %{context: ctx} do
       today = Oli.DateTime.utc_now()
-      assert Utils.days_difference(today, ctx) == "Due Today"
+      assert Utils.days_difference(today, :due_by, ctx) == "Due Today"
     end
 
     test "returns '1 day left' when the resource end date is tomorrow", %{context: ctx} do
       tomorrow = Oli.DateTime.utc_now() |> Timex.shift(days: 1)
-      assert Utils.days_difference(tomorrow, ctx) == "1 day left"
+      assert Utils.days_difference(tomorrow, :due_by, ctx) == "1 day left"
     end
 
     test "returns 'Past Due by a day' when the resource end date was yesterday", %{context: ctx} do
       yesterday = Oli.DateTime.utc_now() |> Timex.shift(days: -1)
-      assert Utils.days_difference(yesterday, ctx) == "Past Due by a day"
+      assert Utils.days_difference(yesterday, :due_by, ctx) == "Past Due by a day"
     end
 
     test "returns 'Past Due by X days' when the resource end date was X days ago", %{context: ctx} do
       days_ago = 5
       past_date = Oli.DateTime.utc_now() |> Timex.shift(days: -days_ago)
-      assert Utils.days_difference(past_date, ctx) == "Past Due by #{days_ago} days"
+      assert Utils.days_difference(past_date, :due_by, ctx) == "Past Due by #{days_ago} days"
     end
 
     test "returns 'X days left' when the resource end date is X days in the future", %{
@@ -78,7 +78,7 @@ defmodule OliWeb.Delivery.Student.UtilsTest do
     } do
       days_ahead = 7
       future_date = Oli.DateTime.utc_now() |> Timex.shift(days: days_ahead)
-      assert Utils.days_difference(future_date, ctx) == "#{days_ahead} days left"
+      assert Utils.days_difference(future_date, :due_by, ctx) == "#{days_ahead} days left"
     end
 
     test "still returns 'Past Due by a day' when the resource end date was yesterday but less than 24 hours ago",
@@ -90,14 +90,14 @@ defmodule OliWeb.Delivery.Student.UtilsTest do
 
       # The end date is 2:59:59 AM in UTC, which is 11:59:59 PM the 23th in Montevideo
       previous_day = ~U[2024-06-24 02:59:59Z]
-      assert Utils.days_difference(previous_day, ctx) == "Past Due by a day"
+      assert Utils.days_difference(previous_day, :due_by, ctx) == "Past Due by a day"
     end
 
     test "still returns 'X days left' when the resource end date cannot be localized" do
       ctx = nil
       days_ahead = 7
       future_date = Oli.DateTime.utc_now() |> Timex.shift(days: days_ahead)
-      assert Utils.days_difference(future_date, ctx) == "#{days_ahead} days left"
+      assert Utils.days_difference(future_date, :due_by, ctx) == "#{days_ahead} days left"
     end
   end
 

--- a/test/oli_web/live/delivery/student/utils_test.exs
+++ b/test/oli_web/live/delivery/student/utils_test.exs
@@ -52,9 +52,10 @@ defmodule OliWeb.Delivery.Student.UtilsTest do
       ]
     end
 
-    test "returns 'Due Today' when the resource end date is today", %{context: ctx} do
+    test "returns the correct label when the resource end date is today", %{context: ctx} do
       today = Oli.DateTime.utc_now()
       assert Utils.days_difference(today, :due_by, ctx) == "Due Today"
+      assert Utils.days_difference(today, :read_by, ctx) == "Suggested for Today"
     end
 
     test "returns '1 day left' when the resource end date is tomorrow", %{context: ctx} do
@@ -62,15 +63,19 @@ defmodule OliWeb.Delivery.Student.UtilsTest do
       assert Utils.days_difference(tomorrow, :due_by, ctx) == "1 day left"
     end
 
-    test "returns 'Past Due by a day' when the resource end date was yesterday", %{context: ctx} do
+    test "returns the correct label when the resource end date was yesterday", %{context: ctx} do
       yesterday = Oli.DateTime.utc_now() |> Timex.shift(days: -1)
       assert Utils.days_difference(yesterday, :due_by, ctx) == "Past Due by a day"
+      assert Utils.days_difference(yesterday, :read_by, ctx) == "Past suggested date by a day"
     end
 
-    test "returns 'Past Due by X days' when the resource end date was X days ago", %{context: ctx} do
+    test "returns the correct label when the resource end date was X days ago", %{context: ctx} do
       days_ago = 5
       past_date = Oli.DateTime.utc_now() |> Timex.shift(days: -days_ago)
       assert Utils.days_difference(past_date, :due_by, ctx) == "Past Due by #{days_ago} days"
+
+      assert Utils.days_difference(past_date, :read_by, ctx) ==
+               "Past suggested date by #{days_ago} days"
     end
 
     test "returns 'X days left' when the resource end date is X days in the future", %{
@@ -81,7 +86,7 @@ defmodule OliWeb.Delivery.Student.UtilsTest do
       assert Utils.days_difference(future_date, :due_by, ctx) == "#{days_ahead} days left"
     end
 
-    test "still returns 'Past Due by a day' when the resource end date was yesterday but less than 24 hours ago",
+    test "still returns the correct label when the resource end date was yesterday but less than 24 hours ago",
          %{
            context: ctx
          } do
@@ -91,6 +96,7 @@ defmodule OliWeb.Delivery.Student.UtilsTest do
       # The end date is 2:59:59 AM in UTC, which is 11:59:59 PM the 23th in Montevideo
       previous_day = ~U[2024-06-24 02:59:59Z]
       assert Utils.days_difference(previous_day, :due_by, ctx) == "Past Due by a day"
+      assert Utils.days_difference(previous_day, :read_by, ctx) == "Past suggested date by a day"
     end
 
     test "still returns 'X days left' when the resource end date cannot be localized" do


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-3798) to the ticket

## Scheduling type label on home agenda:

https://github.com/user-attachments/assets/6cbefb07-e985-40b8-bae6-7383c7224245



## Scheduling type label on containers on Learn page:
When all the contained pages have scheduling type = "suggested by", the container label will be "Read by".

https://github.com/user-attachments/assets/f54a310d-6bab-4e2d-b7ce-4ad182eae45f

