### PR TITLE
[BUG FIX] [MER-4141] Course sections cannot be created

### DIFF
--- a/lib/oli_web/live/new_course/new_course.ex
+++ b/lib/oli_web/live/new_course/new_course.ex
@@ -321,7 +321,8 @@ defmodule OliWeb.Delivery.NewCourse do
               has_experiments: has_experiments,
               analytics_version: :v2,
               welcome_title: project.welcome_title,
-              encouraging_subtitle: project.encouraging_subtitle
+              encouraging_subtitle: project.encouraging_subtitle,
+              certificate: nil
             })
 
           case create_from_publication(socket, publication, section_params) do


### PR DESCRIPTION
[MER-4141](https://eliterate.atlassian.net/browse/MER-4141)

This is a small fix to ensure that instructors are able to create course sections from a base project.

Apparently this bug is happening in Tokamak.




[MER-4141]: https://eliterate.atlassian.net/browse/MER-4141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ