### PR TITLE
[BUG FIX] [MER-3812] fixes the new author email confirmation broken bug

### DIFF
--- a/lib/oli_web/pow/author_controller_callbacks.ex
+++ b/lib/oli_web/pow/author_controller_callbacks.ex
@@ -4,7 +4,7 @@ defmodule OliWeb.Pow.AuthorControllerCallbacks do
   for example, to link the just created authoring account to the user account that is currently in the conn.
   More info in https://hexdocs.pm/pow/1.0.31/README.html#phoenix-controllers
   """
-  use Pow.Extension.Phoenix.ControllerCallbacks.Base
+  alias Pow.Extension.Phoenix.ControllerCallbacks
   use OliWeb, :verified_routes
 
   alias Oli.Utils
@@ -15,11 +15,13 @@ defmodule OliWeb.Pow.AuthorControllerCallbacks do
         Pow.Phoenix.SessionController,
         :create,
         {:error, %Plug.Conn{assigns: %{request_path: "/workspaces/course_author"}} = conn},
-        _config
+        config
       ) do
     conn
-    |> Phoenix.Controller.put_flash(:error, messages(conn).invalid_credentials(conn))
+    |> Phoenix.Controller.put_flash(:error, ControllerCallbacks.messages(conn).invalid_credentials(conn))
     |> Phoenix.Controller.redirect(to: ~p"/workspaces/course_author")
+
+    ControllerCallbacks.before_respond(Pow.Phoenix.SessionController, :create, {:ok, conn}, config)
   end
 
   def before_respond(
@@ -29,7 +31,7 @@ defmodule OliWeb.Pow.AuthorControllerCallbacks do
          %Plug.Conn{
            assigns: %{request_path: "/workspaces/course_author", ctx: %{user: %{author_id: nil}}}
          } = conn},
-        _config
+        config
       ) do
     {:ok, _updated_user} =
       link_to_user_account(conn.assigns.current_user, conn.assigns.current_author.id)
@@ -41,22 +43,26 @@ defmodule OliWeb.Pow.AuthorControllerCallbacks do
       "Account '#{conn.assigns.current_author.email}' is now linked to '#{conn.assigns.current_user.email}'"
     )
     |> Phoenix.Controller.redirect(to: ~p"/workspaces/course_author")
+
+    ControllerCallbacks.before_respond(Pow.Phoenix.SessionController, :create, {:ok, conn}, config)
   end
 
   def before_respond(
         Pow.Phoenix.SessionController,
         :create,
         {:ok, conn},
-        _config
+        config
       ) do
-    {:ok, maybe_logout_user(conn)}
+
+    conn = conn |> maybe_logout_user()
+    ControllerCallbacks.before_respond(Pow.Phoenix.SessionController, :create, {:ok, conn}, config)
   end
 
   def before_respond(
         Pow.Phoenix.RegistrationController,
         :create,
         {:error, author_changeset, conn},
-        _config
+        config
       ) do
     # for security reasons (possible account information leakage)
     # we don't want to show the email "has already been taken" error message (see MER-3129)
@@ -93,13 +99,13 @@ defmodule OliWeb.Pow.AuthorControllerCallbacks do
         conn
       end
 
-    {:error, %{author_changeset | errors: updated_errors}, conn}
+      ControllerCallbacks.before_respond(Pow.Phoenix.RegistrationController, :create, {:error, %{author_changeset | errors: updated_errors}, conn}, config)
   end
 
-  def before_respond(Pow.Phoenix.RegistrationController, :create, {:ok, author, conn}, _config) do
+  def before_respond(Pow.Phoenix.RegistrationController, :create, {:ok, author, conn}, config) do
     conn = maybe_assign_request_path(conn)
 
-    case conn do
+    {:ok, author, conn} = case conn do
       %{query_params: %{"link_to_user_account?" => "true"}, assigns: %{ctx: %{user: user}}}
       when not is_nil(user) ->
         {:ok, _updated_user} = link_to_user_account(user, author.id)
@@ -109,7 +115,12 @@ defmodule OliWeb.Pow.AuthorControllerCallbacks do
       _ ->
         {:ok, author, conn}
     end
+    ControllerCallbacks.before_respond(Pow.Phoenix.RegistrationController, :create, {:ok, author, conn}, config)
   end
+
+  defdelegate before_respond(controller, action, results, config), to:  ControllerCallbacks
+
+  defdelegate before_process(controller, action, results, config), to: ControllerCallbacks
 
   _docp = """
   If there is a "request_path" query parameter in the request, assign it to the conn.

--- a/lib/oli_web/pow/author_controller_callbacks.ex
+++ b/lib/oli_web/pow/author_controller_callbacks.ex
@@ -27,7 +27,7 @@ defmodule OliWeb.Pow.AuthorControllerCallbacks do
     ControllerCallbacks.before_respond(
       Pow.Phoenix.SessionController,
       :create,
-      {:ok, conn},
+      {:error, conn},
       config
     )
   end

--- a/lib/oli_web/pow/author_controller_callbacks.ex
+++ b/lib/oli_web/pow/author_controller_callbacks.ex
@@ -20,7 +20,7 @@ defmodule OliWeb.Pow.AuthorControllerCallbacks do
     conn
     |> Phoenix.Controller.put_flash(
       :error,
-      ControllerCallbacks.messages(conn).invalid_credentials(conn)
+      Pow.Phoenix.Controller.messages(conn, Pow.Phoenix.Messages).invalid_credentials(conn)
     )
     |> Phoenix.Controller.redirect(to: ~p"/workspaces/course_author")
 

--- a/lib/oli_web/pow/author_controller_callbacks.ex
+++ b/lib/oli_web/pow/author_controller_callbacks.ex
@@ -18,10 +18,18 @@ defmodule OliWeb.Pow.AuthorControllerCallbacks do
         config
       ) do
     conn
-    |> Phoenix.Controller.put_flash(:error, ControllerCallbacks.messages(conn).invalid_credentials(conn))
+    |> Phoenix.Controller.put_flash(
+      :error,
+      ControllerCallbacks.messages(conn).invalid_credentials(conn)
+    )
     |> Phoenix.Controller.redirect(to: ~p"/workspaces/course_author")
 
-    ControllerCallbacks.before_respond(Pow.Phoenix.SessionController, :create, {:ok, conn}, config)
+    ControllerCallbacks.before_respond(
+      Pow.Phoenix.SessionController,
+      :create,
+      {:ok, conn},
+      config
+    )
   end
 
   def before_respond(
@@ -44,7 +52,12 @@ defmodule OliWeb.Pow.AuthorControllerCallbacks do
     )
     |> Phoenix.Controller.redirect(to: ~p"/workspaces/course_author")
 
-    ControllerCallbacks.before_respond(Pow.Phoenix.SessionController, :create, {:ok, conn}, config)
+    ControllerCallbacks.before_respond(
+      Pow.Phoenix.SessionController,
+      :create,
+      {:ok, conn},
+      config
+    )
   end
 
   def before_respond(
@@ -53,9 +66,14 @@ defmodule OliWeb.Pow.AuthorControllerCallbacks do
         {:ok, conn},
         config
       ) do
-
     conn = conn |> maybe_logout_user()
-    ControllerCallbacks.before_respond(Pow.Phoenix.SessionController, :create, {:ok, conn}, config)
+
+    ControllerCallbacks.before_respond(
+      Pow.Phoenix.SessionController,
+      :create,
+      {:ok, conn},
+      config
+    )
   end
 
   def before_respond(
@@ -99,26 +117,38 @@ defmodule OliWeb.Pow.AuthorControllerCallbacks do
         conn
       end
 
-      ControllerCallbacks.before_respond(Pow.Phoenix.RegistrationController, :create, {:error, %{author_changeset | errors: updated_errors}, conn}, config)
+    ControllerCallbacks.before_respond(
+      Pow.Phoenix.RegistrationController,
+      :create,
+      {:error, %{author_changeset | errors: updated_errors}, conn},
+      config
+    )
   end
 
   def before_respond(Pow.Phoenix.RegistrationController, :create, {:ok, author, conn}, config) do
     conn = maybe_assign_request_path(conn)
 
-    {:ok, author, conn} = case conn do
-      %{query_params: %{"link_to_user_account?" => "true"}, assigns: %{ctx: %{user: user}}}
-      when not is_nil(user) ->
-        {:ok, _updated_user} = link_to_user_account(user, author.id)
+    {:ok, author, conn} =
+      case conn do
+        %{query_params: %{"link_to_user_account?" => "true"}, assigns: %{ctx: %{user: user}}}
+        when not is_nil(user) ->
+          {:ok, _updated_user} = link_to_user_account(user, author.id)
 
-        {:ok, author, conn}
+          {:ok, author, conn}
 
-      _ ->
-        {:ok, author, conn}
-    end
-    ControllerCallbacks.before_respond(Pow.Phoenix.RegistrationController, :create, {:ok, author, conn}, config)
+        _ ->
+          {:ok, author, conn}
+      end
+
+    ControllerCallbacks.before_respond(
+      Pow.Phoenix.RegistrationController,
+      :create,
+      {:ok, author, conn},
+      config
+    )
   end
 
-  defdelegate before_respond(controller, action, results, config), to:  ControllerCallbacks
+  defdelegate before_respond(controller, action, results, config), to: ControllerCallbacks
 
   defdelegate before_process(controller, action, results, config), to: ControllerCallbacks
 

--- a/test/oli_web/live/workspaces/course_author_test.exs
+++ b/test/oli_web/live/workspaces/course_author_test.exs
@@ -28,7 +28,8 @@ defmodule OliWeb.Workspaces.CourseAuthorTest do
             given_name: "me",
             family_name: "too",
             password: "some_password",
-            password_confirmation: "some_password"
+            password_confirmation: "some_password",
+            email_confirmed_at: Timex.now()
           },
           "g-recaptcha-response": "any"
         }


### PR DESCRIPTION
This PR updates the "OliWeb.Pow.AuthorControllerCallbacks," which was bypassing some upstream POW user and authentication management functionality, to allow delegation back upstream "Pow.Extension.Phoenix.ControllerCallbacks." This, in turn, fixes the broken email confirmation issue encountered when creating a new authoring account.