### PR TITLE
[PERFORMANCE] [MER-3934] Move link calculation upfront to publication diff

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -1263,19 +1263,20 @@ defmodule Oli.Delivery.Sections do
     # We do this because we want to treat these links the same way when we traverse the graph, and
     # we want to be able to handle cases where a page from the hierarchy embeds an activity which
     # links to a page outside the hierarchy.
-    all_links = case all_links do
-      nil ->
-        [
-          get_all_page_links(publication_ids),
-          get_activity_references(publication_ids),
-          get_relates_to(publication_ids)
-        ]
-        |> Enum.reduce(MapSet.new(), fn links, acc -> MapSet.union(links, acc) end)
-        |> MapSet.to_list()
+    all_links =
+      case all_links do
+        nil ->
+          [
+            get_all_page_links(publication_ids),
+            get_activity_references(publication_ids),
+            get_relates_to(publication_ids)
+          ]
+          |> Enum.reduce(MapSet.new(), fn links, acc -> MapSet.union(links, acc) end)
+          |> MapSet.to_list()
 
-      _ ->
-        all_links
-    end
+        _ ->
+          all_links
+      end
 
     link_map =
       Enum.reduce(all_links, %{}, fn {source, target}, map ->

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -1252,7 +1252,7 @@ defmodule Oli.Delivery.Sections do
   # determine and return the list of page resource ids that are not reachable from that
   # hierarchy, taking into account links from pages to other pages and the 'relates_to'
   # relationship between pages.
-  def determine_unreachable_pages(publication_ids, hierarchy_ids) do
+  def determine_unreachable_pages(publication_ids, hierarchy_ids, all_links \\ nil) do
     # Start with all pages
     unreachable =
       Oli.Publishing.all_page_resource_ids(publication_ids)
@@ -1263,14 +1263,19 @@ defmodule Oli.Delivery.Sections do
     # We do this because we want to treat these links the same way when we traverse the graph, and
     # we want to be able to handle cases where a page from the hierarchy embeds an activity which
     # links to a page outside the hierarchy.
-    all_links =
-      [
-        get_all_page_links(publication_ids),
-        get_activity_references(publication_ids),
-        get_relates_to(publication_ids)
-      ]
-      |> Enum.reduce(MapSet.new(), fn links, acc -> MapSet.union(links, acc) end)
-      |> MapSet.to_list()
+    all_links = case all_links do
+      nil ->
+        [
+          get_all_page_links(publication_ids),
+          get_activity_references(publication_ids),
+          get_relates_to(publication_ids)
+        ]
+        |> Enum.reduce(MapSet.new(), fn links, acc -> MapSet.union(links, acc) end)
+        |> MapSet.to_list()
+
+      _ ->
+        all_links
+    end
 
     link_map =
       Enum.reduce(all_links, %{}, fn {source, target}, map ->
@@ -1313,7 +1318,7 @@ defmodule Oli.Delivery.Sections do
 
   # Returns a mapset of two element tuples of the form {source_resource_id, target_resource_id}
   # representing all of the links between pages in the section
-  defp get_all_page_links(publication_ids) do
+  def get_all_page_links(publication_ids) do
     joined_publication_ids = Enum.join(publication_ids, ",")
 
     item_types =
@@ -1353,7 +1358,7 @@ defmodule Oli.Delivery.Sections do
 
   # Returns a mapset of two element tuples of the form {source_resource_id, target_resource_id}
   # representing the links of pages to activities
-  defp get_activity_references(publication_ids) do
+  def get_activity_references(publication_ids) do
     joined_publication_ids = Enum.join(publication_ids, ",")
 
     sql = """
@@ -1375,7 +1380,7 @@ defmodule Oli.Delivery.Sections do
 
   # Returns a mapset of two element tuples of the form {source_resource_id, target_resource_id}
   # representing the relates_to relationship between pages.
-  defp get_relates_to(publication_ids) do
+  def get_relates_to(publication_ids) do
     joined_publication_ids = Enum.join(publication_ids, ",")
     page_type_id = Oli.Resources.ResourceType.id_for_page()
 

--- a/lib/oli/delivery/sections/updates.ex
+++ b/lib/oli/delivery/sections/updates.ex
@@ -166,7 +166,7 @@ defmodule Oli.Delivery.Sections.Updates do
 
         Sections.update_section_project_publication(section, project_id, new_publication.id)
 
-        cull_unreachable_pages(section)
+        cull_unreachable_pages(section, diff)
 
         Logger.info(
           "perform_update.MINOR: section[#{section.slug}] #{Oli.Timing.elapsed(mark) / 1000 / 1000}ms"
@@ -276,7 +276,7 @@ defmodule Oli.Delivery.Sections.Updates do
     Sections.update_section_project_publication(section, project_id, new_publication.id)
 
     with {:ok, _} <- update_container_children(section, prev_publication, new_publication),
-         {:ok, _} <- cull_unreachable_pages(section),
+         {:ok, _} <- cull_unreachable_pages(section, diff),
          {:ok, _} <- Oli.Delivery.PreviousNextIndex.rebuild(section),
          {:ok, _} <- Sections.rebuild_contained_pages(section),
          {:ok, _} <- Sections.rebuild_contained_objectives(section) do
@@ -353,7 +353,7 @@ defmodule Oli.Delivery.Sections.Updates do
     [section_resource | section_resources]
   end
 
-  defp cull_unreachable_pages(section) do
+  defp cull_unreachable_pages(section, %PublicationDiff{to_pub: publication, all_links: all_links}) do
     section_id = section.id
 
     map =
@@ -373,18 +373,16 @@ defmodule Oli.Delivery.Sections.Updates do
       end)
       |> List.flatten()
 
-    publication_ids =
-      Oli.Repo.all(Oli.Delivery.Sections.SectionsProjectsPublications, section_id: section.id)
-      |> Enum.map(fn spp -> spp.publication_id end)
-
     unreachable_page_resource_ids =
       case section.required_survey_resource_id do
         nil ->
-          Oli.Delivery.Sections.determine_unreachable_pages(publication_ids, hierarchy_ids)
+          Oli.Delivery.Sections.determine_unreachable_pages([publication.id], hierarchy_ids, all_links)
 
         id ->
-          Oli.Delivery.Sections.determine_unreachable_pages(publication_ids, [id | hierarchy_ids])
+          Oli.Delivery.Sections.determine_unreachable_pages([publication.id], [id | hierarchy_ids], all_links)
       end
+
+    project_id = publication.project_id
 
     case unreachable_page_resource_ids do
       [] ->
@@ -392,7 +390,9 @@ defmodule Oli.Delivery.Sections.Updates do
 
       _ ->
         from(sr in SectionResource,
-          where: sr.section_id == ^section_id and sr.resource_id in ^unreachable_page_resource_ids
+          where: sr.project_id == ^project_id
+            and sr.section_id == ^section_id
+            and sr.resource_id in ^unreachable_page_resource_ids
         )
         |> Repo.delete_all()
 

--- a/lib/oli/delivery/sections/updates.ex
+++ b/lib/oli/delivery/sections/updates.ex
@@ -376,10 +376,18 @@ defmodule Oli.Delivery.Sections.Updates do
     unreachable_page_resource_ids =
       case section.required_survey_resource_id do
         nil ->
-          Oli.Delivery.Sections.determine_unreachable_pages([publication.id], hierarchy_ids, all_links)
+          Oli.Delivery.Sections.determine_unreachable_pages(
+            [publication.id],
+            hierarchy_ids,
+            all_links
+          )
 
         id ->
-          Oli.Delivery.Sections.determine_unreachable_pages([publication.id], [id | hierarchy_ids], all_links)
+          Oli.Delivery.Sections.determine_unreachable_pages(
+            [publication.id],
+            [id | hierarchy_ids],
+            all_links
+          )
       end
 
     project_id = publication.project_id
@@ -390,9 +398,10 @@ defmodule Oli.Delivery.Sections.Updates do
 
       _ ->
         from(sr in SectionResource,
-          where: sr.project_id == ^project_id
-            and sr.section_id == ^section_id
-            and sr.resource_id in ^unreachable_page_resource_ids
+          where:
+            sr.project_id == ^project_id and
+              sr.section_id == ^section_id and
+              sr.resource_id in ^unreachable_page_resource_ids
         )
         |> Repo.delete_all()
 

--- a/lib/oli/publishing/publications/publication_diff.ex
+++ b/lib/oli/publishing/publications/publication_diff.ex
@@ -9,6 +9,7 @@ defmodule Oli.Publishing.Publications.PublicationDiff do
     :changes,
     :from_pub,
     :to_pub,
+    :all_links,
     :created_at
   ]
 
@@ -20,6 +21,7 @@ defmodule Oli.Publishing.Publications.PublicationDiff do
     :changes,
     :from_pub,
     :to_pub,
+    :all_links,
     :created_at
   ]
 
@@ -31,6 +33,7 @@ defmodule Oli.Publishing.Publications.PublicationDiff do
           changes: Map.t(),
           from_pub: Publication.t(),
           to_pub: Publication.t(),
+          all_links: List.t(),
           created_at: DateTime.t()
         }
 end

--- a/test/oli/publishing/publications/diff_agent_test.exs
+++ b/test/oli/publishing/publications/diff_agent_test.exs
@@ -16,6 +16,7 @@ defmodule Oli.Publishing.Publications.DiffAgentTest do
         minor: 0,
         changes: %{},
         from_pub: 0,
+        all_links: [],
         to_pub: 1,
         created_at: Timex.now() |> Timex.subtract(Timex.Duration.from_days(4))
       })
@@ -30,6 +31,7 @@ defmodule Oli.Publishing.Publications.DiffAgentTest do
         changes: %{},
         from_pub: 0,
         to_pub: 1,
+        all_links: [],
         created_at: Timex.now() |> Timex.subtract(Timex.Duration.from_days(11))
       })
 

--- a/test/oli/publishing_test.exs
+++ b/test/oli/publishing_test.exs
@@ -779,6 +779,7 @@ defmodule Oli.PublishingTest do
         edition: edition,
         major: major,
         minor: minor,
+        all_links: [],
         changes: diff
       } = Publishing.diff_publications(p1, p2)
 


### PR DESCRIPTION
The original plan was to introduce resource link tracking into the DB, but that approach became overly complex - so instead I took this approach of moving the link calculation upfront during the publication process: namely to when the `PublicationDiff` is calculated.  Then, at publication application time, we use those links - but only to cull non-reachable pages from the project pertaining to the publication being updated.  

This does not completely eliminate the issue of "slow queries to calculate links" but it puts a constant upper bound (of 1) on the how many times we run this when a publication is pushed out to many course sections.  