### PR TITLE
[ENHANCEMENT] [MER-4142] construct targeted feedback map for migrated ordering questions that lack it

### DIFF
--- a/assets/src/data/activities/model/rules.ts
+++ b/assets/src/data/activities/model/rules.ts
@@ -240,8 +240,10 @@ export const makeRule = (input: Input): string => {
   throw new Error('Could not make numeric rule for input: ' + input);
 };
 
-const parseSingleRule = (rule: string) =>
-  Maybe.maybe(rule.substring(rule.indexOf('{') + 1, rule.lastIndexOf('}')));
+export const ruleValue = (rule: string) =>
+  rule.substring(rule.indexOf('{') + 1, rule.lastIndexOf('}'));
+
+const parseSingleRule = (rule: string) => Maybe.maybe(ruleValue(rule));
 
 const parseRegex = (rule: string, regex: RegExp) => Maybe.maybe(rule.match(regex));
 


### PR DESCRIPTION
Migration tool output did not fill in the targeted feedback map for ordering questions (a bug), so for migrated courses, any targeted feedback included on ordering questions was not displayed -- so not editable or deletable -- in torus authoring. This was particularly a problem for Evidence Based Management where some ordering questions included auto-generated targeted feedbacks for every possible ordering response. In this case, the invisible targeted feedbacks prevented the catchall incorrect feedback from ever being delivered, making it appear that attempted edits to the incorrect feedback were not taking effect.

This change has torus authoring work around the migration error by filling in the targeted feedback map from the response list at runtime if needed. This repair is done at the point where any model version transformations are checked for and applied. 

Strictly speaking, including the targeted feedback map is unnecessary and ideally it should not exist: all the information needed could just be derived as needed from the response list (some has to be parsed out of response rules, but that is easy). So we could in theory re-implement all targeted feedback UI to do without it. But that would be a big change. The above fix is simple and minimizes code changes. 

Because this used getCorrectAnswer, the PR also includes a small change to getCorrectAnswer to account for possible non-default scoring by choosing the maximum point valued response in the response list as the primary correct response for feedback editing. That appears to be what we want in this case.