### PR TITLE
[BUG FIX] [MER-3869] missing headers in author workspace

### DIFF
--- a/lib/oli_web/live/common/filter_box.ex
+++ b/lib/oli_web/live/common/filter_box.ex
@@ -20,7 +20,7 @@ defmodule OliWeb.Common.FilterBox do
   def render(assigns) do
     ~H"""
     <div class="mb-3 w-full">
-      <h3><%= @card_header_text %></h3>
+      <h2 id="header_id" class="pb-2"><%= @card_header_text %></h2>
       <div>
         <p class="mt-1 mb-4"><%= @card_body_text %></p>
         <div class="filter-opts flex flex-wrap items-center gap-2">

--- a/lib/oli_web/live/workspaces/course_author/activity_bank_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/activity_bank_live.ex
@@ -33,6 +33,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.ActivityBankLive do
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
+    <h2 id="header_id" class="pb-2">Activity Bank</h2>
     <script type="text/javascript" src={Routes.static_path(OliWeb.Endpoint, "/js/activitybank.js")}>
     </script>
 

--- a/lib/oli_web/live/workspaces/course_author/bibliography_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/bibliography_live.ex
@@ -40,6 +40,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.BibliographyLive do
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
+    <h2 id="header_id" class="pb-2">Bibliography</h2>
     <div :if={!@error} id="editor" phx-update="ignore">
       <%= React.component(@ctx, "Components.Bibliography", @context, id: "bibliography") %>
     </div>

--- a/lib/oli_web/live/workspaces/course_author/curriculum_live.html.heex
+++ b/lib/oli_web/live/workspaces/course_author/curriculum_live.html.heex
@@ -1,3 +1,4 @@
+<h2 id="header_id" class="pb-2">Curriculum</h2>
 <%= render_modal(assigns) %>
 
 <Modal.modal

--- a/lib/oli_web/live/workspaces/course_author/experiments_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/experiments_live.ex
@@ -35,6 +35,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.ExperimentsLive do
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
+    <h2 id="header_id" class="pb-2">Experiments</h2>
     <%= render_modal(assigns) %>
 
     <h3>A/B Testing with UpGrade</h3>

--- a/lib/oli_web/live/workspaces/course_author/insights_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/insights_live.ex
@@ -142,6 +142,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.InsightsLive do
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
+    <h2 id="header_id" class="pb-2">Insights</h2>
     <div class="mb-3">
       <p>
         Insights can help you improve your course by providing a statistical analysis of

--- a/lib/oli_web/live/workspaces/course_author/overview_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/overview_live.ex
@@ -73,6 +73,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.OverviewLive do
   def render(assigns) do
     ~H"""
     <div class="overview">
+      <h2 id="header_id" class="pb-2">Overview</h2>
       <.form :let={f} for={@changeset} phx-submit="update" phx-change="validate">
         <Overview.section
           title="Details"

--- a/lib/oli_web/live/workspaces/course_author/products/details_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/products/details_live.ex
@@ -67,6 +67,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.Products.DetailsLive do
 
   def render(assigns) do
     ~H"""
+    <h2 id="header_id" class="pb-2">Product Overview</h2>
     <%= render_modal(assigns) %>
     <div class="overview container">
       <div class="grid grid-cols-12 py-5 border-b">

--- a/lib/oli_web/live/workspaces/course_author/products_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/products_live.ex
@@ -58,6 +58,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.ProductsLive do
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
+    <h2 id="header_id" class="pb-2">Products</h2>
     <%= if @published? do %>
       <.form
         :let={f}

--- a/lib/oli_web/live/workspaces/course_author/publish_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/publish_live.ex
@@ -88,6 +88,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.PublishLive do
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
+    <h2 id="header_id" class="pb-2">Publish</h2>
     <%= render_modal(assigns) %>
     <div class="publish">
       <div class="flex flex-row">

--- a/lib/oli_web/live/workspaces/course_author/review_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/review_live.ex
@@ -35,6 +35,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.ReviewLive do
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
+    <h2 id="header_id" class="pb-2">Review</h2>
     <div class="review">
       <div class="grid grid-cols-12">
         <div class="col-span-12">

--- a/test/oli_web/live/all_pages_live_test.exs
+++ b/test/oli_web/live/all_pages_live_test.exs
@@ -199,7 +199,7 @@ defmodule OliWeb.AllPagesLiveTest do
       {:ok, view, _html} = live(conn, live_view_all_pages_route(project.slug))
 
       assert view
-             |> element("h3")
+             |> element("#header_id")
              |> render() =~
                "Browse All Pages"
 

--- a/test/oli_web/live/sections/admin_index_live_test.exs
+++ b/test/oli_web/live/sections/admin_index_live_test.exs
@@ -33,7 +33,7 @@ defmodule OliWeb.Sections.AdminIndexLiveTest do
     test "loads correctly when there are no sections", %{conn: conn} do
       {:ok, view, _html} = live(conn, @live_view_index_route)
 
-      assert has_element?(view, "h3", "Browse Course Sections")
+      assert has_element?(view, "#header_id", "Browse Course Sections")
       assert has_element?(view, "p", "None exist")
     end
 

--- a/test/oli_web/live/workspaces/course_author/experiments_live_test.exs
+++ b/test/oli_web/live/workspaces/course_author/experiments_live_test.exs
@@ -190,6 +190,13 @@ defmodule OliWeb.Workspaces.CourseAuthor.ExperimentsLiveTest do
       |> step(:test_duplicate_error_message)
       |> step(:test_experiment_has_2_options)
     end
+
+    test "renders header", %{view: view} do
+      assert view
+             |> element("#header_id")
+             |> render() =~
+               "Experiments"
+    end
   end
 
   defp evaluate_assertion(to_evaluate, assert_or_refute) do

--- a/test/oli_web/live/workspaces/course_author/pages_live_test.exs
+++ b/test/oli_web/live/workspaces/course_author/pages_live_test.exs
@@ -197,7 +197,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.PagesLiveTest do
       {:ok, view, _html} = live(conn, live_view_all_pages_route(project.slug))
 
       assert view
-             |> element("h3")
+             |> element("#header_id")
              |> render() =~
                "Browse All Pages"
 

--- a/test/oli_web/live/workspaces/course_author/products/details_live_test.exs
+++ b/test/oli_web/live/workspaces/course_author/products/details_live_test.exs
@@ -12,7 +12,13 @@ defmodule OliWeb.Workspaces.CourseAuthor.Products.DetailsLiveTest do
     do: ~p"/workspaces/course_author/#{project_slug}/products/#{product_slug}/?#{params}"
 
   describe "user cannot access when is not logged in" do
-    setup [:create_project, :publish_project, :create_product]
+    setup attrs do
+      {:ok,
+       attrs
+       |> create_project()
+       |> publish_project()
+       |> create_product()}
+    end
 
     test "redirects to new session when accessing product details view", ctx do
       %{conn: conn, project: project, product: product} = ctx
@@ -31,7 +37,16 @@ defmodule OliWeb.Workspaces.CourseAuthor.Products.DetailsLiveTest do
   end
 
   describe "user cannot access when is logged in as an author but is not an author of the project" do
-    setup [:author_conn, :create_project, :publish_project, :create_product]
+    setup attrs do
+      {:ok,
+       attrs
+       |> author_conn()
+       |> response_to_map()
+       |> add_new_author()
+       |> create_project()
+       |> publish_project()
+       |> create_product()}
+    end
 
     test "redirects to projects view when accessing the bibliography view", ctx do
       %{conn: conn, project: project, product: product} = ctx
@@ -48,24 +63,56 @@ defmodule OliWeb.Workspaces.CourseAuthor.Products.DetailsLiveTest do
     end
   end
 
+  describe "product details page" do
+    setup attrs do
+      {:ok,
+       attrs
+       |> author_conn()
+       |> response_to_map()
+       |> create_project()
+       |> publish_project()
+       |> create_product()}
+    end
+
+    test "renders header", ctx do
+      %{conn: conn, project: project, product: product} = ctx
+
+      {:ok, live, _html} = live(conn, live_view_route(project.slug, product.slug, %{}))
+
+      assert live
+             |> element("#header_id")
+             |> render() =~
+               "Product Overview"
+    end
+  end
+
   ##### HELPER FUNCTIONS #####
   alias Oli.Delivery.Sections.Blueprint
   alias Oli.Publishing
   alias Oli.Resources.ResourceType
 
+  defp response_to_map({:ok, list}) do
+    Enum.into(list, %{})
+  end
+
   defp create_product(ctx) do
     {:ok, product} = Blueprint.create_blueprint(ctx.project.slug, "Some Product", nil)
 
-    {:ok, %{product: product}}
+    Map.merge(ctx, %{product: product})
   end
 
   defp publish_project(ctx) do
     Publishing.publish_project(ctx.project, "Datashop test", ctx.author.id)
-    {:ok, %{}}
+    ctx
   end
 
-  defp create_project(_conn) do
+  defp add_new_author(ctx) do
     author = insert(:author)
+    Map.merge(Enum.into(ctx, %{}), %{author: author})
+  end
+
+  defp create_project(ctx) do
+    author = ctx[:author] || insert(:author)
     project = insert(:project, authors: [author])
     # root container
     container_resource = insert(:resource)
@@ -97,6 +144,6 @@ defmodule OliWeb.Workspaces.CourseAuthor.Products.DetailsLiveTest do
       author: author
     })
 
-    [project: project, publication: publication, author: author]
+    Map.merge(ctx, %{project: project, publication: publication, author: author})
   end
 end

--- a/test/oli_web/live/workspaces/course_author/publish_live_test.exs
+++ b/test/oli_web/live/workspaces/course_author/publish_live_test.exs
@@ -718,5 +718,14 @@ defmodule OliWeb.Workspaces.CourseAuthor.PublishLiveTest do
 
       assert length(enqueued_jobs) == 0
     end
+
+    test "renders header", %{conn: conn, project: project} do
+      {:ok, view, _html} = live(conn, live_view_publish_route(project.slug))
+
+      assert view
+             |> element("#header_id")
+             |> render() =~
+               "Publish"
+    end
   end
 end

--- a/test/oli_web/live/workspaces/course_author_test.exs
+++ b/test/oli_web/live/workspaces/course_author_test.exs
@@ -565,7 +565,7 @@ defmodule OliWeb.Workspaces.CourseAuthorTest do
     } do
       {:ok, view, _html} = live(conn, ~p"/workspaces/course_author/#{project.slug}/objectives")
 
-      assert has_element?(view, "h3", "Learning Objectives")
+      assert has_element?(view, "#header_id", "Learning Objectives")
 
       assert has_element?(
                view,
@@ -626,7 +626,7 @@ defmodule OliWeb.Workspaces.CourseAuthorTest do
     } do
       {:ok, view, _html} = live(conn, ~p"/workspaces/course_author/#{project.slug}/activities")
 
-      assert has_element?(view, "h3", "Browse All Activities")
+      assert has_element?(view, "h2", "Browse All Activities")
       assert has_element?(view, ~s(input[id='text-search-input']))
       assert has_element?(view, "a", "Open Sync View")
     end


### PR DESCRIPTION
Ticket: [MER-3869](https://eliterate.atlassian.net/browse/MER-3869)

This PR adds headers for resources in the course author space.

https://github.com/user-attachments/assets/8d01fec6-0d6b-4b93-a1af-8ad93e82ffeb



[MER-3869]: https://eliterate.atlassian.net/browse/MER-3869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ