### PR TITLE
[BUG FIX] [MER-4191] Exploration pages dont display in explorations tab

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -22,7 +22,8 @@ defmodule Oli.Delivery.Sections do
     Enrollment,
     EnrollmentBrowseOptions,
     EnrollmentContextRole,
-    Scheduling
+    Scheduling,
+    MinimalHierarchy
   }
 
   alias Lti_1p3.Tool.ContextRole
@@ -1803,12 +1804,11 @@ defmodule Oli.Delivery.Sections do
   def fetch_ordered_container_labels(section_slug, opts \\ []) do
     short_label = opts[:short_label] || false
 
-    # TODO: OPTIMIZATION replace this with a minimal hierarchy query after v26.2 is merged
     %Section{customizations: customizations} = get_section_by_slug(section_slug)
-    full_hierarchy = DeliveryResolver.full_hierarchy(section_slug)
+    full_hierarchy = MinimalHierarchy.full_hierarchy(section_slug)
 
     full_hierarchy
-    |> Hierarchy.flatten()
+    |> Hierarchy.flatten_hierarchy()
     |> Enum.filter(fn node ->
       node.revision.resource_type_id == ResourceType.get_id_by_type("container")
     end)

--- a/test/oli/delivery/sections_test.exs
+++ b/test/oli/delivery/sections_test.exs
@@ -1046,6 +1046,7 @@ defmodule Oli.Delivery.SectionsTest do
 
     test "returns the correct ordered container labels for a section", %{
       section: section,
+      curriculum: curriculum,
       unit1: unit1,
       unit1_module1: unit1_module1,
       unit1_module1_section1: unit1_module1_section1,
@@ -1055,22 +1056,24 @@ defmodule Oli.Delivery.SectionsTest do
     } do
       ordered_labels = Sections.fetch_ordered_container_labels(section.slug)
 
-      assert Enum.count(ordered_labels) == 6
+      assert Enum.count(ordered_labels) == 7
 
-      assert Enum.at(ordered_labels, 0) == {unit1.resource_id, "Unit 1: Unit 1"}
+      assert Enum.at(ordered_labels, 0) == {curriculum.resource_id, "Curriculum 1: Curriculum"}
 
-      assert Enum.at(ordered_labels, 1) ==
-               {unit1_module1.resource_id, "Module 1: Unit 1 Module 1"}
+      assert Enum.at(ordered_labels, 1) == {unit1.resource_id, "Unit 1: Unit 1"}
 
       assert Enum.at(ordered_labels, 2) ==
-               {unit1_module1_section1.resource_id, "Section 1: Unit 1 Module 1 Section 1"}
+               {unit1_module1.resource_id, "Module 1: Unit 1 Module 1"}
 
       assert Enum.at(ordered_labels, 3) ==
+               {unit1_module1_section1.resource_id, "Section 1: Unit 1 Module 1 Section 1"}
+
+      assert Enum.at(ordered_labels, 4) ==
                {unit1_module2.resource_id, "Module 2: Unit 1 Module 2"}
 
-      assert Enum.at(ordered_labels, 4) == {unit2.resource_id, "Unit 2: Unit 2"}
+      assert Enum.at(ordered_labels, 5) == {unit2.resource_id, "Unit 2: Unit 2"}
 
-      assert Enum.at(ordered_labels, 5) ==
+      assert Enum.at(ordered_labels, 6) ==
                {unit2_module3.resource_id, "Module 3: Unit 2 Module 3"}
     end
   end

--- a/test/oli_web/live/delivery/student/explorations_live_test.exs
+++ b/test/oli_web/live/delivery/student/explorations_live_test.exs
@@ -33,6 +33,38 @@ defmodule OliWeb.Delivery.Student.ExplorationsLiveTest do
         purpose: :application
       )
 
+    basic_exploration_orphan_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.get_id_by_type("page"),
+        title: "Basic Exploration Orphan Page",
+        duration_minutes: 10,
+        purpose: :application,
+        graded: true
+      )
+
+    adaptive_exploration_orphan_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.get_id_by_type("page"),
+        title: "Adaptive Exploration Orphan Page",
+        duration_minutes: 10,
+        purpose: :application,
+        graded: true,
+        content: %{
+          "model" => [],
+          "advancedDelivery" => true,
+          "displayApplicationChrome" => false
+        }
+      )
+
+    non_exploration_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.get_id_by_type("page"),
+        title: "Non Exploration Page",
+        duration_minutes: 10,
+        purpose: :foundation,
+        graded: true
+      )
+
     ## units...
     unit_1_revision =
       insert(:revision, %{
@@ -45,7 +77,12 @@ defmodule OliWeb.Delivery.Student.ExplorationsLiveTest do
     container_revision =
       insert(:revision, %{
         resource_type_id: Oli.Resources.ResourceType.get_id_by_type("container"),
-        children: [unit_1_revision.resource_id],
+        children: [
+          unit_1_revision.resource_id,
+          basic_exploration_orphan_revision.resource_id,
+          adaptive_exploration_orphan_revision.resource_id,
+          non_exploration_revision.resource_id
+        ],
         title: "Root Container"
       })
 
@@ -53,6 +90,9 @@ defmodule OliWeb.Delivery.Student.ExplorationsLiveTest do
       [
         exploration_1_revision,
         exploration_2_revision,
+        basic_exploration_orphan_revision,
+        adaptive_exploration_orphan_revision,
+        non_exploration_revision,
         unit_1_revision,
         container_revision
       ]
@@ -97,8 +137,12 @@ defmodule OliWeb.Delivery.Student.ExplorationsLiveTest do
       section: section,
       project: project,
       publication: publication,
+      container: container_revision,
       exploration_1: exploration_1_revision,
-      exploration_2: exploration_2_revision
+      exploration_2: exploration_2_revision,
+      basic_exploration_orphan: basic_exploration_orphan_revision,
+      adaptive_exploration_orphan: adaptive_exploration_orphan_revision,
+      non_exploration: non_exploration_revision
     }
   end
 
@@ -161,6 +205,39 @@ defmodule OliWeb.Delivery.Student.ExplorationsLiveTest do
 
       # the redirected page will show the prologue or go directly to the exploration
       # if there is an attempt in progress
+    end
+
+    test "orphaned pages are shown correctly in the explorations tab", %{
+      conn: conn,
+      user: user,
+      section: section,
+      basic_exploration_orphan: basic_exploration_orphan,
+      adaptive_exploration_orphan: adaptive_exploration_orphan,
+      container: container
+    } do
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.mark_section_visited_for_student(section, user)
+
+      {:ok, view, _html} = live(conn, ~p"/sections/#{section.slug}/explorations")
+
+      # assert the container title and the orphaned pages are shown
+      assert has_element?(view, "h2", "Curriculum 1: #{container.title}")
+      assert has_element?(view, "h5", basic_exploration_orphan.title)
+      assert has_element?(view, "h5", adaptive_exploration_orphan.title)
+    end
+
+    test "a non exploration page is not shown in the explorations tab", %{
+      conn: conn,
+      user: user,
+      section: section,
+      non_exploration: non_exploration
+    } do
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.mark_section_visited_for_student(section, user)
+
+      {:ok, view, _html} = live(conn, ~p"/sections/#{section.slug}/explorations")
+
+      refute has_element?(view, "h5", non_exploration.title)
     end
   end
 end


### PR DESCRIPTION
[MER-4191](https://eliterate.atlassian.net/browse/MER-4191)

This PR addresses a bug where exploration purpose pages that are not contained within a Unit or Module type container (orphaned pages) were not displayed in the Explorations tab.

**Root Cause**

The issue was caused by incorrectly retrieving the hierarchy data to display exploration pages. Previously, we were using the function `Hierarchy.flatten`, which only considers pages inside Unit or Module type containers. This approach overlooked pages that are directly attached to the root container, leading to them not being displayed in the Explorations tab.

**Fix**

To ensure that all exploration purpose pages are correctly included, we replaced `Hierarchy.flatten` with `Hierarchy.flatten_hierarchy`. Unlike the previous function, `flatten_hierarchy` properly retrieves all elements in the hierarchy, including those directly attached to the root container. This fix ensures that both basic and adaptive exploration pages are now correctly displayed in the Explorations tab.

Additionally, the method used to retrieve the hierarchy was updated based on an existing To Do in the code, which aimed to optimize the way the hierarchy is fetched. Previously, `DeliveryResolver.full_hierarchy(section_slug)` was used, but it has now been replaced with `MinimalHierarchy.full_hierarchy(section_slug)`. 

- Before
<img width="1440" alt="explorations-tab-before" src="https://github.com/user-attachments/assets/b1de7b9c-b992-4d08-8dd2-f7ec0ec0d079" />


- After
<img width="1440" alt="explorations-tab-after" src="https://github.com/user-attachments/assets/b43c51ad-c063-426b-a21b-e8a249afaa48" />


[MER-4191]: https://eliterate.atlassian.net/browse/MER-4191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ