### PR TITLE
[BUG FIX] [MER-4101] Show the Time Limit page term when is configured

### DIFF
--- a/lib/oli_web/live/delivery/student/utils.ex
+++ b/lib/oli_web/live/delivery/student/utils.ex
@@ -190,6 +190,7 @@ defmodule OliWeb.Delivery.Student.Utils do
         <li id="page_due_terms">
           <.page_due_term effective_settings={@effective_settings} ctx={@ctx} />
         </li>
+        <.maybe_add_time_limit_term effective_settings={@effective_settings} />
         <li
           :if={
             @effective_settings.end_date != nil and @effective_settings.scheduling_type == :due_by and
@@ -209,10 +210,7 @@ defmodule OliWeb.Delivery.Student.Utils do
     """
   end
 
-  attr :effective_settings, Oli.Delivery.Settings.Combined
-  attr :ctx, SessionContext
-
-  defp page_due_term(%{effective_settings: %{end_date: nil, time_limit: time_limit}} = assigns)
+  defp maybe_add_time_limit_term(%{effective_settings: %{time_limit: time_limit}} = assigns)
        when time_limit > 0 do
     minute_label =
       case time_limit do
@@ -223,10 +221,20 @@ defmodule OliWeb.Delivery.Student.Utils do
     assigns = assign(assigns, minute_label: minute_label)
 
     ~H"""
-    You have <b><%= @effective_settings.time_limit %> <%= @minute_label %></b>
-    to complete the assessment. If you exceed this time, it will be marked as late.
+    <li id="page_time_limit_term">
+      You have <b><%= @effective_settings.time_limit %> <%= @minute_label %></b>
+      to complete the assessment. If you exceed this time, it will be marked as late.
+    </li>
     """
   end
+
+  defp maybe_add_time_limit_term(assigns) do
+    ~H"""
+    """
+  end
+
+  attr :effective_settings, Oli.Delivery.Settings.Combined
+  attr :ctx, SessionContext
 
   defp page_due_term(%{effective_settings: %{end_date: nil}} = assigns) do
     ~H"""

--- a/test/oli_web/live/delivery/student/prologue_live_test.exs
+++ b/test/oli_web/live/delivery/student/prologue_live_test.exs
@@ -1200,7 +1200,7 @@ defmodule OliWeb.Delivery.Student.PrologueLiveTest do
       refute has_element?(view, "#page_submission_terms")
     end
 
-    test "page terms show a time limit message when the due date is not set", ctx do
+    test "page terms display a time limit message", ctx do
       %{conn: conn, user: user, section: section, page_2: page_2} = ctx
 
       Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
@@ -1208,21 +1208,24 @@ defmodule OliWeb.Delivery.Student.PrologueLiveTest do
 
       # Singular case
       Sections.get_section_resource(section.id, page_2.resource_id)
-      |> Sections.update_section_resource(%{time_limit: 1, end_date: nil})
+      |> Sections.update_section_resource(%{time_limit: 1})
 
       {:ok, view, _html} = live(conn, Utils.prologue_live_path(section.slug, page_2.slug))
 
       assert view |> element("#page_due_terms") |> render() =~
-               "You have <b>1 minute</b>\nto complete the assessment. If you exceed this time, it will be marked as late."
+               "This assignment was due on"
+
+      assert view |> element("#page_time_limit_term") |> render() =~
+               "You have <b>1 minute</b>\n  to complete the assessment. If you exceed this time, it will be marked as late."
 
       # Plural case
       Sections.get_section_resource(section.id, page_2.resource_id)
-      |> Sections.update_section_resource(%{time_limit: 2, end_date: nil})
+      |> Sections.update_section_resource(%{time_limit: 2})
 
       {:ok, view, _html} = live(conn, Utils.prologue_live_path(section.slug, page_2.slug))
 
-      assert view |> element("#page_due_terms") |> render() =~
-               "You have <b>2 minutes</b>\nto complete the assessment. If you exceed this time, it will be marked as late."
+      assert view |> element("#page_time_limit_term") |> render() =~
+               "You have <b>2 minutes</b>\n  to complete the assessment. If you exceed this time, it will be marked as late."
     end
   end
 


### PR DESCRIPTION
Ticket: [MER-4101](https://eliterate.atlassian.net/browse/MER-4101)

This PR adds the "Time Limit" page term when its value is different from 0, regardless of other conditions.

https://github.com/user-attachments/assets/692041c7-7d8d-4c6b-82b7-02f3c879a402


[MER-4101]: https://eliterate.atlassian.net/browse/MER-4101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ