### PR TITLE
[BUG FIX] [MER-4131] | Dig into chem labs simulations

### DIFF
--- a/assets/src/apps/delivery/store/features/attempt/actions/savePart.ts
+++ b/assets/src/apps/delivery/store/features/attempt/actions/savePart.ts
@@ -62,7 +62,7 @@ export const savePartState = createAsyncThunk(
     if (isPreviewMode && updatedPartResponses?.partId?.length) {
       setVariableWithTypeAssignStatements(updatedPartResponses, updatedPartResponses?.partId);
     }
-    // update scripting env with latest value
+    // update scripting env with latest values
     const assignScripts = getAssignStatements(updatedPartResponses);
     const scriptResult: string[] = [];
     if (Array.isArray(assignScripts)) {

--- a/assets/src/apps/delivery/store/features/attempt/actions/savePart.ts
+++ b/assets/src/apps/delivery/store/features/attempt/actions/savePart.ts
@@ -44,7 +44,6 @@ export const savePartState = createAsyncThunk(
               updatedPartResponses = {
                 ...result.response,
                 ...updatedPartResponses,
-                partId: p.partId,
               };
               result.response = updatedPartResponses;
             }

--- a/assets/src/apps/delivery/store/features/attempt/actions/savePart.ts
+++ b/assets/src/apps/delivery/store/features/attempt/actions/savePart.ts
@@ -56,7 +56,7 @@ export const savePartState = createAsyncThunk(
     if (isPreviewMode && updatedPartResponses?.partId?.length) {
       setVariableWithTypeAssignStatements(updatedPartResponses, updatedPartResponses?.partId);
     }
-    // update scripting env with latest values
+    // update scripting env with latest value
     const assignScripts = getAssignStatements(updatedPartResponses);
     const scriptResult: string[] = [];
     if (Array.isArray(assignScripts)) {

--- a/assets/src/apps/delivery/store/features/attempt/actions/savePart.ts
+++ b/assets/src/apps/delivery/store/features/attempt/actions/savePart.ts
@@ -45,6 +45,12 @@ export const savePartState = createAsyncThunk(
                 ...result.response,
                 ...updatedPartResponses,
               };
+              if (isPreviewMode) {
+                updatedPartResponses = {
+                  ...updatedPartResponses,
+                  partId: p.partId,
+                };
+              }
               result.response = updatedPartResponses;
             }
             return result;


### PR DESCRIPTION
Hey @bsparks, could you please look at this PR? Thanks

I have updated the condition (`to make sure that the partId variable is used in _PREVIEW MODE ONLY & NOT SENT TO SERVER_`) to resolve the earlier issue where this was causing the part responses not to be saved on server hence resume mode and review mode was not working.

I have tested it with the preview mode / Resume mode / Review Mode and part responses are getting saved and are pre-filled in review mode.

Comment from the original PR where the changes were made (just for reference)->  https://github.com/Simon-Initiative/oli-torus/pull/5282

Previously, we did not save the variable type received during the handshake with the CAPI component. As a result, in the Inspector preview tool, the variable type was auto-detected based on its value. This approach caused issues with variables of type ENUM, as ENUMs require a dropdown with allowed values to be displayed. Instead, the current implementation incorrectly shows a text input because it was thinking ENUM values as string.

To address this specifically for the preview mode (Inspector tool), I have introduced a new variable, stage.${partId}.variables.Type, in the scripting (_PREVIEW MODE ONLY & NOT SENT TO SERVER_). This variable stores all variables along with their types and allowed values, ensuring correct representation in the preview tool.