### PR TITLE
[BUG FIX] [MER-4004] Fix snapshot creation for manually graded activities when Oban is enabled.

### DIFF
--- a/lib/oli/delivery/attempts/manual_grading.ex
+++ b/lib/oli/delivery/attempts/manual_grading.ex
@@ -254,8 +254,9 @@ defmodule Oli.Delivery.Attempts.ManualGrading do
            {:ok, _} <-
              Evaluate.rollup_part_attempt_evaluations(activity_attempt.attempt_guid),
            :ok <-
-             to_attempt_guid(finalized_part_attempts)
-             |> Oli.Delivery.Snapshots.queue_or_create_snapshot(section_slug),
+             finalized_part_attempts
+             |> to_attempt_guid()
+             |> queue_or_create_snapshot(section_slug),
            {:ok, _} <- maybe_finalize_resource_attempt(section, graded, resource_attempt_guid) do
         finalized_part_attempts
       else
@@ -367,5 +368,12 @@ defmodule Oli.Delivery.Attempts.ManualGrading do
     |> Enum.map(fn text ->
       %{type: "p", children: [%{text: text}]}
     end)
+  end
+
+  defp queue_or_create_snapshot(part_attempt_guids, section_slug) do
+    case Oli.Delivery.Snapshots.queue_or_create_snapshot(part_attempt_guids, section_slug) do
+      {:ok, _job} -> :ok
+      other -> other
+    end
   end
 end


### PR DESCRIPTION
When Oban was enabled, scoring a manually graded activity would queue the snapshot creation instead of creating it immediately. This caused a false error message to appear in the UI. 

See: https://eliterate.atlassian.net/browse/MER-4004

