### PR TITLE
[BUG FIX] [MER-3995] Fix error inserting link or webpage from media library

### DIFF
--- a/assets/src/components/editing/elements/link/LinkModal.tsx
+++ b/assets/src/components/editing/elements/link/LinkModal.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useState } from 'react';
+import { Provider } from 'react-redux';
 import { Maybe } from 'tsmonad';
 import { CommandContext } from 'components/editing/elements/commands/interfaces';
 import { onEnterApply } from 'components/editing/elements/common/settings/Settings';
@@ -13,7 +14,10 @@ import {
   toInternalLink,
 } from 'data/content/model/elements/utils';
 import * as Persistence from 'data/persistence/resource';
+import { configureStore } from 'state/store';
 import { MediaItem } from 'types/media';
+
+const store = configureStore();
 
 interface ModalProps {
   onDone: (x: any) => void;
@@ -39,6 +43,7 @@ export const LinkModal = ({ onDone, onCancel, model, commandContext, projectSlug
   const [source, setSource] = useState<ContentModel.HyperlinkType>(
     getHyperlinkType(model.linkType, model.href),
   );
+  const store = configureStore();
 
   const [pages, setPages] = useState<LinkablePages>({ type: 'Uninitialized' });
   const [selectedPage, setSelectedPage] = useState<null | Persistence.Page>(null);
@@ -247,14 +252,16 @@ const MediaLibraryInput: React.FC<{
     [setHref],
   );
   return (
-    <UrlOrUpload
-      onUrlChange={setHref}
-      onMediaSelectionChange={onMediaChange}
-      projectSlug={projectSlug}
-      mimeFilter={undefined}
-      selectionType={SELECTION_TYPES.SINGLE}
-      initialSelectionPaths={href ? [href] : []}
-      externalUrlAllowed={false}
-    ></UrlOrUpload>
+    <Provider store={store}>
+      <UrlOrUpload
+        onUrlChange={setHref}
+        onMediaSelectionChange={onMediaChange}
+        projectSlug={projectSlug}
+        mimeFilter={undefined}
+        selectionType={SELECTION_TYPES.SINGLE}
+        initialSelectionPaths={href ? [href] : []}
+        externalUrlAllowed={false}
+      ></UrlOrUpload>
+    </Provider>
   );
 };

--- a/assets/src/components/editing/elements/link/LinkModal.tsx
+++ b/assets/src/components/editing/elements/link/LinkModal.tsx
@@ -43,7 +43,6 @@ export const LinkModal = ({ onDone, onCancel, model, commandContext, projectSlug
   const [source, setSource] = useState<ContentModel.HyperlinkType>(
     getHyperlinkType(model.linkType, model.href),
   );
-  const store = configureStore();
 
   const [pages, setPages] = useState<LinkablePages>({ type: 'Uninitialized' });
   const [selectedPage, setSelectedPage] = useState<null | Persistence.Page>(null);

--- a/assets/src/components/editing/elements/webpage/WebpageModal.tsx
+++ b/assets/src/components/editing/elements/webpage/WebpageModal.tsx
@@ -1,9 +1,13 @@
 import React, { useCallback, useState } from 'react';
+import { Provider } from 'react-redux';
 import { UrlOrUpload } from 'components/media/UrlOrUpload';
 import { SELECTION_TYPES } from 'components/media/manager/MediaManager';
 import { Modal, ModalSize } from 'components/modal/Modal';
 import * as ContentModel from 'data/content/model/elements/types';
+import { configureStore } from 'state/store';
 import { MediaItem } from 'types/media';
+
+const store = configureStore();
 
 interface ModalProps {
   onDone: (x: Partial<ContentModel.Webpage>) => void;
@@ -114,15 +118,17 @@ const MediaEntry: React.FC<{
     [setHref],
   );
   return (
-    <UrlOrUpload
-      onUrlChange={setHref}
-      onMediaSelectionChange={onMediaChange}
-      projectSlug={projectSlug}
-      mimeFilter={undefined}
-      selectionType={SELECTION_TYPES.SINGLE}
-      initialSelectionPaths={href ? [href] : []}
-      externalUrlAllowed={false}
-    ></UrlOrUpload>
+    <Provider store={store}>
+      <UrlOrUpload
+        onUrlChange={setHref}
+        onMediaSelectionChange={onMediaChange}
+        projectSlug={projectSlug}
+        mimeFilter={undefined}
+        selectionType={SELECTION_TYPES.SINGLE}
+        initialSelectionPaths={href ? [href] : []}
+        externalUrlAllowed={false}
+      ></UrlOrUpload>
+    </Provider>
   );
 };
 


### PR DESCRIPTION
The attempt to insert either a Link or an embedded (iframed) web page using the option to link to an item in the Media Library was failing, showing an error message “Cannot read properties of null (reading store)" inside the containing modal where the embedded MediaManager should be rendered. The connected MediaManager component was not finding a react-redux store provider within these modal contexts. This change adds code to wrap the component in the needed Provider. 