### PR TITLE
[BUG FIX] [MER-3701] Error managing gating student exceptions

### DIFF
--- a/lib/oli/delivery/gating.ex
+++ b/lib/oli/delivery/gating.ex
@@ -65,7 +65,8 @@ defmodule Oli.Delivery.Gating do
         select: gc,
         select_merge: %{
           total_count: fragment("count(*) OVER()"),
-          revision: rev
+          revision: rev,
+          user: u
         }
       )
 


### PR DESCRIPTION
[MER-3701](https://eliterate.atlassian.net/browse/MER-3701)

This PR fixes the bug happened when an admin or instructor tried to access the student exceptions view when there were already student exceptions on a gate by clicking the `Manage Student Exceptions` button.


https://github.com/user-attachments/assets/22246867-6b74-461b-8688-53664ac9b844



[MER-3701]: https://eliterate.atlassian.net/browse/MER-3701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ