### PR TITLE
[BUG FIX] [MER-4120] One at a time setting can prevent submissions

### DIFF
--- a/lib/oli_web/live/delivery/student/lesson/components/one_at_a_time_question.ex
+++ b/lib/oli_web/live/delivery/student/lesson/components/one_at_a_time_question.ex
@@ -67,7 +67,10 @@ defmodule OliWeb.Delivery.Student.Lesson.Components.OneAtATimeQuestion do
               class="w-[187.52px] h-[30px] px-5 py-2.5 bg-[#0062f2] rounded-md shadow justify-center items-center gap-2.5 inline-flex"
             >
               <div class="justify-end items-center gap-2 flex">
-                <div class="opacity-90 text-right text-white text-sm font-semibold leading-[14px] whitespace-nowrap">
+                <div
+                  id="submit_answers"
+                  class="opacity-90 text-right text-white text-sm font-semibold leading-[14px] whitespace-nowrap"
+                >
                   Yes, Finish The Attempt
                 </div>
               </div>


### PR DESCRIPTION
[MER-4120](https://eliterate.atlassian.net/browse/MER-4120)

This PR fixes the bug where the auto submit of a page was not working in case the page has a due date and the presentation was `one at a time`. 

With these changes, even if the page has the presentation as `one at a time` if it has a stipulated due date, it will auto submit when the time limit is reached, as it already happens with pages that have a traditional presentation.


https://github.com/user-attachments/assets/90949bb7-0f0c-4523-b5ce-ca4edfeec997



[MER-4120]: https://eliterate.atlassian.net/browse/MER-4120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ