### PR TITLE
[BUG FIX] [MER-4203] expose session_ttl_renewal and credentials_cache_store ttl as configurable env vars

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -41,9 +41,9 @@ end
 
 config :oli,
   # default is 15 minutes
-  session_ttl_renewal: get_env_as_integer("POW_SESSION_TTL_RENEWAL_MINUTES", "15"),
+  session_ttl_renewal: get_env_as_integer("SESSION_TTL_RENEWAL_MINUTES", "15"),
   # default is 30 minutes
-  credentials_cache_store_ttl: get_env_as_integer("POW_CREDENTIALS_CACHE_STORE_TTL_MINUTES", "30")
+  credentials_cache_store_ttl: get_env_as_integer("CREDENTIALS_CACHE_STORE_TTL_MINUTES", "30")
 
 # Production-only configurations
 if config_env() == :prod do

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -39,12 +39,6 @@ if get_env_as_boolean.("APPSIGNAL_ENABLE_LOGGING", "false") do
   config :logger, backends: [:console, {Appsignal.Logger.Backend, [group: "phoenix"]}]
 end
 
-config :oli,
-  # default is 15 minutes
-  session_ttl_renewal: get_env_as_integer.("SESSION_TTL_RENEWAL_MINUTES", "15"),
-  # default is 30 minutes
-  credentials_cache_store_ttl: get_env_as_integer.("CREDENTIALS_CACHE_STORE_TTL_MINUTES", "30")
-
 # Production-only configurations
 if config_env() == :prod do
   database_url =

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -41,9 +41,9 @@ end
 
 config :oli,
   # default is 15 minutes
-  session_ttl_renewal: get_env_as_integer("SESSION_TTL_RENEWAL_MINUTES", "15"),
+  session_ttl_renewal: get_env_as_integer.("SESSION_TTL_RENEWAL_MINUTES", "15"),
   # default is 30 minutes
-  credentials_cache_store_ttl: get_env_as_integer("CREDENTIALS_CACHE_STORE_TTL_MINUTES", "30")
+  credentials_cache_store_ttl: get_env_as_integer.("CREDENTIALS_CACHE_STORE_TTL_MINUTES", "30")
 
 # Production-only configurations
 if config_env() == :prod do

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -39,6 +39,12 @@ if get_env_as_boolean.("APPSIGNAL_ENABLE_LOGGING", "false") do
   config :logger, backends: [:console, {Appsignal.Logger.Backend, [group: "phoenix"]}]
 end
 
+config :oli,
+  # default is 15 minutes
+  session_ttl_renewal: get_env_as_integer("POW_SESSION_TTL_RENEWAL_MINUTES", "15"),
+  # default is 30 minutes
+  credentials_cache_store_ttl: get_env_as_integer("POW_CREDENTIALS_CACHE_STORE_TTL_MINUTES", "30")
+
 # Production-only configurations
 if config_env() == :prod do
   database_url =

--- a/lib/oli_web/pow/pow_helpers.ex
+++ b/lib/oli_web/pow/pow_helpers.ex
@@ -4,6 +4,13 @@ defmodule OliWeb.Pow.PowHelpers do
   alias Phoenix.{HTML, HTML.Link, HTML.Tag, Naming}
   alias PowAssent.Phoenix.AuthorizationController
 
+  defp get_env_as_integer(key, default) do
+    case System.get_env(key) do
+      nil -> default
+      value -> String.to_integer(value)
+    end
+  end
+
   def get_pow_config(:user) do
     [
       repo: Oli.Repo,
@@ -11,11 +18,12 @@ defmodule OliWeb.Pow.PowHelpers do
       current_user_assigns_key: :current_user,
       session_key: "user_auth",
       # default is 15 minutes
-      session_ttl_renewal: System.get_env("SESSION_TTL_RENEWAL_MS", :timer.minutes(15)),
+      session_ttl_renewal:
+        Application.get_env(:oli, :session_ttl_renewal, 15) |> :timer.minutes(),
       # default is 30 minutes
       credentials_cache_store:
         {Pow.Store.CredentialsCache,
-         ttl: System.get_env("CREDENTIALS_CACHE_STORE_TTL_MS", :timer.minutes(30))},
+         ttl: Application.get_env(:oli, :credentials_cache_store_ttl, 30) |> :timer.minutes()},
       plug: Pow.Plug.Session,
       web_module: OliWeb,
       routes_backend: OliWeb.Pow.UserRoutes,
@@ -40,11 +48,12 @@ defmodule OliWeb.Pow.PowHelpers do
       current_user_assigns_key: :current_author,
       session_key: "author_auth",
       # default is 15 minutes
-      session_ttl_renewal: System.get_env("SESSION_TTL_RENEWAL_MS", :timer.minutes(15)),
+      session_ttl_renewal:
+        Application.get_env(:oli, :session_ttl_renewal, 15) |> :timer.minutes(),
       # default is 30 minutes
       credentials_cache_store:
         {Pow.Store.CredentialsCache,
-         ttl: System.get_env("CREDENTIALS_CACHE_STORE_TTL_MS", :timer.minutes(30))},
+         ttl: Application.get_env(:oli, :credentials_cache_store_ttl, 30) |> :timer.minutes()},
       plug: Pow.Plug.Session,
       web_module: OliWeb,
       routes_backend: OliWeb.Pow.AuthorRoutes,

--- a/lib/oli_web/pow/pow_helpers.ex
+++ b/lib/oli_web/pow/pow_helpers.ex
@@ -4,13 +4,6 @@ defmodule OliWeb.Pow.PowHelpers do
   alias Phoenix.{HTML, HTML.Link, HTML.Tag, Naming}
   alias PowAssent.Phoenix.AuthorizationController
 
-  defp get_env_as_integer(key, default) do
-    case System.get_env(key) do
-      nil -> default
-      value -> String.to_integer(value)
-    end
-  end
-
   def get_pow_config(:user) do
     [
       repo: Oli.Repo,

--- a/lib/oli_web/pow/pow_helpers.ex
+++ b/lib/oli_web/pow/pow_helpers.ex
@@ -4,14 +4,19 @@ defmodule OliWeb.Pow.PowHelpers do
   alias Phoenix.{HTML, HTML.Link, HTML.Tag, Naming}
   alias PowAssent.Phoenix.AuthorizationController
 
+  defp get_env_as_integer(key, default) do
+    System.get_env(key, default)
+    |> String.to_integer()
+  end
+
   def get_pow_config(:user) do
     [
       repo: Oli.Repo,
       user: Oli.Accounts.User,
       current_user_assigns_key: :current_user,
       session_key: "user_auth",
-      # session_ttl_renewal: :timer.minutes(15),    # default is 15 minutes
-      # credentials_cache_store: {Pow.Store.CredentialsCache, ttl: :timer.minutes(30)}, # default is 30 minutes
+      session_ttl_renewal: System.get_env("SESSION_TTL_RENEWAL_MS", :timer.minutes(15)),    # default is 15 minutes
+      credentials_cache_store: {Pow.Store.CredentialsCache, ttl: System.get_env("CREDENTIALS_CACHE_STORE_TTL_MS", :timer.minutes(30))},  # default is 30 minutes
       plug: Pow.Plug.Session,
       web_module: OliWeb,
       routes_backend: OliWeb.Pow.UserRoutes,
@@ -35,8 +40,8 @@ defmodule OliWeb.Pow.PowHelpers do
       user: Oli.Accounts.Author,
       current_user_assigns_key: :current_author,
       session_key: "author_auth",
-      # session_ttl_renewal: :timer.minutes(15),    # default is 15 minutes
-      # credentials_cache_store: {Pow.Store.CredentialsCache, ttl: :timer.minutes(30)}, # default is 30 minutes
+      session_ttl_renewal: System.get_env("SESSION_TTL_RENEWAL_MS", :timer.minutes(15)),    # default is 15 minutes
+      credentials_cache_store: {Pow.Store.CredentialsCache, ttl: System.get_env("CREDENTIALS_CACHE_STORE_TTL_MS", :timer.minutes(30))},  # default is 30 minutes
       plug: Pow.Plug.Session,
       web_module: OliWeb,
       routes_backend: OliWeb.Pow.AuthorRoutes,

--- a/lib/oli_web/pow/pow_helpers.ex
+++ b/lib/oli_web/pow/pow_helpers.ex
@@ -4,6 +4,12 @@ defmodule OliWeb.Pow.PowHelpers do
   alias Phoenix.{HTML, HTML.Link, HTML.Tag, Naming}
   alias PowAssent.Phoenix.AuthorizationController
 
+  defp gen_env_minutes(env_key, default) do
+    System.get_env(env_key, default)
+    |> String.to_integer()
+    |> :timer.minutes()
+  end
+
   def get_pow_config(:user) do
     [
       repo: Oli.Repo,
@@ -11,12 +17,11 @@ defmodule OliWeb.Pow.PowHelpers do
       current_user_assigns_key: :current_user,
       session_key: "user_auth",
       # default is 15 minutes
-      session_ttl_renewal:
-        Application.get_env(:oli, :session_ttl_renewal, 15) |> :timer.minutes(),
+      session_ttl_renewal: gen_env_minutes("SESSION_TTL_RENEWAL_MINUTES", "15"),
       # default is 30 minutes
       credentials_cache_store:
         {Pow.Store.CredentialsCache,
-         ttl: Application.get_env(:oli, :credentials_cache_store_ttl, 30) |> :timer.minutes()},
+         ttl: gen_env_minutes("CREDENTIALS_CACHE_STORE_TTL_MINUTES", "30")},
       plug: Pow.Plug.Session,
       web_module: OliWeb,
       routes_backend: OliWeb.Pow.UserRoutes,
@@ -41,12 +46,11 @@ defmodule OliWeb.Pow.PowHelpers do
       current_user_assigns_key: :current_author,
       session_key: "author_auth",
       # default is 15 minutes
-      session_ttl_renewal:
-        Application.get_env(:oli, :session_ttl_renewal, 15) |> :timer.minutes(),
+      session_ttl_renewal: gen_env_minutes("SESSION_TTL_RENEWAL_MINUTES", "15"),
       # default is 30 minutes
       credentials_cache_store:
         {Pow.Store.CredentialsCache,
-         ttl: Application.get_env(:oli, :credentials_cache_store_ttl, 30) |> :timer.minutes()},
+         ttl: gen_env_minutes("CREDENTIALS_CACHE_STORE_TTL_MINUTES", "30")},
       plug: Pow.Plug.Session,
       web_module: OliWeb,
       routes_backend: OliWeb.Pow.AuthorRoutes,

--- a/lib/oli_web/pow/pow_helpers.ex
+++ b/lib/oli_web/pow/pow_helpers.ex
@@ -4,19 +4,18 @@ defmodule OliWeb.Pow.PowHelpers do
   alias Phoenix.{HTML, HTML.Link, HTML.Tag, Naming}
   alias PowAssent.Phoenix.AuthorizationController
 
-  defp get_env_as_integer(key, default) do
-    System.get_env(key, default)
-    |> String.to_integer()
-  end
-
   def get_pow_config(:user) do
     [
       repo: Oli.Repo,
       user: Oli.Accounts.User,
       current_user_assigns_key: :current_user,
       session_key: "user_auth",
-      session_ttl_renewal: System.get_env("SESSION_TTL_RENEWAL_MS", :timer.minutes(15)),    # default is 15 minutes
-      credentials_cache_store: {Pow.Store.CredentialsCache, ttl: System.get_env("CREDENTIALS_CACHE_STORE_TTL_MS", :timer.minutes(30))},  # default is 30 minutes
+      # default is 15 minutes
+      session_ttl_renewal: System.get_env("SESSION_TTL_RENEWAL_MS", :timer.minutes(15)),
+      # default is 30 minutes
+      credentials_cache_store:
+        {Pow.Store.CredentialsCache,
+         ttl: System.get_env("CREDENTIALS_CACHE_STORE_TTL_MS", :timer.minutes(30))},
       plug: Pow.Plug.Session,
       web_module: OliWeb,
       routes_backend: OliWeb.Pow.UserRoutes,
@@ -40,8 +39,12 @@ defmodule OliWeb.Pow.PowHelpers do
       user: Oli.Accounts.Author,
       current_user_assigns_key: :current_author,
       session_key: "author_auth",
-      session_ttl_renewal: System.get_env("SESSION_TTL_RENEWAL_MS", :timer.minutes(15)),    # default is 15 minutes
-      credentials_cache_store: {Pow.Store.CredentialsCache, ttl: System.get_env("CREDENTIALS_CACHE_STORE_TTL_MS", :timer.minutes(30))},  # default is 30 minutes
+      # default is 15 minutes
+      session_ttl_renewal: System.get_env("SESSION_TTL_RENEWAL_MS", :timer.minutes(15)),
+      # default is 30 minutes
+      credentials_cache_store:
+        {Pow.Store.CredentialsCache,
+         ttl: System.get_env("CREDENTIALS_CACHE_STORE_TTL_MS", :timer.minutes(30))},
       plug: Pow.Plug.Session,
       web_module: OliWeb,
       routes_backend: OliWeb.Pow.AuthorRoutes,


### PR DESCRIPTION
Exposes Pow `session_ttl_renewal` and `credentials_cache_store` ttl as configurable environment variables.