### PR TITLE
[BUG FIX] [MER-4219] OAuth google login may result in infinite confirm email step

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -213,8 +213,8 @@ config :ex_money,
 config :oli, :recaptcha,
   verify_url: "https://www.google.com/recaptcha/api/siteverify",
   timeout: 5000,
-  site_key: System.get_env("RECAPTCHA_SITE_KEY"),
-  secret: System.get_env("RECAPTCHA_PRIVATE_KEY")
+  site_key: System.get_env("RECAPTCHA_SITE_KEY", "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"),
+  secret: System.get_env("RECAPTCHA_PRIVATE_KEY", "6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe")
 
 # Configure help
 # HELP_PROVIDER env var must be a string representing an existing provider module, such as "EmailHelp"

--- a/config/config.exs
+++ b/config/config.exs
@@ -213,8 +213,8 @@ config :ex_money,
 config :oli, :recaptcha,
   verify_url: "https://www.google.com/recaptcha/api/siteverify",
   timeout: 5000,
-  site_key: System.get_env("RECAPTCHA_SITE_KEY", "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"),
-  secret: System.get_env("RECAPTCHA_PRIVATE_KEY", "6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe")
+  site_key: System.get_env("RECAPTCHA_SITE_KEY"),
+  secret: System.get_env("RECAPTCHA_PRIVATE_KEY")
 
 # Configure help
 # HELP_PROVIDER env var must be a string representing an existing provider module, such as "EmailHelp"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -206,3 +206,10 @@ config :ex_aws, :s3, region: System.get_env("AWS_REGION", "us-east-1")
 config :ex_aws, :hackney_opts,
   follow_redirect: true,
   recv_timeout: 200_000
+
+# Configure reCAPTCHA
+config :oli, :recaptcha,
+  verify_url: "https://www.google.com/recaptcha/api/siteverify",
+  timeout: 5000,
+  site_key: System.get_env("RECAPTCHA_SITE_KEY", "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"),
+  secret: System.get_env("RECAPTCHA_PRIVATE_KEY", "6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe")

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -207,7 +207,9 @@ config :ex_aws, :hackney_opts,
   follow_redirect: true,
   recv_timeout: 200_000
 
-# Configure reCAPTCHA
+# Configure development reCAPTCHA. This is a publicly available test key and will
+# render a warning to prevent it from being used in production.
+# https://developers.google.com/recaptcha/docs/faq#id-like-to-run-automated-tests-with-recaptcha.-what-should-i-do
 config :oli, :recaptcha,
   verify_url: "https://www.google.com/recaptcha/api/siteverify",
   timeout: 5000,

--- a/lib/oli/accounts/schemas/author.ex
+++ b/lib/oli/accounts/schemas/author.ex
@@ -265,6 +265,7 @@ defmodule Oli.Accounts.Author do
     |> validate_required([:given_name, :family_name])
     |> default_system_role()
     |> maybe_name_from_given_and_family()
+    |> confirm_email_if_verified()
   end
 
   @doc """

--- a/lib/oli/assent_auth.ex
+++ b/lib/oli/assent_auth.ex
@@ -24,22 +24,17 @@ defmodule Oli.AssentAuth do
   @callback has_password?(any()) :: boolean()
 
   @doc """
+  Returns true if the user's email has been confirmed.
+  """
+  @callback email_confirmed?(any()) :: boolean()
+
+  @doc """
   Upserts a user identity.
 
   If a matching user identity already exists for the user, the identity will be updated,
   otherwise a new identity is inserted.
   """
-  @callback upsert(Atom.t(), map()) :: {:ok, map()} | {:error, String.t()}
-
-  @doc """
-  Inserts a user identity for the user.
-  """
-  @callback insert_identity(Atom.t(), map()) :: {:ok, map()} | {:error, String.t()}
-
-  @doc """
-  Updates a user identity.
-  """
-  @callback update_identity(any(), map()) :: {:ok, any()} | {:error, any()}
+  @callback upsert_identity(Atom.t(), map()) :: {:ok, map()} | {:error, String.t()}
 
   @doc """
   Creates a user with user identity.
@@ -47,6 +42,11 @@ defmodule Oli.AssentAuth do
   User schema module and repo module will be fetched from config.
   """
   @callback create_user_with_identity(any(), map()) :: {:ok, any()} | {:error, any()}
+
+  @doc """
+  Updates user details.
+  """
+  @callback update_user_details(any(), map()) :: {:ok, any()} | {:error, any()}
 
   @doc """
   Gets a user by identity provider and uid.

--- a/lib/oli/assent_auth/author_assent_auth.ex
+++ b/lib/oli/assent_auth/author_assent_auth.ex
@@ -14,6 +14,7 @@ defmodule Oli.AssentAuth.AuthorAssentAuth do
   """
   def authentication_providers() do
     Application.get_env(:oli, :author_auth_providers)
+    |> Enum.filter(fn {_, config} -> config != nil end)
   end
 
   @doc """
@@ -42,39 +43,40 @@ defmodule Oli.AssentAuth.AuthorAssentAuth do
   end
 
   @doc """
+  Returns true if the user's email has been confirmed.
+  """
+  def email_confirmed?(user) do
+    user.email_confirmed_at != nil
+  end
+
+  @doc """
   Upserts a user identity.
 
   If a matching user identity already exists for the user, the identity will be updated,
   otherwise a new identity is inserted.
   """
-  def upsert(user, author_identity_params) do
-    {uid_provider_params, additional_params} =
+  def upsert_identity(user, author_identity_params) do
+    {uid_provider_params, _additional_params} =
       Map.split(author_identity_params, ["uid", "provider"])
 
     get_for_user(user, uid_provider_params)
     |> case do
-      nil -> insert_identity(user, author_identity_params)
-      identity -> update_identity(identity, additional_params)
+      nil -> insert_identity(user, uid_provider_params)
+      identity -> update_identity(identity, uid_provider_params)
     end
   end
 
-  @doc """
-  Inserts a user identity for the user.
-  """
-  def insert_identity(user, author_identity_params) do
+  defp insert_identity(user, uid_provider_params) do
     author_identity = Ecto.build_assoc(user, :user_identities)
 
     author_identity
-    |> author_identity.__struct__.changeset(author_identity_params)
+    |> author_identity.__struct__.changeset(uid_provider_params)
     |> Repo.insert()
   end
 
-  @doc """
-  Updates a user identity.
-  """
-  def update_identity(author_identity, additional_params) do
+  defp update_identity(author_identity, uid_provider_params) do
     author_identity
-    |> author_identity.__struct__.changeset(additional_params)
+    |> author_identity.__struct__.changeset(uid_provider_params)
     |> Repo.update()
   end
 
@@ -87,6 +89,15 @@ defmodule Oli.AssentAuth.AuthorAssentAuth do
     %Author{}
     |> Author.author_identity_changeset(author_identity_params, user_params)
     |> Repo.insert()
+  end
+
+  @doc """
+  Updates user details.
+  """
+  def update_user_details(author, attrs) do
+    author
+    |> Author.details_changeset(attrs)
+    |> Repo.update()
   end
 
   @doc """

--- a/lib/oli/utils.ex
+++ b/lib/oli/utils.ex
@@ -104,7 +104,8 @@ defmodule Oli.Utils do
   end
 
   def confirm_email_if_verified(changeset) do
-    if get_change(changeset, :email_verified) do
+    # if the email_verified field is true and the email_confirmed_at field is nil, then set the email_confirmed_at field to now
+    if get_change(changeset, :email_verified) && get_field(changeset, :email_confirmed_at) == nil do
       now = DateTime.utc_now() |> DateTime.truncate(:second)
       change(changeset, email_confirmed_at: now)
     else

--- a/lib/oli_web/common/assent_auth_web.ex
+++ b/lib/oli_web/common/assent_auth_web.ex
@@ -68,15 +68,13 @@ defmodule OliWeb.Common.AssentAuthWeb do
     |> put_private_callback_state(conn)
     |> maybe_authenticate(config)
     |> maybe_upsert_user_identity(config)
-    |> maybe_create_user(config)
+    |> create_or_update_user(config)
     |> case do
-      %{private: %{assent_callback_state: {:ok, :create_user}}} = conn ->
-        conn
-        |> maybe_trigger_registration_email_confirmation(config)
-        |> (&{:ok, &1}).()
-
+      # Regardless of whether the user was just created or updated, we will send a confirmation
+      # email if the user's email has not yet been confirmed.
       %{private: %{assent_callback_state: {:ok, _method}}} = conn ->
-        {:ok, conn}
+        conn
+        |> maybe_send_confirmation_email(config)
 
       %{private: %{assent_callback_state: {:error, error}, assent_callback_error: changeset}} =
           conn ->
@@ -197,7 +195,7 @@ defmodule OliWeb.Common.AssentAuthWeb do
     user_identity_params = convert_params(user_identity_params)
 
     user
-    |> assent_auth_module(config).upsert(user_identity_params)
+    |> assent_auth_module(config).upsert_identity(user_identity_params)
     |> user_identity_bound_different_user_error()
     |> case do
       {:ok, user_identity} ->
@@ -208,35 +206,48 @@ defmodule OliWeb.Common.AssentAuthWeb do
     end
   end
 
-  defp maybe_create_user(conn, config),
-    do: maybe_create_user(current_user(conn, config), conn, config)
-
-  defp maybe_create_user(
-         nil,
-         %{private: %{assent_callback_state: {:ok, :strategy}, assent_callback_params: params}} =
+  defp create_or_update_user(
+         %{private: %{assent_callback_state: {:ok, _method}, assent_callback_params: params}} =
            conn,
          config
        ) do
     user_params = Map.fetch!(params, :user)
     user_identity_params = Map.fetch!(params, :user_identity)
 
-    conn
-    |> create_user(user_identity_params, user_params, config)
-    |> case do
-      {:ok, user, conn} ->
+    case current_user(conn, config) do
+      nil ->
         conn
-        |> Plug.Conn.put_private(:assent_callback_state, {:ok, :create_user})
-        |> create_session(user, config)
-        |> assign_current_user(user, config)
+        |> create_user(user_identity_params, user_params, config)
+        |> case do
+          {:ok, user, conn} ->
+            conn
+            |> Plug.Conn.put_private(:assent_callback_state, {:ok, :create_user})
+            |> create_session(user, config)
+            |> assign_current_user(user, config)
 
-      {:error, changeset, conn} ->
+          {:error, changeset, conn} ->
+            conn
+            |> Plug.Conn.put_private(:assent_callback_state, {:error, :create_user})
+            |> Plug.Conn.put_private(:assent_callback_error, changeset)
+        end
+
+      user ->
         conn
-        |> Plug.Conn.put_private(:assent_callback_state, {:error, :create_user})
-        |> Plug.Conn.put_private(:assent_callback_error, changeset)
+        |> update_user(user, user_params, config)
+        |> case do
+          {:ok, user, conn} ->
+            conn
+            |> Plug.Conn.put_private(:assent_callback_state, {:ok, :update_user})
+            |> create_session(user, config)
+            |> assign_current_user(user, config)
+
+          {:error, changeset, conn} ->
+            conn
+            |> Plug.Conn.put_private(:assent_callback_state, {:error, :update_user})
+            |> Plug.Conn.put_private(:assent_callback_error, changeset)
+        end
     end
   end
-
-  defp maybe_create_user(_user, conn, _config), do: conn
 
   ## Create a user with the provider and provider user params.
   defp create_user(conn, user_identity_params, user_params, config) do
@@ -245,6 +256,15 @@ defmodule OliWeb.Common.AssentAuthWeb do
     |> assent_auth_module(config).create_user_with_identity(user_params)
     |> user_identity_bound_different_user_error()
     |> user_with_email_already_exists_error()
+    |> case do
+      {:ok, user} -> {:ok, user, create_session(conn, user, config)}
+      {:error, error} -> {:error, error, conn}
+    end
+  end
+
+  defp update_user(conn, user, user_params, config) do
+    user
+    |> assent_auth_module(config).update_user_details(user_params)
     |> case do
       {:ok, user} -> {:ok, user, create_session(conn, user, config)}
       {:error, error} -> {:error, error, conn}
@@ -268,17 +288,15 @@ defmodule OliWeb.Common.AssentAuthWeb do
     |> assent_auth_module(config).delete_identity_providers(user)
   end
 
-  defp maybe_trigger_registration_email_confirmation(conn, config) do
-    %{user: user_params} = conn.private[:assent_callback_params]
+  defp maybe_send_confirmation_email(conn, config) do
+    user = current_user(conn, config)
 
-    if email_verified?(user_params) do
-      conn
+    if assent_auth_module(config).email_confirmed?(user) do
+      {:ok, conn}
     else
-      user = current_user(conn, config)
-
       deliver_user_confirmation_instructions(user, config)
 
-      conn
+      {:email_confirmation_required, conn}
     end
   end
 
@@ -352,10 +370,6 @@ defmodule OliWeb.Common.AssentAuthWeb do
 
   defp convert_param({key, value}) when is_atom(key), do: {Atom.to_string(key), value}
   defp convert_param({key, value}) when is_binary(key), do: {key, value}
-
-  defp email_verified?(%{"email_verified" => true}), do: true
-  defp email_verified?(%{email_verified: true}), do: true
-  defp email_verified?(_params), do: false
 
   defp user_identity_bound_different_user_error({:error, %{errors: errors} = changeset}) do
     case unique_constraint_error?(errors, :uid_provider) do

--- a/lib/oli_web/controllers/author_authorization_controller.ex
+++ b/lib/oli_web/controllers/author_authorization_controller.ex
@@ -99,6 +99,14 @@ defmodule OliWeb.AuthorAuthorizationController do
             |> AuthorAuth.maybe_link_user_author_account(conn.assigns.current_author)
             |> redirect(to: redirect_to)
 
+          {:email_confirmation_required, conn} ->
+            conn
+            |> put_flash(
+              :info,
+              "Please confirm your email address to continue. A confirmation email has been sent."
+            )
+            |> redirect(to: ~p"/authors/confirm")
+
           {:error, conn, error} ->
             Logger.error("Error handling authorization success: #{inspect(error)}")
 

--- a/lib/oli_web/controllers/user_authorization_controller.ex
+++ b/lib/oli_web/controllers/user_authorization_controller.ex
@@ -97,6 +97,14 @@ defmodule OliWeb.UserAuthorizationController do
             conn
             |> redirect(to: redirect_to)
 
+          {:email_confirmation_required, conn} ->
+            conn
+            |> put_flash(
+              :info,
+              "Please confirm your email address to continue. A confirmation email has been sent."
+            )
+            |> redirect(to: ~p"/users/confirm")
+
           {:error, conn, error} ->
             Logger.error("Error handling authorization success: #{inspect(error)}")
 

--- a/test/oli_web/common/assent_auth_web_test.exs
+++ b/test/oli_web/common/assent_auth_web_test.exs
@@ -87,13 +87,44 @@ defmodule OliWeb.Common.AssentAuthWebTest do
       author = %{
         "email" => author_email,
         "name" => author_name,
-        "sub" => "123"
+        "sub" => "123",
+        "email_verified" => true
       }
 
       other_params = %{}
       config = test_config()
 
       {:ok, _conn} =
+        AssentAuthWeb.handle_authorization_success(
+          conn,
+          provider,
+          author,
+          other_params,
+          config
+        )
+
+      # no confirmation email is sent for an already verified email
+      TestAssertions.assert_no_email_sent()
+    end
+
+    test "handle_authorization_success/5 returns email_confirmation_required", %{
+      conn: conn
+    } do
+      provider = "google"
+
+      author_email = "new_author@example.edu"
+      author_name = "New Author"
+
+      author = %{
+        "email" => author_email,
+        "name" => author_name,
+        "sub" => "123"
+      }
+
+      other_params = %{}
+      config = test_config()
+
+      {:email_confirmation_required, _conn} =
         AssentAuthWeb.handle_authorization_success(
           conn,
           provider,


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-4219

Fixes an issue where OAuth social login may result in infinite confirmation step loop.

**Cause**
The issue identified was that if an existing OAuth social login account was never confirmed, then subsequent logins would never update this field and the user would be stuck in an infinite "confirm email" loop.

**Fix**
The fix here is to actually update user details on every OAuth flow login so that the email will be automatically confirmed if `email_verified: true` is passed along. This has the additional benefit of keeping other user details up to date such as name and profile picture. A step was also added here to properly handle the case where `email_verified: false` is passed in, in which case a confirmation email is automatically sent, prompting the user to confirm their email. While this should never be true for email based OAuth integrations such as google, it is good to have in place for Github or other OAuth integration types.