### PR TITLE
[BUG FIX] [MER-3933] Authors get sent to old UI when interacting with project collaborators

### DIFF
--- a/lib/oli/authoring/collaborators.ex
+++ b/lib/oli/authoring/collaborators.ex
@@ -1,4 +1,5 @@
 defmodule Oli.Authoring.Collaborators do
+  use OliWeb, :verified_routes
   alias Oli.Authoring.Authors.{AuthorProject, ProjectRole}
   alias Oli.Repo
   alias Oli.Accounts
@@ -145,7 +146,7 @@ defmodule Oli.Authoring.Collaborators do
           Routes.pow_invitation_invitation_path(conn, :edit, token)
 
         :existing_user ->
-          Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.OverviewLive, project.slug)
+          ~p"/workspaces/course_author/#{project.slug}/overview"
       end
 
     invited_by_user_id = Map.get(invited_by, invited_by.__struct__.pow_user_id_field())

--- a/lib/oli_web/common/breadcrumb.ex
+++ b/lib/oli_web/common/breadcrumb.ex
@@ -184,7 +184,7 @@ defmodule OliWeb.Common.Breadcrumb do
     [
       new(%{
         full_title: "Project Overview",
-        link: Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.OverviewLive, project_slug)
+        link: ~p"/workspaces/course_author/#{project_slug}/overview"
       }),
       new(%{
         full_title: "All Pages",
@@ -246,7 +246,7 @@ defmodule OliWeb.Common.Breadcrumb do
     [
       Breadcrumb.new(%{
         full_title: project.title,
-        link: Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.OverviewLive, project.slug)
+        link: ~p"/workspaces/course_author/#{project.slug}/overview"
       })
     ]
   end

--- a/lib/oli_web/controllers/cognito_controller.ex
+++ b/lib/oli_web/controllers/cognito_controller.ex
@@ -185,7 +185,7 @@ defmodule OliWeb.CognitoController do
     case Clone.clone_project(project_slug, author, author_in_project_title: true) do
       {:ok, dupe} ->
         redirect(conn,
-          to: Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.OverviewLive, dupe.slug)
+          to: ~p"/workspaces/course_author/#{dupe.slug}/overview"
         )
 
       {:error, error} ->

--- a/lib/oli_web/controllers/collaborator_controller.ex
+++ b/lib/oli_web/controllers/collaborator_controller.ex
@@ -48,9 +48,7 @@ defmodule OliWeb.CollaboratorController do
                 else: "This person is already a collaborator in this project."
               )
             )
-            |> redirect(
-              to: Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.OverviewLive, project_id)
-            )
+            |> redirect(to: ~p"/workspaces/course_author/#{project_id}/overview")
 
           false ->
             if Enum.count(emails) > @max_invitation_emails do
@@ -59,9 +57,7 @@ defmodule OliWeb.CollaboratorController do
                 :error,
                 "Collaborator invitations cannot exceed #{@max_invitation_emails} emails at a time. Please try again with fewer invites"
               )
-              |> redirect(
-                to: Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.OverviewLive, project_id)
-              )
+              |> redirect(to: ~p"/workspaces/course_author/#{project_id}/overview")
             else
               emails
               |> Enum.reduce({conn, []}, fn email, {conn, failures} ->
@@ -71,10 +67,7 @@ defmodule OliWeb.CollaboratorController do
                 {conn, []} ->
                   conn
                   |> put_flash(:info, "Collaborator invitations sent!")
-                  |> redirect(
-                    to:
-                      Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.OverviewLive, project_id)
-                  )
+                  |> redirect(to: ~p"/workspaces/course_author/#{project_id}/overview")
 
                 {conn, failures} ->
                   if Enum.count(failures) == Enum.count(emails) do
@@ -82,14 +75,7 @@ defmodule OliWeb.CollaboratorController do
 
                     conn
                     |> put_flash(:error, "Failed to add collaborators")
-                    |> redirect(
-                      to:
-                        Routes.live_path(
-                          OliWeb.Endpoint,
-                          OliWeb.Projects.OverviewLive,
-                          project_id
-                        )
-                    )
+                    |> redirect(to: ~p"/workspaces/course_author/#{project_id}/overview")
                   else
                     failed_emails = Enum.map(failures, fn {email, _msg} -> email end)
 
@@ -103,14 +89,7 @@ defmodule OliWeb.CollaboratorController do
                       :error,
                       "Failed to add some collaborators: #{Enum.join(failed_emails, ", ")}"
                     )
-                    |> redirect(
-                      to:
-                        Routes.live_path(
-                          OliWeb.Endpoint,
-                          OliWeb.Projects.OverviewLive,
-                          project_id
-                        )
-                    )
+                    |> redirect(to: ~p"/workspaces/course_author/#{project_id}/overview")
                   end
               end
             end
@@ -119,9 +98,7 @@ defmodule OliWeb.CollaboratorController do
       {:success, false} ->
         conn
         |> put_flash(:error, "reCaptcha failed, please try again")
-        |> redirect(
-          to: Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.OverviewLive, project_id)
-        )
+        |> redirect(to: ~p"/workspaces/course_author/#{project_id}/overview")
     end
   end
 
@@ -132,16 +109,12 @@ defmodule OliWeb.CollaboratorController do
   def delete(conn, %{"project_id" => project_id, "author_email" => author_email}) do
     case Collaborators.remove_collaborator(author_email, project_id) do
       {:ok, _} ->
-        redirect(conn,
-          to: Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.OverviewLive, project_id)
-        )
+        redirect(conn, to: ~p"/workspaces/course_author/#{project_id}/overview")
 
       {:error, message} ->
         conn
         |> put_flash(:error, "We couldn't remove that author from the project. #{message}")
-        |> redirect(
-          to: Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.OverviewLive, project_id)
-        )
+        |> redirect(to: ~p"/workspaces/course_author/#{project_id}/overview")
     end
   end
 

--- a/lib/oli_web/controllers/project_activity_controller.ex
+++ b/lib/oli_web/controllers/project_activity_controller.ex
@@ -6,32 +6,24 @@ defmodule OliWeb.ProjectActivityController do
   def enable_activity(conn, %{"project_id" => project_id, "activity_slug" => activity_slug}) do
     case Activities.enable_activity_in_project(project_id, activity_slug) do
       {:ok, _} ->
-        redirect(conn,
-          to: Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.OverviewLive, project_id)
-        )
+        redirect(conn, to: ~p"/workspaces/course_author/#{project_id}/overview")
 
       {:error, message} ->
         conn
         |> put_flash(:error, "We couldn't enable activity for the project. #{message}")
-        |> redirect(
-          to: Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.OverviewLive, project_id)
-        )
+        |> redirect(to: ~p"/workspaces/course_author/#{project_id}/overview")
     end
   end
 
   def disable_activity(conn, %{"project_id" => project_id, "activity_slug" => activity_slug}) do
     case Activities.disable_activity_in_project(project_id, activity_slug) do
       {:ok, _} ->
-        redirect(conn,
-          to: Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.OverviewLive, project_id)
-        )
+        redirect(conn, to: ~p"/workspaces/course_author/#{project_id}/overview")
 
       {:error, message} ->
         conn
         |> put_flash(:error, "We couldn't disable activity from the project. #{message}")
-        |> redirect(
-          to: Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.OverviewLive, project_id)
-        )
+        |> redirect(to: ~p"/workspaces/course_author/#{project_id}/overview")
     end
   end
 end

--- a/lib/oli_web/live/breadcrumb/breadcrumb_trail_live.ex
+++ b/lib/oli_web/live/breadcrumb/breadcrumb_trail_live.ex
@@ -1,6 +1,6 @@
 defmodule OliWeb.Breadcrumb.BreadcrumbTrailLive do
   use Phoenix.LiveView
-  alias OliWeb.Router.Helpers, as: Routes
+  use OliWeb, :verified_routes
   alias Oli.Authoring.Course
   alias OliWeb.Breadcrumb.BreadcrumbLive
   alias OliWeb.Common.Breadcrumb
@@ -37,7 +37,7 @@ defmodule OliWeb.Breadcrumb.BreadcrumbTrailLive do
             breadcrumb={
               Breadcrumb.new(%{
                 full_title: @project.title,
-                link: Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.OverviewLive, @project.slug)
+                link: ~p"/workspaces/course_author/#{@project.slug}/overview"
               })
             }
             is_last={false}

--- a/lib/oli_web/live/collaboration_live/admin_table_model.ex
+++ b/lib/oli_web/live/collaboration_live/admin_table_model.ex
@@ -1,4 +1,6 @@
 defmodule OliWeb.CollaborationLive.AdminTableModel do
+  use OliWeb, :verified_routes
+
   alias OliWeb.Common.Table.{ColumnSpec, Common, SortableTableModel}
   alias OliWeb.Router.Helpers, as: Routes
 
@@ -48,7 +50,7 @@ defmodule OliWeb.CollaborationLive.AdminTableModel do
   end
 
   def render_project_title(assigns, %{project: %{title: title, slug: project_slug}}, _) do
-    route_path = Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.OverviewLive, project_slug)
+    route_path = ~p"/workspaces/course_author/#{project_slug}/overview"
     SortableTableModel.render_link_column(assigns, title, route_path)
   end
 

--- a/lib/oli_web/live/community_live/associated/table_model.ex
+++ b/lib/oli_web/live/community_live/associated/table_model.ex
@@ -1,5 +1,6 @@
 defmodule OliWeb.CommunityLive.Associated.TableModel do
   use Phoenix.Component
+  use OliWeb, :verified_routes
 
   alias Oli.Groups.CommunityVisibility
   alias OliWeb.Common.Table.{ColumnSpec, Common, SortableTableModel}
@@ -62,8 +63,7 @@ defmodule OliWeb.CommunityLive.Associated.TableModel do
         SortableTableModel.render_link_column(assigns, get_field(:title, item), route_path)
 
       "project" ->
-        route_path =
-          Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.OverviewLive, get_field(:slug, item))
+        route_path = ~p"/workspaces/course_author/#{get_field(:slug, item)}/overview"
 
         SortableTableModel.render_link_column(assigns, get_field(:title, item), route_path)
     end

--- a/lib/oli_web/live/ingest/ingest.ex
+++ b/lib/oli_web/live/ingest/ingest.ex
@@ -65,7 +65,7 @@ defmodule OliWeb.Admin.Ingest do
            ) do
       {:noreply,
        redirect(socket,
-         to: Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.OverviewLive, project.slug)
+         to: ~s"workspaces/course_author/#{project.slug}/overview"
        )}
     else
       error ->

--- a/lib/oli_web/live/ingest/ingestv2.ex
+++ b/lib/oli_web/live/ingest/ingestv2.ex
@@ -118,7 +118,7 @@ defmodule OliWeb.Admin.IngestV2 do
     <%= if @ingestion_step == :processed do %>
       <h4>Ingest succeeded</h4>
 
-      <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.OverviewLive, @state.project.slug)}>
+      <a href={~p"/workspaces/course_author/#{@state.project.slug}/overview"}>
         Access your new course here
       </a>
     <% end %>

--- a/lib/oli_web/live/products/products_table_model.ex
+++ b/lib/oli_web/live/products/products_table_model.ex
@@ -60,7 +60,7 @@ defmodule OliWeb.Products.ProductsTableModel do
   def render_project_column(assigns, %{base_project: base_project}, _) do
     route_path =
       case Map.get(assigns, :project_slug) do
-        "" -> Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.OverviewLive, base_project.slug)
+        "" -> ~p"/workspaces/course_author/#{base_project.slug}/overview"
         _project_slug -> ~p"/workspaces/course_author/#{base_project}/overview"
       end
 

--- a/lib/oli_web/live/projects/table_model.ex
+++ b/lib/oli_web/live/projects/table_model.ex
@@ -1,9 +1,9 @@
 defmodule OliWeb.Projects.TableModel do
   use Phoenix.Component
+  use OliWeb, :verified_routes
 
   alias OliWeb.Common.SessionContext
   alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
-  alias OliWeb.Router.Helpers, as: Routes
 
   def new(%SessionContext{} = ctx, sections) do
     column_specs = [
@@ -46,7 +46,7 @@ defmodule OliWeb.Projects.TableModel do
     case name do
       :title ->
         ~H"""
-        <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.OverviewLive, @project.slug)}>
+        <a href={~p"/workspaces/course_author/#{@project.slug}/overview"}>
           <%= @project.title %>
         </a>
         """

--- a/lib/oli_web/live/resources/activities_view.ex
+++ b/lib/oli_web/live/resources/activities_view.ex
@@ -28,7 +28,7 @@ defmodule OliWeb.Resources.ActivitiesView do
     [
       Breadcrumb.new(%{
         full_title: "Project Overview",
-        link: Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.OverviewLive, project.slug)
+        link: ~p"/workspaces/course_author/#{project.slug}/overview"
       }),
       Breadcrumb.new(%{full_title: "All Activities"})
     ]

--- a/lib/oli_web/live/resources/pages_view.ex
+++ b/lib/oli_web/live/resources/pages_view.ex
@@ -48,7 +48,7 @@ defmodule OliWeb.Resources.PagesView do
     [
       Breadcrumb.new(%{
         full_title: "Project Overview",
-        link: Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.OverviewLive, project.slug)
+        link: ~p"/workspaces/course_author/#{project.slug}/overview"
       }),
       Breadcrumb.new(%{full_title: "All Pages"})
     ]

--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -155,7 +155,7 @@ defmodule OliWeb.Sections.OverviewView do
         <div class="flex flex-col form-group">
           <label>Base Project</label>
           <a
-            href={Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.OverviewLive, @base_project.slug)}
+            href={~p"/workspaces/course_author/#{@base_project.slug}/overview"}
             class="text-[#006CD9] hover:text-[#1B67B2] dark:text-[#4CA6FF] dark:hover:text-[#99CCFF] hover:underline"
           >
             <%= @base_project.title %>

--- a/lib/oli_web/live/sections/table_model.ex
+++ b/lib/oli_web/live/sections/table_model.ex
@@ -1,5 +1,6 @@
 defmodule OliWeb.Sections.SectionsTableModel do
   use Phoenix.Component
+  use OliWeb, :verified_routes
 
   alias OliWeb.Common.SessionContext
   alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
@@ -132,8 +133,7 @@ defmodule OliWeb.Sections.SectionsTableModel do
 
       SortableTableModel.render_link_column(assigns, section.blueprint.title, route_path)
     else
-      route_path =
-        Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.OverviewLive, section.base_project.slug)
+      route_path = ~p"/workspaces/course_author/#{section.base_project.slug}/overview"
 
       SortableTableModel.render_link_column(assigns, section.base_project.title, route_path)
     end

--- a/lib/oli_web/live/users/author_projects_table_model.ex
+++ b/lib/oli_web/live/users/author_projects_table_model.ex
@@ -1,9 +1,9 @@
 defmodule OliWeb.Users.AuthorProjectsTableModel do
   use Phoenix.Component
+  use OliWeb, :verified_routes
 
   alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
   alias OliWeb.Common.FormatDateTime
-  alias OliWeb.Router.Helpers, as: Routes
 
   def new(projects, ctx) do
     column_specs = [
@@ -48,7 +48,7 @@ defmodule OliWeb.Users.AuthorProjectsTableModel do
     assigns = Map.merge(assigns, %{title: project.title, slug: project.slug})
 
     ~H"""
-    <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.OverviewLive, @slug)}>
+    <a href={~p"/workspaces/course_author/#{@slug}/overview"}>
       <%= @title %>
     </a>
     """

--- a/lib/oli_web/live/workspaces/course_author/pages_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/pages_live.ex
@@ -630,7 +630,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.PagesLive do
     [
       Breadcrumb.new(%{
         full_title: "Project Overview",
-        link: Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.OverviewLive, project.slug)
+        link: ~p"/workspaces/course_author/#{project.slug}/overview"
       }),
       Breadcrumb.new(%{full_title: "All Pages"})
     ]

--- a/lib/oli_web/templates/cognito/clone_prompt.html.eex
+++ b/lib/oli_web/templates/cognito/clone_prompt.html.eex
@@ -11,7 +11,7 @@
 
   <ul>
     <%= for p <- @projects do %>
-      <li><%= link p.title, to: Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.OverviewLive, p.slug) %></li>
+      <li><%= link p.title, to: ~p"/workspaces/course_author/#{p.slug}/overview" %></li>
     <% end %>
   </ul>
 

--- a/test/oli_web/controllers/cognito_controller_test.exs
+++ b/test/oli_web/controllers/cognito_controller_test.exs
@@ -484,7 +484,7 @@ defmodule OliWeb.CognitoControllerTest do
       assert conn
              |> get(Routes.project_clone_path(conn, :launch_clone, project.slug, params))
              |> html_response(302) =~
-               "<html><body>You are being <a href=\"/authoring/project"
+               "<html><body>You are being <a href=\"/workspaces/course_author"
 
       # creates new author and links it with user
       author = Accounts.get_author_by_email(email)
@@ -633,7 +633,7 @@ defmodule OliWeb.CognitoControllerTest do
       assert conn
              |> get(Routes.cognito_path(conn, :clone, project.slug))
              |> html_response(302) =~
-               "<html><body>You are being <a href=\"/authoring/project"
+               "<html><body>You are being <a href=\"/workspaces/course_author"
     end
 
     test "fails if the project does not allow duplication",
@@ -686,7 +686,7 @@ defmodule OliWeb.CognitoControllerTest do
                "Would you like to\n<a href=\"/cognito/clone/#{project.slug}\">create another copy</a>"
 
       assert html =~
-               "<a href=\"/authoring/project/#{duplicated.slug}\">#{duplicated.title}</a>"
+               "<a href=\"/workspaces/course_author/#{duplicated.slug}/overview\">#{duplicated.title}</a>"
     end
   end
 

--- a/test/oli_web/controllers/collaborator_controller_test.exs
+++ b/test/oli_web/controllers/collaborator_controller_test.exs
@@ -28,7 +28,7 @@ defmodule OliWeb.CollaboratorControllerTest do
           "g-recaptcha-response": "any"
         )
 
-      assert html_response(conn, 302) =~ "/project/"
+      assert html_response(conn, 302) =~ "/workspaces/course_author/#{project.slug}/overview"
 
       assert Phoenix.Flash.get(conn.assigns.flash, :info) ==
                "Collaborator invitations sent!"
@@ -44,7 +44,7 @@ defmodule OliWeb.CollaboratorControllerTest do
           "g-recaptcha-response": "any"
         )
 
-      assert html_response(conn, 302) =~ "/project/"
+      assert html_response(conn, 302) =~ "/workspaces/course_author/#{project.slug}/overview"
 
       assert Phoenix.Flash.get(conn.assigns.flash, :info) ==
                "Collaborator invitations sent!"
@@ -60,7 +60,7 @@ defmodule OliWeb.CollaboratorControllerTest do
           "g-recaptcha-response": "any"
         )
 
-      assert html_response(conn, 302) =~ "/project/"
+      assert html_response(conn, 302) =~ "/workspaces/course_author/#{project.slug}/overview"
 
       assert Phoenix.Flash.get(conn.assigns.flash, :info) ==
                "Collaborator invitations sent!"
@@ -77,7 +77,8 @@ defmodule OliWeb.CollaboratorControllerTest do
                    "g-recaptcha-response": "any"
                  )
 
-               assert html_response(conn, 302) =~ "/project/"
+               assert html_response(conn, 302) =~
+                        "/workspaces/course_author/#{project.slug}/overview"
 
                assert Phoenix.Flash.get(conn.assigns.flash, :error) =~
                         "Failed to add some collaborators: notevenan_email"
@@ -95,7 +96,7 @@ defmodule OliWeb.CollaboratorControllerTest do
           "g-recaptcha-response": "any"
         )
 
-      assert html_response(conn, 302) =~ "/project/"
+      assert html_response(conn, 302) =~ "/workspaces/course_author/#{project.slug}/overview"
     end
 
     test "shows an error message when the author's email already exists", %{
@@ -114,7 +115,7 @@ defmodule OliWeb.CollaboratorControllerTest do
           "g-recaptcha-response": "any"
         )
 
-      assert html_response(conn, 302) =~ "/project/"
+      assert html_response(conn, 302) =~ "workspaces/course_author/#{project.slug}/overview"
 
       assert Phoenix.Flash.get(conn.assigns.flash, :error) ==
                "This person is already a collaborator in this project."
@@ -139,7 +140,7 @@ defmodule OliWeb.CollaboratorControllerTest do
           "g-recaptcha-response": "any"
         )
 
-      assert html_response(conn, 302) =~ "/project/"
+      assert html_response(conn, 302) =~ "/workspaces/course_author/#{project.slug}/overview"
 
       assert Phoenix.Flash.get(conn.assigns.flash, :error) ==
                "Collaborator invitations cannot exceed 20 emails at a time. Please try again with fewer invites"
@@ -184,12 +185,12 @@ defmodule OliWeb.CollaboratorControllerTest do
     test "redirects to project path when data is valid", %{conn: conn, project: project} do
       Oli.Authoring.Collaborators.add_collaborator(@admin_email, project.slug)
       conn = delete(conn, Routes.collaborator_path(conn, :delete, project, @admin_email))
-      assert html_response(conn, 302) =~ "/project/"
+      assert html_response(conn, 302) =~ "/workspaces/course_author/#{project.slug}/overview"
     end
 
     test "redirects to project path when data is invalid", %{conn: conn, project: project} do
       conn = delete(conn, Routes.collaborator_path(conn, :delete, project, @invalid_email))
-      assert html_response(conn, 302) =~ "/project/"
+      assert html_response(conn, 302) =~ "/workspaces/course_author/#{project.slug}/overview"
     end
   end
 end

--- a/test/oli_web/controllers/project_controller_test.exs
+++ b/test/oli_web/controllers/project_controller_test.exs
@@ -38,8 +38,7 @@ defmodule OliWeb.ProjectControllerTest do
       })
       |> Repo.insert()
 
-      conn =
-        get(conn, Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.OverviewLive, project.slug))
+      conn = get(conn, ~p"/workspaces/course_author/#{project.slug}/overview")
 
       response = html_response(conn, 200)
       assert response =~ "Overview"

--- a/test/oli_web/live/new_course/select_source_test.exs
+++ b/test/oli_web/live/new_course/select_source_test.exs
@@ -450,5 +450,5 @@ defmodule OliWeb.NewCourse.SelectSourceTest do
     do: Routes.live_path(OliWeb.Endpoint, OliWeb.Products.DetailsView, section.slug)
 
   defp details_view(section),
-    do: Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.OverviewLive, section.project.slug)
+    do: ~p"/workspaces/course_author/#{section.project.slug}/overview"
 end

--- a/test/oli_web/live/users/author_detail_view_test.exs
+++ b/test/oli_web/live/users/author_detail_view_test.exs
@@ -337,8 +337,7 @@ defmodule OliWeb.Users.AuthorsDetailViewTest do
 
       assert view
              |> element("#author_projects table tr[id='#{project.id}']")
-             |> render() =~
-               Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.OverviewLive, project.slug)
+             |> render() =~ ~p"/workspaces/course_author/#{project.slug}/overview"
     end
 
     test "system admin can edit author role", %{conn: conn} do


### PR DESCRIPTION
[MER-3933](https://eliterate.atlassian.net/browse/MER-3933)

This PR fixes the routes used to redirect the user on occasions when the user interacts with the functionality of invite collaborators. 

Also, the route used in the `Join as Collaborator` button that a potential collaborator receives in the invitation email is fixed. 

https://github.com/user-attachments/assets/d5be9007-0bb2-4ebd-a9b9-57d23704b4f5



[MER-3933]: https://eliterate.atlassian.net/browse/MER-3933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ