### PR TITLE
[BUG FIX] [MER-4126] Fix targeted retake one question at a time

### DIFF
--- a/lib/oli/delivery/attempts/page_lifecycle/hierarchy.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/hierarchy.ex
@@ -94,7 +94,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Hierarchy do
        do: []
 
   defp construct_attempt_prototypes(%VisitContext{
-         effective_settings: %{retake_mode: :targeted, assessment_mode: :traditional},
+         effective_settings: %{retake_mode: :targeted},
          latest_resource_attempt: latest_resource_attempt,
          page_revision: %Revision{graded: true} = page_revision
        }) do


### PR DESCRIPTION
[MER-4126](https://eliterate.atlassian.net/browse/MER-4126)

This PR aims to fix the retake mode `targeted` for pages that have the `one at a time` display configured.

This already worked correctly with the pages that have the presentation configured as `traditional`.

https://github.com/user-attachments/assets/c70b0317-5bfd-42e4-8684-e868b5781772




[MER-4126]: https://eliterate.atlassian.net/browse/MER-4126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ