### PR TITLE
[BUG FIX] [MER-4131] Dig into chem labs simulations

### DIFF
--- a/assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx
+++ b/assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx
@@ -29,6 +29,7 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
   const [scriptEnv, setScriptEnv] = useState<any>();
   // model items, note that we use default values now because
   // the delay from parsing the json means we can't set them from the model immediately
+  const [randomizeLessonId, setrandomizeLessonId] = useState<boolean>(false);
   const [frameX, setFrameX] = useState<number>(0);
   const [frameY, setFrameY] = useState<number>(0);
   const [frameZ, setFrameZ] = useState<number>(0);
@@ -172,6 +173,10 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
     if (sVisible !== undefined) {
       setFrameVisible(parseBool(sVisible));
     }
+    const srandomizeLessonId = currentStateSnapshot[`${domain}.${id}.IFRAME_randomizeLessonId`];
+    if (srandomizeLessonId !== undefined) {
+      setrandomizeLessonId(parseBool(srandomizeLessonId));
+    }
 
     const sX = currentStateSnapshot[`${domain}.${id}.IFRAME_frameX`];
     if (sX !== undefined) {
@@ -263,6 +268,11 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
     const sVisible = currentStateSnapshot[`${domain}.${id}.IFRAME_frameVisible`];
     if (sVisible !== undefined) {
       setFrameVisible(parseBool(sVisible));
+    }
+
+    const srandomizeLessonId = currentStateSnapshot[`${domain}.${id}.IFRAME_randomizeLessonId`];
+    if (srandomizeLessonId !== undefined) {
+      setrandomizeLessonId(parseBool(srandomizeLessonId));
     }
 
     const sX = currentStateSnapshot[`${domain}.${id}.IFRAME_frameX`];
@@ -657,7 +667,9 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
     // taken from simcapi.js TODO move somewhere, use from settings
     simLife.handshake.config = {
       context: context,
-      lessonId,
+      lessonId: randomizeLessonId
+        ? `${lessonId}_${Math.floor(Math.random() * 100)}_${Math.floor(Math.random() * 100)}`
+        : lessonId,
       questionId,
       sectionSlug,
       userId: currentUserId,
@@ -915,6 +927,12 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
     if (visibility) {
       setFrameVisible(parseBool(visibility.value));
     }
+
+    const srandomizeLessonId = interested.find((v) => v.key === 'IFRAME_randomizeLessonId');
+    if (srandomizeLessonId !== undefined) {
+      setrandomizeLessonId(parseBool(srandomizeLessonId));
+    }
+
     const xPos = interested.find((v) => v.key === 'IFRAME_frameX');
     if (xPos) {
       setFrameX(xPos.value);

--- a/assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx
+++ b/assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx
@@ -29,7 +29,7 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
   const [scriptEnv, setScriptEnv] = useState<any>();
   // model items, note that we use default values now because
   // the delay from parsing the json means we can't set them from the model immediately
-  const [randomizeLessonId, setrandomizeLessonId] = useState<boolean>(false);
+  const [uniqueLessonId, setUniqueLessonId] = useState<boolean>(false);
   const [frameX, setFrameX] = useState<number>(0);
   const [frameY, setFrameY] = useState<number>(0);
   const [frameZ, setFrameZ] = useState<number>(0);
@@ -173,9 +173,9 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
     if (sVisible !== undefined) {
       setFrameVisible(parseBool(sVisible));
     }
-    const srandomizeLessonId = currentStateSnapshot[`${domain}.${id}.IFRAME_randomizeLessonId`];
-    if (srandomizeLessonId !== undefined) {
-      setrandomizeLessonId(parseBool(srandomizeLessonId));
+    const sUniqueLessonId = currentStateSnapshot[`${domain}.${id}.LESSON_ID_UNIQUE`];
+    if (sUniqueLessonId !== undefined) {
+      setUniqueLessonId(parseBool(sUniqueLessonId));
     }
 
     const sX = currentStateSnapshot[`${domain}.${id}.IFRAME_frameX`];
@@ -270,9 +270,9 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
       setFrameVisible(parseBool(sVisible));
     }
 
-    const srandomizeLessonId = currentStateSnapshot[`${domain}.${id}.IFRAME_randomizeLessonId`];
-    if (srandomizeLessonId !== undefined) {
-      setrandomizeLessonId(parseBool(srandomizeLessonId));
+    const sUniqueLessonId = currentStateSnapshot[`${domain}.${id}.LESSON_ID_UNIQUE`];
+    if (sUniqueLessonId !== undefined) {
+      setUniqueLessonId(parseBool(sUniqueLessonId));
     }
 
     const sX = currentStateSnapshot[`${domain}.${id}.IFRAME_frameX`];
@@ -667,9 +667,7 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
     // taken from simcapi.js TODO move somewhere, use from settings
     simLife.handshake.config = {
       context: context,
-      lessonId: randomizeLessonId
-        ? `${lessonId}_${Math.floor(Math.random() * 100)}_${Math.floor(Math.random() * 100)}`
-        : lessonId,
+      lessonId: uniqueLessonId ? `${lessonId}_${guid()}` : lessonId,
       questionId,
       sectionSlug,
       userId: currentUserId,
@@ -928,9 +926,9 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
       setFrameVisible(parseBool(visibility.value));
     }
 
-    const srandomizeLessonId = interested.find((v) => v.key === 'IFRAME_randomizeLessonId');
-    if (srandomizeLessonId !== undefined) {
-      setrandomizeLessonId(parseBool(srandomizeLessonId));
+    const sUniqueLessonId = interested.find((v) => v.key === 'LESSON_ID_UNIQUE');
+    if (sUniqueLessonId !== undefined) {
+      setUniqueLessonId(parseBool(sUniqueLessonId));
     }
 
     const xPos = interested.find((v) => v.key === 'IFRAME_frameX');


### PR DESCRIPTION
Hey @bsparks, could you please look at the PR? Thanks.

The state of these SIMs is saved within the SIM itself and is linked to the repository: `git@github.com:SmartSparrow/componentLibrary-Redux.git#~2`.

During my investigation, I discovered that the state is maintained at the lesson ID level. This means that when a student restarts a lesson, the SIM retrieves the state for that lesson rather than resetting itself.

I also found that appending a random number to the lesson ID causes the SIM to reset, as it perceives it as a new lesson.

To address this, we introduced an iframe property called `IFRAME_randomizeLessonId`, similar to `IFRAME_frameVisible`. In authoring, if this property is set to `true`, we append a random number to the lesson ID. This ensures that when a new attempt is started, the SIM resets itself. 

In the initial state, we set the property to `true` and then use a mutate state action to set its value to `false`.