### PR TITLE
[BUG FIX] [MER-3988] Fix horizontal overflow in all grades view

### DIFF
--- a/lib/oli_web/components/delivery/quiz_scores/quiz_scores.ex
+++ b/lib/oli_web/components/delivery/quiz_scores/quiz_scores.ex
@@ -111,6 +111,7 @@ defmodule OliWeb.Components.Delivery.QuizScores do
             page_change={JS.push("paged_table_page_change", target: @myself)}
             limit_change={JS.push("paged_table_limit_change", target: @myself)}
             show_limit_change={true}
+            overflow_class="block scrollbar"
           />
         <% else %>
           <h6 class="text-center py-4">There are no quiz scores to show</h6>

--- a/lib/oli_web/live/common/table/instructor_dashboard_paged_table.ex
+++ b/lib/oli_web/live/common/table/instructor_dashboard_paged_table.ex
@@ -20,10 +20,11 @@ defmodule OliWeb.Common.InstructorDashboardPagedTable do
   attr :scrollable, :boolean, default: true
   attr :show_limit_change, :boolean, default: false
   attr :no_records_message, :string, default: "None exist"
+  attr :overflow_class, :string, default: "inline"
 
   def render(assigns) do
     ~H"""
-    <div class={if @scrollable, do: "overflow-x-scroll inline"}>
+    <div class={if @scrollable, do: "overflow-x-scroll #{@overflow_class}"}>
       <%= if @filter != "" and @render_top_info do %>
         <strong>Results filtered on &quot;<%= @filter %>&quot;</strong>
       <% end %>

--- a/test/oli_web/live/gradebook_view_live_test.exs
+++ b/test/oli_web/live/gradebook_view_live_test.exs
@@ -92,5 +92,18 @@ defmodule OliWeb.GradebookViewLiveTest do
                |> render =~ "#{@expected_score}/#{@out_of}"
       end
     end
+
+    test "table has classes to ensure overflow", %{conn: conn} do
+      %{section: section} = create_project_with_n_scored_pages(conn, 30)
+
+      user = insert(:user, %{family_name: "James", given_name: "LeBron"})
+      enroll_user_to_section(user, section, :context_learner)
+
+      {:ok, view, _html} = live(conn, live_view_gradebook_view_route(section.slug))
+
+      # Check that the table is rendered with a horizontal scroll bar
+      assert view
+             |> element(~s(table[class="overflow-x-scroll block scrollbar"]))
+    end
   end
 end


### PR DESCRIPTION
[MER-3988](https://eliterate.atlassian.net/browse/MER-3988)

This PR fixes the bug that happened in the `All Grades` view when the table had a lot of content and overflowed outside the border.

The bug was fixed by adding an overflow, which allows to scroll the table horizontally if the content is too long. 

It also adds a custom class to display the scrollbar with a different style than what browsers display. 


https://github.com/user-attachments/assets/d5af8f28-2936-4eff-b3ae-3deba03520fc



[MER-3988]: https://eliterate.atlassian.net/browse/MER-3988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ