### PR TITLE
[FEATURE] [MER-3777] Cannot see comments from manually graded adaptive assignments

### DIFF
--- a/lib/oli/delivery/attempts/core.ex
+++ b/lib/oli/delivery/attempts/core.ex
@@ -590,10 +590,7 @@ defmodule Oli.Delivery.Attempts.Core do
               where: ra.resource_access_id == ^id,
               order_by: ra.attempt_number,
               select: ra,
-              preload: [
-                :revision,
-                activity_attempts: [:part_attempts]
-              ]
+              preload: [:revision]
             )
           )
 
@@ -1024,5 +1021,16 @@ defmodule Oli.Delivery.Attempts.Core do
       select: count(ra.id)
     )
     |> Repo.one()
+  end
+
+  @doc """
+  Preloads `activity_attempts` and their associated `part_attempts` for a given resource attempt or list of attempts.
+
+  This allows fetching detailed attempt data only when needed, avoiding unnecessary preloading in other queries.
+  """
+  def preload_activity_part_attempts(resource_attempts) do
+    Repo.preload(resource_attempts,
+      activity_attempts: [:part_attempts]
+    )
   end
 end

--- a/lib/oli/delivery/attempts/core.ex
+++ b/lib/oli/delivery/attempts/core.ex
@@ -590,7 +590,10 @@ defmodule Oli.Delivery.Attempts.Core do
               where: ra.resource_access_id == ^id,
               order_by: ra.attempt_number,
               select: ra,
-              preload: [:revision]
+              preload: [
+                :revision,
+                activity_attempts: [:part_attempts]
+              ]
             )
           )
 

--- a/lib/oli_web/live/common/utils.ex
+++ b/lib/oli_web/live/common/utils.ex
@@ -233,4 +233,30 @@ defmodule OliWeb.Common.Utils do
         nil
     end
   end
+
+  @doc """
+    Extracts the text for a feedback item from an attempt.
+  """
+  def extract_feedback_text(activity_attempts) do
+    activity_attempts
+    |> Enum.flat_map(&extract_from_activity_attempt/1)
+  end
+
+  defp extract_from_activity_attempt(%{part_attempts: part_attempts}) do
+    part_attempts
+    |> Enum.flat_map(&extract_from_part_attempt/1)
+  end
+
+  defp extract_from_part_attempt(%{feedback: %{"content" => content}}) do
+    content
+    |> Enum.map(&extract_text/1)
+  end
+
+  defp extract_from_part_attempt(%{feedback: nil}), do: []
+
+  defp extract_text(%{"children" => children}) do
+    children
+    |> Enum.map(& &1["text"])
+    |> Enum.join(" ")
+  end
 end

--- a/lib/oli_web/live/delivery/student/prologue_live.ex
+++ b/lib/oli_web/live/delivery/student/prologue_live.ex
@@ -11,7 +11,6 @@ defmodule OliWeb.Delivery.Student.PrologueLive do
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Settings
   alias Oli.Publishing.DeliveryResolver, as: Resolver
-  alias Oli.Repo
   alias OliWeb.Common.{FormatDateTime, Utils}
   alias OliWeb.Components.Modal
   alias OliWeb.Delivery.Student.Utils, as: StudentUtils
@@ -206,10 +205,7 @@ defmodule OliWeb.Delivery.Student.PrologueLive do
   attr :request_path, :string
 
   defp attempt_summary(assigns) do
-    activity_attempts =
-      Repo.preload(assigns.attempt, activity_attempts: [:part_attempts]).activity_attempts
-
-    feedback_texts = Utils.extract_feedback_text(activity_attempts)
+    feedback_texts = Utils.extract_feedback_text(assigns.attempt.activity_attempts)
     assigns = assign(assigns, feedback_texts: feedback_texts)
 
     ~H"""

--- a/lib/oli_web/live/delivery/student/prologue_live.ex
+++ b/lib/oli_web/live/delivery/student/prologue_live.ex
@@ -11,9 +11,10 @@ defmodule OliWeb.Delivery.Student.PrologueLive do
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Settings
   alias Oli.Publishing.DeliveryResolver, as: Resolver
-  alias OliWeb.Common.FormatDateTime
+  alias Oli.Repo
+  alias OliWeb.Common.{FormatDateTime, Utils}
   alias OliWeb.Components.Modal
-  alias OliWeb.Delivery.Student.Utils
+  alias OliWeb.Delivery.Student.Utils, as: StudentUtils
   alias OliWeb.Icons
 
   require Logger
@@ -95,7 +96,7 @@ defmodule OliWeb.Delivery.Student.PrologueLive do
           ctx={@ctx}
           objectives={@objectives}
           index={@current_page["index"]}
-          container_label={Utils.get_container_label(@current_page["id"], @section)}
+          container_label={StudentUtils.get_container_label(@current_page["id"], @section)}
         />
         <div class="self-stretch h-[0px] opacity-80 dark:opacity-20 bg-white border border-gray-200 mt-3 mb-10">
         </div>
@@ -205,6 +206,12 @@ defmodule OliWeb.Delivery.Student.PrologueLive do
   attr :request_path, :string
 
   defp attempt_summary(assigns) do
+    activity_attempts =
+      Repo.preload(assigns.attempt, activity_attempts: [:part_attempts]).activity_attempts
+
+    feedback_texts = Utils.extract_feedback_text(activity_attempts)
+    assigns = assign(assigns, feedback_texts: feedback_texts)
+
     ~H"""
     <div
       id={"attempt_#{@index}_summary"}
@@ -261,12 +268,12 @@ defmodule OliWeb.Delivery.Student.PrologueLive do
         >
           <.link
             href={
-              Utils.review_live_path(
+              StudentUtils.review_live_path(
                 @section_slug,
                 @page_revision_slug,
                 @attempt.attempt_guid,
                 request_path:
-                  Utils.prologue_live_path(@section_slug, @page_revision_slug,
+                  StudentUtils.prologue_live_path(@section_slug, @page_revision_slug,
                     request_path: @request_path
                   )
               )
@@ -278,6 +285,16 @@ defmodule OliWeb.Delivery.Student.PrologueLive do
             </div>
           </.link>
         </div>
+      </div>
+    </div>
+    <div :if={@feedback_texts != []} class="mt-2 mb-8">
+      <div class="text-neutral-500 text-sm font-bold mb-2">Instructor Feedback:</div>
+      <div class="flex flex-col gap-y-2">
+        <%= for feedback <- @feedback_texts do %>
+          <p class="w-full text-black font-normal" readonly>
+            <%= feedback %>
+          </p>
+        <% end %>
       </div>
     </div>
     """
@@ -303,7 +320,7 @@ defmodule OliWeb.Delivery.Student.PrologueLive do
       {:noreply,
        redirect(socket,
          to:
-           Utils.lesson_live_path(section.slug, revision.slug,
+           StudentUtils.lesson_live_path(section.slug, revision.slug,
              request_path: socket.assigns.request_path,
              selected_view: socket.assigns.selected_view
            )

--- a/lib/oli_web/live/delivery/student/prologue_live.ex
+++ b/lib/oli_web/live/delivery/student/prologue_live.ex
@@ -6,7 +6,7 @@ defmodule OliWeb.Delivery.Student.PrologueLive do
 
   alias Oli.Accounts.User
   alias Oli.Delivery.Attempts.Core.ResourceAttempt
-  alias Oli.Delivery.Attempts.PageLifecycle
+  alias Oli.Delivery.Attempts.{Core, PageLifecycle}
   alias Oli.Delivery.Metrics
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Settings
@@ -205,7 +205,8 @@ defmodule OliWeb.Delivery.Student.PrologueLive do
   attr :request_path, :string
 
   defp attempt_summary(assigns) do
-    feedback_texts = Utils.extract_feedback_text(assigns.attempt.activity_attempts)
+    attempt = Core.preload_activity_part_attempts(assigns.attempt)
+    feedback_texts = Utils.extract_feedback_text(attempt.activity_attempts)
     assigns = assign(assigns, feedback_texts: feedback_texts)
 
     ~H"""
@@ -287,7 +288,7 @@ defmodule OliWeb.Delivery.Student.PrologueLive do
       <div class="text-neutral-500 text-sm font-bold mb-2">Instructor Feedback:</div>
       <div class="flex flex-col gap-y-2">
         <%= for feedback <- @feedback_texts do %>
-          <p class="w-full text-black font-normal" readonly>
+          <p class="w-full text-black font-normal dark:text-neutral-500" readonly>
             <%= feedback %>
           </p>
         <% end %>

--- a/lib/oli_web/live/progress/page_attempt_summary.ex
+++ b/lib/oli_web/live/progress/page_attempt_summary.ex
@@ -1,6 +1,5 @@
 defmodule OliWeb.Progress.PageAttemptSummary do
   use OliWeb, :live_component
-  alias Oli.Repo
   alias OliWeb.Common.Utils
   alias OliWeb.Delivery.Student.Utils, as: StudentUtils
 
@@ -56,10 +55,7 @@ defmodule OliWeb.Progress.PageAttemptSummary do
   end
 
   def do_render(%{attempt: %{lifecycle_state: :evaluated}} = assigns) do
-    activity_attempts =
-      Repo.preload(assigns.attempt, activity_attempts: [:part_attempts]).activity_attempts
-
-    feedback_texts = Utils.extract_feedback_text(activity_attempts)
+    feedback_texts = Utils.extract_feedback_text(assigns.attempt.activity_attempts)
     assigns = assign(assigns, feedback_texts: feedback_texts)
 
     ~H"""

--- a/lib/oli_web/live/progress/page_attempt_summary.ex
+++ b/lib/oli_web/live/progress/page_attempt_summary.ex
@@ -1,5 +1,6 @@
 defmodule OliWeb.Progress.PageAttemptSummary do
   use OliWeb, :live_component
+  alias Oli.Delivery.Attempts.Core
   alias OliWeb.Common.Utils
   alias OliWeb.Delivery.Student.Utils, as: StudentUtils
 
@@ -55,11 +56,12 @@ defmodule OliWeb.Progress.PageAttemptSummary do
   end
 
   def do_render(%{attempt: %{lifecycle_state: :evaluated}} = assigns) do
-    feedback_texts = Utils.extract_feedback_text(assigns.attempt.activity_attempts)
+    attempt = Core.preload_activity_part_attempts(assigns.attempt)
+    feedback_texts = Utils.extract_feedback_text(attempt.activity_attempts)
     assigns = assign(assigns, feedback_texts: feedback_texts)
 
     ~H"""
-    <div class="list-group-item list-group-action flex-column align-items-start mb-8">
+    <div class="list-group-item list-group-action flex-column align-items-start mb-8 !border-b-0">
       <.link
         href={
           StudentUtils.review_live_path(@section.slug, @revision.slug, @attempt.attempt_guid,
@@ -91,10 +93,15 @@ defmodule OliWeb.Progress.PageAttemptSummary do
       </.link>
 
       <div :if={@feedback_texts != []} class="mt-8">
-        <div class="text-black text-sm font-normal mb-2">Instructor Feedback:</div>
+        <div class="text-black text-sm font-normal mb-2 dark:text-neutral-500">
+          Instructor Feedback:
+        </div>
         <div class="flex flex-col gap-y-2">
           <%= for feedback <- @feedback_texts do %>
-            <textarea class="w-full bg-neutral-100 rounded-md border border-neutral-300" readonly>
+            <textarea
+              class="w-full bg-neutral-100 rounded-md border border-neutral-300 dark:bg-[#1e1e1e] dark:border-[#525252]"
+              readonly
+            >
             <%= feedback %>
           </textarea>
           <% end %>

--- a/lib/oli_web/live/progress/page_attempt_summary.ex
+++ b/lib/oli_web/live/progress/page_attempt_summary.ex
@@ -60,6 +60,7 @@ defmodule OliWeb.Progress.PageAttemptSummary do
       Repo.preload(assigns.attempt, activity_attempts: [:part_attempts]).activity_attempts
 
     feedback_texts = Utils.extract_feedback_text(activity_attempts)
+    assigns = assign(assigns, feedback_texts: feedback_texts)
 
     ~H"""
     <div class="list-group-item list-group-action flex-column align-items-start mb-8">
@@ -93,10 +94,10 @@ defmodule OliWeb.Progress.PageAttemptSummary do
         </small>
       </.link>
 
-      <div :if={feedback_texts != []} class="mt-8">
+      <div :if={@feedback_texts != []} class="mt-8">
         <div class="text-black text-sm font-normal mb-2">Instructor Feedback:</div>
         <div class="flex flex-col gap-y-2">
-          <%= for feedback <- feedback_texts do %>
+          <%= for feedback <- @feedback_texts do %>
             <textarea class="w-full bg-neutral-100 rounded-md border border-neutral-300" readonly>
             <%= feedback %>
           </textarea>

--- a/lib/oli_web/live/progress/student_resource_view.ex
+++ b/lib/oli_web/live/progress/student_resource_view.ex
@@ -106,7 +106,7 @@ defmodule OliWeb.Progress.StudentResourceView do
         nil
 
       ra ->
-        Oli.Repo.preload(ra, resource_attempts: [activity_attempts: [:part_attempts]])
+        Oli.Repo.preload(ra, :resource_attempts)
     end
   end
 

--- a/lib/oli_web/live/progress/student_resource_view.ex
+++ b/lib/oli_web/live/progress/student_resource_view.ex
@@ -106,7 +106,7 @@ defmodule OliWeb.Progress.StudentResourceView do
         nil
 
       ra ->
-        Oli.Repo.preload(ra, :resource_attempts)
+        Oli.Repo.preload(ra, resource_attempts: [activity_attempts: [:part_attempts]])
     end
   end
 

--- a/test/oli_web/live/progress/page_attempt_summary_test.exs
+++ b/test/oli_web/live/progress/page_attempt_summary_test.exs
@@ -80,6 +80,10 @@ defmodule OliWeb.Progress.PageAttemptSummaryTest do
       revision: revision
     } do
       attempt = %{attempt | lifecycle_state: :evaluated}
+
+      attempt =
+        Oli.Repo.preload(attempt, activity_attempts: [:part_attempts])
+
       assigns = %{attempt: attempt, section: section, ctx: ctx, revision: revision}
 
       html = render_component(PageAttemptSummary, assigns)

--- a/test/oli_web/live/progress/student_resource_view_live_test.exs
+++ b/test/oli_web/live/progress/student_resource_view_live_test.exs
@@ -6,6 +6,9 @@ defmodule OliWeb.Progress.StudentResourceViewLiveTest do
   import Oli.Factory
 
   alias Oli.Delivery.Attempts.Core
+  alias Oli.Delivery.Attempts.Core.{ActivityAttempt, ResourceAccess}
+  alias Oli.Delivery.Sections
+  alias Oli.Repo
 
   defp live_view_student_resource_view_route(section_slug, user_id, resource_id) do
     Routes.live_path(
@@ -40,6 +43,73 @@ defmodule OliWeb.Progress.StudentResourceViewLiveTest do
       )
 
     [section_slug: section.slug, student_id: student.id, resource_id: resource_access.resource_id]
+  end
+
+  defp create_attempt(student, section, revision, resource_attempt_data \\ %{}) do
+    resource_access = get_or_insert_resource_access(student, section, revision)
+
+    resource_attempt =
+      insert(:resource_attempt, %{
+        resource_access: resource_access,
+        revision: revision,
+        date_submitted: resource_attempt_data[:date_submitted] || ~U[2023-11-14 20:00:00Z],
+        date_evaluated: resource_attempt_data[:date_evaluated] || ~U[2023-11-14 20:30:00Z],
+        score: resource_attempt_data[:score] || 5,
+        out_of: resource_attempt_data[:out_of] || 10,
+        lifecycle_state: resource_attempt_data[:lifecycle_state] || :evaluated,
+        content: resource_attempt_data[:content] || %{model: []}
+      })
+
+    activity_attempt =
+      insert(:activity_attempt,
+        resource_attempt: resource_attempt,
+        resource: revision.resource,
+        revision: revision,
+        lifecycle_state: :submitted,
+        score: 5,
+        out_of: 10
+      )
+
+    insert(:part_attempt, %{
+      activity_attempt_id: activity_attempt.id,
+      activity_attempt: activity_attempt,
+      attempt_guid: UUID.uuid4(),
+      part_id: "1",
+      grading_approach: :manual,
+      datashop_session_id: "1234abcd",
+      score: 5,
+      out_of: 10,
+      lifecycle_state: :submitted
+    })
+
+    resource_attempt
+  end
+
+  defp get_or_insert_resource_access(student, section, revision) do
+    Oli.Repo.get_by(
+      ResourceAccess,
+      resource_id: revision.resource_id,
+      section_id: section.id,
+      user_id: student.id
+    )
+    |> case do
+      nil ->
+        insert(:resource_access, %{
+          user: student,
+          section: section,
+          resource: revision.resource
+        })
+
+      resource_access ->
+        resource_access
+    end
+  end
+
+  defp wrap_in_paragraphs(text) do
+    String.split(text, "\n")
+    |> Enum.map(fn text ->
+      %{type: "p", children: [%{text: text}]}
+    end)
   end
 
   describe "student resource view" do
@@ -119,6 +189,57 @@ defmodule OliWeb.Progress.StudentResourceViewLiveTest do
 
       assert score == 2.5
       assert out_of == 2.5
+    end
+
+    test "instructors can see instructor feedback in the attempt history", %{
+      conn: conn,
+      instructor: instructor
+    } do
+      {:ok,
+       section: section,
+       unit_one_revision: _unit_one_revision,
+       page_revision: page_revision,
+       page_2_revision: _page_2_revision} =
+        section_with_assessment(%{})
+
+      user = insert(:user)
+
+      enroll_user_to_section(instructor, section, :context_instructor)
+      enroll_user_to_section(user, section, :context_learner)
+      Sections.mark_section_visited_for_student(section, user)
+      feedback = "This is the feedback for the student"
+
+      attempt = create_attempt(user, section, page_revision)
+
+      activity_attempt =
+        Repo.preload(attempt, activity_attempts: [:part_attempts]).activity_attempts |> hd()
+
+      activity_attempt = %ActivityAttempt{
+        activity_attempt
+        | graded: true,
+          resource_attempt_guid: attempt.attempt_guid,
+          lifecycle_state: :evaluated
+      }
+
+      part_attempt =
+        Core.get_part_attempts_by_activity_attempts([activity_attempt.id]) |> hd()
+
+      Core.update_part_attempt(part_attempt, %{
+        lifecycle_state: :evaluated,
+        date_evaluated: DateTime.utc_now(),
+        score: 1.0,
+        out_of: 1.0,
+        feedback: %{content: wrap_in_paragraphs(feedback)}
+      })
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_student_resource_view_route(section.slug, user.id, page_revision.resource_id)
+        )
+
+      assert has_element?(view, "div", "Instructor Feedback:")
+      assert has_element?(view, "textarea", "This is the feedback for the student")
     end
   end
 end


### PR DESCRIPTION
[MER-3777](https://eliterate.atlassian.net/browse/MER-3777)

This PR aims to show the feedback that an instructor gives to a student if the activity that the student solves is set to be manually evaluated. 

This implementation works for both basic and adaptive pages.

The feedback that the instructor can give will be displayed in two places:

- For the student, in the prologue view of the attempts the student made for a given page.

- For the instructor, in the view showing the attempts a student made on a given page.


https://github.com/user-attachments/assets/655c8a31-a5dc-43bd-a45a-1af9f1ed69f9



[MER-3777]: https://eliterate.atlassian.net/browse/MER-3777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ