### PR TITLE
[BUG FIX] [MER-3841] Make PageContent traversal functions hit content in properties like caption

### DIFF
--- a/lib/oli/authoring/editing/util.ex
+++ b/lib/oli/authoring/editing/util.ex
@@ -49,23 +49,6 @@ defmodule Oli.Authoring.Editing.Utils do
     end
   end
 
-  @doc """
-  Returns a MapSet of all bib_entry_id ids found in the page content hierarchy.
-  """
-  def citation_references(content) do
-    case content do
-      %{"model" => _} ->
-        Oli.Resources.PageContent.flat_filter(content, fn %{"type" => type} ->
-          type == "cite"
-        end)
-        |> Enum.map(fn %{"bib_entry_id" => id} -> id end)
-        |> MapSet.new()
-
-      _ ->
-        MapSet.new([])
-    end
-  end
-
   def new_container_name(numberings, parent_container) do
     numbering = Map.get(numberings, parent_container.id)
 

--- a/lib/oli/resources/page_content.ex
+++ b/lib/oli/resources/page_content.ex
@@ -70,13 +70,12 @@ defmodule Oli.Resources.PageContent do
     end
 
     # must process content in certain properties as well as children
+    props = ["children", "caption", "pronunciation", "translations", "content"]
+
     {item, acc} =
-      {item, acc}
-      |> map_reduce_property.("children")
-      |> map_reduce_property.("caption")
-      |> map_reduce_property.("pronunciation")
-      |> map_reduce_property.("translations")
-      |> map_reduce_property.("content")
+      Enum.reduce(props, {item, acc}, fn prop, {item, acc} ->
+        map_reduce_property.({item, acc}, prop)
+      end)
 
     map_fn.(item, acc, tr_context)
   end

--- a/test/oli/resources/page.json
+++ b/test/oli/resources/page.json
@@ -1,0 +1,187 @@
+{
+  "id": "278749",
+  "type": "Page",
+  "tags": [],
+  "title": "Test Page",
+  "content": {
+    "bibrefs": ["278748", "278747"],
+    "model": [
+      {
+        "children": [
+          {
+            "children": [
+              {
+                "text": "Here is a bit of initial text. "
+              }
+            ],
+            "id": "3028536558",
+            "type": "p"
+          },
+          {
+            "caption": [
+              {
+                "children": [
+                  {
+                    "text": "This "
+                  },
+                  {
+                    "children": [
+                      {
+                        "strong": true,
+                        "text": "thingamajig"
+                      }
+                    ],
+                    "content": [
+                      {
+                        "children": [
+                          {
+                            "text": "A watchamacallit "
+                          }
+                        ],
+                        "id": "1967646312",
+                        "type": "p"
+                      }
+                    ],
+                    "id": "4120843613",
+                    "trigger": "hover",
+                    "type": "popup"
+                  },
+                  {
+                    "text": " from book"
+                  },
+                  {
+                    "bibref": 278748,
+                    "children": [
+                      {
+                        "text": "[citation]"
+                      }
+                    ],
+                    "id": "3592083575",
+                    "type": "cite"
+                  },
+                  {
+                    "text": " I like"
+                  }
+                ],
+                "id": "3219108061",
+                "type": "p"
+              }
+            ],
+            "children": [
+              {
+                "id": "231pnc24ygd4lsh",
+                "text": ""
+              }
+            ],
+            "display": "block",
+            "id": "3532111699",
+            "src": "https://free-images.com/tn/30ad/books_old_books_press.jpg",
+            "type": "img"
+          },
+          {
+            "children": [
+              {
+                "text": ""
+              }
+            ],
+            "id": "3019815556",
+            "type": "p"
+          }
+        ],
+        "editor": "slate",
+        "id": "1638770113",
+        "textDirection": "ltr",
+        "type": "content"
+      },
+      {
+        "children": [
+          {
+            "children": [
+              {
+                "text": "This is some "
+              },
+              {
+                "children": [
+                  {
+                    "strong": true,
+                    "text": "sesquipedalian"
+                  }
+                ],
+                "content": [
+                  {
+                    "children": [
+                      {
+                        "text": "Of a word, long and pedantic."
+                      }
+                    ],
+                    "id": "1242368618",
+                    "type": "p"
+                  },
+                  {
+                    "children": [
+                      {
+                        "text": ""
+                      }
+                    ],
+                    "id": "2390437295",
+                    "type": "p"
+                  },
+                  {
+                    "children": [
+                      {
+                        "text": "Note this word describes itself."
+                      }
+                    ],
+                    "id": "1791462443",
+                    "type": "p"
+                  }
+                ],
+                "id": "220632361",
+                "trigger": "hover",
+                "type": "popup"
+              },
+              {
+                "text": " text "
+              },
+              {
+                "bibref": "278747",
+                "children": [
+                  {
+                    "text": "[citation]"
+                  }
+                ],
+                "id": "438197390",
+                "type": "cite"
+              },
+              {
+                "text": "  I like."
+              }
+            ],
+            "id": "2868870094",
+            "type": "p"
+          }
+        ],
+        "editor": "slate",
+        "id": "2261463222",
+        "textDirection": "ltr",
+        "type": "content"
+      }
+    ],
+    "version": "0.1.0"
+  },
+  "objectives": [],
+  "purpose": "foundation",
+  "originalFile": "",
+  "unresolvedReferences": [],
+  "collabSpace": {
+    "status": "disabled",
+    "threaded": true,
+    "auto_accept": true,
+    "show_full_history": true,
+    "participation_min_replies": 0,
+    "participation_min_posts": 0,
+    "anonymous_posting": true
+  },
+  "isGraded": false,
+  "relatesTo": []
+}

--- a/test/oli/resources/page_content_test.exs
+++ b/test/oli/resources/page_content_test.exs
@@ -171,10 +171,10 @@ defmodule Oli.Resources.PageContentTest do
           end
         )
 
-      # found all original ids
+      # verify found all original ids
       assert visited_id_count == length(original_ids)
 
-      # mapped all ids to "new"-prefixed ones
+      # verify mapped all ids to "new"-prefixed ones
       new_ids = extract_ids(mapped_content)
       assert length(new_ids) == length(original_ids)
       assert Enum.all?(new_ids, &String.starts_with?(&1, "new"))

--- a/test/oli/resources/page_content_test.exs
+++ b/test/oli/resources/page_content_test.exs
@@ -175,7 +175,7 @@ defmodule Oli.Resources.PageContentTest do
       assert visited_id_count == length(original_ids)
 
       # verify mapped all ids to "new"-prefixed ones
-      new_ids = extract_ids(mapped_content)
+      new_ids = extract_ids(mapped_content) |> Enum.uniq()
       assert length(new_ids) == length(original_ids)
       assert Enum.all?(new_ids, &String.starts_with?(&1, "new"))
     end


### PR DESCRIPTION
Citations in image captions were found to get broken on ingesting a correctly-migrated course, or on export-ingest of a correctly working course. This happened because the required rewiring process was not hitting cite elements in image captions. This happened because this rewiring used a function from the PageContent module which only traversed through element children, and caption content is in a caption property of the image,  not a child element. 

This PR implements a general solution to modify the relevant PageContent function to visit and process content in properties like the caption property of an image element, and also the relevant properties of a popup element, as is done correctly in the code that rewires links. 

~The relevant function is also used when generating unique ids for publication, so this change could affect that process as well, though if correct, should only improve it.~ Corrected below.