### PR TITLE
[BUG FIX] [MER-3906] Clicking backspace causes the Delete Component modal to pop up

### DIFF
--- a/assets/src/apps/authoring/components/PropertyEditor/PropertyEditor.tsx
+++ b/assets/src/apps/authoring/components/PropertyEditor/PropertyEditor.tsx
@@ -1,11 +1,9 @@
 import React, { Fragment, useEffect, useState } from 'react';
-import { useDispatch } from 'react-redux';
 import Form from '@rjsf/bootstrap-4';
 import { UiSchema } from '@rjsf/core';
 import { diff } from 'deep-object-diff';
 import { JSONSchema7 } from 'json-schema';
 import { at } from 'lodash';
-import { setCurrentPartPropertyFocus } from 'apps/authoring/store/parts/slice';
 import ColorPickerWidget from './custom/ColorPickerWidget';
 import CustomCheckbox from './custom/CustomCheckbox';
 import { DropdownOptionsEditor } from './custom/DropdownOptionsEditor';
@@ -53,7 +51,6 @@ const PropertyEditor: React.FC<PropertyEditorProps> = ({
   onfocusHandler,
 }) => {
   const [formData, setFormData] = useState<any>(value);
-  const dispatch = useDispatch();
   const findDiffType = (changedProp: any): string => {
     const diffType: Record<string, unknown>[] = Object.values(changedProp);
     if (typeof diffType[0] === 'object') {
@@ -101,10 +98,8 @@ const PropertyEditor: React.FC<PropertyEditorProps> = ({
         if (onfocusHandler) {
           onfocusHandler(false);
         }
-        dispatch(setCurrentPartPropertyFocus({ focus: false }));
       }}
       onBlur={(key, changed) => {
-        dispatch(setCurrentPartPropertyFocus({ focus: true }));
         // key will look like root_Position_x
         // changed will be the new value
         // formData will be the current state of the form
@@ -118,7 +113,8 @@ const PropertyEditor: React.FC<PropertyEditorProps> = ({
           // console.log('ONBLUR TRIGGER SAVE');
 
           onChangeHandler(formData);
-        } else if (onfocusHandler) {
+        }
+        if (onfocusHandler) {
           onfocusHandler(true);
         }
       }}

--- a/assets/src/apps/authoring/components/PropertyEditor/PropertyEditor.tsx
+++ b/assets/src/apps/authoring/components/PropertyEditor/PropertyEditor.tsx
@@ -110,8 +110,6 @@ const PropertyEditor: React.FC<PropertyEditorProps> = ({
         // specifically using != instead of !== because `changed` is always a string
         // and the stakes here are not that high, we are just trying to avoid saving so many times
         if (newValue != changed) {
-          // console.log('ONBLUR TRIGGER SAVE');
-
           onChangeHandler(formData);
         }
         if (onfocusHandler) {


### PR DESCRIPTION
Hey @bsparks could you please look at the PR? Thanks

While working on a ticket related to Pop-up, I found the we are not able to edit the pop-up window. It goes blank and throws an error "`useDispatch() Error: Could not find react-redux context value; please ensure the component is wrapped in a <Provider>`". I removed the code that were using dispatch, and it's handled differently now.

FYI - this PR is similar to other PR related to similar type of issue - https://github.com/Simon-Initiative/oli-torus/pull/5211, https://github.com/Simon-Initiative/oli-torus/pull/5019 and https://github.com/Simon-Initiative/oli-torus/pull/4978