### PR TITLE
[ENHANCEMENT] [MER-3904] only create activity_attempts_submitted index if it doesnt already exist

### DIFF
--- a/priv/repo/migrations/20240917111312_add_lifecycle_index.exs
+++ b/priv/repo/migrations/20240917111312_add_lifecycle_index.exs
@@ -4,7 +4,7 @@ defmodule Oli.Repo.Migrations.AddLifecycleIndex do
   def up do
     # Creates a partial index on the lifecycle_state column where the value is 'submitted'
     execute(
-      "CREATE INDEX activity_attempts_submitted ON activity_attempts (lifecycle_state) WHERE lifecycle_state = 'submitted';"
+      "CREATE INDEX IF NOT EXISTS activity_attempts_submitted ON activity_attempts (lifecycle_state) WHERE lifecycle_state = 'submitted';"
     )
   end
 


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-3904

This PR adjusts a current migration to only attempt to create the activity_attempts_submitted index if it does not already exist.

This will allow us to create the index up-front before running the deployment in order to avoid excessive downtime and CI disconnects.

Without this, creating the index ahead of time would result in the following error:
```
12:48:26.281 [info] execute "CREATE INDEX activity_attempts_submitted ON activity_attempts (lifecycle_state) WHERE lifecycle_state = 'submitted';"
** (Postgrex.Error) ERROR 42P07 (duplicate_table) relation "activity_attempts_submitted" already exists
```