### PR TITLE
[BUG FIX] [MER-3668] Navigation to weird interstitial unit page

### DIFF
--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -923,7 +923,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
           selected_view: selected_view
         )
 
-      # If the given resource is other than a unit or module (page, section/sub-section, unit), we navigate to lesson page.
+      # If the given resource is other than a unit or module (page, section/sub-section), we navigate to lesson page.
       _ ->
         # If the request_path is the Learn page and we navigate to a different lesson,
         # we need to update the request_path to include the new target resource.

--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -916,14 +916,14 @@ defmodule OliWeb.Components.Delivery.Layouts do
          selected_view
        ) do
     case {type, Integer.parse(level)} do
-      # If the given resource is a module (level == 2), we navigate to learn page.
-      {"container", {2, _}} ->
+      # If the given resource is a unit or module (level <= 2), we navigate to learn page.
+      {"container", {level, _}} when level <= 2 ->
         Utils.learn_live_path(section_slug,
           target_resource_id: resource_id,
           selected_view: selected_view
         )
 
-      # If the given resource is other than a module (page, section/sub-section, unit), we navigate to lesson page.
+      # If the given resource is other than a unit or module (page, section/sub-section, unit), we navigate to lesson page.
       _ ->
         # If the request_path is the Learn page and we navigate to a different lesson,
         # we need to update the request_path to include the new target resource.


### PR DESCRIPTION
[MER-3668](https://eliterate.atlassian.net/browse/MER-3668)

This PR modifies the way to navigate between resources while inside a page as a student. 

If the previous or next resource is a `Unit` or `Module` type container, navigating to that resource will redirect to the `Learn view`, going to the resource and highlighting it. 

This implementation was already in place, but we believe it was reverted in one of our previous versions. 

We already have written tests for these use cases. 


https://github.com/user-attachments/assets/0a79194c-8a12-48c6-b872-b873cfcc5f52




[MER-3668]: https://eliterate.atlassian.net/browse/MER-3668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ