### PR TITLE
[FEATURE] [MER-3899] No breadcrumbs in advanced authoring

### DIFF
--- a/assets/src/apps/authoring/Authoring.tsx
+++ b/assets/src/apps/authoring/Authoring.tsx
@@ -256,7 +256,7 @@ const Authoring: React.FC<AuthoringProps> = (props: AuthoringProps) => {
       <ErrorBoundary>
         <ModalContainer>
           {isLoading && (
-            <div id="aa-loading" className="!z-10">
+            <div id="aa-loading" className="!z-10 -mt-2">
               <div className="loader spinner-border text-primary" role="status">
                 <span className="sr-only">Loading...</span>
               </div>

--- a/assets/src/apps/authoring/AuthoringFlowchartPageEditor.tsx
+++ b/assets/src/apps/authoring/AuthoringFlowchartPageEditor.tsx
@@ -53,7 +53,7 @@ export const AuthoringFlowchartPageEditor: React.FC<AuthoringPageEditorProps> = 
   return (
     <div
       id="advanced-authoring"
-      className={`advanced-authoring flowchart-editor ${!sidebarExpanded ? '' : 'ml-[135px]'}`}
+      className={`advanced-authoring flowchart-editor mt-8 ${!sidebarExpanded ? '' : 'ml-[135px]'}`}
       ref={authoringContainer}
     >
       <FlowchartHeaderNav

--- a/assets/src/apps/authoring/BottomPanel.tsx
+++ b/assets/src/apps/authoring/BottomPanel.tsx
@@ -158,7 +158,7 @@ export const BottomPanel: React.FC<BottomPanelProps> = (props: BottomPanelProps)
       <section
         id="aa-bottom-panel"
         ref={ref}
-        className={`aa-panel bottom-panel${panelState['bottom'] ? ' open' : ''} ${
+        className={`aa-panel mt-8 bottom-panel${panelState['bottom'] ? ' open' : ''} ${
           !sidebarExpanded ? '' : 'ml-[135px]'
         }`}
         style={{

--- a/assets/src/apps/authoring/ReadOnlyWarning.tsx
+++ b/assets/src/apps/authoring/ReadOnlyWarning.tsx
@@ -16,49 +16,51 @@ export const ReadOnlyWarning: React.FC<ReadOnlyWarningProps> = ({
   url,
   windowName,
 }) => (
-  <Alert variant={alertSeverity}>
-    <Alert.Heading>Opening in Read-Only Mode</Alert.Heading>
-    {!isAttemptDisableReadOnlyFailed && (
-      <p>
-        You are about to open this page in read-only mode. You are able to view the contents of this
-        page, but any changes you make will not be saved. You may instead attempt to open in editing
-        mode, or open a preview of the page.
-      </p>
-    )}
-    {isAttemptDisableReadOnlyFailed && (
-      <p>
-        Unfortunately, we were unable to disable read-only mode. Another author currently has the
-        page locked for editing. Please try again later. In the meantime, you may continue in Read
-        Only mode or open a preview of the page.
-      </p>
-    )}
-    <hr />
-    <div style={{ textAlign: 'center' }}>
-      <Button
-        variant={`outline-${alertSeverity}`}
-        className="text-dark"
-        onClick={() => dismissReadOnlyWarning({ attemptEdit: false })}
-      >
-        Continue In Read-Only Mode
-      </Button>{' '}
+  <div className="mt-2">
+    <Alert variant={alertSeverity}>
+      <Alert.Heading>Opening in Read-Only Mode</Alert.Heading>
       {!isAttemptDisableReadOnlyFailed && (
-        <>
-          <Button
-            variant={`outline-${alertSeverity}`}
-            className="text-dark"
-            onClick={() => dismissReadOnlyWarning({ attemptEdit: true })}
-          >
-            Open In Edit Mode
-          </Button>{' '}
-        </>
+        <p>
+          You are about to open this page in read-only mode. You are able to view the contents of
+          this page, but any changes you make will not be saved. You may instead attempt to open in
+          editing mode, or open a preview of the page.
+        </p>
       )}
-      <Button
-        variant={`outline-${alertSeverity}`}
-        className="text-dark"
-        onClick={() => window.open(url, windowName)}
-      >
-        Open Preview <i className="fas fa-external-link-alt ml-1"></i>
-      </Button>
-    </div>
-  </Alert>
+      {isAttemptDisableReadOnlyFailed && (
+        <p>
+          Unfortunately, we were unable to disable read-only mode. Another author currently has the
+          page locked for editing. Please try again later. In the meantime, you may continue in Read
+          Only mode or open a preview of the page.
+        </p>
+      )}
+      <hr />
+      <div style={{ textAlign: 'center' }}>
+        <Button
+          variant={`outline-${alertSeverity}`}
+          className="text-dark"
+          onClick={() => dismissReadOnlyWarning({ attemptEdit: false })}
+        >
+          Continue In Read-Only Mode
+        </Button>{' '}
+        {!isAttemptDisableReadOnlyFailed && (
+          <>
+            <Button
+              variant={`outline-${alertSeverity}`}
+              className="text-dark"
+              onClick={() => dismissReadOnlyWarning({ attemptEdit: true })}
+            >
+              Open In Edit Mode
+            </Button>{' '}
+          </>
+        )}
+        <Button
+          variant={`outline-${alertSeverity}`}
+          className="text-dark"
+          onClick={() => window.open(url, windowName)}
+        >
+          Open Preview <i className="fas fa-external-link-alt ml-1"></i>
+        </Button>
+      </div>
+    </Alert>
+  </div>
 );

--- a/assets/src/apps/authoring/components/EditingCanvas/EditingCanvas.tsx
+++ b/assets/src/apps/authoring/components/EditingCanvas/EditingCanvas.tsx
@@ -186,7 +186,7 @@ const EditingCanvas: React.FC = () => {
 
   return (
     <React.Fragment>
-      <section className="aa-stage" onClick={handleStageClick}>
+      <section className="aa-stage mt-8" onClick={handleStageClick}>
         <StagePan>
           {currentActivityTree &&
             currentActivityTree.map((activity) => (

--- a/assets/src/apps/authoring/components/ExpertHeaderNav.tsx
+++ b/assets/src/apps/authoring/components/ExpertHeaderNav.tsx
@@ -53,7 +53,7 @@ const ExpertHeaderNav: React.FC<HeaderNavProps> = (props: HeaderNavProps) => {
   return (
     paths && (
       <nav
-        className={`aa-header-nav top-panel overflow-hidden${
+        className={`aa-header-nav mt-8 top-panel overflow-hidden${
           isVisible ? ' open' : ''
         } d-flex aa-panel-section-title-bar ${!sidebarExpanded ? '' : 'ml-[135px]'}`}
         style={{

--- a/assets/src/apps/authoring/components/Flowchart/FlowchartEditor.tsx
+++ b/assets/src/apps/authoring/components/Flowchart/FlowchartEditor.tsx
@@ -111,7 +111,7 @@ export const FlowchartEditor: React.FC<FlowchartEditorProps> = ({ sidebarExpande
 
   return (
     <FlowchartEventContext.Provider value={events}>
-      <div className={`flowchart-editor ${!sidebarExpanded ? '' : 'ml-[135px]'}`}>
+      <div className={`flowchart-editor mt-8 ${!sidebarExpanded ? '' : 'ml-[135px]'}`}>
         <DndProvider backend={HTML5Backend}>
           <div className="flowchart-left">
             <FlowchartModeOptions activeMode="flowchart" onPageEditMode={onPageEditMode} />

--- a/assets/src/apps/authoring/components/SidePanel.tsx
+++ b/assets/src/apps/authoring/components/SidePanel.tsx
@@ -45,7 +45,7 @@ export const SidePanel: React.FC<SidePanelProps> = (props: SidePanelProps) => {
         </span>
       </button>
       <section
-        className={`aa-panel ${position}-panel${panelState[position] ? ' open' : ''} ${
+        className={`aa-panel mt-8 ${position}-panel${panelState[position] ? ' open' : ''} ${
           !sidebarExpanded ? '' : 'ml-[135px]'
         }`}
       >

--- a/assets/src/stories/advanced-authoring/PropertyPanels.stories.tsx
+++ b/assets/src/stories/advanced-authoring/PropertyPanels.stories.tsx
@@ -117,7 +117,7 @@ export const PanelPicker = () => {
           <code>UI Schema:{JSON.stringify(panel.uiSchema, null, 2)}</code>
         </pre>
         <div className="fixed-right-panel">
-          <section className="aa-panel right-panel open part-property-editor">
+          <section className="aa-panel right-panel open part-property-editor mt-8">
             <div className="aa-panel-inner">
               <div className="tab-content">
                 <div className="fade tab-pane active show">

--- a/lib/oli_web/components/layouts/workspace.html.heex
+++ b/lib/oli_web/components/layouts/workspace.html.heex
@@ -93,11 +93,13 @@
       <% end %>
     </div>
     <div class={OliWeb.Workspaces.Utils.maybe_add_padding(assigns[:uri])}>
-      <Components.Delivery.Layouts.breadcrumb_trail
-        :if={assigns[:breadcrumbs]}
-        breadcrumbs={assigns[:breadcrumbs]}
-        socket={@socket}
-      />
+      <div class="-mt-[28px]">
+        <Components.Delivery.Layouts.breadcrumb_trail
+          :if={assigns[:breadcrumbs]}
+          breadcrumbs={assigns[:breadcrumbs]}
+          socket={@socket}
+        />
+      </div>
 
       <%= @inner_content %>
     </div>

--- a/lib/oli_web/live/breadcrumb/breadcrumb_trail_workspace_live.ex
+++ b/lib/oli_web/live/breadcrumb/breadcrumb_trail_workspace_live.ex
@@ -28,8 +28,8 @@ defmodule OliWeb.Breadcrumb.BreadcrumbTrailWorkspaceLive do
             module={BreadcrumbWorkspaceLive}
             id={"breadcrumb-#{index}"}
             breadcrumb={breadcrumb}
-            is_last={length(@breadcrumbs) - 1 == index}
-            show_short={length(@breadcrumbs) > 3}
+            is_last={@breadcrumbs_count - 1 == index}
+            show_short={@breadcrumbs_count > 3}
           />
         <% end %>
       </ol>

--- a/lib/oli_web/live/breadcrumb/breadcrumb_trail_workspace_live.ex
+++ b/lib/oli_web/live/breadcrumb/breadcrumb_trail_workspace_live.ex
@@ -5,24 +5,29 @@ defmodule OliWeb.Breadcrumb.BreadcrumbTrailWorkspaceLive do
   def mount(_params, session, socket) do
     breadcrumbs = session["breadcrumbs"]
     breadcrumbs_count = length(breadcrumbs)
+    back_link = Enum.at(breadcrumbs, breadcrumbs_count - 2).link
 
-    {:ok, assign(socket, breadcrumbs: breadcrumbs, breadcrumbs_count: breadcrumbs_count)}
+    {:ok,
+     assign(socket,
+       breadcrumbs: breadcrumbs,
+       breadcrumbs_count: breadcrumbs_count,
+       back_link: back_link
+     )}
   end
 
   @spec render(any) :: Phoenix.LiveView.Rendered.t()
   def render(assigns) do
     ~H"""
-    <nav aria-label="breadcrumb overflow-hidden">
+    <nav aria-label="breadcrumb">
       <ol class="breadcrumb custom-breadcrumb">
-        <button
+        <.link
           :if={@breadcrumbs_count > 1}
-          disabled={if @breadcrumbs_count == 2, do: false, else: false}
           id="curriculum-back"
           class="btn btn-sm btn-link pr-5"
-          phx-click="set_active"
+          navigate={@back_link}
         >
           <i class="fas fa-arrow-left"></i>
-        </button>
+        </.link>
         <%= for {breadcrumb, index} <- Enum.with_index(@breadcrumbs) do %>
           <.live_component
             module={BreadcrumbWorkspaceLive}
@@ -35,11 +40,5 @@ defmodule OliWeb.Breadcrumb.BreadcrumbTrailWorkspaceLive do
       </ol>
     </nav>
     """
-  end
-
-  def handle_event("set_active", _params, socket) do
-    breadcrumbs = socket.assigns.breadcrumbs
-    parent_link = Enum.at(breadcrumbs, length(breadcrumbs) - 2).link
-    {:noreply, push_navigate(socket, to: parent_link)}
   end
 end


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-3899) to the ticket

There was no need to add the breadcrumbs in advanced authoring since they were already included in the workspace layout (`lib/oli_web/components/layouts/workspace.html.heex`).
So, the work ended up being adding some margin to different react components to make the breadcrumbs visible.
This PR also includes a minor refactor to`OliWeb.Breadcrumb.BreadcrumbTrailWorkspaceLive`



https://github.com/user-attachments/assets/f1451740-6634-4732-94e6-596dccc66712








