### PR TITLE
[BUG FIX] [MER-4216] correct case in AI icon url

### DIFF
--- a/assets/src/components/activities/common/triggers/TriggerAuthoring.tsx
+++ b/assets/src/components/activities/common/triggers/TriggerAuthoring.tsx
@@ -153,7 +153,7 @@ export const TriggerAuthoring: React.FC<Props> = ({ partId }) => {
   return (
     <>
       <h4>
-        <img src="/images/icons/icon-ai.svg" className="inline mr-1" />
+        <img src="/images/icons/icon-AI.svg" className="inline mr-1" />
         DOT AI Activity Trigger Point
       </h4>
       <p className="mt-2">
@@ -186,7 +186,7 @@ export const TriggerAuthoring: React.FC<Props> = ({ partId }) => {
 export const TriggerLabel = () => {
   return (
     <span>
-      <img src="/images/icons/icon-ai.svg" className="inline" />
+      <img src="/images/icons/icon-AI.svg" className="inline" />
       DOT AI
     </span>
   );


### PR DESCRIPTION
The AI icon was not appearing on the activity authoring tab because the URL used by the code to load AI icon does not exactly match case of the file icon-AI.svg. This was missed because it worked in local dev environment on MacOS, apparently case-insensitive, but does not work on our servers, apparently case-sensitive. Live and learn.