### PR TITLE
[BUG FIX] [MER-3122] Assessment Settings Sorting Capability Broken

### DIFF
--- a/lib/oli/publishing/delivery_resolver.ex
+++ b/lib/oli/publishing/delivery_resolver.ex
@@ -47,7 +47,7 @@ defmodule Oli.Publishing.DeliveryResolver do
     from([sr, s, _spp, _pr, rev] in section_resource_revisions(section_slug),
       where: rev.resource_type_id == 1 and rev.graded == true,
       select: {rev, sr},
-      order_by: [asc: sr.numbering_level, asc: sr.numbering_index]
+      order_by: sr.numbering_index
     )
     |> Repo.all()
   end

--- a/lib/oli_web/live/sections/assessment_settings/settings_table.ex
+++ b/lib/oli_web/live/sections/assessment_settings/settings_table.ex
@@ -998,6 +998,11 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTable do
   end
 
   defp sort_by(assessments, sort_by, sort_order) do
+    to_unix = fn
+      nil -> 0
+      datetime -> DateTime.to_unix(datetime)
+    end
+
     case sort_by do
       :late_policy ->
         Enum.sort_by(
@@ -1011,12 +1016,14 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTable do
         )
 
       :available_date ->
-        Enum.sort_by(assessments, fn a -> a.start_date end, sort_order)
+        Enum.sort_by(assessments, fn a -> to_unix.(a.start_date) end, sort_order)
 
       :due_date ->
         Enum.sort_by(
           assessments,
-          fn a -> if a.scheduling_type == :due_by, do: a.end_date, else: nil end,
+          fn a ->
+            if a.scheduling_type == :due_by, do: to_unix.(a.end_date), else: 0
+          end,
           sort_order
         )
 

--- a/test/oli_web/live/delivery/instructor_dashboard/scored_activities/scored_activities_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/scored_activities/scored_activities_tab_test.exs
@@ -1152,11 +1152,11 @@ defmodule OliWeb.Delivery.InstructorDashboard.ScoredActivitiesTabTest do
       [a0, a1, a2, a3, a4] = table_as_list_of_maps(view, :assessments)
 
       assert has_element?(view, "h4", "Scored Activities")
-      assert a0.title == "Orphaned Page"
-      assert a1.title == "Module 1: IntroductionPage 1"
-      assert a2.title == "Module 1: IntroductionPage 2"
-      assert a3.title == "Module 2: BasicsPage 3"
-      assert a4.title == "Module 2: BasicsPage 4"
+      assert a0.title == "Module 1: IntroductionPage 1"
+      assert a1.title == "Module 1: IntroductionPage 2"
+      assert a2.title == "Module 2: BasicsPage 3"
+      assert a3.title == "Module 2: BasicsPage 4"
+      assert a4.title == "Orphaned Page"
     end
 
     # NON-DETERMINISTIC: https://eliterate.atlassian.net/browse/TRIAGE-4 Fix or remove
@@ -1222,23 +1222,22 @@ defmodule OliWeb.Delivery.InstructorDashboard.ScoredActivitiesTabTest do
       section: section
     } do
       {:ok, view, _html} = live(conn, live_view_scored_activities_route(section.slug))
-      [a0, _a1, _a2, _a3, a4] = table_as_list_of_maps(view, :assessments)
 
       assert view
              |> element("tr:first-child > td:first-child > div")
-             |> render() =~ a0.order
+             |> render() =~ "1"
 
       assert view
              |> element("tr:first-child > td:nth-child(2) > div")
-             |> render() =~ a0.title
+             |> render() =~ "Page 1"
 
       assert view
              |> element("tr:last-child > td:first-child > div")
-             |> render() =~ a4.order
+             |> render() =~ "5"
 
       assert view
              |> element("tr:last-child > td:nth-child(2) > div > div")
-             |> render() =~ "Page 4"
+             |> render() =~ "Orphaned Page"
 
       view
       |> element("th[phx-value-sort_by=order]")
@@ -1246,19 +1245,19 @@ defmodule OliWeb.Delivery.InstructorDashboard.ScoredActivitiesTabTest do
 
       assert view
              |> element("tr:first-child > td:first-child > div")
-             |> render() =~ a4.order
+             |> render() =~ "5"
 
       assert view
              |> element("tr:first-child > td:nth-child(2) > div > div > a")
-             |> render() =~ "Page 4"
+             |> render() =~ "Orphaned Page"
 
       assert view
              |> element("tr:last-child > td:first-child > div")
-             |> render() =~ a0.order
+             |> render() =~ "1"
 
       assert view
              |> element("tr:last-child > td:nth-child(2) > div")
-             |> render() =~ a0.title
+             |> render() =~ "Page 1"
     end
 
     test "displays custom labels", %{
@@ -1275,11 +1274,11 @@ defmodule OliWeb.Delivery.InstructorDashboard.ScoredActivitiesTabTest do
       [a0, a1, a2, a3, a4] = table_as_list_of_maps(view, :assessments)
 
       assert has_element?(view, "h4", "Scored Activities")
-      assert a0.title == "Orphaned Page"
-      assert a1.title == "Chapter 1: IntroductionPage 1"
-      assert a2.title == "Chapter 1: IntroductionPage 2"
-      assert a3.title == "Chapter 2: BasicsPage 3"
-      assert a4.title == "Chapter 2: BasicsPage 4"
+      assert a0.title == "Chapter 1: IntroductionPage 1"
+      assert a1.title == "Chapter 1: IntroductionPage 2"
+      assert a2.title == "Chapter 2: BasicsPage 3"
+      assert a3.title == "Chapter 2: BasicsPage 4"
+      assert a4.title == "Orphaned Page"
     end
 
     test "patches url to see activity details when a row is clicked", %{
@@ -2320,11 +2319,11 @@ defmodule OliWeb.Delivery.InstructorDashboard.ScoredActivitiesTabTest do
 
       [a0, a1, a2, a3, a4] = table_as_list_of_maps(view, :assessments)
 
-      assert a0.title == "Orphaned Page"
-      assert a1.title == "Module 1: IntroductionPage 1"
-      assert a2.title == "Module 1: IntroductionPage 2"
-      assert a3.title == "Module 2: BasicsPage 3"
-      assert a4.title == "Module 2: BasicsPage 4"
+      assert a0.title == "Module 1: IntroductionPage 1"
+      assert a1.title == "Module 1: IntroductionPage 2"
+      assert a2.title == "Module 2: BasicsPage 3"
+      assert a3.title == "Module 2: BasicsPage 4"
+      assert a4.title == "Orphaned Page"
 
       # It does not display pagination options
       refute has_element?(view, "nav[aria-label=\"Paging\"]")
@@ -2347,8 +2346,8 @@ defmodule OliWeb.Delivery.InstructorDashboard.ScoredActivitiesTabTest do
       [a0, a1] = table_as_list_of_maps(view, :assessments)
 
       # Page 1
-      assert a0.title == "Orphaned Page"
-      assert a1.title == "Module 1: IntroductionPage 1"
+      assert a0.title == "Module 1: IntroductionPage 1"
+      assert a1.title == "Module 1: IntroductionPage 2"
     end
 
     test "change page size works as expected", %{
@@ -2368,8 +2367,8 @@ defmodule OliWeb.Delivery.InstructorDashboard.ScoredActivitiesTabTest do
       [a0, a1] = table_as_list_of_maps(view, :assessments)
 
       # Page 1
-      assert a0.title == "Orphaned Page"
-      assert a1.title == "Module 1: IntroductionPage 1"
+      assert a0.title == "Module 1: IntroductionPage 1"
+      assert a1.title == "Module 1: IntroductionPage 2"
 
       # Assert that the pagination options are displayed
       assert has_element?(view, "nav[aria-label=\"Paging\"]")
@@ -2382,8 +2381,8 @@ defmodule OliWeb.Delivery.InstructorDashboard.ScoredActivitiesTabTest do
       [a2, a3] = table_as_list_of_maps(view, :assessments)
 
       # Page 2
-      assert a2.title == "Module 1: IntroductionPage 2"
-      assert a3.title == "Module 2: BasicsPage 3"
+      assert a2.title == "Module 2: BasicsPage 3"
+      assert a3.title == "Module 2: BasicsPage 4"
     end
 
     test "keeps showing the same elements when changing the page size", %{
@@ -2402,8 +2401,8 @@ defmodule OliWeb.Delivery.InstructorDashboard.ScoredActivitiesTabTest do
       [a2, a3] = table_as_list_of_maps(view, :assessments)
 
       # Page 2
-      assert a2.title == "Module 1: IntroductionPage 2"
-      assert a3.title == "Module 2: BasicsPage 3"
+      assert a2.title == "Module 2: BasicsPage 3"
+      assert a3.title == "Module 2: BasicsPage 4"
 
       # Change page size from 2 to 1
       view
@@ -2413,7 +2412,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.ScoredActivitiesTabTest do
       [a2] = table_as_list_of_maps(view, :assessments)
 
       # Page 3. It keeps showing the same element.
-      assert a2.title == "Module 1: IntroductionPage 2"
+      assert a2.title == "Module 2: BasicsPage 3"
     end
   end
 end

--- a/test/oli_web/live/sections/assessment_settings/settings_live_test.exs
+++ b/test/oli_web/live/sections/assessment_settings/settings_live_test.exs
@@ -359,6 +359,20 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
       ContextRoles.get_role(:context_instructor)
     ])
 
+    Sections.get_section_resource(section.id, page_4_revision.resource_id)
+    |> Sections.update_section_resource(%{
+      scheduling_type: :due_by,
+      start_date: ~U[2024-12-18 20:00:00Z],
+      end_date: ~U[2024-12-25 20:00:00Z]
+    })
+
+    Sections.get_section_resource(section.id, page_2_revision.resource_id)
+    |> Sections.update_section_resource(%{
+      scheduling_type: :due_by,
+      start_date: ~U[2024-12-20 20:00:00Z],
+      end_date: ~U[2024-12-22 20:00:00Z]
+    })
+
     %{
       section: section,
       page_1: page_1_revision,
@@ -783,9 +797,21 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
          %{
            conn: conn,
            section: section,
-           page_3: page_3
+           page_1: page_1,
+           page_2: page_2,
+           page_3: page_3,
+           page_4: page_4
          } do
       {:ok, view, _html} = live(conn, live_view_overview_route(section.slug, "settings", "all"))
+
+      # Reset start and end dates for all assessments
+      for page <- [page_1, page_2, page_3, page_4] do
+        Sections.get_section_resource(section.id, page.resource.id)
+        |> Sections.update_section_resource(%{
+          start_date: nil,
+          end_date: nil
+        })
+      end
 
       [assessment_1, assessment_2, assessment_3, assessment_4] =
         table_as_list_of_maps(view, :settings)
@@ -899,7 +925,14 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
     test "can be sorted", %{conn: conn, section: section, page_3: page_3} do
       {:ok, view, _html} = live(conn, live_view_overview_route(section.slug, "settings", "all"))
 
-      [initial_a1, initial_a2, initial_a3, initial_a4] = table_as_list_of_maps(view, :settings)
+      assessments =
+        [initial_a1, initial_a2, initial_a3, initial_a4] = table_as_list_of_maps(view, :settings)
+
+      # Default sort is by index descendent
+      for {assessment, index} <- Enum.with_index(assessments, 1) do
+        assert assessment.index == "#{index}"
+        assert assessment.name == "Page #{index}"
+      end
 
       view
       |> element("th[phx-value-sort_by=index]")
@@ -931,6 +964,48 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
       assert sorted_2.late_policy == "Allow late start and late submit"
       assert sorted_3.late_policy == "Allow late start and late submit"
       assert sorted_4.late_policy == "Allow late start and late submit"
+    end
+
+    test "can be sorted by date", %{conn: conn, section: section} do
+      {:ok, view, _html} = live(conn, live_view_overview_route(section.slug, "settings", "all"))
+
+      # Sort by available date
+      view
+      |> element("th[phx-value-sort_by=available_date]")
+      |> render_click()
+
+      [sorted_1, sorted_2, sorted_3, sorted_4] = table_as_list_of_maps(view, :settings)
+
+      assert sorted_1.name == "Page 1"
+      assert sorted_1.available_date == "Always available"
+
+      assert sorted_2.name == "Page 3"
+      assert sorted_2.available_date == "Always available"
+
+      assert sorted_3.name == "Page 4"
+      assert sorted_3.available_date == "December 18, 2024 8:00 PM UTC"
+
+      assert sorted_4.name == "Page 2"
+      assert sorted_4.available_date == "December 20, 2024 8:00 PM UTC"
+
+      # Sort by due date
+      view
+      |> element("th[phx-value-sort_by=due_date]")
+      |> render_click()
+
+      [sorted_1, sorted_2, sorted_3, sorted_4] = table_as_list_of_maps(view, :settings)
+
+      assert sorted_1.name == "Page 1"
+      assert sorted_1.due_date == "No due date"
+
+      assert sorted_2.name == "Page 3"
+      assert sorted_2.due_date == "No due date"
+
+      assert sorted_3.name == "Page 2"
+      assert sorted_3.due_date == "December 22, 2024 8:00 PM UTC"
+
+      assert sorted_4.name == "Page 4"
+      assert sorted_4.due_date == "December 25, 2024 8:00 PM UTC"
     end
 
     test "can be paginated", %{
@@ -1337,11 +1412,17 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
          %{
            conn: conn,
            section: section,
-           page_1: page_1
+           page_1: page_1,
+           page_2: page_2
          } do
       Sections.get_section_resource(section.id, page_1.resource.id)
       |> Sections.update_section_resource(%{
         start_date: ~U[2023-10-10 16:00:00Z]
+      })
+
+      Sections.get_section_resource(section.id, page_2.resource.id)
+      |> Sections.update_section_resource(%{
+        start_date: nil
       })
 
       {:ok, view, _html} = live(conn, live_view_overview_route(section.slug, "settings", "all"))
@@ -1353,7 +1434,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
       assert assessment_2.available_date =~ "Always available"
     end
 
-    test "due date date can be changed by clicking the due date in the table",
+    test "due date can be changed by clicking the due date in the table",
          %{
            conn: conn,
            section: section,
@@ -1497,7 +1578,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
       assert assessment_2.due_date =~ "No due date"
     end
 
-    test "Changing an assessment setting persists that action in the database", %{
+    test "changing an assessment setting persists that action in the database", %{
       conn: conn,
       section: section,
       page_1: page_1


### PR DESCRIPTION
[MER-3122](https://eliterate.atlassian.net/browse/MER-3122)

Fix default sorting on the Assessment Settings table to respect the order of pages in the course.
Fix available dates and due dates sorting.

**Before:**

https://github.com/user-attachments/assets/56dc7dea-a892-46f6-a964-c8147b1f5674

**After:**


https://github.com/user-attachments/assets/9b48c010-a93a-4535-bb65-df88ebecec51



[MER-3122]: https://eliterate.atlassian.net/browse/MER-3122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ