### PR TITLE
[BUG FIX] [MER-4131] | Dig into chem labs simulations

### DIFF
--- a/assets/src/apps/delivery/store/features/attempt/actions/savePart.ts
+++ b/assets/src/apps/delivery/store/features/attempt/actions/savePart.ts
@@ -44,7 +44,7 @@ export const savePartState = createAsyncThunk(
               updatedPartResponses = {
                 ...result.response,
                 ...updatedPartResponses,
-                partId: p.partId,
+                ...(isPreviewMode ? { partId: p.partId } : {}),
               };
               result.response = updatedPartResponses;
             }

--- a/assets/src/apps/delivery/store/features/attempt/actions/savePart.ts
+++ b/assets/src/apps/delivery/store/features/attempt/actions/savePart.ts
@@ -44,7 +44,7 @@ export const savePartState = createAsyncThunk(
               updatedPartResponses = {
                 ...result.response,
                 ...updatedPartResponses,
-                ...(isPreviewMode ? { partId: p.partId } : {}),
+                ...(isPreviewMode ? { partId: p.partId } : {}), // partId  should never get sent to server. It's only for preview mode
               };
               result.response = updatedPartResponses;
             }


### PR DESCRIPTION
Hey @bsparks, could you please look at this PR? Thanks

The reason for this change is because of the changes made in https://github.com/Simon-Initiative/oli-torus/pull/5282. The new `PartId` variable only needs to be used in preview mode. It should never get sent to server. The server will throw an error because of the format in which it expects the part responses.