### PR TITLE
[BUG FIX] [MER-3931] students can submit after time limit

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -95,22 +95,22 @@ config :oli, OliWeb.Endpoint,
       max_headers: http_max_headers
     ]
   ],
-  url: [
-    scheme: System.get_env("SCHEME", "https"),
-    host: System.get_env("HOST", "localhost"),
-    port: String.to_integer(System.get_env("PORT", "443"))
-  ],
-  https: [
-    port: String.to_integer(System.get_env("HTTPS_PORT", "443")),
-    otp_app: :oli,
-    keyfile: System.get_env("SSL_KEY_PATH", "priv/ssl/localhost.key"),
-    certfile: System.get_env("SSL_CERT_PATH", "priv/ssl/localhost.crt"),
-    protocol_options: [
-      max_header_name_length: http_max_header_name_length,
-      max_header_value_length: http_max_header_value_length,
-      max_headers: http_max_headers
-    ]
-  ],
+  # url: [
+  #   scheme: System.get_env("SCHEME", "https"),
+  #   host: System.get_env("HOST", "localhost"),
+  #   port: String.to_integer(System.get_env("PORT", "443"))
+  # ],
+  # https: [
+  #   port: String.to_integer(System.get_env("HTTPS_PORT", "443")),
+  #   otp_app: :oli,
+  #   keyfile: System.get_env("SSL_KEY_PATH", "priv/ssl/localhost.key"),
+  #   certfile: System.get_env("SSL_CERT_PATH", "priv/ssl/localhost.crt"),
+  #   protocol_options: [
+  #     max_header_name_length: http_max_header_name_length,
+  #     max_header_value_length: http_max_header_value_length,
+  #     max_headers: http_max_headers
+  #   ]
+  # ],
   debug_errors: true,
   code_reloader: true,
   check_origin: false,

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -95,22 +95,22 @@ config :oli, OliWeb.Endpoint,
       max_headers: http_max_headers
     ]
   ],
-  # url: [
-  #   scheme: System.get_env("SCHEME", "https"),
-  #   host: System.get_env("HOST", "localhost"),
-  #   port: String.to_integer(System.get_env("PORT", "443"))
-  # ],
-  # https: [
-  #   port: String.to_integer(System.get_env("HTTPS_PORT", "443")),
-  #   otp_app: :oli,
-  #   keyfile: System.get_env("SSL_KEY_PATH", "priv/ssl/localhost.key"),
-  #   certfile: System.get_env("SSL_CERT_PATH", "priv/ssl/localhost.crt"),
-  #   protocol_options: [
-  #     max_header_name_length: http_max_header_name_length,
-  #     max_header_value_length: http_max_header_value_length,
-  #     max_headers: http_max_headers
-  #   ]
-  # ],
+  url: [
+    scheme: System.get_env("SCHEME", "https"),
+    host: System.get_env("HOST", "localhost"),
+    port: String.to_integer(System.get_env("PORT", "443"))
+  ],
+  https: [
+    port: String.to_integer(System.get_env("HTTPS_PORT", "443")),
+    otp_app: :oli,
+    keyfile: System.get_env("SSL_KEY_PATH", "priv/ssl/localhost.key"),
+    certfile: System.get_env("SSL_CERT_PATH", "priv/ssl/localhost.crt"),
+    protocol_options: [
+      max_header_name_length: http_max_header_name_length,
+      max_header_value_length: http_max_header_value_length,
+      max_headers: http_max_headers
+    ]
+  ],
   debug_errors: true,
   code_reloader: true,
   check_origin: false,

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -93,6 +93,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
       auto_submit = page_context.effective_settings.late_submit == :disallow
 
       now = DateTime.utc_now() |> to_epoch
+
       attempt_expired_auto_submit =
         now > effective_end_time and auto_submit and !page_context.review_mode
 


### PR DESCRIPTION
[MER-3931](https://eliterate.atlassian.net/browse/MER-3931)

This PR addresses an issue where, if a student starts a graded attempt, then navigates away from the quiz and then returns to the quiz after the timeout is expired, the quiz erroneously allows the student to answer and submit responses. 

[MER-3931]: https://eliterate.atlassian.net/browse/MER-3931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ