### PR TITLE
 [FEATURE] [MER-3794] Granted Certificates PDF generation via AWS Lambda

### DIFF
--- a/lib/oli/delivery/granted_certificates.ex
+++ b/lib/oli/delivery/granted_certificates.ex
@@ -1,0 +1,45 @@
+defmodule Oli.Delivery.GrantedCertificates do
+  @moduledoc """
+  The Granted Certificates context
+  """
+
+  alias Ecto.Changeset
+  alias ExAws.Lambda
+  alias Oli.Delivery.Sections.GrantedCertificate
+  alias Oli.{HTTP, Repo}
+
+  # TODO: Change once we know where we'll generate the granted certificate HTML
+  @certificate_html ""
+
+  @generate_pdf_lambda_function "generate_certificate_pdf_from_html"
+
+  def generate_pdf(granted_certificate_id) do
+    case Repo.get(GrantedCertificate, granted_certificate_id) do
+      nil ->
+        {:error, :granted_certificate_not_found}
+
+      %GrantedCertificate{url: url} when not is_nil(url) ->
+        {:error, :granted_certificate_already_has_url}
+
+      gc ->
+        @generate_pdf_lambda_function
+        |> Lambda.invoke(%{certificate_id: gc.guid, html: @certificate_html}, %{})
+        |> aws_request()
+        |> case do
+          {:error, error} ->
+            {:error, :invoke_lambda_error, error}
+
+          {:ok, result} ->
+            if result["statusCode"] == 200 do
+              gc
+              |> Changeset.change(url: result["body"]["s3Path"])
+              |> Repo.update()
+            else
+              {:error, :error_generating_pdf, result}
+            end
+        end
+    end
+  end
+
+  defp aws_request(operation), do: apply(HTTP.aws(), :request, [operation])
+end

--- a/lib/oli/delivery/sections/granted_certificate.ex
+++ b/lib/oli/delivery/sections/granted_certificate.ex
@@ -15,6 +15,7 @@ defmodule Oli.Delivery.Sections.GrantedCertificate do
     field :issued_by, :integer
     field :issued_by_type, Ecto.Enum, values: @issued_by_type_enum, default: :user
     field :issued_at, :utc_datetime
+    field :url, :string
 
     belongs_to :certificate, Certificate
     belongs_to :user, User
@@ -23,7 +24,7 @@ defmodule Oli.Delivery.Sections.GrantedCertificate do
   end
 
   @required_fields [:user_id, :certificate_id, :state, :with_distinction, :guid]
-  @optional_fields [:issued_by, :issued_by_type, :issued_at]
+  @optional_fields [:issued_by, :issued_by_type, :issued_at, :url]
 
   @all_fields @required_fields ++ @optional_fields
 

--- a/priv/repo/migrations/20250108052504_add_url_to_granted_certificates.exs
+++ b/priv/repo/migrations/20250108052504_add_url_to_granted_certificates.exs
@@ -1,0 +1,9 @@
+defmodule Oli.Repo.Migrations.AddUrlToGrantedCertificates do
+  use Ecto.Migration
+
+  def change do
+    alter table(:granted_certificates) do
+      add :url, :string
+    end
+  end
+end

--- a/test/oli/delivery/granted_certificates_test.exs
+++ b/test/oli/delivery/granted_certificates_test.exs
@@ -1,0 +1,43 @@
+defmodule Oli.Delivery.GrantedCertificatesTest do
+  use Oli.DataCase, async: true
+
+  import Mox
+  import Oli.Factory
+
+  alias Oli.Delivery.GrantedCertificates
+  alias Oli.Delivery.Sections.GrantedCertificate
+
+  describe "generate_pdf/1" do
+    test "generates a pdf certificate in a lambda function and stores the url" do
+      gc = insert(:granted_certificate)
+
+      assert gc.url == nil
+
+      expect(Oli.Test.MockAws, :request, 1, fn operation ->
+        assert operation.data.certificate_id == gc.guid
+        {:ok, %{"statusCode" => 200, "body" => %{"s3Path" => "foo/bar"}}}
+      end)
+
+      assert {:ok, _multi} = GrantedCertificates.generate_pdf(gc.id)
+      assert Repo.get(GrantedCertificate, gc.id).url == "foo/bar"
+    end
+
+    test "does not generate a pdf if granted certificate already has a url" do
+      gc = insert(:granted_certificate, url: "foo/bar")
+      expect(Oli.Test.MockAws, :request, 0, fn _ -> :noop end)
+
+      assert {:error, :granted_certificate_already_has_url} =
+               GrantedCertificates.generate_pdf(gc.id)
+    end
+
+    test "fails if aws operation fails" do
+      gc = insert(:granted_certificate)
+
+      expect(Oli.Test.MockAws, :request, 1, fn _operation ->
+        {:ok, %{"statusCode" => 500, "body" => %{"error" => "Internal server error"}}}
+      end)
+
+      assert {:error, :error_generating_pdf, _} = GrantedCertificates.generate_pdf(gc.id)
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -17,6 +17,7 @@ defmodule Oli.Factory do
   alias Oli.Branding.Brand
   alias Oli.Delivery.Page.PageContext
   alias Oli.Delivery.Sections.Certificate
+  alias Oli.Delivery.Sections.GrantedCertificate
   alias Oli.Delivery.Sections.ContainedObjective
 
   alias Oli.Delivery.Attempts.Core.{
@@ -652,6 +653,14 @@ defmodule Oli.Factory do
     %Certificate{
       title: "#{sequence("certificate")}",
       section: anonymous_build(:section)
+    }
+  end
+
+  def granted_certificate_factory() do
+    %GrantedCertificate{
+      guid: UUID.uuid4(),
+      user: build(:user),
+      certificate: build(:certificate)
     }
   end
 


### PR DESCRIPTION
Wrapper function that calls the AWS Lambda function that given an HTML generates a PDF and stores it in S3 so later it can be viewed by anyone that wants to check if a given certification has been granted.