### PR TITLE
[BUG FIX] [MER-3917] set page scoring strategy to "Best" on ingestion, to match new page default

### DIFF
--- a/lib/oli/interop/ingest/processor/pages.ex
+++ b/lib/oli/interop/ingest/processor/pages.ex
@@ -96,7 +96,7 @@ defmodule Oli.Interop.Ingest.Processor.Pages do
       children: {:placeholder, :children},
       resource_type_id: {:placeholder, :resource_type_id},
       activity_type_id: Map.get(state.registration_by_subtype, Map.get(resource, "subType")),
-      scoring_strategy_id: Oli.Resources.ScoringStrategy.get_id_by_type("average"),
+      scoring_strategy_id: Oli.Resources.ScoringStrategy.get_id_by_type("best"),
       explanation_strategy: get_explanation_strategy(graded),
       collab_space_config: read_collab_space(resource),
       purpose: Map.get(resource, "purpose", "foundation") |> String.to_existing_atom(),


### PR DESCRIPTION
Page option settings are not represented in the course archive format; rather, hard-coded defaults are assigned on ingestion. Ingestion code had been assigning a default page scoring strategy of "Average". This does not match the default assigned to newly authored pages, namely "Best". This caused headaches for authors of migrated courses. This PR changes the hard-coded ingestion default to "Best" to match the new page default. 