### PR TITLE
[ENHANCEMENT] [MER-3287] Lesson Page Outline and Annotations Panel Scrollbar Improvements

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -172,3 +172,59 @@ https://tailwindcss.com/docs/utility-first
     @apply border-l border-r; /* Apply your desired border styles here */
   }
 }
+
+/* Customize website's scrollbar to look like Mac OS
+Not supports in Firefox and IE */
+
+.scrollbar {
+  overflow: auto;
+}
+
+/* total width */
+.scrollbar::-webkit-scrollbar {
+  background-color: rgba(0, 0, 0, 0);
+  width: 6px;
+  height: 16px;
+}
+
+/* background of the scrollbar except button or resizer */
+.scrollbar::-webkit-scrollbar-track {
+  background-color: #e6e9f2;
+}
+
+.dark .scrollbar::-webkit-scrollbar-track {
+  background-color: #2f2c33;
+}
+
+/* scrollbar itself */
+.scrollbar::-webkit-scrollbar-thumb {
+  background-color: #757682;
+  border-radius: 16px;
+  border: 0px solid #fff;
+}
+
+.dark .scrollbar::-webkit-scrollbar-thumb {
+  background-color: #524d59;
+  border-radius: 16px;
+  border: 0px solid #fff;
+}
+
+/* set button(top and bottom of the scrollbar) */
+.scrollbar::-webkit-scrollbar-button {
+  display: none;
+  width: 0;
+  height: 0;
+}
+
+/* Firefox customized styles */
+
+@-moz-document url-prefix() {
+  .scrollbar {
+    scrollbar-width: thin;
+    scrollbar-color: #757682 #e6e9f2;
+  }
+
+  .dark .scrollbar {
+    scrollbar-color: #524d59 #2f2c33;
+  }
+}

--- a/lib/oli_web/live/delivery/student/lesson/annotations.ex
+++ b/lib/oli_web/live/delivery/student/lesson/annotations.ex
@@ -75,7 +75,7 @@ defmodule OliWeb.Delivery.Student.Lesson.Annotations do
 
   defp annotations(assigns) do
     ~H"""
-    <div class="flex-1 flex flex-col gap-3 pb-2 overflow-y-scroll">
+    <div class="flex-1 flex flex-col gap-3 pb-2 scrollbar overflow-y-scroll">
       <.add_new_annotation_input
         :if={@selected_point}
         class="my-2"
@@ -119,7 +119,7 @@ defmodule OliWeb.Delivery.Student.Lesson.Annotations do
 
   def search_results(assigns) do
     ~H"""
-    <div class="flex-1 flex flex-col gap-3 pb-2 overflow-y-scroll">
+    <div class="flex-1 flex flex-col gap-3 pb-2 scrollbar overflow-y-scroll">
       <%= case @search_results do %>
         <% :loading -> %>
           <Common.loading_spinner />
@@ -770,7 +770,7 @@ defmodule OliWeb.Delivery.Student.Lesson.Annotations do
 
   def delete_post_modal(assigns) do
     ~H"""
-    <Modal.modal id="delete_post_modal" class="w-1/2">
+    <Modal.modal id="delete_post_modal" class="w-1/2 z-50">
       <:title>Delete Note</:title>
       <.form
         phx-submit={JS.push("delete_post") |> Modal.hide_modal("delete_post_modal")}

--- a/lib/oli_web/live/delivery/student/lesson/components/outline_component.ex
+++ b/lib/oli_web/live/delivery/student/lesson/components/outline_component.ex
@@ -83,7 +83,7 @@ defmodule OliWeb.Delivery.Student.Lesson.Components.OutlineComponent do
         </div>
       </div>
       <div class="flex flex-1 flex-col overflow-hidden pl-2 justify-start items-start gap-2 inline-flex">
-        <div class="flex flex-1 flex-col overflow-y-scroll px-2 justify-start items-center gap-4 inline-flex">
+        <div class="flex flex-1 flex-col scrollbar overflow-y-scroll px-2 justify-start items-center gap-4 inline-flex">
           <.outline_item
             :for={node <- @hierarchy["children"]}
             item={node}

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -709,7 +709,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
     # For practice page the activity scripts and activity_bridge script are needed as soon as the page loads.
     ~H"""
     <Annotations.delete_post_modal />
-    <div id="sticky_panel" class="absolute top-4 right-0 z-50 h-full">
+    <div id="sticky_panel" class="absolute top-4 right-0 z-40 h-full">
       <div class="sticky top-20 right-0">
         <div class={[
           "absolute top-24",


### PR DESCRIPTION
[MER-3827](https://eliterate.atlassian.net/browse/MER-3827)

Implement some styling changes on scrollbars across different browsers and operating systems to unify its appearance and make it look more like the Figma designs.
These tests were made in MacOS and Chrome/Firefox. It was not tested in Windows or Edge.

**Before** (Chrome and Firefox):

https://github.com/user-attachments/assets/29149133-ec1d-473c-b6c9-1e73226d4571



**After** (Chrome and Firefox):

https://github.com/user-attachments/assets/d1268e4b-3108-4223-ad0d-dd8a5bfb1809



[MER-3827]: https://eliterate.atlassian.net/browse/MER-3827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ