### PR TITLE
[ENHANCEMENT] [MER-4119] curriculum edit page js dependency optimization

### DIFF
--- a/lib/oli_web/live/workspaces/course_author/curriculum/entry.ex
+++ b/lib/oli_web/live/workspaces/course_author/curriculum/entry.ex
@@ -53,7 +53,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.Curriculum.Entry do
             <span class="ml-1 mr-1 entry-title"><%= @child.title %></span>
             <.link
               class="entry-title mx-3"
-              href={
+              navigate={
                 ~p"/workspaces/course_author/#{@project.slug}/curriculum/#{@child.slug}/edit?sidebar_expanded=#{@sidebar_expanded}"
               }
             >


### PR DESCRIPTION
Ticket: [MER-4119](https://eliterate.atlassian.net/browse/MER-4119)

This PR introduces optimizations for how authors navigate through the curriculum using breadcrumbs. Currently, when an author edits a page, a full page load occurs, which negates the benefits of LiveView. Additionally, the navigation page links (the bottom buttons) have been modified to navigate without performing a full page reload.

[MER-4119]: https://eliterate.atlassian.net/browse/MER-4119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ