### PR TITLE
[BUG FIX] [MER-4123] Fix high progress low proficiency filter

### DIFF
--- a/lib/oli_web/components/delivery/content/content.ex
+++ b/lib/oli_web/components/delivery/content/content.ex
@@ -37,12 +37,11 @@ defmodule OliWeb.Components.Delivery.Content do
 
   def update(%{containers: {container_count, containers}} = assigns, socket) do
     params =
-      if container_count == 0 do
-        decode_params(assigns.params)
-        |> Map.merge(%{container_filter_by: :pages})
-      else
-        decode_params(assigns.params)
-      end
+      if container_count == 0,
+        do:
+          decode_params(assigns.params)
+          |> Map.merge(%{container_filter_by: :pages}),
+        else: decode_params(assigns.params)
 
     {total_count, column_name, rows} = apply_filters(containers, params)
 
@@ -122,7 +121,8 @@ defmodule OliWeb.Components.Delivery.Content do
        proficiency_options: proficiency_options,
        selected_proficiency_options: selected_proficiency_options,
        selected_proficiency_ids: selected_proficiency_ids,
-       params_from_url: assigns.params
+       params_from_url: assigns.params,
+       disable_containers_filter: container_count == 0
      )}
   end
 
@@ -134,6 +134,7 @@ defmodule OliWeb.Components.Delivery.Content do
   attr(:view, :atom)
   attr(:section_slug, :string)
   attr(:card_props, :list)
+  attr(:disable_containers_filter, :boolean)
 
   def render(assigns) do
     ~H"""
@@ -145,6 +146,7 @@ defmodule OliWeb.Components.Delivery.Content do
           phx-click="filter_container"
           phx-value-filter="units"
           phx-target={@myself}
+          disabled={@disable_containers_filter}
         >
           Units
         </button>
@@ -154,6 +156,7 @@ defmodule OliWeb.Components.Delivery.Content do
           phx-click="filter_container"
           phx-value-filter="modules"
           phx-target={@myself}
+          disabled={@disable_containers_filter}
         >
           Modules
         </button>
@@ -593,6 +596,9 @@ defmodule OliWeb.Components.Delivery.Content do
         pages =
           containers
           |> maybe_filter_by_text(params.text_search)
+          |> maybe_filter_by_card(params.selected_card_value)
+          |> maybe_filter_by_progress(params.progress_selector, params.progress_percentage)
+          |> maybe_filter_by_proficiency(params.selected_proficiency_ids)
           |> sort_by(params.sort_by, params.sort_order)
 
         {length(pages), "PAGES", pages |> Enum.drop(params.offset) |> Enum.take(params.limit)}
@@ -731,8 +737,12 @@ defmodule OliWeb.Components.Delivery.Content do
     )
   end
 
+  defp set_button_background(:pages, _filter), do: "bg-gray-100 dark:bg-gray-800"
+
   defp set_button_background(container_filter_by, filter),
     do: if(container_filter_by == filter, do: "bg-blue-500 dark:bg-gray-800", else: "bg-white")
+
+  defp set_button_text(:pages, _filter), do: "text-gray-700 dark:text-white cursor-not-allowed"
 
   defp set_button_text(container_filter_by, filter),
     do:


### PR DESCRIPTION
[MER-4123](https://eliterate.atlassian.net/browse/MER-4123)

This PR solves the existing problem of the filters in the `content` tab of the `instructor dashboard` whereby if there were no units or modules in the course content, but only pages without containers, the filters did not work correctly. 

In addition, if the case happens that there are only pages in the course content, without containers, the buttons for filtering by modules or units are disabled.


https://github.com/user-attachments/assets/fa914021-8489-4590-9c44-6cce7c6bbb2e



[MER-4123]: https://eliterate.atlassian.net/browse/MER-4123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ