### PR TITLE
[BUG FIX] [MER-3874] Add session id field

### DIFF
--- a/lib/oli/analytics/xapi/events/attempt/part_attempt_evaluated.ex
+++ b/lib/oli/analytics/xapi/events/attempt/part_attempt_evaluated.ex
@@ -20,7 +20,8 @@ defmodule Oli.Analytics.XAPI.Events.Attempt.PartAttemptEvaluated do
           out_of: out_of,
           feedback: feedback,
           date_evaluated: timestamp,
-          part_id: part_id
+          part_id: part_id,
+          datashop_session_id: session_id
         },
         %{
           attempt_guid: page_attempt_guid,
@@ -95,7 +96,8 @@ defmodule Oli.Analytics.XAPI.Events.Attempt.PartAttemptEvaluated do
           "http://oli.cmu.edu/extensions/activity_id" => activity_revision.resource_id,
           "http://oli.cmu.edu/extensions/activity_revision_id" => activity_revision.id,
           "http://oli.cmu.edu/extensions/part_id" => part_id,
-          "http://oli.cmu.edu/extensions/attached_objectives" => attached_objectives
+          "http://oli.cmu.edu/extensions/attached_objectives" => attached_objectives,
+          "http://oli.cmu.edu/extensions/session_id" => session_id
         }
       },
       "timestamp" => timestamp


### PR DESCRIPTION
The xAPI statement for evaluated part attempts is missing the `datashop_session_id` field, which makes DataShop calculations in the cloud a bit harder to do.  This PR adds it in as an extension. 