### PR TITLE
[BUG FIX] [MER-3749] Grid and Guide Options for Simple & Advanced Author Interface

### DIFF
--- a/assets/src/apps/authoring/components/EditingCanvas/EditingCanvas.tsx
+++ b/assets/src/apps/authoring/components/EditingCanvas/EditingCanvas.tsx
@@ -119,7 +119,7 @@ const EditingCanvas: React.FC = () => {
       interfaceSettingClass += ' show-column-guide';
     }
     if (_currentLessonCustom.centerpoint) {
-      interfaceSettingClass += ' show-grid show-center';
+      interfaceSettingClass += ' show-center';
     }
     if (_currentLessonCustom.rowGuides) {
       interfaceSettingClass += ' show-row-guide';


### PR DESCRIPTION
Hey @bsparks, could you please look at the PR? Thanks

This PR is based on the changes done in the https://github.com/Simon-Initiative/oli-torus/pull/5351.

Currently, when user checks only the "CenterPoint" check box 'show-grid show-center' class was getting added instead of only 'show-center'. 