### PR TITLE
[BUG FIX] [MER-3953] Fix names for infiniscope author accounts

### DIFF
--- a/lib/oli/accounts.ex
+++ b/lib/oli/accounts.ex
@@ -1026,10 +1026,10 @@ defmodule Oli.Accounts do
 
   defp get_or_create_author(_repo, %{user: %{author_id: nil} = user}, fields) do
     email = Map.get(fields, "email")
-    username = Map.get(fields, "cognito:username")
+    name = Map.get(fields, "name")
 
     %Author{}
-    |> Author.sso_changeset(%{name: username, email: email})
+    |> Author.sso_changeset(%{name: name, email: email})
     |> Repo.insert()
     |> case do
       {:ok, author} = result ->
@@ -1047,12 +1047,12 @@ defmodule Oli.Accounts do
 
   defp create_sso_author(_repo, _changes, fields) do
     email = Map.get(fields, "email")
-    username = Map.get(fields, "cognito:username")
+    name = Map.get(fields, "name")
 
     case get_author_by_email(email) do
       nil ->
         %Author{}
-        |> Author.noauth_changeset(%{name: username, email: email})
+        |> Author.noauth_changeset(%{name: name, email: email})
         |> Repo.insert()
 
       author ->

--- a/test/oli/accounts_test.exs
+++ b/test/oli/accounts_test.exs
@@ -351,7 +351,14 @@ defmodule Oli.AccountsTest do
 
     test "setup_sso_author/2 creates author and user if do not exist and associates user to the given community" do
       community = insert(:community)
-      fields = %{"sub" => "sub", "cognito:username" => "username", "email" => "email"}
+
+      fields = %{
+        "sub" => "sub",
+        "cognito:username" => "ea06d74d-a1f6-4fdc-a8b3-b4550f9625f1",
+        "email" => "email",
+        "name" => "username"
+      }
+
       {:ok, author} = Accounts.setup_sso_author(fields, community.id)
 
       assert author.name == "username"
@@ -359,7 +366,7 @@ defmodule Oli.AccountsTest do
 
       user = Accounts.get_user_by(%{email: "email"})
       assert user.sub == "sub"
-      assert user.preferred_username == "username"
+      assert user.preferred_username == "ea06d74d-a1f6-4fdc-a8b3-b4550f9625f1"
       assert user.email == "email"
       assert user.can_create_sections
 
@@ -640,7 +647,13 @@ defmodule Oli.AccountsTest do
     test "creates both a user and an author, and links them together" do
       user_email = "user@email.com"
       community = insert(:community)
-      fields = %{"sub" => "sub", "cognito:username" => "username", "email" => user_email}
+
+      fields = %{
+        "sub" => "sub",
+        "name" => "username",
+        "email" => user_email,
+        "cognito:username" => "ea06d74d-a1f6-4fdc-a8b3-b4550f9625f1"
+      }
 
       {:ok, user, author} = Accounts.setup_sso_user(fields, community.id)
 
@@ -648,7 +661,7 @@ defmodule Oli.AccountsTest do
       author_id = author.id
 
       assert user.sub == "sub"
-      assert user.preferred_username == "username"
+      assert user.preferred_username == "ea06d74d-a1f6-4fdc-a8b3-b4550f9625f1"
       assert user.email == user_email
       assert user.can_create_sections
 
@@ -671,7 +684,7 @@ defmodule Oli.AccountsTest do
       existing_user = insert(:user, email: user_email, author: existing_author, sub: "sub")
 
       community = insert(:community)
-      fields = %{"sub" => "sub", "cognito:username" => "username", "email" => user_email}
+      fields = %{"sub" => "sub", "name" => "username", "email" => user_email}
 
       {:ok, user, author} = Accounts.setup_sso_user(fields, community.id)
 

--- a/test/oli_web/live/products_test.exs
+++ b/test/oli_web/live/products_test.exs
@@ -177,17 +177,29 @@ defmodule OliWeb.ProductsLiveTest do
 
       {:ok, view, _html} = live(conn, @live_view_all_products)
 
+      view
+      |> element("th[phx-click=\"paged_table_sort\"][phx-value-sort_by=\"inserted_at\"]")
+      |> render_click()
+
       assert view
              |> element("tr:first-child > td:first-child")
              |> render() =~ product.title
 
+      assert view
+             |> element("tr:last-child > td:first-child")
+             |> render() =~ product_2.title
+
       view
-      |> element("th[phx-click=\"paged_table_sort\"]:first-of-type")
-      |> render_click(%{sort_by: "inserted_at"})
+      |> element("th[phx-click=\"paged_table_sort\"][phx-value-sort_by=\"inserted_at\"]")
+      |> render_click()
 
       assert view
              |> element("tr:first-child > td:first-child")
              |> render() =~ product_2.title
+
+      assert view
+             |> element("tr:last-child > td:first-child")
+             |> render() =~ product.title
     end
 
     test "include archived products", %{conn: conn, product: product} do


### PR DESCRIPTION
[MER-3953](https://eliterate.atlassian.net/browse/MER-3953)

This PR aims to fix getting data from infiniscope or any other LMS that uses SSO. 

In the author creation functions with SSO we were taking the field `cognito:username` as name, which was an error since that field brings us the username that sometimes can be a long string with numbers and letters as indicated in the ticket. 

With these changes we correctly assign the `name` field that comes from the LMS.


https://github.com/user-attachments/assets/abd7c694-cd6f-4a49-b2ad-e0c562b49541



[MER-3953]: https://eliterate.atlassian.net/browse/MER-3953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ