### PR TITLE
[BUG FIX] [MER-4075] cant access video settings

### DIFF
--- a/assets/src/apps/Components.tsx
+++ b/assets/src/apps/Components.tsx
@@ -21,10 +21,8 @@ import { globalStore } from 'state/store';
 import { VideoPlayer } from '../components/video_player/VideoPlayer';
 import { OfflineDetector } from './OfflineDetector';
 import ActivityBank from './bank/ActivityBank';
-import Bibliography from './bibliography/Bibliography';
 import { References } from './bibliography/References';
 
-registerApplication('Bibliography', Bibliography, globalStore);
 registerApplication('ModalDisplay', ModalDisplay, globalStore);
 registerApplication('DarkModeSelector', DarkModeSelector);
 registerApplication('PaginationControls', PaginationControls, globalStore);

--- a/assets/src/apps/app.tsx
+++ b/assets/src/apps/app.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react';
 import { Provider } from 'react-redux';
 import { AnyAction, Store } from 'redux';
 import { Maybe } from 'tsmonad';
+import { ModalDisplay } from 'components/modal/ModalDisplay';
 
 /**
  * Creates a redux store and returns a component that wires up a <Provider>, <ModalDisplay> and <Component>
@@ -15,6 +16,7 @@ const wrapWithRedux = (Component: FC, name: string, store: Store<any, AnyAction>
     return (
       <Provider store={store}>
         <Component {...props} />
+        <ModalDisplay />
       </Provider>
     );
   });

--- a/assets/src/components/editing/elements/audio/AudioSettings.tsx
+++ b/assets/src/components/editing/elements/audio/AudioSettings.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { useDispatch } from 'react-redux';
 import { Tooltip } from 'components/common/Tooltip';
 import { CommandContext } from 'components/editing/elements/commands/interfaces';
 import { Modal, ModalSize } from 'components/modal/Modal';
@@ -20,20 +19,19 @@ interface SettingsButtonProps {
   onEdit: (attrs: Partial<ContentModel.Audio>) => void;
 }
 export const SettingsButton = (props: SettingsButtonProps) => {
-  const dispatch = useDispatch();
   return (
     <DescriptiveButton
       description={createButtonCommandDesc({
         icon: <i className="fa-solid fa-circle-play"></i>,
         description: 'Settings',
         execute: (_context, _editor, _params) =>
-          dispatch(
+          window.oliDispatch(
             modalActions.display(
               <AudioSettingsModal
                 commandContext={props.commandContext}
                 model={props.model}
                 onEdit={(audio: Partial<ContentModel.Audio>) => {
-                  dispatch(modalActions.dismiss());
+                  window.oliDispatch(modalActions.dismiss());
                   props.onEdit(audio);
                 }}
                 onCancel={() => window.oliDispatch(modalActions.dismiss())}

--- a/assets/src/components/editing/elements/audio/AudioSettings.tsx
+++ b/assets/src/components/editing/elements/audio/AudioSettings.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useDispatch } from 'react-redux';
 import { Tooltip } from 'components/common/Tooltip';
 import { CommandContext } from 'components/editing/elements/commands/interfaces';
 import { Modal, ModalSize } from 'components/modal/Modal';
@@ -19,22 +20,24 @@ interface SettingsButtonProps {
   onEdit: (attrs: Partial<ContentModel.Audio>) => void;
 }
 export const SettingsButton = (props: SettingsButtonProps) => {
+  const dispatch = useDispatch();
+
   return (
     <DescriptiveButton
       description={createButtonCommandDesc({
         icon: <i className="fa-solid fa-circle-play"></i>,
         description: 'Settings',
         execute: (_context, _editor, _params) =>
-          window.oliDispatch(
+          dispatch(
             modalActions.display(
               <AudioSettingsModal
                 commandContext={props.commandContext}
                 model={props.model}
                 onEdit={(audio: Partial<ContentModel.Audio>) => {
-                  window.oliDispatch(modalActions.dismiss());
+                  dispatch(modalActions.dismiss());
                   props.onEdit(audio);
                 }}
-                onCancel={() => window.oliDispatch(modalActions.dismiss())}
+                onCancel={() => dispatch(modalActions.dismiss())}
               />,
             ),
           ),

--- a/assets/src/components/editing/elements/video/VideoSettings.tsx
+++ b/assets/src/components/editing/elements/video/VideoSettings.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useDispatch } from 'react-redux';
 import { createButtonCommandDesc } from 'components/editing/elements/commands/commandFactories';
 import { CommandContext } from 'components/editing/elements/commands/interfaces';
 import { Toolbar } from 'components/editing/toolbar/Toolbar';
@@ -36,7 +35,6 @@ interface SettingsButtonProps {
 }
 
 const SettingsButton = (props: SettingsButtonProps) => {
-  const dispatch = useDispatch();
   return (
     <DescriptiveButton
       description={createButtonCommandDesc({
@@ -51,7 +49,7 @@ const SettingsButton = (props: SettingsButtonProps) => {
                 projectSlug={props.projectSlug}
                 model={props.model}
                 onDone={(video: Partial<ContentModel.Video>) => {
-                  dispatch(modalActions.dismiss());
+                  window.oliDispatch(modalActions.dismiss());
                   props.onEdit(video);
                 }}
                 onCancel={() => window.oliDispatch(modalActions.dismiss())}

--- a/assets/src/components/editing/elements/video/VideoSettings.tsx
+++ b/assets/src/components/editing/elements/video/VideoSettings.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useDispatch } from 'react-redux';
 import { createButtonCommandDesc } from 'components/editing/elements/commands/commandFactories';
 import { CommandContext } from 'components/editing/elements/commands/interfaces';
 import { Toolbar } from 'components/editing/toolbar/Toolbar';
@@ -35,6 +36,8 @@ interface SettingsButtonProps {
 }
 
 const SettingsButton = (props: SettingsButtonProps) => {
+  const dispatch = useDispatch();
+
   return (
     <DescriptiveButton
       description={createButtonCommandDesc({
@@ -43,16 +46,16 @@ const SettingsButton = (props: SettingsButtonProps) => {
         execute: (_context, _editor, _params) => {
           console.log('SettingsButton clicked');
 
-          window.oliDispatch(
+          dispatch(
             modalActions.display(
               <VideoModal
                 projectSlug={props.projectSlug}
                 model={props.model}
                 onDone={(video: Partial<ContentModel.Video>) => {
-                  window.oliDispatch(modalActions.dismiss());
+                  dispatch(modalActions.dismiss());
                   props.onEdit(video);
                 }}
-                onCancel={() => window.oliDispatch(modalActions.dismiss())}
+                onCancel={() => dispatch(modalActions.dismiss())}
               />,
             ),
           );

--- a/assets/src/components/editing/elements/video/VideoSettings.tsx
+++ b/assets/src/components/editing/elements/video/VideoSettings.tsx
@@ -42,8 +42,10 @@ const SettingsButton = (props: SettingsButtonProps) => {
       description={createButtonCommandDesc({
         icon: <i className="fa-solid fa-video"></i>,
         description: 'Settings',
-        execute: (_context, _editor, _params) =>
-          dispatch(
+        execute: (_context, _editor, _params) => {
+          console.log('SettingsButton clicked');
+
+          window.oliDispatch(
             modalActions.display(
               <VideoModal
                 projectSlug={props.projectSlug}
@@ -55,7 +57,8 @@ const SettingsButton = (props: SettingsButtonProps) => {
                 onCancel={() => window.oliDispatch(modalActions.dismiss())}
               />,
             ),
-          ),
+          );
+        },
       })}
     />
   );

--- a/lib/oli_web/components/layouts/workspace.html.heex
+++ b/lib/oli_web/components/layouts/workspace.html.heex
@@ -118,5 +118,4 @@
       Map.get(assigns, :has_license) && assigns[:license]
     } />
   </div>
-  <%= react_component("Components.ModalDisplay") %>
 </main>

--- a/lib/oli_web/live/workspaces/course_author/activity_bank_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/activity_bank_live.ex
@@ -49,7 +49,6 @@ defmodule OliWeb.Workspaces.CourseAuthor.ActivityBankLive do
             id: "activity-bank"
           ) %>
         </div>
-        <%= React.component(@ctx, "Components.ModalDisplay", %{}, id: "modal-display") %>
       <% else %>
         <.loader />
       <% end %>

--- a/lib/oli_web/live/workspaces/course_author/bibliography_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/bibliography_live.ex
@@ -40,12 +40,13 @@ defmodule OliWeb.Workspaces.CourseAuthor.BibliographyLive do
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
+    <script type="text/javascript" src={Routes.static_path(OliWeb.Endpoint, "/js/bibliography.js")}>
+    </script>
+
     <h2 id="header_id" class="pb-2">Bibliography</h2>
     <div :if={!@error} id="editor" phx-update="ignore">
       <%= React.component(@ctx, "Components.Bibliography", @context, id: "bibliography") %>
     </div>
-
-    <%= React.component(@ctx, "Components.ModalDisplay", @context, id: "modal-display") %>
     """
   end
 end

--- a/lib/oli_web/templates/layout/workspace.html.heex
+++ b/lib/oli_web/templates/layout/workspace.html.heex
@@ -31,6 +31,4 @@
       </div>
     </div>
   </div>
-
-  <%= react_component("Components.ModalDisplay") %>
 <% end %>

--- a/test/oli_web/live/workspaces/course_author/activity_bank_live_test.exs
+++ b/test/oli_web/live/workspaces/course_author/activity_bank_live_test.exs
@@ -62,7 +62,6 @@ defmodule OliWeb.Workspaces.CourseAuthor.ActivityBankLiveTest do
       refute has_element?(view, "#eventIntercept [role='status']")
 
       assert has_element?(view, ~s(div[data-live-react-class='Components.ActivityBank']))
-      assert has_element?(view, ~s(div[data-live-react-class='Components.ModalDisplay']))
     end
 
     test "renders error message when failed to load scripts", %{conn: conn, project: project} do


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-4075

This PR fixes an issue where the Video and Audio settings modals weren't appearing in the basic page editor. I originally fixed the issue by replacing the `useDispatcher` approach with `window.oliDispatch`, though this was only a bandaid and I then noticed once modals were working that some functionality within the modals were still broken, as seen in the screen capture below.
![2025-01-27 15 47 50](https://github.com/user-attachments/assets/93453089-deaa-41a9-b704-17705b656a10)


The root cause of the issue was the missing `<ModalDisplay />` component that should be added when client components and apps get registered. This was previously removed to fix a 'double modal' effect in certain views, specifically the Bibliography view. So readding this also reintroduced the double modal issue which needed to be fixed by removing the duplicate registration of the Bibliography component (both in BibliographyApp and Components) by removing it from Components and just using the BibliographyApp script in the bibliography live view.