### PR TITLE
[BUG FIX] [MER-3264] Student exceptions drop down defaults to first lesson

### DIFF
--- a/lib/oli_web/live/sections/assessment_settings/student_exceptions_table.ex
+++ b/lib/oli_web/live/sections/assessment_settings/student_exceptions_table.ex
@@ -91,8 +91,6 @@ defmodule OliWeb.Sections.AssessmentSettings.StudentExceptionsTable do
   attr(:selected_setting, :map)
 
   def render(assigns) do
-    assigns = assign(assigns, assessment_changeset: to_form(%{}, as: :assessments))
-
     ~H"""
     <div id="student_exceptions_table" class="bg-white dark:bg-gray-800 shadow-sm">
       <%= due_date_modal(assigns) %>
@@ -102,7 +100,8 @@ defmodule OliWeb.Sections.AssessmentSettings.StudentExceptionsTable do
         <div class="flex flex-col pl-9 mr-auto">
           <h4 class="torus-h4">Student Exceptions</h4>
           <.form
-            for={@assessment_changeset}
+            :let={f}
+            for={%{}}
             id="assessment_select"
             phx-change="change_assessment"
             phx-target={@myself}
@@ -110,9 +109,10 @@ defmodule OliWeb.Sections.AssessmentSettings.StudentExceptionsTable do
             <div class="form-group">
               <.input
                 type="select"
-                field={@assessment_changeset[:assessment_id]}
+                field={f[:assessment_id]}
                 label="Select an assessment to manage student specific exceptions"
                 class="ml-4"
+                value={@selected_assessment && @selected_assessment.resource_id}
                 options={@options_for_select}
               />
             </div>
@@ -746,11 +746,7 @@ defmodule OliWeb.Sections.AssessmentSettings.StudentExceptionsTable do
      )}
   end
 
-  def handle_event(
-        "change_assessment",
-        %{"assessments" => %{"assessment_id" => assessment_id}},
-        socket
-      ) do
+  def handle_event("change_assessment", %{"assessment_id" => assessment_id}, socket) do
     {:noreply,
      push_patch(socket,
        to:

--- a/test/oli_web/live/sections/assessment_settings/settings_live_test.exs
+++ b/test/oli_web/live/sections/assessment_settings/settings_live_test.exs
@@ -1625,9 +1625,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
       # select assessment 1
       view
       |> form(~s{form[id=assessment_select]})
-      |> render_change(%{
-        "assessments" => %{"assessment_id" => page_1.resource.id}
-      })
+      |> render_change(%{"assessment_id" => page_1.resource.id})
 
       assert [se_1, se_2] = table_as_list_of_maps(view, :student_exceptions)
       assert se_1.student =~ student_1.name
@@ -1637,9 +1635,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
       # select assessment 2
       view
       |> form(~s{form[id=assessment_select]})
-      |> render_change(%{
-        "assessments" => %{"assessment_id" => page_2.resource.id}
-      })
+      |> render_change(%{"assessment_id" => page_2.resource.id})
 
       assert [se_1] = table_as_list_of_maps(view, :student_exceptions)
       assert se_1.student =~ student_1.name
@@ -1648,9 +1644,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
       # select assessment 3
       view
       |> form(~s{form[id=assessment_select]})
-      |> render_change(%{
-        "assessments" => %{"assessment_id" => page_3.resource.id}
-      })
+      |> render_change(%{"assessment_id" => page_3.resource.id})
 
       assert [] = table_as_list_of_maps(view, :student_exceptions)
       assert render(view) =~ "None exist"

--- a/test/oli_web/live/sections/assessment_settings/settings_live_test.exs
+++ b/test/oli_web/live/sections/assessment_settings/settings_live_test.exs
@@ -1824,6 +1824,39 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
       refute render(view) =~ "None exist"
     end
 
+    test "retains the selected option after opening modal", ctx do
+      %{conn: conn, section: section, page_1: page_1, page_2: page_2} = ctx
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_overview_route(section.slug, "student_exceptions", page_1.resource.id)
+        )
+
+      # Select Page 2
+      view
+      |> form(~s{form[id=assessment_select]})
+      |> render_change(%{"assessment_id" => page_2.resource.id})
+
+      target_element = ~s{select[id=assessment_select_assessment_id] > option[selected=selected]}
+
+      assert view |> element(target_element) |> render() =~ "Page 2"
+
+      # Open "Add New" modal
+      view
+      |> element(~s{button[phx-click=show_modal]}, "Add New")
+      |> render_click()
+
+      assert view |> element(target_element) |> render() =~ "Page 2"
+
+      # Close "Add New" modal
+      view
+      |> element(~s{button[id=cancel_exception_button]}, "Cancel")
+      |> render_click()
+
+      assert view |> element(target_element) |> render() =~ "Page 2"
+    end
+
     test "the add button is disabled if all students already have an exception for the given assessment",
          %{
            conn: conn,


### PR DESCRIPTION
Ticket: [MER-3264](https://eliterate.atlassian.net/browse/MER-3264)

This PR fixes the bug where selecting an option from the dropdown and then opening a modal resets the selected option to the first one.


https://github.com/user-attachments/assets/a9390704-5de1-4b25-b991-69c79420b119

