### PR TITLE
[FEATURE] [MER-4068] Reimplement user's invite - part 2

### DIFF
--- a/lib/oli_web/controllers/invite_controller.ex
+++ b/lib/oli_web/controllers/invite_controller.ex
@@ -142,7 +142,12 @@ defmodule OliWeb.InviteController do
         :enrollment_invitation,
         %{
           inviter: inviter_name,
-          url: ~p"/users/invite/#{data.token}",
+          url:
+            OliWeb.Router.Helpers.users_invite_path(
+              OliWeb.Endpoint,
+              OliWeb.Users.Invitations.UsersInviteView,
+              data.token
+            ),
           role: role,
           section_title: section_title,
           button_label: "Go to invitation"

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -1335,7 +1335,7 @@ defmodule OliWeb.Router do
   scope "/", OliWeb do
     pipe_through([:browser])
 
-    live "/users/invite/:token", Users.Invitations.UsersInviteView
+    live "/users/invite/:token", Users.Invitations.UsersInviteView, as: :users_invite
 
     post "/users/accept_invitation", InviteController, :accept_user_invitation
   end


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-4068) to the ticket

As [commented on MER-3893](https://eliterate.atlassian.net/browse/MER-3893?focusedCommentId=25179), I forgot to use an absolute URL instead of a relative URL for the email invitation link. This PR fixes that error