### PR TITLE
[BUG FIX] [MER-4102] MCQ options in Advanced Author appear in light gray text by default

### DIFF
--- a/assets/src/components/parts/janus-mcq/McqAuthor.tsx
+++ b/assets/src/components/parts/janus-mcq/McqAuthor.tsx
@@ -234,7 +234,7 @@ const McqAuthor: React.FC<AuthorPartComponentProps<McqModel>> = (props) => {
                   children: [{ children: [], tag: 'text', text: `Option ${mcqItems.length + 1}` }],
                   style: {
                     backgroundColor: 'transparent',
-                    color: '#ebebeb',
+                    color: 'inherit',
                     fontSize: '16px',
                   },
                   tag: 'span',


### PR DESCRIPTION
Hey @bsparks could you please look at the PR. Thanks