### PR TITLE
[BUG FIX] [MER-3612] Fix set num attempts default value

### DIFF
--- a/lib/oli_web/live/curriculum/entries/options_modal.ex
+++ b/lib/oli_web/live/curriculum/entries/options_modal.ex
@@ -385,16 +385,12 @@ defmodule OliWeb.Curriculum.OptionsModalContent do
                       }
                     />
                     <div class="ml-2">
+                      <% explanation_strategy =
+                        Ecto.Changeset.get_field(@form.source, :explanation_strategy) %>
+
                       <.input
                         :if={
-                          Ecto.Changeset.get_field(
-                            @form.source,
-                            :explanation_strategy
-                          ) &&
-                            Ecto.Changeset.get_field(
-                              @form.source,
-                              :explanation_strategy
-                            ).type == :after_set_num_attempts
+                          explanation_strategy && explanation_strategy.type == :after_set_num_attempts
                         }
                         name="revision[explanation_strategy][set_num_attempts]"
                         type="number"
@@ -402,6 +398,7 @@ defmodule OliWeb.Curriculum.OptionsModalContent do
                         placeholder="# of Attempts"
                         min={1}
                         field={es[:set_num_attempts]}
+                        value={explanation_strategy.set_num_attempts || 2}
                       />
                     </div>
                   </.inputs_for>

--- a/test/oli_web/live/curriculum/container_test.exs
+++ b/test/oli_web/live/curriculum/container_test.exs
@@ -622,6 +622,79 @@ defmodule OliWeb.Curriculum.ContainerLiveTest do
                  page_2.slug
                )
     end
+
+    test "an explanation strategy text input has a default value if after set num attempts option is selected",
+         %{
+           conn: conn,
+           project: project,
+           page_2: page_2
+         } do
+      {:ok, view, _html} =
+        live(conn, ~p"/authoring/project/#{project.slug}/curriculum")
+
+      # open options modal
+      view
+      |> element(
+        ~s{button[role="show_options_modal"][phx-value-slug="#{page_2.slug}"]},
+        "Options"
+      )
+      |> render_click()
+
+      # change explanation strategy to 'after set num attempts'
+      view
+      |> form("form#revision-settings-form")
+      |> render_change(%{
+        "revision" => %{
+          "explanation_strategy" => %{"type" => "after_set_num_attempts"}
+        }
+      })
+
+      # assert that input to set num attempts value is present with default value 2
+      assert has_element?(
+               view,
+               "input[id='revision_explanation_strategy_0_set_num_attempts'][value='2']"
+             )
+
+      # change value to 5
+      view
+      |> form("form#revision-settings-form")
+      |> render_change(%{
+        "revision" => %{
+          "explanation_strategy" => %{
+            "type" => "after_set_num_attempts",
+            "set_num_attempts" => "5"
+          }
+        }
+      })
+
+      # submit the form
+      view
+      |> form("form#revision-settings-form")
+      |> render_submit(%{})
+
+      {:ok, view, _html} =
+        live(conn, ~p"/authoring/project/#{project.slug}/curriculum")
+
+      # open options modal again
+      view
+      |> element(
+        ~s{button[role="show_options_modal"][phx-value-slug="#{page_2.slug}"]},
+        "Options"
+      )
+      |> render_click()
+
+      # assert that explanation strategy is set to 'after set num attempts'
+      assert has_element?(
+               view,
+               "option[value='after_set_num_attempts'][selected]"
+             )
+
+      # assert that input to set num attempts value is present with value 5
+      assert has_element?(
+               view,
+               "input[id='revision_explanation_strategy_0_set_num_attempts'][value='5']"
+             )
+    end
   end
 
   describe "Delete page" do


### PR DESCRIPTION
[MER-3612](https://eliterate.atlassian.net/browse/MER-3612)

This PR sets a default value of 2 to the numeric input that is used to set the number of attempts of the `After Set Num Attempts` explanation strategy within the modal that an author/admin uses to set the options for a course curriculum page. 

If the above strategy has no value it will default to a value of 2 and otherwise it will use the value that has been set previously.


https://github.com/user-attachments/assets/256110d8-22b3-4433-8645-5e72ca518f47



[MER-3612]: https://eliterate.atlassian.net/browse/MER-3612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ