### PR TITLE
[BUG FIX] [MER-3965] make ingestion process citations in definitions

### DIFF
--- a/lib/oli/resources/page_content.ex
+++ b/lib/oli/resources/page_content.ex
@@ -70,7 +70,8 @@ defmodule Oli.Resources.PageContent do
     end
 
     # must process content in certain properties as well as children
-    props = ["children", "caption", "pronunciation", "translations", "content"]
+    # definition meanings has list of meaning elements w/content in children
+    props = ["children", "caption", "pronunciation", "translations", "content", "meanings"]
 
     {item, acc} =
       Enum.reduce(props, {item, acc}, fn prop, {item, acc} ->


### PR DESCRIPTION
The fix in https://github.com/Simon-Initiative/oli-torus/pull/5179 changed content traversal functions to find content in captions and popups. But it didn't include content in definitions, so citations in definition content were still missed on ingestion, and this case also occurs in the CAHIMS course to be migrated. This PR adds the `meanings `property to the list of content-bearing properties for the `item_with_children` function to visit. 

A definition's `meanings `property contains a list of meaning elements. Meaning elements are like paragraphs, containers which hold content in their children. So, on visiting a meaning element, the content gets visited by the recursion through `children` which has always been part of this process.