### PR TITLE
[BUG FIX] [MER-4132] Reimplement authors invite functionality - part 2

### DIFF
--- a/lib/oli/authoring/collaborators.ex
+++ b/lib/oli/authoring/collaborators.ex
@@ -96,7 +96,7 @@ defmodule Oli.Authoring.Collaborators do
       :collaborator_invitation,
       %{
         inviter: inviter_name,
-        url: url(OliWeb.Endpoint, ~p"/users/invite/#{email_data.token}"),
+        url: url(OliWeb.Endpoint, ~p"/collaborators/invite/#{email_data.token}"),
         project_title: project_title
       }
     )


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-4132?focusedCommentId=25314) to the comment in the ticket

#### Root cause

In [this commit](https://github.com/Simon-Initiative/oli-torus/pull/5337/commits/ac5a8a0642046d5d2036b708663a32368c39a4ad) of the previous PR I accidentally wrote "users" instead of "collaborators" when implementing the `url()` function.
This error caused that the email invitation pointed to the users liveview instead of the collaborators one, which caused we ended up looking for the token in the `users_token` table instead of doing it in the `authors_token` table.
Since the token was not found, the liveview returned the "This invitation has expired or does not exist" message.