### PR TITLE
[FEATURE] [MER-3360] [MER-3363] Duplicate activity within activity bank and pages

### DIFF
--- a/assets/src/apps/bank/ActivityBank.tsx
+++ b/assets/src/apps/bank/ActivityBank.tsx
@@ -472,10 +472,7 @@ export class ActivityBank extends React.Component<ActivityBankProps, ActivityBan
       (ed: EditorDesc) => ed.slug === context.typeSlug,
     );
     if (editorDesc)
-      createCopy(this.props.projectSlug, editorDesc, context, 'banked', (newContext) =>
-        // include slug of activity to insert before
-        this.onActivityAdd(newContext, context.activitySlug),
-      );
+      createCopy(this.props.projectSlug, editorDesc, context, 'banked', this.onActivityAdd);
   }
 
   createActivityEditors() {

--- a/assets/src/apps/bank/ActivityBank.tsx
+++ b/assets/src/apps/bank/ActivityBank.tsx
@@ -265,13 +265,16 @@ export class ActivityBank extends React.Component<ActivityBankProps, ActivityBan
     );
   }
 
-  onActivityAdd(context: ActivityEditContext) {
-    const inserted = [
-      [context.activitySlug, context],
-      ...this.state.activityContexts.toArray(),
-    ].slice(0, PAGE_SIZE);
+  onActivityAdd(context: ActivityEditContext, atSlug: string | null = null) {
+    const atIndex = this.state.activityContexts.keySeq().findIndex((key) => key === atSlug);
+    const insertPos = atIndex < 0 ? 0 : atIndex;
+
+    const tempContexts = this.state.activityContexts.toArray();
+    tempContexts.splice(insertPos, 0, [context.activitySlug, context]);
+    const newContexts = tempContexts.slice(0, PAGE_SIZE);
+
     this.setState({
-      activityContexts: Immutable.OrderedMap<string, ActivityEditContext>(inserted as any),
+      activityContexts: Immutable.OrderedMap<string, ActivityEditContext>(newContexts as any),
       totalInBank: this.state.totalInBank + 1,
       totalCount: this.state.totalCount + 1,
     });
@@ -469,7 +472,10 @@ export class ActivityBank extends React.Component<ActivityBankProps, ActivityBan
       (ed: EditorDesc) => ed.slug === context.typeSlug,
     );
     if (editorDesc)
-      createCopy(this.props.projectSlug, editorDesc, context, 'banked', this.onActivityAdd);
+      createCopy(this.props.projectSlug, editorDesc, context, 'banked', (newContext) =>
+        // include slug of activity to insert before
+        this.onActivityAdd(newContext, context.activitySlug),
+      );
   }
 
   createActivityEditors() {

--- a/assets/src/apps/bank/ActivityBank.tsx
+++ b/assets/src/apps/bank/ActivityBank.tsx
@@ -40,7 +40,7 @@ import { AppsignalContext, ErrorBoundary } from '../../components/common/ErrorBo
 import { initAppSignal } from '../../utils/appsignal';
 import '../ResourceEditor.scss';
 import styles from './ActivityBank.modules.scss';
-import { CreateActivity } from './CreateActivity';
+import { CreateActivity, createCopy } from './CreateActivity';
 import { EditButton } from './EditButton';
 import { LogicFilter } from './LogicFilter';
 
@@ -464,6 +464,14 @@ export class ActivityBank extends React.Component<ActivityBankProps, ActivityBan
     }
   }
 
+  duplicateActivity(context: ActivityEditContext) {
+    const editorDesc = Object.values(this.props.editorMap).find(
+      (ed: EditorDesc) => ed.slug === context.typeSlug,
+    );
+    if (editorDesc)
+      createCopy(this.props.projectSlug, editorDesc, context, 'banked', this.onActivityAdd);
+  }
+
   createActivityEditors() {
     return this.state.activityContexts.toArray().map((item) => {
       const [key, context] = item;
@@ -478,6 +486,9 @@ export class ActivityBank extends React.Component<ActivityBankProps, ActivityBan
       const onDelete = () => {
         const thisKey = key;
         this.onDelete(thisKey);
+      };
+      const onDuplicateActivity = () => {
+        this.duplicateActivity(context);
       };
 
       const CustomToolbar = (_props: any) => (
@@ -502,6 +513,7 @@ export class ActivityBank extends React.Component<ActivityBankProps, ActivityBan
             banked={true}
             canRemove={true}
             onRemove={onDelete}
+            onDuplicate={onDuplicateActivity}
             customToolbarItems={CustomToolbar}
             contentBreaksExist={false}
             {...context}

--- a/assets/src/apps/bank/ActivityBank.tsx
+++ b/assets/src/apps/bank/ActivityBank.tsx
@@ -467,7 +467,7 @@ export class ActivityBank extends React.Component<ActivityBankProps, ActivityBan
     }
   }
 
-  duplicateActivity(context: ActivityEditContext) {
+  onDuplicateActivity(context: ActivityEditContext) {
     const editorDesc = Object.values(this.props.editorMap).find(
       (ed: EditorDesc) => ed.slug === context.typeSlug,
     );
@@ -490,9 +490,7 @@ export class ActivityBank extends React.Component<ActivityBankProps, ActivityBan
         const thisKey = key;
         this.onDelete(thisKey);
       };
-      const onDuplicateActivity = () => {
-        this.duplicateActivity(context);
-      };
+      const onDuplicate = () => this.onDuplicateActivity(context);
 
       const CustomToolbar = (_props: any) => (
         <React.Fragment>
@@ -516,7 +514,7 @@ export class ActivityBank extends React.Component<ActivityBankProps, ActivityBan
             banked={true}
             canRemove={true}
             onRemove={onDelete}
-            onDuplicate={onDuplicateActivity}
+            onDuplicate={onDuplicate}
             customToolbarItems={CustomToolbar}
             contentBreaksExist={false}
             {...context}

--- a/assets/src/apps/bank/CreateActivity.tsx
+++ b/assets/src/apps/bank/CreateActivity.tsx
@@ -59,7 +59,7 @@ export const createCopy = (
   editorDesc: EditorDesc,
   context: ActivityEditContext,
   scope: 'banked' | 'embedded',
-  onAdded: (context: ActivityEditContext) => void,
+  onAdded: (context: ActivityEditContext, atSlug?: string | null) => void,
 ) => {
   const model = clone(context.model);
   const title = context.title + ' (Copy)';
@@ -80,7 +80,7 @@ export const createCopy = (
         tags,
         variables: editorDesc.variables,
       };
-      onAdded(activity);
+      onAdded(activity, context.activitySlug);
     })
     .catch((err) => {
       // tslint:disable-next-line

--- a/assets/src/apps/bank/CreateActivity.tsx
+++ b/assets/src/apps/bank/CreateActivity.tsx
@@ -3,6 +3,7 @@ import { invokeCreationFunc } from 'components/activities/creation';
 import { ActivityEditContext } from 'data/content/activity';
 import { ActivityEditorMap, EditorDesc } from 'data/content/editors';
 import * as Persistence from 'data/persistence/activity';
+import { clone } from 'utils/common';
 
 export type CreateActivityProps = {
   editorMap: ActivityEditorMap; // Map of activity types to activity elements
@@ -16,7 +17,6 @@ const create = (
   onAdded: (context: ActivityEditContext) => void,
 ) => {
   let model: any;
-
   invokeCreationFunc(editorDesc.slug, {} as any)
     .then((createdModel) => {
       model = createdModel;
@@ -46,6 +46,40 @@ const create = (
         variables: editorDesc.variables,
       };
 
+      onAdded(activity);
+    })
+    .catch((err) => {
+      // tslint:disable-next-line
+      console.error(err);
+    });
+};
+
+export const createCopy = (
+  projectSlug: string,
+  editorDesc: EditorDesc,
+  context: ActivityEditContext,
+  scope: 'banked' | 'embedded',
+  onAdded: (context: ActivityEditContext) => void,
+) => {
+  const model = clone(context.model);
+  const title = context.title + ' (Copy)';
+  const objectives = context.objectives;
+  const tags = context.tags;
+  Persistence.createFull(projectSlug, editorDesc.slug, model, title, objectives, tags, scope)
+    .then((result: Persistence.Created) => {
+      const activity: ActivityEditContext = {
+        authoringElement: editorDesc.authoringElement as string,
+        description: editorDesc.description,
+        friendlyName: editorDesc.friendlyName,
+        typeSlug: editorDesc.slug,
+        activitySlug: result.revisionSlug,
+        activityId: result.resourceId,
+        title,
+        model,
+        objectives,
+        tags,
+        variables: editorDesc.variables,
+      };
       onAdded(activity);
     })
     .catch((err) => {

--- a/assets/src/apps/page-editor/PageEditor.tsx
+++ b/assets/src/apps/page-editor/PageEditor.tsx
@@ -18,6 +18,7 @@ import { Objectives } from 'components/resource/objectives/Objectives';
 import { ObjectivesSelection } from 'components/resource/objectives/ObjectivesSelection';
 import { arrangeObjectives } from 'components/resource/objectives/sort';
 import { UndoToasts } from 'components/resource/undo/UndoToasts';
+import { createCopy } from 'apps/bank/CreateActivity';
 import { ActivityEditContext } from 'data/content/activity';
 import { guaranteeValididty } from 'data/content/bank';
 import { ActivityEditorMap } from 'data/content/editors';
@@ -522,6 +523,25 @@ export class PageEditor extends React.Component<PageEditorProps, PageEditorState
       }
     };
 
+    const onDuplicateActivity = (origContext: ActivityEditContext) => {
+      const editorDesc = props.editorMap[origContext.typeSlug];
+      createCopy(props.projectSlug, editorDesc, origContext, 'embedded', (newContext, atSlug) => {
+        const resourceContent: ActivityReference = {
+          type: 'activity-reference',
+          id: guid(),
+          activitySlug: newContext.activitySlug,
+          children: [],
+        };
+        // find index of original activity by slug
+        const index = this.state.content.findIndex(
+          (c) =>
+            c.type === 'activity-reference' && (c as ActivityReference).activitySlug === atSlug,
+        );
+        // insert at original's position
+        onAddItem(resourceContent, index, newContext);
+      });
+    };
+
     const onRegisterNewObjective = (objective: Objective) => {
       this.setState({
         allObjectives: this.state.allObjectives.push(objective),
@@ -625,6 +645,7 @@ export class PageEditor extends React.Component<PageEditorProps, PageEditorState
                       content={this.state.content}
                       onAddItem={onAddItem}
                       resourceContext={props}
+                      onDuplicate={onDuplicateActivity}
                     />
                   </AlternativesContextProvider>
                 </div>

--- a/assets/src/components/activity/InlineActivityEditor.tsx
+++ b/assets/src/components/activity/InlineActivityEditor.tsx
@@ -28,6 +28,7 @@ export interface ActivityEditorProps extends ActivityEditContext {
   onRegisterNewObjective: (o: Objective) => void;
   onRegisterNewTag: (o: Tag) => void;
   onRemove: () => void;
+  onDuplicate?: () => void;
 }
 
 // This is the state of our activity editing that is undoable
@@ -169,6 +170,18 @@ export class InlineActivityEditor extends React.Component<
       </div>
     ) : null;
 
+    const DuplicateButton = (
+      <button
+        className="btn btn-link"
+        onClick={this.props.onDuplicate}
+        data-bs-toggle="tooltip"
+        data-bs-placement="top"
+        title="Duplicate this activity"
+      >
+        <i className="fa-solid fa-clone mr-2 fa-align-center"></i>
+      </button>
+    );
+
     return (
       <div className={classNames(styles.inlineActivityEditor, 'activity-editor')}>
         <div className="d-flex align-items-baseline flex-grow-1 mr-2">
@@ -194,6 +207,7 @@ export class InlineActivityEditor extends React.Component<
 
           <div className={styles.toolbar}>
             {this.props.customToolbarItems && <this.props.customToolbarItems />}
+            {this.props.onDuplicate && DuplicateButton}
             <DeleteButton
               className="ml-2"
               editMode={this.props.editMode && this.props.canRemove}

--- a/assets/src/components/resource/editors/ActivityEditor.tsx
+++ b/assets/src/components/resource/editors/ActivityEditor.tsx
@@ -25,6 +25,7 @@ export const ActivityEditor = ({
   onPostUndoable,
   onRegisterNewObjective,
   onRegisterNewTag,
+  onDuplicate,
 }: ActivityEditorProps) => {
   const activity = activities.get(contentItem.activitySlug);
 
@@ -61,6 +62,7 @@ export const ActivityEditor = ({
           onPostUndoable={(undoable: Undoable) => onPostUndoable(activity.activitySlug, undoable)}
           onRegisterNewObjective={onRegisterNewObjective}
           onRegisterNewTag={onRegisterNewTag}
+          onDuplicate={() => onDuplicate(activity)}
         />
       </ActivityBlock>
     );

--- a/assets/src/components/resource/editors/Editors.tsx
+++ b/assets/src/components/resource/editors/Editors.tsx
@@ -38,6 +38,7 @@ export type EditorsProps = {
   onRegisterNewTag: (o: Tag) => void;
   onEditActivity: (id: string, update: EditorUpdate) => void;
   onPostUndoable: (id: string, undoable: Undoable) => void;
+  onDuplicate: (context: ActivityEditContext) => void;
 };
 
 // The list of editors
@@ -64,6 +65,7 @@ export const Editors = (props: EditorsProps) => {
     onPostUndoable,
     onRegisterNewObjective,
     onRegisterNewTag,
+    onDuplicate,
   } = props;
 
   const allObjectives = props.objectives.toArray();
@@ -102,6 +104,7 @@ export const Editors = (props: EditorsProps) => {
       onRegisterNewTag,
       onAddItem,
       onRemove,
+      onDuplicate,
     });
 
     return (

--- a/assets/src/components/resource/editors/GroupEditor.tsx
+++ b/assets/src/components/resource/editors/GroupEditor.tsx
@@ -32,6 +32,7 @@ export const GroupEditor = ({
   onPostUndoable,
   onRegisterNewObjective,
   onRegisterNewTag,
+  onDuplicate,
 }: GroupEditorProps) => {
   const onEditChild = (child: ResourceContent) => {
     const updatedContent = {
@@ -82,6 +83,7 @@ export const GroupEditor = ({
               onRegisterNewObjective,
               onRegisterNewTag,
               onAddItem,
+              onDuplicate,
             })}
           </div>
         );

--- a/assets/src/components/resource/editors/PurposeGroupEditor.tsx
+++ b/assets/src/components/resource/editors/PurposeGroupEditor.tsx
@@ -50,6 +50,7 @@ export const PurposeGroupEditor = ({
   onPostUndoable,
   onRegisterNewObjective,
   onRegisterNewTag,
+  onDuplicate,
 }: PurposeGroupEditorProps) => {
   return (
     <PurposeGroupBlock
@@ -84,6 +85,7 @@ export const PurposeGroupEditor = ({
         onPostUndoable={onPostUndoable}
         onRegisterNewObjective={onRegisterNewObjective}
         onRegisterNewTag={onRegisterNewTag}
+        onDuplicate={onDuplicate}
       />
     </PurposeGroupBlock>
   );

--- a/assets/src/components/resource/editors/SurveyEditor.tsx
+++ b/assets/src/components/resource/editors/SurveyEditor.tsx
@@ -39,6 +39,7 @@ export const SurveyEditor = ({
   onPostUndoable,
   onRegisterNewObjective,
   onRegisterNewTag,
+  onDuplicate,
 }: SurveyEditorProps) => {
   const onEditChild = (child: ResourceContent) => {
     const updatedContent = {
@@ -93,6 +94,7 @@ export const SurveyEditor = ({
               onRegisterNewObjective,
               onRegisterNewTag,
               onAddItem,
+              onDuplicate,
             })}
           </div>
         );

--- a/assets/src/components/resource/editors/createEditor.tsx
+++ b/assets/src/components/resource/editors/createEditor.tsx
@@ -42,6 +42,7 @@ export type EditorProps = {
   onRegisterNewObjective: (o: Objective) => void;
   onRegisterNewTag: (o: Tag) => void;
   onAddItem: AddCallback;
+  onDuplicate: (context: ActivityEditContext) => void;
 };
 
 //content or referenced activities

--- a/assets/src/data/persistence/activity.ts
+++ b/assets/src/data/persistence/activity.ts
@@ -163,6 +163,24 @@ export function create(
   return makeRequest<Created>(params);
 }
 
+export function createFull(
+  project: ProjectSlug,
+  activityTypeSlug: ActivityTypeSlug,
+  model: ActivityModelSchema,
+  title: string,
+  objective_map: ObjectiveMap,
+  tags: ResourceId[],
+  scope = 'embedded',
+) {
+  const params = {
+    method: 'POST',
+    body: JSON.stringify({ model, title, objectives: [], objective_map, tags, scope }),
+    url: `/project/${project}/activity/${activityTypeSlug}`,
+  };
+
+  return makeRequest<Created>(params);
+}
+
 export function deleteActivity(project: ProjectSlug, resourceId: ResourceId) {
   const params = {
     method: 'DELETE',

--- a/lib/oli/authoring/editing/activity_editor.ex
+++ b/lib/oli/authoring/editing/activity_editor.ex
@@ -395,11 +395,11 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
   end
 
   # if objectives to attach are provided, attach them to all parts
-  defp attach_objectives(model, objectives_to_attach, raw_objectives) when raw_objectives == %{},
+  defp attach_objectives(model, objectives_to_attach, objective_map) when objective_map == %{},
     do: attach_objectives_to_all_parts(model, objectives_to_attach)
 
   # if the objectives map is already built and can be used directly
-  defp attach_objectives(_model, _objectives = [], raw_objectives), do: {:ok, raw_objectives}
+  defp attach_objectives(_model, _objectives = [], objective_map), do: {:ok, objective_map}
 
   # takes the model of the activity to be created and a list of objective ids and
   # creates a map of all part ids to objective resource ids
@@ -610,7 +610,8 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
         all_parts_objectives,
         scope \\ "embedded",
         title \\ nil,
-        raw_objectives \\ %{}
+        objective_map \\ %{},
+        tags \\ []
       ) do
     Repo.transaction(fn ->
       with {:ok, project} <- Course.get_project_by_slug(project_slug) |> trap_nil(),
@@ -619,7 +620,7 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
              Publishing.project_working_publication(project_slug) |> trap_nil(),
            {:ok, activity_type} <-
              Activities.get_registration_by_slug(activity_type_slug) |> trap_nil(),
-           {:ok, objectives} <- attach_objectives(model, all_parts_objectives, raw_objectives),
+           {:ok, objectives} <- attach_objectives(model, all_parts_objectives, objective_map),
            {:ok, %{content: content} = activity} <-
              Resources.create_new(
                %{
@@ -629,7 +630,8 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
                  author_id: author.id,
                  content: model,
                  scope: scope,
-                 activity_type_id: activity_type.id
+                 activity_type_id: activity_type.id,
+                 tags: tags
                },
                Oli.Resources.ResourceType.id_for_activity()
              ),

--- a/lib/oli_web/controllers/api/activity_controller.ex
+++ b/lib/oli_web/controllers/api/activity_controller.ex
@@ -169,12 +169,15 @@ defmodule OliWeb.Api.ActivityController do
   end
 
   @doc false
-  def create(conn, %{
-        "project" => project_slug,
-        "activity_type" => activity_type_slug,
-        "model" => model,
-        "objectives" => objectives
-      }) do
+  def create(
+        conn,
+        %{
+          "project" => project_slug,
+          "activity_type" => activity_type_slug,
+          "model" => model,
+          "objectives" => objectives
+        }
+      ) do
     author = conn.assigns[:current_author]
 
     scope = Map.get(conn.body_params, "scope", "embedded")
@@ -185,7 +188,11 @@ defmodule OliWeb.Api.ActivityController do
            author,
            model,
            objectives,
-           scope
+           scope,
+           # optional:
+           Map.get(conn.body_params, "title", nil),
+           Map.get(conn.body_params, "objective_map", %{}),
+           Map.get(conn, "tags", [])
          ) do
       {:ok, {%{slug: slug, resource_id: resource_id}, _}} ->
         json(conn, %{


### PR DESCRIPTION
This adds a button to each activity editor to duplicate the given activity within the activity bank and when editing course pages. Because activity duplication is a form of new activity creation, the duplicate button is enabled within the activity bank whether or not the existing activity is unlocked for editing. Demo (activity bank):


https://github.com/user-attachments/assets/4ffe1039-8f6a-4525-a161-b14ea31df052


This does not implement the success/failure flash messages or the Undo behavior specified in [MER-3360](https://eliterate.atlassian.net/browse/MER-3360). Duplicated activities are inserted on the current pageful at the position of the original with a title of "Original Title (Copy)", so user can see immediately that the operation succeeded. And one can always undo the duplication by deleting the new activity. A failure notice would be valuable, but failure is expected be rare. Creating a new activity does not show any message on failure beyond console message, so the behavior is the same on this case. At any rate this feature seems useful as is without these UI niceties.

*While each copy gets a title of the form "Original Title (Copy)", no attempt is made to avoid duplicate titles. So, repeated duplicating of the _same_ original can result in multiple activities with the same title, "Original Title (Copy)" in the total set. However in each case, duplicating should immediately bump the activity one is copying down, replacing it at its position on the screen with a new one containing one more "(Copy)" in its title than the original. This should suffice for immediate indication of successful copying. (The order of activities in the bank will be different on reloading, but because tags are copied, the duplicates will show up in any tag search along with the originals, which is the usual way of locating questions in a large activity bank.)

The implementation required extending existing creation APIs on client and server to allow the option of setting all of title, objectives, and tags at activity creation time. This uses optional parameters so should be entirely backwards compatible. 

Note: the server API for creating a new activity has a required "objectives" parameter containing a flat list of objective ids to be applied to all parts, in addition to (now) taking optional `objective_map` containing a part to objectives map. The flat list parameter appears to be unused anywhere within the system, so seems it is obsolete or never used and could be taken out. But that would require changes in multiple places in the codebase.


[MER-3360]: https://eliterate.atlassian.net/browse/MER-3360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ