### PR TITLE
[FEATURE] [MER-3752] Make agenda enabled by default

### DIFF
--- a/lib/oli/delivery/sections/section.ex
+++ b/lib/oli/delivery/sections/section.ex
@@ -159,7 +159,7 @@ defmodule Oli.Delivery.Sections.Section do
 
     field(:encouraging_subtitle, :string)
 
-    field(:agenda, :boolean, default: false)
+    field(:agenda, :boolean, default: true)
 
     timestamps(type: :utc_datetime)
   end

--- a/priv/repo/migrations/20241209175250_update_agenda_default_to_true.exs
+++ b/priv/repo/migrations/20241209175250_update_agenda_default_to_true.exs
@@ -1,0 +1,9 @@
+defmodule Oli.Repo.Migrations.UpdateAgendaDefaultToTrue do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sections) do
+      modify(:agenda, :boolean, default: true)
+    end
+  end
+end

--- a/test/oli_web/live/delivery/instructor_dashboard/manage/manage_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/manage/manage_tab_test.exs
@@ -86,17 +86,30 @@ defmodule OliWeb.Delivery.InstructorDashboard.ManageTabTest do
           }
         )
 
-      refute has_element?(view, "input[name=\"toggle_agenda\"][checked]")
-
-      element(view, "form[phx-change=\"toggle_agenda\"]")
-      |> render_change(%{})
-
       assert has_element?(view, "input[name=\"toggle_agenda\"][checked]")
 
       element(view, "form[phx-change=\"toggle_agenda\"]")
       |> render_change(%{})
 
       refute has_element?(view, "input[name=\"toggle_agenda\"][checked]")
+
+      element(view, "form[phx-change=\"toggle_agenda\"]")
+      |> render_change(%{})
+
+      assert has_element?(view, "input[name=\"toggle_agenda\"][checked]")
+    end
+
+    test "agenda is enabled by default when creating a course section", %{
+      instructor: instructor,
+      section: section,
+      conn: conn
+    } do
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+
+      {:ok, view, _html} = live(conn, live_view_manage_route(section.slug))
+
+      assert section.agenda
+      assert has_element?(view, "input[name=\"toggle_agenda\"][checked]")
     end
   end
 end

--- a/test/oli_web/live/delivery/student/index_live_test.exs
+++ b/test/oli_web/live/delivery/student/index_live_test.exs
@@ -1115,10 +1115,6 @@ defmodule OliWeb.Delivery.Student.IndexLiveTest do
       page_3: page_3,
       page_4: page_4
     } do
-      Sections.update_section(section, %{
-        agenda: true
-      })
-
       stub_current_time(~U[2023-11-03 21:00:00Z])
       {:ok, view, _html} = live(conn, ~p"/sections/#{section.slug}")
 
@@ -1135,6 +1131,10 @@ defmodule OliWeb.Delivery.Student.IndexLiveTest do
       section: section,
       page_1: page_1
     } do
+      Sections.update_section(section, %{
+        agenda: false
+      })
+
       stub_current_time(~U[2023-11-03 21:00:00Z])
       {:ok, view, _html} = live(conn, ~p"/sections/#{section.slug}")
 


### PR DESCRIPTION
[MER-3752](https://eliterate.atlassian.net/browse/MER-3752)

This PR modifies the default value of the agenda field in the `Section` structure. 

Thus, when a new course section is created, it has by default the option to show the agenda enabled. 


https://github.com/user-attachments/assets/b77dba8e-c0a7-494b-8e26-80d03965e2dd








[MER-3752]: https://eliterate.atlassian.net/browse/MER-3752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ