### PR TITLE
[ENHANCEMENT] [MER-4175] Redirect instructor the correct workspace after login and logout

### DIFF
--- a/lib/oli_web/controllers/invite_controller.ex
+++ b/lib/oli_web/controllers/invite_controller.ex
@@ -38,6 +38,7 @@ defmodule OliWeb.InviteController do
       params
       |> put_in(["user", "email"], email)
       |> put_in(["user", "request_path"], ~p"/sections/#{section_slug}")
+      |> Map.put("section", section_slug)
 
     UserSessionController.create(conn, params, flash_message: nil)
   end

--- a/lib/oli_web/controllers/user_session_controller.ex
+++ b/lib/oli_web/controllers/user_session_controller.ex
@@ -18,13 +18,11 @@ defmodule OliWeb.UserSessionController do
     create(conn, params, flash_message: "Welcome back!")
   end
 
-  def create(conn, %{"user" => user_params}, opts) do
-    %{"email" => email, "password" => password} = user_params
-
+  def create(conn, %{"user" => %{"email" => email, "password" => password}} = params, opts) do
     if user = Accounts.get_user_by_email_and_password(email, password) do
       conn
       |> maybe_add_flash_message(opts[:flash_message])
-      |> UserAuth.log_in_user(user, user_params)
+      |> UserAuth.log_in_user(user, params)
     else
       # In order to prevent user enumeration attacks, don't disclose whether the email is registered.
       conn

--- a/lib/oli_web/user_auth.ex
+++ b/lib/oli_web/user_auth.ex
@@ -23,7 +23,7 @@ defmodule OliWeb.UserAuth do
   def log_in_user(conn, user, params \\ %{}) do
     token = Accounts.generate_user_session_token(user)
 
-    %{"user" => user_params} = params
+    user_params = Map.get(params, "user", %{})
 
     user_return_to =
       maybe_return_to_section(params["section"]) || params["request_path"] ||
@@ -122,7 +122,7 @@ defmodule OliWeb.UserAuth do
   It clears all session data for safety. See renew_session.
   """
   def log_out_user(conn) do
-    user = conn.assigns.current_user
+    user = Map.get(conn.assigns, :current_user)
 
     redirect_to =
       if !is_nil(user) && Sections.is_independent_instructor?(user) do

--- a/lib/oli_web/user_auth.ex
+++ b/lib/oli_web/user_auth.ex
@@ -6,6 +6,7 @@ defmodule OliWeb.UserAuth do
 
   alias Oli.Accounts
   alias Oli.Accounts.{User}
+  alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.Section
   alias OliWeb.AuthorAuth
 
@@ -22,6 +23,8 @@ defmodule OliWeb.UserAuth do
   def log_in_user(conn, user, params \\ %{}) do
     token = Accounts.generate_user_session_token(user)
 
+    %{"user" => user_params} = params
+
     user_return_to =
       maybe_return_to_section(params["section"]) || params["request_path"] ||
         get_session(conn, :user_return_to) || signed_in_path(conn)
@@ -33,7 +36,7 @@ defmodule OliWeb.UserAuth do
     # We eventually want to remove this, but for now, we will add it to appease the existing code.
     |> put_user_id_in_session(user.id)
     |> create_datashop_session_id()
-    |> maybe_write_remember_me_cookie(token, params)
+    |> maybe_write_remember_me_cookie(token, user_params)
     |> redirect(to: user_return_to)
   end
 
@@ -119,9 +122,18 @@ defmodule OliWeb.UserAuth do
   It clears all session data for safety. See renew_session.
   """
   def log_out_user(conn) do
+    user = conn.assigns.current_user
+
+    redirect_to =
+      if !is_nil(user) && Sections.is_independent_instructor?(user) do
+        ~p"/instructors/log_in"
+      else
+        ~p"/"
+      end
+
     conn
     |> clear_all_session_data()
-    |> redirect(to: ~p"/")
+    |> redirect(to: redirect_to)
   end
 
   @doc """

--- a/test/oli_web/live/user_login_live_test.exs
+++ b/test/oli_web/live/user_login_live_test.exs
@@ -35,7 +35,7 @@ defmodule OliWeb.UserLoginLiveTest do
 
       conn = submit_form(form, conn)
 
-      assert redirected_to(conn) == ~p"/workspaces/student"
+      assert redirected_to(conn) == ~p"/workspaces/instructor"
     end
 
     test "redirects to login page with a flash error if there are no valid credentials", %{

--- a/test/oli_web/user_auth_test.exs
+++ b/test/oli_web/user_auth_test.exs
@@ -39,7 +39,11 @@ defmodule OliWeb.UserAuthTest do
     end
 
     test "writes a cookie if remember_me is configured", %{conn: conn, user: user} do
-      conn = conn |> fetch_cookies() |> UserAuth.log_in_user(user, %{"remember_me" => "true"})
+      conn =
+        conn
+        |> fetch_cookies()
+        |> UserAuth.log_in_user(user, %{"user" => %{"remember_me" => "true"}})
+
       assert get_session(conn, :user_token) == conn.cookies[@remember_me_cookie]
 
       assert %{value: signed_token, max_age: max_age} = conn.resp_cookies[@remember_me_cookie]
@@ -94,7 +98,9 @@ defmodule OliWeb.UserAuthTest do
 
     test "authenticates user from cookies", %{conn: conn, user: user} do
       logged_in_conn =
-        conn |> fetch_cookies() |> UserAuth.log_in_user(user, %{"remember_me" => "true"})
+        conn
+        |> fetch_cookies()
+        |> UserAuth.log_in_user(user, %{"user" => %{"remember_me" => "true"}})
 
       user_token = logged_in_conn.cookies[@remember_me_cookie]
       %{value: signed_token} = logged_in_conn.resp_cookies[@remember_me_cookie]


### PR DESCRIPTION
This PR addresses an issue where anyone who logs in via the Instructor interface is redirected to the Student workspace instead of the Instructor workspace. It also fixes Instructor logout so that instructors are redirected to the instructor login after logging out.