### PR TITLE
[ENHANCEMENT] [MER-3570] Add card transitions back for Instructor/Student index

### DIFF
--- a/lib/oli_web/live/workspaces/instructor/index_live.ex
+++ b/lib/oli_web/live/workspaces/instructor/index_live.ex
@@ -330,7 +330,7 @@ defmodule OliWeb.Workspaces.Instructor.IndexLive do
       phx-mounted={
         JS.transition(
           {"ease-out duration-300", "opacity-0 -translate-x-1/2", "opacity-100 translate-x-0"},
-          time: 300
+          time: if(@index < 6, do: 100 + @index * 20, else: 240)
         )
       }
       class="opacity-0 flex flex-col w-96 h-[500px] rounded-lg border-2 border-gray-700 transition-all overflow-hidden bg-white"

--- a/lib/oli_web/live/workspaces/student.ex
+++ b/lib/oli_web/live/workspaces/student.ex
@@ -256,7 +256,7 @@ defmodule OliWeb.Workspaces.Student do
                 JS.transition(
                   {"ease-out duration-300", "opacity-0 -translate-x-1/2",
                    "opacity-100 translate-x-0"},
-                  time: 300 + index * 60
+                  time: if(index < 6, do: 100 + index * 20, else: 240)
                 )
                 |> JS.remove_class("opacity-100 translate-x-0")
               }
@@ -309,7 +309,7 @@ defmodule OliWeb.Workspaces.Student do
       phx-mounted={
         JS.transition(
           {"ease-out duration-300", "opacity-0 -translate-x-1/2", "opacity-100 translate-x-0"},
-          time: 300
+          time: if(@index < 6, do: 100 + @index * 20, else: 240)
         )
       }
       class="opacity-0 flex flex-col w-96 h-[500px] rounded-lg border-2 border-gray-700 transition-all overflow-hidden bg-white"


### PR DESCRIPTION
As commented by @nicocirio in https://github.com/Simon-Initiative/oli-torus/pull/5155#pullrequestreview-2345421105, we can add the transitions back but only make them dynamic up to the 6th card which is what the user sees.