### PR TITLE
[BUG FIX] [MER-4154] Ensure current_user set on superactivity support API calls

### DIFF
--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -298,7 +298,7 @@ defmodule OliWeb.Router do
   end
 
   scope "/" do
-    pipe_through([:skip_csrf_protection, :delivery])
+    pipe_through([:api])
     post("/jcourse/superactivity/server", OliWeb.LegacySuperactivityController, :process)
 
     get(


### PR DESCRIPTION
Since recent change, superactivity support api calls were failing due to unset `current_user` assign. This changes the route to use the `:api` pipeline which will set that, and seems appropriate since these are api calls. 