### PR TITLE
[ENHANCEMENT] [MER-3824] Ensure uniqueness on user subs among different LTI institutions

### DIFF
--- a/lib/oli_web/controllers/lti_controller.ex
+++ b/lib/oli_web/controllers/lti_controller.ex
@@ -181,7 +181,7 @@ defmodule OliWeb.LtiController do
                 "default" => get_course_navigation_default(params),
                 "windowTarget" => "_blank"
               }
-              ## TODO: add support for more placement types in the future, possibly configurable by LMS admin 
+              ## TODO: add support for more placement types in the future, possibly configurable by LMS admin
               # assignment_selection when we support deep linking
               # %{
               #   "placement" => "assignment_selection",
@@ -363,28 +363,30 @@ defmodule OliWeb.LtiController do
 
         # update user values defined by the oidc standard per LTI 1.3 standard user identity claims
         # http://www.imsglobal.org/spec/lti/v1p3/#user-identity-claims
-        case Accounts.insert_or_update_lms_user(%{
-               sub: lti_params["sub"],
-               name: lti_params["name"],
-               given_name: lti_params["given_name"],
-               family_name: lti_params["family_name"],
-               middle_name: lti_params["middle_name"],
-               nickname: lti_params["nickname"],
-               preferred_username: lti_params["preferred_username"],
-               profile: lti_params["profile"],
-               picture: lti_params["picture"],
-               website: lti_params["website"],
-               email: lti_params["email"],
-               email_verified: true,
-               gender: lti_params["gender"],
-               birthdate: lti_params["birthdate"],
-               zoneinfo: lti_params["zoneinfo"],
-               locale: lti_params["locale"],
-               phone_number: lti_params["phone_number"],
-               phone_number_verified: lti_params["phone_number_verified"],
-               address: lti_params["address"],
-               institution_id: institution.id
-             }) do
+        case Accounts.insert_or_update_lms_user(
+               %{
+                 sub: lti_params["sub"],
+                 name: lti_params["name"],
+                 given_name: lti_params["given_name"],
+                 family_name: lti_params["family_name"],
+                 middle_name: lti_params["middle_name"],
+                 nickname: lti_params["nickname"],
+                 preferred_username: lti_params["preferred_username"],
+                 profile: lti_params["profile"],
+                 picture: lti_params["picture"],
+                 website: lti_params["website"],
+                 email: lti_params["email"],
+                 email_verified: true,
+                 gender: lti_params["gender"],
+                 birthdate: lti_params["birthdate"],
+                 zoneinfo: lti_params["zoneinfo"],
+                 locale: lti_params["locale"],
+                 phone_number: lti_params["phone_number"],
+                 phone_number_verified: lti_params["phone_number_verified"],
+                 address: lti_params["address"]
+               },
+               institution.id
+             ) do
           {:ok, user} ->
             # update lti params and session to be associated with the current lms user
             {:ok, %{id: lti_params_id}} =

--- a/priv/repo/migrations/20241017190834_drop_users_sub_index.exs
+++ b/priv/repo/migrations/20241017190834_drop_users_sub_index.exs
@@ -1,0 +1,11 @@
+defmodule Oli.Repo.Migrations.DropUsersSubIndex do
+  use Ecto.Migration
+
+  def up do
+    drop unique_index(:users, [:sub])
+  end
+
+  def down do
+    create unique_index(:users, [:sub])
+  end
+end

--- a/test/oli_web/controllers/cognito_controller_test.exs
+++ b/test/oli_web/controllers/cognito_controller_test.exs
@@ -35,7 +35,7 @@ defmodule OliWeb.CognitoControllerTest do
       email: email
     } do
       {:ok, _user} =
-        Accounts.insert_or_update_lms_user(%{
+        Accounts.insert_or_update_sso_user(%{
           sub: "user999",
           preferred_username: "user999",
           email: email,
@@ -65,7 +65,7 @@ defmodule OliWeb.CognitoControllerTest do
       {:ok, author} = Accounts.insert_or_update_author(%{email: author_email})
 
       {:ok, _user} =
-        Accounts.insert_or_update_lms_user(%{
+        Accounts.insert_or_update_sso_user(%{
           sub: "user999",
           preferred_username: "user999",
           email: email,
@@ -102,7 +102,7 @@ defmodule OliWeb.CognitoControllerTest do
       email: email
     } do
       {:ok, user} =
-        Accounts.insert_or_update_lms_user(%{
+        Accounts.insert_or_update_sso_user(%{
           sub: "user999",
           preferred_username: "user999",
           email: email,
@@ -260,7 +260,7 @@ defmodule OliWeb.CognitoControllerTest do
            email: email
          } do
       {:ok, user} =
-        Accounts.insert_or_update_lms_user(%{
+        Accounts.insert_or_update_sso_user(%{
           sub: "user999",
           preferred_username: "user999",
           email: email,
@@ -295,7 +295,7 @@ defmodule OliWeb.CognitoControllerTest do
            email: email
          } do
       {:ok, user} =
-        Accounts.insert_or_update_lms_user(%{
+        Accounts.insert_or_update_sso_user(%{
           sub: "user999",
           preferred_username: "user999",
           email: email,


### PR DESCRIPTION
[MER-3824](https://eliterate.atlassian.net/browse/MER-3824)

When an LTI launch happened as a student, the system previously used the user's `sub` to create or update the student's data and log him in. Since this sub is an external string, nothing ensures its uniqueness among different LMS institutions.
That's why these changes introduce a new query before an LMS launch to avoid `sub` collisions and be sure that we are under the scope of the LMS institution.

**Important Note:**
The same fix should be made as a separate PR under the SSO process since we could potentially end up with the same issue. 

[MER-3824]: https://eliterate.atlassian.net/browse/MER-3824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ