### PR TITLE
[BUG FIX] [MER-4121] Remove top-level objectives pre-filter

### DIFF
--- a/lib/oli_web/components/delivery/learning_objectives/learning_objectives.ex
+++ b/lib/oli_web/components/delivery/learning_objectives/learning_objectives.ex
@@ -560,9 +560,7 @@ defmodule OliWeb.Components.Delivery.LearningObjectives do
   end
 
   defp apply_filters(objectives, params, :instructor_dashboard) do
-    # Only show top-level objectives on initial table
     objectives
-    |> Enum.filter(fn o -> o.resource_id == o.objective_resource_id end)
     |> do_apply_filters(params)
   end
 


### PR DESCRIPTION
Ticket: [MER-4121](https://eliterate.atlassian.net/browse/MER-4121)

This PR removes the top-level objectives pre-filter. With this change, we now target all objectives.

https://github.com/user-attachments/assets/c5ce00ba-fdd8-4798-b1b6-b72882efd086


[MER-4121]: https://eliterate.atlassian.net/browse/MER-4121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ