### PR TITLE
[CHORE] [MER-4090] only create activity_attempts_submitted index if it does not already exist

### DIFF
--- a/priv/repo/migrations/20240917111312_add_lifecycle_index.exs
+++ b/priv/repo/migrations/20240917111312_add_lifecycle_index.exs
@@ -4,7 +4,7 @@ defmodule Oli.Repo.Migrations.AddLifecycleIndex do
   def up do
     # Creates a partial index on the lifecycle_state column where the value is 'submitted'
     execute(
-      "CREATE INDEX activity_attempts_submitted ON activity_attempts (lifecycle_state) WHERE lifecycle_state = 'submitted';"
+      "CREATE INDEX IF NOT EXISTS activity_attempts_submitted ON activity_attempts (lifecycle_state) WHERE lifecycle_state = 'submitted';"
     )
   end
 


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-4090

We need the ability to run the activity_attempts_submitted index before migration to prevent extended downtime and CI disconnect to make the deployment go smoother.

This PR adds the `IF NOT EXISTS` specification to the index creation during migration to prevent the migration from throwing an error when the index was created ahead of time.