### PR TITLE
[FEATURE] [MER-4093] ExtenD term page cases on prologue

### DIFF
--- a/lib/oli_web/live/delivery/student/prologue_live.ex
+++ b/lib/oli_web/live/delivery/student/prologue_live.ex
@@ -2,7 +2,7 @@ defmodule OliWeb.Delivery.Student.PrologueLive do
   use OliWeb, :live_view
 
   import OliWeb.Delivery.Student.Utils,
-    only: [page_header: 1, page_terms: 1]
+    only: [page_header: 1, page_terms: 1, is_adaptive_page: 1]
 
   alias Oli.Accounts.User
   alias Oli.Delivery.Attempts.Core.ResourceAttempt
@@ -99,7 +99,11 @@ defmodule OliWeb.Delivery.Student.PrologueLive do
         />
         <div class="self-stretch h-[0px] opacity-80 dark:opacity-20 bg-white border border-gray-200 mt-3 mb-10">
         </div>
-        <.page_terms effective_settings={@page_context.effective_settings} ctx={@ctx} />
+        <.page_terms
+          effective_settings={@page_context.effective_settings}
+          ctx={@ctx}
+          is_adaptive={is_adaptive_page(@page_context.page)}
+        />
         <.attempts_summary
           page_context={@page_context}
           attempt_message={@attempt_message}

--- a/lib/oli_web/live/delivery/student/utils.ex
+++ b/lib/oli_web/live/delivery/student/utils.ex
@@ -175,6 +175,7 @@ defmodule OliWeb.Delivery.Student.Utils do
 
   attr :effective_settings, Oli.Delivery.Settings.Combined
   attr :ctx, SessionContext
+  attr :is_adaptive, :boolean
 
   def page_terms(assigns) do
     ~H"""
@@ -189,7 +190,13 @@ defmodule OliWeb.Delivery.Student.Utils do
         <li id="page_due_terms">
           <.page_due_term effective_settings={@effective_settings} ctx={@ctx} />
         </li>
-        <li :if={@effective_settings.end_date != nil} id="page_submission_terms">
+        <li
+          :if={
+            @effective_settings.end_date != nil and @effective_settings.scheduling_type == :due_by and
+              !@is_adaptive and @effective_settings.late_submit != :allow
+          }
+          id="page_submission_terms"
+        >
           <.page_submission_term effective_settings={@effective_settings} ctx={@ctx} />
         </li>
         <li :if={@effective_settings.end_date != nil} id="page_scoring_terms">
@@ -1006,6 +1013,9 @@ defmodule OliWeb.Delivery.Student.Utils do
       {f, _s} -> f
     end
   end
+
+  def is_adaptive_page(%Oli.Resources.Revision{content: %{"advancedDelivery" => true}}), do: true
+  def is_adaptive_page(_), do: false
 
   defp build_page_link_params(section_slug, page, request_path, selected_view) do
     current_page_path =


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-4093) to the ticket

### Submission terms not shown when page has scheduling type = suggested_by

https://github.com/user-attachments/assets/415211d9-495b-4b12-b8db-7a4c1aff6197


###  Submission terms not shown when page has late submit = allowed

https://github.com/user-attachments/assets/3d431adc-4584-4262-b122-28bbc72d2df5



###  Submission terms not shown when page is adaptive (even if it has due date and late submission disallowed)

https://github.com/user-attachments/assets/f62f544b-2587-47f0-b137-ceaecb494d55


 


**co-authored by:** @simonchoxx 