### PR TITLE
[BUG FIX] [MER-3922] Date does not update when using scheduler slider

### DIFF
--- a/assets/src/apps/scheduler/SchedulerSaveBar.tsx
+++ b/assets/src/apps/scheduler/SchedulerSaveBar.tsx
@@ -170,7 +170,7 @@ export const ScheduleSaveBar: React.FC<SaveIndicatorProps> = ({ onSave }) => {
     };
   }, [debouncedEndUpdate]);
 
-  const onChangeEndHandler = (e) => {
+  const onChangeEndHandler = (e: ChangeEvent<HTMLInputElement>) => {
     const newValue = e.target.value;
     setDateInputValue(newValue);
 


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-3922) to the ticket

#### Some context

A page's scheduled date (start or end date) can be updated in three ways:

1. By dragging the page icon to a different position in the schedule grid
2. By selecting the page icon and then selecting a new date from the date input
3. By selecting the page icon and typing in the new date in the date input

In all cases, the date input and the position of the corresponding page icon should stay synchronized (for example, if I drag a page to 09/10/2024, then the input should be updated to that same date - and vice-versa)

This logic applies to the end date (for graded and un-graded pages) and the start/available-from date (for graded pages).

#### Previously fixed issue (MER-3131)
When the user intended to change the date by the third option (typing in the date in the input) we used to parse the date immediately, not letting the user end up writing the new value (that made it impossible to write down a year like `2024` - it was immediately parsed to `1902`).
We fixed this issue by changing how we trigger the parsing, from `onChange` to `onBlur`. This approach fixed the parsing issue but accidentally introduced a synchronization issue between the input and the corresponding date icon. For example, after dragging the icon to a new date, the input was not updated to this new value (the issue reported in this ticket)

#### Fixes implemented in this PR

1. Setting back the `onChange` triggerers (removing the `onBlur` ones) -> This fixed the sync between the input and the icon position in the scheduling grid.
2. Adding a 700ms debounce in the input -> This allows the user to enter years like 2024 before the parsing is triggered and updating the icon position in the scheduling grid.

Some other reactors were made to improve the readability (unifying event handlers, and unifying inputs to handle both date and date-time values)


#### Changing scheduled end dates for non-graded pages (in all the 3 ways of doing this)

https://github.com/user-attachments/assets/62780d61-7543-4104-a0aa-606e47829cd4



#### Changing scheduled start and end dates for graded pages (in all the 3 ways of doing this)

https://github.com/user-attachments/assets/2deb62ae-ee9b-4250-9606-27e5ea93dc71


