### PR TITLE
[ENHANCEMENT] [MER-3831] Improve handling of ungraded pages and their progress in the face of new publications

### DIFF
--- a/lib/oli/delivery/attempts/page_lifecycle/hierarchy.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/hierarchy.ex
@@ -7,7 +7,9 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Hierarchy do
 
   alias Oli.Delivery.Attempts.Core.{
     PartAttempt,
-    ActivityAttempt
+    ActivityAttempt,
+    ResourceAccess,
+    ResourceAttempt
   }
 
   import Oli.Delivery.Attempts.Core
@@ -94,7 +96,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Hierarchy do
   defp construct_attempt_prototypes(%VisitContext{
          effective_settings: %{retake_mode: :targeted, assessment_mode: :traditional},
          latest_resource_attempt: latest_resource_attempt,
-         page_revision: page_revision
+         page_revision: %Revision{graded: true} = page_revision
        }) do
     # If the page has changed revisions between attempts, we do not allow previous
     # correct attempts to manifest as constraining prototypes.  The issue here is that
@@ -102,6 +104,24 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Hierarchy do
     # make this step more robust by diffing all the referenced activities and selections.
     if latest_resource_attempt.revision_id == page_revision.id do
       get_correct_attempts(latest_resource_attempt.id)
+      |> Enum.map(fn attempt ->
+        Oli.Delivery.ActivityProvider.AttemptPrototype.from_attempt(attempt)
+      end)
+    else
+      []
+    end
+  end
+
+  defp construct_attempt_prototypes(%VisitContext{
+    latest_resource_attempt: latest_resource_attempt,
+    page_revision: %Revision{graded: false} = page_revision
+  }) do
+    # For ungraded pages, when the revision of page has changed, we
+    # construct activity attempt prototypes for all activities to pull forward
+    # their state, but only for those whose own revisions have not changed
+    if latest_resource_attempt.revision_id != page_revision.id do
+
+      get_migratable_activity_attempts(latest_resource_attempt.id)
       |> Enum.map(fn attempt ->
         Oli.Delivery.ActivityProvider.AttemptPrototype.from_attempt(attempt)
       end)
@@ -506,6 +526,30 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Hierarchy do
       )
     )
     |> results_to_activity_map
+  end
+
+  def get_migratable_activity_attempts(resource_attempt_id) do
+    Repo.all(
+      from(aa1 in ActivityAttempt,
+        join: ra in ResourceAttempt,
+        on:
+          aa1.resource_attempt_id == ra.id,
+        join: r in assoc(aa1, :revision),
+        left_join: aa2 in ActivityAttempt,
+        on:
+          aa1.resource_id == aa2.resource_id and aa1.id < aa2.id and
+            aa1.resource_attempt_id == aa2.resource_attempt_id,
+        left_join: a in ResourceAccess, on: a.id == ra.resource_access_id,
+        left_join: spp in Oli.Delivery.Sections.SectionsProjectsPublications,
+        on: spp.section_id == a.section_id,
+        left_join: pr in Oli.Publishing.PublishedResource,
+        on: pr.publication_id == spp.publication_id and aa1.revision_id == pr.revision_id,
+        where:
+          ra.id == ^resource_attempt_id and is_nil(aa2.id) and pr.revision_id == r.id,
+        preload: [revision: r],
+        select: aa1
+      )
+    )
   end
 
   # Retrieve the activity attempts that were "correct" for a given resource attempt. This

--- a/lib/oli/delivery/attempts/page_lifecycle/ungraded.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/ungraded.ex
@@ -132,8 +132,12 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Ungraded do
     Oli.Delivery.Metrics.mark_progress_completed(resource_access)
   end
 
-  defp do_update_progress(resource_access, _) do
+  defp do_update_progress(%{progress: nil}, _) do
     Oli.Delivery.Metrics.reset_progress(resource_access)
+  end
+
+  defp do_update_progress(r, _) do
+    {:ok, r}
   end
 
   # We need a new attempt when:

--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -1323,12 +1323,12 @@ defmodule Oli.Delivery.Metrics do
         UPDATE
           resource_accesses
         SET
-          progress = (SELECT
+          progress = GREATEST((SELECT
               COUNT(aa2.id) filter (WHERE aa2.lifecycle_state = 'evaluated' OR aa2.lifecycle_state = 'submitted')::float / COUNT(aa2.id)::float
             FROM activity_attempts as aa
             JOIN resource_attempts as ra ON ra.id = aa.resource_attempt_id
             JOIN activity_attempts as aa2 ON ra.id = aa2.resource_attempt_id
-            WHERE aa.attempt_guid = $1 AND aa2.scoreable = true AND aa2.attempt_number = 1),
+            WHERE aa.attempt_guid = $1 AND aa2.scoreable = true AND aa2.attempt_number = 1), resource_accesses.progress),
           updated_at = NOW()
         WHERE
           id =

--- a/lib/oli_web/live/delivery/student/utils.ex
+++ b/lib/oli_web/live/delivery/student/utils.ex
@@ -274,7 +274,7 @@ defmodule OliWeb.Delivery.Student.Utils do
   def reset_attempts_button(assigns) do
     ~H"""
     <button
-      :if={@page_context.review_mode == false && not @advanced_delivery}
+      :if={@page_context.review_mode == false && not @advanced_delivery && @activity_count > 0}
       id="reset_answers"
       class="btn btn-link btn-sm text-center mb-10"
       onClick={"window.OLI.finalize('#{@section_slug}', '#{@page_context.page.slug}', '#{hd(@page_context.resource_attempts).attempt_guid}', false, 'reset_answers')"}

--- a/test/oli/delivery/metrics/progress_test.exs
+++ b/test/oli/delivery/metrics/progress_test.exs
@@ -240,6 +240,27 @@ defmodule Oli.Delivery.Metrics.ProgressTest do
 
       ra = Oli.Repo.get(ResourceAccess, map.attempt1.resource_access_id)
       assert_in_delta 0.75, ra.progress, 0.0001
+
+      # Now lets simulate a second attempt for this page, which has a lower progress (0%)
+      map = map
+      |> Seeder.create_resource_attempt(
+          %{attempt_number: 2, lifecycle_state: :active},
+          :this_user,
+          :our_page,
+          :attempt2
+        )
+        |> Seeder.create_activity_attempt(
+          %{attempt_number: 1, lifecycle_state: :active, scoreable: true},
+          :activity_a,
+          :attempt1,
+          :a1
+        )
+      assert {:ok, :updated} = Metrics.update_page_progress(guid)
+
+      # Verify that the progress remains at 0.75 and does not go down to zero,
+      # because it can never go lower
+      ra = Oli.Repo.get(ResourceAccess, map.attempt2.resource_access_id)
+      assert_in_delta 0.75, ra.progress, 0.0001
     end
 
     test "progress_for_page/3 calculates correctly", %{


### PR DESCRIPTION
This PR does a few things:

1. Restores the "automatic" moving forward to new page revisions on visitation.  Previously we have disabled this automatic behavior and required the student to click "Reset all answers" because the automatic move forward was resetting progress.
2. Improves the "automatic" moving forward to a new page revision by pulling forward any existing student activity state for activities whose revisions have not changed.  This was done simply by leveraging the existing "constraining prototypes" infrastructure. 
3. Disables resetting of page progress for new attempts.  
4. Changes the "per activity" page progress update to never decrease existing page progress. 
5. Makes the "Reset all answers" link only visible on pages that have 1 or more activities

