### PR TITLE
[ENHANCEMENT] [MER-4031] Dot should not be present on scored pages

### DIFF
--- a/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
+++ b/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
@@ -119,7 +119,7 @@
           </div>
         </div>
 
-        <%= if @section do %>
+        <%= if @section && !@page_context.page.graded do %>
           <%= live_render(@socket, OliWeb.Dialogue.WindowLive,
             session: %{
               "section_slug" => @section.slug,

--- a/test/oli_web/live/delivery/student/lesson_live_test.exs
+++ b/test/oli_web/live/delivery/student/lesson_live_test.exs
@@ -441,7 +441,8 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
         base_project: project,
         title: "The best course ever!",
         start_date: ~U[2023-10-30 20:00:00Z],
-        analytics_version: :v2
+        analytics_version: :v2,
+        assistant_enabled: true
       )
 
     {:ok, section} = Sections.create_section_resources(section, publication)
@@ -1361,6 +1362,41 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
         view,
         request_path
       )
+    end
+
+    test "can see DOT AI Bot interface if it's on a non scored page", %{
+      conn: conn,
+      user: user,
+      section: section,
+      page_1: page_1
+    } do
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.mark_section_visited_for_student(section, user)
+
+      {:ok, view, _html} = live(conn, Utils.lesson_live_path(section.slug, page_1.slug))
+      ensure_content_is_visible(view)
+
+      assert has_element?(view, "div[id='dialogue-window']")
+      assert has_element?(view, "div[id=ai_bot_collapsed]")
+    end
+
+    test "can not see DOT AI Bot interface if it's on a scored page", %{
+      conn: conn,
+      user: user,
+      section: section,
+      page_3: page_3
+    } do
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.mark_section_visited_for_student(section, user)
+
+      _first_attempt_in_progress =
+        create_attempt(user, section, page_3, %{lifecycle_state: :active})
+
+      {:ok, view, _html} = live(conn, Utils.lesson_live_path(section.slug, page_3.slug))
+      ensure_content_is_visible(view)
+
+      refute has_element?(view, "div[id='dialogue-window']")
+      refute has_element?(view, "div[id=ai_bot_collapsed]")
     end
   end
 

--- a/test/oli_web/live/delivery/student/prologue_live_test.exs
+++ b/test/oli_web/live/delivery/student/prologue_live_test.exs
@@ -340,7 +340,8 @@ defmodule OliWeb.Delivery.Student.PrologueLiveTest do
         base_project: project,
         title: "The best course ever!",
         start_date: ~U[2023-10-30 20:00:00Z],
-        analytics_version: :v2
+        analytics_version: :v2,
+        assistant_enabled: true
       )
 
     {:ok, section} = Sections.create_section_resources(section, publication)
@@ -1135,6 +1136,21 @@ defmodule OliWeb.Delivery.Student.PrologueLiveTest do
              |> element("#page_scoring_terms")
              |> render() =~
                "Your overall score for this assignment will be the average score of your attempts."
+    end
+
+    test "can not see DOT AI Bot interface if it's on a scored page", %{
+      conn: conn,
+      user: user,
+      section: section,
+      page_1: page_1
+    } do
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.mark_section_visited_for_student(section, user)
+
+      {:ok, view, _html} = live(conn, Utils.prologue_live_path(section.slug, page_1.slug))
+
+      refute has_element?(view, "div[id='dialogue-window']")
+      refute has_element?(view, "div[id=ai_bot_collapsed]")
     end
   end
 


### PR DESCRIPTION
[MER-4031](https://eliterate.atlassian.net/browse/MER-4031)

This PR adds an enhancement to not show the AI assistant DOT on scored pages. 

It also hides the assistant DOT in the prologue view of the scored pages.

https://github.com/user-attachments/assets/4415ad86-4f1e-405e-b92c-5accfb868f23




[MER-4031]: https://eliterate.atlassian.net/browse/MER-4031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ