### PR TITLE
[FEATURE] [MER-4150] Page progress setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+temp_init_file
 .vscode
 lib/oli/analytics/test.xml
 Mnesia.*

--- a/lib/oli/delivery/attempts/page_lifecycle/ungraded.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/ungraded.ex
@@ -153,7 +153,6 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Ungraded do
     {:ok, resource_access}
   end
 
-
   # We need a new attempt when:
 
   # There isn't a previous attempt

--- a/lib/oli/delivery/attempts/page_lifecycle/ungraded.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/ungraded.ex
@@ -92,15 +92,15 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Ungraded do
 
   @impl Lifecycle
   @decorate transaction_event("Ungraded.start")
-  def start(%VisitContext{} = context) do
+  def start(%VisitContext{page_revision: page_revision} = context) do
     {:ok, resource_attempt} = Hierarchy.create(context)
 
     AttemptState.fetch_attempt_state(resource_attempt, context.page_revision)
-    |> update_progress(resource_attempt)
+    |> update_progress(page_revision, resource_attempt)
   end
 
   @decorate transaction_event("Ungraded.update_progress")
-  defp update_progress({:ok, state}, %ResourceAttempt{
+  defp update_progress({:ok, state}, page_revision, %ResourceAttempt{
          resource_access_id: resource_access_id
        }) do
     number_of_scorable_activities =
@@ -119,26 +119,40 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Ungraded do
       |> Enum.count()
 
     Oli.Delivery.Attempts.Core.get_resource_access(resource_access_id)
-    |> do_update_progress(number_of_scorable_activities)
+    |> do_update_progress(page_revision.full_progress_pct, number_of_scorable_activities)
 
     {:ok, state}
   end
 
-  defp update_progress(other, _) do
+  defp update_progress(other, _, _) do
     other
   end
 
-  defp do_update_progress(resource_access, 0) do
+  # Update the progress of the resource access based on the number of scorable activities
+  # and the full progress percentage of the page revision.  If the full progress percentage
+  # OR the number of scorable activities is 0, then the progress is marked as completed.
+
+  defp do_update_progress(resource_access, _, 0) do
     Oli.Delivery.Metrics.mark_progress_completed(resource_access)
   end
 
-  defp do_update_progress(%{progress: nil} = resource_access, _) do
+  defp do_update_progress(resource_access, 0, _) do
+    Oli.Delivery.Metrics.mark_progress_completed(resource_access)
+  end
+
+  # If the progress is nil, then we reset the progress to 0
+
+  defp do_update_progress(%{progress: nil} = resource_access, _, _) do
     Oli.Delivery.Metrics.reset_progress(resource_access)
   end
 
-  defp do_update_progress(resource_access, _) do
+  # Otherwise, we do not update the progress, preserving the existing progress from
+  # previous attempts on this page
+
+  defp do_update_progress(resource_access, _, _) do
     {:ok, resource_access}
   end
+
 
   # We need a new attempt when:
 

--- a/lib/oli/resources.ex
+++ b/lib/oli/resources.ex
@@ -346,7 +346,8 @@ defmodule Oli.Resources do
           explanation_strategy: previous_revision.explanation_strategy,
           collab_space_config: previous_revision.collab_space_config,
           purpose: previous_revision.purpose,
-          relates_to: previous_revision.relates_to
+          relates_to: previous_revision.relates_to,
+          full_progress_pct: previous_revision.full_progress_pct
         },
         convert_strings_to_atoms(attrs)
       )

--- a/lib/oli/resources/revision.ex
+++ b/lib/oli/resources/revision.ex
@@ -53,6 +53,7 @@ defmodule Oli.Resources.Revision do
     field :intro_content, :map, default: %{}
     field :intro_video, :string, default: nil
     field :poster_image, :string, default: nil
+    field :full_progress_pct, :integer, default: 100
 
     # 0 represents "unlimited" attempts
     field :max_attempts, :integer, default: 0
@@ -127,7 +128,8 @@ defmodule Oli.Resources.Revision do
       :scoring_strategy_id,
       :activity_type_id,
       :purpose,
-      :relates_to
+      :relates_to,
+      :full_progress_pct
     ])
     |> cast_embed(:legacy)
     |> cast_embed(:explanation_strategy)

--- a/lib/oli_web/live/curriculum/entries/options_modal.ex
+++ b/lib/oli_web/live/curriculum/entries/options_modal.ex
@@ -450,6 +450,23 @@ defmodule OliWeb.Curriculum.OptionsModalContent do
             </small>
           </div>
           <div class="form-group">
+            <label for="duration_minutes">Full Progress %</label>
+            <.input
+              id="full_progress_pct"
+              type="number"
+              min="0"
+              max="100"
+              step="1"
+              name="revision[full_progress_pct]"
+              class="form-control"
+              aria-describedby="full_progress_pct_description"
+              field={@form[:full_progress_pct]}
+            />
+            <small id="full_progress_pct_description" class="form-text text-muted">
+              Percentage of activities on the page that must be attempted to receive full progress credit.
+            </small>
+          </div>
+          <div class="form-group">
             <label for="scoring_strategy_id">Scoring Strategy</label>
             <.input
               type="select"

--- a/priv/repo/migrations/20250113190620_add_full_progress_pct.exs
+++ b/priv/repo/migrations/20250113190620_add_full_progress_pct.exs
@@ -1,0 +1,9 @@
+defmodule Oli.Repo.Migrations.AddFullProgressPct do
+  use Ecto.Migration
+
+  def change do
+    alter table(:revisions) do
+      add :full_progress_pct, :integer, default: 100
+    end
+  end
+end

--- a/temp_init_file
+++ b/temp_init_file
@@ -1,0 +1,1 @@
+alias dc=docker-compose; alias reload-env='set -a;source oli.env;';cd() { builtin cd "$@" && ls; };PS1='\n\[\e[0m\]🚧 oli-dev \[\e[0;34m\][\[\e[0;34m\]\w\[\e[0;34m\]]\[\e[0m\] $ \[\e[0m\]';set -a; source oli.env;

--- a/temp_init_file
+++ b/temp_init_file
@@ -1,1 +1,0 @@
-alias dc=docker-compose; alias reload-env='set -a;source oli.env;';cd() { builtin cd "$@" && ls; };PS1='\n\[\e[0m\]🚧 oli-dev \[\e[0;34m\][\[\e[0;34m\]\w\[\e[0;34m\]]\[\e[0m\] $ \[\e[0m\]';set -a; source oli.env;


### PR DESCRIPTION
This adds a new author facing feature, allowing the author some control over the proportion of activities that must be attempted on a page in order to achieve 100% progress (i.e., for the student to then see the "green check" in the Learn view)

We add a new `:full_progress_pct` field to `Revision`, which defaults to the integer value of `100`.  Authors can change this setting in the page options modal from Curriculum or All Pages view. 

This setting is then used in two places during delivery:

1. When a new practice page attempt is started:  If this value is set to `0`, regardless of the number of scoreable activities that are on the page, the system marks the page progress as 100% completed. 
2. When a student attempts an activity: The `:full_progress_pct` value for the revision TIED TO THIS ATTEMPT is taken into account when performing the progress calculation.  