### PR TITLE
[BUG FIX] [MER-4127] Fix Learning Objectives Proficiency Distribution Hover Boundary

### DIFF
--- a/lib/oli_web/components/delivery/learning_objectives/objectives_table_model.ex
+++ b/lib/oli_web/components/delivery/learning_objectives/objectives_table_model.ex
@@ -142,7 +142,7 @@ defmodule OliWeb.Delivery.LearningObjectives.ObjectivesTableModel do
     ~H"""
     <div class="group flex relative">
       <%= render_proficiency_data_chart(@objective_id, @proficiency_distribution) %>
-      <div class="absolute left-1/2 -translate-x-1/2 -translate-y-full bg-black text-white text-sm px-4 py-2 rounded-lg opacity-0 group-hover:opacity-100 transition-opacity shadow-lg whitespace-nowrap inline-block">
+      <div class="-translate-y-[calc(100%-90px)] absolute left-1/2 -translate-x-1/2 bg-black text-white text-sm px-4 py-2 rounded-lg opacity-0 group-hover:opacity-100 transition-opacity shadow-lg whitespace-nowrap inline-block z-50">
         <%= for {label, value} <- calc_percentages(@proficiency_distribution) do %>
           <p><%= label %>: <%= value %>%</p>
         <% end %>


### PR DESCRIPTION
Fixed boundary miscalculation of Proficiency Distribution tooltip and increased stacking context for proper visibility.

See: https://eliterate.atlassian.net/browse/MER-4127


https://github.com/user-attachments/assets/0c688b09-b403-4249-ab5a-a55085d347e2

