### PR TITLE
[BUG FIX] [MER-4033] fix evaluation of signed floats without leading zero

### DIFF
--- a/lib/oli/delivery/evaluation/rule.ex
+++ b/lib/oli/delivery/evaluation/rule.ex
@@ -227,7 +227,7 @@ defmodule Oli.Delivery.Evaluation.Rule do
   defp parse_number(str) when is_binary(str) do
     str =
       if Regex.match?(~r/^[+-]?\.\d+$/, str) do
-        String.replace(str, ".", "0.");
+        String.replace(str, ".", "0.")
       else
         str
       end

--- a/lib/oli/delivery/evaluation/rule.ex
+++ b/lib/oli/delivery/evaluation/rule.ex
@@ -226,8 +226,8 @@ defmodule Oli.Delivery.Evaluation.Rule do
 
   defp parse_number(str) when is_binary(str) do
     str =
-      if Regex.match?(~r/^\.\d+$/, str) do
-        "0#{str}"
+      if Regex.match?(~r/^[+-]?\.\d+$/, str) do
+        String.replace(str, ".", "0.");
       else
         str
       end

--- a/test/oli/delivery/evaluation/rule_eval_test.exs
+++ b/test/oli/delivery/evaluation/rule_eval_test.exs
@@ -40,8 +40,14 @@ defmodule Oli.Delivery.Evaluation.RuleEvalTest do
   test "evaluating floats" do
     assert eval("attemptNumber = {1} && input = {0.1}", "0.1")
     refute eval("attemptNumber = {1} && input = {0.1}", "0.2")
+    # handles odd forms without digits on both sides of decimal
     assert eval("attemptNumber = {1} && input = {0.1}", ".1")
     refute eval("attemptNumber = {1} && input = {0.1}", ".2")
+    assert eval("attemptNumber = {1} && input = {-0.1}", "-.1")
+    refute eval("attemptNumber = {1} && input = {-0.1}", "-.2")
+    assert eval("attemptNumber = {1} && input = {1.0}", "1.")
+    refute eval("attemptNumber = {1} && input = {1.0}", "+2.")
+    assert eval("attemptNumber = {1} && input = {-1.0}", "-1.")
     assert eval("attemptNumber = {1} && input = {3.1}", "3.1")
     refute eval("attemptNumber = {1} && input = {3.1}", "3.2")
     refute eval("attemptNumber = {1} && input = {3.1}", "4")


### PR DESCRIPTION
Torus accepts floating point input without leading zero, e.g. `.333`. However, evaluation code was not properly handling this form when a sign was prefixed, e.g. `-.333`, causing answers of this form to be marked incorrect. Error was caused by a step where code converts the zero-less form to a zero-prefixed form; regexp used there was not allowing for possible sign.

This also adds a few unit tests for this case. 