### PR TITLE
[BUG FIX] [MER-4124] broken internal page links

### DIFF
--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -726,25 +726,16 @@ defmodule Oli.Rendering.Content.Html do
          opts \\ []
        ) do
     href =
-      cond do
-        section_slug in [nil, project_slug] ->
-          case mode do
-            :author_preview ->
-              "/authoring/project/#{project_slug}/preview/#{revision_slug_from_course_link(href)}"
+      case mode do
+        :author_preview ->
+          ~p"/authoring/project/#{project_slug}/preview/#{revision_slug_from_course_link(href)}"
 
-            _ ->
-              "#"
-          end
+        # rewrite internal link using section slug and revision slug
+        :instructor_preview ->
+          ~p"/sections/#{section_slug}/preview/page/#{revision_slug_from_course_link(href)}"
 
-        section_slug != project_slug ->
-          # rewrite internal link using section slug and revision slug
-          case mode do
-            :instructor_preview ->
-              "/sections/#{section_slug}/preview/page/#{revision_slug_from_course_link(href)}"
-
-            _ ->
-              ~p"/sections/#{section_slug}/lesson/#{revision_slug_from_course_link(href)}?#{context.page_link_params}"
-          end
+        _ ->
+          ~p"/sections/#{section_slug}/lesson/#{revision_slug_from_course_link(href)}?#{context.page_link_params}"
       end
 
     target_rel =


### PR DESCRIPTION
Internal page links were not rendered correctly in the case where the project slug was the same as the section slug.  I conjecture that code was using this equality to detect authoring mode, because dummy section slug is set to project slug in that case.  But it can arise in delivery as well, on the first section created with the same title as the authoring project, which is very common in testing, but certainly possible in real courses as well. 

This recodes the logic to simply switch on the mode from the rendering context, which seems like it should be sufficient. 