### PR TITLE
[BUG FIX] [MER-4096] Add depot warmer environment variables to the runtime conf…

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -133,6 +133,8 @@ if config_env() == :prod do
 
   # General OLI app config
   config :oli,
+    depot_warmer_days_lookback: System.get_env("DEPOT_WARMER_DAYS_LOOKBACK", "5"),
+    depot_warmer_max_number_of_entries: System.get_env("DEPOT_WARMER_MAX_NUMBER_OF_ENTRIES", "0"),
     s3_media_bucket_name: s3_media_bucket_name,
     s3_xapi_bucket_name: s3_xapi_bucket_name,
     media_url: media_url,


### PR DESCRIPTION
Ticket: [MER-4096](https://eliterate.atlassian.net/browse/MER-4096)

This PR adds the following two environment variables to the runtime configuration file:

```
depot_warmer_days_lookback: System.get_env("DEPOT_WARMER_DAYS_LOOKBACK", "5")
depot_warmer_max_number_of_entries: System.get_env("DEPOT_WARMER_MAX_NUMBER_OF_ENTRIES", "0")
```

This will allow these variables to be set up without the need to recompile our app.

[MER-4096]: https://eliterate.atlassian.net/browse/MER-4096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ