### PR TITLE
[BUG FIX] [MER-3996] Modules displaying 0 minutes

### DIFF
--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -2397,7 +2397,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
     >
       <div class="dark:text-white text-[13px] font-semibold">
         <%= parse_module_total_pages(@page_metrics.total_pages_count) <>
-          ((@page_metrics.total_duration_minutes > 0 && " · #{parsed_minutes}") || "") %>
+          maybe_add_separator(@page_metrics.total_pages_count, parsed_minutes) <> "#{parsed_minutes}" %>
       </div>
     </div>
     """
@@ -2426,11 +2426,14 @@ defmodule OliWeb.Delivery.Student.LearnLive do
         class="hidden dark:text-white text-[13px] font-semibold pointer-events-none"
       >
         <%= parse_module_total_pages(@page_metrics.total_pages_count) <>
-          ((@page_metrics.total_duration_minutes > 0 && " · #{parsed_minutes}") || "") %>
+          maybe_add_separator(@page_metrics.total_pages_count, parsed_minutes) <> "#{parsed_minutes}" %>
       </div>
     </div>
     """
   end
+
+  def maybe_add_separator(total_pages_count, parsed_minutes),
+    do: if(total_pages_count > 0 and parsed_minutes != "", do: " · ", else: "")
 
   def video_player(assigns) do
     ~H"""
@@ -3051,17 +3054,17 @@ defmodule OliWeb.Delivery.Student.LearnLive do
       |> Timex.Duration.to_clock()
 
     case {clock_duration, resource_type} do
-      {{hours, minutes, _seconds, _milliseconds}, :module} when hours > 0 ->
+      {{hours, minutes, _seconds, _milliseconds}, _resource_type} when hours > 0 ->
         "#{hours}h #{minutes}m"
 
-      {{_, minutes, _seconds, _milliseconds}, :module} ->
+      {{_, minutes, _seconds, _milliseconds}, :module} when minutes > 0 ->
         "#{minutes}m"
 
-      {{hours, minutes, _seconds, _milliseconds}, :page} when hours > 0 ->
-        "#{hours}h #{minutes}m"
-
-      {{_, minutes, _seconds, _milliseconds}, :page} ->
+      {{_, minutes, _seconds, _milliseconds}, :page} when minutes > 0 ->
         "#{minutes} min"
+
+      {{_, _, _seconds, _milliseconds}, _} ->
+        ""
     end
   end
 

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -2397,7 +2397,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
     >
       <div class="dark:text-white text-[13px] font-semibold">
         <%= parse_module_total_pages(@page_metrics.total_pages_count) <>
-          if parsed_minutes, do: " · #{parsed_minutes}" %>
+          ((@page_metrics.total_duration_minutes > 0 && " · #{parsed_minutes}") || "") %>
       </div>
     </div>
     """
@@ -2426,7 +2426,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
         class="hidden dark:text-white text-[13px] font-semibold pointer-events-none"
       >
         <%= parse_module_total_pages(@page_metrics.total_pages_count) <>
-          if parsed_minutes, do: " · #{parsed_minutes}" %>
+          ((@page_metrics.total_duration_minutes > 0 && " · #{parsed_minutes}") || "") %>
       </div>
     </div>
     """

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -154,13 +154,15 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
     page_5_revision =
       insert(:revision,
         resource_type_id: ResourceType.get_id_by_type("page"),
-        title: "Page 5"
+        title: "Page 5",
+        duration_minutes: 0
       )
 
     page_6_revision =
       insert(:revision,
         resource_type_id: ResourceType.get_id_by_type("page"),
-        title: "Page 6"
+        title: "Page 6",
+        duration_minutes: 0
       )
 
     page_7_revision =
@@ -2010,6 +2012,38 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       {:ok, view, _html} = live(conn, Utils.learn_live_path(section.slug))
 
       refute render(view) =~ "Page 7"
+    end
+
+    test "modules do not show duration minutes if duration is 0", %{
+      conn: conn,
+      section: section,
+      module_3: module_3,
+      page_5: page_5,
+      page_6: page_6
+    } do
+      {:ok, view, _html} = live(conn, Utils.learn_live_path(section.slug))
+
+      view
+      |> element(~s{div[id="module_#{module_3.resource_id}"]})
+      |> render_click()
+
+      # assert that page 5 and page 6 have duration 0
+      assert page_5.duration_minutes == 0
+      assert page_6.duration_minutes == 0
+
+      # assert that module 3 contains 2 pages (page 5 and page 6)
+      assert has_element?(
+               view,
+               ~s{div[id="module_#{module_3.resource_id}"] div[role="card badge"]},
+               "2 pages"
+             )
+
+      # assert that module 3 does not show duration minutes (since it is 0)
+      refute has_element?(
+               view,
+               ~s{div[id="module_#{module_3.resource_id}"] div[role="card badge"]},
+               "0 minutes"
+             )
     end
   end
 


### PR DESCRIPTION
[MER-3996](https://eliterate.atlassian.net/browse/MER-3996)

This PR fixes the bug where “0m” was displayed on the module cards for the gallery view on the learn page. 

This happened because it did not take into account if the module had pages with a stipulated duration in minutes. 

Thus, if the pages contained in a module do not have a stipulated duration in minutes, no legend will be shown on the module card. 


https://github.com/user-attachments/assets/af0037ef-3d24-4d3b-9a98-00a4c5b231f7



[MER-3996]: https://eliterate.atlassian.net/browse/MER-3996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ