### PR TITLE
[BUG FIX] [MER-3944] Fix activity bank revision history route

### DIFF
--- a/assets/src/components/activity/InlineActivityEditor.tsx
+++ b/assets/src/components/activity/InlineActivityEditor.tsx
@@ -185,7 +185,7 @@ export class InlineActivityEditor extends React.Component<
             {this.props.revisionHistoryLink && (
               <a
                 className="dropdown-item ml-auto"
-                href={`/project/${this.props.projectSlug}/history/slug/${this.props.activitySlug}`}
+                href={`/workspaces/course_author/${this.props.projectSlug}/curriculum/${this.props.activitySlug}/history`}
               >
                 <i className="fas fa-history mr-1"></i> View revision history
               </a>

--- a/lib/oli_web/live/workspaces/course_author/history_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/history_live.ex
@@ -565,7 +565,10 @@ defmodule OliWeb.Workspaces.CourseAuthor.HistoryLive do
        upload_errors: [],
        edited_json: nil,
        details_modal_assigns: nil,
-       resource_schema: resource_schema
+       resource_schema: resource_schema,
+       resource_title: project.title,
+       resource_slug: project.slug,
+       active_view: :curriculum
      )
      |> assign_new(:revision_root_slug, fn _ -> Resources.get_revision_root_slug(revision.id) end)
      |> allow_upload(:json, accept: ~w(.json), max_entries: 1)}


### PR DESCRIPTION
[MER-3944](https://eliterate.atlassian.net/browse/MER-3944)

This PR fixes the route used to navigate to the `view revision history` link found in each activity that is added in the Activity Bank view within the Course Author Workspace. 


https://github.com/user-attachments/assets/5f32619c-9852-40cf-b856-de10bc4f6d5d



[MER-3944]: https://eliterate.atlassian.net/browse/MER-3944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ