### PR TITLE
[BUG FIX] [MER-4005] First access to a course displays malformed landing page

### DIFF
--- a/lib/oli_web/components/layouts/workspace.html.heex
+++ b/lib/oli_web/components/layouts/workspace.html.heex
@@ -19,7 +19,7 @@
         />
       </div>
     </div>
-    <div class="absolute top-0">
+    <div class={"absolute top-0 #{if @disable_sidebar?, do: "w-full"}"}>
       <Components.Delivery.Layouts.workspace_sidebar_nav
         :if={!@disable_sidebar?}
         ctx={@ctx}

--- a/lib/oli_web/live/delivery/student/index_live.ex
+++ b/lib/oli_web/live/delivery/student/index_live.ex
@@ -319,7 +319,7 @@ defmodule OliWeb.Delivery.Student.IndexLive do
   defp header_banner(assigns) do
     ~H"""
     <div class="relative">
-      <div class="w-full h-1/2 relative flex items-center">
+      <div class="w-full h-72 relative flex items-center">
         <div class="inset-0 absolute">
           <div class="inset-0 absolute bg-purple-700 bg-opacity-50"></div>
           <img


### PR DESCRIPTION
[MER-4005](https://eliterate.atlassian.net/browse/MER-4005)

This PR aims to fix two errors encountered: 

1 - Fixes the style of the banner on a student's landing page, on the student's first access to the course. 

2 - Fixes the top navbar when a student is in the main view to choose which course section to enter.  


- Banner before

![Captura de pantalla 2024-11-26 a la(s) 5 36 59 p  m](https://github.com/user-attachments/assets/270acc46-66fd-406a-9c09-1ba13b1260f3)

- Banner after

![Captura de pantalla 2024-11-26 a la(s) 5 37 28 p  m](https://github.com/user-attachments/assets/dcdfd321-2c81-4692-b438-0882ca919bbe)

- Navbar before

![Captura de pantalla 2024-11-26 a la(s) 5 36 19 p  m](https://github.com/user-attachments/assets/a9191225-21b4-41b4-9897-b3e42a9a914e)

- Navbar after

![Captura de pantalla 2024-11-26 a la(s) 5 35 37 p  m](https://github.com/user-attachments/assets/688b0ef1-2989-4c2e-aaaa-05baf3a3d7ce)


[MER-4005]: https://eliterate.atlassian.net/browse/MER-4005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ