### PR TITLE
[FEATURE] [MER-4068] Reimplement user and author invite functionality - part 4

### DIFF
--- a/lib/oli/accounts.ex
+++ b/lib/oli/accounts.ex
@@ -1467,6 +1467,22 @@ defmodule Oli.Accounts do
   end
 
   @doc """
+  Deletes all the enrollment invitation tokens for a list of emails in a given section.
+  """
+
+  def delete_enrollment_invitation_tokens(section_slug, emails) do
+    from(
+      ut in UserToken,
+      join: u in User,
+      on: ut.user_id == u.id,
+      where:
+        ut.context == ^"enrollment_invitation:#{section_slug}" and
+          u.email in ^emails
+    )
+    |> Repo.delete_all()
+  end
+
+  @doc """
   Resets the user password.
 
   ## Examples

--- a/lib/oli/accounts/schemas/author.ex
+++ b/lib/oli/accounts/schemas/author.ex
@@ -102,6 +102,7 @@ defmodule Oli.Accounts.Author do
     changeset
     |> cast(attrs, [:email])
     |> validate_required([:email])
+    |> unique_constraint(:email)
     |> validate_email(opts)
     |> put_change(:system_role_id, Oli.Accounts.SystemRole.role_id().author)
   end

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -609,6 +609,21 @@ defmodule Oli.Delivery.Sections do
   end
 
   @doc """
+  Updates the status of the enrollments for a given section and a list of user emails.
+  """
+  def bulk_update_enrollment_status(section_slug, emails, new_status) do
+    from(
+      e in Enrollment,
+      join: s in Section,
+      on: e.section_id == s.id,
+      join: u in User,
+      on: e.user_id == u.id,
+      where: s.slug == ^section_slug and u.email in ^emails
+    )
+    |> Repo.update_all(set: [status: new_status])
+  end
+
+  @doc """
   Returns a listing of all open and free sections for a given user,
   ordered by the most recently enrolled.
   """

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -93,6 +93,20 @@ defmodule Oli.Delivery.Sections do
     end)
   end
 
+  @doc """
+  Returns the enrollments for a given section and a list of user emails.
+  """
+  def get_enrollments_by_emails(section_slug, emails) do
+    from(e in Enrollment,
+      join: s in assoc(e, :section),
+      join: ecr in assoc(e, :context_roles),
+      join: u in assoc(e, :user),
+      where: s.slug == ^section_slug and u.email in ^emails,
+      preload: [:user]
+    )
+    |> Repo.all()
+  end
+
   def browse_enrollments_query(
         %Section{id: section_id},
         %Paging{limit: limit, offset: offset},


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-4068?focusedCommentId=25417) to the comment in the ticket

### Admin invites an existing author
The following flash message was added to handle that case (and no email invitation is sent)


### Instructor adds enrollments

This PR allows an instructor to re-send an invitation to any student with an enrollment with any of these statuses:
- rejected
- suspended
- pending confirmation

All previous invitations for that user-course are invalidated before the new invitation is sent. So if the user enters an old invitation through the email invitation link this view will be prompted:

On the other hand, the `step 2` of the "Add Enrollments" wizard was extended to warn about:

- users that do not yet exist in the system (this warning already existed)
- users that already have an "inactive" enrollment -pending confirmation, rejected or suspended- (new warning)
- users that already have an active enrollment in the course (new warning)

Finally, the `step 3` of the same wizard was extended to exclude the existing enrollments from the invitation count (since no invitations are sent to already enrolled users)