### PR TITLE
[BUG FIX] [MER-4185] Reverts the survey tool report to match legacy display 

### DIFF
--- a/lib/oli/activities/reports/providers/OliLikert.ex
+++ b/lib/oli/activities/reports/providers/OliLikert.ex
@@ -232,7 +232,8 @@ defmodule Oli.Activities.Reports.Providers.OliLikert do
                   "y": {
                       "field": "choice",
                       "type": "nominal",
-                      "sort": "descending"
+                      "sort": "descending",
+                      "title": "Choice"
                   }
               }
           }

--- a/lib/oli/activities/reports/providers/OliLikert.ex
+++ b/lib/oli/activities/reports/providers/OliLikert.ex
@@ -185,7 +185,6 @@ defmodule Oli.Activities.Reports.Providers.OliLikert do
       end)
       |> Enum.join(" ---------- ")
 
-    IO.inspect(data)
     encoded = Jason.encode!(data)
 
     VegaLite.from_json("""

--- a/lib/oli/activities/reports/providers/OliLikert.ex
+++ b/lib/oli/activities/reports/providers/OliLikert.ex
@@ -168,7 +168,7 @@ defmodule Oli.Activities.Reports.Providers.OliLikert do
   defp color_pick(c, group) do
     colors = Map.get(c, :colors)
     color_list = Map.get(c, :color_list)
-    index = :rand.uniform(length(color_list))
+    index = :rand.uniform(length(color_list) - 1)
     col = Enum.at(color_list, index)
     color_list = List.delete_at(color_list, index)
     c = Map.put(c, :color_list, color_list)
@@ -185,6 +185,7 @@ defmodule Oli.Activities.Reports.Providers.OliLikert do
       end)
       |> Enum.join(" ---------- ")
 
+    IO.inspect(data)
     encoded = Jason.encode!(data)
 
     VegaLite.from_json("""

--- a/lib/oli/activities/reports/providers/OliLikert.ex
+++ b/lib/oli/activities/reports/providers/OliLikert.ex
@@ -209,7 +209,7 @@ defmodule Oli.Activities.Reports.Providers.OliLikert do
                       },
                       "axis": {
                           "labelAngle": 0,
-                          "titleFontSize": 20,
+                          "titleFontSize": 18,
                           "titleAlign": "center"
                       },
                       "title": "<-- #{groups} -->"
@@ -233,7 +233,8 @@ defmodule Oli.Activities.Reports.Providers.OliLikert do
                       "field": "choice",
                       "type": "nominal",
                       "sort": "descending",
-                      "title": "Choice"
+                      "title": "Choice",
+                      "axis": { "orient": "right" }
                   }
               }
           }


### PR DESCRIPTION
This PR reverts the Likert report back to how it looked in the previous PR, which closely matches what legacy displays. See the recording in the PR [https://github.com/Simon-Initiative/oli-torus/pull/4862](https://github.com/Simon-Initiative/oli-torus/pull/4862) for details
![Screenshot 2025-01-24 at 8 42 36 AM](https://github.com/user-attachments/assets/b0ced028-147d-4fb0-9696-e7c2897292c6)
