### PR TITLE
[FEATURE] [MER-4095] Extend page submission term logic

### DIFF
--- a/lib/oli_web/live/delivery/student/utils.ex
+++ b/lib/oli_web/live/delivery/student/utils.ex
@@ -193,7 +193,9 @@ defmodule OliWeb.Delivery.Student.Utils do
         <li
           :if={
             @effective_settings.end_date != nil and @effective_settings.scheduling_type == :due_by and
-              !@is_adaptive and @effective_settings.late_submit != :allow
+              !@is_adaptive and
+              (@effective_settings.late_submit == :disallow or
+                 (@effective_settings.late_submit == :allow and @effective_settings.time_limit > 0))
           }
           id="page_submission_terms"
         >

--- a/test/oli_web/live/delivery/student/prologue_live_test.exs
+++ b/test/oli_web/live/delivery/student/prologue_live_test.exs
@@ -1149,16 +1149,42 @@ defmodule OliWeb.Delivery.Student.PrologueLiveTest do
 
       refute has_element?(view, "#page_submission_terms")
 
-      # submission terms shouln't be visible when late submit is allowed
+      # submission terms shouldn't be visible when late submit is allowed and time_limit = 0
       Sections.get_section_resource(section.id, page_2.resource_id)
       |> Sections.update_section_resource(%{
         scheduling_type: :due_by,
-        late_submit: :allow
+        late_submit: :allow,
+        time_limit: 0
       })
 
       {:ok, view, _html} = live(conn, Utils.prologue_live_path(section.slug, page_2.slug))
 
       refute has_element?(view, "#page_submission_terms")
+
+      # submission terms should be visible when late submit is allowed and time limit > 0
+      Sections.get_section_resource(section.id, page_2.resource_id)
+      |> Sections.update_section_resource(%{
+        scheduling_type: :due_by,
+        late_submit: :allow,
+        time_limit: 33
+      })
+
+      {:ok, view, _html} = live(conn, Utils.prologue_live_path(section.slug, page_2.slug))
+
+      assert view
+             |> element("#page_submission_terms")
+             |> render() =~
+               "Your work will automatically be submitted"
+
+      assert view
+             |> element("#page_submission_terms")
+             |> render() =~
+               "33 minutes"
+
+      assert view
+             |> element("#page_submission_terms")
+             |> render() =~
+               "after you click the Begin button"
 
       # submission terms shouln't be visible in prologue for adaptive pages
       Sections.get_section_resource(section.id, graded_adaptive_page.resource_id)


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-4095) to the ticket

[MER-4093](https://github.com/Simon-Initiative/oli-torus/pull/5286) should have said: "Assignments should not be auto-submitted if late submission is allowed, **except if there is a time limit**"

### Edge case

https://github.com/user-attachments/assets/293ad64b-0717-430f-8efd-2be8e8d21843

**co-authored**: @simonchoxx 

[MER-4093]: https://eliterate.atlassian.net/browse/MER-4093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ