### PR TITLE
[BUG FIX] [MER-4007] Handle both AND and OR

### DIFF
--- a/test/oli/activities/realizer/selection_test.exs
+++ b/test/oli/activities/realizer/selection_test.exs
@@ -296,14 +296,22 @@ defmodule Oli.Activities.SelectionTest do
 
     # Testing this with ALL should only return 1 item, thus partial fulfillment
     selection =
-      selection(2, [expression(:objectives, :contains, [2]), expression(:tags, :contains, [4])], :all)
+      selection(
+        2,
+        [expression(:objectives, :contains, [2]), expression(:tags, :contains, [4])],
+        :all
+      )
 
     {:partial, result} = Selection.fulfill(selection, source)
     assert length(result.rows) == 1
 
     # Testing this with ANY now matches both
     selection =
-      selection(2, [expression(:objectives, :contains, [2]), expression(:tags, :contains, [4])], :any)
+      selection(
+        2,
+        [expression(:objectives, :contains, [2]), expression(:tags, :contains, [4])],
+        :any
+      )
 
     {:ok, result} = Selection.fulfill(selection, source)
 


### PR DESCRIPTION
This PR fixes the activity bank selection fulfillment to properly take into account the `:any` operator.  
