### PR TITLE
[BUG FIX] [MER-3981] Illegible text in dark mode

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -216,17 +216,6 @@ Not supports in Firefox and IE */
   height: 0;
 }
 
-/* set placeholder text color */
-#project-title-placeholder::placeholder {
-  color: #9ca3af;
-}
-
-/* set placeholder text color in dark mode */
-.dark #project-title-placeholder::placeholder {
-  color: #eeebf5;
-  opacity: 0.7;
-}
-
 /* Firefox customized styles */
 
 @-moz-document url-prefix() {

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -216,6 +216,17 @@ Not supports in Firefox and IE */
   height: 0;
 }
 
+/* set placeholder text color */
+#project-title-placeholder::placeholder {
+  color: #9ca3af;
+}
+
+/* set placeholder text color in dark mode */
+.dark #project-title-placeholder::placeholder {
+  color: #eeebf5;
+  opacity: 0.7;
+}
+
 /* Firefox customized styles */
 
 @-moz-document url-prefix() {

--- a/lib/oli_web/live/projects/create_project_modal.ex
+++ b/lib/oli_web/live/projects/create_project_modal.ex
@@ -39,8 +39,7 @@ defmodule OliWeb.Projects.CreateProjectModal do
               <div class="form-label-group">
                 <%= text_input(f, :title,
                   required: true,
-                  id: "project-title-placeholder",
-                  class: "block min-w-full",
+                  class: "block min-w-full placeholder-[#9ca3af] dark:placeholder-[#eeebf5]/70",
                   placeholder: "e.g. Introduction to Psychology"
                 ) %>
                 <%= label f, :title, class: "block text-sm text-gray-500 dark:text-[#eeebf5]" do %>

--- a/lib/oli_web/live/projects/create_project_modal.ex
+++ b/lib/oli_web/live/projects/create_project_modal.ex
@@ -26,7 +26,10 @@ defmodule OliWeb.Projects.CreateProjectModal do
             action={Routes.project_path(OliWeb.Endpoint, :create)}
           >
             <div class="modal-header flex flex-shrink-0 items-center justify-between p-4 border-b border-gray-200 rounded-t-md">
-              <h5 class="text-xl font-medium leading-normal text-gray-800" id="exampleModalLabel">
+              <h5
+                class="text-xl font-medium leading-normal text-gray-800 dark:text-[#eeebf5]"
+                id="exampleModalLabel"
+              >
                 Create Project
               </h5>
               <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
@@ -36,10 +39,11 @@ defmodule OliWeb.Projects.CreateProjectModal do
               <div class="form-label-group">
                 <%= text_input(f, :title,
                   required: true,
+                  id: "project-title-placeholder",
                   class: "block min-w-full",
                   placeholder: "e.g. Introduction to Psychology"
                 ) %>
-                <%= label f, :title, class: "block text-sm text-gray-500" do %>
+                <%= label f, :title, class: "block text-sm text-gray-500 dark:text-[#eeebf5]" do %>
                   This can be changed later
                 <% end %>
                 <%= error_tag(f, :title) %>

--- a/test/oli_web/live/workspaces/course_author_test.exs
+++ b/test/oli_web/live/workspaces/course_author_test.exs
@@ -326,6 +326,19 @@ defmodule OliWeb.Workspaces.CourseAuthorTest do
       assert project_row =~ "Active"
     end
 
+    test "the modal text displays clearly using the appropriate dark mode class", %{
+      conn: conn
+    } do
+      {:ok, view, _html} = live(conn, ~p"/workspaces/course_author")
+
+      view |> element("button", "New Project") |> render_click()
+
+      html = render(view)
+      parsed_html = Floki.parse_document!(html)
+
+      assert has_class?(parsed_html, "h5", "dark:text-[#eeebf5]")
+    end
+
     test "applies show-all filter", %{conn: conn, admin: admin} do
       admin_project = create_project_with_owner(admin)
       project = insert(:author) |> create_project_with_owner()
@@ -668,5 +681,14 @@ defmodule OliWeb.Workspaces.CourseAuthorTest do
     project = insert(:project, attrs)
     insert(:author_project, project_id: project.id, author_id: owner.id)
     project
+  end
+
+  defp has_class?(parsed_html, tag, class_name) do
+    Floki.find(parsed_html, tag)
+    |> Enum.any?(fn {_tag, attrs, _content} ->
+      Enum.any?(attrs, fn {key, value} ->
+        key == "class" and String.contains?(value, class_name)
+      end)
+    end)
   end
 end


### PR DESCRIPTION
[MER-3981](https://eliterate.atlassian.net/browse/MER-3981)

This PR fixes the color of the texts in the Create Project modal to make them more readable in dark mode. 

These changes include the color of the placeholder text.

The textarea for adding/editing a bibliography entry has been fixed in this [PR](https://github.com/Simon-Initiative/oli-torus/pull/5212).

- Modal to Create Project before

![image](https://github.com/user-attachments/assets/a6148799-8118-4678-bdfc-d95a556b3a9a)

- Modal to Create Project after

![image](https://github.com/user-attachments/assets/82e1ff20-73bd-4afa-a6d0-55aa357d1b9e)



[MER-3981]: https://eliterate.atlassian.net/browse/MER-3981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ