### PR TITLE
[ENHANCEMENT] [MER-4111] Define AI trigger types & add to elements

### DIFF
--- a/assets/src/components/activities/types.ts
+++ b/assets/src/components/activities/types.ts
@@ -3,6 +3,7 @@ import { Model } from 'data/content/model/elements/factories';
 import { ModelElement, TextDirection } from 'data/content/model/elements/types';
 import { ID, Identifiable } from 'data/content/model/other';
 import { EditorType, ResourceContext } from 'data/content/resource';
+import { ActivityTrigger } from 'data/triggers';
 import { ResourceId } from 'data/types';
 import guid from 'utils/guid';
 import { PathOperation } from 'utils/pathOperations';
@@ -581,6 +582,7 @@ export interface Part extends Identifiable {
   outOf?: null | number;
   incorrectScore?: null | number;
   targets?: string[];
+  triggers?: ActivityTrigger[];
 }
 
 /**

--- a/assets/src/data/content/resource.ts
+++ b/assets/src/data/content/resource.ts
@@ -7,6 +7,7 @@ import { ModelElement, TextDirection } from 'data/content/model/elements/types';
 import { Objective } from 'data/content/objective';
 import { Tag } from 'data/content/tags';
 import { ActivityWithReportOption } from 'data/persistence/resource';
+import { ContentBlockTrigger, GroupTrigger, PageTrigger } from 'data/triggers';
 import { ActivitySlug, ActivityTypeSlug, ProjectSlug, ResourceId, ResourceSlug } from 'data/types';
 import guid from 'utils/guid';
 import { getDefaultTextDirection } from 'utils/useDefaultTextDirection';
@@ -15,6 +16,7 @@ import { ActivityEditContext } from './activity';
 export type PageContent = {
   model: ResourceContent[];
   bibrefs?: string[];
+  trigger?: PageTrigger;
   [key: string]: any;
 };
 
@@ -288,6 +290,7 @@ export interface StructuredContent {
   children: ModelElement[];
   editor?: EditorType;
   textDirection?: TextDirection;
+  trigger?: ContentBlockTrigger;
 }
 
 export const DEFAULT_EDITOR: EditorType = 'slate';
@@ -325,6 +328,7 @@ export interface PurposeGroupContent {
   purpose: string;
   audience?: AudienceMode;
   paginationMode?: PaginationMode;
+  trigger?: GroupTrigger;
   children: Immutable.List<ResourceContent>;
 }
 

--- a/assets/src/data/triggers.ts
+++ b/assets/src/data/triggers.ts
@@ -1,0 +1,42 @@
+/**
+ * AI Trigger Types
+ */
+
+export interface IsTrigger {
+  type: 'trigger';
+  trigger_type: string;
+  prompt: string;
+}
+
+export type Trigger = ActivityTrigger | ContentTrigger;
+
+export type ActivityTrigger =
+  | {
+      trigger_type: 'correct_answer' | 'incorrect_answer' | 'explanation';
+    }
+  | HintTrigger
+  | TargetedFeedbackTrigger;
+
+export interface TargetedFeedbackTrigger extends IsTrigger {
+  trigger_type: 'targeted_feedback';
+  response_id: string;
+}
+
+export interface HintTrigger extends IsTrigger {
+  trigger_type: 'hint';
+  hint_number: number; // 1-based ordinal
+}
+
+export type ContentTrigger = PageTrigger | GroupTrigger | ContentBlockTrigger;
+
+export interface PageTrigger extends IsTrigger {
+  trigger_type: 'page';
+}
+
+export interface GroupTrigger extends IsTrigger {
+  trigger_type: 'group';
+}
+
+export interface ContentBlockTrigger extends IsTrigger {
+  trigger_type: 'content';
+}


### PR DESCRIPTION
Adds Typescript definitions for AI trigger point types and adds optional trigger attributes to activity parts and relevant content element definitions (page, group, content block). Placed in new file so all AI trigger types easily viewable in one place.  Defined in the style used in the code for other type hierarchies. Diverged slightly from the sketch in [MER-4111](https://eliterate.atlassian.net/browse/MER-4111), e.g. by using hint number parameter for hint triggers.