### PR TITLE
[BUG FIX] [MER-4122] Restore superactivity state on instructor review of student solution

### DIFF
--- a/lib/oli_web/controllers/legacy_superactivity_controller.ex
+++ b/lib/oli_web/controllers/legacy_superactivity_controller.ex
@@ -33,6 +33,7 @@ defmodule OliWeb.LegacySuperactivityController do
       :activity_attempt,
       :resource_attempt,
       :resource_access,
+      :attempt_user_id,
       :save_files,
       :instructors,
       :enrollment,
@@ -116,6 +117,9 @@ defmodule OliWeb.LegacySuperactivityController do
 
     resource_access = Attempts.get_resource_access(resource_attempt.resource_access_id)
 
+    # different than current user when instructor reviews student attempt
+    attempt_user_id = resource_access.user_id
+
     section =
       Sections.get_section_preloaded!(resource_access.section_id)
       |> Repo.preload([:institution, :section_project_publications])
@@ -134,7 +138,7 @@ defmodule OliWeb.LegacySuperactivityController do
     save_files =
       ActivityLifecycle.get_activity_attempt_save_files(
         activity_attempt.attempt_guid,
-        Integer.to_string(user.id),
+        Integer.to_string(attempt_user_id),
         activity_attempt.attempt_number
       )
 
@@ -147,6 +151,7 @@ defmodule OliWeb.LegacySuperactivityController do
       activity_attempt: activity_attempt,
       resource_attempt: resource_attempt,
       resource_access: resource_access,
+      attempt_user_id: attempt_user_id,
       save_files: save_files,
       instructors: instructors,
       enrollment: enrollment,
@@ -338,19 +343,20 @@ defmodule OliWeb.LegacySuperactivityController do
 
   defp process_command(
          "loadFileRecord",
-         %LegacySuperactivityContext{} = _context,
+         %LegacySuperactivityContext{} = context,
          %{
            "activityContextGuid" => attempt_guid
          } = params
        ) do
     file_name = Map.get(params, "fileName")
     attempt_number = Map.get(params, "attemptNumber")
-    user_id = Map.get(params, "userGuid")
+    # use attempt_user from context to allow for instructor review of student work
+    attempt_user_id = context.attempt_user_id
 
     save_file =
       ActivityLifecycle.get_activity_attempt_save_file(
         attempt_guid,
-        user_id,
+        Integer.to_string(attempt_user_id),
         attempt_number,
         file_name
       )


### PR DESCRIPTION
On the migrated stattutor superactivity in the Alvin statistics course, instructors reviewing student attempts were seeing the problem load successfully, but the student's saved solution state was not being restored, preventing them from seeing what the student had entered. This apparently stemmed from a general problem in the superactivity support: Tutor-saved state files used to restore state are fetched (in part) by user id, and the files were being fetched using the id of the currently logged in user. So, when instructors were current logged in users, the student's solution files were not being found. and no saved file info was included in the BeginSession command response sent to the client. Because of this, the client behaved as if there was no saved solution file to restore. 

This PR modifies the code to find the "attempt_user_id", the id of the user associated with the attempt, add that to the supearactivity context, and use that id when fetching saved files for the student attempt.

As written this will be done in all cases of fetching solution files -- it will fetch the ones associated with the attempt, regardless of user. That seems to be what we want. It is not clear to me if user ids need to be associated with these files at all, or included in any queries for them. After all, if the attempt guid is globally unique that should be sufficient by itself to find the files. But that is how they are currently stored and fetched.