### PR TITLE
[BUG FIX] [MER-3323] Add order column to sort

### DIFF
--- a/lib/oli_web/components/delivery/scored_activities/assessments_table_model.ex
+++ b/lib/oli_web/components/delivery/scored_activities/assessments_table_model.ex
@@ -8,32 +8,38 @@ defmodule OliWeb.Delivery.ScoredActivities.AssessmentsTableModel do
   def new(assessments, ctx, target) do
     column_specs = [
       %ColumnSpec{
+        name: :order,
+        label: "ORDER",
+        render_fn: &render_order_column/3,
+        th_class: "pl-10"
+      },
+      %ColumnSpec{
         name: :title,
         label: "ASSESSMENT",
-        render_fn: &__MODULE__.render_assessment_column/3,
+        render_fn: &render_assessment_column/3,
         th_class: "pl-10"
       },
       %ColumnSpec{
         name: :due_date,
         label: "DUE DATE",
-        render_fn: &__MODULE__.render_due_date_column/3
+        render_fn: &render_due_date_column/3
       },
       %ColumnSpec{
         name: :avg_score,
         label: "AVG SCORE",
-        render_fn: &__MODULE__.render_avg_score_column/3
+        render_fn: &render_avg_score_column/3
       },
       %ColumnSpec{
         name: :total_attempts,
         label: "TOTAL ATTEMPTS",
-        render_fn: &__MODULE__.render_attempts_column/3
+        render_fn: &render_attempts_column/3
       },
       %ColumnSpec{
         name: :students_completion,
         label: "STUDENTS PROGRESS",
         tooltip:
           "Progress is percent attempted of activities present on the page from the most recent page attempt. If there are no activities within the page, and if the student has visited that page, we count that as an attempt.",
-        render_fn: &__MODULE__.render_students_completion_column/3
+        render_fn: &render_students_completion_column/3
       }
     ]
 
@@ -47,6 +53,16 @@ defmodule OliWeb.Delivery.ScoredActivities.AssessmentsTableModel do
         target: target
       }
     )
+  end
+
+  def render_order_column(assigns, assessment, _) do
+    assigns = Map.merge(assigns, %{order: assessment.order})
+
+    ~H"""
+    <div class="pl-9 pr-4 flex flex-col">
+      <%= @order %>
+    </div>
+    """
   end
 
   def render_assessment_column(assigns, assessment, _) do

--- a/lib/oli_web/components/delivery/scored_activities/scored_activities.ex
+++ b/lib/oli_web/components/delivery/scored_activities/scored_activities.ex
@@ -38,7 +38,7 @@ defmodule OliWeb.Components.Delivery.ScoredActivities do
     offset: 0,
     limit: 20,
     sort_order: :asc,
-    sort_by: :title,
+    sort_by: :order,
     text_search: nil
   }
 
@@ -455,11 +455,14 @@ defmodule OliWeb.Components.Delivery.ScoredActivities do
 
       :title ->
         Enum.sort_by(assessments, &String.downcase(&1.title), sort_order)
+
+      :order ->
+        Enum.sort_by(assessments, fn a -> Map.get(a, :order) end, sort_order)
     end
   end
 
   defp decode_params(params) do
-    sort_options = [:title, :due_date, :avg_score, :total_attempts, :students_completion]
+    sort_options = [:order, :title, :due_date, :avg_score, :total_attempts, :students_completion]
 
     %{
       offset: Params.get_int_param(params, "offset", @default_params.offset),

--- a/test/oli_web/live/delivery/instructor_dashboard/scored_activities/scored_activities_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/scored_activities/scored_activities_tab_test.exs
@@ -1136,6 +1136,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.ScoredActivitiesTabTest do
       case tab_name do
         :assessments ->
           [
+            :order,
             :title,
             :due_date,
             :avg_score,
@@ -1297,6 +1298,50 @@ defmodule OliWeb.Delivery.InstructorDashboard.ScoredActivitiesTabTest do
              ] = table_as_list_of_maps(view, :assessments) |> Enum.map(& &1.due_date)
     end
 
+    test "sorting by Order number", %{
+      conn: conn,
+      section: section
+    } do
+      {:ok, view, _html} = live(conn, live_view_scored_activities_route(section.slug))
+      [a0, _a1, _a2, _a3, a4] = table_as_list_of_maps(view, :assessments)
+
+      assert view
+             |> element("tr:first-child > td:first-child > div")
+             |> render() =~ a0.order
+
+      assert view
+             |> element("tr:first-child > td:nth-child(2) > div")
+             |> render() =~ a0.title
+
+      assert view
+             |> element("tr:last-child > td:first-child > div")
+             |> render() =~ a4.order
+
+      assert view
+             |> element("tr:last-child > td:nth-child(2) > div > div")
+             |> render() =~ "Page 4"
+
+      view
+      |> element("th[phx-value-sort_by=order]")
+      |> render_click()
+
+      assert view
+             |> element("tr:first-child > td:first-child > div")
+             |> render() =~ a4.order
+
+      assert view
+             |> element("tr:first-child > td:nth-child(2) > div > div > a")
+             |> render() =~ "Page 4"
+
+      assert view
+             |> element("tr:last-child > td:first-child > div")
+             |> render() =~ a0.order
+
+      assert view
+             |> element("tr:last-child > td:nth-child(2) > div")
+             |> render() =~ a0.title
+    end
+
     test "displays custom labels", %{
       conn: conn,
       section: section
@@ -1342,7 +1387,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.ScoredActivitiesTabTest do
           assert String.starts_with?(url_with_params, url)
           assert url_with_params =~ "assessment_table_params[offset]=0"
           assert url_with_params =~ "assessment_table_params[limit]=20"
-          assert url_with_params =~ "assessment_table_params[sort_by]=title"
+          assert url_with_params =~ "assessment_table_params[sort_by]=order"
           assert url_with_params =~ "assessment_table_params[assessment_id]="
           assert url_with_params =~ "assessment_table_params[text_search]="
           assert url_with_params =~ "assessment_table_params[sort_order]=asc"


### PR DESCRIPTION
[MER-3323](https://eliterate.atlassian.net/browse/MER-3323)

This PR adds a new column to the table that shows the `Scored Activities` tab in the instructor dashboard. 

This new column shows the order that each of the pages in the course has and allows the user to filter by it.

https://github.com/user-attachments/assets/9108f97c-6bdd-4973-bbfc-300db5db6019



[MER-3323]: https://eliterate.atlassian.net/browse/MER-3323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ