### PR TITLE
[BUG FIX] [MER-3169] LTI users should not be allowed to manually enroll in any course

### DIFF
--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -399,6 +399,10 @@ defmodule OliWeb.DeliveryController do
         redirect(conn,
           to: ~p"/?#{[section: section.slug, from_invitation_link?: true]}"
         )
+
+      # redirect to course index when user is not an independent learner (LTI user)
+      {:redirect, :non_independent_learner} ->
+        redirect(conn, to: Routes.delivery_path(conn, :index))
     end
   end
 
@@ -460,6 +464,9 @@ defmodule OliWeb.DeliveryController do
     case conn.assigns.current_user do
       nil ->
         if requires_enrollment, do: {:redirect, nil}, else: Accounts.create_guest_user()
+
+      %User{independent_learner: false} ->
+        {:redirect, :non_independent_learner}
 
       %User{guest: true} = guest ->
         if requires_enrollment, do: {:redirect, nil}, else: {:ok, guest}

--- a/test/oli_web/controllers/delivery_controller_test.exs
+++ b/test/oli_web/controllers/delivery_controller_test.exs
@@ -231,6 +231,19 @@ defmodule OliWeb.DeliveryControllerTest do
     end
   end
 
+  describe "delivery_controller" do
+    setup [:setup_lti_session]
+
+    test "blocks LMS users from manually enrollment", %{conn: conn, section: section} do
+      # Assert that the user is an LMS user
+      assert conn.assigns.current_user.independent_learner == false
+
+      enrollment_path = ~p"/sections/#{section.slug}/enroll"
+      conn = get(conn, enrollment_path)
+      assert response(conn, 302) =~ "You are being <a href=\"/course\">redirected</a>"
+    end
+  end
+
   describe "download_course_content_info" do
     setup [:setup_lti_session, :create_project_with_units_and_modules]
 


### PR DESCRIPTION
Ticket: [MER-3169](https://eliterate.atlassian.net/browse/MER-3169)

This PR prevents LTI users from enrolling manually.

[MER-3169]: https://eliterate.atlassian.net/browse/MER-3169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ