### PR TITLE
[ENHANCEMENT] [MER-3987] [MER-4018] support submitPerPart on math keyboard questions

### DIFF
--- a/assets/src/components/activities/common/delivery/inputs/MathInput.tsx
+++ b/assets/src/components/activities/common/delivery/inputs/MathInput.tsx
@@ -9,9 +9,17 @@ interface InputProps {
   inline?: boolean;
   size?: MultiInputSize;
   onChange: (value: string) => void;
+  onKeyUp: (e: React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
 }
 
-export const MathInput: React.FC<InputProps> = ({ value, inline, disabled, size, onChange }) => {
+export const MathInput: React.FC<InputProps> = ({
+  value,
+  inline,
+  disabled,
+  size,
+  onChange,
+  onKeyUp,
+}) => {
   return (
     <MathLive
       className={classNames('math-input', size && `input-size-${size}`)}
@@ -21,6 +29,7 @@ export const MathInput: React.FC<InputProps> = ({ value, inline, disabled, size,
         readOnly: disabled,
       }}
       onChange={onChange}
+      onKeyUp={onKeyUp}
     />
   );
 };

--- a/assets/src/components/activities/common/delivery/inputs/MathInput.tsx
+++ b/assets/src/components/activities/common/delivery/inputs/MathInput.tsx
@@ -10,6 +10,7 @@ interface InputProps {
   size?: MultiInputSize;
   onChange: (value: string) => void;
   onKeyUp: (e: React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+  onBlur?: () => void;
 }
 
 export const MathInput: React.FC<InputProps> = ({
@@ -19,6 +20,7 @@ export const MathInput: React.FC<InputProps> = ({
   size,
   onChange,
   onKeyUp,
+  onBlur,
 }) => {
   return (
     <MathLive
@@ -30,6 +32,7 @@ export const MathInput: React.FC<InputProps> = ({
       }}
       onChange={onChange}
       onKeyUp={onKeyUp}
+      onBlur={onBlur}
     />
   );
 };

--- a/assets/src/components/activities/multi_input/MultiInputAuthoring.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputAuthoring.tsx
@@ -47,11 +47,9 @@ export const MultiInputComponent = () => {
   const input = model.inputs.find((input) => input.id === selectedInputRef?.id);
   const index = model.inputs.findIndex((input) => input.id === selectedInputRef?.id);
 
-  // submitPerPart setting incompatible with use of math keyboard
-  const usesMathKeyboard = model.inputs.some((input: MultiInput) => input.inputType === 'math');
   const settings = [
     shuffleAnswerChoiceSetting(model, dispatch, input),
-    !usesMathKeyboard && changePerPartSubmission(model, dispatch),
+    changePerPartSubmission(model, dispatch),
   ];
 
   return (

--- a/assets/src/components/activities/multi_input/MultiInputAuthoring.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputAuthoring.tsx
@@ -8,7 +8,7 @@ import {
   changePerPartSubmission,
   shuffleAnswerChoiceSetting,
 } from 'components/activities/common/authoring/settings/activitySettingsActions';
-import { MultiInput, MultiInputSchema } from 'components/activities/multi_input/schema';
+import { MultiInputSchema } from 'components/activities/multi_input/schema';
 import { AnswerKeyTab } from 'components/activities/multi_input/sections/AnswerKeyTab';
 import { HintsTab } from 'components/activities/multi_input/sections/HintsTab';
 import { MultiInputStem } from 'components/activities/multi_input/sections/MultiInputStem';

--- a/assets/src/components/activities/multi_input/actions.ts
+++ b/assets/src/components/activities/multi_input/actions.ts
@@ -185,9 +185,6 @@ export const MultiInputActions = {
         );
       }
 
-      // math keyboard currently incompatible with submitPerPart option
-      if (type === 'math') model.submitPerPart = false;
-
       part.responses = {
         dropdown: Responses.forMultipleChoice(choices[0].id),
         text: Responses.forTextInput(),

--- a/assets/src/components/activities/short_answer/sections/MathInput.tsx
+++ b/assets/src/components/activities/short_answer/sections/MathInput.tsx
@@ -14,13 +14,7 @@ export const MathInput: React.FC<MathInputProps> = ({ input, onEditInput }) => {
     <div className="mb-2">
       <MathLive
         value={input.value}
-        options={{
-          readOnly: !editMode,
-          // need this because while keyboard toggle gets hidden if readonly, it apparently
-          // isn't automatically restored on change back to nonReadOnly, and authoring context
-          // routinely passes through readonly renders before becoming editable
-          virtualKeyboardMode: editMode ? 'manual' : 'off',
-        }}
+        options={{ readOnly: !editMode }}
         onChange={(latex: string) => onEditInput({ ...input, value: latex, operator: 'equals' })}
       />
     </div>

--- a/assets/src/components/common/MathLive.tsx
+++ b/assets/src/components/common/MathLive.tsx
@@ -27,6 +27,7 @@ export interface MathLiveProps {
   initialValue?: string;
   inline?: boolean;
   onChange?: (value: string) => void;
+  onKeyUp?: (e: React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
 }
 
 export const MathLive = ({
@@ -36,11 +37,22 @@ export const MathLive = ({
   initialValue,
   inline,
   onChange,
+  onKeyUp,
 }: MathLiveProps) => {
-  const ref = useRef<HTMLDivElement>(null);
+  const divRef = useRef<HTMLDivElement>(null);
   const mfe = useRef<MathfieldElement | null>(null);
 
+  // state tracked to suppress unnecessary onChange notifications:
+  const [lastNotifiedValue, setLastNotifiedValue] = React.useState<string | null>(null);
+
+  // get effective options as string for useEffect dependency
+  const mathFieldOptions = mergeOptions(DEFAULT_OPTIONS, valueOr(options, {}));
+  const optionString = JSON.stringify(mathFieldOptions);
+
   useEffect(() => {
+    // Setting this to large value ensures MathLive keyboard renders at top of z-order
+    document.body.style.setProperty('--keyboard-zindex', '3000');
+
     // As a workaround to an issue where the MathfieldElement package must be using global state,
     // we must first check to see if it is already defined globally. If so, we use the class that
     // if defined on the window. Otherwise, use the class imported from the package. Ugh.
@@ -50,39 +62,57 @@ export const MathLive = ({
       mfe.current = new MathfieldElement() as MathfieldElement;
     }
 
-    mfe.current.value = initialValue ?? value ?? '';
+    if (initialValue !== undefined) mfe.current.value = initialValue;
 
-    const mathFieldOptions = mergeOptions(DEFAULT_OPTIONS, valueOr(options, {}));
-    if (onChange !== undefined) {
-      mathFieldOptions.onContentDidChange = (mf: Mathfield) => onChange(mf.getValue());
-    }
+    divRef.current?.appendChild(mfe.current as any);
 
-    mfe.current.setOptions(mathFieldOptions);
-
-    ref.current?.appendChild(mfe.current as any);
-
-    const mathLiveRef = ref.current;
-
+    // return value is cleanup function
+    const mathfieldParent = divRef.current;
     return () => {
       if (mfe.current !== null) {
-        mathLiveRef?.removeChild(mfe.current);
+        mathfieldParent?.removeChild(mfe.current);
       }
     };
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // handle any prop change affecting options
   useEffect(() => {
-    mfe.current?.setValue(value);
-  }, [value]);
+    if (onChange !== undefined) {
+      mathFieldOptions.onContentDidChange = (mf: Mathfield) => {
+        // Found can get these when no change in value, causing problems
+        const value = mf.getValue();
+        if (value !== lastNotifiedValue) {
+          onChange(value);
+          setLastNotifiedValue(value);
+        }
+      };
+    }
+
+    if (onKeyUp !== undefined) {
+      // Mathfield fires onCommit on hitting Enter OR losing focus w/change.
+      // Just treat both as Enter keypress for purpose of auto-submitting
+      mathFieldOptions.onCommit = (mf: Mathfield) => {
+        onKeyUp({ key: 'Enter' } as React.KeyboardEvent<HTMLInputElement>);
+      };
+    }
+
+    mfe.current?.setOptions(mathFieldOptions);
+  }, [optionString, onChange, onKeyUp]);
 
   useEffect(() => {
-    mfe.current?.setOptions(valueOr(options, {}));
-  }, [options]);
+    // firing onChange handler in middle of activity reset process led to errors
+    // so suppress change notifications when programmatically setting value
+    if (value !== undefined) {
+      console.log('setting mathfield value to' + value);
+      mfe.current?.setValue(value, { suppressChangeNotifications: true });
+    }
+  }, [value]);
 
   return (
     <div
-      ref={ref}
+      ref={divRef}
       className={classNames(
         styles.mathLive,
         className,

--- a/assets/src/components/common/MathLive.tsx
+++ b/assets/src/components/common/MathLive.tsx
@@ -28,6 +28,7 @@ export interface MathLiveProps {
   inline?: boolean;
   onChange?: (value: string) => void;
   onKeyUp?: (e: React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+  onBlur?: () => void;
 }
 
 export const MathLive = ({
@@ -38,6 +39,7 @@ export const MathLive = ({
   inline,
   onChange,
   onKeyUp,
+  onBlur,
 }: MathLiveProps) => {
   const divRef = useRef<HTMLDivElement>(null);
   const mfe = useRef<MathfieldElement | null>(null);
@@ -90,16 +92,21 @@ export const MathLive = ({
       };
     }
 
+    if (onBlur !== undefined) {
+      mathFieldOptions.onBlur = (mf: Mathfield) => onBlur();
+    }
+
     if (onKeyUp !== undefined) {
       // Mathfield fires onCommit on hitting Enter OR losing focus w/change.
-      // Just treat both as Enter keypress for purpose of auto-submitting
+      // Ignore if we don't have focus; onBlur will be sent instead
       mathFieldOptions.onCommit = (mf: Mathfield) => {
-        onKeyUp({ key: 'Enter' } as React.KeyboardEvent<HTMLInputElement>);
+        if (mfe.current?.hasFocus())
+          onKeyUp({ key: 'Enter' } as React.KeyboardEvent<HTMLInputElement>);
       };
     }
 
     mfe.current?.setOptions(mathFieldOptions);
-  }, [optionString, onChange, onKeyUp]);
+  }, [optionString, onChange, onKeyUp, onBlur]);
 
   useEffect(() => {
     // firing onChange handler in middle of activity reset process led to errors

--- a/assets/src/components/common/MathLive.tsx
+++ b/assets/src/components/common/MathLive.tsx
@@ -105,7 +105,6 @@ export const MathLive = ({
     // firing onChange handler in middle of activity reset process led to errors
     // so suppress change notifications when programmatically setting value
     if (value !== undefined) {
-      console.log('setting mathfield value to' + value);
       mfe.current?.setValue(value, { suppressChangeNotifications: true });
     }
   }, [value]);


### PR DESCRIPTION
This change allows multi-input questions using the MathLive keyboard to work with the `submitPerPart` option, which allows answers on practice pages to be automatically submitted on hitting Enter or focusing out of an input control with changed contents. 

The implementation updates the MathLive keyboard wrapper component to process the idiosyncratic MathLive events and translate into events the containing MultiInputDelivery relies on to implement the auto submit behavior.

The update also includes a fix for independent bug [MER-4018](https://eliterate.atlassian.net/browse/MER-4018), installing a property setting to ensure MathLive popup keyboard appears at top of the z-order.

The update includes a correction to MathLive component option handling that obviates the need for an earlier workaround #5136 to preserve the keyboard toggle button in authoring [MER-3853](https://eliterate.atlassian.net/browse/MER-3853), so that workaround code was removed. 

[MER-4018]: https://eliterate.atlassian.net/browse/MER-4018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MER-3853]: https://eliterate.atlassian.net/browse/MER-3853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ