### PR TITLE
[FEATURE] [MER-3415] Changing number of attempts available in simple author/flowchart tool

### DIFF
--- a/assets/src/apps/authoring/components/Flowchart/rules/create-cata-choice-rules.ts
+++ b/assets/src/apps/authoring/components/Flowchart/rules/create-cata-choice-rules.ts
@@ -26,7 +26,7 @@ import {
   getSequenceIdFromDestinationPath,
   getSequenceIdFromScreenResourceId,
 } from './create-generic-rule';
-import { generateThreeTryWorkflow } from './create-three-try-workflow';
+import { generateMaxTryWorkflow } from './create-three-try-workflow';
 import { RulesAndVariables } from './rule-compilation';
 
 // Check all that apply, aka Multiple Choice Question with multi-selection enabled
@@ -142,7 +142,7 @@ export const generateCATAChoiceRules = (
     return generateAllCorrectWorkflow(correct, [], disableAction, blankCondition);
   }
 
-  return generateThreeTryWorkflow(
+  return generateMaxTryWorkflow(
     correct,
     incorrect,
     commonErrorConditionsFeedback,

--- a/assets/src/apps/authoring/components/Flowchart/rules/create-cata-choice-rules.ts
+++ b/assets/src/apps/authoring/components/Flowchart/rules/create-cata-choice-rules.ts
@@ -149,6 +149,7 @@ export const generateCATAChoiceRules = (
     setCorrect,
     blankCondition,
     disableAction,
+    { maxAttempt: screen?.content?.custom?.maxAttempt || '2' },
   );
 };
 

--- a/assets/src/apps/authoring/components/Flowchart/rules/create-dropdown-rules.ts
+++ b/assets/src/apps/authoring/components/Flowchart/rules/create-dropdown-rules.ts
@@ -25,7 +25,7 @@ import {
   getSequenceIdFromDestinationPath,
   getSequenceIdFromScreenResourceId,
 } from './create-generic-rule';
-import { generateThreeTryWorkflow } from './create-three-try-workflow';
+import { generateMaxTryWorkflow } from './create-three-try-workflow';
 import { RulesAndVariables } from './rule-compilation';
 
 export const generateDropdownRules = (
@@ -118,7 +118,7 @@ export const generateDropdownRules = (
     2,
   );
 
-  return generateThreeTryWorkflow(
+  return generateMaxTryWorkflow(
     correct,
     incorrect,
     commonErrorConditionsFeedback,

--- a/assets/src/apps/authoring/components/Flowchart/rules/create-dropdown-rules.ts
+++ b/assets/src/apps/authoring/components/Flowchart/rules/create-dropdown-rules.ts
@@ -125,6 +125,7 @@ export const generateDropdownRules = (
     setCorrect,
     blankCondition,
     disableAction,
+    { maxAttempt: screen?.content?.custom?.maxAttempt || '2' },
   );
 };
 

--- a/assets/src/apps/authoring/components/Flowchart/rules/create-multiple-choice-rules.ts
+++ b/assets/src/apps/authoring/components/Flowchart/rules/create-multiple-choice-rules.ts
@@ -149,6 +149,7 @@ export const generateMultipleChoiceRules = (
     setCorrect,
     blankCondition,
     disableAction,
+    { maxAttempt: screen?.content?.custom?.maxAttempt || '2' },
   );
 };
 

--- a/assets/src/apps/authoring/components/Flowchart/rules/create-multiple-choice-rules.ts
+++ b/assets/src/apps/authoring/components/Flowchart/rules/create-multiple-choice-rules.ts
@@ -27,7 +27,7 @@ import {
   getSequenceIdFromDestinationPath,
   getSequenceIdFromScreenResourceId,
 } from './create-generic-rule';
-import { generateThreeTryWorkflow } from './create-three-try-workflow';
+import { generateMaxTryWorkflow } from './create-three-try-workflow';
 import { RulesAndVariables } from './rule-compilation';
 
 export const generateMultipleChoiceRules = (
@@ -142,7 +142,7 @@ export const generateMultipleChoiceRules = (
     );
   }
 
-  return generateThreeTryWorkflow(
+  return generateMaxTryWorkflow(
     correct,
     incorrect,
     commonErrorConditionsFeedback,

--- a/assets/src/apps/authoring/components/Flowchart/rules/create-number-input-rules.ts
+++ b/assets/src/apps/authoring/components/Flowchart/rules/create-number-input-rules.ts
@@ -27,7 +27,7 @@ import {
   getSequenceIdFromDestinationPath,
   getSequenceIdFromScreenResourceId,
 } from './create-generic-rule';
-import { generateThreeTryWorkflow } from './create-three-try-workflow';
+import { generateMaxTryWorkflow } from './create-three-try-workflow';
 import { RulesAndVariables } from './rule-compilation';
 
 export const generteNumberInputRules = (
@@ -126,7 +126,7 @@ export const generteNumberInputRules = (
     1,
   );
 
-  return generateThreeTryWorkflow(
+  return generateMaxTryWorkflow(
     correct,
     incorrect,
     commonErrorConditionsFeedback,

--- a/assets/src/apps/authoring/components/Flowchart/rules/create-number-input-rules.ts
+++ b/assets/src/apps/authoring/components/Flowchart/rules/create-number-input-rules.ts
@@ -133,6 +133,7 @@ export const generteNumberInputRules = (
     setCorrect,
     blankCondition,
     disableAction,
+    { maxAttempt: screen?.content?.custom?.maxAttempt || '2' },
   );
 };
 

--- a/assets/src/apps/authoring/components/Flowchart/rules/create-slider-rules.ts
+++ b/assets/src/apps/authoring/components/Flowchart/rules/create-slider-rules.ts
@@ -133,6 +133,7 @@ export const generateSliderRules = (
     setCorrect,
     blankCondition,
     disableAction,
+    { maxAttempt: screen?.content?.custom?.maxAttempt || '2' },
   );
 };
 

--- a/assets/src/apps/authoring/components/Flowchart/rules/create-slider-rules.ts
+++ b/assets/src/apps/authoring/components/Flowchart/rules/create-slider-rules.ts
@@ -107,7 +107,7 @@ export const generateSliderRules = (
 
   const setCorrect: IAction[] = [
     {
-      // Sets the correct answer in the dropdown
+      // Sets the correct  answer in the dropdown
       type: 'mutateState',
       params: {
         value: String(answer),

--- a/assets/src/apps/authoring/components/Flowchart/rules/create-slider-rules.ts
+++ b/assets/src/apps/authoring/components/Flowchart/rules/create-slider-rules.ts
@@ -27,7 +27,7 @@ import {
   getSequenceIdFromDestinationPath,
   getSequenceIdFromScreenResourceId,
 } from './create-generic-rule';
-import { generateThreeTryWorkflow } from './create-three-try-workflow';
+import { generateMaxTryWorkflow } from './create-three-try-workflow';
 import { RulesAndVariables } from './rule-compilation';
 
 export const generateSliderRules = (
@@ -126,7 +126,7 @@ export const generateSliderRules = (
     4,
   );
 
-  return generateThreeTryWorkflow(
+  return generateMaxTryWorkflow(
     correct,
     incorrect,
     commonErrorConditionsFeedback,

--- a/assets/src/apps/authoring/components/Flowchart/rules/create-text-input-rules.ts
+++ b/assets/src/apps/authoring/components/Flowchart/rules/create-text-input-rules.ts
@@ -17,7 +17,7 @@ import {
   IConditionWithFeedback,
   getSequenceIdFromScreenResourceId,
 } from './create-generic-rule';
-import { generateThreeTryWorkflow } from './create-three-try-workflow';
+import { generateMaxTryWorkflow } from './create-three-try-workflow';
 import { RulesAndVariables } from './rule-compilation';
 
 export const generateTextInputRules = (
@@ -93,15 +93,10 @@ export const generateTextInputRules = (
 
   threeTimesFeedback += 'Click next to continue. ';
 
-  return generateThreeTryWorkflow(
-    correct,
-    incorrect,
-    [],
-    setCorrect,
-    blankCondition,
-    disableAction,
-    { threeTimesFeedback, maxAttempt: screen?.content?.custom?.maxAttempt || '2' },
-  );
+  return generateMaxTryWorkflow(correct, incorrect, [], setCorrect, blankCondition, disableAction, {
+    threeTimesFeedback,
+    maxAttempt: screen?.content?.custom?.maxAttempt || '2',
+  });
 };
 
 export const createTextInputCorrectCondition = (

--- a/assets/src/apps/authoring/components/Flowchart/rules/create-text-input-rules.ts
+++ b/assets/src/apps/authoring/components/Flowchart/rules/create-text-input-rules.ts
@@ -100,7 +100,7 @@ export const generateTextInputRules = (
     setCorrect,
     blankCondition,
     disableAction,
-    { threeTimesFeedback },
+    { threeTimesFeedback, maxAttempt: screen?.content?.custom?.maxAttempt || '2' },
   );
 };
 

--- a/assets/src/apps/authoring/components/Flowchart/rules/create-three-try-workflow.ts
+++ b/assets/src/apps/authoring/components/Flowchart/rules/create-three-try-workflow.ts
@@ -45,6 +45,7 @@ export const generateThreeTryWorkflow = (
   disableAction: IAction,
   extraOptions: Partial<{
     threeTimesFeedback: string;
+    maxAttempt: string;
   }> = {},
 ): RulesAndVariables => {
   const rules: IAdaptiveRule[] = [];
@@ -115,7 +116,7 @@ export const generateThreeTryWorkflow = (
     rules.push(
       generateRule(
         'incorrect-3-times',
-        [thirdOrLaterTry(), ...incorrect.conditions.map(newId)],
+        [thirdOrLaterTry(extraOptions.maxAttempt || '2'), ...incorrect.conditions.map(newId)],
         incorrect.destinationId,
         false,
         40,
@@ -165,10 +166,10 @@ export const generateThreeTryWorkflow = (
 //   id: guid(),
 // });
 
-const thirdOrLaterTry = (): ICondition => ({
+const thirdOrLaterTry = (value: string): ICondition => ({
   fact: 'session.attemptNumber',
   operator: 'greaterThan',
-  value: '2',
+  value: value,
   type: 1,
   id: guid(),
 });

--- a/assets/src/apps/authoring/components/PropertyEditor/schemas/screen.ts
+++ b/assets/src/apps/authoring/components/PropertyEditor/schemas/screen.ts
@@ -56,15 +56,16 @@ export const simpleScreenSchema: JSONSchema7 = {
       type: 'object',
       title: 'Scoring',
       properties: {
-        // maxAttempt: {
-        //   title: 'Max Attempts',
-        //   type: 'number',
-        //   default: 3,
-        // },
         maxScore: {
           title: 'Max Score',
           type: 'number',
           default: 4,
+        },
+        maxAttempt: {
+          title: 'Max Attempts',
+          type: 'number',
+          default: 3,
+          enum: [1, 2, 3, 4, 5],
         },
       },
     },


### PR DESCRIPTION
Hey @bsparks could you please look at the PR. Thanks

The simple author currently defaults to 3 attempts for a screen, with no option to change this. The requirement was to introduce the ability to change the number of allowed attempts. The default should remain at three, but users should be able to specify a different number of attempts (1, 2, 3, 4, or 5). The system should honor the specified number.