### PR TITLE
[BUG FIX] [MER-4178] [MER-4186] Fix required survey issues

### DIFF
--- a/lib/oli/delivery/sections/updates.ex
+++ b/lib/oli/delivery/sections/updates.ex
@@ -177,17 +177,26 @@ defmodule Oli.Delivery.Sections.Updates do
   end
 
   def ensure_section_resource_exists(_section_slug, nil), do: {:ok, :exists}
+
   def ensure_section_resource_exists(section_slug, resource_id) do
     case Oli.Publishing.DeliveryResolver.from_resource_id(section_slug, resource_id) do
       nil ->
         # Fetch the published revision of this revision along with section and project id
         query =
           Oli.Delivery.Sections.SectionsProjectsPublications
-          |> join(:left, [spp], pr in Oli.Publishing.PublishedResource, on: pr.publication_id == spp.publication_id)
+          |> join(:left, [spp], pr in Oli.Publishing.PublishedResource,
+            on: pr.publication_id == spp.publication_id
+          )
           |> join(:left, [_, pr], rev in Oli.Resources.Revision, on: rev.id == pr.revision_id)
-          |> join(:left, [spp, _, _], s in Oli.Delivery.Sections.Section, on: s.id == spp.section_id)
+          |> join(:left, [spp, _, _], s in Oli.Delivery.Sections.Section,
+            on: s.id == spp.section_id
+          )
           |> where([spp, pr, rev, s], s.slug == ^section_slug and pr.resource_id == ^resource_id)
-          |> select([spp, _pr, rev, section], %{revision: rev, section: section, project_id: spp.project_id})
+          |> select([spp, _pr, rev, section], %{
+            revision: rev,
+            section: section,
+            project_id: spp.project_id
+          })
           |> limit(1)
 
         case Repo.one(query) do
@@ -404,17 +413,21 @@ defmodule Oli.Delivery.Sections.Updates do
     # Determine the unreachable page resource ids, but taking into account if
     # EITHER the project or the section has a required survey resource id to
     # ensure that it never gets culled.
-    additional_excluded_ids = [section.required_survey_resource_id, project.required_survey_resource_id]
-    |> Enum.filter(& &1 != nil)
-    |> MapSet.new()
+    additional_excluded_ids =
+      [section.required_survey_resource_id, project.required_survey_resource_id]
+      |> Enum.filter(&(&1 != nil))
+      |> MapSet.new()
 
     # Determine the unreachable page resource ids based strictly on hierarchy navigability
-    unreachable_page_resource_ids = Oli.Delivery.Sections.determine_unreachable_pages(
-      [publication.id],
-      hierarchy_ids,
-      all_links
-    )  # But filter out any additional excluded resource ids (like required surveys)
-    |> Enum.filter(fn id -> !Enum.member?(additional_excluded_ids, id) end)
+    unreachable_page_resource_ids =
+      Oli.Delivery.Sections.determine_unreachable_pages(
+        [publication.id],
+        hierarchy_ids,
+        all_links
+      )
+
+      # But filter out any additional excluded resource ids (like required surveys)
+      |> Enum.filter(fn id -> !Enum.member?(additional_excluded_ids, id) end)
 
     project_id = publication.project_id
 

--- a/lib/oli_web/live/delivery/student_onboarding/survey.ex
+++ b/lib/oli_web/live/delivery/student_onboarding/survey.ex
@@ -16,7 +16,10 @@ defmodule OliWeb.Delivery.StudentOnboarding.Survey do
       # Just in time addition of the survey to the course section's section resources.
       # This was needed due to a hotfix bug that was causing the survey to not be added
       # to the section resources at publication application time.
-      Oli.Delivery.Sections.Updates.ensure_section_resource_exists(section.slug, section.required_survey_resource_id)
+      Oli.Delivery.Sections.Updates.ensure_section_resource_exists(
+        section.slug,
+        section.required_survey_resource_id
+      )
 
       context =
         Oli.Delivery.Page.PageContext.create_for_visit(

--- a/lib/oli_web/live/delivery/student_onboarding/survey.ex
+++ b/lib/oli_web/live/delivery/student_onboarding/survey.ex
@@ -13,6 +13,11 @@ defmodule OliWeb.Delivery.StudentOnboarding.Survey do
       survey = assigns.survey
       datashop_session_id = assigns.datashop_session_id
 
+      # Just in time addition of the survey to the course section's section resources.
+      # This was needed due to a hotfix bug that was causing the survey to not be added
+      # to the section resources at publication application time.
+      Oli.Delivery.Sections.Updates.ensure_section_resource_exists(section.slug, section.required_survey_resource_id)
+
       context =
         Oli.Delivery.Page.PageContext.create_for_visit(
           section,

--- a/lib/oli_web/plugs/force_required_survey.ex
+++ b/lib/oli_web/plugs/force_required_survey.ex
@@ -35,7 +35,6 @@ defmodule Oli.Plugs.ForceRequiredSurvey do
         Sections.is_instructor?(user, section_slug)
 
     if !has_completed_survey do
-
       %{slug: survey_slug} = Sections.get_survey(section_slug)
 
       # If the user is trying to access the survey, let them through

--- a/lib/oli_web/plugs/force_required_survey.ex
+++ b/lib/oli_web/plugs/force_required_survey.ex
@@ -26,11 +26,16 @@ defmodule Oli.Plugs.ForceRequiredSurvey do
     section_slug = conn.assigns.section.slug
     user = conn.assigns[:current_user]
 
+    # Just in time, make sure the section resource record exists
+    survey_id = conn.assigns.section.required_survey_resource_id
+    Oli.Delivery.Sections.Updates.ensure_section_resource_exists(section_slug, survey_id)
+
     has_completed_survey =
       Oli.Delivery.has_completed_survey?(section_slug, user.id) or
         Sections.is_instructor?(user, section_slug)
 
     if !has_completed_survey do
+
       %{slug: survey_slug} = Sections.get_survey(section_slug)
 
       # If the user is trying to access the survey, let them through

--- a/test/oli/delivery/sections/ensure_resource_test.exs
+++ b/test/oli/delivery/sections/ensure_resource_test.exs
@@ -1,0 +1,109 @@
+defmodule Oli.Delivery.Sections.SectionResourceDepotTest do
+  use Oli.DataCase
+
+  import Ecto.Query
+  import Oli.Factory
+
+  alias Oli.Delivery.Sections
+  alias Oli.Delivery.Sections.SectionResource
+  alias Oli.Delivery.Sections.Updates
+  alias Oli.Resources.ResourceType
+
+  describe "ensure resource exists" do
+    setup [:create_project]
+
+    test "gets hierarchy and triggers Depot", ctx do
+      %{
+        section: %{id: section_id} = section,
+        page_1_revision: page_1_revision
+      } = ctx
+
+      # Verify that when the resource exists, it doesn't get created again
+      {:ok, :exists} = Updates.ensure_section_resource_exists(section.slug, page_1_revision.resource_id)
+
+      # simulate a missing SR by deleting it
+      Oli.Repo.delete_all(
+        from(sr in SectionResource,
+          where: sr.section_id == ^section_id and sr.resource_id == ^page_1_revision.resource_id
+        )
+      )
+
+      # Ensure the resource gets created
+      {:ok, count_created} = Updates.ensure_section_resource_exists(section.slug, page_1_revision.resource_id)
+      assert count_created == 1
+    end
+  end
+
+  defp create_project(_) do
+    # Revisions tree
+    page_1_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.id_for_page(),
+        title: "Page 1"
+      )
+
+    # Graded page
+    page_2_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.id_for_page(),
+        title: "Page 2",
+        graded: true
+      )
+
+    module_1_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.id_for_container(),
+        children: [page_1_revision.resource_id, page_2_revision.resource_id],
+        title: "Module 1"
+      )
+
+    # Root container
+    container_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.id_for_container(),
+        title: "Root Container",
+        children: [module_1_revision.resource_id]
+      )
+
+    instructor = insert(:user)
+    project = insert(:project, authors: [instructor.author])
+
+    all_revisions = [container_revision, module_1_revision, page_1_revision, page_2_revision]
+
+    # Asociate resources to project
+    Enum.each(all_revisions, fn revision ->
+      insert(:project_resource, %{
+        project_id: project.id,
+        resource_id: revision.resource_id
+      })
+    end)
+
+    # Publish project
+    publication =
+      insert(:publication, %{project: project, root_resource_id: container_revision.resource_id})
+
+    # Publish resources
+    Enum.each(all_revisions, fn revision ->
+      insert(:published_resource, %{
+        publication: publication,
+        resource: revision.resource,
+        revision: revision,
+        author: instructor.author
+      })
+    end)
+
+    # Create section
+    section = insert(:section, base_project: project, title: "The Project")
+
+    # Create section-resources
+    {:ok, section} = Sections.create_section_resources(section, publication)
+
+    %{
+      section: section,
+      container_revision: container_revision,
+      module_1_revision: module_1_revision,
+      page_1_revision: page_1_revision,
+      page_2_revision: page_2_revision
+    }
+  end
+end

--- a/test/oli/delivery/sections/ensure_resource_test.exs
+++ b/test/oli/delivery/sections/ensure_resource_test.exs
@@ -19,7 +19,8 @@ defmodule Oli.Delivery.Sections.SectionResourceDepotTest do
       } = ctx
 
       # Verify that when the resource exists, it doesn't get created again
-      {:ok, :exists} = Updates.ensure_section_resource_exists(section.slug, page_1_revision.resource_id)
+      {:ok, :exists} =
+        Updates.ensure_section_resource_exists(section.slug, page_1_revision.resource_id)
 
       # simulate a missing SR by deleting it
       Oli.Repo.delete_all(
@@ -29,7 +30,9 @@ defmodule Oli.Delivery.Sections.SectionResourceDepotTest do
       )
 
       # Ensure the resource gets created
-      {:ok, count_created} = Updates.ensure_section_resource_exists(section.slug, page_1_revision.resource_id)
+      {:ok, count_created} =
+        Updates.ensure_section_resource_exists(section.slug, page_1_revision.resource_id)
+
       assert count_created == 1
     end
   end


### PR DESCRIPTION
## Core Issue: Incorrect "culling" of section resource during publication update application

The core issue here is that the code that applies new publication updates was incorrectly "culling" the survey resource from a course section.  Function `Oli.Delivery.Sections.determine_unreachable_pages/3` takes as its second argument the list of the hierarchy resource ids and a list of page links and determines reachability of all other pages.  Unreachable pages then get removed from the section.   This means then that there is no SectionResource record for the survey, which breaks the display of the Survey from the onboarding wizard and breaks correct functioning of the `Oli.Plugs.ForceRequiredSurvey` plug. 

The problem here was how the original impl attempted to exempt out and keep the required survey from being culled. It simply included the survey page id in the list of hiearchy ids.  But that wasn't correct - since no hierarchy resource contained a link (either through links or through children) to that survey resource, thus it was culled. 

The easiest way to fix this was to add a post filtering step to remove the survey from the list of pages to cull. 

## Secondary Problem: Fixing affected course sections

Existing, affected course sections where the `SectionResource` for the survey is missing wont' be fixed by the change described above.  It would require the author to delete the survey, recreate it and then republish.  Instead, this PR includes another change which detects the case of the missing section resource of the survey and creates it just in time. 

## Peripheral change: Removing doubled post processing step

In doing this work I noticed that during section update application we were updating the section for "contains explorations" and "contains deliberate practice" twice.  Once from within `PostProcessing.apply(section, :all)` and again explicitly below it.  I removed the second case. 