### PR TITLE
[BUG FIX] [MER-3946] Fix routes all pages and all activities views

### DIFF
--- a/lib/oli_web/common/breadcrumb.ex
+++ b/lib/oli_web/common/breadcrumb.ex
@@ -188,12 +188,7 @@ defmodule OliWeb.Common.Breadcrumb do
       }),
       new(%{
         full_title: "All Pages",
-        link:
-          Routes.live_path(
-            OliWeb.Endpoint,
-            OliWeb.Resources.PagesView,
-            project_slug
-          )
+        link: ~p"/workspaces/course_author/#{project_slug}/pages"
       })
     ]
   end

--- a/lib/oli_web/live/workspaces/course_author/activities/activities_table_model.ex
+++ b/lib/oli_web/live/workspaces/course_author/activities/activities_table_model.ex
@@ -1,7 +1,8 @@
 defmodule OliWeb.Workspaces.CourseAuthor.Activities.ActivitiesTableModel do
+  use OliWeb, :verified_routes
+
   alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
   alias Oli.Resources.Revision
-  alias OliWeb.Router.Helpers, as: Routes
 
   use Phoenix.Component
 
@@ -16,7 +17,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.Activities.ActivitiesTableModel do
       %ColumnSpec{
         name: :activity_type_id,
         label: "Type",
-        render_fn: &OliWeb.Resources.ActivitiesTableModel.render_type_column/3
+        render_fn: &render_type_column/3
       },
       %ColumnSpec{
         name: :title,
@@ -29,13 +30,13 @@ defmodule OliWeb.Workspaces.CourseAuthor.Activities.ActivitiesTableModel do
       %ColumnSpec{
         name: :stem,
         label: "Stem",
-        render_fn: &OliWeb.Resources.ActivitiesTableModel.render_content_column/3,
+        render_fn: &render_content_column/3,
         sortable: false
       },
       %ColumnSpec{
         name: :resource_id,
         label: "Page",
-        render_fn: &OliWeb.Resources.ActivitiesTableModel.render_page_column/3,
+        render_fn: &render_page_column/3,
         sortable: false
       },
       %ColumnSpec{
@@ -74,7 +75,9 @@ defmodule OliWeb.Workspaces.CourseAuthor.Activities.ActivitiesTableModel do
         assigns = Map.merge(assigns, %{slug: slug, title: title})
 
         ~H"""
-        <a href={Routes.resource_path(OliWeb.Endpoint, :edit, @project_slug, @slug)}><%= @title %></a>
+        <.link href={~p"/workspaces/course_author/#{@project_slug}/curriculum/#{@slug}/edit"}>
+          <%= @title %>
+        </.link>
         """
     end
   end

--- a/lib/oli_web/live/workspaces/course_author/activities_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/activities_live.ex
@@ -9,7 +9,6 @@ defmodule OliWeb.Workspaces.CourseAuthor.ActivitiesLive do
   alias Oli.Resources.{ActivityBrowse, ActivityBrowseOptions}
   alias OliWeb.Common.{FilterBox, PagedTable, TextSearch}
   alias OliWeb.Common.Table.SortableTableModel
-  alias OliWeb.Resources.ActivitiesTableModel
   alias OliWeb.Router.Helpers, as: Routes
   alias OliWeb.Workspaces.CourseAuthor.Activities.ActivitiesTableModel
 

--- a/test/oli_web/live/workspaces/course_author/activities_live_test.exs
+++ b/test/oli_web/live/workspaces/course_author/activities_live_test.exs
@@ -1,0 +1,139 @@
+defmodule OliWeb.Workspaces.CourseAuthor.ActivitiesLiveTest do
+  use ExUnit.Case, async: true
+  use OliWeb.ConnCase
+
+  import Oli.Factory
+  import Phoenix.LiveViewTest
+
+  alias OliWeb.Workspaces.CourseAuthor.ActivitiesLive
+
+  defp live_view_all_activities_route(project_slug) do
+    Routes.live_path(OliWeb.Endpoint, ActivitiesLive, project_slug)
+  end
+
+  describe "user cannot access when is not logged in" do
+    test "redirects to overview when accessing the all activities view", %{
+      conn: conn
+    } do
+      project = insert(:project)
+
+      redirect_path =
+        "/workspaces/course_author"
+
+      {:error,
+       {:redirect,
+        %{
+          to: ^redirect_path
+        }}} =
+        live(conn, live_view_all_activities_route(project.slug))
+    end
+  end
+
+  describe "all activities view" do
+    setup [:admin_conn, :create_full_project_with_objectives]
+
+    test "loads all activities view correctly", %{
+      conn: conn,
+      project: project,
+      revisions: revisions
+    } do
+      {:ok, view, _html} = live(conn, live_view_all_activities_route(project.slug))
+
+      assert view
+             |> element("#header_id")
+             |> render() =~
+               "Browse All Activities"
+
+      assert has_element?(
+               view,
+               "input[id=\"text-search-input\"]"
+             )
+
+      assert has_element?(
+               view,
+               "table tbody tr:last-child td:nth-child(2)",
+               revisions.act_revision_w.title
+             )
+    end
+
+    test "loads correctly when there are no activities in the project", %{
+      conn: conn
+    } do
+      %{project: project} = base_project_with_curriculum(nil)
+
+      {:ok, view, _html} =
+        live(conn, live_view_all_activities_route(project.slug))
+
+      assert has_element?(view, "div", "None exist")
+    end
+
+    test "applies sorting", %{
+      conn: conn,
+      project: project,
+      revisions: revisions
+    } do
+      {:ok, view, _html} =
+        live(conn, live_view_all_activities_route(project.slug))
+
+      ## Sort by title asc
+      view
+      |> element("th[phx-click=\"paged_table_sort\"][phx-value-sort_by=\"title\"]")
+      |> render_click()
+
+      assert view
+             |> element("tr:first-child td:nth-child(2) > div")
+             |> render() =~
+               revisions.act_revision_w.title
+
+      assert view
+             |> element("tr:last-child(2) td:nth-child(2) > div")
+             |> render() =~
+               revisions.act_revision_z.title
+
+      ## Sort by title desc
+      view
+      |> element("th[phx-click=\"paged_table_sort\"][phx-value-sort_by=\"title\"]")
+      |> render_click()
+
+      assert view
+             |> element("tr:first-child td:nth-child(2) > div")
+             |> render() =~
+               revisions.act_revision_z.title
+
+      assert view
+             |> element("tr:last-child(2) td:nth-child(2) > div")
+             |> render() =~
+               revisions.act_revision_w.title
+    end
+
+    test "go to the page edit view works correctly", %{
+      conn: conn,
+      project: project,
+      revisions: revisions,
+      admin: admin
+    } do
+      {:ok, view, _html} =
+        live(conn, live_view_all_activities_route(project.slug))
+
+      view
+      |> element(
+        "a[href=\"/workspaces/course_author/#{project.slug}/curriculum/#{revisions.page_revision_1.slug}/edit\"]",
+        revisions.page_revision_1.title
+      )
+      |> render_click()
+
+      conn = recycle_author_session(conn, admin)
+
+      ## Go to the page edit view
+      {:ok, view, _html} =
+        live(
+          conn,
+          "/workspaces/course_author/#{project.slug}/curriculum/#{revisions.page_revision_1.slug}/edit"
+        )
+
+      assert view
+             |> element("li[aria-current=\"page\"]")
+             |> render() =~ revisions.page_revision_1.title
+    end
+  end
+end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -1390,7 +1390,8 @@ defmodule Oli.TestHelpers do
     publication =
       insert(:publication, %{
         project: project,
-        root_resource_id: root_resource.id
+        root_resource_id: root_resource.id,
+        published: nil
       })
 
     # Publish all resources
@@ -1453,7 +1454,11 @@ defmodule Oli.TestHelpers do
         module_resource_1: module_resource_1,
         module_resource_2: module_resource_2,
         unit_resource: unit_resource,
-        root_resource: root_resource
+        root_resource: root_resource,
+        act_revision_w: act_revision_w,
+        act_resource_x: act_resource_x,
+        act_resource_y: act_resource_y,
+        act_resource_z: act_resource_z
       },
       revisions: %{
         obj_revision_a: obj_revision_a,
@@ -1469,7 +1474,11 @@ defmodule Oli.TestHelpers do
         module_revision_1: module_revision_1,
         module_revision_2: module_revision_2,
         unit_revision: unit_revision,
-        root_revision: root_revision
+        root_revision: root_revision,
+        act_revision_w: act_revision_w,
+        act_revision_x: act_revision_x,
+        act_revision_y: act_revision_y,
+        act_revision_z: act_revision_z
       }
     }
   end


### PR DESCRIPTION
[MER-3946](https://eliterate.atlassian.net/browse/MER-3946)

This PR fixes routes in a couple of places to fix the following flows mentioned in the ticket: 

- After user have created a page through the All Pages view then clicks on the breadcrumb to back to All Pages view.

https://github.com/user-attachments/assets/2cd1d05a-7ec5-4d59-a985-04284a2420c5

- User clicks on a page title in the All Activities view and navigates to the clicked page edit.

https://github.com/user-attachments/assets/c7901169-73b9-46ff-87dd-a149e695fa4c



[MER-3946]: https://eliterate.atlassian.net/browse/MER-3946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ