### PR TITLE
[BUG FIX] [MER-4169] Fix guest menu links

### DIFF
--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -409,7 +409,6 @@ defmodule OliWeb.Components.Delivery.Layouts do
             id="mobile-user-account-menu-workspace-sidebar"
             ctx={@ctx}
             is_admin={@is_admin}
-            section={@section}
             dropdown_class="absolute -translate-y-[calc(100%+58px)] right-0 border"
           />
         </div>

--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -73,7 +73,12 @@ defmodule OliWeb.Components.Delivery.Layouts do
           <div class={
             if @force_show_user_menu, do: "block", else: "hidden md:flex justify-center items-center"
           }>
-            <UserAccount.menu id="user-account-menu" ctx={@ctx} is_admin={@is_admin} />
+            <UserAccount.menu
+              id="user-account-menu"
+              ctx={@ctx}
+              is_admin={@is_admin}
+              section={@section}
+            />
           </div>
         </div>
         <div class="flex items-center p-2 ml-auto">
@@ -215,6 +220,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
             id="mobile-user-account-menu-sidebar"
             ctx={@ctx}
             is_admin={@is_admin}
+            section={@section}
             dropdown_class="absolute -translate-y-[calc(100%+58px)] right-0 border"
           />
         </div>
@@ -403,6 +409,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
             id="mobile-user-account-menu-workspace-sidebar"
             ctx={@ctx}
             is_admin={@is_admin}
+            section={@section}
             dropdown_class="absolute -translate-y-[calc(100%+58px)] right-0 border"
           />
         </div>

--- a/lib/oli_web/components/delivery/user_account.ex
+++ b/lib/oli_web/components/delivery/user_account.ex
@@ -231,7 +231,7 @@ defmodule OliWeb.Components.Delivery.UserAccount do
     </.menu_item_link>
     <.menu_divider />
     <.maybe_research_consent_link ctx={@ctx} />
-    <.menu_item_link href={~p"/users/log_out"}>
+    <.menu_item_link href={~p"/users/log_out"} method={:delete}>
       Leave Guest account
     </.menu_item_link>
     """

--- a/lib/oli_web/components/delivery/user_account.ex
+++ b/lib/oli_web/components/delivery/user_account.ex
@@ -132,6 +132,7 @@ defmodule OliWeb.Components.Delivery.UserAccount do
   attr(:ctx, SessionContext)
   attr(:current_user, Accounts.User, default: nil)
   attr(:current_author, Accounts.Author, default: nil)
+  attr(:section, Section, default: nil)
   attr(:is_admin, :boolean, required: true)
   attr(:class, :string, default: "")
   attr(:dropdown_class, :string, default: "")
@@ -156,7 +157,7 @@ defmodule OliWeb.Components.Delivery.UserAccount do
         <% else %>
           <%= case assigns.ctx do %>
             <% %SessionContext{user: %User{guest: true}} -> %>
-              <.guest_menu_items id={"#{@id}-menu-items-admin"} ctx={@ctx} />
+              <.guest_menu_items id={"#{@id}-menu-items-admin"} ctx={@ctx} section={@section} />
             <% %SessionContext{user: %User{}} -> %>
               <.user_menu_items id={"#{@id}-menu-items-admin"} ctx={@ctx} />
             <% %SessionContext{author: %Author{}} -> %>
@@ -219,6 +220,7 @@ defmodule OliWeb.Components.Delivery.UserAccount do
 
   attr(:id, :string, required: true)
   attr(:ctx, SessionContext, required: true)
+  attr(:section, Section, default: nil)
 
   def guest_menu_items(assigns) do
     ~H"""
@@ -226,7 +228,7 @@ defmodule OliWeb.Components.Delivery.UserAccount do
     <.menu_divider />
     <.menu_item_timezone_selector id={"#{@id}-tz-selector"} ctx={@ctx} />
     <.menu_divider />
-    <.menu_item_link href={~p"/users/log_in?#{[section: maybe_section_slug(assigns)]}"}>
+    <.menu_item_link href={~p"/users/register?#{maybe_section_param(@section)}"}>
       Create account or sign in
     </.menu_item_link>
     <.menu_divider />
@@ -502,15 +504,8 @@ defmodule OliWeb.Components.Delivery.UserAccount do
     """
   end
 
-  def maybe_section_slug(assigns) do
-    case assigns[:section] do
-      %Section{slug: slug} ->
-        slug
-
-      _ ->
-        ""
-    end
-  end
+  def maybe_section_param(%Section{slug: slug}), do: [section: slug]
+  def maybe_section_param(_), do: []
 
   def linked_author_account(%User{author: %Author{email: email}}), do: email
   def linked_author_account(_), do: nil

--- a/lib/oli_web/components/header.ex
+++ b/lib/oli_web/components/header.ex
@@ -12,6 +12,7 @@ defmodule OliWeb.Components.Header do
   alias OliWeb.Common.SessionContext
 
   attr(:ctx, SessionContext, required: true)
+  attr(:section, Section, default: nil)
   attr(:is_admin, :boolean, required: true)
 
   def header(assigns) do
@@ -74,7 +75,12 @@ defmodule OliWeb.Components.Header do
             </div>
           <% user_signed_in?(assigns) -> %>
             <div class="max-w-[400px] my-auto">
-              <UserAccount.menu id="user-account-menu" ctx={@ctx} is_admin={@is_admin} />
+              <UserAccount.menu
+                id="user-account-menu"
+                ctx={@ctx}
+                is_admin={@is_admin}
+                section={@section}
+              />
             </div>
           <% true -> %>
             <div class="inline-flex items-center">

--- a/lib/oli_web/live/delivery/student_dashboard/components/helpers.ex
+++ b/lib/oli_web/live/delivery/student_dashboard/components/helpers.ex
@@ -162,7 +162,7 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.Helpers do
         <%= if @preview_mode do %>
           <UserAccount.preview_user_menu ctx={@ctx} />
         <% else %>
-          <UserAccount.menu id="user-account-menu" ctx={@ctx} is_admin={@is_admin} />
+          <UserAccount.menu id="user-account-menu" ctx={@ctx} is_admin={@is_admin} section={@section} />
         <% end %>
         <div class="flex items-center border-l border-slate-300">
           <button

--- a/lib/oli_web/live/user_confirmation_live.ex
+++ b/lib/oli_web/live/user_confirmation_live.ex
@@ -22,6 +22,7 @@ defmodule OliWeb.UserConfirmationLive do
             </:subtitle>
 
             <.input field={@form[:token]} type="hidden" />
+            <.input :if={@section} field={@form[:section]} type="hidden" value={@section} />
 
             <:actions>
               <.button variant={:primary} phx-disable-with="Confirming..." class="w-full mt-4">
@@ -37,18 +38,27 @@ defmodule OliWeb.UserConfirmationLive do
 
   def mount(%{"token" => token}, _session, socket) do
     form = to_form(%{"token" => token}, as: "user")
-    {:ok, assign(socket, form: form), temporary_assigns: [form: nil]}
+    {:ok, assign(socket, form: form, section: nil), temporary_assigns: [form: nil]}
+  end
+
+  def handle_params(unsigned_params, _uri, socket) do
+    section = unsigned_params["section"]
+
+    {:noreply,
+     assign(socket,
+       section: section
+     )}
   end
 
   # Do not log in the user after confirmation to avoid a
   # leaked token giving the user access to the account.
-  def handle_event("confirm_account", %{"user" => %{"token" => token}}, socket) do
+  def handle_event("confirm_account", %{"user" => %{"token" => token} = user_params}, socket) do
     case Accounts.confirm_user(token) do
       {:ok, _} ->
         {:noreply,
          socket
          |> put_flash(:info, "Email successfully confirmed.")
-         |> redirect(to: ~p"/users/log_in")}
+         |> redirect(to: ~p"/users/log_in?#{maybe_section_param(user_params["section"])}")}
 
       :error ->
         # If there is a current user and the account was already confirmed,
@@ -68,4 +78,7 @@ defmodule OliWeb.UserConfirmationLive do
         end
     end
   end
+
+  defp maybe_section_param(nil), do: []
+  defp maybe_section_param(section), do: [section: section]
 end

--- a/lib/oli_web/live/user_registration_live.ex
+++ b/lib/oli_web/live/user_registration_live.ex
@@ -59,7 +59,11 @@ defmodule OliWeb.UserRegistrationLive do
     from_invitation_link? = unsigned_params["from_invitation_link?"] == "true"
     section = unsigned_params["section"]
 
-    {:noreply, assign(socket, from_invitation_link?: from_invitation_link?, section: section)}
+    {:noreply,
+     assign(socket,
+       from_invitation_link?: from_invitation_link?,
+       section: section
+     )}
   end
 
   def handle_event(
@@ -72,7 +76,7 @@ defmodule OliWeb.UserRegistrationLive do
       {:ok, _} =
         Accounts.deliver_user_confirmation_instructions(
           user,
-          &url(~p"/users/confirm/#{&1}")
+          &url(~p"/users/confirm/#{&1}?#{maybe_section_param(user_params["section"])}")
         )
 
       changeset = Accounts.change_user_registration(user)
@@ -109,4 +113,7 @@ defmodule OliWeb.UserRegistrationLive do
       assign(socket, form: form)
     end
   end
+
+  defp maybe_section_param(nil), do: []
+  defp maybe_section_param(section), do: [section: section]
 end

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -196,19 +196,28 @@ defmodule OliWeb.Router do
 
   ## Authentication routes
 
+  # allow access to non-authenticated users or guest users for sign in and account creation
+  scope "/", OliWeb do
+    pipe_through [:browser, :redirect_if_user_is_authenticated_and_not_guest]
+
+    live_session :redirect_if_user_is_authenticated_and_not_guest,
+      on_mount: [{OliWeb.UserAuth, :redirect_if_user_is_authenticated_and_not_guest}] do
+      live "/users/register", UserRegistrationLive, :new
+      live "/users/log_in", UserLoginLive, :new
+    end
+
+    post "/users/log_in", UserSessionController, :create
+  end
+
   scope "/", OliWeb do
     pipe_through [:browser, :redirect_if_user_is_authenticated]
 
     live_session :redirect_if_user_is_authenticated,
       on_mount: [{OliWeb.UserAuth, :redirect_if_user_is_authenticated}] do
-      live "/users/register", UserRegistrationLive, :new
-      live "/users/log_in", UserLoginLive, :new
       live "/instructors/log_in", UserLoginLive, :instructor_new
       live "/users/reset_password", UserForgotPasswordLive, :new
       live "/users/reset_password/:token", UserResetPasswordLive, :edit
     end
-
-    post "/users/log_in", UserSessionController, :create
   end
 
   scope "/", OliWeb do

--- a/lib/oli_web/templates/layout/_workspace_header.html.heex
+++ b/lib/oli_web/templates/layout/_workspace_header.html.heex
@@ -14,7 +14,6 @@
         id="user-account-menu"
         ctx={@ctx}
         is_admin={@is_admin}
-        section={@section}
       />
     </div>
   </div>

--- a/lib/oli_web/templates/layout/_workspace_header.html.heex
+++ b/lib/oli_web/templates/layout/_workspace_header.html.heex
@@ -14,6 +14,7 @@
         id="user-account-menu"
         ctx={@ctx}
         is_admin={@is_admin}
+        section={@section}
       />
     </div>
   </div>

--- a/lib/oli_web/user_auth.ex
+++ b/lib/oli_web/user_auth.ex
@@ -5,6 +5,7 @@ defmodule OliWeb.UserAuth do
   import Phoenix.Controller
 
   alias Oli.Accounts
+  alias Oli.Accounts.{User}
   alias Oli.Delivery.Sections.Section
   alias OliWeb.AuthorAuth
 
@@ -22,7 +23,8 @@ defmodule OliWeb.UserAuth do
     token = Accounts.generate_user_session_token(user)
 
     user_return_to =
-      params["request_path"] || get_session(conn, :user_return_to) || signed_in_path(conn)
+      maybe_return_to_section(params["section"]) || params["request_path"] ||
+        get_session(conn, :user_return_to) || signed_in_path(conn)
 
     conn
     |> renew_session()
@@ -229,6 +231,18 @@ defmodule OliWeb.UserAuth do
     end
   end
 
+  def on_mount(:redirect_if_user_is_authenticated_and_not_guest, _params, session, socket) do
+    socket = mount_current_user(socket, session)
+
+    case socket.assigns.current_user do
+      %User{guest: false} ->
+        {:halt, Phoenix.LiveView.redirect(socket, to: signed_in_path(socket))}
+
+      _ ->
+        {:cont, socket}
+    end
+  end
+
   defp mount_current_user(socket, session) do
     # Note: When a user first accesses an application using LiveView, the LiveView is first rendered
     # in its disconnected state, as part of a regular HTML response. By using assign_new in the
@@ -285,6 +299,22 @@ defmodule OliWeb.UserAuth do
       |> halt()
     else
       conn
+    end
+  end
+
+  @doc """
+  Used for routes that require a user to not be authenticated if they are not a guest. This will
+  allow guest users to access the page that typically cannot be accessed by authenticated users.
+  """
+  def redirect_if_user_is_authenticated_and_not_guest(conn, _opts) do
+    case conn.assigns[:current_user] do
+      %User{guest: false} ->
+        conn
+        |> redirect(to: signed_in_path(conn))
+        |> halt()
+
+      _ ->
+        conn
     end
   end
 
@@ -418,6 +448,9 @@ defmodule OliWeb.UserAuth do
   end
 
   defp maybe_store_return_to(conn), do: conn
+
+  defp maybe_return_to_section(nil), do: nil
+  defp maybe_return_to_section(section), do: ~p"/sections/#{section}"
 
   defp signed_in_path(_conn), do: ~p"/workspaces/student"
 end


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-4169

Fixes 2 issues related to guest menu links:

1. "Leave Guest Account" link was missing the "DELETE" HTTP method, resulting in a 404 error
2. "Create account or sign in" was not allowing "logged in" users, including guests, to access the registration or login pages. Moreover, the section parameter was not properly being handed off to the subsequent steps to allow a guest who just created an account to return directly to the section they were in when they clicked the link.
