### PR TITLE
[FEATURE] [MER-3828] Home screen course progress card - part 2

### DIFF
--- a/lib/oli_web/components/common.ex
+++ b/lib/oli_web/components/common.ex
@@ -586,6 +586,12 @@ defmodule OliWeb.Components.Common do
   attr(:percent, :integer, required: true)
   attr(:width, :string, default: "100%")
   attr(:show_percent, :boolean, default: true)
+
+  attr(:show_halo, :boolean,
+    default: false,
+    doc: "shows a blurry halo at the end of the progress bar"
+  )
+
   attr(:role, :string, default: "progress_bar")
   attr(:height, :string, default: "h-1")
   attr(:rounded, :string, default: "rounded-[60px]")
@@ -608,7 +614,7 @@ defmodule OliWeb.Components.Common do
   def progress_bar(assigns) do
     ~H"""
     <div class="flex flex-row items-center gap-3 mx-auto w-full" role={@role}>
-      <div class="flex justify-center w-full">
+      <div class="flex justify-center w-full relative">
         <div class={"#{@rounded} #{@height} #{@not_completed_colour}"} style={"width: #{@width}"}>
           <div
             role="progress"
@@ -619,6 +625,14 @@ defmodule OliWeb.Components.Common do
             style={"width: #{if @percent == 0, do: 1, else: @percent}%"}
           >
           </div>
+        </div>
+
+        <div
+          :if={@show_halo}
+          role="halo"
+          class="absolute -top-[5px] z-50 w-6 h-3.5 bg-[#39e581]/40 rounded-[47px] blur-[8px]"
+          style={"left: #{@percent}%; transform: translateX(-12px);"}
+        >
         </div>
       </div>
       <div

--- a/lib/oli_web/live/delivery/student/index_live.ex
+++ b/lib/oli_web/live/delivery/student/index_live.ex
@@ -459,7 +459,7 @@ defmodule OliWeb.Delivery.Student.IndexLive do
         </div>
       </Modal.modal>
     </div>
-    <div class="w-full h-fit p-6 bg-[#1C1A20] bg-opacity-20 dark:bg-opacity-100 rounded-2xl justify-start items-start gap-32 inline-flex">
+    <div class="w-full h-fit p-6 bg-white shadow dark:bg-[#1C1A20] dark:bg-opacity-100 rounded-2xl justify-start items-start gap-32 inline-flex">
       <div class="flex-col justify-start items-start gap-5 inline-flex grow">
         <div class="flex items-baseline gap-2.5 relative">
           <div class="text-2xl font-bold leading-loose">
@@ -547,7 +547,7 @@ defmodule OliWeb.Delivery.Student.IndexLive do
     assigns = Map.put(assigns, :lessons, lessons)
 
     ~H"""
-    <div class="w-full h-fit p-6 bg-[#1C1A20] bg-opacity-20 dark:bg-opacity-100 rounded-2xl justify-start items-start gap-32 inline-flex">
+    <div class="w-full h-fit p-6 bg-white shadow dark:bg-[#1C1A20] dark:bg-opacity-100 rounded-2xl justify-start items-start gap-32 inline-flex">
       <div class="w-full flex-col justify-start items-start gap-5 flex grow">
         <div class="w-full xl:w-48 overflow-hidden justify-start items-start gap-2.5 flex">
           <div class="text-2xl font-bold leading-loose tracking-tight">
@@ -827,7 +827,7 @@ defmodule OliWeb.Delivery.Student.IndexLive do
 
   defp agenda(assigns) do
     ~H"""
-    <div class="w-full h-fit overflow-y-auto p-6 bg-[#1C1A20] bg-opacity-20 dark:bg-opacity-100 rounded-2xl justify-start items-start gap-32 inline-flex">
+    <div class="w-full h-fit overflow-y-auto p-6 bg-white shadow dark:bg-[#1C1A20] dark:bg-opacity-100 rounded-2xl justify-start items-start gap-32 inline-flex">
       <div class="flex-col justify-start items-start gap-7 inline-flex grow">
         <div class="self-stretch justify-between items-baseline inline-flex gap-2.5">
           <div class="text-2xl font-bold leading-loose tracking-tight">

--- a/lib/oli_web/live/delivery/student/index_live.ex
+++ b/lib/oli_web/live/delivery/student/index_live.ex
@@ -510,6 +510,7 @@ defmodule OliWeb.Delivery.Student.IndexLive do
             not_completed_colour="bg-gray-600/20 dark:bg-[#385581]"
             role="course progress bar"
             show_percent={false}
+            show_halo={true}
           />
           <.link
             navigate={@page_completed_target_path}

--- a/lib/oli_web/live/delivery/student/index_live.ex
+++ b/lib/oli_web/live/delivery/student/index_live.ex
@@ -391,7 +391,7 @@ defmodule OliWeb.Delivery.Student.IndexLive do
         id="course_progress_calculation_modal"
         class="mx-52"
         header_class="flex items-start justify-between px-[35px] pt-[27px] pb-4"
-        body_class="border-t border-[#3e3f44] px-[35px] pb-[50px] pt-[30px]"
+        body_class="border-t border-[#d4d4d4] dark:border-[#3e3f44] px-[35px] pb-[50px] pt-[30px]"
       >
         <:title>Course Progress Calculation</:title>
         <div class="dark:text-white text-base">
@@ -400,8 +400,10 @@ defmodule OliWeb.Delivery.Student.IndexLive do
           </div>
           <div class="flex-col justify-start items-start gap-[31px] inline-flex">
             <div class="self-stretch justify-start items-start gap-3 inline-flex">
-              <div class="px-3 py-1 bg-[#363b59] rounded-[999px] justify-start items-center gap-1.5 flex">
-                <div class="w-5 h-5 relative text-[#99ccff]"><Icons.clipboard /></div>
+              <div class="px-3 py-1 bg-[#deecff] dark:bg-[#363b59] rounded-[999px] justify-start items-center gap-1.5 flex">
+                <div class="w-5 h-5 relative text-[#1b67b2] dark:text-[#99ccff]">
+                  <Icons.clipboard />
+                </div>
               </div>
               <div class="pb-[3px] justify-end items-center flex">
                 <div class="self-stretch pr-[13px] justify-start items-center inline-flex">
@@ -418,8 +420,8 @@ defmodule OliWeb.Delivery.Student.IndexLive do
               </div>
             </div>
             <div class="justify-start items-center gap-3 inline-flex">
-              <div class="px-3 py-1 bg-[#364147] rounded-[999px] justify-start items-center gap-1.5 flex">
-                <div class="w-5 h-5 relative text-[#87d7e0]"><Icons.book /></div>
+              <div class="px-3 py-1 bg-[#dcf3f5] dark:bg-[#364147] rounded-[999px] justify-start items-center gap-1.5 flex">
+                <div class="w-5 h-5 relative text-[#00808f] dark:text-[#87d7e0]"><Icons.book /></div>
               </div>
               <div class="">
                 <span class="font-bold">
@@ -432,8 +434,10 @@ defmodule OliWeb.Delivery.Student.IndexLive do
               </div>
             </div>
             <div class="justify-start items-center gap-3 inline-flex">
-              <div class="px-3 py-1 bg-[#4c3f39] rounded-[999px] justify-start items-center gap-1.5 flex">
-                <div class="w-5 h-5 relative text-[#ffb387]"><Icons.transparent_flag /></div>
+              <div class="px-3 py-1 bg-[#ffecde] dark:bg-[#4c3f39] rounded-[999px] justify-start items-center gap-1.5 flex">
+                <div class="w-5 h-5 relative text-[#bf5b13] dark:text-[#ffb387]">
+                  <Icons.transparent_flag />
+                </div>
               </div>
               <div>
                 <span class="font-bold">
@@ -470,9 +474,9 @@ defmodule OliWeb.Delivery.Student.IndexLive do
             phx-hook="AutoHideTooltip"
             class="hidden absolute z-50 -top-[89px] -right-[316px] p-4"
           >
-            <div class="w-[320px] h-[88px] px-4 py-2 bg-[#0d0c0f] rounded-md shadow border border-[#3a3740]">
+            <div class="w-[320px] h-[88px] px-4 py-2 bg-white dark:bg-[#0d0c0f] rounded-md shadow border border-[#ced1d9] dark:border-[#3a3740]">
               <div class="grow shrink basis-0">
-                <span class="text-[#eeebf5] text-sm font-normal leading-normal">
+                <span class="text-[#353740] dark:text-[#eeebf5] text-sm font-normal leading-normal">
                   Course progress is calculated based on the pages you visit and the percentage of activities you complete.
                 </span>
                 <button
@@ -480,7 +484,7 @@ defmodule OliWeb.Delivery.Student.IndexLive do
                     Modal.show_modal("course_progress_calculation_modal")
                     |> JS.hide(to: "#course_progress_tooltip")
                   }
-                  class="text-[#eeebf5] text-sm font-bold underline leading-normal"
+                  class="text-[#353740] dark:text-[#eeebf5] text-sm font-bold underline leading-normal"
                 >
                   Learn more.
                 </button>
@@ -507,14 +511,14 @@ defmodule OliWeb.Delivery.Student.IndexLive do
             percent={@completed_pages.completed_pages / @completed_pages.total_pages * 100}
             on_going_colour="bg-[#0CAF61] dark:bg-[#0fb863]"
             completed_colour="bg-[#0CAF61] dark:bg-[#0fb863]"
-            not_completed_colour="bg-gray-600/20 dark:bg-[#385581]"
+            not_completed_colour="bg-[#385581]"
             role="course progress bar"
             show_percent={false}
             show_halo={true}
           />
           <.link
             navigate={@page_completed_target_path}
-            class="text-[#3399FF] text-base font-bold ml-auto hover:text-opacity-80 hover:no-underline"
+            class="text-[#4ca6ff] dark:text-[#3399FF] text-base font-bold ml-auto hover:text-opacity-80 hover:no-underline"
           >
             <%= @completed_pages.completed_pages %>/<%= @completed_pages.total_pages %> Pages Completed
           </.link>


### PR DESCRIPTION
Link to [comment 1](https://eliterate.atlassian.net/browse/MER-3828?focusedCommentId=24822) and [comment 2](https://eliterate.atlassian.net/browse/MER-3828?focusedCommentId=24827) in the ticket

This PR adds some minor changes omitted in the original PR regarding a blur effect on the progress bar and some styling mismatching in light mode.

While working on this I found that the background color for assignments and agenda components was wrong in light mode, so I pushed a fix for that too.


https://github.com/user-attachments/assets/0394d670-d844-468d-b793-5073cc9da343

