### PR TITLE
[ENHANCEMENT] [MER-4184] Add user detail fields to grades CSV download

### DIFF
--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -489,12 +489,20 @@ defmodule OliWeb.DeliveryController do
               out_of = Map.get(page_enrollment, :out_of)
               Map.put(acc, page_title, safe_score(score, out_of))
             end)
-            |> Map.put(:student, OliWeb.Common.Utils.name(enrollment.user))
+            |> Map.put(:student_id, enrollment.user.id)
+            |> Map.put(:student_lms_id, enrollment.user.sub)
+            |> Map.put(:student_family_name, enrollment.user.family_name)
+            |> Map.put(:student_given_name, enrollment.user.given_name)
+            |> Map.put(:student_email, enrollment.user.email)
           end)
           |> DataTable.new()
           |> DataTable.headers(
             [
-              :student
+              :student_id,
+              :student_lms_id,
+              :student_family_name,
+              :student_given_name,
+              :student_email
             ] ++ Enum.map(pages, &elem(&1, 1))
           )
           |> DataTable.to_csv_content()


### PR DESCRIPTION
This removes the "student" field, which was a concatenation of the first and last names, and replaces it with the database id, the user `:sub`, email and last and first names (as separate fields)

Tested locally and it produces the desired .csv:

```
student_id,student_lms_id,student_family_name,student_given_name,student_email,New Assessment,New Assessment
34,82d1fb04-077c-4b93-84af-94fa26a74153,,,adriel_leuschke_33@platform.example.edu,Not finished,Not finished
87,47fe81d3-9e1d-4014-99aa-0ba8159e10fb,,,darian_wuckert_dds_86@platform.example.edu,Not finished,Not finished
89,217d5193-1b1b-4f11-b1c5-c72247027a2a,,,malinda_lehner_88@platform.example.edu,Not finished,Not finished
```