### PR TITLE
[BUG FIX] [MER-4132] Reimplement authors invite functionality - part 3

### DIFF
--- a/lib/oli/authoring/course.ex
+++ b/lib/oli/authoring/course.ex
@@ -160,7 +160,7 @@ defmodule Oli.Authoring.Course do
        ) do
     owner_id = Oli.Authoring.Authors.ProjectRole.role_id().owner
 
-    filter_by_collaborator = dynamic([a, _, _, _], a.author_id == ^id)
+    filter_by_collaborator = dynamic([c, _, _, _], c.author_id == ^id and c.status == :accepted)
 
     filter_by_status =
       if include_deleted do
@@ -186,7 +186,6 @@ defmodule Oli.Authoring.Course do
       |> where(^filter_by_collaborator)
       |> where(^filter_by_status)
       |> where(^filter_by_text)
-      |> where([_, _, o, _], o.status == :accepted and o.author_id == ^id)
       |> limit(^limit)
       |> offset(^offset)
       |> select([_, p, _, a], %{


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-4132?focusedCommentId=25539) to the comment in the ticket

#### Issue
When an author accepts a collaborator invitation, the accepted project is not listed in the "Course Author" workspace. So, the collaborator could access the project only by the email invitation link or by hardcoding the URL.

#### Root cause
The query fetching all the author's projects (as an owner or as a collaborator) incorrectly checked the AuthorProject `status` and `author_id` on the owner binding instead of doing it on the collaborator binding.

#### Fixed issue example (inviting `a_new_author@test.com` as a collaborator to the `Custom Chemistry` project)
Note that the project is not immediately listed after the invitation was sent. Only after the collaborator accepts the invitation the corresponding project gets listed.



https://github.com/user-attachments/assets/cdd42cb6-bc55-4485-9660-af7364c3df1f



