### PR TITLE
[BUG FIX] [MER-4003] fix so hotspot selection highlighted on return to page

### DIFF
--- a/assets/src/components/activities/image_hotspot/ImageHotspotDelivery.tsx
+++ b/assets/src/components/activities/image_hotspot/ImageHotspotDelivery.tsx
@@ -72,10 +72,10 @@ const ImageHotspotComponent: React.FC = () => {
 
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const canvasRef2 = useRef<HTMLCanvasElement>(null);
-  const canvas = canvasRef.current;
-  const ctx = canvas?.getContext('2d');
 
   const showSelected = () => {
+    const canvas = canvasRef.current;
+    const ctx = canvas?.getContext('2d');
     if (canvas && ctx) {
       ctx?.clearRect(0, 0, canvas?.width, canvas.height);
     }


### PR DESCRIPTION
This fixes a coding error which was preventing any existing image hotspot selection from being highlighted on first render. Symptom was that on reloading/returning to practice page or reviewing graded page after selection, the selection was not being highlighted. (Though hovering mouse over ANY hotspot would trigger a re-render that does show the selection). Relevant code to fetch canvas drawing context needed to be located inside the useEffect hook so it executes after rendering the canvas.