### PR TITLE
[BUG FIX] [MER-3269] Fix deletion of bib entry fields

### DIFF
--- a/assets/src/apps/bibliography/BibEntryEditor.tsx
+++ b/assets/src/apps/bibliography/BibEntryEditor.tsx
@@ -215,15 +215,9 @@ export const BibEntryEditor: React.FC<BibEntryEditorProps> = (props: BibEntryEdi
         <Tooltip title="Delete this field">
           <button
             onClick={() => {
-              let m: CitationModel = { id: '', type: '' };
-              m = Object.entries(model).reduce(function (obj, entry) {
-                if (entry[0] != key1) {
-                  obj = { ...obj, [entry[0]]: entry[1] };
-                }
-                return obj;
-              }, m);
-
-              setModel(m);
+              const { [key1]: _deleted, ...newModel } = model as any;
+              setModel(newModel);
+              props.onEdit(newModel);
             }}
             type="button"
             className="btn btn-link text-body-color"


### PR DESCRIPTION
The "manual" bibliography entry editor allows for adding or deleting fields from a bibliography entry. However, the deletions were not taking effect. This occurred because the component was not propagating the change to its parent through props.OnEdit. This PR also recodes to use more concise field deletion code, though this is unrelated to the issue. 