### PR TITLE
[BUG FIX] [MER-3925] Not able to view student attempts

### DIFF
--- a/lib/oli_web/plugs/redirect_by_attempt_state.ex
+++ b/lib/oli_web/plugs/redirect_by_attempt_state.ex
@@ -96,6 +96,11 @@ defmodule OliWeb.Plugs.RedirectByAttemptState do
   defp user_already_authenticated?(%{assigns: %{current_user: %{id: current_user_id}}} = _conn),
     do: {true, current_user_id}
 
+  defp user_already_authenticated?(
+         %{assigns: %{current_author: %{id: current_author_id}}} = _conn
+       ),
+       do: {true, current_author_id}
+
   defp user_already_authenticated?(_conn), do: {false, nil}
 
   defp classify_request(conn) do

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -1103,30 +1103,6 @@ defmodule OliWeb.Router do
       end
     end
 
-    scope "/adaptive_lesson/:revision_slug" do
-      get("/", PageDeliveryController, :page_fullscreen)
-
-      get(
-        "/attempt/:attempt_guid/review",
-        PageDeliveryController,
-        :review_attempt
-      )
-    end
-  end
-
-  scope "/sections/:section_slug", OliWeb do
-    pipe_through([
-      :browser,
-      :require_section,
-      :delivery,
-      :delivery_protected,
-      :maybe_gated_resource,
-      :enforce_enroll_and_paywall,
-      :ensure_user_section_visit,
-      :force_required_survey,
-      :pow_email_layout
-    ])
-
     scope "/lesson/:revision_slug/attempt/:attempt_guid/review" do
       live_session :delivery_lesson_review,
         root_layout: {OliWeb.LayoutView, :delivery},
@@ -1141,6 +1117,16 @@ defmodule OliWeb.Router do
         ] do
         live("/", Delivery.Student.ReviewLive)
       end
+    end
+
+    scope "/adaptive_lesson/:revision_slug" do
+      get("/", PageDeliveryController, :page_fullscreen)
+
+      get(
+        "/attempt/:attempt_guid/review",
+        PageDeliveryController,
+        :review_attempt
+      )
     end
   end
 


### PR DESCRIPTION
[MER-3925](https://eliterate.atlassian.net/browse/MER-3925)

This PR fixes a bug happened when an `instructor` or `admin` tried to view student submitted attempts on adaptive pages. 

- As instructor

https://github.com/user-attachments/assets/d3e3b4ba-60da-4709-9b5a-05a78c607eb4

- As Admin

https://github.com/user-attachments/assets/369de110-7265-4888-b3b2-c562479f86da



[MER-3925]: https://eliterate.atlassian.net/browse/MER-3925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ