### PR TITLE
[BUG FIX] [MER-3708] 500 error with iframed lesson launch links

### DIFF
--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -738,7 +738,8 @@ defmodule OliWeb.PageDeliveryController do
         pageTitle: context.page.title,
         pageSlug: context.page.slug,
         graded: context.page.graded,
-        content: build_page_content(context.page.content, conn.params["request_path"]),
+        content:
+          build_page_content(context.page.content, Plug.Conn.get_session(conn, :request_path)),
         resourceAttemptState: resource_attempt.state,
         resourceAttemptGuid: resource_attempt.attempt_guid,
         currentServerTime: DateTime.utc_now() |> to_epoch,
@@ -803,7 +804,7 @@ defmodule OliWeb.PageDeliveryController do
   before they accessed the page we are building (i.e. the "Learn", "Home" or "Schedule" page)
   """
 
-  defp build_page_content(content, nil), do: content
+  defp build_page_content(content, request_path) when request_path in ["", nil], do: content
   defp build_page_content(content, request_path), do: Map.put(content, "backUrl", request_path)
 
   defp to_epoch(nil), do: nil

--- a/lib/oli_web/plugs/redirect_by_attempt_state.ex
+++ b/lib/oli_web/plugs/redirect_by_attempt_state.ex
@@ -251,7 +251,6 @@ defmodule OliWeb.Plugs.RedirectByAttemptState do
          "/adaptive_lesson/"
        ) do
       conn
-      |> put_session(:request_path, conn.params["request_path"])
       |> assign(:already_been_redirected?, false)
     else
       # adaptive lesson in iframes do not support query params in the url

--- a/lib/oli_web/plugs/redirect_by_attempt_state.ex
+++ b/lib/oli_web/plugs/redirect_by_attempt_state.ex
@@ -222,13 +222,13 @@ defmodule OliWeb.Plugs.RedirectByAttemptState do
     end
   end
 
-  defp ensure_path(conn, rendering_type) when rendering_type in [:adaptive_lesson, :lesson] do
+  defp ensure_path(conn, rendering_type) when rendering_type == :lesson do
     section_slug = conn.params["section_slug"]
     revision_slug = conn.params["revision_slug"]
 
     if String.contains?(
          conn.request_path,
-         "/#{rendering_type}/"
+         "/lesson/"
        ) do
       conn
       |> assign(:already_been_redirected?, false)
@@ -237,7 +237,32 @@ defmodule OliWeb.Plugs.RedirectByAttemptState do
       |> halt()
       |> assign(:already_been_redirected?, true)
       |> Phoenix.Controller.redirect(
-        to: "/sections/#{section_slug}/#{rendering_type}/#{revision_slug}?#{conn.query_string}"
+        to: "/sections/#{section_slug}/lesson/#{revision_slug}?#{conn.query_string}"
+      )
+    end
+  end
+
+  defp ensure_path(conn, rendering_type) when rendering_type == :adaptive_lesson do
+    section_slug = conn.params["section_slug"]
+    revision_slug = conn.params["revision_slug"]
+
+    if String.contains?(
+         conn.request_path,
+         "/adaptive_lesson/"
+       ) do
+      conn
+      |> put_session(:request_path, conn.params["request_path"])
+      |> assign(:already_been_redirected?, false)
+    else
+      # adaptive lesson in iframes do not support query params in the url
+      # so we store the request_path in the session.
+      # * the request_path is used by the adaptive page to redirect the user back to the appropriate page
+      conn
+      |> halt()
+      |> put_session(:request_path, conn.params["request_path"])
+      |> assign(:already_been_redirected?, true)
+      |> Phoenix.Controller.redirect(
+        to: "/sections/#{section_slug}/adaptive_lesson/#{revision_slug}"
       )
     end
   end

--- a/lib/oli_web/plugs/redirect_by_attempt_state.ex
+++ b/lib/oli_web/plugs/redirect_by_attempt_state.ex
@@ -222,7 +222,7 @@ defmodule OliWeb.Plugs.RedirectByAttemptState do
     end
   end
 
-  defp ensure_path(conn, rendering_type) when rendering_type == :lesson do
+  defp ensure_path(conn, :lesson) do
     section_slug = conn.params["section_slug"]
     revision_slug = conn.params["revision_slug"]
 
@@ -242,7 +242,7 @@ defmodule OliWeb.Plugs.RedirectByAttemptState do
     end
   end
 
-  defp ensure_path(conn, rendering_type) when rendering_type == :adaptive_lesson do
+  defp ensure_path(conn, :adaptive_lesson) do
     section_slug = conn.params["section_slug"]
     revision_slug = conn.params["revision_slug"]
 

--- a/test/oli_web/live/delivery/student/lesson_live_test.exs
+++ b/test/oli_web/live/delivery/student/lesson_live_test.exs
@@ -681,9 +681,9 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
           )
         )
 
+      # adaptive pages should not have query params in the url (MER-3708)
       assert redirect_path ==
-               live_view_adaptive_lesson_live_route(section.slug, exploration_1.slug) <>
-                 "?request_path=some_request_path&selected_view=gallery"
+               live_view_adaptive_lesson_live_route(section.slug, exploration_1.slug)
     end
 
     test "can see default logo", %{

--- a/test/oli_web/live/delivery/student/lesson_live_test.exs
+++ b/test/oli_web/live/delivery/student/lesson_live_test.exs
@@ -940,8 +940,9 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
       request_path = "some_request_path"
 
       conn =
-        get(
-          conn,
+        conn
+        |> init_test_session(%{request_path: request_path})
+        |> get(
           live_view_adaptive_lesson_live_route(
             section.slug,
             graded_adaptive_page_revision.slug,
@@ -975,8 +976,9 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
       request_path = "some_other_request_path"
 
       conn =
-        get(
-          conn,
+        conn
+        |> init_test_session(%{request_path: request_path})
+        |> get(
           live_view_adaptive_lesson_live_route(
             section.slug,
             exploration_1.slug,


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-3708) to the ticket

The query params in the URL were causing the iframe to crash. The fix removes the query params from adaptive pages routes and, since the `request_path` query param was needed to provide the back URL path, we now pass it through the session.

### Before
The request_path (used for the back/home button) was passed as an URL query param

https://github.com/user-attachments/assets/e1afcbf5-75ce-44b7-a9d2-ea0204e57d58



### After
The request_path is set to the conn session to keep back/home button functionality working as before


https://github.com/user-attachments/assets/c158de38-1320-4f67-ae83-ccb3c441edf9

