### PR TITLE
[ENHANCEMENT] [MER-4081] allow setting submitAndCompare flag in ShortAnswer authoring

### DIFF
--- a/assets/src/components/activities/common/utils.tsx
+++ b/assets/src/components/activities/common/utils.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { ShortAnswerModelSchema } from '../short_answer/schema';
 import {
   HasPerPartSubmissionOption,
   PartId,
@@ -32,6 +33,12 @@ export const togglePerPartSubmissionOption = () => {
   return (model: HasPerPartSubmissionOption): void => {
     model.submitPerPart =
       model.submitPerPart === undefined || model.submitPerPart === false ? true : false;
+  };
+};
+
+export const toggleSubmitAndCompareOption = () => {
+  return (model: ShortAnswerModelSchema): void => {
+    model.submitAndCompare = !model.submitAndCompare;
   };
 };
 

--- a/assets/src/components/activities/short_answer/ShortAnswerAuthoring.tsx
+++ b/assets/src/components/activities/short_answer/ShortAnswerAuthoring.tsx
@@ -26,8 +26,10 @@ import { defaultWriterContext } from 'data/content/writers/context';
 import { configureStore } from 'state/store';
 import { AuthoringElement, AuthoringElementProps } from '../AuthoringElement';
 import { AuthoringElementProvider, useAuthoringElementContext } from '../AuthoringElementProvider';
+import { ActivitySettings } from '../common/authoring/settings/ActivitySettings';
 import { Explanation } from '../common/explanation/ExplanationAuthoring';
 import { ActivityScoring } from '../common/responses/ActivityScoring';
+import { toggleSubmitAndCompareOption } from '../common/utils';
 import { VariableEditorOrNot } from '../common/variables/VariableEditorOrNot';
 import { VariableActions } from '../common/variables/variableActions';
 import { ShortAnswerActions } from './actions';
@@ -38,6 +40,13 @@ const store = configureStore();
 const ShortAnswer = () => {
   const { dispatch, model, editMode, projectSlug } =
     useAuthoringElementContext<ShortAnswerModelSchema>();
+
+  const submitAndCompareSetting = {
+    label: 'Submit And Compare',
+    isEnabled: model.submitAndCompare === true,
+    onToggle: () => dispatch(toggleSubmitAndCompareOption()),
+  };
+
   return (
     <>
       <TabbedNavigation.Tabs>
@@ -167,6 +176,7 @@ const ShortAnswer = () => {
             onEdit={(t) => dispatch(VariableActions.onUpdateTransformations(t))}
           />
         </TabbedNavigation.Tab>
+        <ActivitySettings settings={[submitAndCompareSetting]} />
       </TabbedNavigation.Tabs>
     </>
   );


### PR DESCRIPTION
Legacy OLI included a "Submit and Compare" type of short answer question, in which there was no wrong answer, the only purpose was to write and submit a short answer and compare it to a correct answer given as feedback These migrate into torus short answer questions using regex checking so that any non-empty answer is correct and the answer to compare is given as correct feedback. To support this, ShortAnswer questions carry an optional SubmitAndCompare flag. Currently the only significance of this flag is that it changes the Submit button to read "Submit and Compare". 

This change provides a setting on the authoring interface so that authors may construct new questions with this submit and compare behavior.

Note it is still on the author to specify response rules in torus to get the submit and compare behavior -- setting the SubmitAndCompare flag does not do that automatically, it just changes the Submit button text.