### PR TITLE
[BUG FIX] [MER-3963] prevent drag and drop hang on change

### DIFF
--- a/assets/src/components/activities/custom_dnd/CustomDnDDelivery.tsx
+++ b/assets/src/components/activities/custom_dnd/CustomDnDDelivery.tsx
@@ -6,7 +6,7 @@ import { GradedPointsConnected } from 'components/activities/common/delivery/gra
 import { ResetButtonConnected } from 'components/activities/common/delivery/reset_button/ResetButtonConnected';
 import { StemDeliveryConnected } from 'components/activities/common/stem/delivery/StemDelivery';
 import { CustomDnDSchema } from 'components/activities/custom_dnd/schema';
-import { Manifest } from 'components/activities/types';
+import { Manifest, PartState } from 'components/activities/types';
 import {
   ActivityDeliveryState,
   activityDeliverySlice,
@@ -171,6 +171,7 @@ export const CustomDnDComponent: React.FC = () => {
           initialState={initialState}
           editMode={editMode && !working}
           activityAttemptGuid={uiState.attemptState.attemptGuid}
+          partAttemptGuids={uiState.attemptState.parts.map((p: PartState) => p.attemptGuid)}
           onRegisterResetCallback={(listener) => {
             setResetListener(() => listener);
           }}

--- a/assets/src/components/activities/custom_dnd/DragCanvas.tsx
+++ b/assets/src/components/activities/custom_dnd/DragCanvas.tsx
@@ -12,6 +12,7 @@ export type DragCanvasProps = {
   initialState: Record<string, string>;
   editMode: boolean;
   activityAttemptGuid: string;
+  partAttemptGuids: string[];
   onRegisterResetCallback: (listener: ResetListener) => void;
 };
 
@@ -26,11 +27,11 @@ export const DragCanvas: React.FC<DragCanvasProps> = (props: DragCanvasProps) =>
   // get another attempt.  We must reset the drop handlers on all drop targets so that
   // these functions close over the most up to date 'onSubmitPart` handler, which allows
   // the parent CustomDnDDelivery component to issue part submissions with the correct
-  // part attempt guids.
+  // part attempt guids. Applies also after reset of individual partAttempts
   useEffect(() => {
     updateDropHandler(id, props);
     updateRootDropHandler(id, props);
-  }, [props.activityAttemptGuid]);
+  }, [props.activityAttemptGuid, props.partAttemptGuids]);
 
   useEffect(() => {
     setEditMode(props.editMode, id);


### PR DESCRIPTION
Custom Drag-and-Drop on a practice page allows one to change a submitted part answer after evaluation. E.g on a three-item question on a practice page, one may drag item1 into slot1, get feedback, and then try to move it to another slot, or back to the starting position. If the new destination slot is occupied, the current occupant is bumped back to the starting position and replaced by the new one. 

Changes after part submission like this were causing the UI to show “working” and hang. (The working spinner was introduced to help prevent race conditions on multiple rapid changes which trigger async operations)

The error came from sending a bad partAttemptGuid in the submit call, presumably an old one which has been superseded by an intervening part reset. This arises from a complexity of the react state management affecting the drag and drop implementation: The delivery component makes use of a child component to manage the drag-drop UI.  The child component is designed to send callback notifications on changes to the UI, and these trigger changes to the activity state including partAttempt resets. But after the parent dispatches a part reset, the child component that manages the dragdrop UI is not forced to re-render so can be left holding a reference to a callback notification function which has closed over an older state from the parent. 

This issue had been carefully noted in the code with respect to a reset of the whole activity which leads to a new activityAttemptGuid, and the child component had been written to take an activityAttemptGuid parameter and update on changes.  This fix does the same thing to take into account individual part resets which lead to new partAttemptGuids.