### PR TITLE
[BUG FIX] [MER-3877] Workspace sidebar overlaps simple adaptive pages

### DIFF
--- a/assets/src/apps/authoring/Authoring.tsx
+++ b/assets/src/apps/authoring/Authoring.tsx
@@ -121,6 +121,12 @@ const Authoring: React.FC<AuthoringProps> = (props: AuthoringProps) => {
   const url = `/authoring/project/${projectSlug}/preview/${revisionSlug}`;
   const windowName = `preview-${projectSlug}`;
 
+  const [sidebarExpanded, setSidebarExpanded] = useState(props.initialSidebarExpanded);
+
+  const handleSidebarExpanded = () => {
+    setSidebarExpanded((prev) => !prev);
+  };
+
   const onOnboardComplete = (appMode: ApplicationMode, title: string) => {
     const { revisionSlug } = props;
     const pageContent = props.content.content;
@@ -240,6 +246,13 @@ const Authoring: React.FC<AuthoringProps> = (props: AuthoringProps) => {
 
   return (
     <AppsignalContext.Provider value={appsignal}>
+      <button
+        role="update sidebar state on React"
+        className="hidden"
+        onClick={() => {
+          handleSidebarExpanded();
+        }}
+      ></button>
       <ErrorBoundary>
         <ModalContainer>
           {isLoading && (
@@ -255,7 +268,7 @@ const Authoring: React.FC<AuthoringProps> = (props: AuthoringProps) => {
               currentRule={currentRule}
               handlePanelStateChange={handlePanelStateChange}
               panelState={panelState}
-              initialSidebarExpanded={props.initialSidebarExpanded}
+              sidebarExpanded={sidebarExpanded}
             />
           )}
 

--- a/assets/src/apps/authoring/Authoring.tsx
+++ b/assets/src/apps/authoring/Authoring.tsx
@@ -276,10 +276,11 @@ const Authoring: React.FC<AuthoringProps> = (props: AuthoringProps) => {
             <AuthoringFlowchartPageEditor
               handlePanelStateChange={handlePanelStateChange}
               panelState={panelState}
+              sidebarExpanded={sidebarExpanded}
             />
           )}
 
-          {shouldShowFlowchartEditor && <FlowchartEditor />}
+          {shouldShowFlowchartEditor && <FlowchartEditor sidebarExpanded={sidebarExpanded} />}
 
           {shouldShowReadOnlyWarning && (
             <ReadOnlyWarning

--- a/assets/src/apps/authoring/AuthoringExpertPageEditor.tsx
+++ b/assets/src/apps/authoring/AuthoringExpertPageEditor.tsx
@@ -21,14 +21,14 @@ interface AuthoringPageEditorProps {
   panelState: PanelState;
   handlePanelStateChange: (p: Partial<PanelState>) => void;
   currentRule: string;
-  initialSidebarExpanded?: boolean;
+  sidebarExpanded?: boolean;
 }
 
 export const AuthoringExpertPageEditor: React.FC<AuthoringPageEditorProps> = ({
   panelState,
   handlePanelStateChange,
   currentRule,
-  initialSidebarExpanded,
+  sidebarExpanded,
 }) => {
   const authoringContainer = useRef<HTMLDivElement>(null);
   const [exportOpen, toggleExport] = useToggle();
@@ -40,13 +40,13 @@ export const AuthoringExpertPageEditor: React.FC<AuthoringPageEditorProps> = ({
         authoringContainer={authoringContainer}
         panelState={panelState}
         isVisible={panelState.top}
-        initialSidebarExpanded={initialSidebarExpanded}
+        sidebarExpanded={sidebarExpanded}
       />
       <SidePanel
         position="left"
         panelState={panelState}
         onToggle={() => handlePanelStateChange({ left: !panelState.left })}
-        initialSidebarExpanded={initialSidebarExpanded}
+        sidebarExpanded={sidebarExpanded}
       >
         <LeftMenu />
       </SidePanel>
@@ -54,7 +54,7 @@ export const AuthoringExpertPageEditor: React.FC<AuthoringPageEditorProps> = ({
       <BottomPanel
         panelState={panelState}
         onToggle={() => handlePanelStateChange({ bottom: !panelState.bottom })}
-        initialSidebarExpanded={initialSidebarExpanded}
+        sidebarExpanded={sidebarExpanded}
       >
         {currentRule === 'initState' && <InitStateEditor authoringContainer={authoringContainer} />}
         {currentRule !== 'initState' && <AdaptivityEditor />}

--- a/assets/src/apps/authoring/AuthoringFlowchartPageEditor.tsx
+++ b/assets/src/apps/authoring/AuthoringFlowchartPageEditor.tsx
@@ -21,10 +21,12 @@ interface PanelState {
 interface AuthoringPageEditorProps {
   panelState: PanelState;
   handlePanelStateChange: (p: Partial<PanelState>) => void;
+  sidebarExpanded?: boolean;
 }
 
 export const AuthoringFlowchartPageEditor: React.FC<AuthoringPageEditorProps> = ({
   panelState,
+  sidebarExpanded,
 }) => {
   const authoringContainer = useRef<HTMLDivElement>(null);
   const dispatch = useDispatch();
@@ -51,7 +53,7 @@ export const AuthoringFlowchartPageEditor: React.FC<AuthoringPageEditorProps> = 
   return (
     <div
       id="advanced-authoring"
-      className="advanced-authoring flowchart-editor "
+      className={`advanced-authoring flowchart-editor ${!sidebarExpanded ? '' : 'ml-[135px]'}`}
       ref={authoringContainer}
     >
       <FlowchartHeaderNav
@@ -59,15 +61,11 @@ export const AuthoringFlowchartPageEditor: React.FC<AuthoringPageEditorProps> = 
         isVisible={panelState.top}
         authoringContainer={authoringContainer}
       />
-
       <ScreenList onFlowchartMode={onFlowchartMode} />
-
       <EditingCanvas />
-
       <div className="fixed-right-panel">
         <RightMenu />
       </div>
-
       {requiresTemplateSelection && (
         <TemplatePicker
           screenType={activity?.authoring?.flowchart?.screenType}
@@ -75,7 +73,6 @@ export const AuthoringFlowchartPageEditor: React.FC<AuthoringPageEditorProps> = 
           onCancel={onCancelTemplate}
         />
       )}
-
       <FlowchartErrorDisplay />
     </div>
   );

--- a/assets/src/apps/authoring/BottomPanel.tsx
+++ b/assets/src/apps/authoring/BottomPanel.tsx
@@ -19,11 +19,11 @@ export interface BottomPanelProps {
   onToggle: any;
   children?: any;
   content?: any;
-  initialSidebarExpanded?: boolean;
+  sidebarExpanded?: boolean;
 }
 
 export const BottomPanel: React.FC<BottomPanelProps> = (props: BottomPanelProps) => {
-  const { panelState, onToggle, children, initialSidebarExpanded } = props;
+  const { panelState, onToggle, children, sidebarExpanded } = props;
   const PANEL_SIDE_WIDTH = '270px';
   const dispatch = useDispatch();
   const currentRule = useSelector(selectCurrentRule);
@@ -34,11 +34,6 @@ export const BottomPanel: React.FC<BottomPanelProps> = (props: BottomPanelProps)
   const isLayer = getIsLayer();
 
   const ref = useRef<HTMLElement>(null);
-  const [sidebarExpanded, setSidebarExpanded] = useState(initialSidebarExpanded);
-
-  const handleSidebarExpanded = () => {
-    setSidebarExpanded((prev) => !prev);
-  };
 
   useEffect(() => {
     if (currentRule === undefined) return;
@@ -160,13 +155,6 @@ export const BottomPanel: React.FC<BottomPanelProps> = (props: BottomPanelProps)
 
   return (
     <>
-      <button
-        role="update sidebar state on React"
-        className="hidden"
-        onClick={() => {
-          handleSidebarExpanded();
-        }}
-      ></button>
       <section
         id="aa-bottom-panel"
         ref={ref}

--- a/assets/src/apps/authoring/components/ExpertHeaderNav.tsx
+++ b/assets/src/apps/authoring/components/ExpertHeaderNav.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useState } from 'react';
 import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
 import {
@@ -21,11 +20,11 @@ interface HeaderNavProps {
   isVisible: boolean;
   authoringContainer: React.RefObject<HTMLElement>;
   onToggleExport?: () => void;
-  initialSidebarExpanded?: boolean;
+  sidebarExpanded?: boolean;
 }
 
 const ExpertHeaderNav: React.FC<HeaderNavProps> = (props: HeaderNavProps) => {
-  const { panelState, isVisible, initialSidebarExpanded } = props;
+  const { panelState, isVisible, sidebarExpanded } = props;
   const projectSlug = useSelector(selectProjectSlug);
   const revisionSlug = useSelector(selectRevisionSlug);
   const paths = useSelector(selectPaths);
@@ -37,12 +36,6 @@ const ExpertHeaderNav: React.FC<HeaderNavProps> = (props: HeaderNavProps) => {
 
   const url = `/authoring/project/${projectSlug}/preview/${revisionSlug}`;
   const windowName = `preview-${projectSlug}`;
-
-  const [sidebarExpanded, setSidebarExpanded] = useState(initialSidebarExpanded);
-
-  const handleSidebarExpanded = () => {
-    setSidebarExpanded((prev) => !prev);
-  };
 
   const handleReadOnlyClick = () => {
     // TODO: show a modal offering to confirm if you want to disable read only
@@ -69,13 +62,6 @@ const ExpertHeaderNav: React.FC<HeaderNavProps> = (props: HeaderNavProps) => {
           right: panelState['right'] ? PANEL_SIDE_WIDTH : 0,
         }}
       >
-        <button
-          role="update sidebar state on React"
-          className="hidden"
-          onClick={() => {
-            handleSidebarExpanded();
-          }}
-        ></button>
         <div className="btn-toolbar" role="toolbar">
           <div className="btn-group pl-3 align-items-center" role="group" aria-label="Third group">
             <UndoRedoToolbar />

--- a/assets/src/apps/authoring/components/Flowchart/FlowchartEditor.tsx
+++ b/assets/src/apps/authoring/components/Flowchart/FlowchartEditor.tsx
@@ -29,7 +29,11 @@ import { FlowchartTopToolbar } from './toolbar/FlowchartTopToolbar';
   The FlowchartComponent deals in flowchart related data.
 */
 
-export const FlowchartEditor = () => {
+interface FlowchartEditorProps {
+  sidebarExpanded?: boolean;
+}
+
+export const FlowchartEditor: React.FC<FlowchartEditorProps> = ({ sidebarExpanded }) => {
   const dispatch = useDispatch();
 
   const activities = useSelector(selectAllActivities);
@@ -107,7 +111,7 @@ export const FlowchartEditor = () => {
 
   return (
     <FlowchartEventContext.Provider value={events}>
-      <div className="flowchart-editor">
+      <div className={`flowchart-editor ${!sidebarExpanded ? '' : 'ml-[135px]'}`}>
         <DndProvider backend={HTML5Backend}>
           <div className="flowchart-left">
             <FlowchartModeOptions activeMode="flowchart" onPageEditMode={onPageEditMode} />

--- a/assets/src/apps/authoring/components/SidePanel.tsx
+++ b/assets/src/apps/authoring/components/SidePanel.tsx
@@ -1,31 +1,18 @@
 import React from 'react';
-import { useState } from 'react';
 
 export interface SidePanelProps {
   position: string;
   panelState: any;
   onToggle: any;
   children?: any;
-  initialSidebarExpanded?: boolean;
+  sidebarExpanded?: boolean;
 }
 
 export const SidePanel: React.FC<SidePanelProps> = (props: SidePanelProps) => {
-  const { position, panelState, onToggle, children, initialSidebarExpanded } = props;
-  const [sidebarExpanded, setSidebarExpanded] = useState(initialSidebarExpanded);
-
-  const handleSidebarExpanded = () => {
-    setSidebarExpanded((prev) => !prev);
-  };
+  const { position, panelState, onToggle, children, sidebarExpanded } = props;
 
   return (
     <>
-      <button
-        role="update sidebar state on React"
-        className="hidden"
-        onClick={() => {
-          handleSidebarExpanded();
-        }}
-      ></button>
       <button
         className={`aa-panel-side-toggle ${position}${
           panelState[position] ? ' open' : ''


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-3877) to the ticket

This PR makes a small refactor on the work done in [MER-3867](https://github.com/Simon-Initiative/oli-torus/pull/5170) (by setting the Authoring component as the source of truth for the sidebar state -collapsed or expanded-) and extends that fix for simple adaptive pages.

https://github.com/user-attachments/assets/488d6a2b-9fd7-4c3d-9afe-64fb679c238f



[MER-3867]: https://eliterate.atlassian.net/browse/MER-3867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ