### PR TITLE
[ENHANCEMENT] [MER-4217] fix sub type concat

### DIFF
--- a/lib/oli/analytics/datasets/emr_serverless.ex
+++ b/lib/oli/analytics/datasets/emr_serverless.ex
@@ -140,7 +140,7 @@ defmodule Oli.Analytics.Datasets.EmrServerless do
       "--chunk_size",
       "#{job.configuration.chunk_size}",
       "--sub_types",
-      "#{if job.job_type == :datashop, do: "datashop", else: job.configuration.event_sub_types}",
+      "#{if job.job_type == :datashop, do: "datashop", else: job.configuration.event_sub_types |> to_str}",
       "--job_id",
       "#{job.job_id}",
       "--section_ids",


### PR DESCRIPTION
This PR adds the missing `|> to_str` to turn the list of sub types into a comma separated string, suitable as an EMR command line argument value. 

Without this, many of the jobs are return zero results - due to no matching event subtypes. 