### PR TITLE
[BUG FIX] [MER-4145] Add datashop_session_id to renew_session

### DIFF
--- a/lib/oli_web/user_auth.ex
+++ b/lib/oli_web/user_auth.ex
@@ -95,7 +95,8 @@ defmodule OliWeb.UserAuth do
         "browser_timezone",
         "author_token",
         "author_live_socket_id",
-        "current_author_id"
+        "current_author_id",
+        "datashop_session_id"
       ])
 
     conn


### PR DESCRIPTION
Ticket: [MER-4145](https://eliterate.atlassian.net/browse/MER-4145)

The issue occurred when a student joined a course through an invitation link. The system renewed the student session but did not preserve the `datashop_session_id`. As a result, when the student navigated to a page that required this key—such as in the case of hints, where it is needed to insert a part_attempt record during an assessment—the record became corrupted due to the `datashop_session_id` being `nil`.

Database queries from Tokamak indicate that the first issue was encountered on 2024-12-19. There are 8,621 part_attempts records with `nil` values. These records are corrupted and need to be addressed appropriately in another ticket.

[MER-4145]: https://eliterate.atlassian.net/browse/MER-4145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ