### PR TITLE
[BUG FIX] [MER-3926] enrolling in a course and logging in with google brings student to instructor dashboard

### DIFF
--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -396,9 +396,13 @@ defmodule OliWeb.DeliveryController do
 
       # guest user cannot access courses that require enrollment
       {:redirect, nil} ->
-        redirect(conn,
-          to: ~p"/?#{[section: section.slug, from_invitation_link?: true]}"
-        )
+        params = [
+          section: section.slug,
+          from_invitation_link?: true,
+          request_path: ~p"/sections/#{section.slug}/enroll"
+        ]
+
+        redirect(conn, to: ~p"/?#{params}")
 
       # redirect to course index when user is not an independent learner (LTI user)
       {:redirect, :non_independent_learner} ->

--- a/lib/oli_web/controllers/static_page_controller.ex
+++ b/lib/oli_web/controllers/static_page_controller.ex
@@ -9,10 +9,17 @@ defmodule OliWeb.StaticPageController do
   plug Oli.Plugs.RestrictAdminAccess when action in [:index]
 
   def index(conn, _params) do
-    if conn.assigns.current_user,
-      do: render(PowHelpers.use_pow_config(conn, :user), "index_logged_in.html"),
-      else: render(PowHelpers.use_pow_config(conn, :user), "index.html")
+    if conn.assigns.current_user do
+      render(PowHelpers.use_pow_config(conn, :user), "index_logged_in.html")
+    else
+      render(PowHelpers.use_pow_config(maybe_put_request_path(conn), :user), "index.html")
+    end
   end
+
+  defp maybe_put_request_path(%{params: %{"request_path" => enrollment_path}} = conn),
+    do: Plug.Conn.put_session(conn, :enrollment_path, enrollment_path)
+
+  defp maybe_put_request_path(conn), do: conn
 
   def unauthorized(conn, _params) do
     render(conn, "unauthorized.html")

--- a/test/oli_web/controllers/delivery_controller_test.exs
+++ b/test/oli_web/controllers/delivery_controller_test.exs
@@ -248,17 +248,10 @@ defmodule OliWeb.DeliveryControllerTest do
       conn = Map.update!(conn, :assigns, &Map.drop(&1, [:current_author, :current_user]))
 
       enrollment_path = ~p"/sections/#{section.slug}/enroll"
-      # Visit enrollment page
+
       conn = get(conn, enrollment_path)
 
-      redirected_path =
-        ~p"/?#{[section: section.slug, from_invitation_link?: true, request_path: enrollment_path]}"
-
-      {:safe, link} =
-        Phoenix.HTML.Link.link("redirected", to: redirected_path) |> Phoenix.HTML.raw()
-
-      # Assert user is redirected to the login page with the requested path as a query param
-      assert response(conn, 302) =~ "You are being #{link}."
+      assert_redirect_to_login(conn, section.slug)
     end
   end
 
@@ -646,8 +639,7 @@ defmodule OliWeb.DeliveryControllerTest do
           )
         )
 
-      assert html_response(conn, 302) =~
-               "You are being <a href=\"/?section=#{section.slug}&amp;from_invitation_link%3F=true\">redirected"
+      assert_redirect_to_login(conn, section.slug)
     end
 
     test "shows enroll view and Sign In link", %{conn: conn} do
@@ -724,8 +716,7 @@ defmodule OliWeb.DeliveryControllerTest do
       section = insert(:section, requires_enrollment: true)
       conn = get(conn, Routes.delivery_path(conn, :show_enroll, section.slug))
 
-      assert html_response(conn, 302) =~
-               "<html><body>You are being <a href=\"/?section=#{section.slug}&amp;from_invitation_link%3F=true\">redirected</a>.</body></html>"
+      assert_redirect_to_login(conn, section.slug)
 
       conn = mock_captcha(conn, section)
 
@@ -978,5 +969,17 @@ defmodule OliWeb.DeliveryControllerTest do
     map = Seeder.base_project_with_resource4()
 
     Map.merge(%{conn: conn, user: user}, map)
+  end
+
+  defp assert_redirect_to_login(conn, section_slug) do
+    enrollment_path = ~p"/sections/#{section_slug}/enroll"
+
+    redirected_path =
+      ~p"/?#{[section: section_slug, from_invitation_link?: true, request_path: enrollment_path]}"
+
+    {:safe, link} =
+      Phoenix.HTML.Link.link("redirected", to: redirected_path) |> Phoenix.HTML.raw()
+
+    assert html_response(conn, 302) =~ "You are being #{link}."
   end
 end


### PR DESCRIPTION
Ticket: [MER-3926](https://eliterate.atlassian.net/browse/MER-3926)

This PR addresses an issue where a user trying to access an enrollment page, signing in with the Google provider, is redirected to the instructor page instead of the enrollment page.

[MER-3926]: https://eliterate.atlassian.net/browse/MER-3926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ