### PR TITLE
[BUG FIX] [MER-3135] Fix sorting payment status

### DIFF
--- a/lib/oli_web/components/delivery/students/students.ex
+++ b/lib/oli_web/components/delivery/students/students.ex
@@ -318,7 +318,11 @@ defmodule OliWeb.Components.Delivery.Students do
         Enum.sort_by(students, fn student -> student.engagement end, sort_order)
 
       :payment_status ->
-        Enum.sort_by(students, fn student -> student.payment_status end, sort_order)
+        Enum.sort_by(
+          students,
+          &{&1.payment_status, &1.payment_date && DateTime.to_unix(&1.payment_date)},
+          sort_order
+        )
 
       _ ->
         Enum.sort_by(


### PR DESCRIPTION
[MER-3135](https://eliterate.atlassian.net/browse/MER-3135)

This PR fixes and improves the sorting by the `Payment Status` column for the table shown within the students tab on the instructor dashboard. 

The aim is to sort by payment status first, so we can group and separate those with `:paid` and `:not_paid` status and then sort in ascending or descending order the records that have a payment date. 


https://github.com/user-attachments/assets/677761f4-261b-4c43-a9b3-e2776f36d6fa

