### PR TITLE
[ENHANCEMENT] [MER-4085] Certificates Thresholds Tab Improvements

### DIFF
--- a/lib/oli_web/live/certificates/certificate_settings_component.ex
+++ b/lib/oli_web/live/certificates/certificate_settings_component.ex
@@ -238,7 +238,7 @@ defmodule OliWeb.Certificates.CertificateSettingsComponent do
         <.input
           field={f[:assessments_apply_to]}
           type="hidden"
-          value={if @selected_ids == [], do: :all, else: :custom}
+          value={if length(@selected_ids) == length(@graded_pages_options), do: :all, else: :custom}
         />
 
         <div class="w-3/4 flex-col justify-start items-start gap-10 inline-flex">
@@ -305,7 +305,6 @@ defmodule OliWeb.Certificates.CertificateSettingsComponent do
                         max="100.0"
                         step="0.1"
                         field={f[:min_percentage_for_completion]}
-                        errors={f.errors}
                         class="pl-6 border-[#D4D4D4] rounded"
                       />
                       <span class="absolute right-8 top-1/2 transform -translate-y-1/2 text-gray-500 pointer-events-none">
@@ -353,6 +352,8 @@ defmodule OliWeb.Certificates.CertificateSettingsComponent do
                     selected_resource_ids={@selected_ids}
                   />
                 </div>
+                <% errors = f.errors[:custom_assessments] %>
+                <.error :if={errors}><%= elem(errors, 0) %></.error>
               </div>
             </div>
             <div class="flex flex-row justify-start items-start gap-[152px]">
@@ -446,7 +447,7 @@ defmodule OliWeb.Certificates.CertificateSettingsComponent do
       </div>
       <div class="w-full relative">
         <div
-          class="w-full h-60 py-4 hidden z-50 absolute dark:bg-gray-800 bg-white border overflow-y-scroll top-1 rounded"
+          class="w-full max-h-60 py-4 hidden z-50 absolute dark:bg-gray-800 bg-white border overflow-y-scroll top-1 rounded"
           id={"#{@id}-options-container"}
           phx-click-away={
             JS.hide() |> JS.hide(to: "##{@id}-up-icon") |> JS.show(to: "##{@id}-down-icon")

--- a/lib/oli_web/live/certificates/certificate_settings_component.ex
+++ b/lib/oli_web/live/certificates/certificate_settings_component.ex
@@ -307,7 +307,11 @@ defmodule OliWeb.Certificates.CertificateSettingsComponent do
                         field={f[:min_percentage_for_completion]}
                         class="pl-6 border-[#D4D4D4] rounded"
                       />
-                      <span class="absolute right-8 top-1/2 transform -translate-y-1/2 text-gray-500 pointer-events-none">
+
+                      <span class={[
+                        "absolute right-8 transform -translate-y-1/2 text-gray-500 pointer-events-none ",
+                        if(f.errors != [], do: "top-1/3", else: "top-1/2")
+                      ]}>
                         %
                       </span>
                     </div>

--- a/test/oli/delivery/sections/certificate_test.exs
+++ b/test/oli/delivery/sections/certificate_test.exs
@@ -95,6 +95,25 @@ defmodule Oli.Delivery.Sections.CertificateTest do
 
       assert %{assessments_apply_to: ["is invalid"]} = errors_on(changeset)
     end
+
+    test "error: when assessments_apply_to is :custom but custom_assessments is empty", %{
+      params: params
+    } do
+      params =
+        params
+        |> Map.put(:assessments_apply_to, :custom)
+        |> Map.put(:custom_assessments, [])
+
+      changeset = Certificate.changeset(params)
+
+      refute changeset.valid?
+
+      assert %{
+               custom_assessments: [
+                 "scored pages must not be empty"
+               ]
+             } = errors_on(changeset)
+    end
   end
 
   describe "insert" do

--- a/test/oli/delivery/sections/certificate_test.exs
+++ b/test/oli/delivery/sections/certificate_test.exs
@@ -45,15 +45,11 @@ defmodule Oli.Delivery.Sections.CertificateTest do
       changeset = %Ecto.Changeset{errors: errors} = Certificate.changeset(params)
 
       refute changeset.valid?
-      assert length(errors) == 7
+      assert length(errors) == 3
 
       assert %{title: ["can't be blank"]} = errors_on(changeset)
       assert %{description: ["can't be blank"]} = errors_on(changeset)
       assert %{section_id: ["can't be blank"]} = errors_on(changeset)
-      assert %{required_discussion_posts: ["can't be blank"]} = errors_on(changeset)
-      assert %{required_class_notes: ["can't be blank"]} = errors_on(changeset)
-      assert %{min_percentage_for_completion: ["can't be blank"]} = errors_on(changeset)
-      assert %{min_percentage_for_distinction: ["can't be blank"]} = errors_on(changeset)
     end
 
     test "success: when distinction > completion", %{params: params} do

--- a/test/oli/interop/export_test.exs
+++ b/test/oli/interop/export_test.exs
@@ -16,7 +16,7 @@ defmodule Oli.Interop.ExportTest do
     required_class_notes: 12,
     min_percentage_for_completion: 0.9,
     min_percentage_for_distinction: 0.99,
-    assessments_apply_to: :custom,
+    assessments_apply_to: :all,
     custom_assessments: [],
     requires_instructor_approval: true,
     title: "My Certificate",

--- a/test/oli_web/live/certificates/certificate_settings_component_test.exs
+++ b/test/oli_web/live/certificates/certificate_settings_component_test.exs
@@ -209,6 +209,42 @@ defmodule OliWeb.Certificates.CertificateSettingsComponentTest do
       refute has_element?(lcd, "input[name=\"#{gp1.resource_id}\"]:checked")
       refute has_element?(lcd, "input[name=\"#{gp2.resource_id}\"]:checked")
     end
+
+    test "fails when selecting no graded pages", %{
+      conn: conn,
+      product: product,
+      certificate: certificate,
+      graded_pages: graded_pages
+    } do
+      {:ok, lcd, _html} =
+        live_component_isolated(conn, CertificateSettingsComponent, %{
+          id: "certificate_settings_component",
+          product: product,
+          certificate: certificate,
+          graded_pages: graded_pages,
+          active_tab: :thresholds,
+          current_path: "/path"
+        })
+
+      lcd
+      |> element("#certificate_form")
+      |> render_submit(%{
+        "certificate" => %{
+          "custom_assessments" => [],
+          "assessments_apply_to" => "custom"
+        }
+      })
+
+      assert has_element?(
+               lcd,
+               "div",
+               "scored pages must not be empty"
+             )
+
+      certificate = Certificates.get_certificate(certificate.id)
+
+      refute certificate.custom_assessments == [] and certificate.assessments_apply_to == :custom
+    end
   end
 
   defp setup_data(%{}) do


### PR DESCRIPTION
[MER-4085](https://eliterate.atlassian.net/browse/MER-4085)

A second version of the Thresholds Tab for handling the Certificate Settings (continuation of https://github.com/Simon-Initiative/oli-torus/pull/5365) includes improvements and small fixes.
- Add default values for the Thresholds form.
- Improve error handling when no scored pages are selected for the certificate.
- Styling fixes (on the percentage symbol when there is an error)


https://github.com/user-attachments/assets/64d29d7c-2d6f-4af3-a0dc-b6f65e3c829e



[MER-4085]: https://eliterate.atlassian.net/browse/MER-4085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ