### PR TITLE
[BUG FIX] [MER-3913] Basic page editor styles broken

### DIFF
--- a/assets/src/components/resource/editors/Editors.scss
+++ b/assets/src/components/resource/editors/Editors.scss
@@ -1,6 +1,7 @@
 @import 'common/mixins.scss';
 
 .editors {
+  background-color: var(--color-body);
   flex: 1;
   min-width: 0;
   border: 1px solid var(--color-gray-200);
@@ -85,6 +86,7 @@
 
 html.dark {
   .editors {
+    background-color: var(--color-body-dark);
     border-color: #3e3f44;
   }
 }

--- a/assets/styles/delivery/layout/delivery.scss
+++ b/assets/styles/delivery/layout/delivery.scss
@@ -53,4 +53,20 @@ html.delivery {
       border: 1px solid #007bff;
     }
   }
+
+  .collab-space-config {
+    background-color: var(--color-body);
+    border-color: #9fbce9;
+  }
+}
+
+html.dark {
+  .collab-space-config {
+    background-color: var(--color-body-dark);
+    border-color: #173667;
+
+    .badge-info {
+      background-color: #173667;
+    }
+  }
 }

--- a/lib/oli_web/live/collaboration_live/collab_space_config_view.ex
+++ b/lib/oli_web/live/collaboration_live/collab_space_config_view.ex
@@ -156,7 +156,7 @@ defmodule OliWeb.CollaborationLive.CollabSpaceConfigView do
     ~H"""
     <.notes_modals form={@form} />
 
-    <div class="border border-blue-200 dark:border-blue-700 rounded-lg p-6">
+    <div class="collab-space-config border rounded-lg p-6">
       <div class="flex flex-col md:flex-row md:items-center card-body justify-between">
         <div class="flex flex-col justify-start md:flex-row md:items-center gap-2">
           <%= unless @is_overview_render do %>

--- a/test/oli_web/live/delivery/student/lesson_live_test.exs
+++ b/test/oli_web/live/delivery/student/lesson_live_test.exs
@@ -1612,7 +1612,10 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
 
       # and is shown in the UI
       assert has_element?(view, "div[role='user name']", "Me")
-      assert has_element?(view, "div[role='posted at']", "now")
+
+      assert has_element?(view, "div[role='posted at']", "now") or
+               has_element?(view, "div[role='posted at']", "1 second ago")
+
       assert has_element?(view, "p[role='post content']", "some new post content")
     end
 


### PR DESCRIPTION
[MER-3912](https://eliterate.atlassian.net/browse/MER-3912)

Besides fixing the styles when editing a basic page, this PR fixes a flaky test on `lesson_live_tests.exs`.

Before:

https://github.com/user-attachments/assets/a7abb9e1-8432-4f61-ac8a-1dd122e8c92d



After:

https://github.com/user-attachments/assets/2a7a1f94-b074-40ee-b331-07fe24267ae8



[MER-3912]: https://eliterate.atlassian.net/browse/MER-3912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ