### PR TITLE
[BUG FIX] [MER-3930] don't autosubmit DND choice selection on graded page

### DIFF
--- a/assets/src/components/activities/custom_dnd/DragCanvas.tsx
+++ b/assets/src/components/activities/custom_dnd/DragCanvas.tsx
@@ -6,7 +6,7 @@ export type ResetListener = () => void;
 
 export type DragCanvasProps = {
   model: CustomDnDSchema;
-  onSubmitPart: (targetId: string, draggableId: string) => void;
+  onDrop: (targetId: string, draggableId: string) => void;
   onFocusChange: (targetId: string | null, draggableId: string | null) => void;
   onDetach: (targetId: string, draggableId: string) => Promise<void>;
   initialState: Record<string, string>;
@@ -151,7 +151,7 @@ function createTargetDropHandler(shadowRoot: any, props: DragCanvasProps) {
         if (prevTargetId) {
           await props.onDetach(prevTargetId, inputVal);
         }
-        props.onSubmitPart(targetId, inputVal);
+        props.onDrop(targetId, inputVal);
       }
     } catch (e) {
       console.error('customDND target drop handler failed', e);


### PR DESCRIPTION
DnD drop handling submit logic was not correct for the context of a graded page: it was always auto-submitting a part response on drop, even on graded pages. The part response gets evaluated on the server. At some point after all parts evaluated, the activity attempt as whole picks up a total score and the DnD's standard GradedPointsConnected UI component, used by most activities, was displaying points earned on page reload in this case, even though the graded assessment had not been submitted as a whole.

This adjusts the logic to only save, not submit, on graded pages, following the model of saveOrSubmit in MultipleChoiceDelivery.

Note: preview mode for dnds has some problems that can hang the interface if one tries to change an existing entry, but these are unrelated and not new. Ideally the UI would freeze entries in preview mode on a practice page, as is done for multi-inputs that have been submitted and evaluated. 

