### PR TITLE
[CHORE] [MER-3959] fix an issue where Oli modules reply on test modules breaking the build

### DIFF
--- a/lib/oli/utils/db_seeder.ex
+++ b/lib/oli/utils/db_seeder.ex
@@ -25,7 +25,7 @@ defmodule Oli.Seeder do
   alias Oli.Delivery.Attempts.PageLifecycle.FinalizationSummary
   alias Oli.Utils.Seeder.StudentAttemptSeed
   alias Oli.Delivery.Attempts.ActivityLifecycle.Evaluate
-  alias Oli.AccountsFixtures
+  alias Oli.Utils.Seeder.AccountsFixtures
 
   def base_project_with_resource(author) do
     {:ok, family} =

--- a/lib/oli/utils/seeder/accounts_fixtures.ex
+++ b/lib/oli/utils/seeder/accounts_fixtures.ex
@@ -1,4 +1,4 @@
-defmodule Oli.AccountsFixtures do
+defmodule Oli.Utils.Seeder.AccountsFixtures do
   @moduledoc """
   This module defines test helpers for creating
   entities via the `Oli.Accounts` context.

--- a/lib/oli/utils/seeder/project.ex
+++ b/lib/oli/utils/seeder/project.ex
@@ -3,7 +3,7 @@ defmodule Oli.Utils.Seeder.Project do
 
   alias Oli.Publishing.AuthoringResolver
   alias Oli.Repo
-  alias Oli.AccountsFixtures
+  alias Oli.Utils.Seeder.AccountsFixtures
   alias Oli.Authoring.Authors.{AuthorProject, ProjectRole}
   alias Oli.Authoring.Course.{Project, Family}
   alias Oli.Publishing.Publications.Publication

--- a/lib/oli/utils/seeder/session.ex
+++ b/lib/oli/utils/seeder/session.ex
@@ -1,15 +1,18 @@
 defmodule Oli.Utils.Seeder.Session do
   import Oli.Utils.Seeder.Utils
 
-  alias Oli.TestHelpers
-
   @doc """
   Creates an author session
   """
   def login_as_author(%{conn: conn} = seeds, author, _tags \\ []) do
     [author] = unpack(seeds, [author])
 
-    conn = TestHelpers.log_in_author(conn, author)
+    token = Oli.Accounts.generate_author_session_token(author)
+
+    conn
+    |> Phoenix.ConnTest.init_test_session(%{})
+    |> Plug.Conn.put_session(:author_token, token)
+    |> Plug.Conn.put_session(:current_author_id, author.id)
 
     %{seeds | conn: conn}
   end
@@ -20,7 +23,12 @@ defmodule Oli.Utils.Seeder.Session do
   def login_as_user(%{conn: conn} = seeds, user, _tags \\ []) do
     [user] = unpack(seeds, [user])
 
-    conn = TestHelpers.log_in_user(conn, user)
+    token = Oli.Accounts.generate_user_session_token(user)
+
+    conn
+    |> Phoenix.ConnTest.init_test_session(%{})
+    |> Plug.Conn.put_session(:user_token, token)
+    |> Plug.Conn.put_session(:current_user_id, user.id)
 
     %{seeds | conn: conn}
   end

--- a/test/oli/accounts_test.exs
+++ b/test/oli/accounts_test.exs
@@ -205,7 +205,7 @@ defmodule Oli.AccountsTest do
     @invalid_attrs %{email: nil, given_name: nil, family_name: nil, sub: nil, picture: nil}
 
     setup do
-      author = Oli.AccountsFixtures.author_fixture()
+      author = Oli.Utils.Seeder.AccountsFixtures.author_fixture()
 
       valid_attrs =
         @valid_attrs

--- a/test/oli_web/author_auth_test.exs
+++ b/test/oli_web/author_auth_test.exs
@@ -13,7 +13,7 @@ defmodule OliWeb.AuthorAuthTest do
       |> Map.replace!(:secret_key_base, OliWeb.Endpoint.config(:secret_key_base))
       |> init_test_session(%{})
 
-    %{author: Oli.AccountsFixtures.author_fixture(), conn: conn}
+    %{author: Oli.Utils.Seeder.AccountsFixtures.author_fixture(), conn: conn}
   end
 
   describe "log_in_author/3" do

--- a/test/oli_web/live/author_forgot_password_live_test.exs
+++ b/test/oli_web/live/author_forgot_password_live_test.exs
@@ -16,7 +16,7 @@ defmodule OliWeb.AuthorForgotPasswordLiveTest do
     test "redirects if already logged in", %{conn: conn} do
       result =
         conn
-        |> log_in_author(Oli.AccountsFixtures.author_fixture())
+        |> log_in_author(Oli.Utils.Seeder.AccountsFixtures.author_fixture())
         |> live(~p"/authors/reset_password")
         |> follow_redirect(conn, ~p"/workspaces/course_author")
 
@@ -26,7 +26,7 @@ defmodule OliWeb.AuthorForgotPasswordLiveTest do
 
   describe "Reset link" do
     setup do
-      %{author: Oli.AccountsFixtures.author_fixture()}
+      %{author: Oli.Utils.Seeder.AccountsFixtures.author_fixture()}
     end
 
     test "sends a new reset password token", %{conn: conn, author: author} do

--- a/test/oli_web/live/author_login_live_test.exs
+++ b/test/oli_web/live/author_login_live_test.exs
@@ -15,7 +15,7 @@ defmodule OliWeb.AuthorLoginLiveTest do
     test "redirects if already logged in", %{conn: conn} do
       result =
         conn
-        |> log_in_author(Oli.AccountsFixtures.author_fixture())
+        |> log_in_author(Oli.Utils.Seeder.AccountsFixtures.author_fixture())
         |> live(~p"/authors/log_in")
         |> follow_redirect(conn, "/workspaces/course_author")
 
@@ -26,7 +26,7 @@ defmodule OliWeb.AuthorLoginLiveTest do
   describe "author login" do
     test "redirects if author login with valid credentials", %{conn: conn} do
       password = "123456789abcd"
-      author = Oli.AccountsFixtures.author_fixture(%{password: password})
+      author = Oli.Utils.Seeder.AccountsFixtures.author_fixture(%{password: password})
 
       {:ok, lv, _html} = live(conn, ~p"/authors/log_in")
 

--- a/test/oli_web/live/user_forgot_password_live_test.exs
+++ b/test/oli_web/live/user_forgot_password_live_test.exs
@@ -16,7 +16,7 @@ defmodule OliWeb.UserForgotPasswordLiveTest do
     test "redirects if already logged in", %{conn: conn} do
       result =
         conn
-        |> log_in_user(Oli.AccountsFixtures.user_fixture())
+        |> log_in_user(Oli.Utils.Seeder.AccountsFixtures.user_fixture())
         |> live(~p"/users/reset_password")
         |> follow_redirect(conn, ~p"/workspaces/student")
 
@@ -26,7 +26,7 @@ defmodule OliWeb.UserForgotPasswordLiveTest do
 
   describe "Reset link" do
     setup do
-      %{user: Oli.AccountsFixtures.user_fixture()}
+      %{user: Oli.Utils.Seeder.AccountsFixtures.user_fixture()}
     end
 
     test "sends a new reset password token", %{conn: conn, user: user} do

--- a/test/oli_web/live/user_login_live_test.exs
+++ b/test/oli_web/live/user_login_live_test.exs
@@ -15,7 +15,7 @@ defmodule OliWeb.UserLoginLiveTest do
     test "redirects if already logged in", %{conn: conn} do
       result =
         conn
-        |> log_in_user(Oli.AccountsFixtures.user_fixture())
+        |> log_in_user(Oli.Utils.Seeder.AccountsFixtures.user_fixture())
         |> live(~p"/users/log_in")
         |> follow_redirect(conn, "/workspaces/student")
 
@@ -26,7 +26,7 @@ defmodule OliWeb.UserLoginLiveTest do
   describe "user login" do
     test "redirects if user login with valid credentials", %{conn: conn} do
       password = "123456789abcd"
-      user = Oli.AccountsFixtures.user_fixture(%{password: password})
+      user = Oli.Utils.Seeder.AccountsFixtures.user_fixture(%{password: password})
 
       {:ok, lv, _html} = live(conn, ~p"/users/log_in")
 

--- a/test/oli_web/user_auth_test.exs
+++ b/test/oli_web/user_auth_test.exs
@@ -13,7 +13,7 @@ defmodule OliWeb.UserAuthTest do
       |> Map.replace!(:secret_key_base, OliWeb.Endpoint.config(:secret_key_base))
       |> init_test_session(%{})
 
-    %{user: Oli.AccountsFixtures.user_fixture(), conn: conn}
+    %{user: Oli.Utils.Seeder.AccountsFixtures.user_fixture(), conn: conn}
   end
 
   describe "log_in_user/3" do

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -24,7 +24,7 @@ defmodule OliWeb.ConnCase do
       use OliWeb, :verified_routes
 
       import Oli.TestHelpers
-      import Oli.AccountsFixtures
+      import Oli.Utils.Seeder.AccountsFixtures
 
       # The default endpoint for testing
       @endpoint OliWeb.Endpoint

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -23,7 +23,7 @@ defmodule Oli.DataCase do
       import Ecto.Query
       import Oli.DataCase
       import Oli.TestHelpers
-      import Oli.AccountsFixtures
+      import Oli.Utils.Seeder.AccountsFixtures
 
       alias Oli.Seeder
     end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -2,7 +2,7 @@ defmodule Oli.TestHelpers do
   import Ecto.Query, warn: false
   import Mox
   import Oli.Factory
-  import Oli.AccountsFixtures
+  import Oli.Utils.Seeder.AccountsFixtures
 
   alias Oli.Repo
   alias Oli.Accounts
@@ -252,7 +252,7 @@ defmodule Oli.TestHelpers do
   test context.
   """
   def register_and_log_in_user(%{conn: conn}, attrs \\ %{}) do
-    user = Oli.AccountsFixtures.user_fixture(attrs)
+    user = Oli.Utils.Seeder.AccountsFixtures.user_fixture(attrs)
     %{conn: log_in_user(conn, user), user: user}
   end
 
@@ -286,7 +286,7 @@ defmodule Oli.TestHelpers do
   test context.
   """
   def register_and_log_in_author(%{conn: conn}, attrs \\ %{}) do
-    author = Oli.AccountsFixtures.author_fixture(attrs)
+    author = Oli.Utils.Seeder.AccountsFixtures.author_fixture(attrs)
     %{conn: log_in_author(conn, author), author: author}
   end
 


### PR DESCRIPTION
This PR fixes the build which was previously broken by MER-3959 where some of the Oli modules were aliasing modules from test.