### PR TITLE
[ENHANCEMENT] [MER-3998] Display Enum CAPI as Dropdowns in Author Preview Tools

### DIFF
--- a/assets/src/adaptivity/scripting.ts
+++ b/assets/src/adaptivity/scripting.ts
@@ -343,6 +343,21 @@ export const getAssignStatements = (
   return letStatements;
 };
 
+export const setVariableWithTypeAssignStatements = (
+  state: Record<string, any>,
+  partId: string,
+): void => {
+  const variableWithTypeAssignStatements = Object.keys(state).reduce((collect: any, key) => {
+    const value = state[key];
+    collect[key] = { type: value?.type || 0, allowedValues: value?.allowedValues || null };
+    return collect;
+  }, {});
+  const myQuery = `let {stage.${partId}.variables.Type} = ${JSON.stringify(
+    variableWithTypeAssignStatements,
+  )};`;
+  evalScript(myQuery, defaultGlobalEnv);
+};
+
 export const getAssignScript = (
   state: Record<string, any>,
   env: Environment = defaultGlobalEnv,

--- a/assets/src/apps/delivery/store/features/attempt/actions/savePart.ts
+++ b/assets/src/apps/delivery/store/features/attempt/actions/savePart.ts
@@ -4,6 +4,7 @@ import {
   evalScript,
   getAssignStatements,
   getValue,
+  setVariableWithTypeAssignStatements,
 } from '../../../../../../adaptivity/scripting';
 import { deferredSavePart } from '../../../../../../data/persistence/deferredSavePart';
 import { DeliveryRootState } from '../../../rootReducer';
@@ -40,7 +41,11 @@ export const savePartState = createAsyncThunk(
             if (p.attemptGuid === partAttemptRecord.attemptGuid) {
               // always want to merge the previous response inputs into the attempt
               // overwrite with later info, but don't delete
-              updatedPartResponses = { ...result.response, ...updatedPartResponses };
+              updatedPartResponses = {
+                ...result.response,
+                ...updatedPartResponses,
+                partId: p.partId,
+              };
               result.response = updatedPartResponses;
             }
             return result;
@@ -49,7 +54,9 @@ export const savePartState = createAsyncThunk(
         await dispatch(upsertActivityAttemptState({ attempt: updated }));
       }
     }
-
+    if (isPreviewMode && updatedPartResponses?.partId?.length) {
+      setVariableWithTypeAssignStatements(updatedPartResponses, updatedPartResponses?.partId);
+    }
     // update scripting env with latest values
     const assignScripts = getAssignStatements(updatedPartResponses);
     const scriptResult: string[] = [];

--- a/assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx
+++ b/assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx
@@ -793,6 +793,9 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
         key: stateValueKey,
         type: msgData.values[stateValueKey] ? msgData.values[stateValueKey].type : null,
         value: msgData.values[stateValueKey] ? msgData.values[stateValueKey].value : null,
+        allowedValues: msgData.values[stateValueKey]
+          ? msgData.values[stateValueKey].allowedValues
+          : null,
       };
       return variableObj;
     }, {} as any);


### PR DESCRIPTION
Hey @bsparks could you please look at the PR. Thanks

Previously, we did not save the variable type received during the handshake with the CAPI component. As a result, in the Inspector preview tool, the variable type was auto-detected based on its value. This approach caused issues with variables of type ENUM, as ENUMs require a dropdown with allowed values to be displayed. Instead, the current implementation incorrectly shows a text input because it was thinking ENUM values as string.

To address this specifically for the preview mode (Inspector tool), I have introduced a new variable, `stage.${partId}.variables.Type`, in the scripting (**`_PREVIEW MODE ONLY & NOT SENT TO SERVER_`**). This variable stores all variables along with their types and allowed values, ensuring correct representation in the preview tool.