### PR TITLE
[BUG FIX] [MER-3960] make bibliography entry editor usable in dark mode

### DIFF
--- a/assets/src/apps/bibliography/PlainEntryEditor.tsx
+++ b/assets/src/apps/bibliography/PlainEntryEditor.tsx
@@ -12,10 +12,6 @@ export interface PlainEntryEditorProps {
 export const PlainEntryEditor: React.FC<PlainEntryEditorProps> = (props: PlainEntryEditorProps) => {
   const [value, setValue] = useState<string>('');
 
-  const textAreaStyle: CSSProperties = {
-    width: '100%',
-  };
-
   useEffect(() => {
     if (props.bibEntry) {
       const data = new Cite(JSON.stringify(props.bibEntry?.content.data[0]));
@@ -50,7 +46,7 @@ export const PlainEntryEditor: React.FC<PlainEntryEditorProps> = (props: PlainEn
           </div>
         </>
       )}
-      <textarea style={textAreaStyle} rows={20} onChange={handleOnChange} value={value} />
+      <textarea className={'w-full bg-inherit'} rows={20} onChange={handleOnChange} value={value} />
     </div>
   );
 };

--- a/assets/src/apps/bibliography/PlainEntryEditor.tsx
+++ b/assets/src/apps/bibliography/PlainEntryEditor.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { CSSProperties, ChangeEvent, useEffect, useState } from 'react';
+import { ChangeEvent, useEffect, useState } from 'react';
 import { BibEntry } from 'data/content/bibentry';
 
 const Cite = (window as any).cite;
@@ -46,7 +46,7 @@ export const PlainEntryEditor: React.FC<PlainEntryEditorProps> = (props: PlainEn
           </div>
         </>
       )}
-      <textarea className={'w-full bg-inherit'} rows={20} onChange={handleOnChange} value={value} />
+      <textarea className="w-full bg-inherit" rows={20} onChange={handleOnChange} value={value} />
     </div>
   );
 };


### PR DESCRIPTION
The modal for adding/editing a bibliography entry as a bibTex string was unusable in dark mode: the text box picked up white text color but did not change its white background color to match. This change makes the text area inherit background color so it is properly responsive to dark mode. 

The alternative modal for "manual" entry definition by filling in field values does not have this issue. 

Old:
<img width="839" alt="Screenshot 2024-10-23 at 2 05 18 PM" src="https://github.com/user-attachments/assets/bbfab430-5eb7-4afd-8037-3906faf601f3">

New:
<img width="737" alt="Screenshot 2024-10-23 at 2 01 08 PM" src="https://github.com/user-attachments/assets/726bbefa-44a3-4095-a76e-30ff728c31e2">
