### PR TITLE
[BUG FIX] [MER-4021] Advanced Author: Attempting to navigate to a sub screen with full clipboard results in a page load error

### DIFF
--- a/assets/src/apps/authoring/components/RightMenu/PartPropertyEditor.tsx
+++ b/assets/src/apps/authoring/components/RightMenu/PartPropertyEditor.tsx
@@ -332,10 +332,10 @@ export const PartPropertyEditor: React.FC<Props> = ({
 
   if (!partDef) return null;
 
+  const selectPartType = selectedPartDef?.type || '';
+
   return (
-    <div
-      className={`component-tab p-3 overflow-hidden part-property-editor ${selectedPartDef.type}`}
-    >
+    <div className={`component-tab p-3 overflow-hidden part-property-editor ${selectPartType}`}>
       {selectedPartDef && partEditMode === 'expert' && (
         <ButtonToolbar aria-label="Component Tools">
           <ButtonGroup className="me-2" aria-label="First group">


### PR DESCRIPTION
Hey @bsparks / @darrensiegel can you please look at the PR. Thanks

This issue came due the changes made in [PR](https://github.com/Simon-Initiative/oli-torus/pull/5235). When navigating to another screen, the `selectedPartDef` was null and hence it was throwing an error for '`selectedPartDef.type`'